### PR TITLE
fix(history): repaint an open history pane after a save (#847, partial)

### DIFF
--- a/browser_tests/unit/thread-workflow-match.test.mjs
+++ b/browser_tests/unit/thread-workflow-match.test.mjs
@@ -4,6 +4,7 @@ import { readFileSync } from "node:fs";
 import {
   threadMatchesCurrentWorkflow,
   currentWorkflowIdentityKeys,
+  migratableRouteIds,
 } from "../../web/js/lib/thread-workflow-match.js";
 
 /**
@@ -267,7 +268,7 @@ test("WIRING #847: the save migration revises EVERY thread holding the old id", 
   // it was not active when the save landed.
   const src = readFileSync(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8");
   const site = src.slice(
-    src.indexOf("const priorRouteIds = new Set();"),
+    src.indexOf("const stillOpenRouteIds = (() => {"),
     src.indexOf("setActiveThread(\"panel:global\", thread.id);"),
   );
   assert.ok(site.length > 0, "the migration must live in the workflow-change path");
@@ -282,7 +283,7 @@ test("WIRING #847: the save migration revises EVERY thread holding the old id", 
   );
   // Both sources, because the WeakMap alone misses when ComfyUI replaces the
   // workflow object across the save — which is what it does.
-  assert.ok(site.includes("currentWorkflowId"), "the tracked id must be one source");
+  assert.ok(site.includes("candidateRouteIds: [currentWorkflowId"), "the tracked id must be one candidate");
   assert.ok(site.includes("_priorTempWorkflowIds.get(wf)"), "the WeakMap must be the other");
   // The active thread's own stamp follows too.
   assert.ok(site.includes("workflowRouteKey: workflowTabId()"), "the active thread must follow as well");
@@ -297,15 +298,100 @@ test("WIRING #847: a migration with no active thread is still persisted", () => 
   assert.ok(src.includes("if (migratedRouteStamp && !thread) persistThreads();"));
 });
 
-test("the sweep only fires on a real tmp: -> wf: migration", () => {
-  const src = readFileSync(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8");
-  const site = src.slice(
-    src.indexOf("const priorRouteIds = new Set();"),
-    src.indexOf("if (migratedRouteStamp && !thread)"),
+test("codex P0: a switch from unsaved A to saved B migrates NOTHING", () => {
+  // The blocker on the first cut. `tmp:` -> `wf:` is the shape of a first save AND of
+  // a switch from an unsaved workflow A to an already-saved workflow B. Reading the
+  // tracked id as "this tab's pre-save identity" rewrote every one of A's threads to
+  // B's path — permanently attributing one workflow's conversations to another, which
+  // is worse than the bug being fixed.
+  //
+  // A is still OPEN and still answers to `tmp:A`, so it is not this tab's past.
+  const out = migratableRouteIds({
+    newRouteId: "wf:workflows/B.json",
+    candidateRouteIds: ["tmp:A"],
+    openRouteIds: new Set(["tmp:A"]),
+  });
+  assert.deepEqual([...out], [], "A's threads must not follow the switch to B");
+});
+
+test("a genuine first save DOES migrate — the tmp: identity is consumed", () => {
+  // The other side, so the guard above cannot be satisfied by refusing everything.
+  const out = migratableRouteIds({
+    newRouteId: "wf:workflows/Saved.json",
+    candidateRouteIds: ["tmp:this-tab"],
+    openRouteIds: new Set(), // nothing answers to it any more
+  });
+  assert.deepEqual([...out], ["tmp:this-tab"]);
+});
+
+test("an unreadable open list migrates nothing — fail closed", () => {
+  // Migrating on a guess is exactly how the cross-attribution happens, and the
+  // in-memory match still covers the session.
+  for (const openRouteIds of [null, undefined, [], "nope", new Map()]) {
+    const out = migratableRouteIds({
+      newRouteId: "wf:workflows/Saved.json",
+      candidateRouteIds: ["tmp:this-tab"],
+      openRouteIds,
+    });
+    assert.deepEqual([...out], [], `openRouteIds ${String(openRouteIds)} must refuse`);
+  }
+});
+
+test("only a SAVE is a migration, and only an UNSAVED id can be migrated from", () => {
+  const open = new Set();
+  // Not a save: the new id is still unsaved.
+  assert.deepEqual(
+    [...migratableRouteIds({ newRouteId: "tmp:other", candidateRouteIds: ["tmp:a"], openRouteIds: open })],
+    [],
   );
-  assert.ok(site.includes('wfid.startsWith("wf:")'), "only when the tab is now SAVED");
-  assert.ok(site.includes('id.startsWith("tmp:")'), "only from an UNSAVED id");
-  assert.ok(site.includes("id !== wfid"), "and only when the id actually changed");
+  // A `wf:` candidate is a saved workflow's id, never a pre-save identity — a rename
+  // is a different event and must not be swept up here.
+  assert.deepEqual(
+    [...migratableRouteIds({
+      newRouteId: "wf:workflows/New.json",
+      candidateRouteIds: ["wf:workflows/Old.json"],
+      openRouteIds: open,
+    })],
+    [],
+  );
+  // And an id identical to the new one is a no-op, not a migration.
+  assert.deepEqual(
+    [...migratableRouteIds({
+      newRouteId: "wf:workflows/Same.json",
+      candidateRouteIds: ["wf:workflows/Same.json"],
+      openRouteIds: open,
+    })],
+    [],
+  );
+});
+
+test("junk candidates are ignored rather than migrated", () => {
+  const out = migratableRouteIds({
+    newRouteId: "wf:workflows/S.json",
+    candidateRouteIds: [null, undefined, "", 42, {}, "tmp:real"],
+    openRouteIds: new Set(),
+  });
+  assert.deepEqual([...out], ["tmp:real"]);
+});
+
+test("WIRING #847: the panel decides through that function, not its own copy", () => {
+  const src = readFileSync(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8");
+  const decl = src.match(/import\s*\{([^}]*)\}\s*from\s*"\.\/lib\/thread-workflow-match\.js";/);
+  assert.ok(decl, "the panel must import from the matcher module");
+  assert.ok(
+    decl[1].split(",").map((x) => x.trim()).includes("migratableRouteIds"),
+    "the decision must be bound, not reimplemented",
+  );
+  const site = src.slice(
+    src.indexOf("const stillOpenRouteIds = (() => {"),
+    src.indexOf("let migratedRouteStamp = false;"),
+  );
+  assert.ok(site.includes("migratableRouteIds({"), "…and called at the migration site");
+  assert.ok(site.includes("openRouteIds: stillOpenRouteIds"), "…with the OPEN set it computed");
+  assert.ok(
+    src.includes("if (!Array.isArray(open)) return null; // unknown — refuse to migrate"),
+    "an unreadable open list must produce null, which the function refuses on",
+  );
 });
 
 test("WIRING #847: an open history pane is repainted after a migration", () => {
@@ -333,7 +419,7 @@ test("WIRING #847: the tab's id lineage is recorded and consulted", () => {
   const src = readFileSync(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8");
   assert.ok(src.includes("const _routeIdLineage = new Map();"), "the lineage map must exist");
   const record = src.slice(
-    src.indexOf("const priorRouteIds = new Set();"),
+    src.indexOf("const priorRouteIds = migratableRouteIds({"),
     src.indexOf("let migratedRouteStamp = false;"),
   );
   assert.ok(record.includes("_routeIdLineage.set(wfid, held)"), "it must be recorded, keyed by the NEW id");

--- a/browser_tests/unit/thread-workflow-match.test.mjs
+++ b/browser_tests/unit/thread-workflow-match.test.mjs
@@ -228,75 +228,15 @@ test("a thread from ANOTHER workflow still does not match", () => {
   );
 });
 
-// ── #847: the route stamp must survive a reload, not just the session ──────
-
-test("workflowRouteKey is a REVISABLE thread field", async () => {
-  // It was write-once: stamped at thread creation and never again, which is why a
-  // first save left every thread on that workflow holding a `tmp:` id nothing
-  // answers to. Being revisable is what lets it travel the causal field-op path —
-  // revisions, tombstones, cross-tab merge — instead of being poked directly and
-  // losing to a stale tab's write.
-  const { ChatHistoryStore } = await import("../../web/js/lib/chat-history-store.js");
-  const store = new ChatHistoryStore({ storage: memoryStorage(), indexedDb: null });
-  const thread = {
-    id: "t1",
-    ts: 1,
-    updatedAt: 1,
-    msgs: [],
-    workflowKey: "workflow:old",
-    workflowRouteKey: "tmp:before-the-save",
-  };
-  store.reviseThread(thread, { workflowRouteKey: "wf:workflows/Saved.json" });
-  assert.equal(
-    thread.workflowRouteKey,
-    "wf:workflows/Saved.json",
-    "a revise must be able to carry the route stamp",
-  );
-});
-
-test("a route id long enough to hold a path is not truncated", () => {
-  // `wf:` ids carry a workflow PATH, so the cap has to match workflowKey's rather
-  // than a title-sized one — a silently trimmed id matches nothing at all.
-  const src = readFileSync(new URL("../../web/js/lib/chat-history-store.js", import.meta.url), "utf8");
-  const limits = src.slice(src.indexOf("const THREAD_STRING_LIMITS = {"), src.indexOf("const MAX_TODOS"));
-  assert.match(limits, /workflowRouteKey:\s*512/);
-});
-
-test("WIRING #847: the save migration revises EVERY thread holding the old id", () => {
-  // Revising only the active thread is what left the reported case broken: chat,
-  // save, start a new chat, filter — and the FIRST chat is the one missing, because
-  // it was not active when the save landed.
-  const src = readFileSync(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8");
-  const site = src.slice(
-    src.indexOf("const stillOpenRouteIds = (() => {"),
-    src.indexOf("setActiveThread(\"panel:global\", thread.id);"),
-  );
-  assert.ok(site.length > 0, "the migration must live in the workflow-change path");
-  assert.ok(site.includes("for (const candidate of threads)"), "it must sweep every thread");
-  assert.ok(
-    site.includes("!priorRouteIds.has(candidate?.workflowRouteKey)"),
-    "…matching on the PRE-SAVE ids, so it cannot touch another workflow's threads",
-  );
-  assert.ok(
-    site.includes("reviseThread(candidate, { workflowRouteKey: wfid })"),
-    "…and revise rather than assign, so it merges causally",
-  );
-  // Both sources, because the WeakMap alone misses when ComfyUI replaces the
-  // workflow object across the save — which is what it does.
-  assert.ok(site.includes("candidateRouteIds: [currentWorkflowId"), "the tracked id must be one candidate");
-  assert.ok(site.includes("_priorTempWorkflowIds.get(wf)"), "the WeakMap must be the other");
-  // The active thread's own stamp follows too.
-  assert.ok(site.includes("workflowRouteKey: workflowTabId()"), "the active thread must follow as well");
-});
-
-test("WIRING #847: a migration with no active thread is still persisted", () => {
-  // `persistThreads()` lives inside `if (thread)`, and the whole point of the sweep
-  // is the threads that are NOT active — on a save with the composer empty, that is
-  // all of them. Without this the migration happens in memory and dies on reload,
-  // which is the bug.
-  const src = readFileSync(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8");
-  assert.ok(src.includes("if (migratedRouteStamp && !thread) persistThreads();"));
-});
+// ── #847: the route stamp must survive a first SAVE within the session ────
+//
+// The durable half — rewriting the stamps on disk — is deliberately NOT here. It
+// needs positive proof that an old id was this tab's, and the panel does not have
+// it: `openWorkflows` not claiming an id is absence of a competing claimant, not
+// ownership (codex). Close A, switch to B, and A's conversations would migrate to
+// B permanently. Measured that the in-memory match fixes the reported case on its
+// own, so the persisted write buys nothing and risks the one thing this area must
+// never do.
 
 test("codex P0: a switch from unsaved A to saved B migrates NOTHING", () => {
   // The blocker on the first cut. `tmp:` -> `wf:` is the shape of a first save AND of
@@ -404,7 +344,7 @@ test("WIRING #847: an open history pane is repainted after a migration", () => {
   assert.ok(src.includes("let repaintHistoryList = null;"), "a module-level handle must exist");
   assert.ok(src.includes("repaintHistoryList = paintList;"), "the pane must publish its repaint");
   const site = src.slice(
-    src.indexOf("if (migratedRouteStamp && !thread) persistThreads();"),
+    src.indexOf("const migratedRouteStamp = priorRouteIds.size > 0;"),
     src.indexOf("      if (thread) {"),
   );
   assert.ok(site.includes("repaintHistoryList?.()"), "a migration must repaint an open pane");

--- a/browser_tests/unit/thread-workflow-match.test.mjs
+++ b/browser_tests/unit/thread-workflow-match.test.mjs
@@ -228,7 +228,7 @@ test("a thread from ANOTHER workflow still does not match", () => {
   );
 });
 
-// ── #847: the route stamp must survive a first SAVE within the session ────
+// ── #847: what a first SAVE does to history, and what the panel may infer ──
 //
 // The durable half — rewriting the stamps on disk — is deliberately NOT here. It
 // needs positive proof that an old id was this tab's, and the panel does not have
@@ -324,7 +324,7 @@ test("WIRING #847: the panel decides through that function, not its own copy", (
   );
   const site = src.slice(
     src.indexOf("const stillOpenRouteIds = (() => {"),
-    src.indexOf("let migratedRouteStamp = false;"),
+    src.indexOf("let savedThisTick = false;"),
   );
   assert.ok(site.includes("migratableRouteIds({"), "…and called at the migration site");
   assert.ok(site.includes("openRouteIds: stillOpenRouteIds"), "…with the OPEN set it computed");
@@ -344,31 +344,10 @@ test("WIRING #847: an open history pane is repainted after a migration", () => {
   assert.ok(src.includes("let repaintHistoryList = null;"), "a module-level handle must exist");
   assert.ok(src.includes("repaintHistoryList = paintList;"), "the pane must publish its repaint");
   const site = src.slice(
-    src.indexOf("const migratedRouteStamp = priorRouteIds.size > 0;"),
+    src.indexOf("const savedThisTick = priorRouteIds.size > 0;"),
     src.indexOf("      if (thread) {"),
   );
   assert.ok(site.includes("repaintHistoryList?.()"), "a migration must repaint an open pane");
   assert.ok(site.includes("try {") && site.includes("} catch {"), "and a stale handle must not break the poll");
 });
 
-test("WIRING #847: the tab's id lineage is recorded and consulted", () => {
-  // The durable rewrite lands on the poll. Until it does, the filter still has to
-  // be right — so the ids this tab used to carry are remembered under the id it has
-  // now, in a plain Map that survives the workflow OBJECT being replaced (which is
-  // what defeats `_priorTempWorkflowIds`).
-  const src = readFileSync(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8");
-  assert.ok(src.includes("const _routeIdLineage = new Map();"), "the lineage map must exist");
-  const record = src.slice(
-    src.indexOf("const priorRouteIds = migratableRouteIds({"),
-    src.indexOf("let migratedRouteStamp = false;"),
-  );
-  assert.ok(record.includes("_routeIdLineage.set(wfid, held)"), "it must be recorded, keyed by the NEW id");
-  const filter = src.slice(
-    src.indexOf("const liveRouteId = workflowTabId();"),
-    src.indexOf("threadMatchesCurrentWorkflow(candidate, currentWorkflowKeys)"),
-  );
-  assert.ok(
-    filter.includes("_routeIdLineage.get(liveRouteId)"),
-    "…and consulted by the filter, or it buys nothing",
-  );
-});

--- a/browser_tests/unit/thread-workflow-match.test.mjs
+++ b/browser_tests/unit/thread-workflow-match.test.mjs
@@ -267,19 +267,23 @@ test("WIRING #847: the save migration revises EVERY thread holding the old id", 
   // it was not active when the save landed.
   const src = readFileSync(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8");
   const site = src.slice(
-    src.indexOf("const priorRouteId = wf ? _priorTempWorkflowIds.get(wf) : null;"),
+    src.indexOf("const priorRouteIds = new Set();"),
     src.indexOf("setActiveThread(\"panel:global\", thread.id);"),
   );
   assert.ok(site.length > 0, "the migration must live in the workflow-change path");
   assert.ok(site.includes("for (const candidate of threads)"), "it must sweep every thread");
   assert.ok(
-    site.includes("candidate?.workflowRouteKey !== priorRouteId"),
-    "…matching on the PRE-SAVE id, so it cannot touch another workflow's threads",
+    site.includes("!priorRouteIds.has(candidate?.workflowRouteKey)"),
+    "…matching on the PRE-SAVE ids, so it cannot touch another workflow's threads",
   );
   assert.ok(
     site.includes("reviseThread(candidate, { workflowRouteKey: wfid })"),
     "…and revise rather than assign, so it merges causally",
   );
+  // Both sources, because the WeakMap alone misses when ComfyUI replaces the
+  // workflow object across the save — which is what it does.
+  assert.ok(site.includes("currentWorkflowId"), "the tracked id must be one source");
+  assert.ok(site.includes("_priorTempWorkflowIds.get(wf)"), "the WeakMap must be the other");
   // The active thread's own stamp follows too.
   assert.ok(site.includes("workflowRouteKey: workflowTabId()"), "the active thread must follow as well");
 });
@@ -296,9 +300,49 @@ test("WIRING #847: a migration with no active thread is still persisted", () => 
 test("the sweep only fires on a real tmp: -> wf: migration", () => {
   const src = readFileSync(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8");
   const site = src.slice(
-    src.indexOf("const priorRouteId = wf ? _priorTempWorkflowIds.get(wf) : null;"),
+    src.indexOf("const priorRouteIds = new Set();"),
     src.indexOf("if (migratedRouteStamp && !thread)"),
   );
   assert.ok(site.includes('wfid.startsWith("wf:")'), "only when the tab is now SAVED");
-  assert.ok(site.includes("priorRouteId !== wfid"), "and only when the id actually changed");
+  assert.ok(site.includes('id.startsWith("tmp:")'), "only from an UNSAVED id");
+  assert.ok(site.includes("id !== wfid"), "and only when the id actually changed");
+});
+
+test("WIRING #847: an open history pane is repainted after a migration", () => {
+  // The list paints once when the pane opens; the migration lands on the 600 ms
+  // workflow poll, and nothing else changes its rows. A pane opened just before a
+  // first save therefore showed the pre-migration answer and never corrected
+  // itself — which is why the spec stayed red through two otherwise-correct fixes,
+  // and why Playwright's auto-retry could not rescue it either.
+  const src = readFileSync(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8");
+  assert.ok(src.includes("let repaintHistoryList = null;"), "a module-level handle must exist");
+  assert.ok(src.includes("repaintHistoryList = paintList;"), "the pane must publish its repaint");
+  const site = src.slice(
+    src.indexOf("if (migratedRouteStamp && !thread) persistThreads();"),
+    src.indexOf("      if (thread) {"),
+  );
+  assert.ok(site.includes("repaintHistoryList?.()"), "a migration must repaint an open pane");
+  assert.ok(site.includes("try {") && site.includes("} catch {"), "and a stale handle must not break the poll");
+});
+
+test("WIRING #847: the tab's id lineage is recorded and consulted", () => {
+  // The durable rewrite lands on the poll. Until it does, the filter still has to
+  // be right — so the ids this tab used to carry are remembered under the id it has
+  // now, in a plain Map that survives the workflow OBJECT being replaced (which is
+  // what defeats `_priorTempWorkflowIds`).
+  const src = readFileSync(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8");
+  assert.ok(src.includes("const _routeIdLineage = new Map();"), "the lineage map must exist");
+  const record = src.slice(
+    src.indexOf("const priorRouteIds = new Set();"),
+    src.indexOf("let migratedRouteStamp = false;"),
+  );
+  assert.ok(record.includes("_routeIdLineage.set(wfid, held)"), "it must be recorded, keyed by the NEW id");
+  const filter = src.slice(
+    src.indexOf("const liveRouteId = workflowTabId();"),
+    src.indexOf("threadMatchesCurrentWorkflow(candidate, currentWorkflowKeys)"),
+  );
+  assert.ok(
+    filter.includes("_routeIdLineage.get(liveRouteId)"),
+    "…and consulted by the filter, or it buys nothing",
+  );
 });

--- a/browser_tests/unit/thread-workflow-match.test.mjs
+++ b/browser_tests/unit/thread-workflow-match.test.mjs
@@ -22,6 +22,16 @@ import {
 
 const keys = (...k) => new Set(k);
 
+/** A localStorage stand-in for the store tests below. */
+function memoryStorage() {
+  const map = new Map();
+  return {
+    getItem: (k) => (map.has(k) ? map.get(k) : null),
+    setItem: (k, v) => map.set(k, String(v)),
+    removeItem: (k) => map.delete(k),
+  };
+}
+
 test("the reporter's case: two threads, different uuids, same live canvas — both match", () => {
   const current = keys("workflow:uuid-B", "tmp:live-object-1");
   const older = { workflowKey: "workflow:uuid-A", workflowRouteKey: "tmp:live-object-1" };
@@ -215,4 +225,80 @@ test("a thread from ANOTHER workflow still does not match", () => {
     ),
     false,
   );
+});
+
+// ── #847: the route stamp must survive a reload, not just the session ──────
+
+test("workflowRouteKey is a REVISABLE thread field", async () => {
+  // It was write-once: stamped at thread creation and never again, which is why a
+  // first save left every thread on that workflow holding a `tmp:` id nothing
+  // answers to. Being revisable is what lets it travel the causal field-op path —
+  // revisions, tombstones, cross-tab merge — instead of being poked directly and
+  // losing to a stale tab's write.
+  const { ChatHistoryStore } = await import("../../web/js/lib/chat-history-store.js");
+  const store = new ChatHistoryStore({ storage: memoryStorage(), indexedDb: null });
+  const thread = {
+    id: "t1",
+    ts: 1,
+    updatedAt: 1,
+    msgs: [],
+    workflowKey: "workflow:old",
+    workflowRouteKey: "tmp:before-the-save",
+  };
+  store.reviseThread(thread, { workflowRouteKey: "wf:workflows/Saved.json" });
+  assert.equal(
+    thread.workflowRouteKey,
+    "wf:workflows/Saved.json",
+    "a revise must be able to carry the route stamp",
+  );
+});
+
+test("a route id long enough to hold a path is not truncated", () => {
+  // `wf:` ids carry a workflow PATH, so the cap has to match workflowKey's rather
+  // than a title-sized one — a silently trimmed id matches nothing at all.
+  const src = readFileSync(new URL("../../web/js/lib/chat-history-store.js", import.meta.url), "utf8");
+  const limits = src.slice(src.indexOf("const THREAD_STRING_LIMITS = {"), src.indexOf("const MAX_TODOS"));
+  assert.match(limits, /workflowRouteKey:\s*512/);
+});
+
+test("WIRING #847: the save migration revises EVERY thread holding the old id", () => {
+  // Revising only the active thread is what left the reported case broken: chat,
+  // save, start a new chat, filter — and the FIRST chat is the one missing, because
+  // it was not active when the save landed.
+  const src = readFileSync(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8");
+  const site = src.slice(
+    src.indexOf("const priorRouteId = wf ? _priorTempWorkflowIds.get(wf) : null;"),
+    src.indexOf("setActiveThread(\"panel:global\", thread.id);"),
+  );
+  assert.ok(site.length > 0, "the migration must live in the workflow-change path");
+  assert.ok(site.includes("for (const candidate of threads)"), "it must sweep every thread");
+  assert.ok(
+    site.includes("candidate?.workflowRouteKey !== priorRouteId"),
+    "…matching on the PRE-SAVE id, so it cannot touch another workflow's threads",
+  );
+  assert.ok(
+    site.includes("reviseThread(candidate, { workflowRouteKey: wfid })"),
+    "…and revise rather than assign, so it merges causally",
+  );
+  // The active thread's own stamp follows too.
+  assert.ok(site.includes("workflowRouteKey: workflowTabId()"), "the active thread must follow as well");
+});
+
+test("WIRING #847: a migration with no active thread is still persisted", () => {
+  // `persistThreads()` lives inside `if (thread)`, and the whole point of the sweep
+  // is the threads that are NOT active — on a save with the composer empty, that is
+  // all of them. Without this the migration happens in memory and dies on reload,
+  // which is the bug.
+  const src = readFileSync(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8");
+  assert.ok(src.includes("if (migratedRouteStamp && !thread) persistThreads();"));
+});
+
+test("the sweep only fires on a real tmp: -> wf: migration", () => {
+  const src = readFileSync(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8");
+  const site = src.slice(
+    src.indexOf("const priorRouteId = wf ? _priorTempWorkflowIds.get(wf) : null;"),
+    src.indexOf("if (migratedRouteStamp && !thread)"),
+  );
+  assert.ok(site.includes('wfid.startsWith("wf:")'), "only when the tab is now SAVED");
+  assert.ok(site.includes("priorRouteId !== wfid"), "and only when the id actually changed");
 });

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -1469,20 +1469,7 @@ const _tempWorkflowInstanceIds = new WeakMap(); // wf object -> "tmp:<uuid>"
 // migration (the orchestrator moves the pin unchanged), so the guard must still
 // recognize it as naming this same instance (#186).
 const _priorTempWorkflowIds = new WeakMap();
-/**
- * Route ids this tab USED TO have, keyed by the id it has now (#847).
- *
- * `_priorTempWorkflowIds` above is keyed on the live workflow OBJECT, and ComfyUI
- * replaces that object across a save — verified while fixing this: a thread stamped
- * `tmp:` on a tab that was already saved could not be matched back to it, because by
- * the time anything asked, the WeakMap's key was gone.
- *
- * A plain Map keyed by the NEW id survives that. It only ever holds ids this panel
- * minted for this tab, so it cannot name another workflow's threads, and it is
- * in-memory by design: the durable half is the stamp rewrite in
- * `onWorkflowMaybeChanged`, which this exists to cover until that lands.
- */
-const _routeIdLineage = new Map();
+
 const _workflowObjectUuids = new WeakMap();
 const _workflowUuidOwners = new Map();
 
@@ -22263,22 +22250,25 @@ function buildPanel() {
         candidateRouteIds: [currentWorkflowId, wf ? _priorTempWorkflowIds.get(wf) : null],
         openRouteIds: stillOpenRouteIds,
       });
-      if (priorRouteIds.size) {
-        const held = _routeIdLineage.get(wfid) ?? new Set();
-        for (const id of priorRouteIds) held.add(id);
-        _routeIdLineage.set(wfid, held);
-      }
-      // NO DURABLE REWRITE HERE, deliberately — see the note on `_routeIdLineage`.
-      // Rewriting the stamps on disk needs POSITIVE proof that an old id was this
-      // tab's, and the panel does not have it: `openWorkflows` not claiming an id is
-      // absence of a competing claimant, not ownership (codex). Close A, switch to
-      // B, and A's conversations would migrate to B permanently. Measured that the
-      // in-memory match below fixes the reported case on its own, so the persisted
-      // write buys nothing here and risks the one thing this area must never do.
-      const migratedRouteStamp = priorRouteIds.size > 0;
+
+      // NOTHING IS MIGRATED HERE, and that is the finding rather than an omission.
+      //
+      // Threads stamped before a first save hold an id nothing answers to afterwards,
+      // and both ways of fixing that need to know the old id was THIS tab's past.
+      // The panel cannot prove it: the workflow OBJECT is replaced across the save
+      // (instrumented — the WeakMap that would vouch has nothing under its key by
+      // then), and `openWorkflows` not claiming an id is absence of a competing
+      // claimant, not ownership (codex). Close A, switch to B, and A's conversations
+      // would be attributed to B.
+      //
+      // So `priorRouteIds` is used for ONE thing: knowing that a genuine first save
+      // just happened, which is when an open history pane is showing a stale answer.
+      // No stamp is rewritten and no identity is inferred. #847 stays open for the
+      // rest, with the ownership gap written down rather than guessed at.
+      const savedThisTick = priorRouteIds.size > 0;
       // A pane that is already open painted the pre-migration answer and will not
       // repaint itself; nothing else changes its rows.
-      if (migratedRouteStamp) {
+      if (savedThisTick) {
         try {
           repaintHistoryList?.();
         } catch {
@@ -22464,10 +22454,7 @@ function buildPanel() {
         routeId: liveRouteId,
         priorRouteId: activeWf ? _priorTempWorkflowIds.get(activeWf) : null,
       });
-      // …plus every id this tab is known to have carried before (#847). The WeakMap
-      // above misses whenever ComfyUI replaced the workflow object across the save,
-      // which is most of the time.
-      for (const id of _routeIdLineage.get(liveRouteId) ?? []) currentWorkflowKeys.add(id);
+
       const visible = threads
         .filter((candidate) =>
           !currentOnly.checked || threadMatchesCurrentWorkflow(candidate, currentWorkflowKeys))

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -22268,20 +22268,14 @@ function buildPanel() {
         for (const id of priorRouteIds) held.add(id);
         _routeIdLineage.set(wfid, held);
       }
-      let migratedRouteStamp = false;
-      if (priorRouteIds.size) {
-        for (const candidate of threads) {
-          if (!priorRouteIds.has(candidate?.workflowRouteKey)) continue;
-          historyStore.reviseThread(candidate, { workflowRouteKey: wfid });
-          migratedRouteStamp = true;
-        }
-      }
-      // Persist it even with no active thread. The revise below carries its own
-      // `persistThreads()`, but it is inside `if (thread)` — and the whole point of
-      // the loop above is the threads that are NOT active, which on a save with the
-      // composer empty is all of them. Leaving it to that branch would migrate them
-      // in memory and lose it on reload, which is the bug being fixed.
-      if (migratedRouteStamp && !thread) persistThreads();
+      // NO DURABLE REWRITE HERE, deliberately — see the note on `_routeIdLineage`.
+      // Rewriting the stamps on disk needs POSITIVE proof that an old id was this
+      // tab's, and the panel does not have it: `openWorkflows` not claiming an id is
+      // absence of a competing claimant, not ownership (codex). Close A, switch to
+      // B, and A's conversations would migrate to B permanently. Measured that the
+      // in-memory match below fixes the reported case on its own, so the persisted
+      // write buys nothing here and risks the one thing this area must never do.
+      const migratedRouteStamp = priorRouteIds.size > 0;
       // A pane that is already open painted the pre-migration answer and will not
       // repaint itself; nothing else changes its rows.
       if (migratedRouteStamp) {
@@ -22294,10 +22288,6 @@ function buildPanel() {
       if (thread) {
         historyStore.reviseThread(thread, {
           workflowKey: workflowStorageKey(),
-          // The active thread's route stamp follows too. It was absent here because
-          // `workflowRouteKey` was not a revisable field at all (#847) — set once at
-          // creation, then stale forever.
-          workflowRouteKey: workflowTabId(),
           workflowTitle: getWorkflowTitle(),
         }); // archive provenance
         setActiveThread("panel:global", thread.id);

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -1468,6 +1468,20 @@ const _tempWorkflowInstanceIds = new WeakMap(); // wf object -> "tmp:<uuid>"
 // migration (the orchestrator moves the pin unchanged), so the guard must still
 // recognize it as naming this same instance (#186).
 const _priorTempWorkflowIds = new WeakMap();
+/**
+ * Route ids this tab USED TO have, keyed by the id it has now (#847).
+ *
+ * `_priorTempWorkflowIds` above is keyed on the live workflow OBJECT, and ComfyUI
+ * replaces that object across a save — verified while fixing this: a thread stamped
+ * `tmp:` on a tab that was already saved could not be matched back to it, because by
+ * the time anything asked, the WeakMap's key was gone.
+ *
+ * A plain Map keyed by the NEW id survives that. It only ever holds ids this panel
+ * minted for this tab, so it cannot name another workflow's threads, and it is
+ * in-memory by design: the durable half is the stamp rewrite in
+ * `onWorkflowMaybeChanged`, which this exists to cover until that lands.
+ */
+const _routeIdLineage = new Map();
 const _workflowObjectUuids = new WeakMap();
 const _workflowUuidOwners = new Map();
 
@@ -7462,6 +7476,22 @@ function revalidateGraphMutationContext(captured) {
 // The currently-mounted panel root (set by buildPanel). Used by canvas "fit" to
 // measure how much of the canvas the open sidebar panel overlays.
 let activePanelRoot = null;
+/**
+ * Repaint the open Chat-history list, if one is open (#847).
+ *
+ * The list paints once when the pane opens. A route-stamp migration lands on the
+ * 600 ms workflow poll, so a pane opened just before a first save shows the
+ * pre-migration answer and never corrects itself — the rows do not change, so
+ * Playwright's auto-retry cannot save it either, and neither can a user staring
+ * at it.
+ *
+ * Reassigned on every render of the pane rather than nulled on close: the pane is
+ * a popover that is re-rendered in place (`histPop.textContent = ""`) and has no
+ * teardown to hang a null on. A handle left over from a closed popover repaints a
+ * hidden node, which costs nothing and shows nobody anything — and it closes over
+ * the same `threads` BINDING, not a copy, so it cannot paint a stale list.
+ */
+let repaintHistoryList = null;
 
 /**
  * #851 — WHICH ComfyUI a reboot reply is about.
@@ -22173,9 +22203,76 @@ function buildPanel() {
     if (followsPanel) {
       // tmp→wf adopt bookkeeping (a save gave the unsaved workflow a real id).
       if (wfid.startsWith("wf:") && wf) _tempWorkflowInstanceIds.delete(wf);
+      // #847 — CARRY THE ROUTE STAMP ACROSS THE SAVE, on every thread that holds it.
+      //
+      // A first save moves the tab from `tmp:<uuid>` to `wf:<path>` and re-mints the
+      // storage uuid at the same moment, so a conversation recorded before it holds
+      // neither of the live workflow's identity forms and drops out of "Current
+      // workflow only" — the workflow it was actually held on. 0.11.56 matched those
+      // threads in memory via `_priorTempWorkflowIds`; that is a WeakMap, so the
+      // match died on reload and this is the durable half.
+      //
+      // EVERY thread, not just the active one. Revising only `thread` is what left
+      // the reported case broken: chat, save, start a new chat, filter — and the
+      // FIRST chat is the one missing, because it was not the active thread when the
+      // save landed.
+      //
+      // Rewrites a routing stamp and nothing else. No transcript is touched, and it
+      // goes through `reviseThread` so it travels the same causal field-op path as
+      // the other stamps rather than losing to a stale tab's write.
+      // The ids to migrate FROM. Two sources, because neither alone is enough:
+      //
+      //   currentWorkflowId  the id this panel was last using — a plain variable, so
+      //                      it survives ComfyUI replacing the activeWorkflow OBJECT.
+      //                      Verified necessary: in the failing spec the tab was
+      //                      already saved before the first message, yet the thread
+      //                      was stamped `tmp:` — the panel's VIEW of the tab changed
+      //                      later, and the object had been swapped by then, so the
+      //                      WeakMap below found nothing.
+      //   _priorTempWorkflowIds  the first tmp: id ever minted for this live object,
+      //                      which covers a migration this poll did not itself see.
+      //
+      // Both are ids this panel MINTED for this tab, so neither can name another
+      // workflow's threads.
+      const priorRouteIds = new Set();
+      for (const id of [currentWorkflowId, wf ? _priorTempWorkflowIds.get(wf) : null]) {
+        if (typeof id === "string" && id.startsWith("tmp:") && id !== wfid) priorRouteIds.add(id);
+      }
+      if (priorRouteIds.size) {
+        const held = _routeIdLineage.get(wfid) ?? new Set();
+        for (const id of priorRouteIds) held.add(id);
+        _routeIdLineage.set(wfid, held);
+      }
+      let migratedRouteStamp = false;
+      if (wfid.startsWith("wf:") && priorRouteIds.size) {
+        for (const candidate of threads) {
+          if (!priorRouteIds.has(candidate?.workflowRouteKey)) continue;
+          historyStore.reviseThread(candidate, { workflowRouteKey: wfid });
+          migratedRouteStamp = true;
+        }
+      }
+      // Persist it even with no active thread. The revise below carries its own
+      // `persistThreads()`, but it is inside `if (thread)` — and the whole point of
+      // the loop above is the threads that are NOT active, which on a save with the
+      // composer empty is all of them. Leaving it to that branch would migrate them
+      // in memory and lose it on reload, which is the bug being fixed.
+      if (migratedRouteStamp && !thread) persistThreads();
+      // A pane that is already open painted the pre-migration answer and will not
+      // repaint itself; nothing else changes its rows.
+      if (migratedRouteStamp) {
+        try {
+          repaintHistoryList?.();
+        } catch {
+          // A stale handle must never break the workflow poll.
+        }
+      }
       if (thread) {
         historyStore.reviseThread(thread, {
           workflowKey: workflowStorageKey(),
+          // The active thread's route stamp follows too. It was absent here because
+          // `workflowRouteKey` was not a revisable field at all (#847) — set once at
+          // creation, then stale forever.
+          workflowRouteKey: workflowTabId(),
           workflowTitle: getWorkflowTitle(),
         }); // archive provenance
         setActiveThread("panel:global", thread.id);
@@ -22346,11 +22443,16 @@ function buildPanel() {
       // object's lifetime, and `workflowRecordMatchesSelector` already honours it — this
       // was the one reader that did not.
       const activeWf = activeWorkflowRef();
+      const liveRouteId = workflowTabId();
       const currentWorkflowKeys = currentWorkflowIdentityKeys({
         storageKey: workflowStorageKey(),
-        routeId: workflowTabId(),
+        routeId: liveRouteId,
         priorRouteId: activeWf ? _priorTempWorkflowIds.get(activeWf) : null,
       });
+      // …plus every id this tab is known to have carried before (#847). The WeakMap
+      // above misses whenever ComfyUI replaced the workflow object across the save,
+      // which is most of the time.
+      for (const id of _routeIdLineage.get(liveRouteId) ?? []) currentWorkflowKeys.add(id);
       const visible = threads
         .filter((candidate) =>
           !currentOnly.checked || threadMatchesCurrentWorkflow(candidate, currentWorkflowKeys))
@@ -22536,6 +22638,9 @@ function buildPanel() {
       picker.click();
     });
     paintList();
+    // Publish the repaint so a migration landing while this pane is open can
+    // correct it (#847).
+    repaintHistoryList = paintList;
 
     const footer = document.createElement("div");
     footer.className = "cmcp-hist-footer";

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -204,6 +204,7 @@ import { boundSubgraphList } from "./lib/subgraph-list-bound.js";
 import {
   threadMatchesCurrentWorkflow,
   currentWorkflowIdentityKeys,
+  migratableRouteIds,
 } from "./lib/thread-workflow-match.js";
 import { subgraphValueProvenance } from "./lib/subgraph-value-provenance.js";
 import { describeMissingNode } from "./lib/node-scope-locator.js";
@@ -22220,31 +22221,55 @@ function buildPanel() {
       // Rewrites a routing stamp and nothing else. No transcript is touched, and it
       // goes through `reviseThread` so it travels the same causal field-op path as
       // the other stamps rather than losing to a stale tab's write.
-      // The ids to migrate FROM. Two sources, because neither alone is enough:
+      // The ids to migrate FROM — and the hard part is PROVING one belongs to this
+      // tab rather than to a workflow the user merely switched away from (codex P0).
       //
-      //   currentWorkflowId  the id this panel was last using — a plain variable, so
-      //                      it survives ComfyUI replacing the activeWorkflow OBJECT.
-      //                      Verified necessary: in the failing spec the tab was
-      //                      already saved before the first message, yet the thread
-      //                      was stamped `tmp:` — the panel's VIEW of the tab changed
-      //                      later, and the object had been swapped by then, so the
-      //                      WeakMap below found nothing.
-      //   _priorTempWorkflowIds  the first tmp: id ever minted for this live object,
-      //                      which covers a migration this poll did not itself see.
+      // `tmp:` -> `wf:` is the shape of a first save. It is ALSO the shape of a
+      // switch from an unsaved workflow A to an already-saved workflow B, and an
+      // earlier cut could not tell them apart: it read `currentWorkflowId` starting
+      // with `tmp:` as "this tab's pre-save id" and rewrote every one of A's threads
+      // to B's path — permanently attributing one workflow's conversations to
+      // another. That is the cross-attribution this whole area exists to prevent,
+      // and it is worse than the bug being fixed.
       //
-      // Both are ids this panel MINTED for this tab, so neither can name another
-      // workflow's threads.
-      const priorRouteIds = new Set();
-      for (const id of [currentWorkflowId, wf ? _priorTempWorkflowIds.get(wf) : null]) {
-        if (typeof id === "string" && id.startsWith("tmp:") && id !== wfid) priorRouteIds.add(id);
-      }
+      // The discriminator is whether the old id STILL NAMES AN OPEN TAB. A save
+      // consumes the tmp: identity — nothing answers to it afterwards. A switch
+      // leaves A open and answering. So an id is only a pre-save identity of THIS
+      // tab if no open workflow still claims it.
+      //
+      // Fails closed: if the open list cannot be read, nothing is migrated and the
+      // in-memory match (0.11.56) still covers the session.
+      const stillOpenRouteIds = (() => {
+        try {
+          const svc = app?.extensionManager?.workflow;
+          const open = svc?.openWorkflows;
+          if (!Array.isArray(open)) return null; // unknown — refuse to migrate
+          const ids = new Set();
+          for (const candidate of open) {
+            if (candidate === wf) continue; // the tab we are migrating TO
+            const id = workflowTabId(candidate);
+            if (typeof id === "string" && id) ids.add(id);
+          }
+          return ids;
+        } catch {
+          return null;
+        }
+      })();
+      // The decision itself lives in lib/ so it can be tested against the real
+      // function rather than asserted about at source — including the switch case
+      // that made an earlier cut re-attribute one workflow's chats to another.
+      const priorRouteIds = migratableRouteIds({
+        newRouteId: wfid,
+        candidateRouteIds: [currentWorkflowId, wf ? _priorTempWorkflowIds.get(wf) : null],
+        openRouteIds: stillOpenRouteIds,
+      });
       if (priorRouteIds.size) {
         const held = _routeIdLineage.get(wfid) ?? new Set();
         for (const id of priorRouteIds) held.add(id);
         _routeIdLineage.set(wfid, held);
       }
       let migratedRouteStamp = false;
-      if (wfid.startsWith("wf:") && priorRouteIds.size) {
+      if (priorRouteIds.size) {
         for (const candidate of threads) {
           if (!priorRouteIds.has(candidate?.workflowRouteKey)) continue;
           historyStore.reviseThread(candidate, { workflowRouteKey: wfid });

--- a/web/js/lib/chat-history-store.js
+++ b/web/js/lib/chat-history-store.js
@@ -63,13 +63,6 @@ const THREAD_FIELDS = [
   "sessionId",
   "todos",
   "workflowKey",
-  // #847 — REVISABLE, not write-once. The route stamp was set at thread creation
-  // and never again, so a first save (which migrates the tab from `tmp:<uuid>` to
-  // `wf:<path>`) left every thread on that workflow holding an id nothing answers
-  // to any more. Being in this list is what lets it travel the same causal
-  // field-op path as the other stamps — revisions, tombstones, cross-tab merge —
-  // instead of being poked directly and losing to a stale tab's write.
-  "workflowRouteKey",
   "workflowTitle",
   "provider",
   "model",
@@ -81,9 +74,6 @@ const INVALID_FIELD_VALUE = Symbol("invalid-thread-field-value");
 const THREAD_STRING_LIMITS = {
   sessionId: 512,
   workflowKey: 512,
-  // A `wf:` route id carries a workflow PATH, so it needs the same headroom as
-  // workflowKey rather than a title-sized cap.
-  workflowRouteKey: 512,
   workflowTitle: 240,
   provider: 80,
   model: 200,

--- a/web/js/lib/chat-history-store.js
+++ b/web/js/lib/chat-history-store.js
@@ -63,6 +63,13 @@ const THREAD_FIELDS = [
   "sessionId",
   "todos",
   "workflowKey",
+  // #847 — REVISABLE, not write-once. The route stamp was set at thread creation
+  // and never again, so a first save (which migrates the tab from `tmp:<uuid>` to
+  // `wf:<path>`) left every thread on that workflow holding an id nothing answers
+  // to any more. Being in this list is what lets it travel the same causal
+  // field-op path as the other stamps — revisions, tombstones, cross-tab merge —
+  // instead of being poked directly and losing to a stale tab's write.
+  "workflowRouteKey",
   "workflowTitle",
   "provider",
   "model",
@@ -74,6 +81,9 @@ const INVALID_FIELD_VALUE = Symbol("invalid-thread-field-value");
 const THREAD_STRING_LIMITS = {
   sessionId: 512,
   workflowKey: 512,
+  // A `wf:` route id carries a workflow PATH, so it needs the same headroom as
+  // workflowKey rather than a title-sized cap.
+  workflowRouteKey: 512,
   workflowTitle: 240,
   provider: 80,
   model: 200,

--- a/web/js/lib/thread-workflow-match.js
+++ b/web/js/lib/thread-workflow-match.js
@@ -86,3 +86,44 @@ export function threadMatchesCurrentWorkflow(thread, currentKeys) {
   const route = thread.workflowRouteKey;
   return typeof route === "string" && route !== "" && currentKeys.has(route);
 }
+
+/**
+ * Which previous route ids may this tab claim as ITS OWN past (#847)?
+ *
+ * A first save moves a tab from `tmp:<uuid>` to `wf:<path>`, and every thread stamped
+ * with the old id has to follow or it drops out of "Current workflow only". The whole
+ * difficulty is that `tmp:` -> `wf:` is ALSO the shape of a SWITCH from an unsaved
+ * workflow A to an already-saved workflow B. An earlier cut could not tell them apart
+ * and rewrote every one of A's threads to B's path — permanently attributing one
+ * workflow's conversations to another (codex). That is worse than the bug being fixed,
+ * and it is the failure this whole area exists to prevent.
+ *
+ * THE DISCRIMINATOR IS WHETHER THE OLD ID STILL NAMES AN OPEN TAB. A save CONSUMES the
+ * tmp: identity — nothing answers to it afterwards. A switch leaves A open and still
+ * answering. So a candidate is this tab's past only if no other open workflow claims it.
+ *
+ * FAILS CLOSED on an unreadable open list (`openRouteIds == null`): migrating on a guess
+ * is how the cross-attribution happens, and the in-memory match covers the session
+ * anyway. Returns a Set so the caller can test membership directly.
+ *
+ * @param {{newRouteId?: string, candidateRouteIds?: Array<string|null|undefined>,
+ *          openRouteIds?: Set<string>|null}} input
+ * @returns {Set<string>}
+ */
+export function migratableRouteIds({ newRouteId, candidateRouteIds, openRouteIds } = {}) {
+  const out = new Set();
+  // Only a SAVE produces a `wf:` id for this tab. Anything else is not a migration.
+  if (typeof newRouteId !== "string" || !newRouteId.startsWith("wf:")) return out;
+  // Unknown open set — refuse. See above.
+  if (!(openRouteIds instanceof Set)) return out;
+  for (const id of Array.isArray(candidateRouteIds) ? candidateRouteIds : []) {
+    if (typeof id !== "string" || !id) continue;
+    // Only an UNSAVED id can be a pre-save identity.
+    if (!id.startsWith("tmp:")) continue;
+    if (id === newRouteId) continue;
+    // Still open under that id ⇒ a different workflow, not this tab's past.
+    if (openRouteIds.has(id)) continue;
+    out.add(id);
+  }
+  return out;
+}


### PR DESCRIPTION
Works #847 — **does not close it.** Scope reduced twice under review; both reductions were right.

## What ships

**An open Chat-history pane repaints when a first save lands.** It paints once on open, the save is noticed on the 600 ms workflow poll, and nothing else changes its rows — so a pane opened just before a save showed the pre-save answer until you closed and reopened it. A real bug on its own, and the reason the spec stayed red through two otherwise-correct attempts at the underlying identity problem.

**`migratableRouteIds`** (in `lib/`) decides whether a genuine first save just happened. Extracted so it's driven by tests rather than asserted about at source — codex's objection to the first version: the switch case, the real save, a fail-closed open list, rename-shaped ids, junk candidates.

## What does not ship, and why that's the useful part

Threads stamped before a first save hold a route id nothing answers to afterwards. Every way of fixing that needs to know the old id was **this tab's** past, and the panel cannot prove it:

- The workflow **object is replaced** across a save — instrumented, so `_priorTempWorkflowIds` (a WeakMap keyed on that object) has nothing under its key by the time anything asks.
- `openWorkflows` not claiming an id is **absence of a competing claimant, not ownership**. Close A, switch to B, and A's conversations get attributed to B.

I built the durable rewrite; measured that the in-memory match alone fixed the reported case, and removed the persisted write. Codex then showed the in-memory match carries the same inference one severity down — a wrong entry shows A's history under B's filter for the session — and I removed that too rather than argue the residue was small enough.

## Review history

| round | finding |
|---|---|
| r1 | **P0** — `tmp:`→`wf:` is also the shape of a switch from unsaved A to saved B; the sweep would rewrite A's threads to B's path and persist it |
| r1 | tests restated source rather than driving the scenario |
| r2 | the still-open check is not positive ownership: close/replace A and the same misattribution returns |
| r2 | `_routeIdLineage` unbounded, and can persist a bad A→B association |
| r3 | removing the persisted write closes the integrity finding; the in-memory inference still misinforms for a session |

## Verification

- **49/49 e2e** with the full change (first fully green run of this suite); **48/49** with the inference removed. The difference is exactly the spec this cannot honestly fix yet.
- 3295 unit tests pass; the extracted decision is mutation-verified five ways.

## Left open on #847

The identity half, with the ownership gap documented. `chat-history-v2:66` stays red. I'd rather say that than ship inference to turn it green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)