### PR TITLE
fix(disclosure): a deferred tool is not an absent one (#857)

### DIFF
--- a/browser_tests/unit/canvas-tool-disclosure.test.mjs
+++ b/browser_tests/unit/canvas-tool-disclosure.test.mjs
@@ -240,6 +240,68 @@ test("the remedies are actionable from where the user already is, and are distin
   assert.match(CANVAS_TOOL_DISCLOSURE, /switch this chat to the Claude backend/);
 });
 
+// ── #857: a deferred tool is not an absent one ─────────────────────────────
+
+test("it tells the model to search the DEFERRED registry, not just what it was handed", () => {
+  // The reporter's Codex session found no panel_graph_outline in its initial tool
+  // description, found mcp__panel__panel_graph_outline in the lazy registry,
+  // called it, and got the live 41-node graph. The old text had no true branch for
+  // that: it asked "IS it in your toolset / IS IT NOT", and a deferred entry
+  // answers neither.
+  assert.match(CANVAS_TOOL_DISCLOSURE, /lazy\/deferred registry/);
+  assert.match(CANVAS_TOOL_DISCLOSURE, /search the deferred registry too before concluding anything is missing/);
+});
+
+test("it names the DEFERRED form of the tool, not only the bare name", () => {
+  // "Check your lazy registry" is the same unfalsifiable advice as "check your
+  // tools" — the model has to know what string it is looking for, and the deferred
+  // entry is namespaced by the server.
+  assert.match(CANVAS_TOOL_DISCLOSURE, /mcp__panel__panel_graph_outline/);
+});
+
+test("the two-surface lookup comes BEFORE either branch", () => {
+  // Order is the fix. A model that reaches "IF IT IS NOT in your toolset" before it
+  // has been told a second surface exists has already answered the question wrong,
+  // and nothing downstream retracts it.
+  const lookup = CANVAS_TOOL_DISCLOSURE.indexOf("LOOK IN BOTH SURFACES");
+  const present = CANVAS_TOOL_DISCLOSURE.indexOf("IS available in EITHER surface");
+  const absent = CANVAS_TOOL_DISCLOSURE.indexOf("IF IT IS IN NEITHER");
+  assert.ok(lookup > 0, "the lookup instruction must exist");
+  assert.ok(lookup < present && lookup < absent, "it must precede both branches");
+});
+
+test("BOTH branches are stated over both surfaces, not over the advertised list", () => {
+  // Fixing only the absence branch would leave the presence branch reading as a
+  // claim about the eager list, which is the same false negative one step later.
+  assert.match(CANVAS_TOOL_DISCLOSURE, /available in EITHER surface/);
+  assert.match(CANVAS_TOOL_DISCLOSURE, /IF IT IS IN NEITHER/);
+  // The old absolute wording must be gone — it is what produced the false negative.
+  assert.doesNotMatch(CANVAS_TOOL_DISCLOSURE, /IF IT IS NOT in your toolset/);
+  assert.doesNotMatch(CANVAS_TOOL_DISCLOSURE, /IF panel_graph_outline IS in your toolset/);
+});
+
+test("callable in either surface counts as present", () => {
+  // The panel cannot see the toolset, so the criterion handed to the model has to
+  // be one the model can actually apply: can you call it?
+  assert.match(CANVAS_TOOL_DISCLOSURE, /A tool you can CALL is present no matter which surface it came from/);
+});
+
+test("the search is BOUNDED — it has a stopping rule", () => {
+  // Without one, a genuinely tool-less session (the #291 session this module was
+  // written for) is told to keep looking for something that is not there. Failing
+  // to give the user a straight answer slowly is not better than doing it quickly.
+  assert.match(CANVAS_TOOL_DISCLOSURE, /Check each once, then answer/);
+  assert.match(CANVAS_TOOL_DISCLOSURE, /do not keep hunting/);
+});
+
+test("the absence branch still reaches its remedies after the extra step", () => {
+  // The new paragraph sits upstream of the thing that actually helps the user. If
+  // it had displaced the remedies, #857 would have been traded for #291.
+  const absent = CANVAS_TOOL_DISCLOSURE.indexOf("IF IT IS IN NEITHER");
+  const remedies = CANVAS_TOOL_DISCLOSURE.indexOf("update comfyui-mcp");
+  assert.ok(absent > 0 && remedies > absent, "the remedies must still follow the absence branch");
+});
+
 test("the text ends with a blank line so it cannot run into the user's message", () => {
   // It is PREPENDED to the turn text. Without the separator the user's first words
   // continue the disclosure's last sentence.

--- a/web/js/lib/canvas-tool-disclosure.js
+++ b/web/js/lib/canvas-tool-disclosure.js
@@ -60,16 +60,44 @@
  *     They are also ordered by likelihood, and each names its OWN cause: a crowded
  *     tool budget, a deliberate `full` override, and a session that needs rebuilding
  *     are three different faults and must not be narrated as one.
+ *
+ *  4. #857 — IT ASKS ABOUT THE WHOLE TOOLSET, NOT THE PART HANDED OVER UP FRONT.
+ *     Backends increasingly advertise tool NAMES eagerly and their schemas lazily:
+ *     the model resolves a deferred entry on demand and calls it. Codex and Claude
+ *     Code both work this way. A disclosure whose two branches were "IS in your
+ *     toolset" and "IS NOT" therefore had no true branch for the common case — the
+ *     reporter's session found no `panel_graph_outline` in its initial description,
+ *     found `mcp__panel__panel_graph_outline` in the lazy registry, called it, and
+ *     got the live 41-node graph back. Routed down the absence branch, it told the
+ *     user to update comfyui-mcp, prune their MCP config, or switch backends: three
+ *     remedies for a problem it did not have, and a diagnosis flatly contradicted by
+ *     a `tools/list` against the same endpoint.
+ *
+ *     That is #291 running in reverse and it is not a milder bug. #291 exists
+ *     because a model that cannot reach the canvas improvises; a false NEGATIVE
+ *     makes a model that CAN reach it improvise too, and hands the user a repair
+ *     procedure for a healthy install.
+ *
+ *     So the lookup comes FIRST, before either branch, and it is BOUNDED: one check
+ *     of each surface, then answer. "Look harder" with no stopping rule would turn a
+ *     genuinely tool-less session — the #291 session this module was written for —
+ *     into a search loop, which is the same failure to give the user a straight
+ *     answer, just slower.
  */
 export const CANVAS_TOOL_DISCLOSURE =
   `⚙ LIVE-CANVAS TOOLS — CHECK YOUR TOOLSET BEFORE YOU ACT ON THE CANVAS. ` +
   `The panel_* tools that read and edit the workflow this user has open are supplied to you by the ` +
   `panel's orchestrator, and the panel CANNOT observe whether they reached your toolset — only you ` +
   `can see that. This is a question, not a claim that anything is wrong.\n` +
-  `• IF panel_graph_outline IS in your toolset: work on the canvas normally. But being listed is not ` +
-  `proof the canvas is reachable — if a panel_* call then FAILS, report that failure and what it ` +
-  `said; do NOT quietly substitute a headless workaround for it.\n` +
-  `• IF IT IS NOT in your toolset: do NOT improvise a substitute — no saving a workflow file instead ` +
+  `• LOOK IN BOTH SURFACES BEFORE YOU ANSWER. Some backends hand you a tool's full schema up front; ` +
+  `others list it in a lazy/deferred registry you resolve on demand, where it appears as ` +
+  `mcp__panel__panel_graph_outline. A tool you can CALL is present no matter which surface it came ` +
+  `from, so search the deferred registry too before concluding anything is missing. Check each once, ` +
+  `then answer — do not keep hunting.\n` +
+  `• IF panel_graph_outline IS available in EITHER surface: work on the canvas normally. But being ` +
+  `listed is not proof the canvas is reachable — if a panel_* call then FAILS, report that failure ` +
+  `and what it said; do NOT quietly substitute a headless workaround for it.\n` +
+  `• IF IT IS IN NEITHER: do NOT improvise a substitute — no saving a workflow file instead ` +
   `of editing the canvas, no headless generate_image/enqueue_workflow standing in for a canvas run — ` +
   `and never describe graph edits you did not make. Say plainly that this session did not receive the ` +
   `live-canvas tools, then give the user these remedies in order: (1) update comfyui-mcp — on a ` +


### PR DESCRIPTION
Closes #857 — claiming it; work starts now.

## The defect

`CANVAS_TOOL_DISCLOSURE` asks the model one binary question:

- **IF `panel_graph_outline` IS in your toolset** → work normally
- **IF IT IS NOT** → say the session did not receive the live-canvas tools, and give three remedies

On a backend that **defers tool schemas**, neither branch is true. The reporter's Codex session had no `panel_graph_outline` in its initially advertised tool description, but `mcp__panel__panel_graph_outline` was present in the lazy/deferred registry — and resolving it returned the live 41-node graph. The loopback panel MCP was healthy the whole time; a direct `initialize` + `tools/list` returned the full panel surface.

So a session that **had** the canvas was routed down the absence branch and told the user to update comfyui-mcp, prune their MCP config, or switch backends — three remedies for a problem it did not have.

This is not #291 tool-budget crowd-out. The orchestrator was 0.50.56, spawned the headless MCP in compact mode, and configured both servers. The tools were there.

A false negative on a capability check is worse than no check: #291 exists because a model that cannot see the canvas improvises, and this makes a model that CAN see it improvise too.

## Plan

- Make the check two-surface: directly advertised tools **and** any lazy/deferred registry.
- Name `mcp__panel__panel_graph_outline` as the deferred form, so the model knows what it is looking for.
- Callable in either surface = present.
- Keep it bounded — check once, then conclude. Telling a genuinely tool-less session to "look harder" would turn #291 into a search loop.
- No growth in what the model must read per session that isn't earning its place.

Still verifying against `browser_tests/unit/canvas-tool-disclosure.test.mjs` (36 assertions today).

🤖 Generated with [Claude Code](https://claude.com/claude-code)