### PR TITLE
0.11.79 — e2e cleanup proves ownership before deleting (#907)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+## [0.11.79] - 2026-08-09
+
+> Covers changes since 0.11.78.
+
+### Fixed
+
+- **The e2e suite stops leaving saved workflows in your library, and says so when it
+  cannot be sure (#907).** Specs that persist a workflow were leaving the file behind:
+  1272 of 1288 files in the dev workflow directory were test output. Per-spec cleanup
+  could not fix it, because it sat at the end of a test body and so never ran when a
+  test failed. Cleanup is now suite-level, and deletes only files that appeared during
+  the run AND carry the suite's own name prefix — ComfyUI names an unnamed save
+  `Untitled <date> <time>`, which is exactly what it names YOURS, so nothing keyed on
+  that name is safe to delete automatically. Anything else that appears is reported by
+  name rather than removed or ignored. Developer-facing only; nothing in the shipped
+  panel changes.
+
 ## [0.11.78] - 2026-08-09
 
 > Covers changes since 0.11.77.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-agent-panel"
 description = "Autonomous AI agent in the ComfyUI sidebar - local-first, bring any LLM. Run it on your Claude or ChatGPT subscription (no API keys, no extra LLM costs), on a Kimi K3 / GLM / OpenRouter key, or fully offline on free local models via Ollama, LM Studio, or llama.cpp. The agent drives your live canvas at full parity: add, wire, move and tweak nodes with Ctrl+Z undo, load whole workflows and installer packs in one shot, generate images, video and audio, browse CivitAI, and run your workflow - asking before it spends paid API credits. The sidebar UI for comfyui-mcp, the local-first, agent-native control plane for ComfyUI."
-version = "0.11.78"
+version = "0.11.79"
 license = { file = "LICENSE" }
 requires-python = ">=3.9"
 # UI-only pack: no Python deps. The frontend floor guarantees

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -880,7 +880,7 @@ const DOCS_URL = "https://comfyui-mcp.artokun.io/docs";
 // Panel version — surfaced in the "Need help?" diagnostics blob. Bump via
 // `node scripts/set-version.mjs <v>` (updates this AND pyproject together); CI
 // and the publish gate FAIL if the two ever drift, so this can't go stale.
-const PANEL_VERSION = "0.11.78";
+const PANEL_VERSION = "0.11.79";
 
 // The connected orchestrator's console URL/token (captured off the `backends`
 // bridge message — see onBackends). Drives the "API Keys" credentials frame;


### PR DESCRIPTION
Version bump + changelog for 0.11.79, covering #940.

Developer-facing only — nothing in the shipped panel changes. Releasing it so the version the suite runs against matches main.