### PR TITLE
test(bridge): pin that the tab re-registers after the bridge dies (#654)

### DIFF
--- a/browser_tests/bridge-reregisters-after-restart.spec.ts
+++ b/browser_tests/bridge-reregisters-after-restart.spec.ts
@@ -2,7 +2,8 @@
  * #654 — after the orchestrator dies and comes back, the tab must re-register itself.
  *
  * The report: `panel_restart_comfyui` confirms `server_ready:true`, and the panel tab
- * never becomes usable again — `panel_tab_reconnected:false`, `graph_tools_ready:false`,
+ * never becomes usable again — the restart reply's tab-reconnected and
+ * graph-tools-ready flags both stay false,
  * `panel_set_workflow_target({mode:"current"})` deferred with no connected tab. Only a
  * manual browser refresh recovers it.
  *

--- a/browser_tests/bridge-reregisters-after-restart.spec.ts
+++ b/browser_tests/bridge-reregisters-after-restart.spec.ts
@@ -20,6 +20,13 @@
  * Driven on a SAVED workflow deliberately: its route is `wf:<tabRouteId>:<path>`, not a
  * per-object `tmp:<uuid>`, so this also pins that the composed route survives the round
  * trip — an unsaved tab would pass on a simpler code path and prove less.
+ *
+ * BOUNDARY: the fixture shuts its sockets down CLEANLY. A killed child process would
+ * terminate them abruptly, so this is a different close shape, not a milder one — it
+ * covers reconnect and re-registration across a bridge replacement and a dead-port
+ * interval, but would miss a regression that branched on the close code or `wasClean`.
+ * Engineering an abrupt kill is only worth it if the reconnect path starts telling those
+ * apart, or if #654 evidence points there (codex).
  */
 import { test, expect } from './fixtures/panelTest'
 import { MockBridge } from './fixtures/MockBridge'

--- a/browser_tests/bridge-reregisters-after-restart.spec.ts
+++ b/browser_tests/bridge-reregisters-after-restart.spec.ts
@@ -84,6 +84,16 @@ test('the tab re-registers after the bridge dies and respawns', async ({
         /^wf:[^:]+:workflows\//
       )
       expect(route, 'and it must name the workflow that is actually open').toContain(savedName)
+
+      // The hello is only the ANNOUNCEMENT. #654's symptom is that graph tools stay
+      // unusable afterwards, so drive one through the revived bridge: that proves the
+      // new bridge accepted the registration and can route on it (codex).
+      const outline = await revived.command('graph_outline', {})
+      expect(
+        outline.ok,
+        'a graph command must route through the revived bridge — announcing the ' +
+          'registration is not the same as being usable again'
+      ).toBe(true)
     } finally {
       await revived.close()
     }

--- a/browser_tests/bridge-reregisters-after-restart.spec.ts
+++ b/browser_tests/bridge-reregisters-after-restart.spec.ts
@@ -1,0 +1,93 @@
+/**
+ * #654 — after the orchestrator dies and comes back, the tab must re-register itself.
+ *
+ * The report: `panel_restart_comfyui` confirms `server_ready:true`, and the panel tab
+ * never becomes usable again — `panel_tab_reconnected:false`, `graph_tools_ready:false`,
+ * `panel_set_workflow_target({mode:"current"})` deferred with no connected tab. Only a
+ * manual browser refresh recovers it.
+ *
+ * Prior analysis ruled out retry ARMING from source (`closed` latches only in `stop()`
+ * and `destroy()`, neither on a restart path) and handed over the decisive measurement:
+ * after `onopen` on a post-restart socket, is the hello sent, and does it carry the
+ * right route? Nothing exercised that, because the fixture could only `close()` the
+ * whole server — which leaves the panel's re-dial nothing to reach.
+ *
+ * The orchestrator is ComfyUI's child, so a ComfyUI restart kills it and the port is
+ * dead until a fresh one spawns. That is what this reproduces: the bridge dies, the
+ * panel retries against a dead port, a new bridge appears on the SAME port, and the
+ * panel must re-hello itself back into service without a page reload.
+ *
+ * Driven on a SAVED workflow deliberately: its route is `wf:<tabRouteId>:<path>`, not a
+ * per-object `tmp:<uuid>`, so this also pins that the composed route survives the round
+ * trip — an unsaved tab would pass on a simpler code path and prove less.
+ */
+import { test, expect } from './fixtures/panelTest'
+import { MockBridge } from './fixtures/MockBridge'
+
+test.setTimeout(180_000)
+
+test('the tab re-registers after the bridge dies and respawns', async ({
+  page,
+  panel,
+  mockBridge
+}) => {
+  await panel.goto()
+  await panel.setBridgeUrl(mockBridge.url)
+  await panel.openSidebar()
+  await panel.connect()
+
+  const saved = await mockBridge.command('workflow_save', {})
+  expect(saved.ok, 'the workflow must save so the route is the composed wf: form').toBe(true)
+  const savedName = String(saved.result?.workflow || '')
+  expect(savedName).toBeTruthy()
+  // This spec persists a file on the real ComfyUI — remove it however the test ends.
+  const cleanup = async () => {
+    await page.evaluate(async (p) => {
+      const api = (window as any).comfyAPI?.api?.api
+      await api?.fetchApi?.(`/userdata/${encodeURIComponent(p)}`, { method: 'DELETE' })
+    }, `workflows/${savedName}.json`)
+  }
+
+  try {
+    const port = mockBridge.port
+    await expect(panel.statusPill).toHaveText(/connected/i, { timeout: 20_000 })
+
+    // The orchestrator dies with ComfyUI; its port is dead until a fresh one spawns.
+    await mockBridge.close()
+    await expect(panel.statusPill).not.toHaveText(/^connected$/i, { timeout: 30_000 })
+
+    // …and a new one comes up on the same port.
+    const revived = new MockBridge({ port })
+    const hellos: any[] = []
+    revived.onFrame((f) => {
+      if (f.type === 'hello') hellos.push(f)
+    })
+    await revived.start()
+
+    try {
+      // THE INVARIANT: the panel re-registers itself, with no page reload. Before this
+      // was measured, nothing proved the hello was ever re-sent.
+      await expect
+        .poll(() => hellos.length, {
+          timeout: 60_000,
+          message: 'the panel must re-hello the revived bridge without a page reload'
+        })
+        .toBeGreaterThan(0)
+      await expect(panel.statusPill).toHaveText(/connected/i, { timeout: 30_000 })
+
+      // And it must re-register for the SAVED workflow, on the composed route. A
+      // re-hello carrying the bare file path would be the #693 collision; one carrying
+      // a stale `tmp:` id would leave graph tools pointed at a route the orchestrator
+      // no longer maps.
+      const route = String(hellos[hellos.length - 1]?.tab_id ?? '')
+      expect(route, 'the re-hello must carry the composed saved route').toMatch(
+        /^wf:[^:]+:workflows\//
+      )
+      expect(route, 'and it must name the workflow that is actually open').toContain(savedName)
+    } finally {
+      await revived.close()
+    }
+  } finally {
+    await cleanup()
+  }
+})

--- a/browser_tests/fixtures/MockBridge.ts
+++ b/browser_tests/fixtures/MockBridge.ts
@@ -406,27 +406,6 @@ export class MockBridge {
     const uuid = await this.activeWorkflowUuid()
     return this.sendCommand(cmd, uuid ? { ...args, workflow_uuid: uuid } : args, timeoutMs)
   }
-  /**
-   * Drop every client socket but KEEP LISTENING — what a ComfyUI/orchestrator restart
-   * looks like from the panel's side (#654). `close()` stops the server too, so the
-   * panel's re-dial has nothing to reach and cannot show whether re-registration works.
-   *
-   * Returns how many sockets were dropped, so a spec can assert it actually severed a
-   * live connection rather than passing because there was none.
-   */
-  dropConnections(code = 1006): number {
-    const live = [...this.sockets]
-    for (const s of live) {
-      try {
-        s.terminate?.() ?? s.close(code)
-      } catch {
-        // a socket already gone is already dropped
-      }
-    }
-    this.sockets.clear()
-    return live.length
-  }
-
   /** Close all sockets and the server. */
   async close(): Promise<void> {
     for (const s of this.sockets) {

--- a/browser_tests/fixtures/MockBridge.ts
+++ b/browser_tests/fixtures/MockBridge.ts
@@ -406,6 +406,27 @@ export class MockBridge {
     const uuid = await this.activeWorkflowUuid()
     return this.sendCommand(cmd, uuid ? { ...args, workflow_uuid: uuid } : args, timeoutMs)
   }
+  /**
+   * Drop every client socket but KEEP LISTENING — what a ComfyUI/orchestrator restart
+   * looks like from the panel's side (#654). `close()` stops the server too, so the
+   * panel's re-dial has nothing to reach and cannot show whether re-registration works.
+   *
+   * Returns how many sockets were dropped, so a spec can assert it actually severed a
+   * live connection rather than passing because there was none.
+   */
+  dropConnections(code = 1006): number {
+    const live = [...this.sockets]
+    for (const s of live) {
+      try {
+        s.terminate?.() ?? s.close(code)
+      } catch {
+        // a socket already gone is already dropped
+      }
+    }
+    this.sockets.clear()
+    return live.length
+  }
+
   /** Close all sockets and the server. */
   async close(): Promise<void> {
     for (const s of this.sockets) {


### PR DESCRIPTION
Takes the measurement #654's handover asked for. **Not a fix** — the issue stays open.

The prior analysis ruled out retry *arming* from source and handed over: after `onopen` on
a post-restart socket, is the hello re-sent and does it carry the right route? That could
not be measured, because the fixture could only `close()` the whole server, leaving the
panel's re-dial nothing to reach.

The orchestrator is ComfyUI's child, so a restart kills it and the port is dead until a
fresh one spawns. The spec reproduces that: bridge dies, panel retries a dead port, a new
bridge appears on the **same** port, and the panel must re-register without a page reload.

Measured on current code — three shapes, all recover:

| shape | result |
|---|---|
| bare socket drop | re-hello, same tab id, connected |
| orchestrator dies + respawns | retries dead port, re-hellos on revival, connected |
| same, on a **saved** workflow | re-hellos with the composed `wf:<tabRouteId>:<path>` route |

So the panel side does not reproduce here. The reporter was on panel 0.11.39 (27 releases
back), and the untested half is the orchestrator's — whether it accepts the re-hello and
flips `panel_tab_reconnected` — which needs a live restart cycle.

**What ships is coverage.** Nothing exercised re-registration before, so a regression in
it would have been invisible. Per codex the spec now also drives a real `graph_outline`
through the revived bridge, proving the registration is *usable* rather than merely
announced. Verified to fail when the revived bridge never starts.

Test-only — nothing ships (`browser_tests/` is excluded from the published pack).

🤖 Generated with [Claude Code](https://claude.com/claude-code)