### PR TITLE
fix(manager): report the provenance a catalogue answer can actually establish (#890)

### DIFF
--- a/browser_tests/unit/catalogue-no-match-provenance.test.mjs
+++ b/browser_tests/unit/catalogue-no-match-provenance.test.mjs
@@ -1,0 +1,111 @@
+/**
+ * #890 — a blocked registry does not yield an EMPTY catalogue. It yields a FULL one that
+ * may be months old, presented identically to a current one, so a user searching for a
+ * recently published pack gets "no matches" — indistinguishable from "that pack does not
+ * exist". #808 closed the empty case; this is the one it left open, and the likelier one
+ * in the field, because Manager works hard never to return empty.
+ *
+ * WHAT CANNOT BE CLAIMED, and the issue's own follow-up establishes it by measurement:
+ * the served catalogue is NOT the bundled `extension-node-map.json` (5583 served vs 4884
+ * bundled on a working rig, sharing only ~1800 keys), so a "is this the bundled map"
+ * discriminator would never fire and would ship as a check that always passes. Nothing in
+ * the payload carries a fetch time or a source, so staleness is not observable and is not
+ * asserted here.
+ *
+ * WHAT CAN: the panel asked for `mode=cache`. That is its own request, not an inference
+ * about the response, and it is exactly the fact a reader needs before concluding a pack
+ * does not exist.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+import { cachedCatalogueNoMatch, searchNodesVia, parseNodeMappings } from "../../web/js/lib/manager-install.js";
+
+/** A populated catalogue in the object shape Manager serves. */
+const catalogue = (n) =>
+  Object.fromEntries(
+    Array.from({ length: n }, (_, i) => [
+      `https://github.com/someone/pack-${i}`,
+      [[`Node${i}`], { title_aux: `Pack ${i}`, id: `pack-${i}` }],
+    ]),
+  );
+
+test("#890 a no-match over a CACHED catalogue says which catalogue was searched", () => {
+  const note = cachedCatalogueNoMatch("brand-new-pack", 5583, "customnode/getmappings?mode=cache");
+  assert.equal(note.catalogue_mode, "cache");
+  assert.match(note.no_match_note, /"brand-new-pack"/, "names what was searched for");
+  assert.match(note.no_match_note, /CACHED copy \(5583 packs\)/, "and what was searched");
+  assert.match(note.no_match_note, /published after the cache was last refreshed will not appear/);
+  assert.match(note.no_match_note, /refresh the cache from the Manager UI/, "the remedy");
+});
+
+test("#890 it claims NOTHING about the cache's age or its source", () => {
+  const note = cachedCatalogueNoMatch("x", 5583, "customnode/getmappings?mode=cache");
+  assert.match(note.no_match_note, /The panel makes no claim about the cache's age/);
+  assert.doesNotMatch(note.no_match_note, /stale|out of date|months/i, "staleness is not observable and is not asserted");
+  assert.doesNotMatch(note.no_match_note, /blocked|offline|unreachable/i, "nor the network condition behind it");
+  // The three possible sources are NAMED as unknown rather than picked.
+  assert.match(note.no_match_note, /whether it came from the network, the on-disk cache or the copy/);
+});
+
+test("#890 the mode is read off the ROUTE, so the note cannot outlive the request it describes", () => {
+  assert.deepEqual(cachedCatalogueNoMatch("x", 10, "customnode/getmappings?mode=default"), {}, "a live fetch says nothing");
+  assert.deepEqual(cachedCatalogueNoMatch("x", 10, "customnode/getmappings"), {}, "no mode, no claim");
+  assert.deepEqual(cachedCatalogueNoMatch("x", 10, null), {});
+  assert.deepEqual(cachedCatalogueNoMatch("x", 10, undefined), {});
+  assert.equal(cachedCatalogueNoMatch("x", 10, "a?mode=cache&extra=1").catalogue_mode, "cache", "other params are fine");
+});
+
+test("#890 an unreadable size is omitted rather than printed as garbage", () => {
+  for (const size of [null, undefined, NaN, "many", {}]) {
+    const note = cachedCatalogueNoMatch("x", size, "r?mode=cache");
+    assert.equal(note.catalogue_mode, "cache");
+    assert.doesNotMatch(note.no_match_note, /\(null packs\)|\(NaN packs\)|\(undefined packs\)|\[object/);
+    assert.match(note.no_match_note, /CACHED copy —/, "the sentence still reads");
+  }
+});
+
+test("#890 a MATCH is untouched — the note is for the answer that can mislead", async () => {
+  const data = catalogue(50);
+  const hit = await searchNodesVia(async () => data, async () => data, { query: "pack-7", limit: 15 });
+  assert.ok(hit.count > 0, "found something");
+  assert.equal("no_match_note" in hit, false, "a result that found packs needs no disclaimer");
+  assert.equal("catalogue_mode" in hit, false);
+});
+
+test("#890 a no-match through the real search path carries the note", async () => {
+  const data = catalogue(5583);
+  const miss = await searchNodesVia(async () => data, async () => data, { query: "definitely-not-here", limit: 15 });
+  assert.equal(miss.count, 0);
+  assert.equal(miss.catalogue_size, 5583, "the #808 fact is still reported");
+  assert.equal(miss.catalogue_mode, "cache");
+  assert.match(miss.no_match_note, /definitely-not-here/);
+});
+
+test("#890 an EMPTY catalogue keeps its own #808 answer, which says something stronger", async () => {
+  // "Nothing was searched" is a different and more serious statement than "nothing
+  // matched", and it must not be replaced by the softer no-match note.
+  const empty = await searchNodesVia(async () => ({}), async () => ({}), { query: "x", limit: 15 });
+  assert.equal(empty.catalogue_empty, true);
+  assert.equal(empty.searched, false);
+  assert.equal("no_match_note" in empty, false);
+  assert.match(empty.message, /contains ZERO packs/);
+});
+
+test("#890 the parser itself is unchanged — the note is added at the search boundary", () => {
+  const parsed = parseNodeMappings(catalogue(20), "nothing-matches", 15);
+  assert.equal(parsed.count, 0);
+  assert.equal(parsed.catalogue_size, 20);
+  assert.equal("no_match_note" in parsed, false, "parseNodeMappings stays a pure parse");
+});
+
+test("#890 source guard: the search route still asks for the cache the note describes", () => {
+  const src = readFileSync(new URL("../../web/js/lib/manager-install.js", import.meta.url), "utf8");
+  assert.match(src, /const route = "customnode\/getmappings\?mode=cache";/, "the route the note reads");
+  assert.match(
+    src,
+    /parsed\.count === 0 \? \{ \.\.\.parsed, \.\.\.cachedCatalogueNoMatch\(query, parsed\.catalogue_size, route\) \} : parsed/,
+    "applied only to a no-match, and given the route actually requested",
+  );
+});

--- a/browser_tests/unit/catalogue-no-match-provenance.test.mjs
+++ b/browser_tests/unit/catalogue-no-match-provenance.test.mjs
@@ -12,9 +12,9 @@
  * the payload carries a fetch time or a source, so staleness is not observable and is not
  * asserted here.
  *
- * WHAT CAN: the panel asked for `mode=cache`. That is its own request, not an inference
- * about the response, and it is exactly the fact a reader needs before concluding a pack
- * does not exist.
+ * WHAT CAN: the panel ASKED for `mode=cache`. That is its own request — and only that.
+ * Manager does not report whether it honoured the parameter, so the note names the request
+ * and says explicitly that the response's source is unknown (codex).
  */
 import test from "node:test";
 import assert from "node:assert/strict";
@@ -31,22 +31,29 @@ const catalogue = (n) =>
     ]),
   );
 
-test("#890 a no-match over a CACHED catalogue says which catalogue was searched", () => {
+test("#890 a no-match names the MODE THAT WAS REQUESTED and how much was searched", () => {
   const note = cachedCatalogueNoMatch("brand-new-pack", 5583, "customnode/getmappings?mode=cache");
-  assert.equal(note.catalogue_mode, "cache");
+  assert.equal(note.requested_mode, "cache");
   assert.match(note.no_match_note, /"brand-new-pack"/, "names what was searched for");
-  assert.match(note.no_match_note, /CACHED copy \(5583 packs\)/, "and what was searched");
-  assert.match(note.no_match_note, /published after the cache was last refreshed will not appear/);
-  assert.match(note.no_match_note, /refresh the cache from the Manager UI/, "the remedy");
+  assert.match(note.no_match_note, /out of 5583 packs searched/, "and how much was searched");
+  assert.doesNotMatch(note.no_match_note, /is ComfyUI-Manager.s CACHED copy/, "the response is not called cached");
+  assert.match(note.no_match_note, /asked ComfyUI-Manager for mode=cache/, "what was REQUESTED");
+  assert.match(note.no_match_note, /a pack too recent for whatever list was searched/);
+  assert.match(note.no_match_note, /refresh Manager.s cache from its UI/, "the remedy");
 });
 
-test("#890 it claims NOTHING about the cache's age or its source", () => {
+test("#890 it claims NOTHING about the response's age, source, or that the mode was honoured", () => {
   const note = cachedCatalogueNoMatch("x", 5583, "customnode/getmappings?mode=cache");
-  assert.match(note.no_match_note, /The panel makes no claim about the cache's age/);
+  assert.match(
+    note.no_match_note,
+    /Manager does not report whether it honoured that parameter/,
+    "the request is not evidence about the answer",
+  );
+  assert.match(note.no_match_note, /when the data was fetched/, "freshness is named as unknown");
   assert.doesNotMatch(note.no_match_note, /stale|out of date|months/i, "staleness is not observable and is not asserted");
   assert.doesNotMatch(note.no_match_note, /blocked|offline|unreachable/i, "nor the network condition behind it");
   // The three possible sources are NAMED as unknown rather than picked.
-  assert.match(note.no_match_note, /whether it came from the network, the on-disk cache or the copy/);
+  assert.match(note.no_match_note, /whether it served the network, its on-disk cache or the copy/);
 });
 
 test("#890 the mode is read off the ROUTE, so the note cannot outlive the request it describes", () => {
@@ -54,15 +61,16 @@ test("#890 the mode is read off the ROUTE, so the note cannot outlive the reques
   assert.deepEqual(cachedCatalogueNoMatch("x", 10, "customnode/getmappings"), {}, "no mode, no claim");
   assert.deepEqual(cachedCatalogueNoMatch("x", 10, null), {});
   assert.deepEqual(cachedCatalogueNoMatch("x", 10, undefined), {});
-  assert.equal(cachedCatalogueNoMatch("x", 10, "a?mode=cache&extra=1").catalogue_mode, "cache", "other params are fine");
+  assert.equal(cachedCatalogueNoMatch("x", 10, "a?mode=cache&extra=1").requested_mode, "cache", "other params are fine");
 });
 
 test("#890 an unreadable size is omitted rather than printed as garbage", () => {
   for (const size of [null, undefined, NaN, "many", {}]) {
     const note = cachedCatalogueNoMatch("x", size, "r?mode=cache");
-    assert.equal(note.catalogue_mode, "cache");
-    assert.doesNotMatch(note.no_match_note, /\(null packs\)|\(NaN packs\)|\(undefined packs\)|\[object/);
-    assert.match(note.no_match_note, /CACHED copy —/, "the sentence still reads");
+    assert.equal(note.requested_mode, "cache");
+    assert.doesNotMatch(note.no_match_note, /null packs|NaN packs|undefined packs|\[object/);
+    assert.doesNotMatch(note.no_match_note, /out of .{0,20} packs searched/, "an unreadable size is omitted entirely");
+    assert.match(note.no_match_note, /This request asked ComfyUI-Manager for mode=cache/, "the sentence still reads");
   }
 });
 
@@ -71,7 +79,7 @@ test("#890 a MATCH is untouched — the note is for the answer that can mislead"
   const hit = await searchNodesVia(async () => data, async () => data, { query: "pack-7", limit: 15 });
   assert.ok(hit.count > 0, "found something");
   assert.equal("no_match_note" in hit, false, "a result that found packs needs no disclaimer");
-  assert.equal("catalogue_mode" in hit, false);
+  assert.equal("requested_mode" in hit, false);
 });
 
 test("#890 a no-match through the real search path carries the note", async () => {
@@ -79,7 +87,7 @@ test("#890 a no-match through the real search path carries the note", async () =
   const miss = await searchNodesVia(async () => data, async () => data, { query: "definitely-not-here", limit: 15 });
   assert.equal(miss.count, 0);
   assert.equal(miss.catalogue_size, 5583, "the #808 fact is still reported");
-  assert.equal(miss.catalogue_mode, "cache");
+  assert.equal(miss.requested_mode, "cache");
   assert.match(miss.no_match_note, /definitely-not-here/);
 });
 
@@ -108,4 +116,25 @@ test("#890 source guard: the search route still asks for the cache the note desc
     /parsed\.count === 0 \? \{ \.\.\.parsed, \.\.\.cachedCatalogueNoMatch\(query, parsed\.catalogue_size, route\) \} : parsed/,
     "applied only to a no-match, and given the route actually requested",
   );
+});
+
+test("#890 (codex) the field NAMES the request, so it cannot be read as response provenance", () => {
+  // `catalogue_mode: "cache"` asserted where the bytes came from — the one thing this code
+  // cannot see. Manager may ignore the parameter and serve a live fetch; nothing in the
+  // answer says. The field is the panel's own request, and named that way.
+  const note = cachedCatalogueNoMatch("x", 10, "r?mode=cache");
+  assert.equal("catalogue_mode" in note, false, "the provenance-shaped name is gone");
+  assert.equal(note.requested_mode, "cache");
+  // The old name must not come back as a FIELD. It survives in the comment that explains
+  // why it was wrong, which is where a reader needs it — so this looks for the assignment.
+  const src = readFileSync(new URL("../../web/js/lib/manager-install.js", import.meta.url), "utf8");
+  assert.ok(!/catalogue_mode\s*:/.test(src), "and cannot come back as a field");
+});
+
+test("#890 (codex) the note never says the answer IS the cache", () => {
+  const note = cachedCatalogueNoMatch("x", 10, "r?mode=cache").no_match_note;
+  assert.doesNotMatch(note, /the catalogue that was searched is/, "no claim about what was served");
+  assert.doesNotMatch(note, /reflects whatever that cache last held/, "nor about what it reflects");
+  // What it DOES do is refuse the distinction, which is the honest answer.
+  assert.match(note, /cannot distinguish "no such pack" from/);
 });

--- a/web/js/lib/manager-install.js
+++ b/web/js/lib/manager-install.js
@@ -664,6 +664,42 @@ export function managerUnavailableResult(query, err) {
  * needing a signal Manager does not expose today; inventing a staleness claim here would
  * repeat the very fault #808 reports.
  */
+/**
+ * #890 — what a NO-MATCH over a populated catalogue may honestly say.
+ *
+ * Only two things are claimed, and the panel knows both for certain: how many packs the
+ * catalogue it searched contained, and that it asked Manager for the CACHED copy. It does
+ * NOT claim the cache is stale, or old, or that the registry is blocked — none of that is
+ * observable from the response, and asserting it is the fault the parent issue was filed
+ * about.
+ *
+ * `mode=cache` is read off the route actually requested rather than hardcoded, so if the
+ * route changes and this text does not, the note stops claiming a mode that was not asked
+ * for.
+ */
+export function cachedCatalogueNoMatch(query, catalogueSize, route) {
+  const q = query == null ? "" : String(query);
+  const mode = /[?&]mode=([^&]+)/.exec(String(route ?? ""))?.[1] ?? null;
+  // STRICTLY a number. `Number.isFinite(Number(v))` accepts `null` — Number(null) is 0 —
+  // and would print "(0 packs)" for an absent size, which reads as an EMPTY catalogue:
+  // the one thing this branch is not about, and the case #808 answers far more strongly.
+  const size = typeof catalogueSize === "number" && Number.isFinite(catalogueSize) ? catalogueSize : null;
+  if (mode !== "cache") return {};
+  return {
+    catalogue_mode: "cache",
+    no_match_note:
+      `No pack in the catalogue matched${q ? ` "${q}"` : ""}, and the catalogue that was ` +
+      `searched is ComfyUI-Manager's CACHED copy${size == null ? "" : ` (${size} packs)`} — ` +
+      "this search asked for mode=cache, so it reflects whatever that cache last held. A " +
+      "pack published after the cache was last refreshed will not appear here, and this " +
+      "result cannot tell you which of the two you are looking at. The panel makes no " +
+      "claim about the cache's age: nothing in Manager's response says when it was " +
+      "fetched, or whether it came from the network, the on-disk cache or the copy " +
+      "bundled with Manager (#890). If the pack is recent, refresh the cache from the " +
+      "Manager UI and search again before concluding it does not exist.",
+  };
+}
+
 export function emptyCatalogueResult(query) {
   const q = query == null ? "" : String(query);
   return {
@@ -733,7 +769,19 @@ export async function searchNodesVia(
   // `count` (packs that matched), because a healthy catalogue legitimately returns
   // count 0 all the time and must keep reading as the ordinary no-match it is.
   if (parsed.catalogue_size === 0) return emptyCatalogueResult(query);
-  return parsed;
+  // #890 — a NO-MATCH over a populated catalogue is the case #808 left open, and it is
+  // the likelier one in the field because Manager works hard never to return empty. A
+  // blocked registry yields a FULL list that may be months old, presented identically to
+  // a current one, so "no matches" and "that pack does not exist" arrive as the same
+  // answer. Nothing in the payload carries provenance — no fetch time, no indication of
+  // network vs cache vs bundle — and the issue's own follow-up measured that a
+  // "is this the bundled map" discriminator would never fire (5583 served vs 4884
+  // bundled, sharing ~1800 keys), so it would ship as a check that always passes.
+  //
+  // What IS observable without inventing anything: this search asked for `mode=cache`.
+  // That is the panel's own request, not an inference about the payload, and it is
+  // exactly the fact a reader needs before concluding a pack does not exist.
+  return parsed.count === 0 ? { ...parsed, ...cachedCatalogueNoMatch(query, parsed.catalogue_size, route) } : parsed;
 }
 
 /** #425 — ordered reboot {route, method} candidates for the detected dialect.

--- a/web/js/lib/manager-install.js
+++ b/web/js/lib/manager-install.js
@@ -686,17 +686,20 @@ export function cachedCatalogueNoMatch(query, catalogueSize, route) {
   const size = typeof catalogueSize === "number" && Number.isFinite(catalogueSize) ? catalogueSize : null;
   if (mode !== "cache") return {};
   return {
-    catalogue_mode: "cache",
+    // REQUESTED, not served (codex). Naming this `catalogue_mode` asserted where the
+    // bytes came from, which is the one thing this code cannot see: the parameter is what
+    // the panel ASKED for, and nothing in the answer says whether Manager honoured it.
+    requested_mode: "cache",
     no_match_note:
-      `No pack in the catalogue matched${q ? ` "${q}"` : ""}, and the catalogue that was ` +
-      `searched is ComfyUI-Manager's CACHED copy${size == null ? "" : ` (${size} packs)`} — ` +
-      "this search asked for mode=cache, so it reflects whatever that cache last held. A " +
-      "pack published after the cache was last refreshed will not appear here, and this " +
-      "result cannot tell you which of the two you are looking at. The panel makes no " +
-      "claim about the cache's age: nothing in Manager's response says when it was " +
-      "fetched, or whether it came from the network, the on-disk cache or the copy " +
-      "bundled with Manager (#890). If the pack is recent, refresh the cache from the " +
-      "Manager UI and search again before concluding it does not exist.",
+      `No pack in the catalogue matched${q ? ` "${q}"` : ""}${
+        size == null ? "" : `, out of ${size} packs searched`
+      }. This request asked ComfyUI-Manager for mode=cache. What the response came FROM is ` +
+      "not something the panel can tell: Manager does not report whether it honoured that " +
+      "parameter, when the data was fetched, or whether it served the network, its on-disk " +
+      "cache or the copy bundled with the Manager package (#890). So this result cannot " +
+      "distinguish \"no such pack\" from \"a pack too recent for whatever list was " +
+      "searched\". If the pack is recent, refresh Manager's cache from its UI and search " +
+      "again before concluding it does not exist.",
   };
 }
 


### PR DESCRIPTION
Claims #890. Draft opened before starting.

A blocked registry does not yield an empty catalogue — it yields a FULL one that may be
months old, presented identically to a current one. A user searching for a recently
released pack gets "no matches", which is indistinguishable from "that pack does not
exist".

The issue's own follow-up already withdrew the attractive fix: the served catalogue is NOT
the bundled `extension-node-map.json` (measured — 5583 vs 4884 entries, sharing only ~1800
keys), so a "is this the bundled map" discriminator would never fire and would ship as a
check that always passes.

What that comment DID establish is observable provenance of a different kind:

```
GET /api/customnode/getlist?mode=cache      -> HTTP 500
GET /api/customnode/getmappings?mode=cache  -> HTTP 200
GET /api/manager/channel_url_list           -> {"selected":"custom", ...}
GET /api/manager/version                    -> V3.41
```

So the direction to weigh is reporting what the panel can actually see — which endpoints
answered, which failed, and which channel is selected — WITHOUT inferring a staleness
claim it cannot support. First step is to measure those endpoints on this install and read
what the panel reports today.