### PR TITLE
0.11.58 — reopening a workflow stops reading as lost work (#696)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,31 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+## [0.11.58] - 2026-08-09
+
+> Covers changes since 0.11.57.
+
+### Fixed
+
+- **Reopening a workflow no longer reads as though work went missing (#696).** When
+  the canvas came back with an unfamiliar per-node field — a display toggle like
+  `showAdvanced` from rgthree or Impact, alongside the usual re-measured sizes —
+  `panel_open_workflow` said it could not tell whether "the load only partly
+  applied", which sent people hunting for work to redo that was never gone.
+
+  The panel had been deciding this by checking every differing field against a list
+  of names it considered harmless, so one flag it had never seen was enough. It now
+  reports what it actually proved: every node that was loaded is on the canvas with
+  the same id and type, so no node was lost — whatever fields differ, and without
+  needing to know what any of them mean. A difference confined to sizes, positions
+  and colours still gets the stronger answer, that the widget values and links
+  matched too.
+
+  Also stopped claiming the difference was something "the ComfyUI frontend
+  recomputes on load". Node colours are on that same list and nothing recomputes
+  them, so that was untrue whenever a colour differed.
+
+
 ## [0.11.57] - 2026-08-09
 
 > Covers changes since 0.11.56.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-agent-panel"
 description = "Autonomous AI agent in the ComfyUI sidebar - local-first, bring any LLM. Run it on your Claude or ChatGPT subscription (no API keys, no extra LLM costs), on a Kimi K3 / GLM / OpenRouter key, or fully offline on free local models via Ollama, LM Studio, or llama.cpp. The agent drives your live canvas at full parity: add, wire, move and tweak nodes with Ctrl+Z undo, load whole workflows and installer packs in one shot, generate images, video and audio, browse CivitAI, and run your workflow - asking before it spends paid API credits. The sidebar UI for comfyui-mcp, the local-first, agent-native control plane for ComfyUI."
-version = "0.11.57"
+version = "0.11.58"
 license = { file = "LICENSE" }
 requires-python = ">=3.9"
 # UI-only pack: no Python deps. The frontend floor guarantees

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -875,7 +875,7 @@ const DOCS_URL = "https://comfyui-mcp.artokun.io/docs";
 // Panel version — surfaced in the "Need help?" diagnostics blob. Bump via
 // `node scripts/set-version.mjs <v>` (updates this AND pyproject together); CI
 // and the publish gate FAIL if the two ever drift, so this can't go stale.
-const PANEL_VERSION = "0.11.57";
+const PANEL_VERSION = "0.11.58";
 
 // The connected orchestrator's console URL/token (captured off the `backends`
 // bridge message — see onBackends). Drives the "API Keys" credentials frame;


### PR DESCRIPTION
Releases the single fix merged since 0.11.57.

## What ships

**#696** (#870) — the regression reported on 0.11.50: `panel_open_workflow` reported a mismatch on a workflow differing only in `order`, `showAdvanced`, and `size`, every node id and type present. The user was told the panel "cannot tell whether the ComfyUI frontend merely normalized it or the load only partly applied" — i.e. sent looking for work to redo that was never gone.

The reassurance had been gated on `cosmeticOnly`: every differing field had to appear on an allowlist of names. One unrecognised display flag defeated it.

**The fix is to stop needing the question answered.** The reassurance now rests on `sameNodeSet` — which the panel actually *proved* — so an intact node set reports "no node was lost" whatever fields differ, and it works for the next pack's flag without anyone filing again. `cosmeticOnly` still gates the stronger claim ("carrying the same widget values and links"), which is supported because those fields are off the allowlist and so are known to have matched.

## Verification

- 3288 unit tests pass.
- **In the live browser, against the served module**, the reporter's exact trio: `sameNodeSet: true`, `cosmeticOnly: false`, message says "no node was lost", does **not** say "partly applied", and names `showAdvanced`.
- Panel mounts clean; e2e 47/49 (the two failures are the known #847 residual and an unrelated intermittent spec that passes 7/7 in isolation).
- **Codex: SHIP**, after three rounds.

## Codex review, three rounds — the approach changed twice

| round | finding |
|---|---|
| r1 | `color`/`bgcolor` are user-authored, so "nothing was lost; only presentation differs" was false whenever a colour differed — and my new rule comment reaffirmed it without testing it |
| r1 | `showAdvanced` trusted globally by name; any pack could serialize real state under it |
| r2 | my value-shape guard proved nothing — **a boolean IS a value**, so "a boolean cannot carry a lost widget value" was simply false |
| r2 | "no value is missing" still overclaimed; "same widget values and links" is what's supported |
| r3 | resting on `sameNodeSet` is only sound if `[id,type]` is unique — duplicates would collapse a set comparison |

r2 dissolved my approach rather than patching it: if a field name can't be trusted and its value shape can't either, then don't ask what fields mean — rest the claim on the node set, which is proven. r3 turned out to be already guarded (`byKey` refuses duplicate identities), but the property became load-bearing in a way it wasn't before, so it's now pinned by test including codex's exact counterexample.

**My own mutation suite also caught me**: I'd made the headline name the differing fields, but the `because` clause already named them in nearly the same words — the message repeated itself and `showAdvanced` appeared twice. The mutation refusing to fail was the signal that the addition was redundant.

## Changelog note

Hand-written — `scripts/gen-changelog.mjs` walks back to the last git **tag**, so it regenerated 160 commits already shipped in 0.11.47–0.11.57.

🤖 Generated with [Claude Code](https://claude.com/claude-code)