### PR TITLE
fix(manager): send ONLY UpdatePackParams fields — the extras crash Manager v4 (#809)

### DIFF
--- a/browser_tests/unit/manager-update-params-shape.test.mjs
+++ b/browser_tests/unit/manager-update-params-shape.test.mjs
@@ -1,0 +1,77 @@
+// panel#809 — panel_update_node crashed BEFORE updating anything on ComfyUI-
+// Manager v4:
+//
+//   AttributeError: 'InstallPackParams' object has no attribute 'node_name'
+//     comfyui_manager/glob/manager_server.py, do_update(), line 879
+//
+// Manager v4's QueueTaskItem.params is an UNTAGGED Pydantic union with
+// InstallPackParams listed FIRST:
+//
+//   params: Union[InstallPackParams, UpdatePackParams, UpdateAllPacksParams, ...]
+//
+// InstallPackParams requires exactly {id, selected_version, mode, channel} —
+// every field the v2 update dispatch used to send ALONGSIDE node_name, "for
+// correlation parity with install (harmless if the server ignores it)". It is
+// not harmless: sending all of InstallPackParams' required fields makes THAT
+// model match FIRST, Pydantic silently drops the unrecognized node_name as an
+// extra field, and `kind: "update"` is never consulted for which model to
+// pick. do_update then reads params.node_name off an InstallPackParams object
+// and crashes — before the update itself ever runs.
+//
+// UpdatePackParams is exactly {node_name, node_ver?} and nothing else. Sending
+// ONLY those two fields is what makes it the sole match. Verified against a
+// local ComfyUI-Manager 4.2.2 install (see the issue).
+//
+// There is no live-Manager harness in this unit suite, and exercising this
+// against a real install would mutate an installed package on shared
+// infrastructure — a live end-to-end check is not appropriate verification
+// here. Source inspection is the established idiom for this class of fix in
+// this codebase (see open-workflow-fence-unreadable.test.ts's equivalent
+// pattern on the orchestrator side).
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const PANEL_JS = join(HERE, "../../web/js/comfyui-mcp-panel.js");
+
+function updateV2Block() {
+  const src = readFileSync(PANEL_JS, "utf8");
+  const fnStart = src.indexOf("async graph_update_node({");
+  assert.ok(fnStart > 0, "graph_update_node not found in the shipped source");
+  const v2Start = src.indexOf('if (dialect === "v2")', fnStart);
+  assert.ok(v2Start > fnStart, "the v2 dialect branch was not found inside graph_update_node");
+  // Bounded to the v2 branch only — the sibling v2-batch/legacy dialects build
+  // an entirely different body for a different endpoint (manager/queue/batch,
+  // not manager/queue/task) and are not subject to this Pydantic union at all.
+  return src.slice(v2Start, v2Start + 1500);
+}
+
+test("#809 the v2 update dispatch sends ONLY UpdatePackParams-shaped fields", () => {
+  const block = updateV2Block();
+  assert.match(block, /const params = \{ node_name: id, node_ver: sel \};/);
+});
+
+test("#809 the InstallPackParams-shaped extras are GONE — this is the actual fix", () => {
+  const block = updateV2Block();
+  // Any one of these present alongside node_name reproduces the union
+  // collision. Assert the exact removed fields are absent from the params
+  // object construction, not merely that node_ver/node_name are present —
+  // a regression that re-adds `id` back in without touching node_name/node_ver
+  // would still crash and must still be caught.
+  for (const leaked of ["id,\n", "selected_version:", "version: sel,", 'mode || "remote"', 'channel || "default"']) {
+    assert.ok(!block.includes(leaked), `InstallPackParams-shaped field leaked back in: ${JSON.stringify(leaked)}`);
+  }
+});
+
+test("#809 the request body still names kind:\"update\" and carries ui_id/client_id at the envelope level", () => {
+  // ui_id/client_id sit OUTSIDE the params union entirely — this is where
+  // correlation belongs, per the issue's own fix note ("ui_id already carries
+  // it at the envelope level"). Confirms the fix did not also strip envelope
+  // fields the server genuinely needs.
+  const block = updateV2Block();
+  assert.match(block, /body: \{ kind: "update", params, ui_id, client_id \}/);
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -13959,16 +13959,24 @@ const GRAPH_TOOL_EXECUTORS = {
     let methodRejected = false;
     for (;;) {
       if (dialect === "v2") {
-        const params = {
-          // The Manager's update task keys off node_name; include id too for
-          // correlation parity with install (harmless if the server ignores it).
-          node_name: id,
-          id,
-          selected_version: sel,
-          version: sel,
-          mode: mode || "remote",
-          channel: channel || "default",
-        };
+        // panel#809 — those "harmless for correlation" extras are not harmless.
+        // Manager v4's QueueTaskItem.params is an UNTAGGED Pydantic union with
+        // InstallPackParams listed FIRST. InstallPackParams needs exactly
+        // {id, selected_version, mode, channel} — every field this used to send
+        // alongside node_name — so it validated as an INSTALL, Pydantic silently
+        // dropped node_name as an unknown field, and `kind: "update"` was never
+        // consulted for which model to pick. do_update then read
+        // params.node_name off an InstallPackParams object and crashed:
+        //
+        //   AttributeError: 'InstallPackParams' object has no attribute 'node_name'
+        //
+        // UpdatePackParams is exactly {node_name, node_ver?} and nothing else —
+        // sending ONLY those two is what makes it the sole match. If `id` is
+        // ever needed for correlation, `ui_id` already carries it at the
+        // envelope level, outside the union — verified against a local Manager
+        // 4.2.2 install. The orchestrator's own update path already sends
+        // {node_name} alone and was never affected.
+        const params = { node_name: id, node_ver: sel };
         let enqueued = false;
         try {
           await managerV2("manager/queue/task", {


### PR DESCRIPTION
```
AttributeError: 'InstallPackParams' object has no attribute 'node_name'
  comfyui_manager/glob/manager_server.py, do_update(), line 879
```

`panel_update_node` crashed before updating anything, on every ComfyUI-Manager v4 host. Root-caused and verified against a local Manager 4.2.2 install by the reporter, with the exact fix specified in the issue.

## Root cause

Manager's `QueueTaskItem.params` is an **untagged** Pydantic union with `InstallPackParams` listed **first**:

```python
params: Union[InstallPackParams, UpdatePackParams, UpdateAllPacksParams, ...]
```

`InstallPackParams` requires exactly `{id, selected_version, mode, channel}` — every field the v2 update dispatch sent alongside `node_name`, "for correlation parity with install (harmless if the server ignores it)". It was not harmless: sending all of `InstallPackParams`' required fields made **that** model match first. Pydantic silently drops the unrecognized `node_name` as an extra field, and `kind: "update"` is never consulted for which model to pick. `do_update` then reads `params.node_name` off an `InstallPackParams` object and crashes.

`UpdatePackParams` is exactly `{node_name, node_ver?}` and nothing else — sending **only** those two is what makes it the sole match. If `id` is ever needed for correlation, `ui_id` already carries it at the envelope level, outside the union.

## The fix

```js
const params = { node_name: id, node_ver: sel };
```

Kept `node_ver: sel` rather than omitting it: `sel` always resolves to a caller-meaningful value (`"nightly"` when the caller explicitly requested it via `panel_update_node`'s `version` arg, else `"latest"`) — dropping it would silently lose that distinction, which the crash made moot in practice but the fix shouldn't reintroduce as a regression.

**Audited the suggestion in the issue** ("worth auditing every `manager/queue/task` body for extras"). Only one other call site exists (install) — its `params` come from `req.params`, genuinely `InstallPackParams`-shaped, not at risk of the same collision. The v2-batch/legacy dialects post to a different endpoint (`manager/queue/batch`) with a different model entirely — not subject to this union at all.

## Verification

Source inspection, not a live Manager call: reproducing this against a real install would mutate an installed package on shared infrastructure, which isn't appropriate for verification. 3 new tests confirm the corrected shape, the removed fields' absence, and the envelope-level fields survive untouched. Full unit suite: 3028 pass / 0 fail.

Mutation-verified: reverting to the original 6-field `params` object fails all 3 new tests.

Refs #809 (reported at artokun/comfyui-mcp#1128; the payload is built here)