### PR TITLE
fix(subgraph): do not advise deleting a blueprint ComfyUI refuses to delete (#636)

### DIFF
--- a/browser_tests/unit/blueprint-collision.test.mjs
+++ b/browser_tests/unit/blueprint-collision.test.mjs
@@ -183,3 +183,27 @@ test("#636: an unrecognised prefix does not get asked at all", () => {
     "the predicate must be gated on the prefix having matched",
   );
 });
+
+// ── the refusal must not advise an impossible remedy ───────────────────────
+
+const refusalSite = src.slice(
+  src.indexOf("let collisionIsGlobal = false;"),
+  src.indexOf("await store.publishSubgraph(finalName);"),
+);
+
+test("#636: a GLOBAL collision is not told to delete it", () => {
+  // subgraphStore.deleteBlueprint refuses a bundled blueprint outright, so "delete it and
+  // retry" is unfollowable — and on a stock install most blueprints are global, making it
+  // the likeliest collision.
+  assert.ok(refusalSite.length > 0, "the refusal must classify the collision");
+  assert.match(refusalSite, /ships WITH ComfyUI/, "it must say why the name cannot be freed");
+  assert.match(refusalSite, /Save under a different one/, "and give the one remedy that works");
+});
+
+test("#636: UNKNOWN is not treated as global", () => {
+  // Only a positive true narrows the remedy. An older frontend or unreadable predicate
+  // keeps the existing wording rather than withholding an option that may well work.
+  assert.match(refusalSite, /=== true;/, "globality must be a positive test");
+  assert.match(refusalSite, /collisionIsGlobal = false;/, "and anything else falls back");
+  assert.match(refusalSite, /startsWith\(prefix\)/, "with the same prefix gate as the listing");
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -13026,11 +13026,39 @@ const GRAPH_TOOL_EXECUTORS = {
     const beforeKeys = new Set(before.map((d) => d?.name));
     const collision = before.find(matchesRequested);
     if (collision) {
+      // #636 — DON'T SEND THEM AFTER A BLUEPRINT COMFYUI WON'T DELETE. The remedy below
+      // used to say "delete it from the library and retry" unconditionally, and
+      // subgraphStore.deleteBlueprint refuses a global/bundled one outright:
+      //
+      //     if (isGlobalBlueprint(name)) { toast(cannotDeleteGlobal); return }
+      //
+      // On a stock install the overwhelming majority of blueprints are global (89 of 91
+      // measured here), so the collision most likely to happen is exactly the one where
+      // that advice cannot be followed — the user goes looking for a delete that is not
+      // offered, and the message has suggested nothing else.
+      //
+      // Unknown is not global: only a POSITIVE true narrows the remedy, so an older
+      // frontend or an unreadable predicate keeps the existing wording rather than
+      // withholding an option that may well work.
+      let collisionIsGlobal = false;
+      try {
+        const collidedBare = bareName(collision);
+        collisionIsGlobal =
+          typeof store.isGlobalBlueprint === "function" &&
+          String(collision?.name ?? "").startsWith(prefix) &&
+          store.isGlobalBlueprint(collidedBare) === true;
+      } catch {
+        collisionIsGlobal = false;
+      }
       throw new Error(
         `a subgraph blueprint named "${finalName}" already exists (type "${collision.name}") and this ` +
           `tool will not replace it — replacing one programmatically would need ComfyUI's overwrite ` +
-          `dialog, which cannot be answered from here. Either save under a different name, or delete ` +
-          `"${finalName}" from the subgraph library in the ComfyUI UI first and then retry this call.`,
+          `dialog, which cannot be answered from here. ` +
+          (collisionIsGlobal
+            ? `That one ships WITH ComfyUI, and ComfyUI refuses to delete a bundled blueprint — so ` +
+              `there is no way to free the name. Save under a different one.`
+            : `Either save under a different name, or delete "${finalName}" from the subgraph library ` +
+              `in the ComfyUI UI first and then retry this call.`),
       );
     }
     await store.publishSubgraph(finalName);


### PR DESCRIPTION
`graph_save_subgraph` refuses a name collision with: *"delete `<name>` from the subgraph
library in the ComfyUI UI first and then retry"*.

Measured in `subgraphStore.deleteBlueprint`:

```js
if (isGlobalBlueprint(name)) { useToastStore().add({ ...cannotDeleteGlobal }); return }
```

**ComfyUI refuses to delete a global/bundled blueprint.** On this install **89 of 91** are
global — so the collision most likely to happen is exactly the one where the advice
cannot be followed. The user goes to the library, finds no way to remove it, and the
message has offered nothing else.

The panel can now tell them apart: 0.11.73 wired `isGlobalBlueprint` correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)