### PR TITLE
0.11.81 — a Save-As stops stranding the agent that performed it (#941)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,30 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+## [0.11.81] - 2026-08-09
+
+> Covers changes since 0.11.80.
+
+### Fixed
+
+- **A Save-As no longer strands the agent that performed it (#941).** `panel_save_workflow`
+  with a new name writes the copy and switches the active canvas to it — which fences the
+  very session that asked for the save, so every following `panel_*` graph call is refused.
+  That is survivable only if the reply says what to re-fence to, and it did not: it reported
+  the identity as unavailable, while the next call was refused *using* an identity the panel
+  had declined to publish one call earlier.
+
+  The identity read is deliberately pure — a fence refreshed from a value a read invented
+  would be agreeing with itself rather than observing anything — and a Save-As activates a
+  brand-new object nothing had established an identity for. So the read honestly found
+  nothing while the fence, whose own read mints, immediately found one. The identity is now
+  established as part of the save, from the record the save itself produced and proved
+  active, never from a later look at whichever canvas happens to be current. A Save-As that
+  cannot produce one still reports absence rather than substituting a different canvas.
+
+- Name the canvas swap point, from the canvas-rebuild side (#944).
+
+
 ## [0.11.80] - 2026-08-09
 
 > Covers changes since 0.11.79.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-agent-panel"
 description = "Autonomous AI agent in the ComfyUI sidebar - local-first, bring any LLM. Run it on your Claude or ChatGPT subscription (no API keys, no extra LLM costs), on a Kimi K3 / GLM / OpenRouter key, or fully offline on free local models via Ollama, LM Studio, or llama.cpp. The agent drives your live canvas at full parity: add, wire, move and tweak nodes with Ctrl+Z undo, load whole workflows and installer packs in one shot, generate images, video and audio, browse CivitAI, and run your workflow - asking before it spends paid API credits. The sidebar UI for comfyui-mcp, the local-first, agent-native control plane for ComfyUI."
-version = "0.11.80"
+version = "0.11.81"
 license = { file = "LICENSE" }
 requires-python = ">=3.9"
 # UI-only pack: no Python deps. The frontend floor guarantees

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -884,7 +884,7 @@ const DOCS_URL = "https://comfyui-mcp.artokun.io/docs";
 // Panel version — surfaced in the "Need help?" diagnostics blob. Bump via
 // `node scripts/set-version.mjs <v>` (updates this AND pyproject together); CI
 // and the publish gate FAIL if the two ever drift, so this can't go stale.
-const PANEL_VERSION = "0.11.80";
+const PANEL_VERSION = "0.11.81";
 
 // The connected orchestrator's console URL/token (captured off the `backends`
 // bridge message — see onBackends). Drives the "API Keys" credentials frame;


### PR DESCRIPTION
Releases the #941 fix.

A Save-As switches the active canvas to the copy, fencing the session that asked for it, and the reply carried no identity to re-fence to — while the next call was refused using an identity the panel had declined to publish one call earlier. The identity now comes from the record the save itself produced and proved active.

Closes #941