### PR TITLE
0.11.70 — a video your browser can't play says so (#909)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+## [0.11.70] - 2026-08-09
+
+> Covers changes since 0.11.69.
+
+### Fixed
+
+- **A video your browser can't play now says so instead of showing a blank card (#909).**
+  Asking the agent to show a video reported success and displayed nothing, because the
+  tool answers for handing the video to the page — not for whether the browser could
+  actually decode it. An MP4 in an older format (MPEG-4 Part 2) is the reported case.
+
+  The card now says the format can't be played and suggests re-encoding as H.264 or
+  WebM, instead of leaving you to guess whether the video is broken, still loading, or
+  never arrived.
+
+  Two things it deliberately does not do: it does not report a failure when a working
+  video is simply scrolled out of view (tearing one down looks identical to a decode
+  error from the outside), and it does not keep retrying media it has already failed on,
+  which would make the message flicker away each time you scrolled back.
+
 ## [0.11.69] - 2026-08-09
 
 > Covers changes since 0.11.68.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-agent-panel"
 description = "Autonomous AI agent in the ComfyUI sidebar - local-first, bring any LLM. Run it on your Claude or ChatGPT subscription (no API keys, no extra LLM costs), on a Kimi K3 / GLM / OpenRouter key, or fully offline on free local models via Ollama, LM Studio, or llama.cpp. The agent drives your live canvas at full parity: add, wire, move and tweak nodes with Ctrl+Z undo, load whole workflows and installer packs in one shot, generate images, video and audio, browse CivitAI, and run your workflow - asking before it spends paid API credits. The sidebar UI for comfyui-mcp, the local-first, agent-native control plane for ComfyUI."
-version = "0.11.69"
+version = "0.11.70"
 license = { file = "LICENSE" }
 requires-python = ">=3.9"
 # UI-only pack: no Python deps. The frontend floor guarantees

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -879,7 +879,7 @@ const DOCS_URL = "https://comfyui-mcp.artokun.io/docs";
 // Panel version — surfaced in the "Need help?" diagnostics blob. Bump via
 // `node scripts/set-version.mjs <v>` (updates this AND pyproject together); CI
 // and the publish gate FAIL if the two ever drift, so this can't go stale.
-const PANEL_VERSION = "0.11.69";
+const PANEL_VERSION = "0.11.70";
 
 // The connected orchestrator's console URL/token (captured off the `backends`
 // bridge message — see onBackends). Drives the "API Keys" credentials frame;


### PR DESCRIPTION
Releases #913 (fixes #909).

`panel_show_media` answers for the DOM dispatch, not the decode, so an MP4 the browser
refuses returned ok:true and rendered a blank card. The card now states the failure and
suggests H.264/WebM.

Two guards it needed beyond the reported patch: a teardown (`removeAttribute('src')` +
`load()`) fires `error` too, so a healthy video scrolled out of view must not report a
failure; and the failure is terminal for that source, or the lazy observer remounts
known-bad media and the message flickers away.

Verification note: unit-asserted at source and codex-reviewed across four rounds. I could
not get the browser to fire the decode error on demand in the harness, so the error path
itself is not covered end-to-end — stated rather than implied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)