### PR TITLE
fix(get_errors): a workflow whose loaders name absent model files must not report clean (#984)

### DIFF
--- a/browser_tests/unit/asset-staleness.test.mjs
+++ b/browser_tests/unit/asset-staleness.test.mjs
@@ -900,6 +900,59 @@ test("#984: the overlap join is injective — a concatenation collision cannot s
   assert.equal(counts.unavailable, 1, "different (node, file) pairs must not collide into one key");
 });
 
+test("#984 (codex r2): a filename containing the separator BYTE cannot forge a duplicate", () => {
+  // A delimiter is not an encoding, whichever byte it is — a POSIX filename may contain
+  // 0x1f, so `(node 1, file "x\x1fy")` and `(node 1, widget "x", value "y")` keyed the
+  // same and the live finding vanished. The fields are escaped now, not just separated.
+  // The collision must be built WITHIN one key shape, or the shape tag masks it — the
+  // first version of this test put the two entries in different shapes and passed
+  // against the broken join, proving nothing. Here both sides key as (node, widget,
+  // file): the store's widget "x" + file "y<SEP>z" and the live entry's widget
+  // "x<SEP>y" + value "z" delimit to the same string.
+  const SEP = String.fromCharCode(31); // built, never written literally into source
+  const counts = graphErrorsFindingCounts({
+    missing_models: [{ node_id: "1", widget: "x", file: `y${SEP}z` }],
+    unavailable_widget_values: [{ id: "1", widget: `x${SEP}y`, value: "z", kind: "missing_asset" }],
+  });
+  assert.equal(counts.unavailable, 1, "a control byte inside a field must not forge a key collision");
+});
+
+test("#984 (codex r2): a store miss on ONE widget does not swallow a live finding on ANOTHER", () => {
+  // Same node, same filename, different widgets — genuinely two faults. The first
+  // version added the widget-less key unconditionally, so the store's `unet_name` miss
+  // absorbed the live scan's distinct `config_name` finding.
+  const counts = graphErrorsFindingCounts({
+    missing_models: [{ node_id: 1, file: "shared.safetensors", widget: "unet_name" }],
+    unavailable_widget_values: [
+      { id: 1, widget: "unet_name", value: "shared.safetensors", kind: "missing_asset" },
+      { id: 1, widget: "config_name", value: "shared.safetensors", kind: "invalid_value" },
+    ],
+  });
+  assert.equal(counts.missingAssets, 1);
+  assert.equal(counts.unavailable, 1, "only the widget the store actually named is absorbed");
+});
+
+test("#984 (codex r2): a store entry with NO widget still absorbs any widget on that node", () => {
+  // The other direction: with no widget recorded there is no identity to tell the
+  // node's widgets apart, so the store entry has to be allowed to cover them.
+  const counts = graphErrorsFindingCounts({
+    missing_media: [{ node_id: 3, file: "in.png" }],
+    unavailable_widget_values: [{ id: 3, widget: "image", value: "in.png", kind: "missing_asset" }],
+  });
+  assert.equal(counts.unavailable, 0);
+});
+
+test("#984 (codex r2): a subgraph LOCATOR and a bare id are kept apart, deliberately", () => {
+  // The two producers do not canonicalize locators between them. Treating
+  // "<uuid>:7" and 7 as the same node would merge findings on different nodes;
+  // keeping them apart over-reports at worst. Over-reporting is the safe direction.
+  const counts = graphErrorsFindingCounts({
+    missing_models: [{ node_id: "a1b2c3d4-e5f6-7890-abcd-ef1234567890:7", file: "m.safetensors" }],
+    unavailable_widget_values: [{ id: 7, widget: "unet_name", value: "m.safetensors" }],
+  });
+  assert.equal(counts.unavailable, 1);
+});
+
 test("#984: graphErrorsFindingCounts is total — a malformed or absent result yields zeroes", () => {
   for (const bad of [null, undefined, 42, "x", {}, { missing_models: "nope", unavailable_widget_values: 7 }]) {
     const c = graphErrorsFindingCounts(bad);

--- a/browser_tests/unit/asset-staleness.test.mjs
+++ b/browser_tests/unit/asset-staleness.test.mjs
@@ -25,6 +25,7 @@ import {
   collectMissingNodeTypeReasons,
   collectUnexplainedRedOutlines,
   combineNodeErrorMaps,
+  graphErrorsFindingCounts,
   graphErrorsResultIsClean,
   nodeRedFlagIsStale,
   collectLinkedNeighborNodeIds,
@@ -821,6 +822,91 @@ test("graphErrorsResultIsClean: FALSE for an unavailable_widget_values-ONLY resu
   assert.equal(graphErrorsResultIsClean({ unavailable_widget_values: [] }), true, "an empty list is still clean");
 });
 
+test("#984 (codex): the two detection halves finding the SAME defect count ONCE", () => {
+  // Measured on a live install: three absent UNET files appeared in BOTH the load-time
+  // missingModel store and the #745 live scan. Adding the lists claimed six findings
+  // for three problems — two corroborating signals, not two defects.
+  const counts = graphErrorsFindingCounts({
+    missing_models: [
+      { node_id: 1, file: "a.safetensors", widget: "unet_name" },
+      { node_id: 2, file: "b.safetensors", widget: "unet_name" },
+    ],
+    unavailable_widget_values: [
+      { id: 1, widget: "unet_name", value: "a.safetensors", kind: "missing_asset" },
+      { id: 2, widget: "unet_name", value: "b.safetensors", kind: "missing_asset" },
+    ],
+  });
+  assert.equal(counts.missingAssets, 2);
+  assert.equal(counts.unavailable, 0, "both halves saw the same two files — nothing extra to report");
+});
+
+test("#984 (codex): a live-scan finding the load-time half MISSED is still counted", () => {
+  // The whole reason the live scan exists. CheckpointLoader.config_name is the measured
+  // case: no missing-MODEL store adjudicates models/configs, so this is the only report.
+  const counts = graphErrorsFindingCounts({
+    missing_models: [{ node_id: 1, file: "a.safetensors", widget: "unet_name" }],
+    unavailable_widget_values: [
+      { id: 1, widget: "unet_name", value: "a.safetensors", kind: "missing_asset" }, // dup
+      { id: 7, widget: "config_name", value: "totally_absent_config.yaml", kind: "missing_asset" },
+    ],
+  });
+  assert.equal(counts.missingAssets, 1);
+  assert.equal(counts.unavailable, 1, "the config_name finding is new information");
+});
+
+test("#984 (codex): overlap is detected even when the store entry omits `widget`", () => {
+  const counts = graphErrorsFindingCounts({
+    missing_media: [{ node_id: 3, file: "in.png" }], // no widget recorded
+    unavailable_widget_values: [{ id: 3, widget: "image", value: "in.png", kind: "missing_asset" }],
+  });
+  assert.equal(counts.unavailable, 0, "the (node, file) join still catches it");
+});
+
+test("#984 (codex): an unjoinable live-scan entry is counted rather than silently dropped", () => {
+  const counts = graphErrorsFindingCounts({
+    missing_models: [{ node_id: 1, file: "a.safetensors" }],
+    unavailable_widget_values: [{ widget: "unet_name", value: "a.safetensors" }], // no id
+  });
+  assert.equal(counts.unavailable, 1, "no identity to join on ⇒ report it, never assume a duplicate");
+});
+
+test("#984 (codex): node-type surfaces have no widget identity and are never deduped away", () => {
+  const counts = graphErrorsFindingCounts({
+    missing_node_types: ["RIFEInterpolation"],
+    missing_node_count: 2,
+    errored_count: 4,
+  });
+  assert.equal(counts.missingAssets, 3, "1 type + a count of 2");
+  assert.equal(counts.erroredNodes, 4);
+  assert.equal(counts.unavailable, 0);
+});
+
+test("#984 (codex): `unchecked` is reported but is never a finding", () => {
+  const counts = graphErrorsFindingCounts({ unchecked_nodes: [{ id: 9 }, { id: 10 }] });
+  assert.equal(counts.unchecked, 2);
+  assert.equal(counts.missingAssets, 0);
+  assert.equal(counts.unavailable, 0);
+  assert.equal(counts.erroredNodes, 0);
+});
+
+test("#984: the overlap join is injective — a concatenation collision cannot swallow a finding", () => {
+  // Without a field separator, (node "1", file "23") and (node "12", file "3") produce
+  // the same key, and a real live-scan finding is silently deduped away as a phantom
+  // duplicate. Suppressing a finding is the exact failure this whole issue is about.
+  const counts = graphErrorsFindingCounts({
+    missing_models: [{ node_id: "1", file: "23" }],
+    unavailable_widget_values: [{ id: "12", value: "3", kind: "missing_asset" }],
+  });
+  assert.equal(counts.unavailable, 1, "different (node, file) pairs must not collide into one key");
+});
+
+test("#984: graphErrorsFindingCounts is total — a malformed or absent result yields zeroes", () => {
+  for (const bad of [null, undefined, 42, "x", {}, { missing_models: "nope", unavailable_widget_values: 7 }]) {
+    const c = graphErrorsFindingCounts(bad);
+    assert.deepEqual(c, { erroredNodes: 0, missingAssets: 0, unavailable: 0, unchecked: 0 });
+  }
+});
+
 test("#984 source guard: graph_get_errors' own `clean` folds in the live scan", () => {
   // The helper above governs the SUMMARY LABEL. The `note: "no errors recorded…"` in
   // the payload comes from a separate `clean` expression inside the monolith's
@@ -834,10 +920,18 @@ test("#984 source guard: graph_get_errors' own `clean` folds in the live scan", 
   for (const surface of ["missingModels", "missingMedia", "missingNodeTypes", "missingNodeCount"]) {
     assert.match(cleanExpr, new RegExp(`!${surface}`), `the #399 surfaces must survive: ${surface}`);
   }
+  // The summary now derives every count from the shared helper above, which is tested
+  // BEHAVIOURALLY. This only pins that the label is wired to it — codex was right that
+  // a source regex cannot prove the wiring, so the regex is kept as thin as possible
+  // and the real assertions live on the importable helper.
   assert.match(
     panelSrc,
-    /r\.unavailable_widget_values\?\.length \|\| 0/,
-    "the summary label must count the live-scan findings too, or an unavailable-only result reads as a bare read",
+    /const counts = graphErrorsFindingCounts\(r\);/,
+    "the summary label must count through the deduping helper, not by adding the lists",
+  );
+  assert.ok(
+    !/\(r\.missing_models\?\.length \|\| 0\) \+/.test(panelSrc),
+    "the old hand-rolled summing must not reappear — it double-counted the overlap",
   );
 });
 

--- a/browser_tests/unit/asset-staleness.test.mjs
+++ b/browser_tests/unit/asset-staleness.test.mjs
@@ -7,6 +7,7 @@
  */
 import test from "node:test";
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 
 import {
   findNodeByScopedId,
@@ -785,6 +786,69 @@ test("graphErrorsResultIsClean: FALSE for missing_models / missing_media / missi
   assert.equal(graphErrorsResultIsClean({ missing_models: [{ file: "x.safetensors" }] }), false);
   assert.equal(graphErrorsResultIsClean({ missing_media: [{ file: "in.png" }] }), false);
   assert.equal(graphErrorsResultIsClean({ missing_node_count: 2 }), false);
+});
+
+test("graphErrorsResultIsClean: FALSE for an unavailable_widget_values-ONLY result (#984)", () => {
+  // Measured on a live install before the fix: a CheckpointLoader whose `config_name`
+  // named an absent models/configs .yaml. No missing-MODEL store adjudicates that
+  // folder, so every load-time surface was empty while the #745 live scan found it —
+  // and the payload carried the finding AND "Checked errors — none".
+  assert.equal(
+    graphErrorsResultIsClean({
+      errored_count: 0,
+      node_errors: null,
+      last_execution_error: null,
+      unavailable_widget_values: [
+        {
+          id: 1,
+          type: "CheckpointLoader",
+          widget: "config_name",
+          value: "totally_absent_config.yaml",
+          kind: "missing_asset",
+        },
+      ],
+    }),
+    false,
+  );
+  // The other kind the scan reports is just as fatal at queue time — a value outside
+  // the options the server publishes — so it must not be treated as cosmetic either.
+  assert.equal(
+    graphErrorsResultIsClean({
+      unavailable_widget_values: [{ id: 2, widget: "sampler_name", value: "nope", kind: "invalid_value" }],
+    }),
+    false,
+  );
+  assert.equal(graphErrorsResultIsClean({ unavailable_widget_values: [] }), true, "an empty list is still clean");
+});
+
+test("#984 source guard: graph_get_errors' own `clean` folds in the live scan", () => {
+  // The helper above governs the SUMMARY LABEL. The `note: "no errors recorded…"` in
+  // the payload comes from a separate `clean` expression inside the monolith's
+  // executor, which is not importable — and it is the one that produced the
+  // self-contradicting payload. Both must fold in the live scan or the contradiction
+  // simply moves. Deleting either half fails here.
+  const panelSrc = readFileSync(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8");
+  const cleanExpr = /const clean =([\s\S]{0,600}?);/.exec(panelSrc)?.[1] ?? "";
+  assert.ok(cleanExpr.length > 0, "the `clean` expression must still exist to be checked");
+  assert.match(cleanExpr, /!liveScan\?\.unavailable\?\.length/, "`clean` must account for the live scan (#984)");
+  for (const surface of ["missingModels", "missingMedia", "missingNodeTypes", "missingNodeCount"]) {
+    assert.match(cleanExpr, new RegExp(`!${surface}`), `the #399 surfaces must survive: ${surface}`);
+  }
+  assert.match(
+    panelSrc,
+    /r\.unavailable_widget_values\?\.length \|\| 0/,
+    "the summary label must count the live-scan findings too, or an unavailable-only result reads as a bare read",
+  );
+});
+
+test("graphErrorsResultIsClean: unchecked_nodes alone does NOT make a result dirty (#984 scope)", () => {
+  // The scan reports what it could not judge on almost every call. Treating that as an
+  // error would make "Checked errors — none" unreachable on a normal canvas, which is
+  // a different lie. Only what the scan positively FOUND counts.
+  assert.equal(
+    graphErrorsResultIsClean({ unchecked_nodes: [{ id: 9, type: "SomePack" }], unchecked_budget_exhausted: true }),
+    true,
+  );
 });
 
 test("graphErrorsResultIsClean: FALSE for raw validation / execution errors", () => {

--- a/browser_tests/unit/live-combo-availability.test.mjs
+++ b/browser_tests/unit/live-combo-availability.test.mjs
@@ -23,6 +23,7 @@ import {
   comboInputsOf,
   optionsLookLikeFiles,
   comboAvailabilityNote,
+  linkDrivenWidgetNames,
 } from "../../web/js/lib/live-combo-availability.js";
 
 /** An /object_info/<class> body in the verified shape. */
@@ -223,3 +224,79 @@ test("#745 WIRING: get_errors actually calls the scan, inside its budget", async
   assert.match(src, /unavailable_widget_values: liveScan\.unavailable/)
   assert.match(src, /unchecked_nodes: liveScan\.unknown/)
 })
+
+// ---------------------------------------------------------------------------
+// #984 — a widget the graph does not READ must not be judged. When a widget is
+// converted to an input, ComfyUI keeps it in `node.widgets` AND adds an input of
+// the same name; while that input is CONNECTED the queue reads the link and the
+// widget's own `.value` is dead weight, frequently a stale leftover from before
+// the conversion. Verified against a live ComfyUI: converting KSampler's
+// `sampler_name` leaves the widget in `node.widgets` and adds a `sampler_name`
+// input alongside the connection inputs. Judging that value reports an error on a
+// workflow that runs correctly — which mattered once #984 made the scan's findings
+// decide whether get_errors may say "no errors recorded".
+// ---------------------------------------------------------------------------
+
+const inputEntry = (name, link, widgetName) => ({
+  name,
+  link,
+  ...(widgetName ? { widget: { name: widgetName } } : {}),
+});
+
+test("#984 a CONNECTED widget-input's stale value is not judged", async () => {
+  const n = node(1, "KSampler", [{ name: "sampler_name", value: "left_over_from_before" }]);
+  n.inputs = [inputEntry("model", 3), inputEntry("sampler_name", 7, "sampler_name")];
+  const res = await scanComboAvailability([n], async () => SAMPLER);
+  assert.deepEqual(res.unavailable, [], "the link supplies this value — the widget's copy is not used");
+});
+
+test("#984 an UNCONNECTED widget-input is still judged (link: null)", async () => {
+  const n = node(1, "KSampler", [{ name: "sampler_name", value: "not_a_sampler" }]);
+  n.inputs = [inputEntry("sampler_name", null, "sampler_name")];
+  const res = await scanComboAvailability([n], async () => SAMPLER);
+  assert.equal(res.unavailable.length, 1, "nothing drives it, so the widget value is what runs");
+  assert.equal(res.unavailable[0].value, "not_a_sampler");
+});
+
+test("#984 the skip matches by NAME when the input carries no widget back-reference", async () => {
+  const n = node(1, "KSampler", [{ name: "sampler_name", value: "stale" }]);
+  n.inputs = [inputEntry("sampler_name", 12)]; // older frontend shape
+  const res = await scanComboAvailability([n], async () => SAMPLER);
+  assert.deepEqual(res.unavailable, []);
+});
+
+test("#984 a connected input never silences a DIFFERENT widget", async () => {
+  const n = node(1, "KSampler", [
+    { name: "sampler_name", value: "not_a_sampler" },
+    { name: "scheduler", value: "normal" },
+  ]);
+  n.inputs = [inputEntry("scheduler", 4, "scheduler")]; // a different widget is linked
+  const res = await scanComboAvailability(
+    [n],
+    async () => classBody("KSampler", { sampler_name: [["euler"], {}], scheduler: [["normal"], {}] }),
+  );
+  assert.equal(res.unavailable.length, 1);
+  assert.equal(res.unavailable[0].widget, "sampler_name", "only the linked widget is exempt");
+});
+
+test("#984 a node with no inputs array, or a malformed one, is judged exactly as before", async () => {
+  const mk = (inputs) => {
+    const n = node(1, "KSampler", [{ name: "sampler_name", value: "not_a_sampler" }]);
+    if (inputs !== undefined) n.inputs = inputs;
+    return n;
+  };
+  for (const inputs of [undefined, null, [], "nope", [null], [{}], [{ name: "sampler_name" }]]) {
+    const res = await scanComboAvailability([mk(inputs)], async () => SAMPLER);
+    assert.equal(res.unavailable.length, 1, `must still judge with inputs=${JSON.stringify(inputs)}`);
+  }
+});
+
+test("#984 linkDrivenWidgetNames reports only CONNECTED inputs", () => {
+  assert.deepEqual(
+    [...linkDrivenWidgetNames({ inputs: [inputEntry("a", 1), inputEntry("b", null), inputEntry("c", 0, "c_w")] })],
+    ["a", "c_w"],
+    "link 0 is a real link id; only null/undefined mean unconnected",
+  );
+  assert.deepEqual([...linkDrivenWidgetNames(null)], []);
+  assert.deepEqual([...linkDrivenWidgetNames({ inputs: {} })], []);
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -11665,6 +11665,14 @@ const GRAPH_TOOL_EXECUTORS = {
     // NOT emit the "no errors recorded" note alongside a populated missing_* field
     // (#399/#356 self-contradiction). Fold the asset surfaces in so the note and the
     // reported misses can never disagree in one payload.
+    //
+    // #984 — the SAME contradiction, re-opened by the #745 live scan. That field was
+    // added to the payload below without being folded in here, so a graph whose only
+    // defect the LOAD-TIME stores cannot adjudicate (measured: `CheckpointLoader`'s
+    // `config_name`, a models/configs .yaml that no missing-MODEL store tracks)
+    // emitted `unavailable_widget_values: [...]` and "no errors recorded" in ONE
+    // payload. Every entry in that list is a value the server does not offer, so the
+    // node fails on it at queue time whichever kind it is.
     const clean =
       !nodeErrors &&
       !lastExecFailure &&
@@ -11672,7 +11680,8 @@ const GRAPH_TOOL_EXECUTORS = {
       !missingModels.length &&
       !missingMedia.length &&
       !missingNodeTypes.length &&
-      !missingNodeCount;
+      !missingNodeCount &&
+      !liveScan?.unavailable?.length;
     return {
       viewing: describeActiveGraph(graph),
       node_count: nodes.length,
@@ -18374,9 +18383,17 @@ function describeCommand(cmd, msg, reply) {
         (r.missing_media?.length || 0) +
         (r.missing_node_types?.length || 0) +
         (Number(r.missing_node_count) || 0);
+      // #984 — count the LIVE scan too, or a result whose ONLY finding came from it
+      // reads "Read execution errors" (the empty-parts fallback) while its payload
+      // names the offending widget. Kept as its own part rather than folded into
+      // missingAssets: these were established from the server's current /object_info,
+      // and the list mixes absent files with values outside the offered options.
+      const unavailable = r.unavailable_widget_values?.length || 0;
       const parts = [];
       if (r.errored_count) parts.push(`${r.errored_count} node${r.errored_count === 1 ? "" : "s"}`);
       if (missingAssets) parts.push(`${missingAssets} missing asset${missingAssets === 1 ? "" : "s"}`);
+      if (unavailable)
+        parts.push(`${unavailable} unavailable widget value${unavailable === 1 ? "" : "s"}`);
       return {
         icon: "pi-exclamation-triangle",
         text: parts.length ? `Found errors — ${parts.join(", ")}` : "Read execution errors",

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -138,6 +138,7 @@ import {
   collectMissingNodeTypeReasons,
   collectUnexplainedRedOutlines,
   combineNodeErrorMaps,
+  graphErrorsFindingCounts,
   graphErrorsResultIsClean,
   nodeRedFlagIsStale,
   collectLinkedNeighborNodeIds,
@@ -18375,25 +18376,33 @@ function describeCommand(cmd, msg, reply) {
       // a missing-asset-ONLY result (e.g. a bypassed uninstalled node — #399) carries
       // neither node_errors nor last_execution_error, so the old check mislabelled it
       // "none" while the payload actually reported missing_node_types/models/media.
+      // #984 — counts come from the shared helper so the OVERLAP between the two
+      // detection halves is removed: an absent model file is reported by BOTH the
+      // load-time store and the live scan, and adding the lists claimed six findings
+      // for three problems.
+      const counts = graphErrorsFindingCounts(r);
       if (graphErrorsResultIsClean(r)) {
-        return { icon: "pi-info-circle", text: "Checked errors — none" };
+        // #984 (codex): "none" is a claim about the whole canvas, and the scan leaves
+        // something unjudged on most calls — a node type it could not look up, a
+        // budget cutoff. No positive findings is not a complete check, so say which
+        // one this was rather than let an incomplete pass read as an all-clear.
+        return counts.unchecked
+          ? {
+              icon: "pi-info-circle",
+              text: `Checked errors — none found (${counts.unchecked} node${counts.unchecked === 1 ? "" : "s"} could not be checked)`,
+            }
+          : { icon: "pi-info-circle", text: "Checked errors — none" };
       }
-      const missingAssets =
-        (r.missing_models?.length || 0) +
-        (r.missing_media?.length || 0) +
-        (r.missing_node_types?.length || 0) +
-        (Number(r.missing_node_count) || 0);
-      // #984 — count the LIVE scan too, or a result whose ONLY finding came from it
-      // reads "Read execution errors" (the empty-parts fallback) while its payload
-      // names the offending widget. Kept as its own part rather than folded into
-      // missingAssets: these were established from the server's current /object_info,
-      // and the list mixes absent files with values outside the offered options.
-      const unavailable = r.unavailable_widget_values?.length || 0;
       const parts = [];
-      if (r.errored_count) parts.push(`${r.errored_count} node${r.errored_count === 1 ? "" : "s"}`);
-      if (missingAssets) parts.push(`${missingAssets} missing asset${missingAssets === 1 ? "" : "s"}`);
-      if (unavailable)
-        parts.push(`${unavailable} unavailable widget value${unavailable === 1 ? "" : "s"}`);
+      if (counts.erroredNodes)
+        parts.push(`${counts.erroredNodes} node${counts.erroredNodes === 1 ? "" : "s"}`);
+      if (counts.missingAssets)
+        parts.push(`${counts.missingAssets} missing asset${counts.missingAssets === 1 ? "" : "s"}`);
+      // Kept as its own category rather than folded into missing assets: these were
+      // established from the server's CURRENT /object_info, not the load-time scan,
+      // and the list mixes absent files with values outside the offered options.
+      if (counts.unavailable)
+        parts.push(`${counts.unavailable} unavailable widget value${counts.unavailable === 1 ? "" : "s"}`);
       return {
         icon: "pi-exclamation-triangle",
         text: parts.length ? `Found errors — ${parts.join(", ")}` : "Read execution errors",

--- a/web/js/lib/asset-staleness.js
+++ b/web/js/lib/asset-staleness.js
@@ -528,7 +528,13 @@ export function graphErrorsResultIsClean(result) {
     !len(result.missing_models) &&
     !len(result.missing_media) &&
     !len(result.missing_node_types) &&
-    !(Number(result.missing_node_count) > 0)
+    !(Number(result.missing_node_count) > 0) &&
+    // #984 — the #745 LIVE scan was added to the payload after this helper was
+    // written and never folded in, so a result carrying `unavailable_widget_values`
+    // was still labelled "Checked errors — none". Every entry there is a widget
+    // value the server does not offer (a file it does not have, or a value outside
+    // the options it publishes) — the node fails on it at queue time either way.
+    !len(result.unavailable_widget_values)
   );
 }
 

--- a/web/js/lib/asset-staleness.js
+++ b/web/js/lib/asset-staleness.js
@@ -538,6 +538,61 @@ export function graphErrorsResultIsClean(result) {
   );
 }
 
+// #984 — a field separator for the overlap-join keys below. Written as an ESCAPE, never
+// as a literal control byte: a raw 0x1f in shipped source trips the repo's own guard
+// (and the Registry's scanners), which is exactly how this was caught.
+const JOIN_SEP = "\x1f";
+
+/**
+ * #984 — the counts a `graph_get_errors` summary label should show, with the OVERLAP
+ * between the two detection halves removed.
+ *
+ * The load-time stores and the #745 live scan frequently find the SAME defect: an
+ * absent model file is both a `missing_models` entry and an `unavailable_widget_values`
+ * entry (measured — three absent UNET files appeared in both). Adding the lists gives
+ * six findings for three problems. Two corroborating signals are not two defects.
+ *
+ * So `unavailable` counts only what the load-time surfaces did NOT already report, on
+ * the (node, widget, value) it names. `missing_node_types`/`missing_node_count` have no
+ * widget-level identity and cannot overlap, so they stay in `missingAssets` untouched.
+ *
+ * `unchecked` is reported SEPARATELY and is never a finding: the scan leaves something
+ * unjudged on nearly every call, and counting that as an error would make a quiet label
+ * unreachable on a healthy canvas. It exists so a caller can decline to say "none" when
+ * the check was not complete — no positive findings is not the same as a clean result.
+ */
+export function graphErrorsFindingCounts(result) {
+  const arr = (v) => (Array.isArray(v) ? v : []);
+  const r = result && typeof result === "object" ? result : {};
+  const models = arr(r.missing_models);
+  const media = arr(r.missing_media);
+  // Two keys: with the widget when the store named one, and without — a store entry
+  // may omit `widget`, and an overlap must not be missed on that account.
+  const seen = new Set();
+  for (const m of [...models, ...media]) {
+    const node = m?.node_id ?? null;
+    const file = m?.file ?? null;
+    if (node == null || file == null) continue;
+    seen.add(`${String(node)}${JOIN_SEP}${String(file)}`);
+    if (m?.widget != null) seen.add(`${String(node)}${JOIN_SEP}${String(m.widget)}${JOIN_SEP}${String(file)}`);
+  }
+  const unavailable = arr(r.unavailable_widget_values).filter((u) => {
+    const node = u?.id ?? null;
+    const value = u?.value ?? null;
+    if (node == null || value == null) return true; // unjoinable → count it
+    if (seen.has(`${String(node)}${JOIN_SEP}${String(value)}`)) return false;
+    if (u?.widget != null && seen.has(`${String(node)}${JOIN_SEP}${String(u.widget)}${JOIN_SEP}${String(value)}`)) return false;
+    return true;
+  }).length;
+  return {
+    erroredNodes: Number(r.errored_count) || 0,
+    missingAssets:
+      models.length + media.length + arr(r.missing_node_types).length + (Number(r.missing_node_count) || 0),
+    unavailable,
+    unchecked: arr(r.unchecked_nodes).length,
+  };
+}
+
 // Input types that ComfyUI renders as a WIDGET rather than a connection socket.
 // A combo (the type spec is an array of option values) is also a widget.
 const WIDGET_INPUT_TYPES = new Set(["INT", "FLOAT", "STRING", "BOOLEAN", "COMBO"]);

--- a/web/js/lib/asset-staleness.js
+++ b/web/js/lib/asset-staleness.js
@@ -541,7 +541,20 @@ export function graphErrorsResultIsClean(result) {
 // #984 — a field separator for the overlap-join keys below. Written as an ESCAPE, never
 // as a literal control byte: a raw 0x1f in shipped source trips the repo's own guard
 // (and the Registry's scanners), which is exactly how this was caught.
-const JOIN_SEP = "\x1f";
+/**
+ * #984 — an INJECTIVE key for the overlap join below.
+ *
+ * A delimiter is not enough, whichever byte it is. `"\x1f"` only moves the control
+ * character from the source file to runtime, and a POSIX filename may legally contain
+ * it: `(node "1", file "x\x1fy")` and `(node "1", widget "x", value "y")` then produce
+ * the same key, and a real live-scan finding is discarded as a phantom duplicate
+ * (codex round 2). `JSON.stringify` of an array of strings escapes every field, so
+ * distinct tuples cannot collide. The leading tag keeps the two key SHAPES apart too.
+ *
+ * Suppressing a finding is precisely the failure this issue is about, so the join
+ * fails toward counting: anything it cannot key is reported rather than merged.
+ */
+const joinKey = (tag, ...parts) => JSON.stringify([tag, ...parts.map((p) => String(p))]);
 
 /**
  * #984 — the counts a `graph_get_errors` summary label should show, with the OVERLAP
@@ -556,6 +569,12 @@ const JOIN_SEP = "\x1f";
  * the (node, widget, value) it names. `missing_node_types`/`missing_node_count` have no
  * widget-level identity and cannot overlap, so they stay in `missingAssets` untouched.
  *
+ * KNOWN, deliberate limit: node ids are compared as written. `"7"` and `7` merge, but a
+ * subgraph locator `"<uuid>:7"` on one side and a bare `7` on the other do NOT — the
+ * two producers do not canonicalize locators between them, and guessing an equivalence
+ * would merge findings on genuinely different nodes. Splitting over-reports; merging
+ * hides. This splits.
+ *
  * `unchecked` is reported SEPARATELY and is never a finding: the scan leaves something
  * unjudged on nearly every call, and counting that as an error would make a quiet label
  * unreachable on a healthy canvas. It exists so a caller can decline to say "none" when
@@ -566,23 +585,34 @@ export function graphErrorsFindingCounts(result) {
   const r = result && typeof result === "object" ? result : {};
   const models = arr(r.missing_models);
   const media = arr(r.missing_media);
-  // Two keys: with the widget when the store named one, and without — a store entry
-  // may omit `widget`, and an overlap must not be missed on that account.
-  const seen = new Set();
+  // How precisely a store entry identifies its finding decides what it may absorb
+  // (codex round 2 — the first version added the widget-less key ALWAYS, so a store
+  // miss on `unet_name` swallowed a distinct live finding for `config_name` on the
+  // same node carrying the same filename, which can be two different faults).
+  //
+  //   named   — the store told us the widget: absorbs only that widget
+  //   unnamed — the store could not: absorbs any widget on that node, since there is
+  //             no identity to distinguish them by
+  //   anyFile — every store entry by (node, file), consulted ONLY when the LIVE entry
+  //             is the one that cannot name a widget
+  const named = new Set();
+  const unnamed = new Set();
+  const anyFile = new Set();
   for (const m of [...models, ...media]) {
     const node = m?.node_id ?? null;
     const file = m?.file ?? null;
     if (node == null || file == null) continue;
-    seen.add(`${String(node)}${JOIN_SEP}${String(file)}`);
-    if (m?.widget != null) seen.add(`${String(node)}${JOIN_SEP}${String(m.widget)}${JOIN_SEP}${String(file)}`);
+    anyFile.add(joinKey("nf", node, file));
+    if (m?.widget != null) named.add(joinKey("nwf", node, m.widget, file));
+    else unnamed.add(joinKey("nf", node, file));
   }
   const unavailable = arr(r.unavailable_widget_values).filter((u) => {
     const node = u?.id ?? null;
     const value = u?.value ?? null;
-    if (node == null || value == null) return true; // unjoinable → count it
-    if (seen.has(`${String(node)}${JOIN_SEP}${String(value)}`)) return false;
-    if (u?.widget != null && seen.has(`${String(node)}${JOIN_SEP}${String(u.widget)}${JOIN_SEP}${String(value)}`)) return false;
-    return true;
+    if (node == null || value == null) return true; // no identity to join on → count it
+    if (u?.widget == null) return !anyFile.has(joinKey("nf", node, value));
+    if (unnamed.has(joinKey("nf", node, value))) return false;
+    return !named.has(joinKey("nwf", node, u.widget, value));
   }).length;
   return {
     erroredNodes: Number(r.errored_count) || 0,

--- a/web/js/lib/live-combo-availability.js
+++ b/web/js/lib/live-combo-availability.js
@@ -93,6 +93,40 @@ export function comboInputsOf(body, className) {
  *   /object_info/<class> body; may reject.
  * @returns {Promise<{unavailable: Array<object>, unknown: Array<object>}>}
  */
+/**
+ * #984 — names of this node's widgets whose value the graph does NOT use, because a
+ * matching input is connected.
+ *
+ * When a widget is converted to an input, ComfyUI keeps the entry in `node.widgets`
+ * AND adds an input of the same name. While that input is CONNECTED the widget's own
+ * `.value` is dead weight — frequently a stale leftover from before the conversion —
+ * and the queue reads the link instead. Judging such a value against the combo
+ * reports an error on a graph that runs fine.
+ *
+ * Deliberately narrow: an input counts only when it names the widget (directly or via
+ * its `widget.name` back-reference) AND holds a non-null `link`. Everything else —
+ * no `inputs` array, an unconnected input, a malformed entry — yields nothing, so the
+ * widget stays judged. Skipping is the only thing this can do, and only on evidence.
+ */
+export function linkDrivenWidgetNames(node) {
+  const names = new Set();
+  try {
+    const inputs = node?.inputs;
+    if (!Array.isArray(inputs)) return names;
+    for (const input of inputs) {
+      if (!input || input.link === null || input.link === undefined) continue;
+      const name = typeof input.name === "string" ? input.name : null;
+      // Newer frontends carry the association explicitly; older ones match by name.
+      const widgetName = typeof input.widget?.name === "string" ? input.widget.name : null;
+      if (widgetName) names.add(widgetName);
+      else if (name) names.add(name);
+    }
+  } catch {
+    /* a malformed node judges every widget, exactly as before */
+  }
+  return names;
+}
+
 export async function scanComboAvailability(
   nodes,
   fetchClassInfo,
@@ -157,9 +191,17 @@ export async function scanComboAvailability(
       continue;
     }
     const combos = entry.combos;
+    // #984 — a widget whose matching input carries a LINK is driven by that link;
+    // ComfyUI serializes the connection and ignores the widget's own value, which is
+    // often a stale leftover from before the conversion. Judging it reports an error
+    // on a workflow that runs correctly. Consulted ONLY to skip: an unlinked input, a
+    // node with no `inputs`, or any unexpected shape leaves the widget judged exactly
+    // as before, so this can never suppress a value the graph really uses.
+    const linkDriven = linkDrivenWidgetNames(node);
     for (const widget of node.widgets) {
       const name = typeof widget?.name === "string" ? widget.name : null;
       if (!name) continue;
+      if (linkDriven.has(name)) continue;
       const options = combos.get(name);
       if (!options) continue; // not a combo input — nothing to judge it against
       const value = widget.value;


### PR DESCRIPTION
Refs #984. **Does not close it** — see "What this does not fix" below.

## The reported shape does not reproduce on main

Measured on a live install rather than reasoned about. Three `UNETLoader`s naming absent files — `h3\back.safetensors`, `h3/forward.safetensors`, `plain.safetensors`:

- the frontend's `missingModel` store populated **all three**, `name` matching the widget value exactly, backslash included
- the panel's staleness filter kept all three (both `trustCombo` settings)
- the #745 live scan found all three independently

So the reporter's separator hypothesis is not it. The store also turned out **not** to be load-time-only on this frontend — it tracked a loader added after load, contradicting several comments in the panel.

## What is actually wrong

`clean` — the thing that emits `note: "no errors recorded since the last execution start"` — predates the #745 live scan and was never folded into it. `graphErrorsResultIsClean`, which drives the summary label, had the same omission.

So one payload could carry a finding **and** say there were no errors, and the label said `Checked errors — none`.

Reproduced live: a `CheckpointLoader` whose `config_name` names an absent `models/configs` `.yaml`. No missing-**model** store adjudicates that folder, so every load-time surface is empty while the live scan finds it. The comment directly above `clean` already swears this can never happen — it was written for #399/#356, and the later field slipped past it.

## Codex found three more things on top, all real

1. **Double-counting.** My own measurement showed both halves find the same absent file; the first draft added the lists anyway — six findings for three problems. Counting now runs through a shared importable helper that removes the overlap.
2. **The scan judged widgets the graph does not read.** It never consulted `node.inputs`, so a widget converted to an input and *connected* was judged on a stale value the queue ignores. Verified live that the widget stays in `node.widgets` after conversion — a false positive that was about to become fatal once findings started deciding "clean".
3. **The dedupe key was not injective, and over-absorbed.** A delimiter is not an encoding (a filename may contain the separator byte), and the widget-less key was added for every store entry, so a store miss on `unet_name` swallowed a distinct live finding for `config_name`. Both suppress findings — the exact failure direction this issue is about.

Also caught, by the repo's own guard: the first key implementation put **raw `0x1f` bytes into shipped source**.

## Verification

- full suite: **3504 pass / 0 fail**
- every behavioural claim mutation-verified. One of those mutations proved a test of mine was **worthless** — my first separator-collision test put the entries in different key shapes, so the shape tag masked the collision and it passed against the broken join. Fixed to build the collision within one shape.
- browser-verified on live ComfyUI: the original contradiction now reports `Found errors — 1 unavailable widget value`; 2 store + 2 live findings dedupe to 2 (naive sum: 4); a connected `sampler_name` stops being flagged while an unconnected one is still flagged.
- codex: SHIP after three rounds.

## What this does not fix

The reporter's own missing-model symptom. Their `panel_query_graph` was refused with *"does not implement graph_query … update to >=0.7.0"* against a 0.11.x panel, which points at a stale or mixed client bundle rather than at this logic. I'll ask them for their actual panel version and whether a hard refresh changes it.
