### PR TITLE
fix(open): a reopen must not revert what the ChangeTracker never saw (#874)

### DIFF
--- a/browser_tests/reopen-preserves-node-set-values.spec.ts
+++ b/browser_tests/reopen-preserves-node-set-values.spec.ts
@@ -114,10 +114,33 @@ test('reopening the active workflow keeps a value the tracker never saw', async 
   // CONTENT_UNVERIFIED — the panel cannot call a repaint byte-identical — and that
   // verdict is `ok: false` by design. What this spec is about is whether the repaint
   // DESTROYED anything, so assert the open actually ran and then check the value.
+  //
+  // This sentence is emitted ONLY by the CONTENT_UNVERIFIED branch, which is reached
+  // only after the repaint has run and its rebind marker has been checked. A loose
+  // match here (codex) would accept an error raised BEFORE the repaint — and then the
+  // final assertion below passes vacuously, because the widget write was never
+  // touched by anything.
   const ran = JSON.stringify(reopened)
-  expect(ran, 'the open must have run and bound the canvas').toMatch(/workflow_open RAN|opened/i)
+  expect(ran, 'the reply must be the post-repaint verdict, not an earlier failure').toContain(
+    'workflow_open RAN, the canvas IS bound to'
+  )
 
-  // The value must still be there. Before #874 the repaint reloaded the stale
-  // snapshot and this came back as the default.
+  // Two independent signals, because either alone can be satisfied for the wrong
+  // reason.
+  //
+  // 1. The tracker snapshot must now carry the value — that is the capture this fix
+  //    adds, and it is false without it.
+  const trackerCaughtUp = await page.evaluate(() => {
+    const w = window as any
+    const app = w.comfyAPI?.app?.app || w.app
+    const wf = app?.extensionManager?.workflow?.activeWorkflow
+    const tracked = wf?.changeTracker?.activeState
+    const node = (tracked?.nodes || []).find((n: any) => n.type === 'EmptyLatentImage')
+    return ((node?.widgets_values || []) as unknown[]).includes(1337)
+  })
+  expect(trackerCaughtUp, 'the repaint must capture the live canvas before reading it').toBe(true)
+
+  // 2. And the canvas must still hold it. Before #874 the repaint reloaded the stale
+  //    snapshot and this came back as the node's DEFAULT.
   await expect.poll(() => readWidget(page, 'EmptyLatentImage', 'width')).toBe(1337)
 })

--- a/browser_tests/reopen-preserves-node-set-values.spec.ts
+++ b/browser_tests/reopen-preserves-node-set-values.spec.ts
@@ -1,0 +1,123 @@
+/**
+ * #874 — reopening a workflow must not revert values the ChangeTracker never saw.
+ *
+ * `workflow_open` on an ALREADY-OPEN workflow does not re-read the file. It repaints
+ * the canvas from `changeTracker.activeState` in order to PROVE it rebound the right
+ * canvas (#721, and the receipts #604/#603/#616 lean on that proof).
+ *
+ * ComfyUI's ChangeTracker captures on USER INPUT events only. So every value a NODE
+ * wrote without user input — an ImpactWildcardEncode populate, a control_after_generate
+ * roll, a subgraph proxy the frontend filled in — was absent from that snapshot, and the
+ * repaint reverted it. Silently: nothing errored and the graph looked right afterwards.
+ *
+ * This drives the real path (a `workflow_open` command over the bridge, the way the
+ * orchestrator sends it) rather than asserting about the source, because the bug lives
+ * in the interaction between two ComfyUI subsystems and only shows up when both run.
+ */
+import { test, expect } from './fixtures/panelTest'
+import { claimFreshCanvas, settleCanvas } from './fixtures/canvasIdentity'
+
+/** Set a widget the way a NODE does: directly, with no user input event. */
+async function setWidgetWithoutUserInput(
+  page: import('@playwright/test').Page,
+  nodeType: string,
+  widgetName: string,
+  value: number
+) {
+  return page.evaluate(
+    ({ nodeType: t, widgetName: n, value: v }) => {
+      const w = window as any
+      const app = w.comfyAPI?.app?.app || w.app
+      const graph = app?.canvas?.graph ?? app?.graph
+      const node = (graph?.nodes || []).find((x: any) => x.type === t)
+      if (!node) throw new Error(`no ${t} on the canvas`)
+      const widget = (node.widgets || []).find((x: any) => x.name === n)
+      if (!widget) throw new Error(`${t} has no widget ${n}`)
+      widget.value = v
+      return { nodeId: String(node.id), value: widget.value }
+    },
+    { nodeType, widgetName, value }
+  )
+}
+
+async function readWidget(
+  page: import('@playwright/test').Page,
+  nodeType: string,
+  widgetName: string
+) {
+  return page.evaluate(
+    ({ nodeType: t, widgetName: n }) => {
+      const w = window as any
+      const app = w.comfyAPI?.app?.app || w.app
+      const graph = app?.canvas?.graph ?? app?.graph
+      const node = (graph?.nodes || []).find((x: any) => x.type === t)
+      const widget = (node?.widgets || []).find((x: any) => x.name === n)
+      return widget ? widget.value : null
+    },
+    { nodeType, widgetName }
+  )
+}
+
+test('reopening the active workflow keeps a value the tracker never saw', async ({
+  page,
+  panel,
+  mockBridge
+}) => {
+  await panel.goto()
+  await panel.setBridgeUrl(mockBridge.url)
+  await panel.openSidebar()
+  await panel.connect()
+
+  await claimFreshCanvas(page, mockBridge)
+  await page.evaluate(() => {
+    const w = window as any
+    const app = w.comfyAPI?.app?.app || w.app
+    const graph = app?.canvas?.graph ?? app?.graph
+    const LG = w.LiteGraph || w.comfyAPI?.litegraph?.LiteGraph
+    const node = LG.createNode('EmptyLatentImage')
+    graph.add(node)
+  })
+  await settleCanvas(page)
+
+  // Resolve the reopen target BEFORE touching the widget. Order is load-bearing:
+  // the panel's command dispatch calls `changeTracker.checkState()` after every
+  // successful command, so ANY panel command issued after the change refreshes the
+  // tracker and hides the very lag this spec is about. An earlier draft fetched the
+  // target after the change and passed with the fix removed, for exactly that reason.
+  const active = await mockBridge.command('workflow_list', {})
+  const target =
+    active.result?.active?.routing_key ||
+    active.result?.active?.key ||
+    active.result?.active?.path
+  expect(target, 'workflow_list must report an active workflow to reopen').toBeTruthy()
+
+  // NOW change a value the way a node would — no user input, and no panel command
+  // after it, so nothing tells the tracker.
+  const changed = await setWidgetWithoutUserInput(page, 'EmptyLatentImage', 'width', 1337)
+  expect(changed.value).toBe(1337)
+
+  // Precondition: this is the state the bug depends on. If the tracker HAD seen it,
+  // the test would pass for the wrong reason.
+  const trackerLagged = await page.evaluate(() => {
+    const w = window as any
+    const app = w.comfyAPI?.app?.app || w.app
+    const wf = app?.extensionManager?.workflow?.activeWorkflow
+    const tracked = wf?.changeTracker?.activeState
+    const node = (tracked?.nodes || []).find((n: any) => n.type === 'EmptyLatentImage')
+    return !((node?.widgets_values || []) as unknown[]).includes(1337)
+  })
+  expect(trackerLagged, 'precondition: the tracker must not have seen the change').toBe(true)
+
+  // Reopen the workflow that is already active — the path that repaints.
+  const reopened = await mockBridge.command('workflow_open', { path: target })
+  // NOT `ok: true`. Reopening the already-active workflow legitimately answers
+  // CONTENT_UNVERIFIED — the panel cannot call a repaint byte-identical — and that
+  // verdict is `ok: false` by design. What this spec is about is whether the repaint
+  // DESTROYED anything, so assert the open actually ran and then check the value.
+  const ran = JSON.stringify(reopened)
+  expect(ran, 'the open must have run and bound the canvas').toMatch(/workflow_open RAN|opened/i)
+
+  // The value must still be there. Before #874 the repaint reloaded the stale
+  // snapshot and this came back as the default.
+  await expect.poll(() => readWidget(page, 'EmptyLatentImage', 'width')).toBe(1337)
+})

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -11668,7 +11668,12 @@ const GRAPH_TOOL_EXECUTORS = {
           // Best-effort. A frontend without `checkState` behaves exactly as before —
           // this must never be the thing that fails an open.
           try {
-            target.changeTracker?.checkState?.();
+            // AWAITED (codex). A frontend whose tracker captures asynchronously would
+            // otherwise have `activeState` read before the capture landed — the silent
+            // revert intact, and a late rejection escaping this try/catch to become an
+            // unhandled rejection. Awaiting a non-promise is free, so the synchronous
+            // trackers this ships against are unaffected.
+            await target.changeTracker?.checkState?.();
           } catch {
             // A tracker that refuses to capture leaves the stale snapshot in place,
             // which is today's behaviour, not a new failure.

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -11645,6 +11645,34 @@ const GRAPH_TOOL_EXECUTORS = {
       // LiteGraph canvas flag, not a workflow-service member.
         beginWorkflowReloadStep(reloadGuardToken);
         try {
+          // #874 — CAPTURE THE LIVE CANVAS, not the last thing a user touched.
+          //
+          // This repaint reloads the graph from `activeState`, and ComfyUI's
+          // ChangeTracker captures on USER INPUT events only. So every value a NODE
+          // wrote without user input — an ImpactWildcardEncode populate, a
+          // control_after_generate roll, a subgraph proxy the frontend filled in — is
+          // absent from that snapshot, and reloading it REVERTED them. Silently:
+          // nothing errored and the graph looked right afterwards. Measured in a live
+          // browser: live width 775, snapshot [768, 768, 1].
+          //
+          // `checkState()` is the tracker's own capture — the same call the command
+          // dispatch already makes after every successful command, for exactly this
+          // reason. Taking it here makes the snapshot mean what this repaint has always
+          // assumed it means.
+          //
+          // It DIFFS FIRST, so an unchanged canvas stays a no-op and no undo entry
+          // appears. Where it does find a change it records one, which is the honest
+          // outcome rather than a side effect: the change really happened, and until
+          // now it was silently discarded instead of being undoable.
+          //
+          // Best-effort. A frontend without `checkState` behaves exactly as before —
+          // this must never be the thing that fails an open.
+          try {
+            target.changeTracker?.checkState?.();
+          } catch {
+            // A tracker that refuses to capture leaves the stale snapshot in place,
+            // which is today's behaviour, not a new failure.
+          }
           // `activeWorkflowNodeCount` deliberately accepts both tracker-owned and flat
           // activeState shapes. Use that SAME state source here: otherwise a frontend
           // that reports the active workflow's 15 nodes through flat `target.activeState`


### PR DESCRIPTION
Closes #874 — claiming it. Mechanism already confirmed on the issue.

## The bug

`workflow_open` on an **already-open** workflow does not re-read the file. It repaints the canvas from `changeTracker.activeState` (`comfyui-mcp-panel.js` ~11653 → ~11712, scoped to `wasOpen`).

That snapshot is captured on **user input events only**. Confirmed live:

```json
{ "liveValue": 775, "trackedWidgetsValues": [768, 768, 1], "activeStateLagsTheLiveGraph": true }
```

So any value a *node* set — an `ImpactWildcardEncode` populate, a `control_after_generate` roll, a subgraph proxy the frontend filled in — is reverted by a reopen. Silently: nothing errors and the graph looks right.

Panel-driven writes are safe; the command dispatch already calls `checkState()` after each successful command, which is exactly what keeps `activeState` current for those.

## Approach

The repaint has to stay — it is how the open proves it rebound the right canvas (#721; #604/#603/#616 depend on those receipts). So make the snapshot true at the moment it is taken: `checkState()` before capturing it, which is the same call the command path already uses for the same reason.

Two things to get right, and I will say what I find on both:

- `checkState()` diffs first, so an unchanged canvas stays a no-op. Where it *does* find a change it pushes an undo entry — which is arguably correct (the change really happened and should be undoable), but it is a behaviour change and needs stating rather than discovering.
- If the frontend has no `checkState`, behaviour must be exactly as today.

Regression test via MockBridge: set a widget with no user input, `workflow_open` the same workflow, assert the value survived.

🤖 Generated with [Claude Code](https://claude.com/claude-code)