### PR TITLE
fix(install): send the repository URL Manager v4 requires for a nightly install (#920)

### DIFF
--- a/browser_tests/unit/install-repository-url.test.mjs
+++ b/browser_tests/unit/install-repository-url.test.mjs
@@ -1,0 +1,103 @@
+// panel#920 — `panel_install_node({repository:"https://github.com/kijai/ComfyUI-SolAttn_triton.git",
+// version:"nightly"})` queued a REGISTRY LOOKUP instead of a source install:
+//
+//   Node 'ComfyUI-SolAttn_triton@nightly' not found in
+//   [ManagerChannel.dev, ManagerDatabaseSource.cache]
+//
+// `buildInstallRequest`'s v2 branch reduced the URL to its basename via
+// gitRepoName() and never sent it. Manager got id:"ComfyUI-SolAttn_triton",
+// channel:"dev", mode:"cache" — which is exactly the pair the error names.
+//
+// WHY IT WAS WRITTEN THAT WAY, and why that reasoning does not extend here: a
+// full URL sent as `id` made Manager v4 silently mark the install "done" while
+// doing nothing, and made 3.x fail late. So the panel derives a name instead.
+// That is right for `id`. It is wrong when the caller supplied `repository`,
+// because then the URL IS the request and no registry entry exists to find.
+//
+// THE CONTRACT (not a guess — this is why the fix waited). Generated from the
+// Manager v4 API in Comfy-Org/ComfyUI_frontend,
+// src/workbench/extensions/manager/types/generatedManagerTypes.ts:
+//
+//   InstallPackParams: ManagerPackInfo & {
+//     selected_version: string | 'latest' | 'nightly'
+//     /** GitHub repository URL (required if selected_version is nightly) */
+//     repository?: string
+//     mode: ManagerDatabaseSource
+//     channel: ManagerChannel
+//     ...
+//   }
+//   ManagerPackInfo: {
+//     /** Either github-author/github-repo or name of pack from the registry */
+//     id: string
+//     version: string
+//   }
+//
+// The consequence this fixes: `repository` is REQUIRED for a nightly install and
+// was being dropped. `id` is left alone — see the note in the source.
+//
+// `params` is an UNTAGGED Pydantic union with InstallPackParams first, so a
+// guessed field would be dropped SILENTLY and the wrong model could win — that
+// is #809. Adding `repository` makes this payload match InstallPackParams more
+// specifically, which is the safe direction across that union.
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { buildInstallRequest } from "../../web/js/lib/manager-install.js";
+
+const URL_GIT = "https://github.com/kijai/ComfyUI-SolAttn_triton.git";
+
+// ---------------------------------------------------------------------------
+// 1. The report, end to end.
+// ---------------------------------------------------------------------------
+
+test("#920 a repository-only nightly install SENDS the url", () => {
+  const req = buildInstallRequest("v2", { repository: URL_GIT, version: "nightly" });
+
+  assert.equal(req.dialect, "v2");
+  assert.equal(req.params.repository, URL_GIT, "the URL must reach Manager — this is the fix");
+  assert.equal(req.params.selected_version, "nightly");
+  // `id` is UNCHANGED — still the repo name. Sending owner/repo instead looked
+  // right from ManagerPackInfo's description and broke #301's assertion that a
+  // bare shorthand must never be sent as `id`, which exists because of a real
+  // failure. The dropped URL is the proven bug; the id form is not, and is filed
+  // separately rather than bundled in here.
+  assert.equal(req.params.id, "ComfyUI-SolAttn_triton");
+});
+
+test("#920 the url is sent whether it arrives as `repository` or as `id`", () => {
+  // The tool documents both spellings, and the reporter's workaround was to move
+  // the URL into `id`. Both must now produce a source install.
+  for (const args of [{ repository: URL_GIT }, { id: URL_GIT }]) {
+    const req = buildInstallRequest("v2", { ...args, version: "nightly" });
+    assert.equal(req.params.repository, URL_GIT, JSON.stringify(args));
+    assert.equal(req.params.id, "ComfyUI-SolAttn_triton", JSON.stringify(args));
+  }
+});
+
+// ---------------------------------------------------------------------------
+// 2. The registry path must be untouched.
+// ---------------------------------------------------------------------------
+
+test("#920 a plain registry id still installs from the registry, with no repository", () => {
+  const req = buildInstallRequest("v2", { id: "comfyui-impact-pack", version: "1.2.3" });
+
+  assert.equal(req.params.id, "comfyui-impact-pack");
+  assert.equal(req.params.repository, undefined, "a registry install must not claim a repository");
+  assert.equal(req.params.mode, "remote");
+  assert.equal(req.params.channel, "default");
+});
+
+test("#920 the non-v2 dialects are unchanged — they install the URL natively", () => {
+  // v2-batch and legacy put the URL in `files`, which already worked. This fix
+  // must not disturb them.
+  for (const dialect of ["v2-batch", "legacy"]) {
+    const req = buildInstallRequest(dialect, { repository: URL_GIT }, "ui-1");
+    assert.deepEqual(req.body.files, [URL_GIT], dialect);
+    assert.equal(req.body.id, "ComfyUI-SolAttn_triton", `${dialect} keeps the repo name`);
+  }
+});
+
+// The owner/repo derivation that used to live here went with the helper: `id` is
+// unchanged by this fix, so a helper only its own tests exercised would be dead
+// code inviting someone to wire it without the empirical check that is missing.
+// Filed separately.

--- a/web/js/lib/manager-install.js
+++ b/web/js/lib/manager-install.js
@@ -69,11 +69,13 @@ export function installGitUrl({ id, repository } = {}) {
  *
  * A git URL (via `id` OR `repository`, any recognized protocol) always routes to
  * the repo-name-as-id payload: v4 installs by {id: repoName, selected_version:
- * ref||"nightly", channel:"dev"} (no files — v4 resolves by CNR/repo name);
- * v2-batch + legacy install the URL natively via {id: repoName, version:
- * "unknown", files:[url]}. A registry id keeps the versioned body. `id` is
- * NEVER a full URL (a full URL matches nothing on v4 → silent "done"; on 3.x it
- * fails LATER while resolving, past the immediate `failed` array).
+ * ref||"nightly", repository: url, channel:"dev"} (no files — that is a 3.x
+ * shape); v2-batch + legacy install the URL natively via {id: repoName, version:
+ * "unknown", files:[url]}. A registry id keeps the versioned body and carries NO
+ * repository. `id` is NEVER a full URL (a full URL matches nothing on v4 →
+ * silent "done"; on 3.x it fails LATER while resolving, past the immediate
+ * `failed` array) — the URL travels in `repository`, which is where v4's schema
+ * puts it and which it REQUIRES for a nightly install (#920).
  */
 export function buildInstallRequest(dialect, args = {}, ui_id) {
   const { id, version, repository, channel, mode, selected_version } = args;
@@ -82,6 +84,41 @@ export function buildInstallRequest(dialect, args = {}, ui_id) {
   if (dialect === "v2") {
     if (gitUrl) {
       const selected = selected_version || version || "nightly";
+      // #920 — SEND THE URL. Manager v4's InstallPackParams carries a
+      // `repository` field, and the v4 API's own generated schema says it is
+      // REQUIRED when `selected_version` is nightly:
+      //
+      //   InstallPackParams: ManagerPackInfo & {
+      //     selected_version: string | 'latest' | 'nightly'
+      //     /** GitHub repository URL (required if selected_version is nightly) */
+      //     repository?: string
+      //     ...
+      //   }
+      //
+      // (Comfy-Org/ComfyUI_frontend, manager/types/generatedManagerTypes.ts —
+      // generated FROM the v4 API, so this is the contract rather than a guess.
+      // Guessing is what #809 was: `params` is an UNTAGGED Pydantic union with
+      // InstallPackParams first, so unrecognised fields are dropped silently and
+      // the wrong model can win.)
+      //
+      // Dropping it did not merely lose detail — it turned a source install into
+      // a REGISTRY LOOKUP, which is why the report reads "not found in
+      // [ManagerChannel.dev, ManagerDatabaseSource.cache]": those are the
+      // channel/mode defaults immediately below. Adding `repository` makes this
+      // payload match InstallPackParams MORE specifically, which is the safe
+      // direction across that union.
+      //
+      // `id` is deliberately LEFT as the repo name. ManagerPackInfo describes it
+      // as "Either github-author/github-repo or name of pack from the registry",
+      // which reads as though owner/repo would be better — I changed it to that
+      // first, and it broke three existing tests, one of them #301's assertion
+      // that a bare `author/repo` SHORTHAND must never be sent as `id`. That
+      // assertion exists because of a real failure.
+      //
+      // A doc string is not evidence that v4 ACCEPTS the other form, and this
+      // change fixes a PROVEN bug (the dropped URL). Bundling an unproven id
+      // change into it would risk the installs that currently work to chase a
+      // description. Filed separately instead.
       return {
         dialect,
         envelope: "task",
@@ -89,6 +126,7 @@ export function buildInstallRequest(dialect, args = {}, ui_id) {
           id: gitRepoName(gitUrl),
           version: selected,
           selected_version: selected,
+          repository: gitUrl,
           channel: channel || "dev",
           mode: mode || "cache",
         },


### PR DESCRIPTION
Fixes #920.

`panel_install_node({repository:"https://github.com/kijai/ComfyUI-SolAttn_triton.git", version:"nightly"})` queued a **registry lookup** instead of a source install, and failed with:

```
Node 'ComfyUI-SolAttn_triton@nightly' not found in [ManagerChannel.dev, ManagerDatabaseSource.cache]
```

`buildInstallRequest`'s v2 branch reduces the URL to its basename via `gitRepoName()` and never sends it. Manager receives `id:"ComfyUI-SolAttn_triton"`, `channel:"dev"`, `mode:"cache"` — which is exactly the pair the error names.

## The blocking unknown is now answered

I previously left this unfixed because I did not know Manager v4's source-install parameter, and guessing at `QueueTaskItem.params` — an **untagged** Pydantic union — is how #809 happened (extra fields silently dropped, wrong model selected).

The authoritative shape is generated from the Manager v4 API in `Comfy-Org/ComfyUI_frontend`, `src/workbench/extensions/manager/types/generatedManagerTypes.ts`:

```ts
InstallPackParams: ManagerPackInfo & {
  selected_version: string | 'latest' | 'nightly'
  /** GitHub repository URL (required if selected_version is nightly) */
  repository?: string
  pip?: string[]
  mode: ManagerDatabaseSource
  channel: ManagerChannel
  skip_post_install?: boolean
}

ManagerPackInfo: {
  /** Either github-author/github-repo or name of pack from the registry */
  id: string
  version: string
  ui_id?: string
}
```

Two things follow, and the current code gets **both** wrong:

1. **`repository` is an accepted field and is REQUIRED when `selected_version` is `nightly`.** Dropping it does not degrade the request — it guarantees failure for exactly the call in this report.
2. **`id` should be `github-author/github-repo`**, per its own description — not the bare basename the panel derives. `kijai/ComfyUI-SolAttn_triton`, not `ComfyUI-SolAttn_triton`.

This also means adding `repository` makes the payload match `InstallPackParams` *more* specifically rather than less, which is the safe direction across that untagged union.

## Status

Draft — implementation and the regression test the reporter asked for to follow. What this must prove: a repository-only request sends the URL through, `id` carries the owner, and the registry path for a plain pack id is unchanged.