### PR TITLE
fix(binding): an empty (0-node) workflow must not wedge every graph tool (#833)

### DIFF
--- a/browser_tests/unit/empty-canvas-wedge.test.mjs
+++ b/browser_tests/unit/empty-canvas-wedge.test.mjs
@@ -70,17 +70,48 @@ test("a REAL empty workflow is provably empty — version stamps are not content
   assert.equal(activeWorkflowProvenEmpty(blankTab("Untitled")), true);
 });
 
-test("a scalar in `extra` cannot be graph content, whatever the extension called it", () => {
+test("a BOOLEAN or NUMBER in `extra` is admitted — a graph cannot be encoded in one", () => {
+  // Admitted by TYPE, so no allowlist is needed and no future extension can
+  // invalidate it. These are the per-workflow flags extensions actually write.
   for (const extra of [
-    { frontendVersion: "1.47.12" },
-    { workflowRendererVersion: 2 },
     { VHS_latentpreview: false },
-    { workflowHash: "abc123" },
-    { some_future_extension_setting: "on" },
+    { VHS_KeepIntermediate: true },
+    { qgn_locked: false },
+    { workflowRendererVersion: 2 },
+    { some_future_extension_flag: true },
     { aNumber: 0.5 },
   ]) {
     assert.equal(serializedStateProvenEmpty(emptyState(extra)), true, JSON.stringify(extra));
   }
+});
+
+test("a NAMED version string is admitted — these are what made every workflow unprovable", () => {
+  for (const extra of [
+    { frontendVersion: "1.47.12" },
+    { workflowHash: "abc123" },
+    { version: "1" },
+    { revision: "7" },
+  ]) {
+    assert.equal(serializedStateProvenEmpty(emptyState(extra)), true, JSON.stringify(extra));
+  }
+});
+
+test("an UNNAMED string stays content — a graph can be stashed as JSON text (codex)", () => {
+  // The counterexample that killed "any scalar is safe": accepting unknown
+  // strings is an accept-all-unknown policy on a fence that also gates root
+  // UUID stamping. A workflow that keeps refusing is recoverable; a canvas
+  // stamped with the wrong identity is not.
+  assert.equal(
+    serializedStateProvenEmpty(emptyState({ extension_graph: '{"nodes":[{"id":1}],"links":[]}' })),
+    false,
+  );
+  assert.equal(serializedStateProvenEmpty(emptyState({ some_future_extension_setting: "on" })), false);
+});
+
+test("exotic types are not evidence of emptiness either", () => {
+  assert.equal(serializedStateProvenEmpty(emptyState({ weird: 10n })), false);
+  assert.equal(serializedStateProvenEmpty(emptyState({ weird: Symbol("x") })), false);
+  assert.equal(serializedStateProvenEmpty(emptyState({ weird: () => {} })), false);
 });
 
 test("a STRUCTURED extra value still defeats the proof — that is where content hides", () => {
@@ -205,4 +236,33 @@ test("an empty root whose workflow is UNREADABLE still refuses — proof, not as
     true,
     "an unreadable workflow state is not evidence the canvas is genuinely empty",
   );
+});
+
+// ── The same bar gates root STAMPING, not just command authorization ────────
+// graphRootProvenEmpty runs this predicate on the LIVE root, and the panel uses
+// `graphRootProvenEmpty(root) && activeWorkflowProvenEmpty(wf)` to rebind a stale
+// root uuid and to stamp a newly created workflow. A false "proven empty" there
+// authorizes an identity write, so the tightened rule has to hold on this side
+// too (codex).
+
+test("graphRootProvenEmpty admits a real blank root", () => {
+  assert.equal(graphRootProvenEmpty(emptyRoot()), true);
+});
+
+test("graphRootProvenEmpty refuses a root stashing a graph as JSON text", () => {
+  const root = {
+    _nodes: [],
+    extra: {},
+    serialize: () => ({ ...emptyState(), extra: { extension_graph: '{"nodes":[{"id":1}]}' } }),
+  };
+  assert.equal(graphRootProvenEmpty(root), false, "an identity stamp must not be authorized here");
+});
+
+test("graphRootProvenEmpty refuses a root with structured extra content", () => {
+  const root = {
+    _nodes: [],
+    extra: {},
+    serialize: () => ({ ...emptyState(), extra: { groupNodes: { g: { nodes: [{ id: 1 }] } } } }),
+  };
+  assert.equal(graphRootProvenEmpty(root), false);
 });

--- a/browser_tests/unit/empty-canvas-wedge.test.mjs
+++ b/browser_tests/unit/empty-canvas-wedge.test.mjs
@@ -1,0 +1,208 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  serializedStateProvenEmpty,
+  activeWorkflowProvenEmpty,
+  graphRootProvenEmpty,
+  graphEmptyBindingUnproven,
+  sealProvenRootBinding,
+  graphRootMatchesState,
+  resolveGraphBindingVerdict,
+} from "../../web/js/lib/graph-binding.js";
+
+// #833 — with an EMPTY workflow active, every panel_* graph tool was refused and
+// no documented recovery cleared it. The mechanism, reproduced against these
+// functions before anything was changed:
+//
+//   1. A real empty ComfyUI workflow is not `activeWorkflowProvenEmpty`, because
+//      every workflow ComfyUI writes carries `extra.frontendVersion` (a version
+//      STRING) and installed extensions add their own per-workflow scalars. The
+//      old rule was "any non-empty value in `extra` defeats the proof", so on a
+//      real install NO blank workflow was ever provably empty.
+//   2. That is the FIRST escape out of `graphEmptyBindingUnproven`. Missing it,
+//      the panel needs the second: a root carrying the workflow's uuid, which
+//      `sealProvenRootBinding` supplies.
+//   3. The seal's exclusivity probe refuses when another CLEAN open workflow's
+//      state also matches the root — and against an EMPTY root, every other
+//      blank tab matches. Two blank tabs therefore blocked the seal permanently.
+//
+// So the exit existed only while exactly one blank tab was open, and
+// `panel_new_workflow` — step 5 of the report, the one the reporter said
+// "escalates the problem" — creates the second one.
+
+/** What a real empty ComfyUI workflow serializes as: zero nodes, but frontend
+ *  and extension metadata in `extra`. Verified against this repo owner's own
+ *  user/default/workflows — every file carries frontendVersion. */
+const REAL_EXTRA = {
+  frontendVersion: "1.47.12",
+  workflowRendererVersion: 2,
+  VHS_latentpreview: false,
+  ue_links: [],
+  ds: { scale: 1, offset: [0, 0] },
+};
+const emptyState = (extra = REAL_EXTRA) => ({
+  nodes: [], links: [], groups: [], config: {}, extra: { ...extra },
+});
+const emptyRoot = () => ({ _nodes: [], extra: {}, serialize: () => emptyState() });
+const blankTab = (name) => ({
+  path: `workflows/${name}.json`,
+  filename: `${name}.json`,
+  isPersisted: true,
+  isModified: false,
+  changeTracker: { activeState: emptyState() },
+});
+
+/** The panel's own exclusivity computation (comfyui-mcp-panel.js, seal call site). */
+const proofExclusive = (rootGraph, active, others) =>
+  !others.some(
+    (o) =>
+      o &&
+      o !== active &&
+      o.isModified !== true &&
+      graphRootMatchesState({ rootGraph, state: o.changeTracker?.activeState }),
+  );
+
+// ── The proof bar ──────────────────────────────────────────────────────────
+
+test("a REAL empty workflow is provably empty — version stamps are not content", () => {
+  assert.equal(serializedStateProvenEmpty(emptyState()), true);
+  assert.equal(activeWorkflowProvenEmpty(blankTab("Untitled")), true);
+});
+
+test("a scalar in `extra` cannot be graph content, whatever the extension called it", () => {
+  for (const extra of [
+    { frontendVersion: "1.47.12" },
+    { workflowRendererVersion: 2 },
+    { VHS_latentpreview: false },
+    { workflowHash: "abc123" },
+    { some_future_extension_setting: "on" },
+    { aNumber: 0.5 },
+  ]) {
+    assert.equal(serializedStateProvenEmpty(emptyState(extra)), true, JSON.stringify(extra));
+  }
+});
+
+test("a STRUCTURED extra value still defeats the proof — that is where content hides", () => {
+  for (const [what, extra] of [
+    ["groupNodes", { groupNodes: { g1: { nodes: [{ id: 1 }] } } }],
+    ["ue_links", { ue_links: [{ from: 1, to: 2 }] }],
+    ["linkExtensions", { linkExtensions: [{ id: 1 }] }],
+    ["a stashed reroutes array", { reroutes: [{ id: 1, pos: [0, 0] }] }],
+  ]) {
+    assert.equal(serializedStateProvenEmpty(emptyState(extra)), false, what);
+  }
+});
+
+test("the graph's OWN surfaces keep the strict rule — a scalar there is malformed, not a stamp", () => {
+  assert.equal(serializedStateProvenEmpty({ ...emptyState(), groups: [{ title: "g" }] }), false);
+  assert.equal(serializedStateProvenEmpty({ ...emptyState(), links: [[1, 2]] }), false);
+  assert.equal(serializedStateProvenEmpty({ ...emptyState(), subgraphs: [{ id: "s" }] }), false);
+  assert.equal(serializedStateProvenEmpty({ ...emptyState(), definitions: { x: 1 } }), false);
+  // The scalar relaxation is for `extra` ONLY, and this is what says so. A
+  // scalar where a graph surface belongs is a MALFORMED read, and an unreadable
+  // state is never proof of emptiness — the same "unknown is not a value" rule
+  // the rest of this module runs on. Applying the extra rule here would quietly
+  // upgrade a corrupt state into a proven-empty canvas.
+  assert.equal(serializedStateProvenEmpty({ ...emptyState(), links: "corrupt" }), false);
+  assert.equal(serializedStateProvenEmpty({ ...emptyState(), groups: 5 }), false);
+  assert.equal(serializedStateProvenEmpty({ ...emptyState(), reroutes: true }), false);
+});
+
+test("a canvas WITH NODES is never proven empty — the #560 protection is untouched", () => {
+  // A mid-restore tab holds the full graph in its tracker state (that IS the
+  // restore source), so it fails on nodes and never reaches the extra rule.
+  assert.equal(serializedStateProvenEmpty({ ...emptyState(), nodes: [{ id: 1, type: "KSampler" }] }), false);
+  const restoring = blankTab("Restoring");
+  restoring.changeTracker.activeState = { ...emptyState(), nodes: [{ id: 1, type: "KSampler" }] };
+  assert.equal(activeWorkflowProvenEmpty(restoring), false);
+});
+
+test("a DIRTY tab still cannot prove emptiness", () => {
+  const dirty = blankTab("Dirty");
+  dirty.isModified = true;
+  assert.equal(activeWorkflowProvenEmpty(dirty), false);
+});
+
+test("an absent or malformed state still proves nothing", () => {
+  assert.equal(serializedStateProvenEmpty(null), false);
+  assert.equal(serializedStateProvenEmpty({}), false);
+  assert.equal(serializedStateProvenEmpty({ nodes: "nope" }), false);
+  assert.equal(serializedStateProvenEmpty({ ...emptyState(), extra: "scalar-extra" }), false);
+  assert.equal(activeWorkflowProvenEmpty({ isModified: false }), false);
+});
+
+// ── The wedge itself ───────────────────────────────────────────────────────
+
+test("TWO blank tabs no longer wedge every graph tool (#833)", () => {
+  const active = blankTab("Untitled A");
+  const other = blankTab("Untitled B");
+  const uuid = "48e8cdaa-f399-4ba8-a76d-45dafc43d859";
+  const root = emptyRoot();
+
+  // The seal is still refused — two blank tabs genuinely are ambiguous, and this
+  // change does not pretend otherwise.
+  const exclusive = proofExclusive(root, active, [active, other]);
+  assert.equal(exclusive, false, "a second blank tab still blocks the seal");
+  assert.equal(
+    sealProvenRootBinding({ rootGraph: root, activeWorkflow: active, activeWorkflowUuid: uuid, proofExclusive: exclusive }),
+    false,
+  );
+
+  // …and the tools work anyway, because the canvas is now PROVABLY empty, which
+  // is the first escape and never needed the seal.
+  assert.equal(graphEmptyBindingUnproven({ graph: root, rootGraph: root, activeWorkflow: active, activeWorkflowUuid: uuid }), false);
+  assert.equal(
+    resolveGraphBindingVerdict({
+      graph: root, rootGraph: root, activeWorkflow: active, activeWorkflowUuid: uuid,
+      nodeCount: 0, includeBaselineReadGuard: true, requireDirtyMutationBinding: true,
+    }),
+    null,
+    "no refusal — a blank canvas is a legitimate state to read and build on",
+  );
+});
+
+test("the ONE-blank-tab case that used to work still works", () => {
+  const active = blankTab("Only");
+  const uuid = "48e8cdaa-f399-4ba8-a76d-45dafc43d859";
+  const root = emptyRoot();
+  assert.equal(proofExclusive(root, active, [active]), true);
+  assert.equal(
+    resolveGraphBindingVerdict({
+      graph: root, rootGraph: root, activeWorkflow: active, activeWorkflowUuid: uuid,
+      nodeCount: 0, includeBaselineReadGuard: true, requireDirtyMutationBinding: true,
+    }),
+    null,
+  );
+});
+
+test("a canvas that is empty but whose workflow claims NODES still refuses", () => {
+  // The genuinely dangerous shape: the workflow says it has content, the canvas
+  // shows none. That is the false-empty read (#560/#604) and must stay fenced.
+  const active = blankTab("Has content");
+  active.changeTracker.activeState = { ...emptyState(), nodes: [{ id: 1, type: "KSampler" }] };
+  const root = emptyRoot();
+  const verdict = resolveGraphBindingVerdict({
+    graph: root, rootGraph: root, activeWorkflow: active, activeWorkflowUuid: "u",
+    nodeCount: 0, includeBaselineReadGuard: true, requireDirtyMutationBinding: true,
+  });
+  assert.ok(verdict, "an empty canvas under a content-bearing workflow must still refuse");
+  // The shape guard reaches it first (the workflow's 1-node state does not
+  // reproduce on an empty root); the count guard would catch it too. Either is a
+  // correct refusal — what must never happen is no refusal at all.
+  assert.ok(
+    ["root-shape-mismatch", "root-node-count-desync"].includes(verdict.reason),
+    `unexpected reason ${verdict.reason}`,
+  );
+});
+
+test("an empty root whose workflow is UNREADABLE still refuses — proof, not assumption", () => {
+  const root = emptyRoot();
+  const unreadable = { isModified: false }; // no tracker, no state
+  assert.equal(graphRootProvenEmpty(root), true, "the ROOT is observably empty");
+  assert.equal(
+    graphEmptyBindingUnproven({ graph: root, rootGraph: root, activeWorkflow: unreadable, activeWorkflowUuid: "u" }),
+    true,
+    "an unreadable workflow state is not evidence the canvas is genuinely empty",
+  );
+});

--- a/browser_tests/unit/empty-canvas-wedge.test.mjs
+++ b/browser_tests/unit/empty-canvas-wedge.test.mjs
@@ -266,3 +266,29 @@ test("graphRootProvenEmpty refuses a root with structured extra content", () => 
   };
   assert.equal(graphRootProvenEmpty(root), false);
 });
+
+// ── codex round 2: a graph smuggled somewhere a type check does not look ────
+
+test("a graph encoded in the KEY is content, whatever the value's type is", () => {
+  const key = '{"nodes":[{"id":1}],"links":[]}';
+  assert.equal(serializedStateProvenEmpty(emptyState({ [key]: true })), false);
+  assert.equal(serializedStateProvenEmpty(emptyState({ [key]: 1 })), false);
+  assert.equal(serializedStateProvenEmpty(emptyState({ [key]: "x" })), false);
+});
+
+test("a NAMED stamp still has to look like a stamp", () => {
+  // Trusting the key alone admits anything an extension chooses to put there.
+  assert.equal(serializedStateProvenEmpty(emptyState({ frontendVersion: '{"nodes":[{"id":1}]}' })), false);
+  assert.equal(serializedStateProvenEmpty(emptyState({ workflowHash: "[1,2,3]" })), false);
+  assert.equal(serializedStateProvenEmpty(emptyState({ version: "x".repeat(200) })), false);
+  // …and a real one still passes.
+  assert.equal(serializedStateProvenEmpty(emptyState({ frontendVersion: "1.47.12" })), true);
+  assert.equal(serializedStateProvenEmpty(emptyState({ workflowHash: "9f3ac21e" })), true);
+});
+
+test("the same two routes are blocked on the STAMPING side", () => {
+  const rootWith = (extra) => ({ _nodes: [], extra: {}, serialize: () => ({ ...emptyState(), extra }) });
+  assert.equal(graphRootProvenEmpty(rootWith({ '{"nodes":[{"id":1}]}': true })), false);
+  assert.equal(graphRootProvenEmpty(rootWith({ frontendVersion: '{"nodes":[{"id":1}]}' })), false);
+  assert.equal(graphRootProvenEmpty(rootWith({ frontendVersion: "1.47.12" })), true);
+});

--- a/web/js/lib/graph-binding.js
+++ b/web/js/lib/graph-binding.js
@@ -227,16 +227,48 @@ const SERIALIZED_FORMAT_METADATA_KEYS = new Set([
 ]);
 
 /**
+ * Can a value inside `extra` be GRAPH CONTENT — nodes, links, groups, subgraph
+ * definitions, anything whose loss would mean a canvas is not really empty?
+ *
+ * #833 — the rule used to be "any non-empty value in `extra` defeats the proof",
+ * and on a real install that meant NO empty workflow was ever provably empty.
+ * Every workflow ComfyUI writes carries `extra.frontendVersion` (a version
+ * string), and installed extensions add their own per-workflow settings —
+ * `VHS_latentpreview: false`, `workflowRendererVersion`, `workflowHash`. All
+ * verified against this repo owner's own `user/default/workflows`. A blank
+ * canvas therefore failed `activeWorkflowProvenEmpty`, which is the FIRST escape
+ * out of `graphEmptyBindingUnproven`, and the panel fell through to the seal —
+ * where a second blank tab makes the exclusivity probe ambiguous, so nothing
+ * sealed and every graph tool refused with no way out.
+ *
+ * A SCALAR cannot be graph content. Nodes, links, groups, reroutes and subgraph
+ * definitions are structured; a string, number or boolean in `extra` is a stamp
+ * or a setting, and neither is a graph. So scalars no longer defeat the proof,
+ * while a non-empty ARRAY or OBJECT still does — which is what keeps the keys
+ * that ARE content-bearing (`groupNodes`, `ue_links`, `linkExtensions`, a
+ * stashed `reroutes`) defeating it exactly as before.
+ *
+ * This does not weaken the #560 protection it was written for. A tab that is
+ * MID-RESTORE has the full graph in its tracker state — that is the restore
+ * source — so it fails the `nodes.length !== 0` check above and never reaches
+ * this rule. The strictness on scalars was protecting nothing and costing the
+ * empty-canvas case its only exit.
+ */
+const extraValueMayBeGraphContent = (value) =>
+  !isEmptySurfaceValue(value) && typeof value === "object";
+
+/**
  * POSITIVE proof that a serialized graph state holds NO workflow content at
  * all — the empty-canvas relaxation's evidence bar (#565 gate). True only
  * when `state` is a well-formed serialized graph whose `nodes` is a PRESENT
  * empty array (a missing/malformed read proves nothing) AND every own
  * surface outside the format-metadata allowlist is absent-or-empty. Inside
  * `extra`, `ds` (viewport) and `comfyui_mcp` (the panel's own identity tag)
- * are not content; any other key must hold an empty value. A single
- * non-empty subgraphs/groups/reroutes/links surface — or any unknown
- * non-empty surface — defeats the proof, so a foreign content-bearing canvas
- * can never be re-stamped through the relaxation.
+ * are not content, and neither is a scalar (see above, #833); any other key
+ * must hold an empty value. A single non-empty subgraphs/groups/reroutes/links
+ * surface — or any unknown non-empty STRUCTURED surface — defeats the proof, so
+ * a foreign content-bearing canvas can never be re-stamped through the
+ * relaxation.
  */
 export function serializedStateProvenEmpty(state) {
   try {
@@ -249,10 +281,13 @@ export function serializedStateProvenEmpty(state) {
         if (typeof value !== "object" || Array.isArray(value)) return false;
         const { ds: viewport, comfyui_mcp: panelTag, ...workflowExtra } = value;
         for (const extraValue of Object.values(workflowExtra)) {
-          if (!isEmptySurfaceValue(extraValue)) return false;
+          if (extraValueMayBeGraphContent(extraValue)) return false;
         }
         continue;
       }
+      // OUTSIDE `extra` the surfaces are the graph's own (nodes, links, groups,
+      // reroutes, subgraphs, definitions), so the strict rule stands: anything
+      // non-empty here is content by construction.
       if (!isEmptySurfaceValue(value)) return false;
     }
     return true;

--- a/web/js/lib/graph-binding.js
+++ b/web/js/lib/graph-binding.js
@@ -241,21 +241,46 @@ const SERIALIZED_FORMAT_METADATA_KEYS = new Set([
  * where a second blank tab makes the exclusivity probe ambiguous, so nothing
  * sealed and every graph tool refused with no way out.
  *
- * A SCALAR cannot be graph content. Nodes, links, groups, reroutes and subgraph
- * definitions are structured; a string, number or boolean in `extra` is a stamp
- * or a setting, and neither is a graph. So scalars no longer defeat the proof,
- * while a non-empty ARRAY or OBJECT still does — which is what keeps the keys
- * that ARE content-bearing (`groupNodes`, `ue_links`, `linkExtensions`, a
- * stashed `reroutes`) defeating it exactly as before.
+ * THE RULE IS BY TYPE, NOT BY TRUST (codex). The first cut said "a scalar cannot
+ * be graph content" and admitted every scalar, present and future, from any
+ * extension. That is an accept-all-unknown policy on a fence that also gates root
+ * UUID stamping, and it has a real counterexample: an extension may stash a
+ * serialized graph as a JSON STRING. So:
+ *
+ *  - a BOOLEAN or a NUMBER is admitted, because a graph cannot be encoded in one.
+ *    That is a property of the type, not a judgement about who wrote it, so it
+ *    needs no allowlist and cannot be invalidated by a future extension;
+ *  - a STRING must be NAMED. `extra.frontendVersion` and its siblings are the
+ *    stamps that made every real workflow unprovable, and they are a short,
+ *    knowable list. Anything else stays content until someone establishes
+ *    otherwise — a workflow that keeps refusing is recoverable, a canvas stamped
+ *    with the wrong identity is not;
+ *  - an ARRAY or OBJECT is structured and stays content, which is what keeps
+ *    `groupNodes`, `ue_links`, `linkExtensions` and a stashed `reroutes`
+ *    defeating the proof exactly as before.
  *
  * This does not weaken the #560 protection it was written for. A tab that is
  * MID-RESTORE has the full graph in its tracker state — that is the restore
  * source — so it fails the `nodes.length !== 0` check above and never reaches
- * this rule. The strictness on scalars was protecting nothing and costing the
- * empty-canvas case its only exit.
+ * this rule. The strictness on version stamps was protecting nothing and costing
+ * the empty-canvas case its only exit.
  */
-const extraValueMayBeGraphContent = (value) =>
-  !isEmptySurfaceValue(value) && typeof value === "object";
+const EXTRA_METADATA_STRING_KEYS = new Set([
+  "frontendVersion",
+  "workflowRendererVersion",
+  "workflowHash",
+  "version",
+  "revision",
+]);
+
+const extraValueMayBeGraphContent = (key, value) => {
+  if (isEmptySurfaceValue(value)) return false;
+  if (typeof value === "boolean" || typeof value === "number") return false;
+  if (typeof value === "string") return !EXTRA_METADATA_STRING_KEYS.has(key);
+  // Arrays, objects, and anything exotic (bigint, symbol, function) stay content:
+  // an unrecognized shape is not evidence of emptiness.
+  return true;
+};
 
 /**
  * POSITIVE proof that a serialized graph state holds NO workflow content at
@@ -280,8 +305,8 @@ export function serializedStateProvenEmpty(state) {
         if (value == null) continue;
         if (typeof value !== "object" || Array.isArray(value)) return false;
         const { ds: viewport, comfyui_mcp: panelTag, ...workflowExtra } = value;
-        for (const extraValue of Object.values(workflowExtra)) {
-          if (extraValueMayBeGraphContent(extraValue)) return false;
+        for (const [extraKey, extraValue] of Object.entries(workflowExtra)) {
+          if (extraValueMayBeGraphContent(extraKey, extraValue)) return false;
         }
         continue;
       }

--- a/web/js/lib/graph-binding.js
+++ b/web/js/lib/graph-binding.js
@@ -273,10 +273,26 @@ const EXTRA_METADATA_STRING_KEYS = new Set([
   "revision",
 ]);
 
+/** Could this text be carrying STRUCTURED data rather than naming or stamping
+ *  something? A version, a hash and an extension's setting name are all short and
+ *  free of JSON delimiters; a stashed graph is neither. Applied to admitted string
+ *  VALUES and to the KEY itself, because a graph can be encoded in an object key
+ *  with a boolean value just as easily as in a string value (codex round 2). */
+const STRUCTURAL_TEXT_CHARS = ["{", "}", "[", "]"];
+const looksStructured = (text) =>
+  text.length > 64 || STRUCTURAL_TEXT_CHARS.some((ch) => text.includes(ch));
+
 const extraValueMayBeGraphContent = (key, value) => {
+  // The KEY first: a name carrying JSON delimiters is not a setting name, and the
+  // value's type says nothing about what the key is smuggling.
+  if (typeof key === "string" && looksStructured(key)) return true;
   if (isEmptySurfaceValue(value)) return false;
   if (typeof value === "boolean" || typeof value === "number") return false;
-  if (typeof value === "string") return !EXTRA_METADATA_STRING_KEYS.has(key);
+  if (typeof value === "string") {
+    // A named stamp still has to LOOK like one. Trusting the key alone would let
+    // `frontendVersion: '{"nodes":[…]}'` through on the strength of its name.
+    return !EXTRA_METADATA_STRING_KEYS.has(key) || looksStructured(value);
+  }
   // Arrays, objects, and anything exotic (bigint, symbol, function) stay content:
   // an unrecognized shape is not evidence of emptiness.
   return true;
@@ -289,7 +305,8 @@ const extraValueMayBeGraphContent = (key, value) => {
  * empty array (a missing/malformed read proves nothing) AND every own
  * surface outside the format-metadata allowlist is absent-or-empty. Inside
  * `extra`, `ds` (viewport) and `comfyui_mcp` (the panel's own identity tag)
- * are not content, and neither is a scalar (see above, #833); any other key
+ * are not content, and neither is a boolean, a number or a NAMED version stamp
+ * (see above, #833); any other key
  * must hold an empty value. A single non-empty subgraphs/groups/reroutes/links
  * surface — or any unknown non-empty STRUCTURED surface — defeats the proof, so
  * a foreign content-bearing canvas can never be re-stamped through the


### PR DESCRIPTION
With an empty workflow active, **every** `panel_*` graph tool was refused as out-of-sync and no documented recovery cleared it.

## Reproduced before changing anything

I drove the real functions with a real blank-workflow payload. The mechanism is exact:

1. `activeWorkflowProvenEmpty` is the **first** escape out of `graphEmptyBindingUnproven`. It required every value in the state's `extra` to be an "empty surface" — and on a real install **nothing** passes that. Every workflow ComfyUI writes carries `extra.frontendVersion` (a version *string*), plus whatever per-workflow scalars the installed extensions add. Verified against this repo owner's own `user/default/workflows`: all of them carry it. So no blank workflow was ever provably empty.
2. Missing that escape, the panel needs the second: a root carrying the workflow's uuid, supplied by `sealProvenRootBinding`.
3. The seal's exclusivity probe refuses when another **clean** open workflow's state also matches the root — and against an **empty** root, every other blank tab matches.

So the only exit existed while exactly **one** blank tab was open. `panel_new_workflow` — step 5 of the report, the rung the reporter said *"escalates the problem"* — creates the second one. That is not a coincidence in their transcript; it is the mechanism.

## The fix

Inside `extra` only, admit by what the type can actually encode:

- **boolean / number** — admitted. A graph cannot be encoded in one; that is a property of the type, so it needs no allowlist and no future extension can invalidate it.
- **string** — must be a *named* stamp (`frontendVersion`, `workflowRendererVersion`, `workflowHash`, `version`, `revision`) **and** must look like one: short, no JSON delimiters.
- **array / object / anything exotic** — unchanged, still content. `groupNodes`, `ue_links`, `linkExtensions` and a stashed `reroutes` defeat the proof exactly as before.

Outside `extra` nothing is relaxed — those surfaces are the graph's own, so a scalar there is a malformed read and still blocks.

**This does not weaken the #560 protection it was written for.** A mid-restore tab holds the full graph in its *tracker* state — that is the restore source — so it fails on `nodes.length !== 0` and never reaches the `extra` rule. The strictness on version stamps was protecting nothing and costing the empty-canvas case its only exit.

## The other three asks were already fixed

The reporter is on panel **0.11.37** and filed this as upstream-only because the guard string isn't in the `comfyui-mcp` package — it's in this repo. Checked each ask against the code rather than assuming:

| ask | status |
|---|---|
| 1 — 0-node treated as out-of-sync | `graphReadDesynced` already exempts a 0-node workflow explicitly; the `empty-binding-unproven` predicate that replaced the old wording landed in **0.11.39** |
| 2 — identity match should let the call through | same predicate |
| 3 — `workflow_new` leaving a stale fence | it has published its own minted `workflow_uuid` since #755, in **0.11.45** |
| 4 — "make the empty-canvas case self-healing" | **the live one — this PR** |

## Review

Codex ran twice. Round 1 rejected my first rule ("a scalar cannot be graph content") as an accept-all-unknown policy on a fence that also gates root **UUID stamping** — a false "proven empty" authorizes an identity *write*, not just a command — with a concrete counterexample: an extension stashing a serialized graph as a JSON string. Round 2 found two more routes: a graph encoded in the object **key** with a boolean value, and a graph stashed under an allowlisted key name. All closed.

Round 2 also caught something my own new test then caught independently: the delimiter check was a regex, and writing it through two layers of quoting ate the backslashes, leaving `/[{}[]]/` — a class of `{ } [` followed by a *literal* `]`, which matches `"[]"` but not `"[1,2,3]"`. It is now an escape-free membership check that cannot regress that way.

I am not claiming exhaustiveness — a predicate reading untyped extension data can always be handed a constructed payload, and both round-2 cases were constructed. What it does is fail in the safe direction: an unrecognised shape stays content, so being wrong costs a recoverable refusal, never a canvas stamped with the wrong identity.

## Verification

20 new unit tests. Mutation-verified: restoring the strict extra rule, letting any extra value through, applying the scalar relaxation to the graph's own surfaces, admitting any string, rejecting booleans/numbers again, admitting exotic types, skipping the key check, trusting an allowlisted key without inspecting its value, and dropping the length bound each fail. Full unit suite: **3163 pass / 0 fail**.

Refs #833
