### PR TITLE
fix(ask): mark a question card whose connection dropped, instead of leaving two live ones (#952)

### DIFF
--- a/browser_tests/unit/bridge-disconnect.test.mjs
+++ b/browser_tests/unit/bridge-disconnect.test.mjs
@@ -12,7 +12,7 @@ const panelPath = fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", imp
 
 function bridgeStatusHandler() {
   const source = readFileSync(panelPath, "utf8").replace(/\r\n/g, "\n");
-  const start = source.indexOf("const client = createBridgeClient({\n    onStatus(state) {");
+  const start = source.indexOf("const client = createBridgeClient({\n    onStatus(state, socketId) {");
   assert.notEqual(start, -1, "could not locate the bridge status callback");
   const end = source.indexOf("\n    onSay(", start);
   assert.notEqual(end, -1, "could not locate the callback following onStatus");

--- a/browser_tests/unit/interactive-card-fence.test.mjs
+++ b/browser_tests/unit/interactive-card-fence.test.mjs
@@ -235,7 +235,10 @@ test("an unknown reason still produces a refusal, never an empty or partial stri
 
 /** Pull one 4-space-indented object-literal method out of the panel source. */
 function extractMethod(name) {
-  const re = new RegExp(`\\n {4}${name}\\(msg\\) \\{[\\s\\S]*?\\n {4}\\},`);
+  // #952 threaded the painting socket id through these callbacks, so they take a second
+  // parameter now. Matched on the NAME and an open paren, so a later parameter cannot
+  // break a guard that is about the fence rather than the signature.
+  const re = new RegExp(`\\n {4}${name}\\(msg[^)]*\\) \\{[\\s\\S]*?\\n {4}\\},`);
   const m = panelSrc.match(re);
   assert.ok(m, `could not locate ${name} in the panel source`);
   return m[0];

--- a/browser_tests/unit/pi-readiness-ordering.test.mjs
+++ b/browser_tests/unit/pi-readiness-ordering.test.mjs
@@ -26,7 +26,7 @@ test("#505 panel wiring records the backends frame before allowing Pi ack promot
   assert.ok(backendsStart >= 0 && ackStart > backendsStart, "could not locate bridge callbacks");
   const backends = source.slice(backendsStart, ackStart);
   const ack = source.slice(ackStart, source.indexOf("    getResume:", ackStart));
-  const statusStart = source.indexOf("    onStatus(state) {");
+  const statusStart = source.indexOf("    onStatus(state, socketId) {");
   const status = source.slice(statusStart, source.indexOf("    onSay(", statusStart));
 
   assert.match(backends, /piBackendsReadinessReceived = true/, "backends frame must unlock Pi ack promotion");

--- a/browser_tests/unit/secret-card-sizing.test.mjs
+++ b/browser_tests/unit/secret-card-sizing.test.mjs
@@ -30,7 +30,10 @@ const PANEL_JS = join(HERE, "../../web/js/comfyui-mcp-panel.js");
 /** The paintSecret body, from its signature to the next top-level function. */
 function paintSecretBody() {
   const src = readFileSync(PANEL_JS, "utf8");
-  const start = src.indexOf("function paintSecret(msg) {");
+  // #952 threaded the painting socket id through, so the signature carries a second
+  // parameter now. Anchored on the NAME rather than the whole signature so the next
+  // parameter does not break a layout guard that has nothing to do with it.
+  const start = src.indexOf("function paintSecret(");
   assert.notEqual(start, -1, "paintSecret must exist");
   const end = src.indexOf("\n  function ", start + 1);
   assert.notEqual(end, -1, "paintSecret must be followed by another function");

--- a/browser_tests/unit/stale-interactive-card.test.mjs
+++ b/browser_tests/unit/stale-interactive-card.test.mjs
@@ -128,7 +128,11 @@ test("#952 (codex) source guard: a DIFFERENT SOCKET retires cards, and nothing r
 test("#952 source guard: a question card registers itself and unregisters when answered", () => {
   const src = readFileSync(PANEL_JS, "utf8");
   const paint = namedFunctionSource(src, "paintQuestion");
-  assert.match(paint, /const unregister = registerInteractiveCard\(\{/, "registered at paint");
+  assert.match(
+    paint,
+    /const unregister = paintedOnSocket == null \? \(\) => \{\} : registerInteractiveCard\(\{/,
+    "registered at paint, and ONLY when a command painted it",
+  );
   assert.match(paint, /alreadyAnswered: \(\) => done,/, "so an answered card is skipped");
   assert.match(paint, /promise\.then\(unregister, unregister\)/, "and dropped once it settles, either way");
 });
@@ -139,7 +143,11 @@ test("#952 (codex) a SECRET card is retired too, with secret-safe wording", () =
   // when nothing received it.
   const src = readFileSync(PANEL_JS, "utf8");
   const paint = namedFunctionSource(src, "paintSecret");
-  assert.match(paint, /const unregisterSecret = registerInteractiveCard\(\{/, "registered at paint");
+  assert.match(
+    paint,
+    /const unregisterSecret = paintedOnSocket == null \? \(\) => \{\} : registerInteractiveCard\(\{/,
+    "registered at paint, and ONLY when a command painted it",
+  );
   assert.match(paint, /what: "secret request"/);
   assert.match(paint, /Nothing was sent and nothing was stored/, "no false 'saved' impression survives");
   assert.match(paint, /do not paste the value into the chat/, "never redirect a secret into the transcript");
@@ -189,13 +197,13 @@ test("#952 (codex r2) a card painted BEFORE its socket handshakes is not retired
   // Socket A connects; a card is painted and answered normally.
   s.onStatus("connected", 1);
   const retiredA = [];
-  s.registerInteractiveCard({ retire: () => retiredA.push("A") });
+  s.registerInteractiveCard({ paintedOnSocket: 1, retire: () => retiredA.push("A") });
 
   // A drops, B opens ("connecting" carries B's id) and receives ask_user BEFORE its models
   // frame — the window this test exists for.
   s.onStatus("connecting", 2);
   const retiredB = [];
-  s.registerInteractiveCard({ retire: () => retiredB.push("B") });
+  s.registerInteractiveCard({ paintedOnSocket: 2, retire: () => retiredB.push("B") });
 
   // B handshakes.
   s.onStatus("connected", 2);
@@ -219,7 +227,7 @@ test("#952 (codex r2) a RE-HANDSHAKE on the same socket retires nothing", () => 
   )();
   make.onStatus("connected", 7);
   const retired = [];
-  make.registerInteractiveCard({ retire: () => retired.push("x") });
+  make.registerInteractiveCard({ paintedOnSocket: 7, retire: () => retired.push("x") });
   // Every models frame re-emits "connected" on the SAME socket; a workflow change re-hellos it.
   make.onStatus("connected", 7);
   make.onStatus("connected", 7);
@@ -257,9 +265,9 @@ test("#952 (codex r2) the card records the socket that ASKED, not the UI's belie
   // BOTH painters, COUNTED. Matching once passed while one of the two had lost it — a
   // guard that cannot tell "both do this" from "at least one does" is not guarding much.
   assert.equal(
-    (src.match(/\.\.\.\(paintedOnSocket != null \? \{ paintedOnSocket \} : \{\}\),/g) ?? []).length,
+    (src.match(/paintedOnSocket == null \? \(\) => \{\} : registerInteractiveCard\(\{/g) ?? []).length,
     2,
-    "the question card AND the secret card each record the socket they were painted on",
+    "the question card AND the secret card each register only when a command painted them",
   );
 });
 
@@ -283,7 +291,7 @@ test("#952 (codex r2) a card painted on a socket the UI never adopted is still t
   )();
   make.onStatus("connected", 1); // socket A is live
   const retiredA = [];
-  make.registerInteractiveCard({ retire: () => retiredA.push("A") });
+  make.registerInteractiveCard({ paintedOnSocket: 1, retire: () => retiredA.push("A") });
   // Socket B opens with NO status reaching the UI, and an ask_user arrives on it: the
   // painter names B explicitly.
   const retiredB = [];
@@ -291,4 +299,32 @@ test("#952 (codex r2) a card painted on a socket the UI never adopted is still t
   make.onStatus("connected", 2); // B finally handshakes
   assert.deepEqual(retiredA, ["A"], "the card from A is retired");
   assert.deepEqual(retiredB, [], "the card that named B survives B handshaking");
+});
+
+test("#952 (codex r3) a SETTINGS token card is never registered — it is agent-free", () => {
+  // `paintSecret` also serves the Settings "Set … token" buttons, which have no command
+  // behind them. That card can still send its set_secret on whatever socket is current
+  // after a reconnect, so retiring it would disable a working control and tell the user to
+  // wait for a request that is never coming.
+  const src = readFileSync(PANEL_JS, "utf8");
+  const settingsCall = src.slice(src.indexOf("    paintSecret({"), src.indexOf("    paintSecret({") + 400);
+  assert.ok(settingsCall.length > 0, "the Settings call site exists");
+  assert.ok(!/socketId/.test(settingsCall), "it passes no socket id");
+  // …and with none passed, the painter does not register it at all.
+  const make = new Function(
+    `let liveSocketId = 9;
+     const liveInteractiveCards = new Set();
+     ${namedFunctionSource(src, "registerInteractiveCard")}
+     return { registerInteractiveCard, size: () => liveInteractiveCards.size };`,
+  )();
+  // The painter's own gate is what skips registration; this asserts the registry keeps no
+  // belief-based fallback that would put a socket on an entry that never named one.
+  const off = make.registerInteractiveCard({ retire: () => {} });
+  assert.equal(make.size(), 1);
+  off();
+  assert.match(
+    namedFunctionSource(src, "registerInteractiveCard"),
+    /const record = \{ paintedOnSocket: null, \.\.\.entry \};/,
+    "no liveSocketId fallback — an entry names its own socket or none",
+  );
 });

--- a/browser_tests/unit/stale-interactive-card.test.mjs
+++ b/browser_tests/unit/stale-interactive-card.test.mjs
@@ -163,3 +163,132 @@ test("#952 (codex) the retirement note takes the caller's detail, and defaults f
   retire(q, { alreadyAnswered: () => false });
   assert.match(q._children[0].textContent, /If it asked again, answer the newer card\./, "the default stands");
 });
+
+test("#952 (codex r2) a card painted BEFORE its socket handshakes is not retired by that handshake", () => {
+  // A command frame is accepted before the handshake, so an interactive card can be painted
+  // on socket B while the UI still believes A is live. Retiring on B's `connected` would
+  // then kill a card that is perfectly answerable — worse than the duplicate this fixes.
+  // The sandbox runs the SHIPPED registry functions with the shipped handler's two lines,
+  // which the source guard below pins.
+  const src = readFileSync(PANEL_JS, "utf8");
+  const register = namedFunctionSource(src, "registerInteractiveCard");
+  const sweep = namedFunctionSource(src, "retireInteractiveCardsFromPreviousSockets");
+  const make = new Function(
+    `let liveSocketId = null;
+     const liveInteractiveCards = new Set();
+     ${register}
+     ${sweep}
+     function onStatus(state, socketId) {
+       if (socketId != null && socketId !== liveSocketId) liveSocketId = socketId;
+       if (state === "connected") retireInteractiveCardsFromPreviousSockets();
+     }
+     return { registerInteractiveCard, onStatus, liveCount: () => liveInteractiveCards.size };`,
+  );
+  const s = make();
+
+  // Socket A connects; a card is painted and answered normally.
+  s.onStatus("connected", 1);
+  const retiredA = [];
+  s.registerInteractiveCard({ retire: () => retiredA.push("A") });
+
+  // A drops, B opens ("connecting" carries B's id) and receives ask_user BEFORE its models
+  // frame — the window this test exists for.
+  s.onStatus("connecting", 2);
+  const retiredB = [];
+  s.registerInteractiveCard({ retire: () => retiredB.push("B") });
+
+  // B handshakes.
+  s.onStatus("connected", 2);
+  assert.deepEqual(retiredA, ["A"], "the card from the previous socket IS retired");
+  assert.deepEqual(retiredB, [], "the card painted on B, before B handshaked, is NOT");
+  assert.equal(s.liveCount(), 1, "and B's card is still tracked");
+});
+
+test("#952 (codex r2) a RE-HANDSHAKE on the same socket retires nothing", () => {
+  const src = readFileSync(PANEL_JS, "utf8");
+  const make = new Function(
+    `let liveSocketId = null;
+     const liveInteractiveCards = new Set();
+     ${namedFunctionSource(src, "registerInteractiveCard")}
+     ${namedFunctionSource(src, "retireInteractiveCardsFromPreviousSockets")}
+     function onStatus(state, socketId) {
+       if (socketId != null && socketId !== liveSocketId) liveSocketId = socketId;
+       if (state === "connected") retireInteractiveCardsFromPreviousSockets();
+     }
+     return { registerInteractiveCard, onStatus };`,
+  )();
+  make.onStatus("connected", 7);
+  const retired = [];
+  make.registerInteractiveCard({ retire: () => retired.push("x") });
+  // Every models frame re-emits "connected" on the SAME socket; a workflow change re-hellos it.
+  make.onStatus("connected", 7);
+  make.onStatus("connected", 7);
+  assert.deepEqual(retired, [], "a live card survives any number of re-handshakes");
+});
+
+test("#952 (codex r2) source guard: adoption is unconditional, retirement waits for the handshake", () => {
+  const src = readFileSync(PANEL_JS, "utf8");
+  assert.match(
+    src,
+    /if \(socketId != null && socketId !== liveSocketId\) liveSocketId = socketId;\r?\n\s*if \(state === "connected"\) retireInteractiveCardsFromPreviousSockets\(\);/,
+    "adopt on any status carrying a new id; sweep only on connected",
+  );
+  // The open path must actually emit a status carrying the new socket's id, or a card
+  // painted pre-handshake would still record the previous one.
+  assert.match(src, /thisSock\.__cmcpSocketId = \+\+socketSeq;/);
+  assert.match(src, /onStatus\(s, sock\?\.__cmcpSocketId \?\? null\)/);
+});
+
+test("#952 (codex r2) the card records the socket that ASKED, not the UI's belief", () => {
+  // The open status that would tell the UI about a new socket is suppressed once the
+  // patience window has been given up on (`if (!gaveUp) emitStatus("connecting")`), so a
+  // UI-side belief can be stale exactly when a pre-handshake command arrives. Taking the
+  // id from the command's own socket removes the dependency entirely.
+  const src = readFileSync(PANEL_JS, "utf8");
+  assert.match(src, /result = await onAsk\(msg, thisSock\.__cmcpSocketId \?\? null\);/, "ask carries its socket");
+  assert.match(src, /result = await onSecret\(msg, thisSock\.__cmcpSocketId \?\? null\);/, "so does the secret request");
+  assert.match(src, /onAsk\(msg, socketId\) \{/, "the UI takes it");
+  assert.match(src, /onSecret\(msg, socketId\) \{/);
+  assert.match(src, /const p = paintQuestion\(msg, socketId\);/, "and threads it to the painter");
+  assert.match(src, /const p = paintSecret\(msg, socketId\);/);
+  assert.match(src, /function paintQuestion\(msg, paintedOnSocket = null\) \{/);
+  assert.match(src, /function paintSecret\(msg, paintedOnSocket = null\) \{/);
+  // The registry entry prefers the painter's own id and falls back to the UI's belief.
+  // BOTH painters, COUNTED. Matching once passed while one of the two had lost it — a
+  // guard that cannot tell "both do this" from "at least one does" is not guarding much.
+  assert.equal(
+    (src.match(/\.\.\.\(paintedOnSocket != null \? \{ paintedOnSocket \} : \{\}\),/g) ?? []).length,
+    2,
+    "the question card AND the secret card each record the socket they were painted on",
+  );
+});
+
+test("#952 (codex r2) a card painted on a socket the UI never adopted is still tied to it", () => {
+  // The behavioural half: with the id coming from the COMMAND, a card painted while
+  // `liveSocketId` is stale still records the socket that asked, so that socket
+  // handshaking does not retire it — and the older one still does. This matters because
+  // the open status carrying a new socket's id is suppressed once the patience window has
+  // been given up on, so the UI's belief can be stale exactly when it counts.
+  const src = readFileSync(PANEL_JS, "utf8");
+  const make = new Function(
+    `let liveSocketId = null;
+     const liveInteractiveCards = new Set();
+     ${namedFunctionSource(src, "registerInteractiveCard")}
+     ${namedFunctionSource(src, "retireInteractiveCardsFromPreviousSockets")}
+     function onStatus(state, socketId) {
+       if (socketId != null && socketId !== liveSocketId) liveSocketId = socketId;
+       if (state === "connected") retireInteractiveCardsFromPreviousSockets();
+     }
+     return { registerInteractiveCard, onStatus };`,
+  )();
+  make.onStatus("connected", 1); // socket A is live
+  const retiredA = [];
+  make.registerInteractiveCard({ retire: () => retiredA.push("A") });
+  // Socket B opens with NO status reaching the UI, and an ask_user arrives on it: the
+  // painter names B explicitly.
+  const retiredB = [];
+  make.registerInteractiveCard({ paintedOnSocket: 2, retire: () => retiredB.push("B") });
+  make.onStatus("connected", 2); // B finally handshakes
+  assert.deepEqual(retiredA, ["A"], "the card from A is retired");
+  assert.deepEqual(retiredB, [], "the card that named B survives B handshaking");
+});

--- a/browser_tests/unit/stale-interactive-card.test.mjs
+++ b/browser_tests/unit/stale-interactive-card.test.mjs
@@ -1,0 +1,128 @@
+/**
+ * #952 — a `panel_ask` whose tab disconnects mid-command returns an unknown outcome, and
+ * the orchestrator's own message (comfyui-mcp 0.50.88) has to warn:
+ *
+ *   "Expect the stale card to remain on screen: retry suppression is keyed to the socket
+ *    that dropped, so this counts as a new command and the user may see two. Tell them
+ *    which one to answer."
+ *
+ * The panel is the side that can just say it. A card painted on a connection that has since
+ * been replaced cannot deliver an answer to anyone — the panel deliberately does not replay
+ * a reply of this kind across a reconnect — yet it looks exactly as clickable as the newer
+ * card beside it.
+ *
+ * DELIBERATELY NOT TOUCHED, because they are design questions this issue records and leaves
+ * to its owner: whether interactive cards should dedupe on a scope that survives a
+ * reconnect, and what a retry should return while the original is unanswered. Retiring a
+ * dead card needs neither — no new scope, no retry semantics, no ledger change.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const PANEL_JS = join(HERE, "../../web/js/comfyui-mcp-panel.js");
+
+function namedFunctionSource(src, name) {
+  const start = src.indexOf(`function ${name}(`);
+  if (start === -1) return null;
+  const bodyOpen = src.indexOf(") {", start);
+  if (bodyOpen === -1) return null;
+  let depth = 0;
+  for (let i = bodyOpen + 2; i < src.length; i += 1) {
+    if (src[i] === "{") depth += 1;
+    if (src[i] === "}" && --depth === 0) return src.slice(start, i + 1);
+  }
+  return null;
+}
+
+/** A DOM stub with exactly the surface `retireInteractiveCard` touches. */
+function fakeCard({ connected = true, controls = 2 } = {}) {
+  const children = [];
+  const els = Array.from({ length: controls }, () => ({ disabled: false, style: {} }));
+  return {
+    isConnected: connected,
+    style: {},
+    querySelectorAll: () => els,
+    appendChild: (n) => children.push(n),
+    _children: children,
+    _controls: els,
+  };
+}
+
+/** The shipped retire function, with a document stub for the note element. */
+function loadRetire() {
+  const src = readFileSync(PANEL_JS, "utf8");
+  const fn = namedFunctionSource(src, "retireInteractiveCard");
+  assert.ok(fn, "retireInteractiveCard not found");
+  const document = {
+    createElement: () => ({ className: "", style: { cssText: "" }, textContent: "" }),
+  };
+  return new Function("document", `${fn}; return retireInteractiveCard;`)(document);
+}
+
+const retire = loadRetire();
+
+test("#952 a retired card loses every control and says why", () => {
+  const card = fakeCard({ controls: 3 });
+  retire(card, { alreadyAnswered: () => false, what: "question" });
+  assert.ok(card._controls.every((c) => c.disabled === true), "nothing stays clickable");
+  assert.ok(card._controls.every((c) => c.style.cursor === "not-allowed"));
+  assert.equal(card._children.length, 1, "one explanatory line is added");
+  assert.match(card._children[0].textContent, /connection that asked this question dropped/);
+  assert.match(card._children[0].textContent, /answer here can no longer reach the agent/);
+  assert.match(card._children[0].textContent, /If it asked again, answer the newer card\./, "and what to do");
+});
+
+test("#952 an ANSWERED card is left completely alone", () => {
+  // It is already collapsed into a static result, and its answer DID reach the agent.
+  // Adding a note about a dropped connection there would be false.
+  const card = fakeCard();
+  retire(card, { alreadyAnswered: () => true, what: "question" });
+  assert.equal(card._children.length, 0);
+  assert.ok(card._controls.every((c) => c.disabled === false));
+});
+
+test("#952 a card already removed from the log is not touched", () => {
+  const card = fakeCard({ connected: false });
+  retire(card, { alreadyAnswered: () => false });
+  assert.equal(card._children.length, 0);
+});
+
+test("#952 retirement is presentation only — a hostile card cannot break a reconnect", () => {
+  const hostile = {
+    isConnected: true,
+    style: {},
+    querySelectorAll() {
+      throw new Error("boom");
+    },
+    appendChild() {},
+  };
+  assert.doesNotThrow(() => retire(hostile, { alreadyAnswered: () => false }));
+  assert.doesNotThrow(() => retire(null, {}));
+  assert.doesNotThrow(() => retire(fakeCard(), { alreadyAnswered: () => { throw new Error("boom"); } }));
+});
+
+test("#952 source guard: a CONNECT retires earlier cards, and nothing resolves their promise", () => {
+  const src = readFileSync(PANEL_JS, "utf8");
+  // The trigger is a positive fact — a new connection exists — not a "connecting" blip.
+  assert.match(src, /if \(state === "connected"\) \{\r?\n\s*bridgeConnectSeq \+= 1;/, "counted on connect");
+  assert.match(src, /retireInteractiveCardsFromPreviousConnections\(\);/);
+  const sweep = namedFunctionSource(src, "retireInteractiveCardsFromPreviousConnections");
+  assert.match(sweep, /if \(record\.paintedOnConnect >= bridgeConnectSeq\) continue;/, "only EARLIER cards");
+  // Resolving would send an answer to a socket that is gone, and the panel's own rule is
+  // that a reply of this kind does not cross a reconnect.
+  assert.ok(!/resolveFn|resolve\(/.test(sweep), "the sweep must not answer anything");
+  const retireSrc = namedFunctionSource(src, "retireInteractiveCard");
+  assert.ok(!/resolveFn|resolve\(/.test(retireSrc), "nor may the retirement itself");
+});
+
+test("#952 source guard: a question card registers itself and unregisters when answered", () => {
+  const src = readFileSync(PANEL_JS, "utf8");
+  const paint = namedFunctionSource(src, "paintQuestion");
+  assert.match(paint, /const unregister = registerInteractiveCard\(\{/, "registered at paint");
+  assert.match(paint, /alreadyAnswered: \(\) => done,/, "so an answered card is skipped");
+  assert.match(paint, /promise\.then\(unregister, unregister\)/, "and dropped once it settles, either way");
+});

--- a/browser_tests/unit/stale-interactive-card.test.mjs
+++ b/browser_tests/unit/stale-interactive-card.test.mjs
@@ -105,13 +105,19 @@ test("#952 retirement is presentation only — a hostile card cannot break a rec
   assert.doesNotThrow(() => retire(fakeCard(), { alreadyAnswered: () => { throw new Error("boom"); } }));
 });
 
-test("#952 source guard: a CONNECT retires earlier cards, and nothing resolves their promise", () => {
+test("#952 (codex) source guard: a DIFFERENT SOCKET retires cards, and nothing resolves their promise", () => {
   const src = readFileSync(PANEL_JS, "utf8");
-  // The trigger is a positive fact — a new connection exists — not a "connecting" blip.
-  assert.match(src, /if \(state === "connected"\) \{\r?\n\s*bridgeConnectSeq \+= 1;/, "counted on connect");
-  assert.match(src, /retireInteractiveCardsFromPreviousConnections\(\);/);
-  const sweep = namedFunctionSource(src, "retireInteractiveCardsFromPreviousConnections");
-  assert.match(sweep, /if \(record\.paintedOnConnect >= bridgeConnectSeq\) continue;/, "only EARLIER cards");
+  // `"connected"` re-fires on every re-handshake — each `models` frame calls markConnected,
+  // and a workflow change re-hellos the LIVE socket — so keying on the status string would
+  // retire cards that are still perfectly answerable. The socket's identity can tell them
+  // apart; the string cannot.
+  assert.match(src, /socketId != null && socketId !== liveSocketId/, "a DIFFERENT socket");
+  assert.match(src, /retireInteractiveCardsFromPreviousSockets\(\);/);
+  assert.ok(!/bridgeConnectSeq/.test(src), "the status-counting trigger must not come back");
+  assert.match(src, /thisSock\.__cmcpSocketId = \+\+socketSeq;/, "minted once per WebSocket");
+  assert.match(src, /onStatus\(s, sock\?\.__cmcpSocketId \?\? null\)/, "and handed to the UI");
+  const sweep = namedFunctionSource(src, "retireInteractiveCardsFromPreviousSockets");
+  assert.match(sweep, /if \(record\.paintedOnSocket === liveSocketId\) continue;/, "only cards from another socket");
   // Resolving would send an answer to a socket that is gone, and the panel's own rule is
   // that a reply of this kind does not cross a reconnect.
   assert.ok(!/resolveFn|resolve\(/.test(sweep), "the sweep must not answer anything");
@@ -125,4 +131,35 @@ test("#952 source guard: a question card registers itself and unregisters when a
   assert.match(paint, /const unregister = registerInteractiveCard\(\{/, "registered at paint");
   assert.match(paint, /alreadyAnswered: \(\) => done,/, "so an answered card is skipped");
   assert.match(paint, /promise\.then\(unregister, unregister\)/, "and dropped once it settles, either way");
+});
+
+test("#952 (codex) a SECRET card is retired too, with secret-safe wording", () => {
+  // It matters more here than for a question: a live password field whose reply has
+  // nowhere to go can still display "Token saved", telling a user their token was stored
+  // when nothing received it.
+  const src = readFileSync(PANEL_JS, "utf8");
+  const paint = namedFunctionSource(src, "paintSecret");
+  assert.match(paint, /const unregisterSecret = registerInteractiveCard\(\{/, "registered at paint");
+  assert.match(paint, /what: "secret request"/);
+  assert.match(paint, /Nothing was sent and nothing was stored/, "no false 'saved' impression survives");
+  assert.match(paint, /do not paste the value into the chat/, "never redirect a secret into the transcript");
+  assert.match(paint, /promise\.then\(unregisterSecret, unregisterSecret\)/);
+  // The question card's advice would be actively wrong here.
+  assert.ok(!/answer the newer card/.test(paint), "a secret card must not reuse the question wording");
+});
+
+test("#952 (codex) the retirement note takes the caller's detail, and defaults for a question", () => {
+  const card = fakeCard();
+  retire(card, {
+    alreadyAnswered: () => false,
+    what: "secret request",
+    detail: "Nothing was sent and nothing was stored. Wait for the agent to ask again.",
+  });
+  assert.match(card._children[0].textContent, /connection that asked this secret request dropped/);
+  assert.match(card._children[0].textContent, /Nothing was sent and nothing was stored/);
+  assert.doesNotMatch(card._children[0].textContent, /answer the newer card/);
+
+  const q = fakeCard();
+  retire(q, { alreadyAnswered: () => false });
+  assert.match(q._children[0].textContent, /If it asked again, answer the newer card\./, "the default stands");
 });

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -16062,7 +16062,11 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
     // readiness probe, which can be wrong (e.g. a CLI the orchestrator's PATH
     // can't see). try/catch guards the case where the card isn't built yet.
     if (s === "connected") { try { onboard.hidden = true; } catch {} }
-    onStatus(s);
+    // #952 — the SOCKET this status is about. `"connected"` re-fires on every
+    // re-handshake, so the string alone cannot distinguish a replacement connection
+    // from the live one saying hello again; the id can, and a consumer that ignores
+    // the argument behaves exactly as before.
+    onStatus(s, sock?.__cmcpSocketId ?? null);
   }
   // FIX 1/2 — STEADY status + cold-start patience. While we're actively (auto)
   // reconnecting we hold the pill on a steady "connecting"; a terminal
@@ -16118,6 +16122,7 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
       handshakeTimer = null;
     }
   }
+  let socketSeq = 0;
   function markConnected() {
     handshakeDone = true;
     handshakenSock = sock;
@@ -16317,6 +16322,13 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
       return;
     }
     sock = thisSock;
+    // #952 — a SOCKET identity for the UI. `"connected"` is emitted on every
+    // re-handshake (every `models` frame calls markConnected, and a workflow change
+    // re-hellos the LIVE socket), so the status string cannot tell a replacement
+    // connection from the same one saying hello again — and a UI that treats each as a
+    // replacement would retire question cards that are still perfectly answerable
+    // (codex). This id changes only when a WebSocket is constructed.
+    thisSock.__cmcpSocketId = ++socketSeq;
     // Stamp the socket with the bridge it belongs to, so a replay onto it can be checked
     // against the entry's origin rather than against the mutable current `url`.
     try {
@@ -22848,28 +22860,31 @@ function buildPanel() {
   /**
    * #952 — cards painted on a connection that has since been replaced.
    *
-   * `bridgeConnectSeq` counts CONNECTS, not status changes: a card records the value at
-   * paint time, and a later connect retires everything painted before it. That is a
-   * positive fact — a new connection exists — rather than an inference from a transient
-   * "connecting" blip, and it needs no bridge epoch plumbed into the UI.
+   * KEYED ON THE SOCKET, not on the status string (codex). `"connected"` is emitted on
+   * every RE-HANDSHAKE — each `models` frame calls `markConnected`, and a workflow change
+   * re-hellos the LIVE socket — so counting those would retire question cards that are
+   * still perfectly answerable, which is worse than the duplicate this fixes. The client
+   * mints an id per WebSocket and hands it to `onStatus`; a card records the id that was
+   * live when it was painted, and only a DIFFERENT id retires it.
    *
    * Deliberately NOT resolving the card's promise. The command that painted it already
    * failed with an unknown outcome on the socket that dropped; resolving here would send
    * an answer nowhere, and the panel's own rule is that a reply of this kind does not
    * cross a reconnect. The card stops LOOKING answerable, and says why.
    */
-  let bridgeConnectSeq = 0;
+  /** The socket id the UI currently believes it is talking to (#952). */
+  let liveSocketId = null;
   const liveInteractiveCards = new Set();
 
   function registerInteractiveCard(entry) {
-    const record = { paintedOnConnect: bridgeConnectSeq, ...entry };
+    const record = { paintedOnSocket: liveSocketId, ...entry };
     liveInteractiveCards.add(record);
     return () => liveInteractiveCards.delete(record);
   }
 
-  function retireInteractiveCardsFromPreviousConnections() {
+  function retireInteractiveCardsFromPreviousSockets() {
     for (const record of [...liveInteractiveCards]) {
-      if (record.paintedOnConnect >= bridgeConnectSeq) continue;
+      if (record.paintedOnSocket === liveSocketId) continue;
       liveInteractiveCards.delete(record);
       try {
         record.retire?.();
@@ -22881,7 +22896,7 @@ function buildPanel() {
   }
 
   /** Turn a live interactive card into a dead one: no controls, and a reason. */
-  function retireInteractiveCard(card, { alreadyAnswered, what } = {}) {
+  function retireInteractiveCard(card, { alreadyAnswered, what, detail } = {}) {
     try {
       if (typeof alreadyAnswered === "function" && alreadyAnswered()) return;
       if (!card || !card.isConnected) return;
@@ -22896,7 +22911,8 @@ function buildPanel() {
       note.style.cssText = "font-size:0.68rem;opacity:0.8;margin-top:0.4rem;";
       note.textContent =
         `The connection that asked this ${what ?? "question"} dropped, so an answer here can no ` +
-        `longer reach the agent. If it asked again, answer the newer card.`;
+        `longer reach the agent. ` +
+        (detail ?? "If it asked again, answer the newer card.");
       card.appendChild(note);
     } catch {
       /* presentation only — never break a reconnect */
@@ -23031,6 +23047,23 @@ function buildPanel() {
     log.appendChild(card);
     scrollLog();
     setTimeout(() => input.focus(), 0);
+    // #952 — the SECRET card needs this more than the question card does (codex). It is
+    // a live password field whose reply has nowhere to go once its connection is
+    // replaced, and it can still display "Token saved" — telling a user their token was
+    // stored when nothing received it. Same retirement, different words: never suggest
+    // typing the value somewhere else, because the whole point of this card is that the
+    // value reaches the orchestrator through an input the agent never sees.
+    const unregisterSecret = registerInteractiveCard({
+      retire: () =>
+        retireInteractiveCard(card, {
+          alreadyAnswered: () => done,
+          what: "secret request",
+          detail:
+            "Nothing was sent and nothing was stored. Wait for the agent to ask again on " +
+            "the new connection — do not paste the value into the chat.",
+        }),
+    });
+    promise.then(unregisterSecret, unregisterSecret);
     return promise;
   }
 
@@ -24639,15 +24672,16 @@ function buildPanel() {
   // here; the `pair_url`/`pair_error` reply consumes it (mirrors pendingSetSecret).
   let pendingPair = null;
   const client = createBridgeClient({
-    onStatus(state) {
+    onStatus(state, socketId) {
       statusText.textContent = state;
-      // #952 — a CONNECT retires interactive cards painted on an earlier connection.
-      // Counting connects rather than reacting to "connecting"/"disconnected" keeps this
-      // on a positive fact: a new connection exists, so anything asked on the previous one
-      // can no longer deliver an answer.
-      if (state === "connected") {
-        bridgeConnectSeq += 1;
-        retireInteractiveCardsFromPreviousConnections();
+      // #952 — a card painted on a connection that has since been REPLACED can no longer
+      // deliver an answer. The trigger is the socket's identity, not the status string:
+      // `"connected"` re-fires on every re-handshake (each `models` frame, and a workflow
+      // change re-hellos the live socket), so keying on it would retire cards that are
+      // still perfectly answerable (codex).
+      if (state === "connected" && socketId != null && socketId !== liveSocketId) {
+        liveSocketId = socketId;
+        retireInteractiveCardsFromPreviousSockets();
       }
       dot.className = "cmcp-dot" + (state === "connected" ? " connected" : state === "connecting" ? " connecting" : "");
       // Connection status does NOT drive this box's visibility. It's a

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -16595,13 +16595,18 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
             // chat (UI scope) and block on the user's pick. The chosen string
             // becomes the tool result the agent receives.
             if (!onAsk) throw new Error("This panel build can't display questions.");
-            result = await onAsk(msg);
+            // #952 — the card is tied to the socket that ASKED, taken from the frame's own
+            // socket rather than from whatever the UI currently believes is live. A command
+            // is accepted before the handshake, and the open status that would have told the
+            // UI about this socket is suppressed once the patience window has been given up
+            // on — so a UI-side belief can be stale exactly when it matters (codex r2).
+            result = await onAsk(msg, thisSock.__cmcpSocketId ?? null);
           } else if (msg.cmd === "request_secret") {
             // Secure secret entry. The pasted value rides back to the
             // orchestrator (which writes it to config) and is the tool's reply;
             // it is never surfaced to the agent's context or recorded to history.
             if (!onSecret) throw new Error("This panel build can't collect secrets.");
-            result = await onSecret(msg);
+            result = await onSecret(msg, thisSock.__cmcpSocketId ?? null);
           } else if (msg.cmd === "soft_reload") {
             // Agent-triggered soft reload. Reply FIRST (below), then bounce —
             // an "orchestrator" scope kills this very session, so the resume
@@ -22723,7 +22728,7 @@ function buildPanel() {
    * An always-present "Other…" field lets the user answer freely. Returns the
    * chosen string (comma-joined for multi-select) — the agent's tool result.
    */
-  function paintQuestion(msg) {
+  function paintQuestion(msg, paintedOnSocket = null) {
     clearEmpty();
     const opts = Array.isArray(msg.options) ? msg.options : [];
     const multi = !!msg.multi_select;
@@ -22847,6 +22852,7 @@ function buildPanel() {
     // has to warn "the user may see two … tell them which one to answer"; the panel is
     // the side that can just say it.
     const unregister = registerInteractiveCard({
+      ...(paintedOnSocket != null ? { paintedOnSocket } : {}),
       retire: () =>
         retireInteractiveCard(card, {
           alreadyAnswered: () => done,
@@ -22877,6 +22883,8 @@ function buildPanel() {
   const liveInteractiveCards = new Set();
 
   function registerInteractiveCard(entry) {
+    // The socket the CARD was painted on, taken from the command frame when the caller
+    // knows it. `liveSocketId` is only a fallback for a painter with no frame in hand.
     const record = { paintedOnSocket: liveSocketId, ...entry };
     liveInteractiveCards.add(record);
     return () => liveInteractiveCards.delete(record);
@@ -22927,7 +22935,7 @@ function buildPanel() {
    * over the bridge to the orchestrator (which writes it to config); it never
    * enters the agent's context.
    */
-  function paintSecret(msg) {
+  function paintSecret(msg, paintedOnSocket = null) {
     clearEmpty();
     const card = document.createElement("div");
     card.className = "cmcp-card cmcp-secret";
@@ -23054,6 +23062,7 @@ function buildPanel() {
     // typing the value somewhere else, because the whole point of this card is that the
     // value reaches the orchestrator through an input the agent never sees.
     const unregisterSecret = registerInteractiveCard({
+      ...(paintedOnSocket != null ? { paintedOnSocket } : {}),
       retire: () =>
         retireInteractiveCard(card, {
           alreadyAnswered: () => done,
@@ -24679,10 +24688,15 @@ function buildPanel() {
       // `"connected"` re-fires on every re-handshake (each `models` frame, and a workflow
       // change re-hellos the live socket), so keying on it would retire cards that are
       // still perfectly answerable (codex).
-      if (state === "connected" && socketId != null && socketId !== liveSocketId) {
-        liveSocketId = socketId;
-        retireInteractiveCardsFromPreviousSockets();
-      }
+      // ADOPT AS SOON AS THE SOCKET EXISTS, RETIRE ONLY ONCE IT HAS HANDSHAKEN (codex r2).
+      // A command frame is accepted before the handshake, so an interactive card CAN be
+      // painted on a socket whose id the UI has not adopted yet — and it would then look
+      // like it belonged to the PREVIOUS connection and be retired the moment this one
+      // finished handshaking, killing a card that is perfectly live. Adoption happens on
+      // the open status that carries the new id; the sweep waits for `connected`, which is
+      // the point at which the previous connection is definitively replaced.
+      if (socketId != null && socketId !== liveSocketId) liveSocketId = socketId;
+      if (state === "connected") retireInteractiveCardsFromPreviousSockets();
       dot.className = "cmcp-dot" + (state === "connected" ? " connected" : state === "connecting" ? " connecting" : "");
       // Connection status does NOT drive this box's visibility. It's a
       // dropdown: the user opens it and the user closes it (trigger, click
@@ -24799,11 +24813,11 @@ function buildPanel() {
     },
     // The agent called panel_ask — render a question card and resolve with the
     // user's pick. Keep the working indicator pinned below it while we wait.
-    onAsk(msg) {
+    onAsk(msg, socketId) {
       // Fence FIRST: a card from a turn this tab no longer owns must not paint,
       // and must not revive the working indicator on its way past either.
       fenceInteractiveCard("ask_user");
-      const p = paintQuestion(msg);
+      const p = paintQuestion(msg, socketId);
       bumpThinking();
       noteActivity(); // a panel_ask frame is real turn activity → reset the clock
       return p;
@@ -24959,7 +24973,7 @@ function buildPanel() {
       setThinkingTokens(tokens);
     },
     // The agent called panel_request_secret — collect a token securely.
-    onSecret(msg) {
+    onSecret(msg, socketId) {
       // If this secure request was kicked off from a Settings "Set … token" button,
       // record a (non-secret) "set at" marker once a non-empty value is submitted so
       // the Settings indicator can show set/not-set. Only the timestamp is stored.
@@ -24973,7 +24987,7 @@ function buildPanel() {
       // no longer owns must not get a masked input painted into the conversation
       // that happens to be on screen — see lib/interactive-card-fence.js.
       fenceInteractiveCard("request_secret");
-      const p = paintSecret(msg);
+      const p = paintSecret(msg, socketId);
       bumpThinking();
       if (req) {
         p.then((value) => {

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -22851,8 +22851,11 @@ function buildPanel() {
     // as clickable as a newer card asking the same thing. The orchestrator's own message
     // has to warn "the user may see two … tell them which one to answer"; the panel is
     // the side that can just say it.
-    const unregister = registerInteractiveCard({
-      ...(paintedOnSocket != null ? { paintedOnSocket } : {}),
+    // #952 — tracked ONLY when a command painted it. A card with no command behind it
+    // has no socket to be orphaned by, and retiring it would disable something that
+    // still works (codex r3).
+    const unregister = paintedOnSocket == null ? () => {} : registerInteractiveCard({
+      paintedOnSocket,
       retire: () =>
         retireInteractiveCard(card, {
           alreadyAnswered: () => done,
@@ -22883,9 +22886,9 @@ function buildPanel() {
   const liveInteractiveCards = new Set();
 
   function registerInteractiveCard(entry) {
-    // The socket the CARD was painted on, taken from the command frame when the caller
-    // knows it. `liveSocketId` is only a fallback for a painter with no frame in hand.
-    const record = { paintedOnSocket: liveSocketId, ...entry };
+    // Every entry names the socket its COMMAND arrived on; a card with no command
+    // behind it is never registered, so there is no belief-based fallback here.
+    const record = { paintedOnSocket: null, ...entry };
     liveInteractiveCards.add(record);
     return () => liveInteractiveCards.delete(record);
   }
@@ -23061,8 +23064,13 @@ function buildPanel() {
     // stored when nothing received it. Same retirement, different words: never suggest
     // typing the value somewhere else, because the whole point of this card is that the
     // value reaches the orchestrator through an input the agent never sees.
-    const unregisterSecret = registerInteractiveCard({
-      ...(paintedOnSocket != null ? { paintedOnSocket } : {}),
+    // #952 — command-originated cards only. The Settings "Set … token" buttons paint
+    // this same card with no command behind them, and that card is agent-free: after a
+    // reconnect it can still send its set_secret on the current socket, so retiring it
+    // would disable a working control and tell the user to wait for a request that is
+    // never coming (codex r3).
+    const unregisterSecret = paintedOnSocket == null ? () => {} : registerInteractiveCard({
+      paintedOnSocket,
       retire: () =>
         retireInteractiveCard(card, {
           alreadyAnswered: () => done,

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -22828,7 +22828,79 @@ function buildPanel() {
 
     log.appendChild(card);
     scrollLog();
+    // #952 — REGISTER THE CARD AGAINST THE CONNECTION THAT PAINTED IT. A reply of this
+    // kind is deliberately not replayed across a reconnect, so once this connection is
+    // replaced the card cannot deliver an answer to anyone — while still looking exactly
+    // as clickable as a newer card asking the same thing. The orchestrator's own message
+    // has to warn "the user may see two … tell them which one to answer"; the panel is
+    // the side that can just say it.
+    const unregister = registerInteractiveCard({
+      retire: () =>
+        retireInteractiveCard(card, {
+          alreadyAnswered: () => done,
+          what: "question",
+        }),
+    });
+    promise.then(unregister, unregister);
     return promise;
+  }
+
+  /**
+   * #952 — cards painted on a connection that has since been replaced.
+   *
+   * `bridgeConnectSeq` counts CONNECTS, not status changes: a card records the value at
+   * paint time, and a later connect retires everything painted before it. That is a
+   * positive fact — a new connection exists — rather than an inference from a transient
+   * "connecting" blip, and it needs no bridge epoch plumbed into the UI.
+   *
+   * Deliberately NOT resolving the card's promise. The command that painted it already
+   * failed with an unknown outcome on the socket that dropped; resolving here would send
+   * an answer nowhere, and the panel's own rule is that a reply of this kind does not
+   * cross a reconnect. The card stops LOOKING answerable, and says why.
+   */
+  let bridgeConnectSeq = 0;
+  const liveInteractiveCards = new Set();
+
+  function registerInteractiveCard(entry) {
+    const record = { paintedOnConnect: bridgeConnectSeq, ...entry };
+    liveInteractiveCards.add(record);
+    return () => liveInteractiveCards.delete(record);
+  }
+
+  function retireInteractiveCardsFromPreviousConnections() {
+    for (const record of [...liveInteractiveCards]) {
+      if (record.paintedOnConnect >= bridgeConnectSeq) continue;
+      liveInteractiveCards.delete(record);
+      try {
+        record.retire?.();
+      } catch {
+        // A card that cannot be retired is left exactly as it was — never a thrown
+        // error out of a connection callback.
+      }
+    }
+  }
+
+  /** Turn a live interactive card into a dead one: no controls, and a reason. */
+  function retireInteractiveCard(card, { alreadyAnswered, what } = {}) {
+    try {
+      if (typeof alreadyAnswered === "function" && alreadyAnswered()) return;
+      if (!card || !card.isConnected) return;
+      for (const el of card.querySelectorAll("button, input, textarea, select")) {
+        el.disabled = true;
+        el.style.opacity = "0.5";
+        el.style.cursor = "not-allowed";
+      }
+      card.style.opacity = "0.6";
+      const note = document.createElement("div");
+      note.className = "cmcp-card-stale";
+      note.style.cssText = "font-size:0.68rem;opacity:0.8;margin-top:0.4rem;";
+      note.textContent =
+        `The connection that asked this ${what ?? "question"} dropped, so an answer here can no ` +
+        `longer reach the agent. If it asked again, answer the newer card.`;
+      card.appendChild(note);
+    } catch {
+      /* presentation only — never break a reconnect */
+    }
   }
 
   /**
@@ -24569,6 +24641,14 @@ function buildPanel() {
   const client = createBridgeClient({
     onStatus(state) {
       statusText.textContent = state;
+      // #952 — a CONNECT retires interactive cards painted on an earlier connection.
+      // Counting connects rather than reacting to "connecting"/"disconnected" keeps this
+      // on a positive fact: a new connection exists, so anything asked on the previous one
+      // can no longer deliver an answer.
+      if (state === "connected") {
+        bridgeConnectSeq += 1;
+        retireInteractiveCardsFromPreviousConnections();
+      }
       dot.className = "cmcp-dot" + (state === "connected" ? " connected" : state === "connecting" ? " connecting" : "");
       // Connection status does NOT drive this box's visibility. It's a
       // dropdown: the user opens it and the user closes it (trigger, click


### PR DESCRIPTION
Claims #952 — the part of it that needs no design decision.

The two design questions this issue records are deliberately left alone: whether interactive
cards should dedupe on a scope that survives a reconnect, and what a retry should return
while the original card is unanswered. Both are still the owner's call, and the orchestrator
half shipped in comfyui-mcp 0.50.88.

What that fix has to tell the user today is this:

> Expect the stale card to remain on screen: retry suppression is keyed to the socket that
> dropped, so this counts as a new command and the user may see two. Tell them which one to
> answer.

The panel can say that itself. A card painted on a connection that has since been replaced
can no longer deliver its answer — the panel deliberately does not replay a reply of this
kind across a reconnect — so it is not merely stale, it is dead, and it still looks exactly
as clickable as the live one beside it.

Marking it needs no new scope, no retry semantics, and no ledger change: a card records
which connection painted it, and a later connect retires the ones from before.