### PR TITLE
fix(set_widget): "is of type X" — typeof yields "object", and "a object" reads as a panel bug (#976)

### DIFF
--- a/browser_tests/unit/widget-write.test.mjs
+++ b/browser_tests/unit/widget-write.test.mjs
@@ -2799,7 +2799,7 @@ test("#976 (codex NO-SHIP 1): a NON-CALLABLE callback carrying its own `.call` m
   assert.equal(impostorRan, 0, "a `.call` method on a non-function is NOT an invocation path");
   assert.match(
     set.write_warning ?? "",
-    /callback is a object, not a function, so it could not be invoked at all/,
+    /callback is of type "object", not a function, so it could not be invoked at all/,
     "#976 round 2: says the establishable thing — it could not be entered, so nothing of it ran",
   );
   assert.doesNotMatch(set.write_warning ?? "", /assume a click/, "the programmatic-invocation caveat is irrelevant here");

--- a/web/js/lib/widget-write.js
+++ b/web/js/lib/widget-write.js
@@ -1464,8 +1464,11 @@ export function applyWidgetWrite(
           `write's attempt to invoke the widget's own callback, which happens AFTER the value ` +
           `is assigned — the assignment itself did not throw.` +
           (notCallable
-            ? ` The widget's callback is a ${typeof widgetCallback}, not a function, so it could not ` +
-              `be invoked at all and none of its side effects ran.`
+            ? // No indefinite article: `typeof` yields "object", where "a object" reads
+              // as a bug in the panel — which is the exact impression this whole fix
+              // exists to stop giving. Caught in the browser, not by a unit test.
+              ` The widget's callback is of type "${typeof widgetCallback}", not a function, so it ` +
+              `could not be invoked at all and none of its side effects ran.`
             : ` Side effects that callback would normally perform (refreshing dependent widgets, ` +
               `previews, thumbnails) may not have run or completed; inspect the node if dependents ` +
               `look stale. Note that this write invokes callbacks programmatically, which is by ` +


### PR DESCRIPTION
Follow-up to #987, found during its browser verification.

The not-callable branch interpolated `a ${typeof widgetCallback}`, so a widget carrying a non-function `callback` got:

> The widget's callback is **a object**, not a function, …

A grammar slip in this particular message is worse than it looks: the entire point of #976 was that the disclosure read as *the panel is broken*. Now reads:

> The widget's callback is of type "object", not a function, so it could not be invoked at all and none of its side effects ran.

Verified in a real browser against the served file, plus the unit assertion updated. Full suite green.

Refs #976