### PR TITLE
0.11.60 — reopening a workflow stops reverting values a node set (#874)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+## [0.11.60] - 2026-08-09
+
+> Covers changes since 0.11.59.
+
+### Fixed
+
+- **Reopening a workflow no longer silently reverts values a node set for you
+  (#874).** Reopening an already-open workflow repaints the canvas from ComfyUI's
+  change snapshot rather than from the file — and that snapshot only records what
+  a *user* typed or clicked. So anything a node wrote by itself was quietly rolled
+  back: an ImpactWildcardEncode populate, a `control_after_generate` roll, a
+  subgraph's promoted widgets. Nothing errored, and the graph looked right
+  afterwards, which is why it read as "my edits didn't stick" rather than as a bug.
+
+  Measured: a value of 1337 on the canvas came back as the node's default of 512.
+  The panel now asks ComfyUI to capture the live canvas before it repaints, so what
+  is on screen is what gets restored.
+
+
 ## [0.11.59] - 2026-08-09
 
 > Covers changes since 0.11.58.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-agent-panel"
 description = "Autonomous AI agent in the ComfyUI sidebar - local-first, bring any LLM. Run it on your Claude or ChatGPT subscription (no API keys, no extra LLM costs), on a Kimi K3 / GLM / OpenRouter key, or fully offline on free local models via Ollama, LM Studio, or llama.cpp. The agent drives your live canvas at full parity: add, wire, move and tweak nodes with Ctrl+Z undo, load whole workflows and installer packs in one shot, generate images, video and audio, browse CivitAI, and run your workflow - asking before it spends paid API credits. The sidebar UI for comfyui-mcp, the local-first, agent-native control plane for ComfyUI."
-version = "0.11.59"
+version = "0.11.60"
 license = { file = "LICENSE" }
 requires-python = ">=3.9"
 # UI-only pack: no Python deps. The frontend floor guarantees

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -876,7 +876,7 @@ const DOCS_URL = "https://comfyui-mcp.artokun.io/docs";
 // Panel version — surfaced in the "Need help?" diagnostics blob. Bump via
 // `node scripts/set-version.mjs <v>` (updates this AND pyproject together); CI
 // and the publish gate FAIL if the two ever drift, so this can't go stale.
-const PANEL_VERSION = "0.11.59";
+const PANEL_VERSION = "0.11.60";
 
 // The connected orchestrator's console URL/token (captured off the `backends`
 // bridge message — see onBackends). Drives the "API Keys" credentials frame;


### PR DESCRIPTION
Releases the single fix merged since 0.11.59.

## What ships

**#874** (#875) — silent data loss on reopen.

`workflow_open` on an **already-open** workflow does not re-read the file. It repaints the canvas from `changeTracker.activeState`, which is how the open proves it rebound the right canvas (#721; the receipts in #604/#603/#616 depend on it). But ComfyUI's ChangeTracker captures on **user input events only** — so any value a *node* wrote was absent from that snapshot and got reverted.

Nothing errored, and the graph looked right afterwards. It reads as "my edits didn't stick", not as a bug.

Measured end to end:

| | snapshot | canvas after reopen |
|---|---|---|
| before | `512` (node default) | **512** — value lost |
| after | `1337` | **1337** |

Fix: ask the tracker to capture the live canvas before reading it — the same `checkState()` the command dispatch already calls after every successful command, for the same reason.

## Scope note

This arrived as a subgraph report (promoted proxy values resetting to defaults). Subgraphs are where it gets *noticed* — the frontend fills those in itself — but the cause is general: it reverted **any** programmatically-set value, including the `ImpactWildcardEncode` populate case #696 was about. The issue was retitled accordingly.

## Verification

- New e2e spec drives a real `workflow_open` over the bridge. **Mutation-verified**: removing the fix fails it — and fails on the *semantic* assertion (the tracker snapshot must carry the value), not only on the widget.
- 3295 unit tests pass.
- Full e2e on a clean server: **48/50**, the two failures being the documented #847 residual and a pre-existing `conversation-persistence` flake.

## Codex review — two blockers, both real

| finding | resolution |
|---|---|
| `checkState()` was not awaited — an async tracker would leave the stale read intact, and a late rejection would escape the `try/catch` | awaited inside the same block |
| the e2e matched `/workflow_open RAN\|opened/i`, which an error raised *before* the repaint also satisfies — the final assertion would then pass vacuously | exact post-repaint sentence **plus** an independent snapshot assertion |

Both were caught in review, not by me. Also worth recording: my first version of the test passed with the fix removed, because I resolved the reopen target *after* changing the widget and the dispatch's post-command `checkState()` refreshed the tracker. Order is load-bearing there, and the spec now says so.

## A caveat on measurement

Mid-session the bare ComfyUI serving `:8188` died and the user's ComfyUI Desktop instance took the port — different model paths and IO dirs. Full-suite numbers swung 4 → 19 → 10 failures on identical code with run time doubling. I did not report any of those; the 48/50 above is from a clean server that stayed up for the whole run.

## Changelog note

Hand-written — `scripts/gen-changelog.mjs` walks back to the last git **tag**, so it regenerated 164 commits already shipped in 0.11.47–0.11.59.

🤖 Generated with [Claude Code](https://claude.com/claude-code)