### PR TITLE
fix(save): an in-place save must not write stale bytes (#878)

### DIFF
--- a/browser_tests/save-persists-node-set-values.spec.ts
+++ b/browser_tests/save-persists-node-set-values.spec.ts
@@ -1,0 +1,100 @@
+/**
+ * #878 — an in-place save must not write stale bytes.
+ *
+ * Every save route persists `wf.activeState` (workflow-save.js states this at ~394), and
+ * ComfyUI's ChangeTracker fills that on USER INPUT events only. So a value written by a
+ * NODE — an ImpactWildcardEncode populate, a control_after_generate roll, a subgraph's
+ * promoted widgets — was absent from it, and an in-place save wrote the STALE bytes over
+ * the user's real file.
+ *
+ * The COPY routes have flushed the canvas into the tracker before reading it since #708.
+ * In-place — the one route that overwrites an EXISTING file — did not.
+ *
+ * This asserts on the BYTES ON DISK, read back through ComfyUI's own userdata API, not on
+ * anything the panel reports. A save that returns `saved: true` while the file disagrees
+ * with the screen is exactly the failure, so the panel's own account of it proves nothing.
+ */
+import { test, expect } from './fixtures/panelTest'
+import { claimFreshCanvas, settleCanvas } from './fixtures/canvasIdentity'
+
+/** Read a saved workflow back off disk through ComfyUI's userdata API. */
+async function readWidgetsFromDisk(
+  page: import('@playwright/test').Page,
+  workflowName: string,
+  nodeType: string
+) {
+  return page.evaluate(
+    async ({ name, type }) => {
+      const api = (window as any).comfyAPI?.api?.api
+      const res = await api.fetchApi(`/userdata/${encodeURIComponent('workflows/' + name + '.json')}`)
+      if (!res.ok) return { error: res.status as number }
+      const json = await res.json()
+      const node = (json?.nodes || []).find((n: any) => n.type === type)
+      return { widgets: (node?.widgets_values ?? null) as unknown[] | null }
+    },
+    { name: workflowName, type: nodeType }
+  )
+}
+
+test('an in-place save persists a value the tracker never saw', async ({
+  page,
+  panel,
+  mockBridge
+}) => {
+  await panel.goto()
+  await panel.setBridgeUrl(mockBridge.url)
+  await panel.openSidebar()
+  await panel.connect()
+
+  await claimFreshCanvas(page, mockBridge)
+  await page.evaluate(() => {
+    const w = window as any
+    const app = w.comfyAPI?.app?.app || w.app
+    const graph = app?.canvas?.graph ?? app?.graph
+    const LG = w.LiteGraph || w.comfyAPI?.litegraph?.LiteGraph
+    graph.add(LG.createNode('EmptyLatentImage'))
+  })
+  await settleCanvas(page)
+
+  // First save gives the tab a real path. A never-saved tab takes the COPY route,
+  // which already flushed — this spec is about the in-place overwrite.
+  const first = await mockBridge.command('workflow_save', {})
+  expect(first.ok, 'the first save must succeed so the tab has a path').toBe(true)
+  const name = String(first.result?.workflow || '')
+  expect(name, 'the save must report the workflow name').toBeTruthy()
+
+  // Change a value the way a NODE does: directly, no user input event — and issue no
+  // panel command afterwards, because the dispatch captures after every completed
+  // command and would refresh the tracker, hiding the very lag this is about.
+  await page.evaluate(() => {
+    const w = window as any
+    const app = w.comfyAPI?.app?.app || w.app
+    const graph = app?.canvas?.graph ?? app?.graph
+    const node = (graph?.nodes || []).find((n: any) => n.type === 'EmptyLatentImage')
+    const widget = (node.widgets || []).find((x: any) => x.name === 'width')
+    widget.value = 1337
+  })
+
+  // Precondition: the tracker must NOT have seen it, or this passes for the wrong reason.
+  const trackerLagged = await page.evaluate(() => {
+    const w = window as any
+    const app = w.comfyAPI?.app?.app || w.app
+    const wf = app?.extensionManager?.workflow?.activeWorkflow
+    const node = (wf?.changeTracker?.activeState?.nodes || []).find(
+      (n: any) => n.type === 'EmptyLatentImage'
+    )
+    return !((node?.widgets_values || []) as unknown[]).includes(1337)
+  })
+  expect(trackerLagged, 'precondition: the tracker must not have seen the change').toBe(true)
+
+  const saved = await mockBridge.command('workflow_save', {})
+  expect(saved.ok, 'the in-place save must succeed').toBe(true)
+
+  // THE BYTES, not the panel's account of them. Before #878 this was the node's
+  // default — the file quietly disagreeing with the screen.
+  const onDisk = await readWidgetsFromDisk(page, name, 'EmptyLatentImage')
+  expect(onDisk.error, 'the saved workflow must be readable from disk').toBeUndefined()
+  expect(onDisk.widgets, 'the saved file must carry the live value, not the tracker default').toContain(
+    1337
+  )
+})

--- a/web/js/lib/workflow-save.js
+++ b/web/js/lib/workflow-save.js
@@ -784,8 +784,20 @@ export async function saveActiveWorkflow(
   //   · An ABSENT tracker/method is not a throw. Optional chaining takes no capture,
   //     which is the same position as an unproven binding and stays allowed.
   //
+  // WHY "bound" IS ENOUGH, since it is the highest-risk question here (codex).
+  // `prepareForSave()` serializes the ONE shared root into whichever tracker is
+  // ACTIVE, so the worry is a bound canvas coexisting with a non-active `wf`. It
+  // cannot write the wrong graph either way: ComfyUI's `prepareForSave` is a
+  // documented no-op unless its own workflow is the active one (isActiveTracker) —
+  // the same fact the copy route relies on below — so a `wf` that is not active
+  // captures NOTHING, and a `wf` that IS active captures a canvas "bound" has
+  // already proven to be this workflow's. Both branches are safe; the guard is the
+  // belt over ComfyUI's braces, not the only thing standing between us and #708.
+  //
   // Synchronous, immediately after the re-assert and with nothing awaited before the
-  // write, so it cannot open a window the assert just closed.
+  // write, so it cannot open a window the assert just closed — and, for the same
+  // reason, it cannot widen the #442 raw-byte gate's check-to-write interval either:
+  // no other JS runs between them.
   if (normalizeCanvasBinding(canvasBinding, wf) === "bound") {
     try {
       wf?.changeTracker?.prepareForSave?.();

--- a/web/js/lib/workflow-save.js
+++ b/web/js/lib/workflow-save.js
@@ -758,6 +758,46 @@ export async function saveActiveWorkflow(
   // with nothing awaited between it and saveInPlace (see the guard's own note on the
   // residual microtask gap inside ComfyUI's save()).
   assertCanvasNotForeign();
+  // #878 — REFRESH BEFORE OVERWRITING, exactly as the copy route does at its own
+  // write (see the `prepareForSave` note in the save-as adapter below).
+  //
+  // This route persists `wf.activeState` through `saveWorkflow`, and ComfyUI fills
+  // that on USER INPUT events. So a value written by a NODE — an
+  // ImpactWildcardEncode populate, a control_after_generate roll, a subgraph's
+  // promoted widgets — was absent from it, and an in-place save wrote the STALE
+  // bytes over the user's real file. Measured: live canvas 1337, tracker
+  // [512,512,1], on disk after the save [512,512,1]. Silent, because a save does
+  // not repaint: the screen still showed 1337 while the file disagreed.
+  //
+  // The copy routes have had this flush since #708; in-place — the one route that
+  // overwrites an EXISTING file — did not. The panel's own command dispatch
+  // captures after each completed command, which is why a panel edit then a save
+  // was fine and only node-written values were exposed.
+  //
+  // Same three properties as the copy route, and for the same reasons:
+  //   · ONLY when the canvas is PROVEN this tab's. `prepareForSave` serializes the
+  //     one shared root into whichever tracker is active, so capturing an unproven
+  //     canvas is how #708 wrote a foreign graph into the wrong file.
+  //   · A THROWING capture REFUSES the save. It leaves the tracker knowably behind
+  //     the canvas, and writing anyway would silently drop the newest edit — the
+  //     precise failure this fix exists to remove, reintroduced one line later.
+  //   · An ABSENT tracker/method is not a throw. Optional chaining takes no capture,
+  //     which is the same position as an unproven binding and stays allowed.
+  //
+  // Synchronous, immediately after the re-assert and with nothing awaited before the
+  // write, so it cannot open a window the assert just closed.
+  if (normalizeCanvasBinding(canvasBinding, wf) === "bound") {
+    try {
+      wf?.changeTracker?.prepareForSave?.();
+    } catch (err) {
+      throw new Error(
+        `refusing to save "${currentName || finalTargetPath}" in place: the live canvas is this ` +
+          `workflow's, but capturing it failed (${describeThrown(err)}), so the overwrite could ` +
+          `silently drop the newest edits. Nothing was written — retry, or reload the ComfyUI tab ` +
+          `if it persists (#878).`,
+      );
+    }
+  }
   if (inPlace === "authorize") markPersistedForOverwrite(wf); // sync (post-assert) ⇒ no leak window
   recordOutcome(details, "in-place", { sourcePath: currentPath, targetPath: finalTargetPath });
   const savedRecord = await saveInPlace(svc, wf, { readSaveFailureCause, path: finalTargetPath });


### PR DESCRIPTION
Closes #878 — claiming it. Reproduced end to end before filing.

## Measured

```
live canvas width : 1337
changeTracker     : [512, 512, 1]
ON DISK after save: [512, 512, 1]     <- read back through ComfyUI's /userdata API
```

`panel_save_workflow({})` overwrote the user's real file with the default. Silent — nothing errors, and the canvas still shows 1337 because a save does not repaint.

## Why

`workflow-save.js:394` states it: every route persists `wf.activeState`, and ComfyUI fills that on **user input events only**. The **copy** routes already compensate with a guarded `prepareForSave()` flush (~913, with the reasoning written out). `saveInPlace` (~1325) has none — so the one route that overwrites an existing file is the one that does not refresh first.

## Approach

Give the in-place route the same guarded flush the copy route has, with the same properties, because they were chosen deliberately:

- **Only when the canvas is proven to be this tab's** (`normalizeCanvasBinding(...) === "bound"`). Capturing an unproven canvas is how #708 wrote a foreign graph into the wrong file.
- **A throwing capture REFUSES the save** rather than proceeding. A serializer that failed mid-capture leaves the tracker behind the canvas, and saving anyway would silently drop the newest edit — the copy route already reasons exactly this way.
- **An absent tracker/method is not a throw** — optional chaining simply takes no capture, which is the same position as an unproven binding and stays allowed.

Regression test: change a widget with no user input, save in place, read the bytes back off disk through ComfyUI's own API and assert the value survived. Mutation-verified against the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)