### PR TITLE
0.11.55 — a deferred tool is no longer read as an absent one (#857)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+## [0.11.55] - 2026-08-09
+
+> Covers changes since 0.11.54.
+
+### Fixed
+
+- **A deferred tool is no longer read as an absent one (#857).** The live-canvas
+  disclosure asked one binary question — is `panel_graph_outline` in your toolset
+  or not — and on a backend that defers tool schemas, neither answer is true. A
+  Codex session found nothing in its initially advertised tools, found
+  `mcp__panel__panel_graph_outline` in the lazy registry, called it, and got the
+  live 41-node graph; it had still been told to report the canvas unreachable and
+  hand the user three remedies for a healthy install. The lookup now comes first
+  and covers both surfaces — a tool you can call is present wherever it came from
+  — and it stops after one check, so a session that genuinely has no canvas tools
+  still reaches its remedies instead of searching forever.
+
+
 ## [0.11.54] - 2026-08-09
 
 > Covers changes since 0.11.53.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-agent-panel"
 description = "Autonomous AI agent in the ComfyUI sidebar - local-first, bring any LLM. Run it on your Claude or ChatGPT subscription (no API keys, no extra LLM costs), on a Kimi K3 / GLM / OpenRouter key, or fully offline on free local models via Ollama, LM Studio, or llama.cpp. The agent drives your live canvas at full parity: add, wire, move and tweak nodes with Ctrl+Z undo, load whole workflows and installer packs in one shot, generate images, video and audio, browse CivitAI, and run your workflow - asking before it spends paid API credits. The sidebar UI for comfyui-mcp, the local-first, agent-native control plane for ComfyUI."
-version = "0.11.54"
+version = "0.11.55"
 license = { file = "LICENSE" }
 requires-python = ">=3.9"
 # UI-only pack: no Python deps. The frontend floor guarantees

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -872,7 +872,7 @@ const DOCS_URL = "https://comfyui-mcp.artokun.io/docs";
 // Panel version — surfaced in the "Need help?" diagnostics blob. Bump via
 // `node scripts/set-version.mjs <v>` (updates this AND pyproject together); CI
 // and the publish gate FAIL if the two ever drift, so this can't go stale.
-const PANEL_VERSION = "0.11.54";
+const PANEL_VERSION = "0.11.55";
 
 // The connected orchestrator's console URL/token (captured off the `backends`
 // bridge message — see onBackends). Drives the "API Keys" credentials frame;


### PR DESCRIPTION
Releases the single fix merged since 0.11.54.

## What ships

- **#857** (#860) — the live-canvas disclosure asked a binary question ("IS `panel_graph_outline` in your toolset / IS IT NOT") that has no true answer on a backend which defers tool schemas. A Codex session found nothing in its initially advertised tools, found `mcp__panel__panel_graph_outline` in the lazy registry, called it, and got the live 41-node graph back — and had still been routed down the absence branch, telling the user to update comfyui-mcp, prune their MCP config, or switch backends for an install that was working.

  The lookup now comes **before** both branches and covers both surfaces; a tool you can call is present wherever it came from. It is bounded to one check per surface, so a session that genuinely lacks the tools (#291) still reaches its remedies instead of searching forever.

  Not Codex-specific — Claude Code defers MCP tool schemas the same way.

## Verification

- 3232 unit tests pass; the 7 new assertions were each mutation-verified, including the ordering one (moving the lookup after the branches fails it).
- `scripts/check-tool-vocabulary.mjs` passes with the new namespaced tool name.
- Codex review: SHIP, no merge-blocking findings.
- Live browser: the served module imports in the page and the assembled string satisfies every property — deferred form named, lookup before both branches, old binary wording gone, stopping rule present, remedies still after the absence branch. Panel mounts with no console errors.

## Changelog note

Hand-written again — `scripts/gen-changelog.mjs` walks back to the last git **tag** rather than the last release, so it regenerated 153 commits already shipped in 0.11.47–0.11.54.

🤖 Generated with [Claude Code](https://claude.com/claude-code)