### PR TITLE
fix(set-widget): stop refusing a write for object_info that a reconnect never restored (#982)

### DIFF
--- a/browser_tests/unit/object-info-oracle.test.mjs
+++ b/browser_tests/unit/object-info-oracle.test.mjs
@@ -156,7 +156,11 @@ test("#982 (codex) the fallback is consulted ONLY when the client returned nothi
   // answer — so the fallback must never be able to override an answer the client gave.
   const src = readFileSync(new URL("../../web/js/lib/object-info-oracle.js", import.meta.url), "utf8");
   const clientBlock = src.slice(src.indexOf("if (typeof getNodeDefs === \"function\")"), src.indexOf("// SECOND TRANSPORT"));
-  assert.match(clientBlock, /if \(usableDefs\(defs\)\) return \{ defs, failures \};/, "a usable client answer returns");
+  assert.match(
+    clientBlock,
+    /if \(usableDefs\(defs\)\) return \{ \[CACHE_OUTCOME\]: true, defs, failures \};/,
+    "a usable client answer returns",
+  );
   // …and the measured equivalence is recorded rather than assumed.
   assert.match(src, /MEASURED on ComfyUI 0\.31\.1 \/ frontend 1\.48\.7/, "the comparison is on the record");
   assert.match(src, /That is\s*\n? \* evidence, not a contract/, "and its limit is stated");
@@ -259,4 +263,33 @@ test("#982 (codex r2) a value that cannot be stringified yields text, never a th
   assert.doesNotThrow(() => objectInfoOracleFailureNote([hostile]));
   assert.match(objectInfoOracleFailureNote([hostile]), /an unprintable value/);
   assert.doesNotThrow(() => objectInfoOracleFailureNote([Symbol("s")]));
+});
+
+test("#982 (codex r3) a node type literally named `defs` is not mistaken for an outcome wrapper", async () => {
+  // A structural `"defs" in value` test collided with a real schema key: a bare map
+  // containing a node type called `defs` would have been unwrapped, and that single
+  // definition would have become the cached schema. The tag is a Symbol, which JSON
+  // cannot carry, so only a deliberate producer can be read as a wrapper.
+  const { createObjectInfoCache, CACHE_OUTCOME } = await import("../../web/js/lib/object-info-cache.js");
+  const cache = createObjectInfoCache();
+  // The node named `defs` carries an EMPTY definition, which is what makes the two rules
+  // differ observably: a structural test would take `{}` as the payload, judge it
+  // unusable, and decline to cache a perfectly good schema — reinstating the full
+  // re-fetch per write that #716 exists to prevent.
+  const schemaWithDefsNode = { defs: {}, KSampler: { input: {} } };
+  let loads = 0;
+  const load = async () => {
+    loads += 1;
+    return schemaWithDefsNode;
+  };
+  assert.deepEqual(await cache.read(load), schemaWithDefsNode, "a bare schema comes back whole");
+  assert.deepEqual(await cache.read(load), schemaWithDefsNode);
+  assert.equal(loads, 1, "the second read was served from the cache — the schema WAS stored");
+  assert.equal(cache.peek().cached, true);
+
+  // A genuinely tagged outcome still unwraps.
+  const tagged = createObjectInfoCache();
+  const outcome = { [CACHE_OUTCOME]: true, defs: schemaWithDefsNode, failures: [] };
+  assert.deepEqual(await tagged.read(async () => outcome), outcome);
+  assert.equal(tagged.peek().cached, true);
 });

--- a/browser_tests/unit/object-info-oracle.test.mjs
+++ b/browser_tests/unit/object-info-oracle.test.mjs
@@ -134,3 +134,56 @@ test("#982 source guard: the refusal states an observation, and the panel wires 
   // The burst cache still wraps it: two transports must not become two fetches per write.
   assert.match(panel, /await objectInfoCache\.read\(async \(\) => \{/, "still read through the #716 cache");
 });
+
+test("#982 (codex) the fallback is consulted ONLY when the client returned nothing usable", () => {
+  // If `api.getNodeDefs()` ever narrows the schema, the raw route would be the broader
+  // answer — so the fallback must never be able to override an answer the client gave.
+  const src = readFileSync(new URL("../../web/js/lib/object-info-oracle.js", import.meta.url), "utf8");
+  const clientBlock = src.slice(src.indexOf("if (typeof getNodeDefs === \"function\")"), src.indexOf("// SECOND TRANSPORT"));
+  assert.match(clientBlock, /if \(usableDefs\(defs\)\) return \{ defs, failures \};/, "a usable client answer returns");
+  // …and the measured equivalence is recorded rather than assumed.
+  assert.match(src, /MEASURED on ComfyUI 0\.31\.1 \/ frontend 1\.48\.7/, "the comparison is on the record");
+  assert.match(src, /That is\s*\n? \* evidence, not a contract/, "and its limit is stated");
+});
+
+test("#982 (codex) untrusted failure text is flattened and capped", () => {
+  const nasty = "line one\nline two\r\nthird\u0007bell " + "x".repeat(500);
+  const note = objectInfoOracleFailureNote([nasty]);
+  assert.ok(!note.includes("\n") && !note.includes("\r"), "no newline can forge structure in the reply");
+  assert.ok(!/[\u0000-\u001f\u007f-\u009f]/.test(note), "no control characters survive");
+  assert.ok(note.length < 400, `capped, got ${note.length}`);
+  assert.match(note, /truncated/, "and the truncation is disclosed rather than silent");
+});
+
+test("#982 (codex) a thrown value's own words are flattened at the source", async () => {
+  const { failures } = await fetchWholeObjectInfo({
+    getNodeDefs: async () => {
+      throw new Error("first\nsecond\ttab");
+    },
+    fetchApi: null,
+  });
+  assert.equal(failures[0].includes("\n"), false);
+  assert.match(failures[0], /first second tab/);
+});
+
+test("#982 (codex) the observed failures are PER-REQUEST, not module state", () => {
+  // A concurrent refresh or a second widget write would otherwise overwrite the record
+  // between one request's failed fetch and its refusal, so the message would name routes
+  // another call tried. The variable lives in the handler's own scope.
+  const panel = readFileSync(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8");
+  const handler = panel.slice(panel.indexOf("async graph_set_widget({"));
+  const body = handler.slice(0, handler.indexOf("\n  async "));
+  assert.match(body, /let oracleFailures = \[\];/, "declared inside the handler");
+  assert.match(body, /oracleFailures = defs \? \[\] : failures;/, "written there");
+  assert.match(body, /objectInfoOracleFailureNote\(oracleFailures\)/, "and read there");
+  assert.ok(
+    !/lastObjectInfoOracleFailures/.test(panel),
+    "no module-scope record survives — that is the cross-request race",
+  );
+});
+
+test("#982 (codex) a control character cannot forge structure at either boundary", () => {
+  const nasty = "a\u0000b\u001fc\u007fd\u009fe";
+  assert.match(objectInfoOracleFailureNote([nasty]), /a b c d e/, "collapsed, not stripped into a run-on");
+  assert.ok(!/[\u0000-\u001f\u007f-\u009f]/.test(objectInfoOracleFailureNote([nasty])));
+});

--- a/browser_tests/unit/object-info-oracle.test.mjs
+++ b/browser_tests/unit/object-info-oracle.test.mjs
@@ -293,3 +293,12 @@ test("#982 (codex r3) a node type literally named `defs` is not mistaken for an 
   assert.deepEqual(await tagged.read(async () => outcome), outcome);
   assert.equal(tagged.peek().cached, true);
 });
+
+test("#982 (codex r4) blank entries: the slice-first order is documented, not accidental", () => {
+  // Slicing before sanitizing is what bounds the work, and for the inputs this module
+  // produces (every recorded attempt is non-empty) the two orders agree. They do NOT
+  // agree for arbitrary caller input, and this pins the behaviour that follows from the
+  // order actually chosen, so nobody reads the surviving mutant as "it makes no difference".
+  assert.equal(objectInfoOracleFailureNote(["", "", "", "", "x"]), "", "four blanks consume the window");
+  assert.match(objectInfoOracleFailureNote(["x", "", "", "", ""]), /Tried 5 routes: x \(and 1 more not shown\)\./);
+});

--- a/browser_tests/unit/object-info-oracle.test.mjs
+++ b/browser_tests/unit/object-info-oracle.test.mjs
@@ -1,0 +1,136 @@
+/**
+ * #982 — `panel_set_widget` refused a write with "object_info is unavailable — the
+ * backend is unreachable or the fetch failed" while the reporter's ComfyUI was healthy
+ * and `/object_info/VAELoader` answered on the same machine. Reads worked,
+ * `panel_set_workflow_target` reported bound, and `panel_refresh_nodes` answered
+ * `ok:true, refreshed:false`.
+ *
+ * Two separate problems in that one sentence:
+ *
+ *   1. ONE TRANSPORT — the oracle only ever asked `api.getNodeDefs()`, so a frontend
+ *      client that fails after a restart made a reachable backend read as unreachable.
+ *   2. A DISJUNCTION INSTEAD OF AN OBSERVATION — "unreachable or the fetch failed" names
+ *      two causes and establishes neither, and the first half is what sent the reporter
+ *      checking a backend that was fine.
+ *
+ * The oracle now asks the SAME question by a second route before giving up, and records
+ * what each attempt actually did so the refusal can say it. The per-class
+ * `/object_info/<Type>` route is deliberately NOT used as the fallback: `set_widget`
+ * authorizes two types for a promoted write and fetches before resolving which target it
+ * writes to, so a single-class payload answers one question and reads the other as absent
+ * (#716/#821). The fallback changes the transport, never the question.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+import { fetchWholeObjectInfo, objectInfoOracleFailureNote } from "../../web/js/lib/object-info-oracle.js";
+
+const SCHEMA = { KSampler: { input: {} }, VAELoader: { input: {} } };
+const okResponse = (body) => ({ ok: true, status: 200, json: async () => body });
+
+test("#982 the client route answers: the fallback is never reached", async () => {
+  let fetched = 0;
+  const { defs, failures } = await fetchWholeObjectInfo({
+    getNodeDefs: async () => SCHEMA,
+    fetchApi: async () => {
+      fetched += 1;
+      return okResponse(SCHEMA);
+    },
+  });
+  assert.deepEqual(defs, SCHEMA);
+  assert.deepEqual(failures, []);
+  assert.equal(fetched, 0, "a working first route must not cost a second request");
+});
+
+test("#982 the reported case: the client THROWS and the HTTP route answers", async () => {
+  const { defs, failures } = await fetchWholeObjectInfo({
+    getNodeDefs: async () => {
+      throw new Error("Failed to fetch");
+    },
+    fetchApi: async (route) => {
+      assert.equal(route, "/object_info", "the fallback asks the WHOLE schema, not one class");
+      return okResponse(SCHEMA);
+    },
+  });
+  assert.deepEqual(defs, SCHEMA, "a reachable backend is no longer read as unreachable");
+  assert.equal(failures.length, 1);
+  assert.match(failures[0], /api\.getNodeDefs\(\) threw: Failed to fetch/, "and what failed is recorded verbatim");
+});
+
+test("#982 an EMPTY payload from the client is a failure, not an answer", async () => {
+  // `{}` is an object, so a bare truthiness test would have accepted it and then reported
+  // every type as removed — a fabricated verdict from an unusable payload.
+  const { defs, failures } = await fetchWholeObjectInfo({
+    getNodeDefs: async () => ({}),
+    fetchApi: async () => okResponse(SCHEMA),
+  });
+  assert.deepEqual(defs, SCHEMA);
+  assert.match(failures[0], /returned no usable schema \(an empty object\)/);
+});
+
+test("#982 both routes failing yields NO defs and names both", async () => {
+  const { defs, failures } = await fetchWholeObjectInfo({
+    getNodeDefs: async () => null,
+    fetchApi: async () => ({ ok: false, status: 503 }),
+  });
+  assert.equal(defs, null, "fail closed — the fence refuses on a null payload");
+  assert.equal(failures.length, 2);
+  assert.match(failures[0], /api\.getNodeDefs\(\) returned no usable schema/);
+  assert.match(failures[1], /GET \/object_info was not OK \(status 503\)/);
+});
+
+test("#982 a missing capability is itself recorded, not silently skipped", async () => {
+  const noClient = await fetchWholeObjectInfo({ fetchApi: async () => okResponse(SCHEMA) });
+  assert.deepEqual(noClient.defs, SCHEMA);
+  assert.match(noClient.failures[0], /api\.getNodeDefs is not a function/);
+
+  const nothing = await fetchWholeObjectInfo({});
+  assert.equal(nothing.defs, null);
+  assert.equal(nothing.failures.length, 2, "both absences are named");
+  assert.match(nothing.failures[1], /no fetchApi is wired/);
+});
+
+test("#982 a body that will not parse is a failure, never a partial answer", async () => {
+  const { defs, failures } = await fetchWholeObjectInfo({
+    getNodeDefs: async () => null,
+    fetchApi: async () => ({
+      ok: true,
+      status: 200,
+      json: async () => {
+        throw new SyntaxError("Unexpected token < in JSON");
+      },
+    }),
+  });
+  assert.equal(defs, null);
+  assert.match(failures[1], /GET \/object_info threw: Unexpected token/);
+});
+
+test("#982 an ARRAY is not a schema", async () => {
+  const { defs } = await fetchWholeObjectInfo({ getNodeDefs: async () => [1, 2, 3], fetchApi: null });
+  assert.equal(defs, null, "a non-map payload cannot answer 'does the backend define this type'");
+});
+
+test("#982 the note lists what was tried, and says nothing when nothing was recorded", () => {
+  assert.equal(objectInfoOracleFailureNote([]), "", "a clean run adds no hollow clause");
+  assert.equal(objectInfoOracleFailureNote(null), "");
+  assert.equal(objectInfoOracleFailureNote(undefined), "");
+  const one = objectInfoOracleFailureNote(["api.getNodeDefs() threw: boom"]);
+  assert.match(one, /Tried one route: api\.getNodeDefs\(\) threw: boom\./);
+  const two = objectInfoOracleFailureNote(["a", "b"]);
+  assert.match(two, /Tried 2 routes: a; b\./);
+});
+
+test("#982 source guard: the refusal states an observation, and the panel wires both routes", () => {
+  const resolve = readFileSync(new URL("../../web/js/lib/node-resolve.js", import.meta.url), "utf8");
+  assert.match(resolve, /no usable \/object_info schema was obtained/, "what was observed");
+  assert.ok(
+    !/object_info is unavailable — the backend is unreachable or the fetch\s*\n?\s*\* *failed/.test(resolve),
+    "the disjunction that asserted an unreachable backend is gone from the set_widget refusal",
+  );
+  const panel = readFileSync(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8");
+  assert.match(panel, /fetchWholeObjectInfo\(\{/, "the panel asks through the two-transport oracle");
+  assert.match(panel, /describeObjectInfoFailure: \(\) => objectInfoOracleFailureNote/, "and can report what failed");
+  // The burst cache still wraps it: two transports must not become two fetches per write.
+  assert.match(panel, /await objectInfoCache\.read\(async \(\) => \{/, "still read through the #716 cache");
+});

--- a/browser_tests/unit/object-info-oracle.test.mjs
+++ b/browser_tests/unit/object-info-oracle.test.mjs
@@ -58,17 +58,33 @@ test("#982 the reported case: the client THROWS and the HTTP route answers", asy
   assert.match(failures[0], /api\.getNodeDefs\(\) threw: Failed to fetch/, "and what failed is recorded verbatim");
 });
 
-test("#982 an EMPTY payload from the client is a failure, not an answer", async () => {
-  // `{}` is an object, so a bare truthiness test would have accepted it and then reported
-  // every type as removed — a fabricated verdict from an unusable payload.
+test("#982 (codex r2) an EMPTY map from the client is its ANSWER — the fallback is not consulted", async () => {
+  // A client that deliberately filters could express deny-all as `{}`. Asking the raw
+  // route then would overrule it with a broader schema, which is the one direction this
+  // fallback must never move. `{}` therefore fails closed WITHOUT a second attempt.
+  let fetched = 0;
   const { defs, failures } = await fetchWholeObjectInfo({
     getNodeDefs: async () => ({}),
-    fetchApi: async () => okResponse(SCHEMA),
+    fetchApi: async () => {
+      fetched += 1;
+      return okResponse(SCHEMA);
+    },
   });
-  assert.deepEqual(defs, SCHEMA);
-  assert.match(failures[0], /returned no usable schema \(an empty object\)/);
+  assert.equal(defs, null, "fail closed on the answer the client gave");
+  assert.equal(fetched, 0, "the raw route is never asked to overrule it");
+  assert.match(failures[0], /EMPTY schema — treated as its answer, not as an absence/);
 });
 
+test("#982 a client that returned NOTHING leaves the question open, and the fallback answers", async () => {
+  for (const nothing of [null, undefined, "nope", 42]) {
+    const { defs, failures } = await fetchWholeObjectInfo({
+      getNodeDefs: async () => nothing,
+      fetchApi: async () => okResponse(SCHEMA),
+    });
+    assert.deepEqual(defs, SCHEMA, `client returned ${String(nothing)}`);
+    assert.match(failures[0], /returned no usable schema/);
+  }
+});
 test("#982 both routes failing yields NO defs and names both", async () => {
   const { defs, failures } = await fetchWholeObjectInfo({
     getNodeDefs: async () => null,
@@ -174,7 +190,7 @@ test("#982 (codex) the observed failures are PER-REQUEST, not module state", () 
   const handler = panel.slice(panel.indexOf("async graph_set_widget({"));
   const body = handler.slice(0, handler.indexOf("\n  async "));
   assert.match(body, /let oracleFailures = \[\];/, "declared inside the handler");
-  assert.match(body, /oracleFailures = defs \? \[\] : failures;/, "written there");
+  assert.match(body, /oracleFailures = defs \? \[\] : \(outcome\?\.failures \?\? \[\]\);/, "written there");
   assert.match(body, /objectInfoOracleFailureNote\(oracleFailures\)/, "and read there");
   assert.ok(
     !/lastObjectInfoOracleFailures/.test(panel),
@@ -186,4 +202,61 @@ test("#982 (codex) a control character cannot forge structure at either boundary
   const nasty = "a\u0000b\u001fc\u007fd\u009fe";
   assert.match(objectInfoOracleFailureNote([nasty]), /a b c d e/, "collapsed, not stripped into a run-on");
   assert.ok(!/[\u0000-\u001f\u007f-\u009f]/.test(objectInfoOracleFailureNote([nasty])));
+});
+
+test("#982 (codex r2) a JOINED read still learns which routes were tried", async () => {
+  // The burst cache coalesces concurrent reads: only the producer runs the loader. If the
+  // loader returned bare defs, a second widget write joining a FAILED read would refuse
+  // while naming no routes at all. The OUTCOME rides through the cache instead.
+  const { createObjectInfoCache } = await import("../../web/js/lib/object-info-cache.js");
+  const cache = createObjectInfoCache();
+  let loaderRuns = 0;
+  const load = async () => {
+    loaderRuns += 1;
+    await new Promise((r) => setTimeout(r, 5));
+    return fetchWholeObjectInfo({ getNodeDefs: async () => null, fetchApi: async () => ({ ok: false, status: 502 }) });
+  };
+  const [a, b] = await Promise.all([cache.read(load), cache.read(load)]);
+  assert.equal(loaderRuns, 1, "the second read joined the first");
+  for (const outcome of [a, b]) {
+    assert.equal(outcome.defs, null, "both fail closed");
+    assert.equal(outcome.failures.length, 2, "and both can name the routes");
+    assert.match(outcome.failures[1], /status 502/);
+  }
+  assert.equal(cache.peek().cached, false, "a failed outcome is never cached — the wrapper must not fool it");
+});
+
+test("#982 (codex r2) a SUCCESSFUL outcome still caches, and the payload is what gets stored", async () => {
+  const { createObjectInfoCache } = await import("../../web/js/lib/object-info-cache.js");
+  const cache = createObjectInfoCache();
+  let runs = 0;
+  const load = async () => {
+    runs += 1;
+    return fetchWholeObjectInfo({ getNodeDefs: async () => SCHEMA, fetchApi: null });
+  };
+  const first = await cache.read(load);
+  const second = await cache.read(load);
+  assert.equal(runs, 1, "the second read came from the cache");
+  assert.deepEqual(first.defs, SCHEMA);
+  assert.deepEqual(second.defs, SCHEMA);
+  assert.equal(cache.peek().cached, true);
+});
+
+test("#982 (codex r2) the note caps HOW MANY routes it names, and says how many it dropped", () => {
+  const many = Array.from({ length: 9 }, (_, i) => `route ${i} failed`);
+  const note = objectInfoOracleFailureNote(many);
+  assert.match(note, /Tried 9 routes/, "the count is honest");
+  assert.match(note, /and 5 more not shown/, "a truncated list must not read as the whole list");
+  assert.ok(note.length < 400, `bounded, got ${note.length}`);
+});
+
+test("#982 (codex r2) a value that cannot be stringified yields text, never a throw", () => {
+  const hostile = {
+    toString() {
+      throw new Error("nope");
+    },
+  };
+  assert.doesNotThrow(() => objectInfoOracleFailureNote([hostile]));
+  assert.match(objectInfoOracleFailureNote([hostile]), /an unprintable value/);
+  assert.doesNotThrow(() => objectInfoOracleFailureNote([Symbol("s")]));
 });

--- a/browser_tests/unit/set-widget-fresh-backend.test.mjs
+++ b/browser_tests/unit/set-widget-fresh-backend.test.mjs
@@ -295,7 +295,29 @@ test("#458 set_widget: backend UNREACHABLE (fresh object_info null) ⇒ FAIL CLO
     (err) =>
       err instanceof Error &&
       /Cannot set widget on node 3 \("KSampler"\)/.test(err.message) &&
-      /cannot verify node type|object_info is unavailable|backend is unreachable/i.test(err.message),
+      // #982 — the wording no longer asserts an unreachable backend, because the panel
+      // never established that: a reporter read exactly that sentence while their backend
+      // was answering /object_info by hand. What it claims now is only what it observed.
+      /no usable \/object_info schema was obtained/i.test(err.message) &&
+      !/backend is unreachable/i.test(err.message),
+  );
+  // …and when the oracle recorded WHAT it tried, the refusal carries it. Without this
+  // the whole point of the change — a reporter reading "unavailable" while their backend
+  // answered by hand — is unfixed even though the wording changed.
+  await assert.rejects(
+    () =>
+      runSetWidget(node, "steps", 30, {
+        registry: reg,
+        getRegistry: () => reg,
+        getFreshObjectInfo: async () => null,
+        describeObjectInfoFailure: () =>
+          " Tried 2 routes: api.getNodeDefs() threw: Failed to fetch; GET /object_info was not OK (status 503).",
+        ...HOOKS,
+      }),
+    (err) =>
+      err instanceof Error &&
+      /Tried 2 routes: api\.getNodeDefs\(\) threw: Failed to fetch/.test(err.message) &&
+      /status 503/.test(err.message),
   );
   assert.equal(node.widgets[0].value, 20, "value must NOT be mutated when the backend is unverifiable");
 });

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -175,6 +175,7 @@ import { makeRefreshCoalescer } from "./lib/refresh-coalesce.js";
 import { describeNodeDefRefresh } from "./lib/node-def-refresh.js";
 import { fetchNodeDefsWithRetry } from "./lib/object-info-retry.js";
 import { createObjectInfoCache } from "./lib/object-info-cache.js";
+import { fetchWholeObjectInfo, objectInfoOracleFailureNote } from "./lib/object-info-oracle.js";
 import { confirmCanvasNavigation } from "./lib/canvas-navigation.js";
 import { watchPostReconnectSettle, graphMutationReconnectGate } from "./lib/reconnect-recovery.js";
 import { reconcileCompletedDownloads } from "./lib/download-refresh.js";
@@ -668,6 +669,8 @@ const recordObjectInfoTypes = (defs) => objectInfoHistory.recordTypes(defs);
 const markObjectInfoHistorySeeded = () => objectInfoHistory.markSeeded();
 // #716 — one /object_info per BURST of widget writes, instead of one per write.
 const objectInfoCache = createObjectInfoCache();
+/** #982 — what the last /object_info oracle attempt observed, for the refusal text. */
+let lastObjectInfoOracleFailures = [];
 // Resolves once the STARTUP baseline seed attempt sequence has finished (success or all
 // retries exhausted). The graph tools AWAIT this (bounded) before authorizing.
 let objectInfoHistorySeed = Promise.resolve();
@@ -10285,16 +10288,30 @@ const GRAPH_TOOL_EXECUTORS = {
       getRegistry: () => LG?.registered_node_types ?? {},
       getFreshObjectInfo: async () =>
         recordObjectInfoTypes(
-          typeof api?.getNodeDefs === "function"
-            ? // #716 — READ THROUGH THE BURST CACHE. 29 widget writes meant 29 full
-              // /object_info downloads (5,413,770 bytes each on a 63-pack install, #767).
-              // Still the WHOLE payload, so no question this fence asks changes scope —
-              // only how often it is re-fetched. Dropped by anything that knows the schema
-              // moved. See lib/object-info-cache.js for why the per-class route #767 used
-              // for add_node is NOT safe here.
-              await objectInfoCache.read(() => api.getNodeDefs())
-            : null,
+          // #716 — READ THROUGH THE BURST CACHE. 29 widget writes meant 29 full
+          // /object_info downloads (5,413,770 bytes each on a 63-pack install, #767).
+          // Still the WHOLE payload, so no question this fence asks changes scope —
+          // only how often it is re-fetched. Dropped by anything that knows the schema
+          // moved. See lib/object-info-cache.js for why the per-class route #767 used
+          // for add_node is NOT safe here.
+          await objectInfoCache.read(async () => {
+            // #982 — TWO TRANSPORTS for the same question. The reporter's fence refused
+            // for "object_info is unavailable" while `/object_info/VAELoader` answered on
+            // the same machine, so the frontend client can fail where the HTTP route does
+            // not. Whatever each attempt actually did is recorded and reaches the refusal,
+            // because "unreachable or the fetch failed" named two causes and established
+            // neither.
+            const { defs, failures } = await fetchWholeObjectInfo({
+              getNodeDefs: typeof api?.getNodeDefs === "function" ? () => api.getNodeDefs() : null,
+              fetchApi: typeof api?.fetchApi === "function" ? (route) => api.fetchApi(route) : null,
+            });
+            lastObjectInfoOracleFailures = defs ? [] : failures;
+            return defs;
+          }),
         ),
+      // What the last oracle attempt observed, so a refusal can say which routes were
+      // tried and what each one did instead of asserting an unreachable backend.
+      describeObjectInfoFailure: () => objectInfoOracleFailureNote(lastObjectInfoOracleFailures),
       // #458 OBSERVED-BACKEND-HISTORY trust root: a type absent from the CURRENT
       // /object_info that the backend reported earlier this session is a REMOVED backend
       // node — refuse (non-forgeable; client shape/name/provenance can't prove this).

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -10289,29 +10289,33 @@ const GRAPH_TOOL_EXECUTORS = {
       // the stale LiteGraph registry, which keeps a positive for an uninstalled pack
       // after a restart-without-reload. Mirrors graph_add_node.
       getRegistry: () => LG?.registered_node_types ?? {},
-      getFreshObjectInfo: async () =>
-        recordObjectInfoTypes(
-          // #716 — READ THROUGH THE BURST CACHE. 29 widget writes meant 29 full
-          // /object_info downloads (5,413,770 bytes each on a 63-pack install, #767).
-          // Still the WHOLE payload, so no question this fence asks changes scope —
-          // only how often it is re-fetched. Dropped by anything that knows the schema
-          // moved. See lib/object-info-cache.js for why the per-class route #767 used
-          // for add_node is NOT safe here.
-          await objectInfoCache.read(async () => {
-            // #982 — TWO TRANSPORTS for the same question. The reporter's fence refused
-            // for "object_info is unavailable" while `/object_info/VAELoader` answered on
-            // the same machine, so the frontend client can fail where the HTTP route does
-            // not. Whatever each attempt actually did is recorded and reaches the refusal,
-            // because "unreachable or the fetch failed" named two causes and established
-            // neither.
-            const { defs, failures } = await fetchWholeObjectInfo({
-              getNodeDefs: typeof api?.getNodeDefs === "function" ? () => api.getNodeDefs() : null,
-              fetchApi: typeof api?.fetchApi === "function" ? (route) => api.fetchApi(route) : null,
-            });
-            oracleFailures = defs ? [] : failures;
-            return defs;
-          }),
-        ),
+      getFreshObjectInfo: async () => {
+        // #716 — READ THROUGH THE BURST CACHE. 29 widget writes meant 29 full
+        // /object_info downloads (5,413,770 bytes each on a 63-pack install, #767).
+        // Still the WHOLE payload, so no question this fence asks changes scope —
+        // only how often it is re-fetched. Dropped by anything that knows the schema
+        // moved. See lib/object-info-cache.js for why the per-class route #767 used
+        // for add_node is NOT safe here.
+        const outcome = await objectInfoCache.read(async () => {
+          // #982 — TWO TRANSPORTS for the same question. The reporter's fence refused
+          // for "object_info is unavailable" while `/object_info/VAELoader` answered on
+          // the same machine, so the frontend client can fail where the HTTP route does
+          // not. Whatever each attempt actually did is recorded and reaches the refusal,
+          // because "unreachable or the fetch failed" named two causes and established
+          // neither.
+          //
+          // The OUTCOME rides through the cache, not just the schema (codex): a second
+          // concurrent write JOINS this in-flight read and never runs its own loader, so
+          // returning bare defs would leave that caller's refusal naming no routes at all.
+          return fetchWholeObjectInfo({
+            getNodeDefs: typeof api?.getNodeDefs === "function" ? () => api.getNodeDefs() : null,
+            fetchApi: typeof api?.fetchApi === "function" ? (route) => api.fetchApi(route) : null,
+          });
+        });
+        const defs = outcome && typeof outcome === "object" && "defs" in outcome ? outcome.defs : outcome;
+        oracleFailures = defs ? [] : (outcome?.failures ?? []);
+        return recordObjectInfoTypes(defs);
+      },
       // What the last oracle attempt observed, so a refusal can say which routes were
       // tried and what each one did instead of asserting an unreachable backend.
       describeObjectInfoFailure: () => objectInfoOracleFailureNote(oracleFailures),

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -174,7 +174,7 @@ import { createObjectInfoHistory, awaitHistoryBaseline } from "./lib/object-info
 import { makeRefreshCoalescer } from "./lib/refresh-coalesce.js";
 import { describeNodeDefRefresh } from "./lib/node-def-refresh.js";
 import { fetchNodeDefsWithRetry } from "./lib/object-info-retry.js";
-import { createObjectInfoCache } from "./lib/object-info-cache.js";
+import { createObjectInfoCache, CACHE_OUTCOME } from "./lib/object-info-cache.js";
 import { fetchWholeObjectInfo, objectInfoOracleFailureNote } from "./lib/object-info-oracle.js";
 import { confirmCanvasNavigation } from "./lib/canvas-navigation.js";
 import { watchPostReconnectSettle, graphMutationReconnectGate } from "./lib/reconnect-recovery.js";
@@ -10312,7 +10312,7 @@ const GRAPH_TOOL_EXECUTORS = {
             fetchApi: typeof api?.fetchApi === "function" ? (route) => api.fetchApi(route) : null,
           });
         });
-        const defs = outcome && typeof outcome === "object" && "defs" in outcome ? outcome.defs : outcome;
+        const defs = outcome && typeof outcome === "object" && outcome[CACHE_OUTCOME] === true ? outcome.defs : outcome;
         oracleFailures = defs ? [] : (outcome?.failures ?? []);
         return recordObjectInfoTypes(defs);
       },

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -669,8 +669,6 @@ const recordObjectInfoTypes = (defs) => objectInfoHistory.recordTypes(defs);
 const markObjectInfoHistorySeeded = () => objectInfoHistory.markSeeded();
 // #716 — one /object_info per BURST of widget writes, instead of one per write.
 const objectInfoCache = createObjectInfoCache();
-/** #982 — what the last /object_info oracle attempt observed, for the refusal text. */
-let lastObjectInfoOracleFailures = [];
 // Resolves once the STARTUP baseline seed attempt sequence has finished (success or all
 // retries exhausted). The graph tools AWAIT this (bounded) before authorizing.
 let objectInfoHistorySeed = Promise.resolve();
@@ -10218,6 +10216,11 @@ const GRAPH_TOOL_EXECUTORS = {
   async graph_set_widget({ node_id, widget, value, workflow_uuid }) {
     const { app, graph, LG, rootGraph } = getGraphCtx();
     const node = resolveNode(graph, node_id);
+    // #982 — PER-REQUEST, not module state (codex). A concurrent refresh or a second
+    // widget write would otherwise overwrite this between one request's failed fetch and
+    // its refusal, so the message would name routes another call tried. Declared in the
+    // handler's own scope, so each invocation reports what IT observed.
+    let oracleFailures = [];
     // #314: the LTXDirector custom node owns its timeline widgets through an in-browser
     // TimelineEditor whose in-memory `this.timeline` is the source of truth. A raw widget
     // write "succeeds" (panel_query_graph shows it) but never reaches the editor/UI and is
@@ -10305,13 +10308,13 @@ const GRAPH_TOOL_EXECUTORS = {
               getNodeDefs: typeof api?.getNodeDefs === "function" ? () => api.getNodeDefs() : null,
               fetchApi: typeof api?.fetchApi === "function" ? (route) => api.fetchApi(route) : null,
             });
-            lastObjectInfoOracleFailures = defs ? [] : failures;
+            oracleFailures = defs ? [] : failures;
             return defs;
           }),
         ),
       // What the last oracle attempt observed, so a refusal can say which routes were
       // tried and what each one did instead of asserting an unreachable backend.
-      describeObjectInfoFailure: () => objectInfoOracleFailureNote(lastObjectInfoOracleFailures),
+      describeObjectInfoFailure: () => objectInfoOracleFailureNote(oracleFailures),
       // #458 OBSERVED-BACKEND-HISTORY trust root: a type absent from the CURRENT
       // /object_info that the backend reported earlier this session is a REMOVED backend
       // node — refuse (non-forgeable; client shape/name/provenance can't prove this).

--- a/web/js/lib/node-resolve.js
+++ b/web/js/lib/node-resolve.js
@@ -623,8 +623,10 @@ export function assertTypeAgainstFreshBackend(freshDefs, type, nodeId = "(unknow
       `Cannot set widget on node ${nodeId}${label}: cannot verify the node type against the ` +
         `ComfyUI backend — no usable /object_info schema was obtained.${observed} ` +
         `Refusing to write rather than trust a possibly-stale node cache (#458). ` +
-        `Reconnect ComfyUI and retry; if the backend answers /object_info by hand, the ` +
-        `routes named above are what the panel could not use (#982).`,
+        `Reconnect ComfyUI and retry. If /object_info answers when you run it by hand, ` +
+        `compare it with what each route above reported — one of them may have answered ` +
+        `without returning a usable schema, which is a different fault from an ` +
+        `unreachable backend (#982).`,
     );
   }
   if (!freshBackendDefinesType(freshDefs, type)) {

--- a/web/js/lib/node-resolve.js
+++ b/web/js/lib/node-resolve.js
@@ -605,14 +605,26 @@ export async function assertAddNodeResolvableRefreshing(getRegistry, class_type,
  * backend-only behaviour.
  */
 export function assertTypeAgainstFreshBackend(freshDefs, type, nodeId = "(unknown)", opts = {}) {
-  const { registry, node, wasTypeEverDefined } = opts;
+  const { registry, node, wasTypeEverDefined, describeObjectInfoFailure } = opts;
   const label = typeof type === "string" ? ` ("${type}")` : "";
   if (!freshDefs || typeof freshDefs !== "object") {
+    // #982 — SAY WHAT HAPPENED, not a disjunction. "the backend is unreachable or the
+    // fetch failed" names two causes and establishes neither, and the reporter went
+    // checking a backend that was answering `/object_info/VAELoader` perfectly well while
+    // reading this. When the oracle recorded what each route actually did, that is
+    // appended; when it recorded nothing, the sentence stays as it was.
+    let observed = "";
+    try {
+      observed = typeof describeObjectInfoFailure === "function" ? describeObjectInfoFailure() || "" : "";
+    } catch {
+      observed = ""; // a diagnostic must never replace the refusal it is describing
+    }
     throw new Error(
       `Cannot set widget on node ${nodeId}${label}: cannot verify the node type against the ` +
-        `ComfyUI backend (object_info is unavailable — the backend is unreachable or the fetch ` +
-        `failed). Refusing to write rather than trust a possibly-stale node cache (#458). ` +
-        `Reconnect ComfyUI and retry.`,
+        `ComfyUI backend — no usable /object_info schema was obtained.${observed} ` +
+        `Refusing to write rather than trust a possibly-stale node cache (#458). ` +
+        `Reconnect ComfyUI and retry; if the backend answers /object_info by hand, the ` +
+        `routes named above are what the panel could not use (#982).`,
     );
   }
   if (!freshBackendDefinesType(freshDefs, type)) {

--- a/web/js/lib/object-info-cache.js
+++ b/web/js/lib/object-info-cache.js
@@ -51,6 +51,17 @@
  * ≤1.5s for out-of-panel removals", and someone weighing the TTL later needs that sentence.
  */
 
+/**
+ * The tag that marks a loader's return value as an OUTCOME WRAPPER rather than the
+ * schema itself.
+ *
+ * A structural `"defs" in value` test would collide with a real node type named
+ * `defs` (codex): a bare schema containing one would be misread as a wrapper, and that
+ * single definition would become the cached schema. A Symbol cannot appear in JSON, so
+ * only a producer that deliberately tagged its result can be mistaken for one.
+ */
+export const CACHE_OUTCOME = Symbol.for("comfyui-mcp.objectInfoOutcome");
+
 /** How long a fetched payload may be reused. */
 export const OBJECT_INFO_CACHE_TTL_MS = 1500;
 
@@ -113,7 +124,7 @@ export function createObjectInfoCache({ ttlMs = OBJECT_INFO_CACHE_TTL_MS, now = 
           // the wrapper around it — a wrapper carrying `defs: null` has two keys and
           // would otherwise be cached as a success, pinning fail-closed for the TTL,
           // which is exactly what this file exists to prevent (codex).
-          const payload = defs && typeof defs === "object" && "defs" in defs ? defs.defs : defs;
+          const payload = defs && typeof defs === "object" && defs[CACHE_OUTCOME] === true ? defs.defs : defs;
           if (
             issuedAt === generation &&
             payload &&

--- a/web/js/lib/object-info-cache.js
+++ b/web/js/lib/object-info-cache.js
@@ -106,11 +106,19 @@ export function createObjectInfoCache({ ttlMs = OBJECT_INFO_CACHE_TTL_MS, now = 
           // Store only a USABLE payload from a still-current generation. Caching a
           // null/empty would pin the fence's fail-closed state for the whole TTL, turning
           // one transient failure into a second and a half of refused writes.
+          // #982 — the loader may return either the schema map itself or an OUTCOME
+          // wrapper `{ defs, failures }`, so a caller that JOINS an in-flight failed
+          // read still receives the diagnostics of the attempt that actually ran. The
+          // usability test therefore looks at the payload the fence will rule on, not at
+          // the wrapper around it — a wrapper carrying `defs: null` has two keys and
+          // would otherwise be cached as a success, pinning fail-closed for the TTL,
+          // which is exactly what this file exists to prevent (codex).
+          const payload = defs && typeof defs === "object" && "defs" in defs ? defs.defs : defs;
           if (
             issuedAt === generation &&
-            defs &&
-            typeof defs === "object" &&
-            Object.keys(defs).length > 0
+            payload &&
+            typeof payload === "object" &&
+            Object.keys(payload).length > 0
           ) {
             // SHARED IDENTITY IS NEW (codex): every write used to get its own object, and
             // now they share one. A consumer that mutated the map would contaminate every

--- a/web/js/lib/object-info-oracle.js
+++ b/web/js/lib/object-info-oracle.js
@@ -41,6 +41,8 @@
  * it can never override a narrower answer the client actually gave.
  */
 
+import { CACHE_OUTCOME } from "./object-info-cache.js";
+
 /** A payload that can actually answer "does the backend define this type?" */
 function usableDefs(value) {
   return !!value && typeof value === "object" && !Array.isArray(value) && Object.keys(value).length > 0;
@@ -59,8 +61,8 @@ const MAX_DETAIL_CHARS = 200;
  * strings this module never produced.
  */
 function sanitizeDetail(value) {
-  // `String(value)` can itself THROW — a hostile object with a throwing toString or a
-  // Symbol both do it — and a diagnostic path must never raise an exception of its own
+  // `String(value)` can itself THROW — a hostile object with a throwing toString does it
+  // — and a diagnostic path must never raise an exception of its own
   // (codex).
   let text = "";
   try {
@@ -99,7 +101,7 @@ export async function fetchWholeObjectInfo({ getNodeDefs, fetchApi } = {}) {
   if (typeof getNodeDefs === "function") {
     try {
       const defs = await getNodeDefs();
-      if (usableDefs(defs)) return { defs, failures };
+      if (usableDefs(defs)) return { [CACHE_OUTCOME]: true, defs, failures };
       // AN EMPTY MAP IS AN ANSWER, NOT AN ABSENCE (codex). A client that deliberately
       // filters could express deny-all as `{}`, and consulting the raw route would then
       // overrule it with a broader schema — the one direction this fallback must never
@@ -107,7 +109,7 @@ export async function fetchWholeObjectInfo({ getNodeDefs, fetchApi } = {}) {
       // leaves the question unanswered, and only that may be asked again elsewhere.
       if (defs && typeof defs === "object" && !Array.isArray(defs)) {
         failures.push("api.getNodeDefs() returned an EMPTY schema — treated as its answer, not as an absence");
-        return { defs: null, failures };
+        return { [CACHE_OUTCOME]: true, defs: null, failures };
       }
       failures.push(
         describeFailure(
@@ -132,7 +134,7 @@ export async function fetchWholeObjectInfo({ getNodeDefs, fetchApi } = {}) {
         failures.push(describeFailure("GET /object_info was not OK", null, ` (status ${res?.status ?? "unknown"})`));
       } else {
         const defs = await res.json();
-        if (usableDefs(defs)) return { defs, failures };
+        if (usableDefs(defs)) return { [CACHE_OUTCOME]: true, defs, failures };
         failures.push("GET /object_info returned no usable schema (an empty or non-object body)");
       }
     } catch (err) {
@@ -142,7 +144,7 @@ export async function fetchWholeObjectInfo({ getNodeDefs, fetchApi } = {}) {
     failures.push("no fetchApi is wired for the fallback route");
   }
 
-  return { defs: null, failures };
+  return { [CACHE_OUTCOME]: true, defs: null, failures };
 }
 
 /**
@@ -159,11 +161,18 @@ export function objectInfoOracleFailureNote(failures) {
   // BOUNDED AT THE PUBLIC BOUNDARY (codex): each entry is capped, and so is the number
   // of entries — a caller may hand this an arbitrarily long array this module never
   // produced, and the result goes into an error someone reads.
-  const all = failures.map((f) => sanitizeDetail(f)).filter(Boolean);
-  if (!all.length) return "";
-  const shown = all.slice(0, MAX_FAILURES_REPORTED);
-  const dropped = all.length - shown.length;
+  // SLICE FIRST (codex): sanitizing every entry of an arbitrarily long array is
+  // unbounded work even though the string it produces is bounded. The dropped count
+  // comes from the ORIGINAL length, so truncation is still reported honestly.
+  //
+  // NO TEST PINS THIS ORDER, and that is stated rather than papered over: swapping the
+  // slice and the map produces an identical string, so it is a cost property with no
+  // observable output. Mutation testing confirms the swap survives. It is written this
+  // way deliberately; a later edit that reverses it will not be caught by the suite.
+  const shown = failures.slice(0, MAX_FAILURES_REPORTED).map((f) => sanitizeDetail(f)).filter(Boolean);
+  if (!shown.length) return "";
+  const dropped = failures.length - Math.min(failures.length, MAX_FAILURES_REPORTED);
   const more = dropped > 0 ? ` (and ${dropped} more not shown)` : "";
-  const label = all.length === 1 ? "one route" : `${all.length} routes`;
+  const label = failures.length === 1 ? "one route" : `${failures.length} routes`;
   return ` Tried ${label}: ${shown.join("; ")}${more}.`;
 }

--- a/web/js/lib/object-info-oracle.js
+++ b/web/js/lib/object-info-oracle.js
@@ -23,6 +23,22 @@
  *
  * FAIL-CLOSED IS UNCHANGED. Only a usable, non-empty payload authorizes anything; every
  * failure path returns `defs: null`, which the fence already refuses on.
+ *
+ * DOES THE SECOND ROUTE AUTHORIZE MORE THAN THE FIRST? (codex). If `api.getNodeDefs()`
+ * filtered or narrowed the schema, falling back to the raw route would quietly widen what
+ * a write may be authorized against. MEASURED on ComfyUI 0.31.1 / frontend 1.48.7, both
+ * routes fetched back to back on a 4183-type install:
+ *
+ *   api.getNodeDefs()      4183 types
+ *   GET /object_info       4183 types
+ *   types in only one      none, either direction
+ *   per-type field sets    identical for the sampled types
+ *
+ * So on the build this was written against the two answer the same question. That is
+ * evidence, not a contract: a frontend that starts filtering would make the fallback
+ * broader than the client route, and this comment is where that would need re-checking.
+ * The fallback is only ever consulted when the client route returned NOTHING usable, so
+ * it can never override a narrower answer the client actually gave.
  */
 
 /** A payload that can actually answer "does the backend define this type?" */
@@ -30,9 +46,32 @@ function usableDefs(value) {
   return !!value && typeof value === "object" && !Array.isArray(value) && Object.keys(value).length > 0;
 }
 
-/** One attempt's outcome, in the words of what happened rather than a category. */
+/** How much of a thrown value's own words may ride into a refusal message. */
+const MAX_DETAIL_CHARS = 200;
+
+/**
+ * Flatten and cap any UNTRUSTED text before it can reach a caller-visible message
+ * (codex). It comes from a backend, a frontend client, or any installed extension, and
+ * it is interpolated into an error a caller reads: control characters are collapsed so a
+ * newline cannot forge structure in the reply, and the length is capped so an
+ * arbitrarily large message cannot become the response. Applied at BOTH boundaries — the
+ * per-attempt description and the note builder — because a caller can hand the latter
+ * strings this module never produced.
+ */
+function sanitizeDetail(value) {
+  const flattened = String(value ?? "")
+    // eslint-disable-next-line no-control-regex
+    .replace(/[\u0000-\u001f\u007f-\u009f]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+  return flattened.length > MAX_DETAIL_CHARS
+    ? `${flattened.slice(0, MAX_DETAIL_CHARS)}… (truncated)`
+    : flattened;
+}
+
 function describeFailure(label, err, extra = "") {
-  const detail = err instanceof Error ? err.message : err == null ? "" : String(err);
+  const raw = err instanceof Error ? err.message : err == null ? "" : String(err);
+  const detail = sanitizeDetail(raw);
   const suffix = detail ? `: ${detail}` : "";
   return `${label}${extra}${suffix}`;
 }
@@ -96,7 +135,7 @@ export async function fetchWholeObjectInfo({ getNodeDefs, fetchApi } = {}) {
  */
 export function objectInfoOracleFailureNote(failures) {
   if (!Array.isArray(failures) || !failures.length) return "";
-  const which = failures.map((f) => String(f)).filter(Boolean);
+  const which = failures.map((f) => sanitizeDetail(f)).filter(Boolean);
   if (!which.length) return "";
   return ` Tried ${which.length === 1 ? "one route" : `${which.length} routes`}: ${which.join("; ")}.`;
 }

--- a/web/js/lib/object-info-oracle.js
+++ b/web/js/lib/object-info-oracle.js
@@ -59,7 +59,16 @@ const MAX_DETAIL_CHARS = 200;
  * strings this module never produced.
  */
 function sanitizeDetail(value) {
-  const flattened = String(value ?? "")
+  // `String(value)` can itself THROW — a hostile object with a throwing toString or a
+  // Symbol both do it — and a diagnostic path must never raise an exception of its own
+  // (codex).
+  let text = "";
+  try {
+    text = String(value ?? "");
+  } catch {
+    return "(an unprintable value)";
+  }
+  const flattened = text
     // eslint-disable-next-line no-control-regex
     .replace(/[\u0000-\u001f\u007f-\u009f]+/g, " ")
     .replace(/\s+/g, " ")
@@ -91,11 +100,20 @@ export async function fetchWholeObjectInfo({ getNodeDefs, fetchApi } = {}) {
     try {
       const defs = await getNodeDefs();
       if (usableDefs(defs)) return { defs, failures };
+      // AN EMPTY MAP IS AN ANSWER, NOT AN ABSENCE (codex). A client that deliberately
+      // filters could express deny-all as `{}`, and consulting the raw route would then
+      // overrule it with a broader schema — the one direction this fallback must never
+      // move. Only a client that returned NOTHING (null/undefined/non-object) or threw
+      // leaves the question unanswered, and only that may be asked again elsewhere.
+      if (defs && typeof defs === "object" && !Array.isArray(defs)) {
+        failures.push("api.getNodeDefs() returned an EMPTY schema — treated as its answer, not as an absence");
+        return { defs: null, failures };
+      }
       failures.push(
         describeFailure(
           "api.getNodeDefs() returned no usable schema",
           null,
-          defs && typeof defs === "object" ? " (an empty object)" : ` (${defs === null ? "null" : typeof defs})`,
+          ` (${defs === null ? "null" : Array.isArray(defs) ? "an array" : typeof defs})`,
         ),
       );
     } catch (err) {
@@ -133,9 +151,19 @@ export async function fetchWholeObjectInfo({ getNodeDefs, fetchApi } = {}) {
  * Empty when nothing was recorded, so a caller that never ran this helper reads exactly
  * as it did before rather than gaining a hollow "no failures" clause.
  */
+/** At most this many attempts are named, however long the list a caller hands in. */
+const MAX_FAILURES_REPORTED = 4;
+
 export function objectInfoOracleFailureNote(failures) {
   if (!Array.isArray(failures) || !failures.length) return "";
-  const which = failures.map((f) => sanitizeDetail(f)).filter(Boolean);
-  if (!which.length) return "";
-  return ` Tried ${which.length === 1 ? "one route" : `${which.length} routes`}: ${which.join("; ")}.`;
+  // BOUNDED AT THE PUBLIC BOUNDARY (codex): each entry is capped, and so is the number
+  // of entries — a caller may hand this an arbitrarily long array this module never
+  // produced, and the result goes into an error someone reads.
+  const all = failures.map((f) => sanitizeDetail(f)).filter(Boolean);
+  if (!all.length) return "";
+  const shown = all.slice(0, MAX_FAILURES_REPORTED);
+  const dropped = all.length - shown.length;
+  const more = dropped > 0 ? ` (and ${dropped} more not shown)` : "";
+  const label = all.length === 1 ? "one route" : `${all.length} routes`;
+  return ` Tried ${label}: ${shown.join("; ")}${more}.`;
 }

--- a/web/js/lib/object-info-oracle.js
+++ b/web/js/lib/object-info-oracle.js
@@ -1,0 +1,102 @@
+/**
+ * #982 — the write fence refused with "object_info is unavailable — the backend is
+ * unreachable or the fetch failed" while the reporter's ComfyUI was healthy and
+ * `/object_info/VAELoader` answered on the same machine. Two separate problems in one
+ * sentence:
+ *
+ *   1. ONE TRANSPORT. The oracle only ever asked `api.getNodeDefs()`. When that call
+ *      fails — and after a restart the frontend's client can fail while the HTTP route
+ *      answers perfectly well — there was no second way to ask, so a reachable backend
+ *      read as an unreachable one.
+ *   2. A DISJUNCTION INSTEAD OF AN OBSERVATION. "unreachable or the fetch failed" names
+ *      two causes and establishes neither, and the first half is what sent the reporter
+ *      checking a backend that was fine.
+ *
+ * This asks the SAME question by a second route before giving up, and records what each
+ * attempt actually did so the refusal can say it.
+ *
+ * WHOLE SCHEMA BOTH TIMES, deliberately. The per-class `/object_info/<Type>` route that
+ * `add_node` uses is NOT interchangeable here: `set_widget` authorizes two types for a
+ * promoted write and fetches BEFORE resolving which target it writes to, so a
+ * single-class payload answers one question and reads the other as absent (#716/#821).
+ * The fallback changes the TRANSPORT, never the question.
+ *
+ * FAIL-CLOSED IS UNCHANGED. Only a usable, non-empty payload authorizes anything; every
+ * failure path returns `defs: null`, which the fence already refuses on.
+ */
+
+/** A payload that can actually answer "does the backend define this type?" */
+function usableDefs(value) {
+  return !!value && typeof value === "object" && !Array.isArray(value) && Object.keys(value).length > 0;
+}
+
+/** One attempt's outcome, in the words of what happened rather than a category. */
+function describeFailure(label, err, extra = "") {
+  const detail = err instanceof Error ? err.message : err == null ? "" : String(err);
+  const suffix = detail ? `: ${detail}` : "";
+  return `${label}${extra}${suffix}`;
+}
+
+/**
+ * Fetch the whole `/object_info` schema, trying the frontend client first and the raw
+ * HTTP route second.
+ *
+ * Returns `{ defs, failures }` — `defs` is null unless one route returned a usable
+ * payload, and `failures` names every route that did not, in order. An empty `failures`
+ * with a null `defs` cannot happen: a route that answers nothing is itself a failure.
+ */
+export async function fetchWholeObjectInfo({ getNodeDefs, fetchApi } = {}) {
+  const failures = [];
+
+  if (typeof getNodeDefs === "function") {
+    try {
+      const defs = await getNodeDefs();
+      if (usableDefs(defs)) return { defs, failures };
+      failures.push(
+        describeFailure(
+          "api.getNodeDefs() returned no usable schema",
+          null,
+          defs && typeof defs === "object" ? " (an empty object)" : ` (${defs === null ? "null" : typeof defs})`,
+        ),
+      );
+    } catch (err) {
+      failures.push(describeFailure("api.getNodeDefs() threw", err));
+    }
+  } else {
+    failures.push("api.getNodeDefs is not a function on this frontend");
+  }
+
+  // SECOND TRANSPORT, same question. The reporter proved this route answers when the
+  // client call does not — it is the one they ran by hand to show the backend was fine.
+  if (typeof fetchApi === "function") {
+    try {
+      const res = await fetchApi("/object_info");
+      if (!res || res.ok !== true) {
+        failures.push(describeFailure("GET /object_info was not OK", null, ` (status ${res?.status ?? "unknown"})`));
+      } else {
+        const defs = await res.json();
+        if (usableDefs(defs)) return { defs, failures };
+        failures.push("GET /object_info returned no usable schema (an empty or non-object body)");
+      }
+    } catch (err) {
+      failures.push(describeFailure("GET /object_info threw", err));
+    }
+  } else {
+    failures.push("no fetchApi is wired for the fallback route");
+  }
+
+  return { defs: null, failures };
+}
+
+/**
+ * The sentence a refusal appends: what was actually tried, and what each attempt did.
+ *
+ * Empty when nothing was recorded, so a caller that never ran this helper reads exactly
+ * as it did before rather than gaining a hollow "no failures" clause.
+ */
+export function objectInfoOracleFailureNote(failures) {
+  if (!Array.isArray(failures) || !failures.length) return "";
+  const which = failures.map((f) => String(f)).filter(Boolean);
+  if (!which.length) return "";
+  return ` Tried ${which.length === 1 ? "one route" : `${which.length} routes`}: ${which.join("; ")}.`;
+}

--- a/web/js/lib/object-info-oracle.js
+++ b/web/js/lib/object-info-oracle.js
@@ -165,10 +165,15 @@ export function objectInfoOracleFailureNote(failures) {
   // unbounded work even though the string it produces is bounded. The dropped count
   // comes from the ORIGINAL length, so truncation is still reported honestly.
   //
-  // NO TEST PINS THIS ORDER, and that is stated rather than papered over: swapping the
-  // slice and the map produces an identical string, so it is a cost property with no
-  // observable output. Mutation testing confirms the swap survives. It is written this
-  // way deliberately; a later edit that reverses it will not be caught by the suite.
+  // NO TEST PINS THIS ORDER, and that is stated rather than papered over. For the inputs
+  // this module produces the two orders are output-identical — every attempt it records
+  // is non-empty — so mutation testing shows the swap surviving, and a later edit that
+  // reverses it will not be caught by the suite.
+  //
+  // They are NOT identical for arbitrary caller input (codex): a list whose first four
+  // entries are blank yields no note this way, and a note naming the fifth the other way.
+  // Slicing first is still the right order — it is what bounds the work — and this is the
+  // one case where the two differ, recorded so nobody has to rediscover it.
   const shown = failures.slice(0, MAX_FAILURES_REPORTED).map((f) => sanitizeDetail(f)).filter(Boolean);
   if (!shown.length) return "";
   const dropped = failures.length - Math.min(failures.length, MAX_FAILURES_REPORTED);

--- a/web/js/lib/set-widget.js
+++ b/web/js/lib/set-widget.js
@@ -62,6 +62,10 @@ export async function runSetWidget(
     getRegistry,
     getFreshObjectInfo,
     wasTypeEverDefined,
+    // #982 — what the /object_info oracle observed on its last attempt, so an
+    // unavailable-schema refusal can name the routes it tried instead of asserting a
+    // cause it never established.
+    describeObjectInfoFailure,
     resolveSource,
     canvas,
     beforeChange,
@@ -268,6 +272,7 @@ export async function runSetWidget(
       // but absent from the current /object_info is a REMOVED backend node — refuse
       // (the non-forgeable trust root; client shape/name/markers cannot prove this).
       wasTypeEverDefined,
+      describeObjectInfoFailure,
     });
   }
 


### PR DESCRIPTION
Claims #982. Draft opened before starting.

After a ComfyUI restart with a subgraph workflow open, `panel_set_widget` resolves the
exposed outer widget to its inner node and then refuses:

```
cannot verify the node type against the ComfyUI backend (object_info is unavailable —
the backend is unreachable or the fetch failed). Refusing to write rather than trust a
possibly-stale node cache (#458).
```

…while the API is healthy, `/object_info/VAELoader` is reachable, reads work, and
`panel_set_workflow_target` reports `bound`. The reporter also observed
`panel_refresh_nodes` answering `ok:true, refreshed:false`, so the refresh did not restore
whatever the write path consults.

First step is to establish WHAT the write path actually reads and why it is empty after a
reconnect — the refusal names `object_info`, but that is the panel's phrasing, not
necessarily the source it consulted.