### PR TITLE
0.11.80 — your first chat about a workflow stops vanishing from its own filter (#847)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,38 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+## [0.11.80] - 2026-08-09
+
+> Covers changes since 0.11.79.
+
+### Fixed
+
+- **Your first chat about a workflow no longer disappears when you filter to that
+  workflow (#847).** Chat, start a second chat, then tick "Current workflow only": the
+  first conversation vanished, even though both were held on the same canvas.
+
+  The panel saves an unsaved workflow before a turn ("grounding", #330), and ComfyUI
+  replaces the workflow object at that save. Every carrier that could hand the identity
+  to the successor is empty at that instant — the object maps are keyed on the object
+  that just went away, the embedded uuid is unreadable because the fields it is looked
+  for in are all absent on this frontend, and the path alias gets written from the new
+  id. So the successor minted a fresh identity and the conversation from seconds earlier
+  was left holding one that nothing answered to.
+
+  The tab's pre-save route id is now captured *inside* the grounding transaction and
+  filed under the path that save produced. That location matters: an observer watching
+  the change afterwards cannot prove the old id was this tab's past rather than a
+  workflow you switched away from, which is why the panel deliberately migrates nothing
+  there. The save knows by causation — it is the panel's own call, on its own active
+  workflow — so nothing is inferred.
+
+  Scope is small on purpose: these forms are consulted by the history filter alone.
+  They never resolve a workflow's identity, authorize a graph write, or restore a
+  session. One limit stays open and is documented rather than hidden — deleting a
+  workflow and creating a new one with the same name can show the old chats under the
+  new one, since a path is not proof of ownership.
+
+
 ## [0.11.79] - 2026-08-09
 
 > Covers changes since 0.11.78.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-agent-panel"
 description = "Autonomous AI agent in the ComfyUI sidebar - local-first, bring any LLM. Run it on your Claude or ChatGPT subscription (no API keys, no extra LLM costs), on a Kimi K3 / GLM / OpenRouter key, or fully offline on free local models via Ollama, LM Studio, or llama.cpp. The agent drives your live canvas at full parity: add, wire, move and tweak nodes with Ctrl+Z undo, load whole workflows and installer packs in one shot, generate images, video and audio, browse CivitAI, and run your workflow - asking before it spends paid API credits. The sidebar UI for comfyui-mcp, the local-first, agent-native control plane for ComfyUI."
-version = "0.11.79"
+version = "0.11.80"
 license = { file = "LICENSE" }
 requires-python = ">=3.9"
 # UI-only pack: no Python deps. The frontend floor guarantees

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -884,7 +884,7 @@ const DOCS_URL = "https://comfyui-mcp.artokun.io/docs";
 // Panel version — surfaced in the "Need help?" diagnostics blob. Bump via
 // `node scripts/set-version.mjs <v>` (updates this AND pyproject together); CI
 // and the publish gate FAIL if the two ever drift, so this can't go stale.
-const PANEL_VERSION = "0.11.79";
+const PANEL_VERSION = "0.11.80";
 
 // The connected orchestrator's console URL/token (captured off the `backends`
 // bridge message — see onBackends). Drives the "API Keys" credentials frame;


### PR DESCRIPTION
Releases the #847 fix.

Grounding replaces the workflow object mid-save and nothing survives to hand the identity on, so the conversation recorded seconds earlier was orphaned and dropped out of "Current workflow only". The pre-save route id is now captured inside the grounding transaction, where ownership is known by causation rather than inferred.

Second entry generated correctly by gen-changelog since #932 — anchored on the 0.11.79 release commit, 1 commit since.

Closes #847