### PR TITLE
0.11.82 — workflow_open reports the workflow it observed active (refs #887)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+## [0.11.82] - 2026-08-09
+
+> Covers changes since 0.11.81.
+
+### Added
+
+- **`panel_open_workflow` now reports which workflow it observed to be active, beside the
+  one that was requested (refs #887).** The reply named only the target, so a caller could
+  not tell "the requested workflow is active" from "the requested workflow is what you
+  asked for" — and a Save-As taken on that reading writes the live canvas, which may be a
+  different workflow. The reply carries `active_routing_key` and `active_matches_target`
+  (true, false, or null when it could not be read), with a warning when they disagree.
+
+  This is groundwork, not the fix: the contradictory "you are NOT on the wrong workflow"
+  message is composed by the orchestrator, which does not read these fields yet, so nothing
+  user-visible changes until it does. #887 stays open.
+
 ## [0.11.81] - 2026-08-09
 
 > Covers changes since 0.11.80.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-agent-panel"
 description = "Autonomous AI agent in the ComfyUI sidebar - local-first, bring any LLM. Run it on your Claude or ChatGPT subscription (no API keys, no extra LLM costs), on a Kimi K3 / GLM / OpenRouter key, or fully offline on free local models via Ollama, LM Studio, or llama.cpp. The agent drives your live canvas at full parity: add, wire, move and tweak nodes with Ctrl+Z undo, load whole workflows and installer packs in one shot, generate images, video and audio, browse CivitAI, and run your workflow - asking before it spends paid API credits. The sidebar UI for comfyui-mcp, the local-first, agent-native control plane for ComfyUI."
-version = "0.11.81"
+version = "0.11.82"
 license = { file = "LICENSE" }
 requires-python = ">=3.9"
 # UI-only pack: no Python deps. The frontend floor guarantees

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -885,7 +885,7 @@ const DOCS_URL = "https://comfyui-mcp.artokun.io/docs";
 // Panel version — surfaced in the "Need help?" diagnostics blob. Bump via
 // `node scripts/set-version.mjs <v>` (updates this AND pyproject together); CI
 // and the publish gate FAIL if the two ever drift, so this can't go stale.
-const PANEL_VERSION = "0.11.81";
+const PANEL_VERSION = "0.11.82";
 
 // The connected orchestrator's console URL/token (captured off the `backends`
 // bridge message — see onBackends). Drives the "API Keys" credentials frame;


### PR DESCRIPTION
Releases the #887 panel-half groundwork.

The open reply now says what it observed in the active slot, not only what was requested. #887 stays open — the contradictory assertion is composed upstream and the real Save-As protection belongs at the save boundary.

Refs #887