### PR TITLE
0.11.46 — a valid node stops being refused for a type its neighbour produces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+## [0.11.46] - 2026-08-08
+
+> Covers changes since 0.11.45.
+
+### Fixed
+- `panel_add_node` refused a node whose input types ARE produced by nodes already on the
+  canvas. The socket proof — "which datatypes does some installed node output?" — was being
+  read off the single-class `/object_info` payload introduced in 0.11.45 for the cheap
+  per-class existence check, so any custom link datatype produced by a SIBLING node read as
+  unproven and the refusal claimed "no installed node outputs X" while the node producing X
+  sat on the canvas. Nothing could clear it: `panel_refresh_nodes` re-registers the class,
+  which is exactly what armed the fast path. The proof is now widened against the whole
+  schema on the path that is about to refuse, so the cheap path is kept for every add that
+  does not need it (#822, #821)
+- `panel_move_group` treated a restored node position as an unrestorable node, so a
+  rollback reported failure after it had in fact succeeded (#819)
+- `panel_update_node` sent extra fields that made Manager v4's untagged Pydantic union
+  match `InstallPackParams` instead of `UpdatePackParams` and crash (#816)
+
 ## [0.11.45] - 2026-08-08
 
 > Covers changes since 0.11.44. Versions 0.11.42-0.11.44 shipped without CHANGELOG sections;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-agent-panel"
 description = "Autonomous AI agent in the ComfyUI sidebar - local-first, bring any LLM. Run it on your Claude or ChatGPT subscription (no API keys, no extra LLM costs), on a Kimi K3 / GLM / OpenRouter key, or fully offline on free local models via Ollama, LM Studio, or llama.cpp. The agent drives your live canvas at full parity: add, wire, move and tweak nodes with Ctrl+Z undo, load whole workflows and installer packs in one shot, generate images, video and audio, browse CivitAI, and run your workflow - asking before it spends paid API credits. The sidebar UI for comfyui-mcp, the local-first, agent-native control plane for ComfyUI."
-version = "0.11.45"
+version = "0.11.46"
 license = { file = "LICENSE" }
 requires-python = ">=3.9"
 # UI-only pack: no Python deps. The frontend floor guarantees

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -865,7 +865,7 @@ const DOCS_URL = "https://comfyui-mcp.artokun.io/docs";
 // Panel version — surfaced in the "Need help?" diagnostics blob. Bump via
 // `node scripts/set-version.mjs <v>` (updates this AND pyproject together); CI
 // and the publish gate FAIL if the two ever drift, so this can't go stale.
-const PANEL_VERSION = "0.11.45";
+const PANEL_VERSION = "0.11.46";
 
 // The connected orchestrator's console URL/token (captured off the `backends`
 // bridge message — see onBackends). Drives the "API Keys" credentials frame;


### PR DESCRIPTION
Release cut covering the three fixes merged since 0.11.45.

| PR | issue | what users see |
|---|---|---|
| #822 | #821 | `panel_add_node` no longer refuses a node whose input types are produced by nodes already on the canvas |
| #819 | #813 | `panel_move_group` no longer reports a failed rollback that succeeded |
| #816 | #809 | `panel_update_node` no longer crashes Manager v4 with a wrong-variant payload |

The headline fix is a regression **introduced in 0.11.45**: that release made `panel_add_node` verify one node type instead of re-downloading the whole schema (a real 1,667x saving), but the same single-class payload was also feeding the socket proof, which asks a question about the entire install. Anyone who installed a pack with custom link datatypes and tried to add its main node hit a hard refusal with a false explanation. It is worth shipping promptly for that reason.

Verified before release:
- 3044 unit tests pass
- publish gates run locally: JS syntax, tool vocabulary (34 literals, all valid), YARA registry parity over all 132 shipped files — clean
- `pyproject.toml` 0.11.46 and `PANEL_VERSION` 0.11.46 in sync (the publish gate asserts this)
- the #821 fix re-verified in real Chromium on merged main: the reported three-node sequence adds cleanly, one whole-schema fetch, no page errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)