### PR TITLE
fix(run_scope): drop the frontend version range, print what the body held

### DIFF
--- a/browser_tests/unit/run-scope-guard.test.mjs
+++ b/browser_tests/unit/run-scope-guard.test.mjs
@@ -13,7 +13,7 @@
  */
 import test from "node:test";
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
+import { readFileSync, readdirSync, statSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 
@@ -373,11 +373,16 @@ test("#572 promptContentHash: the narrowed exclusion tolerates ONLY the hook's o
 test("#630 scopeDroppedError: the no-scope refusal states the OBSERVATION and no longer asserts a cause it cannot see", () => {
   // The pre-#630 message asserted "this frontend build ignored the run-to-node
   // argument" for every no-usable-scope state. That is a bucket narrated as a
-  // cause, and the evidence contradicts it: ComfyUI_frontend 1.42 through 1.50
-  // all accept BOTH app.queuePrompt third-argument shapes and funnel them into
-  // api.queuePrompt's options.partialExecutionTargets. Three #556 field reports
-  // pasted that asserted cause into the tracker, which is why the real cause is
-  // still unknown. The message must survive that lesson.
+  // cause, and three #556 field reports pasted that asserted cause into the
+  // tracker, which is why the real cause is still unknown.
+  //
+  // #752 — THE REPLACEMENT WAS ALSO AN UNEARNED CLAIM, and this comment used to
+  // state it as fact: that ComfyUI_frontend 1.42 through 1.50 all accept BOTH
+  // third-argument shapes. Only 1.47.12 was ever measured. Three field reports on
+  // 1.45.21 — inside that range — hit this path, so the range was wrong, and
+  // saying so in the shipped message told each reporter their own evidence could
+  // not be happening. Whatever this note says next, it may not assert behaviour
+  // of a build nobody here has run.
   const msg = scopeDroppedError({
     toNodeId: 4995,
     verdict: { ok: false, reason: "scope_missing", expected: ["4995"], got: null, bodyKeys: ["client_id", "extra_data", "number", "prompt"] },
@@ -843,8 +848,20 @@ test("#630 gate r1: graph_run's repair disclosure separates what was OBSERVED fr
   // Rebuild the message the caller actually receives: the source spells it as
   // adjacent template chunks joined with `+`, so strip the concatenation
   // scaffolding and assert against the prose itself, not its line breaks.
+  //
+  // #752 — two things the first version of this got wrong, both of which made it
+  // assert against text that is not in the message. It sliced a magic 1800
+  // characters, so growing the note silently pushed the last assertion off the
+  // end; and it did not strip `//` comments, so a comment ABOUT the message read
+  // as part of it. Now it slices to the end of the statement and drops comment
+  // lines, which is what "the message the caller receives" actually means.
+  const end = source.indexOf("\n    }", start);
+  assert.ok(end > start, "the scope_note assignment must be a bounded block");
   const note = source
-    .slice(start, start + 1800)
+    .slice(start, end)
+    .split("\n")
+    .filter((l) => !/^\s*\/\//.test(l))
+    .join("\n")
     .replace(/`\s*\+\s*\n\s*`/g, "")
     .replace(/\s+/g, " ");
   assert.match(note, /OBSERVED: the request ComfyUI received names ONLY node \$\{to_node_id\} as an execution root/,
@@ -2528,4 +2545,133 @@ test("#659 integration: a graph_changed refusal through dispatchScopedRun NAMES 
   } finally {
     stop();
   }
+});
+
+test("#752 the repair keeps WHAT THE BODY CONTAINED, not just that it repaired", async () => {
+  // Three field reports stalled because the note said the scope "did not reach
+  // the request" without saying what did reach it. The guard already computed the
+  // body keys and threw them away — yet a frontend that DROPPED the field and one
+  // that RENAMED it produce the same sentence otherwise, and that is precisely
+  // the distinction the next report has to carry.
+  const stop = keepAlive();
+  try {
+    const server = makeServer();
+    const guard = createScopedRunGuard({
+      origFetchApi: server, execIds: ["14"], contentHash: OUR_HASH, batch: 1, toNodeId: 14,
+      queueMark: MARK_A, repairScope: true,
+    });
+    await guard(...promptPost({ prompt: OUR_OUTPUT, client_id: "x", number: MARK_A }));
+    assert.equal(guard.state.repaired, 1, "an absent key is ours to fill");
+    assert.ok(Array.isArray(guard.state.repairedFromKeys), "and the keys survive the repair");
+    assert.deepEqual(
+      guard.state.repairedFromKeys,
+      ["client_id", "number", "prompt"],
+      "exactly what the frontend sent, sorted",
+    );
+    assert.ok(
+      !guard.state.repairedFromKeys.includes("partial_execution_targets"),
+      "the key that was MISSING must never appear in the list of what was present",
+    );
+  } finally {
+    stop();
+  }
+});
+
+test("#752 the recorded keys are the FIRST repair's, not a growing list", async () => {
+  // A batch repairs once per post. Appending would read as several different
+  // causes in the report when it is one frontend behaving one way.
+  const stop = keepAlive();
+  try {
+    const server = makeServer();
+    const guard = createScopedRunGuard({
+      origFetchApi: server, execIds: ["14"], contentHash: OUR_HASH, batch: 2, toNodeId: 14,
+      queueMark: MARK_A, repairScope: true,
+    });
+    await guard(...promptPost({ prompt: OUR_OUTPUT, client_id: "x", number: MARK_A }));
+    await guard(...promptPost({ prompt: OUR_OUTPUT, client_id: "x", number: MARK_A, extra_data: {} }));
+    assert.equal(guard.state.repaired, 2);
+    assert.deepEqual(guard.state.repairedFromKeys, ["client_id", "number", "prompt"], "first only");
+  } finally {
+    stop();
+  }
+});
+
+test("#752 an unrepaired run reports no keys, rather than an empty list", async () => {
+  // "" and [] would both render as 'the body carried these keys: ' in the note.
+  // null is the honest value for 'no repair happened, so nothing was observed'.
+  const stop = keepAlive();
+  try {
+    const server = makeServer();
+    const guard = createScopedRunGuard({
+      origFetchApi: server, execIds: ["14"], contentHash: OUR_HASH, batch: 1, toNodeId: 14,
+      queueMark: MARK_A, repairScope: true,
+    });
+    await guard(
+      ...promptPost({ prompt: OUR_OUTPUT, client_id: "x", number: MARK_A, partial_execution_targets: ["14"] }),
+    );
+    assert.equal(guard.state.repaired, 0, "the frontend delivered it; nothing to repair");
+    assert.equal(guard.state.repairedFromKeys, null);
+  } finally {
+    stop();
+  }
+});
+
+test("#752 NO shipped message asserts a ComfyUI_frontend version range", () => {
+  // The messages claimed this path was "not reproducible against ComfyUI_frontend
+  // 1.42–1.50". Three field reports on 1.45.21 sit INSIDE that range and hit it.
+  // Only 1.47.12 was ever measured here, so the range was never earned — and
+  // shipping it told each reporter their own evidence could not be happening.
+  //
+  // Scanned across ALL shipped panel JS rather than asserted on one string: the
+  // claim lived in TWO places (the graph_run note and the guard's own refusal),
+  // and fixing only the one quoted in the issue would have left the other
+  // shipping the same false statement.
+  const here = dirname(fileURLToPath(import.meta.url));
+  const offenders = [];
+  const walk = (dir) => {
+    for (const name of readdirSync(dir)) {
+      const p = join(dir, name);
+      if (statSync(p).isDirectory()) walk(p);
+      else if (name.endsWith(".js")) {
+        readFileSync(p, "utf8")
+          .split("\n")
+          .forEach((line, i) => {
+            // A comment ABOUT the removed claim is the record of why; only
+            // shipped prose is the problem.
+            if (/^\s*(\/\/|\*)/.test(line)) return;
+            if (/1\.\d\d\s*[-–]\s*1\.\d\d/.test(line)) offenders.push(`${name}:${i + 1}  ${line.trim()}`);
+          });
+      }
+    }
+  };
+  walk(join(here, "../../web/js"));
+  assert.deepEqual(offenders, [], `these ship a frontend version range:\n${offenders.join("\n")}`);
+});
+
+test("#752 WIRING: the graph_run note actually PRINTS the observed body keys", () => {
+  // Recording them on the guard and never rendering them would leave the note
+  // exactly as unhelpful as it was, with a passing test suite. The value has to
+  // reach the sentence a reporter reads.
+  const here = dirname(fileURLToPath(import.meta.url));
+  const source = readFileSync(join(here, "../../web/js/comfyui-mcp-panel.js"), "utf8");
+  const start = source.indexOf('accept.scope_applied_by = "request_body_repair"');
+  assert.ok(start > 0);
+  const end = source.indexOf("\n    }", start);
+  const raw = source.slice(start, end);
+  assert.match(raw, /runScopeResult\?\.repairedFromKeys/, "the note reads the recorded keys");
+  assert.match(raw, /repairedFromKeys\.join\(", "\)/, "and renders them into the prose");
+  // Same normalisation as the #630 reconstruction above: the prose is spelled as
+  // adjacent template chunks, so a phrase that reads as one sentence is not one
+  // string in the source.
+  const prose = raw
+    .split("\n")
+    .filter((l) => !/^\s*\/\//.test(l))
+    .join("\n")
+    .replace(/`\s*\+\s*\n\s*`/g, "")
+    .replace(/\s+/g, " ");
+  assert.match(
+    prose,
+    /carried these keys and no partial_execution_targets/,
+    "labelled as what was present INSTEAD of the scope, not as a bare key dump",
+  );
 });

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -10372,13 +10372,33 @@ const GRAPH_TOOL_EXECUTORS = {
         `partial_execution_targets into this run's own request and confirmed it was ` +
         `there before dispatch. OBSERVED: the request ComfyUI received names ONLY ` +
         `node ${to_node_id} as an execution root, so only that branch executes. ` +
+        // #752 — say what the body DID contain. Three reports stalled on this note
+        // because "the scope did not reach the request" does not distinguish a
+        // frontend that dropped the field from one that renamed it or moved it,
+        // and every reporter (and I) went off inspecting argument shapes that turn
+        // out to be fine. The key list is the cheap discriminator, and the guard
+        // was already computing it — it just was not printed.
+        (Array.isArray(runScopeResult?.repairedFromKeys) && runScopeResult.repairedFromKeys.length
+          ? `The request the frontend produced carried these keys and no ` +
+            `partial_execution_targets: ${runScopeResult.repairedFromKeys.join(", ")}. ` +
+            `If a key there looks like it should have carried the scope, that name is ` +
+            `the useful part of a report. `
+          : "") +
         `NOT OBSERVED: whether the frontend also treated this as a partial execution ` +
         `internally — the panel can see the request body but not the frontend's queue ` +
         `loop. If it did not, its queue-time widget hooks ran as they would for a full ` +
         `run, so a control_after_generate widget may have advanced its value ` +
         `differently than a natively scoped run would. This does not change which ` +
-        `nodes execute. Please report this build (#556) — this path is not ` +
-        `reproducible against ComfyUI_frontend 1.42-1.50.`;
+        `nodes execute. ` +
+        // #752 — the removed sentence claimed this path was "not reproducible
+        // against ComfyUI_frontend 1.42-1.50". Three field reports on 1.45.21 are
+        // INSIDE that range and reproduced it, so the claim was false and it cost
+        // real time: it told reporters their own evidence could not be happening.
+        // A version range is a claim about builds nobody here has measured, and
+        // this note has no way to earn one — so it no longer makes it.
+        `Please report this build (#556), including your ComfyUI_frontend version — ` +
+        `which builds take which argument shape is not something the panel can ` +
+        `determine from inside one of them.`;
     }
     // #556 (codex gate r3) — an EXTRA /prompt post carrying this run's identity
     // was fenced out. The requested prompts queued, so this is a DISCLOSURE and

--- a/web/js/lib/run-scope-guard.js
+++ b/web/js/lib/run-scope-guard.js
@@ -739,8 +739,16 @@ export function scopeDroppedError({ toNodeId, verdict }) {
     `To render this branch now, either run it unscoped (panel_run without to_node_id, ` +
     `which executes the WHOLE graph — every other output branch included, at full GPU/API ` +
     `cost) or delete/bypass the output nodes you do not want and run unscoped. ` +
-    `Please report this with the body keys above — this path is not reproducible against ` +
-    `ComfyUI_frontend 1.42–1.50, where both argument shapes are honoured.`
+    // #752 — the removed clause said this path is "not reproducible against
+    // ComfyUI_frontend 1.42–1.50, where both argument shapes are honoured".
+    // Three field reports on 1.45.21 sit INSIDE that range and reproduced it, so
+    // the claim was false, and it was expensive: it told each reporter their own
+    // evidence could not be happening, and sent them (and me) to audit argument
+    // shapes that were fine. A build range is a claim about builds nobody here
+    // has run — the panel can measure the request it just made and nothing else.
+    `Please report this with the body keys above, and your ComfyUI_frontend version — ` +
+    `which builds honour which argument shape is not something the panel can determine ` +
+    `from inside one of them.`
   );
 }
 
@@ -994,7 +1002,7 @@ export function createScopedRunGuard({
 } = {}) {
   const expected = (execIds ?? []).map(String);
   const maxBatch = Math.max(1, Math.floor(Number(batch)) || 1);
-  const state = { observed: 0, repaired: 0, rejected: 0, refused: 0, overrun: 0, overrunError: null, inFlight: 0, indeterminate: 0, closed: false, retired: false, dropped: null, droppedReason: null, failed: null };
+  const state = { observed: 0, repaired: 0, rejected: 0, refused: 0, overrun: 0, overrunError: null, inFlight: 0, indeterminate: 0, closed: false, retired: false, dropped: null, droppedReason: null, failed: null, repairedFromKeys: null };
   const waiters = new Set();
   const notify = () => {
     for (const fire of [...waiters]) fire();
@@ -1096,6 +1104,14 @@ export function createScopedRunGuard({
         forwardOptions = { ...options, body: repairedBody };
         targets = expected.slice();
         state.repaired++;
+        // #752 — WHAT THE BODY ACTUALLY CONTAINED. Three reports have not
+        // narrowed this because the note says the scope "did not reach the
+        // request" without saying what did. The keys distinguish the cases
+        // that matter: a frontend that dropped the field entirely, versus one
+        // that renamed it, versus one that put it somewhere else. Recorded
+        // from the FIRST repair only — later posts in a batch are the same
+        // shape, and a growing list would read as several distinct causes.
+        if (state.repairedFromKeys === null) state.repairedFromKeys = scopeRead.bodyKeys;
       }
     }
     if (contentOk && targets && sameSet(targets, expected)) {
@@ -1589,6 +1605,7 @@ export async function dispatchScopedRun({
         verified: guard.state.observed,
         repaired: guard.state.repaired,
         scopeAppliedBy: guard.state.repaired > 0 ? "request_body_repair" : "frontend",
+        repairedFromKeys: guard.state.repairedFromKeys,
         indeterminate: guard.state.indeterminate,
       volatileInputs: volatileList,
       };
@@ -1608,6 +1625,7 @@ export async function dispatchScopedRun({
         // ran with isPartialExecution=false. graph_run states this in the
         // result rather than letting the caller infer a native scoped run.
         scopeAppliedBy: guard.state.repaired > 0 ? "request_body_repair" : "frontend",
+        repairedFromKeys: guard.state.repairedFromKeys,
         // DISCLOSE a fenced overrun (r3). The requested prompts DID queue, so
         // this is not a failure and must not be reported as one — but an extra
         // identical-identity post was blocked, and the caller should know their


### PR DESCRIPTION
Refs #752, #746, #748

Two shipped messages told reporters that what they were looking at could not be happening:

> this path is not reproducible against ComfyUI_frontend 1.42–1.50, where both argument shapes are honoured

Three field reports on **1.45.21** — *inside* that range — hit this path. The claim was false, and it was expensive: each reporter had to weigh their own evidence against the panel asserting it was impossible, and the first one said so outright. It also sent them, and me, to audit `app.queuePrompt` argument shapes that turn out to be fine.

Only **1.47.12** was ever measured. A build range is a claim about builds nobody here has run, and a note written from inside one frontend has no way to earn it. Both messages now ask for the reporter's frontend version instead of telling them what it does.

**The claim lived in two places** — the `graph_run` scope note and the guard's own refusal. Fixing only the one quoted in the issue would have left the other shipping the same sentence, so a test scans **all** shipped panel JS for a version-range literal rather than asserting on one string. Comments about the removed claim are exempt; the record of why it went is worth keeping.

## Say what the body actually contained

`repaired > 0` means the guard *saw* this run's POST and found `partial_execution_targets` genuinely absent. It already computed the body's key list to decide that — and then threw it away. So the note could only ever say the scope "did not reach the request", which does not separate:

- a frontend that **dropped** the field, from
- one that **renamed** it, from
- one that **moved** it somewhere else.

That is exactly the distinction three reports have failed to narrow. The keys are now carried through and printed:

> The request the frontend produced carried these keys and no partial_execution_targets: `client_id, extra_data, number, prompt`. If a key there looks like it should have carried the scope, that name is the useful part of a report.

From the **first** repair only — appending across a batch would read as several distinct causes when it's one frontend behaving one way — and `null` rather than `[]` when nothing was repaired, so "no repair happened" can't render as "the body had no keys".

## Two test-scaffolding defects, found while in here

Both made assertions run against text that is not in the message:

1. The #630 reconstruction sliced a **magic 1800 characters**, so growing the note silently pushed its last assertion off the end.
2. It did not strip `//` comments, so a comment *about* the message read as part of it.

It now slices to the end of the statement and drops comment lines. The test comment that *justified* the removed claim — asserting 1.42–1.50 all accept both shapes — is corrected too; leaving it would have re-licensed adding the sentence back.

## Verification

| mutation | result |
|---|---|
| stop recording the body keys | 2 failed |
| append across the batch instead of first-only | 1 failed |
| unwire the render from the note | 1 failed |
| re-introduce the version range in `run-scope-guard.js` | 1 failed |
| re-introduce it in `comfyui-mcp-panel.js` | 1 failed |

Each asserted an exact pre-count of 1 before mutating.

5 new tests · panel unit suite **2892 passed** · typecheck and the vocabulary gate exit 0 · control-byte scan clean.

**Not fixed here, and deliberately:** why the frontend omits the field on those builds. That is still unknown, and this PR is the instrumentation that lets the next report say something new instead of repeating the last three.

🤖 Generated with [Claude Code](https://claude.com/claude-code)