### PR TITLE
fix(open): re-verify the active workflow before asserting it is active (#887)

### DIFF
--- a/browser_tests/unit/open-active-drift.test.mjs
+++ b/browser_tests/unit/open-active-drift.test.mjs
@@ -1,0 +1,256 @@
+// panel#887 — `panel_open_workflow` reported:
+//
+//   workflow_open RAN and the canvas IS bound to VOICEvideo_LTX23_SAFE_TEST ...
+//   You are NOT on the wrong workflow.
+//
+// and `panel_list_workflows`, called immediately afterwards, reported a DIFFERENT
+// workflow active. The reporter names the sharp end of it: a Save-As on that state
+// writes the wrong canvas.
+//
+// THE DEFECT IS NOT IN THE VERDICT. `resolveOpenRebindVerdict` is sound —
+// CONTENT_UNVERIFIED requires instance AND marker AND identity, each compared
+// against `true`, so an unreadable observation counts as not-proven. Nothing there
+// admits a wrong canvas.
+//
+// It is a TENSE defect. All four proofs are captured in one synchronous window
+// straight after `await app.loadGraphData(...)`, which is the correct place to take
+// them — it is the only moment this attempt's single-use marker is known to be on
+// the root. But three of those proofs are about the ROOT, which nothing else
+// touches, while `instanceStillTarget` is about the ACTIVE POINTER, which is
+// frontend state that keeps moving. Re-opening an already-open MODIFIED workflow —
+// the reporter's exact case — lets ComfyUI's own tab machinery settle after the
+// await returns. The disclosure then asserts that one past observation in the
+// PRESENT tense ("X IS the active one"), so the sentence is true when measured and
+// false when read.
+//
+// THE FIX re-earns the reassurance at composition time instead of inheriting it,
+// and fails closed in BOTH directions: drift is only claimed when it is observed,
+// and reassurance is only given when it is re-proven. An unreadable pointer gets
+// neither — the rule this repo already applies to every other proof-of-sameness
+// oracle: unproven degrades to unknown, never to the negative.
+//
+// WHY THE DECISION IS A PURE EXPORTED FUNCTION. The wording branches on it, and an
+// assertion on message TEXT cannot tell this logic from its own inversion — two
+// earlier fences in this repo shipped with tests that survived exactly that
+// mutation. These tests drive the real functions and assert on OUTCOMES.
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import {
+  OPEN_ACTIVE_DRIFT,
+  OPEN_REBIND_STATUS,
+  openActiveDriftVerdict,
+  resolveOpenRebindVerdict,
+  describeOpenRebindOutcome,
+} from "../../web/js/lib/graph-binding.js";
+
+// ---------------------------------------------------------------------------
+// 1. The decision itself.
+// ---------------------------------------------------------------------------
+
+test("#887 still the target on re-read ⇒ held", () => {
+  assert.equal(
+    openActiveDriftVerdict({ instanceProvenAtLoad: true, activeStillTargetNow: true }),
+    OPEN_ACTIVE_DRIFT.HELD,
+  );
+});
+
+test("#887 something else active on re-read ⇒ drifted", () => {
+  assert.equal(
+    openActiveDriftVerdict({ instanceProvenAtLoad: true, activeStillTargetNow: false }),
+    OPEN_ACTIVE_DRIFT.DRIFTED,
+  );
+});
+
+test("#887 an unreadable re-read is NOT drift and NOT reassurance", () => {
+  // The whole point of the tri-state. Folding null into `false` would invent a
+  // wrong-canvas warning the panel never observed; folding it into `true` restores
+  // the bug. Both are wrong, so it gets its own answer.
+  for (const unreadable of [null, undefined]) {
+    assert.equal(
+      openActiveDriftVerdict({ instanceProvenAtLoad: true, activeStillTargetNow: unreadable }),
+      OPEN_ACTIVE_DRIFT.UNREADABLE,
+    );
+  }
+});
+
+test("#887 a non-boolean re-read is treated as unreadable, never as proof", () => {
+  // Defensive for the same reason every proof here compares against `true`
+  // explicitly: a truthy non-boolean must not be able to buy a present-tense claim.
+  for (const junk of ["true", 1, {}, []]) {
+    assert.equal(
+      openActiveDriftVerdict({ instanceProvenAtLoad: true, activeStillTargetNow: junk }),
+      OPEN_ACTIVE_DRIFT.UNREADABLE,
+    );
+  }
+});
+
+test("#887 an instance never proven at load time keeps its existing wording", () => {
+  // This fix must not weaken the already-honest branch: when the instance was never
+  // proven, the disclosure already says the panel could not confirm which workflow
+  // is active, and that stays the answer regardless of what the re-read says.
+  for (const now of [true, false, null]) {
+    assert.equal(
+      openActiveDriftVerdict({ instanceProvenAtLoad: false, activeStillTargetNow: now }),
+      OPEN_ACTIVE_DRIFT.NOT_PROVEN,
+    );
+  }
+});
+
+test("#887 the decision defaults closed when called with nothing", () => {
+  assert.equal(openActiveDriftVerdict(), OPEN_ACTIVE_DRIFT.NOT_PROVEN);
+  assert.equal(openActiveDriftVerdict({}), OPEN_ACTIVE_DRIFT.NOT_PROVEN);
+});
+
+// ---------------------------------------------------------------------------
+// 2. The message, driven end-to-end through the real verdict.
+// ---------------------------------------------------------------------------
+
+const contentUnverified = () =>
+  resolveOpenRebindVerdict({
+    instanceStillTarget: true,
+    markerMatches: true,
+    identityMatches: true,
+    contentMatches: false,
+  });
+
+const describe = (activeStillTargetNow, extra = {}) =>
+  describeOpenRebindOutcome(contentUnverified(), {
+    targetLabel: "TARGET_WF",
+    activeLabel: "TARGET_WF",
+    activeStillTargetNow,
+    activeNowLabel: "OTHER_WF",
+    contentComparable: true,
+    contentSurfaces: ["nodes"],
+    contentNodeDifference: null,
+    ...extra,
+  });
+
+test("#887 the verdict is unchanged — this fix touches disclosure only", () => {
+  // Guards the blast radius: the fence still refuses exactly what it refused.
+  assert.equal(contentUnverified().status, OPEN_REBIND_STATUS.CONTENT_UNVERIFIED);
+  assert.equal(contentUnverified().bindingProven, true);
+});
+
+test("#887 REGRESSION: a drifted pointer no longer says the target is active", () => {
+  const text = describe(false);
+  assert.doesNotMatch(text, /You are NOT on the wrong workflow/);
+  assert.doesNotMatch(text, /TARGET_WF IS the active one/);
+  assert.doesNotMatch(text, /You are on the right workflow/);
+});
+
+test("#887 a drifted pointer NAMES what is active and warns before a save", () => {
+  const text = describe(false);
+  assert.match(text, /OTHER_WF is active NOW, not TARGET_WF/);
+  assert.match(text, /NOT the one a save would write/);
+  assert.match(text, /panel_list_workflows/);
+});
+
+test("#887 a re-proven pointer still gets its reassurance — no false alarm", () => {
+  // The other half of failing closed. If drift were assumed whenever it was not
+  // disproven, every healthy open would gain a scary warning, which is the
+  // false-positive this repo has fixed twice (#696, #825).
+  const text = describe(true);
+  assert.match(text, /You are NOT on the wrong workflow: TARGET_WF IS the active one/);
+  assert.doesNotMatch(text, /is active NOW, not/);
+});
+
+test("#887 an unreadable pointer asserts NEITHER direction", () => {
+  const text = describe(null);
+  assert.doesNotMatch(text, /TARGET_WF IS the active one/, "does not reassure");
+  assert.doesNotMatch(text, /OTHER_WF is active NOW/, "does not invent drift");
+  assert.match(text, /could not be re-read/);
+  assert.match(text, /panel_list_workflows/);
+});
+
+test("#887 drift is retracted on the nodes-intact branches too, not just the general one", () => {
+  // CONTENT_UNVERIFIED has three wordings; the reassurance had to be removed from
+  // ALL of them. An earlier cut fixed only the sentence quoted in the report, which
+  // left the two friendlier branches — the ones a healthy-looking open actually
+  // takes — still asserting the stale claim.
+  const nodesIntact = (valuesMatched) =>
+    describeOpenRebindOutcome(contentUnverified(), {
+      targetLabel: "TARGET_WF",
+      activeStillTargetNow: false,
+      activeNowLabel: "OTHER_WF",
+      contentComparable: true,
+      contentSurfaces: ["nodes"],
+      contentNodeDifference: { comparable: true, sameNodeSet: true, cosmeticOnly: valuesMatched },
+    });
+  for (const valuesMatched of [true, false]) {
+    const text = nodesIntact(valuesMatched);
+    assert.doesNotMatch(text, /You are on the right workflow/, `values-matched=${valuesMatched}`);
+    assert.match(text, /OTHER_WF is active NOW, not TARGET_WF/, `values-matched=${valuesMatched}`);
+  }
+});
+
+test("#887 the fence-refresh note survives every drift branch", () => {
+  // #702's recovery instruction is appended after the reassurance slot. Rewriting
+  // that slot must not drop it, or a drifted open loses the one cheap call that
+  // clears the fence.
+  for (const now of [true, false, null]) {
+    assert.match(describe(now), /NO fence refresh/, `re-read=${String(now)}`);
+  }
+});
+
+test("#887 an UNPROVEN open is untouched by this change", () => {
+  const unproven = resolveOpenRebindVerdict({
+    instanceStillTarget: false,
+    markerMatches: true,
+    identityMatches: true,
+    contentMatches: true,
+  });
+  const text = describeOpenRebindOutcome(unproven, {
+    targetLabel: "TARGET_WF",
+    activeStillTargetNow: false,
+    activeNowLabel: "OTHER_WF",
+  });
+  assert.match(text, /could not prove that the active canvas was rebound/);
+  assert.match(text, /could not confirm which workflow is active/);
+});
+
+// ---------------------------------------------------------------------------
+// 3. The WIRING. The helper being right is worth nothing if the call site
+//    hands it the stale observation — which is the bug itself.
+// ---------------------------------------------------------------------------
+
+const panelSrc = readFileSync(
+  fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url)),
+  "utf8",
+);
+
+test("#887 WIRING: the call site RE-READS the pointer instead of reusing activeNow", () => {
+  // The mutation this catches is `activeStillTargetNow: instanceStillTarget` — which
+  // type-checks, reads plausibly, passes every behavioural test above, and restores
+  // the bug exactly. Only the call site can rule it out.
+  assert.match(
+    panelSrc,
+    /const activeAtCompose = activeWorkflowRef\(\);/,
+    "a second, later read of the active pointer",
+  );
+  assert.match(
+    panelSrc,
+    /const activeStillTargetNow = activeAtCompose \? sameWorkflowObject\(activeAtCompose, target\) : null;/,
+    "compared against the target, with an unreadable pointer passed through as null",
+  );
+  // Asserted as a boolean, not `assert.match` on the whole file: a failure there
+  // dumps 1.4MB of source into the report and buries what actually broke.
+  assert.ok(
+    /^\s*activeStillTargetNow,\s*$/m.test(panelSrc),
+    "the re-read is actually handed to the disclosure as `activeStillTargetNow`",
+  );
+  assert.ok(
+    /^\s*activeNowLabel: activeAtCompose$/m.test(panelSrc),
+    "and the label naming what IS active comes from the same re-read",
+  );
+});
+
+test("#887 WIRING: the re-read happens AFTER the load-window observation", () => {
+  // Ordering is the whole fix. A re-read hoisted above the original observation
+  // would be the same instant and prove nothing.
+  const atLoad = panelSrc.indexOf("const instanceStillTarget = sameWorkflowObject(activeNow, target);");
+  const atCompose = panelSrc.indexOf("const activeAtCompose = activeWorkflowRef();");
+  assert.ok(atLoad > 0 && atCompose > 0, "both reads are present");
+  assert.ok(atCompose > atLoad, "the re-read comes later in the flow");
+});

--- a/browser_tests/unit/open-node-difference.test.mjs
+++ b/browser_tests/unit/open-node-difference.test.mjs
@@ -256,6 +256,12 @@ test("a re-measured graph says nothing was lost, and drops the data-loss framing
     contentComparable: true,
     contentSurfaces: ["nodes"],
     contentNodeDifference: { comparable: true, sameNodeSet: true, cosmeticOnly: true, fields: ["size"] },
+    // #887 — the "no missing work to redo" reassurance asserted below is only emitted
+    // while the target is STILL the active workflow at composition time, re-read rather
+    // than inherited from the load window. This test's scenario is a re-measured graph
+    // on the workflow that is still active, so it states that; an absent re-read
+    // withholds the reassurance by design rather than presuming it.
+    activeStillTargetNow: true,
   });
   // #696 (codex) — the claim is narrower than it was, and the assertion follows it.
   // The old wording promised "the only difference is presentation, which the ComfyUI

--- a/browser_tests/unit/open-rebind-proof.test.mjs
+++ b/browser_tests/unit/open-rebind-proof.test.mjs
@@ -124,6 +124,13 @@ test("#604/#603/#616: the reported failure — a faithful repaint the frontend N
     targetLabel: "a.json",
     contentComparable: true,
     contentSurfaces: describeGraphStateDifference({ rootGraph, state: loaded }).surfaces,
+    // #887 — this scenario is a faithful repaint of the workflow that IS still active,
+    // so it now says so explicitly. The reassurance asserted below is re-earned at
+    // composition time from a SECOND read of the active pointer, rather than inherited
+    // from the one taken in the load window; an ABSENT re-read deliberately withholds
+    // it, because the sentence is in the present tense and absent evidence must not
+    // buy one. Passing `true` states the condition this test was always assuming.
+    activeStillTargetNow: true,
   });
   assert.match(text, /canvas IS bound to a\.json/, "the settled half must be stated as settled");
   assert.match(text, /You are NOT on the wrong workflow/, "the old message's worst implication is retracted");

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -11998,10 +11998,23 @@ const GRAPH_TOOL_EXECUTORS = {
                 const contentDiff = contentMatches
                   ? { comparable: true, surfaces: [], nodeDifference: null }
                   : describeGraphStateDifference({ rootGraph, state: repaintState });
+                // #887 — RE-READ the active pointer here rather than reusing `activeNow`.
+                // That one was measured inside the load's synchronous window; this message
+                // claims the target IS active in the present tense, and re-opening an
+                // already-open MODIFIED workflow lets the frontend's tab machinery settle
+                // after the await. A null pointer is deliberately passed as null, not false:
+                // "no active tab" and "could not read it" are the same observation here, and
+                // neither licenses asserting drift the panel did not actually see.
+                const activeAtCompose = activeWorkflowRef();
+                const activeStillTargetNow = activeAtCompose ? sameWorkflowObject(activeAtCompose, target) : null;
                 rebindFailed = new Error(
                   describeOpenRebindOutcome(verdict, {
                     targetLabel: target.filename || target.path || "the requested workflow",
                     activeLabel: activeNow ? activeNow.filename || activeNow.path || "another tab" : "no active tab",
+                    activeStillTargetNow,
+                    activeNowLabel: activeAtCompose
+                      ? activeAtCompose.filename || activeAtCompose.path || "another workflow"
+                      : null,
                     expectedMarker: openProofMarker,
                     observedMarker: rootGraph?.extra?.[WORKFLOW_META_NAMESPACE]?.[OPEN_PROOF_FIELD] ?? null,
                     expectedUuid: targetUuid,

--- a/web/js/lib/graph-binding.js
+++ b/web/js/lib/graph-binding.js
@@ -1127,6 +1127,51 @@ export function resolveOpenRebindVerdict({
 }
 
 /**
+ * #887 — whether workflow_open may still SAY the target is active.
+ *
+ * Every proof in `resolveOpenRebindVerdict` is captured in one synchronous window
+ * immediately after `loadGraphData` resolves. That is the right place to take them:
+ * it is the only moment this attempt's marker is known to be on the root. But
+ * `instanceStillTarget` is the one proof whose subject KEEPS MOVING afterwards — the
+ * active pointer is frontend state, and re-opening an already-open MODIFIED workflow
+ * lets ComfyUI's own tab machinery settle after the await returns.
+ *
+ * The disclosure then states that one observation in the PRESENT tense ("X IS the
+ * active one"). A past observation asserted as a standing fact is exactly what #887
+ * reports: true when measured, false when read — and the caller's next act is a
+ * Save-As onto whatever is actually active.
+ *
+ * So the reassurance is re-earned at composition time rather than inherited:
+ *
+ *   held       — re-read, still the target. The claim is current; say it.
+ *   drifted    — re-read, something ELSE is active now. The open did not stick, and
+ *                this is the case that makes Save-As unsafe. Say so plainly.
+ *   unreadable — could not re-read. NOT evidence of drift, and not licence to
+ *                reassure either: an unproven present-tense claim degrades to
+ *                unknown, never to the negative and never to the positive.
+ *   not-proven — the instance was never proven at load time; the existing "could not
+ *                confirm which workflow is active" wording already covers that and is
+ *                not weakened here.
+ *
+ * Kept as a pure exported decision because the wording branches on it: asserting on
+ * the message TEXT cannot tell this logic from its own inversion, which is how two
+ * earlier fences shipped with tests that survived the mutation.
+ */
+export const OPEN_ACTIVE_DRIFT = Object.freeze({
+  HELD: "held",
+  DRIFTED: "drifted",
+  UNREADABLE: "unreadable",
+  NOT_PROVEN: "not-proven",
+});
+
+export function openActiveDriftVerdict({ instanceProvenAtLoad, activeStillTargetNow } = {}) {
+  if (instanceProvenAtLoad !== true) return OPEN_ACTIVE_DRIFT.NOT_PROVEN;
+  if (activeStillTargetNow === true) return OPEN_ACTIVE_DRIFT.HELD;
+  if (activeStillTargetNow === false) return OPEN_ACTIVE_DRIFT.DRIFTED;
+  return OPEN_ACTIVE_DRIFT.UNREADABLE;
+}
+
+/**
  * What a CONTENT_UNVERIFIED open must ALSO say (#702).
  *
  * That branch has already PROVEN the binding — instance, marker and identity all match —
@@ -1276,6 +1321,32 @@ export function describeOpenRebindOutcome(verdict, observed = {}) {
   // unreadable pointer produces just as a real switch does, so that direction can only
   // say the panel could not confirm which workflow is active.
   const activeIsTarget = !(verdict?.unproven ?? []).includes("instance");
+  // #887 — the instance proof was taken in the load's synchronous window; the pointer
+  // can move afterwards. Re-earn the present-tense reassurance instead of inheriting it.
+  const drift = openActiveDriftVerdict({
+    instanceProvenAtLoad: activeIsTarget,
+    activeStillTargetNow: observed.activeStillTargetNow,
+  });
+  const activeNowLabel = observed.activeNowLabel || "another workflow";
+  // `reassurance` is the sentence each branch WOULD have ended with. It survives only
+  // while the claim is still true; drift replaces it with the warning the caller needs
+  // BEFORE a Save-As, and an unreadable re-read replaces it with neither.
+  const stillActive = (reassurance) => {
+    if (drift === OPEN_ACTIVE_DRIFT.DRIFTED) {
+      return (
+        ` ${activeNowLabel} is active NOW, not ${workflow} — the active workflow moved after the ` +
+        `open completed, so this canvas is NOT the one a save would write. Do NOT save or edit ` +
+        `expecting ${workflow}: re-open it and confirm with panel_list_workflows first.`
+      );
+    }
+    if (drift === OPEN_ACTIVE_DRIFT.UNREADABLE) {
+      return (
+        ` Which workflow is active NOW could not be re-read, so this reply cannot say that ` +
+        `${workflow} still is — confirm with panel_list_workflows before saving or editing.`
+      );
+    }
+    return reassurance;
+  };
   if (verdict?.status === OPEN_REBIND_STATUS.CONTENT_UNVERIFIED) {
     // The precise answer, and precisely as far as it goes: the canvas IS this
     // workflow's, and what is unknown is narrower than "which workflow is this".
@@ -1343,17 +1414,22 @@ export function describeOpenRebindOutcome(verdict, observed = {}) {
         return (
           `${head}, carrying the same widget values and links. What differs is per-node ` +
           `presentation only, which the panel cannot call byte-identical, so the content ` +
-          `is reported UNCONFIRMED rather than failed.${because} You are on the right workflow ` +
-          `and there is no missing work to redo; if you need the exact graph, read it with ` +
-          `panel_graph_outline.` + FENCE_NOT_REFRESHED
+          `is reported UNCONFIRMED rather than failed.${because}` +
+          stillActive(
+            ` You are on the right workflow and there is no missing work to redo; if you need ` +
+              `the exact graph, read it with panel_graph_outline.`,
+          ) + FENCE_NOT_REFRESHED
         );
       }
       return (
         `${head}, and nothing extra appeared — no node was lost. What differs is ` +
         `per-node fields; the panel cannot tell from here whether the ComfyUI frontend ` +
         `normalized those or the load applied them differently, so the content is reported ` +
-        `UNCONFIRMED rather than failed.${because} You are on the right workflow; if you need ` +
-        `the exact graph, read it with panel_graph_outline.` + FENCE_NOT_REFRESHED
+        `UNCONFIRMED rather than failed.${because}` +
+        stillActive(
+          ` You are on the right workflow; if you need the exact graph, read it with ` +
+            `panel_graph_outline.`,
+        ) + FENCE_NOT_REFRESHED
       );
     }
     return (
@@ -1364,8 +1440,9 @@ export function describeOpenRebindOutcome(verdict, observed = {}) {
           `partly applied. `
         : `the panel could not READ the graph on it to compare against the state that was loaded, so ` +
           `whether the whole graph landed is unestablished — NOT established as wrong. `) +
-      `Treat the canvas as UNKNOWN and re-read it (panel_graph_outline) before editing.${because} ` +
-      `You are NOT on the wrong workflow: ${workflow} IS the active one.` + FENCE_NOT_REFRESHED
+      `Treat the canvas as UNKNOWN and re-read it (panel_graph_outline) before editing.${because}` +
+      stillActive(` You are NOT on the wrong workflow: ${workflow} IS the active one.`) +
+      FENCE_NOT_REFRESHED
     );
   }
   if (verdict?.status === OPEN_REBIND_STATUS.UNPROVEN) {


### PR DESCRIPTION
Closes #887.

`panel_open_workflow` reported *"the canvas IS bound to X … You are NOT on the wrong workflow: X IS the active one"*, and `panel_list_workflows` called immediately afterwards reported a different workflow active. The sharp end, as the reporter puts it: a Save-As on that state writes the wrong canvas.

## The verdict was not wrong — the TENSE was

`resolveOpenRebindVerdict` requires instance AND marker AND identity, each compared against `true`, so nothing there admits a wrong canvas. I checked that first and it is sound.

The four proofs are captured in one synchronous window right after `await app.loadGraphData(...)` — which is the correct place to take them, because it is the only moment this attempt's single-use marker is known to be on the root. But they are not the same KIND of observation:

- `markerMatches`, `identityMatches`, `contentMatches` describe the **root graph**, which nothing else touches between the observation and the message.
- `instanceStillTarget` describes the **active pointer**, which is frontend state that keeps moving. Re-opening an already-open **modified** workflow — the reporter's exact case — lets ComfyUI's own tab machinery settle after the await returns.

The disclosure then asserted that one past observation in the present tense. True when measured, false when read.

## The fix

`openActiveDriftVerdict()` — a pure exported decision, four outcomes:

| | meaning |
|---|---|
| `held` | re-read, still the target — the claim is current, say it |
| `drifted` | re-read, something else is active — name it and warn before a save |
| `unreadable` | could not re-read — assert **neither** direction |
| `not-proven` | instance never proven at load time; existing wording already covers it |

The call site re-reads the pointer at message-composition time rather than reusing the load-window value, and the reassurance is rewritten in **all three** `CONTENT_UNVERIFIED` branches (the report quotes one; the two friendlier branches are the ones a healthy-looking open actually takes).

Fails closed in both directions: drift is claimed only when observed, reassurance given only when re-proven. An absent or unreadable re-read buys neither — unproven degrades to unknown, never to the negative. That is why the two existing tests that model a healthy open now state the condition they were always assuming, rather than relying on a permissive default.

## Verification

Behavioural, through the real functions — an assertion on message text cannot tell this logic from its own inversion, which is how two earlier fences in this repo shipped with tests that survived the mutation.

Five mutations, **each confirmed applied before its result was trusted** (two initially reported "survived" because CRLF line endings defeated the patch — the applied-check is what caught it, not the test result):

| mutation | |
|---|---|
| reuse the stale observation (`activeStillTargetNow: instanceStillTarget`) | killed |
| fold `unreadable` into reassurance | killed |
| fold `drifted` into reassurance (the #887 behaviour itself) | killed |
| restore the reassurance on one branch only | killed |
| hoist the re-read back into the load window | killed |

3326/3326 unit tests, `typecheck` clean, tool-vocabulary gate clean, no control bytes in changed files.

## What I could NOT verify, stated plainly

**I did not reproduce the race live.** I tried to drive a workflow switch in a headless harness and could not: `wf.openWorkflow(obj)` moves the store pointer without rebuilding the canvas, `createTemporary` does not open a tab, and the node count never left the default template's. So the diagnosis above is from reading the code, not from watching the pointer move.

That does not make the change speculative — the message asserts a **single past observation in the present tense with no re-check**, which is a defect visible in the source regardless of which mechanism moves the pointer, and the fix is a strict honesty improvement that fails closed. But if the true mechanism turns out to be different (for instance `loadGraphData` painting onto the current canvas without ever switching tabs), then this fix is still correct and the *narrative* above is wrong, and I would rather say that up front than have it discovered later.