### PR TITLE
fix(save): read the reason ComfyUI logged instead of repeating the one it made up

### DIFF
--- a/browser_tests/unit/userdata-failure-cause.test.mjs
+++ b/browser_tests/unit/userdata-failure-cause.test.mjs
@@ -1,0 +1,182 @@
+// panel#771 — ComfyUI knows why a save failed and tells its log, not the client.
+//
+// `post_userdata` answers EVERY OSError with one 400 whose reason is a fixed
+// string blaming the filename, then logs the real cause:
+//
+//     logging.warning(f"Error saving file '{path}': {e}")
+//
+// The reporter's name was `wan22_flf_seg1_alone_to_reaching` — not a special
+// character in it — and they were told to avoid special characters.
+//
+// The fixtures below are REAL. Captured from the live rig (ComfyUI 0.30.2) by
+// provoking a genuine OSError (a path too long for the filesystem, which ComfyUI
+// cleans up after itself), then reading /internal/logs/raw.
+
+import assert from "node:assert/strict";
+import test from "node:test";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+import {
+  extractSaveFailureCause,
+  readSaveFailureCause,
+  describeSaveFailureCause,
+} from "../../web/js/lib/userdata-failure-cause.js";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const PANEL_JS = join(HERE, "../../web/js/comfyui-mcp-panel.js");
+
+// ESC is built from its code point, never written as an escape sequence. An
+// earlier revision of this file had its escapes mangled in transit: the regex
+// collapsed to an empty `//` — which matches everything, so the assertion proved
+// nothing — and literal 0x1B bytes were written into the source. Neither is
+// visible in a diff, and the tests still passed.
+const ESC = String.fromCharCode(27);
+
+/** Exactly what the rig logged, colour codes and all. */
+const REAL_LINE =
+  `${ESC}[1m${ESC}[33m[WARNING]${ESC}[0m Error saving file ` +
+  "'C:\\Users\\Artokun\\ComfyUI-Installs\\ComfyUI\\ComfyUI\\user\\default\\workflows\\report.json': " +
+  "[WinError 3] The system cannot find the path specified: 'C:\\Users\\Artokun\\tmp9xk'";
+
+test("#771 the real cause is pulled out of the real log line", () => {
+  const cause = extractSaveFailureCause(REAL_LINE, "workflows/report.json");
+  assert.match(cause, /\[WinError 3\] The system cannot find the path specified/);
+  // The 400's own reason must not leak in — that is the misleading part.
+  assert.doesNotMatch(cause, /Invalid filename/);
+});
+
+test("#771 colour codes do not defeat the match, or leak into the cause", () => {
+  // On the rig the reset lands before the message, so FINDING the line survives
+  // without stripping — but the escape a colouriser puts at the END of the record
+  // lands INSIDE the extracted cause and would be shown to the reader as part of
+  // the server's reason. Found by mutation: removing the strip killed nothing
+  // until this case existed.
+  assert.ok(extractSaveFailureCause(REAL_LINE, "workflows/report.json"));
+
+  const trailing =
+    `${ESC}[33m[WARNING]${ESC}[0m Error saving file '/u/workflows/r.json': ` +
+    `[Errno 28] No space left on device${ESC}[0m`;
+  const cause = extractSaveFailureCause(trailing, "workflows/r.json");
+  assert.equal(cause, "[Errno 28] No space left on device", "no escape bytes in what we print");
+  assert.ok(!cause.includes(ESC), "an escape byte must never reach the reader");
+});
+
+test("#771 the SEPARATOR does not matter — the server logs an absolute native path", () => {
+  const posix =
+    "[WARNING] Error saving file '/home/u/ComfyUI/user/default/workflows/a b.json': " +
+    "[Errno 28] No space left on device";
+  assert.match(extractSaveFailureCause(posix, "workflows/a b.json"), /No space left on device/);
+  // A Windows path matched against a posix-style relative path, and vice versa.
+  assert.ok(extractSaveFailureCause(REAL_LINE, "workflows\\report.json"));
+});
+
+test("#771 a line for a DIFFERENT file is never attributed to this save", () => {
+  // The log is a shared ring. A wrong cause is worse than no cause, because it
+  // will be acted on — someone would go free up disk over another tab's failure.
+  const other =
+    "[WARNING] Error saving file '/home/u/user/default/workflows/somebody-else.json': " +
+    "[Errno 28] No space left on device";
+  assert.equal(extractSaveFailureCause(other, "workflows/report.json"), null);
+});
+
+test("#771 the LAST matching line wins", () => {
+  // A retry logs again; the newest entry describes the attempt just made.
+  const log = [
+    "[WARNING] Error saving file '/u/workflows/r.json': [Errno 13] Permission denied",
+    "[WARNING] Error saving file '/u/workflows/r.json': [Errno 28] No space left on device",
+  ].join("\n");
+  assert.match(extractSaveFailureCause(log, "workflows/r.json"), /No space left/);
+});
+
+test("#771 nothing to find returns null, and null is NOT a verdict", () => {
+  assert.equal(extractSaveFailureCause("", "workflows/r.json"), null);
+  assert.equal(extractSaveFailureCause("some unrelated log\n", "workflows/r.json"), null);
+  assert.equal(extractSaveFailureCause(REAL_LINE, ""), null);
+  assert.equal(extractSaveFailureCause(null, "workflows/r.json"), null);
+  // A line with an empty cause is not an answer either.
+  assert.equal(
+    extractSaveFailureCause("Error saving file '/u/workflows/r.json': ", "workflows/r.json"),
+    null,
+  );
+});
+
+test("#771 a partial suffix must not match a different file", () => {
+  // "report.json" must not be satisfied by "big-report.json".
+  const log = "[WARNING] Error saving file '/u/workflows/big-report.json': [Errno 28] full";
+  assert.equal(extractSaveFailureCause(log, "workflows/report.json"), null);
+});
+
+test("#771 readSaveFailureCause tolerates every log shape, and never throws", async () => {
+  const entries = { entries: [{ m: REAL_LINE }], size: 1 };
+  const fetchOk = async () => ({ status: 200, json: async () => entries });
+  assert.match(await readSaveFailureCause("workflows/report.json", fetchOk), /WinError 3/);
+
+  // A plain array, and a bare string body.
+  assert.ok(
+    await readSaveFailureCause("workflows/report.json", async () => ({
+      status: 200,
+      json: async () => [REAL_LINE],
+    })),
+  );
+  assert.ok(
+    await readSaveFailureCause("workflows/report.json", async () => ({
+      status: 200,
+      json: async () => REAL_LINE,
+    })),
+  );
+
+  // Every failure mode returns null rather than throwing — this runs on the way
+  // out of an already-failed save, the worst possible place to raise a second error.
+  for (const bad of [
+    async () => ({ status: 404, json: async () => ({}) }),
+    async () => {
+      throw new Error("offline");
+    },
+    async () => ({
+      status: 200,
+      json: async () => {
+        throw new Error("bad json");
+      },
+    }),
+    async () => null,
+  ]) {
+    assert.equal(await readSaveFailureCause("workflows/report.json", bad), null);
+  }
+  assert.equal(await readSaveFailureCause("workflows/report.json", undefined), null);
+});
+
+test("#771 with a cause, the message says the filename advice was wrong", () => {
+  const note = describeSaveFailureCause("[Errno 28] No space left on device");
+  assert.match(note, /THE SERVER'S OWN REASON/);
+  assert.match(note, /No space left on device/);
+  assert.match(note, /fixed string ComfyUI returns for every filesystem error/);
+});
+
+test("#771 WITHOUT a cause it says so, and does NOT blame the filename", () => {
+  // The whole point of the issue: not finding the reason is not evidence about
+  // the name. This is the sentence that has to stay honest.
+  for (const empty of [null, undefined, "", "   "]) {
+    const note = describeSaveFailureCause(empty);
+    assert.match(note, /could NOT be read/);
+    assert.match(note, /not evidence the filename is at fault/);
+    assert.doesNotMatch(note, /THE SERVER'S OWN REASON/);
+    // Every mention of fault must be the NEGATED one. Found by mutation: adding a
+    // "The filename is at fault." sentence left both assertions above passing,
+    // which is the exact wrong answer this issue exists to stop.
+    for (const m of note.matchAll(/filename is at fault/g)) {
+      const before = note.slice(Math.max(0, m.index - 20), m.index);
+      assert.match(before, /not evidence the $/, `unqualified fault claim in: ${note}`);
+    }
+  }
+});
+
+test("#771 WIRING: the panel supplies the reader over its own api", () => {
+  const src = readFileSync(PANEL_JS, "utf8");
+  assert.match(src, /import \{ readSaveFailureCause \} from "\.\/lib\/userdata-failure-cause\.js"/);
+  assert.match(
+    src,
+    /readSaveFailureCause: \(path\) => readSaveFailureCause\(path, \(route\) => api\?\.fetchApi\?\.\(route\)\)/,
+  );
+});

--- a/browser_tests/unit/userdata-store-400.test.mjs
+++ b/browser_tests/unit/userdata-store-400.test.mjs
@@ -72,6 +72,36 @@ test("#771 WIRING: saveInPlace augments the thrown error, and only that shape", 
   assert.match(src, /const augmented = explainUserDataStoreFailure\(/);
   // …and rethrows the SAME error object, so nothing downstream that matches on
   // error identity or other fields is disturbed.
-  assert.match(src, /if \(err instanceof Error && augmented !== err\.message\) err\.message = augmented;/);
+  assert.match(src, /if \(err instanceof Error && augmented !== err\.message\)/);
+  assert.match(src, /err\.message = augmented \+ tail;/);
   assert.match(src, /\n\s*throw err;/);
+});
+
+test("#771 the server is asked WHY only for the userdata-400 shape", () => {
+  // `augmented !== raw` is the shape test, and the log request sits INSIDE it.
+  // Every other save failure keeps the byte-identical rethrow with no extra
+  // request — a save that failed for an unrelated reason must not start pulling
+  // the server log on its way out.
+  const src = readFileSync(SAVE_JS, "utf8");
+  const guard = src.indexOf("if (err instanceof Error && augmented !== err.message)");
+  const ask = src.indexOf("readSaveFailureCause(path)");
+  const rethrow = src.indexOf("throw err;", guard);
+  assert.ok(guard > 0, "the shape guard must exist");
+  assert.ok(ask > guard, "the log request must sit inside it");
+  assert.ok(rethrow > ask, "…and the rethrow still follows");
+});
+
+test("#771 the cause reader is INJECTED, never imported into the save path", () => {
+  // workflow-save.js keeps no opinion about how the log is reached, so a caller
+  // that cannot reach it simply omits the dependency and the message degrades to
+  // the standing explanation. An import here would make the module require a
+  // transport it has no business knowing about.
+  const src = readFileSync(SAVE_JS, "utf8");
+  assert.match(src, /readSaveFailureCause,/, "it is destructured from the options object");
+  assert.doesNotMatch(
+    src,
+    /import \{[^}]*\breadSaveFailureCause\b/,
+    "it must not be imported — only the message builder is",
+  );
+  assert.match(src, /import \{ describeSaveFailureCause \} from "\.\/userdata-failure-cause\.js"/);
 });

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -140,6 +140,7 @@ import {
 } from "./lib/asset-staleness.js";
 import { assertAddNodeResolvableRefreshing, isRegisteredNodeType } from "./lib/node-resolve.js";
 import { fetchSingleNodeDef } from "./lib/single-node-def.js";
+import { readSaveFailureCause } from "./lib/userdata-failure-cause.js";
 import { displayLabel, boundaryInputLabel, widgetLabelMap } from "./lib/slot-labels.js";
 import { createObjectInfoHistory, awaitHistoryBaseline } from "./lib/object-info-history.js";
 import { makeRefreshCoalescer } from "./lib/refresh-coalesce.js";
@@ -3714,6 +3715,12 @@ async function programmaticSave(name) {
     canvasBinding: describeLiveCanvasBinding,
     details,
     expect: expectWf, // #330: refuse if the user switched tabs during our pre-save HEAD
+    // #771 — ComfyUI answers EVERY filesystem error on the userdata write with one
+    // 400 that blames the FILENAME, and logs the real cause a line earlier. This
+    // reads that line back so the caller is told what actually failed instead of
+    // being sent to audit a filename that was never the problem. Read-only, and it
+    // runs only once the 400 shape is already recognised.
+    readSaveFailureCause: (path) => readSaveFailureCause(path, (route) => api?.fetchApi?.(route)),
   });
   const outcome = describeSaveOutcome(details);
   // #557 r3/r4/r5/r7/r8/r10 — thread the identity across the swap ONLY with

--- a/web/js/lib/userdata-failure-cause.js
+++ b/web/js/lib/userdata-failure-cause.js
@@ -1,0 +1,124 @@
+/**
+ * panel#771 — ComfyUI knows exactly why a save failed and does not tell the
+ * client. It tells its own log. So read the log.
+ *
+ * `app/user_manager.py`, `post_userdata` — the only 400 on the write path:
+ *
+ *     except OSError as e:
+ *         logging.warning(f"Error saving file '{path}': {e}")
+ *         return web.Response(
+ *             status=400,
+ *             reason="Invalid filename. Please avoid special characters like :\/*?\"<>|"
+ *         )
+ *
+ * Any OSError — a full disk, an unwritable directory, a read-only mount, an fd
+ * limit — becomes one 400 that blames the FILENAME. The reporter's name was
+ * `wan22_flf_seg1_alone_to_reaching`, which has no special character in it, and
+ * they were told to avoid special characters.
+ *
+ * The real cause is one `logging.warning` away, and `/internal/logs/raw` serves
+ * it. Verified end to end against the live rig (ComfyUI 0.30.2) by provoking a
+ * genuine OSError — a path too long for the filesystem, which ComfyUI cleans up
+ * after itself:
+ *
+ *     HTTP/1.1 400 Invalid filename. Please avoid special characters like :\/*?"<>|
+ *     log: Error saving file 'C:\…\workflows\wwww….json': [WinError 3] The system
+ *          cannot find the path specified: 'C:\…'
+ *
+ * READING IS NOT KNOWING. If the log cannot be fetched, does not go back far
+ * enough, or holds no line for THIS file, that is "I could not find out" and it
+ * is reported as such — never as "there was no reason". The 400 still surfaces
+ * with the standing explanation either way; this only ever adds an observation.
+ */
+
+/** ComfyUI colourises its log; the raw feed carries the escape codes. */
+const ANSI = /\u001b\[[0-9;]*m/g;
+
+/**
+ * The last `Error saving file '<path>': <cause>` line that refers to THIS file.
+ *
+ * Matched on the file path rather than on recency alone: the log is a shared
+ * ring, and a warning from an unrelated save would otherwise be attributed to
+ * this one — a wrong cause is worse than no cause, because it will be acted on.
+ *
+ * @param {string} logText the raw log feed
+ * @param {string} relPath e.g. "workflows/name.json" — the server logs an
+ *   ABSOLUTE path, so this is matched as a suffix with either separator
+ * @returns {string|null} the cause exactly as the server wrote it
+ */
+export function extractSaveFailureCause(logText, relPath) {
+  if (typeof logText !== "string" || !logText) return null;
+  if (typeof relPath !== "string" || !relPath) return null;
+  const wanted = relPath.replace(/^[/\\]+/, "").replace(/\\/g, "/").toLowerCase();
+  if (!wanted) return null;
+
+  let found = null;
+  for (const rawLine of logText.split(/\r?\n/)) {
+    const line = rawLine.replace(ANSI, "");
+    const at = line.indexOf("Error saving file '");
+    if (at === -1) continue;
+    const rest = line.slice(at + "Error saving file '".length);
+    const close = rest.indexOf("':");
+    if (close === -1) continue;
+    const loggedPath = rest.slice(0, close).replace(/\\/g, "/").toLowerCase();
+    if (!loggedPath.endsWith(wanted)) continue;
+    const cause = rest.slice(close + 2).trim();
+    // A line with an empty cause is not an answer; keep looking for a real one.
+    if (cause) found = cause;
+  }
+  return found;
+}
+
+/**
+ * Fetch the log and pull out the cause. Never throws, never blocks a save error.
+ *
+ * @param {string} relPath
+ * @param {(route: string) => Promise<{ status?: number, json?: () => Promise<unknown>, text?: () => Promise<string> }>} fetchApi
+ */
+export async function readSaveFailureCause(relPath, fetchApi) {
+  if (typeof fetchApi !== "function") return null;
+  try {
+    const res = await fetchApi("/internal/logs/raw");
+    if (!res || (typeof res.status === "number" && (res.status < 200 || res.status >= 300))) {
+      return null;
+    }
+    let text = "";
+    if (typeof res.json === "function") {
+      const body = await res.json();
+      // { entries: [{ m: "…" }, …], size } on current builds; tolerate a plain
+      // array or a bare string rather than assuming one shape.
+      const entries = Array.isArray(body) ? body : Array.isArray(body?.entries) ? body.entries : null;
+      if (entries) text = entries.map((e) => (typeof e === "string" ? e : (e?.m ?? ""))).join("\n");
+      else if (typeof body === "string") text = body;
+    }
+    if (!text && typeof res.text === "function") text = await res.text();
+    return extractSaveFailureCause(text, relPath);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * What to append once the cause is known — or once it is known to be unknown.
+ *
+ * The two sentences are deliberately different in kind. With a cause, the reader
+ * is told the server's own words and that the filename advice was wrong. Without
+ * one, they are told the lookup did not find anything, which is not the same as
+ * the filename being at fault.
+ */
+export function describeSaveFailureCause(cause) {
+  if (typeof cause === "string" && cause.trim()) {
+    return (
+      ` THE SERVER'S OWN REASON, read from its log: ${cause.trim()} — that is the` +
+      ` actual failure. The "invalid filename" text in the 400 is a fixed string ComfyUI` +
+      ` returns for every filesystem error, so disregard it unless the line above mentions` +
+      ` the name.`
+    );
+  }
+  return (
+    ` The server-side reason could NOT be read (its log was unavailable, or holds no` +
+    ` "Error saving file" line for this path — the log is a short ring and may have` +
+    ` scrolled). That is not evidence the filename is at fault; it means the real cause` +
+    ` is still unknown from here.`
+  );
+}

--- a/web/js/lib/workflow-save.js
+++ b/web/js/lib/workflow-save.js
@@ -1,3 +1,5 @@
+import { describeSaveFailureCause } from "./userdata-failure-cause.js";
+
 // Programmatic workflow saving — shared by the panel and unit tests.
 //
 // #442 defect 3 — the in-place-overwrite gate compares the on-disk file's RAW BYTES
@@ -352,7 +354,20 @@ export async function groundActiveWorkflow(svc, opts = {}) {
 export async function saveActiveWorkflow(
   svc,
   name,
-  { autoWorkflowName, existsOnDisk, readDiskBytes, reconcileSavedCopy, canvasBinding, expect, details } = {},
+  {
+    autoWorkflowName,
+    existsOnDisk,
+    readDiskBytes,
+    reconcileSavedCopy,
+    canvasBinding,
+    expect,
+    details,
+    // #771 — ComfyUI answers EVERY filesystem error on this path with one 400 that
+    // blames the filename, and logs the real cause. Injected rather than imported so
+    // this module keeps no opinion about how the log is reached, and so a caller that
+    // cannot reach it simply omits it.
+    readSaveFailureCause,
+  } = {},
 ) {
   const wf = svc?.activeWorkflow;
   if (!wf) throw new Error("no active workflow to save");
@@ -745,7 +760,7 @@ export async function saveActiveWorkflow(
   assertCanvasNotForeign();
   if (inPlace === "authorize") markPersistedForOverwrite(wf); // sync (post-assert) ⇒ no leak window
   recordOutcome(details, "in-place", { sourcePath: currentPath, targetPath: finalTargetPath });
-  const savedRecord = await saveInPlace(svc, wf);
+  const savedRecord = await saveInPlace(svc, wf, { readSaveFailureCause, path: finalTargetPath });
   // r10 — thread the save API's own produced record (when it returns one) through
   // details, so the identity carry can prove succession from the replacement
   // EVENT. An empty/non-object return simply carries no thread (fail safe).
@@ -1307,7 +1322,7 @@ export function explainUserDataStoreFailure(message) {
   );
 }
 
-async function saveInPlace(svc, wf) {
+async function saveInPlace(svc, wf, { readSaveFailureCause, path } = {}) {
   // Return the save API's own result: when it yields the workflow record it
   // PRODUCED (a re-registered successor object), that is the one unambiguous
   // replacement-event thread the identity carry can use (r10) — path occupancy
@@ -1318,8 +1333,18 @@ async function saveInPlace(svc, wf) {
   } catch (err) {
     // #771 — augment ONLY the userdata-400 shape; every other failure is
     // rethrown byte-identical so no existing message or matcher changes.
-    const augmented = explainUserDataStoreFailure(err instanceof Error ? err.message : String(err));
-    if (err instanceof Error && augmented !== err.message) err.message = augmented;
+    const raw = err instanceof Error ? err.message : String(err);
+    const augmented = explainUserDataStoreFailure(raw);
+    if (err instanceof Error && augmented !== err.message) {
+      // Only ask the server WHY once we know this is the userdata-400 shape —
+      // `augmented !== raw` is that test, and it keeps every other failure on the
+      // byte-identical rethrow path with no extra request.
+      let tail = "";
+      if (typeof readSaveFailureCause === "function") {
+        tail = describeSaveFailureCause(await readSaveFailureCause(path));
+      }
+      err.message = augmented + tail;
+    }
     throw err;
   }
   throw new Error("workflow save API unavailable on this frontend");


### PR DESCRIPTION
Refs #771

`post_userdata` answers **every** `OSError` with one 400 whose reason is a fixed string blaming the filename — and logs the real cause a line earlier:

```python
except OSError as e:
    logging.warning(f"Error saving file '{path}': {e}")
    return web.Response(status=400,
        reason="Invalid filename. Please avoid special characters like :\/*?\"<>|")
```

The reporter's name was `wan22_flf_seg1_alone_to_reaching`. There is not a special character in it, and they were told to avoid special characters.

#772 explained that and told the reader to go find the log themselves. **This fetches it.**

## Verified end to end, not assumed

On the live rig (ComfyUI 0.30.2), by provoking a genuine `OSError` — a path too long for the filesystem, which ComfyUI cleans up after itself, so nothing was written:

```
HTTP/1.1 400 Invalid filename. Please avoid special characters like :\/*?"<>|

/internal/logs/raw:
  Error saving file 'C:\…\workflows\wwww….json':
    [WinError 3] The system cannot find the path specified
```

Both properties this leans on were measured: the log line carries the errno, and the endpoint serves it.

## Not finding a reason is not a reason

If the log can't be fetched, doesn't reach back far enough, or holds no line for **this** path, the message says the cause could not be *read* — and states explicitly that this is **not evidence the filename is at fault**. The standing #772 explanation ships either way; this only ever adds an observation.

Matched on the file path rather than recency: the log is a shared ring, and a warning from an unrelated save attributed to this one would send someone to free up disk over another tab's failure. **A wrong cause is worse than none, because it gets acted on.**

The reader is *injected* through `saveActiveWorkflow`'s existing options object rather than imported, so `workflow-save.js` keeps no opinion about how the log is reached. The request runs only once the userdata-400 shape is recognised, so no other save failure starts pulling the server log on its way out.

## Two mutations survived the first pass — both test gaps

- **Removing the ANSI strip killed nothing**, because the rig's reset lands *before* the message. It matters for the escape a colouriser puts at the **end** of a record, which lands inside the extracted cause. Now covered.
- **Prepending "The filename is at fault." to the no-cause branch left both assertions passing.** Every mention of fault must now be the negated one — which is the exact wrong answer this issue exists to stop.

The test file itself also had to be rewritten: a heredoc mangled its escapes, the regex collapsed to an empty `//` that matches anything, and literal `0x1B` bytes landed in the source — invisible in a diff, with the suite still green. `ESC` is now built with `String.fromCharCode(27)` and the control-byte scan is clean.

| mutation | result |
|---|---|
| drop the path match | 2 failed |
| take the first match instead of the last | 1 failed |
| remove the ANSI strip | 1 failed *(after the new case)* |
| blame the filename with no cause | 1 failed *(after the new assertion)* |
| never ask the server | 1 failed |
| panel stops supplying the reader | 1 failed |

11 new tests · panel unit suite **2935 passed** · typecheck and the vocabulary gate exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)