### PR TITLE
docs(run-scope): replace a build-range claim this file disproves (#752)

### DIFF
--- a/web/js/lib/run-scope-guard.js
+++ b/web/js/lib/run-scope-guard.js
@@ -478,16 +478,34 @@ function bodyQueueMark(bodyText) {
  *
  * The previous single "scope_missing" verdict covered FOUR different states
  * and its message asserted one specific cause for all of them ("this frontend
- * build ignored the run-to-node argument"). That assertion is a BUCKET
- * narrated as a CAUSE, and the evidence says it is usually the wrong cause:
- * every ComfyUI_frontend build from 1.42 through 1.50 demonstrably accepts
- * BOTH `app.queuePrompt` third-argument shapes (the positional
- * `NodeExecutionId[]` natively on older builds, and on newer builds through an
- * `Array.isArray(optionsOrQueueNodeIds)` normalisation into
- * `{ queueNodeIds }`), and both funnel into `api.queuePrompt`'s
- * `options.partialExecutionTargets` → `body.partial_execution_targets`. Three
- * separate field reports on #556 pasted that asserted cause verbatim into the
- * tracker, which is precisely why the real cause is still unknown.
+ * That assertion is a BUCKET narrated as a CAUSE. Three separate field reports
+ * on #556 pasted that asserted cause verbatim into the tracker, which is
+ * precisely why the real cause stayed unknown for so long.
+ *
+ * #752 - this paragraph USED to continue: "every ComfyUI_frontend build from
+ * 1.42 through 1.50 demonstrably accepts BOTH third-argument shapes ... and both
+ * funnel into api.queuePrompt's options.partialExecutionTargets ->
+ * body.partial_execution_targets". It is FALSE on at least one build, and it was
+ * the same defect this paragraph is ABOUT: a claim about builds nobody here had
+ * run, stated as demonstrated.
+ *
+ * MEASURED on a live ComfyUI_frontend 1.48.7 - intercepting POST /prompt and
+ * BLOCKING it so nothing queued - calling app.queuePrompt(0, 1, third):
+ *
+ *   positional [id]             -> partial_execution_targets: ["9"]
+ *   { queueNodeIds: [id] }      -> partial_execution_targets: {"queueNodeIds":["9"]}
+ *   { partialExecutionTargets } -> partial_execution_targets: {"partialExecutionTargets":["9"]}
+ *
+ * The third argument is copied into the body VERBATIM; nothing unwraps an
+ * options object. So on that build only the positional shape yields a usable
+ * target list, and either options shape puts an OBJECT where the server expects
+ * an array. readScopeFromBody's `not_a_list` state is what catches it - which is
+ * why that state must stay: the KEY being present is not evidence the scope
+ * landed, and a presence-only check would have accepted a malformed body.
+ *
+ * Which builds honour which shape is still not something this file can assert.
+ * The shapes are tried in order and the emitted request is measured; that is the
+ * only claim available from inside one of them.
  *
  * So the states are now reported separately, the message states only what was
  * OBSERVED, and the body's top-level keys ride along as evidence.


### PR DESCRIPTION
**Docs only, and mostly a correction to my own claim on #752.**

## What I got wrong

I claimed this on the issue and started work, then found both of its asks were already done on main: the third `{ partialExecutionTargets }` shape was added, and the false build-range clause was removed from the user-facing message with a good explanation of why. That was the other session's work and I should have read the file before claiming.

## What is left, and it is real

The user-facing claim was removed. The **internal** one it was written from was not:

> every ComfyUI_frontend build from 1.42 through 1.50 demonstrably accepts BOTH `app.queuePrompt` third-argument shapes … and both funnel into `api.queuePrompt`'s `options.partialExecutionTargets` → `body.partial_execution_targets`

That sits three lines below the sentence explaining that asserting a cause you did not observe is the defect this module exists to avoid.

## Measured, on a live frontend

ComfyUI_frontend **1.48.7**, intercepting `POST /prompt` and **blocking** it so nothing queued:

```
positional [id]             -> partial_execution_targets: ["9"]
{ queueNodeIds: [id] }      -> partial_execution_targets: {"queueNodeIds":["9"]}
{ partialExecutionTargets } -> partial_execution_targets: {"partialExecutionTargets":["9"]}
```

The third argument is copied into the body **verbatim** — nothing unwraps an options object. So only the positional shape yields a usable target list on that build, and either options shape puts an object where the server expects an array.

## This validates the design rather than exposing a gap

Positional is tried first, and `readScopeFromBody`'s `not_a_list` state refuses the malformed body. The measurement is recorded next to that state because it is the evidence for why it must stay: **the key being present is not evidence the scope landed**, and a presence-only check would have accepted `{"queueNodeIds":[...]}` as a successful scope.

## Not claimed

Whether 1.45.20/1.45.21 behave the same — I do not have those builds, and asserting it would repeat the error being fixed. The issue now carries the probe so a reporter can settle it in one paste.

Docs only. 3467/3467 unit, typecheck clean, no control bytes.