### PR TITLE
fix(log): the internal-logs endpoint is NOT under /api — both readers were no-ops

### DIFF
--- a/browser_tests/unit/pack-import-failures.test.mjs
+++ b/browser_tests/unit/pack-import-failures.test.mjs
@@ -101,15 +101,35 @@ test("#775 no failures means NO note — the ordinary advice stands", () => {
   assert.equal(importFailureNote(undefined), "");
 });
 
-test("#775 the reader is never handed a throw", async () => {
-  // This runs while reporting a load that already went wrong.
-  assert.deepEqual(await readPackImportFailures(undefined), []);
-  assert.deepEqual(await readPackImportFailures(async () => { throw new Error("down"); }), []);
-  assert.deepEqual(await readPackImportFailures(async () => ({ status: 404 })), []);
-  assert.deepEqual(
-    await readPackImportFailures(async () => ({ status: 200, json: async () => ({ entries: [{ m: REAL_LOG }] }) })),
-    ["comfyui-does-not-exist-99999", "ComfyUI-LTXVideo"],
-  );
+test("#775 the reader is never handed a throw, and does not use /api", async () => {
+  // The transport is the whole bug: api.fetchApi prefixes /api and this endpoint
+  // is not there, so the feature was a silent no-op in every real browser while
+  // these tests passed against a fake. Stub the REAL global fetch instead.
+  const calls = [];
+  const realFetch = globalThis.fetch;
+  const api = { fileURL: (r) => `/base${r}` };
+  try {
+    globalThis.fetch = async (url) => {
+      calls.push(String(url));
+      return { ok: true, json: async () => ({ entries: [{ m: REAL_LOG }] }) };
+    };
+    assert.deepEqual(await readPackImportFailures(api), [
+      "comfyui-does-not-exist-99999",
+      "ComfyUI-LTXVideo",
+    ]);
+    assert.deepEqual(calls, ["/base/internal/logs/raw"], "fileURL is honoured, /api is not");
+    assert.ok(!calls[0].includes("/api/"), "the /api prefix is what 404s");
+
+    // Every failure mode still yields [] rather than throwing.
+    globalThis.fetch = async () => ({ ok: false, status: 404 });
+    assert.deepEqual(await readPackImportFailures(api), []);
+    globalThis.fetch = async () => { throw new Error("offline"); };
+    assert.deepEqual(await readPackImportFailures(api), []);
+    globalThis.fetch = async () => ({ ok: true, json: async () => { throw new Error("bad"); } });
+    assert.deepEqual(await readPackImportFailures(api), []);
+  } finally {
+    globalThis.fetch = realFetch;
+  }
 });
 
 test("#775 WIRING: the load asks only when something is MISSING", () => {
@@ -189,8 +209,5 @@ test("#775 a reader that THROWS does not replace the refusal", async () => {
 
 test("#775 WIRING: the panel supplies the reader to the add-node resolver", () => {
   const src = readFileSync(PANEL_JS, "utf8");
-  assert.match(
-    src,
-    /readImportFailures: \(\) => readPackImportFailures\(\(route\) => api\?\.fetchApi\?\.\(route\)\)/,
-  );
+  assert.match(src, /readImportFailures: \(\) => readPackImportFailures\(api\)/);
 });

--- a/browser_tests/unit/userdata-failure-cause.test.mjs
+++ b/browser_tests/unit/userdata-failure-cause.test.mjs
@@ -108,41 +108,33 @@ test("#771 a partial suffix must not match a different file", () => {
   assert.equal(extractSaveFailureCause(log, "workflows/report.json"), null);
 });
 
-test("#771 readSaveFailureCause tolerates every log shape, and never throws", async () => {
-  const entries = { entries: [{ m: REAL_LINE }], size: 1 };
-  const fetchOk = async () => ({ status: 200, json: async () => entries });
-  assert.match(await readSaveFailureCause("workflows/report.json", fetchOk), /WinError 3/);
+test("#771 readSaveFailureCause reads the log WITHOUT the /api prefix", async () => {
+  // The transport was the bug. api.fetchApi prefixes /api and this endpoint is
+  // not there, so this feature was a silent no-op in every real browser — the
+  // message always said "the server-side reason could NOT be read" — while these
+  // tests passed against an injected fake that did no URL rewriting.
+  const calls = [];
+  const realFetch = globalThis.fetch;
+  const api = { fileURL: (r) => `/base${r}` };
+  try {
+    globalThis.fetch = async (url) => {
+      calls.push(String(url));
+      return { ok: true, json: async () => ({ entries: [{ m: REAL_LINE }] }) };
+    };
+    assert.match(await readSaveFailureCause("workflows/report.json", api), /WinError 3/);
+    assert.deepEqual(calls, ["/base/internal/logs/raw"], "fileURL is honoured");
+    assert.ok(!calls[0].includes("/api/"), "the /api prefix is what 404s");
 
-  // A plain array, and a bare string body.
-  assert.ok(
-    await readSaveFailureCause("workflows/report.json", async () => ({
-      status: 200,
-      json: async () => [REAL_LINE],
-    })),
-  );
-  assert.ok(
-    await readSaveFailureCause("workflows/report.json", async () => ({
-      status: 200,
-      json: async () => REAL_LINE,
-    })),
-  );
-
-  // Every failure mode returns null rather than throwing — this runs on the way
-  // out of an already-failed save, the worst possible place to raise a second error.
-  for (const bad of [
-    async () => ({ status: 404, json: async () => ({}) }),
-    async () => {
-      throw new Error("offline");
-    },
-    async () => ({
-      status: 200,
-      json: async () => {
-        throw new Error("bad json");
-      },
-    }),
-    async () => null,
-  ]) {
-    assert.equal(await readSaveFailureCause("workflows/report.json", bad), null);
+    // Every failure mode still yields null rather than throwing — this runs on
+    // the way out of an already-failed save.
+    globalThis.fetch = async () => ({ ok: false, status: 404 });
+    assert.equal(await readSaveFailureCause("workflows/report.json", api), null);
+    globalThis.fetch = async () => { throw new Error("offline"); };
+    assert.equal(await readSaveFailureCause("workflows/report.json", api), null);
+    globalThis.fetch = async () => ({ ok: true, json: async () => { throw new Error("bad"); } });
+    assert.equal(await readSaveFailureCause("workflows/report.json", api), null);
+  } finally {
+    globalThis.fetch = realFetch;
   }
   assert.equal(await readSaveFailureCause("workflows/report.json", undefined), null);
 });
@@ -175,8 +167,5 @@ test("#771 WITHOUT a cause it says so, and does NOT blame the filename", () => {
 test("#771 WIRING: the panel supplies the reader over its own api", () => {
   const src = readFileSync(PANEL_JS, "utf8");
   assert.match(src, /import \{ readSaveFailureCause \} from "\.\/lib\/userdata-failure-cause\.js"/);
-  assert.match(
-    src,
-    /readSaveFailureCause: \(path\) => readSaveFailureCause\(path, \(route\) => api\?\.fetchApi\?\.\(route\)\)/,
-  );
+  assert.match(src, /readSaveFailureCause: \(path\) => readSaveFailureCause\(path, api\)/);
 });

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -3729,7 +3729,7 @@ async function programmaticSave(name) {
     // reads that line back so the caller is told what actually failed instead of
     // being sent to audit a filename that was never the problem. Read-only, and it
     // runs only once the 400 shape is already recognised.
-    readSaveFailureCause: (path) => readSaveFailureCause(path, (route) => api?.fetchApi?.(route)),
+    readSaveFailureCause: (path) => readSaveFailureCause(path, api),
   });
   const outcome = describeSaveOutcome(details);
   // #557 r3/r4/r5/r7/r8/r10 — thread the identity across the swap ONLY with
@@ -8636,7 +8636,7 @@ const GRAPH_TOOL_EXECUTORS = {
       // #775 — consulted ONLY when the type is about to be refused, so a healthy
       // add never pays for it. A pack that failed to import looks exactly like a
       // pack that is not installed, and the refusal used to name only the latter.
-      readImportFailures: () => readPackImportFailures((route) => api?.fetchApi?.(route)),
+      readImportFailures: () => readPackImportFailures(api),
     });
     const nodeData = LG?.registered_node_types?.[class_type]?.nodeData;
     // A pack upgraded mid-session can add required inputs to an ALREADY
@@ -8864,7 +8864,7 @@ const GRAPH_TOOL_EXECUTORS = {
         // when something IS missing: a clean load must not pay for a log fetch,
         // and there would be nothing for the note to say.
         const importFailures = shortfall.length
-          ? await readPackImportFailures((route) => api?.fetchApi?.(route))
+          ? await readPackImportFailures(api)
           : [];
         return {
           loaded: true,

--- a/web/js/lib/comfy-log.js
+++ b/web/js/lib/comfy-log.js
@@ -1,0 +1,42 @@
+/**
+ * Read ComfyUI's raw log feed.
+ *
+ * NOT via `api.fetchApi`. That prefixes every route with `/api`, and this
+ * endpoint does not live there — measured in a real browser against a live
+ * ComfyUI 0.30.2:
+ *
+ *     api.fetchApi("/internal/logs/raw")        ->  /api/internal/logs/raw   404
+ *     fetch(api.fileURL("/internal/logs/raw"))  ->  /internal/logs/raw       200
+ *
+ * Both features that read this log shipped calling `fetchApi`, and were therefore
+ * SILENT NO-OPS in a browser: the save-failure cause always reported "could not
+ * be read", and the failed-import note never appeared. Their unit tests passed
+ * because they inject a fake `fetchApi` that does no URL rewriting — the wiring
+ * was tested and the TRANSPORT was not. Nothing short of loading the shipped
+ * module in a real page would have caught it.
+ *
+ * `api.fileURL` is preferred over a bare "/internal/logs/raw" so a ComfyUI
+ * mounted under a base path still resolves.
+ *
+ * @param {{ fileURL?: (route: string) => string }} api
+ * @returns {Promise<string>} the joined log text, or "" when it cannot be read
+ */
+export async function readComfyLogText(api) {
+  try {
+    const route = "/internal/logs/raw";
+    const url = typeof api?.fileURL === "function" ? api.fileURL(route) : route;
+    const res = await fetch(url, { cache: "no-store" });
+    if (!res || !res.ok) return "";
+    const body = await res.json().catch(() => null);
+    const entries = Array.isArray(body) ? body : Array.isArray(body?.entries) ? body.entries : null;
+    if (entries) {
+      return entries.map((e) => (typeof e === "string" ? e : (e?.m ?? ""))).join("\n");
+    }
+    if (typeof body === "string") return body;
+    return "";
+  } catch {
+    // This runs while explaining a failure. Returning "" keeps the caller on its
+    // "could not be read" branch, which is already worded for exactly this.
+    return "";
+  }
+}

--- a/web/js/lib/pack-import-failures.js
+++ b/web/js/lib/pack-import-failures.js
@@ -1,3 +1,5 @@
+import { readComfyLogText } from "./comfy-log.js";
+
 /**
  * panel#775/#778 — a missing node type is not proof of a missing PACK.
  *
@@ -61,25 +63,12 @@ export function packsThatFailedToImport(logText) {
  *
  * @param {(route: string) => Promise<{ status?: number, json?: () => Promise<unknown>, text?: () => Promise<string> }>} fetchApi
  */
-export async function readPackImportFailures(fetchApi) {
-  if (typeof fetchApi !== "function") return [];
-  try {
-    const res = await fetchApi("/internal/logs/raw");
-    if (!res || (typeof res.status === "number" && (res.status < 200 || res.status >= 300))) {
-      return [];
-    }
-    let text = "";
-    if (typeof res.json === "function") {
-      const body = await res.json();
-      const entries = Array.isArray(body) ? body : Array.isArray(body?.entries) ? body.entries : null;
-      if (entries) text = entries.map((e) => (typeof e === "string" ? e : (e?.m ?? ""))).join("\n");
-      else if (typeof body === "string") text = body;
-    }
-    if (!text && typeof res.text === "function") text = await res.text();
-    return packsThatFailedToImport(text);
-  } catch {
-    return [];
-  }
+export async function readPackImportFailures(api) {
+  // #775 — the log is NOT under /api; see readComfyLogText. Passing
+  // api.fetchApi here is what made this a silent no-op in a real browser.
+  const text = await readComfyLogText(api);
+  if (!text) return [];
+  return packsThatFailedToImport(text);
 }
 
 /**

--- a/web/js/lib/userdata-failure-cause.js
+++ b/web/js/lib/userdata-failure-cause.js
@@ -1,3 +1,5 @@
+import { readComfyLogText } from "./comfy-log.js";
+
 /**
  * panel#771 — ComfyUI knows exactly why a save failed and does not tell the
  * client. It tells its own log. So read the log.
@@ -75,27 +77,12 @@ export function extractSaveFailureCause(logText, relPath) {
  * @param {string} relPath
  * @param {(route: string) => Promise<{ status?: number, json?: () => Promise<unknown>, text?: () => Promise<string> }>} fetchApi
  */
-export async function readSaveFailureCause(relPath, fetchApi) {
-  if (typeof fetchApi !== "function") return null;
-  try {
-    const res = await fetchApi("/internal/logs/raw");
-    if (!res || (typeof res.status === "number" && (res.status < 200 || res.status >= 300))) {
-      return null;
-    }
-    let text = "";
-    if (typeof res.json === "function") {
-      const body = await res.json();
-      // { entries: [{ m: "…" }, …], size } on current builds; tolerate a plain
-      // array or a bare string rather than assuming one shape.
-      const entries = Array.isArray(body) ? body : Array.isArray(body?.entries) ? body.entries : null;
-      if (entries) text = entries.map((e) => (typeof e === "string" ? e : (e?.m ?? ""))).join("\n");
-      else if (typeof body === "string") text = body;
-    }
-    if (!text && typeof res.text === "function") text = await res.text();
-    return extractSaveFailureCause(text, relPath);
-  } catch {
-    return null;
-  }
+export async function readSaveFailureCause(relPath, api) {
+  // #775 — the log is NOT under /api; see readComfyLogText. Passing
+  // api.fetchApi here is what made this a silent no-op in a real browser.
+  const text = await readComfyLogText(api);
+  if (!text) return null;
+  return extractSaveFailureCause(text, relPath);
 }
 
 /**


### PR DESCRIPTION
Refs #771, #775

**Caught by loading the shipped module in a real browser.** Both features I added today that read ComfyUI's log did nothing at all in production:

```
api.fetchApi("/internal/logs/raw")        ->  /api/internal/logs/raw   404
fetch(api.fileURL("/internal/logs/raw"))  ->  /internal/logs/raw       200
```

`api.fetchApi` prefixes every route with `/api`. This endpoint is not there. So:

- **#782's save-failure cause** always reported *"the server-side reason could NOT be read"* — on every failed save, on every install;
- **#790/#791's failed-import note** never appeared, including for the exact `ComfyUI-LTXVideo` case that motivated it.

Both degraded *honestly* — which is why nothing looked broken — and both were dead.

## The tests passed because they injected a fake `fetchApi`

…one that did no URL rewriting. **The wiring was tested; the transport was not.** That's the same lesson as testing a helper instead of its call site, one level lower down — and nothing short of loading the module in a real page would have found it. Every unit test, every gate, and a full CI run were green over a feature that could not work.

Both readers now go through one `readComfyLogText(api)`, which uses `api.fileURL` — so a ComfyUI mounted under a base path still resolves — and a plain `fetch`. The tests now stub the **real** global `fetch` and assert the requested URL, including explicitly that it does not contain `/api/`.

## Verified live

Against ComfyUI 0.30.2, with the shipped module, cache-busted so it could not be the copy already in memory:

```
before: []
after:  ["comfyui-does-not-exist-99999", "ComfyUI-LTXVideo"]
```

3 tests rewritten to exercise the real transport · panel unit suite **2989 passed** · typecheck and the vocabulary gate exit 0 · control-byte scan clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)