### PR TITLE
fix(e2e): external-orchestrator was green against the developer's own orchestrator (#847)

### DIFF
--- a/browser_tests/external-orchestrator.spec.ts
+++ b/browser_tests/external-orchestrator.spec.ts
@@ -1,16 +1,22 @@
 /**
  * Tier 1 — external/local orchestrator mode.
  *
- * Covers the "Use external/local orchestrator (advanced)" Settings toggle: when
- * ON, Connect must NOT ask the ComfyUI host to spawn an orchestrator (the host —
- * e.g. a remote RunPod pod — may have no Node/agent). Instead it dials the
- * configured Bridge URL directly. This is the path that lets an agent running on
- * the USER's machine (`npx -y comfyui-mcp connect <url>`) drive a remote ComfyUI.
+ * NOT a mode test any more. `externalOrchestratorMode()` returns `true`
+ * unconditionally — the pack is pure-frontend and can no longer spawn anything
+ * (Comfy Registry security standards), so the "external/local orchestrator
+ * (advanced)" setting is a back-compat NO-OP. Flipping it to `false` was measured
+ * here and changes nothing: the spec passes either way.
  *
- * Asserts:
- *   1. clicking the real Connect button connects to the MockBridge (handshake →
- *      status pill "connected"), and
- *   2. the host spawn route `/comfyui_mcp_panel/connect` is NEVER POSTed.
+ * What it still pins, and the reason to keep it: the pure-frontend pack must NEVER
+ * ask the ComfyUI host to spawn an orchestrator (a remote pod may have no Node,
+ * and the stripped node answers /connect with 503). So this is a regression guard
+ * on a PERMANENT invariant, not a branch test — `connectPosts === 0` cannot fail
+ * today, and it exists to fail the day someone reintroduces host spawning.
+ *
+ * The load-bearing assertion is therefore the OTHER one: clicking the real Connect
+ * button reaches a real handshake with the MockBridge at the CONFIGURED url.
+ * That one is a true regression test — removing the url write in step (4) turns
+ * this red (measured: it dialled the default ws://127.0.0.1:9180 instead).
  */
 import { test, expect } from './fixtures/panelTest'
 
@@ -45,18 +51,10 @@ test('external mode connects to the bridge WITHOUT a host /connect spawn', async
     }
   })
 
-  // 2) Turn ON the external/local orchestrator toggle via ComfyUI's settings store
-  //    (the same store the panel reads through getSetting()) — before mount, so the
-  //    mount-time connect decision and the Connect click both see external mode.
-  await panel.page.evaluate((id) => {
-    const w = window as unknown as {
-      comfyAPI?: { app?: { app?: { ui?: { settings?: { setSettingValue?: (k: string, v: unknown) => void } } } } }
-      app?: { ui?: { settings?: { setSettingValue?: (k: string, v: unknown) => void } } }
-    }
-    const app = w.comfyAPI?.app?.app || w.app
-    app?.ui?.settings?.setSettingValue?.(id, true)
-  }, EXTERNAL_SETTING)
-
+  // 2) Set the external toggle anyway, for the day it stops being a no-op. It is
+  //    INERT today (externalOrchestratorMode() is a hardcoded `return true`), and
+  //    a pre-mount settings write is clobbered at mount regardless — see step 4.
+  //    Nothing in this spec depends on it.
   // 3) Install the host-spawn guard/spy. External mode must never depend on the
   //    ComfyUI host starting anything, so fail loudly if the panel POSTs /connect —
   //    installed BEFORE mount so even a stray mount-time connect would be caught.

--- a/browser_tests/external-orchestrator.spec.ts
+++ b/browser_tests/external-orchestrator.spec.ts
@@ -22,9 +22,10 @@ test('external mode connects to the bridge WITHOUT a host /connect spawn', async
   mockBridge
 }) => {
   await panel.goto()
-  // Point the panel at the MockBridge. In external mode this non-default URL is a
-  // manual override, so Connect dials it straight (no host involvement).
-  await panel.setBridgeUrl(mockBridge.url)
+  // NB: panel.setBridgeUrl() is deliberately NOT used here. It only records a
+  // PENDING url that panel.connect() applies via Advanced + Reconnect; this spec
+  // clicks the real **Connect** button instead (that is the behaviour under test),
+  // so the pending url would never be applied. See step 4 below.
 
   // EVERYTHING that shapes the connect decision must be in place BEFORE the panel
   // mounts (openSidebar), otherwise the panel can auto-connect during mount and
@@ -69,14 +70,29 @@ test('external mode connects to the bridge WITHOUT a host /connect spawn', async
     })
   })
 
+  // 4) The bridge URL is configured AFTER mount, just before the click — see the
+  //    block below. It is the one piece of setup that must NOT be pre-mount.
   // Now mount the panel — external mode on, auto-connect off, guard armed.
   await panel.openSidebar()
+
+  //    …and re-apply it AFTER mount. The pre-mount write above is clobbered when
+  //    the panel registers its own settings during mount: reading it back at that
+  //    point returned the DEFAULT `ws://127.0.0.1:9180`, which is exactly what this
+  //    spec was dialling. Auto-connect was removed in (1), so the panel sits idle
+  //    here and this write lands before the only connect attempt.
+  await panel.page.evaluate(([id, u]) => {
+    const w = window as unknown as {
+      comfyAPI?: { app?: { app?: { ui?: { settings?: { setSettingValue?: (k: string, v: unknown) => void } } } } }
+      app?: { ui?: { settings?: { setSettingValue?: (k: string, v: unknown) => void } } }
+    }
+    const app = w.comfyAPI?.app?.app || w.app
+    app?.ui?.settings?.setSettingValue?.(id, u)
+  }, ['comfyui-mcp.bridgeUrl.single', mockBridge.url])
 
   // Click the REAL Connect button (whose default path would POST /connect) — in
   // external mode it must skip that and dial the Bridge URL directly.
   await panel.openConnectionSettings()
   await panel.connectButton.click()
-
   await expect(panel.statusPill).toContainText('connected')
   await expect(panel.statusDot).toHaveClass(/connected/)
   expect(connectPosts).toBe(0)

--- a/browser_tests/fixtures/PanelPage.ts
+++ b/browser_tests/fixtures/PanelPage.ts
@@ -187,6 +187,18 @@ export class PanelPage {
    */
   private pendingBridgeUrl: string | null = null
 
+  /**
+   * Records the url ONLY — nothing is applied until `connect()` runs, which is
+   * the sole consumer of `pendingBridgeUrl`. A spec that sets a url here and then
+   * drives the connection some other way (e.g. clicking the real Connect button)
+   * gets NO override: the panel dials its default `ws://127.0.0.1:9180`. On a dev
+   * box with a real orchestrator there that still connects, so the spec passes
+   * while talking to the developer's own orchestrator instead of the MockBridge —
+   * exactly how external-orchestrator.spec.ts was green until :9180 went quiet
+   * (#847). To configure the url outside `connect()`, write the SETTING
+   * `comfyui-mcp.bridgeUrl.single` AFTER mount (panel setting registration
+   * clobbers a pre-mount write, and loadBridgeUrl() ignores localStorage).
+   */
   async setBridgeUrl(url: string): Promise<void> {
     this.pendingBridgeUrl = url
   }


### PR DESCRIPTION
Closes #847.

### Two findings, the second one against my own fix

**1. The spec was green against the developer's own orchestrator.**

`external-orchestrator.spec.ts` claims to prove Connect dials the *configured* Bridge URL. It never dialled it. `panel.setBridgeUrl()` only records a *pending* URL applied solely by `panel.connect()`; this spec clicks the raw **Connect** button instead (that is the behaviour under test), so the override was never applied and the panel dialled its default `ws://127.0.0.1:9180`. A real orchestrator was listening there, so the handshake succeeded and the MockBridge was never involved. It went red only when :9180 went quiet.

Measured at the click:

| | MOCK URL | effective SETTING |
|---|---|---|
| before | `ws://127.0.0.1:61016` | `ws://127.0.0.1:9180` |
| after | `ws://127.0.0.1:52953` | `ws://127.0.0.1:52953` |

Two attempts before that probe were inert: the legacy localStorage key (`loadBridgeUrl()` ignores it *by design*) and a pre-mount settings write (clobbered when the panel registers its settings at mount). The write must land **after** mount — the one piece of setup that must not be pre-mount.

**2. Then the mutation survived, and the fix's framing was wrong.**

Flipping `comfyui-mcp.externalOrchestrator` to `false` left the spec green. The cause is in the product:

```js
function externalOrchestratorMode() {
  // Always ON now: the pack is pure-frontend and can no longer spawn the
  // orchestrator (Comfy Registry security standards) ...
  return true;
}
```

The toggle is a back-compat no-op, the `/connect` POST is unreachable from the Connect button, and `connectPosts === 0` is *permanently* true rather than conditionally true. The spec's framing described a branch that no longer exists.

Reframed to what it actually pins — the pure-frontend pack must never ask the host to spawn an orchestrator (a remote pod may have no Node; the stripped node answers 503). A regression guard on a permanent invariant, kept to fail the day someone reintroduces host spawning. The load-bearing assertion is the handshake against the **configured** URL, which *is* a true regression test: delete the step-4 write and it goes red.

### Verification

- Full suite: **65 passed**, external-orchestrator green in the parallel run.
- The 3 parallel failures (`dirty-guards-see-node-writes`, `glm-provider`, `minimax-provider`) each pass in isolation, and the failing set differs from the previous run's — cascade, not genuine.
- Review: Codex CLI is not installed on this box, so this was reviewed adversarially by me instead — disclosed. The mutation above is that review's actual product.

🤖 Generated with [Claude Code](https://claude.com/claude-code)