### PR TITLE
fix(reload): say when a commanded frontend reload did not happen

### DIFF
--- a/browser_tests/unit/reload-blocked.test.mjs
+++ b/browser_tests/unit/reload-blocked.test.mjs
@@ -1,0 +1,97 @@
+// panel#701(2) — a commanded frontend reload that never happens must say so.
+//
+// Reproduced on released builds: panel_reload({scope:"frontend"}) returned
+// "soft reload (frontend) scheduled", the orchestrator logged
+// `panel tab disconnected`, the page never navigated (no cmcpReload param), and
+// the socket never came back. ComfyUI's unsaved-work beforeunload had cancelled
+// the navigation after the browser began tearing the socket down, leaving a modal
+// waiting for a click nobody knew about.
+
+import assert from "node:assert/strict";
+import test from "node:test";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+import {
+  armReloadBlockedNotice,
+  reloadBlockedMessage,
+  RELOAD_BLOCKED_AFTER_MS,
+} from "../../web/js/lib/reload-blocked.js";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const PANEL_JS = join(HERE, "../../web/js/comfyui-mcp-panel.js");
+
+/** Capture the scheduled callback instead of waiting on a real clock. */
+function fakeTimer() {
+  const calls = [];
+  return { setTimer: (fn, ms) => (calls.push({ fn, ms }), calls.length), calls };
+}
+
+test("#701 the notice fires only if the page SURVIVED the deadline", () => {
+  const said = [];
+  const t = fakeTimer();
+  armReloadBlockedNotice({ notify: (m) => said.push(m), setTimer: t.setTimer });
+  assert.equal(said.length, 0, "nothing is said at arm time");
+  assert.equal(t.calls[0].ms, RELOAD_BLOCKED_AFTER_MS);
+  t.calls[0].fn();
+  assert.equal(said.length, 1, "surviving the deadline is the evidence");
+});
+
+test("#701 a successful reload says NOTHING — the page is gone", () => {
+  // The real mechanism: the document is destroyed and the callback never runs.
+  // Modelled by a stillHere that reports the page died, which is also the guard
+  // against speaking about a page that no longer exists.
+  const said = [];
+  const t = fakeTimer();
+  armReloadBlockedNotice({ notify: (m) => said.push(m), stillHere: () => false, setTimer: t.setTimer });
+  t.calls[0].fn();
+  assert.equal(said.length, 0);
+});
+
+test("#701 it says NOT YET rather than declaring failure", () => {
+  // The one false-positive risk is a navigation slower than the deadline. The
+  // wording has to survive that case being wrong.
+  const msg = reloadBlockedMessage();
+  assert.match(msg, /has NOT happened yet/);
+  assert.doesNotMatch(msg, /reload failed|could not reload|reload was refused/i);
+});
+
+test("#701 it names the likely cause WITHOUT asserting it", () => {
+  // This code cannot see which handler cancelled the unload — another pack or a
+  // browser extension can register one too. Unsaved work is by far the likeliest
+  // and is named as such, not as fact.
+  const msg = reloadBlockedMessage();
+  assert.match(msg, /almost certainly/);
+  assert.match(msg, /unsaved workflows/);
+  assert.doesNotMatch(msg, /because you have unsaved work\b/i);
+});
+
+test("#701 it tells the reader what to DO, in the browser", () => {
+  const msg = reloadBlockedMessage();
+  assert.match(msg, /Check the ComfyUI tab/);
+  assert.match(msg, /confirm the prompt|confirm\s+the prompt/i);
+  assert.match(msg, /save the modified workflows/);
+});
+
+test("#701 it warns that the connection may ALREADY have dropped", () => {
+  // The socket teardown begins before the dialog resolves, so "the agent looks
+  // disconnected" is expected here and would otherwise read as a second fault.
+  assert.match(reloadBlockedMessage(), /may already have dropped/);
+});
+
+test("#701 a missing notify sink is a no-op, never a throw", () => {
+  // This runs on the way out of the page; throwing here would be the worst
+  // possible place to fail.
+  assert.equal(armReloadBlockedNotice({}), null);
+  assert.equal(armReloadBlockedNotice({ notify: "not a function" }), null);
+});
+
+test("#701 WIRING: armed BEFORE the navigation, in the frontend branch", () => {
+  const src = readFileSync(PANEL_JS, "utf8");
+  const i = src.indexOf("armReloadBlockedNotice({ notify:");
+  const j = src.indexOf('u.searchParams.set("cmcpReload"', i);
+  assert.ok(i !== -1, "the notice must be armed in the shipped source");
+  assert.ok(j > i, "…and armed BEFORE location.replace, or the page may die first");
+  assert.match(src, /import \{ armReloadBlockedNotice \} from "\.\/lib\/reload-blocked\.js"/);
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -66,6 +66,7 @@ import { marked } from "./vendor/marked.esm.js";
 import DOMPurify from "./vendor/purify.es.js";
 import qrcodegen from "./vendor/qrcode.esm.js";
 import { computeLayout } from "./lib/layout-engine.js";
+import { armReloadBlockedNotice } from "./lib/reload-blocked.js";
 import { pairDurabilityView } from "./lib/pair-durability-view.js";
 import { describeUploadFailure, attachmentSummaryLine } from "./lib/attachment-upload.js";
 import {
@@ -24697,6 +24698,11 @@ function buildPanel() {
       } catch {
         /* reload regardless — worst case is the pre-#584 behaviour */
       }
+      // #701(2) — the navigation below can be CANCELLED by ComfyUI's unsaved-work
+      // beforeunload, after the browser has already torn down our socket. If that
+      // happens this code survives the deadline and says so; if the reload works, the
+      // document is destroyed and the notice never fires. Arm it BEFORE navigating.
+      armReloadBlockedNotice({ notify: (m) => appendSystem(m) });
       try {
         const u = new URL(window.location.href);
         u.searchParams.set("cmcpReload", String(Date.now()));

--- a/web/js/lib/reload-blocked.js
+++ b/web/js/lib/reload-blocked.js
@@ -1,0 +1,75 @@
+/**
+ * panel#701(2) — a commanded frontend reload that never happens must SAY SO.
+ *
+ * `softReload("…", "frontend")` ends in `window.location.replace(...)`, and a
+ * ComfyUI tab with unsaved work has a `beforeunload` handler. The browser begins
+ * the unload — enough to tear down the panel's WebSocket — and then blocks on a
+ * confirmation dialog nobody answers, because the caller was an agent rather than
+ * a person sitting at the tab.
+ *
+ * The end state, reproduced on released builds: the orchestrator logs
+ * `panel tab disconnected`, the page never navigates (no `cmcpReload` param on the
+ * URL), the socket does not come back, and the tool has already reported
+ * "soft reload (frontend) scheduled". Nothing tells anyone a modal is waiting.
+ *
+ * THIS IS THE VERIFICATION HALF ONLY. Whether the tool should REFUSE outright when
+ * workflows are modified is a product decision and is left alone. Noticing that a
+ * navigation we requested did not occur, and saying so, cannot make anything worse
+ * — the alternative is the current silence.
+ *
+ * WHY A TIMER IS SOUND HERE. If the navigation succeeds this code is destroyed
+ * with the document and the callback never runs; that is the intended "no news"
+ * path. Surviving the deadline is therefore positive evidence that the unload was
+ * cancelled — not an inference, an observation. The one false-positive risk is a
+ * navigation slower than the deadline, so the message says the reload "has not
+ * happened yet" rather than declaring it failed, and re-checks before speaking.
+ */
+
+/** Generous enough that an ordinary reload is long gone (a same-origin document
+ *  swap is tens of ms), short enough that a stranded user is told promptly. */
+export const RELOAD_BLOCKED_AFTER_MS = 4000;
+
+/**
+ * Arm a check that runs only if the page is STILL ALIVE afterwards.
+ *
+ * @param {object} deps
+ * @param {(msg: string) => void} deps.notify  where to surface the finding.
+ * @param {() => boolean} [deps.stillHere]  re-checked at fire time; default true.
+ * @param {(fn: () => void, ms: number) => unknown} [deps.setTimer]
+ * @param {number} [deps.afterMs]
+ * @returns {unknown} the timer handle, so a caller can cancel it.
+ */
+export function armReloadBlockedNotice({
+  notify,
+  stillHere = () => true,
+  setTimer = (fn, ms) => setTimeout(fn, ms),
+  afterMs = RELOAD_BLOCKED_AFTER_MS,
+} = {}) {
+  if (typeof notify !== "function") return null;
+  return setTimer(() => {
+    // Re-check rather than assume: between arming and firing the document may
+    // have gone, and speaking then would be a claim about a page that no longer
+    // exists.
+    if (!stillHere()) return;
+    notify(reloadBlockedMessage());
+  }, afterMs);
+}
+
+/**
+ * Names the cause it can actually support, and the two ways out.
+ *
+ * It does NOT assert "you have unsaved work" — this code cannot see which handler
+ * cancelled the unload, and a browser extension or another pack can register one
+ * too. Unsaved work is by far the most likely and is named as such, not as fact.
+ */
+export function reloadBlockedMessage() {
+  return (
+    "The panel reload was requested but has NOT happened yet — this page is still running " +
+    "the old code. A browser dialog is almost certainly waiting for a click: ComfyUI asks " +
+    "for confirmation before leaving a tab with unsaved workflows, and that prompt blocks " +
+    "the reload until someone answers it in the browser. Check the ComfyUI tab and confirm " +
+    "the prompt, or save the modified workflows and try again. Note the panel's connection " +
+    "may already have dropped while the browser was preparing to navigate, so the agent can " +
+    "appear disconnected until the reload completes or is dismissed."
+  );
+}


### PR DESCRIPTION
For #701 (2) — the **verification half only**. Whether `panel_reload` should *refuse
outright* when workflows are modified is a product decision and is deliberately untouched.

## What happens today

`softReload(…, "frontend")` ends in `window.location.replace()`, and a ComfyUI tab with
unsaved work has a `beforeunload` handler. The browser begins the unload — enough to tear
down the panel's WebSocket — then blocks on a confirmation dialog nobody answers, because
the caller was an agent rather than a person sitting at the tab.

Reproduced on released builds (`mcp 0.50.15` / `panel 0.11.44`) over the loopback panel MCP:

- the tool returned `soft reload (frontend) scheduled`
- the orchestrator logged `panel tab disconnected`
- the page **never navigated** — no `cmcpReload` param on the URL
- the socket never returned
- **nothing told anyone a modal was waiting**

## Why a timer is evidence here, not a guess

Armed **before** the navigation: if the reload succeeds, this code is destroyed with the
document and never runs. So *surviving the deadline* is an observation that the unload was
cancelled. It re-checks liveness at fire time rather than assuming, since the page may
legitimately have gone between arming and firing.

## Wording chosen for the case where it is wrong

The one false positive is a navigation slower than the deadline, so it says the reload
**"has NOT happened yet"** rather than declaring failure.

It names unsaved work as **almost certain**, not as fact — this code cannot see which
handler cancelled the unload, and another pack or a browser extension can register one.

And it warns the connection **may already have dropped**, because the socket teardown
begins before the dialog resolves. Without that, "the agent is disconnected" reads as a
second, unrelated fault.

## Tests

2872 pass; typecheck and vocabulary gate green; all three files clean of control bytes.

Mutation-verified — each fails a test:

| mutation | result |
|---|---|
| drop the liveness re-check (speak about a dead page) | fails |
| declare failure instead of "not yet" | fails |
| assert the cause as fact | fails |
| arm the notice *after* the navigation | fails |

Two of those first reported **pre-count 0** against a string spanning a concatenation
break. Redone against the exact literal rather than banked as passes — a mutation that does
not land reads as reassurance.
