### PR TITLE
fix(panel): the sidebar guard must not destroy on an UNKNOWN active tab

### DIFF
--- a/browser_tests/unit/active-sidebar-tab.test.mjs
+++ b/browser_tests/unit/active-sidebar-tab.test.mjs
@@ -1,0 +1,147 @@
+// panel#779 — the panel rendered BLANK on ComfyUI frontend 1.50.x, and it was ours.
+//
+// `installSidebarTabGuard` removes our root when another sidebar tab is active.
+// It identified the active tab from the selected button's CSS classes. ComfyUI
+// 1.50 moved the id into an attribute — diffed from the shipped bundles:
+//
+//     1.47.12   class: I(e.id + `-tab-button`)
+//     1.50.3    "data-testid": `${e.id}-tab-button`      (the class is gone)
+//
+// So the lookup found nothing, returned null, and the guard read that as "some
+// OTHER tab is active" — removing `.cmcp-root` the instant render() attached it.
+// The observer watches class changes on the toolbar, so selecting our tab was
+// itself the trigger. A new user was blocked on first install with no error.
+
+import assert from "node:assert/strict";
+import test from "node:test";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+import {
+  readActiveSidebarTab,
+  shouldDetachPanelRoot,
+} from "../../web/js/lib/active-sidebar-tab.js";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const PANEL_JS = join(HERE, "../../web/js/comfyui-mcp-panel.js");
+const OURS = "comfyui-mcp.agent";
+
+/** A rail button double. `attrs` is what getAttribute sees. */
+function button({ classes = [], attrs = {} } = {}) {
+  return {
+    classList: classes,
+    getAttribute: (k) => (Object.prototype.hasOwnProperty.call(attrs, k) ? attrs[k] : null),
+  };
+}
+
+/** How 1.50.3 marks the selected button. */
+const modern = (id) =>
+  button({
+    classes: ["side-bar-button", "side-bar-button-selected", "p-button"],
+    attrs: { "data-testid": `${id}-tab-button` },
+  });
+
+/** How 1.47.12 marked it. */
+const legacy = (id) =>
+  button({ classes: ["side-bar-button", "side-bar-button-selected", `${id}-tab-button`] });
+
+test("#779 the 1.50 shape (data-testid) is read", () => {
+  assert.deepEqual(readActiveSidebarTab(modern(OURS)), { state: "id", id: OURS });
+  assert.deepEqual(readActiveSidebarTab(modern("workflows")), { state: "id", id: "workflows" });
+});
+
+test("#779 the pre-1.50 shape (class) still works", () => {
+  // Both generations must work — users are spread across them, and a fix that
+  // traded one break for another would be no fix at all.
+  assert.deepEqual(readActiveSidebarTab(legacy(OURS)), { state: "id", id: OURS });
+  assert.deepEqual(readActiveSidebarTab(legacy("queue")), { state: "id", id: "queue" });
+});
+
+test("#779 an id containing a DOT survives — ours does", () => {
+  // "comfyui-mcp.agent" is not a valid CSS class selector, which is why the guard
+  // reads classList rather than querying. The dot must not be mangled either way.
+  assert.equal(readActiveSidebarTab(modern(OURS)).id, "comfyui-mcp.agent");
+  assert.equal(readActiveSidebarTab(legacy(OURS)).id, "comfyui-mcp.agent");
+});
+
+test("#779 no selection at all is NONE, not unknown", () => {
+  // Genuinely nothing selected: our content should detach. That is an
+  // observation, and it stays actionable.
+  assert.deepEqual(readActiveSidebarTab(null), { state: "none" });
+  assert.deepEqual(readActiveSidebarTab(undefined), { state: "none" });
+  assert.equal(shouldDetachPanelRoot({ state: "none" }, OURS), true);
+});
+
+test("#779 a selected-but-UNIDENTIFIABLE button is UNKNOWN", () => {
+  // This is the 1.50 case, and the whole bug. A button is selected and carries
+  // no marker we recognise.
+  const mystery = button({ classes: ["side-bar-button", "side-bar-button-selected"] });
+  assert.deepEqual(readActiveSidebarTab(mystery), { state: "unknown" });
+  // A future frontend that renames the suffix lands here too.
+  const renamed = button({
+    classes: ["side-bar-button-selected"],
+    attrs: { "data-testid": "workflows-sidebar-item" },
+  });
+  assert.deepEqual(readActiveSidebarTab(renamed), { state: "unknown" });
+});
+
+test("#779 UNKNOWN never destroys — the fix that matters", () => {
+  // "I cannot tell which tab is active" is not "it is not ours" (#796). Getting
+  // this wrong is what turned a moved DOM marker into a blank panel for a new
+  // user, with no error anywhere.
+  assert.equal(shouldDetachPanelRoot({ state: "unknown" }, OURS), false);
+});
+
+test("#779 a provably different tab still detaches", () => {
+  // The guard has a real job — a stray panel lingering over someone else's tab
+  // is what it exists to prevent. Failing safe must not disable it.
+  assert.equal(shouldDetachPanelRoot({ state: "id", id: "workflows" }, OURS), true);
+  assert.equal(shouldDetachPanelRoot({ state: "id", id: OURS }, OURS), false);
+});
+
+test("#779 a bare suffix is not an id", () => {
+  // "-tab-button" with nothing before it names no tab; treating "" as an id
+  // would make it unequal to ours and detach.
+  const bare = button({ classes: ["side-bar-button-selected", "-tab-button"] });
+  assert.deepEqual(readActiveSidebarTab(bare), { state: "unknown" });
+  const bareAttr = button({
+    classes: ["side-bar-button-selected"],
+    attrs: { "data-testid": "-tab-button" },
+  });
+  assert.deepEqual(readActiveSidebarTab(bareAttr), { state: "unknown" });
+});
+
+test("#779 data-testid WINS when both are present", () => {
+  // A transitional build could carry both. The attribute is the current source
+  // of truth, so it decides.
+  const both = button({
+    classes: ["side-bar-button-selected", "stale-id-tab-button"],
+    attrs: { "data-testid": `${OURS}-tab-button` },
+  });
+  assert.deepEqual(readActiveSidebarTab(both), { state: "id", id: OURS });
+});
+
+test("#779 a button with no getAttribute does not throw", () => {
+  // This runs inside a MutationObserver on ComfyUI's toolbar. A throw there is
+  // silent and would leave the guard dead.
+  const odd = { classList: ["side-bar-button-selected", `${OURS}-tab-button`] };
+  assert.deepEqual(readActiveSidebarTab(odd), { state: "id", id: OURS });
+  assert.deepEqual(readActiveSidebarTab({}), { state: "unknown" });
+});
+
+test("#779 WIRING: the guard uses the three-state read, not a class lookup", () => {
+  const src = readFileSync(PANEL_JS, "utf8");
+  assert.match(
+    src,
+    /import \{ readActiveSidebarTab, shouldDetachPanelRoot \} from "\.\/lib\/active-sidebar-tab\.js"/,
+  );
+  const i = src.indexOf("function installSidebarTabGuard(");
+  assert.ok(i > 0, "the guard must be findable");
+  const body = src.slice(i, src.indexOf("\n}", i));
+  assert.match(body, /readActiveSidebarTab\(document\.querySelector\("\.side-bar-button-selected"\)\)/);
+  assert.match(body, /if \(!shouldDetachPanelRoot\(active, tabId\)\) return;/);
+  // The discredited lookup must be gone, not merely bypassed.
+  assert.doesNotMatch(body, /classList\].*endsWith\("-tab-button"\)/);
+  assert.doesNotMatch(body, /activeTabId\(\) === tabId/);
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -142,6 +142,7 @@ import { assertAddNodeResolvableRefreshing, isRegisteredNodeType } from "./lib/n
 import { fetchSingleNodeDef } from "./lib/single-node-def.js";
 import { readSaveFailureCause } from "./lib/userdata-failure-cause.js";
 import { describeScreenshotFraming } from "./lib/screenshot-framing.js";
+import { readActiveSidebarTab, shouldDetachPanelRoot } from "./lib/active-sidebar-tab.js";
 import { displayLabel, boundaryInputLabel, widgetLabelMap } from "./lib/slot-labels.js";
 import { createObjectInfoHistory, awaitHistoryBaseline } from "./lib/object-info-history.js";
 import { makeRefreshCoalescer } from "./lib/refresh-coalesce.js";
@@ -27056,20 +27057,21 @@ function buildPanel() {
 // extensions (e.g. ComfyUI-Easy-Use's NodesMap) render elsewhere and never touch
 // the shared host — so our panel stays painted when another tab is active and the
 // panels visibly stack. `activeSidebarTabId` is unreliable in this frontend build,
-// so we read the active tab from the DOM: the selected rail button carries
-// `side-bar-button-selected` plus a unique `<tabId>-tab-button` class. When our tab
-// isn't selected we remove our own root; render() rebuilds it on re-entry. We guard
-// only OUR root, never another tab's.
+// so we read the active tab from the DOM: the selected rail button identifies its
+// tab, on 1.50+ via `data-testid="<tabId>-tab-button"` and on earlier builds via a
+// `<tabId>-tab-button` CLASS. When our tab isn't selected we remove our own root;
+// render() rebuilds it on re-entry. We guard only OUR root, never another tab's.
+//
+// #779 — reading ONLY the class blanked the panel on frontend 1.50.x. The id moved
+// to an attribute there, the class lookup found nothing, and "I cannot tell which
+// tab is active" was read as "some other tab is active" — so this removed
+// `.cmcp-root` the instant render() attached it. An unidentifiable selection now
+// changes nothing, which is what keeps this cosmetic the next time the marker moves.
 function installSidebarTabGuard(tabId, getRoot, onDetach) {
-  const activeTabId = () => {
-    const b = document.querySelector(".side-bar-button-selected");
-    if (!b) return null;
-    const t = [...b.classList].find((c) => c.endsWith("-tab-button"));
-    return t ? t.slice(0, -"-tab-button".length) : null;
-  };
   const enforce = () => {
-    if (activeTabId() === tabId) return;             // our tab active → keep content
-    const r = getRoot();                              // inactive → drop our stray content
+    const active = readActiveSidebarTab(document.querySelector(".side-bar-button-selected"));
+    if (!shouldDetachPanelRoot(active, tabId)) return; // ours, or unknown → keep content
+    const r = getRoot();                               // provably elsewhere → drop our stray content
     if (r && r.isConnected) {
       // This is the OTHER path that detaches a live panel (the tab's own
       // destroy() is the first), so audio has to be paused here too — a

--- a/web/js/lib/active-sidebar-tab.js
+++ b/web/js/lib/active-sidebar-tab.js
@@ -1,0 +1,85 @@
+/**
+ * panel#779 — the panel renders blank on ComfyUI frontend 1.50.x, and the cause
+ * is ours.
+ *
+ * `installSidebarTabGuard` removes our root whenever another sidebar tab is
+ * active, so a stray panel can't linger over someone else's tab. It identified
+ * the active tab by reading the selected button's CSS classes:
+ *
+ *     [...b.classList].find((c) => c.endsWith("-tab-button"))
+ *
+ * ComfyUI 1.50 moved the id out of the class and into an attribute. Verified by
+ * diffing the shipped bundles:
+ *
+ *     1.47.12   class: I(e.id + `-tab-button`)
+ *     1.50.3    "data-testid": `${e.id}-tab-button`      (the class is gone)
+ *
+ * So on 1.50 the lookup found nothing, returned null, and the guard read that as
+ * "some OTHER tab is active" — then removed `.cmcp-root` the moment `render()`
+ * attached it. The MutationObserver watches class changes on the toolbar, so
+ * selecting our tab is itself what triggered the removal. Symptom: the tab
+ * registers, is selectable, nothing paints, `.cmcp-root` is absent, and no error
+ * is attributed to us. A new user was blocked on first install.
+ *
+ * TWO CHANGES, AND THE SECOND MATTERS MORE.
+ *
+ * 1. Read `data-testid` first, then fall back to the class, so both frontend
+ *    generations work.
+ *
+ * 2. NEVER DESTROY ON AN UNREADABLE SELECTION. A selected button we cannot
+ *    identify is "I do not know which tab is active" — not "it is not ours"
+ *    (#796). The first is the only honest reading, and it is the one that would
+ *    have made this a cosmetic bug instead of a blank panel: the next time
+ *    ComfyUI moves this marker, the panel keeps working.
+ *
+ * The three states are deliberately distinct:
+ *   - "none"    no tab is selected at all → our content genuinely should detach
+ *   - "id"      we know which tab is active → compare it
+ *   - "unknown" a tab is selected but unidentifiable → change nothing
+ */
+
+const SUFFIX = "-tab-button";
+
+/**
+ * Which sidebar tab is active, as a three-state answer.
+ *
+ * @param {Element|null|undefined} selectedButton the `.side-bar-button-selected`
+ *   element, or null/undefined when none is selected.
+ * @returns {{state: "none"} | {state: "id", id: string} | {state: "unknown"}}
+ */
+export function readActiveSidebarTab(selectedButton) {
+  if (!selectedButton) return { state: "none" };
+
+  // 1.50+: the id lives on data-testid.
+  const testId =
+    typeof selectedButton.getAttribute === "function"
+      ? selectedButton.getAttribute("data-testid")
+      : null;
+  if (typeof testId === "string" && testId.endsWith(SUFFIX) && testId.length > SUFFIX.length) {
+    return { state: "id", id: testId.slice(0, -SUFFIX.length) };
+  }
+
+  // <=1.49: the id was a CSS class.
+  const classes = selectedButton.classList ? [...selectedButton.classList] : [];
+  const cls = classes.find((c) => c.endsWith(SUFFIX) && c.length > SUFFIX.length);
+  if (cls) return { state: "id", id: cls.slice(0, -SUFFIX.length) };
+
+  // A tab IS selected and we cannot name it. Saying "not ours" here is what
+  // blanked the panel on 1.50.
+  return { state: "unknown" };
+}
+
+/**
+ * Should the guard detach our root right now?
+ *
+ * Only on evidence: either nothing is selected, or something else provably is.
+ *
+ * @param {ReturnType<typeof readActiveSidebarTab>} active
+ * @param {string} ourTabId
+ */
+export function shouldDetachPanelRoot(active, ourTabId) {
+  if (!active) return false;
+  if (active.state === "none") return true;
+  if (active.state === "unknown") return false;
+  return active.id !== ourTabId;
+}


### PR DESCRIPTION
Fixes #779 — **P0**. The panel rendered completely blank on ComfyUI frontend 1.50.x. A new user was blocked on first install, spent an hour reinstalling software that was never the problem, and nothing in the console pointed at us.

**The cause is ours.**

`installSidebarTabGuard` removes our root whenever another sidebar tab is active, so a stray panel can't linger over someone else's tab. It identified the active tab from the selected rail button's CSS classes. ComfyUI 1.50 moved the id into an attribute — diffed from the shipped bundles:

| frontend | how the id is exposed |
|---|---|
| 1.47.12 | ``class: I(e.id + `-tab-button`)`` |
| 1.50.3 | ``"data-testid": `${e.id}-tab-button` `` — **the class is gone** |

So on 1.50 the lookup found nothing and returned `null`, and the guard read `null` as *"some other tab is active"* — removing `.cmcp-root` **the instant `render()` attached it**. The MutationObserver watches class changes on the toolbar, so *selecting our tab* was itself the trigger. Tab registers, is selectable, nothing paints, no error attributed to us.

## Two changes, and the second matters more

**1.** Read `data-testid` first, then fall back to the class, so both frontend generations work. Users are spread across them, and a fix that traded one break for another would be no fix.

**2. Never destroy on an unreadable selection.** A selected button we cannot identify is *"I do not know which tab is active"*, not *"it is not ours"* (#796). That distinction is the difference between a cosmetic bug and a blank panel: with it, the next time ComfyUI moves this marker the panel keeps working and someone files a stray-content nuisance instead of a P0.

Three states, deliberately distinct:

| state | meaning | action |
|---|---|---|
| `none` | nothing selected | detach — a real observation, still acted on |
| `id` | we know which tab | compare it |
| `unknown` | selected, unnameable | **change nothing** |

The guard still does its job — a provably different tab still detaches, verified by mutation rather than assumed.

## Verification

| mutation | result |
|---|---|
| drop the `data-testid` read (regress to 1.47-only) | **3 failed** — reproduces the original bug |
| make `unknown` destroy again | 1 failed |
| stop detaching on a different tab (guard disabled) | 1 failed |
| treat `none` as keep | 1 failed |
| unwire the guard at the call site | 1 failed |

11 new tests · panel unit suite **2946 passed** · typecheck and the vocabulary gate exit 0 · control-byte scan clean.

**Diagnosis credit is the reporter's.** They eliminated the install, the browser, the cache and the orchestrator before asking, confirmed `.cmcp-root` was absent rather than hidden, and then proved it by pinning the frontend to 1.47.12 on the same machine. That is what turned "blank panel" into a one-variable diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)