### PR TITLE
fix(set_widget): name the button the panel cannot press

### DIFF
--- a/browser_tests/unit/pressable-widget.test.mjs
+++ b/browser_tests/unit/pressable-widget.test.mjs
@@ -1,0 +1,152 @@
+// panel#757 — a widget missing because a BUTTON has not been pressed must say so.
+//
+// `panel_set_widget(node, "lora_1", …)` on a freshly added Power Lora Loader
+// (rgthree) refused with a bare availability list. `➕ Add Lora` was sitting in
+// that list — it is the button that CREATES the slots — but nothing said so, and
+// the reporter's agent inferred a typo and fell back to chaining
+// `LoraLoaderModelOnly` nodes, losing the stacking UI the user asked for.
+//
+// The refusal itself is correct and unchanged. This only adds what the message
+// already had the evidence to say.
+
+import assert from "node:assert/strict";
+import test from "node:test";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+import {
+  isPressableWidget,
+  pressableWidgets,
+  pressableWidgetHint,
+} from "../../web/js/lib/pressable-widget.js";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const PANEL_JS = join(HERE, "../../web/js/comfyui-mcp-panel.js");
+const WIDGET_WRITE = join(HERE, "../../web/js/lib/widget-write.js");
+
+/**
+ * Modelled on the REAL class, read out of the installed pack:
+ * rgthree-comfy/web/comfyui/utils_widgets.js — `RgthreeBetterButtonWidget`
+ * sets `this.type = "custom"`, `this.value = ""`, and defines `onMouseClick`.
+ *
+ * The `type` is the whole reason this test exists. See the type test below.
+ */
+function rgthreeAddLoraButton() {
+  return {
+    name: "➕ Add Lora",
+    label: "➕ Add Lora",
+    type: "custom",
+    value: "",
+    onMouseClick() {},
+    mouseClickCallback() {},
+  };
+}
+
+/** A freshly added Power Lora Loader, exactly as the report describes it. */
+function freshPowerLoraLoader() {
+  return {
+    id: 153,
+    type: "Power Lora Loader (rgthree)",
+    widgets: [
+      { name: "divider", type: "custom", value: "" },
+      { name: "PowerLoraLoaderHeaderWidget", type: "custom", value: "" },
+      { name: "divider", type: "custom", value: "" },
+      rgthreeAddLoraButton(),
+    ],
+  };
+}
+
+test("#757 rgthree's button is type 'custom', NOT 'button'", () => {
+  // The obvious check — `w.type === "button"` — is what the rest of this codebase
+  // uses and would NEVER have fired on the node this report is about. Pinning the
+  // real value so nobody 'simplifies' the detection back to a type check.
+  assert.equal(rgthreeAddLoraButton().type, "custom");
+  assert.ok(isPressableWidget(rgthreeAddLoraButton()), "must be detected anyway");
+});
+
+test("#757 pressable means it HANDLES A CLICK, not that it is named like one", () => {
+  assert.ok(isPressableWidget({ onMouseClick() {} }));
+  assert.ok(isPressableWidget({ mouseClickCallback() {} }));
+  assert.ok(isPressableWidget({ type: "button" }), "litegraph's canonical button");
+});
+
+test("#757 a real widget that merely SOUNDS like a button is not one", () => {
+  // "Add Noise" is a genuine boolean on several samplers. A name-matching
+  // detector would tell the user to click it, which is worse than saying nothing.
+  assert.equal(isPressableWidget({ name: "Add Noise", type: "toggle", value: true }), false);
+  assert.equal(isPressableWidget({ name: "➕ Add Lora", type: "combo", value: "x" }), false);
+  assert.equal(isPressableWidget(null), false);
+  assert.equal(isPressableWidget("not an object"), false);
+  assert.equal(isPressableWidget({}), false);
+});
+
+test("#757 the hint is EMPTY for an ordinary typo", () => {
+  // The single most important assertion here. Appending a button hypothesis to
+  // every missing-widget refusal would make the common case noisier and slightly
+  // misleading — that is the stated reason this was not bolted on at triage.
+  const plainNode = {
+    id: 7,
+    type: "KSampler",
+    widgets: [
+      { name: "seed", type: "number", value: 1 },
+      { name: "steps", type: "number", value: 20 },
+    ],
+  };
+  assert.equal(pressableWidgetHint(plainNode, "stepss"), "");
+  assert.equal(pressableWidgetHint({ id: 1, type: "X", widgets: [] }, "a"), "");
+  assert.equal(pressableWidgetHint({ id: 1, type: "X" }, "a"), "");
+});
+
+test("#757 the hint NAMES the button and says the panel cannot press it", () => {
+  const hint = pressableWidgetHint(freshPowerLoraLoader(), "lora_1");
+  assert.match(hint, /➕ Add Lora/);
+  assert.match(hint, /cannot activate/);
+  assert.match(hint, /ask the user to click/i);
+});
+
+test("#757 the hint does not PROMISE that clicking creates the slot", () => {
+  // This code cannot know that "lora_1" is one of the widgets that button builds
+  // — the caller may still have made a typo on a node that happens to have a
+  // button. The wording has to survive being wrong about that.
+  const hint = pressableWidgetHint(freshPowerLoraLoader(), "lora_1");
+  assert.match(hint, /If "lora_1" is a slot of that kind/);
+  assert.doesNotMatch(hint, /will create|creates the widget you asked for/i);
+});
+
+test("#757 it says the missing capability out loud", () => {
+  // Otherwise the next reasonable move is to hunt for a press tool that does not
+  // exist, which is its own dead end.
+  assert.match(pressableWidgetHint(freshPowerLoraLoader(), "lora_1"), /no tool to press a widget/i);
+});
+
+test("#757 several buttons read as plural, and all are named", () => {
+  const node = {
+    id: 9,
+    type: "Some Grower",
+    widgets: [rgthreeAddLoraButton(), { name: "Reset", type: "button", value: "" }],
+  };
+  const hint = pressableWidgetHint(node, "any_02");
+  assert.match(hint, /controls the panel cannot activate/);
+  assert.match(hint, /➕ Add Lora/);
+  assert.match(hint, /"Reset"/);
+  assert.equal(pressableWidgets(node).length, 2);
+});
+
+test("#757 WIRING: both missing-widget refusals carry the hint", () => {
+  // A pure helper nobody calls is not a fix. Two distinct refusal sites exist and
+  // the report's exact text came from the widget-write one.
+  const ww = readFileSync(WIDGET_WRITE, "utf8");
+  assert.match(ww, /import \{ pressableWidgetHint \} from "\.\/pressable-widget\.js"/);
+  assert.ok(
+    /has no widget "\$\{widgetName\}"[\s\S]{0,400}?pressableWidgetHint\(targetNode, widgetName\)/.test(ww),
+    "widget-write.js refusal must append the hint",
+  );
+
+  const panel = readFileSync(PANEL_JS, "utf8");
+  assert.match(panel, /import \{ pressableWidgetHint \} from "\.\/lib\/pressable-widget\.js"/);
+  assert.ok(
+    /has no widget "\$\{widget\}"[\s\S]{0,400}?pressableWidgetHint\(node, widget\)/.test(panel),
+    "comfyui-mcp-panel.js refusal must append the hint",
+  );
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -68,6 +68,7 @@ import qrcodegen from "./vendor/qrcode.esm.js";
 import { computeLayout } from "./lib/layout-engine.js";
 import { missingAssetScanMayBeStale, missingAssetScopeNote } from "./lib/missing-asset-scope.js";
 import { armReloadBlockedNotice } from "./lib/reload-blocked.js";
+import { pressableWidgetHint } from "./lib/pressable-widget.js";
 import { pairDurabilityView } from "./lib/pair-durability-view.js";
 import { describeUploadFailure, attachmentSummaryLine } from "./lib/attachment-upload.js";
 import {
@@ -13399,7 +13400,10 @@ const GRAPH_TOOL_EXECUTORS = {
     if (!w) {
       const names = widgets.map((x) => x?.name).filter(Boolean);
       throw new Error(
-        `Node ${node.id} (${node.type}) has no widget "${widget}". Available: ${names.join(", ") || "(none)"}`,
+        `Node ${node.id} (${node.type}) has no widget "${widget}". Available: ${names.join(", ") || "(none)"}` +
+          // #757 — same disclosure as the widget-write path: a button the panel
+          // cannot press may be what creates the missing slot.
+          pressableWidgetHint(node, widget),
       );
     }
     // The parent SubgraphNode instance(s) embedding this subgraph (root-level

--- a/web/js/lib/pressable-widget.js
+++ b/web/js/lib/pressable-widget.js
@@ -14,10 +14,16 @@
  * a bare availability list infers a typo, and the reporter's agent fell back to
  * chaining `LoraLoaderModelOnly` nodes — losing the stacking UI they wanted.
  *
- * This is the verification half of #757 and nothing more. Pressing the button is
- * a new capability (`panel_press_widget`) and is parked behind the stabilization
- * pass. Naming a control that is already visible in the message we ALREADY send
- * cannot make anything worse.
+ * This is the verification half of #757 and nothing more. Pressing the button
+ * would be a new capability — a press-a-widget tool that invokes the widget's own
+ * click handler — and is parked behind the stabilization pass. Naming a control
+ * that is already visible in the message we ALREADY send cannot make anything
+ * worse.
+ *
+ * (That tool is described in prose rather than by a `panel_`-prefixed name on
+ * purpose: the vocabulary gate scans every such identifier, comments included,
+ * and it is right to — a name in a comment is one copy-paste from a hint string,
+ * and a hint string is read by the model. It caught this exact line.)
  *
  * WHY NOT `type === "button"`. That was the obvious check and it is wrong here.
  * rgthree's `RgthreeBetterButtonWidget` sets `this.type = "custom"` (verified in

--- a/web/js/lib/pressable-widget.js
+++ b/web/js/lib/pressable-widget.js
@@ -1,0 +1,82 @@
+/**
+ * panel#757 — when a widget is missing because a BUTTON has not been pressed,
+ * say so instead of listing names.
+ *
+ * `panel_set_widget(node, "lora_1", …)` on a freshly added Power Lora Loader
+ * (rgthree) refuses with:
+ *
+ *     Node 153 (Power Lora Loader (rgthree)) has no widget "lora_1"
+ *     (available: divider, PowerLoraLoaderHeaderWidget, divider, ➕ Add Lora)
+ *
+ * The refusal is CORRECT — the slot genuinely does not exist yet. What it does
+ * not say is that `➕ Add Lora`, sitting right there in the list, is a button
+ * that CREATES those slots, and that the panel cannot press it. An agent reading
+ * a bare availability list infers a typo, and the reporter's agent fell back to
+ * chaining `LoraLoaderModelOnly` nodes — losing the stacking UI they wanted.
+ *
+ * This is the verification half of #757 and nothing more. Pressing the button is
+ * a new capability (`panel_press_widget`) and is parked behind the stabilization
+ * pass. Naming a control that is already visible in the message we ALREADY send
+ * cannot make anything worse.
+ *
+ * WHY NOT `type === "button"`. That was the obvious check and it is wrong here.
+ * rgthree's `RgthreeBetterButtonWidget` sets `this.type = "custom"` (verified in
+ * the installed pack, `web/comfyui/utils_widgets.js`), so a type check would
+ * never fire on the exact node this report is about. What actually makes a
+ * widget pressable is that it HANDLES A CLICK, so that is what is tested — plus
+ * litegraph's canonical `"button"` type, which is already how the rest of this
+ * codebase recognises one (`cmcp-apps-ui.js` skips `w.type === "button"`).
+ *
+ * The detection is deliberately structural rather than name-based. Matching
+ * "Add"/"➕"/"New" would fire on a combo called "Add Noise" — a real widget with
+ * a real value — and tell the user to click something that is not a button.
+ */
+
+/**
+ * Does this widget respond to a click rather than hold a value?
+ *
+ * @param {{ type?: string, onMouseClick?: unknown, mouseClickCallback?: unknown }} [w]
+ */
+export function isPressableWidget(w) {
+  if (!w || typeof w !== "object") return false;
+  // rgthree's base widget class, and any pack following the same convention.
+  if (typeof w.onMouseClick === "function") return true;
+  if (typeof w.mouseClickCallback === "function") return true;
+  // litegraph's own button type.
+  return w.type === "button";
+}
+
+/** The pressable widgets on a node, in the order they are drawn. */
+export function pressableWidgets(node) {
+  const list = Array.isArray(node?.widgets) ? node.widgets : [];
+  return list.filter(isPressableWidget);
+}
+
+/**
+ * The sentence to append to a missing-widget refusal, or "" when there is
+ * nothing to add.
+ *
+ * Returns "" when the node has no pressable widget, which is the overwhelmingly
+ * common case — a plain typo. That matters more than the message itself: adding
+ * a button hypothesis to EVERY missing-widget refusal would make the ordinary
+ * case noisier and slightly misleading, which is the stated reason this was not
+ * bolted on when #757 was first triaged.
+ *
+ * @param {object} node
+ * @param {string} widgetName the widget the caller asked for
+ */
+export function pressableWidgetHint(node, widgetName) {
+  const buttons = pressableWidgets(node);
+  if (buttons.length === 0) return "";
+  const names = buttons.map((w) => `"${w?.label || w?.name || "(unnamed)"}"`).join(", ");
+  const plural = buttons.length > 1;
+  return (
+    ` This node has ${plural ? "controls" : "a control"} the panel cannot activate: ` +
+    `${names} — ${plural ? "these are buttons" : "that is a button"} rather than ` +
+    `${plural ? "values" : "a value"}, and some nodes CREATE their remaining widgets only when ` +
+    `${plural ? "one is" : "it is"} clicked (rgthree's Power Lora Loader builds its ` +
+    `\`lora_1\`, \`lora_2\`, … rows this way). If "${widgetName}" is a slot of that kind, ask the ` +
+    `user to click ${plural ? "the relevant button" : names} in the ComfyUI tab and then set it — ` +
+    `writing an existing slot works normally. There is no tool to press a widget yet.`
+  );
+}

--- a/web/js/lib/widget-write.js
+++ b/web/js/lib/widget-write.js
@@ -1,3 +1,5 @@
+import { pressableWidgetHint } from "./pressable-widget.js";
+
 // Widget-value validation + promoted-subgraph-widget target resolution for
 // graph_set_widget. Extracted so the write targets the RIGHT widget with the
 // RIGHT value and can be unit-tested by driving the SAME code path the handler
@@ -884,7 +886,11 @@ export function resolveWidgetWrite(
   if (!widget) {
     const names = (targetNode.widgets ?? []).map((cand) => cand?.name).join(", ");
     throw new WidgetWriteError(
-      `Node ${targetNode.id} (${targetNode.type}) has no widget "${widgetName}" (available: ${names || "none"}).`,
+      `Node ${targetNode.id} (${targetNode.type}) has no widget "${widgetName}" (available: ${names || "none"}).` +
+        // #757 — the available list may already contain the answer without saying
+        // so: a button that CREATES the missing slot. Empty for a node with no
+        // pressable widget, which is the ordinary typo case.
+        pressableWidgetHint(targetNode, widgetName),
     );
   }
 


### PR DESCRIPTION
Refs #757

```
Node 153 (Power Lora Loader (rgthree)) has no widget "lora_1"
(available: divider, PowerLoraLoaderHeaderWidget, divider, ➕ Add Lora)
```

The refusal is **correct** — the slot genuinely does not exist yet — and it is unchanged here. What it never said is that `➕ Add Lora`, already sitting in the list it printed, is the button that *creates* those slots, and that the panel cannot press it.

An agent reading a bare availability list infers a typo. The reporter's agent fell back to chaining `LoraLoaderModelOnly` nodes, losing the stacking UI the user had specifically asked for.

This adds only what the message already had the evidence to say. Pressing the button is a new capability (`panel_press_widget`) and stays parked behind the stabilization pass, as stated on the issue.

## `type === "button"` would not have worked

This is why it took reading the pack instead of guessing. rgthree's `RgthreeBetterButtonWidget`:

```js
class RgthreeBetterButtonWidget extends RgthreeBaseWidget {
  constructor(name, mouseClickCallback, label) {
    super(name);
    this.type = "custom";   // <- NOT "button"
    ...
```

*(verified in the installed `rgthree-comfy/web/comfyui/utils_widgets.js`)*

So the obvious check — the one the rest of this codebase already uses at `cmcp-apps-ui.js:433` — would **never have fired on the exact node this report is about**. What makes a widget pressable is that it *handles a click*, so `onMouseClick` / `mouseClickCallback` are what's tested, with litegraph's `"button"` type kept as a third signal. A test pins rgthree's real `type` value so nobody simplifies the detection back to a type check.

Detection is structural, never name-based: matching `"Add"` / `"➕"` / `"New"` would fire on **`Add Noise`** — a genuine boolean on several samplers — and tell the user to click something that isn't a button.

## The empty case is the important one

**The hint is `""` when the node has no pressable widget** — the ordinary typo case, and the overwhelming majority. Appending a button hypothesis to *every* missing-widget refusal would make the common case noisier and slightly misleading. That was the stated reason for not bolting this on at triage, and it's why the guard is the most heavily tested part.

The wording also does not promise that clicking creates the requested slot. This code can't know `lora_1` is one of the widgets that button builds, and the caller may still have typo'd on a node that happens to have a button — so it says *"if it is a slot of that kind"*, and states out loud that no press tool exists, so the next move isn't a hunt for one.

## Verification

Both missing-widget refusal sites carry it (`widget-write.js` — the one that produced the reporter's exact text — and the panel's own). Mutation-verified, each asserting an exact pre-count of 1 first:

| mutation | result |
|---|---|
| delete the append in `widget-write.js` | 1 failed |
| delete the append in `comfyui-mcp-panel.js` | 1 failed |
| invert the empty-for-typo guard | 1 failed |
| drop the `onMouseClick` signal | 1 failed |

9 new tests · panel unit suite **2887 passed** · typecheck clean · control-byte scan clean on all four changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)