### PR TITLE
0.11.73 — the saved-subgraph list stops claiming every blueprint is yours (#636)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+## [0.11.73] - 2026-08-09
+
+> Covers changes since 0.11.72.
+
+### Fixed
+
+- **The saved-subgraph list no longer claims every blueprint is yours (#636).** Listing
+  saved subgraphs reported `is_global: false` for all of them — including the ones
+  ComfyUI ships — because it read a property blueprints do not have. The agent had no way
+  to tell a bundled subgraph from one you saved.
+
+  It now asks ComfyUI, using the same call ComfyUI's own library menu uses. Where that
+  answer can't be trusted — an older frontend, or one that names blueprints in a shape
+  the panel doesn't recognise — the field is `null` rather than a guess. "I can't tell"
+  and "this one is yours" are different answers, and reporting the second in place of the
+  first is exactly what was wrong before.
+
 ## [0.11.72] - 2026-08-09
 
 > Covers changes since 0.11.71.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-agent-panel"
 description = "Autonomous AI agent in the ComfyUI sidebar - local-first, bring any LLM. Run it on your Claude or ChatGPT subscription (no API keys, no extra LLM costs), on a Kimi K3 / GLM / OpenRouter key, or fully offline on free local models via Ollama, LM Studio, or llama.cpp. The agent drives your live canvas at full parity: add, wire, move and tweak nodes with Ctrl+Z undo, load whole workflows and installer packs in one shot, generate images, video and audio, browse CivitAI, and run your workflow - asking before it spends paid API credits. The sidebar UI for comfyui-mcp, the local-first, agent-native control plane for ComfyUI."
-version = "0.11.72"
+version = "0.11.73"
 license = { file = "LICENSE" }
 requires-python = ">=3.9"
 # UI-only pack: no Python deps. The frontend floor guarantees

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -879,7 +879,7 @@ const DOCS_URL = "https://comfyui-mcp.artokun.io/docs";
 // Panel version — surfaced in the "Need help?" diagnostics blob. Bump via
 // `node scripts/set-version.mjs <v>` (updates this AND pyproject together); CI
 // and the publish gate FAIL if the two ever drift, so this can't go stale.
-const PANEL_VERSION = "0.11.72";
+const PANEL_VERSION = "0.11.73";
 
 // The connected orchestrator's console URL/token (captured off the `backends`
 // bridge message — see onBackends). Drives the "API Keys" credentials frame;


### PR DESCRIPTION
Releases #921. Fifth defect found on this surface by enumerating the live store.

`is_global` read a property blueprints do not have, so it was always `false` — asserting
"user blueprint" for every bundled one. It now asks `isGlobalBlueprint` with the
prefix-stripped name, which is what ComfyUI's own library menu passes, and reports
`null` rather than a guess when the prefix is unrecognised or the predicate is absent.

Codex reviewed twice: blocked an unstripped name reaching the predicate (a `false` there
is indistinguishable from a real answer), then cleared the output-contract concern once I
checked the installed orchestrator — `is_global` appears only in description prose, which
guarantees presence and not type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)