### PR TITLE
fix(945): give allowGraph:false a workflow-owned carrier that actually holds the uuid

### DIFF
--- a/browser_tests/unit/embedded-uuid-carrier.test.mjs
+++ b/browser_tests/unit/embedded-uuid-carrier.test.mjs
@@ -135,7 +135,7 @@ test("OBSERVATION (#945): the original three-rung chain yields nothing", () => {
   );
 });
 
-test("#945 FIXED: the READ carrier reaches it, so `allowGraph:false` is no longer null", () => {
+test("#945 FIXED: a NON-mounted workflow is reached, where `allowGraph:false` used to be null", () => {
   const wf = realComfyWorkflow();
   // Not the mounted one — see the codex P0 test below for why that distinction is the
   // whole design.

--- a/browser_tests/unit/embedded-uuid-carrier.test.mjs
+++ b/browser_tests/unit/embedded-uuid-carrier.test.mjs
@@ -54,6 +54,7 @@ import { readFileSync } from "node:fs";
 import test from "node:test";
 
 import {
+  sameWorkflowObject,
   shouldForkEmbeddedUuidForLiveOwner,
   shouldForkEmbeddedWorkflowUuid,
 } from "../../web/js/lib/workflow-chat-identity.js";
@@ -72,7 +73,7 @@ const workflowOwnedExtra = (wf) => {
 const workflowOwnedExtraForRead = (wf, active = null) => {
   const owned = workflowOwnedExtra(wf);
   if (owned) return owned;
-  if (!wf || (active && wf === active)) return null;
+  if (!wf || sameWorkflowObject(wf, active)) return null;
   const state = wf?.activeState?.extra;
   return state && typeof state === "object" ? state : null;
 };
@@ -190,6 +191,41 @@ test("#945 (codex P0) the MOUNTED workflow is refused — its activeState IS the
   // An UNSPECIFIED workflow defaults to the active one in production, so it lands here too.
   assert.equal(embeddedUuidRead(null, active), null);
   assert.equal(embeddedUuidRead(undefined, active), null);
+});
+
+test("#945 (codex r2) a Vue PROXY of the mounted workflow is still refused", () => {
+  // The exclusion cannot use `===`. The workflow service hands out reactive PROXIES in
+  // its computed lists while raw objects flow through the uuid stores, and the active
+  // binding path unwraps deliberately: the graph fence calls
+  // `workflowOwnsRootUuidTag(activeWorkflowRef())`, which re-enters this reader with
+  // `rawWorkflowObject(w)`. A strict comparison against the proxy is FALSE for the
+  // mounted workflow's own raw target — so the canvas state walks back in through the
+  // door the exclusion was supposed to close, on the one path that matters most.
+  const raw = realComfyWorkflow("e66e531b-a4ca-4bee-8a11-12df34b830e2");
+  const proxy = new Proxy(raw, {
+    get: (t, k) => (k === "__v_raw" ? t : Reflect.get(t, k, t)),
+  });
+  assert.notEqual(proxy, raw, "the shapes really are different objects");
+  assert.equal(
+    embeddedUuidRead(raw, proxy),
+    null,
+    "raw target vs proxy active — the exact shape the fence produces",
+  );
+  assert.equal(embeddedUuidRead(proxy, raw), null, "and the reverse");
+  // A DIFFERENT workflow that merely looks similar is still answered — the refusal is
+  // identity, not a blanket refusal of anything proxy-shaped.
+  const other = realComfyWorkflow("30dfba50-4c01-4c40-a4c2-72a47e12269c");
+  assert.equal(embeddedUuidRead(other, proxy), "30dfba50-4c01-4c40-a4c2-72a47e12269c");
+});
+
+test("#945 (codex r2) two references sharing a changeTracker are the same workflow", () => {
+  // `activeState` reads THROUGH `changeTracker`, so two references to the same tracker
+  // cannot meaningfully disagree about whether it is mounted. sameWorkflowObject already
+  // treats that as identity; relying on it is what makes this exclusion total.
+  const raw = realComfyWorkflow("e66e531b-a4ca-4bee-8a11-12df34b830e2");
+  const twin = { path: raw.path, changeTracker: raw.changeTracker, get activeState() { return this.changeTracker?.activeState ?? null; } };
+  assert.equal(sameWorkflowObject(twin, raw), true, "shared tracker is shared identity");
+  assert.equal(embeddedUuidRead(twin, raw), null, "so the mounted canvas is refused here too");
 });
 
 test("#945 a NON-mounted workflow is answered from its own capture", () => {
@@ -342,7 +378,7 @@ test("SOURCE: the modelled chain is the one production actually reads", async ()
   // would otherwise start deciding on a different field without anything failing.
   assert.match(
     src,
-    /const owned = workflowOwnedExtra\(wf\);\r?\n\s*if \(owned\) return owned;[\s\S]{0,400}?if \(!wf \|\| \(active && wf === active\)\) return null;\r?\n\s*const state = wf\?\.activeState\?\.extra;/,
+    /const owned = workflowOwnedExtra\(wf\);\r?\n\s*if \(owned\) return owned;[\s\S]{0,400}?if \(!wf \|\| sameWorkflowObject\(wf, active\)\) return null;\r?\n\s*const state = wf\?\.activeState\?\.extra;/,
     "the read carrier's order changed — re-check which field decides identity",
   );
   // Both guards still read the value under the name the tests use, so a rename

--- a/browser_tests/unit/embedded-uuid-carrier.test.mjs
+++ b/browser_tests/unit/embedded-uuid-carrier.test.mjs
@@ -50,6 +50,7 @@
 // production chain, and it fails if the chain changes.
 
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 import test from "node:test";
 
 import {
@@ -57,16 +58,28 @@ import {
   shouldForkEmbeddedWorkflowUuid,
 } from "../../web/js/lib/workflow-chat-identity.js";
 
-/** The candidate chain, exactly as `workflowOwnedExtra` implements it. */
+/** The candidate chain, exactly as `workflowOwnedExtra` implements it. This is now
+ *  the WRITE-side helper only: the embed write still goes through it, unchanged. */
 const workflowOwnedExtra = (wf) => {
   const candidate = wf?.extra || wf?.workflow?.extra || wf?.data?.extra;
   return candidate && typeof candidate === "object" ? candidate : null;
 };
-const embeddedUuid = (wf) => {
-  const ns = workflowOwnedExtra(wf)?.comfyui_mcp;
-  const id = ns?.workflow_uuid;
+/** The READ carrier, exactly as `workflowOwnedExtraForRead` implements it: the same
+ *  chain, with `activeState.extra` behind it. Ordered so an older build that really
+ *  does carry one of the three original fields keeps answering from it. */
+const workflowOwnedExtraForRead = (wf) => {
+  const owned = workflowOwnedExtra(wf);
+  if (owned) return owned;
+  const state = wf?.activeState?.extra;
+  return state && typeof state === "object" ? state : null;
+};
+const uuidFrom = (extra) => {
+  const id = extra?.comfyui_mcp?.workflow_uuid;
   return typeof id === "string" && id ? id : null;
 };
+const embeddedUuid = (wf) => uuidFrom(workflowOwnedExtra(wf));
+/** What `embeddedWorkflowUuid(wf, {allowGraph:false})` now resolves. */
+const embeddedUuidRead = (wf) => uuidFrom(workflowOwnedExtraForRead(wf));
 
 /** The real shape, from ComfyUI 0.31.1 / frontend 1.44.19. `activeState` is a
  *  getter onto the change tracker, which is where the uuid actually lives. */
@@ -104,11 +117,12 @@ test("the helper DOES work when a workflow-owned carrier is present", () => {
   assert.equal(embeddedUuid({ extra: "not-an-object" }), null);
 });
 
-test("OBSERVATION (#945): the real ComfyWorkflow shape yields nothing", () => {
-  // Recorded, not required. The uuid is genuinely present on this object — it is
-  // just not on any rung the chain looks at, so `allowGraph:false` cannot see it.
+test("OBSERVATION (#945): the original three-rung chain yields nothing", () => {
+  // Recorded, not required. The uuid is genuinely present on this object — it is just
+  // not on any rung THAT chain looks at. Still true, and still what the WRITE side goes
+  // through, which is why the embed write does not land on the workflow object.
   const wf = realComfyWorkflow();
-  assert.equal(workflowOwnedExtra(wf), null, "no rung of the chain matches the real class");
+  assert.equal(workflowOwnedExtra(wf), null, "no rung of the original chain matches the real class");
   assert.equal(embeddedUuid(wf), null);
   // The uuid IS there, one field over. This is the whole of #945 in two lines.
   assert.equal(
@@ -117,12 +131,80 @@ test("OBSERVATION (#945): the real ComfyWorkflow shape yields nothing", () => {
   );
 });
 
-test("so both fork guards are handed null, and decide nothing", () => {
-  // They read as live guards. Both call sites pass `embeddedUuid: embedded`,
-  // where `embedded` is `embeddedWorkflowUuid(wf, { allowGraph: false })` —
-  // permanently null — so both short-circuit on their first line, whatever they
-  // were written to prevent. Pinning it makes the dead branch visible in the
-  // suite rather than only in a comment.
+test("#945 FIXED: the READ carrier reaches it, so `allowGraph:false` is no longer null", () => {
+  const wf = realComfyWorkflow();
+  assert.equal(embeddedUuidRead(wf), "ff7890d8-1111-4111-8111-111111111111");
+  // Through the real getter, not a planted own-property: `activeState` delegates to
+  // `changeTracker.activeState`, so a build that stops populating the tracker goes back
+  // to null rather than to a stale value.
+  wf.changeTracker.activeState = null;
+  assert.equal(embeddedUuidRead(wf), null, "no tracker state → no identity, not a guess");
+
+  // Same SHAPE check as the original chain, so the two rungs cannot disagree about what
+  // counts as a carrier. A non-object here reads as no carrier rather than being handed
+  // on: today a string would fall out as null one line later anyway, but that is the
+  // reader's accident, not this function's contract.
+  for (const bad of ["not-an-object", 42, true]) {
+    assert.equal(workflowOwnedExtraForRead({ activeState: { extra: bad } }), null, String(bad));
+  }
+  const src = readFileSync(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8");
+  assert.match(src, /const state = wf\?\.activeState\?\.extra;\r?\n\s*return state && typeof state === "object" \? state : null;/, "production applies the same check");
+});
+
+test("#945 the original rungs still WIN — the new one only fills the gap", () => {
+  // Order matters: a build that really does carry `wf.extra` must keep answering from
+  // it. Putting `activeState` first would silently change which field decides on any
+  // frontend where both exist, and they can disagree.
+  const wf = realComfyWorkflow("from-active-state-1111-4111-8111-111111111111");
+  wf.extra = { comfyui_mcp: { workflow_uuid: "from-wf-extra" } };
+  assert.equal(embeddedUuidRead(wf), "from-wf-extra");
+  delete wf.extra;
+  assert.equal(embeddedUuidRead(wf), "from-active-state-1111-4111-8111-111111111111");
+});
+
+test("#945 the READ carrier is not the live canvas — it tracks the WORKFLOW", () => {
+  // The point of `allowGraph:false` is to refuse the canvas's identity for a workflow
+  // object, so a carrier that were secretly the canvas would defeat it silently.
+  // Measured on 0.31.1 / frontend 1.48.7 with three workflows open: each NON-ACTIVE
+  // workflow's `activeState.extra` held its OWN uuid (30dfba50…, 2d7fa288…), distinct
+  // from `app.graph.extra` (e66e531b…, the active one).
+  const background = realComfyWorkflow("30dfba50-4c01-4c40-a4c2-72a47e12269c");
+  const active = realComfyWorkflow("e66e531b-a4ca-4bee-8a11-12df34b830e2");
+  assert.notEqual(embeddedUuidRead(background), embeddedUuidRead(active));
+  assert.equal(embeddedUuidRead(background), "30dfba50-4c01-4c40-a4c2-72a47e12269c");
+});
+
+test("#945 the WRITE was deliberately not repointed", () => {
+  // Embedding into `activeState.extra` moves where identity PERSISTS — it stops reaching
+  // `app.graph.extra`, which is what a save serializes — and was reverted once for
+  // exactly that. Reading a field is not writing it, so the revert's reason survives this
+  // change. Pinned on the source, since that is the only place the asymmetry is visible.
+  const src = readFileSync(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8");
+  const uuidFn = src.slice(
+    src.indexOf("function embeddedWorkflowUuid("),
+    src.indexOf("function persistWorkflowAliases("),
+  );
+  assert.match(uuidFn, /workflowOwnedExtraForRead\(wf\)/, "both readers use the extended carrier");
+  assert.equal(
+    (uuidFn.match(/workflowOwnedExtraForRead\(wf\)/g) ?? []).length,
+    2,
+    "uuid AND path — reading them from different carriers could answer about two workflows",
+  );
+  // Every place that MUTATES what it got back still uses the original chain.
+  assert.ok(src.includes("const extra = workflowOwnedExtra(wf);"), "write site unchanged");
+  assert.ok(
+    !/const extra = workflowOwnedExtraForRead\(wf\);[\s\S]{0,400}?extra\[WORKFLOW_META_NAMESPACE\] =/.test(src),
+    "nothing writes into the read carrier",
+  );
+});
+
+test("BEFORE #945: handed null, both fork guards decide nothing", () => {
+  // Kept as the null CONTRACT, not as a description of the frontend any more. Both
+  // call sites pass `embeddedUuid: embedded`, and before this fix `embedded` was
+  // permanently null on the observed frontend, so both short-circuited on their first
+  // line whatever they were written to prevent. With the read carrier extended they
+  // now receive the workflow's own uuid — see the FIXED test above — but null must
+  // still be answered this way on a build that genuinely carries no identity.
   //
   // NOTE ON PARAMETER NAMES: an earlier draft of this file passed `embedded:`,
   // which these functions do not read, so the assertions passed for the wrong
@@ -218,11 +300,21 @@ test("SOURCE: the modelled chain is the one production actually reads", async ()
     /const candidate = wf\?\.extra \|\| wf\?\.workflow\?\.extra \|\| wf\?\.data\?\.extra;/,
     "the carrier chain changed — update the model above, and re-check #945's conclusion",
   );
-  // The call site that feeds the fork guards a permanently-null value.
+  // The call site that feeds the fork guards. No longer permanently null (#945): the
+  // read carrier behind it now reaches `activeState.extra`, which is where the uuid is.
   assert.match(
     src,
     /const embedded = embeddedWorkflowUuid\(wf, \{ allowGraph: false \}\);/,
     "the guards are no longer fed from the workflow-owned carrier",
+  );
+  // …and the read carrier itself, which this file reimplements as
+  // `workflowOwnedExtraForRead`. Its ORDER is the assertion that matters: the original
+  // three rungs first, `activeState.extra` only behind them — a build carrying both
+  // would otherwise start deciding on a different field without anything failing.
+  assert.match(
+    src,
+    /const owned = workflowOwnedExtra\(wf\);\r?\n\s*if \(owned\) return owned;[\s\S]{0,300}?const state = wf\?\.activeState\?\.extra;/,
+    "the read carrier's order changed — re-check which field decides identity",
   );
   // Both guards still read the value under the name the tests use, so a rename
   // cannot make these assertions pass by not applying.

--- a/browser_tests/unit/embedded-uuid-carrier.test.mjs
+++ b/browser_tests/unit/embedded-uuid-carrier.test.mjs
@@ -65,11 +65,14 @@ const workflowOwnedExtra = (wf) => {
   return candidate && typeof candidate === "object" ? candidate : null;
 };
 /** The READ carrier, exactly as `workflowOwnedExtraForRead` implements it: the same
- *  chain, with `activeState.extra` behind it. Ordered so an older build that really
- *  does carry one of the three original fields keeps answering from it. */
-const workflowOwnedExtraForRead = (wf) => {
+ *  chain, with `activeState.extra` behind it — and ONLY for a workflow that is not the
+ *  mounted one. Ordered so an older build that really does carry one of the three
+ *  original fields keeps answering from it. `active` stands in for the module's
+ *  `activeWorkflowRef()`. */
+const workflowOwnedExtraForRead = (wf, active = null) => {
   const owned = workflowOwnedExtra(wf);
   if (owned) return owned;
+  if (!wf || (active && wf === active)) return null;
   const state = wf?.activeState?.extra;
   return state && typeof state === "object" ? state : null;
 };
@@ -79,7 +82,7 @@ const uuidFrom = (extra) => {
 };
 const embeddedUuid = (wf) => uuidFrom(workflowOwnedExtra(wf));
 /** What `embeddedWorkflowUuid(wf, {allowGraph:false})` now resolves. */
-const embeddedUuidRead = (wf) => uuidFrom(workflowOwnedExtraForRead(wf));
+const embeddedUuidRead = (wf, active = null) => uuidFrom(workflowOwnedExtraForRead(wf, active));
 
 /** The real shape, from ComfyUI 0.31.1 / frontend 1.44.19. `activeState` is a
  *  getter onto the change tracker, which is where the uuid actually lives. */
@@ -133,19 +136,22 @@ test("OBSERVATION (#945): the original three-rung chain yields nothing", () => {
 
 test("#945 FIXED: the READ carrier reaches it, so `allowGraph:false` is no longer null", () => {
   const wf = realComfyWorkflow();
-  assert.equal(embeddedUuidRead(wf), "ff7890d8-1111-4111-8111-111111111111");
+  // Not the mounted one — see the codex P0 test below for why that distinction is the
+  // whole design.
+  const mounted = realComfyWorkflow("e66e531b-a4ca-4bee-8a11-12df34b830e2");
+  assert.equal(embeddedUuidRead(wf, mounted), "ff7890d8-1111-4111-8111-111111111111");
   // Through the real getter, not a planted own-property: `activeState` delegates to
   // `changeTracker.activeState`, so a build that stops populating the tracker goes back
   // to null rather than to a stale value.
   wf.changeTracker.activeState = null;
-  assert.equal(embeddedUuidRead(wf), null, "no tracker state → no identity, not a guess");
+  assert.equal(embeddedUuidRead(wf, mounted), null, "no tracker state → no identity, not a guess");
 
   // Same SHAPE check as the original chain, so the two rungs cannot disagree about what
   // counts as a carrier. A non-object here reads as no carrier rather than being handed
   // on: today a string would fall out as null one line later anyway, but that is the
   // reader's accident, not this function's contract.
   for (const bad of ["not-an-object", 42, true]) {
-    assert.equal(workflowOwnedExtraForRead({ activeState: { extra: bad } }), null, String(bad));
+    assert.equal(workflowOwnedExtraForRead({ activeState: { extra: bad } }, mounted), null, String(bad));
   }
   const src = readFileSync(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8");
   assert.match(src, /const state = wf\?\.activeState\?\.extra;\r?\n\s*return state && typeof state === "object" \? state : null;/, "production applies the same check");
@@ -157,21 +163,44 @@ test("#945 the original rungs still WIN — the new one only fills the gap", () 
   // frontend where both exist, and they can disagree.
   const wf = realComfyWorkflow("from-active-state-1111-4111-8111-111111111111");
   wf.extra = { comfyui_mcp: { workflow_uuid: "from-wf-extra" } };
-  assert.equal(embeddedUuidRead(wf), "from-wf-extra");
+  // Mounted OR not: the original rungs are consulted first either way, so this holds
+  // even for the workflow on screen.
+  assert.equal(embeddedUuidRead(wf, wf), "from-wf-extra");
+  assert.equal(embeddedUuidRead(wf, null), "from-wf-extra");
   delete wf.extra;
-  assert.equal(embeddedUuidRead(wf), "from-active-state-1111-4111-8111-111111111111");
+  assert.equal(embeddedUuidRead(wf, null), "from-active-state-1111-4111-8111-111111111111");
 });
 
-test("#945 the READ carrier is not the live canvas — it tracks the WORKFLOW", () => {
-  // The point of `allowGraph:false` is to refuse the canvas's identity for a workflow
-  // object, so a carrier that were secretly the canvas would defeat it silently.
-  // Measured on 0.31.1 / frontend 1.48.7 with three workflows open: each NON-ACTIVE
-  // workflow's `activeState.extra` held its OWN uuid (30dfba50…, 2d7fa288…), distinct
-  // from `app.graph.extra` (e66e531b…, the active one).
-  const background = realComfyWorkflow("30dfba50-4c01-4c40-a4c2-72a47e12269c");
+test("#945 (codex P0) the MOUNTED workflow is refused — its activeState IS the canvas", () => {
+  // The finding that reshaped this fix. `activeState` is a getter onto
+  // `changeTracker.activeState`, and for the workflow currently mounted the tracker
+  // fills it from `captureCanvasState()`, which clones `app.rootGraph.serialize()`.
+  // Reading it there would answer `allowGraph:false` with the mounted root's identity —
+  // the exact authority that flag exists to refuse — and nothing would look wrong.
+  //
+  // My measurement missed it: with three workflows open, the two NON-ACTIVE rows carried
+  // their own uuids (30dfba50…, 2d7fa288…) and the ACTIVE row matched `app.graph.extra`
+  // (e66e531b…). That reads as 'distinct from the canvas' only if you skip the active row.
   const active = realComfyWorkflow("e66e531b-a4ca-4bee-8a11-12df34b830e2");
-  assert.notEqual(embeddedUuidRead(background), embeddedUuidRead(active));
-  assert.equal(embeddedUuidRead(background), "30dfba50-4c01-4c40-a4c2-72a47e12269c");
+  assert.equal(
+    embeddedUuidRead(active, active),
+    null,
+    "the mounted workflow gets no answer from this carrier, exactly as before the fix",
+  );
+  // An UNSPECIFIED workflow defaults to the active one in production, so it lands here too.
+  assert.equal(embeddedUuidRead(null, active), null);
+  assert.equal(embeddedUuidRead(undefined, active), null);
+});
+
+test("#945 a NON-mounted workflow is answered from its own capture", () => {
+  // Its tracker state is the capture from when it was last live, which no mounted root
+  // is consulted for. That is a workflow-owned answer, and it is what revives the guards.
+  const active = realComfyWorkflow("e66e531b-a4ca-4bee-8a11-12df34b830e2");
+  const background = realComfyWorkflow("30dfba50-4c01-4c40-a4c2-72a47e12269c");
+  assert.equal(embeddedUuidRead(background, active), "30dfba50-4c01-4c40-a4c2-72a47e12269c");
+  assert.notEqual(embeddedUuidRead(background, active), embeddedUuidRead(active, active));
+  // And with no active workflow at all, a workflow still answers for itself.
+  assert.equal(embeddedUuidRead(background, null), "30dfba50-4c01-4c40-a4c2-72a47e12269c");
 });
 
 test("#945 the WRITE was deliberately not repointed", () => {
@@ -313,7 +342,7 @@ test("SOURCE: the modelled chain is the one production actually reads", async ()
   // would otherwise start deciding on a different field without anything failing.
   assert.match(
     src,
-    /const owned = workflowOwnedExtra\(wf\);\r?\n\s*if \(owned\) return owned;[\s\S]{0,300}?const state = wf\?\.activeState\?\.extra;/,
+    /const owned = workflowOwnedExtra\(wf\);\r?\n\s*if \(owned\) return owned;[\s\S]{0,400}?if \(!wf \|\| \(active && wf === active\)\) return null;\r?\n\s*const state = wf\?\.activeState\?\.extra;/,
     "the read carrier's order changed — re-check which field decides identity",
   );
   // Both guards still read the value under the name the tests use, so a rename

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -1944,15 +1944,48 @@ function workflowOwnedExtra(wf = activeWorkflowRef()) {
   return candidate && typeof candidate === "object" ? candidate : null;
 }
 
+/**
+ * #945 — the READ carrier for `allowGraph: false`, and deliberately NOT the write
+ * one.
+ *
+ * `workflowOwnedExtra` above answers null on every frontend observed here, so the
+ * two fork guards behind it arbitrate a value they never receive. The uuid is on
+ * the workflow object — one field away, in `activeState.extra`.
+ *
+ * MEASURED before adding it, because the whole point of `allowGraph: false` is to
+ * refuse the live canvas's identity for a workflow object, and a carrier that is
+ * secretly the canvas would defeat that silently. On 0.31.1 / frontend 1.48.7 with
+ * three workflows open, each NON-ACTIVE workflow's `activeState.extra` carried its
+ * OWN uuid (30dfba50…, 2d7fa288…), distinct from the canvas's (e66e531b…, which is
+ * what `app.graph.extra` held). It tracks the workflow, not the screen — so it
+ * satisfies the contract this parameter exists to enforce.
+ *
+ * THE WRITE IS NOT REPOINTED. Embedding into `activeState.extra` moves where
+ * identity persists — it stops reaching `app.graph.extra`, which is what a save
+ * serializes — and was reverted once for exactly that. Reading a field is not
+ * writing it, so the revert's reason is preserved rather than re-argued: this
+ * function has no callers that mutate what it returns.
+ */
+function workflowOwnedExtraForRead(wf = activeWorkflowRef()) {
+  const owned = workflowOwnedExtra(wf);
+  if (owned) return owned;
+  // Last, not first: an older build that really does carry one of the three fields
+  // above keeps answering from it, so this only fills the gap where they are absent.
+  const state = wf?.activeState?.extra;
+  return state && typeof state === "object" ? state : null;
+}
+
 function embeddedWorkflowUuid(wf = activeWorkflowRef(), { allowGraph = true } = {}) {
-  const extra = allowGraph ? activeWorkflowExtra(wf) : workflowOwnedExtra(wf);
+  const extra = allowGraph ? activeWorkflowExtra(wf) : workflowOwnedExtraForRead(wf);
   const ns = extra?.[WORKFLOW_META_NAMESPACE];
   const id = ns?.[WORKFLOW_UUID_FIELD];
   return typeof id === "string" && id ? id : null;
 }
 
 function embeddedWorkflowPath(wf = activeWorkflowRef(), { allowGraph = true } = {}) {
-  const extra = allowGraph ? activeWorkflowExtra(wf) : workflowOwnedExtra(wf);
+  // Same carrier as the uuid — they are recorded together in one namespace, so
+  // reading them from different places could answer about two different workflows.
+  const extra = allowGraph ? activeWorkflowExtra(wf) : workflowOwnedExtraForRead(wf);
   const ns = extra?.[WORKFLOW_META_NAMESPACE];
   const path = ns?.[WORKFLOW_PATH_FIELD];
   return typeof path === "string" && path ? path : null;

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -1966,11 +1966,21 @@ function workflowOwnedExtra(wf = activeWorkflowRef()) {
  * (e66e531b…) — which reads as "distinct from the canvas" only if you never look at
  * the active row.
  *
- * So the rung applies to a workflow that is NOT mounted. Its tracker state is the
- * capture from when that workflow was last live, which is genuinely its own: no
- * mounted root is being consulted, and the active workflow keeps answering null
- * here, exactly as before, because for it there is no workflow-owned carrier that
- * is distinguishable from the canvas.
+ * So the rung applies to a workflow that is NOT mounted — and "not mounted" is
+ * decided with `sameWorkflowObject`, never `===` (codex r2). The workflow service
+ * hands out Vue PROXIES in its computed lists while raw objects flow through the
+ * uuid stores, and the active binding path unwraps deliberately: the graph fence
+ * calls `workflowOwnsRootUuidTag(activeWorkflowRef())`, which re-enters here with
+ * `rawWorkflowObject(w)`. A strict comparison against the proxy would be false for
+ * the mounted workflow's own raw target, and the exclusion would let exactly the
+ * canvas state back in through the back door. `sameWorkflowObject` also matches on
+ * the shared `changeTracker` object, which is what `activeState` reads from, so two
+ * references to the same tracker cannot disagree about whether it is mounted.
+ *
+ * With that comparison, a non-mounted workflow's tracker state is the capture from
+ * when it was last live: its own, with no mounted root consulted. The active
+ * workflow keeps answering null here, exactly as before, because for it there is no
+ * workflow-owned carrier distinguishable from the canvas.
  *
  * THE WRITE IS NOT REPOINTED. Embedding into `activeState.extra` moves where
  * identity persists — it stops reaching `app.graph.extra`, which is what a save
@@ -1985,7 +1995,7 @@ function workflowOwnedExtraForRead(wf = activeWorkflowRef()) {
   // workflow-owned answer at all. Absent `wf` defaults to the active one, which lands
   // here too — an unspecified workflow must never be answered from the canvas.
   const active = activeWorkflowRef();
-  if (!wf || (active && wf === active)) return null;
+  if (!wf || sameWorkflowObject(wf, active)) return null;
   const state = wf?.activeState?.extra;
   return state && typeof state === "object" ? state : null;
 }

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -1952,13 +1952,25 @@ function workflowOwnedExtra(wf = activeWorkflowRef()) {
  * two fork guards behind it arbitrate a value they never receive. The uuid is on
  * the workflow object — one field away, in `activeState.extra`.
  *
- * MEASURED before adding it, because the whole point of `allowGraph: false` is to
- * refuse the live canvas's identity for a workflow object, and a carrier that is
- * secretly the canvas would defeat that silently. On 0.31.1 / frontend 1.48.7 with
- * three workflows open, each NON-ACTIVE workflow's `activeState.extra` carried its
- * OWN uuid (30dfba50…, 2d7fa288…), distinct from the canvas's (e66e531b…, which is
- * what `app.graph.extra` held). It tracks the workflow, not the screen — so it
- * satisfies the contract this parameter exists to enforce.
+ * NOT FOR THE ACTIVE WORKFLOW, and that restriction is the whole design (codex).
+ * `activeState` is a getter onto `changeTracker.activeState`, and for the workflow
+ * that is CURRENTLY MOUNTED the tracker fills it from `captureCanvasState()`, which
+ * clones `app.rootGraph.serialize()` — so on the active tab this field IS the live
+ * canvas's identity wearing a different name. Reading it there would satisfy
+ * `allowGraph: false` with exactly the mounted-root authority that flag exists to
+ * refuse, and nothing would look wrong.
+ *
+ * My own measurement did not catch that: with three workflows open on 0.31.1 /
+ * frontend 1.48.7, each NON-ACTIVE workflow's `activeState.extra` carried its OWN
+ * uuid (30dfba50…, 2d7fa288…) while the active one's matched `app.graph.extra`
+ * (e66e531b…) — which reads as "distinct from the canvas" only if you never look at
+ * the active row.
+ *
+ * So the rung applies to a workflow that is NOT mounted. Its tracker state is the
+ * capture from when that workflow was last live, which is genuinely its own: no
+ * mounted root is being consulted, and the active workflow keeps answering null
+ * here, exactly as before, because for it there is no workflow-owned carrier that
+ * is distinguishable from the canvas.
  *
  * THE WRITE IS NOT REPOINTED. Embedding into `activeState.extra` moves where
  * identity persists — it stops reaching `app.graph.extra`, which is what a save
@@ -1969,8 +1981,11 @@ function workflowOwnedExtra(wf = activeWorkflowRef()) {
 function workflowOwnedExtraForRead(wf = activeWorkflowRef()) {
   const owned = workflowOwnedExtra(wf);
   if (owned) return owned;
-  // Last, not first: an older build that really does carry one of the three fields
-  // above keeps answering from it, so this only fills the gap where they are absent.
+  // The mounted workflow's tracker state is a clone of the live root, so it is not a
+  // workflow-owned answer at all. Absent `wf` defaults to the active one, which lands
+  // here too — an unspecified workflow must never be answered from the canvas.
+  const active = activeWorkflowRef();
+  if (!wf || (active && wf === active)) return null;
   const state = wf?.activeState?.extra;
   return state && typeof state === "object" ? state : null;
 }


### PR DESCRIPTION
The carrier call this issue was parked on, now made — and made on a measurement rather than
a preference.

**Measured live on ComfyUI 0.31.1 / frontend 1.48.7, three workflows open:**

| workflow | active | `wf.extra` / `.workflow.extra` / `.data.extra` | `activeState.extra` uuid |
|---|---|---|---|
| krea2_identity_edit | yes | all null | `e66e531b…` |
| Anima Wojak Batch | no | all null | `30dfba50…` |
| Unsaved Workflow | no | all null | `2d7fa288…` |

`app.graph.extra` carried `e66e531b…` — the ACTIVE one.

Two things follow, and the second is the one that was uncertain:

1. The three fields `workflowOwnedExtra()` reads are null on this frontend too, so
   `embeddedWorkflowUuid(wf, {allowGraph:false})` is still unconditionally null and the two
   fork guards are still arbitrating a value they never receive.

2. **`activeState.extra` is not the live canvas by another name.** Each non-active workflow
   carries its OWN uuid there, different from the canvas's. That is precisely the property
   `allowGraph:false` exists to require: a workflow object's identity must not be answered
   with whatever is on screen.

So the pick is asymmetric, and deliberately so:

- **READ** gains `activeState.extra` as a workflow-owned source, which revives the guards.
- **WRITE stays exactly where it is.** Repointing the embed write was tried and reverted
  once because it moves where identity persists — `loadGraphData` stamps `graphData.extra`
  and the root graph carries it, which is what a save serializes. Nothing here touches
  that, so the revert's reason is preserved rather than re-litigated.

Draft first, per the loop. Codex review before merge.

Refs #945

🤖 Generated with [Claude Code](https://claude.com/claude-code)