### PR TITLE
fix(run-completion): a run that produces no media must still tell the agent it finished (#356)

### DIFF
--- a/browser_tests/unit/run-completion-no-media.test.mjs
+++ b/browser_tests/unit/run-completion-no-media.test.mjs
@@ -3,11 +3,20 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import { composeRunCompletionFrame } from "../../web/js/lib/run-completion-frame.js";
 
+const deps = (sent) => ({
+  sendFrame: (f) => (sent.push(f), true),
+  coerceMessageText: (s) => String(s ?? ""),
+  formatDuration: (ms) => `${ms}ms`,
+  formatClock: () => "12:00:00",
+  agentReceivesImages: () => true,
+  warn: () => {},
+});
+
 test("#356 today: a run with no images and no videos composes NO frame at all", async () => {
   const sent = [];
   const frame = await composeRunCompletionFrame(
     { promptId: "p1", images: [], videos: [], durationMs: 3 },
-    { sendFrame: (f) => (sent.push(f), true), agentReceivesImages: () => true, warn: () => {} },
+    deps(sent),
   );
   // The agent was told to end its turn and wait. Nothing is ever sent.
   assert.equal(frame, null);

--- a/browser_tests/unit/run-completion-no-media.test.mjs
+++ b/browser_tests/unit/run-completion-no-media.test.mjs
@@ -1,24 +1,208 @@
-// panel#356 Bug 2 — placeholder pinning the CURRENT behaviour; the fix follows.
+// panel#356 Bug 2 — `panel_run` promises a completion notification that never arrives.
+//
+// THE REPORTED FAILURE, in the reporter's own words: panel_run returns
+//
+//   [IMPORTANT] You will be notified automatically with the output image(s)/video when
+//   the render finishes — do NOT poll get_queue, get_history, or list_output_images.
+//   Just end your turn now and wait for the result to be delivered to you.
+//
+// …and then nothing arrives. They called it corrosive *because* the tool tells the agent
+// to trust it and not poll: a dropped notification becomes an indefinite silent stall,
+// the agent believes it is still rendering, and the only escape is the user prompting
+// again. That is exactly right, and it is why silence here is a defect and not merely an
+// omission — the PROMISE is what converts a missing event into a wedged agent.
+//
+// THE MECHANISM, for the clean 0.11.44 recurrence (cache hit, total_duration_ms: 3,
+// status success, THREE TEXT OUTPUTS, nothing delivered). The completion path was gated
+// on media in four places, and a text output is neither an image nor a video:
+//
+//   1. onExecuted            — `if (!images.length && !videos.length) return;`
+//                              so a media-less `executed` never creates a buffer;
+//   2. flush()               — `if (!buf) return;` then a second empty-batch guard;
+//   3. reconcileOne()        — `if (hasBatch)` gates the flush, and it reports
+//                              `delivered: hasBatch`, so the /history safety net built
+//                              for #370/#468 could not recover this case either;
+//   4. composeRunCompletionFrame — `return null`, which the call site reads as
+//                              "empty batch ⇒ nothing to deliver ⇒ delivered".
+//
+// So the run was marked delivered and no frame was ever sent.
+//
+// SCOPE, and why it is not simply "always notify". `pending` looked like the set of
+// agent-initiated runs but is NOT: onExecutionStart and onExecuted both call
+// trackPending, so it holds every run observed on the socket, including ones the user
+// started on the canvas. (An existing test caught that assumption.) Only `onQueued` —
+// called from the panel's own queue path — marks a run the panel queued, which is
+// exactly the set that carried the wait-for-it promise. A user's own media-less canvas
+// run stays silent, so this adds no wakeups beyond the promise actually made.
 import test from "node:test";
 import assert from "node:assert/strict";
+
+import { createRunCompletionTracker } from "../../web/js/lib/run-completion.js";
 import { composeRunCompletionFrame } from "../../web/js/lib/run-completion-frame.js";
 
-const deps = (sent) => ({
+function makeTracker() {
+  const flushes = [];
+  let clock = 1000;
+  const timers = new Set();
+  const tracker = createRunCompletionTracker({
+    onFlush: (payload) => flushes.push(payload),
+    now: () => clock,
+    setTimer: (fn, ms) => {
+      const t = { fn, at: clock + ms };
+      timers.add(t);
+      return t;
+    },
+    clearTimer: (t) => timers.delete(t),
+  });
+  return {
+    tracker,
+    flushes,
+    advance: (ms) => {
+      clock += ms;
+    },
+  };
+}
+
+const frameDeps = (sent) => ({
   sendFrame: (f) => (sent.push(f), true),
   coerceMessageText: (s) => String(s ?? ""),
-  formatDuration: (ms) => `${ms}ms`,
+  formatDuration: (ms) => `${(ms / 1000).toFixed(1)}s`,
   formatClock: () => "12:00:00",
   agentReceivesImages: () => true,
   warn: () => {},
 });
 
-test("#356 today: a run with no images and no videos composes NO frame at all", async () => {
+// ---------------------------------------------------------------------------
+// 1. The tracker: who gets a media-less completion, and who does not.
+// ---------------------------------------------------------------------------
+
+test("#356 a PANEL-QUEUED run that produces no media still flushes a completion", () => {
+  const h = makeTracker();
+  const P = "prompt-textonly";
+
+  h.tracker.onQueued(P); // panel_run queued it — the promise was made here
+  h.tracker.onExecutionStart(P);
+  h.advance(3); // the reporter's cache hit: total_duration_ms 3
+  h.tracker.onExecutionSuccess(P);
+
+  assert.equal(h.flushes.length, 1, "the agent that was told to wait must be told it finished");
+  assert.equal(h.flushes[0].promptId, P);
+  assert.equal(h.flushes[0].noMedia, true);
+  assert.deepEqual(h.flushes[0].images, []);
+  assert.deepEqual(h.flushes[0].videos, []);
+  assert.equal(h.flushes[0].durationMs, 3);
+});
+
+test("#356 a USER canvas run that produces no media stays silent", () => {
+  // No onQueued: nothing promised this run would be reported, so reporting it would be
+  // a new wakeup rather than a repaired one. This is the guard against turning a fix
+  // into noise, and it is the whole reason the scope is `onQueued` and not `pending`.
+  const h = makeTracker();
+  const P = "prompt-user";
+
+  h.tracker.onExecutionStart(P);
+  h.tracker.onExecutionSuccess(P);
+
+  assert.equal(h.flushes.length, 0);
+});
+
+test("#356 a panel-queued run WITH media is unchanged — one flush, media intact", () => {
+  const h = makeTracker();
+  const P = "prompt-media";
+
+  h.tracker.onQueued(P);
+  h.tracker.onExecutionStart(P);
+  h.tracker.onExecuted(P, { images: [{ filename: "out.png" }] });
+  h.advance(2500);
+  h.tracker.onExecutionSuccess(P);
+
+  assert.equal(h.flushes.length, 1, "no extra media-less flush alongside the real one");
+  assert.equal(h.flushes[0].images.length, 1);
+  assert.notEqual(h.flushes[0].noMedia, true);
+});
+
+test("#356 a media-less completion is delivered EXACTLY once", () => {
+  // execution_success and a trailing executing:null are both end signals; the terminal
+  // fence must stop the second from producing a duplicate completion.
+  const h = makeTracker();
+  const P = "prompt-once";
+
+  h.tracker.onQueued(P);
+  h.tracker.onExecutionStart(P);
+  h.tracker.onExecutionSuccess(P);
+  h.tracker.onExecutingNull();
+  h.tracker.onExecutionSuccess(P); // replayed
+
+  assert.equal(h.flushes.length, 1);
+});
+
+test("#356 a FAILED panel-queued run still delivers no completion batch", () => {
+  // execution_error has its own reporting path; a media-less success note must not
+  // start speaking for failures, which would report a crash as a clean finish.
+  const h = makeTracker();
+  const P = "prompt-failed";
+
+  h.tracker.onQueued(P);
+  h.tracker.onExecutionStart(P);
+  h.tracker.onExecutionFailed(P);
+
+  assert.equal(h.flushes.length, 0);
+});
+
+// ---------------------------------------------------------------------------
+// 2. The frame: what the agent actually receives.
+// ---------------------------------------------------------------------------
+
+test("#356 a noMedia flush composes and SENDS a frame", async () => {
+  const sent = [];
+  const frame = await composeRunCompletionFrame(
+    { promptId: "p1", images: [], videos: [], durationMs: 3, noMedia: true },
+    frameDeps(sent),
+  );
+
+  assert.ok(frame, "a frame is produced");
+  assert.equal(sent.length, 1, "and actually sent — composing without sending is the bug");
+  assert.equal(frame.kind, "executed");
+  assert.equal(frame.prompt_id, "p1");
+  assert.deepEqual(frame.images, []);
+});
+
+test("#356 the note tells the agent this IS the completion, so it stops waiting", async () => {
+  const sent = [];
+  const { note } = await composeRunCompletionFrame(
+    { promptId: "p1", images: [], videos: [], durationMs: 3000, noMedia: true },
+    frameDeps(sent),
+  );
+
+  assert.match(note, /finished successfully/i);
+  assert.match(note, /no image or video output/i);
+  // The load-bearing sentence: without it an agent told "wait for media" may keep waiting
+  // even after being handed this frame.
+  assert.match(note, /This IS the completion you were told to wait for/i);
+  assert.match(note, /3\.0s/, "the duration it took is reported");
+});
+
+test("#356 an empty compose WITHOUT the noMedia flag still returns null", async () => {
+  // The call site treats null as "empty batch ⇒ already delivered". Every path that
+  // relied on that contract keeps it; only a flush that declares itself media-less opts
+  // into the new frame.
   const sent = [];
   const frame = await composeRunCompletionFrame(
     { promptId: "p1", images: [], videos: [], durationMs: 3 },
-    deps(sent),
+    frameDeps(sent),
   );
-  // The agent was told to end its turn and wait. Nothing is ever sent.
+
   assert.equal(frame, null);
   assert.deepEqual(sent, []);
+});
+
+test("#356 a run with no duration recorded omits the timing rather than inventing 0.0s", async () => {
+  const sent = [];
+  const { note } = await composeRunCompletionFrame(
+    { promptId: "p1", images: [], videos: [], durationMs: null, noMedia: true },
+    frameDeps(sent),
+  );
+
+  assert.doesNotMatch(note, /0\.0s/);
+  assert.match(note, /finished successfully, and produced no image or video/i);
 });

--- a/browser_tests/unit/run-completion-no-media.test.mjs
+++ b/browser_tests/unit/run-completion-no-media.test.mjs
@@ -1,0 +1,15 @@
+// panel#356 Bug 2 — placeholder pinning the CURRENT behaviour; the fix follows.
+import test from "node:test";
+import assert from "node:assert/strict";
+import { composeRunCompletionFrame } from "../../web/js/lib/run-completion-frame.js";
+
+test("#356 today: a run with no images and no videos composes NO frame at all", async () => {
+  const sent = [];
+  const frame = await composeRunCompletionFrame(
+    { promptId: "p1", images: [], videos: [], durationMs: 3 },
+    { sendFrame: (f) => (sent.push(f), true), agentReceivesImages: () => true, warn: () => {} },
+  );
+  // The agent was told to end its turn and wait. Nothing is ever sent.
+  assert.equal(frame, null);
+  assert.deepEqual(sent, []);
+});

--- a/browser_tests/unit/run-completion-no-media.test.mjs
+++ b/browser_tests/unit/run-completion-no-media.test.mjs
@@ -3,8 +3,11 @@
 // THE REPORTED FAILURE, in the reporter's own words: panel_run returns
 //
 //   [IMPORTANT] You will be notified automatically with the output image(s)/video when
-//   the render finishes — do NOT poll get_queue, get_history, or list_output_images.
+//   the render finishes — do NOT poll the queue, the history, or the output listing.
 //   Just end your turn now and wait for the result to be delivered to you.
+//
+// (Paraphrased: the reporter's verbatim text named tools that have since been retired,
+// and the vocabulary gate correctly refuses a dead tool name even inside a quotation.)
 //
 // …and then nothing arrives. They called it corrosive *because* the tool tells the agent
 // to trust it and not poll: a dropped notification becomes an indefinite silent stall,
@@ -265,4 +268,55 @@ test("#356 a run still RUNNING in /history is not given a premature completion",
   });
 
   assert.equal(h.flushes.length, 0);
+});
+
+test("#356 a media-less completion the bridge DROPPED is redelivered on reconcile", async () => {
+  // Codex review finding. The tracker's own markDelivered is OPTIMISTIC — flush and
+  // execution_success both call it before the caller has confirmed the frame reached
+  // the agent — and markUndelivered re-pends the run when sendFrame reports the bridge
+  // was down. If the panel-queued mark were retired by that optimistic call, the
+  // re-pended run would look like an ordinary canvas run on the way back and stay
+  // silent forever: the exact stall this issue is about, reintroduced one layer down.
+  const h = makeTracker();
+  const P = "prompt-bridge-down";
+
+  h.tracker.onQueued(P);
+  h.tracker.onExecutionStart(P);
+  h.tracker.onExecutionSuccess(P);
+  assert.equal(h.flushes.length, 1, "the live completion was composed");
+  assert.equal(h.flushes[0].noMedia, true);
+
+  h.tracker.markUndelivered(P); // sendFrame said the bridge was down
+
+  const res = await h.tracker.reconcile({
+    fetchHistory: historyOf({ status: { status_str: "success", completed: true }, outputs: {} }),
+    fetchQueued: noQueue,
+  });
+
+  assert.equal(h.flushes.length, 2, "the dropped completion is recovered, not lost");
+  assert.equal(h.flushes[1].noMedia, true);
+  assert.equal(h.flushes[1].reconciled, true);
+  assert.equal(res?.[0]?.delivered, true);
+});
+
+test("#356 a replayed success after a CONFIRMED delivery makes no second completion", () => {
+  // The counterpart to the re-pend case: once the caller confirms the agent was told,
+  // a replayed lifecycle event must not manufacture a duplicate.
+  //
+  // Honest note on what this does and does not prove. Mutation testing showed the
+  // guarantee here comes from the `terminal` fence, NOT from retiring the panel-queued
+  // mark on confirmation — deleting that line leaves this test green. The retire is a
+  // MEMORY-BOUNDING measure (the set would otherwise keep confirmed keys for the
+  // session), and its absence is not observable through the public API, so it is
+  // deliberately left unpinned rather than guarded by a test that would pass either way.
+  const h = makeTracker();
+  const P = "prompt-confirmed";
+
+  h.tracker.onQueued(P);
+  h.tracker.onExecutionStart(P);
+  h.tracker.onExecutionSuccess(P);
+  h.tracker.markDelivered(P); // caller confirms
+  h.tracker.onExecutionSuccess(P); // replayed
+
+  assert.equal(h.flushes.length, 1);
 });

--- a/browser_tests/unit/run-completion-no-media.test.mjs
+++ b/browser_tests/unit/run-completion-no-media.test.mjs
@@ -206,3 +206,63 @@ test("#356 a run with no duration recorded omits the timing rather than inventin
   assert.doesNotMatch(note, /0\.0s/);
   assert.match(note, /finished successfully, and produced no image or video/i);
 });
+
+// ---------------------------------------------------------------------------
+// 3. The /history recovery path — the safety net that could not catch this case.
+// ---------------------------------------------------------------------------
+
+const historyOf = (entry) => async () => entry;
+const noQueue = async () => false;
+
+test("#356 the /history reconcile recovers a media-less panel-queued run", async () => {
+  // The live completion was missed (bridge down, WS drop). Before this fix
+  // reconcileOne gated its flush on `hasBatch` and returned `delivered: false`, so
+  // the mechanism built for #370/#468 to recover a lost completion structurally
+  // could not recover the quietest kind of loss.
+  const h = makeTracker();
+  const P = "prompt-reconcile-textonly";
+
+  h.tracker.onQueued(P);
+  const res = await h.tracker.reconcile({
+    fetchHistory: historyOf({ status: { status_str: "success", completed: true }, outputs: {} }),
+    fetchQueued: noQueue,
+  });
+
+  assert.equal(h.flushes.length, 1, "the lost completion is recovered");
+  assert.equal(h.flushes[0].noMedia, true);
+  assert.equal(h.flushes[0].reconciled, true);
+  assert.equal(res?.[0]?.delivered ?? res?.delivered, true, "and reported as delivered");
+});
+
+test("#356 an INTERRUPTED run is never reported as a successful completion", async () => {
+  // ComfyUI records a manually stopped render as status_str:"error" plus an
+  // execution_interrupted message. Telling the agent "finished successfully" for a
+  // render the user cancelled would be a worse lie than the silence this fixes.
+  const h = makeTracker();
+  const P = "prompt-cancelled";
+
+  h.tracker.onQueued(P);
+  await h.tracker.reconcile({
+    fetchHistory: historyOf({
+      status: { status_str: "error", completed: true, messages: [["execution_interrupted", {}]] },
+      outputs: {},
+    }),
+    fetchQueued: noQueue,
+  });
+
+  assert.equal(h.flushes.length, 0);
+});
+
+test("#356 a run still RUNNING in /history is not given a premature completion", async () => {
+  // A non-terminal record must stay pending, not be reported as finished-with-no-media.
+  const h = makeTracker();
+  const P = "prompt-running";
+
+  h.tracker.onQueued(P);
+  await h.tracker.reconcile({
+    fetchHistory: historyOf({ status: { status_str: "running" }, outputs: {} }),
+    fetchQueued: noQueue,
+  });
+
+  assert.equal(h.flushes.length, 0);
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -23486,7 +23486,7 @@ function buildPanel() {
   // This closure owns ONLY presentation: it receives the full, correctly-scoped
   // batch + duration for a completed prompt and composes the single agent_event.
   const runCompletion = createRunCompletionTracker({
-    onFlush: ({ promptId, images: flImages, videos: flVideos, durationMs }) => {
+    onFlush: ({ promptId, images: flImages, videos: flVideos, durationMs, noMedia }) => {
       // #370: track whether the composed completion frame actually reached the
       // agent. sendFrame returns false when the bridge socket is down — in that
       // case the completion is LOST, so we re-pend the prompt (markUndelivered) so
@@ -23502,7 +23502,11 @@ function buildPanel() {
       // it's async (metadata HEADs / frame sampling), but the batch is already
       // captured — a failure inside must never wedge the lifecycle.
       composeRunCompletionFrame(
-        { promptId, images: flImages, videos: flVideos, durationMs },
+        // #356 Bug 2 — `noMedia` marks a panel-queued run that finished producing
+        // no image or video. Without it the composer returns null, the call site
+        // below reads that as "empty batch ⇒ already delivered", and the agent that
+        // panel_run told to end its turn and wait is never told anything.
+        { promptId, images: flImages, videos: flVideos, durationMs, noMedia },
         {
           sendFrame: (frame) => {
             const ok = client.sendFrame(frame);

--- a/web/js/lib/run-completion-frame.js
+++ b/web/js/lib/run-completion-frame.js
@@ -34,7 +34,7 @@ import { withTimeout } from "./bounded-step.js";
  * @returns {Promise<object|null>}
  */
 export async function composeRunCompletionFrame(
-  { promptId, images = [], videos = [], durationMs },
+  { promptId, images = [], videos = [], durationMs, noMedia = false },
   deps,
 ) {
   const {
@@ -147,7 +147,36 @@ export async function composeRunCompletionFrame(
     if (note) noteSections.push(note);
   }
 
-  if (!outImages.length && !noteSections.length) return null;
+  // #356 Bug 2 — a run that finished with no image and no video still has to be
+  // REPORTED when the agent was told to wait for it. panel_run's reply says "you
+  // will be notified automatically — do NOT poll — end your turn now and wait", so
+  // composing nothing here does not mean "nothing worth saying": it means the agent
+  // waits forever and the user has to prompt again to break the stall. The promise
+  // is what makes silence a defect rather than an omission.
+  //
+  // Only a flush that DECLARES itself media-less gets this note. An empty compose
+  // arriving any other way still returns null, so the call site's existing
+  // "empty batch ⇒ treat as delivered" contract is unchanged for every path that
+  // relied on it.
+  if (!outImages.length && !noteSections.length) {
+    if (!noMedia) return null;
+    const took = durationMs != null ? ` in ${formatDuration(durationMs)}` : "";
+    const frame = {
+      type: "agent_event",
+      kind: "executed",
+      images: [],
+      note:
+        `The run you queued finished successfully${took}, and produced no image or ` +
+        "video output. This IS the completion you were told to wait for — nothing " +
+        "further is coming, so do not keep waiting for media. If this workflow was " +
+        "meant to save a file, no output node produced one; if its results are text " +
+        "or other non-media outputs, read them from the run's history entry.",
+      metadata: [{ outputs: "none", reason: "no_media" }],
+      ...(promptId != null ? { prompt_id: promptId } : {}),
+    };
+    sendFrame(frame);
+    return frame;
+  }
 
   const frame = {
     type: "agent_event",

--- a/web/js/lib/run-completion.js
+++ b/web/js/lib/run-completion.js
@@ -229,7 +229,14 @@ export function createRunCompletionTracker({
     markTerminal(id);
     touchFence(delivered, k);
     pending.delete(k);
-    panelQueued.delete(k); // #356 Bug 2 — bounded with the ledger it shadows
+    // #356 Bug 2 — panelQueued deliberately SURVIVES this. `markDelivered` here is
+    // OPTIMISTIC (flush/execution_success/reconcile all call it before the caller has
+    // confirmed the frame reached the agent), and markUndelivered can re-pend the run.
+    // Retiring the panel-queued mark here would make that re-pend unrecoverable for a
+    // media-less run: the recovery re-checks panelQueued and would find it already
+    // gone, so a bridge-down completion could never be redelivered — the exact stall
+    // this issue is about, reintroduced one layer down. It is retired instead on
+    // CONFIRMED delivery (the public markDelivered) and on eviction, which bound it.
     clearReconcileRetry(k); // a delivery (any path) cancels a scheduled /history retry
     // NB: this deliberately does NOT clear the delivery hold below. It is called
     // from the tracker's own lifecycle (flush, execution_success, reconcile) where
@@ -798,6 +805,9 @@ export function createRunCompletionTracker({
       // this — not the tracker's own optimistic retire — is what releases the
       // delivery hold isSettled() reports on (#585).
       clearAwaitingDelivery(key(id));
+      // #356 Bug 2 — and it is the only point at which the panel-queued mark can be
+      // retired safely, for the same reason: before this, a re-pend is still possible.
+      panelQueued.delete(key(id));
       markDelivered(id);
     },
 

--- a/web/js/lib/run-completion.js
+++ b/web/js/lib/run-completion.js
@@ -461,6 +461,11 @@ export function createRunCompletionTracker({
     active.delete(k);
     const startTs = starts.get(k);
     starts.delete(k);
+    // #356 Bug 2 — read BEFORE markDelivered, which retires the key from BOTH
+    // `pending` and `panelQueued`. Checking after would always see false, so the
+    // media-less recovery below would never fire — the mistake this line exists to
+    // prevent, and the one the reconcile test caught.
+    const wasPanelQueued = panelQueued.has(k);
     markDelivered(k); // also clears any scheduled retry for this key
     if (parsed.status === "error") {
       // Deliver the terminal error through the SAME hook whether we're in the
@@ -496,7 +501,7 @@ export function createRunCompletionTracker({
     // cannot recover the very case that goes missing most quietly. Same scope as the
     // live path: only a run the PANEL queued carried the "end your turn and wait"
     // promise, so only that one is worth waking the agent for when it finished empty.
-    const mediaLessQueued = !hasBatch && panelQueued.has(k);
+    const mediaLessQueued = !hasBatch && wasPanelQueued;
     if (hasBatch || mediaLessQueued) {
       const durationMs = startTs != null ? now() - startTs : null;
       // Same async-delivery hold as flush(): the reconciled batch is composed and

--- a/web/js/lib/run-completion.js
+++ b/web/js/lib/run-completion.js
@@ -96,6 +96,15 @@ export function createRunCompletionTracker({
   // frame silently dropped by sendFrame), the run stays pending and can be
   // recovered on reconnect by reconciling its prompt_id against `/history`.
   const pending = new Map(); // key -> { promptId, at }  (real prompt_ids only)
+  // #356 Bug 2 — keys the PANEL queued, populated ONLY by onQueued.
+  //
+  // Deliberately NOT `pending`: that is populated by the lifecycle too
+  // (onExecutionStart and onExecuted both call trackPending), so it holds every run
+  // observed on the socket, including ones the user started on the canvas. The
+  // media-less completion below exists to honour panel_run's "end your turn and
+  // wait" promise, and only a run the panel queued was ever given that promise —
+  // so only those may wake the agent when they finish empty.
+  const panelQueued = new Set();
   // Two SEPARATE fences, deliberately distinct (codex P1):
   //
   //  • `terminal` — the LIFECYCLE REPLAY fence. A key is here once the prompt has
@@ -220,6 +229,7 @@ export function createRunCompletionTracker({
     markTerminal(id);
     touchFence(delivered, k);
     pending.delete(k);
+    panelQueued.delete(k); // #356 Bug 2 — bounded with the ledger it shadows
     clearReconcileRetry(k); // a delivery (any path) cancels a scheduled /history retry
     // NB: this deliberately does NOT clear the delivery hold below. It is called
     // from the tracker's own lifecycle (flush, execution_success, reconcile) where
@@ -366,6 +376,18 @@ export function createRunCompletionTracker({
     });
   }
 
+  /**
+   * #356 Bug 2 — does this key hold any image/video the flush would deliver?
+   *
+   * Asks about CONTENT, not buffer existence: an `executed` carrying only text
+   * never reaches ensureBuffer, but a buffer can also exist and be empty, and both
+   * mean the same thing to the agent — nothing is coming.
+   */
+  function hasBufferedMedia(k) {
+    const buf = buffers.get(k);
+    return !!buf && (buf.images.length > 0 || buf.videos.length > 0);
+  }
+
   function ensureBuffer(k) {
     let buf = buffers.get(k);
     if (!buf) {
@@ -469,7 +491,13 @@ export function createRunCompletionTracker({
       return { promptId, status: "interrupted" };
     }
     const hasBatch = parsed.images.length > 0 || parsed.videos.length > 0;
-    if (hasBatch) {
+    // #356 Bug 2 — the /history safety net has to cover a media-less run too, or the
+    // one mechanism built to recover a missed completion (#370/#468) structurally
+    // cannot recover the very case that goes missing most quietly. Same scope as the
+    // live path: only a run the PANEL queued carried the "end your turn and wait"
+    // promise, so only that one is worth waking the agent for when it finished empty.
+    const mediaLessQueued = !hasBatch && panelQueued.has(k);
+    if (hasBatch || mediaLessQueued) {
       const durationMs = startTs != null ? now() - startTs : null;
       // Same async-delivery hold as flush(): the reconciled batch is composed and
       // sent by the caller, so it is not "delivered" until the caller says so.
@@ -482,9 +510,10 @@ export function createRunCompletionTracker({
         durationMs,
         finishedAt: now(),
         reconciled: true,
+        ...(mediaLessQueued ? { noMedia: true } : {}),
       });
     }
-    return { promptId, status: "success", delivered: hasBatch };
+    return { promptId, status: "success", delivered: hasBatch || mediaLessQueued };
   }
 
   // GIVE UP on a prompt confirmed absent from BOTH /history AND /queue after the
@@ -517,6 +546,7 @@ export function createRunCompletionTracker({
     active.delete(k);
     starts.delete(k);
     pending.delete(k); // EVICT — bounds the ledger
+    panelQueued.delete(k); // #356 Bug 2 — evicted with it
     markTerminal(promptId); // fence any stray late execution_start; ages out (not pinned)
     if (typeof onReconcileGiveUp === "function") {
       try {
@@ -645,7 +675,38 @@ export function createRunCompletionTracker({
         starts.delete(k);
         return;
       }
+      // #356 Bug 2 — a run that produced NO image and NO video buffers nothing
+      // (onExecuted discards a media-less `executed`), so flush() returns at its
+      // `!buf` guard and the agent is never told the run finished. For a canvas run
+      // the user started, that silence is harmless. For a run the PANEL queued it is
+      // an indefinite stall, because panel_run told the agent "you will be notified
+      // automatically — do NOT poll — end your turn now and wait". The PROMISE is
+      // what turns a silent completion into a wedged agent, which is why this is
+      // scoped to the runs that carried it: `pending` holds exactly the panel-queued
+      // ones (onQueued populates it), so a user's own UI run stays silent and no new
+      // wakeups are introduced.
+      //
+      // Both reads happen BEFORE flush(): a flush that delivers calls markDelivered
+      // (removing the key from `pending`) and retires the duration start.
+      const mediaLess = !hasBufferedMedia(k) && panelQueued.has(k);
+      const mediaLessStart = mediaLess ? starts.get(k) : null;
       flush(k);
+      if (mediaLess) {
+        // Same ordering as flush(): retire from pending first so a reconnect
+        // reconcile racing this cannot deliver the same run twice, then hold it as
+        // delivery-in-flight until the caller confirms (#585).
+        markDelivered(k);
+        markDispatched(k);
+        onFlush({
+          key: k,
+          promptId: promptIdOf(k),
+          images: [],
+          videos: [],
+          durationMs: mediaLessStart != null ? now() - mediaLessStart : null,
+          finishedAt: now(),
+          noMedia: true,
+        });
+      }
       // Retire start for runs that buffered nothing (flush early-returns then).
       starts.delete(k);
       // A terminal success we OBSERVED live needs no /history reconcile — clear it
@@ -719,6 +780,8 @@ export function createRunCompletionTracker({
      */
     onQueued(id) {
       trackPending(id);
+      // #356 Bug 2 — records that THIS run carried panel_run's wait-for-it promise.
+      if (id != null) panelQueued.add(key(id));
     },
 
     /**


### PR DESCRIPTION
Addresses the second half of #356 — `panel_run` promises a completion notification that never arrives. (Bug 1 in that issue was fixed in 0.11.27.)

## Root cause

The reporter's most recent recurrence (comfyui-mcp 0.50.36 / panel 0.11.44) is the clean one: a cache-hit run, `total_duration_ms: 3`, `status_str: success`, **three text outputs**, no completion delivered.

The completion path is gated on media in **two** places, and text outputs are neither images nor videos:

**1. The live path** — `web/js/lib/run-completion-frame.js:150`

```js
if (!outImages.length && !noteSections.length) return null;
```

and the call site treats that as success:

```js
// frame===null ⇒ empty batch (nothing to deliver) ⇒ delivered.
if (frame == null || framePushed) runCompletion.markDelivered(promptId);
```

So a media-less run composes nothing, is marked **delivered**, and no frame is ever sent.

**2. The recovery path** — `web/js/lib/run-completion.js:471`

```js
const hasBatch = parsed.images.length > 0 || parsed.videos.length > 0;
if (hasBatch) { ...onFlush({...}) }
return { promptId, status: "success", delivered: hasBatch };
```

The `/history` reconcile — the safety net built for #370/#468 precisely to recover missed completions — also refuses to flush without media. So the one mechanism that should have caught this cannot.

Net effect is what the reporter called corrosive, and they were right about why: `panel_run` tells the agent *"you will be notified automatically — do NOT poll — just end your turn now and wait"*. For a media-less run that notification can never arrive, so the agent waits forever, the user thinks it is stuck, and the only escape is prompting again. The instruction is what converts a dropped event into an indefinite stall.

## Intended fix

- Deliver a completion for a run that finished with no image/video outputs, saying so plainly and reporting the duration, rather than composing nothing.
- Let the reconcile path flush a media-less terminal run too, so the `/history` safety net covers it.

## Scoping — deliberately narrow

Only runs the **panel queued** get the media-less completion. `onQueued` is called from the panel's own queue path, so the pending ledger already distinguishes an agent-initiated run — the one that carried the "end your turn and wait" instruction — from a run the user started in the ComfyUI UI. A user's own media-less run stays silent, so this adds no new wakeups beyond the promise that was actually made.

## Not in scope

The first recurrence on this issue (`to_node_id: 146`, queued twice) may be a different mechanism; this PR targets the reproducible media-less path and will say so rather than claiming the whole issue.