### PR TITLE
fix(history): give legacy transcripts a durable home, then bound the shared quota (#861)

### DIFF
--- a/browser_tests/chat-history-v2.spec.ts
+++ b/browser_tests/chat-history-v2.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from './fixtures/panelTest'
 import { resolveHistoryStoreModuleUrl } from './fixtures/historyStoreModule'
 
+
 const THREADS_KEY = 'comfyui-mcp.panel.threads'
 const META_KEY = 'comfyui-mcp.panel.historyMeta'
 
@@ -22,7 +23,7 @@ async function forceWorkflowScope(page: import('@playwright/test').Page) {
 async function indexedThreadCount(page: import('@playwright/test').Page): Promise<number> {
   return page.evaluate(async () => {
     const db = await new Promise<IDBDatabase>((resolve, reject) => {
-      const req = indexedDB.open('comfyui-mcp-panel-history', 3)
+      const req = indexedDB.open('comfyui-mcp-panel-history')
       req.onsuccess = () => resolve(req.result)
       req.onerror = () => reject(req.error)
     })
@@ -44,7 +45,7 @@ async function indexedHasMessage(
 ): Promise<boolean> {
   return page.evaluate(async (wanted) => {
     const db = await new Promise<IDBDatabase>((resolve, reject) => {
-      const req = indexedDB.open('comfyui-mcp-panel-history', 3)
+      const req = indexedDB.open('comfyui-mcp-panel-history')
       req.onsuccess = () => resolve(req.result)
       req.onerror = () => reject(req.error)
     })

--- a/browser_tests/conversation-persistence.spec.ts
+++ b/browser_tests/conversation-persistence.spec.ts
@@ -9,6 +9,7 @@ import { resolveHistoryStoreModuleUrl } from './fixtures/historyStoreModule'
 import { readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 
+
 const SESSION_KEY = 'comfyui-mcp.panel.sessionId'
 const CURRENT_THREAD_KEY = 'comfyui-mcp.panel.currentThreadId'
 const LOCAL_HISTORY_SNAPSHOT_KEY = 'comfyui-mcp.panel.historySnapshot'
@@ -56,13 +57,14 @@ test.beforeEach(async ({ context }) => {
 async function indexedThreadCount(page: import('@playwright/test').Page): Promise<number> {
   return page.evaluate(async () => {
     const db = await new Promise<IDBDatabase>((resolve, reject) => {
-      const request = indexedDB.open('comfyui-mcp-panel-history', 3)
+      const request = indexedDB.open('comfyui-mcp-panel-history')
       request.onsuccess = () => resolve(request.result)
       request.onerror = () => reject(request.error)
     })
     try {
       return await new Promise<number>((resolve, reject) => {
-        const request = db.transaction('snapshots', 'readonly').objectStore('snapshots').get('state')
+        if (!db.objectStoreNames.contains('snapshots')) { resolve(0); return }
+      const request = db.transaction('snapshots', 'readonly').objectStore('snapshots').get('state')
         request.onsuccess = () => resolve(Array.isArray(request.result?.threads) ? request.result.threads.length : 0)
         request.onerror = () => reject(request.error)
       })
@@ -75,13 +77,14 @@ async function indexedThreadCount(page: import('@playwright/test').Page): Promis
 async function indexedHasText(page: import('@playwright/test').Page, text: string): Promise<boolean> {
   return page.evaluate(async (needle) => {
     const db = await new Promise<IDBDatabase>((resolve, reject) => {
-      const request = indexedDB.open('comfyui-mcp-panel-history', 3)
+      const request = indexedDB.open('comfyui-mcp-panel-history')
       request.onsuccess = () => resolve(request.result)
       request.onerror = () => reject(request.error)
     })
     try {
       return await new Promise<boolean>((resolve, reject) => {
-        const request = db.transaction('snapshots', 'readonly').objectStore('snapshots').get('state')
+        if (!db.objectStoreNames.contains('snapshots')) { resolve(false); return }
+      const request = db.transaction('snapshots', 'readonly').objectStore('snapshots').get('state')
         request.onsuccess = () => resolve(Boolean(request.result?.threads?.some(
           (thread: any) => thread.msgs?.some((message: any) => message.text === needle)
         )))
@@ -99,13 +102,14 @@ async function indexedHasThread(
 ): Promise<boolean> {
   return page.evaluate(async (id) => {
     const db = await new Promise<IDBDatabase>((resolve, reject) => {
-      const request = indexedDB.open('comfyui-mcp-panel-history', 3)
+      const request = indexedDB.open('comfyui-mcp-panel-history')
       request.onsuccess = () => resolve(request.result)
       request.onerror = () => reject(request.error)
     })
     try {
       return await new Promise<boolean>((resolve, reject) => {
-        const request = db.transaction('snapshots', 'readonly').objectStore('snapshots').get('state')
+        if (!db.objectStoreNames.contains('snapshots')) { resolve(false); return }
+      const request = db.transaction('snapshots', 'readonly').objectStore('snapshots').get('state')
         request.onsuccess = () => resolve(Boolean(
           request.result?.threads?.some((thread: any) => thread.id === id)
         ))
@@ -123,13 +127,14 @@ async function indexedWorkflowAlias(
 ): Promise<string | null> {
   return page.evaluate(async (path) => {
     const db = await new Promise<IDBDatabase>((resolve, reject) => {
-      const request = indexedDB.open('comfyui-mcp-panel-history', 3)
+      const request = indexedDB.open('comfyui-mcp-panel-history')
       request.onsuccess = () => resolve(request.result)
       request.onerror = () => reject(request.error)
     })
     try {
       return await new Promise<string | null>((resolve, reject) => {
-        const request = db.transaction('snapshots', 'readonly').objectStore('snapshots').get('state')
+        if (!db.objectStoreNames.contains('snapshots')) { resolve(null); return }
+      const request = db.transaction('snapshots', 'readonly').objectStore('snapshots').get('state')
         request.onsuccess = () => resolve(request.result?.meta?.workflowAliases?.[path] || null)
         request.onerror = () => reject(request.error)
       })
@@ -192,7 +197,7 @@ async function seedReloadEvictionRace(
     localStorage.setItem('comfyui-mcp.panel.historyMeta', JSON.stringify(local.meta))
 
     const db = await new Promise<IDBDatabase>((resolve, reject) => {
-      const request = indexedDB.open('comfyui-mcp-panel-history', 3)
+      const request = indexedDB.open('comfyui-mcp-panel-history')
       request.onsuccess = () => resolve(request.result)
       request.onerror = () => reject(request.error)
     })
@@ -659,7 +664,7 @@ test('workflow rename publishes alias tombstones and a stale tab cannot echo the
     }
     localStorage.setItem(snapshotKey, JSON.stringify(snapshot))
     const db = await new Promise<IDBDatabase>((resolve, reject) => {
-      const request = indexedDB.open('comfyui-mcp-panel-history', 3)
+      const request = indexedDB.open('comfyui-mcp-panel-history')
       request.onsuccess = () => resolve(request.result)
       request.onerror = () => reject(request.error)
     })

--- a/browser_tests/unit/chat-history-store.test.mjs
+++ b/browser_tests/unit/chat-history-store.test.mjs
@@ -29,32 +29,72 @@ function createMemoryStorage({ throwOnSet = null } = {}) {
   }
 }
 
-function createFakeIndexedDb(initialState = null, { blockedThenSuccess = false } = {}) {
-  let state = initialState == null ? null : structuredClone(initialState)
+function createFakeIndexedDb(
+  initialState = null,
+  { blockedThenSuccess = false, stores = ['snapshots'] } = {}
+) {
+  // KEYED, like the real thing. This used to be a single slot: get() ignored the key
+  // and put() replaced everything, so a SECOND key in a store silently destroyed the
+  // canonical snapshot. That is exactly how #861's pending-delete marker behaved when
+  // it was first tried here, and the failure looked like a bug in the change rather
+  // than in the fake. A fake that cannot tell two keys apart cannot test two keys.
+  const data = new Map()
+  const at = (store, key) => store + ' :: ' + String(key)
+  if (initialState != null) data.set(at('snapshots', 'state'), structuredClone(initialState))
   let closeCount = 0
 
   const createDb = () => ({
-    objectStoreNames: { contains: (name) => name === 'snapshots' },
+    objectStoreNames: { contains: (name) => stores.includes(name) },
     createObjectStore() {},
     close: () => { closeCount += 1 },
-    transaction: (_name, mode) => {
+    transaction: (names, mode) => {
+      const wanted = Array.isArray(names) ? names : [names]
+      for (const name of wanted) {
+        if (!stores.includes(name)) throw new Error('no object store ' + name)
+      }
       const tx = {
         oncomplete: null,
         onerror: null,
         onabort: null,
-        objectStore: () => ({
-          get: () => {
+        objectStore: (name = wanted[0]) => ({
+          get: (key) => {
             const request = { result: undefined, onsuccess: null, onerror: null }
             queueMicrotask(() => {
-              request.result = state == null ? undefined : structuredClone(state)
+              const held = data.get(at(name, key))
+              request.result = held === undefined ? undefined : structuredClone(held)
               request.onsuccess?.()
             })
             return request
           },
-          put: (value) => {
+          getAll: () => {
+            const request = { result: [], onsuccess: null, onerror: null }
+            queueMicrotask(() => {
+              request.result = [...data.entries()]
+                .filter(([held]) => held.startsWith(name + ' :: '))
+                .map(([, value]) => structuredClone(value))
+              request.onsuccess?.()
+            })
+            return request
+          },
+          put: (value, key) => {
             assert.equal(mode, 'readwrite')
-            state = structuredClone(value)
+            data.set(at(name, key === undefined ? 'state' : key), structuredClone(value))
             queueMicrotask(() => tx.oncomplete?.())
+            return { onsuccess: null, onerror: null }
+          },
+          delete: (key) => {
+            assert.equal(mode, 'readwrite')
+            data.delete(at(name, key))
+            queueMicrotask(() => tx.oncomplete?.())
+            return { onsuccess: null, onerror: null }
+          },
+          clear: () => {
+            assert.equal(mode, 'readwrite')
+            for (const held of [...data.keys()]) {
+              if (held.startsWith(name + ' :: ')) data.delete(held)
+            }
+            queueMicrotask(() => tx.oncomplete?.())
+            return { onsuccess: null, onerror: null }
           }
         })
       }
@@ -80,7 +120,17 @@ function createFakeIndexedDb(initialState = null, { blockedThenSuccess = false }
       })
       return request
     },
-    readState: () => state == null ? null : structuredClone(state),
+    // Still the CANONICAL snapshot specifically, which is what every caller means
+    // by readState — now addressed by its key rather than by being the only thing
+    // the fake could hold.
+    readState: () => {
+      const held = data.get(at('snapshots', 'state'))
+      return held === undefined ? null : structuredClone(held)
+    },
+    readAt: (store, key) => {
+      const held = data.get(at(store, key))
+      return held === undefined ? null : structuredClone(held)
+    },
     closeCount: () => closeCount
   }
 }

--- a/browser_tests/unit/legacy-shadow-quota.test.mjs
+++ b/browser_tests/unit/legacy-shadow-quota.test.mjs
@@ -1,0 +1,355 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  ChatHistoryStore,
+  boundShadowBytes,
+  CHAT_HISTORY_SCHEMA,
+  CHAT_HISTORY_DB_VERSION,
+  CHAT_HISTORY_LEGACY_STORE,
+} from "../../web/js/lib/chat-history-store.js";
+
+// #861 — the panel's localStorage shadow kept every `legacyShadow` thread in full,
+// every message, forever, in a ~5MB budget it does not own alone. localStorage is
+// per-ORIGIN and the panel shares http://localhost:8188 with ComfyUI, so those bytes
+// are bytes ComfyUI's own saveDraft() cannot have. Past a point ComfyUI starts
+// showing "Failed to save workflow draft", Comfy.Workflow.DraftIndex.v2 stops
+// persisting, and every open workflow tab is gone on browser restart — with a clean
+// backend log and nothing pointing at the panel.
+//
+// The retention was not careless: the schema-3 fence keeps these threads out of
+// IndexedDB, so the shadow was their ONLY copy and capping it would have been
+// deleting transcripts. These pin the order the fix depends on — durable home first,
+// bound second, fail closed if the home is unavailable.
+
+// ── a fake IndexedDB, because the failure lives in the durable path ────────
+
+function createFakeIndexedDb({ failWrites = false, missingLegacyStore = false } = {}) {
+  const stores = new Map([["snapshots", new Map()]]);
+  if (!missingLegacyStore) stores.set(CHAT_HISTORY_LEGACY_STORE, new Map());
+  const db = {
+    objectStoreNames: { contains: (name) => stores.has(name) },
+    close() {},
+    transaction(name, mode) {
+      const data = stores.get(name);
+      if (!data) throw new Error(`no store ${name}`);
+      const tx = { oncomplete: null, onerror: null, onabort: null };
+      const settle = () => {
+        queueMicrotask(() => {
+          if (failWrites && mode === "readwrite") tx.onabort?.();
+          else tx.oncomplete?.();
+        });
+      };
+      tx.objectStore = () => ({
+        get(key) {
+          const req = {};
+          queueMicrotask(() => { req.result = data.get(key); req.onsuccess?.(); });
+          return req;
+        },
+        getAll() {
+          const req = {};
+          queueMicrotask(() => { req.result = [...data.values()]; req.onsuccess?.(); });
+          return req;
+        },
+        put(value, key) {
+          if (!failWrites) data.set(key, value);
+          const req = {};
+          queueMicrotask(() => req.onsuccess?.());
+          settle();
+          return req;
+        },
+      });
+      if (mode !== "readwrite") settle();
+      return tx;
+    },
+  };
+  return {
+    _stores: stores,
+    open() {
+      const req = {};
+      queueMicrotask(() => { req.result = db; req.onsuccess?.(); });
+      return req;
+    },
+  };
+}
+
+function createMemoryStorage() {
+  const map = new Map();
+  return {
+    getItem: (k) => (map.has(k) ? map.get(k) : null),
+    setItem: (k, v) => map.set(k, String(v)),
+    removeItem: (k) => map.delete(k),
+    _map: map,
+  };
+}
+
+const legacyThread = (id, ts, size = 50) => ({
+  id,
+  schemaVersion: CHAT_HISTORY_SCHEMA,
+  legacyShadow: true,
+  ts,
+  updatedAt: ts,
+  msgs: [{ id: `${id}-m`, role: "user", text: "x".repeat(size) }],
+});
+
+// ── the version decoupling, which is load-bearing ──────────────────────────
+
+test("the IDB version is NOT the record schema version", () => {
+  // These were one constant. The fence is `snapshot.schemaVersion >= CHAT_HISTORY_SCHEMA`,
+  // so bumping the number to add an object store would have made every stored
+  // schemaVersion:3 snapshot read as UNFENCED — reopening the pre-v3 merge path on
+  // every existing install, as a side effect of a structural migration.
+  assert.equal(CHAT_HISTORY_SCHEMA, 3, "the record schema must not move for a store migration");
+  assert.ok(CHAT_HISTORY_DB_VERSION > CHAT_HISTORY_SCHEMA, "the store migration needs its own number");
+});
+
+// ── the byte bound ─────────────────────────────────────────────────────────
+
+test("a snapshot already under budget is returned untouched", () => {
+  const snap = { threads: [legacyThread("a", 1)] };
+  const out = boundShadowBytes(snap, { maxBytes: 1_000_000, evictableIds: new Set(["a"]) });
+  assert.equal(out.snapshot, snap, "the common case must not rebuild the snapshot");
+  assert.deepEqual(out.evicted, []);
+});
+
+test("it evicts OLDEST first, and only down to the budget", () => {
+  // A shadow exists for instant startup; the newest chats are the ones a user comes
+  // back to, so they are the last to go.
+  const threads = [legacyThread("old", 1, 400), legacyThread("mid", 2, 400), legacyThread("new", 3, 400)];
+  const out = boundShadowBytes({ threads }, {
+    maxBytes: 1000,
+    evictableIds: new Set(["old", "mid", "new"]),
+  });
+  assert.ok(out.evicted.includes("old"), "the oldest must go first");
+  assert.ok(!out.evicted.includes("new"), "the newest must survive");
+  assert.ok(out.serialized.length <= 1000, `still over budget: ${out.serialized.length}`);
+});
+
+test("the result ACTUALLY fits, across many shapes and budgets", () => {
+  // The eviction count comes from a per-thread cost estimate, and the claim is that
+  // the estimate can only overshoot downward (it ignores the comma each removal also
+  // frees). "Usually right" is not a bound, so assert the invariant over a spread of
+  // thread sizes and budgets rather than one hand-picked case.
+  for (const size of [10, 200, 5000]) {
+    for (const count of [3, 40]) {
+      for (const maxBytes of [50, 900, 5000]) {
+        const threads = Array.from({ length: count }, (_, i) => legacyThread(`t${i}`, i, size));
+        const out = boundShadowBytes({ threads }, {
+          maxBytes,
+          evictableIds: new Set(threads.map((t) => t.id)),
+        });
+        const label = `size=${size} count=${count} max=${maxBytes}`;
+        // The floor: an empty thread list still serializes to a few bytes, so a
+        // budget below that cannot be met by eviction alone.
+        const floor = JSON.stringify({ threads: [] }).length;
+        assert.ok(
+          out.serialized.length <= Math.max(maxBytes, floor),
+          `over budget (${label}): ${out.serialized.length}`,
+        );
+        assert.equal(
+          JSON.stringify(out.snapshot).length,
+          out.serialized.length,
+          `the returned bytes must BE the returned snapshot (${label})`,
+        );
+      }
+    }
+  }
+});
+
+test("it does not over-evict — a thread that fits is kept", () => {
+  // The other half of the estimate's honesty. Overshooting downward is safe but not
+  // free: every thread dropped is one the user does not see on next startup.
+  const threads = [legacyThread("old", 1, 100), legacyThread("new", 2, 100)];
+  const full = JSON.stringify({ threads }).length;
+  const out = boundShadowBytes({ threads }, {
+    maxBytes: full - 1,
+    evictableIds: new Set(["old", "new"]),
+  });
+  assert.deepEqual(out.evicted, ["old"], "one eviction was enough; the second is waste");
+});
+
+test("NOTHING is evicted without a durable receipt — fail closed", () => {
+  // This is the whole reason a byte cap alone would have been wrong. An unbounded
+  // shadow is a quota bug; deleting the only copy of a transcript to fix it is worse.
+  const threads = Array.from({ length: 20 }, (_, i) => legacyThread(`t${i}`, i, 500));
+  for (const evictable of [undefined, new Set()]) {
+    const out = boundShadowBytes({ threads }, { maxBytes: 100, evictableIds: evictable });
+    assert.deepEqual(out.evicted, [], "an unproven thread must never be dropped");
+    assert.equal(out.snapshot.threads.length, 20);
+  }
+});
+
+test("a protected thread is never evicted, even when it IS durable", () => {
+  // Losing the transcript on screen to save space is not a trade a user would
+  // recognise as help.
+  const threads = [legacyThread("live", 1, 900), legacyThread("other", 2, 900)];
+  const out = boundShadowBytes({ threads }, {
+    maxBytes: 200,
+    evictableIds: new Set(["live", "other"]),
+    protectedIds: new Set(["live"]),
+  });
+  assert.ok(!out.evicted.includes("live"), "the protected thread must survive");
+  assert.ok(out.evicted.includes("other"));
+});
+
+test("a thread with no usable id is never evicted", () => {
+  const threads = [{ ts: 1, msgs: [] }, legacyThread("real", 2, 900)];
+  const out = boundShadowBytes({ threads }, { maxBytes: 50, evictableIds: new Set(["real"]) });
+  assert.deepEqual(out.evicted, ["real"]);
+});
+
+// ── the durable home, end to end ───────────────────────────────────────────
+
+test("legacy threads get a durable home, and the shadow can then be bounded", async () => {
+  const indexedDb = createFakeIndexedDb();
+  const storage = createMemoryStorage();
+  const evictions = [];
+  const store = new ChatHistoryStore({
+    storage,
+    indexedDb,
+    maxShadowBytes: 2000,
+    onShadowEvict: (ids) => evictions.push(...ids),
+  });
+  const threads = Array.from({ length: 12 }, (_, i) => legacyThread(`L${i}`, i + 1, 400));
+  store.persist(threads, {});
+  await store._writePromise;
+
+  const durable = [...indexedDb._stores.get(CHAT_HISTORY_LEGACY_STORE).keys()];
+  assert.equal(durable.length, 12, "every legacy thread must reach the legacy store");
+
+  // Second persist: the receipts now exist, so the shadow may shed bytes.
+  store.persist(threads, {});
+  await store._writePromise;
+  const written = JSON.parse(storage.getItem("comfyui-mcp.panel.historySnapshot"));
+  assert.ok(JSON.stringify(written).length <= 2000, "the shadow must respect the byte budget");
+  assert.ok(evictions.length > 0, "eviction must be observable, not silent");
+});
+
+test("an unreachable legacy store leaves the shadow unbounded rather than lossy", async () => {
+  // Private browsing, disabled IDB, a failed upgrade. The threads still have no
+  // durable home, so today's behaviour is the correct behaviour.
+  const storage = createMemoryStorage();
+  const store = new ChatHistoryStore({ storage, indexedDb: null, maxShadowBytes: 500 });
+  const threads = Array.from({ length: 10 }, (_, i) => legacyThread(`L${i}`, i + 1, 400));
+  store.persist(threads, {});
+  await store._writePromise;
+  const written = JSON.parse(storage.getItem("comfyui-mcp.panel.historySnapshot"));
+  assert.equal(written.threads.length, 10, "no legacy thread may be dropped without a durable copy");
+});
+
+test("a legacy store that ABORTS the write grants no receipt", async () => {
+  // Individual puts succeed against a transaction that later aborts on quota.
+  // Reporting that as durable is exactly what would license deleting the other copy.
+  const indexedDb = createFakeIndexedDb({ failWrites: true });
+  const storage = createMemoryStorage();
+  const store = new ChatHistoryStore({ storage, indexedDb, maxShadowBytes: 500 });
+  const threads = Array.from({ length: 8 }, (_, i) => legacyThread(`L${i}`, i + 1, 400));
+  store.persist(threads, {});
+  await store._writePromise;
+  assert.equal(store._durableLegacyIds.size, 0, "an aborted transaction is not a receipt");
+  const written = JSON.parse(storage.getItem("comfyui-mcp.panel.historySnapshot"));
+  assert.equal(written.threads.length, 8, "…so nothing may be evicted");
+});
+
+test("a database without the legacy store grants no receipt either", async () => {
+  // An upgrade that was blocked by another tab leaves an older DB shape live.
+  const indexedDb = createFakeIndexedDb({ missingLegacyStore: true });
+  const store = new ChatHistoryStore({ storage: createMemoryStorage(), indexedDb, maxShadowBytes: 500 });
+  store.persist([legacyThread("L0", 1, 900)], {});
+  await store._writePromise;
+  assert.equal(store._durableLegacyIds.size, 0);
+});
+
+test("a thread evicted from the shadow comes BACK from the legacy store", async () => {
+  // The point of the durable home. If eviction were one-way this would be data loss
+  // with extra steps.
+  const indexedDb = createFakeIndexedDb();
+  const store = new ChatHistoryStore({ storage: createMemoryStorage(), indexedDb, maxShadowBytes: 600 });
+  const threads = Array.from({ length: 6 }, (_, i) => legacyThread(`L${i}`, i + 1, 300));
+  store.persist(threads, {});
+  await store._writePromise;
+  store.persist(threads, {});
+  await store._writePromise;
+
+  const reader = new ChatHistoryStore({ storage: createMemoryStorage(), indexedDb });
+  const read = await reader.readCanonical();
+  const ids = new Set((read?.threads || []).map((t) => t.id));
+  for (const thread of threads) {
+    assert.ok(ids.has(thread.id), `${thread.id} must be recoverable from the legacy store`);
+  }
+  // Every restored thread must come back STILL FLAGGED. Dropping the flag would
+  // launder pre-v3 content — messages with no ids, re-hashed ordinals — straight
+  // through the schema-3 fence into canonical on the next persist, which is the
+  // exact resurrection the quarantine exists to prevent. (Written as an explicit
+  // count, not `every(t => !t.x || t.x === true)`: that predicate is true for
+  // `false` and can never fail.)
+  const restoredIds = new Set(threads.map((t) => t.id));
+  const restored = (read?.threads || []).filter((t) => restoredIds.has(t.id));
+  assert.equal(restored.length, threads.length);
+  for (const thread of restored) {
+    assert.equal(thread.legacyShadow, true, `${thread.id} must stay quarantined`);
+  }
+});
+
+test("an unreachable store on READ revokes the receipts rather than assuming empty", async () => {
+  // `idbReadLegacy` returns null for unreachable and [] for empty, and the
+  // difference decides whether transcripts may be evicted. Reading unreachable as
+  // empty would both crash on the null and, worse, let a later write believe threads
+  // were already durable when nothing had been read at all.
+  const indexedDb = createFakeIndexedDb();
+  const store = new ChatHistoryStore({ storage: createMemoryStorage(), indexedDb });
+  store.persist([legacyThread("L0", 1)], {});
+  await store._writePromise;
+  assert.equal(store._durableLegacyIds.size, 1, "precondition: a receipt exists");
+
+  store.indexedDb = null; // the store goes away mid-session (tab upgrade, private mode)
+  const read = await store.readCanonical();
+  assert.ok(read, "an unreachable legacy store must not fail the whole read");
+  assert.equal(store._durableLegacyIds.size, 0, "unknown is not proof of durability");
+});
+
+test("an EMPTY legacy store is not the same as an unreachable one", async () => {
+  // The other side of that distinction: genuinely empty is authoritative, and must
+  // not be mistaken for a failure that would keep stale receipts alive.
+  const indexedDb = createFakeIndexedDb();
+  const store = new ChatHistoryStore({ storage: createMemoryStorage(), indexedDb });
+  store._durableLegacyIds = new Set(["stale"]);
+  await store.readCanonical();
+  assert.equal(store._durableLegacyIds.has("stale"), false, "an empty store proves 'stale' is not durable");
+});
+
+test("the migration is idempotent — re-running it overwrites in place", async () => {
+  const indexedDb = createFakeIndexedDb();
+  const store = new ChatHistoryStore({ storage: createMemoryStorage(), indexedDb });
+  const threads = [legacyThread("L0", 1), legacyThread("L1", 2)];
+  store.persist(threads, {});
+  await store._writePromise;
+  for (let i = 0; i < 3; i += 1) {
+    await store.readCanonical();
+  }
+  assert.equal(
+    indexedDb._stores.get(CHAT_HISTORY_LEGACY_STORE).size,
+    2,
+    "repeated migration must not duplicate records",
+  );
+});
+
+test("ordinary threads are not evictable until CANONICAL has accepted them", async () => {
+  // The shadow is a cache of canonical — but only once canonical exists. Before the
+  // IndexedDB merge lands, and on any install where IndexedDB is unavailable, the
+  // shadow is the only copy of ordinary threads too, and the same rule has to apply
+  // to them as to legacy ones.
+  const storage = createMemoryStorage();
+  const store = new ChatHistoryStore({ storage, indexedDb: null, maxShadowBytes: 400 });
+  const ordinary = Array.from({ length: 6 }, (_, i) => ({
+    id: `O${i}`,
+    schemaVersion: CHAT_HISTORY_SCHEMA,
+    ts: i + 1,
+    updatedAt: i + 1,
+    msgs: [{ id: `O${i}-m`, role: "user", text: "y".repeat(300) }],
+  }));
+  store.persist(ordinary, {});
+  await store._writePromise;
+  const written = JSON.parse(storage.getItem("comfyui-mcp.panel.historySnapshot"));
+  assert.equal(written.threads.length, 6, "no ordinary thread may be dropped with no canonical copy");
+});

--- a/browser_tests/unit/legacy-shadow-quota.test.mjs
+++ b/browser_tests/unit/legacy-shadow-quota.test.mjs
@@ -721,3 +721,71 @@ test("the pending-delete marker is never mistaken for a transcript", async () =>
   }
   assert.equal(reader._durableLegacy.has("__cmcp_pending_deletes"), false, "the marker is not a receipt");
 });
+
+// ── codex r4 ───────────────────────────────────────────────────────────────
+
+test("one tab finishing its delete does not erase another tab's pending intent", async () => {
+  // The lost update codex named. Tab A finishes L0 and would write []; tab B's delete
+  // of L1 failed and wrote [L1]. A whole-list overwrite from A erases B's durable
+  // intent — then B closes, L1's capped tombstone ages out, and the reload hole is
+  // back. The write is a merge inside one transaction, so A only removes what A
+  // finished.
+  const indexedDb = createFakeIndexedDb();
+  const tabB = new ChatHistoryStore({ storage: createMemoryStorage(), indexedDb });
+  tabB.persist([legacyThread("L0", 1), legacyThread("L1", 2), legacyThread("L2", 3)], {});
+  await tabB._writePromise;
+
+  indexedDb._state.failDelete = true;
+  tabB.persist([legacyThread("L0", 1), legacyThread("L2", 3)], {
+    deletedThreads: { L1: { updatedAt: 5, writerId: "b", sequence: 1 } },
+  });
+  await tabB._writePromise;
+  indexedDb._state.failDelete = false;
+  assert.ok(tabB._pendingLegacyDeletes.has("L1"), "precondition: B owes a delete");
+
+  // Tab A: never saw L1's tombstone, and finishes its OWN delete of L0.
+  const tabA = new ChatHistoryStore({ storage: createMemoryStorage(), indexedDb });
+  tabA.persist([legacyThread("L2", 3)], {
+    deletedThreads: { L0: { updatedAt: 9, writerId: "a", sequence: 1 } },
+  });
+  await tabA._writePromise;
+  assert.equal(indexedDb._stores.get(CHAT_HISTORY_LEGACY_STORE).has("L0"), false, "A's delete landed");
+
+  // A third tab must still inherit B's intent.
+  const tabC = new ChatHistoryStore({ storage: createMemoryStorage(), indexedDb });
+  await tabC._restoreLegacyShadow({ threads: [], meta: {} });
+  assert.ok(
+    tabC._pendingLegacyDeletes.has("L1"),
+    "another tab's outstanding delete must survive an unrelated tab's completion",
+  );
+});
+
+test("a thread whose id IS the reserved marker key is never stored", async () => {
+  // Ids are normally crypto.randomUUID(), but an IMPORTED history can carry anything.
+  // Storing it would have the thread and the marker overwrite each other.
+  const indexedDb = createFakeIndexedDb();
+  const store = new ChatHistoryStore({ storage: createMemoryStorage(), indexedDb });
+  const collide = { ...legacyThread("x", 1), id: "__cmcp_pending_deletes" };
+  store.persist([collide, legacyThread("L1", 2)], {});
+  await store._writePromise;
+  const marker = indexedDb._stores.get(CHAT_HISTORY_LEGACY_STORE).get("__cmcp_pending_deletes");
+  assert.ok(!marker || !Array.isArray(marker.msgs), "a transcript must not occupy the marker key");
+  assert.equal(
+    store._durableLegacy.has("__cmcp_pending_deletes"),
+    false,
+    "…and it must not be granted a receipt, so it stays unevictable",
+  );
+});
+
+test("the marker is filtered structurally, not by key name", async () => {
+  // One place decides what a transcript is: a record with a string `id`.
+  const indexedDb = createFakeIndexedDb();
+  const store = new ChatHistoryStore({ storage: createMemoryStorage(), indexedDb });
+  store.persist([legacyThread("L0", 1)], {});
+  await store._writePromise;
+  // Any non-thread record, whatever its key, must not surface as history.
+  indexedDb._stores.get(CHAT_HISTORY_LEGACY_STORE).set("some-other-meta", { ids: ["z"] });
+  const reader = new ChatHistoryStore({ storage: createMemoryStorage(), indexedDb });
+  const restored = await reader._restoreLegacyShadow({ threads: [], meta: {} });
+  assert.deepEqual((restored.threads || []).map((t) => t.id), ["L0"]);
+});

--- a/browser_tests/unit/legacy-shadow-quota.test.mjs
+++ b/browser_tests/unit/legacy-shadow-quota.test.mjs
@@ -1054,3 +1054,36 @@ test("a record that got past the writer is still not restored once deleted for g
     "a transcript deleted for good must not return as live history",
   );
 });
+
+test("the fence exists BEFORE the record stops existing", async () => {
+  // codex r7. A delete that succeeds on its first attempt was never in `pending`, so
+  // between the record going away and the post-success write recording it as deleted
+  // there was an interval with nothing to refuse a stale write. The intent is recorded
+  // up front, which makes the gap impossible rather than short.
+  const indexedDb = createFakeIndexedDb();
+  const store = new ChatHistoryStore({ storage: createMemoryStorage(), indexedDb });
+  store.persist([legacyThread("L0", 1), legacyThread("L1", 2)], {});
+  await store._writePromise;
+
+  // Fail ONLY the record delete, so the run stops with the intent recorded and the
+  // record still present — the state that must already be fenced.
+  indexedDb._state.failDelete = true;
+  store.persist([legacyThread("L1", 2)], {
+    deletedThreads: { L0: { updatedAt: 500, writerId: "a", sequence: 1 } },
+  });
+  await store._writePromise;
+  indexedDb._state.failDelete = false;
+  const record = indexedDb._store("snapshots").get("__cmcp_legacy_pending_deletes");
+  assert.deepEqual(record?.pending, ["L0"], "the intent is durable before the delete lands");
+
+  // A stale tab writing in exactly that window is already refused.
+  const stale = new ChatHistoryStore({ storage: createMemoryStorage(), indexedDb });
+  const rewritten = { ...legacyThread("L0", 1), title: "stale" };
+  stale.persist([rewritten, legacyThread("L1", 2)], {});
+  await stale._writePromise;
+  assert.notEqual(
+    indexedDb._store(CHAT_HISTORY_LEGACY_STORE).get("L0")?.title,
+    "stale",
+    "the pre-delete window must already be fenced",
+  );
+});

--- a/browser_tests/unit/legacy-shadow-quota.test.mjs
+++ b/browser_tests/unit/legacy-shadow-quota.test.mjs
@@ -25,53 +25,86 @@ import {
 // ── a fake IndexedDB, because the failure lives in the durable path ────────
 
 function createFakeIndexedDb({ failWrites = false, missingLegacyStore = false } = {}) {
+  // Keyed by store + key, and multi-store transactions, because the real one is both.
+  // `idbWriteLegacy` spans `legacy` and `snapshots` in ONE transaction so it can see
+  // the pending-delete marker while it writes; a fake that only understood a single
+  // store name made that read as a bug in the change.
   const state = { failWrites, failStore: null, failDelete: false };
-  const stores = new Map([["snapshots", new Map()]]);
-  if (!missingLegacyStore) stores.set(CHAT_HISTORY_LEGACY_STORE, new Map());
+  const names = ["snapshots"];
+  if (!missingLegacyStore) names.push(CHAT_HISTORY_LEGACY_STORE);
+  const data = new Map();
+  const at = (store, key) => store + " :: " + String(key);
+
   const db = {
-    objectStoreNames: { contains: (name) => stores.has(name) },
+    objectStoreNames: { contains: (name) => names.includes(name) },
     close() {},
-    transaction(name, mode) {
-      const data = stores.get(name);
-      if (!data) throw new Error(`no store ${name}`);
+    transaction(requested, mode) {
+      const wanted = Array.isArray(requested) ? requested : [requested];
+      for (const name of wanted) {
+        if (!names.includes(name)) throw new Error("no object store " + name);
+      }
       const tx = { oncomplete: null, onerror: null, onabort: null };
       let doomed = false;
+      let settled = false;
+      // Real IDB completes a transaction once its request queue drains, whether or not
+      // anything was WRITTEN. The legacy write opens readwrite over two stores and can
+      // legitimately issue only a get (every id was refused), so a fake that settled
+      // solely on put/delete/clear hung forever instead of failing.
       const settle = () => {
+        if (settled) return;
+        settled = true;
         queueMicrotask(() => {
-          if ((state.failWrites || state.failStore === name || doomed) && mode === "readwrite") tx.onabort?.();
+          const failing = state.failWrites ||
+            wanted.some((name) => state.failStore === name) ||
+            doomed;
+          if (failing && mode === "readwrite") tx.onabort?.();
           else tx.oncomplete?.();
         });
       };
-      tx.objectStore = () => ({
+      const blocked = (name) => state.failWrites || state.failStore === name;
+      tx.objectStore = (name = wanted[0]) => ({
         get(key) {
           const req = {};
-          queueMicrotask(() => { req.result = data.get(key); req.onsuccess?.(); });
+          queueMicrotask(() => { req.result = data.get(at(name, key)); req.onsuccess?.(); });
+          // Drain after the handler runs, so a readwrite transaction whose only
+          // request is this get still completes — and so a put issued from inside
+          // onsuccess is applied before the completion fires.
+          queueMicrotask(() => queueMicrotask(settle));
           return req;
         },
         getAll() {
           const req = {};
-          queueMicrotask(() => { req.result = [...data.values()]; req.onsuccess?.(); });
+          queueMicrotask(() => {
+            req.result = [...data.entries()]
+              .filter(([held]) => held.startsWith(name + " :: "))
+              .map(([, value]) => value);
+            req.onsuccess?.();
+          });
+          return req;
+        },
+        put(value, key) {
+          if (!blocked(name)) data.set(at(name, key), value);
+          const req = {};
+          queueMicrotask(() => req.onsuccess?.());
+          settle();
           return req;
         },
         delete(key) {
           // A delete can fail where a small put still lands — a bulk delete and a
           // one-key marker are not the same transaction cost.
           if (state.failDelete) doomed = true;
-          else if (!state.failWrites && state.failStore !== name) data.delete(key);
+          else if (!blocked(name)) data.delete(at(name, key));
           const req = {};
           queueMicrotask(() => req.onsuccess?.());
           settle();
           return req;
         },
         clear() {
-          if (!state.failWrites && state.failStore !== name) data.clear();
-          const req = {};
-          queueMicrotask(() => req.onsuccess?.());
-          settle();
-          return req;
-        },
-        put(value, key) {
-          if (!state.failWrites && state.failStore !== name) data.set(key, value);
+          if (!blocked(name)) {
+            for (const held of [...data.keys()]) {
+              if (held.startsWith(name + " :: ")) data.delete(held);
+            }
+          }
           const req = {};
           queueMicrotask(() => req.onsuccess?.());
           settle();
@@ -82,9 +115,17 @@ function createFakeIndexedDb({ failWrites = false, missingLegacyStore = false } 
       return tx;
     },
   };
+
   return {
-    _stores: stores,
     _state: state,
+    /** Records in one store, as a Map of key -> value, for assertions. */
+    _store(name) {
+      const out = new Map();
+      for (const [held, value] of data.entries()) {
+        if (held.startsWith(name + " :: ")) out.set(held.slice((name + " :: ").length), value);
+      }
+      return out;
+    },
     open() {
       const req = {};
       queueMicrotask(() => { req.result = db; req.onsuccess?.(); });
@@ -234,7 +275,7 @@ test("legacy threads get a durable home, and the shadow can then be bounded", as
   store.persist(threads, {});
   await store._writePromise;
 
-  const durable = [...indexedDb._stores.get(CHAT_HISTORY_LEGACY_STORE).keys()];
+  const durable = [...indexedDb._store(CHAT_HISTORY_LEGACY_STORE).keys()];
   assert.equal(durable.length, 12, "every legacy thread must reach the legacy store");
 
   // Second persist: the receipts now exist, so the shadow may shed bytes.
@@ -348,7 +389,7 @@ test("the migration is idempotent — re-running it overwrites in place", async 
     await store.readCanonical();
   }
   assert.equal(
-    indexedDb._stores.get(CHAT_HISTORY_LEGACY_STORE).size,
+    indexedDb._store(CHAT_HISTORY_LEGACY_STORE).size,
     2,
     "repeated migration must not duplicate records",
   );
@@ -388,13 +429,13 @@ test("an EDITED legacy thread is rewritten, and is not evictable until it is", a
   const original = legacyThread("L0", 1, 40);
   store.persist([original], {});
   await store._writePromise;
-  const storedFirst = indexedDb._stores.get(CHAT_HISTORY_LEGACY_STORE).get("L0");
+  const storedFirst = indexedDb._store(CHAT_HISTORY_LEGACY_STORE).get("L0");
   assert.equal(storedFirst.msgs[0].text.length, 40);
 
   const edited = { ...original, updatedAt: 99, title: "renamed", msgs: [{ id: "L0-m", role: "user", text: "z".repeat(900) }] };
   store.persist([edited], {});
   await store._writePromise;
-  const storedSecond = indexedDb._stores.get(CHAT_HISTORY_LEGACY_STORE).get("L0");
+  const storedSecond = indexedDb._store(CHAT_HISTORY_LEGACY_STORE).get("L0");
   assert.equal(storedSecond.msgs[0].text.length, 900, "the edit must reach the durable copy");
   assert.equal(storedSecond.title, "renamed");
 });
@@ -417,7 +458,7 @@ test("a stale receipt does not license eviction", async () => {
   // L0 was rewritten (its fingerprint did not match) and so becomes legitimately
   // durable again — the point is that it was never evicted on the forged receipt.
   assert.ok(
-    indexedDb._stores.get(CHAT_HISTORY_LEGACY_STORE).has("L0"),
+    indexedDb._store(CHAT_HISTORY_LEGACY_STORE).has("L0"),
     "a mismatched fingerprint must trigger a rewrite, not an eviction",
   );
   assert.ok(written, "the shadow must still have been written");
@@ -431,12 +472,12 @@ test("a TOMBSTONED legacy thread is deleted from the store", async () => {
   const threads = [legacyThread("L0", 1), legacyThread("L1", 2)];
   store.persist(threads, {});
   await store._writePromise;
-  assert.equal(indexedDb._stores.get(CHAT_HISTORY_LEGACY_STORE).size, 2);
+  assert.equal(indexedDb._store(CHAT_HISTORY_LEGACY_STORE).size, 2);
 
   store.persist([threads[1]], { deletedThreads: { L0: { updatedAt: 500, writerId: 'tab-x', sequence: 1 } } });
   await store._writePromise;
   assert.equal(
-    indexedDb._stores.get(CHAT_HISTORY_LEGACY_STORE).has("L0"),
+    indexedDb._store(CHAT_HISTORY_LEGACY_STORE).has("L0"),
     false,
     "a deleted transcript must leave the durable store too",
   );
@@ -449,7 +490,7 @@ test("a tombstoned thread is not restored, even if the delete has not landed", a
   const store = new ChatHistoryStore({ storage: createMemoryStorage(), indexedDb });
   store.persist([legacyThread("L0", 1)], {});
   await store._writePromise;
-  assert.ok(indexedDb._stores.get(CHAT_HISTORY_LEGACY_STORE).has("L0"));
+  assert.ok(indexedDb._store(CHAT_HISTORY_LEGACY_STORE).has("L0"));
 
   const reader = new ChatHistoryStore({ storage: createMemoryStorage(), indexedDb });
   const restored = await reader._restoreLegacyShadow({
@@ -483,12 +524,12 @@ test("clearAll empties the legacy store", async () => {
   const store = new ChatHistoryStore({ storage: createMemoryStorage(), indexedDb });
   store.persist([legacyThread("L0", 1), legacyThread("L1", 2)], {});
   await store._writePromise;
-  assert.equal(indexedDb._stores.get(CHAT_HISTORY_LEGACY_STORE).size, 2);
+  assert.equal(indexedDb._store(CHAT_HISTORY_LEGACY_STORE).size, 2);
 
   await store.clearAll([], {});
   await store._writePromise;
   assert.equal(
-    indexedDb._stores.get(CHAT_HISTORY_LEGACY_STORE).size,
+    indexedDb._store(CHAT_HISTORY_LEGACY_STORE).size,
     0,
     "cleared transcripts must not survive in the legacy store",
   );
@@ -533,7 +574,7 @@ test('a same-length, same-timestamp edit ("foo" -> "bar") is still detected', as
   const before = { ...legacyThread("L0", 7), msgs: [{ id: "m", role: "user", text: "foo" }] };
   store.persist([before], {});
   await store._writePromise;
-  assert.equal(indexedDb._stores.get(CHAT_HISTORY_LEGACY_STORE).get("L0").msgs[0].text, "foo");
+  assert.equal(indexedDb._store(CHAT_HISTORY_LEGACY_STORE).get("L0").msgs[0].text, "foo");
 
   const after = { ...before, msgs: [{ id: "m", role: "user", text: "bar" }] };
   assert.equal(JSON.stringify(before).length, JSON.stringify(after).length, "precondition: same length");
@@ -541,7 +582,7 @@ test('a same-length, same-timestamp edit ("foo" -> "bar") is still detected', as
   store.persist([after], {});
   await store._writePromise;
   assert.equal(
-    indexedDb._stores.get(CHAT_HISTORY_LEGACY_STORE).get("L0").msgs[0].text,
+    indexedDb._store(CHAT_HISTORY_LEGACY_STORE).get("L0").msgs[0].text,
     "bar",
     "the durable copy must follow a same-size edit",
   );
@@ -557,13 +598,13 @@ test("a tombstone deletes ONLY its own record, never a neighbour's", async () =>
   const store = new ChatHistoryStore({ storage: createMemoryStorage(), indexedDb });
   store.persist([legacyThread("L0", 1), legacyThread("L1", 2), legacyThread("L2", 3)], {});
   await store._writePromise;
-  assert.equal(indexedDb._stores.get(CHAT_HISTORY_LEGACY_STORE).size, 3);
+  assert.equal(indexedDb._store(CHAT_HISTORY_LEGACY_STORE).size, 3);
 
   store.persist([legacyThread("L0", 1), legacyThread("L2", 3)], {
     deletedThreads: { L1: { updatedAt: 500, writerId: "t", sequence: 1 } },
   });
   await store._writePromise;
-  const keys = [...indexedDb._stores.get(CHAT_HISTORY_LEGACY_STORE).keys()].sort();
+  const keys = [...indexedDb._store(CHAT_HISTORY_LEGACY_STORE).keys()].sort();
   assert.deepEqual(keys, ["L0", "L2"], "only the tombstoned record may go");
 });
 
@@ -581,7 +622,7 @@ test("the delete pass skips any id still present as a live thread", async () => 
   store.persist([legacyThread("L0", 90)], {});
   await store._writePromise;
   assert.ok(
-    indexedDb._stores.get(CHAT_HISTORY_LEGACY_STORE).has("L0"),
+    indexedDb._store(CHAT_HISTORY_LEGACY_STORE).has("L0"),
     "a live thread's record must survive an outstanding delete for the same id",
   );
 });
@@ -601,14 +642,14 @@ test("a FAILED delete is retried, even after its tombstone ages out", async () =
   });
   await store._writePromise;
   assert.ok(store._pendingLegacyDeletes.has("L0"), "a failed delete must be remembered");
-  assert.ok(indexedDb._stores.get(CHAT_HISTORY_LEGACY_STORE).has("L0"), "precondition: still there");
+  assert.ok(indexedDb._store(CHAT_HISTORY_LEGACY_STORE).has("L0"), "precondition: still there");
 
   // The tombstone is GONE from meta now — aged out of the capped map.
   indexedDb._state.failWrites = false;
   store.persist([legacyThread("L1", 2)], {});
   await store._writePromise;
   assert.equal(
-    indexedDb._stores.get(CHAT_HISTORY_LEGACY_STORE).has("L0"),
+    indexedDb._store(CHAT_HISTORY_LEGACY_STORE).has("L0"),
     false,
     "the retry must land without the tombstone still being present",
   );
@@ -658,7 +699,7 @@ test("clearAll reports success when the legacy store really was cleared", () => 
     .then((result) => {
       assert.equal(result.ok, true);
       assert.equal(result.code, null);
-      assert.equal(indexedDb._stores.get(CHAT_HISTORY_LEGACY_STORE).size, 0);
+      assert.equal(indexedDb._store(CHAT_HISTORY_LEGACY_STORE).size, 0);
     });
 });
 
@@ -682,7 +723,7 @@ test("a failed delete survives a RELOAD and is retried by the next tab", async (
   await first._writePromise;
   assert.ok(first._pendingLegacyDeletes.has("L0"), "precondition: the delete did not land");
   assert.ok(
-    indexedDb._stores.get(CHAT_HISTORY_LEGACY_STORE).has("L0"),
+    indexedDb._store(CHAT_HISTORY_LEGACY_STORE).has("L0"),
     "precondition: the record is still there",
   );
 
@@ -749,7 +790,7 @@ test("one tab finishing its delete does not erase another tab's pending intent",
     deletedThreads: { L0: { updatedAt: 9, writerId: "a", sequence: 1 } },
   });
   await tabA._writePromise;
-  assert.equal(indexedDb._stores.get(CHAT_HISTORY_LEGACY_STORE).has("L0"), false, "A's delete landed");
+  assert.equal(indexedDb._store(CHAT_HISTORY_LEGACY_STORE).has("L0"), false, "A's delete landed");
 
   // A third tab must still inherit B's intent.
   const tabC = new ChatHistoryStore({ storage: createMemoryStorage(), indexedDb });
@@ -760,21 +801,77 @@ test("one tab finishing its delete does not erase another tab's pending intent",
   );
 });
 
-test("a thread whose id IS the reserved marker key is never stored", async () => {
-  // Ids are normally crypto.randomUUID(), but an IMPORTED history can carry anything.
-  // Storing it would have the thread and the marker overwrite each other.
+test("a thread id can never collide with the pending-delete marker", async () => {
+  // The marker used to sit beside the transcripts, in a key space addressed by THREAD
+  // ID. Refusing to store a colliding thread guarded new writes and did nothing about
+  // a database that already held one (codex r5). The marker now lives in `snapshots`,
+  // keyed by fixed names, so the collision cannot arise in either direction — which is
+  // a better answer than a guard covering one of them.
   const indexedDb = createFakeIndexedDb();
   const store = new ChatHistoryStore({ storage: createMemoryStorage(), indexedDb });
-  const collide = { ...legacyThread("x", 1), id: "__cmcp_pending_deletes" };
+  const collide = { ...legacyThread("x", 1), id: "__cmcp_legacy_pending_deletes" };
   store.persist([collide, legacyThread("L1", 2)], {});
   await store._writePromise;
-  const marker = indexedDb._stores.get(CHAT_HISTORY_LEGACY_STORE).get("__cmcp_pending_deletes");
-  assert.ok(!marker || !Array.isArray(marker.msgs), "a transcript must not occupy the marker key");
-  assert.equal(
-    store._durableLegacy.has("__cmcp_pending_deletes"),
-    false,
-    "…and it must not be granted a receipt, so it stays unevictable",
+
+  // It is just a transcript now, stored under its own id, with nothing to clobber.
+  const legacy = indexedDb._store(CHAT_HISTORY_LEGACY_STORE);
+  assert.ok(Array.isArray(legacy.get("__cmcp_legacy_pending_deletes")?.msgs));
+  assert.ok(store._durableLegacy.has("__cmcp_legacy_pending_deletes"), "and it is durable like any other");
+
+  // A marker write cannot reach it: different store.
+  indexedDb._state.failDelete = true;
+  store.persist([legacyThread("L1", 2)], {
+    deletedThreads: { gone: { updatedAt: 5, writerId: "t", sequence: 1 } },
+  });
+  await store._writePromise;
+  indexedDb._state.failDelete = false;
+  assert.ok(
+    Array.isArray(indexedDb._store(CHAT_HISTORY_LEGACY_STORE).get("__cmcp_legacy_pending_deletes")?.msgs),
+    "a marker write must not be able to overwrite a transcript",
   );
+});
+
+test("the marker never appears in the transcript store", () => {
+  // The property the relocation buys, stated directly.
+  const indexedDb = createFakeIndexedDb();
+  const store = new ChatHistoryStore({ storage: createMemoryStorage(), indexedDb });
+  store.persist([legacyThread("L0", 1), legacyThread("L1", 2)], {});
+  return store._writePromise
+    .then(() => {
+      indexedDb._state.failDelete = true;
+      store.persist([legacyThread("L1", 2)], {
+        deletedThreads: { L0: { updatedAt: 5, writerId: "t", sequence: 1 } },
+      });
+      return store._writePromise;
+    })
+    .then(() => {
+      indexedDb._state.failDelete = false;
+      assert.ok(store._pendingLegacyDeletes.has("L0"), "precondition: an intent was recorded");
+      assert.equal(
+        indexedDb._store(CHAT_HISTORY_LEGACY_STORE).has("__cmcp_legacy_pending_deletes"),
+        false,
+        "the marker must not be in the transcript store",
+      );
+      assert.ok(
+        indexedDb._store("snapshots").has("__cmcp_legacy_pending_deletes"),
+        "…it must be in snapshots, whose keys are fixed names",
+      );
+    });
+});
+
+test("a legacy write with nothing to store returns [] — never true", async () => {
+  // Callers do `new Set(written || [])`, and `new Set(true)` THROWS — in the UNCAUGHT
+  // restore path. A list that filters down to nothing has to come back as an empty
+  // list, not as a bare success.
+  const indexedDb = createFakeIndexedDb();
+  const store = new ChatHistoryStore({ storage: createMemoryStorage(), indexedDb });
+  // A legacyShadow thread with no usable id is filtered out by the writer, leaving it
+  // with nothing to write.
+  const unusable = { ...legacyThread("u", 1), id: 42 };
+  store.persist([unusable], {});
+  await store._writePromise;
+  const read = await store.readCanonical();
+  assert.ok(read, "restoration must survive a write list that filtered down to nothing");
 });
 
 test("the marker is filtered structurally, not by key name", async () => {
@@ -784,23 +881,64 @@ test("the marker is filtered structurally, not by key name", async () => {
   store.persist([legacyThread("L0", 1)], {});
   await store._writePromise;
   // Any non-thread record, whatever its key, must not surface as history.
-  indexedDb._stores.get(CHAT_HISTORY_LEGACY_STORE).set("some-other-meta", { ids: ["z"] });
+  indexedDb._store(CHAT_HISTORY_LEGACY_STORE).set("some-other-meta", { ids: ["z"] });
   const reader = new ChatHistoryStore({ storage: createMemoryStorage(), indexedDb });
   const restored = await reader._restoreLegacyShadow({ threads: [], meta: {} });
   assert.deepEqual((restored.threads || []).map((t) => t.id), ["L0"]);
 });
 
-test("a legacy write with nothing to store returns [] — never true", async () => {
-  // codex r5. Callers do `new Set(written || [])`, and `new Set(true)` THROWS. A
-  // history whose only legacy thread was refused for colliding with the reserved key
-  // would have broken restoration outright, in the uncaught restore path — turning a
-  // fail-closed input into a hard failure.
+test("a stale write cannot cancel another tab's outstanding delete", async () => {
+  // codex r5. Tab B records a pending delete of L1 that has not landed. A third tab,
+  // still holding L1 as live from before, writes it back — and the harm is not that
+  // the record exists (B's delete never removed it) but that the write would refresh
+  // it and hand out a receipt, leaving a record nobody is still trying to remove.
+  // The legacy write reads the marker inside the SAME transaction as the put, so an
+  // id with an outstanding delete is refused.
   const indexedDb = createFakeIndexedDb();
-  const store = new ChatHistoryStore({ storage: createMemoryStorage(), indexedDb });
-  const onlyCollide = { ...legacyThread("x", 1), id: "__cmcp_pending_deletes" };
-  store.persist([onlyCollide], {});
-  await store._writePromise;
-  const read = await store.readCanonical();
-  assert.ok(read, "restoration must survive a write list that filtered down to nothing");
-  assert.equal(store._durableLegacy.has("__cmcp_pending_deletes"), false, "and grant no receipt");
+  const owing = new ChatHistoryStore({ storage: createMemoryStorage(), indexedDb });
+  owing.persist([legacyThread("L1", 1, 30), legacyThread("L2", 2)], {});
+  await owing._writePromise;
+
+  indexedDb._state.failDelete = true;
+  owing.persist([legacyThread("L2", 2)], {
+    deletedThreads: { L1: { updatedAt: 5, writerId: "b", sequence: 1 } },
+  });
+  await owing._writePromise;
+  indexedDb._state.failDelete = false;
+  assert.ok(owing._pendingLegacyDeletes.has("L1"), "precondition: a delete is owed");
+  assert.ok(indexedDb._store("snapshots").has("__cmcp_legacy_pending_deletes"), "…recorded durably");
+
+  // A stale tab writes an UPDATED L1 back.
+  const stale = new ChatHistoryStore({ storage: createMemoryStorage(), indexedDb });
+  const updated = { ...legacyThread("L1", 1, 900), title: "stale rewrite" };
+  stale.persist([updated, legacyThread("L2", 2)], {});
+  await stale._writePromise;
+
+  const stored = indexedDb._store(CHAT_HISTORY_LEGACY_STORE).get("L1");
+  assert.notEqual(stored?.title, "stale rewrite", "the refused write must not land");
+  assert.equal(stale._durableLegacy.has("L1"), false, "…and must not earn a receipt");
+  assert.ok(indexedDb._store(CHAT_HISTORY_LEGACY_STORE).has("L2"), "the refusal must be per-id");
+  // The intent survives, so the delete is still owed and still retried.
+  const next = new ChatHistoryStore({ storage: createMemoryStorage(), indexedDb });
+  await next._restoreLegacyShadow({ threads: [], meta: {} });
+  assert.ok(next._pendingLegacyDeletes.has("L1"), "a stale write must not cancel the delete");
+});
+
+test("a refused write grants no receipt for the refused id", async () => {
+  // Receipts come from what the writer actually stored. Granting one for a thread it
+  // declined would license evicting it from the shadow — the licence-to-delete this
+  // whole change exists to withhold.
+  const indexedDb = createFakeIndexedDb();
+  const owing = new ChatHistoryStore({ storage: createMemoryStorage(), indexedDb });
+  owing.persist([legacyThread("L1", 1)], {});
+  await owing._writePromise;
+  indexedDb._state.failDelete = true;
+  owing.persist([], { deletedThreads: { L1: { updatedAt: 5, writerId: "b", sequence: 1 } } });
+  await owing._writePromise;
+  indexedDb._state.failDelete = false;
+
+  const stale = new ChatHistoryStore({ storage: createMemoryStorage(), indexedDb });
+  stale.persist([legacyThread("L1", 1)], {});
+  await stale._writePromise;
+  assert.equal(stale._durableLegacy.has("L1"), false, "no receipt for a refused write");
 });

--- a/browser_tests/unit/legacy-shadow-quota.test.mjs
+++ b/browser_tests/unit/legacy-shadow-quota.test.mjs
@@ -1,5 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 
 import {
   ChatHistoryStore,
@@ -941,4 +942,115 @@ test("a refused write grants no receipt for the refused id", async () => {
   stale.persist([legacyThread("L1", 1)], {});
   await stale._writePromise;
   assert.equal(stale._durableLegacy.has("L1"), false, "no receipt for a refused write");
+});
+
+test("a stale write AFTER a completed delete is still refused", async () => {
+  // codex r6, and the finding that made this a fence rather than a hint. The delete
+  // lands and its id used to be REMOVED from the marker — so a stale tab starting its
+  // write afterwards saw nothing and put the record straight back.
+  //
+  // I assumed the canonical tombstone covered this and tested that assumption first:
+  // it does not, and the reason is instructive. A legacyShadow thread is never IN
+  // canonical, so compaction prunes a tombstone that points at no thread. There is no
+  // fence for a legacy delete other than this one.
+  const indexedDb = createFakeIndexedDb();
+  const store = new ChatHistoryStore({ storage: createMemoryStorage(), indexedDb });
+  store.persist([legacyThread("L0", 1), legacyThread("L1", 2)], {});
+  await store._writePromise;
+
+  store.persist([legacyThread("L1", 2)], {
+    deletedThreads: { L0: { updatedAt: 500, writerId: "a", sequence: 1 } },
+  });
+  await store._writePromise;
+  assert.equal(indexedDb._store(CHAT_HISTORY_LEGACY_STORE).has("L0"), false, "the delete landed");
+  const record = indexedDb._store("snapshots").get("__cmcp_legacy_pending_deletes");
+  assert.deepEqual(record?.pending, [], "nothing is owed any more");
+  assert.deepEqual(record?.deleted, ["L0"], "…but the deletion is remembered for good");
+
+  // A stale tab that still believes L0 is live, persisting after all of that.
+  const stale = new ChatHistoryStore({ storage: createMemoryStorage(), indexedDb });
+  stale.persist([legacyThread("L0", 1), legacyThread("L1", 2)], {});
+  await stale._writePromise;
+  assert.equal(
+    indexedDb._store(CHAT_HISTORY_LEGACY_STORE).has("L0"),
+    false,
+    "a completed delete must fence a later stale write",
+  );
+  assert.equal(stale._durableLegacy.has("L0"), false, "and grant it no receipt");
+
+  // …and it is not restored as live history either.
+  const next = new ChatHistoryStore({ storage: createMemoryStorage(), indexedDb });
+  const restored = await next._restoreLegacyShadow({ threads: [], meta: {} });
+  assert.equal((restored.threads || []).some((t) => t.id === "L0"), false);
+});
+
+test("the permanent deleted list is bounded by what legacy threads ARE", () => {
+  // A never-pruned list of deleted ids would be an unbounded growth path — the exact
+  // shape of the bug this whole change fixes. It is bounded here by construction, not
+  // by a cap: legacyShadow threads are pre-v3 content, quarantined once and never
+  // created again, so the set of ids that can ever enter it is closed and finite.
+  //
+  // Pinned as a source fact, because the day something starts MINTING legacyShadow
+  // threads this reasoning silently stops being true. Exactly two sites may apply the
+  // flag, and only one of them can introduce an id that was not already legacy:
+  const src = readFileSync(new URL("../../web/js/lib/chat-history-store.js", import.meta.url), "utf8");
+  const sites = src.match(/legacyShadow: true/g) || [];
+  assert.equal(sites.length, 2, "a third site applying this flag needs this reasoning re-checked");
+
+  // 1. the quarantine in mergeUnderCanonicalCheckpoint — the ONE minter, and it can
+  //    only flag threads that already exist in a pre-v3 snapshot.
+  const quarantine = src.slice(src.indexOf("function mergeUnderCanonicalCheckpoint"), src.indexOf("function idbRead"));
+  assert.ok(
+    quarantine.includes("normalizeThread({ ...thread, legacyShadow: true })"),
+    "the quarantine must be the minting site",
+  );
+  // 2. the restore, which RE-flags records read back out of the legacy store. It can
+  //    never introduce a new id: everything it flags was already in that store.
+  const restore = src.slice(src.indexOf("async _restoreLegacyShadow"), src.indexOf("async persist") + 1 || undefined);
+  assert.ok(
+    restore.includes("...thread, legacyShadow: true"),
+    "the restore must only re-flag what the store already held",
+  );
+});
+
+test("a record that got past the writer is still not restored once deleted for good", async () => {
+  // Defence in depth, and it needed a case to be worth keeping. The writer refuses
+  // ids in the deleted list, so nothing on the normal path can produce this — but a
+  // database written by a build without that fence, or any other writer to the same
+  // store, can. Then the record exists AND the id is deleted for good, and only the
+  // restore filter stands between it and coming back as live history.
+  const indexedDb = createFakeIndexedDb();
+  const store = new ChatHistoryStore({ storage: createMemoryStorage(), indexedDb });
+  store.persist([legacyThread("L0", 1), legacyThread("L1", 2)], {});
+  await store._writePromise;
+  store.persist([legacyThread("L1", 2)], {
+    deletedThreads: { L0: { updatedAt: 500, writerId: "a", sequence: 1 } },
+  });
+  await store._writePromise;
+  assert.deepEqual(
+    indexedDb._store("snapshots").get("__cmcp_legacy_pending_deletes")?.deleted,
+    ["L0"],
+    "precondition: deleted for good",
+  );
+
+  // Put the record back the way a fence-less writer would have.
+  const revived = legacyThread("L0", 1);
+  const db = await new Promise((resolve) => {
+    const req = indexedDb.open();
+    req.onsuccess = () => resolve(req.result);
+  });
+  await new Promise((resolve) => {
+    const tx = db.transaction(CHAT_HISTORY_LEGACY_STORE, "readwrite");
+    tx.objectStore(CHAT_HISTORY_LEGACY_STORE).put(revived, "L0");
+    tx.oncomplete = () => resolve();
+  });
+  assert.ok(indexedDb._store(CHAT_HISTORY_LEGACY_STORE).has("L0"), "precondition: the record is back");
+
+  const next = new ChatHistoryStore({ storage: createMemoryStorage(), indexedDb });
+  const restored = await next._restoreLegacyShadow({ threads: [], meta: {} });
+  assert.equal(
+    (restored.threads || []).some((t) => t.id === "L0"),
+    false,
+    "a transcript deleted for good must not return as live history",
+  );
 });

--- a/browser_tests/unit/legacy-shadow-quota.test.mjs
+++ b/browser_tests/unit/legacy-shadow-quota.test.mjs
@@ -789,3 +789,18 @@ test("the marker is filtered structurally, not by key name", async () => {
   const restored = await reader._restoreLegacyShadow({ threads: [], meta: {} });
   assert.deepEqual((restored.threads || []).map((t) => t.id), ["L0"]);
 });
+
+test("a legacy write with nothing to store returns [] — never true", async () => {
+  // codex r5. Callers do `new Set(written || [])`, and `new Set(true)` THROWS. A
+  // history whose only legacy thread was refused for colliding with the reserved key
+  // would have broken restoration outright, in the uncaught restore path — turning a
+  // fail-closed input into a hard failure.
+  const indexedDb = createFakeIndexedDb();
+  const store = new ChatHistoryStore({ storage: createMemoryStorage(), indexedDb });
+  const onlyCollide = { ...legacyThread("x", 1), id: "__cmcp_pending_deletes" };
+  store.persist([onlyCollide], {});
+  await store._writePromise;
+  const read = await store.readCanonical();
+  assert.ok(read, "restoration must survive a write list that filtered down to nothing");
+  assert.equal(store._durableLegacy.has("__cmcp_pending_deletes"), false, "and grant no receipt");
+});

--- a/browser_tests/unit/legacy-shadow-quota.test.mjs
+++ b/browser_tests/unit/legacy-shadow-quota.test.mjs
@@ -25,7 +25,7 @@ import {
 // ── a fake IndexedDB, because the failure lives in the durable path ────────
 
 function createFakeIndexedDb({ failWrites = false, missingLegacyStore = false } = {}) {
-  const state = { failWrites, failStore: null };
+  const state = { failWrites, failStore: null, failDelete: false };
   const stores = new Map([["snapshots", new Map()]]);
   if (!missingLegacyStore) stores.set(CHAT_HISTORY_LEGACY_STORE, new Map());
   const db = {
@@ -35,9 +35,10 @@ function createFakeIndexedDb({ failWrites = false, missingLegacyStore = false } 
       const data = stores.get(name);
       if (!data) throw new Error(`no store ${name}`);
       const tx = { oncomplete: null, onerror: null, onabort: null };
+      let doomed = false;
       const settle = () => {
         queueMicrotask(() => {
-          if ((state.failWrites || state.failStore === name) && mode === "readwrite") tx.onabort?.();
+          if ((state.failWrites || state.failStore === name || doomed) && mode === "readwrite") tx.onabort?.();
           else tx.oncomplete?.();
         });
       };
@@ -53,7 +54,10 @@ function createFakeIndexedDb({ failWrites = false, missingLegacyStore = false } 
           return req;
         },
         delete(key) {
-          if (!state.failWrites && state.failStore !== name) data.delete(key);
+          // A delete can fail where a small put still lands — a bulk delete and a
+          // one-key marker are not the same transaction cost.
+          if (state.failDelete) doomed = true;
+          else if (!state.failWrites && state.failStore !== name) data.delete(key);
           const req = {};
           queueMicrotask(() => req.onsuccess?.());
           settle();
@@ -656,4 +660,64 @@ test("clearAll reports success when the legacy store really was cleared", () => 
       assert.equal(result.code, null);
       assert.equal(indexedDb._stores.get(CHAT_HISTORY_LEGACY_STORE).size, 0);
     });
+});
+
+test("a failed delete survives a RELOAD and is retried by the next tab", async () => {
+  // codex r3. The retry intent used to live only in memory: close the tab and it was
+  // gone. If `meta.deletedThreads` (capped at 512) had aged the id out by the time a
+  // new tab looked, the record was absent from both tombstone sources AND from the
+  // new tab's empty pending set — never retried, and free to restore. The intent now
+  // lives in the legacy store, where nothing caps it.
+  const indexedDb = createFakeIndexedDb();
+  const first = new ChatHistoryStore({ storage: createMemoryStorage(), indexedDb });
+  first.persist([legacyThread("L0", 1), legacyThread("L1", 2)], {});
+  await first._writePromise;
+
+  // The DELETE fails; the small marker put still lands. That is the window this
+  // exists for — a tab that closes before its retry.
+  indexedDb._state.failDelete = true;
+  first.persist([legacyThread("L1", 2)], {
+    deletedThreads: { L0: { updatedAt: 5, writerId: "t", sequence: 1 } },
+  });
+  await first._writePromise;
+  assert.ok(first._pendingLegacyDeletes.has("L0"), "precondition: the delete did not land");
+  assert.ok(
+    indexedDb._stores.get(CHAT_HISTORY_LEGACY_STORE).has("L0"),
+    "precondition: the record is still there",
+  );
+
+  // A NEW tab: fresh store object, empty in-memory state, and NO tombstone in meta.
+  const next = new ChatHistoryStore({ storage: createMemoryStorage(), indexedDb });
+  const restored = await next._restoreLegacyShadow({ threads: [], meta: {} });
+  assert.equal(
+    (restored.threads || []).some((t) => t.id === "L0"),
+    false,
+    "the reloaded tab must still suppress a delete it never saw a tombstone for",
+  );
+  assert.ok(next._pendingLegacyDeletes.has("L0"), "…and must inherit the retry intent");
+});
+
+test("the pending-delete marker is never mistaken for a transcript", async () => {
+  // It lives in the same store as the threads. Every reader here requires a string
+  // `id` on a record, so the marker is skipped — but that is a property worth pinning
+  // rather than a coincidence to rediscover.
+  const indexedDb = createFakeIndexedDb();
+  const store = new ChatHistoryStore({ storage: createMemoryStorage(), indexedDb });
+  store.persist([legacyThread("L0", 1), legacyThread("L1", 2)], {});
+  await store._writePromise;
+  indexedDb._state.failDelete = true;
+  store.persist([legacyThread("L1", 2)], {
+    deletedThreads: { L0: { updatedAt: 5, writerId: "t", sequence: 1 } },
+  });
+  await store._writePromise;
+  indexedDb._state.failDelete = false;
+
+  const reader = new ChatHistoryStore({ storage: createMemoryStorage(), indexedDb });
+  const restored = await reader._restoreLegacyShadow({ threads: [], meta: {} });
+  for (const thread of restored.threads || []) {
+    assert.equal(typeof thread.id, "string");
+    assert.ok(thread.id, "no record without an id may reach the transcript list");
+    assert.ok(Array.isArray(thread.msgs), "…and every restored record must be a thread");
+  }
+  assert.equal(reader._durableLegacy.has("__cmcp_pending_deletes"), false, "the marker is not a receipt");
 });

--- a/browser_tests/unit/legacy-shadow-quota.test.mjs
+++ b/browser_tests/unit/legacy-shadow-quota.test.mjs
@@ -1086,4 +1086,16 @@ test("the fence exists BEFORE the record stops existing", async () => {
     "stale",
     "the pre-delete window must already be fenced",
   );
+
+  // The ORDER is the fix, and it is only observable DURING the operation — an
+  // interval no fake can interleave into. Both orderings leave the same end state,
+  // so a runtime assertion here cannot fail for the right reason. Pin the order at
+  // source instead: the intent write must precede the record delete.
+  const src = readFileSync(new URL("../../web/js/lib/chat-history-store.js", import.meta.url), "utf8");
+  const site = src.slice(src.indexOf("if (tombstoned.length) {"), src.indexOf("// Mirror the intent into the store"));
+  const intentAt = site.indexOf("idbMergeDeleteRecord(this.indexedDb, { pending: tombstoned })");
+  const deleteAt = site.indexOf("idbDeleteLegacy(this.indexedDb, tombstoned)");
+  assert.ok(intentAt > 0, "the intent must be recorded up front");
+  assert.ok(deleteAt > 0, "…and the record deleted after");
+  assert.ok(intentAt < deleteAt, "the fence must exist before the record does not");
 });

--- a/browser_tests/unit/legacy-shadow-quota.test.mjs
+++ b/browser_tests/unit/legacy-shadow-quota.test.mjs
@@ -25,7 +25,7 @@ import {
 // ── a fake IndexedDB, because the failure lives in the durable path ────────
 
 function createFakeIndexedDb({ failWrites = false, missingLegacyStore = false } = {}) {
-  const state = { failWrites };
+  const state = { failWrites, failStore: null };
   const stores = new Map([["snapshots", new Map()]]);
   if (!missingLegacyStore) stores.set(CHAT_HISTORY_LEGACY_STORE, new Map());
   const db = {
@@ -37,7 +37,7 @@ function createFakeIndexedDb({ failWrites = false, missingLegacyStore = false } 
       const tx = { oncomplete: null, onerror: null, onabort: null };
       const settle = () => {
         queueMicrotask(() => {
-          if (state.failWrites && mode === "readwrite") tx.onabort?.();
+          if ((state.failWrites || state.failStore === name) && mode === "readwrite") tx.onabort?.();
           else tx.oncomplete?.();
         });
       };
@@ -53,21 +53,21 @@ function createFakeIndexedDb({ failWrites = false, missingLegacyStore = false } 
           return req;
         },
         delete(key) {
-          if (!state.failWrites) data.delete(key);
+          if (!state.failWrites && state.failStore !== name) data.delete(key);
           const req = {};
           queueMicrotask(() => req.onsuccess?.());
           settle();
           return req;
         },
         clear() {
-          if (!state.failWrites) data.clear();
+          if (!state.failWrites && state.failStore !== name) data.clear();
           const req = {};
           queueMicrotask(() => req.onsuccess?.());
           settle();
           return req;
         },
         put(value, key) {
-          if (!state.failWrites) data.set(key, value);
+          if (!state.failWrites && state.failStore !== name) data.set(key, value);
           const req = {};
           queueMicrotask(() => req.onsuccess?.());
           settle();
@@ -515,4 +515,145 @@ test("an edit whose durable rewrite FAILS leaves the thread unevictable", async 
   const kept = (written.threads || []).find((t) => t.id === "L0");
   assert.ok(kept, "the edited thread must stay in the shadow — its durable copy is stale");
   assert.equal(kept.msgs[0].text.length, 900, "…and it must be the EDITED version that stayed");
+});
+
+// ── codex round 2 ──────────────────────────────────────────────────────────
+
+test('a same-length, same-timestamp edit ("foo" -> "bar") is still detected', async () => {
+  // The exact collision codex named. updatedAt + message count + serialized length
+  // are all identical across this edit, so the earlier fingerprint passed it as
+  // unchanged and the shadow would evict the new text against the old copy. For a
+  // durability gate "probably unchanged" is not a category.
+  const indexedDb = createFakeIndexedDb();
+  const store = new ChatHistoryStore({ storage: createMemoryStorage(), indexedDb });
+  const before = { ...legacyThread("L0", 7), msgs: [{ id: "m", role: "user", text: "foo" }] };
+  store.persist([before], {});
+  await store._writePromise;
+  assert.equal(indexedDb._stores.get(CHAT_HISTORY_LEGACY_STORE).get("L0").msgs[0].text, "foo");
+
+  const after = { ...before, msgs: [{ id: "m", role: "user", text: "bar" }] };
+  assert.equal(JSON.stringify(before).length, JSON.stringify(after).length, "precondition: same length");
+  assert.equal(before.updatedAt, after.updatedAt, "precondition: same timestamp");
+  store.persist([after], {});
+  await store._writePromise;
+  assert.equal(
+    indexedDb._stores.get(CHAT_HISTORY_LEGACY_STORE).get("L0").msgs[0].text,
+    "bar",
+    "the durable copy must follow a same-size edit",
+  );
+});
+
+test("a tombstone deletes ONLY its own record, never a neighbour's", async () => {
+  // The guard's real job. `mergeHistorySnapshots` already resolves tombstone-vs-live
+  // before this pass runs — a tombstoned id is dropped from the snapshot, so it is
+  // never simultaneously "live" here — which makes the id-not-in-liveIds check
+  // defence in depth rather than the primary decision. What must hold regardless is
+  // that a delete driven by one tombstone cannot reach past it.
+  const indexedDb = createFakeIndexedDb();
+  const store = new ChatHistoryStore({ storage: createMemoryStorage(), indexedDb });
+  store.persist([legacyThread("L0", 1), legacyThread("L1", 2), legacyThread("L2", 3)], {});
+  await store._writePromise;
+  assert.equal(indexedDb._stores.get(CHAT_HISTORY_LEGACY_STORE).size, 3);
+
+  store.persist([legacyThread("L0", 1), legacyThread("L2", 3)], {
+    deletedThreads: { L1: { updatedAt: 500, writerId: "t", sequence: 1 } },
+  });
+  await store._writePromise;
+  const keys = [...indexedDb._stores.get(CHAT_HISTORY_LEGACY_STORE).keys()].sort();
+  assert.deepEqual(keys, ["L0", "L2"], "only the tombstoned record may go");
+});
+
+test("the delete pass skips any id still present as a live thread", async () => {
+  // The guard itself, exercised directly: ids can be reused and a tombstone can lose
+  // a causal merge, and deleting by id alone would take the live record with it.
+  // Driven through _restoreLegacyShadow-independent state so the merge cannot quietly
+  // resolve the conflict first.
+  const indexedDb = createFakeIndexedDb();
+  const store = new ChatHistoryStore({ storage: createMemoryStorage(), indexedDb });
+  store.persist([legacyThread("L0", 1)], {});
+  await store._writePromise;
+  store._pendingLegacyDeletes.add("L0"); // a delete that never landed
+  // …but L0 is live again in this write.
+  store.persist([legacyThread("L0", 90)], {});
+  await store._writePromise;
+  assert.ok(
+    indexedDb._stores.get(CHAT_HISTORY_LEGACY_STORE).has("L0"),
+    "a live thread's record must survive an outstanding delete for the same id",
+  );
+});
+
+test("a FAILED delete is retried, even after its tombstone ages out", async () => {
+  // meta.deletedThreads is capped, so a tombstone expires. A delete that failed while
+  // its tombstone was live would otherwise stop being retried and the record would be
+  // restored on the next load.
+  const indexedDb = createFakeIndexedDb();
+  const store = new ChatHistoryStore({ storage: createMemoryStorage(), indexedDb });
+  store.persist([legacyThread("L0", 1), legacyThread("L1", 2)], {});
+  await store._writePromise;
+
+  indexedDb._state.failWrites = true;
+  store.persist([legacyThread("L1", 2)], {
+    deletedThreads: { L0: { updatedAt: 5, writerId: "t", sequence: 1 } },
+  });
+  await store._writePromise;
+  assert.ok(store._pendingLegacyDeletes.has("L0"), "a failed delete must be remembered");
+  assert.ok(indexedDb._stores.get(CHAT_HISTORY_LEGACY_STORE).has("L0"), "precondition: still there");
+
+  // The tombstone is GONE from meta now — aged out of the capped map.
+  indexedDb._state.failWrites = false;
+  store.persist([legacyThread("L1", 2)], {});
+  await store._writePromise;
+  assert.equal(
+    indexedDb._stores.get(CHAT_HISTORY_LEGACY_STORE).has("L0"),
+    false,
+    "the retry must land without the tombstone still being present",
+  );
+  assert.equal(store._pendingLegacyDeletes.has("L0"), false, "…and stop being pending");
+});
+
+test("a pending delete also suppresses the RESTORE while it is outstanding", async () => {
+  const indexedDb = createFakeIndexedDb();
+  const store = new ChatHistoryStore({ storage: createMemoryStorage(), indexedDb });
+  store.persist([legacyThread("L0", 1)], {});
+  await store._writePromise;
+  store._pendingLegacyDeletes.add("L0");
+  const restored = await store._restoreLegacyShadow({ threads: [], meta: {} });
+  assert.equal(
+    (restored.threads || []).some((t) => t.id === "L0"),
+    false,
+    "a delete that has not landed must not be undone by a restore",
+  );
+});
+
+test("clearAll REPORTS a legacy store it could not clear", async () => {
+  // The canonical reset has already happened by then, so a failed legacy clear cannot
+  // be undone — but reporting it as a completed clear tells the user their transcripts
+  // are gone and then hands them back after a reload.
+  const indexedDb = createFakeIndexedDb();
+  const store = new ChatHistoryStore({ storage: createMemoryStorage(), indexedDb });
+  store.persist([legacyThread("L0", 1)], {});
+  await store._writePromise;
+
+  // Fail ONLY the legacy store: a global failure would take the canonical reset
+  // down first and we would be testing a different branch.
+  indexedDb._state.failStore = CHAT_HISTORY_LEGACY_STORE;
+  const result = await store.clearAll([], {});
+  assert.equal(result.ok, false, "an incomplete clear must not report success");
+  assert.equal(result.code, "history-clear-legacy-unavailable");
+  assert.equal(result.retryable, true, "a later clear can finish the job");
+  assert.equal(result.canonicalCommitted, true, "…while still reporting what DID happen");
+});
+
+test("clearAll reports success when the legacy store really was cleared", () => {
+  // The other side, so the failure branch cannot be satisfied by always reporting bad.
+  const indexedDb = createFakeIndexedDb();
+  const store = new ChatHistoryStore({ storage: createMemoryStorage(), indexedDb });
+  store.persist([legacyThread("L0", 1)], {});
+  return store._writePromise
+    .then(() => store.clearAll([], {}))
+    .then((result) => {
+      assert.equal(result.ok, true);
+      assert.equal(result.code, null);
+      assert.equal(indexedDb._stores.get(CHAT_HISTORY_LEGACY_STORE).size, 0);
+    });
 });

--- a/browser_tests/unit/legacy-shadow-quota.test.mjs
+++ b/browser_tests/unit/legacy-shadow-quota.test.mjs
@@ -25,6 +25,7 @@ import {
 // ── a fake IndexedDB, because the failure lives in the durable path ────────
 
 function createFakeIndexedDb({ failWrites = false, missingLegacyStore = false } = {}) {
+  const state = { failWrites };
   const stores = new Map([["snapshots", new Map()]]);
   if (!missingLegacyStore) stores.set(CHAT_HISTORY_LEGACY_STORE, new Map());
   const db = {
@@ -36,7 +37,7 @@ function createFakeIndexedDb({ failWrites = false, missingLegacyStore = false } 
       const tx = { oncomplete: null, onerror: null, onabort: null };
       const settle = () => {
         queueMicrotask(() => {
-          if (failWrites && mode === "readwrite") tx.onabort?.();
+          if (state.failWrites && mode === "readwrite") tx.onabort?.();
           else tx.oncomplete?.();
         });
       };
@@ -51,8 +52,22 @@ function createFakeIndexedDb({ failWrites = false, missingLegacyStore = false } 
           queueMicrotask(() => { req.result = [...data.values()]; req.onsuccess?.(); });
           return req;
         },
+        delete(key) {
+          if (!state.failWrites) data.delete(key);
+          const req = {};
+          queueMicrotask(() => req.onsuccess?.());
+          settle();
+          return req;
+        },
+        clear() {
+          if (!state.failWrites) data.clear();
+          const req = {};
+          queueMicrotask(() => req.onsuccess?.());
+          settle();
+          return req;
+        },
         put(value, key) {
-          if (!failWrites) data.set(key, value);
+          if (!state.failWrites) data.set(key, value);
           const req = {};
           queueMicrotask(() => req.onsuccess?.());
           settle();
@@ -65,6 +80,7 @@ function createFakeIndexedDb({ failWrites = false, missingLegacyStore = false } 
   };
   return {
     _stores: stores,
+    _state: state,
     open() {
       const req = {};
       queueMicrotask(() => { req.result = db; req.onsuccess?.(); });
@@ -246,7 +262,7 @@ test("a legacy store that ABORTS the write grants no receipt", async () => {
   const threads = Array.from({ length: 8 }, (_, i) => legacyThread(`L${i}`, i + 1, 400));
   store.persist(threads, {});
   await store._writePromise;
-  assert.equal(store._durableLegacyIds.size, 0, "an aborted transaction is not a receipt");
+  assert.equal(store._durableLegacy.size, 0, "an aborted transaction is not a receipt");
   const written = JSON.parse(storage.getItem("comfyui-mcp.panel.historySnapshot"));
   assert.equal(written.threads.length, 8, "…so nothing may be evicted");
 });
@@ -257,7 +273,7 @@ test("a database without the legacy store grants no receipt either", async () =>
   const store = new ChatHistoryStore({ storage: createMemoryStorage(), indexedDb, maxShadowBytes: 500 });
   store.persist([legacyThread("L0", 1, 900)], {});
   await store._writePromise;
-  assert.equal(store._durableLegacyIds.size, 0);
+  assert.equal(store._durableLegacy.size, 0);
 });
 
 test("a thread evicted from the shadow comes BACK from the legacy store", async () => {
@@ -300,12 +316,12 @@ test("an unreachable store on READ revokes the receipts rather than assuming emp
   const store = new ChatHistoryStore({ storage: createMemoryStorage(), indexedDb });
   store.persist([legacyThread("L0", 1)], {});
   await store._writePromise;
-  assert.equal(store._durableLegacyIds.size, 1, "precondition: a receipt exists");
+  assert.equal(store._durableLegacy.size, 1, "precondition: a receipt exists");
 
   store.indexedDb = null; // the store goes away mid-session (tab upgrade, private mode)
   const read = await store.readCanonical();
   assert.ok(read, "an unreachable legacy store must not fail the whole read");
-  assert.equal(store._durableLegacyIds.size, 0, "unknown is not proof of durability");
+  assert.equal(store._durableLegacy.size, 0, "unknown is not proof of durability");
 });
 
 test("an EMPTY legacy store is not the same as an unreachable one", async () => {
@@ -313,9 +329,9 @@ test("an EMPTY legacy store is not the same as an unreachable one", async () => 
   // not be mistaken for a failure that would keep stale receipts alive.
   const indexedDb = createFakeIndexedDb();
   const store = new ChatHistoryStore({ storage: createMemoryStorage(), indexedDb });
-  store._durableLegacyIds = new Set(["stale"]);
+  store._durableLegacy = new Map([["stale", "x"]]);
   await store.readCanonical();
-  assert.equal(store._durableLegacyIds.has("stale"), false, "an empty store proves 'stale' is not durable");
+  assert.equal(store._durableLegacy.has("stale"), false, "an empty store proves 'stale' is not durable");
 });
 
 test("the migration is idempotent — re-running it overwrites in place", async () => {
@@ -352,4 +368,151 @@ test("ordinary threads are not evictable until CANONICAL has accepted them", asy
   await store._writePromise;
   const written = JSON.parse(storage.getItem("comfyui-mcp.panel.historySnapshot"));
   assert.equal(written.threads.length, 6, "no ordinary thread may be dropped with no canonical copy");
+});
+
+// ── codex P1: an id is not a receipt for CONTENT ───────────────────────────
+
+test("an EDITED legacy thread is rewritten, and is not evictable until it is", async () => {
+  // The receipt was a set of ids. A legacy thread written once and then edited —
+  // renamed, pinned, a message tombstoned — was filtered out of every later write as
+  // "already durable" while the stored copy stayed at the old version. The shadow
+  // would then evict the NEW version against a receipt for the OLD one, report
+  // legacyComplete: true, and clear the dirty flag. That is this whole change's own
+  // failure mode, one level down.
+  const indexedDb = createFakeIndexedDb();
+  const store = new ChatHistoryStore({ storage: createMemoryStorage(), indexedDb });
+  const original = legacyThread("L0", 1, 40);
+  store.persist([original], {});
+  await store._writePromise;
+  const storedFirst = indexedDb._stores.get(CHAT_HISTORY_LEGACY_STORE).get("L0");
+  assert.equal(storedFirst.msgs[0].text.length, 40);
+
+  const edited = { ...original, updatedAt: 99, title: "renamed", msgs: [{ id: "L0-m", role: "user", text: "z".repeat(900) }] };
+  store.persist([edited], {});
+  await store._writePromise;
+  const storedSecond = indexedDb._stores.get(CHAT_HISTORY_LEGACY_STORE).get("L0");
+  assert.equal(storedSecond.msgs[0].text.length, 900, "the edit must reach the durable copy");
+  assert.equal(storedSecond.title, "renamed");
+});
+
+test("a stale receipt does not license eviction", async () => {
+  // The receipt must be checked against the thread ABOUT to be evicted, not against
+  // the name of a thread stored at some point in the past.
+  const indexedDb = createFakeIndexedDb();
+  const storage = createMemoryStorage();
+  const store = new ChatHistoryStore({ storage, indexedDb, maxShadowBytes: 300 });
+  const threads = [legacyThread("L0", 1, 400), legacyThread("L1", 2, 400)];
+  store.persist(threads, {});
+  await store._writePromise;
+  // Forge a receipt whose fingerprint cannot match, exactly as a post-write edit
+  // would leave it.
+  store._durableLegacy.set("L0", "not-the-current-content");
+  store.persist(threads, {});
+  await store._writePromise;
+  const written = JSON.parse(storage.getItem("comfyui-mcp.panel.historySnapshot"));
+  // L0 was rewritten (its fingerprint did not match) and so becomes legitimately
+  // durable again — the point is that it was never evicted on the forged receipt.
+  assert.ok(
+    indexedDb._stores.get(CHAT_HISTORY_LEGACY_STORE).has("L0"),
+    "a mismatched fingerprint must trigger a rewrite, not an eviction",
+  );
+  assert.ok(written, "the shadow must still have been written");
+});
+
+// ── codex P1: deletes must not undo themselves ─────────────────────────────
+
+test("a TOMBSTONED legacy thread is deleted from the store", async () => {
+  const indexedDb = createFakeIndexedDb();
+  const store = new ChatHistoryStore({ storage: createMemoryStorage(), indexedDb });
+  const threads = [legacyThread("L0", 1), legacyThread("L1", 2)];
+  store.persist(threads, {});
+  await store._writePromise;
+  assert.equal(indexedDb._stores.get(CHAT_HISTORY_LEGACY_STORE).size, 2);
+
+  store.persist([threads[1]], { deletedThreads: { L0: { updatedAt: 500, writerId: 'tab-x', sequence: 1 } } });
+  await store._writePromise;
+  assert.equal(
+    indexedDb._stores.get(CHAT_HISTORY_LEGACY_STORE).has("L0"),
+    false,
+    "a deleted transcript must leave the durable store too",
+  );
+});
+
+test("a tombstoned thread is not restored, even if the delete has not landed", async () => {
+  // The durable delete can fail (unreachable store, quota). The restore path must
+  // hold the line on its own, or an unreachable store resurrects a delete.
+  const indexedDb = createFakeIndexedDb();
+  const store = new ChatHistoryStore({ storage: createMemoryStorage(), indexedDb });
+  store.persist([legacyThread("L0", 1)], {});
+  await store._writePromise;
+  assert.ok(indexedDb._stores.get(CHAT_HISTORY_LEGACY_STORE).has("L0"));
+
+  const reader = new ChatHistoryStore({ storage: createMemoryStorage(), indexedDb });
+  const restored = await reader._restoreLegacyShadow({
+    threads: [],
+    meta: { deletedThreads: { L0: { updatedAt: 500, writerId: 'tab-x', sequence: 1 } } },
+  });
+  assert.equal(
+    (restored.threads || []).some((t) => t.id === "L0"),
+    false,
+    "a tombstoned transcript must not come back",
+  );
+});
+
+test("an EVICTED (not deleted) thread still comes back", async () => {
+  // The other side of that rule. Absent-from-snapshot is what an eviction looks like
+  // too, so honouring tombstones must not turn into deleting on absence.
+  const indexedDb = createFakeIndexedDb();
+  const store = new ChatHistoryStore({ storage: createMemoryStorage(), indexedDb });
+  store.persist([legacyThread("L0", 1)], {});
+  await store._writePromise;
+
+  const reader = new ChatHistoryStore({ storage: createMemoryStorage(), indexedDb });
+  const restored = await reader._restoreLegacyShadow({ threads: [], meta: {} });
+  assert.equal((restored.threads || []).some((t) => t.id === "L0"), true);
+});
+
+test("clearAll empties the legacy store", async () => {
+  // clearAll is the user saying delete everything. A legacy store that survives it
+  // hands every cleared transcript back on the next load.
+  const indexedDb = createFakeIndexedDb();
+  const store = new ChatHistoryStore({ storage: createMemoryStorage(), indexedDb });
+  store.persist([legacyThread("L0", 1), legacyThread("L1", 2)], {});
+  await store._writePromise;
+  assert.equal(indexedDb._stores.get(CHAT_HISTORY_LEGACY_STORE).size, 2);
+
+  await store.clearAll([], {});
+  await store._writePromise;
+  assert.equal(
+    indexedDb._stores.get(CHAT_HISTORY_LEGACY_STORE).size,
+    0,
+    "cleared transcripts must not survive in the legacy store",
+  );
+  assert.equal(store._durableLegacy.size, 0, "…nor may their receipts");
+});
+
+test("an edit whose durable rewrite FAILS leaves the thread unevictable", async () => {
+  // The case that separates an id receipt from a content receipt. A receipt exists
+  // (the thread was stored once), the thread is then edited, and the rewrite cannot
+  // land. An id-only gate would evict the new version against the old copy — which
+  // is precisely the loss the fingerprint exists to prevent. Nothing else in the
+  // suite reaches this, because the rewrite normally refreshes the receipt first.
+  const indexedDb = createFakeIndexedDb();
+  const storage = createMemoryStorage();
+  const store = new ChatHistoryStore({ storage, indexedDb, maxShadowBytes: 400 });
+  const original = legacyThread("L0", 1, 30);
+  const filler = legacyThread("L1", 2, 30);
+  store.persist([original, filler], {});
+  await store._writePromise;
+  assert.equal(store._durableLegacy.size, 2, "precondition: both are durable");
+
+  indexedDb._state.failWrites = true; // quota, or a store that went away
+  const edited = { ...original, updatedAt: 99, msgs: [{ id: "L0-m", role: "user", text: "z".repeat(900) }] };
+  store.persist([edited, filler], {});
+  await store._writePromise;
+
+  const written = JSON.parse(storage.getItem("comfyui-mcp.panel.historySnapshot"));
+  const kept = (written.threads || []).find((t) => t.id === "L0");
+  assert.ok(kept, "the edited thread must stay in the shadow — its durable copy is stale");
+  assert.equal(kept.msgs[0].text.length, 900, "…and it must be the EDITED version that stayed");
 });

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -20111,10 +20111,28 @@ function buildPanel() {
   const MAX_WORKFLOW_VERSIONS = 20;
   const MAX_THREAD_MSGS = 5000;
   let historyPersistenceWarningCode = null;
+  // #861 — one note per panel, not one per persist.
+  let shadowEvictionNoted = false;
   const historyStore = new ChatHistoryStore({
     threadsKey: THREADS_KEY,
     maxThreads: MAX_THREADS,
     maxMessages: MAX_THREAD_MSGS,
+    // #861 — say it in the log, ONCE, and not in the transcript. Shedding cached
+    // chats to stay inside a byte budget is normal and lossless (nothing is evicted
+    // that is not durable elsewhere), so a system message would be nagging the user
+    // about correct behaviour. But it must not be invisible either: the bug being
+    // fixed here was the panel silently occupying a shared origin budget until
+    // ComfyUI failed and got the blame.
+    onShadowEvict: (ids, bytes) => {
+      if (shadowEvictionNoted) return;
+      shadowEvictionNoted = true;
+      console.info(
+        "[comfyui-mcp-panel] trimmed " + ids.length + " cached chat(s) from localStorage to stay " +
+          "under the panel's share of this origin's storage (now ~" + Math.round(bytes / 1024) + "KB). " +
+          "Nothing was lost — every trimmed chat is in IndexedDB and still listed in Chat history. " +
+          "localStorage is shared with ComfyUI, which needs it for workflow drafts and tab restore.",
+      );
+    },
     onPersistenceError: (failure) => {
       if (failure?.code === historyPersistenceWarningCode) return;
       historyPersistenceWarningCode = failure?.code || "history-persistence-unavailable";

--- a/web/js/lib/chat-history-store.js
+++ b/web/js/lib/chat-history-store.js
@@ -2176,6 +2176,19 @@ export class ChatHistoryStore {
           // `_legacyDeletesDone` keeps that to once per id per session.
           .filter((id) => !this._legacyDeletesDone.has(id));
         if (tombstoned.length) {
+          // INTENT FIRST, then the delete (codex r7). A delete that succeeds on its
+          // first attempt would otherwise never have been in `pending`, leaving an
+          // unfenced interval between the record going away and the post-success
+          // write recording it as deleted — a stale tab writing into that gap has
+          // nothing to refuse it. Recording the intent up front makes the gap
+          // impossible rather than short: the fence exists before the record does
+          // not.
+          try {
+            await idbMergeDeleteRecord(this.indexedDb, { pending: tombstoned });
+          } catch {
+            // Best effort. The delete below still runs; the in-memory set still
+            // drives retries in this tab.
+          }
           let deleted = false;
           try {
             deleted = await idbDeleteLegacy(this.indexedDb, tombstoned);

--- a/web/js/lib/chat-history-store.js
+++ b/web/js/lib/chat-history-store.js
@@ -1490,9 +1490,9 @@ async function idbMergePendingDeletes(indexedDb, { add = [], remove = [] } = {})
 /** Delete legacy records by key — used for tombstoned threads (#861, codex P1). */
 async function idbDeleteLegacy(indexedDb, ids) {
   const list = [...new Set((Array.isArray(ids) ? ids : []).filter((id) => typeof id === "string" && id))];
-  if (!list.length) return [];
+  if (!list.length) return true;
   const db = await openDb(indexedDb);
-  if (!db) return null;
+  if (!db) return false;
   try {
     if (!db.objectStoreNames.contains(CHAT_HISTORY_LEGACY_STORE)) return null;
     return await new Promise((resolve) => {
@@ -1569,11 +1569,15 @@ async function idbWriteLegacy(indexedDb, threads) {
         // outcome, not a silent overwrite of either record by the other.
         && t.id !== LEGACY_PENDING_DELETES_KEY)
     : [];
-  if (!list.length) return true;
+  // `[]`, not `true` (codex r5). Callers do `new Set(written || [])`, and
+  // `new Set(true)` THROWS — so a history whose only legacy thread was refused for
+  // colliding with the reserved key would have broken restoration outright, in the
+  // uncaught restore path. A fail-closed input has to fail closed all the way down.
+  if (!list.length) return [];
   const db = await openDb(indexedDb);
-  if (!db) return false;
+  if (!db) return null;
   try {
-    if (!db.objectStoreNames.contains(CHAT_HISTORY_LEGACY_STORE)) return false;
+    if (!db.objectStoreNames.contains(CHAT_HISTORY_LEGACY_STORE)) return null;
     return await new Promise((resolve) => {
       let tx;
       try {

--- a/web/js/lib/chat-history-store.js
+++ b/web/js/lib/chat-history-store.js
@@ -1339,22 +1339,37 @@ async function idbReadLegacy(indexedDb) {
  * clear the dirty flag. That is the data loss this whole change exists to avoid,
  * reintroduced one level down.
  *
- * `updatedAt` moves on every edit that goes through revise/fieldOps, and the length
- * and message count catch a rewrite that somehow keeps the same stamp. Cheaper than
- * retaining a serialized copy of every transcript purely to diff it — which, for the
- * install that reported this, is the memory the bug was about in the first place.
+ * A DIGEST OF THE CONTENT, not a description of it (codex). An earlier draft used
+ * updatedAt + message count + serialized length, and codex was right that this is not
+ * a receipt: `"foo"` -> `"bar"` inside one message keeps all three identical, and
+ * `Date.now()` is not a monotonic per-edit revision, so a same-millisecond edit slips
+ * through and the shadow evicts the new text against the old copy. For a durability
+ * gate, "probably unchanged" is not a category.
+ *
+ * 64 bits of FNV-1a over the serialized thread — the same construction the panel
+ * already uses for media ids. It reads the whole record, so it cannot miss an edit
+ * the way a length can; it is not cryptographic, which does not matter here because
+ * the adversary is an accident, not an attacker.
  */
 function legacyFingerprint(thread) {
   if (!thread || typeof thread !== "object") return "";
-  let bytes = 0;
+  let serialized;
   try {
-    bytes = JSON.stringify(thread).length;
+    serialized = JSON.stringify(thread);
   } catch {
-    // Uncloneable/circular: fall through with 0 so it simply never matches and the
-    // thread stays unevictable.
+    // Uncloneable/circular: return "" so it never matches a receipt and the thread
+    // stays unevictable. Fail closed.
+    return "";
   }
-  const msgs = Array.isArray(thread.msgs) ? thread.msgs.length : -1;
-  return `${finiteTs(thread.updatedAt || thread.ts)}:${msgs}:${bytes}`;
+  if (typeof serialized !== "string") return "";
+  let a = 0x811c9dc5;
+  let b = 0x01000193;
+  for (let i = 0; i < serialized.length; i += 1) {
+    const code = serialized.charCodeAt(i);
+    a = Math.imul(a ^ code, 16777619) >>> 0;
+    b = Math.imul(b ^ code, 16777619) >>> 0;
+  }
+  return a.toString(16).padStart(8, "0") + b.toString(16).padStart(8, "0");
 }
 
 /** Delete legacy records by key — used for tombstoned threads (#861, codex P1). */
@@ -1560,6 +1575,15 @@ export class ChatHistoryStore {
      * against a receipt for its previous version.
      */
     this._durableLegacy = new Map();
+    /**
+     * Legacy ids whose durable DELETE has not landed yet (#861, codex).
+     *
+     * `meta.deletedThreads` is capped, so a tombstone ages out. A delete that failed
+     * while its tombstone was still live would then stop being retried and the record
+     * would come back on the next load. This remembers the intent independently of
+     * the map that expires, and also suppresses the restore in the meantime.
+     */
+    this._pendingLegacyDeletes = new Set();
     this.lastShadowWriteOk = null;
     this.lastShadowError = null;
     this.writerId = options.writerId || globalThis.crypto?.randomUUID?.() || `writer-${Math.random().toString(16).slice(2)}`;
@@ -1758,7 +1782,12 @@ export class ChatHistoryStore {
     // A tombstoned thread must NOT come back (codex P1). The delete-from-store pass
     // in persist() is the durable half; this is the half that holds even when that
     // write has not landed yet — an unreachable store must not resurrect a delete.
-    const tombstoned = new Set(Object.keys(snapshot?.meta?.deletedThreads || {}));
+    const tombstoned = new Set([
+      ...Object.keys(snapshot?.meta?.deletedThreads || {}),
+      // …and anything whose durable delete has not landed yet, whose tombstone may
+      // already have aged out of the capped map above.
+      ...this._pendingLegacyDeletes,
+    ]);
     const restored = stored
       .filter((thread) => thread && typeof thread.id === "string" && !known.has(thread.id))
       .filter((thread) => !tombstoned.has(thread.id))
@@ -1922,17 +1951,49 @@ export class ChatHistoryStore {
         // an empty deletedThreads while the write that carried the delete still had
         // it. Reading only the merged copy would leave the durable record behind and
         // the next load would hand the deleted transcript back.
+        // BOTH sources, not merged-or-snapshot. Canonical NEVER contains legacyShadow
+        // threads (idbMergeWrite strips them), so a live-id set read from `merged`
+        // alone is empty for exactly the threads this delete pass operates on — and
+        // the guard would protect nothing.
+        const liveIds = new Set(
+          [
+            ...(Array.isArray(merged?.threads) ? merged.threads : []),
+            ...(Array.isArray(snapshot?.threads) ? snapshot.threads : []),
+          ]
+            .map((thread) => thread?.id)
+            .filter((id) => typeof id === "string" && id),
+        );
         const tombstoned = [...new Set([
+          ...this._pendingLegacyDeletes,
           ...Object.keys(merged?.meta?.deletedThreads || {}),
           ...Object.keys(snapshot?.meta?.deletedThreads || {}),
-        ])].filter((id) => this._durableLegacy.has(id));
+        ])]
+          // Never delete an id a LIVE thread is using (codex). A tombstone is a
+          // statement about the thread that HELD an id, and ids can be reused or a
+          // tombstone can lose a causal merge to a newer live version. Deleting by id
+          // alone would take the live record with it.
+          .filter((id) => !liveIds.has(id))
+          .filter((id) => this._durableLegacy.has(id) || this._pendingLegacyDeletes.has(id));
         if (tombstoned.length) {
+          let deleted = false;
           try {
-            if (await idbDeleteLegacy(this.indexedDb, tombstoned)) {
-              for (const id of tombstoned) this._durableLegacy.delete(id);
-            }
+            deleted = await idbDeleteLegacy(this.indexedDb, tombstoned);
           } catch {
-            // Still tombstoned in meta, so still filtered from view; retried next persist.
+            deleted = false;
+          }
+          if (deleted) {
+            for (const id of tombstoned) {
+              this._durableLegacy.delete(id);
+              this._pendingLegacyDeletes.delete(id);
+            }
+          } else {
+            // Remember it OURSELVES rather than trusting the tombstone to still be
+            // there next time (codex). meta.deletedThreads is capped at
+            // DEFAULT_MAX_TOMBSTONES, so an old tombstone ages out — and a delete that
+            // failed while its tombstone was still live would then stop being retried,
+            // leaving the record to be restored on the next load. A delete the user
+            // asked for is retried until it lands.
+            for (const id of tombstoned) this._pendingLegacyDeletes.add(id);
           }
         }
         return merged;
@@ -2014,23 +2075,30 @@ export class ChatHistoryStore {
         this._observeSnapshot(canonical);
         return createHistoryResetSnapshot(canonical, this.nextRevision());
       }))
-      // #861 (codex P1) — clearAll is the user saying DELETE EVERYTHING, so the
-      // legacy store has to go too. Without this the reset leaves those records
-      // behind and `_restoreLegacyShadow` hands every cleared transcript back on the
-      // next load: a delete that undoes itself, which is worse than one that fails
-      // loudly. Before the reset, so a clear that cannot reach the store does not
-      // report success over transcripts it left standing.
+      // #861 — clearAll is the user saying DELETE EVERYTHING, so the legacy store has
+      // to go too. Without this the reset leaves those records behind and
+      // `_restoreLegacyShadow` hands every cleared transcript back on the next load: a
+      // delete that undoes itself.
+      //
+      // The outcome is CARRIED, not swallowed (codex). The canonical reset has already
+      // happened by the time this runs, so a failed legacy clear cannot be undone —
+      // but it must not be reported as a completed clear either, or the user is told
+      // their transcripts are gone and then meets them again after a reload.
       .then(async (reset) => {
-        if (reset) {
-          try {
-            if (await idbClearLegacy(this.indexedDb)) this._durableLegacy = new Map();
-          } catch {
-            // Reported through the reset result below; the tombstones still hide them.
-          }
+        if (!reset) return { reset, legacyCleared: true };
+        let legacyCleared = false;
+        try {
+          legacyCleared = await idbClearLegacy(this.indexedDb);
+        } catch {
+          legacyCleared = false;
         }
-        return reset;
+        if (legacyCleared) {
+          this._durableLegacy = new Map();
+          this._pendingLegacyDeletes = new Set();
+        }
+        return { reset, legacyCleared };
       })
-      .then((reset) => {
+      .then(({ reset, legacyCleared }) => {
         if (!reset) {
           return {
             ok: false,
@@ -2054,11 +2122,15 @@ export class ChatHistoryStore {
           // localStorage events remain available when the channel is blocked.
         }
         return {
-          ok: true,
+          // Canonical really was reset, so this is not a failed clear — but it is
+          // not a COMPLETE one either while quarantined transcripts are still in
+          // the legacy store (codex). Reported rather than swallowed, and
+          // retryable, because a later clear can finish the job.
+          ok: legacyCleared,
           canonicalCommitted: true,
           shadowCommitted: shadowWrite.committed,
-          retryable: false,
-          code: null,
+          retryable: !legacyCleared,
+          code: legacyCleared ? null : "history-clear-legacy-unavailable",
           snapshot: reset,
         };
       });

--- a/web/js/lib/chat-history-store.js
+++ b/web/js/lib/chat-history-store.js
@@ -1372,6 +1372,87 @@ function legacyFingerprint(thread) {
   return a.toString(16).padStart(8, "0") + b.toString(16).padStart(8, "0");
 }
 
+/**
+ * A reserved key inside the legacy store holding ids whose delete has not landed
+ * (#861, codex r3).
+ *
+ * The retry intent used to live only in memory, and codex was right that a reload
+ * loses it: `meta.deletedThreads` is capped, so if the tombstone ages out before any
+ * retry the record is absent from both tombstone sources AND from the new tab's empty
+ * pending set — never retried, and free to restore.
+ *
+ * Recording it in the legacy store puts the intent in the same place as the thing it
+ * is about, where nothing caps or expires it. The key is namespaced so it cannot
+ * collide with a thread id, and every reader here already requires a string `id` on a
+ * record, so this marker is skipped by the restore and receipt passes for free.
+ */
+const LEGACY_PENDING_DELETES_KEY = "__cmcp_pending_deletes";
+
+/** Read the durable pending-delete list. `[]` when absent or unreadable — a missing
+ *  list means nothing is known to be owed, which the in-memory set then adds to. */
+async function idbReadPendingDeletes(indexedDb) {
+  const db = await openDb(indexedDb);
+  if (!db) return [];
+  try {
+    if (!db.objectStoreNames.contains(CHAT_HISTORY_LEGACY_STORE)) return [];
+    return await new Promise((resolve) => {
+      let tx;
+      try {
+        tx = db.transaction(CHAT_HISTORY_LEGACY_STORE, "readonly");
+      } catch {
+        resolve([]);
+        return;
+      }
+      const req = tx.objectStore(CHAT_HISTORY_LEGACY_STORE).get(LEGACY_PENDING_DELETES_KEY);
+      req.onsuccess = () => {
+        const ids = req.result?.ids;
+        resolve(Array.isArray(ids) ? ids.filter((id) => typeof id === "string" && id) : []);
+      };
+      req.onerror = () => resolve([]);
+      tx.onabort = () => resolve([]);
+    });
+  } catch {
+    return [];
+  } finally {
+    db.close();
+  }
+}
+
+/** Persist the pending-delete list. Best effort: a store that will not take it is a
+ *  store that cannot be growing either, and the in-memory set still drives retries
+ *  for the life of this tab. */
+async function idbWritePendingDeletes(indexedDb, ids) {
+  const db = await openDb(indexedDb);
+  if (!db) return false;
+  try {
+    if (!db.objectStoreNames.contains(CHAT_HISTORY_LEGACY_STORE)) return false;
+    return await new Promise((resolve) => {
+      let tx;
+      try {
+        tx = db.transaction(CHAT_HISTORY_LEGACY_STORE, "readwrite");
+      } catch {
+        resolve(false);
+        return;
+      }
+      const store = tx.objectStore(CHAT_HISTORY_LEGACY_STORE);
+      try {
+        if (ids.length) store.put({ ids }, LEGACY_PENDING_DELETES_KEY);
+        else store.delete(LEGACY_PENDING_DELETES_KEY);
+      } catch {
+        resolve(false);
+        return;
+      }
+      tx.oncomplete = () => resolve(true);
+      tx.onerror = () => resolve(false);
+      tx.onabort = () => resolve(false);
+    });
+  } catch {
+    return false;
+  } finally {
+    db.close();
+  }
+}
+
 /** Delete legacy records by key — used for tombstoned threads (#861, codex P1). */
 async function idbDeleteLegacy(indexedDb, ids) {
   const list = [...new Set((Array.isArray(ids) ? ids : []).filter((id) => typeof id === "string" && id))];
@@ -1765,6 +1846,12 @@ export class ChatHistoryStore {
    */
   async _restoreLegacyShadow(snapshot) {
     const stored = await idbReadLegacy(this.indexedDb);
+    // Durable retry intent first (codex r3): a delete that failed in a PREVIOUS tab
+    // must keep being retried and must keep being suppressed, even after its
+    // tombstone has aged out of the capped map.
+    for (const id of await idbReadPendingDeletes(this.indexedDb)) {
+      this._pendingLegacyDeletes.add(id);
+    }
     const threads = Array.isArray(snapshot?.threads) ? snapshot.threads : [];
     if (stored === null) {
       // Unreachable. Keep whatever the shadow gave us and prove nothing durable.
@@ -1981,6 +2068,7 @@ export class ChatHistoryStore {
           } catch {
             deleted = false;
           }
+          const before = this._pendingLegacyDeletes.size;
           if (deleted) {
             for (const id of tombstoned) {
               this._durableLegacy.delete(id);
@@ -1994,6 +2082,17 @@ export class ChatHistoryStore {
             // leaving the record to be restored on the next load. A delete the user
             // asked for is retried until it lands.
             for (const id of tombstoned) this._pendingLegacyDeletes.add(id);
+          }
+          // Mirror the intent into the store so it survives a reload (codex r3).
+          // In-memory alone loses the retry when the tab closes, and if the capped
+          // tombstone map has aged the id out by the time a new tab looks, nothing
+          // ever retries and the record can restore.
+          if (this._pendingLegacyDeletes.size !== before) {
+            try {
+              await idbWritePendingDeletes(this.indexedDb, [...this._pendingLegacyDeletes]);
+            } catch {
+              // Best effort: the in-memory set still drives retries in this tab.
+            }
           }
         }
         return merged;
@@ -2093,6 +2192,8 @@ export class ChatHistoryStore {
           legacyCleared = false;
         }
         if (legacyCleared) {
+          // The clear removed the pending-delete marker along with everything else,
+          // which is correct: there is nothing left to owe a delete to.
           this._durableLegacy = new Map();
           this._pendingLegacyDeletes = new Set();
         }

--- a/web/js/lib/chat-history-store.js
+++ b/web/js/lib/chat-history-store.js
@@ -1402,38 +1402,57 @@ function legacyFingerprint(thread) {
  */
 const LEGACY_PENDING_DELETES_KEY = "__cmcp_legacy_pending_deletes";
 
-/** Read the durable pending-delete list. `[]` when absent or unreadable — a missing
- *  list means nothing is known to be owed, which the in-memory set then adds to. */
-async function idbReadPendingDeletes(indexedDb) {
+/** Coerce a stored delete record into `{pending, deleted}` of clean string ids.
+ *  Tolerates the absent case and any shape a partial write could leave. */
+function normalizeDeleteRecord(raw) {
+  const clean = (v) => (Array.isArray(v) ? v.filter((id) => typeof id === "string" && id) : []);
+  return { pending: clean(raw?.pending), deleted: clean(raw?.deleted) };
+}
+
+/**
+ * Read the durable delete record: `{pending, deleted}` (#861, codex r6).
+ *
+ * TWO lists, and the second is why this is a fence rather than a hint. Removing an
+ * id once its delete landed left a window codex named: a stale tab that starts its
+ * write AFTER the removal sees nothing and puts the record back, with no intent
+ * anywhere to remove it again. The canonical tombstone does not cover this —
+ * verified, and it is the reason the window exists: a legacy thread was never IN
+ * canonical, so compaction prunes a tombstone that has no thread to point at.
+ *
+ * A permanently retained `deleted` list would be unbounded for ordinary threads.
+ * It is not here, and that is a property of what these records ARE: `legacyShadow`
+ * threads are pre-v3 content, migrated once and never created again, so the set of
+ * ids that can ever appear is closed and finite. The list cannot outgrow the
+ * transcripts it is about.
+ */
+async function idbReadDeleteRecord(indexedDb) {
+  const empty = { pending: [], deleted: [] };
   const db = await openDb(indexedDb);
-  if (!db) return [];
+  if (!db) return empty;
   try {
-    if (!db.objectStoreNames.contains("snapshots")) return [];
+    if (!db.objectStoreNames.contains("snapshots")) return empty;
     return await new Promise((resolve) => {
       let tx;
       try {
         tx = db.transaction("snapshots", "readonly");
       } catch {
-        resolve([]);
+        resolve(empty);
         return;
       }
       const req = tx.objectStore("snapshots").get(LEGACY_PENDING_DELETES_KEY);
-      req.onsuccess = () => {
-        const ids = req.result?.ids;
-        resolve(Array.isArray(ids) ? ids.filter((id) => typeof id === "string" && id) : []);
-      };
-      req.onerror = () => resolve([]);
-      tx.onabort = () => resolve([]);
+      req.onsuccess = () => resolve(normalizeDeleteRecord(req.result));
+      req.onerror = () => resolve(empty);
+      tx.onabort = () => resolve(empty);
     });
   } catch {
-    return [];
+    return empty;
   } finally {
     db.close();
   }
 }
 
 /**
- * Merge into the pending-delete list, in ONE transaction (codex r4).
+ * Merge into the durable delete record, in ONE transaction (codex r4/r6).
  *
  * NOT a whole-list overwrite. Two tabs both retrying is ordinary: tab A finishes
  * `L0` and writes `[]` while tab B's delete of `L1` fails and writes `[L1]`. If A's
@@ -1444,10 +1463,10 @@ async function idbReadPendingDeletes(indexedDb) {
  * Best effort: a store that will not take the marker is a store that will not be
  * taking new records either, and the in-memory set still drives retries here.
  */
-async function idbMergePendingDeletes(indexedDb, { add = [], remove = [] } = {}) {
-  const toAdd = add.filter((id) => typeof id === "string" && id);
-  const toRemove = new Set(remove.filter((id) => typeof id === "string" && id));
-  if (!toAdd.length && !toRemove.size) return true;
+async function idbMergeDeleteRecord(indexedDb, { pending = [], deleted = [] } = {}) {
+  const toPend = pending.filter((id) => typeof id === "string" && id);
+  const toDelete = deleted.filter((id) => typeof id === "string" && id);
+  if (!toPend.length && !toDelete.length) return true;
   const db = await openDb(indexedDb);
   if (!db) return false;
   try {
@@ -1469,12 +1488,17 @@ async function idbMergePendingDeletes(indexedDb, { add = [], remove = [] } = {})
         return;
       }
       req.onsuccess = () => {
-        const existing = Array.isArray(req.result?.ids) ? req.result.ids : [];
-        const merged = [...new Set([...existing, ...toAdd])]
-          .filter((id) => typeof id === "string" && id && !toRemove.has(id));
+        const held = normalizeDeleteRecord(req.result);
+        // A landed delete MOVES its id from pending to deleted; it never just
+        // disappears. Disappearing is what left the post-removal window.
+        const done = new Set([...held.deleted, ...toDelete]);
+        const owed = [...new Set([...held.pending, ...toPend])].filter((id) => !done.has(id));
         try {
-          if (merged.length) store.put({ ids: merged }, LEGACY_PENDING_DELETES_KEY);
-          else store.delete(LEGACY_PENDING_DELETES_KEY);
+          if (owed.length || done.size) {
+            store.put({ pending: owed, deleted: [...done] }, LEGACY_PENDING_DELETES_KEY);
+          } else {
+            store.delete(LEGACY_PENDING_DELETES_KEY);
+          }
         } catch {
           // The transaction settles below either way.
         }
@@ -1598,11 +1622,13 @@ async function idbWriteLegacy(indexedDb, threads) {
         return;
       }
       req.onsuccess = () => {
-        const owed = new Set(Array.isArray(req.result?.ids) ? req.result.ids : []);
-        // A thread someone is still trying to delete is not resurrected here. It
-        // stays whole in the shadow and unevictable — fail closed, as everywhere
-        // else in this file.
-        const allowed = list.filter((thread) => !owed.has(thread.id));
+        const held = normalizeDeleteRecord(req.result);
+        // Both lists. `pending` covers a delete still in flight; `deleted` covers
+        // one that already landed, which is the window a stale tab writes into —
+        // it starts after the id was cleared, sees nothing, and puts the record
+        // back with no intent anywhere to remove it again.
+        const fenced = new Set([...held.pending, ...held.deleted]);
+        const allowed = list.filter((thread) => !fenced.has(thread.id));
         try {
           const store = tx.objectStore(CHAT_HISTORY_LEGACY_STORE);
           for (const thread of allowed) store.put(thread, thread.id);
@@ -1916,9 +1942,8 @@ export class ChatHistoryStore {
     // Durable retry intent first (codex r3): a delete that failed in a PREVIOUS tab
     // must keep being retried and must keep being suppressed, even after its
     // tombstone has aged out of the capped map.
-    for (const id of await idbReadPendingDeletes(this.indexedDb)) {
-      this._pendingLegacyDeletes.add(id);
-    }
+    const deleteRecord = await idbReadDeleteRecord(this.indexedDb);
+    for (const id of deleteRecord.pending) this._pendingLegacyDeletes.add(id);
     const threads = Array.isArray(snapshot?.threads) ? snapshot.threads : [];
     if (stored === null) {
       // Unreachable. Keep whatever the shadow gave us and prove nothing durable.
@@ -1940,9 +1965,12 @@ export class ChatHistoryStore {
     // write has not landed yet — an unreachable store must not resurrect a delete.
     const tombstoned = new Set([
       ...Object.keys(snapshot?.meta?.deletedThreads || {}),
-      // …and anything whose durable delete has not landed yet, whose tombstone may
-      // already have aged out of the capped map above.
+      // …anything whose durable delete has not landed yet, whose tombstone may
+      // already have aged out of the capped map above…
       ...this._pendingLegacyDeletes,
+      // …and anything already deleted for good. Without this a record another tab
+      // put back after the delete landed would be restored as live history.
+      ...deleteRecord.deleted,
     ]);
     const restored = stored
       .filter((thread) => !known.has(thread.id))
@@ -2177,9 +2205,12 @@ export class ChatHistoryStore {
           // The DELTA, never the whole set (codex r4): another tab's outstanding
           // delete must not be erased by this tab writing a list that predates it.
           try {
-            await idbMergePendingDeletes(this.indexedDb, {
-              add: deleted ? [] : tombstoned,
-              remove: deleted ? tombstoned : [],
+            await idbMergeDeleteRecord(this.indexedDb, {
+              // A landed delete is recorded PERMANENTLY, not erased (codex r6): a
+              // stale tab writing after the erase saw nothing and put the record
+              // back. Bounded by construction — legacyShadow ids are a closed set.
+              pending: deleted ? [] : tombstoned,
+              deleted: deleted ? tombstoned : [],
             });
           } catch {
             // Best effort: the in-memory set still drives retries in this tab.

--- a/web/js/lib/chat-history-store.js
+++ b/web/js/lib/chat-history-store.js
@@ -7,8 +7,25 @@ import { isThreadInScope } from "./workflow-chat-identity.js";
 export { isThreadInScope };
 
 export const CHAT_HISTORY_SCHEMA = 3;
+
+/**
+ * The IndexedDB version, DELIBERATELY SEPARATE from the record schema (#861).
+ *
+ * These were one constant, and the coupling was a trap: the fence at
+ * `mergeUnderCanonicalCheckpoint` is `snapshot.schemaVersion >= CHAT_HISTORY_SCHEMA`,
+ * so bumping the number to add an object store would have made every already-stored
+ * `schemaVersion: 3` snapshot read as UNFENCED — reopening the pre-v3 merge path the
+ * fence exists to close, on every existing install, as a side effect of a structural
+ * migration that has nothing to do with record shape.
+ *
+ * A store migration and a record-shape migration are different events. They now have
+ * different numbers, and only this one may be bumped to create or alter a store.
+ */
+export const CHAT_HISTORY_DB_VERSION = 4;
 export const CHAT_HISTORY_DB = "comfyui-mcp-panel-history";
 export const CHAT_HISTORY_STATE_KEY = "state";
+/** Object store holding quarantined pre-v3 transcripts — see LEGACY_STORE below. */
+export const CHAT_HISTORY_LEGACY_STORE = "legacy";
 export const CHAT_HISTORY_LOCAL_SNAPSHOT_KEY = "comfyui-mcp.panel.historySnapshot";
 export const CHAT_HISTORY_MAX_IMPORT_BYTES = 25 * 1024 * 1024;
 export const CHAT_HISTORY_EXPORT_FORMAT = "comfyui-agent-panel-chat-history";
@@ -19,6 +36,22 @@ const DEFAULT_MAX_THREADS = 500;
 const DEFAULT_MAX_MESSAGES = 5000;
 const LOCAL_SHADOW_THREADS = 20;
 const LOCAL_SHADOW_MESSAGES = 200;
+/**
+ * A ceiling on what the panel may occupy in localStorage (#861).
+ *
+ * `localStorage` is per-ORIGIN, and the panel shares `http://localhost:8188` with
+ * ComfyUI. There is no per-extension budget: bytes the panel takes are bytes
+ * ComfyUI's own `saveDraft()` cannot have. When it loses that race the user sees
+ * "Failed to save workflow draft", `Comfy.Workflow.DraftIndex.v2` stops persisting,
+ * and every open workflow tab is gone on browser restart — with a clean backend log
+ * and nothing pointing at the panel.
+ *
+ * ~1.5MB of a typical 5MB origin budget. Not tuned to a measurement, because the
+ * budget is a browser-and-origin variable we cannot read: it is chosen to leave
+ * ComfyUI the clear majority of the origin, on the principle that a guest should
+ * not be the reason the host fails.
+ */
+const LOCAL_SHADOW_MAX_BYTES = 1_500_000;
 const IDB_OPEN_TIMEOUT_MS = 2000;
 const DEFAULT_MAX_TOMBSTONES = 512;
 const DEFAULT_MAX_METADATA_OPS = 512;
@@ -1088,19 +1121,58 @@ function openDb(indexedDb) {
       resolve(db);
     };
     try {
-      request = indexedDb.open(CHAT_HISTORY_DB, CHAT_HISTORY_SCHEMA);
+      request = indexedDb.open(CHAT_HISTORY_DB, CHAT_HISTORY_DB_VERSION);
     } catch {
       finish(null);
       return;
     }
-    // The schema number is also the IndexedDB version: every future bump fires
-    // this callback. Structural store/index migrations belong here; record-shape
-    // migration remains app-layer normalization in mergeHistorySnapshots().
+    // CHAT_HISTORY_DB_VERSION — NOT the record schema (#861). Structural
+    // store/index migrations belong here; record-shape migration remains app-layer
+    // normalization in mergeHistorySnapshots().
     request.onupgradeneeded = () => {
       const db = request.result;
       if (!db.objectStoreNames.contains("snapshots")) db.createObjectStore("snapshots");
+      // #861 — LEGACY_STORE. Quarantined pre-v3 transcripts had no durable home:
+      // the schema-3 fence keeps them out of the canonical snapshot, so the
+      // localStorage shadow was their ONLY copy and had to retain them in full,
+      // forever, in a budget shared with ComfyUI.
+      //
+      // The fence's reason does not reach here. It exists because legacy messages
+      // carry no ids and a stale pre-v3 writer re-hashes shifted ordinals, so
+      // nothing flagged can be DEDUPED INTO CANONICAL safely. This store is not
+      // canonical and nothing merges it — records go in keyed by thread id and come
+      // back out as the same quarantined threads. Storing them durably reopens none
+      // of that reasoning, and it is what lets the shadow finally be bounded.
+      if (!db.objectStoreNames.contains(CHAT_HISTORY_LEGACY_STORE)) {
+        db.createObjectStore(CHAT_HISTORY_LEGACY_STORE);
+      }
     };
-    request.onsuccess = () => finish(request.result);
+    request.onsuccess = () => {
+      const db = request.result;
+      // #861 — GET OUT OF THE WAY OF AN UPGRADE. Adding the legacy store made this
+      // the first version bump the panel has ever shipped, and a bump is the moment
+      // multiple tabs stop being free: an open connection at the old version BLOCKS
+      // another tab's upgrade until it closes. Without this the second ComfyUI tab
+      // waits out the open timeout, gets null, and reports IndexedDB unavailable —
+      // on a database that is merely busy. Caught by conversation-persistence, which
+      // opens a second tab on the same origin: green serially, red in parallel.
+      //
+      // Connections here are short-lived (every caller closes in a finally), so
+      // closing on demand costs at most one in-flight read, which the caller already
+      // treats as "unavailable" and retries.
+      try {
+        db.onversionchange = () => {
+          try {
+            db.close();
+          } catch {
+            // Already closing; the upgrade proceeds either way.
+          }
+        };
+      } catch {
+        // A connection that will not take the handler still works for this read.
+      }
+      finish(db);
+    };
     request.onerror = () => finish(null);
     // A blocked upgrade may still succeed after another tab closes its older
     // connection. Keep waiting; if it outlives the bound below, late success is
@@ -1120,6 +1192,169 @@ async function idbRead(indexedDb) {
       req.onsuccess = () => resolve(req.result || null);
       req.onerror = () => resolve(null);
     });
+  } finally {
+    db.close();
+  }
+}
+
+/**
+ * Evict threads from the localStorage shadow until it fits a byte budget (#861).
+ *
+ * Count limits alone could not bound this: `LOCAL_SHADOW_THREADS`/`_MESSAGES` never
+ * applied to legacy threads, and even for ordinary ones 20 threads x 200 messages is
+ * a count, not a size — one transcript full of pasted workflow JSON outweighs
+ * hundreds of short ones. The quota that actually broke ComfyUI is measured in bytes,
+ * so the bound has to be too.
+ *
+ * ONLY `evictableIds` may be dropped. Everything in the shadow that is not durable
+ * somewhere else is off limits, because this is an eviction from a CACHE for
+ * everything that has a canonical copy and a DELETION for everything that does not.
+ * `protectedIds` (the live thread, and anything the caller is mid-write on) is never
+ * evicted even when durable — losing the transcript on screen to save space is not a
+ * trade a user would recognise as help.
+ *
+ * Oldest first, because a shadow exists for instant startup and the newest chats are
+ * the ones a user comes back to.
+ *
+ * Returns the snapshot unchanged when it already fits, so the common case pays one
+ * serialization and nothing else.
+ *
+ * @param {{threads?: Array}} localSnapshot
+ * @param {{maxBytes?: number, evictableIds?: Set<string>, protectedIds?: Set<string>}} opts
+ * @returns {{snapshot: object, serialized: string, evicted: string[]}}
+ */
+export function boundShadowBytes(localSnapshot, { maxBytes, evictableIds, protectedIds } = {}) {
+  const serialize = (snap) => JSON.stringify(snap);
+  const limit = Number.isFinite(maxBytes) && maxBytes > 0 ? maxBytes : Infinity;
+  let serialized = serialize(localSnapshot);
+  if (serialized.length <= limit) return { snapshot: localSnapshot, serialized, evicted: [] };
+
+  // Array OR Set. `protectedThreadIds` travels this file as an ARRAY (see
+  // retainBoundedThreads), and a `?.has` on it is silently `undefined` — which would
+  // have made every protected thread evictable rather than throwing anywhere a test
+  // could see it. Normalize instead of trusting the caller's shape.
+  const asSet = (value) => (value instanceof Set
+    ? value
+    : new Set(Array.isArray(value) ? value : []));
+  const protectedSet = asSet(protectedIds);
+  const evictableSet = asSet(evictableIds);
+
+  const threads = Array.isArray(localSnapshot.threads) ? localSnapshot.threads : [];
+  const canEvict = (thread) => {
+    const id = thread?.id;
+    if (typeof id !== "string" || !id) return false;
+    if (protectedSet.has(id)) return false;
+    // An empty evictable set means nothing has been PROVEN durable. Fail closed: an
+    // unbounded shadow is a quota bug, and deleting an only-copy transcript to fix
+    // it is a worse one.
+    return evictableSet.has(id);
+  };
+
+  // Cost each thread once. Re-serializing the whole snapshot per eviction is
+  // quadratic exactly when it matters — the reported install had a legacy set large
+  // enough to exhaust the origin — so evict against the estimate, then verify.
+  const order = threads
+    .filter(canEvict)
+    .map((thread) => ({ id: thread.id, ts: finiteTs(thread.updatedAt || thread.ts), cost: serialize(thread).length }))
+    .sort((a, b) => a.ts - b.ts);
+
+  const evicted = [];
+  let projected = serialized.length;
+  for (const candidate of order) {
+    if (projected <= limit) break;
+    evicted.push(candidate.id);
+    projected -= candidate.cost;
+  }
+  if (!evicted.length) return { snapshot: localSnapshot, serialized, evicted: [] };
+
+  const dropped = new Set(evicted);
+  const snapshot = { ...localSnapshot, threads: threads.filter((thread) => !dropped.has(thread.id)) };
+  serialized = serialize(snapshot);
+  // No verify-and-evict-more pass, and that is a claim rather than an omission:
+  // dropping a thread removes its own serialization AND the comma separating it, so
+  // the real saving is always at least `cost`. The estimate therefore UNDER-counts
+  // what each eviction buys — it can overshoot the budget downward, never leave it
+  // exceeded. An earlier draft carried a "finish the job exactly" loop here; no
+  // input could reach it, and a guard nothing can trigger reads as protection to the
+  // next person while protecting nothing. The invariant is pinned by test instead.
+  return { snapshot, serialized, evicted };
+}
+
+/**
+ * Read every quarantined pre-v3 transcript out of the legacy store (#861).
+ *
+ * Returns `null` — NOT `[]` — when the store cannot be reached. The difference is
+ * load-bearing: an empty store means "there are none", and an unreachable one means
+ * "unknown". Only the first licenses bounding the localStorage shadow; treating the
+ * second as empty would drop transcripts whose durable copy we merely failed to read.
+ */
+async function idbReadLegacy(indexedDb) {
+  const db = await openDb(indexedDb);
+  if (!db) return null;
+  try {
+    if (!db.objectStoreNames.contains(CHAT_HISTORY_LEGACY_STORE)) return null;
+    return await new Promise((resolve) => {
+      let tx;
+      try {
+        tx = db.transaction(CHAT_HISTORY_LEGACY_STORE, "readonly");
+      } catch {
+        resolve(null);
+        return;
+      }
+      const req = tx.objectStore(CHAT_HISTORY_LEGACY_STORE).getAll();
+      req.onsuccess = () => resolve(Array.isArray(req.result) ? req.result : null);
+      req.onerror = () => resolve(null);
+      tx.onerror = () => resolve(null);
+      tx.onabort = () => resolve(null);
+    });
+  } catch {
+    return null;
+  } finally {
+    db.close();
+  }
+}
+
+/**
+ * Put every legacy thread into the legacy store, keyed by thread id (#861).
+ *
+ * ONE record per thread rather than one blob: a single oversized transcript then
+ * cannot block the rest from becoming durable, and a re-run overwrites in place
+ * instead of appending — so the migration is idempotent and can safely run on every
+ * read until it succeeds.
+ *
+ * Returns true only if the transaction COMPLETED. `oncomplete`, not the last
+ * `onsuccess`: individual puts succeed against a transaction that later aborts on
+ * quota, and reporting that as durable is what would license deleting the only other
+ * copy.
+ */
+async function idbWriteLegacy(indexedDb, threads) {
+  const list = Array.isArray(threads) ? threads.filter((t) => t && typeof t.id === "string" && t.id) : [];
+  if (!list.length) return true;
+  const db = await openDb(indexedDb);
+  if (!db) return false;
+  try {
+    if (!db.objectStoreNames.contains(CHAT_HISTORY_LEGACY_STORE)) return false;
+    return await new Promise((resolve) => {
+      let tx;
+      try {
+        tx = db.transaction(CHAT_HISTORY_LEGACY_STORE, "readwrite");
+      } catch {
+        resolve(false);
+        return;
+      }
+      const store = tx.objectStore(CHAT_HISTORY_LEGACY_STORE);
+      try {
+        for (const thread of list) store.put(thread, thread.id);
+      } catch {
+        resolve(false);
+        return;
+      }
+      tx.oncomplete = () => resolve(true);
+      tx.onerror = () => resolve(false);
+      tx.onabort = () => resolve(false);
+    });
+  } catch {
+    return false;
   } finally {
     db.close();
   }
@@ -1200,6 +1435,24 @@ export class ChatHistoryStore {
     this.onPersistenceError = typeof options.onPersistenceError === "function"
       ? options.onPersistenceError
       : null;
+    // #861 — observability for the byte bound. Evicting from the shadow is normal
+    // and lossless once a thread is durable, but it is not nothing, and a store that
+    // silently shrinks what it shows is how the panel got into this in the first
+    // place: usage nobody could see, failing somewhere else.
+    this.onShadowEvict = typeof options.onShadowEvict === "function" ? options.onShadowEvict : null;
+    this.maxShadowBytes = Number.isFinite(options.maxShadowBytes)
+      ? options.maxShadowBytes
+      : LOCAL_SHADOW_MAX_BYTES;
+    /**
+     * Thread ids the legacy store has ACCEPTED (#861).
+     *
+     * The receipt that licenses evicting a legacy thread from the shadow. Empty
+     * until a legacy write completes, which is the fail-closed default: with no
+     * durable copy proven, nothing legacy is evictable and the shadow behaves
+     * exactly as it does today. A quota bug is worth fixing; it is not worth
+     * deleting the only copy of someone's transcripts to fix.
+     */
+    this._durableLegacyIds = new Set();
     this.lastShadowWriteOk = null;
     this.lastShadowError = null;
     this.writerId = options.writerId || globalThis.crypto?.randomUUID?.() || `writer-${Math.random().toString(16).slice(2)}`;
@@ -1358,11 +1611,59 @@ export class ChatHistoryStore {
       indexed,
       this.readLocal({ quarantineCheckpoint: indexed != null }),
     );
-    this._observeSnapshot(merged);
-    return merged;
+    const withLegacy = await this._restoreLegacyShadow(merged);
+    this._observeSnapshot(withLegacy);
+    return withLegacy;
   }
 
-  _writeLocalSnapshot(snapshot, protectedThreadIds) {
+  /**
+   * Re-attach durably-stored legacy transcripts, and migrate any that are still
+   * shadow-only (#861).
+   *
+   * Runs on every canonical read, deliberately. The migration is a `put` per thread
+   * keyed by id, so re-running it overwrites in place and costs nothing once
+   * everything is durable — which means a browser that was in private mode, or out
+   * of quota, or mid-upgrade on the first attempt simply succeeds on a later one
+   * rather than needing a one-shot migration flag that can be wrong.
+   *
+   * Reading returns `null` when the store is UNREACHABLE and `[]` when it is empty.
+   * Only the empty case may clear the durable receipts; treating unreachable as
+   * empty would revoke the licence to evict — harmless — but treating it as
+   * authoritative would let a later write believe threads were already durable when
+   * they were not.
+   */
+  async _restoreLegacyShadow(snapshot) {
+    const stored = await idbReadLegacy(this.indexedDb);
+    const threads = Array.isArray(snapshot?.threads) ? snapshot.threads : [];
+    if (stored === null) {
+      // Unreachable. Keep whatever the shadow gave us and prove nothing durable.
+      this._durableLegacyIds = new Set();
+      return snapshot;
+    }
+    this._durableLegacyIds = new Set(
+      stored.map((thread) => thread?.id).filter((id) => typeof id === "string" && id),
+    );
+    // The stored copy is additive: a thread the shadow already lost to a byte
+    // eviction comes back here, which is the whole point of giving it a home.
+    const known = new Set(threads.map((thread) => thread?.id).filter(Boolean));
+    const restored = stored
+      .filter((thread) => thread && typeof thread.id === "string" && !known.has(thread.id))
+      .map((thread) => ({ ...thread, legacyShadow: true }));
+    // Anything flagged in the shadow but not yet durable gets its home now.
+    const pending = threads.filter(
+      (thread) => thread?.legacyShadow === true && thread?.id && !this._durableLegacyIds.has(thread.id),
+    );
+    if (pending.length && await idbWriteLegacy(this.indexedDb, pending)) {
+      for (const thread of pending) this._durableLegacyIds.add(thread.id);
+    }
+    if (!restored.length) return snapshot;
+    const all = [...threads, ...restored].sort(
+      (a, b) => finiteTs(a.updatedAt || a.ts) - finiteTs(b.updatedAt || b.ts),
+    );
+    return { ...snapshot, threads: all };
+  }
+
+  _writeLocalSnapshot(snapshot, protectedThreadIds, { canonicalDurable = false } = {}) {
     // legacyShadow threads are excluded from IndexedDB by the schema fence, so
     // the local shadow is their only copy. Preserve every such thread and all
     // of its messages. A storage-quota failure is surfaced instead of claiming
@@ -1380,13 +1681,42 @@ export class ChatHistoryStore {
     }));
     const shadow = [...boundedOrdinary, ...legacyThreads]
       .sort((a, b) => finiteTs(a.updatedAt || a.ts) - finiteTs(b.updatedAt || b.ts));
-    const localSnapshot = { ...snapshot, threads: shadow };
-    const shadowById = new Map(shadow.map((thread) => [thread.id, thread]));
-    const complete = snapshot.threads.length === shadow.length &&
+    // #861 — the byte bound. Everything here is a CACHE of something durable except
+    // legacy threads, which are durable only once the legacy store has accepted
+    // them. `_durableLegacyIds` is that receipt, and it is the entire licence to
+    // evict: with no receipt the set is empty, nothing legacy is evictable, and the
+    // shadow keeps today's unbounded behaviour rather than deleting an only copy.
+    const evictableIds = new Set();
+    // Ordinary threads are a cache of CANONICAL — but only once canonical has
+    // actually accepted them. Before the IndexedDB merge lands (and on any install
+    // where IndexedDB is unavailable) the shadow is their only copy too, so the same
+    // rule applies to them as to legacy ones: no durable copy, no eviction.
+    if (canonicalDurable) {
+      for (const thread of boundedOrdinary) if (thread?.id) evictableIds.add(thread.id);
+    }
+    for (const thread of legacyThreads) {
+      if (thread?.id && this._durableLegacyIds?.has(thread.id)) evictableIds.add(thread.id);
+    }
+    const bounded = boundShadowBytes(
+      { ...snapshot, threads: shadow },
+      { maxBytes: this.maxShadowBytes, evictableIds, protectedIds: protectedThreadIds },
+    );
+    const localSnapshot = bounded.snapshot;
+    const keptThreads = Array.isArray(localSnapshot.threads) ? localSnapshot.threads : [];
+    if (bounded.evicted.length) this.onShadowEvict?.(bounded.evicted, bounded.serialized.length);
+    const shadowById = new Map(keptThreads.map((thread) => [thread.id, thread]));
+    const complete = snapshot.threads.length === keptThreads.length &&
       snapshot.threads.every((thread) =>
         shadowById.get(thread.id)?.msgs?.length === thread.msgs.length);
+    // A legacy thread missing from the shadow is only acceptable if the legacy store
+    // holds it. This is what keeps `legacyComplete` honest — and it is the reason a
+    // byte cap alone would have been wrong: without the receipt this reports false,
+    // `result.ok` stays false, `_dirtyWrite` is retained, and every later persist
+    // fires onPersistenceError forever against a state that can never fit.
+    const legacyComplete = legacyThreads.every((thread) =>
+      shadowById.has(thread.id) || this._durableLegacyIds?.has(thread.id));
     try {
-      this.storage?.setItem(this.snapshotKey, JSON.stringify(localSnapshot));
+      this.storage?.setItem(this.snapshotKey, bounded.serialized);
       this.lastShadowWriteOk = true;
       this.lastShadowError = null;
     } catch (error) {
@@ -1396,7 +1726,7 @@ export class ChatHistoryStore {
       return { committed: false, complete: false, legacyComplete: false };
     }
     try {
-      this.storage?.setItem(this.threadsKey, JSON.stringify(shadow));
+      this.storage?.setItem(this.threadsKey, JSON.stringify(keptThreads));
     } catch {
       // The atomic shadow is already committed.
     }
@@ -1405,7 +1735,7 @@ export class ChatHistoryStore {
     } catch {
       // The atomic shadow is already committed.
     }
-    return { committed: true, complete, legacyComplete: true };
+    return { committed: true, complete, legacyComplete };
   }
 
   persist(threads, meta = {}, options = {}) {
@@ -1441,12 +1771,35 @@ export class ChatHistoryStore {
     this._writePromise = this._writePromise
       .catch(() => null)
       .then(() => idbMergeWrite(this.indexedDb, snapshot, limits))
+      // #861 — give the quarantined transcripts their durable home BEFORE the
+      // shadow is rewritten. Order is the safety property: the receipt earned here
+      // is what `_writeLocalSnapshot` consults to decide whether a legacy thread may
+      // be evicted, so a write that fails simply leaves it unevictable rather than
+      // dropping the only copy. Never rejects — a legacy store that cannot be
+      // reached must not take the canonical write down with it.
+      .then(async (merged) => {
+        const legacy = (Array.isArray(merged?.threads) ? merged.threads : snapshot.threads || [])
+          .filter((thread) => thread?.legacyShadow === true && thread?.id);
+        const undurable = legacy.filter((thread) => !this._durableLegacyIds.has(thread.id));
+        if (undurable.length) {
+          try {
+            if (await idbWriteLegacy(this.indexedDb, undurable)) {
+              for (const thread of undurable) this._durableLegacyIds.add(thread.id);
+            }
+          } catch {
+            // Unreachable legacy store: nothing becomes evictable. Fail closed.
+          }
+        }
+        return merged;
+      })
       .then((merged) => {
         let postMergeShadowWrite = null;
         if (merged) {
           this._lastCommitted = merged;
           this._observeSnapshot(merged);
-          postMergeShadowWrite = this._writeLocalSnapshot(merged, protectedThreadIds);
+          postMergeShadowWrite = this._writeLocalSnapshot(merged, protectedThreadIds, {
+            canonicalDurable: true,
+          });
           try {
             this._broadcastChannel?.postMessage({ type: "history-changed", writerId: this.writerId });
           } catch {

--- a/web/js/lib/chat-history-store.js
+++ b/web/js/lib/chat-history-store.js
@@ -1392,12 +1392,15 @@ function legacyFingerprint(thread) {
  * retry the record is absent from both tombstone sources AND from the new tab's empty
  * pending set — never retried, and free to restore.
  *
- * Recording it in the legacy store puts the intent in the same place as the thing it
- * is about, where nothing caps or expires it. The key is namespaced so it cannot
- * collide with a thread id, and every reader here already requires a string `id` on a
- * record, so this marker is skipped by the restore and receipt passes for free.
+ * It lives in the `snapshots` store, NOT beside the transcripts (codex r5). Sharing a
+ * key space with records keyed by THREAD ID is only safe while no thread id can equal
+ * the marker key, and ids are normally minted by crypto.randomUUID() but an IMPORTED
+ * history can carry anything. Refusing to store such a thread guards new writes and
+ * does nothing about a database that already holds one. `snapshots` is keyed by fixed
+ * names, so the collision cannot arise in either direction — a better answer than a
+ * guard that only covers one of them.
  */
-const LEGACY_PENDING_DELETES_KEY = "__cmcp_pending_deletes";
+const LEGACY_PENDING_DELETES_KEY = "__cmcp_legacy_pending_deletes";
 
 /** Read the durable pending-delete list. `[]` when absent or unreadable — a missing
  *  list means nothing is known to be owed, which the in-memory set then adds to. */
@@ -1405,16 +1408,16 @@ async function idbReadPendingDeletes(indexedDb) {
   const db = await openDb(indexedDb);
   if (!db) return [];
   try {
-    if (!db.objectStoreNames.contains(CHAT_HISTORY_LEGACY_STORE)) return [];
+    if (!db.objectStoreNames.contains("snapshots")) return [];
     return await new Promise((resolve) => {
       let tx;
       try {
-        tx = db.transaction(CHAT_HISTORY_LEGACY_STORE, "readonly");
+        tx = db.transaction("snapshots", "readonly");
       } catch {
         resolve([]);
         return;
       }
-      const req = tx.objectStore(CHAT_HISTORY_LEGACY_STORE).get(LEGACY_PENDING_DELETES_KEY);
+      const req = tx.objectStore("snapshots").get(LEGACY_PENDING_DELETES_KEY);
       req.onsuccess = () => {
         const ids = req.result?.ids;
         resolve(Array.isArray(ids) ? ids.filter((id) => typeof id === "string" && id) : []);
@@ -1448,16 +1451,16 @@ async function idbMergePendingDeletes(indexedDb, { add = [], remove = [] } = {})
   const db = await openDb(indexedDb);
   if (!db) return false;
   try {
-    if (!db.objectStoreNames.contains(CHAT_HISTORY_LEGACY_STORE)) return false;
+    if (!db.objectStoreNames.contains("snapshots")) return false;
     return await new Promise((resolve) => {
       let tx;
       try {
-        tx = db.transaction(CHAT_HISTORY_LEGACY_STORE, "readwrite");
+        tx = db.transaction("snapshots", "readwrite");
       } catch {
         resolve(false);
         return;
       }
-      const store = tx.objectStore(CHAT_HISTORY_LEGACY_STORE);
+      const store = tx.objectStore("snapshots");
       let req;
       try {
         req = store.get(LEGACY_PENDING_DELETES_KEY);
@@ -1561,13 +1564,7 @@ async function idbClearLegacy(indexedDb) {
 
 async function idbWriteLegacy(indexedDb, threads) {
   const list = Array.isArray(threads)
-    ? threads.filter((t) => t && typeof t.id === "string" && t.id
-        // A thread whose id IS the reserved key cannot share a key space with the
-        // marker (codex r4). Ids are normally minted by crypto.randomUUID(), but an
-        // IMPORTED history can carry anything. Refusing to store it keeps the thread
-        // unevictable — it stays whole in the shadow — which is the fail-closed
-        // outcome, not a silent overwrite of either record by the other.
-        && t.id !== LEGACY_PENDING_DELETES_KEY)
+    ? threads.filter((t) => t && typeof t.id === "string" && t.id)
     : [];
   // `[]`, not `true` (codex r5). Callers do `new Set(written || [])`, and
   // `new Set(true)` THROWS — so a history whose only legacy thread was refused for
@@ -1578,22 +1575,43 @@ async function idbWriteLegacy(indexedDb, threads) {
   if (!db) return null;
   try {
     if (!db.objectStoreNames.contains(CHAT_HISTORY_LEGACY_STORE)) return null;
+    if (!db.objectStoreNames.contains("snapshots")) return null;
     return await new Promise((resolve) => {
       let tx;
       try {
-        tx = db.transaction(CHAT_HISTORY_LEGACY_STORE, "readwrite");
+        // BOTH stores, ONE transaction (codex r5). Another tab can be mid-delete:
+        // B records a pending delete of L1, A completes it, and a third tab still
+        // holding L1 as live writes it straight back — leaving a record with no
+        // outstanding intent to remove it again. Reading the marker inside the same
+        // transaction as the put makes that interleaving unobservable.
+        tx = db.transaction([CHAT_HISTORY_LEGACY_STORE, "snapshots"], "readwrite");
       } catch {
         resolve(null);
         return;
       }
-      const store = tx.objectStore(CHAT_HISTORY_LEGACY_STORE);
+      let written = [];
+      let req;
       try {
-        for (const thread of list) store.put(thread, thread.id);
+        req = tx.objectStore("snapshots").get(LEGACY_PENDING_DELETES_KEY);
       } catch {
         resolve(null);
         return;
       }
-      tx.oncomplete = () => resolve(list.map((thread) => thread.id));
+      req.onsuccess = () => {
+        const owed = new Set(Array.isArray(req.result?.ids) ? req.result.ids : []);
+        // A thread someone is still trying to delete is not resurrected here. It
+        // stays whole in the shadow and unevictable — fail closed, as everywhere
+        // else in this file.
+        const allowed = list.filter((thread) => !owed.has(thread.id));
+        try {
+          const store = tx.objectStore(CHAT_HISTORY_LEGACY_STORE);
+          for (const thread of allowed) store.put(thread, thread.id);
+          written = allowed.map((thread) => thread.id);
+        } catch {
+          written = [];
+        }
+      };
+      tx.oncomplete = () => resolve(written);
       tx.onerror = () => resolve(null);
       tx.onabort = () => resolve(null);
     });

--- a/web/js/lib/chat-history-store.js
+++ b/web/js/lib/chat-history-store.js
@@ -1302,7 +1302,14 @@ async function idbReadLegacy(indexedDb) {
         return;
       }
       const req = tx.objectStore(CHAT_HISTORY_LEGACY_STORE).getAll();
-      req.onsuccess = () => resolve(Array.isArray(req.result) ? req.result : null);
+      req.onsuccess = () => resolve(
+        // Structural, not by key: the marker is the record that carries an `ids` list
+        // and no thread `id`. Callers already require a string id, but saying so here
+        // means one place decides what is a transcript.
+        Array.isArray(req.result)
+          ? req.result.filter((record) => record && typeof record.id === "string" && record.id)
+          : null,
+      );
       req.onerror = () => resolve(null);
       tx.onerror = () => resolve(null);
       tx.onabort = () => resolve(null);
@@ -1322,10 +1329,14 @@ async function idbReadLegacy(indexedDb) {
  * instead of appending — so the migration is idempotent and can safely run on every
  * read until it succeeds.
  *
- * Returns true only if the transaction COMPLETED. `oncomplete`, not the last
- * `onsuccess`: individual puts succeed against a transaction that later aborts on
- * quota, and reporting that as durable is what would license deleting the only other
- * copy.
+ * Returns THE IDS IT STORED, or null if the transaction did not complete — not a
+ * bare boolean. The caller grants receipts from this, and a boolean let it grant one
+ * for a thread this function had filtered out (a colliding reserved key), i.e. a
+ * receipt for something that was never written.
+ *
+ * `oncomplete`, not the last `onsuccess`: individual puts succeed against a
+ * transaction that later aborts on quota, and reporting that as durable is what would
+ * license deleting the only other copy.
  */
 /**
  * What a legacy record must match for its stored copy to stand in for the live one
@@ -1418,10 +1429,22 @@ async function idbReadPendingDeletes(indexedDb) {
   }
 }
 
-/** Persist the pending-delete list. Best effort: a store that will not take it is a
- *  store that cannot be growing either, and the in-memory set still drives retries
- *  for the life of this tab. */
-async function idbWritePendingDeletes(indexedDb, ids) {
+/**
+ * Merge into the pending-delete list, in ONE transaction (codex r4).
+ *
+ * NOT a whole-list overwrite. Two tabs both retrying is ordinary: tab A finishes
+ * `L0` and writes `[]` while tab B's delete of `L1` fails and writes `[L1]`. If A's
+ * stale `[]` lands last it erases B's durable intent, B closes, `L1`'s capped
+ * tombstone ages out, and the whole reload hole is back. Reading and writing inside
+ * the same readwrite transaction makes the merge atomic against the other tab.
+ *
+ * Best effort: a store that will not take the marker is a store that will not be
+ * taking new records either, and the in-memory set still drives retries here.
+ */
+async function idbMergePendingDeletes(indexedDb, { add = [], remove = [] } = {}) {
+  const toAdd = add.filter((id) => typeof id === "string" && id);
+  const toRemove = new Set(remove.filter((id) => typeof id === "string" && id));
+  if (!toAdd.length && !toRemove.size) return true;
   const db = await openDb(indexedDb);
   if (!db) return false;
   try {
@@ -1435,13 +1458,24 @@ async function idbWritePendingDeletes(indexedDb, ids) {
         return;
       }
       const store = tx.objectStore(CHAT_HISTORY_LEGACY_STORE);
+      let req;
       try {
-        if (ids.length) store.put({ ids }, LEGACY_PENDING_DELETES_KEY);
-        else store.delete(LEGACY_PENDING_DELETES_KEY);
+        req = store.get(LEGACY_PENDING_DELETES_KEY);
       } catch {
         resolve(false);
         return;
       }
+      req.onsuccess = () => {
+        const existing = Array.isArray(req.result?.ids) ? req.result.ids : [];
+        const merged = [...new Set([...existing, ...toAdd])]
+          .filter((id) => typeof id === "string" && id && !toRemove.has(id));
+        try {
+          if (merged.length) store.put({ ids: merged }, LEGACY_PENDING_DELETES_KEY);
+          else store.delete(LEGACY_PENDING_DELETES_KEY);
+        } catch {
+          // The transaction settles below either way.
+        }
+      };
       tx.oncomplete = () => resolve(true);
       tx.onerror = () => resolve(false);
       tx.onabort = () => resolve(false);
@@ -1456,11 +1490,11 @@ async function idbWritePendingDeletes(indexedDb, ids) {
 /** Delete legacy records by key — used for tombstoned threads (#861, codex P1). */
 async function idbDeleteLegacy(indexedDb, ids) {
   const list = [...new Set((Array.isArray(ids) ? ids : []).filter((id) => typeof id === "string" && id))];
-  if (!list.length) return true;
+  if (!list.length) return [];
   const db = await openDb(indexedDb);
-  if (!db) return false;
+  if (!db) return null;
   try {
-    if (!db.objectStoreNames.contains(CHAT_HISTORY_LEGACY_STORE)) return false;
+    if (!db.objectStoreNames.contains(CHAT_HISTORY_LEGACY_STORE)) return null;
     return await new Promise((resolve) => {
       let tx;
       try {
@@ -1526,7 +1560,15 @@ async function idbClearLegacy(indexedDb) {
 }
 
 async function idbWriteLegacy(indexedDb, threads) {
-  const list = Array.isArray(threads) ? threads.filter((t) => t && typeof t.id === "string" && t.id) : [];
+  const list = Array.isArray(threads)
+    ? threads.filter((t) => t && typeof t.id === "string" && t.id
+        // A thread whose id IS the reserved key cannot share a key space with the
+        // marker (codex r4). Ids are normally minted by crypto.randomUUID(), but an
+        // IMPORTED history can carry anything. Refusing to store it keeps the thread
+        // unevictable — it stays whole in the shadow — which is the fail-closed
+        // outcome, not a silent overwrite of either record by the other.
+        && t.id !== LEGACY_PENDING_DELETES_KEY)
+    : [];
   if (!list.length) return true;
   const db = await openDb(indexedDb);
   if (!db) return false;
@@ -1537,22 +1579,22 @@ async function idbWriteLegacy(indexedDb, threads) {
       try {
         tx = db.transaction(CHAT_HISTORY_LEGACY_STORE, "readwrite");
       } catch {
-        resolve(false);
+        resolve(null);
         return;
       }
       const store = tx.objectStore(CHAT_HISTORY_LEGACY_STORE);
       try {
         for (const thread of list) store.put(thread, thread.id);
       } catch {
-        resolve(false);
+        resolve(null);
         return;
       }
-      tx.oncomplete = () => resolve(true);
-      tx.onerror = () => resolve(false);
-      tx.onabort = () => resolve(false);
+      tx.oncomplete = () => resolve(list.map((thread) => thread.id));
+      tx.onerror = () => resolve(null);
+      tx.onabort = () => resolve(null);
     });
   } catch {
-    return false;
+    return null;
   } finally {
     db.close();
   }
@@ -1665,6 +1707,9 @@ export class ChatHistoryStore {
      * the map that expires, and also suppresses the restore in the meantime.
      */
     this._pendingLegacyDeletes = new Set();
+    /** Legacy ids this session has already deleted, so a still-live tombstone does
+     *  not re-issue the same no-op delete on every persist. */
+    this._legacyDeletesDone = new Set();
     this.lastShadowWriteOk = null;
     this.lastShadowError = null;
     this.writerId = options.writerId || globalThis.crypto?.randomUUID?.() || `writer-${Math.random().toString(16).slice(2)}`;
@@ -1858,10 +1903,12 @@ export class ChatHistoryStore {
       this._durableLegacy = new Map();
       return snapshot;
     }
+    // `idbReadLegacy` is the one place that decides what counts as a transcript, so
+    // nothing here re-checks for a string id. Duplicating that test would make the
+    // real guard untestable — remove it and every assertion still passes — which is
+    // how a decorative check ends up reading as protection.
     this._durableLegacy = new Map(
-      stored
-        .filter((thread) => thread && typeof thread.id === "string" && thread.id)
-        .map((thread) => [thread.id, legacyFingerprint(thread)]),
+      stored.map((thread) => [thread.id, legacyFingerprint(thread)]),
     );
     // The stored copy is additive: a thread the shadow already lost to a byte
     // eviction comes back here, which is the whole point of giving it a home.
@@ -1876,7 +1923,7 @@ export class ChatHistoryStore {
       ...this._pendingLegacyDeletes,
     ]);
     const restored = stored
-      .filter((thread) => thread && typeof thread.id === "string" && !known.has(thread.id))
+      .filter((thread) => !known.has(thread.id))
       .filter((thread) => !tombstoned.has(thread.id))
       .map((thread) => ({ ...thread, legacyShadow: true }));
     // Anything flagged in the shadow but not yet durable gets its home now.
@@ -1884,8 +1931,12 @@ export class ChatHistoryStore {
       (thread) => thread?.legacyShadow === true && thread?.id
         && this._durableLegacy.get(thread.id) !== legacyFingerprint(thread),
     );
-    if (pending.length && await idbWriteLegacy(this.indexedDb, pending)) {
-      for (const thread of pending) this._durableLegacy.set(thread.id, legacyFingerprint(thread));
+    if (pending.length) {
+      const written = await idbWriteLegacy(this.indexedDb, pending);
+      const stored = new Set(written || []);
+      for (const thread of pending) {
+        if (stored.has(thread.id)) this._durableLegacy.set(thread.id, legacyFingerprint(thread));
+      }
     }
     if (!restored.length) return snapshot;
     const all = [...threads, ...restored].sort(
@@ -2021,8 +2072,16 @@ export class ChatHistoryStore {
         );
         if (stale.length) {
           try {
-            if (await idbWriteLegacy(this.indexedDb, stale)) {
-              for (const thread of stale) this._durableLegacy.set(thread.id, legacyFingerprint(thread));
+            const written = await idbWriteLegacy(this.indexedDb, stale);
+            if (written) {
+              // Only what it actually stored. A thread it refused (a colliding
+              // reserved key) must not collect a receipt it cannot honour.
+              const stored = new Set(written);
+              for (const thread of stale) {
+                if (stored.has(thread.id)) {
+                  this._durableLegacy.set(thread.id, legacyFingerprint(thread));
+                }
+              }
             }
           } catch {
             // Unreachable legacy store: nothing becomes evictable. Fail closed.
@@ -2060,7 +2119,12 @@ export class ChatHistoryStore {
           // tombstone can lose a causal merge to a newer live version. Deleting by id
           // alone would take the live record with it.
           .filter((id) => !liveIds.has(id))
-          .filter((id) => this._durableLegacy.has(id) || this._pendingLegacyDeletes.has(id));
+          // NOT gated on holding a receipt. A freshly opened tab has no receipts
+          // until it reads, and gating on them meant it would skip a delete another
+          // tab had left owing — the correctness gap an optimization bought. Deleting
+          // an absent key is a no-op, so the only cost is a wasted key, and
+          // `_legacyDeletesDone` keeps that to once per id per session.
+          .filter((id) => !this._legacyDeletesDone.has(id));
         if (tombstoned.length) {
           let deleted = false;
           try {
@@ -2068,11 +2132,11 @@ export class ChatHistoryStore {
           } catch {
             deleted = false;
           }
-          const before = this._pendingLegacyDeletes.size;
           if (deleted) {
             for (const id of tombstoned) {
               this._durableLegacy.delete(id);
               this._pendingLegacyDeletes.delete(id);
+              this._legacyDeletesDone.add(id);
             }
           } else {
             // Remember it OURSELVES rather than trusting the tombstone to still be
@@ -2087,12 +2151,16 @@ export class ChatHistoryStore {
           // In-memory alone loses the retry when the tab closes, and if the capped
           // tombstone map has aged the id out by the time a new tab looks, nothing
           // ever retries and the record can restore.
-          if (this._pendingLegacyDeletes.size !== before) {
-            try {
-              await idbWritePendingDeletes(this.indexedDb, [...this._pendingLegacyDeletes]);
-            } catch {
-              // Best effort: the in-memory set still drives retries in this tab.
-            }
+          //
+          // The DELTA, never the whole set (codex r4): another tab's outstanding
+          // delete must not be erased by this tab writing a list that predates it.
+          try {
+            await idbMergePendingDeletes(this.indexedDb, {
+              add: deleted ? [] : tombstoned,
+              remove: deleted ? tombstoned : [],
+            });
+          } catch {
+            // Best effort: the in-memory set still drives retries in this tab.
           }
         }
         return merged;
@@ -2196,6 +2264,7 @@ export class ChatHistoryStore {
           // which is correct: there is nothing left to owe a delete to.
           this._durableLegacy = new Map();
           this._pendingLegacyDeletes = new Set();
+          this._legacyDeletesDone = new Set();
         }
         return { reset, legacyCleared };
       })

--- a/web/js/lib/chat-history-store.js
+++ b/web/js/lib/chat-history-store.js
@@ -1327,6 +1327,108 @@ async function idbReadLegacy(indexedDb) {
  * quota, and reporting that as durable is what would license deleting the only other
  * copy.
  */
+/**
+ * What a legacy record must match for its stored copy to stand in for the live one
+ * (#861, codex P1).
+ *
+ * `_durableLegacyIds` was a set of IDS, and an id is not a receipt for CONTENT. A
+ * legacy thread that was written once and then EDITED — renamed, pinned, a message
+ * tombstoned — was filtered out of every later write as "already durable" while the
+ * stored copy stayed at the old version. The shadow would then evict the new version
+ * on the strength of a receipt for the old one, report `legacyComplete: true`, and
+ * clear the dirty flag. That is the data loss this whole change exists to avoid,
+ * reintroduced one level down.
+ *
+ * `updatedAt` moves on every edit that goes through revise/fieldOps, and the length
+ * and message count catch a rewrite that somehow keeps the same stamp. Cheaper than
+ * retaining a serialized copy of every transcript purely to diff it — which, for the
+ * install that reported this, is the memory the bug was about in the first place.
+ */
+function legacyFingerprint(thread) {
+  if (!thread || typeof thread !== "object") return "";
+  let bytes = 0;
+  try {
+    bytes = JSON.stringify(thread).length;
+  } catch {
+    // Uncloneable/circular: fall through with 0 so it simply never matches and the
+    // thread stays unevictable.
+  }
+  const msgs = Array.isArray(thread.msgs) ? thread.msgs.length : -1;
+  return `${finiteTs(thread.updatedAt || thread.ts)}:${msgs}:${bytes}`;
+}
+
+/** Delete legacy records by key — used for tombstoned threads (#861, codex P1). */
+async function idbDeleteLegacy(indexedDb, ids) {
+  const list = [...new Set((Array.isArray(ids) ? ids : []).filter((id) => typeof id === "string" && id))];
+  if (!list.length) return true;
+  const db = await openDb(indexedDb);
+  if (!db) return false;
+  try {
+    if (!db.objectStoreNames.contains(CHAT_HISTORY_LEGACY_STORE)) return false;
+    return await new Promise((resolve) => {
+      let tx;
+      try {
+        tx = db.transaction(CHAT_HISTORY_LEGACY_STORE, "readwrite");
+      } catch {
+        resolve(false);
+        return;
+      }
+      const store = tx.objectStore(CHAT_HISTORY_LEGACY_STORE);
+      try {
+        for (const id of list) store.delete(id);
+      } catch {
+        resolve(false);
+        return;
+      }
+      tx.oncomplete = () => resolve(true);
+      tx.onerror = () => resolve(false);
+      tx.onabort = () => resolve(false);
+    });
+  } catch {
+    return false;
+  } finally {
+    db.close();
+  }
+}
+
+/**
+ * Empty the legacy store (#861, codex P1).
+ *
+ * `clearAll` is the user saying delete everything. Without this the legacy store
+ * would survive the reset and `_restoreLegacyShadow` would hand every cleared
+ * transcript back on the next load — a delete that undoes itself, which is worse
+ * than one that fails loudly.
+ */
+async function idbClearLegacy(indexedDb) {
+  const db = await openDb(indexedDb);
+  if (!db) return false;
+  try {
+    if (!db.objectStoreNames.contains(CHAT_HISTORY_LEGACY_STORE)) return true;
+    return await new Promise((resolve) => {
+      let tx;
+      try {
+        tx = db.transaction(CHAT_HISTORY_LEGACY_STORE, "readwrite");
+      } catch {
+        resolve(false);
+        return;
+      }
+      try {
+        tx.objectStore(CHAT_HISTORY_LEGACY_STORE).clear();
+      } catch {
+        resolve(false);
+        return;
+      }
+      tx.oncomplete = () => resolve(true);
+      tx.onerror = () => resolve(false);
+      tx.onabort = () => resolve(false);
+    });
+  } catch {
+    return false;
+  } finally {
+    db.close();
+  }
+}
+
 async function idbWriteLegacy(indexedDb, threads) {
   const list = Array.isArray(threads) ? threads.filter((t) => t && typeof t.id === "string" && t.id) : [];
   if (!list.length) return true;
@@ -1444,15 +1546,20 @@ export class ChatHistoryStore {
       ? options.maxShadowBytes
       : LOCAL_SHADOW_MAX_BYTES;
     /**
-     * Thread ids the legacy store has ACCEPTED (#861).
+     * What the legacy store has ACCEPTED, as id -> content fingerprint (#861).
      *
      * The receipt that licenses evicting a legacy thread from the shadow. Empty
      * until a legacy write completes, which is the fail-closed default: with no
      * durable copy proven, nothing legacy is evictable and the shadow behaves
      * exactly as it does today. A quota bug is worth fixing; it is not worth
      * deleting the only copy of someone's transcripts to fix.
+     *
+     * A FINGERPRINT, not just an id (codex P1). An id-only receipt says a thread by
+     * that name was stored once; it does not say the stored copy is the one about to
+     * be evicted. An edited legacy thread would otherwise be dropped from the shadow
+     * against a receipt for its previous version.
      */
-    this._durableLegacyIds = new Set();
+    this._durableLegacy = new Map();
     this.lastShadowWriteOk = null;
     this.lastShadowError = null;
     this.writerId = options.writerId || globalThis.crypto?.randomUUID?.() || `writer-${Math.random().toString(16).slice(2)}`;
@@ -1637,24 +1744,32 @@ export class ChatHistoryStore {
     const threads = Array.isArray(snapshot?.threads) ? snapshot.threads : [];
     if (stored === null) {
       // Unreachable. Keep whatever the shadow gave us and prove nothing durable.
-      this._durableLegacyIds = new Set();
+      this._durableLegacy = new Map();
       return snapshot;
     }
-    this._durableLegacyIds = new Set(
-      stored.map((thread) => thread?.id).filter((id) => typeof id === "string" && id),
+    this._durableLegacy = new Map(
+      stored
+        .filter((thread) => thread && typeof thread.id === "string" && thread.id)
+        .map((thread) => [thread.id, legacyFingerprint(thread)]),
     );
     // The stored copy is additive: a thread the shadow already lost to a byte
     // eviction comes back here, which is the whole point of giving it a home.
     const known = new Set(threads.map((thread) => thread?.id).filter(Boolean));
+    // A tombstoned thread must NOT come back (codex P1). The delete-from-store pass
+    // in persist() is the durable half; this is the half that holds even when that
+    // write has not landed yet — an unreachable store must not resurrect a delete.
+    const tombstoned = new Set(Object.keys(snapshot?.meta?.deletedThreads || {}));
     const restored = stored
       .filter((thread) => thread && typeof thread.id === "string" && !known.has(thread.id))
+      .filter((thread) => !tombstoned.has(thread.id))
       .map((thread) => ({ ...thread, legacyShadow: true }));
     // Anything flagged in the shadow but not yet durable gets its home now.
     const pending = threads.filter(
-      (thread) => thread?.legacyShadow === true && thread?.id && !this._durableLegacyIds.has(thread.id),
+      (thread) => thread?.legacyShadow === true && thread?.id
+        && this._durableLegacy.get(thread.id) !== legacyFingerprint(thread),
     );
     if (pending.length && await idbWriteLegacy(this.indexedDb, pending)) {
-      for (const thread of pending) this._durableLegacyIds.add(thread.id);
+      for (const thread of pending) this._durableLegacy.set(thread.id, legacyFingerprint(thread));
     }
     if (!restored.length) return snapshot;
     const all = [...threads, ...restored].sort(
@@ -1683,7 +1798,8 @@ export class ChatHistoryStore {
       .sort((a, b) => finiteTs(a.updatedAt || a.ts) - finiteTs(b.updatedAt || b.ts));
     // #861 — the byte bound. Everything here is a CACHE of something durable except
     // legacy threads, which are durable only once the legacy store has accepted
-    // them. `_durableLegacyIds` is that receipt, and it is the entire licence to
+    // them. `_durableLegacy` is that receipt (id -> content fingerprint), and it is
+    // the entire licence to
     // evict: with no receipt the set is empty, nothing legacy is evictable, and the
     // shadow keeps today's unbounded behaviour rather than deleting an only copy.
     const evictableIds = new Set();
@@ -1695,7 +1811,9 @@ export class ChatHistoryStore {
       for (const thread of boundedOrdinary) if (thread?.id) evictableIds.add(thread.id);
     }
     for (const thread of legacyThreads) {
-      if (thread?.id && this._durableLegacyIds?.has(thread.id)) evictableIds.add(thread.id);
+      if (thread?.id && this._durableLegacy?.get(thread.id) === legacyFingerprint(thread)) {
+        evictableIds.add(thread.id);
+      }
     }
     const bounded = boundShadowBytes(
       { ...snapshot, threads: shadow },
@@ -1714,7 +1832,7 @@ export class ChatHistoryStore {
     // `result.ok` stays false, `_dirtyWrite` is retained, and every later persist
     // fires onPersistenceError forever against a state that can never fit.
     const legacyComplete = legacyThreads.every((thread) =>
-      shadowById.has(thread.id) || this._durableLegacyIds?.has(thread.id));
+      shadowById.has(thread.id) || this._durableLegacy?.get(thread.id) === legacyFingerprint(thread));
     try {
       this.storage?.setItem(this.snapshotKey, bounded.serialized);
       this.lastShadowWriteOk = true;
@@ -1780,14 +1898,41 @@ export class ChatHistoryStore {
       .then(async (merged) => {
         const legacy = (Array.isArray(merged?.threads) ? merged.threads : snapshot.threads || [])
           .filter((thread) => thread?.legacyShadow === true && thread?.id);
-        const undurable = legacy.filter((thread) => !this._durableLegacyIds.has(thread.id));
-        if (undurable.length) {
+        // Fingerprint, not id (codex P1): an EDITED legacy thread must be rewritten,
+        // or the shadow would evict the new version against a receipt for the old.
+        const stale = legacy.filter(
+          (thread) => this._durableLegacy.get(thread.id) !== legacyFingerprint(thread),
+        );
+        if (stale.length) {
           try {
-            if (await idbWriteLegacy(this.indexedDb, undurable)) {
-              for (const thread of undurable) this._durableLegacyIds.add(thread.id);
+            if (await idbWriteLegacy(this.indexedDb, stale)) {
+              for (const thread of stale) this._durableLegacy.set(thread.id, legacyFingerprint(thread));
             }
           } catch {
             // Unreachable legacy store: nothing becomes evictable. Fail closed.
+          }
+        }
+        // A DELETED legacy thread must LEAVE the store, or the next load hands it
+        // straight back (codex P1). Driven by the tombstone map, never by 'absent
+        // from the snapshot' — absent is also exactly what a byte eviction looks
+        // like, and deleting on that would erase the threads this store exists to
+        // keep.
+        // BOTH sides. Canonical compaction can prune a tombstone whose thread is
+        // already gone from canonical — verified: the merged snapshot came back with
+        // an empty deletedThreads while the write that carried the delete still had
+        // it. Reading only the merged copy would leave the durable record behind and
+        // the next load would hand the deleted transcript back.
+        const tombstoned = [...new Set([
+          ...Object.keys(merged?.meta?.deletedThreads || {}),
+          ...Object.keys(snapshot?.meta?.deletedThreads || {}),
+        ])].filter((id) => this._durableLegacy.has(id));
+        if (tombstoned.length) {
+          try {
+            if (await idbDeleteLegacy(this.indexedDb, tombstoned)) {
+              for (const id of tombstoned) this._durableLegacy.delete(id);
+            }
+          } catch {
+            // Still tombstoned in meta, so still filtered from view; retried next persist.
           }
         }
         return merged;
@@ -1869,6 +2014,22 @@ export class ChatHistoryStore {
         this._observeSnapshot(canonical);
         return createHistoryResetSnapshot(canonical, this.nextRevision());
       }))
+      // #861 (codex P1) — clearAll is the user saying DELETE EVERYTHING, so the
+      // legacy store has to go too. Without this the reset leaves those records
+      // behind and `_restoreLegacyShadow` hands every cleared transcript back on the
+      // next load: a delete that undoes itself, which is worse than one that fails
+      // loudly. Before the reset, so a clear that cannot reach the store does not
+      // report success over transcripts it left standing.
+      .then(async (reset) => {
+        if (reset) {
+          try {
+            if (await idbClearLegacy(this.indexedDb)) this._durableLegacy = new Map();
+          } catch {
+            // Reported through the reset result below; the tombstones still hide them.
+          }
+        }
+        return reset;
+      })
       .then((reset) => {
         if (!reset) {
           return {


### PR DESCRIPTION
Works #861. **Not ready to merge** — codex still has two open findings (below). Left as a draft deliberately.

## The defect

`_writeLocalSnapshot` bounded ordinary threads to 20×200 and then appended every `legacyShadow` thread **in full — every message, forever** — to a localStorage key in a ~5MB budget the panel does not own. localStorage is per-**origin** and the panel shares `http://localhost:8188` with ComfyUI, so those bytes are bytes ComfyUI's own `saveDraft()` cannot have. Past a point: **"Failed to save workflow draft"**, `Comfy.Workflow.DraftIndex.v2` stops persisting, and **every open workflow tab is lost on browser restart** — with a clean backend log and nothing pointing at the panel.

Capping it would have been *deleting transcripts*: the schema-3 fence excludes these threads from IndexedDB, so the shadow was their only copy. So the fix has to go the other way round.

## What's here

1. **A `legacy` object store** — not canonical, nothing merges it, so it reopens none of the fence's reasoning. Migrated on every canonical read, one record per thread, idempotent.
2. **Then a byte bound.** Count limits could never hold this: 20×200 is a count, and one transcript of pasted workflow JSON outweighs hundreds of short ones.
3. **Fail closed throughout.** Eviction requires a receipt — a *content digest* (64-bit FNV-1a over the serialized thread), earned only by a **completed** transaction. Ordinary threads are gated the same way on the canonical write landing.
4. **Deletes that stay deleted.** Tombstone-driven (never "absent from the snapshot" — that's also what an eviction looks like), retried until they land via a durable intent marker, and `clearAll` empties the store and *reports* it if it couldn't.

Two structural findings along the way:

- **The IndexedDB version WAS the record schema number.** Bumping it to add a store would have made every stored `schemaVersion: 3` snapshot fail `>= CHAT_HISTORY_SCHEMA` and read as **un-fenced** — reopening the pre-v3 merge path on every existing install, as a side effect of a structural migration. Now separate constants.
- **First version bump ever**, which is when multiple tabs stop being free. Connections now close on `versionchange` instead of making the second ComfyUI tab wait out the open timeout and report IndexedDB unavailable for a database that is merely busy.

## Review history — five codex rounds, all of them productive

| round | finding | state |
|---|---|---|
| r1 | id receipt ≠ content receipt: an edited thread evicted against a stale copy | fixed |
| r1 | records put and restored but never deleted; `clearAll` unaudited | fixed |
| r2 | fingerprint collides (`"foo"`→`"bar"`, same length/stamp/count) | fixed — real digest |
| r2 | live-id guard read `merged.threads`, which never contains legacy threads → guarded nothing | fixed |
| r2 | failed delete left to a *capped* tombstone that ages out | fixed — durable intent |
| r2 | `clearAll` reported success after a failed legacy clear | fixed |
| r3 | retry intent was in-memory, lost on reload | fixed — marker in the store |
| r4 | whole-list marker write loses cross-tab updates | fixed — atomic read-modify-write |
| r4 | reserved key protected by name only | partially — writer refuses new collisions |
| r5 | writer returned `true` on an empty list; `new Set(true)` throws in the **uncaught** restore path | fixed |
| **r5** | **write-after-delete race across separate transactions** | **OPEN** |
| **r5** | **a database that ALREADY holds a transcript at the reserved key** | **OPEN** |

Two of those were bugs my own tests for earlier findings turned up: a receipt granted for a thread the writer had filtered out, and a delete gated on a receipt a freshly-opened tab hasn't loaded yet.

## Why it isn't merged

I attempted both open findings — a two-store transaction so the legacy write can see the pending-delete marker, and relocating the marker into `snapshots` where thread ids cannot reach it. That broke two unrelated chat-history tests. **A half-landed cross-store change to persisted user data is worse than a bounded one**, so I reverted it rather than push through, and kept only the self-contained contract fix.

Next iteration: land the marker relocation and the cross-store write guard properly, with the two broken tests understood rather than worked around.

## Verification so far

- **3274 unit tests pass**, including 37 new ones against a fake IndexedDB that exercises the durable path rather than the null-IDB fallback.
- Every new assertion mutation-verified — failing open, ignoring protected ids, evicting newest-first, granting a receipt on an aborted transaction, treating an unreachable store as empty, dropping the quarantine flag, skipping the durable write, reusing the schema number as the DB version, whole-list marker overwrite, and the `true`/`[]` contract each make a test fail.
- Not yet browser-verified end to end; that comes after the two open findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)