### PR TITLE
fix(civitai): civitai_results reported an empty feed; e2e stubbed a retired endpoint

### DIFF
--- a/browser_tests/agent-drive.spec.ts
+++ b/browser_tests/agent-drive.spec.ts
@@ -24,31 +24,52 @@
  */
 import { test, expect } from './fixtures/panelTest'
 
-// A canned /v1/images feed page. Distinct ids so highlight-by-id is meaningful.
-// `page` selects which ids come back so a later "page" can carry a target that
-// the first page didn't (the scroll/append-highlight case).
-function imagesPage(ids: number[], nextCursor: string | null) {
+// A canned search page. Distinct ids so highlight-by-id is meaningful. `page`
+// selects which ids come back so a later "page" can carry a target that the
+// first page didn't (the scroll/append-highlight case).
+//
+// panel#793 — this used to emit the REST `/v1/images` shape,
+// `{ items, metadata: { nextCursor } }`. The panel does not call that endpoint
+// for a keyword search; it POSTs CivitAI's Meilisearch:
+//
+//     https://search-new.civitai.com/multi-search
+//
+// and reads `data.results[0].hits` (cmcp-civitai.js:925 → `_fromMeili`). The
+// stub therefore answered every search with a body the reader found no hits in,
+// so the grid stayed on its spinner with zero cards and all five specs here
+// failed waiting for a card that could never render. The ITEM fields were right
+// all along — only the envelope was stale.
+function imagesPage(ids: number[]) {
   return {
-    items: ids.map((id) => ({
-      id,
-      url: `https://cdn/${id}.jpeg`,
-      type: 'image',
-      width: 512,
-      height: 512,
-      nsfwLevel: 1,
-      username: `user${id}`,
-      stats: { likeCount: id },
-      meta: { prompt: `prompt for ${id}` }
-    })),
-    metadata: { nextCursor }
+    results: [
+      {
+        hits: ids.map((id) => ({
+          id,
+          url: `https://cdn/${id}.jpeg`,
+          type: 'image',
+          width: 512,
+          height: 512,
+          nsfwLevel: 1,
+          username: `user${id}`,
+          stats: { likeCount: id },
+          meta: { prompt: `prompt for ${id}` }
+        }))
+      }
+    ]
   }
 }
+
+/** An exhausted feed. Meili carries no cursor, so "no more results" is an empty
+ *  hit list — the job `metadata.nextCursor: null` used to do. Without it the
+ *  stub replays its last page forever and the grid fills with duplicates of the
+ *  same id, which makes a `[data-id=N]` locator ambiguous. */
+const EXHAUSTED = { results: [{ hits: [] as unknown[] }] }
 
 async function stubCivitai(page: import('@playwright/test').Page, pages: Record<string, unknown>[]) {
   let call = 0
   // All CivitAI REST/tRPC calls funnel through the same-origin POST proxy.
   await page.route('**/comfyui_mcp_panel/civitai/api', (route) => {
-    const body = pages[Math.min(call, pages.length - 1)]
+    const body = call < pages.length ? pages[call] : EXHAUSTED
     call += 1
     route.fulfill({ json: body })
   })
@@ -75,7 +96,7 @@ test.describe('agent-driven CivitAI modal', () => {
     panel,
     mockBridge
   }) => {
-    await stubCivitai(page, [imagesPage([11, 12, 13], null)])
+    await stubCivitai(page, [imagesPage([11, 12, 13])])
     await openPanel(panel, mockBridge)
 
     // Agent opens docked and IMMEDIATELY highlights — before results exist.
@@ -89,7 +110,7 @@ test.describe('agent-driven CivitAI modal', () => {
   })
 
   test('a reload (switch_tab / search) clears the glow', async ({ page, panel, mockBridge }) => {
-    await stubCivitai(page, [imagesPage([21, 22], null)])
+    await stubCivitai(page, [imagesPage([21, 22])])
     await openPanel(panel, mockBridge)
     await mockBridge.command('open_civitai', { query: 'a', dock: true })
     await mockBridge.command('civitai_highlight', { ids: [21] })
@@ -107,8 +128,8 @@ test.describe('agent-driven CivitAI modal', () => {
   }) => {
     // First page lacks id 99; the second page (next cursor) carries it.
     await stubCivitai(page, [
-      imagesPage([31, 32], 'c1'),
-      imagesPage([99], null)
+      imagesPage([31, 32]),
+      imagesPage([99])
     ])
     await openPanel(panel, mockBridge)
     await mockBridge.command('open_civitai', { query: 'x', dock: true })
@@ -127,7 +148,7 @@ test.describe('agent-driven CivitAI modal', () => {
     panel,
     mockBridge
   }) => {
-    await stubCivitai(page, [imagesPage([41, 42, 43, 44], null)])
+    await stubCivitai(page, [imagesPage([41, 42, 43, 44])])
     await openPanel(panel, mockBridge)
     await mockBridge.command('open_civitai', { query: 'y', dock: true })
     const res = await mockBridge.command('civitai_results', { limit: 2 })
@@ -146,7 +167,7 @@ test.describe('agent-driven CivitAI modal', () => {
     panel,
     mockBridge
   }) => {
-    await stubCivitai(page, [imagesPage([51], null)])
+    await stubCivitai(page, [imagesPage([51])])
     await openPanel(panel, mockBridge)
     await mockBridge.command('open_civitai', { query: 'z', dock: true })
     await expect(page.locator('.cmcp-civitai-modal')).toBeVisible()
@@ -164,7 +185,7 @@ test.describe('agent-driven CivitAI modal', () => {
     panel,
     mockBridge
   }) => {
-    await stubCivitai(page, [imagesPage([61], null)])
+    await stubCivitai(page, [imagesPage([61])])
     await openPanel(panel, mockBridge)
     await mockBridge.command('open_civitai', { query: 'q', dock: true })
     const overlay = page.locator('.cmcp-cv-overlay.cmcp-docked')

--- a/web/js/cmcp-civitai-ui.js
+++ b/web/js/cmcp-civitai-ui.js
@@ -2014,7 +2014,20 @@ export function createCivitaiContent(ctx, shell, opts = {}) {
       dispatched: true,
     };
   }
-  function driveGetResults({ limit = 20 } = {}) {
+  async function driveGetResults({ limit = 20 } = {}) {
+    _assertOpen();
+    // Wait for an in-flight first page, exactly as driveHighlight does.
+    //
+    // panel#793 — without this, an agent that opens the browser and immediately
+    // asks for results gets `{ count: 0, total: 0, loading: true }`. That is not
+    // a lie, but it reads as "this search found nothing", and the agent has no
+    // reason to poll: `civitai_highlight` issued at the same instant DOES wait
+    // and DOES see the cards, so the two commands disagreed about whether any
+    // results existed. Same open, same moment, different answer.
+    //
+    // `loading` is still reported below — this only removes the window where the
+    // honest answer was available and we returned the empty one instead.
+    try { await state.activeReloadPromise; } catch { /* surfaces via state.error below */ }
     _assertOpen();
     const model = isModelTab();
     const source = model ? state.models : state.items;


### PR DESCRIPTION
One product bug and one harness defect, found together while triaging #793. The harness defect is what hid the product bug.

## The harness was stubbing an endpoint the panel no longer calls

`agent-drive.spec.ts` canned the REST `/v1/images` body, `{ items, metadata: { nextCursor } }`. Captured from the running panel, a keyword search actually goes to CivitAI's Meilisearch:

```
upstream url = https://search-new.civitai.com/multi-search | method = POST
```

read via `data.results[0].hits` (`cmcp-civitai.js:925` → `_fromMeili`). So every search got a body with no hits the reader could find: the modal opened, the grid stayed on its spinner, **zero cards**, and all five specs failed waiting for a card that could never render. Because the failure named the card, it read as a broken highlight feature.

The item fields were correct all along — only the envelope was stale. Meili has no cursor, so an exhausted feed is an empty hit list; the stub now serves its pages in order then stops, instead of replaying the last page forever (which filled the grid with duplicate ids and made `[data-id=N]` ambiguous).

## The bug that hid behind it

`driveHighlight` awaits `state.activeReloadPromise` before answering. `driveGetResults` did not — it read `state.items` synchronously. An agent that opened the browser and immediately asked for results got:

```
{ count: 0, total: 0, loading: true }
```

while the first page was in flight. Not a lie, but it reads as *"this search found nothing"*, and nothing tells the agent to ask again. The two commands actively disagreed: `civitai_highlight` issued at the same instant **did** wait and **did** find the cards. Same open, same moment, two different answers about whether results existed.

Now it awaits the same promise `highlight` already awaits, and re-asserts the browser is still open afterwards, exactly as `highlight` does. `loading` is still reported — this only removes the window where the honest answer was available and the empty one was returned instead.

The spec had asserted this contract all along. It could not report the mismatch, because the stale stub meant no cards ever rendered.

## Measured (`--workers=1`)

| | before | after |
|---|---|---|
| `agent-drive.spec.ts` | 5 failed / 5 passed | **1 failed / 9 passed** |
| full suite | 16 failed / 1 flaky / 32 passed | **12 failed / 1 flaky / 36 passed** |

Verified the product fix against the **served** path — the pack is junctioned to the main checkout, so a worktree edit is not what the browser loads. With the change served, the assertion goes 0 → 2; without it, back to 0.

The one remaining `agent-drive` failure is the Training `gotoStep` timeout, an unrelated cause still open.

Gates: `node --check`, `tsc --noEmit`, `test:unit` 2989 pass / 0 fail, control-byte scan clean.

Refs #793