### PR TITLE
fix(panel): a blank tab is never an acceptable failure state

### DIFF
--- a/browser_tests/unit/panel-failure-shell.test.mjs
+++ b/browser_tests/unit/panel-failure-shell.test.mjs
@@ -1,0 +1,137 @@
+// panel#779 — a blank tab is not an acceptable failure state.
+//
+// A new user installed the pack, opened the Agent tab, and got a black
+// rectangle: no header, no Connect button, no "not connected" state, nothing in
+// the console attributed to us. Unable to tell "broken" from "not connected"
+// from "not installed", they reinstalled ComfyUI, tried a second browser, and
+// hard-refreshed both — an hour on things that were never the problem.
+//
+// The cause that time was a frontend DOM marker that moved (#784, fixed). This is
+// the floor underneath it: ComfyUI mounts us with
+// `mountCustomExtension = (e, t) => e.render(t)` and has NO handler, so anything
+// that throws in render() leaves the container empty. Every future cause lands
+// the same way, which is why this is a floor and not another special case.
+
+import assert from "node:assert/strict";
+import test from "node:test";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+import {
+  panelFailureReport,
+  buildPanelFailureShell,
+} from "../../web/js/lib/panel-failure-shell.js";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const PANEL_JS = join(HERE, "../../web/js/comfyui-mcp-panel.js");
+
+/** A minimal document double — no jsdom in this suite. */
+function fakeDoc() {
+  const make = (tag) => ({
+    tagName: tag,
+    className: "",
+    children: [],
+    attrs: {},
+    textContent: "",
+    setAttribute(k, v) {
+      this.attrs[k] = v;
+    },
+    appendChild(c) {
+      this.children.push(c);
+      return c;
+    },
+  });
+  return { createElement: make };
+}
+
+const textOf = (el) =>
+  [el.textContent, ...el.children.map(textOf)].filter(Boolean).join("\n");
+
+test("#779 it reports what was OBSERVED and diagnoses nothing", () => {
+  // Inventing a cause is what sent the reporter to reinstall. A wrong
+  // explanation is worse than a blank tab, because it gets acted on.
+  const r = panelFailureReport(new TypeError("x is not a function"));
+  assert.match(r.message, /TypeError: x is not a function/);
+  assert.match(r.body, /nothing here is a diagnosis of the cause/);
+});
+
+test("#779 it rules OUT the two things the reporter wasted an hour on", () => {
+  const r = panelFailureReport(new Error("boom"));
+  assert.match(r.body, /NOT a connection problem/);
+  assert.match(r.body, /reinstalling ComfyUI or the pack will not change it/);
+});
+
+test("#779 a non-Error, and a message-less failure, still produce text", () => {
+  // Whatever escapes a build can be anything. "" must not render an empty pre
+  // that looks like the blank tab all over again.
+  assert.equal(panelFailureReport("plain string").message, "plain string");
+  assert.match(panelFailureReport(undefined).message, /no message/);
+  assert.match(panelFailureReport(null).message, /no message/);
+  assert.match(panelFailureReport("").message, /no message/);
+  assert.match(panelFailureReport({ weird: true }).message, /no message/);
+});
+
+test("#779 versions are carried, and unknown is stated rather than blank", () => {
+  const known = panelFailureReport(new Error("e"), {
+    panelVersion: "0.11.44",
+    frontendVersion: "1.50.3",
+  });
+  assert.equal(known.panelVersion, "0.11.44");
+  assert.equal(known.frontendVersion, "1.50.3");
+  // The frontend version is the single most useful field here — #779 turned on
+  // it — so its absence must be visible rather than an empty gap.
+  const bare = panelFailureReport(new Error("e"));
+  assert.equal(bare.panelVersion, "unknown");
+  assert.equal(bare.frontendVersion, "unknown");
+});
+
+test("#779 the shell renders the message, versions and where to report", () => {
+  const el = buildPanelFailureShell(fakeDoc(), new Error("kaboom"), {
+    panelVersion: "0.11.44",
+    frontendVersion: "1.50.3",
+  });
+  assert.ok(el, "a shell must be produced");
+  const text = textOf(el);
+  assert.match(text, /could not start/);
+  assert.match(text, /kaboom/);
+  assert.match(text, /panel 0\.11\.44 · ComfyUI frontend 1\.50\.3/);
+  assert.match(text, /github\.com\/artokun\/comfyui-mcp-panel\/issues/);
+});
+
+test("#779 the message goes in as TEXT, never markup", () => {
+  // An error message can contain anything, and this renders inside ComfyUI's
+  // page. textContent is the only safe sink.
+  const el = buildPanelFailureShell(fakeDoc(), new Error("<img src=x onerror=alert(1)>"));
+  const pre = el.children.find((c) => c.tagName === "pre");
+  assert.ok(pre.textContent.includes("<img src=x onerror=alert(1)>"));
+  assert.equal(pre.innerHTML, undefined, "innerHTML must never be set");
+});
+
+test("#779 it NEVER throws — it runs because something already did", () => {
+  // A second throw here puts us back at the blank tab this exists to prevent.
+  assert.equal(buildPanelFailureShell(null, new Error("e")), null);
+  assert.equal(buildPanelFailureShell({}, new Error("e")), null);
+  const hostile = {
+    createElement: () => {
+      throw new Error("no elements for you");
+    },
+  };
+  assert.equal(buildPanelFailureShell(hostile, new Error("e")), null);
+});
+
+test("#779 WIRING: render() catches, resets `mounted`, and appends the shell", () => {
+  const src = readFileSync(PANEL_JS, "utf8");
+  assert.match(src, /import \{ buildPanelFailureShell \} from "\.\/lib\/panel-failure-shell\.js"/);
+  const i = src.indexOf("render: (container) => {");
+  assert.ok(i > 0, "the render callback must be findable");
+  const body = src.slice(i, src.indexOf("\n        destroy:", i));
+  assert.match(body, /try \{/, "the build path is guarded");
+  assert.match(body, /\} catch \(err\) \{/);
+  // A half-built root must not survive, or the next render appends a second one.
+  assert.match(body, /mounted = null;/);
+  assert.match(body, /buildPanelFailureShell\(document, err, \{/);
+  assert.match(body, /if \(shell\) container\.appendChild\(shell\);/);
+  // The frontend version is passed — it is what #779 turned on.
+  assert.match(body, /frontendVersion:/);
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -143,6 +143,7 @@ import { fetchSingleNodeDef } from "./lib/single-node-def.js";
 import { readSaveFailureCause } from "./lib/userdata-failure-cause.js";
 import { describeScreenshotFraming } from "./lib/screenshot-framing.js";
 import { readActiveSidebarTab, shouldDetachPanelRoot } from "./lib/active-sidebar-tab.js";
+import { buildPanelFailureShell } from "./lib/panel-failure-shell.js";
 import { displayLabel, boundaryInputLabel, widgetLabelMap } from "./lib/slot-labels.js";
 import { createObjectInfoHistory, awaitHistoryBaseline } from "./lib/object-info-history.js";
 import { makeRefreshCoalescer } from "./lib/refresh-coalesce.js";
@@ -27264,16 +27265,39 @@ function registerExtensionWhenReady(tries = 0) {
         // switches to another sidebar tab) only DETACHES it — the agent keeps
         // working in the background and the sidebar-icon badge shows its state.
         render: (container) => {
-          if (!mounted) mounted = buildPanel();
-          // Make the tab content a full-height flex column so the panel's header
-          // and input pin to the edges and only the chat body scrolls (the
-          // container otherwise sizes to content and the whole panel scrolls).
-          container.style.height = "100%";
-          container.style.minHeight = "0";
-          container.style.display = "flex";
-          container.style.flexDirection = "column";
-          container.appendChild(mounted.root);
-          mounted.onShow?.();
+          // #779 — A BLANK TAB IS NOT AN ACCEPTABLE FAILURE STATE. ComfyUI mounts
+          // us with `mountCustomExtension = (e, t) => e.render(t)` and has no
+          // handler, so anything that throws in here leaves the container empty
+          // with nothing in the console attributed to us. A reporter could not
+          // tell "broken" from "not connected" from "not installed" and spent an
+          // hour reinstalling ComfyUI. Whatever fails, say so in the tab.
+          try {
+            if (!mounted) mounted = buildPanel();
+            // Make the tab content a full-height flex column so the panel's header
+            // and input pin to the edges and only the chat body scrolls (the
+            // container otherwise sizes to content and the whole panel scrolls).
+            container.style.height = "100%";
+            container.style.minHeight = "0";
+            container.style.display = "flex";
+            container.style.flexDirection = "column";
+            container.appendChild(mounted.root);
+            mounted.onShow?.();
+          } catch (err) {
+            // Do not leave a half-built root behind — it would be neither the
+            // panel nor the notice, and the next render() would append a second.
+            mounted = null;
+            try {
+              console.error("[comfyui-mcp-panel] panel construction failed", err);
+            } catch { /* a logger that throws must not also eat the notice */ }
+            const shell = buildPanelFailureShell(document, err, {
+              panelVersion: typeof PANEL_VERSION === "string" ? PANEL_VERSION : undefined,
+              frontendVersion:
+                window.__COMFYUI_FRONTEND_VERSION__ ??
+                app?.extensionManager?.frontendVersion ??
+                undefined,
+            });
+            if (shell) container.appendChild(shell);
+          }
         },
         destroy: () => {
           // Detach only — never mounted.destroy(). Tearing down here is what used

--- a/web/js/lib/panel-failure-shell.js
+++ b/web/js/lib/panel-failure-shell.js
@@ -1,0 +1,117 @@
+/**
+ * panel#779 — a blank tab is not an acceptable failure state.
+ *
+ * A new user installed the pack, opened the Agent tab, and got a black rectangle.
+ * No header, no Connect button, no "not connected" state, nothing in the console
+ * attributed to us. They could not tell "broken" from "not connected" from "not
+ * installed", so they uninstalled and reinstalled ComfyUI, tried a second
+ * browser, and hard-refreshed both — an hour spent on things that were never the
+ * problem. The actual cause (a frontend DOM marker that moved, #784) is fixed;
+ * this is the floor underneath it.
+ *
+ * `render(container)` builds the panel on first entry. If ANYTHING in that path
+ * throws, the exception escapes into ComfyUI's `mountCustomExtension = (e, t) =>
+ * e.render(t)`, which has no handler — the container simply stays empty. Every
+ * future cause of that lands the same way, which is why the fix is a floor rather
+ * than another special case.
+ *
+ * WHAT THIS DELIBERATELY DOES NOT DO: diagnose. It cannot know why the build
+ * failed, and inventing a cause is what sent this reporter to reinstall. It
+ * reports what it OBSERVED — that construction threw, with the message and the
+ * versions — and says where to send it. A wrong explanation would be worse than
+ * the blank tab, because it would be acted on.
+ */
+
+/** Kept inline: the panel stylesheet is loaded by the panel we just failed to build. */
+const STYLE = {
+  wrap: "padding:16px;font:13px/1.5 system-ui,sans-serif;color:#ddd;height:100%;overflow:auto;box-sizing:border-box",
+  h: "margin:0 0 10px;font-size:14px;font-weight:600;color:#ff8a80",
+  p: "margin:0 0 10px",
+  pre: "margin:0 0 10px;padding:8px;background:#00000055;border:1px solid #ffffff22;border-radius:4px;white-space:pre-wrap;word-break:break-word;font:11px/1.45 ui-monospace,monospace;color:#ffb4a8",
+  dl: "margin:0 0 10px;font:11px/1.6 ui-monospace,monospace;color:#aaa",
+};
+
+/**
+ * The text of the failure notice.
+ *
+ * Separated from the DOM so it can be asserted without a document, and so the
+ * wording is reviewable on its own.
+ *
+ * @param {unknown} err
+ * @param {{ panelVersion?: string, frontendVersion?: string }} [info]
+ */
+export function panelFailureReport(err, info = {}) {
+  const message =
+    err instanceof Error
+      ? `${err.name}: ${err.message}`
+      : typeof err === "string" && err
+        ? err
+        : "(the failure produced no message)";
+  const stack = err instanceof Error && typeof err.stack === "string" ? err.stack : "";
+  return {
+    title: "The agent panel could not start.",
+    body:
+      "Building the panel threw, so nothing was rendered. This is a fault in the panel " +
+      "itself — it is NOT a connection problem, and reinstalling ComfyUI or the pack will " +
+      "not change it. The details below are what was actually observed; nothing here is a " +
+      "diagnosis of the cause.",
+    message,
+    stack,
+    panelVersion: info.panelVersion || "unknown",
+    frontendVersion: info.frontendVersion || "unknown",
+    where:
+      "Please report this at https://github.com/artokun/comfyui-mcp-panel/issues with the " +
+      "text above, your ComfyUI frontend version, and your browser.",
+  };
+}
+
+/**
+ * Build the failure shell element.
+ *
+ * Never throws: it runs because something already did, and a second throw here
+ * would put us back at the blank tab this exists to prevent.
+ *
+ * @param {Document} doc
+ * @param {unknown} err
+ * @param {{ panelVersion?: string, frontendVersion?: string }} [info]
+ * @returns {Element|null} null only if the document itself cannot make elements
+ */
+export function buildPanelFailureShell(doc, err, info = {}) {
+  try {
+    if (!doc || typeof doc.createElement !== "function") return null;
+    const r = panelFailureReport(err, info);
+    const wrap = doc.createElement("div");
+    wrap.className = "cmcp-failure-shell";
+    wrap.setAttribute("style", STYLE.wrap);
+
+    const h = doc.createElement("div");
+    h.setAttribute("style", STYLE.h);
+    h.textContent = r.title;
+    wrap.appendChild(h);
+
+    const p = doc.createElement("div");
+    p.setAttribute("style", STYLE.p);
+    p.textContent = r.body;
+    wrap.appendChild(p);
+
+    const pre = doc.createElement("pre");
+    pre.setAttribute("style", STYLE.pre);
+    // textContent, never innerHTML — the message can carry anything.
+    pre.textContent = r.stack ? `${r.message}\n\n${r.stack}` : r.message;
+    wrap.appendChild(pre);
+
+    const dl = doc.createElement("div");
+    dl.setAttribute("style", STYLE.dl);
+    dl.textContent = `panel ${r.panelVersion} · ComfyUI frontend ${r.frontendVersion}`;
+    wrap.appendChild(dl);
+
+    const w = doc.createElement("div");
+    w.setAttribute("style", STYLE.p);
+    w.textContent = r.where;
+    wrap.appendChild(w);
+
+    return wrap;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
Refs #779 — the second half, and the one that outlives its cause.

A new user opened the Agent tab and got a black rectangle: no header, no Connect button, no "not connected" state, nothing in the console attributed to us. Unable to tell *broken* from *not connected* from *not installed*, they uninstalled and reinstalled ComfyUI, tried a second browser, and hard-refreshed both — an hour on things that were never the problem.

ComfyUI mounts us with `mountCustomExtension = (e, t) => e.render(t)` and has **no handler** around it. So anything that throws while building the panel escapes into Vue's ref callback and the container simply stays empty. The specific cause that time is fixed (#784) — but **every future cause lands the same way**, which is why this is a floor rather than another special case.

`render()` now catches, and the tab says what happened.

## It deliberately does not diagnose

It cannot know why the build failed, and **inventing a cause is exactly what sent this reporter to reinstall**. It reports what was *observed* — that construction threw, the message, the stack, the panel version and the ComfyUI **frontend** version — and where to send it. A wrong explanation would be worse than the blank tab, because it would be acted on.

It does rule out the two things that cost the hour: this is not a connection problem, and reinstalling will not change it.

The frontend version is in there because **#779 turned entirely on it**, and it's the field a reporter is least likely to think to include.

## Details that matter more than they look

- **`mounted` is reset on failure** — otherwise a half-built root survives and the next `render()` appends a second one.
- **`textContent`, never `innerHTML`** — an error string can contain anything and this renders inside ComfyUI's page.
- **The shell builder never throws.** It runs because something already did; a second throw puts us back at the blank tab it exists to prevent.
- **A non-`Error`, a `null`, and an empty message all still produce text** — `""` would render an empty box that looks like the blank tab all over again.

## Verification

Each mutation confirmed *applied* before running — two of my first attempts silently didn't match and had to be redone:

| mutation | result |
|---|---|
| remove the try/catch | 1 failed |
| keep the half-built root | 1 failed |
| swap `textContent` for `innerHTML` | 2 failed |
| make the shell builder rethrow | 1 failed |
| drop the not-a-connection-problem sentence | 1 failed |

8 new tests · panel unit suite **2961 passed** · typecheck and the vocabulary gate exit 0 · control-byte scan clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)