### PR TITLE
fix(manager): an EMPTY catalogue is not 'no matches' (#808)

### DIFF
--- a/browser_tests/unit/manager-catalogue-empty.test.mjs
+++ b/browser_tests/unit/manager-catalogue-empty.test.mjs
@@ -1,14 +1,200 @@
-// panel#808 — an unreachable Manager catalogue renders as an empty node list, not as
-// "could not reach it". Placeholder pinning the CURRENT conflation; the fix follows.
+// panel#808 — an unreachable Manager catalogue rendered as an empty node list rather
+// than as "could not reach it".
+//
+// THE REPORTED FAILURE. A Chinese-speaking user was told to update the panel through
+// ComfyUI Manager and replied "我这边搜不到任何内容" — I can't find anything when I search.
+// That was read as a stale cache; a blocked registry fits the evidence better. Three
+// rounds of advice were spent sending them at a door that could not open, and neither
+// side could see it from the symptom, because EMPTY AND UNREACHABLE LOOK IDENTICAL.
+//
+// THE MECHANISM. `searchNodesVia` requests `customnode/getmappings?mode=cache`, so
+// Manager serves from its own local cache. A cache Manager never managed to populate —
+// because Manager itself could not reach the registry — answers HTTP 200 with `{}`.
+// `parseNodeMappings` filters zero entries and returns `count: 0`, which is exactly what
+// a healthy catalogue returns when the query matches nothing. The reader takes the first
+// for the second, concludes the pack does not exist, and keeps trying variations.
+//
+// THE DISCRIMINATOR is local and needs no new signal from Manager: how many packs the
+// payload CONTAINED, before the query filter. Zero is sound evidence — a working install
+// has thousands.
+//
+// WHAT IS DELIBERATELY NOT CLAIMED. The panel does not make the registry request, so it
+// never observed DNS/timeout/TLS and must not report one. These tests pin that the
+// message states only what was observed.
 import test from "node:test";
 import assert from "node:assert/strict";
-import { parseNodeMappings } from "../../web/js/lib/manager-install.js";
 
-test("#808 today: an EMPTY catalogue and a populated one that misses are indistinguishable", () => {
-  const populated = { "https://github.com/a/b": [[], { title: "Impact Pack" }] };
-  const empty = {};
-  // Both collapse to the same "nothing here" answer, so a caller cannot tell whether
-  // the query missed or the catalogue was never populated.
-  assert.deepEqual(parseNodeMappings(empty, "seedvr2", 15), { count: 0, results: [] });
-  assert.deepEqual(parseNodeMappings(populated, "seedvr2", 15), { count: 0, results: [] });
+import {
+  catalogueSize,
+  emptyCatalogueResult,
+  parseNodeMappings,
+  searchNodesVia,
+} from "../../web/js/lib/manager-install.js";
+
+/** A catalogue in the documented MAP shape: repo URL -> [ [classes…], meta ]. */
+const POPULATED = {
+  "https://github.com/ltdrdata/ComfyUI-Impact-Pack": [
+    [],
+    { title: "Impact Pack", description: "detailer and background tools" },
+  ],
+  "https://github.com/rgthree/rgthree-comfy": [[], { title: "rgthree-comfy" }],
+};
+
+// ---------------------------------------------------------------------------
+// 1. The discriminator itself.
+// ---------------------------------------------------------------------------
+
+test("#808 catalogueSize counts packs RAW — before ids, before the query filter", () => {
+  assert.equal(catalogueSize(POPULATED), 2);
+  assert.equal(catalogueSize([{ id: "a" }, { id: "b" }, { id: "c" }]), 3);
+  assert.equal(catalogueSize({}), 0);
+  assert.equal(catalogueSize([]), 0);
+  // A body that is not a catalogue at all carries no packs either.
+  assert.equal(catalogueSize(null), 0);
+  assert.equal(catalogueSize(undefined), 0);
+  assert.equal(catalogueSize("<html>proxy sign-in</html>"), 0);
+  // Entries with no installable id still COUNT as packs: a parse fault is a different
+  // problem from an empty catalogue, and folding them together would hide both.
+  assert.equal(catalogueSize({ "https://github.com/a/b": [[], {}] }), 1);
+});
+
+test("#808 parseNodeMappings reports catalogue_size alongside the matches", () => {
+  // Populated catalogue, query matches nothing: count 0, but TWO packs were searched.
+  const missed = parseNodeMappings(POPULATED, "seedvr2", 15);
+  assert.equal(missed.count, 0);
+  assert.equal(missed.catalogue_size, 2);
+
+  // Empty catalogue: count 0 and NOTHING was searched. Same count, different fact.
+  const empty = parseNodeMappings({}, "seedvr2", 15);
+  assert.equal(empty.count, 0);
+  assert.equal(empty.catalogue_size, 0);
+
+  // A hit is unchanged, and still reports what it searched.
+  const hit = parseNodeMappings(POPULATED, "impact", 15);
+  assert.equal(hit.count, 1);
+  assert.equal(hit.catalogue_size, 2);
+});
+
+// ---------------------------------------------------------------------------
+// 2. The flow: which of the three states each payload produces.
+// ---------------------------------------------------------------------------
+
+const get = (payload) => async () => payload;
+const throwing = () => async () => {
+  throw new Error("not reachable");
+};
+
+test("#808 an EMPTY catalogue no longer reads as 'no matches'", async () => {
+  const res = await searchNodesVia(get({}), throwing(), { query: "seedvr2" });
+
+  assert.equal(res.catalogue_empty, true);
+  assert.equal(res.searched, false, "the caller must be able to see nothing was searched");
+  assert.equal(res.count, 0);
+  assert.deepEqual(res.results, []);
+  // Manager itself WAS reachable — this is not the Manager-unavailable case.
+  assert.equal(res.managerReachable, true);
+  assert.equal(res.supported, true);
+  assert.equal(res.query, "seedvr2");
+});
+
+test("#808 a POPULATED catalogue that misses is still an ordinary no-match", async () => {
+  // The regression this fix must not cause: a healthy catalogue returns count 0 all the
+  // time, and that has to keep reading as the plain no-match it is.
+  const res = await searchNodesVia(get(POPULATED), throwing(), { query: "seedvr2" });
+
+  assert.equal(res.count, 0);
+  assert.equal(res.catalogue_size, 2);
+  assert.notEqual(res.catalogue_empty, true);
+  assert.equal(res.searched, undefined, "no 'nothing was searched' claim — it did search");
+  assert.equal(res.message, undefined, "a no-match needs no explanation");
+});
+
+test("#808 a normal hit is untouched", async () => {
+  const res = await searchNodesVia(get(POPULATED), throwing(), { query: "impact" });
+  assert.equal(res.count, 1);
+  assert.equal(res.results[0].id, "https://github.com/ltdrdata/ComfyUI-Impact-Pack");
+  assert.notEqual(res.catalogue_empty, true);
+});
+
+test("#808 an UNREACHABLE Manager keeps its own distinct result (#251/#255 intact)", async () => {
+  // Three states, three answers. This one must not be absorbed into the new branch:
+  // Manager could not be reached at all, which has a different remedy.
+  const res = await searchNodesVia(throwing(), throwing(), { query: "seedvr2" });
+
+  assert.equal(res.supported, false);
+  assert.equal(res.managerReachable, false);
+  assert.notEqual(res.catalogue_empty, true);
+  assert.match(res.message, /could not\s+be reached/);
+});
+
+test("#808 the object_info fallback still wins over the empty-catalogue branch", async () => {
+  // #426: when Manager is unreachable but installed nodes match, the agent gets those.
+  // The new branch is about a REACHABLE Manager and must not intercept this path.
+  const objectInfoGet = async () => ({
+    SeedVR2VideoUpscaler: { display_name: "SeedVR2 Video Upscaler", category: "upscaling" },
+  });
+  const res = await searchNodesVia(throwing(), throwing(), {
+    query: "seedvr2",
+    objectInfoGet,
+  });
+
+  assert.equal(res.supported, true);
+  assert.equal(res.source, "object_info");
+  assert.equal(res.installedOnly, true);
+  assert.equal(res.count, 1);
+  assert.notEqual(res.catalogue_empty, true);
+});
+
+test("#808 a non-catalogue 200 body (a proxy sign-in page) is reported as empty, not as a miss", async () => {
+  const res = await searchNodesVia(get("<html>sign in</html>"), throwing(), { query: "x" });
+  assert.equal(res.catalogue_empty, true);
+  assert.equal(res.searched, false);
+});
+
+// ---------------------------------------------------------------------------
+// 3. The message. This is the deliverable — the report is about what the user is told.
+// ---------------------------------------------------------------------------
+
+test("#808 the message says nothing was searched, and that no conclusion follows", () => {
+  const m = emptyCatalogueResult("seedvr2").message;
+  assert.match(m, /nothing was actually searched/i);
+  assert.match(m, /says NOTHING about whether "seedvr2" exists/);
+  assert.match(m, /not "no matches"/i);
+});
+
+test("#808 the message NAMES the hosts, so a filtered user recognises their situation", () => {
+  // The report's core ask. Without a host, a user behind a national or corporate filter
+  // has no way to connect "empty list" to "my network blocks this".
+  const m = emptyCatalogueResult("seedvr2").message;
+  assert.match(m, /api\.comfy\.org/);
+  assert.match(m, /raw\.githubusercontent\.com/);
+  assert.match(m, /filtering/i);
+});
+
+test("#808 the cheap remedy comes BEFORE the network conclusion", () => {
+  // A cache that simply never populated is the commoner cause, and sending that user to
+  // a VPN is the same class of wrong answer as sending a blocked user to a retry.
+  const m = emptyCatalogueResult("seedvr2").message;
+  const refresh = m.search(/refresh the .*cache|refresh the\s+cache/i);
+  const network = m.search(/not reachable from this machine/i);
+  assert.ok(refresh >= 0, "the cache-refresh remedy is offered");
+  assert.ok(network >= 0, "the network cause is named");
+  assert.ok(refresh < network, "cheap-and-common first, network conclusion second");
+});
+
+test("#808 the message does NOT claim a transport failure the panel never observed", () => {
+  // The panel does not make the registry request — Manager does. Asserting DNS/timeout/
+  // TLS here would be inventing an observation, which is the failure mode #695/#700 were
+  // filed about pointing the other way.
+  const m = emptyCatalogueResult("seedvr2").message;
+  for (const invented of [/\bDNS\b/, /ENOTFOUND/, /timed out/i, /\bTLS\b/, /certificate/i]) {
+    assert.doesNotMatch(m, invented);
+  }
+});
+
+test("#808 a missing query still produces a coherent message", () => {
+  const m = emptyCatalogueResult(undefined).message;
+  assert.match(m, /whether a pack exists/);
+  assert.doesNotMatch(m, /undefined/);
+  assert.equal(emptyCatalogueResult(undefined).query, "");
 });

--- a/browser_tests/unit/manager-catalogue-empty.test.mjs
+++ b/browser_tests/unit/manager-catalogue-empty.test.mjs
@@ -7,20 +7,34 @@
 // rounds of advice were spent sending them at a door that could not open, and neither
 // side could see it from the symptom, because EMPTY AND UNREACHABLE LOOK IDENTICAL.
 //
-// THE MECHANISM. `searchNodesVia` requests `customnode/getmappings?mode=cache`, so
-// Manager serves from its own local cache. A cache Manager never managed to populate —
-// because Manager itself could not reach the registry — answers HTTP 200 with `{}`.
-// `parseNodeMappings` filters zero entries and returns `count: 0`, which is exactly what
-// a healthy catalogue returns when the query matches nothing. The reader takes the first
-// for the second, concludes the pack does not exist, and keeps trying variations.
+// THE MECHANISM. `searchNodesVia` requests `customnode/getmappings?mode=cache`. When that
+// answers HTTP 200 with `{}`, `parseNodeMappings` filters zero entries and returns
+// `count: 0` — exactly what a healthy catalogue returns when the query matches nothing.
+// The reader takes the first for the second, concludes the pack does not exist, and keeps
+// trying variations of a search that cannot succeed.
+//
+// WHEN `{}` ACTUALLY HAPPENS — read out of ComfyUI-Manager's own source
+// (glob/manager_core.py, `get_data_by_mode`) rather than assumed, because the first cut of
+// this fix assumed wrong:
+//
+//   • A NETWORK failure does NOT empty the catalogue. The `except` branch falls back to
+//     the bundled `extension-node-map.json` inside the Manager package — 2.2 MB and
+//     populated on a stock install — so a blocked channel yields a full, if stale, list.
+//   • `{}` comes from the `network_mode == 'offline'` path with neither a cache file nor
+//     a local file, or from a data file that is itself empty/unreadable.
+//
+// So zero packs means Manager assembled a catalogue from NONE of its three sources, which
+// is genuinely anomalous and is what keeps this branch free of false positives.
 //
 // THE DISCRIMINATOR is local and needs no new signal from Manager: how many packs the
-// payload CONTAINED, before the query filter. Zero is sound evidence — a working install
-// has thousands.
+// payload CONTAINED, before the query filter.
 //
-// WHAT IS DELIBERATELY NOT CLAIMED. The panel does not make the registry request, so it
-// never observed DNS/timeout/TLS and must not report one. These tests pin that the
-// message states only what was observed.
+// WHAT IS DELIBERATELY NOT CLAIMED. The panel does not make the channel request, so it
+// never observed DNS/timeout/TLS and must not report one — and it names Manager's actual
+// DEFAULT_CHANNEL host, not api.comfy.org, which serves a different thing. These tests pin
+// both. The related gap they do NOT close: because Manager degrades to the bundled copy, a
+// genuinely blocked channel surfaces as a STALE catalogue, and the panel cannot yet tell
+// stale from current.
 import test from "node:test";
 import assert from "node:assert/strict";
 
@@ -162,24 +176,44 @@ test("#808 the message says nothing was searched, and that no conclusion follows
   assert.match(m, /not "no matches"/i);
 });
 
-test("#808 the message NAMES the hosts, so a filtered user recognises their situation", () => {
-  // The report's core ask. Without a host, a user behind a national or corporate filter
+test("#808 the message names the host THIS catalogue comes from — and not the wrong one", () => {
+  // The report's core ask: without a host, a user behind a national or corporate filter
   // has no way to connect "empty list" to "my network blocks this".
+  //
+  // The host has to be the RIGHT one. Verified against ComfyUI-Manager's own source:
+  // DEFAULT_CHANNEL = "https://raw.githubusercontent.com/ltdrdata/ComfyUI-Manager/main".
+  // api.comfy.org serves pack INSTALLS, not this mapping — naming it would send a
+  // filtered user to check something irrelevant, which fails the report's ask as surely
+  // as naming no host at all.
   const m = emptyCatalogueResult("seedvr2").message;
-  assert.match(m, /api\.comfy\.org/);
-  assert.match(m, /raw\.githubusercontent\.com/);
+  assert.match(m, /raw\.githubusercontent\.com\/ltdrdata\/ComfyUI-Manager/);
+  assert.doesNotMatch(m, /api\.comfy\.org/);
   assert.match(m, /filtering/i);
 });
 
-test("#808 the cheap remedy comes BEFORE the network conclusion", () => {
-  // A cache that simply never populated is the commoner cause, and sending that user to
-  // a VPN is the same class of wrong answer as sending a blocked user to a retry.
+test("#808 the message states the causes Manager's source actually produces", () => {
+  // Read out of glob/manager_core.py `get_data_by_mode`: a NETWORK error falls back to
+  // the bundled extension-node-map.json (populated), so it does NOT empty the list.
+  // `{}` comes from network_mode 'offline' with no cache and no local file. Leading with
+  // "your network is filtered" would therefore assert a cause the code contradicts.
   const m = emptyCatalogueResult("seedvr2").message;
-  const refresh = m.search(/refresh the .*cache|refresh the\s+cache/i);
-  const network = m.search(/not reachable from this machine/i);
+  assert.match(m, /network_mode 'offline'/);
+  assert.match(m, /missing or unreadable/);
+  // All three sources are named, because "empty" means all three produced nothing.
+  assert.match(m, /channel/i);
+  assert.match(m, /cache/i);
+  assert.match(m, /bundled/i);
+});
+
+test("#808 the cheap remedy comes BEFORE the network conclusion", () => {
+  // A cache that never populated is the likelier cause, and sending that user to a VPN
+  // is the same class of wrong answer as sending a blocked user to a retry.
+  const m = emptyCatalogueResult("seedvr2").message;
+  const refresh = m.search(/refresh the cache/i);
+  const network = m.search(/behind corporate, campus or national network/i);
   assert.ok(refresh >= 0, "the cache-refresh remedy is offered");
   assert.ok(network >= 0, "the network cause is named");
-  assert.ok(refresh < network, "cheap-and-common first, network conclusion second");
+  assert.ok(refresh < network, "cheap-and-likely first, network conclusion second");
 });
 
 test("#808 the message does NOT claim a transport failure the panel never observed", () => {

--- a/browser_tests/unit/manager-catalogue-empty.test.mjs
+++ b/browser_tests/unit/manager-catalogue-empty.test.mjs
@@ -1,0 +1,14 @@
+// panel#808 — an unreachable Manager catalogue renders as an empty node list, not as
+// "could not reach it". Placeholder pinning the CURRENT conflation; the fix follows.
+import test from "node:test";
+import assert from "node:assert/strict";
+import { parseNodeMappings } from "../../web/js/lib/manager-install.js";
+
+test("#808 today: an EMPTY catalogue and a populated one that misses are indistinguishable", () => {
+  const populated = { "https://github.com/a/b": [[], { title: "Impact Pack" }] };
+  const empty = {};
+  // Both collapse to the same "nothing here" answer, so a caller cannot tell whether
+  // the query missed or the catalogue was never populated.
+  assert.deepEqual(parseNodeMappings(empty, "seedvr2", 15), { count: 0, results: [] });
+  assert.deepEqual(parseNodeMappings(populated, "seedvr2", 15), { count: 0, results: [] });
+});

--- a/web/js/lib/manager-install.js
+++ b/web/js/lib/manager-install.js
@@ -611,15 +611,37 @@ export function managerUnavailableResult(query, err) {
  *
  * Zero packs is sound evidence: any working install has thousands.
  *
- * WHAT THIS DOES NOT CLAIM. The panel does not make the registry request — Manager does —
+ * WHAT AN EMPTY CATALOGUE ACTUALLY MEANS — read out of ComfyUI-Manager's own source
+ * (`glob/manager_core.py`, `get_data_by_mode`), not assumed:
+ *
+ *   • A NETWORK failure does NOT produce `{}`. The `except` branch falls back to the
+ *     copy of `extension-node-map.json` BUNDLED in the Manager package (2.2 MB and
+ *     populated on a stock install), so a blocked channel still yields a full — if
+ *     stale — catalogue. This is why the message below does NOT lead with "your
+ *     network is filtered": Manager masks that case rather than emptying the list.
+ *   • `{}` comes from the `network_mode == 'offline'` path when NEITHER the cache file
+ *     NOR the local bundled file exists, or when the file that is found is itself empty
+ *     or unreadable.
+ *
+ * So zero packs means Manager assembled a catalogue from NONE of its three sources —
+ * channel, cache, bundled copy. That is genuinely anomalous (a working install has
+ * thousands), which is what makes the branch safe from false positives.
+ *
+ * WHAT THIS DOES NOT CLAIM. The panel does not make the channel request — Manager does —
  * so it never observed a DNS failure, a timeout or a TLS error and must not report one.
  * It says what it saw: Manager answered, the catalogue is empty, so NOTHING WAS SEARCHED
- * and nothing follows about whether the pack exists. Naming the hosts the catalogue comes
- * from is what lets a filtered user recognise their own situation, which no amount of
- * "no results" ever will. The remedy that costs nothing (refresh the cache) is offered
- * BEFORE the network conclusion, because a stale-but-reachable install is the commoner
- * case and sending that user to a VPN is the same class of wrong answer pointing the
- * other way.
+ * and nothing follows about whether the pack exists. The host it names is the one this
+ * catalogue actually comes from — Manager's `DEFAULT_CHANNEL`,
+ * `raw.githubusercontent.com/ltdrdata/ComfyUI-Manager` — and NOT `api.comfy.org`, which
+ * serves pack installs rather than this mapping. Naming the wrong host would send a
+ * filtered user to check something irrelevant, which is the same failure as saying
+ * nothing.
+ *
+ * KNOWN LIMITATION, deliberately not solved here: because Manager degrades to the bundled
+ * copy, a genuinely blocked channel surfaces as a STALE catalogue rather than an empty
+ * one, and the panel cannot currently tell stale from current. That is a separate gap
+ * needing a signal Manager does not expose today; inventing a staleness claim here would
+ * repeat the very fault #808 reports.
  */
 export function emptyCatalogueResult(query) {
   const q = query == null ? "" : String(query);
@@ -633,17 +655,19 @@ export function emptyCatalogueResult(query) {
     results: [],
     query: q,
     message:
-      "ComfyUI-Manager answered, but its cached node catalogue contains ZERO packs — so " +
+      "ComfyUI-Manager answered, but its node catalogue contains ZERO packs — so " +
       `nothing was actually searched, and this result says NOTHING about whether ${
         q ? `"${q}"` : "a pack"
       } exists. (This is not "no matches": a populated catalogue has thousands of packs.) ` +
-      "Manager builds that cache by fetching the node registry — api.comfy.org, and " +
-      "raw.githubusercontent.com / github.com on channel-based builds. First refresh the " +
-      "cache from the Manager UI and retry, since a cache that simply never populated is " +
-      "the commonest cause. If it comes back empty again, those hosts are not reachable " +
-      "from this machine — corporate, campus or national network filtering blocks them " +
-      "routinely, and an empty list is not something you could have inferred that from. " +
-      "Nodes already installed are unaffected: list them with panel_list_nodes.",
+      "Manager assembles this list from its channel (by default " +
+      "raw.githubusercontent.com/ltdrdata/ComfyUI-Manager), falling back to its on-disk " +
+      "cache and then to the copy bundled in the Manager package — so an empty list " +
+      "means NONE of those three produced data. The usual causes are Manager running " +
+      "with network_mode 'offline' and no cache yet, or a Manager install whose data " +
+      "files are missing or unreadable. Refresh the cache from the Manager UI and " +
+      "retry; if this machine is behind corporate, campus or national network " +
+      "filtering, that channel host is the one to check. Nodes already installed are " +
+      "unaffected: list them with panel_list_nodes.",
   };
 }
 

--- a/web/js/lib/manager-install.js
+++ b/web/js/lib/manager-install.js
@@ -484,7 +484,28 @@ export function parseNodeMappings(data, query, limit) {
     }
   }
   const max = Math.min(Number(limit) || 15, 40);
-  return { count: out.length, results: out.slice(0, max) };
+  // #808 — `catalogue_size` is how many packs the payload CONTAINED, before the query
+  // filter. Without it, "the catalogue is empty" and "the catalogue is fine, your query
+  // matched nothing" both arrive as `count: 0` — and the reader takes the first for the
+  // second, concludes the pack does not exist, and goes on trying variations of a search
+  // that cannot succeed. That conflation is the whole of #808.
+  return { count: out.length, results: out.slice(0, max), catalogue_size: catalogueSize(data) };
+}
+
+/**
+ * #808 — how many packs a `/customnode/getmappings` payload actually carries, counted
+ * RAW: before id extraction, and before the query filter.
+ *
+ * Raw deliberately. The question is "did Manager return any packs at all", and counting
+ * only the entries that yielded an installable id would fold a PARSE fault into the
+ * EMPTY-CATALOGUE answer — a different problem with a different remedy. A body that is
+ * not a catalogue at all (null, a string, a proxy's sign-in HTML) contains no packs
+ * either, so 0 is the correct answer for it too.
+ */
+export function catalogueSize(data) {
+  if (Array.isArray(data)) return data.length;
+  if (data && typeof data === "object") return Object.keys(data).length;
+  return 0;
 }
 
 /**
@@ -577,6 +598,56 @@ export function managerUnavailableResult(query, err) {
 }
 
 /**
+ * #808 — Manager ANSWERED, and its node catalogue is EMPTY.
+ *
+ * `searchNodesVia` asks for `customnode/getmappings?mode=cache`, so Manager serves from
+ * its own local cache. A cache it never managed to populate — because Manager itself
+ * could not reach the node registry — answers HTTP 200 with `{}`. Filtered against a
+ * query that produces `count: 0`, which is the SAME answer a healthy catalogue gives when
+ * nothing matches. Empty and unreachable look identical, so the reader concludes their
+ * query was wrong and keeps trying variations of an action that can never succeed. A
+ * Chinese-speaking user reported exactly that — "我这边搜不到任何内容" — and three rounds
+ * of advice were spent sending them at a door that could not open.
+ *
+ * Zero packs is sound evidence: any working install has thousands.
+ *
+ * WHAT THIS DOES NOT CLAIM. The panel does not make the registry request — Manager does —
+ * so it never observed a DNS failure, a timeout or a TLS error and must not report one.
+ * It says what it saw: Manager answered, the catalogue is empty, so NOTHING WAS SEARCHED
+ * and nothing follows about whether the pack exists. Naming the hosts the catalogue comes
+ * from is what lets a filtered user recognise their own situation, which no amount of
+ * "no results" ever will. The remedy that costs nothing (refresh the cache) is offered
+ * BEFORE the network conclusion, because a stale-but-reachable install is the commoner
+ * case and sending that user to a VPN is the same class of wrong answer pointing the
+ * other way.
+ */
+export function emptyCatalogueResult(query) {
+  const q = query == null ? "" : String(query);
+  return {
+    supported: true,
+    managerReachable: true,
+    catalogue_empty: true,
+    catalogue_size: 0,
+    searched: false,
+    count: 0,
+    results: [],
+    query: q,
+    message:
+      "ComfyUI-Manager answered, but its cached node catalogue contains ZERO packs — so " +
+      `nothing was actually searched, and this result says NOTHING about whether ${
+        q ? `"${q}"` : "a pack"
+      } exists. (This is not "no matches": a populated catalogue has thousands of packs.) ` +
+      "Manager builds that cache by fetching the node registry — api.comfy.org, and " +
+      "raw.githubusercontent.com / github.com on channel-based builds. First refresh the " +
+      "cache from the Manager UI and retry, since a cache that simply never populated is " +
+      "the commonest cause. If it comes back empty again, those hosts are not reachable " +
+      "from this machine — corporate, campus or national network filtering blocks them " +
+      "routinely, and an empty list is not something you could have inferred that from. " +
+      "Nodes already installed are unaffected: list them with panel_list_nodes.",
+  };
+}
+
+/**
  * Run the nodes_search flow with graceful degradation against an unreachable /
  * legacy ComfyUI-Manager (#251/#255). Dependency-injected `managerGet` (dialect-
  * routed; adds /v2 for pip builds, strips it for legacy) and `managerCall`
@@ -611,7 +682,13 @@ export async function searchNodesVia(
       throw err2;
     }
   }
-  return parseNodeMappings(data, query, limit);
+  const parsed = parseNodeMappings(data, query, limit);
+  // #808 — an EMPTY catalogue is not a no-match, and only this branch can tell the
+  // caller so. Checked on `catalogue_size` (packs the payload carried) rather than
+  // `count` (packs that matched), because a healthy catalogue legitimately returns
+  // count 0 all the time and must keep reading as the ordinary no-match it is.
+  if (parsed.catalogue_size === 0) return emptyCatalogueResult(query);
+  return parsed;
 }
 
 /** #425 — ordered reboot {route, method} candidates for the detected dialect.


### PR DESCRIPTION
Fixes #808. Panel half of the split; the orchestrator half shipped in artokun/comfyui-mcp#1139.

## What the panel can honestly say

The panel does not perform the outbound registry fetch — ComfyUI-Manager does — so it cannot observe DNS/timeout/TLS directly and must not claim to have diagnosed the transport.

But it *can* distinguish the two states the report says look identical, and the discriminator is already local:

| observed | today | should be |
|---|---|---|
| Manager unreachable on every route | structured `{supported:false}` capability result | unchanged, already correct |
| Manager reachable, catalogue has packs, none match the query | `count: 0` | unchanged — a genuine no-match |
| **Manager reachable, catalogue has ZERO packs** | **`count: 0` — indistinguishable from a no-match** | **distinct: nothing was searched** |

`searchNodesVia` requests `customnode/getmappings?mode=cache`, so Manager serves from its LOCAL cache. A cache that was never populated — because Manager itself could not reach the registry, which is exactly the blocked-registry case in the report — answers HTTP 200 with `{}`. `parseNodeMappings` then filters zero entries and returns `count: 0`, which reads as "nothing matched", so the user concludes their query was wrong and tries variations of an action that can never succeed.

That is the reported failure, and a zero-entry catalogue is sound evidence for it: a working Manager on any real install has thousands of packs.

## Plan

1. Expose the catalogue size (entries **before** query filtering) from `parseNodeMappings`, so "empty" and "missed" stop collapsing.
2. When the catalogue is structurally empty, return a distinct result saying **nothing was searched**, so nothing follows about whether the pack exists — naming the hosts Manager depends on so a filtered user recognises their own situation, and pointing at Manager's cache-update as the remedy.
3. Keep a genuine no-match exactly as it is today.

Following `panel_civitai_results`, which the report correctly cites as the existing right answer: a `total:0` is not automatically "no matches" when an error field may be present.

## Deliberately not doing

Not claiming a cause the panel did not observe. The panel saw "Manager answered; its catalogue is empty" — it did not see a DNS failure, so it will not say one occurred. Per the report's own timeout-vs-filtering point, sending someone to a VPN for a problem a cache refresh would have solved is the same class of wrong answer pointing the other way.

Not touching `nodes_list`: an empty INSTALLED list is legitimate.