### PR TITLE
fix(history): the first chat in a workflow stops vanishing from its own filter (#847)

### DIFF
--- a/browser_tests/unit/pre-grounding-identity.test.mjs
+++ b/browser_tests/unit/pre-grounding-identity.test.mjs
@@ -19,6 +19,7 @@ import {
   rememberPreGroundingIdentity,
   preGroundingIdentityForms,
   pruneGroundingIdentities,
+  groundedWorkflowPath,
   normalizedWorkflowPath,
 } from "../../web/js/lib/workflow-chat-identity.js";
 import { normalizePath } from "../../web/js/lib/workflow-save.js";
@@ -155,12 +156,7 @@ test("#847: a save's name canonicalises to one path shape", () => {
   // (codex): `Name.json` became `workflows/Name.json.json`, `workflows\Name.json` grew a
   // second prefix, and `workflows/Name` never got an extension. All four shapes must land
   // on the same key, or the lineage is filed where nothing will look for it.
-  const canon = (savedName) => {
-    const raw = normalizePath(savedName).replace(/^\/+/, "");
-    if (!raw) return null;
-    const withDir = raw.includes("/") ? raw : `workflows/${raw}`;
-    return /\.json$/i.test(withDir) ? withDir : `${withDir}.json`;
-  };
+  const canon = groundedWorkflowPath;
   const BACKSLASH = String.fromCharCode(92); // heredocs eat escaped backslashes; be literal
   for (const name of ["Flow", "Flow.json", "workflows/Flow.json", `workflows${BACKSLASH}Flow.json`, "workflows/Flow", "/workflows/Flow.json"]) {
     assert.equal(normalizedWorkflowPath(canon(name)), "workflows/flow.json", name);

--- a/browser_tests/unit/pre-grounding-identity.test.mjs
+++ b/browser_tests/unit/pre-grounding-identity.test.mjs
@@ -21,6 +21,7 @@ import {
   pruneGroundingIdentities,
   normalizedWorkflowPath,
 } from "../../web/js/lib/workflow-chat-identity.js";
+import { normalizePath } from "../../web/js/lib/workflow-save.js";
 
 const TMP = "tmp:8b7791e6-e618-4266-93fa-b3a1434d6902";
 const KEY = "workflow:ad8c385e-1111-2222-3333-444455556666";
@@ -103,7 +104,12 @@ test("#847: a lineage whose workflow is gone is dropped, not left to catch a nam
   const map = {};
   rememberPreGroundingIdentity(map, { path: "workflows/Gone.json", storageKey: KEY, routeId: TMP });
   rememberPreGroundingIdentity(map, { path: "workflows/Live.json", storageKey: KEY, routeId: TMP });
-  assert.equal(pruneGroundingIdentities(map, { knownPaths: ["workflows/Live.json"] }), true);
+  // Only over the cap: under it, an unlisted path is far more likely a store that has not
+  // caught up than a deletion, and eagerly pruning that lost real history (codex).
+  assert.equal(pruneGroundingIdentities(map, { knownPaths: ["workflows/Live.json"] }), false);
+  assert.deepEqual(preGroundingIdentityForms(map, "workflows/Gone.json"), [KEY, TMP]);
+  // Over the cap something must go, so the dead path goes first and the live one survives.
+  assert.equal(pruneGroundingIdentities(map, { knownPaths: ["workflows/Live.json"], max: 1 }), true);
   assert.deepEqual(preGroundingIdentityForms(map, "workflows/Gone.json"), []);
   assert.deepEqual(preGroundingIdentityForms(map, "workflows/Live.json"), [KEY, TMP]);
 });
@@ -115,6 +121,10 @@ test("#847: an unreadable workflow list prunes nothing", () => {
   rememberPreGroundingIdentity(map, { path: PATH, storageKey: KEY, routeId: TMP });
   assert.equal(pruneGroundingIdentities(map, { knownPaths: null }), false);
   assert.deepEqual(preGroundingIdentityForms(map, PATH), [KEY, TMP]);
+  // Even over the cap an unreadable list only evicts by age, never by "not listed".
+  rememberPreGroundingIdentity(map, { path: "workflows/Second.json", storageKey: KEY, routeId: TMP });
+  pruneGroundingIdentities(map, { knownPaths: null, max: 1 });
+  assert.deepEqual(preGroundingIdentityForms(map, "workflows/Second.json"), [KEY, TMP], "newest kept");
 });
 
 test("#847: the map stays bounded, oldest first", () => {
@@ -125,4 +135,36 @@ test("#847: the map stays bounded, oldest first", () => {
   assert.equal(Object.keys(map).length, 4);
   assert.deepEqual(preGroundingIdentityForms(map, paths[0]), [], "the oldest went first");
   assert.deepEqual(preGroundingIdentityForms(map, paths[5]), [KEY, TMP], "the newest stayed");
+});
+
+test("#847: re-grounding a path refreshes its position, so the cap cannot evict it", () => {
+  // Plain assignment leaves an existing key where it was in insertion order, and the cap
+  // evicts from the front — so a lineage refreshed seconds ago could be dropped as the
+  // "oldest" one (codex).
+  const map = {};
+  rememberPreGroundingIdentity(map, { path: "workflows/a.json", storageKey: KEY, routeId: TMP });
+  rememberPreGroundingIdentity(map, { path: "workflows/b.json", storageKey: KEY, routeId: TMP });
+  rememberPreGroundingIdentity(map, { path: "workflows/a.json", storageKey: KEY, routeId: "tmp:refreshed" });
+  pruneGroundingIdentities(map, { knownPaths: ["workflows/a.json", "workflows/b.json"], max: 1 });
+  assert.deepEqual(preGroundingIdentityForms(map, "workflows/a.json"), [KEY, "tmp:refreshed"]);
+  assert.deepEqual(preGroundingIdentityForms(map, "workflows/b.json"), [], "the genuinely older one went");
+});
+
+test("#847: a save's name canonicalises to one path shape", () => {
+  // The naive `includes("/") ? name : \`workflows/${name}.json\`` mangled real inputs
+  // (codex): `Name.json` became `workflows/Name.json.json`, `workflows\Name.json` grew a
+  // second prefix, and `workflows/Name` never got an extension. All four shapes must land
+  // on the same key, or the lineage is filed where nothing will look for it.
+  const canon = (savedName) => {
+    const raw = normalizePath(savedName).replace(/^\/+/, "");
+    if (!raw) return null;
+    const withDir = raw.includes("/") ? raw : `workflows/${raw}`;
+    return /\.json$/i.test(withDir) ? withDir : `${withDir}.json`;
+  };
+  const BACKSLASH = String.fromCharCode(92); // heredocs eat escaped backslashes; be literal
+  for (const name of ["Flow", "Flow.json", "workflows/Flow.json", `workflows${BACKSLASH}Flow.json`, "workflows/Flow", "/workflows/Flow.json"]) {
+    assert.equal(normalizedWorkflowPath(canon(name)), "workflows/flow.json", name);
+  }
+  assert.equal(canon(""), null);
+  assert.equal(canon(null), null);
 });

--- a/browser_tests/unit/pre-grounding-identity.test.mjs
+++ b/browser_tests/unit/pre-grounding-identity.test.mjs
@@ -1,0 +1,88 @@
+// #847 — the identity a tab held before GROUNDING saved it, kept so the conversation
+// recorded a moment earlier still belongs to the workflow it was held on.
+//
+// Grounding (#330) auto-saves an unsaved workflow before a turn. ComfyUI REPLACES the
+// ComfyWorkflow object at that save, and the successor finds nothing to inherit from:
+// the object WeakMaps are keyed on the object that is gone, the embedded-uuid carriers
+// `workflowOwnedExtra` reads are all absent on this frontend, and the path alias is
+// written from the NEW id. So it mints a fresh identity, and the first chat about the
+// workflow drops out of "Current workflow only".
+//
+// Instrumented on a live ComfyUI before writing any of this — the two threads carried
+// `workflow:ff7890d8…`/`tmp:bbf55b89…` and `workflow:80140efd…`/`wf:workflows/Untitled…`,
+// with `activeState.extra` holding the original uuid right after the save and null by the
+// time the filter ran. Nothing live survives to be read later, which is why the record has
+// to be written AT the save.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  rememberPreGroundingIdentity,
+  preGroundingIdentityForms,
+  normalizedWorkflowPath,
+} from "../../web/js/lib/workflow-chat-identity.js";
+
+const TMP = "tmp:8b7791e6-e618-4266-93fa-b3a1434d6902";
+const KEY = "workflow:ad8c385e-1111-2222-3333-444455556666";
+const PATH = "workflows/Untitled 2026-08-09 19-40-25.json";
+
+test("#847: a grounded path remembers the forms the tab held before the save", () => {
+  const map = {};
+  assert.equal(rememberPreGroundingIdentity(map, { path: PATH, storageKey: KEY, routeId: TMP }), true);
+  const forms = preGroundingIdentityForms(map, PATH);
+  assert.ok(forms.includes(KEY), "the pre-save storage key is what the orphaned thread carries");
+  assert.ok(forms.includes(TMP), "the pre-save route id is the other form a thread may hold");
+});
+
+test("#847: lookup is path-normalised, not literal", () => {
+  // Windows hands back backslashes and case varies; a filter that misses on either shows
+  // the bug this fixes while looking like it works.
+  const map = {};
+  rememberPreGroundingIdentity(map, { path: PATH, storageKey: KEY, routeId: TMP });
+  assert.deepEqual(
+    preGroundingIdentityForms(map, "workflows\\Untitled 2026-08-09 19-40-25.json"),
+    [KEY, TMP],
+  );
+  assert.deepEqual(preGroundingIdentityForms(map, PATH.toUpperCase()), [KEY, TMP]);
+});
+
+test("#847: only a genuine pre-save boundary is recorded", () => {
+  // Saving an ALREADY-saved workflow breaks no lineage. Recording one would invent a
+  // relationship rather than remember it, and the whole safety argument here is that
+  // nothing is inferred.
+  const map = {};
+  assert.equal(
+    rememberPreGroundingIdentity(map, { path: PATH, storageKey: KEY, routeId: "wf:workflows/Other.json" }),
+    false,
+    "a wf: route means this tab was already saved — no boundary",
+  );
+  assert.equal(rememberPreGroundingIdentity(map, { path: PATH, storageKey: KEY, routeId: null }), false);
+  assert.equal(rememberPreGroundingIdentity(map, { path: "", storageKey: KEY, routeId: TMP }), false);
+  assert.equal(rememberPreGroundingIdentity(map, { path: PATH, storageKey: null, routeId: null }), false);
+  assert.deepEqual(map, {}, "nothing unprovable is written");
+});
+
+test("#847: an unknown path contributes no identity forms", () => {
+  // The filter unions these into the current workflow's key set. Returning anything for a
+  // path never grounded would let one workflow's chats appear under another — the
+  // cross-attribution this area exists to prevent.
+  // Entries are STORED under the normalised path, so a hand-built map has to use it too —
+  // the writer normalises and the reader normalises, and that symmetry is the point.
+  const stored = normalizedWorkflowPath(PATH);
+  assert.deepEqual(preGroundingIdentityForms({}, PATH), []);
+  assert.deepEqual(preGroundingIdentityForms(null, PATH), []);
+  assert.deepEqual(preGroundingIdentityForms({ [stored]: "not-an-array" }, PATH), []);
+  assert.deepEqual(preGroundingIdentityForms({ [stored]: [KEY, null, 7, ""] }, PATH), [KEY]);
+  assert.deepEqual(preGroundingIdentityForms({}, null), []);
+  // A raw, unnormalised key must NOT resolve — that would mean the two halves disagree.
+  assert.deepEqual(preGroundingIdentityForms({ "WORKFLOWS/Foo.json": [KEY] }, "WORKFLOWS/Foo.json"), []);
+});
+
+test("#847: the latest grounding into a path replaces an older lineage", () => {
+  // A path is created fresh by the grounding that names it. If a name is ever reused, the
+  // record must describe the workflow living there NOW — otherwise a deleted workflow's
+  // chats surface under its successor.
+  const map = {};
+  rememberPreGroundingIdentity(map, { path: PATH, storageKey: KEY, routeId: TMP });
+  rememberPreGroundingIdentity(map, { path: PATH, storageKey: "workflow:newer", routeId: "tmp:newer" });
+  assert.deepEqual(preGroundingIdentityForms(map, PATH), ["workflow:newer", "tmp:newer"]);
+});

--- a/browser_tests/unit/pre-grounding-identity.test.mjs
+++ b/browser_tests/unit/pre-grounding-identity.test.mjs
@@ -18,6 +18,7 @@ import assert from "node:assert/strict";
 import {
   rememberPreGroundingIdentity,
   preGroundingIdentityForms,
+  pruneGroundingIdentities,
   normalizedWorkflowPath,
 } from "../../web/js/lib/workflow-chat-identity.js";
 
@@ -85,4 +86,43 @@ test("#847: the latest grounding into a path replaces an older lineage", () => {
   rememberPreGroundingIdentity(map, { path: PATH, storageKey: KEY, routeId: TMP });
   rememberPreGroundingIdentity(map, { path: PATH, storageKey: "workflow:newer", routeId: "tmp:newer" });
   assert.deepEqual(preGroundingIdentityForms(map, PATH), ["workflow:newer", "tmp:newer"]);
+});
+
+test("#847: a bare tmp: prefix is not an identity", () => {
+  // `startsWith("tmp:")` accepted `tmp:` itself (codex) — a prefix with nothing behind it,
+  // which names no workflow and could only ever match by accident.
+  const map = {};
+  assert.equal(rememberPreGroundingIdentity(map, { path: PATH, storageKey: KEY, routeId: "tmp:" }), false);
+  assert.deepEqual(map, {});
+});
+
+test("#847: a lineage whose workflow is gone is dropped, not left to catch a namesake", () => {
+  // The dangerous direction. Delete a workflow, let a new one take the name, and a kept
+  // entry would show the dead workflow's chats under its successor — a false INCLUSION in
+  // the one filter whose entire promise is not to do that.
+  const map = {};
+  rememberPreGroundingIdentity(map, { path: "workflows/Gone.json", storageKey: KEY, routeId: TMP });
+  rememberPreGroundingIdentity(map, { path: "workflows/Live.json", storageKey: KEY, routeId: TMP });
+  assert.equal(pruneGroundingIdentities(map, { knownPaths: ["workflows/Live.json"] }), true);
+  assert.deepEqual(preGroundingIdentityForms(map, "workflows/Gone.json"), []);
+  assert.deepEqual(preGroundingIdentityForms(map, "workflows/Live.json"), [KEY, TMP]);
+});
+
+test("#847: an unreadable workflow list prunes nothing", () => {
+  // Absence of evidence is not evidence every workflow was deleted. Clearing here would
+  // silently reintroduce the bug whenever the store is momentarily unavailable.
+  const map = {};
+  rememberPreGroundingIdentity(map, { path: PATH, storageKey: KEY, routeId: TMP });
+  assert.equal(pruneGroundingIdentities(map, { knownPaths: null }), false);
+  assert.deepEqual(preGroundingIdentityForms(map, PATH), [KEY, TMP]);
+});
+
+test("#847: the map stays bounded, oldest first", () => {
+  const map = {};
+  const paths = Array.from({ length: 6 }, (_, i) => `workflows/w${i}.json`);
+  for (const p of paths) rememberPreGroundingIdentity(map, { path: p, storageKey: KEY, routeId: TMP });
+  pruneGroundingIdentities(map, { knownPaths: paths, max: 4 });
+  assert.equal(Object.keys(map).length, 4);
+  assert.deepEqual(preGroundingIdentityForms(map, paths[0]), [], "the oldest went first");
+  assert.deepEqual(preGroundingIdentityForms(map, paths[5]), [KEY, TMP], "the newest stayed");
 });

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -126,6 +126,7 @@ import {
   rememberPreGroundingIdentity,
   preGroundingIdentityForms,
   pruneGroundingIdentities,
+  groundedWorkflowPath,
 } from "./lib/workflow-chat-identity.js";
 import { validateA2UISpec, renderA2UICard, renderA2UIInert, renderA2UIFailCard, A2UI_CSS } from "./cmcp-a2ui.js";
 import { openSidePanel } from "./cmcp-sidepanel-ui.js";
@@ -4305,20 +4306,24 @@ async function groundUnsavedWorkflow() {
       // #847 — both halves run INSIDE the serialized grounding, against the workflow that
       // transaction is saving. The probe is synchronous with reading it, and the path comes
       // from the save's own result, so neither can be about a tab the user switched to.
-      identityProbe: (wf) => ({
-        storageKey: workflowStorageKey(),
-        routeId: workflowTabId(wf),
-      }),
+      // ROUTE ID ONLY, and that restriction is the fix for a regression I caused:
+      // `workflowStorageKey()` is NOT a read. It runs the full identity resolution, which
+      // mints uuids and writes path aliases — so probing it here performed identity work at
+      // a point in the save where it had never happened, and conversation-persistence:350
+      // ("clear all … preserves workflow identity") went red. `workflowTabId` returns the
+      // tmp: id this tab already routes on, and threads carry it as `workflowRouteKey`,
+      // which is what the filter matches. Enough to bridge, without touching identity.
+      // A PURE READ. Neither `workflowStorageKey()` nor `workflowTabId()` is one:
+      // the first runs full identity resolution (minting uuids, writing path aliases) and
+      // the second mints a tmp: id. Calling either here performed identity work at a point
+      // in the save where it had never happened, and turned conversation-persistence:350
+      // ("clear all … preserves workflow identity") red. The tmp: id this tab already
+      // routes on is enough — threads carry it as `workflowRouteKey`, which is what the
+      // filter matches — and if none exists yet there is nothing to bridge anyway.
+      identityProbe: (wf) => ({ routeId: (wf ? _tempWorkflowInstanceIds.get(wf) : null) ?? null }),
       onGrounded: ({ savedName, identity }) => {
-        // Canonicalise the save's own name into the SAME shape savedWorkflowPath()
-        // produces. Naive concatenation mangled real inputs (codex): `Name.json` became
-        // `workflows/Name.json.json`, and `workflows\Name.json` grew a second prefix.
-        const path = (() => {
-          const raw = normalizePath(savedName).replace(/^\/+/, "");
-          if (!raw) return null;
-          const withDir = raw.includes("/") ? raw : `workflows/${raw}`;
-          return /\.json$/i.test(withDir) ? withDir : `${withDir}.json`;
-        })();
+        // One implementation, shared with the tests (codex) — see groundedWorkflowPath.
+        const path = groundedWorkflowPath(savedName);
         if (!path) return;
         // Prune BEFORE recording, never after: the path this save just created is not in
         // the workflow store's list yet, so pruning afterwards deletes the very entry it

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -123,6 +123,8 @@ import {
   shouldForkInPlaceReload,
   workflowAliasForPath,
   workflowIdentityForms,
+  rememberPreGroundingIdentity,
+  preGroundingIdentityForms,
 } from "./lib/workflow-chat-identity.js";
 import { validateA2UISpec, renderA2UICard, renderA2UIInert, renderA2UIFailCard, A2UI_CSS } from "./cmcp-a2ui.js";
 import { openSidePanel } from "./cmcp-sidepanel-ui.js";
@@ -1518,6 +1520,28 @@ let _workflowUuidAliases = (() => {
     return {};
   }
 })();
+
+// #847 — path -> the identity forms the tab held immediately before the panel GROUNDED it
+// into that path. Durable (localStorage) because the in-memory carriers all die with the
+// workflow object the save replaces, so a reload would otherwise lose the lineage that a
+// WeakMap held for the session. Read only by the chat-history filter.
+const PRE_GROUNDING_IDENTITIES_KEY = "comfyui-mcp.panel.preGroundingIdentities";
+const _preGroundingIdentities = (() => {
+  try {
+    const parsed = JSON.parse(window.localStorage.getItem(PRE_GROUNDING_IDENTITIES_KEY) || "{}");
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? parsed : {};
+  } catch {
+    return {};
+  }
+})();
+
+function persistPreGroundingIdentities() {
+  try {
+    window.localStorage.setItem(PRE_GROUNDING_IDENTITIES_KEY, JSON.stringify(_preGroundingIdentities));
+  } catch {
+    // Quota/private-mode: the in-memory map still covers this session.
+  }
+}
 let workflowAliasMutationSink = null;
 // MODULE-scoped so they survive buildPanel re-mounts (the panel re-mounts on every
 // ComfyUI workflow switch). If these lived in the panel closure, each re-mount would
@@ -4253,13 +4277,32 @@ function describeLiveCanvasBinding(wf) {
 /** If the open workflow was never saved to disk, save it (no dialog) so the
  *  agent works from a grounded file. Best-effort. Returns the saved name or null. */
 async function groundUnsavedWorkflow() {
+  // #847 — capture the identity this tab holds BEFORE the save, while it still holds it.
+  // Grounding replaces the ComfyWorkflow object and re-mints the storage uuid, and by the
+  // time anything observes the result every live carrier of the old identity is gone
+  // (measured: the object WeakMaps die with the object, `activeState.extra` is cleared,
+  // and the path alias is written from the NEW id). Read it here or not at all.
+  const preGroundRoute = (() => {
+    try {
+      return workflowTabId();
+    } catch {
+      return null;
+    }
+  })();
+  const preGroundStorageKey = (() => {
+    try {
+      return workflowStorageKey();
+    } catch {
+      return null;
+    }
+  })();
   try {
     // #330: ground the active workflow ATOMICALLY — probe its on-disk state and save
     // the EXACT SAME workflow (refusing if the user switched tabs during the async
     // probe, so we can't authorize on tab A and overwrite tab B), single-flighted so
     // concurrent turns can't create duplicate copies. Only a provably never-persisted
     // source is saved; anything unprovable is left for a manual Ctrl+S.
-    return await groundActiveWorkflow(app?.extensionManager?.workflow, {
+    const saved = await groundActiveWorkflow(app?.extensionManager?.workflow, {
       existsOnDisk: workflowExistsOnDisk,
       autoWorkflowName,
       reconcileSavedCopy: reconcileSavedWorkflowCopy,
@@ -4267,6 +4310,26 @@ async function groundUnsavedWorkflow() {
       // one that must not write a canvas belonging to a different workflow into it.
       canvasBinding: describeLiveCanvasBinding,
     });
+    // #847 — bind the pre-save identity to the path the save just created. `saved` is a
+    // truthy name ONLY when this call actually persisted this tab's workflow, which is the
+    // causal ownership the history filter needs and which no later observer can prove.
+    if (saved) {
+      try {
+        const path = savedWorkflowPath(activeWorkflowRef()) || `workflows/${saved}.json`;
+        if (
+          rememberPreGroundingIdentity(_preGroundingIdentities, {
+            path,
+            storageKey: preGroundStorageKey,
+            routeId: preGroundRoute,
+          })
+        ) {
+          persistPreGroundingIdentities();
+        }
+      } catch {
+        // Bookkeeping for a chat filter must never break the save that just succeeded.
+      }
+    }
+    return saved;
   } catch {
     return null; // best-effort — never block the chat on a save hiccup
   }
@@ -23092,6 +23155,13 @@ function buildPanel() {
         routeId: liveRouteId,
         priorRouteId: activeWf ? _priorTempWorkflowIds.get(activeWf) : null,
       });
+      // #847 — and the identity this tab held before GROUNDING created this path. The
+      // WeakMap above cannot help here: grounding replaces the workflow object, so it has
+      // nothing under the successor's key. This lineage was recorded by the save itself,
+      // which is the only observer that can prove the old id was this tab's.
+      for (const form of preGroundingIdentityForms(_preGroundingIdentities, savedWorkflowPath(activeWf))) {
+        currentWorkflowKeys.add(form);
+      }
 
       const visible = threads
         .filter((candidate) =>

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -4310,22 +4310,31 @@ async function groundUnsavedWorkflow() {
         routeId: workflowTabId(wf),
       }),
       onGrounded: ({ savedName, identity }) => {
-        // A bare name from the save; a name that already carries a directory is used as-is.
-        const path = String(savedName).includes("/") ? String(savedName) : `workflows/${savedName}.json`;
+        // Canonicalise the save's own name into the SAME shape savedWorkflowPath()
+        // produces. Naive concatenation mangled real inputs (codex): `Name.json` became
+        // `workflows/Name.json.json`, and `workflows\Name.json` grew a second prefix.
+        const path = (() => {
+          const raw = normalizePath(savedName).replace(/^\/+/, "");
+          if (!raw) return null;
+          const withDir = raw.includes("/") ? raw : `workflows/${raw}`;
+          return /\.json$/i.test(withDir) ? withDir : `${withDir}.json`;
+        })();
+        if (!path) return;
         // Prune BEFORE recording, never after: the path this save just created is not in
         // the workflow store's list yet, so pruning afterwards deletes the very entry it
         // just wrote. That is not theoretical — it broke conversation-persistence:507 the
         // first time round.
-        pruneGroundingIdentities(_preGroundingIdentities, { knownPaths: knownWorkflowPaths() });
-        if (
-          rememberPreGroundingIdentity(_preGroundingIdentities, {
-            path,
-            storageKey: identity?.storageKey,
-            routeId: identity?.routeId,
-          })
-        ) {
-          persistPreGroundingIdentities();
-        }
+        const pruned = pruneGroundingIdentities(_preGroundingIdentities, {
+          knownPaths: knownWorkflowPaths(),
+        });
+        const recorded = rememberPreGroundingIdentity(_preGroundingIdentities, {
+          path,
+          storageKey: identity?.storageKey,
+          routeId: identity?.routeId,
+        });
+        // EITHER change has to be persisted. Persisting only on `recorded` left a prune's
+        // deletions in memory alone, so they came back from localStorage on reload (codex).
+        if (pruned || recorded) persistPreGroundingIdentities();
       },
     });
     return saved;

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -125,6 +125,7 @@ import {
   workflowIdentityForms,
   rememberPreGroundingIdentity,
   preGroundingIdentityForms,
+  pruneGroundingIdentities,
 } from "./lib/workflow-chat-identity.js";
 import { validateA2UISpec, renderA2UICard, renderA2UIInert, renderA2UIFailCard, A2UI_CSS } from "./cmcp-a2ui.js";
 import { openSidePanel } from "./cmcp-sidepanel-ui.js";
@@ -1534,6 +1535,17 @@ const _preGroundingIdentities = (() => {
     return {};
   }
 })();
+
+/** Paths the workflow store currently lists, or null when it cannot be read (#847). */
+function knownWorkflowPaths() {
+  try {
+    const list = app?.extensionManager?.workflow?.workflows;
+    if (!Array.isArray(list)) return null;
+    return list.map((w) => w?.path).filter((p) => typeof p === "string" && p);
+  } catch {
+    return null;
+  }
+}
 
 function persistPreGroundingIdentities() {
   try {
@@ -4277,25 +4289,6 @@ function describeLiveCanvasBinding(wf) {
 /** If the open workflow was never saved to disk, save it (no dialog) so the
  *  agent works from a grounded file. Best-effort. Returns the saved name or null. */
 async function groundUnsavedWorkflow() {
-  // #847 — capture the identity this tab holds BEFORE the save, while it still holds it.
-  // Grounding replaces the ComfyWorkflow object and re-mints the storage uuid, and by the
-  // time anything observes the result every live carrier of the old identity is gone
-  // (measured: the object WeakMaps die with the object, `activeState.extra` is cleared,
-  // and the path alias is written from the NEW id). Read it here or not at all.
-  const preGroundRoute = (() => {
-    try {
-      return workflowTabId();
-    } catch {
-      return null;
-    }
-  })();
-  const preGroundStorageKey = (() => {
-    try {
-      return workflowStorageKey();
-    } catch {
-      return null;
-    }
-  })();
   try {
     // #330: ground the active workflow ATOMICALLY — probe its on-disk state and save
     // the EXACT SAME workflow (refusing if the user switched tabs during the async
@@ -4309,26 +4302,32 @@ async function groundUnsavedWorkflow() {
       // #708 — grounding is the save that CREATES the "Untitled …" file, so it is the
       // one that must not write a canvas belonging to a different workflow into it.
       canvasBinding: describeLiveCanvasBinding,
-    });
-    // #847 — bind the pre-save identity to the path the save just created. `saved` is a
-    // truthy name ONLY when this call actually persisted this tab's workflow, which is the
-    // causal ownership the history filter needs and which no later observer can prove.
-    if (saved) {
-      try {
-        const path = savedWorkflowPath(activeWorkflowRef()) || `workflows/${saved}.json`;
+      // #847 — both halves run INSIDE the serialized grounding, against the workflow that
+      // transaction is saving. The probe is synchronous with reading it, and the path comes
+      // from the save's own result, so neither can be about a tab the user switched to.
+      identityProbe: (wf) => ({
+        storageKey: workflowStorageKey(),
+        routeId: workflowTabId(wf),
+      }),
+      onGrounded: ({ savedName, identity }) => {
+        // A bare name from the save; a name that already carries a directory is used as-is.
+        const path = String(savedName).includes("/") ? String(savedName) : `workflows/${savedName}.json`;
+        // Prune BEFORE recording, never after: the path this save just created is not in
+        // the workflow store's list yet, so pruning afterwards deletes the very entry it
+        // just wrote. That is not theoretical — it broke conversation-persistence:507 the
+        // first time round.
+        pruneGroundingIdentities(_preGroundingIdentities, { knownPaths: knownWorkflowPaths() });
         if (
           rememberPreGroundingIdentity(_preGroundingIdentities, {
             path,
-            storageKey: preGroundStorageKey,
-            routeId: preGroundRoute,
+            storageKey: identity?.storageKey,
+            routeId: identity?.routeId,
           })
         ) {
           persistPreGroundingIdentities();
         }
-      } catch {
-        // Bookkeeping for a chat filter must never break the save that just succeeded.
-      }
-    }
+      },
+    });
     return saved;
   } catch {
     return null; // best-effort — never block the chat on a save hiccup

--- a/web/js/lib/workflow-chat-identity.js
+++ b/web/js/lib/workflow-chat-identity.js
@@ -121,6 +121,13 @@ export function shouldCarryIdentityAcrossSaveSwap({
  * Only a genuinely pre-save form is recorded — `routeId` must be a `tmp:` id. A save of an
  * already-saved workflow has no lineage break to bridge, and recording one would invent a
  * relationship rather than remember it.
+ *
+ * ACCEPTED LIMIT, written down rather than left to be discovered (codex): a path is not
+ * durable ownership. Delete a workflow, create a new one with the SAME name, and nothing
+ * available here tells them apart — the old workflow's chats can appear under the new one.
+ * Grounded names are `Untitled <timestamp>`, so reuse takes deliberate effort, and the cost
+ * is one extra row in a chat list. Closing it properly needs a delete/rename signal the
+ * panel does not currently receive.
  */
 export function rememberPreGroundingIdentity(map, { path, storageKey, routeId } = {}) {
   const key = normalizedWorkflowPath(path);
@@ -132,9 +139,11 @@ export function rememberPreGroundingIdentity(map, { path, storageKey, routeId } 
   if (typeof routeId !== "string" || !/^tmp:.+/.test(routeId)) return false;
   const forms = [storageKey, routeId].filter((f) => typeof f === "string" && f);
   if (!forms.length) return false;
-  // Latest grounding into a path wins. A path is created fresh by the grounding that
-  // names it, so this is self-healing if a name is ever reused rather than accumulating
-  // lineages that no longer apply.
+  // Latest grounding into a path wins. Delete first so a REFRESHED lineage moves to the
+  // end of the insertion order — plain assignment leaves an existing key in place, and the
+  // cap evicts from the front, so a just-refreshed entry could be dropped as "oldest"
+  // (codex).
+  delete map[key];
   map[key] = forms;
   return true;
 }
@@ -157,19 +166,25 @@ export function rememberPreGroundingIdentity(map, { path, storageKey, routeId } 
  */
 export function pruneGroundingIdentities(map, { knownPaths, max = 200 } = {}) {
   if (!map || typeof map !== "object") return false;
-  let changed = false;
-  if (Array.isArray(knownPaths)) {
-    const live = new Set(knownPaths.map((p) => normalizedWorkflowPath(p)).filter(Boolean));
-    for (const key of Object.keys(map)) {
-      if (!live.has(key)) {
-        delete map[key];
-        changed = true;
-      }
-    }
-  }
-  const keys = Object.keys(map);
   const limit = Number.isFinite(max) && max > 0 ? max : 200;
-  for (const key of keys.slice(0, Math.max(0, keys.length - limit))) {
+  const keys = Object.keys(map);
+  // ONLY act when over the cap. Pruning eagerly on every grounding raced the store
+  // (codex): a just-created path is not listed yet — that is established, it is why the
+  // prune runs before the record — so an EARLIER legitimate lineage whose path was still
+  // unlisted got deleted by the next grounding, losing exactly the history this restores.
+  // Over the cap something must go regardless, so preferring dead paths is free there.
+  if (keys.length <= limit) return false;
+  let changed = false;
+  const overBy = keys.length - limit;
+  const live = Array.isArray(knownPaths)
+    ? new Set(knownPaths.map((p) => normalizedWorkflowPath(p)).filter(Boolean))
+    : null;
+  // Dead paths first, oldest first within that; then oldest overall.
+  const victims = [
+    ...(live ? keys.filter((k) => !live.has(k)) : []),
+    ...keys.filter((k) => !live || live.has(k)),
+  ].slice(0, overBy);
+  for (const key of victims) {
     delete map[key];
     changed = true;
   }

--- a/web/js/lib/workflow-chat-identity.js
+++ b/web/js/lib/workflow-chat-identity.js
@@ -74,6 +74,26 @@ export function sameWorkflowObject(a, b) {
  *  can't prove fails SAFE (no carry); the lazy backstop / proven repaint heals
  *  the genuine case afterward. Unknown predecessor state defaults to still-open
  *  (fail-safe: no carry). */
+export function shouldCarryIdentityAcrossSaveSwap({
+  preWf,
+  postWf,
+  savedAs = false,
+  preWfStillOpen = true,
+  postWfHasConflictingEstablishedIdentity = false,
+  postWfIsSaveProducedRecord = false,
+} = {}) {
+  if (savedAs) return false;
+  if (!preWf || !postWf || typeof postWf !== "object") return false;
+  if (preWf === postWf || sameWorkflowObject(preWf, postWf)) return false;
+  if (preWfStillOpen) return false;
+  // r7 P0 — an established, DIFFERENT identity on the successor is a conflict:
+  // overwriting it would promote the pre-save stamp over the object's own
+  // identity and poison the owner map (the r6 stale-lineage bypass, via
+  // registration this time). Fail closed; the proven-repaint remedy heals.
+  if (postWfHasConflictingEstablishedIdentity) return false;
+  return postWfIsSaveProducedRecord === true;
+}
+
 /**
  * #847 — remember the identity a tab held immediately BEFORE the panel grounded it.
  *
@@ -107,7 +127,9 @@ export function rememberPreGroundingIdentity(map, { path, storageKey, routeId } 
   if (!key || !map || typeof map !== "object") return false;
   // A `tmp:` route is the proof that this tab was unsaved a moment ago. Without it there
   // is no boundary to bridge.
-  if (typeof routeId !== "string" || !routeId.startsWith("tmp:")) return false;
+  // `tmp:` alone is a prefix with no identifier behind it and matches nothing real
+  // (codex). Require an actual id.
+  if (typeof routeId !== "string" || !/^tmp:.+/.test(routeId)) return false;
   const forms = [storageKey, routeId].filter((f) => typeof f === "string" && f);
   if (!forms.length) return false;
   // Latest grounding into a path wins. A path is created fresh by the grounding that
@@ -117,32 +139,49 @@ export function rememberPreGroundingIdentity(map, { path, storageKey, routeId } 
   return true;
 }
 
+/**
+ * Drop lineages that can no longer be about a workflow that exists (#847, codex).
+ *
+ * A path is not durable ownership. Delete `Untitled 2026-08-09.json` and let a later
+ * workflow take the same name and the stale entry would surface a dead workflow's
+ * conversations under its namesake — a false INCLUSION, which is worse than the missing
+ * row this fixes, because "Current workflow only" is precisely a promise not to do that.
+ *
+ * `knownPaths` is the workflow store's own list. An entry whose path is not in it names a
+ * file that is gone, so its lineage can never legitimately match again. When the list
+ * cannot be read the map is left ALONE rather than cleared — absence of evidence is not
+ * evidence that every workflow was deleted.
+ *
+ * `max` is hygiene, not correctness: insertion order is preserved by JS objects for string
+ * keys, so the oldest entries go first once the map exceeds it.
+ */
+export function pruneGroundingIdentities(map, { knownPaths, max = 200 } = {}) {
+  if (!map || typeof map !== "object") return false;
+  let changed = false;
+  if (Array.isArray(knownPaths)) {
+    const live = new Set(knownPaths.map((p) => normalizedWorkflowPath(p)).filter(Boolean));
+    for (const key of Object.keys(map)) {
+      if (!live.has(key)) {
+        delete map[key];
+        changed = true;
+      }
+    }
+  }
+  const keys = Object.keys(map);
+  const limit = Number.isFinite(max) && max > 0 ? max : 200;
+  for (const key of keys.slice(0, Math.max(0, keys.length - limit))) {
+    delete map[key];
+    changed = true;
+  }
+  return changed;
+}
+
 /** The pre-grounding identity forms recorded for `path`, if any (#847). */
 export function preGroundingIdentityForms(map, path) {
   const key = normalizedWorkflowPath(path);
   if (!key || !map || typeof map !== "object") return [];
   const forms = map[key];
   return Array.isArray(forms) ? forms.filter((f) => typeof f === "string" && f) : [];
-}
-
-export function shouldCarryIdentityAcrossSaveSwap({
-  preWf,
-  postWf,
-  savedAs = false,
-  preWfStillOpen = true,
-  postWfHasConflictingEstablishedIdentity = false,
-  postWfIsSaveProducedRecord = false,
-} = {}) {
-  if (savedAs) return false;
-  if (!preWf || !postWf || typeof postWf !== "object") return false;
-  if (preWf === postWf || sameWorkflowObject(preWf, postWf)) return false;
-  if (preWfStillOpen) return false;
-  // r7 P0 — an established, DIFFERENT identity on the successor is a conflict:
-  // overwriting it would promote the pre-save stamp over the object's own
-  // identity and poison the owner map (the r6 stale-lineage bypass, via
-  // registration this time). Fail closed; the proven-repaint remedy heals.
-  if (postWfHasConflictingEstablishedIdentity) return false;
-  return postWfIsSaveProducedRecord === true;
 }
 
 /** Return true when an embedded UUID belongs to a different workflow file.

--- a/web/js/lib/workflow-chat-identity.js
+++ b/web/js/lib/workflow-chat-identity.js
@@ -191,6 +191,29 @@ export function pruneGroundingIdentities(map, { knownPaths, max = 200 } = {}) {
   return changed;
 }
 
+/**
+ * The path a grounding save's returned NAME refers to, in the one shape this map is keyed
+ * on (#847).
+ *
+ * Exported so the panel and its tests share it. The first cut inlined this in the panel and
+ * asserted a copy of it in the test — which passes happily while the shipped behaviour
+ * diverges (codex; same trap as #932 earlier today).
+ *
+ * Naive concatenation mangled real inputs: `Name.json` became `workflows/Name.json.json`,
+ * a backslash path grew a second prefix, and `workflows/Name` never got an extension. Each
+ * files the lineage under a key nothing will look for, so the fix silently does nothing.
+ */
+export function groundedWorkflowPath(savedName) {
+  const raw = String(savedName ?? "")
+    .replaceAll("\\", "/")
+    .replace(/\/{2,}/g, "/")
+    .replace(/\/+$/, "")
+    .replace(/^\/+/, "");
+  if (!raw) return null;
+  const withDir = raw.includes("/") ? raw : `workflows/${raw}`;
+  return /\.json$/i.test(withDir) ? withDir : `${withDir}.json`;
+}
+
 /** The pre-grounding identity forms recorded for `path`, if any (#847). */
 export function preGroundingIdentityForms(map, path) {
   const key = normalizedWorkflowPath(path);

--- a/web/js/lib/workflow-chat-identity.js
+++ b/web/js/lib/workflow-chat-identity.js
@@ -74,6 +74,57 @@ export function sameWorkflowObject(a, b) {
  *  can't prove fails SAFE (no carry); the lazy backstop / proven repaint heals
  *  the genuine case afterward. Unknown predecessor state defaults to still-open
  *  (fail-safe: no carry). */
+/**
+ * #847 — remember the identity a tab held immediately BEFORE the panel grounded it.
+ *
+ * The problem this closes: grounding (the automatic save before a turn, #330) gives an
+ * unsaved workflow a real path, and ComfyUI REPLACES the ComfyWorkflow object at that
+ * moment. The successor finds no object uuid (new object), no embedded uuid (the carriers
+ * `workflowOwnedExtra` reads are all absent on this frontend), and no path alias (the path
+ * was just created), so it mints a fresh identity. A conversation recorded seconds earlier
+ * keeps the old one and vanishes from "Current workflow only" — the workflow it was
+ * actually held on.
+ *
+ * Why keyed on PATH and written HERE, when `onWorkflowMaybeChanged` deliberately refuses
+ * to migrate anything: that observer sees the transition after the fact and cannot prove
+ * the old id was THIS tab's past rather than a workflow the user switched away from —
+ * `openWorkflows` not claiming an id is absence of a competing claimant, not ownership
+ * (codex). Grounding is different in kind. The panel CALLS it, on its own active
+ * workflow, and awaits it; `groundActiveWorkflow` already refuses if the user switched
+ * tabs during the probe. Ownership is known by CAUSATION, not inferred from evidence.
+ * That is the whole reason this can be recorded safely and that one cannot.
+ *
+ * Scope, deliberately: these forms feed the history FILTER only. They never enter identity
+ * resolution, never authorize a graph write, and never define a workflow's uuid. The worst
+ * a wrong entry can do is show one extra row in a chat list.
+ *
+ * Only a genuinely pre-save form is recorded — `routeId` must be a `tmp:` id. A save of an
+ * already-saved workflow has no lineage break to bridge, and recording one would invent a
+ * relationship rather than remember it.
+ */
+export function rememberPreGroundingIdentity(map, { path, storageKey, routeId } = {}) {
+  const key = normalizedWorkflowPath(path);
+  if (!key || !map || typeof map !== "object") return false;
+  // A `tmp:` route is the proof that this tab was unsaved a moment ago. Without it there
+  // is no boundary to bridge.
+  if (typeof routeId !== "string" || !routeId.startsWith("tmp:")) return false;
+  const forms = [storageKey, routeId].filter((f) => typeof f === "string" && f);
+  if (!forms.length) return false;
+  // Latest grounding into a path wins. A path is created fresh by the grounding that
+  // names it, so this is self-healing if a name is ever reused rather than accumulating
+  // lineages that no longer apply.
+  map[key] = forms;
+  return true;
+}
+
+/** The pre-grounding identity forms recorded for `path`, if any (#847). */
+export function preGroundingIdentityForms(map, path) {
+  const key = normalizedWorkflowPath(path);
+  if (!key || !map || typeof map !== "object") return [];
+  const forms = map[key];
+  return Array.isArray(forms) ? forms.filter((f) => typeof f === "string" && f) : [];
+}
+
 export function shouldCarryIdentityAcrossSaveSwap({
   preWf,
   postWf,

--- a/web/js/lib/workflow-save.js
+++ b/web/js/lib/workflow-save.js
@@ -272,18 +272,45 @@ const _groundingChain = new Map(); // svc -> tail Promise<void>
  *  EXACT SAME workflow it probed (`expect: wf` → saveActiveWorkflow refuses if the
  *  active workflow changed during the async probe, so we never authorize on tab A
  *  and write to tab B). Best-effort: any refusal/hiccup ⇒ null (leave ungrounded). */
-async function groundOnce(svc, { existsOnDisk, autoWorkflowName, reconcileSavedCopy, canvasBinding } = {}) {
+async function groundOnce(
+  svc,
+  { existsOnDisk, autoWorkflowName, reconcileSavedCopy, canvasBinding, identityProbe, onGrounded } = {},
+) {
   try {
     const wf = svc?.activeWorkflow;
     if (!needsGrounding(wf)) return null;
+    // #847 — probe the identity of the EXACT workflow this transaction is about to save,
+    // SYNCHRONOUSLY with reading it, before any await can change what is active.
+    //
+    // Doing this in the caller around `await groundActiveWorkflow(...)` is NOT equivalent,
+    // and that difference was a real defect (codex): grounding is single-flighted, so a
+    // caller can capture workflow B, await a grounding already running for A, and receive a
+    // truthy result — then record B's forms against A's save. Capture and record have to
+    // sit inside the same serialized operation as the save itself, keyed to `wf`.
+    let preIdentity = null;
+    try {
+      preIdentity = typeof identityProbe === "function" ? identityProbe(wf) : null;
+    } catch {
+      preIdentity = null; // bookkeeping must never stop a save that protects user work
+    }
     if (!(await groundingIsSafe(wf, existsOnDisk))) return null;
-    return await saveActiveWorkflow(svc, undefined, {
+    const savedName = await saveActiveWorkflow(svc, undefined, {
       autoWorkflowName,
       existsOnDisk,
       reconcileSavedCopy,
       canvasBinding,
       expect: wf,
     });
+    // The name the save ITSELF produced — never re-read from `svc.activeWorkflow`, which by
+    // now may be a different tab entirely.
+    if (savedName && preIdentity && typeof onGrounded === "function") {
+      try {
+        onGrounded({ savedName, identity: preIdentity, workflow: wf });
+      } catch {
+        /* same rule: never fail the save for bookkeeping */
+      }
+    }
+    return savedName;
   } catch {
     return null;
   }


### PR DESCRIPTION
Draft — claiming the one spec still failing in #847.

Measured last iteration: two conversations in ONE workflow get stamped with two different storage uuids, because the uuid is re-minted at the unsaved→named boundary. The earlier thread keeps the dead key, so `Current workflow only` hides it — 2 rows unfiltered, 1 filtered.

`_priorTempWorkflowIds` already solves exactly this for the *route* id. Nothing retains the prior *storage uuid*, which is what `workflowKey` holds and what `threadMatchesCurrentWorkflow` checks first.

Refs #847