### PR TITLE
fix(panel): find the tab button the way 1.50 marks it, at the SECOND site too

### DIFF
--- a/browser_tests/unit/active-sidebar-tab.test.mjs
+++ b/browser_tests/unit/active-sidebar-tab.test.mjs
@@ -21,6 +21,7 @@ import { dirname, join } from "node:path";
 import {
   readActiveSidebarTab,
   shouldDetachPanelRoot,
+  findSidebarTabButton,
 } from "../../web/js/lib/active-sidebar-tab.js";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
@@ -132,10 +133,14 @@ test("#779 a button with no getAttribute does not throw", () => {
 
 test("#779 WIRING: the guard uses the three-state read, not a class lookup", () => {
   const src = readFileSync(PANEL_JS, "utf8");
-  assert.match(
-    src,
-    /import \{ readActiveSidebarTab, shouldDetachPanelRoot \} from "\.\/lib\/active-sidebar-tab\.js"/,
-  );
+  // Assert the NAMES are imported from that module, not the literal import line:
+  // pinning the exact list means every added export breaks an unrelated test,
+  // which is noise rather than protection.
+  const imp = src.match(/import \{([^}]*)\} from "\.\/lib\/active-sidebar-tab\.js"/);
+  assert.ok(imp, "the guard's helpers must come from lib/active-sidebar-tab.js");
+  const names = imp[1].split(",").map((n) => n.trim());
+  assert.ok(names.includes("readActiveSidebarTab"), `missing readActiveSidebarTab in ${imp[1]}`);
+  assert.ok(names.includes("shouldDetachPanelRoot"), `missing shouldDetachPanelRoot in ${imp[1]}`);
   const i = src.indexOf("function installSidebarTabGuard(");
   assert.ok(i > 0, "the guard must be findable");
   const body = src.slice(i, src.indexOf("\n}", i));
@@ -144,4 +149,65 @@ test("#779 WIRING: the guard uses the three-state read, not a class lookup", () 
   // The discredited lookup must be gone, not merely bypassed.
   assert.doesNotMatch(body, /classList\].*endsWith\("-tab-button"\)/);
   assert.doesNotMatch(body, /activeTabId\(\) === tabId/);
+});
+
+// ---------------------------------------------------------------------------
+// #779, second site: findAgentTabIcon read the id out of a CLASS too.
+// ---------------------------------------------------------------------------
+
+/** A document double whose querySelector understands the two forms we use. */
+function docWith(button, { supportsAttrSelector = true } = {}) {
+  return {
+    querySelector(sel) {
+      if (sel.startsWith("[data-testid=")) {
+        if (!supportsAttrSelector) throw new SyntaxError("unsupported selector");
+        const want = sel.slice('[data-testid="'.length, -2);
+        return button?.testId === want ? button : null;
+      }
+      if (sel.startsWith("button[class~=")) {
+        const want = sel.slice('button[class~="'.length, -2);
+        return button?.classes?.includes(want) ? button : null;
+      }
+      return null;
+    },
+  };
+}
+
+test("#779 the button is found on 1.50 (data-testid)", () => {
+  const btn = { testId: "comfyui-mcp.agent-tab-button", classes: [] };
+  assert.equal(findSidebarTabButton(docWith(btn), OURS), btn);
+});
+
+test("#779 the button is still found on <=1.49 (class)", () => {
+  const btn = { classes: ["comfyui-mcp.agent-tab-button"] };
+  assert.equal(findSidebarTabButton(docWith(btn), OURS), btn);
+});
+
+test("#779 a foreign tab's button is not ours", () => {
+  const other = { testId: "workflows-tab-button", classes: ["workflows-tab-button"] };
+  assert.equal(findSidebarTabButton(docWith(other), OURS), null);
+});
+
+test("#779 a thrown selector falls through to the class form, not out", () => {
+  // An engine that rejects the attribute selector must not take the fallback
+  // down with it — this runs on the badge path, where a throw is invisible.
+  const btn = { classes: ["comfyui-mcp.agent-tab-button"] };
+  assert.equal(findSidebarTabButton(docWith(btn, { supportsAttrSelector: false }), OURS), btn);
+});
+
+test("#779 bad inputs are null, never a throw", () => {
+  assert.equal(findSidebarTabButton(null, OURS), null);
+  assert.equal(findSidebarTabButton({}, OURS), null);
+  assert.equal(findSidebarTabButton(docWith(null), ""), null);
+  assert.equal(findSidebarTabButton(docWith(null), null), null);
+});
+
+test("#779 WIRING: findAgentTabIcon uses the finder, not a class query", () => {
+  const src = readFileSync(PANEL_JS, "utf8");
+  const i = src.indexOf("function findAgentTabIcon()");
+  assert.ok(i > 0, "findAgentTabIcon must be findable");
+  const body = src.slice(i, src.indexOf("\n}", i));
+  assert.match(body, /findSidebarTabButton\(document, SIDEBAR_TAB_ID\)/);
+  // The class-only query must be gone, not merely bypassed.
+  assert.doesNotMatch(body, /querySelector\(`button\[class~=/);
 });

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -142,7 +142,7 @@ import { assertAddNodeResolvableRefreshing, isRegisteredNodeType } from "./lib/n
 import { fetchSingleNodeDef } from "./lib/single-node-def.js";
 import { readSaveFailureCause } from "./lib/userdata-failure-cause.js";
 import { describeScreenshotFraming } from "./lib/screenshot-framing.js";
-import { readActiveSidebarTab, shouldDetachPanelRoot } from "./lib/active-sidebar-tab.js";
+import { readActiveSidebarTab, shouldDetachPanelRoot, findSidebarTabButton } from "./lib/active-sidebar-tab.js";
 import { buildPanelFailureShell } from "./lib/panel-failure-shell.js";
 import { displayLabel, boundaryInputLabel, widgetLabelMap } from "./lib/slot-labels.js";
 import { createObjectInfoHistory, awaitHistoryBaseline } from "./lib/object-info-history.js";
@@ -2347,7 +2347,12 @@ function findAgentTabIcon() {
   // ComfyUI stamps the toolbar button with `${tabId}-tab-button` — the precise
   // hook (attribute selector: the id contains a dot). Fall back to the chat
   // glyph inside a sidebar container for older frontends.
-  const btn = document.querySelector(`button[class~="${SIDEBAR_TAB_ID}-tab-button"]`);
+  // #779 — 1.50 moved this id from the CLASS to data-testid. That break blanked
+  // the panel at the guard; HERE it only degraded, because the toolbar scan below
+  // still found our glyph. That is why it went unnoticed — and why it is worth
+  // closing: on 1.50 the fallback is no longer a fallback, and it matches
+  // `.pi-comments`, which another extension is free to use.
+  const btn = findSidebarTabButton(document, SIDEBAR_TAB_ID);
   if (btn) {
     const icon = btn.querySelector("[data-cmcp-agent-icon]") || btn.querySelector(".pi");
     if (icon) {

--- a/web/js/lib/active-sidebar-tab.js
+++ b/web/js/lib/active-sidebar-tab.js
@@ -83,3 +83,50 @@ export function shouldDetachPanelRoot(active, ourTabId) {
   if (active.state === "unknown") return false;
   return active.id !== ourTabId;
 }
+
+/**
+ * The sidebar rail BUTTON for a given tab id, however this frontend marks it.
+ *
+ * #779 had two sites reading the id out of a CSS class. The guard was the one
+ * that blanked the panel; this is the other — `findAgentTabIcon`, which paints
+ * the unread/working badge on the rail. It fails softer (there is a fallback
+ * that scans the toolbar for our glyph), which is exactly why it would have gone
+ * unnoticed: on 1.50 the fallback is no longer a fallback, it is the only path,
+ * and it matches `.pi-comments` — an icon another extension is free to use.
+ *
+ * Verified against the shipped bundles: 1.50.3 marks the button with
+ * `data-testid="<tabId>-tab-button"`, 1.47.12 with a `<tabId>-tab-button` CLASS.
+ * Every other ComfyUI selector the panel relies on is present in both.
+ *
+ * The id contains a dot ("comfyui-mcp.agent"), which is why the class form uses
+ * `[class~=...]` rather than `.<id>-tab-button` — the latter would parse the dot
+ * as a descendant class.
+ *
+ * @param {Document|Element|null} root
+ * @param {string} tabId
+ * @returns {Element|null}
+ */
+export function findSidebarTabButton(root, tabId) {
+  if (!root || typeof root.querySelector !== "function") return null;
+  if (typeof tabId !== "string" || !tabId) return null;
+  // No regex here on purpose. The first draft escaped quotes with a character
+  // class, and the backslashes were eaten in transit — leaving `/["\]/g`, which
+  // is an invalid regular expression and took the whole module down at import.
+  // CSS.escape exists in every browser that runs ComfyUI; the bare fallback is
+  // only for a non-DOM test environment, and this id is a known constant with
+  // no quotes or backslashes in it.
+  const marker = `${tabId}-tab-button`;
+  const esc =
+    typeof CSS !== "undefined" && typeof CSS.escape === "function" ? CSS.escape(marker) : marker;
+  try {
+    // 1.50+ — the current source of truth.
+    const byTestId = root.querySelector(`[data-testid="${esc}"]`);
+    if (byTestId) return byTestId;
+  } catch { /* an unsupported selector must not take the fallback down with it */ }
+  try {
+    // <=1.49 — the id was a class.
+    return root.querySelector(`button[class~="${esc}"]`) ?? null;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
Refs #779

#784 fixed the site that blanked the panel. **This is the other one.**

After that fix I swept every ComfyUI-owned selector the panel depends on and checked each against the shipped 1.47.12 and 1.50.3 bundles:

| selector | 1.47.12 | 1.50.3 |
|---|---|---|
| `side-bar-button-selected` | ✓ | ✓ |
| `side-tool-bar-container` | ✓ | ✓ |
| `side-tool-bar-end` | ✓ | ✓ |
| `p-dialog-mask` | ✓ | ✓ |
| `pi-comments` | ✓ | ✓ |
| **`<tabId>-tab-button` CLASS** | ✓ | **moved to `data-testid`** |

Exactly one had moved — and it had **two** readers. `findAgentTabIcon`, which paints the unread/working badge on the rail, queried `button[class~="<tabId>-tab-button"]`.

## Why it went unnoticed, which is the point

It fails **softer** than the guard did. There's a fallback that scans the toolbar for our glyph, so on 1.50 the badge still mostly worked. But that fallback is no longer a fallback — **it is the only path** — and it matches `.pi-comments`, an icon any other extension is free to use.

A soft failure that silently becomes the primary path is worse than a loud one, because nobody goes looking.

`findSidebarTabButton` now reads `data-testid` first and falls back to the class, so both generations work, and it never throws: an engine that rejects the attribute selector falls through rather than taking the badge path down with it.

The id contains a dot (`comfyui-mcp.agent`), which is why the class form stays `[class~=…]` — `.comfyui-mcp.agent-tab-button` would parse the dot as a second class.

## Two things this cost, both mine

- The first draft escaped quotes with a character class and **the backslashes were eaten in transit**, leaving `/["\]/g` — an invalid regular expression that took the whole module down at import. There is no regex here now; `CSS.escape` covers every browser that runs ComfyUI and the id is a known constant.
- #784's wiring test pinned the exact **import list**, so adding one export failed an unrelated assertion. It now checks that the *names* are imported, which is what it meant to say.

## Verification

Each mutation confirmed applied before running:

| mutation | result |
|---|---|
| drop the `data-testid` lookup | 1 failed — reproduces the 1.50 break |
| drop the class fallback | 2 failed — breaks ≤1.49 |
| let a thrown selector escape | 1 failed |
| revert the call site to the class query | 1 failed |

6 new tests · panel unit suite **2967 passed** · typecheck and the vocabulary gate exit 0 · control-byte scan clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)