### PR TITLE
0.11.75 — installing a custom node from a GitHub URL clones it again (#920)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+## [0.11.75] - 2026-08-10
+
+> Covers changes since 0.11.74.
+
+### Fixed
+
+- **Installing a custom node from a GitHub URL actually clones it now (#920).** Passing a
+  repository URL queued a search of the node registry instead, and failed with
+  *"Node 'ComfyUI-SolAttn_triton@nightly' not found"* — because the panel reduced your URL
+  to just the repo's name and threw the rest away, leaving ComfyUI-Manager nothing to
+  clone from.
+
+  The URL is now passed through. Manager's own install parameters require it for a
+  nightly install, which is the case this was reported against.
+
+  The workaround of putting the URL in `id` instead still works and is unchanged.
+
 ## [0.11.74] - 2026-08-09
 
 > Covers changes since 0.11.73.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-agent-panel"
 description = "Autonomous AI agent in the ComfyUI sidebar - local-first, bring any LLM. Run it on your Claude or ChatGPT subscription (no API keys, no extra LLM costs), on a Kimi K3 / GLM / OpenRouter key, or fully offline on free local models via Ollama, LM Studio, or llama.cpp. The agent drives your live canvas at full parity: add, wire, move and tweak nodes with Ctrl+Z undo, load whole workflows and installer packs in one shot, generate images, video and audio, browse CivitAI, and run your workflow - asking before it spends paid API credits. The sidebar UI for comfyui-mcp, the local-first, agent-native control plane for ComfyUI."
-version = "0.11.74"
+version = "0.11.75"
 license = { file = "LICENSE" }
 requires-python = ">=3.9"
 # UI-only pack: no Python deps. The frontend floor guarantees

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -879,7 +879,7 @@ const DOCS_URL = "https://comfyui-mcp.artokun.io/docs";
 // Panel version — surfaced in the "Need help?" diagnostics blob. Bump via
 // `node scripts/set-version.mjs <v>` (updates this AND pyproject together); CI
 // and the publish gate FAIL if the two ever drift, so this can't go stale.
-const PANEL_VERSION = "0.11.74";
+const PANEL_VERSION = "0.11.75";
 
 // The connected orchestrator's console URL/token (captured off the `backends`
 // bridge message — see onBackends). Drives the "API Keys" credentials frame;


### PR DESCRIPTION
Releases #926. The URL was reduced to a repo name and dropped, turning a from-source install into a registry lookup. Manager's own InstallPackParams requires `repository` for a nightly install; it is now sent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)