### PR TITLE
spec(run): establish which app.queuePrompt shape carries run-to-node scope on 1.48.x (#996)

### DIFF
--- a/browser_tests/unit/run-scope-guard.test.mjs
+++ b/browser_tests/unit/run-scope-guard.test.mjs
@@ -905,12 +905,21 @@ test("#630 gate r1: graph_run's repair disclosure separates what was OBSERVED fr
   );
   assert.match(note, /measured by capturing the outgoing body/, "and how it was established");
   assert.match(note, /please report this build \(#996\)/, "the ask survives — one datum is not a diagnosis");
+  // The workaround must name the version that was actually measured. "upgrading may
+  // help" does not say to WHAT, and no 1.48.6→1.48.7 end-to-end result was taken
+  // (codex).
+  assert.match(note, /trying ComfyUI_frontend 1\.48\.7 may be the quickest workaround/i,
+    "the workaround names the measured build, not upgrading in general");
+  // And the datum is bounded to what capturing a request body can show.
+  assert.match(note, /establishes that the request is built correctly there, not that a whole run behaves differently/,
+    "serialization is not end-to-end behaviour, and the note says so");
   // #752's lesson, which this change sits one edit away from repeating: a version
   // RANGE is a claim about builds nobody here has measured. One build must not
-  // become one.
+  // become one. The first version of this guard missed "all 1.48.x builds" and
+  // "1.48.6 through 1.48.9" (codex), so it matches the SHAPES a range takes.
   assert.doesNotMatch(
     note,
-    /affects versions|all builds (before|after)|1\.4\d\s*-\s*1\.\d+/i,
+    /affects versions|all builds (before|after)|all 1\.\d+\.x|\d+\.\d+\.\d+\s*(-|–|through|to)\s*\d+\.\d+\.\d+|1\.4\d\s*-\s*1\.\d+/i,
     "one measured build must never be inflated into a range",
   );
 });

--- a/browser_tests/unit/run-scope-guard.test.mjs
+++ b/browser_tests/unit/run-scope-guard.test.mjs
@@ -893,6 +893,26 @@ test("#630 gate r1: graph_run's repair disclosure separates what was OBSERVED fr
   assert.match(note, /If it did not, its queue-time widget hooks ran/,
     "the hook consequence is conditional on the unobserved branch");
   assert.match(note, /does not change which nodes execute/, "and its blast radius is bounded honestly");
+  // #996 — the note used to end by sending reporters off to file with nothing to
+  // compare against. There is now one MEASURED fact to give them: on 1.48.7 the
+  // positional shape DOES put partial_execution_targets into the request, captured
+  // from the outgoing body, so the capability exists upstream and upgrading may be
+  // the shortest fix.
+  assert.match(
+    note,
+    /On ComfyUI_frontend 1\.48\.7 the positional argument shape DOES carry the scope/,
+    "the measured build is named, together with what was measured about it",
+  );
+  assert.match(note, /measured by capturing the outgoing body/, "and how it was established");
+  assert.match(note, /please report this build \(#996\)/, "the ask survives — one datum is not a diagnosis");
+  // #752's lesson, which this change sits one edit away from repeating: a version
+  // RANGE is a claim about builds nobody here has measured. One build must not
+  // become one.
+  assert.doesNotMatch(
+    note,
+    /affects versions|all builds (before|after)|1\.4\d\s*-\s*1\.\d+/i,
+    "one measured build must never be inflated into a range",
+  );
 });
 
 test("#630 gate r2: an explicit partial_execution_targets:null is a PRESENT key, never reported as 'no key at all'", async () => {

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -11355,11 +11355,13 @@ const GRAPH_TOOL_EXECUTORS = {
         // NOT paired with a claim about which builds are broken: this is one build
         // measured, and inventing a range from it is the #752 mistake exactly.
         `On ComfyUI_frontend 1.48.7 the positional argument shape DOES carry the ` +
-        `scope into the request — measured by capturing the outgoing body — so this ` +
-        `fallback is not expected on that build, and upgrading may be the shortest ` +
-        `fix. Which OTHER builds take which shape is not something the panel can ` +
-        `determine from inside one of them, so please report this build (#996), ` +
-        `including your ComfyUI_frontend version.`;
+        `scope into the request — measured by capturing the outgoing body, which ` +
+        `establishes that the request is built correctly there, not that a whole run ` +
+        `behaves differently — so this fallback is not expected on that build, and ` +
+        `trying ComfyUI_frontend 1.48.7 may be the quickest workaround. Which OTHER ` +
+        `builds take which shape is not something the panel can determine from inside ` +
+        `one of them, so please report this build (#996), including your ` +
+        `ComfyUI_frontend version.`;
     }
     // #556 (codex gate r3) — an EXTRA /prompt post carrying this run's identity
     // was fenced out. The requested prompts queued, so this is a DISCLOSURE and

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -11347,9 +11347,19 @@ const GRAPH_TOOL_EXECUTORS = {
         // real time: it told reporters their own evidence could not be happening.
         // A version range is a claim about builds nobody here has measured, and
         // this note has no way to earn one — so it no longer makes it.
-        `Please report this build (#556), including your ComfyUI_frontend version — ` +
-        `which builds take which argument shape is not something the panel can ` +
-        `determine from inside one of them.`;
+        // #996 — one MEASURED datum, because the note above sent reporters off to
+        // file with nothing to compare against. Measured directly on 1.48.7 by
+        // capturing the outgoing body: the POSITIONAL array shape puts
+        // `partial_execution_targets: ["<id>"]` into the request, so the capability
+        // is present upstream and this fallback should not fire there. Deliberately
+        // NOT paired with a claim about which builds are broken: this is one build
+        // measured, and inventing a range from it is the #752 mistake exactly.
+        `On ComfyUI_frontend 1.48.7 the positional argument shape DOES carry the ` +
+        `scope into the request — measured by capturing the outgoing body — so this ` +
+        `fallback is not expected on that build, and upgrading may be the shortest ` +
+        `fix. Which OTHER builds take which shape is not something the panel can ` +
+        `determine from inside one of them, so please report this build (#996), ` +
+        `including your ComfyUI_frontend version.`;
     }
     // #556 (codex gate r3) — an EXTRA /prompt post carrying this run's identity
     // was fenced out. The requested prompts queued, so this is a DISCLOSURE and


### PR DESCRIPTION
Claims #996.

**Reported:** on frontend **1.48.6**, every `panel_run({to_node_id})` falls back to `request_body_repair` — neither supported `app.queuePrompt` argument shape carries `partial_execution_targets` to `/prompt`. The repair works (only the requested branch executed, confirmed by render times), but it is now the *only* thing between a scoped request and a full-graph execution.

The panel's own note asks reporters to file this, so this is the note doing its job.

**Question 1 is directly measurable and I have the rig**: I run frontend **1.48.7**, one patch above the report. I can read `app.queuePrompt`'s actual signature and determine which shape — positional `NodeExecutionId[]`, or `{queueNodeIds}` options — reaches the request, without executing anything.

- [ ] read the real `app.queuePrompt` signature on 1.48.7 and determine whether either shape carries the scope
- [ ] if neither does, establish whether the capability was dropped or renamed upstream
- [ ] question 3: whether the affected range can be detected up front instead of per-call
- [ ] question 2 (`uncovered_inputs` drift) — likely a consequence, to be confirmed or split out
- [ ] codex review
- [ ] browser verification

Deliberately **not** starting from the assumption that the panel is passing the wrong shape. It may be that 1.48.x genuinely dropped the parameter, in which case the honest fix is detection and a clear up-front statement rather than a third argument shape to try.