### PR TITLE
fix(#584): make the tab measure its own module cache instead of asking for DevTools

### DIFF
--- a/browser_tests/unit/module-cache-report.test.mjs
+++ b/browser_tests/unit/module-cache-report.test.mjs
@@ -49,7 +49,10 @@ test("a healthy page reads all-network — and must not warn", () => {
   assert.equal(s.verdict, "all-network");
   assert.equal(s.total, 2);
   assert.equal(s.cached, 0);
-  assert.match(describeModuleCache(s), /staleness here is NOT the HTTP cache/);
+  // The claim is bounded to what the buffer can support (codex review): "every
+  // module STILL IN THE BUFFER", never "every module".
+  assert.match(describeModuleCache(s), /STILL IN THE BUFFER was fetched/);
+  assert.ok(!/Every module was fetched/.test(describeModuleCache(s)), "an unbounded claim");
 });
 
 test("MIXED is the finding this issue is missing — some modules stale, version healthy", () => {
@@ -63,8 +66,14 @@ test("MIXED is the finding this issue is missing — some modules stale, version
   assert.equal(s.verdict, "mixed");
   assert.equal(s.cached, 2);
   const msg = describeModuleCache(s);
-  assert.match(msg, /MIXTURE of versions/);
-  // …and it names WHICH ones, because that is what separates skew from an old page.
+  // States what it OBSERVED and what that makes possible — not the conclusion.
+  // Cache provenance is not content equality: a cached module can be identical to
+  // the served one, so "this page is running a MIXTURE of versions" asserted more
+  // than the evidence carries (codex review).
+  assert.match(msg, /makes version skew POSSIBLE/);
+  assert.match(msg, /not proof of it/);
+  assert.ok(!/is running a MIXTURE of versions/.test(msg), "overstated conclusion");
+  // …and it names WHICH ones, because that is what a follow-up needs.
   assert.match(msg, /js\/lib\/graph-write-fence\.js/);
 });
 
@@ -168,4 +177,70 @@ test("WIRING: user-copied diagnostics carry the measurement", async () => {
     block.includes("describeModuleCache(readModuleCacheSummary())"),
     "the diagnostics a user pastes into an issue must include it",
   );
+});
+
+// ── CODEX REVIEW FINDINGS ─────────────────────────────────────────────────
+// Each of these was a way the diagnostic could report a FALSE ALL-CLEAR, which
+// is the only failure mode that matters here: it would send a sixth attempt back
+// down the path this module exists to close.
+
+test("a 304 is a CACHE HIT — the exact mechanism this issue is about", () => {
+  // A revalidation transfers headers, so transferSize is NONZERO while the body
+  // comes from cache. Classifying by bytes alone called this "network" and would
+  // have reported "not the HTTP cache" for a page built entirely of stale 304s —
+  // which is the mechanism ComfyUI's own e0982a71 describes (aiohttp ETag from
+  // mtime+size matches, 304, stale content served).
+  const revalidated = entry("js/a.js", { transferSize: 380, decodedBodySize: 12000, responseStatus: 304 });
+  assert.equal(classifyEntry(revalidated), "revalidated");
+
+  const s = summarizeModuleCache([revalidated, entry("js/b.js", { responseStatus: 304, transferSize: 300 })]);
+  assert.equal(s.verdict, "all-cached", "a page of 304s is cache-served, not fresh");
+  assert.equal(s.revalidated, 2);
+  assert.match(describeModuleCache(s), /304 revalidations, where an ETag matched/);
+});
+
+test("one 304 among fetches is MIXED, not all-network", () => {
+  const s = summarizeModuleCache([
+    entry("js/a.js"),
+    entry("js/b.js", { responseStatus: 304, transferSize: 300 }),
+  ]);
+  assert.equal(s.verdict, "mixed");
+});
+
+test("a full timing buffer cannot be reported as completeness", () => {
+  // The spec's floor is 250 entries and this page loads 112 panel modules on top
+  // of ComfyUI's own. If the cached ones were evicted and the fetched ones
+  // survived, the naive read is "everything was fetched".
+  const many = Array.from({ length: 300 }, (_, i) => entry(`js/lib/m${i}.js`));
+  const s = summarizeModuleCache(many);
+  assert.equal(s.bufferMaybeFull, true);
+  assert.equal(s.verdict, "all-network");
+  assert.match(describeModuleCache(s), /may have been dropped and this list may be incomplete/);
+});
+
+test("a small buffer carries no truncation caveat", () => {
+  const s = summarizeModuleCache([entry("js/a.js")]);
+  assert.equal(s.bufferMaybeFull, false);
+  assert.ok(!/may be incomplete/.test(describeModuleCache(s)));
+});
+
+test("a cached STYLESHEET must not manufacture a finding", () => {
+  // Resource Timing reports a stylesheet and a `link rel=modulepreload` both as
+  // "link", so filtering by initiatorType admitted CSS. Every module ComfyUI
+  // auto-imports is a .js, so the URL decides.
+  const css = {
+    name: url("css/panel.css"),
+    transferSize: 0,
+    decodedBodySize: 4000,
+    initiatorType: "link",
+  };
+  const s = summarizeModuleCache([entry("js/comfyui-mcp-panel.js"), css]);
+  assert.equal(s.total, 1, "a cached CSS file is not a cached module");
+  assert.equal(s.verdict, "all-network");
+});
+
+test("a query string does not hide a .js module", () => {
+  const s = summarizeModuleCache([{ ...fromCache("js/a.js"), name: url("js/a.js?v=0.11.76") }]);
+  assert.equal(s.total, 1);
+  assert.equal(s.verdict, "all-cached");
 });

--- a/browser_tests/unit/module-cache-report.test.mjs
+++ b/browser_tests/unit/module-cache-report.test.mjs
@@ -1,0 +1,171 @@
+// #584 — measuring what five fixes assumed.
+//
+// The recurring symptom is a tab running stale panel JS while its version check
+// reads healthy. Every fix so far has been built on a hypothesis about the
+// browser cache that nobody measured, because the only way to measure it was to
+// ask a wedged user to open DevTools — which never comes back.
+//
+// The page already knows. PerformanceResourceTiming records, per module fetch,
+// whether bytes crossed the wire. This is the classifier for that, and its whole
+// job is to be trustworthy in the one direction that matters: it must never
+// report "fresh" when what actually happened is "could not tell". Reporting a
+// false all-clear is what would send the sixth attempt back down the same path.
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  classifyEntry,
+  describeModuleCache,
+  readModuleCacheSummary,
+  summarizeModuleCache,
+} from "../../web/js/lib/module-cache-report.js";
+
+const BASE = "/extensions/comfyui-mcp-panel/";
+const url = (p) => `http://127.0.0.1:8188${BASE}${p}`;
+
+/** A resource entry as the browser reports one. */
+function entry(p, { transferSize = 4096, decodedBodySize = 12000, responseStatus = 200, initiatorType = "script" } = {}) {
+  return { name: url(p), transferSize, decodedBodySize, responseStatus, initiatorType };
+}
+const fromCache = (p) => entry(p, { transferSize: 0 });
+
+test("bytes on the wire is a network fetch; a decoded body with none is cache", () => {
+  assert.equal(classifyEntry(entry("js/comfyui-mcp-panel.js")), "network");
+  assert.equal(classifyEntry(fromCache("js/comfyui-mcp-panel.js")), "cached");
+});
+
+test("UNKNOWN is a distinct answer — the API not saying is not 'it was fresh'", () => {
+  // Sizes are not guaranteed to be exposed.
+  assert.equal(classifyEntry({ name: url("js/a.js") }), "unknown");
+  assert.equal(classifyEntry({ name: url("js/a.js"), transferSize: 0 }), "unknown");
+  // transferSize 0 AND no decoded body is the cross-origin/opaque shape, which
+  // is byte-identical to a cache hit. Calling it "cached" would invent evidence.
+  assert.equal(classifyEntry(entry("js/a.js", { transferSize: 0, decodedBodySize: 0 })), "unknown");
+});
+
+test("a healthy page reads all-network — and must not warn", () => {
+  const s = summarizeModuleCache([entry("js/comfyui-mcp-panel.js"), entry("js/lib/bundle-version.js")]);
+  assert.equal(s.verdict, "all-network");
+  assert.equal(s.total, 2);
+  assert.equal(s.cached, 0);
+  assert.match(describeModuleCache(s), /staleness here is NOT the HTTP cache/);
+});
+
+test("MIXED is the finding this issue is missing — some modules stale, version healthy", () => {
+  // The exact shape that defeats a single version check: the module carrying
+  // PANEL_VERSION is fresh, a sibling is not.
+  const s = summarizeModuleCache([
+    entry("js/comfyui-mcp-panel.js"),
+    fromCache("js/lib/graph-write-fence.js"),
+    fromCache("js/cmcp-apps.js"),
+  ]);
+  assert.equal(s.verdict, "mixed");
+  assert.equal(s.cached, 2);
+  const msg = describeModuleCache(s);
+  assert.match(msg, /MIXTURE of versions/);
+  // …and it names WHICH ones, because that is what separates skew from an old page.
+  assert.match(msg, /js\/lib\/graph-write-fence\.js/);
+});
+
+test("ALL-CACHED points outside the panel, and says so", () => {
+  const s = summarizeModuleCache([fromCache("js/comfyui-mcp-panel.js"), fromCache("js/lib/a.js")]);
+  assert.equal(s.verdict, "all-cached");
+  const msg = describeModuleCache(s);
+  // ComfyUI sets no-store on every .js, so a wholly-cached pack means something
+  // in between is not passing it. Naming the suspects is the actionable part.
+  assert.match(msg, /no-store on every \.js/);
+  assert.match(msg, /proxy, tunnel, or Desktop's server/);
+});
+
+test("no measurement is reported as no measurement, never as fresh", () => {
+  for (const nothing of [null, undefined, []]) {
+    const s = summarizeModuleCache(nothing);
+    assert.equal(s.verdict, "unknown");
+    assert.match(describeModuleCache(s), /could not be measured/);
+    assert.match(describeModuleCache(s), /not evidence that they were fresh/);
+  }
+});
+
+test("counts only OUR modules — the page is full of other people's", () => {
+  const foreign = {
+    name: "http://127.0.0.1:8188/extensions/some-other-pack/js/x.js",
+    transferSize: 0,
+    decodedBodySize: 900,
+    initiatorType: "script",
+  };
+  const s = summarizeModuleCache([entry("js/comfyui-mcp-panel.js"), foreign]);
+  assert.equal(s.total, 1, "another pack's cached module must not be reported as ours");
+  assert.equal(s.verdict, "all-network");
+});
+
+test("carries the server's status codes — a 304 is the other way to serve stale", () => {
+  const s = summarizeModuleCache([
+    entry("js/a.js", { responseStatus: 200 }),
+    entry("js/b.js", { transferSize: 0, responseStatus: 304 }),
+  ]);
+  assert.equal(s.statuses[200], 1);
+  assert.equal(s.statuses[304], 1);
+  assert.match(describeModuleCache(s), /status .*304/);
+});
+
+test("the sample list is bounded — a wedged page has 112 of these", () => {
+  const many = Array.from({ length: 60 }, (_, i) => fromCache(`js/lib/m${i}.js`));
+  const s = summarizeModuleCache(many);
+  assert.equal(s.total, 60);
+  assert.ok(s.cachedUrls.length <= 12, `listed ${s.cachedUrls.length}`);
+});
+
+test("reading the live document never throws, whatever the API does", () => {
+  assert.equal(readModuleCacheSummary(null).verdict, "unknown");
+  assert.equal(readModuleCacheSummary({}).verdict, "unknown");
+  const hostile = {
+    getEntriesByType() {
+      throw new Error("Resource Timing is disabled");
+    },
+  };
+  assert.equal(readModuleCacheSummary(hostile).verdict, "unknown");
+  // And the real shape, through the same door.
+  const perf = { getEntriesByType: (t) => (t === "resource" ? [fromCache("js/a.js")] : []) };
+  assert.equal(readModuleCacheSummary(perf).verdict, "all-cached");
+});
+
+// ── WIRING ────────────────────────────────────────────────────────────────
+// The measurement is worthless if it is never taken. Both call sites are pinned
+// at source: the module is not importable under Node (it is the panel bundle).
+test("WIRING: the CURRENT-version path takes the measurement", async () => {
+  const { readFile } = await import("node:fs/promises");
+  const src = await readFile(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8");
+  assert.match(
+    src,
+    /import \{ describeModuleCache, readModuleCacheSummary \} from "\.\/lib\/module-cache-report\.js";/,
+  );
+
+  const heal = src.slice(src.indexOf("async function healStaleBundleIfNeeded()"));
+  const body = heal.slice(0, heal.indexOf("\n}\n"));
+  // THE POINT OF THE CHANGE: the check runs on the `current` branch — the one
+  // that used to return silently. Wiring it only to the already-stale paths
+  // would add nothing, since those already warn.
+  const currentBranch = body.slice(body.indexOf('if (staleness === "current")'));
+  assert.ok(
+    currentBranch.includes("readModuleCacheSummary()"),
+    "the blind spot is the `current` branch — it must be measured there",
+  );
+  assert.ok(currentBranch.includes('cache.verdict === "mixed"'), "skew must be what triggers it");
+  // A healthy page must stay silent, or the warning trains people to ignore it.
+  assert.ok(
+    !currentBranch.includes('cache.verdict === "all-network"'),
+    "an all-network page must not warn",
+  );
+});
+
+test("WIRING: user-copied diagnostics carry the measurement", async () => {
+  const { readFile } = await import("node:fs/promises");
+  const src = await readFile(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8");
+  const diag = src.slice(src.indexOf("--- comfyui-mcp panel diagnostics ---"));
+  const block = diag.slice(0, diag.indexOf("].join("));
+  assert.ok(
+    block.includes("describeModuleCache(readModuleCacheSummary())"),
+    "the diagnostics a user pastes into an issue must include it",
+  );
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -393,6 +393,7 @@ import {
 } from "./lib/session-rebind.js";
 import { createRestartTabIdentity, sendBridgeHello } from "./lib/restart-tab-identity.js";
 import { primeModuleCache, resolveBundleStaleness } from "./lib/bundle-version.js";
+import { describeModuleCache, readModuleCacheSummary } from "./lib/module-cache-report.js";
 import { classifyManager404 } from "./lib/manager-404.js";
 import { probeConsoleRoute, UNBUILT_ROUTE_TITLE } from "./lib/console-route-probe.js";
 import {
@@ -3386,6 +3387,10 @@ function panelSettingsList() {
             `backend: ${(getSetting(SETTING_BACKEND) ?? "claude")}`,
             `comfyui: ${window.app?.frontendVersion ?? window.app?.extensionManager?.appVersion ?? "unknown"}`,
             `page: ${location.origin}`,
+            // #584 — the one fact five rounds of fixes were guessing at. A user
+            // pasting diagnostics into an issue now brings the measurement with
+            // them instead of being asked to open DevTools afterwards.
+            describeModuleCache(readModuleCacheSummary()),
             `ua: ${navigator.userAgent}`,
             `time: ${new Date().toISOString()}`,
           ].join("\n");
@@ -28481,6 +28486,31 @@ async function healStaleBundleIfNeeded() {
     if (staleness === "current") {
       // A previous heal took — clear the marker so the NEXT update heals too.
       if (ssGet(BUNDLE_HEAL_KEY)) ssSet(BUNDLE_HEAL_KEY, null);
+      // #584 — "current" IS THE BLIND SPOT. This compares one number: the
+      // PANEL_VERSION of the module that happens to hold it. ComfyUI imports
+      // 112 of our modules independently, so a page can carry that constant
+      // fresh and its siblings stale, report `current`, heal nothing, and still
+      // refuse every write. That is the shape this issue keeps coming back
+      // with — a version check that looks healthy while the page does not
+      // behave like it.
+      //
+      // So when the version says current, ask the OTHER question: did these
+      // modules actually come off the wire? A healthy load is all-network and
+      // says nothing. Anything else is the datum five rounds of fixes have been
+      // missing, and it is stated once, at the moment it is observable.
+      try {
+        const cache = readModuleCacheSummary();
+        if (cache.verdict === "mixed" || cache.verdict === "all-cached") {
+          console.warn(
+            `[comfyui-mcp-panel] version reads CURRENT (${PANEL_VERSION}), but ${describeModuleCache(cache)} ` +
+              `If panel_* writes are being refused, quote this line in ` +
+              `https://github.com/artokun/comfyui-mcp-panel/issues/584 — it is the measurement that ` +
+              `issue is missing. A hard refresh (Ctrl+Shift+R) is the workaround.`,
+          );
+        }
+      } catch {
+        /* a diagnostic must never break startup */
+      }
       return;
     }
     if (staleness !== "stale") return;

--- a/web/js/lib/module-cache-report.js
+++ b/web/js/lib/module-cache-report.js
@@ -41,11 +41,13 @@
 function isOurModule(entry, base) {
   const name = typeof entry?.name === "string" ? entry.name : "";
   if (!name.includes(base)) return false;
-  // `initiatorType` is "script" for a module fetch; a `link rel=modulepreload`
-  // shows as "link". Both are real fetches of our code. Anything else with this
-  // prefix (an image, a fetch() of the version probe) is not a module.
-  const kind = entry?.initiatorType;
-  return kind === undefined || kind === "script" || kind === "link" || kind === "other";
+  // MUST BE A .js URL, not merely one of ours (codex review). Filtering by
+  // `initiatorType` does not work: Resource Timing reports a stylesheet and a
+  // `link rel=modulepreload` both as "link", so a cached panel CSS file would
+  // have manufactured a "some modules are cached" finding out of nothing.
+  // Every module ComfyUI auto-imports is a .js, so the URL decides.
+  const path = name.split("?")[0].split("#")[0];
+  return path.endsWith(".js");
 }
 
 /**
@@ -54,6 +56,14 @@ function isOurModule(entry, base) {
  * @returns {"cached"|"network"|"unknown"}
  */
 export function classifyEntry(entry) {
+  // A 304 IS A CACHE HIT, AND IT IS *THE* ONE THIS ISSUE IS ABOUT (codex review).
+  // A revalidation transfers headers — so transferSize is NONZERO — while the
+  // body comes from the cache. Classifying it by bytes alone called it "network"
+  // and would have reported "staleness here is NOT the HTTP cache" for a page
+  // built entirely of stale 304s. That is precisely the mechanism ComfyUI's own
+  // e0982a71 describes: an aiohttp ETag from mtime+size matching, 304, stale
+  // content served. A false all-clear on the exact case under investigation.
+  if (entry?.responseStatus === 304) return "revalidated";
   const transfer = entry?.transferSize;
   const decoded = entry?.decodedBodySize;
   // The API is not required to expose sizes. Absent numbers are not evidence.
@@ -76,20 +86,37 @@ export function classifyEntry(entry) {
  */
 export function summarizeModuleCache(entries, opts = {}) {
   const base = typeof opts.base === "string" && opts.base ? opts.base : "/extensions/comfyui-mcp-panel/";
-  const empty = { total: 0, cached: 0, network: 0, unknown: 0, verdict: "unknown", cachedUrls: [], statuses: {} };
+  const empty = {
+    total: 0,
+    cached: 0,
+    revalidated: 0,
+    network: 0,
+    unknown: 0,
+    verdict: "unknown",
+    cachedUrls: [],
+    statuses: {},
+    bufferMaybeFull: false,
+  };
   if (!entries || typeof entries.length !== "number") return empty;
 
   const out = { ...empty, cachedUrls: [], statuses: {} };
+  // THE BUFFER DROPS ENTRIES ONCE FULL, and the spec's floor is 250 while this
+  // page alone loads 112 panel modules on top of ComfyUI's own (codex review).
+  // A page whose cached modules were evicted and whose fetched ones survived
+  // reads as "everything was fetched" — the false all-clear this module exists
+  // to prevent. We cannot know what was dropped, so we record that we might be
+  // looking at a partial list and never let the summary claim completeness.
+  out.bufferMaybeFull = entries.length >= 250;
   for (let i = 0; i < entries.length; i++) {
     const entry = entries[i];
     if (!isOurModule(entry, base)) continue;
     out.total++;
     const verdict = classifyEntry(entry);
     out[verdict]++;
-    if (verdict === "cached") {
-      // The URL is the actionable half — WHICH modules are stale tells skew
-      // apart from a uniformly old page. Bounded: a wedged page has 112 of
-      // these and an unbounded list helps nobody read the first ten.
+    if (verdict === "cached" || verdict === "revalidated") {
+      // The URL is the actionable half — WHICH modules came from cache tells a
+      // partial page apart from a uniformly old one. Bounded: a wedged page has
+      // 112 of these and an unbounded list helps nobody read the first ten.
       if (out.cachedUrls.length < 12) out.cachedUrls.push(shortName(entry.name, base));
     }
     const status = entry?.responseStatus;
@@ -98,10 +125,15 @@ export function summarizeModuleCache(entries, opts = {}) {
     }
   }
 
+  // A revalidated body came out of the cache exactly as a `cached` one did; only
+  // the round trip differs. They are counted apart because the REMEDY differs (a
+  // 304 means an ETag matched and the server participated), but for "did the
+  // cache serve this page", they are the same answer.
+  const fromCache = out.cached + out.revalidated;
   if (out.total === 0) out.verdict = "unknown";
-  else if (out.cached === 0 && out.unknown === 0) out.verdict = "all-network";
-  else if (out.cached === out.total) out.verdict = "all-cached";
-  else if (out.cached > 0) out.verdict = "mixed";
+  else if (fromCache === out.total) out.verdict = "all-cached";
+  else if (fromCache > 0) out.verdict = "mixed";
+  else if (out.unknown === 0) out.verdict = "all-network";
   else out.verdict = "unknown";
   return out;
 }
@@ -130,28 +162,48 @@ export function describeModuleCache(summary) {
       "this is not evidence that they were fresh."
     );
   }
-  const head = `module cache: ${total} panel module(s) — ${s.network || 0} from the network, ${s.cached || 0} from cache, ${s.unknown || 0} undetermined`;
+  const fromCache = (s.cached || 0) + (s.revalidated || 0);
+  const head =
+    `module cache: ${total} panel module(s) in the timing buffer — ${s.network || 0} fetched, ` +
+    `${s.cached || 0} from cache, ${s.revalidated || 0} revalidated (304), ${s.unknown || 0} undetermined`;
   const statuses = Object.keys(s.statuses || {}).length
     ? ` [status ${Object.entries(s.statuses).map(([k, v]) => `${k}×${v}`).join(", ")}]`
     : "";
+  // Never claim completeness the buffer cannot support (codex review).
+  const partial = s.bufferMaybeFull
+    ? " NOTE: the Resource Timing buffer was at or over its default limit, so entries may have been" +
+      " dropped and this list may be incomplete."
+    : "";
+
   if (s.verdict === "all-network") {
-    return `${head}${statuses}. Every module was fetched — staleness here is NOT the HTTP cache.`;
+    return (
+      `${head}${statuses}. Every panel module STILL IN THE BUFFER was fetched from the server, so` +
+      ` nothing here shows the cache serving stale code.${partial}`
+    );
   }
   if (s.verdict === "all-cached") {
     return (
-      `${head}${statuses}. The whole pack came from cache, which ComfyUI's own cache middleware ` +
-      `(no-store on every .js) should prevent — so something between this browser and ComfyUI is ` +
-      `not passing that header: a proxy, tunnel, or Desktop's server. Sample: ${(s.cachedUrls || []).join(", ")}`
+      `${head}${statuses}. The whole pack came from cache${s.revalidated ? " (including 304 revalidations, where an ETag matched and the cached body was reused)" : ""}` +
+      `, which ComfyUI's own cache middleware (no-store on every .js) should prevent — so something` +
+      ` between this browser and ComfyUI is not passing that header: a proxy, tunnel, or Desktop's` +
+      ` server. Sample: ${(s.cachedUrls || []).join(", ")}${partial}`
     );
   }
   if (s.verdict === "mixed") {
     return (
-      `${head}${statuses}. SOME modules are cached and some are not, so this page is running a ` +
-      `MIXTURE of versions — which is why a single version check can look healthy while writes ` +
-      `stay broken. Cached: ${(s.cachedUrls || []).join(", ")}`
+      `${head}${statuses}. ${fromCache} module(s) came from cache while others were fetched.` +
+      // WHAT THIS DOES AND DOES NOT ESTABLISH (codex review). Cache provenance is
+      // not content equality: a cached module can be byte-identical to the served
+      // one. Saying "this page is running a MIXTURE of versions" asserted the
+      // conclusion this evidence only makes POSSIBLE — and version skew is
+      // precisely what a single version check cannot see, so overstating it would
+      // send the next investigation off on a finding that was never established.
+      ` That makes version skew POSSIBLE — cached and fetched modules can still be identical, so` +
+      ` this is not proof of it — and skew is invisible to the single-version check that just` +
+      ` reported healthy. Cached: ${(s.cachedUrls || []).join(", ")}${partial}`
     );
   }
-  return `${head}${statuses}. Too little was reported to tell cache from network.`;
+  return `${head}${statuses}. Too little was reported to tell cache from network.${partial}`;
 }
 
 /** Read the live document's timings; safe to call anywhere (returns the empty

--- a/web/js/lib/module-cache-report.js
+++ b/web/js/lib/module-cache-report.js
@@ -1,0 +1,166 @@
+/**
+ * #584 — THE PAGE ALREADY KNOWS WHETHER ITS MODULES CAME FROM CACHE.
+ *
+ * Five fixes have shipped against "this tab is running stale panel JS" and it
+ * keeps recurring, because every one of them was built on an unmeasured
+ * hypothesis about the browser's cache. The evidence that would settle it has
+ * only ever been askable as "open DevTools → Network → filter, and tell me what
+ * you see" — which almost never comes back, and never comes back from the tab
+ * that was actually wedged.
+ *
+ * It does not need asking. `performance.getEntriesByType("resource")` records
+ * every module fetch the document made, and PerformanceResourceTiming carries
+ * exactly the two facts in dispute:
+ *
+ *   transferSize === 0 with a decoded body  →  served from the HTTP cache
+ *   responseStatus                          →  what the server actually said
+ *
+ * So the tab can report its own cache state, on the recurrence, without a human
+ * in the loop.
+ *
+ * WHAT THIS DOES NOT DO. It does not fix staleness and does not claim to. It
+ * decides between the two live explanations, which no amount of source reading
+ * can: modules disagreeing with each other (skew), or an intermediary stripping
+ * the `no-store` that ComfyUI's own cache middleware puts on every `.js`.
+ *
+ * THREE STATES, NOT TWO. "Cannot tell" is a real answer here and is kept
+ * separate from "came from the network":
+ *
+ *   • the Resource Timing API may be unavailable or the buffer already dropped;
+ *   • `transferSize` is 0 for a CROSS-ORIGIN response without
+ *     Timing-Allow-Origin, which looks identical to a cache hit. Our modules are
+ *     same-origin so it should not arise — but "should not" is how this issue
+ *     got five fixes, so an entry with no decoded body is `unknown`, never
+ *     `cached`.
+ *
+ * Reporting "all fresh" when the truth is "the API told us nothing" would send
+ * the next investigation down exactly the path this module exists to close.
+ */
+
+/** A resource entry that is one of OUR modules, by URL prefix. */
+function isOurModule(entry, base) {
+  const name = typeof entry?.name === "string" ? entry.name : "";
+  if (!name.includes(base)) return false;
+  // `initiatorType` is "script" for a module fetch; a `link rel=modulepreload`
+  // shows as "link". Both are real fetches of our code. Anything else with this
+  // prefix (an image, a fetch() of the version probe) is not a module.
+  const kind = entry?.initiatorType;
+  return kind === undefined || kind === "script" || kind === "link" || kind === "other";
+}
+
+/**
+ * Classify ONE resource entry.
+ *
+ * @returns {"cached"|"network"|"unknown"}
+ */
+export function classifyEntry(entry) {
+  const transfer = entry?.transferSize;
+  const decoded = entry?.decodedBodySize;
+  // The API is not required to expose sizes. Absent numbers are not evidence.
+  if (typeof transfer !== "number" || typeof decoded !== "number") return "unknown";
+  // A body we never saw the size of cannot be called a cache hit — this is the
+  // cross-origin/opaque shape, and it is indistinguishable from one.
+  if (decoded <= 0) return "unknown";
+  // Bytes crossed the wire.
+  if (transfer > 0) return "network";
+  // Decoded content with nothing transferred: the cache served it.
+  return "cached";
+}
+
+/**
+ * Summarise how this document obtained the panel's modules.
+ *
+ * @param {ArrayLike<PerformanceResourceTiming>|null|undefined} entries
+ * @param {{ base?: string }} [opts] `base` is the URL fragment identifying our
+ *        modules; defaults to the pack's extension path.
+ */
+export function summarizeModuleCache(entries, opts = {}) {
+  const base = typeof opts.base === "string" && opts.base ? opts.base : "/extensions/comfyui-mcp-panel/";
+  const empty = { total: 0, cached: 0, network: 0, unknown: 0, verdict: "unknown", cachedUrls: [], statuses: {} };
+  if (!entries || typeof entries.length !== "number") return empty;
+
+  const out = { ...empty, cachedUrls: [], statuses: {} };
+  for (let i = 0; i < entries.length; i++) {
+    const entry = entries[i];
+    if (!isOurModule(entry, base)) continue;
+    out.total++;
+    const verdict = classifyEntry(entry);
+    out[verdict]++;
+    if (verdict === "cached") {
+      // The URL is the actionable half — WHICH modules are stale tells skew
+      // apart from a uniformly old page. Bounded: a wedged page has 112 of
+      // these and an unbounded list helps nobody read the first ten.
+      if (out.cachedUrls.length < 12) out.cachedUrls.push(shortName(entry.name, base));
+    }
+    const status = entry?.responseStatus;
+    if (typeof status === "number" && status > 0) {
+      out.statuses[status] = (out.statuses[status] || 0) + 1;
+    }
+  }
+
+  if (out.total === 0) out.verdict = "unknown";
+  else if (out.cached === 0 && out.unknown === 0) out.verdict = "all-network";
+  else if (out.cached === out.total) out.verdict = "all-cached";
+  else if (out.cached > 0) out.verdict = "mixed";
+  else out.verdict = "unknown";
+  return out;
+}
+
+/** `/extensions/comfyui-mcp-panel/js/lib/x.js` → `js/lib/x.js`. */
+function shortName(name, base) {
+  const i = typeof name === "string" ? name.indexOf(base) : -1;
+  return i === -1 ? String(name ?? "") : name.slice(i + base.length);
+}
+
+/**
+ * The human/agent-readable line for a summary — the sentence that lands in a
+ * console warning and in an issue report.
+ *
+ * Deliberately states the OBSERVATION and its consequence separately, because
+ * the two branches have different owners: `mixed` is ours to fix (modules
+ * disagreeing), `all-cached` points outside the panel entirely (something is
+ * not honouring the `no-store` ComfyUI sets on every .js).
+ */
+export function describeModuleCache(summary) {
+  const s = summary ?? {};
+  const total = s.total || 0;
+  if (!total) {
+    return (
+      "module cache: could not be measured (the Resource Timing buffer held no panel modules) — " +
+      "this is not evidence that they were fresh."
+    );
+  }
+  const head = `module cache: ${total} panel module(s) — ${s.network || 0} from the network, ${s.cached || 0} from cache, ${s.unknown || 0} undetermined`;
+  const statuses = Object.keys(s.statuses || {}).length
+    ? ` [status ${Object.entries(s.statuses).map(([k, v]) => `${k}×${v}`).join(", ")}]`
+    : "";
+  if (s.verdict === "all-network") {
+    return `${head}${statuses}. Every module was fetched — staleness here is NOT the HTTP cache.`;
+  }
+  if (s.verdict === "all-cached") {
+    return (
+      `${head}${statuses}. The whole pack came from cache, which ComfyUI's own cache middleware ` +
+      `(no-store on every .js) should prevent — so something between this browser and ComfyUI is ` +
+      `not passing that header: a proxy, tunnel, or Desktop's server. Sample: ${(s.cachedUrls || []).join(", ")}`
+    );
+  }
+  if (s.verdict === "mixed") {
+    return (
+      `${head}${statuses}. SOME modules are cached and some are not, so this page is running a ` +
+      `MIXTURE of versions — which is why a single version check can look healthy while writes ` +
+      `stay broken. Cached: ${(s.cachedUrls || []).join(", ")}`
+    );
+  }
+  return `${head}${statuses}. Too little was reported to tell cache from network.`;
+}
+
+/** Read the live document's timings; safe to call anywhere (returns the empty
+ *  summary when the API is missing, which is `unknown`, not `fresh`). */
+export function readModuleCacheSummary(perf = typeof performance === "undefined" ? null : performance, opts) {
+  try {
+    if (!perf || typeof perf.getEntriesByType !== "function") return summarizeModuleCache(null, opts);
+    return summarizeModuleCache(perf.getEntriesByType("resource"), opts);
+  } catch {
+    return summarizeModuleCache(null, opts); // a diagnostic must never throw
+  }
+}


### PR DESCRIPTION
Draft — claiming #584.

## Why another round at a different layer

Five fixes have shipped against this issue and it keeps recurring. Measurements I took against the live rig today move the ground under the current plan of record:

**1. It is 112 modules, not 12.** `/api/extensions` lists every `.js` recursively — 12 top-level, 96 `lib/`, 4 `vendor/`. The last analysis on this thread assumed `lib/*` arrived as nested imports beneath a dozen entry points; they are independent auto-imported fetches.

**2. The scan filters by suffix, and it is live.** A `.mjs` dropped next to a `.js` is not listed, and `/api/extensions` reflects the change with no restart. So "collapse to one entry point" is achievable — by taking modules out of the `.js` scan — but that is a 100-file rename and not this PR.

**3. The heal already reaches all 12 top-level modules.** I expected `primeModuleCache` to miss the siblings ComfyUI imports directly; computed over the real import graph, 108 of 112 are reachable and every top-level module is. That hypothesis is dead.

**4. All 112 are served `no-store` — and that is ComfyUI's doing, not ours.** `middleware/cache_middleware.py` sets `Cache-Control: no-store` on any path ending `.js`, introduced by ComfyUI e0982a71 (*"use no-store cache headers to prevent stale frontend chunks"*, #12911) — whose own commit message describes this issue's mechanism, down to ETags from mtime+size returning 304 with stale content. It predates every reporter's ComfyUI version.

So on a direct connection the HTTP cache **cannot** serve a stale module — yet a hard refresh is what fixes it, which means on affected machines the response is not arriving with that header. I cannot reproduce that here; every request on this rig is a real 200 with `no-store`.

## What this PR does

Stops asking users to open DevTools. The page already knows: `performance.getEntriesByType("resource")` reports, per module, whether it came from the network or from cache (`transferSize`), and what status it got. The panel will summarise its own module fetches and surface it where a wedged session actually looks.

That yields the decisive datum automatically on the next recurrence, and distinguishes the two live branches — version skew across modules vs. a header-stripping intermediary — which no amount of source reading can settle.

Not claiming a fix for the staleness itself. Instrumenting it first, because five attempts have now been built on an unmeasured hypothesis.