### PR TITLE
fix(binding): a display-only node flag is not a different graph (#696)

### DIFF
--- a/browser_tests/unit/open-node-difference.test.mjs
+++ b/browser_tests/unit/open-node-difference.test.mjs
@@ -257,9 +257,20 @@ test("a re-measured graph says nothing was lost, and drops the data-loss framing
     contentSurfaces: ["nodes"],
     contentNodeDifference: { comparable: true, sameNodeSet: true, cosmeticOnly: true, fields: ["size"] },
   });
-  assert.match(msg, /nothing was lost/i);
+  // #696 (codex) — the claim is narrower than it was, and the assertion follows it.
+  // The old wording promised "the only difference is presentation, which the ComfyUI
+  // frontend recomputes on load"; the frontend does NOT recompute a node's colour,
+  // and colour is in the cosmetic set, so that was false whenever one differed. What
+  // the comparison actually proves is same nodes, same values, same links.
+  assert.match(msg, /no node and no value is missing/i);
+  assert.match(msg, /same widget values and links/i);
   assert.match(msg, /no missing work to redo/i);
-  assert.match(msg, /size/);
+  assert.match(msg, /size/, "the differing fields are named so a reader can judge for themselves");
+  assert.doesNotMatch(
+    msg,
+    /frontend recomputes on load/i,
+    "the panel must not claim a recompute it cannot know happened",
+  );
   assert.doesNotMatch(
     msg,
     /the load only\s+partly applied/i,
@@ -276,7 +287,10 @@ test("a MISSING node keeps the full warning and says the set itself differs", ()
   });
   assert.match(msg, /the node SET itself differs/);
   assert.match(msg, /partly applied/i, "a real content loss must keep the unresolved wording");
-  assert.doesNotMatch(msg, /nothing was lost/i);
+  // Pin the CURRENT reassurance, not a phrase the code no longer uses — a negative
+  // assertion against dead wording passes for free and guards nothing.
+  assert.doesNotMatch(msg, /no node and no value is missing/i);
+  assert.doesNotMatch(msg, /no missing work to redo/i);
 });
 
 test("a widget-value difference is same-set but gets no reassurance", () => {
@@ -499,4 +513,58 @@ test("showAdvanced alongside a REAL change is still not cosmetic", () => {
   });
   assert.deepEqual(out.fields, ["showAdvanced", "widgets_values"]);
   assert.equal(out.cosmeticOnly, false);
+});
+
+test("showAdvanced is trusted only when it is a BOOLEAN", () => {
+  // codex — a field NAME is not a contract. `showAdvanced` is a boolean display
+  // toggle in the packs that prompted this, but the classifier sees every node type
+  // there will ever be, and a pack storing real state under that name would
+  // otherwise collect an all-clear it never earned. A boolean cannot carry a lost
+  // widget value; anything richer is unknown and fails closed.
+  const node = (v) => ({ id: 1, type: "T", widgets_values: ["a"], showAdvanced: v });
+  const classify = (a, b) =>
+    classifyNodeDifference({ expectedNodes: [node(a)], actualNodes: [node(b)] });
+
+  assert.equal(classify(false, true).cosmeticOnly, true, "boolean toggle is cosmetic");
+
+  for (const [a, b, why] of [
+    [{ lora_1: "x" }, { lora_1: "y" }, "an object could be real state"],
+    [["a"], ["b"], "so could an array"],
+    ["basic", "advanced", "and a string"],
+    [0, 1, "numbers are not the toggle this trusts"],
+    [false, { on: true }, "a mixed pair is still unknown on one side"],
+  ]) {
+    const out = classify(a, b);
+    assert.deepEqual(out.fields, ["showAdvanced"], why);
+    assert.equal(out.cosmeticOnly, false, why);
+  }
+});
+
+test("a guard failure still REPORTS the field, it just refuses the all-clear", () => {
+  // The caller needs to know what differed either way; the guard decides only
+  // whether the reassuring sentence may be used.
+  const node = (v) => ({ id: 1, type: "T", widgets_values: ["a"], showAdvanced: v });
+  const out = classifyNodeDifference({
+    expectedNodes: [node({ deep: 1 })],
+    actualNodes: [node({ deep: 2 })],
+  });
+  assert.deepEqual(out.fields, ["showAdvanced"]);
+  assert.equal(out.sameNodeSet, true);
+  assert.equal(out.cosmeticOnly, false);
+});
+
+test("the reassuring sentence claims only what was compared", () => {
+  // #696 (codex) — `color`/`bgcolor` are cosmetic AND user-authored, and the
+  // frontend does not recompute them, so the old "which the ComfyUI frontend
+  // recomputes on load" was false whenever a colour differed. What the comparison
+  // establishes is same nodes, same values, same links.
+  const msg = describeOpenRebindOutcome(CONTENT_ONLY, {
+    targetLabel: "origami.json",
+    contentComparable: true,
+    contentSurfaces: ["nodes"],
+    contentNodeDifference: { comparable: true, sameNodeSet: true, cosmeticOnly: true, fields: ["color"] },
+  });
+  assert.match(msg, /no node and no value is missing/i);
+  assert.match(msg, /color/, "the field is named rather than described as 'presentation'");
+  assert.doesNotMatch(msg, /recomputes on load/i);
 });

--- a/browser_tests/unit/open-node-difference.test.mjs
+++ b/browser_tests/unit/open-node-difference.test.mjs
@@ -262,7 +262,6 @@ test("a re-measured graph says nothing was lost, and drops the data-loss framing
   // frontend recomputes on load"; the frontend does NOT recompute a node's colour,
   // and colour is in the cosmetic set, so that was false whenever one differed. What
   // the comparison actually proves is same nodes, same values, same links.
-  assert.match(msg, /no node and no value is missing/i);
   assert.match(msg, /same widget values and links/i);
   assert.match(msg, /no missing work to redo/i);
   assert.match(msg, /size/, "the differing fields are named so a reader can judge for themselves");
@@ -289,7 +288,7 @@ test("a MISSING node keeps the full warning and says the set itself differs", ()
   assert.match(msg, /partly applied/i, "a real content loss must keep the unresolved wording");
   // Pin the CURRENT reassurance, not a phrase the code no longer uses — a negative
   // assertion against dead wording passes for free and guards nothing.
-  assert.doesNotMatch(msg, /no node and no value is missing/i);
+  assert.doesNotMatch(msg, /same widget values and links/i);
   assert.doesNotMatch(msg, /no missing work to redo/i);
 });
 
@@ -446,42 +445,74 @@ test("layout edge keys are injective — a delimiter collision cannot drop an ed
   assert.ok(col.get("b|c") > col.get("a"), "edge a -> b|c must survive dedup");
 });
 
-// ── #696: a display-only flag is not lost content ──────────────────────────
+// ── #696: an unrecognised field must not read as lost work ────────────────
 
-test("the reporter's trio — order + size + showAdvanced — is cosmetic", () => {
-  // The 0.11.50 regression on #696: `panel_open_workflow` reported a mismatch on a
-  // flat workflow that differed only in these three, with every node id and type
-  // present. Two were already cosmetic; `showAdvanced` alone was enough to send a
-  // healthy open down the "the panel cannot tell whether the load only partly
-  // applied" path, which reads as possible data loss.
-  const node = (over) => ({
-    id: 1, type: "ImpactWildcardEncode", pos: [10, 20], size: [300, 100],
-    flags: {}, order: 0, mode: 0, inputs: [], outputs: [],
-    properties: {}, widgets_values: ["a", "b"], showAdvanced: false, ...over,
+test("the reporter's trio still reassures, WITHOUT the panel guessing what a field means", () => {
+  // The 0.11.50 regression: `panel_open_workflow` reported a mismatch on a flat
+  // workflow differing only in `order`, `showAdvanced`, and `size`, every node id
+  // and type present. `showAdvanced` is not on the cosmetic allowlist and — per
+  // codex — must not be: a field NAME is not a contract, a boolean IS a value, and
+  // this classifier sees every node type there will ever be.
+  //
+  // So the fix is not to bless the name. The node SET is what was actually proven,
+  // and that is what the headline rests on now.
+  const msg = describeOpenRebindOutcome(CONTENT_ONLY, {
+    targetLabel: "origami.json",
+    contentComparable: true,
+    contentSurfaces: ["nodes"],
+    contentNodeDifference: {
+      comparable: true,
+      sameNodeSet: true,
+      cosmeticOnly: false,
+      fields: ["order", "showAdvanced", "size"],
+    },
   });
-  const out = classifyNodeDifference({
-    expectedNodes: [node({})],
-    actualNodes: [node({ order: 2, size: [310, 120], showAdvanced: true })],
+  assert.match(msg, /no node was lost/i, "the set was compared; say so");
+  assert.match(msg, /showAdvanced/, "and name what differed so the reader can judge");
+  assert.doesNotMatch(
+    msg,
+    /the load only\s+partly applied/i,
+    "an intact node set must not read as possible data loss",
+  );
+});
+
+test("an unrecognised field does NOT earn the values claim", () => {
+  // The reassurance is tiered. An intact set gets "no node was lost"; only a
+  // cosmetic-only difference additionally gets "same widget values and links",
+  // because those fields are off the allowlist and therefore known to have matched.
+  const msg = describeOpenRebindOutcome(CONTENT_ONLY, {
+    targetLabel: "origami.json",
+    contentComparable: true,
+    contentSurfaces: ["nodes"],
+    contentNodeDifference: {
+      comparable: true, sameNodeSet: true, cosmeticOnly: false, fields: ["showAdvanced"],
+    },
   });
-  assert.equal(out.comparable, true);
-  assert.equal(out.sameNodeSet, true);
-  assert.deepEqual(out.fields, ["order", "showAdvanced", "size"]);
-  assert.equal(out.cosmeticOnly, true, "a display toggle cannot mean a node or a value was lost");
+  assert.doesNotMatch(msg, /same widget values and links/i);
+  assert.doesNotMatch(msg, /no missing work to redo/i, "unknown fields cannot promise that");
+});
+
+test("showAdvanced is NOT on the cosmetic allowlist", () => {
+  // Pinned as a decision, not an oversight: adding it would have the panel assert a
+  // meaning it cannot know for an arbitrary node pack.
+  const node = (v) => ({ id: 1, type: "T", widgets_values: ["a"], showAdvanced: v });
+  const out = classifyNodeDifference({ expectedNodes: [node(false)], actualNodes: [node(true)] });
+  assert.deepEqual(out.fields, ["showAdvanced"]);
+  assert.equal(out.sameNodeSet, true, "the set is still intact, which is what carries the reassurance");
+  assert.equal(out.cosmeticOnly, false, "a field name is not a contract");
 });
 
 test("the rule's boundary: fields that CAN mean lost content stay non-cosmetic", () => {
-  // The point of stating a rule rather than keeping a list. Each of these fails the
-  // test "a difference here is compatible with 'nothing was lost'".
   const node = (over) => ({
     id: 1, type: "T", pos: [0, 0], size: [10, 10], flags: {}, order: 0, mode: 0,
     inputs: [], outputs: [], properties: {}, widgets_values: ["a"], title: "mine", ...over,
   });
   for (const [field, changed] of [
     ["widgets_values", { widgets_values: ["CHANGED"] }],
-    ["mode", { mode: 4 }],                    // bypass — changes what executes
-    ["title", { title: "renamed" }],          // authored, and losing it IS loss
-    ["properties", { properties: { k: 1 } }], // pack-specific; unknowable from here
-    ["inputs", { inputs: [{ name: "x" }] }],  // links
+    ["mode", { mode: 4 }],
+    ["title", { title: "renamed" }],
+    ["properties", { properties: { k: 1 } }],
+    ["inputs", { inputs: [{ name: "x" }] }],
   ]) {
     const out = classifyNodeDifference({ expectedNodes: [node({})], actualNodes: [node(changed)] });
     assert.deepEqual(out.fields, [field], `expected only ${field} to differ`);
@@ -489,82 +520,18 @@ test("the rule's boundary: fields that CAN mean lost content stay non-cosmetic",
   }
 });
 
-test("an UNKNOWN field is not cosmetic — the set stays a denylist", () => {
-  // A pack the panel has never seen makes the disclosure cautious rather than
-  // confidently wrong. Inverting to an allowlist would make every unfamiliar field
-  // cosmetic, i.e. claim "nothing was lost" about a surface never heard of.
-  const node = (over) => ({ id: 1, type: "T", widgets_values: ["a"], ...over });
-  const out = classifyNodeDifference({
-    expectedNodes: [node({ someFuturePackFlag: 1 })],
-    actualNodes: [node({ someFuturePackFlag: 2 })],
-  });
-  assert.equal(out.cosmeticOnly, false);
-});
-
-test("showAdvanced alongside a REAL change is still not cosmetic", () => {
-  // Widening the set must not let a genuine difference ride along with a display
-  // toggle — the all-clear is per-difference-set, not per-field.
-  const node = (over) => ({
-    id: 1, type: "T", widgets_values: ["a"], showAdvanced: false, ...over,
-  });
-  const out = classifyNodeDifference({
-    expectedNodes: [node({})],
-    actualNodes: [node({ showAdvanced: true, widgets_values: ["CHANGED"] })],
-  });
-  assert.deepEqual(out.fields, ["showAdvanced", "widgets_values"]);
-  assert.equal(out.cosmeticOnly, false);
-});
-
-test("showAdvanced is trusted only when it is a BOOLEAN", () => {
-  // codex — a field NAME is not a contract. `showAdvanced` is a boolean display
-  // toggle in the packs that prompted this, but the classifier sees every node type
-  // there will ever be, and a pack storing real state under that name would
-  // otherwise collect an all-clear it never earned. A boolean cannot carry a lost
-  // widget value; anything richer is unknown and fails closed.
-  const node = (v) => ({ id: 1, type: "T", widgets_values: ["a"], showAdvanced: v });
-  const classify = (a, b) =>
-    classifyNodeDifference({ expectedNodes: [node(a)], actualNodes: [node(b)] });
-
-  assert.equal(classify(false, true).cosmeticOnly, true, "boolean toggle is cosmetic");
-
-  for (const [a, b, why] of [
-    [{ lora_1: "x" }, { lora_1: "y" }, "an object could be real state"],
-    [["a"], ["b"], "so could an array"],
-    ["basic", "advanced", "and a string"],
-    [0, 1, "numbers are not the toggle this trusts"],
-    [false, { on: true }, "a mixed pair is still unknown on one side"],
-  ]) {
-    const out = classify(a, b);
-    assert.deepEqual(out.fields, ["showAdvanced"], why);
-    assert.equal(out.cosmeticOnly, false, why);
-  }
-});
-
-test("a guard failure still REPORTS the field, it just refuses the all-clear", () => {
-  // The caller needs to know what differed either way; the guard decides only
-  // whether the reassuring sentence may be used.
-  const node = (v) => ({ id: 1, type: "T", widgets_values: ["a"], showAdvanced: v });
-  const out = classifyNodeDifference({
-    expectedNodes: [node({ deep: 1 })],
-    actualNodes: [node({ deep: 2 })],
-  });
-  assert.deepEqual(out.fields, ["showAdvanced"]);
-  assert.equal(out.sameNodeSet, true);
-  assert.equal(out.cosmeticOnly, false);
-});
-
-test("the reassuring sentence claims only what was compared", () => {
-  // #696 (codex) — `color`/`bgcolor` are cosmetic AND user-authored, and the
-  // frontend does not recompute them, so the old "which the ComfyUI frontend
-  // recomputes on load" was false whenever a colour differed. What the comparison
-  // establishes is same nodes, same values, same links.
+test("a cosmetic-only difference still earns the stronger, narrower claim", () => {
+  // And it claims only what the comparison establishes. `color`/`bgcolor` are
+  // cosmetic AND user-authored, so "no value is missing" would overclaim; "same
+  // widget values and links" is what the allowlist actually proves.
   const msg = describeOpenRebindOutcome(CONTENT_ONLY, {
     targetLabel: "origami.json",
     contentComparable: true,
     contentSurfaces: ["nodes"],
     contentNodeDifference: { comparable: true, sameNodeSet: true, cosmeticOnly: true, fields: ["color"] },
   });
-  assert.match(msg, /no node and no value is missing/i);
-  assert.match(msg, /color/, "the field is named rather than described as 'presentation'");
-  assert.doesNotMatch(msg, /recomputes on load/i);
+  assert.match(msg, /same widget values and links/i);
+  assert.match(msg, /color/, "the field is named rather than described only as 'presentation'");
+  assert.doesNotMatch(msg, /recomputes on load/i, "the frontend does not recompute a colour");
+  assert.doesNotMatch(msg, /no value is missing/i, "colour IS a value, and it differed");
 });

--- a/browser_tests/unit/open-node-difference.test.mjs
+++ b/browser_tests/unit/open-node-difference.test.mjs
@@ -535,3 +535,47 @@ test("a cosmetic-only difference still earns the stronger, narrower claim", () =
   assert.doesNotMatch(msg, /recomputes on load/i, "the frontend does not recompute a colour");
   assert.doesNotMatch(msg, /no value is missing/i, "colour IS a value, and it differed");
 });
+
+test("codex r3's duplicate-identity case fails closed, so the set claim holds", () => {
+  // The reassurance now rests on `sameNodeSet` alone, so it matters that the set
+  // comparison cannot be fooled by repeated identities. Codex's exact example:
+  //
+  //   expected: [1,A] [1,A] [2,B]      actual: [1,A] [2,B] [2,B]
+  //
+  // Both SETS are {[1,A],[2,B]} while an A was lost and a B appeared. Comparing
+  // sets rather than multiplicities would call that intact.
+  //
+  // It does not, and the guard predates this change: `byKey` refuses a duplicate
+  // identity outright ("cannot pair them up honestly"), which yields
+  // `comparable: false` — and `nodeSetIntact` requires `comparable === true`, so
+  // the cautious message stands.
+  const n = (id, type) => ({ id, type, widgets_values: ["v"] });
+  const out = classifyNodeDifference({
+    expectedNodes: [n(1, "A"), n(1, "A"), n(2, "B")],
+    actualNodes: [n(1, "A"), n(2, "B"), n(2, "B")],
+  });
+  assert.equal(out.comparable, false, "duplicate identities are not comparable");
+  assert.equal(out.sameNodeSet, false, "…so no set claim is made either");
+
+  // And the message that consumes it stays on the cautious path.
+  const msg = describeOpenRebindOutcome(CONTENT_ONLY, {
+    targetLabel: "origami.json",
+    contentComparable: true,
+    contentSurfaces: ["nodes"],
+    contentNodeDifference: out,
+  });
+  assert.doesNotMatch(msg, /no node was lost/i);
+  assert.match(msg, /partly applied/i);
+});
+
+test("a duplicate on EITHER side alone is enough to refuse the comparison", () => {
+  const n = (id, type) => ({ id, type });
+  for (const [expectedNodes, actualNodes] of [
+    [[n(1, "A"), n(1, "A")], [n(1, "A")]],
+    [[n(1, "A")], [n(1, "A"), n(1, "A")]],
+  ]) {
+    const out = classifyNodeDifference({ expectedNodes, actualNodes });
+    assert.equal(out.comparable, false);
+    assert.equal(out.sameNodeSet, false);
+  }
+});

--- a/browser_tests/unit/open-node-difference.test.mjs
+++ b/browser_tests/unit/open-node-difference.test.mjs
@@ -431,3 +431,72 @@ test("layout edge keys are injective — a delimiter collision cannot drop an ed
   assert.ok(col.get("c") > col.get("a|b"), "edge a|b -> c must order them");
   assert.ok(col.get("b|c") > col.get("a"), "edge a -> b|c must survive dedup");
 });
+
+// ── #696: a display-only flag is not lost content ──────────────────────────
+
+test("the reporter's trio — order + size + showAdvanced — is cosmetic", () => {
+  // The 0.11.50 regression on #696: `panel_open_workflow` reported a mismatch on a
+  // flat workflow that differed only in these three, with every node id and type
+  // present. Two were already cosmetic; `showAdvanced` alone was enough to send a
+  // healthy open down the "the panel cannot tell whether the load only partly
+  // applied" path, which reads as possible data loss.
+  const node = (over) => ({
+    id: 1, type: "ImpactWildcardEncode", pos: [10, 20], size: [300, 100],
+    flags: {}, order: 0, mode: 0, inputs: [], outputs: [],
+    properties: {}, widgets_values: ["a", "b"], showAdvanced: false, ...over,
+  });
+  const out = classifyNodeDifference({
+    expectedNodes: [node({})],
+    actualNodes: [node({ order: 2, size: [310, 120], showAdvanced: true })],
+  });
+  assert.equal(out.comparable, true);
+  assert.equal(out.sameNodeSet, true);
+  assert.deepEqual(out.fields, ["order", "showAdvanced", "size"]);
+  assert.equal(out.cosmeticOnly, true, "a display toggle cannot mean a node or a value was lost");
+});
+
+test("the rule's boundary: fields that CAN mean lost content stay non-cosmetic", () => {
+  // The point of stating a rule rather than keeping a list. Each of these fails the
+  // test "a difference here is compatible with 'nothing was lost'".
+  const node = (over) => ({
+    id: 1, type: "T", pos: [0, 0], size: [10, 10], flags: {}, order: 0, mode: 0,
+    inputs: [], outputs: [], properties: {}, widgets_values: ["a"], title: "mine", ...over,
+  });
+  for (const [field, changed] of [
+    ["widgets_values", { widgets_values: ["CHANGED"] }],
+    ["mode", { mode: 4 }],                    // bypass — changes what executes
+    ["title", { title: "renamed" }],          // authored, and losing it IS loss
+    ["properties", { properties: { k: 1 } }], // pack-specific; unknowable from here
+    ["inputs", { inputs: [{ name: "x" }] }],  // links
+  ]) {
+    const out = classifyNodeDifference({ expectedNodes: [node({})], actualNodes: [node(changed)] });
+    assert.deepEqual(out.fields, [field], `expected only ${field} to differ`);
+    assert.equal(out.cosmeticOnly, false, `${field} must not be treated as cosmetic`);
+  }
+});
+
+test("an UNKNOWN field is not cosmetic — the set stays a denylist", () => {
+  // A pack the panel has never seen makes the disclosure cautious rather than
+  // confidently wrong. Inverting to an allowlist would make every unfamiliar field
+  // cosmetic, i.e. claim "nothing was lost" about a surface never heard of.
+  const node = (over) => ({ id: 1, type: "T", widgets_values: ["a"], ...over });
+  const out = classifyNodeDifference({
+    expectedNodes: [node({ someFuturePackFlag: 1 })],
+    actualNodes: [node({ someFuturePackFlag: 2 })],
+  });
+  assert.equal(out.cosmeticOnly, false);
+});
+
+test("showAdvanced alongside a REAL change is still not cosmetic", () => {
+  // Widening the set must not let a genuine difference ride along with a display
+  // toggle — the all-clear is per-difference-set, not per-field.
+  const node = (over) => ({
+    id: 1, type: "T", widgets_values: ["a"], showAdvanced: false, ...over,
+  });
+  const out = classifyNodeDifference({
+    expectedNodes: [node({})],
+    actualNodes: [node({ showAdvanced: true, widgets_values: ["CHANGED"] })],
+  });
+  assert.deepEqual(out.fields, ["showAdvanced", "widgets_values"]);
+  assert.equal(out.cosmeticOnly, false);
+});

--- a/web/js/lib/graph-binding.js
+++ b/web/js/lib/graph-binding.js
@@ -507,20 +507,19 @@ function graphShape(state) {
  * By that test:
  *   size, pos     the frontend re-measures and re-places on load
  *   order         recomputed topologically, never authored directly
- *   color/bgcolor authored, and a difference here IS an authoring difference — but
- *                 not a lost node and not a lost value. See the note below: the
- *                 sentence downstream is worded to claim only that.
- *   showAdvanced  a display toggle. VALUE-GATED (codex): trusted only when both
- *                 sides are booleans, because the classifier knows field names and
- *                 not node packs — anything richer under that name could be real
- *                 state, and claiming otherwise would fabricate the all-clear.
+ *   color/bgcolor authored, and a difference IS an authoring difference — but not a
+ *                 lost node and not a lost widget value, which is all the sentence
+ *                 downstream now claims.
  *
- * `color`/`bgcolor` were already here before this rule was written down, and writing
- * it down exposed that the sentence they licensed overclaimed: the frontend does NOT
- * recompute a node's colour, so "the only difference is presentation, which the
- * frontend recomputes" was false whenever one differed. Rather than drop them —
- * a colour difference genuinely is not lost work — the claim was narrowed to what
- * the comparison actually establishes.
+ * `showAdvanced` was added here for #696 and then REMOVED again (codex). The
+ * argument for it was that a display toggle cannot carry a lost value; the argument
+ * against is simply that a boolean IS a value, and this classifier sees every node
+ * type there will ever be. A pack can legitimately serialize meaningful state under
+ * that name, and nothing here can tell the two apart — a field name is not a
+ * contract, and a value-shape guard only re-states the name's promise in another
+ * form. #696 is fixed instead by not needing the question answered: see
+ * `nodeSetIntact` below, where the reassurance that actually matters rests on the
+ * node SET, which is proven, rather than on guessing what a field means.
  *
  * DENYLIST, deliberately, and it must stay one. An unknown field reads as
  * non-cosmetic, so a pack the panel has never seen makes the disclosure cautious —
@@ -529,29 +528,8 @@ function graphShape(state) {
  * about a surface it has never heard of. That is the fabricated all-clear this whole
  * module exists to avoid, and it is worth more than the noise.
  */
-const COSMETIC_NODE_FIELDS = new Set([
-  "size",
-  "pos",
-  "order",
-  "color",
-  "bgcolor",
-  "showAdvanced",
-]);
+const COSMETIC_NODE_FIELDS = new Set(["size", "pos", "order", "color", "bgcolor"]);
 
-/**
- * Extra proof a named field must supply before it counts as cosmetic (#696, codex).
- *
- * A field name is not a contract. `showAdvanced` is a boolean display toggle in the
- * packs that prompted this, but the classifier sees every node type there will ever
- * be, and a pack storing real state under that name would otherwise collect an
- * all-clear it never earned. A boolean cannot carry a lost widget value; anything
- * else under that name is unknown, so it fails closed and the cautious sentence
- * stands.
- */
-const COSMETIC_FIELD_VALUE_GUARDS = {
-  showAdvanced: (a, b) =>
-    (a === undefined || typeof a === "boolean") && (b === undefined || typeof b === "boolean"),
-};
 
 /** The node's identity for set comparison: what makes it THIS node rather than
  *  another one. Type included, because an id reused for a different type is a
@@ -622,10 +600,7 @@ export function classifyNodeDifference({ expectedNodes, actualNodes } = {}) {
     // is the worst possible failure here.
     const has = (node, field) => Object.prototype.hasOwnProperty.call(node, field);
     const fields = new Set();
-    // Fields whose NAME is cosmetic but whose VALUES failed the guard for it. Kept
-    // separate so the classifier still reports the field as differing (the caller
-    // needs that) while refusing to count it as cosmetic (codex).
-    const guardFailed = new Set();
+
     for (const [key, expectedNode] of expected) {
       const actualNode = actual.get(key);
       const keys = new Set([...Object.keys(expectedNode), ...Object.keys(actualNode)]);
@@ -636,20 +611,14 @@ export function classifyNodeDifference({ expectedNodes, actualNodes } = {}) {
         }
         const a = JSON.stringify(canonicalizeShapeValue(expectedNode[field]));
         const b = JSON.stringify(canonicalizeShapeValue(actualNode[field]));
-        if (a !== b) {
-          fields.add(field);
-          const guard = COSMETIC_FIELD_VALUE_GUARDS[field];
-          if (guard && !guard(expectedNode[field], actualNode[field])) guardFailed.add(field);
-        }
+        if (a !== b) fields.add(field);
       }
     }
     const list = [...fields].sort();
     return {
       comparable: true,
       sameNodeSet: true,
-      cosmeticOnly:
-        list.length > 0 &&
-        list.every((field) => COSMETIC_NODE_FIELDS.has(field) && !guardFailed.has(field)),
+      cosmeticOnly: list.length > 0 && list.every((field) => COSMETIC_NODE_FIELDS.has(field)),
       fields: list,
     };
   } catch {
@@ -1248,28 +1217,58 @@ export function describeOpenRebindOutcome(verdict, observed = {}) {
     // it falls back to the honest "cannot tell".
     const nodesOnly =
       (observed.contentSurfaces ?? []).length === 1 && (observed.contentSurfaces ?? [])[0] === "nodes";
+    // #696 — this used to also require `cosmeticOnly`, i.e. that every differing
+    // field be on an allowlist of names. That made the reassurance hostage to
+    // guessing what a field MEANS: one unrecognised display flag from any node pack
+    // (`showAdvanced` was the reported one) sent a perfectly healthy open down the
+    // "the load may only have partly applied" path. Chasing it by extending the
+    // allowlist just moves the problem to the next pack, and a value-shape guard only
+    // restates the name's promise in another form (codex).
+    //
+    // The node SET is what the panel actually PROVED: every node that was loaded is
+    // on the canvas with the same id and type, and nothing extra appeared. That is
+    // worth saying on its own, whatever fields differ — so it is what the headline
+    // now rests on, with the differing fields NAMED so the reader judges the rest.
     const nodeSetIntact =
       observed.contentNodeDifference?.comparable === true &&
-      observed.contentNodeDifference?.sameNodeSet === true &&
-      observed.contentNodeDifference?.cosmeticOnly === true;
+      observed.contentNodeDifference?.sameNodeSet === true;
+    const valuesMatched = observed.contentNodeDifference?.cosmeticOnly === true;
     if (compared && nodesOnly && nodeSetIntact) {
-      // #696 (codex) — claim only what the comparison ESTABLISHES, and name the
-      // fields. The old wording said the difference was "presentation, which the
-      // ComfyUI frontend recomputes on load"; `color`/`bgcolor` are in the cosmetic
-      // set and the frontend does NOT recompute those, so that sentence was false
-      // whenever a colour differed. What the comparison really proves is narrower
-      // and still exactly what the reader needs: same nodes, same values, same
-      // links. Naming the fields also lets a reader judge for themselves rather
-      // than trusting the word "presentation".
-      const differing = (observed.contentNodeDifference?.fields ?? []).join(", ");
-      const which = differing ? ` (${differing})` : "";
+      // Two claims, and only the ones the comparison supports (codex). The node set
+      // is proven in both branches. `cosmeticOnly` additionally establishes that the
+      // fields carrying VALUES — `widgets_values`, `inputs` — matched, because those
+      // are not on the cosmetic allowlist; it does NOT establish "no value is
+      // missing" in general, since `color`/`bgcolor` are authored values that may
+      // legitimately differ. So say the narrow thing.
+      // The differing fields are NOT named here: `because` already names them, in
+      // almost these words. An earlier cut added them to the headline too and a
+      // mutation test caught the duplication by refusing to fail — the assertion
+      // could not tell the addition from the clause that was already there. The
+      // headline states the conclusion; `because` carries the detail.
+      // Each branch is its OWN sentence. An earlier cut shared a `which the panel
+      // cannot call byte-identical` tail between them, which read fine after the
+      // cosmetic clause and attached to the wrong phrase after the other one
+      // ("...or the load applied them differently, which the panel cannot call
+      // byte-identical"). Sharing a tail across two different claims is how wording
+      // drifts away from meaning.
+      const head =
+        `workflow_open RAN, the canvas IS bound to ${workflow}, and every node that was loaded ` +
+        `is on it with the same id and type`;
+      if (valuesMatched) {
+        return (
+          `${head}, carrying the same widget values and links. What differs is per-node ` +
+          `presentation only, which the panel cannot call byte-identical, so the content ` +
+          `is reported UNCONFIRMED rather than failed.${because} You are on the right workflow ` +
+          `and there is no missing work to redo; if you need the exact graph, read it with ` +
+          `panel_graph_outline.`
+        );
+      }
       return (
-        `workflow_open RAN, the canvas IS bound to ${workflow}, and every node that was loaded is on ` +
-        `it with the same id and type, carrying the same widget values and links — no node and no ` +
-        `value is missing. What differs is per-node presentation only${which}, which the panel cannot ` +
-        `call byte-identical, so the content is reported UNCONFIRMED rather than failed.${because} ` +
-        `You are on the right workflow and there is no missing work to redo; if you need the exact ` +
-        `graph, read it with panel_graph_outline.`
+        `${head}, and nothing extra appeared — no node was lost. What differs is ` +
+        `per-node fields; the panel cannot tell from here whether the ComfyUI frontend ` +
+        `normalized those or the load applied them differently, so the content is reported ` +
+        `UNCONFIRMED rather than failed.${because} You are on the right workflow; if you need ` +
+        `the exact graph, read it with panel_graph_outline.`
       );
     }
     return (

--- a/web/js/lib/graph-binding.js
+++ b/web/js/lib/graph-binding.js
@@ -507,10 +507,20 @@ function graphShape(state) {
  * By that test:
  *   size, pos     the frontend re-measures and re-places on load
  *   order         recomputed topologically, never authored directly
- *   color/bgcolor authored, but a difference cannot hide a missing node or value
- *   showAdvanced  a display toggle: it changes which widgets are VISIBLE, never
- *                 their values, which stay in `widgets_values` and are compared
- *                 separately
+ *   color/bgcolor authored, and a difference here IS an authoring difference — but
+ *                 not a lost node and not a lost value. See the note below: the
+ *                 sentence downstream is worded to claim only that.
+ *   showAdvanced  a display toggle. VALUE-GATED (codex): trusted only when both
+ *                 sides are booleans, because the classifier knows field names and
+ *                 not node packs — anything richer under that name could be real
+ *                 state, and claiming otherwise would fabricate the all-clear.
+ *
+ * `color`/`bgcolor` were already here before this rule was written down, and writing
+ * it down exposed that the sentence they licensed overclaimed: the frontend does NOT
+ * recompute a node's colour, so "the only difference is presentation, which the
+ * frontend recomputes" was false whenever one differed. Rather than drop them —
+ * a colour difference genuinely is not lost work — the claim was narrowed to what
+ * the comparison actually establishes.
  *
  * DENYLIST, deliberately, and it must stay one. An unknown field reads as
  * non-cosmetic, so a pack the panel has never seen makes the disclosure cautious —
@@ -527,6 +537,21 @@ const COSMETIC_NODE_FIELDS = new Set([
   "bgcolor",
   "showAdvanced",
 ]);
+
+/**
+ * Extra proof a named field must supply before it counts as cosmetic (#696, codex).
+ *
+ * A field name is not a contract. `showAdvanced` is a boolean display toggle in the
+ * packs that prompted this, but the classifier sees every node type there will ever
+ * be, and a pack storing real state under that name would otherwise collect an
+ * all-clear it never earned. A boolean cannot carry a lost widget value; anything
+ * else under that name is unknown, so it fails closed and the cautious sentence
+ * stands.
+ */
+const COSMETIC_FIELD_VALUE_GUARDS = {
+  showAdvanced: (a, b) =>
+    (a === undefined || typeof a === "boolean") && (b === undefined || typeof b === "boolean"),
+};
 
 /** The node's identity for set comparison: what makes it THIS node rather than
  *  another one. Type included, because an id reused for a different type is a
@@ -597,6 +622,10 @@ export function classifyNodeDifference({ expectedNodes, actualNodes } = {}) {
     // is the worst possible failure here.
     const has = (node, field) => Object.prototype.hasOwnProperty.call(node, field);
     const fields = new Set();
+    // Fields whose NAME is cosmetic but whose VALUES failed the guard for it. Kept
+    // separate so the classifier still reports the field as differing (the caller
+    // needs that) while refusing to count it as cosmetic (codex).
+    const guardFailed = new Set();
     for (const [key, expectedNode] of expected) {
       const actualNode = actual.get(key);
       const keys = new Set([...Object.keys(expectedNode), ...Object.keys(actualNode)]);
@@ -607,14 +636,20 @@ export function classifyNodeDifference({ expectedNodes, actualNodes } = {}) {
         }
         const a = JSON.stringify(canonicalizeShapeValue(expectedNode[field]));
         const b = JSON.stringify(canonicalizeShapeValue(actualNode[field]));
-        if (a !== b) fields.add(field);
+        if (a !== b) {
+          fields.add(field);
+          const guard = COSMETIC_FIELD_VALUE_GUARDS[field];
+          if (guard && !guard(expectedNode[field], actualNode[field])) guardFailed.add(field);
+        }
       }
     }
     const list = [...fields].sort();
     return {
       comparable: true,
       sameNodeSet: true,
-      cosmeticOnly: list.length > 0 && list.every((field) => COSMETIC_NODE_FIELDS.has(field)),
+      cosmeticOnly:
+        list.length > 0 &&
+        list.every((field) => COSMETIC_NODE_FIELDS.has(field) && !guardFailed.has(field)),
       fields: list,
     };
   } catch {
@@ -1106,10 +1141,14 @@ function nodeSurfaceClause(observed = {}) {
     // conclusion is the headline's to draw, and only when `nodes` is the sole
     // surface that differed — a group or a link lost alongside the re-measured
     // boxes is work the node set cannot vouch for.
+    // #696 (codex) — no claim about WHO changed these. "which the ComfyUI frontend
+    // recomputes on load" was true of size/pos/order and false of `color`/`bgcolor`,
+    // which are in the same cosmetic set and are authored by the user, not
+    // recomputed by anything. Naming the fields says more than the guess did, and
+    // says only what was observed.
     return (
       ` — but every node that was loaded IS on the canvas with the same id and type, and nothing ` +
-      `extra appeared, so NO node was lost. What differs is per-node presentation (${fields}), ` +
-      `which the ComfyUI frontend recomputes on load`
+      `extra appeared, so NO node was lost. What differs is per-node presentation (${fields})`
     );
   }
   return (
@@ -1214,11 +1253,21 @@ export function describeOpenRebindOutcome(verdict, observed = {}) {
       observed.contentNodeDifference?.sameNodeSet === true &&
       observed.contentNodeDifference?.cosmeticOnly === true;
     if (compared && nodesOnly && nodeSetIntact) {
+      // #696 (codex) — claim only what the comparison ESTABLISHES, and name the
+      // fields. The old wording said the difference was "presentation, which the
+      // ComfyUI frontend recomputes on load"; `color`/`bgcolor` are in the cosmetic
+      // set and the frontend does NOT recompute those, so that sentence was false
+      // whenever a colour differed. What the comparison really proves is narrower
+      // and still exactly what the reader needs: same nodes, same values, same
+      // links. Naming the fields also lets a reader judge for themselves rather
+      // than trusting the word "presentation".
+      const differing = (observed.contentNodeDifference?.fields ?? []).join(", ");
+      const which = differing ? ` (${differing})` : "";
       return (
         `workflow_open RAN, the canvas IS bound to ${workflow}, and every node that was loaded is on ` +
-        `it with the same id and type — nothing was lost. The only difference is per-node ` +
-        `presentation, which the ComfyUI frontend recomputes on load, so the panel cannot call the ` +
-        `repaint byte-identical and reports the content as UNCONFIRMED rather than failed.${because} ` +
+        `it with the same id and type, carrying the same widget values and links — no node and no ` +
+        `value is missing. What differs is per-node presentation only${which}, which the panel cannot ` +
+        `call byte-identical, so the content is reported UNCONFIRMED rather than failed.${because} ` +
         `You are on the right workflow and there is no missing work to redo; if you need the exact ` +
         `graph, read it with panel_graph_outline.`
       );

--- a/web/js/lib/graph-binding.js
+++ b/web/js/lib/graph-binding.js
@@ -494,7 +494,39 @@ function graphShape(state) {
  *  - `flags` — not just `collapsed`: `graph_edit_node` persists `pinned` here too.
  *  - `mode` — bypass/mute is execution semantics.
  */
-const COSMETIC_NODE_FIELDS = new Set(["size", "pos", "order", "color", "bgcolor"]);
+/**
+ * Node fields whose difference cannot mean AUTHORED CONTENT WAS LOST (#696).
+ *
+ * The rule, because a bare list grows by whoever filed last. `cosmeticOnly` licenses
+ * exactly one sentence downstream — "every node that was loaded is on it with the
+ * same id and type, nothing was lost" — so a field belongs here only when a
+ * difference in it is compatible with that sentence being TRUE. Not "does not affect
+ * execution": a node `title` does not affect execution either, and a title that
+ * changed IS lost authoring, so it stays out.
+ *
+ * By that test:
+ *   size, pos     the frontend re-measures and re-places on load
+ *   order         recomputed topologically, never authored directly
+ *   color/bgcolor authored, but a difference cannot hide a missing node or value
+ *   showAdvanced  a display toggle: it changes which widgets are VISIBLE, never
+ *                 their values, which stay in `widgets_values` and are compared
+ *                 separately
+ *
+ * DENYLIST, deliberately, and it must stay one. An unknown field reads as
+ * non-cosmetic, so a pack the panel has never seen makes the disclosure cautious —
+ * noisy, and safe. Inverting to an allowlist of execution-relevant fields would make
+ * every unknown field cosmetic, i.e. the panel would tell a user "nothing was lost"
+ * about a surface it has never heard of. That is the fabricated all-clear this whole
+ * module exists to avoid, and it is worth more than the noise.
+ */
+const COSMETIC_NODE_FIELDS = new Set([
+  "size",
+  "pos",
+  "order",
+  "color",
+  "bgcolor",
+  "showAdvanced",
+]);
 
 /** The node's identity for set comparison: what makes it THIS node rather than
  *  another one. Type included, because an id reused for a different type is a


### PR DESCRIPTION
Works #696 — the regression reported on panel 0.11.50.

## The report

> `panel_open_workflow` again reported a graph mismatch when a flat workflow differed only in `order`, `showAdvanced`, and `size`, with all node ids/types present.

Two of those three are already handled:

```js
const COSMETIC_NODE_FIELDS = new Set(["size", "pos", "order", "color", "bgcolor"]);
```

`showAdvanced` is not. So a single display toggle is enough to make an ordinary, correct canvas read as a foreign one — which is the inference #825 narrowed and this issue exists to stop.

## Approach

Not just adding `showAdvanced`. The next node pack will carry its own display flag and the report will come back, so the question is what actually belongs in that set and on what basis: a field is cosmetic when changing it cannot change what the graph *executes*. I'd like the rule to be statable, not a growing list of names people hit.

Investigating where `showAdvanced` comes from, whether it can affect execution, and whether the classification should key on something more durable than an allowlist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)