### PR TITLE
fix(add_node): a union of PRIMITIVES needs no registered widget

### DIFF
--- a/browser_tests/unit/node-widget-materialization.test.mjs
+++ b/browser_tests/unit/node-widget-materialization.test.mjs
@@ -609,10 +609,26 @@ test("#695: a union whose members are only proven by /object_info outputs resolv
   );
 });
 
-test("#695: a union input that DECLARES a widget value still fails closed (#580/#626 intact)", () => {
+test("#788: a union of PRIMITIVES is added, not waited on (reverses #695's ruling)", () => {
   // LTXVEmptyLatentAudio.frame_rate = ["FLOAT,INT", {widgetType:"FLOAT", default:25, min, max, step}].
-  // Both members are output by some node, so the type half passes — but the input half
-  // says this carries a VALUE, so the wait for its widget constructor must survive.
+  //
+  // This test previously asserted the OPPOSITE, on the reasoning that the input
+  // declares a VALUE so the wait for its widget constructor must survive. The
+  // first half is right and the conclusion is wrong: nothing will ever register a
+  // constructor keyed "FLOAT,INT". FLOAT and INT are implemented by the core
+  // frontend, not by packs, so this was waiting on evidence that cannot arrive
+  // (#796) — and the refusal's own remedy, reload the tab, could not help.
+  //
+  // Three pieces of evidence, none of them inference:
+  //   - the node is CORE ComfyUI (comfy_extras), so no pack exists to register it;
+  //   - the stock frontend resolves it with `widgetType ?? type` — verified in the
+  //     shipped 1.47.12 bundle — and never looks for a union-keyed constructor;
+  //   - a reporter confirmed the stock UI adds this node fine by double-click,
+  //     while panel_add_node refused it after every restart and refresh.
+  //
+  // Cost of the old ruling: LTXVEmptyLatentAudio was permanently unaddable, which
+  // blocks every LTX-2.3 audio-video graph — the audio latent is mandatory for AV
+  // models (panel#788).
   const def = {
     input: {
       required: {
@@ -620,14 +636,38 @@ test("#695: a union input that DECLARES a widget value still fails closed (#580/
       },
     },
   };
+  assert.deepEqual(unavailableRequiredCustomWidgetTypes(def, {}, new Set(["FLOAT", "INT"]), def), []);
+  // …and with no output proof at all, which is the fresh-tab case.
+  assert.deepEqual(unavailableRequiredCustomWidgetTypes(def, {}, new Set(), def), []);
+});
+
+test("#788 #580 INTACT: a union naming a CUSTOM member still fails closed", () => {
+  // The guard this reverses is narrow. A pack's own type mixed with a primitive
+  // still needs that pack's constructor, and still waits for it — waiving on
+  // "contains a primitive" would be the #580 false accept all over again.
+  const def = {
+    input: { required: { style: ["ACME_VALUE,INT", { default: 1, min: 0, max: 9 }] } },
+  };
   assert.deepEqual(
-    unavailableRequiredCustomWidgetTypes(def, {}, new Set(["FLOAT", "INT"]), def),
-    ["FLOAT,INT"],
+    unavailableRequiredCustomWidgetTypes(def, {}, new Set(["INT"]), def),
+    ["ACME_VALUE,INT"],
   );
-  // …and it clears the instant the constructor registers under the union's own key.
   assert.deepEqual(
-    unavailableRequiredCustomWidgetTypes(def, { "FLOAT,INT": () => {} }, new Set(["FLOAT", "INT"]), def),
+    unavailableRequiredCustomWidgetTypes(def, { "ACME_VALUE,INT": () => {} }, new Set(["INT"]), def),
     [],
+  );
+});
+
+test("#788 a union of SOCKET types is unchanged by this", () => {
+  // ("IMAGE,MASK", {widgetType:"IMAGE", default}) — the shape the old comment
+  // reasoned about. Sockets are not primitives, so the new waiver does not reach
+  // it and the existing input-level bar still decides.
+  const def = {
+    input: { required: { img: ["IMAGE,MASK", { widgetType: "IMAGE", default: null }] } },
+  };
+  assert.deepEqual(
+    unavailableRequiredCustomWidgetTypes(def, {}, new Set(["IMAGE", "MASK"]), def),
+    ["IMAGE,MASK"],
   );
 });
 

--- a/web/js/lib/node-widget-materialization.js
+++ b/web/js/lib/node-widget-materialization.js
@@ -62,6 +62,35 @@ const SAFE_SOCKET_TYPES = new Set([
 ]);
 
 /**
+ * Widget types ComfyUI's core frontend implements ITSELF.
+ *
+ * No pack registers these — they are built in — so waiting for a constructor to
+ * appear for one is waiting for evidence that cannot arrive.
+ */
+const PRIMITIVE_WIDGET_TYPES = new Set(["FLOAT", "INT", "STRING", "BOOLEAN"]);
+
+// COMBO is deliberately NOT in that set. A combo is declared as a LIST of options,
+// so a bare "COMBO" type string is not the ordinary case, and two existing tests
+// assert it must still wait. The justification here only reaches as far as the
+// numeric/text primitives the core frontend certainly implements.
+
+/**
+ * A keyed name (`INT:seed`) is deliberately NOT unwrapped here.
+ *
+ * It would only matter inside a UNION — a lone `INT:seed` never reaches this
+ * waiver, which requires more than one member — and no union naming a keyed
+ * primitive has been observed. Mutation testing found the unwrapping killed no
+ * test, which is the honest signal that it was handling a shape nobody has seen.
+ * If one turns up, this fails CLOSED (the node waits, as it does today) rather
+ * than silently accepting something unverified.
+ */
+function isPrimitiveWidgetType(member) {
+  if (typeof member !== "string") return false;
+  return PRIMITIVE_WIDGET_TYPES.has(member.trim().toUpperCase());
+}
+
+
+/**
  * The individual datatypes a declared input type names.
  *
  * ComfyUI declares a link-compatible UNION of datatypes as ONE COMMA-JOINED string:
@@ -215,6 +244,31 @@ export function unavailableRequiredWidgetReport(
     // widget constructor can ever appear, so there is nothing here that a retry could be
     // waiting for. Single-member only — a union naming a dynamic declaration is not a shape
     // ComfyUI emits, and admitting one would be guessing.
+    // panel#788 — A UNION OF PRIMITIVES NEEDS NO REGISTERED WIDGET. The comment
+    // above cites this exact shape and reaches the wrong conclusion about it:
+    // core ComfyUI declares `frame_rate: ("FLOAT,INT", {widgetType: "FLOAT",
+    // default, min, max})` on LTXVEmptyLatentAudio, and the panel waited 5s for a
+    // constructor keyed "FLOAT,INT" that nothing will ever register. The node was
+    // permanently unaddable — which blocks every LTX-2.3 audio-video graph, since
+    // the audio latent is mandatory for AV models.
+    //
+    // Nothing was ever coming. FLOAT/INT/STRING/BOOLEAN are implemented by the
+    // core frontend, not registered by packs, so this is the tracked pattern of
+    // waiting on evidence that cannot arrive (#796) — and a reload, the remedy the
+    // refusal named, cannot help.
+    //
+    // The stock frontend resolves it with `widgetType ?? type` (verified in the
+    // shipped 1.47.12 bundle), i.e. the config's own hint wins and the declared
+    // type is the fallback. Both are primitives here, so either way a native
+    // widget is built and no registration is involved.
+    //
+    // This does NOT waive a union that merely CONTAINS a primitive: a pack's
+    // ("ACME_VALUE,INT", …) still needs ACME_VALUE's constructor, and is still
+    // held to the bar above. Every member must be primitive.
+    // Restricted to UNIONS. A single primitive already resolves through the
+    // constructor registry checked above, so widening it further would change
+    // behaviour beyond the reported bug for no evidence.
+    if (members.length > 1 && members.every(isPrimitiveWidgetType)) continue;
     if (members.length === 1 && isCoreDynamicV3Type(type)) continue;
     report.push({ type, inputs, linkProven });
   }


### PR DESCRIPTION
Fixes #788

`LTXVEmptyLatentAudio` was permanently unaddable. Core ComfyUI declares:

```python
frame_rate: ("FLOAT,INT", { widgetType: "FLOAT", default: 25, min, max, step })
```

and the panel waited 5s for a widget constructor keyed `"FLOAT,INT"` that nothing will ever register, then refused. Restarts, reloads and `panel_refresh_nodes` all made no difference — **there was nothing to wait for**. That blocks every LTX-2.3 audio-video graph: the audio latent is mandatory for AV models.

## This reverses a deliberate ruling, so the evidence matters

A test added by #695 asserted **this exact def** must fail closed, reasoning that the input declares a *value* so the wait must survive. The first half is right; the conclusion isn't. FLOAT and INT are implemented by the core frontend, not registered by packs — so this was waiting on evidence that cannot arrive (#796), and the refusal's own remedy (*reload the tab*) could not help.

Three pieces of evidence, none of them inference:

- the node is **core ComfyUI** (`comfy_extras`) — there is no pack that could ever register a `"FLOAT,INT"` constructor;
- the stock frontend resolves it as **`widgetType ?? type`** — verified by grepping the shipped 1.47.12 bundle — and never looks for a union-keyed constructor;
- the reporter confirmed the stock UI adds this node fine by double-click, while `panel_add_node` refused it after every restart and refresh.

Verified against the **live def** fetched from a running ComfyUI 0.30.2:

```
before: ["FLOAT,INT"]      after: []
```

## Deliberately narrow

| shape | behaviour |
|---|---|
| `("FLOAT,INT", …)` | **waived** — both primitive |
| `("ACME_VALUE,INT", …)` | still waits — waiving on *contains* a primitive would be the #580 false accept |
| `("IMAGE,MASK", …)` | unchanged — sockets aren't primitives; the existing input-level bar decides |
| bare `"COMBO"` | unchanged — a combo is declared as a *list* of options, and two tests assert it must wait |
| a single primitive | unchanged — already resolves through the constructor registry |

## One thing mutation testing removed rather than added

I had unwrapped keyed names (`INT:seed`) inside the union check. **No test died when it was deleted** — the honest signal that it handled a shape nobody has seen (a lone `INT:seed` never reaches this waiver anyway). It's gone, with a note that such a case fails **closed** rather than being silently accepted on no evidence.

| mutation | result |
|---|---|
| remove the waiver | 1 failed — restores the bug |
| `some` instead of `every` | 1 failed — the #580 guard |
| add socket types to the primitive set | 2 failed |

3 tests rewritten/added · panel unit suite **2975 passed** · typecheck and the vocabulary gate exit 0 · control-byte scan clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)