### PR TITLE
fix(e2e): the agent-drive append-on-scroll race (#847)

### DIFF
--- a/browser_tests/agent-drive.spec.ts
+++ b/browser_tests/agent-drive.spec.ts
@@ -73,9 +73,28 @@ async function stubCivitai(page: import('@playwright/test').Page, pages: Record<
     call += 1
     route.fulfill({ json: body })
   })
-  // Media proxy — a 1px PNG is enough for <img>/<video> src.
+  // Media proxy. This must be a DECODABLE image, not just the PNG signature.
+  //
+  // #847 — it used to be `Buffer.from([0x89, 0x50, 0x4e, 0x47])`, four bytes that
+  // look like a PNG header and are not a PNG. Chrome fails to decode it and fires
+  // `error` on the <img>, and the card's own handler responds by hiding itself:
+  //
+  //     img.addEventListener("error", () => { card.style.display = "none" })
+  //
+  // …which is correct product behaviour (a broken thumbnail should not leave a dead
+  // tile in the grid) and made every card in this file disappear a moment after it
+  // rendered. Assertions RACED that error event: `toBeVisible()` won often enough
+  // that the specs mostly passed, and `append-on-scroll` — which waits for a second
+  // page before asserting — lost about one run in three. The card was in the DOM
+  // with the right class the whole time; it was `display: none`.
+  //
+  // A real 1x1 PNG decodes, so no card hides and nothing is racing.
+  const ONE_PIXEL_PNG = Buffer.from(
+    'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==',
+    'base64'
+  )
   await page.route('**/comfyui_mcp_panel/civitai/media*', (route) =>
-    route.fulfill({ body: Buffer.from([0x89, 0x50, 0x4e, 0x47]), contentType: 'image/png' })
+    route.fulfill({ body: ONE_PIXEL_PNG, contentType: 'image/png' })
   )
   // Signed-out OAuth status so the favorites tab / account button stay inert.
   await page.route('**/comfyui_mcp_panel/civitai/oauth/status', (route) =>

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -34,7 +34,21 @@ export default defineConfig({
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
-  workers: process.env.CI ? 1 : undefined,
+  // #847 — BOUND, not `undefined`. Playwright's default is roughly half the cores,
+  // which on a 16-worker machine puts sixteen browsers through ONE ComfyUI and one
+  // origin's storage. Measured on the same suite, same machine, back to back:
+  //
+  //     16 workers (the default here) ...  3 of 49 passed, 2.1 min
+  //      2 workers ....................... 48 of 49 passed, 2.1 min
+  //
+  // The parallelism costs 45 specs and buys no wall-clock at all — the run is
+  // bounded by ComfyUI, not by the browsers. Worse, it cost the suite its meaning:
+  // anyone running `npm run test:e2e` locally met a wall of red and learned to
+  // ignore it, which is how a genuine regression gets waved through.
+  //
+  // Two rather than one because the difference is not measurable here and a single
+  // worker has no headroom if a spec hangs. 4 was also tried: 2-4 specs fail.
+  workers: process.env.CI ? 1 : 2,
   reporter: 'html',
   timeout: 30_000,
   expect: { timeout: 10_000 },


### PR DESCRIPTION
Works #847 — the second of its two surviving failures.

## Measured, not assumed

`agent-drive.spec.ts:124` ("append-on-scroll re-applies the highlight to a card from a LATER page") fails **about one run in three at `--workers=1`**:

| run | result |
|---|---|
| 1 | 1 failed, 9 passed |
| 2 | 10 passed |
| 3 | 10 passed |

So unlike the rest of #847 — which turned out to be parallel-load artefacts on this machine — this one is a real race.

## Why it's worth fixing rather than tolerating

A spec that fails a third of the time is worse than one that fails always: it teaches everyone to re-run rather than read. That is precisely how a genuine regression gets waved through, and the binding-wedge cluster (#607/#688/#689/#702) is the class of bug an e2e suite exists to catch.

## Approach

Find out whether the race is in the spec (scrolling before the grid is ready to load more) or in the panel's `loadMore`/`appendItems` path, and fix whichever it actually is. I'll say which before changing anything — a flaky test papered over with a longer timeout is still flaky, just slower.

🤖 Generated with [Claude Code](https://claude.com/claude-code)