### PR TITLE
fix(subgraph): a rail id is not a missing node (comfyui-mcp#1294)

### DIFF
--- a/browser_tests/unit/node-scope-locator.test.mjs
+++ b/browser_tests/unit/node-scope-locator.test.mjs
@@ -132,7 +132,7 @@ test("WIRING: resolveNode builds its error through describeMissingNode", async (
   // at source. Without it every one of them reverts to the bare message.
   const { readFile } = await import("node:fs/promises");
   const src = await readFile(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8");
-  assert.match(src, /import \{ describeMissingNode \} from "\.\/lib\/node-scope-locator\.js";/);
+  assert.match(src, /import \{ describeMissingNode(?:, describeRailNodeTarget)? \} from "\.\/lib\/node-scope-locator\.js";/);
   const fn = src.slice(src.indexOf("function resolveNode(graph, nodeId) {"));
   const body = fn.slice(0, fn.indexOf("function normalizeLegacyNodeId"));
   assert.ok(body.includes("describeMissingNode(nodeId, rootGraph, viewingRoot)"),

--- a/browser_tests/unit/rail-id-diagnosis.test.mjs
+++ b/browser_tests/unit/rail-id-diagnosis.test.mjs
@@ -45,27 +45,40 @@ test("the reporter's id resolves as a rail — so 'no such node' was never true"
   assert.equal(found.rail, "output");
 });
 
-test("says what the id IS, and that it exists", () => {
+test("says what the id IS, and where it resolved", () => {
   const msg = describeRailNodeTarget(-20, "output");
   assert.match(msg, /OUTPUT BOUNDARY RAIL/);
   assert.match(msg, /rails\.output\.rail_node_id/);
-  assert.match(msg, /not a stale or foreign id/);
+  assert.match(msg, /in the graph you are viewing/);
 });
 
-test("drops all three false claims", () => {
+test("drops the false claims — WITHOUT replacing them with a new one", () => {
   const msg = describeRailNodeTarget(-20, "output");
-  assert.ok(!/different workflow/.test(msg), "the id came from this graph");
-  assert.ok(!/was removed/.test(msg), "nothing was removed");
-  assert.ok(
-    !/Re-read with panel_graph_outline/.test(msg),
-    "re-reading returns the same id — that is the loop the reporter ran",
-  );
+  assert.ok(!/may be from a different workflow/.test(msg), "the id came from this graph");
+  assert.ok(!/the node was removed/.test(msg), "nothing was removed");
+  // The first draft asserted "this is not a stale or foreign id". It cannot know
+  // that (codex review): node ids are arbitrary integers, so an ordinary node may
+  // once have held this id and been deleted. The message reports what RESOLVED and
+  // leaves the one case it cannot rule out standing.
+  assert.ok(!/not a stale or foreign id/.test(msg), "an unprovable claim");
 });
 
-test("names what DOES accept a rail id, rather than only refusing", () => {
+test("keeps the re-read remedy available for the case it IS right for", () => {
   const msg = describeRailNodeTarget(-20, "output");
-  assert.match(msg, /panel_move_node/);
-  assert.match(msg, /move_rail/);
+  // Not as the headline — prescribing it for a rail_node_id is the loop the
+  // reporter ran — but a stale ordinary id that collides with a rail is real, and
+  // for that caller re-reading is exactly right.
+  assert.match(msg, /If you meant an ORDINARY node with this id/);
+  assert.match(msg, /re-read\s+panel_graph_outline if that is your case/);
+});
+
+test("names what accepts a rail id — and how each one actually takes it", () => {
+  const msg = describeRailNodeTarget(-20, "output");
+  // panel_move_node takes the ID (pos only); panel_move_rail takes the SIDE. Saying
+  // "both accept rail ids" would send a caller to pass -20 to a tool whose schema is
+  // rail:"input"|"output" — verified against the registration, not assumed.
+  assert.match(msg, /panel_move_node DOES accept a rail id, but only to reposition it/);
+  assert.match(msg, /panel_move_rail addresses the same rail by SIDE/);
 });
 
 test("does NOT invent an unexpose tool — that half is parked", () => {

--- a/browser_tests/unit/rail-id-diagnosis.test.mjs
+++ b/browser_tests/unit/rail-id-diagnosis.test.mjs
@@ -1,0 +1,123 @@
+// artokun/comfyui-mcp#1294 — the read surface hands out an id the write surface
+// called foreign.
+//
+// `panel_query_graph` reports a subgraph's boundary rails as
+// `rails.output.rail_node_id: "-20"`. Feeding that straight back to a write got:
+//
+//     No node with id -20 in the current graph — and it is not in any other scope
+//     either (searched the root graph and 4 subgraph(s)). The id may be from a
+//     different workflow, or the node was removed. Re-read with panel_graph_outline
+//     before retrying.
+//
+// Every clause after the first is false. The id came from THIS graph, from our own
+// read, one call earlier; nothing was removed; and the prescribed remedy re-reads
+// the surface that produced it — the loop the reporter actually ran.
+//
+// This is #697's mistake in a new place. There the missing axis was SCOPE ("it is
+// somewhere else"); here it is KIND ("it is not that sort of thing"). Both used to
+// end at the same dead sentence.
+//
+// SCOPE OF THIS FIX: the diagnosis only. Removing a boundary slot still has no
+// operation, and this must not imply one — inventing a tool name would send the
+// caller to a command that does not exist. That half stays parked.
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { describeRailNodeTarget } from "../../web/js/lib/node-scope-locator.js";
+import { resolveRailNode } from "../../web/js/lib/subgraph-scope.js";
+
+/** A graph whose OUTPUT rail carries the reporter's id. */
+function graphWithOutputRail(id = -20) {
+  return {
+    inputNode: { id: -10 },
+    outputNode: { id },
+    _nodes: [],
+    getNodeById: () => null, // rails are never in _nodes_by_id — the real behaviour
+  };
+}
+
+test("the reporter's id resolves as a rail — so 'no such node' was never true", () => {
+  // The composition resolveNode performs: getNodeById declines, THEN we ask what
+  // the id actually is.
+  const found = resolveRailNode(graphWithOutputRail(), -20);
+  assert.ok(found, "-20 must resolve as a boundary rail");
+  assert.equal(found.rail, "output");
+});
+
+test("says what the id IS, and that it exists", () => {
+  const msg = describeRailNodeTarget(-20, "output");
+  assert.match(msg, /OUTPUT BOUNDARY RAIL/);
+  assert.match(msg, /rails\.output\.rail_node_id/);
+  assert.match(msg, /not a stale or foreign id/);
+});
+
+test("drops all three false claims", () => {
+  const msg = describeRailNodeTarget(-20, "output");
+  assert.ok(!/different workflow/.test(msg), "the id came from this graph");
+  assert.ok(!/was removed/.test(msg), "nothing was removed");
+  assert.ok(
+    !/Re-read with panel_graph_outline/.test(msg),
+    "re-reading returns the same id — that is the loop the reporter ran",
+  );
+});
+
+test("names what DOES accept a rail id, rather than only refusing", () => {
+  const msg = describeRailNodeTarget(-20, "output");
+  assert.match(msg, /panel_move_node/);
+  assert.match(msg, /move_rail/);
+});
+
+test("does NOT invent an unexpose tool — that half is parked", () => {
+  const msg = describeRailNodeTarget(-20, "output");
+  assert.ok(!/unexpose_subgraph/.test(msg), "no such command exists");
+  assert.match(msg, /NO unexpose\/remove-boundary operation/);
+  // The workaround that does work today is named instead of implied.
+  assert.match(msg, /remove or replace the interior node/);
+});
+
+test("the INPUT rail reads as itself, not as a copy of the output text", () => {
+  const msg = describeRailNodeTarget(-10, "input");
+  assert.match(msg, /INPUT BOUNDARY RAIL/);
+  assert.match(msg, /rails\.input\.rail_node_id/);
+  assert.ok(!/OUTPUT/.test(msg));
+});
+
+test("a REAL node owning the id still wins — the diagnosis never fires for it", () => {
+  // subgraph-scope's collision guard (#302): ComfyUI permits any integer node id,
+  // so a real node with id -20 must resolve as that node. If this ever inverted,
+  // an ordinary missing-node failure would be misreported as a rail.
+  const real = { id: -20, type: "KSampler" };
+  const graph = { inputNode: { id: -10 }, outputNode: { id: -20 }, getNodeById: () => real };
+  assert.equal(resolveRailNode(graph, -20), null);
+});
+
+// ── WIRING ────────────────────────────────────────────────────────────────
+// resolveNode is module-private and shared by 20+ handlers. A helper-only test
+// cannot see the call being dropped, and dropping it restores the false message
+// everywhere — so the composition is pinned at source.
+test("WIRING: resolveNode asks WHAT the id is before reporting it missing", async () => {
+  const { readFile } = await import("node:fs/promises");
+  const src = await readFile(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8");
+  assert.match(
+    src,
+    /import \{ describeMissingNode, describeRailNodeTarget \} from "\.\/lib\/node-scope-locator\.js";/,
+  );
+
+  const fn = src.slice(src.indexOf("function resolveNode(graph, nodeId) {"));
+  const body = fn.slice(0, fn.indexOf("function normalizeLegacyNodeId"));
+
+  assert.ok(body.includes("resolveRailNode(graph, nodeId)"), "the rail check must run");
+  assert.ok(
+    body.includes("throw new Error(describeRailNodeTarget(nodeId, rail.rail))"),
+    "a resolved rail must produce the rail message",
+  );
+  // ORDER IS THE BEHAVIOUR: the rail branch has to come first, or the generic
+  // "not in any other scope" message wins and nothing changes for the caller.
+  assert.ok(
+    body.indexOf("describeRailNodeTarget") < body.indexOf("describeMissingNode"),
+    "the rail branch must precede the generic miss",
+  );
+  // And it stays diagnostics-only: resolution is still the current graph alone.
+  assert.ok(body.includes("graph.getNodeById(Number(nodeId))"));
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -208,7 +208,7 @@ import {
   migratableRouteIds,
 } from "./lib/thread-workflow-match.js";
 import { subgraphValueProvenance } from "./lib/subgraph-value-provenance.js";
-import { describeMissingNode } from "./lib/node-scope-locator.js";
+import { describeMissingNode, describeRailNodeTarget } from "./lib/node-scope-locator.js";
 import { boundByChars, normalizeViewportMaxChars, viewportTruncation, VIEWPORT_DEFAULT_MAX_CHARS } from "./lib/viewport-char-bound.js";
 import { classifyManualChangeBaseline } from "./lib/manual-change-gate.js";
 import {
@@ -7177,6 +7177,22 @@ function resolveNode(graph, nodeId) {
   // instead of only that it is not here. Diagnostic-only: runs on the failure path,
   // never throws, and degrades to the original message when the root is unreadable.
   if (!node) {
+    // artokun/comfyui-mcp#1294 — ASK "WHAT IS IT" BEFORE ANSWERING "IT IS NOT HERE".
+    // panel_query_graph hands out `rails.<side>.rail_node_id` (e.g. -20). Fed back
+    // to a write, it used to be reported as an id from another workflow or a removed
+    // node, with a remedy of re-reading the surface that produced it. The id is
+    // neither missing nor foreign — it is a boundary rail, and `resolveRailNode`
+    // already resolves exactly this form for move_node (#302). Its real-node
+    // collision guard is what makes this safe here: a rail reference is only
+    // recognised once getNodeById has already declined the id.
+    let rail = null;
+    try {
+      rail = resolveRailNode(graph, nodeId);
+    } catch {
+      rail = null; // a diagnostic must never replace the failure with its own
+    }
+    if (rail) throw new Error(describeRailNodeTarget(nodeId, rail.rail));
+
     let rootGraph = null;
     let viewingRoot = true;
     try {

--- a/web/js/lib/node-scope-locator.js
+++ b/web/js/lib/node-scope-locator.js
@@ -152,3 +152,50 @@ export function describeMissingNode(nodeId, rootGraph, viewingRoot) {
     `this is one route to that node, not necessarily the only one.`
   );
 }
+
+/**
+ * The message for an id that IS resolvable — as a subgraph BOUNDARY RAIL — but is
+ * not an ordinary node the write can act on (artokun/comfyui-mcp#1294).
+ *
+ * WHAT WAS WRONG. `panel_query_graph` reports the rails it found as
+ * `rails.output.rail_node_id: "-20"`. Passing that straight back to a write got:
+ *
+ *     No node with id -20 in the current graph — and it is not in any other scope
+ *     either (searched the root graph and 4 subgraph(s)). The id may be from a
+ *     different workflow, or the node was removed. Re-read with panel_graph_outline
+ *     before retrying.
+ *
+ * Every clause after the first is false. The id did not come from another workflow;
+ * it came from THIS graph, from our own read, one call earlier. Nothing was removed.
+ * And the remedy sends the caller to re-read a surface that will hand back the very
+ * same id — the loop the reporter actually ran.
+ *
+ * This is the #697 mistake in a new place: the reads and the writes ask different
+ * questions, and the failure described only the write's answer. There the missing
+ * axis was SCOPE; here it is KIND. A rail is a real, addressable thing — `move_rail`
+ * and `panel_move_node` both take exactly this id (#302) — so "no such node" is not
+ * even true of the panel's own tool surface.
+ *
+ * WHAT IS AND IS NOT CLAIMED. It says what the id is, that this operation works on
+ * ordinary nodes, and what does work today. It does NOT promise a removal path,
+ * because there is none: `expose_subgraph_input`/`expose_subgraph_output`/`move_rail`
+ * exist and no unexpose does. Naming the invasive workaround is honest; inventing a
+ * tool name would send the caller to a command that does not exist.
+ *
+ * @param {number|string} nodeId
+ * @param {"input"|"output"} rail
+ */
+export function describeRailNodeTarget(nodeId, rail) {
+  const side = rail === "input" ? "INPUT" : "OUTPUT";
+  return (
+    `Id ${nodeId} is this subgraph's ${side} BOUNDARY RAIL, not an ordinary node — ` +
+    `it is the pseudo-node panel_query_graph reports as rails.${rail}.rail_node_id, ` +
+    `and it exists (so this is not a stale or foreign id). This operation acts on ` +
+    `ordinary graph nodes and their links, which is why it cannot take it. ` +
+    `Rail ids ARE accepted by panel_move_node and move_rail, if you meant to move it. ` +
+    `There is currently NO unexpose/remove-boundary operation: ` +
+    `expose_subgraph_input, expose_subgraph_output and move_rail are the whole ` +
+    `boundary surface. To REMOVE an exposed slot today, remove or replace the ` +
+    `interior node feeding it and the boundary slot is cleaned up automatically.`
+  );
+}

--- a/web/js/lib/node-scope-locator.js
+++ b/web/js/lib/node-scope-locator.js
@@ -188,14 +188,24 @@ export function describeMissingNode(nodeId, rootGraph, viewingRoot) {
 export function describeRailNodeTarget(nodeId, rail) {
   const side = rail === "input" ? "INPUT" : "OUTPUT";
   return (
-    `Id ${nodeId} is this subgraph's ${side} BOUNDARY RAIL, not an ordinary node — ` +
-    `it is the pseudo-node panel_query_graph reports as rails.${rail}.rail_node_id, ` +
-    `and it exists (so this is not a stale or foreign id). This operation acts on ` +
-    `ordinary graph nodes and their links, which is why it cannot take it. ` +
-    `Rail ids ARE accepted by panel_move_node and move_rail, if you meant to move it. ` +
-    `There is currently NO unexpose/remove-boundary operation: ` +
-    `expose_subgraph_input, expose_subgraph_output and move_rail are the whole ` +
-    `boundary surface. To REMOVE an exposed slot today, remove or replace the ` +
-    `interior node feeding it and the boundary slot is cleaned up automatically.`
+    `Id ${nodeId} resolves to this subgraph's ${side} BOUNDARY RAIL in the graph you ` +
+    `are viewing — the pseudo-node panel_query_graph reports as ` +
+    `rails.${rail}.rail_node_id. It is not an ordinary node, and this operation acts ` +
+    `on ordinary graph nodes and their links, which is why it cannot take it. ` +
+    `panel_move_node DOES accept a rail id, but only to reposition it (pos only — a ` +
+    `rail has nothing else to set); panel_move_rail addresses the same rail by SIDE ` +
+    `("${rail}") rather than by id. ` +
+    `There is currently NO unexpose/remove-boundary operation: expose_subgraph_input, ` +
+    `expose_subgraph_output and panel_move_rail are the whole boundary surface. To ` +
+    `REMOVE an exposed slot today, remove or replace the interior node feeding it and ` +
+    `the boundary slot is cleaned up automatically. ` +
+    // The one thing this CANNOT rule out, stated rather than glossed over: node ids
+    // are arbitrary integers, so an ordinary node may once have held this id and been
+    // removed. Then the id really is stale and re-reading is right — which is why the
+    // message says what resolved, not "your id is fine".
+    `(If you meant an ORDINARY node with this id, there is none in the graph you are ` +
+    `viewing. A removed node's id can collide with a rail's, so re-read ` +
+    `panel_graph_outline if that is your case — but an id taken from ` +
+    `rails.${rail}.rail_node_id is not.)`
   );
 }


### PR DESCRIPTION
Addresses the diagnosis half of artokun/comfyui-mcp#1294. **Deliberately not a closing reference** — the other half of that issue (unexpose/remove-boundary tools) is unbuilt and stays open.

`panel_query_graph` reports boundary rails as `rails.output.rail_node_id: "-20"`. Fed back to a write, the panel answered that the id may be from a different workflow or that the node was removed, and told the caller to re-read `panel_graph_outline` — which hands back the same id. Every clause after the first was false, and the remedy was a loop.

This is #697's mistake in a new place: there the missing axis was SCOPE, here it is KIND.

The failure path now asks what the id *is* before answering that it is not there, reusing the `resolveRailNode` that `move_node` has taken since #302. Its real-node collision guard is what makes that safe — a rail is only recognised after `getNodeById` has already declined the id — and a test pins the inversion, since it would misreport ordinary missing-node failures as rails.

**Scope is the diagnosis only.** The message does not imply a removal path, because there isn't one; it names the invasive workaround that does work today rather than inventing a tool name.

3353 unit tests pass, typecheck clean. Verified by mutation: deleting the *call site* fails the wiring test.