### PR TITLE
0.11.52 — the sidebar can be made readable (#753)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+## [0.11.52] - 2026-08-09
+
+> Covers changes since 0.11.51.
+
+### Added
+- **Panel UI scale.** A new setting in ComfyUI Settings (Comfy MCP Agent → General → "Panel UI
+  scale (%)") scales the whole Agent sidebar — text, icons and spacing together — from 100% to
+  250%. Reported by a user on Windows 11 for whom the panel text was barely readable.
+
+  Worth knowing if you tried to fix this yourself: overriding `.cmcp-root { font-size }` in a
+  user stylesheet does **not** work, and that is not your mistake. The panel's inner sizes are
+  `rem`, which resolve against the page root rather than against the panel, so most text ignores
+  the override. This setting is the supported way to scale the panel (#753)
+
 ## [0.11.51] - 2026-08-09
 
 > Covers changes since 0.11.50.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-agent-panel"
 description = "Autonomous AI agent in the ComfyUI sidebar - local-first, bring any LLM. Run it on your Claude or ChatGPT subscription (no API keys, no extra LLM costs), on a Kimi K3 / GLM / OpenRouter key, or fully offline on free local models via Ollama, LM Studio, or llama.cpp. The agent drives your live canvas at full parity: add, wire, move and tweak nodes with Ctrl+Z undo, load whole workflows and installer packs in one shot, generate images, video and audio, browse CivitAI, and run your workflow - asking before it spends paid API credits. The sidebar UI for comfyui-mcp, the local-first, agent-native control plane for ComfyUI."
-version = "0.11.51"
+version = "0.11.52"
 license = { file = "LICENSE" }
 requires-python = ">=3.9"
 # UI-only pack: no Python deps. The frontend floor guarantees

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -872,7 +872,7 @@ const DOCS_URL = "https://comfyui-mcp.artokun.io/docs";
 // Panel version — surfaced in the "Need help?" diagnostics blob. Bump via
 // `node scripts/set-version.mjs <v>` (updates this AND pyproject together); CI
 // and the publish gate FAIL if the two ever drift, so this can't go stale.
-const PANEL_VERSION = "0.11.51";
+const PANEL_VERSION = "0.11.52";
 
 // The connected orchestrator's console URL/token (captured off the `backends`
 // bridge message — see onBackends). Drives the "API Keys" credentials frame;


### PR DESCRIPTION
One user-facing change since 0.11.51: **#753**.

A **"Panel UI scale (%)"** setting (Comfy MCP Agent → General), 100–250, scaling the whole sidebar — text, icons and spacing together. Reported by a user on Windows 11 for whom the panel text was barely readable.

Worth stating because it wasn't the user's mistake: overriding `.cmcp-root { font-size }` in a stylesheet does **not** work. The panel's inner sizes are `rem`, which resolve against the page root rather than the panel, so most text ignores the override. The tooltip says so too.

#853 corrects a height compensation #850 shipped on the reporter's speculative caveat. It wasn't needed and was actively wrong — a percentage height inside a zoomed element already resolves against the parent in the zoomed space, so dividing by the scale applied it twice (619 px slot → 202 px root at 175%) and left the composer stranded mid-panel above empty background. Caught by screenshotting the panel rather than reasoning about the CSS.

Also on main since 0.11.51, test-only and not user-facing: #793/#845 and #847/#849, which took the e2e suite from 17 failing specs to 2.

## Gates

- `pyproject` 0.11.52 and `PANEL_VERSION` 0.11.52 match (the publish gate's own check, run locally).
- Full unit suite: **3204 pass / 0 fail**.
- Verified live in Chrome at 100% and 175%: root fills its parent exactly, composer pinned to the bottom, transcript above it, text visibly larger.

Refs #753