### PR TITLE
0.11.74 — the subgraph name-clash refusal stops advising an impossible fix (#636)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+## [0.11.74] - 2026-08-09
+
+> Covers changes since 0.11.73.
+
+### Fixed
+
+- **Saving a subgraph over a built-in name no longer sends you looking for a delete
+  button that isn't there (#636).** When the name clashes, the panel refuses and suggests
+  deleting the existing one from ComfyUI's library. But ComfyUI won't delete the
+  subgraphs it ships with — and on a stock install nearly all of them are its own, so the
+  clash you're most likely to hit is the one where that advice can't be followed.
+
+  It now recognises a built-in and says the name can't be freed, so the only thing left is
+  to pick a different one. Clashes with a subgraph you saved yourself still suggest
+  deleting it, and so does any case where the panel can't tell — withholding an option
+  that might work is worse than offering one you'd rule out in seconds.
+
 ## [0.11.73] - 2026-08-09
 
 > Covers changes since 0.11.72.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-agent-panel"
 description = "Autonomous AI agent in the ComfyUI sidebar - local-first, bring any LLM. Run it on your Claude or ChatGPT subscription (no API keys, no extra LLM costs), on a Kimi K3 / GLM / OpenRouter key, or fully offline on free local models via Ollama, LM Studio, or llama.cpp. The agent drives your live canvas at full parity: add, wire, move and tweak nodes with Ctrl+Z undo, load whole workflows and installer packs in one shot, generate images, video and audio, browse CivitAI, and run your workflow - asking before it spends paid API credits. The sidebar UI for comfyui-mcp, the local-first, agent-native control plane for ComfyUI."
-version = "0.11.73"
+version = "0.11.74"
 license = { file = "LICENSE" }
 requires-python = ">=3.9"
 # UI-only pack: no Python deps. The frontend floor guarantees

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -879,7 +879,7 @@ const DOCS_URL = "https://comfyui-mcp.artokun.io/docs";
 // Panel version — surfaced in the "Need help?" diagnostics blob. Bump via
 // `node scripts/set-version.mjs <v>` (updates this AND pyproject together); CI
 // and the publish gate FAIL if the two ever drift, so this can't go stale.
-const PANEL_VERSION = "0.11.73";
+const PANEL_VERSION = "0.11.74";
 
 // The connected orchestrator's console URL/token (captured off the `backends`
 // bridge message — see onBackends). Drives the "API Keys" credentials frame;


### PR DESCRIPTION
Releases #923.

The collision refusal said, unconditionally, to delete the existing blueprint from the
ComfyUI library. `subgraphStore.deleteBlueprint` refuses a bundled one outright — and 89
of 91 blueprints on a stock install are bundled, so the likeliest collision was exactly
the one where the advice could not be followed.

A positively-identified global collision now says the name cannot be freed. Unknown keeps
the existing advice, gated on the same prefix check as 0.11.73.

Codex SHIP on the first pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)