### PR TITLE
0.11.71 — the subgraph name-clash check works on current ComfyUI again (#636)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+## [0.11.71] - 2026-08-09
+
+> Covers changes since 0.11.70.
+
+### Fixed
+
+- **Saving a subgraph under a name you've already used is caught again (#636).** The
+  panel refuses to save a reusable subgraph over an existing one, because replacing it
+  needs ComfyUI's own confirmation dialog — which an agent has no way to answer. On
+  current ComfyUI that check had stopped working: blueprints are now stored under a
+  generated id rather than the name you gave them, so the panel was comparing your name
+  against an id it could never equal, and saw no clash at all.
+
+  It now also compares the name shown in the library, which is where your name actually
+  lives. Older ComfyUI versions that store blueprints by name are unaffected, and a
+  different subgraph is still not treated as a clash.
+
+  Updating an existing saved subgraph is still not possible from the agent — that half
+  of the report is open.
+
 ## [0.11.70] - 2026-08-09
 
 > Covers changes since 0.11.69.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-agent-panel"
 description = "Autonomous AI agent in the ComfyUI sidebar - local-first, bring any LLM. Run it on your Claude or ChatGPT subscription (no API keys, no extra LLM costs), on a Kimi K3 / GLM / OpenRouter key, or fully offline on free local models via Ollama, LM Studio, or llama.cpp. The agent drives your live canvas at full parity: add, wire, move and tweak nodes with Ctrl+Z undo, load whole workflows and installer packs in one shot, generate images, video and audio, browse CivitAI, and run your workflow - asking before it spends paid API credits. The sidebar UI for comfyui-mcp, the local-first, agent-native control plane for ComfyUI."
-version = "0.11.70"
+version = "0.11.71"
 license = { file = "LICENSE" }
 requires-python = ">=3.9"
 # UI-only pack: no Python deps. The frontend floor guarantees

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -879,7 +879,7 @@ const DOCS_URL = "https://comfyui-mcp.artokun.io/docs";
 // Panel version — surfaced in the "Need help?" diagnostics blob. Bump via
 // `node scripts/set-version.mjs <v>` (updates this AND pyproject together); CI
 // and the publish gate FAIL if the two ever drift, so this can't go stale.
-const PANEL_VERSION = "0.11.70";
+const PANEL_VERSION = "0.11.71";
 
 // The connected orchestrator's console URL/token (captured off the `backends`
 // bridge message — see onBackends). Drives the "API Keys" credentials frame;


### PR DESCRIPTION
Releases #916.

Blueprints are now stored under a content hash rather than the name the user typed
(measured: `typePrefix` absent, 89/91 hash-named, the human name in `display_name`), so
the collision preflight compared a name against a hash and never matched. It now also
matches `display_name`, restoring the refusal that keeps a programmatic save away from
ComfyUI's unanswerable overwrite dialog.

Codex SHIP on the first pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)