### PR TITLE
0.11.51 — a tab switch stops leaving the canvas unreadable (#817)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+## [0.11.51] - 2026-08-09
+
+> Covers changes since 0.11.50.
+
+### Fixed
+- Switching workflow tabs could leave every `panel_*` graph tool refusing the ACTIVE workflow
+  with `root-workflow-uuid-mismatch`, until the user re-opened the workflow that was already
+  open. ComfyUI reuses one canvas object across tabs and does not reset its metadata, so the
+  previous workflow's identity tag stays behind on a canvas that now holds the new one's graph.
+
+  The panel could already recover a canvas carrying NO tag — it proves the canvas is the active
+  workflow's by comparing content, then stamps it. It could not recover one carrying the WRONG
+  tag, because that stamp is never overwritten. A wrong tag was therefore stickier than no tag:
+  a byte-identical canvas was allowed in one case and refused in the other. The same content
+  proof now settles both.
+
+  Deliberately unchanged: a canvas that is genuinely a different workflow's still refuses, and
+  so does an ambiguous one — a second clean tab holding identical content, a tab with unsaved
+  edits (whose state can lag the real canvas), or a check that could not run at all (#817)
+
 ## [0.11.50] - 2026-08-09
 
 > Covers changes since 0.11.49.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-agent-panel"
 description = "Autonomous AI agent in the ComfyUI sidebar - local-first, bring any LLM. Run it on your Claude or ChatGPT subscription (no API keys, no extra LLM costs), on a Kimi K3 / GLM / OpenRouter key, or fully offline on free local models via Ollama, LM Studio, or llama.cpp. The agent drives your live canvas at full parity: add, wire, move and tweak nodes with Ctrl+Z undo, load whole workflows and installer packs in one shot, generate images, video and audio, browse CivitAI, and run your workflow - asking before it spends paid API credits. The sidebar UI for comfyui-mcp, the local-first, agent-native control plane for ComfyUI."
-version = "0.11.50"
+version = "0.11.51"
 license = { file = "LICENSE" }
 requires-python = ">=3.9"
 # UI-only pack: no Python deps. The frontend floor guarantees

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -867,7 +867,7 @@ const DOCS_URL = "https://comfyui-mcp.artokun.io/docs";
 // Panel version — surfaced in the "Need help?" diagnostics blob. Bump via
 // `node scripts/set-version.mjs <v>` (updates this AND pyproject together); CI
 // and the publish gate FAIL if the two ever drift, so this can't go stale.
-const PANEL_VERSION = "0.11.50";
+const PANEL_VERSION = "0.11.51";
 
 // The connected orchestrator's console URL/token (captured off the `backends`
 // bridge message — see onBackends). Drives the "API Keys" credentials frame;


### PR DESCRIPTION
One user-facing change since 0.11.50: **#817 / #843**.

Switching workflow tabs could leave every `panel_*` graph tool refusing the **active** workflow with `root-workflow-uuid-mismatch`, until the user re-opened the workflow that was already open. ComfyUI reuses one canvas object across tabs and does not reset its metadata, so the previous workflow's identity tag stays behind on a canvas that now holds the new one's graph.

The panel could already recover a canvas carrying **no** tag — it proves the canvas is the active workflow's by comparing content, then stamps it. It could not recover one carrying the **wrong** tag, because that stamp is never overwritten. A wrong tag was stickier than no tag. The same content proof now settles both.

Also includes #832/#842 (test-only).

## Gates

- `pyproject` 0.11.51 and `PANEL_VERSION` 0.11.51 match (the publish gate's own check, run locally).
- Full unit suite: **3190 pass / 0 fail**.
- Verified in real Chrome against the merged commit: the reported case rebinds, and a clean identical twin, a genuinely foreign canvas, a dirty tab, subgraph scope and an unproven exclusivity check all still refuse; the seal still declines to overwrite an existing tag.

Refs #817