### PR TITLE
docs(changelog): 0.11.47 shipped two changes, not one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,14 @@ All notable changes to this project are documented here. This project adheres to
   immediately instead of leaving it decoding behind a hidden box, and expanding an
   off-screen card does not resurrect one (#818, #823)
 
+### Fixed
+- An UNREACHABLE ComfyUI-Manager catalogue no longer renders as an empty node list. A
+  `getmappings` cache that was never populated — because Manager itself could not reach the
+  registry — answers HTTP 200 with `{}`, which came back as `count: 0` and read as “nothing
+  matched”, so a user behind a filter kept trying variations of a search that could never
+  succeed. A zero-entry catalogue is now reported as its own state: nothing was searched
+  (#808, #826)
+
 ## [0.11.46] - 2026-08-08
 
 > Covers changes since 0.11.45.


### PR DESCRIPTION
`#826` (the #808 empty-vs-unreachable Manager catalogue fix) merged between release PR #827 being opened and being merged, so it rode 0.11.47 while the section claimed one change since 0.11.46.

Changelog only — no code, no version bump. 0.11.47 is already published, so this corrects the record rather than changing what shipped.