### PR TITLE
test: stop the e2e suite leaving saved workflows behind (#907)

### DIFF
--- a/browser_tests/bridge-reregisters-after-restart.spec.ts
+++ b/browser_tests/bridge-reregisters-after-restart.spec.ts
@@ -29,7 +29,7 @@
  * Engineering an abrupt kill is only worth it if the reconnect path starts telling those
  * apart, or if #654 evidence points there (codex).
  */
-import { test, expect } from './fixtures/panelTest'
+import { test, expect, deleteSavedWorkflow } from './fixtures/panelTest'
 import { MockBridge } from './fixtures/MockBridge'
 
 test.setTimeout(180_000)
@@ -49,12 +49,7 @@ test('the tab re-registers after the bridge dies and respawns', async ({
   const savedName = String(saved.result?.workflow || '')
   expect(savedName).toBeTruthy()
   // This spec persists a file on the real ComfyUI — remove it however the test ends.
-  const cleanup = async () => {
-    await page.evaluate(async (p) => {
-      const api = (window as any).comfyAPI?.api?.api
-      await api?.fetchApi?.(`/userdata/${encodeURIComponent(p)}`, { method: 'DELETE' })
-    }, `workflows/${savedName}.json`)
-  }
+  const cleanup = () => deleteSavedWorkflow(page, savedName)
 
   try {
     const port = mockBridge.port

--- a/browser_tests/bridge-route-never-file-derived.spec.ts
+++ b/browser_tests/bridge-route-never-file-derived.spec.ts
@@ -23,7 +23,7 @@
  * `wf:<one-shared-id>:<path>` for every tab matches the form and recreates #693 exactly
  * (codex). Uniqueness is the invariant; the form is only how it is carried.
  */
-import { test, expect, isolatePanelPage } from './fixtures/panelTest'
+import { test, expect, isolatePanelPage, deleteSavedWorkflow } from './fixtures/panelTest'
 import { PanelPage } from './fixtures/PanelPage'
 
 /** Record the `tab_id` of every hello this page sends, from before it connects. */
@@ -88,12 +88,7 @@ test('two tabs on one saved workflow never share a bridge route', async ({
     const savedPath = `workflows/${savedName}.json`
     // This spec PERSISTS a file on the developer's real ComfyUI. Remove it however the
     // test ends — an assertion failure must not leave litter behind (codex).
-    cleanup.push(async () => {
-      await page.evaluate(async (p) => {
-        const api = (window as any).comfyAPI?.api?.api
-        await api?.fetchApi?.(`/userdata/${encodeURIComponent(p)}`, { method: 'DELETE' })
-      }, savedPath)
-    })
+    cleanup.push(() => deleteSavedWorkflow(page, savedName))
     await page.waitForTimeout(2500)
 
     // Tab B: a second real browser tab in the same context, opening that same file.

--- a/browser_tests/dirty-guards-see-node-writes.spec.ts
+++ b/browser_tests/dirty-guards-see-node-writes.spec.ts
@@ -55,12 +55,14 @@ test('closing a workflow refuses when a NODE left unsaved work', async ({
   // Save so the tab is genuinely clean, and resolve the close target BEFORE the write.
   // Order is load-bearing: the command dispatch captures after every completed command,
   // so any panel command issued after the write refreshes the tracker and hides the lag.
+  // #907 — the try opens BEFORE the save, so a save that lands and then fails an
+  // assertion is still cleaned up (codex).
+  let savedName = ''
+  try {
   const saved = await mockBridge.command('workflow_save', {})
   expect(saved.ok, 'the save must succeed so the tab starts clean').toBe(true)
-  // #907 — a REAL file lands in the developer's workflow library; remove it whatever
-  // happens below.
-  const savedName = String(saved.result?.workflow || '')
-  try {
+  savedName = String(saved.result?.workflow || '')
+  expect(savedName, 'the save must report a name, or cleanup has nothing to remove').toBeTruthy()
   const listed = await mockBridge.command('workflow_list', {})
   const target =
     listed.result?.active?.routing_key || listed.result?.active?.key || listed.result?.active?.path
@@ -128,9 +130,14 @@ test('force:true still discards — the guard refuses, it does not trap', async 
     ;(app?.canvas?.graph ?? app?.graph).add(LG.createNode('EmptyLatentImage'))
   })
   await settleCanvas(page)
-  const saved2 = await mockBridge.command('workflow_save', {})
-  const savedName2 = String(saved2.result?.workflow || '')
+  let savedName2 = ''
   try {
+  const saved2 = await mockBridge.command('workflow_save', {})
+  // Asserted, not assumed (codex): without this the setup save could fail, the test
+  // still pass, and cleanup ask to delete `workflows/.json`.
+  expect(saved2.ok, 'the setup save must succeed').toBe(true)
+  savedName2 = String(saved2.result?.workflow || '')
+  expect(savedName2, 'the setup save must report a name').toBeTruthy()
   const listed = await mockBridge.command('workflow_list', {})
   const target =
     listed.result?.active?.routing_key || listed.result?.active?.key || listed.result?.active?.path

--- a/browser_tests/dirty-guards-see-node-writes.spec.ts
+++ b/browser_tests/dirty-guards-see-node-writes.spec.ts
@@ -59,52 +59,52 @@ test('closing a workflow refuses when a NODE left unsaved work', async ({
   // assertion is still cleaned up (codex).
   let savedName = ''
   try {
-  const saved = await mockBridge.command('workflow_save', {})
-  expect(saved.ok, 'the save must succeed so the tab starts clean').toBe(true)
-  savedName = String(saved.result?.workflow || '')
-  expect(savedName, 'the save must report a name, or cleanup has nothing to remove').toBeTruthy()
-  const listed = await mockBridge.command('workflow_list', {})
-  const target =
+    const saved = await mockBridge.command('workflow_save', {})
+    expect(saved.ok, 'the save must succeed so the tab starts clean').toBe(true)
+    savedName = String(saved.result?.workflow || '')
+    expect(savedName, 'the save must report a name, or cleanup has nothing to remove').toBeTruthy()
+    const listed = await mockBridge.command('workflow_list', {})
+    const target =
     listed.result?.active?.routing_key || listed.result?.active?.key || listed.result?.active?.path
-  expect(target, 'the active workflow must be resolvable').toBeTruthy()
-  // Stamp the close explicitly. Closing the ACTIVE workflow is deliberately FENCED
-  // (only a close resolving to a genuinely non-active tab is exempt), and MockBridge
-  // sends every `workflow_close` unstamped on the assumption that the whole command
-  // is exempt — so an unstamped close is refused for identity reasons before it ever
-  // reaches the dirty guard this spec is about.
-  const stamp = listed.result?.active?.workflow_uuid
-  expect(stamp, 'workflow_list must report the active workflow uuid').toBeTruthy()
+    expect(target, 'the active workflow must be resolvable').toBeTruthy()
+    // Stamp the close explicitly. Closing the ACTIVE workflow is deliberately FENCED
+    // (only a close resolving to a genuinely non-active tab is exempt), and MockBridge
+    // sends every `workflow_close` unstamped on the assumption that the whole command
+    // is exempt — so an unstamped close is refused for identity reasons before it ever
+    // reaches the dirty guard this spec is about.
+    const stamp = listed.result?.active?.workflow_uuid
+    expect(stamp, 'workflow_list must report the active workflow uuid').toBeTruthy()
 
-  await nodeWritesWidget(page, 1337)
+    await nodeWritesWidget(page, 1337)
 
-  // Precondition: the tab must still LOOK clean, or this passes for the wrong reason.
-  const looksClean = await page.evaluate(() => {
+    // Precondition: the tab must still LOOK clean, or this passes for the wrong reason.
+    const looksClean = await page.evaluate(() => {
     const w = window as any
     const app = w.comfyAPI?.app?.app || w.app
     return app?.extensionManager?.workflow?.activeWorkflow?.isModified === false
-  })
-  expect(looksClean, 'precondition: isModified must still read false').toBe(true)
+    })
+    expect(looksClean, 'precondition: isModified must still read false').toBe(true)
 
-  // The guard must now refuse. Before #882 this closed the tab and the value was gone.
-  //
-  // Assert the ORIGINAL guard's sentence, not a loose /unsaved changes/: the refusal
-  // for an UNPROVEN capture reads "could not be checked for unsaved changes", so a
-  // loose match would be satisfied by a capture that never landed — passing while the
-  // flag this spec is about stayed stale. This wording is reached only when the
-  // capture succeeded AND flipped `isModified` to true, which is the whole fix.
-  const closed = await mockBridge.command('workflow_close', { path: target, workflow_uuid: stamp })
-  expect(JSON.stringify(closed)).toContain('has unsaved changes')
+    // The guard must now refuse. Before #882 this closed the tab and the value was gone.
+    //
+    // Assert the ORIGINAL guard's sentence, not a loose /unsaved changes/: the refusal
+    // for an UNPROVEN capture reads "could not be checked for unsaved changes", so a
+    // loose match would be satisfied by a capture that never landed — passing while the
+    // flag this spec is about stayed stale. This wording is reached only when the
+    // capture succeeded AND flipped `isModified` to true, which is the whole fix.
+    const closed = await mockBridge.command('workflow_close', { path: target, workflow_uuid: stamp })
+    expect(JSON.stringify(closed)).toContain('has unsaved changes')
 
-  // …and the workflow must still be open with the value on it.
-  const stillThere = await page.evaluate(() => {
+    // …and the workflow must still be open with the value on it.
+    const stillThere = await page.evaluate(() => {
     const w = window as any
     const app = w.comfyAPI?.app?.app || w.app
     const graph = app?.canvas?.graph ?? app?.graph
     const node = (graph?.nodes || []).find((n: any) => n.type === 'EmptyLatentImage')
     const widget = (node?.widgets || []).find((x: any) => x.name === 'width')
     return widget ? widget.value : null
-  })
-  expect(stillThere, 'the refused close must leave the work on the canvas').toBe(1337)
+    })
+    expect(stillThere, 'the refused close must leave the work on the canvas').toBe(1337)
   } finally {
     await deleteSavedWorkflow(page, savedName)
   }
@@ -132,25 +132,25 @@ test('force:true still discards — the guard refuses, it does not trap', async 
   await settleCanvas(page)
   let savedName2 = ''
   try {
-  const saved2 = await mockBridge.command('workflow_save', {})
-  // Asserted, not assumed (codex): without this the setup save could fail, the test
-  // still pass, and cleanup ask to delete `workflows/.json`.
-  expect(saved2.ok, 'the setup save must succeed').toBe(true)
-  savedName2 = String(saved2.result?.workflow || '')
-  expect(savedName2, 'the setup save must report a name').toBeTruthy()
-  const listed = await mockBridge.command('workflow_list', {})
-  const target =
+    const saved2 = await mockBridge.command('workflow_save', {})
+    // Asserted, not assumed (codex): without this the setup save could fail, the test
+    // still pass, and cleanup ask to delete `workflows/.json`.
+    expect(saved2.ok, 'the setup save must succeed').toBe(true)
+    savedName2 = String(saved2.result?.workflow || '')
+    expect(savedName2, 'the setup save must report a name').toBeTruthy()
+    const listed = await mockBridge.command('workflow_list', {})
+    const target =
     listed.result?.active?.routing_key || listed.result?.active?.key || listed.result?.active?.path
-  const stamp = listed.result?.active?.workflow_uuid
+    const stamp = listed.result?.active?.workflow_uuid
 
-  await nodeWritesWidget(page, 4242)
+    await nodeWritesWidget(page, 4242)
 
-  const closed = await mockBridge.command('workflow_close', {
+    const closed = await mockBridge.command('workflow_close', {
     path: target,
     workflow_uuid: stamp,
     force: true
-  })
-  expect(closed.ok, 'force:true must still close').toBe(true)
+    })
+    expect(closed.ok, 'force:true must still close').toBe(true)
   } finally {
     await deleteSavedWorkflow(page, savedName2)
   }

--- a/browser_tests/dirty-guards-see-node-writes.spec.ts
+++ b/browser_tests/dirty-guards-see-node-writes.spec.ts
@@ -17,7 +17,7 @@
  * Driven over the bridge rather than asserted at source, because the bug is an interaction
  * between ComfyUI's tracker and the panel's guard and only appears when both run.
  */
-import { test, expect } from './fixtures/panelTest'
+import { test, expect, deleteSavedWorkflow } from './fixtures/panelTest'
 import { claimFreshCanvas, settleCanvas } from './fixtures/canvasIdentity'
 
 /** Change a widget the way a NODE does: directly, no user input event. */
@@ -57,6 +57,10 @@ test('closing a workflow refuses when a NODE left unsaved work', async ({
   // so any panel command issued after the write refreshes the tracker and hides the lag.
   const saved = await mockBridge.command('workflow_save', {})
   expect(saved.ok, 'the save must succeed so the tab starts clean').toBe(true)
+  // #907 — a REAL file lands in the developer's workflow library; remove it whatever
+  // happens below.
+  const savedName = String(saved.result?.workflow || '')
+  try {
   const listed = await mockBridge.command('workflow_list', {})
   const target =
     listed.result?.active?.routing_key || listed.result?.active?.key || listed.result?.active?.path
@@ -99,6 +103,9 @@ test('closing a workflow refuses when a NODE left unsaved work', async ({
     return widget ? widget.value : null
   })
   expect(stillThere, 'the refused close must leave the work on the canvas').toBe(1337)
+  } finally {
+    await deleteSavedWorkflow(page, savedName)
+  }
 })
 
 test('force:true still discards — the guard refuses, it does not trap', async ({
@@ -121,7 +128,9 @@ test('force:true still discards — the guard refuses, it does not trap', async 
     ;(app?.canvas?.graph ?? app?.graph).add(LG.createNode('EmptyLatentImage'))
   })
   await settleCanvas(page)
-  await mockBridge.command('workflow_save', {})
+  const saved2 = await mockBridge.command('workflow_save', {})
+  const savedName2 = String(saved2.result?.workflow || '')
+  try {
   const listed = await mockBridge.command('workflow_list', {})
   const target =
     listed.result?.active?.routing_key || listed.result?.active?.key || listed.result?.active?.path
@@ -135,4 +144,7 @@ test('force:true still discards — the guard refuses, it does not trap', async 
     force: true
   })
   expect(closed.ok, 'force:true must still close').toBe(true)
+  } finally {
+    await deleteSavedWorkflow(page, savedName2)
+  }
 })

--- a/browser_tests/fixtures/panelTest.ts
+++ b/browser_tests/fixtures/panelTest.ts
@@ -119,4 +119,32 @@ export const test = base.extend<PanelFixtures & PanelOptions>({
   }
 })
 
+/**
+ * Delete a workflow this spec persisted, through ComfyUI's own userdata API (#907).
+ *
+ * Specs that call `workflow_save` write a REAL file into the developer's workflow
+ * library. Nothing removed them, and it compounded: 1221 of 1240 files on this machine
+ * were `Untitled 2026-08-*` test output, burying the ~19 real workflows and inflating
+ * every `workflows` store read the panel does.
+ *
+ * It lives HERE because the three specs that did clean up each hand-rolled their own
+ * copy, and that is exactly how the two that did not came to be missed. One helper, so
+ * forgetting is a shorter path than remembering.
+ *
+ * Best-effort by construction: a cleanup that throws must never mask the assertion that
+ * actually failed, and a file that is already gone is already clean. Call it from a
+ * `finally`, so a failing test does not leave litter either.
+ */
+export async function deleteSavedWorkflow(page: Page, workflowName: string): Promise<void> {
+  try {
+    await page.evaluate(async (path) => {
+      const api = (window as any).comfyAPI?.api?.api
+      await api?.fetchApi?.(`/userdata/${encodeURIComponent(path)}`, { method: 'DELETE' })
+    }, `workflows/${workflowName}.json`)
+  } catch {
+    // The page may already be closed, or the API unreachable — neither is worth failing
+    // a test over, and the next run's cleanup will not be blocked by it.
+  }
+}
+
 export { expect } from '@playwright/test'

--- a/browser_tests/fixtures/panelTest.ts
+++ b/browser_tests/fixtures/panelTest.ts
@@ -136,14 +136,31 @@ export const test = base.extend<PanelFixtures & PanelOptions>({
  * `finally`, so a failing test does not leave litter either.
  */
 export async function deleteSavedWorkflow(page: Page, workflowName: string): Promise<void> {
+  const name = String(workflowName ?? '').trim()
+  // An empty name would DELETE `workflows/.json` — a request about a file this spec never
+  // created. Nothing to clean, and asking is worse than not asking.
+  if (!name) {
+    console.warn('[e2e cleanup] no workflow name to delete — a setup save likely failed')
+    return
+  }
+  let outcome: string
   try {
-    await page.evaluate(async (path) => {
+    outcome = await page.evaluate(async (path) => {
       const api = (window as any).comfyAPI?.api?.api
-      await api?.fetchApi?.(`/userdata/${encodeURIComponent(path)}`, { method: 'DELETE' })
-    }, `workflows/${workflowName}.json`)
-  } catch {
-    // The page may already be closed, or the API unreachable — neither is worth failing
-    // a test over, and the next run's cleanup will not be blocked by it.
+      if (typeof api?.fetchApi !== 'function') return 'no api'
+      // fetchApi RESOLVES on an HTTP error, so the status has to be read (codex) —
+      // otherwise a 500 leaves litter and looks exactly like success.
+      const res = await api.fetchApi(`/userdata/${encodeURIComponent(path)}`, { method: 'DELETE' })
+      return res?.ok ? 'ok' : `HTTP ${res?.status ?? '?'}`
+    }, `workflows/${name}.json`)
+  } catch (err) {
+    outcome = `threw: ${String(err)}`
+  }
+  // NON-MASKING but not SILENT. Throwing would replace a real assertion failure with a
+  // cleanup failure, which is strictly worse for diagnosis — but a cleanup that quietly
+  // fails forever is how 1221 files accumulated in the first place, so it must say so.
+  if (outcome !== 'ok') {
+    console.warn(`[e2e cleanup] failed to delete workflows/${name}.json — ${outcome}`)
   }
 }
 

--- a/browser_tests/save-persists-node-set-values.spec.ts
+++ b/browser_tests/save-persists-node-set-values.spec.ts
@@ -14,7 +14,7 @@
  * anything the panel reports. A save that returns `saved: true` while the file disagrees
  * with the screen is exactly the failure, so the panel's own account of it proves nothing.
  */
-import { test, expect } from './fixtures/panelTest'
+import { test, expect, deleteSavedWorkflow } from './fixtures/panelTest'
 import { claimFreshCanvas, settleCanvas } from './fixtures/canvasIdentity'
 
 /** Read a saved workflow back off disk through ComfyUI's userdata API. */
@@ -62,39 +62,45 @@ test('an in-place save persists a value the tracker never saw', async ({
   expect(first.ok, 'the first save must succeed so the tab has a path').toBe(true)
   const name = String(first.result?.workflow || '')
   expect(name, 'the save must report the workflow name').toBeTruthy()
+  // #907 — this spec writes a REAL file into the developer's workflow library. Remove it
+  // however the test ends; an assertion failure must not leave litter either.
+  try {
 
-  // Change a value the way a NODE does: directly, no user input event — and issue no
-  // panel command afterwards, because the dispatch captures after every completed
-  // command and would refresh the tracker, hiding the very lag this is about.
-  await page.evaluate(() => {
-    const w = window as any
-    const app = w.comfyAPI?.app?.app || w.app
-    const graph = app?.canvas?.graph ?? app?.graph
-    const node = (graph?.nodes || []).find((n: any) => n.type === 'EmptyLatentImage')
-    const widget = (node.widgets || []).find((x: any) => x.name === 'width')
-    widget.value = 1337
-  })
+    // Change a value the way a NODE does: directly, no user input event — and issue no
+    // panel command afterwards, because the dispatch captures after every completed
+    // command and would refresh the tracker, hiding the very lag this is about.
+    await page.evaluate(() => {
+      const w = window as any
+      const app = w.comfyAPI?.app?.app || w.app
+      const graph = app?.canvas?.graph ?? app?.graph
+      const node = (graph?.nodes || []).find((n: any) => n.type === 'EmptyLatentImage')
+      const widget = (node.widgets || []).find((x: any) => x.name === 'width')
+      widget.value = 1337
+    })
 
-  // Precondition: the tracker must NOT have seen it, or this passes for the wrong reason.
-  const trackerLagged = await page.evaluate(() => {
-    const w = window as any
-    const app = w.comfyAPI?.app?.app || w.app
-    const wf = app?.extensionManager?.workflow?.activeWorkflow
-    const node = (wf?.changeTracker?.activeState?.nodes || []).find(
-      (n: any) => n.type === 'EmptyLatentImage'
+    // Precondition: the tracker must NOT have seen it, or this passes for the wrong reason.
+    const trackerLagged = await page.evaluate(() => {
+      const w = window as any
+      const app = w.comfyAPI?.app?.app || w.app
+      const wf = app?.extensionManager?.workflow?.activeWorkflow
+      const node = (wf?.changeTracker?.activeState?.nodes || []).find(
+        (n: any) => n.type === 'EmptyLatentImage'
+      )
+      return !((node?.widgets_values || []) as unknown[]).includes(1337)
+    })
+    expect(trackerLagged, 'precondition: the tracker must not have seen the change').toBe(true)
+
+    const saved = await mockBridge.command('workflow_save', {})
+    expect(saved.ok, 'the in-place save must succeed').toBe(true)
+
+    // THE BYTES, not the panel's account of them. Before #878 this was the node's
+    // default — the file quietly disagreeing with the screen.
+    const onDisk = await readWidgetsFromDisk(page, name, 'EmptyLatentImage')
+    expect(onDisk.error, 'the saved workflow must be readable from disk').toBeUndefined()
+    expect(onDisk.widgets, 'the saved file must carry the live value, not the tracker default').toContain(
+      1337
     )
-    return !((node?.widgets_values || []) as unknown[]).includes(1337)
-  })
-  expect(trackerLagged, 'precondition: the tracker must not have seen the change').toBe(true)
-
-  const saved = await mockBridge.command('workflow_save', {})
-  expect(saved.ok, 'the in-place save must succeed').toBe(true)
-
-  // THE BYTES, not the panel's account of them. Before #878 this was the node's
-  // default — the file quietly disagreeing with the screen.
-  const onDisk = await readWidgetsFromDisk(page, name, 'EmptyLatentImage')
-  expect(onDisk.error, 'the saved workflow must be readable from disk').toBeUndefined()
-  expect(onDisk.widgets, 'the saved file must carry the live value, not the tracker default').toContain(
-    1337
-  )
+  } finally {
+    await deleteSavedWorkflow(page, name)
+  }
 })

--- a/browser_tests/save-persists-node-set-values.spec.ts
+++ b/browser_tests/save-persists-node-set-values.spec.ts
@@ -58,13 +58,15 @@ test('an in-place save persists a value the tracker never saw', async ({
 
   // First save gives the tab a real path. A never-saved tab takes the COPY route,
   // which already flushed — this spec is about the in-place overwrite.
+  // #907 — the try opens BEFORE the save, so a save that lands but then fails an
+  // assertion is still cleaned up (codex). `name` is assigned inside and read by the
+  // finally, which no-ops on an empty one.
+  let name = ''
+  try {
   const first = await mockBridge.command('workflow_save', {})
   expect(first.ok, 'the first save must succeed so the tab has a path').toBe(true)
-  const name = String(first.result?.workflow || '')
+  name = String(first.result?.workflow || '')
   expect(name, 'the save must report the workflow name').toBeTruthy()
-  // #907 — this spec writes a REAL file into the developer's workflow library. Remove it
-  // however the test ends; an assertion failure must not leave litter either.
-  try {
 
     // Change a value the way a NODE does: directly, no user input event — and issue no
     // panel command afterwards, because the dispatch captures after every completed

--- a/browser_tests/save-persists-node-set-values.spec.ts
+++ b/browser_tests/save-persists-node-set-values.spec.ts
@@ -63,10 +63,10 @@ test('an in-place save persists a value the tracker never saw', async ({
   // finally, which no-ops on an empty one.
   let name = ''
   try {
-  const first = await mockBridge.command('workflow_save', {})
-  expect(first.ok, 'the first save must succeed so the tab has a path').toBe(true)
-  name = String(first.result?.workflow || '')
-  expect(name, 'the save must report the workflow name').toBeTruthy()
+    const first = await mockBridge.command('workflow_save', {})
+    expect(first.ok, 'the first save must succeed so the tab has a path').toBe(true)
+    name = String(first.result?.workflow || '')
+    expect(name, 'the save must report the workflow name').toBeTruthy()
 
     // Change a value the way a NODE does: directly, no user input event — and issue no
     // panel command afterwards, because the dispatch captures after every completed


### PR DESCRIPTION
Closes #907.

Measured on this machine: **1221 of 1240** files in the workflows dir are
`Untitled 2026-08-*` test output — ~98% of the developer's library, with the ~19 real
workflows buried in it.

Two specs persist a workflow and never remove it (`dirty-guards-see-node-writes` from
#882, `save-persists-node-set-values` from #878). I wrote both without cleanup and only
started adding it after codex flagged the same defect in #693 — after which three later
specs each hand-rolled their own copy. That hand-rolling is precisely why the first two
were missed, so this adds a shared fixture helper rather than a fourth copy.

Deleting the existing 1221 files is the developer's call and is deliberately out of
scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)