### PR TITLE
fix(manager): a 405 on queue/task must fall back, not fail (#367)

### DIFF
--- a/browser_tests/unit/manager-dialect.test.mjs
+++ b/browser_tests/unit/manager-dialect.test.mjs
@@ -799,6 +799,61 @@ test("#367: the proven dialect is recorded so the dead route is not re-POSTed", 
   assert.deepEqual(noted, ["v2-batch"], "the method rejection must update the cached dialect");
 });
 
+test("#367: a build that refuses BOTH /v2 mutations caches nothing and lands on legacy", async () => {
+  // The case that makes the cache write dangerous (codex): `queue/task` 405s, and so
+  // does `batch`. Recording v2-batch on the first 405 would leave this backend — which
+  // updates FINE on legacy — permanently cached at a route it refuses, re-paying that
+  // POST on every later call. The heal only runs on a route-MISSING verdict, not a 405,
+  // so nothing would clear it.
+  const noted = [];
+  const calls = [];
+  const update = buildGraphUpdateNode(
+    graphUpdateDeps({
+      detectManagerDialect: async () => "v2",
+      noteManagerDialectDowngrade: (d) => noted.push(d),
+      managerV2: async (route) => {
+        calls.push(["v2", route]);
+        throw new Error(`Manager ${route}: HTTP 405`);
+      },
+      managerCall: async (route) => {
+        calls.push(["legacy", route]);
+        return {};
+      },
+    }),
+  );
+  const res = await update({ id: "comfyui-manager" });
+  assert.equal(res.dialect, "legacy", "legacy is where this backend actually works");
+  assert.deepEqual(noted, [], "a dialect that never worked must not be cached");
+  assert.deepEqual(calls, [
+    ["v2", "manager/queue/task"],
+    ["v2", "manager/queue/batch"],
+    ["legacy", "manager/queue/update"],
+    ["legacy", "manager/queue/start"],
+  ]);
+});
+
+test("#367: task 405 then batch 404 heals through the ladder rather than caching", async () => {
+  // A 404 on batch is a route-level rejection, not a method one, so it takes the
+  // existing re-probe ladder instead of the legacy rung. Either way nothing is cached
+  // from a route that never ran an enqueue.
+  const noted = [];
+  const update = buildGraphUpdateNode(
+    graphUpdateDeps({
+      detectManagerDialect: async () => "v2",
+      reProbeManagerDialect: async () => "legacy",
+      noteManagerDialectDowngrade: (d) => noted.push(d),
+      managerV2: async (route) => {
+        if (route === "manager/queue/task") throw new Error(`Manager ${route}: HTTP 405`);
+        throw routeMissing();
+      },
+      managerCall: async () => ({}),
+    }),
+  );
+  const res = await update({ id: "comfyui-manager" });
+  assert.equal(res.dialect, "legacy");
+  assert.deepEqual(noted, [], "an enqueue that never landed must not be cached");
+});
+
 // ---------------------------------------------------------------------------
 // Real-source harness: nodes_install (the mutation path)
 // ---------------------------------------------------------------------------

--- a/browser_tests/unit/manager-dialect.test.mjs
+++ b/browser_tests/unit/manager-dialect.test.mjs
@@ -779,11 +779,11 @@ test("#367: a v4 that 405s queue/task updates through BATCH, not legacy", async 
   );
 });
 
-test("#367: the proven dialect is recorded so the dead route is not re-POSTed", async () => {
-  // Detection got it wrong from the probe; the 405 is stronger evidence than the probe,
-  // because it proves the route is REGISTERED and refuses this method — which is exactly
-  // what separates the two pip dialects. Without recording it, every later call pays the
-  // failed POST again, which is what "the tool immediately errors" looked like.
+test("#367: a dialect that WORKED is recorded so the refused route is not re-POSTed", async () => {
+  // Detection got it wrong from the probe. What corrects it is not the 405 — that is
+  // only a candidate — but the batch enqueue LANDING, which is what this fixture does.
+  // Without recording that, every later call pays the refused POST again, which is what
+  // "the tool immediately errors" looked like.
   const noted = [];
   const update = buildGraphUpdateNode(
     graphUpdateDeps({
@@ -796,7 +796,7 @@ test("#367: the proven dialect is recorded so the dead route is not re-POSTed", 
     }),
   );
   await update({ id: "ComfyUI-LTXVideo" });
-  assert.deepEqual(noted, ["v2-batch"], "the method rejection must update the cached dialect");
+  assert.deepEqual(noted, ["v2-batch"], "a batch enqueue that LANDED must update the cached dialect");
 });
 
 test("#367: a build that refuses BOTH /v2 mutations caches nothing and lands on legacy", async () => {

--- a/browser_tests/unit/manager-dialect.test.mjs
+++ b/browser_tests/unit/manager-dialect.test.mjs
@@ -526,8 +526,8 @@ function graphUpdateDeps(overrides) {
     isManagerUnreachable,
     isManagerRouteMissing,
     dialectRetryTarget,
-    // #367 — the panel records a dialect the LIVE backend proved by rejecting the
-    // method. Harmless here; asserted directly in its own test below.
+    // #367 — the panel records a dialect the LIVE backend demonstrated by completing an
+    // enqueue on it. Harmless here; asserted directly in its own test below.
     noteManagerDialectDowngrade: () => {},
     reProbeManagerDialect: async () => "v2",
     waitForUpdateResult: async () => ({
@@ -668,9 +668,10 @@ test("#605: graph_update_node legacy-on-legacy unreachable surfaces the original
 
 test("#424: a 405 on the /v2 envelope still lands on the legacy self-update route (via marker)", async () => {
   // #367 reordered the ladder to v2 → v2-batch → legacy. The legacy landing this test
-  // exists for is unchanged; it is now reached after the batch route is tried, because
-  // a 405 on `queue/task` is the DEFINITION of v2-batch and this backend serves /v2.
-  // Here managerV2 405s every route, so the batch rung is refused too and legacy wins.
+  // exists for is unchanged; it is now reached after the batch route is TRIED, because a
+  // 405 on `queue/task` makes v2-batch the candidate worth one POST on a backend whose
+  // /v2 routes answer. It is only a candidate: here managerV2 405s every route, so the
+  // batch rung is refused too, legacy wins, and nothing is cached.
   const calls = [];
   const update = buildGraphUpdateNode(
     graphUpdateDeps({

--- a/browser_tests/unit/manager-dialect.test.mjs
+++ b/browser_tests/unit/manager-dialect.test.mjs
@@ -526,6 +526,9 @@ function graphUpdateDeps(overrides) {
     isManagerUnreachable,
     isManagerRouteMissing,
     dialectRetryTarget,
+    // #367 — the panel records a dialect the LIVE backend proved by rejecting the
+    // method. Harmless here; asserted directly in its own test below.
+    noteManagerDialectDowngrade: () => {},
     reProbeManagerDialect: async () => "v2",
     waitForUpdateResult: async () => ({
       item: { ui_id: "u-1", status: { status_str: "success", completed: true, messages: [] } },
@@ -664,6 +667,10 @@ test("#605: graph_update_node legacy-on-legacy unreachable surfaces the original
 });
 
 test("#424: a 405 on the /v2 envelope still lands on the legacy self-update route (via marker)", async () => {
+  // #367 reordered the ladder to v2 → v2-batch → legacy. The legacy landing this test
+  // exists for is unchanged; it is now reached after the batch route is tried, because
+  // a 405 on `queue/task` is the DEFINITION of v2-batch and this backend serves /v2.
+  // Here managerV2 405s every route, so the batch rung is refused too and legacy wins.
   const calls = [];
   const update = buildGraphUpdateNode(
     graphUpdateDeps({
@@ -686,6 +693,7 @@ test("#424: a 405 on the /v2 envelope still lands on the legacy self-update rout
     calls,
     [
       ["v2", "manager/queue/task"], // method-rejected — nothing landed
+      ["v2", "manager/queue/batch"], // #367 rung: also method-rejected here
       ["legacy", "manager/queue/update"],
       ["legacy", "manager/queue/start"],
     ],
@@ -721,12 +729,74 @@ test("codex r2: a route-404 from the 405-fallback's legacy POST heals through th
     calls,
     [
       ["v2", "manager/queue/task"], // 405 — nothing landed
+      ["v2", "manager/queue/batch"], // #367 rung — 405 too on this build
       ["legacy", "manager/queue/update"], // 404 after the restart — nothing landed
       ["v2", "manager/queue/task"], // healed re-enqueue on the live v4
       ["v2", "manager/queue/start"],
     ],
     "exactly one update lands, on the live dialect",
   );
+});
+
+test("#367: a v4 that 405s queue/task updates through BATCH, not legacy", async () => {
+  // The reported backend: built-in Manager v4 whose /v2 GETs (installed/list/status)
+  // all answer, but POST /v2/manager/queue/task returns 405. Detection reads
+  // /v2/manager/is_legacy_manager_ui to split v2 from v2-batch, and this build does not
+  // report a legacy UI — so it is classified "v2" and every attempt re-POSTs the one
+  // route it refuses. Update was unusable with a working batch route sitting unused.
+  const calls = [];
+  const update = buildGraphUpdateNode(
+    graphUpdateDeps({
+      detectManagerDialect: async () => "v2",
+      managerV2: async (route) => {
+        calls.push(["v2", route]);
+        if (route === "manager/queue/task") throw new Error(`Manager ${route}: HTTP 405`);
+        return {}; // batch and start are served
+      },
+      managerCall: async (route) => {
+        calls.push(["legacy", route]);
+        throw routeMissing(); // a pip v4 does not serve the un-prefixed 3.x routes
+      },
+    }),
+  );
+  const res = await update({ id: "ComfyUI-LTXVideo", version: "nightly" });
+  assert.equal(res.queued, true, "the update must be queued instead of erroring");
+  assert.equal(res.dialect, "v2-batch", "and name the dialect it actually used");
+  assert.equal(res.via, undefined, "this is not a legacy self-update");
+  // Honest, and unchanged by this fix: the batch dialect exposes no per-task result,
+  // so the outcome cannot be auto-verified. Queued-and-pending is the correct answer
+  // for this backend — the bug was that it returned HTTP 405 instead of an answer.
+  assert.equal(res.pending, true, "a batch update reports honest pending");
+  assert.equal(res.verified, false);
+  assert.deepEqual(
+    calls,
+    [
+      ["v2", "manager/queue/task"], // 405 — method-rejected, nothing landed
+      ["v2", "manager/queue/batch"], // the rung #367 adds
+      ["v2", "manager/queue/start"],
+    ],
+    "it must never reach the legacy routes a pip v4 does not serve",
+  );
+});
+
+test("#367: the proven dialect is recorded so the dead route is not re-POSTed", async () => {
+  // Detection got it wrong from the probe; the 405 is stronger evidence than the probe,
+  // because it proves the route is REGISTERED and refuses this method — which is exactly
+  // what separates the two pip dialects. Without recording it, every later call pays the
+  // failed POST again, which is what "the tool immediately errors" looked like.
+  const noted = [];
+  const update = buildGraphUpdateNode(
+    graphUpdateDeps({
+      detectManagerDialect: async () => "v2",
+      noteManagerDialectDowngrade: (d) => noted.push(d),
+      managerV2: async (route) => {
+        if (route === "manager/queue/task") throw new Error(`Manager ${route}: HTTP 405`);
+        return {};
+      },
+    }),
+  );
+  await update({ id: "ComfyUI-LTXVideo" });
+  assert.deepEqual(noted, ["v2-batch"], "the method rejection must update the cached dialect");
 });
 
 // ---------------------------------------------------------------------------

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -84,6 +84,7 @@ import {
   isManagerRouteMissing,
   isManagerUnreachable,
   isMethodNotAllowed,
+  assertBatchOk,
   legacyUpdateBody,
   parseTaskHistoryItem,
   queueDrained,
@@ -4439,6 +4440,25 @@ function invalidateManagerDialectCache() {
   managerDialectCache = null;
 }
 
+/**
+ * Record a dialect the LIVE backend just proved, by rejecting the method the cached
+ * dialect routes to (#367).
+ *
+ * Detection picks `v2` vs `v2-batch` from `/v2/manager/is_legacy_manager_ui`, and a
+ * build that 405s `queue/task` without reporting a legacy UI is classified `v2` — so
+ * every later call re-POSTs the same dead route and 405s again. A 405 is not an
+ * ambiguous failure: it means the route is REGISTERED and refuses this method, which
+ * is exactly what separates the two pip dialects. So it is stronger evidence than the
+ * probe that produced the cache, and it replaces it.
+ *
+ * Only ever called after a method rejection on a route the cached dialect chose. It
+ * does not invalidate: the answer is known, and clearing would just make the next call
+ * re-run the probe that got it wrong.
+ */
+function noteManagerDialectDowngrade(dialect) {
+  managerDialectCache = dialect;
+}
+
 /** #605 — drop the cached dialect and re-probe the LIVE backend once. Returns
  *  the fresh dialect, or null when the Manager currently answers no dialect at
  *  all (mid-restart / disabled) — the caller then surfaces its ORIGINAL error,
@@ -4656,20 +4676,6 @@ async function managerQueueControl(call, route, { signal } = {}) {
     // (not ComfyUI's frontend catchall, which only serves UNREGISTERED GETs).
     if (!isMethodNotAllowed(err)) throw err;
     await call(route, { signal: anyAbortSignal([AbortSignal.timeout(MANAGER_FETCH_TIMEOUT_MS), signal]) });
-  }
-}
-
-/** Throw if a /v2/manager/queue/batch response reported the target id as failed.
- *  The batch runs synchronously and surfaces failures as {failed:[id,...]} — a
- *  silent success on a failed op is exactly the #184 no-op bug. */
-function assertBatchOk(res, id, op) {
-  const failed = Array.isArray(res?.failed) ? res.failed : [];
-  if (failed.length && (id === undefined || failed.includes(id))) {
-    throw new Error(
-      `ComfyUI-Manager batch reported the ${op} of "${String(id ?? "?")}" as failed ` +
-        "(check the ComfyUI server log for the underlying error — security_level " +
-        "gating is a common cause). The pack was NOT installed.",
-    );
   }
 }
 
@@ -14499,11 +14505,25 @@ const GRAPH_TOOL_EXECUTORS = {
           enqueued = true;
           await managerV2("manager/queue/start", { method: "POST" });
         } catch (err) {
-          // The 405 legacy self-update fallback wraps ONLY the enqueue: once the
-          // task POST landed, a legacyUpdate would queue a SECOND update.
+          // The 405 fallback wraps ONLY the enqueue: once the task POST landed, a
+          // retry on another dialect would queue a SECOND update.
+          //
+          // #367 — a 405 HERE goes to v2-batch, not straight to legacy. A 405 on
+          // `queue/task` is the DEFINITION of the v2-batch dialect ("POST
+          // /v2/manager/queue/task 405s (frontend catchall)"), and the backend that
+          // produced it is a pip v4 whose /v2 GETs all answer — so the legacy routes,
+          // which carry no /v2 prefix, are the one thing it is LEAST likely to serve.
+          // The reporter's Manager v4 405'd here and the legacy fallback failed too,
+          // leaving update unusable with a fully working batch route sitting unused.
+          //
+          // The legacy rung is not lost, it is reordered behind this one: the v2-batch
+          // branch below falls to legacy on its own 405, so the ladder is
+          // v2 → v2-batch → legacy, each step taken only on a proven method rejection.
+          // Monotonic, so it cannot cycle. #424's eventual legacy landing still
+          // happens for a backend that really is legacy — it just gets there second.
           if (!enqueued && isMethodNotAllowed(err)) {
-            methodRejected = true;
-            dialect = "legacy";
+            noteManagerDialectDowngrade("v2-batch");
+            dialect = "v2-batch";
             continue;
           }
           // codex P0: the heal retries ONLY a PROVEN route-level rejection (the

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -4441,19 +4441,22 @@ function invalidateManagerDialectCache() {
 }
 
 /**
- * Record a dialect the LIVE backend just proved, by rejecting the method the cached
- * dialect routes to (#367).
+ * Record a dialect the LIVE backend has DEMONSTRATED by completing an enqueue on it
+ * (#367).
  *
  * Detection picks `v2` vs `v2-batch` from `/v2/manager/is_legacy_manager_ui`, and a
  * build that 405s `queue/task` without reporting a legacy UI is classified `v2` — so
- * every later call re-POSTs the same dead route and 405s again. A 405 is not an
- * ambiguous failure: it means the route is REGISTERED and refuses this method, which
- * is exactly what separates the two pip dialects. So it is stronger evidence than the
- * probe that produced the cache, and it replaces it.
+ * every later call re-POSTs the same refused route.
  *
- * Only ever called after a method rejection on a route the cached dialect chose. It
- * does not invalidate: the answer is known, and clearing would just make the next call
- * re-run the probe that got it wrong.
+ * A 405 on that route is only a CANDIDATE signal, never the proof (codex). It says the
+ * task route refuses this method; it says nothing about whether `batch` is served, and
+ * a generic frontend catchall can refuse both. Caching on the 405 would leave a backend
+ * that refuses BOTH — and updates fine on legacy — pinned to a route it will never
+ * accept, with nothing to clear it: the heal runs on a route-MISSING verdict, not a
+ * method rejection.
+ *
+ * So this is called only where an enqueue actually landed. It does not invalidate: the
+ * answer is now known, and clearing would just re-run the probe that got it wrong.
  */
 function noteManagerDialectDowngrade(dialect) {
   managerDialectCache = dialect;
@@ -14508,11 +14511,14 @@ const GRAPH_TOOL_EXECUTORS = {
           // The 405 fallback wraps ONLY the enqueue: once the task POST landed, a
           // retry on another dialect would queue a SECOND update.
           //
-          // #367 — a 405 HERE goes to v2-batch, not straight to legacy. A 405 on
-          // `queue/task` is the DEFINITION of the v2-batch dialect ("POST
-          // /v2/manager/queue/task 405s (frontend catchall)"), and the backend that
-          // produced it is a pip v4 whose /v2 GETs all answer — so the legacy routes,
-          // which carry no /v2 prefix, are the one thing it is LEAST likely to serve.
+          // #367 — a 405 HERE tries v2-batch before legacy. It is a CANDIDATE, not a
+          // verdict (codex): `queue/task` 405ing is the SHAPE this file has described
+          // as v2-batch since #187/#182/#184 ("POST /v2/manager/queue/task 405s
+          // (frontend catchall). Mutations go through POST /v2/manager/queue/batch"),
+          // and the backend that produced it is a pip v4 whose /v2 GETs all answer — so
+          // the legacy routes, which carry no /v2 prefix, are the one thing it is LEAST
+          // likely to serve. But a generic catchall can refuse batch too, which is why
+          // this costs one POST, keeps the legacy rung behind it, and caches nothing.
           // The reporter's Manager v4 405'd here and the legacy fallback failed too,
           // leaving update unusable with a fully working batch route sitting unused.
           //

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -14524,7 +14524,9 @@ const GRAPH_TOOL_EXECUTORS = {
           //
           // The legacy rung is not lost, it is reordered behind this one: the v2-batch
           // branch below falls to legacy on its own 405, so the ladder is
-          // v2 → v2-batch → legacy, each step taken only on a proven method rejection.
+          // v2 → v2-batch → legacy, each TRANSITION triggered only by a method rejection
+          // (the rejection is proven; what it proves is that THIS route refuses, never
+          // that the next dialect works — that is settled by the next enqueue landing).
           // Monotonic, so it cannot cycle. #424's eventual legacy landing still
           // happens for a backend that really is legacy — it just gets there second.
           if (!enqueued && isMethodNotAllowed(err)) {

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -14522,7 +14522,12 @@ const GRAPH_TOOL_EXECUTORS = {
           // Monotonic, so it cannot cycle. #424's eventual legacy landing still
           // happens for a backend that really is legacy — it just gets there second.
           if (!enqueued && isMethodNotAllowed(err)) {
-            noteManagerDialectDowngrade("v2-batch");
+            // NOTHING is cached here (codex): a 405 proves only that `queue/task` was
+            // refused, never that `batch` is usable. Recording it before the batch POST
+            // lands would leave a build that refuses BOTH — and updates fine on legacy —
+            // permanently cached as v2-batch, re-paying the refused batch POST on every
+            // later call, and the heal only runs on a route-MISSING verdict, not a 405.
+            // The cache is written below, once batch actually works.
             dialect = "v2-batch";
             continue;
           }
@@ -14549,6 +14554,11 @@ const GRAPH_TOOL_EXECUTORS = {
           });
           enqueued = true;
           assertBatchOk(res, id, "update");
+          // #367 — PROVEN, so record it. Detection reads /v2/manager/is_legacy_manager_ui
+          // and a build that refuses `queue/task` without reporting a legacy UI is
+          // classified `v2`, so every later call re-POSTs the refused route. This says
+          // what the backend just demonstrated: batch is the route that works here.
+          noteManagerDialectDowngrade("v2-batch");
           await managerV2("manager/queue/start", { method: "POST" });
         } catch (err) {
           // The 405 legacy self-update fallback wraps ONLY the enqueue (as above).

--- a/web/js/lib/manager-install.js
+++ b/web/js/lib/manager-install.js
@@ -899,3 +899,24 @@ export function classifyUpdateOutcome({ item, status, target, dialect } = {}) {
       `ComfyUI server log.`,
   };
 }
+
+/** Throw if a /v2/manager/queue/batch response reported the target id as failed.
+ *  The batch runs synchronously and surfaces failures as {failed:[id,...]} — a
+ *  silent success on a failed op is exactly the #184 no-op bug.
+ *
+ *  Lives HERE rather than in the panel (#367): the unit harness injects the panel's
+ *  mutation deps by name from this module, and it was destructuring an `assertBatchOk`
+ *  this module never exported — so every batch-path test would have crashed on
+ *  `assertBatchOk is not a function`. None did, because none reached the batch branch.
+ *  Exporting it is what makes that branch testable at all.
+ */
+export function assertBatchOk(res, id, op) {
+  const failed = Array.isArray(res?.failed) ? res.failed : [];
+  if (failed.length && (id === undefined || failed.includes(id))) {
+    throw new Error(
+      `ComfyUI-Manager batch reported the ${op} of "${String(id ?? "?")}" as failed ` +
+        "(check the ComfyUI server log for the underlying error — security_level " +
+        "gating is a common cause). The pack was NOT installed.",
+    );
+  }
+}


### PR DESCRIPTION
Closes #367.

`panel_update_node` POSTs `/v2/manager/queue/task` and gets HTTP 405 from a built-in
Manager v4 whose `/v2` GETs all answer. A 405 fallback already existed (#424) — but it
went straight to `legacy`, whose routes carry no `/v2` prefix and are the one thing a
pip v4 is least likely to serve. So the fallback failed too and update was unusable,
with a working batch route sitting unused.

**The rung is inserted, not replaced:** `v2 → v2-batch → legacy`, each transition
triggered by a method rejection, monotonic so it cannot cycle. #424's legacy landing
still happens for a backend that really is legacy — it just gets there second.

A 405 on `queue/task` is a **candidate**, not proof: a generic frontend catchall can
refuse batch too. So it costs one POST, keeps the legacy rung behind it, and caches
nothing. The dialect is recorded only once a batch enqueue actually **lands** — codex
caught the first version writing the cache on the 405, which would have pinned a
both-refusing backend to a route it will never accept, with nothing to clear it (the
heal runs on route-MISSING, not method rejection).

What this does **not** change: on the batch dialect the update is queued and honestly
reported `pending`/`verified:false`, because that Manager build exposes no per-task
result. Queued-and-pending is the right answer for this backend; the bug was returning
HTTP 405 instead of an answer at all.

Found while writing the test: `assertBatchOk` lived in the panel while the unit harness
destructured it from `lib/manager-install.js`, which never exported it — so **any** test
reaching the batch branch would have died on `assertBatchOk is not a function`. None ever
did. Moved to the lib, which is what makes that branch testable at all.

Verified: 3314/3314 unit tests; three mutations each verified to fail (including
re-introducing the premature cache write); coverage added for both-405 and task-405 +
batch-404, both asserting nothing is cached.

🤖 Generated with [Claude Code](https://claude.com/claude-code)