### PR TITLE
fix(save-as): the reply carries the new workflow identity, so the fence can follow (#941)

### DIFF
--- a/browser_tests/save-as-reports-identity.spec.ts
+++ b/browser_tests/save-as-reports-identity.spec.ts
@@ -1,0 +1,83 @@
+/**
+ * #941 — a Save-As must report the identity of the workflow it just made active.
+ *
+ * `panel_save_workflow({name})` writes the copy correctly and switches the active canvas to
+ * it. The caller's session is still fenced to the workflow it held BEFORE its own save, so
+ * every following `panel_*` graph call is refused — the agent breaks its own binding by
+ * using a documented tool exactly as documented.
+ *
+ * That is survivable only if the reply says what to re-fence TO. It did not: the reply
+ * carried `workflow_identity_unavailable`, because the identity read is deliberately pure
+ * (#716) and a Save-As activates a brand-new object nothing has established one for. One
+ * call later the fence refused with that very identity, which its own minting read had by
+ * then produced. The panel knew the value and would not publish it.
+ *
+ * This asserts the reply carries it. Asserting only that a later call SUCCEEDS would not do:
+ * the recovery path (`workflow_open`, fence-exempt) works on its own and would make the test
+ * pass with the reply still empty — which is the bug.
+ */
+import { test, expect, deleteSavedWorkflow } from './fixtures/panelTest'
+
+test('a Save-As reply carries the new workflow instance identity', async ({
+  page,
+  panel,
+  mockBridge
+}) => {
+  const cleanup: string[] = []
+  try {
+    await panel.goto()
+    await panel.setBridgeUrl(mockBridge.url)
+    await panel.openSidebar()
+    await panel.connect()
+
+    // Start from a SAVED workflow, as the report does — a Save-As from an unsaved canvas is
+    // a different path (first_save) and already reported identity correctly.
+    const first = await mockBridge.command('workflow_save', {})
+    expect(first.ok, 'the setup save must succeed').toBe(true)
+    const original = String(first.result?.workflow || '')
+    expect(original, 'the setup save must report a name').toBeTruthy()
+    cleanup.push(original)
+    expect(
+      first.result?.workflow_uuid,
+      'an in-place/first save already reported identity — if this is missing the fix is aimed at the wrong path'
+    ).toBeTruthy()
+
+    // The Save-As. This is what strands a caller.
+    const copyName = `e2e-941-${Date.now()}`
+    const saved = await mockBridge.command('workflow_save', { name: copyName })
+    expect(saved.ok, 'the Save-As must succeed').toBe(true)
+    cleanup.push(copyName)
+    expect(saved.result?.saved_as, 'this must actually be a Save-As, not an in-place save').toBe(true)
+
+    // THE ASSERTION. Without an identity here the caller has nothing to re-fence to, and
+    // every call that could tell it is itself refused.
+    expect(
+      saved.result?.workflow_identity_unavailable,
+      'the reply must not report identity as unavailable — that is the wedge'
+    ).toBeFalsy()
+    expect(saved.result?.workflow_uuid, 'the reply must carry the new instance uuid').toBeTruthy()
+    expect(saved.result?.routing_key, 'and the routing key the list records agree on').toBe(
+      `wf:workflows/${copyName}.json`
+    )
+    // The caller must also be TOLD its fence is now stale, or it has no reason to use the
+    // identity it was just handed.
+    expect(saved.result?.workflow_instance_changed).toBe(true)
+
+    // The published identity has to be the one the fence actually compares against —
+    // otherwise it is a plausible-looking value that re-fences to nothing.
+    const refused = await mockBridge.command('graph_outline', {})
+    expect(refused.ok, 'the session is still fenced to the pre-save workflow, so this is refused').toBe(false)
+    expect(
+      String(refused.error || ''),
+      'the mismatch must name the identity the save reported, or the reply cannot recover the session'
+    ).toContain(String(saved.result.workflow_uuid))
+  } finally {
+    for (const name of cleanup.reverse()) {
+      try {
+        await deleteSavedWorkflow(page, name)
+      } catch {
+        // Best-effort: cleanup must never mask the assertion that failed.
+      }
+    }
+  }
+})

--- a/browser_tests/save-as-reports-identity.spec.ts
+++ b/browser_tests/save-as-reports-identity.spec.ts
@@ -63,6 +63,21 @@ test('a Save-As reply carries the new workflow instance identity', async ({
     // identity it was just handed.
     expect(saved.result?.workflow_instance_changed).toBe(true)
 
+    // A Save-As copy is a NEW workflow and must not inherit the original's instance
+    // identity — shouldCarryIdentityAcrossSaveSwap refuses the carry for savedAs, but the
+    // resolution order is `objectUuid || embedded || pathAlias || random`, so an inherited
+    // embedded id could still collapse the two onto one uuid (codex). Assert the outcome,
+    // not the intent.
+    expect(
+      saved.result?.workflow_uuid,
+      'the copy must not share the original workflow instance identity'
+    ).not.toBe(first.result?.workflow_uuid)
+
+    // The identity must describe the COPY, not whichever canvas happened to be active when
+    // the reply was built — the reply's name and its identity have to be one snapshot.
+    expect(saved.result?.routing_key).toBe(`wf:workflows/${copyName}.json`)
+    expect(saved.result?.routing_key).not.toBe(`wf:workflows/${original}.json`)
+
     // The published identity has to be the one the fence actually compares against —
     // otherwise it is a plausible-looking value that re-fences to nothing.
     const refused = await mockBridge.command('graph_outline', {})
@@ -71,6 +86,13 @@ test('a Save-As reply carries the new workflow instance identity', async ({
       String(refused.error || ''),
       'the mismatch must name the identity the save reported, or the reply cannot recover the session'
     ).toContain(String(saved.result.workflow_uuid))
+
+    // And the reported identity genuinely recovers the session: re-open the copy (the
+    // fence-exempt path), then a graph read must succeed against it.
+    const reopened = await mockBridge.command('workflow_open', { path: `workflows/${copyName}.json` })
+    expect(reopened.ok, 'the fence-exempt recovery must work').toBe(true)
+    const after = await mockBridge.command('graph_outline', {})
+    expect(after.ok, 'graph tools must work again once the session is re-fenced').toBe(true)
   } finally {
     for (const name of cleanup.reverse()) {
       try {

--- a/browser_tests/unit/save-as-identity.test.mjs
+++ b/browser_tests/unit/save-as-identity.test.mjs
@@ -1,0 +1,64 @@
+// #941 — a Save-As must report the identity of the workflow it just made active.
+//
+// Measured on 0.11.80 before the fix:
+//
+//   workflow_save({name}) -> { saved:true, saved_as:true, workflow_identity_unavailable:true }
+//   graph_outline()       -> "workflow instance mismatch: ... issued for instance b273a69f,
+//                             and the active canvas reports 14d699d3"
+//
+// The panel knew the new identity well enough to refuse the next call with it, and had
+// declined to report it one call earlier. `establishedWorkflowReplyIdentity` is a pure read
+// by design (#716 — a fence refreshed from a value a read invented agrees with itself), and
+// a Save-As activates a brand-new object nothing has established an identity for. So the
+// read honestly found nothing while the fence's own minting read immediately found one.
+//
+// The fix establishes the identity as part of the SAVE, which is a mutation whose job is to
+// change which canvas is active — not a read inventing one.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  saveReplyIdentity,
+  shouldEstablishIdentityAfterSave,
+} from "../../web/js/lib/save-reply-identity.js";
+
+test("#941: a Save-As with nothing established is the case that must establish", () => {
+  assert.equal(shouldEstablishIdentityAfterSave({ savedAs: true, alreadyEstablished: false }), true);
+});
+
+test("#941: an already-established canvas is left alone", () => {
+  // Minting over an established identity would change what the canvas IS as a side effect
+  // of saving it — the opposite of the bug, and worse.
+  assert.equal(shouldEstablishIdentityAfterSave({ savedAs: true, alreadyEstablished: true }), false);
+});
+
+test("#941: an in-place save never establishes", () => {
+  // It keeps the same object, whose identity is already established; there is nothing to
+  // mint and no caller to strand. Deliberately not widened — measured, an in-place/first
+  // save already reports `workflow_uuid` correctly.
+  assert.equal(shouldEstablishIdentityAfterSave({ savedAs: false, alreadyEstablished: false }), false);
+  assert.equal(shouldEstablishIdentityAfterSave({ savedAs: false, alreadyEstablished: true }), false);
+  assert.equal(shouldEstablishIdentityAfterSave({}), false, "unknown shape must not mint");
+  assert.equal(shouldEstablishIdentityAfterSave(), false);
+});
+
+test("#941: once established, the reply carries what the fence compares against", () => {
+  // The whole point: the value published here is the one the next mismatch error names, so
+  // a stranded session has something to re-fence to.
+  const reply = saveReplyIdentity(
+    { uuid: "aafd364e-7093-4daa-b5ed-df8541e696d9", routingKey: "wf:workflows/copy.json" },
+    { savedAs: true },
+  );
+  assert.equal(reply.workflow_uuid, "aafd364e-7093-4daa-b5ed-df8541e696d9");
+  assert.equal(reply.routing_key, "wf:workflows/copy.json");
+  assert.equal(reply.workflow_instance_changed, true, "the caller must be told its fence is stale");
+  assert.ok(!("workflow_identity_unavailable" in reply));
+});
+
+test("#941: an unknown identity still says so rather than implying continuity", () => {
+  // The establish step is best-effort — it sits behind a try/catch so a bookkeeping failure
+  // cannot fail a save that already wrote the file. When it does not produce an identity the
+  // reply must keep reporting absence, not silence, which is what stranded the reporter.
+  const reply = saveReplyIdentity(null, { savedAs: true });
+  assert.equal(reply.workflow_identity_unavailable, true);
+  assert.match(reply.workflow_identity_note, /fenced to the workflow that was active BEFORE this save/);
+});

--- a/browser_tests/unit/save-reply-identity.test.mjs
+++ b/browser_tests/unit/save-reply-identity.test.mjs
@@ -91,9 +91,12 @@ test("#747 WIRING: BOTH save handlers report the identity, and save_as always fl
   const saveAsBlock = src.slice(saveAsIdx, saveAsIdx + 900);
 
   // workflow_save is only a Save-As when the outcome says so…
-  assert.match(saveBlock, /saveReplyIdentity\(replyIdentity \?\? liveWorkflowListActive\(\)\.activeIdentity, \{ savedAs: !!outcome\.saved_as \}\)/);
+  assert.match(saveBlock, /saveReplyIdentity\(outcome\.saved_as \? replyIdentity : replyIdentity \?\? liveWorkflowListActive\(\)\.activeIdentity, \{ savedAs: !!outcome\.saved_as \}\)/);
   // …while workflow_save_as always changes which workflow is active.
-  assert.match(saveAsBlock, /saveReplyIdentity\(replyIdentity \?\? liveWorkflowListActive\(\)\.activeIdentity, \{ savedAs: true \}\)/);
+  assert.match(saveAsBlock, /saveReplyIdentity\(replyIdentity, \{ savedAs: true \}\)/);
+  // #941 — and a Save-As must NOT fall back to the live active canvas. Absence stays
+  // absence; substituting whatever is active can name a foreign canvas (codex).
+  assert.doesNotMatch(saveAsBlock, /savedAs: true[\s\S]{0,80}liveWorkflowListActive/);
 
   // #941 — and BOTH must establish the identity first, or the read above finds nothing for
   // a Save-As's brand-new object and reports `workflow_identity_unavailable` while the

--- a/browser_tests/unit/save-reply-identity.test.mjs
+++ b/browser_tests/unit/save-reply-identity.test.mjs
@@ -78,7 +78,10 @@ test("#747 non-string identity fields are rejected, not stringified into the fen
 test("#747 WIRING: BOTH save handlers report the identity, and save_as always flags the change", () => {
   // A green helper proves nothing about the reply the agent receives (#792).
   const src = readFileSync(PANEL_JS, "utf8");
-  assert.match(src, /import \{ saveReplyIdentity \} from "\.\/lib\/save-reply-identity\.js"/);
+  // The SYMBOL is imported from that module — not the exact import line. Pinning the whole
+  // line broke the moment #941 added a second export beside it, which says nothing about
+  // whether the reply is wired up.
+  assert.match(src, /import \{[^}]*saveReplyIdentity[^}]*\} from "\.\/lib\/save-reply-identity\.js"/);
 
   const saveIdx = src.indexOf("async workflow_save({ name } = {})");
   const saveAsIdx = src.indexOf("async workflow_save_as({ name })");
@@ -91,4 +94,11 @@ test("#747 WIRING: BOTH save handlers report the identity, and save_as always fl
   assert.match(saveBlock, /saveReplyIdentity\(liveWorkflowListActive\(\)\.activeIdentity, \{ savedAs: !!outcome\.saved_as \}\)/);
   // …while workflow_save_as always changes which workflow is active.
   assert.match(saveAsBlock, /saveReplyIdentity\(liveWorkflowListActive\(\)\.activeIdentity, \{ savedAs: true \}\)/);
+
+  // #941 — and BOTH must establish the identity first, or the read above finds nothing for
+  // a Save-As's brand-new object and reports `workflow_identity_unavailable` while the
+  // fence, whose own read mints, refuses the next call with the identity it just declined
+  // to publish.
+  assert.match(saveBlock, /establishActiveIdentityAfterSave\(!!outcome\.saved_as\)/);
+  assert.match(saveAsBlock, /establishActiveIdentityAfterSave\(true\)/);
 });

--- a/browser_tests/unit/save-reply-identity.test.mjs
+++ b/browser_tests/unit/save-reply-identity.test.mjs
@@ -91,14 +91,15 @@ test("#747 WIRING: BOTH save handlers report the identity, and save_as always fl
   const saveAsBlock = src.slice(saveAsIdx, saveAsIdx + 900);
 
   // workflow_save is only a Save-As when the outcome says so…
-  assert.match(saveBlock, /saveReplyIdentity\(liveWorkflowListActive\(\)\.activeIdentity, \{ savedAs: !!outcome\.saved_as \}\)/);
+  assert.match(saveBlock, /saveReplyIdentity\(replyIdentity \?\? liveWorkflowListActive\(\)\.activeIdentity, \{ savedAs: !!outcome\.saved_as \}\)/);
   // …while workflow_save_as always changes which workflow is active.
-  assert.match(saveAsBlock, /saveReplyIdentity\(liveWorkflowListActive\(\)\.activeIdentity, \{ savedAs: true \}\)/);
+  assert.match(saveAsBlock, /saveReplyIdentity\(replyIdentity \?\? liveWorkflowListActive\(\)\.activeIdentity, \{ savedAs: true \}\)/);
 
   // #941 — and BOTH must establish the identity first, or the read above finds nothing for
   // a Save-As's brand-new object and reports `workflow_identity_unavailable` while the
   // fence, whose own read mints, refuses the next call with the identity it just declined
   // to publish.
-  assert.match(saveBlock, /establishActiveIdentityAfterSave\(!!outcome\.saved_as\)/);
-  assert.match(saveAsBlock, /establishActiveIdentityAfterSave\(true\)/);
+  // …from the record the SAVE produced, not a later active-canvas read (#941, codex).
+  assert.match(saveBlock, /saveProducedIdentity\(producedRecord, !!outcome\.saved_as\)/);
+  assert.match(saveAsBlock, /saveProducedIdentity\(producedRecord, true\)/);
 });

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -2386,39 +2386,40 @@ function isCanonicalWorkflowInstanceUuid(value) {
 // canonical workflow. A tmp: routing handle is intentionally not durable enough
 // to publish as a command-fence refresh source.
 /**
- * #941 — after a save that made a DIFFERENT workflow active, establish that canvas's
- * identity so the reply can report it.
+ * #941 — the identity to report for the workflow a save just produced.
  *
- * A Save-As activates a brand-new object. Nothing has established an identity for it, so
- * `establishedWorkflowReplyIdentity` (a deliberate pure read, #716) found none and the
- * reply said "unavailable" — while the very next command was refused BY that identity,
+ * A Save-As activates a brand-new object that nothing has established an identity for, so
+ * `establishedWorkflowReplyIdentity` — a deliberate pure read (#716) — found none and the
+ * reply said "unavailable", while the very next command was refused BY that identity,
  * because the fence's own read mints. The panel knew the value and would not publish it,
- * which is what made the wedge unrecoverable: the documented recovery is fence-exempt but
- * cannot re-derive something that was never reported.
+ * and a caller fenced to the pre-save workflow had nothing to recover with.
  *
- * Minting here does not weaken the #716 rule. That rule stops a READ from deciding what
- * the canvas is. This runs inside `workflow_save`, a mutation that just changed which
- * canvas is active — establishing the identity of the canvas it created is part of doing
- * the work, not a read inventing one.
+ * Minting here does not weaken #716. That rule stops a READ from deciding what the canvas
+ * is. This runs inside `workflow_save`, a mutation whose job is to change which canvas is
+ * active, and it establishes for the object the SAVE ITSELF produced — never for whatever
+ * happens to be active afterwards, which a tab switch during the save's awaits could make
+ * a different workflow entirely (codex).
  */
-function establishActiveIdentityAfterSave(savedAs) {
+function saveProducedIdentity(savedRecord, savedAs) {
   try {
-    const active = activeWorkflowRef();
-    if (!active) return;
+    if (!savedRecord || typeof savedRecord !== "object") return null;
     if (
       !shouldEstablishIdentityAfterSave({
         savedAs,
-        alreadyEstablished: Boolean(establishedWorkflowReplyIdentity(active)),
+        alreadyEstablished: Boolean(establishedWorkflowReplyIdentity(savedRecord)),
       })
     ) {
-      return;
+      return establishedWorkflowReplyIdentity(savedRecord);
     }
-    // The minting read. Records into the live-object map + owner map, which is exactly
-    // what `establishedWorkflowReplyIdentity` then finds.
-    workflowStableUuid(active);
+    // The minting read — records into the live-object and owner maps, which is exactly
+    // what establishedWorkflowReplyIdentity then finds.
+    workflowStableUuid(savedRecord);
+    return establishedWorkflowReplyIdentity(savedRecord);
   } catch {
     // A reply that cannot report identity is the bug being fixed, not a reason to fail a
-    // save that already succeeded.
+    // save that already wrote the file. saveReplyIdentity(null) still reports ABSENCE
+    // explicitly, so the caller is told rather than left to assume continuity.
+    return null;
   }
 }
 
@@ -4147,7 +4148,21 @@ async function programmaticSave(name) {
       outcome.original_on_disk = status === "present" ? true : "unverified";
     }
   }
-  return { name: saved || getWorkflowTitle(), ...outcome };
+  // #941 — establish the identity of the object the SAVE PRODUCED, and report THAT.
+  //
+  // Not `activeWorkflowRef()` after the await (codex): a tab switch during the save's
+  // internal awaits would mint for whichever canvas happens to be active, and the reply
+  // would then pair `workflow: "<copy>"` with a uuid describing a DIFFERENT canvas. An
+  // agent re-fencing on it would authorize graph writes against that other workflow. Same
+  // transaction-boundary mistake as #847, one iteration later.
+  //
+  // `details.savedRecord` is the save's own authoritative output — the same value
+  // shouldCarryIdentityAcrossSaveSwap is threaded with above — so name, routing key and
+  // uuid all come from one snapshot.
+  // Hand back the RECORD, and let the caller resolve identity from it. `activatedRecord` is
+  // the Save-As copy the adapter PROVED active; `savedRecord` covers the first-save path.
+  // Either way it is the save transaction's own output, never a later active-canvas read.
+  return { name: saved || getWorkflowTitle(), producedRecord: details?.activatedRecord || details?.savedRecord || null, ...outcome };
 }
 
 /** Authoritative read-back oracle for saveActiveWorkflow's post-write guards.
@@ -11594,7 +11609,8 @@ const GRAPH_TOOL_EXECUTORS = {
   async workflow_save({ name } = {}) {
     // Fully programmatic — no Save/Rename dialog. Auto-names a never-saved
     // workflow; saves in place otherwise.
-    const { name: workflow, ...outcome } = await programmaticSave(name);
+    const { name: workflow, producedRecord, ...outcome } = await programmaticSave(name);
+    const replyIdentity = saveProducedIdentity(producedRecord, !!outcome.saved_as);
     // outcome surfaces WHAT happened (saved_as/copied_from/original_preserved or
     // first_save) so a rename-vs-copy is never silent (mcp#579).
     //
@@ -11602,17 +11618,16 @@ const GRAPH_TOOL_EXECUTORS = {
     // DIFFERENT workflow active, which fences the very session that asked for the
     // save; without an identity in this reply the caller has nothing to re-fence
     // to, and every call that could tell it is itself refused.
-    establishActiveIdentityAfterSave(!!outcome.saved_as);
-    return { saved: true, workflow, ...outcome, ...saveReplyIdentity(liveWorkflowListActive().activeIdentity, { savedAs: !!outcome.saved_as }) };
+    return { saved: true, workflow, ...outcome, ...saveReplyIdentity(replyIdentity ?? liveWorkflowListActive().activeIdentity, { savedAs: !!outcome.saved_as }) };
   },
 
   async workflow_save_as({ name }) {
     if (!name || typeof name !== "string") throw new Error("name (string) is required");
-    const { name: workflow, ...outcome } = await programmaticSave(name);
+    const { name: workflow, producedRecord, ...outcome } = await programmaticSave(name);
     // #747 — this path ALWAYS changes which workflow is active, so it is the one
     // that strands a caller. Report the new instance identity here.
-    establishActiveIdentityAfterSave(true);
-    return { saved: true, workflow, ...outcome, ...saveReplyIdentity(liveWorkflowListActive().activeIdentity, { savedAs: true }) };
+    const replyIdentity = saveProducedIdentity(producedRecord, true);
+    return { saved: true, workflow, ...outcome, ...saveReplyIdentity(replyIdentity ?? liveWorkflowListActive().activeIdentity, { savedAs: true }) };
   },
 
   // --- Workflow tabs: new / list / open / switch / rename / close ----------

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -146,7 +146,7 @@ import {
 } from "./lib/asset-staleness.js";
 import { assertAddNodeResolvableRefreshing, isRegisteredNodeType } from "./lib/node-resolve.js";
 import { fetchSingleNodeDef } from "./lib/single-node-def.js";
-import { saveReplyIdentity } from "./lib/save-reply-identity.js";
+import { saveReplyIdentity, shouldEstablishIdentityAfterSave } from "./lib/save-reply-identity.js";
 import { scanComboAvailability, comboAvailabilityNote } from "./lib/live-combo-availability.js";
 import { readSaveFailureCause } from "./lib/userdata-failure-cause.js";
 import { describeScreenshotFraming } from "./lib/screenshot-framing.js";
@@ -2385,6 +2385,43 @@ function isCanonicalWorkflowInstanceUuid(value) {
 // a real workflow. Accept only an already-established UUID on a persisted,
 // canonical workflow. A tmp: routing handle is intentionally not durable enough
 // to publish as a command-fence refresh source.
+/**
+ * #941 — after a save that made a DIFFERENT workflow active, establish that canvas's
+ * identity so the reply can report it.
+ *
+ * A Save-As activates a brand-new object. Nothing has established an identity for it, so
+ * `establishedWorkflowReplyIdentity` (a deliberate pure read, #716) found none and the
+ * reply said "unavailable" — while the very next command was refused BY that identity,
+ * because the fence's own read mints. The panel knew the value and would not publish it,
+ * which is what made the wedge unrecoverable: the documented recovery is fence-exempt but
+ * cannot re-derive something that was never reported.
+ *
+ * Minting here does not weaken the #716 rule. That rule stops a READ from deciding what
+ * the canvas is. This runs inside `workflow_save`, a mutation that just changed which
+ * canvas is active — establishing the identity of the canvas it created is part of doing
+ * the work, not a read inventing one.
+ */
+function establishActiveIdentityAfterSave(savedAs) {
+  try {
+    const active = activeWorkflowRef();
+    if (!active) return;
+    if (
+      !shouldEstablishIdentityAfterSave({
+        savedAs,
+        alreadyEstablished: Boolean(establishedWorkflowReplyIdentity(active)),
+      })
+    ) {
+      return;
+    }
+    // The minting read. Records into the live-object map + owner map, which is exactly
+    // what `establishedWorkflowReplyIdentity` then finds.
+    workflowStableUuid(active);
+  } catch {
+    // A reply that cannot report identity is the bug being fixed, not a reason to fail a
+    // save that already succeeded.
+  }
+}
+
 function establishedWorkflowReplyIdentity(wf) {
   if (!wf || typeof wf !== "object") return null;
   // THE ESTABLISHMENT TEST, and the only one that matters here (#716): the uuid
@@ -11565,6 +11602,7 @@ const GRAPH_TOOL_EXECUTORS = {
     // DIFFERENT workflow active, which fences the very session that asked for the
     // save; without an identity in this reply the caller has nothing to re-fence
     // to, and every call that could tell it is itself refused.
+    establishActiveIdentityAfterSave(!!outcome.saved_as);
     return { saved: true, workflow, ...outcome, ...saveReplyIdentity(liveWorkflowListActive().activeIdentity, { savedAs: !!outcome.saved_as }) };
   },
 
@@ -11573,6 +11611,7 @@ const GRAPH_TOOL_EXECUTORS = {
     const { name: workflow, ...outcome } = await programmaticSave(name);
     // #747 — this path ALWAYS changes which workflow is active, so it is the one
     // that strands a caller. Report the new instance identity here.
+    establishActiveIdentityAfterSave(true);
     return { saved: true, workflow, ...outcome, ...saveReplyIdentity(liveWorkflowListActive().activeIdentity, { savedAs: true }) };
   },
 

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -11618,7 +11618,15 @@ const GRAPH_TOOL_EXECUTORS = {
     // DIFFERENT workflow active, which fences the very session that asked for the
     // save; without an identity in this reply the caller has nothing to re-fence
     // to, and every call that could tell it is itself refused.
-    return { saved: true, workflow, ...outcome, ...saveReplyIdentity(replyIdentity ?? liveWorkflowListActive().activeIdentity, { savedAs: !!outcome.saved_as }) };
+    // NO active-canvas fallback for a Save-As (codex). If the produced record yielded no
+    // identity, absence must STAY absence: falling back to whatever is active now can pair
+    // this reply’s `workflow: "<copy>"` with a DIFFERENT canvas’s uuid, and an agent
+    // re-fencing on that would authorize graph writes against the wrong workflow — the
+    // exact misbinding this fix exists to prevent. saveReplyIdentity(null) reports
+    // `workflow_identity_unavailable` explicitly, so the caller is told rather than misled.
+    // An in-place save does not change which workflow is active, so its pre-existing #747
+    // fallback strands nobody and stays.
+    return { saved: true, workflow, ...outcome, ...saveReplyIdentity(outcome.saved_as ? replyIdentity : replyIdentity ?? liveWorkflowListActive().activeIdentity, { savedAs: !!outcome.saved_as }) };
   },
 
   async workflow_save_as({ name }) {
@@ -11627,7 +11635,7 @@ const GRAPH_TOOL_EXECUTORS = {
     // #747 — this path ALWAYS changes which workflow is active, so it is the one
     // that strands a caller. Report the new instance identity here.
     const replyIdentity = saveProducedIdentity(producedRecord, true);
-    return { saved: true, workflow, ...outcome, ...saveReplyIdentity(replyIdentity ?? liveWorkflowListActive().activeIdentity, { savedAs: true }) };
+    return { saved: true, workflow, ...outcome, ...saveReplyIdentity(replyIdentity, { savedAs: true }) };
   },
 
   // --- Workflow tabs: new / list / open / switch / rename / close ----------

--- a/web/js/lib/save-reply-identity.js
+++ b/web/js/lib/save-reply-identity.js
@@ -65,3 +65,36 @@ export function saveReplyIdentity(identity, { savedAs = false } = {}) {
       : {}),
   };
 }
+
+/**
+ * Should the panel ESTABLISH an identity for the canvas a save just made active (#941)?
+ *
+ * The #716 rule this sits next to is that a READ must never establish identity — a fence
+ * refreshed from a value a read invented is agreeing with itself rather than observing
+ * anything. `establishedWorkflowReplyIdentity` therefore refuses to mint, and that is
+ * right.
+ *
+ * But a Save-As is not a read. It is a mutation whose entire job is to make a DIFFERENT
+ * workflow active, and the object it activates is brand new — nothing has ever established
+ * an identity for it. So the reply found none and said so honestly, while the fence, whose
+ * own read DOES mint, immediately saw one. Measured on 0.11.80:
+ *
+ *     workflow_save({name}) -> { saved: true, saved_as: true, workflow_identity_unavailable: true }
+ *     graph_outline()       -> "workflow instance mismatch: ... issued for instance b273a69f,
+ *                               and the active canvas reports 14d699d3"
+ *
+ * The panel knew the new identity well enough to refuse the next call with it, and had
+ * refused to report it one call earlier. Every `panel_*` graph tool is then dead for the
+ * session, and the documented recovery is fence-exempt but cannot re-derive what was never
+ * published — which left the reporter choosing between a ComfyUI restart and ~3h of queued
+ * renders (#941).
+ *
+ * Establishing it as part of the save closes that gap at the only moment the panel knows
+ * the new instance and the caller does not. Deliberately NOT widened to every save: an
+ * in-place save keeps the same object, whose identity is already established, so there is
+ * nothing to mint and no reason to touch it. Only the case that strands a caller.
+ */
+export function shouldEstablishIdentityAfterSave({ savedAs = false, alreadyEstablished = false } = {}) {
+  if (alreadyEstablished) return false;
+  return savedAs === true;
+}

--- a/web/js/lib/workflow-save.js
+++ b/web/js/lib/workflow-save.js
@@ -688,6 +688,17 @@ export async function saveActiveWorkflow(
       // user/reconnect switch to a DISTINCT tab during the awaited persist fails that
       // proof ⇒ consume NOTHING and thread NOTHING (fail safe: the cosmetic ghost
       // stays — never the #349 wrong-canvas seeding of a foreign tab).
+      // #941 — thread the adapter's PROVEN produced record for the reply's identity,
+      // whatever the source classification. A Save-As from a PERSISTED workflow takes the
+      // branch below and so never reached `details`, which is why the reply had no identity
+      // to report and the caller's session was stranded.
+      //
+      // A SEPARATE field from `savedRecord` deliberately: that one is the #557 succession
+      // proof and carries the PREDECESSOR's identity onto the successor, which a Save-As
+      // copy must never do — it is a new workflow. This one only says "the save activated
+      // this object", so the reply can report ITS identity rather than re-reading whichever
+      // canvas is active later (codex).
+      if (details && producedRecord.record) details.activatedRecord = producedRecord.record;
       if (cls === "never-persisted") {
         const produced = producedRecord.record ?? null;
         if (produced) {


### PR DESCRIPTION
Draft — claiming #941 (which subsumes #939).

Save-As writes the file correctly but the panel cannot report the new workflow's identity on the reply, so the orchestrator's fence stays bound to the PREVIOUS instance and every later `panel_*` graph call is refused. The documented recovery (`panel_open_workflow`, which is fence-exempt) also fails to re-derive it, leaving a ComfyUI restart as the only escape — which cost the reporter ~3h of queued renders.

Reported against panel 0.11.38/0.11.51; current is 0.11.80. Measuring whether it still reproduces before writing anything.

Refs #941, #939