### PR TITLE
fix(open): a content-unverified open must name the fence recovery (#702)

### DIFF
--- a/browser_tests/open-unverified-names-recovery.spec.ts
+++ b/browser_tests/open-unverified-names-recovery.spec.ts
@@ -1,0 +1,77 @@
+/**
+ * #702 — an open that proves the binding but not the CONTENT must not strand the caller.
+ *
+ * `workflow_open` on the already-active tab legitimately answers CONTENT_UNVERIFIED: the
+ * binding is proven (instance, marker and identity all match) and only the content
+ * cannot be called byte-identical. That outcome THROWS, so it never reaches the line
+ * that publishes `workflow_uuid` — and the caller's command fence keeps whatever it had.
+ *
+ * The disclosure then closed by recommending `panel_graph_outline`, which is exactly the
+ * call about to be refused as a `workflow instance mismatch`. Two reporters followed that
+ * advice into the refusal and concluded only a full `panel_reload` could recover.
+ *
+ * Measured here before the fix, in this order:
+ *     workflow_open (already active) -> ok:false, CONTENT_UNVERIFIED, no workflow_uuid
+ *     workflow_list                  -> ok:true, republishes the SAME active uuid
+ *     graph_outline stamped with it  -> ok:true
+ *
+ * So the recovery already existed and the reply simply never named it. This asserts both
+ * halves: the disclosure names it, and it actually works.
+ */
+import { test, expect } from './fixtures/panelTest'
+import { claimFreshCanvas, settleCanvas } from './fixtures/canvasIdentity'
+
+test('a content-unverified open names the fence recovery, and it works', async ({
+  page,
+  panel,
+  mockBridge
+}) => {
+  await panel.goto()
+  await panel.setBridgeUrl(mockBridge.url)
+  await panel.openSidebar()
+  await panel.connect()
+  await claimFreshCanvas(page, mockBridge)
+
+  await page.evaluate(() => {
+    const w = window as any
+    const app = w.comfyAPI?.app?.app || w.app
+    const LG = w.LiteGraph || w.comfyAPI?.litegraph?.LiteGraph
+    ;(app?.canvas?.graph ?? app?.graph).add(LG.createNode('EmptyLatentImage'))
+  })
+  await settleCanvas(page)
+
+  const listed = await mockBridge.command('workflow_list', {})
+  const target =
+    listed.result?.active?.routing_key || listed.result?.active?.key || listed.result?.active?.path
+  expect(target, 'an active workflow must be resolvable').toBeTruthy()
+
+  // Reopening the ALREADY-ACTIVE workflow is the CONTENT_UNVERIFIED path.
+  const reopened = await mockBridge.command('workflow_open', { path: target })
+  const text = JSON.stringify(reopened)
+  // Precondition: this must be the outcome the issue is about, not some other failure.
+  expect(text, 'the reply must be the post-repaint content verdict').toContain(
+    'workflow_open RAN, the canvas IS bound to'
+  )
+  expect(reopened.ok, 'content-unverified is ok:false by design').toBe(false)
+
+  // It must SAY the fence was not refreshed, and name the call that refreshes it.
+  // Without this the reply recommends the graph read that is about to be refused.
+  expect(text, 'the reply must disclose that no fence refresh rode with it').toContain(
+    'carries NO fence refresh'
+  )
+  expect(text, 'the reply must name the fence-exempt recovery probe').toContain(
+    'panel_list_workflows'
+  )
+
+  // And the named recovery must actually work — a remedy that does not is worse than none.
+  const after = await mockBridge.command('workflow_list', {})
+  expect(after.ok, 'workflow_list must stay usable — it is the fence-exempt probe').toBe(true)
+  const stamp = after.result?.active?.workflow_uuid
+  expect(stamp, 'workflow_list must republish the active identity').toBeTruthy()
+
+  const outline = await mockBridge.command('graph_outline', { workflow_uuid: stamp })
+  expect(
+    outline.ok,
+    'a graph read stamped from the recovery probe must succeed — this is the whole loop'
+  ).toBe(true)
+})

--- a/browser_tests/unit/open-rebind-proof.test.mjs
+++ b/browser_tests/unit/open-rebind-proof.test.mjs
@@ -661,3 +661,56 @@ test("#641: a save/reconnect INSTANCE REFRESH of the same file keeps its uuid (f
     "a genuine co-open copy must still get its own identity (#557/#570)",
   );
 });
+
+// ── #702: a proven-binding open must not strand the caller's fence ──────────
+//
+// CONTENT_UNVERIFIED throws, so it never reaches the line that publishes
+// `workflow_uuid`, and the caller's command fence keeps whatever it had. The
+// disclosure closed by recommending `panel_graph_outline` — precisely the call about
+// to be refused as a `workflow instance mismatch`. Two reporters followed that advice
+// into the refusal and concluded only a full panel_reload could recover.
+//
+// Measured end-to-end (browser_tests/open-unverified-names-recovery.spec.ts): after
+// this outcome, `workflow_list` still republishes the active identity and a graph read
+// stamped with it succeeds. The recovery existed; the reply never named it.
+
+test("#702: a content-unverified open discloses that no fence refresh rode with it", () => {
+  // EVERY content-unverified wording strands the caller the same way, so every one
+  // of them must carry the note. The generic branch was missed on the first pass and
+  // this loop is what caught it.
+  for (const observed of [
+    // Both CONTENT_UNVERIFIED wordings: values matched (presentation-only drift), and
+    // per-node fields differing. They are separate sentences and both stranded callers.
+    // node set intact + values matched — the presentation-only wording
+    { contentComparable: true, contentSurfaces: ["nodes"], contentNodeDifference: { comparable: true, sameNodeSet: true, cosmeticOnly: true } },
+    // node set intact, values differ — the per-node-fields wording
+    { contentComparable: true, contentSurfaces: ["nodes"], contentNodeDifference: { comparable: true, sameNodeSet: true, cosmeticOnly: false } },
+    // node set NOT intact, and a second surface — the generic "treat as UNKNOWN" wording
+    { contentComparable: true, contentSurfaces: ["nodes", "links"], contentNodeDifference: { comparable: true, sameNodeSet: false } },
+    // the content could not be READ at all — the non-asserting wording
+    { contentComparable: false, contentSurfaces: [], contentNodeDifference: null },
+  ]) {
+    const text = describeOpenRebindOutcome(
+      { status: OPEN_REBIND_STATUS.CONTENT_UNVERIFIED, bindingProven: true, unproven: ["content"] },
+      { targetLabel: "My Workflow", ...observed },
+    );
+    assert.match(text, /carries NO fence refresh/, "it must say the fence was not refreshed");
+    assert.match(text, /panel_list_workflows/, "it must name the fence-exempt recovery probe");
+    assert.match(
+      text,
+      /Reloading the panel is NOT required/,
+      "it must retract the panel_reload advice both reporters followed",
+    );
+  }
+});
+
+test("#702: the fence note is ONLY on the content-unverified outcome", () => {
+  // An UNPROVEN open has not established identity, so `workflow_list` republishing the
+  // active identity is not a remedy for it — promising one there would send a caller
+  // to re-stamp against a canvas whose binding was never proven.
+  const unproven = describeOpenRebindOutcome(
+    { status: OPEN_REBIND_STATUS.UNPROVEN, bindingProven: false, unproven: ["identity"] },
+    { targetLabel: "My Workflow", expectedUuid: "a", observedUuid: "b" },
+  );
+  assert.doesNotMatch(unproven, /carries NO fence refresh/);
+});

--- a/browser_tests/unit/open-rebind-proof.test.mjs
+++ b/browser_tests/unit/open-rebind-proof.test.mjs
@@ -698,8 +698,16 @@ test("#702: a content-unverified open discloses that no fence refresh rode with 
     assert.match(text, /panel_list_workflows/, "it must name the fence-exempt recovery probe");
     assert.match(
       text,
-      /Reloading the panel is NOT required/,
+      /Reloading the panel is NOT required to refresh the fence/,
       "it must retract the panel_reload advice both reporters followed",
+    );
+    // It must promise a fence refresh and NOTHING more. On the wording where the panel
+    // could not read the graph at all, a refreshed fence cannot make that read succeed —
+    // it only stops the mismatch from being the reason it fails (codex).
+    assert.doesNotMatch(
+      text,
+      /the graph read then works/,
+      "the note must not promise a graph read will succeed",
     );
   }
 });
@@ -713,4 +721,10 @@ test("#702: the fence note is ONLY on the content-unverified outcome", () => {
     { targetLabel: "My Workflow", expectedUuid: "a", observedUuid: "b" },
   );
   assert.doesNotMatch(unproven, /carries NO fence refresh/);
+  // It may still say to CHECK panel_list_workflows — it does, and that is right: with
+  // the binding unproven you look at what is actually active. What it must NOT do is
+  // retract the reload, because there the reload is the remedy. Re-stamping from the
+  // probe would otherwise be invited against a binding that was never proven.
+  assert.doesNotMatch(unproven, /Reloading the panel is NOT required/);
+  assert.match(unproven, /reload the panel before graph edits/);
 });

--- a/web/js/lib/graph-binding.js
+++ b/web/js/lib/graph-binding.js
@@ -1141,13 +1141,17 @@ export function resolveOpenRebindVerdict({
  * `workflow_list` is deliberately fence-EXEMPT (#759/#932) precisely to be the recovery
  * probe, and it republishes the active identity — measured: after this outcome it
  * returns the same uuid and a stamped graph read then succeeds.
+ *
+ * The note promises a fence refresh and nothing more (codex). On the fourth wording the
+ * panel could not READ the graph at all, and a refreshed fence cannot make that read
+ * succeed — it only stops the mismatch from being the reason it fails.
  */
 const FENCE_NOT_REFRESHED =
   " This reply carries NO fence refresh — an open that could not verify its content" +
   " publishes no workflow_uuid, so a command stamped from an older one is still refused" +
   " as a workflow instance mismatch. Call panel_list_workflows first: it is exempt from" +
-  " the fence and republishes the active identity, and the graph read then works." +
-  " Reloading the panel is NOT required for this (#702).";
+  " the fence and republishes the active identity, which permits a freshly stamped graph" +
+  " read. Reloading the panel is NOT required to refresh the fence (#702).";
 
 /** Did a content comparison actually HAPPEN? The single rule every sentence about
  *  content asks, so the headline and the per-part clause cannot disagree with each

--- a/web/js/lib/graph-binding.js
+++ b/web/js/lib/graph-binding.js
@@ -1126,6 +1126,29 @@ export function resolveOpenRebindVerdict({
   return { status: OPEN_REBIND_STATUS.PROVEN, bindingProven: true, unproven: [] };
 }
 
+/**
+ * What a CONTENT_UNVERIFIED open must ALSO say (#702).
+ *
+ * That branch has already PROVEN the binding — instance, marker and identity all match —
+ * and only the content is unconfirmed. But the reply still throws, so it never reaches
+ * the line that publishes `workflow_uuid`, and the caller's fence keeps whatever it had.
+ * The disclosure then closed by recommending `panel_graph_outline`, which is precisely
+ * the call that is about to be refused as a `workflow instance mismatch`. Two reporters
+ * followed that advice into the refusal and concluded, reasonably, that only a full
+ * panel_reload could recover.
+ *
+ * So the reply names the state it leaves behind and the ONE cheap call that clears it.
+ * `workflow_list` is deliberately fence-EXEMPT (#759/#932) precisely to be the recovery
+ * probe, and it republishes the active identity — measured: after this outcome it
+ * returns the same uuid and a stamped graph read then succeeds.
+ */
+const FENCE_NOT_REFRESHED =
+  " This reply carries NO fence refresh — an open that could not verify its content" +
+  " publishes no workflow_uuid, so a command stamped from an older one is still refused" +
+  " as a workflow instance mismatch. Call panel_list_workflows first: it is exempt from" +
+  " the fence and republishes the active identity, and the graph read then works." +
+  " Reloading the panel is NOT required for this (#702).";
+
 /** Did a content comparison actually HAPPEN? The single rule every sentence about
  *  content asks, so the headline and the per-part clause cannot disagree with each
  *  other — which they did, because one tested `=== true` and the other `=== false`
@@ -1318,7 +1341,7 @@ export function describeOpenRebindOutcome(verdict, observed = {}) {
           `presentation only, which the panel cannot call byte-identical, so the content ` +
           `is reported UNCONFIRMED rather than failed.${because} You are on the right workflow ` +
           `and there is no missing work to redo; if you need the exact graph, read it with ` +
-          `panel_graph_outline.`
+          `panel_graph_outline.` + FENCE_NOT_REFRESHED
         );
       }
       return (
@@ -1326,7 +1349,7 @@ export function describeOpenRebindOutcome(verdict, observed = {}) {
         `per-node fields; the panel cannot tell from here whether the ComfyUI frontend ` +
         `normalized those or the load applied them differently, so the content is reported ` +
         `UNCONFIRMED rather than failed.${because} You are on the right workflow; if you need ` +
-        `the exact graph, read it with panel_graph_outline.`
+        `the exact graph, read it with panel_graph_outline.` + FENCE_NOT_REFRESHED
       );
     }
     return (
@@ -1338,7 +1361,7 @@ export function describeOpenRebindOutcome(verdict, observed = {}) {
         : `the panel could not READ the graph on it to compare against the state that was loaded, so ` +
           `whether the whole graph landed is unestablished — NOT established as wrong. `) +
       `Treat the canvas as UNKNOWN and re-read it (panel_graph_outline) before editing.${because} ` +
-      `You are NOT on the wrong workflow: ${workflow} IS the active one.`
+      `You are NOT on the wrong workflow: ${workflow} IS the active one.` + FENCE_NOT_REFRESHED
     );
   }
   if (verdict?.status === OPEN_REBIND_STATUS.UNPROVEN) {


### PR DESCRIPTION
Closes #702.

`workflow_open` on the already-active tab answers CONTENT_UNVERIFIED: the binding is
**proven** — instance, marker and identity all match — and only the content cannot be
called byte-identical. That outcome throws, so it never reaches the line that publishes
`workflow_uuid`, and the caller's command fence keeps whatever it had.

The disclosure then closed by recommending `panel_graph_outline` — precisely the call
about to be refused as a `workflow instance mismatch`. Both reporters followed that
advice into the refusal and concluded only a full `panel_reload` could recover.

Measured against the real functions before changing anything:

| call | result |
|---|---|
| `workflow_open` (already active) | `ok:false`, CONTENT_UNVERIFIED, no `workflow_uuid` |
| `workflow_list` | `ok:true`, republishes the **same** active uuid |
| `graph_outline` stamped with it | `ok:true` |

The recovery already existed — `workflow_list` is deliberately fence-exempt (#759/#932)
to be exactly this probe — and the reply never named it while recommending the one call
that fails. **This is a wording fix because the defect is in the wording**; no binding
logic changed.

All four CONTENT_UNVERIFIED wordings carry the note. The generic "treat the canvas as
UNKNOWN" branch was missed on the first pass and a unit test looping over all four is
what caught it, so it loops on purpose. Per codex the note promises a fence refresh and
nothing more — on the wording where the graph could not be READ, a refreshed fence
cannot make that read succeed — and it stays off the UNPROVEN outcome, where the reload
is still the remedy.

Verified: 3310/3310 unit tests; four mutations each verified to fail the suite, with a
no-op control that correctly does not; and an e2e spec driving the whole loop over the
bridge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)