### PR TITLE
feat(chat): collapse/expand large media inline in the transcript (#818)

### DIFF
--- a/browser_tests/unit/media-collapse.test.mjs
+++ b/browser_tests/unit/media-collapse.test.mjs
@@ -1,0 +1,298 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+import {
+  MEDIA_COLLAPSE_KEY,
+  MAX_COLLAPSED_ENTRIES,
+  mediaCollapseId,
+  createMediaCollapseStore,
+} from "../../web/js/lib/media-collapse.js";
+
+// Per-item collapse state for chat media cards (#818). A run that produces a 4K
+// still or a 15-second clip renders at full card width in the transcript
+// forever; the only existing affordance (⛶) goes the other way. These tests pin
+// the store that remembers what the user hid — the identity it keys on, the
+// bounds that keep it out of sessionStorage's way, and the degradation when
+// storage refuses to play along.
+
+function memoryStorage(initial = {}) {
+  const values = new Map(Object.entries(initial));
+  return {
+    values,
+    getItem: (k) => (values.has(k) ? values.get(k) : null),
+    setItem: (k, v) => values.set(k, v),
+  };
+}
+
+// ── Identity ───────────────────────────────────────────────────────────────
+
+test("the id is stable for one url and different for another", () => {
+  const a = mediaCollapseId("/view?filename=out_00001_.png&type=output");
+  assert.equal(a, mediaCollapseId("/view?filename=out_00001_.png&type=output"));
+  assert.notEqual(a, mediaCollapseId("/view?filename=out_00002_.png&type=output"));
+});
+
+test("the id is fixed width regardless of url size — a data: URI cannot bloat storage", () => {
+  const tiny = mediaCollapseId("/view?filename=a.png");
+  const huge = mediaCollapseId(`data:image/png;base64,${"A".repeat(4_000_000)}`);
+  assert.equal(tiny.length, 16);
+  assert.equal(huge.length, 16);
+  assert.match(huge, /^[0-9a-f]{16}$/);
+});
+
+test("two long urls sharing a head and tail still differ — the length is keyed in", () => {
+  // The sampled hash reads only the ends, which is exactly the shape a query
+  // string variant takes. Without the length in the key these would collide.
+  const head = "x".repeat(600);
+  const tail = "y".repeat(600);
+  assert.notEqual(
+    mediaCollapseId(`${head}AAAA${tail}`),
+    mediaCollapseId(`${head}AAAAA${tail}`),
+  );
+});
+
+test("nothing keyable is null, not a shared bucket every card falls into", () => {
+  assert.equal(mediaCollapseId(""), null);
+  assert.equal(mediaCollapseId("   "), null);
+  assert.equal(mediaCollapseId(null), null);
+  assert.equal(mediaCollapseId(undefined), null);
+  assert.equal(mediaCollapseId(42), null);
+  assert.equal(mediaCollapseId({}), null);
+});
+
+test("surrounding whitespace does not mint a second id for one url", () => {
+  assert.equal(mediaCollapseId(" /view?filename=a.png "), mediaCollapseId("/view?filename=a.png"));
+});
+
+// ── Round trip ─────────────────────────────────────────────────────────────
+
+test("a collapse survives a reload — a fresh store over the same storage agrees", () => {
+  const storage = memoryStorage();
+  const first = createMediaCollapseStore(storage);
+  assert.equal(first.isCollapsed("/view?filename=clip.mp4"), false);
+  first.setCollapsed("/view?filename=clip.mp4", true);
+
+  const reloaded = createMediaCollapseStore(storage);
+  assert.equal(reloaded.isCollapsed("/view?filename=clip.mp4"), true);
+  assert.equal(reloaded.isCollapsed("/view?filename=other.mp4"), false);
+});
+
+test("it writes under the panel's namespaced sessionStorage key", () => {
+  const storage = memoryStorage();
+  createMediaCollapseStore(storage).setCollapsed("/view?filename=a.png", true);
+  assert.equal(MEDIA_COLLAPSE_KEY, "comfyui-mcp.panel.collapsedMedia");
+  assert.ok(storage.values.has(MEDIA_COLLAPSE_KEY));
+  assert.deepEqual(JSON.parse(storage.values.get(MEDIA_COLLAPSE_KEY)), [
+    mediaCollapseId("/view?filename=a.png"),
+  ]);
+});
+
+test("expanding removes the id rather than leaving a tombstone", () => {
+  const storage = memoryStorage();
+  const store = createMediaCollapseStore(storage);
+  store.setCollapsed("/view?filename=a.png", true);
+  store.setCollapsed("/view?filename=a.png", false);
+  assert.deepEqual(store.ids(), []);
+  assert.equal(createMediaCollapseStore(storage).isCollapsed("/view?filename=a.png"), false);
+});
+
+test("toggle returns the state now in effect", () => {
+  const store = createMediaCollapseStore(memoryStorage());
+  assert.equal(store.toggle("/view?filename=a.png"), true);
+  assert.equal(store.isCollapsed("/view?filename=a.png"), true);
+  assert.equal(store.toggle("/view?filename=a.png"), false);
+  assert.equal(store.isCollapsed("/view?filename=a.png"), false);
+});
+
+test("collapsing twice does not duplicate the id or churn storage", () => {
+  const storage = memoryStorage();
+  let writes = 0;
+  const counted = { ...storage, setItem: (k, v) => { writes += 1; storage.setItem(k, v); } };
+  const store = createMediaCollapseStore(counted);
+  store.setCollapsed("/view?filename=a.png", true);
+  store.setCollapsed("/view?filename=a.png", true);
+  assert.equal(writes, 1);
+  assert.deepEqual(store.ids(), [mediaCollapseId("/view?filename=a.png")]);
+});
+
+test("expanding something never collapsed writes nothing", () => {
+  let writes = 0;
+  const store = createMediaCollapseStore({ getItem: () => null, setItem: () => { writes += 1; } });
+  assert.equal(store.setCollapsed("/view?filename=a.png", false), false);
+  assert.equal(writes, 0);
+});
+
+// ── Bounds ─────────────────────────────────────────────────────────────────
+
+test("the remembered list is capped, evicting the OLDEST decision", () => {
+  const storage = memoryStorage();
+  const store = createMediaCollapseStore({ ...storage, limit: 3 });
+  for (const n of [1, 2, 3, 4]) store.setCollapsed(`/view?filename=${n}.png`, true);
+  assert.equal(store.ids().length, 3);
+  assert.equal(store.isCollapsed("/view?filename=1.png"), false, "oldest evicted");
+  assert.equal(store.isCollapsed("/view?filename=4.png"), true, "newest kept");
+});
+
+test("an over-cap list already in storage is trimmed on read, newest kept", () => {
+  const ids = Array.from({ length: 5 }, (_, i) => mediaCollapseId(`/view?filename=${i}.png`));
+  const storage = memoryStorage({ [MEDIA_COLLAPSE_KEY]: JSON.stringify(ids) });
+  const store = createMediaCollapseStore({ ...storage, limit: 2 });
+  assert.deepEqual(store.ids(), ids.slice(-2));
+});
+
+test("the default cap is a real, positive bound", () => {
+  assert.ok(Number.isInteger(MAX_COLLAPSED_ENTRIES) && MAX_COLLAPSED_ENTRIES > 0);
+});
+
+test("a nonsense limit falls back to the default rather than disabling the store", () => {
+  for (const limit of [0, -5, Number.NaN, "many", null]) {
+    const store = createMediaCollapseStore({ ...memoryStorage(), limit });
+    store.setCollapsed("/view?filename=a.png", true);
+    assert.equal(store.isCollapsed("/view?filename=a.png"), true, `limit ${String(limit)}`);
+  }
+});
+
+// ── Degradation ────────────────────────────────────────────────────────────
+
+test("corrupt stored values are discarded, not repaired into false state", () => {
+  for (const raw of ["not json", "{}", '"a"', "null", "17", "[1,2,3]", '[""]']) {
+    const store = createMediaCollapseStore(memoryStorage({ [MEDIA_COLLAPSE_KEY]: raw }));
+    assert.deepEqual(store.ids(), [], `raw ${raw}`);
+  }
+});
+
+test("a mixed array keeps its usable ids and drops the junk", () => {
+  const good = mediaCollapseId("/view?filename=a.png");
+  const store = createMediaCollapseStore(
+    memoryStorage({ [MEDIA_COLLAPSE_KEY]: JSON.stringify([good, null, 7, "", good, "b"]) }),
+  );
+  assert.deepEqual(store.ids(), [good, "b"]);
+});
+
+test("a throwing getItem leaves a working, empty store instead of a broken panel", () => {
+  const store = createMediaCollapseStore({
+    getItem: () => { throw new Error("SecurityError"); },
+    setItem: () => {},
+  });
+  assert.equal(store.isCollapsed("/view?filename=a.png"), false);
+  assert.equal(store.toggle("/view?filename=a.png"), true);
+});
+
+test("a throwing setItem still holds the state for the life of the page", () => {
+  // Quota, or a privacy mode. The user clicked collapse; the card must collapse.
+  const store = createMediaCollapseStore({
+    getItem: () => null,
+    setItem: () => { throw new Error("QuotaExceededError"); },
+  });
+  assert.equal(store.setCollapsed("/view?filename=a.png", true), true);
+  assert.equal(store.isCollapsed("/view?filename=a.png"), true);
+});
+
+test("no storage at all is a working store, not a throw", () => {
+  const store = createMediaCollapseStore();
+  assert.equal(store.isCollapsed("/view?filename=a.png"), false);
+  assert.equal(store.toggle("/view?filename=a.png"), true);
+  assert.equal(store.isCollapsed("/view?filename=a.png"), true);
+});
+
+test("an unkeyable url reports the state asked for and persists nothing", () => {
+  const storage = memoryStorage();
+  const store = createMediaCollapseStore(storage);
+  assert.equal(store.setCollapsed("", true), true);
+  assert.equal(store.isCollapsed(""), false, "nothing to remember it by");
+  assert.equal(storage.values.has(MEDIA_COLLAPSE_KEY), false);
+});
+
+test("ids() hands out a copy — a caller cannot mutate the store's list", () => {
+  const store = createMediaCollapseStore(memoryStorage());
+  store.setCollapsed("/view?filename=a.png", true);
+  store.ids().push("injected");
+  assert.equal(store.ids().length, 1);
+});
+
+// ── The panel wiring these tests cannot reach directly ─────────────────────
+// attachMediaCollapse lives in the DOM closure. These assert the specific
+// couplings whose absence would silently un-fix #818 — each one is a decision
+// argued in that function's comment, and a regression would look like working
+// code.
+
+const PANEL = readFileSync(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8");
+
+test("both media painters attach the collapse control", () => {
+  for (const kind of ["image", "video"]) {
+    assert.match(
+      PANEL,
+      new RegExp(`attachMediaCollapse\\(card, \\{[\\s\\S]{0,120}kind: "${kind}"`),
+      `${kind} cards must be collapsible`,
+    );
+  }
+});
+
+test("collapsing a video releases the decoded element, and never mounts one", () => {
+  // Collapsed media is display:none, so the observer would unmount it anyway;
+  // this makes a hidden clip stop now rather than a frame later. The inverse —
+  // calling mountHolderVideo on expand — would resurrect a live <video> for a
+  // card scrolled off-screen, which is the observer fight the issue warned of.
+  assert.match(PANEL, /onCollapse: \(\) => unmountHolderVideo\(holder\)/);
+  const fn = PANEL.slice(
+    PANEL.indexOf("function attachMediaCollapse"),
+    PANEL.indexOf("function paintImage"),
+  );
+  assert.ok(fn.length > 0, "attachMediaCollapse must precede paintImage");
+  // \b excludes "unmountHolderVideo" — "n" and "m" are both word characters, so
+  // the boundary only matches a bare `mountHolderVideo` call.
+  assert.doesNotMatch(fn, /\bmountHolderVideo\b/);
+});
+
+test("the store is wired to sessionStorage, not localStorage", () => {
+  // "For the session" was the owner's decision on the issue: a collapse from
+  // last week must not follow someone into a new browser session.
+  assert.match(PANEL, /createMediaCollapseStore\(\{ getItem: ssGet, setItem: ssSet \}\)/);
+});
+
+test("collapse state is applied at paint time so a replayed card comes back hidden", () => {
+  // paintThread replays stored media through paintImage/paintVideo, so applying
+  // the state inside attachMediaCollapse is what makes reload + thread switch
+  // work without a second restore path that can drift from this one.
+  assert.match(PANEL, /apply\(mediaCollapse\.isCollapsed\(url\)\)/);
+});
+
+test("collapsed cards hide the media element itself, and hide the ⛶ with it", () => {
+  assert.match(PANEL, /\.cmcp-imgcard\.cmcp-media-collapsed > img[\s\S]{0,120}display: none/);
+  assert.match(
+    PANEL,
+    /\.cmcp-imgcard\.cmcp-media-collapsed > \.cmcp-video-holder \{ display: none; \}/,
+  );
+  assert.match(
+    PANEL,
+    /\.cmcp-imgcard\.cmcp-media-collapsed \.cmcp-media-expand \{ display: none; \}/,
+  );
+});
+
+test("a collapsed card's toggle is not hover-gated — the way back must be visible", () => {
+  assert.match(
+    PANEL,
+    /\.cmcp-imgcard\.cmcp-media-collapsed \.cmcp-media-collapse \{ opacity: 1; \}/,
+  );
+  assert.match(PANEL, /\.cmcp-imgcard\.cmcp-media-collapsed \.cmcp-media-stub \{ display: flex; \}/);
+});
+
+test("a collapsed card does not print its filename twice", () => {
+  // The stub names the file, so the caption under it would repeat it. Both
+  // media painters must therefore tag their caption for the rule to reach it.
+  assert.match(
+    PANEL,
+    /\.cmcp-imgcard\.cmcp-media-collapsed \.cmcp-media-caption \{ display: none; \}/,
+  );
+  assert.equal(
+    (PANEL.match(/cap\.className = "cmcp-media-caption";/g) || []).length,
+    2,
+    "both the image and the video painter must tag their caption",
+  );
+});
+
+test("the control cluster does not eat clicks meant for a click-to-zoom image", () => {
+  assert.match(PANEL, /\.cmcp-media-tools \{ pointer-events: none; \}/);
+  assert.match(PANEL, /\.cmcp-media-tools > button \{ pointer-events: auto; \}/);
+});

--- a/browser_tests/unit/media-collapse.test.mjs
+++ b/browser_tests/unit/media-collapse.test.mjs
@@ -7,6 +7,7 @@ import {
   MAX_COLLAPSED_ENTRIES,
   mediaCollapseId,
   createMediaCollapseStore,
+  MAX_KEYABLE_URL_LENGTH,
 } from "../../web/js/lib/media-collapse.js";
 import { MAX_MEDIA_URL_LENGTH } from "../../web/js/lib/chat-media.js";
 
@@ -34,17 +35,18 @@ test("the id is stable for one url and different for another", () => {
   assert.notEqual(a, mediaCollapseId("/view?filename=out_00002_.png&type=output"));
 });
 
-test("the id is fixed width regardless of url size — a data: URI cannot bloat storage", () => {
+test("the id is fixed width whatever the url's size — it cannot bloat storage", () => {
+  // The whole point of hashing rather than storing the url: a stored key is 16
+  // characters whether the url was 20 or 8,000.
   const tiny = mediaCollapseId("/view?filename=a.png");
-  const huge = mediaCollapseId(`data:image/png;base64,${"A".repeat(4_000_000)}`);
-  assert.equal(tiny.length, 16);
-  assert.equal(huge.length, 16);
-  assert.match(huge, /^[0-9a-f]{16}$/);
+  const long = mediaCollapseId(`/view?filename=${"a".repeat(4000)}.png`);
+  assert.match(tiny, /^[0-9a-f]{16}$/);
+  assert.match(long, /^[0-9a-f]{16}$/);
 });
 
-test("two long urls sharing a head and tail still differ — the length is keyed in", () => {
-  // The sampled hash reads only fixed windows, which is exactly the shape a
-  // query-string variant takes. Without the length in the key these collide.
+test("a url is not confusable with the string it extends", () => {
+  const base = "/view?filename=a.png";
+  assert.notEqual(mediaCollapseId(base), mediaCollapseId(`${base}&type=output`));
   const head = "x".repeat(600);
   const tail = "y".repeat(600);
   assert.notEqual(
@@ -54,69 +56,80 @@ test("two long urls sharing a head and tail still differ — the length is keyed
 });
 
 test("same length, same head and tail, different MIDDLE ⇒ different ids (codex)", () => {
-  // Head + tail + length alone aliases deterministically here, which for a
-  // `data:` URI is not far-fetched: two renders of one size from one encoder
-  // share a long header and can share a trailing chunk. Interior windows are
-  // what make this case separate.
-  const head = "h".repeat(5000);
-  const tail = "t".repeat(5000);
-  const a = `${head}${"a".repeat(5000)}${tail}`;
-  const b = `${head}${"b".repeat(5000)}${tail}`;
+  // Head + tail + length alone aliased deterministically for this pair, which
+  // for a `data:` URI is not far-fetched: two renders of one size from one
+  // encoder share a long header and can share a trailing chunk. Reading the url
+  // whole is what separates them.
+  const head = "h".repeat(2000);
+  const tail = "t".repeat(2000);
+  const a = `${head}${"a".repeat(2000)}${tail}`;
+  const b = `${head}${"b".repeat(2000)}${tail}`;
   assert.equal(a.length, b.length);
   assert.notEqual(mediaCollapseId(a), mediaCollapseId(b));
 });
 
-test("every PERSISTABLE url is hashed exactly — no sampling gap can alias one", () => {
-  // The gap only matters for urls whose collapse state can outlive the page,
-  // and the panel refuses to persist a media record over MAX_MEDIA_URL_LENGTH.
-  // Hashing in full up to a limit above that ceiling is what makes the sampler
-  // unreachable for every url that counts (codex round 2).
-  assert.ok(
-    MAX_MEDIA_URL_LENGTH <= 8192,
-    "the full-read limit must stay above the durable-url ceiling",
-  );
-  const pad = "z".repeat(MAX_MEDIA_URL_LENGTH);
-  for (const at of [1, 700, 1300, 2500, MAX_MEDIA_URL_LENGTH - 2]) {
+test("a difference ANYWHERE in a keyable url separates the ids", () => {
+  // No sampling, so no gaps: a change at any offset must be visible. An earlier
+  // revision sampled fixed windows and a difference landing between two of them
+  // keyed identically — for a persisted record that means one media item
+  // restoring another's collapse state (codex rounds 2 and 3).
+  const pad = "z".repeat(MAX_KEYABLE_URL_LENGTH);
+  for (const at of [0, 1, 700, 1300, 2500, 5000, MAX_KEYABLE_URL_LENGTH - 1]) {
     const a = `${pad.slice(0, at)}A${pad.slice(at + 1)}`;
     const b = `${pad.slice(0, at)}B${pad.slice(at + 1)}`;
-    assert.equal(a.length, MAX_MEDIA_URL_LENGTH);
+    assert.equal(a.length, MAX_KEYABLE_URL_LENGTH);
     assert.notEqual(mediaCollapseId(a), mediaCollapseId(b), `differ at index ${at}`);
   }
 });
 
-test("a difference at ANY sampled position separates the ids", () => {
-  // Over the full-read limit: head, 25%, 50%, 75%, tail — one window each. A
-  // change landing in any of them must still be visible to the hash.
-  const base = "z".repeat(200_000);
-  const ids = new Set([mediaCollapseId(base)]);
-  for (const at of [0, 0.25, 0.5, 0.75, 1]) {
-    const i = Math.min(Math.floor(base.length * at), base.length - 1);
-    ids.add(mediaCollapseId(`${base.slice(0, i)}Q${base.slice(i + 1)}`));
-  }
-  assert.equal(ids.size, 6, "every sampled position must be load-bearing");
+test("the keyable limit clears the panel's own persistable-url ceiling", () => {
+  // Every url whose collapse state can outlive the page must be keyable, or the
+  // feature quietly stops persisting for long /view links.
+  assert.ok(
+    MAX_KEYABLE_URL_LENGTH > MAX_MEDIA_URL_LENGTH,
+    `keyable ${MAX_KEYABLE_URL_LENGTH} must exceed durable ${MAX_MEDIA_URL_LENGTH}`,
+  );
+  const long = `/view?filename=${"a".repeat(MAX_MEDIA_URL_LENGTH - 20)}`;
+  assert.equal(long.length <= MAX_MEDIA_URL_LENGTH, true);
+  assert.ok(mediaCollapseId(long), "a max-length durable url must still key");
 });
 
-test("above the limit it samples, and that residual limit is documented", () => {
-  // A 200k string is a data:/blob: url — never written to a media record, so an
-  // aliased id here cannot survive a reload, and within one page the worst case
-  // is a card starting collapsed when its neighbour was the one collapsed.
-  // Pinned so the trade stays a decision rather than a surprise.
-  const pad = "z".repeat(200_000);
-  const gap = 80_000; // between the 25% (50k) and 50% (100k) windows
-  const a = `${pad.slice(0, gap)}AAAA${pad.slice(gap + 4)}`;
-  const b = `${pad.slice(0, gap)}BBBB${pad.slice(gap + 4)}`;
-  assert.equal(a.length, b.length);
-  assert.equal(mediaCollapseId(a), mediaCollapseId(b));
+test("a url too long to key EXACTLY gets no id at all, never an approximate one", () => {
+  // A persisted role:"media" message replays without being re-validated, so an
+  // imported or legacy history can carry a url no live path would write. Rather
+  // than guess which of two such items the user hid, refuse to key it: the store
+  // no-ops and the card still toggles for the life of the page.
+  const over = "z".repeat(MAX_KEYABLE_URL_LENGTH + 1);
+  assert.equal(mediaCollapseId(over), null);
+  assert.equal(mediaCollapseId(`data:image/png;base64,${"A".repeat(4_000_000)}`), null);
 });
 
-test("hashing a multi-megabyte data URI stays cheap", () => {
-  // Sampling, not reading. A thread replay paints every card at once, so an
-  // O(n) hash over several megabytes per card would be felt.
+test("an over-limit url costs persistence only — never the toggle", () => {
+  const storage = memoryStorage();
+  const store = createMediaCollapseStore(storage);
+  const over = "z".repeat(MAX_KEYABLE_URL_LENGTH + 1);
+  assert.equal(store.setCollapsed(over, true), true, "the caller is told what it asked for");
+  assert.equal(store.isCollapsed(over), false, "nothing was remembered");
+  assert.equal(storage.values.has(MEDIA_COLLAPSE_KEY), false, "and nothing was written");
+});
+
+test("keying a max-length url stays cheap", () => {
+  // Bounded by construction now — the limit is the budget.
+  const url = "z".repeat(MAX_KEYABLE_URL_LENGTH);
+  const started = process.hrtime.bigint();
+  for (let i = 0; i < 200; i += 1) mediaCollapseId(url);
+  const ms = Number(process.hrtime.bigint() - started) / 1e6;
+  assert.ok(ms < 200, `200 max-length keyings took ${ms.toFixed(1)}ms`);
+});
+
+test("a multi-megabyte data URI is rejected on LENGTH, without being read", () => {
+  // A thread replay paints every card at once, so an O(n) pass over several
+  // megabytes per card would be felt. The length check runs before any hashing.
   const huge = `data:image/png;base64,${"A".repeat(8_000_000)}`;
   const started = process.hrtime.bigint();
-  mediaCollapseId(huge);
+  assert.equal(mediaCollapseId(huge), null);
   const ms = Number(process.hrtime.bigint() - started) / 1e6;
-  assert.ok(ms < 50, `expected a bounded hash, took ${ms.toFixed(1)}ms`);
+  assert.ok(ms < 50, `expected an O(1) refusal, took ${ms.toFixed(1)}ms`);
 });
 
 test("nothing keyable is null, not a shared bucket every card falls into", () => {

--- a/browser_tests/unit/media-collapse.test.mjs
+++ b/browser_tests/unit/media-collapse.test.mjs
@@ -42,14 +42,64 @@ test("the id is fixed width regardless of url size — a data: URI cannot bloat 
 });
 
 test("two long urls sharing a head and tail still differ — the length is keyed in", () => {
-  // The sampled hash reads only the ends, which is exactly the shape a query
-  // string variant takes. Without the length in the key these would collide.
+  // The sampled hash reads only fixed windows, which is exactly the shape a
+  // query-string variant takes. Without the length in the key these collide.
   const head = "x".repeat(600);
   const tail = "y".repeat(600);
   assert.notEqual(
     mediaCollapseId(`${head}AAAA${tail}`),
     mediaCollapseId(`${head}AAAAA${tail}`),
   );
+});
+
+test("same length, same head and tail, different MIDDLE ⇒ different ids (codex)", () => {
+  // Head + tail + length alone aliases deterministically here, which for a
+  // `data:` URI is not far-fetched: two renders of one size from one encoder
+  // share a long header and can share a trailing chunk. Interior windows are
+  // what make this case separate.
+  const head = "h".repeat(5000);
+  const tail = "t".repeat(5000);
+  const a = `${head}${"a".repeat(5000)}${tail}`;
+  const b = `${head}${"b".repeat(5000)}${tail}`;
+  assert.equal(a.length, b.length);
+  assert.notEqual(mediaCollapseId(a), mediaCollapseId(b));
+});
+
+test("a difference at ANY sampled position separates the ids", () => {
+  // head, 25%, 50%, 75%, tail — one window each. A change landing in any of
+  // them must be visible to the hash.
+  const base = "z".repeat(20_000);
+  const ids = new Set([mediaCollapseId(base)]);
+  for (const at of [0, 0.25, 0.5, 0.75, 1]) {
+    const i = Math.min(Math.floor(base.length * at), base.length - 1);
+    ids.add(mediaCollapseId(`${base.slice(0, i)}Q${base.slice(i + 1)}`));
+  }
+  assert.equal(ids.size, 6, "every sampled position must be load-bearing");
+});
+
+test("the sampling limit is real and documented, not accidental", () => {
+  // Two urls of equal length agreeing in every sampled window DO collide. This
+  // is the accepted trade: the consequence is one card starting collapsed when
+  // its neighbour was the one collapsed, and reading megabytes per painted card
+  // to avoid it is the worse deal. Pinned so it stays a decision, not a surprise.
+  // For a 20k string the windows sit at 0, 5000, 10000, 15000 and 19488, each
+  // 512 wide. Offset 8000 falls in the gap between the 25% and 50% windows, so
+  // the hash never reads it.
+  const pad = "z".repeat(20_000);
+  const a = `${pad.slice(0, 8000)}AAAA${pad.slice(8004)}`;
+  const b = `${pad.slice(0, 8000)}BBBB${pad.slice(8004)}`;
+  assert.equal(a.length, b.length);
+  assert.equal(mediaCollapseId(a), mediaCollapseId(b));
+});
+
+test("hashing a multi-megabyte data URI stays cheap", () => {
+  // Sampling, not reading. A thread replay paints every card at once, so an
+  // O(n) hash over several megabytes per card would be felt.
+  const huge = `data:image/png;base64,${"A".repeat(8_000_000)}`;
+  const started = process.hrtime.bigint();
+  mediaCollapseId(huge);
+  const ms = Number(process.hrtime.bigint() - started) / 1e6;
+  assert.ok(ms < 50, `expected a bounded hash, took ${ms.toFixed(1)}ms`);
 });
 
 test("nothing keyable is null, not a shared bucket every card falls into", () => {
@@ -276,6 +326,41 @@ test("a collapsed card's toggle is not hover-gated — the way back must be visi
     /\.cmcp-imgcard\.cmcp-media-collapsed \.cmcp-media-collapse \{ opacity: 1; \}/,
   );
   assert.match(PANEL, /\.cmcp-imgcard\.cmcp-media-collapsed \.cmcp-media-stub \{ display: flex; \}/);
+});
+
+test("the image carries NO inline display — it would outrank the collapsed rule", () => {
+  // codex, #818: an inline `display:block` beats any stylesheet selector, so
+  // `.cmcp-media-collapsed > img { display: none }` was silently ignored and a
+  // collapsed image stayed on screen under its own "hidden" stub. The <img>
+  // must take `display` from the stylesheet, where the collapsed rule can win
+  // on specificity.
+  const painter = PANEL.slice(PANEL.indexOf("function paintImage"), PANEL.indexOf("function videoObserver"));
+  const inline = /img\.style\.cssText = "([^"]*)"/.exec(painter);
+  assert.ok(inline, "paintImage must still set the image's inline style");
+  assert.doesNotMatch(inline[1], /display\s*:/);
+  assert.match(PANEL, /\.cmcp-imgcard > img \{ display: block; \}/);
+});
+
+test("the video holder carries no inline display either", () => {
+  const painter = PANEL.slice(PANEL.indexOf("function paintVideo"), PANEL.indexOf("function paintAudio"));
+  const inline = /holder\.style\.cssText =\s*"([^"]*)"/.exec(painter);
+  assert.ok(inline, "paintVideo must still set the holder's inline style");
+  assert.doesNotMatch(inline[1], /display\s*:/);
+});
+
+test("no stray control characters reached the shipped sources", () => {
+  // A NUL and a U+0001 both landed inside string literals in this feature's
+  // sources during authoring — one of them made git treat the module as binary.
+  // They parse, they mostly even behave, and they are invisible in review.
+  const files = ["../../web/js/lib/media-collapse.js", "../../web/js/comfyui-mcp-panel.js"];
+  for (const rel of files) {
+    const s = readFileSync(new URL(rel, import.meta.url), "utf8");
+    const at = [...s].findIndex((ch) => {
+      const c = ch.charCodeAt(0);
+      return c < 9 || (c > 10 && c < 13) || (c > 13 && c < 32);
+    });
+    assert.equal(at, -1, `${rel} has a control character at index ${at}`);
+  }
 });
 
 test("a collapsed card does not print its filename twice", () => {

--- a/browser_tests/unit/media-collapse.test.mjs
+++ b/browser_tests/unit/media-collapse.test.mjs
@@ -8,6 +8,7 @@ import {
   mediaCollapseId,
   createMediaCollapseStore,
 } from "../../web/js/lib/media-collapse.js";
+import { MAX_MEDIA_URL_LENGTH } from "../../web/js/lib/chat-media.js";
 
 // Per-item collapse state for chat media cards (#818). A run that produces a 4K
 // still or a 15-second clip renders at full card width in the transcript
@@ -65,10 +66,28 @@ test("same length, same head and tail, different MIDDLE ⇒ different ids (codex
   assert.notEqual(mediaCollapseId(a), mediaCollapseId(b));
 });
 
+test("every PERSISTABLE url is hashed exactly — no sampling gap can alias one", () => {
+  // The gap only matters for urls whose collapse state can outlive the page,
+  // and the panel refuses to persist a media record over MAX_MEDIA_URL_LENGTH.
+  // Hashing in full up to a limit above that ceiling is what makes the sampler
+  // unreachable for every url that counts (codex round 2).
+  assert.ok(
+    MAX_MEDIA_URL_LENGTH <= 8192,
+    "the full-read limit must stay above the durable-url ceiling",
+  );
+  const pad = "z".repeat(MAX_MEDIA_URL_LENGTH);
+  for (const at of [1, 700, 1300, 2500, MAX_MEDIA_URL_LENGTH - 2]) {
+    const a = `${pad.slice(0, at)}A${pad.slice(at + 1)}`;
+    const b = `${pad.slice(0, at)}B${pad.slice(at + 1)}`;
+    assert.equal(a.length, MAX_MEDIA_URL_LENGTH);
+    assert.notEqual(mediaCollapseId(a), mediaCollapseId(b), `differ at index ${at}`);
+  }
+});
+
 test("a difference at ANY sampled position separates the ids", () => {
-  // head, 25%, 50%, 75%, tail — one window each. A change landing in any of
-  // them must be visible to the hash.
-  const base = "z".repeat(20_000);
+  // Over the full-read limit: head, 25%, 50%, 75%, tail — one window each. A
+  // change landing in any of them must still be visible to the hash.
+  const base = "z".repeat(200_000);
   const ids = new Set([mediaCollapseId(base)]);
   for (const at of [0, 0.25, 0.5, 0.75, 1]) {
     const i = Math.min(Math.floor(base.length * at), base.length - 1);
@@ -77,17 +96,15 @@ test("a difference at ANY sampled position separates the ids", () => {
   assert.equal(ids.size, 6, "every sampled position must be load-bearing");
 });
 
-test("the sampling limit is real and documented, not accidental", () => {
-  // Two urls of equal length agreeing in every sampled window DO collide. This
-  // is the accepted trade: the consequence is one card starting collapsed when
-  // its neighbour was the one collapsed, and reading megabytes per painted card
-  // to avoid it is the worse deal. Pinned so it stays a decision, not a surprise.
-  // For a 20k string the windows sit at 0, 5000, 10000, 15000 and 19488, each
-  // 512 wide. Offset 8000 falls in the gap between the 25% and 50% windows, so
-  // the hash never reads it.
-  const pad = "z".repeat(20_000);
-  const a = `${pad.slice(0, 8000)}AAAA${pad.slice(8004)}`;
-  const b = `${pad.slice(0, 8000)}BBBB${pad.slice(8004)}`;
+test("above the limit it samples, and that residual limit is documented", () => {
+  // A 200k string is a data:/blob: url — never written to a media record, so an
+  // aliased id here cannot survive a reload, and within one page the worst case
+  // is a card starting collapsed when its neighbour was the one collapsed.
+  // Pinned so the trade stays a decision rather than a surprise.
+  const pad = "z".repeat(200_000);
+  const gap = 80_000; // between the 25% (50k) and 50% (100k) windows
+  const a = `${pad.slice(0, gap)}AAAA${pad.slice(gap + 4)}`;
+  const b = `${pad.slice(0, gap)}BBBB${pad.slice(gap + 4)}`;
   assert.equal(a.length, b.length);
   assert.equal(mediaCollapseId(a), mediaCollapseId(b));
 });

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -16453,6 +16453,12 @@ const PANEL_CSS = `
    the picture. Only the buttons in it do. */
 .cmcp-media-tools { pointer-events: none; }
 .cmcp-media-tools > button { pointer-events: auto; }
+/* A media card's img takes its display FROM HERE and not from an inline style,
+   because an inline "display:block" outranks any stylesheet rule — the collapsed
+   rule below would then be silently ignored and the picture would stay on screen
+   under its own "hidden" stub (codex, #818). The video holder sets no inline
+   display, so it needs no equivalent. */
+.cmcp-imgcard > img { display: block; }
 /* Collapsed (#818). The media element is display:none rather than height-0 —
    that is what makes the video observer unmount the live <video> instead of
    leaving a decoding, looping element behind an invisible box. The stub is the
@@ -20685,7 +20691,9 @@ function buildPanel() {
     img.src = url;
     img.alt = name || "output";
     img.loading = "lazy";
-    img.style.cssText = "max-width:100%;border-radius:6px;display:block;cursor:zoom-in;";
+    // NO inline `display` — it would outrank the collapsed rule in the stylesheet
+    // and the card would never actually hide (#818). `.cmcp-imgcard > img` sets it.
+    img.style.cssText = "max-width:100%;border-radius:6px;cursor:zoom-in;";
     img.addEventListener("click", (e) => { e.stopPropagation(); openLightboxFromCard(card); });
     card.appendChild(img);
     attachMediaCollapse(card, { url, kind: "image", name, tools });

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -268,6 +268,7 @@ import {
   getEffectiveClipboard,
 } from "./lib/clipboard-store.js";
 import { createMediaRecorder } from "./lib/chat-media.js";
+import { createMediaCollapseStore } from "./lib/media-collapse.js";
 import { createLightboxModel } from "./lib/lightbox-gallery.js";
 import {
   vueNodesActive,
@@ -16428,18 +16429,51 @@ const PANEL_CSS = `
   background: var(--p-surface-800, #27272a); border: 1px solid var(--p-content-border-color, #3f3f46);
 }
 .cmcp-lightbox-open:hover { border-color: var(--p-primary-color, #60a5fa); color: var(--p-primary-color, #60a5fa); }
-/* Expand affordance on video cards — images open on click, but a video's own
-   surface is owned by its native controls, so it gets a dedicated button. */
+/* Media-card controls. Two buttons that must never be confused for each other:
+   .cmcp-media-expand (⛶) makes the media BIGGER — it opens the lightbox (#163);
+   .cmcp-media-collapse (a disclosure chevron) makes the card SMALLER in place
+   (#818). Images open the lightbox on click, but a video's own surface is owned
+   by its native controls, so only videos carry the ⛶ button. */
 .cmcp-imgcard { position: relative; }
-.cmcp-media-expand {
+.cmcp-media-tools {
   position: absolute; top: 0.4rem; right: 0.4rem; z-index: 2;
+  display: flex; gap: 0.25rem;
+}
+.cmcp-media-expand, .cmcp-media-collapse {
   width: 1.8rem; height: 1.8rem; border-radius: 6px; cursor: pointer;
   font-size: 0.95rem; line-height: 1; display: flex; align-items: center; justify-content: center;
   color: #fff; background: rgba(0,0,0,0.5); border: 1px solid rgba(255,255,255,0.25);
   opacity: 0; transition: opacity 0.12s ease;
 }
-.cmcp-imgcard:hover .cmcp-media-expand, .cmcp-media-expand:focus-visible { opacity: 1; }
-.cmcp-media-expand:hover { background: var(--p-primary-color, #3a7bd5); }
+.cmcp-imgcard:hover .cmcp-media-expand, .cmcp-media-expand:focus-visible,
+.cmcp-imgcard:hover .cmcp-media-collapse, .cmcp-media-collapse:focus-visible { opacity: 1; }
+.cmcp-media-expand:hover, .cmcp-media-collapse:hover { background: var(--p-primary-color, #3a7bd5); }
+/* The cluster is a hover target over the top-right corner of every card, and an
+   image card is click-to-zoom — so the box itself must not take clicks meant for
+   the picture. Only the buttons in it do. */
+.cmcp-media-tools { pointer-events: none; }
+.cmcp-media-tools > button { pointer-events: auto; }
+/* Collapsed (#818). The media element is display:none rather than height-0 —
+   that is what makes the video observer unmount the live <video> instead of
+   leaving a decoding, looping element behind an invisible box. The stub is the
+   only thing left, so its own toggle can NOT be hover-revealed: a control the
+   user cannot find is a card they cannot get back. */
+.cmcp-imgcard.cmcp-media-collapsed > img,
+.cmcp-imgcard.cmcp-media-collapsed > .cmcp-video-holder { display: none; }
+.cmcp-imgcard.cmcp-media-collapsed .cmcp-media-expand { display: none; }
+.cmcp-imgcard.cmcp-media-collapsed .cmcp-media-collapse { opacity: 1; }
+.cmcp-media-stub {
+  display: none; align-items: center; gap: 0.4rem; cursor: pointer;
+  min-height: 1.8rem; padding: 0.35rem 2.6rem 0.35rem 0.55rem; border-radius: 6px;
+  font-size: 0.7rem; color: var(--p-text-muted-color, #a1a1aa);
+  background: var(--p-content-hover-background, #2a2a2e);
+  border: 1px dashed var(--p-content-border-color, #3f3f46);
+}
+.cmcp-imgcard.cmcp-media-collapsed .cmcp-media-stub { display: flex; }
+/* The stub already names the file — a caption under it would say it twice. */
+.cmcp-imgcard.cmcp-media-collapsed .cmcp-media-caption { display: none; }
+.cmcp-media-stub:hover { color: var(--p-text-color, #fafafa); border-color: var(--p-primary-color, #60a5fa); }
+.cmcp-media-stub-name { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 /* Audio cards (#710) — a real <audio controls> player, and a link card for a
    kind the panel can neither draw nor play. Neither is a .cmcp-imgcard: the
    lightbox gallery collects those and renders every member as image/video. */
@@ -20210,6 +20244,12 @@ function buildPanel() {
     mediaRecorder.record(mkind, url, caption);
   }
 
+  // Per-item media collapse state (#818). sessionStorage-backed via ssGet/ssSet,
+  // so a collapse survives a reload and a thread switch inside this tab and is
+  // gone when the tab closes — the "for the session" semantics the issue asked
+  // for. See lib/media-collapse.js for why the key is a hash and not the url.
+  const mediaCollapse = createMediaCollapseStore({ getItem: ssGet, setItem: ssSet });
+
   /** Bind the agent's current session id to the open thread (for reload/resume). */
   function bindSession(sessionId) {
     const previousSessionId = thread?.sessionId || null;
@@ -20519,6 +20559,119 @@ function buildPanel() {
     openMediaLightbox(items, index);
   }
 
+  /** The absolutely-positioned control cluster on a media card. Both buttons
+   *  live here so a video's ⛶ and ▾ sit side by side instead of on top of each
+   *  other. */
+  function mediaToolsFor(card) {
+    const tools = document.createElement("div");
+    tools.className = "cmcp-media-tools";
+    card.appendChild(tools);
+    return tools;
+  }
+
+  /**
+   * Give one media card its inline collapse control (#818).
+   *
+   * WHAT COLLAPSING IS, AND WHAT IT IS NOT. This shrinks the card IN PLACE, in
+   * the transcript. It is the opposite of `.cmcp-media-expand` (⛶), which opens
+   * the lightbox — the two must not read as variations of one control, which is
+   * why one is a framing glyph and the other a disclosure chevron.
+   *
+   * HOW IT COMPOSES WITH THE VIDEO OBSERVER. `videoObserver()` swaps a
+   * `.cmcp-video-holder` between a live `<video>` and a gray placeholder as it
+   * scrolls in and out of view, and collapsing must not fight that:
+   *
+   *  - Collapsed media is `display:none`, so a collapsed holder has NO box and
+   *    the observer reports it as non-intersecting → the live `<video>` is
+   *    released exactly the way scrolling away releases it. The eager
+   *    `onCollapse` unmount here is the SAME operation done a frame earlier, so
+   *    a clip stops the instant the user hides it rather than on the next
+   *    observer cycle.
+   *  - Nothing here ever MOUNTS. Un-collapsing restores the box and the observer
+   *    decides — so expanding a card that is scrolled off-screen leaves it a
+   *    placeholder, instead of resurrecting a decoding video nobody can see.
+   *
+   * The state is applied at PAINT time, which is what makes it survive a reload
+   * and a thread switch for free: `paintThread` replays stored media through
+   * these same painters.
+   */
+  function attachMediaCollapse(card, { url, kind, name, tools, onCollapse }) {
+    const btn = document.createElement("button");
+    btn.type = "button";
+    btn.className = "cmcp-media-collapse";
+    tools.appendChild(btn);
+
+    // The only thing left in the card when collapsed, so it has to say what is
+    // hidden AND be a way back on its own — the chevron is a 1.8rem target the
+    // user has to already know about.
+    const stub = document.createElement("div");
+    stub.className = "cmcp-media-stub";
+    stub.setAttribute("role", "button");
+    stub.tabIndex = 0;
+    stub.title = `Show this ${kind}`;
+    const icon = document.createElement("span");
+    icon.setAttribute("aria-hidden", "true");
+    icon.textContent = kind === "video" ? "🎬" : "🖼";
+    const label = document.createElement("span");
+    label.className = "cmcp-media-stub-name";
+    label.textContent = name || (kind === "video" ? "Video" : "Image");
+    const hint = document.createElement("span");
+    hint.textContent = "· hidden, click to show";
+    stub.append(icon, label, hint);
+    card.appendChild(stub);
+
+    const apply = (collapsed) => {
+      card.classList.toggle("cmcp-media-collapsed", collapsed);
+      btn.textContent = collapsed ? "▸" : "▾";
+      const verb = collapsed ? "Show" : "Hide";
+      btn.title = `${verb} this ${kind}`;
+      btn.setAttribute("aria-label", `${verb} this ${kind}`);
+      btn.setAttribute("aria-expanded", collapsed ? "false" : "true");
+      if (collapsed) {
+        try {
+          onCollapse?.();
+        } catch {
+          // Releasing the <video> early is an optimisation; the observer still
+          // does it. It must never cost the user the toggle they just clicked.
+        }
+      }
+    };
+    // Re-applied when ANOTHER card showing the same media is toggled, so two
+    // cards of one output can't disagree about whether it is hidden.
+    card._cmcpApplyCollapse = apply;
+
+    // Drive the DOM from the DOM, and tell the store afterwards. A url the store
+    // cannot key on (or storage that refuses to write) then costs the user
+    // persistence only — never the ability to expand a card they collapsed.
+    const set = (collapsed) => {
+      mediaCollapse.setCollapsed(url, collapsed);
+      for (const other of log.querySelectorAll(".cmcp-imgcard")) {
+        if (other === card || other._cmcpMedia?.url !== url) continue;
+        try {
+          other._cmcpApplyCollapse?.(collapsed);
+        } catch {
+          /* one stale card must not break the toggle */
+        }
+      }
+      apply(collapsed);
+    };
+
+    btn.addEventListener("click", (e) => {
+      e.stopPropagation();
+      set(!card.classList.contains("cmcp-media-collapsed"));
+    });
+    stub.addEventListener("click", (e) => { e.stopPropagation(); set(false); });
+    stub.addEventListener("keydown", (e) => {
+      if (isImeComposing(e)) return;
+      if (e.key !== "Enter" && e.key !== " ") return;
+      e.preventDefault();
+      e.stopPropagation();
+      set(false);
+    });
+
+    apply(mediaCollapse.isCollapsed(url));
+  }
+
   function paintImage(url, name) {
     // Coerce the caption at the painter boundary — a structured/persisted caption
     // must never render (or re-persist) as "[object Object]", live OR on replay (#276).
@@ -20527,6 +20680,7 @@ function buildPanel() {
     const card = document.createElement("div");
     card.className = "cmcp-bubble agent cmcp-imgcard";
     card._cmcpMedia = { url, type: "image", caption: name || "" };
+    const tools = mediaToolsFor(card);
     const img = document.createElement("img");
     img.src = url;
     img.alt = name || "output";
@@ -20534,8 +20688,10 @@ function buildPanel() {
     img.style.cssText = "max-width:100%;border-radius:6px;display:block;cursor:zoom-in;";
     img.addEventListener("click", (e) => { e.stopPropagation(); openLightboxFromCard(card); });
     card.appendChild(img);
+    attachMediaCollapse(card, { url, kind: "image", name, tools });
     if (name) {
       const cap = document.createElement("div");
+      cap.className = "cmcp-media-caption";
       cap.style.cssText = "font-size:0.625rem;color:var(--p-text-muted-color,#a1a1aa);margin-top:0.25rem;";
       cap.textContent = name;
       card.appendChild(cap);
@@ -20617,6 +20773,7 @@ function buildPanel() {
     // A video's own surface is owned by its native controls, so it can't be
     // "click to zoom" like an image — give it a dedicated expand button that opens
     // the same in-panel lightbox (#163). The video still plays inline in the chat.
+    const tools = mediaToolsFor(card);
     const expandBtn = document.createElement("button");
     expandBtn.type = "button";
     expandBtn.className = "cmcp-media-expand";
@@ -20624,9 +20781,19 @@ function buildPanel() {
     expandBtn.setAttribute("aria-label", "View full size");
     expandBtn.innerHTML = "⛶";
     expandBtn.addEventListener("click", (e) => { e.stopPropagation(); openLightboxFromCard(card); });
-    card.appendChild(expandBtn);
+    tools.appendChild(expandBtn);
+    // Release the decoded <video> the moment it is hidden rather than waiting for
+    // the observer's next cycle (#818) — see attachMediaCollapse.
+    attachMediaCollapse(card, {
+      url,
+      kind: "video",
+      name,
+      tools,
+      onCollapse: () => unmountHolderVideo(holder),
+    });
     if (name) {
       const cap = document.createElement("div");
+      cap.className = "cmcp-media-caption";
       cap.style.cssText = "font-size:0.625rem;color:var(--p-text-muted-color,#a1a1aa);margin-top:0.25rem;";
       cap.textContent = name;
       card.appendChild(cap);

--- a/web/js/lib/media-collapse.js
+++ b/web/js/lib/media-collapse.js
@@ -41,37 +41,44 @@ export const MEDIA_COLLAPSE_KEY = "comfyui-mcp.panel.collapsedMedia";
  *  they collapsed a very long time ago comes back expanded. */
 export const MAX_COLLAPSED_ENTRIES = 300;
 
-/** How much of a url is fed to the hash from each sampled position. A ComfyUI
- *  /view link is under ~1.5 kB and lands here whole; a `data:` URI is sampled
- *  instead of read in full, so painting a card costs O(1) in the url's length
- *  rather than O(n) over several megabytes — and a thread replay paints every
- *  card at once. */
+/** Read a url of AT MOST this length in FULL. Set above the panel’s own ceiling
+ *  on a persistable media url (MAX_MEDIA_URL_LENGTH, 4096 — lib/chat-media.js),
+ *  which is what makes the sampling below unreachable for every url whose
+ *  collapse state can actually outlive the page. A ComfyUI /view link is a
+ *  couple of hundred characters; only a `data:` or `blob:` url gets anywhere
+ *  near this, and neither is persisted as a media record at all. */
+const HASH_FULL_LIMIT = 8192;
+
+/** How much of an OVER-LIMIT url is fed to the hash from each sampled position.
+ *  Reading a multi-megabyte `data:` URI in full would cost O(n) per painted
+ *  card, and a thread replay paints every card at once. */
 const HASH_SAMPLE = 512;
 
-/** Fractions of the url the sampler reads from, besides the head and the tail.
- *  Head + tail + length alone aliases DETERMINISTICALLY for two urls that share
- *  their ends and their length (codex, #818) — which for a `data:` URI is not
- *  the far-fetched case it sounds like: two renders of the same size from the
- *  same encoder share a long header and can share a trailing chunk. Interior
- *  samples make that require agreement in five separate places. */
+/** Fractions of an over-limit url the sampler reads from, besides the head and
+ *  the tail. Head + tail + length alone aliases DETERMINISTICALLY for two urls
+ *  that share their ends and their length (codex, #818) — which for a `data:`
+ *  URI is not the far-fetched case it sounds like: two renders of the same size
+ *  from the same encoder share a long header and can share a trailing chunk. */
 const HASH_INTERIOR = [0.25, 0.5, 0.75];
 
 /**
- * The bounded slice of a url the hash actually reads: the whole thing when it is
- * small, otherwise fixed windows at the head, at each HASH_INTERIOR fraction, and
- * at the tail.
+ * The slice of a url the hash actually reads.
  *
- * THIS IS A SAMPLING HASH, AND THE LIMIT IS DELIBERATE. Two urls that agree in
- * LENGTH and in every sampled window get the same id. That is accepted because of
- * what the id decides: at worst one card starts collapsed when its neighbour was
- * the one collapsed. What is NOT accepted is aliasing that a realistic pair of
- * urls hits systematically, which head + tail + length alone did (codex, #818) —
- * two renders of one size from one encoder share a long header and can share a
- * trailing chunk, so the interior windows are what separate them.
+ * Up to HASH_FULL_LIMIT that is the WHOLE url, so every url the panel can
+ * persist a collapse for is hashed exactly — no aliasing, at a cost bounded by a
+ * constant. Past it, fixed windows at the head, at each HASH_INTERIOR fraction,
+ * and at the tail.
+ *
+ * ABOVE THE LIMIT THIS IS A SAMPLING HASH, AND THAT LIMIT IS DELIBERATE. Two
+ * over-limit urls agreeing in length and in every sampled window get one id. What
+ * that can cost is bounded twice over: such a url is a `data:`/`blob:` source,
+ * which is never written to a media record, so the mixup cannot survive a reload
+ * — and within one page the worst outcome is a card starting collapsed when its
+ * neighbour was the one collapsed. Reading megabytes per painted card to remove
+ * that is the worse deal.
  */
 function hashSample(s) {
-  const windows = 2 + HASH_INTERIOR.length;
-  if (s.length <= HASH_SAMPLE * windows) return s;
+  if (s.length <= HASH_FULL_LIMIT) return s;
   const parts = [s.slice(0, HASH_SAMPLE)];
   for (const at of HASH_INTERIOR) {
     const from = Math.floor(s.length * at);

--- a/web/js/lib/media-collapse.js
+++ b/web/js/lib/media-collapse.js
@@ -13,7 +13,8 @@
 //     The url is the only stable thing a replayed card carries — but a url can
 //     also be a multi-megabyte `data:` URI, and putting one of those in
 //     sessionStorage is how you take the whole thread's storage down with it. So
-//     ids are HASHED to a fixed width, from a bounded sample of the url.
+//     ids are HASHED to a fixed width; a url too long to hash exactly gets NO id
+//     rather than an approximate one (see MAX_KEYABLE_URL_LENGTH).
 //
 //  2. STORAGE IS NOT GUARANTEED. sessionStorage throws outright in some browser
 //     privacy modes and on quota. A collapse toggle that throws while the user
@@ -41,52 +42,28 @@ export const MEDIA_COLLAPSE_KEY = "comfyui-mcp.panel.collapsedMedia";
  *  they collapsed a very long time ago comes back expanded. */
 export const MAX_COLLAPSED_ENTRIES = 300;
 
-/** Read a url of AT MOST this length in FULL. Set above the panel’s own ceiling
- *  on a persistable media url (MAX_MEDIA_URL_LENGTH, 4096 — lib/chat-media.js),
- *  which is what makes the sampling below unreachable for every url whose
- *  collapse state can actually outlive the page. A ComfyUI /view link is a
- *  couple of hundred characters; only a `data:` or `blob:` url gets anywhere
- *  near this, and neither is persisted as a media record at all. */
-const HASH_FULL_LIMIT = 8192;
-
-/** How much of an OVER-LIMIT url is fed to the hash from each sampled position.
- *  Reading a multi-megabyte `data:` URI in full would cost O(n) per painted
- *  card, and a thread replay paints every card at once. */
-const HASH_SAMPLE = 512;
-
-/** Fractions of an over-limit url the sampler reads from, besides the head and
- *  the tail. Head + tail + length alone aliases DETERMINISTICALLY for two urls
- *  that share their ends and their length (codex, #818) — which for a `data:`
- *  URI is not the far-fetched case it sounds like: two renders of the same size
- *  from the same encoder share a long header and can share a trailing chunk. */
-const HASH_INTERIOR = [0.25, 0.5, 0.75];
-
 /**
- * The slice of a url the hash actually reads.
+ * The longest url this module will key on. Above it, there IS no id (see
+ * mediaCollapseId) — the url is read in full or not at all.
  *
- * Up to HASH_FULL_LIMIT that is the WHOLE url, so every url the panel can
- * persist a collapse for is hashed exactly — no aliasing, at a cost bounded by a
- * constant. Past it, fixed windows at the head, at each HASH_INTERIOR fraction,
- * and at the tail.
+ * The alternative was a sampling hash: fixed windows at the head, the tail and a
+ * few interior fractions. It was written, and it was wrong. A sampler has gaps by
+ * construction, so two same-length urls differing only inside a gap key
+ * IDENTICALLY — and current-code admission rules are not a defence, because a
+ * persisted role:"media" message replays through paintImage/paintVideo without
+ * being re-validated (codex round 3), so an imported or legacy history can carry a
+ * url no live code path would write. Guessing which of two media items the user
+ * hid is exactly the kind of confident wrong answer this codebase refuses
+ * elsewhere, and it is not worth buying with anything.
  *
- * ABOVE THE LIMIT THIS IS A SAMPLING HASH, AND THAT LIMIT IS DELIBERATE. Two
- * over-limit urls agreeing in length and in every sampled window get one id. What
- * that can cost is bounded twice over: such a url is a `data:`/`blob:` source,
- * which is never written to a media record, so the mixup cannot survive a reload
- * — and within one page the worst outcome is a card starting collapsed when its
- * neighbour was the one collapsed. Reading megabytes per painted card to remove
- * that is the worse deal.
+ * Set well above the panel’s own ceiling on a persistable media url
+ * (MAX_MEDIA_URL_LENGTH, 4096 — lib/chat-media.js), so every url whose collapse
+ * CAN outlive the page is keyed exactly. Past it lie only `data:` and `blob:`
+ * sources, which are never written to a media record and so never come back after
+ * a reload anyway — losing their persistence costs nothing, and the toggle still
+ * works for the life of the page because the panel drives the DOM from the DOM.
  */
-function hashSample(s) {
-  if (s.length <= HASH_FULL_LIMIT) return s;
-  const parts = [s.slice(0, HASH_SAMPLE)];
-  for (const at of HASH_INTERIOR) {
-    const from = Math.floor(s.length * at);
-    parts.push(s.slice(from, from + HASH_SAMPLE));
-  }
-  parts.push(s.slice(-HASH_SAMPLE));
-  return parts.join("~");
-}
+export const MAX_KEYABLE_URL_LENGTH = 8192;
 
 /** FNV-1a, 32-bit, as an unsigned integer. */
 function fnv1a(str, seed) {
@@ -100,24 +77,24 @@ function fnv1a(str, seed) {
 }
 
 /**
- * The stable id for a media url, or null when there is nothing to key on.
+ * The stable id for a media url, or null when there is nothing to key on —
+ * including a url too long to key EXACTLY (MAX_KEYABLE_URL_LENGTH). Null is a
+ * decision, not a failure: the store no-ops, the card still toggles for the life
+ * of the page, and no other item can inherit its state.
  *
- * Two independently-seeded FNV-1a passes concatenated → 16 hex chars, i.e. a
- * 64-bit space. A collision would only mean one card starts collapsed when its
- * neighbour was the one collapsed, which is why a cryptographic digest (async,
- * and unavailable in a non-secure context) would be the wrong tool here.
- *
- * The sampled input carries the url's LENGTH plus interior windows, so two urls
- * that agree on a long head and tail — the shape query-string variants and
- * same-encoder `data:` URIs actually take — still differ.
+ * Two independently-seeded FNV-1a passes over the whole url, concatenated → 16
+ * hex chars, i.e. a 64-bit space — over the WHOLE url, so any difference at any
+ * offset shows up. A collision at this width
+ * would only mean one card starts collapsed when its neighbour was the one
+ * collapsed, which is why a cryptographic digest (async, and unavailable in a
+ * non-secure context) would be the wrong tool here.
  */
 export function mediaCollapseId(url) {
   if (typeof url !== "string") return null;
   const trimmed = url.trim();
-  if (!trimmed) return null;
-  const keyed = `${trimmed.length} ${hashSample(trimmed)}`;
-  const a = fnv1a(keyed, 0x811c9dc5);
-  const b = fnv1a(keyed, 0x01000193);
+  if (!trimmed || trimmed.length > MAX_KEYABLE_URL_LENGTH) return null;
+  const a = fnv1a(trimmed, 0x811c9dc5);
+  const b = fnv1a(trimmed, 0x01000193);
   return a.toString(16).padStart(8, "0") + b.toString(16).padStart(8, "0");
 }
 

--- a/web/js/lib/media-collapse.js
+++ b/web/js/lib/media-collapse.js
@@ -1,0 +1,198 @@
+// Per-item collapse state for chat-transcript media cards (#818).
+//
+// THE REQUEST. A run that produces a 4K still or a 15-second clip renders at
+// full card width in the log, forever. The only existing media affordance goes
+// the OTHER way — `.cmcp-media-expand` (`⛶`) opens the lightbox — so a user with
+// a tall transcript has no way to make a card take less room.
+//
+// WHY THIS IS A MODULE AND NOT FOUR LINES IN THE PAINTER. Two things here are
+// easy to get subtly wrong and impossible to test from the DOM closure:
+//
+//  1. WHAT IDENTIFIES A CARD ACROSS A RELOAD. The transcript is repainted from
+//     stored role:"media" records, so a card's identity has to survive that trip.
+//     The url is the only stable thing a replayed card carries — but a url can
+//     also be a multi-megabyte `data:` URI, and putting one of those in
+//     sessionStorage is how you take the whole thread's storage down with it. So
+//     ids are HASHED to a fixed width, from a bounded sample of the url.
+//
+//  2. STORAGE IS NOT GUARANTEED. sessionStorage throws outright in some browser
+//     privacy modes and on quota. A collapse toggle that throws while the user
+//     is clicking it is worse than one that forgets — so every read and write is
+//     guarded, and a store that cannot persist still answers correctly for the
+//     life of the page from its in-memory copy.
+//
+// WHY sessionStorage AND NOT localStorage. Decided on the issue: collapse state
+// should last "for the session". sessionStorage is exactly that — tab-scoped,
+// survives a reload and a thread switch, gone when the tab closes — and it is
+// already the panel's per-tab persistence layer (the tab id, the agent session
+// id, the currently-shown thread all live there). A collapse decision from last
+// week should not follow someone into a new browser session.
+//
+// Kept standalone (no browser globals) so it is unit-testable under
+// `node --test`; the panel injects sessionStorage's getItem/setItem.
+
+/** sessionStorage key holding the collapsed-media id list. Namespaced like every
+ *  other panel key ("comfyui-mcp.panel.*"). */
+export const MEDIA_COLLAPSE_KEY = "comfyui-mcp.panel.collapsedMedia";
+
+/** Upper bound on remembered ids. A long session can paint hundreds of cards,
+ *  and an unbounded list would grow for the whole tab's life. Oldest-first
+ *  eviction: the worst case for a user who blows past the cap is that a card
+ *  they collapsed a very long time ago comes back expanded. */
+export const MAX_COLLAPSED_ENTRIES = 300;
+
+/** How much of a url is fed to the hash from each end. A ComfyUI /view link is
+ *  under 200 chars and lands here whole; a `data:` URI is sampled instead of
+ *  read in full, so painting a card is O(1) in the url's length rather than O(n)
+ *  over several megabytes. Head + tail + length is enough to separate any two
+ *  urls the panel actually paints. */
+const HASH_SAMPLE = 512;
+
+/** FNV-1a, 32-bit, as an unsigned integer. */
+function fnv1a(str, seed) {
+  let h = seed >>> 0;
+  for (let i = 0; i < str.length; i += 1) {
+    h ^= str.charCodeAt(i);
+    // 32-bit FNV prime (16777619) via shifts — Math.imul keeps it exact.
+    h = Math.imul(h, 16777619) >>> 0;
+  }
+  return h >>> 0;
+}
+
+/**
+ * The stable id for a media url, or null when there is nothing to key on.
+ *
+ * Two independently-seeded FNV-1a passes concatenated → 16 hex chars, i.e. a
+ * 64-bit space. A collision would only mean one card starts collapsed when its
+ * neighbour was the one collapsed, which is why a cryptographic digest (async,
+ * and unavailable in a non-secure context) would be the wrong tool here.
+ *
+ * The sampled input carries the url's LENGTH, so two urls sharing a long head
+ * and tail — the shape query-string variants actually take — still differ.
+ */
+export function mediaCollapseId(url) {
+  if (typeof url !== "string") return null;
+  const trimmed = url.trim();
+  if (!trimmed) return null;
+  const sample =
+    trimmed.length <= HASH_SAMPLE * 2
+      ? trimmed
+      : `${trimmed.slice(0, HASH_SAMPLE)} ${trimmed.slice(-HASH_SAMPLE)}`;
+  const keyed = `${trimmed.length} ${sample}`;
+  const a = fnv1a(keyed, 0x811c9dc5);
+  const b = fnv1a(keyed, 0x01000193);
+  return a.toString(16).padStart(8, "0") + b.toString(16).padStart(8, "0");
+}
+
+/** Parse a persisted payload into a clean, capped id list. Anything that is not
+ *  an array of non-empty strings is discarded rather than repaired — a corrupt
+ *  value is not evidence about what the user collapsed. */
+function parseIds(raw, limit) {
+  if (typeof raw !== "string" || !raw) return [];
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return [];
+  }
+  if (!Array.isArray(parsed)) return [];
+  const seen = new Set();
+  const out = [];
+  for (const v of parsed) {
+    if (typeof v !== "string" || !v || seen.has(v)) continue;
+    seen.add(v);
+    out.push(v);
+  }
+  // Keep the MOST RECENT when a stored list is over the cap — same end that
+  // eviction drops from, so a shrunk limit behaves like repeated eviction.
+  return out.length > limit ? out.slice(out.length - limit) : out;
+}
+
+/**
+ * The collapse-state store the panel actually uses.
+ *
+ * `getItem`/`setItem` are injected (the panel passes sessionStorage's, already
+ * wrapped by ssGet/ssSet) so the whole decision path is testable off-browser.
+ * Neither is required: with no storage at all the store still works for the
+ * life of the page, which is the correct degradation for a view preference.
+ *
+ * Ids are held in memory after the first read, so a card paint never re-parses
+ * the JSON — a thread switch repaints the entire transcript at once.
+ */
+export function createMediaCollapseStore({
+  getItem,
+  setItem,
+  key = MEDIA_COLLAPSE_KEY,
+  limit = MAX_COLLAPSED_ENTRIES,
+} = {}) {
+  const cap = Number.isFinite(limit) && limit > 0 ? Math.floor(limit) : MAX_COLLAPSED_ENTRIES;
+  /** Insertion-ordered, most-recently-collapsed LAST. */
+  let ids = null;
+
+  function load() {
+    if (ids) return ids;
+    let raw = null;
+    if (typeof getItem === "function") {
+      try {
+        raw = getItem(key);
+      } catch {
+        raw = null; // storage disabled mid-session — start empty, keep working
+      }
+    }
+    ids = parseIds(raw, cap);
+    return ids;
+  }
+
+  function flush() {
+    if (typeof setItem !== "function") return false;
+    try {
+      setItem(key, JSON.stringify(ids));
+      return true;
+    } catch {
+      // Quota or a privacy mode. The in-memory list stays authoritative for this
+      // page, so the toggle the user just clicked still holds — it simply will
+      // not survive the next reload.
+      return false;
+    }
+  }
+
+  return {
+    /** Is the media at `url` currently collapsed? False for anything unkeyable. */
+    isCollapsed(url) {
+      const id = mediaCollapseId(url);
+      if (!id) return false;
+      return load().includes(id);
+    },
+
+    /** Record (or clear) the collapsed state for `url`. Returns the state that is
+     *  now in effect — always `collapsed`, so a caller can drive the DOM from the
+     *  return value whether or not anything could be persisted. */
+    setCollapsed(url, collapsed) {
+      const id = mediaCollapseId(url);
+      if (!id) return !!collapsed;
+      const list = load();
+      const at = list.indexOf(id);
+      if (collapsed) {
+        if (at >= 0) return true; // already recorded; don't churn storage
+        list.push(id);
+        // Evict from the OLD end so the newest decisions are the ones kept.
+        if (list.length > cap) list.splice(0, list.length - cap);
+      } else {
+        if (at < 0) return false;
+        list.splice(at, 1);
+      }
+      flush();
+      return !!collapsed;
+    },
+
+    /** Flip the state for `url` and return the new one. */
+    toggle(url) {
+      return this.setCollapsed(url, !this.isCollapsed(url));
+    },
+
+    /** The remembered ids, oldest first. For tests and diagnostics. */
+    ids() {
+      return [...load()];
+    },
+  };
+}

--- a/web/js/lib/media-collapse.js
+++ b/web/js/lib/media-collapse.js
@@ -41,12 +41,45 @@ export const MEDIA_COLLAPSE_KEY = "comfyui-mcp.panel.collapsedMedia";
  *  they collapsed a very long time ago comes back expanded. */
 export const MAX_COLLAPSED_ENTRIES = 300;
 
-/** How much of a url is fed to the hash from each end. A ComfyUI /view link is
- *  under 200 chars and lands here whole; a `data:` URI is sampled instead of
- *  read in full, so painting a card is O(1) in the url's length rather than O(n)
- *  over several megabytes. Head + tail + length is enough to separate any two
- *  urls the panel actually paints. */
+/** How much of a url is fed to the hash from each sampled position. A ComfyUI
+ *  /view link is under ~1.5 kB and lands here whole; a `data:` URI is sampled
+ *  instead of read in full, so painting a card costs O(1) in the url's length
+ *  rather than O(n) over several megabytes — and a thread replay paints every
+ *  card at once. */
 const HASH_SAMPLE = 512;
+
+/** Fractions of the url the sampler reads from, besides the head and the tail.
+ *  Head + tail + length alone aliases DETERMINISTICALLY for two urls that share
+ *  their ends and their length (codex, #818) — which for a `data:` URI is not
+ *  the far-fetched case it sounds like: two renders of the same size from the
+ *  same encoder share a long header and can share a trailing chunk. Interior
+ *  samples make that require agreement in five separate places. */
+const HASH_INTERIOR = [0.25, 0.5, 0.75];
+
+/**
+ * The bounded slice of a url the hash actually reads: the whole thing when it is
+ * small, otherwise fixed windows at the head, at each HASH_INTERIOR fraction, and
+ * at the tail.
+ *
+ * THIS IS A SAMPLING HASH, AND THE LIMIT IS DELIBERATE. Two urls that agree in
+ * LENGTH and in every sampled window get the same id. That is accepted because of
+ * what the id decides: at worst one card starts collapsed when its neighbour was
+ * the one collapsed. What is NOT accepted is aliasing that a realistic pair of
+ * urls hits systematically, which head + tail + length alone did (codex, #818) —
+ * two renders of one size from one encoder share a long header and can share a
+ * trailing chunk, so the interior windows are what separate them.
+ */
+function hashSample(s) {
+  const windows = 2 + HASH_INTERIOR.length;
+  if (s.length <= HASH_SAMPLE * windows) return s;
+  const parts = [s.slice(0, HASH_SAMPLE)];
+  for (const at of HASH_INTERIOR) {
+    const from = Math.floor(s.length * at);
+    parts.push(s.slice(from, from + HASH_SAMPLE));
+  }
+  parts.push(s.slice(-HASH_SAMPLE));
+  return parts.join("~");
+}
 
 /** FNV-1a, 32-bit, as an unsigned integer. */
 function fnv1a(str, seed) {
@@ -67,18 +100,15 @@ function fnv1a(str, seed) {
  * neighbour was the one collapsed, which is why a cryptographic digest (async,
  * and unavailable in a non-secure context) would be the wrong tool here.
  *
- * The sampled input carries the url's LENGTH, so two urls sharing a long head
- * and tail — the shape query-string variants actually take — still differ.
+ * The sampled input carries the url's LENGTH plus interior windows, so two urls
+ * that agree on a long head and tail — the shape query-string variants and
+ * same-encoder `data:` URIs actually take — still differ.
  */
 export function mediaCollapseId(url) {
   if (typeof url !== "string") return null;
   const trimmed = url.trim();
   if (!trimmed) return null;
-  const sample =
-    trimmed.length <= HASH_SAMPLE * 2
-      ? trimmed
-      : `${trimmed.slice(0, HASH_SAMPLE)} ${trimmed.slice(-HASH_SAMPLE)}`;
-  const keyed = `${trimmed.length} ${sample}`;
+  const keyed = `${trimmed.length} ${hashSample(trimmed)}`;
   const a = fnv1a(keyed, 0x811c9dc5);
   const b = fnv1a(keyed, 0x01000193);
   return a.toString(16).padStart(8, "0") + b.toString(16).padStart(8, "0");


### PR DESCRIPTION
> Add a collapse button for videos and images in the panel — that way we can expand and collapse large images / videos in the panel that eat up a bunch of room

The panel already had a media affordance, and it went the **other** way: `.cmcp-media-expand` (`⛶`) opens the lightbox (#163). Nothing shrank a card, so a run that produced a 4K still or a 15-second clip owned full card width in the transcript permanently.

## What this adds

A per-item disclosure chevron on every image and video card. Collapsed, the card becomes a one-line stub naming the file; the stub is itself the way back (click, Enter or Space), because once the media is gone a hover-revealed 1.8 rem button is a control the user cannot find. The two controls are deliberately not variations of each other — a framing glyph that goes bigger, a chevron that goes smaller — and the `⛶` hides while collapsed rather than floating over nothing.

## Persistence — the decision from the issue

> yes they should persist for the session, just track in session storage

`sessionStorage`, through the panel's existing `ssGet`/`ssSet`. State is applied at **paint** time, which is what makes reload and thread switch work for free: `paintThread` replays stored media through these same painters, so there is no second restore path to drift.

## Composing with the video observer, not fighting it

Both directions the issue flagged hold:

- collapsed media is `display:none`, so a collapsed `.cmcp-video-holder` has no box and the observer reports it non-intersecting — the decoded `<video>` is released exactly as scrolling away releases it. The eager `onCollapse` unmount is that same operation one frame earlier, so a hidden clip stops immediately;
- nothing in the collapse path ever **mounts**. Expanding restores the box and lets the observer decide, so un-collapsing an off-screen card leaves it a placeholder instead of resurrecting a video nobody can see.

## Review rounds

Codex found a blocker and two follow-ons, all fixed:

1. **The feature did not work for images.** `paintImage` set `display:block` in the `<img>`'s inline style, and an inline declaration outranks any stylesheet selector — so the collapsed rule was silently ignored and the picture stayed fully visible under its own "hidden" stub. The `<img>` now takes `display` from `.cmcp-imgcard > img`, where the collapsed rule wins on specificity.
2. **The url hash aliased deterministically.** Head + tail + length collided for two long urls sharing their ends — a shape `data:` URIs really take. Two rounds of narrowing the sampler each left a reachable gap, including one inside the range of urls that actually persist, so the sampler is **gone**: a url is hashed in full or gets no id at all (`MAX_KEYABLE_URL_LENGTH`, 8192, above the 4096 persistable ceiling). Null is a decision — the store no-ops, no item can inherit another's state, and the toggle still works for the page.
3. **Two stray control characters** (a NUL and a U+0001) had landed inside string literals during authoring. They parsed, they behaved, and one made git treat the module as binary so it had no reviewable diff. Removed, and a test now fails on any control character in either source.

Remaining and accepted: a 64-bit FNV collision is possible in principle (~2.4e-15 across the 300-entry store), costing at most one card starting collapsed. Documented in the module.

## Not in scope

The global "collapse media over N pixels" default — the issue records it as still open and this PR does not settle it.

## Verification

40 new unit tests. Mutation-verified: restoring the inline `display:block`, dropping the `.cmcp-imgcard > img` rule, keying an over-limit url anyway, setting the keyable limit below the durable ceiling, evicting the newest instead of the oldest, pointing the store at `localStorage`, skipping the paint-time restore, mounting a video from the collapse path, letting the control cluster eat clicks meant for a click-to-zoom image, dropping the toggle from the video painter, and reintroducing a control character each fail at least one test. Full unit suite: **3071 pass / 0 fail**.

Refs #818
