### PR TITLE
test(e2e): recover 9 e2e tests — off-by-default flags and a routed mount probe

### DIFF
--- a/browser_tests/agent-drive.spec.ts
+++ b/browser_tests/agent-drive.spec.ts
@@ -177,6 +177,9 @@ test.describe('agent-driven CivitAI modal', () => {
 })
 
 test.describe('agent-driven Training modal', () => {
+  // panel#793 — off-by-default flag; see fixtures/panelTest.ts.
+  test.use({ panelFlags: ['comfyui-mcp.featureFlag.training'] })
+
   test('training-first glow: step highlight works without the CivitAI CSS ever loading', async ({
     page,
     panel,

--- a/browser_tests/apps.spec.ts
+++ b/browser_tests/apps.spec.ts
@@ -13,6 +13,14 @@
 import { test, expect } from './fixtures/panelTest'
 import type { Page, Route } from '@playwright/test'
 
+// panel#793 — the Apps toolbar button is behind a flag that is `defaultValue:
+// false`, and the fixture strips panel settings for hermeticity. Without this
+// every test here spent 30s waiting to click a correctly-hidden button.
+// RunPod is listed too: two tests below drive the RunPod run path.
+test.use({
+  panelFlags: ['comfyui-mcp.featureFlag.apps', 'comfyui-mcp.featureFlag.runpod'],
+})
+
 const APP_ID = '123e4567-e89b-42d3-a456-426614174000'
 
 // 1x1 transparent PNG.

--- a/browser_tests/fixtures/historyStoreModule.ts
+++ b/browser_tests/fixtures/historyStoreModule.ts
@@ -4,6 +4,25 @@ import type { Page } from '@playwright/test'
  * Resolve the extension mount ComfyUI actually loaded. Registry installs use
  * `comfyui-agent-panel`, while repository-named dev junctions commonly use
  * `comfyui-mcp-panel`; tests must work with either without editing the spec.
+ *
+ * panel#793 — this used to probe the two known names with `fetch` and take the
+ * first that answered 200. That is unsound HERE, and produced three specs that
+ * failed with an error naming a file which had loaded perfectly:
+ *
+ *     TypeError: Failed to fetch dynamically imported module:
+ *     http://localhost:8188/extensions/comfyui-agent-panel/js/lib/chat-history-store.js
+ *
+ * The specs route `/extensions/<any>/js/lib/chat-history-store.js` to serve the
+ * checked-out source instead of the server's copy. That pattern matches EVERY
+ * mount, so the probe got 200 for a mount this server does not have, and picked
+ * whichever name the candidate list held first. The module then imported its
+ * relative sibling `./workflow-chat-identity.js`, which is NOT routed — measured
+ * against the live server, 404 under the wrong mount and 200 under the right
+ * one. Chrome reports a failed dependency against the URL you asked for, not the
+ * one that 404'd, so the message accused the routed file.
+ *
+ * So ask the server which mount it serves rather than probing a route the test
+ * has already overridden.
  */
 export async function resolveHistoryStoreModuleUrl(page: Page): Promise<string> {
   return page.evaluate(async () => {
@@ -17,12 +36,39 @@ export async function resolveHistoryStoreModuleUrl(page: Page): Promise<string> 
     }
 
     // Some browser builds omit module requests from the resource timeline.
-    // Probe the two supported mount names rather than assuming the registry one.
-    for (const mount of ['comfyui-agent-panel', 'comfyui-mcp-panel']) {
-      const candidate = new URL(`/extensions/${mount}/js/lib/chat-history-store.js`, location.href)
+    // ComfyUI's own extension list is authoritative and is not routed by any
+    // spec, so it survives the interception that defeats a probe.
+    try {
+      const response = await fetch('/api/extensions', { cache: 'no-store' })
+      if (response.ok) {
+        const listed: unknown = await response.json()
+        const entry = Array.isArray(listed)
+          ? listed.find(
+              (path): path is string =>
+                typeof path === 'string' && /\/js\/comfyui-mcp-panel\.js$/.test(path)
+            )
+          : undefined
+        if (entry) {
+          return new URL('./lib/chat-history-store.js', new URL(entry, location.href)).href
+        }
+      }
+    } catch {
+      // Fall through to the probe below.
+    }
+
+    // Last resort. Probe a file NO spec routes — routing the module under test
+    // is exactly what made the old probe lie. If a future spec starts routing
+    // this sibling too, this branch will start lying in the same way.
+    for (const mount of ['comfyui-mcp-panel', 'comfyui-agent-panel']) {
+      const sibling = new URL(
+        `/extensions/${mount}/js/lib/workflow-chat-identity.js`,
+        location.href
+      )
       try {
-        const response = await fetch(candidate, { cache: 'no-store' })
-        if (response.ok) return candidate.href
+        const response = await fetch(sibling, { cache: 'no-store' })
+        if (response.ok) {
+          return new URL(`/extensions/${mount}/js/lib/chat-history-store.js`, location.href).href
+        }
       } catch {
         // Try the next mount.
       }

--- a/browser_tests/fixtures/panelTest.ts
+++ b/browser_tests/fixtures/panelTest.ts
@@ -19,14 +19,34 @@ interface PanelFixtures {
   panel: PanelPage
 }
 
-export const test = base.extend<PanelFixtures>({
+interface PanelOptions {
+  /**
+   * Panel feature flags to force ON for this spec, e.g.
+   * `test.use({ panelFlags: ['comfyui-mcp.featureFlag.apps'] })`.
+   *
+   * panel#793 — the settings strip below deletes EVERY `comfyui-mcp.` key for
+   * hermeticity. That is correct for `autoConnect`, and it also removed the
+   * three feature flags, which are `defaultValue: false`. So the toolbar button
+   * a flagged feature lives behind never rendered, and every spec for those
+   * features failed the same way: a 30s timeout waiting to click a button that
+   * was correctly hidden. The specs were not asserting a broken feature — they
+   * were asserting one the harness had switched off.
+   *
+   * Opt-in per spec rather than blanket-on: a spec that checks a flagged button
+   * is ABSENT by default must keep seeing it absent.
+   */
+  panelFlags: string[]
+}
+
+export const test = base.extend<PanelFixtures & PanelOptions>({
+  panelFlags: [[], { option: true }],
   mockBridge: async ({}, use) => {
     const bridge = new MockBridge({ port: 0 })
     await bridge.start()
     await use(bridge)
     await bridge.close()
   },
-  panel: async ({ page }, use) => {
+  panel: async ({ page, panelFlags }, use) => {
     // Hermetic runs on a dev box with a REAL orchestrator listening on :9180:
     // the panel's mount probe (GET /comfyui_mcp_panel/status → { running: true })
     // would auto-connect it to the live agent before the spec's setBridgeUrl()
@@ -72,6 +92,9 @@ export const test = base.extend<PanelFixtures>({
         for (const key of Object.keys(body)) {
           if (key.startsWith('comfyui-mcp.')) delete body[key]
         }
+        // Put back only what this spec explicitly asked for, AFTER the strip, so
+        // the flag value comes from the spec and never from the dev box.
+        for (const flag of panelFlags) body[flag] = true
         return route.fulfill({ response: res, json: body })
       }
     )

--- a/browser_tests/training-wizard.spec.ts
+++ b/browser_tests/training-wizard.spec.ts
@@ -22,6 +22,10 @@
  */
 import { test, expect } from './fixtures/panelTest'
 
+// panel#793 — the Training entry point is behind an off-by-default flag; see
+// the note on `panelFlags` in fixtures/panelTest.ts.
+test.use({ panelFlags: ['comfyui-mcp.featureFlag.training'] })
+
 const OUT_IMAGES = [
   { filename: 'char_a.png', subfolder: '', type: 'output', size: 100, mtime: 2000 },
   { filename: 'char_b.png', subfolder: '', type: 'output', size: 100, mtime: 1000 }


### PR DESCRIPTION
Two harness defects found while triaging #793. Neither touches shipped panel code.

## 1. Specs waited on buttons the harness had switched off

The `panel` fixture strips every `comfyui-mcp.` key from the settings payload so a dev box cannot auto-connect the panel to a live orchestrator mid-test. Correct for `autoConnect` — but it also stripped the three feature flags, all `defaultValue: false`. Every spec for a flagged feature then failed the same way:

```
Error: locator.click: Test timeout of 30000ms exceeded.
- waiting for locator('.cmcp-root').getByRole('button', { name: 'Apps', exact: true })
```

All six `apps` failures were that one line. The features work; the button was correctly hidden.

`test.use({ panelFlags: [...] })` re-adds only the named flags **after** the strip, so the value comes from the spec, never from the developer's machine. Opt-in, so a spec asserting a flagged button is absent by default keeps seeing it absent.

## 2. The mount probe was defeated by the specs' own routing

`resolveHistoryStoreModuleUrl` probed two mount names with `fetch` and took the first 200. The specs route `/extensions/<any>/js/lib/chat-history-store.js`, and that matches **every** mount — so a mount the server does not have answered 200. The module's unrouted sibling then 404'd, and Chrome blamed the top-level URL:

```
TypeError: Failed to fetch dynamically imported module:
  .../extensions/comfyui-agent-panel/js/lib/chat-history-store.js
```

Measured live: `comfyui-agent-panel/...` 404, `comfyui-mcp-panel/...` 200. Now resolved from ComfyUI's own extension list, which no spec routes.

**This one fixes zero tests.** The bad path needs the browser to omit module requests from the resource timeline, so it is intermittent — I hit it once and lost time chasing a file that was never broken. It removes a false signal.

## Measured

`--workers=1` on this rig:

| | before | after |
|---|---|---|
| `apps.spec.ts` | 6 failed | **6 passed** |
| `training-wizard.spec.ts` | 1 failed | **1 passed** |
| `agent-drive.spec.ts` | 5 failed / 5 passed | 5 failed / 5 passed |
| **full suite** | 25 failed / 1 flaky / 23 passed | **16 failed / 1 flaky / 32 passed** |

Nine recovered in the suite versus seven per-file — the flags also removed some cross-file cascade.

`agent-drive` is unchanged: its five failures are a separate CivitAI-modal cause, still open.

Gates: `tsc --noEmit` clean, `test:unit` 0 failures, control-byte scan clean on all five files.

Refs #793