### PR TITLE
0.11.45 — the blank-panel fix reaches users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,51 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+## [0.11.45] - 2026-08-08
+
+> Covers changes since 0.11.44. Versions 0.11.42-0.11.44 shipped without CHANGELOG sections;
+> see their release commits (#709, #722, #743) until those are backfilled.
+
+### Added
+- show whether the QR's URL survives an orchestrator restart (#770)
+- return the workflow_uuid it just minted (#762)
+
+### Fixed
+- a value the widget's own grid explains is NOT a failed write (#806)
+- the soft_reload REPLY reports the refusal, not "scheduled" (#803)
+- refuse an agent reload that unsaved work will block (#801)
+- report the workflow instance a save leaves active (#800)
+- try the option key the api layer actually reads (#799)
+- scan the live graph for unavailable widget values (#745) (#798)
+- civitai_results reported an empty feed; e2e stubbed a retired endpoint (#796)
+- the internal-logs endpoint is NOT under /api — both readers were no-ops (#792)
+- an unknown node type may be a pack that FAILED TO IMPORT (#791)
+- a missing node type may be a pack that FAILED TO IMPORT (#790)
+- a union of PRIMITIVES needs no registered widget (#789)
+- find the tab button the way 1.50 marks it, at the SECOND site too (#786)
+- a blank tab is never an acceptable failure state (#785)
+- the sidebar guard must not destroy on an UNKNOWN active tab (#784)
+- say that a capture frames the WHOLE graph (#783)
+- read the reason ComfyUI logged instead of repeating the one it made up (#782)
+- a combo refresh that found nothing is not a refresh (#781)
+- API-format workflows ARE loadable — import them (#778)
+- drop the frontend version range, print what the body held (#777)
+- name the button the panel cannot press (#776)
+- disclose that missing-asset detection is load-time only (#774)
+- say when a commanded frontend reload did not happen (#773)
+- a userdata 400 says what it can mean, and where the real cause is (#772)
+- keep the upload status and the exception (#764)
+- report the comparison, not a cause the panel never observed (#763)
+- let an UNSAVED canvas publish its established identity (#761)
+- let the recovery probe through both target guards (#759)
+
+### Changed
+- give gotoStep the 15s its capability probe actually takes (#797)
+- recover 9 e2e tests — off-by-default flags and a routed mount probe (#795)
+- declare every reach into ComfyUI's own DOM (#787)
+- verify ONE node type, not the whole schema (#780)
+
+
 ## [0.11.41] - 2026-08-05
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-agent-panel"
 description = "Autonomous AI agent in the ComfyUI sidebar - local-first, bring any LLM. Run it on your Claude or ChatGPT subscription (no API keys, no extra LLM costs), on a Kimi K3 / GLM / OpenRouter key, or fully offline on free local models via Ollama, LM Studio, or llama.cpp. The agent drives your live canvas at full parity: add, wire, move and tweak nodes with Ctrl+Z undo, load whole workflows and installer packs in one shot, generate images, video and audio, browse CivitAI, and run your workflow - asking before it spends paid API credits. The sidebar UI for comfyui-mcp, the local-first, agent-native control plane for ComfyUI."
-version = "0.11.44"
+version = "0.11.45"
 license = { file = "LICENSE" }
 requires-python = ">=3.9"
 # UI-only pack: no Python deps. The frontend floor guarantees

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -865,7 +865,7 @@ const DOCS_URL = "https://comfyui-mcp.artokun.io/docs";
 // Panel version — surfaced in the "Need help?" diagnostics blob. Bump via
 // `node scripts/set-version.mjs <v>` (updates this AND pyproject together); CI
 // and the publish gate FAIL if the two ever drift, so this can't go stale.
-const PANEL_VERSION = "0.11.44";
+const PANEL_VERSION = "0.11.45";
 
 // The connected orchestrator's console URL/token (captured off the `backends`
 // bridge message — see onBackends). Drives the "API Keys" credentials frame;


### PR DESCRIPTION
## Why now

**Anyone on ComfyUI frontend 1.50.x currently has a completely blank Agent panel**, silently, with reinstalling as the natural and useless response. The fix has been sitting on `main` since this morning (#784/#785/#786) and is unreleased, so no user has it.

That is the reason for this release. The rest rides along.

## What shipped

`0.11.44..HEAD` — 33 commits.

**The blank panel (#784, #785, #786).** ComfyUI 1.50 moved the `<tabId>-tab-button` id from a CSS class to `data-testid`. Our own `installSidebarTabGuard` read "cannot identify the selected tab" as "another tab is active" and deleted `.cmcp-root` the instant `render()` attached it. The tab registered correctly, the content area stayed empty, and nothing appeared in the console — so the failure was indistinguishable from a broken install.

Verified live on a real 1.50.3 frontend (official `dist.zip`, isolated instance) as well as 1.47.12.

**The rest** continues the honest-result sweep: a value the widget's own grid explains is not a failed write (#806), `soft_reload`'s reply reports the refusal rather than "scheduled" (#803), an unknown node type may be a pack that failed to import rather than a typo (#790/#791), a userdata 400 says what it can mean (#772), a fence reports the comparison rather than a cause it never observed (#763).

## A note on the CHANGELOG section

The generator wanted to write **122 commits across four versions** under `0.11.45`, because 0.11.42–0.11.44 shipped without CHANGELOG sections and it walks back to the last documented one.

That is the same defect being fixed for GitHub Releases in `artokun/comfyui-mcp#1138` — a version's notes should describe that version, not everything since the last time someone wrote notes. So this section covers `0.11.44..HEAD` only, with an explicit pointer to the release commits for 0.11.42–0.11.44 (#709, #722, #743) rather than misattributing their work to this release.

**Backfilling those three sections is a follow-up**, deliberately not bundled into a release that users are waiting on.

## Checks

- `pyproject.toml` and `PANEL_VERSION` both at `0.11.45` (set via `scripts/set-version.mjs`, so they cannot drift — the publish gate asserts it)
- Unit suite **3025/3025**
- Control-byte scan clean on all three changed files
- No process-spawn literals in added lines (the YARA publish gate flags those even in comments)

Merging this to `main` fires the Comfy Registry publish on the `pyproject.toml` change.