### PR TITLE
0.11.61 — centring on a node honours the zoom you asked for

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+## [0.11.61] - 2026-08-09
+
+> Covers changes since 0.11.60.
+
+### Fixed
+- Centring on a node now honours the zoom you asked for. `panel_canvas` with
+  `action:"center_on_node"` accepted a `scale` and quietly ignored it, so "centre on node
+  42 at 1.5x" centred at whatever zoom happened to be set — and the reply echoed the old
+  zoom back, so nothing said the request had been dropped. The zoom is applied before the
+  centring (applying it afterwards would slide the node straight back off-centre), the
+  reply reports the zoom that took effect, and a scale outside the accepted range is
+  refused rather than silently clamped — the same range `action:"zoom"` already enforced
+  (#876, #754)
+
 ## [0.11.60] - 2026-08-09
 
 > Covers changes since 0.11.59.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-agent-panel"
 description = "Autonomous AI agent in the ComfyUI sidebar - local-first, bring any LLM. Run it on your Claude or ChatGPT subscription (no API keys, no extra LLM costs), on a Kimi K3 / GLM / OpenRouter key, or fully offline on free local models via Ollama, LM Studio, or llama.cpp. The agent drives your live canvas at full parity: add, wire, move and tweak nodes with Ctrl+Z undo, load whole workflows and installer packs in one shot, generate images, video and audio, browse CivitAI, and run your workflow - asking before it spends paid API credits. The sidebar UI for comfyui-mcp, the local-first, agent-native control plane for ComfyUI."
-version = "0.11.60"
+version = "0.11.61"
 license = { file = "LICENSE" }
 requires-python = ">=3.9"
 # UI-only pack: no Python deps. The frontend floor guarantees

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -876,7 +876,7 @@ const DOCS_URL = "https://comfyui-mcp.artokun.io/docs";
 // Panel version — surfaced in the "Need help?" diagnostics blob. Bump via
 // `node scripts/set-version.mjs <v>` (updates this AND pyproject together); CI
 // and the publish gate FAIL if the two ever drift, so this can't go stale.
-const PANEL_VERSION = "0.11.60";
+const PANEL_VERSION = "0.11.61";
 
 // The connected orchestrator's console URL/token (captured off the `backends`
 // bridge message — see onBackends). Drives the "API Keys" credentials frame;


### PR DESCRIPTION
One change since 0.11.60: **#876 / #754 part (3)**.

`panel_canvas` with `action:"center_on_node"` accepted a `scale` and never read it. The zoom was discarded and the reply echoed the *old* zoom back, so nothing indicated the request had been dropped — the same accepted-then-discarded shape as the `node_ids` half of #754.

The zoom is applied **before** the centring; applying it afterwards would slide the node straight back off-centre, which is #401's hazard one branch over. A test pins that both `center_on_node` and `zoom` accept exactly the same range, so the duplicated literal cannot drift.

## Gates
- 3302 panel unit tests
- three mutations killed, including moving the zoom after the centring
- tool vocabulary + typecheck clean; `pyproject` and `PANEL_VERSION` both 0.11.61
- verified in real Chromium on merged main: zoom applied (1.5), centring observed the new scale, reply reports 1.5, zoom-then-centre offsets equal centring already at that zoom, out-of-range refused, zero page errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)