### PR TITLE
fix(install): tell the truth when a git URL is not installable, and correct the 0.11.75 note (#920)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,16 +12,24 @@ All notable changes to this project are documented here. This project adheres to
 
 ### Fixed
 
-- **Installing a custom node from a GitHub URL actually clones it now (#920).** Passing a
-  repository URL queued a search of the node registry instead, and failed with
-  *"Node 'ComfyUI-SolAttn_triton@nightly' not found"* — because the panel reduced your URL
-  to just the repo's name and threw the rest away, leaving ComfyUI-Manager nothing to
-  clone from.
+- **The install request now carries your repository URL (#920).** The panel used to reduce
+  a GitHub URL to just the repo's name and throw the rest away; it now sends the URL in the
+  `repository` field ComfyUI-Manager's API declares for it.
 
-  The URL is now passed through. Manager's own install parameters require it for a
-  nightly install, which is the case this was reported against.
+  **This does not yet make such an install succeed, and this entry originally said it did —
+  that was wrong.** ComfyUI-Manager v4 accepts the field and then ignores it: its install
+  handler reads only `id`, `selected_version`, `channel`, `mode` and `skip_post_install`,
+  and resolves the clone URL from its own database instead. A pack that is not in the
+  registry still cannot be installed by URL on a stock v4, and you will still see
+  *"Node '<name>@<version>' not found in [...]"*.
 
-  The workaround of putting the URL in `id` instead still works and is unchanged.
+  The change is kept because it is what the documented API asks for and it will start
+  working if Manager implements the field — but it is forward-compatibility, not a fix.
+
+  What works today for an unlisted pack: run ComfyUI with `--enable-manager-legacy-ui`
+  (which registers the legacy route that installs from a URL), `git clone` into
+  `custom_nodes/` and restart, or ask the pack author to publish to the registry.
+  Tracking in #920.
 
 ## [0.11.74] - 2026-08-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,8 @@ All notable changes to this project are documented here. This project adheres to
   `repository` field ComfyUI-Manager's API declares for it.
 
   **This does not yet make such an install succeed, and this entry originally said it did —
-  that was wrong.** ComfyUI-Manager v4 accepts the field and then ignores it: its install
-  handler reads only `id`, `selected_version`, `channel`, `mode` and `skip_post_install`,
+  that was wrong.** ComfyUI-Manager v4's v2 install handler accepts the field and then ignores it: it
+  reads only `id`, `selected_version`, `channel`, `mode` and `skip_post_install`,
   and resolves the clone URL from its own database instead. A pack that is not in the
   registry still cannot be installed by URL on a stock v4, and you will still see
   *"Node '<name>@<version>' not found in [...]"*.
@@ -26,10 +26,12 @@ All notable changes to this project are documented here. This project adheres to
   The change is kept because it is what the documented API asks for and it will start
   working if Manager implements the field — but it is forward-compatibility, not a fix.
 
-  What works today for an unlisted pack: run ComfyUI with `--enable-manager-legacy-ui`
-  (which registers the legacy route that installs from a URL), `git clone` into
-  `custom_nodes/` and restart, or ask the pack author to publish to the registry.
-  Tracking in #920.
+  What works today for an unlisted pack, least effort first: `git clone` into
+  `custom_nodes/` and restart, or ask the pack author to publish to the registry. There is
+  a legacy git-URL route, but reaching it takes two steps — `--enable-manager-legacy-ui`
+  (which *replaces* the v2 Manager API rather than adding to it) **and**
+  `allow_git_url_install = true` in ComfyUI-Manager's `config.ini`; an unlisted pack is
+  rated "high+" risk and without that setting the route answers 404. Tracking in #920.
 
 ## [0.11.74] - 2026-08-09
 

--- a/browser_tests/unit/install-unlisted-url-advice.test.mjs
+++ b/browser_tests/unit/install-unlisted-url-advice.test.mjs
@@ -41,7 +41,11 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 
-import { isRegistryLookupMiss, unlistedGitUrlAdvice } from "../../web/js/lib/manager-install.js";
+import {
+  collectRecentTaskFailures,
+  isRegistryLookupMiss,
+  unlistedGitUrlAdvice,
+} from "../../web/js/lib/manager-install.js";
 
 const MISS =
   "Node 'ComfyUI-SolAttn_triton@nightly' not found in [ManagerChannel.dev, ManagerDatabaseSource.cache]";
@@ -68,6 +72,13 @@ test("#920 an unrelated failure is left completely alone", () => {
     "pip install failed: No matching distribution found for torch==9.9",
     "git clone failed: repository not found",
     "the Manager reported the task as failed (no detail provided)",
+    // The reason the pattern requires Manager's literal `Node '<id>@<ver>'` prefix
+    // rather than just "not found in [...]": a custom node's own post-install code
+    // can raise this shape, and it lands in status.messages the same way. Without
+    // the prefix, a pack whose installer throws a plain ValueError would be told
+    // its GIT URL is the problem.
+    "ValueError: 'chroma' not found in ['red', 'green', 'blue']",
+    "KeyError: 'sampler' not found in [euler, dpmpp_2m]",
     "",
     null,
     undefined,
@@ -87,9 +98,23 @@ test("#920 the advice names the real blocker and the routes that work", () => {
 
   assert.match(a, /NODE REGISTRY lookup/, "names what the lookup actually was");
   assert.match(a, /accepted and then IGNORED/, "says the repository field does nothing");
-  assert.match(a, /--enable-manager-legacy-ui/, "the route that does install from a URL");
   assert.match(a, /custom_nodes\//, "the manual clone");
   assert.match(a, /publish it to the registry/, "the durable fix");
+});
+
+test("#920 the legacy-route advice names BOTH steps, or it sends people to a 404", () => {
+  // The first cut said "start ComfyUI with --enable-manager-legacy-ui" and stopped.
+  // That is not sufficient for the only case this advice is shown for: an UNLISTED
+  // pack is rated "high+" by get_risky_level, and the legacy route then requires
+  // config allow_git_url_install (default FALSE) or it answers
+  // 404 "A security error has occurred". Following the advice as written would have
+  // been the THIRD wrong instruction on this issue.
+  const a = unlistedGitUrlAdvice(MISS);
+  assert.match(a, /--enable-manager-legacy-ui/, "step one");
+  assert.match(a, /allow_git_url_install\s*=\s*true/, "step two — without it the route 404s");
+  assert.match(a, /security error/i, "and says what failure to expect if it is skipped");
+  // It also REPLACES the v2 API rather than adding to it, which the wording must not hide.
+  assert.match(a, /REPLACES/, "the mutex, not additive");
 });
 
 test("#920 the advice does NOT assert which mistake the caller made", () => {
@@ -112,14 +137,42 @@ test("#920 the advice never promises the install can be made to work from here",
 // 3. WIRING — the advice is worth nothing if the surface never appends it.
 // ---------------------------------------------------------------------------
 
-test("#920 WIRING: the queue-status failure note appends the advice", () => {
-  // This is the surface the reporter actually polled ("Poll
-  // panel_node_queue_status. Observe the task failure below"), so it is the one
-  // that has to carry the explanation.
+test("#920 WIRING: a real Manager history reaches the advice END TO END", () => {
+  // THE ASSERTION THE FIRST CUT OF THIS FILE WAS MISSING. It matched
+  // /unlistedGitUrlAdvice\(recentFailures\.map\(/ and stopped BEFORE the field
+  // name — so it passed against `f?.reason` (always undefined, advice always ""),
+  // against `f?.result` (correct), and against a garbage field. The suite was
+  // green with the defect in place. That is the third inert fix on this issue and
+  // the second caused by a wiring assertion that could not fail.
+  //
+  // This drives the real chain instead: Manager history -> collectRecentTaskFailures
+  // -> the exact join the handler performs -> the advice.
+  const history = {
+    history: [
+      {
+        ui_id: "ui-1",
+        kind: "install",
+        params: { id: "ComfyUI-SolAttn_triton" },
+        status: { status_str: "error", messages: [MISS] },
+      },
+    ],
+  };
+  const failures = collectRecentTaskFailures(history);
+  assert.equal(failures.length, 1, "the failure must be collected at all");
+
+  // The handler's own expression. If the field name drifts, this dies.
+  const joined = failures.map((f) => f?.result ?? "").join(" ");
+  assert.ok(joined.includes("not found in"), `the joined text lost the reason: ${JSON.stringify(joined)}`);
+  assert.notEqual(unlistedGitUrlAdvice(joined), "", "the advice must actually be produced");
+});
+
+test("#920 WIRING: the handler joins on the field collectRecentTaskFailures emits", () => {
+  // Pins the field name specifically, since that is what broke. `reason` is the
+  // plausible-sounding wrong one — it is what I wrote.
   const panel = readFileSync(fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url)), "utf8");
   assert.ok(
-    /unlistedGitUrlAdvice\(recentFailures\.map\(/.test(panel),
-    "the queue-status note must append unlistedGitUrlAdvice over the recent failures",
+    /unlistedGitUrlAdvice\(recentFailures\.map\(\(f\) => f\?\.result \?\? ""\)\.join\(" "\)\)/.test(panel),
+    "the queue-status note must join on `result` — `reason` is always undefined here",
   );
   assert.ok(/^\s*unlistedGitUrlAdvice,\s*$/m.test(panel), "and it must be imported");
 });

--- a/browser_tests/unit/install-unlisted-url-advice.test.mjs
+++ b/browser_tests/unit/install-unlisted-url-advice.test.mjs
@@ -1,0 +1,125 @@
+// panel#920 — the SECOND attempt at this issue, after the first one shipped and
+// did nothing.
+//
+// The reporter passed a GitHub URL and got:
+//
+//   Node 'ComfyUI-SolAttn_triton@nightly' not found in
+//   [ManagerChannel.dev, ManagerDatabaseSource.cache]
+//
+// which names a pack id they never supplied and reads like a registry lookup bug.
+// Two rounds of work then went into reshaping the install payload — first by the
+// other session (shipped as 0.11.75), then by me (PR #927) — both sending
+// `repository`, both justified by ComfyUI-Manager's own generated schema:
+//
+//   InstallPackParams.repository: "GitHub repository URL (required if
+//                                  selected_version is nightly)"
+//
+// BOTH WERE INERT. Read from Manager's SOURCE rather than its schema:
+//
+//   async def do_install(params: InstallPackParams):
+//       node_id = params.id; node_version = params.selected_version
+//       channel = params.channel; mode = params.mode
+//       skip_post_install = params.skip_post_install
+//
+//   params.repository read 0 times — tags 4.2.2, 4.1, branch draft-v4
+//
+// `install_by_id(node_name, version_spec, channel, mode, …)` takes no repository
+// argument, and the nightly path resolves the clone URL from Manager's own
+// database. A generated OpenAPI model is the contract of what a server ACCEPTS,
+// never of what it DOES — and with Pydantic's default extra='ignore', a
+// declared-but-unread field is invisible from the client.
+//
+// So there is nothing to send. On a stock v4 an unlisted git URL is simply not
+// installable: the legacy /manager/queue/install route does support it
+// (@unknown + files:[url]), but comfyui_manager/__init__.py registers the legacy
+// server only under --enable-manager-legacy-ui.
+//
+// The remaining panel-side fix is therefore an HONEST ERROR, which is what this
+// pins. It cannot make the install work; it stops the failure from misdirecting.
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import { isRegistryLookupMiss, unlistedGitUrlAdvice } from "../../web/js/lib/manager-install.js";
+
+const MISS =
+  "Node 'ComfyUI-SolAttn_triton@nightly' not found in [ManagerChannel.dev, ManagerDatabaseSource.cache]";
+
+// ---------------------------------------------------------------------------
+// 1. Recognising the miss — narrow on purpose.
+// ---------------------------------------------------------------------------
+
+test("#920 the reporter's exact failure is recognised", () => {
+  assert.equal(isRegistryLookupMiss(MISS), true);
+});
+
+test("#920 recognition does not depend on the enum spellings", () => {
+  // channel/mode vary per request, so matching them would make this fire for one
+  // configuration and silently stop for another.
+  assert.equal(
+    isRegistryLookupMiss("Node 'x@1.0' not found in [ManagerChannel.default, ManagerDatabaseSource.remote]"),
+    true,
+  );
+});
+
+test("#920 an unrelated failure is left completely alone", () => {
+  for (const other of [
+    "pip install failed: No matching distribution found for torch==9.9",
+    "git clone failed: repository not found",
+    "the Manager reported the task as failed (no detail provided)",
+    "",
+    null,
+    undefined,
+    42,
+  ]) {
+    assert.equal(isRegistryLookupMiss(other), false, String(other));
+    assert.equal(unlistedGitUrlAdvice(other), "", `advice must stay empty for: ${String(other)}`);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// 2. What the advice says — and, as importantly, what it does not claim.
+// ---------------------------------------------------------------------------
+
+test("#920 the advice names the real blocker and the routes that work", () => {
+  const a = unlistedGitUrlAdvice(MISS);
+
+  assert.match(a, /NODE REGISTRY lookup/, "names what the lookup actually was");
+  assert.match(a, /accepted and then IGNORED/, "says the repository field does nothing");
+  assert.match(a, /--enable-manager-legacy-ui/, "the route that does install from a URL");
+  assert.match(a, /custom_nodes\//, "the manual clone");
+  assert.match(a, /publish it to the registry/, "the durable fix");
+});
+
+test("#920 the advice does NOT assert which mistake the caller made", () => {
+  // The surface that shows this failure (panel_node_queue_status) does not carry
+  // the original request, so claiming "you passed a URL" would be asserting an
+  // unobserved fact — the exact defect that produced two wrong fixes here.
+  const a = unlistedGitUrlAdvice(MISS);
+  assert.match(a, /IF YOU PASSED A GIT URL/, "conditional, not an assertion");
+  assert.match(a, /IF YOU MEANT A REGISTRY PACK/, "the other reader is served too");
+});
+
+test("#920 the advice never promises the install can be made to work from here", () => {
+  const a = unlistedGitUrlAdvice(MISS);
+  assert.match(a, /no argument to this tool will make it clone your URL/i);
+  // The claim that shipped in 0.11.75 and was false.
+  assert.doesNotMatch(a, /now clones|actually clones|is now installed/i);
+});
+
+// ---------------------------------------------------------------------------
+// 3. WIRING — the advice is worth nothing if the surface never appends it.
+// ---------------------------------------------------------------------------
+
+test("#920 WIRING: the queue-status failure note appends the advice", () => {
+  // This is the surface the reporter actually polled ("Poll
+  // panel_node_queue_status. Observe the task failure below"), so it is the one
+  // that has to carry the explanation.
+  const panel = readFileSync(fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url)), "utf8");
+  assert.ok(
+    /unlistedGitUrlAdvice\(recentFailures\.map\(/.test(panel),
+    "the queue-status note must append unlistedGitUrlAdvice over the recent failures",
+  );
+  assert.ok(/^\s*unlistedGitUrlAdvice,\s*$/m.test(panel), "and it must be imported");
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -14850,7 +14850,7 @@ const GRAPH_TOOL_EXECUTORS = {
           // #920 — a registry-lookup miss reads like a lookup bug and sends people to
           // re-check spelling and channels. On a stock v4 an unlisted git URL is simply
           // not installable, and saying so beats echoing a name the caller never supplied.
-          unlistedGitUrlAdvice(recentFailures.map((f) => f?.reason ?? "").join(" ")),
+          unlistedGitUrlAdvice(recentFailures.map((f) => f?.result ?? "").join(" ")),
       };
     }
     return { status };

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -91,6 +91,7 @@ import {
   rebootCandidates,
   searchNodesVia,
   taskFailureReason,
+  unlistedGitUrlAdvice,
   taskSucceeded,
 } from "./lib/manager-install.js";
 import {
@@ -14845,7 +14846,11 @@ const GRAPH_TOOL_EXECUTORS = {
         note:
           `${recentFailures.length} recent ComfyUI-Manager task(s) FAILED (see recent_failures). ` +
           `A drained queue that shows "done" does NOT mean every task succeeded — check these ` +
-          `before reporting an install/update as successful.`,
+          `before reporting an install/update as successful.` +
+          // #920 — a registry-lookup miss reads like a lookup bug and sends people to
+          // re-check spelling and channels. On a stock v4 an unlisted git URL is simply
+          // not installable, and saying so beats echoing a name the caller never supplied.
+          unlistedGitUrlAdvice(recentFailures.map((f) => f?.reason ?? "").join(" ")),
       };
     }
     return { status };

--- a/web/js/lib/manager-install.js
+++ b/web/js/lib/manager-install.js
@@ -811,7 +811,7 @@ function taskStatusStr(item) {
  * message we positively recognise is reshaped, everything else passes through.
  */
 export function isRegistryLookupMiss(text) {
-  return typeof text === "string" && /not found in\s*\[[^\]]*\]/i.test(text);
+  return typeof text === "string" && /Node\s+'[^']*@[^']*'\s+not found in\s*\[[^\]]*\]/i.test(text);
 }
 
 /**
@@ -846,9 +846,13 @@ export function unlistedGitUrlAdvice(failureText) {
     ` name. IF YOU PASSED A GIT URL: this ComfyUI-Manager cannot install one. It resolves` +
     ` installs from its own database, and the parameter that would carry a URL (repository)` +
     ` is accepted and then IGNORED by its install handler — so no argument to this tool will` +
-    ` make it clone your URL. What does work: start ComfyUI with --enable-manager-legacy-ui` +
-    ` (that registers the legacy route, which installs from a URL), or clone the repo into` +
-    ` custom_nodes/ and restart, or ask the pack author to publish it to the registry.` +
+    ` make it clone your URL. WHAT WORKS, least effort first: clone the repo into` +
+    ` custom_nodes/ and restart ComfyUI; or ask the pack author to publish it to the` +
+    ` registry. There IS a legacy git-URL route, but reaching it takes TWO steps: start` +
+    ` ComfyUI with --enable-manager-legacy-ui (which REPLACES the v2 Manager API rather` +
+    ` than adding to it) AND set allow_git_url_install = true in ComfyUI-Manager's` +
+    ` config.ini — an unlisted pack is rated "high+" risk, and without that setting the` +
+    ` route answers 404 "A security error has occurred".` +
     ` IF YOU MEANT A REGISTRY PACK: check the id and the channel/mode named in the brackets.`
   );
 }

--- a/web/js/lib/manager-install.js
+++ b/web/js/lib/manager-install.js
@@ -798,6 +798,61 @@ function taskStatusStr(item) {
  * shape we don't recognize can never become a FALSE failure). Prefers the
  * `status.messages` (the crash/exception text) for the reason, then `result`.
  */
+/**
+ * #920 — does this Manager failure mean "that pack is not in the registry"?
+ *
+ * v4 resolves an install from its OWN database — `get_custom_nodes(channel, mode)`,
+ * falling back to `cnr_map[node_id]` — and when neither has the pack it answers
+ *
+ *   Node '<id>@<version>' not found in [ManagerChannel.<ch>, ManagerDatabaseSource.<mode>]
+ *
+ * Matched on the STABLE part ("not found in" + a bracketed source list) rather than
+ * the enum spellings, which vary with channel/mode. Deliberately narrow: only a
+ * message we positively recognise is reshaped, everything else passes through.
+ */
+export function isRegistryLookupMiss(text) {
+  return typeof text === "string" && /not found in\s*\[[^\]]*\]/i.test(text);
+}
+
+/**
+ * #920 — what to add when a GIT URL install hits that miss.
+ *
+ * The reporter passed a repository URL and got a registry-lookup failure naming a
+ * pack id they never supplied. That reads like a lookup bug and sends people to
+ * re-check spelling, channel and mode; none of it is the problem.
+ *
+ * Both facts below are read from ComfyUI-Manager's SOURCE, not its schema — the
+ * schema is what misled two separate attempts at this issue (`InstallPackParams`
+ * declares `repository` "required if selected_version is nightly", and `do_install`
+ * reads only id/selected_version/channel/mode/skip_post_install):
+ *
+ *   1. the pack is not in the registry — that IS what the lookup missed;
+ *   2. a stock v4 has NO route that installs an arbitrary git URL. The legacy
+ *      `/manager/queue/install` route does (`@unknown` + `files:[url]`), but
+ *      `comfyui_manager/__init__.py` registers the legacy server only under
+ *      `--enable-manager-legacy-ui`.
+ *
+ * Returns "" when there is nothing extra to say, so callers may append blindly.
+ */
+export function unlistedGitUrlAdvice(failureText) {
+  if (!isRegistryLookupMiss(failureText)) return "";
+  // Phrased for BOTH readers, because the surface that shows this failure
+  // (panel_node_queue_status) does not carry the original request and plumbing it
+  // through for a message is not worth the coupling. Someone who mistyped a
+  // registry id needs the first sentence; someone who passed a git URL needs the
+  // rest, and the conditional wording keeps it from asserting which they did.
+  return (
+    ` — NOTE: that is a NODE REGISTRY lookup. The pack is not in the registry under that` +
+    ` name. IF YOU PASSED A GIT URL: this ComfyUI-Manager cannot install one. It resolves` +
+    ` installs from its own database, and the parameter that would carry a URL (repository)` +
+    ` is accepted and then IGNORED by its install handler — so no argument to this tool will` +
+    ` make it clone your URL. What does work: start ComfyUI with --enable-manager-legacy-ui` +
+    ` (that registers the legacy route, which installs from a URL), or clone the repo into` +
+    ` custom_nodes/ and restart, or ask the pack author to publish it to the registry.` +
+    ` IF YOU MEANT A REGISTRY PACK: check the id and the channel/mode named in the brackets.`
+  );
+}
+
 export function taskFailureReason(item) {
   if (!isTaskHistoryItem(item)) return null;
   if (!TASK_FAILURE_STATUS.has(taskStatusStr(item))) return null;


### PR DESCRIPTION
Third pass at #920. The first two both reshaped the install payload and **both did nothing**.

## Why the two previous attempts were inert

The other session's (shipped as **0.11.75**) and mine (PR #927) each sent `repository`, justified by ComfyUI-Manager's generated schema documenting it as *"required if selected_version is nightly"*. Read from Manager's **source** instead:

```py
async def do_install(params: InstallPackParams):
    node_id = params.id; node_version = params.selected_version
    channel = params.channel; mode = params.mode
    skip_post_install = params.skip_post_install
```

```
params.repository read 0 times  —  tags 4.2.2, 4.1, branch draft-v4
```

`install_by_id(node_name, version_spec, channel, mode, …)` takes no repository argument, and the nightly path resolves the clone URL from Manager's **own database**. The only `params.model_dump()` forwarding is in `do_install_model`, a different handler — checked, because it was the one hole in the argument.

**A generated OpenAPI model is the contract of what a server ACCEPTS, never of what it DOES.** With Pydantic's default `extra='ignore'`, a declared-but-unread field is indistinguishable from a working one on the client side. That is how two independent attempts landed on the same wrong fix within an hour.

## What this changes

**Nothing about the payload** — there is nothing to send. On a stock v4 an unlisted git URL is not installable at all: the legacy `/manager/queue/install` route supports it (`@unknown` + `files:[url]`), but `comfyui_manager/__init__.py` registers the legacy server only under `--enable-manager-legacy-ui`.

**The failure message.** `panel_node_queue_status` — the surface the reporter actually polled — now says this is a *registry* lookup, that the `repository` parameter is accepted and ignored, and names the three things that work: `--enable-manager-legacy-ui`, a manual clone into `custom_nodes/`, or asking the author to publish.

Deliberately **conditional** (`IF YOU PASSED A GIT URL` / `IF YOU MEANT A REGISTRY PACK`): that surface does not carry the original request, so asserting which mistake the caller made would be claiming an unobserved fact — precisely the defect that produced both wrong fixes.

## The 0.11.75 release note is corrected

It promised *"Installing a custom node from a GitHub URL actually clones it now (#920)"*. It does not clone anything. The entry now states the payload change is forward-compatibility, that the install still fails on a stock v4, and what works today. The code itself is kept — it is what the documented API asks for and costs nothing if upstream implements the field.

A user who upgraded to 0.11.75, retried, and hit the identical error would reasonably have concluded the tool was broken in a new way. That is the part worth correcting quickly.

## Verification

- 3352/3352 unit, typecheck clean, vocabulary gate clean, no control bytes
- four mutations, each confirmed applied: never recognise the miss, assert the cause instead of offering it conditionally, remove the call site, fire on every failure — all killed

## Upstream

Worth an issue against ComfyUI-Manager: v4's schema declares `repository` required for a nightly install and the handler discards it. That mismatch is what made two of us confident and wrong.