### PR TITLE
fix(subgraph): add a saved subgraph by the name shown in the library (#636)

### DIFF
--- a/browser_tests/unit/blueprint-collision.test.mjs
+++ b/browser_tests/unit/blueprint-collision.test.mjs
@@ -78,3 +78,38 @@ test("#636: the panel actually uses the display-name test", () => {
     "and compare it against the requested name",
   );
 });
+
+// ── Adding a saved blueprint by the name the library shows ──────────────────
+//
+// Same root cause as the preflight above: `graph_add_subgraph` built the type as
+// prefix + name and called getBlueprint(type). On a hash-keyed store that resolves to
+// nothing for the ONE name a user or agent would use — the one the library shows — while
+// the opaque hash worked.
+
+const addSite = src.slice(
+  src.indexOf("const asType = name.startsWith(prefix)"),
+  src.indexOf("const position = placementFor(graph, pos);"),
+);
+
+test("#636: the add path resolves a blueprint by display_name", () => {
+  assert.ok(addSite.length > 0, "the resolution must exist");
+  assert.match(addSite, /d\.display_name === name/, "the library name must be consulted");
+  assert.match(addSite, /store\.getBlueprint\(type\)/, "and resolved through the store");
+});
+
+test("#636: the caller's string is tried AS A TYPE first", () => {
+  // So an exact type or a hash resolves exactly as it did before, and this can only ever
+  // add a resolution that previously failed — never change one that already worked.
+  const typeFirst = addSite.indexOf("let type = asType;");
+  const displayAfter = addSite.indexOf("byDisplayName()");
+  assert.ok(typeFirst >= 0 && displayAfter > typeFirst, "display_name is the FALLBACK, not the first try");
+});
+
+test("#636: the refusal names both things the caller could pass", () => {
+  // The old message said only "No saved subgraph blueprint X", which on a hash-keyed
+  // store was true of the name the user could actually see — unhelpful precisely when it
+  // fired most.
+  const msg = src.slice(src.indexOf("No saved subgraph blueprint"), src.indexOf("const position = placementFor"));
+  assert.match(msg, /display_name/, "the library name is an accepted input and must be named");
+  assert.match(msg, /type/, "so is the type");
+});

--- a/browser_tests/unit/blueprint-collision.test.mjs
+++ b/browser_tests/unit/blueprint-collision.test.mjs
@@ -100,9 +100,12 @@ test("#636: the add path resolves a blueprint by display_name", () => {
 test("#636: the caller's string is tried AS A TYPE first", () => {
   // So an exact type or a hash resolves exactly as it did before, and this can only ever
   // add a resolution that previously failed — never change one that already worked.
+  // The type lookup is attempted first; the display-name candidate is only CONSULTED
+  // after it fails (it is computed earlier, but nothing is resolved from it until then).
   const typeFirst = addSite.indexOf("let type = asType;");
-  const displayAfter = addSite.indexOf("byDisplayName()");
-  assert.ok(typeFirst >= 0 && displayAfter > typeFirst, "display_name is the FALLBACK, not the first try");
+  const displayUsed = addSite.indexOf("displayMatches[0]?.name");
+  assert.ok(typeFirst >= 0, "the type attempt must exist");
+  assert.ok(displayUsed > typeFirst, "display_name is the FALLBACK, not the first try");
 });
 
 test("#636: the refusal names both things the caller could pass", () => {
@@ -112,4 +115,26 @@ test("#636: the refusal names both things the caller could pass", () => {
   const msg = src.slice(src.indexOf("No saved subgraph blueprint"), src.indexOf("const position = placementFor"));
   assert.match(msg, /display_name/, "the library name is an accepted input and must be named");
   assert.match(msg, /type/, "so is the type");
+});
+
+test("#636: an AMBIGUOUS library name refuses rather than guessing", () => {
+  // display_name is user-controlled and not unique. Taking the first match could insert a
+  // DIFFERENT graph than the one asked for, and a wrong subgraph silently added is far
+  // worse than a refusal the caller can resolve by passing the unique type (codex).
+  const site = src.slice(
+    src.indexOf("const displayMatches ="),
+    src.indexOf("const position = placementFor(graph, pos);"),
+  );
+  assert.match(site, /displayMatches\.length > 1/, "more than one match must be detected");
+  assert.match(site, /would be a guess/, "and refused in those words");
+  assert.doesNotMatch(site, /\.find\(/, "no first-match shortcut may remain");
+});
+
+test("#636: a real store failure is not reported as 'never saved'", () => {
+  const site = src.slice(
+    src.indexOf("const displayMatches ="),
+    src.indexOf("const position = placementFor(graph, pos);"),
+  );
+  assert.match(site, /lookupError = err;/, "the thrown error must be kept");
+  assert.match(site, /the lookup also failed/, "and surfaced when nothing resolves");
 });

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -13128,27 +13128,39 @@ const GRAPH_TOOL_EXECUTORS = {
     // hash keeps resolving exactly as before and this can only ever add a resolution that
     // previously failed. Only if that finds nothing is `display_name` consulted.
     const asType = name.startsWith(prefix) ? name : `${prefix}${name}`;
-    const byDisplayName = () => {
-      const match = (store.subgraphBlueprints ?? []).find(
-        (d) => typeof d?.display_name === "string" && d.display_name === name,
-      );
-      return typeof match?.name === "string" ? match.name : null;
-    };
+    // AMBIGUITY REFUSES, it does not guess (codex). `display_name` is user-controlled and
+    // not unique, so taking the first match could insert a DIFFERENT graph than the one
+    // asked for — and a wrong subgraph silently added is far worse than a refusal, which
+    // the caller can resolve by passing the unique `type`.
+    const displayMatches = (store.subgraphBlueprints ?? []).filter(
+      (d) => typeof d?.display_name === "string" && d.display_name === name,
+    );
     let type = asType;
-    let bp;
+    let bp = null;
+    let lookupError = null;
     try {
       bp = store.getBlueprint(type);
-    } catch {
-      bp = null;
+    } catch (err) {
+      // Kept, not discarded: if nothing resolves, a real store failure must not be
+      // reported as "you never saved this" (codex).
+      lookupError = err;
     }
     if (!bp) {
-      const viaDisplay = byDisplayName();
+      if (displayMatches.length > 1) {
+        throw new Error(
+          `"${name}" matches ${displayMatches.length} saved subgraphs with that library ` +
+            `name, so adding one would be a guess. Pass the unique \`type\` instead — ` +
+            `panel_list_subgraphs reports it for each.`,
+        );
+      }
+      const viaDisplay =
+        typeof displayMatches[0]?.name === "string" ? displayMatches[0].name : null;
       if (viaDisplay) {
         type = viaDisplay;
         try {
           bp = store.getBlueprint(type);
-        } catch {
-          bp = null;
+        } catch (err) {
+          lookupError = err;
         }
       }
     }
@@ -13156,7 +13168,10 @@ const GRAPH_TOOL_EXECUTORS = {
       throw new Error(
         `No saved subgraph blueprint "${name}" — neither as a blueprint type nor as the ` +
           `name shown in the library. List them with panel_list_subgraphs and use either ` +
-          `the \`type\` or the \`display_name\` it reports.`,
+          `the \`type\` or the \`display_name\` it reports.` +
+          // A store that THREW is a different fact from one that simply has no such
+          // blueprint, and the caller cannot act on the second remedy if it was the first.
+          (lookupError ? ` (the lookup also failed: ${coerceMessageText(lookupError?.message ?? lookupError)})` : ""),
       );
     }
     const position = placementFor(graph, pos);

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -13114,16 +13114,49 @@ const GRAPH_TOOL_EXECUTORS = {
     if (!name || typeof name !== "string") throw new Error("name (blueprint name or type) is required");
     const store = getSubgraphStore();
     const prefix = store.typePrefix ?? "SubgraphBlueprint.";
-    const type = name.startsWith(prefix) ? name : `${prefix}${name}`;
     if (typeof store.getBlueprint !== "function") {
       throw new Error("subgraph store does not expose getBlueprint on this frontend");
     }
+    // #636 — RESOLVE THE NAME THE USER CAN SEE. Blueprints are keyed by a content hash on
+    // current ComfyUI (measured: 89 of 91 named `SubgraphBlueprint.<hash>`, the typed name
+    // in `display_name`, and `typePrefix` absent so the literal fallback above is what is
+    // used). Building the type as prefix+name therefore resolved to nothing for the ONLY
+    // name a user or agent would think to use — the one the library shows — while the
+    // opaque hash worked. Same root cause as the collision preflight fixed in 0.11.71.
+    //
+    // Order matters: the caller's string is tried AS a type first, so an exact type or a
+    // hash keeps resolving exactly as before and this can only ever add a resolution that
+    // previously failed. Only if that finds nothing is `display_name` consulted.
+    const asType = name.startsWith(prefix) ? name : `${prefix}${name}`;
+    const byDisplayName = () => {
+      const match = (store.subgraphBlueprints ?? []).find(
+        (d) => typeof d?.display_name === "string" && d.display_name === name,
+      );
+      return typeof match?.name === "string" ? match.name : null;
+    };
+    let type = asType;
     let bp;
     try {
       bp = store.getBlueprint(type);
-    } catch (err) {
+    } catch {
+      bp = null;
+    }
+    if (!bp) {
+      const viaDisplay = byDisplayName();
+      if (viaDisplay) {
+        type = viaDisplay;
+        try {
+          bp = store.getBlueprint(type);
+        } catch {
+          bp = null;
+        }
+      }
+    }
+    if (!bp) {
       throw new Error(
-        `No saved subgraph blueprint "${name}" (${coerceMessageText(err?.message ?? err)}). List them with panel_list_subgraphs.`,
+        `No saved subgraph blueprint "${name}" — neither as a blueprint type nor as the ` +
+          `name shown in the library. List them with panel_list_subgraphs and use either ` +
+          `the \`type\` or the \`display_name\` it reports.`,
       );
     }
     const position = placementFor(graph, pos);


### PR DESCRIPTION
Same root cause as the preflight fix released in 0.11.71, on the neighbouring path.

`graph_add_subgraph(name)` builds `${prefix}${name}` and calls `store.getBlueprint(type)`.
On ComfyUI 0.31 the real type is `SubgraphBlueprint.<content hash>`, so the human name —
the one shown in the library and the only one a user or agent would think to use —
resolves to nothing and the add fails with *"No saved subgraph blueprint"*.

`graph_list_subgraphs` compounds it: it reports `name` as the prefix-stripped type, which
on this frontend is the **hash**, with the human name separately in `display_name`. So
the documented "list them, then add by name" loop hands back an opaque hash, and the
recognisable name is the one thing that does not work.

Draft while I confirm the resolution order and that adding by hash still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)