### PR TITLE
fix(reboot): the reboot reply names the server it restarted (#851)

### DIFF
--- a/browser_tests/unit/reboot-target-identity.test.mjs
+++ b/browser_tests/unit/reboot-target-identity.test.mjs
@@ -1,0 +1,141 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+// #851 — the reboot reply named the ROUTE and never the HOST.
+//
+// When the panel drives a ComfyUI that is NOT the orchestrator's headless
+// COMFYUI_URL, a confirmation timeout sends the user to `restart_comfyui`, which
+// targets the OTHER machine and answers "No ComfyUI process found on port 8188"
+// — while the panel had been operating on the live one all along. Nothing in any
+// reply revealed the two were different, so nobody could notice before acting on
+// advice aimed at the wrong server.
+//
+// The panel is the one component that knows this for certain: it runs inside the
+// ComfyUI it reboots. These pin that it says so, on EVERY branch, and that the
+// value it says it with is the same one the orchestrator was told to target.
+
+const PANEL = readFileSync(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8");
+
+const reboot = (() => {
+  const at = PANEL.indexOf("  async comfy_reboot({ force } = {}) {");
+  assert.ok(at > 0, "comfy_reboot must exist");
+  return PANEL.slice(at, PANEL.indexOf("  async free_vram()", at));
+})();
+
+test("the target comes from the SAME value handed to the orchestrator in hello", () => {
+  // If this used its own notion of the ComfyUI URL, the identity a caller
+  // compares against its own target could drift from the one it was told to
+  // target — which is the entire failure being fixed.
+  const fn = PANEL.slice(
+    PANEL.indexOf("function rebootTargetFields() {"),
+    PANEL.indexOf("const GRAPH_TOOL_EXECUTORS = {"),
+  );
+  assert.ok(fn.length > 0, "the helper must precede the executors table");
+  assert.ok(fn.includes("comfyuiUrlForAgent()"), "it must reuse the hello identity");
+});
+
+test("an unknown target is OMITTED, never guessed", () => {
+  // `comfyuiUrlForAgent()` returns "" when it cannot read the location. Emitting
+  // `target: ""` would be worse than saying nothing: a caller comparing hosts
+  // would read it as a real, different one.
+  const fn = PANEL.slice(
+    PANEL.indexOf("function rebootTargetFields() {"),
+    PANEL.indexOf("const GRAPH_TOOL_EXECUTORS = {"),
+  );
+  assert.ok(fn.includes("target ? { target } : {}"), "an empty target must be omitted");
+});
+
+test("it is a plain function, not a method on the executors table", () => {
+  // Dispatch calls `executor(msg)` with no receiver, so `this` is undefined in a
+  // module — a method call would throw a TypeError instead of rebooting, turning
+  // a reply-shape improvement into a broken reboot.
+  assert.ok(PANEL.includes("function rebootTargetFields() {"), "must be a standalone function");
+  assert.ok(!reboot.includes("this.rebootTargetFields"), "must not be called as a method");
+  assert.ok(PANEL.includes("result = await executor(msg);"), "dispatch really is receiver-less");
+});
+
+// ── every branch, including the ones that failed ───────────────────────────
+
+test("all six reply branches name the target", () => {
+  // The failures matter most: "which server refused?" is the whole question when
+  // the panel and the headless tool disagree about what they are pointing at.
+  const spread = (reboot.match(/\.\.\.rebootTargetFields\(\)/g) || []).length;
+  assert.equal(spread, 6, `expected 6 branches to carry the target, found ${spread}`);
+});
+
+test("the successful reboot says which server is going down", () => {
+  assert.ok(
+    reboot.includes("return { rebooting: true, endpoint: route, method, ...rebootTargetFields() };"),
+    "the ok branch must carry it",
+  );
+});
+
+test("the Manager 403 refusal says which server refused", () => {
+  const at = reboot.indexOf("ComfyUI-Manager refused the reboot (HTTP 403)");
+  assert.ok(at > 0);
+  const branch = reboot.slice(reboot.lastIndexOf("return {", at), at);
+  assert.ok(branch.includes("rebootTargetFields()"), "a refusal must name the server that refused");
+});
+
+test("the exhausted-endpoints failure says which server could not be reached", () => {
+  const at = reboot.indexOf("Could not reach any ComfyUI-Manager reboot endpoint");
+  assert.ok(at > 0);
+  const branch = reboot.slice(reboot.lastIndexOf("return {", at), at);
+  assert.ok(branch.includes("rebootTargetFields()"));
+});
+
+test("the busy refusal names the server it declined to restart", () => {
+  const at = reboot.indexOf("blocked_busy: true");
+  assert.ok(at > 0);
+  const branch = reboot.slice(at, at + 200);
+  assert.ok(branch.includes("rebootTargetFields()"));
+});
+
+// ── the prose a human actually reads ───────────────────────────────────────
+
+test("the failure messages name the server, not only the structured field", () => {
+  // `target` is for a caller comparing hosts. These strings are what gets shown,
+  // and "could not reach any reboot endpoint" that cannot say WHICH server it
+  // failed to reach is the reported failure in miniature.
+  assert.ok(
+    reboot.includes('rebootTargetLabel("Could not reach any ComfyUI-Manager reboot endpoint")'),
+    "the unreachable-endpoints error must name the server",
+  );
+  assert.ok(
+    reboot.includes('rebootTargetLabel("ComfyUI-Manager refused the reboot (HTTP 403)")'),
+    "the 403 refusal must name the server that refused",
+  );
+});
+
+test("the label appends nothing when the target is unknown", () => {
+  // Same rule as the field: a blank host is worse than no host, because it reads
+  // as a real one. `prefix` must come back untouched.
+  const fn = PANEL.slice(
+    PANEL.indexOf("function rebootTargetLabel(prefix) {"),
+    PANEL.indexOf("function rebootTargetFields() {"),
+  );
+  assert.ok(fn.length > 0, "the label helper must exist");
+  assert.ok(fn.includes("comfyuiUrlForAgent()"), "it must reuse the hello identity too");
+  assert.ok(fn.includes("target ? prefix"), "an unknown target must yield the bare prefix");
+  assert.ok(fn.includes(": prefix;"), "…and nothing appended to it");
+});
+
+test("naming the server did not swallow the rest of either message", () => {
+  // Both messages carry their remedy — lower the Manager security level; check
+  // the Manager is enabled — and a refusal that lost its recovery is worse than
+  // one that never named the host.
+  assert.ok(reboot.includes("security level to be 'middle' or below"), "the 403 remedy survives");
+  assert.ok(reboot.includes("(is the built-in Manager enabled?). Tried: "), "the retry list survives");
+  assert.ok(reboot.includes("ComfyUI was NOT restarted"), "both must still say nothing happened");
+});
+
+test("the proxy-5xx and dropped-connection branches keep reporting a FIRED reboot", () => {
+  // Both are successes (the origin is going down). Adding the target must not
+  // have disturbed `rebooting: true` — reporting a fired reboot as a failure is
+  // the defect those branches exist to prevent.
+  const proxy = reboot.slice(reboot.indexOf("proxy returned") - 260, reboot.indexOf("proxy returned"));
+  assert.ok(proxy.includes("rebooting: true") && proxy.includes("rebootTargetFields()"));
+  const dropped = reboot.slice(reboot.indexOf("connection dropped") - 260, reboot.indexOf("connection dropped"));
+  assert.ok(dropped.includes("rebooting: true") && dropped.includes("rebootTargetFields()"));
+});

--- a/browser_tests/unit/reboot-target-identity.test.mjs
+++ b/browser_tests/unit/reboot-target-identity.test.mjs
@@ -92,6 +92,43 @@ test("the busy refusal names the server it declined to restart", () => {
   assert.ok(branch.includes("rebootTargetFields()"));
 });
 
+// ── it has to be safe where it is called ───────────────────────────────────
+
+test("resolving the target cannot throw — one branch runs inside a catch", () => {
+  // The dropped-connection branch is a `catch`. If reading the identity could
+  // throw there, a reboot that FIRED would be reported as a failure — the exact
+  // inversion those branches exist to prevent. The whole chain swallows:
+  // getSetting catches, remoteUrlSetting type-guards, comfyuiUrlForAgent catches.
+  const url = PANEL.slice(
+    PANEL.indexOf("function comfyuiUrlForAgent() {"),
+    PANEL.indexOf("// #296/#291 — Local ComfyUI workspace path"),
+  );
+  assert.ok(url.includes("} catch {"), "the origin read must be guarded");
+  assert.ok(url.includes('return "";'), "…and fall back to an empty string");
+  const setting = PANEL.slice(
+    PANEL.indexOf("function remoteUrlSetting() {"),
+    PANEL.indexOf("function externalOrchestratorMode() {"),
+  );
+  assert.ok(setting.includes('typeof v === "string" ? v.trim() : ""'), "a non-string setting must not blow up");
+  const get = PANEL.slice(PANEL.indexOf("\nfunction getSetting(id) {"), PANEL.indexOf("function chatScopeMode() {"));
+  assert.ok(get.includes("} catch {"), "the settings read must be guarded");
+});
+
+test("a remote-URL override IS the target — not window.location.origin", () => {
+  // This is the reported case: the panel driving a ComfyUI that is not the one
+  // the headless tool targets. If the reply named the browser's own origin while
+  // the panel was actually operating on the override, the field would be a
+  // confident wrong answer — worse than the missing one it replaces.
+  const url = PANEL.slice(
+    PANEL.indexOf("function comfyuiUrlForAgent() {"),
+    PANEL.indexOf("// #296/#291 — Local ComfyUI workspace path"),
+  );
+  const overrideAt = url.indexOf("if (override) return override;");
+  const originAt = url.indexOf("window.location.origin");
+  assert.ok(overrideAt > 0 && originAt > 0, "both sources must be present");
+  assert.ok(overrideAt < originAt, "the override must win over the page origin");
+});
+
 // ── the prose a human actually reads ───────────────────────────────────────
 
 test("the failure messages name the server, not only the structured field", () => {

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -7460,6 +7460,44 @@ function revalidateGraphMutationContext(captured) {
 // measure how much of the canvas the open sidebar panel overlays.
 let activePanelRoot = null;
 
+/**
+ * #851 — WHICH ComfyUI a reboot reply is about.
+ *
+ * The reply named the ROUTE (`/v2/manager/reboot`) and never the HOST, so a caller
+ * could not tell which server had just gone down. That is not cosmetic: when the
+ * panel is driving a ComfyUI that is NOT the orchestrator's headless COMFYUI_URL, a
+ * confirmation timeout sends the user to `restart_comfyui`, which targets the OTHER
+ * machine and answers "No ComfyUI process found on port 8188" — while the panel had
+ * been operating happily on the live one all along. Nothing in any reply revealed the
+ * two were different.
+ *
+ * The panel is the one component that knows this for certain: it runs INSIDE the
+ * ComfyUI it reboots. `comfyuiUrlForAgent()` is deliberately the SAME value handed to
+ * the orchestrator in `hello`, so the identity a caller compares against its own
+ * target cannot drift from the one it was told to target.
+ *
+ * A plain function, NOT a method on the executors table: dispatch invokes
+ * `executor(msg)` with no receiver, so `this` is undefined in a module and a method
+ * call here would throw instead of rebooting.
+ */
+/**
+ * The same identity, for prose (#851).
+ *
+ * `target` is for a caller comparing hosts; these strings are what a HUMAN reads,
+ * and "could not reach any reboot endpoint" that cannot say WHICH server it failed
+ * to reach is the reported failure in miniature. Appends nothing when the target is
+ * unknown, rather than naming a blank one.
+ */
+function rebootTargetLabel(prefix) {
+  const target = comfyuiUrlForAgent();
+  return target ? prefix + " on " + target : prefix;
+}
+
+function rebootTargetFields() {
+  const target = comfyuiUrlForAgent();
+  return target ? { target } : {};
+}
+
 const GRAPH_TOOL_EXECUTORS = {
   // #608: force a fresh /object_info re-register + combo refresh so an asset that
   // appeared server-side AFTER page-load — an upload_image action:"stage" input, a freshly
@@ -14244,6 +14282,8 @@ const GRAPH_TOOL_EXECUTORS = {
     return { status };
   },
 
+  // #851 — every branch below names the TARGET as well as the route, via
+  // `rebootTargetFields()`. See that function for why the host matters.
   async comfy_reboot({ force } = {}) {
     // Restart the ComfyUI server (to load newly installed nodes). ComfyUI and the
     // orchestrator go down briefly; the panel auto-reconnects + resumes after.
@@ -14260,6 +14300,7 @@ const GRAPH_TOOL_EXECUTORS = {
           return {
             rebooting: false,
             blocked_busy: true,
+            ...rebootTargetFields(),
             queue_running: running,
             queue_pending: pending,
             message:
@@ -14307,12 +14348,14 @@ const GRAPH_TOOL_EXECUTORS = {
     for (const { route, method } of candidates) {
       try {
         const res = await api.fetchApi(route, { method });
-        if (res && res.ok) return { rebooting: true, endpoint: route, method };
+        if (res && res.ok) return { rebooting: true, endpoint: route, method, ...rebootTargetFields() };
         if (res && res.status === 403) {
           return {
             rebooting: false,
+            ...rebootTargetFields(),
             error:
-              "ComfyUI-Manager refused the reboot (HTTP 403): rebooting requires the Manager " +
+              rebootTargetLabel("ComfyUI-Manager refused the reboot (HTTP 403)") +
+              ": rebooting requires the Manager " +
               "security level to be 'middle' or below. Ask the user to lower it in ComfyUI-Manager " +
               "settings, then retry. ComfyUI was NOT restarted.",
           };
@@ -14328,6 +14371,7 @@ const GRAPH_TOOL_EXECUTORS = {
             rebooting: true,
             endpoint: route,
             method,
+            ...rebootTargetFields(),
             note: `proxy returned ${res.status} (origin going down) — reboot initiated`,
           };
         }
@@ -14339,14 +14383,17 @@ const GRAPH_TOOL_EXECUTORS = {
           rebooting: true,
           endpoint: route,
           method,
+          ...rebootTargetFields(),
           note: "connection dropped (server going down) — reboot initiated",
         };
       }
     }
     return {
       rebooting: false,
+      ...rebootTargetFields(),
       error:
-        "Could not reach any ComfyUI-Manager reboot endpoint — ComfyUI was NOT restarted " +
+        rebootTargetLabel("Could not reach any ComfyUI-Manager reboot endpoint") +
+        " — ComfyUI was NOT restarted " +
         "(is the built-in Manager enabled?). Tried: " +
         errors.join("; "),
     };


### PR DESCRIPTION
Claiming the **panel-side half** of #851, and I want to be precise about which half, because the report says "upstream-only: yes" and it is mostly right.

**Out of my reach here:** the 90s confirmation card, its timeout wording (`No confirmation received within 90s, so I did NOT restart ComfyUI`), and the recommendation to fall back to headless `restart_comfyui`. Those live in the orchestrator; the panel only executes `comfy_reboot`. The reporter searched for the string locally and correctly found no panel target.

**What IS panel-side, and is the root of the reported harm:** the reboot reply never says *which server* it rebooted. It returns `{ rebooting: true, endpoint: "/v2/manager/reboot", method: "POST" }` — the route, not the host. So when the panel is driving a ComfyUI that is **not** the headless `COMFYUI_URL`, nothing in the reply reveals that, and the caller has no way to notice before being sent to a fallback that targets a different machine and fails with `No ComfyUI process found on port 8188`.

The panel is the one component that knows this for certain — it is running *inside* the ComfyUI it is rebooting. Naming that in the reply is what lets the orchestrator's fallback advice become conditional instead of assumed, and it is useful on its own: an agent reading `rebooting: true` today cannot tell the user which server just went down.

Scope: report the target the panel actually rebooted, on every branch of that reply (success, proxy-5xx, and the structured failure), so a caller can compare it against wherever it is about to send them.

Refs #851