### PR TITLE
fix(reload): refuse an agent reload that unsaved work will block (#701 defect 2)

### DIFF
--- a/browser_tests/unit/reload-blocked.test.mjs
+++ b/browser_tests/unit/reload-blocked.test.mjs
@@ -17,6 +17,8 @@ import {
   armReloadBlockedNotice,
   reloadBlockedMessage,
   RELOAD_BLOCKED_AFTER_MS,
+  unsavedReloadBlockers,
+  reloadWouldBeBlockedMessage,
 } from "../../web/js/lib/reload-blocked.js";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
@@ -93,5 +95,68 @@ test("#701 WIRING: armed BEFORE the navigation, in the frontend branch", () => {
   const j = src.indexOf('u.searchParams.set("cmcpReload"', i);
   assert.ok(i !== -1, "the notice must be armed in the shipped source");
   assert.ok(j > i, "…and armed BEFORE location.replace, or the page may die first");
-  assert.match(src, /import \{ armReloadBlockedNotice \} from "\.\/lib\/reload-blocked\.js"/);
+  // The MEMBER LIST is not the invariant — #701's guard imports two more names
+  // from the same module. What must hold is that the notice comes from there.
+  assert.match(src, /import \{[^}]*armReloadBlockedNotice[^}]*\} from "\.\/lib\/reload-blocked\.js"/);
 });
+
+// panel#701 defect (2) — reproduced on the rig: with 3 unsaved workflows open,
+// panel_reload({scope:"frontend"}) reported "scheduled", the orchestrator logged
+// `panel tab disconnected`, and then nothing happened. The page never navigated
+// (no `cmcpReload` in the URL, unsaved `*` still in the title) and stopped
+// accepting script injection at all.
+//
+// beforeunload is the mechanism, and the ORDER is what turns it into a wedge: the
+// browser drops the socket first, THEN raises "Leave site?" — which nobody is
+// there to answer during an agent-commanded reload. The tab is left with neither
+// a reload nor a bridge, strictly worse than before the command.
+
+test("#701 unsaved workflows are reported as reload blockers", () => {
+  const blockers = unsavedReloadBlockers([
+    { isModified: true, filename: "a.json" },
+    { isModified: false, filename: "b.json" },
+    { isModified: true, path: "workflows/c.json" },
+  ])
+  assert.deepEqual(blockers, ["a.json", "workflows/c.json"])
+})
+
+test("#701 an UNKNOWN modified flag is not treated as unsaved work", () => {
+  // Refusing on an absent flag would make the reload unusable on any build that
+  // does not expose the field — an unobserved edit is not an observed one.
+  assert.deepEqual(unsavedReloadBlockers([{ filename: "a.json" }]), [])
+  assert.deepEqual(unsavedReloadBlockers([{ isModified: undefined }]), [])
+  assert.deepEqual(unsavedReloadBlockers([{ isModified: "yes" }]), [])
+  assert.deepEqual(unsavedReloadBlockers(null), [])
+  assert.deepEqual(unsavedReloadBlockers([]), [])
+})
+
+test("#701 a blocked reload names the tabs, the mechanism, and BOTH ways out", () => {
+  const msg = reloadWouldBeBlockedMessage(["a.json", "b.json"])
+  assert.match(msg, /Did NOT reload/)
+  assert.match(msg, /a\.json, b\.json/)
+  assert.match(msg, /drops this tab's bridge connection BEFORE/)
+  assert.match(msg, /Nothing was changed/)
+  assert.match(msg, /Save or close/)
+  assert.match(msg, /Ctrl\+Shift\+R/)
+})
+
+test("#701 WIRING: only the AGENT path refuses, and it refuses BEFORE navigating", async () => {
+  const { readFileSync } = await import("node:fs")
+  const { fileURLToPath } = await import("node:url")
+  const { dirname, join } = await import("node:path")
+  const src = readFileSync(
+    join(dirname(fileURLToPath(import.meta.url)), "../../web/js/comfyui-mcp-panel.js"),
+    "utf8",
+  )
+  const i = src.indexOf('if (scope === "frontend")')
+  assert.ok(i > 0)
+  const block = src.slice(i, i + 2600)
+  // The guard is gated on the commanded path — a user standing at the keyboard
+  // can answer the dialog, so their reload must still proceed.
+  assert.match(block, /if \(origin === "agent"\)[\s\S]{0,400}unsavedReloadBlockers/)
+  // …and it must return BEFORE the navigation, not merely warn about it.
+  const guardAt = block.indexOf("unsavedReloadBlockers")
+  const navAt = block.indexOf("cmcpReload")
+  assert.ok(guardAt > 0 && navAt > guardAt, "the blocker check must precede the navigation")
+  assert.match(block.slice(guardAt, navAt), /return;/)
+})

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -67,7 +67,7 @@ import DOMPurify from "./vendor/purify.es.js";
 import qrcodegen from "./vendor/qrcode.esm.js";
 import { computeLayout } from "./lib/layout-engine.js";
 import { missingAssetScanMayBeStale, missingAssetScopeNote } from "./lib/missing-asset-scope.js";
-import { armReloadBlockedNotice } from "./lib/reload-blocked.js";
+import { armReloadBlockedNotice, unsavedReloadBlockers, reloadWouldBeBlockedMessage } from "./lib/reload-blocked.js";
 import { pressableWidgetHint } from "./lib/pressable-widget.js";
 import { looksLikeApiWorkflow, apiLoadShortfall, apiLoadNote } from "./lib/api-workflow-load.js";
 import { readPackImportFailures } from "./lib/pack-import-failures.js";
@@ -24857,6 +24857,23 @@ function buildPanel() {
       // session id persists in sessionStorage, so we reconnect + resume on load.
       // Arm the reopen flag so our sidebar tab re-activates after the reload
       // (ComfyUI won't, since our tab isn't registered yet when it restores).
+      // #701 defect (2) — an AGENT-commanded reload must not start something the
+      // browser will refuse to finish. With unsaved work open, `beforeunload`
+      // blocks the navigation, and it drops this tab's socket BEFORE raising the
+      // dialog: the tab ends up with no reload and no bridge, and nobody is at the
+      // keyboard to answer the prompt. Reproduced on the rig with 3 unsaved
+      // workflows — "soft reload (frontend) scheduled", then a disconnect, then
+      // nothing, with the page never navigating.
+      //
+      // A USER-initiated reload still proceeds: they are right there and can
+      // answer the dialog. Only the commanded path refuses.
+      if (origin === "agent") {
+        const blockers = unsavedReloadBlockers(app?.extensionManager?.workflow?.openWorkflows);
+        if (blockers.length) {
+          appendSystem(reloadWouldBeBlockedMessage(blockers));
+          return;
+        }
+      }
       ssSet(SIDEBAR_REOPEN_KEY, "1");
       appendSystem("Reloading the panel UI (new frontend code)…");
       // #584 — the cmcpReload page-URL param busts only the top document; the

--- a/web/js/lib/reload-blocked.js
+++ b/web/js/lib/reload-blocked.js
@@ -73,3 +73,65 @@ export function reloadBlockedMessage() {
     "appear disconnected until the reload completes or is dismissed."
   );
 }
+
+/**
+ * The open workflows whose unsaved edits will make the browser block a
+ * programmatic navigation.
+ *
+ * panel#701 defect (2) — reproduced on the rig: with 3 unsaved workflows open,
+ * `panel_reload({scope:"frontend"})` reported "soft reload (frontend) scheduled",
+ * the orchestrator logged `panel tab disconnected`, and then nothing. The page
+ * never navigated (the URL still lacked `cmcpReload`, the title still carried its
+ * unsaved `*`) and stopped accepting script injection at all.
+ *
+ * `beforeunload` is why, and the ORDER is what makes it a wedge rather than a
+ * no-op: the browser tears the socket down first and only then puts up the
+ * "Leave site?" dialog. Nobody is at the keyboard to answer it during an
+ * agent-commanded reload, so the tab is left with no navigation AND no bridge —
+ * strictly worse off than before the command.
+ *
+ * We must NOT suppress the dialog. It is the only thing standing between an
+ * agent-issued reload and someone's unsaved graph.
+ *
+ * So detect it instead, and don't start something that cannot finish.
+ *
+ * @param {Array<{isModified?: boolean, filename?: string, path?: string, key?: string}>} openWorkflows
+ * @returns {string[]} human-readable labels of the blocking tabs
+ */
+export function unsavedReloadBlockers(openWorkflows) {
+  if (!Array.isArray(openWorkflows)) return [];
+  const out = [];
+  for (const w of openWorkflows) {
+    // Only a DEFINITE modification blocks. An absent/unknown flag is not
+    // evidence of unsaved work, and refusing on it would make the reload
+    // unusable on any build that does not expose the field.
+    if (w?.isModified !== true) continue;
+    const label =
+      (typeof w.filename === "string" && w.filename) ||
+      (typeof w.path === "string" && w.path) ||
+      (typeof w.key === "string" && w.key) ||
+      "an unsaved workflow";
+    if (!out.includes(label)) out.push(label);
+  }
+  return out;
+}
+
+/**
+ * What to say instead of navigating. Names the tabs, the mechanism, and the two
+ * ways forward — a refusal without a route out is just a different dead end.
+ *
+ * @param {string[]} blockers
+ */
+export function reloadWouldBeBlockedMessage(blockers) {
+  const list = blockers.join(", ");
+  const many = blockers.length > 1;
+  return (
+    `Did NOT reload the panel: ${many ? "these workflows have" : "this workflow has"} unsaved ` +
+    `changes — ${list}. The browser blocks a scripted navigation while unsaved work is open, ` +
+    `and it drops this tab's bridge connection BEFORE showing the "Leave site?" dialog — so ` +
+    `reloading now would leave the tab with neither a reload nor a connection, and no one at ` +
+    `the keyboard to answer the prompt. Nothing was changed. Save or close ` +
+    `${many ? "those tabs" : "that tab"} and ask again, or reload the tab yourself ` +
+    `(Ctrl+Shift+R) and confirm the dialog.`
+  );
+}


### PR DESCRIPTION
Reproduced on the rig — released panel 0.11.44, ComfyUI 0.30.2, 3 unsaved workflows open:

```
panel_reload({scope:"frontend"})  ->  "soft reload (frontend) scheduled"
orchestrator log                  ->  panel tab disconnected: tmp:c251
…then nothing.
```

The page never navigated: the URL still lacked the `cmcpReload` cache-bust, the title still carried its unsaved `*`, and the tab stopped accepting script injection entirely.

## Why it wedges rather than no-ops

`beforeunload` blocks the navigation — but the **order** is what does the damage. The browser tears the socket down **first**, and only then raises "Leave site?". During an agent-commanded reload nobody is at the keyboard to answer it, so the tab is left with **no navigation and no bridge** — strictly worse off than before the command ran.

Suppressing the dialog is not on the table: it is the only thing standing between an agent-issued reload and someone's unsaved graph.

## The change

Don't start something that cannot finish. A commanded frontend reload now checks the open workflows for a definite `isModified`; if any are found it reports which tabs block it, why the connection would drop, that **nothing was changed**, and both ways forward — instead of navigating.

- A **user**-initiated reload still proceeds. They are standing there and can answer the dialog. Only the commanded path refuses.
- An **absent or unknown** modified flag does not block. An unobserved edit is not an observed one, and refusing on it would make the reload unusable on any build that doesn't expose the field.

## Verification

Mutation-verified: dropping the import, ungating the guard from `origin === "agent"`, and warning-but-still-navigating each fail a test.

Worth flagging: the ungate mutation **initially "survived"**. Its anchor substring-matched an unrelated 8-space `if (origin === "agent") {` about 1,700 lines earlier, so it was never applied to the guard at all — the mutation tested nothing. Re-run against a unique anchor with the occurrence count asserted (2 → 1), it fails as it should. A mutation you don't confirm landed is not evidence.

One pre-existing test also needed updating: it pinned `import { armReloadBlockedNotice }` as the sole member of that import. The member list was never the invariant — that the notice comes from that module is — so it now asserts the intent and still bites when the import is removed.

Gates: `node --check`, `tsc --noEmit`, `test:unit` 3016 pass / 0 fail, control-byte scan clean on all three files.

Covers **defect (2)** only. Defect (1) shipped in 0.11.44 via #720; defect (3) is untouched.

Refs #701