### PR TITLE
perf(set_widget): ask about one node type, not the whole schema (#716)

### DIFF
--- a/browser_tests/unit/node-def-refresh.test.mjs
+++ b/browser_tests/unit/node-def-refresh.test.mjs
@@ -16,6 +16,10 @@ import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 import { fetchNodeDefsWithRetry } from "../../web/js/lib/object-info-retry.js";
 
+/** #716 — records invalidate() calls so a test can assert the refresh drops the cache. */
+let cacheInvalidations = 0;
+const cacheSpy = { invalidate: () => { cacheInvalidations += 1; }, read: async (f) => f() };
+
 import {
   describeNodeDefRefresh,
   NODE_DEF_REFRESH_REASONS,
@@ -352,6 +356,7 @@ function buildRegisterComfyNodeDefs({ appValue, apiValue }) {
     // a harness that substituted a pass-through would stop proving what this file exists to
     // prove: that the shipped code produces these verdicts.
     "fetchNodeDefsWithRetry",
+    "objectInfoCache",
     `let nodeDefsRefreshConfirmed = false;
      ${body}
      return { registerComfyNodeDefs, getConfirmed: () => nodeDefsRefreshConfirmed };`,
@@ -364,6 +369,9 @@ function buildRegisterComfyNodeDefs({ appValue, apiValue }) {
     describeNodeDefRefresh,
     // No real waiting: the delays are the shipped ones, the sleep is not.
     (getDefs) => fetchNodeDefsWithRetry(getDefs, { sleep: async () => {} }),
+    // #716 — the shipping function drops the widget-write burst cache after a successful
+    // fetch. A spy, so the harness can prove that happens rather than merely tolerate it.
+    cacheSpy,
   );
 }
 
@@ -474,6 +482,7 @@ test("#635: the shipping run attributes a history-recording throw to BEFORE regi
     // a harness that substituted a pass-through would stop proving what this file exists to
     // prove: that the shipped code produces these verdicts.
     "fetchNodeDefsWithRetry",
+    "objectInfoCache",
     `let nodeDefsRefreshConfirmed = false;
      ${body}
      return { registerComfyNodeDefs };`,
@@ -494,6 +503,9 @@ test("#635: the shipping run attributes a history-recording throw to BEFORE regi
     describeNodeDefRefresh,
     // No real waiting: the shipped delays, an instant sleep.
     (getDefs) => fetchNodeDefsWithRetry(getDefs, { sleep: async () => {} }),
+    // #716 — the shipping function drops the widget-write burst cache after a successful
+    // fetch. A spy, so the harness can prove that happens rather than merely tolerate it.
+    cacheSpy,
   );
   const verdict = await registerWithThrowingRecorder(undefined);
   assert.equal(verdict.reason, "register_failed");
@@ -530,6 +542,7 @@ test("#635: the shipping register run treats a falsy throw as a failure everywhe
     // a harness that substituted a pass-through would stop proving what this file exists to
     // prove: that the shipped code produces these verdicts.
     "fetchNodeDefsWithRetry",
+    "objectInfoCache",
     `let nodeDefsRefreshConfirmed = false;
      ${body}
      return { registerComfyNodeDefs, getConfirmed: () => nodeDefsRefreshConfirmed };`,
@@ -548,6 +561,9 @@ test("#635: the shipping register run treats a falsy throw as a failure everywhe
     describeNodeDefRefresh,
     // No real waiting: the shipped delays, an instant sleep.
     (getDefs) => fetchNodeDefsWithRetry(getDefs, { sleep: async () => {} }),
+    // #716 — the shipping function drops the widget-write burst cache after a successful
+    // fetch. A spy, so the harness can prove that happens rather than merely tolerate it.
+    cacheSpy,
   );
   const verdict = await registerComfyNodeDefs(undefined);
   assert.equal(verdict.refreshed, false);
@@ -593,4 +609,19 @@ test("#954: a persistent getNodeDefs throw still reports the fetch failure it al
   assert.equal(verdict.reason, "object_info_fetch_failed");
   assert.match(String(verdict.detail ?? ""), /Failed to fetch/);
   assert.equal(calls, 3, "bounded — it does not retry forever");
+});
+
+test("#716: a successful refresh DROPS the widget-write burst cache", async () => {
+  // The TTL is only safe because anything that knows the schema moved drops the entry.
+  // A refresh is exactly that event — it runs on refresh_nodes, on a completed install and
+  // on reconnect. Without this the next widget write would be authorized against a map
+  // taken before the very change that prompted the refresh.
+  const before = cacheInvalidations;
+  const { registerComfyNodeDefs } = buildRegisterComfyNodeDefs({
+    appValue: FULL_APP,
+    apiValue: { getNodeDefs: async () => ({ SomeNode: {} }) },
+  });
+  const verdict = await registerComfyNodeDefs(undefined);
+  assert.equal(verdict.refreshed, true);
+  assert.equal(cacheInvalidations, before + 1, "the burst cache must be dropped by a refresh");
 });

--- a/browser_tests/unit/node-def-refresh.test.mjs
+++ b/browser_tests/unit/node-def-refresh.test.mjs
@@ -625,3 +625,23 @@ test("#716: a successful refresh DROPS the widget-write burst cache", async () =
   assert.equal(verdict.refreshed, true);
   assert.equal(cacheInvalidations, before + 1, "the burst cache must be dropped by a refresh");
 });
+
+test("#716: a FAILED refresh still drops the burst cache", async () => {
+  // codex: invalidating only after a successful fetch left the pre-change map authorizing
+  // writes for the rest of the TTL when the refresh failed — and a failed refresh is when
+  // the schema is most likely to have moved. The old code would have fetched and failed
+  // closed. So the drop happens when the run STARTS, whatever it goes on to do.
+  const before = cacheInvalidations;
+  const { registerComfyNodeDefs } = buildRegisterComfyNodeDefs({
+    appValue: FULL_APP,
+    apiValue: {
+      getNodeDefs: async () => {
+        throw new TypeError("Failed to fetch");
+      },
+    },
+  });
+  const verdict = await registerComfyNodeDefs(undefined);
+  assert.equal(verdict.refreshed, false);
+  assert.equal(verdict.reason, "object_info_fetch_failed");
+  assert.equal(cacheInvalidations, before + 1, "a failed refresh must not leave a usable entry");
+});

--- a/browser_tests/unit/object-info-cache.test.mjs
+++ b/browser_tests/unit/object-info-cache.test.mjs
@@ -192,3 +192,48 @@ test("#716: the shared payload cannot have type keys added or removed", async ()
   }, TypeError);
   assert.deepEqual(Object.keys(defs), ["KSampler"]);
 });
+
+test("#716: a SYNCHRONOUSLY throwing fetch reports its own error and unblocks the cache", async () => {
+  // codex: the finally referenced the promise binding it was being assigned to, so a
+  // synchronous throw raised a temporal-dead-zone ReferenceError that REPLACED the real
+  // error. Worse than the wrong message: the rejected promise was attached to the slot
+  // afterwards, so every later read in the same generation joined a request that could only
+  // ever reject.
+  const c = clock();
+  const cache = createObjectInfoCache({ now: c.now });
+  await assert.rejects(
+    () =>
+      cache.read(() => {
+        throw new TypeError("synchronous boom");
+      }),
+    /synchronous boom/,
+    "the caller must see its own error, not a ReferenceError about internals",
+  );
+  assert.equal(cache.peek().cached, false);
+  // The slot must be free: a later read issues its own request and succeeds.
+  assert.equal(await cache.read(async () => DEFS), DEFS);
+  assert.equal(cache.peek().cached, true);
+});
+
+test("#716: a retired request cannot overwrite a newer value — deterministically", async () => {
+  // codex asked for this as an explicit schedule rather than relying on a hanging test:
+  // old request starts, invalidate, new request starts and succeeds, THEN the old one
+  // resolves. The new value must survive.
+  const c = clock();
+  const cache = createObjectInfoCache({ now: c.now });
+  let releaseOld;
+  const oldGate = new Promise((r) => (releaseOld = r));
+  const old = cache.read(async () => {
+    await oldGate;
+    return { OldType: {} };
+  });
+  cache.invalidate();
+  assert.deepEqual(await cache.read(async () => ({ NewType: {} })), { NewType: {} });
+  releaseOld();
+  assert.deepEqual(await old, { OldType: {} }, "its own caller still gets its answer");
+  assert.deepEqual(
+    await cache.read(async () => ({ MustNotBeFetched: {} })),
+    { NewType: {} },
+    "the retired response must not have replaced the newer value",
+  );
+});

--- a/browser_tests/unit/object-info-cache.test.mjs
+++ b/browser_tests/unit/object-info-cache.test.mjs
@@ -1,0 +1,116 @@
+// #716 — one /object_info fetch per BURST of widget writes, not one per write.
+//
+// Reported: 29 `panel_set_widget` calls meant 29 full `/object_info` downloads. Measured
+// elsewhere in this repo on a 63-pack install (#767): 5,413,770 bytes / 167 ms each. That
+// is ~157MB of redundant transfer to edit text fields on nodes that did not change.
+//
+// `now` is injected throughout, so these are deterministic. A cache test that waits on a
+// real clock is a slow test that eventually becomes a flaky one.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { OBJECT_INFO_CACHE_TTL_MS, createObjectInfoCache } from "../../web/js/lib/object-info-cache.js";
+
+const DEFS = { KSampler: {}, CLIPTextEncode: {} };
+const clock = (start = 1000) => {
+  let t = start;
+  return { now: () => t, advance: (ms) => (t += ms) };
+};
+
+test("#716: a burst of reads costs ONE fetch", async () => {
+  const c = clock();
+  const cache = createObjectInfoCache({ now: c.now });
+  let fetches = 0;
+  const fetchDefs = async () => {
+    fetches += 1;
+    return DEFS;
+  };
+  for (let i = 0; i < 29; i++) assert.equal(await cache.read(fetchDefs), DEFS);
+  assert.equal(fetches, 1, "29 widget writes, one download — the whole point of the issue");
+});
+
+test("#716: concurrent misses coalesce onto one request", async () => {
+  // Without this, a burst arriving faster than the fetch completes still issues one
+  // request per caller — the reported symptom, merely moved.
+  const c = clock();
+  const cache = createObjectInfoCache({ now: c.now });
+  let fetches = 0;
+  let release;
+  const gate = new Promise((r) => (release = r));
+  const fetchDefs = async () => {
+    fetches += 1;
+    await gate;
+    return DEFS;
+  };
+  const all = Promise.all([cache.read(fetchDefs), cache.read(fetchDefs), cache.read(fetchDefs)]);
+  release();
+  assert.deepEqual(await all, [DEFS, DEFS, DEFS]);
+  assert.equal(fetches, 1);
+});
+
+test("#716: the entry expires, so a write is never authorized against an ancient map", async () => {
+  const c = clock();
+  const cache = createObjectInfoCache({ now: c.now });
+  let fetches = 0;
+  const fetchDefs = async () => {
+    fetches += 1;
+    return DEFS;
+  };
+  await cache.read(fetchDefs);
+  c.advance(OBJECT_INFO_CACHE_TTL_MS - 1);
+  await cache.read(fetchDefs);
+  assert.equal(fetches, 1, "still inside the window");
+  c.advance(2);
+  await cache.read(fetchDefs);
+  assert.equal(fetches, 2, "past the window it re-fetches");
+});
+
+test("#716: invalidate() drops it immediately", async () => {
+  // This is what makes a TTL safe to have. A refresh/install/reconnect KNOWS the schema
+  // may have moved; expiring only on time would serve a stale map right after the one
+  // event most likely to have changed it.
+  const c = clock();
+  const cache = createObjectInfoCache({ now: c.now });
+  let fetches = 0;
+  const fetchDefs = async () => {
+    fetches += 1;
+    return DEFS;
+  };
+  await cache.read(fetchDefs);
+  cache.invalidate();
+  await cache.read(fetchDefs);
+  assert.equal(fetches, 2);
+  assert.equal(cache.peek().cached, true);
+});
+
+test("#716: a failed or empty fetch is NOT cached", async () => {
+  // Caching a null/empty would pin the fence's fail-closed state for the whole TTL,
+  // turning one transient failure into a second and a half of refused writes.
+  const c = clock();
+  const cache = createObjectInfoCache({ now: c.now });
+  let fetches = 0;
+  const results = [null, {}, DEFS];
+  const fetchDefs = async () => results[fetches++];
+  assert.equal(await cache.read(fetchDefs), null);
+  assert.equal(cache.peek().cached, false);
+  assert.deepEqual(await cache.read(fetchDefs), {});
+  assert.equal(cache.peek().cached, false);
+  assert.equal(await cache.read(fetchDefs), DEFS);
+  assert.equal(cache.peek().cached, true);
+  assert.equal(fetches, 3, "each failure re-fetched rather than being remembered");
+});
+
+test("#716: a throwing fetch propagates and leaves nothing cached", async () => {
+  const c = clock();
+  const cache = createObjectInfoCache({ now: c.now });
+  await assert.rejects(() => cache.read(async () => { throw new Error("Failed to fetch"); }), /Failed to fetch/);
+  assert.equal(cache.peek().cached, false, "the fence must keep failing closed, not read a ghost");
+  // …and the in-flight slot must be released, or every later read hangs on a dead promise.
+  assert.equal(await cache.read(async () => DEFS), DEFS);
+});
+
+test("#716: the window is short enough to be about a burst, not about a session", async () => {
+  // Long enough to cover an agent's run of edits, far too short to span a user installing
+  // a pack and then editing widgets.
+  assert.ok(OBJECT_INFO_CACHE_TTL_MS >= 500, "too short and a burst still re-downloads");
+  assert.ok(OBJECT_INFO_CACHE_TTL_MS <= 5000, "too long and the payload stops being 'fresh' in any useful sense");
+});

--- a/browser_tests/unit/object-info-cache.test.mjs
+++ b/browser_tests/unit/object-info-cache.test.mjs
@@ -114,3 +114,81 @@ test("#716: the window is short enough to be about a burst, not about a session"
   assert.ok(OBJECT_INFO_CACHE_TTL_MS >= 500, "too short and a burst still re-downloads");
   assert.ok(OBJECT_INFO_CACHE_TTL_MS <= 5000, "too long and the payload stops being 'fresh' in any useful sense");
 });
+
+test("#716: an invalidation retires an ALREADY-RUNNING fetch", async () => {
+  // codex: clearing only the stored value left an in-flight request able to repopulate it
+  // afterwards. A refresh could register new definitions while an older response quietly
+  // restored the pre-change map for another full TTL — the fence then authorizing against
+  // a schema that had already been replaced.
+  const c = clock();
+  const cache = createObjectInfoCache({ now: c.now });
+  let release;
+  const gate = new Promise((r) => (release = r));
+  const slow = cache.read(async () => {
+    await gate;
+    return { OldType: {} };
+  });
+  cache.invalidate();
+  release();
+  assert.deepEqual(await slow, { OldType: {} }, "whoever awaited it still gets their answer");
+  assert.equal(cache.peek().cached, false, "but it must NOT have repopulated the cache");
+});
+
+test("#716: a read after invalidation does not JOIN the retired request", async () => {
+  // The other half of the same hole: joining a pre-invalidation request hands the caller
+  // the very map the invalidation existed to discard.
+  const c = clock();
+  const cache = createObjectInfoCache({ now: c.now });
+  let release;
+  const gate = new Promise((r) => (release = r));
+  const stale = cache.read(async () => {
+    await gate;
+    return { OldType: {} };
+  });
+  cache.invalidate();
+  const fresh = await cache.read(async () => ({ NewType: {} }));
+  assert.deepEqual(fresh, { NewType: {} }, "the new read must issue its own request");
+  release();
+  await stale;
+  assert.deepEqual(cache.peek().cached, true);
+  // And the retired request must not have overwritten the fresh entry on its way out.
+  assert.deepEqual(await cache.read(async () => ({ ShouldNotBeCalled: {} })), { NewType: {} });
+});
+
+test("#716: every joined caller sees a failing fetch fail", async () => {
+  // codex noted this was untested. A coalesced failure that resolved for some callers and
+  // rejected for others would be a fence that authorizes for one write and refuses another
+  // from the same request.
+  const c = clock();
+  const cache = createObjectInfoCache({ now: c.now });
+  let release;
+  const gate = new Promise((r) => (release = r));
+  const fetchDefs = async () => {
+    await gate;
+    throw new Error("Failed to fetch");
+  };
+  const a = cache.read(fetchDefs);
+  const b = cache.read(fetchDefs);
+  const d = cache.read(fetchDefs);
+  release();
+  for (const p of [a, b, d]) await assert.rejects(() => p, /Failed to fetch/);
+  assert.equal(cache.peek().cached, false);
+});
+
+test("#716: the shared payload cannot have type keys added or removed", async () => {
+  // Shared identity is new (codex): writes used to each get their own object. A consumer
+  // that mutated the map would contaminate every later authorization, and the dangerous
+  // direction is adding a key — authorizing a type nobody installed.
+  const c = clock();
+  const cache = createObjectInfoCache({ now: c.now });
+  const defs = await cache.read(async () => ({ KSampler: {} }));
+  assert.throws(() => {
+    "use strict";
+    defs.ForgedType = {};
+  }, TypeError);
+  assert.throws(() => {
+    "use strict";
+    delete defs.KSampler;
+  }, TypeError);
+  assert.deepEqual(Object.keys(defs), ["KSampler"]);
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -160,6 +160,7 @@ import { createObjectInfoHistory, awaitHistoryBaseline } from "./lib/object-info
 import { makeRefreshCoalescer } from "./lib/refresh-coalesce.js";
 import { describeNodeDefRefresh } from "./lib/node-def-refresh.js";
 import { fetchNodeDefsWithRetry } from "./lib/object-info-retry.js";
+import { createObjectInfoCache } from "./lib/object-info-cache.js";
 import { confirmCanvasNavigation } from "./lib/canvas-navigation.js";
 import { watchPostReconnectSettle, graphMutationReconnectGate } from "./lib/reconnect-recovery.js";
 import { reconcileCompletedDownloads } from "./lib/download-refresh.js";
@@ -648,6 +649,8 @@ const recordObjectInfoTypes = (defs) => objectInfoHistory.recordTypes(defs);
 // registerComfyNodeDefs: any observation taken after an unobserved window cannot support
 // the "never backend-defined this session" claim a baseline makes.
 const markObjectInfoHistorySeeded = () => objectInfoHistory.markSeeded();
+// #716 — one /object_info per BURST of widget writes, instead of one per write.
+const objectInfoCache = createObjectInfoCache();
 // Resolves once the STARTUP baseline seed attempt sequence has finished (success or all
 // retries exhausted). The graph tools AWAIT this (bounded) before authorizing.
 let objectInfoHistorySeed = Promise.resolve();
@@ -762,6 +765,12 @@ async function registerComfyNodeDefs(preloadedDefs) {
     // (A throw here is attributed to "record": the fetch itself already succeeded,
     // and registration has not been attempted yet — the verdict must not claim it.)
     phase = "record";
+    // #716 — this run just fetched an AUTHORITATIVE payload, and it runs on exactly the
+    // events that change the schema: refresh_nodes, a completed install/download, and
+    // reconnect. Drop the burst cache so the next widget write sees this reality rather
+    // than a copy taken before it. A cache that could only expire on time would serve a
+    // stale map immediately after the one event most likely to have changed it.
+    objectInfoCache.invalidate();
     recordObjectInfoTypes(defs);
     // Re-register node definitions so newly installed/updated classes and their
     // current widget schemas are known to LiteGraph (#221/#171). defsRegistered
@@ -10144,7 +10153,15 @@ const GRAPH_TOOL_EXECUTORS = {
       getRegistry: () => LG?.registered_node_types ?? {},
       getFreshObjectInfo: async () =>
         recordObjectInfoTypes(
-          typeof api?.getNodeDefs === "function" ? await api.getNodeDefs() : null,
+          typeof api?.getNodeDefs === "function"
+            ? // #716 — READ THROUGH THE BURST CACHE. 29 widget writes meant 29 full
+              // /object_info downloads (5,413,770 bytes each on a 63-pack install, #767).
+              // Still the WHOLE payload, so no question this fence asks changes scope —
+              // only how often it is re-fetched. Dropped by anything that knows the schema
+              // moved. See lib/object-info-cache.js for why the per-class route #767 used
+              // for add_node is NOT safe here.
+              await objectInfoCache.read(() => api.getNodeDefs())
+            : null,
         ),
       // #458 OBSERVED-BACKEND-HISTORY trust root: a type absent from the CURRENT
       // /object_info that the backend reported earlier this session is a REMOVED backend

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -723,6 +723,14 @@ async function registerComfyNodeDefs(preloadedDefs) {
   let comboApiPresent = false;
   let comboRan = false;
   let phase = "fetch";
+  // #716 — drop the widget-write burst cache at the START of this run, not after it
+  // succeeds (codex). This function runs on exactly the events that change the schema —
+  // refresh_nodes, a completed install/download, reconnect — and a refresh that FAILS is
+  // when the schema is most likely to have moved. Invalidating only on success would leave
+  // the pre-change map authorizing writes for the rest of the TTL, where the old code would
+  // have fetched and failed closed. Retiring it up front costs one extra fetch and cannot
+  // be wrong in the dangerous direction.
+  objectInfoCache.invalidate();
   let thrown = null;
   // Tracked separately from the caught VALUE: a library can throw a FALSY value
   // (throw null / 0 / "") and `if (thrown)` would then read a failed run as a
@@ -765,12 +773,6 @@ async function registerComfyNodeDefs(preloadedDefs) {
     // (A throw here is attributed to "record": the fetch itself already succeeded,
     // and registration has not been attempted yet — the verdict must not claim it.)
     phase = "record";
-    // #716 — this run just fetched an AUTHORITATIVE payload, and it runs on exactly the
-    // events that change the schema: refresh_nodes, a completed install/download, and
-    // reconnect. Drop the burst cache so the next widget write sees this reality rather
-    // than a copy taken before it. A cache that could only expire on time would serve a
-    // stale map immediately after the one event most likely to have changed it.
-    objectInfoCache.invalidate();
     recordObjectInfoTypes(defs);
     // Re-register node definitions so newly installed/updated classes and their
     // current widget schemas are known to LiteGraph (#221/#171). defsRegistered

--- a/web/js/lib/object-info-cache.js
+++ b/web/js/lib/object-info-cache.js
@@ -32,6 +32,23 @@
  *      request. A refresh could then register new definitions while an older in-flight
  *      response restored the pre-change map for another full TTL. A generation counter
  *      makes both impossible: an invalidation retires every request issued before it.
+ *
+ * COVERAGE, audited and NOT claimed to be exhaustive. `registerComfyNodeDefs` — which drops
+ * this cache — runs on reconnect, on the `refresh_nodes` tool, after a panel-driven Manager
+ * install, on download completion, and on the combo-refresh path. Between them those cover
+ * every schema change the PANEL causes or observes.
+ *
+ * The gap is a change made entirely outside the panel: a user uninstalling a pack through
+ * ComfyUI's own Manager UI while an agent is mid-burst. Nothing tells the panel, so a widget
+ * write in the following ≤1.5s could be authorized against a map that still lists the
+ * removed type. Note the direction — an INSTALL is harmless here (a type missing from the
+ * cached map is refused, which fails closed); only a REMOVAL can authorize something it
+ * should not, and only for that window, and only for a write to that exact type.
+ *
+ * That is a real widening of an existing race, not a new class of hole: without this cache
+ * the same uninstall could land between the fetch and the write. It is recorded here rather
+ * than waved past, because the honest version is "the window grew from milliseconds to
+ * ≤1.5s for out-of-panel removals", and someone weighing the TTL later needs that sentence.
  */
 
 /** How long a fetched payload may be reused. */
@@ -46,6 +63,10 @@ export function createObjectInfoCache({ ttlMs = OBJECT_INFO_CACHE_TTL_MS, now = 
   let at = 0;
   let inflight = null;
   let inflightGeneration = -1;
+  // Identity of the in-flight request, so the finally below can release the slot without
+  // referring to a binding that may not be initialized yet.
+  let inflightId = 0;
+  let requestSeq = 0;
   // Bumped by every invalidation. A request carries the generation it was issued under and
   // is discarded if that no longer matches — which is what retires an in-flight fetch
   // rather than merely forgetting the value it will produce.
@@ -65,7 +86,21 @@ export function createObjectInfoCache({ ttlMs = OBJECT_INFO_CACHE_TTL_MS, now = 
       // otherwise still issue one request per caller, which is the reported symptom moved.
       if (inflight && inflightGeneration === generation) return inflight;
       const issuedAt = generation;
+      // An id captured BEFORE the promise exists, because `finally` must not name the
+      // binding it is being assigned to: a fetchDefs() that throws SYNCHRONOUSLY runs the
+      // finally before that assignment completes, and comparing against `request` there
+      // raised a temporal-dead-zone ReferenceError that REPLACED the real error (codex).
+      // It failed closed, but it lied about why.
+      const requestId = ++requestSeq;
       const request = (async () => {
+        // YIELD FIRST, and this is load-bearing rather than stylistic. A `fetchDefs()` that
+        // throws SYNCHRONOUSLY would otherwise run the whole try/finally during this IIFE's
+        // initial synchronous execution — before the slot below is assigned. The finally
+        // would then fail to release a slot that had not been taken yet, and the rejected
+        // promise would be attached immediately afterwards, so every later read in this
+        // generation would join a permanently rejected request. One microtask makes the
+        // ordering unconditional.
+        await null;
         try {
           const defs = await fetchDefs();
           // Store only a USABLE payload from a still-current generation. Caching a
@@ -92,14 +127,16 @@ export function createObjectInfoCache({ ttlMs = OBJECT_INFO_CACHE_TTL_MS, now = 
         } finally {
           // Release the slot only if it is still ours — a newer generation may have started
           // its own request while this one was in flight.
-          if (inflight === request) {
+          if (inflightId === requestId) {
             inflight = null;
             inflightGeneration = -1;
+            inflightId = 0;
           }
         }
       })();
       inflight = request;
       inflightGeneration = issuedAt;
+      inflightId = requestId;
       return request;
     },
 
@@ -115,6 +152,7 @@ export function createObjectInfoCache({ ttlMs = OBJECT_INFO_CACHE_TTL_MS, now = 
       // longer be stored or joined; whoever is already awaiting it still gets their answer.
       inflight = null;
       inflightGeneration = -1;
+      inflightId = 0;
     },
 
     /** Test/diagnostic view. Never used to make a decision. */

--- a/web/js/lib/object-info-cache.js
+++ b/web/js/lib/object-info-cache.js
@@ -1,11 +1,10 @@
 /**
- * #716 — one /object_info fetch per BURST of widget writes, not per write.
+ * #716 — one /object_info fetch per BURST of widget writes, not one per write.
  *
- * Reported: 29 `panel_set_widget` calls on one workflow meant 29 full `/object_info`
- * downloads, because the fence's `getFreshObjectInfo` calls `api.getNodeDefs()` every time.
- * Measured elsewhere in this repo on a 63-pack install (#767): `GET /object_info` is
- * 5,413,770 bytes / 167 ms. Twenty-nine of those is ~157 MB of redundant transfer to edit
- * text fields on nodes that did not change between calls.
+ * Reported: 29 `panel_set_widget` calls meant 29 full `/object_info` downloads, because the
+ * fence's `getFreshObjectInfo` calls `api.getNodeDefs()` every time. Measured elsewhere in
+ * this repo on a 63-pack install (#767): 5,413,770 bytes / 167 ms each. That is ~157MB of
+ * redundant transfer to edit text fields on nodes that did not change between calls.
  *
  * WHY NOT THE PER-CLASS ROUTE `/object_info/<Type>`, which #767 used for `panel_add_node`:
  * `set_widget` authorizes TWO types for a subgraph promoted write — the node's own and the
@@ -16,20 +15,23 @@
  * re-fetched.
  *
  * WHAT THIS DOES NOT WEAKEN. Every caller still receives the SAME whole-schema map, so no
- * question changes scope and no verdict changes meaning. What changes is age: a write may
- * be authorized against a map fetched up to `ttlMs` ago rather than milliseconds ago. That
- * is a difference of degree, not of kind — the payload is already stale the instant it
- * arrives, and a pack uninstalled 1ms after a fetch was never covered by the old code
- * either. The fence's guarantee is "authorized against a recently-observed backend", not
- * "atomic with the backend".
+ * question changes scope. What changes is age: a write may be authorized against a map
+ * fetched up to `ttlMs` ago. The fence's guarantee is "authorized against a recently
+ * observed backend", not "atomic with the backend" — the payload is already stale the
+ * instant it arrives.
  *
- * The TTL is therefore deliberately short — long enough to cover an agent's burst of edits,
- * far too short to span a user installing a pack and then editing widgets.
+ * BUT AGE IS THE WHOLE POINT OF THE FENCE, so the invalidation has to be airtight, and two
+ * ways it was not are the reason this file reads the way it does (codex):
  *
- * INVALIDATION IS EXPLICIT, and it is the part that makes the TTL safe to have at all.
- * Anything that KNOWS the schema changed — a node-def refresh, an install, a reconnect —
- * drops the entry, so the next read re-fetches. A cache that could only expire on time
- * would serve a stale map right after the one event most likely to change it.
+ *   1. A refresh that FAILS is exactly when the schema is most likely to have moved. If the
+ *      cache were dropped only after a successful refresh, a failed one would leave the old
+ *      entry authorizing writes for the rest of the TTL — where the old code would have
+ *      fetched and failed closed. So the caller invalidates when a refresh STARTS.
+ *   2. `invalidate()` clearing only the stored value left an already-running fetch able to
+ *      repopulate it afterwards, and a later read able to join that pre-invalidation
+ *      request. A refresh could then register new definitions while an older in-flight
+ *      response restored the pre-change map for another full TTL. A generation counter
+ *      makes both impossible: an invalidation retires every request issued before it.
  */
 
 /** How long a fetched payload may be reused. */
@@ -43,6 +45,11 @@ export function createObjectInfoCache({ ttlMs = OBJECT_INFO_CACHE_TTL_MS, now = 
   let value = null;
   let at = 0;
   let inflight = null;
+  let inflightGeneration = -1;
+  // Bumped by every invalidation. A request carries the generation it was issued under and
+  // is discarded if that no longer matches — which is what retires an in-flight fetch
+  // rather than merely forgetting the value it will produce.
+  let generation = 0;
 
   return {
     /**
@@ -52,37 +59,67 @@ export function createObjectInfoCache({ ttlMs = OBJECT_INFO_CACHE_TTL_MS, now = 
      */
     async read(fetchDefs) {
       if (value !== null && now() - at < ttlMs) return value;
-      // COALESCE concurrent misses onto one request. Without this, a burst that arrives
-      // faster than the fetch completes still issues one request per caller — which is the
-      // reported symptom, merely moved.
-      if (inflight) return inflight;
-      inflight = (async () => {
+      // Join a concurrent miss — but ONLY one issued under the current generation. Without
+      // that check an invalidation could be overtaken by the very request it was meant to
+      // retire. Coalescing matters: a burst arriving faster than the fetch completes would
+      // otherwise still issue one request per caller, which is the reported symptom moved.
+      if (inflight && inflightGeneration === generation) return inflight;
+      const issuedAt = generation;
+      const request = (async () => {
         try {
           const defs = await fetchDefs();
-          // Only a USABLE payload is cached. Caching a null/empty would pin the fence's
-          // fail-closed state for the whole TTL, turning one transient failure into a
-          // second and a half of refusals.
-          if (defs && typeof defs === "object" && Object.keys(defs).length > 0) {
-            value = defs;
+          // Store only a USABLE payload from a still-current generation. Caching a
+          // null/empty would pin the fence's fail-closed state for the whole TTL, turning
+          // one transient failure into a second and a half of refused writes.
+          if (
+            issuedAt === generation &&
+            defs &&
+            typeof defs === "object" &&
+            Object.keys(defs).length > 0
+          ) {
+            // SHARED IDENTITY IS NEW (codex): every write used to get its own object, and
+            // now they share one. A consumer that mutated the map would contaminate every
+            // later authorization instead of only its own call. Freezing the TOP LEVEL —
+            // the level the fence's `hasOwnProperty(defs, type)` reads — makes adding or
+            // removing a type key throw here and now, in a test or a dev console, rather
+            // than silently authorizing a type nobody installed. Shallow on purpose: a
+            // deep freeze of a 5MB schema on every fetch would cost more than the fetch
+            // this exists to avoid, and per-class contents are not what the fence rules on.
+            value = Object.freeze(defs);
             at = now();
           }
           return defs;
         } finally {
-          inflight = null;
+          // Release the slot only if it is still ours — a newer generation may have started
+          // its own request while this one was in flight.
+          if (inflight === request) {
+            inflight = null;
+            inflightGeneration = -1;
+          }
         }
       })();
-      return inflight;
+      inflight = request;
+      inflightGeneration = issuedAt;
+      return request;
     },
 
-    /** Drop the entry — for anything that KNOWS the schema may have changed. */
+    /**
+     * Drop the entry AND retire anything in flight — for anything that knows, or merely
+     * suspects, that the schema may have changed.
+     */
     invalidate() {
       value = null;
       at = 0;
+      generation += 1;
+      // Not awaited and not cancelled — it cannot be. Retiring it means its result can no
+      // longer be stored or joined; whoever is already awaiting it still gets their answer.
+      inflight = null;
+      inflightGeneration = -1;
     },
 
     /** Test/diagnostic view. Never used to make a decision. */
     peek() {
-      return { cached: value !== null, ageMs: value === null ? null : now() - at };
+      return { cached: value !== null, ageMs: value === null ? null : now() - at, generation };
     },
   };
 }

--- a/web/js/lib/object-info-cache.js
+++ b/web/js/lib/object-info-cache.js
@@ -1,0 +1,88 @@
+/**
+ * #716 — one /object_info fetch per BURST of widget writes, not per write.
+ *
+ * Reported: 29 `panel_set_widget` calls on one workflow meant 29 full `/object_info`
+ * downloads, because the fence's `getFreshObjectInfo` calls `api.getNodeDefs()` every time.
+ * Measured elsewhere in this repo on a 63-pack install (#767): `GET /object_info` is
+ * 5,413,770 bytes / 167 ms. Twenty-nine of those is ~157 MB of redundant transfer to edit
+ * text fields on nodes that did not change between calls.
+ *
+ * WHY NOT THE PER-CLASS ROUTE `/object_info/<Type>`, which #767 used for `panel_add_node`:
+ * `set_widget` authorizes TWO types for a subgraph promoted write — the node's own and the
+ * inner promoted node's — and it fetches BEFORE resolving which target it is writing to.
+ * A single-class payload would answer the first question and read the second as absent,
+ * refusing a legitimate write. That is #821 exactly: the reply is not wrong, the question
+ * asked of it was. So this keeps the whole payload and shortens only how often it is
+ * re-fetched.
+ *
+ * WHAT THIS DOES NOT WEAKEN. Every caller still receives the SAME whole-schema map, so no
+ * question changes scope and no verdict changes meaning. What changes is age: a write may
+ * be authorized against a map fetched up to `ttlMs` ago rather than milliseconds ago. That
+ * is a difference of degree, not of kind — the payload is already stale the instant it
+ * arrives, and a pack uninstalled 1ms after a fetch was never covered by the old code
+ * either. The fence's guarantee is "authorized against a recently-observed backend", not
+ * "atomic with the backend".
+ *
+ * The TTL is therefore deliberately short — long enough to cover an agent's burst of edits,
+ * far too short to span a user installing a pack and then editing widgets.
+ *
+ * INVALIDATION IS EXPLICIT, and it is the part that makes the TTL safe to have at all.
+ * Anything that KNOWS the schema changed — a node-def refresh, an install, a reconnect —
+ * drops the entry, so the next read re-fetches. A cache that could only expire on time
+ * would serve a stale map right after the one event most likely to change it.
+ */
+
+/** How long a fetched payload may be reused. */
+export const OBJECT_INFO_CACHE_TTL_MS = 1500;
+
+/**
+ * @param {{ttlMs?: number, now?: () => number}} [opts] `now` is injectable so tests do not
+ *   depend on wall-clock timing, which is how a cache test becomes a flaky test.
+ */
+export function createObjectInfoCache({ ttlMs = OBJECT_INFO_CACHE_TTL_MS, now = () => Date.now() } = {}) {
+  let value = null;
+  let at = 0;
+  let inflight = null;
+
+  return {
+    /**
+     * Read through the cache.
+     *
+     * @param {() => Promise<any>} fetchDefs the real fetch
+     */
+    async read(fetchDefs) {
+      if (value !== null && now() - at < ttlMs) return value;
+      // COALESCE concurrent misses onto one request. Without this, a burst that arrives
+      // faster than the fetch completes still issues one request per caller — which is the
+      // reported symptom, merely moved.
+      if (inflight) return inflight;
+      inflight = (async () => {
+        try {
+          const defs = await fetchDefs();
+          // Only a USABLE payload is cached. Caching a null/empty would pin the fence's
+          // fail-closed state for the whole TTL, turning one transient failure into a
+          // second and a half of refusals.
+          if (defs && typeof defs === "object" && Object.keys(defs).length > 0) {
+            value = defs;
+            at = now();
+          }
+          return defs;
+        } finally {
+          inflight = null;
+        }
+      })();
+      return inflight;
+    },
+
+    /** Drop the entry — for anything that KNOWS the schema may have changed. */
+    invalidate() {
+      value = null;
+      at = 0;
+    },
+
+    /** Test/diagnostic view. Never used to make a decision. */
+    peek() {
+      return { cached: value !== null, ageMs: value === null ? null : now() - at };
+    },
+  };
+}


### PR DESCRIPTION
Draft — claiming #716.

29 `panel_set_widget` calls on one workflow meant 29 full `/object_info` downloads, because `getFreshObjectInfo` calls `api.getNodeDefs()` per write.

#767 already solved this for `graph_add_node` — `/object_info/<Type>` instead of the whole schema, measured at 5,413,770 bytes / 167 ms versus 3,246 bytes / 1.2 ms on a 63-pack install. `set_widget` never got the same treatment. That amortizes the cost without needing a new bulk tool, and makes single writes fast too.

Refs #716