### PR TITLE
fix(reload): the soft_reload reply reports the refusal, not "scheduled" (#701)

### DIFF
--- a/browser_tests/unit/reload-blocked.test.mjs
+++ b/browser_tests/unit/reload-blocked.test.mjs
@@ -160,3 +160,32 @@ test("#701 WIRING: only the AGENT path refuses, and it refuses BEFORE navigating
   assert.ok(guardAt > 0 && navAt > guardAt, "the blocker check must precede the navigation")
   assert.match(block.slice(guardAt, navAt), /return;/)
 })
+
+test("#701 WIRING: the soft_reload REPLY reports the refusal, before scheduling anything", async () => {
+  // Live-verified on the rig that the guard works and the socket survives — and
+  // that the agent was still told "soft reload (frontend) scheduled", with the
+  // panel-side notice nowhere the agent can read it. A command that reports the
+  // REQUEST instead of the observed EFFECT is the defect, not the navigation.
+  const { readFileSync } = await import("node:fs")
+  const { fileURLToPath } = await import("node:url")
+  const { dirname, join } = await import("node:path")
+  const src = readFileSync(
+    join(dirname(fileURLToPath(import.meta.url)), "../../web/js/comfyui-mcp-panel.js"),
+    "utf8",
+  )
+  const i = src.indexOf('msg.cmd === "soft_reload"')
+  assert.ok(i > 0)
+  const block = src.slice(i, i + 1800)
+  // The blockers are consulted in the command handler…
+  assert.match(block, /unsavedReloadBlockers\(app\?\.extensionManager\?\.workflow\?\.openWorkflows\)/)
+  // …the refusal becomes the REPLY…
+  assert.match(block, /result = reloadWouldBeBlockedMessage\(reloadBlockers\)/)
+  // …and "scheduled" + the actual reload are the ELSE branch, so a blocked
+  // reload can never be reported as scheduled.
+  const refusalAt = block.indexOf("reloadWouldBeBlockedMessage(reloadBlockers)")
+  const schedAt = block.indexOf("scheduled`")
+  assert.ok(refusalAt > 0 && schedAt > refusalAt, "the refusal must be decided before the scheduled reply")
+  assert.match(block.slice(refusalAt, schedAt), /\} else \{/)
+  // Only the frontend scope is gated — an orchestrator respawn does not navigate.
+  assert.match(block, /scope === "frontend"\s*\?\s*unsavedReloadBlockers/)
+})

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -15061,8 +15061,25 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
             // flow (SOFT_RELOAD_KEY) continues the conversation afterward.
             if (!onReload) throw new Error("This panel build can't soft-reload.");
             const scope = msg.scope === "frontend" ? "frontend" : "orchestrator";
-            result = `soft reload (${scope}) scheduled`;
-            setTimeout(() => onReload(scope), 60);
+            // #701 — decide BEFORE replying. The guard that stops a doomed
+            // frontend reload runs 60ms later inside onReload, by which point
+            // this command has already told the agent "scheduled". Live-verified
+            // on the rig: the tab correctly did NOT navigate and its socket
+            // survived, and the agent was still told the reload was scheduled —
+            // so it has no reason to look, and the panel-side notice it does
+            // emit is not something the agent can read.
+            //
+            // Report what will actually happen, on the reply the caller gets.
+            const reloadBlockers =
+              scope === "frontend"
+                ? unsavedReloadBlockers(app?.extensionManager?.workflow?.openWorkflows)
+                : [];
+            if (reloadBlockers.length) {
+              result = reloadWouldBeBlockedMessage(reloadBlockers);
+            } else {
+              result = `soft reload (${scope}) scheduled`;
+              setTimeout(() => onReload(scope), 60);
+            }
           } else if (msg.cmd === "set_todo") {
             // Render/update the agent's live TODO checklist in the footer tray.
             const items = Array.isArray(msg.items) ? msg.items : [];


### PR DESCRIPTION
Follow-up to #801, found by live-verifying it rather than trusting its green unit tests.

#801 stopped the wedge — a commanded frontend reload with unsaved work no longer navigates, so the tab keeps its bridge instead of being left with neither a reload nor a connection. Confirmed on the rig: `navigated = false`, `socket alive = true`.

The same probe showed the fix was **half done**:

```
PROBE reply  = "soft reload (frontend) scheduled"
PROBE system message = (not in document text)
```

The guard runs 60ms later inside `onReload`, by which point the command has already replied. And the notice it emits goes to the panel transcript via `appendSystem` — which the probe could not locate anywhere in the document, and which the agent could not read regardless.

So the caller was told its reload was scheduled, given no reason to check, and left with a panel that had correctly declined. A command reporting the **request** instead of the observed **effect**.

## The change

Decide before replying. The frontend scope consults the blockers in the command handler, and the refusal — naming the tabs, the mechanism, that nothing changed, and both ways forward — becomes the reply. `"scheduled"` and the actual reload move into the `else` branch, so a blocked reload can never be reported as scheduled. The orchestrator scope is untouched; it does not navigate.

## Live-verified, with the change served through the pack junction

```
reply        -> "Did NOT reload the panel: this workflow has unsaved changes — Unsaved Workflow. …"
navigated    -> false
socket alive -> true
```

Mutation-verified: replying `"scheduled"` regardless fails the wiring test, with a unique anchor and the occurrence count asserted — after an earlier mutation in this same area silently hit the wrong site.

Gates: `node --check`, `tsc --noEmit`, `test:unit` clean, control-byte scan clean.

Refs #701