### PR TITLE
0.11.67 — adding a node stops refusing a type your install can handle (#636)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,35 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+## [0.11.67] - 2026-08-09
+
+> Covers changes since 0.11.66.
+
+### Fixed
+
+- **Adding a node no longer refuses a type your install can clearly handle (#636).**
+  Asking the agent to add `SaveVideo` failed with *"Required custom widget VIDEO have not
+  registered"* — on a canvas where a working `SaveVideo` was already sitting. Retrying
+  never helped, because nothing about the check could change.
+
+  The check asks whether a datatype could still be a widget that hasn't finished loading.
+  It answers that by looking at whether any installed node *produces* that type. On an
+  install where nothing happens to produce it, the answer is permanently "can't tell", and
+  the node becomes unaddable forever — even though ComfyUI builds it perfectly well.
+
+  The panel now also looks at the canvas. If a node of that same type is already there,
+  how ComfyUI actually built it is visible: an input wired as a connection is a
+  connection, and one shown as a widget already has what it needs. That is exactly the
+  evidence the reporter was staring at while being told the node couldn't be added.
+
+  This only ever lets an attempt proceed — the newly added node is still checked before
+  you're told it worked, so a genuinely missing widget still fails, and a still-loading
+  one still gets its full wait first. Nothing changes for a type the canvas can't vouch
+  for.
+
+  The other half of that report — `SaveVideo`'s `codec` input — was already fixed in
+  0.11.61. Verified here against a live ComfyUI: `SaveVideo` now adds cleanly.
+
 ## [0.11.66] - 2026-08-09
 
 > Covers changes since 0.11.65.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-agent-panel"
 description = "Autonomous AI agent in the ComfyUI sidebar - local-first, bring any LLM. Run it on your Claude or ChatGPT subscription (no API keys, no extra LLM costs), on a Kimi K3 / GLM / OpenRouter key, or fully offline on free local models via Ollama, LM Studio, or llama.cpp. The agent drives your live canvas at full parity: add, wire, move and tweak nodes with Ctrl+Z undo, load whole workflows and installer packs in one shot, generate images, video and audio, browse CivitAI, and run your workflow - asking before it spends paid API credits. The sidebar UI for comfyui-mcp, the local-first, agent-native control plane for ComfyUI."
-version = "0.11.66"
+version = "0.11.67"
 license = { file = "LICENSE" }
 requires-python = ">=3.9"
 # UI-only pack: no Python deps. The frontend floor guarantees

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -879,7 +879,7 @@ const DOCS_URL = "https://comfyui-mcp.artokun.io/docs";
 // Panel version — surfaced in the "Need help?" diagnostics blob. Bump via
 // `node scripts/set-version.mjs <v>` (updates this AND pyproject together); CI
 // and the publish gate FAIL if the two ever drift, so this can't go stale.
-const PANEL_VERSION = "0.11.66";
+const PANEL_VERSION = "0.11.67";
 
 // The connected orchestrator's console URL/token (captured off the `backends`
 // bridge message — see onBackends). Drives the "API Keys" credentials frame;


### PR DESCRIPTION
Releases #899 (fixes part 1 of #636; parts 2 and 3 remain open).

`panel_add_node("SaveVideo")` was refused with `Required custom widget "VIDEO" have not
registered` on a canvas that already held a working SaveVideo. The precondition asks
whether a datatype might still be a loading widget, and answers it by whether any
installed node OUTPUTS that type — so on an install where nothing does, the node is
unaddable forever and no retry can change it.

The panel now also consults the canvas: a node of the same class already there shows how
ComfyUI actually materialised each input. Consulted last, after the full wait, and it
only permits an attempt — the created node is still verified before success is reported.

The codec half of that report was already fixed in 0.11.44 (#686). Verified against a
live ComfyUI: SaveVideo adds cleanly, and the reporter's backend shape still refuses
without a live witness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)