### PR TITLE
fix(graph_load): API-format workflows ARE loadable — import them

### DIFF
--- a/browser_tests/unit/api-workflow-load.test.mjs
+++ b/browser_tests/unit/api-workflow-load.test.mjs
@@ -1,0 +1,206 @@
+// panel#775 — API/prompt-format workflows ARE loadable, and the panel refused
+// them on a false premise.
+//
+// The refusal said: "workflow is in API/prompt format; provide the UI workflow
+// JSON (the pack workflow.json is UI format)". Both halves were wrong. ComfyUI
+// ships `app.loadApiJson` and uses it on its own file-drop path, and the pack
+// that prompted the report ships API format — as does its upstream source — so
+// the file it told the reader to provide does not exist.
+//
+// The numbers below are MEASURED, not invented: against the live rig
+// (ComfyUI 0.30.2 / frontend 1.47.12) the report's exact workflow
+// (jcd315/comfyui-mcp-muse workflows/ltx23_distill_3stage.json, 59 API entries)
+// loaded as 56 nodes and 70 links with no throw, and the three that did not
+// arrive were all LTXVImgToVideoConditionOnly — a node type the installed
+// ComfyUI-LTXVideo does not provide.
+
+import assert from "node:assert/strict";
+import test from "node:test";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+import {
+  looksLikeApiWorkflow,
+  apiClassCounts,
+  apiLoadShortfall,
+  apiLoadNote,
+} from "../../web/js/lib/api-workflow-load.js";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const PANEL_JS = join(HERE, "../../web/js/comfyui-mcp-panel.js");
+
+/** The report's shape, reduced: numeric keys -> {class_type, inputs}. */
+const API = {
+  1: { class_type: "UNETLoader", inputs: { unet_name: "ltx.safetensors" } },
+  10: { class_type: "LTXVImgToVideoConditionOnly", inputs: { positive: ["1", 0] } },
+  11: { class_type: "LTXVImgToVideoConditionOnly", inputs: { positive: ["1", 0] } },
+  12: { class_type: "LTXVImgToVideoConditionOnly", inputs: { positive: ["1", 0] } },
+  20: { class_type: "KSamplerSelect", inputs: { sampler_name: "euler" } },
+};
+
+describe_shape();
+function describe_shape() {
+  test("#775 the API shape is recognised, and a UI workflow is not", () => {
+    assert.equal(looksLikeApiWorkflow(API), true);
+    // A UI workflow has a top-level nodes array — the two cannot be confused.
+    assert.equal(looksLikeApiWorkflow({ nodes: [], links: [] }), false);
+    // Neither can anything else that happens to be an object.
+    assert.equal(looksLikeApiWorkflow({}), false);
+    assert.equal(looksLikeApiWorkflow(null), false);
+    assert.equal(looksLikeApiWorkflow([]), false);
+    assert.equal(looksLikeApiWorkflow("{}"), false);
+    // Numeric keys alone are not enough — something must carry class_type.
+    assert.equal(looksLikeApiWorkflow({ 1: { foo: 1 }, 2: { bar: 2 } }), false);
+    // A single non-numeric key disqualifies it (that is a UI-ish object).
+    assert.equal(looksLikeApiWorkflow({ 1: { class_type: "X" }, extra: {} }), false);
+  });
+}
+
+test("#775 a fully-loaded graph reports NO shortfall", () => {
+  const landed = [
+    { type: "UNETLoader" },
+    { type: "LTXVImgToVideoConditionOnly" },
+    { type: "LTXVImgToVideoConditionOnly" },
+    { type: "LTXVImgToVideoConditionOnly" },
+    { type: "KSamplerSelect" },
+  ];
+  assert.deepEqual(apiLoadShortfall(API, landed), []);
+});
+
+test("#775 the MEASURED case: three nodes of one missing type", () => {
+  // Exactly what the rig produced — the type is absent from the canvas entirely,
+  // so all three instances are gone while everything else arrives.
+  const landed = [{ type: "UNETLoader" }, { type: "KSamplerSelect" }];
+  assert.deepEqual(apiLoadShortfall(API, landed), [
+    { type: "LTXVImgToVideoConditionOnly", wanted: 3, got: 0 },
+  ]);
+});
+
+test("#775 a PARTIAL shortfall is still a shortfall", () => {
+  // One of three arriving is not success. Counting types rather than presence is
+  // what catches this.
+  const landed = [
+    { type: "UNETLoader" },
+    { type: "LTXVImgToVideoConditionOnly" },
+    { type: "KSamplerSelect" },
+  ];
+  assert.deepEqual(apiLoadShortfall(API, landed), [
+    { type: "LTXVImgToVideoConditionOnly", wanted: 3, got: 1 },
+  ]);
+});
+
+test("#775 EXTRA nodes on the canvas never mask a shortfall", () => {
+  // The canvas may hold nodes the API workflow never asked for. Comparing totals
+  // would let 3 unrelated nodes hide 3 missing ones; comparing per TYPE cannot.
+  const landed = [
+    { type: "UNETLoader" },
+    { type: "KSamplerSelect" },
+    { type: "PreviewImage" },
+    { type: "PreviewImage" },
+    { type: "PreviewImage" },
+  ];
+  assert.deepEqual(apiLoadShortfall(API, landed), [
+    { type: "LTXVImgToVideoConditionOnly", wanted: 3, got: 0 },
+  ]);
+});
+
+test("#775 counts are per class_type", () => {
+  const c = apiClassCounts(API);
+  assert.equal(c.get("LTXVImgToVideoConditionOnly"), 3);
+  assert.equal(c.get("UNETLoader"), 1);
+  assert.equal(c.size, 3);
+});
+
+test("#775 the note ALWAYS states the layout caveat", () => {
+  // It is always true and it is the one consequence a caller cannot infer from a
+  // node count — and saving the result makes it permanent.
+  const clean = apiLoadNote([]);
+  assert.match(clean, /layout is generated rather than the author's/);
+  assert.match(clean, /execution is unaffected/);
+  assert.match(clean, /replaces the original layout permanently/);
+  // With no shortfall it must NOT invent a missing-node warning.
+  assert.doesNotMatch(clean, /NODES ARE MISSING/);
+});
+
+test("#775 the note NAMES the missing types and when they will bite", () => {
+  const note = apiLoadNote([{ type: "LTXVImgToVideoConditionOnly", wanted: 3, got: 0 }]);
+  assert.match(note, /NODES ARE MISSING/);
+  assert.match(note, /LTXVImgToVideoConditionOnly \(3 of 3\)/);
+  // The timing is the point: the graph looks fine and fails later, somewhere else.
+  assert.match(note, /fail at queue time, not at load time/);
+  assert.match(note, /Install the custom-node pack/);
+});
+
+test("#775 the note reads correctly for a single missing node", () => {
+  const note = apiLoadNote([{ type: "Foo", wanted: 1, got: 0 }]);
+  assert.match(note, /this node type/);
+  assert.match(note, /that node did not load/);
+  assert.match(note, /wired to it is now disconnected/);
+  assert.doesNotMatch(note, /these node types/);
+});
+
+test("#775 ONE missing type can mean SEVERAL missing nodes", () => {
+  // The measured case, and a grammar bug the real output exposed: three
+  // instances of one type rendered as "that node ... wired to THEM". Types and
+  // nodes are separate counts and the sentence has to track both.
+  const note = apiLoadNote([{ type: "LTXVImgToVideoConditionOnly", wanted: 3, got: 0 }]);
+  assert.match(note, /this node type/, "one TYPE is missing");
+  assert.match(note, /those nodes did not load/, "but three NODES are");
+  assert.match(note, /wired to them is now disconnected/);
+  assert.match(note, /provides it and load again/, "and the pack to install is singular");
+});
+
+test("#775 WIRING: graph_load delegates to loadApiJson instead of refusing", () => {
+  const src = readFileSync(PANEL_JS, "utf8");
+  assert.match(
+    src,
+    /import \{ looksLikeApiWorkflow, apiLoadShortfall, apiLoadNote \} from "\.\/lib\/api-workflow-load\.js"/,
+  );
+  const i = src.indexOf("if (looksLikeApiWorkflow(data))");
+  assert.ok(i > 0, "graph_load must branch on the API shape");
+  const branch = src.slice(i, i + 2200);
+  assert.match(branch, /app\.loadApiJson\(apiClone, "graph_load\.json"\)/, "it imports rather than refusing");
+  // The label avoids naming the internal bridge command on purpose: the
+  // vocabulary gate reads any such name in a string as advice a model could try
+  // to call, and it caught the first version of this line.
+  assert.match(
+    branch,
+    /captureGraphSnapshot\(null, "before loading an API-format workflow"\)/,
+    "and stays undoable like every other graph edit",
+  );
+  assert.match(branch, /apiLoadShortfall\(apiClone, landed\)/, "and compares what arrived");
+  assert.match(branch, /note: apiLoadNote\(shortfall\)/, "and discloses it");
+});
+
+test("#775 the DISCREDITED refusal text is gone from the shipped panel", () => {
+  // It told the reader to provide a UI workflow JSON that, for the pack in the
+  // report, does not exist anywhere — not in the pack and not upstream.
+  //
+  // Comment lines are excluded deliberately: the docblock QUOTES the removed
+  // text to record what was wrong and why, and the first run of this test caught
+  // that quotation. The record is worth keeping; only shipped prose is the bug.
+  const shipped = readFileSync(PANEL_JS, "utf8")
+    .split("\n")
+    .filter((l) => !/^\s*(\/\/|\*|\/\*)/.test(l))
+    .join("\n");
+  assert.doesNotMatch(shipped, /the pack workflow\.json is UI format/);
+  assert.doesNotMatch(shipped, /is in API\/prompt format; provide the UI workflow JSON/);
+});
+
+test("#775 a frontend WITHOUT loadApiJson still refuses, and says why", () => {
+  // The capability is not universal. Falling through to loadGraphData with API
+  // data would produce the 0-node "successful" load this issue also reported.
+  const src = readFileSync(PANEL_JS, "utf8");
+  const i = src.indexOf('typeof app.loadApiJson !== "function"');
+  assert.ok(i > 0, "the absent-capability guard must exist");
+  // Join the adjacent string chunks: a sentence the caller reads as one line is
+  // not one literal in the source, and asserting on the raw text tests the line
+  // breaks rather than the message.
+  const guard = src
+    .slice(i, i + 700)
+    .replace(/"\s*\+\s*\n\s*"/g, "")
+    .replace(/\s+/g, " ");
+  assert.match(guard, /has no app\.loadApiJson to import it/);
+  assert.match(guard, /top-level `nodes` array/, "and points at what WOULD work");
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -69,6 +69,7 @@ import { computeLayout } from "./lib/layout-engine.js";
 import { missingAssetScanMayBeStale, missingAssetScopeNote } from "./lib/missing-asset-scope.js";
 import { armReloadBlockedNotice } from "./lib/reload-blocked.js";
 import { pressableWidgetHint } from "./lib/pressable-widget.js";
+import { looksLikeApiWorkflow, apiLoadShortfall, apiLoadNote } from "./lib/api-workflow-load.js";
 import { pairDurabilityView } from "./lib/pair-durability-view.js";
 import { describeUploadFailure, attachmentSummaryLine } from "./lib/attachment-upload.js";
 import {
@@ -8780,19 +8781,46 @@ const GRAPH_TOOL_EXECUTORS = {
     if (!data || typeof data !== "object") {
       throw new Error("graph (object or JSON string) is required");
     }
-    // Validate UI/litegraph format. The live canvas loads UI-format graphs
-    // (top-level `nodes` array); API/prompt format (top-level numeric keys, each
-    // an object with `class_type`) is NOT loadable here.
+    // #775 — API/prompt format IS loadable, through the frontend's own importer.
+    // This branch used to refuse it outright and tell the caller to "provide the
+    // UI workflow JSON (the pack workflow.json is UI format)". Both halves were
+    // wrong: ComfyUI ships `app.loadApiJson` and uses it on its own file-drop
+    // path, and the pack that prompted the report ships API format — as does its
+    // upstream source — so the file it pointed at does not exist.
+    //
+    // Verified against the live rig (ComfyUI 0.30.2 / frontend 1.47.12) with that
+    // exact workflow: 59 API entries loaded as 56 nodes and 70 links with no
+    // throw, rgthree's Power Lora Loader included. The frontend instantiates real
+    // node classes, so widget/link separation is done by the nodes themselves
+    // rather than by a converter guessing from /object_info.
     if (!Array.isArray(data.nodes)) {
-      const keys = Object.keys(data);
-      const looksLikeApi =
-        keys.length > 0 &&
-        keys.every((k) => /^\d+$/.test(k)) &&
-        keys.some((k) => data[k] && typeof data[k] === "object" && "class_type" in data[k]);
-      if (looksLikeApi) {
-        throw new Error(
-          "workflow is in API/prompt format; provide the UI workflow JSON (the pack workflow.json is UI format)",
-        );
+      if (looksLikeApiWorkflow(data)) {
+        if (typeof app.loadApiJson !== "function") {
+          throw new Error(
+            "workflow is in API/prompt format and this frontend has no app.loadApiJson to " +
+              "import it. Provide a UI workflow JSON (one with a top-level `nodes` array), " +
+              "or open the API JSON in the ComfyUI tab by hand.",
+          );
+        }
+        const apiClone = JSON.parse(JSON.stringify(data));
+        // Snapshot first, exactly like the UI path — an API import replaces the
+        // canvas too, and must be as undoable as any other graph edit this turn.
+        captureGraphSnapshot(null, "before loading an API-format workflow");
+        await app.loadApiJson(apiClone, "graph_load.json");
+        // COMPARE WHAT ARRIVED. A missing node type is an uninstalled pack, and a
+        // load that quietly drops nodes and reports success is the exact failure
+        // this codebase keeps fixing — the graph then fails at QUEUE time, with a
+        // disconnected input, far from the call that caused it.
+        const landed = app?.graph?._nodes ?? [];
+        const shortfall = apiLoadShortfall(apiClone, landed);
+        return {
+          loaded: true,
+          format: "api",
+          node_count: landed.length,
+          entries_in: Object.keys(apiClone).length,
+          ...(shortfall.length ? { missing_node_types: shortfall } : {}),
+          note: apiLoadNote(shortfall),
+        };
       }
       throw new Error(
         "graph is not a UI workflow (missing a `nodes` array). Provide the UI workflow JSON.",

--- a/web/js/lib/api-workflow-load.js
+++ b/web/js/lib/api-workflow-load.js
@@ -1,0 +1,131 @@
+/**
+ * panel#775 — API/prompt-format workflows ARE loadable. The panel was refusing
+ * them on a premise that is false.
+ *
+ * `graph_load` said:
+ *
+ *     API/prompt format (top-level numeric keys, each an object with
+ *     `class_type`) is NOT loadable here
+ *     -> "workflow is in API/prompt format; provide the UI workflow JSON
+ *         (the pack workflow.json is UI format)"
+ *
+ * Both halves are wrong. ComfyUI's own frontend carries `isApiJson` and
+ * `app.loadApiJson(data, fileName)`, and uses them on its own file-drop path.
+ * Measured against the live rig (ComfyUI 0.30.2 / frontend 1.47.12) with the
+ * exact workflow from the report — `jcd315/comfyui-mcp-muse`
+ * workflows/ltx23_distill_3stage.json, 59 API entries:
+ *
+ *     app.loadApiJson(api, "ltx23_distill_3stage.json")
+ *       -> 56 nodes, 70 links, no throw, no alert
+ *
+ * Including rgthree's Power Lora Loader, which rebuilt its five widgets. The
+ * frontend instantiates real nodes, so widget/link separation is done by the
+ * node classes themselves rather than by a converter guessing from
+ * `/object_info` — which is why this works where a hand-rolled API->UI
+ * conversion would not.
+ *
+ * And the parenthetical was false for the pack that prompted the report: that
+ * pack ships API format, and so does its upstream source. Telling the reader to
+ * "provide the UI workflow JSON" pointed at a file that does not exist.
+ *
+ * WHAT IS GENUINELY LOST, and why the caller is told rather than left to notice:
+ * API format has already discarded node POSITIONS, so the layout is synthesized.
+ * Nothing about execution changes — topology and widget values are intact — but
+ * the graph will not look like the author's, and someone who saves it has
+ * replaced the layout for good.
+ *
+ * THE SHORTFALL IS THE IMPORTANT PART. 59 entries became 56 nodes, and the three
+ * that vanished are all `LTXVImgToVideoConditionOnly`, a node type the installed
+ * ComfyUI-LTXVideo does not provide. A load that silently drops three nodes and
+ * reports success is the failure this codebase keeps fixing, so the count is
+ * compared and any missing TYPE is named. Without that, the graph looks loaded
+ * and fails at queue time with a disconnected input.
+ */
+
+/**
+ * Is this the API/prompt shape — a map of node id to `{class_type, inputs}`?
+ *
+ * Deliberately the same test the caller already used, extracted so it can be
+ * exercised directly. It requires EVERY key to be numeric and at least one entry
+ * to carry `class_type`: a UI workflow has a top-level `nodes` array and fails
+ * the first condition, so the two shapes cannot be confused.
+ *
+ * @param {unknown} data
+ */
+export function looksLikeApiWorkflow(data) {
+  if (!data || typeof data !== "object" || Array.isArray(data)) return false;
+  if (Array.isArray(/** @type {any} */ (data).nodes)) return false;
+  const keys = Object.keys(data);
+  if (keys.length === 0) return false;
+  if (!keys.every((k) => /^\d+$/.test(k))) return false;
+  return keys.some((k) => {
+    const v = /** @type {any} */ (data)[k];
+    return v && typeof v === "object" && "class_type" in v;
+  });
+}
+
+/** How many of each class_type the API workflow asked for. */
+export function apiClassCounts(apiData) {
+  const want = new Map();
+  for (const v of Object.values(apiData ?? {})) {
+    const t = v && typeof v === "object" ? v.class_type : undefined;
+    if (typeof t === "string") want.set(t, (want.get(t) ?? 0) + 1);
+  }
+  return want;
+}
+
+/**
+ * Which node types asked for did NOT arrive on the canvas.
+ *
+ * A missing type is almost always an uninstalled custom-node pack, and it is the
+ * one thing that makes a "loaded" graph unrunnable while looking fine.
+ *
+ * @param {object} apiData the API/prompt workflow that was loaded
+ * @param {Array<{type?: string}>} landedNodes `graph._nodes` after the load
+ * @returns {{type: string, wanted: number, got: number}[]}
+ */
+export function apiLoadShortfall(apiData, landedNodes) {
+  const want = apiClassCounts(apiData);
+  const got = new Map();
+  for (const n of landedNodes ?? []) {
+    const t = n?.type;
+    if (typeof t === "string") got.set(t, (got.get(t) ?? 0) + 1);
+  }
+  const out = [];
+  for (const [type, wanted] of want) {
+    const have = got.get(type) ?? 0;
+    if (have < wanted) out.push({ type, wanted, got: have });
+  }
+  return out.sort((a, b) => a.type.localeCompare(b.type));
+}
+
+/**
+ * What to tell the caller about a load that went through the API path.
+ *
+ * Always states the layout caveat, because it is always true and it is the one
+ * consequence a caller cannot see from a node count. Names missing types only
+ * when there are any.
+ */
+export function apiLoadNote(shortfall) {
+  const layout =
+    "Loaded from API/prompt format via the frontend's own importer. Node positions are " +
+    "NOT in that format, so the layout is generated rather than the author's — execution " +
+    "is unaffected (topology and widget values are intact), but saving this workflow " +
+    "replaces the original layout permanently.";
+  if (!shortfall?.length) return layout;
+  const missing = shortfall.map((s) => `${s.type} (${s.wanted - s.got} of ${s.wanted})`).join(", ");
+  // Two independent counts, and mixing them reads as a bug in the message itself:
+  // ONE missing type can account for SEVERAL missing nodes (the measured case is
+  // exactly that — three instances of one type). Types decide "this node type" vs
+  // "these node types"; nodes decide "that node" vs "those nodes".
+  const typeCount = shortfall.length;
+  const nodeCount = shortfall.reduce((n, s) => n + (s.wanted - s.got), 0);
+  return (
+    `${layout} NODES ARE MISSING: ${missing}. The canvas does not have ${
+      typeCount > 1 ? "these node types" : "this node type"
+    }, so ${nodeCount > 1 ? "those nodes" : "that node"} did not load and anything wired to ${
+      nodeCount > 1 ? "them is" : "it is"
+    } now disconnected — this graph will fail at queue time, not at load time. Install the ` +
+    `custom-node pack that provides ${typeCount > 1 ? "them" : "it"} and load again.`
+  );
+}


### PR DESCRIPTION
Refs #775

`graph_load` refused API/prompt format on a premise that is false:

```js
// API/prompt format ... is NOT loadable here
throw new Error("workflow is in API/prompt format; provide the UI workflow JSON (the pack workflow.json is UI format)")
```

**Both halves are wrong.** ComfyUI's frontend carries `isApiJson` and `app.loadApiJson(data, fileName)` and uses them on its own file-drop path. And the parenthetical was false for the pack that prompted the report: that pack ships API format — **and so does its upstream source**, `jcd315/comfyui-mcp-muse` `workflows/ltx23_distill_3stage.json`, which I fetched and checked. The message pointed the reader at a file that does not exist anywhere.

## Measured, not assumed

Against the live rig — ComfyUI 0.30.2, frontend 1.47.12 — with that exact workflow:

```
app.loadApiJson(api, "ltx23_distill_3stage.json")
  59 API entries -> 56 nodes, 70 links, no throw, no alert
```

rgthree's Power Lora Loader rebuilt its five widgets. That's the reason to use the frontend's importer rather than writing a converter: it instantiates **real node classes**, so widget/link separation is done by the nodes themselves instead of guessing from `/object_info` — which cannot work for a node whose widgets are dynamic.

## What did *not* arrive is the point

59 entries became 56 nodes. The three that vanished were all `LTXVImgToVideoConditionOnly` — a node type the installed ComfyUI-LTXVideo does not provide.

A load that silently drops three nodes and reports success is the failure this codebase keeps fixing: the graph then fails at **queue** time, on a disconnected input, far from the call that caused it. So the result compares asked-for against landed **per type** — a total would let unrelated canvas nodes mask a shortfall — and names anything missing:

> Loaded from API/prompt format via the frontend's own importer. Node positions are NOT in that format, so the layout is generated rather than the author's — execution is unaffected (topology and widget values are intact), but saving this workflow replaces the original layout permanently. **NODES ARE MISSING: LTXVImgToVideoConditionOnly (3 of 3).** The canvas does not have this node type, so those nodes did not load and anything wired to them is now disconnected — this graph will fail at queue time, not at load time. Install the custom-node pack that provides it and load again.

`loadApiJson` is not universal — a frontend without it still refuses and says so, rather than falling through to `loadGraphData` with API data, which is what produced the **0-node "successful" load** also reported on this issue.

## Two things the real output caught that the tests hadn't

- The snapshot label named an internal bridge command, which the vocabulary gate reads as advice a model could try to call. **Relabelled, not waived.**
- *"that node ... wired to **them**"* — one missing **type** can mean several missing **nodes**, and the sentence has to track both counts separately.

## Verification

| mutation | result |
|---|---|
| revert to refusing API format | 2 failed |
| drop the shortfall comparison | 2 failed |
| drop the snapshot (undo-ability) | 2 failed |
| remove the absent-capability guard | 1 failed |
| compare totals instead of per-type | 2 failed |

Each asserted an exact pre-count of 1 first.

13 new tests · panel unit suite **2905 passed** · typecheck and the vocabulary gate exit 0 · control-byte scan clean.

**Still open on #775, and not addressed here:** the pack arguably shouldn't ship API format in the first place, and `LTXVImgToVideoConditionOnly` appears to be a genuinely missing dependency rather than a format problem — that's a second, independent defect in the pack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)