### PR TITLE
docs(changelog): the codec half shipped in 0.11.44, not 0.11.61

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ All notable changes to this project are documented here. This project adheres to
   for.
 
   The other half of that report — `SaveVideo`'s `codec` input — was already fixed in
-  0.11.61. Verified here against a live ComfyUI: `SaveVideo` now adds cleanly.
+  0.11.44. Verified here against a live ComfyUI: `SaveVideo` now adds cleanly.
 
 ## [0.11.66] - 2026-08-09
 


### PR DESCRIPTION
0.11.67's entry names the wrong release for the already-fixed half of #636. My correction
did not apply before the release — the string wraps a line break, so the replace missed
it.

Traced properly this time: the #686 fix is `7cdf2ea`, first contained in **0.11.44**.

Documentation only; no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)