### PR TITLE
0.11.62 — saving stops writing stale values over your file (#878)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,28 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+## [0.11.62] - 2026-08-09
+
+> Covers changes since 0.11.61.
+
+### Fixed
+
+- **Saving a workflow no longer writes stale values over your file (#878).** Saving
+  in place persisted ComfyUI's change snapshot rather than the live canvas, and that
+  snapshot only records what a *user* typed or clicked. So anything a node had set
+  for you was written out at its old value: an ImpactWildcardEncode populate, a
+  `control_after_generate` roll, a subgraph's promoted widgets.
+
+  Measured: with 1337 on the canvas, the file on disk received the node's default of
+  512. Nothing errored, and the canvas still showed 1337 — a save does not repaint —
+  so the file quietly disagreed with the screen until the next reopen.
+
+  Saving under a *new* name already refreshed the canvas first; the route that
+  overwrites an existing file was the one that did not. It now does, and refuses the
+  save outright if that refresh fails rather than writing something it knows is
+  behind.
+
+
 ## [0.11.61] - 2026-08-09
 
 > Covers changes since 0.11.60.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-agent-panel"
 description = "Autonomous AI agent in the ComfyUI sidebar - local-first, bring any LLM. Run it on your Claude or ChatGPT subscription (no API keys, no extra LLM costs), on a Kimi K3 / GLM / OpenRouter key, or fully offline on free local models via Ollama, LM Studio, or llama.cpp. The agent drives your live canvas at full parity: add, wire, move and tweak nodes with Ctrl+Z undo, load whole workflows and installer packs in one shot, generate images, video and audio, browse CivitAI, and run your workflow - asking before it spends paid API credits. The sidebar UI for comfyui-mcp, the local-first, agent-native control plane for ComfyUI."
-version = "0.11.61"
+version = "0.11.62"
 license = { file = "LICENSE" }
 requires-python = ">=3.9"
 # UI-only pack: no Python deps. The frontend floor guarantees

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -876,7 +876,7 @@ const DOCS_URL = "https://comfyui-mcp.artokun.io/docs";
 // Panel version — surfaced in the "Need help?" diagnostics blob. Bump via
 // `node scripts/set-version.mjs <v>` (updates this AND pyproject together); CI
 // and the publish gate FAIL if the two ever drift, so this can't go stale.
-const PANEL_VERSION = "0.11.61";
+const PANEL_VERSION = "0.11.62";
 
 // The connected orchestrator's console URL/token (captured off the `backends`
 // bridge message — see onBackends). Drives the "API Keys" credentials frame;


### PR DESCRIPTION
Releases the fix merged since 0.11.61.

## Why .62 and not .61

Another session's 0.11.61 release commit (`8f115e5`, for #876) landed **between** my #878 fix merging (`a3d4cc4`) and this release being cut — so the published 0.11.61 does **not** contain the save fix. Verified against the release commit's tree rather than assumed. Cutting .62 rather than renumbering.

## What ships

**#878** (#879) — an in-place save wrote stale bytes over the user's real file.

Every save route persists `wf.activeState`, and ComfyUI's ChangeTracker fills that on **user input events only**. So a value written by a *node* was absent from it and got written out at its old value.

```
live canvas width : 1337
changeTracker     : [512, 512, 1]
ON DISK after save: [512, 512, 1]
```

Silent — a save does not repaint, so the screen still showed 1337 while the file disagreed. The next reopen shows the file's value and the edit reads as "didn't stick".

The **copy** routes have flushed the canvas into the tracker before reading it since #708. `saveInPlace` — the only route that overwrites an **existing** file — had no equivalent. It does now, with the same three properties: only when the canvas is proven this tab's, refusing the save if the capture throws, and treating an absent tracker as "no capture" rather than an error.

## How it was found

Not reported. It fell out of #874 (shipped in 0.11.60): while fixing the reopen path I read `workflow-save.js:394` — *"EVERY save route here ultimately persists `wf.activeState`"* — and checked whether the same staleness reached disk. It did.

That makes three issues from one ChangeTracker property: #696 (misdiagnosed as a binding mismatch), #874 (reopen reverted the canvas), #878 (save wrote stale bytes). This one was the worst, because it was the only one that touched the file.

## Verification

- Regression test asserts on the **bytes read back off disk** through ComfyUI's userdata API, not on the panel's reply — a save reporting `saved: true` while the file disagrees is exactly the bug. **Mutation-verified**: removing the flush puts `[512, 512, 1]` back on disk.
- 3302 unit tests pass; 48/51 e2e (three known-failing: the #847 residual and two pre-existing flakes).
- Both data-loss fixes (#874, #878) re-verified together against merged main.

## Codex review

One finding, and it was the right one: the diff alone did not prove `canvasBinding === "bound"` implies `wf` is the *active* tracker that `prepareForSave()` writes into. Answered from this file's own copy-route comment — `prepareForSave` is a documented no-op unless its workflow is active, so an inactive `wf` captures nothing and an active one captures a canvas already proven to be its. Now written at the new call site rather than left to be rediscovered.

## Changelog note

Hand-written — `scripts/gen-changelog.mjs` walks back to the last git **tag**, so it regenerated 168 commits already shipped in 0.11.47–0.11.61.

🤖 Generated with [Claude Code](https://claude.com/claude-code)