### PR TITLE
0.11.63 — closing a workflow stops discarding changes a node made (#882)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,39 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+## [0.11.63] - 2026-08-09
+
+> Covers changes since 0.11.62.
+
+### Fixed
+
+- **Closing a workflow no longer discards changes a node made (#882).** ComfyUI decides
+  whether a tab has unsaved work from a snapshot it takes when *you* type or click.
+  Anything a node set for you is invisible to it — an ImpactWildcardEncode populate, a
+  `control_after_generate` roll, a subgraph's promoted widgets — so the tab kept
+  reporting itself as clean while the canvas already differed from the file.
+
+  Two guards exist precisely to stop work being thrown away, and both believed that
+  report. Closing a workflow refuses when there are unsaved changes, because closing
+  bypasses ComfyUI's own save prompt — it saw "clean" and closed, and the values were
+  gone. The confirmation before an operation overwrites the canvas was skipped the same
+  way, so the canvas was replaced without anyone being asked.
+
+  Measured: after a save the tab reads clean, correctly. After a node writes a value it
+  still reads clean — wrong. Refreshing the snapshot flips it to modified, which is the
+  truth.
+
+  Both guards now refresh the snapshot before trusting it, and — this is the part that
+  matters — they only trust the answer when the refresh can be shown to have actually
+  happened. ComfyUI silently skips it while a graph is loading, while an undo is
+  replaying, and in a few other moments, in a way that is indistinguishable from success
+  from the outside. When it cannot be established that the refresh landed, the close
+  refuses and the confirmation is shown, rather than assuming. `force: true` still
+  closes, so nothing becomes unclosable.
+
+  Fourth and last of a family: #696, #874 and #878 were the same stale snapshot read in
+  other places — this one was the guards meant to protect you from it.
+
 ## [0.11.62] - 2026-08-09
 
 > Covers changes since 0.11.61.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-agent-panel"
 description = "Autonomous AI agent in the ComfyUI sidebar - local-first, bring any LLM. Run it on your Claude or ChatGPT subscription (no API keys, no extra LLM costs), on a Kimi K3 / GLM / OpenRouter key, or fully offline on free local models via Ollama, LM Studio, or llama.cpp. The agent drives your live canvas at full parity: add, wire, move and tweak nodes with Ctrl+Z undo, load whole workflows and installer packs in one shot, generate images, video and audio, browse CivitAI, and run your workflow - asking before it spends paid API credits. The sidebar UI for comfyui-mcp, the local-first, agent-native control plane for ComfyUI."
-version = "0.11.62"
+version = "0.11.63"
 license = { file = "LICENSE" }
 requires-python = ">=3.9"
 # UI-only pack: no Python deps. The frontend floor guarantees

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -876,7 +876,7 @@ const DOCS_URL = "https://comfyui-mcp.artokun.io/docs";
 // Panel version — surfaced in the "Need help?" diagnostics blob. Bump via
 // `node scripts/set-version.mjs <v>` (updates this AND pyproject together); CI
 // and the publish gate FAIL if the two ever drift, so this can't go stale.
-const PANEL_VERSION = "0.11.62";
+const PANEL_VERSION = "0.11.63";
 
 // The connected orchestrator's console URL/token (captured off the `backends`
 // bridge message — see onBackends). Drives the "API Keys" credentials frame;


### PR DESCRIPTION
Releases #883 (fixes #882).

ComfyUI reports a tab as clean based on a snapshot it takes on user input only, so
anything a *node* wrote was invisible to it. `workflow_close` refuses to close a tab
with unsaved changes precisely because closing bypasses ComfyUI's save prompt — it saw
"clean" and closed. The overwrite confirmation was skipped the same way.

Both guards now refresh the snapshot first, and only trust the result when the refresh
can be shown to have landed: ComfyUI silently skips it mid-load, mid-undo and inside an
open change transaction, indistinguishably from success. Unproven means refuse, with
`force: true` still available.

Verification: 3306/3306 unit tests; 24 targeted mutations each verified to fail the
suite when applied; e2e family specs pass, and the new spec was mutation-checked to
confirm the close *succeeds* and loses the value without the fix. Six codex review
passes — five real defects found and fixed (async rejection falling open, inactive-tab
misclassification, unguarded snapshot reads, hostile-thenable bypass, renamed-field
hole) — ending at SHIP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)