### PR TITLE
0.11.76 — a rail id is not a missing node (comfyui-mcp#1294)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+## [0.11.76] - 2026-08-09
+
+> Covers changes since 0.11.75.
+
+### Fixed
+
+- **A subgraph boundary rail is no longer reported as a node that doesn't exist
+  (comfyui-mcp#1294).** `panel_query_graph` hands out a subgraph's rails as
+  `rails.output.rail_node_id: "-20"`. Passing that back to an edit answered *"No node with
+  id -20 in the current graph … The id may be from a different workflow, or the node was
+  removed. Re-read with panel_graph_outline before retrying."* Every clause after the
+  first was false — the id came from that graph, from the panel's own read, one call
+  earlier — and the remedy re-read the surface that produced it, so following it looped.
+  The failure now names what the id actually is, notes that `panel_move_node` takes a rail
+  id (position only) while `panel_move_rail` addresses it by side, and says plainly that
+  no unexpose operation exists rather than implying one.
+
 ## [0.11.75] - 2026-08-10
 
 > Covers changes since 0.11.74.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-agent-panel"
 description = "Autonomous AI agent in the ComfyUI sidebar - local-first, bring any LLM. Run it on your Claude or ChatGPT subscription (no API keys, no extra LLM costs), on a Kimi K3 / GLM / OpenRouter key, or fully offline on free local models via Ollama, LM Studio, or llama.cpp. The agent drives your live canvas at full parity: add, wire, move and tweak nodes with Ctrl+Z undo, load whole workflows and installer packs in one shot, generate images, video and audio, browse CivitAI, and run your workflow - asking before it spends paid API credits. The sidebar UI for comfyui-mcp, the local-first, agent-native control plane for ComfyUI."
-version = "0.11.75"
+version = "0.11.76"
 license = { file = "LICENSE" }
 requires-python = ">=3.9"
 # UI-only pack: no Python deps. The frontend floor guarantees

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -879,7 +879,7 @@ const DOCS_URL = "https://comfyui-mcp.artokun.io/docs";
 // Panel version — surfaced in the "Need help?" diagnostics blob. Bump via
 // `node scripts/set-version.mjs <v>` (updates this AND pyproject together); CI
 // and the publish gate FAIL if the two ever drift, so this can't go stale.
-const PANEL_VERSION = "0.11.75";
+const PANEL_VERSION = "0.11.76";
 
 // The connected orchestrator's console URL/token (captured off the `backends`
 // bridge message — see onBackends). Drives the "API Keys" credentials frame;


### PR DESCRIPTION
Version bump + changelog for 0.11.76, covering #930.

**Note on the changelog, because I did not use the generated output.** `scripts/set-version.mjs` ran `gen-changelog` and it produced a 209-line entry covering **200 commits** back to `ee7fd628`, including work that shipped in 0.11.66–0.11.75 (e.g. the UI-scale setting, #850) and was never recorded at the time. Those entries are not duplicates — they are genuinely missing from earlier releases — but attributing them to 0.11.76 would tell users that months-old work is new in this release.

So this entry is hand-written to cover only what changed since 0.11.75, matching every prior entry's scope. The base-detection bug is real and I've filed it separately rather than fixing it inside a release PR.