### PR TITLE
0.11.48 — a run with no image or video stops leaving the agent waiting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+## [0.11.48] - 2026-08-09
+
+> Covers changes since 0.11.47.
+
+### Fixed
+- A run that finished without producing an image or a video now tells the agent it
+  finished, instead of leaving it waiting forever. `panel_run` promises the agent it will
+  be notified automatically and instructs it not to poll — so for a run whose outputs are
+  text, or a cache hit that saves no file, that notification could never arrive and the
+  agent stalled silently until the user prompted again. The promise is what turned a quiet
+  completion into a wedged session. The completion is now delivered on the live path and
+  recovered by the `/history` reconcile, including when the bridge was down at the moment
+  it first fired. Only runs the panel itself queued are affected — a render you start on
+  the canvas yourself is still silent (#831, #356)
+
 ## [0.11.47] - 2026-08-09
 
 > Covers changes since 0.11.46.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-agent-panel"
 description = "Autonomous AI agent in the ComfyUI sidebar - local-first, bring any LLM. Run it on your Claude or ChatGPT subscription (no API keys, no extra LLM costs), on a Kimi K3 / GLM / OpenRouter key, or fully offline on free local models via Ollama, LM Studio, or llama.cpp. The agent drives your live canvas at full parity: add, wire, move and tweak nodes with Ctrl+Z undo, load whole workflows and installer packs in one shot, generate images, video and audio, browse CivitAI, and run your workflow - asking before it spends paid API credits. The sidebar UI for comfyui-mcp, the local-first, agent-native control plane for ComfyUI."
-version = "0.11.47"
+version = "0.11.48"
 license = { file = "LICENSE" }
 requires-python = ">=3.9"
 # UI-only pack: no Python deps. The frontend floor guarantees

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -866,7 +866,7 @@ const DOCS_URL = "https://comfyui-mcp.artokun.io/docs";
 // Panel version — surfaced in the "Need help?" diagnostics blob. Bump via
 // `node scripts/set-version.mjs <v>` (updates this AND pyproject together); CI
 // and the publish gate FAIL if the two ever drift, so this can't go stale.
-const PANEL_VERSION = "0.11.47";
+const PANEL_VERSION = "0.11.48";
 
 // The connected orchestrator's console URL/token (captured off the `backends`
 // bridge message — see onBackends). Drives the "API Keys" credentials frame;


### PR DESCRIPTION
One change since 0.11.47: **#831 / #356** — a run that finishes without producing an image or video now delivers a completion instead of silently stalling the agent.

`panel_run` tells the agent it will be notified automatically and must not poll. For a run whose outputs are text, or a cache hit that saves no file, that notification could never arrive — the completion path was gated on media in four places, including the `/history` reconcile that exists precisely to recover missed completions. The reporter called it corrosive and was right about why: the instruction to trust it and not poll is what converts a dropped event into an indefinite stall.

Scoped to runs the panel queued (a dedicated `panelQueued` set — `pending` looks like that set but is populated by the lifecycle too), so a render you start on the canvas yourself stays silent and no wakeup is added beyond the promise actually made.

## Gates
- 3112 unit tests pass
- tool vocabulary, typecheck, JS syntax: clean locally
- `pyproject` 0.11.48 and `PANEL_VERSION` 0.11.48 in sync
- re-verified in real Chromium on merged main: cache-hit text-only run delivers once, user canvas run silent, media run unchanged, bridge-down re-pend recovered via reconcile, zero page errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)