### PR TITLE
fix(binding): panel_graph_outline rejects the active workflow after a tab switch (#817)

### DIFF
--- a/browser_tests/unit/graph-binding.test.mjs
+++ b/browser_tests/unit/graph-binding.test.mjs
@@ -36,6 +36,7 @@ import {
   graphReadBindingChanged,
   resolveGraphRootUuidRebind,
   sealProvenRootBinding,
+  rootContentProvesActiveWorkflow,
   serializedStateProvenEmpty,
 } from "../../web/js/lib/graph-binding.js";
 import {
@@ -275,6 +276,7 @@ function buildDirtyStaleRouteHarness({
     "resolveGraphRootUuidRebind",
     "postReconnectSettleWindow",
     "sealProvenRootBinding",
+    "rootContentProvesActiveWorkflow",
     "graphRootMatchesState",
     "sameWorkflowObject",
     "app",
@@ -297,6 +299,7 @@ function buildDirtyStaleRouteHarness({
     // harnesses default to OUTSIDE the window and opt in explicitly.
     () => postReconnectWindow === true,
     sealProvenRootBinding,
+    rootContentProvesActiveWorkflow,
     graphRootMatchesState,
     sameWorkflowObject,
     { graph: rootB, extensionManager: { workflow: { openWorkflows } } },

--- a/browser_tests/unit/stale-tag-after-tab-switch.test.mjs
+++ b/browser_tests/unit/stale-tag-after-tab-switch.test.mjs
@@ -1,0 +1,208 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  rootContentProvesActiveWorkflow,
+  resolveGraphRootUuidRebind,
+  sealProvenRootBinding,
+  graphRootMatchesState,
+} from "../../web/js/lib/graph-binding.js";
+
+// #817 — "panel_graph_outline rejects active workflow after tab switch with
+// root-workflow-uuid-mismatch". Reproduced against these functions before
+// anything was changed.
+//
+// ComfyUI reuses one app.graph object across tabs and its clear/configure does
+// NOT reset graph.extra — the same mechanism the #565 both-empty clause already
+// records. So switching from A to B leaves A's identity tag sitting on a canvas
+// that now holds B's graph, and the tag guard refuses every graph tool.
+//
+// Nothing self-healed it, and that is the sharp part: `sealProvenRootBinding`
+// declines a root that ALREADY carries a tag, so a WRONG tag was stickier than
+// no tag at all. A byte-identical canvas with no tag was allowed; the same
+// canvas wearing a stale tag was refused until the user re-opened the workflow.
+
+const NODES = [
+  { id: 1, type: "KSampler", pos: [0, 0], size: [100, 50] },
+  { id: 2, type: "VAEDecode", pos: [0, 0], size: [100, 50] },
+];
+const B_EXTRA = { frontendVersion: "1.47.12" };
+const stateOf = (nodes = NODES) => ({ nodes, links: [], groups: [], config: {}, extra: { ...B_EXTRA } });
+
+/** A live root holding B's graph, optionally still tagged with A's identity. */
+const rootOf = (tag, nodes = NODES) => ({
+  _nodes: nodes,
+  extra: tag ? { ...B_EXTRA, comfyui_mcp: { workflow_uuid: tag } } : { ...B_EXTRA },
+  serialize() {
+    return { ...stateOf(nodes), extra: { ...this.extra } };
+  },
+});
+const tabOf = (name, nodes = NODES) => ({
+  path: `workflows/${name}.json`,
+  filename: `${name}.json`,
+  isPersisted: true,
+  isModified: false,
+  changeTracker: { activeState: stateOf(nodes) },
+});
+
+/** The panel's exclusivity computation, as the fence performs it. */
+const exclusive = (rootGraph, active, others) =>
+  !others.some(
+    (o) =>
+      o &&
+      o !== active &&
+      o.isModified !== true &&
+      graphRootMatchesState({ rootGraph, state: o.changeTracker?.activeState }),
+  );
+
+const rebindFor = (rootGraph, active, others, { ownsTag = false, staleEmpty = false } = {}) =>
+  resolveGraphRootUuidRebind({
+    rootGraph,
+    activeWorkflowUuid: "UUID-B",
+    rootTagClaimedByActiveWorkflow: ownsTag,
+    staleTagOnEmptyCanvas: staleEmpty,
+    contentProvesActiveWorkflow: rootContentProvesActiveWorkflow({
+      rootGraph,
+      activeWorkflow: active,
+      proofExclusive: exclusive(rootGraph, active, others),
+    }),
+  });
+
+// ── the reported case ──────────────────────────────────────────────────────
+
+test("a stale tag on a canvas that IS the active workflow's now rebinds", () => {
+  const b = tabOf("B");
+  const root = rootOf("UUID-A");
+  assert.equal(
+    graphRootMatchesState({ rootGraph: root, state: b.changeTracker.activeState }),
+    true,
+    "precondition: the canvas really is B's",
+  );
+  assert.equal(rebindFor(root, b, [b]), "rebind");
+});
+
+test("the asymmetry is gone — a tagged canvas is treated like its untagged twin", () => {
+  // This is the whole defect in one assertion: identical content, one wearing a
+  // stale tag. Before #817 the untagged one sealed and the tagged one refused.
+  const b = tabOf("B");
+  const untagged = rootOf(null);
+  const tagged = rootOf("UUID-A");
+  const proof = (rootGraph) =>
+    rootContentProvesActiveWorkflow({ rootGraph, activeWorkflow: b, proofExclusive: true });
+  assert.equal(proof(untagged), true);
+  assert.equal(proof(tagged), true, "a stale tag does not weaken the content evidence");
+});
+
+// ── what must still refuse ─────────────────────────────────────────────────
+
+test("a clean identical TWIN makes the binding ambiguous — still refuses", () => {
+  // Two clean tabs with byte-identical state: equality cannot tell the active
+  // tab's canvas from its twin's, so nothing may be re-stamped.
+  const b = tabOf("B");
+  const twin = tabOf("Twin");
+  const root = rootOf("UUID-A");
+  assert.equal(exclusive(root, b, [b, twin]), false);
+  assert.equal(rebindFor(root, b, [b, twin]), "conflict");
+});
+
+test("a genuinely FOREIGN canvas still refuses — this is the #349 case", () => {
+  const b = tabOf("B");
+  const foreign = rootOf("UUID-A", [{ id: 9, type: "SaveImage", pos: [0, 0], size: [10, 10] }]);
+  assert.equal(rebindFor(foreign, b, [b]), "conflict");
+});
+
+test("a DIRTY tab proves nothing — a lagging tracker is not evidence (#545)", () => {
+  const dirty = tabOf("B");
+  dirty.isModified = true;
+  const root = rootOf("UUID-A");
+  assert.equal(rootContentProvesActiveWorkflow({ rootGraph: root, activeWorkflow: dirty, proofExclusive: true }), false);
+  assert.equal(rebindFor(root, dirty, [dirty]), "conflict");
+});
+
+test("an unreadable exclusivity check is NOT exclusive — fails closed", () => {
+  const b = tabOf("B");
+  const root = rootOf("UUID-A");
+  assert.equal(
+    rootContentProvesActiveWorkflow({ rootGraph: root, activeWorkflow: b, proofExclusive: false }),
+    false,
+  );
+});
+
+test("a descended SUBGRAPH is not the workflow's root canvas", () => {
+  const b = tabOf("B");
+  const root = rootOf("UUID-A");
+  assert.equal(
+    rootContentProvesActiveWorkflow({ rootGraph: root, activeWorkflow: b, inSubgraph: true, proofExclusive: true }),
+    false,
+  );
+});
+
+test("missing inputs prove nothing", () => {
+  assert.equal(rootContentProvesActiveWorkflow(), false);
+  assert.equal(rootContentProvesActiveWorkflow({ proofExclusive: true }), false);
+  assert.equal(rootContentProvesActiveWorkflow({ rootGraph: rootOf(null), proofExclusive: true }), false);
+  assert.equal(rootContentProvesActiveWorkflow({ activeWorkflow: tabOf("B"), proofExclusive: true }), false);
+});
+
+test("no UUID conflict at all is still 'none', not a rebind", () => {
+  const b = tabOf("B");
+  assert.equal(
+    resolveGraphRootUuidRebind({
+      rootGraph: rootOf("UUID-B"),
+      activeWorkflowUuid: "UUID-B",
+      contentProvesActiveWorkflow: true,
+    }),
+    "none",
+  );
+  assert.equal(
+    resolveGraphRootUuidRebind({ rootGraph: rootOf(null), activeWorkflowUuid: "UUID-B", contentProvesActiveWorkflow: true }),
+    "none",
+    "an untagged root is inconclusive, not a conflict",
+  );
+  void b;
+});
+
+// ── the seal's own contract is unchanged ───────────────────────────────────
+
+test("the seal still refuses to overwrite an existing tag", () => {
+  // The rebind path owns that decision. If the seal started overwriting tags,
+  // the #349 conflict case would lose its refusal entirely.
+  const b = tabOf("B");
+  const tagged = rootOf("UUID-A");
+  assert.equal(
+    sealProvenRootBinding({ rootGraph: tagged, activeWorkflow: b, activeWorkflowUuid: "UUID-B", proofExclusive: true }),
+    false,
+  );
+  assert.equal(tagged.extra.comfyui_mcp.workflow_uuid, "UUID-A", "the tag is untouched");
+});
+
+test("the seal still stamps an untagged, proven, exclusive root", () => {
+  const b = tabOf("B");
+  const untagged = rootOf(null);
+  assert.equal(
+    sealProvenRootBinding({ rootGraph: untagged, activeWorkflow: b, activeWorkflowUuid: "UUID-B", proofExclusive: true }),
+    true,
+  );
+  assert.equal(untagged.extra.comfyui_mcp.workflow_uuid, "UUID-B");
+});
+
+test("the seal and the rebind ask the SAME question", () => {
+  // They drifted once already. The seal now delegates to the shared predicate,
+  // so a change to one cannot silently leave the other behind.
+  const b = tabOf("B");
+  const dirty = tabOf("B");
+  dirty.isModified = true;
+  for (const [label, active, expected] of [["clean", b, true], ["dirty", dirty, false]]) {
+    const untagged = rootOf(null);
+    assert.equal(
+      sealProvenRootBinding({ rootGraph: untagged, activeWorkflow: active, activeWorkflowUuid: "UUID-B", proofExclusive: true }),
+      expected,
+      `seal, ${label}`,
+    );
+    assert.equal(
+      rootContentProvesActiveWorkflow({ rootGraph: rootOf(null), activeWorkflow: active, proofExclusive: true }),
+      expected,
+      `proof, ${label}`,
+    );
+  }
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -359,6 +359,7 @@ import {
   OPEN_REBIND_STATUS,
   OPEN_PROOF_FIELD,
   sealProvenRootBinding,
+  rootContentProvesActiveWorkflow,
 } from "./lib/graph-binding.js";
 import { summarizePromptRejection, buildQueueAcceptResult } from "./lib/queue-rejection.js";
 import { createRunFetchInterceptor, dispatchScopedRun } from "./lib/run-scope-guard.js";
@@ -5107,6 +5108,28 @@ function assertGraphBoundToActiveWorkflow(
   // drifted binding the tracker cannot prove is panel_open_workflow's proven
   // repaint re-stamp. The ONE exception is the both-empty stale tag below
   // (#565): with zero nodes on either side there is no content to protect.
+  // #817 — the exclusivity proof is computed HERE, above the rebind, because BOTH
+  // decisions below need it: the stale-tag rebind and the unstamped-root seal ask
+  // the same question (is this canvas provably the active workflow's?) and must not
+  // answer it differently.
+  let sealProofExclusive = false;
+  try {
+    const others = app?.extensionManager?.workflow?.openWorkflows;
+    if (Array.isArray(others)) {
+      sealProofExclusive = true;
+      for (const other of others) {
+        if (!other || sameWorkflowObject(other, activeWorkflow)) continue;
+        if (other.isModified === true) continue; // unprovable — not evidence of ambiguity
+        const otherState = other.changeTracker?.activeState ?? other.activeState;
+        if (graphRootMatchesState({ rootGraph, state: otherState })) {
+          sealProofExclusive = false; // a proven identical twin — binding is ambiguous
+          break;
+        }
+      }
+    }
+  } catch {
+    sealProofExclusive = false; // enumeration failed → exclusivity unproven → no seal
+  }
   let rootUuidMismatch = graphRootWorkflowUuidMismatches({ rootGraph, activeWorkflowUuid });
   if (rootUuidMismatch) {
     const rootUuid = rootGraph?.extra?.[WORKFLOW_META_NAMESPACE]?.[WORKFLOW_UUID_FIELD];
@@ -5133,8 +5156,24 @@ function assertGraphBoundToActiveWorkflow(
     // guard below.
     const staleTagOnEmptyCanvas =
       graphRootProvenEmpty(rootGraph) && activeWorkflowProvenEmpty(activeWorkflow);
+    // #817 — a tab switch leaves the PREVIOUS workflow's tag on the reused
+    // app.graph, so a canvas that IS the active workflow's was refused where an
+    // untagged copy of it was allowed, and nothing self-healed it: the seal below
+    // declines a root that already carries a tag. Same proof the seal accepts.
+    const contentProvesActiveWorkflow = rootContentProvesActiveWorkflow({
+      rootGraph,
+      activeWorkflow,
+      inSubgraph,
+      proofExclusive: sealProofExclusive,
+    });
     if (
-      resolveGraphRootUuidRebind({ rootGraph, activeWorkflowUuid, rootTagClaimedByActiveWorkflow, staleTagOnEmptyCanvas }) === "rebind"
+      resolveGraphRootUuidRebind({
+        rootGraph,
+        activeWorkflowUuid,
+        rootTagClaimedByActiveWorkflow,
+        staleTagOnEmptyCanvas,
+        contentProvesActiveWorkflow,
+      }) === "rebind"
     ) {
       try {
         stampGraphRootWorkflowUuid(rootGraph, activeWorkflowUuid, activeWorkflow);
@@ -5163,24 +5202,6 @@ function assertGraphBoundToActiveWorkflow(
   // exclusivity check itself cannot run — the seal stays off and the command
   // keeps the pre-seal fail-closed behaviour. A DIRTY twin cannot prove a match
   // (its tracker may lag) and does not block the seal.
-  let sealProofExclusive = false;
-  try {
-    const others = app?.extensionManager?.workflow?.openWorkflows;
-    if (Array.isArray(others)) {
-      sealProofExclusive = true;
-      for (const other of others) {
-        if (!other || sameWorkflowObject(other, activeWorkflow)) continue;
-        if (other.isModified === true) continue; // unprovable — not evidence of ambiguity
-        const otherState = other.changeTracker?.activeState ?? other.activeState;
-        if (graphRootMatchesState({ rootGraph, state: otherState })) {
-          sealProofExclusive = false; // a proven identical twin — binding is ambiguous
-          break;
-        }
-      }
-    }
-  } catch {
-    sealProofExclusive = false; // enumeration failed → exclusivity unproven → no seal
-  }
   sealProvenRootBinding({
     rootGraph,
     activeWorkflow,

--- a/web/js/lib/graph-binding.js
+++ b/web/js/lib/graph-binding.js
@@ -1241,6 +1241,20 @@ export function describeOpenRebindOutcome(verdict, observed = {}) {
  *                zero nodes on BOTH sides there is no workflow content that
  *                could be confused — the #349 fence protects CONTENT — so the
  *                leftover tag is stale metadata: re-stamp and proceed;
+ *                Also when `contentProvesActiveWorkflow` is set (#817): the live
+ *                root serializes EQUAL to the active workflow's own current
+ *                state, on a clean tab, with no other open workflow able to
+ *                claim the same canvas. That is the same proof
+ *                `sealProvenRootBinding` accepts to stamp an UNTAGGED root, and
+ *                the evidence does not get weaker because a stale tag happens to
+ *                be sitting on the object. The asymmetry it removes was the #817
+ *                report: switching tabs leaves the PREVIOUS workflow's tag on the
+ *                reused app.graph (configure does not reset graph.extra — the
+ *                same mechanism the empty-canvas clause above records), so a
+ *                canvas that IS the active workflow's, byte for byte, was refused
+ *                where an untagged copy of it was allowed. Nothing self-healed
+ *                it: the seal declines a root that already carries a tag, so a
+ *                WRONG tag was stickier than no tag at all;
  *   "conflict" — anything else. A tag claimed by a FOREIGN open workflow is the
  *                #349 wrong-canvas case, and a tag NOBODY claims may be a
  *                closed tab's stale canvas — re-stamping either would authorize
@@ -1253,9 +1267,12 @@ export function resolveGraphRootUuidRebind({
   activeWorkflowUuid,
   rootTagClaimedByActiveWorkflow = false,
   staleTagOnEmptyCanvas = false,
+  contentProvesActiveWorkflow = false,
 } = {}) {
   if (!graphRootWorkflowUuidMismatches({ rootGraph, activeWorkflowUuid })) return "none";
-  return rootTagClaimedByActiveWorkflow || staleTagOnEmptyCanvas ? "rebind" : "conflict";
+  return rootTagClaimedByActiveWorkflow || staleTagOnEmptyCanvas || contentProvesActiveWorkflow
+    ? "rebind"
+    : "conflict";
 }
 
 /**
@@ -1322,6 +1339,41 @@ export function graphCommandMayMutateWorkflow(command) {
  *     keeps the pre-seal fail-closed behaviour.
  * Returns true only when it actually wrote the stamp.
  */
+/**
+ * POSITIVE proof that the live root graph IS the active workflow's own canvas,
+ * from its CONTENT alone — independent of whatever identity tag it happens to
+ * carry.
+ *
+ * This is the bar `sealProvenRootBinding` has always used; #817 lifted it out so
+ * a second caller could ask the same question without the two drifting. Every
+ * clause is load-bearing:
+ *   - ROOT scope: a descended subgraph is not the workflow's root canvas;
+ *   - CLEAN tab: a dirty tracker's state can lag the real canvas (#545), so it
+ *     cannot prove anything about it;
+ *   - the root must serialize EQUAL to the workflow's own CURRENT state — not
+ *     its load baseline, which legitimately differs from an edited canvas;
+ *   - EXCLUSIVE: two clean, separately open DUPLICATE tabs can carry
+ *     byte-identical state, and equality alone cannot tell the active tab's
+ *     canvas from its twin's. The caller establishes this by enumerating the
+ *     other open workflows; an enumeration that cannot run is NOT exclusive.
+ */
+export function rootContentProvesActiveWorkflow({
+  rootGraph,
+  activeWorkflow,
+  inSubgraph = false,
+  proofExclusive = false,
+} = {}) {
+  try {
+    if (inSubgraph) return false;
+    if (proofExclusive !== true) return false;
+    if (!rootGraph || !activeWorkflow) return false;
+    if (activeWorkflow.isModified === true) return false;
+    return graphRootMatchesState({ rootGraph, state: activeWorkflowCurrentState(activeWorkflow) });
+  } catch {
+    return false;
+  }
+}
+
 export function sealProvenRootBinding({
   rootGraph,
   activeWorkflow,
@@ -1330,14 +1382,11 @@ export function sealProvenRootBinding({
   proofExclusive = true,
 } = {}) {
   try {
-    if (inSubgraph) return false;
-    if (proofExclusive !== true) return false;
-    if (!rootGraph || !activeWorkflow) return false;
     if (typeof activeWorkflowUuid !== "string" || !activeWorkflowUuid) return false;
-    if (activeWorkflow.isModified === true) return false;
+    // A CONFLICTING stamp is the rebind path's decision, never overwritten here.
     const existing = rootGraph?.extra?.comfyui_mcp?.workflow_uuid;
     if (typeof existing === "string" && existing) return false;
-    if (!graphRootMatchesState({ rootGraph, state: activeWorkflowCurrentState(activeWorkflow) })) {
+    if (!rootContentProvesActiveWorkflow({ rootGraph, activeWorkflow, inSubgraph, proofExclusive })) {
       return false;
     }
     const extra =


### PR DESCRIPTION
> Immediately after the panel announced a switch to an active workflow, `panel_graph_outline` rejected the graph because the canvas identity tag was stale. Re-opening the already-active workflow fixed the binding.

Reproduced against the real predicates before changing anything — the reporter's error text comes back verbatim.

## The mechanism

ComfyUI reuses **one** `app.graph` across tabs and its clear/configure does **not** reset `graph.extra` — the same thing the #565 both-empty clause already records for blank tabs. So switching A → B leaves A's identity tag sitting on a canvas that now holds B's graph, and the tag guard refuses every graph tool.

Nothing self-healed it, and that is the sharp part: `sealProvenRootBinding` declines a root that **already carries a tag**, so a *wrong* tag was stickier than *no* tag at all. A byte-identical canvas with no tag sealed and read fine; the same canvas wearing a stale tag was refused until the user re-opened the workflow — exactly the workaround the reporter found.

## The fix

The rebind gains a third escape: the live root serializes **equal to the active workflow's own current state**. That is not a new bar — it is precisely the proof `sealProvenRootBinding` already accepts to stamp an untagged root, and the evidence does not get weaker because a stale tag happens to be sitting on the object.

Rather than copy it, the bar is lifted into `rootContentProvesActiveWorkflow` and **the seal now delegates to it**, so the two cannot answer the same question differently. Every clause is kept: ROOT scope, CLEAN tab (a dirty tracker can lag the real canvas, #545), equality against the workflow's own *current* state (never its load baseline), and EXCLUSIVE — two clean duplicate tabs can carry byte-identical state, and equality alone cannot tell the active tab's canvas from its twin's. The panel's exclusivity enumeration moves above the rebind block, because both decisions now need it.

## What still refuses — verified, not assumed

A clean identical **twin** open (ambiguous), a canvas whose content is genuinely not the active workflow's (the #349 wrong-canvas case), a **dirty** tab, a descended **subgraph**, and an exclusivity check that could not run. The seal still refuses to overwrite an existing tag — that decision belongs to the rebind path, and moving it would cost #349 its refusal.

## Review

Codex opened at **NO-SHIP** with four findings. One was a misread of my prompt's ellipsis (the string literals are real; I ran the seal to confirm it stamps). The other three — `staleTagOnEmptyCanvas` rebinding without an exclusivity proof, the exclusivity scan skipping dirty twins, and the scan covering only `openWorkflows` — I verified are all present on `origin/main` verbatim and untouched by this diff.

Asked specifically whether a stale-tagged root is now re-stamped in any case where an otherwise-identical untagged root would *not* have been sealed, it answered **no**, and withdrew the verdict: *"NO-SHIP is not warranted for this diff; my prior verdict incorrectly treated inherited fence behavior as a regression. This change repairs the tagged-versus-untagged asymmetry without weakening the content-proof bar."*

Those three inherited properties are worth their own look, but they are not this issue and I have not touched them.

## Test-harness note

`graph-binding.test.mjs` injects the fence function's **source** into `new Function` with an explicit dependency list, so a new dependency made 21 assertions die on a `ReferenceError` rather than exercise the guard. Added. Worth knowing about — it reads as a behavioural regression and is not one.

## Verification

12 new unit tests. Mutation-verified: dropping the new escape (the original bug), dropping the exclusivity requirement, letting a dirty tab prove it, dropping the subgraph guard, and letting the seal overwrite an existing tag each fail. Full unit suite: **3190 pass / 0 fail**.

Refs #817
