### PR TITLE
0.11.49 — a blank canvas stops wedging every graph tool (#833)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,31 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+## [0.11.49] - 2026-08-09
+
+> Covers changes since 0.11.48.
+
+### Fixed
+- An EMPTY (0-node) workflow no longer wedges every `panel_*` graph tool. A blank canvas is
+  exactly the state a user is in right before asking the agent to build something, and it was
+  the one state in which nothing could be read or edited — with no recovery: re-targeting
+  reported success without changing anything, `panel_new_workflow` made it worse, and
+  `panel_open_workflow` could not prove its rebind. A browser refresh was the only exit.
+
+  The panel proves a canvas genuinely empty before trusting a 0-node read, and that proof
+  required every value in the workflow's `extra` to be empty — which nothing on a real install
+  satisfies, because ComfyUI stamps `extra.frontendVersion` into every workflow it writes and
+  installed extensions add their own per-workflow flags. So no blank workflow was ever provably
+  empty, and the fallback (stamping the canvas with the workflow's identity) is refused when
+  another blank tab could equally explain the empty canvas. Two blank tabs therefore had no exit
+  at all — and `panel_new_workflow` creates the second one, which is why that step escalated it.
+
+  A version stamp is not a graph. Booleans and numbers in `extra` are now admitted (a graph
+  cannot be encoded in one), and named version strings are admitted when they look like version
+  strings. Anything structured — or any text carrying JSON delimiters, wherever it appears — is
+  still treated as content, so a canvas that actually holds something is never proven empty
+  (#833)
+
 ## [0.11.48] - 2026-08-09
 
 > Covers changes since 0.11.47.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-agent-panel"
 description = "Autonomous AI agent in the ComfyUI sidebar - local-first, bring any LLM. Run it on your Claude or ChatGPT subscription (no API keys, no extra LLM costs), on a Kimi K3 / GLM / OpenRouter key, or fully offline on free local models via Ollama, LM Studio, or llama.cpp. The agent drives your live canvas at full parity: add, wire, move and tweak nodes with Ctrl+Z undo, load whole workflows and installer packs in one shot, generate images, video and audio, browse CivitAI, and run your workflow - asking before it spends paid API credits. The sidebar UI for comfyui-mcp, the local-first, agent-native control plane for ComfyUI."
-version = "0.11.48"
+version = "0.11.49"
 license = { file = "LICENSE" }
 requires-python = ">=3.9"
 # UI-only pack: no Python deps. The frontend floor guarantees

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -866,7 +866,7 @@ const DOCS_URL = "https://comfyui-mcp.artokun.io/docs";
 // Panel version — surfaced in the "Need help?" diagnostics blob. Bump via
 // `node scripts/set-version.mjs <v>` (updates this AND pyproject together); CI
 // and the publish gate FAIL if the two ever drift, so this can't go stale.
-const PANEL_VERSION = "0.11.48";
+const PANEL_VERSION = "0.11.49";
 
 // The connected orchestrator's console URL/token (captured off the `backends`
 // bridge message — see onBackends). Drives the "API Keys" credentials frame;


### PR DESCRIPTION
One change since 0.11.48: **#833 / #836**.

An empty (0-node) workflow refused every `panel_*` graph tool with no recovery — the state a user is in immediately before asking the agent to build something.

The panel proves a canvas genuinely empty before trusting a 0-node read, and that proof required every value in the workflow's `extra` to be empty — which nothing on a real install satisfies, because ComfyUI stamps `extra.frontendVersion` into every workflow it writes. With the proof unreachable, the fallback is stamping the canvas with the workflow's identity, and that is refused when another blank tab could equally explain an empty canvas. Two blank tabs therefore had no exit at all — and `panel_new_workflow` creates the second one, which is exactly why the reporter saw that step escalate the failure.

## Gates

- `pyproject` 0.11.49 and `PANEL_VERSION` 0.11.49 match (the publish gate's own check, run locally).
- Full unit suite: **3163 pass / 0 fail**.
- Verified in Chrome against the merged commit: a real blank workflow is proven empty, both the one- and two-blank-tab cases produce no refusal, a workflow claiming nodes over an empty canvas still refuses, and all three adversarial routes codex found (graph in an extra key, graph under a stamp name, structured extra) stay blocked.

Refs #833