### PR TITLE
fix(get_errors): disclose that missing-asset detection is load-time only

### DIFF
--- a/browser_tests/unit/missing-asset-scope.test.mjs
+++ b/browser_tests/unit/missing-asset-scope.test.mjs
@@ -1,0 +1,63 @@
+// panel#745 — panel_get_errors omitted a missing model on a node added after load.
+//
+// The missing-asset stores are populated by ComfyUI at workflow LOAD; the panel
+// reads them and its own logic only SUBTRACTS. So a LoraLoaderModelOnly added this
+// session, holding an unavailable basename, was absent from both nodes[] and
+// missing_models[] while the four load-time nodes reported correctly.
+
+import assert from "node:assert/strict";
+import test from "node:test";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+import {
+  missingAssetScanMayBeStale,
+  missingAssetScopeNote,
+} from "../../web/js/lib/missing-asset-scope.js";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const PANEL_JS = join(HERE, "../../web/js/comfyui-mcp-panel.js");
+
+test("#745 the caveat fires exactly when the workflow was edited since the scan", () => {
+  assert.equal(missingAssetScanMayBeStale({ isModified: true }), true);
+  assert.equal(missingAssetScanMayBeStale({ isModified: false }), false);
+});
+
+test("#745 an UNKNOWN modification state does not trigger it", () => {
+  // An unobserved edit is not an observed one, and a caveat on every call trains
+  // readers to skip it — which would cost more than the omission it warns about.
+  for (const wf of [undefined, null, {}, { isModified: undefined }, { isModified: "yes" }, { isModified: 1 }]) {
+    assert.equal(missingAssetScanMayBeStale(wf), false, `${JSON.stringify(wf)} must not trigger`);
+  }
+});
+
+test("#745 the note says an EMPTY list is not proof", () => {
+  // The precise failure: the reporter's newly added node was missing from the
+  // list, and an empty list reads as "nothing is missing".
+  const n = missingAssetScopeNote();
+  assert.match(n, /not proof that nothing\s+is missing/);
+  assert.match(n, /NOT re-scanned/);
+});
+
+test("#745 it names the reason and the check that closes it", () => {
+  const n = missingAssetScopeNote();
+  assert.match(n, /when a workflow is\s+LOADED/, "names WHY the blind spot exists");
+  assert.match(n, /panel_query_graph/, "a limitation without a workaround is a dead end");
+  assert.match(n, /combo's options/);
+});
+
+test("#745 it claims no capability it does not have", () => {
+  // It must not imply the scan now covers new nodes — that is the fix this
+  // deliberately is not.
+  const n = missingAssetScopeNote();
+  assert.doesNotMatch(n, /now (detects|includes|scans)/i);
+  assert.doesNotMatch(n, /has been re-scanned/i);
+});
+
+test("#745 WIRING: the reply carries it, gated on the modified check", () => {
+  const src = readFileSync(PANEL_JS, "utf8");
+  assert.match(src, /import \{ missingAssetScanMayBeStale, missingAssetScopeNote \}/);
+  assert.match(src, /missingAssetScanMayBeStale\(activeWorkflowRef\(\)\)/);
+  assert.match(src, /missing_asset_scope: missingAssetScopeNote\(\)/);
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -66,6 +66,7 @@ import { marked } from "./vendor/marked.esm.js";
 import DOMPurify from "./vendor/purify.es.js";
 import qrcodegen from "./vendor/qrcode.esm.js";
 import { computeLayout } from "./lib/layout-engine.js";
+import { missingAssetScanMayBeStale, missingAssetScopeNote } from "./lib/missing-asset-scope.js";
 import { armReloadBlockedNotice } from "./lib/reload-blocked.js";
 import { pairDurabilityView } from "./lib/pair-durability-view.js";
 import { describeUploadFailure, attachmentSummaryLine } from "./lib/attachment-upload.js";
@@ -10721,6 +10722,13 @@ const GRAPH_TOOL_EXECUTORS = {
                 }
               : {}),
           }
+        : {}),
+      // #745 — the missing-asset stores are populated at workflow LOAD and never
+      // re-evaluated, so a loader added since is invisible here. Disclose that the
+      // answer has a known blind spot rather than let an empty list read as proof.
+      // Only when the workflow has actually been edited since the scan ran.
+      ...(missingAssetScanMayBeStale(activeWorkflowRef())
+        ? { missing_asset_scope: missingAssetScopeNote() }
         : {}),
       ...(missingModels.length ? { missing_models: missingModels } : {}),
       ...(missingMedia.length ? { missing_media: missingMedia } : {}),

--- a/web/js/lib/missing-asset-scope.js
+++ b/web/js/lib/missing-asset-scope.js
@@ -1,0 +1,45 @@
+/**
+ * panel#745 — panel_get_errors reports missing MODELS from a scan that only ever
+ * ran at workflow LOAD, so a loader added afterwards is invisible to it.
+ *
+ * ComfyUI populates the `missingModel`/`missingMedia` Pinia stores when a workflow
+ * is loaded. The panel reads them (four read sites, zero writes) and its own logic
+ * only ever SUBTRACTS — isStaleAssetCandidate drops a candidate whose file has
+ * since appeared. There is no counterpart that finds new ones. So the reporter's
+ * newly added LoraLoaderModelOnly, holding an unavailable basename, was absent
+ * from both `nodes[]` and `missing_models[]` while four load-time nodes reported
+ * correctly.
+ *
+ * THIS IS THE DISCLOSURE HALF ONLY. Actually scanning the live graph is the real
+ * fix and is deliberately not done here: judging a combo value requires a TRUSTED
+ * /object_info refresh, the refresh is gated on the store already having
+ * candidates, and getting that wrong reports every combo on the canvas as missing
+ * — mass false positives on the error surface, which is worse than the omission.
+ * Saying "this answer has a known blind spot" costs nothing and cannot misfire.
+ *
+ * FIRES ONLY WHEN IT MATTERS. An unmodified workflow has not changed since the
+ * scan ran, so the scan is current and a caveat would be noise on every call.
+ * `isModified` is the exact, non-heuristic signal for "edits happened after the
+ * scan" — which is precisely the window in which the answer can be incomplete.
+ */
+
+/** True when the missing-asset answer may be incomplete: the workflow has been
+ *  edited since the load-time scan that produced it. Absent/unknown modification
+ *  state does NOT trigger it — an unobserved edit is not an observed one, and a
+ *  caveat on every call trains readers to skip it. */
+export function missingAssetScanMayBeStale(activeWorkflow) {
+  return activeWorkflow?.isModified === true;
+}
+
+/** The caveat itself. Names the blind spot, the reason, and the check that closes
+ *  it — a limitation without a workaround is a dead end. */
+export function missingAssetScopeNote() {
+  return (
+    "SCOPE: missing-model/media detection comes from the scan ComfyUI runs when a workflow is " +
+    "LOADED, and this workflow has been edited since. Nodes or widget values added after the " +
+    "load are NOT re-scanned, so a loader added this session pointing at an unavailable file " +
+    "will not appear above. An empty missing_models list is therefore not proof that nothing " +
+    "is missing. To check a node you added, read it with panel_query_graph {ids:[…], " +
+    "fields:'detail'} and compare its value against the combo's options."
+  );
+}


### PR DESCRIPTION
For #745 — the **disclosure half**. Actually scanning the live graph is the real fix and is
deliberately not done here.

## The blind spot

ComfyUI populates the `missingModel`/`missingMedia` stores when a workflow is **loaded**.
The panel reads them — four read sites, **zero writes** — and its own logic only ever
*subtracts* (`isStaleAssetCandidate` drops a candidate whose file has since appeared). There
is no counterpart that finds new ones.

So the reporter's newly added `LoraLoaderModelOnly`, holding an unavailable basename, was
absent from both `nodes[]` and `missing_models[]` while the four load-time nodes reported
correctly. **An empty `missing_models` does not mean nothing is missing — and nothing said
so.**

## Why not the real fix

Judging a combo value needs a *trusted* `/object_info` refresh. The forced refresh is gated
on the store already having candidates, so a fresh workflow whose only problem is a new node
never earns that trust — and judging against an untrusted combo list reports **every combo
on the canvas** as missing. Mass false positives on the error surface are worse than the
omission being fixed, and that function carries ten rounds of adversarial-review
annotations about exactly this trust boundary. The two-phase design I would build is written
up on the issue.

## Fires only when it matters

An unmodified workflow has not changed since the scan, so the scan is current and a caveat
would be noise on every call. `isModified` is the exact, non-heuristic signal for "edits
happened after the scan" — precisely the window where the answer can be incomplete.

Strict `=== true`: an **unknown** modification state does not trigger it. An unobserved edit
is not an observed one, and a caveat on every call trains readers to skip it — which would
cost more than the omission it warns about.

## Claims no capability it does not have

It says the scan does not cover new nodes and names the check that does
(`panel_query_graph {ids:[…], fields:'detail'}` against the combo's options). A limitation
without a workaround is a dead end. There is a test that it never implies the scan now
includes them.

## Tests

2878 pass; typecheck and vocabulary gate green; all three files clean of control bytes.

| mutation | result |
|---|---|
| loosen the strict `isModified === true` | fails |
| drop the "an empty list is not proof" sentence | fails |
| stop emitting it from the reply | fails |
