### PR TITLE
fix(history): a first save must not hide the chat you had before it (#847)

### DIFF
--- a/browser_tests/unit/thread-workflow-match.test.mjs
+++ b/browser_tests/unit/thread-workflow-match.test.mjs
@@ -108,12 +108,17 @@ test("WIRING: threads are STAMPED with the route key and the picker matches on i
   const { readFile } = await import("node:fs/promises");
   const src = await readFile(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8");
 
-  // The IMPORT, not its formatting. An earlier version pinned the exact one-line
-  // form and failed the moment a second named export was added — a wiring test that
-  // breaks on a line wrap is a tax on every future change, not a guard.
-  assert.ok(src.includes("threadMatchesCurrentWorkflow"), "the matcher must be imported");
-  assert.ok(src.includes("currentWorkflowIdentityKeys"), "the identity-set builder must be imported");
-  assert.ok(src.includes('from "./lib/thread-workflow-match.js";'), "…from this module");
+  // The IMPORT BINDING, tolerant of formatting. Pinning the exact one-line form
+  // broke the moment a second named export was added; but relaxing it to three
+  // separate `includes` was worse (codex) — both identifiers appear elsewhere in
+  // this file, and the module path could belong to an import of something else
+  // entirely, so all three could pass with neither symbol bound. Parse the
+  // declaration instead: line wrapping is free, an unbound symbol is not.
+  const decl = src.match(/import\s*\{([^}]*)\}\s*from\s*"\.\/lib\/thread-workflow-match\.js";/);
+  assert.ok(decl, "the panel must import from the matcher module");
+  const named = decl[1].split(",").map((s) => s.trim()).filter(Boolean);
+  assert.ok(named.includes("threadMatchesCurrentWorkflow"), "the matcher must be bound");
+  assert.ok(named.includes("currentWorkflowIdentityKeys"), "the identity-set builder must be bound");
   // Stamped at thread creation AND on the revise that follows it.
   const stamps = src.match(/workflowRouteKey: workflowTabId\(\),/g) ?? [];
   assert.ok(stamps.length >= 2, `expected the route stamp at creation and revise, saw ${stamps.length}`);

--- a/browser_tests/unit/thread-workflow-match.test.mjs
+++ b/browser_tests/unit/thread-workflow-match.test.mjs
@@ -1,6 +1,10 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { threadMatchesCurrentWorkflow } from "../../web/js/lib/thread-workflow-match.js";
+import { readFileSync } from "node:fs";
+import {
+  threadMatchesCurrentWorkflow,
+  currentWorkflowIdentityKeys,
+} from "../../web/js/lib/thread-workflow-match.js";
 
 /**
  * #694 — "Current workflow only" showed 1 of 2 conversations created on the same
@@ -104,11 +108,106 @@ test("WIRING: threads are STAMPED with the route key and the picker matches on i
   const { readFile } = await import("node:fs/promises");
   const src = await readFile(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8");
 
-  assert.match(src, /import \{ threadMatchesCurrentWorkflow \} from "\.\/lib\/thread-workflow-match\.js";/);
+  // The IMPORT, not its formatting. An earlier version pinned the exact one-line
+  // form and failed the moment a second named export was added — a wiring test that
+  // breaks on a line wrap is a tax on every future change, not a guard.
+  assert.ok(src.includes("threadMatchesCurrentWorkflow"), "the matcher must be imported");
+  assert.ok(src.includes("currentWorkflowIdentityKeys"), "the identity-set builder must be imported");
+  assert.ok(src.includes('from "./lib/thread-workflow-match.js";'), "…from this module");
   // Stamped at thread creation AND on the revise that follows it.
   const stamps = src.match(/workflowRouteKey: workflowTabId\(\),/g) ?? [];
   assert.ok(stamps.length >= 2, `expected the route stamp at creation and revise, saw ${stamps.length}`);
   // And actually consulted by the "Current workflow only" filter.
   assert.ok(src.includes("threadMatchesCurrentWorkflow(candidate, currentWorkflowKeys)"),
     "the picker must use the matcher — otherwise #694's under-report returns");
+});
+
+test("WIRING #847: the filter's key set carries the PRIOR tmp: id", () => {
+  // The helper accepting a priorRouteId proves nothing if the panel never passes
+  // one. This is the whole fix: `_priorTempWorkflowIds` already retains that id for
+  // the live workflow object's lifetime, and `workflowRecordMatchesSelector` already
+  // honours it — the history filter was the one reader that did not.
+  const src = readFileSync(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8");
+  const site = src.slice(
+    src.indexOf("const currentWorkflowKeys = currentWorkflowIdentityKeys({"),
+    src.indexOf("threadMatchesCurrentWorkflow(candidate, currentWorkflowKeys)"),
+  );
+  assert.ok(site.length > 0, "the filter must build its key set through the shared builder");
+  assert.ok(site.includes("priorRouteId:"), "it must pass a prior route id");
+  assert.ok(site.includes("_priorTempWorkflowIds.get(activeWf)"), "…read from the map that retains it");
+  // Guarded: activeWorkflowRef() is null with no canvas, and a WeakMap.get(null)
+  // throws. A history pane that crashes on an empty canvas would be a worse bug
+  // than the one being fixed.
+  assert.ok(site.includes("activeWf ? _priorTempWorkflowIds.get(activeWf) : null"), "the lookup must be guarded");
+});
+
+// ── #847: a first SAVE moves both identity forms at once ───────────────────
+
+test("the prior tmp: id is part of the current workflow's identity set", () => {
+  // A first save migrates the route id (tmp:<uuid> -> wf:<path>) AND re-mints the
+  // storage uuid at the same boundary. A thread recorded before the save then holds
+  // neither live form, and "Current workflow only" hides a conversation the user had
+  // on the workflow they are looking at — same tab, same canvas, minutes earlier.
+  const keys = currentWorkflowIdentityKeys({
+    storageKey: "workflow:8765613d-614f-4cc6-a86b-607bdd3d2c2c",
+    routeId: "wf:workflows/Untitled.json",
+    priorRouteId: "tmp:15530147-0b52-4f52-9e09-732978ea6652",
+  });
+  // Observed in the live suite: these are the two stamps the two threads actually
+  // carried, and before this change nothing they held was in the set.
+  const beforeSave = {
+    workflowKey: "workflow:eff67d7a-4716-4c14-82f6-1ce4d47f0a72",
+    workflowRouteKey: "tmp:15530147-0b52-4f52-9e09-732978ea6652",
+  };
+  const afterSave = {
+    workflowKey: "workflow:8765613d-614f-4cc6-a86b-607bdd3d2c2c",
+    workflowRouteKey: "wf:workflows/Untitled.json",
+  };
+  assert.equal(threadMatchesCurrentWorkflow(beforeSave, keys), true, "the pre-save chat must not vanish");
+  assert.equal(threadMatchesCurrentWorkflow(afterSave, keys), true);
+});
+
+test("without the prior id, the pre-save thread is exactly the one that disappears", () => {
+  // The regression this guards. Stated as its own case so a future edit that drops
+  // priorRouteId fails with the reason rather than with an opaque count.
+  const keys = currentWorkflowIdentityKeys({
+    storageKey: "workflow:new-uuid",
+    routeId: "wf:workflows/Untitled.json",
+  });
+  assert.equal(
+    threadMatchesCurrentWorkflow(
+      { workflowKey: "workflow:old-uuid", workflowRouteKey: "tmp:abc" },
+      keys,
+    ),
+    false,
+  );
+});
+
+test("the identity set holds only real strings", () => {
+  // An absent form is absent, not a hole in the set. `undefined` could never match a
+  // thread's stamp anyway, but a set that silently carries holes invites a later
+  // reader to treat membership as meaningful when it is not.
+  const keys = currentWorkflowIdentityKeys({ storageKey: "workflow:x", routeId: null, priorRouteId: undefined });
+  assert.deepEqual([...keys], ["workflow:x"]);
+  assert.equal(currentWorkflowIdentityKeys({}).size, 0);
+  assert.equal(currentWorkflowIdentityKeys().size, 0);
+  // Empty strings are not identities.
+  assert.equal(currentWorkflowIdentityKeys({ storageKey: "", routeId: "" }).size, 0);
+});
+
+test("a thread from ANOTHER workflow still does not match", () => {
+  // Widening the identity set is only safe if it cannot pull in a foreign
+  // conversation — the failure the uuid re-mint exists to prevent (#570).
+  const keys = currentWorkflowIdentityKeys({
+    storageKey: "workflow:mine",
+    routeId: "wf:workflows/Mine.json",
+    priorRouteId: "tmp:mine-was",
+  });
+  assert.equal(
+    threadMatchesCurrentWorkflow(
+      { workflowKey: "workflow:theirs", workflowRouteKey: "tmp:theirs" },
+      keys,
+    ),
+    false,
+  );
 });

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -201,7 +201,10 @@ import {
 import { slotRenameLines } from "./lib/slot-rename-diff.js";
 import { describeRenameFailure } from "./lib/workflow-rename-error.js";
 import { boundSubgraphList } from "./lib/subgraph-list-bound.js";
-import { threadMatchesCurrentWorkflow } from "./lib/thread-workflow-match.js";
+import {
+  threadMatchesCurrentWorkflow,
+  currentWorkflowIdentityKeys,
+} from "./lib/thread-workflow-match.js";
 import { subgraphValueProvenance } from "./lib/subgraph-value-provenance.js";
 import { describeMissingNode } from "./lib/node-scope-locator.js";
 import { boundByChars, normalizeViewportMaxChars, viewportTruncation, VIEWPORT_DEFAULT_MAX_CHARS } from "./lib/viewport-char-bound.js";
@@ -22315,9 +22318,21 @@ function buildPanel() {
       listEl.textContent = "";
       const q = search.value.trim().toLocaleLowerCase();
       // Panel-owned threads keep workflow provenance instead of the global
-      // active-pointer key. Accept both the durable workflow UUID and the
-      // current bridge-tab id so the filter works before and after first save.
-      const currentWorkflowKeys = new Set([workflowStorageKey(), workflowTabId()]);
+      // active-pointer key. Accept the durable workflow UUID and the current
+      // bridge-tab id — which between them cover a thread written on either side
+      // of a first save, but NOT one written across it.
+      // #847 — the PRIOR tmp: id counts too. A first save migrates the route id
+      // (tmp:<uuid> -> wf:<path>) and re-mints the storage uuid at the same boundary, so a
+      // thread recorded minutes earlier on this very tab holds neither live form and drops
+      // out of this filter. `_priorTempWorkflowIds` already retains that id for the live
+      // object's lifetime, and `workflowRecordMatchesSelector` already honours it — this
+      // was the one reader that did not.
+      const activeWf = activeWorkflowRef();
+      const currentWorkflowKeys = currentWorkflowIdentityKeys({
+        storageKey: workflowStorageKey(),
+        routeId: workflowTabId(),
+        priorRouteId: activeWf ? _priorTempWorkflowIds.get(activeWf) : null,
+      });
       const visible = threads
         .filter((candidate) =>
           !currentOnly.checked || threadMatchesCurrentWorkflow(candidate, currentWorkflowKeys))

--- a/web/js/lib/thread-workflow-match.js
+++ b/web/js/lib/thread-workflow-match.js
@@ -30,6 +30,44 @@
  */
 
 /**
+ * #847 — the two mitigations above each cover ONE axis, and a SAVE moves both at once.
+ *
+ * A first save migrates the tab's route id from `tmp:<uuid>` to `wf:<path>`, and the
+ * same boundary re-mints the storage uuid. A thread recorded before the save is then
+ * left holding neither of the live workflow's identity forms, and "Current workflow
+ * only" hides a conversation the user had on the workflow they are looking at — same
+ * tab, same canvas, minutes earlier. It reads as history loss, which is the one thing
+ * a history pane must never appear to do.
+ *
+ * The panel does not have to GUESS that lineage: it already records it.
+ * `_priorTempWorkflowIds` retains the first tmp: id ever minted for a live workflow
+ * object, for that object's whole life, precisely "so a create-time pin survives the
+ * tab's first save" — and `workflowRecordMatchesSelector` has always honoured it when
+ * resolving a selector. This makes the history filter consult the same evidence
+ * instead of being the one reader that ignores it. Nothing is inferred: the prior id
+ * is keyed on the live object, and a copy never shares the object.
+ *
+ * LIMIT, stated rather than left to be discovered: `_priorTempWorkflowIds` is an
+ * in-memory WeakMap, so this match does not survive a reload. A thread written before
+ * a save and read after a refresh still falls back to today's behaviour. Closing that
+ * needs the stamps REWRITTEN at the save boundary — a change to persisted history —
+ * which is a bigger and separately reviewable step, not something to smuggle in here.
+ *
+ * @param {{storageKey?: string, routeId?: string, priorRouteId?: string}} forms
+ * @returns {Set<string>} the identity forms a thread may legitimately match on
+ */
+export function currentWorkflowIdentityKeys({ storageKey, routeId, priorRouteId } = {}) {
+  const keys = new Set();
+  // Only real, non-empty strings. An `undefined` in the set can never match a
+  // thread's stamp anyway, but a set that silently carries holes invites a later
+  // reader to treat membership as meaningful when it is not.
+  for (const form of [storageKey, routeId, priorRouteId]) {
+    if (typeof form === "string" && form) keys.add(form);
+  }
+  return keys;
+}
+
+/**
  * Does `thread` belong to the workflow whose current identity forms are `currentKeys`?
  *
  * @param {{workflowKey?: string, workflowRouteKey?: string}} thread


### PR DESCRIPTION
Works #847 (does not close it — see *What this does not fix*).

## What I found

`chat-history-v2:66` fails at line **95**, not line 91. The first `toHaveCount(2)` passes — both rows render. The failure is the **"Current workflow only"** filter dropping one.

Traced end to end against a live panel. The two threads, created on the same tab and same canvas about a minute apart:

| | `workflowKey` | `workflowRouteKey` |
|---|---|---|
| chat 1 | `workflow:eff67d7a…` | `tmp:15530147…` |
| chat 2 | `workflow:8765613d…` | `wf:workflows/Untitled.json` |

Same workflow, same title, **neither identity form in common** — because a first **save** moves both at once: it migrates the route id (`tmp:<uuid>` → `wf:<path>`) *and* re-mints the storage uuid at the same boundary. #694 made the route stamp survive a uuid re-mint; #570 made the uuid fail closed. Each covers one axis, and a save crosses both.

**This is a product bug, not a spec bug.** For a user: chat, save your workflow, start a new chat, filter to this workflow — and the conversation you had five minutes ago on this very workflow is gone. That reads as history loss, which is the one thing a history pane must never appear to do.

## The fix

No lineage is guessed. Guessing it wrong attaches another workflow's conversation to this one, which is exactly what the uuid re-mint exists to prevent.

The panel already **records** this lineage. `_priorTempWorkflowIds` retains the first `tmp:` id minted for a live workflow object for that object's whole life — explicitly *"so a create-time pin survives the tab's first save"* — and `workflowRecordMatchesSelector` has always honoured it. The history filter was the one reader that didn't. It now consults the same evidence, through a shared `currentWorkflowIdentityKeys` builder so the rule is unit-testable against the real function rather than a copy.

Also corrected a stale comment at the call site claiming the existing two forms made "the filter work before and after first save". They cover a thread written on *either side* of a save, not one written *across* it.

## Verification

- `chat-history-v2.spec.ts` in isolation: **4/4 green**, was 3/4.
- Full e2e at `--workers=4`: **4 failed → 2 failed**, 43 → 45 passed. No spec moved the other way.
- 3237 unit tests pass, including 5 new ones and a wiring test pinning that the panel actually passes a prior route id (and guards the `WeakMap.get` against a null active workflow).
- Also fixed an existing wiring assertion that pinned the *exact one-line import* and broke on a line wrap — a guard that fails on formatting is a tax, not a guard.

## What this does not fix

Stated in the module rather than left to be discovered:

- `_priorTempWorkflowIds` is an **in-memory WeakMap**, so the match does not survive a reload.
- It misses if a save **replaces** the workflow object rather than mutating it — which is why `chat-history-v2:66` still fails under heavier parallel load even with this change.

Closing those needs the stamps **rewritten at the save boundary**, i.e. a change to persisted history. That is a bigger, separately reviewable step and I'm not smuggling it in here. **#847 stays open for it**, along with `agent-drive:124`.

## Separate finding worth recording

The e2e suite is **unusable at Playwright's default worker count** on this machine (16 workers → 45–46 of 49 fail; at `--workers=4`, 2–4 fail). That is not a code regression — the baseline without this change is equally bad — but it means anyone running `npm run test:e2e` locally sees a wall of red and learns to ignore the suite. Worth pinning the worker count in the config; noted on #847.

🤖 Generated with [Claude Code](https://claude.com/claude-code)