### PR TITLE
fix(install): send the repository URL instead of a registry id (#920)

### DIFF
--- a/browser_tests/unit/manager-dialect.test.mjs
+++ b/browser_tests/unit/manager-dialect.test.mjs
@@ -1000,3 +1000,48 @@ test("#605: nodes_install legacy-on-legacy unreachable surfaces the original err
   );
   assert.deepEqual(calls, ["manager/queue/install"], "the rejected submit is not repeated");
 });
+
+// ── #920: a repository URL must reach Manager, not be reduced to an id ──────
+//
+// buildInstallRequest's v2 git branch sent `id: gitRepoName(url)` and dropped the URL, so
+// a from-source install became a registry lookup and Manager answered:
+//
+//   Node 'ComfyUI-SolAttn_triton@nightly' not found in
+//     [ManagerChannel.dev, ManagerDatabaseSource.cache]
+//
+// both sources being that branch's own channel:"dev" and mode:"cache" defaults.
+//
+// The field is read from Manager's installed model, not inferred:
+//
+//   class InstallPackParams(ManagerPackInfo):
+//     repository: Optional[str] = Field(
+//       None, description="GitHub repository URL (required if selected_version is nightly)")
+
+const GIT_URL = "https://github.com/kijai/ComfyUI-SolAttn_triton.git";
+
+test("#920: a repository-only nightly install carries the URL", () => {
+  const req = ManagerInstall.buildInstallRequest("v2", { repository: GIT_URL, version: "nightly" }, "u-1");
+  assert.equal(req.params.repository, GIT_URL, "the URL must reach Manager");
+  assert.equal(req.params.selected_version, "nightly", "and nightly is what makes it required");
+});
+
+test("#920: the id stays the derived NAME, not the URL", () => {
+  // Sending a URL as `id` made v4 silently mark the install done while doing nothing,
+  // which is why it was derived. That behaviour is preserved — this only stops the URL
+  // being discarded.
+  const req = ManagerInstall.buildInstallRequest("v2", { repository: GIT_URL, version: "nightly" }, "u-1");
+  assert.equal(req.params.id, "ComfyUI-SolAttn_triton");
+  assert.notEqual(req.params.id, GIT_URL);
+});
+
+test("#920: a URL passed as `id` is carried too — same routing, either field", () => {
+  const req = ManagerInstall.buildInstallRequest("v2", { id: GIT_URL, version: "nightly" }, "u-1");
+  assert.equal(req.params.repository, GIT_URL);
+  assert.equal(req.params.id, "ComfyUI-SolAttn_triton");
+});
+
+test("#920: a REGISTRY install is untouched — no repository field invented", () => {
+  const req = ManagerInstall.buildInstallRequest("v2", { id: "comfyui-impact-pack", version: "1.2.3" }, "u-1");
+  assert.equal(req.params.repository, undefined, "a non-git install must not carry one");
+  assert.equal(req.params.id, "comfyui-impact-pack");
+});

--- a/web/js/lib/manager-install.js
+++ b/web/js/lib/manager-install.js
@@ -89,6 +89,23 @@ export function buildInstallRequest(dialect, args = {}, ui_id) {
           id: gitRepoName(gitUrl),
           version: selected,
           selected_version: selected,
+          // #920 — SEND THE URL. Reducing it to `gitRepoName` and stopping there turned a
+          // from-source install into a registry lookup, and Manager answered
+          // "Node '<name>@nightly' not found in [ManagerChannel.dev,
+          // ManagerDatabaseSource.cache]" — both sources being the two defaults below.
+          //
+          // The field is not inferred. Manager's own model declares it:
+          //
+          //   class InstallPackParams(ManagerPackInfo):
+          //     repository: Optional[str] = Field(
+          //       None, description="GitHub repository URL (required if selected_version
+          //                          is nightly)")
+          //
+          // and "required if nightly" is exactly the reported call. `id` stays the derived
+          // NAME rather than the URL: sending a URL there made v4 silently mark the
+          // install done while doing nothing, which is why it was derived in the first
+          // place — that behaviour is preserved, this only stops discarding the URL.
+          repository: gitUrl,
           channel: channel || "dev",
           mode: mode || "cache",
         },

--- a/web/js/lib/manager-install.js
+++ b/web/js/lib/manager-install.js
@@ -69,9 +69,13 @@ export function installGitUrl({ id, repository } = {}) {
  *
  * A git URL (via `id` OR `repository`, any recognized protocol) always routes to
  * the repo-name-as-id payload: v4 installs by {id: repoName, selected_version:
- * ref||"nightly", channel:"dev"} (no files — v4 resolves by CNR/repo name);
- * v2-batch + legacy install the URL natively via {id: repoName, version:
- * "unknown", files:[url]}. A registry id keeps the versioned body. `id` is
+ * ref||"nightly", channel:"dev", repository: url}. The `repository` half was missing
+ * and is #920 — without it v4 has only the NAME and resolves it against the registry,
+ * which is a lookup rather than a clone; Manager's own InstallPackParams documents the
+ * field as "required if selected_version is nightly". v2-batch + legacy install the URL
+ * natively via {id: repoName, version: "unknown", files:[url]} — a different shape whose
+ * handler reads files[0], so they were never missing it. A registry id keeps the
+ * versioned body and carries no `repository` at all. `id` is
  * NEVER a full URL (a full URL matches nothing on v4 → silent "done"; on 3.x it
  * fails LATER while resolving, past the immediate `failed` array).
  */


### PR DESCRIPTION
Closes #920.

`panel_install_node` with a `repository` URL and `version:"nightly"` queued a **registry
lookup** instead of a clone. `buildInstallRequest`'s v2 git branch reduced the URL to
`gitRepoName(gitUrl)` and dropped it, so Manager answered:

```
Node 'ComfyUI-SolAttn_triton@nightly' not found in [ManagerChannel.dev, ManagerDatabaseSource.cache]
```

Both sources named are that branch's own defaults (`channel:"dev"`, `mode:"cache"`), so
nothing else in the path could have produced that pair.

**The parameter is read, not guessed** — which is what blocked me on the first pass:

```python
class InstallPackParams(ManagerPackInfo):
    repository: Optional[str] = Field(
        None, description="GitHub repository URL (required if selected_version is nightly)")
```

That mattered: `params` is an untagged Pydantic union with `InstallPackParams` first, so a
guessed field name would be silently dropped and the install would fail identically with
no new signal. panel#809 is the scar from exactly that.

`id` still carries the derived name — sending a URL there made v4 silently mark the
install "done" while doing nothing. Codex confirmed the scoping: `v2-batch`/`legacy`
already carry the URL as `files:[url]`, whose handler reads `files[0]`.

Four regressions, mutation-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)