### PR TITLE
fix(add-node): SaveVideo refused on a canvas that already holds one (#636)

### DIFF
--- a/browser_tests/unit/node-widget-materialization.test.mjs
+++ b/browser_tests/unit/node-widget-materialization.test.mjs
@@ -12,6 +12,7 @@ import {
   unavailableRequiredCustomWidgetTypes,
   unavailableRequiredWidgetMessage,
   unavailableRequiredWidgetReport,
+  unavailableEntriesLiveNodeCannotExplain,
 } from "../../web/js/lib/node-widget-materialization.js";
 
 const PANEL_JS = fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url));
@@ -791,8 +792,21 @@ test("#695: graph_add_node consumes the report and message, and names the class"
   );
   assert.match(
     src,
-    /await awaitRequiredCustomWidgetRegistration\(\s*nodeData,\s*comfyApp,\s*knownSocketTypes,\s*currentDef,\s*class_type,\s*widenSocketProof,\s*\)/,
+    /await awaitRequiredCustomWidgetRegistration\(\s*nodeData,\s*comfyApp,\s*knownSocketTypes,\s*currentDef,\s*class_type,\s*widenSocketProof,/,
     "the class_type reaches the message, and #821's widen reaches the guard",
+  );
+  // #636 — the live-canvas evidence must reach it too, or the refusal it exists to
+  // convert stays permanent on a backend that never outputs the datatype.
+  assert.match(src, /unavailableEntriesLiveNodeCannotExplain,/, "imported");
+  assert.match(
+    src,
+    /unavailableEntriesLiveNodeCannotExplain\(unavailable, live\)/,
+    "the guard consults the live node before refusing",
+  );
+  assert.match(
+    src,
+    /nodes\.find\(\(n\) => n\?\.type === cls\)/,
+    "and the caller supplies a resolver that finds a node of the SAME class",
   );
 });
 
@@ -973,4 +987,98 @@ test("#686 a registered constructor still wins — the waiver never shadows a re
     unavailableRequiredCustomWidgetTypes(def, { ...REGISTERED, [AUTOGROW]: () => {} }, undefined, def),
     [],
   );
+});
+
+// ── #636: the canvas as evidence of last resort ────────────────────────────
+//
+// `SaveVideo` was refused with 'Required custom widget "VIDEO" have not registered' on a
+// canvas that already held a WORKING SaveVideo. Reproduced exactly, at this level: with
+// nothing in the backend outputting VIDEO, `video: ["VIDEO"]` is socket-shaped but not
+// link-proven, so it fails closed — and no retry can clear it, because every input to
+// that decision is a snapshot.
+//
+// (The OTHER half of that node, `codec: COMFY_DYNAMICCOMBO_V3`, was already waived by
+// #686. Verified against a live ComfyUI: SaveVideo adds fine where something outputs
+// VIDEO, which is why this only reproduces on the reporter's shape.)
+
+const SAVE_VIDEO_DEF = {
+  input: {
+    required: {
+      video: ["VIDEO"],
+      filename_prefix: ["STRING", { default: "video/ComfyUI" }],
+      format: ["COMBO", { options: ["auto"] }],
+      codec: ["COMFY_DYNAMICCOMBO_V3", { options: [] }],
+    },
+  },
+};
+const BASIC_WIDGETS = { STRING: () => {}, COMBO: () => {} };
+
+test("#636: VIDEO fails closed only where nothing outputs it", () => {
+  const report = (known) =>
+    unavailableRequiredWidgetReport(null, BASIC_WIDGETS, known, SAVE_VIDEO_DEF);
+  assert.deepEqual(report(new Set(["VIDEO"])), [], "output-proven ⇒ addable (a normal install)");
+  const refused = report(new Set());
+  assert.equal(refused.length, 1, "the reporter's backend refuses");
+  assert.equal(refused[0].type, "VIDEO");
+  assert.deepEqual(refused[0].inputs, ["video"]);
+});
+
+test("#636: a live node of the class explains an input that materialised as a SLOT", () => {
+  const refused = unavailableRequiredWidgetReport(null, BASIC_WIDGETS, new Set(), SAVE_VIDEO_DEF);
+  // What ComfyUI actually built here: `video` came out as a link slot, so it is a socket
+  // and there is no constructor to wait for — observed, not inferred.
+  const live = { type: "SaveVideo", inputs: [{ name: "video" }], widgets: [{ name: "filename_prefix" }] };
+  assert.deepEqual(unavailableEntriesLiveNodeCannotExplain(refused, live), []);
+});
+
+test("#636: a widget on the live node explains it too", () => {
+  const refused = unavailableRequiredWidgetReport(null, BASIC_WIDGETS, new Set(), SAVE_VIDEO_DEF);
+  const live = { type: "SaveVideo", inputs: [], widgets: [{ name: "video" }] };
+  assert.deepEqual(unavailableEntriesLiveNodeCannotExplain(refused, live), []);
+});
+
+test("#636: it ADDS evidence — it never lowers the bar", () => {
+  const refused = unavailableRequiredWidgetReport(null, BASIC_WIDGETS, new Set(), SAVE_VIDEO_DEF);
+  // No live node at all: unchanged, still refused. This is the #580 case.
+  assert.deepEqual(unavailableEntriesLiveNodeCannotExplain(refused, null), refused);
+  // A live node that does NOT account for the input explains nothing.
+  const unrelated = { type: "SaveVideo", inputs: [{ name: "audio" }], widgets: [{ name: "format" }] };
+  assert.deepEqual(unavailableEntriesLiveNodeCannotExplain(refused, unrelated), refused);
+  // An unreadable node explains nothing.
+  assert.deepEqual(
+    unavailableEntriesLiveNodeCannotExplain(refused, { get widgets() { throw new Error("boom"); } }),
+    refused,
+  );
+});
+
+test("#636: an entry naming NO inputs can never be explained away", () => {
+  // Nothing to check the live node against, so there is nothing it could have observed.
+  // Treating that as explained would waive a type on the mere PRESENCE of a same-class
+  // node, which is the accept-all-unknown shape #580 exists to prevent.
+  const live = { type: "X", inputs: [{ name: "video" }], widgets: [{ name: "video" }] };
+  for (const entry of [{ type: "VIDEO" }, { type: "VIDEO", inputs: [] }, { type: "VIDEO", inputs: null }]) {
+    assert.deepEqual(
+      unavailableEntriesLiveNodeCannotExplain([entry], live),
+      [entry],
+      JSON.stringify(entry),
+    );
+  }
+});
+
+test("#636: EVERY input carrying the type must be accounted for, not just one", () => {
+  // A def can require the same datatype twice. Explaining one occurrence says nothing
+  // about the other — the same rule the socket/widget split is built on.
+  const twice = {
+    input: { required: { video: ["VIDEO"], video_b: ["VIDEO"] } },
+  };
+  const refused = unavailableRequiredWidgetReport(null, BASIC_WIDGETS, new Set(), twice);
+  assert.deepEqual(refused[0].inputs, ["video", "video_b"]);
+  const half = { type: "X", inputs: [{ name: "video" }], widgets: [] };
+  assert.deepEqual(
+    unavailableEntriesLiveNodeCannotExplain(refused, half),
+    refused,
+    "half an explanation is not an explanation",
+  );
+  const both = { type: "X", inputs: [{ name: "video" }, { name: "video_b" }], widgets: [] };
+  assert.deepEqual(unavailableEntriesLiveNodeCannotExplain(refused, both), []);
 });

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -249,6 +249,7 @@ import {
   registeredSocketTypes,
   unavailableRequiredWidgetMessage,
   unavailableRequiredWidgetReport,
+  unavailableEntriesLiveNodeCannotExplain,
 } from "./lib/node-widget-materialization.js";
 import {
   describeUnmaterializedRequiredWidgets,
@@ -7595,6 +7596,7 @@ async function awaitRequiredCustomWidgetRegistration(
   currentDef,
   classType,
   widenSocketProof,
+  liveNodeOfClass,
 ) {
   const startedAt = Date.now();
   const deadline = startedAt + CUSTOM_WIDGET_REGISTRATION_TIMEOUT_MS;
@@ -7627,6 +7629,29 @@ async function awaitRequiredCustomWidgetRegistration(
     unavailable = check();
   }
   if (!unavailable.length) return;
+  // #636 — LAST, and only once the wait has already failed: ask what this ComfyUI
+  // actually DID. Everything above reasons about what SHOULD happen, and on a backend
+  // where nothing outputs the datatype a socket-shaped input has no proof and fails
+  // closed forever — no retry can change it, because every input to that decision is a
+  // snapshot. The reporter had a WORKING node of this very class on the canvas while
+  // being told the class could not be built.
+  //
+  // Placed after the poll on purpose: a genuinely still-loading widget must get its full
+  // 5 s first, so this can only ever convert a permanent refusal into a success, never
+  // shorten a legitimate wait.
+  if (typeof liveNodeOfClass === "function") {
+    let live = null;
+    try {
+      live = liveNodeOfClass(classType);
+    } catch {
+      live = null; // an unreadable canvas explains nothing; fall through and refuse
+    }
+    if (live) {
+      const stillUnexplained = unavailableEntriesLiveNodeCannotExplain(unavailable, live);
+      if (!stillUnexplained.length) return;
+      unavailable = stillUnexplained;
+    }
+  }
   // #695: the poll is the ONLY thing here a retry can change (nodeData, currentDef and
   // knownSocketTypes are all snapshots), so a type that is structurally a socket must be
   // waived by the check rather than waited out — and whatever is left after the wait gets
@@ -9095,6 +9120,19 @@ const GRAPH_TOOL_EXECUTORS = {
       currentDef,
       class_type,
       widenSocketProof,
+      // #636 — the canvas as evidence of last resort. A node of this class that ComfyUI
+      // ALREADY built here shows how each input actually materialised, which no amount of
+      // schema reasoning can establish on a backend that never outputs the datatype.
+      // Read lazily: only the refusal path calls it, so a healthy add pays nothing.
+      (cls) => {
+        try {
+          const graph = getGraphCtx()?.graph ?? app?.graph ?? null;
+          const nodes = graph?._nodes ?? graph?.nodes ?? [];
+          return nodes.find((n) => n?.type === cls) ?? null;
+        } catch {
+          return null;
+        }
+      },
     );
     const node = LG.createNode(class_type);
     if (!node) {

--- a/web/js/lib/node-widget-materialization.js
+++ b/web/js/lib/node-widget-materialization.js
@@ -553,3 +553,54 @@ export function missingRequiredWidgetMaterializations(node, widgetConstructors, 
   }
   return missing;
 }
+
+/**
+ * Which unavailable entries a node of the SAME CLASS, already live on the canvas,
+ * does NOT explain (#636).
+ *
+ * The type reasoning above asks what SHOULD happen: does some node output this
+ * datatype, does this input declare itself socket-shaped. On a backend where nothing
+ * outputs the type, a socket-shaped input has no proof and fails closed forever — no
+ * retry can change it, because every input to the decision is a snapshot. That is the
+ * reported case: `SaveVideo` refused for `VIDEO` on an install whose node set never
+ * outputs one.
+ *
+ * A live node of that class answers a different and better question: what DID happen.
+ * ComfyUI already built this class on THIS backend, so how it materialised each input
+ * is observed fact rather than inference — an input that came out as a link SLOT is a
+ * socket, and one that came out as a WIDGET has its constructor. Either way there is
+ * nothing left for the guard to wait for.
+ *
+ * This is deliberately NOT a relaxation of the type rules. It adds evidence rather than
+ * lowering a bar: an input the live node does not account for stays unavailable, so
+ * #580's protection is untouched for every case this cannot observe.
+ *
+ * Requires EVERY input carrying the type to be accounted for. A def can require the same
+ * datatype twice, and explaining one occurrence says nothing about the other — the same
+ * "every, not some" rule the socket/widget split above is built on.
+ */
+export function unavailableEntriesLiveNodeCannotExplain(report, liveNode) {
+  if (!Array.isArray(report) || !report.length) return [];
+  if (!liveNode || typeof liveNode !== "object") return report;
+  let widgetNames;
+  let slotNames;
+  try {
+    widgetNames = new Set(
+      (Array.isArray(liveNode.widgets) ? liveNode.widgets : [])
+        .map((w) => (w && typeof w.name === "string" ? w.name : null))
+        .filter(Boolean),
+    );
+    slotNames = new Set(
+      (Array.isArray(liveNode.inputs) ? liveNode.inputs : [])
+        .map((i) => (i && typeof i.name === "string" ? i.name : null))
+        .filter(Boolean),
+    );
+  } catch {
+    return report; // an unreadable node explains nothing
+  }
+  return report.filter((entry) => {
+    const inputs = Array.isArray(entry?.inputs) ? entry.inputs : [];
+    if (!inputs.length) return true; // nothing to check against ⇒ unexplained
+    return !inputs.every((name) => widgetNames.has(name) || slotNames.has(name));
+  });
+}

--- a/web/js/lib/node-widget-materialization.js
+++ b/web/js/lib/node-widget-materialization.js
@@ -565,14 +565,20 @@ export function missingRequiredWidgetMaterializations(node, widgetConstructors, 
  * reported case: `SaveVideo` refused for `VIDEO` on an install whose node set never
  * outputs one.
  *
- * A live node of that class answers a different and better question: what DID happen.
- * ComfyUI already built this class on THIS backend, so how it materialised each input
- * is observed fact rather than inference — an input that came out as a link SLOT is a
- * socket, and one that came out as a WIDGET has its constructor. Either way there is
- * nothing left for the guard to wait for.
+ * A live node of that class answers a different question: what DID happen. ComfyUI
+ * already built this class on THIS backend — an input that came out as a link SLOT is a
+ * socket, one that came out as a WIDGET had its constructor.
  *
- * This is deliberately NOT a relaxation of the type rules. It adds evidence rather than
- * lowering a bar: an input the live node does not account for stays unavailable, so
+ * It is a WITNESS, not a proof (codex). A widget can survive from an earlier
+ * registration, or have been converted to a slot, so it does not guarantee a fresh node
+ * materialises identically — and the argument must NOT rest on "extensions never
+ * unregister". What makes admitting it safe is that it only permits an ATTEMPT: the
+ * newly created node still goes through missingRequiredWidgetMaterializations before any
+ * success is reported, and that post-creation check is the real soundness boundary. The
+ * worst case here is a creation attempt that then fails closed.
+ *
+ * So this is deliberately NOT a relaxation of the type rules. It adds evidence rather
+ * than lowering a bar: an input the live node does not account for stays unavailable, so
  * #580's protection is untouched for every case this cannot observe.
  *
  * Requires EVERY input carrying the type to be accounted for. A def can require the same


### PR DESCRIPTION
Addresses **part 1** of #636. Parts 2 (labels absent from every reader) and 3 (no
overwrite/delete for a saved blueprint) are separate changes — the issue stays open.

`panel_add_node("SaveVideo")` was refused with `Required custom widget "VIDEO" have not
registered` on a canvas that already held a **working** SaveVideo.

**Half was already fixed.** `codec: COMFY_DYNAMICCOMBO_V3` was waived by #686, and
against a live ComfyUI here SaveVideo adds cleanly, cold and warm. The remaining half is
`video: ["VIDEO"]`, reproduced deterministically at the pure-module level:

| backend | report |
|---|---|
| `knownSocketTypes = {VIDEO}` (normal install — 109 classes output VIDEO here) | `[]` |
| `knownSocketTypes = {}` (the reporter's remote install) | `[{type:"VIDEO", inputs:["video"]}]` |

So the trigger is an install whose node set never **outputs** the datatype. `video` is
socket-shaped but not link-proven, and the waiver needs both — permanently, since every
input to that decision is a snapshot.

**The bar is not lowered.** Waiving on socket-shape alone would re-open #580: a bare
`("MYTYPE",)` with no widget config could still be a custom widget type. Evidence is
added instead — the evidence the reporter was looking at the whole time. A node of that
class already on the canvas shows how each input actually materialised: a link slot means
socket, a widget means the constructor exists.

Consulted **last**, after the 5s poll has already failed, so it can only convert a
permanent refusal into a success and never shorten a legitimate wait. Read lazily, so a
healthy add pays nothing.

Per codex, the live node is a **witness, not a proof** — a widget can survive from an
earlier registration or have been converted to a slot. What makes it safe is that it only
permits an *attempt*: the created node still goes through
`missingRequiredWidgetMaterializations` before success is reported, and that is the real
soundness boundary. Worst case is a creation attempt that then fails closed.

Every unobservable case is unchanged: no live node, a node that doesn't account for the
input, an unreadable node, or an entry naming no inputs. Five mutations verified to fail
the suite, including `some` for `every` and treating an unreadable node as an explanation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)