### PR TITLE
test(e2e): teach the harness to stamp workflow_uuid, reviving ~60% of the suite (#793)

### DIFF
--- a/browser_tests/auto-layout.spec.ts
+++ b/browser_tests/auto-layout.spec.ts
@@ -27,32 +27,24 @@ interface CmdReply {
 }
 
 /**
- * Send a graph command through the bridge and resolve with its result. The panel
- * replies `{rid, ok, result|error}`; we match on rid via the MockBridge frame tap.
+ * Send a graph command and resolve with its result, throwing the panel's own
+ * error text on refusal.
+ *
+ * #793 — this used to build and send the frame itself, which meant it never
+ * carried a `workflow_uuid` and every mutation here was refused by the #718
+ * fence before it reached an executor. It now delegates to
+ * `MockBridge.command()`, which stamps. A second hand-rolled sender is exactly
+ * how this file drifted out of the fix the fixture already had.
  */
-function command(
+async function command(
   bridge: MockBridge,
   cmd: string,
   args: Record<string, unknown> = {},
   timeoutMs = 15_000
 ): Promise<Record<string, unknown>> {
-  const rid = `t-${cmd}-${Math.random().toString(36).slice(2)}`
-  return new Promise((resolve, reject) => {
-    const timer = setTimeout(() => {
-      off()
-      reject(new Error(`command "${cmd}" timed out`))
-    }, timeoutMs)
-    const off = bridge.onFrame((frame) => {
-      const f = frame as unknown as CmdReply
-      if (f.rid === rid && typeof f.ok === 'boolean') {
-        clearTimeout(timer)
-        off()
-        if (f.ok) resolve(f.result ?? {})
-        else reject(new Error(f.error ?? `command "${cmd}" failed`))
-      }
-    })
-    bridge.send({ rid, cmd, ...args })
-  })
+  const reply = (await bridge.command(cmd, args, timeoutMs)) as unknown as CmdReply
+  if (!reply.ok) throw new Error(reply.error ?? `command "${cmd}" failed`)
+  return reply.result ?? {}
 }
 
 /** Best-effort connect (ignores type-incompat refusals — layout is edge-tolerant). */

--- a/browser_tests/connect-matcher.spec.ts
+++ b/browser_tests/connect-matcher.spec.ts
@@ -23,7 +23,7 @@
  */
 import { test, expect } from './fixtures/panelTest'
 import type { Page } from '@playwright/test'
-import { claimFreshCanvas } from './fixtures/canvasIdentity'
+import { claimFreshCanvas, settleCanvas } from './fixtures/canvasIdentity'
 import type { MockBridge } from './fixtures/MockBridge'
 
 interface SlotSpec {
@@ -52,7 +52,7 @@ async function buildGraph(
   // below is refused as dirty-mutation-binding-unproven, which is what made
   // this file fail 6/6 while the code under test was fine.
   await claimFreshCanvas(page, bridge)
-  return page.evaluate((nodeSpecs: NodeSpec[]) => {
+  const ids = await page.evaluate((nodeSpecs: NodeSpec[]) => {
     const w = window as any
     const app = w.comfyAPI?.app?.app || w.app
     const LiteGraph = w.LiteGraph
@@ -84,6 +84,12 @@ async function buildGraph(
     }
     return ids
   }, specs)
+  // #793 — the tracker captures on the events the real UI emits, and
+  // graph.add() from the page fires none of them. Without this the workflow's
+  // own state still describes the canvas from BEFORE the build, and the
+  // binding guard correctly refuses the mismatch.
+  await settleCanvas(page)
+  return ids
 }
 
 /** Bring the panel up and connected to the MockBridge. */
@@ -124,7 +130,7 @@ test('1. omitted to_input auto-matches clip ← CLIP', async ({ panel, mockBridg
     // to_input omitted → auto-match by type
   })
 
-  expect(reply.ok).toBe(true)
+  expect(reply.ok, JSON.stringify(reply).slice(0, 500)).toBe(true)
   expect(reply.result.connected.to.input).toBe('clip')
   expect(reply.result.connected.from.output).toBe('CLIP')
   expect(reply.result.connected.type).toBe('CLIP')
@@ -203,7 +209,7 @@ test('3. auto_match:false + omitted slots reproduces legacy index-0 behavior', a
     // both slots omitted → legacy index 0 → MODEL(out 0) → model(in 0)
   })
 
-  expect(reply.ok).toBe(true)
+  expect(reply.ok, JSON.stringify(reply).slice(0, 500)).toBe(true)
   expect(reply.result.connected.from.output_index).toBe(0)
   expect(reply.result.connected.to.input_index).toBe(0)
   expect(reply.result.connected.from.output).toBe('MODEL')
@@ -303,7 +309,7 @@ test('6. wildcard ("*") connects but loses to an exact-type match', async ({
     // both omitted → exact MODEL→model must beat "*"→model
   })
 
-  expect(reply.ok).toBe(true)
+  expect(reply.ok, JSON.stringify(reply).slice(0, 500)).toBe(true)
   expect(reply.result.connected.from.output_index).toBe(1)
   expect(reply.result.connected.from.output).toBe('MODEL')
   expect(reply.result.connected.type).toBe('MODEL')

--- a/browser_tests/connect-matcher.spec.ts
+++ b/browser_tests/connect-matcher.spec.ts
@@ -23,6 +23,8 @@
  */
 import { test, expect } from './fixtures/panelTest'
 import type { Page } from '@playwright/test'
+import { claimFreshCanvas } from './fixtures/canvasIdentity'
+import type { MockBridge } from './fixtures/MockBridge'
 
 interface SlotSpec {
   name: string
@@ -40,7 +42,16 @@ interface NodeSpec {
  * slot shapes a test wants. Returns the assigned node ids, one per spec (order
  * preserved). Runs entirely in the page against window.LiteGraph / app.graph.
  */
-async function buildGraph(page: Page, specs: NodeSpec[]): Promise<number[]> {
+async function buildGraph(
+  page: Page,
+  bridge: MockBridge,
+  specs: NodeSpec[]
+): Promise<number[]> {
+  // #793 — clear the canvas and let the PANEL claim it, so the graph these
+  // nodes land on carries a real identity stamp. Without it every mutation
+  // below is refused as dirty-mutation-binding-unproven, which is what made
+  // this file fail 6/6 while the code under test was fine.
+  await claimFreshCanvas(page, bridge)
   return page.evaluate((nodeSpecs: NodeSpec[]) => {
     const w = window as any
     const app = w.comfyAPI?.app?.app || w.app
@@ -54,7 +65,6 @@ async function buildGraph(page: Page, specs: NodeSpec[]): Promise<number[]> {
       LiteGraph.registerNodeType(TYPE, CmcpMatcherNode)
     }
 
-    graph.clear()
     const ids: number[] = []
     for (const spec of nodeSpecs) {
       const node = LiteGraph.createNode(TYPE)
@@ -95,7 +105,7 @@ const CHECKPOINT: NodeSpec = {
 
 test('1. omitted to_input auto-matches clip ← CLIP', async ({ panel, mockBridge }) => {
   await connectPanel(panel, mockBridge)
-  const [ckpt, enc] = await buildGraph(panel.page, [
+  const [ckpt, enc] = await buildGraph(panel.page, mockBridge, [
     CHECKPOINT,
     {
       title: 'CLIPTextEncode',
@@ -126,7 +136,7 @@ test('2. CONDITIONING ambiguity errors with both slot names + [connected] marker
   mockBridge
 }) => {
   await connectPanel(panel, mockBridge)
-  const [ckpt, enc, ksampler] = await buildGraph(panel.page, [
+  const [ckpt, enc, ksampler] = await buildGraph(panel.page, mockBridge, [
     CHECKPOINT,
     {
       title: 'CLIPTextEncode',
@@ -175,7 +185,7 @@ test('3. auto_match:false + omitted slots reproduces legacy index-0 behavior', a
   mockBridge
 }) => {
   await connectPanel(panel, mockBridge)
-  const [ckpt, ksampler] = await buildGraph(panel.page, [
+  const [ckpt, ksampler] = await buildGraph(panel.page, mockBridge, [
     CHECKPOINT,
     {
       title: 'KSampler',
@@ -206,7 +216,7 @@ test('4. explicit wrong name errors with the full slot listing', async ({
   mockBridge
 }) => {
   await connectPanel(panel, mockBridge)
-  const [ckpt, ksampler] = await buildGraph(panel.page, [
+  const [ckpt, ksampler] = await buildGraph(panel.page, mockBridge, [
     CHECKPOINT,
     {
       title: 'KSampler',
@@ -236,7 +246,7 @@ test('5. reconnect over a connected input reports replaced_link', async ({
   mockBridge
 }) => {
   await connectPanel(panel, mockBridge)
-  const [ckptA, ckptB, ksampler] = await buildGraph(panel.page, [
+  const [ckptA, ckptB, ksampler] = await buildGraph(panel.page, mockBridge, [
     CHECKPOINT,
     CHECKPOINT,
     {
@@ -273,7 +283,7 @@ test('6. wildcard ("*") connects but loses to an exact-type match', async ({
   // A reroute-style origin with BOTH a "*" wildcard output and an exact MODEL
   // output. Auto-match to a MODEL input must prefer the exact output (index 1),
   // proving wildcard is ranked below exact.
-  const [reroute, ksampler] = await buildGraph(panel.page, [
+  const [reroute, ksampler] = await buildGraph(panel.page, mockBridge, [
     {
       title: 'Reroute',
       outputs: [
@@ -300,7 +310,7 @@ test('6. wildcard ("*") connects but loses to an exact-type match', async ({
 
   // And a pure wildcard source still connects (wildcard is compatible, just
   // lower-ranked): a lone "*" output auto-matches the MODEL input.
-  const [rerouteOnly, ks2] = await buildGraph(panel.page, [
+  const [rerouteOnly, ks2] = await buildGraph(panel.page, mockBridge, [
     { title: 'Reroute', outputs: [{ name: 'wild', type: '*' }] },
     { title: 'KSampler', inputs: [{ name: 'model', type: 'MODEL' }] }
   ])

--- a/browser_tests/fixtures/MockBridge.ts
+++ b/browser_tests/fixtures/MockBridge.ts
@@ -81,11 +81,22 @@ export class MockBridge {
   private readonly frameCbs = new Set<FrameCb>()
   private readonly userMessages: UserMessage[] = []
   private readonly userMessageWaiters: Array<(m: UserMessage) => void> = []
+  /** Commands that change WHICH workflow is active, so a cached identity for the
+   *  outgoing one must not survive them. All are exempt from the workflow fence,
+   *  so they need no stamp of their own. */
+  private static readonly WORKFLOW_REPOINTING_COMMANDS = new Set([
+    'workflow_new',
+    'workflow_open',
+    'workflow_close'
+  ])
   private streamSeq = 0
   /** #793 — the active canvas's workflow-instance uuid, learned once per page
    *  and reused. Cleared by `forgetWorkflowUuid()` when a spec deliberately
    *  changes which workflow is active. */
   private workflowUuid: string | null = null
+  /** In-flight identity lookup, so two commands racing the first send do not
+   *  each probe (codex). */
+  private workflowUuidInFlight: Promise<string | null> | null = null
 
   constructor(options: MockBridgeOptions = {}) {
     this.opts = {
@@ -329,15 +340,30 @@ export class MockBridge {
    */
   async activeWorkflowUuid(): Promise<string | null> {
     if (this.workflowUuid) return this.workflowUuid
-    const reply = await this.sendCommand('workflow_list', {})
-    const uuid = reply?.result?.active?.workflow_uuid
-    this.workflowUuid = typeof uuid === 'string' && uuid ? uuid : null
-    return this.workflowUuid
+    // SINGLE-FLIGHT (codex): `command()` is async before it sends, so two
+    // commands issued together both reach here with an empty cache. Sharing the
+    // probe keeps it to one round trip and, more importantly, keeps them from
+    // resolving against two different reads.
+    if (!this.workflowUuidInFlight) {
+      this.workflowUuidInFlight = this.sendCommand('workflow_list', {})
+        .then((reply) => {
+          const uuid = (reply as any)?.result?.active?.workflow_uuid
+          this.workflowUuid = typeof uuid === 'string' && uuid ? uuid : null
+          return this.workflowUuid
+        })
+        .finally(() => {
+          this.workflowUuidInFlight = null
+        })
+    }
+    return this.workflowUuidInFlight
   }
 
-  /** Drop the cached uuid — call after a spec switches or creates a workflow. */
+  /** Drop the cached uuid — call after a spec switches or creates a workflow.
+   *  Rarely needed by hand: the commands that re-point the active workflow
+   *  invalidate it themselves (see WORKFLOW_REPOINTING_COMMANDS). */
   forgetWorkflowUuid(): void {
     this.workflowUuid = null
+    this.workflowUuidInFlight = null
   }
 
   /**
@@ -365,6 +391,17 @@ export class MockBridge {
     if (Object.prototype.hasOwnProperty.call(args, 'workflow_uuid')) {
       const { workflow_uuid: explicit, ...rest } = args
       return this.sendCommand(cmd, explicit == null ? rest : args, timeoutMs)
+    }
+    // A command that RE-POINTS the active workflow invalidates the cache before
+    // it runs, not after (codex): otherwise it stamps itself with the identity of
+    // the workflow it is about to leave, and the next command inherits a uuid for
+    // a canvas that is no longer active. These are all fence-exempt, so sending
+    // them unstamped is exactly what the orchestrator does.
+    if (MockBridge.WORKFLOW_REPOINTING_COMMANDS.has(cmd)) {
+      this.forgetWorkflowUuid()
+      const reply = await this.sendCommand(cmd, args, timeoutMs)
+      this.forgetWorkflowUuid()
+      return reply
     }
     const uuid = await this.activeWorkflowUuid()
     return this.sendCommand(cmd, uuid ? { ...args, workflow_uuid: uuid } : args, timeoutMs)

--- a/browser_tests/fixtures/MockBridge.ts
+++ b/browser_tests/fixtures/MockBridge.ts
@@ -82,6 +82,10 @@ export class MockBridge {
   private readonly userMessages: UserMessage[] = []
   private readonly userMessageWaiters: Array<(m: UserMessage) => void> = []
   private streamSeq = 0
+  /** #793 — the active canvas's workflow-instance uuid, learned once per page
+   *  and reused. Cleared by `forgetWorkflowUuid()` when a spec deliberately
+   *  changes which workflow is active. */
+  private workflowUuid: string | null = null
 
   constructor(options: MockBridgeOptions = {}) {
     this.opts = {
@@ -283,7 +287,11 @@ export class MockBridge {
    * ({ rid, ok, result } | { rid, ok:false, error }). Used by the connect-matcher
    * suite to exercise GRAPH_TOOL_EXECUTORS against the live LiteGraph graph.
    */
-  command(
+  /**
+   * Send one command frame and resolve with the panel's reply. Internal: does
+   * NOT stamp, so the identity probe below can use it without recursing.
+   */
+  private sendCommand(
     cmd: string,
     args: Record<string, unknown> = {},
     timeoutMs = 10_000
@@ -305,6 +313,62 @@ export class MockBridge {
     })
   }
 
+  /**
+   * The active canvas's workflow-instance uuid, learned from the panel itself.
+   *
+   * #793 — `workflow_list` is the right source and the only one that always
+   * works: it reports `active.workflow_uuid`, and it is deliberately EXEMPT
+   * from the very fence we are trying to satisfy (#759/#932 — it is the
+   * orchestrator's own recovery probe, so fencing it would make the repair
+   * require the fence to be already correct). That is why the harness can read
+   * identity even from a wedged session, and why this needs no new panel API.
+   *
+   * Cached: the uuid is per workflow INSTANCE, so re-reading it before every
+   * command would double the frame count for no gain. A spec that switches or
+   * creates a workflow calls `forgetWorkflowUuid()`.
+   */
+  async activeWorkflowUuid(): Promise<string | null> {
+    if (this.workflowUuid) return this.workflowUuid
+    const reply = await this.sendCommand('workflow_list', {})
+    const uuid = reply?.result?.active?.workflow_uuid
+    this.workflowUuid = typeof uuid === 'string' && uuid ? uuid : null
+    return this.workflowUuid
+  }
+
+  /** Drop the cached uuid — call after a spec switches or creates a workflow. */
+  forgetWorkflowUuid(): void {
+    this.workflowUuid = null
+  }
+
+  /**
+   * Drive a graph command the way the real orchestrator does: send
+   * { rid, cmd, workflow_uuid, ...args } to the panel and resolve with the
+   * panel's reply frame ({ rid, ok, result } | { rid, ok:false, error }).
+   *
+   * #793 — THE STAMP IS WHY THIS SUITE WORKS. The panel advertises the
+   * workflow-stamp capability, so the #718 fence refuses any active-canvas
+   * MUTATION that arrives without one — correctly: an unstamped mutation is
+   * indistinguishable from one issued for a workflow the user has since
+   * switched away from. The harness never learned to stamp, so every
+   * graph-mutating spec was refused before it reached its executor and the
+   * suite silently stopped covering the thing it exists to cover.
+   *
+   * A caller that passes `workflow_uuid` explicitly keeps it verbatim — a spec
+   * testing the FENCE ITSELF needs to send a stale one, or none (pass
+   * `workflow_uuid: undefined`), and must not have this quietly repair it.
+   */
+  async command(
+    cmd: string,
+    args: Record<string, unknown> = {},
+    timeoutMs = 10_000
+  ): Promise<{ rid: string; ok: boolean; result?: any; error?: string }> {
+    if (Object.prototype.hasOwnProperty.call(args, 'workflow_uuid')) {
+      const { workflow_uuid: explicit, ...rest } = args
+      return this.sendCommand(cmd, explicit == null ? rest : args, timeoutMs)
+    }
+    const uuid = await this.activeWorkflowUuid()
+    return this.sendCommand(cmd, uuid ? { ...args, workflow_uuid: uuid } : args, timeoutMs)
+  }
   /** Close all sockets and the server. */
   async close(): Promise<void> {
     for (const s of this.sockets) {

--- a/browser_tests/fixtures/canvasIdentity.ts
+++ b/browser_tests/fixtures/canvasIdentity.ts
@@ -50,9 +50,8 @@ export async function claimFreshCanvas(page: Page, bridge: MockBridge): Promise<
   if (!created.ok) {
     throw new Error(`claimFreshCanvas: workflow_new failed — ${created.error ?? 'no reason given'}`)
   }
-  // The new tab is a new INSTANCE, so anything the bridge cached for the previous
-  // one is stale; the next stamped command must re-read.
-  bridge.forgetWorkflowUuid()
+  // No manual invalidation needed: `workflow_new` is one of the commands
+  // MockBridge treats as re-pointing, so it drops the cache around the call.
   return bridge.activeWorkflowUuid()
 }
 
@@ -75,12 +74,22 @@ export async function claimFreshCanvas(page: Page, bridge: MockBridge): Promise<
  * Call it after building, before the first command.
  */
 export async function settleCanvas(page: Page): Promise<void> {
-  await page.evaluate(() => {
+  const settled = await page.evaluate(() => {
     const w = window as any
     const app = w.comfyAPI?.app?.app || w.app
     const tracker = app?.extensionManager?.workflow?.activeWorkflow?.changeTracker
-    // Best-effort by design: a frontend without this hook leaves the spec to
-    // fail on its own assertion rather than on a confusing helper error.
-    tracker?.checkState?.()
+    if (typeof tracker?.checkState !== 'function') return false
+    tracker.checkState()
+    return true
   })
+  // NOT best-effort (codex). A silent no-op here surfaces later as a binding
+  // refusal in the middle of an assertion, which is precisely the misdirection
+  // that left this suite's real cause unread for months. If the harness cannot
+  // set the fixture up, it says so where it happened.
+  if (!settled) {
+    throw new Error(
+      'settleCanvas: no ChangeTracker on the active workflow — the panel cannot be ' +
+        'told about nodes this spec added, so every mutation would be refused as a desync'
+    )
+  }
 }

--- a/browser_tests/fixtures/canvasIdentity.ts
+++ b/browser_tests/fixtures/canvasIdentity.ts
@@ -55,3 +55,32 @@ export async function claimFreshCanvas(page: Page, bridge: MockBridge): Promise<
   bridge.forgetWorkflowUuid()
   return bridge.activeWorkflowUuid()
 }
+
+/**
+ * Let the panel SEE the nodes a spec just added (#793).
+ *
+ * ComfyUI's ChangeTracker captures the canvas on the events the real UI emits.
+ * A spec that builds its fixture by calling `graph.add()` from the page fires
+ * none of them, so the workflow's tracked state still reports the canvas it had
+ * BEFORE the build — and the binding guard, comparing the two, refuses:
+ *
+ *   [root-shape-mismatch] … the canvas's content does not match the active
+ *   workflow's own state … The panel cannot tell whether this is a DIFFERENT
+ *   workflow's canvas or this workflow's own canvas drifted …
+ *
+ * Which is the correct answer to the question it was asked. `checkState()` is
+ * the tracker's own capture — the same one a real edit triggers — so this makes
+ * the fixture look like an edit rather than like a desync.
+ *
+ * Call it after building, before the first command.
+ */
+export async function settleCanvas(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    const w = window as any
+    const app = w.comfyAPI?.app?.app || w.app
+    const tracker = app?.extensionManager?.workflow?.activeWorkflow?.changeTracker
+    // Best-effort by design: a frontend without this hook leaves the spec to
+    // fail on its own assertion rather than on a confusing helper error.
+    tracker?.checkState?.()
+  })
+}

--- a/browser_tests/fixtures/canvasIdentity.ts
+++ b/browser_tests/fixtures/canvasIdentity.ts
@@ -1,0 +1,57 @@
+/**
+ * Give the test canvas a real workflow identity before a spec mutates it (#793).
+ *
+ * THE PROBLEM. Specs build their fixtures by driving LiteGraph directly from the
+ * page — `graph.clear()`, then `graph.add(node)`. That produces a canvas which is
+ * DIRTY (unsaved changes) and carries NO identity stamp, and the panel refuses
+ * every mutation on exactly that combination:
+ *
+ *   [dirty-mutation-binding-unproven] The active tab has unsaved changes and the
+ *   live canvas carries no identity stamp proving it belongs to this workflow …
+ *   so the canvas COULD be a stale graph from another tab
+ *
+ * The guard is right. A real user's canvas arrives through a load that stamps it;
+ * a canvas assembled out of band has never been proven to belong to anything.
+ *
+ * THE FIX IS THE PANEL'S OWN PATH, NOT A SYNTHETIC STAMP. It would be easy to
+ * write `graph.extra.comfyui_mcp = { workflow_uuid }` from the page and move on.
+ * That would be the harness forging the very evidence the fence exists to check,
+ * and every spec after it would be testing a canvas no production path can
+ * produce. So instead this issues `workflow_new`, which stamps the canvas the way
+ * it stamps any blank workflow the user creates — real code, real stamp.
+ *
+ * ORDER MATTERS, and it is the whole reason this is a helper rather than a line.
+ * `graph.clear()` DROPS `graph.extra`, so stamping before the clear is erased by
+ * it. Verified in the live browser: stamp-then-clear leaves `comfyui_mcp` null
+ * and the mutation is still refused; clear-then-stamp leaves it set and the
+ * mutation succeeds. Nodes added afterwards do not disturb it.
+ */
+import type { Page } from '@playwright/test'
+import type { MockBridge } from './MockBridge'
+
+/**
+ * Clear the live graph, then have the PANEL claim the empty canvas so it carries
+ * a real identity stamp. Call this before building nodes; build them after.
+ *
+ * Returns the workflow uuid now stamped on the canvas, for a spec that wants to
+ * assert on it.
+ */
+export async function claimFreshCanvas(page: Page, bridge: MockBridge): Promise<string | null> {
+  await page.evaluate(() => {
+    const w = window as any
+    const app = w.comfyAPI?.app?.app || w.app
+    const graph = app?.canvas?.graph ?? app?.graph
+    if (!graph) throw new Error('claimFreshCanvas: graph unavailable')
+    graph.clear()
+  })
+  // workflow_new stamps the canvas only when it can PROVE it is empty, which is
+  // what the clear above guarantees. Its reply carries the minted uuid (#755).
+  const created = await bridge.command('workflow_new', {})
+  if (!created.ok) {
+    throw new Error(`claimFreshCanvas: workflow_new failed — ${created.error ?? 'no reason given'}`)
+  }
+  // The new tab is a new INSTANCE, so anything the bridge cached for the previous
+  // one is stale; the next stamped command must re-read.
+  bridge.forgetWorkflowUuid()
+  return bridge.activeWorkflowUuid()
+}


### PR DESCRIPTION
> 30 failed · 2 flaky · 17 passed. **The specs send commands unstamped.** The #718 fence refuses unstamped mutations — which is exactly what it is for. The fence is right; the harness never learned to stamp.

The diagnosis was correct. Fixing it took **three** blockers, and only the first was the one reported.

## Measured, not inferred

I ran the suite against a live ComfyUI rather than reading it.

| | before | after |
|---|---|---|
| failed | 17 | **10** |
| passed | 30 | **39** |

The 8 recovered are `connect-matcher` (6/6) and `auto-layout` (2/2) — every spec the binding fence was refusing.

**The issue's 30-failed figure is stale**: it was measured on 0.11.44, and later fixes moved it to 17. Of those 17, only 8 were the fence, so *"every graph-mutating spec"* no longer describes the failure set.

## Blocker 1 — no stamp

`MockBridge.command()` now learns the uuid and stamps every command. The reporter's open design question was *where to read it from*; the answer is `workflow_list`, and it is the right one for a specific reason: it reports `active.workflow_uuid` **and** it is deliberately exempt from the very fence being satisfied (#759/#932 — it is the orchestrator's own recovery probe, so fencing it would make the repair require the fence to be already correct). **No new panel API needed.**

A caller passing `workflow_uuid` explicitly keeps it verbatim, so a spec testing the *fence itself* can still send a stale stamp or none.

## Blocker 2 — an unclaimed canvas

With the stamp landing, mutations hit `[dirty-mutation-binding-unproven]`: specs build fixtures by driving LiteGraph from the page, which leaves the canvas **dirty and unstamped** — precisely the pair that guard refuses, and correctly.

`claimFreshCanvas()` goes through the panel's **own** path: clear, then `workflow_new`, which stamps a canvas it can prove is empty. Writing `graph.extra.comfyui_mcp` from the page would have been one line — and would have had the harness forge the exact evidence the fence exists to check, leaving every later spec testing a canvas no production path can produce.

**Order is load-bearing**: `graph.clear()` *drops* `graph.extra`, so stamping before the clear is erased by it. Verified both ways in the live browser.

## Blocker 3 — an uncaptured tracker

Then `[root-shape-mismatch]`. ComfyUI's ChangeTracker captures on the events the real UI emits, and `graph.add()` from the page fires none, so the workflow's own state still described the canvas from *before* the build. `settleCanvas()` calls the tracker's own `checkState()` — the same capture a real edit triggers.

`auto-layout` needed none of the canvas work; it already builds through panel commands. It needed its **duplicate** `command()` helper — which hand-rolled the frame and therefore never stamped — to delegate. A second hand-rolled sender is how one file drifted out of a fixture-level fix.

## Review

Codex found three real defects, all fixed: `claimFreshCanvas` stamping its own `workflow_new` with the outgoing workflow's identity; a race where two commands issued together each probed for the uuid; and `settleCanvas` silently succeeding when the tracker was absent — which would surface later as a binding refusal mid-assertion, the same misdirection that left this suite's cause unread. Re-measured after: unchanged at 10/39, so none of it cost a recovered spec.

The identity cache is now self-invalidating (`workflow_new`/`workflow_open`/`workflow_close` drop it around the call) and single-flight.

## What is NOT fixed, stated plainly

**10 still fail** and this PR does not claim them: `conversation-persistence` (7), `chat-history-v2` (1), `workflow-chat-identity` (1) — a different cause, outside the issue's diagnosis — and `agent-drive:124`, which I confirmed **also fails on main** under the same `--workers=2` scheduling and passes in isolation. Pre-existing, not introduced here.

Also worth recording against the issue's "worth deciding alongside it": **the suite ran fine without `--enable-cors-header`** on this machine, contrary to the config's stated prerequisites.

Also: the three `expect(reply.ok).toBe(true)` assertions now carry the reply in their failure message. This suite spent months failing with a bare `Expected: true / Received: false`; the panel's refusal text names its own predicate and is worth surfacing.

Refs #793
