### PR TITLE
0.11.54 — the reboot reply names the server it restarted (#851)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+## [0.11.54] - 2026-08-09
+
+> Covers changes since 0.11.53.
+
+### Fixed
+
+- **The reboot reply now says WHICH ComfyUI it restarted (#851).** `comfy_reboot`
+  returned the route (`/v2/manager/reboot`) and never the host, so a caller could
+  not tell which server had just gone down. When the panel drives a ComfyUI that
+  is not the orchestrator's headless `COMFYUI_URL`, that gap sends a confirmation
+  timeout to a fallback aimed at the other machine — which answers "No ComfyUI
+  process found on port 8188" while the panel was operating on the live one all
+  along. Every branch now carries `target`, and the two failure messages name the
+  host in prose; an unknown target is omitted rather than reported blank. The
+  confirmation card and its timeout wording are orchestrator-side and unchanged.
+
+
 ## [0.11.53] - 2026-08-09
 
 > Covers changes since 0.11.52.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-agent-panel"
 description = "Autonomous AI agent in the ComfyUI sidebar - local-first, bring any LLM. Run it on your Claude or ChatGPT subscription (no API keys, no extra LLM costs), on a Kimi K3 / GLM / OpenRouter key, or fully offline on free local models via Ollama, LM Studio, or llama.cpp. The agent drives your live canvas at full parity: add, wire, move and tweak nodes with Ctrl+Z undo, load whole workflows and installer packs in one shot, generate images, video and audio, browse CivitAI, and run your workflow - asking before it spends paid API credits. The sidebar UI for comfyui-mcp, the local-first, agent-native control plane for ComfyUI."
-version = "0.11.53"
+version = "0.11.54"
 license = { file = "LICENSE" }
 requires-python = ">=3.9"
 # UI-only pack: no Python deps. The frontend floor guarantees

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -872,7 +872,7 @@ const DOCS_URL = "https://comfyui-mcp.artokun.io/docs";
 // Panel version — surfaced in the "Need help?" diagnostics blob. Bump via
 // `node scripts/set-version.mjs <v>` (updates this AND pyproject together); CI
 // and the publish gate FAIL if the two ever drift, so this can't go stale.
-const PANEL_VERSION = "0.11.53";
+const PANEL_VERSION = "0.11.54";
 
 // The connected orchestrator's console URL/token (captured off the `backends`
 // bridge message — see onBackends). Drives the "API Keys" credentials frame;


### PR DESCRIPTION
Releases the single fix merged since 0.11.53.

## What ships

- **#851** (#858) — `comfy_reboot` returned the route (`/v2/manager/reboot`) and never the host, so a caller could not tell which ComfyUI had just gone down. All six reply branches now carry `target`, taken from `comfyuiUrlForAgent()` — the same value the panel hands the orchestrator in `hello`, so the identity a caller compares against its own target cannot drift from the one it was told to target. The two failure messages name the host in prose as well. An unknown target is omitted rather than emitted blank.

## Verification

- 3225 unit tests pass; every new assertion was mutation-verified (breaking the corresponding source line makes it fail).
- Codex review: SHIP, no correctness or compatibility blockers.
- Live browser: the served JS is the merged build, the panel mounts clean with `rebootTargetFields` lifted to module scope (no `this`-binding TypeError, no console errors), and the target resolves correctly in the page.

## Changelog note

The 0.11.54 section is hand-written. `scripts/gen-changelog.mjs` walks back to the last git **tag** rather than the last release, so it regenerated 151 commits already shipped in 0.11.47–0.11.53.

🤖 Generated with [Claude Code](https://claude.com/claude-code)