### PR TITLE
fix(e2e): find and stop the last three workflow leaks (#907)

### DIFF
--- a/browser_tests/fixtures/panelTest.ts
+++ b/browser_tests/fixtures/panelTest.ts
@@ -9,9 +9,10 @@
  * A typical spec: point the panel at `mockBridge.url`, open the sidebar, connect,
  * then drive the conversation via the MockBridge helpers.
  */
-import type { Page } from '@playwright/test'
+import type { BrowserContext, Page } from '@playwright/test'
 import { test as base } from '@playwright/test'
 
+import { deleteWorkflowByPath } from '../global-workflow-litter'
 import { MockBridge } from './MockBridge'
 import { PanelPage } from './PanelPage'
 
@@ -105,6 +106,55 @@ export async function isolatePanelPage(page: Page, panelFlags: string[] = []) {
   await applyPanelRouteStubs(page, panelFlags)
 }
 
+/**
+ * Record every workflow file a test WRITES, so the fixture deletes exactly those (#907).
+ *
+ * The leaks left after 0.11.79 were not `workflow_save` — converted to an owned
+ * `cmcp-e2e-*` name — and not `workflow_new`, which persists nothing. They are GROUNDING
+ * (#330): the panel auto-saves an unsaved workflow before a turn, so any spec that calls
+ * `sendMessage` silently creates `Untitled <date> <time>.json`. Measured:
+ *
+ *   before  workflows/Unsaved Workflow.json
+ *   after   workflows/Untitled 2026-08-09 22-51-44.json   persisted: true
+ *
+ * Which is why auditing the save TOOLS never found it — nothing in those specs asks to save.
+ *
+ * OWNERSHIP IS OBSERVED, NOT INFERRED, and that is what makes this safe where name-matching
+ * was not. `Untitled <date> <time>` is also what ComfyUI names a developer's own unnamed
+ * save, so a cleanup keyed on that pattern could delete their file (codex refused exactly
+ * that on #940). This records the requests this test's own browser context actually issued.
+ *
+ * Recorded in the TEST PROCESS rather than in the page, and both page-side attempts that
+ * failed are worth keeping: a window array is wiped by `addInitScript` re-running on every
+ * navigation, and sessionStorage dies with the page — a spec calling `pageB.close()` takes
+ * its record with it, which was the last leak left in a full suite run.
+ */
+function recordWorkflowWrites(context: BrowserContext, sink: Set<string>) {
+  context.on('request', (request) => {
+    try {
+      const method = request.method().toUpperCase()
+      if (method === 'GET' || method === 'HEAD') return
+      const m = /\/userdata\/([^?]+)/.exec(request.url())
+      if (!m) return
+      const decoded = decodeURIComponent(m[1])
+      if (/^workflows\//.test(decoded) && /\.json$/i.test(decoded)) sink.add(decoded)
+    } catch {
+      // Never let bookkeeping interfere with the request under test.
+    }
+  })
+}
+
+/** Delete what this test wrote. Best-effort: a cleanup failure must never mask a real one. */
+async function cleanupRecordedWorkflowWrites(sink: Set<string>) {
+  for (const userdataPath of sink) {
+    try {
+      await deleteWorkflowByPath(userdataPath)
+    } catch {
+      // The suite-level sweep still reports anything left behind.
+    }
+  }
+}
+
 export const test = base.extend<PanelFixtures & PanelOptions>({
   panelFlags: [[], { option: true }],
   mockBridge: async ({}, use) => {
@@ -115,7 +165,13 @@ export const test = base.extend<PanelFixtures & PanelOptions>({
   },
   panel: async ({ page, panelFlags }, use) => {
     await applyPanelRouteStubs(page, panelFlags)
+    // #907 — record before anything loads, clean up after the test whatever it ends up
+    // being. Runs on FAILURE too, which per-spec cleanup at the end of a test body never
+    // did — and a failing test is exactly when a spec is most likely to have left a file.
+    const wrote = new Set<string>()
+    recordWorkflowWrites(page.context(), wrote)
     await use(new PanelPage(page))
+    await cleanupRecordedWorkflowWrites(wrote)
   }
 })
 
@@ -151,6 +207,11 @@ export async function deleteSavedWorkflow(page: Page, workflowName: string): Pro
       // fetchApi RESOLVES on an HTTP error, so the status has to be read (codex) —
       // otherwise a 500 leaves litter and looks exactly like success.
       const res = await api.fetchApi(`/userdata/${encodeURIComponent(path)}`, { method: 'DELETE' })
+      // 404 IS success: the file is gone, which is the whole objective. It happens
+      // routinely now that the fixture also sweeps what the page wrote — a spec that
+      // cleaned up after itself is then asked a second time. Warning on it trains readers
+      // to ignore the warning, which is worse than not printing it.
+      if (res?.status === 404) return 'ok'
       return res?.ok ? 'ok' : `HTTP ${res?.status ?? '?'}`
     }, `workflows/${name}.json`)
   } catch (err) {

--- a/browser_tests/fixtures/panelTest.ts
+++ b/browser_tests/fixtures/panelTest.ts
@@ -12,7 +12,7 @@
 import type { BrowserContext, Page } from '@playwright/test'
 import { test as base } from '@playwright/test'
 
-import { deleteWorkflowByPath } from '../global-workflow-litter'
+import { COMFY_BASE_URL, deleteWorkflowByPath } from '../global-workflow-litter'
 import { MockBridge } from './MockBridge'
 import { PanelPage } from './PanelPage'
 
@@ -129,24 +129,81 @@ export async function isolatePanelPage(page: Page, panelFlags: string[] = []) {
  * navigation, and sessionStorage dies with the page — a spec calling `pageB.close()` takes
  * its record with it, which was the last leak left in a full suite run.
  */
-function recordWorkflowWrites(context: BrowserContext, sink: Set<string>) {
+function recordWorkflowWrites(context: BrowserContext, state: WriteRecord) {
+  // A CREATE is what proves ownership. ComfyUI's workflow write is
+  // `POST /api/userdata/workflows%2F<name>.json?overwrite=false`, and `overwrite=false`
+  // means the server REFUSES an existing path — so an ok response is proof the file did not
+  // exist a moment ago and this browser is what brought it into being. Anything else is
+  // skipped rather than guessed at (codex): an OPTIONS preflight, a DELETE, a write that
+  // permits overwriting, a failed write, or a request to some other instance are all cases
+  // where deleting the path could destroy a file this test did not create.
+  const owns = (url: string, method: string) => {
+    if (method !== 'POST' && method !== 'PUT') return null
+    let parsed: URL
+    try {
+      parsed = new URL(url)
+    } catch {
+      return null
+    }
+    // Same instance the cleanup will delete against — a spec pointed at another ComfyUI
+    // must never make us delete a same-named workflow on the default one.
+    if (parsed.origin !== new URL(COMFY_BASE_URL).origin) return null
+    if (parsed.pathname !== '/api/userdata' && !parsed.pathname.startsWith('/api/userdata/')) return null
+    if (parsed.searchParams.get('overwrite') !== 'false') return null
+    const m = /^\/api\/userdata\/(.+)$/.exec(parsed.pathname)
+    if (!m) return null
+    let decoded: string
+    try {
+      decoded = decodeURIComponent(m[1])
+    } catch {
+      return null
+    }
+    if (!/^workflows\//.test(decoded) || !/\.json$/i.test(decoded)) return null
+    return decoded
+  }
+
   context.on('request', (request) => {
     try {
-      const method = request.method().toUpperCase()
-      if (method === 'GET' || method === 'HEAD') return
-      const m = /\/userdata\/([^?]+)/.exec(request.url())
-      if (!m) return
-      const decoded = decodeURIComponent(m[1])
-      if (/^workflows\//.test(decoded) && /\.json$/i.test(decoded)) sink.add(decoded)
+      if (owns(request.url(), request.method().toUpperCase())) state.pending.add(request)
     } catch {
-      // Never let bookkeeping interfere with the request under test.
+      /* bookkeeping must never interfere with the request under test */
     }
+  })
+  const settle = (request: import('@playwright/test').Request) => state.pending.delete(request)
+  context.on('requestfailed', settle)
+  context.on('requestfinished', (request) => {
+    settle(request)
+    void (async () => {
+      try {
+        const path = owns(request.url(), request.method().toUpperCase())
+        if (!path) return
+        const response = await request.response()
+        // Only a SUCCEEDED create is ours to remove.
+        if (response?.ok()) state.created.add(path)
+      } catch {
+        /* unreadable response ⇒ claim nothing */
+      }
+    })()
   })
 }
 
-/** Delete what this test wrote. Best-effort: a cleanup failure must never mask a real one. */
-async function cleanupRecordedWorkflowWrites(sink: Set<string>) {
-  for (const userdataPath of sink) {
+interface WriteRecord {
+  created: Set<string>
+  pending: Set<import('@playwright/test').Request>
+}
+
+/** Delete what this test created. Best-effort: a cleanup failure must never mask a real one. */
+async function cleanupRecordedWorkflowWrites(state: WriteRecord) {
+  // WAIT FOR IN-FLIGHT WRITES FIRST (codex). Deleting while a save is still on the wire
+  // gets a 404 and then the write lands afterwards — recreating the very file this is
+  // supposed to remove, and doing it invisibly because the delete "succeeded". Bounded, so
+  // a wedged request delays teardown by a second rather than hanging the suite; anything
+  // still pending after that is left to the suite-level sweep, which reports it.
+  const deadline = Date.now() + 1000
+  while (state.pending.size > 0 && Date.now() < deadline) {
+    await new Promise((resolve) => setTimeout(resolve, 25))
+  }
+  for (const userdataPath of state.created) {
     try {
       await deleteWorkflowByPath(userdataPath)
     } catch {
@@ -168,7 +225,7 @@ export const test = base.extend<PanelFixtures & PanelOptions>({
     // #907 — record before anything loads, clean up after the test whatever it ends up
     // being. Runs on FAILURE too, which per-spec cleanup at the end of a test body never
     // did — and a failing test is exactly when a spec is most likely to have left a file.
-    const wrote = new Set<string>()
+    const wrote: WriteRecord = { created: new Set<string>(), pending: new Set() }
     recordWorkflowWrites(page.context(), wrote)
     await use(new PanelPage(page))
     await cleanupRecordedWorkflowWrites(wrote)

--- a/browser_tests/fixtures/panelTest.ts
+++ b/browser_tests/fixtures/panelTest.ts
@@ -138,7 +138,10 @@ function recordWorkflowWrites(context: BrowserContext, state: WriteRecord) {
   // permits overwriting, a failed write, or a request to some other instance are all cases
   // where deleting the path could destroy a file this test did not create.
   const owns = (url: string, method: string) => {
-    if (method !== 'POST' && method !== 'PUT') return null
+    // POST only. That is the contract actually observed for the workflow save; accepting
+    // PUT as well would widen the trusted surface on an assumption rather than evidence
+    // (codex).
+    if (method !== 'POST') return null
     let parsed: URL
     try {
       parsed = new URL(url)
@@ -172,16 +175,31 @@ function recordWorkflowWrites(context: BrowserContext, state: WriteRecord) {
   const settle = (request: import('@playwright/test').Request) => state.pending.delete(request)
   context.on('requestfailed', settle)
   context.on('requestfinished', (request) => {
-    settle(request)
+    let path: string | null = null
+    try {
+      path = owns(request.url(), request.method().toUpperCase())
+    } catch {
+      path = null
+    }
+    if (!path) {
+      settle(request)
+      return
+    }
+    // STAY PENDING UNTIL CLASSIFIED (codex). Settling first and classifying in a detached
+    // promise let teardown observe zero pending, delete the `created` set it had, and only
+    // then receive the path — recreating the missed-cleanup bug without needing a hung
+    // request at all. The drain below is only meaningful if "pending" covers the
+    // bookkeeping too, not just the wire.
+    const owned = path
     void (async () => {
       try {
-        const path = owns(request.url(), request.method().toUpperCase())
-        if (!path) return
         const response = await request.response()
         // Only a SUCCEEDED create is ours to remove.
-        if (response?.ok()) state.created.add(path)
+        if (response?.ok()) state.created.add(owned)
       } catch {
         /* unreadable response ⇒ claim nothing */
+      } finally {
+        settle(request)
       }
     })()
   })
@@ -197,8 +215,13 @@ async function cleanupRecordedWorkflowWrites(state: WriteRecord) {
   // WAIT FOR IN-FLIGHT WRITES FIRST (codex). Deleting while a save is still on the wire
   // gets a 404 and then the write lands afterwards — recreating the very file this is
   // supposed to remove, and doing it invisibly because the delete "succeeded". Bounded, so
-  // a wedged request delays teardown by a second rather than hanging the suite; anything
-  // still pending after that is left to the suite-level sweep, which reports it.
+  // a wedged request delays teardown by a second rather than hanging the suite.
+  //
+  // WHAT THIS DOES NOT PROMISE, stated rather than implied: it drains writes it has already
+  // OBSERVED. A save kicked off by a pending timer after the drain reads zero is recorded
+  // too late for this pass. Closing that needs quiescence the fixture cannot establish
+  // without closing the context first; the suite-level sweep still REPORTS anything left,
+  // which is how these were found in the first place.
   const deadline = Date.now() + 1000
   while (state.pending.size > 0 && Date.now() < deadline) {
     await new Promise((resolve) => setTimeout(resolve, 25))

--- a/browser_tests/global-workflow-litter.ts
+++ b/browser_tests/global-workflow-litter.ts
@@ -18,6 +18,8 @@ import { tmpdir } from 'node:os'
 import { leakReport, plannedDeletions, workflowUserdataPath } from './fixtures/workflow-litter'
 
 const BASE_URL = process.env.PLAYWRIGHT_BASE_URL || 'http://localhost:8188'
+/** #907 — the fixture must delete against the SAME instance it observed a write on. */
+export const COMFY_BASE_URL = BASE_URL
 /**
  * PER RUN, not per machine (codex). A shared, predictable path let two runs
  * against one ComfyUI overwrite each other's ownership record — and then run A's

--- a/browser_tests/global-workflow-litter.ts
+++ b/browser_tests/global-workflow-litter.ts
@@ -193,3 +193,22 @@ export async function cleanWorkflowLitter(): Promise<void> {
     )
   }
 }
+
+/**
+ * Delete one workflow by its userdata path (#907), straight over HTTP.
+ *
+ * Exported so the per-test fixture can sweep what a page WROTE even after that page has
+ * been closed — a spec that calls `pageB.close()` takes its in-page record with it, and
+ * the last leak of a full suite run was exactly that. A 404 is success: the file is gone,
+ * which is the objective.
+ */
+export async function deleteWorkflowByPath(userdataPath: string): Promise<boolean> {
+  try {
+    const res = await fetch(`${BASE_URL}/api/userdata/${encodeURIComponent(userdataPath)}`, {
+      method: "DELETE",
+    })
+    return res.ok || res.status === 404
+  } catch {
+    return false
+  }
+}


### PR DESCRIPTION
Draft — claiming #907's remainder.

0.11.79 fixed the two named specs and moved cleanup to suite level. Three leaks remain and their source was never found:

```
workflow-chat-identity          2 Untitled
bridge-reregisters-after-restart 1 Untitled
bridge-route-never-file-derived  1 Untitled
```

Not `workflow_save` (converted to the owned `cmcp-e2e-*` prefix), not `workflow_new` (persists nothing), autosave off. Starting where the last pass said to: `bridge-route-never-file-derived` reproduces one file in a single-spec run.

Refs #907