### PR TITLE
fix(e2e): the suite cleans up the workflows it saves, and proves it

### DIFF
--- a/browser_tests/bridge-reregisters-after-restart.spec.ts
+++ b/browser_tests/bridge-reregisters-after-restart.spec.ts
@@ -44,7 +44,11 @@ test('the tab re-registers after the bridge dies and respawns', async ({
   await panel.openSidebar()
   await panel.connect()
 
-  const saved = await mockBridge.command('workflow_save', {})
+  // #907 — an unnamed save gets ComfyUI's `Untitled <date> <time>`, the SAME
+  // name it gives the developer's own unnamed saves, so nothing downstream can
+  // tell them apart and the cleanup must not try. Name it ours.
+  const e2eSaveName = `cmcp-e2e-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`
+  const saved = await mockBridge.command('workflow_save_as', { name: e2eSaveName })
   expect(saved.ok, 'the workflow must save so the route is the composed wf: form').toBe(true)
   const savedName = String(saved.result?.workflow || '')
   expect(savedName).toBeTruthy()

--- a/browser_tests/bridge-route-never-file-derived.spec.ts
+++ b/browser_tests/bridge-route-never-file-derived.spec.ts
@@ -81,7 +81,11 @@ test('two tabs on one saved workflow never share a bridge route', async ({
 
     // A SAVED workflow specifically. An unsaved tab routes on a per-object `tmp:<uuid>`
     // and could never collide, so using one would pass for the wrong reason.
-    const saved = await mockBridge.command('workflow_save', {})
+    // #907 — an unnamed save gets ComfyUI's `Untitled <date> <time>`, the SAME
+    // name it gives the developer's own unnamed saves, so nothing downstream can
+    // tell them apart and the cleanup must not try. Name it ours.
+    const e2eSaveName = `cmcp-e2e-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`
+    const saved = await mockBridge.command('workflow_save_as', { name: e2eSaveName })
     expect(saved.ok, 'the workflow must save so both tabs share a FILE').toBe(true)
     const savedName = String(saved.result?.workflow || '')
     expect(savedName, 'the save must report a name').toBeTruthy()

--- a/browser_tests/dirty-guards-see-node-writes.spec.ts
+++ b/browser_tests/dirty-guards-see-node-writes.spec.ts
@@ -59,7 +59,13 @@ test('closing a workflow refuses when a NODE left unsaved work', async ({
   // assertion is still cleaned up (codex).
   let savedName = ''
   try {
-    const saved = await mockBridge.command('workflow_save', {})
+    // #907 — SAVE UNDER A NAME THAT IS UNMISTAKABLY OURS. An unnamed save gets
+    // ComfyUI's `Untitled <date> <time>`, which is the SAME shape it gives the
+    // developer's own unnamed saves — so a cleanup keyed on that name can delete
+    // their work if they happen to save while the suite runs (codex). Naming it
+    // here means nothing the suite deletes is ever ambiguous.
+    const e2eName = `cmcp-e2e-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`
+    const saved = await mockBridge.command('workflow_save_as', { name: e2eName })
     expect(saved.ok, 'the save must succeed so the tab starts clean').toBe(true)
     savedName = String(saved.result?.workflow || '')
     expect(savedName, 'the save must report a name, or cleanup has nothing to remove').toBeTruthy()
@@ -132,7 +138,11 @@ test('force:true still discards — the guard refuses, it does not trap', async 
   await settleCanvas(page)
   let savedName2 = ''
   try {
-    const saved2 = await mockBridge.command('workflow_save', {})
+    // #907 — an unnamed save gets ComfyUI's `Untitled <date> <time>`, the SAME
+    // name it gives the developer's own unnamed saves, so nothing downstream can
+    // tell them apart and the cleanup must not try. Name it ours.
+    const e2eSaveName = `cmcp-e2e-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`
+    const saved2 = await mockBridge.command('workflow_save_as', { name: e2eSaveName })
     // Asserted, not assumed (codex): without this the setup save could fail, the test
     // still pass, and cleanup ask to delete `workflows/.json`.
     expect(saved2.ok, 'the setup save must succeed').toBe(true)

--- a/browser_tests/fixtures/workflow-litter.ts
+++ b/browser_tests/fixtures/workflow-litter.ts
@@ -1,0 +1,103 @@
+/**
+ * #907 — the e2e suite saves real workflows into the developer's own library and
+ * leaves them there. Measured on this machine: 1269 of 1286 files were
+ * `Untitled 2026-08-*` test output, so ~99% of a real workflow library was
+ * litter, and every `workflows` store read the panel does on a dev box
+ * enumerated 1286 entries — a shape no user's install has.
+ *
+ * WHY THIS IS NOT PER-SPEC CLEANUP. The suite already tried that. Three specs
+ * delete what they saved and two do not, and the two that do not were written
+ * before the review that added it to the others. Worse, the cleanup that DOES
+ * exist sits at the end of the test body — so it runs only when the test PASSES.
+ * A failing or timing-out spec leaks by construction, which is exactly when a
+ * spec is most likely to run.
+ *
+ * So the guarantee belongs to the suite, and this module holds the part worth
+ * testing: deciding what may be deleted. Everything here is pure.
+ *
+ * THE SAFETY PROPERTY. This deletes files from a directory that also holds the
+ * developer's real work, so "delete what the tests made" must never widen into
+ * "delete what looks disposable". A file is removable only when BOTH hold:
+ *
+ *   1. it did not exist when the run started, and
+ *   2. its name matches a pattern the suite itself produces.
+ *
+ * Either alone is unsafe. (1) alone would delete a workflow the user saved while
+ * the suite ran. (2) alone would delete the `Untitled 2026-08-04.json` they made
+ * last week — the same shape ComfyUI gives every unnamed save, including theirs.
+ */
+
+/** Names the suite is known to create. */
+const LITTER_PATTERNS: readonly RegExp[] = [
+  // ComfyUI's default name for an unnamed `workflow_save`. MEASURED against the
+  // real directory rather than assumed: it carries a TIME as well as a date —
+  // "Untitled 2026-08-09 19-37-51.json". The first version of this pattern
+  // stopped at the date and matched ZERO of the 1272 real files, which would have
+  // deleted nothing and then failed every run by reporting all of them as
+  // unrecognised. The date-only form is kept as an alternative because older
+  // frontends produced it.
+  /^Untitled \d{4}-\d{2}-\d{2}(?: \d{2}-\d{2}-\d{2})?(?: \(\d+\))?\.json$/,
+  // The suite's own explicit prefix, used by specs that save under a nonce.
+  /^cmcp-e2e-[A-Za-z0-9-]+\.json$/,
+]
+
+/** Does this filename match something the suite creates? */
+export function isTestLitter(name: string): boolean {
+  if (typeof name !== 'string' || !name) return false
+  return LITTER_PATTERNS.some((re) => re.test(name))
+}
+
+/**
+ * The files this run may delete: new since the baseline AND recognisably ours.
+ *
+ * `before`/`after` are the raw listings from ComfyUI's userdata API.
+ */
+export function plannedDeletions(before: readonly string[], after: readonly string[]): string[] {
+  const baseline = new Set(before ?? [])
+  const seen = new Set<string>()
+  const out: string[] = []
+  for (const name of after ?? []) {
+    if (typeof name !== 'string' || baseline.has(name) || seen.has(name)) continue
+    seen.add(name)
+    if (isTestLitter(name)) out.push(name)
+  }
+  return out.sort()
+}
+
+/**
+ * What is left over after the deletions ran — the LEAK REPORT.
+ *
+ * A cleanup that silently stops working is the defect this issue actually
+ * describes: 1269 files accumulated with nobody noticing. So the teardown does
+ * not just delete, it checks, and anything new that it could NOT account for is
+ * named rather than shrugged off.
+ *
+ * Deliberately reports two kinds separately, because they mean different things:
+ *
+ *   `undeleted` — we recognised it and the delete did not take (an API failure,
+ *                 a permission problem). The cleanup is broken.
+ *   `unrecognised` — new, but matching no pattern we know. Either a spec started
+ *                 saving under a new name, or the user saved something mid-run.
+ *                 Naming it is the only way the first case gets noticed.
+ */
+export function leakReport(
+  before: readonly string[],
+  afterCleanup: readonly string[],
+  attempted: readonly string[],
+): { undeleted: string[]; unrecognised: string[] } {
+  const baseline = new Set(before ?? [])
+  const tried = new Set(attempted ?? [])
+  const undeleted: string[] = []
+  const unrecognised: string[] = []
+  for (const name of afterCleanup ?? []) {
+    if (typeof name !== 'string' || baseline.has(name)) continue
+    if (tried.has(name)) undeleted.push(name)
+    else unrecognised.push(name)
+  }
+  return { undeleted: undeleted.sort(), unrecognised: unrecognised.sort() }
+}
+
+/** The userdata path for a workflow filename. */
+export function workflowUserdataPath(name: string): string {
+  return `workflows/${name}`
+}

--- a/browser_tests/fixtures/workflow-litter.ts
+++ b/browser_tests/fixtures/workflow-litter.ts
@@ -27,19 +27,22 @@
  * last week — the same shape ComfyUI gives every unnamed save, including theirs.
  */
 
-/** Names the suite is known to create. */
-const LITTER_PATTERNS: readonly RegExp[] = [
-  // ComfyUI's default name for an unnamed `workflow_save`. MEASURED against the
-  // real directory rather than assumed: it carries a TIME as well as a date —
-  // "Untitled 2026-08-09 19-37-51.json". The first version of this pattern
-  // stopped at the date and matched ZERO of the 1272 real files, which would have
-  // deleted nothing and then failed every run by reporting all of them as
-  // unrecognised. The date-only form is kept as an alternative because older
-  // frontends produced it.
-  /^Untitled \d{4}-\d{2}-\d{2}(?: \d{2}-\d{2}-\d{2})?(?: \(\d+\))?\.json$/,
-  // The suite's own explicit prefix, used by specs that save under a nonce.
-  /^cmcp-e2e-[A-Za-z0-9-]+\.json$/,
-]
+/**
+ * Names the suite is known to create — and ONLY names no one else can produce.
+ *
+ * The first version of this also matched ComfyUI's `Untitled <date> <time>`,
+ * because that is what an unnamed `workflow_save` produces and 1272 such files
+ * were sitting in the library. Codex was right to refuse it: that is the SAME
+ * name ComfyUI gives the developer's own unnamed saves. A developer who hits
+ * save during a run creates a file that is both new and matching, and this would
+ * delete their work. "Both conditions" is not enough when one of them is a name
+ * anybody can produce by accident.
+ *
+ * So the specs now save under this prefix instead (workflow_save_as), and the
+ * automated cleanup deletes nothing else. Pre-existing `Untitled` litter is left
+ * to scripts/clean-e2e-litter.mjs, where a human decides.
+ */
+const LITTER_PATTERNS: readonly RegExp[] = [/^cmcp-e2e-[A-Za-z0-9._-]+\.json$/]
 
 /** Does this filename match something the suite creates? */
 export function isTestLitter(name: string): boolean {

--- a/browser_tests/global-setup.ts
+++ b/browser_tests/global-setup.ts
@@ -1,0 +1,6 @@
+// #907 — see global-workflow-litter.ts. Runs once, before any worker.
+import { recordWorkflowBaseline } from './global-workflow-litter'
+
+export default async function globalSetup(): Promise<void> {
+  await recordWorkflowBaseline()
+}

--- a/browser_tests/global-teardown.ts
+++ b/browser_tests/global-teardown.ts
@@ -1,0 +1,6 @@
+// #907 — see global-workflow-litter.ts. Runs once, after the last worker.
+import { cleanWorkflowLitter } from './global-workflow-litter'
+
+export default async function globalTeardown(): Promise<void> {
+  await cleanWorkflowLitter()
+}

--- a/browser_tests/global-workflow-litter.ts
+++ b/browser_tests/global-workflow-litter.ts
@@ -1,0 +1,161 @@
+/**
+ * #907 — suite-level cleanup for the workflows the e2e specs really persist.
+ *
+ * Playwright runs `globalSetup` before any worker and `globalTeardown` after the
+ * last one, which is the only place that can see the whole run. Per-spec cleanup
+ * cannot: it lives at the end of a test body and therefore does not run when the
+ * test fails — precisely when it matters.
+ *
+ * The baseline is passed between the two halves through a file rather than
+ * module state, because Playwright may run them in different processes.
+ */
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { request as httpRequest } from 'node:http'
+import { request as httpsRequest } from 'node:https'
+import { dirname, join } from 'node:path'
+import { tmpdir } from 'node:os'
+
+import { leakReport, plannedDeletions, workflowUserdataPath } from './fixtures/workflow-litter'
+
+const BASE_URL = process.env.PLAYWRIGHT_BASE_URL || 'http://localhost:8188'
+const BASELINE_FILE = join(tmpdir(), 'cmcp-e2e-workflow-baseline.json')
+
+/**
+ * NOT `fetch`. Global fetch is undici, whose connection pool outlives these
+ * hooks: with it, a PASSING single-spec run exited 127 on Windows with
+ * `Assertion failed: !(handle->flags & UV_HANDLE_CLOSING)` — a native abort
+ * during teardown, after the result was already printed. A green suite that
+ * exits non-zero fails CI on every run, which is a worse defect than the litter
+ * this file exists to clear.
+ *
+ * `agent: false` gives each request its own socket and closes it on response, so
+ * nothing is left for the process to tear down.
+ */
+function httpJson(method: 'GET' | 'DELETE', url: string): Promise<unknown | null> {
+  return new Promise((resolve) => {
+    let target: URL
+    try {
+      target = new URL(url)
+    } catch {
+      resolve(null)
+      return
+    }
+    const send = target.protocol === 'https:' ? httpsRequest : httpRequest
+    const req = send(target, { method, agent: false }, (res) => {
+      const chunks: Buffer[] = []
+      res.on('data', (c: Buffer) => chunks.push(c))
+      res.on('end', () => {
+        const ok = (res.statusCode ?? 0) >= 200 && (res.statusCode ?? 0) < 300
+        if (!ok) {
+          resolve(null)
+          return
+        }
+        try {
+          resolve(JSON.parse(Buffer.concat(chunks).toString('utf-8')))
+        } catch {
+          resolve(method === 'DELETE' ? true : null) // a DELETE need not return JSON
+        }
+      })
+    })
+    req.on('error', () => resolve(null))
+    req.end()
+  })
+}
+
+async function listWorkflows(): Promise<string[] | null> {
+  const body = await httpJson('GET', `${BASE_URL}/api/userdata?dir=workflows`)
+  return Array.isArray(body) ? body.filter((n): n is string => typeof n === 'string') : null
+}
+
+/**
+ * Record what the developer's workflow library held BEFORE the run.
+ *
+ * FAILS OPEN, DELIBERATELY. If ComfyUI cannot be listed we write no baseline,
+ * and the teardown then deletes NOTHING. The alternative — treating an
+ * unreadable listing as "the directory was empty" — would make every file in it
+ * look new, and this code deletes files. An unrunnable cleanup is a bad day; a
+ * cleanup that deletes someone's workflows because a fetch failed is
+ * unrecoverable.
+ */
+export async function recordWorkflowBaseline(): Promise<void> {
+  const before = await listWorkflows()
+  try {
+    rmSync(BASELINE_FILE, { force: true })
+  } catch {
+    /* nothing to clear */
+  }
+  if (!before) {
+    console.warn(
+      '[e2e] could not list workflows before the run — saved-workflow cleanup is DISABLED for it ' +
+        '(#907). Nothing will be deleted.',
+    )
+    return
+  }
+  mkdirSync(dirname(BASELINE_FILE), { recursive: true })
+  writeFileSync(BASELINE_FILE, JSON.stringify(before), 'utf-8')
+}
+
+function readBaseline(): string[] | null {
+  try {
+    const parsed = JSON.parse(readFileSync(BASELINE_FILE, 'utf-8'))
+    return Array.isArray(parsed) ? parsed : null
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Delete what the run added, then CHECK — and fail the run if the check does not
+ * come back clean.
+ *
+ * The check is the point. #907 is not "the suite saves files", it is that 1269
+ * of them accumulated with nobody noticing. A cleanup with no assertion behind
+ * it is the same silence one layer down: it would go on reporting success while
+ * quietly matching nothing.
+ */
+export async function cleanWorkflowLitter(): Promise<void> {
+  const before = readBaseline()
+  if (!before) return // fail-open: no baseline, no deletions
+  const after = await listWorkflows()
+  if (!after) {
+    console.warn('[e2e] could not list workflows after the run — skipping cleanup (#907).')
+    return
+  }
+
+  const planned = plannedDeletions(before, after)
+  for (const name of planned) {
+    // A failure here is not swallowed — it shows up as `undeleted` below.
+    await httpJson(
+      'DELETE',
+      `${BASE_URL}/api/userdata/${encodeURIComponent(workflowUserdataPath(name))}`,
+    )
+  }
+
+  const remaining = (await listWorkflows()) ?? after
+  const { undeleted, unrecognised } = leakReport(before, remaining, planned)
+  rmSync(BASELINE_FILE, { force: true })
+
+  if (planned.length) {
+    console.log(`[e2e] removed ${planned.length - undeleted.length} saved workflow(s) this run (#907).`)
+  }
+  if (undeleted.length || unrecognised.length) {
+    const lines = [
+      `[e2e] SAVED-WORKFLOW LEAK (#907) — the suite left files in the user's workflow library.`,
+    ]
+    if (undeleted.length) {
+      lines.push(
+        `  ${undeleted.length} recognised file(s) could NOT be deleted, so the cleanup itself is broken: ` +
+          undeleted.slice(0, 10).join(', '),
+      )
+    }
+    if (unrecognised.length) {
+      lines.push(
+        `  ${unrecognised.length} new file(s) match no pattern the suite knows: ` +
+          unrecognised.slice(0, 10).join(', ') +
+          `. If a spec started saving under a new name, add it to LITTER_PATTERNS; if this was ` +
+          `saved by hand while the suite ran, it is safe to ignore.`,
+      )
+    }
+    throw new Error(lines.join('\n'))
+  }
+}

--- a/browser_tests/global-workflow-litter.ts
+++ b/browser_tests/global-workflow-litter.ts
@@ -18,7 +18,21 @@ import { tmpdir } from 'node:os'
 import { leakReport, plannedDeletions, workflowUserdataPath } from './fixtures/workflow-litter'
 
 const BASE_URL = process.env.PLAYWRIGHT_BASE_URL || 'http://localhost:8188'
-const BASELINE_FILE = join(tmpdir(), 'cmcp-e2e-workflow-baseline.json')
+/**
+ * PER RUN, not per machine (codex). A shared, predictable path let two runs
+ * against one ComfyUI overwrite each other's ownership record — and then run A's
+ * teardown would delete files run B was still using, judged against a baseline
+ * that was never A's. globalSetup and globalTeardown share a process, so the env
+ * var carries it; the pid-named file is the fallback.
+ */
+const BASELINE_ENV = 'CMCP_E2E_WORKFLOW_BASELINE'
+function BASELINE_FILE_PATH(): string {
+  const named = process.env[BASELINE_ENV]
+  if (named) return named
+  const path = join(tmpdir(), `cmcp-e2e-workflow-baseline-${process.pid}.json`)
+  process.env[BASELINE_ENV] = path
+  return path
+}
 
 /**
  * NOT `fetch`. Global fetch is undici, whose connection pool outlives these
@@ -41,7 +55,10 @@ function httpJson(method: 'GET' | 'DELETE', url: string): Promise<unknown | null
       return
     }
     const send = target.protocol === 'https:' ? httpsRequest : httpRequest
-    const req = send(target, { method, agent: false }, (res) => {
+    // BOUNDED (codex). A server that accepts the connection and never ends the
+    // response would hang setup or teardown forever — wedging CI rather than
+    // failing open, which is the opposite of every other guard here.
+    const req = send(target, { method, agent: false, timeout: 10_000 }, (res) => {
       const chunks: Buffer[] = []
       res.on('data', (c: Buffer) => chunks.push(c))
       res.on('end', () => {
@@ -56,6 +73,10 @@ function httpJson(method: 'GET' | 'DELETE', url: string): Promise<unknown | null
           resolve(method === 'DELETE' ? true : null) // a DELETE need not return JSON
         }
       })
+    })
+    req.on('timeout', () => {
+      req.destroy()
+      resolve(null)
     })
     req.on('error', () => resolve(null))
     req.end()
@@ -80,7 +101,7 @@ async function listWorkflows(): Promise<string[] | null> {
 export async function recordWorkflowBaseline(): Promise<void> {
   const before = await listWorkflows()
   try {
-    rmSync(BASELINE_FILE, { force: true })
+    rmSync(BASELINE_FILE_PATH(), { force: true })
   } catch {
     /* nothing to clear */
   }
@@ -91,13 +112,13 @@ export async function recordWorkflowBaseline(): Promise<void> {
     )
     return
   }
-  mkdirSync(dirname(BASELINE_FILE), { recursive: true })
-  writeFileSync(BASELINE_FILE, JSON.stringify(before), 'utf-8')
+  mkdirSync(dirname(BASELINE_FILE_PATH()), { recursive: true })
+  writeFileSync(BASELINE_FILE_PATH(), JSON.stringify(before), 'utf-8')
 }
 
 function readBaseline(): string[] | null {
   try {
-    const parsed = JSON.parse(readFileSync(BASELINE_FILE, 'utf-8'))
+    const parsed = JSON.parse(readFileSync(BASELINE_FILE_PATH(), 'utf-8'))
     return Array.isArray(parsed) ? parsed : null
   } catch {
     return null
@@ -131,31 +152,44 @@ export async function cleanWorkflowLitter(): Promise<void> {
     )
   }
 
-  const remaining = (await listWorkflows()) ?? after
-  const { undeleted, unrecognised } = leakReport(before, remaining, planned)
-  rmSync(BASELINE_FILE, { force: true })
+  // If the CHECK cannot be taken, say so — do not treat a failed listing as proof
+  // that every delete failed (codex). The old `?? after` did exactly that, and
+  // would have failed a green run on a transient read error.
+  const remaining = await listWorkflows()
+  rmSync(BASELINE_FILE_PATH(), { force: true })
+  if (!remaining) {
+    console.warn(
+      `[e2e] removed ${planned.length} saved workflow(s), but the directory could not be re-read, ` +
+        `so the cleanup is UNVERIFIED for this run (#907).`,
+    )
+    return
+  }
 
+  const { undeleted, unrecognised } = leakReport(before, remaining, planned)
   if (planned.length) {
     console.log(`[e2e] removed ${planned.length - undeleted.length} saved workflow(s) this run (#907).`)
   }
-  if (undeleted.length || unrecognised.length) {
-    const lines = [
-      `[e2e] SAVED-WORKFLOW LEAK (#907) — the suite left files in the user's workflow library.`,
-    ]
-    if (undeleted.length) {
-      lines.push(
-        `  ${undeleted.length} recognised file(s) could NOT be deleted, so the cleanup itself is broken: ` +
-          undeleted.slice(0, 10).join(', '),
-      )
-    }
-    if (unrecognised.length) {
-      lines.push(
-        `  ${unrecognised.length} new file(s) match no pattern the suite knows: ` +
-          unrecognised.slice(0, 10).join(', ') +
-          `. If a spec started saving under a new name, add it to LITTER_PATTERNS; if this was ` +
-          `saved by hand while the suite ran, it is safe to ignore.`,
-      )
-    }
-    throw new Error(lines.join('\n'))
+
+  // A NEW FILE WE DID NOT MAKE IS NOT A FAILURE (codex). A developer saving
+  // something while the suite runs is normal, and failing their run for it — with
+  // a message that itself said "safe to ignore" — teaches people to distrust the
+  // check. Warn and name it, so a spec that starts saving under a new name still
+  // surfaces.
+  if (unrecognised.length) {
+    console.warn(
+      `[e2e] ${unrecognised.length} workflow(s) appeared during this run that the suite does not ` +
+        `recognise: ${unrecognised.slice(0, 10).join(', ')}. Left alone. If a spec started saving ` +
+        `under a new name, add it to LITTER_PATTERNS (#907).`,
+    )
+  }
+
+  // THIS is the failure: we recognised the file as ours, tried to delete it, and it
+  // is still there — the cleanup itself has stopped working. That is the silence
+  // that let 1269 files accumulate, so it has to be loud.
+  if (undeleted.length) {
+    throw new Error(
+      `[e2e] SAVED-WORKFLOW CLEANUP IS BROKEN (#907): ${undeleted.length} file(s) the suite created ` +
+        `could not be deleted: ${undeleted.slice(0, 10).join(', ')}`,
+    )
   }
 }

--- a/browser_tests/save-persists-node-set-values.spec.ts
+++ b/browser_tests/save-persists-node-set-values.spec.ts
@@ -63,7 +63,13 @@ test('an in-place save persists a value the tracker never saw', async ({
   // finally, which no-ops on an empty one.
   let name = ''
   try {
-    const first = await mockBridge.command('workflow_save', {})
+    // #907 — SAVE UNDER A NAME THAT IS UNMISTAKABLY OURS. An unnamed save gets
+    // ComfyUI's `Untitled <date> <time>`, which is the SAME shape it gives the
+    // developer's own unnamed saves — so a cleanup keyed on that name can delete
+    // their work if they happen to save while the suite runs (codex). Naming it
+    // here means nothing the suite deletes is ever ambiguous.
+    const e2eName = `cmcp-e2e-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`
+    const first = await mockBridge.command('workflow_save_as', { name: e2eName })
     expect(first.ok, 'the first save must succeed so the tab has a path').toBe(true)
     name = String(first.result?.workflow || '')
     expect(name, 'the save must report the workflow name').toBeTruthy()

--- a/browser_tests/unit/workflow-litter.test.mjs
+++ b/browser_tests/unit/workflow-litter.test.mjs
@@ -16,17 +16,37 @@ import {
   workflowUserdataPath,
 } from "../fixtures/workflow-litter.ts";
 
-test("recognises the names the suite actually produces", () => {
-  // ComfyUI's default for an unnamed save. TAKEN FROM THE REAL DIRECTORY, not
-  // from what the format looked like it should be: it carries a time too. The
-  // first pattern I wrote stopped at the date and matched zero of 1272 files.
-  assert.equal(isTestLitter("Untitled 2026-08-09 19-37-51.json"), true);
-  assert.equal(isTestLitter("Untitled 2026-08-06 21-12-26.json"), true);
-  // The date-only form older frontends produced.
-  assert.equal(isTestLitter("Untitled 2026-08-09.json"), true);
-  assert.equal(isTestLitter("Untitled 2026-08-09 (2).json"), true);
-  // The suite's own nonce prefix.
+test("recognises ONLY names the suite itself chose", () => {
+  assert.equal(isTestLitter("cmcp-e2e-m2x1a-a7bd9c.json"), true);
+  // ComfyUI's `Untitled <date> <time>` is deliberately NOT matched by the
+  // automated cleanup, even though 1272 such files were the original symptom.
+  // It is the same name ComfyUI gives the developer's own unnamed saves, so a
+  // developer who saves during a run would lose it (codex P0). The specs save
+  // under the prefix above instead, and the ambiguous family is left to a human
+  // running scripts/clean-e2e-litter.mjs --include-untitled.
+  assert.equal(isTestLitter("Untitled 2026-08-09 19-37-51.json"), false);
+  assert.equal(isTestLitter("Untitled 2026-08-09.json"), false);
+});
+
+test("THE P0: a developer's unnamed save during a run is never a target", () => {
+  // Both conditions used to hold for this file — new since baseline, and matching
+  // the pattern — so it would have been deleted. That is someone's work.
+  const before = ["Artokun Flow v1.json"];
+  const after = [...before, "Untitled 2026-08-09 20-15-00.json"];
+  assert.deepEqual(plannedDeletions(before, after), []);
+});
+
+test("recognises the suite prefix in the shapes the specs generate", () => {
+  // Every spec builds its name as `cmcp-e2e-<base36 time>-<nonce>`, and one adds
+  // a purpose in the middle. Dots and dashes are allowed because a name is
+  // assembled, not validated, at the call site.
+  assert.equal(isTestLitter("cmcp-e2e-m2x1a-a7bd9c.json"), true);
   assert.equal(isTestLitter("cmcp-e2e-identity-m2x1-a7bd9c.json"), true);
+  assert.equal(isTestLitter("cmcp-e2e-b-1.json"), true);
+  assert.equal(isTestLitter("cmcp-e2e-x.y.json"), true);
+  // Near misses stay out: the prefix is the whole ownership claim.
+  assert.equal(isTestLitter("cmcp-e2e.json"), false);
+  assert.equal(isTestLitter("my-cmcp-e2e-copy.json"), false);
 });
 
 test("does not recognise the user's own work", () => {
@@ -42,14 +62,14 @@ test("does not recognise the user's own work", () => {
 });
 
 test("BOTH conditions are required — new AND recognisable", () => {
-  const before = ["Artokun Flow v1.json", "Untitled 2026-08-01.json"];
+  const before = ["Artokun Flow v1.json", "cmcp-e2e-old.json"];
   const after = [
     "Artokun Flow v1.json",
-    "Untitled 2026-08-01.json", // recognisable BUT pre-existing → the user's
-    "Untitled 2026-08-09.json", // new AND recognisable → ours
+    "cmcp-e2e-old.json", // recognisable BUT pre-existing → left alone
+    "cmcp-e2e-abc123.json", // new AND recognisable → ours
     "New Idea.json", // new but NOT recognisable → the user saved it mid-run
   ];
-  assert.deepEqual(plannedDeletions(before, after), ["Untitled 2026-08-09.json"]);
+  assert.deepEqual(plannedDeletions(before, after), ["cmcp-e2e-abc123.json"]);
 });
 
 test("a file the user saved DURING the run is never deleted", () => {
@@ -61,7 +81,7 @@ test("a file the user saved DURING the run is never deleted", () => {
 test("last week's Untitled is never deleted", () => {
   // The case that makes "matches the pattern" alone unsafe — ComfyUI gives the
   // user's own unnamed saves exactly this shape.
-  const before = ["Untitled 2026-08-04.json"];
+  const before = ["cmcp-e2e-lastweek.json"];
   assert.deepEqual(plannedDeletions(before, [...before]), []);
 });
 
@@ -72,8 +92,8 @@ test("an empty or unreadable listing plans nothing", () => {
 });
 
 test("duplicates in a listing are planned once", () => {
-  const planned = plannedDeletions([], ["Untitled 2026-08-09.json", "Untitled 2026-08-09.json"]);
-  assert.deepEqual(planned, ["Untitled 2026-08-09.json"]);
+  const planned = plannedDeletions([], ["cmcp-e2e-x.json", "cmcp-e2e-x.json"]);
+  assert.deepEqual(planned, ["cmcp-e2e-x.json"]);
 });
 
 // ── THE LEAK REPORT ───────────────────────────────────────────────────────
@@ -82,15 +102,15 @@ test("duplicates in a listing are planned once", () => {
 // down, so the teardown has to be able to say it failed.
 
 test("a clean run reports nothing", () => {
-  const r = leakReport(["a.json"], ["a.json"], ["Untitled 2026-08-09.json"]);
+  const r = leakReport(["a.json"], ["a.json"], ["cmcp-e2e-zz.json"]);
   assert.deepEqual(r, { undeleted: [], unrecognised: [] });
 });
 
 test("a delete that did not take is UNDELETED — the cleanup is broken", () => {
-  const r = leakReport(["a.json"], ["a.json", "Untitled 2026-08-09.json"], [
-    "Untitled 2026-08-09.json",
+  const r = leakReport(["a.json"], ["a.json", "cmcp-e2e-zz.json"], [
+    "cmcp-e2e-zz.json",
   ]);
-  assert.deepEqual(r.undeleted, ["Untitled 2026-08-09.json"]);
+  assert.deepEqual(r.undeleted, ["cmcp-e2e-zz.json"]);
   assert.deepEqual(r.unrecognised, []);
 });
 
@@ -103,15 +123,15 @@ test("a new name we never tried is UNRECOGNISED — a spec may have changed", ()
 });
 
 test("the two kinds are reported separately — they mean different things", () => {
-  const r = leakReport([], ["Untitled 2026-08-09.json", "something-else.json"], [
-    "Untitled 2026-08-09.json",
+  const r = leakReport([], ["cmcp-e2e-zz.json", "something-else.json"], [
+    "cmcp-e2e-zz.json",
   ]);
-  assert.deepEqual(r.undeleted, ["Untitled 2026-08-09.json"]);
+  assert.deepEqual(r.undeleted, ["cmcp-e2e-zz.json"]);
   assert.deepEqual(r.unrecognised, ["something-else.json"]);
 });
 
 test("userdata paths are namespaced to workflows", () => {
-  assert.equal(workflowUserdataPath("Untitled 2026-08-09.json"), "workflows/Untitled 2026-08-09.json");
+  assert.equal(workflowUserdataPath("cmcp-e2e-zz.json"), "workflows/cmcp-e2e-zz.json");
 });
 
 // ── WIRING ────────────────────────────────────────────────────────────────

--- a/browser_tests/unit/workflow-litter.test.mjs
+++ b/browser_tests/unit/workflow-litter.test.mjs
@@ -1,0 +1,135 @@
+// #907 — the suite saves real workflows into the developer's library and leaves
+// them there: 1269 of 1286 files were test output when this was measured.
+//
+// The cleanup deletes files from a directory that also holds the user's real
+// work, so the tests that matter here are the ones about what it must NOT touch.
+// A cleanup that removes too much is a far worse defect than the leak it fixes,
+// and it is unrecoverable.
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  isTestLitter,
+  leakReport,
+  plannedDeletions,
+  workflowUserdataPath,
+} from "../fixtures/workflow-litter.ts";
+
+test("recognises the names the suite actually produces", () => {
+  // ComfyUI's default for an unnamed save. TAKEN FROM THE REAL DIRECTORY, not
+  // from what the format looked like it should be: it carries a time too. The
+  // first pattern I wrote stopped at the date and matched zero of 1272 files.
+  assert.equal(isTestLitter("Untitled 2026-08-09 19-37-51.json"), true);
+  assert.equal(isTestLitter("Untitled 2026-08-06 21-12-26.json"), true);
+  // The date-only form older frontends produced.
+  assert.equal(isTestLitter("Untitled 2026-08-09.json"), true);
+  assert.equal(isTestLitter("Untitled 2026-08-09 (2).json"), true);
+  // The suite's own nonce prefix.
+  assert.equal(isTestLitter("cmcp-e2e-identity-m2x1-a7bd9c.json"), true);
+});
+
+test("does not recognise the user's own work", () => {
+  for (const real of [
+    "Artokun Flow v1.json",
+    "krea2_identity_edit.json",
+    "MiniMax_H3_00173_ (Copy).json",
+    "my Untitled experiment.json", // contains the word, is not the pattern
+    "Untitled.json", // no date — ComfyUI never names an autosave this
+  ]) {
+    assert.equal(isTestLitter(real), false, real);
+  }
+});
+
+test("BOTH conditions are required — new AND recognisable", () => {
+  const before = ["Artokun Flow v1.json", "Untitled 2026-08-01.json"];
+  const after = [
+    "Artokun Flow v1.json",
+    "Untitled 2026-08-01.json", // recognisable BUT pre-existing → the user's
+    "Untitled 2026-08-09.json", // new AND recognisable → ours
+    "New Idea.json", // new but NOT recognisable → the user saved it mid-run
+  ];
+  assert.deepEqual(plannedDeletions(before, after), ["Untitled 2026-08-09.json"]);
+});
+
+test("a file the user saved DURING the run is never deleted", () => {
+  // The case that makes "new" alone unsafe.
+  const planned = plannedDeletions(["a.json"], ["a.json", "Tuesday sketch.json"]);
+  assert.deepEqual(planned, []);
+});
+
+test("last week's Untitled is never deleted", () => {
+  // The case that makes "matches the pattern" alone unsafe — ComfyUI gives the
+  // user's own unnamed saves exactly this shape.
+  const before = ["Untitled 2026-08-04.json"];
+  assert.deepEqual(plannedDeletions(before, [...before]), []);
+});
+
+test("an empty or unreadable listing plans nothing", () => {
+  assert.deepEqual(plannedDeletions([], []), []);
+  assert.deepEqual(plannedDeletions(null, null), []);
+  assert.deepEqual(plannedDeletions(["a.json"], null), []);
+});
+
+test("duplicates in a listing are planned once", () => {
+  const planned = plannedDeletions([], ["Untitled 2026-08-09.json", "Untitled 2026-08-09.json"]);
+  assert.deepEqual(planned, ["Untitled 2026-08-09.json"]);
+});
+
+// ── THE LEAK REPORT ───────────────────────────────────────────────────────
+// #907 is not "the suite saves files" — it is that 1269 accumulated with nobody
+// noticing. A cleanup with no check behind it reproduces that silence one layer
+// down, so the teardown has to be able to say it failed.
+
+test("a clean run reports nothing", () => {
+  const r = leakReport(["a.json"], ["a.json"], ["Untitled 2026-08-09.json"]);
+  assert.deepEqual(r, { undeleted: [], unrecognised: [] });
+});
+
+test("a delete that did not take is UNDELETED — the cleanup is broken", () => {
+  const r = leakReport(["a.json"], ["a.json", "Untitled 2026-08-09.json"], [
+    "Untitled 2026-08-09.json",
+  ]);
+  assert.deepEqual(r.undeleted, ["Untitled 2026-08-09.json"]);
+  assert.deepEqual(r.unrecognised, []);
+});
+
+test("a new name we never tried is UNRECOGNISED — a spec may have changed", () => {
+  // The direction that catches the next version of this bug: a spec starts
+  // saving under a name no pattern matches, and the leak resumes silently.
+  const r = leakReport([], ["e2e-brand-new-shape.json"], []);
+  assert.deepEqual(r.unrecognised, ["e2e-brand-new-shape.json"]);
+  assert.deepEqual(r.undeleted, []);
+});
+
+test("the two kinds are reported separately — they mean different things", () => {
+  const r = leakReport([], ["Untitled 2026-08-09.json", "something-else.json"], [
+    "Untitled 2026-08-09.json",
+  ]);
+  assert.deepEqual(r.undeleted, ["Untitled 2026-08-09.json"]);
+  assert.deepEqual(r.unrecognised, ["something-else.json"]);
+});
+
+test("userdata paths are namespaced to workflows", () => {
+  assert.equal(workflowUserdataPath("Untitled 2026-08-09.json"), "workflows/Untitled 2026-08-09.json");
+});
+
+// ── WIRING ────────────────────────────────────────────────────────────────
+test("WIRING: playwright runs the cleanup, and it FAILS OPEN without a baseline", async () => {
+  const { readFile } = await import("node:fs/promises");
+  const cfg = await readFile(new URL("../../playwright.config.ts", import.meta.url), "utf8");
+  // Per-spec cleanup cannot cover a failing test; only these see the whole run.
+  assert.match(cfg, /globalSetup: '\.\/browser_tests\/global-setup\.ts'/);
+  assert.match(cfg, /globalTeardown: '\.\/browser_tests\/global-teardown\.ts'/);
+
+  const impl = await readFile(new URL("../global-workflow-litter.ts", import.meta.url), "utf8");
+  const clean = impl.slice(impl.indexOf("export async function cleanWorkflowLitter"));
+  // THE SAFETY PROPERTY, pinned at source: no baseline ⇒ no deletions. Treating
+  // an unreadable listing as "the directory was empty" would make every file in
+  // it look new — and this code deletes files.
+  assert.ok(
+    /const before = readBaseline\(\)\s*\n\s*if \(!before\) return/.test(clean),
+    "a missing baseline must delete nothing",
+  );
+  assert.ok(clean.includes("throw new Error("), "a broken cleanup must fail the run, not warn");
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -31,6 +31,13 @@ export default defineConfig({
   // `node --test` (npm run test:unit), NOT Playwright — Playwright's default
   // testMatch would otherwise import them (node:test auto-runs on import).
   testIgnore: '**/unit/**',
+  // #907 — the suite persists real workflows through ComfyUI's userdata API, and
+  // was leaving them in the developer's own library (1269 of 1286 files were test
+  // output when this was measured). Per-spec cleanup could not fix it: it sits at
+  // the end of a test body, so it does not run when the test FAILS. Only these
+  // two see the whole run.
+  globalSetup: './browser_tests/global-setup.ts',
+  globalTeardown: './browser_tests/global-teardown.ts',
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,

--- a/scripts/clean-e2e-litter.mjs
+++ b/scripts/clean-e2e-litter.mjs
@@ -1,0 +1,65 @@
+#!/usr/bin/env node
+// #907 — remove e2e litter that accumulated BEFORE the suite started cleaning up
+// after itself.
+//
+// Separate from the teardown on purpose. The teardown deletes only what the run
+// it is part of created, and knows that because it took a baseline first. This
+// script has no baseline: it is looking at files whose origin nobody recorded,
+// months of them, in a directory that also holds the developer's real work.
+//
+// So it DOES NOT DELETE unless told to, twice: it prints what it would remove and
+// exits, and only `--apply` acts. Anything it is not sure about, it leaves.
+//
+//   node scripts/clean-e2e-litter.mjs              # report only (default)
+//   node scripts/clean-e2e-litter.mjs --apply      # actually delete
+//   node scripts/clean-e2e-litter.mjs --url http://localhost:8189
+import { isTestLitter } from "../browser_tests/fixtures/workflow-litter.ts";
+
+const args = process.argv.slice(2);
+const apply = args.includes("--apply");
+const urlIdx = args.indexOf("--url");
+const base = urlIdx !== -1 ? args[urlIdx + 1] : process.env.PLAYWRIGHT_BASE_URL || "http://localhost:8188";
+
+const res = await fetch(`${base}/api/userdata?dir=workflows`).catch((err) => {
+  console.error(`could not reach ComfyUI at ${base}: ${err?.message ?? err}`);
+  process.exit(2);
+});
+if (!res.ok) {
+  console.error(`ComfyUI answered ${res.status} listing workflows`);
+  process.exit(2);
+}
+const all = (await res.json()).filter((n) => typeof n === "string");
+const litter = all.filter(isTestLitter).sort();
+const keep = all.length - litter.length;
+
+console.log(`${all.length} workflow(s) in ${base}`);
+console.log(`  ${keep} kept`);
+console.log(`  ${litter.length} match the e2e litter patterns`);
+if (!litter.length) process.exit(0);
+
+console.log("\nfirst 20 matches:");
+for (const name of litter.slice(0, 20)) console.log(`  ${name}`);
+if (litter.length > 20) console.log(`  … and ${litter.length - 20} more`);
+
+if (!apply) {
+  console.log(
+    `\nNothing was deleted. These are files in YOUR workflows directory — read the list above, ` +
+      `then re-run with --apply if it is all test output.`,
+  );
+  process.exit(0);
+}
+
+let removed = 0;
+const failed = [];
+for (const name of litter) {
+  const r = await fetch(`${base}/api/userdata/${encodeURIComponent(`workflows/${name}`)}`, {
+    method: "DELETE",
+  }).catch(() => null);
+  if (r && r.ok) removed++;
+  else failed.push(name);
+}
+console.log(`\nremoved ${removed} file(s)`);
+if (failed.length) {
+  console.log(`FAILED to remove ${failed.length}: ${failed.slice(0, 10).join(", ")}`);
+  process.exit(1);
+}

--- a/scripts/clean-e2e-litter.mjs
+++ b/scripts/clean-e2e-litter.mjs
@@ -2,23 +2,39 @@
 // #907 — remove e2e litter that accumulated BEFORE the suite started cleaning up
 // after itself.
 //
-// Separate from the teardown on purpose. The teardown deletes only what the run
-// it is part of created, and knows that because it took a baseline first. This
-// script has no baseline: it is looking at files whose origin nobody recorded,
-// months of them, in a directory that also holds the developer's real work.
+// Separate from the teardown on purpose, and far more cautious. The teardown
+// deletes only files that appeared during its own run AND carry the suite's
+// `cmcp-e2e-` prefix, so it can never be wrong about ownership. This script has
+// neither: it looks at files whose origin nobody recorded, months of them, in a
+// directory that also holds the developer's real work.
 //
-// So it DOES NOT DELETE unless told to, twice: it prints what it would remove and
-// exits, and only `--apply` acts. Anything it is not sure about, it leaves.
+// THE FAMILY YOU ACTUALLY WANT GONE IS THE AMBIGUOUS ONE. The ~1272 files here
+// are named `Untitled <date> <time>.json` — exactly what ComfyUI names the user's
+// OWN unnamed saves. Nothing in the name distinguishes a test artifact from a
+// workflow someone meant to keep, so a script cannot decide it and must not
+// pretend to (codex). Hence:
 //
-//   node scripts/clean-e2e-litter.mjs              # report only (default)
-//   node scripts/clean-e2e-litter.mjs --apply      # actually delete
-//   node scripts/clean-e2e-litter.mjs --url http://localhost:8189
+//   • `cmcp-e2e-*` is unambiguous and needs only --apply;
+//   • the Untitled family needs --include-untitled ON TOP of --apply, and the
+//     full list goes to a file first, because a 20-line preview of 1272
+//     deletions is not review, it is a formality.
+//
+//   node scripts/clean-e2e-litter.mjs                              # report only
+//   node scripts/clean-e2e-litter.mjs --apply                      # cmcp-e2e-* only
+//   node scripts/clean-e2e-litter.mjs --apply --include-untitled   # + Untitled family
+import { writeFileSync } from "node:fs";
+
 import { isTestLitter } from "../browser_tests/fixtures/workflow-litter.ts";
+
+/** ComfyUI's default for an unnamed save — AMBIGUOUS by construction. */
+const UNTITLED = /^Untitled \d{4}-\d{2}-\d{2}(?: \d{2}-\d{2}-\d{2})?(?: \(\d+\))?\.json$/;
 
 const args = process.argv.slice(2);
 const apply = args.includes("--apply");
+const includeUntitled = args.includes("--include-untitled");
 const urlIdx = args.indexOf("--url");
-const base = urlIdx !== -1 ? args[urlIdx + 1] : process.env.PLAYWRIGHT_BASE_URL || "http://localhost:8188";
+const base =
+  urlIdx !== -1 ? args[urlIdx + 1] : process.env.PLAYWRIGHT_BASE_URL || "http://localhost:8188";
 
 const res = await fetch(`${base}/api/userdata?dir=workflows`).catch((err) => {
   console.error(`could not reach ComfyUI at ${base}: ${err?.message ?? err}`);
@@ -29,29 +45,45 @@ if (!res.ok) {
   process.exit(2);
 }
 const all = (await res.json()).filter((n) => typeof n === "string");
-const litter = all.filter(isTestLitter).sort();
-const keep = all.length - litter.length;
+const suiteNamed = all.filter(isTestLitter).sort();
+const untitled = all.filter((n) => UNTITLED.test(n)).sort();
+const targets = includeUntitled ? [...suiteNamed, ...untitled].sort() : suiteNamed;
 
 console.log(`${all.length} workflow(s) in ${base}`);
-console.log(`  ${keep} kept`);
-console.log(`  ${litter.length} match the e2e litter patterns`);
-if (!litter.length) process.exit(0);
+console.log(`  ${suiteNamed.length} named by the suite (cmcp-e2e-*) — unambiguous`);
+console.log(
+  `  ${untitled.length} Untitled <date> — ComfyUI's name for ANY unnamed save, including yours`,
+);
+console.log(`  ${all.length - suiteNamed.length - untitled.length} other`);
 
-console.log("\nfirst 20 matches:");
-for (const name of litter.slice(0, 20)) console.log(`  ${name}`);
-if (litter.length > 20) console.log(`  … and ${litter.length - 20} more`);
+if (!targets.length) {
+  console.log(`\nNothing to do.`);
+  process.exit(0);
+}
+
+const listing = "cmcp-e2e-litter-review.txt";
+writeFileSync(listing, `${targets.join("\n")}\n`, "utf-8");
+console.log(`\nfull list of ${targets.length} candidate(s) written to ${listing}`);
 
 if (!apply) {
-  console.log(
-    `\nNothing was deleted. These are files in YOUR workflows directory — read the list above, ` +
-      `then re-run with --apply if it is all test output.`,
-  );
+  const untitledHint =
+    untitled.length && !includeUntitled
+      ? ` (add --include-untitled to also remove the ${untitled.length} Untitled files — read the` +
+        ` list for anything you saved yourself first; this script cannot tell them apart).`
+      : ".";
+  console.log(`\nNothing was deleted. Read ${listing}, then re-run with --apply${untitledHint}`);
   process.exit(0);
+}
+
+if (untitled.length && !includeUntitled) {
+  console.log(
+    `\nSkipping the ${untitled.length} Untitled files — pass --include-untitled to remove them too.`,
+  );
 }
 
 let removed = 0;
 const failed = [];
-for (const name of litter) {
+for (const name of targets) {
   const r = await fetch(`${base}/api/userdata/${encodeURIComponent(`workflows/${name}`)}`, {
     method: "DELETE",
   }).catch(() => null);


### PR DESCRIPTION
Draft — claiming #907.

Re-measured on this machine before starting: **1269 of 1286** files in `user/default/workflows` are `Untitled 2026-08-*` test output. The issue reported 1221 of 1240, so it is still leaking.

Two things follow that shape the fix:

1. Per-spec cleanup is what this repo already tried. Three specs clean up, two do not, and the two that do not were written before the review that added it to the others. A convention nobody can forget is not a convention — so the guarantee belongs to the suite.
2. **A leak nobody notices is the actual defect.** 1269 files accumulated silently. Whatever cleanup lands has to fail loudly when it stops working, or this is back in a month.

Also worth testing while here: #847's two remaining failures are a chat-history **row count** and a workflow-chat-identity **first record**. A workflows store holding 1286 entries on a dev box is exactly the kind of thing that perturbs those, and no user install looks like that. I will measure whether the litter causes them before assuming the two issues are independent.

I will **not** mass-delete the existing 1269 files — that is the user's workflow directory and the deletion is theirs to authorise. A dry-run-by-default cleanup script comes with this instead.