### PR TITLE
fix(add_node): the schema-drift refusal names the wrong recovery (#852)

### DIFF
--- a/browser_tests/unit/add-node-schema-drift-recovery.test.mjs
+++ b/browser_tests/unit/add-node-schema-drift-recovery.test.mjs
@@ -1,0 +1,90 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+// #852 — `panel_add_node` refuses correctly when a class's required inputs drifted
+// since the page loaded its schema (a model file moved between folders changes a
+// loader's combo, and creating the node now would build the OLD shape). The
+// refusal was right; the recovery it named was not.
+//
+// It said to reload the ComfyUI tab. `panel_refresh_nodes` clears the same
+// condition in place — it re-fetches /object_info and calls
+// `registerNodesFromDefs`, which is precisely what updates the `nodeData` this
+// check reads — and the reporter verified that. Telling a user to throw away
+// their canvas state for something the panel can fix without it is the same
+// class of defect as #663: a refusal that sends the caller to the wrong recovery
+// costs more than the refusal.
+
+const PANEL = readFileSync(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8");
+
+/** The refusal text, read from the source it is built in. */
+const refusal = (() => {
+  const at = PANEL.indexOf("added or retyped since this page loaded its node schema");
+  assert.ok(at > 0, "the schema-drift refusal must exist");
+  return PANEL.slice(at, PANEL.indexOf("      );", at));
+})();
+
+test("the refusal names panel_refresh_nodes", () => {
+  assert.ok(refusal.includes("panel_refresh_nodes"), "the working recovery must be named");
+});
+
+test("panel_refresh_nodes comes FIRST, before the tab reload", () => {
+  // Order is the whole point. Both work; only one keeps the user's canvas, and a
+  // reader takes the first remedy offered.
+  const refreshAt = refusal.indexOf("panel_refresh_nodes");
+  const reloadAt = refusal.indexOf("Reloading the ComfyUI tab");
+  assert.ok(refreshAt > 0 && reloadAt > 0, "both remedies must be present");
+  assert.ok(refreshAt < reloadAt, "the non-destructive remedy must be offered first");
+});
+
+test("the tab reload survives as the FALLBACK, not as the only answer", () => {
+  // refresh_nodes can report that it did not complete (it returns
+  // `refreshed:false` with a reason), and a refusal that had removed the reload
+  // would then leave the caller with nothing.
+  assert.ok(refusal.includes("fallback"), "the reload must remain as a fallback");
+});
+
+test("it says what the refresh does NOT fix", () => {
+  // registerNodesFromDefs mints new classes; node INSTANCES already on the canvas
+  // keep the shape they were created with. A recovery that oversells itself sends
+  // someone hunting for why an existing node still looks wrong.
+  assert.ok(refusal.includes("ALREADY on the canvas"), "the limit must be stated");
+});
+
+test("it no longer tells the user to reload as the primary remedy", () => {
+  assert.ok(
+    !refusal.includes("Reload the ComfyUI tab so"),
+    "the old reload-first wording must be gone",
+  );
+});
+
+// ── the claim the message makes has to be true ─────────────────────────────
+
+test("refresh_nodes really does re-register the class this check reads", () => {
+  // The message asserts refresh_nodes re-fetches /object_info and re-registers
+  // the class. If that stopped being true the refusal would be lying, so pin the
+  // chain: refresh_nodes -> refreshComfyNodeDefs(force) -> getNodeDefs +
+  // registerNodesFromDefs.
+  const fn = PANEL.slice(PANEL.indexOf("async refresh_nodes() {"), PANEL.indexOf("graph_serialize() {"));
+  assert.ok(fn.includes("refreshComfyNodeDefs(undefined, { force: true })"));
+  const register = PANEL.slice(
+    PANEL.indexOf("async function registerComfyNodeDefs"),
+    PANEL.indexOf("const refreshComfyNodeDefs = makeRefreshCoalescer"),
+  );
+  assert.ok(register.includes("api.getNodeDefs()"), "it must re-fetch the schema");
+  assert.ok(register.includes("registerNodesFromDefs(defs)"), "it must re-register the classes");
+});
+
+test("the drift check reads the registry nodeData the refresh updates", () => {
+  // The two halves have to be about the same thing, or the named recovery is a
+  // coincidence rather than a fix.
+  const site = PANEL.slice(
+    PANEL.indexOf("const drifted = driftedRequiredInputNames"),
+    PANEL.indexOf("added or retyped since this page loaded its node schema"),
+  );
+  assert.ok(site.includes("driftedRequiredInputNames(currentDef, nodeData)"));
+  assert.ok(
+    PANEL.includes("const nodeData = LG?.registered_node_types?.[class_type]?.nodeData;"),
+    "nodeData must come from the LiteGraph registry that registerNodesFromDefs writes",
+  );
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -8769,13 +8769,26 @@ const GRAPH_TOOL_EXECUTORS = {
     // createNode would build the OLD shape — a new link input would not even
     // get a slot and the node could never validate. Refuse before creating
     // anything, with the remedy that actually updates the schema.
+    //
+    // #852 — and that remedy is panel_refresh_nodes, not a tab reload. This text
+    // named the reload alone, so a user whose loader options had merely drifted
+    // (a model file moved between folders) was told to throw away their canvas
+    // state for a condition the panel can clear in place: refresh_nodes re-fetches
+    // /object_info and calls registerNodesFromDefs, which is precisely what updates
+    // the nodeData this check reads. Same class of defect as #663 — a refusal that
+    // sends the caller to the wrong recovery costs more than the refusal itself.
     const drifted = driftedRequiredInputNames(currentDef, nodeData);
     if (drifted.length) {
       throw new Error(
         `"${class_type}" required input${drifted.length === 1 ? "" : "s"} ` +
           `${drifted.map((name) => `"${name}"`).join(", ")} ${drifted.length === 1 ? "was" : "were"} ` +
-          "added or retyped since this page loaded its node schema. Reload the ComfyUI tab so " +
-          "the frontend picks up the updated node definition, then retry.",
+          "added or retyped since this page loaded its node schema, so creating it now would " +
+          "build the OLD shape. Call panel_refresh_nodes and retry — it re-fetches /object_info " +
+          "and re-registers the class in place, which is exactly what this refusal is waiting " +
+          "for, and it costs you no canvas state. Reloading the ComfyUI tab also works and is " +
+          "the fallback if the refresh reports it did not complete. NOTE: the refresh updates " +
+          "the CLASS, so the node you add next is correct; nodes ALREADY on the canvas keep the " +
+          "shape they were created with.",
       );
     }
     // Socket proof comes from the SAME fresh defs — NOT the LiteGraph


### PR DESCRIPTION
> its only recovery text said to reload the entire ComfyUI tab even though `panel_refresh_nodes` is the built-in, non-destructive recovery and was verified to resolve the condition immediately.

The refusal itself is right: a class whose required inputs drifted since the page loaded its schema would be built in the **old** shape, and a new link input wouldn't even get a slot. What was wrong is where it sent the caller — a model file moved between folders changes a loader's combo, and the panel answered that by telling the user to throw away their canvas state.

## The remedy and the check are about the same object

Not incidental — pinned by tests so it stays true:

`refresh_nodes` → `refreshComfyNodeDefs(force)` → `api.getNodeDefs()` + `registerNodesFromDefs(defs)`

and `registerNodesFromDefs` is what writes the `LG.registered_node_types[type].nodeData` that `driftedRequiredInputNames` reads.

## What the new text does

- leads with `panel_refresh_nodes`;
- keeps the tab reload as the **fallback** — `refresh_nodes` can return `refreshed:false` with a reason, and a message that had dropped the reload would leave that caller with nothing;
- states what the refresh does **not** fix: it updates the **class**, so the next node added is correct, while nodes already on the canvas keep the shape they were created with. A recovery that oversells itself sends someone hunting for why an existing node still looks wrong.

Same class as #663 — a refusal that names the wrong recovery costs more than the refusal did.

## Verification

7 new unit tests. Mutation-verified: restoring the old reload-only wording fails 5, dropping the reload fallback fails 2, dropping the already-on-canvas caveat fails 1. The tests also pin the **claim** the message makes — that `refresh_nodes` really re-fetches and re-registers — so the text can't quietly become a lie if that chain changes.

Tool-vocabulary gate passes (`panel_refresh_nodes` is a real tool). Full unit suite: **3211 pass / 0 fail**.

Codex: **ship**, no defects. It noted that ordinary refresh failures surface as thrown errors rather than a `{refreshed:false}` report — not a correctness issue, and the fallback sentence covers both shapes.

Message-only change; no behavioural code touched.

Refs #852
