### PR TITLE
fix(run): a scoped batch must advance randomize seeds between items (#988)

### DIFF
--- a/browser_tests/unit/scoped-batch-seed.test.mjs
+++ b/browser_tests/unit/scoped-batch-seed.test.mjs
@@ -1,0 +1,112 @@
+/**
+ * #988 — a SCOPED batch repeats the same seed, so every item after the first is served
+ * from ComfyUI's cache and returns identical pixels.
+ *
+ * MEASURED on ComfyUI 0.31.1 / frontend 1.48.7 by capturing the outgoing /prompt bodies
+ * behind an interceptor that answered them locally — nothing queued, no GPU time:
+ *
+ *   app.queuePrompt(0, 3, undefined)  -> seeds 0, 275253667108059, 219005225600584
+ *   app.queuePrompt(0, 3, ["<id>"])   -> seeds 0, 0, 0
+ *
+ * ComfyUI's own queue loop, called directly with no panel code in the path. A partial
+ * execution skips the queue-time widget hooks, so `control_after_generate` never
+ * advances. The panel reports it rather than rewriting seeds — see the module header.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  findRepeatingControlWidgets,
+  scopedBatchSeedNote,
+} from "../../web/js/lib/scoped-batch-seed.js";
+
+/** The real KSampler widget order: the control sits immediately after the value. */
+const ksampler = (id, mode) => ({
+  id,
+  type: "KSampler",
+  widgets: [
+    { name: "seed", value: 0 },
+    { name: "control_after_generate", value: mode },
+    { name: "steps", value: 20 },
+  ],
+});
+
+test("#988 an advancing control is found, with the value widget it governs", () => {
+  const found = findRepeatingControlWidgets([ksampler(42, "randomize")]);
+  assert.equal(found.length, 1);
+  assert.deepEqual(found[0], {
+    node_id: "42",
+    node_type: "KSampler",
+    widget: "control_after_generate",
+    mode: "randomize",
+    paired_widget: "seed",
+  });
+});
+
+test("#988 increment and decrement repeat too — randomize is not the only affected mode", () => {
+  for (const mode of ["increment", "decrement"]) {
+    assert.equal(findRepeatingControlWidgets([ksampler(1, mode)]).length, 1, mode);
+  }
+});
+
+test("#988 `fixed` is NEVER reported — repeating is what it asks for", () => {
+  assert.deepEqual(findRepeatingControlWidgets([ksampler(1, "fixed")]), []);
+});
+
+test("#988 a node with no control widget is not a finding", () => {
+  const plain = { id: 2, type: "EmptyLatentImage", widgets: [{ name: "width", value: 512 }] };
+  assert.deepEqual(findRepeatingControlWidgets([plain]), []);
+});
+
+test("#988 the paired widget is reported only when it EXISTS — never guessed", () => {
+  // A control with nothing before it: the value it governs cannot be identified, and
+  // naming the wrong widget would be worse than naming none.
+  const odd = { id: 3, type: "Weird", widgets: [{ name: "control_after_generate", value: "randomize" }] };
+  const found = findRepeatingControlWidgets([odd]);
+  assert.equal(found.length, 1);
+  assert.equal("paired_widget" in found[0], false);
+});
+
+test("#988 the collector is total — malformed input yields fewer findings, never a throw", () => {
+  const hostile = {
+    id: 4,
+    get widgets() {
+      throw new Error("boom");
+    },
+  };
+  assert.doesNotThrow(() => findRepeatingControlWidgets([hostile, ksampler(5, "randomize")]));
+  assert.deepEqual(
+    findRepeatingControlWidgets([hostile, ksampler(5, "randomize")]).map((f) => f.node_id),
+    ["5"],
+    "one bad node costs its own entry, not the whole diagnosis",
+  );
+  for (const bad of [null, undefined, "nope", [null], [{}], [{ widgets: "x" }]]) {
+    assert.deepEqual(findRepeatingControlWidgets(bad), []);
+  }
+});
+
+test("#988 the note fires ONLY for the reported combination", () => {
+  const controls = findRepeatingControlWidgets([ksampler(42, "randomize")]);
+  assert.equal(scopedBatchSeedNote(controls, 1), "", "a batch of one repeats nothing");
+  assert.equal(scopedBatchSeedNote([], 3), "", "no advancing control, nothing to say");
+  assert.equal(scopedBatchSeedNote(null, 3), "");
+  assert.ok(scopedBatchSeedNote(controls, 3).length > 0, "scoped batch > 1 with an advancing control");
+});
+
+test("#988 the note names the nodes, the cause, and the two things that DO work", () => {
+  const note = scopedBatchSeedNote(findRepeatingControlWidgets([ksampler(42, "randomize")]), 3);
+  assert.match(note, /^EVERY ITEM OF THIS BATCH WILL USE THE SAME/, "the consequence first");
+  assert.match(note, /node 42 \(KSampler\) seed=randomize/, "which widget on which node");
+  assert.match(note, /1\.48\.7/, "attributes the behaviour to the build it was measured on");
+  assert.match(note, /batch_count:1/, "workaround one");
+  assert.match(note, /drop to_node_id/, "workaround two");
+  // Two claims it must NOT make.
+  assert.match(note, /not something the panel chose/, "the cause is the frontend's queue loop");
+  assert.match(note, /does not rewrite your seeds/, "and the panel says what it declined to do");
+});
+
+test("#988 the note caps its list but says how many it left out", () => {
+  const many = Array.from({ length: 9 }, (_, i) => ksampler(i, "randomize"));
+  const note = scopedBatchSeedNote(findRepeatingControlWidgets(many), 2);
+  assert.match(note, /and 4 more/, "a truncated list must not read as the whole list");
+});

--- a/browser_tests/unit/scoped-batch-seed.test.mjs
+++ b/browser_tests/unit/scoped-batch-seed.test.mjs
@@ -125,12 +125,18 @@ test("#988 (codex): `increment-wrap` advances too and must be warned about", () 
 test("#988 (codex): LINKAGE beats adjacency for naming the governed widget", () => {
   // Adjacency is a UI-insertion convention custom nodes need not preserve, so the
   // source of the pairing is reported and linkage wins when the frontend supplies it.
+  // The link points VALUE -> CONTROL, which is the direction ComfyUI actually uses.
+  // An earlier version of this test attached `linkedWidgets` to the CONTROL and passed
+  // against code reading it the same wrong way — so it validated the wrong shape and
+  // the authoritative signal was never really exercised.
+  const control = { name: "control_after_generate", value: "randomize" };
   const node = {
     id: 7,
     type: "Custom",
     widgets: [
       { name: "not_the_seed", value: 1 },
-      { name: "control_after_generate", value: "randomize", linkedWidgets: [{ name: "real_seed" }] },
+      { name: "real_seed", value: 5, linkedWidgets: [control] },
+      control,
     ],
   };
   const found = findRepeatingControlWidgets([node]);

--- a/browser_tests/unit/scoped-batch-seed.test.mjs
+++ b/browser_tests/unit/scoped-batch-seed.test.mjs
@@ -14,6 +14,7 @@
  */
 import test from "node:test";
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 
 import {
   findRepeatingControlWidgets,
@@ -40,6 +41,7 @@ test("#988 an advancing control is found, with the value widget it governs", () 
     widget: "control_after_generate",
     mode: "randomize",
     paired_widget: "seed",
+    paired_widget_source: "adjacent",
   });
 });
 
@@ -95,18 +97,54 @@ test("#988 the note fires ONLY for the reported combination", () => {
 
 test("#988 the note names the nodes, the cause, and the two things that DO work", () => {
   const note = scopedBatchSeedNote(findRepeatingControlWidgets([ksampler(42, "randomize")]), 3);
-  assert.match(note, /^EVERY ITEM OF THIS BATCH WILL USE THE SAME/, "the consequence first");
+  assert.match(note, /^THIS BATCH WILL REUSE THE SAME/, "the consequence first");
   assert.match(note, /node 42 \(KSampler\) seed=randomize/, "which widget on which node");
   assert.match(note, /1\.48\.7/, "attributes the behaviour to the build it was measured on");
   assert.match(note, /batch_count:1/, "workaround one");
   assert.match(note, /drop to_node_id/, "workaround two");
   // Two claims it must NOT make.
-  assert.match(note, /not something the panel chose/, "the cause is the frontend's queue loop");
-  assert.match(note, /does not rewrite your seeds/, "and the panel says what it declined to do");
+  assert.match(note, /not something the panel chose/, "the cause is the frontend queue loop");
+  // codex: the scan is workflow-wide but the run is scoped, so the claim is conditional.
+  assert.match(note, /any of these controls its scope actually reaches/, "conditional, not absolute");
+  assert.match(note, /ALREADY QUEUED/, "and it does not pretend the caller can still prevent it");
+  assert.match(note, /does not rewrite your values/, "and the panel says what it declined to do");
 });
 
 test("#988 the note caps its list but says how many it left out", () => {
   const many = Array.from({ length: 9 }, (_, i) => ksampler(i, "randomize"));
   const note = scopedBatchSeedNote(findRepeatingControlWidgets(many), 2);
   assert.match(note, /and 4 more/, "a truncated list must not read as the whole list");
+});
+
+test("#988 (codex): `increment-wrap` advances too and must be warned about", () => {
+  // ComfyUI ships it. The report only names randomize, and warning on that alone would
+  // have left a mode silently broken.
+  assert.equal(findRepeatingControlWidgets([ksampler(1, "increment-wrap")]).length, 1);
+});
+
+test("#988 (codex): LINKAGE beats adjacency for naming the governed widget", () => {
+  // Adjacency is a UI-insertion convention custom nodes need not preserve, so the
+  // source of the pairing is reported and linkage wins when the frontend supplies it.
+  const node = {
+    id: 7,
+    type: "Custom",
+    widgets: [
+      { name: "not_the_seed", value: 1 },
+      { name: "control_after_generate", value: "randomize", linkedWidgets: [{ name: "real_seed" }] },
+    ],
+  };
+  const found = findRepeatingControlWidgets([node]);
+  assert.equal(found[0].paired_widget, "real_seed");
+  assert.equal(found[0].paired_widget_source, "linked");
+});
+
+test("#988 (codex) source guard: the scan runs BEFORE dispatch, not after", () => {
+  // Measuring afterwards described a run already submitted while the note claimed it
+  // let the caller cancel — a remedy it could not offer.
+  const src = readFileSync(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8");
+  const scan = src.indexOf("repeatingControls = findRepeatingControlWidgets(");
+  const dispatch = src.indexOf("await app.queuePrompt(0, batch, undefined)");
+  const scopedDispatch = src.indexOf("runScopeResult = await dispatchScopedRun({");
+  assert.ok(scan > 0, "the pre-dispatch scan must exist");
+  assert.ok(scan < dispatch && scan < scopedDispatch, "and precede BOTH dispatch paths");
 });

--- a/browser_tests/unit/scoped-batch-seed.test.mjs
+++ b/browser_tests/unit/scoped-batch-seed.test.mjs
@@ -154,3 +154,20 @@ test("#988 (codex) source guard: the scan runs BEFORE dispatch, not after", () =
   assert.ok(scan > 0, "the pre-dispatch scan must exist");
   assert.ok(scan < dispatch && scan < scopedDispatch, "and precede BOTH dispatch paths");
 });
+
+test("#988 (codex r3): the warning is NOT gated on Comfy.WidgetControlMode — measured in both", () => {
+  // ComfyUI can install the control's mutation as beforeQueued OR afterQueued, and only
+  // one mode had been observed. Flipping `Comfy.WidgetControlMode` on the live install
+  // and repeating the prompt-body capture:
+  //
+  //   mode "after"   scoped [0,0,0]   unscoped [0, 1052866786709601, 413884900582428]
+  //   mode "before"  scoped [0,0,0]   unscoped [267357841888133, 145435791190359, 43867923644491]
+  //
+  // The scoped batch repeats in BOTH, so a mode-dependent gate would add a branch that
+  // is never taken — and gating on a setting the panel cannot see would have been
+  // guesswork. This pins that the detector deliberately ignores the setting.
+  const controls = findRepeatingControlWidgets([ksampler(42, "randomize")]);
+  assert.equal(controls.length, 1, "detection does not consult any widget-control-mode setting");
+  const note = scopedBatchSeedNote(controls, 3);
+  assert.doesNotMatch(note, /WidgetControlMode|beforeQueued|afterQueued/, "and makes no claim about it");
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -11142,6 +11142,30 @@ const GRAPH_TOOL_EXECUTORS = {
     // the deferred serialization queuePrompt runs when its processor is already
     // busy) without permanently altering the live workflow.
     installGraphToPromptNullSafety(app);
+    // #988 — computed BEFORE dispatch (codex). Measuring it afterwards described a
+    // run that had already been submitted, while the note claimed it let the caller
+    // cancel — a remedy it could not offer. Reading the graph first means the finding
+    // is about the state these prompts were built from, not whatever the queue-time
+    // hooks left behind.
+    //
+    // MEASURED: an unscoped batch of 3 sent three different seeds; a scoped batch of 3
+    // sent the same seed three times. ComfyUI does not advance control_after_generate
+    // between the items of a PARTIAL execution, so every item after the first is an
+    // identical prompt it answers from cache.
+    //
+    // Reported, not repaired: rewriting the values would mean re-deriving the
+    // frontend’s widget semantics on the one path where the panel already has to
+    // patch the request body.
+    let repeatingControls = [];
+    if (partialTargets && batch > 1) {
+      try {
+        repeatingControls = findRepeatingControlWidgets(
+          collectAllGraphs(rootGraph).flatMap((g) => g?._nodes ?? []),
+        );
+      } catch {
+        repeatingControls = []; /* a warning must never take down the run */
+      }
+    }
     if (!partialTargets) {
       // UNSCOPED full run — the historical single-shot path: capture wrap for
       // exactly the duration of the queuePrompt call, then restore.
@@ -11288,30 +11312,11 @@ const GRAPH_TOOL_EXECUTORS = {
       promptIds: queuedPromptIds,
       ranToNode: partialTargets ? Number(to_node_id) : null,
     });
-    // #988 — a SCOPED batch repeats the same seed. Measured on frontend 1.48.7 by
-    // capturing the submitted bodies: an unscoped batch of 3 sent three different
-    // seeds, a scoped batch of 3 sent the same seed three times. ComfyUI does not
-    // advance control_after_generate between the items of a PARTIAL execution, so
-    // every item after the first is an identical prompt answered from cache.
-    //
-    // Reported, not repaired. Rewriting the seeds would mean re-deriving the
-    // frontend's widget semantics — randomize, increment and decrement all differ and
-    // each has a range — on the one path where the panel already has to patch the
-    // request body. Saying it at queue time lets the caller cancel instead of finding
-    // out from identical outputs.
-    if (partialTargets && batch > 1) {
-      try {
-        // Every graph level, so a control inside a subgraph is not missed.
-        const allNodes = collectAllGraphs(rootGraph).flatMap((g) => g?._nodes ?? []);
-        const repeating = findRepeatingControlWidgets(allNodes);
-        const note = scopedBatchSeedNote(repeating, batch);
-        if (note) {
-          accept.repeating_controls = repeating;
-          accept.repeating_controls_note = note;
-        }
-      } catch {
-        /* a warning must never take down the run it describes */
-      }
+    // #988 — attach the PRE-dispatch finding.
+    const repeatingNote = scopedBatchSeedNote(repeatingControls, batch);
+    if (repeatingNote) {
+      accept.repeating_controls = repeatingControls;
+      accept.repeating_controls_note = repeatingNote;
     }
     // #572 — TRUTHFUL drift-coverage note for a scoped run: the drift hash
     // excluded queue-time hook inputs (beforeQueued carriers + their linked,

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -135,6 +135,7 @@ import {
   isStaleAssetCandidate as isStaleAssetCandidateLib,
   reapplyDefsToLiveNodes,
   refreshComboOptionsFromDefs,
+  collectAllGraphs,
   collectMissingNodeTypeReasons,
   collectUnexplainedRedOutlines,
   combineNodeErrorMaps,
@@ -157,6 +158,7 @@ import {
   disabledOutputsInPrompt,
   disabledOutputsNote,
 } from "./lib/muted-subgraph-outputs.js";
+import { findRepeatingControlWidgets, scopedBatchSeedNote } from "./lib/scoped-batch-seed.js";
 import {
   materializePromotedValues,
   materializedValuesNote,
@@ -11286,6 +11288,31 @@ const GRAPH_TOOL_EXECUTORS = {
       promptIds: queuedPromptIds,
       ranToNode: partialTargets ? Number(to_node_id) : null,
     });
+    // #988 — a SCOPED batch repeats the same seed. Measured on frontend 1.48.7 by
+    // capturing the submitted bodies: an unscoped batch of 3 sent three different
+    // seeds, a scoped batch of 3 sent the same seed three times. ComfyUI does not
+    // advance control_after_generate between the items of a PARTIAL execution, so
+    // every item after the first is an identical prompt answered from cache.
+    //
+    // Reported, not repaired. Rewriting the seeds would mean re-deriving the
+    // frontend's widget semantics — randomize, increment and decrement all differ and
+    // each has a range — on the one path where the panel already has to patch the
+    // request body. Saying it at queue time lets the caller cancel instead of finding
+    // out from identical outputs.
+    if (partialTargets && batch > 1) {
+      try {
+        // Every graph level, so a control inside a subgraph is not missed.
+        const allNodes = collectAllGraphs(rootGraph).flatMap((g) => g?._nodes ?? []);
+        const repeating = findRepeatingControlWidgets(allNodes);
+        const note = scopedBatchSeedNote(repeating, batch);
+        if (note) {
+          accept.repeating_controls = repeating;
+          accept.repeating_controls_note = note;
+        }
+      } catch {
+        /* a warning must never take down the run it describes */
+      }
+    }
     // #572 — TRUTHFUL drift-coverage note for a scoped run: the drift hash
     // excluded queue-time hook inputs (beforeQueued carriers + their linked,
     // serialized targets — e.g. a control_after_generate seed reroll). A user

--- a/web/js/lib/scoped-batch-seed.js
+++ b/web/js/lib/scoped-batch-seed.js
@@ -21,8 +21,10 @@
  * rewrite seeds. Doing that would mean reimplementing the frontend's widget semantics
  * (`increment`/`decrement`/`randomize` differ, and each has a range), on the one path
  * where the panel already has to repair the request body — and this codebase has been
- * burned by re-deriving frontend behaviour before. Naming the problem at queue time
- * lets the caller cancel instead of discovering it from identical outputs.
+ * burned by re-deriving frontend behaviour before. It is computed BEFORE dispatch, so
+ * it describes the state the prompts were built from — but the prompts ARE submitted by
+ * the time anyone reads it, so the remedy it offers is interrupting the queue, not
+ * preventing it.
  */
 
 /**
@@ -67,12 +69,22 @@ export function findRepeatingControlWidgets(nodes) {
         // value widget is worse than naming none. Adjacency stays as a LABELLED
         // fallback — `paired_widget_source` says which was used, so a reader knows how
         // much to trust it.
+        // The link points VALUE -> CONTROL, not the other way round (codex): ComfyUI
+        // attaches the control to the VALUE widget's `linkedWidgets`. Reading it off
+        // the control found nothing in the ordinary core case and fell through to
+        // adjacency, so the authoritative signal was never actually being used.
         let pairedName = null;
         let pairedSource = null;
-        const linked = Array.isArray(w.linkedWidgets) ? w.linkedWidgets : null;
-        const linkedName = linked?.find((lw) => typeof lw?.name === "string")?.name ?? null;
-        if (linkedName) {
-          pairedName = linkedName;
+        const owner = widgets.find((cand) => {
+          try {
+            return Array.isArray(cand?.linkedWidgets) && cand.linkedWidgets.includes(w);
+          } catch {
+            return false;
+          }
+        });
+        const ownerName = typeof owner?.name === "string" ? owner.name : null;
+        if (ownerName) {
+          pairedName = ownerName;
           pairedSource = "linked";
         } else {
           const prev = i > 0 ? widgets[i - 1] : null;
@@ -120,8 +132,10 @@ export function scopedBatchSeedNote(controls, batchCount) {
     `is a PARTIAL execution, and ComfyUI does not advance control_after_generate between the ` +
     `items of one — measured on frontend 1.48.7 by comparing the submitted prompts, where an ` +
     `unscoped batch of 3 sent three different seeds and a scoped batch of 3 sent the same seed ` +
-    `three times. Items after the first are then identical prompts, which ComfyUI answers from ` +
-    `cache in a fraction of a second with the same output file (#988). Every such control in ` +
+    `three times. A control that repeats can produce duplicate prompts, cache hits and repeated ` +
+    `output files — though not necessarily: another extension's queue-time hook may still vary a ` +
+    `prompt independently, so this says what WILL repeat, not that every later prompt is ` +
+    `identical (#988). Every such control in ` +
     `the workflow is listed because the panel cannot tell from here which ones this scope ` +
     `reaches; one outside the executed branch is harmless. This is the frontend's queue ` +
     `behaviour, not something the panel chose, and the panel does not rewrite your values to ` +

--- a/web/js/lib/scoped-batch-seed.js
+++ b/web/js/lib/scoped-batch-seed.js
@@ -8,6 +8,17 @@
  *   app.queuePrompt(0, 3, undefined)   -> seeds 0, 275253667108059, 219005225600584
  *   app.queuePrompt(0, 3, ["<id>"])    -> seeds 0, 0, 0
  *
+ * MEASURED IN BOTH WIDGET-CONTROL MODES, because ComfyUI can install the control's
+ * mutation as either `beforeQueued` or `afterQueued` and only one had been observed
+ * (codex). Flipping `Comfy.WidgetControlMode` and repeating the capture:
+ *
+ *   mode "after"  scoped [0,0,0]   unscoped [0, 1052866786709601, 413884900582428]
+ *   mode "before" scoped [0,0,0]   unscoped [267357841888133, 145435791190359, 43867923644491]
+ *
+ * The scoped batch repeats in BOTH, so the warning does not need gating on the setting.
+ * (The unscoped difference is the setting doing its job: "before" randomizes the first
+ * item too, "after" sends the value you set and advances from there.)
+ *
  * That is ComfyUI's OWN queue loop, called directly with no panel code in the path.
  * Passing the scope as the third argument stops it advancing `control_after_generate`
  * between batch items — a partial execution skips the queue-time widget hooks. The

--- a/web/js/lib/scoped-batch-seed.js
+++ b/web/js/lib/scoped-batch-seed.js
@@ -25,8 +25,15 @@
  * lets the caller cancel instead of discovering it from identical outputs.
  */
 
-/** Values of `control_after_generate` that mean "change this between runs". */
-const ADVANCING = new Set(["randomize", "increment", "decrement"]);
+/**
+ * Values of `control_after_generate` that mean "change this between runs".
+ *
+ * `increment-wrap` is here because ComfyUI ships it and it advances like the rest
+ * (codex) — the report only names `randomize`, and warning on that alone would have
+ * left a mode silently broken. `fixed` is the only standard non-advancing value, so it
+ * is the only one that legitimately repeats.
+ */
+const ADVANCING = new Set(["randomize", "increment", "decrement", "increment-wrap"]);
 
 /**
  * Widgets whose value an unscoped batch would have advanced between items, and which
@@ -54,17 +61,33 @@ export function findRepeatingControlWidgets(nodes) {
         // `fixed` is the one setting that WANTS the same value every time, so a scoped
         // batch repeating it is correct and must not be warned about.
         if (!mode || !ADVANCING.has(mode)) continue;
-        // ComfyUI places the control immediately AFTER the value it governs. Reported
-        // only when that neighbour exists — a guess about which widget is affected
-        // would be worse than saying nothing about it.
-        const prev = i > 0 ? widgets[i - 1] : null;
-        const pairedName = typeof prev?.name === "string" ? prev.name : null;
+        // Prefer the widget's own LINKAGE when the frontend provides it (codex).
+        // Adjacency is only a UI-insertion convention: custom nodes, promoted widgets
+        // and widget-mutating extensions need not preserve it, and blaming the wrong
+        // value widget is worse than naming none. Adjacency stays as a LABELLED
+        // fallback — `paired_widget_source` says which was used, so a reader knows how
+        // much to trust it.
+        let pairedName = null;
+        let pairedSource = null;
+        const linked = Array.isArray(w.linkedWidgets) ? w.linkedWidgets : null;
+        const linkedName = linked?.find((lw) => typeof lw?.name === "string")?.name ?? null;
+        if (linkedName) {
+          pairedName = linkedName;
+          pairedSource = "linked";
+        } else {
+          const prev = i > 0 ? widgets[i - 1] : null;
+          const adjacent = typeof prev?.name === "string" ? prev.name : null;
+          if (adjacent) {
+            pairedName = adjacent;
+            pairedSource = "adjacent";
+          }
+        }
         found.push({
           node_id: node?.id != null ? String(node.id) : null,
           node_type: node?.type ?? null,
           widget: name,
           mode,
-          ...(pairedName ? { paired_widget: pairedName } : {}),
+          ...(pairedName ? { paired_widget: pairedName, paired_widget_source: pairedSource } : {}),
         });
       }
     } catch {
@@ -86,16 +109,24 @@ export function scopedBatchSeedNote(controls, batchCount) {
     .map((c) => `node ${c.node_id}${c.node_type ? ` (${c.node_type})` : ""} ${c.paired_widget ?? "value"}=${c.mode}`)
     .join("; ");
   const more = controls.length > 5 ? `, and ${controls.length - 5} more` : "";
+  // CONDITIONAL, not absolute (codex). The scan walks every graph level, while a scoped
+  // run executes only what feeds `to_node_id` — so a control on a branch this run never
+  // reaches would otherwise be described as certainly repeating. The panel cannot
+  // cheaply derive the executed set from here, so it says "the ones its scope reaches"
+  // and admits it is listing all of them.
   return (
-    `EVERY ITEM OF THIS BATCH WILL USE THE SAME ${controls.length === 1 ? "VALUE" : "VALUES"}: ` +
-    `${which}${more}. A run scoped with to_node_id is a PARTIAL execution, and ComfyUI does ` +
-    `not advance control_after_generate between the items of one — measured on frontend ` +
-    `1.48.7 by comparing the submitted prompts, where an unscoped batch of 3 sent three ` +
-    `different seeds and a scoped batch of 3 sent the same seed three times. So items after ` +
-    `the first are identical prompts, which ComfyUI answers from cache in a fraction of a ` +
-    `second with the same output file (#988). This is the frontend's queue behaviour, not ` +
-    `something the panel chose, and the panel does not rewrite your seeds to work around it. ` +
-    `To get different results: run batch_count:1 several times setting the value yourself ` +
-    `between runs, or drop to_node_id so the run is unscoped and ComfyUI advances it for you.`
+    `THIS BATCH WILL REUSE THE SAME ${controls.length === 1 ? "VALUE" : "VALUES"} for any of ` +
+    `these controls its scope actually reaches: ${which}${more}. A run scoped with to_node_id ` +
+    `is a PARTIAL execution, and ComfyUI does not advance control_after_generate between the ` +
+    `items of one — measured on frontend 1.48.7 by comparing the submitted prompts, where an ` +
+    `unscoped batch of 3 sent three different seeds and a scoped batch of 3 sent the same seed ` +
+    `three times. Items after the first are then identical prompts, which ComfyUI answers from ` +
+    `cache in a fraction of a second with the same output file (#988). Every such control in ` +
+    `the workflow is listed because the panel cannot tell from here which ones this scope ` +
+    `reaches; one outside the executed branch is harmless. This is the frontend's queue ` +
+    `behaviour, not something the panel chose, and the panel does not rewrite your values to ` +
+    `work around it. The prompts are ALREADY QUEUED — interrupt them if this is not what you ` +
+    `wanted. For different results: run batch_count:1 several times, setting the value ` +
+    `yourself between runs, or drop to_node_id so the run is unscoped and ComfyUI advances it.`
   );
 }

--- a/web/js/lib/scoped-batch-seed.js
+++ b/web/js/lib/scoped-batch-seed.js
@@ -1,0 +1,101 @@
+/**
+ * #988 — a SCOPED batch repeats the same seed, so every item after the first is
+ * served from ComfyUI's cache and returns identical pixels.
+ *
+ * MEASURED on ComfyUI 0.31.1 / frontend 1.48.7, by capturing the outgoing /prompt
+ * bodies behind an interceptor that answered them locally (nothing queued):
+ *
+ *   app.queuePrompt(0, 3, undefined)   -> seeds 0, 275253667108059, 219005225600584
+ *   app.queuePrompt(0, 3, ["<id>"])    -> seeds 0, 0, 0
+ *
+ * That is ComfyUI's OWN queue loop, called directly with no panel code in the path.
+ * Passing the scope as the third argument stops it advancing `control_after_generate`
+ * between batch items — a partial execution skips the queue-time widget hooks. The
+ * panel is only the thing that passes that argument.
+ *
+ * It also explains why the reporter's own fix failed: looping with batch:1 separates
+ * the dispatches in time, but the advance is not time-dependent. It never runs on this
+ * path, so no amount of sequencing was going to trigger it.
+ *
+ * WHAT THIS MODULE DOES: detect the combination before dispatch and say so. It does not
+ * rewrite seeds. Doing that would mean reimplementing the frontend's widget semantics
+ * (`increment`/`decrement`/`randomize` differ, and each has a range), on the one path
+ * where the panel already has to repair the request body — and this codebase has been
+ * burned by re-deriving frontend behaviour before. Naming the problem at queue time
+ * lets the caller cancel instead of discovering it from identical outputs.
+ */
+
+/** Values of `control_after_generate` that mean "change this between runs". */
+const ADVANCING = new Set(["randomize", "increment", "decrement"]);
+
+/**
+ * Widgets whose value an unscoped batch would have advanced between items, and which
+ * a scoped batch will therefore repeat.
+ *
+ * Returns `[{ node_id, node_type, widget, mode, paired_widget }]` — `paired_widget` is
+ * the value widget the control governs (conventionally the one immediately before it,
+ * which is how ComfyUI pairs `seed` with `control_after_generate`), reported only when
+ * it can be identified. Purely observational: nothing is written.
+ *
+ * Fully defensive — a malformed node or a throwing accessor reduces what is found,
+ * never throws. A warning must not be able to take down the run it is about.
+ */
+export function findRepeatingControlWidgets(nodes) {
+  const found = [];
+  if (!Array.isArray(nodes)) return found;
+  for (const node of nodes) {
+    try {
+      const widgets = Array.isArray(node?.widgets) ? node.widgets : [];
+      for (let i = 0; i < widgets.length; i++) {
+        const w = widgets[i];
+        const name = typeof w?.name === "string" ? w.name : null;
+        if (name !== "control_after_generate") continue;
+        const mode = typeof w.value === "string" ? w.value : null;
+        // `fixed` is the one setting that WANTS the same value every time, so a scoped
+        // batch repeating it is correct and must not be warned about.
+        if (!mode || !ADVANCING.has(mode)) continue;
+        // ComfyUI places the control immediately AFTER the value it governs. Reported
+        // only when that neighbour exists — a guess about which widget is affected
+        // would be worse than saying nothing about it.
+        const prev = i > 0 ? widgets[i - 1] : null;
+        const pairedName = typeof prev?.name === "string" ? prev.name : null;
+        found.push({
+          node_id: node?.id != null ? String(node.id) : null,
+          node_type: node?.type ?? null,
+          widget: name,
+          mode,
+          ...(pairedName ? { paired_widget: pairedName } : {}),
+        });
+      }
+    } catch {
+      /* one unreadable node costs its own entry, never the whole diagnosis */
+    }
+  }
+  return found;
+}
+
+/**
+ * The disclosure. Empty unless this is genuinely the reported combination: a SCOPED
+ * run, a batch of more than one, and at least one advancing control widget.
+ */
+export function scopedBatchSeedNote(controls, batchCount) {
+  if (!Array.isArray(controls) || !controls.length) return "";
+  if (!(Number(batchCount) > 1)) return "";
+  const which = controls
+    .slice(0, 5)
+    .map((c) => `node ${c.node_id}${c.node_type ? ` (${c.node_type})` : ""} ${c.paired_widget ?? "value"}=${c.mode}`)
+    .join("; ");
+  const more = controls.length > 5 ? `, and ${controls.length - 5} more` : "";
+  return (
+    `EVERY ITEM OF THIS BATCH WILL USE THE SAME ${controls.length === 1 ? "VALUE" : "VALUES"}: ` +
+    `${which}${more}. A run scoped with to_node_id is a PARTIAL execution, and ComfyUI does ` +
+    `not advance control_after_generate between the items of one — measured on frontend ` +
+    `1.48.7 by comparing the submitted prompts, where an unscoped batch of 3 sent three ` +
+    `different seeds and a scoped batch of 3 sent the same seed three times. So items after ` +
+    `the first are identical prompts, which ComfyUI answers from cache in a fraction of a ` +
+    `second with the same output file (#988). This is the frontend's queue behaviour, not ` +
+    `something the panel chose, and the panel does not rewrite your seeds to work around it. ` +
+    `To get different results: run batch_count:1 several times setting the value yourself ` +
+    `between runs, or drop to_node_id so the run is unscoped and ComfyUI advances it for you.`
+  );
+}


### PR DESCRIPTION
Claims #988.

**Reported:** `panel_run({to_node_id, batch_count: 2..3})` returns distinct prompt ids, but a `KSampler` with `control_after_generate=randomize` serializes the **same seed** for every item. The first renders (22s), the rest complete from cache (0.2–0.3s) with the same filename and identical pixels. Observed twice.

Silent duplicate output — the tool reports `queued:true` with several prompt ids and nothing says the results will be the same.

**The reporter already tried the obvious fix and reverted it.** Looping `dispatchScopedRun` with `batch:1` and awaiting each call passed 114 unit tests and still produced cached duplicates live. That is worth taking seriously: it means the seed does not advance simply because the calls are separated in time, so whatever advances it is not being invoked on this path at all.

**Directly measurable without executing anything.** The seeds live in the outgoing `/prompt` bodies, and I can capture those behind an interceptor that refuses locally — the same technique that answered #996. Two runs, two bodies, compare the seed. That distinguishes "the panel sends identical prompts" from "the panel sends different prompts and ComfyUI still caches", which are different bugs with different owners.

- [ ] capture the submitted bodies for a scoped batch_count:2 and compare seeds
- [ ] establish what advances `control_after_generate` on the UNSCOPED path, and whether the scoped path reaches it
- [ ] fix + a regression test asserting distinct serialized seeds across scoped batch items
- [ ] codex review
- [ ] browser verification

Note the interaction with #986, just released: identical outputs now arrive **labelled** as duplicates rather than silently, so this failure is already less invisible than when it was filed.