### PR TITLE
spec: #986 — output-identity dedupe, and why suppression must become annotation

### DIFF
--- a/browser_tests/unit/completion-dedupe.test.mjs
+++ b/browser_tests/unit/completion-dedupe.test.mjs
@@ -23,7 +23,7 @@ test("#986 the reported burst: six cached re-queues of one clip deliver ONCE", (
   const ids = ["2d9d64f5", "c3e90187", "c5184f9e", "4ce0a352", "740ff0f5", "aa11bb22"];
   const delivered = ids.filter(
     (promptId) =>
-      d.consider({ signature: mediaSignature([], media), panelQueued: false, promptId, durationMs: 100 }).deliver,
+      d.consider({ signature: mediaSignature([], media), panelQueued: false, promptId, durationMs: 100, durationTrusted: true }).deliver,
   );
   assert.deepEqual(delivered, ["2d9d64f5"], "only the first announcement survives");
 });
@@ -32,7 +32,7 @@ test("#986 the suppressed ones name what they duplicate", () => {
   const d = createCompletionDeduper();
   const sig = mediaSignature([], [vid("Video_00144.mp4")]);
   d.consider({ signature: sig, panelQueued: false, promptId: "first" });
-  const second = d.consider({ signature: sig, panelQueued: false, promptId: "second", durationMs: 100 });
+  const second = d.consider({ signature: sig, panelQueued: false, promptId: "second", durationMs: 100, durationTrusted: true });
   assert.equal(second.deliver, false);
   assert.equal(second.duplicateOf, "first");
 });
@@ -43,7 +43,7 @@ test("#986 a PANEL-QUEUED run is NEVER suppressed — it was promised a notifica
   // duplicates this fixes.
   const d = createCompletionDeduper();
   const sig = mediaSignature([], [vid("same.mp4")]);
-  assert.equal(d.consider({ signature: sig, panelQueued: false, promptId: "canvas", durationMs: 100 }).deliver, true);
+  assert.equal(d.consider({ signature: sig, panelQueued: false, promptId: "canvas", durationMs: 100, durationTrusted: true }).deliver, true);
   assert.equal(d.consider({ signature: sig, panelQueued: true, promptId: "panel" }).deliver, true);
   assert.equal(d.consider({ signature: sig, panelQueued: true, promptId: "panel2" }).deliver, true);
 });
@@ -53,7 +53,7 @@ test("#986 a panel-queued delivery is RECORDED, so a later canvas replay is caug
   const d = createCompletionDeduper();
   const sig = mediaSignature([], [vid("same.mp4")]);
   d.record({ signature: sig, promptId: "panel-run" });
-  const replay = d.consider({ signature: sig, panelQueued: false, promptId: "canvas-replay", durationMs: 100 });
+  const replay = d.consider({ signature: sig, panelQueued: false, promptId: "canvas-replay", durationMs: 100, durationTrusted: true });
   assert.equal(replay.deliver, false);
   assert.equal(replay.duplicateOf, "panel-run");
 });
@@ -62,19 +62,19 @@ test("#986 a DIFFERENT output is always delivered", () => {
   const d = createCompletionDeduper();
   const a = mediaSignature([], [vid("Video_00144.mp4")]);
   const b = mediaSignature([], [vid("Video_00145.mp4")]);
-  assert.equal(d.consider({ signature: a, panelQueued: false, promptId: "1", durationMs: 100 }).deliver, true);
-  assert.equal(d.consider({ signature: b, panelQueued: false, promptId: "2", durationMs: 100 }).deliver, true);
+  assert.equal(d.consider({ signature: a, panelQueued: false, promptId: "1", durationMs: 100, durationTrusted: true }).deliver, true);
+  assert.equal(d.consider({ signature: b, panelQueued: false, promptId: "2", durationMs: 100, durationTrusted: true }).deliver, true);
 });
 
 test("#986 the window EXPIRES — a deliberate re-render later is a real event", () => {
   let t = 0;
   const d = createCompletionDeduper({ ttlMs: 1000, now: () => t });
   const sig = mediaSignature([], [vid("same.mp4")]);
-  assert.equal(d.consider({ signature: sig, panelQueued: false, promptId: "1", durationMs: 100 }).deliver, true);
+  assert.equal(d.consider({ signature: sig, panelQueued: false, promptId: "1", durationMs: 100, durationTrusted: true }).deliver, true);
   t = 500;
-  assert.equal(d.consider({ signature: sig, panelQueued: false, promptId: "2", durationMs: 100 }).deliver, false);
+  assert.equal(d.consider({ signature: sig, panelQueued: false, promptId: "2", durationMs: 100, durationTrusted: true }).deliver, false);
   t = 2000; // past the window
-  assert.equal(d.consider({ signature: sig, panelQueued: false, promptId: "3", durationMs: 100 }).deliver, true);
+  assert.equal(d.consider({ signature: sig, panelQueued: false, promptId: "3", durationMs: 100, durationTrusted: true }).deliver, true);
 });
 
 test("#986 signature ignores ORDER but not identity", () => {
@@ -102,8 +102,8 @@ test("#986 an UNIDENTIFIABLE media set yields no signature, and is therefore nev
   assert.equal(mediaSignature([], []), null);
   assert.equal(mediaSignature(null, null), null);
   const d = createCompletionDeduper();
-  assert.equal(d.consider({ signature: null, panelQueued: false, promptId: "1", durationMs: 100 }).deliver, true);
-  assert.equal(d.consider({ signature: null, panelQueued: false, promptId: "2", durationMs: 100 }).deliver, true);
+  assert.equal(d.consider({ signature: null, panelQueued: false, promptId: "1", durationMs: 100, durationTrusted: true }).deliver, true);
+  assert.equal(d.consider({ signature: null, panelQueued: false, promptId: "2", durationMs: 100, durationTrusted: true }).deliver, true);
 });
 
 test("#986 one unnamed item poisons the whole signature, rather than hashing the rest", () => {
@@ -115,7 +115,7 @@ test("#986 the deduper is bounded in TIME, so it cannot grow without limit", () 
   let t = 0;
   const d = createCompletionDeduper({ ttlMs: 100, now: () => t });
   for (let i = 0; i < 50; i++) {
-    d.consider({ signature: `sig-${i}`, panelQueued: false, promptId: String(i), durationMs: 100 });
+    d.consider({ signature: `sig-${i}`, panelQueued: false, promptId: String(i), durationMs: 100, durationTrusted: true });
     t += 10;
   }
   assert.ok(d.size() < 50, "entries older than the window are pruned");
@@ -138,9 +138,9 @@ test("#986 (codex): a REAL re-render that overwrites the same filename is always
   // report itself.
   const d = createCompletionDeduper();
   const sig = mediaSignature([], [vid("clip.mp4")]);
-  assert.equal(d.consider({ signature: sig, panelQueued: false, promptId: "r1", durationMs: 651000 }).deliver, true);
+  assert.equal(d.consider({ signature: sig, panelQueued: false, promptId: "r1", durationMs: 651000, durationTrusted: true }).deliver, true);
   assert.equal(
-    d.consider({ signature: sig, panelQueued: false, promptId: "r2", durationMs: 640000 }).deliver,
+    d.consider({ signature: sig, panelQueued: false, promptId: "r2", durationMs: 640000, durationTrusted: true }).deliver,
     true,
     "a 10-minute render is never a cache hit, whatever it is called",
   );
@@ -149,10 +149,10 @@ test("#986 (codex): a REAL re-render that overwrites the same filename is always
 test("#986 (codex): an UNKNOWN duration never suppresses — null is not evidence of a cache hit", () => {
   const d = createCompletionDeduper();
   const sig = mediaSignature([], [vid("clip.mp4")]);
-  d.consider({ signature: sig, panelQueued: false, promptId: "1", durationMs: 100 });
+  d.consider({ signature: sig, panelQueued: false, promptId: "1", durationMs: 100, durationTrusted: true });
   for (const durationMs of [null, undefined, -1, Number.NaN, "100"]) {
     assert.equal(
-      d.consider({ signature: sig, panelQueued: false, promptId: "x", durationMs }).deliver,
+      d.consider({ signature: sig, panelQueued: false, promptId: "x", durationMs, durationTrusted: true }).deliver,
       true,
       `durationMs=${String(durationMs)} must not be read as cached`,
     );
@@ -169,4 +169,39 @@ test("#986 (codex): the signature is INJECTIVE — delimiters in a filename cann
   const c = mediaSignature([], [{ filename: "x.mp4", subfolder: 'sub", "', type: "output" }]);
   const e = mediaSignature([], [{ filename: "x.mp4", subfolder: "sub", type: '", "output' }]);
   assert.notEqual(c, e);
+});
+
+test("#986 (codex r2): an UNTRUSTED duration never suppresses, however small", () => {
+  // When execution_start and executing() are both dropped, the tracker invents a
+  // start at the FINAL output event — so a genuine ten-minute render reports a
+  // sub-second duration. Suppressing on that would lose a real result exactly when
+  // frames are being dropped, which is when recovery matters most.
+  const d = createCompletionDeduper();
+  const sig = mediaSignature([], [vid("clip.mp4")]);
+  d.consider({ signature: sig, panelQueued: false, promptId: "1", durationMs: 100, durationTrusted: true });
+  assert.equal(
+    d.consider({ signature: sig, panelQueued: false, promptId: "2", durationMs: 100 }).deliver,
+    true,
+    "durationTrusted defaults to false — an unproven duration is not evidence",
+  );
+  assert.equal(
+    d.consider({ signature: sig, panelQueued: false, promptId: "3", durationMs: 100, durationTrusted: false }).deliver,
+    true,
+  );
+});
+
+test("#986 (codex r2): a video arriving in the RECONCILE wrapper signs the same as a live one", () => {
+  // parseHistoryEntry wraps videos as { m, nodeId }. Signing those as null meant a
+  // recovered video seeded nothing and its next replay was announced again.
+  const live = mediaSignature([], [vid("Video_00144.mp4")]);
+  const reconciled = mediaSignature([], [{ m: vid("Video_00144.mp4"), nodeId: "12" }]);
+  assert.equal(reconciled, live, "the two paths must agree or the fence has a hole");
+});
+
+test("#986 (codex r2): fields cannot bleed into each other across the delimiter", () => {
+  // `type:"output/foo" subfolder:"bar"` vs `type:"output" subfolder:"foo/bar"` produced
+  // the same part when the fields were concatenated.
+  const a = mediaSignature([], [{ filename: "x.png", type: "output/foo", subfolder: "bar" }]);
+  const b = mediaSignature([], [{ filename: "x.png", type: "output", subfolder: "foo/bar" }]);
+  assert.notEqual(a, b);
 });

--- a/browser_tests/unit/completion-dedupe.test.mjs
+++ b/browser_tests/unit/completion-dedupe.test.mjs
@@ -125,13 +125,15 @@ test("#986 the deduper is bounded in TIME, so it cannot grow without limit", () 
 
 test("#986 the note distinguishes a likely replay from a possible real re-render", () => {
   const cached = duplicateCompletionNote("2d9d64f5", true);
-  assert.match(cached, /already delivered by prompt 2d9d64f5/);
-  assert.match(cached, /spent no real time rendering/, "the strongest available hint");
-  assert.match(cached, /very likely the same result again/);
+  assert.match(cached, /Prompt 2d9d64f5 already delivered/);
+  assert.match(cached, /compares references, not file contents/, "codex: same name is not same bytes");
+  assert.match(cached, /finished too fast to have rendered anything/, "the strongest available hint");
+  assert.match(cached, /served from ComfyUI.s cache looks like/);
 
   const real = duplicateCompletionNote("2d9d64f5", false);
-  assert.match(real, /DID spend real time rendering/);
-  assert.match(real, /cannot tell those apart and does not guess/, "no claim it cannot establish");
+  assert.match(real, /did NOT finish suspiciously fast/);
+  assert.match(real, /duration simply could not be established/, "codex: false also covers unknown");
+  assert.match(real, /does not guess/, "no claim it cannot establish");
 
   for (const note of [cached, real]) {
     assert.match(note, /Nothing is withheld/, "the guarantee that matters most");
@@ -248,6 +250,6 @@ test("#986 the duplicate note reaches the agent-facing FRAME, not just the paylo
   );
   assert.equal(frames.length, 1, "one completion frame");
   const note = String(frames[0]?.note ?? "");
-  assert.match(note, /already delivered by prompt first/, "the agent is told, in the frame it reads");
+  assert.match(note, /Prompt first already delivered/, "the agent is told, in the frame it reads");
   assert.match(note, /Nothing is withheld/);
 });

--- a/browser_tests/unit/completion-dedupe.test.mjs
+++ b/browser_tests/unit/completion-dedupe.test.mjs
@@ -1,0 +1,131 @@
+/**
+ * #986 — one finished clip re-announced six times in ~30s, each under a DIFFERENT
+ * prompt id, with sub-second "render" times against a genuine 10m51s first render.
+ *
+ * The existing fence dedupes on prompt id, and these were genuinely different prompts:
+ * the user re-queued from the canvas and ComfyUI served the identical output from
+ * cache. Nothing keyed on prompt id can collapse them. What is the same is the OUTPUT.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  mediaSignature,
+  createCompletionDeduper,
+  duplicateSuppressedNote,
+} from "../../web/js/lib/completion-dedupe.js";
+
+const vid = (filename, subfolder = "", type = "output") => ({ filename, subfolder, type });
+
+test("#986 the reported burst: six cached re-queues of one clip deliver ONCE", () => {
+  const d = createCompletionDeduper();
+  const media = [vid("Video_00144.mp4")];
+  const ids = ["2d9d64f5", "c3e90187", "c5184f9e", "4ce0a352", "740ff0f5", "aa11bb22"];
+  const delivered = ids.filter(
+    (promptId) =>
+      d.consider({ signature: mediaSignature([], media), panelQueued: false, promptId }).deliver,
+  );
+  assert.deepEqual(delivered, ["2d9d64f5"], "only the first announcement survives");
+});
+
+test("#986 the suppressed ones name what they duplicate", () => {
+  const d = createCompletionDeduper();
+  const sig = mediaSignature([], [vid("Video_00144.mp4")]);
+  d.consider({ signature: sig, panelQueued: false, promptId: "first" });
+  const second = d.consider({ signature: sig, panelQueued: false, promptId: "second" });
+  assert.equal(second.deliver, false);
+  assert.equal(second.duplicateOf, "first");
+});
+
+test("#986 a PANEL-QUEUED run is NEVER suppressed — it was promised a notification", () => {
+  // panel_run tells the agent "you will be notified automatically, do NOT poll, end
+  // your turn now". Swallowing one wedges the agent forever, which is worse than the
+  // duplicates this fixes.
+  const d = createCompletionDeduper();
+  const sig = mediaSignature([], [vid("same.mp4")]);
+  assert.equal(d.consider({ signature: sig, panelQueued: false, promptId: "canvas" }).deliver, true);
+  assert.equal(d.consider({ signature: sig, panelQueued: true, promptId: "panel" }).deliver, true);
+  assert.equal(d.consider({ signature: sig, panelQueued: true, promptId: "panel2" }).deliver, true);
+});
+
+test("#986 a panel-queued delivery is RECORDED, so a later canvas replay is caught", () => {
+  // Otherwise the first canvas re-queue after a panel run gets one free pass.
+  const d = createCompletionDeduper();
+  const sig = mediaSignature([], [vid("same.mp4")]);
+  d.record({ signature: sig, promptId: "panel-run" });
+  const replay = d.consider({ signature: sig, panelQueued: false, promptId: "canvas-replay" });
+  assert.equal(replay.deliver, false);
+  assert.equal(replay.duplicateOf, "panel-run");
+});
+
+test("#986 a DIFFERENT output is always delivered", () => {
+  const d = createCompletionDeduper();
+  const a = mediaSignature([], [vid("Video_00144.mp4")]);
+  const b = mediaSignature([], [vid("Video_00145.mp4")]);
+  assert.equal(d.consider({ signature: a, panelQueued: false, promptId: "1" }).deliver, true);
+  assert.equal(d.consider({ signature: b, panelQueued: false, promptId: "2" }).deliver, true);
+});
+
+test("#986 the window EXPIRES — a deliberate re-render later is a real event", () => {
+  let t = 0;
+  const d = createCompletionDeduper({ ttlMs: 1000, now: () => t });
+  const sig = mediaSignature([], [vid("same.mp4")]);
+  assert.equal(d.consider({ signature: sig, panelQueued: false, promptId: "1" }).deliver, true);
+  t = 500;
+  assert.equal(d.consider({ signature: sig, panelQueued: false, promptId: "2" }).deliver, false);
+  t = 2000; // past the window
+  assert.equal(d.consider({ signature: sig, panelQueued: false, promptId: "3" }).deliver, true);
+});
+
+test("#986 signature ignores ORDER but not identity", () => {
+  const a = mediaSignature([vid("a.png")], [vid("b.mp4")]);
+  const b = mediaSignature([vid("a.png")], [vid("b.mp4")]);
+  assert.equal(a, b);
+  assert.notEqual(a, mediaSignature([vid("a.png")], [vid("c.mp4")]));
+  // subfolder and type are part of identity — the same filename elsewhere is a
+  // different file.
+  assert.notEqual(
+    mediaSignature([], [vid("v.mp4", "sub")]),
+    mediaSignature([], [vid("v.mp4", "")]),
+  );
+  assert.notEqual(
+    mediaSignature([], [vid("v.mp4", "", "output")]),
+    mediaSignature([], [vid("v.mp4", "", "temp")]),
+  );
+});
+
+test("#986 an UNIDENTIFIABLE media set yields no signature, and is therefore never suppressed", () => {
+  // A completion with an unnamed output could otherwise collide with a different
+  // unnamed output. Suppressing the wrong result costs the result itself; missing a
+  // duplicate costs one redundant message.
+  assert.equal(mediaSignature([], [{ subfolder: "x" }]), null);
+  assert.equal(mediaSignature([], []), null);
+  assert.equal(mediaSignature(null, null), null);
+  const d = createCompletionDeduper();
+  assert.equal(d.consider({ signature: null, panelQueued: false, promptId: "1" }).deliver, true);
+  assert.equal(d.consider({ signature: null, panelQueued: false, promptId: "2" }).deliver, true);
+});
+
+test("#986 one unnamed item poisons the whole signature, rather than hashing the rest", () => {
+  // Hashing only the named half would let two different sets share a signature.
+  assert.equal(mediaSignature([vid("named.png")], [{ subfolder: "x" }]), null);
+});
+
+test("#986 the deduper is bounded in TIME, so it cannot grow without limit", () => {
+  let t = 0;
+  const d = createCompletionDeduper({ ttlMs: 100, now: () => t });
+  for (let i = 0; i < 50; i++) {
+    d.consider({ signature: `sig-${i}`, panelQueued: false, promptId: String(i) });
+    t += 10;
+  }
+  assert.ok(d.size() < 50, "entries older than the window are pruned");
+});
+
+test("#986 the note explains the collapse and reassures about panel_run", () => {
+  const note = duplicateSuppressedNote(5, "2d9d64f5");
+  assert.match(note, /5 further completions/);
+  assert.match(note, /2d9d64f5/);
+  assert.match(note, /served from ComfyUI's cache/, "names the likely cause without asserting internals");
+  assert.match(note, /queued through panel_run are never suppressed/, "the guarantee that matters");
+  assert.equal(duplicateSuppressedNote(0, "x"), "", "silent when nothing was suppressed");
+});

--- a/browser_tests/unit/completion-dedupe.test.mjs
+++ b/browser_tests/unit/completion-dedupe.test.mjs
@@ -23,7 +23,7 @@ test("#986 the reported burst: six cached re-queues of one clip deliver ONCE", (
   const ids = ["2d9d64f5", "c3e90187", "c5184f9e", "4ce0a352", "740ff0f5", "aa11bb22"];
   const delivered = ids.filter(
     (promptId) =>
-      d.consider({ signature: mediaSignature([], media), panelQueued: false, promptId }).deliver,
+      d.consider({ signature: mediaSignature([], media), panelQueued: false, promptId, durationMs: 100 }).deliver,
   );
   assert.deepEqual(delivered, ["2d9d64f5"], "only the first announcement survives");
 });
@@ -32,7 +32,7 @@ test("#986 the suppressed ones name what they duplicate", () => {
   const d = createCompletionDeduper();
   const sig = mediaSignature([], [vid("Video_00144.mp4")]);
   d.consider({ signature: sig, panelQueued: false, promptId: "first" });
-  const second = d.consider({ signature: sig, panelQueued: false, promptId: "second" });
+  const second = d.consider({ signature: sig, panelQueued: false, promptId: "second", durationMs: 100 });
   assert.equal(second.deliver, false);
   assert.equal(second.duplicateOf, "first");
 });
@@ -43,7 +43,7 @@ test("#986 a PANEL-QUEUED run is NEVER suppressed — it was promised a notifica
   // duplicates this fixes.
   const d = createCompletionDeduper();
   const sig = mediaSignature([], [vid("same.mp4")]);
-  assert.equal(d.consider({ signature: sig, panelQueued: false, promptId: "canvas" }).deliver, true);
+  assert.equal(d.consider({ signature: sig, panelQueued: false, promptId: "canvas", durationMs: 100 }).deliver, true);
   assert.equal(d.consider({ signature: sig, panelQueued: true, promptId: "panel" }).deliver, true);
   assert.equal(d.consider({ signature: sig, panelQueued: true, promptId: "panel2" }).deliver, true);
 });
@@ -53,7 +53,7 @@ test("#986 a panel-queued delivery is RECORDED, so a later canvas replay is caug
   const d = createCompletionDeduper();
   const sig = mediaSignature([], [vid("same.mp4")]);
   d.record({ signature: sig, promptId: "panel-run" });
-  const replay = d.consider({ signature: sig, panelQueued: false, promptId: "canvas-replay" });
+  const replay = d.consider({ signature: sig, panelQueued: false, promptId: "canvas-replay", durationMs: 100 });
   assert.equal(replay.deliver, false);
   assert.equal(replay.duplicateOf, "panel-run");
 });
@@ -62,19 +62,19 @@ test("#986 a DIFFERENT output is always delivered", () => {
   const d = createCompletionDeduper();
   const a = mediaSignature([], [vid("Video_00144.mp4")]);
   const b = mediaSignature([], [vid("Video_00145.mp4")]);
-  assert.equal(d.consider({ signature: a, panelQueued: false, promptId: "1" }).deliver, true);
-  assert.equal(d.consider({ signature: b, panelQueued: false, promptId: "2" }).deliver, true);
+  assert.equal(d.consider({ signature: a, panelQueued: false, promptId: "1", durationMs: 100 }).deliver, true);
+  assert.equal(d.consider({ signature: b, panelQueued: false, promptId: "2", durationMs: 100 }).deliver, true);
 });
 
 test("#986 the window EXPIRES — a deliberate re-render later is a real event", () => {
   let t = 0;
   const d = createCompletionDeduper({ ttlMs: 1000, now: () => t });
   const sig = mediaSignature([], [vid("same.mp4")]);
-  assert.equal(d.consider({ signature: sig, panelQueued: false, promptId: "1" }).deliver, true);
+  assert.equal(d.consider({ signature: sig, panelQueued: false, promptId: "1", durationMs: 100 }).deliver, true);
   t = 500;
-  assert.equal(d.consider({ signature: sig, panelQueued: false, promptId: "2" }).deliver, false);
+  assert.equal(d.consider({ signature: sig, panelQueued: false, promptId: "2", durationMs: 100 }).deliver, false);
   t = 2000; // past the window
-  assert.equal(d.consider({ signature: sig, panelQueued: false, promptId: "3" }).deliver, true);
+  assert.equal(d.consider({ signature: sig, panelQueued: false, promptId: "3", durationMs: 100 }).deliver, true);
 });
 
 test("#986 signature ignores ORDER but not identity", () => {
@@ -102,8 +102,8 @@ test("#986 an UNIDENTIFIABLE media set yields no signature, and is therefore nev
   assert.equal(mediaSignature([], []), null);
   assert.equal(mediaSignature(null, null), null);
   const d = createCompletionDeduper();
-  assert.equal(d.consider({ signature: null, panelQueued: false, promptId: "1" }).deliver, true);
-  assert.equal(d.consider({ signature: null, panelQueued: false, promptId: "2" }).deliver, true);
+  assert.equal(d.consider({ signature: null, panelQueued: false, promptId: "1", durationMs: 100 }).deliver, true);
+  assert.equal(d.consider({ signature: null, panelQueued: false, promptId: "2", durationMs: 100 }).deliver, true);
 });
 
 test("#986 one unnamed item poisons the whole signature, rather than hashing the rest", () => {
@@ -115,7 +115,7 @@ test("#986 the deduper is bounded in TIME, so it cannot grow without limit", () 
   let t = 0;
   const d = createCompletionDeduper({ ttlMs: 100, now: () => t });
   for (let i = 0; i < 50; i++) {
-    d.consider({ signature: `sig-${i}`, panelQueued: false, promptId: String(i) });
+    d.consider({ signature: `sig-${i}`, panelQueued: false, promptId: String(i), durationMs: 100 });
     t += 10;
   }
   assert.ok(d.size() < 50, "entries older than the window are pruned");
@@ -128,4 +128,45 @@ test("#986 the note explains the collapse and reassures about panel_run", () => 
   assert.match(note, /served from ComfyUI's cache/, "names the likely cause without asserting internals");
   assert.match(note, /queued through panel_run are never suppressed/, "the guarantee that matters");
   assert.equal(duplicateSuppressedNote(0, "x"), "", "silent when nothing was suppressed");
+});
+
+test("#986 (codex): a REAL re-render that overwrites the same filename is always delivered", () => {
+  // The false positive that would make this worse than the bug. A node writing a fixed
+  // name — no counter in the prefix — produces two genuine results with identical
+  // signatures. Same filename is not the same result; what separates a cache replay
+  // from a real render is that the replay did not render. 0.1s vs 10m51s, from the
+  // report itself.
+  const d = createCompletionDeduper();
+  const sig = mediaSignature([], [vid("clip.mp4")]);
+  assert.equal(d.consider({ signature: sig, panelQueued: false, promptId: "r1", durationMs: 651000 }).deliver, true);
+  assert.equal(
+    d.consider({ signature: sig, panelQueued: false, promptId: "r2", durationMs: 640000 }).deliver,
+    true,
+    "a 10-minute render is never a cache hit, whatever it is called",
+  );
+});
+
+test("#986 (codex): an UNKNOWN duration never suppresses — null is not evidence of a cache hit", () => {
+  const d = createCompletionDeduper();
+  const sig = mediaSignature([], [vid("clip.mp4")]);
+  d.consider({ signature: sig, panelQueued: false, promptId: "1", durationMs: 100 });
+  for (const durationMs of [null, undefined, -1, Number.NaN, "100"]) {
+    assert.equal(
+      d.consider({ signature: sig, panelQueued: false, promptId: "x", durationMs }).deliver,
+      true,
+      `durationMs=${String(durationMs)} must not be read as cached`,
+    );
+  }
+});
+
+test("#986 (codex): the signature is INJECTIVE — delimiters in a filename cannot forge a collision", () => {
+  // The fields are producer-controlled. Concatenating them with delimiters let a name
+  // containing one make two different sets share a signature, which here means a real
+  // result is suppressed.
+  const a = mediaSignature([], [vid('a", "b.mp4')]);
+  const b = mediaSignature([], [vid("a", "b.mp4")]);
+  assert.notEqual(a, b);
+  const c = mediaSignature([], [{ filename: "x.mp4", subfolder: 'sub", "', type: "output" }]);
+  const e = mediaSignature([], [{ filename: "x.mp4", subfolder: "sub", type: '", "output' }]);
+  assert.notEqual(c, e);
 });

--- a/browser_tests/unit/completion-dedupe.test.mjs
+++ b/browser_tests/unit/completion-dedupe.test.mjs
@@ -12,28 +12,30 @@ import assert from "node:assert/strict";
 import {
   mediaSignature,
   createCompletionDeduper,
-  duplicateSuppressedNote,
+  duplicateCompletionNote,
 } from "../../web/js/lib/completion-dedupe.js";
 
 const vid = (filename, subfolder = "", type = "output") => ({ filename, subfolder, type });
 
-test("#986 the reported burst: six cached re-queues of one clip deliver ONCE", () => {
+test("#986 the reported burst: every repeat is DELIVERED and labelled", () => {
   const d = createCompletionDeduper();
   const media = [vid("Video_00144.mp4")];
-  const ids = ["2d9d64f5", "c3e90187", "c5184f9e", "4ce0a352", "740ff0f5", "aa11bb22"];
-  const delivered = ids.filter(
-    (promptId) =>
-      d.consider({ signature: mediaSignature([], media), panelQueued: false, promptId, durationMs: 100, durationTrusted: true }).deliver,
+  const ids = ["2d9d64f5", "c3e90187", "c5184f9e"];
+  const results = ids.map((promptId) =>
+    d.consider({ signature: mediaSignature([], media), panelQueued: false, promptId, durationMs: 100, durationTrusted: true }),
   );
-  assert.deepEqual(delivered, ["2d9d64f5"], "only the first announcement survives");
+  assert.ok(results.every((r) => r.deliver), "nothing is ever withheld");
+  assert.equal(results[0].duplicateOf, null);
+  assert.equal(results[1].duplicateOf, "2d9d64f5");
+  assert.equal(results[1].looksCached, true);
 });
 
-test("#986 the suppressed ones name what they duplicate", () => {
+test("#986 a repeat names what it duplicates", () => {
   const d = createCompletionDeduper();
   const sig = mediaSignature([], [vid("Video_00144.mp4")]);
   d.consider({ signature: sig, panelQueued: false, promptId: "first" });
   const second = d.consider({ signature: sig, panelQueued: false, promptId: "second", durationMs: 100, durationTrusted: true });
-  assert.equal(second.deliver, false);
+  assert.equal(second.deliver, true);
   assert.equal(second.duplicateOf, "first");
 });
 
@@ -54,8 +56,8 @@ test("#986 a panel-queued delivery is RECORDED, so a later canvas replay is caug
   const sig = mediaSignature([], [vid("same.mp4")]);
   d.record({ signature: sig, promptId: "panel-run" });
   const replay = d.consider({ signature: sig, panelQueued: false, promptId: "canvas-replay", durationMs: 100, durationTrusted: true });
-  assert.equal(replay.deliver, false);
-  assert.equal(replay.duplicateOf, "panel-run");
+  assert.equal(replay.deliver, true, "delivered — nothing is ever withheld");
+  assert.equal(replay.duplicateOf, "panel-run", "but labelled with what it repeats");
 });
 
 test("#986 a DIFFERENT output is always delivered", () => {
@@ -72,7 +74,7 @@ test("#986 the window EXPIRES — a deliberate re-render later is a real event",
   const sig = mediaSignature([], [vid("same.mp4")]);
   assert.equal(d.consider({ signature: sig, panelQueued: false, promptId: "1", durationMs: 100, durationTrusted: true }).deliver, true);
   t = 500;
-  assert.equal(d.consider({ signature: sig, panelQueued: false, promptId: "2", durationMs: 100, durationTrusted: true }).deliver, false);
+  assert.equal(d.consider({ signature: sig, panelQueued: false, promptId: "2", durationMs: 100, durationTrusted: true }).duplicateOf, "1");
   t = 2000; // past the window
   assert.equal(d.consider({ signature: sig, panelQueued: false, promptId: "3", durationMs: 100, durationTrusted: true }).deliver, true);
 });
@@ -121,13 +123,20 @@ test("#986 the deduper is bounded in TIME, so it cannot grow without limit", () 
   assert.ok(d.size() < 50, "entries older than the window are pruned");
 });
 
-test("#986 the note explains the collapse and reassures about panel_run", () => {
-  const note = duplicateSuppressedNote(5, "2d9d64f5");
-  assert.match(note, /5 further completions/);
-  assert.match(note, /2d9d64f5/);
-  assert.match(note, /served from ComfyUI's cache/, "names the likely cause without asserting internals");
-  assert.match(note, /queued through panel_run are never suppressed/, "the guarantee that matters");
-  assert.equal(duplicateSuppressedNote(0, "x"), "", "silent when nothing was suppressed");
+test("#986 the note distinguishes a likely replay from a possible real re-render", () => {
+  const cached = duplicateCompletionNote("2d9d64f5", true);
+  assert.match(cached, /already delivered by prompt 2d9d64f5/);
+  assert.match(cached, /spent no real time rendering/, "the strongest available hint");
+  assert.match(cached, /very likely the same result again/);
+
+  const real = duplicateCompletionNote("2d9d64f5", false);
+  assert.match(real, /DID spend real time rendering/);
+  assert.match(real, /cannot tell those apart and does not guess/, "no claim it cannot establish");
+
+  for (const note of [cached, real]) {
+    assert.match(note, /Nothing is withheld/, "the guarantee that matters most");
+  }
+  assert.equal(duplicateCompletionNote(null, true), "", "silent when nothing is duplicated");
 });
 
 test("#986 (codex): a REAL re-render that overwrites the same filename is always delivered", () => {
@@ -204,4 +213,41 @@ test("#986 (codex r2): fields cannot bleed into each other across the delimiter"
   const a = mediaSignature([], [{ filename: "x.png", type: "output/foo", subfolder: "bar" }]);
   const b = mediaSignature([], [{ filename: "x.png", type: "output", subfolder: "foo/bar" }]);
   assert.notEqual(a, b);
+});
+
+test("#986 the duplicate note reaches the agent-facing FRAME, not just the payload", async () => {
+  // The annotation is worthless if it only exists in a result field nobody renders.
+  // Asserted through the real composer, which is what the agent actually receives.
+  const { composeRunCompletionFrame } = await import("../../web/js/lib/run-completion-frame.js");
+  const frames = [];
+  await composeRunCompletionFrame(
+    {
+      promptId: "second",
+      images: [{ filename: "a.png", type: "output" }],
+      videos: [],
+      durationMs: 100,
+      duplicateOf: "first",
+      looksCached: true,
+    },
+    {
+      sendFrame: (f) => (frames.push(f), true),
+      coerceMessageText: (t) => t,
+      formatDuration: (ms) => `${ms}ms`,
+      formatClock: () => "12:00",
+      imageViewUrl: () => "u",
+      fetchImageBytes: async () => null,
+      fetchImageDimensions: async () => null,
+      humanizeBytes: () => "1 KB",
+      buildVideoStoryboard: async () => null,
+      uploadBlobToInput: async () => null,
+      storyboardFrameCount: () => 0,
+      paintImage: async () => null,
+      agentReceivesImages: () => true,
+      now: () => new Date(0),
+    },
+  );
+  assert.equal(frames.length, 1, "one completion frame");
+  const note = String(frames[0]?.note ?? "");
+  assert.match(note, /already delivered by prompt first/, "the agent is told, in the frame it reads");
+  assert.match(note, /Nothing is withheld/);
 });

--- a/browser_tests/unit/run-completion.test.mjs
+++ b/browser_tests/unit/run-completion.test.mjs
@@ -648,10 +648,8 @@ function makeDedupeHarness({ duplicateWindowMs = 5 * 60 * 1000 } = {}) {
   let seq = 0;
   const timers = new Map();
   const flushes = [];
-  const suppressed = [];
   const tracker = createRunCompletionTracker({
     onFlush: (p) => flushes.push(p),
-    onDuplicateSuppressed: (p) => suppressed.push(p),
     duplicateWindowMs,
     now: () => clock,
     setTimer: (fn, ms) => {
@@ -661,7 +659,7 @@ function makeDedupeHarness({ duplicateWindowMs = 5 * 60 * 1000 } = {}) {
     },
     clearTimer: (id) => timers.delete(id),
   });
-  return { tracker, flushes, suppressed, advance: (ms) => (clock += ms) };
+  return { tracker, flushes, advance: (ms) => (clock += ms) };
 }
 
 /** One canvas run that produces the given video and finishes. */
@@ -671,16 +669,18 @@ const canvasRun = (h, promptId, filename) => {
   h.tracker.onExecutionSuccess(promptId);
 };
 
-test("#986: six cached canvas re-queues of one clip deliver ONE completion", () => {
+test("#986: the reported burst — every repeat is DELIVERED, and every repeat is labelled", () => {
   const h = makeDedupeHarness();
   for (const id of ["2d9d64f5", "c3e90187", "c5184f9e", "4ce0a352", "740ff0f5", "aa11bb22"]) {
     canvasRun(h, id, "Video_00144.mp4");
     h.advance(5000); // the reported burst was ~30s across six
   }
-  assert.equal(h.flushes.length, 1, "the agent is told once");
-  assert.equal(h.flushes[0].promptId, "2d9d64f5");
-  assert.equal(h.suppressed.length, 5, "and the rest are accounted for, not silently dropped");
-  assert.equal(h.suppressed[0].duplicateOf, "2d9d64f5", "naming what they duplicate");
+  assert.equal(h.flushes.length, 6, "no result is ever swallowed");
+  assert.equal(h.flushes[0].duplicateOf, undefined, "the first duplicates nothing");
+  for (const f of h.flushes.slice(1)) {
+    assert.equal(f.duplicateOf, "2d9d64f5", "each repeat names the delivery it duplicates");
+    assert.equal(f.looksCached, true, "and says it did no real work — the 0.1s giveaway");
+  }
 });
 
 test("#986: a PANEL-QUEUED run is delivered even when its output was already seen", () => {
@@ -692,7 +692,7 @@ test("#986: a PANEL-QUEUED run is delivered even when its output was already see
   h.tracker.onQueued("panel-1");
   canvasRun(h, "panel-1", "same.mp4");
   assert.equal(h.flushes.length, 2, "the run the agent is waiting for always arrives");
-  assert.deepEqual(h.suppressed, []);
+  assert.equal(h.flushes[h.flushes.length-1].duplicateOf, undefined, "not labelled a duplicate");
 });
 
 test("#986: a DIFFERENT output is never collapsed into a previous one", () => {
@@ -700,7 +700,7 @@ test("#986: a DIFFERENT output is never collapsed into a previous one", () => {
   canvasRun(h, "p1", "Video_00144.mp4");
   canvasRun(h, "p2", "Video_00145.mp4");
   assert.equal(h.flushes.length, 2);
-  assert.deepEqual(h.suppressed, []);
+  assert.equal(h.flushes[h.flushes.length-1].duplicateOf, undefined, "not labelled a duplicate");
 });
 
 test("#986: past the window, a deliberate re-render of the same file is a real event again", () => {
@@ -711,12 +711,17 @@ test("#986: past the window, a deliberate re-render of the same file is a real e
   assert.equal(h.flushes.length, 2, "an hour-later re-render is not a duplicate");
 });
 
-test("#986: a suppressed duplicate is RETIRED, so a later reconcile cannot re-deliver it", () => {
-  const h = makeDedupeHarness();
-  canvasRun(h, "p1", "same.mp4");
-  canvasRun(h, "p2", "same.mp4");
-  assert.equal(h.suppressed.length, 1);
-  assert.equal(h.tracker.isSettled("p2"), true, "not left pending for a sweep to pick up");
+test("#986: a REAL re-render overwriting the same filename is delivered and NOT called cached", () => {
+  // The case that killed suppression: a fixed-name writer producing different bytes.
+  const h = makeDedupeHarness({ duplicateWindowMs: 60 * 60 * 1000 });
+  canvasRun(h, "first", "fixed.mp4");
+  h.tracker.onExecutionStart("second");
+  h.advance(600000);
+  h.tracker.onExecuted("second", { images: [], videos: [{ filename: "fixed.mp4", subfolder: "", type: "output" }] });
+  h.tracker.onExecutionSuccess("second");
+  assert.equal(h.flushes.length, 2, "a real render always arrives");
+  assert.equal(h.flushes[1].duplicateOf, "first", "the filename repeat is still disclosed");
+  assert.equal(h.flushes[1].looksCached, false, "but it is NOT claimed to be a replay");
 });
 
 test("#986 (codex r3): a later `executing` must NOT upgrade a FABRICATED start to trusted", () => {
@@ -735,5 +740,5 @@ test("#986 (codex r3): a later `executing` must NOT upgrade a FABRICATED start t
   h.tracker.onExecutingNode("second", "node-2"); // later signal, different node
   h.tracker.onExecutionSuccess("second"); // finishes within the cache-hit threshold
   assert.equal(h.flushes.length, 2, "a real render is delivered even when its duration looks tiny");
-  assert.deepEqual(h.suppressed, []);
+  assert.equal(h.flushes[1].looksCached, false, "an INVENTED duration is never called a cache hit");
 });

--- a/browser_tests/unit/run-completion.test.mjs
+++ b/browser_tests/unit/run-completion.test.mjs
@@ -633,3 +633,88 @@ test("#609 wiring: the panel call site feeds the composer the gate's own blind p
     "the note's review request must be conditioned on the SAME blind flag the sendFrame gate strips by",
   );
 });
+
+// ---------------------------------------------------------------------------
+// #986 — the SAME finished output re-announced as separate completions. Six in
+// ~30s, each under a different prompt id with a sub-second "render" time, because
+// the user re-queued from the canvas and ComfyUI served it from cache. The
+// prompt-id fence cannot collapse genuinely different prompts; the OUTPUT is what
+// repeats. These drive the real tracker, so the wiring is what is under test.
+// ---------------------------------------------------------------------------
+
+/** A harness that also captures suppressions and lets the dedupe window be set. */
+function makeDedupeHarness({ duplicateWindowMs = 5 * 60 * 1000 } = {}) {
+  let clock = 0;
+  let seq = 0;
+  const timers = new Map();
+  const flushes = [];
+  const suppressed = [];
+  const tracker = createRunCompletionTracker({
+    onFlush: (p) => flushes.push(p),
+    onDuplicateSuppressed: (p) => suppressed.push(p),
+    duplicateWindowMs,
+    now: () => clock,
+    setTimer: (fn, ms) => {
+      const id = ++seq;
+      timers.set(id, { at: clock + ms, fn });
+      return id;
+    },
+    clearTimer: (id) => timers.delete(id),
+  });
+  return { tracker, flushes, suppressed, advance: (ms) => (clock += ms) };
+}
+
+/** One canvas run that produces the given video and finishes. */
+const canvasRun = (h, promptId, filename) => {
+  h.tracker.onExecutionStart(promptId);
+  h.tracker.onExecuted(promptId, { images: [], videos: [{ filename, subfolder: "", type: "output" }] });
+  h.tracker.onExecutionSuccess(promptId);
+};
+
+test("#986: six cached canvas re-queues of one clip deliver ONE completion", () => {
+  const h = makeDedupeHarness();
+  for (const id of ["2d9d64f5", "c3e90187", "c5184f9e", "4ce0a352", "740ff0f5", "aa11bb22"]) {
+    canvasRun(h, id, "Video_00144.mp4");
+    h.advance(5000); // the reported burst was ~30s across six
+  }
+  assert.equal(h.flushes.length, 1, "the agent is told once");
+  assert.equal(h.flushes[0].promptId, "2d9d64f5");
+  assert.equal(h.suppressed.length, 5, "and the rest are accounted for, not silently dropped");
+  assert.equal(h.suppressed[0].duplicateOf, "2d9d64f5", "naming what they duplicate");
+});
+
+test("#986: a PANEL-QUEUED run is delivered even when its output was already seen", () => {
+  // panel_run promised the agent a notification and told it to end its turn.
+  // Suppressing that wedges it forever — strictly worse than the duplicates.
+  const h = makeDedupeHarness();
+  canvasRun(h, "canvas-1", "same.mp4");
+  assert.equal(h.flushes.length, 1);
+  h.tracker.onQueued("panel-1");
+  canvasRun(h, "panel-1", "same.mp4");
+  assert.equal(h.flushes.length, 2, "the run the agent is waiting for always arrives");
+  assert.deepEqual(h.suppressed, []);
+});
+
+test("#986: a DIFFERENT output is never collapsed into a previous one", () => {
+  const h = makeDedupeHarness();
+  canvasRun(h, "p1", "Video_00144.mp4");
+  canvasRun(h, "p2", "Video_00145.mp4");
+  assert.equal(h.flushes.length, 2);
+  assert.deepEqual(h.suppressed, []);
+});
+
+test("#986: past the window, a deliberate re-render of the same file is a real event again", () => {
+  const h = makeDedupeHarness({ duplicateWindowMs: 1000 });
+  canvasRun(h, "p1", "same.mp4");
+  h.advance(5000);
+  canvasRun(h, "p2", "same.mp4");
+  assert.equal(h.flushes.length, 2, "an hour-later re-render is not a duplicate");
+});
+
+test("#986: a suppressed duplicate is RETIRED, so a later reconcile cannot re-deliver it", () => {
+  const h = makeDedupeHarness();
+  canvasRun(h, "p1", "same.mp4");
+  canvasRun(h, "p2", "same.mp4");
+  assert.equal(h.suppressed.length, 1);
+  assert.equal(h.tracker.isSettled("p2"), true, "not left pending for a sweep to pick up");
+});

--- a/browser_tests/unit/run-completion.test.mjs
+++ b/browser_tests/unit/run-completion.test.mjs
@@ -718,3 +718,22 @@ test("#986: a suppressed duplicate is RETIRED, so a later reconcile cannot re-de
   assert.equal(h.suppressed.length, 1);
   assert.equal(h.tracker.isSettled("p2"), true, "not left pending for a sweep to pick up");
 });
+
+test("#986 (codex r3): a later `executing` must NOT upgrade a FABRICATED start to trusted", () => {
+  // Partial frame loss: execution_start and the first node's `executing` are both
+  // dropped, so `onExecuted` invents a timestamp. A later `executing` for a SECOND
+  // output node used to mark that invented value trusted — making a genuine long
+  // multi-output render look sub-second AND trusted, which is the shape that gets
+  // suppressed. It must deliver.
+  const h = makeDedupeHarness();
+  // Seed: an earlier run announced the same fixed filename.
+  canvasRun(h, "earlier", "fixed.mp4");
+  assert.equal(h.flushes.length, 1);
+  h.advance(1000);
+  // The genuine second render, with its start frames lost.
+  h.tracker.onExecuted("second", { images: [], videos: [{ filename: "fixed.mp4", subfolder: "", type: "output" }] });
+  h.tracker.onExecutingNode("second", "node-2"); // later signal, different node
+  h.tracker.onExecutionSuccess("second"); // finishes within the cache-hit threshold
+  assert.equal(h.flushes.length, 2, "a real render is delivered even when its duration looks tiny");
+  assert.deepEqual(h.suppressed, []);
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -25122,6 +25122,23 @@ function buildPanel() {
   // This closure owns ONLY presentation: it receives the full, correctly-scoped
   // batch + duration for a completed prompt and composes the single agent_event.
   const runCompletion = createRunCompletionTracker({
+    // #986 — a suppressed duplicate is not silently dropped. It is a canvas re-queue
+    // whose output was already announced and which plainly did not render (a
+    // sub-second "render" of a clip that took minutes the first time), so the agent
+    // gains nothing from a second identical turn — but the console should still be
+    // able to show that it happened, and this is the seam that makes it observable
+    // rather than a claim in a comment.
+    onDuplicateSuppressed: ({ promptId, duplicateOf, durationMs }) => {
+      try {
+        console.info(
+          `[comfyui-mcp-panel] #986 duplicate completion suppressed: prompt ${promptId} ` +
+            `delivered the same output as ${duplicateOf ?? "an earlier run"} in ${durationMs}ms ` +
+            `(cache replay, not a new render)`,
+        );
+      } catch {
+        /* logging must never break the run lifecycle */
+      }
+    },
     onFlush: ({ promptId, images: flImages, videos: flVideos, durationMs, noMedia }) => {
       // #370: track whether the composed completion frame actually reached the
       // agent. sendFrame returns false when the bridge socket is down — in that

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -25128,18 +25128,11 @@ function buildPanel() {
     // gains nothing from a second identical turn — but the console should still be
     // able to show that it happened, and this is the seam that makes it observable
     // rather than a claim in a comment.
-    onDuplicateSuppressed: ({ promptId, duplicateOf, durationMs }) => {
-      try {
-        console.info(
-          `[comfyui-mcp-panel] #986 duplicate completion suppressed: prompt ${promptId} ` +
-            `delivered the same output as ${duplicateOf ?? "an earlier run"} in ${durationMs}ms ` +
-            `(cache replay, not a new render)`,
-        );
-      } catch {
-        /* logging must never break the run lifecycle */
-      }
-    },
-    onFlush: ({ promptId, images: flImages, videos: flVideos, durationMs, noMedia }) => {
+    // #986 — a repeated output is ANNOTATED, never withheld: which of a cache replay
+    // or a fast re-render it is cannot be proven, and losing a render the user waited
+    // for would be worse than an extra message. The console line makes the annotation
+    // visible without the agent having to infer it.
+    onFlush: ({ promptId, images: flImages, videos: flVideos, durationMs, noMedia, duplicateOf, looksCached }) => {
       // #370: track whether the composed completion frame actually reached the
       // agent. sendFrame returns false when the bridge socket is down — in that
       // case the completion is LOST, so we re-pend the prompt (markUndelivered) so
@@ -25159,7 +25152,7 @@ function buildPanel() {
         // no image or video. Without it the composer returns null, the call site
         // below reads that as "empty batch ⇒ already delivered", and the agent that
         // panel_run told to end its turn and wait is never told anything.
-        { promptId, images: flImages, videos: flVideos, durationMs, noMedia },
+        { promptId, images: flImages, videos: flVideos, durationMs, noMedia, duplicateOf, looksCached },
         {
           sendFrame: (frame) => {
             const ok = client.sendFrame(frame);

--- a/web/js/lib/completion-dedupe.js
+++ b/web/js/lib/completion-dedupe.js
@@ -1,0 +1,127 @@
+/**
+ * #986 — the same finished output re-announced as several separate completions.
+ *
+ * REPORTED: one 10s clip (`Video_00144.mp4`) delivered to the agent six or more times
+ * in ~30 seconds. Each arrived with a DIFFERENT prompt id, an implausible render time
+ * (0.3s, 0.1s, …) against a genuine first render of 10m51s, an identical contact
+ * sheet, and the "origin is UNDETERMINED" banner. Every one demanded a reply, and the
+ * agent had no way to tell a replay from a real re-render.
+ *
+ * WHY THE EXISTING FENCE DOES NOT CATCH IT. `run-completion.js` dedupes on the PROMPT
+ * ID (`delivered` is keyed by it). These were genuinely different prompts: the user
+ * queued, cancelled and re-queued from the canvas, and ComfyUI served the identical
+ * output from cache each time — which is also why the durations are sub-second. So
+ * the fence is working exactly as designed and is simply looking at the wrong thing.
+ * Nothing keyed on prompt id can collapse them.
+ *
+ * WHAT IS THE SAME is the OUTPUT. So the dedupe is on the media itself.
+ *
+ * SCOPED TO RUNS THE PANEL DID NOT QUEUE. A panel-queued run was promised a
+ * notification — `panel_run` tells the agent "you will be notified automatically, do
+ * NOT poll, end your turn now" — so suppressing one would wedge the agent waiting for
+ * a message that never comes. That is a worse failure than the duplicates. A canvas
+ * run carries no such promise, which is exactly the case the report is about.
+ */
+
+/**
+ * A stable identity for a completion's media: what files it delivered, not which
+ * prompt produced them.
+ *
+ * Sorted so ordering differences cannot mint a new signature, and built from the
+ * fields that identify a file on the server (`filename`, `subfolder`, `type`).
+ * Returns null when there is nothing identifying to hash — no signature means no
+ * suppression, which is the safe direction.
+ */
+export function mediaSignature(images, videos) {
+  const parts = [];
+  const add = (kind, list) => {
+    if (!Array.isArray(list)) return;
+    for (const item of list) {
+      if (!item || typeof item !== "object") continue;
+      const filename = item.filename ?? item.name ?? null;
+      // A media item with no filename cannot be identified across runs. Including a
+      // placeholder would let two DIFFERENT unnamed outputs collide, so the whole
+      // signature is abandoned instead (see the null return below).
+      if (typeof filename !== "string" || filename === "") return null;
+      parts.push(`${kind}:${item.type ?? ""}/${item.subfolder ?? ""}/${filename}`);
+    }
+  };
+  if (add("i", images) === null) return null;
+  if (add("v", videos) === null) return null;
+  if (!parts.length) return null;
+  parts.sort();
+  return parts.join("|");
+}
+
+/**
+ * Tracks which media sets have already been announced, so an identical one arriving
+ * again under a new prompt id can be recognised.
+ *
+ * `ttlMs` bounds it in time rather than in count: two renders of the same file an hour
+ * apart are two real events and must both be delivered. The default window is minutes,
+ * which covers the reported burst (six in ~30 seconds) without swallowing a later
+ * deliberate re-render.
+ */
+export function createCompletionDeduper({ ttlMs = 5 * 60 * 1000, now = () => Date.now() } = {}) {
+  const seen = new Map(); // signature -> { at, promptId }
+
+  const prune = () => {
+    const cutoff = now() - ttlMs;
+    for (const [sig, entry] of seen) if (entry.at < cutoff) seen.delete(sig);
+  };
+
+  return {
+    /**
+     * Should this completion be delivered?
+     *
+     * Returns `{ deliver, duplicateOf }`. `deliver` is false ONLY when every condition
+     * holds: the panel did not queue this run, the media is identifiable, and the same
+     * media was announced within the window. Anything unestablished delivers — a
+     * missed duplicate costs a redundant message, a wrongly-suppressed completion
+     * costs the result itself.
+     */
+    consider({ signature, panelQueued, promptId }) {
+      prune();
+      if (panelQueued) return { deliver: true, duplicateOf: null };
+      if (!signature) return { deliver: true, duplicateOf: null };
+      const hit = seen.get(signature);
+      if (hit) return { deliver: false, duplicateOf: hit.promptId ?? null };
+      seen.set(signature, { at: now(), promptId: promptId ?? null });
+      return { deliver: true, duplicateOf: null };
+    },
+
+    /**
+     * Record a delivery made outside `consider` (a panel-queued run), so a later
+     * canvas re-queue of the SAME output is recognised as the duplicate it is.
+     * Without this the first canvas replay after a panel run would always get through.
+     */
+    record({ signature, promptId }) {
+      if (!signature) return;
+      prune();
+      if (!seen.has(signature)) seen.set(signature, { at: now(), promptId: promptId ?? null });
+    },
+
+    /** Test/observability seam: how many signatures are currently held. */
+    size() {
+      prune();
+      return seen.size;
+    },
+  };
+}
+
+/**
+ * The note attached to a suppressed duplicate's counterpart — used by the caller to
+ * explain, once, that further identical completions are being collapsed. States what
+ * was observed rather than diagnosing ComfyUI's caching.
+ */
+export function duplicateSuppressedNote(count, duplicateOf) {
+  if (!count) return "";
+  return (
+    `${count} further completion${count === 1 ? "" : "s"} carrying this exact output ` +
+    `${count === 1 ? "was" : "were"} not re-announced. They arrived under different prompt ids ` +
+    `${duplicateOf ? `(first seen as ${duplicateOf}) ` : ""}but delivered the same file(s), which is ` +
+    `what a re-queue served from ComfyUI's cache looks like — the sub-second durations are the ` +
+    `giveaway. Runs queued through panel_run are never suppressed, so a result you asked for ` +
+    `always arrives.`
+  );
+}

--- a/web/js/lib/completion-dedupe.js
+++ b/web/js/lib/completion-dedupe.js
@@ -38,12 +38,22 @@ export function mediaSignature(images, videos) {
     if (!Array.isArray(list)) return;
     for (const item of list) {
       if (!item || typeof item !== "object") continue;
-      const filename = item.filename ?? item.name ?? null;
+      // Reconciled videos arrive WRAPPED as `{ m, nodeId }` from parseHistoryEntry,
+      // not as the bare ref (codex). Unwrapping here rather than at each call site
+      // keeps the two paths producing the SAME signature — without it a recovered
+      // video signed as null, so the reported clip shape seeded nothing and its next
+      // replay was announced again.
+      const ref = item.m && typeof item.m === "object" ? item.m : item;
+      const filename = ref.filename ?? ref.name ?? null;
       // A media item with no filename cannot be identified across runs. Including a
       // placeholder would let two DIFFERENT unnamed outputs collide, so the whole
       // signature is abandoned instead (see the null return below).
       if (typeof filename !== "string" || filename === "") return null;
-      parts.push(`${kind}:${item.type ?? ""}/${item.subfolder ?? ""}/${filename}`);
+      // JSON-encoded per FIELD, not concatenated (codex). An earlier attempt encoded
+      // only the outer array while each part stayed `kind:type/subfolder/filename`,
+      // so `type:"output/foo" subfolder:"bar"` and `type:"output" subfolder:"foo/bar"`
+      // still produced the same part — a collision here suppresses a real result.
+      parts.push(JSON.stringify([kind, ref.type ?? "", ref.subfolder ?? "", filename]));
     }
   };
   if (add("i", images) === null) return null;
@@ -96,7 +106,7 @@ export function createCompletionDeduper({
      * missed duplicate costs a redundant message, a wrongly-suppressed completion
      * costs the result itself.
      */
-    consider({ signature, panelQueued, promptId, durationMs }) {
+    consider({ signature, panelQueued, promptId, durationMs, durationTrusted = false }) {
       prune();
       if (panelQueued) return { deliver: true, duplicateOf: null };
       if (!signature) return { deliver: true, duplicateOf: null };
@@ -107,7 +117,17 @@ export function createCompletionDeduper({
       }
       // Same output as something already announced — but that alone does not make it
       // a replay. Only a run that plainly did not render is suppressed.
-      const looksCached = typeof durationMs === "number" && durationMs >= 0 && durationMs <= cacheHitMaxMs;
+      // `durationTrusted` is required (codex): when execution_start and executing()
+      // are both dropped, the tracker invents a start at the FINAL output event, so a
+      // genuine ten-minute render reports a sub-second duration. An invented duration
+      // is not evidence of a cache hit, and suppressing on it would lose a real result
+      // precisely when frames were being dropped.
+      const looksCached =
+        durationTrusted &&
+        typeof durationMs === "number" &&
+        Number.isFinite(durationMs) &&
+        durationMs >= 0 &&
+        durationMs <= cacheHitMaxMs;
       if (!looksCached) return { deliver: true, duplicateOf: null };
       return { deliver: false, duplicateOf: hit.promptId ?? null };
     },

--- a/web/js/lib/completion-dedupe.js
+++ b/web/js/lib/completion-dedupe.js
@@ -162,15 +162,21 @@ export function createCompletionDeduper({
  */
 export function duplicateCompletionNote(duplicateOf, looksCached) {
   if (!duplicateOf) return "";
+  // Says only what the mechanism saw (codex). It compared FILE REFERENCES, not bytes,
+  // and `looksCached === false` covers "took longer than the threshold" AND "the
+  // duration could not be trusted" — two different things, neither of which is proof
+  // that work happened.
   return (
-    `This output was already delivered by prompt ${duplicateOf}. The files are identical; only ` +
-    `the prompt id differs.` +
+    `Prompt ${duplicateOf} already delivered output with the same file reference(s) — same ` +
+    `name, folder and type. The panel compares references, not file contents, so it cannot ` +
+    `say whether the bytes are the same.` +
     (looksCached
-      ? ` It also spent no real time rendering, which is what a re-queue served from ComfyUI's ` +
-        `cache looks like — so this is very likely the same result again, not new work.`
-      : ` It DID spend real time rendering, so this may be a genuine re-render that happens to ` +
-        `write the same filename — the panel cannot tell those apart and does not guess.`) +
-    ` Nothing is withheld either way: a completion is always delivered, because losing a render ` +
-    `you waited for would be worse than an extra message.`
+      ? ` This run also finished too fast to have rendered anything, which is what a re-queue ` +
+        `served from ComfyUI's cache looks like.`
+      : ` This run did NOT finish suspiciously fast, so it may be a genuine re-render that ` +
+        `happens to write the same filename — or its duration simply could not be established. ` +
+        `Either way the panel does not guess.`) +
+    ` Nothing is withheld on any of this: a completion is always delivered, because losing a ` +
+    `render you waited for would be worse than an extra message.`
   );
 }

--- a/web/js/lib/completion-dedupe.js
+++ b/web/js/lib/completion-dedupe.js
@@ -16,11 +16,16 @@
  *
  * WHAT IS THE SAME is the OUTPUT. So the dedupe is on the media itself.
  *
- * SCOPED TO RUNS THE PANEL DID NOT QUEUE. A panel-queued run was promised a
- * notification — `panel_run` tells the agent "you will be notified automatically, do
- * NOT poll, end your turn now" — so suppressing one would wedge the agent waiting for
- * a message that never comes. That is a worse failure than the duplicates. A canvas
- * run carries no such promise, which is exactly the case the report is about.
+ * NOTHING IS EVER WITHHELD. The first design suppressed a repeat that looked cached,
+ * and review showed that cannot be made sound: a fixed-name writer can produce
+ * different bytes in under a second with a normal lifecycle, so no duration threshold
+ * separates a replay from a fast re-render. A completion is therefore always
+ * delivered, ANNOTATED with the prompt it duplicates and whether it looks cached —
+ * which is what the agent lacked. Losing a render someone waited for is the worse
+ * failure, and it is the one this cannot commit.
+ *
+ * A panel-queued run is never even annotated as a duplicate: `panel_run` promised the
+ * agent a notification and told it to end its turn, so that delivery is its own event.
  */
 
 /**
@@ -30,7 +35,7 @@
  * Sorted so ordering differences cannot mint a new signature, and built from the
  * fields that identify a file on the server (`filename`, `subfolder`, `type`).
  * Returns null when there is nothing identifying to hash — no signature means no
- * suppression, which is the safe direction.
+ * duplicate claim, which is the safe direction.
  */
 export function mediaSignature(images, videos) {
   const parts = [];
@@ -75,18 +80,10 @@ export function mediaSignature(images, videos) {
 export function createCompletionDeduper({
   ttlMs = 5 * 60 * 1000,
   now = () => Date.now(),
-  // #986 (codex NO-SHIP): same filename is NOT the same result. A node that writes a
-  // fixed name — no counter in the prefix — produces two REAL renders with identical
-  // signatures, and suppressing the second loses work the user waited for.
-  //
-  // The reporter's own evidence supplies the discriminator: the duplicates ran in
-  // 0.1-0.3s against a genuine first render of 10m51s. Nothing renders a 10s clip in
-  // 100ms; that is ComfyUI returning a cached result. So a repeat is only suppressed
-  // when it did not actually render. A real overwrite render takes real time and is
-  // always delivered.
-  //
-  // An UNKNOWN duration never suppresses: a missing start yields null, and null is
-  // not evidence of a cache hit.
+  // Below this, a repeat is flagged as looking like a cache hit rather than work. The
+  // reporter's numbers set it: 0.1-0.3s replays against a genuine 10m51s first render.
+  // It only ever changes the WORDING of an annotation — nothing is withheld on it —
+  // so being approximate here is cheap.
   cacheHitMaxMs = 1500,
 } = {}) {
   const seen = new Map(); // signature -> { at, promptId }
@@ -98,13 +95,13 @@ export function createCompletionDeduper({
 
   return {
     /**
-     * Should this completion be delivered?
+     * How should this completion be reported?
      *
-     * Returns `{ deliver, duplicateOf }`. `deliver` is false ONLY when every condition
-     * holds: the panel did not queue this run, the media is identifiable, and the same
-     * media was announced within the window. Anything unestablished delivers — a
-     * missed duplicate costs a redundant message, a wrongly-suppressed completion
-     * costs the result itself.
+     * Returns `{ deliver, duplicateOf, looksCached }`. `deliver` is ALWAYS true — see
+     * the module header. `duplicateOf` names the earlier prompt that delivered this
+     * exact media, or null; `looksCached` says whether this repeat also failed to
+     * spend any real time rendering, which is the strongest available hint that it
+     * came from ComfyUI's cache rather than from work.
      */
     consider({ signature, panelQueued, promptId, durationMs, durationTrusted = false }) {
       prune();
@@ -115,21 +112,28 @@ export function createCompletionDeduper({
         seen.set(signature, { at: now(), promptId: promptId ?? null });
         return { deliver: true, duplicateOf: null };
       }
-      // Same output as something already announced — but that alone does not make it
-      // a replay. Only a run that plainly did not render is suppressed.
-      // `durationTrusted` is required (codex): when execution_start and executing()
-      // are both dropped, the tracker invents a start at the FINAL output event, so a
-      // genuine ten-minute render reports a sub-second duration. An invented duration
-      // is not evidence of a cache hit, and suppressing on it would lose a real result
-      // precisely when frames were being dropped.
+      // Same output as one already announced. Whether that is a cache REPLAY or a
+      // genuinely fast re-render CANNOT be proven from here (codex, final round): a
+      // custom fixed-name writer can legitimately produce different bytes in under a
+      // second, with an entirely normal lifecycle making its duration trustworthy. No
+      // threshold separates the two, and a first-run comparator does not either.
+      //
+      // So nothing is ever withheld. Losing a render someone waited for is a worse
+      // outcome than an extra message, and the agent's actual complaint — being unable
+      // to tell a replay from a real result — is answered by SAYING which it looks
+      // like, not by deciding on its behalf.
+      //
+      // `durationTrusted` still gates the flag. When execution_start and executing()
+      // are both dropped the tracker invents a start at the final output event, so a
+      // ten-minute render can report a sub-second duration; calling that a cache hit
+      // would be wrong on the facts as well as unhelpful.
       const looksCached =
         durationTrusted &&
         typeof durationMs === "number" &&
         Number.isFinite(durationMs) &&
         durationMs >= 0 &&
         durationMs <= cacheHitMaxMs;
-      if (!looksCached) return { deliver: true, duplicateOf: null };
-      return { deliver: false, duplicateOf: hit.promptId ?? null };
+      return { deliver: true, duplicateOf: hit.promptId ?? null, looksCached };
     },
 
     /**
@@ -156,14 +160,17 @@ export function createCompletionDeduper({
  * explain, once, that further identical completions are being collapsed. States what
  * was observed rather than diagnosing ComfyUI's caching.
  */
-export function duplicateSuppressedNote(count, duplicateOf) {
-  if (!count) return "";
+export function duplicateCompletionNote(duplicateOf, looksCached) {
+  if (!duplicateOf) return "";
   return (
-    `${count} further completion${count === 1 ? "" : "s"} carrying this exact output ` +
-    `${count === 1 ? "was" : "were"} not re-announced. They arrived under different prompt ids ` +
-    `${duplicateOf ? `(first seen as ${duplicateOf}) ` : ""}but delivered the same file(s), which is ` +
-    `what a re-queue served from ComfyUI's cache looks like — the sub-second durations are the ` +
-    `giveaway. Runs queued through panel_run are never suppressed, so a result you asked for ` +
-    `always arrives.`
+    `This output was already delivered by prompt ${duplicateOf}. The files are identical; only ` +
+    `the prompt id differs.` +
+    (looksCached
+      ? ` It also spent no real time rendering, which is what a re-queue served from ComfyUI's ` +
+        `cache looks like — so this is very likely the same result again, not new work.`
+      : ` It DID spend real time rendering, so this may be a genuine re-render that happens to ` +
+        `write the same filename — the panel cannot tell those apart and does not guess.`) +
+    ` Nothing is withheld either way: a completion is always delivered, because losing a render ` +
+    `you waited for would be worse than an extra message.`
   );
 }

--- a/web/js/lib/completion-dedupe.js
+++ b/web/js/lib/completion-dedupe.js
@@ -50,7 +50,7 @@ export function mediaSignature(images, videos) {
   if (add("v", videos) === null) return null;
   if (!parts.length) return null;
   parts.sort();
-  return parts.join("|");
+  return JSON.stringify(parts);
 }
 
 /**
@@ -62,7 +62,23 @@ export function mediaSignature(images, videos) {
  * which covers the reported burst (six in ~30 seconds) without swallowing a later
  * deliberate re-render.
  */
-export function createCompletionDeduper({ ttlMs = 5 * 60 * 1000, now = () => Date.now() } = {}) {
+export function createCompletionDeduper({
+  ttlMs = 5 * 60 * 1000,
+  now = () => Date.now(),
+  // #986 (codex NO-SHIP): same filename is NOT the same result. A node that writes a
+  // fixed name — no counter in the prefix — produces two REAL renders with identical
+  // signatures, and suppressing the second loses work the user waited for.
+  //
+  // The reporter's own evidence supplies the discriminator: the duplicates ran in
+  // 0.1-0.3s against a genuine first render of 10m51s. Nothing renders a 10s clip in
+  // 100ms; that is ComfyUI returning a cached result. So a repeat is only suppressed
+  // when it did not actually render. A real overwrite render takes real time and is
+  // always delivered.
+  //
+  // An UNKNOWN duration never suppresses: a missing start yields null, and null is
+  // not evidence of a cache hit.
+  cacheHitMaxMs = 1500,
+} = {}) {
   const seen = new Map(); // signature -> { at, promptId }
 
   const prune = () => {
@@ -80,14 +96,20 @@ export function createCompletionDeduper({ ttlMs = 5 * 60 * 1000, now = () => Dat
      * missed duplicate costs a redundant message, a wrongly-suppressed completion
      * costs the result itself.
      */
-    consider({ signature, panelQueued, promptId }) {
+    consider({ signature, panelQueued, promptId, durationMs }) {
       prune();
       if (panelQueued) return { deliver: true, duplicateOf: null };
       if (!signature) return { deliver: true, duplicateOf: null };
       const hit = seen.get(signature);
-      if (hit) return { deliver: false, duplicateOf: hit.promptId ?? null };
-      seen.set(signature, { at: now(), promptId: promptId ?? null });
-      return { deliver: true, duplicateOf: null };
+      if (!hit) {
+        seen.set(signature, { at: now(), promptId: promptId ?? null });
+        return { deliver: true, duplicateOf: null };
+      }
+      // Same output as something already announced — but that alone does not make it
+      // a replay. Only a run that plainly did not render is suppressed.
+      const looksCached = typeof durationMs === "number" && durationMs >= 0 && durationMs <= cacheHitMaxMs;
+      if (!looksCached) return { deliver: true, duplicateOf: null };
+      return { deliver: false, duplicateOf: hit.promptId ?? null };
     },
 
     /**

--- a/web/js/lib/run-completion-frame.js
+++ b/web/js/lib/run-completion-frame.js
@@ -22,6 +22,7 @@
 // the SAME bound, so it now lives in one place both import. Behaviour is
 // unchanged except that a throwing `onTimeout`/`clearTimer` degrades instead of
 // leaving the segment pending forever.
+import { duplicateCompletionNote } from "./completion-dedupe.js";
 import { withTimeout } from "./bounded-step.js";
 
 /**
@@ -34,7 +35,7 @@ import { withTimeout } from "./bounded-step.js";
  * @returns {Promise<object|null>}
  */
 export async function composeRunCompletionFrame(
-  { promptId, images = [], videos = [], durationMs, noMedia = false },
+  { promptId, images = [], videos = [], durationMs, noMedia = false, duplicateOf = null, looksCached = false },
   deps,
 ) {
   const {
@@ -81,6 +82,10 @@ export async function composeRunCompletionFrame(
 
   const outImages = []; // consolidated images for the single frame
   const noteSections = []; // note segments joined into the single note
+  // #986 — FIRST section, because it changes how everything after it should be read:
+  // this exact output has already been delivered under another prompt id. It is never
+  // a reason to withhold the completion (see completion-dedupe.js), only to say so.
+  if (duplicateOf) noteSections.push(duplicateCompletionNote(duplicateOf, looksCached));
   let metadata = [];
 
   // ── Stills segment ─────────────────────────────────────────────────────

--- a/web/js/lib/run-completion.js
+++ b/web/js/lib/run-completion.js
@@ -383,6 +383,7 @@ export function createRunCompletionTracker({
       signature,
       panelQueued: panelQueued.has(k),
       promptId: promptIdOf(k),
+      durationMs,
     });
     if (!verdict.deliver) {
       // Retire it exactly as a delivered run would be: it IS accounted for, and
@@ -550,6 +551,13 @@ export function createRunCompletionTracker({
       // Same async-delivery hold as flush(): the reconciled batch is composed and
       // sent by the caller, so it is not "delivered" until the caller says so.
       markDispatched(k);
+      // #986 (codex NO-SHIP): a reconciled delivery must RECORD its signature too.
+      // Without this, a completion recovered from /history after a reconnect left no
+      // trace, so the first canvas re-queue of that same cached output afterwards got
+      // a free pass — the guarantee flush() makes was simply false on the #370 path.
+      // Recorded, never suppressed: a reconcile exists to deliver something the agent
+      // has NOT been told about, so it always goes through.
+      deduper.record({ signature: mediaSignature(parsed.images, parsed.videos), promptId });
       onFlush({
         key: k,
         promptId,

--- a/web/js/lib/run-completion.js
+++ b/web/js/lib/run-completion.js
@@ -96,6 +96,8 @@ export function createRunCompletionTracker({
   const buffers = new Map(); // key -> { images: any[], videos: any[], timer, rearms }
   const active = new Set(); // keys ComfyUI currently reports as running
   const starts = new Map(); // key -> start timestamp
+  // Keys whose start came from a real lifecycle signal, not a fallback (#986).
+  const startObserved = new Set();
   // #370 reconciliation state. A run is PENDING from its first liveness signal
   // until its completion is CONFIRMED delivered to the agent. If the connection
   // drops (WS lost → execution_success missed, OR bridge down → the composed
@@ -321,10 +323,20 @@ export function createRunCompletionTracker({
     retryCounts.delete(k);
   }
 
-  function markStart(id) {
+  function markStart(id, { observed = true } = {}) {
     const k = key(id);
-    // First signal wins — a later per-node event must not reset an earlier start.
-    if (!starts.has(k)) starts.set(k, now());
+    // #986 (codex): remember whether this start was OBSERVED or FABRICATED. When
+    // execution_start and executing(node) are both dropped, the start is invented at
+    // the FINAL output event, so a genuine ten-minute render reports a sub-second
+    // duration. The dedupe gate reads duration as evidence of a cache hit, and an
+    // invented duration is not evidence of anything.
+    if (!starts.has(k)) {
+      starts.set(k, now());
+      if (observed) startObserved.add(k);
+      else startObserved.delete(k);
+    } else if (observed) {
+      startObserved.add(k);
+    }
     // Bound the map so a run that never signals end can't leak entries.
     if (starts.size > 20) {
       const oldest = starts.keys().next().value;
@@ -366,7 +378,13 @@ export function createRunCompletionTracker({
     // Read + retire the start synchronously so a concurrent flush can't
     // double-count it. A missing start ⇒ null duration (never a bogus 0.0s).
     const startTs = starts.get(k);
+    // Read the trust flag BEFORE retiring it — the dedupe gate below needs to know
+    // whether this duration came from a real lifecycle signal or was invented at the
+    // final output event. Retiring first made every duration untrusted, which the
+    // integration tests caught by refusing to suppress the reported burst.
+    const durationTrusted = startObserved.has(k);
     starts.delete(k);
+    startObserved.delete(k);
     const durationMs = startTs != null ? now() - startTs : null;
     if (!buf.images.length && !buf.videos.length) return;
     // #986 — the same finished output was re-announced six times in ~30s, each under
@@ -384,6 +402,7 @@ export function createRunCompletionTracker({
       panelQueued: panelQueued.has(k),
       promptId: promptIdOf(k),
       durationMs,
+      durationTrusted,
     });
     if (!verdict.deliver) {
       // Retire it exactly as a delivered run would be: it IS accounted for, and
@@ -505,6 +524,7 @@ export function createRunCompletionTracker({
     active.delete(k);
     const startTs = starts.get(k);
     starts.delete(k);
+    startObserved.delete(k);
     // #356 Bug 2 — read BEFORE markDelivered, which retires the key from BOTH
     // `pending` and `panelQueued`. Checking after would always see false, so the
     // media-less recovery below would never fire — the mistake this line exists to
@@ -601,6 +621,7 @@ export function createRunCompletionTracker({
     buffers.delete(k);
     active.delete(k);
     starts.delete(k);
+    startObserved.delete(k);
     pending.delete(k); // EVICT — bounds the ledger
     panelQueued.delete(k); // #356 Bug 2 — evicted with it
     markTerminal(promptId); // fence any stray late execution_start; ages out (not pinned)
@@ -710,7 +731,9 @@ export function createRunCompletionTracker({
       // Fallback render-start if execution_start was missed (no-op otherwise).
       // Does NOT mark active: `executing(node)` is the run-liveness signal, so an
       // output with no start AND no executing(node) is treated as an orphan.
-      markStart(id);
+      // FABRICATED (#986): invented at the final output, so any duration derived from
+      // it is meaningless and must never be read as a cache-hit signal.
+      markStart(id, { observed: false });
       trackPending(id);
       const k = key(id);
       const buf = ensureBuffer(k);
@@ -729,6 +752,7 @@ export function createRunCompletionTracker({
       // live state (codex P1 idempotency fence; `terminal`, not `delivered`).
       if (terminal.has(k)) {
         starts.delete(k);
+    startObserved.delete(k);
         return;
       }
       // #356 Bug 2 — a run that produced NO image and NO video buffers nothing
@@ -765,6 +789,7 @@ export function createRunCompletionTracker({
       }
       // Retire start for runs that buffered nothing (flush early-returns then).
       starts.delete(k);
+    startObserved.delete(k);
       // A terminal success we OBSERVED live needs no /history reconcile — clear it
       // from pending. (If the completion frame is later reported undelivered, the
       // caller's markUndelivered re-pends it, so a bridge-down drop still recovers.)
@@ -779,6 +804,7 @@ export function createRunCompletionTracker({
       if (buf?.timer) clearTimer(buf.timer);
       buffers.delete(k);
       starts.delete(k);
+    startObserved.delete(k);
       // If already terminal (reconcile surfaced this run's outcome), don't re-mark
       // (which would clear a re-pend). The caller uses wasTerminal() BEFORE calling
       // this to suppress a duplicate run_error frame (codex P1).

--- a/web/js/lib/run-completion.js
+++ b/web/js/lib/run-completion.js
@@ -330,17 +330,26 @@ export function createRunCompletionTracker({
     // the FINAL output event, so a genuine ten-minute render reports a sub-second
     // duration. The dedupe gate reads duration as evidence of a cache hit, and an
     // invented duration is not evidence of anything.
+    // The trust bit belongs to the TIMESTAMP, and only the first signal sets one.
+    // A later observed signal must NOT upgrade a fabricated start (codex): with the
+    // start frame and the first node's `executing` both lost, `onExecuted` invents a
+    // timestamp, and a subsequent `executing` for a second output node would then mark
+    // that invented value trusted — making a genuine long multi-output render look
+    // sub-second and trusted, which is exactly the shape that gets suppressed. Once
+    // fabricated, untrusted for the life of the run.
     if (!starts.has(k)) {
       starts.set(k, now());
       if (observed) startObserved.add(k);
       else startObserved.delete(k);
-    } else if (observed) {
-      startObserved.add(k);
     }
-    // Bound the map so a run that never signals end can't leak entries.
+    // Bound the map so a run that never signals end can't leak entries — and retire
+    // the trust bit WITH it, or the set outlives the map it describes.
     if (starts.size > 20) {
       const oldest = starts.keys().next().value;
-      if (oldest !== k) starts.delete(oldest);
+      if (oldest !== k) {
+        starts.delete(oldest);
+        startObserved.delete(oldest);
+      }
     }
   }
 

--- a/web/js/lib/run-completion.js
+++ b/web/js/lib/run-completion.js
@@ -76,7 +76,6 @@ export function createRunCompletionTracker({
   maxReconcileRetries = 5,
   // #986 — injected so the dedupe window is testable and the tracker keeps no
   // second source of truth for time.
-  onDuplicateSuppressed = null,
   duplicateWindowMs = 5 * 60 * 1000,
 } = {}) {
   if (typeof onFlush !== "function") {
@@ -413,18 +412,6 @@ export function createRunCompletionTracker({
       durationMs,
       durationTrusted,
     });
-    if (!verdict.deliver) {
-      // Retire it exactly as a delivered run would be: it IS accounted for, and
-      // leaving it pending would have a later reconcile deliver the duplicate anyway.
-      markDelivered(k);
-      onDuplicateSuppressed?.({
-        key: k,
-        promptId: promptIdOf(k),
-        duplicateOf: verdict.duplicateOf,
-        durationMs,
-      });
-      return;
-    }
     // A panel-queued delivery still records its signature, so a canvas re-queue of
     // the SAME output afterwards is recognised rather than getting one free pass.
     if (panelQueued.has(k)) deduper.record({ signature, promptId: promptIdOf(k) });
@@ -445,6 +432,12 @@ export function createRunCompletionTracker({
       videos: buf.videos,
       durationMs,
       finishedAt: now(),
+      // #986 — the agent is TOLD this output was already announced, never denied it.
+      // Which of a replay or a fast re-render it is cannot be proven, so the panel
+      // reports what it observed and lets the reader decide.
+      ...(verdict.duplicateOf
+        ? { duplicateOf: verdict.duplicateOf, looksCached: !!verdict.looksCached }
+        : {}),
     });
   }
 

--- a/web/js/lib/run-completion.js
+++ b/web/js/lib/run-completion.js
@@ -45,6 +45,7 @@
 // `onFlush` callback, which receives the full, correctly-scoped batch — plus the
 // prompt_id `key` for machine-readable attribution — exactly once per completion.
 
+import { mediaSignature, createCompletionDeduper } from "./completion-dedupe.js";
 import { parseHistoryEntry } from "./history-reconcile.js";
 
 export const NO_PROMPT_KEY = "__no_prompt__";
@@ -73,6 +74,10 @@ export function createRunCompletionTracker({
   maxRearms = 40,
   reconcileRetryMs = 3000,
   maxReconcileRetries = 5,
+  // #986 — injected so the dedupe window is testable and the tracker keeps no
+  // second source of truth for time.
+  onDuplicateSuppressed = null,
+  duplicateWindowMs = 5 * 60 * 1000,
 } = {}) {
   if (typeof onFlush !== "function") {
     throw new TypeError("createRunCompletionTracker requires an onFlush callback");
@@ -87,6 +92,7 @@ export function createRunCompletionTracker({
   // (no real prompt) collapses to the shared NO_PROMPT_KEY.
   const key = (id) => (id == null ? NO_PROMPT_KEY : String(id));
   const promptIdOf = (k) => (k === NO_PROMPT_KEY ? null : k);
+  const deduper = createCompletionDeduper({ ttlMs: duplicateWindowMs, now });
   const buffers = new Map(); // key -> { images: any[], videos: any[], timer, rearms }
   const active = new Set(); // keys ComfyUI currently reports as running
   const starts = new Map(); // key -> start timestamp
@@ -363,6 +369,36 @@ export function createRunCompletionTracker({
     starts.delete(k);
     const durationMs = startTs != null ? now() - startTs : null;
     if (!buf.images.length && !buf.videos.length) return;
+    // #986 — the same finished output was re-announced six times in ~30s, each under
+    // a DIFFERENT prompt id, because the user re-queued from the canvas and ComfyUI
+    // served it from cache (hence the 0.1s "renders"). The `delivered` fence above is
+    // keyed by prompt id, so it cannot collapse genuinely different prompts; what is
+    // the same is the OUTPUT, so that is what this compares.
+    //
+    // Only for runs the panel did NOT queue. `panel_run` promises the agent it will
+    // be notified and tells it to end its turn — suppressing one of those would wedge
+    // it waiting for a message that never comes, which is worse than the duplicates.
+    const signature = mediaSignature(buf.images, buf.videos);
+    const verdict = deduper.consider({
+      signature,
+      panelQueued: panelQueued.has(k),
+      promptId: promptIdOf(k),
+    });
+    if (!verdict.deliver) {
+      // Retire it exactly as a delivered run would be: it IS accounted for, and
+      // leaving it pending would have a later reconcile deliver the duplicate anyway.
+      markDelivered(k);
+      onDuplicateSuppressed?.({
+        key: k,
+        promptId: promptIdOf(k),
+        duplicateOf: verdict.duplicateOf,
+        durationMs,
+      });
+      return;
+    }
+    // A panel-queued delivery still records its signature, so a canvas re-queue of
+    // the SAME output afterwards is recognised rather than getting one free pass.
+    if (panelQueued.has(k)) deduper.record({ signature, promptId: promptIdOf(k) });
     // Optimistically mark delivered so a reconnect-triggered reconcile racing
     // this flush can't double-deliver the same prompt. If the caller reports the
     // send FAILED (bridge down), it calls markUndelivered() to re-pend it (#370).


### PR DESCRIPTION
Claims #986.

**Reported:** the same finished file (`Video_00144.mp4`) was delivered to the agent **six or more times in ~30 seconds**, each as a fresh completion event with a **different prompt id** and an implausible render time (`0.3s`, `0.1s`, …) for a clip whose real render took **10m51s**. Every one carried the "origin is UNDETERMINED" banner and an identical contact sheet.

Two costs, and the second is the serious one:
- each event prompts the agent for a reply, so turns are burned acknowledging duplicates
- the agent **cannot tell a genuine re-render from a replay**, and the banner simultaneously tells it not to trust the correlation

The reporter's reading — cache hits or replayed history entries surfaced as new completions, with distinct prompt ids defeating any prompt-id-based dedup — is plausible and matches the sub-second times. The repro involves queueing **manually from the canvas** and cancelling/re-queueing, so these are runs the panel did not originate, which is also why origin is undetermined.

That points at the reconcile/sweep path rather than the ordinary completion path: `run-completion.js`, `run-completion-frame.js` and `run-reconcile-sweep.js` all exist to recover completions the tab may have missed, and a sweep that re-announces already-delivered history entries would produce exactly this.

**Not started.** Measuring before assuming — the sub-second times and fresh prompt ids are the two facts a fix has to explain, and I want to know which component mints those ids.

- [ ] establish what produces a completion event with a new prompt id for an old output
- [ ] determine whether dedup exists and is defeated, or does not exist on this path
- [ ] fix + tests that fail against the broken source
- [ ] codex review
- [ ] browser verification