### PR TITLE
0.11.53 — a schema-drift refusal stops costing you the canvas (#852)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+## [0.11.53] - 2026-08-09
+
+> Covers changes since 0.11.52.
+
+### Fixed
+- `panel_add_node`'s schema-drift refusal pointed at the wrong recovery. When a node class's
+  required inputs changed since the page loaded its schema — moving a model file between
+  folders is enough — the panel correctly refuses to build the stale shape, but it told you to
+  reload the whole ComfyUI tab. `panel_refresh_nodes` clears the same condition in place and
+  costs no canvas state: it re-fetches `/object_info` and re-registers the class, which is
+  exactly what the refusal is waiting for. The message now leads with that, keeps the tab reload
+  as the fallback, and says what the refresh does NOT fix — nodes already on the canvas keep the
+  shape they were created with (#852)
+
 ## [0.11.52] - 2026-08-09
 
 > Covers changes since 0.11.51.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-agent-panel"
 description = "Autonomous AI agent in the ComfyUI sidebar - local-first, bring any LLM. Run it on your Claude or ChatGPT subscription (no API keys, no extra LLM costs), on a Kimi K3 / GLM / OpenRouter key, or fully offline on free local models via Ollama, LM Studio, or llama.cpp. The agent drives your live canvas at full parity: add, wire, move and tweak nodes with Ctrl+Z undo, load whole workflows and installer packs in one shot, generate images, video and audio, browse CivitAI, and run your workflow - asking before it spends paid API credits. The sidebar UI for comfyui-mcp, the local-first, agent-native control plane for ComfyUI."
-version = "0.11.52"
+version = "0.11.53"
 license = { file = "LICENSE" }
 requires-python = ">=3.9"
 # UI-only pack: no Python deps. The frontend floor guarantees

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -872,7 +872,7 @@ const DOCS_URL = "https://comfyui-mcp.artokun.io/docs";
 // Panel version — surfaced in the "Need help?" diagnostics blob. Bump via
 // `node scripts/set-version.mjs <v>` (updates this AND pyproject together); CI
 // and the publish gate FAIL if the two ever drift, so this can't go stale.
-const PANEL_VERSION = "0.11.52";
+const PANEL_VERSION = "0.11.53";
 
 // The connected orchestrator's console URL/token (captured off the `backends`
 // bridge message — see onBackends). Drives the "API Keys" credentials frame;


### PR DESCRIPTION
One change since 0.11.52: **#852**.

`panel_add_node` correctly refuses to build a node whose required inputs drifted since the page loaded its schema — moving a model file between folders is enough — but its only stated recovery was reloading the whole ComfyUI tab.

`panel_refresh_nodes` clears the same condition **in place**: it re-fetches `/object_info` and calls `registerNodesFromDefs`, which is what writes the `nodeData` the drift check reads. The message now leads with that, keeps the reload as the fallback (the refresh can report it didn't complete), and says what the refresh does **not** fix — nodes already on the canvas keep the shape they were created with.

## Gates

- `pyproject` 0.11.53 and `PANEL_VERSION` 0.11.53 match (the publish gate's own check, run locally).
- Full unit suite: **3211 pass / 0 fail**.
- **Verified end-to-end in a live browser**, not just asserted: made a real registered class drift, got the new refusal, called `refresh_nodes` (`refreshed: true`), retried the add — **succeeded**. The message's claim is demonstrated rather than argued.

Refs #852