### PR TITLE
fix(952): an abandoned question settles its ledger entry instead of hanging on it

### DIFF
--- a/browser_tests/unit/interactive-abandon.test.mjs
+++ b/browser_tests/unit/interactive-abandon.test.mjs
@@ -158,8 +158,10 @@ test("#952 (codex ×2) the claim is the LEDGER — not a caller-visible recovery
   // buffer keeps `msg.ok` only. The second retreated to "a REDELIVERY reads it", which is
   // also not a production path for these two commands: every dispatch mints a fresh rid,
   // `retry_of` is injected only for RETRY_TOKEN_CMDS (which excludes both), and re-asking
-  // mints a new `ask_id` that is part of the fingerprint. What survives is narrow and
-  // true: the entry settles, so it is evictable and no later delivery can hang.
+  // mints a new `ask_id` that is part of the fingerprint. What survives is narrow: while
+  // the settled entry is RETAINED a matching duplicate replays its recorded failure, and
+  // settling makes the entry eligible for ordinary cap eviction. Not more — eviction is
+  // fail-open, so a duplicate after it ages out executes fresh and blocks on a human again.
   const src = readFileSync(new URL("../../web/js/lib/interactive-abandon.js", import.meta.url), "utf8");
   assert.match(src, /It does NOT rescue the interrupted call/, "the limit is stated, not implied");
   assert.match(src, /the caller\s*(?:\/\/\s*)?never sees the text below/, "and stated concretely");
@@ -171,14 +173,38 @@ test("#952 (codex ×2) the claim is the LEDGER — not a caller-visible recovery
   assert.match(src, /While the settled \(epoch, rid, fingerprint\) entry is RETAINED/);
   assert.match(src, /eligible for normal cap eviction/);
   assert.match(src, /Eviction is deliberately fail-open/);
+  // Scanned across the module AND this file (codex r4): a negative assertion that only
+  // polices the source lets the retracted claim survive in the comment that explains it,
+  // which is where the next reader would pick it back up.
+  const self = readFileSync(new URL("./interactive-abandon.test.mjs", import.meta.url), "utf8");
   for (const overclaim of [
     /the caller (?:learns|is told|sees) (?:that )?the card was withdrawn/i,
     /the only path on which a caller reads it/i,
     /does still reach the handler/i,
-    /no future delivery of that rid\s*(?:\/\/\s*)?can hang the handler/i,
+    /no (?:later|future) delivery (?:of that rid\s*(?:\/\/\s*)?)?can hang/i,
   ]) {
-    assert.ok(!overclaim.test(src), `retracted claim is gone: ${overclaim}`);
+    assert.ok(!overclaim.test(src), `retracted claim is gone from the module: ${overclaim}`);
+    // This file quotes the retracted phrasings inside the regex list itself, so compare
+    // against the prose only — everything outside these bracketed patterns.
+    const prose = self.replace(/for \(const overclaim of \[[\s\S]*?\]\) \{/, "");
+    assert.ok(!overclaim.test(prose), `…and from this test's own comments: ${overclaim}`);
   }
+});
+
+test("#952 (codex r4) the trigger is a REPLACEMENT connection, not a bare disconnect", () => {
+  // The header used to say the card is retired "when the connection that asked drops".
+  // The sweep runs from a `connected` status carrying a different socket id — so a socket
+  // that simply drops retires nothing, and the card stays live until something replaces
+  // it. Documenting the wrong trigger would have a reader expect an abandonment reply at
+  // a moment when none is produced.
+  const src = readFileSync(new URL("../../web/js/lib/interactive-abandon.js", import.meta.url), "utf8");
+  assert.match(src, /a bare disconnect retires nothing/, "the trigger is stated correctly");
+  const panel = readFileSync(PANEL, "utf8");
+  assert.match(
+    panel,
+    /if \(state === "connected"\) retireInteractiveCardsFromPreviousSockets\(\);/,
+    "and that is what the wiring does",
+  );
 });
 
 test("#952 (codex r3) the note does not claim a card that may not be on screen", () => {

--- a/browser_tests/unit/interactive-abandon.test.mjs
+++ b/browser_tests/unit/interactive-abandon.test.mjs
@@ -165,13 +165,30 @@ test("#952 (codex ×2) the claim is the LEDGER — not a caller-visible recovery
   assert.match(src, /the caller\s*(?:\/\/\s*)?never sees the text below/, "and stated concretely");
   assert.match(src, /keeps `msg\.ok` replies only/, "and names the specific orchestrator behaviour");
   assert.match(src, /Treat that branch as\s*(?:\/\/\s*)?defensive/, "the replay branch is not sold as recovery");
-  assert.match(src, /evictable and the cap applies again/, "the claim that IS established");
+  // The claim that IS established, and it is bounded by RETENTION — eviction is fail-open,
+  // so a duplicate arriving after the entry ages out executes fresh and blocks on a human
+  // again. The eviction test above is that counterexample, so the two must agree.
+  assert.match(src, /While the settled \(epoch, rid, fingerprint\) entry is RETAINED/);
+  assert.match(src, /eligible for normal cap eviction/);
+  assert.match(src, /Eviction is deliberately fail-open/);
   for (const overclaim of [
     /the caller (?:learns|is told|sees) (?:that )?the card was withdrawn/i,
     /the only path on which a caller reads it/i,
     /does still reach the handler/i,
+    /no future delivery of that rid\s*(?:\/\/\s*)?can hang the handler/i,
   ]) {
     assert.ok(!overclaim.test(src), `retracted claim is gone: ${overclaim}`);
+  }
+});
+
+test("#952 (codex r3) the note does not claim a card that may not be on screen", () => {
+  // Retirement returns early when the card is no longer in the DOM, and abandons the
+  // command anyway. "The card on screen has been disabled" was therefore false in exactly
+  // that case; scoping it to a card that IS still there is true in both.
+  for (const cmd of ["ask_user", "request_secret"]) {
+    const note = abandonedInteractiveError(cmd);
+    assert.match(note, /any card still on screen for it has been disabled/, cmd);
+    assert.ok(!/the card on screen has been disabled/.test(note), cmd);
   }
 });
 

--- a/browser_tests/unit/interactive-abandon.test.mjs
+++ b/browser_tests/unit/interactive-abandon.test.mjs
@@ -151,6 +151,23 @@ test("#952 a reply that CARRIES the answer is still redacted — both commands",
   assert.equal(redactSensitiveReply(graph, "graph_add_node"), graph);
 });
 
+test("#952 (codex) the module says where this reply is read — it is NOT the disconnected caller", () => {
+  // The first draft implied the caller would read "the question was withdrawn". Measured
+  // against the orchestrator, they do not: the old socket's close already rejected the
+  // call with the bridge's own outcome-unknown error, the journal replay finds no pending
+  // rid, and the bridge's late-answer buffer for `ask_user` keeps `msg.ok` replies only —
+  // so a payload-free failure is dropped there, and `request_secret` has no late route at
+  // all. The settle is worth doing for the LEDGER; the prose is read on a redelivery.
+  const src = readFileSync(new URL("../../web/js/lib/interactive-abandon.js", import.meta.url), "utf8");
+  assert.match(src, /does NOT reach the\s*(?:\/\/\s*)?caller/, "the limit is stated, not implied");
+  assert.match(src, /keeps `msg\.ok` replies only/, "and names the specific orchestrator behaviour");
+  assert.match(src, /REDELIVERY of that rid/, "and the one path that does read it");
+  assert.ok(
+    !/the caller (?:learns|is told|sees) (?:that )?the card was withdrawn/i.test(src),
+    "no claim that the disconnected caller receives this",
+  );
+});
+
 test("#952 source: retirement disables the card AND ends its command, in that order", () => {
   const src = readFileSync(PANEL, "utf8");
   const start = src.indexOf("function retireInteractiveCardsFromPreviousSockets()");

--- a/browser_tests/unit/interactive-abandon.test.mjs
+++ b/browser_tests/unit/interactive-abandon.test.mjs
@@ -151,21 +151,28 @@ test("#952 a reply that CARRIES the answer is still redacted — both commands",
   assert.equal(redactSensitiveReply(graph, "graph_add_node"), graph);
 });
 
-test("#952 (codex) the module says where this reply is read — it is NOT the disconnected caller", () => {
-  // The first draft implied the caller would read "the question was withdrawn". Measured
-  // against the orchestrator, they do not: the old socket's close already rejected the
-  // call with the bridge's own outcome-unknown error, the journal replay finds no pending
-  // rid, and the bridge's late-answer buffer for `ask_user` keeps `msg.ok` replies only —
-  // so a payload-free failure is dropped there, and `request_secret` has no late route at
-  // all. The settle is worth doing for the LEDGER; the prose is read on a redelivery.
+test("#952 (codex ×2) the claim is the LEDGER — not a caller-visible recovery", () => {
+  // Two drafts were too generous and both were caught here. The first implied the
+  // disconnected caller would read "the question was withdrawn"; they do not — the bridge
+  // already failed that call, the journal replay finds no pending rid, and the late-ask
+  // buffer keeps `msg.ok` only. The second retreated to "a REDELIVERY reads it", which is
+  // also not a production path for these two commands: every dispatch mints a fresh rid,
+  // `retry_of` is injected only for RETRY_TOKEN_CMDS (which excludes both), and re-asking
+  // mints a new `ask_id` that is part of the fingerprint. What survives is narrow and
+  // true: the entry settles, so it is evictable and no later delivery can hang.
   const src = readFileSync(new URL("../../web/js/lib/interactive-abandon.js", import.meta.url), "utf8");
-  assert.match(src, /does NOT reach the\s*(?:\/\/\s*)?caller/, "the limit is stated, not implied");
+  assert.match(src, /It does NOT rescue the interrupted call/, "the limit is stated, not implied");
+  assert.match(src, /the caller\s*(?:\/\/\s*)?never sees the text below/, "and stated concretely");
   assert.match(src, /keeps `msg\.ok` replies only/, "and names the specific orchestrator behaviour");
-  assert.match(src, /REDELIVERY of that rid/, "and the one path that does read it");
-  assert.ok(
-    !/the caller (?:learns|is told|sees) (?:that )?the card was withdrawn/i.test(src),
-    "no claim that the disconnected caller receives this",
-  );
+  assert.match(src, /Treat that branch as\s*(?:\/\/\s*)?defensive/, "the replay branch is not sold as recovery");
+  assert.match(src, /evictable and the cap applies again/, "the claim that IS established");
+  for (const overclaim of [
+    /the caller (?:learns|is told|sees) (?:that )?the card was withdrawn/i,
+    /the only path on which a caller reads it/i,
+    /does still reach the handler/i,
+  ]) {
+    assert.ok(!overclaim.test(src), `retracted claim is gone: ${overclaim}`);
+  }
 });
 
 test("#952 source: retirement disables the card AND ends its command, in that order", () => {

--- a/browser_tests/unit/interactive-abandon.test.mjs
+++ b/browser_tests/unit/interactive-abandon.test.mjs
@@ -1,0 +1,206 @@
+/**
+ * #952 (second half) — withdrawing an interactive card must END the command behind it.
+ *
+ * A CORRECTION to the trace on the issue comes first, because the shipped design rests on
+ * it. That comment said a tab which disconnects mid-command "reconnects on a new socket
+ * with a new epoch", so a retry lands in a different ledger scope and fails open into a
+ * duplicate card. The orchestrator mints `SESSION_EPOCH` once per PROCESS, so a tab
+ * reconnecting to the same process carries the SAME scope — the scope only changes across
+ * an orchestrator restart. "Dedupe interactive cards on a scope that survives a reconnect"
+ * was therefore a no-op: it already does.
+ *
+ * What is real is underneath it. `ask_user` / `request_secret` are the only commands whose
+ * executor blocks on a human, and retirement (0.13.0) deliberately does not resolve the
+ * card's promise. So the executor stays suspended forever, `settleRid` never runs, and the
+ * ledger keeps an IN-FLIGHT entry — which is never evicted, by design, because dropping an
+ * unsettled command would let its replay double-apply. Two consequences, both tested here:
+ * the entry is unreclaimable, and a redelivery of that rid awaits a promise that can never
+ * resolve, so the panel answers NOTHING at all.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+import {
+  INTERACTIVE_ABANDONED,
+  abandonedInteractiveError,
+  isAbandonedInteractive,
+} from "../../web/js/lib/interactive-abandon.js";
+import { createCommandDedupeLedger } from "../../web/js/lib/command-dedupe.js";
+import { redactSensitiveReply } from "../../web/js/lib/command-liveness.js";
+
+const PANEL = new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url);
+
+test("#952 the sentinel cannot be produced by a user's own answer", () => {
+  // The question card's "Other…" field accepts arbitrary text, so a sentinel a human can
+  // type is a sentinel a human can forge into an answer that fails their own command.
+  assert.equal(typeof INTERACTIVE_ABANDONED, "symbol");
+  for (const answer of [
+    "Symbol(comfyui-mcp.interactiveAbandoned)",
+    "comfyui-mcp.interactiveAbandoned",
+    "abandoned",
+    "",
+    null,
+    undefined,
+    0,
+    false,
+    {},
+    Symbol("comfyui-mcp.interactiveAbandoned"), // same DESCRIPTION, different symbol
+  ]) {
+    assert.equal(isAbandonedInteractive(answer), false, String(answer?.toString?.() ?? answer));
+  }
+  assert.equal(isAbandonedInteractive(INTERACTIVE_ABANDONED), true);
+});
+
+test("#952 the sentinel survives the module being evaluated twice", async () => {
+  // Registry-backed on purpose: a second module instance holding a private Symbol() would
+  // make the sentinel unrecognizable to the executor, silently restoring the hang.
+  const again = await import("../../web/js/lib/interactive-abandon.js?dup=1");
+  assert.equal(again.INTERACTIVE_ABANDONED, INTERACTIVE_ABANDONED);
+  assert.equal(isAbandonedInteractive(again.INTERACTIVE_ABANDONED), true);
+});
+
+test("#952 the failure text claims only what withdrawal establishes", () => {
+  for (const cmd of ["ask_user", "request_secret"]) {
+    const note = abandonedInteractiveError(cmd);
+    assert.match(note, /NOTHING WAS ANSWERED/, cmd);
+    assert.match(note, /nothing was applied/, cmd);
+    assert.match(note, /Re-issue it on the current connection/, cmd);
+    // What the panel CANNOT know: whether the person ever looked at the card. Claiming a
+    // decline or a dismissal would be a fabricated user action.
+    assert.ok(!/declined|dismissed|refused|cancelled|canceled/i.test(note), cmd);
+    // And it must not claim an answer exists somewhere, which is what would send a caller
+    // hunting for one.
+    assert.ok(!/collected|received the answer/i.test(note), cmd);
+  }
+  assert.match(abandonedInteractiveError("request_secret"), /secret request/);
+  assert.match(abandonedInteractiveError("ask_user"), /question/);
+});
+
+test("#952 THE DEFECT: an unresolved card strands an in-flight ledger entry forever", async () => {
+  // Reproduce the pre-fix shape with the real ledger: begin() a command whose executor
+  // never returns, then run a full cap's worth of settled traffic past it.
+  const ledger = createCommandDedupeLedger(4);
+  ledger.begin("rid-ask", "fp-ask", "epoch-1"); // never settled — the abandoned question
+  for (let i = 0; i < 12; i += 1) {
+    ledger.begin(`rid-${i}`, `fp-${i}`, "epoch-1")({ rid: `rid-${i}`, ok: true });
+  }
+  const stranded = ledger.get("rid-ask", "fp-ask", "epoch-1");
+  assert.ok(stranded instanceof Promise, "still in-flight after 12 settled commands evicted past cap");
+
+  // And this is why it matters more than a leak: a redelivery of that rid awaits it.
+  const raced = await Promise.race([
+    stranded.then(() => "answered"),
+    new Promise((r) => setTimeout(() => r("hung"), 30)),
+  ]);
+  assert.equal(raced, "hung", "the replay would wait forever and the panel would send nothing");
+});
+
+test("#952 THE FIX: abandoning settles the entry, and a replay learns the outcome", async () => {
+  const ledger = createCommandDedupeLedger(4);
+  const settle = ledger.begin("rid-ask", "fp-ask", "epoch-1");
+  // What the wiring does: the card resolves with the sentinel, the executor recognizes it
+  // and fails the command, and that failure settles the rid.
+  const cardResult = INTERACTIVE_ABANDONED;
+  assert.equal(isAbandonedInteractive(cardResult), true);
+  settle({ rid: "rid-ask", ok: false, error: abandonedInteractiveError("ask_user") });
+
+  const replay = await ledger.get("rid-ask", "fp-ask", "epoch-1");
+  assert.equal(replay.ok, false, "the replay is answered rather than hanging");
+  assert.match(replay.error, /NOTHING WAS ANSWERED/);
+
+  // Settled entries are evictable, so the ledger's bound applies again.
+  for (let i = 0; i < 12; i += 1) {
+    ledger.begin(`rid-${i}`, `fp-${i}`, "epoch-1")({ rid: `rid-${i}`, ok: true });
+  }
+  assert.equal(ledger.get("rid-ask", "fp-ask", "epoch-1"), undefined, "aged out like any settled entry");
+});
+
+test("#952 a payload-free failure is journaled AS ITSELF, not as 'we collected an answer'", () => {
+  // The redaction exists so a successful answer is never replayed onto a different
+  // orchestrator. Applied to a FAILURE it asserted a collection that never happened —
+  // the caller was told the panel had their answer and could not return it.
+  const withdrawn = {
+    rid: "r1",
+    ok: false,
+    error: abandonedInteractiveError("ask_user"),
+  };
+  assert.deepEqual(redactSensitiveReply(withdrawn, "ask_user"), withdrawn, "passes through");
+  assert.deepEqual(
+    redactSensitiveReply({ rid: "r2", ok: false, error: "This panel build can't collect secrets." }, "request_secret"),
+    { rid: "r2", ok: false, error: "This panel build can't collect secrets." },
+    "and so does any other panel-authored failure",
+  );
+});
+
+test("#952 a reply that CARRIES the answer is still redacted — both commands", () => {
+  for (const cmd of ["ask_user", "request_secret"]) {
+    const answered = { rid: "r3", ok: true, result: "hunter2" };
+    const safe = redactSensitiveReply(answered, cmd);
+    assert.equal(safe.ok, false, cmd);
+    assert.equal(safe.result, undefined, cmd);
+    assert.ok(!JSON.stringify(safe).includes("hunter2"), `${cmd}: no trace of the value`);
+    assert.equal(safe.rid, "r3", `${cmd}: still rid-correlated`);
+    // The failing shape that motivated the narrowing: `ok:false` WITH a result present.
+    // It is not produced today, but the rule is mechanical so it stays covered.
+    const oddity = { rid: "r4", ok: false, result: "hunter2" };
+    assert.ok(!JSON.stringify(redactSensitiveReply(oddity, cmd)).includes("hunter2"), cmd);
+  }
+  // Non-sensitive commands are untouched in every case.
+  const graph = { rid: "r5", ok: true, result: { node_id: 4 } };
+  assert.equal(redactSensitiveReply(graph, "graph_add_node"), graph);
+});
+
+test("#952 source: retirement disables the card AND ends its command, in that order", () => {
+  const src = readFileSync(PANEL, "utf8");
+  const start = src.indexOf("function retireInteractiveCardsFromPreviousSockets()");
+  assert.ok(start > 0, "the sweep exists");
+  const body = src.slice(start, src.indexOf("\n  }", start));
+  const retireAt = body.indexOf("record.retire?.()");
+  const abandonAt = body.indexOf("record.abandon?.()");
+  assert.ok(retireAt > 0 && abandonAt > 0, "both halves run");
+  // ORDER: retirement asks the card whether it was already answered. Abandoning first
+  // would make that question unanswerable and skip the visible half.
+  assert.ok(retireAt < abandonAt, "retire before abandon");
+  // SEPARATE try blocks — one throwing must not skip the other.
+  assert.equal((body.match(/try \{/g) ?? []).length, 2, "each half guarded on its own");
+});
+
+test("#952 source: the abandon flag is NOT the answered flag", () => {
+  const src = readFileSync(PANEL, "utf8");
+  for (const fn of ["function paintQuestion(", "function paintSecret("]) {
+    const start = src.indexOf(fn);
+    assert.ok(start > 0, fn);
+    const body = src.slice(start, start + 3000);
+    assert.match(body, /let abandoned = false;/, fn);
+    assert.match(body, /abandoned = true;\s*\r?\n\s*resolveFn\(INTERACTIVE_ABANDONED\);/, fn);
+    // The trap this avoids: retirement checks `alreadyAnswered: () => done`, so an abandon
+    // that set `done` would suppress the card's own retirement and leave it looking live.
+    assert.ok(
+      !/abandon = \(\) => \{[\s\S]{0,200}done = true;/.test(body),
+      `${fn}: abandoning must not mark the card answered`,
+    );
+    // And a late click cannot resolve a promise whose command was already failed.
+    assert.match(body, /if \(done \|\| abandoned\) return;/, fn);
+  }
+});
+
+test("#952 source: both interactive executors recognize the sentinel and throw", () => {
+  const src = readFileSync(PANEL, "utf8");
+  for (const call of ["onAsk(msg, thisSock.__cmcpSocketId", "onSecret(msg, thisSock.__cmcpSocketId"]) {
+    const at = src.indexOf(call);
+    assert.ok(at > 0, call);
+    const after = src.slice(at, at + 900);
+    assert.match(
+      after,
+      /if \(isAbandonedInteractive\(result\)\) throw new Error\(abandonedInteractiveError\(msg\.cmd\)\);/,
+      call,
+    );
+  }
+  // THROWN, not replied directly: the existing catch is what builds the frame, and
+  // `settleRid(reply)` runs right after it. A hand-built reply that bypassed the catch
+  // would leave the ledger entry in flight — the whole defect.
+  const settleAt = src.indexOf("settleRid(reply);");
+  const catchAt = src.lastIndexOf("} catch (err) {", settleAt);
+  assert.ok(catchAt > 0 && catchAt < settleAt, "the catch feeds the settle");
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -337,6 +337,11 @@ import {
 } from "./lib/reconnect-staleness.js";
 import { pickRevertSnapshot, describeRevertOutcome, revertDidRestore } from "./lib/graph-revert.js";
 import { commandFingerprint, createCommandDedupeLedger } from "./lib/command-dedupe.js";
+import {
+  INTERACTIVE_ABANDONED,
+  abandonedInteractiveError,
+  isAbandonedInteractive,
+} from "./lib/interactive-abandon.js";
 import { decideOpenStaleness } from "./lib/workflow-open-staleness.js";
 import {
   OPEN_DISK_READ_BUDGET_MS,
@@ -16677,12 +16682,21 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
             // UI about this socket is suppressed once the patience window has been given up
             // on — so a UI-side belief can be stale exactly when it matters (codex r2).
             result = await onAsk(msg, thisSock.__cmcpSocketId ?? null);
+            // #952 — a card withdrawn by a reconnect resolves with a SENTINEL rather
+            // than staying pending forever. Thrown, so the ordinary error path builds
+            // the reply AND `settleRid` runs: without this the ledger keeps an
+            // un-evictable in-flight entry whose replay would await a promise that can
+            // never resolve, and answer nothing at all.
+            if (isAbandonedInteractive(result)) throw new Error(abandonedInteractiveError(msg.cmd));
           } else if (msg.cmd === "request_secret") {
             // Secure secret entry. The pasted value rides back to the
             // orchestrator (which writes it to config) and is the tool's reply;
             // it is never surfaced to the agent's context or recorded to history.
             if (!onSecret) throw new Error("This panel build can't collect secrets.");
             result = await onSecret(msg, thisSock.__cmcpSocketId ?? null);
+            // #952 — same withdrawal, and the failure carries NO payload, so the
+            // undeliverable-reply path has nothing of the user's to redact.
+            if (isAbandonedInteractive(result)) throw new Error(abandonedInteractiveError(msg.cmd));
           } else if (msg.cmd === "soft_reload") {
             // Agent-triggered soft reload. Reply FIRST (below), then bounce —
             // an "orchestrator" scope kills this very session, so the resume
@@ -22826,11 +22840,27 @@ function buildPanel() {
 
     const selected = new Set();
     let done = false;
+    // #952 — SEPARATE from `done`, which means "the user answered". Retirement asks
+    // `alreadyAnswered: () => done` before disabling anything, so an abandon that set
+    // `done` would make the card skip its own retirement and stay live-looking.
+    let abandoned = false;
     let resolveFn;
     const promise = new Promise((res) => { resolveFn = res; });
 
+    // #952 — end the command WITHOUT answering it. The executor turns this sentinel
+    // into an explicit failure, which settles the rid ledger; leaving the promise
+    // pending instead is what stranded an un-evictable in-flight entry whose replay
+    // could never be answered.
+    const abandon = () => {
+      if (done || abandoned) return;
+      abandoned = true;
+      resolveFn(INTERACTIVE_ABANDONED);
+    };
+
     const finish = (answer) => {
-      if (done) return;
+      // `abandoned` too: the command behind this card has already been failed, so a
+      // late click must not resolve a promise whose reply was already sent.
+      if (done || abandoned) return;
       done = true;
       // Collapse the interactive card into a STATIC result — remove every button
       // and input so it no longer looks clickable / awaiting an answer.
@@ -22937,6 +22967,7 @@ function buildPanel() {
           alreadyAnswered: () => done,
           what: "question",
         }),
+      abandon,
     });
     promise.then(unregister, unregister);
     return promise;
@@ -22973,11 +23004,25 @@ function buildPanel() {
     for (const record of [...liveInteractiveCards]) {
       if (record.paintedOnSocket === liveSocketId) continue;
       liveInteractiveCards.delete(record);
+      // RETIRE FIRST, then abandon — and in SEPARATE try blocks, so neither step can
+      // be skipped by the other throwing. Order matters: retirement asks the card
+      // whether it was already answered, and abandonment is what makes that question
+      // unanswerable, so abandoning first would be indistinguishable from an answer
+      // to a future reader of either flag.
       try {
         record.retire?.();
       } catch {
         // A card that cannot be retired is left exactly as it was — never a thrown
         // error out of a connection callback.
+      }
+      // #952 — the DOM half above only stops the card LOOKING answerable. This half
+      // ends the command behind it: without it the executor stays suspended, its rid
+      // ledger entry stays in-flight forever (in-flight entries are never evicted),
+      // and a redelivery of that rid awaits a promise that can never resolve.
+      try {
+        record.abandon?.();
+      } catch {
+        // Same rule: a card whose command cannot be ended is exactly where it was.
       }
     }
   }
@@ -23038,8 +23083,21 @@ function buildPanel() {
     card.appendChild(hint);
 
     let done = false;
+    // #952 — see paintQuestion: distinct from `done`, because retirement asks
+    // `alreadyAnswered: () => done` and an abandon that set it would suppress the
+    // card's own retirement.
+    let abandoned = false;
     let resolveFn;
     const promise = new Promise((res) => { resolveFn = res; });
+
+    // #952 — end the command without producing a value. Nothing was typed, so the
+    // failure that the executor builds from this carries no payload at all: there is
+    // no secret for the undeliverable-reply path to have to redact.
+    const abandon = () => {
+      if (done || abandoned) return;
+      abandoned = true;
+      resolveFn(INTERACTIVE_ABANDONED);
+    };
 
     // #8 SIZING. The field is the whole point of this card, and it used to be the
     // first thing squeezed: on one unwrapped line the two buttons cannot shrink
@@ -23075,7 +23133,9 @@ function buildPanel() {
     const mask = (v) =>
       !v ? "" : v.length <= 8 ? "•".repeat(v.length) : `${v.slice(0, 4)}…${v.slice(-4)}`;
     const finish = (value) => {
-      if (done) return;
+      // `abandoned` too — a late submit must not resolve a promise whose command was
+      // already failed and replied to (#952).
+      if (done || abandoned) return;
       done = true;
       input.value = ""; // clear the field immediately
       card.replaceChildren();
@@ -23155,6 +23215,7 @@ function buildPanel() {
             "Nothing was sent and nothing was stored. Wait for the agent to ask again on " +
             "the new connection — do not paste the value into the chat.",
         }),
+      abandon,
     });
     promise.then(unregisterSecret, unregisterSecret);
     return promise;

--- a/web/js/lib/command-liveness.js
+++ b/web/js/lib/command-liveness.js
@@ -111,6 +111,17 @@ export const SENSITIVE_RESULT_CMDS = new Set(["request_secret", "ask_user"]);
  *  tells the caller to re-request on the current connection. */
 export function redactSensitiveReply(reply, cmd) {
   if (!reply || !SENSITIVE_RESULT_CMDS.has(cmd)) return reply;
+  // #952 — redact what CARRIES the user's input, not every reply for these commands.
+  // A payload-free FAILURE has no private content in it: its `error` is panel-authored
+  // (the build cannot display questions; the card was fenced; the card was withdrawn
+  // unanswered). Rewriting those with the text below asserted something false — that
+  // "the panel collected the response" — about a command where nothing was collected,
+  // which is exactly the misreport #952 is about. The rule is mechanical rather than a
+  // judgement about which errors are safe: a reply is redacted if it succeeded or if it
+  // carries a `result` at all.
+  const carriesUserInput =
+    reply.ok !== false || Object.prototype.hasOwnProperty.call(reply, "result");
+  if (!carriesUserInput) return reply;
   return {
     rid: reply.rid,
     ok: false,

--- a/web/js/lib/interactive-abandon.js
+++ b/web/js/lib/interactive-abandon.js
@@ -1,0 +1,64 @@
+// #952 — withdrawing an interactive card must also END the command behind it.
+//
+// `ask_user` and `request_secret` are the only panel commands whose executor
+// blocks on a HUMAN. When the connection that asked drops, the card is retired
+// (its controls are disabled and it says why) but its promise was deliberately
+// left unresolved: resolving it with an ANSWER would fabricate one, and the
+// panel's rule is that a reply of this kind does not cross a reconnect.
+//
+// Leaving it unresolved has its own cost, and that cost is what this module is
+// for. The executor stays suspended on `await onAsk(...)` forever, so:
+//
+//   * `settleRid` never runs, and the rid ledger keeps an IN-FLIGHT entry. Those
+//     are never evicted — by design, since dropping an unsettled command would
+//     let its replay double-apply — so every abandoned question permanently
+//     occupies a slot and holds the settled cap out of reach.
+//
+//   * a redelivery of that rid `await`s the in-flight promise, which can never
+//     resolve. The panel then sends NOTHING: a second outcome-unknown for the
+//     caller, this time with no timeout of the panel's own to end it.
+//
+// The fix is a value that is NOT an answer. Retiring a card resolves its promise
+// with the sentinel below; the executor recognizes it and fails the command
+// explicitly, which settles the ledger through the ordinary error path. Nothing
+// is fabricated — the reply says the question was withdrawn unanswered — and the
+// reply is undeliverable on the socket that died, so it takes the existing
+// lost-reply path exactly like any other late answer.
+//
+// A SYMBOL, not a string: the "Other…" field lets a user type any text they
+// like, and a sentinel a human can type is a sentinel a human can forge. The
+// global registry (`Symbol.for`) is used so the identity survives the module
+// being evaluated twice — a duplicate instance would otherwise make the sentinel
+// unrecognizable and silently restore the hang this exists to remove.
+//
+// Dependency-free (no DOM, no LiteGraph). Unit-testable with plain fixtures.
+
+/** Resolution value meaning "this card was withdrawn; the user answered nothing". */
+export const INTERACTIVE_ABANDONED = Symbol.for("comfyui-mcp.interactiveAbandoned");
+
+/**
+ * Identity check, deliberately strict. Anything else — including a string that
+ * happens to read like the sentinel's description — is a real user answer.
+ */
+export function isAbandonedInteractive(value) {
+  return value === INTERACTIVE_ABANDONED;
+}
+
+/**
+ * The failure text for a withdrawn interactive command.
+ *
+ * States only what the mechanism establishes: the card is gone, nothing was
+ * answered, and the answer cannot arrive later. It does NOT claim the user saw
+ * the card, ignored it, or declined — the panel cannot know any of that. The
+ * remedy names the current connection because a reply of this kind is never
+ * replayed across a reconnect.
+ */
+export function abandonedInteractiveError(cmd) {
+  const what = cmd === "request_secret" ? "secret request" : "question";
+  return (
+    `The ${what} was withdrawn: the connection it was asked on was replaced before anyone ` +
+    `answered. NOTHING WAS ANSWERED and nothing was applied — the card on screen has been ` +
+    `disabled, so a late answer to it cannot reach you either. Re-issue it on the current ` +
+    `connection if you still need it.`
+  );
+}

--- a/web/js/lib/interactive-abandon.js
+++ b/web/js/lib/interactive-abandon.js
@@ -23,9 +23,11 @@
 // explicitly, which settles the ledger through the ordinary error path. Nothing
 // is fabricated — the reply says the question was withdrawn unanswered.
 //
-// WHERE THE TEXT BELOW IS ACTUALLY READ, measured against the orchestrator rather
-// than assumed (codex). In the ordinary disconnect this reply does NOT reach the
-// caller, and this module does not pretend otherwise:
+// WHAT SETTLING BUYS — and what it does not. Measured against the orchestrator
+// twice, because the first two answers here were both too generous (codex).
+//
+// It does NOT rescue the interrupted call. In the ordinary disconnect the caller
+// never sees the text below:
 //
 //   * the old socket's close already removed the pending rid and rejected the call
 //     with the bridge's own OUTCOME-UNKNOWN error, before anything from the panel
@@ -36,11 +38,17 @@
 //     payload-free FAILURE is dropped there; `request_secret` has no late route at
 //     all.
 //
-// So the value of settling is the LEDGER, not this prose: the entry becomes
-// evictable, and a REDELIVERY of that rid — which does still reach the handler and
-// is answered from the ledger — gets this text instead of silence. That is the
-// only path on which a caller reads it, and it is worth having: the alternative is
-// a second outcome-unknown with no timeout of the panel's own to end it.
+// Nor is the ledger's replay branch a recovery path for these two commands. It
+// needs the SAME rid (every dispatch mints a fresh UUID and overwrites a supplied
+// one) or a `retry_of` naming it (injected only for RETRY_TOKEN_CMDS, which
+// excludes both) — and re-asking mints a new `ask_id`, which is part of the
+// fingerprint, so even a hand-written token would miss. Treat that branch as
+// defensive: it answers a duplicate frame if one is ever delivered, instead of
+// waiting forever on a promise that cannot resolve.
+//
+// What settling actually buys is the LEDGER ITSELF: the entry becomes settled, so
+// it is evictable and the cap applies again, and no future delivery of that rid
+// can hang the handler. That is the whole claim.
 //
 // The reply is journaled by the existing lost-reply path like any other
 // undelivered outcome. Unlike an ANSWER, it is safe to replay across a reconnect —
@@ -75,7 +83,9 @@ export function isAbandonedInteractive(value) {
  * remedy names the current connection because the ANSWER to a withdrawn card is
  * never replayed across a reconnect, so re-asking is the only way to get one.
  *
- * See the header for the one path a caller actually reads this on.
+ * Rarely read, and the header says why: the interrupted call has already been
+ * failed by the bridge. This is the outcome the panel RECORDS, and what a
+ * duplicate frame would be answered with — not a rescue for the original caller.
  */
 export function abandonedInteractiveError(cmd) {
   const what = cmd === "request_secret" ? "secret request" : "question";

--- a/web/js/lib/interactive-abandon.js
+++ b/web/js/lib/interactive-abandon.js
@@ -1,10 +1,17 @@
 // #952 — withdrawing an interactive card must also END the command behind it.
 //
 // `ask_user` and `request_secret` are the only panel commands whose executor
-// blocks on a HUMAN. When the connection that asked drops, the card is retired
-// (its controls are disabled and it says why) but its promise was deliberately
-// left unresolved: resolving it with an ANSWER would fabricate one, and the
-// panel's rule is that a reply CARRYING one does not cross a reconnect.
+// blocks on a HUMAN. Once a DIFFERENT socket reaches `connected`, cards painted
+// on the superseded one are retired (their controls are disabled and they say
+// why) but their promises were deliberately left unresolved: resolving one with
+// an ANSWER would fabricate it, and the panel's rule is that a reply CARRYING an
+// answer does not cross a reconnect.
+//
+// Note the trigger precisely (codex r4): a bare disconnect retires nothing. Until
+// a replacement connection hands the UI a new socket id, the card stays live and
+// its command stays pending — which is correct, since a socket that comes back is
+// the same conversation. Everything below is about what happens once the sweep
+// does run.
 //
 // Leaving it unresolved has its own cost, and that cost is what this module is
 // for. The executor stays suspended on `await onAsk(...)` forever, so:

--- a/web/js/lib/interactive-abandon.js
+++ b/web/js/lib/interactive-abandon.js
@@ -46,9 +46,19 @@
 // defensive: it answers a duplicate frame if one is ever delivered, instead of
 // waiting forever on a promise that cannot resolve.
 //
-// What settling actually buys is the LEDGER ITSELF: the entry becomes settled, so
-// it is evictable and the cap applies again, and no future delivery of that rid
-// can hang the handler. That is the whole claim.
+// What settling actually buys, stated exactly (codex r3 — the earlier "no future
+// delivery of that rid can hang the handler" was one step too broad, and the
+// tests below contain its own counterexample):
+//
+//   While the settled (epoch, rid, fingerprint) entry is RETAINED, a matching
+//   duplicate replays its recorded failure instead of awaiting the abandoned
+//   promise. Settling also makes the entry eligible for normal cap eviction.
+//
+// Not more than that. Eviction is deliberately fail-open, so a duplicate arriving
+// after the entry ages out calls `begin()` and executes a fresh interactive
+// command — which blocks on a human again, correctly. A same-rid frame with a
+// DIFFERENT fingerprint is treated as new work for the same reason. Both are the
+// ledger behaving as designed; neither is something this change removes.
 //
 // The reply is journaled by the existing lost-reply path like any other
 // undelivered outcome. Unlike an ANSWER, it is safe to replay across a reconnect —
@@ -91,8 +101,8 @@ export function abandonedInteractiveError(cmd) {
   const what = cmd === "request_secret" ? "secret request" : "question";
   return (
     `The ${what} was withdrawn: the connection it was asked on was replaced before anyone ` +
-    `answered. NOTHING WAS ANSWERED and nothing was applied — the card on screen has been ` +
-    `disabled, so a late answer to it cannot reach you either. Re-issue it on the current ` +
-    `connection if you still need it.`
+    `answered. NOTHING WAS ANSWERED and nothing was applied — and any card still on screen ` +
+    `for it has been disabled, so a late answer given there cannot reach you either. ` +
+    `Re-issue it on the current connection if you still need it.`
   );
 }

--- a/web/js/lib/interactive-abandon.js
+++ b/web/js/lib/interactive-abandon.js
@@ -4,7 +4,7 @@
 // blocks on a HUMAN. When the connection that asked drops, the card is retired
 // (its controls are disabled and it says why) but its promise was deliberately
 // left unresolved: resolving it with an ANSWER would fabricate one, and the
-// panel's rule is that a reply of this kind does not cross a reconnect.
+// panel's rule is that a reply CARRYING one does not cross a reconnect.
 //
 // Leaving it unresolved has its own cost, and that cost is what this module is
 // for. The executor stays suspended on `await onAsk(...)` forever, so:
@@ -21,9 +21,31 @@
 // The fix is a value that is NOT an answer. Retiring a card resolves its promise
 // with the sentinel below; the executor recognizes it and fails the command
 // explicitly, which settles the ledger through the ordinary error path. Nothing
-// is fabricated — the reply says the question was withdrawn unanswered — and the
-// reply is undeliverable on the socket that died, so it takes the existing
-// lost-reply path exactly like any other late answer.
+// is fabricated — the reply says the question was withdrawn unanswered.
+//
+// WHERE THE TEXT BELOW IS ACTUALLY READ, measured against the orchestrator rather
+// than assumed (codex). In the ordinary disconnect this reply does NOT reach the
+// caller, and this module does not pretend otherwise:
+//
+//   * the old socket's close already removed the pending rid and rejected the call
+//     with the bridge's own OUTCOME-UNKNOWN error, before anything from the panel
+//     could arrive;
+//
+//   * the journal replay on the fresh socket then finds no pending rid. The
+//     bridge's late-answer buffer for `ask_user` keeps `msg.ok` replies only, so a
+//     payload-free FAILURE is dropped there; `request_secret` has no late route at
+//     all.
+//
+// So the value of settling is the LEDGER, not this prose: the entry becomes
+// evictable, and a REDELIVERY of that rid — which does still reach the handler and
+// is answered from the ledger — gets this text instead of silence. That is the
+// only path on which a caller reads it, and it is worth having: the alternative is
+// a second outcome-unknown with no timeout of the panel's own to end it.
+//
+// The reply is journaled by the existing lost-reply path like any other
+// undelivered outcome. Unlike an ANSWER, it is safe to replay across a reconnect —
+// it carries no user input — which is why `redactSensitiveReply` was narrowed to
+// replies that actually carry one.
 //
 // A SYMBOL, not a string: the "Other…" field lets a user type any text they
 // like, and a sentinel a human can type is a sentinel a human can forge. The
@@ -50,8 +72,10 @@ export function isAbandonedInteractive(value) {
  * States only what the mechanism establishes: the card is gone, nothing was
  * answered, and the answer cannot arrive later. It does NOT claim the user saw
  * the card, ignored it, or declined — the panel cannot know any of that. The
- * remedy names the current connection because a reply of this kind is never
- * replayed across a reconnect.
+ * remedy names the current connection because the ANSWER to a withdrawn card is
+ * never replayed across a reconnect, so re-asking is the only way to get one.
+ *
+ * See the header for the one path a caller actually reads this on.
  */
 export function abandonedInteractiveError(cmd) {
   const what = cmd === "request_secret" ? "secret request" : "question";


### PR DESCRIPTION
Second half of #952 — the panel-side design question the orchestrator's 0.50.88 fix
deliberately left open.

**A correction to my own earlier trace on that issue comes first**, because the plan
was built on it: I wrote that a tab which disconnects mid-command "reconnects on a new
socket with a new epoch", so the retry lands in a different ledger scope and fails open.
Measured against the orchestrator source, that is wrong — `SESSION_EPOCH` is minted
**once per orchestrator process**, so a tab reconnecting to the same process carries the
same scope. The scope only changes across an orchestrator **restart**. Deduping
interactive cards on "a scope that survives a reconnect" is therefore a no-op: it
already does.

What measurement does show is a different and real defect underneath it.

- `ask_user` / `request_secret` are not in the orchestrator's `RETRY_TOKEN_CMDS`, so no
  `retry_of` is minted or forwarded for them.
- When the connection drops mid-question, the card is retired (0.13.0, first half) but
  its promise is deliberately never resolved — so the executor's `await onAsk(...)`
  never returns, `settleRid` is never called, and the ledger entry stays **IN-FLIGHT
  forever**.
- In-flight entries are never evicted, by design (evicting an unsettled command would
  let its replay double-apply). So every abandoned question permanently occupies a slot
  and pushes the settled cap out of reach.
- Worse than the leak: a redelivery of that rid hits `await priorRidReply` on a promise
  that can never resolve. The panel then sends **nothing at all** — a second
  outcome-unknown, this time with no timeout of its own.

Planned change, scoped to that: retiring a card **abandons its command explicitly** —
the promise settles with a sentinel that is not an answer, the executor turns it into a
definitive `ok:false` reply, and the ledger entry settles. The reply is undeliverable
(that socket is gone) and takes the existing lost-reply path; a later replay gets that
recorded negative instead of an indefinite hang. No answer is fabricated and no payload
is invented, which is what the current comment was protecting.

Draft first, per the loop. Codex review before merge.

Closes #952

🤖 Generated with [Claude Code](https://claude.com/claude-code)