### PR TITLE
0.11.78 — a tab measures its own module cache (#584)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,21 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [0.11.78] - 2026-08-09
 
-### Fixed
-- make the tab measure its own module cache instead of asking for DevTools (#934)
+> Covers changes since 0.11.77.
 
+### Fixed
+
+- **A tab now measures its own module cache instead of asking you to open DevTools
+  (#584).** This issue has had five fixes and keeps coming back, because each was built
+  on a hypothesis about the browser cache that nobody had measured — and the only way to
+  measure it was to ask someone whose tab was already wedged to read their Network tab.
+  The panel now reports, per module, whether it came from the server, from cache, or via
+  a 304 revalidation, and says so when the version check reads healthy but the modules
+  did not. That branch used to return silently, which is the shape this issue keeps
+  returning with: one version constant looking fine while the page it belongs to does
+  not behave like it. A healthy load stays silent. The same summary goes into the
+  diagnostics you copy into an issue, so the next report arrives with the measurement
+  already in it.
 
 ## [0.11.77] - 2026-08-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+## [0.11.78] - 2026-08-09
+
+### Fixed
+- make the tab measure its own module cache instead of asking for DevTools (#934)
+
+
 ## [0.11.77] - 2026-08-09
 
 > Covers changes since 0.11.76. The first entry this generator produced correctly.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-agent-panel"
 description = "Autonomous AI agent in the ComfyUI sidebar - local-first, bring any LLM. Run it on your Claude or ChatGPT subscription (no API keys, no extra LLM costs), on a Kimi K3 / GLM / OpenRouter key, or fully offline on free local models via Ollama, LM Studio, or llama.cpp. The agent drives your live canvas at full parity: add, wire, move and tweak nodes with Ctrl+Z undo, load whole workflows and installer packs in one shot, generate images, video and audio, browse CivitAI, and run your workflow - asking before it spends paid API credits. The sidebar UI for comfyui-mcp, the local-first, agent-native control plane for ComfyUI."
-version = "0.11.77"
+version = "0.11.78"
 license = { file = "LICENSE" }
 requires-python = ">=3.9"
 # UI-only pack: no Python deps. The frontend floor guarantees

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -880,7 +880,7 @@ const DOCS_URL = "https://comfyui-mcp.artokun.io/docs";
 // Panel version — surfaced in the "Need help?" diagnostics blob. Bump via
 // `node scripts/set-version.mjs <v>` (updates this AND pyproject together); CI
 // and the publish gate FAIL if the two ever drift, so this can't go stale.
-const PANEL_VERSION = "0.11.77";
+const PANEL_VERSION = "0.11.78";
 
 // The connected orchestrator's console URL/token (captured off the `backends`
 // bridge message — see onBackends). Drives the "API Keys" credentials frame;


### PR DESCRIPTION
Version bump + changelog for 0.11.78, covering #934.

First release cut with the fixed `gen-changelog` (#933, released in 0.11.77): it anchored on `b2e75a9` and found **1 commit**, against the 200 it claimed when I hit #932 two releases ago. Entry expanded by hand to match the file's voice, but the base and the scope came out correct on their own.