### PR TITLE
fix(screenshot): say that a capture frames the WHOLE graph

### DIFF
--- a/browser_tests/unit/screenshot-framing.test.mjs
+++ b/browser_tests/unit/screenshot-framing.test.mjs
@@ -1,0 +1,102 @@
+// panel#754(2) — a screenshot frames the WHOLE GRAPH, and never said so.
+//
+// The reporter centred on node 42, zoomed to 0.55, then took three screenshots.
+// All three came back pixel-identical fit-all framing of a 175-node graph; the
+// only frame-to-frame difference was the FPS counter. They concluded the
+// screenshot "does not follow the viewport" and filed it.
+//
+// The code is doing what it was built to do: fit-all, then restore the caller's
+// scale and offset. What was missing is that the reply never mentioned it — size,
+// renderer and which-graph were all reported, and the FRAMING, the one thing that
+// explains three identical images, was not. So the only way to learn it was the
+// experiment they ran.
+
+import assert from "node:assert/strict";
+import test from "node:test";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+import { describeScreenshotFraming } from "../../web/js/lib/screenshot-framing.js";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const PANEL_JS = join(HERE, "../../web/js/comfyui-mcp-panel.js");
+
+test("#754 it states the mode, and the counts it framed", () => {
+  const f = describeScreenshotFraming({ nodes: 175, groups: 4 });
+  assert.equal(f.mode, "fit-all");
+  assert.equal(f.nodes, 175);
+  assert.equal(f.groups, 4);
+});
+
+test("#754 it says the viewport is NOT used, and is restored", () => {
+  // Both halves matter. "Not used" explains the identical images; "restored" is
+  // why panel_canvas state survives a capture — without it a reader would
+  // reasonably assume the screenshot had clobbered their view.
+  const note = describeScreenshotFraming({ nodes: 175, groups: 0 }).note;
+  assert.match(note, /does NOT use the current viewport/);
+  assert.match(note, /restores the scale and offset you had/);
+});
+
+test("#754 it names the exact thing the reporter tested", () => {
+  // center_on_node + zoom returning success while screenshots stay identical is
+  // the whole report. Saying it outright is what saves the next person the three
+  // captures.
+  const note = describeScreenshotFraming({ nodes: 10, groups: 0 }).note;
+  assert.match(note, /center_on_node/);
+  assert.match(note, /zoom/);
+  assert.match(note, /identical is expected, not a failure/);
+});
+
+test("#754 it points at what DOES work for one node", () => {
+  // A dead end plus no alternative is how someone ends up re-filing. Reading a
+  // single node's state is available today; capturing one is not.
+  const note = describeScreenshotFraming({ nodes: 1, groups: 0 }).note;
+  assert.match(note, /no way to capture a single node/);
+  assert.match(note, /panel_query_graph/);
+});
+
+test("#754 counts are sanitised, never NaN or negative in the prose", () => {
+  for (const bad of [{}, { nodes: NaN, groups: undefined }, { nodes: -3, groups: -1 }]) {
+    const f = describeScreenshotFraming(bad);
+    assert.ok(Number.isInteger(f.nodes) && f.nodes >= 0, `bad nodes for ${JSON.stringify(bad)}`);
+    assert.ok(Number.isInteger(f.groups) && f.groups >= 0);
+    assert.doesNotMatch(f.note, /NaN|undefined|-\d/);
+  }
+  assert.equal(describeScreenshotFraming(undefined).nodes, 0);
+  assert.equal(describeScreenshotFraming({ nodes: 3.7 }).nodes, 3);
+});
+
+test("#754 WIRING: graph_screenshot returns it, with the counts it actually framed", () => {
+  // A helper nobody calls changes nothing, and the counts must come from the
+  // same arrays the bounds were computed over — reporting a different number
+  // than was framed would be its own small lie.
+  const src = readFileSync(PANEL_JS, "utf8");
+  assert.match(
+    src,
+    /import \{ describeScreenshotFraming \} from "\.\/lib\/screenshot-framing\.js"/,
+  );
+  const i = src.indexOf("graph_screenshot({ padding } = {})");
+  assert.ok(i > 0, "graph_screenshot must be findable");
+  const body = src.slice(i, src.indexOf("\n  },", i));
+  assert.match(
+    body,
+    /framing: describeScreenshotFraming\(\{ nodes: nodes\.length, groups: groups\.length \}\)/,
+  );
+  // The same arrays the bounds loop uses.
+  assert.match(body, /for \(const n of nodes\)/);
+  assert.match(body, /for \(const g of groups\)/);
+});
+
+test("#754 the capture still RESTORES the viewport — the claim must stay true", () => {
+  // The note promises the caller's scale and offset come back. If that restore
+  // were ever dropped, the disclosure would become a false statement, which is
+  // worse than the silence it replaced.
+  const src = readFileSync(PANEL_JS, "utf8");
+  const i = src.indexOf("graph_screenshot({ padding } = {})");
+  const body = src.slice(i, src.indexOf("\n  },", i));
+  assert.match(body, /const saved = \{ scale: ds\.scale, ox: ds\.offset\[0\], oy: ds\.offset\[1\] \}/);
+  assert.match(body, /ds\.scale = saved\.scale/);
+  assert.match(body, /ds\.offset\[0\] = saved\.ox/);
+  assert.match(body, /ds\.offset\[1\] = saved\.oy/);
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -141,6 +141,7 @@ import {
 import { assertAddNodeResolvableRefreshing, isRegisteredNodeType } from "./lib/node-resolve.js";
 import { fetchSingleNodeDef } from "./lib/single-node-def.js";
 import { readSaveFailureCause } from "./lib/userdata-failure-cause.js";
+import { describeScreenshotFraming } from "./lib/screenshot-framing.js";
 import { displayLabel, boundaryInputLabel, widgetLabelMap } from "./lib/slot-labels.js";
 import { createObjectInfoHistory, awaitHistoryBaseline } from "./lib/object-info-history.js";
 import { makeRefreshCoalescer } from "./lib/refresh-coalesce.js";
@@ -13204,6 +13205,10 @@ const GRAPH_TOOL_EXECUTORS = {
         ? (vueToggled ? "vue-nodes (forced litegraph paint for capture)" : "vue-nodes (could not force litegraph paint)")
         : "litegraph",
       viewing: describeActiveGraph(app?.canvas?.graph ?? graph),
+      // #754(2) — the reply reported size, renderer and which graph, but never the
+      // FRAMING, which is the one thing that explains three identical captures after
+      // moving the canvas. The reporter had to discover it by experiment.
+      framing: describeScreenshotFraming({ nodes: nodes.length, groups: groups.length }),
     };
   },
 

--- a/web/js/lib/screenshot-framing.js
+++ b/web/js/lib/screenshot-framing.js
@@ -1,0 +1,48 @@
+/**
+ * panel#754(2) — a screenshot frames the WHOLE GRAPH, and never said so.
+ *
+ * The reporter centred on node 42, zoomed to 0.55, and took three screenshots.
+ * All three came back pixel-identical fit-all framing of a 175-node graph; the
+ * only frame-to-frame difference was the FPS counter. They reasonably concluded
+ * "screenshot does not follow the viewport" and filed it as a defect.
+ *
+ * It is not a defect in the code. `graph_screenshot` computes bounds over every
+ * node and group, temporarily sets its own scale/offset to fit them, captures,
+ * and restores the caller's viewport afterwards. Fit-all is what it is FOR — a
+ * capture that inherited a half-scrolled canvas would be worse for the common
+ * case, and the restore is why `panel_canvas` state survives a capture.
+ *
+ * What was missing is that the reply never mentioned it. `width`, `height`,
+ * `renderer` and `viewing` are all reported; the FRAMING — the one thing that
+ * explains three identical images — was not. So the only way to learn it was the
+ * experiment they ran.
+ *
+ * This adds the disclosure and nothing else. No pixel changes, no viewport
+ * behaviour changes. Framing a subset (the "show me just this node" the reporter
+ * actually wanted) is a capability and stays parked; when it lands, `mode` is
+ * where it announces itself, which is why this is a field rather than a sentence.
+ */
+
+/**
+ * Describe how a capture was framed.
+ *
+ * @param {object} counts
+ * @param {number} counts.nodes  nodes included in the bounds
+ * @param {number} counts.groups groups included in the bounds
+ */
+export function describeScreenshotFraming({ nodes = 0, groups = 0 } = {}) {
+  const n = Number.isFinite(nodes) ? Math.max(0, Math.trunc(nodes)) : 0;
+  const g = Number.isFinite(groups) ? Math.max(0, Math.trunc(groups)) : 0;
+  return {
+    mode: "fit-all",
+    nodes: n,
+    groups: g,
+    note:
+      `This capture FRAMED THE WHOLE GRAPH (${n} node(s), ${g} group(s)). It does NOT use the ` +
+      `current viewport: it sets its own scale and offset to fit everything, captures, then ` +
+      `restores the scale and offset you had. So panel_canvas center_on_node / zoom change the ` +
+      `live canvas but do NOT change what a screenshot shows — repeated captures after moving ` +
+      `the canvas being identical is expected, not a failure. There is currently no way to ` +
+      `capture a single node; read its state with panel_query_graph instead.`,
+  };
+}


### PR DESCRIPTION
Refs #754(2)

The reporter centred on node 42, zoomed to 0.55 — both calls returned success with the new scale and offset — and took three screenshots. All three came back **pixel-identical fit-all framing** of a 175-node graph; the only frame-to-frame difference was the FPS counter. They concluded *"screenshot does not follow the viewport"* and filed it.

**The code is doing exactly what it was built to do.** `graph_screenshot` computes bounds over every node and group, sets its own scale/offset to fit them, captures, and restores the caller's viewport. Fit-all is the point — a capture that inherited a half-scrolled canvas would be worse for the common case — and the restore is why `panel_canvas` state survives a capture.

**What was missing is that the reply never mentioned it.** `width`, `height`, `renderer` and `viewing` were all reported. The *framing* — the one thing that explains three identical images — was not, so the only way to learn it was the experiment they ran.

The reply now carries it:

> This capture **FRAMED THE WHOLE GRAPH** (175 node(s), 4 group(s)). It does NOT use the current viewport: it sets its own scale and offset to fit everything, captures, then restores the scale and offset you had. So `panel_canvas` center_on_node / zoom change the live canvas but do NOT change what a screenshot shows — repeated captures after moving the canvas being identical is expected, not a failure. There is currently no way to capture a single node; read its state with `panel_query_graph` instead.

It names the exact thing they tested, and points at what does work — a dead end with no alternative is how someone ends up re-filing.

**No pixels change and no viewport behaviour changes.** Framing a subset — the *"show me just this node"* actually wanted — is a capability and stays parked. When it lands, `mode` is where it announces itself, which is why this is a structured field rather than a sentence.

One test guards the disclosure from becoming a lie: the note promises the caller's scale and offset are restored, so **the restore itself is now pinned**. A false statement would be worse than the silence it replaced.

| mutation | result |
|---|---|
| stop returning the field | 1 failed |
| report counts that were not framed | 1 failed |
| drop the viewport restore | 1 failed |
| remove the not-a-failure sentence | 1 failed |
| remove the count sanitising | 1 failed |

7 new tests · panel unit suite **2942 passed** · typecheck and the vocabulary gate exit 0 · control-byte scan clean.

**Also on #754, for the record:** part (1) is resolved — the 135k-character reply was bounded in artokun/comfyui-mcp#1055, and `node_ids` was never a parameter (the schema is literally `{}`), so nothing was being ignored. Part (3), `center_on_node` ignoring scale, is untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)