### PR TITLE
fix(install): point at the tool that CAN clone an unlisted URL (#920)

### DIFF
--- a/browser_tests/unit/install-unlisted-url-advice.test.mjs
+++ b/browser_tests/unit/install-unlisted-url-advice.test.mjs
@@ -99,7 +99,28 @@ test("#920 the advice names the real blocker and the routes that work", () => {
   assert.match(a, /NODE REGISTRY lookup/, "names what the lookup actually was");
   assert.match(a, /accepted and then IGNORED/, "says the repository field does nothing");
   assert.match(a, /custom_nodes\//, "the manual clone");
-  assert.match(a, /publish it to the registry/, "the durable fix");
+  assert.match(a, /publish to the registry/, "the durable fix");
+});
+
+test("#920 the advice names the tool that CAN clone, and says the usual preference is off", () => {
+  // The workaround, found after the honest error shipped: install_custom_node
+  // runs on the MACHINE, and its install path clones directly when the Manager
+  // accepts a task but the pack never appears installed — exactly this case
+  // (node-management.ts, cloneCustomNodeFallback). panel_install_node's own
+  // description says "Prefer this over the headless install_custom_node tool",
+  // which is precisely backwards here, so the advice has to say so explicitly or
+  // a reader follows the description and stays stuck.
+  const a = unlistedGitUrlAdvice(MISS);
+  // The RECOMMENDATION, not just the name: the tool is mentioned twice (once to
+  // cancel the standing preference), so /install_custom_node/ alone passed even
+  // when the recommendation itself was deleted. Caught by mutation.
+  assert.match(a, /USE install_custom_node INSTEAD/, "recommends it, not merely mentions it");
+  assert.match(a, /clones the repository into custom_nodes/, "and why it can");
+  assert.match(a, /does NOT hold/, "cancels the standing preference for this case");
+  // A remote target genuinely cannot: there is no local tree to clone into, and
+  // the orchestrator keeps the Manager's error for that reason. Saying so stops
+  // this reading as a promise that always works.
+  assert.match(a, /REMOTE target has no local tree/, "the case where it does not apply");
 });
 
 test("#920 the legacy-route advice names BOTH steps, or it sends people to a 404", () => {
@@ -112,7 +133,7 @@ test("#920 the legacy-route advice names BOTH steps, or it sends people to a 404
   const a = unlistedGitUrlAdvice(MISS);
   assert.match(a, /--enable-manager-legacy-ui/, "step one");
   assert.match(a, /allow_git_url_install\s*=\s*true/, "step two — without it the route 404s");
-  assert.match(a, /security error/i, "and says what failure to expect if it is skipped");
+  assert.match(a, /answers 404/, "and says what failure to expect if the second step is skipped");
   // It also REPLACES the v2 API rather than adding to it, which the wording must not hide.
   assert.match(a, /REPLACES/, "the mutex, not additive");
 });

--- a/web/js/lib/manager-install.js
+++ b/web/js/lib/manager-install.js
@@ -846,13 +846,17 @@ export function unlistedGitUrlAdvice(failureText) {
     ` name. IF YOU PASSED A GIT URL: this ComfyUI-Manager cannot install one. It resolves` +
     ` installs from its own database, and the parameter that would carry a URL (repository)` +
     ` is accepted and then IGNORED by its install handler — so no argument to this tool will` +
-    ` make it clone your URL. WHAT WORKS, least effort first: clone the repo into` +
-    ` custom_nodes/ and restart ComfyUI; or ask the pack author to publish it to the` +
-    ` registry. There IS a legacy git-URL route, but reaching it takes TWO steps: start` +
-    ` ComfyUI with --enable-manager-legacy-ui (which REPLACES the v2 Manager API rather` +
-    ` than adding to it) AND set allow_git_url_install = true in ComfyUI-Manager's` +
-    ` config.ini — an unlisted pack is rated "high+" risk, and without that setting the` +
-    ` route answers 404 "A security error has occurred".` +
+    ` make it clone your URL. USE install_custom_node INSTEAD: that tool runs on the` +
+    ` machine rather than in this browser, and when the Manager cannot resolve a pack it` +
+    ` clones the repository into custom_nodes/ itself. It is the one path that installs an` +
+    ` unlisted URL — so this tool's usual "prefer me over the headless install_custom_node"` +
+    ` guidance does NOT hold for this case. Restart ComfyUI afterwards to load it.` +
+    ` If that is not available (a REMOTE target has no local tree to clone into, and it` +
+    ` keeps the Manager's error for that reason), the remaining options are to clone into` +
+    ` custom_nodes/ by hand, or ask the pack author to publish to the registry. A legacy` +
+    ` git-URL route also exists but needs TWO steps — --enable-manager-legacy-ui (which` +
+    ` REPLACES the v2 Manager API) AND allow_git_url_install = true in ComfyUI-Manager's` +
+    ` config.ini, without which an unlisted pack is rated "high+" risk and it answers 404.` +
     ` IF YOU MEANT A REGISTRY PACK: check the id and the channel/mode named in the brackets.`
   );
 }


### PR DESCRIPTION
Follow-up to the honest error shipped in 0.11.83. **The workaround was already in the codebase** — the message just did not know about it.

## The finding

`install_custom_node` runs on the machine, not in the browser. Its install path clones the repository into `custom_nodes/` when the Manager accepts a task but the pack never appears installed (`node-management.ts` → `cloneCustomNodeFallback`) — which is exactly the registry-miss this advice fires on.

So the answer to "this pack is unlisted" is not "clone it by hand". It is **use the other tool**.

## Why the message has to say it loudly

`panel_install_node`'s own description reads:

> Prefer this over the headless `install_custom_node` tool.

For this case that is backwards, and a reader who follows the tool description stays stuck. The advice now cancels the preference explicitly for the unlisted-URL case.

## And where it does not apply

A **remote** target has no local tree to clone into, and the orchestrator deliberately keeps the Manager's error there rather than writing to a machine that is not the server you are connected to. The advice says so — without that, it reads as a promise that always works.

## Verification

3467/3467 unit, typecheck clean, vocabulary gate clean.

Three mutations, each confirmed applied: drop the recommendation, keep the standing "prefer panel_install_node" guidance, drop the remote caveat — all killed.

The first one **initially survived**: my assertion matched `/install_custom_node/`, which still appears in the sentence cancelling the preference, so deleting the recommendation left it green. Tightened to assert the recommendation itself. That is the third time on this issue that an assertion matched something incidental rather than the thing it claimed to protect — worth naming, since it is clearly my recurring failure mode here.