### PR TITLE
fix(a2ui): a same-thread repaint must not silently kill a live card (#832)

### DIFF
--- a/browser_tests/unit/a2ui-repaint-live-card.test.mjs
+++ b/browser_tests/unit/a2ui-repaint-live-card.test.mjs
@@ -121,3 +121,15 @@ test("#832 first paint and repaint mount through the SAME function", () => {
 test("#832 the live registry is written on both paths, via that shared function", () => {
   assert.match(fn(panelSrc, "mountLiveA2UICard"), /liveA2uiCards\.set\(handle\.cardId, \{ handle, rec \}\)/);
 });
+
+test("#832 the card is RECORDED before it is mounted — record() can repaint", () => {
+  // record() can reach detachInvalidCurrentThread(), which calls resetFeed() (clearing
+  // liveA2uiCards) and repaints. Mounting first would place the card into a feed that
+  // the very next statement can wipe, and the card is not yet in any thread, so the
+  // repaint would not bring it back. This is the ordering the pre-refactor code had.
+  const append = fn(panelSrc, "appendA2UICard");
+  assert.ok(
+    append.indexOf("record(rec)") < append.indexOf("mountLiveA2UICard(rec)"),
+    "record(rec) must precede the mount",
+  );
+});

--- a/browser_tests/unit/a2ui-repaint-live-card.test.mjs
+++ b/browser_tests/unit/a2ui-repaint-live-card.test.mjs
@@ -136,3 +136,20 @@ test("#832 the card is RECORDED before it is mounted — record() can repaint", 
     "record(rec) must precede the mount",
   );
 });
+
+test("#832 (codex): the PRE-HYDRATION restore paint replays cards inert", () => {
+  // The synchronous restore pass declares itself "paint-only": settings are not hydrated,
+  // so the thread it paints comes from a tab pointer and may not be the authoritative one.
+  // Mounting a card LIVE there would register one belonging to a thread about to be
+  // replaced, and an update could land on it — a correctness bug traded for a convenience
+  // one. Liveness waits until the real thread is chosen.
+  assert.match(panelSrc, /let a2uiPaintProvisional = false;/);
+  assert.match(
+    fn(panelSrc, "paintA2UIRecord"),
+    /m\.resolved !== true && !a2uiPaintProvisional/,
+    "the live branch is suppressed during the provisional paint",
+  );
+  const restore = panelSrc.match(/\(function restoreLastThread\(\) \{[\s\S]*?\n  \}\)\(\);/)[0];
+  assert.match(restore, /a2uiPaintProvisional = true;/);
+  assert.match(restore, /finally \{\s*a2uiPaintProvisional = false;/, "reset even if paint throws");
+});

--- a/browser_tests/unit/a2ui-repaint-live-card.test.mjs
+++ b/browser_tests/unit/a2ui-repaint-live-card.test.mjs
@@ -1,0 +1,26 @@
+// panel#832 — placeholder pinning the CURRENT behaviour; the fix follows.
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+const panelSrc = readFileSync(
+  fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url)), "utf8");
+const a2uiSrc = readFileSync(
+  fileURLToPath(new URL("../../web/js/cmcp-a2ui.js", import.meta.url)), "utf8");
+
+test("#832 today: a repainted record is rendered INERT and never re-registered", () => {
+  const paint = panelSrc.match(/function paintA2UIRecord\(m\) \{[\s\S]*?\n  \}/)[0];
+  assert.match(paint, /renderA2UIInert/, "the replay is inert");
+  assert.doesNotMatch(paint, /liveA2uiCards\.set/, "and nothing is put back in the live registry");
+});
+
+test("#832 today: the record carries no card_id, so a repaint could not restore one", () => {
+  const append = panelSrc.match(/function appendA2UICard\(spec\) \{[\s\S]*?\n  \}/)[0];
+  assert.match(append, /const rec = \{ role: "card", kind: "a2ui", spec, resolved: false, choice: null \}/);
+  assert.doesNotMatch(append, /rec\.cardId/, "the id the agent holds is never persisted on the record");
+});
+
+test("#832 today: renderA2UICard always mints a fresh id, with no way to supply one", () => {
+  assert.match(a2uiSrc, /export function renderA2UICard\(spec, \{ onAction, onDismiss \} = \{\}\) \{/);
+});

--- a/browser_tests/unit/a2ui-repaint-live-card.test.mjs
+++ b/browser_tests/unit/a2ui-repaint-live-card.test.mjs
@@ -53,8 +53,11 @@ test("#832 renderA2UICard can be given an id instead of always minting one", () 
     /export function renderA2UICard\(spec, \{ onAction, onDismiss, cardId: reuseId \} = \{\}\)/,
     "the renderer accepts a caller-supplied id",
   );
-  // Minting remains the DEFAULT, so every ordinary render is unchanged.
-  assert.match(a2uiSrc, /: `a2ui-\$\{Date\.now\(\)\.toString\(36\)\}-\$\{\+\+_cardSeq\}`/);
+  // Minting remains the DEFAULT, so every ordinary render is unchanged — and it now
+  // carries a random nonce. `_cardSeq` restarts at 0 on module load and a REUSED id does
+  // not advance it, so Date.now()+counter alone could mint an id equal to one a repaint
+  // had already registered, silently overwriting that map entry (codex review finding).
+  assert.match(a2uiSrc, /a2ui-\$\{Date\.now\(\)\.toString\(36\)\}-\$\{\+\+_cardSeq\}-\$\{Math\.random\(\)/);
   assert.match(
     a2uiSrc,
     /typeof reuseId === "string" && reuseId\s*\?\s*reuseId/,

--- a/browser_tests/unit/a2ui-repaint-live-card.test.mjs
+++ b/browser_tests/unit/a2ui-repaint-live-card.test.mjs
@@ -1,26 +1,123 @@
-// panel#832 — placeholder pinning the CURRENT behaviour; the fix follows.
+// panel#832 — `panel_ui_render` returned a card_id, and an immediate `panel_ui_update`
+// in the SAME agent turn failed with:
+//
+//   no live card "a2ui-mslhgcem-8" (already resolved, dismissed, or from a previous view)
+//
+// with no click, no dismissal, and no workflow/tab switch in between.
+//
+// THE MECHANISM. `appendA2UICard` registers a live card in `liveA2uiCards`;
+// `resetFeed()` unconditionally does `liveA2uiCards.clear()`; `paintA2UIRecord()` replays
+// every persisted record INERT and re-registers nothing; `onUiUpdate` requires
+// `liveA2uiCards.get(card_id)`. So any same-thread repaint between two tool calls turns
+// an unresolved card inert and drops its handle.
+//
+// THE HALF THE REPORT COULD NOT SEE. Re-rendering the record live on repaint would NOT
+// have been enough: the record never stored its card_id —
+//
+//   const rec = { role: "card", kind: "a2ui", spec, resolved: false, choice: null };
+//
+// — and `renderA2UICard` minted a fresh id on every call. A repaint would therefore have
+// re-registered the card under a NEW id while the agent still held the old one, so
+// panel_ui_update would keep failing, for a new reason instead of the old one. Restoring
+// liveness required restoring IDENTITY.
+//
+// WHY THESE ARE SOURCE-STRUCTURE ASSERTIONS. This suite has no DOM, and the sibling A2UI
+// tests (a2ui-validate, secret-card-sizing, interactive-card-fence) are written the same
+// way for the same reason: `renderA2UICard` builds real elements. These pin the wiring
+// that decides the bug — which render path a record takes, whether the id is persisted,
+// and whether the id survives a repaint — each of which is individually mutable and is
+// mutation-tested. A DOM-driven render → repaint → update test would be stronger and is
+// not possible until this suite grows a DOM harness.
 import test from "node:test";
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 
-const panelSrc = readFileSync(
-  fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url)), "utf8");
-const a2uiSrc = readFileSync(
-  fileURLToPath(new URL("../../web/js/cmcp-a2ui.js", import.meta.url)), "utf8");
+const read = (rel) => readFileSync(fileURLToPath(new URL(rel, import.meta.url)), "utf8");
+const panelSrc = read("../../web/js/comfyui-mcp-panel.js");
+const a2uiSrc = read("../../web/js/cmcp-a2ui.js");
 
-test("#832 today: a repainted record is rendered INERT and never re-registered", () => {
-  const paint = panelSrc.match(/function paintA2UIRecord\(m\) \{[\s\S]*?\n  \}/)[0];
-  assert.match(paint, /renderA2UIInert/, "the replay is inert");
-  assert.doesNotMatch(paint, /liveA2uiCards\.set/, "and nothing is put back in the live registry");
+const fn = (src, name) => {
+  const m = src.match(new RegExp(`function ${name}\\([^)]*\\) \\{[\\s\\S]*?\\n  \\}`));
+  assert.ok(m, `could not locate ${name}`);
+  return m[0];
+};
+
+// ---------------------------------------------------------------------------
+// 1. Identity — the half that was missing.
+// ---------------------------------------------------------------------------
+
+test("#832 renderA2UICard can be given an id instead of always minting one", () => {
+  assert.match(
+    a2uiSrc,
+    /export function renderA2UICard\(spec, \{ onAction, onDismiss, cardId: reuseId \} = \{\}\)/,
+    "the renderer accepts a caller-supplied id",
+  );
+  // Minting remains the DEFAULT, so every ordinary render is unchanged.
+  assert.match(a2uiSrc, /: `a2ui-\$\{Date\.now\(\)\.toString\(36\)\}-\$\{\+\+_cardSeq\}`/);
+  assert.match(
+    a2uiSrc,
+    /typeof reuseId === "string" && reuseId\s*\?\s*reuseId/,
+    "a supplied id wins; an empty or non-string one falls back to minting",
+  );
 });
 
-test("#832 today: the record carries no card_id, so a repaint could not restore one", () => {
-  const append = panelSrc.match(/function appendA2UICard\(spec\) \{[\s\S]*?\n  \}/)[0];
-  assert.match(append, /const rec = \{ role: "card", kind: "a2ui", spec, resolved: false, choice: null \}/);
-  assert.doesNotMatch(append, /rec\.cardId/, "the id the agent holds is never persisted on the record");
+test("#832 the record persists the card_id the agent was handed", () => {
+  // Without this the id lives only on the transient handle, and a repaint cannot
+  // reconstruct the identity the agent is holding.
+  assert.match(fn(panelSrc, "mountLiveA2UICard"), /rec\.cardId = handle\.cardId;/);
 });
 
-test("#832 today: renderA2UICard always mints a fresh id, with no way to supply one", () => {
-  assert.match(a2uiSrc, /export function renderA2UICard\(spec, \{ onAction, onDismiss \} = \{\}\) \{/);
+// ---------------------------------------------------------------------------
+// 2. Liveness — an unresolved record comes back live, a resolved one does not.
+// ---------------------------------------------------------------------------
+
+test("#832 an UNRESOLVED record is repainted LIVE, under its original id", () => {
+  const paint = fn(panelSrc, "paintA2UIRecord");
+  assert.match(paint, /m\.resolved !== true/, "the branch turns on resolved-ness");
+  assert.match(
+    paint,
+    /mountLiveA2UICard\(m, typeof m\.cardId === "string" \? m\.cardId : undefined\)/,
+    "it re-mounts live and hands back the ORIGINAL id",
+  );
+});
+
+test("#832 a RESOLVED record stays inert — an answered question is not re-offered", () => {
+  const paint = fn(panelSrc, "paintA2UIRecord");
+  assert.match(paint, /renderA2UIInert\(m\.spec, m\.choice\)/);
+  // The inert path must remain reachable: it is the whole non-regression here.
+  assert.ok(
+    paint.indexOf("renderA2UIInert") > paint.indexOf("m.resolved !== true"),
+    "inert is the fall-through for a resolved record, not dead code",
+  );
+});
+
+test("#832 dismissal still retires the card — resurrection must not undo it", () => {
+  // onDismiss sets resolved = true, which is exactly what routes a dismissed card down
+  // the inert path above. If dismissal stopped marking the record, a repaint would bring
+  // a dismissed card back to life.
+  const mount = fn(panelSrc, "mountLiveA2UICard");
+  assert.match(mount, /onDismiss\(\) \{\s*rec\.resolved = true;/);
+  assert.match(mount, /onAction\(text\) \{\s*rec\.resolved = true;/);
+});
+
+// ---------------------------------------------------------------------------
+// 3. The handlers are shared, so the two paths cannot drift apart.
+// ---------------------------------------------------------------------------
+
+test("#832 first paint and repaint mount through the SAME function", () => {
+  // Two copies of the resolve/dismiss handlers would be two chances for a repainted
+  // card to behave differently from a freshly rendered one — the class of bug this
+  // issue already is.
+  assert.match(fn(panelSrc, "appendA2UICard"), /mountLiveA2UICard\(rec\)/);
+  assert.match(fn(panelSrc, "paintA2UIRecord"), /mountLiveA2UICard\(m, /);
+  assert.equal(
+    (panelSrc.match(/renderA2UICard\(/g) || []).length,
+    1,
+    "exactly one live-render call site in the panel",
+  );
+});
+
+test("#832 the live registry is written on both paths, via that shared function", () => {
+  assert.match(fn(panelSrc, "mountLiveA2UICard"), /liveA2uiCards\.set\(handle\.cardId, \{ handle, rec \}\)/);
 });

--- a/web/js/cmcp-a2ui.js
+++ b/web/js/cmcp-a2ui.js
@@ -550,7 +550,14 @@ export function renderA2UICard(spec, { onAction, onDismiss, cardId: reuseId } = 
   const cardId =
     typeof reuseId === "string" && reuseId
       ? reuseId
-      : `a2ui-${Date.now().toString(36)}-${++_cardSeq}`;
+      : // panel#832 (codex) — `_cardSeq` restarts at 0 on every module load, and an id
+        // REUSED from a persisted record does not advance it. Minting from
+        // Date.now()+counter alone therefore has a path where a fresh id equals one a
+        // repaint has already put back in `liveA2uiCards`, silently overwriting that
+        // entry so an update lands on the wrong card. A random nonce removes the class
+        // rather than narrowing it — the id is an opaque handle, so nothing depends on
+        // it being sequential or on encoding a time.
+        `a2ui-${Date.now().toString(36)}-${++_cardSeq}-${Math.random().toString(36).slice(2, 8)}`;
   const el = document.createElement("div");
   el.className = "cmcp-a2ui";
   el.dataset.cardId = cardId;

--- a/web/js/cmcp-a2ui.js
+++ b/web/js/cmcp-a2ui.js
@@ -541,8 +541,16 @@ let _cardSeq = 0;
  * onAction(text): user clicked a button / submitted — send `text` as a visible
  * chat message and mark the card resolved. onDismiss(): user hit ✕.
  */
-export function renderA2UICard(spec, { onAction, onDismiss } = {}) {
-  const cardId = `a2ui-${Date.now().toString(36)}-${++_cardSeq}`;
+export function renderA2UICard(spec, { onAction, onDismiss, cardId: reuseId } = {}) {
+  // panel#832 — a caller may supply the id instead of minting one. A repaint that
+  // re-renders an UNRESOLVED record has to come back as the SAME card: the agent is
+  // holding the id it was given at render time, and a fresh id would leave
+  // panel_ui_update failing for a new reason rather than the old one. Minting stays
+  // the default, so every ordinary render is unchanged.
+  const cardId =
+    typeof reuseId === "string" && reuseId
+      ? reuseId
+      : `a2ui-${Date.now().toString(36)}-${++_cardSeq}`;
   const el = document.createElement("div");
   el.className = "cmcp-a2ui";
   el.dataset.cardId = cardId;

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -21803,7 +21803,16 @@ function buildPanel() {
     // a ui_update against a card from a previous view would silently repaint a
     // DETACHED element (and mutate+persist the background thread's record) while
     // claiming success; and a stale unresolved surface:"wide" entry would keep
-    // the sidebar wide forever. Cards replay INERT from the thread instead.
+    // the sidebar wide forever.
+    //
+    // #832 — this used to end "Cards replay INERT from the thread instead", which
+    // is no longer true and was the whole bug: an UNRESOLVED card now replays LIVE
+    // under its original card_id (see paintA2UIRecord), because clearing here and
+    // replaying inert killed a card the agent had just been handed, mid-turn, with
+    // no user action. The protection above is unaffected: only the thread being
+    // painted is replayed, and every element was just removed, so nothing from a
+    // previous view can come back and no card can end up with two DOM nodes. A
+    // RESOLVED card still replays inert.
     liveA2uiCards.clear();
     // The thinking indicator lived in `log` and was just detached along with
     // everything else. Drop the stale refs — otherwise a later showThinking()

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -20993,11 +20993,17 @@ function buildPanel() {
     if (!ok) appendSystem("Card reply couldn't be sent — agent disconnected.");
   }
 
-  /** Paint + record + register one live A2UI card. Returns its card_id. */
-  function appendA2UICard(spec) {
-    clearEmpty();
-    const rec = { role: "card", kind: "a2ui", spec, resolved: false, choice: null };
-    const handle = renderA2UICard(spec, {
+  /**
+   * Render one A2UI record as a LIVE card and put it in the live registry.
+   *
+   * panel#832 — shared by the first paint and by a repaint of an unresolved record,
+   * deliberately: the resolve/dismiss handlers retire the card from `liveA2uiCards`
+   * and persist the choice, and two copies of that would be two chances to drift.
+   * `reuseId` is what makes a repaint the SAME card rather than a new one.
+   */
+  function mountLiveA2UICard(rec, reuseId) {
+    const handle = renderA2UICard(rec.spec, {
+      ...(reuseId ? { cardId: reuseId } : {}),
       onAction(text) {
         rec.resolved = true;
         rec.choice = text;
@@ -21015,21 +21021,52 @@ function buildPanel() {
         setChatSurfaceForCards();
       },
     });
-    record(rec);
+    // panel#832 — the id the AGENT holds now lives on the record, not only on the
+    // transient handle. Without it a repaint could re-render the card live and still
+    // register it under a freshly minted id, so panel_ui_update would keep failing —
+    // for a new reason instead of the old one. Identity is the half that was missing.
+    rec.cardId = handle.cardId;
     liveA2uiCards.set(handle.cardId, { handle, rec });
     log.appendChild(handle.el);
+    if (rec.spec?.surface === "wide") setChatSurfaceForCards();
+    return handle;
+  }
+
+  /** Paint + record + register one live A2UI card. Returns its card_id. */
+  function appendA2UICard(spec) {
+    clearEmpty();
+    const rec = { role: "card", kind: "a2ui", spec, resolved: false, choice: null };
+    const handle = mountLiveA2UICard(rec);
+    record(rec);
     scrollLog();
-    if (spec.surface === "wide") setChatSurfaceForCards();
     return handle.cardId;
   }
 
-  /** Replay one persisted a2ui record inert (reload / thread switch). */
+  /**
+   * Replay one persisted a2ui record (reload / thread switch / same-thread repaint).
+   *
+   * panel#832 — an UNRESOLVED record comes back LIVE, under its original card_id.
+   * It used to be replayed inert unconditionally, and `resetFeed()` clears
+   * `liveA2uiCards`, so a repaint landing between `panel_ui_render` and
+   * `panel_ui_update` silently killed a card the agent had just been handed — no
+   * click, no dismissal, no view switch, just `no live card "…"`.
+   *
+   * A RESOLVED record (answered or dismissed) stays inert exactly as before: it is
+   * finished, and bringing it back would offer the user buttons for a question that
+   * has already been answered. The thread/view guard is untouched — repaint only ever
+   * replays the records of the thread being painted, so this cannot resurrect a card
+   * into a view it does not belong to.
+   */
   function paintA2UIRecord(m) {
     clearEmpty();
     try {
+      if (m && m.resolved !== true) {
+        mountLiveA2UICard(m, typeof m.cardId === "string" ? m.cardId : undefined);
+        return;
+      }
       log.appendChild(renderA2UIInert(m.spec, m.choice));
     } catch {
-      log.appendChild(renderA2UIFailCard(m.spec, ["stored card failed to render"]));
+      log.appendChild(renderA2UIFailCard(m?.spec, ["stored card failed to render"]));
     }
   }
 

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -21036,8 +21036,14 @@ function buildPanel() {
   function appendA2UICard(spec) {
     clearEmpty();
     const rec = { role: "card", kind: "a2ui", spec, resolved: false, choice: null };
-    const handle = mountLiveA2UICard(rec);
+    // RECORD BEFORE MOUNTING, deliberately — this preserves the original ordering and
+    // it is load-bearing: record() can reach detachInvalidCurrentThread(), which calls
+    // resetFeed() and repaints. A card placed in the DOM and in `liveA2uiCards` BEFORE
+    // that would be wiped by the repaint it triggered, and — not yet being in any
+    // thread — would not come back. Recording first means the repaint happens while the
+    // card is still an unplaced value, and the mount below lands on the settled feed.
     record(rec);
+    const handle = mountLiveA2UICard(rec);
     scrollLog();
     return handle.cardId;
   }

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -20979,6 +20979,13 @@ function buildPanel() {
   // the registry is mount-local on purpose — a workflow switch re-mounts and
   // replays cards INERT from the thread (live handles don't survive, by design).
   const liveA2uiCards = new Map(); // cardId -> { handle, rec }
+  // panel#832 (codex) — TRUE only during the synchronous pre-hydration restore paint.
+  // That pass declares itself "paint-only": settings are not hydrated yet, so the thread
+  // it paints comes from a tab pointer and may not be the authoritative one. Replaying a
+  // card INERT there was harmless; mounting it LIVE would register a card belonging to a
+  // thread that is about to be replaced, and an update could then land on it. Liveness
+  // waits until the real thread has been chosen.
+  let a2uiPaintProvisional = false;
 
   /** Round-trip: a card interaction becomes a normal, visible user message. */
   function sendCardReply(text) {
@@ -21066,7 +21073,7 @@ function buildPanel() {
   function paintA2UIRecord(m) {
     clearEmpty();
     try {
-      if (m && m.resolved !== true) {
+      if (m && m.resolved !== true && !a2uiPaintProvisional) {
         mountLiveA2UICard(m, typeof m.cardId === "string" ? m.cardId : undefined);
         return;
       }
@@ -27095,7 +27102,16 @@ function buildPanel() {
       const pointed = reloadThreadId
         ? threads.find((candidate) => candidate.id === reloadThreadId)
         : null;
-      if (pointed?.msgs?.length) paintThread(pointed);
+      if (pointed?.msgs?.length) {
+        // #832 — paint-only, as the comment above requires: cards replay inert here
+        // because the authoritative thread has not been selected yet.
+        a2uiPaintProvisional = true;
+        try {
+          paintThread(pointed);
+        } finally {
+          a2uiPaintProvisional = false;
+        }
+      }
     } catch {
       // Corrupt/absent state — start clean.
     }


### PR DESCRIPTION
Fixes #832. Same root cause as #132.

## Root cause — confirmed, and one layer deeper than reported

The report is right about the mechanism:

- `appendA2UICard` renders a **live** card and registers it: `liveA2uiCards.set(handle.cardId, { handle, rec })`
- `resetFeed()` unconditionally does `liveA2uiCards.clear()`
- `paintA2UIRecord()` replays every persisted record **inert** via `renderA2UIInert(...)` and re-registers nothing
- `onUiUpdate` requires `liveA2uiCards.get(card_id)`

So a same-thread repaint between two tool calls turns an unresolved card inert and drops the handle, and `panel_ui_update` fails with `no live card "…"` — with no user action, dismissal, or view switch, exactly as reported.

**The part the report could not see from the outside:** even re-rendering the record live on repaint would not fix it, because **the record never stores its `card_id`**:

```js
const rec = { role: "card", kind: "a2ui", spec, resolved: false, choice: null };
```

The id lives only on the transient `handle`. And `renderA2UICard` mints a fresh one every call:

```js
export function renderA2UICard(spec, { onAction, onDismiss } = {}) {
  const cardId = `a2ui-${Date.now().toString(36)}-${++_cardSeq}`;
```

So a repaint would re-register under a **new** id while the agent still holds the old one — the update would keep failing, just for a different reason. Restoring liveness requires restoring *identity*, which needs both a persisted id and a way to render with it.

## Shape of the fix

1. `renderA2UICard` accepts an optional `cardId` and mints one only when none is supplied.
2. `appendA2UICard` persists `rec.cardId`, so the id the agent holds survives into history.
3. `paintA2UIRecord` renders an **unresolved** record live — same action/dismiss handlers — and re-registers it under its original `cardId`. A **resolved** record stays inert exactly as today.

The thread/view ownership guard is untouched: repaint still only replays the records of the thread being painted, so a card cannot come back to life in a view it does not belong to.

## Regression coverage

The report asks for render -> same-thread repaint -> update, which is the test that would have caught this. That plus: a resolved card stays inert after repaint; a dismissed card is not resurrected; and the id is stable across the repaint rather than re-minted.