### PR TITLE
fix(binding): a tab switch onto a MODIFIED workflow still refuses on a stale tag (#995)

### DIFF
--- a/browser_tests/unit/canvas-graph-divergence.test.mjs
+++ b/browser_tests/unit/canvas-graph-divergence.test.mjs
@@ -1373,6 +1373,11 @@ test("graphCommandBindingBar: reads get the reduced DISPATCH bar (they re-assert
     assert.deepEqual(graphCommandBindingBar(cmd), {
       includeBaselineReadGuard: false,
       requireDirtyMutationBinding: false,
+      // #995 — the opt-IN that lets a classified read past a STALE TAG on a canvas whose
+      // content equals the active workflow's own snapshot. Set here and nowhere else, so
+      // this list is the whole surface that can reach it; a fence call that omits it (or
+      // any future caller) gets no bypass.
+      staleTagReadBypass: true,
     });
   }
 });

--- a/browser_tests/unit/graph-binding.test.mjs
+++ b/browser_tests/unit/graph-binding.test.mjs
@@ -37,6 +37,8 @@ import {
   resolveGraphRootUuidRebind,
   sealProvenRootBinding,
   rootContentProvesActiveWorkflow,
+  rootContentProvesActiveWorkflowDespiteEdits,
+  contentProofExclusiveAmongOpen,
   serializedStateProvenEmpty,
 } from "../../web/js/lib/graph-binding.js";
 import {
@@ -277,6 +279,8 @@ function buildDirtyStaleRouteHarness({
     "postReconnectSettleWindow",
     "sealProvenRootBinding",
     "rootContentProvesActiveWorkflow",
+    "rootContentProvesActiveWorkflowDespiteEdits",
+    "contentProofExclusiveAmongOpen",
     "graphRootMatchesState",
     "sameWorkflowObject",
     "app",
@@ -300,6 +304,8 @@ function buildDirtyStaleRouteHarness({
     () => postReconnectWindow === true,
     sealProvenRootBinding,
     rootContentProvesActiveWorkflow,
+    rootContentProvesActiveWorkflowDespiteEdits,
+    contentProofExclusiveAmongOpen,
     graphRootMatchesState,
     sameWorkflowObject,
     { graph: rootB, extensionManager: { workflow: { openWorkflows } } },

--- a/browser_tests/unit/stale-tag-dirty-tab.test.mjs
+++ b/browser_tests/unit/stale-tag-dirty-tab.test.mjs
@@ -199,7 +199,7 @@ test("#995 (codex P1) source guard: READS only, and NOTHING is written", () => {
   // onto the OTHER workflow and the wedge would follow the user back to it. So the flag
   // is cleared for one call and the tag is left alone.
   const src = readFileSync(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8");
-  const escape = src.slice(src.indexOf("if (rootUuidMismatch && requireDirtyMutationBinding !== true)"));
+  const escape = src.slice(src.indexOf("if (rootUuidMismatch && staleTagReadBypass === true)"));
   assert.ok(escape, "the escape must be gated on the command being read-only");
   const body = escape.slice(0, escape.indexOf("\n  }"));
   assert.match(body, /rootContentProvesActiveWorkflowDespiteEdits\(\{/, "it uses the relaxed proof");
@@ -212,24 +212,31 @@ test("#995 (codex P1) source guard: READS only, and NOTHING is written", () => {
   assert.match(body, /if \(Array\.isArray\(open\)\) others = open\.filter/, "only a readable list is used");
   // The REBIND path keeps the clean-only proof: it re-stamps, which this evidence
   // cannot license.
-  const rebind = src.slice(src.indexOf("resolveGraphRootUuidRebind({"), src.indexOf("if (rootUuidMismatch && requireDirtyMutationBinding"));
+  const rebind = src.slice(src.indexOf("resolveGraphRootUuidRebind({"), src.indexOf("if (rootUuidMismatch && staleTagReadBypass"));
   assert.ok(!/DespiteEdits/.test(rebind), "the re-stamp must not run on dirty-tab evidence");
 });
 
-test("#995 (codex P1) a MUTATION is still refused on the same evidence", () => {
-  // The read escape is gated on requireDirtyMutationBinding !== true. A mutation on a
-  // canvas whose identity is unproven is exactly what the fence exists to refuse, and
-  // dirty-tab content equality cannot license one: the content may be another tab's
-  // matching graph, and a write would land on it.
+test("#995 (codex r2) the bypass is OPT-IN, never inferred from the absence of a flag", () => {
+  // `requireDirtyMutationBinding !== true` was default-permit: a caller that omits the
+  // flag, or any fence call added later without the classification, would have inherited
+  // a bypass nobody decided to give it. The gate is now positive, set in exactly one
+  // place, so the read-only command list is the whole surface that can reach it.
   const src = readFileSync(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8");
   assert.ok(
-    src.includes("if (rootUuidMismatch && requireDirtyMutationBinding !== true) {"),
-    "mutations never reach the relaxed proof",
+    src.includes("if (rootUuidMismatch && staleTagReadBypass === true) {"),
+    "the bypass is opt-IN",
   );
-  // …and the bar itself still separates the two: a mutating command asks for
-  // requireDirtyMutationBinding true, so the escape above is unreachable for it.
-  assert.equal(graphCommandBindingBar("graph_outline").requireDirtyMutationBinding, false);
-  assert.equal(graphCommandBindingBar("graph_add_node").requireDirtyMutationBinding, true);
+  assert.ok(
+    !src.includes("rootUuidMismatch && requireDirtyMutationBinding !== true"),
+    "a default-permit gate must not come back",
+  );
+  assert.match(src, /staleTagReadBypass = false,/, "and it defaults to OFF at the fence");
+  assert.equal(graphCommandBindingBar("graph_outline").staleTagReadBypass, true, "a read opts in");
+  assert.equal(graphCommandBindingBar("graph_add_node").staleTagReadBypass, undefined, "a mutation never does");
+  // The bar is the ONLY place that sets it, so a new fence call cannot acquire it by
+  // accident — it has to be classified read-only first.
+  const lib = readFileSync(new URL("../../web/js/lib/graph-binding.js", import.meta.url), "utf8");
+  assert.equal((lib.match(/staleTagReadBypass: true/g) ?? []).length, 1, "set in exactly one place");
 });
 
 test("#995 the SEAL path is untouched — writing a tag is a different decision from re-stamping one", () => {

--- a/browser_tests/unit/stale-tag-dirty-tab.test.mjs
+++ b/browser_tests/unit/stale-tag-dirty-tab.test.mjs
@@ -39,6 +39,7 @@ import {
   rootContentProvesActiveWorkflowDespiteEdits,
   rootContentProvesActiveWorkflow,
   resolveGraphRootUuidRebind,
+  graphCommandBindingBar,
 } from "../../web/js/lib/graph-binding.js";
 
 const STALE = "aaaaaaaa-1111-4111-8111-111111111111";
@@ -79,11 +80,14 @@ test("#995 the reported state: a MODIFIED tab whose canvas is provably its own",
     activeWorkflow: active,
     proofExclusive: contentProofExclusiveAmongOpen({ rootGraph: root, others: [] }),
   });
-  assert.equal(proof, true, "…and the relaxed one proves it, because the content matches");
+  assert.equal(proof, true, "…and the relaxed one proves the content matches");
+  // What that licenses is a READ, not a rebind: the panel clears the mismatch for the
+  // call and leaves the tag alone. Feeding this proof to the REBIND resolver — which
+  // re-stamps — is exactly the P1 the review caught, so the panel does not do it.
   assert.equal(
-    resolveGraphRootUuidRebind({ rootGraph: root, activeWorkflowUuid: ACTIVE, contentProvesActiveWorkflow: proof }),
-    "rebind",
-    "so the stale tag is re-stamped instead of wedging every graph tool",
+    resolveGraphRootUuidRebind({ rootGraph: root, activeWorkflowUuid: ACTIVE, contentProvesActiveWorkflow: false }),
+    "conflict",
+    "the re-stamp path is not reached on dirty-tab evidence",
   );
 });
 
@@ -188,15 +192,44 @@ test("#995 exclusivity is REQUIRED — the proof never fires on its own", () => 
   );
 });
 
-test("#995 source guard: the panel tries the relaxed proof only after the clean one, with the strict list", () => {
+test("#995 (codex P1) source guard: READS only, and NOTHING is written", () => {
+  // Equality against a dirty tab's snapshot cannot establish whose canvas this is — two
+  // tabs can hold the same content, the snapshot can lag, and the owner may not be in
+  // `openWorkflows` at that instant. Re-stamping on that evidence would move the error
+  // onto the OTHER workflow and the wedge would follow the user back to it. So the flag
+  // is cleared for one call and the tag is left alone.
   const src = readFileSync(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8");
-  assert.match(src, /if \(!contentProvesActiveWorkflow\) \{/, "the clean proof is still tried first");
-  assert.match(src, /rootContentProvesActiveWorkflowDespiteEdits\(\{/, "and the relaxed one only after it");
-  assert.match(src, /proofExclusive: contentProofExclusiveAmongOpen\(\{ rootGraph, others \}\)/, "with the STRICT exclusivity");
+  const escape = src.slice(src.indexOf("if (rootUuidMismatch && requireDirtyMutationBinding !== true)"));
+  assert.ok(escape, "the escape must be gated on the command being read-only");
+  const body = escape.slice(0, escape.indexOf("\n  }"));
+  assert.match(body, /rootContentProvesActiveWorkflowDespiteEdits\(\{/, "it uses the relaxed proof");
+  assert.match(body, /proofExclusive: contentProofExclusiveAmongOpen\(\{ rootGraph, others \}\)/, "with STRICT exclusivity");
+  assert.match(body, /rootUuidMismatch = false; \/\/ this call only/, "and clears the flag for this call");
+  assert.ok(!/stampGraphRootWorkflowUuid/.test(body), "it must NOT write the tag — that is the P1 hole");
   // `others` must stay null when the tab list cannot be read: an empty array would read
   // as "no other tabs" and make exclusivity vacuously true.
-  assert.match(src, /let others = null;/, "unreadable enumeration must not become an empty list");
-  assert.match(src, /if \(Array\.isArray\(open\)\) others = open\.filter/, "only a readable list is used");
+  assert.match(body, /let others = null;/, "unreadable enumeration must not become an empty list");
+  assert.match(body, /if \(Array\.isArray\(open\)\) others = open\.filter/, "only a readable list is used");
+  // The REBIND path keeps the clean-only proof: it re-stamps, which this evidence
+  // cannot license.
+  const rebind = src.slice(src.indexOf("resolveGraphRootUuidRebind({"), src.indexOf("if (rootUuidMismatch && requireDirtyMutationBinding"));
+  assert.ok(!/DespiteEdits/.test(rebind), "the re-stamp must not run on dirty-tab evidence");
+});
+
+test("#995 (codex P1) a MUTATION is still refused on the same evidence", () => {
+  // The read escape is gated on requireDirtyMutationBinding !== true. A mutation on a
+  // canvas whose identity is unproven is exactly what the fence exists to refuse, and
+  // dirty-tab content equality cannot license one: the content may be another tab's
+  // matching graph, and a write would land on it.
+  const src = readFileSync(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8");
+  assert.ok(
+    src.includes("if (rootUuidMismatch && requireDirtyMutationBinding !== true) {"),
+    "mutations never reach the relaxed proof",
+  );
+  // …and the bar itself still separates the two: a mutating command asks for
+  // requireDirtyMutationBinding true, so the escape above is unreachable for it.
+  assert.equal(graphCommandBindingBar("graph_outline").requireDirtyMutationBinding, false);
+  assert.equal(graphCommandBindingBar("graph_add_node").requireDirtyMutationBinding, true);
 });
 
 test("#995 the SEAL path is untouched — writing a tag is a different decision from re-stamping one", () => {

--- a/browser_tests/unit/stale-tag-dirty-tab.test.mjs
+++ b/browser_tests/unit/stale-tag-dirty-tab.test.mjs
@@ -1,0 +1,210 @@
+/**
+ * #995 — after a tab switch (or a reconnect in the same interval) the live canvas keeps
+ * the PREVIOUS workflow's identity tag, and `panel_graph_outline` refuses the active
+ * canvas with `[root-workflow-uuid-mismatch]` while `panel_list_workflows` independently
+ * confirms the intended workflow active.
+ *
+ * The reporter concluded it was already fixed upstream by #817/#843, which added
+ * `contentProvesActiveWorkflow` to `resolveGraphRootUuidRebind`. Re-running those
+ * predicates under BOTH halves of their own stated conditions on 0.11.96:
+ *
+ *   dirty=false   contentProof=true    verdict=rebind      <- the escape they credit
+ *   dirty=true    contentProof=false   verdict=conflict    <- the state they reported
+ *
+ * Their report says "The active workflow was modified", and
+ * `rootContentProvesActiveWorkflow` bails on `isModified === true`.
+ *
+ * REPRODUCED LIVE through UI clicks on ComfyUI 0.31.1 / frontend 1.48.7 — a modified
+ * workflow, a canvas the panel's own comparison proves is that workflow's, and the
+ * previous workflow's tag still on the root:
+ *
+ *   active workflow                             probe995.json, isModified true
+ *   root tag                                    e66e531b…  (another workflow's)
+ *   graphRootWorkflowUuidMismatches             true
+ *   rootContentProvesActiveWorkflow             false      <- only the dirty bail
+ *   graphRootMatchesState(root, tracker state)  TRUE
+ *   resolveGraphRootUuidRebind                  "conflict" -> every graph tool refused
+ *
+ * The clean-tab requirement exists because a dirty tracker can LAG the canvas (#545) —
+ * but a lagging snapshot makes an equality test FAIL, not falsely succeed. What a dirty
+ * tab genuinely costs is the TWIN comparison, so the relaxed proof takes a stricter
+ * exclusivity where a dirty twin disqualifies instead of being skipped.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+import {
+  contentProofExclusiveAmongOpen,
+  rootContentProvesActiveWorkflowDespiteEdits,
+  rootContentProvesActiveWorkflow,
+  resolveGraphRootUuidRebind,
+} from "../../web/js/lib/graph-binding.js";
+
+const STALE = "aaaaaaaa-1111-4111-8111-111111111111";
+const ACTIVE = "6548a06c-8244-4523-b44c-d03d505d04e7";
+
+const state = (n, tweak = {}) => ({
+  nodes: Array.from({ length: n }, (_, i) => ({ id: i + 1, type: "KSampler", pos: [0, 0], size: [200, 100] })),
+  links: [],
+  groups: [],
+  config: {},
+  extra: {},
+  ...tweak,
+});
+/** A root that serialises to `s`, carrying the PREVIOUS workflow's tag. */
+const rootOf = (s, tag = STALE) => ({
+  _nodes: s.nodes,
+  extra: { comfyui_mcp: { workflow_uuid: tag } },
+  serialize: () => ({ ...s, extra: { ...(s.extra ?? {}), comfyui_mcp: { workflow_uuid: tag } } }),
+});
+const workflow = (s, { modified = true } = {}) => ({
+  isModified: modified,
+  changeTracker: { activeState: s },
+});
+
+test("#995 the reported state: a MODIFIED tab whose canvas is provably its own", () => {
+  const s = state(3);
+  const root = rootOf(s);
+  const active = workflow(s, { modified: true });
+  // What ships today, and why the report was not fixed by #817/#843.
+  assert.equal(
+    rootContentProvesActiveWorkflow({ rootGraph: root, activeWorkflow: active, proofExclusive: true }),
+    false,
+    "the clean-only proof refuses a dirty tab",
+  );
+  // The relaxed proof, with the stricter exclusivity satisfied (no other tabs open).
+  const proof = rootContentProvesActiveWorkflowDespiteEdits({
+    rootGraph: root,
+    activeWorkflow: active,
+    proofExclusive: contentProofExclusiveAmongOpen({ rootGraph: root, others: [] }),
+  });
+  assert.equal(proof, true, "…and the relaxed one proves it, because the content matches");
+  assert.equal(
+    resolveGraphRootUuidRebind({ rootGraph: root, activeWorkflowUuid: ACTIVE, contentProvesActiveWorkflow: proof }),
+    "rebind",
+    "so the stale tag is re-stamped instead of wedging every graph tool",
+  );
+});
+
+test("#995 a canvas that is NOT the active workflow's stays refused", () => {
+  // The fence's whole job. A root holding different content must never be proven,
+  // however dirty or clean anything is.
+  const root = rootOf(state(5));
+  const active = workflow(state(3));
+  assert.equal(
+    rootContentProvesActiveWorkflowDespiteEdits({ rootGraph: root, activeWorkflow: active, proofExclusive: true }),
+    false,
+  );
+  assert.equal(
+    resolveGraphRootUuidRebind({ rootGraph: root, activeWorkflowUuid: ACTIVE, contentProvesActiveWorkflow: false }),
+    "conflict",
+  );
+});
+
+test("#995 a DIRTY TWIN disqualifies the proof — it cannot be skipped as it is for a clean tab", () => {
+  // The ordinary exclusivity check skips a dirty twin ("unprovable, not evidence of
+  // ambiguity"), which is safe only while the ACTIVE side must be clean. With both sides
+  // possibly dirty, a twin holding the same content would be invisible and the panel
+  // could re-stamp the active identity onto the TWIN's canvas — wedging that tab.
+  const s = state(3);
+  const root = rootOf(s);
+  const dirtyTwin = workflow(s, { modified: true });
+  assert.equal(
+    contentProofExclusiveAmongOpen({ rootGraph: root, others: [dirtyTwin] }),
+    false,
+    "a modified other tab makes exclusivity unprovable",
+  );
+  // A CLEAN twin with different content is fine; a clean twin with the SAME content is not.
+  assert.equal(contentProofExclusiveAmongOpen({ rootGraph: root, others: [workflow(state(9), { modified: false })] }), true);
+  assert.equal(contentProofExclusiveAmongOpen({ rootGraph: root, others: [workflow(s, { modified: false })] }), false);
+});
+
+test("#995 an unreadable or absent tab list is NOT exclusivity", () => {
+  const root = rootOf(state(3));
+  for (const others of [null, undefined, "nope", 42, {}]) {
+    assert.equal(contentProofExclusiveAmongOpen({ rootGraph: root, others }), false, JSON.stringify(others) ?? "undefined");
+  }
+  // A tab whose own state cannot be read proves nothing either.
+  assert.equal(contentProofExclusiveAmongOpen({ rootGraph: root, others: [{ isModified: false }] }), false);
+  assert.equal(contentProofExclusiveAmongOpen({ rootGraph: root, others: [null] }), false);
+});
+
+test("#995 (the #565 gate) an EMPTY canvas can never prove itself, however it is compared", () => {
+  // Every blank graph serialises alike, so equality says nothing about WHOSE canvas this
+  // is — a dirty blank twin is exactly as plausible an owner, and re-stamping would wedge
+  // that tab. Caught by the existing gate, not by reasoning about it.
+  const empty = state(0);
+  const root = rootOf(empty);
+  assert.equal(
+    rootContentProvesActiveWorkflowDespiteEdits({
+      rootGraph: root,
+      activeWorkflow: workflow(empty),
+      proofExclusive: contentProofExclusiveAmongOpen({ rootGraph: root, others: [] }),
+    }),
+    false,
+    "an empty root is not identified by being empty",
+  );
+});
+
+test("#995 a SUBGRAPH scope is never proven — the root canvas is a different question", () => {
+  const s = state(3);
+  assert.equal(
+    rootContentProvesActiveWorkflowDespiteEdits({
+      rootGraph: rootOf(s),
+      activeWorkflow: workflow(s),
+      inSubgraph: true,
+      proofExclusive: true,
+    }),
+    false,
+  );
+});
+
+test("#995 the relaxed proof is total — hostile inputs answer false, never throw", () => {
+  const s = state(2);
+  const hostile = {
+    get serialize() {
+      throw new Error("boom");
+    },
+  };
+  assert.doesNotThrow(() => rootContentProvesActiveWorkflowDespiteEdits({ rootGraph: hostile, activeWorkflow: workflow(s), proofExclusive: true }));
+  assert.equal(rootContentProvesActiveWorkflowDespiteEdits({ rootGraph: hostile, activeWorkflow: workflow(s), proofExclusive: true }), false);
+  assert.equal(rootContentProvesActiveWorkflowDespiteEdits(), false);
+  assert.equal(rootContentProvesActiveWorkflowDespiteEdits({ rootGraph: rootOf(s), activeWorkflow: null, proofExclusive: true }), false);
+  assert.equal(
+    rootContentProvesActiveWorkflowDespiteEdits({ rootGraph: rootOf(s), activeWorkflow: { isModified: true }, proofExclusive: true }),
+    false,
+    "a workflow with no readable tracker state proves nothing",
+  );
+  assert.doesNotThrow(() => contentProofExclusiveAmongOpen({ rootGraph: rootOf(s), others: [hostile] }));
+  assert.equal(contentProofExclusiveAmongOpen(), false);
+});
+
+test("#995 exclusivity is REQUIRED — the proof never fires on its own", () => {
+  const s = state(3);
+  assert.equal(
+    rootContentProvesActiveWorkflowDespiteEdits({ rootGraph: rootOf(s), activeWorkflow: workflow(s), proofExclusive: false }),
+    false,
+  );
+});
+
+test("#995 source guard: the panel tries the relaxed proof only after the clean one, with the strict list", () => {
+  const src = readFileSync(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8");
+  assert.match(src, /if \(!contentProvesActiveWorkflow\) \{/, "the clean proof is still tried first");
+  assert.match(src, /rootContentProvesActiveWorkflowDespiteEdits\(\{/, "and the relaxed one only after it");
+  assert.match(src, /proofExclusive: contentProofExclusiveAmongOpen\(\{ rootGraph, others \}\)/, "with the STRICT exclusivity");
+  // `others` must stay null when the tab list cannot be read: an empty array would read
+  // as "no other tabs" and make exclusivity vacuously true.
+  assert.match(src, /let others = null;/, "unreadable enumeration must not become an empty list");
+  assert.match(src, /if \(Array\.isArray\(open\)\) others = open\.filter/, "only a readable list is used");
+});
+
+test("#995 the SEAL path is untouched — writing a tag is a different decision from re-stamping one", () => {
+  const src = readFileSync(new URL("../../web/js/lib/graph-binding.js", import.meta.url), "utf8");
+  const seal = src.slice(src.indexOf("export function sealProvenRootBinding"));
+  assert.match(seal, /rootContentProvesActiveWorkflow\(\{ rootGraph, activeWorkflow, inSubgraph, proofExclusive \}\)/);
+  assert.ok(
+    !/rootContentProvesActiveWorkflowDespiteEdits/.test(seal),
+    "the seal must keep the clean-only bar: it writes onto an UNTAGGED root",
+  );
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -396,6 +396,8 @@ import {
   sealProvenRootBinding,
   emptyCanvasBindingProven,
   rootContentProvesActiveWorkflow,
+  rootContentProvesActiveWorkflowDespiteEdits,
+  contentProofExclusiveAmongOpen,
 } from "./lib/graph-binding.js";
 import { summarizePromptRejection, buildQueueAcceptResult } from "./lib/queue-rejection.js";
 import { createRunFetchInterceptor, dispatchScopedRun } from "./lib/run-scope-guard.js";
@@ -5770,12 +5772,38 @@ function assertGraphBoundToActiveWorkflow(
     // app.graph, so a canvas that IS the active workflow's was refused where an
     // untagged copy of it was allowed, and nothing self-healed it: the seal below
     // declines a root that already carries a tag. Same proof the seal accepts.
-    const contentProvesActiveWorkflow = rootContentProvesActiveWorkflow({
+    let contentProvesActiveWorkflow = rootContentProvesActiveWorkflow({
       rootGraph,
       activeWorkflow,
       inSubgraph,
       proofExclusive: sealProofExclusive,
     });
+    // #995 — the same escape for a tab with UNSAVED EDITS. MEASURED live, reproducing
+    // the report through UI clicks: a modified workflow, a root the panel's own
+    // comparison proves is that workflow's canvas, and the PREVIOUS workflow's tag still
+    // on it — verdict "conflict", every graph tool refused. The clean-tab requirement is
+    // there because a lagging tracker cannot describe the canvas, but a lagging snapshot
+    // makes an equality test FAIL rather than falsely succeed. What a dirty tab really
+    // costs is the twin comparison, so this takes a STRICTER exclusivity: every other
+    // open workflow must be readable and provably different, and any one of them being
+    // modified makes it unprovable. Only then may a dirty tab's content speak.
+    if (!contentProvesActiveWorkflow) {
+      let others = null;
+      try {
+        const open = app?.extensionManager?.workflow?.openWorkflows;
+        // Unreadable enumeration → `others` stays null → the proof refuses. Never an
+        // empty list by default: "no other tabs" and "could not look" are different.
+        if (Array.isArray(open)) others = open.filter((w) => !sameWorkflowObject(w, activeWorkflow));
+      } catch {
+        others = null;
+      }
+      contentProvesActiveWorkflow = rootContentProvesActiveWorkflowDespiteEdits({
+        rootGraph,
+        activeWorkflow,
+        inSubgraph,
+        proofExclusive: contentProofExclusiveAmongOpen({ rootGraph, others }),
+      });
+    }
     if (
       resolveGraphRootUuidRebind({
         rootGraph,

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -5772,38 +5772,12 @@ function assertGraphBoundToActiveWorkflow(
     // app.graph, so a canvas that IS the active workflow's was refused where an
     // untagged copy of it was allowed, and nothing self-healed it: the seal below
     // declines a root that already carries a tag. Same proof the seal accepts.
-    let contentProvesActiveWorkflow = rootContentProvesActiveWorkflow({
+    const contentProvesActiveWorkflow = rootContentProvesActiveWorkflow({
       rootGraph,
       activeWorkflow,
       inSubgraph,
       proofExclusive: sealProofExclusive,
     });
-    // #995 — the same escape for a tab with UNSAVED EDITS. MEASURED live, reproducing
-    // the report through UI clicks: a modified workflow, a root the panel's own
-    // comparison proves is that workflow's canvas, and the PREVIOUS workflow's tag still
-    // on it — verdict "conflict", every graph tool refused. The clean-tab requirement is
-    // there because a lagging tracker cannot describe the canvas, but a lagging snapshot
-    // makes an equality test FAIL rather than falsely succeed. What a dirty tab really
-    // costs is the twin comparison, so this takes a STRICTER exclusivity: every other
-    // open workflow must be readable and provably different, and any one of them being
-    // modified makes it unprovable. Only then may a dirty tab's content speak.
-    if (!contentProvesActiveWorkflow) {
-      let others = null;
-      try {
-        const open = app?.extensionManager?.workflow?.openWorkflows;
-        // Unreadable enumeration → `others` stays null → the proof refuses. Never an
-        // empty list by default: "no other tabs" and "could not look" are different.
-        if (Array.isArray(open)) others = open.filter((w) => !sameWorkflowObject(w, activeWorkflow));
-      } catch {
-        others = null;
-      }
-      contentProvesActiveWorkflow = rootContentProvesActiveWorkflowDespiteEdits({
-        rootGraph,
-        activeWorkflow,
-        inSubgraph,
-        proofExclusive: contentProofExclusiveAmongOpen({ rootGraph, others }),
-      });
-    }
     if (
       resolveGraphRootUuidRebind({
         rootGraph,
@@ -5818,6 +5792,45 @@ function assertGraphBoundToActiveWorkflow(
         rootUuidMismatch = false;
       } catch {
         // A root that refuses the re-stamp stays mismatched and throws below.
+      }
+    }
+    // #995 — A READ, AND ONLY A READ, may proceed on a stale tag when the root's content
+    // equals the active workflow's own current state. MEASURED live through UI clicks: a
+    // MODIFIED workflow, a canvas the panel's own comparison proves matches it, the
+    // previous workflow's tag still on the root — and every graph tool refused, including
+    // panel_graph_outline.
+    //
+    // NOT a rebind, and the distinction is the whole safety argument (codex). Equality
+    // against a DIRTY tab's tracker snapshot cannot establish whose canvas this is: two
+    // tabs can hold the same content, the snapshot can lag, and the owner may not even be
+    // in `openWorkflows` at this instant (mid-switch, background load, a closed tab's
+    // canvas still mounted). Re-stamping on that would move the error onto the OTHER
+    // workflow — its canvas would carry this identity, and the wedge would follow the user
+    // when they switched back. So nothing is written: the flag is cleared for THIS call.
+    //
+    // What a read can then return is content EQUAL to what the active workflow's own
+    // tracker reports for it. If the snapshot lags, that is stale-but-its-own content —
+    // the lag the read path already tolerates by design (#545) — never a different
+    // workflow's different content, because unequal content fails the proof outright.
+    if (rootUuidMismatch && requireDirtyMutationBinding !== true) {
+      let others = null;
+      try {
+        const open = app?.extensionManager?.workflow?.openWorkflows;
+        // Unreadable enumeration → `others` stays null → the proof refuses. Never an
+        // empty list by default: "no other tabs" and "could not look" are different.
+        if (Array.isArray(open)) others = open.filter((w) => !sameWorkflowObject(w, activeWorkflow));
+      } catch {
+        others = null;
+      }
+      if (
+        rootContentProvesActiveWorkflowDespiteEdits({
+          rootGraph,
+          activeWorkflow,
+          inSubgraph,
+          proofExclusive: contentProofExclusiveAmongOpen({ rootGraph, others }),
+        })
+      ) {
+        rootUuidMismatch = false; // this call only — the tag on the root is left alone
       }
     }
   }

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -5667,7 +5667,14 @@ function kickPostReconnectSettleWatch(epoch) {
 function assertGraphBoundToActiveWorkflow(
   graph,
   rootGraph,
-  { includeBaselineReadGuard = true, requireDirtyMutationBinding = false } = {},
+  {
+    includeBaselineReadGuard = true,
+    requireDirtyMutationBinding = false,
+    // #995 — opt-IN, and false unless a caller classified this command as a read through
+    // `graphCommandBindingBar`. Gating the stale-tag bypass on the absence of the
+    // mutation flag would be default-permit (codex).
+    staleTagReadBypass = false,
+  } = {},
 ) {
   const liveNodeCount = rootGraph?._nodes?.length ?? 0;
   const inSubgraph = !!rootGraph && graph !== rootGraph;
@@ -5808,11 +5815,16 @@ function assertGraphBoundToActiveWorkflow(
     // workflow — its canvas would carry this identity, and the wedge would follow the user
     // when they switched back. So nothing is written: the flag is cleared for THIS call.
     //
-    // What a read can then return is content EQUAL to what the active workflow's own
-    // tracker reports for it. If the snapshot lags, that is stale-but-its-own content —
-    // the lag the read path already tolerates by design (#545) — never a different
-    // workflow's different content, because unequal content fails the proof outright.
-    if (rootUuidMismatch && requireDirtyMutationBinding !== true) {
+    // WHAT IS ESTABLISHED, exactly: serialized-content EQUALITY between the mounted root
+    // and the active workflow's tracker snapshot. NOT ownership (codex) — in the A/B
+    // sequence above the returned graph equals A's snapshot while being B's mounted
+    // canvas, and nothing here can tell those apart. What follows is only that a read
+    // returns content equal to what the active workflow itself reports, which is the bar
+    // the read path already works to (#545 exempts read-only tools from the proof
+    // requirement precisely so a lagging tracker cannot block inspection). Unequal
+    // content fails the proof outright, so no read can return a graph the active
+    // workflow's own snapshot disagrees with.
+    if (rootUuidMismatch && staleTagReadBypass === true) {
       let others = null;
       try {
         const open = app?.extensionManager?.workflow?.openWorkflows;

--- a/web/js/lib/graph-binding.js
+++ b/web/js/lib/graph-binding.js
@@ -1860,7 +1860,17 @@ export const MUTATION_BINDING_BAR = Object.freeze({
 export function graphCommandBindingBar(command) {
   return graphCommandMayMutateWorkflow(command)
     ? { ...MUTATION_BINDING_BAR }
-    : { includeBaselineReadGuard: false, requireDirtyMutationBinding: false };
+    : {
+        includeBaselineReadGuard: false,
+        requireDirtyMutationBinding: false,
+        // #995 — POSITIVE evidence that this call is a classified read, set in exactly
+        // one place. The stale-tag content bypass is gated on this rather than on
+        // `requireDirtyMutationBinding !== true`, which is default-permit: a caller that
+        // omits the flag, or a fence call added later without the classification, would
+        // have inherited a bypass nobody decided to give it (codex). Opting in here means
+        // the read list above is the whole surface that can reach it.
+        staleTagReadBypass: true,
+      };
 }
 
 /**

--- a/web/js/lib/graph-binding.js
+++ b/web/js/lib/graph-binding.js
@@ -1706,6 +1706,94 @@ export function rootContentProvesActiveWorkflow({
   }
 }
 
+/**
+ * EXCLUSIVITY for a content proof that has to hold even though the active tab has
+ * unsaved edits (#995).
+ *
+ * The ordinary exclusivity check SKIPS a dirty twin — "unprovable, not evidence of
+ * ambiguity" — which is right while the ACTIVE side must be clean, because a clean
+ * active workflow plus a dirty twin still leaves only one provable owner. Once the
+ * active side may itself be dirty, that skip becomes the hole: a dirty twin holding the
+ * same content would be invisible, and the panel could re-stamp the active identity onto
+ * a root that is the twin's canvas — wedging THAT tab the moment the user switched to it.
+ *
+ * So here a dirty twin is DISQUALIFYING rather than skippable. `others` is every OTHER
+ * open workflow; each must be readable and provably different from the root, and any one
+ * of them being modified (or unreadable) makes the whole thing unprovable.
+ */
+export function contentProofExclusiveAmongOpen({ rootGraph, others } = {}) {
+  try {
+    if (!rootGraph || !Array.isArray(others)) return false;
+    for (const other of others) {
+      if (!other || typeof other !== "object") return false; // unreadable — prove nothing
+      // A lagging tracker cannot establish that its canvas DIFFERS either, so a dirty
+      // twin is not "no evidence" here: it is missing evidence the proof requires.
+      if (other.isModified === true) return false;
+      const state = activeWorkflowCurrentState(other);
+      if (state == null) return false; // no readable state — same reason
+      if (graphRootMatchesState({ rootGraph, state })) return false; // a proven twin
+    }
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * #995 — the content proof, for a canvas whose tab has UNSAVED EDITS.
+ *
+ * MEASURED on ComfyUI 0.31.1 / frontend 1.48.7, reproducing the report through UI clicks:
+ * a modified workflow whose canvas the panel's own comparison proves is its own, and a
+ * root still carrying the PREVIOUS workflow's tag:
+ *
+ *   active workflow            probe995.json, isModified true
+ *   root tag                   e66e531b…  (another workflow's)
+ *   uuid mismatch              true
+ *   rootContentProvesActiveWorkflow   false   <- only because the tab is dirty
+ *   graphRootMatchesState(root, tracker state)   TRUE
+ *   rebind verdict             "conflict"      -> every graph tool refused
+ *
+ * The clean-tab requirement on the ordinary proof exists because a dirty tracker can LAG
+ * the canvas (#545). But a lagging snapshot makes an equality test FAIL, not falsely
+ * succeed — the failure mode it guards against is a false NEGATIVE. What a dirty tab
+ * genuinely costs is the twin comparison, which is why this takes its exclusivity from
+ * `contentProofExclusiveAmongOpen` instead, where a dirty twin disqualifies.
+ *
+ * Deliberately NOT used by `sealProvenRootBinding`. That path WRITES a tag onto an
+ * untagged root, and relaxing what may be written is a different decision from relaxing
+ * what may be re-stamped over a tag the panel itself minted.
+ */
+export function rootContentProvesActiveWorkflowDespiteEdits({
+  rootGraph,
+  activeWorkflow,
+  inSubgraph = false,
+  proofExclusive = false,
+} = {}) {
+  try {
+    if (inSubgraph) return false;
+    if (proofExclusive !== true) return false;
+    if (!rootGraph || !activeWorkflow) return false;
+    // AN EMPTY CANVAS CANNOT IDENTIFY ITSELF. Every blank graph serialises alike, so
+    // equality against a blank tracker state is not evidence about WHOSE canvas this is —
+    // a dirty blank twin is exactly as plausible an owner, and re-stamping would wedge
+    // THAT tab. The clean path guards this through `staleTagOnEmptyCanvas`, which demands
+    // both sides be provably empty AND the tab be clean; here the tab is dirty, so the
+    // only safe answer is to refuse. (Caught by the #565 gate, not by reasoning.)
+    // Both sides are tested, and neither can be killed alone by mutation: the proof only
+    // fires when the two are EQUAL, so an empty one implies an empty other and either
+    // check refuses. Removing BOTH does fail the suite. They are kept as two because they
+    // answer the question about different objects, and a later change to one side's
+    // emptiness rule must not silently remove the other's guarantee.
+    if (graphRootProvenEmpty(rootGraph)) return false;
+    const state = activeWorkflowCurrentState(activeWorkflow);
+    if (state == null) return false;
+    if (serializedStateProvenEmpty(state)) return false;
+    return graphRootMatchesState({ rootGraph, state });
+  } catch {
+    return false;
+  }
+}
+
 export function sealProvenRootBinding({
   rootGraph,
   activeWorkflow,


### PR DESCRIPTION
Claims #995. Draft opened before starting.

The report concludes it is already fixed upstream by #817/#843 (`contentProvesActiveWorkflow`
in `resolveGraphRootUuidRebind`). **Measured on current main, that is true for a clean tab
and false for the reported one.** The report's own state says "the active workflow was
modified":

```
dirty=false   contentProof=true    verdict=rebind      <- the fix they credit
dirty=true    contentProof=false   verdict=conflict    <- the reported state
```

`rootContentProvesActiveWorkflow` requires a CLEAN tab, so on a modified workflow the
escape never fires and `panel_graph_outline` is still refused with
`[root-workflow-uuid-mismatch]`.

Next step is to establish whether the clean-tab requirement can be narrowed without
weakening the fence — the concern behind it (#545) is that a dirty tracker can LAG the
canvas, and a lagging snapshot can only make an equality proof fail, not falsely succeed.
Whether that reasoning survives contact with the duplicate-content case is what has to be
measured before any code changes.