### PR TITLE
test(e2e): the 9 remaining specs — conversation persistence (#847)

### DIFF
--- a/browser_tests/fixtures/PanelPage.ts
+++ b/browser_tests/fixtures/PanelPage.ts
@@ -118,7 +118,11 @@ export class PanelPage {
     )
     await tabButton
       .first()
-      .waitFor({ state: 'visible', timeout: 30_000 })
+    // 8s, not 30s (#847): the per-test timeout is also 30_000, so a 30s wait here
+    // consumes the entire budget and the programmatic fallback below can never
+    // run — it is dead code by construction, and the spec dies with an opaque
+    // 'Test timeout of 30000ms exceeded' instead of saying what never appeared.
+      .waitFor({ state: 'visible', timeout: 8_000 })
       .catch(() => {})
 
     if (await tabButton.count()) {
@@ -132,7 +136,23 @@ export class PanelPage {
       await this.root.waitFor({ state: 'visible', timeout: 8_000 })
     } catch {
       await this.activateSidebarProgrammatically()
-      await this.root.waitFor({ state: 'visible', timeout: 8_000 })
+      try {
+        await this.root.waitFor({ state: 'visible', timeout: 8_000 })
+      } catch (err) {
+        // #847 — the panel not mounting AT ALL has one cause that costs hours to
+        // find, because the symptom is a bare timeout: a spec that routes
+        // `comfyui-mcp-panel.js` from the checked-out tree while ComfyUI still
+        // serves its `./lib/*` imports from a DIFFERENT checkout. The panel then
+        // fails to import and nothing renders. Common when running from a git
+        // worktree. Say so rather than let the next person bisect it.
+        throw new Error(
+          'The Agent panel never mounted (.cmcp-root not visible). Check the browser ' +
+            'console for a module-load error: if this spec routes the panel source from ' +
+            'this checkout, ComfyUI must be serving the SAME commit — its custom_nodes ' +
+            'copy provides the ./lib/* imports, and a version mismatch there fails the ' +
+            'import silently. Original: ' + (err instanceof Error ? err.message : String(err))
+        )
+      }
     }
   }
 

--- a/browser_tests/workflow-chat-identity.spec.ts
+++ b/browser_tests/workflow-chat-identity.spec.ts
@@ -83,6 +83,50 @@ test('opening a workflow does not dirty it and first record embeds silently', as
 
   await panel.setBridgeUrl(mockBridge.url)
   await panel.connect()
+
+  // #847 — SAVE FIRST, then assert the embed.
+  //
+  // The panel embeds its identity into `graph.extra` only for a PERSISTED
+  // workflow: #570 fails closed on the copyable carrier, because an embedded
+  // uuid on an unsaved canvas would be inherited by a copy/import and
+  // cross-resume the source's conversation. So on a rig whose default canvas is
+  // an unsaved 'Untitled' — which is most of them — this assertion could never
+  // pass, and the spec was failing on the environment rather than on the panel.
+  //
+  // Save through the panel's own command so the workflow is genuinely persisted,
+  // then re-zero the counters: saving legitimately touches the graph, and the
+  // claim under test is that the EMBED is silent, not that saving is.
+  const savedAs = `cmcp-e2e-identity-${Date.now().toString(36)}`
+  const saveReply = await mockBridge.command('workflow_save_as', { name: savedAs })
+  expect(saveReply.ok, JSON.stringify(saveReply).slice(0, 300)).toBe(true)
+  await expect
+    .poll(() =>
+      page.evaluate(
+        () =>
+          ((window as any).comfyAPI?.app?.app || (window as any).app)?.extensionManager?.workflow
+            ?.activeWorkflow?.isPersisted ?? false
+      )
+    )
+    .toBe(true)
+  await page.evaluate(() => {
+    ;(window as any).__cmcpIdentityMutationCalls = { before: 0, after: 0, dirty: 0 }
+    const w = window as any
+    const app = w.comfyAPI?.app?.app || w.app
+    if (app.graph?.extra?.comfyui_mcp) delete app.graph.extra.comfyui_mcp
+  })
+
+  // The embed rides the next RECORD, so give it one.
+  await panel.sendMessage('first record after save')
+  await expect
+    .poll(() =>
+      page.evaluate(
+        () =>
+          ((window as any).comfyAPI?.app?.app || (window as any).app)?.graph?.extra?.comfyui_mcp
+            ?.workflow_uuid ?? null
+      )
+    )
+    .not.toBeNull()
+
   const recorded = await page.evaluate(() => {
     const w = window as any
     const app = w.comfyAPI?.app?.app || w.app
@@ -93,6 +137,19 @@ test('opening a workflow does not dirty it and first record embeds silently', as
   })
   expect(recorded.uuid).toMatch(/^[0-9a-f-]{36}$/i)
   expect(recorded.calls).toEqual({ before: 0, after: 0, dirty: 0 })
+
+  // Do not leave the file behind. This spec has to SAVE to exercise the embed,
+  // and a suite that drops a workflow into the user's own workflows folder on
+  // every run is its own small defect.
+  await page.evaluate(async (name) => {
+    try {
+      await fetch(`/api/userdata/${encodeURIComponent(`workflows/${name}.json`)}`, {
+        method: 'DELETE'
+      })
+    } catch {
+      // Best-effort: a failed cleanup must not fail a passing assertion.
+    }
+  }, savedAs)
 })
 
 test('default mode opens pre-upgrade history without re-keying it', async ({

--- a/browser_tests/workflow-chat-identity.spec.ts
+++ b/browser_tests/workflow-chat-identity.spec.ts
@@ -96,7 +96,12 @@ test('opening a workflow does not dirty it and first record embeds silently', as
   // Save through the panel's own command so the workflow is genuinely persisted,
   // then re-zero the counters: saving legitimately touches the graph, and the
   // claim under test is that the EMBED is silent, not that saving is.
-  const savedAs = `cmcp-e2e-identity-${Date.now().toString(36)}`
+  // Timestamp AND a nonce: two workers can start in the same millisecond, and
+  // each test's cleanup deletes by name — a collision would have one test
+  // delete the other's workflow out from under it (codex).
+  const savedAs = `cmcp-e2e-identity-${Date.now().toString(36)}-${Math.random()
+    .toString(36)
+    .slice(2, 8)}`
   const saveReply = await mockBridge.command('workflow_save_as', { name: savedAs })
   expect(saveReply.ok, JSON.stringify(saveReply).slice(0, 300)).toBe(true)
   await expect
@@ -117,6 +122,9 @@ test('opening a workflow does not dirty it and first record embeds silently', as
 
   // The embed rides the next RECORD, so give it one.
   await panel.sendMessage('first record after save')
+  // Wait for a WELL-FORMED uuid, not merely something non-null: the assertion
+  // below checks the shape, and a gate that accepts any truthy value would let a
+  // malformed write satisfy the wait and then fail confusingly (codex).
   await expect
     .poll(() =>
       page.evaluate(
@@ -125,7 +133,7 @@ test('opening a workflow does not dirty it and first record embeds silently', as
             ?.workflow_uuid ?? null
       )
     )
-    .not.toBeNull()
+    .toMatch(/^[0-9a-f-]{36}$/i)
 
   const recorded = await page.evaluate(() => {
     const w = window as any


### PR DESCRIPTION
Fixes the `workflow-chat-identity` failure and two harness defects. **One failure remains and is not fixed here** — see below.

## First, a correction to my own issue

I filed #847 claiming 9 failures with a shared cause. **Seven were my environment.**

These specs route the panel's own source into the browser from the checked-out tree — but **not** its `./lib/*` imports, which ComfyUI still serves from its own checkout. Running from a git worktree at 0.11.51 against a ComfyUI junctioned to a tree on 0.11.50, the panel imported an export #817 had added that the served `lib` didn't have. The module failed to load, the sidebar never mounted, and all seven sat waiting for `.cmcp-root` until the 30 s test timeout.

Same commit in both trees: **9 failed → 2**.

## `workflow-chat-identity:33` — a real bug, in the spec

It asserts the panel embeds its identity into `graph.extra` after the first record. The panel does that **only for a persisted workflow** — #570 fails closed on the copyable carrier, because an embedded uuid on an unsaved canvas is inherited by a copy/import and cross-resumes the source's conversation.

The spec never saves anything. On any rig whose default canvas is an unsaved "Untitled" — most of them — the assertion could not pass. It was failing on the environment, not the panel.

It now saves through the panel's own `workflow_save_as`, re-zeroes the mutation counters (saving legitimately touches the graph; the claim under test is that the **embed** is silent, not that saving is), then asserts. It also **deletes the file afterwards** — a suite that drops a workflow into the user's own workflows folder on every run is its own small defect. Verified: 0 leftovers after a run.

## Two harness fixes that cost me the hours above

**`PanelPage.openSidebar()` waited 30 s for the tab button while the per-test timeout is also 30 000** — so the programmatic fallback beneath it was **dead code by construction**, and every failure surfaced as a bare `Test timeout of 30000ms exceeded`. 8 s now, so the fallback runs and the real error appears. That single change is what turned the mystery into `waiting for locator('.cmcp-root') to be visible` and led to the diagnosis above.

**When the panel never mounts at all**, that fallback now names the cause worth checking first: a routed panel source against a differently-versioned served `lib/`. It is invisible from the symptom and is a normal thing to hit when running from a worktree.

## Still failing — not fixed here

`chat-history-v2:66` (expects 2 `.cmcp-hist-row`, gets 1). Characterised but not solved:

- both stores have the threads — IndexedDB **and** the localStorage shadow reach 2 before the list is opened (I added a gate on the shadow specifically to rule that out; it passes and the row count is still 1, so I reverted it as unjustified churn);
- the list **snapshots on open** rather than live-updating, and inserting an 800 ms wait before clicking "Chat history" makes it render 2. So this is render-timing or scope resolution, **not** persistence;
- worth a look: the two chats land in **different** `workflow:<uuid>` scopes despite being on the same unsaved canvas, which may be what the list is filtering on.

Verified: `workflow-chat-identity` 4/4, `conversation-persistence` 7/7, unit suite 3190/0.

Refs #847
