### PR TITLE
fix(a2ui): a same-thread repaint must not lose a card the same turn just created (#832)

### DIFF
--- a/browser_tests/unit/a2ui-card-identity.test.mjs
+++ b/browser_tests/unit/a2ui-card-identity.test.mjs
@@ -1,0 +1,176 @@
+// #832 — a card the agent was just handed must survive a repaint.
+//
+// `panel_ui_render` returns a `card_id`; `panel_ui_update` names it. A history
+// repaint landing between the two — with no user click, no dismissal, no tab
+// switch — invalidated that id, because the repaint path was DIFFERENT code from
+// the create path: creating produced a live, registered handle, while repainting
+// the same record produced an inert clone with a brand-new id and no
+// registration.
+//
+// This file drives the real `renderA2UICard` against a minimal DOM to pin the
+// half that is a pure function of its arguments (does an id survive a re-mount?),
+// and reads the panel source for the wiring that only exists inside the DOM
+// closure. Both matter: an id that can be reused is useless if the repaint path
+// does not reuse it.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+// ── minimal DOM ────────────────────────────────────────────────────────────
+// Only what the card renderer touches, plus the handful of globals the vendored
+// Lit bundle reads at module scope. Deliberately small: a fuller shim would let
+// the module rely on behaviour this file does not actually model.
+class El {
+  constructor(tag) {
+    this.tagName = String(tag).toUpperCase();
+    this.children = [];
+    this.style = { cssText: "" };
+    this.dataset = {};
+    this.hidden = false;
+    this.className = "";
+    this._text = "";
+    this._listeners = new Map();
+    this.classList = { add() {}, remove() {}, toggle() {}, contains: () => false };
+  }
+  set textContent(v) { this._text = String(v ?? ""); this.children = []; }
+  get textContent() { return this._text; }
+  appendChild(c) { this.children.push(c); return c; }
+  append(...c) { for (const x of c) this.children.push(x); }
+  replaceChildren(...c) { this.children = [...c]; }
+  remove() {}
+  setAttribute(k, v) { this[k] = v; }
+  removeAttribute(k) { delete this[k]; }
+  addEventListener(t, fn) {
+    if (!this._listeners.has(t)) this._listeners.set(t, []);
+    this._listeners.get(t).push(fn);
+  }
+  querySelector() { return null; }
+  querySelectorAll() { return []; }
+  focus() {}
+}
+
+globalThis.HTMLElement = class {};
+globalThis.Document = class { };
+globalThis.Document.prototype.adoptedStyleSheets = [];
+globalThis.CSSStyleSheet = class { replaceSync() {} get cssRules() { return []; } };
+globalThis.customElements = { define() {}, get() { return undefined; } };
+globalThis.document = {
+  adoptedStyleSheets: [],
+  createElement: (t) => new El(t),
+  createElementNS: (_ns, t) => new El(t),
+  createTextNode: (t) => ({ nodeType: 3, textContent: String(t) }),
+  createComment: () => ({ nodeType: 8 }),
+  createDocumentFragment: () => new El("#fragment"),
+  // The vendored Lit bundle walks a template fragment when the card renders
+  // through the Lit adapter. That render is ASYNCHRONOUS and lands after the
+  // test that triggered it, so without this it surfaces as an unhandled
+  // rejection that fails the file while every assertion passes. Nothing here
+  // asserts over Lit's output — the walker only has to terminate.
+  createTreeWalker: () => ({ currentNode: null, nextNode: () => null }),
+};
+globalThis.window = globalThis;
+
+const { renderA2UICard, renderA2UIInert, validateA2UISpec } = await import("../../web/js/cmcp-a2ui.js");
+
+const spec = () =>
+  validateA2UISpec({
+    root: "c",
+    components: [
+      { id: "c", type: "Column", children: ["t", "b"] },
+      { id: "t", type: "Text", text: "Which sampler?" },
+      { id: "b", type: "Button", label: "Euler", reply: "euler" },
+    ],
+  }).spec;
+
+// ── the id has to be re-usable ─────────────────────────────────────────────
+
+test("a card minted without an id gets a fresh one", () => {
+  const a = renderA2UICard(spec(), {});
+  const b = renderA2UICard(spec(), {});
+  assert.match(a.cardId, /^a2ui-/);
+  assert.notEqual(a.cardId, b.cardId, "two independent cards are two cards");
+});
+
+test("re-mounting with an id keeps it — the agent's handle survives", () => {
+  const first = renderA2UICard(spec(), {});
+  const remounted = renderA2UICard(spec(), { cardId: first.cardId });
+  assert.equal(remounted.cardId, first.cardId);
+  assert.equal(remounted.el.dataset.cardId, first.cardId, "the DOM must agree with the handle");
+  assert.notEqual(remounted.el, first.el, "it is a NEW element carrying the SAME identity");
+});
+
+test("a blank or non-string id is ignored rather than adopted", () => {
+  // An empty id would make every such card collide in the registry.
+  for (const cardId of ["", null, undefined, 0, {}, []]) {
+    const h = renderA2UICard(spec(), { cardId });
+    assert.match(h.cardId, /^a2ui-/, `cardId ${JSON.stringify(cardId)} must not be adopted`);
+  }
+});
+
+test("a re-mounted card is live — it can still be updated and resolved", () => {
+  const first = renderA2UICard(spec(), {});
+  const remounted = renderA2UICard(spec(), { cardId: first.cardId });
+  assert.equal(remounted.isResolved(), false);
+  assert.equal(remounted.update(spec()), true, "an unresolved card accepts an update");
+  remounted.resolve("euler");
+  assert.equal(remounted.isResolved(), true);
+  assert.equal(remounted.update(spec()), false, "a resolved card refuses one");
+});
+
+test("renderA2UIInert still produces a resolved, non-interactive card", () => {
+  // Unchanged behaviour for records that WERE answered — nothing may answer
+  // them twice.
+  const el = renderA2UIInert(spec(), "euler");
+  assert.ok(el, "inert render still returns an element");
+});
+
+// ── the wiring that lives in the DOM closure ───────────────────────────────
+
+const PANEL = readFileSync(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8");
+
+test("create and repaint share ONE mount path", () => {
+  // Two paths is how they drifted: only one of them registered the card.
+  assert.match(PANEL, /function mountLiveA2UICard\(rec\) \{/);
+  assert.match(PANEL, /const handle = mountLiveA2UICard\(rec\);/, "appendA2UICard mounts through it");
+  assert.match(PANEL, /mountLiveA2UICard\(m\);/, "paintA2UIRecord mounts through it");
+});
+
+test("the mount reuses the record's id and writes it back", () => {
+  const fn = PANEL.slice(
+    PANEL.indexOf("function mountLiveA2UICard"),
+    PANEL.indexOf("function appendA2UICard"),
+  );
+  assert.ok(fn.length > 0, "mountLiveA2UICard must precede appendA2UICard");
+  assert.match(fn, /cardId: rec\.cardId/, "a re-mount must pass the existing id");
+  assert.match(fn, /rec\.cardId = handle\.cardId;/, "the first mount must persist the minted id");
+  assert.match(fn, /liveA2uiCards\.set\(handle\.cardId, \{ handle, rec \}\)/);
+});
+
+test("the record is created with its id BEFORE it is persisted", () => {
+  // A record persisted without a cardId cannot be re-registered on replay, so
+  // the order here is load-bearing rather than stylistic.
+  const fn = PANEL.slice(PANEL.indexOf("function appendA2UICard"), PANEL.indexOf("function paintA2UIRecord"));
+  assert.ok(fn.indexOf("mountLiveA2UICard(rec)") < fn.indexOf("record(rec)"), "mount, then record");
+});
+
+test("an UNRESOLVED record repaints live; a RESOLVED one stays inert", () => {
+  const fn = PANEL.slice(PANEL.indexOf("function paintA2UIRecord"), PANEL.indexOf("function setChatSurfaceForCards"));
+  assert.match(fn, /if \(m\.resolved\) \{[\s\S]{0,200}renderA2UIInert\(m\.spec, m\.choice\)/);
+  assert.match(fn, /mountLiveA2UICard\(m\);/);
+});
+
+test("the previous-view guard is untouched — resetFeed still clears the registry", () => {
+  // This is what keeps a ui_update naming another thread's card refusing. The
+  // fix restores the CURRENT thread's cards; it does not widen the window.
+  const fn = PANEL.slice(PANEL.indexOf("function resetFeed"), PANEL.indexOf("function newChat"));
+  assert.match(fn, /liveA2uiCards\.clear\(\);/);
+});
+
+test("the card surface is recomputed AFTER the replay, not only before it", () => {
+  // resetFeed() runs its own setChatSurfaceForCards() against an EMPTY registry.
+  // Without a second pass, a repainted unresolved surface:"wide" card would come
+  // back live in a narrowed sidebar.
+  const fn = PANEL.slice(PANEL.indexOf("function paintThread"), PANEL.indexOf("function resumableSessionId"));
+  assert.match(fn, /setChatSurfaceForCards\(\);/);
+});

--- a/browser_tests/unit/a2ui-card-identity.test.mjs
+++ b/browser_tests/unit/a2ui-card-identity.test.mjs
@@ -174,3 +174,29 @@ test("the card surface is recomputed AFTER the replay, not only before it", () =
   const fn = PANEL.slice(PANEL.indexOf("function paintThread"), PANEL.indexOf("function resumableSessionId"));
   assert.match(fn, /setChatSurfaceForCards\(\);/);
 });
+
+// ── the safety properties a reviewer asks about ────────────────────────────
+
+test("a repaint can only ever register the VIEWED thread's cards", () => {
+  // The worry: repaint thread B while viewing A, and a ui_update now resolves
+  // B's card and persists that into a background thread. It cannot happen —
+  // paintThread's FIRST statement makes the thread it paints the viewed one, so
+  // "the thread being painted" and "the thread being viewed" are the same thing
+  // by construction, not by a guard that could be forgotten.
+  const fn = PANEL.slice(PANEL.indexOf("function paintThread(t) {"), PANEL.indexOf("function resumableSessionId"));
+  assert.match(fn, /function paintThread\(t\) \{\s*\n\s*thread = t;\s*\n\s*resetFeed\(\);/);
+});
+
+test("the replay loop is the ONLY thing that repaints a card", () => {
+  // A second caller could mount a card without an intervening resetFeed and
+  // strand the previous handle. There is exactly one, inside that loop.
+  const callers = [...PANEL.matchAll(/paintA2UIRecord\(/g)].length;
+  assert.equal(callers, 2, "one definition + one call site");
+});
+
+test("a card reply that cannot be sent SAYS so", () => {
+  // An unresolved card is live again after a reload, so it can be clicked when
+  // the agent session is gone. That path must not drop the reply silently.
+  const fn = PANEL.slice(PANEL.indexOf("function sendCardReply"), PANEL.indexOf("function mountLiveA2UICard"));
+  assert.match(fn, /if \(!ok\) appendSystem\(/);
+});

--- a/web/js/cmcp-a2ui.js
+++ b/web/js/cmcp-a2ui.js
@@ -540,9 +540,17 @@ let _cardSeq = 0;
  * Render a VALIDATED spec as a live interactive card.
  * onAction(text): user clicked a button / submitted — send `text` as a visible
  * chat message and mark the card resolved. onDismiss(): user hit ✕.
+ *
+ * `cardId` (#832): reuse an EXISTING id instead of minting one. The id is the
+ * agent's only handle on a card — `panel_ui_update` names it — so a card that is
+ * re-mounted (a same-thread repaint puts the same unresolved card back on
+ * screen) has to come back as the SAME card, not a new one wearing its content.
+ * Minting unconditionally is what made a repaint silently orphan a card_id the
+ * agent was handed seconds earlier. Omitted ⇒ a fresh card, as before.
  */
-export function renderA2UICard(spec, { onAction, onDismiss } = {}) {
-  const cardId = `a2ui-${Date.now().toString(36)}-${++_cardSeq}`;
+export function renderA2UICard(spec, { onAction, onDismiss, cardId: reuseId } = {}) {
+  const cardId =
+    typeof reuseId === "string" && reuseId ? reuseId : `a2ui-${Date.now().toString(36)}-${++_cardSeq}`;
   const el = document.createElement("div");
   el.className = "cmcp-a2ui";
   el.dataset.cardId = cardId;

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -20993,11 +20993,25 @@ function buildPanel() {
     if (!ok) appendSystem("Card reply couldn't be sent — agent disconnected.");
   }
 
-  /** Paint + record + register one live A2UI card. Returns its card_id. */
-  function appendA2UICard(spec) {
-    clearEmpty();
-    const rec = { role: "card", kind: "a2ui", spec, resolved: false, choice: null };
-    const handle = renderA2UICard(spec, {
+  /**
+   * Mount ONE live, interactive A2UI card for an existing record, wire its
+   * handlers, register it under its card_id and append it to the log.
+   *
+   * #832 — SHARED by the create path and the repaint path on purpose. The two
+   * used to be different code: creating a card produced a live, registered
+   * handle, while repainting the SAME card produced an inert clone with no
+   * registration and a brand-new id. A history repaint landing between
+   * `panel_ui_render` and `panel_ui_update` — with no user action at all — then
+   * invalidated a card_id the agent had just been handed. One mount path is what
+   * makes a repainted card the same card rather than a lookalike.
+   *
+   * `rec.cardId` is minted on first mount and REUSED on every later one, so the
+   * id the agent holds keeps naming this card across repaints and reloads. It is
+   * persisted with the record, which is what makes that true after a reload too.
+   */
+  function mountLiveA2UICard(rec) {
+    const handle = renderA2UICard(rec.spec, {
+      cardId: rec.cardId,
       onAction(text) {
         rec.resolved = true;
         rec.choice = text;
@@ -21015,19 +21029,51 @@ function buildPanel() {
         setChatSurfaceForCards();
       },
     });
-    record(rec);
+    rec.cardId = handle.cardId;
     liveA2uiCards.set(handle.cardId, { handle, rec });
     log.appendChild(handle.el);
+    return handle;
+  }
+
+  /** Paint + record + register one live A2UI card. Returns its card_id. */
+  function appendA2UICard(spec) {
+    clearEmpty();
+    const rec = { role: "card", kind: "a2ui", spec, resolved: false, choice: null };
+    // Mounted BEFORE record() so the stored record already carries its cardId —
+    // a record persisted without one cannot be re-registered on replay (#832).
+    const handle = mountLiveA2UICard(rec);
+    record(rec);
     scrollLog();
     if (spec.surface === "wide") setChatSurfaceForCards();
     return handle.cardId;
   }
 
-  /** Replay one persisted a2ui record inert (reload / thread switch). */
+  /**
+   * Replay one persisted a2ui record (reload / thread switch / same-thread
+   * repaint).
+   *
+   * RESOLVED records stay inert — they were answered or dismissed, and nothing
+   * should be able to answer them twice. An UNRESOLVED record is put back LIVE
+   * (#832): it is a question still on screen and still waiting, so it must stay
+   * answerable by the user and addressable by the agent. Painting it inert
+   * claimed the opposite twice over — the agent lost its card_id, and a user who
+   * reloaded mid-question was left looking at a card that rendered as already
+   * answered and could not be clicked.
+   *
+   * The previous-view guard this replaces is UNCHANGED in effect: `resetFeed()`
+   * still clears the registry, so only records belonging to the thread now being
+   * painted are re-registered. A `ui_update` naming a card from a different
+   * thread still finds nothing and still refuses — it just no longer refuses for
+   * a card sitting in front of the user.
+   */
   function paintA2UIRecord(m) {
     clearEmpty();
     try {
-      log.appendChild(renderA2UIInert(m.spec, m.choice));
+      if (m.resolved) {
+        log.appendChild(renderA2UIInert(m.spec, m.choice));
+        return;
+      }
+      mountLiveA2UICard(m);
     } catch {
       log.appendChild(renderA2UIFailCard(m.spec, ["stored card failed to render"]));
     }
@@ -21827,6 +21873,11 @@ function buildPanel() {
     // resetFeed() recreated the indicator (if a turn is live) ABOVE these
     // repainted messages — re-pin it to the bottom so it trails the newest one.
     if (agentWorking) bumpThinking();
+    // #832 — recompute AFTER the replay. resetFeed() ran this against an empty
+    // registry; any unresolved surface:"wide" card the replay just put back live
+    // has to widen the sidebar again, or a repaint silently narrows a card that
+    // asked for the room.
+    setChatSurfaceForCards();
     renderTodo(t.todos || [], { persist: false });
   }
 


### PR DESCRIPTION
> A card created by `panel_ui_render` returned a valid `card_id`, but an immediate `panel_ui_update` in the same agent turn failed because the card was no longer present in the panel's `liveA2uiCards` registry. No user click, dismissal, or workflow/tab switch occurred between the two calls.

The reporter's analysis is right, and there is a second half not visible from the source they had.

## Two code paths for one card

Creating a card and repainting it were **different code**. `appendA2UICard` rendered live, wired the handlers and registered the handle; `paintA2UIRecord` rendered `renderA2UIInert` — no handlers, no registration. So any `paintThread` between the two tool calls left the card visible and the registry empty.

Worse, **the id could not have survived even if it had re-registered**: `renderA2UICard` minted a fresh `cardId` on *every* call, and the record never persisted one. The agent's only handle on a card was per-mount state.

## The fix

One mount path. `mountLiveA2UICard(rec)` wires the handlers, registers the handle and appends the element, and both paths go through it. `renderA2UICard` accepts an existing `cardId` and reuses it — a blank or non-string one is ignored rather than adopted, since an empty id would collide every such card in the registry — and the record carries its id from first mount, persisted, so it keeps naming the same card across repaints and reloads.

`appendA2UICard` mounts **before** it records, so the stored record already carries its id; a record persisted without one cannot be re-registered on replay.

## What stays refused

**Resolved** records still repaint inert — they were answered or dismissed, and nothing should answer them twice. And `resetFeed()` still clears the whole registry, so only records belonging to the thread now being painted come back. A `ui_update` naming another thread's card still finds nothing and still refuses. The guard's stated reasons hold exactly as before: no detached element is repainted, and no background thread's record is mutated. It simply no longer refuses for a card sitting in front of the user.

## A quieter defect this also fixes

An unresolved card replayed through `renderA2UIInert` is resolved with a null choice — so a user who reloaded mid-question was left looking at a card that **rendered as already answered and could not be clicked**. A pending question is answerable again after a reload, which is what it always looked like it should be.

`setChatSurfaceForCards()` also now runs after the replay: `resetFeed()` runs it against an empty registry, so a repainted unresolved `surface:"wide"` card would otherwise come back live in a narrowed sidebar.

## Review

Codex's sandbox denied it shell access on the first two attempts, so it returned its four safety questions unanswered rather than a grounded review. They were the right questions; I answered them from the code and **pinned all three testable ones** so the answers stay true — cross-thread leakage (impossible by construction: `paintThread`'s first statement is `thread = t`), double registration (exactly one caller, after `resetFeed` cleared the map), and a post-reload click when the agent is gone (`sendCardReply` already surfaces "agent disconnected" rather than dropping the reply).

Re-run with the source inlined, it raised one finding, which I am **declining**: that a `ui_update` for a card in a *previously viewed* thread throws "no live card". That is the pre-existing guard working as designed — mutating a background thread's persisted record while claiming success is precisely what it exists to prevent, and the error message already names that case. This PR leaves that path byte-identical.

## Verification

14 new unit tests — the real `renderA2UICard` driven against a minimal DOM for the identity half, plus source guards for the wiring that only exists inside the DOM closure. Mutation-verified: minting unconditionally (the original bug), adopting a blank id, repainting every record inert (the reported bug), not writing the minted id back, and recording before mounting each fail. Full unit suite: **3177 pass / 0 fail**.

Refs #832, #132
