### PR TITLE
fix(refresh): stop claiming a complete refresh that did not rehydrate anything (#981)

### DIFF
--- a/browser_tests/unit/stale-placeholders.test.mjs
+++ b/browser_tests/unit/stale-placeholders.test.mjs
@@ -131,7 +131,13 @@ test("#981 the note credits what the refresh DID do, and names the one thing tha
     { node_id: "2", type: "MiniMaxChunkFeedForward" },
     { node_id: "3", type: "MiniMaxLowVRAMAttention" },
   ]);
-  assert.match(note, /definitions ARE now current/, "the refresh is not described as having failed");
+  // codex r2: the predicate establishes that the CLIENT can instantiate the class now —
+  // not that the definition is current, not that this refresh registered it, and nothing
+  // at all about what the backend will do with the prompt. The note may claim only that.
+  assert.match(note, /This page can NOW instantiate/, "the refresh is not described as having failed");
+  assert.doesNotMatch(note, /definitions ARE now current/, "…but does not claim currency it never checked");
+  assert.doesNotMatch(note, /will still fail at queue time/, "nor a backend outcome it never measured");
+  assert.match(note, /does not serialize the values its class expects/, "what it CAN say about the dead node");
   assert.match(note, /MiniMaxChunkFeedForward/, "names the classes");
   assert.match(note, /still a PLACEHOLDER/, "and what did not happen");
   assert.match(note, /does not rehydrate nodes that were created while it was unknown/, "why");
@@ -235,4 +241,17 @@ test("#981 (codex): an UNAVAILABLE missing-node record claims nothing at all", (
     1,
     "and Note/Reroute stay excluded even then",
   );
+});
+
+test("#981 (codex r2) source guard: the disclosure survives the SUCCESS path of refresh_nodes", () => {
+  // It is only ever produced on a successful refresh, and `{ok:true, refreshed:true}`
+  // dropped every extra field — so the warning existed but no caller could ever see it.
+  // Found by tracing the consumers of the verdict, not by reading the producer.
+  const src = readFileSync(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8");
+  assert.match(src, /if \(refreshed\) return \{ ok: true, refreshed: true, \.\.\.stale \};/, "forwarded on success");
+  assert.match(src, /stale_placeholders_note: verdict\.stale_placeholders_note/, "and the note with it");
+  // `ok` must stay true: the refresh did what it claims, and the reload flag is about
+  // the canvas, not about the refresh having failed.
+  assert.ok(!/ok: false/.test(src.slice(src.indexOf("async refresh_nodes()"), src.indexOf("graph_serialize()"))),
+    "requires_reload must not be turned into a failure");
 });

--- a/browser_tests/unit/stale-placeholders.test.mjs
+++ b/browser_tests/unit/stale-placeholders.test.mjs
@@ -32,7 +32,23 @@ import {
 const realNode = (id, type) => ({ id, type, constructor: { nodeData: { name: type }, title: type } });
 /** A placeholder: instantiated while the class was unknown, so it carries no def. */
 const placeholder = (id, type) => ({ id, type, constructor: {} });
-const registry = (...types) => (type) => types.includes(type);
+/** Every type these fixtures ever place as a placeholder — i.e. what the frontend would
+ *  have recorded as missing at load. The collector requires membership here, so a
+ *  frontend-only node (Note, Reroute, …) can never be mistaken for a placeholder. */
+const RECORDED = [
+  "MiniMaxChunkFeedForward",
+  "MiniMaxLowVRAMAttention",
+  "OllamaImageList_CLIPGenerateText",
+  "NeverInstalled",
+  "StillGone",
+  "CLIPTextEncode",
+  "X",
+];
+/** `registry(...clientRegistered)` — what THIS page can instantiate now. */
+const registry = (...clientRegistered) => ({
+  recordedMissingTypes: RECORDED,
+  isClientRegistered: (type) => clientRegistered.includes(type),
+});
 
 test("#981 a node with no nodeData is a placeholder; one with it is not", () => {
   assert.equal(isPlaceholderNode(placeholder(1, "X")), true);
@@ -84,8 +100,11 @@ test("#981 the reporter's three classes, mixed with healthy nodes", () => {
 });
 
 test("#981 a registration lookup that THROWS skips that node rather than guessing", () => {
-  const stale = findStalePlaceholders([placeholder(1, "X")], () => {
-    throw new Error("registry boom");
+  const stale = findStalePlaceholders([placeholder(1, "X")], {
+    recordedMissingTypes: RECORDED,
+    isClientRegistered: () => {
+      throw new Error("registry boom");
+    },
   });
   assert.deepEqual(stale, [], "unknown registration status is not evidence the node is recoverable");
 });
@@ -116,8 +135,11 @@ test("#981 the note credits what the refresh DID do, and names the one thing tha
   assert.match(note, /MiniMaxChunkFeedForward/, "names the classes");
   assert.match(note, /still a PLACEHOLDER/, "and what did not happen");
   assert.match(note, /does not rehydrate nodes that were created while it was unknown/, "why");
-  assert.match(note, /Reload the workflow/, "the remedy");
-  assert.match(note, /Save first/, "and its cost, since a reload discards unsaved work");
+  // codex: "reload" on its own is ambiguous — a browser refresh restores the last
+  // autosave, not necessarily the graph on screen. The remedy must name both steps.
+  assert.match(note, /SAVE the workflow, then reload\/reopen that saved workflow/, "the remedy, both steps");
+  assert.match(note, /anything not saved is not rebuilt/, "and its cost");
+  assert.match(note, /browser refresh restores whatever the frontend last autosaved/, "not a plain refresh");
   assert.equal(stalePlaceholderNote([]), "", "silent when nothing is stale");
   assert.equal(stalePlaceholderNote(null), "");
 });
@@ -131,5 +153,86 @@ test("#981 source guard: the refresh reports requires_reload and does NOT clear 
   assert.ok(
     !/removeMissingNodesByType\s*\(/.test(src),
     "the missing-node store must NOT be cleared while the placeholders remain",
+  );
+});
+
+test("#981 (codex): FRONTEND-ONLY nodes are never reported — the false positive that killed v1", () => {
+  // MEASURED live: Note, Reroute, PrimitiveNode and MarkdownNote all lack
+  // `constructor.nodeData`, so the first version reported ALL FOUR. A canvas with one
+  // Note on it would have demanded a workflow reload after every refresh. They are
+  // excluded because the frontend never recorded them as missing — membership in that
+  // load-time record is the discriminator, not the absence of a definition.
+  const nodes = ["Note", "Reroute", "PrimitiveNode", "MarkdownNote"].map((t, i) => placeholder(i + 1, t));
+  const stale = findStalePlaceholders(nodes, {
+    recordedMissingTypes: [], // none of them were ever missing
+    isClientRegistered: () => true, // and all are instantiable
+  });
+  assert.deepEqual(stale, [], "a node the frontend never called missing is not a stale placeholder");
+});
+
+test("#981 (codex): BACKEND availability is not CLIENT registration", () => {
+  // /object_info proves the server has the definition; it does not prove this page can
+  // instantiate the class. Only the latter makes a reload capable of repairing the node,
+  // so the lookup is deliberately the client registry.
+  const nodes = [placeholder(1, "X")];
+  const backendOnly = findStalePlaceholders(nodes, {
+    recordedMissingTypes: ["X"],
+    isClientRegistered: () => false, // present on the server, not registered here
+  });
+  assert.deepEqual(backendOnly, [], "no reload claim while the class cannot be instantiated here");
+  assert.equal(findStalePlaceholders(nodes, registry("X")).length, 1, "…and one once it can");
+});
+
+test("#981 (codex) source guard: the panel feeds the load-time record and the CLIENT registry", () => {
+  const src = readFileSync(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8");
+  assert.match(src, /const recordedMissingTypes = collectMissingAssets\(\)\.nodeTypes \?\? \[\]/, "the frontend's own record");
+  assert.match(src, /findStalePlaceholders\(nodes, \{\r?\n\s*recordedMissingTypes,/, "…is what the scan is given");
+  assert.match(src, /isClientRegistered: \(type\) => !!LiteGraph\?\.registered_node_types\?\.\[type\]/, "client registry");
+  assert.ok(
+    !/Object\.prototype\.hasOwnProperty\.call\(registry, type\)/.test(src),
+    "the /object_info lookup must not come back — backend availability is a different fact",
+  );
+});
+
+test("#981 (codex): a REBUILT node plus a stale missing-store snapshot is NOT a finding", () => {
+  // The store is a load-time snapshot the frontend never clears, so it keeps naming a
+  // type long after the node was rebuilt. The node's own state, not the record, decides:
+  // the record only narrows WHICH types may be considered.
+  const stale = findStalePlaceholders([realNode(1, "MiniMaxChunkFeedForward")], registry("MiniMaxChunkFeedForward"));
+  assert.deepEqual(stale, [], "a node carrying a definition is healthy whatever the snapshot says");
+});
+
+test("#981 (codex): the warning PERSISTS across refreshes until the node is rebuilt", () => {
+  // Registering the class does not rehydrate the node, so a second and third refresh
+  // must keep saying so. The collector holds no state that could let it go quiet.
+  const nodes = [placeholder(1, "MiniMaxChunkFeedForward")];
+  const opts = registry("MiniMaxChunkFeedForward");
+  const runs = [findStalePlaceholders(nodes, opts), findStalePlaceholders(nodes, opts), findStalePlaceholders(nodes, opts)];
+  for (const r of runs) assert.deepEqual(r, [{ node_id: "1", type: "MiniMaxChunkFeedForward" }]);
+  // …and goes quiet only once the reload actually replaced the node.
+  nodes[0] = realNode(1, "MiniMaxChunkFeedForward");
+  assert.deepEqual(findStalePlaceholders(nodes, opts), [], "silent once the rebuild happened");
+});
+
+test("#981 (codex): an UNAVAILABLE missing-node record claims nothing at all", () => {
+  // If the frontend's record cannot be read the discriminator is gone, and without it
+  // every frontend-only node looks like a placeholder. Absent record means silence, not
+  // a fallback to the shape test that produced the false positives.
+  const nodes = [placeholder(1, "Note"), placeholder(2, "Reroute"), placeholder(3, "MiniMaxChunkFeedForward")];
+  for (const absent of [undefined, null, [], "boom", 42, new Set()]) {
+    assert.deepEqual(
+      findStalePlaceholders(nodes, { recordedMissingTypes: absent, isClientRegistered: () => true }),
+      [],
+      `no record (${String(absent)}) -> no claim`,
+    );
+  }
+  // A Set is accepted when it HAS entries — the panel may hand either shape.
+  assert.equal(
+    findStalePlaceholders(nodes, {
+      recordedMissingTypes: new Set(["MiniMaxChunkFeedForward"]),
+      isClientRegistered: () => true,
+    }).length,
+    1,
+    "and Note/Reroute stay excluded even then",
   );
 });

--- a/browser_tests/unit/stale-placeholders.test.mjs
+++ b/browser_tests/unit/stale-placeholders.test.mjs
@@ -134,10 +134,14 @@ test("#981 the note credits what the refresh DID do, and names the one thing tha
   // codex r2: the predicate establishes that the CLIENT can instantiate the class now —
   // not that the definition is current, not that this refresh registered it, and nothing
   // at all about what the backend will do with the prompt. The note may claim only that.
-  assert.match(note, /This page can NOW instantiate/, "the refresh is not described as having failed");
-  assert.doesNotMatch(note, /definitions ARE now current/, "…but does not claim currency it never checked");
+  assert.match(note, /NOW registered in this page's client node registry/, "exactly the predicate");
+  assert.doesNotMatch(note, /definitions ARE now current/, "…not currency it never checked");
   assert.doesNotMatch(note, /will still fail at queue time/, "nor a backend outcome it never measured");
-  assert.match(note, /does not serialize the values its class expects/, "what it CAN say about the dead node");
+  // codex r3: a registry ENTRY is not a successful createNode, and "no widgets" says
+  // nothing about values arriving over links, retained properties or class defaults.
+  assert.doesNotMatch(note, /can NOW instantiate/, "an entry is not a proven instantiation");
+  assert.doesNotMatch(note, /does not serialize the values its class expects/, "nor a serialization claim");
+  assert.match(note, /never rebuilt against the class/, "what it CAN say about the dead node");
   assert.match(note, /MiniMaxChunkFeedForward/, "names the classes");
   assert.match(note, /still a PLACEHOLDER/, "and what did not happen");
   assert.match(note, /does not rehydrate nodes that were created while it was unknown/, "why");
@@ -244,9 +248,10 @@ test("#981 (codex): an UNAVAILABLE missing-node record claims nothing at all", (
 });
 
 test("#981 (codex r2) source guard: the disclosure survives the SUCCESS path of refresh_nodes", () => {
-  // It is only ever produced on a successful refresh, and `{ok:true, refreshed:true}`
-  // dropped every extra field — so the warning existed but no caller could ever see it.
-  // Found by tracing the consumers of the verdict, not by reading the producer.
+  // The producer runs the scan whatever the verdict says, so the disclosure can ride on
+  // either path — but `{ok:true, refreshed:true}` discarded every extra field, so on the
+  // success path the warning existed and no caller could ever see it. Found by tracing
+  // the consumers of the verdict, not by reading the producer.
   const src = readFileSync(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8");
   assert.match(src, /if \(refreshed\) return \{ ok: true, refreshed: true, \.\.\.stale \};/, "forwarded on success");
   assert.match(src, /stale_placeholders_note: verdict\.stale_placeholders_note/, "and the note with it");

--- a/browser_tests/unit/stale-placeholders.test.mjs
+++ b/browser_tests/unit/stale-placeholders.test.mjs
@@ -1,0 +1,135 @@
+/**
+ * #981 — `panel_refresh_nodes` returned `{ok:true, refreshed:true}` while
+ * `panel_get_errors` still listed the same classes as missing, after the packs were
+ * installed and ComfyUI restarted.
+ *
+ * MEASURED on ComfyUI 0.31.1 / frontend 1.48.7: a workflow was loaded referencing an
+ * absent class, the class was then registered exactly as an install would make it
+ * appear, and the already-placed node was re-read:
+ *
+ *   registered in LiteGraph  : true
+ *   node constructor title   : null     (unchanged)
+ *   node constructor nodeData: false    (unchanged)
+ *   node widgets             : []       (unchanged)
+ *   missingNodesError store  : still reports it
+ *
+ * So the node does NOT come back. Clearing the missing-node store — which the frontend
+ * does expose a method for — would make get_errors report clean while the canvas still
+ * holds a dead node that fails at queue time. The refresh says a reload is needed
+ * instead.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+import {
+  isPlaceholderNode,
+  findStalePlaceholders,
+  stalePlaceholderNote,
+} from "../../web/js/lib/stale-placeholders.js";
+
+/** A node whose class WAS registered: ComfyUI attaches `nodeData` to the constructor. */
+const realNode = (id, type) => ({ id, type, constructor: { nodeData: { name: type }, title: type } });
+/** A placeholder: instantiated while the class was unknown, so it carries no def. */
+const placeholder = (id, type) => ({ id, type, constructor: {} });
+const registry = (...types) => (type) => types.includes(type);
+
+test("#981 a node with no nodeData is a placeholder; one with it is not", () => {
+  assert.equal(isPlaceholderNode(placeholder(1, "X")), true);
+  assert.equal(isPlaceholderNode(realNode(1, "X")), false);
+});
+
+test("#981 an unreadable node is NOT claimed to be a placeholder", () => {
+  // Reporting a healthy node as dead would send someone reloading a workflow that was
+  // fine, so absence of evidence is not treated as evidence.
+  const hostile = {
+    get constructor() {
+      throw new Error("boom");
+    },
+  };
+  assert.equal(isPlaceholderNode(hostile), false);
+  for (const bad of [null, undefined, 42, "x"]) assert.equal(isPlaceholderNode(bad), false);
+});
+
+test("#981 the reported case: a placeholder whose class is NOW registered is stale", () => {
+  const nodes = [placeholder(1, "MiniMaxChunkFeedForward")];
+  assert.deepEqual(findStalePlaceholders(nodes, registry("MiniMaxChunkFeedForward")), [
+    { node_id: "1", type: "MiniMaxChunkFeedForward" },
+  ]);
+});
+
+test("#981 a placeholder whose class is STILL absent is NOT stale — it is genuinely missing", () => {
+  // The existing missing_node_types reporting already covers that one, and nothing
+  // about it is out of date. Claiming a reload would fix it would be false.
+  assert.deepEqual(findStalePlaceholders([placeholder(1, "StillGone")], registry("SomethingElse")), []);
+});
+
+test("#981 a healthy node is never reported, however its class is registered", () => {
+  assert.deepEqual(findStalePlaceholders([realNode(1, "CLIPTextEncode")], registry("CLIPTextEncode")), []);
+});
+
+test("#981 the reporter's three classes, mixed with healthy nodes", () => {
+  const nodes = [
+    realNode(1, "CLIPTextEncode"),
+    placeholder(2, "MiniMaxChunkFeedForward"),
+    placeholder(3, "MiniMaxLowVRAMAttention"),
+    placeholder(4, "OllamaImageList_CLIPGenerateText"),
+    placeholder(5, "NeverInstalled"),
+  ];
+  const stale = findStalePlaceholders(
+    nodes,
+    registry("CLIPTextEncode", "MiniMaxChunkFeedForward", "MiniMaxLowVRAMAttention", "OllamaImageList_CLIPGenerateText"),
+  );
+  assert.deepEqual(stale.map((s) => s.node_id), ["2", "3", "4"], "the still-absent one is not included");
+});
+
+test("#981 a registration lookup that THROWS skips that node rather than guessing", () => {
+  const stale = findStalePlaceholders([placeholder(1, "X")], () => {
+    throw new Error("registry boom");
+  });
+  assert.deepEqual(stale, [], "unknown registration status is not evidence the node is recoverable");
+});
+
+test("#981 the collector is total — malformed input yields fewer findings, never a throw", () => {
+  const hostile = {
+    get type() {
+      throw new Error("boom");
+    },
+  };
+  assert.doesNotThrow(() => findStalePlaceholders([hostile, placeholder(2, "X")], registry("X")));
+  assert.deepEqual(
+    findStalePlaceholders([hostile, placeholder(2, "X")], registry("X")).map((s) => s.node_id),
+    ["2"],
+  );
+  for (const bad of [null, undefined, "nope", [null], [{}]]) {
+    assert.deepEqual(findStalePlaceholders(bad, registry("X")), []);
+  }
+  assert.deepEqual(findStalePlaceholders([placeholder(1, "X")], null), []);
+});
+
+test("#981 the note credits what the refresh DID do, and names the one thing that fixes it", () => {
+  const note = stalePlaceholderNote([
+    { node_id: "2", type: "MiniMaxChunkFeedForward" },
+    { node_id: "3", type: "MiniMaxLowVRAMAttention" },
+  ]);
+  assert.match(note, /definitions ARE now current/, "the refresh is not described as having failed");
+  assert.match(note, /MiniMaxChunkFeedForward/, "names the classes");
+  assert.match(note, /still a PLACEHOLDER/, "and what did not happen");
+  assert.match(note, /does not rehydrate nodes that were created while it was unknown/, "why");
+  assert.match(note, /Reload the workflow/, "the remedy");
+  assert.match(note, /Save first/, "and its cost, since a reload discards unsaved work");
+  assert.equal(stalePlaceholderNote([]), "", "silent when nothing is stale");
+  assert.equal(stalePlaceholderNote(null), "");
+});
+
+test("#981 source guard: the refresh reports requires_reload and does NOT clear the store", () => {
+  // Clearing `removeMissingNodesByType` would make get_errors report clean while the
+  // canvas still holds a dead node — a worse answer than the stale one.
+  const src = readFileSync(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8");
+  assert.match(src, /verdict\.requires_reload = true/, "the refresh must say a reload is needed");
+  assert.match(src, /findStalePlaceholders\(/, "and detect the condition");
+  assert.ok(
+    !/removeMissingNodesByType\s*\(/.test(src),
+    "the missing-node store must NOT be cleared while the placeholders remain",
+  );
+});

--- a/browser_tests/unit/stale-placeholders.test.mjs
+++ b/browser_tests/unit/stale-placeholders.test.mjs
@@ -148,6 +148,12 @@ test("#981 the note credits what the refresh DID do, and names the one thing tha
   // codex: "reload" on its own is ambiguous — a browser refresh restores the last
   // autosave, not necessarily the graph on screen. The remedy must name both steps.
   assert.match(note, /SAVE the workflow, then reload\/reopen that saved workflow/, "the remedy, both steps");
+  // codex r4: only `constructor.nodeData` is tested per node — "no widgets" was measured
+  // on one instance — and a registry entry makes a reload worth trying, not certain.
+  assert.match(note, /on the instance measured for #981/, "the widgets claim is attributed");
+  assert.doesNotMatch(note, /they keep no definition and no widgets/, "not asserted of every node");
+  assert.match(note, /To ATTEMPT a rebuild/, "an attempt, not a guarantee");
+  assert.match(note, /not a guarantee the class constructs cleanly/, "and says why it is only an attempt");
   assert.match(note, /anything not saved is not rebuilt/, "and its cost");
   assert.match(note, /browser refresh restores whatever the frontend last autosaved/, "not a plain refresh");
   assert.equal(stalePlaceholderNote([]), "", "silent when nothing is stale");

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -158,6 +158,7 @@ import {
   disabledOutputsInPrompt,
   disabledOutputsNote,
 } from "./lib/muted-subgraph-outputs.js";
+import { findStalePlaceholders, stalePlaceholderNote } from "./lib/stale-placeholders.js";
 import { findRepeatingControlWidgets, scopedBatchSeedNote } from "./lib/scoped-batch-seed.js";
 import {
   materializePromotedValues,
@@ -834,7 +835,33 @@ async function registerComfyNodeDefs(preloadedDefs) {
   // coalescer forwards this through a forced trailing run, so get_errors' awaited
   // `force:true` refresh resolves to the freshness verdict of the fetch IT triggered
   // (codex round-6 P0).
-  return describeNodeDefRefresh({ appAvailable, defsObtained: !!defs, defsRegistered, comboApiPresent, comboRan, phase, didThrow, thrown });
+  const verdict = describeNodeDefRefresh({ appAvailable, defsObtained: !!defs, defsRegistered, comboApiPresent, comboRan, phase, didThrow, thrown });
+  // #981 — a refresh that registered the definitions has NOT necessarily fixed the
+  // canvas. MEASURED: after registering a formerly-missing class, an already-placed
+  // node of that class keeps no definition, no widgets and no title — it stays a
+  // placeholder, and get_errors keeps reporting it. Reporting a clean refresh there is
+  // the same over-claim this session keeps removing, and the reporter asked for exactly
+  // this: say a reload is required rather than claim a complete refresh.
+  //
+  // Note what is deliberately NOT done: the frontend's missing-node store exposes
+  // `removeMissingNodesByType`, and clearing it here would make get_errors report clean
+  // while the canvas still holds a dead node that fails at queue time — trading one
+  // wrong answer for a worse one.
+  try {
+    const nodes = collectAllGraphs(getGraphCtx().rootGraph).flatMap((g) => g?._nodes ?? []);
+    const registry = defs && typeof defs === "object" ? defs : null;
+    const stale = findStalePlaceholders(nodes, (type) =>
+      registry ? Object.prototype.hasOwnProperty.call(registry, type) : !!LiteGraph?.registered_node_types?.[type],
+    );
+    if (stale.length) {
+      verdict.requires_reload = true;
+      verdict.stale_placeholders = stale;
+      verdict.stale_placeholders_note = stalePlaceholderNote(stale);
+    }
+  } catch {
+    /* a diagnosis must never turn a successful refresh into a failure */
+  }
+  return verdict;
 }
 
 // Single-flight refresh that never drops a caller-supplied fresh payload (#289 P2).

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -8098,10 +8098,23 @@ const GRAPH_TOOL_EXECUTORS = {
   async refresh_nodes() {
     const verdict = await refreshComfyNodeDefs(undefined, { force: true });
     const refreshed = verdict === true || (verdict != null && typeof verdict === "object" && verdict.refreshed === true);
-    if (refreshed) return { ok: true, refreshed: true };
+    // #981: the stale-placeholder disclosure has to survive the SUCCESS path, which is
+    // the only path it is ever produced on. `{ok:true, refreshed:true}` dropped it —
+    // caught by tracing the consumers rather than assuming the verdict flowed through.
+    // `ok` stays true and `refreshed` stays true: the refresh did what it claims. The
+    // reload flag is advisory, about the canvas, not a failure of the refresh.
+    const stale = verdict != null && typeof verdict === "object" && verdict.requires_reload
+      ? {
+          requires_reload: true,
+          stale_placeholders: verdict.stale_placeholders,
+          stale_placeholders_note: verdict.stale_placeholders_note,
+        }
+      : {};
+    if (refreshed) return { ok: true, refreshed: true, ...stale };
     return {
       ok: true,
       refreshed: false,
+      ...stale,
       reason: verdict?.reason ?? "unknown",
       ...(verdict?.detail ? { detail: verdict.detail } : {}),
       remedy:

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -8098,9 +8098,11 @@ const GRAPH_TOOL_EXECUTORS = {
   async refresh_nodes() {
     const verdict = await refreshComfyNodeDefs(undefined, { force: true });
     const refreshed = verdict === true || (verdict != null && typeof verdict === "object" && verdict.refreshed === true);
-    // #981: the stale-placeholder disclosure has to survive the SUCCESS path, which is
-    // the only path it is ever produced on. `{ok:true, refreshed:true}` dropped it —
-    // caught by tracing the consumers rather than assuming the verdict flowed through.
+    // #981: the stale-placeholder disclosure has to survive BOTH paths. The producer
+    // runs the scan whatever the verdict says — a refresh that failed at the combo phase
+    // can still leave placeholders behind — but only this branch dropped it, because
+    // `{ok:true, refreshed:true}` discards every other field. Caught by tracing the
+    // consumers rather than assuming the verdict flowed through.
     // `ok` stays true and `refreshed` stays true: the refresh did what it claims. The
     // reload flag is advisory, about the canvas, not a failure of the refresh.
     const stale = verdict != null && typeof verdict === "object" && verdict.requires_reload

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -849,10 +849,19 @@ async function registerComfyNodeDefs(preloadedDefs) {
   // wrong answer for a worse one.
   try {
     const nodes = collectAllGraphs(getGraphCtx().rootGraph).flatMap((g) => g?._nodes ?? []);
-    const registry = defs && typeof defs === "object" ? defs : null;
-    const stale = findStalePlaceholders(nodes, (type) =>
-      registry ? Object.prototype.hasOwnProperty.call(registry, type) : !!LiteGraph?.registered_node_types?.[type],
-    );
+    // The frontend's own load-time record of what was missing. Without it a
+    // frontend-only node — Note, Reroute, PrimitiveNode, MarkdownNote, none of which
+    // carry `nodeData` — is indistinguishable from a real placeholder, and MEASURED,
+    // all four were reported by the first version. Absent store ⇒ empty set ⇒ nothing
+    // claimed.
+    const recordedMissingTypes = collectMissingAssets().nodeTypes ?? [];
+    const stale = findStalePlaceholders(nodes, {
+      recordedMissingTypes,
+      // CLIENT registration, deliberately: /object_info proves the BACKEND has the
+      // definition, which is not the same as this page being able to instantiate it,
+      // and only the latter makes a reload capable of repairing the node.
+      isClientRegistered: (type) => !!LiteGraph?.registered_node_types?.[type],
+    });
     if (stale.length) {
       verdict.requires_reload = true;
       verdict.stale_placeholders = stale;

--- a/web/js/lib/stale-placeholders.js
+++ b/web/js/lib/stale-placeholders.js
@@ -1,0 +1,107 @@
+/**
+ * #981 — `panel_refresh_nodes` returns `{ok:true, refreshed:true}` and `panel_get_errors`
+ * immediately still lists the same classes as missing, after the packs were installed
+ * and ComfyUI restarted.
+ *
+ * MEASURED on ComfyUI 0.31.1 / frontend 1.48.7. A workflow was loaded referencing a
+ * class that did not exist, the class was then registered exactly as an install would
+ * make it appear, and the already-placed node was re-read:
+ *
+ *   registered in LiteGraph : true
+ *   node constructor title  : null      (unchanged)
+ *   node constructor nodeData: false    (unchanged)
+ *   node widgets            : []        (unchanged)
+ *   missingNodesError store : still reports it
+ *
+ * So TWO things are stale, and the second is why the obvious fix is wrong:
+ *
+ *   1. the `missingNodesError` store is a LOAD-TIME snapshot the panel never clears —
+ *      it exposes `removeMissingNodesByType`, and nothing in this codebase calls it;
+ *   2. the already-instantiated node is NOT rehydrated by registering the class. It
+ *      stays a placeholder with no definition and no widgets.
+ *
+ * Clearing the store alone would therefore trade one wrong answer for a worse one:
+ * `panel_get_errors` would report clean while the canvas still holds a dead node that
+ * fails at queue time. The reporter's own second option is the correct one — do not
+ * claim a complete refresh when the placeholders did not come back — and this module
+ * establishes exactly that condition.
+ */
+
+/**
+ * Is this node a PLACEHOLDER — instantiated when its class was unknown, so it carries
+ * no definition?
+ *
+ * The signal is the absence of `constructor.nodeData`, which is what ComfyUI attaches
+ * when it registers a real class. Checked defensively: an unreadable node is not
+ * claimed to be a placeholder, because reporting a healthy node as dead would send
+ * someone reloading a workflow that was fine.
+ */
+export function isPlaceholderNode(node) {
+  try {
+    if (!node || typeof node !== "object") return false;
+    return !node.constructor?.nodeData;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Nodes that are STILL placeholders even though their class is now registered — the
+ * exact state a refresh leaves behind, and the one a caller must not be told is clean.
+ *
+ * `isRegistered(type)` is injected so this stays pure; the caller passes a lookup over
+ * the live registry or a fresh `/object_info`.
+ *
+ * Returns `[{ node_id, type }]`. A placeholder whose class is STILL absent is NOT
+ * included: that one is genuinely missing, the existing `missing_node_types` reporting
+ * already covers it, and nothing about it is stale.
+ */
+export function findStalePlaceholders(nodes, isRegistered) {
+  const found = [];
+  if (!Array.isArray(nodes) || typeof isRegistered !== "function") return found;
+  for (const node of nodes) {
+    try {
+      if (!isPlaceholderNode(node)) continue;
+      const type = typeof node.type === "string" ? node.type : null;
+      if (!type) continue;
+      let registered = false;
+      try {
+        registered = !!isRegistered(type);
+      } catch {
+        // Unknown registration status is not evidence the node is recoverable, and
+        // claiming a reload would fix it would be a guess. Skipped.
+        continue;
+      }
+      if (!registered) continue;
+      found.push({ node_id: node.id != null ? String(node.id) : null, type });
+    } catch {
+      /* one unreadable node costs its own entry, never the whole scan */
+    }
+  }
+  return found;
+}
+
+/**
+ * The disclosure a refresh must carry when it did not finish the job.
+ *
+ * Says what the refresh DID do (definitions are current), what it did not (these nodes
+ * are still placeholders), and the one thing that fixes it. Empty when nothing is
+ * stale, so an ordinary refresh stays quiet.
+ */
+export function stalePlaceholderNote(stale) {
+  if (!Array.isArray(stale) || !stale.length) return "";
+  const types = [...new Set(stale.map((s) => s.type))];
+  const which = types.slice(0, 6).join(", ");
+  const more = types.length > 6 ? `, and ${types.length - 6} more` : "";
+  return (
+    `The node definitions ARE now current — ${types.length} class${types.length === 1 ? "" : "es"} ` +
+    `that ${types.length === 1 ? "was" : "were"} missing ${types.length === 1 ? "is" : "are"} ` +
+    `registered (${which}${more}). But ${stale.length} node${stale.length === 1 ? "" : "s"} already ` +
+    `on the canvas ${stale.length === 1 ? "is" : "are"} still a PLACEHOLDER: registering a class ` +
+    `does not rehydrate nodes that were created while it was unknown — measured, they keep no ` +
+    `definition and no widgets. They will still be reported as missing, and they will still fail ` +
+    `at queue time. Reload the workflow to rebuild them against the definitions that are now ` +
+    `present (#981). Save first if you have unsaved changes: a reload rebuilds from the stored ` +
+    `workflow, so anything not saved is lost.`
+  );
+}

--- a/web/js/lib/stale-placeholders.js
+++ b/web/js/lib/stale-placeholders.js
@@ -56,20 +56,41 @@ export function isPlaceholderNode(node) {
  * included: that one is genuinely missing, the existing `missing_node_types` reporting
  * already covers it, and nothing about it is stale.
  */
-export function findStalePlaceholders(nodes, isRegistered) {
+export function findStalePlaceholders(nodes, options) {
   const found = [];
-  if (!Array.isArray(nodes) || typeof isRegistered !== "function") return found;
+  // `= {}` in the signature would only cover `undefined` — a caller that computed its
+  // options and got `null` would take a TypeError out of a diagnostic, which is exactly
+  // the failure this module exists to avoid.
+  const { recordedMissingTypes, isClientRegistered } = options && typeof options === "object" ? options : {};
+  if (!Array.isArray(nodes) || typeof isClientRegistered !== "function") return found;
+  // MEMBERSHIP IN THE LOAD-TIME MISSING SNAPSHOT is the discriminator (codex), not the
+  // absence of `nodeData`. Frontend-only nodes have no backend definition and no
+  // `nodeData` at all — MEASURED: Note, Reroute, PrimitiveNode and MarkdownNote were ALL
+  // reported by the first version, so a canvas with a single Note on it would have
+  // demanded a reload after every refresh. Only a type the frontend actually recorded
+  // as missing can have a placeholder that a reload would repair.
+  const recorded =
+    recordedMissingTypes instanceof Set
+      ? recordedMissingTypes
+      : new Set(Array.isArray(recordedMissingTypes) ? recordedMissingTypes : []);
+  // Fast path only — `recorded.has(type)` below is the actual guard, and deleting this
+  // line changes no behaviour (verified by mutation). It is kept so the common case,
+  // where nothing was ever missing, does not walk the graph at all.
+  if (!recorded.size) return found;
   for (const node of nodes) {
     try {
       if (!isPlaceholderNode(node)) continue;
       const type = typeof node.type === "string" ? node.type : null;
-      if (!type) continue;
+      if (!type || !recorded.has(type)) continue;
       let registered = false;
       try {
-        registered = !!isRegistered(type);
+        // CLIENT registration, deliberately — /object_info proves the BACKEND has the
+        // definition, which is not the same as this page being able to instantiate it
+        // (codex). A reload only helps once the class exists here.
+        registered = !!isClientRegistered(type);
       } catch {
         // Unknown registration status is not evidence the node is recoverable, and
-        // claiming a reload would fix it would be a guess. Skipped.
+        // claiming a reload would fix it would be a guess.
         continue;
       }
       if (!registered) continue;
@@ -80,6 +101,7 @@ export function findStalePlaceholders(nodes, isRegistered) {
   }
   return found;
 }
+
 
 /**
  * The disclosure a refresh must carry when it did not finish the job.
@@ -100,8 +122,14 @@ export function stalePlaceholderNote(stale) {
     `on the canvas ${stale.length === 1 ? "is" : "are"} still a PLACEHOLDER: registering a class ` +
     `does not rehydrate nodes that were created while it was unknown — measured, they keep no ` +
     `definition and no widgets. They will still be reported as missing, and they will still fail ` +
-    `at queue time. Reload the workflow to rebuild them against the definitions that are now ` +
-    `present (#981). Save first if you have unsaved changes: a reload rebuilds from the stored ` +
-    `workflow, so anything not saved is lost.`
+    // "Reload" alone is ambiguous (codex) — a browser refresh restores whatever the
+    // frontend last autosaved, which is not reliably the graph on screen. The remedy is
+    // stated as the two steps it actually is: persist the graph, then reopen THAT
+    // workflow, so the rebuild reads a document whose contents are known.
+    `at queue time. To rebuild them against the definitions that are now present: SAVE the ` +
+    `workflow, then reload/reopen that saved workflow (#981). The save is the load-bearing ` +
+    `step — the rebuild reads the stored document, so anything not saved is not rebuilt, and ` +
+    `a plain browser refresh restores whatever the frontend last autosaved rather than the ` +
+    `graph in front of you.`
   );
 }

--- a/web/js/lib/stale-placeholders.js
+++ b/web/js/lib/stale-placeholders.js
@@ -121,23 +121,26 @@ export function stalePlaceholderNote(stale) {
   const types = [...new Set(stale.map((s) => s.type))];
   const which = types.slice(0, 6).join(", ");
   const more = types.length > 6 ? `, and ${types.length - 6} more` : "";
-  // EVERY CLAIM HERE IS ONE THE PREDICATE ESTABLISHES (codex r2). What was actually
-  // tested is that the class is present in the client registry NOW — not that its
-  // definition is current, not that this refresh is what registered it, and not what the
-  // backend will do with the serialized prompt. The earlier wording asserted all three.
+  // EVERY CLAIM HERE IS ONE THE PREDICATE ESTABLISHES (codex r2/r3). The predicate is
+  // exactly `!!LiteGraph.registered_node_types[type]` — an ENTRY in the client registry.
+  // Not that the definition is current, not that this refresh registered it, not that
+  // `createNode` would succeed (a constructor can be present and still throw), and
+  // nothing about what the backend would do with the prompt. Earlier drafts claimed all
+  // four in turn.
   return (
-    `This page can NOW instantiate ${types.length} class${types.length === 1 ? "" : "es"} ` +
-    `that ${types.length === 1 ? "was" : "were"} recorded as missing when this workflow ` +
-    `loaded (${which}${more}). But ${stale.length} node${stale.length === 1 ? "" : "s"} already ` +
+    `${types.length} class${types.length === 1 ? "" : "es"} ` +
+    `that ${types.length === 1 ? "was" : "were"} recorded as missing when this workflow loaded ` +
+    `${types.length === 1 ? "is" : "are"} NOW registered in this page's client node registry ` +
+    `(${which}${more}). But ${stale.length} node${stale.length === 1 ? "" : "s"} already ` +
     `on the canvas ${stale.length === 1 ? "is" : "are"} still a PLACEHOLDER: registering a class ` +
     `does not rehydrate nodes that were created while it was unknown — measured, they keep no ` +
-    `definition and no widgets. They will still be reported as missing, and a node with no ` +
-    `widgets does not serialize the values its class expects, so do not rely on ${stale.length === 1 ? "it" : "them"} ` +
+    `definition and no widgets. They will still be reported as missing, and they were never ` +
+    `rebuilt against the class, so do not rely on ${stale.length === 1 ? "it" : "them"} ` +
     // "Reload" alone is ambiguous (codex) — a browser refresh restores whatever the
     // frontend last autosaved, which is not reliably the graph on screen. The remedy is
     // stated as the two steps it actually is: persist the graph, then reopen THAT
     // workflow, so the rebuild reads a document whose contents are known.
-    `at queue time. To rebuild them against the class this page can now instantiate: SAVE the ` +
+    `at queue time. To rebuild them against the registered class: SAVE the ` +
     `workflow, then reload/reopen that saved workflow (#981). The save is the load-bearing ` +
     `step — the rebuild reads the stored document, so anything not saved is not rebuilt, and ` +
     `a plain browser refresh restores whatever the frontend last autosaved rather than the ` +

--- a/web/js/lib/stale-placeholders.js
+++ b/web/js/lib/stale-placeholders.js
@@ -133,15 +133,24 @@ export function stalePlaceholderNote(stale) {
     `${types.length === 1 ? "is" : "are"} NOW registered in this page's client node registry ` +
     `(${which}${more}). But ${stale.length} node${stale.length === 1 ? "" : "s"} already ` +
     `on the canvas ${stale.length === 1 ? "is" : "are"} still a PLACEHOLDER: registering a class ` +
-    `does not rehydrate nodes that were created while it was unknown — measured, they keep no ` +
-    `definition and no widgets. They will still be reported as missing, and they were never ` +
+    // PER-NODE vs MEASURED-ONCE (codex r4). The only thing tested on each reported node
+    // is the absence of `constructor.nodeData`. "No widgets" came from the one live
+    // instance that was instrumented, so it is attributed to that measurement rather
+    // than asserted of every node in the list.
+    `does not rehydrate nodes that were created while it was unknown. Each of these carries no ` +
+    `class definition; on the instance measured for #981 that also meant no widgets and no ` +
+    `title. They will still be reported as missing, and they were never ` +
     `rebuilt against the class, so do not rely on ${stale.length === 1 ? "it" : "them"} ` +
     // "Reload" alone is ambiguous (codex) — a browser refresh restores whatever the
     // frontend last autosaved, which is not reliably the graph on screen. The remedy is
     // stated as the two steps it actually is: persist the graph, then reopen THAT
     // workflow, so the rebuild reads a document whose contents are known.
-    `at queue time. To rebuild them against the registered class: SAVE the ` +
-    `workflow, then reload/reopen that saved workflow (#981). The save is the load-bearing ` +
+    // ATTEMPT, not guarantee (codex r4): the same registry entry that makes a reload
+    // worth trying does not prove `createNode` will succeed.
+    `at queue time. To ATTEMPT a rebuild against the registered class: SAVE the ` +
+    `workflow, then reload/reopen that saved workflow (#981) — the entry in the registry is ` +
+    `what makes that worth trying, not a guarantee the class constructs cleanly. The save is ` +
+    `the load-bearing ` +
     `step — the rebuild reads the stored document, so anything not saved is not rebuilt, and ` +
     `a plain browser refresh restores whatever the frontend last autosaved rather than the ` +
     `graph in front of you.`

--- a/web/js/lib/stale-placeholders.js
+++ b/web/js/lib/stale-placeholders.js
@@ -55,6 +55,12 @@ export function isPlaceholderNode(node) {
  * Returns `[{ node_id, type }]`. A placeholder whose class is STILL absent is NOT
  * included: that one is genuinely missing, the existing `missing_node_types` reporting
  * already covers it, and nothing about it is stale.
+ *
+ * KNOWN FALSE NEGATIVE, deliberately (codex r2). Requiring membership in the load-time
+ * record means a genuine placeholder whose miss the frontend did NOT record is missed —
+ * the gate is not a proof that such a node cannot exist, only a refusal to guess. That
+ * is the safe direction: under-reporting costs a diagnosis, while the over-reporting it
+ * replaced sent people reloading workflows that were fine.
  */
 export function findStalePlaceholders(nodes, options) {
   const found = [];
@@ -106,27 +112,32 @@ export function findStalePlaceholders(nodes, options) {
 /**
  * The disclosure a refresh must carry when it did not finish the job.
  *
- * Says what the refresh DID do (definitions are current), what it did not (these nodes
- * are still placeholders), and the one thing that fixes it. Empty when nothing is
- * stale, so an ordinary refresh stays quiet.
+ * Says exactly what the predicate established (this page can instantiate the class now),
+ * what it did not (these nodes are still placeholders), and the one thing that fixes it.
+ * Empty when nothing is stale, so an ordinary refresh stays quiet.
  */
 export function stalePlaceholderNote(stale) {
   if (!Array.isArray(stale) || !stale.length) return "";
   const types = [...new Set(stale.map((s) => s.type))];
   const which = types.slice(0, 6).join(", ");
   const more = types.length > 6 ? `, and ${types.length - 6} more` : "";
+  // EVERY CLAIM HERE IS ONE THE PREDICATE ESTABLISHES (codex r2). What was actually
+  // tested is that the class is present in the client registry NOW — not that its
+  // definition is current, not that this refresh is what registered it, and not what the
+  // backend will do with the serialized prompt. The earlier wording asserted all three.
   return (
-    `The node definitions ARE now current — ${types.length} class${types.length === 1 ? "" : "es"} ` +
-    `that ${types.length === 1 ? "was" : "were"} missing ${types.length === 1 ? "is" : "are"} ` +
-    `registered (${which}${more}). But ${stale.length} node${stale.length === 1 ? "" : "s"} already ` +
+    `This page can NOW instantiate ${types.length} class${types.length === 1 ? "" : "es"} ` +
+    `that ${types.length === 1 ? "was" : "were"} recorded as missing when this workflow ` +
+    `loaded (${which}${more}). But ${stale.length} node${stale.length === 1 ? "" : "s"} already ` +
     `on the canvas ${stale.length === 1 ? "is" : "are"} still a PLACEHOLDER: registering a class ` +
     `does not rehydrate nodes that were created while it was unknown — measured, they keep no ` +
-    `definition and no widgets. They will still be reported as missing, and they will still fail ` +
+    `definition and no widgets. They will still be reported as missing, and a node with no ` +
+    `widgets does not serialize the values its class expects, so do not rely on ${stale.length === 1 ? "it" : "them"} ` +
     // "Reload" alone is ambiguous (codex) — a browser refresh restores whatever the
     // frontend last autosaved, which is not reliably the graph on screen. The remedy is
     // stated as the two steps it actually is: persist the graph, then reopen THAT
     // workflow, so the rebuild reads a document whose contents are known.
-    `at queue time. To rebuild them against the definitions that are now present: SAVE the ` +
+    `at queue time. To rebuild them against the class this page can now instantiate: SAVE the ` +
     `workflow, then reload/reopen that saved workflow (#981). The save is the load-bearing ` +
     `step — the rebuild reads the stored document, so anything not saved is not rebuilt, and ` +
     `a plain browser refresh restores whatever the frontend last autosaved rather than the ` +


### PR DESCRIPTION
Claims #981.

**Reported:** after installing the packs and restarting, `/object_info` reports all three formerly-missing classes as registered. `panel_refresh_nodes` returns `{ok:true, refreshed:true}`, and `panel_get_errors` immediately still lists the same three in `missing_node_types` — the classes being inside **subgraph definitions**.

The reporter offers the fix as an either/or, and the second half is the interesting one:

> If live rehydration is unsafe, return  instead of claiming a complete refresh

That is the same defect class as #976, #984 and #988 this session: a reply asserting more than the mechanism did. `refreshed:true` after a refresh that rehydrated nothing is exactly that.

**Two candidates, and they need separating by measurement before either is written:**
- the frontend refreshes definitions but leaves already-instantiated placeholders alone, so the nodes stay placeholders
- `panel_get_errors` reads a missing-node store populated at load and never re-evaluated

The second is very plausible given what I measured on #984 — the `missingNodesError` store is a load-time snapshot, and `collectMissingNodeTypeReasons` reads it. If that store is the source, refreshing definitions would never clear it no matter how well rehydration worked.

- [ ] reproduce with a class that is genuinely absent, then registered
- [ ] establish which of the two is reporting stale — the placeholders or the store
- [ ] fix, or report `requires_reload` honestly if live rehydration is not safe
- [ ] codex review
- [ ] browser verification