### PR TITLE
0.11.64 — a blank canvas stops refusing every graph tool (#833)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,37 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+## [0.11.64] - 2026-08-09
+
+> Covers changes since 0.11.63.
+
+### Fixed
+
+- **A blank canvas no longer refuses every graph tool (#833).** An empty canvas is the
+  ordinary state you are in right before asking the agent to build a workflow — and it
+  was the one state where the agent could not read the graph at all. Nothing cleared it:
+  re-targeting, creating a new workflow, and re-opening the tab all failed, and the
+  latest report adds that it survived both a hard refresh and a ComfyUI restart.
+
+  The guard was not treating "0 nodes" as a wrong canvas, as it appeared. It was
+  treating it as *unproven*, and on a blank canvas neither available proof can ever
+  succeed: identifying a canvas by its contents is impossible when there are none — every
+  blank canvas looks alike — and the other proof requires an unmodified tab, which a
+  blank one never is, because creating or clearing it is what marks it modified.
+
+  An empty canvas is now accepted as genuinely empty when both the canvas and the
+  workflow are independently shown to hold nothing. There is no content to attribute to
+  the wrong workflow, which is the same reasoning the panel already used elsewhere; it
+  simply could not be reached here. A canvas that merely *looks* empty because a
+  workflow is still loading is still refused, using ComfyUI's own loading signal.
+
+  **Reading works; building does not yet.** Adding nodes to a blank canvas is still
+  refused. Proving there is nothing to lose is enough to trust what a read returns, but
+  not enough to say *which* workflow an empty canvas belongs to — and a reconnect can
+  leave the canvas belonging to one blank tab while the panel is pointed at another, so
+  the first node could land on the wrong one. That half is tracked on #833 and needs a
+  real identity proof rather than a relaxation.
+
 ## [0.11.63] - 2026-08-09
 
 > Covers changes since 0.11.62.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-agent-panel"
 description = "Autonomous AI agent in the ComfyUI sidebar - local-first, bring any LLM. Run it on your Claude or ChatGPT subscription (no API keys, no extra LLM costs), on a Kimi K3 / GLM / OpenRouter key, or fully offline on free local models via Ollama, LM Studio, or llama.cpp. The agent drives your live canvas at full parity: add, wire, move and tweak nodes with Ctrl+Z undo, load whole workflows and installer packs in one shot, generate images, video and audio, browse CivitAI, and run your workflow - asking before it spends paid API credits. The sidebar UI for comfyui-mcp, the local-first, agent-native control plane for ComfyUI."
-version = "0.11.63"
+version = "0.11.64"
 license = { file = "LICENSE" }
 requires-python = ">=3.9"
 # UI-only pack: no Python deps. The frontend floor guarantees

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -877,7 +877,7 @@ const DOCS_URL = "https://comfyui-mcp.artokun.io/docs";
 // Panel version — surfaced in the "Need help?" diagnostics blob. Bump via
 // `node scripts/set-version.mjs <v>` (updates this AND pyproject together); CI
 // and the publish gate FAIL if the two ever drift, so this can't go stale.
-const PANEL_VERSION = "0.11.63";
+const PANEL_VERSION = "0.11.64";
 
 // The connected orchestrator's console URL/token (captured off the `backends`
 // bridge message — see onBackends). Drives the "API Keys" credentials frame;


### PR DESCRIPTION
Releases #885 (fixes the read half of #833).

An empty canvas is the ordinary state a user is in right before asking the agent to
build a workflow, and it was the one state where every `panel_*` graph tool was
refused with no recovery — surviving, per the latest report, both a hard refresh and a
ComfyUI restart.

Neither available proof can succeed there: content cannot identify an empty canvas, and
the emptiness proof requires a clean tab, which a blank one never is. An empty read is
now admitted when both sides are independently proven content-free, with ComfyUI's own
`isLoadingGraph` excluding the mid-load false-empty.

Building is deliberately still refused — see the PR and CHANGELOG for why emptiness
cannot authorise a write, and the reconnect scenario that makes it concrete.

Verified live against the real frontend on a dirty blank canvas: the pre-existing proof
unavailable, the new one true, the refusal gone, and the mid-load gate still refusing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)