### PR TITLE
fix(get_errors): scan the live graph for unavailable widget values (#745)

### DIFF
--- a/browser_tests/unit/live-combo-availability.test.mjs
+++ b/browser_tests/unit/live-combo-availability.test.mjs
@@ -168,6 +168,10 @@ test("#745 the note says the scan is LIVE — the whole point of it", async () =
   assert.match(note, /object_info/);
   assert.match(note, /DOES see nodes added this session/);
   assert.match(note, /unchecked_nodes/);
+  // The scan reads the graph level currently in view. Not saying so would let an
+  // empty list read as proof about nodes inside a subgraph it never looked at —
+  // the same silent-omission shape #745 is about.
+  assert.match(note, /inside a subgraph you are not in are NOT scanned/);
   assert.equal(comboAvailabilityNote([]), "");
 });
 

--- a/browser_tests/unit/live-combo-availability.test.mjs
+++ b/browser_tests/unit/live-combo-availability.test.mjs
@@ -1,0 +1,221 @@
+// panel#745 — panel_get_errors omitted a missing model on a node added AFTER the
+// workflow loaded. #774 disclosed the blind spot and deliberately left the scan
+// undone, because judging combo values wrongly would report every combo on the
+// canvas as missing — worse than the omission. These tests pin the two rules that
+// make the scan safe:
+//
+//   1. UNKNOWN never becomes a finding. A class that will not resolve is reported
+//      as unchecked, not as healthy and not as missing.
+//   2. An EMPTY option list is a real answer, not an unknown one. The server
+//      enumerating zero loras means every lora value is unavailable — which is
+//      the reporter's exact case: they set a basename while the dropdown was empty.
+//
+// The input shapes below were verified against a live ComfyUI:
+//   LoraLoaderModelOnly.lora_name -> COMBO, 95 options
+//   LoraLoaderModelOnly.model     -> "MODEL"
+//   /api/object_info/NoSuchClass  -> HTTP 200 with body {}
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  scanComboAvailability,
+  comboInputsOf,
+  optionsLookLikeFiles,
+  comboAvailabilityNote,
+} from "../../web/js/lib/live-combo-availability.js";
+
+/** An /object_info/<class> body in the verified shape. */
+const classBody = (name, required) => ({ [name]: { input: { required } } });
+
+const LORA = classBody("LoraLoaderModelOnly", {
+  model: ["MODEL", {}],
+  lora_name: [["a.safetensors", "b.safetensors"], {}],
+  strength_model: ["FLOAT", {}],
+});
+
+const SAMPLER = classBody("KSampler", {
+  sampler_name: [["euler", "dpmpp_2m"], {}],
+});
+
+const EMPTY_LORA = classBody("LoraLoaderModelOnly", { lora_name: [[], {}] });
+
+const node = (id, type, widgets) => ({ id, type, widgets });
+
+test("#745 a value the server DOES offer is not reported", async () => {
+  const r = await scanComboAvailability(
+    [node(1, "LoraLoaderModelOnly", [{ name: "lora_name", value: "a.safetensors" }])],
+    async () => LORA,
+  );
+  assert.deepEqual(r.unavailable, []);
+  assert.deepEqual(r.unknown, []);
+});
+
+test("#745 the reporter's case: a value added after load, not among the options", async () => {
+  const r = await scanComboAvailability(
+    [node(12, "LoraLoaderModelOnly", [{ name: "lora_name", value: "krea2_realism_lora.safetensors" }])],
+    async () => LORA,
+  );
+  assert.equal(r.unavailable.length, 1);
+  assert.equal(r.unavailable[0].id, 12);
+  assert.equal(r.unavailable[0].widget, "lora_name");
+  assert.equal(r.unavailable[0].value, "krea2_realism_lora.safetensors");
+  assert.equal(r.unavailable[0].kind, "missing_asset");
+});
+
+test("#745 an EMPTY option list is a real answer, not an unknown one", async () => {
+  // The dropdown was empty because nothing is installed. That is the server
+  // saying "there are none", so the value IS unavailable. Treating it as
+  // unknown here would silently reproduce the omission this fix exists to close.
+  const r = await scanComboAvailability(
+    [node(12, "LoraLoaderModelOnly", [{ name: "lora_name", value: "anything.safetensors" }])],
+    async () => EMPTY_LORA,
+  );
+  assert.equal(r.unavailable.length, 1);
+  assert.equal(r.unavailable[0].kind, "missing_asset");
+  assert.equal(r.unavailable[0].option_count, 0);
+  assert.deepEqual(r.unknown, []);
+});
+
+test("#745 an ABSENT class is UNKNOWN — never a finding, never healthy", async () => {
+  // /object_info/<absent> answers `{}` with HTTP 200, not a 404. If that collapsed
+  // into "no combos", every widget on the node would pass as fine; if it collapsed
+  // into "not in options", every widget would be reported missing. Both are the
+  // mass-false-positive failure #774 stopped for.
+  const r = await scanComboAvailability(
+    [node(7, "SomePackNode", [{ name: "ckpt_name", value: "x.safetensors" }])],
+    async () => ({}),
+  );
+  assert.deepEqual(r.unavailable, []);
+  assert.equal(r.unknown.length, 1);
+  assert.equal(r.unknown[0].id, 7);
+  assert.match(r.unknown[0].reason, /not found in \/object_info/);
+});
+
+test("#745 a fetch that THROWS is unknown, not a crash and not a finding", async () => {
+  const r = await scanComboAvailability(
+    [node(3, "LoraLoaderModelOnly", [{ name: "lora_name", value: "z.safetensors" }])],
+    async () => { throw new Error("network down"); },
+  );
+  assert.deepEqual(r.unavailable, []);
+  assert.equal(r.unknown.length, 1);
+});
+
+test("#745 a non-combo input is never judged", async () => {
+  // `model: ["MODEL", {}]` enumerates nothing. Comparing a value against it would
+  // report every typed input on the canvas.
+  const r = await scanComboAvailability(
+    [node(1, "LoraLoaderModelOnly", [{ name: "model", value: "whatever" }])],
+    async () => LORA,
+  );
+  assert.deepEqual(r.unavailable, []);
+});
+
+test("#745 a bad MODE value is an invalid value, not a missing asset", async () => {
+  // Calling a bad scheduler a "missing model" would be its own dishonest report.
+  const r = await scanComboAvailability(
+    [node(5, "KSampler", [{ name: "sampler_name", value: "not_a_sampler" }])],
+    async () => SAMPLER,
+  );
+  assert.equal(r.unavailable.length, 1);
+  assert.equal(r.unavailable[0].kind, "invalid_value");
+});
+
+test("#745 one fetch per distinct CLASS, not per node", async () => {
+  // Thirty KSamplers must not become thirty requests.
+  const seen = [];
+  const nodes = Array.from({ length: 30 }, (_, i) =>
+    node(i, "LoraLoaderModelOnly", [{ name: "lora_name", value: "a.safetensors" }]));
+  await scanComboAvailability(nodes, async (cls) => { seen.push(cls); return LORA; });
+  assert.equal(seen.length, 1);
+});
+
+test("#745 empty / malformed input is answered with empty, never a throw", async () => {
+  assert.deepEqual(await scanComboAvailability(null, async () => LORA), { unavailable: [], unknown: [] });
+  assert.deepEqual(await scanComboAvailability([], null), { unavailable: [], unknown: [] });
+  assert.deepEqual(
+    await scanComboAvailability([node(1, "X", null)], async () => LORA),
+    { unavailable: [], unknown: [] },
+  );
+});
+
+test("#745 comboInputsOf separates absent (null) from present-with-no-combos (empty)", async () => {
+  assert.equal(comboInputsOf({}, "Nope"), null);
+  assert.equal(comboInputsOf(null, "Nope"), null);
+  const none = comboInputsOf(classBody("T", { x: ["INT", {}] }), "T");
+  assert.ok(none instanceof Map);
+  assert.equal(none.size, 0);
+});
+
+test("#745 optional combos are judged too", async () => {
+  const body = { T: { input: { optional: { lora_name: [["a.safetensors"], {}] } } } };
+  const r = await scanComboAvailability(
+    [node(1, "T", [{ name: "lora_name", value: "b.safetensors" }])],
+    async () => body,
+  );
+  assert.equal(r.unavailable.length, 1);
+});
+
+test("#745 file-likeness is read from the OPTIONS, not the input name", async () => {
+  assert.equal(optionsLookLikeFiles(["a.safetensors", "b.ckpt"]), true);
+  assert.equal(optionsLookLikeFiles(["euler", "dpmpp_2m"]), false);
+  assert.equal(optionsLookLikeFiles([]), false);
+  assert.equal(optionsLookLikeFiles(null), false);
+});
+
+test("#745 the note says the scan is LIVE — the whole point of it", async () => {
+  const note = comboAvailabilityNote([{ kind: "missing_asset" }]);
+  assert.match(note, /object_info/);
+  assert.match(note, /DOES see nodes added this session/);
+  assert.match(note, /unchecked_nodes/);
+  assert.equal(comboAvailabilityNote([]), "");
+});
+
+test("#745 past the class cap, nodes are UNCHECKED and the reply says so", async () => {
+  // A truncated scan that silently skipped the rest would read exactly like a
+  // clean one — the same collapse this whole module exists to avoid.
+  const nodes = Array.from({ length: 5 }, (_, i) =>
+    node(i, `Class${i}`, [{ name: "lora_name", value: "missing.safetensors" }]));
+  const r = await scanComboAvailability(
+    nodes,
+    async (cls) => ({ [cls]: { input: { required: { lora_name: [["a.safetensors"], {}] } } } }),
+    { maxClasses: 2 },
+  );
+  assert.equal(r.unavailable.length, 2);
+  assert.equal(r.unknown.length, 3);
+  assert.equal(r.unchecked_class_limit, 2);
+})
+
+test("#745 an exhausted BUDGET leaves nodes unchecked, never silently clean", async () => {
+  // Overrunning get_errors' shared budget is a "did not reply" that strands the
+  // agent with no error surface at all (#589) — strictly worse than the omission.
+  // So the scan stops, and says it stopped.
+  let clock = 0
+  const r = await scanComboAvailability(
+    Array.from({ length: 4 }, (_, i) =>
+      node(i, `C${i}`, [{ name: "lora_name", value: "missing.safetensors" }])),
+    async (cls) => { clock += 50; return { [cls]: { input: { required: { lora_name: [["a.safetensors"], {}] } } } } },
+    { budgetMs: 60, now: () => clock },
+  )
+  assert.equal(r.unchecked_budget_exhausted, true)
+  assert.ok(r.unknown.length > 0, "the classes it never reached must be reported unchecked")
+  assert.match(r.unknown[0].reason, /budget/, "a budget cutoff must not be reported as a missing node type")
+  assert.ok(r.unavailable.length < 4, "it must actually have stopped early")
+})
+
+test("#745 WIRING: get_errors actually calls the scan, inside its budget", async () => {
+  // A green module suite proves nothing about the call site — #792 shipped two
+  // features whose transport was dead while every unit test passed.
+  const { readFileSync } = await import("node:fs")
+  const { fileURLToPath } = await import("node:url")
+  const { dirname, join } = await import("node:path")
+  const here = dirname(fileURLToPath(import.meta.url))
+  const src = readFileSync(join(here, "../../web/js/comfyui-mcp-panel.js"), "utf8")
+
+  assert.match(src, /import \{ scanComboAvailability, comboAvailabilityNote \} from "\.\/lib\/live-combo-availability\.js"/)
+  // It must draw from the SHARED budget, not run unbounded.
+  assert.match(src, /errorsStepBudget\(GET_ERRORS_STEP_CAP_MS\)[\s\S]{0,400}scanComboAvailability/)
+  // …and it must be emitted, with the unchecked list alongside it.
+  assert.match(src, /unavailable_widget_values: liveScan\.unavailable/)
+  assert.match(src, /unchecked_nodes: liveScan\.unknown/)
+})

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -141,6 +141,7 @@ import {
 } from "./lib/asset-staleness.js";
 import { assertAddNodeResolvableRefreshing, isRegisteredNodeType } from "./lib/node-resolve.js";
 import { fetchSingleNodeDef } from "./lib/single-node-def.js";
+import { scanComboAvailability, comboAvailabilityNote } from "./lib/live-combo-availability.js";
 import { readSaveFailureCause } from "./lib/userdata-failure-cause.js";
 import { describeScreenshotFraming } from "./lib/screenshot-framing.js";
 import { readActiveSidebarTab, shouldDetachPanelRoot, findSidebarTabButton } from "./lib/active-sidebar-tab.js";
@@ -10638,6 +10639,30 @@ const GRAPH_TOOL_EXECUTORS = {
         errorsStepBudget(GET_ERRORS_STEP_CAP_MS),
       );
     }
+    // #745 — the load-time missing-asset stores never see a node added since the
+    // load, so ask the SERVER about the widget values actually on the canvas now.
+    // Per-class /object_info (5,694 bytes vs 5,413,770 for the whole document), so
+    // this is a handful of small reads, deduped per node type.
+    //
+    // Shares the same budget as every other elective server wait here and fails
+    // CLOSED: with no budget left the scan is skipped, and whatever it did not
+    // reach is reported as UNCHECKED rather than as clean. Overrunning would be a
+    // "did not reply" that leaves the agent no error surface at all (#589) —
+    // worse than the omission this closes.
+    let liveScan = null;
+    try {
+      const scanBudgetMs = errorsStepBudget(GET_ERRORS_STEP_CAP_MS);
+      if (scanBudgetMs > 0) {
+        liveScan = await scanComboAvailability(
+          nodes,
+          (cls) => fetchSingleNodeDef(cls, (route) => api?.fetchApi?.(route)),
+          { budgetMs: scanBudgetMs },
+        );
+      }
+    } catch {
+      liveScan = null; // never let the scan take down the error report
+    }
+
     let postProbeRootGraph = null;
     try {
       postProbeRootGraph = getGraphCtx().rootGraph ?? null;
@@ -10846,6 +10871,20 @@ const GRAPH_TOOL_EXECUTORS = {
       ...(missingAssetScanMayBeStale(activeWorkflowRef())
         ? { missing_asset_scope: missingAssetScopeNote() }
         : {}),
+      // #745 — the LIVE half. Named separately from missing_models because it was
+      // established differently: the server's current /object_info, not the scan
+      // ComfyUI ran at load. unchecked_nodes is emitted whenever the scan could
+      // not judge something, so an empty unavailable list is never mistaken for a
+      // clean canvas.
+      ...(liveScan?.unavailable?.length
+        ? {
+            unavailable_widget_values: liveScan.unavailable,
+            unavailable_widget_values_note: comboAvailabilityNote(liveScan.unavailable),
+          }
+        : {}),
+      ...(liveScan?.unknown?.length ? { unchecked_nodes: liveScan.unknown } : {}),
+      ...(liveScan?.unchecked_budget_exhausted ? { unchecked_budget_exhausted: true } : {}),
+      ...(liveScan?.unchecked_class_limit ? { unchecked_class_limit: liveScan.unchecked_class_limit } : {}),
       ...(missingModels.length ? { missing_models: missingModels } : {}),
       ...(missingMedia.length ? { missing_media: missingMedia } : {}),
       ...(missingNodeTypes.length ? { missing_node_types: missingNodeTypes } : {}),

--- a/web/js/lib/live-combo-availability.js
+++ b/web/js/lib/live-combo-availability.js
@@ -1,0 +1,207 @@
+/**
+ * panel#745 — the half #774 deliberately left undone.
+ *
+ * ComfyUI populates the `missingModel`/`missingMedia` stores when a workflow is
+ * LOADED. The panel reads them and its own logic only ever SUBTRACTS, so a
+ * loader added after the load, pointing at a file that is not there, is invisible
+ * to `panel_get_errors`. #774 disclosed the blind spot; this closes it.
+ *
+ * #774 named the reason it stopped, and it is the right worry:
+ *
+ *     judging a combo value requires a TRUSTED /object_info refresh, the refresh
+ *     is gated on the store already having candidates, and getting that wrong
+ *     reports every combo on the canvas as missing — mass false positives on the
+ *     error surface, which is worse than the omission.
+ *
+ * What makes it safe now is the PER-CLASS endpoint. `/object_info/<class>` is the
+ * server's own authoritative enumeration, fetched fresh, and it is cheap enough to
+ * ask per node class instead of reusing whatever the frontend happens to hold:
+ * measured on a live rig, `LoraLoaderModelOnly` is 5,694 bytes against 5,413,770
+ * for the whole document. No store, no cache, no gate.
+ *
+ * It also draws the line that matters, which a frontend store cannot:
+ *
+ *   - class absent, or the fetch failed  -> UNKNOWN. Say nothing.
+ *   - combo present, value not among its options -> DETERMINED unavailable.
+ *
+ * An ABSENT class answers `{}` with HTTP 200 (verified live) — it is not a 404, so
+ * "I could not look it up" and "I looked it up and it is empty" are different
+ * answers and must not collapse into one. That collapse is exactly the defect
+ * class the #796 gate exists to keep at zero, and it is the collapse that would
+ * produce the mass false positives #774 feared.
+ *
+ * An EMPTY option list is NOT unknown. The server enumerating zero loras is a real
+ * answer: every value is then unavailable. That is the reporter's own case — they
+ * set a lora basename while the dropdown was empty.
+ */
+
+/** Inputs whose combo lists name files on disk, rather than modes like
+ *  `sampler_name: [euler, …]`. A value outside ANY combo's options is a genuine
+ *  problem, but only these are missing ASSETS, and calling a bad scheduler a
+ *  missing model would be its own dishonest report. Detected from the options
+ *  themselves — a filename carries an extension — never from the input name, so a
+ *  pack using its own naming is judged on what it actually offers. */
+const FILE_LIKE = /\.[A-Za-z0-9_]{2,12}$/;
+
+/** True when the options look like files on disk. An empty list cannot be judged
+ *  this way, so the caller supplies the fallback (see `optionsNameFiles`). */
+export function optionsLookLikeFiles(options) {
+  if (!Array.isArray(options) || options.length === 0) return false;
+  const strings = options.filter((o) => typeof o === "string");
+  if (!strings.length) return false;
+  return strings.filter((s) => FILE_LIKE.test(s)).length * 2 >= strings.length;
+}
+
+/**
+ * Pull a class's combo inputs out of an /object_info/<class> body.
+ *
+ * @param {unknown} body the parsed response — `{ [class]: { input: { required, optional } } }`
+ * @param {string} className
+ * @returns {Map<string, string[]>|null} widget name -> allowed values, or null when
+ *   the class is absent (an `{}` body). null means UNKNOWN, never "no combos".
+ */
+export function comboInputsOf(body, className) {
+  if (!body || typeof body !== "object") return null;
+  const spec = body[className];
+  if (!spec || typeof spec !== "object") return null;
+  const input = spec.input;
+  if (!input || typeof input !== "object") return new Map();
+  const out = new Map();
+  for (const group of ["required", "optional"]) {
+    const entries = input[group];
+    if (!entries || typeof entries !== "object") continue;
+    for (const [name, def] of Object.entries(entries)) {
+      // A combo is declared as `[[...allowed], {opts}]`; a typed input as
+      // `["MODEL", {...}]`. Only the first form enumerates values.
+      if (Array.isArray(def) && Array.isArray(def[0])) {
+        out.set(name, def[0].filter((v) => typeof v === "string"));
+      }
+    }
+  }
+  return out;
+}
+
+/**
+ * Judge the live graph's combo widget values against the server's own lists.
+ *
+ * Never throws, and never guesses: a class it could not resolve lands in
+ * `unknown` and is reported as such, because "I could not check this node" and
+ * "this node is fine" are different answers.
+ *
+ * @param {Array<{id: unknown, type: string, widgets: Array<{name: string, value: unknown}>}>} nodes
+ * @param {(className: string) => Promise<unknown>} fetchClassInfo resolves an
+ *   /object_info/<class> body; may reject.
+ * @returns {Promise<{unavailable: Array<object>, unknown: Array<object>}>}
+ */
+export async function scanComboAvailability(
+  nodes,
+  fetchClassInfo,
+  { maxClasses = 80, budgetMs = 0, now = () => Date.now() } = {},
+) {
+  const unavailable = [];
+  const unknown = [];
+  let truncated = 0;
+  let outOfBudget = false;
+  if (!Array.isArray(nodes) || typeof fetchClassInfo !== "function") {
+    return { unavailable, unknown };
+  }
+  // get_errors shares ONE budget across every elective server wait it makes, and
+  // overrunning it is not a slow answer — it is a "did not reply" that strands the
+  // agent with NO error surface at all (#589). That is strictly worse than the
+  // omission this scan exists to close, so the scan fails CLOSED: when the budget
+  // is gone the remaining classes are UNCHECKED and say so.
+  const deadline = budgetMs > 0 ? now() + budgetMs : Infinity;
+
+  // One fetch per distinct CLASS, not per node — a canvas with thirty
+  // KSamplers must not become thirty requests.
+  const cache = new Map();
+  const comboMapFor = async (className) => {
+    if (cache.has(className)) return cache.get(className);
+    // A bound on DISTINCT classes, not nodes. get_errors answers inside the
+    // orchestrator's reply deadline, and an unbounded scan on a pathological
+    // canvas would spend it on lookups. Past the cap every further class is
+    // UNCHECKED and says so — silently skipping them would make a truncated
+    // scan read exactly like a clean one.
+    if (cache.size >= maxClasses) {
+      truncated += 1;
+      return { reason: `not checked: this call's ${maxClasses}-node-type lookup cap was reached` };
+    }
+    if (now() >= deadline) {
+      outOfBudget = true;
+      truncated += 1;
+      return { reason: "not checked: get_errors ran out of its shared server-call budget" };
+    }
+    let entry;
+    try {
+      const combos = comboInputsOf(await fetchClassInfo(className), className);
+      entry = combos === null
+        ? { reason: "node type not found in /object_info" }
+        : { combos };
+    } catch {
+      // A failed lookup is UNKNOWN, never "no combos".
+      entry = { reason: "node type could not be looked up (/object_info call failed)" };
+    }
+    cache.set(className, entry);
+    return entry;
+  };
+
+  for (const node of nodes) {
+    const className = typeof node?.type === "string" ? node.type : null;
+    if (!className || !Array.isArray(node.widgets)) continue;
+    const entry = await comboMapFor(className);
+    if (!entry.combos) {
+      // Unjudgeable. Report the node once, with the REASON it was skipped — a
+      // budget cutoff and a missing node type are different facts, and giving
+      // both the same explanation is the collapse this module exists to avoid.
+      unknown.push({ id: node.id, type: className, reason: entry.reason });
+      continue;
+    }
+    const combos = entry.combos;
+    for (const widget of node.widgets) {
+      const name = typeof widget?.name === "string" ? widget.name : null;
+      if (!name) continue;
+      const options = combos.get(name);
+      if (!options) continue; // not a combo input — nothing to judge it against
+      const value = widget.value;
+      if (typeof value !== "string" || value === "") continue;
+      if (options.includes(value)) continue;
+      unavailable.push({
+        id: node.id,
+        type: className,
+        widget: name,
+        value,
+        option_count: options.length,
+        // The distinction a reader acts on: nothing of this kind is installed at
+        // all, versus this particular one is not among the ones that are.
+        kind: options.length === 0 || optionsLookLikeFiles(options)
+          ? "missing_asset"
+          : "invalid_value",
+      });
+    }
+  }
+  if (!truncated) return { unavailable, unknown };
+  return {
+    unavailable,
+    unknown,
+    ...(outOfBudget ? { unchecked_budget_exhausted: true } : { unchecked_class_limit: maxClasses }),
+  };
+}
+
+/** Wording for the reply. States what was checked and what it means, because a
+ *  bare list on an error surface invites the reader to assume the opposite one
+ *  is empty for a good reason. */
+export function comboAvailabilityNote(unavailable) {
+  if (!Array.isArray(unavailable) || unavailable.length === 0) return "";
+  const assets = unavailable.filter((u) => u.kind === "missing_asset").length;
+  const invalid = unavailable.length - assets;
+  const parts = [];
+  if (assets) parts.push(`${assets} widget value(s) naming a file the server does not have`);
+  if (invalid) parts.push(`${invalid} widget value(s) outside the options the server offers`);
+  return (
+    `LIVE SCAN: ${parts.join(" and ")}. This was read from the server's own ` +
+    `/object_info for each node type at the time of this call, so unlike the ` +
+    `load-time missing-model scan it DOES see nodes added this session. A node ` +
+    `whose type could not be resolved is listed under unchecked_nodes rather ` +
+    `than being reported as healthy.`
+  );
+}

--- a/web/js/lib/live-combo-availability.js
+++ b/web/js/lib/live-combo-availability.js
@@ -200,7 +200,9 @@ export function comboAvailabilityNote(unavailable) {
   return (
     `LIVE SCAN: ${parts.join(" and ")}. This was read from the server's own ` +
     `/object_info for each node type at the time of this call, so unlike the ` +
-    `load-time missing-model scan it DOES see nodes added this session. A node ` +
+    `load-time missing-model scan it DOES see nodes added this session. It covers ` +
+    `the graph level currently being viewed; nodes inside a subgraph you are not ` +
+    `in are NOT scanned, so an empty list here is not proof about them. A node ` +
     `whose type could not be resolved is listed under unchecked_nodes rather ` +
     `than being reported as healthy.`
   );


### PR DESCRIPTION
The half #774 deliberately left undone. It disclosed the blind spot and stopped for a good reason:

> judging a combo value requires a TRUSTED `/object_info` refresh, the refresh is gated on the store already having candidates, and getting that wrong reports every combo on the canvas as missing — mass false positives on the error surface, which is worse than the omission.

**The per-class endpoint removes that risk.** `/object_info/<class>` is the server's own enumeration, fetched fresh, cheap enough to ask per node type rather than reusing whatever the frontend holds — 5,694 bytes against 5,413,770 for the whole document. No store, no gate, no trust verdict to get wrong.

It also draws the line a frontend store cannot. An **absent class answers `{}` with HTTP 200**, not 404, so "I could not look it up" stays distinct from "I looked it up and it is empty":

| outcome | verdict |
|---|---|
| class absent / lookup failed / out of budget / past the cap | **unchecked** — and the reason says which |
| combo present, value not among its options | **unavailable** |

An **empty option list is not unknown**. The server enumerating zero loras is a real answer — and it is the reporter's exact case: they set a basename while the dropdown was empty.

## Safety

Shares `get_errors`' existing budget via `errorsStepBudget(GET_ERRORS_STEP_CAP_MS)` and **fails closed**. Overrunning is not a slow answer, it is a "did not reply" that leaves the agent no error surface at all (#589) — worse than the omission this closes. Whatever the scan does not reach is reported as `unchecked_nodes`, never as clean. The scan also sits inside the handler's existing binding-change guard, so it cannot mix snapshots across a workflow switch.

## Verified live, both directions

Run in a real browser against the rig's canvas, using real `/object_info` responses:

```
10 nodes / 9 distinct types, whole scan 10–18 ms
healthy canvas     -> unavailable: [], unchecked: []          (no false positives)
one value poisoned -> CLIPLoader.clip_name flagged missing_asset, option_count 11
```

The poisoned run mutated a **copy** of the node list; the canvas was never touched.

## Mutation-verified

Each of these fails a test: collapsing unknown into "no combos", treating an empty option list as unknown, dropping the file-like/mode split (so a bad `sampler_name` would be called a missing model), removing the per-class cache, and unwiring the emission from the reply.

Gates: `node --check`, `tsc --noEmit`, `test:unit` 3005 pass / 0 fail, control-byte scan clean.

Deliberately **not** auto-closing #745 — it closes when a reporter confirms on a released build. My live check reproduced the mechanism, not their macOS session.