### PR TITLE
test(e2e): gotoStep needs 15s for its capability probe, the harness allowed 10

### DIFF
--- a/browser_tests/agent-drive.spec.ts
+++ b/browser_tests/agent-drive.spec.ts
@@ -246,7 +246,11 @@ test.describe('agent-driven Training modal', () => {
     await openPanel(panel, mockBridge)
     await mockBridge.command('open_training', { dock: true })
     await expect(page.locator('.cmcp-tr-modal')).toBeVisible()
-    const reply = await mockBridge.command('training_goto_step', { step: 2 })
+    // panel#793 — entering a wizard step runs the backend-capability probe,
+    // which callJson's with a 15s timeout. MockBridge.command defaults to 10s,
+    // so the harness gave up 5s before the panel could answer and the failure
+    // read as a hung command. The rejection itself is correct and honest.
+    const reply = await mockBridge.command('training_goto_step', { step: 2 }, 25_000)
     expect(reply.ok).toBe(false)
     // Backend-capability or dataset-name/image gate fires — either is an honest
     // rejection rather than a silent jump.


### PR DESCRIPTION
`training_goto_step` failed with:

```
Error: MockBridge.command("training_goto_step") timed out
```

which reads as a hung agent command. It is not hung. Entering a wizard step enforces the same prerequisites as the Next button, and the first is `checkBackendCapable()` — which calls `train_start` / `list_flows` with a **15s** timeout (`cmcp-training-ui.js:452`). `MockBridge.command` defaults to **10s**. The harness gave up five seconds before the panel could answer.

The rejection the test asserts is correct and honest; with no orchestrator exposing the `train_*` tools it simply arrives at ~15s. `MockBridge.command` already takes a per-call timeout, so this is scoped to the one test that needs it rather than a blanket raise.

## Measured (`--workers=1`)

| | before | after |
|---|---|---|
| `agent-drive.spec.ts:241` | timed out at 10s | **passes in 18.7s** |
| full suite | 12 failed / 1 flaky / 36 passed | **11 failed / 38 passed** |

Gates: `tsc --noEmit` clean, control-byte scan clean.

Refs #793