### PR TITLE
0.11.72 — add a saved subgraph by the name shown in the library (#636)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,29 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+## [0.11.72] - 2026-08-09
+
+> Covers changes since 0.11.71.
+
+### Fixed
+
+- **You can add a saved subgraph by the name you see in the library (#636).** Asking for
+  one by its name failed with *"No saved subgraph blueprint"*, because current ComfyUI
+  stores them under a generated id and the panel only looked for that. The name shown in
+  the library — the only one you'd think to use — was the one thing that didn't work,
+  while the unreadable id did.
+
+  It now accepts either. The id is still tried first, so nothing that already worked
+  changes.
+
+  If two saved subgraphs share the same library name, it says so and asks for the id
+  instead of picking one. Adding the wrong graph quietly is worse than being asked to be
+  specific. And if the lookup itself fails, the error says that rather than claiming you
+  never saved it.
+
+  Same cause as the name-clash fix in 0.11.71. Updating an existing saved subgraph is
+  still not possible from the agent — that part of the report remains open.
+
 ## [0.11.71] - 2026-08-09
 
 > Covers changes since 0.11.70.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-agent-panel"
 description = "Autonomous AI agent in the ComfyUI sidebar - local-first, bring any LLM. Run it on your Claude or ChatGPT subscription (no API keys, no extra LLM costs), on a Kimi K3 / GLM / OpenRouter key, or fully offline on free local models via Ollama, LM Studio, or llama.cpp. The agent drives your live canvas at full parity: add, wire, move and tweak nodes with Ctrl+Z undo, load whole workflows and installer packs in one shot, generate images, video and audio, browse CivitAI, and run your workflow - asking before it spends paid API credits. The sidebar UI for comfyui-mcp, the local-first, agent-native control plane for ComfyUI."
-version = "0.11.71"
+version = "0.11.72"
 license = { file = "LICENSE" }
 requires-python = ">=3.9"
 # UI-only pack: no Python deps. The frontend floor guarantees

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -879,7 +879,7 @@ const DOCS_URL = "https://comfyui-mcp.artokun.io/docs";
 // Panel version — surfaced in the "Need help?" diagnostics blob. Bump via
 // `node scripts/set-version.mjs <v>` (updates this AND pyproject together); CI
 // and the publish gate FAIL if the two ever drift, so this can't go stale.
-const PANEL_VERSION = "0.11.71";
+const PANEL_VERSION = "0.11.72";
 
 // The connected orchestrator's console URL/token (captured off the `backends`
 // bridge message — see onBackends). Drives the "API Keys" credentials frame;


### PR DESCRIPTION
Releases #918.

Same root cause as 0.11.71, on the neighbouring path: blueprints are keyed by a content
hash, so `graph_add_subgraph` resolving `prefix + name` failed for the human name and
worked only for the opaque id.

Verified live against the real store on merged main: for an actual blueprint
(`"Image to Pose Map (SDPose-OOD)"`), the old predicate matches **false** and the new one
**true**.

Per codex, an ambiguous library name refuses rather than guessing — a wrong subgraph
silently added is worse than being asked for the unique type — and a store error is no
longer reported as "never saved".

🤖 Generated with [Claude Code](https://claude.com/claude-code)