### PR TITLE
0.11.57 — the panel stops eating ComfyUI's storage (#861)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,30 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+## [0.11.57] - 2026-08-09
+
+> Covers changes since 0.11.56.
+
+### Fixed
+
+- **The panel no longer eats the storage ComfyUI needs for your workflow tabs
+  (#861).** Chat history kept every pre-v3 transcript in `localStorage` in full,
+  forever. That budget belongs to the whole origin, not to the panel, so past a
+  point ComfyUI itself could not save workflow drafts — "Failed to save workflow
+  draft", and every open workflow tab gone on the next browser restart, with
+  nothing in any log pointing at the panel.
+
+  Those transcripts had nowhere else to live, which is why they were never
+  trimmed: capping them would have been deleting them. They now have a durable
+  home of their own, and only then is the local copy bounded — by size, since one
+  transcript full of pasted JSON outweighs hundreds of short ones. Nothing is
+  dropped that is not safely stored elsewhere first: if the durable copy cannot be
+  written, nothing is trimmed at all.
+
+  Deleting a chat now removes it for good, including from the new store, and a
+  delete that fails is retried rather than quietly forgotten.
+
+
 ## [0.11.56] - 2026-08-09
 
 > Covers changes since 0.11.55.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-agent-panel"
 description = "Autonomous AI agent in the ComfyUI sidebar - local-first, bring any LLM. Run it on your Claude or ChatGPT subscription (no API keys, no extra LLM costs), on a Kimi K3 / GLM / OpenRouter key, or fully offline on free local models via Ollama, LM Studio, or llama.cpp. The agent drives your live canvas at full parity: add, wire, move and tweak nodes with Ctrl+Z undo, load whole workflows and installer packs in one shot, generate images, video and audio, browse CivitAI, and run your workflow - asking before it spends paid API credits. The sidebar UI for comfyui-mcp, the local-first, agent-native control plane for ComfyUI."
-version = "0.11.56"
+version = "0.11.57"
 license = { file = "LICENSE" }
 requires-python = ">=3.9"
 # UI-only pack: no Python deps. The frontend floor guarantees

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -875,7 +875,7 @@ const DOCS_URL = "https://comfyui-mcp.artokun.io/docs";
 // Panel version — surfaced in the "Need help?" diagnostics blob. Bump via
 // `node scripts/set-version.mjs <v>` (updates this AND pyproject together); CI
 // and the publish gate FAIL if the two ever drift, so this can't go stale.
-const PANEL_VERSION = "0.11.56";
+const PANEL_VERSION = "0.11.57";
 
 // The connected orchestrator's console URL/token (captured off the `backends`
 // bridge message — see onBackends). Drives the "API Keys" credentials frame;


### PR DESCRIPTION
Releases the single fix merged since 0.11.56.

## What ships

**#861** (#865) — chat history kept every pre-v3 (`legacyShadow`) transcript in `localStorage` in full, every message, forever. That budget is per-**origin** and the panel shares `http://localhost:8188` with ComfyUI, so past a point ComfyUI's own `saveDraft()` began failing: **"Failed to save workflow draft"**, `Comfy.Workflow.DraftIndex.v2` unable to persist, and **every open workflow tab lost on browser restart** — with a clean backend log and nothing pointing at the panel.

The retention wasn't careless: the schema-3 fence kept those threads out of IndexedDB, so `localStorage` was their only copy and capping it would have been deleting transcripts. So the fix goes the other way — a durable home first (a store nothing merges, so the fence's reasoning doesn't apply), *then* a byte bound, failing closed at every step.

Two structural finds:
- **The IndexedDB version WAS the record schema number.** Bumping it to add a store would have made every stored `schemaVersion: 3` snapshot read as **un-fenced** — reopening the pre-v3 merge path on every existing install, as a side effect of a structural migration.
- **First version bump the panel has ever shipped**, which is when multiple tabs stop being free. Connections now yield on `versionchange` instead of making a second ComfyUI tab report IndexedDB unavailable for a database that is merely busy.

## Verification

**Live upgrade path**, against a database seeded at v3 with the old shape and a pre-existing transcript:

| | result |
|---|---|
| DB version | 3 → **4** |
| stores | `snapshots` → **`snapshots` + `legacy`** |
| pre-existing transcript | **survived** |
| `schemaVersion` on canonical | **still 3** — the fence stays closed |
| panel snapshot in localStorage | 387KB, under the 1.5MB cap, 39% of origin |
| console | no errors |

That fourth row is the one that mattered most: it's the decoupling holding on real data.

- 3281 unit tests pass, including 44 new against a keyed fake IndexedDB exercising the durable path.
- Serial e2e: 14/15, the one failure being the known #847 residual, unchanged by this.
- **Codex: SHIP**, after seven review rounds.

## Codex review, seven rounds

Every round found something real. Recorded because the list is the argument for the shape of the fix:

| round | finding |
|---|---|
| r1 | an id receipt is not a content receipt — an edited thread evicted against a stale copy |
| r1 | records stored and restored but never deleted; `clearAll` unaudited |
| r2 | fingerprint collided (`"foo"`→`"bar"`: same length, stamp, count) |
| r2 | live-id guard read a set that by design never contains legacy threads |
| r2 | a failed delete left to a *capped* tombstone that ages out |
| r2 | `clearAll` reported success after a failed legacy clear |
| r3 | retry intent in-memory only, lost on reload |
| r4 | whole-list marker write lost cross-tab updates |
| r4 | reserved key protected by name only |
| r5 | writer returned `true` on an empty list — `new Set(true)` throws, in an uncaught path |
| r5 | write-after-delete race across transactions |
| r6 | a landed delete erased its own intent, leaving a post-removal window |
| r7 | a first-pass success never recorded intent, leaving a pre-delete interval |

Along the way I tested one of my own assumptions — that the canonical tombstone fences a stale writer — and it turned out **false**, for an instructive reason: a legacy thread is never *in* canonical, so compaction prunes a tombstone pointing at no thread. That's why the delete marker had to become a real fence.

## Changelog note

Hand-written — `scripts/gen-changelog.mjs` walks back to the last git **tag**, so it regenerated 157 commits already shipped in 0.11.47–0.11.56.

🤖 Generated with [Claude Code](https://claude.com/claude-code)