### PR TITLE
0.11.69 — a downloaded workflow can't forge status tags in the outline (#904)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,31 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+## [0.11.69] - 2026-08-09
+
+> Covers changes since 0.11.68.
+
+### Security
+
+- **A workflow you open can no longer lie to the agent about your graph (#904).** The
+  graph outline the agent reads marks nodes with short status tags — `[bypass]` and
+  `[mute]` mean a node isn't running, `[after_gen=randomize]` means ComfyUI quietly
+  changes that value on every run. Node titles and widget values were written into that
+  same text as-is, so text containing one of those tags was indistinguishable from a tag
+  the panel had actually emitted.
+
+  This is reachable by **workflows you download**, not just by what you type: a prompt in
+  a shared JSON could make the agent believe a node was disabled, or that a value was
+  being rewritten behind its back, and act on it.
+
+  Values are not censored to fix it — bracket syntax like `[cat|dog]` is ordinary prompt
+  content, and deleting it would corrupt what you asked to see. Instead a value
+  containing brackets is now quoted, so a tag outside quotes is always the panel's own.
+  Ordinary values are unchanged. Titles, which were already quoted, can no longer end
+  their own quoting early.
+
+  Found while fixing #636 and verified against a live ComfyUI before and after.
+
 ## [0.11.68] - 2026-08-09
 
 > Covers changes since 0.11.67.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-agent-panel"
 description = "Autonomous AI agent in the ComfyUI sidebar - local-first, bring any LLM. Run it on your Claude or ChatGPT subscription (no API keys, no extra LLM costs), on a Kimi K3 / GLM / OpenRouter key, or fully offline on free local models via Ollama, LM Studio, or llama.cpp. The agent drives your live canvas at full parity: add, wire, move and tweak nodes with Ctrl+Z undo, load whole workflows and installer packs in one shot, generate images, video and audio, browse CivitAI, and run your workflow - asking before it spends paid API credits. The sidebar UI for comfyui-mcp, the local-first, agent-native control plane for ComfyUI."
-version = "0.11.68"
+version = "0.11.69"
 license = { file = "LICENSE" }
 requires-python = ">=3.9"
 # UI-only pack: no Python deps. The frontend floor guarantees

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -879,7 +879,7 @@ const DOCS_URL = "https://comfyui-mcp.artokun.io/docs";
 // Panel version — surfaced in the "Need help?" diagnostics blob. Bump via
 // `node scripts/set-version.mjs <v>` (updates this AND pyproject together); CI
 // and the publish gate FAIL if the two ever drift, so this can't go stale.
-const PANEL_VERSION = "0.11.68";
+const PANEL_VERSION = "0.11.69";
 
 // The connected orchestrator's console URL/token (captured off the `backends`
 // bridge message — see onBackends). Drives the "API Keys" credentials frame;


### PR DESCRIPTION
Releases #905 (fixes #904).

The outline the agent reads marks nodes with `[bypass]`, `[mute]` and
`[after_gen=randomize]` — tags that mean a node isn't running, or that ComfyUI rewrites a
value every run. Node titles and widget values rendered into that text unescaped, and
values render *unquoted in exactly the position a genuine tag occupies*, so a forged one
was byte-identical in shape.

Reachable via workflows people download, not just their own typing.

Values are not censored — `[cat|dog]` is ordinary prompt syntax and deleting it would
corrupt the content. A bracketed value is quoted instead, so a tag outside quotes is
always the panel's own; ordinary values are byte-identical to before. Titles can no
longer close their own quoting early.

Verified live before and after; five e2e tests including the clip/escape boundaries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)