### PR TITLE
fix(panel): the UI-scale height compensation was the bug, not the fix (#753)

### DIFF
--- a/browser_tests/unit/panel-ui-scale.test.mjs
+++ b/browser_tests/unit/panel-ui-scale.test.mjs
@@ -52,31 +52,41 @@ test("an unreadable value reads as 100%, not as zero", () => {
   }
 });
 
-// ── the height compensation ────────────────────────────────────────────────
+// ── the height, which needs NO compensation ───────────────────────
 
-test("the root height is divided by the scale, or a zoomed panel overflows", () => {
-  // Raised by the reporter and it is real: a zoomed element resolves a
-  // percentage height in the ZOOMED coordinate space, so `height: 100%` at 150%
-  // is half again taller than the space available and the composer goes
-  // off-screen. This is the line that cancels it.
-  assert.match(PANEL, /height: calc\(100% \/ var\(--cmcp-ui-scale, 1\)\)/);
-  // …and the plain `height: 100%` it replaces must be gone from that rule.
-  const rule = PANEL.slice(PANEL.indexOf(".cmcp-root {"), PANEL.indexOf("}", PANEL.indexOf(".cmcp-root {")));
-  assert.doesNotMatch(rule, /height: 100%/);
+test("the root keeps a plain 100% height — dividing by the scale is the bug", () => {
+  // Measured in Chrome, both ways: a percentage height inside a zoomed element
+  // ALREADY resolves against the parent in the zoomed coordinate space. The
+  // `calc(100% / scale)` that shipped first applied that correction a second
+  // time — at 175% a 619px parent gave a 202px root — and left the composer
+  // stranded mid-panel above a band of empty space.
+  // No slicing and no escapes: assert on the exact rule text. Anchoring by
+  // indexOf found the COMMENT that quotes this selector, and an escaped newline
+  // did not survive being generated.
+  assert.ok(
+    PANEL.includes("display: flex; flex-direction: column; height: 100%; min-height: 0;"),
+    "the root must keep a plain 100% height",
+  );
+  assert.ok(
+    !PANEL.includes("calc(100% / var(--cmcp-ui-scale"),
+    "the scale division must not come back",
+  );
 });
 
-test("the variable and the zoom are written together", () => {
-  // Either one alone is a broken panel: the variable without zoom shrinks the
-  // root for no reason, zoom without the variable overflows it.
+test("nothing writes the --cmcp-ui-scale variable any more", () => {
+  // It existed only to feed that calc. Leaving it behind would invite someone to
+  // reintroduce the division it was for.
+  assert.ok(!PANEL.includes("--cmcp-ui-scale"), "the variable and its calc go together");
+});
+
+test("the zoom is still what does the scaling", () => {
   const fn = PANEL.slice(
     PANEL.indexOf("function applyPanelUiScale(raw, target) {"),
     PANEL.indexOf("function getSetting(id)"),
   );
   assert.ok(fn.length > 0);
-  assert.match(fn, /setProperty\("--cmcp-ui-scale", String\(scale\)\)/);
-  assert.match(fn, /root\.style\.zoom = String\(scale\)/);
+  assert.ok(fn.includes("root.style.zoom = String(scale)"), "zoom is what scales the panel");
 });
-
 test("a scale of exactly 1 clears the zoom rather than writing a no-op", () => {
   const fn = PANEL.slice(
     PANEL.indexOf("function applyPanelUiScale(raw, target) {"),

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -2780,13 +2780,12 @@ function effortComboOptions(backend) {
  * scaled panel would keep its original box and overflow or clip. zoom scales the
  * box too, which is what makes the sidebar's own scrolling keep working.
  *
- * THE HEIGHT COMPENSATION IS NOT OPTIONAL (#753, raised by the reporter).
- * `.cmcp-root` is `height: 100%`, and a zoomed element resolves its percentage
- * height in the ZOOMED coordinate space — at 150% it becomes half again taller
- * than the space it has, and the bottom of the composer goes off-screen. The
- * root's height is `calc(100% / var(--cmcp-ui-scale))`, so the variable set here
- * cancels exactly that. Scale and variable are written together for that reason;
- * setting one without the other is a broken panel.
+ * NO HEIGHT COMPENSATION IS NEEDED, and adding one is actively wrong. The
+ * reporter flagged that a zoomed element MIGHT overflow a percentage-height
+ * parent; measured in Chrome, it does not — `height: 100%` inside a zoomed
+ * element already resolves against the parent in the zoomed coordinate space.
+ * The `calc(100% / scale)` that shipped first applied that correction a SECOND
+ * time and left the panel at 1/scale of its slot.
  * `target` — the specific root to style, for a panel that has been BUILT but not
  * yet ATTACHED (codex). `buildPanel` creates its root with `createElement` and
  * mounts it later, so a document query at that moment finds every panel except
@@ -2800,7 +2799,6 @@ function applyPanelUiScale(raw, target) {
   try {
     const roots = target ? [target] : document.querySelectorAll(".cmcp-root");
     for (const root of roots) {
-      root.style.setProperty("--cmcp-ui-scale", String(scale));
       // 1 is the default everywhere; clearing it keeps the DOM free of a no-op
       // zoom that would otherwise show up in every inspection of the panel.
       if (scale === 1) root.style.removeProperty("zoom");
@@ -16309,10 +16307,13 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
 
 const PANEL_CSS = `
 .cmcp-root {
-  display: flex; flex-direction: column; min-height: 0;
-  /* #753 — divided by the UI scale so a zoomed panel still fits its parent;
-     see applyPanelUiScale. Defaults to 1, i.e. plain 100%. */
-  height: calc(100% / var(--cmcp-ui-scale, 1));
+  display: flex; flex-direction: column; height: 100%; min-height: 0;
+  /* #753 — a plain 100% is CORRECT under the UI-scale zoom, and dividing by the
+     scale is not. A percentage height inside a zoomed element ALREADY resolves
+     against the parent in the zoomed coordinate space, so the compensation that
+     shipped applied it twice (at 175%: 619px parent -> 202px root) and left the
+     composer stranded mid-panel above a band of empty space. Measured in Chrome,
+     both ways. Do not re-add it. */
   position: relative; /* positioning context for the rollback modal overlay */
   font-family: var(--font-inter, "Inter", ui-sans-serif, system-ui, sans-serif);
   font-size: 0.8125rem; line-height: 1.5;


### PR DESCRIPTION
Follow-up to #850, caught by **looking at the panel** rather than at the code.

#850 shipped `height: calc(100% / var(--cmcp-ui-scale, 1))` on `.cmcp-root`, acting on the reporter's caveat that a zoomed element *might* overflow a percentage-height parent. Measured in Chrome, it does not — and the compensation applies the correction a **second** time.

At 175% in a 619 px slot:

| | root computed height |
|---|---|
| with the calc | **202 px** (619 ÷ 1.75 ÷ 1.75) |
| plain `height: 100%` | **353 px** (619 ÷ 1.75) — fills exactly |

The visible result was a panel whose content stopped two-thirds of the way down, with the composer stranded mid-panel above a band of empty background. A percentage height inside a zoomed element already resolves against the parent in the zoomed coordinate space; there is nothing to cancel.

So `.cmcp-root` returns to a plain `height: 100%`, and `--cmcp-ui-scale` goes with it — the variable existed only to feed that calc, and leaving it behind invites someone to reintroduce the division it was for. The comment now records the measurement **in both directions**, so the next reader doesn't re-derive the caveat and re-add it.

**Verified live** at 100% and 175%: the root fills its parent (619 = 619), the composer is back at the bottom, the transcript occupies the space above it, and the text is visibly larger.

Worth noting: codex reviewed #850 and answered that the calc had "no conflict" with the flex column. That was reasoning about the CSS in the abstract, and it was wrong in the same direction I was — this only surfaced from a screenshot and a geometry measurement.

Mutation-verified: re-adding the calc fails 2 tests; removing the zoom fails 1. Full unit suite: **3204 pass / 0 fail**.

Refs #753