### PR TITLE
docs(changelog): the 0.11.47 entry states a cause the fix itself disproved (#808)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,12 +21,18 @@ All notable changes to this project are documented here. This project adheres to
   off-screen card does not resurrect one (#818, #823)
 
 ### Fixed
-- An UNREACHABLE ComfyUI-Manager catalogue no longer renders as an empty node list. A
-  `getmappings` cache that was never populated — because Manager itself could not reach the
-  registry — answers HTTP 200 with `{}`, which came back as `count: 0` and read as “nothing
-  matched”, so a user behind a filter kept trying variations of a search that could never
-  succeed. A zero-entry catalogue is now reported as its own state: nothing was searched
-  (#808, #826)
+- An EMPTY ComfyUI-Manager catalogue no longer renders as “no matches”. A `getmappings`
+  response with no packs in it came back as `count: 0` — exactly what a healthy catalogue
+  returns when a query matches nothing — so the two were indistinguishable, and a user
+  whose Manager had no catalogue at all concluded the pack did not exist and kept trying
+  variations of a search that could never succeed. A zero-pack catalogue is now reported as
+  its own state: nothing was searched, so nothing follows about whether the pack exists.
+  The message names the host the catalogue actually comes from (Manager’s default channel,
+  not the pack-install registry) and the causes ComfyUI-Manager really produces an empty
+  one from — offline mode with no cache yet, or missing/unreadable Manager data files.
+  Note that a network failure does NOT empty the catalogue: Manager falls back to the copy
+  bundled in its own package, so a blocked channel surfaces as a STALE list rather than an
+  empty one, and telling stale from current is a gap this does not close (#808, #826)
 
 ## [0.11.46] - 2026-08-08
 


### PR DESCRIPTION
Superseded my original intent — #828 already credited #808 in the 0.11.47 section while this was open. This now **corrects that entry's wording** instead of duplicating it.

The entry says a `getmappings` cache is empty "because Manager itself could not reach the registry". Reading ComfyUI-Manager's source while building the fix showed that is not what happens — `glob/manager_core.py`, `get_data_by_mode`:

```python
except Exception as e:
    print("[ComfyUI-Manager] Due to a network error, switching to local mode.")
    uri = os.path.join(manager_util.comfyui_manager_path, filename)
    json_obj = await manager_util.get_data(uri)
```

A network error falls back to the `extension-node-map.json` bundled inside the Manager package — 2.2 MB and populated on a stock install. So a blocked channel yields a **full but stale** catalogue, not an empty one. `{}` comes from `network_mode: 'offline'` with no cache, or missing/unreadable data files.

This matters more than a usual wording nit: the fix's whole point is not asserting a cause nobody observed, and its code comments and tests pin the accurate version. A changelog contradicting them sends the wrong reader to the wrong place — the same failure the issue reports.

Rewritten to state what the fix does, name the right host (Manager's default channel, not the pack-install registry), and record the stale-vs-current gap it deliberately does not close.

CHANGELOG.md only; version untouched, so this does not re-publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)