### PR TITLE
0.11.65 — re-opening the current workflow stops sending the agent in a circle (#702)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,28 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+## [0.11.65] - 2026-08-09
+
+> Covers changes since 0.11.64.
+
+### Fixed
+
+- **Re-opening the current workflow no longer sends the agent in a circle (#702).**
+  Re-opening the tab that is already open answers "the canvas IS this workflow's, but I
+  can't call the contents byte-identical" — normal, and not a failure. What that answer
+  did not say is that it carries no refreshed workflow stamp, so the agent's *next*
+  command was rejected as belonging to a different workflow. And the answer ended by
+  recommending exactly that next command.
+
+  Two people followed that advice into the rejection and concluded the only way out was
+  reloading the whole panel. It wasn't: listing workflows re-publishes the current
+  identity and the read then goes through — one call, no reload. The reply now says so.
+
+  Nothing about how the panel decides which canvas it is bound to changed; the answer
+  was right and only its advice was wrong. All four phrasings of that outcome carry the
+  correction, and it stays off the case where the workflow genuinely *cannot* be
+  confirmed, because there reloading really is the remedy.
+
 ## [0.11.64] - 2026-08-09
 
 > Covers changes since 0.11.63.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-agent-panel"
 description = "Autonomous AI agent in the ComfyUI sidebar - local-first, bring any LLM. Run it on your Claude or ChatGPT subscription (no API keys, no extra LLM costs), on a Kimi K3 / GLM / OpenRouter key, or fully offline on free local models via Ollama, LM Studio, or llama.cpp. The agent drives your live canvas at full parity: add, wire, move and tweak nodes with Ctrl+Z undo, load whole workflows and installer packs in one shot, generate images, video and audio, browse CivitAI, and run your workflow - asking before it spends paid API credits. The sidebar UI for comfyui-mcp, the local-first, agent-native control plane for ComfyUI."
-version = "0.11.64"
+version = "0.11.65"
 license = { file = "LICENSE" }
 requires-python = ">=3.9"
 # UI-only pack: no Python deps. The frontend floor guarantees

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -877,7 +877,7 @@ const DOCS_URL = "https://comfyui-mcp.artokun.io/docs";
 // Panel version — surfaced in the "Need help?" diagnostics blob. Bump via
 // `node scripts/set-version.mjs <v>` (updates this AND pyproject together); CI
 // and the publish gate FAIL if the two ever drift, so this can't go stale.
-const PANEL_VERSION = "0.11.64";
+const PANEL_VERSION = "0.11.65";
 
 // The connected orchestrator's console URL/token (captured off the `backends`
 // bridge message — see onBackends). Drives the "API Keys" credentials frame;


### PR DESCRIPTION
Releases #892 (fixes #702).

Re-opening the already-active tab answers CONTENT_UNVERIFIED — the binding is proven and
only the content cannot be called byte-identical. That outcome throws, so it never
publishes a `workflow_uuid`, and the caller's fence goes stale. The reply then closed by
recommending `panel_graph_outline`, the exact call about to be refused as a workflow
instance mismatch. Both reporters followed it into the refusal and concluded only
`panel_reload` could recover.

Measured: after that outcome `workflow_list` still republishes the same active uuid and a
stamped graph read succeeds. The recovery existed; the reply never named it. Wording
fix — no binding logic changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)