### PR TITLE
perf(add_node): verify ONE node type, not the whole schema

### DIFF
--- a/browser_tests/unit/add-node-upload-widget.test.mjs
+++ b/browser_tests/unit/add-node-upload-widget.test.mjs
@@ -54,6 +54,13 @@ import {
   WIDGET_ABSENT,
   WIDGET_NON_SERIALIZING,
 } from "../../web/js/lib/add-node-widget-guard.js";
+// #767 — graph_add_node now consults ONE node type instead of re-downloading the
+// whole schema. Both are free identifiers inside the extracted body, so they have
+// to be injected like every other dependency; without them the body throws a
+// ReferenceError that the resolver catches and reports as "object_info is
+// unavailable", which is how this harness caught the omission.
+import { isRegisteredNodeType } from "../../web/js/lib/node-resolve.js";
+import { fetchSingleNodeDef } from "../../web/js/lib/single-node-def.js";
 
 const panelPath = fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url));
 const panelSrc = readFileSync(panelPath, "utf8");
@@ -214,6 +221,8 @@ function realGraphAddNode(comfy, overrides = {}) {
     unavailableRequiredWidgetReport,
     unavailableRequiredWidgetMessage,
     snapshotBackendDef,
+    isRegisteredNodeType,
+    fetchSingleNodeDef,
     describeUnmaterializedRequiredWidgets,
     ...overrides,
   };
@@ -512,4 +521,84 @@ test("classifyUnmaterializedWidget distinguishes the two faults", () => {
   assert.equal(classifyUnmaterializedWidget(node, "upload"), WIDGET_NON_SERIALIZING);
   assert.equal(classifyUnmaterializedWidget(node, "image"), WIDGET_ABSENT);
   assert.equal(classifyUnmaterializedWidget(undefined, "image"), WIDGET_ABSENT);
+});
+
+// ---------------------------------------------------------------------------
+// #767 — the fast path: verify ONE node type, not the whole schema.
+// ---------------------------------------------------------------------------
+
+test("#767 an ALREADY-REGISTERED type is verified with one class, not the whole schema", async () => {
+  // The reported failure: ~10 parallel adds on an 88-node workflow, each pulling
+  // the full /object_info (5.4 MB on a 63-pack install), serialising behind the
+  // coalescer and blowing the 30 s deadline — after which the adds landed anyway
+  // and left ghosts. LoadImage is already registered here, which is the shape of
+  // every add in that report.
+  const comfy = makeComfy();
+  let fullFetches = 0;
+  const routes = [];
+  const addNode = realGraphAddNode(comfy, {
+    api: {
+      getNodeDefs: async () => {
+        fullFetches++;
+        return backendObjectInfo();
+      },
+      fetchApi: async (route) => {
+        routes.push(route);
+        return { status: 200, json: async () => ({ LoadImage: backendObjectInfo().LoadImage }) };
+      },
+    },
+  });
+
+  const res = await addNode({ class_type: "LoadImage", pos: [10, 10] });
+  assert.deepEqual(res.added.widgets, ["image", "upload"], "the add still succeeds, fully");
+  assert.deepEqual(routes, ["/object_info/LoadImage"], "it asked about exactly one class");
+  assert.equal(fullFetches, 0, "and never pulled the whole schema");
+});
+
+test("#767 ANY doubt on the single-class route falls back to the full fetch", async () => {
+  // The safety property this whole change rests on: the fast path may only
+  // CONFIRM. A 404 (an older ComfyUI without the route) must not become a verdict
+  // about the node type — it must reach exactly the code that runs today.
+  const comfy = makeComfy();
+  let fullFetches = 0;
+  const addNode = realGraphAddNode(comfy, {
+    api: {
+      getNodeDefs: async () => {
+        fullFetches++;
+        return backendObjectInfo();
+      },
+      fetchApi: async () => ({ status: 404, json: async () => ({}) }),
+    },
+  });
+
+  const res = await addNode({ class_type: "LoadImage", pos: [10, 10] });
+  assert.deepEqual(res.added.widgets, ["image", "upload"], "the add still succeeds, via the unchanged path");
+  assert.equal(fullFetches, 1, "the full fetch is the fallback and it ran");
+});
+
+test("#767 an UNREGISTERED type never takes the fast path", async () => {
+  // Not about speed. The resolver hands freshDefs to refreshComfyNodeDefs() when a
+  // type still needs registering, and a single-class payload reaching a
+  // whole-schema refresh could deregister everything else. The gate makes that
+  // branch unreachable; this proves the gate holds.
+  const comfy = makeComfy();
+  delete comfy.LG.registered_node_types.LoadImage;
+  let fullFetches = 0;
+  let singleFetches = 0;
+  const addNode = realGraphAddNode(comfy, {
+    api: {
+      getNodeDefs: async () => {
+        fullFetches++;
+        return backendObjectInfo();
+      },
+      fetchApi: async () => {
+        singleFetches++;
+        return { status: 200, json: async () => ({ LoadImage: backendObjectInfo().LoadImage }) };
+      },
+    },
+  });
+
+  await addNode({ class_type: "LoadImage", pos: [10, 10] });
+  assert.equal(singleFetches, 0, "an unregistered type must not use the single-class route");
+  assert.equal(fullFetches, 1, "it takes the full-schema path, which the refresh needs");
 });

--- a/browser_tests/unit/single-node-def.test.mjs
+++ b/browser_tests/unit/single-node-def.test.mjs
@@ -1,0 +1,146 @@
+// panel#767 — every panel_add_node re-downloaded the ENTIRE node schema.
+//
+// #458 made the fresh /object_info the sole authority for "does the backend still
+// provide this type", which is right — a stale registry keeps positives for packs
+// that have since been uninstalled. But it fetched the whole document. Measured on
+// the rig (ComfyUI 0.30.2, 63 custom-node packs):
+//
+//     GET /object_info            5,413,770 bytes   167 ms
+//     GET /object_info/KSampler       3,246 bytes   1.2 ms
+//
+// A burst of ten adds pulled ~54 MB, the payload-carrying refreshes serialised
+// behind each other, and the 30 s reply deadline expired — after which the adds
+// landed anyway, which is where the report's "ghost" nodes came from.
+//
+// The rule this file exists to hold: the fast path may only ever CONFIRM. Every
+// other outcome falls through to the full fetch, so no refusal, removal verdict or
+// history check is ever decided on the smaller payload.
+
+import assert from "node:assert/strict";
+import test from "node:test";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+import { fetchSingleNodeDef, singleDefConfirms } from "../../web/js/lib/single-node-def.js";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const PANEL_JS = join(HERE, "../../web/js/comfyui-mcp-panel.js");
+
+/** A fetchApi double. Records routes so "did it ask for one class?" is checkable. */
+function fakeApi({ status = 200, body = undefined, throws = false, json } = {}) {
+  const routes = [];
+  const fetchApi = async (route) => {
+    routes.push(route);
+    if (throws) throw new Error("network down");
+    return {
+      status,
+      json: json ?? (async () => body),
+    };
+  };
+  fetchApi.routes = routes;
+  return fetchApi;
+}
+
+test("#767 it asks for exactly the one class, url-encoded", async () => {
+  const api = fakeApi({ body: { "Power Lora Loader (rgthree)": { input: {} } } });
+  const got = await fetchSingleNodeDef("Power Lora Loader (rgthree)", api);
+  assert.ok(got, "a body containing the class is a confirmation");
+  assert.deepEqual(api.routes, ["/object_info/Power%20Lora%20Loader%20(rgthree)"]);
+});
+
+test("#767 a confirmation returns the defs, shaped like the full document", async () => {
+  // The caller feeds this straight to hasOwnProperty(defs, class_type) — the same
+  // authority test #458 runs against the whole schema — so the shape must match.
+  const body = { KSampler: { input: { required: {} } } };
+  const got = await fetchSingleNodeDef("KSampler", fakeApi({ body }));
+  assert.ok(Object.prototype.hasOwnProperty.call(got, "KSampler"));
+});
+
+test("#767 ABSENCE is {} with HTTP 200 on this route, and is NOT a verdict", async () => {
+  // Verified against the live rig: /object_info/LTXVImgToVideoConditionOnly — a type
+  // that install does not have — answers 200 with `{}`, not 404. Returning null
+  // sends the caller to the full fetch, where the existing removal/history logic
+  // decides. Concluding "removed" here would be this codebase's own defect class:
+  // an observation collapsed into a definite negative.
+  const got = await fetchSingleNodeDef("LTXVImgToVideoConditionOnly", fakeApi({ body: {} }));
+  assert.equal(got, null);
+});
+
+test("#767 every kind of DOUBT returns null, never a conclusion", async () => {
+  // An older ComfyUI without the route.
+  assert.equal(await fetchSingleNodeDef("KSampler", fakeApi({ status: 404, body: {} })), null);
+  // A proxy sign-in page: 200, but not our document.
+  assert.equal(await fetchSingleNodeDef("KSampler", fakeApi({ status: 200, body: "<html>" })), null);
+  // A body that will not parse.
+  assert.equal(
+    await fetchSingleNodeDef("KSampler", fakeApi({ json: async () => { throw new Error("bad json"); } })),
+    null,
+  );
+  // The request itself failed.
+  assert.equal(await fetchSingleNodeDef("KSampler", fakeApi({ throws: true })), null);
+  // A response carrying a DIFFERENT class than the one asked for.
+  assert.equal(await fetchSingleNodeDef("KSampler", fakeApi({ body: { LoadImage: {} } })), null);
+  // Arrays and nulls are not documents.
+  assert.equal(await fetchSingleNodeDef("KSampler", fakeApi({ body: [] })), null);
+  assert.equal(await fetchSingleNodeDef("KSampler", fakeApi({ body: null })), null);
+});
+
+test("#767 a non-2xx is not evidence, even when the body confirms", async () => {
+  // Found by mutation: deleting the status check killed no test, because every
+  // non-2xx fixture also had a non-confirming body — so the check was passing for
+  // the wrong reason. The rule it actually encodes is that a request the server
+  // said FAILED is not an observation about the node type, whatever bytes came
+  // with it: a caching proxy answering 5xx from a stale entry, or an error page
+  // that happens to carry JSON, must both reach the full fetch rather than
+  // authorize an add on their own.
+  const confirming = { KSampler: { input: { required: {} } } };
+  assert.equal(await fetchSingleNodeDef("KSampler", fakeApi({ status: 500, body: confirming })), null);
+  assert.equal(await fetchSingleNodeDef("KSampler", fakeApi({ status: 404, body: confirming })), null);
+  assert.equal(await fetchSingleNodeDef("KSampler", fakeApi({ status: 302, body: confirming })), null);
+  // …and 2xx with a confirming body is still the one accepted case.
+  assert.ok(await fetchSingleNodeDef("KSampler", fakeApi({ status: 200, body: confirming })));
+  assert.ok(await fetchSingleNodeDef("KSampler", fakeApi({ status: 204, body: confirming })));
+});
+
+test("#767 a missing capability is a no-op, not a throw", async () => {
+  // This runs inside graph_add_node's fresh-oracle callback, and the resolver
+  // catches everything that escapes it and reports "object_info is unavailable" —
+  // so a throw here would surface as a FALSE refusal on a healthy backend.
+  assert.equal(await fetchSingleNodeDef("KSampler", undefined), null);
+  assert.equal(await fetchSingleNodeDef("", fakeApi({ body: { "": {} } })), null);
+  assert.equal(await fetchSingleNodeDef(null, fakeApi({})), null);
+});
+
+test("#767 singleDefConfirms accepts only an own property on a real object", () => {
+  assert.equal(singleDefConfirms({ KSampler: {} }, "KSampler"), true);
+  assert.equal(singleDefConfirms({}, "KSampler"), false);
+  assert.equal(singleDefConfirms(null, "KSampler"), false);
+  assert.equal(singleDefConfirms([], "KSampler"), false);
+  assert.equal(singleDefConfirms("KSampler", "KSampler"), false);
+  // An inherited key is not the backend saying it has the type.
+  assert.equal(singleDefConfirms(Object.create({ KSampler: {} }), "KSampler"), false);
+});
+
+test("#767 WIRING: the fast path is gated on the type ALREADY being registered", () => {
+  // Not an optimisation detail — a safety one. assertAddNodeResolvableRefreshing
+  // hands `freshDefs` to refreshComfyNodeDefs() when a type still needs
+  // registering, and a single-class payload reaching a whole-schema refresh could
+  // deregister everything else. Under this gate that branch is unreachable.
+  const src = readFileSync(PANEL_JS, "utf8");
+  const i = src.indexOf("getFreshObjectInfo: async () => {");
+  assert.ok(i > 0, "the fresh-oracle callback must be findable");
+  const body = src.slice(i, i + 2600);
+  const guard = body.indexOf("isRegisteredNodeType(LG?.registered_node_types");
+  const call = body.indexOf("fetchSingleNodeDef(class_type");
+  assert.ok(guard > 0, "the registered-type gate must be present");
+  assert.ok(call > guard, "…and the single-class fetch must sit INSIDE it");
+  // The full fetch must still be there as the fallback, unchanged.
+  assert.match(body, /api\?\.getNodeDefs === "function" \? await api\.getNodeDefs\(\) : null/);
+  // And the snapshot must be taken on BOTH paths — #700 turns on it.
+  assert.equal(
+    (body.match(/snapshotBackendDef\(freshDefs, class_type\)/g) ?? []).length,
+    2,
+    "both the fast and full paths must snapshot the backend def before any refresh mutates it",
+  );
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -138,7 +138,8 @@ import {
   findVisibleNodeByScopedId,
   resolveMissingModelDirectory,
 } from "./lib/asset-staleness.js";
-import { assertAddNodeResolvableRefreshing } from "./lib/node-resolve.js";
+import { assertAddNodeResolvableRefreshing, isRegisteredNodeType } from "./lib/node-resolve.js";
+import { fetchSingleNodeDef } from "./lib/single-node-def.js";
 import { displayLabel, boundaryInputLabel, widgetLabelMap } from "./lib/slot-labels.js";
 import { createObjectInfoHistory, awaitHistoryBaseline } from "./lib/object-info-history.js";
 import { makeRefreshCoalescer } from "./lib/refresh-coalesce.js";
@@ -8581,6 +8582,32 @@ const GRAPH_TOOL_EXECUTORS = {
     let currentDef;
     await assertAddNodeResolvableRefreshing(() => LG?.registered_node_types ?? {}, class_type, {
       getFreshObjectInfo: async () => {
+        // #767 — ask about ONE type instead of re-downloading the whole schema.
+        // Measured on a 63-pack install: /object_info is 5,413,770 bytes / 167 ms,
+        // /object_info/KSampler is 3,246 bytes / 1.2 ms. A burst of adds pulled
+        // ~54 MB and blew through the 30 s reply deadline, which is how the report's
+        // "ghost" nodes appeared — the adds landed after the timeout had already
+        // been reported as a failure.
+        //
+        // GATED ON ALREADY-REGISTERED, and not for speed. The resolver hands
+        // `freshDefs` to refreshComfyNodeDefs() when a type still needs
+        // registering, and a single-class payload reaching a whole-schema refresh
+        // could deregister everything else. When the type is already registered
+        // that branch is unreachable, so the hazard is removed by construction
+        // rather than by remembering not to trip it.
+        //
+        // The fast path only ever CONFIRMS. Any doubt — an empty {}, a non-200, an
+        // older build without the route, an unparseable body — returns null and
+        // falls through to the identical full fetch below, so no refusal, removal
+        // verdict or history check is decided on anything new.
+        if (isRegisteredNodeType(LG?.registered_node_types ?? {}, class_type)) {
+          const one = await fetchSingleNodeDef(class_type, (route) => api?.fetchApi?.(route));
+          if (one) {
+            freshDefs = recordObjectInfoTypes(one);
+            currentDef = snapshotBackendDef(freshDefs, class_type);
+            return freshDefs;
+          }
+        }
         freshDefs = recordObjectInfoTypes(
           typeof api?.getNodeDefs === "function" ? await api.getNodeDefs() : null,
         );

--- a/web/js/lib/single-node-def.js
+++ b/web/js/lib/single-node-def.js
@@ -1,0 +1,77 @@
+/**
+ * panel#767 — every `panel_add_node` re-downloads the ENTIRE node schema.
+ *
+ * `#458` made the fresh `/object_info` the sole authority for "does the backend
+ * still provide this type", and it is right to: a stale registry keeps positives
+ * for packs that have since been uninstalled. But the fetch it uses is the whole
+ * document, and on a real install that is not small. Measured on the rig
+ * (ComfyUI 0.30.2, 63 custom-node packs):
+ *
+ *     GET /object_info              5,413,770 bytes   167 ms
+ *     GET /object_info/KSampler         3,246 bytes   1.2 ms
+ *
+ * 1,667x smaller, 135x faster. Ten `panel_add_node` calls in a burst therefore
+ * pull ~54 MB and, once the coalescer serialises the payload-carrying refreshes
+ * behind each other, blow through the 30 s reply deadline — the exact failure in
+ * the report, where the adds then landed anyway and left "ghost" nodes behind a
+ * timeout that had already been reported as failure.
+ *
+ * ComfyUI answers per class, and answers ABSENCE as `{}` with HTTP 200 (verified
+ * against `LTXVImgToVideoConditionOnly`, a type that install does not have). So
+ * `hasOwnProperty(defs, class_type)` — the authority test #458 performs — behaves
+ * identically on the single-class response.
+ *
+ * THIS CANNOT CHANGE A VERDICT, ONLY THE COST OF REACHING ONE.
+ *
+ * The fast path is taken only when it can CONFIRM the type: a live response that
+ * actually contains the class. Every other outcome — an empty `{}`, a non-200, a
+ * body that will not parse, an older ComfyUI without the route, a network failure
+ * — returns null and the caller falls through to the full fetch it does today,
+ * unchanged. A confirmation is the one answer that cannot be wrong in the
+ * dangerous direction: refusals, removal verdicts and history checks are all
+ * still decided by the existing code on the existing payload.
+ *
+ * The caller additionally gates this on the type ALREADY BEING REGISTERED in
+ * LiteGraph, which matters for a reason that is not about speed:
+ * `assertAddNodeResolvableRefreshing` passes its `freshDefs` to
+ * `refreshComfyNodeDefs()` when a type needs registering, and handing a
+ * single-class payload to a whole-schema refresh could deregister everything
+ * else. Under that gate the resolver's refresh branch is unreachable, so a
+ * partial payload can never get there — the hazard is removed by construction
+ * rather than by remembering not to trip it.
+ */
+
+/** Absence is `{}` with HTTP 200 on this route, not a 404. */
+export function singleDefConfirms(body, classType) {
+  if (!body || typeof body !== "object" || Array.isArray(body)) return false;
+  return Object.prototype.hasOwnProperty.call(body, classType);
+}
+
+/**
+ * Ask the backend about ONE node type.
+ *
+ * @param {string} classType
+ * @param {(route: string) => Promise<{ status?: number, json?: () => Promise<unknown> }>} fetchApi
+ * @returns {Promise<object|null>} the defs object when it CONFIRMS the type,
+ *   null in every other case — including every kind of doubt.
+ */
+export async function fetchSingleNodeDef(classType, fetchApi) {
+  if (typeof classType !== "string" || classType === "") return null;
+  if (typeof fetchApi !== "function") return null;
+  let body;
+  try {
+    const res = await fetchApi(`/object_info/${encodeURIComponent(classType)}`);
+    // A non-2xx is not evidence of anything about the type — an older build
+    // without this route answers 404, and a proxy sign-in page answers 200 with
+    // HTML. Both must reach the full fetch, not a conclusion.
+    if (!res || (typeof res.status === "number" && (res.status < 200 || res.status >= 300))) {
+      return null;
+    }
+    body = typeof res.json === "function" ? await res.json() : null;
+  } catch {
+    // Network failure, abort, unparseable body. All of them mean "I did not find
+    // out", and this returns the value that says exactly that.
+    return null;
+  }
+  return singleDefConfirms(body, classType) ? body : null;
+}


### PR DESCRIPTION
Refs #767

Every `panel_add_node` re-downloaded the entire node schema.

`#458` made the fresh `/object_info` the sole authority for *"does the backend still provide this type"*, and it's right to — a stale registry keeps positives for packs that have since been uninstalled. But the fetch it used is the **whole document**. Measured on the rig (ComfyUI 0.30.2, 63 custom-node packs):

| request | bytes | time |
|---|---:|---:|
| `GET /object_info` | **5,413,770** | 167 ms |
| `GET /object_info/KSampler` | **3,246** | 1.2 ms |

**1,667× smaller, 135× faster.** The report's burst of ~10 parallel adds on an 88-node workflow pulled ~54 MB; the payload-carrying refreshes serialise behind each other by design (#289), the 30 s reply deadline expired — and the adds landed anyway, which is exactly where their **ghost nodes** came from.

## This cannot change a verdict, only the cost of reaching one

The fast path is taken **only when it confirms**: a live response that actually contains the class. Every other outcome — `{}`, a non-2xx, an older build without the route, an unparseable body, a network failure — returns `null` and falls through to the identical full fetch. Refusals, removal verdicts and the ever-seen history check are all still decided by the existing code on the existing payload.

ComfyUI answers absence as `{}` with **HTTP 200** (verified against `LTXVImgToVideoConditionOnly`, a type this install genuinely lacks), so `hasOwnProperty(defs, class_type)` — the authority test #458 runs — behaves identically on the small response.

## Gated on already-registered, and not for speed

`assertAddNodeResolvableRefreshing` hands `freshDefs` to `refreshComfyNodeDefs()` when a type still needs registering, and **a single-class payload reaching a whole-schema refresh could deregister everything else.** When the type is already registered that branch is unreachable, so the hazard is removed by construction rather than by remembering not to trip it. That's also the shape of every add in the report — nodes added to an existing workflow.

## Two things the tests caught that I had wrong

- **The add-node harness extracts `graph_add_node` from source** and evaluates it with an injected dependency list. My two new free identifiers arrived as `undefined` and threw a `ReferenceError` — which the resolver catches and reports as *"object_info is unavailable"*, i.e. a **false refusal on a healthy backend**. Five tests caught it. Both are now injected like every other collaborator.
- **The HTTP-status check survived mutation.** Every non-2xx fixture also had a non-confirming body, so the check was passing for the wrong reason. The rule it actually encodes — *a request the server said failed is not an observation about the node type, whatever bytes came with it* — is now pinned with a confirming body behind 500/404/302.

## Verification

| mutation | result |
|---|---|
| remove the fast path | 2 failed |
| drop the registered-type gate | 2 failed |
| treat `{}` as a confirmation | 3 failed |
| ignore the HTTP status | 1 failed *(after the new test; survived before it)* |

Each asserted an exact pre-count first.

11 new tests · panel unit suite **2916 passed** · typecheck and the vocabulary gate exit 0 · control-byte scan clean.

**Not addressed here:** the serial coalescer itself (#289 made payload refreshes serial deliberately), and whether the 30 s deadline should scale with graph size. This removes the cost that made those bite; it doesn't change either policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)