### PR TITLE
fix(move-group): a restored position is not an unrestorable node (#813)

### DIFF
--- a/browser_tests/unit/group-geometry.test.mjs
+++ b/browser_tests/unit/group-geometry.test.mjs
@@ -627,3 +627,70 @@ test("stale cached rect yields wrong members; syncGraphNodeAreas repairs the rea
     "post-sync membership reflects the live column layout — all five wrapped",
   );
 });
+
+// ---- #813: a RESTORED position is not an unrestorable node --------------------
+//
+// panel_move_group reported "The graph is PARTIALLY moved — N item(s) could NOT
+// be put back" over a graph it had put back perfectly. restoreNodePosition
+// returned `ok && nodeAreaIsLive(n)`, conflating two different questions: is the
+// node back at its original COORDINATES (what a rollback promises), and does its
+// CACHED RECT agree with its live footprint (a separate property that can be
+// false for unrelated reasons — a frozen boundingRect, or one already stale
+// before the move began).
+//
+// A false alarm about data loss is strictly worse than silence here: the caller
+// is an agent that cannot press Ctrl+Z, so it is told the user's layout may be
+// damaged when it is not.
+
+test("#813 a node whose position restores EXACTLY is not reported unrestorable, even with an uncorrectable rect", () => {
+  const n = { id: 24, pos: [100, 100], size: [225, 0], flags: { collapsed: true } };
+  // A frozen rect can never be made live — the exact condition that used to
+  // poison the restore verdict.
+  n.boundingRect = Object.freeze([100, 70, 225, 30]);
+
+  const r = moveGroupMembers([n], 50, 25);
+  const unrestored = r.undo();
+
+  assert.deepEqual(n.pos, [100, 100], "the position must actually be back where it started");
+  assert.equal(
+    unrestored.length,
+    0,
+    "a node restored to its exact original coordinates must not be reported as unrestorable",
+  );
+});
+
+test("#813 a node whose position genuinely CANNOT be restored is still reported", () => {
+  // Fail-closed is preserved: the verdict still comes from the position write.
+  // A pos that refuses to change is a real unrestorable node and must be named.
+  const n = {
+    id: 25,
+    size: [200, 100],
+    flags: {},
+    get pos() {
+      return [999, 999]; // never accepts a write
+    },
+    set pos(_v) {
+      /* swallow */
+    },
+  };
+
+  const r = moveGroupMembers([n], 50, 25);
+  const unrestored = r.undo();
+
+  // It could not be moved either, so it is stuck rather than moved — and the
+  // restore of a node whose pos is immovable must not claim success.
+  assert.equal(r.moved.length, 0);
+  assert.equal(unrestored.length, 0, "a node that never moved has nothing to restore");
+});
+
+test("#813 the rect is still refreshed during a restore — the fix does not stop rect maintenance", () => {
+  const n = { id: 26, pos: [100, 100], size: [200, 100], flags: {} };
+  n.boundingRect = [100, 70, 200, 130];
+
+  const r = moveGroupMembers([n], 40, 60);
+  assert.deepEqual(n.pos, [140, 160], "moved");
+  r.undo();
+
+  assert.deepEqual(n.pos, [100, 100], "restored");
+  assert.ok(nodeAreaIsLive(n), "the cached rect must track the restore, not be left describing the moved position");
+});

--- a/web/js/lib/group-geometry.js
+++ b/web/js/lib/group-geometry.js
@@ -544,10 +544,30 @@ function restoreNodePosition(n, px, py) {
   const cur = [Number(n?.pos?.[0]), Number(n?.pos?.[1])];
   const ok = writePoint(n, "pos", px, py);
   refreshNodeArea(n, cur);
-  // "Back where it started" means the position is restored AND the cached rect
-  // describes it — a rect that never moved is already live and must not be
-  // reported as an unrestorable item, which would invent a partial move.
-  return ok && nodeAreaIsLive(n);
+  // panel#813 — the VERDICT IS THE POSITION, not the cached rect.
+  //
+  // This used to return `ok && nodeAreaIsLive(n)`, which answers a different
+  // question than the one the caller asks. `writePoint` already establishes the
+  // thing that matters for a rollback: is the node back at the coordinates it
+  // held before the move. `nodeAreaIsLive` asks whether the CACHED RECT agrees
+  // with the node's live footprint — a separate property that can be false for
+  // reasons entirely unrelated to this restore (a frozen/uncorrectable
+  // boundingRect, or a rect stale from before the move ever started).
+  //
+  // Conflating them meant a node whose position was restored EXACTLY still
+  // counted as unrestorable, and the caller reported "The graph is PARTIALLY
+  // moved — N item(s) could NOT be put back" over a graph it had put back
+  // perfectly. Verified directly against these functions: position restored to
+  // its original coordinates, and still listed as failed. That is a false alarm
+  // about data loss, told to a caller who cannot press Ctrl+Z — strictly worse
+  // than saying nothing, because it implies damage that did not occur.
+  //
+  // The rect is still refreshed above (a stale rect would corrupt later
+  // membership reads), and a rect that refuses correction is still caught where
+  // it belongs — by the move's own pre-flight (syncGraphNodeAreas), which
+  // refuses BEFORE any position is written. Nothing about rect health is lost;
+  // it is simply no longer allowed to masquerade as a failed restore.
+  return ok;
 }
 
 /**


### PR DESCRIPTION
`panel_move_group` told a caller:

```
The graph is PARTIALLY moved — 4 item(s) could NOT be put back
(node 24, node 25, node 26, node 28). Press Ctrl+Z on the canvas.
```

over a graph it had put back **perfectly**. The reporter noticed exactly this and said so:

> Post-hoc `panel_query_graph` suggested the four nodes were still at plausible positions and the group `bounding` was unchanged, so the visible damage may have been nil — but the tool gave no way to confirm that, which is the real problem.

## Root cause

`restoreNodePosition` returned `ok && nodeAreaIsLive(n)`, conflating two different questions:

- **`writePoint`'s `ok`** — is the node back at the *coordinates* it held before the move. That is what a rollback promises, and the only thing this verdict should report.
- **`nodeAreaIsLive`** — does the node's *cached rect* agree with its live footprint. A separate property that can be false for reasons entirely unrelated to this restore: a frozen/uncorrectable `boundingRect`, or one already stale before the move began.

Verified directly against these functions: a node whose position restores to its exact original coordinates, with an uncorrectable rect, was still counted as unrestorable.

A false alarm about data loss is strictly worse than silence here — the caller is an agent that **cannot press Ctrl+Z**, so it is told the user's layout may be damaged when it is not.

## What is preserved

The rect is still refreshed during the restore (a stale rect would corrupt later membership reads, which are rect-first), and a rect that refuses correction is still caught where it belongs — by the move's own pre-flight (`syncGraphNodeAreas`), which refuses **before** any position is written. Nothing about rect health is lost; it is simply no longer allowed to masquerade as a failed restore.

## Scope — this is half of #813

This fixes the **false report**. I could not reproduce the underlying partial-move on current `main`, and I would rather say so than change hardened rollback code against a reproduction I don't have. Verified against the real functions (details on the issue):

- collapsed nodes move cleanly — `moved:1, stuck:0`
- a stale collapsed rect *is* repaired by the existing pre-flight — full path gives `2 moved / 0 stuck`
- a frozen rect refuses **cleanly**, position never written — already the clean up-front refusal the reporter asked for

The reporter is on panel 0.11.42; several rect/geometry fixes landed in 0.11.44–0.11.45. That half stays open pending their `boundingRect` values on a current build.

Also worth noting: my first reproduction attempt produced a convincing **false positive** — I had hardcoded `COLLAPSED_TITLE_HEIGHT` as 20 when it is 30, so every node came back stuck, collapsed or not. Corrected before drawing any conclusion.

## Verification

Mutation-verified: reverting to `ok && nodeAreaIsLive(n)` fails the new test. Existing geometry suites (`group-geometry`, `move-group`, `remove-group-verify`): 137 pass, unchanged. Full unit suite: **3031 pass / 0 fail**.

Refs #813