### PR TITLE
0.11.56 — a first save no longer hides the chat you had before it (#847)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+## [0.11.56] - 2026-08-09
+
+> Covers changes since 0.11.55.
+
+### Fixed
+
+- **A first save no longer hides the chat you had before it (#847).** "Current
+  workflow only" showed one of two conversations held on the same tab and the
+  same canvas, minutes apart. Saving a workflow migrates its route id
+  (`tmp:<uuid>` to `wf:<path>`) and re-mints its storage uuid at the same
+  moment, so a chat recorded before the save shared no identity with the live
+  workflow and dropped out of a filter named for the workflow it was actually
+  held on. The filter now also accepts the workflow's pre-save id, which the
+  panel already records — nothing about lineage is guessed, so another
+  workflow's conversation still cannot be pulled in. Threads written before a
+  save are matched within the session; carrying that across a reload needs the
+  stamps rewritten at the save boundary and is still open.
+
+
 ## [0.11.55] - 2026-08-09
 
 > Covers changes since 0.11.54.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-agent-panel"
 description = "Autonomous AI agent in the ComfyUI sidebar - local-first, bring any LLM. Run it on your Claude or ChatGPT subscription (no API keys, no extra LLM costs), on a Kimi K3 / GLM / OpenRouter key, or fully offline on free local models via Ollama, LM Studio, or llama.cpp. The agent drives your live canvas at full parity: add, wire, move and tweak nodes with Ctrl+Z undo, load whole workflows and installer packs in one shot, generate images, video and audio, browse CivitAI, and run your workflow - asking before it spends paid API credits. The sidebar UI for comfyui-mcp, the local-first, agent-native control plane for ComfyUI."
-version = "0.11.55"
+version = "0.11.56"
 license = { file = "LICENSE" }
 requires-python = ">=3.9"
 # UI-only pack: no Python deps. The frontend floor guarantees

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -875,7 +875,7 @@ const DOCS_URL = "https://comfyui-mcp.artokun.io/docs";
 // Panel version — surfaced in the "Need help?" diagnostics blob. Bump via
 // `node scripts/set-version.mjs <v>` (updates this AND pyproject together); CI
 // and the publish gate FAIL if the two ever drift, so this can't go stale.
-const PANEL_VERSION = "0.11.55";
+const PANEL_VERSION = "0.11.56";
 
 // The connected orchestrator's console URL/token (captured off the `backends`
 // bridge message — see onBackends). Drives the "API Keys" credentials frame;


### PR DESCRIPTION
Releases the single fix merged since 0.11.55.

## What ships

- **#847** (#863) — "Current workflow only" showed one of two conversations held on the same tab and the same canvas, minutes apart. A first save migrates the workflow's route id (`tmp:<uuid>` → `wf:<path>`) *and* re-mints its storage uuid at the same boundary, so the earlier chat shared no identity form with the live workflow and fell out of a filter named for the workflow it was actually held on.

  The filter now also accepts the workflow's pre-save id — which the panel already records in `_priorTempWorkflowIds`, and which `workflowRecordMatchesSelector` has always honoured. No lineage is inferred, so a foreign workflow's conversation still cannot be pulled in.

## Verification

- `chat-history-v2.spec.ts` against merged main in a real browser: **4/4 green**, was 3/4.
- Full e2e at `--workers=4`: 4 failed → 2 failed, no spec regressing.
- 3237 unit tests pass, including a wiring guard that fails when the new symbol is unbound and stays green when the import is reformatted.
- Codex review: NO-SHIP on first pass (my replacement import guard could pass with neither symbol bound — a real weakening), then **SHIP** after restoring a declaration-parsing guard.

## Known limits, carried on #847

- The match is in-session only: `_priorTempWorkflowIds` is a WeakMap that does not survive a reload, and it misses if a save replaces the workflow object rather than mutating it. Carrying it across needs the stamps rewritten at the save boundary — a change to persisted history.
- `agent-drive:124` is still red.
- The e2e suite is unusable at Playwright's default worker count on this machine (16 workers → 45 of 49 fail; the same is true without this change). Worth pinning workers in the config.

## Changelog note

Hand-written — `scripts/gen-changelog.mjs` walks back to the last git **tag** rather than the last release, so it regenerated 155 commits already shipped in 0.11.47–0.11.55.

🤖 Generated with [Claude Code](https://claude.com/claude-code)