### PR TITLE
fix(load): a missing node type may be a pack that FAILED TO IMPORT

### DIFF
--- a/browser_tests/unit/api-workflow-load.test.mjs
+++ b/browser_tests/unit/api-workflow-load.test.mjs
@@ -170,7 +170,9 @@ test("#775 WIRING: graph_load delegates to loadApiJson instead of refusing", () 
     "and stays undoable like every other graph edit",
   );
   assert.match(branch, /apiLoadShortfall\(apiClone, landed\)/, "and compares what arrived");
-  assert.match(branch, /note: apiLoadNote\(shortfall\)/, "and discloses it");
+  // #775 — the note now also receives the packs that failed to import, so this
+  // asserts the note is WIRED rather than pinning its exact argument list.
+  assert.match(branch, /note: apiLoadNote\(shortfall/, "and discloses it");
 });
 
 test("#775 the DISCREDITED refusal text is gone from the shipped panel", () => {

--- a/browser_tests/unit/pack-import-failures.test.mjs
+++ b/browser_tests/unit/pack-import-failures.test.mjs
@@ -1,0 +1,125 @@
+// panel#775/#778 — a missing node type is not proof of a missing PACK.
+//
+// `apiLoadNote` told the reader to "install the custom-node pack that provides
+// it". I followed that advice on my own machine and it was wrong: the pack WAS
+// installed and had failed to import. I then reported a missing dependency in
+// the pack's manifest, on a public issue, and had to correct it.
+//
+// What made it convincing is worth keeping in front of whoever reads this next:
+// the OTHER LTX nodes resolved, because they come from core `comfy_extras`. So 34
+// of 35 types were present and exactly the pack-provided one was not — a broken
+// install looked precisely like a bad manifest.
+//
+// The log lines below are REAL, captured from the rig that fooled me.
+
+import assert from "node:assert/strict";
+import test from "node:test";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+import {
+  packsThatFailedToImport,
+  importFailureNote,
+  readPackImportFailures,
+} from "../../web/js/lib/pack-import-failures.js";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const PANEL_JS = join(HERE, "../../web/js/comfyui-mcp-panel.js");
+
+const ESC = String.fromCharCode(27);
+
+/** Verbatim from /internal/logs on the rig, colour codes included. */
+const REAL_LOG = [
+  `${ESC}[33m[WARNING]${ESC}[0m Cannot import C:\\Users\\a\\ComfyUI\\custom_nodes\\ComfyUI-LTXVideo module for custom nodes: cannot import name 'interleaved_freqs_cis'`,
+  `${ESC}[32m[INFO]${ESC}[0m    0.0 seconds (IMPORT FAILED): C:\\Users\\a\\ComfyUI\\custom_nodes\\comfyui-does-not-exist-99999`,
+  `${ESC}[32m[INFO]${ESC}[0m    0.0 seconds (IMPORT FAILED): C:\\Users\\a\\ComfyUI\\custom_nodes\\ComfyUI-LTXVideo`,
+  `${ESC}[32m[INFO]${ESC}[0m    1.2 seconds: C:\\Users\\a\\ComfyUI\\custom_nodes\\rgthree-comfy`,
+].join("\n");
+
+test("#775 it finds the packs ComfyUI said failed to import", () => {
+  assert.deepEqual(packsThatFailedToImport(REAL_LOG), [
+    "comfyui-does-not-exist-99999",
+    "ComfyUI-LTXVideo",
+  ]);
+});
+
+test("#775 a pack that imported FINE is not listed", () => {
+  // The same summary line shape without the marker. Listing a healthy pack would
+  // send someone to debug something that works.
+  assert.ok(!packsThatFailedToImport(REAL_LOG).includes("rgthree-comfy"));
+});
+
+test("#775 only the pack NAME is reported, never the full path", () => {
+  // These messages get pasted into public issues. An absolute path leaks the
+  // user's directory layout and their username for no diagnostic gain.
+  for (const name of packsThatFailedToImport(REAL_LOG)) {
+    assert.ok(!name.includes("\\"), `leaked a path: ${name}`);
+    assert.ok(!name.includes("/"), `leaked a path: ${name}`);
+    assert.ok(!/Users|home/i.test(name), `leaked a home directory: ${name}`);
+  }
+});
+
+test("#775 posix paths and duplicates behave", () => {
+  const log = [
+    "[INFO] 0.0 seconds (IMPORT FAILED): /home/u/ComfyUI/custom_nodes/My-Pack",
+    "[INFO] 0.0 seconds (IMPORT FAILED): /home/u/ComfyUI/custom_nodes/My-Pack",
+  ].join("\n");
+  assert.deepEqual(packsThatFailedToImport(log), ["My-Pack"]);
+});
+
+test("#775 nothing to find is an empty list, not a guess", () => {
+  assert.deepEqual(packsThatFailedToImport(""), []);
+  assert.deepEqual(packsThatFailedToImport("all packs loaded fine\n"), []);
+  assert.deepEqual(packsThatFailedToImport(null), []);
+});
+
+test("#775 the note contradicts the 'install it' advice", () => {
+  // This is the whole point: the standing message says install the pack, and
+  // that cannot work for a pack which is already there and failing to load.
+  const note = importFailureNote(["ComfyUI-LTXVideo"]);
+  assert.match(note, /BEFORE INSTALLING ANYTHING/);
+  assert.match(note, /ComfyUI-LTXVideo/);
+  assert.match(note, /installing it again will not help/);
+  assert.match(note, /registers NONE of its nodes/);
+});
+
+test("#775 it does NOT claim the failed pack owns the missing types", () => {
+  // Establishing that needs the pack's NODE_CLASS_MAPPINGS, which the browser
+  // cannot read. Asserting it would be the same overreach that produced the
+  // wrong public diagnosis in the first place.
+  const note = importFailureNote(["ComfyUI-LTXVideo"]);
+  assert.match(note, /does not prove it owns the missing types/);
+  assert.match(note, /first thing to rule out/);
+});
+
+test("#775 no failures means NO note — the ordinary advice stands", () => {
+  // When nothing failed, "install the pack" really is the best available advice
+  // and a hedge would only dilute it.
+  assert.equal(importFailureNote([]), "");
+  assert.equal(importFailureNote(null), "");
+  assert.equal(importFailureNote(undefined), "");
+});
+
+test("#775 the reader is never handed a throw", async () => {
+  // This runs while reporting a load that already went wrong.
+  assert.deepEqual(await readPackImportFailures(undefined), []);
+  assert.deepEqual(await readPackImportFailures(async () => { throw new Error("down"); }), []);
+  assert.deepEqual(await readPackImportFailures(async () => ({ status: 404 })), []);
+  assert.deepEqual(
+    await readPackImportFailures(async () => ({ status: 200, json: async () => ({ entries: [{ m: REAL_LOG }] }) })),
+    ["comfyui-does-not-exist-99999", "ComfyUI-LTXVideo"],
+  );
+});
+
+test("#775 WIRING: the load asks only when something is MISSING", () => {
+  // A clean load must not pay for a log fetch — there would be nothing to say.
+  const src = readFileSync(PANEL_JS, "utf8");
+  assert.match(src, /import \{ readPackImportFailures \} from "\.\/lib\/pack-import-failures\.js"/);
+  const i = src.indexOf("const shortfall = apiLoadShortfall(apiClone, landed);");
+  assert.ok(i > 0);
+  const block = src.slice(i, i + 900);
+  assert.match(block, /shortfall\.length[\s\S]{0,120}readPackImportFailures/);
+  assert.match(block, /note: apiLoadNote\(shortfall, importFailures\)/);
+  assert.match(block, /packs_failed_to_import: importFailures/);
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -70,6 +70,7 @@ import { missingAssetScanMayBeStale, missingAssetScopeNote } from "./lib/missing
 import { armReloadBlockedNotice } from "./lib/reload-blocked.js";
 import { pressableWidgetHint } from "./lib/pressable-widget.js";
 import { looksLikeApiWorkflow, apiLoadShortfall, apiLoadNote } from "./lib/api-workflow-load.js";
+import { readPackImportFailures } from "./lib/pack-import-failures.js";
 import { pairDurabilityView } from "./lib/pair-durability-view.js";
 import { describeUploadFailure, attachmentSummaryLine } from "./lib/attachment-upload.js";
 import {
@@ -8855,13 +8856,20 @@ const GRAPH_TOOL_EXECUTORS = {
         // disconnected input, far from the call that caused it.
         const landed = app?.graph?._nodes ?? [];
         const shortfall = apiLoadShortfall(apiClone, landed);
+        // #775 — a missing node type is not proof of a missing PACK. Only asked
+        // when something IS missing: a clean load must not pay for a log fetch,
+        // and there would be nothing for the note to say.
+        const importFailures = shortfall.length
+          ? await readPackImportFailures((route) => api?.fetchApi?.(route))
+          : [];
         return {
           loaded: true,
           format: "api",
           node_count: landed.length,
           entries_in: Object.keys(apiClone).length,
           ...(shortfall.length ? { missing_node_types: shortfall } : {}),
-          note: apiLoadNote(shortfall),
+          ...(importFailures.length ? { packs_failed_to_import: importFailures } : {}),
+          note: apiLoadNote(shortfall, importFailures),
         };
       }
       throw new Error(

--- a/web/js/lib/api-workflow-load.js
+++ b/web/js/lib/api-workflow-load.js
@@ -1,3 +1,5 @@
+import { importFailureNote } from "./pack-import-failures.js";
+
 /**
  * panel#775 — API/prompt-format workflows ARE loadable. The panel was refusing
  * them on a premise that is false.
@@ -106,7 +108,7 @@ export function apiLoadShortfall(apiData, landedNodes) {
  * consequence a caller cannot see from a node count. Names missing types only
  * when there are any.
  */
-export function apiLoadNote(shortfall) {
+export function apiLoadNote(shortfall, importFailures = []) {
   const layout =
     "Loaded from API/prompt format via the frontend's own importer. Node positions are " +
     "NOT in that format, so the layout is generated rather than the author's — execution " +
@@ -126,6 +128,13 @@ export function apiLoadNote(shortfall) {
     }, so ${nodeCount > 1 ? "those nodes" : "that node"} did not load and anything wired to ${
       nodeCount > 1 ? "them is" : "it is"
     } now disconnected — this graph will fail at queue time, not at load time. Install the ` +
-    `custom-node pack that provides ${typeCount > 1 ? "them" : "it"} and load again.`
+    `custom-node pack that provides ${typeCount > 1 ? "them" : "it"} and load again.` +
+    // #775 — "install the pack" is WRONG ADVICE when the pack is installed and
+    // failed to import. I followed it on my own machine, reported a missing
+    // dependency on a public issue, and had to correct it: ComfyUI-LTXVideo had
+    // IMPORT FAILED, so none of its nodes registered while the core comfy_extras
+    // LTX nodes resolved fine — 34 of 35 present, and a broken install looked
+    // exactly like a bad manifest.
+    importFailureNote(importFailures)
   );
 }

--- a/web/js/lib/pack-import-failures.js
+++ b/web/js/lib/pack-import-failures.js
@@ -1,0 +1,104 @@
+/**
+ * panel#775/#778 — a missing node type is not proof of a missing PACK.
+ *
+ * `apiLoadNote` told the reader to "install the custom-node pack that provides
+ * it". I followed that advice on my own machine and it was wrong: the pack WAS
+ * installed, and had failed to import.
+ *
+ *     File ".../ComfyUI-LTXVideo/embeddings_connector.py", line 7, in <module>
+ *     ImportError: cannot import name 'interleaved_freqs_cis'
+ *                  from 'comfy.ldm.lightricks.model'
+ *     [INFO] 0.0 seconds (IMPORT FAILED): .../ComfyUI-LTXVideo
+ *
+ * I reported that as a missing dependency in the pack's manifest, on a public
+ * issue, and had to correct it. The node was in the pack's NODE_CLASS_MAPPINGS
+ * the whole time. What made it convincing was that the OTHER LTX nodes resolved
+ * — they come from core `comfy_extras`, so 34 of 35 types were present and
+ * exactly the pack-provided one was not. A broken install looked like a bad
+ * manifest.
+ *
+ * ComfyUI logs this plainly at startup. So read it instead of guessing: when
+ * types are missing AND a pack failed to import, that pack is the far likelier
+ * cause, and "install it" is advice that cannot work.
+ *
+ * This NAMES what failed; it does not claim the failed pack owns the missing
+ * types. Establishing that needs the pack's NODE_CLASS_MAPPINGS, which is not
+ * readable from the browser — so the wording stays at "check these first".
+ */
+
+// Built from the code point, never written as a literal escape. The first
+// version of this line carried a raw 0x1B byte in the source: functional, but
+// invisible in a diff and one mangling edit away from silently matching
+// nothing. The control-byte scan is what caught it.
+const ANSI = new RegExp(String.fromCharCode(27) + "\[[0-9;]*m", "g");
+
+/** `[INFO] 0.0 seconds (IMPORT FAILED): <path>` — ComfyUI's own startup summary. */
+const IMPORT_FAILED = /\(IMPORT FAILED\):\s*(.+?)\s*$/;
+
+/**
+ * Packs ComfyUI reported as failing to import, newest last, de-duplicated.
+ *
+ * @param {string} logText raw /internal/logs feed
+ * @returns {string[]} pack names (the final path segment), never full paths —
+ *   an absolute path leaks the user's directory layout into a message they may
+ *   paste into a public issue.
+ */
+export function packsThatFailedToImport(logText) {
+  if (typeof logText !== "string" || !logText) return [];
+  const out = [];
+  for (const rawLine of logText.split(/\r?\n/)) {
+    const line = rawLine.replace(ANSI, "");
+    const m = IMPORT_FAILED.exec(line);
+    if (!m) continue;
+    const name = m[1].split(/[/\\]/).filter(Boolean).pop();
+    if (name && !out.includes(name)) out.push(name);
+  }
+  return out;
+}
+
+/**
+ * Fetch the log and extract the failures. Never throws.
+ *
+ * @param {(route: string) => Promise<{ status?: number, json?: () => Promise<unknown>, text?: () => Promise<string> }>} fetchApi
+ */
+export async function readPackImportFailures(fetchApi) {
+  if (typeof fetchApi !== "function") return [];
+  try {
+    const res = await fetchApi("/internal/logs/raw");
+    if (!res || (typeof res.status === "number" && (res.status < 200 || res.status >= 300))) {
+      return [];
+    }
+    let text = "";
+    if (typeof res.json === "function") {
+      const body = await res.json();
+      const entries = Array.isArray(body) ? body : Array.isArray(body?.entries) ? body.entries : null;
+      if (entries) text = entries.map((e) => (typeof e === "string" ? e : (e?.m ?? ""))).join("\n");
+      else if (typeof body === "string") text = body;
+    }
+    if (!text && typeof res.text === "function") text = await res.text();
+    return packsThatFailedToImport(text);
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * What to add to a missing-node message once the import failures are known.
+ *
+ * Empty when nothing failed — then "install the pack" really is the best advice
+ * available, and adding a hedge would only dilute it.
+ */
+export function importFailureNote(failed) {
+  if (!Array.isArray(failed) || failed.length === 0) return "";
+  const list = failed.join(", ");
+  const plural = failed.length > 1;
+  return (
+    ` BEFORE INSTALLING ANYTHING: ComfyUI reported that ${plural ? "these packs" : "this pack"} ` +
+    `FAILED TO IMPORT at startup — ${list}. A pack that fails to import registers NONE of its ` +
+    `nodes, so its node types are missing exactly as if it were not installed, and installing it ` +
+    `again will not help. Check the server log (get_system_stats action:"logs") for the ` +
+    `ImportError above ${plural ? "those lines" : "that line"} — it is usually a version mismatch ` +
+    `between the pack and ComfyUI. This does not prove ${plural ? "they own" : "it owns"} the ` +
+    `missing types; it is the first thing to rule out.`
+  );
+}


### PR DESCRIPTION
Refs #775, #778

`apiLoadNote` told the reader to *"install the custom-node pack that provides it"*. **I followed that advice on my own machine and it was wrong.**

The pack was installed. It had failed to import:

```
File ".../ComfyUI-LTXVideo/embeddings_connector.py", line 7, in <module>
ImportError: cannot import name 'interleaved_freqs_cis'
             from 'comfy.ldm.lightricks.model'
[INFO] 0.0 seconds (IMPORT FAILED): .../ComfyUI-LTXVideo
```

I reported that as a missing dependency in the LTX pack's manifest, on a public issue, and had to correct it. The node was in the pack's `NODE_CLASS_MAPPINGS` the whole time.

**What made it convincing is the part worth keeping.** The other LTX nodes resolved, because they come from core `comfy_extras`. So 34 of 35 types were present and exactly the pack-provided one was not — a broken install looked precisely like a bad manifest.

ComfyUI logs this plainly at startup. So the missing-node message now reads it and **contradicts its own standing advice** when it applies: a pack that fails to import registers *none* of its nodes, so installing it again cannot help.

## What it deliberately does not say

**It does not claim the failed pack owns the missing types.** Establishing that needs the pack's `NODE_CLASS_MAPPINGS`, which the browser cannot read — asserting it would be the same overreach that produced the wrong public diagnosis. The wording stays at *"the first thing to rule out"*.

Only the pack **name** is reported, never the path: these messages get pasted into public issues, and an absolute path leaks the user's home directory for no diagnostic gain. A test asserts that.

The log is fetched **only when something is missing** — a clean load pays nothing and would have nothing to say.

## Proven against the log that fooled me

Detects `ComfyUI-LTXVideo` and `comfyui-does-not-exist-99999`; does **not** list `rgthree-comfy`, which imported fine.

| mutation | result |
|---|---|
| never ask (restores the wrong advice) | 2 failed |
| ask on a clean load | 2 failed |
| report the full path | 4 failed |
| claim ownership of the missing types | 2 failed |
| emit the note with no failures | 2 failed |

One existing wiring test pinned `apiLoadNote(shortfall)` exactly and was updated to assert the note is **wired** rather than its argument list.

**Also fixed before merge:** my first version of the ANSI-stripping regex carried a literal `0x1B` byte in the source — functional, but invisible in a diff and one mangling edit from silently matching nothing. The control-byte scan caught it; it's now built from `String.fromCharCode(27)`, and I verified empirically that both forms compile to the identical pattern rather than assuming it.

10 new tests · panel unit suite **2985 passed** · typecheck and the vocabulary gate exit 0 · control-byte scan clean on the committed tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)