### PR TITLE
0.11.59 — an open history pane updates itself after a save (#847 partial)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+## [0.11.59] - 2026-08-09
+
+> Covers changes since 0.11.58.
+
+### Fixed
+
+- **An open Chat history pane now updates itself when you save a workflow
+  (#847, partial).** The list was painted once when the pane opened, so if you
+  saved a workflow while it was on screen it kept showing the pre-save answer
+  until you closed and reopened it.
+
+  This does not yet fix the related report that a chat held on a workflow *before*
+  its first save can drop out of "Current workflow only". That needs the panel to
+  prove an old identity belonged to the same tab, and it currently cannot — the
+  workflow object is replaced by the save, and "no other tab claims this id" is not
+  the same as "this tab owned it". Guessing there would attach one workflow's
+  conversations to another, so it stays unfixed and #847 stays open.
+
+
 ## [0.11.58] - 2026-08-09
 
 > Covers changes since 0.11.57.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-agent-panel"
 description = "Autonomous AI agent in the ComfyUI sidebar - local-first, bring any LLM. Run it on your Claude or ChatGPT subscription (no API keys, no extra LLM costs), on a Kimi K3 / GLM / OpenRouter key, or fully offline on free local models via Ollama, LM Studio, or llama.cpp. The agent drives your live canvas at full parity: add, wire, move and tweak nodes with Ctrl+Z undo, load whole workflows and installer packs in one shot, generate images, video and audio, browse CivitAI, and run your workflow - asking before it spends paid API credits. The sidebar UI for comfyui-mcp, the local-first, agent-native control plane for ComfyUI."
-version = "0.11.58"
+version = "0.11.59"
 license = { file = "LICENSE" }
 requires-python = ">=3.9"
 # UI-only pack: no Python deps. The frontend floor guarantees

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -876,7 +876,7 @@ const DOCS_URL = "https://comfyui-mcp.artokun.io/docs";
 // Panel version — surfaced in the "Need help?" diagnostics blob. Bump via
 // `node scripts/set-version.mjs <v>` (updates this AND pyproject together); CI
 // and the publish gate FAIL if the two ever drift, so this can't go stale.
-const PANEL_VERSION = "0.11.58";
+const PANEL_VERSION = "0.11.59";
 
 // The connected orchestrator's console URL/token (captured off the `backends`
 // bridge message — see onBackends). Drives the "API Keys" credentials frame;


### PR DESCRIPTION
Releases the partial fix merged since 0.11.58.

## What ships

**#847** (#872) — an open Chat history pane repaints when a first save lands. It painted once on open and nothing else changed its rows, so a pane on screen during a save kept showing the pre-save answer until you closed and reopened it.

Plus `migratableRouteIds` in `lib/` — the "did a genuine first save just happen" decision, extracted so it's driven by tests rather than asserted about at source.

## What deliberately does not ship

The identity half of #847: a chat held on a workflow **before** its first save can still drop out of "Current workflow only". Fixing it needs the panel to prove an old route id belonged to the *same tab*, and it cannot:

- The workflow **object is replaced** across a save — instrumented, so the WeakMap that would vouch has nothing under its key by then.
- `openWorkflows` not claiming an id is **absence of a competing claimant, not ownership**. Close A, switch to B, and A's conversations get attributed to B.

I built the durable rewrite first, measured that an in-memory match alone fixed the reported case and dropped the persisted write; codex then showed the in-memory match carries the same inference one severity down, and I dropped that too rather than argue the residue was small enough.

**The consequence is honest and visible: `chat-history-v2:66` stays red.** 49/49 e2e with the inference in, 48/49 with it removed — that one spec is exactly what this cannot fix without guessing.

## Verification

- 3295 unit tests pass; the extracted decision is mutation-verified five ways.
- e2e against merged main: history-pane specs 10/11, the one failure being the documented case above.
- **Codex: three rounds.** A P0 on the first (a switch from unsaved A to saved B would have rewritten A's threads to B's path and persisted it), then the ownership gap, then sign-off on the reduced scope.

## Changelog note

Hand-written — `scripts/gen-changelog.mjs` walks back to the last git **tag**, so it regenerated 162 commits already shipped in 0.11.47–0.11.58.

🤖 Generated with [Claude Code](https://claude.com/claude-code)