### PR TITLE
feat(panel): a UI-scale setting for the sidebar (#753)

### DIFF
--- a/browser_tests/unit/panel-ui-scale.test.mjs
+++ b/browser_tests/unit/panel-ui-scale.test.mjs
@@ -1,0 +1,145 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+// The REAL clamp, not a copy of it. An earlier version of this file
+// reimplemented the arithmetic and therefore tested itself: mutating the
+// panel's own `Number.isFinite` guard changed nothing here. Extracting it to a
+// module is what makes these assertions mean something.
+import {
+  panelUiScaleFraction,
+  PANEL_UI_SCALE_MIN,
+  PANEL_UI_SCALE_MAX,
+} from "../../web/js/lib/ui-scale.js";
+
+// #753 — the sidebar had no way to make its text bigger, and the workaround a
+// user would reach for does not work: `.cmcp-root` sets `font-size: 0.8125rem`,
+// but the inner rules are `rem`, which resolve against the PAGE root rather
+// than the panel. Overriding `.cmcp-root { font-size }` therefore moves only the
+// few elements that inherit; every rem-sized label stays exactly as it was.
+//
+// The setting scales the panel with `zoom`, which is the one lever that moves
+// all of it at once. These pin the parts that are easy to get quietly wrong: the
+// clamp, the height compensation that keeps a zoomed panel inside its parent,
+// and the fact that the scale is applied at MOUNT and not only on change.
+
+const PANEL = readFileSync(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8");
+
+// ── the clamp ──────────────────────────────────────────────────────────────
+
+test("100% is 1 — the default changes nothing", () => {
+  assert.equal(panelUiScaleFraction(100), 1);
+});
+
+test("a value in range scales proportionally", () => {
+  assert.equal(panelUiScaleFraction(150), 1.5);
+  assert.equal(panelUiScaleFraction(250), 2.5);
+});
+
+test("out-of-range values are clamped, never applied raw", () => {
+  // A stored value from an older/edited settings file must not be able to leave
+  // the panel microscopic or off-screen.
+  assert.equal(panelUiScaleFraction(0), 1);
+  assert.equal(panelUiScaleFraction(-500), 1);
+  assert.equal(panelUiScaleFraction(10_000), 2.5);
+});
+
+test("an unreadable value reads as 100%, not as zero", () => {
+  // `Number(null)` is 0 and `Number([])` is 0 — a clamp that trusted Number()
+  // alone would collapse the panel for a corrupt setting rather than ignore it.
+  for (const raw of [undefined, null, "", "abc", NaN, {}, [], () => {}]) {
+    assert.equal(panelUiScaleFraction(raw), 1, `raw ${String(raw)}`);
+  }
+});
+
+// ── the height compensation ────────────────────────────────────────────────
+
+test("the root height is divided by the scale, or a zoomed panel overflows", () => {
+  // Raised by the reporter and it is real: a zoomed element resolves a
+  // percentage height in the ZOOMED coordinate space, so `height: 100%` at 150%
+  // is half again taller than the space available and the composer goes
+  // off-screen. This is the line that cancels it.
+  assert.match(PANEL, /height: calc\(100% \/ var\(--cmcp-ui-scale, 1\)\)/);
+  // …and the plain `height: 100%` it replaces must be gone from that rule.
+  const rule = PANEL.slice(PANEL.indexOf(".cmcp-root {"), PANEL.indexOf("}", PANEL.indexOf(".cmcp-root {")));
+  assert.doesNotMatch(rule, /height: 100%/);
+});
+
+test("the variable and the zoom are written together", () => {
+  // Either one alone is a broken panel: the variable without zoom shrinks the
+  // root for no reason, zoom without the variable overflows it.
+  const fn = PANEL.slice(
+    PANEL.indexOf("function applyPanelUiScale(raw) {"),
+    PANEL.indexOf("function getSetting(id)"),
+  );
+  assert.ok(fn.length > 0);
+  assert.match(fn, /setProperty\("--cmcp-ui-scale", String\(scale\)\)/);
+  assert.match(fn, /root\.style\.zoom = String\(scale\)/);
+});
+
+test("a scale of exactly 1 clears the zoom rather than writing a no-op", () => {
+  const fn = PANEL.slice(
+    PANEL.indexOf("function applyPanelUiScale(raw) {"),
+    PANEL.indexOf("function getSetting(id)"),
+  );
+  assert.match(fn, /if \(scale === 1\) root\.style\.removeProperty\("zoom"\)/);
+});
+
+test("a frontend that refuses the style write does not break the panel", () => {
+  const fn = PANEL.slice(
+    PANEL.indexOf("function applyPanelUiScale(raw) {"),
+    PANEL.indexOf("function getSetting(id)"),
+  );
+  assert.match(fn, /try \{[\s\S]*\} catch \{/);
+});
+
+// ── the wiring ─────────────────────────────────────────────────────────────
+
+test("the scale is applied when a panel MOUNTS, not only when the slider moves", () => {
+  // A saved scale has to reach a panel that mounts later — a reload, or a
+  // workflow switch that re-mounts the sidebar. Applying it only in onChange
+  // would make the setting appear to forget itself on every reload.
+  const build = PANEL.slice(PANEL.indexOf("function buildPanel() {"), PANEL.indexOf("function buildPanel() {") + 1200);
+  assert.match(build, /applyPanelUiScale\(getSetting\(SETTING_UI_SCALE\)\)/);
+});
+
+test("the panel uses the shared clamp rather than its own arithmetic", () => {
+  assert.ok(PANEL.includes("panelUiScaleFraction(raw)"), "the panel must call the shared clamp");
+  // A substring, not a regex: a path contains `/`, and generating a regex
+  // literal for it is how this line broke in the first place.
+  assert.ok(PANEL.includes('from "./lib/ui-scale.js"'), "the panel must import the shared module");
+  assert.ok(PANEL_UI_SCALE_MIN === 100 && PANEL_UI_SCALE_MAX === 250);
+});
+
+test("the setting is registered with the panel's own id namespace and range", () => {
+  assert.match(PANEL, /const SETTING_UI_SCALE = "comfyui-mcp\.uiScale";/);
+  assert.match(PANEL, /id: SETTING_UI_SCALE/);
+  assert.match(PANEL, /attrs: \{ min: PANEL_UI_SCALE_MIN, max: PANEL_UI_SCALE_MAX, step: 5 \}/);
+  assert.match(PANEL, /defaultValue: 100/);
+});
+
+test("onChange applies immediately and is NOT gated on settingsArmed", () => {
+  // The armed gate exists for settings that SEED the panel's runtime, so a
+  // hydration pass cannot re-seed them. This one writes nothing but CSS, and a
+  // user dragging the slider expects the panel to move while they drag.
+  const entry = PANEL.slice(PANEL.indexOf("id: SETTING_UI_SCALE"), PANEL.indexOf("id: SETTING_STALL_S"));
+  assert.match(entry, /onChange: \(value\) => \{[\s\S]*applyPanelUiScale\(value\)/);
+  // The GUARD, not the word: the comment above the handler explains why the
+  // guard is absent, so matching the identifier would fail on the explanation.
+  // A plain substring, NOT a regex: the guard text contains `(` and `||`, which
+  // are regex syntax — an unescaped version of this assertion parses as an
+  // alternation, matches nothing, and can never fail.
+  assert.ok(
+    !entry.includes("if (suppressSettingOnChange || !settingsArmed) return;"),
+    "the UI-scale handler must not be gated on settingsArmed",
+  );
+});
+
+test("the tooltip tells the user why their stylesheet override did not work", () => {
+  // The reported confusion was not just "text is small" — it was that the
+  // obvious fix silently does nothing. A setting that does not explain that
+  // leaves the next person to rediscover it.
+  const entry = PANEL.slice(PANEL.indexOf("id: SETTING_UI_SCALE"), PANEL.indexOf("id: SETTING_STALL_S"));
+  assert.match(entry, /rem/);
+  assert.match(entry, /font-size/);
+});

--- a/browser_tests/unit/panel-ui-scale.test.mjs
+++ b/browser_tests/unit/panel-ui-scale.test.mjs
@@ -69,7 +69,7 @@ test("the variable and the zoom are written together", () => {
   // Either one alone is a broken panel: the variable without zoom shrinks the
   // root for no reason, zoom without the variable overflows it.
   const fn = PANEL.slice(
-    PANEL.indexOf("function applyPanelUiScale(raw) {"),
+    PANEL.indexOf("function applyPanelUiScale(raw, target) {"),
     PANEL.indexOf("function getSetting(id)"),
   );
   assert.ok(fn.length > 0);
@@ -79,7 +79,7 @@ test("the variable and the zoom are written together", () => {
 
 test("a scale of exactly 1 clears the zoom rather than writing a no-op", () => {
   const fn = PANEL.slice(
-    PANEL.indexOf("function applyPanelUiScale(raw) {"),
+    PANEL.indexOf("function applyPanelUiScale(raw, target) {"),
     PANEL.indexOf("function getSetting(id)"),
   );
   assert.match(fn, /if \(scale === 1\) root\.style\.removeProperty\("zoom"\)/);
@@ -87,7 +87,7 @@ test("a scale of exactly 1 clears the zoom rather than writing a no-op", () => {
 
 test("a frontend that refuses the style write does not break the panel", () => {
   const fn = PANEL.slice(
-    PANEL.indexOf("function applyPanelUiScale(raw) {"),
+    PANEL.indexOf("function applyPanelUiScale(raw, target) {"),
     PANEL.indexOf("function getSetting(id)"),
   );
   assert.match(fn, /try \{[\s\S]*\} catch \{/);
@@ -100,7 +100,13 @@ test("the scale is applied when a panel MOUNTS, not only when the slider moves",
   // workflow switch that re-mounts the sidebar. Applying it only in onChange
   // would make the setting appear to forget itself on every reload.
   const build = PANEL.slice(PANEL.indexOf("function buildPanel() {"), PANEL.indexOf("function buildPanel() {") + 1200);
-  assert.match(build, /applyPanelUiScale\(getSetting\(SETTING_UI_SCALE\)\)/);
+  // …and it must pass the ROOT (codex): buildPanel creates the element and mounts
+  // it later, so a document query at that moment finds every panel except the one
+  // being built, and the saved scale would apply to nothing.
+  assert.ok(
+    build.includes("applyPanelUiScale(getSetting(SETTING_UI_SCALE), root)"),
+    "the mount-time apply must target the freshly built, still-detached root",
+  );
 });
 
 test("the panel uses the shared clamp rather than its own arithmetic", () => {

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -269,6 +269,11 @@ import {
 } from "./lib/clipboard-store.js";
 import { createMediaRecorder } from "./lib/chat-media.js";
 import { createMediaCollapseStore } from "./lib/media-collapse.js";
+import {
+  PANEL_UI_SCALE_MIN,
+  PANEL_UI_SCALE_MAX,
+  panelUiScaleFraction,
+} from "./lib/ui-scale.js";
 import { createLightboxModel } from "./lib/lightbox-gallery.js";
 import {
   vueNodesActive,
@@ -2570,6 +2575,13 @@ const SETTING_BRIDGE = "comfyui-mcp.bridgeUrl.single";
 const SETTING_AUTOCONNECT = "comfyui-mcp.autoConnect";
 const SETTING_FOCUS_FOLLOW = "comfyui-mcp.zoomToAction";
 const SETTING_STALL_S = "comfyui-mcp.stallWarningSeconds";
+// #753 — the sidebar had no way to make its text bigger, and the obvious user
+// workaround does not work: `.cmcp-root` sets `font-size: 0.8125rem`, but the
+// inner rules are `rem`, which resolve against the PAGE root rather than the
+// panel. Overriding `.cmcp-root { font-size }` therefore scales only the few
+// elements that inherit, and every rem-sized label stays exactly as it was.
+// A scale transform is the one lever that moves the whole panel at once.
+const SETTING_UI_SCALE = "comfyui-mcp.uiScale";
 const SETTING_REMOTE_URL = "comfyui-mcp.remoteComfyuiUrl";
 // Mobile app (beta) feature flag: gates the header "Remote control" QR button and
 // surfaces the tester-channel download links in Settings. The links are the
@@ -2759,6 +2771,37 @@ function effortComboOptions(backend) {
     { value: "", text: "Model default" },
     ...scale.map((id) => ({ value: id, text: effortMeta(id).label })),
   ];
+}
+
+/**
+ * Apply the UI scale to every mounted panel root.
+ *
+ * `zoom` rather than `transform: scale()`: transform does not affect LAYOUT, so a
+ * scaled panel would keep its original box and overflow or clip. zoom scales the
+ * box too, which is what makes the sidebar's own scrolling keep working.
+ *
+ * THE HEIGHT COMPENSATION IS NOT OPTIONAL (#753, raised by the reporter).
+ * `.cmcp-root` is `height: 100%`, and a zoomed element resolves its percentage
+ * height in the ZOOMED coordinate space — at 150% it becomes half again taller
+ * than the space it has, and the bottom of the composer goes off-screen. The
+ * root's height is `calc(100% / var(--cmcp-ui-scale))`, so the variable set here
+ * cancels exactly that. Scale and variable are written together for that reason;
+ * setting one without the other is a broken panel.
+ */
+function applyPanelUiScale(raw) {
+  const scale = panelUiScaleFraction(raw);
+  try {
+    for (const root of document.querySelectorAll(".cmcp-root")) {
+      root.style.setProperty("--cmcp-ui-scale", String(scale));
+      // 1 is the default everywhere; clearing it keeps the DOM free of a no-op
+      // zoom that would otherwise show up in every inspection of the panel.
+      if (scale === 1) root.style.removeProperty("zoom");
+      else root.style.zoom = String(scale);
+    }
+  } catch {
+    // A frontend that refuses the style write keeps the default size; a panel
+    // that is merely not scaled is still a usable panel.
+  }
 }
 
 function getSetting(id) {
@@ -3352,6 +3395,28 @@ function panelSettingsList() {
         );
         wrap.append(note, row);
         return wrap;
+      },
+    },
+    {
+      id: SETTING_UI_SCALE,
+      name: "Panel UI scale (%)",
+      category: cat("General", "Panel UI scale (%)"),
+      sortOrder: 143,
+      tooltip:
+        "Scales the whole Agent sidebar — text, icons and spacing together. Raise it if the panel is hard " +
+        "to read on a high-DPI or large display. 100% is the default; 100-250. Applies immediately, to " +
+        "every open panel. Note that overriding `.cmcp-root { font-size }` in a user stylesheet does NOT " +
+        "work: the panel's inner sizes are `rem`, which resolve against the page root rather than the " +
+        "panel, so most text ignores it. This setting is the supported way to scale the panel.",
+      type: "slider",
+      attrs: { min: PANEL_UI_SCALE_MIN, max: PANEL_UI_SCALE_MAX, step: 5 },
+      defaultValue: 100,
+      onChange: (value) => {
+        // NOT gated on settingsArmed, unlike the settings that seed the panel's
+        // runtime: this one writes nothing but CSS, has no default to re-seed,
+        // and a user dragging the slider expects the panel to move while they
+        // drag — including before the panel has finished arming.
+        applyPanelUiScale(value);
       },
     },
     {
@@ -16236,7 +16301,10 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
 
 const PANEL_CSS = `
 .cmcp-root {
-  display: flex; flex-direction: column; height: 100%; min-height: 0;
+  display: flex; flex-direction: column; min-height: 0;
+  /* #753 — divided by the UI scale so a zoomed panel still fits its parent;
+     see applyPanelUiScale. Defaults to 1, i.e. plain 100%. */
+  height: calc(100% / var(--cmcp-ui-scale, 1));
   position: relative; /* positioning context for the rollback modal overlay */
   font-family: var(--font-inter, "Inter", ui-sans-serif, system-ui, sans-serif);
   font-size: 0.8125rem; line-height: 1.5;
@@ -17580,6 +17648,10 @@ function buildPanel() {
 
   const root = document.createElement("div");
   root.className = "cmcp-root";
+  // #753 — a saved scale has to apply to a panel that mounts LATER (a reload, a
+  // workflow switch that re-mounts the sidebar), not only to one that is open
+  // when the slider moves. Read it here, at the one place a root is created.
+  applyPanelUiScale(getSetting(SETTING_UI_SCALE));
   // A2UI seam (forward-compat, see spec): the chat surface width is a SINGLE piece
   // of owned state, not scattered CSS, so a future A2UI layer can widen the surface
   // (e.g. to show a diagram) and shrink it back. No-op visual default today.

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -2787,11 +2787,19 @@ function effortComboOptions(backend) {
  * root's height is `calc(100% / var(--cmcp-ui-scale))`, so the variable set here
  * cancels exactly that. Scale and variable are written together for that reason;
  * setting one without the other is a broken panel.
+ * `target` — the specific root to style, for a panel that has been BUILT but not
+ * yet ATTACHED (codex). `buildPanel` creates its root with `createElement` and
+ * mounts it later, so a document query at that moment finds every panel except
+ * the one being built: the saved scale would then apply to nothing until the user
+ * touched the slider, i.e. the setting would look like it forgot itself on every
+ * reload — exactly the bug the mount-time call exists to prevent. Omitted, it
+ * styles every mounted root, which is what the settings handler wants.
  */
-function applyPanelUiScale(raw) {
+function applyPanelUiScale(raw, target) {
   const scale = panelUiScaleFraction(raw);
   try {
-    for (const root of document.querySelectorAll(".cmcp-root")) {
+    const roots = target ? [target] : document.querySelectorAll(".cmcp-root");
+    for (const root of roots) {
       root.style.setProperty("--cmcp-ui-scale", String(scale));
       // 1 is the default everywhere; clearing it keeps the DOM free of a no-op
       // zoom that would otherwise show up in every inspection of the panel.
@@ -17651,7 +17659,7 @@ function buildPanel() {
   // #753 — a saved scale has to apply to a panel that mounts LATER (a reload, a
   // workflow switch that re-mounts the sidebar), not only to one that is open
   // when the slider moves. Read it here, at the one place a root is created.
-  applyPanelUiScale(getSetting(SETTING_UI_SCALE));
+  applyPanelUiScale(getSetting(SETTING_UI_SCALE), root);
   // A2UI seam (forward-compat, see spec): the chat surface width is a SINGLE piece
   // of owned state, not scattered CSS, so a future A2UI layer can widen the surface
   // (e.g. to show a diagram) and shrink it back. No-op visual default today.

--- a/web/js/lib/ui-scale.js
+++ b/web/js/lib/ui-scale.js
@@ -1,0 +1,32 @@
+// Panel UI scale (#753).
+//
+// THE REPORT. A user on Windows 11 found the sidebar text barely readable, and
+// the fix anyone would reach for does nothing: `.cmcp-root` sets
+// `font-size: 0.8125rem`, but the panel's inner rules are `rem`, which resolve
+// against the PAGE root rather than against the panel. Overriding
+// `.cmcp-root { font-size }` in a user stylesheet therefore moves only the few
+// elements that inherit, and every rem-sized label stays exactly as it was.
+// Scaling the whole panel is the one lever that works.
+//
+// This module is the arithmetic, kept out of the DOM closure so it can be tested
+// against the real implementation rather than a copy of it.
+
+/** The range the setting offers. A stored value outside it — an older build, a
+ *  hand-edited comfy.settings.json — is clamped rather than honoured. */
+export const PANEL_UI_SCALE_MIN = 100;
+export const PANEL_UI_SCALE_MAX = 250;
+
+/**
+ * The scale to apply, as a fraction (1 = 100%).
+ *
+ * FAIL-SAFE, and that is the whole point of it being a function. `Number(null)`
+ * is 0 and `Number([])` is 0, so a clamp that trusted `Number()` alone would
+ * collapse the panel to nothing for a setting it merely could not read. Anything
+ * non-finite reads as 100% — the panel stays exactly as it was, which is the only
+ * answer that cannot make things worse than not having the setting at all.
+ */
+export function panelUiScaleFraction(raw) {
+  const pct = Number(raw);
+  if (!Number.isFinite(pct)) return 1;
+  return Math.min(PANEL_UI_SCALE_MAX, Math.max(PANEL_UI_SCALE_MIN, pct)) / 100;
+}


### PR DESCRIPTION
> A user on Windows 11 reported the panel text is barely readable.

And the fix anyone would reach for does nothing — which is the part worth stating. `.cmcp-root` sets `font-size: 0.8125rem`, but the panel's inner rules are **`rem`**: they resolve against the *page* root, not against the panel. Overriding `.cmcp-root { font-size }` in a user stylesheet therefore moves only the few elements that inherit, and every rem-sized label stays exactly as it was. There was no CSS-only way for a user to make this readable.

## What this adds

**"Panel UI scale (%)"** in ComfyUI's Settings dialog — a slider, 100–250, applying `zoom` to every mounted `.cmcp-root`.

`zoom` rather than `transform: scale()`: transform doesn't affect **layout**, so a scaled panel would keep its original box and clip or overflow. `zoom` scales the box too, which is what keeps the sidebar's own scrolling working.

**The height compensation is load-bearing, and the reporter called it.** `.cmcp-root` is `height: 100%`, and a zoomed element resolves a percentage height in the *zoomed* coordinate space — at 150% it becomes half again taller than the space it has, and the bottom of the composer goes off-screen. The rule is now `height: calc(100% / var(--cmcp-ui-scale, 1))`, and the variable is written alongside the zoom because either one alone is a broken panel.

The scale applies at **mount** as well as on change, so a panel that mounts later — a reload, a workflow switch that re-mounts the sidebar — picks up the saved value.

The tooltip explains the `rem` trap, so the next person doesn't spend an evening on a stylesheet override that cannot work.

## Review

Codex caught the one defect that would have made this look broken to the very user it's for: `applyPanelUiScale` styled `document.querySelectorAll(".cmcp-root")`, but the mount-time call runs in `buildPanel()` right after `createElement` — **before the root is attached** — so the query found every panel except the one being built. The saved scale applied to nothing until the slider was touched again, i.e. "the setting forgets itself on every reload", which is exactly what that call exists to prevent. It now takes the element directly.

On re-review it also confirmed the two interactions I wanted checked: the height `calc` doesn't conflict with the flex column (`min-height: 0` governs children; the calc compensates the root's own zoomed box), and `zoom` on a `position: relative` root doesn't break the absolutely-positioned rollback-modal overlay — zoom scales the containing block and its absolute descendants as one coordinate space.

## Not done here, deliberately

The reporter's **option 2** — convert inner `rem` to `em` so `.cmcp-root { font-size }` cascades. It's the more correct long-term fix and it is **not** a unit rename: with the root at `0.8125rem`, `0.625rem` → `0.625em` makes that text *smaller*, so every inner value needs rescaling by 1/0.8125 across ~15 rules. That deserves its own change with visual verification rather than riding along here. Flagged on the issue.

## On the tests

The clamp lives in `lib/ui-scale.js` rather than the DOM closure, because the first version of these tests **reimplemented** it and therefore tested itself — deleting the panel's `Number.isFinite` guard changed nothing. That guard matters: `Number(null)` and `Number([])` are both `0`, so a clamp trusting `Number()` alone collapses the panel for a setting it merely couldn't read.

Mutation-verified against the real module: dropping the height compensation, not writing the CSS variable, removing the mount-time apply, reverting it to the document query, dropping the finite guard, and dropping the clamp each fail. Full unit suite: **3203 pass / 0 fail**.

Refs #753
