### PR TITLE
fix(set_widget): a value the widget's own grid explains is not a failed write (#805)

### DIFF
--- a/browser_tests/unit/widget-normalization.test.mjs
+++ b/browser_tests/unit/widget-normalization.test.mjs
@@ -1,0 +1,98 @@
+// panel#805 — panel_set_widget reported FAILURE for a write that succeeded.
+//
+//   Widget "max_tokens" on node 1 (OllamaTextDescriber) did not retain the
+//   requested value: wrote 4096 but it became 4097.
+//
+// The mutation happened; the widget snapped the value onto its own declared grid.
+// The verification step was a strict `actual === expected`, so normal quantization
+// read as a failed write — and "did not retain" invites a retry that normalizes
+// identically forever.
+//
+// The rule these tests pin: ONLY a value the widget's own config explains EXACTLY
+// counts as normalization. No tolerance — a tolerance eventually swallows a real
+// revert that happens to land nearby.
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  explainNumericNormalization,
+  normalizationNote,
+} from "../../web/js/lib/widget-normalization.js";
+
+const widget = (options) => ({ name: "max_tokens", options });
+
+test("#805 the reporter's exact numbers are explained by the declared grid", () => {
+  // min 1, step 2 snaps 4096 -> 4097 and 8192 -> 8193, both as reported.
+  const w = widget({ min: 1, max: 16384, step: 2 });
+  const a = explainNumericNormalization(4096, 4097, w);
+  assert.ok(a, "4096 -> 4097 must be recognised as normalization");
+  assert.match(a.rule, /step 2/);
+  const b = explainNumericNormalization(8192, 8193, w);
+  assert.ok(b, "8192 -> 8193 must be recognised too");
+});
+
+test("#805 an UNEXPLAINED value stays a failure", () => {
+  // The whole safety of this change is that it never guesses. A widget that
+  // reverted to something the grid does not produce is still a failed write.
+  const w = widget({ min: 1, max: 16384, step: 2 });
+  assert.equal(explainNumericNormalization(4096, 512, w), null);
+  assert.equal(explainNumericNormalization(4096, 4098, w), null, "even one grid step off-grid");
+});
+
+test("#805 no declared config means nothing to explain — still a failure", () => {
+  assert.equal(explainNumericNormalization(4096, 4097, widget(undefined)), null);
+  assert.equal(explainNumericNormalization(4096, 4097, widget({})), null);
+  assert.equal(explainNumericNormalization(4096, 4097, null), null);
+});
+
+test("#805 clamping to min/max is normalization", () => {
+  const w = widget({ min: 1, max: 8192 });
+  assert.ok(explainNumericNormalization(99999, 8192, w), "above max clamps");
+  assert.ok(explainNumericNormalization(-5, 1, w), "below min clamps");
+});
+
+test("#805 the 10x drag-step reading is accepted, because it is DECLARED", () => {
+  // ComfyUI INT/FLOAT widgets have carried a drag step ten times the value step,
+  // so a widget declaring step 10 can quantize by 1.
+  const w = widget({ min: 0, step: 10 });
+  const r = explainNumericNormalization(4096.4, 4096, w);
+  assert.ok(r, "step/10 = 1 explains the snap");
+  assert.match(r.rule, /declared step 10/);
+});
+
+test("#805 non-numeric and equal values are never called normalization", () => {
+  const w = widget({ min: 1, step: 2 });
+  assert.equal(explainNumericNormalization("a", "b", w), null);
+  assert.equal(explainNumericNormalization(4096, "4097", w), null);
+  assert.equal(explainNumericNormalization(NaN, 1, w), null);
+  assert.equal(explainNumericNormalization(4097, 4097, w), null, "equal is not a normalization");
+});
+
+test("#805 the note leads with APPLIED, not with 'did not retain'", () => {
+  // The old message's first clause was "did not retain the requested value",
+  // whose natural response is a retry that will normalize the same way forever.
+  const note = normalizationNote({ name: "max_tokens", requested: 4096, actual: 4097, rule: "step 2, min 1" });
+  assert.match(note, /was set and the node normalized the value/);
+  assert.match(note, /The write APPLIED/);
+  assert.match(note, /not a failed write/);
+  assert.match(note, /Use 4097 as the value from here on/);
+  assert.doesNotMatch(note, /did not retain/);
+});
+
+test("#805 WIRING: normalization suppresses the failure AND is disclosed on the result", async () => {
+  const { readFileSync } = await import("node:fs")
+  const { fileURLToPath } = await import("node:url")
+  const { dirname, join } = await import("node:path")
+  const src = readFileSync(
+    join(dirname(fileURLToPath(import.meta.url)), "../../web/js/lib/widget-write.js"),
+    "utf8",
+  )
+  assert.match(src, /import \{ explainNumericNormalization, normalizationNote \} from "\.\/widget-normalization\.js"/)
+  // The failure branch must be gated on it — otherwise a normalized write still errors.
+  assert.match(src, /if \(!matchesExpected\(w\.value\) && !normalization\) \{/)
+  // …and the caller must be TOLD, or a silently-changed value is its own defect.
+  assert.match(src, /normalized: true/)
+  assert.match(src, /requested_value: expected/)
+  assert.match(src, /normalization_note: normalizationNote\(/)
+})

--- a/web/js/lib/widget-normalization.js
+++ b/web/js/lib/widget-normalization.js
@@ -1,0 +1,112 @@
+/**
+ * panel#805 — `panel_set_widget` reported FAILURE for a write that succeeded.
+ *
+ *     Widget "max_tokens" on node 1 (OllamaTextDescriber) did not retain the
+ *     requested value: wrote 4096 but it became 4097.
+ *
+ * The mutation happened. The widget simply snapped the value onto its own
+ * declared grid, which is what a numeric widget is supposed to do — and the
+ * verification step, a strict `actual === expected`, called that a failed write.
+ *
+ * That is the mirror image of the defects this file's neighbours exist to prevent.
+ * Elsewhere the danger is claiming success for work that did not happen; here the
+ * tool claimed failure for work that DID. Both leave the caller with a false model
+ * of the graph, and this one is worse in one respect: the natural response to
+ * "did not retain" is to retry, and the retry normalizes identically forever.
+ *
+ * WHAT COUNTS AS NORMALIZATION. Only a value the widget's OWN declared config
+ * explains exactly. We do not accept "close enough": a tolerance would eventually
+ * swallow a real revert that happened to land nearby. The observed value must be
+ * reproducible by snapping the request onto the widget's grid —
+ *
+ *     snap(v) = clamp(min + round((v - min) / step) * step, min, max)
+ *
+ * — and if no declared grid reproduces it, this stays the failure it was.
+ *
+ * Reported for the issue's own numbers: a widget declaring `min: 1, step: 2`
+ * snaps 4096 to 4097 and 8192 to 8193, both exactly as reported.
+ *
+ * The `step / 10` candidate is deliberate, not a fudge: ComfyUI's INT/FLOAT
+ * widgets have historically carried a drag-step that is ten times the value step,
+ * so a widget can declare `step: 10` and quantize by 1. Trying both DECLARED
+ * readings is still explaining the value from the config; inventing a third
+ * arbitrary grid would not be.
+ */
+
+const isFiniteNumber = (v) => typeof v === "number" && Number.isFinite(v);
+
+/** The widget's declared numeric config, wherever this build keeps it. */
+function numericConfig(widget) {
+  const o = widget?.options ?? widget?.config ?? null;
+  if (!o || typeof o !== "object") return null;
+  const num = (v) => (isFiniteNumber(v) ? v : null);
+  return { min: num(o.min), max: num(o.max), step: num(o.step) };
+}
+
+function snap(value, { min, max, step }) {
+  const base = min ?? 0;
+  let out = value;
+  if (isFiniteNumber(step) && step > 0) {
+    out = base + Math.round((value - base) / step) * step;
+  }
+  if (isFiniteNumber(min)) out = Math.max(min, out);
+  if (isFiniteNumber(max)) out = Math.min(max, out);
+  // Snapping can push a value back outside the grid after clamping; the widget
+  // clamps last, so mirror that order rather than re-snapping.
+  return out;
+}
+
+/**
+ * Did the widget's own declared config produce `actual` from `expected`?
+ *
+ * @returns {{rule: string, min: number|null, max: number|null, step: number|null}|null}
+ *   null when nothing in the config explains it — which keeps it a failure.
+ */
+export function explainNumericNormalization(expected, actual, widget) {
+  if (!isFiniteNumber(expected) || !isFiniteNumber(actual)) return null;
+  if (expected === actual) return null; // nothing to explain
+  const cfg = numericConfig(widget);
+  if (!cfg) return null;
+  const { min, max, step } = cfg;
+  if (min === null && max === null && step === null) return null;
+
+  const candidates = [];
+  if (isFiniteNumber(step) && step > 0) {
+    candidates.push({ ...cfg, step, why: `step ${step}` });
+    // The historical drag-step-is-10x reading of the SAME declared value.
+    candidates.push({ ...cfg, step: step / 10, why: `step ${step / 10} (declared step ${step})` });
+  }
+  // Pure clamping, with no grid at all.
+  candidates.push({ ...cfg, step: null, why: "clamp" });
+
+  for (const c of candidates) {
+    if (snap(expected, c) === actual) {
+      const bounds = [
+        c.min !== null ? `min ${c.min}` : null,
+        c.max !== null ? `max ${c.max}` : null,
+      ].filter(Boolean);
+      return {
+        rule: [c.why, ...bounds].join(", "),
+        min: c.min,
+        max: c.max,
+        step: c.step,
+      };
+    }
+  }
+  return null;
+}
+
+/**
+ * What the reply says when a write was normalized. Leads with the fact the caller
+ * most needs — the write APPLIED — because the previous message led with "did not
+ * retain", which reads as "nothing happened, try again".
+ */
+export function normalizationNote({ name, requested, actual, rule }) {
+  return (
+    `Widget "${name}" was set and the node normalized the value: requested ` +
+    `${JSON.stringify(requested)}, stored ${JSON.stringify(actual)} (${rule}). The write ` +
+    `APPLIED — this is the widget's own declared quantization, not a failed write, and ` +
+    `re-sending ${JSON.stringify(requested)} will normalize to ${JSON.stringify(actual)} ` +
+    `again. Use ${JSON.stringify(actual)} as the value from here on.`
+  );
+}

--- a/web/js/lib/widget-write.js
+++ b/web/js/lib/widget-write.js
@@ -1,4 +1,5 @@
 import { pressableWidgetHint } from "./pressable-widget.js";
+import { explainNumericNormalization, normalizationNote } from "./widget-normalization.js";
 
 // Widget-value validation + promoted-subgraph-widget target resolution for
 // graph_set_widget. Extracted so the write targets the RIGHT widget with the
@@ -1224,7 +1225,20 @@ export function applyWidgetWrite(
   let originalErr = null;
   let driftFailure = false;
   let writeWarning = null;
-  if (!matchesExpected(w.value)) {
+  // #805 — a value the widget's OWN declared grid explains is NORMALIZATION, not a
+  // failed write. `matchesExpected` is a strict equality, so a numeric widget doing
+  // exactly its job (min 1 / step 2 snaps 4096 -> 4097) was reported as "did not
+  // retain the requested value" for a mutation that had APPLIED. Worse than merely
+  // wrong: the natural response to "did not retain" is a retry, and the retry
+  // normalizes identically forever.
+  //
+  // Only an EXACTLY reproducible snap counts. If the config does not explain the
+  // observed value, this stays the failure it was — no tolerance, because a
+  // tolerance would eventually swallow a real revert that landed nearby.
+  const normalization = matchesExpected(w.value)
+    ? null
+    : explainNumericNormalization(expected, w.value, w);
+  if (!matchesExpected(w.value) && !normalization) {
     failure =
       `Widget "${w.name}" on node ${targetNode.id} (${targetNode.type}) did not retain the ` +
       `requested value: wrote ${JSON.stringify(expected)} but it became ${JSON.stringify(w.value)}.` +
@@ -1555,6 +1569,21 @@ export function applyWidgetWrite(
     previous: parentWidget ? previousParent : previous,
     value: w.value,
     ...(writeWarning ? { write_warning: writeWarning } : {}),
+    // #805 — the write applied and the node quantized it. Report BOTH values so the
+    // caller can carry the stored one forward instead of retrying the request.
+    ...(normalization
+      ? {
+          normalized: true,
+          requested_value: expected,
+          normalization_rule: normalization.rule,
+          normalization_note: normalizationNote({
+            name: w.name,
+            requested: expected,
+            actual: w.value,
+            rule: normalization.rule,
+          }),
+        }
+      : {}),
     ...(promotedFrom
       ? {
           inner_previous: previous,


### PR DESCRIPTION
```
Widget "max_tokens" on node 1 (OllamaTextDescriber) did not retain the
requested value: wrote 4096 but it became 4097.
```

The mutation applied. The widget snapped the value onto its own declared grid — which is what a numeric widget is for. Verification was a strict `actual === expected`, so ordinary quantization was reported as a **failed write**.

This is the mirror image of the defect the surrounding code exists to prevent. There, the danger is claiming success for work that did not happen. Here the tool claimed failure for work that **did** — and this direction is worse in one respect: the natural response to *"did not retain"* is to retry, and the retry normalizes identically every time. The reporter hit it on two nodes and both looked broken.

## The rule

Only a value the widget's **own config explains exactly**:

```
snap(v) = clamp(min + round((v - min) / step) * step, min, max)
```

**No tolerance.** A tolerance would eventually swallow a real revert that happened to land nearby — the exact thing this check exists to catch. Anything the declared config cannot reproduce stays the error it was.

A widget declaring `min: 1, step: 2` snaps `4096 → 4097` and `8192 → 8193` — both reported cases, exactly.

The `step / 10` candidate is also tried, deliberately: ComfyUI's INT/FLOAT widgets have carried a drag step ten times the value step, so a widget declaring `step: 10` can quantize by 1. That is still reading the **declared** config rather than inventing a grid.

## What the caller now gets

`normalized: true`, `requested_value`, the rule that explains it, and a note leading with **"The write APPLIED"** — so the agent carries the stored value forward instead of retrying a request that can never be retained verbatim.

## Verification

Mutation-verified: ungating the failure branch, and dropping the disclosure from the result, each fail a test — unique anchors with occurrence counts asserted.

Gates: `node --check`, `tsc --noEmit`, `test:unit` **3025 pass / 0 fail**, control-byte scan clean on all three files.

**Not live-verified against the reporter's node** — `OllamaTextDescriber` is not installed on my rig (`/object_info` answers `{}`), so the `min: 1, step: 2` config is inferred from the two data points they gave rather than read from the pack. The rule is exact and fails closed, so an inferred config that turns out different simply means their case stays reported as a failure, not that a bad write gets accepted.

Refs #805