### PR TITLE
fix(add_node): an unknown node type may be a pack that FAILED TO IMPORT

### DIFF
--- a/browser_tests/unit/pack-import-failures.test.mjs
+++ b/browser_tests/unit/pack-import-failures.test.mjs
@@ -123,3 +123,74 @@ test("#775 WIRING: the load asks only when something is MISSING", () => {
   assert.match(block, /note: apiLoadNote\(shortfall, importFailures\)/);
   assert.match(block, /packs_failed_to_import: importFailures/);
 });
+
+// ---------------------------------------------------------------------------
+// #775 second site: panel_add_node's unknown-type refusal.
+// ---------------------------------------------------------------------------
+
+test("#775 the unknown-node refusal now NAMES the failed-import possibility", async () => {
+  // This is the message people actually hit — far more often than the API-load
+  // path — and it listed only "not installed, or its pack was removed". A pack
+  // that IS installed and failed to import produces exactly the same absence,
+  // and both listed remedies are dead ends for it.
+  const { assertAddNodeResolvableRefreshing } = await import(
+    "../../web/js/lib/node-resolve.js"
+  );
+  const err = await assertAddNodeResolvableRefreshing({}, "LTXVImgToVideoConditionOnly", {
+    getFreshObjectInfo: async () => ({ KSampler: {} }), // backend answers, type absent
+    wasTypeEverDefined: () => false,
+    readImportFailures: async () => ["ComfyUI-LTXVideo"],
+  }).then(
+    () => null,
+    (e) => e,
+  );
+  assert.ok(err, "an absent type must still be refused");
+  assert.match(err.message, /or its pack failed to import/);
+  assert.match(err.message, /ComfyUI-LTXVideo/);
+  assert.match(err.message, /installing it again will not help/);
+});
+
+test("#775 with NO failed imports the refusal is unchanged", async () => {
+  // The ordinary case must not gain a hedge it does not need.
+  const { assertAddNodeResolvableRefreshing } = await import(
+    "../../web/js/lib/node-resolve.js"
+  );
+  const err = await assertAddNodeResolvableRefreshing({}, "TotallyMadeUpNode", {
+    getFreshObjectInfo: async () => ({ KSampler: {} }),
+    wasTypeEverDefined: () => false,
+    readImportFailures: async () => [],
+  }).then(
+    () => null,
+    (e) => e,
+  );
+  assert.match(err.message, /Unknown node type "TotallyMadeUpNode"/);
+  assert.doesNotMatch(err.message, /BEFORE INSTALLING ANYTHING/);
+});
+
+test("#775 a reader that THROWS does not replace the refusal", async () => {
+  // The diagnostic runs while explaining a failure. If it throws, the caller
+  // must still get the refusal it came for, not a second unrelated error.
+  const { assertAddNodeResolvableRefreshing } = await import(
+    "../../web/js/lib/node-resolve.js"
+  );
+  const err = await assertAddNodeResolvableRefreshing({}, "TotallyMadeUpNode", {
+    getFreshObjectInfo: async () => ({ KSampler: {} }),
+    wasTypeEverDefined: () => false,
+    readImportFailures: async () => {
+      throw new Error("log unreachable");
+    },
+  }).then(
+    () => null,
+    (e) => e,
+  );
+  assert.match(err.message, /Unknown node type "TotallyMadeUpNode"/);
+  assert.doesNotMatch(err.message, /log unreachable/);
+});
+
+test("#775 WIRING: the panel supplies the reader to the add-node resolver", () => {
+  const src = readFileSync(PANEL_JS, "utf8");
+  assert.match(
+    src,
+    /readImportFailures: \(\) => readPackImportFailures\(\(route\) => api\?\.fetchApi\?\.\(route\)\)/,
+  );
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -8633,6 +8633,10 @@ const GRAPH_TOOL_EXECUTORS = {
       refresh: (defs) => refreshComfyNodeDefs(defs),
       // #458 OBSERVED-BACKEND-HISTORY trust root, identical to graph_set_widget's.
       wasTypeEverDefined: (t) => objectInfoHistory.wasTypeEverDefined(t),
+      // #775 — consulted ONLY when the type is about to be refused, so a healthy
+      // add never pays for it. A pack that failed to import looks exactly like a
+      // pack that is not installed, and the refusal used to name only the latter.
+      readImportFailures: () => readPackImportFailures((route) => api?.fetchApi?.(route)),
     });
     const nodeData = LG?.registered_node_types?.[class_type]?.nodeData;
     // A pack upgraded mid-session can add required inputs to an ALREADY

--- a/web/js/lib/node-resolve.js
+++ b/web/js/lib/node-resolve.js
@@ -28,6 +28,8 @@ export const COMFY_CORE_SENTINEL_TYPES = [
   "SaveImage",
 ];
 
+import { importFailureNote } from "./pack-import-failures.js";
+
 /** True when `type` is registered in the live LiteGraph registry object
  *  (LG.registered_node_types). */
 export function isRegisteredNodeType(registry, type) {
@@ -448,7 +450,9 @@ export function assertAddNodeResolvable(registry, class_type) {
  *                        exempted (fail closed, pre-#496 behaviour).
  */
 export async function assertAddNodeResolvableRefreshing(getRegistry, class_type, opts = {}) {
-  const { getFreshObjectInfo, refresh, wasTypeEverDefined } = opts;
+  // #775 — `readImportFailures` is injected and awaited ONLY on the refusal path,
+  // so a healthy add pays nothing for it.
+  const { getFreshObjectInfo, refresh, wasTypeEverDefined, readImportFailures } = opts;
   const readRegistry = () =>
     typeof getRegistry === "function" ? getRegistry() : getRegistry;
 
@@ -522,9 +526,25 @@ export async function assertAddNodeResolvableRefreshing(getRegistry, class_type,
       // (create_workflow action:"node_info", the live /object_info) —
       // panel_search_nodes searches Manager PACKS, which structurally cannot
       // resolve an exact class_type.
+      // #775 — "not installed, or its pack was removed" is not the whole list, and
+      // the missing entry is the one that makes the advice useless: a pack that IS
+      // installed and FAILED TO IMPORT registers none of its nodes, so its types
+      // are absent from /object_info exactly as if it were gone. Installing it
+      // again cannot help. I walked into that dead end myself and filed a wrong
+      // diagnosis from it (ComfyUI-LTXVideo, ImportError on a core rename).
+      let failedNote = "";
+      if (typeof readImportFailures === "function") {
+        try {
+          failedNote = importFailureNote(await readImportFailures());
+        } catch {
+          // A diagnostic that throws must not replace the refusal it explains.
+        }
+      }
       throw new Error(
         `Unknown node type "${class_type}" — the ComfyUI backend does not provide it ` +
-          `(not installed, or its pack was removed). Check the exact class_type via create_workflow (action:"node_info")`,
+          `(not installed, its pack was removed, or its pack failed to import). ` +
+          `Check the exact class_type via create_workflow (action:"node_info")` +
+          failedNote,
       );
     }
     // Backend HAS it. Make sure LiteGraph can construct it — refresh to register the


### PR DESCRIPTION
Refs #775

#790 added this to the API-load path. **This is the site people actually hit.**

`panel_add_node` on a type the backend doesn't provide said:

```
Unknown node type "X" — the ComfyUI backend does not provide it
(not installed, or its pack was removed).
```

Both listed causes point at the same remedy, and neither is the one that bites: **a pack that is installed and failed to import registers none of its nodes**, so its types are absent from `/object_info` exactly as if it were gone — and installing it again cannot help.

I walked into that dead end personally. I concluded the LTX pack was missing a dependency, wrote it up as a defect on a public issue, and had to correct it: the node was in the pack's `NODE_CLASS_MAPPINGS` and `ComfyUI-LTXVideo` had died on an `ImportError` from a core rename. **The refusal I'm changing here is what I would have been reading.**

The third cause is now named, and when the log confirms it the message says which pack, and that reinstalling won't help.

## Costs nothing on the happy path

`readImportFailures` is injected and awaited **only** on the refusal branch. A reader that throws is swallowed — a diagnostic that fails must not replace the refusal it was explaining, which would hand the caller an unrelated error instead of the answer they came for.

| mutation | result |
|---|---|
| revert the wording | 1 failed |
| never append the note | 1 failed |
| let the reader's throw escape | 3 failed |
| panel stops supplying the reader | 1 failed |

Each confirmed applied before running.

4 new tests · panel unit suite **2989 passed** · typecheck and the vocabulary gate exit 0 · control-byte scan clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)