### PR TITLE
0.11.66 — updating a node pack stops dead-ending on some Manager builds (#367)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,32 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+## [0.11.66] - 2026-08-09
+
+> Covers changes since 0.11.65.
+
+### Fixed
+
+- **Updating a node pack no longer dead-ends on some Manager builds (#367).** On certain
+  built-in Manager v4 installs, asking the agent to update a pack failed instantly with
+  `HTTP 405` — the Manager refuses that particular request on that build, even though
+  listing and installing work fine.
+
+  The panel already knows how to talk to those builds; it has a second route for exactly
+  this case. It just never tried it. There *was* a fallback, but it dropped to the old
+  3.x-style routes, which a modern Manager doesn't serve either — so the retry failed
+  too, and update was unusable while a perfectly good route sat unused.
+
+  Now it tries that route before giving up, and remembers which one worked so later
+  updates go straight there. On a build where the original request is fine, nothing
+  changes — verified against a live Manager here, which accepts it and doesn't serve the
+  alternative at all.
+
+  One honest caveat: on the builds this unblocks, the Manager reports no per-task
+  result, so the update is reported as *queued* rather than confirmed. Check
+  `panel_node_queue_status` and restart ComfyUI to load the updated pack. That is the
+  best answer that Manager can give — the bug was getting no answer at all.
+
 ## [0.11.65] - 2026-08-09
 
 > Covers changes since 0.11.64.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-agent-panel"
 description = "Autonomous AI agent in the ComfyUI sidebar - local-first, bring any LLM. Run it on your Claude or ChatGPT subscription (no API keys, no extra LLM costs), on a Kimi K3 / GLM / OpenRouter key, or fully offline on free local models via Ollama, LM Studio, or llama.cpp. The agent drives your live canvas at full parity: add, wire, move and tweak nodes with Ctrl+Z undo, load whole workflows and installer packs in one shot, generate images, video and audio, browse CivitAI, and run your workflow - asking before it spends paid API credits. The sidebar UI for comfyui-mcp, the local-first, agent-native control plane for ComfyUI."
-version = "0.11.65"
+version = "0.11.66"
 license = { file = "LICENSE" }
 requires-python = ">=3.9"
 # UI-only pack: no Python deps. The frontend floor guarantees

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -878,7 +878,7 @@ const DOCS_URL = "https://comfyui-mcp.artokun.io/docs";
 // Panel version — surfaced in the "Need help?" diagnostics blob. Bump via
 // `node scripts/set-version.mjs <v>` (updates this AND pyproject together); CI
 // and the publish gate FAIL if the two ever drift, so this can't go stale.
-const PANEL_VERSION = "0.11.65";
+const PANEL_VERSION = "0.11.66";
 
 // The connected orchestrator's console URL/token (captured off the `backends`
 // bridge message — see onBackends). Drives the "API Keys" credentials frame;


### PR DESCRIPTION
Releases #895 (fixes #367).

`panel_update_node` POSTed `/v2/manager/queue/task` and got HTTP 405 from a built-in
Manager v4 whose `/v2` GETs all answer. The existing 405 fallback dropped to the
un-prefixed 3.x routes, which a pip v4 does not serve either, so update was unusable
with a working batch route sitting unused.

The ladder is now `v2 → v2-batch → legacy`. A 405 on `queue/task` is treated as a
candidate rather than proof — a generic catchall can refuse batch too — so it costs one
POST, keeps the legacy rung behind it, and caches nothing until an enqueue actually
lands.

Verified inert on a normal v4: probed live here, `queue/task` answers 400 (accepts the
method) and `queue/batch` 405s, so the new rung is never taken on that build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)