### PR TITLE
0.11.47 — large images and videos stop eating the transcript (#818)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+## [0.11.47] - 2026-08-09
+
+> Covers changes since 0.11.46.
+
+### Added
+- Large images and videos can be collapsed **in place** in the chat transcript. Every media
+  card gets a disclosure chevron; collapsed, it becomes a one-line stub naming the file that
+  is itself the way back (click, Enter or Space). This is the opposite of the existing `⛶`
+  button, which opens the lightbox — one goes smaller, one goes bigger. Collapse state is
+  remembered in `sessionStorage`, so it survives a reload and a thread switch inside the tab
+  and clears when the tab closes. Collapsing a video releases its decoded `<video>`
+  immediately instead of leaving it decoding behind a hidden box, and expanding an
+  off-screen card does not resurrect one (#818, #823)
+
 ## [0.11.46] - 2026-08-08
 
 > Covers changes since 0.11.45.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-agent-panel"
 description = "Autonomous AI agent in the ComfyUI sidebar - local-first, bring any LLM. Run it on your Claude or ChatGPT subscription (no API keys, no extra LLM costs), on a Kimi K3 / GLM / OpenRouter key, or fully offline on free local models via Ollama, LM Studio, or llama.cpp. The agent drives your live canvas at full parity: add, wire, move and tweak nodes with Ctrl+Z undo, load whole workflows and installer packs in one shot, generate images, video and audio, browse CivitAI, and run your workflow - asking before it spends paid API credits. The sidebar UI for comfyui-mcp, the local-first, agent-native control plane for ComfyUI."
-version = "0.11.46"
+version = "0.11.47"
 license = { file = "LICENSE" }
 requires-python = ">=3.9"
 # UI-only pack: no Python deps. The frontend floor guarantees

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -866,7 +866,7 @@ const DOCS_URL = "https://comfyui-mcp.artokun.io/docs";
 // Panel version — surfaced in the "Need help?" diagnostics blob. Bump via
 // `node scripts/set-version.mjs <v>` (updates this AND pyproject together); CI
 // and the publish gate FAIL if the two ever drift, so this can't go stale.
-const PANEL_VERSION = "0.11.46";
+const PANEL_VERSION = "0.11.47";
 
 // The connected orchestrator's console URL/token (captured off the `backends`
 // bridge message — see onBackends). Drives the "API Keys" credentials frame;


### PR DESCRIPTION
One change since 0.11.46: **#818 / #823** — media cards in the chat transcript can be collapsed **in place**.

A run that produced a 4K still or a 15-second clip owned full card width in the log forever, and the only existing affordance (`⛶`) went the other way, into the lightbox. Collapsed, a card becomes a one-line stub naming the file that is itself the way back. State is remembered in `sessionStorage` — it survives a reload and a thread switch inside the tab, and clears when the tab closes.

Collapsing a video releases its decoded `<video>` immediately rather than leaving it decoding behind a hidden box, and expanding an off-screen card does not resurrect one.

## Gates

- `pyproject` 0.11.47 and `PANEL_VERSION` 0.11.47 match (the publish gate's own check, run locally).
- Full unit suite: **3084 pass / 0 fail**.
- Verified live in Chrome against local ComfyUI: with the shipped CSS and the shipped card DOM, a collapsed card resolves `img` to `display:none`, shows the stub, hides the caption and the `⛶`, and its own toggle resolves to `opacity: 1`; a collapsed `.cmcp-video-holder` has `display:none` and **zero** client rects, so the observer has no box to intersect and takes the unmount path; and the store's exact key/payload survives a real page reload at the ComfyUI origin.

Refs #818