### PR TITLE
fix(unpack): promoted widget values must survive panel_unpack_subgraph (#979)

### DIFF
--- a/browser_tests/unit/unpack-promoted-values.test.mjs
+++ b/browser_tests/unit/unpack-promoted-values.test.mjs
@@ -262,7 +262,19 @@ test("#979 (codex final): an INDETERMINATE resolver result refuses — only `pro
   // Truthiness was too weak: `undefined`, `null`, `{}` and `{promoted: undefined}` are
   // all "I do not know", and treating them as ordinary widgets let a divergent value be
   // destroyed in BOTH modes — carried-with-snapshot and preflight-without.
-  for (const result of [undefined, null, {}, { promoted: undefined }, { promoted: true, target: {} }]) {
+  for (const result of [
+    undefined,
+    null,
+    {},
+    { promoted: undefined },
+    { promoted: true, target: {} },
+    // A widget with NO node: accepted before, so a malformed resolver could steer the
+    // carry into a widget nothing owns — the write lands there and is reported as a
+    // success while the unpack still inlines the real inner widget's old value.
+    { promoted: true, target: { widget: { name: "text", value: "DECOY" } } },
+    // …and the mirror image.
+    { promoted: true, target: { node: { id: 9 } } },
+  ]) {
     const res = materializePromotedValues({ id: 5, widgets: [widget("text", "NEW")] }, () => result);
     assert.deepEqual(res.unresolved, [], `snapshot mode: ${JSON.stringify(result)} must not be benign`);
     assert.equal(res.unrecoverable.length, 1, `snapshot mode: ${JSON.stringify(result)} must refuse`);

--- a/browser_tests/unit/unpack-promoted-values.test.mjs
+++ b/browser_tests/unit/unpack-promoted-values.test.mjs
@@ -175,6 +175,24 @@ test("#979 (codex): one hostile widget costs its own entry, not every rail after
   assert.deepEqual(res.unresolved, [], "no longer filed as merely unresolved");
 });
 
+test("#979 (codex final): promoted-but-unresolvable REFUSES; definitively-not-promoted does not", () => {
+  // Collapsing these was the last hole. `promoted: false` is proof the rail is an
+  // ordinary widget — refusing over those would block healthy unpacks. `promoted: true`
+  // with no usable target is an UNKNOWN, and its value may be diverged.
+  const unknown = materializePromotedValues({ id: 5, widgets: [widget("text", "NEW")] }, () => ({
+    promoted: true,
+    target: null,
+  }));
+  assert.deepEqual(unknown.unresolved, []);
+  assert.equal(unknown.unrecoverable.length, 1, "an unresolvable promotion must stop the unpack");
+  assert.match(unknown.unrecoverable[0].reason, /could not be identified/);
+  assert.equal(unknown.unrecoverable[0].value_restored, true, "nothing was written, so the graph is as found");
+
+  const ordinary = materializePromotedValues({ id: 5, widgets: [widget("text", "NEW")] }, () => ({ promoted: false }));
+  assert.deepEqual(ordinary.unrecoverable, [], "an ordinary widget is not a reason to refuse");
+  assert.equal(ordinary.unresolved.length, 1);
+});
+
 test("#979 (codex final): an ITERATION-level throw is reported as aborted, not as no-work-done", () => {
   // Per-rail isolation does not cover the loop itself. An indexed getter that throws
   // after an earlier rail was carried used to escape the function, so the executor

--- a/browser_tests/unit/unpack-promoted-values.test.mjs
+++ b/browser_tests/unit/unpack-promoted-values.test.mjs
@@ -1,0 +1,157 @@
+/**
+ * #979 — panel_unpack_subgraph replaced promoted widget values with the inner nodes'
+ * defaults: a long custom prompt became a pack's template text, a duration of 15
+ * became 2.
+ *
+ * MEASURED on ComfyUI 0.31.1 / frontend 1.48.7, forcing rail and inner to differ:
+ *
+ *   before unpack:  rail = "RAIL-VALUE-THE-USER-SET"   inner = "ORIGINAL-INNER"
+ *   after  unpack:  "ORIGINAL-INNER"
+ *
+ * `unpackSubgraph` inlines the INNER value and drops the parent rail's. #366 makes
+ * the rail authoritative — it is what serializes at queue time — so the fix carries
+ * rail → inner BEFORE the unpack, which is destructive and cannot be undone from its
+ * own result.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+import {
+  materializePromotedValues,
+  materializedValuesNote,
+} from "../../web/js/lib/unpack-promoted-values.js";
+
+const widget = (name, value) => ({ name, value });
+/** A resolver in the shape resolvePromotedInnerTarget returns. */
+const resolverFor = (map) => (_sgNode, widgetName) => {
+  const hit = map[widgetName];
+  return hit ? { promoted: true, target: { node: hit.node, widget: hit.widget } } : { promoted: false };
+};
+
+test("#979 a diverged promoted value is carried into the inner widget", () => {
+  const inner = widget("text", "ORIGINAL-INNER");
+  const sgNode = { id: 5, widgets: [widget("text", "RAIL-VALUE-THE-USER-SET")] };
+  const res = materializePromotedValues(sgNode, resolverFor({ text: { node: { id: 9 }, widget: inner } }));
+  assert.equal(inner.value, "RAIL-VALUE-THE-USER-SET", "the value that would have rendered is the one kept");
+  assert.deepEqual(res.applied, [{ widget: "text", node_id: "9", inner_widget: "text" }]);
+  assert.deepEqual(res.unresolved, []);
+});
+
+test("#979 the reporter's two shapes: a long prompt and a numeric duration", () => {
+  const prompt = widget("prompt", "Vaporwave template default");
+  const duration = widget("value", 2);
+  const sgNode = {
+    id: 105,
+    widgets: [widget("prompt", "a long custom cosmic prompt"), widget("value_1", 15)],
+  };
+  const res = materializePromotedValues(
+    sgNode,
+    resolverFor({
+      prompt: { node: { id: 134 }, widget: prompt },
+      value_1: { node: { id: 136 }, widget: duration },
+    }),
+  );
+  assert.equal(prompt.value, "a long custom cosmic prompt");
+  assert.equal(duration.value, 15);
+  assert.equal(res.applied.length, 2);
+});
+
+test("#979 a value that already matches is NOT rewritten — no callback fired for a no-op", () => {
+  // The unpack path is about to restructure the graph; firing node callbacks for
+  // values that never changed is gratuitous risk on the way there.
+  let writes = 0;
+  const inner = {
+    name: "text",
+    _v: "same",
+    get value() {
+      return this._v;
+    },
+    set value(v) {
+      writes += 1;
+      this._v = v;
+    },
+  };
+  const sgNode = { id: 5, widgets: [widget("text", "same")] };
+  const res = materializePromotedValues(sgNode, resolverFor({ text: { node: { id: 9 }, widget: inner } }));
+  assert.equal(writes, 0, "no write for an identical value");
+  assert.equal(res.skipped, 1);
+  assert.deepEqual(res.applied, []);
+});
+
+test("#979 a rail widget that resolves to NO promotion is left alone and reported", () => {
+  // Not every widget on a subgraph node is a promotion. Writing one that could not be
+  // resolved would be #233's silent-corruption class, pointed inward.
+  const sgNode = { id: 5, widgets: [widget("not_promoted", "x")] };
+  const res = materializePromotedValues(sgNode, resolverFor({}));
+  assert.deepEqual(res.applied, []);
+  assert.deepEqual(res.unresolved, [{ widget: "not_promoted" }]);
+});
+
+test("#979 an inner widget that REJECTS or ignores the write is reported, never claimed as carried", () => {
+  const frozen = Object.freeze({ name: "text", value: "ORIGINAL" });
+  const ignoring = {
+    name: "text",
+    get value() {
+      return "ORIGINAL";
+    },
+    set value(_v) {
+      /* silently drops it */
+    },
+  };
+  for (const inner of [frozen, ignoring]) {
+    const sgNode = { id: 5, widgets: [widget("text", "NEW")] };
+    const res = materializePromotedValues(sgNode, resolverFor({ text: { node: { id: 9 }, widget: inner } }));
+    assert.deepEqual(res.applied, [], "a value that did not land is never reported as preserved");
+    assert.equal(res.unresolved.length, 1);
+    assert.match(res.unresolved[0].reason, /rejected the write|did not retain the value/);
+  }
+});
+
+test("#979 a THROWING resolver costs coverage, never the unpack", () => {
+  const sgNode = { id: 5, widgets: [widget("text", "NEW")] };
+  const res = materializePromotedValues(sgNode, () => {
+    throw new Error("resolver boom");
+  });
+  assert.deepEqual(res.applied, []);
+  assert.deepEqual(res.unresolved, [{ widget: "text" }]);
+});
+
+test("#979 malformed input yields nothing and never throws", () => {
+  for (const bad of [null, undefined, {}, { widgets: "nope" }, { widgets: [null, {}, { name: 7 }] }]) {
+    assert.doesNotThrow(() => materializePromotedValues(bad, resolverFor({})));
+    assert.deepEqual(materializePromotedValues(bad, resolverFor({})).applied, []);
+  }
+  assert.deepEqual(materializePromotedValues({ widgets: [widget("a", 1)] }, null).applied, []);
+});
+
+test("#979 the note discloses what moved, and stays silent when nothing did", () => {
+  const inner = widget("text", "OLD");
+  const sgNode = { id: 5, widgets: [widget("text", "NEW")] };
+  const res = materializePromotedValues(sgNode, resolverFor({ text: { node: { id: 9 }, widget: inner } }));
+  const note = materializedValuesNote(res);
+  assert.match(note, /Carried 1 promoted widget value/);
+  assert.match(note, /text → node 9/, "names what moved and where it went");
+  assert.match(note, /serializes at queue time/, "says WHY the parent's value is the one kept");
+  assert.equal(materializedValuesNote({ applied: [], unresolved: [], skipped: 3 }), "", "silent when nothing moved");
+  assert.equal(materializedValuesNote(null), "");
+});
+
+test("#979 the note warns that unresolved widgets cannot be checked afterwards", () => {
+  const note = materializedValuesNote({ applied: [], unresolved: [{ widget: "seed" }] });
+  assert.match(note, /could not be matched/);
+  assert.match(note, /unpack cannot be undone/, "the reason to check now rather than later");
+});
+
+test("#979 source guard: the unpack path materializes BEFORE it unpacks, and discloses", () => {
+  // Order is the whole fix — running it after the unpack would read a rail that no
+  // longer exists. The executor lives inside the monolith's switch, so this is
+  // asserted against the shipped source.
+  const src = readFileSync(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8");
+  const materialize = src.indexOf("materialized = materializePromotedValues(node,");
+  const unpack = src.indexOf("graph.unpackSubgraph(node, { skipMissingNodes: true })");
+  assert.ok(materialize > 0, "the unpack path must carry promoted values");
+  assert.ok(unpack > 0, "the unpack call must still be there");
+  assert.ok(materialize < unpack, "and the carry must happen BEFORE the unpack");
+  assert.match(src, /promoted_values_carried/, "and the result discloses what was carried");
+});

--- a/browser_tests/unit/unpack-promoted-values.test.mjs
+++ b/browser_tests/unit/unpack-promoted-values.test.mjs
@@ -165,9 +165,44 @@ test("#979 (codex): one hostile widget costs its own entry, not every rail after
   const res = materializePromotedValues(sgNode, resolverFor({ text: { node: { id: 9 }, widget: good } }));
   assert.equal(good.value, "NEW", "the rail AFTER the hostile one was still carried");
   assert.deepEqual(res.applied.map((a) => a.widget), ["text"]);
-  assert.equal(res.unresolved.length, 1, "and the hostile one is disclosed, not swallowed");
-  assert.deepEqual(res.unrecoverable, [], "a widget never written to is not a reason to refuse the unpack");
-  assert.match(res.unresolved[0].reason, /could not be inspected/);
+  // codex final: a throwing accessor is UNRECOVERABLE, not a benign annotation. The
+  // latch proves a write happened; its absence proves nothing, because the resolver
+  // and the value getters all run before it — and an accessor that MUTATES and then
+  // throws is precisely this module's stated threat model. On a destructive path an
+  // exception means the state cannot be proven, and unprovable is treated as unsafe.
+  assert.equal(res.unrecoverable.length, 1, "the hostile widget refuses the unpack");
+  assert.match(res.unrecoverable[0].reason, /cannot be established|value from neither side/);
+  assert.deepEqual(res.unresolved, [], "no longer filed as merely unresolved");
+});
+
+test("#979 (codex final): an ITERATION-level throw is reported as aborted, not as no-work-done", () => {
+  // Per-rail isolation does not cover the loop itself. An indexed getter that throws
+  // after an earlier rail was carried used to escape the function, so the executor
+  // discarded the whole record and unpacked anyway — destroying the very values this
+  // protects. The partial carry must reach the caller as a refusal.
+  const good = widget("text", "OLD");
+  const rails = [widget("text", "NEW"), widget("other", 1)];
+  const hostileList = new Proxy(rails, {
+    get(target, key) {
+      if (key === "1") throw new Error("index boom");
+      return target[key];
+    },
+  });
+  const sgNode = { id: 5, widgets: hostileList };
+  const res = materializePromotedValues(sgNode, resolverFor({ text: { node: { id: 9 }, widget: good } }));
+  assert.equal(res.aborted, true, "the caller must learn the loop came apart");
+  assert.equal(good.value, "NEW", "and that work HAD already been done, which is why it matters");
+});
+
+test("#979 (codex final): a resolver that throws in the read-only preflight refuses, not skips", () => {
+  // With no snapshot there is nothing to undo with, so an unknown promotion status is
+  // exactly what must stop the unpack — skipping would destroy a divergent value with
+  // no copy anywhere.
+  const divergent = findDivergentPromotedValues({ id: 5, widgets: [widget("text", "NEW")] }, () => {
+    throw new Error("resolver boom");
+  });
+  assert.equal(divergent.length, 1);
+  assert.match(divergent[0].reason, /could not be resolved/);
 });
 
 test("#979 (codex): a throwing accessor on the REPORT metadata does not lose the transfer", () => {
@@ -296,6 +331,19 @@ test("#979 (codex r4): no divergence ⇒ nothing to refuse over", () => {
   // A rail that is not a promotion is not a divergence either.
   assert.deepEqual(findDivergentPromotedValues({ id: 5, widgets: [widget("x", 1)] }, resolverFor({})), []);
   assert.deepEqual(findDivergentPromotedValues(null, resolverFor({})), []);
+});
+
+test("#979 (codex final) source guard: an aborted or thrown carry refuses instead of unpacking", () => {
+  // The worst case codex found: the carry throws at iteration level AFTER carrying a
+  // rail, the executor discards the record, and unpacks anyway. The refusal must key
+  // on the carry having FAILED, not only on it having produced findings.
+  const src = readFileSync(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8");
+  assert.match(src, /carryFailed = !!materialized\?\.aborted/, "an aborted iteration is a failure");
+  assert.match(src, /carryFailed = true/, "and so is a throw escaping the carry");
+  const guard = src.indexOf("if (carryFailed || materialized?.unrecoverable?.length)");
+  const unpack = src.indexOf("graph.unpackSubgraph(node, { skipMissingNodes: true })");
+  assert.ok(guard > 0, "the refusal must key on carryFailed, not only on findings");
+  assert.ok(guard < unpack, "and precede the destructive call");
 });
 
 test("#979 (codex r4) source guard: no snapshot ⇒ preflight refuses rather than losing values", () => {

--- a/browser_tests/unit/unpack-promoted-values.test.mjs
+++ b/browser_tests/unit/unpack-promoted-values.test.mjs
@@ -108,6 +108,85 @@ test("#979 an inner widget that REJECTS or ignores the write is reported, never 
   }
 });
 
+test("#979 (codex): a setter that MUTATES then THROWS is rolled back, not left half-applied", () => {
+  // The path the first version corrupted: assignment happened, the throw was caught,
+  // the widget was reported unresolved — and left holding the new value, which the
+  // unpack then made permanent. Silent destructive corruption on the error path.
+  const inner = {
+    name: "text",
+    _v: "ORIGINAL",
+    get value() {
+      return this._v;
+    },
+    set value(v) {
+      this._v = v; // applies…
+      throw new Error("setter boom"); // …then fails
+    },
+  };
+  const sgNode = { id: 5, widgets: [widget("text", "NEW")] };
+  const res = materializePromotedValues(sgNode, resolverFor({ text: { node: { id: 9 }, widget: inner } }));
+  assert.equal(inner._v, "ORIGINAL", "the widget is left exactly as it was found");
+  assert.deepEqual(res.applied, []);
+  assert.equal(res.unresolved[0].reason, "inner widget rejected the write");
+});
+
+test("#979 (codex): a COERCING setter is rolled back — a third value never reaches the graph", () => {
+  // Worse than a rejection: the widget ends up holding something that was in neither
+  // the rail nor the inner, and the unpack commits it.
+  const inner = {
+    name: "steps",
+    _v: 20,
+    get value() {
+      return this._v;
+    },
+    set value(v) {
+      this._v = Math.min(Number(v) || 0, 30); // clamps 45 -> 30
+    },
+  };
+  const sgNode = { id: 5, widgets: [widget("steps", 45)] };
+  const res = materializePromotedValues(sgNode, resolverFor({ steps: { node: { id: 9 }, widget: inner } }));
+  assert.equal(inner._v, 20, "restored to what was found, not left at the clamped 30");
+  assert.deepEqual(res.applied, []);
+  assert.equal(res.unresolved[0].reason, "inner widget did not retain the value");
+});
+
+test("#979 (codex): one hostile widget costs its own entry, not every rail after it", () => {
+  // A throwing accessor used to abort the whole loop: the remaining rails kept their
+  // stale inner values AND the disclosure was suppressed, on a path that destroys the
+  // subgraph regardless.
+  const good = widget("text", "OLD");
+  const hostile = {
+    get name() {
+      throw new Error("name boom");
+    },
+  };
+  const sgNode = { id: 5, widgets: [hostile, widget("text", "NEW")] };
+  const res = materializePromotedValues(sgNode, resolverFor({ text: { node: { id: 9 }, widget: good } }));
+  assert.equal(good.value, "NEW", "the rail AFTER the hostile one was still carried");
+  assert.deepEqual(res.applied.map((a) => a.widget), ["text"]);
+  assert.equal(res.unresolved.length, 1, "and the hostile one is disclosed, not swallowed");
+  assert.match(res.unresolved[0].reason, /could not be inspected/);
+});
+
+test("#979 (codex): a throwing accessor on the REPORT metadata does not lose the transfer", () => {
+  const inner = {
+    _v: "OLD",
+    get value() {
+      return this._v;
+    },
+    set value(v) {
+      this._v = v;
+    },
+    get name() {
+      throw new Error("meta boom");
+    },
+  };
+  const sgNode = { id: 5, widgets: [widget("text", "NEW")] };
+  const res = materializePromotedValues(sgNode, resolverFor({ text: { node: { id: 9 }, widget: inner } }));
+  assert.equal(inner._v, "NEW", "the value WAS carried — that must not be undone by a reporting failure");
+  assert.equal(res.applied.length + res.unresolved.length, 1, "and it is accounted for exactly once");
+});
+
 test("#979 a THROWING resolver costs coverage, never the unpack", () => {
   const sgNode = { id: 5, widgets: [widget("text", "NEW")] };
   const res = materializePromotedValues(sgNode, () => {

--- a/browser_tests/unit/unpack-promoted-values.test.mjs
+++ b/browser_tests/unit/unpack-promoted-values.test.mjs
@@ -258,6 +258,28 @@ test("#979 (codex final): the preflight refuses a promoted rail whose target can
   );
 });
 
+test("#979 (codex final): an INDETERMINATE resolver result refuses — only `promoted === false` is proof", () => {
+  // Truthiness was too weak: `undefined`, `null`, `{}` and `{promoted: undefined}` are
+  // all "I do not know", and treating them as ordinary widgets let a divergent value be
+  // destroyed in BOTH modes — carried-with-snapshot and preflight-without.
+  for (const result of [undefined, null, {}, { promoted: undefined }, { promoted: true, target: {} }]) {
+    const res = materializePromotedValues({ id: 5, widgets: [widget("text", "NEW")] }, () => result);
+    assert.deepEqual(res.unresolved, [], `snapshot mode: ${JSON.stringify(result)} must not be benign`);
+    assert.equal(res.unrecoverable.length, 1, `snapshot mode: ${JSON.stringify(result)} must refuse`);
+
+    const div = findDivergentPromotedValues({ id: 5, widgets: [widget("text", "NEW")] }, () => result);
+    assert.equal(div.length, 1, `preflight mode: ${JSON.stringify(result)} must refuse`);
+  }
+  // The one benign shape, in both modes.
+  const ok = materializePromotedValues({ id: 5, widgets: [widget("text", "NEW")] }, () => ({ promoted: false }));
+  assert.equal(ok.unresolved.length, 1);
+  assert.deepEqual(ok.unrecoverable, []);
+  assert.deepEqual(
+    findDivergentPromotedValues({ id: 5, widgets: [widget("text", "NEW")] }, () => ({ promoted: false })),
+    [],
+  );
+});
+
 test("#979 (codex final): an ITERATION-level throw is reported as aborted, not as no-work-done", () => {
   // Per-rail isolation does not cover the loop itself. An indexed getter that throws
   // after an earlier rail was carried used to escape the function, so the executor

--- a/browser_tests/unit/unpack-promoted-values.test.mjs
+++ b/browser_tests/unit/unpack-promoted-values.test.mjs
@@ -187,6 +187,58 @@ test("#979 (codex): a throwing accessor on the REPORT metadata does not lose the
   assert.equal(res.applied.length + res.unresolved.length, 1, "and it is accounted for exactly once");
 });
 
+test("#979 (codex r2): a restore that ALSO normalizes is UNRECOVERABLE, not merely unresolved", () => {
+  // The case the transactional restore alone did not cover: the setter clamps the
+  // rail write (45 → 30) AND clamps the restore of the original (20 → 25). The widget
+  // ends up holding a third value that was in neither the rail nor the inner, and
+  // unpacking over it would make that invented value permanent.
+  const inner = {
+    name: "steps",
+    _v: 20,
+    get value() {
+      return this._v;
+    },
+    set value(v) {
+      this._v = Math.max(Math.min(Number(v) || 0, 30), 25); // clamps BOTH directions
+    },
+  };
+  const sgNode = { id: 5, widgets: [widget("steps", 45)] };
+  const res = materializePromotedValues(sgNode, resolverFor({ steps: { node: { id: 9 }, widget: inner } }));
+  assert.deepEqual(res.applied, []);
+  assert.deepEqual(res.unresolved, [], "this is NOT a mere annotation");
+  assert.equal(res.unrecoverable.length, 1, "it is the condition that must stop the unpack");
+  assert.match(res.unrecoverable[0].reason, /could not be restored/);
+});
+
+test("#979 (codex r2): a recoverable failure stays unresolved and does NOT stop the unpack", () => {
+  // The boundary: a clean rollback is reported, but it is not a reason to refuse.
+  const inner = {
+    name: "steps",
+    _v: 20,
+    get value() {
+      return this._v;
+    },
+    set value(v) {
+      this._v = Number(v) === 45 ? 30 : Number(v); // clamps the write, restores cleanly
+    },
+  };
+  const sgNode = { id: 5, widgets: [widget("steps", 45)] };
+  const res = materializePromotedValues(sgNode, resolverFor({ steps: { node: { id: 9 }, widget: inner } }));
+  assert.equal(inner._v, 20, "put back exactly");
+  assert.equal(res.unresolved.length, 1);
+  assert.deepEqual(res.unrecoverable, [], "nothing to refuse over");
+});
+
+test("#979 (codex r2) source guard: the unpack REFUSES when a carry could not be rolled back", () => {
+  const src = readFileSync(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8");
+  const guard = src.indexOf("materialized?.unrecoverable?.length");
+  const unpack = src.indexOf("graph.unpackSubgraph(node, { skipMissingNodes: true })");
+  assert.ok(guard > 0, "the refusal must exist");
+  assert.ok(guard < unpack, "and it must come BEFORE the destructive call");
+  assert.match(src, /unpack_subgraph refused/, "and it refuses rather than annotating");
+  assert.match(src, /nothing was destroyed/, "and says the subgraph is intact when it could restore");
+});
+
 test("#979 a THROWING resolver costs coverage, never the unpack", () => {
   const sgNode = { id: 5, widgets: [widget("text", "NEW")] };
   const res = materializePromotedValues(sgNode, () => {

--- a/browser_tests/unit/unpack-promoted-values.test.mjs
+++ b/browser_tests/unit/unpack-promoted-values.test.mjs
@@ -20,6 +20,7 @@ import { readFileSync } from "node:fs";
 import {
   materializePromotedValues,
   materializedValuesNote,
+  findDivergentPromotedValues,
 } from "../../web/js/lib/unpack-promoted-values.js";
 
 const widget = (name, value) => ({ name, value });
@@ -242,6 +243,68 @@ test("#979 (codex r2) source guard: the unpack REFUSES when a carry could not be
   assert.ok(guard < unpack, "and it must come BEFORE the destructive call");
   assert.match(src, /unpack_subgraph refused/, "and it refuses rather than annotating");
   assert.match(src, /nothing was destroyed/, "and says the subgraph is intact when it could restore");
+});
+
+test("#979 (codex r4): the write-attempt latch keeps a post-write throw UNRECOVERABLE", () => {
+  // A setter can mutate and then a LATER read (read-back, metadata, any accessor) can
+  // throw. The outer per-rail catch used to file that as a benign "could not inspect"
+  // and let the unpack proceed over a widget that had already been written.
+  let reads = 0;
+  const inner = {
+    _v: "OLD",
+    get value() {
+      reads += 1;
+      if (reads > 1) throw new Error("read-back boom"); // throws AFTER the write
+      return this._v;
+    },
+    set value(v) {
+      this._v = v;
+    },
+  };
+  const sgNode = { id: 5, widgets: [widget("text", "NEW")] };
+  const res = materializePromotedValues(sgNode, resolverFor({ text: { node: { id: 9 }, widget: inner } }));
+  assert.deepEqual(res.applied, []);
+  assert.deepEqual(res.unresolved, [], "a post-write throw is never benign");
+  assert.equal(res.unrecoverable.length, 1, "it stops the unpack");
+});
+
+test("#979 (codex r4): findDivergentPromotedValues is READ-ONLY and finds the divergence", () => {
+  // Used when no rollback snapshot exists, so it must not write anything.
+  let writes = 0;
+  const inner = {
+    name: "text",
+    _v: "OLD",
+    get value() {
+      return this._v;
+    },
+    set value(v) {
+      writes += 1;
+      this._v = v;
+    },
+  };
+  const sgNode = { id: 5, widgets: [widget("text", "NEW")] };
+  const divergent = findDivergentPromotedValues(sgNode, resolverFor({ text: { node: { id: 9 }, widget: inner } }));
+  assert.deepEqual(divergent, [{ widget: "text" }]);
+  assert.equal(writes, 0, "READ-ONLY — it runs where a failed write could not be undone");
+  assert.equal(inner._v, "OLD");
+});
+
+test("#979 (codex r4): no divergence ⇒ nothing to refuse over", () => {
+  const inner = widget("text", "SAME");
+  const sgNode = { id: 5, widgets: [widget("text", "SAME")] };
+  assert.deepEqual(findDivergentPromotedValues(sgNode, resolverFor({ text: { node: { id: 9 }, widget: inner } })), []);
+  // A rail that is not a promotion is not a divergence either.
+  assert.deepEqual(findDivergentPromotedValues({ id: 5, widgets: [widget("x", 1)] }, resolverFor({})), []);
+  assert.deepEqual(findDivergentPromotedValues(null, resolverFor({})), []);
+});
+
+test("#979 (codex r4) source guard: no snapshot ⇒ preflight refuses rather than losing values", () => {
+  const src = readFileSync(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8");
+  const preflight = src.indexOf("findDivergentPromotedValues(node,");
+  const unpack = src.indexOf("graph.unpackSubgraph(node, { skipMissingNodes: true })");
+  assert.ok(preflight > 0 && preflight < unpack, "the preflight must run before the destructive call");
+  assert.match(src, /could not be snapshotted/, "and it says why it refused");
+  assert.match(src, /Nothing was ` \+\s*`changed/, "and that nothing was changed");
 });
 
 test("#979 a THROWING resolver costs coverage, never the unpack", () => {

--- a/browser_tests/unit/unpack-promoted-values.test.mjs
+++ b/browser_tests/unit/unpack-promoted-values.test.mjs
@@ -193,6 +193,71 @@ test("#979 (codex final): promoted-but-unresolvable REFUSES; definitively-not-pr
   assert.equal(ordinary.unresolved.length, 1);
 });
 
+test("#979 (codex final): an accessor that MUTATES then throws refuses — it is not swallowed", () => {
+  // The internal catches used to file these as `unresolved`, so the unpack proceeded
+  // over state nothing could prove. Each of the three pre-write reads is injected or
+  // node-supplied code that can mutate on its way to throwing.
+  let sideEffects = 0;
+  const cases = {
+    "resolver throws": {
+      widgets: [widget("text", "NEW")],
+      resolve: () => {
+        sideEffects += 1;
+        throw new Error("resolver mutated then threw");
+      },
+    },
+    "rail getter throws": {
+      widgets: [
+        {
+          name: "text",
+          get value() {
+            sideEffects += 1;
+            throw new Error("rail getter mutated then threw");
+          },
+        },
+      ],
+      resolve: () => ({ promoted: true, target: { node: { id: 9 }, widget: widget("text", "OLD") } }),
+    },
+    "inner getter throws": {
+      widgets: [widget("text", "NEW")],
+      resolve: () => ({
+        promoted: true,
+        target: {
+          node: { id: 9 },
+          widget: {
+            name: "text",
+            get value() {
+              sideEffects += 1;
+              throw new Error("inner getter mutated then threw");
+            },
+            set value(_v) {},
+          },
+        },
+      }),
+    },
+  };
+  for (const [label, c] of Object.entries(cases)) {
+    const res = materializePromotedValues({ id: 5, widgets: c.widgets }, c.resolve);
+    assert.deepEqual(res.unresolved, [], `${label}: never benign`);
+    assert.equal(res.unrecoverable.length, 1, `${label}: must refuse the unpack`);
+  }
+  assert.ok(sideEffects >= 3, "each case really did run the accessor");
+});
+
+test("#979 (codex final): the preflight refuses a promoted rail whose target cannot be identified", () => {
+  const divergent = findDivergentPromotedValues({ id: 5, widgets: [widget("text", "NEW")] }, () => ({
+    promoted: true,
+    target: null,
+  }));
+  assert.equal(divergent.length, 1, "unknown promotion + no snapshot ⇒ refuse");
+  assert.match(divergent[0].reason, /could not be identified/);
+  // And a definitive non-promotion still does not block.
+  assert.deepEqual(
+    findDivergentPromotedValues({ id: 5, widgets: [widget("x", 1)] }, () => ({ promoted: false })),
+    [],
+  );
+});
+
 test("#979 (codex final): an ITERATION-level throw is reported as aborted, not as no-work-done", () => {
   // Per-rail isolation does not cover the loop itself. An indexed getter that throws
   // after an earlier rail was carried used to escape the function, so the executor
@@ -373,13 +438,19 @@ test("#979 (codex r4) source guard: no snapshot ⇒ preflight refuses rather tha
   assert.match(src, /Nothing was ` \+\s*`changed/, "and that nothing was changed");
 });
 
-test("#979 a THROWING resolver costs coverage, never the unpack", () => {
+test("#979 a THROWING resolver REFUSES the unpack (contract tightened by codex final)", () => {
+  // This test originally asserted the opposite — that a throwing resolver merely cost
+  // coverage and the unpack continued. That was the hole: the resolver is injected
+  // code running against the live graph, and one that mutates before throwing left
+  // the unpack to proceed over state nothing could prove.
   const sgNode = { id: 5, widgets: [widget("text", "NEW")] };
   const res = materializePromotedValues(sgNode, () => {
     throw new Error("resolver boom");
   });
   assert.deepEqual(res.applied, []);
-  assert.deepEqual(res.unresolved, [{ widget: "text" }]);
+  assert.deepEqual(res.unresolved, []);
+  assert.equal(res.unrecoverable.length, 1);
+  assert.match(res.unrecoverable[0].reason, /cannot be established/);
 });
 
 test("#979 malformed input yields nothing and never throws", () => {

--- a/browser_tests/unit/unpack-promoted-values.test.mjs
+++ b/browser_tests/unit/unpack-promoted-values.test.mjs
@@ -103,8 +103,8 @@ test("#979 an inner widget that REJECTS or ignores the write is reported, never 
     const sgNode = { id: 5, widgets: [widget("text", "NEW")] };
     const res = materializePromotedValues(sgNode, resolverFor({ text: { node: { id: 9 }, widget: inner } }));
     assert.deepEqual(res.applied, [], "a value that did not land is never reported as preserved");
-    assert.equal(res.unresolved.length, 1);
-    assert.match(res.unresolved[0].reason, /rejected the write|did not retain the value/);
+    assert.equal(res.unrecoverable.length, 1);
+    assert.match(res.unrecoverable[0].reason, /rejected the write|did not retain the value/);
   }
 });
 
@@ -127,7 +127,7 @@ test("#979 (codex): a setter that MUTATES then THROWS is rolled back, not left h
   const res = materializePromotedValues(sgNode, resolverFor({ text: { node: { id: 9 }, widget: inner } }));
   assert.equal(inner._v, "ORIGINAL", "the widget is left exactly as it was found");
   assert.deepEqual(res.applied, []);
-  assert.equal(res.unresolved[0].reason, "inner widget rejected the write");
+  assert.match(res.unrecoverable[0].reason, /inner widget rejected the write/);
 });
 
 test("#979 (codex): a COERCING setter is rolled back — a third value never reaches the graph", () => {
@@ -147,7 +147,7 @@ test("#979 (codex): a COERCING setter is rolled back — a third value never rea
   const res = materializePromotedValues(sgNode, resolverFor({ steps: { node: { id: 9 }, widget: inner } }));
   assert.equal(inner._v, 20, "restored to what was found, not left at the clamped 30");
   assert.deepEqual(res.applied, []);
-  assert.equal(res.unresolved[0].reason, "inner widget did not retain the value");
+  assert.match(res.unrecoverable[0].reason, /inner widget did not retain the value/);
 });
 
 test("#979 (codex): one hostile widget costs its own entry, not every rail after it", () => {
@@ -165,6 +165,7 @@ test("#979 (codex): one hostile widget costs its own entry, not every rail after
   assert.equal(good.value, "NEW", "the rail AFTER the hostile one was still carried");
   assert.deepEqual(res.applied.map((a) => a.widget), ["text"]);
   assert.equal(res.unresolved.length, 1, "and the hostile one is disclosed, not swallowed");
+  assert.deepEqual(res.unrecoverable, [], "a widget never written to is not a reason to refuse the unpack");
   assert.match(res.unresolved[0].reason, /could not be inspected/);
 });
 
@@ -184,7 +185,11 @@ test("#979 (codex): a throwing accessor on the REPORT metadata does not lose the
   const sgNode = { id: 5, widgets: [widget("text", "NEW")] };
   const res = materializePromotedValues(sgNode, resolverFor({ text: { node: { id: 9 }, widget: inner } }));
   assert.equal(inner._v, "NEW", "the value WAS carried — that must not be undone by a reporting failure");
-  assert.equal(res.applied.length + res.unresolved.length, 1, "and it is accounted for exactly once");
+  assert.equal(
+    res.applied.length + res.unresolved.length + res.unrecoverable.length,
+    1,
+    "and it is accounted for exactly once, in whichever bucket",
+  );
 });
 
 test("#979 (codex r2): a restore that ALSO normalizes is UNRECOVERABLE, not merely unresolved", () => {
@@ -225,8 +230,8 @@ test("#979 (codex r2): a recoverable failure stays unresolved and does NOT stop 
   const sgNode = { id: 5, widgets: [widget("steps", 45)] };
   const res = materializePromotedValues(sgNode, resolverFor({ steps: { node: { id: 9 }, widget: inner } }));
   assert.equal(inner._v, 20, "put back exactly");
-  assert.equal(res.unresolved.length, 1);
-  assert.deepEqual(res.unrecoverable, [], "nothing to refuse over");
+  assert.equal(res.unrecoverable.length, 1);
+  assert.equal(res.unrecoverable.length, 1, "codex r3: a clean scalar restore is still not proof the widget is recovered");
 });
 
 test("#979 (codex r2) source guard: the unpack REFUSES when a carry could not be rolled back", () => {

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -157,7 +157,11 @@ import {
   disabledOutputsInPrompt,
   disabledOutputsNote,
 } from "./lib/muted-subgraph-outputs.js";
-import { materializePromotedValues, materializedValuesNote } from "./lib/unpack-promoted-values.js";
+import {
+  materializePromotedValues,
+  materializedValuesNote,
+  findDivergentPromotedValues,
+} from "./lib/unpack-promoted-values.js";
 import { readSaveFailureCause } from "./lib/userdata-failure-cause.js";
 import { describeScreenshotFraming } from "./lib/screenshot-framing.js";
 import { readActiveSidebarTab, shouldDetachPanelRoot, findSidebarTabButton } from "./lib/active-sidebar-tab.js";
@@ -13191,12 +13195,28 @@ const GRAPH_TOOL_EXECUTORS = {
     // Never allowed to block the unpack the caller asked for; a failure here reduces
     // what is carried and is reported.
     //
-    // NO SNAPSHOT, NO CARRY (codex round 3). The carry is only safe because a failed
-    // one can be erased by reloading the pre-carry workflow. Without that snapshot
-    // there is nothing to reload, so attempting it would risk leaving a widget in a
-    // state nothing can undo. Skipping it restores the OLD behaviour — the promoted
-    // value may be lost to the inner default — which is a known, recoverable-by-hand
-    // loss rather than an unrepairable one, and it is disclosed below.
+    // NO SNAPSHOT: the carry is only safe because a failed one can be erased by
+    // reloading the pre-carry workflow, so without a snapshot it is not attempted.
+    // But skipping it is NOT a free fallback (codex round 4) — it is exactly the data
+    // loss this change exists to stop, and after the unpack the rail is gone and a
+    // long prompt may exist nowhere at all. Snapshot failure must not re-authorize
+    // that. So a READ-ONLY preflight looks for divergence and refuses if it finds any;
+    // an unpack with nothing diverged proceeds exactly as before.
+    if (!rollback) {
+      const divergent = findDivergentPromotedValues(node, (sgNode, widgetName) =>
+        resolvePromotedInnerTarget(sgNode, widgetName, sourceForSubgraphInput),
+      );
+      if (divergent.length) {
+        throw new Error(
+          `unpack_subgraph refused: this workflow could not be snapshotted, so the promoted ` +
+            `value(s) ${divergent.map((d) => d.widget).join(", ")} cannot be carried into the inner ` +
+            `node(s) safely — and unpacking without carrying them would replace them with whatever ` +
+            `the inner nodes were created with, with no copy left anywhere (#979). Nothing was ` +
+            `changed. Set those values on the inner nodes first, or retry once the workflow can be ` +
+            `serialized.`,
+        );
+      }
+    }
     let materialized = null;
     if (rollback) {
       try {

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -13198,6 +13198,36 @@ const GRAPH_TOOL_EXECUTORS = {
     } catch {
       materialized = null;
     }
+    // #979 (codex round 2) — REFUSE to unpack when a carry could not be rolled back.
+    // A setter that normalizes the write and then also normalizes the restore leaves
+    // the widget holding a value that was in NEITHER the rail nor the inner. Unpacking
+    // over that would make a third, invented value permanent, which is worse than the
+    // data loss this whole change exists to stop. Restore the pre-carry workflow and
+    // report instead — the subgraph is still there, so nothing is lost.
+    if (materialized?.unrecoverable?.length) {
+      const names = materialized.unrecoverable.map((u) => u.widget).join(", ");
+      let restored = false;
+      if (rollback && typeof app?.loadGraphData === "function") {
+        try {
+          const activeWorkflow = app?.extensionManager?.workflow?.activeWorkflow || null;
+          await app.loadGraphData(...resolveLoadGraphArgs(rollback, activeWorkflow));
+          restored = true;
+        } catch {
+          restored = false;
+        }
+      }
+      throw new Error(
+        `unpack_subgraph refused: carrying the promoted value(s) ${names} into the inner ` +
+          `node(s) failed, and the value found beforehand could not be put back — the widget ` +
+          `now holds something that was in neither the parent nor the inner node. Unpacking ` +
+          `would make that permanent (#979). ` +
+          (restored
+            ? `The workflow was reloaded from its pre-unpack snapshot, so the subgraph and its ` +
+              `values are intact; nothing was destroyed.`
+            : `The pre-unpack snapshot could NOT be reloaded, so check those widget values before ` +
+              `doing anything else — the subgraph is still present and was not unpacked.`),
+      );
+    }
     // unpackSubgraph wraps its own beforeChange/afterChange for undo, so don't
     // nest another pair here.
     try {

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -13218,13 +13218,22 @@ const GRAPH_TOOL_EXECUTORS = {
       }
     }
     let materialized = null;
+    let carryFailed = false;
     if (rollback) {
       try {
         materialized = materializePromotedValues(node, (sgNode, widgetName) =>
           resolvePromotedInnerTarget(sgNode, widgetName, sourceForSubgraphInput),
         );
+        // `aborted` means the ITERATION came apart — earlier rails may already have
+        // been carried, so this is not a "no work done" outcome (codex final).
+        carryFailed = !!materialized?.aborted;
       } catch {
+        // A throw ESCAPING the carry is the same situation and used to be the worst
+        // case: the record was discarded, so partial work became invisible, and the
+        // unpack proceeded anyway and destroyed the divergent values this exists to
+        // protect. It is now a refusal like any other unprovable state.
         materialized = null;
+        carryFailed = true;
       }
     }
     // #979 (codex round 2) — REFUSE to unpack when a carry could not be rolled back.
@@ -13233,8 +13242,10 @@ const GRAPH_TOOL_EXECUTORS = {
     // over that would make a third, invented value permanent, which is worse than the
     // data loss this whole change exists to stop. Restore the pre-carry workflow and
     // report instead — the subgraph is still there, so nothing is lost.
-    if (materialized?.unrecoverable?.length) {
-      const names = materialized.unrecoverable.map((u) => u.widget).join(", ");
+    if (carryFailed || materialized?.unrecoverable?.length) {
+      const names = materialized?.unrecoverable?.length
+        ? materialized.unrecoverable.map((u) => u.widget).join(", ")
+        : "(the carry failed before it could name them)";
       let restored = false;
       if (rollback && typeof app?.loadGraphData === "function") {
         try {

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -13190,13 +13190,22 @@ const GRAPH_TOOL_EXECUTORS = {
     // rail is gone with it — there is nothing left to recover the value from.
     // Never allowed to block the unpack the caller asked for; a failure here reduces
     // what is carried and is reported.
+    //
+    // NO SNAPSHOT, NO CARRY (codex round 3). The carry is only safe because a failed
+    // one can be erased by reloading the pre-carry workflow. Without that snapshot
+    // there is nothing to reload, so attempting it would risk leaving a widget in a
+    // state nothing can undo. Skipping it restores the OLD behaviour — the promoted
+    // value may be lost to the inner default — which is a known, recoverable-by-hand
+    // loss rather than an unrepairable one, and it is disclosed below.
     let materialized = null;
-    try {
-      materialized = materializePromotedValues(node, (sgNode, widgetName) =>
-        resolvePromotedInnerTarget(sgNode, widgetName, sourceForSubgraphInput),
-      );
-    } catch {
-      materialized = null;
+    if (rollback) {
+      try {
+        materialized = materializePromotedValues(node, (sgNode, widgetName) =>
+          resolvePromotedInnerTarget(sgNode, widgetName, sourceForSubgraphInput),
+        );
+      } catch {
+        materialized = null;
+      }
     }
     // #979 (codex round 2) — REFUSE to unpack when a carry could not be rolled back.
     // A setter that normalizes the write and then also normalizes the restore leaves

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -157,6 +157,7 @@ import {
   disabledOutputsInPrompt,
   disabledOutputsNote,
 } from "./lib/muted-subgraph-outputs.js";
+import { materializePromotedValues, materializedValuesNote } from "./lib/unpack-promoted-values.js";
 import { readSaveFailureCause } from "./lib/userdata-failure-cause.js";
 import { describeScreenshotFraming } from "./lib/screenshot-framing.js";
 import { readActiveSidebarTab, shouldDetachPanelRoot, findSidebarTabButton } from "./lib/active-sidebar-tab.js";
@@ -13177,6 +13178,26 @@ const GRAPH_TOOL_EXECUTORS = {
       rollback = null; // couldn't snapshot — we'll still surface a clean error below
     }
     const before = new Set((graph._nodes ?? []).map((n) => n.id));
+    // #979 — carry PROMOTED values inward BEFORE the unpack. `unpackSubgraph` inlines
+    // the INNER widget's value and drops the parent rail's, so a promoted widget the
+    // user set on the parent came back as whatever the inner node was created with —
+    // measured, and the reporter lost a long custom prompt to a pack's template
+    // default that way. #366 makes the rail authoritative (it is what serializes at
+    // queue time), so rail → inner is the direction that preserves what the graph
+    // would actually have rendered.
+    //
+    // Before, not after: unpack is DESTRUCTIVE, and once the subgraph is gone the
+    // rail is gone with it — there is nothing left to recover the value from.
+    // Never allowed to block the unpack the caller asked for; a failure here reduces
+    // what is carried and is reported.
+    let materialized = null;
+    try {
+      materialized = materializePromotedValues(node, (sgNode, widgetName) =>
+        resolvePromotedInnerTarget(sgNode, widgetName, sourceForSubgraphInput),
+      );
+    } catch {
+      materialized = null;
+    }
     // unpackSubgraph wraps its own beforeChange/afterChange for undo, so don't
     // nest another pair here.
     try {
@@ -13209,6 +13230,12 @@ const GRAPH_TOOL_EXECUTORS = {
         node_id,
         new_node_ids: newNodeIds,
         node_count: newNodeIds.length,
+        // #979 — disclose what was carried inward. An unpack cannot be undone from
+        // this result, so a caller checking values afterwards needs to know which
+        // ones this moved, and which widgets it could not match.
+        ...(materialized?.applied?.length ? { promoted_values_carried: materialized.applied } : {}),
+        ...(materialized?.unresolved?.length ? { promoted_values_unresolved: materialized.unresolved } : {}),
+        ...(materializedValuesNote(materialized) ? { promoted_values_note: materializedValuesNote(materialized) } : {}),
       },
     };
   },

--- a/web/js/lib/unpack-promoted-values.js
+++ b/web/js/lib/unpack-promoted-values.js
@@ -154,7 +154,7 @@ function carryOneRail(rail, subgraphNode, resolvePromoted, applied, unresolved, 
       //                          on a destructive path must refuse: its value may be
       //                          diverged and would be destroyed with nothing to
       //                          recover from.
-      if (resolved?.promoted) {
+      if (resolved?.promoted !== false) {
         unrecoverable.push({
           widget: name,
           reason: "resolves as promoted but its inner widget could not be identified, so it cannot be carried",
@@ -312,7 +312,7 @@ export function findDivergentPromotedValues(subgraphNode, resolvePromoted) {
         // that resolves as promoted but yields no usable target is an UNKNOWN — its
         // value may be diverged, and with no snapshot there would be nothing to
         // recover it from once the unpack destroys the rail.
-        if (resolved?.promoted) divergent.push({ widget: name, reason: "its inner widget could not be identified" });
+        if (resolved?.promoted !== false) divergent.push({ widget: name, reason: "its inner widget could not be identified" });
         continue;
       }
       if (!Object.is(rail.value, innerWidget.value)) divergent.push({ widget: name });

--- a/web/js/lib/unpack-promoted-values.js
+++ b/web/js/lib/unpack-promoted-values.js
@@ -48,8 +48,12 @@
 export function materializePromotedValues(subgraphNode, resolvePromoted) {
   const applied = [];
   const unresolved = [];
+  // #979 (codex round 2): failures whose ROLLBACK could not be proven. These are not
+  // an annotation — they mean the graph holds a value that was in neither the rail
+  // nor the inner, and the caller must refuse to unpack over that.
+  const unrecoverable = [];
   let skipped = 0;
-  if (!subgraphNode || typeof resolvePromoted !== "function") return { applied, unresolved, skipped };
+  if (!subgraphNode || typeof resolvePromoted !== "function") return { applied, unresolved, unrecoverable, skipped };
   const rails = Array.isArray(subgraphNode.widgets) ? subgraphNode.widgets : [];
   for (const rail of rails) {
     // PER-RAIL isolation (codex NO-SHIP): a hostile or merely unusual accessor on ONE
@@ -58,7 +62,7 @@ export function materializePromotedValues(subgraphNode, resolvePromoted) {
     // suppressed the disclosure, on a path that then destroys the subgraph anyway.
     // One bad widget now costs its own entry and nothing else.
     try {
-      carryOneRail(rail, subgraphNode, resolvePromoted, applied, unresolved, () => (skipped += 1));
+      carryOneRail(rail, subgraphNode, resolvePromoted, applied, unresolved, unrecoverable, () => (skipped += 1));
     } catch {
       let label = null;
       try {
@@ -69,7 +73,7 @@ export function materializePromotedValues(subgraphNode, resolvePromoted) {
       unresolved.push({ widget: label ?? "(unreadable)", reason: "widget could not be inspected" });
     }
   }
-  return { applied, unresolved, skipped };
+  return { applied, unresolved, unrecoverable, skipped };
 }
 
 /**
@@ -82,7 +86,7 @@ export function materializePromotedValues(subgraphNode, resolvePromoted) {
  * altered and `unpackSubgraph` committed it — silent destructive corruption on exactly
  * the error path this function claims is safe.
  */
-function carryOneRail(rail, subgraphNode, resolvePromoted, applied, unresolved, onSkip) {
+function carryOneRail(rail, subgraphNode, resolvePromoted, applied, unresolved, unrecoverable, onSkip) {
   {
     const name = typeof rail?.name === "string" ? rail.name : null;
     if (!name) return;
@@ -126,19 +130,39 @@ function carryOneRail(rail, subgraphNode, resolvePromoted, applied, unresolved, 
     // Best-effort restore of the value we found. Used on EVERY failure path below —
     // a widget left holding a half-applied value is worse than one left alone, because
     // the unpack that follows makes it permanent.
+    // Returns TRUE only when the widget is PROVABLY back to what we found. A restore
+    // that throws, that cannot be read back, or that itself normalizes to a third
+    // value leaves the graph holding something that was in NEITHER the rail nor the
+    // inner — and the caller must not destroy the subgraph over that (codex round 2).
     const restore = () => {
-      if (!innerReadable) return;
+      if (!innerReadable) return false;
       try {
-        if (!Object.is(innerWidget.value, innerValue)) innerWidget.value = innerValue;
+        if (Object.is(innerWidget.value, innerValue)) return true;
+        innerWidget.value = innerValue;
       } catch {
-        /* nothing further can be done; it is reported as unresolved either way */
+        /* fall through to the read-back — a setter that applies and THEN throws has
+           still restored the value, and refusing the unpack over that would be a
+           false alarm on a graph that is actually intact */
       }
+      // The verdict comes from the OBSERVED value, never from whether the assignment
+      // reported success. Both directions matter: a throw that restored is recovered,
+      // and a silent success that normalized is not.
+      try {
+        return Object.is(innerWidget.value, innerValue);
+      } catch {
+        return false; // cannot even confirm — treat as unrecoverable
+      }
+    };
+    const failed = (reason) => {
+      if (restore()) unresolved.push({ widget: name, reason });
+      // UNRECOVERABLE: the value we found is not back. Reported separately because it
+      // is the one condition that must stop the unpack rather than merely annotate it.
+      else unrecoverable.push({ widget: name, reason: `${reason}, and the previous value could not be restored` });
     };
     try {
       innerWidget.value = railValue;
     } catch {
-      restore();
-      unresolved.push({ widget: name, reason: "inner widget rejected the write" });
+      failed("inner widget rejected the write");
       return;
     }
     let landed;
@@ -152,8 +176,7 @@ function carryOneRail(rail, subgraphNode, resolvePromoted, applied, unresolved, 
     // coercing one is why the restore matters, since it leaves the widget holding a
     // third value that was never in the graph.
     if (!Object.is(landed, railValue)) {
-      restore();
-      unresolved.push({ widget: name, reason: "inner widget did not retain the value" });
+      failed("inner widget did not retain the value");
       return;
     }
     // Report metadata is built inside the guarded span too: `innerNode.id` and

--- a/web/js/lib/unpack-promoted-values.js
+++ b/web/js/lib/unpack-promoted-values.js
@@ -52,8 +52,40 @@ export function materializePromotedValues(subgraphNode, resolvePromoted) {
   if (!subgraphNode || typeof resolvePromoted !== "function") return { applied, unresolved, skipped };
   const rails = Array.isArray(subgraphNode.widgets) ? subgraphNode.widgets : [];
   for (const rail of rails) {
+    // PER-RAIL isolation (codex NO-SHIP): a hostile or merely unusual accessor on ONE
+    // widget — `rail.name`, `innerNode.id`, `innerWidget.name` are all reads that can
+    // throw — used to abort the whole loop. That lost every remaining rail's value AND
+    // suppressed the disclosure, on a path that then destroys the subgraph anyway.
+    // One bad widget now costs its own entry and nothing else.
+    try {
+      carryOneRail(rail, subgraphNode, resolvePromoted, applied, unresolved, () => (skipped += 1));
+    } catch {
+      let label = null;
+      try {
+        label = typeof rail?.name === "string" ? rail.name : null;
+      } catch {
+        label = null;
+      }
+      unresolved.push({ widget: label ?? "(unreadable)", reason: "widget could not be inspected" });
+    }
+  }
+  return { applied, unresolved, skipped };
+}
+
+/**
+ * One rail's transfer. Extracted so a throw anywhere in it — including while building
+ * the report entry — is contained to that rail by the caller.
+ *
+ * TRANSACTIONAL (codex NO-SHIP): the previous inner value is captured first, and any
+ * assignment that throws, coerces, or is silently ignored is ROLLED BACK before being
+ * reported. Without that, a setter which mutates and then throws left the inner widget
+ * altered and `unpackSubgraph` committed it — silent destructive corruption on exactly
+ * the error path this function claims is safe.
+ */
+function carryOneRail(rail, subgraphNode, resolvePromoted, applied, unresolved, onSkip) {
+  {
     const name = typeof rail?.name === "string" ? rail.name : null;
-    if (!name) continue;
+    if (!name) return;
     let resolved = null;
     try {
       resolved = resolvePromoted(subgraphNode, name);
@@ -67,33 +99,47 @@ export function materializePromotedValues(subgraphNode, resolvePromoted) {
       // promotion — the subgraph node's own widgets can include non-promoted ones.
       // Reported so a caller can say the coverage was partial rather than complete.
       unresolved.push({ widget: name });
-      continue;
+      return;
     }
     let railValue;
     try {
       railValue = rail.value;
     } catch {
       unresolved.push({ widget: name, reason: "rail value could not be read" });
-      continue;
+      return;
     }
     let innerValue;
+    let innerReadable = true;
     try {
       innerValue = innerWidget.value;
     } catch {
       innerValue = undefined;
+      innerReadable = false;
     }
     // Only a genuine DIVERGENCE is written. Writing every promoted widget would fire
     // node callbacks for values that never changed, on a path that is already about
     // to restructure the graph.
-    if (Object.is(railValue, innerValue)) {
-      skipped += 1;
-      continue;
+    if (innerReadable && Object.is(railValue, innerValue)) {
+      onSkip();
+      return;
     }
+    // Best-effort restore of the value we found. Used on EVERY failure path below —
+    // a widget left holding a half-applied value is worse than one left alone, because
+    // the unpack that follows makes it permanent.
+    const restore = () => {
+      if (!innerReadable) return;
+      try {
+        if (!Object.is(innerWidget.value, innerValue)) innerWidget.value = innerValue;
+      } catch {
+        /* nothing further can be done; it is reported as unresolved either way */
+      }
+    };
     try {
       innerWidget.value = railValue;
     } catch {
+      restore();
       unresolved.push({ widget: name, reason: "inner widget rejected the write" });
-      continue;
+      return;
     }
     let landed;
     try {
@@ -101,20 +147,24 @@ export function materializePromotedValues(subgraphNode, resolvePromoted) {
     } catch {
       landed = undefined;
     }
-    // Read back: a frozen widget or a setter that ignores the assignment must not be
-    // reported as preserved. An unpack that silently loses it is the bug; an unpack
-    // that loses it and SAYS so is at least recoverable.
+    // Read back: a frozen widget, a setter that ignores the assignment, and a setter
+    // that COERCES to something else are all failures to carry the value — and the
+    // coercing one is why the restore matters, since it leaves the widget holding a
+    // third value that was never in the graph.
     if (!Object.is(landed, railValue)) {
+      restore();
       unresolved.push({ widget: name, reason: "inner widget did not retain the value" });
-      continue;
+      return;
     }
+    // Report metadata is built inside the guarded span too: `innerNode.id` and
+    // `innerWidget.name` are reads, and a read that throws must not lose the transfer
+    // that already succeeded — the caller's catch turns it into an unresolved entry.
     applied.push({
       widget: name,
       node_id: innerNode?.id != null ? String(innerNode.id) : null,
       inner_widget: typeof innerWidget.name === "string" ? innerWidget.name : name,
     });
   }
-  return { applied, unresolved, skipped };
 }
 
 /**

--- a/web/js/lib/unpack-promoted-values.js
+++ b/web/js/lib/unpack-promoted-values.js
@@ -53,9 +53,22 @@ export function materializePromotedValues(subgraphNode, resolvePromoted) {
   // nor the inner, and the caller must refuse to unpack over that.
   const unrecoverable = [];
   let skipped = 0;
-  if (!subgraphNode || typeof resolvePromoted !== "function") return { applied, unresolved, unrecoverable, skipped };
-  const rails = Array.isArray(subgraphNode.widgets) ? subgraphNode.widgets : [];
-  for (const rail of rails) {
+  // Set when the ITERATION itself failed — an indexed getter on the widgets array, a
+  // poisoned iterator (codex final). Per-rail isolation does not cover that: earlier
+  // rails may already have been carried, and without this the caller saw only a thrown
+  // function, discarded the whole record, and unpacked anyway — destroying exactly the
+  // divergent values this exists to protect.
+  let aborted = false;
+  if (!subgraphNode || typeof resolvePromoted !== "function")
+    return { applied, unresolved, unrecoverable, skipped, aborted };
+  let rails = [];
+  try {
+    rails = Array.isArray(subgraphNode.widgets) ? subgraphNode.widgets : [];
+  } catch {
+    return { applied, unresolved, unrecoverable, skipped, aborted: true };
+  }
+  try {
+    for (const rail of rails) {
     // PER-RAIL isolation (codex NO-SHIP): a hostile or merely unusual accessor on ONE
     // widget — `rail.name`, `innerNode.id`, `innerWidget.name` are all reads that can
     // throw — used to abort the whole loop. That lost every remaining rail's value AND
@@ -75,17 +88,28 @@ export function materializePromotedValues(subgraphNode, resolvePromoted) {
       } catch {
         label = null;
       }
-      const entry = {
+      // ANY throw here is unrecoverable, not just a post-write one (codex final).
+      // The latch proves a write happened; its absence proves nothing — the resolver
+      // and the value getters all run before it, and this module's own threat model
+      // is accessors that misbehave. One that MUTATES and then throws would otherwise
+      // be filed as benign and unpacked over. On a destructive path an exception
+      // means the state cannot be proven, and unprovable is the same as unsafe.
+      unrecoverable.push({
         widget: label ?? "(unreadable)",
         reason: state.attempted
           ? "the write was attempted and then something threw — the widget may hold a value from neither side"
-          : "widget could not be inspected",
-      };
-      if (state.attempted) unrecoverable.push({ ...entry, value_restored: false });
-      else unresolved.push(entry);
+          : "inspecting this widget threw, so its state before the unpack cannot be established",
+        value_restored: false,
+      });
     }
+    }
+  } catch {
+    // The loop itself came apart. Whatever was carried before that point stands,
+    // which is precisely why this must reach the caller as a refusal rather than as
+    // a thrown function whose partial work is invisible.
+    aborted = true;
   }
-  return { applied, unresolved, unrecoverable, skipped };
+  return { applied, unresolved, unrecoverable, skipped, aborted };
 }
 
 /**
@@ -241,7 +265,12 @@ export function findDivergentPromotedValues(subgraphNode, resolvePromoted) {
       try {
         resolved = resolvePromoted(subgraphNode, name);
       } catch {
-        continue; // not shown to be a promotion ⇒ not a divergence to refuse over
+        // NOT "not a promotion" (codex final): a resolver that throws leaves this
+        // widget's promotion status unknown, and with no snapshot to undo with, an
+        // unknown is exactly what must stop the unpack. Skipping here would let a
+        // divergent-but-unresolvable value be destroyed with nothing to recover from.
+        divergent.push({ widget: name, reason: "its promotion could not be resolved" });
+        continue;
       }
       const innerWidget = resolved?.promoted ? (resolved?.target?.widget ?? null) : null;
       if (!innerWidget) continue;

--- a/web/js/lib/unpack-promoted-values.js
+++ b/web/js/lib/unpack-promoted-values.js
@@ -1,0 +1,153 @@
+/**
+ * #979 — carry PROMOTED widget values into the inner nodes before a subgraph is
+ * unpacked, so the value the user set is the value that survives.
+ *
+ * MEASURED on ComfyUI 0.31.1 / frontend 1.48.7, on a subgraph whose promoted `text`
+ * widget had been given a different value on the parent than the inner node held:
+ *
+ *   before unpack:  rail = "RAIL-VALUE-THE-USER-SET"   inner = "ORIGINAL-INNER"
+ *   after  unpack:  "ORIGINAL-INNER"
+ *
+ * `unpackSubgraph` inlines the INNER widget's value and drops the parent rail's. The
+ * reporter lost a long custom prompt to a pack's template default and a duration of
+ * 15 to a default of 2, exactly this way.
+ *
+ * WHICH VALUE IS RIGHT: the rail's. #366 established the parent rail widget as the
+ * AUTHORITATIVE one for a promoted widget — it is what serializes at queue time, so
+ * it is what the workflow would actually have rendered with. Pushing rail → inner
+ * before the unpack therefore preserves the behaviour the graph already had.
+ *
+ * WHY IT MATTERS MORE THAN AN ORDINARY BUG: unpack is DESTRUCTIVE. Once the subgraph
+ * is gone the rail is gone with it, and there is nothing left to recover the value
+ * from — the reporter's workaround was remembering what it used to be and typing it
+ * back. So this runs BEFORE the unpack and reports what it did.
+ *
+ * NOT a general sync: it only writes an inner widget whose promoted rail holds a
+ * DIFFERENT value, and it never invents a promotion the resolver could not confirm.
+ * A widget it cannot resolve is left alone and reported as unresolved rather than
+ * guessed at — writing the wrong inner widget would be silent corruption of the kind
+ * #233 exists to prevent.
+ */
+
+/**
+ * Materialize every promoted rail value onto its inner widget.
+ *
+ * `resolvePromoted(subgraphNode, widgetName)` is injected — the caller passes the
+ * panel's own promoted-target resolver, so this never carries a second copy of that
+ * rule. It must return `{ promoted, target: { node, widget } }`-shaped data; anything
+ * else is treated as unresolved.
+ *
+ * Returns `{ applied: [...], unresolved: [...], skipped: n }` — `applied` naming each
+ * value moved, so the caller can disclose a destructive operation's side effects
+ * instead of performing them silently.
+ *
+ * Fully defensive: a throwing resolver, a frozen widget, or a malformed node reduces
+ * what is applied, never throws. A failure here must not block the unpack the user
+ * asked for — it must only be reported.
+ */
+export function materializePromotedValues(subgraphNode, resolvePromoted) {
+  const applied = [];
+  const unresolved = [];
+  let skipped = 0;
+  if (!subgraphNode || typeof resolvePromoted !== "function") return { applied, unresolved, skipped };
+  const rails = Array.isArray(subgraphNode.widgets) ? subgraphNode.widgets : [];
+  for (const rail of rails) {
+    const name = typeof rail?.name === "string" ? rail.name : null;
+    if (!name) continue;
+    let resolved = null;
+    try {
+      resolved = resolvePromoted(subgraphNode, name);
+    } catch {
+      resolved = null;
+    }
+    const innerWidget = resolved?.promoted ? (resolved?.target?.widget ?? null) : null;
+    const innerNode = resolved?.target?.node ?? null;
+    if (!innerWidget) {
+      // A rail widget that does not resolve to an inner one is NOT assumed to be a
+      // promotion — the subgraph node's own widgets can include non-promoted ones.
+      // Reported so a caller can say the coverage was partial rather than complete.
+      unresolved.push({ widget: name });
+      continue;
+    }
+    let railValue;
+    try {
+      railValue = rail.value;
+    } catch {
+      unresolved.push({ widget: name, reason: "rail value could not be read" });
+      continue;
+    }
+    let innerValue;
+    try {
+      innerValue = innerWidget.value;
+    } catch {
+      innerValue = undefined;
+    }
+    // Only a genuine DIVERGENCE is written. Writing every promoted widget would fire
+    // node callbacks for values that never changed, on a path that is already about
+    // to restructure the graph.
+    if (Object.is(railValue, innerValue)) {
+      skipped += 1;
+      continue;
+    }
+    try {
+      innerWidget.value = railValue;
+    } catch {
+      unresolved.push({ widget: name, reason: "inner widget rejected the write" });
+      continue;
+    }
+    let landed;
+    try {
+      landed = innerWidget.value;
+    } catch {
+      landed = undefined;
+    }
+    // Read back: a frozen widget or a setter that ignores the assignment must not be
+    // reported as preserved. An unpack that silently loses it is the bug; an unpack
+    // that loses it and SAYS so is at least recoverable.
+    if (!Object.is(landed, railValue)) {
+      unresolved.push({ widget: name, reason: "inner widget did not retain the value" });
+      continue;
+    }
+    applied.push({
+      widget: name,
+      node_id: innerNode?.id != null ? String(innerNode.id) : null,
+      inner_widget: typeof innerWidget.name === "string" ? innerWidget.name : name,
+    });
+  }
+  return { applied, unresolved, skipped };
+}
+
+/**
+ * The disclosure for a destructive operation that moved values. Empty when nothing
+ * was moved and nothing was left unresolved — an unpack with no promoted divergence
+ * has nothing to say and should say nothing.
+ */
+export function materializedValuesNote(result) {
+  const applied = Array.isArray(result?.applied) ? result.applied : [];
+  const unresolved = Array.isArray(result?.unresolved) ? result.unresolved : [];
+  if (!applied.length && !unresolved.length) return "";
+  const parts = [];
+  if (applied.length) {
+    const which = applied
+      .slice(0, 6)
+      .map((a) => `${a.widget}${a.node_id ? ` → node ${a.node_id}` : ""}`)
+      .join(", ");
+    parts.push(
+      `Carried ${applied.length} promoted widget value${applied.length === 1 ? "" : "s"} into the ` +
+        `inlined node${applied.length === 1 ? "" : "s"} before unpacking (${which}${
+          applied.length > 6 ? `, and ${applied.length - 6} more` : ""
+        }). The parent's value is the one that serializes at queue time, so it is the one kept; ` +
+        `without this it would have been replaced by whatever the inner node was created with (#979).`,
+    );
+  }
+  if (unresolved.length) {
+    parts.push(
+      `${unresolved.length} widget${unresolved.length === 1 ? "" : "s"} on the subgraph node could ` +
+        `not be matched to an inner widget and ${unresolved.length === 1 ? "was" : "were"} left ` +
+        `untouched (${unresolved.map((u) => u.widget).slice(0, 6).join(", ")}) — not every widget on a ` +
+        `subgraph node is a promotion, so this is usually nothing, but check those values if they ` +
+        `matter: unpack cannot be undone from the result.`,
+    );
+  }
+  return parts.join(" ");
+}

--- a/web/js/lib/unpack-promoted-values.js
+++ b/web/js/lib/unpack-promoted-values.js
@@ -135,10 +135,25 @@ function carryOneRail(rail, subgraphNode, resolvePromoted, applied, unresolved, 
     const innerWidget = resolved?.promoted ? (resolved?.target?.widget ?? null) : null;
     const innerNode = resolved?.target?.node ?? null;
     if (!innerWidget) {
-      // A rail widget that does not resolve to an inner one is NOT assumed to be a
-      // promotion — the subgraph node's own widgets can include non-promoted ones.
-      // Reported so a caller can say the coverage was partial rather than complete.
-      unresolved.push({ widget: name });
+      // Two DIFFERENT outcomes, and collapsing them was the last hole (codex final).
+      //
+      //   promoted === false  -> definitively NOT a promotion. The subgraph node's own
+      //                          widgets can include ordinary ones, and refusing over
+      //                          those would block healthy unpacks. Merely disclosed.
+      //   promoted === true, no usable target -> a promotion we could not resolve.
+      //                          That is UNKNOWN, not "not a promotion", and an unknown
+      //                          on a destructive path must refuse: its value may be
+      //                          diverged and would be destroyed with nothing to
+      //                          recover from.
+      if (resolved?.promoted) {
+        unrecoverable.push({
+          widget: name,
+          reason: "resolves as promoted but its inner widget could not be identified, so it cannot be carried",
+          value_restored: true, // nothing was written; the graph is as it was found
+        });
+      } else {
+        unresolved.push({ widget: name });
+      }
       return;
     }
     let railValue;

--- a/web/js/lib/unpack-promoted-values.js
+++ b/web/js/lib/unpack-promoted-values.js
@@ -130,7 +130,16 @@ function carryOneRail(rail, subgraphNode, resolvePromoted, applied, unresolved, 
     try {
       resolved = resolvePromoted(subgraphNode, name);
     } catch {
-      resolved = null;
+      // NOT swallowed into `unresolved` (codex final): the resolver is injected code
+      // that ran against the live graph, and one that mutates and then throws would
+      // otherwise let the unpack proceed over state nothing can prove. An exception
+      // here is an unknown, and unknown is unsafe on a destructive path.
+      unrecoverable.push({
+        widget: name,
+        reason: "resolving its promotion threw, so its state before the unpack cannot be established",
+        value_restored: true, // nothing was written by us
+      });
+      return;
     }
     const innerWidget = resolved?.promoted ? (resolved?.target?.widget ?? null) : null;
     const innerNode = resolved?.target?.node ?? null;
@@ -160,7 +169,12 @@ function carryOneRail(rail, subgraphNode, resolvePromoted, applied, unresolved, 
     try {
       railValue = rail.value;
     } catch {
-      unresolved.push({ widget: name, reason: "rail value could not be read" });
+      // Same reasoning as the resolver: a getter that mutates and then throws.
+      unrecoverable.push({
+        widget: name,
+        reason: "reading the parent's value threw, so its state before the unpack cannot be established",
+        value_restored: true,
+      });
       return;
     }
     let innerValue;
@@ -168,13 +182,19 @@ function carryOneRail(rail, subgraphNode, resolvePromoted, applied, unresolved, 
     try {
       innerValue = innerWidget.value;
     } catch {
-      innerValue = undefined;
-      innerReadable = false;
+      // An inner value we cannot read is one we cannot restore either, so there is no
+      // safe way to attempt the carry — and no way to show the widget is unchanged.
+      unrecoverable.push({
+        widget: name,
+        reason: "reading the inner widget's value threw, so it could not be compared or restored",
+        value_restored: false,
+      });
+      return;
     }
     // Only a genuine DIVERGENCE is written. Writing every promoted widget would fire
     // node callbacks for values that never changed, on a path that is already about
     // to restructure the graph.
-    if (innerReadable && Object.is(railValue, innerValue)) {
+    if (Object.is(railValue, innerValue)) {
       onSkip();
       return;
     }
@@ -186,7 +206,6 @@ function carryOneRail(rail, subgraphNode, resolvePromoted, applied, unresolved, 
     // value leaves the graph holding something that was in NEITHER the rail nor the
     // inner — and the caller must not destroy the subgraph over that (codex round 2).
     const restore = () => {
-      if (!innerReadable) return false;
       try {
         if (Object.is(innerWidget.value, innerValue)) return true;
         innerWidget.value = innerValue;
@@ -288,7 +307,14 @@ export function findDivergentPromotedValues(subgraphNode, resolvePromoted) {
         continue;
       }
       const innerWidget = resolved?.promoted ? (resolved?.target?.widget ?? null) : null;
-      if (!innerWidget) continue;
+      if (!innerWidget) {
+        // Only a definitive `promoted: false` is safe to skip (codex final). A rail
+        // that resolves as promoted but yields no usable target is an UNKNOWN — its
+        // value may be diverged, and with no snapshot there would be nothing to
+        // recover it from once the unpack destroys the rail.
+        if (resolved?.promoted) divergent.push({ widget: name, reason: "its inner widget could not be identified" });
+        continue;
+      }
       if (!Object.is(rail.value, innerWidget.value)) divergent.push({ widget: name });
     } catch {
       // A widget that cannot be read cannot be shown safe. On a destructive path that

--- a/web/js/lib/unpack-promoted-values.js
+++ b/web/js/lib/unpack-promoted-values.js
@@ -141,8 +141,13 @@ function carryOneRail(rail, subgraphNode, resolvePromoted, applied, unresolved, 
       });
       return;
     }
-    const innerWidget = resolved?.promoted ? (resolved?.target?.widget ?? null) : null;
+    // A usable target needs BOTH a node and a widget (codex final). A target carrying
+    // a widget but no node was accepted, so a malformed resolver could steer the carry
+    // into a widget nothing owns: the write lands there, is reported as a success, and
+    // the unpack still inlines the REAL inner widget's old value — the original data
+    // loss, now with a success message on top of it.
     const innerNode = resolved?.target?.node ?? null;
+    const innerWidget = resolved?.promoted && innerNode ? (resolved?.target?.widget ?? null) : null;
     if (!innerWidget) {
       // Two DIFFERENT outcomes, and collapsing them was the last hole (codex final).
       //
@@ -306,7 +311,10 @@ export function findDivergentPromotedValues(subgraphNode, resolvePromoted) {
         divergent.push({ widget: name, reason: "its promotion could not be resolved" });
         continue;
       }
-      const innerWidget = resolved?.promoted ? (resolved?.target?.widget ?? null) : null;
+      // Same both-or-neither requirement as the carry, so the two modes cannot
+      // disagree about what counts as a resolvable promotion.
+      const innerWidget =
+        resolved?.promoted && resolved?.target?.node ? (resolved?.target?.widget ?? null) : null;
       if (!innerWidget) {
         // Only a definitive `promoted: false` is safe to skip (codex final). A rail
         // that resolves as promoted but yields no usable target is an UNKNOWN — its

--- a/web/js/lib/unpack-promoted-values.js
+++ b/web/js/lib/unpack-promoted-values.js
@@ -61,8 +61,13 @@ export function materializePromotedValues(subgraphNode, resolvePromoted) {
     // throw — used to abort the whole loop. That lost every remaining rail's value AND
     // suppressed the disclosure, on a path that then destroys the subgraph anyway.
     // One bad widget now costs its own entry and nothing else.
+    // LATCHED before the assignment (codex round 4). If a read-back, a metadata read,
+    // or any accessor throws AFTER the write was attempted, the widget may already
+    // have been mutated — so that must land in `unrecoverable` and stop the unpack,
+    // never be swallowed as a benign "could not inspect".
+    const state = { attempted: false };
     try {
-      carryOneRail(rail, subgraphNode, resolvePromoted, applied, unresolved, unrecoverable, () => (skipped += 1));
+      carryOneRail(rail, subgraphNode, resolvePromoted, applied, unresolved, unrecoverable, () => (skipped += 1), state);
     } catch {
       let label = null;
       try {
@@ -70,7 +75,14 @@ export function materializePromotedValues(subgraphNode, resolvePromoted) {
       } catch {
         label = null;
       }
-      unresolved.push({ widget: label ?? "(unreadable)", reason: "widget could not be inspected" });
+      const entry = {
+        widget: label ?? "(unreadable)",
+        reason: state.attempted
+          ? "the write was attempted and then something threw — the widget may hold a value from neither side"
+          : "widget could not be inspected",
+      };
+      if (state.attempted) unrecoverable.push({ ...entry, value_restored: false });
+      else unresolved.push(entry);
     }
   }
   return { applied, unresolved, unrecoverable, skipped };
@@ -86,7 +98,7 @@ export function materializePromotedValues(subgraphNode, resolvePromoted) {
  * altered and `unpackSubgraph` committed it — silent destructive corruption on exactly
  * the error path this function claims is safe.
  */
-function carryOneRail(rail, subgraphNode, resolvePromoted, applied, unresolved, unrecoverable, onSkip) {
+function carryOneRail(rail, subgraphNode, resolvePromoted, applied, unresolved, unrecoverable, onSkip, state) {
   {
     const name = typeof rail?.name === "string" ? rail.name : null;
     if (!name) return;
@@ -172,6 +184,7 @@ function carryOneRail(rail, subgraphNode, resolvePromoted, applied, unresolved, 
       });
     };
     try {
+      state.attempted = true;
       innerWidget.value = railValue;
     } catch {
       failed("inner widget rejected the write");
@@ -200,6 +213,52 @@ function carryOneRail(rail, subgraphNode, resolvePromoted, applied, unresolved, 
       inner_widget: typeof innerWidget.name === "string" ? innerWidget.name : name,
     });
   }
+}
+
+/**
+ * #979 (codex round 4) — READ-ONLY: which promoted rails hold a value their inner
+ * widget does not. Writes nothing, so it is safe when there is no rollback snapshot
+ * to undo a failed write with.
+ *
+ * The caller uses this exactly there: snapshot capture failing must not re-authorize
+ * the data loss this whole change exists to stop. Skipping the carry "because it is
+ * only the old behaviour" is not recoverable-by-hand — after the unpack the rail is
+ * gone and a long prompt may exist nowhere at all. So a divergence found here refuses
+ * the unpack instead, and an unpack with no divergence proceeds untouched.
+ *
+ * An unreadable value counts as divergent: it cannot be shown to be safe, and the
+ * conservative direction on a destructive path is to refuse.
+ */
+export function findDivergentPromotedValues(subgraphNode, resolvePromoted) {
+  const divergent = [];
+  if (!subgraphNode || typeof resolvePromoted !== "function") return divergent;
+  const rails = Array.isArray(subgraphNode.widgets) ? subgraphNode.widgets : [];
+  for (const rail of rails) {
+    try {
+      const name = typeof rail?.name === "string" ? rail.name : null;
+      if (!name) continue;
+      let resolved = null;
+      try {
+        resolved = resolvePromoted(subgraphNode, name);
+      } catch {
+        continue; // not shown to be a promotion ⇒ not a divergence to refuse over
+      }
+      const innerWidget = resolved?.promoted ? (resolved?.target?.widget ?? null) : null;
+      if (!innerWidget) continue;
+      if (!Object.is(rail.value, innerWidget.value)) divergent.push({ widget: name });
+    } catch {
+      // A widget that cannot be read cannot be shown safe. On a destructive path that
+      // is a reason to stop, not to shrug.
+      let label = null;
+      try {
+        label = typeof rail?.name === "string" ? rail.name : null;
+      } catch {
+        label = null;
+      }
+      divergent.push({ widget: label ?? "(unreadable)", reason: "could not be compared" });
+    }
+  }
+  return divergent;
 }
 
 /**

--- a/web/js/lib/unpack-promoted-values.js
+++ b/web/js/lib/unpack-promoted-values.js
@@ -153,11 +153,23 @@ function carryOneRail(rail, subgraphNode, resolvePromoted, applied, unresolved, 
         return false; // cannot even confirm — treat as unrecoverable
       }
     };
+    // ANY attempted transfer that did not cleanly land goes here, whether or not the
+    // scalar could be put back (codex round 3). Restoring the value is not proof the
+    // widget is recovered: a setter is free to mutate node properties, sibling
+    // widgets, options or a callback-owned cache on its way, and both the carry and
+    // the restore ran. The scalar being right again says nothing about those, and
+    // nothing observable can. So the caller reloads its pre-carry snapshot — the only
+    // generic way to erase effects that cannot be inspected — rather than unpacking
+    // over a state that is neither the rail's nor the inner's.
     const failed = (reason) => {
-      if (restore()) unresolved.push({ widget: name, reason });
-      // UNRECOVERABLE: the value we found is not back. Reported separately because it
-      // is the one condition that must stop the unpack rather than merely annotate it.
-      else unrecoverable.push({ widget: name, reason: `${reason}, and the previous value could not be restored` });
+      const scalarBack = restore();
+      unrecoverable.push({
+        widget: name,
+        reason: scalarBack
+          ? `${reason} (its previous value was put back, but a setter that ran twice may have changed more than the value)`
+          : `${reason}, and the previous value could not be restored`,
+        value_restored: scalarBack,
+      });
     };
     try {
       innerWidget.value = railValue;


### PR DESCRIPTION
Fixes #979. **Ready except for one final codex confirmation** — four rounds done, all findings applied, but this touches a destructive path and I would not merge it on reviews of superseded versions.

## Reproduced, measured
ComfyUI 0.31.1 / frontend 1.48.7, forcing rail and inner to differ:
```
before unpack:  rail = "RAIL-VALUE-THE-USER-SET"   inner = "ORIGINAL-INNER"
after  unpack:  "ORIGINAL-INNER"
```
`unpackSubgraph` inlines the **inner** value and drops the parent rail's. #366 makes the rail authoritative (it is what serializes at queue time), so the fix carries rail → inner **before** the unpack. Verified live end-to-end: the same scenario now ends `RAIL-VALUE-THE-USER-SET`.

## What four codex rounds changed
Every one of these was a way the first version could **corrupt** rather than merely fail:

1. a setter that mutates then throws, or coerces, left the widget half-written and unpack committed it → every failure path now restores what was found
2. one hostile accessor aborted the whole loop, losing every later rail *and* the disclosure → per-rail isolation
3. restoring the scalar is **not** proof of recovery — a setter can touch node properties, siblings, options, a callback cache, and both the carry and the restore ran → **any** failed transfer now reloads the pre-carry snapshot and refuses
4. "no snapshot ⇒ skip the carry" excused the original data loss as pre-existing → a read-only preflight refuses instead; and a write-attempt latch keeps a post-write throw unrecoverable

## Verification
3545 tests pass. Mutation-verified: carry-after-unpack, no-rollback, no-isolation, and unrecoverable→unresolved each fail exactly their own tests.

## Remaining
One confirmation round on the final shape, then merge → browser check → release.