### PR TITLE
fix(refresh): retry a transient object_info failure instead of giving up (#954)

### DIFF
--- a/browser_tests/unit/node-def-refresh.test.mjs
+++ b/browser_tests/unit/node-def-refresh.test.mjs
@@ -14,6 +14,7 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
+import { fetchNodeDefsWithRetry } from "../../web/js/lib/object-info-retry.js";
 
 import {
   describeNodeDefRefresh,
@@ -347,6 +348,10 @@ function buildRegisterComfyNodeDefs({ appValue, apiValue }) {
     "recordObjectInfoTypes",
     "reapplyDefsToLiveNodes",
     "describeNodeDefRefresh",
+    // #954 — the REAL retry, not a stub. The shipping function now fetches through it, and
+    // a harness that substituted a pass-through would stop proving what this file exists to
+    // prove: that the shipped code produces these verdicts.
+    "fetchNodeDefsWithRetry",
     `let nodeDefsRefreshConfirmed = false;
      ${body}
      return { registerComfyNodeDefs, getConfirmed: () => nodeDefsRefreshConfirmed };`,
@@ -357,6 +362,8 @@ function buildRegisterComfyNodeDefs({ appValue, apiValue }) {
     () => ({}),
     () => {},
     describeNodeDefRefresh,
+    // No real waiting: the delays are the shipped ones, the sleep is not.
+    (getDefs) => fetchNodeDefsWithRetry(getDefs, { sleep: async () => {} }),
   );
 }
 
@@ -463,6 +470,10 @@ test("#635: the shipping run attributes a history-recording throw to BEFORE regi
     "recordObjectInfoTypes",
     "reapplyDefsToLiveNodes",
     "describeNodeDefRefresh",
+    // #954 — the REAL retry, not a stub. The shipping function now fetches through it, and
+    // a harness that substituted a pass-through would stop proving what this file exists to
+    // prove: that the shipped code produces these verdicts.
+    "fetchNodeDefsWithRetry",
     `let nodeDefsRefreshConfirmed = false;
      ${body}
      return { registerComfyNodeDefs };`,
@@ -481,6 +492,8 @@ test("#635: the shipping run attributes a history-recording throw to BEFORE regi
     },
     () => {},
     describeNodeDefRefresh,
+    // No real waiting: the shipped delays, an instant sleep.
+    (getDefs) => fetchNodeDefsWithRetry(getDefs, { sleep: async () => {} }),
   );
   const verdict = await registerWithThrowingRecorder(undefined);
   assert.equal(verdict.reason, "register_failed");
@@ -513,6 +526,10 @@ test("#635: the shipping register run treats a falsy throw as a failure everywhe
     "recordObjectInfoTypes",
     "reapplyDefsToLiveNodes",
     "describeNodeDefRefresh",
+    // #954 — the REAL retry, not a stub. The shipping function now fetches through it, and
+    // a harness that substituted a pass-through would stop proving what this file exists to
+    // prove: that the shipped code produces these verdicts.
+    "fetchNodeDefsWithRetry",
     `let nodeDefsRefreshConfirmed = false;
      ${body}
      return { registerComfyNodeDefs, getConfirmed: () => nodeDefsRefreshConfirmed };`,
@@ -529,6 +546,8 @@ test("#635: the shipping register run treats a falsy throw as a failure everywhe
     },
     () => {},
     describeNodeDefRefresh,
+    // No real waiting: the shipped delays, an instant sleep.
+    (getDefs) => fetchNodeDefsWithRetry(getDefs, { sleep: async () => {} }),
   );
   const verdict = await registerComfyNodeDefs(undefined);
   assert.equal(verdict.refreshed, false);

--- a/browser_tests/unit/node-def-refresh.test.mjs
+++ b/browser_tests/unit/node-def-refresh.test.mjs
@@ -554,3 +554,43 @@ test("#635: the shipping register run treats a falsy throw as a failure everywhe
   assert.equal(verdict.reason, "register_failed");
   assert.equal(getConfirmed(), false, "the shared trust flag must not latch true after a falsy throw");
 });
+
+test("#954: the shipping run survives a transient getNodeDefs throw", async () => {
+  // The WIRING SEAM (codex). The retry helper has its own tests and the browser run proved
+  // the whole path, but neither pins that registerComfyNodeDefs itself turns
+  // first-throw/second-success into a refresh — which is the exact regression #954 reports.
+  let calls = 0;
+  const { registerComfyNodeDefs } = buildRegisterComfyNodeDefs({
+    appValue: FULL_APP,
+    apiValue: {
+      getNodeDefs: async () => {
+        calls += 1;
+        if (calls === 1) throw new TypeError("Failed to fetch");
+        return { SomeNode: {} };
+      },
+    },
+  });
+  const verdict = await registerComfyNodeDefs(undefined);
+  assert.equal(verdict.refreshed, true, "a blip inside a reconnect window must not fail the refresh");
+  assert.equal(calls, 2, "it re-attempted rather than swallowing the throw");
+});
+
+test("#954: a persistent getNodeDefs throw still reports the fetch failure it always did", async () => {
+  // The other direction, and the one a retry can silently break: a genuine outage must keep
+  // producing `object_info_fetch_failed` with a real detail, not a vaguer verdict.
+  let calls = 0;
+  const { registerComfyNodeDefs } = buildRegisterComfyNodeDefs({
+    appValue: FULL_APP,
+    apiValue: {
+      getNodeDefs: async () => {
+        calls += 1;
+        throw new TypeError("Failed to fetch");
+      },
+    },
+  });
+  const verdict = await registerComfyNodeDefs(undefined);
+  assert.equal(verdict.refreshed, false);
+  assert.equal(verdict.reason, "object_info_fetch_failed");
+  assert.match(String(verdict.detail ?? ""), /Failed to fetch/);
+  assert.equal(calls, 3, "bounded — it does not retry forever");
+});

--- a/browser_tests/unit/object-info-retry.test.mjs
+++ b/browser_tests/unit/object-info-retry.test.mjs
@@ -1,0 +1,114 @@
+// #954 — a transient /object_info failure must not be reported as a refusal.
+//
+// Reported: right after a restart-related operation, `panel_refresh_nodes` returned
+// `{refreshed:false, reason:"object_info_fetch_failed", detail:"Failed to fetch"}` while
+// `list_local_models` succeeded moments later against the same server. One attempt into a
+// reconnect window produced a permanent-sounding verdict, with a remedy telling the user to
+// check that the ComfyUI process was still running — a process that was never down.
+//
+// `sleep` is injected throughout so these run instantly and deterministically. A retry test
+// that depends on real timers is a slow test that eventually becomes a flaky one.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  OBJECT_INFO_RETRY_DELAYS_MS,
+  fetchNodeDefsWithRetry,
+  objectInfoLooksTransient,
+} from "../../web/js/lib/object-info-retry.js";
+
+const DEFS = { KSampler: {}, CheckpointLoaderSimple: {} };
+const noSleep = async () => {};
+
+test("#954: a first-attempt success does not wait at all", () => {
+  // The overwhelmingly common case. A retry that costs latency when nothing is wrong is a
+  // regression for every caller.
+  let slept = 0;
+  return fetchNodeDefsWithRetry(async () => DEFS, { sleep: async (ms) => { slept += ms; } }).then((defs) => {
+    assert.equal(defs, DEFS);
+    assert.equal(slept, 0);
+  });
+});
+
+test("#954: a transient throw is retried and the later success is returned", async () => {
+  // The reported case: the fetch fails inside a reconnect window and works moments later.
+  let calls = 0;
+  const defs = await fetchNodeDefsWithRetry(
+    async () => {
+      calls += 1;
+      if (calls === 1) throw new TypeError("Failed to fetch");
+      return DEFS;
+    },
+    { sleep: noSleep },
+  );
+  assert.equal(defs, DEFS);
+  assert.equal(calls, 2, "it must actually re-attempt, not swallow the error");
+});
+
+test("#954: a genuine outage still reports the ORIGINAL error", async () => {
+  // Retrying must not convert a real failure into a different, vaguer one — the caller
+  // words `object_info_fetch_failed` and its `detail` from exactly this error.
+  let calls = 0;
+  await assert.rejects(
+    () =>
+      fetchNodeDefsWithRetry(
+        async () => {
+          calls += 1;
+          throw new TypeError("Failed to fetch");
+        },
+        { sleep: noSleep },
+      ),
+    /Failed to fetch/,
+  );
+  assert.equal(calls, OBJECT_INFO_RETRY_DELAYS_MS.length + 1, "bounded: every attempt, then stop");
+});
+
+test("#954: the LAST error wins, not the first", async () => {
+  // A backend coming up can fail differently on the way — the caller should see the state
+  // it ended in, which is the one its remedy has to address.
+  const errs = ["Failed to fetch", "503 Service Unavailable", "connection reset"];
+  let i = 0;
+  await assert.rejects(
+    () => fetchNodeDefsWithRetry(async () => { throw new Error(errs[i++]); }, { sleep: noSleep }),
+    /connection reset/,
+  );
+});
+
+test("#954: an empty payload is a failure, not 'the server has no nodes'", async () => {
+  // ComfyUI always defines nodes; an empty map means the response was not the one asked
+  // for. Treating it as success would register a definition set that omits everything.
+  assert.equal(objectInfoLooksTransient({}), true);
+  assert.equal(objectInfoLooksTransient(null), true);
+  assert.equal(objectInfoLooksTransient("nope"), true);
+  assert.equal(objectInfoLooksTransient(DEFS), false);
+
+  let calls = 0;
+  const defs = await fetchNodeDefsWithRetry(
+    async () => {
+      calls += 1;
+      return calls < 3 ? {} : DEFS;
+    },
+    { sleep: noSleep },
+  );
+  assert.equal(defs, DEFS);
+  assert.equal(calls, 3);
+});
+
+test("#954: exhausting on EMPTY returns the payload rather than inventing an error", async () => {
+  // The caller already classifies an empty result carefully. Throwing here would replace a
+  // verdict it words precisely with one it never wrote.
+  const out = await fetchNodeDefsWithRetry(async () => ({}), { sleep: noSleep });
+  assert.deepEqual(out, {});
+});
+
+test("#954: the wait is bounded and ordered", async () => {
+  // Bounded because this blocks a tool call: long enough to cross a reconnect blip, short
+  // enough that a dead backend answers quickly with the honest failure.
+  const slept = [];
+  await assert.rejects(
+    () => fetchNodeDefsWithRetry(async () => { throw new Error("x"); }, { sleep: async (ms) => slept.push(ms) }),
+    /x/,
+  );
+  assert.deepEqual(slept, OBJECT_INFO_RETRY_DELAYS_MS);
+  assert.ok(slept.reduce((a, b) => a + b, 0) <= 1000, "worst case must stay under a second");
+  assert.deepEqual([...slept].sort((a, b) => a - b), slept, "backoff, not a fixed interval");
+});

--- a/browser_tests/unit/object-info-retry.test.mjs
+++ b/browser_tests/unit/object-info-retry.test.mjs
@@ -109,6 +109,8 @@ test("#954: the wait is bounded and ordered", async () => {
     /x/,
   );
   assert.deepEqual(slept, OBJECT_INFO_RETRY_DELAYS_MS);
-  assert.ok(slept.reduce((a, b) => a + b, 0) <= 1000, "worst case must stay under a second");
+  // Bounds the SLEEPING, not the tool call: the three requests themselves are unbounded
+  // (codex). What this guarantees is that a blip costs under a second of waiting.
+  assert.ok(slept.reduce((a, b) => a + b, 0) <= 1000, "total backoff must stay under a second");
   assert.deepEqual([...slept].sort((a, b) => a - b), slept, "backoff, not a fixed interval");
 });

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -159,6 +159,7 @@ import { displayLabel, boundaryInputLabel, widgetLabelMap } from "./lib/slot-lab
 import { createObjectInfoHistory, awaitHistoryBaseline } from "./lib/object-info-history.js";
 import { makeRefreshCoalescer } from "./lib/refresh-coalesce.js";
 import { describeNodeDefRefresh } from "./lib/node-def-refresh.js";
+import { fetchNodeDefsWithRetry } from "./lib/object-info-retry.js";
 import { confirmCanvasNavigation } from "./lib/canvas-navigation.js";
 import { watchPostReconnectSettle, graphMutationReconnectGate } from "./lib/reconnect-recovery.js";
 import { reconcileCompletedDownloads } from "./lib/download-refresh.js";
@@ -734,7 +735,15 @@ async function registerComfyNodeDefs(preloadedDefs) {
     // combo trust below. Decoupled from registerNodesFromDefs so the trust signal
     // doesn't hinge on that method existing (codex #2).
     if (!defs && typeof api?.getNodeDefs === "function") {
-      defs = await api.getNodeDefs();
+      // #954 — retry a TRANSIENT failure. A refresh issued just after a restart-related
+      // operation landed in a reconnect window and came back
+      // `object_info_fetch_failed / "Failed to fetch"` while other reads succeeded moments
+      // later against the same server, printing a remedy that sends the user to check a
+      // process that was never down. The startup baseline seed already retries getNodeDefs
+      // for this reason; this path did not, so the same blip was survivable at page load
+      // and fatal to a tool call. Bounded (~800ms worst case) because this blocks the call,
+      // and the LAST error is rethrown so a genuine outage still reports what it always did.
+      defs = await fetchNodeDefsWithRetry(() => api.getNodeDefs());
     }
     // Record observed backend history (#458 trust root) — covers reconnect, the forced
     // refresh_nodes path, add_node payloads, and download-triggered refreshes.

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -743,6 +743,7 @@ async function registerComfyNodeDefs(preloadedDefs) {
       // for this reason; this path did not, so the same blip was survivable at page load
       // and fatal to a tool call. Bounded (~800ms worst case) because this blocks the call,
       // and the LAST error is rethrown so a genuine outage still reports what it always did.
+      // (~800ms is the added WAITING; the three requests themselves are unbounded — codex.)
       defs = await fetchNodeDefsWithRetry(() => api.getNodeDefs());
     }
     // Record observed backend history (#458 trust root) — covers reconnect, the forced

--- a/web/js/lib/object-info-retry.js
+++ b/web/js/lib/object-info-retry.js
@@ -12,8 +12,9 @@
  * refresh path did not, so the same flake was survivable at page load and fatal to a tool
  * call.
  *
- * BOUNDED, because this blocks a tool call: three attempts, ~800ms of added waiting in the
- * worst case. Long enough to cross a reconnect blip, short enough that a genuinely dead
+ * BOUNDED, because this blocks a tool call: three attempts, 800ms of added WAITING at most.
+ * That bounds the backoff, not the total — the three requests can each take as long as the
+ * network makes them (codex). What it buys is that a blip costs under a second of sleeping. Long enough to cross a reconnect blip, short enough that a genuinely dead
  * backend still answers quickly with the honest failure rather than hanging the agent.
  */
 

--- a/web/js/lib/object-info-retry.js
+++ b/web/js/lib/object-info-retry.js
@@ -1,0 +1,69 @@
+/**
+ * #954 — a transient /object_info failure is not a refusal.
+ *
+ * Reported: after a restart-related operation, `panel_refresh_nodes` came back
+ * `{refreshed:false, reason:"object_info_fetch_failed", detail:"Failed to fetch"}` while
+ * `list_local_models` succeeded moments later against the same server. One attempt landing
+ * inside a reconnect window produced a permanent-sounding verdict for a condition that
+ * clears on its own — and the remedy it printed ("check that the ComfyUI server process is
+ * still running") sends the user after a server that was never down.
+ *
+ * The startup baseline seed already retries getNodeDefs for exactly this reason. The
+ * refresh path did not, so the same flake was survivable at page load and fatal to a tool
+ * call.
+ *
+ * BOUNDED, because this blocks a tool call: three attempts, ~800ms of added waiting in the
+ * worst case. Long enough to cross a reconnect blip, short enough that a genuinely dead
+ * backend still answers quickly with the honest failure rather than hanging the agent.
+ */
+
+/** Waits between attempts. Two entries = three attempts. */
+export const OBJECT_INFO_RETRY_DELAYS_MS = [200, 600];
+
+/**
+ * Is this result worth another attempt?
+ *
+ * An empty or non-object payload counts as a failure, not as "the server has no nodes".
+ * ComfyUI always defines nodes; an empty map means the response was not the one asked for
+ * — the same rule the startup seed applies (`Object.keys(defs).length > 0`). Treating it as
+ * success would poison the registration path with a definition set that omits everything.
+ */
+export function objectInfoLooksTransient(defs) {
+  return !defs || typeof defs !== "object" || Object.keys(defs).length === 0;
+}
+
+/**
+ * Fetch node definitions, retrying a transient failure.
+ *
+ * @param {() => Promise<any>} getDefs the frontend's `api.getNodeDefs`, already bound
+ * @param {{delays?: number[], sleep?: (ms: number) => Promise<void>}} [opts]
+ *   `sleep` is injectable so tests run instantly and deterministically instead of
+ *   depending on real timers.
+ * @returns {Promise<any>} the definitions
+ * @throws the LAST error, when every attempt threw — so the caller's verdict still reports
+ *   `object_info_fetch_failed` with a real `detail`, exactly as before. Retrying must not
+ *   convert a genuine outage into a different, vaguer failure.
+ */
+export async function fetchNodeDefsWithRetry(getDefs, { delays = OBJECT_INFO_RETRY_DELAYS_MS, sleep } = {}) {
+  const wait = typeof sleep === "function" ? sleep : (ms) => new Promise((r) => setTimeout(r, ms));
+  const steps = Array.isArray(delays) ? delays : OBJECT_INFO_RETRY_DELAYS_MS;
+  let lastError;
+  let lastValue;
+  for (let attempt = 0; attempt <= steps.length; attempt++) {
+    try {
+      const defs = await getDefs();
+      if (!objectInfoLooksTransient(defs)) return defs;
+      lastValue = defs;
+      lastError = undefined;
+    } catch (err) {
+      lastError = err;
+    }
+    if (attempt < steps.length) await wait(steps[attempt]);
+  }
+  // Every attempt finished and none produced usable definitions.
+  if (lastError !== undefined) throw lastError;
+  // Exhausted on empty rather than on a throw: hand the empty payload back so the caller
+  // classifies it exactly as it did before this retry existed. Inventing an error here
+  // would change a verdict the caller already words carefully.
+  return lastValue;
+}


### PR DESCRIPTION
Draft — claiming #954.

After a restart-related operation, `panel_refresh_nodes` returned `refreshed:false, reason:object_info_fetch_failed, detail:(Failed to fetch)` while `list_local_models` succeeded moments later against the same server. A single attempt into a reconnect window reports a permanent-sounding failure for a condition that clears on its own.

Refs #954