### PR TITLE
fix(binding): a blank canvas must be readable (#833)

### DIFF
--- a/browser_tests/blank-canvas-not-wedged.spec.ts
+++ b/browser_tests/blank-canvas-not-wedged.spec.ts
@@ -1,5 +1,5 @@
 /**
- * #833 — a blank canvas must be readable AND buildable.
+ * #833 — a blank canvas must be READABLE.
  *
  * An empty canvas is the ordinary state a user is in right before asking the agent to
  * build a workflow. It was the one state where every `panel_*` graph tool was refused,
@@ -18,10 +18,17 @@
  *     graph_outline    -> [empty-binding-unproven]
  *     graph_add_node   -> [dirty-mutation-binding-unproven]
  *
+ * SCOPE: the READ half only. Admitting mutations needs more than emptiness, and the
+ * difference is not academic — the panel's own reconnect tab restore can leave the
+ * shared root holding workflow W while the active pointer names a different workflow N
+ * (the #708 mismatch). If both are blank, both sides read provably empty, and a seal
+ * on that evidence would create N's first node on W's canvas. Emptiness proves there is
+ * nothing to mis-attribute; it does not prove WHOSE canvas this is, and a mutation
+ * needs the second thing. Tracked on #833 for a deliberate fix.
+ *
  * Driven over the bridge rather than asserted at source, because the wedge is the
  * interaction of the binding guard with ComfyUI's real tracker and only appears when
- * both run. Both halves are asserted: fixing only the read half would still leave the
- * user unable to build, which is what they actually wanted to do.
+ * both run.
  */
 import { test, expect } from './fixtures/panelTest'
 import { claimFreshCanvas, settleCanvas } from './fixtures/canvasIdentity'
@@ -34,7 +41,7 @@ async function emptyTheCanvas(page: import('@playwright/test').Page) {
   })
 }
 
-test('a blank canvas can be read and built on', async ({ page, panel, mockBridge }) => {
+test('a blank canvas can be read', async ({ page, panel, mockBridge }) => {
   await panel.goto()
   await panel.setBridgeUrl(mockBridge.url)
   await panel.openSidebar()
@@ -65,24 +72,11 @@ test('a blank canvas can be read and built on', async ({ page, panel, mockBridge
   expect(outline.ok, 'a blank canvas must be readable').toBe(true)
   expect(outline.result?.node_count).toBe(0)
 
-  // BUILD. Before the fix: [dirty-mutation-binding-unproven]. This is the half that
-  // matters — a user on a blank canvas is about to add nodes, not read zero of them.
+  // Mutations are deliberately NOT admitted by this change — see the scope note above.
+  // Asserted so the boundary is pinned: if a later change starts admitting them, it
+  // must do so on identity evidence and update this test on purpose.
   const added = await mockBridge.command('graph_add_node', { class_type: 'EmptyLatentImage' })
-  expect(JSON.stringify(added)).not.toContain('dirty-mutation-binding-unproven')
-  expect(added.ok, 'a blank canvas must be buildable').toBe(true)
-
-  // And the node must actually be on the canvas — an `ok` that changed nothing would
-  // satisfy the assertions above while leaving the user exactly as stuck.
-  await expect
-    .poll(() =>
-      page.evaluate(() => {
-        const w = window as any
-        const app = w.comfyAPI?.app?.app || w.app
-        const graph = app?.canvas?.graph ?? app?.graph
-        return (graph?.nodes || []).filter((n: any) => n.type === 'EmptyLatentImage').length
-      })
-    )
-    .toBe(1)
+  expect(added.ok, 'building still needs identity evidence emptiness cannot supply').toBe(false)
 })
 
 // The negative case — a canvas that reads empty while its workflow claims NODES — is

--- a/browser_tests/blank-canvas-not-wedged.spec.ts
+++ b/browser_tests/blank-canvas-not-wedged.spec.ts
@@ -1,0 +1,93 @@
+/**
+ * #833 — a blank canvas must be readable AND buildable.
+ *
+ * An empty canvas is the ordinary state a user is in right before asking the agent to
+ * build a workflow. It was the one state where every `panel_*` graph tool was refused,
+ * with no recovery: the reporter's ladder (re-target, new workflow, re-open) all failed,
+ * and the regression report adds that it survives both Ctrl+Shift+R and a ComfyUI
+ * restart.
+ *
+ * The cause is that BOTH available proofs are structurally unavailable here:
+ *
+ *   - content cannot identify an empty canvas — every blank canvas serialises alike, so
+ *     the content proof behind the seal has nothing to match;
+ *   - a blank tab is ALWAYS dirty (creating or clearing it is what dirties it), so the
+ *     emptiness proof short-circuits on `isModified` and can never succeed.
+ *
+ * Measured before the fix, on this exact path:
+ *     graph_outline    -> [empty-binding-unproven]
+ *     graph_add_node   -> [dirty-mutation-binding-unproven]
+ *
+ * Driven over the bridge rather than asserted at source, because the wedge is the
+ * interaction of the binding guard with ComfyUI's real tracker and only appears when
+ * both run. Both halves are asserted: fixing only the read half would still leave the
+ * user unable to build, which is what they actually wanted to do.
+ */
+import { test, expect } from './fixtures/panelTest'
+import { claimFreshCanvas, settleCanvas } from './fixtures/canvasIdentity'
+
+async function emptyTheCanvas(page: import('@playwright/test').Page) {
+  await page.evaluate(() => {
+    const w = window as any
+    const app = w.comfyAPI?.app?.app || w.app
+    ;(app?.canvas?.graph ?? app?.graph).clear()
+  })
+}
+
+test('a blank canvas can be read and built on', async ({ page, panel, mockBridge }) => {
+  await panel.goto()
+  await panel.setBridgeUrl(mockBridge.url)
+  await panel.openSidebar()
+  await panel.connect()
+  await claimFreshCanvas(page, mockBridge)
+
+  await emptyTheCanvas(page)
+  await settleCanvas(page)
+
+  // Precondition: this must be the wedge's own shape, or the test passes for the
+  // wrong reason. The canvas is empty AND the tab is dirty — the combination that
+  // no proof could clear.
+  const shape = await page.evaluate(() => {
+    const w = window as any
+    const app = w.comfyAPI?.app?.app || w.app
+    const wf = app?.extensionManager?.workflow?.activeWorkflow
+    return {
+      liveNodes: (app?.rootGraph ?? app?.graph)?._nodes?.length ?? null,
+      isModified: wf?.isModified ?? null
+    }
+  })
+  expect(shape.liveNodes, 'precondition: the canvas must be empty').toBe(0)
+  expect(shape.isModified, 'precondition: a blank tab is dirty — that is the wedge').toBe(true)
+
+  // READ. Before the fix: [empty-binding-unproven].
+  const outline = await mockBridge.command('graph_outline', {})
+  expect(JSON.stringify(outline)).not.toContain('empty-binding-unproven')
+  expect(outline.ok, 'a blank canvas must be readable').toBe(true)
+  expect(outline.result?.node_count).toBe(0)
+
+  // BUILD. Before the fix: [dirty-mutation-binding-unproven]. This is the half that
+  // matters — a user on a blank canvas is about to add nodes, not read zero of them.
+  const added = await mockBridge.command('graph_add_node', { class_type: 'EmptyLatentImage' })
+  expect(JSON.stringify(added)).not.toContain('dirty-mutation-binding-unproven')
+  expect(added.ok, 'a blank canvas must be buildable').toBe(true)
+
+  // And the node must actually be on the canvas — an `ok` that changed nothing would
+  // satisfy the assertions above while leaving the user exactly as stuck.
+  await expect
+    .poll(() =>
+      page.evaluate(() => {
+        const w = window as any
+        const app = w.comfyAPI?.app?.app || w.app
+        const graph = app?.canvas?.graph ?? app?.graph
+        return (graph?.nodes || []).filter((n: any) => n.type === 'EmptyLatentImage').length
+      })
+    )
+    .toBe(1)
+})
+
+// The negative case — a canvas that reads empty while its workflow claims NODES — is
+// asserted in browser_tests/unit/empty-canvas-wedge.test.mjs, not here. Constructing it
+// end-to-end is unreliable: settling the canvas legitimately SEALS the binding while the
+// node is present, after which deleting it is an ordinary edit on a proven canvas and is
+// correctly allowed. The dangerous shape is a binding that was NEVER proven, which the
+// unit suite can build exactly.

--- a/browser_tests/unit/empty-canvas-wedge.test.mjs
+++ b/browser_tests/unit/empty-canvas-wedge.test.mjs
@@ -9,6 +9,10 @@ import {
   sealProvenRootBinding,
   graphRootMatchesState,
   resolveGraphBindingVerdict,
+  emptyCanvasBindingProven,
+  emptySealStampReassignable,
+  EMPTY_SEAL_FIELD,
+  rootContentProvesActiveWorkflow,
 } from "../../web/js/lib/graph-binding.js";
 
 // #833 — with an EMPTY workflow active, every panel_* graph tool was refused and
@@ -171,22 +175,29 @@ test("TWO blank tabs no longer wedge every graph tool (#833)", () => {
   const uuid = "48e8cdaa-f399-4ba8-a76d-45dafc43d859";
   const root = emptyRoot();
 
-  // The seal is still refused — two blank tabs genuinely are ambiguous, and this
-  // change does not pretend otherwise.
-  const exclusive = proofExclusive(root, active, [active, other]);
-  assert.equal(exclusive, false, "a second blank tab still blocks the seal");
-  assert.equal(
-    sealProvenRootBinding({ rootGraph: root, activeWorkflow: active, activeWorkflowUuid: uuid, proofExclusive: exclusive }),
-    false,
-  );
+  // The CONTENT exclusivity probe is not satisfied — two blank tabs genuinely are
+  // ambiguous about which one an empty root belongs to.
+  assert.equal(proofExclusive(root, active, [active, other]), false);
 
-  // …and the tools work anyway, because the canvas is now PROVABLY empty, which
-  // is the first escape and never needed the seal.
+  // The seal fires anyway, on the EMPTY path, which does not ask for exclusivity.
+  // Requiring it made the seal unreachable in practice: any open tab not activated
+  // this session has no tracker state and reads as "could also be blank". Ambiguity
+  // is handled by making the stamp re-assignable instead — see below.
+  assert.equal(
+    sealProvenRootBinding({
+      rootGraph: root, activeWorkflow: active, activeWorkflowUuid: uuid,
+      proofExclusive: false,
+    }),
+    true,
+  );
+  assert.equal(root.extra.comfyui_mcp[EMPTY_SEAL_FIELD], true, "the stamp must mark itself");
+
+  // …and the tools work, which is the point of the whole issue.
   assert.equal(graphEmptyBindingUnproven({ graph: root, rootGraph: root, activeWorkflow: active, activeWorkflowUuid: uuid }), false);
   assert.equal(
     resolveGraphBindingVerdict({
       graph: root, rootGraph: root, activeWorkflow: active, activeWorkflowUuid: uuid,
-      nodeCount: 0, includeBaselineReadGuard: true, requireDirtyMutationBinding: true,
+      liveNodeCount: 0, includeBaselineReadGuard: true, requireDirtyMutationBinding: true,
     }),
     null,
     "no refusal — a blank canvas is a legitimate state to read and build on",
@@ -291,4 +302,159 @@ test("the same two routes are blocked on the STAMPING side", () => {
   assert.equal(graphRootProvenEmpty(rootWith({ '{"nodes":[{"id":1}]}': true })), false);
   assert.equal(graphRootProvenEmpty(rootWith({ frontendVersion: '{"nodes":[{"id":1}]}' })), false);
   assert.equal(graphRootProvenEmpty(rootWith({ frontendVersion: "1.47.12" })), true);
+});
+
+// ── The DIRTY blank tab — the half 0.11.49 could not reach (#833 regression) ──
+//
+// Reported again on panel 0.11.62 after the 0.11.49 fix shipped. The escapes above
+// all require a CLEAN tab, and a blank tab is never clean: creating or clearing it
+// is what dirties it. So on the reported path both proofs are structurally
+// unavailable, and the regression report adds that it survives a hard refresh AND a
+// ComfyUI restart — there was no exit at all.
+//
+// Reproduced end-to-end before changing anything (browser_tests/blank-canvas-not-wedged.spec.ts):
+//     graph_outline  -> [empty-binding-unproven]
+//     graph_add_node -> [dirty-mutation-binding-unproven]
+
+const dirtyBlankTab = (name) => ({ ...blankTab(name), isModified: true });
+
+test("#833 regression: a DIRTY blank canvas is readable", () => {
+  const active = dirtyBlankTab("Untitled");
+  const root = emptyRoot();
+  // The old escapes genuinely cannot fire here — this is what makes it a wedge.
+  assert.equal(activeWorkflowProvenEmpty(active), false, "cleanliness proof is unavailable");
+  assert.equal(
+    rootContentProvesActiveWorkflow({ rootGraph: root, activeWorkflow: active, proofExclusive: true }),
+    false,
+    "content proof is unavailable — an empty canvas has nothing to match",
+  );
+  // …and the read is admitted anyway, because BOTH sides are provably content-free.
+  assert.equal(emptyCanvasBindingProven({ rootGraph: root, activeWorkflow: active }), true);
+  assert.equal(
+    graphEmptyBindingUnproven({ graph: root, rootGraph: root, activeWorkflow: active, activeWorkflowUuid: null }),
+    false,
+  );
+});
+
+test("#833 regression: a DIRTY blank canvas is BUILDABLE — the seal fires", () => {
+  // The half that matters: a user on a blank canvas is about to add nodes. Without
+  // the seal every mutation stays refused as dirty-mutation-binding-unproven.
+  const active = dirtyBlankTab("Untitled");
+  const uuid = "48e8cdaa-f399-4ba8-a76d-45dafc43d859";
+  const root = emptyRoot();
+  assert.equal(
+    sealProvenRootBinding({
+      rootGraph: root, activeWorkflow: active, activeWorkflowUuid: uuid,
+      proofExclusive: true, emptyProofExclusive: true,
+    }),
+    true,
+  );
+  assert.equal(root.extra.comfyui_mcp.workflow_uuid, uuid, "the root must carry the identity");
+  assert.equal(
+    resolveGraphBindingVerdict({
+      graph: root, rootGraph: root, activeWorkflow: active, activeWorkflowUuid: uuid,
+      liveNodeCount: 0, includeBaselineReadGuard: true, requireDirtyMutationBinding: true,
+    }),
+    null,
+    "no refusal — the sealed root now proves the binding",
+  );
+});
+
+test("#833: emptiness is not a skeleton key", () => {
+  const uuid = "48e8cdaa-f399-4ba8-a76d-45dafc43d859";
+
+  // A workflow that claims NODES against an empty canvas is the FALSE-EMPTY read
+  // (#389/#604) and must stay fenced — this is the shape the guard exists for.
+  const claimsNodes = dirtyBlankTab("Has content");
+  claimsNodes.changeTracker.activeState = { ...emptyState(), nodes: [{ id: 1, type: "KSampler" }] };
+  assert.equal(emptyCanvasBindingProven({ rootGraph: emptyRoot(), activeWorkflow: claimsNodes }), false);
+
+  // A root holding content is not empty, whatever the workflow says.
+  const populatedRoot = {
+    _nodes: [{ id: 1 }],
+    extra: {},
+    serialize: () => ({ ...emptyState(), nodes: [{ id: 1, type: "KSampler" }] }),
+  };
+  assert.equal(
+    emptyCanvasBindingProven({ rootGraph: populatedRoot, activeWorkflow: dirtyBlankTab("A") }),
+    false,
+  );
+
+  // MID-LOAD is the one false-empty emptiness cannot exclude on its own: the canvas
+  // reads genuinely empty at that instant and is about to be populated.
+  assert.equal(
+    emptyCanvasBindingProven({ rootGraph: emptyRoot(), activeWorkflow: dirtyBlankTab("A"), graphLoading: true }),
+    false,
+  );
+  assert.equal(
+    sealProvenRootBinding({
+      rootGraph: emptyRoot(), activeWorkflow: dirtyBlankTab("A"),
+      activeWorkflowUuid: uuid, proofExclusive: true, emptyProofExclusive: true, graphLoading: true,
+    }),
+    false,
+    "a mid-load canvas must never be sealed",
+  );
+
+  // An unserializable root proves nothing (a bare empty _nodes array is not proof).
+  assert.equal(
+    emptyCanvasBindingProven({
+      rootGraph: { _nodes: [], extra: {} },
+      activeWorkflow: dirtyBlankTab("A"),
+    }),
+    false,
+  );
+
+  // No workflow service at all: the legacy availability path, not a new proof.
+  assert.equal(emptyCanvasBindingProven({ rootGraph: emptyRoot(), activeWorkflow: null }), false);
+});
+
+test("#833: the empty seal's own stamp is re-assignable — no mirror-image wedge", () => {
+  // The stamp tab A writes lands on the shared root. When the user switches to blank
+  // tab B, ComfyUI reuses that root and does NOT reset `graph.extra`, so B meets A's
+  // tag. If that tag were immovable, B would be wedged on `rootUuidMismatch` — this
+  // bug's mirror image, and the #349 protections would rightly refuse to re-stamp it.
+  //
+  // It moves only because it is marked as the empty seal's own AND both sides are
+  // still provably empty. A stamp on an empty canvas asserts only "this blank canvas
+  // is currently that tab's", which discards nothing when re-pointed.
+  const uuidA = "48e8cdaa-f399-4ba8-a76d-45dafc43d859";
+  const tabA = dirtyBlankTab("Untitled A");
+  const tabB = dirtyBlankTab("Untitled B");
+  const root = emptyRoot();
+
+  assert.equal(
+    sealProvenRootBinding({ rootGraph: root, activeWorkflow: tabA, activeWorkflowUuid: uuidA }),
+    true,
+  );
+  assert.equal(root.extra.comfyui_mcp.workflow_uuid, uuidA);
+  assert.equal(root.extra.comfyui_mcp[EMPTY_SEAL_FIELD], true);
+
+  // B may reclaim it.
+  assert.equal(emptySealStampReassignable({ rootGraph: root, activeWorkflow: tabB }), true);
+  // And B's reads are admitted regardless of whose tag the root carries.
+  assert.equal(
+    graphEmptyBindingUnproven({ graph: root, rootGraph: root, activeWorkflow: tabB, activeWorkflowUuid: null }),
+    false,
+  );
+});
+
+test("#833: a tag that is NOT the empty seal's own is never re-assignable", () => {
+  // The #349 protections are untouched: a foreign tab's claim, or a tag nobody
+  // claims, stays immovable even on an empty canvas.
+  const foreign = emptyRoot();
+  foreign.extra = { comfyui_mcp: { workflow_uuid: "some-other-tab" } };
+  assert.equal(
+    emptySealStampReassignable({ rootGraph: foreign, activeWorkflow: dirtyBlankTab("A") }),
+    false,
+  );
+  // Nor while a graph is loading, nor once content exists.
+  const ours = emptyRoot();
+  ours.extra = { comfyui_mcp: { workflow_uuid: "x", [EMPTY_SEAL_FIELD]: true } };
+  assert.equal(
+    emptySealStampReassignable({ rootGraph: ours, activeWorkflow: dirtyBlankTab("A"), graphLoading: true }),
+    false,
+  );
+  const withContent = dirtyBlankTab("A");
+  withContent.changeTracker.activeState = { ...emptyState(), nodes: [{ id: 1, type: "KSampler" }] };
+  assert.equal(emptySealStampReassignable({ rootGraph: ours, activeWorkflow: withContent }), false);
 });

--- a/browser_tests/unit/empty-canvas-wedge.test.mjs
+++ b/browser_tests/unit/empty-canvas-wedge.test.mjs
@@ -10,8 +10,6 @@ import {
   graphRootMatchesState,
   resolveGraphBindingVerdict,
   emptyCanvasBindingProven,
-  emptySealStampReassignable,
-  EMPTY_SEAL_FIELD,
   rootContentProvesActiveWorkflow,
 } from "../../web/js/lib/graph-binding.js";
 
@@ -179,18 +177,14 @@ test("TWO blank tabs no longer wedge every graph tool (#833)", () => {
   // ambiguous about which one an empty root belongs to.
   assert.equal(proofExclusive(root, active, [active, other]), false);
 
-  // The seal fires anyway, on the EMPTY path, which does not ask for exclusivity.
-  // Requiring it made the seal unreachable in practice: any open tab not activated
-  // this session has no tracker state and reads as "could also be blank". Ambiguity
-  // is handled by making the stamp re-assignable instead — see below.
+  // The seal is still refused — two blank tabs genuinely are ambiguous, and this
+  // change does not pretend otherwise.
   assert.equal(
     sealProvenRootBinding({
-      rootGraph: root, activeWorkflow: active, activeWorkflowUuid: uuid,
-      proofExclusive: false,
+      rootGraph: root, activeWorkflow: active, activeWorkflowUuid: uuid, proofExclusive: false,
     }),
-    true,
+    false,
   );
-  assert.equal(root.extra.comfyui_mcp[EMPTY_SEAL_FIELD], true, "the stamp must mark itself");
 
   // …and the tools work, which is the point of the whole issue.
   assert.equal(graphEmptyBindingUnproven({ graph: root, rootGraph: root, activeWorkflow: active, activeWorkflowUuid: uuid }), false);
@@ -336,30 +330,6 @@ test("#833 regression: a DIRTY blank canvas is readable", () => {
   );
 });
 
-test("#833 regression: a DIRTY blank canvas is BUILDABLE — the seal fires", () => {
-  // The half that matters: a user on a blank canvas is about to add nodes. Without
-  // the seal every mutation stays refused as dirty-mutation-binding-unproven.
-  const active = dirtyBlankTab("Untitled");
-  const uuid = "48e8cdaa-f399-4ba8-a76d-45dafc43d859";
-  const root = emptyRoot();
-  assert.equal(
-    sealProvenRootBinding({
-      rootGraph: root, activeWorkflow: active, activeWorkflowUuid: uuid,
-      proofExclusive: true, emptyProofExclusive: true,
-    }),
-    true,
-  );
-  assert.equal(root.extra.comfyui_mcp.workflow_uuid, uuid, "the root must carry the identity");
-  assert.equal(
-    resolveGraphBindingVerdict({
-      graph: root, rootGraph: root, activeWorkflow: active, activeWorkflowUuid: uuid,
-      liveNodeCount: 0, includeBaselineReadGuard: true, requireDirtyMutationBinding: true,
-    }),
-    null,
-    "no refusal — the sealed root now proves the binding",
-  );
-});
-
 test("#833: emptiness is not a skeleton key", () => {
   const uuid = "48e8cdaa-f399-4ba8-a76d-45dafc43d859";
 
@@ -408,53 +378,3 @@ test("#833: emptiness is not a skeleton key", () => {
   assert.equal(emptyCanvasBindingProven({ rootGraph: emptyRoot(), activeWorkflow: null }), false);
 });
 
-test("#833: the empty seal's own stamp is re-assignable — no mirror-image wedge", () => {
-  // The stamp tab A writes lands on the shared root. When the user switches to blank
-  // tab B, ComfyUI reuses that root and does NOT reset `graph.extra`, so B meets A's
-  // tag. If that tag were immovable, B would be wedged on `rootUuidMismatch` — this
-  // bug's mirror image, and the #349 protections would rightly refuse to re-stamp it.
-  //
-  // It moves only because it is marked as the empty seal's own AND both sides are
-  // still provably empty. A stamp on an empty canvas asserts only "this blank canvas
-  // is currently that tab's", which discards nothing when re-pointed.
-  const uuidA = "48e8cdaa-f399-4ba8-a76d-45dafc43d859";
-  const tabA = dirtyBlankTab("Untitled A");
-  const tabB = dirtyBlankTab("Untitled B");
-  const root = emptyRoot();
-
-  assert.equal(
-    sealProvenRootBinding({ rootGraph: root, activeWorkflow: tabA, activeWorkflowUuid: uuidA }),
-    true,
-  );
-  assert.equal(root.extra.comfyui_mcp.workflow_uuid, uuidA);
-  assert.equal(root.extra.comfyui_mcp[EMPTY_SEAL_FIELD], true);
-
-  // B may reclaim it.
-  assert.equal(emptySealStampReassignable({ rootGraph: root, activeWorkflow: tabB }), true);
-  // And B's reads are admitted regardless of whose tag the root carries.
-  assert.equal(
-    graphEmptyBindingUnproven({ graph: root, rootGraph: root, activeWorkflow: tabB, activeWorkflowUuid: null }),
-    false,
-  );
-});
-
-test("#833: a tag that is NOT the empty seal's own is never re-assignable", () => {
-  // The #349 protections are untouched: a foreign tab's claim, or a tag nobody
-  // claims, stays immovable even on an empty canvas.
-  const foreign = emptyRoot();
-  foreign.extra = { comfyui_mcp: { workflow_uuid: "some-other-tab" } };
-  assert.equal(
-    emptySealStampReassignable({ rootGraph: foreign, activeWorkflow: dirtyBlankTab("A") }),
-    false,
-  );
-  // Nor while a graph is loading, nor once content exists.
-  const ours = emptyRoot();
-  ours.extra = { comfyui_mcp: { workflow_uuid: "x", [EMPTY_SEAL_FIELD]: true } };
-  assert.equal(
-    emptySealStampReassignable({ rootGraph: ours, activeWorkflow: dirtyBlankTab("A"), graphLoading: true }),
-    false,
-  );
-  const withContent = dirtyBlankTab("A");
-  withContent.changeTracker.activeState = { ...emptyState(), nodes: [{ id: 1, type: "KSampler" }] };
-  assert.equal(emptySealStampReassignable({ rootGraph: ours, activeWorkflow: withContent }), false);
-});

--- a/browser_tests/unit/graph-binding.test.mjs
+++ b/browser_tests/unit/graph-binding.test.mjs
@@ -36,7 +36,6 @@ import {
   graphReadBindingChanged,
   resolveGraphRootUuidRebind,
   sealProvenRootBinding,
-  emptySealStampReassignable,
   rootContentProvesActiveWorkflow,
   serializedStateProvenEmpty,
 } from "../../web/js/lib/graph-binding.js";
@@ -277,7 +276,6 @@ function buildDirtyStaleRouteHarness({
     "resolveGraphRootUuidRebind",
     "postReconnectSettleWindow",
     "sealProvenRootBinding",
-    "emptySealStampReassignable",
     "rootContentProvesActiveWorkflow",
     "graphRootMatchesState",
     "sameWorkflowObject",
@@ -301,7 +299,6 @@ function buildDirtyStaleRouteHarness({
     // harnesses default to OUTSIDE the window and opt in explicitly.
     () => postReconnectWindow === true,
     sealProvenRootBinding,
-    emptySealStampReassignable,
     rootContentProvesActiveWorkflow,
     graphRootMatchesState,
     sameWorkflowObject,

--- a/browser_tests/unit/graph-binding.test.mjs
+++ b/browser_tests/unit/graph-binding.test.mjs
@@ -36,6 +36,7 @@ import {
   graphReadBindingChanged,
   resolveGraphRootUuidRebind,
   sealProvenRootBinding,
+  emptySealStampReassignable,
   rootContentProvesActiveWorkflow,
   serializedStateProvenEmpty,
 } from "../../web/js/lib/graph-binding.js";
@@ -276,6 +277,7 @@ function buildDirtyStaleRouteHarness({
     "resolveGraphRootUuidRebind",
     "postReconnectSettleWindow",
     "sealProvenRootBinding",
+    "emptySealStampReassignable",
     "rootContentProvesActiveWorkflow",
     "graphRootMatchesState",
     "sameWorkflowObject",
@@ -299,6 +301,7 @@ function buildDirtyStaleRouteHarness({
     // harnesses default to OUTSIDE the window and opt in explicitly.
     () => postReconnectWindow === true,
     sealProvenRootBinding,
+    emptySealStampReassignable,
     rootContentProvesActiveWorkflow,
     graphRootMatchesState,
     sameWorkflowObject,

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -5422,12 +5422,11 @@ function assertGraphBoundToActiveWorkflow(
     // Anything unprovable fails closed, and the #389 case (empty root while
     // the workflow reports N>0 nodes) still fires via the baseline read
     // guard below.
-    // #833 — the DIRTY blank tab reaches the same conclusion by the same rule. A blank
-    // tab is never clean, so `activeWorkflowProvenEmpty` cannot fire here either, and
-    // without this a root stamped by one blank tab would WEDGE the next blank tab the
-    // user switched to — this bug's mirror image, and the reason the seal can hand out
-    // an empty root's stamp at all: in the both-empty case a stamp is freely
-    // re-assignable, because there is no content for it to protect.
+    // #833 deliberately does NOT relax this. A DIRTY blank tab cannot clear the clean-tab
+    // proof, so a blank canvas still cannot re-stamp a tag here — extending it was tried
+    // and withdrawn: it broke all 19 fence-protection tests, because re-stamping a tag on
+    // an empty root is a claim about WHOSE canvas it is, which emptiness cannot support.
+    // The #833 read relaxation is confined to `graphEmptyBindingUnproven`.
     const staleTagOnEmptyCanvas =
       graphRootProvenEmpty(rootGraph) && activeWorkflowProvenEmpty(activeWorkflow);
     // #817 — a tab switch leaves the PREVIOUS workflow's tag on the reused

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -369,7 +369,6 @@ import {
   OPEN_PROOF_FIELD,
   sealProvenRootBinding,
   emptyCanvasBindingProven,
-  emptySealStampReassignable,
   rootContentProvesActiveWorkflow,
 } from "./lib/graph-binding.js";
 import { summarizePromptRejection, buildQueueAcceptResult } from "./lib/queue-rejection.js";
@@ -5429,14 +5428,8 @@ function assertGraphBoundToActiveWorkflow(
     // user switched to — this bug's mirror image, and the reason the seal can hand out
     // an empty root's stamp at all: in the both-empty case a stamp is freely
     // re-assignable, because there is no content for it to protect.
-    // #833 — plus the empty seal's OWN leftover. A blank tab is never clean, so the
-    // clause above cannot fire for one; without this the stamp the seal writes for tab A
-    // wedges tab B the moment the user switches to it. Narrow on purpose: ONLY a tag
-    // this mechanism wrote on a provably empty canvas is re-pointable, so every #349
-    // protection (a foreign tab's claim, a tag nobody claims) is untouched.
     const staleTagOnEmptyCanvas =
-      (graphRootProvenEmpty(rootGraph) && activeWorkflowProvenEmpty(activeWorkflow)) ||
-      emptySealStampReassignable({ rootGraph, activeWorkflow, graphLoading });
+      graphRootProvenEmpty(rootGraph) && activeWorkflowProvenEmpty(activeWorkflow);
     // #817 — a tab switch leaves the PREVIOUS workflow's tag on the reused
     // app.graph, so a canvas that IS the active workflow's was refused where an
     // untagged copy of it was allowed, and nothing self-healed it: the seal below
@@ -5489,7 +5482,6 @@ function assertGraphBoundToActiveWorkflow(
     activeWorkflowUuid,
     inSubgraph,
     proofExclusive: sealProofExclusive,
-    graphLoading,
   });
   // The verdict itself is a PURE function of the resolved evidence, lifted into
   // lib/graph-binding.js (#604) so the read-vs-mutation evidence bar is observable

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -368,6 +368,8 @@ import {
   OPEN_REBIND_STATUS,
   OPEN_PROOF_FIELD,
   sealProvenRootBinding,
+  emptyCanvasBindingProven,
+  emptySealStampReassignable,
   rootContentProvesActiveWorkflow,
 } from "./lib/graph-binding.js";
 import { summarizePromptRejection, buildQueueAcceptResult } from "./lib/queue-rejection.js";
@@ -5359,7 +5361,27 @@ function assertGraphBoundToActiveWorkflow(
   // decisions below need it: the stale-tag rebind and the unstamped-root seal ask
   // the same question (is this canvas provably the active workflow's?) and must not
   // answer it differently.
+  // #833 — ComfyUI's OWN mid-load flag, not a proxy for it. A canvas mid-load reads
+  // genuinely empty at that instant and is about to be populated, which is the only
+  // FALSE-EMPTY reading a both-sides-empty proof cannot exclude by itself. Unreadable
+  // ⇒ true, so an unknown frontend proves nothing and the empty gate stays closed.
+  let graphLoading = true;
+  try {
+    const flag = activeWorkflow?.changeTracker?.constructor?.isLoadingGraph;
+    graphLoading = typeof flag === "boolean" ? flag : true;
+  } catch {
+    graphLoading = true;
+  }
   let sealProofExclusive = false;
+  // #833 — the EMPTY case needs its OWN exclusivity, because the rule below inverts
+  // here. Skipping a DIRTY twin is right for a CONTENT match (a lagging tracker cannot
+  // prove its state equals the root), but an empty root needs no proof to match a blank
+  // tab: a dirty blank twin is exactly as plausible an owner as the active tab. Sealing
+  // on the content rule would stamp the active identity onto a root that may be the
+  // other blank tab's, wedging THAT tab on the foreign tag the moment the user switched
+  // to it — this bug's mirror image, and the #349 tag protections rightly refuse to
+  // re-stamp it back. So: every OTHER open workflow must be READABLY non-empty.
+  // Unreadable or absent enumeration proves nothing and blocks the seal.
   try {
     const others = app?.extensionManager?.workflow?.openWorkflows;
     if (Array.isArray(others)) {
@@ -5401,8 +5423,20 @@ function assertGraphBoundToActiveWorkflow(
     // Anything unprovable fails closed, and the #389 case (empty root while
     // the workflow reports N>0 nodes) still fires via the baseline read
     // guard below.
+    // #833 — the DIRTY blank tab reaches the same conclusion by the same rule. A blank
+    // tab is never clean, so `activeWorkflowProvenEmpty` cannot fire here either, and
+    // without this a root stamped by one blank tab would WEDGE the next blank tab the
+    // user switched to — this bug's mirror image, and the reason the seal can hand out
+    // an empty root's stamp at all: in the both-empty case a stamp is freely
+    // re-assignable, because there is no content for it to protect.
+    // #833 — plus the empty seal's OWN leftover. A blank tab is never clean, so the
+    // clause above cannot fire for one; without this the stamp the seal writes for tab A
+    // wedges tab B the moment the user switches to it. Narrow on purpose: ONLY a tag
+    // this mechanism wrote on a provably empty canvas is re-pointable, so every #349
+    // protection (a foreign tab's claim, a tag nobody claims) is untouched.
     const staleTagOnEmptyCanvas =
-      graphRootProvenEmpty(rootGraph) && activeWorkflowProvenEmpty(activeWorkflow);
+      (graphRootProvenEmpty(rootGraph) && activeWorkflowProvenEmpty(activeWorkflow)) ||
+      emptySealStampReassignable({ rootGraph, activeWorkflow, graphLoading });
     // #817 — a tab switch leaves the PREVIOUS workflow's tag on the reused
     // app.graph, so a canvas that IS the active workflow's was refused where an
     // untagged copy of it was allowed, and nothing self-healed it: the seal below
@@ -5455,6 +5489,7 @@ function assertGraphBoundToActiveWorkflow(
     activeWorkflowUuid,
     inSubgraph,
     proofExclusive: sealProofExclusive,
+    graphLoading,
   });
   // The verdict itself is a PURE function of the resolved evidence, lifted into
   // lib/graph-binding.js (#604) so the read-vs-mutation evidence bar is observable
@@ -5474,6 +5509,7 @@ function assertGraphBoundToActiveWorkflow(
     includeBaselineReadGuard,
     requireDirtyMutationBinding,
     postReconnectWindow: postReconnectSettleWindow(),
+    graphLoading,
   });
   if (verdict) throw new Error(graphBindingRefusalMessage(verdict));
 }

--- a/web/js/lib/graph-binding.js
+++ b/web/js/lib/graph-binding.js
@@ -169,13 +169,23 @@ export function graphRootMidPopulation({
  *   - with NO active workflow service at all, the legacy availability path
  *     stands (that frontend never had binding fences).
  */
-export function graphEmptyBindingUnproven({ graph, rootGraph, activeWorkflow, activeWorkflowUuid } = {}) {
+export function graphEmptyBindingUnproven({
+  graph,
+  rootGraph,
+  activeWorkflow,
+  activeWorkflowUuid,
+  graphLoading = false,
+} = {}) {
   if (!!rootGraph && graph && graph !== rootGraph) return false; // subgraph scope
   const live = rootGraph?._nodes;
   if (!Array.isArray(live) || live.length !== 0) return false; // populated or unobservable
   if (!activeWorkflow) return false; // no workflow service — legacy availability
   if (activeWorkflowProvenEmpty(activeWorkflow)) return false; // PROVEN empty — truthful 0
   if (graphRootWorkflowUuidMatches({ rootGraph, activeWorkflowUuid })) return false; // positively bound
+  // #833 — both sides provably content-free. The clause above cannot fire on a blank
+  // tab (always dirty), which left the ordinary "about to build a workflow" state
+  // permanently refused.
+  if (emptyCanvasBindingProven({ rootGraph, activeWorkflow, graphLoading })) return false;
   return true; // empty + unproven + unbound ⇒ inconclusive, never authoritative-empty
 }
 
@@ -352,6 +362,54 @@ export function serializedStateProvenEmpty(state) {
 export function activeWorkflowProvenEmpty(activeWorkflow) {
   try {
     if (activeWorkflow?.isModified === true) return false;
+    return serializedStateProvenEmpty(activeWorkflowCurrentState(activeWorkflow));
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * BOTH SIDES PROVABLY CONTENT-FREE — the one thing that can bind an EMPTY canvas
+ * (#833).
+ *
+ * Content cannot identify an empty canvas: every blank canvas serializes alike, so
+ * `rootContentProvesActiveWorkflow` has nothing to compare and the seal never fires.
+ * And a blank tab is ALWAYS dirty — creating or clearing it is what dirties it — so
+ * `activeWorkflowProvenEmpty` short-circuits on `isModified` and can never succeed
+ * either. Both proofs are therefore permanently unavailable in exactly the state a
+ * user is in right before asking an agent to build a workflow: reads refused as
+ * `empty-binding-unproven`, mutations as `dirty-mutation-binding-unproven`, with no
+ * recovery that clears it.
+ *
+ * This is #565's own rule, applied where it was never reached. That gate already
+ * re-stamps a MISMATCHED tag when both sides are proven content-free, on the stated
+ * grounds that **the #349 fence protects CONTENT** and there is none. The same holds
+ * for an UNTAGGED root, and it does not stop holding because the tab is dirty:
+ *
+ *   - the lag `isModified` guards against (#545) is neutralised by the CONJUNCTION,
+ *     not by cleanliness. A lagging tracker's state is merely OLD; if either the
+ *     stale snapshot or the live root held content, that side fails its proof and
+ *     this returns false. Both sides can only agree on empty when neither has any.
+ *   - what cleanliness genuinely proves elsewhere is IDENTITY by content match, and
+ *     that is not what is claimed here. Nothing is being matched — the claim is only
+ *     that there is no content anywhere to mis-attribute.
+ *
+ * `graphLoading` is the one case emptiness alone cannot exclude: a canvas mid-load
+ * reads genuinely empty at that instant and is about to be populated, which is the
+ * FALSE-EMPTY reading the refusal text names. The caller passes ComfyUI's own
+ * `ChangeTracker.isLoadingGraph` rather than a proxy for it; unreadable ⇒ pass true
+ * and prove nothing.
+ *
+ * Deliberately NOT weakened to "the root is empty": an empty ROOT with a workflow
+ * that reports content is #389, and it must keep failing.
+ */
+export function emptyCanvasBindingProven({ rootGraph, activeWorkflow, graphLoading = false } = {}) {
+  try {
+    if (graphLoading === true) return false; // mid-load ⇒ a 0 read may be FALSE-empty
+    if (!activeWorkflow) return false; // no workflow service — legacy availability path
+    if (!graphRootProvenEmpty(rootGraph)) return false; // the live canvas holds content
+    // The workflow's OWN current state, WITHOUT the cleanliness short-circuit — see
+    // above for why dirtiness does not weaken a both-sides-empty claim.
     return serializedStateProvenEmpty(activeWorkflowCurrentState(activeWorkflow));
   } catch {
     return false;
@@ -1454,19 +1512,71 @@ export function rootContentProvesActiveWorkflow({
   }
 }
 
+/** Marks a stamp written by the empty-canvas seal, which alone is re-assignable. */
+export const EMPTY_SEAL_FIELD = "empty_seal";
+
+/**
+ * May the tag already on this root be re-pointed at the ACTIVE workflow? (#833)
+ *
+ * Only for a tag THIS mechanism wrote on a provably empty canvas, and only while the
+ * canvas is still provably empty. That keeps the #349 protections exactly as they were
+ * — a tag a foreign tab claims, or that nobody claims, is still never re-stamped — while
+ * stopping the empty seal from wedging the next blank tab with its own leftover.
+ *
+ * The asymmetry is the point: a stamp on an empty canvas asserts only "this blank canvas
+ * is currently that tab's". It cannot be evidence about content, because there is none,
+ * so re-pointing it discards nothing. A stamp written over CONTENT asserts something
+ * much stronger, and stays immovable.
+ */
+export function emptySealStampReassignable({ rootGraph, activeWorkflow, graphLoading = false } = {}) {
+  try {
+    const tag = rootGraph?.extra?.[PANEL_GRAPH_META_KEY];
+    if (!tag || typeof tag !== "object") return false;
+    if (tag[EMPTY_SEAL_FIELD] !== true) return false; // not ours ⇒ never re-stamp
+    return emptyCanvasBindingProven({ rootGraph, activeWorkflow, graphLoading });
+  } catch {
+    return false;
+  }
+}
+
 export function sealProvenRootBinding({
   rootGraph,
   activeWorkflow,
   activeWorkflowUuid,
   inSubgraph = false,
   proofExclusive = true,
+  emptyProofExclusive = false,
+  graphLoading = false,
 } = {}) {
   try {
     if (typeof activeWorkflowUuid !== "string" || !activeWorkflowUuid) return false;
     // A CONFLICTING stamp is the rebind path's decision, never overwritten here.
     const existing = rootGraph?.extra?.comfyui_mcp?.workflow_uuid;
     if (typeof existing === "string" && existing) return false;
-    if (!rootContentProvesActiveWorkflow({ rootGraph, activeWorkflow, inSubgraph, proofExclusive })) {
+    // #833 — an EMPTY canvas can never clear the content proof (nothing to match) and
+    // is always dirty, so without this the seal never fires and every mutation stays
+    // refused as dirty-mutation-binding-unproven with no recovery. Sealing here is what
+    // converts the wedge into an ordinary bound canvas. Subgraph scope still excluded:
+    // a descended empty subgraph is not the workflow's root canvas.
+    //
+    // EXCLUSIVITY STILL REQUIRED, and it is not implied by emptiness. Emptiness says
+    // there is no content to mis-attribute; exclusivity says WHICH tab this canvas is.
+    // With a second blank tab open the root could be its canvas, and stamping the
+    // ACTIVE identity onto it would wedge that tab the moment the user switches to it —
+    // trading this bug for its mirror image. Two blank tabs stay honestly ambiguous:
+    // reads are admitted by the empty proof above, the seal is not.
+    // NO exclusivity requirement, deliberately. Requiring it made the seal essentially
+    // unreachable — any open tab never activated this session has no tracker state, so
+    // it reads as "could also be blank" and blocked everything. Ambiguity is handled by
+    // making this stamp RE-ASSIGNABLE (below) rather than by withholding it: a stamp
+    // this path writes is marked as its own, and only such a stamp may later be
+    // re-pointed at another blank tab. A tag from anywhere else still fails closed.
+    const emptyBindingProven =
+      !inSubgraph && emptyCanvasBindingProven({ rootGraph, activeWorkflow, graphLoading });
+    if (
+      !emptyBindingProven &&
+      !rootContentProvesActiveWorkflow({ rootGraph, activeWorkflow, inSubgraph, proofExclusive })
+    ) {
       return false;
     }
     const extra =
@@ -1475,6 +1585,11 @@ export function sealProvenRootBinding({
     extra.comfyui_mcp = {
       ...(prior && typeof prior === "object" ? prior : {}),
       workflow_uuid: activeWorkflowUuid,
+      // #833 — a stamp written on a PROVABLY EMPTY canvas records that it was, because
+      // that is the one stamp that may later be re-pointed at a different blank tab
+      // (emptySealStampReassignable). Without the marker the next blank tab inherits
+      // this tag as a FOREIGN one and is wedged by it — this bug's mirror image.
+      ...(emptyBindingProven ? { [EMPTY_SEAL_FIELD]: true } : {}),
     };
     return true;
   } catch {
@@ -1539,6 +1654,7 @@ export function resolveGraphBindingVerdict({
   includeBaselineReadGuard = true,
   requireDirtyMutationBinding = false,
   postReconnectWindow = false,
+  graphLoading = false,
 } = {}) {
   const nodeCount = Number.isFinite(Number(liveNodeCount))
     ? Number(liveNodeCount)
@@ -1616,7 +1732,7 @@ export function resolveGraphBindingVerdict({
       ...(reason === "root-shape-mismatch" ? { structureMatches: structureMatches === true } : {}),
     };
   }
-  if (graphEmptyBindingUnproven({ graph, rootGraph, activeWorkflow, activeWorkflowUuid })) {
+  if (graphEmptyBindingUnproven({ graph, rootGraph, activeWorkflow, activeWorkflowUuid, graphLoading })) {
     return { reason: "empty-binding-unproven", expected: activeWorkflowNodeCount(activeWorkflow) };
   }
   return null;

--- a/web/js/lib/graph-binding.js
+++ b/web/js/lib/graph-binding.js
@@ -1512,41 +1512,12 @@ export function rootContentProvesActiveWorkflow({
   }
 }
 
-/** Marks a stamp written by the empty-canvas seal, which alone is re-assignable. */
-export const EMPTY_SEAL_FIELD = "empty_seal";
-
-/**
- * May the tag already on this root be re-pointed at the ACTIVE workflow? (#833)
- *
- * Only for a tag THIS mechanism wrote on a provably empty canvas, and only while the
- * canvas is still provably empty. That keeps the #349 protections exactly as they were
- * — a tag a foreign tab claims, or that nobody claims, is still never re-stamped — while
- * stopping the empty seal from wedging the next blank tab with its own leftover.
- *
- * The asymmetry is the point: a stamp on an empty canvas asserts only "this blank canvas
- * is currently that tab's". It cannot be evidence about content, because there is none,
- * so re-pointing it discards nothing. A stamp written over CONTENT asserts something
- * much stronger, and stays immovable.
- */
-export function emptySealStampReassignable({ rootGraph, activeWorkflow, graphLoading = false } = {}) {
-  try {
-    const tag = rootGraph?.extra?.[PANEL_GRAPH_META_KEY];
-    if (!tag || typeof tag !== "object") return false;
-    if (tag[EMPTY_SEAL_FIELD] !== true) return false; // not ours ⇒ never re-stamp
-    return emptyCanvasBindingProven({ rootGraph, activeWorkflow, graphLoading });
-  } catch {
-    return false;
-  }
-}
-
 export function sealProvenRootBinding({
   rootGraph,
   activeWorkflow,
   activeWorkflowUuid,
   inSubgraph = false,
   proofExclusive = true,
-  emptyProofExclusive = false,
-  graphLoading = false,
 } = {}) {
   try {
     if (typeof activeWorkflowUuid !== "string" || !activeWorkflowUuid) return false;
@@ -1565,18 +1536,7 @@ export function sealProvenRootBinding({
     // ACTIVE identity onto it would wedge that tab the moment the user switches to it —
     // trading this bug for its mirror image. Two blank tabs stay honestly ambiguous:
     // reads are admitted by the empty proof above, the seal is not.
-    // NO exclusivity requirement, deliberately. Requiring it made the seal essentially
-    // unreachable — any open tab never activated this session has no tracker state, so
-    // it reads as "could also be blank" and blocked everything. Ambiguity is handled by
-    // making this stamp RE-ASSIGNABLE (below) rather than by withholding it: a stamp
-    // this path writes is marked as its own, and only such a stamp may later be
-    // re-pointed at another blank tab. A tag from anywhere else still fails closed.
-    const emptyBindingProven =
-      !inSubgraph && emptyCanvasBindingProven({ rootGraph, activeWorkflow, graphLoading });
-    if (
-      !emptyBindingProven &&
-      !rootContentProvesActiveWorkflow({ rootGraph, activeWorkflow, inSubgraph, proofExclusive })
-    ) {
+    if (!rootContentProvesActiveWorkflow({ rootGraph, activeWorkflow, inSubgraph, proofExclusive })) {
       return false;
     }
     const extra =
@@ -1585,11 +1545,6 @@ export function sealProvenRootBinding({
     extra.comfyui_mcp = {
       ...(prior && typeof prior === "object" ? prior : {}),
       workflow_uuid: activeWorkflowUuid,
-      // #833 — a stamp written on a PROVABLY EMPTY canvas records that it was, because
-      // that is the one stamp that may later be re-pointed at a different blank tab
-      // (emptySealStampReassignable). Without the marker the next blank tab inherits
-      // this tag as a FOREIGN one and is wedged by it — this bug's mirror image.
-      ...(emptyBindingProven ? { [EMPTY_SEAL_FIELD]: true } : {}),
     };
     return true;
   } catch {

--- a/web/js/lib/graph-binding.js
+++ b/web/js/lib/graph-binding.js
@@ -1524,18 +1524,13 @@ export function sealProvenRootBinding({
     // A CONFLICTING stamp is the rebind path's decision, never overwritten here.
     const existing = rootGraph?.extra?.comfyui_mcp?.workflow_uuid;
     if (typeof existing === "string" && existing) return false;
-    // #833 — an EMPTY canvas can never clear the content proof (nothing to match) and
-    // is always dirty, so without this the seal never fires and every mutation stays
-    // refused as dirty-mutation-binding-unproven with no recovery. Sealing here is what
-    // converts the wedge into an ordinary bound canvas. Subgraph scope still excluded:
-    // a descended empty subgraph is not the workflow's root canvas.
-    //
-    // EXCLUSIVITY STILL REQUIRED, and it is not implied by emptiness. Emptiness says
-    // there is no content to mis-attribute; exclusivity says WHICH tab this canvas is.
-    // With a second blank tab open the root could be its canvas, and stamping the
-    // ACTIVE identity onto it would wedge that tab the moment the user switches to it —
-    // trading this bug for its mirror image. Two blank tabs stay honestly ambiguous:
-    // reads are admitted by the empty proof above, the seal is not.
+    // #833 — an EMPTY canvas can never clear this proof: every blank canvas serialises
+    // alike, so there is nothing to match, and a blank tab is always dirty besides. That
+    // is why mutations stay refused on one. Sealing on emptiness was tried and withdrawn:
+    // it would stamp the ACTIVE identity onto a root that a reconnect tab restore may
+    // have left holding a DIFFERENT blank workflow (the #708 mismatch), putting the first
+    // node on the wrong canvas. Emptiness proves there is nothing to mis-attribute; a
+    // seal claims WHOSE canvas this is, and only the read gate needs the weaker fact.
     if (!rootContentProvesActiveWorkflow({ rootGraph, activeWorkflow, inSubgraph, proofExclusive })) {
       return false;
     }


### PR DESCRIPTION
Fixes the READ half of #833 (regression reported against panel 0.11.62).

An empty canvas is the ordinary state a user is in right before asking the agent to
build a workflow, and it was the one state where every `panel_*` graph tool was refused
with no recovery. Reproduced end-to-end against the real functions first:

    graph_outline   -> [empty-binding-unproven]
    graph_add_node  -> [dirty-mutation-binding-unproven]

Both available proofs are structurally unavailable there, which is why no rung of the
documented recovery ladder worked: content cannot identify an empty canvas (every blank
canvas serialises alike), and a blank tab is ALWAYS dirty, so the emptiness proof
short-circuits on `isModified`. 0.11.49 fixed the first half by making emptiness
provable; it could not reach the dirty case.

`emptyCanvasBindingProven` admits an empty READ when both sides are provably
content-free — #565's own rule (the #349 fence protects CONTENT, and there is none),
applied where it was never reached. Dirtiness does not weaken it: a lagging snapshot
that held content would fail its own proof.

**Scope: reads only, deliberately.** Sealing the binding to admit mutations was
implemented, reviewed, and withdrawn. The panel's reconnect tab restore can leave the
shared root holding workflow W while the active pointer names a different workflow N
(the #708 mismatch). If both are blank, both sides read provably empty, and a seal on
that evidence would put N's first node on W's canvas — a previously-refused wrong-canvas
mutation. Emptiness proves there is nothing to mis-attribute; a mutation needs to know
whose canvas this is, and those are different claims. The e2e spec pins that boundary so
a later change must admit mutations on purpose.

An earlier, broader version that also relaxed the stale-tag rebind broke all 19
fence-protection tests in `graph-binding.test.mjs` and was withdrawn.

Verification: 3308/3308 unit tests with those 19 green; six mutations verified to fail
the suite when applied; the e2e spec confirmed to fail with the fix removed. Codex
review: NO-SHIP on the seal, SHIP on this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)