### PR TITLE
fix(set_widget): say whose exception it was when a node's callback throws (#976)

### DIFF
--- a/browser_tests/unit/widget-write.test.mjs
+++ b/browser_tests/unit/widget-write.test.mjs
@@ -1214,7 +1214,7 @@ test("#366×#639: an INNER callback that throws AFTER the value landed is DISCLO
   assert.equal(parent.widgets[0].value, 704, "rail synced — never reported failed while applied");
   assert.match(
     set.write_warning ?? "",
-    /The exception \(inner boom\) came out of the widget's OWN callback/,
+    /The exception \(inner boom\) came from this \s*write's invocation of the widget's own callback/,
     "the throw is disclosed, not hidden — and #976 says which construct it came out of",
   );
   assert.equal(afterChangeRan, true, "afterChange still closes the envelope");
@@ -1366,7 +1366,7 @@ test("#366×#639: a THROWING afterChange hook does not bypass verification — a
   // effect and is disclosed, never reported as a clean failure (#639).
   assert.equal(inner.widgets[0].value, 704, "inner write stays");
   assert.equal(parent.widgets[0].value, 704, "rail synced");
-  assert.match(set.write_warning ?? "", /\(inner boom\) came out of the widget's OWN callback/);
+  assert.match(set.write_warning ?? "", /\(inner boom\) came from this write's invocation/);
   assert.equal(
     set.write_warning_source,
     "widget_callback",
@@ -2462,12 +2462,16 @@ test("#639: a throwing callback on a verified write is DISCLOSED (write_warning)
   // your write" and filed it here as a panel defect. The disclosure now leads with the
   // write having SUCCEEDED and names whose code threw.
   assert.match(set.write_warning, /^the write itself SUCCEEDED/, "leads with the outcome, not with the exception");
-  assert.match(set.write_warning, /came out of the\s+widget's OWN callback/, "says WHERE the exception came from");
+  assert.match(set.write_warning, /came from this write's invocation of the widget's own callback/, "says WHERE the exception came from");
   assert.match(
     set.write_warning,
-    /the\s+assignment did not throw/,
+    /the assignment itself did not throw/,
     "the distinction that stops this being read as a failed write",
   );
+  // codex NO-SHIP round 2: a non-callable value, a class constructor, a revoked Proxy
+  // and a throwing `apply` trap all throw at the invocation without entering a body,
+  // so the text must never say the callback executed.
+  assert.doesNotMatch(set.write_warning, /callback threw|the callback ran|callback executed/);
   assert.equal(set.write_warning_source, "widget_callback", "the attribution is DATA, not only prose");
   // codex NO-SHIP round 1: the first draft said the node supplies the callback and the
   // fault is the node's. Neither is establishable — a pack, an extension, a prototype
@@ -2573,6 +2577,106 @@ test("#976 (codex NO-SHIP 1): a poisoned `.call` on the callback neither throws 
   assert.equal(set.write_warning, undefined, "nothing threw, so nothing is disclosed");
 });
 
+test("#976 (codex NO-SHIP 2): a callback that throws `undefined` is still disclosed — a falsy throw is not a clean write", () => {
+  // `if (threw)` tested the thrown VALUE for truthiness, so `throw undefined` (also
+  // null, 0, "", false) produced no warning at all: the write reported clean while the
+  // callback's side effects had not run. Pre-existing, and it silently defeated the
+  // whole attribution for a callback that really did throw.
+  const node = {
+    id: 1,
+    type: "N",
+    widgets: [
+      {
+        name: "n",
+        type: "INT",
+        value: 1,
+        callback() {
+          throw undefined; // eslint-disable-line no-throw-literal
+        },
+      },
+    ],
+  };
+  const set = applyWidgetWrite(node, "n", 5, HOOKS);
+  assert.equal(node.widgets[0].value, 5, "the value is in effect");
+  assert.ok(typeof set.write_warning === "string", "a falsy throw is STILL a throw and is disclosed");
+  assert.match(set.write_warning, /non-Error value thrown: undefined/, "describes it instead of printing nothing");
+  assert.equal(set.write_warning_source, "widget_callback");
+});
+
+test("#976 (codex NO-SHIP 2): a CLASS constructor callback is attributed to the invocation, never described as having run", () => {
+  // `typeof class {} === "function"`, so this passes the callability check and then
+  // throws inside Reflect.apply ("Class constructor cannot be invoked without 'new'").
+  // Nothing of the class body executed — the wording must survive that.
+  let constructed = 0;
+  const node = {
+    id: 1,
+    type: "N",
+    widgets: [
+      {
+        name: "n",
+        type: "INT",
+        value: 1,
+        callback: class {
+          constructor() {
+            constructed += 1;
+          }
+        },
+      },
+    ],
+  };
+  const set = applyWidgetWrite(node, "n", 5, HOOKS);
+  assert.equal(constructed, 0, "no body ran");
+  assert.match(set.write_warning ?? "", /came from this write's invocation of the widget's own callback/);
+  assert.doesNotMatch(set.write_warning ?? "", /callback threw|the callback ran/, "never claims a body executed");
+  assert.equal(set.write_warning_source, "widget_callback");
+});
+
+test("#976 (codex NO-SHIP 2): a REVOKED Proxy callback is attributed to the invocation, and the write still verifies", () => {
+  const { proxy, revoke } = Proxy.revocable(function () {}, {});
+  revoke();
+  const node = { id: 1, type: "N", widgets: [{ name: "n", type: "INT", value: 1, callback: proxy }] };
+  const set = applyWidgetWrite(node, "n", 5, HOOKS);
+  assert.equal(node.widgets[0].value, 5, "the value landed before the invocation was attempted");
+  assert.match(set.write_warning ?? "", /came from this write's invocation of the widget's own callback/);
+  assert.equal(set.write_warning_source, "widget_callback");
+});
+
+test("#976 (codex NO-SHIP 2): a callable Proxy whose `apply` trap throws is attributed — the trap IS the callback's invocation", () => {
+  let targetRan = 0;
+  const proxy = new Proxy(
+    function () {
+      targetRan += 1;
+    },
+    {
+      apply() {
+        throw new Error("trap boom");
+      },
+    },
+  );
+  const node = { id: 1, type: "N", widgets: [{ name: "n", type: "INT", value: 1, callback: proxy }] };
+  const set = applyWidgetWrite(node, "n", 5, HOOKS);
+  assert.equal(targetRan, 0, "the trap replaced the target — its body never ran");
+  assert.match(set.write_warning ?? "", /trap boom/);
+  assert.equal(set.write_warning_source, "widget_callback", "the trap IS this callback's invocation behaviour");
+});
+
+test("#976 (codex NO-SHIP 2): a NON-CALLABLE callback plus a throwing `node.pos` reports the pos error, unattributed", () => {
+  // Precedence: the arguments are built before the invocation, so `pos` throws first
+  // and the callability of the callback is never reached. The disclosure must follow
+  // what actually threw, not what would have thrown next.
+  const node = {
+    id: 1,
+    type: "N",
+    get pos() {
+      throw new Error("pos boom");
+    },
+    widgets: [{ name: "n", type: "INT", value: 1, callback: { call() {} } }],
+  };
+  const set = applyWidgetWrite(node, "n", 5, HOOKS);
+  assert.match(set.write_warning ?? "", /^an exception was thrown while applying the write \(pos boom\)/);
+  assert.equal(set.write_warning_source, undefined, "the invocation was never attempted");
+});
+
 test("#976 (codex NO-SHIP 1): a NON-CALLABLE callback carrying its own `.call` method still throws, as it always did", () => {
   // The real regression behind the poisoned-`.call` finding: `{ call() {} }` is not
   // callable, and `w.callback?.(…)` threw for it. Invoking through `.call` would have
@@ -2591,6 +2695,12 @@ test("#976 (codex NO-SHIP 1): a NON-CALLABLE callback carrying its own `.call` m
   const node = { id: 1, type: "N", widgets: [w] };
   const set = applyWidgetWrite(node, "n", 5, HOOKS);
   assert.equal(impostorRan, 0, "a `.call` method on a non-function is NOT an invocation path");
+  assert.match(
+    set.write_warning ?? "",
+    /callback is a object, not a function, so it could not be invoked at all/,
+    "#976 round 2: says the establishable thing — it could not be entered, so nothing of it ran",
+  );
+  assert.doesNotMatch(set.write_warning ?? "", /assume a click/, "the programmatic-invocation caveat is irrelevant here");
   assert.ok(typeof set.write_warning === "string", "a non-callable callback still throws, and is still disclosed");
   assert.equal(set.write_warning_source, "widget_callback", "attributed: the callback the widget carries is unusable");
 });
@@ -2661,7 +2771,7 @@ test("#976: the panel's own graph_set_widget summary reads the attribution DATA,
   );
   assert.match(
     panelSrc,
-    /the exception came out of the widget's own callback, so its side effects may not have run/,
+    /the exception came from invoking the widget's own callback, so its side effects may not have run/,
     "the attributed summary line",
   );
   assert.match(
@@ -2711,7 +2821,7 @@ test("#639: a callback that throws AND leaves the write unverified still FAILS +
       err instanceof WidgetWriteError &&
       // #976: the failure branch is attributed too — the structural verdict is the
       // panel's, the exception that preceded it is the node's, and both are named.
-      /came out of the widget's OWN callback while applying the write \(combo boom\)/.test(err.message) &&
+      /came from invoking the widget's OWN callback while applying the write \(combo boom\)/.test(err.message) &&
       /did not retain the requested value/.test(err.message),
   );
   assert.equal(seenAtCallback, "a", "the requested value WAS assigned before the callback fired");
@@ -2739,7 +2849,7 @@ test("#639: a thrown WidgetWriteError on an unverified write keeps BOTH causes a
     (err) =>
       err instanceof WidgetWriteError &&
       err.combo === true && // the refresh-retry signal survives the composition
-      /came out of the widget's OWN callback while applying the write \(combo list went stale\)/.test(err.message) &&
+      /came from invoking the widget's OWN callback while applying the write \(combo list went stale\)/.test(err.message) &&
       /did not retain the requested value/.test(err.message),
   );
   assert.equal(node.widgets[0].value, "b", "rolled back");

--- a/browser_tests/unit/widget-write.test.mjs
+++ b/browser_tests/unit/widget-write.test.mjs
@@ -1214,8 +1214,8 @@ test("#366×#639: an INNER callback that throws AFTER the value landed is DISCLO
   assert.equal(parent.widgets[0].value, 704, "rail synced — never reported failed while applied");
   assert.match(
     set.write_warning ?? "",
-    /widget's OWN callback, which the node supplies and this write only invokes \(inner boom\)/,
-    "the throw is disclosed, not hidden — and #976 attributes it to the node's callback",
+    /The exception \(inner boom\) came out of the widget's OWN callback/,
+    "the throw is disclosed, not hidden — and #976 says which construct it came out of",
   );
   assert.equal(afterChangeRan, true, "afterChange still closes the envelope");
 });
@@ -1366,7 +1366,7 @@ test("#366×#639: a THROWING afterChange hook does not bypass verification — a
   // effect and is disclosed, never reported as a clean failure (#639).
   assert.equal(inner.widgets[0].value, 704, "inner write stays");
   assert.equal(parent.widgets[0].value, 704, "rail synced");
-  assert.match(set.write_warning ?? "", /widget's OWN callback[\s\S]*\(inner boom\)/);
+  assert.match(set.write_warning ?? "", /\(inner boom\) came out of the widget's OWN callback/);
   assert.equal(
     set.write_warning_source,
     "widget_callback",
@@ -2462,20 +2462,32 @@ test("#639: a throwing callback on a verified write is DISCLOSED (write_warning)
   // your write" and filed it here as a panel defect. The disclosure now leads with the
   // write having SUCCEEDED and names whose code threw.
   assert.match(set.write_warning, /^the write itself SUCCEEDED/, "leads with the outcome, not with the exception");
-  assert.match(set.write_warning, /widget's OWN callback/, "says WHOSE exception it was");
+  assert.match(set.write_warning, /came out of the\s+widget's OWN callback/, "says WHERE the exception came from");
   assert.match(
     set.write_warning,
-    /not in the panel's write/,
-    "states the negative explicitly — this is what stops it being filed as a panel defect",
+    /the\s+assignment did not throw/,
+    "the distinction that stops this being read as a failed write",
   );
   assert.equal(set.write_warning_source, "widget_callback", "the attribution is DATA, not only prose");
+  // codex NO-SHIP round 1: the first draft said the node supplies the callback and the
+  // fault is the node's. Neither is establishable — a pack, an extension, a prototype
+  // or the frontend may have installed it, and a programmatic invocation can be the
+  // whole reason it threw. Overshooting the attribution just relocates the wrong blame.
+  assert.doesNotMatch(set.write_warning, /fault/, "assigns no fault");
+  assert.doesNotMatch(set.write_warning, /the node supplies/, "does not claim who installed the callback");
+  assert.match(set.write_warning, /invocation is programmatic/, "names the one thing that could make it our doing");
 });
 
 // ---- #976 boundary: attribution is claimed ONLY for the invocation itself. The
 //      lookup of `w.callback` and the evaluation of the callback's arguments happen
 //      OUTSIDE the attributed span, because a throwing accessor and a throwing
 //      `node.pos` getter are not the callback failing — and blaming the node's
-//      callback for them is precisely the unestablishable claim #639 forbids. -----
+//      callback for them is precisely the unestablishable claim #639 forbids.
+//
+//      Several of these hold behaviour that ALREADY held before #976 (they pass
+//      against the old source too, which codex checked and said so). They are here as
+//      the boundary's regression fence, not as proof of the fix — the tests that prove
+//      the fix are the attributed ones above and the poisoned-`.call` pair below. -----
 
 test("#976 boundary: a throwing `callback` ACCESSOR is NOT attributed to the callback — it never ran", () => {
   const w = {
@@ -2518,6 +2530,69 @@ test("#976 boundary: a throwing `node.pos` GETTER is NOT attributed to the callb
   assert.equal(node.widgets[0].value, 5);
   assert.match(set.write_warning ?? "", /^an exception was thrown while applying the write \(pos boom\)/);
   assert.equal(set.write_warning_source, undefined, "no source claimed");
+});
+
+test("#976 (codex NO-SHIP 1): with NO callback, a throwing `node.pos` getter is never read — the write stays clean", () => {
+  // The optional-call form short-circuited: no callback meant no argument evaluation.
+  // Building the argument list before the nullish guard turned a clean verified write
+  // into a post-write exception warning for any node with a throwing `pos` getter.
+  let posReads = 0;
+  const node = {
+    id: 1,
+    type: "N",
+    get pos() {
+      posReads += 1;
+      throw new Error("pos boom");
+    },
+    widgets: [{ name: "n", type: "INT", value: 1 }], // no callback at all
+  };
+  const set = applyWidgetWrite(node, "n", 5, HOOKS);
+  assert.equal(posReads, 0, "`node.pos` is not touched when there is nothing to pass it to");
+  assert.equal(node.widgets[0].value, 5);
+  assert.equal(set.write_warning, undefined, "a clean write — nothing threw");
+  assert.equal(set.write_warning_source, undefined);
+});
+
+test("#976 (codex NO-SHIP 1): a poisoned `.call` on the callback neither throws nor steals the attribution", () => {
+  // Invoking via `widgetCallback.call(w, …)` reads `.call` OFF the callback, inside
+  // the attributed span — so a poisoned getter (or a Proxy `get` trap) threw where
+  // the callback had not run, and got reported as the callback's exception.
+  let ran = 0;
+  const cb = function () {
+    ran += 1;
+  };
+  Object.defineProperty(cb, "call", {
+    get() {
+      throw new Error("call getter boom");
+    },
+  });
+  const node = { id: 1, type: "N", widgets: [{ name: "n", type: "INT", value: 1, callback: cb }] };
+  const set = applyWidgetWrite(node, "n", 5, HOOKS);
+  assert.equal(ran, 1, "the callback itself ran — its `.call` property is irrelevant to invoking it");
+  assert.equal(node.widgets[0].value, 5);
+  assert.equal(set.write_warning, undefined, "nothing threw, so nothing is disclosed");
+});
+
+test("#976 (codex NO-SHIP 1): a NON-CALLABLE callback carrying its own `.call` method still throws, as it always did", () => {
+  // The real regression behind the poisoned-`.call` finding: `{ call() {} }` is not
+  // callable, and `w.callback?.(…)` threw for it. Invoking through `.call` would have
+  // run that object's method instead and reported a clean write.
+  let impostorRan = 0;
+  const w = {
+    name: "n",
+    type: "INT",
+    value: 1,
+    callback: {
+      call() {
+        impostorRan += 1;
+      },
+    },
+  };
+  const node = { id: 1, type: "N", widgets: [w] };
+  const set = applyWidgetWrite(node, "n", 5, HOOKS);
+  assert.equal(impostorRan, 0, "a `.call` method on a non-function is NOT an invocation path");
+  assert.ok(typeof set.write_warning === "string", "a non-callable callback still throws, and is still disclosed");
+  assert.equal(set.write_warning_source, "widget_callback", "attributed: the callback the widget carries is unusable");
 });
 
 test("#976: a callback that RETURNS normally leaves no attribution behind for a later throw", () => {
@@ -2586,7 +2661,7 @@ test("#976: the panel's own graph_set_widget summary reads the attribution DATA,
   );
   assert.match(
     panelSrc,
-    /the node's own widget callback threw, so its side effects may not have run/,
+    /the exception came out of the widget's own callback, so its side effects may not have run/,
     "the attributed summary line",
   );
   assert.match(
@@ -2636,7 +2711,7 @@ test("#639: a callback that throws AND leaves the write unverified still FAILS +
       err instanceof WidgetWriteError &&
       // #976: the failure branch is attributed too — the structural verdict is the
       // panel's, the exception that preceded it is the node's, and both are named.
-      /thrown by the widget's OWN callback while applying the write \(combo boom\)/.test(err.message) &&
+      /came out of the widget's OWN callback while applying the write \(combo boom\)/.test(err.message) &&
       /did not retain the requested value/.test(err.message),
   );
   assert.equal(seenAtCallback, "a", "the requested value WAS assigned before the callback fired");
@@ -2664,7 +2739,7 @@ test("#639: a thrown WidgetWriteError on an unverified write keeps BOTH causes a
     (err) =>
       err instanceof WidgetWriteError &&
       err.combo === true && // the refresh-retry signal survives the composition
-      /thrown by the widget's OWN callback while applying the write \(combo list went stale\)/.test(err.message) &&
+      /came out of the widget's OWN callback while applying the write \(combo list went stale\)/.test(err.message) &&
       /did not retain the requested value/.test(err.message),
   );
   assert.equal(node.widgets[0].value, "b", "rolled back");

--- a/browser_tests/unit/widget-write.test.mjs
+++ b/browser_tests/unit/widget-write.test.mjs
@@ -15,6 +15,7 @@
  */
 import test from "node:test";
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 
 import {
   applyWidgetWrite,
@@ -1211,7 +1212,11 @@ test("#366×#639: an INNER callback that throws AFTER the value landed is DISCLO
   // NOT rolled back: both inner and parent rail hold the new value (verified).
   assert.equal(inner.widgets[0].value, 704, "inner write stays — it took effect before the throw");
   assert.equal(parent.widgets[0].value, 704, "rail synced — never reported failed while applied");
-  assert.match(set.write_warning ?? "", /thrown while applying the write \(inner boom\)/, "the throw is disclosed, not hidden");
+  assert.match(
+    set.write_warning ?? "",
+    /widget's OWN callback, which the node supplies and this write only invokes \(inner boom\)/,
+    "the throw is disclosed, not hidden — and #976 attributes it to the node's callback",
+  );
   assert.equal(afterChangeRan, true, "afterChange still closes the envelope");
 });
 
@@ -1361,7 +1366,12 @@ test("#366×#639: a THROWING afterChange hook does not bypass verification — a
   // effect and is disclosed, never reported as a clean failure (#639).
   assert.equal(inner.widgets[0].value, 704, "inner write stays");
   assert.equal(parent.widgets[0].value, 704, "rail synced");
-  assert.match(set.write_warning ?? "", /thrown while applying the write \(inner boom\)/);
+  assert.match(set.write_warning ?? "", /widget's OWN callback[\s\S]*\(inner boom\)/);
+  assert.equal(
+    set.write_warning_source,
+    "widget_callback",
+    "a throwing afterChange hook does not steal the attribution from the callback that actually threw",
+  );
 });
 
 test("#366 HARD FAIL: an afterChange HOOK that re-stales the rail (after all callbacks) is still caught + rolled back", () => {
@@ -2446,9 +2456,144 @@ test("#639: a throwing callback on a verified write is DISCLOSED (write_warning)
   assert.equal(node.widgets[0].value, 10, "the write took effect and is NOT rolled back");
   assert.equal(set.value, 10);
   assert.ok(typeof set.write_warning === "string", "the throw is disclosed, never hidden");
-  assert.match(set.write_warning, /thrown while applying the write/, "the throw is disclosed, not hidden");
   assert.match(set.write_warning, /reading 'options'/, "carries the original error message");
   assert.match(set.write_warning, /IS in effect/, "says the requested value is present — never a clean-failure report");
+  // #976: the reporter read the old unattributed lede as "the panel failed to apply
+  // your write" and filed it here as a panel defect. The disclosure now leads with the
+  // write having SUCCEEDED and names whose code threw.
+  assert.match(set.write_warning, /^the write itself SUCCEEDED/, "leads with the outcome, not with the exception");
+  assert.match(set.write_warning, /widget's OWN callback/, "says WHOSE exception it was");
+  assert.match(
+    set.write_warning,
+    /not in the panel's write/,
+    "states the negative explicitly — this is what stops it being filed as a panel defect",
+  );
+  assert.equal(set.write_warning_source, "widget_callback", "the attribution is DATA, not only prose");
+});
+
+// ---- #976 boundary: attribution is claimed ONLY for the invocation itself. The
+//      lookup of `w.callback` and the evaluation of the callback's arguments happen
+//      OUTSIDE the attributed span, because a throwing accessor and a throwing
+//      `node.pos` getter are not the callback failing — and blaming the node's
+//      callback for them is precisely the unestablishable claim #639 forbids. -----
+
+test("#976 boundary: a throwing `callback` ACCESSOR is NOT attributed to the callback — it never ran", () => {
+  const w = {
+    name: "n",
+    type: "INT",
+    value: 1,
+    get callback() {
+      throw new Error("accessor boom");
+    },
+  };
+  const node = { id: 1, type: "N", widgets: [w] };
+  const set = applyWidgetWrite(node, "n", 5, HOOKS);
+  assert.equal(node.widgets[0].value, 5, "the value assignment ran before the accessor was read");
+  assert.match(set.write_warning ?? "", /^an exception was thrown while applying the write \(accessor boom\)/);
+  assert.equal(set.write_warning_source, undefined, "no source claimed — the callback function never executed");
+  assert.doesNotMatch(set.write_warning ?? "", /OWN callback/, "must not blame a callback that never ran");
+});
+
+test("#976 boundary: a throwing `node.pos` GETTER is NOT attributed to the callback — the args failed, not the node's code", () => {
+  let callbackRan = false;
+  const node = {
+    id: 1,
+    type: "N",
+    get pos() {
+      throw new Error("pos boom");
+    },
+    widgets: [
+      {
+        name: "n",
+        type: "INT",
+        value: 1,
+        callback() {
+          callbackRan = true;
+        },
+      },
+    ],
+  };
+  const set = applyWidgetWrite(node, "n", 5, HOOKS);
+  assert.equal(callbackRan, false, "the argument list is evaluated before the call, so the callback never ran");
+  assert.equal(node.widgets[0].value, 5);
+  assert.match(set.write_warning ?? "", /^an exception was thrown while applying the write \(pos boom\)/);
+  assert.equal(set.write_warning_source, undefined, "no source claimed");
+});
+
+test("#976: a callback that RETURNS normally leaves no attribution behind for a later throw", () => {
+  // The flag is raised around the invocation and cleared when it returns. If it were
+  // only ever raised, every subsequent throw in the envelope would be mis-blamed on a
+  // callback that completed successfully. Nothing in this envelope throws after the
+  // callback today; this pins the clear so that stays true when something does.
+  let callbackRan = false;
+  const node = {
+    id: 1,
+    type: "N",
+    widgets: [
+      {
+        name: "n",
+        type: "INT",
+        value: 1,
+        callback() {
+          callbackRan = true;
+        },
+      },
+    ],
+  };
+  const set = applyWidgetWrite(node, "n", 5, HOOKS);
+  assert.equal(callbackRan, true);
+  assert.equal(set.write_warning, undefined, "a clean write discloses nothing");
+  assert.equal(set.write_warning_source, undefined);
+});
+
+test("#976: the callback is still invoked with the widget as `this` and the same five arguments", () => {
+  // The attributed call binds explicitly (`cb.call(w, …)`) where the original used
+  // `w.callback?.(…)`. Both bind `this` to the widget and callbacks read `this.value`
+  // — a regression here would silently break every node that does.
+  let seenThis = null;
+  let seenArgs = null;
+  const canvas = { marker: "canvas" };
+  const w = {
+    name: "n",
+    type: "INT",
+    value: 1,
+    callback(...args) {
+      seenThis = this;
+      seenArgs = args;
+    },
+  };
+  const node = { id: 7, type: "N", pos: [10, 20], widgets: [w] };
+  applyWidgetWrite(node, "n", 5, { canvas });
+  assert.equal(seenThis, w, "`this` is the widget");
+  assert.equal(seenArgs.length, 5);
+  assert.equal(seenArgs[0], 5, "the coerced value");
+  assert.equal(seenArgs[1], canvas);
+  assert.equal(seenArgs[2], node);
+  assert.deepEqual(seenArgs[3], [10, 20], "node.pos");
+  assert.equal(seenArgs[4], undefined);
+});
+
+test("#976: the panel's own graph_set_widget summary reads the attribution DATA, and still has its unattributed fallback", () => {
+  // The lib's prose is what an AGENT reads; the summary line is what the USER reads,
+  // and it repeated the same "an exception was thrown while applying it" lede. This
+  // asserts the SHIPPED panel source (the summariser lives inside the monolith's
+  // switch and is not importable), so deleting either branch fails here.
+  const panelSrc = readFileSync(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8");
+  assert.match(
+    panelSrc,
+    /r\.set\?\.write_warning_source === "widget_callback"/,
+    "reads the structured field — never pattern-matches the warning prose",
+  );
+  assert.match(
+    panelSrc,
+    /the node's own widget callback threw, so its side effects may not have run/,
+    "the attributed summary line",
+  );
+  assert.match(
+    panelSrc,
+    /an exception was thrown while applying it; side effects may not have run or completed/,
+    "the unattributed line SURVIVES — an unrecognised source must degrade to it, not mis-attribute",
+  );
 });
 
 test("#639: a promoted write whose inner callback throws still discloses success when inner + rail both verify", () => {
@@ -2489,7 +2634,9 @@ test("#639: a callback that throws AND leaves the write unverified still FAILS +
     () => applyWidgetWrite(node, "c", "a", HOOKS),
     (err) =>
       err instanceof WidgetWriteError &&
-      /thrown while applying the write \(combo boom\)/.test(err.message) &&
+      // #976: the failure branch is attributed too — the structural verdict is the
+      // panel's, the exception that preceded it is the node's, and both are named.
+      /thrown by the widget's OWN callback while applying the write \(combo boom\)/.test(err.message) &&
       /did not retain the requested value/.test(err.message),
   );
   assert.equal(seenAtCallback, "a", "the requested value WAS assigned before the callback fired");
@@ -2517,7 +2664,7 @@ test("#639: a thrown WidgetWriteError on an unverified write keeps BOTH causes a
     (err) =>
       err instanceof WidgetWriteError &&
       err.combo === true && // the refresh-retry signal survives the composition
-      /thrown while applying the write \(combo list went stale\)/.test(err.message) &&
+      /thrown by the widget's OWN callback while applying the write \(combo list went stale\)/.test(err.message) &&
       /did not retain the requested value/.test(err.message),
   );
   assert.equal(node.widgets[0].value, "b", "rolled back");
@@ -2547,9 +2694,10 @@ test("#639: a throwing value SETTER on a verified write is disclosed without une
   assert.match(set.write_warning ?? "", /IS in effect/);
   assert.doesNotMatch(
     set.write_warning ?? "",
-    /never ran|after applying|callback threw|setter threw/,
+    /never ran|after applying|callback threw|setter threw|OWN callback/,
     "names NO construct — the mechanism cannot establish which one threw (codex delta-gate)",
   );
+  assert.equal(set.write_warning_source, undefined, "#976: no source claimed for a throw outside the invocation");
 });
 
 test("#639: a REENTRANT setter (one that invokes the callback, which throws) gets the same attribution-free wording", () => {
@@ -2578,6 +2726,11 @@ test("#639: a REENTRANT setter (one that invokes the callback, which throws) get
   assert.match(set.write_warning ?? "", /thrown while applying the write/);
   assert.match(set.write_warning ?? "", /reentrant boom/);
   assert.doesNotMatch(set.write_warning ?? "", /callback never ran|after applying|callback threw|setter threw/);
+  // #976: the callback DID run and DID throw here — but the throw surfaced from the
+  // ASSIGNMENT, before the attributed span was entered, so nothing may be claimed.
+  // This is the case that keeps the attribution honest rather than merely plausible.
+  assert.doesNotMatch(set.write_warning ?? "", /OWN callback/);
+  assert.equal(set.write_warning_source, undefined);
 });
 
 test("#667×#507: a numeric request against a numeric-LABELLED rail option is ADOPTED on the empty-inner-list path (codex round-3)", () => {
@@ -2683,6 +2836,7 @@ test("#639 (delta-gate 2): a FROZEN widget already holding the requested value r
   assert.match(set.write_warning ?? "", /thrown while applying the write/);
   assert.match(set.write_warning ?? "", /IS in effect/);
   assert.doesNotMatch(set.write_warning ?? "", /DID take effect/);
+  assert.equal(set.write_warning_source, undefined, "#976: a frozen widget throws with no node code involved");
 });
 
 test("#667×#507 (delta-gate 2): re-validation checks the SAME list snapshot as admission — a stateful non-function source cannot cause a false DISAGREE", () => {

--- a/browser_tests/unit/widget-write.test.mjs
+++ b/browser_tests/unit/widget-write.test.mjs
@@ -2649,6 +2649,12 @@ test("#976 (codex NO-SHIP 3): the detail text renders exactly what it rendered b
   assert.doesNotMatch(detailFor(new Error("")), /non-Error/, "an Error is never labelled a non-Error value");
   assert.match(detailFor({ message: 0 }), /The exception \(0\) came from/, "a non-string message renders as before");
   assert.match(detailFor("boom"), /The exception \(boom\) came from/, "a thrown string renders as itself");
+  // codex round 4: the ONE place it is deliberately NOT equivalent. Implicit coercion
+  // of a Symbol throws, so the old `${threw?.message ?? threw}` blew up inside the
+  // reporting path — the throw that reports a throw. `String()` is explicit and does
+  // not, so this is now describable instead of fatal.
+  assert.match(detailFor(Symbol("sym boom")), /The exception \(Symbol\(sym boom\)\) came from/);
+  assert.match(detailFor({ message: Symbol("msg boom") }), /The exception \(Symbol\(msg boom\)\) came from/);
 });
 
 test("#976 (codex NO-SHIP 3): a HOSTILE thrown value cannot break the report that exists to disclose it", () => {

--- a/browser_tests/unit/widget-write.test.mjs
+++ b/browser_tests/unit/widget-write.test.mjs
@@ -1214,7 +1214,7 @@ test("#366×#639: an INNER callback that throws AFTER the value landed is DISCLO
   assert.equal(parent.widgets[0].value, 704, "rail synced — never reported failed while applied");
   assert.match(
     set.write_warning ?? "",
-    /The exception \(inner boom\) came from this \s*write's invocation of the widget's own callback/,
+    /The exception \(inner boom\) came from this \s*write's attempt to invoke the widget's own callback/,
     "the throw is disclosed, not hidden — and #976 says which construct it came out of",
   );
   assert.equal(afterChangeRan, true, "afterChange still closes the envelope");
@@ -1366,7 +1366,7 @@ test("#366×#639: a THROWING afterChange hook does not bypass verification — a
   // effect and is disclosed, never reported as a clean failure (#639).
   assert.equal(inner.widgets[0].value, 704, "inner write stays");
   assert.equal(parent.widgets[0].value, 704, "rail synced");
-  assert.match(set.write_warning ?? "", /\(inner boom\) came from this write's invocation/);
+  assert.match(set.write_warning ?? "", /\(inner boom\) came from this write's attempt to invoke/);
   assert.equal(
     set.write_warning_source,
     "widget_callback",
@@ -2462,7 +2462,7 @@ test("#639: a throwing callback on a verified write is DISCLOSED (write_warning)
   // your write" and filed it here as a panel defect. The disclosure now leads with the
   // write having SUCCEEDED and names whose code threw.
   assert.match(set.write_warning, /^the write itself SUCCEEDED/, "leads with the outcome, not with the exception");
-  assert.match(set.write_warning, /came from this write's invocation of the widget's own callback/, "says WHERE the exception came from");
+  assert.match(set.write_warning, /came from this write's attempt to invoke the widget's own callback/, "says WHERE the exception came from");
   assert.match(
     set.write_warning,
     /the assignment itself did not throw/,
@@ -2479,7 +2479,7 @@ test("#639: a throwing callback on a verified write is DISCLOSED (write_warning)
   // whole reason it threw. Overshooting the attribution just relocates the wrong blame.
   assert.doesNotMatch(set.write_warning, /fault/, "assigns no fault");
   assert.doesNotMatch(set.write_warning, /the node supplies/, "does not claim who installed the callback");
-  assert.match(set.write_warning, /invocation is programmatic/, "names the one thing that could make it our doing");
+  assert.match(set.write_warning, /invokes callbacks programmatically/, "names the one thing that could make it our doing");
 });
 
 // ---- #976 boundary: attribution is claimed ONLY for the invocation itself. The
@@ -2599,8 +2599,99 @@ test("#976 (codex NO-SHIP 2): a callback that throws `undefined` is still disclo
   const set = applyWidgetWrite(node, "n", 5, HOOKS);
   assert.equal(node.widgets[0].value, 5, "the value is in effect");
   assert.ok(typeof set.write_warning === "string", "a falsy throw is STILL a throw and is disclosed");
-  assert.match(set.write_warning, /non-Error value thrown: undefined/, "describes it instead of printing nothing");
+  assert.match(set.write_warning, /a non-Error value was thrown: undefined/, "describes it instead of printing nothing");
   assert.equal(set.write_warning_source, "widget_callback");
+});
+
+test("#976 (codex NO-SHIP 2): `throw null` is disclosed too — null was the old sentinel value for 'nothing was thrown'", () => {
+  const node = {
+    id: 1,
+    type: "N",
+    widgets: [
+      {
+        name: "n",
+        type: "INT",
+        value: 1,
+        callback() {
+          throw null; // eslint-disable-line no-throw-literal
+        },
+      },
+    ],
+  };
+  const set = applyWidgetWrite(node, "n", 5, HOOKS);
+  assert.ok(typeof set.write_warning === "string", "the sentinel collision must not read as 'nothing was thrown'");
+  assert.match(set.write_warning, /a non-Error value was thrown: null/);
+  assert.equal(set.write_warning_source, "widget_callback");
+});
+
+test("#976 (codex NO-SHIP 3): the detail text renders exactly what it rendered before for real Errors and odd shapes", () => {
+  // describeThrown replaced `${threw?.message ?? threw}`. Round 3 caught a first draft
+  // that labelled `new Error("")` as a non-Error value — factually false — and
+  // stringified `{ message: 0 }` whole. These pin the equivalence.
+  const detailFor = (thrown) => {
+    const node = {
+      id: 1,
+      type: "N",
+      widgets: [
+        {
+          name: "n",
+          type: "INT",
+          value: 1,
+          callback() {
+            throw thrown;
+          },
+        },
+      ],
+    };
+    return applyWidgetWrite(node, "n", 5, HOOKS).write_warning ?? "";
+  };
+  assert.match(detailFor(new Error("")), /The exception \(\) came from/, "an empty Error message stays empty");
+  assert.doesNotMatch(detailFor(new Error("")), /non-Error/, "an Error is never labelled a non-Error value");
+  assert.match(detailFor({ message: 0 }), /The exception \(0\) came from/, "a non-string message renders as before");
+  assert.match(detailFor("boom"), /The exception \(boom\) came from/, "a thrown string renders as itself");
+});
+
+test("#976 (codex NO-SHIP 3): a HOSTILE thrown value cannot break the report that exists to disclose it", () => {
+  // A Proxy whose `message` getter throws AND whose `getPrototypeOf` trap throws:
+  // `describeThrown` must not throw, and `instanceof WidgetWriteError` must not either
+  // — that classification runs while composing a failure we ALREADY know, and letting
+  // it escape would lose the failure entirely.
+  const hostile = new Proxy(
+    {},
+    {
+      get(_t, prop) {
+        if (prop === "message" || prop === "combo" || prop === "emptyOptions") throw new Error("getter boom");
+        return undefined;
+      },
+      getPrototypeOf() {
+        throw new Error("proto boom");
+      },
+    },
+  );
+  const node = {
+    id: 1,
+    type: "N",
+    widgets: [
+      {
+        name: "c",
+        options: { values: ["a", "b", "c"] },
+        value: "b",
+        callback() {
+          this.value = "c"; // drift so verification FAILS and the composition branch runs
+          throw hostile;
+        },
+      },
+    ],
+  };
+  assert.throws(
+    () => applyWidgetWrite(node, "c", "a", HOOKS),
+    (err) =>
+      err instanceof WidgetWriteError &&
+      /a thrown value that could not be described/.test(err.message) &&
+      /did not retain the requested value/.test(err.message),
+    "the structural failure survives a thrown value that fights back",
+  );
+  assert.equal(node.widgets[0].value, "b", "still rolled back");
 });
 
 test("#976 (codex NO-SHIP 2): a CLASS constructor callback is attributed to the invocation, never described as having run", () => {
@@ -2626,7 +2717,7 @@ test("#976 (codex NO-SHIP 2): a CLASS constructor callback is attributed to the 
   };
   const set = applyWidgetWrite(node, "n", 5, HOOKS);
   assert.equal(constructed, 0, "no body ran");
-  assert.match(set.write_warning ?? "", /came from this write's invocation of the widget's own callback/);
+  assert.match(set.write_warning ?? "", /came from this write's attempt to invoke the widget's own callback/);
   assert.doesNotMatch(set.write_warning ?? "", /callback threw|the callback ran/, "never claims a body executed");
   assert.equal(set.write_warning_source, "widget_callback");
 });
@@ -2637,7 +2728,12 @@ test("#976 (codex NO-SHIP 2): a REVOKED Proxy callback is attributed to the invo
   const node = { id: 1, type: "N", widgets: [{ name: "n", type: "INT", value: 1, callback: proxy }] };
   const set = applyWidgetWrite(node, "n", 5, HOOKS);
   assert.equal(node.widgets[0].value, 5, "the value landed before the invocation was attempted");
-  assert.match(set.write_warning ?? "", /came from this write's invocation of the widget's own callback/);
+  assert.match(set.write_warning ?? "", /came from this write's attempt to invoke the widget's own callback/);
+  assert.doesNotMatch(
+    set.write_warning ?? "",
+    /callback threw|the callback ran|which runs AFTER/,
+    "a revoked Proxy passes `typeof === 'function'` and then throws before any target code — nothing ran",
+  );
   assert.equal(set.write_warning_source, "widget_callback");
 });
 
@@ -2821,7 +2917,7 @@ test("#639: a callback that throws AND leaves the write unverified still FAILS +
       err instanceof WidgetWriteError &&
       // #976: the failure branch is attributed too — the structural verdict is the
       // panel's, the exception that preceded it is the node's, and both are named.
-      /came from invoking the widget's OWN callback while applying the write \(combo boom\)/.test(err.message) &&
+      /came from attempting to invoke the widget's OWN callback while applying the write \(combo boom\)/.test(err.message) &&
       /did not retain the requested value/.test(err.message),
   );
   assert.equal(seenAtCallback, "a", "the requested value WAS assigned before the callback fired");
@@ -2849,7 +2945,7 @@ test("#639: a thrown WidgetWriteError on an unverified write keeps BOTH causes a
     (err) =>
       err instanceof WidgetWriteError &&
       err.combo === true && // the refresh-retry signal survives the composition
-      /came from invoking the widget's OWN callback while applying the write \(combo list went stale\)/.test(err.message) &&
+      /came from attempting to invoke the widget's OWN callback while applying the write \(combo list went stale\)/.test(err.message) &&
       /did not retain the requested value/.test(err.message),
   );
   assert.equal(node.widgets[0].value, "b", "rolled back");

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -18234,7 +18234,14 @@ function describeCommand(cmd, msg, reply) {
       // names NO construct: `write_warning` covers a throwing setter, accessor, or
       // callback on any of the widgets the write touches, so it must not assert
       // which one threw (codex delta-gate).
+      //
+      // #976: unless the lib says which — `write_warning_source` is DATA the lib only
+      // emits for the case it can establish, so this reads the field rather than
+      // pattern-matching the prose. Any other value (or none) keeps the unattributed
+      // wording, so a future source the summary does not know about degrades to the
+      // line it already showed.
       const writeDisclosed = typeof r.set?.write_warning === "string";
+      const threwInNodeCallback = r.set?.write_warning_source === "widget_callback";
       return railStale
         ? {
             icon: "pi-exclamation-triangle",
@@ -18246,7 +18253,9 @@ function describeCommand(cmd, msg, reply) {
             text:
               `Set ${r.set?.widget} = ${JSON.stringify(r.set?.value)} on node ${r.set?.node_id}` +
               (writeDisclosed
-                ? ` — requested value verified in effect, but an exception was thrown while applying it; side effects may not have run or completed`
+                ? threwInNodeCallback
+                  ? ` — value verified in effect; the node's own widget callback threw, so its side effects may not have run`
+                  : ` — requested value verified in effect, but an exception was thrown while applying it; side effects may not have run or completed`
                 : ""),
             detail: `was ${JSON.stringify(r.set?.previous)}`,
           };

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -18256,7 +18256,7 @@ function describeCommand(cmd, msg, reply) {
               `Set ${r.set?.widget} = ${JSON.stringify(r.set?.value)} on node ${r.set?.node_id}` +
               (writeDisclosed
                 ? threwInNodeCallback
-                  ? ` — value verified in effect; the exception came out of the widget's own callback, so its side effects may not have run`
+                  ? ` — value verified in effect; the exception came from invoking the widget's own callback, so its side effects may not have run`
                   : ` — requested value verified in effect, but an exception was thrown while applying it; side effects may not have run or completed`
                 : ""),
             detail: `was ${JSON.stringify(r.set?.previous)}`,

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -18239,7 +18239,9 @@ function describeCommand(cmd, msg, reply) {
       // emits for the case it can establish, so this reads the field rather than
       // pattern-matching the prose. Any other value (or none) keeps the unattributed
       // wording, so a future source the summary does not know about degrades to the
-      // line it already showed.
+      // line it already showed. The attributed line says where the exception came
+      // FROM and stops there; it does not assign fault, because this write invokes
+      // the callback programmatically and that alone can be why it threw.
       const writeDisclosed = typeof r.set?.write_warning === "string";
       const threwInNodeCallback = r.set?.write_warning_source === "widget_callback";
       return railStale
@@ -18254,7 +18256,7 @@ function describeCommand(cmd, msg, reply) {
               `Set ${r.set?.widget} = ${JSON.stringify(r.set?.value)} on node ${r.set?.node_id}` +
               (writeDisclosed
                 ? threwInNodeCallback
-                  ? ` — value verified in effect; the node's own widget callback threw, so its side effects may not have run`
+                  ? ` — value verified in effect; the exception came out of the widget's own callback, so its side effects may not have run`
                   : ` — requested value verified in effect, but an exception was thrown while applying it; side effects may not have run or completed`
                 : ""),
             detail: `was ${JSON.stringify(r.set?.previous)}`,

--- a/web/js/lib/widget-write.js
+++ b/web/js/lib/widget-write.js
@@ -1176,6 +1176,11 @@ export function applyWidgetWrite(
   // fired its hooks: an afterChange hook can itself re-stale a widget or change the
   // promotion topology, and that must be caught too (not just callback-time drift).
   let threw = null;
+  // #976: TRUE only while the widget's own callback function is executing. It is the
+  // one construct in this envelope whose throw the mechanism can ATTRIBUTE, and only
+  // because the lookup and the argument evaluation are hoisted out of it below — see
+  // the note there. Everything else stays unattributed, exactly as #639 requires.
+  let threwFromCallback = false;
   safeBefore();
   try {
     // Assign BOTH values first. The parent's projected promoted widget is a VIEW of
@@ -1192,14 +1197,33 @@ export function applyWidgetWrite(
     for (const dw of displayWidgets) dw.value = coerced;
     // Fire the inner widget's own callback so combo/number side effects run — the
     // same single invocation a manual UI edit of the promoted control performs.
-    w.callback?.(coerced, canvas, targetNode, targetNode.pos, undefined);
+    //
+    // #976: the lookup and the arguments are evaluated BEFORE `threwFromCallback` is
+    // raised, and deliberately so. `w.callback` may be a throwing ACCESSOR and
+    // `targetNode.pos` a GETTER; neither of those is the callback failing, and
+    // blaming the node's callback for them would be exactly the unestablishable
+    // attribution #639 forbids. Only the invocation itself carries the flag.
+    //
+    // The call is bound explicitly because the original `w.callback?.(…)` form binds
+    // `this` to the widget and callbacks read `this.value`. A non-null callback that
+    // is not callable still throws a TypeError from this same point (from `.call`),
+    // which is attributable to the callback the node supplied.
+    const widgetCallback = w.callback;
+    const callbackArgs = [coerced, canvas, targetNode, targetNode.pos, undefined];
+    if (widgetCallback !== null && widgetCallback !== undefined) {
+      threwFromCallback = true;
+      widgetCallback.call(w, ...callbackArgs);
+      threwFromCallback = false; // reached only when it RETURNED — a throw leaves it set
+    }
   } catch (err) {
-    // #639 (codex round-3 + delta-gate): WHICH construct threw is NOT recorded — a
-    // value setter can invoke the callback itself, `w.callback` can be a throwing
-    // accessor, a setter can throw before OR after applying, a rail/proxy setter
-    // or a `targetNode.pos` getter can throw, and a write to a frozen widget
-    // throws with no user code at all — so no attribution the mechanism cannot
-    // establish is ever reported. The disclosure below names none of them.
+    // #639 (codex round-3 + delta-gate): WHICH construct threw is not recorded for
+    // anything but the callback invocation — a value setter can invoke the callback
+    // itself, `w.callback` can be a throwing accessor, a setter can throw before OR
+    // after applying, a rail/proxy setter or a `targetNode.pos` getter can throw,
+    // and a write to a frozen widget throws with no user code at all. For every one
+    // of those `threwFromCallback` is FALSE and the disclosure names no construct,
+    // unchanged. #976 adds the single case the mechanism CAN establish: the throw
+    // propagated out of calling the widget's own callback function.
     threw = err;
   } finally {
     safeAfter();
@@ -1328,23 +1352,41 @@ export function applyWidgetWrite(
   // ESTABLISH is claimed. The write envelope evaluates value setters on the inner,
   // rail, and display proxies, property reads (`w.callback` may be a throwing
   // accessor, `targetNode.pos` a getter), and the callback invocation — and a
-  // plain write to a frozen widget throws with NO user code involved. So the
-  // message does not name ANY construct: only that an exception was thrown while
+  // plain write to a frozen widget throws with NO user code involved. So for all of
+  // those the message names NO construct: only that an exception was thrown while
   // applying the write. And read-back verifies only that the requested value IS
   // present — not that THIS write put it there (a frozen widget may already have
   // held it), so the disclosure claims "IS in effect", never "DID take effect".
   // What IS established and claimed: the requested value is present by read-back,
   // and the write's side effects may not have run or completed.
+  //
+  // #976: the callback INVOCATION is the one construct that is establishable, once
+  // its lookup and arguments are hoisted out of it (see the envelope above) — and
+  // naming it matters, because the unattributed wording leads with "an exception was
+  // thrown while applying the write", which reads as THE PANEL FAILED TO APPLY YOUR
+  // WRITE. That is the opposite of what happened, and #976 was filed here as a panel
+  // defect because of it. When the node's own callback is what threw, the disclosure
+  // leads with the write having succeeded and says whose code threw. Same facts, and
+  // an agent reading it stops treating an applied write as a failed one.
   if (threw) {
-    const threwLabel = "an exception was thrown while applying the write";
+    const threwDetail = threw?.message ?? threw;
+    const threwLabel = threwFromCallback
+      ? `an exception was thrown by the widget's OWN callback while applying the write`
+      : `an exception was thrown while applying the write`;
     if (!failure) {
-      writeWarning =
-        `${threwLabel} (${threw?.message ?? threw}); the requested value IS in effect — ` +
-        `verified present by read-back — and was NOT rolled back. Side effects the write ` +
-        `would normally trigger (refreshing dependent widgets, previews, thumbnails) may ` +
-        `not have run or completed; inspect the node if dependents look stale.`;
+      writeWarning = threwFromCallback
+        ? `the write itself SUCCEEDED: the requested value IS in effect — verified present by ` +
+          `read-back — and was NOT rolled back. What threw is the widget's OWN callback, which ` +
+          `the node supplies and this write only invokes (${threwDetail}) — the fault is in that ` +
+          `node's code, not in the panel's write. Side effects that callback would normally ` +
+          `perform (refreshing dependent widgets, previews, thumbnails) may not have run or ` +
+          `completed; inspect the node if dependents look stale.`
+        : `${threwLabel} (${threwDetail}); the requested value IS in effect — ` +
+          `verified present by read-back — and was NOT rolled back. Side effects the write ` +
+          `would normally trigger (refreshing dependent widgets, previews, thumbnails) may ` +
+          `not have run or completed; inspect the node if dependents look stale.`;
     } else {
-      failure = `${threwLabel} (${threw?.message ?? threw}); ${failure}`;
+      failure = `${threwLabel} (${threwDetail}); ${failure}`;
       if (threw instanceof WidgetWriteError) {
         originalErr = new WidgetWriteError(failure, {
           combo: threw.combo,
@@ -1563,12 +1605,20 @@ export function applyWidgetWrite(
   // proxies also synced so the outer node no longer shows a stale value (#477).
   // #639: write_warning discloses a widget callback that threw AFTER the verified
   // write landed — the value IS in effect, its side effects are uncertain.
+  // #976: `write_warning_source` carries the attribution as DATA, so a caller does not
+  // have to pattern-match prose to render it. Present ONLY for the establishable case;
+  // its absence means "not attributable", never "the panel's fault".
   return {
     node_id: targetNode.id,
     widget: w.name,
     previous: parentWidget ? previousParent : previous,
     value: w.value,
-    ...(writeWarning ? { write_warning: writeWarning } : {}),
+    ...(writeWarning
+      ? {
+          write_warning: writeWarning,
+          ...(threwFromCallback ? { write_warning_source: "widget_callback" } : {}),
+        }
+      : {}),
     // #805 — the write applied and the node quantized it. Report BOTH values so the
     // caller can carry the stored one forward instead of retrying the request.
     ...(normalization

--- a/web/js/lib/widget-write.js
+++ b/web/js/lib/widget-write.js
@@ -14,15 +14,19 @@ const reflectApply = Reflect.apply;
 /**
  * #976: describe a thrown value for a disclosure message.
  *
- * `throw` accepts any value, so `.message` may be absent, empty, or itself a getter
- * that throws — and interpolating a value whose `toString` throws would blow up the
- * disclosure that exists to report a throw. Total by construction.
+ * Renders EXACTLY what `${threw?.message ?? threw}` rendered before — `new Error("")`
+ * still yields an empty detail, a thrown string still yields itself, `{ message: 0 }`
+ * still yields `0` — and adds only the two things that were missing: nullish throws
+ * (which the old truthiness test never reached) and totality. `throw` accepts any
+ * value, so `.message` may be a getter that throws and `toString` may throw, and a
+ * disclosure that exists to REPORT a throw must not itself throw (codex round 3).
  */
 function describeThrown(err) {
+  // The one case where a label is warranted: there is nothing else to print, and
+  // "(undefined)" alone reads like a bug in the reporting rather than the thrown value.
+  if (err === null || err === undefined) return `a non-Error value was thrown: ${String(err)}`;
   try {
-    const message = err === null || err === undefined ? null : err.message;
-    if (typeof message === "string" && message !== "") return message;
-    return `non-Error value thrown: ${String(err)}`;
+    return String(err.message ?? err);
   } catch {
     return "a thrown value that could not be described";
   }
@@ -1436,39 +1440,53 @@ export function applyWidgetWrite(
   // An attribution that overshoots just relocates the wrong blame.
   if (didThrow) {
     const threwDetail = describeThrown(threw);
+    // "ATTEMPT to invoke", uniformly (codex round 3). A class constructor and a
+    // revoked Proxy both satisfy `typeof === "function"` and then throw before any
+    // body runs, so any wording that says the callback RAN is false for them — and
+    // the mechanism cannot tell them from a body that threw. The weaker claim is true
+    // of every case, so it is the only one made.
     const threwLabel = threwFromCallback
-      ? `an exception came from invoking the widget's OWN callback while applying the write`
+      ? `an exception came from attempting to invoke the widget's OWN callback while applying the write`
       : `an exception was thrown while applying the write`;
     // Establishable and worth saying when it holds: a value that is not a function
-    // cannot have been entered, so the throw is the invocation refusing, not the
-    // node's logic failing.
-    // Reads the value CAPTURED at lookup time — never `w.callback` again, which would
-    // invoke a throwing accessor a second time.
+    // cannot have been entered at all. Reads the value CAPTURED at lookup time —
+    // never `w.callback` again, which would invoke a throwing accessor a second time.
     const notCallable = threwFromCallback && typeof widgetCallback !== "function";
     if (!failure) {
       writeWarning = threwFromCallback
         ? `the write itself SUCCEEDED: the requested value IS in effect — verified present by ` +
           `read-back — and was NOT rolled back. The exception (${threwDetail}) came from this ` +
-          `write's invocation of the widget's own callback, which runs AFTER the value is ` +
-          `assigned — the assignment itself did not throw.` +
+          `write's attempt to invoke the widget's own callback, which happens AFTER the value ` +
+          `is assigned — the assignment itself did not throw.` +
           (notCallable
             ? ` The widget's callback is a ${typeof widgetCallback}, not a function, so it could not ` +
               `be invoked at all and none of its side effects ran.`
             : ` Side effects that callback would normally perform (refreshing dependent widgets, ` +
               `previews, thumbnails) may not have run or completed; inspect the node if dependents ` +
-              `look stale. This invocation is programmatic, so a callback written to assume a click ` +
-              `can throw here and not in the UI.`)
+              `look stale. Note that this write invokes callbacks programmatically, which is by ` +
+              `itself enough to make a callback written for a click throw.`)
         : `${threwLabel} (${threwDetail}); the requested value IS in effect — ` +
           `verified present by read-back — and was NOT rolled back. Side effects the write ` +
           `would normally trigger (refreshing dependent widgets, previews, thumbnails) may ` +
           `not have run or completed; inspect the node if dependents look stale.`;
     } else {
       failure = `${threwLabel} (${threwDetail}); ${failure}`;
-      if (threw instanceof WidgetWriteError) {
-        originalErr = new WidgetWriteError(failure, {
-          combo: threw.combo,
-          emptyOptions: threw.emptyOptions,
-        });
+      // #976 round 3: CLASSIFYING the thrown value can itself throw — a Proxy with a
+      // hostile `getPrototypeOf` trap breaks `instanceof`, and hostile `combo` /
+      // `emptyOptions` getters break the property reads that follow a successful one.
+      // That would escape from the branch whose whole job is to report a failure we
+      // ALREADY know, losing it. A thrown value gets to be described and, if it
+      // cooperates, classified — never to decide whether we report at all.
+      try {
+        if (threw instanceof WidgetWriteError) {
+          originalErr = new WidgetWriteError(failure, {
+            combo: threw.combo,
+            emptyOptions: threw.emptyOptions,
+          });
+        }
+      } catch {
+        // Composed message stands on its own; the retry flags are simply unavailable.
+        originalErr = null;
       }
     }
   }

--- a/web/js/lib/widget-write.js
+++ b/web/js/lib/widget-write.js
@@ -6,6 +6,27 @@ import { explainNumericNormalization, normalizationNote } from "./widget-normali
 // throw INSIDE the span that attributes the throw to the callback body) and cannot
 // depend on globals a page could later redefine.
 const reflectApply = Reflect.apply;
+// A module-load capture cannot defend against a `Reflect.apply` that was already
+// replaced BEFORE this module evaluated (codex round 2). Nothing here can: at that
+// point the page owns the intrinsics the whole panel runs on. Written down rather
+// than defended, so the limit is known instead of assumed away.
+
+/**
+ * #976: describe a thrown value for a disclosure message.
+ *
+ * `throw` accepts any value, so `.message` may be absent, empty, or itself a getter
+ * that throws — and interpolating a value whose `toString` throws would blow up the
+ * disclosure that exists to report a throw. Total by construction.
+ */
+function describeThrown(err) {
+  try {
+    const message = err === null || err === undefined ? null : err.message;
+    if (typeof message === "string" && message !== "") return message;
+    return `non-Error value thrown: ${String(err)}`;
+  } catch {
+    return "a thrown value that could not be described";
+  }
+}
 
 // Widget-value validation + promoted-subgraph-widget target resolution for
 // graph_set_widget. Extracted so the write targets the RIGHT widget with the
@@ -1182,11 +1203,26 @@ export function applyWidgetWrite(
   // fired its hooks: an afterChange hook can itself re-stale a widget or change the
   // promotion topology, and that must be caught too (not just callback-time drift).
   let threw = null;
-  // #976: TRUE only while the widget's own callback function is executing. It is the
-  // one construct in this envelope whose throw the mechanism can ATTRIBUTE, and only
-  // because the lookup and the argument evaluation are hoisted out of it below — see
-  // the note there. Everything else stays unattributed, exactly as #639 requires.
+  // #976 (codex NO-SHIP round 2): a captured throw cannot be detected by testing
+  // `threw` for truthiness — `throw undefined`, `throw null`, `throw 0`, `throw ""`
+  // are all legal, and a callback that did any of them produced NO disclosure at all:
+  // the write reported clean while its side effects had not run. Pre-existing, and it
+  // silently defeats the whole attribution, so it is fixed here.
+  let didThrow = false;
+  // #976: TRUE when the throw arose from this write's INVOCATION of the widget's own
+  // callback — including a callback that could not be invoked at all. It is the one
+  // step in this envelope whose throw the mechanism can attribute, and only because
+  // the lookup and the argument evaluation are hoisted out of it below (see the note
+  // there). Everything else stays unattributed, exactly as #639 requires.
+  //
+  // It does NOT establish that the callback's BODY ran: a non-callable value, a class
+  // constructor, a revoked Proxy and a throwing `apply` trap all throw at the
+  // invocation without entering any body (codex NO-SHIP round 2). The wording below is
+  // written to be true of all of them, and never says the callback executed.
   let threwFromCallback = false;
+  // Captured at lookup so the disclosure can describe it WITHOUT reading `w.callback`
+  // a second time (it may be an accessor with side effects, or a throwing one).
+  let widgetCallback = null;
   safeBefore();
   try {
     // Assign BOTH values first. The parent's projected promoted widget is a VIEW of
@@ -1224,7 +1260,7 @@ export function applyWidgetWrite(
     // non-callable callback still throws a TypeError exactly as before, and it takes
     // the argument list without spreading — no `Symbol.iterator` to poison either.
     // `reflectApply` is captured at module load for the same reason.
-    const widgetCallback = w.callback;
+    widgetCallback = w.callback;
     if (widgetCallback !== null && widgetCallback !== undefined) {
       const callbackArgs = [coerced, canvas, targetNode, targetNode.pos, undefined];
       threwFromCallback = true;
@@ -1239,7 +1275,8 @@ export function applyWidgetWrite(
     // and a write to a frozen widget throws with no user code at all. For every one
     // of those `threwFromCallback` is FALSE and the disclosure names no construct,
     // unchanged. #976 adds the single case the mechanism CAN establish: the throw
-    // propagated out of calling the widget's own callback function.
+    // arose from this write's invocation of the widget's own callback.
+    didThrow = true;
     threw = err;
   } finally {
     safeAfter();
@@ -1384,27 +1421,43 @@ export function applyWidgetWrite(
   // defect because of it.
   //
   // The attributed wording says exactly what the mechanism observed — the exception
-  // came OUT OF the callback, not out of the assignment — and stops there. It does
-  // NOT say whose code the callback is (a pack, an extension, a prototype, or the
-  // frontend itself may have installed it) and it does NOT assign fault: this write
-  // invokes the callback PROGRAMMATICALLY, and a callback written for a click can
-  // throw here for that reason alone (measured on #757). Both of those were codex
-  // NO-SHIP findings on the first draft of this text, and both were right — an
-  // attribution that overshoots just relocates the wrong blame.
-  if (threw) {
-    const threwDetail = threw?.message ?? threw;
+  // arose from the INVOCATION step, not from the assignment — and stops there. Three
+  // things it deliberately does NOT claim, each a codex NO-SHIP finding on an earlier
+  // draft of this text, each right:
+  //   * whose code the callback is. A pack, an extension, a prototype or the frontend
+  //     itself may have installed it.
+  //   * that anyone is at FAULT. This write invokes the callback PROGRAMMATICALLY, and
+  //     a callback written for a click can throw for that reason alone (measured on
+  //     #757), which would make the throw ours as much as anyone's.
+  //   * that the callback's BODY ran. A non-callable value, a class constructor, a
+  //     revoked Proxy and a throwing `apply` trap all throw at the invocation without
+  //     entering a body. "came from this write's invocation of" is true of every one
+  //     of them; "the callback threw" would not be.
+  // An attribution that overshoots just relocates the wrong blame.
+  if (didThrow) {
+    const threwDetail = describeThrown(threw);
     const threwLabel = threwFromCallback
-      ? `an exception came out of the widget's OWN callback while applying the write`
+      ? `an exception came from invoking the widget's OWN callback while applying the write`
       : `an exception was thrown while applying the write`;
+    // Establishable and worth saying when it holds: a value that is not a function
+    // cannot have been entered, so the throw is the invocation refusing, not the
+    // node's logic failing.
+    // Reads the value CAPTURED at lookup time — never `w.callback` again, which would
+    // invoke a throwing accessor a second time.
+    const notCallable = threwFromCallback && typeof widgetCallback !== "function";
     if (!failure) {
       writeWarning = threwFromCallback
         ? `the write itself SUCCEEDED: the requested value IS in effect — verified present by ` +
-          `read-back — and was NOT rolled back. The exception (${threwDetail}) came out of the ` +
-          `widget's OWN callback, which this write invokes AFTER assigning the value — the ` +
-          `assignment did not throw. Side effects that callback would normally perform ` +
-          `(refreshing dependent widgets, previews, thumbnails) may not have run or completed; ` +
-          `inspect the node if dependents look stale. This invocation is programmatic, so a ` +
-          `callback written to assume a click can throw here and not in the UI.`
+          `read-back — and was NOT rolled back. The exception (${threwDetail}) came from this ` +
+          `write's invocation of the widget's own callback, which runs AFTER the value is ` +
+          `assigned — the assignment itself did not throw.` +
+          (notCallable
+            ? ` The widget's callback is a ${typeof widgetCallback}, not a function, so it could not ` +
+              `be invoked at all and none of its side effects ran.`
+            : ` Side effects that callback would normally perform (refreshing dependent widgets, ` +
+              `previews, thumbnails) may not have run or completed; inspect the node if dependents ` +
+              `look stale. This invocation is programmatic, so a callback written to assume a click ` +
+              `can throw here and not in the UI.`)
         : `${threwLabel} (${threwDetail}); the requested value IS in effect — ` +
           `verified present by read-back — and was NOT rolled back. Side effects the write ` +
           `would normally trigger (refreshing dependent widgets, previews, thumbnails) may ` +

--- a/web/js/lib/widget-write.js
+++ b/web/js/lib/widget-write.js
@@ -14,12 +14,17 @@ const reflectApply = Reflect.apply;
 /**
  * #976: describe a thrown value for a disclosure message.
  *
- * Renders EXACTLY what `${threw?.message ?? threw}` rendered before — `new Error("")`
- * still yields an empty detail, a thrown string still yields itself, `{ message: 0 }`
- * still yields `0` — and adds only the two things that were missing: nullish throws
- * (which the old truthiness test never reached) and totality. `throw` accepts any
- * value, so `.message` may be a getter that throws and `toString` may throw, and a
- * disclosure that exists to REPORT a throw must not itself throw (codex round 3).
+ * Renders what `${threw?.message ?? threw}` rendered before — `new Error("")` still
+ * yields an empty detail, a thrown string still yields itself, `{ message: 0 }` still
+ * yields `0` — and adds only what was missing: nullish throws (which the old
+ * truthiness test never reached) and totality. `throw` accepts any value, so
+ * `.message` may be a getter that throws and `toString` may throw, and a disclosure
+ * that exists to REPORT a throw must not itself throw (codex round 3).
+ *
+ * Not equivalent in the cases where the OLD form threw: a Symbol (or a Symbol-valued
+ * `message`) cannot be implicitly coerced, so template interpolation threw where
+ * `String()` returns `Symbol(x)`. Deliberate — those are exactly the throws that used
+ * to escape the reporting path (codex round 4).
  */
 function describeThrown(err) {
   // The one case where a label is warranted: there is nothing else to print, and

--- a/web/js/lib/widget-write.js
+++ b/web/js/lib/widget-write.js
@@ -1,6 +1,12 @@
 import { pressableWidgetHint } from "./pressable-widget.js";
 import { explainNumericNormalization, normalizationNote } from "./widget-normalization.js";
 
+// #976: captured at module load so invoking a widget's callback cannot read any
+// property off the callback itself (a poisoned `.call` getter or a Proxy trap would
+// throw INSIDE the span that attributes the throw to the callback body) and cannot
+// depend on globals a page could later redefine.
+const reflectApply = Reflect.apply;
+
 // Widget-value validation + promoted-subgraph-widget target resolution for
 // graph_set_widget. Extracted so the write targets the RIGHT widget with the
 // RIGHT value and can be unit-tested by driving the SAME code path the handler
@@ -1198,21 +1204,31 @@ export function applyWidgetWrite(
     // Fire the inner widget's own callback so combo/number side effects run — the
     // same single invocation a manual UI edit of the promoted control performs.
     //
-    // #976: the lookup and the arguments are evaluated BEFORE `threwFromCallback` is
-    // raised, and deliberately so. `w.callback` may be a throwing ACCESSOR and
-    // `targetNode.pos` a GETTER; neither of those is the callback failing, and
-    // blaming the node's callback for them would be exactly the unestablishable
-    // attribution #639 forbids. Only the invocation itself carries the flag.
+    // #976: the flagged span contains the INVOCATION and nothing else, because the
+    // flag is an attribution and an attribution that can be raised by anything but
+    // the callback body is a lie. Hoisted out of it, in order:
+    //   - the `w.callback` LOOKUP: it may be a throwing accessor, which is not the
+    //     callback failing (it never ran)
+    //   - the ARGUMENTS, including `targetNode.pos`, which may be a throwing getter
+    //   - and they are built INSIDE the nullish guard, because the original
+    //     `w.callback?.(…)` short-circuited: with no callback, `pos` was never read,
+    //     and a node with a throwing `pos` getter and no callback must keep the clean
+    //     verified write it had (codex NO-SHIP round 1)
     //
-    // The call is bound explicitly because the original `w.callback?.(…)` form binds
-    // `this` to the widget and callbacks read `this.value`. A non-null callback that
-    // is not callable still throws a TypeError from this same point (from `.call`),
-    // which is attributable to the callback the node supplied.
+    // `Reflect.apply` rather than `widgetCallback.call(…)`: `.call` is a property read
+    // ON the callback, so a poisoned getter or a Proxy `get` trap could throw INSIDE
+    // the flagged span without the callback running — and, worse, a non-callable
+    // `{ call() {} }` would have been INVOKED through its own `.call` method and
+    // reported as a clean write, where the optional-call form correctly threw
+    // (codex NO-SHIP round 1). Reflect.apply checks callability first, so a
+    // non-callable callback still throws a TypeError exactly as before, and it takes
+    // the argument list without spreading — no `Symbol.iterator` to poison either.
+    // `reflectApply` is captured at module load for the same reason.
     const widgetCallback = w.callback;
-    const callbackArgs = [coerced, canvas, targetNode, targetNode.pos, undefined];
     if (widgetCallback !== null && widgetCallback !== undefined) {
+      const callbackArgs = [coerced, canvas, targetNode, targetNode.pos, undefined];
       threwFromCallback = true;
-      widgetCallback.call(w, ...callbackArgs);
+      reflectApply(widgetCallback, w, callbackArgs);
       threwFromCallback = false; // reached only when it RETURNED — a throw leaves it set
     }
   } catch (err) {
@@ -1365,22 +1381,30 @@ export function applyWidgetWrite(
   // naming it matters, because the unattributed wording leads with "an exception was
   // thrown while applying the write", which reads as THE PANEL FAILED TO APPLY YOUR
   // WRITE. That is the opposite of what happened, and #976 was filed here as a panel
-  // defect because of it. When the node's own callback is what threw, the disclosure
-  // leads with the write having succeeded and says whose code threw. Same facts, and
-  // an agent reading it stops treating an applied write as a failed one.
+  // defect because of it.
+  //
+  // The attributed wording says exactly what the mechanism observed — the exception
+  // came OUT OF the callback, not out of the assignment — and stops there. It does
+  // NOT say whose code the callback is (a pack, an extension, a prototype, or the
+  // frontend itself may have installed it) and it does NOT assign fault: this write
+  // invokes the callback PROGRAMMATICALLY, and a callback written for a click can
+  // throw here for that reason alone (measured on #757). Both of those were codex
+  // NO-SHIP findings on the first draft of this text, and both were right — an
+  // attribution that overshoots just relocates the wrong blame.
   if (threw) {
     const threwDetail = threw?.message ?? threw;
     const threwLabel = threwFromCallback
-      ? `an exception was thrown by the widget's OWN callback while applying the write`
+      ? `an exception came out of the widget's OWN callback while applying the write`
       : `an exception was thrown while applying the write`;
     if (!failure) {
       writeWarning = threwFromCallback
         ? `the write itself SUCCEEDED: the requested value IS in effect — verified present by ` +
-          `read-back — and was NOT rolled back. What threw is the widget's OWN callback, which ` +
-          `the node supplies and this write only invokes (${threwDetail}) — the fault is in that ` +
-          `node's code, not in the panel's write. Side effects that callback would normally ` +
-          `perform (refreshing dependent widgets, previews, thumbnails) may not have run or ` +
-          `completed; inspect the node if dependents look stale.`
+          `read-back — and was NOT rolled back. The exception (${threwDetail}) came out of the ` +
+          `widget's OWN callback, which this write invokes AFTER assigning the value — the ` +
+          `assignment did not throw. Side effects that callback would normally perform ` +
+          `(refreshing dependent widgets, previews, thumbnails) may not have run or completed; ` +
+          `inspect the node if dependents look stale. This invocation is programmatic, so a ` +
+          `callback written to assume a click can throw here and not in the UI.`
         : `${threwLabel} (${threwDetail}); the requested value IS in effect — ` +
           `verified present by read-back — and was NOT rolled back. Side effects the write ` +
           `would normally trigger (refreshing dependent widgets, previews, thumbnails) may ` +


### PR DESCRIPTION
Fixes #976.

## What was wrong

`panel_set_widget` did everything right and then described it wrongly.

It applied the value, verified by read-back that the value was in effect, refused to roll back a change that had taken effect — and reported:

> `an exception was thrown while applying the write (Cannot read properties of undefined (reading 'options')); the requested value IS in effect …`

An agent (or a human) reading that lede concludes **the panel failed to apply the write**. That is the opposite of what happened, and it is why this was filed here as a panel defect.

I reproduced the identical message on a stock `CLIPTextEncode` by making its own widget callback throw, so it was never a `MiniMaxH3Director` bug — the panel wraps the node's callback, the node throws, and the panel reports it without saying whose exception it was.

## Why the message named nothing, and why that was right

Deliberate, from #639 (codex rounds 2–3 + delta-gates). The write envelope evaluates:

- value setters on the inner widget, the promoted rail, and every display proxy — any of which may throw, before or after applying
- property reads — `w.callback` can be a throwing accessor, `targetNode.pos` a getter
- the callback invocation
- and a plain write to a **frozen** widget throws with no node code involved at all

Naming "the callback" for any of those is a claim the mechanism cannot establish.

## What this does instead

It does not blame the callback. It **measures** it.

`w.callback` is looked up and its arguments are evaluated **before** the attributed span opens; the span closes when the call returns. The only thing that can set the flag is an exception propagating out of invoking the widget's own callback function. Every other path keeps the existing attribution-free wording, byte for byte.

When it *is* the callback:

> `the write itself SUCCEEDED: the requested value IS in effect — verified present by read-back — and was NOT rolled back. What threw is the widget's OWN callback, which the node supplies and this write only invokes (…) — the fault is in that node's code, not in the panel's write. Side effects that callback would normally perform … may not have run or completed; inspect the node if dependents look stale.`

The attribution is also emitted as **data** — `write_warning_source: "widget_callback"` — so the panel's chat summary line renders it without pattern-matching prose. An unrecognised source degrades to the line the summary already showed, rather than mis-attributing.

The failure branch (throw *and* verification failed) is attributed too: the structural verdict is the panel's, the exception that preceded it is the node's, and both are named.

## The tests are mostly about the boundary

Three assert that **nothing** is claimed:

| case | why unattributed |
|---|---|
| throwing `callback` **accessor** | the callback function never ran |
| throwing `node.pos` **getter** | the arguments failed, not the node's code |
| **reentrant** setter that calls the callback itself | the callback DID run and DID throw — but the throw surfaced from the *assignment*, outside the span |

That last one is what keeps the attribution honest rather than merely plausible.

Also pinned: `this` is still the widget and the five callback arguments are unchanged (the attributed call binds explicitly where the original used optional-call syntax), and a callback that returns normally leaves no attribution behind.

Every test that changed here **failed** against the pre-change source — verified, not assumed.

## Verification

- `node --test browser_tests/unit/*.test.mjs` — 3472 pass, 0 fail
- codex review: pending
- browser check on a live ComfyUI: pending
