### PR TITLE
fix(changelog): anchor on the previous release, not a stale base (#932)

### DIFF
--- a/browser_tests/unit/changelog-base.test.mjs
+++ b/browser_tests/unit/changelog-base.test.mjs
@@ -14,15 +14,15 @@
 //
 // Both failure directions produce a plausible file — too wide misattributes shipped work,
 // too narrow silently drops the release's own changes — which is why this is pinned.
+//
+// These import the SHIPPED predicate. The first version of this file re-declared it
+// locally, so it asserted against its own copy: reverting the source to the broken
+// original left all three tests green. That is why the rules were moved into
+// scripts/lib/changelog-match.mjs — gen-changelog.mjs rewrites CHANGELOG.md at import
+// time and cannot be imported by a test.
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
-
-const src = readFileSync(new URL("../../scripts/gen-changelog.mjs", import.meta.url), "utf8");
-
-/** The shipped release-subject predicate, kept in step with the source below. */
-const isReleaseSubject = (s) =>
-  /^release:/i.test(s) || /^v?\d+\.\d+\.\d+([^0-9]|$)/.test(s);
+import { RELEASE_SUBJECT_ERE, isReleaseSubject } from "../../scripts/lib/changelog-match.mjs";
 
 test("#932: this repo's own release subjects are recognised", () => {
   // The shape every release here actually has. The old predicate matched none of them.
@@ -45,24 +45,24 @@ test("#932: ordinary commits are not mistaken for releases", () => {
     "docs(changelog): 0.11.75 said the wrong thing",
     "feat: support 1.2.3 style ids",
     "chore: bump deps",
+    "",
+    "0.11", // not a version
   ]) {
-    assert.equal(isReleaseSubject(s), false, s);
+    assert.equal(isReleaseSubject(s), false, JSON.stringify(s));
   }
 });
 
-test("#932: the base anchors on a version subject, not a release: prefix", () => {
-  assert.ok(
-    src.includes('-E --grep="^v?[0-9]+'),
-    "prevTag must grep for a leading VERSION — the anchor this repo's releases carry",
-  );
-  // The old grep, not any MENTION of it — the comment explaining this fix names the
-  // pattern it replaced, and an unscoped check matches that instead of the code.
-  assert.ok(
-    !/--grep="\^\\\(chore\(release\)/.test(src),
-    "the release:-prefix grep matched nothing here and must be gone",
-  );
-  assert.ok(
-    src.includes("rev-list --max-parents=0"),
-    "the first-commit fallback stays as the last resort, just no longer the only outcome",
-  );
+test("#932: the grep the base search uses is the same rule, in ERE", () => {
+  // prevTag() hands this to `git log -E --grep`. If it drifts from isReleaseSubject, the
+  // base commit and the commits excluded from the entry disagree — which is exactly the
+  // silent, plausible-looking corruption this issue is about.
+  const ere = new RegExp(RELEASE_SUBJECT_ERE);
+  for (const s of ["0.11.75 — a thing (#920)", "0.11.40 (#656)", "v1.2.3"]) {
+    assert.equal(ere.test(s), true, `grep must match ${s}`);
+  }
+  for (const s of ["fix(x): not a release", "feat: support 1.2.3 style ids"]) {
+    assert.equal(ere.test(s), false, `grep must not match ${s}`);
+  }
+  // A version must not anchor on a LONGER one: 0.11.7 is not 0.11.75.
+  assert.equal(new RegExp("^v?0\\.11\\.7([^0-9]|$)").test("0.11.75 — x"), false);
 });

--- a/browser_tests/unit/changelog-base.test.mjs
+++ b/browser_tests/unit/changelog-base.test.mjs
@@ -22,7 +22,7 @@
 // time and cannot be imported by a test.
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { RELEASE_SUBJECT_ERE, isReleaseSubject } from "../../scripts/lib/changelog-match.mjs";
+import { SEP, isReleaseSubject, pickReleaseSha } from "../../scripts/lib/changelog-match.mjs";
 
 test("#932: this repo's own release subjects are recognised", () => {
   // The shape every release here actually has. The old predicate matched none of them.
@@ -52,17 +52,43 @@ test("#932: ordinary commits are not mistaken for releases", () => {
   }
 });
 
-test("#932: the grep the base search uses is the same rule, in ERE", () => {
-  // prevTag() hands this to `git log -E --grep`. If it drifts from isReleaseSubject, the
-  // base commit and the commits excluded from the entry disagree — which is exactly the
-  // silent, plausible-looking corruption this issue is about.
-  const ere = new RegExp(RELEASE_SUBJECT_ERE);
-  for (const s of ["0.11.75 — a thing (#920)", "0.11.40 (#656)", "v1.2.3"]) {
-    assert.equal(ere.test(s), true, `grep must match ${s}`);
-  }
-  for (const s of ["fix(x): not a release", "feat: support 1.2.3 style ids"]) {
-    assert.equal(ere.test(s), false, `grep must not match ${s}`);
-  }
-  // A version must not anchor on a LONGER one: 0.11.7 is not 0.11.75.
-  assert.equal(new RegExp("^v?0\\.11\\.7([^0-9]|$)").test("0.11.75 — x"), false);
+/** One `--pretty=format:%H%x1f%s` line. */
+const logLine = (sha, subject) => `${sha}${SEP}${subject}`;
+
+test("#932: the base is the most recent release commit", () => {
+  const sha = pickReleaseSha(
+    [
+      logLine("aaaaaaa1", "fix(save): report the workflow instance a save leaves active (#800)"),
+      logLine("bbbbbbb2", "0.11.76 — a rail id is not a missing node (comfyui-mcp#1294) (#931)"),
+      logLine("ccccccc3", "0.11.75 — installing a custom node clones it again (#920) (#928)"),
+    ].join("\n"),
+  );
+  assert.equal(sha, "bbbbbbb2", "the FIRST release in log order — git logs newest first");
+});
+
+test("#932: a version at the start of a commit BODY is not a release boundary", () => {
+  // The hazard that made `git log --grep` wrong (codex): --grep searches the whole message
+  // and matches per line, so `^<version>` fires on body lines too. Reading %s only is what
+  // makes this safe — and the commits in this very fix have bodies quoting versions.
+  //
+  // The body cannot even reach the predicate now, so this asserts the SHAPE that keeps it
+  // that way: a line whose subject is ordinary is skipped no matter what follows it, and
+  // the real release below it is the one selected.
+  const sha = pickReleaseSha(
+    [
+      logLine("aaaaaaa1", "docs(release): quote the release titles we produce"),
+      // If a body ever leaked into the subject field, it would arrive looking like this —
+      // and must still not win, because the subject is what is tested.
+      logLine("bbbbbbb2", "fix(changelog): anchor on the previous release (#932)"),
+      logLine("ccccccc3", "0.11.76 — a rail id is not a missing node (#931)"),
+    ].join("\n"),
+  );
+  assert.equal(sha, "ccccccc3", "an ordinary subject must never become the release anchor");
+});
+
+test("#932: no release in history falls back to the caller's first-commit path", () => {
+  assert.equal(pickReleaseSha([logLine("aaaaaaa1", "feat: initial commit")].join("\n")), null);
+  assert.equal(pickReleaseSha(""), null);
+  // Malformed lines must be skipped, not crash a release.
+  assert.equal(pickReleaseSha("garbage\nnot-a-sha\x1f0.11.76 — x"), null);
 });

--- a/browser_tests/unit/changelog-base.test.mjs
+++ b/browser_tests/unit/changelog-base.test.mjs
@@ -66,14 +66,16 @@ test("#932: the base is the most recent release commit", () => {
   assert.equal(sha, "bbbbbbb2", "the FIRST release in log order — git logs newest first");
 });
 
-test("#932: a version at the start of a commit BODY is not a release boundary", () => {
-  // The hazard that made `git log --grep` wrong (codex): --grep searches the whole message
-  // and matches per line, so `^<version>` fires on body lines too. Reading %s only is what
-  // makes this safe — and the commits in this very fix have bodies quoting versions.
+test("#932: an ordinary subject is never chosen as the release boundary", () => {
+  // Scope, stated honestly (codex): this feeds SUBJECTS, so it cannot prove git has
+  // stopped searching bodies, and it would NOT catch a future rewrite of prevTag() back
+  // to `--grep`. Catching that automatically needs a fixture repository, which this does
+  // not have. What it does pin is the selection rule itself.
   //
-  // The body cannot even reach the predicate now, so this asserts the SHAPE that keeps it
-  // that way: a line whose subject is ordinary is skipped no matter what follows it, and
-  // the real release below it is the one selected.
+  // The hazard it descends from is real and live: `--grep "^<version>"` matches per line
+  // over the WHOLE message, and in this repo's own history it selects 7521519, whose
+  // subject is `fix(subgraph): …` and which matched on a body line. Reading %s is what
+  // keeps a body away from the predicate.
   const sha = pickReleaseSha(
     [
       logLine("aaaaaaa1", "docs(release): quote the release titles we produce"),

--- a/browser_tests/unit/changelog-base.test.mjs
+++ b/browser_tests/unit/changelog-base.test.mjs
@@ -55,8 +55,10 @@ test("#932: the base anchors on a version subject, not a release: prefix", () =>
     src.includes('-E --grep="^v?[0-9]+'),
     "prevTag must grep for a leading VERSION — the anchor this repo's releases carry",
   );
+  // The old grep, not any MENTION of it — the comment explaining this fix names the
+  // pattern it replaced, and an unscoped check matches that instead of the code.
   assert.ok(
-    !src.includes("chore(release)"),
+    !/--grep="\^\\\(chore\(release\)/.test(src),
     "the release:-prefix grep matched nothing here and must be gone",
   );
   assert.ok(

--- a/browser_tests/unit/changelog-base.test.mjs
+++ b/browser_tests/unit/changelog-base.test.mjs
@@ -1,0 +1,66 @@
+// #932 — gen-changelog must anchor on the previous RELEASE, not the first commit.
+//
+// Cutting a release regenerated ~200 commits of already-shipped work into one entry. The
+// cause is that this repo's releases are squash merges titled
+//
+//     0.11.75 — installing a custom node from a GitHub URL clones it again (#920) (#928)
+//
+// and BOTH matchers were written for shapes it has never produced:
+//
+//   * prevTag() grepped for `^release:` / `^chore(release):`, matched nothing, and fell
+//     through to `rev-list --max-parents=0` — the FIRST COMMIT;
+//   * isReleaseSubject() required the version to be the whole subject, so release commits
+//     were also written INTO the entries announcing them.
+//
+// Both failure directions produce a plausible file — too wide misattributes shipped work,
+// too narrow silently drops the release's own changes — which is why this is pinned.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const src = readFileSync(new URL("../../scripts/gen-changelog.mjs", import.meta.url), "utf8");
+
+/** The shipped release-subject predicate, kept in step with the source below. */
+const isReleaseSubject = (s) =>
+  /^release:/i.test(s) || /^v?\d+\.\d+\.\d+([^0-9]|$)/.test(s);
+
+test("#932: this repo's own release subjects are recognised", () => {
+  // The shape every release here actually has. The old predicate matched none of them.
+  for (const s of [
+    "0.11.75 — installing a custom node from a GitHub URL clones it again (#920) (#928)",
+    "0.11.76 — a rail id is not a missing node (comfyui-mcp#1294)",
+    "0.11.40 (#656)",
+    "release: 0.11.40",
+    "v1.2.3",
+  ]) {
+    assert.equal(isReleaseSubject(s), true, s);
+  }
+});
+
+test("#932: ordinary commits are not mistaken for releases", () => {
+  // Broadening the match must not start swallowing real changes — that is the
+  // too-narrow direction, which silently drops the release's own content.
+  for (const s of [
+    "fix(x): not a release",
+    "docs(changelog): 0.11.75 said the wrong thing",
+    "feat: support 1.2.3 style ids",
+    "chore: bump deps",
+  ]) {
+    assert.equal(isReleaseSubject(s), false, s);
+  }
+});
+
+test("#932: the base anchors on a version subject, not a release: prefix", () => {
+  assert.ok(
+    src.includes('-E --grep="^v?[0-9]+'),
+    "prevTag must grep for a leading VERSION — the anchor this repo's releases carry",
+  );
+  assert.ok(
+    !src.includes("chore(release)"),
+    "the release:-prefix grep matched nothing here and must be gone",
+  );
+  assert.ok(
+    src.includes("rev-list --max-parents=0"),
+    "the first-commit fallback stays as the last resort, just no longer the only outcome",
+  );
+});

--- a/scripts/gen-changelog.mjs
+++ b/scripts/gen-changelog.mjs
@@ -52,10 +52,14 @@ const git = (args) => execSync(`git ${args}`, { cwd: ROOT, encoding: "utf-8", st
  *  has no per-release tags); else the first commit. */
 function prevTag() {
   try {
-    const t = git("describe --tags --abbrev=0");
+    // --match, because bare `describe --tags` accepts the nearest reachable tag of ANY
+    // name — a `backup`, a CI marker, anything — and would silently make it the release
+    // base (codex, #932). This repo has no tags today, so this guards the sibling mcp
+    // repo and whatever tags land here later, not a present bug.
+    const t = git('describe --tags --abbrev=0 --match "v[0-9]*.[0-9]*.[0-9]*" --match "[0-9]*.[0-9]*.[0-9]*"');
     if (t) return t;
   } catch {
-    /* no tags */
+    /* no version tags */
   }
   try {
     // #932 — match the shape this repo ACTUALLY produces. Releases here are squash

--- a/scripts/gen-changelog.mjs
+++ b/scripts/gen-changelog.mjs
@@ -57,7 +57,12 @@ function prevTag() {
     /* no tags */
   }
   try {
-    const sha = git('log -1 --pretty=format:%H --grep="^\\(chore(release)\\|release\\):"');
+    // #932 — match the shape this repo ACTUALLY produces. Releases here are squash
+    // merges titled `<version> — <description> (#N)`, so a grep for `release:` or
+    // `chore(release):` never matched one, every run fell through to the first commit,
+    // and each entry regenerated the entire history. The anchor is the version at the
+    // START of the subject; whatever follows it is free text.
+    const sha = git('log -1 --pretty=format:%H -E --grep="^v?[0-9]+\\.[0-9]+\\.[0-9]+([^0-9]|$)"');
     if (/^[0-9a-f]{7,40}$/.test(sha)) return sha;
   } catch {
     /* no release commit */
@@ -68,7 +73,13 @@ function prevTag() {
 /** A release commit, in either shape we actually produce: `release: 0.11.40`, or the
  *  squash-merge form GitHub writes from a PR titled with the bare version — `0.11.40 (#656)`.
  *  Only the first was recognised. */
-const isReleaseSubject = (s) => /^release:/i.test(s) || /^v?\d+\.\d+\.\d+\s*(\(#\d+\))?$/.test(s);
+const isReleaseSubject = (s) =>
+  /^release:/i.test(s) ||
+  // #932 — a release subject is a version FOLLOWED BY ANYTHING. Requiring the version to
+  // be the whole line (optionally plus a PR ref) matched no release this repo has ever
+  // cut, because they read `0.11.75 — <description> (#920) (#928)`. So release commits
+  // were also written INTO the entries they announce.
+  /^v?\d+\.\d+\.\d+([^0-9]|$)/.test(s);
 
 /** Parsed commits since `range`, newest-first, minus noise.
  *

--- a/scripts/gen-changelog.mjs
+++ b/scripts/gen-changelog.mjs
@@ -22,6 +22,7 @@ import { readFileSync, writeFileSync } from "node:fs";
 import { execSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
+import { RELEASE_SUBJECT_ERE, isReleaseSubject } from "./lib/changelog-match.mjs";
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
 const CHANGELOG = join(ROOT, "CHANGELOG.md");
@@ -62,7 +63,7 @@ function prevTag() {
     // `chore(release):` never matched one, every run fell through to the first commit,
     // and each entry regenerated the entire history. The anchor is the version at the
     // START of the subject; whatever follows it is free text.
-    const sha = git('log -1 --pretty=format:%H -E --grep="^v?[0-9]+\\.[0-9]+\\.[0-9]+([^0-9]|$)"');
+    const sha = git(`log -1 --pretty=format:%H -E --grep="${RELEASE_SUBJECT_ERE}"`);
     if (/^[0-9a-f]{7,40}$/.test(sha)) return sha;
   } catch {
     /* no release commit */
@@ -70,16 +71,10 @@ function prevTag() {
   return git("rev-list --max-parents=0 HEAD").split(/\s+/)[0]; // first commit
 }
 
-/** A release commit, in either shape we actually produce: `release: 0.11.40`, or the
- *  squash-merge form GitHub writes from a PR titled with the bare version — `0.11.40 (#656)`.
- *  Only the first was recognised. */
-const isReleaseSubject = (s) =>
-  /^release:/i.test(s) ||
-  // #932 — a release subject is a version FOLLOWED BY ANYTHING. Requiring the version to
-  // be the whole line (optionally plus a PR ref) matched no release this repo has ever
-  // cut, because they read `0.11.75 — <description> (#920) (#928)`. So release commits
-  // were also written INTO the entries they announce.
-  /^v?\d+\.\d+\.\d+([^0-9]|$)/.test(s);
+// The release-subject rules live in ./lib/changelog-match.mjs so the tests can import the
+// SHIPPED predicate. This file rewrites CHANGELOG.md at import time and so is untestable
+// directly — the first attempt at a test copied the predicate instead, and passed against
+// a copy while the real one stayed broken (#932).
 
 /** Parsed commits since `range`, newest-first, minus noise.
  *

--- a/scripts/gen-changelog.mjs
+++ b/scripts/gen-changelog.mjs
@@ -22,7 +22,7 @@ import { readFileSync, writeFileSync } from "node:fs";
 import { execSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
-import { RELEASE_SUBJECT_ERE, isReleaseSubject } from "./lib/changelog-match.mjs";
+import { isReleaseSubject, pickReleaseSha } from "./lib/changelog-match.mjs";
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
 const CHANGELOG = join(ROOT, "CHANGELOG.md");
@@ -63,8 +63,11 @@ function prevTag() {
     // `chore(release):` never matched one, every run fell through to the first commit,
     // and each entry regenerated the entire history. The anchor is the version at the
     // START of the subject; whatever follows it is free text.
-    const sha = git(`log -1 --pretty=format:%H -E --grep="${RELEASE_SUBJECT_ERE}"`);
-    if (/^[0-9a-f]{7,40}$/.test(sha)) return sha;
+    // Subjects only, matched in JS. NOT `--grep`: that searches the whole message per
+    // line, so `^<version>` also fires on a BODY line and an ordinary commit becomes the
+    // release boundary — silently truncating the entry (codex, #932).
+    const sha = pickReleaseSha(git("log --pretty=format:%H%x1f%s"));
+    if (sha) return sha;
   } catch {
     /* no release commit */
   }

--- a/scripts/gen-changelog.mjs
+++ b/scripts/gen-changelog.mjs
@@ -56,6 +56,13 @@ function prevTag() {
     // name — a `backup`, a CI marker, anything — and would silently make it the release
     // base (codex, #932). This repo has no tags today, so this guards the sibling mcp
     // repo and whatever tags land here later, not a present bug.
+    //
+    // It is a GLOB, not a regex: `[0-9]*` is one digit followed by anything, so a tag like
+    // `v1.backup.2.3` still gets through (codex). It rules out the obviously-unrelated
+    // names, not every malformed one. Two further limits on a tagged repo, unaddressed
+    // because neither can arise here: describe can pick the CURRENT release's tag if
+    // generation runs after tagging, yielding an empty range, and nothing validates that
+    // the tag is an exact version.
     const t = git('describe --tags --abbrev=0 --match "v[0-9]*.[0-9]*.[0-9]*" --match "[0-9]*.[0-9]*.[0-9]*"');
     if (t) return t;
   } catch {

--- a/scripts/lib/changelog-match.mjs
+++ b/scripts/lib/changelog-match.mjs
@@ -11,7 +11,13 @@
  * is exactly one copy to be wrong.
  */
 
-/** Field separator for `--pretty=format:%H%x1f%s` — a byte no commit subject contains. */
+/**
+ * Field separator for `--pretty=format:%H%x1f%s`.
+ *
+ * Not a byte git forbids in a subject (codex) — parsing is safe because only the FIRST
+ * separator is read, and it always follows the fixed-width SHA. A later one lands
+ * harmlessly inside the subject.
+ */
 export const SEP = "\x1f";
 
 /**

--- a/scripts/lib/changelog-match.mjs
+++ b/scripts/lib/changelog-match.mjs
@@ -1,0 +1,38 @@
+/**
+ * How a release commit is recognised (#932).
+ *
+ * This lives in its own module for one reason: `gen-changelog.mjs` runs git and REWRITES
+ * CHANGELOG.md at import time, so a test cannot import it. The first version of the #932
+ * test worked around that by re-declaring the predicate in the test file — which asserted
+ * against its own copy and passed happily with the broken original still shipped. A test
+ * that cannot fail is worse than no test, because it reads like coverage.
+ *
+ * So the matching rules live here, imported by both the generator and its tests, and there
+ * is exactly one copy to be wrong.
+ */
+
+/**
+ * The `git log --grep` pattern (POSIX ERE, for `-E`) that finds the previous release commit.
+ *
+ * Releases in this repo are squash merges titled `0.11.75 — <description> (#920) (#928)`.
+ * The generator used to grep for `^release:` / `^chore(release):`, which matched NONE of
+ * them, so every run fell through to `rev-list --max-parents=0` — the first commit — and
+ * regenerated the entire history into each entry.
+ *
+ * The anchor is a version at the START of the subject. `([^0-9]|$)` stops `0.11.7` from
+ * anchoring on `0.11.75`.
+ */
+export const RELEASE_SUBJECT_ERE = "^v?[0-9]+\\.[0-9]+\\.[0-9]+([^0-9]|$)";
+
+/**
+ * True when a commit subject announces a release, in every shape this repo produces:
+ * `release: 0.11.40`, the bare squash form `0.11.40 (#656)`, and the current
+ * `0.11.75 — <description> (#920) (#928)`.
+ *
+ * Deliberately anchored at the start and followed by a non-digit, so ordinary commits that
+ * merely CONTAIN a version — `docs(changelog): 0.11.75 said the wrong thing`, `feat:
+ * support 1.2.3 style ids` — are not swallowed. That direction is the dangerous one: it
+ * silently drops real changes out of the entry rather than adding noise to it.
+ */
+export const isReleaseSubject = (s) =>
+  /^release:/i.test(String(s ?? "")) || /^v?\d+\.\d+\.\d+([^0-9]|$)/.test(String(s ?? ""));

--- a/scripts/lib/changelog-match.mjs
+++ b/scripts/lib/changelog-match.mjs
@@ -11,18 +11,8 @@
  * is exactly one copy to be wrong.
  */
 
-/**
- * The `git log --grep` pattern (POSIX ERE, for `-E`) that finds the previous release commit.
- *
- * Releases in this repo are squash merges titled `0.11.75 — <description> (#920) (#928)`.
- * The generator used to grep for `^release:` / `^chore(release):`, which matched NONE of
- * them, so every run fell through to `rev-list --max-parents=0` — the first commit — and
- * regenerated the entire history into each entry.
- *
- * The anchor is a version at the START of the subject. `([^0-9]|$)` stops `0.11.7` from
- * anchoring on `0.11.75`.
- */
-export const RELEASE_SUBJECT_ERE = "^v?[0-9]+\\.[0-9]+\\.[0-9]+([^0-9]|$)";
+/** Field separator for `--pretty=format:%H%x1f%s` — a byte no commit subject contains. */
+export const SEP = "\x1f";
 
 /**
  * True when a commit subject announces a release, in every shape this repo produces:
@@ -36,3 +26,33 @@ export const RELEASE_SUBJECT_ERE = "^v?[0-9]+\\.[0-9]+\\.[0-9]+([^0-9]|$)";
  */
 export const isReleaseSubject = (s) =>
   /^release:/i.test(String(s ?? "")) || /^v?\d+\.\d+\.\d+([^0-9]|$)/.test(String(s ?? ""));
+
+/**
+ * Pick the most recent release commit from `git log --pretty=format:%H%x1f%s` output.
+ *
+ * This exists instead of a `git log --grep` pattern, and the reason is the whole point
+ * (codex, #932): **`--grep` searches the entire commit message and matches per LINE**, so a
+ * `^`-anchored pattern also fires on BODY lines. An ordinary commit whose body happens to
+ * quote a version at the start of a line — which the messages in this very fix do — would
+ * be chosen as the release boundary, silently truncating the entry to a few commits. That
+ * is the same class of silent wrongness as the bug being fixed, just in the other
+ * direction.
+ *
+ * Matching `%s` in JS also collapses the two spellings of the rule into one. The first fix
+ * carried an ERE beside the JS regex, and they had already drifted: the ERE did not accept
+ * `release: 0.11.40`, which the predicate does. Two spellings of one rule is a drift
+ * waiting to happen, and drift here is invisible in the output.
+ *
+ * Returns null when no release commit appears — the caller falls back to the first commit.
+ */
+export function pickReleaseSha(logOutput) {
+  for (const line of String(logOutput ?? "").split("\n")) {
+    const i = line.indexOf(SEP);
+    if (i < 0) continue;
+    const sha = line.slice(0, i);
+    // Only the subject. Everything after the first separator is `%s`, which git guarantees
+    // is a single line — the body never reaches this predicate.
+    if (/^[0-9a-f]{7,40}$/.test(sha) && isReleaseSubject(line.slice(i + 1))) return sha;
+  }
+  return null;
+}


### PR DESCRIPTION
`gen-changelog` regenerates every commit since `ee7fd628` instead of since the previous
release, so a new entry claims ~200 commits of already-shipped work. The repo has **no
tags** — releases are version-bump commits on main — so a tag-based anchor cannot resolve.

Both failure directions produce a plausible file, which is why this needs an assertion
rather than an eyeball.

I hit this on all fourteen releases today and hand-wrote every entry around it. That is
precisely why it stayed invisible: the workaround is silent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)