### PR TITLE
fix(subgraph): is_global was false for every blueprint (#636)

### DIFF
--- a/browser_tests/unit/blueprint-collision.test.mjs
+++ b/browser_tests/unit/blueprint-collision.test.mjs
@@ -170,3 +170,16 @@ test("#636: an unavailable predicate reports null, never false", () => {
   assert.match(listSite, /isGlobal = null;/, "and a throw returns to null");
   assert.doesNotMatch(listSite, /isGlobal = false/, "absence must never be reported as user-owned");
 });
+
+test("#636: an unrecognised prefix does not get asked at all", () => {
+  // `prefix` is a fallback — the measured frontend exposes no typePrefix — so a type that
+  // does not start with it leaves the name UNSTRIPPED, and the predicate would answer
+  // `false` for a question it was never asked properly. That is indistinguishable from a
+  // real user blueprint, and nothing at runtime can detect the disagreement, so the only
+  // honest answer is null (codex).
+  assert.match(
+    listSite,
+    /type\.startsWith\(prefix\) && typeof store\.isGlobalBlueprint === "function"/,
+    "the predicate must be gated on the prefix having matched",
+  );
+});

--- a/browser_tests/unit/blueprint-collision.test.mjs
+++ b/browser_tests/unit/blueprint-collision.test.mjs
@@ -138,3 +138,35 @@ test("#636: a real store failure is not reported as 'never saved'", () => {
   assert.match(site, /lookupError = err;/, "the thrown error must be kept");
   assert.match(site, /the lookup also failed/, "and surfaced when nothing resolves");
 });
+
+// ── is_global was false for every blueprint ────────────────────────────────
+
+const listStart = src.indexOf("const blueprints = [...defs].map((d) => {");
+const listSite = src.slice(listStart, src.indexOf("});", src.indexOf("is_global: isGlobal")) + 3);
+
+test("#636: is_global asks the STORE, not a property that does not exist", () => {
+  // It read `d?.isGlobal === true`. A blueprint's keys are name, display_name, category,
+  // main_category, python_module, description, help, deprecated — no isGlobal — so the
+  // field was always false, asserting "user blueprint" for every bundled one.
+  assert.ok(listSite.length > 0, "the list mapper must exist");
+  // The dead READ, not any mention of it — the comment above the fix quotes the old
+  // expression on purpose, so the assertion has to name the assignment.
+  assert.doesNotMatch(listSite, /is_global: d\?\.isGlobal/, "the dead property read must be gone");
+  assert.match(listSite, /store\.isGlobalBlueprint\(bare\)/, "the store predicate must be asked");
+});
+
+test("#636: it passes the PREFIX-STRIPPED name, as ComfyUI itself does", () => {
+  // subgraphStore.isGlobalBlueprint(name.slice(BLUEPRINT_TYPE_PREFIX.length)) — passing
+  // the object instead is what made an earlier probe answer false for everything and
+  // look correct.
+  assert.match(listSite, /const bare = type\.startsWith\(prefix\)/, "the name must be stripped");
+  assert.match(listSite, /isGlobalBlueprint\(bare\)/, "and the stripped form passed");
+});
+
+test("#636: an unavailable predicate reports null, never false", () => {
+  // "This frontend cannot tell me" and "this is a user blueprint" are different answers,
+  // and asserting the second in place of the first IS the defect being fixed.
+  assert.match(listSite, /let isGlobal = null;/, "unknown starts as null");
+  assert.match(listSite, /isGlobal = null;/, "and a throw returns to null");
+  assert.doesNotMatch(listSite, /isGlobal = false/, "absence must never be reported as user-owned");
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -13088,12 +13088,35 @@ const GRAPH_TOOL_EXECUTORS = {
     const defs = store.subgraphBlueprints ?? [];
     const blueprints = [...defs].map((d) => {
       const type = d?.name ?? "";
+      const bare = type.startsWith(prefix) ? type.slice(prefix.length) : type;
+      // #636 — ASK THE STORE. This read `d?.isGlobal === true`, and a blueprint carries no
+      // such property (its keys are name, display_name, category, main_category,
+      // python_module, description, help, deprecated), so the field was ALWAYS false —
+      // reporting a confident "user blueprint" for every bundled one. The store answers it
+      // with a predicate, and ComfyUI's own call site shows what it wants:
+      //
+      //     subgraphStore.isGlobalBlueprint(name.slice(BLUEPRINT_TYPE_PREFIX.length))
+      //
+      // the PREFIX-STRIPPED name, not the object. Passing the object is what made an
+      // earlier probe of mine answer false for everything and look correct.
+      //
+      // `null` when the predicate is absent or throws, NOT false: "this frontend cannot
+      // tell me" and "this is a user blueprint" are different answers, and the whole
+      // defect here was the second being asserted in place of the first.
+      let isGlobal = null;
+      try {
+        if (typeof store.isGlobalBlueprint === "function") {
+          isGlobal = store.isGlobalBlueprint(bare) === true;
+        }
+      } catch {
+        isGlobal = null;
+      }
       return {
-        name: type.startsWith(prefix) ? type.slice(prefix.length) : type,
+        name: bare,
         type,
         display_name: d?.display_name ?? null,
         description: d?.description ?? null,
-        is_global: d?.isGlobal === true,
+        is_global: isGlobal,
       };
     });
     // #690(5) — bounded like every other panel read. `count` stays the LIBRARY

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -13103,9 +13103,15 @@ const GRAPH_TOOL_EXECUTORS = {
       // `null` when the predicate is absent or throws, NOT false: "this frontend cannot
       // tell me" and "this is a user blueprint" are different answers, and the whole
       // defect here was the second being asserted in place of the first.
+      // ONLY when the prefix actually matched (codex). `prefix` is a FALLBACK — the
+      // measured frontend exposes no `typePrefix` — so a type that does not start with it
+      // leaves `bare` unstripped, and passing that yields a `false` indistinguishable from
+      // a real user blueprint. A predicate cannot report "you asked me the wrong
+      // question", and nothing at runtime can detect the disagreement, so the only honest
+      // answer for an unrecognised prefix is null.
       let isGlobal = null;
       try {
-        if (typeof store.isGlobalBlueprint === "function") {
+        if (type.startsWith(prefix) && typeof store.isGlobalBlueprint === "function") {
           isGlobal = store.isGlobalBlueprint(bare) === true;
         }
       } catch {


### PR DESCRIPTION
Fifth defect on this surface, same measurement.

`graph_list_subgraphs` reports `is_global: d?.isGlobal === true`, but a blueprint carries
no such property — the live keys are `name, display_name, category, main_category,
python_module, description, help, deprecated`. So the field is **always false**, and an
agent cannot tell a bundled blueprint from one the user saved.

I could not fix this last round because I did not know what `isGlobalBlueprint` expects —
my probe passed the object and got `false` for everything, which is indistinguishable
from a correct answer. ComfyUI's own call site settles it:

```js
subgraphStore.isGlobalBlueprint(name.slice(BLUEPRINT_TYPE_PREFIX.length))
```

It takes the **prefix-stripped name**. Read from the frontend sourcemap rather than
inferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)