### PR TITLE
test(bridge): prove two tabs on one saved workflow route apart (#693)

### DIFF
--- a/browser_tests/bridge-route-never-file-derived.spec.ts
+++ b/browser_tests/bridge-route-never-file-derived.spec.ts
@@ -1,0 +1,90 @@
+/**
+ * #693 — two browser tabs on the SAME saved workflow must not share a bridge route.
+ *
+ * The reported symptom was a permanent reconnect storm: sockets opening, helloing, and
+ * being closed ~2s later forever, at ~2 hellos/sec, with every close `code=1005
+ * clean=true` — a SERVER-side close. The bridge keeps exactly one connection per
+ * `tab_id` and closes the older socket whenever a new hello arrives for the same one,
+ * so two clients helloing with an identical `tab_id` evict each other indefinitely.
+ * Closing the sidebar did not stop it; only a page reload did.
+ *
+ * The reported hellos carried `tab_id = wf:workflows/<name>` — the bare saved-workflow
+ * HANDLE, which names the FILE. Every browser tab showing that file produces the same
+ * string, so two tabs collided by construction.
+ *
+ * #640 replaced the route with `wf:<tabRouteId>:<path>`, composing the tab's own
+ * established identity in front of the path, and `savedWorkflowRoute` REFUSES (returns
+ * null) rather than falling back to the bare path — the fallback being the collision
+ * itself. The composition is unit-tested, but nothing checked what a real panel
+ * actually PUTS ON THE WIRE, which is where the reported collision was observed.
+ *
+ * So this asserts the wire form directly: on a saved workflow the hello must carry the
+ * composed route and must never be the bare file handle. A tab-specific route cannot
+ * collide with another tab's by construction, so pinning the form is what pins the
+ * property — and it fails on any change that reintroduces a file-derived route,
+ * including a "helpful" fallback when the tab identity is not yet established.
+ */
+import { test, expect } from './fixtures/panelTest'
+
+/** Record the `tab_id` of every hello this page sends. */
+async function captureHellos(page: import('@playwright/test').Page) {
+  await page.addInitScript(() => {
+    const w = window as any
+    w.__hellos = []
+    const O = w.WebSocket
+    const W = function (url: string, p?: any) {
+      const ws = p ? new O(url, p) : new O(url)
+      const send = ws.send.bind(ws)
+      ws.send = (d: any) => {
+        try {
+          const f = typeof d === 'string' ? JSON.parse(d) : null
+          if (f && f.type === 'hello') w.__hellos.push(String(f.tab_id ?? ''))
+        } catch {}
+        return send(d)
+      }
+      return ws
+    } as any
+    W.prototype = O.prototype
+    W.OPEN = O.OPEN; W.CONNECTING = O.CONNECTING; W.CLOSING = O.CLOSING; W.CLOSED = O.CLOSED
+    w.WebSocket = W
+  })
+}
+
+test('a saved workflow never routes on its file path', async ({ page, panel, mockBridge }) => {
+  await captureHellos(page)
+  await panel.goto()
+  await panel.setBridgeUrl(mockBridge.url)
+  await panel.openSidebar()
+  await panel.connect()
+
+  // Give tab A a SAVED workflow. The collision is specific to saved workflows: an
+  // unsaved tab already routes on a per-object `tmp:<uuid>`, so it could never collide
+  // and would make this pass for the wrong reason.
+  const saved = await mockBridge.command('workflow_save', {})
+  expect(saved.ok, 'the workflow must save so both tabs share a FILE').toBe(true)
+  const savedName = String(saved.result?.workflow || '')
+  expect(savedName, 'the save must report a name').toBeTruthy()
+
+  // Re-hello on the SAVED workflow, then read what went on the wire.
+  await page.waitForTimeout(2500)
+  const hellos: string[] = await page.evaluate(() => (window as any).__hellos ?? [])
+  expect(hellos.length, 'the panel must have helloed').toBeGreaterThan(0)
+
+  const bareHandle = `wf:workflows/${savedName}.json`
+  const saved_hellos = hellos.filter((id) => id.startsWith('wf:'))
+  expect(
+    saved_hellos.length,
+    `the saved workflow must produce a wf: route (got ${JSON.stringify(hellos)})`
+  ).toBeGreaterThan(0)
+
+  for (const id of saved_hellos) {
+    // The bare handle names the FILE, so every browser tab showing it produces the
+    // same string. That is the collision, and it must never reach the wire.
+    expect(id, 'a route must never be the bare file handle').not.toBe(bareHandle)
+    // The composed form is `wf:<tabRouteId>:<path>` — the tab's own identity in
+    // front of the path, which is what makes two tabs on one file route separately.
+    expect(id, 'the route must compose the tab identity in front of the path').toMatch(
+      /^wf:[^:]+:workflows\//
+    )
+  }
+})

--- a/browser_tests/bridge-route-never-file-derived.spec.ts
+++ b/browser_tests/bridge-route-never-file-derived.spec.ts
@@ -23,7 +23,7 @@
  * `wf:<one-shared-id>:<path>` for every tab matches the form and recreates #693 exactly
  * (codex). Uniqueness is the invariant; the form is only how it is carried.
  */
-import { test, expect } from './fixtures/panelTest'
+import { test, expect, isolatePanelPage } from './fixtures/panelTest'
 import { PanelPage } from './fixtures/PanelPage'
 
 /** Record the `tab_id` of every hello this page sends, from before it connects. */
@@ -71,62 +71,83 @@ test('two tabs on one saved workflow never share a bridge route', async ({
   mockBridge,
   context
 }) => {
-  await captureHellos(page)
-  await panel.goto()
-  await panel.setBridgeUrl(mockBridge.url)
-  await panel.openSidebar()
-  await panel.connect()
+  const cleanup: Array<() => Promise<void>> = []
+  try {
+    await captureHellos(page)
+    await panel.goto()
+    await panel.setBridgeUrl(mockBridge.url)
+    await panel.openSidebar()
+    await panel.connect()
 
-  // A SAVED workflow specifically. An unsaved tab routes on a per-object `tmp:<uuid>`
-  // and could never collide, so using one would pass for the wrong reason.
-  const saved = await mockBridge.command('workflow_save', {})
-  expect(saved.ok, 'the workflow must save so both tabs share a FILE').toBe(true)
-  const savedName = String(saved.result?.workflow || '')
-  expect(savedName, 'the save must report a name').toBeTruthy()
-  const savedPath = `workflows/${savedName}.json`
-  await page.waitForTimeout(2500)
+    // A SAVED workflow specifically. An unsaved tab routes on a per-object `tmp:<uuid>`
+    // and could never collide, so using one would pass for the wrong reason.
+    const saved = await mockBridge.command('workflow_save', {})
+    expect(saved.ok, 'the workflow must save so both tabs share a FILE').toBe(true)
+    const savedName = String(saved.result?.workflow || '')
+    expect(savedName, 'the save must report a name').toBeTruthy()
+    const savedPath = `workflows/${savedName}.json`
+    // This spec PERSISTS a file on the developer's real ComfyUI. Remove it however the
+    // test ends — an assertion failure must not leave litter behind (codex).
+    cleanup.push(async () => {
+      await page.evaluate(async (p) => {
+        const api = (window as any).comfyAPI?.api?.api
+        await api?.fetchApi?.(`/userdata/${encodeURIComponent(p)}`, { method: 'DELETE' })
+      }, savedPath)
+    })
+    await page.waitForTimeout(2500)
 
-  // Tab B: a second real browser tab in the same context, opening that same file.
-  const pageB = await context.newPage()
-  await captureHellos(pageB)
-  await pageB.route('**/comfyui_mcp_panel/status*', (r) => r.fulfill({ json: { running: false } }))
-  await pageB.route('**/comfyui_mcp_panel/backends*', (r) => r.fulfill({ json: { backends: [] } }))
-  const panelB = new PanelPage(pageB)
-  await panelB.goto()
-  await panelB.setBridgeUrl(mockBridge.url)
-  await panelB.openSidebar()
-  await panelB.connect()
+    // Tab B: a second real browser tab in the same context, opening that same file.
+    const pageB = await context.newPage()
+    await captureHellos(pageB)
+    // The fixture only isolates the test's OWN page. Page B needs the identical stub set
+    // or its Reconnect writes this throwaway mock bridge URL into the developer's REAL
+    // ComfyUI settings, leaving a dead port behind after the suite exits (codex).
+    await isolatePanelPage(pageB)
+    const panelB = new PanelPage(pageB)
+    await panelB.goto()
+    await panelB.setBridgeUrl(mockBridge.url)
+    await panelB.openSidebar()
+    await panelB.connect()
 
-  const openedB = await openSavedWorkflow(pageB, savedPath)
-  expect(openedB.opened, `tab B must open ${savedPath}`).toBe(true)
-  await pageB.waitForTimeout(3000)
+    const openedB = await openSavedWorkflow(pageB, savedPath)
+    expect(openedB.opened, `tab B must open ${savedPath}`).toBe(true)
+    await pageB.waitForTimeout(3000)
 
-  const hellosA = savedHellos(await page.evaluate(() => (window as any).__hellos ?? []))
-  const hellosB = savedHellos(await pageB.evaluate(() => (window as any).__hellos ?? []))
-  expect(hellosA.length, 'tab A must have helloed on the saved workflow').toBeGreaterThan(0)
-  expect(hellosB.length, 'tab B must have helloed on the saved workflow').toBeGreaterThan(0)
+    const hellosA = savedHellos(await page.evaluate(() => (window as any).__hellos ?? []))
+    const hellosB = savedHellos(await pageB.evaluate(() => (window as any).__hellos ?? []))
+    expect(hellosA.length, 'tab A must have helloed on the saved workflow').toBeGreaterThan(0)
+    expect(hellosB.length, 'tab B must have helloed on the saved workflow').toBeGreaterThan(0)
 
-  // Both must be routing for the SAME file, or they were never in a position to
-  // collide and this proves nothing.
-  expect(hellosA.some((id) => id.endsWith(`:${savedPath}`)), 'tab A must route for the saved file').toBe(true)
-  expect(hellosB.some((id) => id.endsWith(`:${savedPath}`)), 'tab B must route for the saved file').toBe(true)
+    // Both must be routing for the SAME file, or they were never in a position to
+    // collide and this proves nothing.
+    expect(hellosA.some((id) => id.endsWith(`:${savedPath}`)), 'tab A must route for the saved file').toBe(true)
+    expect(hellosB.some((id) => id.endsWith(`:${savedPath}`)), 'tab B must route for the saved file').toBe(true)
 
-  // The bare handle names the FILE, so every tab showing it produces the same string.
-  for (const [label, ids] of [['A', hellosA], ['B', hellosB]] as const) {
-    for (const id of ids) {
-      expect(id, `tab ${label} must not route on the bare file handle`).not.toBe(`wf:${savedPath}`)
+    // The bare handle names the FILE, so every tab showing it produces the same string.
+    for (const [label, ids] of [['A', hellosA], ['B', hellosB]] as const) {
+      for (const id of ids) {
+        expect(id, `tab ${label} must not route on the bare file handle`).not.toBe(`wf:${savedPath}`)
+      }
+    }
+
+    // THE INVARIANT: no route may be shared. This is what the bridge keys on, and a
+    // shared value is what makes two clients evict each other forever.
+    const shared = hellosA.filter((id) => hellosB.includes(id))
+    expect(
+      shared,
+      `both tabs helloed with the same route — the bridge keeps one connection per ` +
+        `tab_id, so these two would close each other's sockets indefinitely ` +
+        `(A=${JSON.stringify(hellosA)} B=${JSON.stringify(hellosB)})`
+    ).toEqual([])
+
+    await pageB.close()
+  } finally {
+    for (const fn of cleanup.reverse()) {
+      try {
+        await fn()
+      } catch {
+        // Best-effort: a failed cleanup must not mask the assertion that failed.
+      }
     }
   }
-
-  // THE INVARIANT: no route may be shared. This is what the bridge keys on, and a
-  // shared value is what makes two clients evict each other forever.
-  const shared = hellosA.filter((id) => hellosB.includes(id))
-  expect(
-    shared,
-    `both tabs helloed with the same route — the bridge keeps one connection per ` +
-      `tab_id, so these two would close each other's sockets indefinitely ` +
-      `(A=${JSON.stringify(hellosA)} B=${JSON.stringify(hellosB)})`
-  ).toEqual([])
-
-  await pageB.close()
 })

--- a/browser_tests/bridge-route-never-file-derived.spec.ts
+++ b/browser_tests/bridge-route-never-file-derived.spec.ts
@@ -15,18 +15,18 @@
  * #640 replaced the route with `wf:<tabRouteId>:<path>`, composing the tab's own
  * established identity in front of the path, and `savedWorkflowRoute` REFUSES (returns
  * null) rather than falling back to the bare path — the fallback being the collision
- * itself. The composition is unit-tested, but nothing checked what a real panel
- * actually PUTS ON THE WIRE, which is where the reported collision was observed.
+ * itself. The composition is unit-tested, but nothing exercised the property that
+ * actually matters through two real pages, real Web Locks, and real wire serialisation.
  *
- * So this asserts the wire form directly: on a saved workflow the hello must carry the
- * composed route and must never be the bare file handle. A tab-specific route cannot
- * collide with another tab's by construction, so pinning the form is what pins the
- * property — and it fails on any change that reintroduces a file-derived route,
- * including a "helpful" fallback when the tab identity is not yet established.
+ * So this opens the same saved workflow in TWO pages and asserts their routes DIFFER.
+ * Asserting the wire FORM alone would not do: an implementation that emitted
+ * `wf:<one-shared-id>:<path>` for every tab matches the form and recreates #693 exactly
+ * (codex). Uniqueness is the invariant; the form is only how it is carried.
  */
 import { test, expect } from './fixtures/panelTest'
+import { PanelPage } from './fixtures/PanelPage'
 
-/** Record the `tab_id` of every hello this page sends. */
+/** Record the `tab_id` of every hello this page sends, from before it connects. */
 async function captureHellos(page: import('@playwright/test').Page) {
   await page.addInitScript(() => {
     const w = window as any
@@ -50,41 +50,83 @@ async function captureHellos(page: import('@playwright/test').Page) {
   })
 }
 
-test('a saved workflow never routes on its file path', async ({ page, panel, mockBridge }) => {
+/** Open an already-saved workflow by path, the way switching to its tab would. */
+async function openSavedWorkflow(page: import('@playwright/test').Page, path: string) {
+  return page.evaluate(async (p) => {
+    const w = window as any
+    const app = w.comfyAPI?.app?.app || w.app
+    const store = app?.extensionManager?.workflow
+    const wf = (store?.workflows || []).find((x: any) => x?.path === p)
+    if (!wf) return { opened: false, reason: 'not in store' }
+    await store.openWorkflow(wf)
+    return { opened: true, active: store?.activeWorkflow?.path ?? null }
+  }, path)
+}
+
+const savedHellos = (ids: string[]) => ids.filter((id) => id.startsWith('wf:'))
+
+test('two tabs on one saved workflow never share a bridge route', async ({
+  page,
+  panel,
+  mockBridge,
+  context
+}) => {
   await captureHellos(page)
   await panel.goto()
   await panel.setBridgeUrl(mockBridge.url)
   await panel.openSidebar()
   await panel.connect()
 
-  // Give tab A a SAVED workflow. The collision is specific to saved workflows: an
-  // unsaved tab already routes on a per-object `tmp:<uuid>`, so it could never collide
-  // and would make this pass for the wrong reason.
+  // A SAVED workflow specifically. An unsaved tab routes on a per-object `tmp:<uuid>`
+  // and could never collide, so using one would pass for the wrong reason.
   const saved = await mockBridge.command('workflow_save', {})
   expect(saved.ok, 'the workflow must save so both tabs share a FILE').toBe(true)
   const savedName = String(saved.result?.workflow || '')
   expect(savedName, 'the save must report a name').toBeTruthy()
-
-  // Re-hello on the SAVED workflow, then read what went on the wire.
+  const savedPath = `workflows/${savedName}.json`
   await page.waitForTimeout(2500)
-  const hellos: string[] = await page.evaluate(() => (window as any).__hellos ?? [])
-  expect(hellos.length, 'the panel must have helloed').toBeGreaterThan(0)
 
-  const bareHandle = `wf:workflows/${savedName}.json`
-  const saved_hellos = hellos.filter((id) => id.startsWith('wf:'))
-  expect(
-    saved_hellos.length,
-    `the saved workflow must produce a wf: route (got ${JSON.stringify(hellos)})`
-  ).toBeGreaterThan(0)
+  // Tab B: a second real browser tab in the same context, opening that same file.
+  const pageB = await context.newPage()
+  await captureHellos(pageB)
+  await pageB.route('**/comfyui_mcp_panel/status*', (r) => r.fulfill({ json: { running: false } }))
+  await pageB.route('**/comfyui_mcp_panel/backends*', (r) => r.fulfill({ json: { backends: [] } }))
+  const panelB = new PanelPage(pageB)
+  await panelB.goto()
+  await panelB.setBridgeUrl(mockBridge.url)
+  await panelB.openSidebar()
+  await panelB.connect()
 
-  for (const id of saved_hellos) {
-    // The bare handle names the FILE, so every browser tab showing it produces the
-    // same string. That is the collision, and it must never reach the wire.
-    expect(id, 'a route must never be the bare file handle').not.toBe(bareHandle)
-    // The composed form is `wf:<tabRouteId>:<path>` — the tab's own identity in
-    // front of the path, which is what makes two tabs on one file route separately.
-    expect(id, 'the route must compose the tab identity in front of the path').toMatch(
-      /^wf:[^:]+:workflows\//
-    )
+  const openedB = await openSavedWorkflow(pageB, savedPath)
+  expect(openedB.opened, `tab B must open ${savedPath}`).toBe(true)
+  await pageB.waitForTimeout(3000)
+
+  const hellosA = savedHellos(await page.evaluate(() => (window as any).__hellos ?? []))
+  const hellosB = savedHellos(await pageB.evaluate(() => (window as any).__hellos ?? []))
+  expect(hellosA.length, 'tab A must have helloed on the saved workflow').toBeGreaterThan(0)
+  expect(hellosB.length, 'tab B must have helloed on the saved workflow').toBeGreaterThan(0)
+
+  // Both must be routing for the SAME file, or they were never in a position to
+  // collide and this proves nothing.
+  expect(hellosA.some((id) => id.endsWith(`:${savedPath}`)), 'tab A must route for the saved file').toBe(true)
+  expect(hellosB.some((id) => id.endsWith(`:${savedPath}`)), 'tab B must route for the saved file').toBe(true)
+
+  // The bare handle names the FILE, so every tab showing it produces the same string.
+  for (const [label, ids] of [['A', hellosA], ['B', hellosB]] as const) {
+    for (const id of ids) {
+      expect(id, `tab ${label} must not route on the bare file handle`).not.toBe(`wf:${savedPath}`)
+    }
   }
+
+  // THE INVARIANT: no route may be shared. This is what the bridge keys on, and a
+  // shared value is what makes two clients evict each other forever.
+  const shared = hellosA.filter((id) => hellosB.includes(id))
+  expect(
+    shared,
+    `both tabs helloed with the same route — the bridge keeps one connection per ` +
+      `tab_id, so these two would close each other's sockets indefinitely ` +
+      `(A=${JSON.stringify(hellosA)} B=${JSON.stringify(hellosB)})`
+  ).toEqual([])
+
+  await pageB.close()
 })

--- a/browser_tests/fixtures/panelTest.ts
+++ b/browser_tests/fixtures/panelTest.ts
@@ -9,6 +9,7 @@
  * A typical spec: point the panel at `mockBridge.url`, open the sidebar, connect,
  * then drive the conversation via the MockBridge helpers.
  */
+import type { Page } from '@playwright/test'
 import { test as base } from '@playwright/test'
 
 import { MockBridge } from './MockBridge'
@@ -38,6 +39,72 @@ interface PanelOptions {
   panelFlags: string[]
 }
 
+/** The stub set itself, kept in one place so the fixture and a spec's second page
+ *  can never drift apart. */
+async function applyPanelRouteStubs(page: Page, panelFlags: string[]) {
+  // Hermetic runs on a dev box with a REAL orchestrator listening on :9180:
+  // the panel's mount probe (GET /comfyui_mcp_panel/status → { running: true })
+  // would auto-connect it to the live agent before the spec's setBridgeUrl()
+  // override applies — the real greeting then pollutes the transcript and the
+  // MockBridge never sees the session. Stub the discovery routes so every spec
+  // sees "no orchestrator"; connection goes only where the spec points it.
+  await page.route('**/comfyui_mcp_panel/status*', (route) =>
+    route.fulfill({ json: { running: false } })
+  )
+  await page.route('**/comfyui_mcp_panel/backends*', (route) =>
+    route.fulfill({ json: { backends: [] } })
+  )
+  await page.route('**/comfyui_mcp_panel/bridge_url*', (route) =>
+    route.fulfill({ json: { url: null } })
+  )
+  // Panel-setting WRITES must never reach the real server: Reconnect mirrors
+  // the (per-test, throwaway) mock URL into `comfyui-mcp.bridgeUrl.single`,
+  // which would poison the developer's live panel with a dead port after the
+  // suite exits. Swallow them; the panel treats the write as fire-and-forget.
+  await page.route(
+    (url) => /\/(api\/)?settings\/comfyui-mcp\./.test(url.pathname),
+    (route) =>
+      route.request().method() === 'GET'
+        ? route.continue()
+        : route.fulfill({ status: 200, json: {} })
+  )
+  // Same hermeticity for SERVER-STORED user settings: a dev box that uses the
+  // panel daily has `comfyui-mcp.autoConnect: true` (+ a saved bridge URL) in
+  // ComfyUI's /settings store, which auto-connects the panel to the live
+  // orchestrator on mount even in a fresh browser profile. Strip the panel's
+  // keys from the settings payload; everything else passes through untouched.
+  await page.route(
+    (url) => /\/(api\/)?settings\/?$/.test(url.pathname),
+    async (route) => {
+      if (route.request().method() !== 'GET') return route.continue()
+      const res = await route.fetch()
+      let body: Record<string, unknown>
+      try {
+        body = await res.json()
+      } catch {
+        return route.fulfill({ response: res })
+      }
+      for (const key of Object.keys(body)) {
+        if (key.startsWith('comfyui-mcp.')) delete body[key]
+      }
+      // Put back only what this spec explicitly asked for, AFTER the strip, so
+      // the flag value comes from the spec and never from the dev box.
+      for (const flag of panelFlags) body[flag] = true
+      return route.fulfill({ response: res, json: body })
+    }
+  )
+}
+
+/**
+ * Apply every hermeticity stub to a page. Exported because the fixture only covers the
+ * test's OWN `page`: a spec that opens a SECOND page must apply the identical set, or
+ * that page's Reconnect writes the throwaway mock bridge URL into the developer's REAL
+ * ComfyUI settings and leaves a dead port behind after the suite exits (codex, #693).
+ */
+export async function isolatePanelPage(page: Page, panelFlags: string[] = []) {
+  await applyPanelRouteStubs(page, panelFlags)
+}
+
 export const test = base.extend<PanelFixtures & PanelOptions>({
   panelFlags: [[], { option: true }],
   mockBridge: async ({}, use) => {
@@ -47,57 +114,7 @@ export const test = base.extend<PanelFixtures & PanelOptions>({
     await bridge.close()
   },
   panel: async ({ page, panelFlags }, use) => {
-    // Hermetic runs on a dev box with a REAL orchestrator listening on :9180:
-    // the panel's mount probe (GET /comfyui_mcp_panel/status → { running: true })
-    // would auto-connect it to the live agent before the spec's setBridgeUrl()
-    // override applies — the real greeting then pollutes the transcript and the
-    // MockBridge never sees the session. Stub the discovery routes so every spec
-    // sees "no orchestrator"; connection goes only where the spec points it.
-    await page.route('**/comfyui_mcp_panel/status*', (route) =>
-      route.fulfill({ json: { running: false } })
-    )
-    await page.route('**/comfyui_mcp_panel/backends*', (route) =>
-      route.fulfill({ json: { backends: [] } })
-    )
-    await page.route('**/comfyui_mcp_panel/bridge_url*', (route) =>
-      route.fulfill({ json: { url: null } })
-    )
-    // Panel-setting WRITES must never reach the real server: Reconnect mirrors
-    // the (per-test, throwaway) mock URL into `comfyui-mcp.bridgeUrl.single`,
-    // which would poison the developer's live panel with a dead port after the
-    // suite exits. Swallow them; the panel treats the write as fire-and-forget.
-    await page.route(
-      (url) => /\/(api\/)?settings\/comfyui-mcp\./.test(url.pathname),
-      (route) =>
-        route.request().method() === 'GET'
-          ? route.continue()
-          : route.fulfill({ status: 200, json: {} })
-    )
-    // Same hermeticity for SERVER-STORED user settings: a dev box that uses the
-    // panel daily has `comfyui-mcp.autoConnect: true` (+ a saved bridge URL) in
-    // ComfyUI's /settings store, which auto-connects the panel to the live
-    // orchestrator on mount even in a fresh browser profile. Strip the panel's
-    // keys from the settings payload; everything else passes through untouched.
-    await page.route(
-      (url) => /\/(api\/)?settings\/?$/.test(url.pathname),
-      async (route) => {
-        if (route.request().method() !== 'GET') return route.continue()
-        const res = await route.fetch()
-        let body: Record<string, unknown>
-        try {
-          body = await res.json()
-        } catch {
-          return route.fulfill({ response: res })
-        }
-        for (const key of Object.keys(body)) {
-          if (key.startsWith('comfyui-mcp.')) delete body[key]
-        }
-        // Put back only what this spec explicitly asked for, AFTER the strip, so
-        // the flag value comes from the spec and never from the dev box.
-        for (const flag of panelFlags) body[flag] = true
-        return route.fulfill({ response: res, json: body })
-      }
-    )
+    await applyPanelRouteStubs(page, panelFlags)
     await use(new PanelPage(page))
   }
 })


### PR DESCRIPTION
Closes #693 — **already fixed by #640**; this adds the regression test that was missing.

#693 reported a permanent reconnect storm: sockets helloing and being closed ~2s later
forever, every close `code=1005 clean=true` (a server-side close). The bridge keeps one
connection per `tab_id` and closes the older socket when a new hello arrives for the
same one, so two clients sharing a `tab_id` evict each other indefinitely.

The reported hellos carried `tab_id = wf:workflows/<name>` — the bare saved-workflow
handle, which names the FILE, so every browser tab showing it produced the same string.
That form cannot reach the wire on current main: #640 (2026-08-05, the day before this
report) composed the route as `wf:<tabRouteId>:<path>`, and `savedWorkflowRoute` returns
null rather than falling back to the bare path.

I ruled out the live alternatives by measurement before concluding that:
- sidebar toggling does not duplicate the client (one `.cmcp-root`, zero new sockets);
- a duplicate module instance cannot register a second panel — ComfyUI throws
  `Extension named 'comfyui-mcp.agent-panel' already registered`;
- the orphaned-client window I suspected cannot storm, because a client only dials once
  `client.start()` runs, which is after the singleton assignment.

**The test.** Two real pages in one browser context, both opening the same saved file;
assert both routed for that file and that no route is shared. An earlier version pinned
only the wire FORM — codex showed that `wf:<one-shared-id>:<path>` matches the form and
recreates #693 exactly, so uniqueness is asserted directly. Mutation-verified against
both shapes: the bare handle fails, and the shared-id fails.

Also fixes two hygiene defects codex found, both of which touched the real machine: the
second page now gets the fixture's full stub set (it could otherwise write the throwaway
mock bridge URL into real ComfyUI settings), and the spec deletes the workflow it
persists in a `finally`.

Test-only — nothing ships (`browser_tests/` is excluded from the published pack).

🤖 Generated with [Claude Code](https://claude.com/claude-code)