### PR TITLE
0.11.50 — an interactive card stops going deaf mid-turn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+## [0.11.50] - 2026-08-09
+
+> Covers changes since 0.11.49.
+
+### Fixed
+- An interactive card the agent had just created could stop responding to it mid-turn.
+  `panel_ui_render` returned a card_id and an immediate `panel_ui_update` failed with
+  "no live card" — no click, no dismissal, no view switch. Any repaint of the chat feed
+  between the two calls (which happens on its own) replayed the card as a finished, inert
+  one and dropped the handle the update needs. An unanswered card now comes back live
+  under the same id the agent was given; an answered or dismissed one still comes back
+  inert, so a question you already answered is never re-offered. Card ids are also now
+  collision-resistant across a page reload, and the provisional paint that runs before the
+  panel has decided which conversation is authoritative stays inert deliberately, so a
+  card can never come back live in a conversation that is about to be replaced
+  (#837, #832)
+
 ## [0.11.49] - 2026-08-09
 
 > Covers changes since 0.11.48.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-agent-panel"
 description = "Autonomous AI agent in the ComfyUI sidebar - local-first, bring any LLM. Run it on your Claude or ChatGPT subscription (no API keys, no extra LLM costs), on a Kimi K3 / GLM / OpenRouter key, or fully offline on free local models via Ollama, LM Studio, or llama.cpp. The agent drives your live canvas at full parity: add, wire, move and tweak nodes with Ctrl+Z undo, load whole workflows and installer packs in one shot, generate images, video and audio, browse CivitAI, and run your workflow - asking before it spends paid API credits. The sidebar UI for comfyui-mcp, the local-first, agent-native control plane for ComfyUI."
-version = "0.11.49"
+version = "0.11.50"
 license = { file = "LICENSE" }
 requires-python = ">=3.9"
 # UI-only pack: no Python deps. The frontend floor guarantees

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -866,7 +866,7 @@ const DOCS_URL = "https://comfyui-mcp.artokun.io/docs";
 // Panel version — surfaced in the "Need help?" diagnostics blob. Bump via
 // `node scripts/set-version.mjs <v>` (updates this AND pyproject together); CI
 // and the publish gate FAIL if the two ever drift, so this can't go stale.
-const PANEL_VERSION = "0.11.49";
+const PANEL_VERSION = "0.11.50";
 
 // The connected orchestrator's console URL/token (captured off the `backends`
 // bridge message — see onBackends). Drives the "API Keys" credentials frame;


### PR DESCRIPTION
One change since 0.11.49: **#837 / #832** — a same-thread repaint no longer silently kills a live A2UI card.

`resetFeed()` clears `liveA2uiCards` and `paintA2UIRecord()` replayed every record inert, so a repaint landing between `panel_ui_render` and `panel_ui_update` killed a card the agent had just been handed. Re-rendering live was not enough on its own — the record never stored its card_id and the renderer minted a fresh one each call, so a repaint would have re-registered under a new id while the agent held the old one.

Codex review found two further defects, both fixed before merge: id collision across a module reload, and the pre-hydration restore paint mounting live cards for a thread that hydration may replace.

## Gates
- 3152 unit tests pass; nine mutations killed
- tool vocabulary, typecheck, JS syntax clean locally
- `pyproject` and `PANEL_VERSION` both 0.11.50
- verified in real Chromium against a real DOM: id reuse matches, fresh mints differ and carry a nonce, an empty id falls back to minting, the DOM carries the reused id, and the card renders with live buttons — zero page errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)