### PR TITLE
0.11.77 — a changelog entry stops replaying the whole history (#932)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,34 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+## [0.11.77] - 2026-08-09
+
+> Covers changes since 0.11.76. The first entry this generator produced correctly.
+
+### Fixed
+
+- **Generating a changelog no longer replays the entire history into one release
+  (#932).** Every entry was built from the first commit onward, so a release claimed
+  ~200 commits of already-shipped work as its own. Both release matchers had been
+  written for commit shapes this repo has never produced: the base search grepped for
+  `release:` / `chore(release):`, which matched nothing and fell through to
+  `rev-list --max-parents=0` — the root commit — and the predicate that keeps release
+  commits *out* of an entry required the version to be the whole subject, so releases
+  were written into the entries announcing them. Releases here read
+  `0.11.76 — <description> (#930) (#931)`, and now both rules key on a version at the
+  start of the subject.
+
+  The fix is deliberately not a `git log --grep`. `--grep` searches the whole commit
+  message and matches per line, so `^<version>` also fires on a *body* line — in this
+  repo's own history it selects 7521519, an ordinary `fix(subgraph):` commit, which
+  would have anchored a release on itself and silently truncated the entry. Subjects
+  are read from `%s` and matched in JS, by the same predicate the generator already
+  used, so there is one rule rather than two that can drift.
+
+  This was worked around by hand for all fourteen releases from 0.11.63 to 0.11.76.
+  A silent workaround is how a broken tool survives that long.
+
+
 ## [0.11.76] - 2026-08-09
 
 > Covers changes since 0.11.75.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-agent-panel"
 description = "Autonomous AI agent in the ComfyUI sidebar - local-first, bring any LLM. Run it on your Claude or ChatGPT subscription (no API keys, no extra LLM costs), on a Kimi K3 / GLM / OpenRouter key, or fully offline on free local models via Ollama, LM Studio, or llama.cpp. The agent drives your live canvas at full parity: add, wire, move and tweak nodes with Ctrl+Z undo, load whole workflows and installer packs in one shot, generate images, video and audio, browse CivitAI, and run your workflow - asking before it spends paid API credits. The sidebar UI for comfyui-mcp, the local-first, agent-native control plane for ComfyUI."
-version = "0.11.76"
+version = "0.11.77"
 license = { file = "LICENSE" }
 requires-python = ">=3.9"
 # UI-only pack: no Python deps. The frontend floor guarantees

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -879,7 +879,7 @@ const DOCS_URL = "https://comfyui-mcp.artokun.io/docs";
 // Panel version — surfaced in the "Need help?" diagnostics blob. Bump via
 // `node scripts/set-version.mjs <v>` (updates this AND pyproject together); CI
 // and the publish gate FAIL if the two ever drift, so this can't go stale.
-const PANEL_VERSION = "0.11.76";
+const PANEL_VERSION = "0.11.77";
 
 // The connected orchestrator's console URL/token (captured off the `backends`
 // bridge message — see onBackends). Drives the "API Keys" credentials frame;


### PR DESCRIPTION
Releases the #932 fix.

Every changelog entry was generated from the root commit, so a release claimed ~200 commits of already-shipped work. Hand-corrected on all fourteen releases since 0.11.63; this is the first entry the generator produced correctly on its own — anchored on the 0.11.76 release commit, 1 commit since.

Closes #932