### PR TITLE
fix(save): report the workflow instance a save leaves active (#747)

### DIFF
--- a/browser_tests/unit/save-reply-identity.test.mjs
+++ b/browser_tests/unit/save-reply-identity.test.mjs
@@ -1,0 +1,94 @@
+// panel#747 — a Save-As fenced the session that performed it, unrecoverably.
+//
+// `panel_save_workflow({name})` doing a Save-As switches the active canvas to the
+// newly created workflow, so the calling session is left fenced to the instance it
+// held BEFORE its own save. Every following panel_* call is refused with
+// `workflow instance mismatch`.
+//
+// The mismatch alone would be recoverable. What made it a dead end is that the
+// reply was `{saved: true, workflow: "<name>"}` and nothing else — no identity to
+// re-fence to, and every call that could supply one is itself fenced. The reporter
+// watched a single stale uuid survive seven set_workflow_target calls, an
+// orchestrator update, several reconnects, and a browser hard reset.
+
+import assert from "node:assert/strict";
+import test from "node:test";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+import { saveReplyIdentity } from "../../web/js/lib/save-reply-identity.js";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const PANEL_JS = join(HERE, "../../web/js/comfyui-mcp-panel.js");
+
+const IDENTITY = { routingKey: "wf:workflows/new.json", uuid: "8c778b58-c38f-4bce-b975-b0981456c230" };
+
+test("#747 a Save-As reply carries the identity the caller must re-fence to", () => {
+  const r = saveReplyIdentity(IDENTITY, { savedAs: true });
+  assert.equal(r.workflow_uuid, IDENTITY.uuid);
+  assert.equal(r.routing_key, IDENTITY.routingKey);
+  assert.equal(r.workflow_instance_changed, true);
+  assert.match(r.workflow_instance_note, /re-fence it to the workflow_uuid reported here/);
+});
+
+test("#747 an in-place save reports identity but does NOT claim the instance changed", () => {
+  // Saving in place leaves the same workflow active. Flagging a change here would
+  // send a caller to re-fence for no reason, and train it to ignore the flag.
+  const r = saveReplyIdentity(IDENTITY, { savedAs: false });
+  assert.equal(r.workflow_uuid, IDENTITY.uuid);
+  assert.equal(r.workflow_instance_changed, undefined);
+  assert.equal(r.workflow_instance_note, undefined);
+});
+
+test("#747 an UNESTABLISHED identity is declared absent, never guessed", () => {
+  // The reply must not mint an identity — a read that could establish one lets the
+  // fence agree with itself instead of observing anything (#716). But silence would
+  // read as "identity unchanged", which is the assumption that stranded the
+  // reporter, so the absence is stated.
+  for (const empty of [null, undefined, {}, { uuid: "" }, { routingKey: "" }]) {
+    const r = saveReplyIdentity(empty, { savedAs: true });
+    assert.equal(r.workflow_uuid, undefined);
+    assert.equal(r.routing_key, undefined);
+    assert.equal(r.workflow_identity_unavailable, true);
+    assert.match(r.workflow_identity_note, /fenced to the workflow that was active BEFORE this save/);
+  }
+});
+
+test("#747 a partial identity reports what it has and omits what it lacks", () => {
+  const onlyUuid = saveReplyIdentity({ uuid: IDENTITY.uuid }, { savedAs: true });
+  assert.equal(onlyUuid.workflow_uuid, IDENTITY.uuid);
+  assert.equal(onlyUuid.routing_key, undefined);
+  assert.equal(onlyUuid.workflow_identity_unavailable, undefined);
+
+  const onlyKey = saveReplyIdentity({ routingKey: IDENTITY.routingKey }, { savedAs: false });
+  assert.equal(onlyKey.routing_key, IDENTITY.routingKey);
+  assert.equal(onlyKey.workflow_uuid, undefined);
+});
+
+test("#747 non-string identity fields are rejected, not stringified into the fence", () => {
+  // A number or object reaching workflow_uuid would be compared against a real
+  // uuid and never match — an unrecoverable fence built out of garbage input.
+  const r = saveReplyIdentity({ uuid: 12345, routingKey: { k: 1 } }, { savedAs: true });
+  assert.equal(r.workflow_uuid, undefined);
+  assert.equal(r.routing_key, undefined);
+  assert.equal(r.workflow_identity_unavailable, true);
+});
+
+test("#747 WIRING: BOTH save handlers report the identity, and save_as always flags the change", () => {
+  // A green helper proves nothing about the reply the agent receives (#792).
+  const src = readFileSync(PANEL_JS, "utf8");
+  assert.match(src, /import \{ saveReplyIdentity \} from "\.\/lib\/save-reply-identity\.js"/);
+
+  const saveIdx = src.indexOf("async workflow_save({ name } = {})");
+  const saveAsIdx = src.indexOf("async workflow_save_as({ name })");
+  assert.ok(saveIdx > 0 && saveAsIdx > saveIdx);
+
+  const saveBlock = src.slice(saveIdx, saveAsIdx);
+  const saveAsBlock = src.slice(saveAsIdx, saveAsIdx + 900);
+
+  // workflow_save is only a Save-As when the outcome says so…
+  assert.match(saveBlock, /saveReplyIdentity\(liveWorkflowListActive\(\)\.activeIdentity, \{ savedAs: !!outcome\.saved_as \}\)/);
+  // …while workflow_save_as always changes which workflow is active.
+  assert.match(saveAsBlock, /saveReplyIdentity\(liveWorkflowListActive\(\)\.activeIdentity, \{ savedAs: true \}\)/);
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -141,6 +141,7 @@ import {
 } from "./lib/asset-staleness.js";
 import { assertAddNodeResolvableRefreshing, isRegisteredNodeType } from "./lib/node-resolve.js";
 import { fetchSingleNodeDef } from "./lib/single-node-def.js";
+import { saveReplyIdentity } from "./lib/save-reply-identity.js";
 import { scanComboAvailability, comboAvailabilityNote } from "./lib/live-combo-availability.js";
 import { readSaveFailureCause } from "./lib/userdata-failure-cause.js";
 import { describeScreenshotFraming } from "./lib/screenshot-framing.js";
@@ -10906,13 +10907,20 @@ const GRAPH_TOOL_EXECUTORS = {
     const { name: workflow, ...outcome } = await programmaticSave(name);
     // outcome surfaces WHAT happened (saved_as/copied_from/original_preserved or
     // first_save) so a rename-vs-copy is never silent (mcp#579).
-    return { saved: true, workflow, ...outcome };
+    //
+    // #747 — and report WHICH workflow instance is active now. A Save-As makes a
+    // DIFFERENT workflow active, which fences the very session that asked for the
+    // save; without an identity in this reply the caller has nothing to re-fence
+    // to, and every call that could tell it is itself refused.
+    return { saved: true, workflow, ...outcome, ...saveReplyIdentity(liveWorkflowListActive().activeIdentity, { savedAs: !!outcome.saved_as }) };
   },
 
   async workflow_save_as({ name }) {
     if (!name || typeof name !== "string") throw new Error("name (string) is required");
     const { name: workflow, ...outcome } = await programmaticSave(name);
-    return { saved: true, workflow, ...outcome };
+    // #747 — this path ALWAYS changes which workflow is active, so it is the one
+    // that strands a caller. Report the new instance identity here.
+    return { saved: true, workflow, ...outcome, ...saveReplyIdentity(liveWorkflowListActive().activeIdentity, { savedAs: true }) };
   },
 
   // --- Workflow tabs: new / list / open / switch / rename / close ----------

--- a/web/js/lib/save-reply-identity.js
+++ b/web/js/lib/save-reply-identity.js
@@ -1,0 +1,67 @@
+/**
+ * panel#747 — a Save-As fenced the session that performed it, unrecoverably.
+ *
+ * `panel_save_workflow({name})` doing a Save-As switches the active canvas to the
+ * NEWLY CREATED workflow. The caller's session is still fenced to the instance it
+ * held BEFORE its own save, so every following `panel_*` call is refused with
+ * `workflow instance mismatch`. The agent breaks its own binding by using a
+ * documented tool exactly as documented.
+ *
+ * What made it UNRECOVERABLE is the shape of the deadlock, not the mismatch: the
+ * reply said `{saved: true, workflow: "<name>"}` and nothing else. It carried no
+ * identity, so the orchestrator had no value to re-fence to — and every call that
+ * could have told it is itself fenced. The reporter watched one stale uuid survive
+ * seven `panel_set_workflow_target({mode:"current"})` calls, an orchestrator
+ * update, several reconnects, and a browser hard reset.
+ *
+ * So the save reply now carries the identity of the workflow that is active when
+ * the save finishes. That is the one moment the panel knows the new instance and
+ * the caller does not.
+ *
+ * NEVER MINTS. The identity comes from `establishedWorkflowReplyIdentity`, a pure
+ * read: an identity that has not been established yet stays unreported, and the
+ * reply says so instead of inventing one. A reply that could establish identity
+ * would let a mere read decide what the canvas IS (#716) — the fence would then be
+ * agreeing with itself rather than observing anything.
+ */
+
+/**
+ * The identity fields a save reply should carry.
+ *
+ * @param {{routingKey?: string, uuid?: string}|null|undefined} identity the result
+ *   of `establishedWorkflowReplyIdentity(activeWorkflowRef())`, or null when the
+ *   panel has not established one.
+ * @param {{savedAs?: boolean}} [opts] `savedAs` marks a save that CHANGED which
+ *   workflow is active, which is the case that can strand the caller.
+ * @returns {object} fields to spread into the reply — `{}` when nothing is known
+ */
+export function saveReplyIdentity(identity, { savedAs = false } = {}) {
+  const uuid = typeof identity?.uuid === "string" && identity.uuid ? identity.uuid : null;
+  const routingKey =
+    typeof identity?.routingKey === "string" && identity.routingKey ? identity.routingKey : null;
+  if (!uuid && !routingKey) {
+    // Absent, not empty. Saying nothing here would read as "identity unchanged",
+    // which is the exact assumption that stranded the reporter.
+    return {
+      workflow_identity_unavailable: true,
+      workflow_identity_note:
+        "This save did not report a workflow instance identity because the panel has not " +
+        "established one for the active canvas. If a following command is refused with " +
+        "\"workflow instance mismatch\", the session is fenced to the workflow that was " +
+        "active BEFORE this save; re-target it against the live canvas rather than retrying.",
+    };
+  }
+  return {
+    ...(uuid ? { workflow_uuid: uuid } : {}),
+    ...(routingKey ? { routing_key: routingKey } : {}),
+    ...(savedAs
+      ? {
+          workflow_instance_changed: true,
+          workflow_instance_note:
+            "Save-As made a DIFFERENT workflow active. A session still fenced to the " +
+            "previous instance will have every following command refused with \"workflow " +
+            "instance mismatch\" — re-fence it to the workflow_uuid reported here.",
+        }
+      : {}),
+  };
+}


### PR DESCRIPTION
A Save-As switches the active canvas to the newly created workflow, so the session that **asked for the save** is left fenced to the instance it held beforehand. Every following `panel_*` call — including read-only ones — is refused with `workflow instance mismatch`. The agent breaks its own binding by using a documented tool as documented.

## Why it was unrecoverable rather than merely wrong

The mismatch alone would be fixable. The dead end is the shape of the reply:

```json
{ "saved": true, "workflow": "<name>" }
```

No identity. So the caller had no value to re-fence **to**, and every call that could have supplied one is itself fenced. The reporter watched one stale uuid survive seven `panel_set_workflow_target({mode:"current"})` calls, an orchestrator update, several reconnects, and a browser hard reset.

## The change

The save reply now carries the identity of the workflow that is active when the save finishes — the one moment the panel knows the new instance and the caller does not.

**It never mints.** The value comes from `establishedWorkflowReplyIdentity`, a pure read. An identity that has not been established stays unreported; a reply that could establish one would let a read decide what the canvas *is* (#716), and the fence would be agreeing with itself instead of observing anything.

**Absence is declared, not silent.** Silence reads as "identity unchanged" — precisely the assumption that stranded the reporter — so an unavailable identity says so and names the likely cause.

`workflow_save` flags the instance change only when the outcome reports a Save-As; `workflow_save_as` always does, since that path always changes which workflow is active. Flagging an in-place save would send callers to re-fence for no reason and train them to ignore the flag.

## Verification

Mutation-verified — each of these fails a test: omitting the absent-identity declaration, accepting a non-string uuid (which would build an unrecoverable fence out of garbage), and flagging an in-place save as a change. Plus a wiring test asserting **both** handlers report identity with the correct `savedAs`, because a green helper proves nothing about the reply the agent receives (#792).

Gates: `node --check`, `tsc --noEmit`, `test:unit` 3012 pass / 0 fail, control-byte scan clean.

## Scope

This is the **panel half**: the reply now carries what a re-fence needs. The orchestrator consuming it to actually re-bind the session is a separate change in `comfyui-mcp`, and it touches fence semantics — so I have not made that call here.

Refs #747