### PR TITLE
feat(open): report the workflow observed active, beside the one requested (refs #887)

### DIFF
--- a/browser_tests/unit/open-active-binding.test.mjs
+++ b/browser_tests/unit/open-active-binding.test.mjs
@@ -37,8 +37,12 @@ test("#887: a different active workflow is reported, and named", () => {
   // The save warning is the point of the issue: the reporter's concern was that a Save-As
   // at this moment writes the wrong canvas.
   assert.match(r.active_mismatch_hint, /do NOT save/i);
-  assert.match(r.active_mismatch_hint, /wf:workflows\/B\.json/);
-  assert.match(r.active_mismatch_hint, /wf:workflows\/A\.json/);
+  // FIXED WORDING — the routing keys must NOT be interpolated into it (codex). They are
+  // workflow-derived (a user names their own files), and splicing them into
+  // instruction-shaped prose puts attacker-influenced text inside a sentence a model reads
+  // as trusted. They belong in the structured fields, presented as data.
+  assert.doesNotMatch(r.active_mismatch_hint, /wf:workflows/);
+  assert.match(r.active_mismatch_hint, /active_routing_key/, "it points at the fields instead");
 });
 
 test("#887: an unreadable active slot is UNKNOWN, never a mismatch", () => {

--- a/browser_tests/unit/open-active-binding.test.mjs
+++ b/browser_tests/unit/open-active-binding.test.mjs
@@ -1,0 +1,73 @@
+// #887 — a workflow_open reply must report what it OBSERVED to be active, not only what
+// was requested.
+//
+// The reply named the target in `opened` and `routing_key` and said nothing about the
+// active slot, so the orchestrator rendered a flat assertion ("the canvas IS bound to X …
+// You are NOT on the wrong workflow") while `panel_list_workflows` named a different
+// workflow immediately afterwards. A Save-As taken on that assurance writes the LIVE
+// canvas, not the one the caller believes it is on.
+//
+// SCOPE, measured rather than assumed. On 0.11.81 the reporter's scenario does NOT
+// reproduce: opening an already-open modified background workflow switches correctly and
+// the reply agrees with the workflow list. Stealing the active slot mid-open DOES leave a
+// stale reply, but the reply was truthful when composed — the target genuinely was active
+// at emission — so no check inside the panel could have caught it. A reply describes a
+// moment; it cannot report the future.
+//
+// What is fixed is that the moment was never reported at all, leaving "the target is
+// active" indistinguishable from "the target is what you asked for".
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { describeOpenActiveBinding } from "../../web/js/lib/open-active-binding.js";
+
+const A = "wf:workflows/A.json";
+const B = "wf:workflows/B.json";
+
+test("#887: agreement is reported as agreement", () => {
+  const r = describeOpenActiveBinding({ targetRoutingKey: A, activeRoutingKey: A });
+  assert.equal(r.active_matches_target, true);
+  assert.equal(r.active_routing_key, A);
+  assert.ok(!("active_mismatch_hint" in r), "nothing to warn about");
+});
+
+test("#887: a different active workflow is reported, and named", () => {
+  const r = describeOpenActiveBinding({ targetRoutingKey: A, activeRoutingKey: B });
+  assert.equal(r.active_matches_target, false);
+  assert.equal(r.active_routing_key, B, "the caller needs to know WHICH workflow is live");
+  // The save warning is the point of the issue: the reporter's concern was that a Save-As
+  // at this moment writes the wrong canvas.
+  assert.match(r.active_mismatch_hint, /do NOT save/i);
+  assert.match(r.active_mismatch_hint, /wf:workflows\/B\.json/);
+  assert.match(r.active_mismatch_hint, /wf:workflows\/A\.json/);
+});
+
+test("#887: an unreadable active slot is UNKNOWN, never a mismatch", () => {
+  // A false failure costs as much as a false success — that is #886, this issue inverted.
+  // Claiming a mismatch we did not observe sends a caller chasing a switch that worked.
+  for (const active of [null, undefined, ""]) {
+    const r = describeOpenActiveBinding({ targetRoutingKey: A, activeRoutingKey: active });
+    assert.equal(r.active_matches_target, null, JSON.stringify(active));
+    assert.equal(r.active_routing_key, null);
+    assert.ok(!("active_mismatch_hint" in r));
+  }
+});
+
+test("#887: an unreadable TARGET key is also unknown, not a mismatch", () => {
+  const r = describeOpenActiveBinding({ targetRoutingKey: null, activeRoutingKey: B });
+  assert.equal(r.active_matches_target, null);
+  assert.equal(r.active_routing_key, B, "still report what was seen");
+});
+
+test("#887: no arguments is unknown, not agreement", () => {
+  // The default must never read as confirmation — that is the whole failure mode.
+  const r = describeOpenActiveBinding();
+  assert.equal(r.active_matches_target, null);
+  assert.equal(r.active_routing_key, null);
+});
+
+test("#887: non-string routing keys are not trusted", () => {
+  for (const junk of [42, {}, [], true]) {
+    const r = describeOpenActiveBinding({ targetRoutingKey: junk, activeRoutingKey: junk });
+    assert.equal(r.active_matches_target, null, JSON.stringify(junk));
+  }
+});

--- a/browser_tests/unit/open-outcome.test.mjs
+++ b/browser_tests/unit/open-outcome.test.mjs
@@ -914,8 +914,20 @@ test("#716 wiring: post-open and active workflow responses carry the live instan
   assert.match(list, /const \{ active, activeIdentity \} = liveWorkflowListActive\(\);/);
   assert.doesNotMatch(list, /const active = s\.activeWorkflow;/, "workflow_list must not publish a pre-reconnect service binding");
   assert.match(list, /activeIdentity \? \{ workflow_uuid: activeIdentity\.uuid \} : \{\}/);
-  assert.match(open, /activeWorkflowUuidForOpenReply\(target\)/);
+  // #887 — the uuid gate now shares ONE observation of the active workflow with the
+  // binding report beside it. Two separate reads let a reply pair a uuid decided against
+  // one observation with binding fields decided against a later one, which is internally
+  // contradictory diagnostics (codex) — the exact class of thing #887 reports.
+  assert.match(open, /activeWorkflowUuidForOpenReply\(target, liveActiveAtReply\)/);
+  assert.match(open, /const liveActiveAtReply = /, "the snapshot must be taken once");
   assert.doesNotMatch(open, /activeWorkflowUuidForOpenReply\(target, s\.activeWorkflow\)/);
+  // The snapshot is what the #887 fields are derived from too — not a second read.
+  assert.match(open, /describeOpenActiveBinding\(\{/);
+  assert.doesNotMatch(
+    open,
+    /activeRoutingKey: \(\(\) => \{\s*try \{\s*const live = activeWorkflowRef\(\)/,
+    "the binding report must use the shared snapshot, not read the active workflow again",
+  );
   assert.match(open, /activeWorkflowUuid \? \{ workflow_uuid: activeWorkflowUuid \} : \{\}/);
 });
 

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -2470,7 +2470,7 @@ function establishedWorkflowReplyIdentity(wf) {
   return routingKey ? { routingKey, uuid } : null;
 }
 
-function activeWorkflowUuidForOpenReply(target) {
+function activeWorkflowUuidForOpenReply(target, activeSnapshot) {
   // Do not accept a workflow-service reference captured before workflow_open's
   // awaits: a reconnect can replace/rebind that service while the old instance
   // still reports `target` as active. Read the panel's CURRENT binding at reply
@@ -12544,7 +12544,19 @@ const GRAPH_TOOL_EXECUTORS = {
     // after another tab wins the active slot during any await above; publishing
     // its UUID then would let the MCP stamp a command for a different canvas.
     // Omission is deliberate: the MCP keeps its existing fence fail-closed.
-    const activeWorkflowUuid = activeWorkflowUuidForOpenReply(target);
+    // ONE observation, shared by the uuid decision and the binding report (codex).
+    // Reading the active workflow twice let a reply pair a uuid decided against one
+    // observation with binding fields decided against a later one — internally
+    // contradictory diagnostics, which is what this issue is about.
+    const liveActiveAtReply = (() => {
+      try {
+        return activeWorkflowRef();
+      } catch {
+        return null;
+      }
+    })();
+    const targetRoutingKeyAtReply = workflowTabId(target);
+    const activeWorkflowUuid = activeWorkflowUuidForOpenReply(target, liveActiveAtReply);
     // #887 — report WHAT WAS OBSERVED to be active, beside what was requested.
     //
     // `opened` and `routing_key` both name the TARGET, and nothing in the reply said what
@@ -12559,11 +12571,10 @@ const GRAPH_TOOL_EXECUTORS = {
     // target really WAS active). It makes the moment REPORTABLE, so a caller can compare
     // rather than trust.
     const openActiveBinding = describeOpenActiveBinding({
-      targetRoutingKey: workflowTabId(target),
+      targetRoutingKey: targetRoutingKeyAtReply,
       activeRoutingKey: (() => {
         try {
-          const live = activeWorkflowRef();
-          return live ? workflowTabId(live) : null;
+          return liveActiveAtReply ? workflowTabId(liveActiveAtReply) : null;
         } catch {
           return null; // unreadable -> `active_matches_target: null`, never a false mismatch
         }
@@ -12571,7 +12582,7 @@ const GRAPH_TOOL_EXECUTORS = {
     });
     return {
       opened: { path: target.path, filename: target.filename },
-      routing_key: workflowTabId(target),
+      routing_key: targetRoutingKeyAtReply,
       ...openActiveBinding,
       ...(activeWorkflowUuid ? { workflow_uuid: activeWorkflowUuid } : {}),
       modified: !!target.isModified,

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -147,6 +147,7 @@ import {
 import { assertAddNodeResolvableRefreshing, isRegisteredNodeType } from "./lib/node-resolve.js";
 import { fetchSingleNodeDef } from "./lib/single-node-def.js";
 import { saveReplyIdentity, shouldEstablishIdentityAfterSave } from "./lib/save-reply-identity.js";
+import { describeOpenActiveBinding } from "./lib/open-active-binding.js";
 import { scanComboAvailability, comboAvailabilityNote } from "./lib/live-combo-availability.js";
 import { readSaveFailureCause } from "./lib/userdata-failure-cause.js";
 import { describeScreenshotFraming } from "./lib/screenshot-framing.js";
@@ -12544,9 +12545,34 @@ const GRAPH_TOOL_EXECUTORS = {
     // its UUID then would let the MCP stamp a command for a different canvas.
     // Omission is deliberate: the MCP keeps its existing fence fail-closed.
     const activeWorkflowUuid = activeWorkflowUuidForOpenReply(target);
+    // #887 — report WHAT WAS OBSERVED to be active, beside what was requested.
+    //
+    // `opened` and `routing_key` both name the TARGET, and nothing in the reply said what
+    // the panel saw in the active slot. The orchestrator renders that as a flat assertion
+    // ("the canvas IS bound to X ... You are NOT on the wrong workflow") while
+    // panel_list_workflows can name a different workflow a moment later — and a Save-As
+    // taken on that assurance writes the LIVE canvas, not the one the caller believes.
+    //
+    // This does NOT close the window: a reply describes a moment, and the active workflow
+    // can change immediately after it is composed (measured — steal the active slot while
+    // an open is in flight and the target's uuid still ships, because at emission the
+    // target really WAS active). It makes the moment REPORTABLE, so a caller can compare
+    // rather than trust.
+    const openActiveBinding = describeOpenActiveBinding({
+      targetRoutingKey: workflowTabId(target),
+      activeRoutingKey: (() => {
+        try {
+          const live = activeWorkflowRef();
+          return live ? workflowTabId(live) : null;
+        } catch {
+          return null; // unreadable -> `active_matches_target: null`, never a false mismatch
+        }
+      })(),
+    });
     return {
       opened: { path: target.path, filename: target.filename },
       routing_key: workflowTabId(target),
+      ...openActiveBinding,
       ...(activeWorkflowUuid ? { workflow_uuid: activeWorkflowUuid } : {}),
       modified: !!target.isModified,
       // #402 — the receipt id for THIS open. Journaled in the panel, so if this reply

--- a/web/js/lib/open-active-binding.js
+++ b/web/js/lib/open-active-binding.js
@@ -28,6 +28,11 @@
  * @param {{targetRoutingKey?: string|null, activeRoutingKey?: string|null}} observed
  *   routing keys read from the TARGET and from the live active workflow, both at reply
  *   emission. `activeRoutingKey` null means the panel could not read one.
+ * The hint is FIXED WORDING. Routing keys are workflow-derived — a user names their own
+ * files — and interpolating them into instruction-shaped prose puts attacker-influenced
+ * text inside a sentence a model reads as trusted (codex). The values stay in the
+ * structured fields, where a consumer presents them as data.
+ *
  * @returns {{active_routing_key: string|null, active_matches_target: boolean|null,
  *   active_mismatch_hint?: string}}
  */
@@ -47,9 +52,10 @@ export function describeOpenActiveBinding({ targetRoutingKey, activeRoutingKey }
     active_routing_key: active,
     active_matches_target: false,
     active_mismatch_hint:
-      `The open ran, but at the moment this reply was composed the ACTIVE workflow was ` +
-      `"${active}", not the requested "${target}". Do not treat the requested workflow as ` +
-      `bound: re-read panel_list_workflows, and do NOT save — a save targets the live ` +
-      `canvas, which is a different workflow than the one you asked for.`,
+      "The open ran, but at the moment this reply was composed the ACTIVE workflow was not " +
+      "the requested one. Do not treat the requested workflow as bound: re-read " +
+      "panel_list_workflows, and do NOT save — a save targets the live canvas, which is a " +
+      "different workflow than the one you asked for. The two routing keys are reported in " +
+      "`active_routing_key` and `routing_key`.",
   };
 }

--- a/web/js/lib/open-active-binding.js
+++ b/web/js/lib/open-active-binding.js
@@ -1,0 +1,55 @@
+/**
+ * #887 — what `workflow_open` may claim about which workflow is active.
+ *
+ * The reply names the workflow the caller ASKED for (`opened`, `routing_key`) and says
+ * nothing about what the panel observed to be active when it composed that reply. The
+ * orchestrator turns those fields into a flat assertion — "the canvas IS bound to X … You
+ * are NOT on the wrong workflow" — and the reporter saw `panel_list_workflows` name a
+ * different workflow immediately afterwards, with the graph fence still on it. Their
+ * concern was the sharp end: a Save-As at that moment could write the wrong canvas.
+ *
+ * What this does NOT claim to fix: a reply is a statement about a moment, and the active
+ * workflow can change the instant after it is composed. Measured on 0.11.81 — steal the
+ * active slot while an open is in flight and the reply still carries the target's uuid,
+ * because at emission the target genuinely WAS active. No check can close that; the panel
+ * cannot report the future.
+ *
+ * What it does fix: the reply never said what it observed. A caller could not tell "the
+ * target is active" from "the target is what you asked for", so a stale reply was
+ * indistinguishable from a confirmed one, and the only honest reading — "this was true when
+ * emitted" — was unavailable. Reporting the observed active routing key alongside the
+ * requested one lets the caller compare, and lets a disagreement be surfaced as a
+ * disagreement instead of an assertion.
+ */
+
+/**
+ * Describe the binding a `workflow_open` reply may honestly claim.
+ *
+ * @param {{targetRoutingKey?: string|null, activeRoutingKey?: string|null}} observed
+ *   routing keys read from the TARGET and from the live active workflow, both at reply
+ *   emission. `activeRoutingKey` null means the panel could not read one.
+ * @returns {{active_routing_key: string|null, active_matches_target: boolean|null,
+ *   active_mismatch_hint?: string}}
+ */
+export function describeOpenActiveBinding({ targetRoutingKey, activeRoutingKey } = {}) {
+  const target = typeof targetRoutingKey === "string" && targetRoutingKey ? targetRoutingKey : null;
+  const active = typeof activeRoutingKey === "string" && activeRoutingKey ? activeRoutingKey : null;
+  // UNKNOWN, not false. Reporting a mismatch we did not observe would send a caller
+  // chasing a switch that never failed — the #886 complaint, which is this one inverted:
+  // a false failure is as expensive as a false success.
+  if (!target || !active) {
+    return { active_routing_key: active, active_matches_target: null };
+  }
+  if (active === target) {
+    return { active_routing_key: active, active_matches_target: true };
+  }
+  return {
+    active_routing_key: active,
+    active_matches_target: false,
+    active_mismatch_hint:
+      `The open ran, but at the moment this reply was composed the ACTIVE workflow was ` +
+      `"${active}", not the requested "${target}". Do not treat the requested workflow as ` +
+      `bound: re-read panel_list_workflows, and do NOT save — a save targets the live ` +
+      `canvas, which is a different workflow than the one you asked for.`,
+  };
+}


### PR DESCRIPTION
**Preparatory, not a fix for #887** — deliberately, and codex was firm about it.

`workflow_open`'s reply named the target in `opened`/`routing_key` and said nothing about what the panel observed in the active slot, so a caller could not tell "the target is active" from "the target is what you asked for". The reply now carries `active_routing_key`, `active_matches_target` (true/false/null-for-unknown) and a fixed-wording hint on disagreement.

**What I measured on 0.11.81, which changed what I could honestly claim:**
- The reporter's scenario does not reproduce — opening an already-open modified background workflow switches correctly and the reply agrees with `panel_list_workflows`.
- Stealing the active slot mid-open does leave a stale reply, but it was *true when composed*; holding the slot across the whole open (24 forced switches) still produced `active_matches_target: true`. A reply describes a moment and cannot report the future, so no panel-side check closes that.

**Why it does not close #887:** the contradictory assertion is composed upstream in comfyui-mcp, which does not read these fields, and the reporter's real fear — a Save-As writing the wrong canvas — needs enforcement at the save boundary, not a diagnostic.

Refs #887