### PR TITLE
test(dom): declare every reach into ComfyUI's own DOM

### DIFF
--- a/browser_tests/unit/comfyui-dom-deps.test.mjs
+++ b/browser_tests/unit/comfyui-dom-deps.test.mjs
@@ -1,0 +1,127 @@
+// panel#779 — every reach into ComfyUI's OWN DOM must be declared.
+//
+// ComfyUI 1.50 moved a sidebar tab's id from a CSS class to `data-testid`. The
+// panel read that class in two places: one blanked the panel for a new user
+// (#784), the other only degraded so nobody noticed (#786). Both were found by
+// hand afterwards, by diffing two frontend bundles. That is luck, not a process.
+//
+// This gate makes the surface finite and attributed, so "check our DOM
+// assumptions against the new frontend" becomes a task someone can complete.
+// It cannot tell you a selector STOPPED MATCHING — only a real frontend can —
+// but it can stop the list from growing silently.
+
+import assert from "node:assert/strict";
+import test from "node:test";
+import { readdirSync, statSync, readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join, relative, sep } from "node:path";
+
+import {
+  COMFYUI_DOM_DEPS,
+  VERIFIED_FRONTENDS,
+  declaredSelectors,
+} from "../../web/js/lib/comfyui-dom-deps.js";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const WEB_JS = join(HERE, "../../web/js");
+
+const DOM_API = /(?:querySelector|querySelectorAll|closest|matches)\(\s*(['"`])(.*?)\1/g;
+
+/**
+ * Does this selector target markup we do NOT own?
+ *
+ * A class or id reference that is not cmcp-namespaced. Bare tag selectors
+ * (`audio`, `pre`, `button`) are excluded because we only ever run those inside
+ * our own root, and `[data-…]` hooks are ours by construction — including them
+ * would bury the ten that matter under forty that do not.
+ */
+function isForeignSelector(sel) {
+  if (sel.includes("cmcp")) return false;
+  return /(^|[\s,>+~(])[.#][A-Za-z_-]/.test(sel) || /\[(class|id)[*~^$|]?=/.test(sel);
+}
+
+function walk(dir, out = []) {
+  for (const name of readdirSync(dir)) {
+    if (name === "vendor") continue; // third-party bundles are not ours to declare
+    const p = join(dir, name);
+    if (statSync(p).isDirectory()) walk(p, out);
+    else if (name.endsWith(".js")) out.push(p);
+  }
+  return out;
+}
+
+function scanForeign() {
+  const found = new Map();
+  for (const file of walk(WEB_JS)) {
+    const rel = relative(join(HERE, "../.."), file).split(sep).join("/");
+    const text = readFileSync(file, "utf8");
+    DOM_API.lastIndex = 0;
+    let m;
+    while ((m = DOM_API.exec(text))) {
+      const sel = m[2];
+      if (!isForeignSelector(sel)) continue;
+      if (!found.has(sel)) found.set(sel, new Set());
+      found.get(sel).add(rel);
+    }
+  }
+  return found;
+}
+
+test("#779 the scan finds a surface at all", () => {
+  // Guards the gate itself: if the pattern stopped matching, every assertion
+  // below would pass vacuously on an empty set.
+  const found = scanForeign();
+  assert.ok(found.size >= 8, `expected the known ComfyUI DOM surface, got ${found.size}`);
+});
+
+test("#779 every ComfyUI selector the panel uses is DECLARED", () => {
+  const declared = declaredSelectors();
+  const found = scanForeign();
+  const undeclared = [...found.entries()]
+    .filter(([sel]) => !declared.has(sel))
+    .map(([sel, files]) => `${JSON.stringify(sel)}  (${[...files].sort()[0]})`);
+  assert.deepEqual(
+    undeclared,
+    [],
+    "these reach into ComfyUI's DOM without being declared in " +
+      "web/js/lib/comfyui-dom-deps.js. Add each with what it is for, its fallback, " +
+      "and the frontend versions you CHECKED it against:\n" +
+      undeclared.join("\n"),
+  );
+});
+
+test("#779 the registry has no entries the panel no longer uses", () => {
+  // A stale entry is worse than a missing one: it makes the surface look larger
+  // than it is, and the next reviewer wastes time checking dead selectors.
+  const found = scanForeign();
+  const stale = [...declaredSelectors()].filter((s) => !found.has(s));
+  assert.deepEqual(stale, [], `declared but unused — delete these:\n${stale.join("\n")}`);
+});
+
+test("#779 every entry says what it is FOR and what it was checked against", () => {
+  // "verified" records versions someone actually grepped the bundle for. An
+  // entry without one is a guess wearing a registry's clothes.
+  for (const d of COMFYUI_DOM_DEPS) {
+    assert.ok(d.why && d.why.split(/\s+/).length >= 6, `${d.selector}: needs a real reason`);
+    assert.ok(Array.isArray(d.verified) && d.verified.length > 0, `${d.selector}: no verified versions`);
+    for (const v of d.verified) {
+      assert.match(v, /^\d+\.\d+\.\d+$/, `${d.selector}: "${v}" is not a frontend version`);
+    }
+  }
+});
+
+test("#779 the selector that caused the outage is declared WITH its history", () => {
+  // The one that moved. Its entry has to carry why data-testid is tried first,
+  // or the next person "simplifies" it back to a class lookup.
+  const cls = COMFYUI_DOM_DEPS.find((d) => d.selector.includes("class~="));
+  assert.ok(cls, "the <=1.49 class form must be declared");
+  assert.match(cls.why, /1\.50/, "…and must say what 1.50 changed");
+  assert.match(cls.why, /data-testid/);
+});
+
+test("#779 VERIFIED_FRONTENDS spans both sides of the break", () => {
+  // 1.47.12 works, 1.50.3 was the outage. A registry checked against only one of
+  // them proves nothing about skew, which is the whole reason it exists.
+  assert.ok(VERIFIED_FRONTENDS.includes("1.47.12"));
+  assert.ok(VERIFIED_FRONTENDS.includes("1.50.3"));
+});

--- a/web/js/lib/comfyui-dom-deps.js
+++ b/web/js/lib/comfyui-dom-deps.js
@@ -1,0 +1,96 @@
+/**
+ * panel#779 — every place the panel reaches into ComfyUI's OWN DOM, declared.
+ *
+ * ComfyUI 1.50 moved a sidebar tab's id from a CSS class to a `data-testid`
+ * attribute. The panel read that class in two places. One blanked the panel
+ * entirely for a new user (#784); the other only degraded, so nobody noticed
+ * (#786). Both were found by hand, after the fact, by diffing two frontend
+ * bundles — which is not a process, it is luck.
+ *
+ * This is the list that makes the next skew a REVIEW instead of a discovery.
+ * Every selector below targets markup we do not own and cannot change, and a
+ * test fails if the panel grows one that is not declared here.
+ *
+ * WHAT THIS IS NOT. It cannot tell you a selector has stopped matching — only a
+ * real frontend can, and the test has no browser. What it does is make the
+ * surface finite, attributed and reviewable, so "check our DOM assumptions
+ * against the new frontend" is a task someone can actually complete.
+ *
+ * `verified` records the frontend versions each selector was CHECKED against by
+ * grepping the shipped bundles — not versions it is assumed to work on. Add to
+ * it when you check; do not widen it because it probably still works.
+ */
+
+/** Frontend bundles whose markup has been inspected for these selectors. */
+export const VERIFIED_FRONTENDS = ["1.47.12", "1.50.3"];
+
+/**
+ * @type {{ selector: string, why: string, fallback?: string, verified: string[] }[]}
+ */
+export const COMFYUI_DOM_DEPS = [
+  {
+    selector: ".side-bar-button-selected",
+    why: "Which sidebar tab is currently selected — the guard that detaches our root when another tab is active.",
+    fallback: "None. An unreadable selection is treated as UNKNOWN and changes nothing (#784).",
+    verified: ["1.47.12", "1.50.3"],
+  },
+  {
+    selector: ".side-tool-bar-container",
+    why: "The sidebar rail, observed for tab-selection changes.",
+    fallback: "Retried for ~10s while the frontend boots; absent means the guard never arms.",
+    verified: ["1.47.12", "1.50.3"],
+  },
+  {
+    selector: ".side-tool-bar-container, .side-tool-bar-end, nav.side-tool-bar",
+    why: "Where our tab's rail icon lives, for the unread/working badge.",
+    fallback: "Scans for our own glyph inside these containers.",
+    verified: ["1.47.12", "1.50.3"],
+  },
+  {
+    selector: 'button[class~="${esc}"]',
+    why: "Our tab's rail button on frontends <=1.49, where the id was a CSS class. 1.50 moved it to data-testid, which is tried FIRST (#786).",
+    fallback: "data-testid is the primary; this is the older form.",
+    verified: ["1.47.12", "1.50.3"],
+  },
+  {
+    selector: ".side-bar-panel",
+    why: "The pane our tab content is mounted into — used to size/scroll correctly.",
+    fallback: "[class*='sidebar'], then the element itself.",
+    verified: ["1.47.12", "1.50.3"],
+  },
+  {
+    selector: "[class*='sidebar']",
+    why: "Fallback for the mounting pane when .side-bar-panel is absent.",
+    fallback: "The element itself.",
+    verified: ["1.47.12", "1.50.3"],
+  },
+  {
+    selector: "[id*='vue']",
+    why: "The frontend's Vue root, when #vue-app is not present.",
+    fallback: "getElementById('vue-app') is tried first.",
+    verified: ["1.47.12", "1.50.3"],
+  },
+  {
+    selector: ".p-dialog-mask, dialog[open]",
+    why: "An open PrimeVue dialog or native <dialog>, so the panel does not steal focus from one.",
+    fallback: "None needed — absence simply means no modal is open.",
+    verified: ["1.47.12", "1.50.3"],
+  },
+  {
+    selector: ".pi",
+    why: "A PrimeIcons glyph inside our own rail button, to swap for the badge state.",
+    fallback: "[data-cmcp-agent-icon] is tried first, and marks the element once found.",
+    verified: ["1.47.12", "1.50.3"],
+  },
+  {
+    selector: ".fg",
+    why: "LiteGraph's foreground canvas, for pointer-coordinate mapping.",
+    fallback: "app.canvas is the primary source; this is a DOM-side lookup.",
+    verified: ["1.47.12", "1.50.3"],
+  },
+];
+
+/** Declared selectors, for the gate. */
+export function declaredSelectors() {
+  return new Set(COMFYUI_DOM_DEPS.map((d) => d.selector));
+}


### PR DESCRIPTION
Refs #779

ComfyUI 1.50 moved a sidebar tab's id from a CSS class to `data-testid`. The panel read that class in **two** places. One blanked the panel for a new user on first install (#784); the other only degraded, so nobody noticed (#786).

Both were found by hand, afterwards, by downloading two frontend bundles and diffing them. **That is luck, not a process.**

This makes the surface finite and attributed: ten selectors, each declared with what it's for, what it falls back to, and the frontend versions it was actually **checked** against. A test fails if the panel grows an eleventh without saying so.

## The full surface

Verified against 1.47.12 and 1.50.3 by grepping the shipped bundles — all present in both except the one that moved:

| selector | for |
|---|---|
| `.side-bar-button-selected` | the tab-active guard |
| `.side-tool-bar-container` | the rail, observed for changes |
| `.side-tool-bar-container, .side-tool-bar-end, nav.side-tool-bar` | where our rail icon lives |
| `button[class~="<tabId>-tab-button"]` | **≤1.49 only** — 1.50 uses `data-testid` |
| `.side-bar-panel` / `[class*='sidebar']` | the pane we mount into |
| `[id*='vue']` | the Vue root |
| `.p-dialog-mask, dialog[open]` | an open modal, so we don't steal focus |
| `.pi` | the glyph in our own rail button |
| `.fg` | LiteGraph's foreground canvas |

## What this is not

**It cannot tell you a selector has stopped matching.** Only a real frontend can, and this test has no browser. What it does is turn *"check our DOM assumptions against the new frontend"* into a task someone can complete, against a list that cannot silently grow.

`verified` records versions somebody grepped the bundle for — not versions it's assumed to work on. An entry with an empty list fails, because that's a guess wearing a registry's clothes. `VERIFIED_FRONTENDS` is asserted to span **both sides of the break**: a registry checked only against the working version proves nothing about skew, which is the entire reason it exists.

**Stale entries fail too.** One is worse than a missing entry — it makes the surface look larger than it is and sends the next reviewer to check dead selectors.

The scan ignores bare tag selectors and `[data-…]` hooks: we only run those inside our own root, and including them buries the ten that matter under forty that don't.

## Verification

Each mutation confirmed applied:

| mutation | result |
|---|---|
| add an undeclared ComfyUI selector to the panel | 1 failed |
| leave a stale registry entry | 1 failed |
| strip `verified` from an entry | 1 failed |
| remove the 1.50 history from the outage entry | 1 failed |
| neuter the scanner itself | 2 failed — caught by the does-it-find-anything guard |

6 tests · panel unit suite **2973 passed** · typecheck and the vocabulary gate exit 0 · control-byte scan clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)