### PR TITLE
feat(i18n): translate the CivitAI panel (unit 6)

### DIFF
--- a/browser_tests/unit/i18n.test.mjs
+++ b/browser_tests/unit/i18n.test.mjs
@@ -106,7 +106,24 @@ test("every shipped locale file matches the English key set exactly", () => {
     }
     return out;
   };
+  // Plural siblings are per-LANGUAGE and must not be compared as a flat set. English has
+  // `_one`/`_other`; Korean, Japanese and Chinese use `other` alone, and Russian needs
+  // `few`/`many` that English will never have. A naive set comparison demands zh carry
+  // `n_nodes_one` — the exact key `scripts/i18n-check.mjs` rejects as "has `_one`, which zh
+  // never uses — remove it". The two gates were mutually unsatisfiable the moment any plural
+  // key entered the catalog, which nothing noticed because the catalog had none: the panel's
+  // first counted strings arrive with the CivitAI unit. Verified both directions — adding the
+  // `_one` siblings turns this test green and i18n-check red with 18 problems; removing them
+  // does the reverse. So plural bases are checked against Intl here, exactly as the gate does,
+  // and only non-plural keys are compared literally.
+  const splitPlural = (k) => {
+    const m = k.match(/^(.*)_(zero|one|two|few|many|other)$/);
+    return m ? { base: m[1], cat: m[2] } : null;
+  };
   const expected = flat(en);
+  const plainExpected = [...expected].filter((k) => !splitPlural(k));
+  const basesExpected = new Set([...expected].map(splitPlural).filter(Boolean).map((p) => p.base));
+
   for (const { code } of LOCALES) {
     if (code === "en") continue;
     let target;
@@ -116,10 +133,27 @@ test("every shipped locale file matches the English key set exactly", () => {
       continue; // not started yet — falls back to English wholesale, which is fine
     }
     const got = flat(target);
-    const missing = [...expected].filter((k) => !got.has(k));
-    const extra = [...got].filter((k) => !expected.has(k));
-    assert.deepEqual(missing, [], `${code} is missing keys`);
-    assert.deepEqual(extra, [], `${code} has keys English does not`);
+    const plainGot = [...got].filter((k) => !splitPlural(k));
+    assert.deepEqual(plainExpected.filter((k) => !got.has(k)), [], `${code} is missing keys`);
+    assert.deepEqual(plainGot.filter((k) => !expected.has(k)), [], `${code} has keys English does not`);
+
+    // Every plural base English declares must be present in EXACTLY this language's categories.
+    const cats = new Intl.PluralRules(code).resolvedOptions().pluralCategories;
+    for (const base of basesExpected) {
+      const have = new Set(
+        [...got].map(splitPlural).filter((p) => p && p.base === base).map((p) => p.cat),
+      );
+      assert.deepEqual(
+        cats.filter((c) => !have.has(c)),
+        [],
+        `${code} plural "${base}" is missing categories it needs [${cats.join(", ")}]`,
+      );
+      assert.deepEqual(
+        [...have].filter((c) => !cats.includes(c)),
+        [],
+        `${code} plural "${base}" has categories ${code} never uses`,
+      );
+    }
   }
 });
 
@@ -271,6 +305,41 @@ test("regenerating English is a ROUND TRIP — it never loses a converted key", 
     [],
     "these catalog keys have no tr() call site — stale after a revert or rename",
   );
+});
+
+test("a plural call site is readable back — including the {count} in its own text", () => {
+  // The round-trip test above CANNOT catch this, and that is the point of a separate one.
+  // `readConverted` found the plural object's end with `indexOf("}")`, so the first `}` it hit
+  // was the one inside `{count}` — the placeholder that makes a fallback a plural at all. The
+  // body was truncated mid-string, the form regex matched nothing, and the site disappeared.
+  //
+  // Disappeared from BOTH sides: absent from the extractor output means absent from `converted`
+  // AND never expected in the catalog, so the round trip stayed green while every counted
+  // string in the panel was permanently untranslatable. Measured before the fix: 6 plural call
+  // sites in the tree, 0 plural keys in the catalog, 0 failures reported.
+  const out = execFileSync("node", ["scripts/i18n-extract.mjs", "--json"], {
+    cwd: ROOT,
+    encoding: "utf8",
+    maxBuffer: 1 << 26,
+  });
+  const candidates = JSON.parse(out);
+  const plural = candidates.filter((c) => c.converted && /_(zero|one|two|few|many|other)$/.test(c.key));
+
+  // Asserted against the SOURCE, not against a fixture: the guard has to fail when the code
+  // stops emitting these, not when a hand-written expectation drifts.
+  const sites = readFileSync(join(ROOT, "web/js/cmcp-civitai-ui.js"), "utf8")
+    .match(/\btr\(\s*"[\w.]+"\s*,\s*\{\s*(?:\/\/[^\n]*\n\s*)?one\s*:/g) || [];
+  assert.ok(sites.length > 0, "cmcp-civitai-ui.js should still hold plural call sites to check");
+  assert.equal(
+    plural.length,
+    sites.length * 2,
+    `each plural site must yield _one and _other; got ${plural.length} for ${sites.length} sites`,
+  );
+
+  // And the text must survive INTACT — a truncation at `{count}` would still emit a candidate
+  // if the regex happened to close, just with the placeholder chopped off.
+  const withHole = plural.filter((c) => /\{(count|n)\}/.test(c.text));
+  assert.equal(withHole.length, plural.length, "every plural form must keep its {count}/{n} placeholder");
 });
 
 test("RTL is actually WIRED, not just implemented", () => {

--- a/scripts/i18n-extract.mjs
+++ b/scripts/i18n-extract.mjs
@@ -83,6 +83,37 @@ function makeKey(file, text) {
 }
 
 /**
+ * Index of the `}` that closes the object starting at `s[0] === '{'`, or -1.
+ *
+ * `s.indexOf('}')` cannot be used here, and the reason is not hypothetical: a plural fallback
+ * is written `{ one: "{count} node", other: "{count} nodes" }`, so the FIRST `}` in the text
+ * is the one inside `{count}` — the placeholder that makes it a plural in the first place.
+ * Truncating there left a body with no complete `key: "value"` pair, the form regex matched
+ * nothing, and the site vanished. Silently: an unreadable call site is missing from BOTH
+ * sides of the round-trip comparison, so the gate that exists to catch exactly this stayed
+ * green while every counted string in the panel became permanently untranslatable.
+ *
+ * Braces are therefore counted at depth, skipping string literals (where a `{` or `}` is
+ * text, not structure) and their escapes.
+ */
+function objectBodyEnd(s) {
+  let depth = 0;
+  let quote = null;
+  for (let i = 0; i < s.length; i++) {
+    const c = s[i];
+    if (quote) {
+      if (c === '\\') i++;            // escaped char — never closes the string
+      else if (c === quote) quote = null;
+      continue;
+    }
+    if (c === '"' || c === "'" || c === '`') quote = c;
+    else if (c === '{') depth++;
+    else if (c === '}' && --depth === 0) return i;
+  }
+  return -1;
+}
+
+/**
  * Read back an ALREADY-CONVERTED call site: `tr("key", "English")`, or the plural form
  * `tr("key", { one: "…", other: "…" })`.
  *
@@ -110,7 +141,7 @@ function readConverted(src, file) {
     }
     // Plural object: emit one candidate per category so English carries `key_one`/`key_other`.
     if (rest.startsWith('{')) {
-      const close = rest.indexOf('}');
+      const close = objectBodyEnd(rest);
       if (close === -1) continue;
       const body = rest.slice(1, close);
       const form = /(\w+)\s*:\s*(["'`])((?:\\.|(?!\2)[^\\])*)\2/g;

--- a/web/js/cmcp-civitai-ui.js
+++ b/web/js/cmcp-civitai-ui.js
@@ -480,7 +480,13 @@ export function createCivitaiContent(ctx, shell, opts = {}) {
   const subTabsWrap = el("div", "cmcp-cv-tabs");
   for (const t of TABS) {
     const b = el("button", "cmcp-cv-tab");
-    b.innerHTML = `<i class="pi ${t.icon}"></i><span>${t.label}</span>`;
+    // The label goes in as TEXT rather than through innerHTML. `lib/i18n.js` documents
+    // that `tr()` "returns a string and never HTML, so it introduces no injection
+    // path" — true of the helper, but only true of a call site that writes text, and
+    // this was the one that wrote markup. `/i18n` merges EVERY installed pack's
+    // main.json, so a label is a string another pack can influence. Same DOM as the
+    // template it replaces: `el()` sets className and textContent.
+    b.append(el("i", `pi ${t.icon}`), el("span", null, t.label));
     b.addEventListener("click", () => { state.tab = t.key; syncTabs(); reload(); });
     b._key = t.key;
     subTabsWrap.appendChild(b);
@@ -1741,8 +1747,12 @@ export function createCivitaiContent(ctx, shell, opts = {}) {
           foot.appendChild(el("span", null, tr("civitai_ui.n_selected", {
             one: "{count} selected", other: "{count} selected",
           }, { count: f.baseModels.length })));
-          // Reuses the panel-wide "Clear" — same word, already in the catalog.
-          const clear = el("button", "cmcp-cv-ddclear", tr("panel.clear", "Clear"));
+          // Its OWN key, not the panel-wide `panel.clear`, even though the English is
+          // identical. That key labels the credentials card's "clear this API key"
+          // button; a translator seeing only that context can legitimately render it
+          // ja "キーを消去" ("clear the key"), which would then mislabel THIS button —
+          // which clears base-model filters. Sharing a key shares the context too.
+          const clear = el("button", "cmcp-cv-ddclear", tr("civitai_ui.clear", "Clear"));
           clear.type = "button";
           // Left button only — right-clicking "Clear" would otherwise wipe every
           // selected model before the context menu even appeared.
@@ -1842,6 +1852,16 @@ export function createCivitaiContent(ctx, shell, opts = {}) {
             // Counted, but the number the user READS is abbreviated ("1.2M"), and a
             // plural category can't be derived from that string. So `count` carries the
             // real total for Intl and `{n}` carries the abbreviation for display.
+            //
+            // Known residual, bounded and deliberate: once abbreviated, the category
+            // follows the TRUE total, not the displayed numeral. `compactCount(1001)`
+            // is "1K" while ru's rule for 1001 is `one`, so that row reads "1K
+            // загрузка" where the displayed "1K" wants the genitive. Getting this
+            // exactly right needs locale-aware compact formatting
+            // (Intl.NumberFormat notation:"compact"), which would also change the
+            // digits every existing row shows — a bigger change than this row is
+            // worth. Every count below 1000 displays in full and is exactly right,
+            // which is most creators; English is immune either way.
             const sub = c.position != null
               ? [
                   c.downloads != null
@@ -2010,8 +2030,10 @@ export function createCivitaiContent(ctx, shell, opts = {}) {
           newBtn.disabled = false;
         }
       });
-      // Reuses the panel-wide "Sign out" — same two words, already in the catalog.
-      const out = el("button", "cmcp-btn", tr("panel.sign_out", "Sign out"));
+      // Its own key rather than `panel.sign_out` — see the note on civitai_ui.clear.
+      // That one signs out of an AI provider; this one signs out of CivitAI, and the
+      // two need not share a verb in every language.
+      const out = el("button", "cmcp-btn", tr("civitai_ui.sign_out", "Sign out"));
       out.addEventListener("click", async () => {
         await ctx.api.fetchApi("/comfyui_mcp_panel/civitai/oauth/logout", { method: "POST" });
         await refreshAuth(); sheet.close();

--- a/web/js/cmcp-civitai-ui.js
+++ b/web/js/cmcp-civitai-ui.js
@@ -249,6 +249,18 @@ export function graphDirtyForConfirm(ctx) {
   }
 }
 
+/** The one-line verdict on a post's embedded graph, shown in both the lightbox
+ *  side pane and the standalone generation-info sheet. Factored out when these
+ *  three strings were translated: the two copies were byte-identical, and three
+ *  keys duplicated across two call sites is three chances for them to drift.
+ *  A plain `tr()` is correct — this runs per render, long after the catalog loads. */
+function embeddedWorkflowNote(wf) {
+  if (!wf) return tr("civitai_ui.no_embedded_workflow", "No embedded workflow");
+  if (wf.format === "ui") return tr("civitai_ui.embedded_comfyui_workflow", "✓ Embedded ComfyUI workflow");
+  return tr("civitai_ui.embedded_graph_is_api_format_only_it",
+    "Embedded graph is API-format only — it can't load onto the canvas, but Save keeps its JSON.");
+}
+
 /** Serialize result rows — `state.items` (media) or `state.models` (models) —
  *  to the agent's `civitai_results` contract shape: id, kind, title, creator,
  *  baseModel/type, stats, prompt, media URL(s), and `gated`. Metadata + URLs
@@ -475,8 +487,15 @@ export function createCivitaiContent(ctx, shell, opts = {}) {
   }
 
   // Favorites media-type chips (shown only on the Favorites sub-tab).
+  // Built INSIDE this function, which runs long after setup() awaited the catalog,
+  // so a plain tr() is correct here — unlike module-scope TABS above, which needs
+  // getters. "Images"/"Videos" reuse the sub-tab labels' keys: identical English.
   const favChips = el("div", "cmcp-cv-frow");
-  for (const [label, val] of [["All", "all"], ["Images", "image"], ["Videos", "video"]]) {
+  for (const [label, val] of [
+    [tr("civitai_ui.all", "All"), "all"],
+    [tr("civitai_ui.images", "Images"), "image"],
+    [tr("civitai_ui.videos", "Videos"), "video"],
+  ]) {
     const chip = el("button", "cmcp-cv-chip", label);
     chip._fv = val;
     chip.addEventListener("click", () => {
@@ -700,7 +719,8 @@ export function createCivitaiContent(ctx, shell, opts = {}) {
       if (stalled) {
         // Explicit affordance instead of a silent dead end.
         sentinel.textContent = "";
-        const more = el("button", "cmcp-btn", "No matches yet — keep searching");
+        const more = el("button", "cmcp-btn",
+          tr("civitai_ui.no_matches_yet_keep_searching", "No matches yet — keep searching"));
         more.addEventListener("click", () => loadMore());
         sentinel.appendChild(more);
       } else if (state.done && !grid.children.length) {
@@ -810,13 +830,21 @@ export function createCivitaiContent(ctx, shell, opts = {}) {
         const on = _liked.get(it.id) === true;
         likeBtn.classList.toggle("on", on);
         likeBtn.innerHTML = `<i class="pi ${on ? "pi-heart-fill" : "pi-heart"}"></i>`;
-        likeBtn.title = !state.signedIn ? "Sign in to CivitAI to like" : on ? "Unlike on CivitAI" : "Like on CivitAI";
+        likeBtn.title = !state.signedIn
+          ? tr("civitai_ui.sign_in_to_civitai_to_like", "Sign in to CivitAI to like")
+          : on
+            ? tr("civitai_ui.unlike_on_civitai", "Unlike on CivitAI")
+            : tr("civitai_ui.like_on_civitai", "Like on CivitAI");
       };
       paintLike();
       card.addEventListener("mouseenter", paintLike); // resync after lightbox toggles
       likeBtn.addEventListener("click", (e) => {
         e.stopPropagation();
-        if (!state.signedIn) { toast("Sign in to CivitAI to like — opening sign-in…"); accountFlow(); return; }
+        if (!state.signedIn) {
+          toast(tr("civitai_ui.sign_in_to_civitai_to_like_opening", "Sign in to CivitAI to like — opening sign-in…"));
+          accountFlow();
+          return;
+        }
         void toggleLike(it, paintLike);
       });
       card.appendChild(likeBtn);
@@ -833,7 +861,7 @@ export function createCivitaiContent(ctx, shell, opts = {}) {
     img.loading = "lazy"; img.src = m.coverUrl;
     img.addEventListener("error", () => { card.style.display = "none"; });
     card.append(img, el("span", "cmcp-cv-badge", m.type));
-    if (owned(m.fileName)) card.appendChild(el("span", "cmcp-cv-owned", "✓ In library"));
+    if (owned(m.fileName)) card.appendChild(el("span", "cmcp-cv-owned", tr("civitai_ui.in_library", "✓ In library")));
     const foot = el("div", "cmcp-cv-cardfoot", `${m.name}\n${m.baseModel || ""} · ⬇ ${m.downloadCount ?? "?"}`);
     foot.style.whiteSpace = "pre-line";
     card.appendChild(foot);
@@ -864,14 +892,16 @@ export function createCivitaiContent(ctx, shell, opts = {}) {
       _liked.set(it.id, !next); paint();
       const msg = String(e.message || e);
       toast(msg.includes("403")
-        ? "CivitAI permissions changed -- use the account button to sign out and back in."
-        : "Like failed: " + msg);
+        ? tr("civitai_ui.civitai_permissions_changed_use_the_account_button",
+          "CivitAI permissions changed -- use the account button to sign out and back in.")
+        : tr("civitai_ui.like_failed", "Like failed: {error}", { error: msg }));
       return;
     }
     const col = likesCollection();
     if (col?.id) {
       client.setImageInCollection(it.id, col.id, next).catch((e) =>
-        toast(`Couldn't update collection "${col.name}": ` + (e.message || e)));
+        toast(tr("civitai_ui.couldn_t_update_collection", "Couldn't update collection \"{name}\": {error}",
+          { name: col.name, error: e.message || e })));
     }
   }
 
@@ -907,7 +937,7 @@ export function createCivitaiContent(ctx, shell, opts = {}) {
     const nextBtn = el("button", "cmcp-cv-lb-nav", "›"); nextBtn.style.right = ".6rem";
     prevBtn.addEventListener("click", () => step(-1));
     nextBtn.addEventListener("click", () => step(1));
-    const closeBtn2 = mk("pi-times", closeLb, "Close (Esc)");
+    const closeBtn2 = mk("pi-times", closeLb, tr("civitai_ui.close_esc", "Close (Esc)"));
     closeBtn2.classList.add("cmcp-cv-lb-close");
 
     async function genFor(it) {
@@ -944,8 +974,15 @@ export function createCivitaiContent(ctx, shell, opts = {}) {
       // right: identity + actions immediately, generation info when it arrives
       side.innerHTML = "";
       const titleRow = el("div", "cmcp-cv-lb-title");
+      // Anonymous posts fall back to "CivitAI <kind>". Two whole keys rather than
+      // interpolating `it.type` — that field is the API's wire value ("image"/"video")
+      // and splicing it into a translated sentence would leave an English word inside
+      // a Korean title.
+      const kindLabel = it.type === "video"
+        ? tr("civitai_ui.civitai_video", "CivitAI video")
+        : tr("civitai_ui.civitai_image", "CivitAI image");
       titleRow.appendChild(el("span", null,
-        `${it.type === "video" ? "🎬" : "🖼"} ${it.author ? "@" + it.author : "CivitAI " + it.type}`));
+        `${it.type === "video" ? "🎬" : "🖼"} ${it.author ? "@" + it.author : kindLabel}`));
       {
         // Like toggle — the same tRPC mutation the CivitAI site fires
         // (reaction.toggle; calling it again un-likes). Optimistic flip,
@@ -957,11 +994,19 @@ export function createCivitaiContent(ctx, shell, opts = {}) {
           const on = _liked.get(it.id) === true;
           likeBtn.classList.toggle("on", on);
           likeBtn.innerHTML = `<i class="pi ${on ? "pi-heart-fill" : "pi-heart"}"></i>`;
-          likeBtn.title = !state.signedIn ? "Sign in to CivitAI to like" : on ? "Unlike on CivitAI" : "Like on CivitAI";
+          likeBtn.title = !state.signedIn
+            ? tr("civitai_ui.sign_in_to_civitai_to_like", "Sign in to CivitAI to like")
+            : on
+              ? tr("civitai_ui.unlike_on_civitai", "Unlike on CivitAI")
+              : tr("civitai_ui.like_on_civitai", "Like on CivitAI");
         };
         paintLike();
         likeBtn.addEventListener("click", () => {
-          if (!state.signedIn) { toast("Sign in to CivitAI to like — opening sign-in…"); accountFlow(); return; }
+          if (!state.signedIn) {
+            toast(tr("civitai_ui.sign_in_to_civitai_to_like_opening", "Sign in to CivitAI to like — opening sign-in…"));
+            accountFlow();
+            return;
+          }
           void toggleLike(it, paintLike);
         });
         titleRow.appendChild(likeBtn);
@@ -972,7 +1017,8 @@ export function createCivitaiContent(ctx, shell, opts = {}) {
 
       const actions = el("div", "cmcp-cv-actions");
       if (it.author) {
-        const moreBtn = el("button", "cmcp-btn", `See more from @${it.author}`);
+        const moreBtn = el("button", "cmcp-btn",
+          tr("civitai_ui.see_more_from", "See more from @{creator}", { creator: it.author }));
         moreBtn.addEventListener("click", () => {
           closeLb();
           seeMoreFromCreator(it.author);
@@ -981,52 +1027,51 @@ export function createCivitaiContent(ctx, shell, opts = {}) {
       }
       side.appendChild(actions);
       const genBox = el("div");
-      genBox.appendChild(el("div", "cmcp-cv-lb-muted", "Loading generation info…"));
+      genBox.appendChild(el("div", "cmcp-cv-lb-muted",
+        tr("civitai_ui.loading_generation_info", "Loading generation info…")));
       side.appendChild(genBox);
 
       genFor(it).then((gen) => {
         if (seq !== renderSeq) return; // user already paged on
         // actions need the gen payload (caption/workflow), so they land here
         const shareBtn = el("button", "cmcp-btn cmcp-btn-primary",
-          ctx.isMuted() ? "Save reference to inputs" : "Share with agent");
+          ctx.isMuted() ? tr("civitai_ui.save_reference_to_inputs", "Save reference to inputs") : tr("civitai_ui.share_with_agent", "Share with agent"));
         shareBtn.addEventListener("click", () => shareImage(it, gen));
         actions.appendChild(shareBtn);
         const wf = CivitaiClient.comfyGraphInfo(gen.meta);
         if (wf) {
           if (wf.format === "ui") {
-            const loadBtn = el("button", "cmcp-btn", "Load onto canvas");
+            const loadBtn = el("button", "cmcp-btn", tr("civitai_ui.load_onto_canvas", "Load onto canvas"));
             loadBtn.title = tr("civitai_ui.replace_the_current_canvas_with_this_post", "Replace the current canvas with this post's embedded ComfyUI workflow (Ctrl+Z undoes it).");
             loadBtn.addEventListener("click", () => { void loadOntoCanvas(wf.graph, closeLb); });
             actions.appendChild(loadBtn);
             // Same loadable-workflow condition as "Load onto canvas": load the graph,
             // then jump to the Apps tab's convert view seeded from the live canvas.
-            const appBtn = el("button", "cmcp-btn", "Create App from workflow");
+            const appBtn = el("button", "cmcp-btn", tr("civitai_ui.create_app_from_workflow", "Create App from workflow"));
             appBtn.title = tr("civitai_ui.load_this_workflow_onto_the_canvas_and", "Load this workflow onto the canvas and package it as a one-click app.");
             appBtn.addEventListener("click", () => {
               void createAppFromWorkflow(() => loadOntoCanvas(wf.graph, closeLb, { keepPanelOpen: true }));
             });
             actions.appendChild(appBtn);
           }
-          const saveBtn = el("button", "cmcp-btn", "Save workflow");
+          const saveBtn = el("button", "cmcp-btn", tr("civitai_ui.save_workflow", "Save workflow"));
           saveBtn.addEventListener("click", () => saveWorkflow(it, wf.graph));
           actions.appendChild(saveBtn);
         }
         genBox.innerHTML = "";
-        genBox.appendChild(el("div", "cmcp-cv-lb-muted",
-          !wf ? "No embedded workflow"
-          : wf.format === "ui" ? "✓ Embedded ComfyUI workflow"
-          : "Embedded graph is API-format only — it can't load onto the canvas, but Save keeps its JSON."));
+        genBox.appendChild(el("div", "cmcp-cv-lb-muted", embeddedWorkflowNote(wf)));
         if (gen.meta?.prompt) {
-          genBox.appendChild(el("div", "cmcp-cv-flabel", "Prompt"));
+          // Distinct from `civitai_ui.prompt` ("Prompt: "), which is a sentence prefix.
+          genBox.appendChild(el("div", "cmcp-cv-flabel", tr("civitai_ui.prompt_label", "Prompt")));
           genBox.appendChild(el("div", "cmcp-cv-lb-prompt", gen.meta.prompt));
         }
         if (gen.meta?.negativePrompt) {
-          genBox.appendChild(el("div", "cmcp-cv-flabel", "Negative"));
+          genBox.appendChild(el("div", "cmcp-cv-flabel", tr("civitai_ui.negative", "Negative")));
           genBox.appendChild(el("div", "cmcp-cv-lb-prompt", gen.meta.negativePrompt));
         }
         const params = CivitaiClient.params(gen.meta);
         if (params.length) {
-          genBox.appendChild(el("div", "cmcp-cv-flabel", "Parameters"));
+          genBox.appendChild(el("div", "cmcp-cv-flabel", tr("civitai_ui.parameters", "Parameters")));
           const grid2 = el("div", "cmcp-cv-lb-params");
           for (const [k, val] of params) {
             grid2.appendChild(el("span", "k", k));
@@ -1037,10 +1082,11 @@ export function createCivitaiContent(ctx, shell, opts = {}) {
       }).catch((e) => {
         if (seq !== renderSeq) return;
         genBox.innerHTML = "";
-        genBox.appendChild(el("div", "cmcp-cv-lb-muted", "No generation data: " + (e.message || e)));
+        genBox.appendChild(el("div", "cmcp-cv-lb-muted",
+          tr("civitai_ui.no_generation_data", "No generation data: {error}", { error: e.message || e })));
         // sharing works without gen data — caption just has no settings
         const shareBtn = el("button", "cmcp-btn cmcp-btn-primary",
-          ctx.isMuted() ? "Save reference to inputs" : "Share with agent");
+          ctx.isMuted() ? tr("civitai_ui.save_reference_to_inputs", "Save reference to inputs") : tr("civitai_ui.share_with_agent", "Share with agent"));
         shareBtn.addEventListener("click", () => shareImage(it, { meta: {} }));
         actions.appendChild(shareBtn);
       });
@@ -1069,31 +1115,32 @@ export function createCivitaiContent(ctx, shell, opts = {}) {
 
   // ── generation info + share/save (mute-aware) ────────────────────────
   async function showGenInfo(it) {
-    const sheet = openSubModal("Generation info");
-    sheet.body.appendChild(el("div", "cmcp-cv-loading", "Loading…"));
+    const sheet = openSubModal(tr("civitai_ui.generation_info", "Generation info"));
+    sheet.body.appendChild(el("div", "cmcp-cv-loading", tr("civitai_ui.loading", "Loading…")));
     let gen;
     try { gen = await client.getGenerationData(it.id); }
-    catch (e) { sheet.body.innerHTML = ""; sheet.body.appendChild(el("div", null, "No data: " + e.message)); return; }
+    catch (e) {
+      sheet.body.innerHTML = "";
+      sheet.body.appendChild(el("div", null, tr("civitai_ui.no_data", "No data: {error}", { error: e.message })));
+      return;
+    }
     sheet.body.innerHTML = "";
     const wf = CivitaiClient.comfyGraphInfo(gen.meta);
-    sheet.body.appendChild(el("div", null,
-      !wf ? "No embedded workflow"
-      : wf.format === "ui" ? "✓ Embedded ComfyUI workflow"
-      : "Embedded graph is API-format only — it can't load onto the canvas, but Save keeps its JSON."));
+    sheet.body.appendChild(el("div", null, embeddedWorkflowNote(wf)));
 
     const actions = el("div", "cmcp-cv-actions");
     const shareBtn = el("button", "cmcp-btn cmcp-btn-primary",
-      ctx.isMuted() ? "Save reference to inputs" : "Share with agent");
+      ctx.isMuted() ? tr("civitai_ui.save_reference_to_inputs", "Save reference to inputs") : tr("civitai_ui.share_with_agent", "Share with agent"));
     shareBtn.addEventListener("click", () => shareImage(it, gen));
     actions.appendChild(shareBtn);
     if (wf) {
       if (wf.format === "ui") {
-        const loadBtn = el("button", "cmcp-btn", "Load onto canvas");
+        const loadBtn = el("button", "cmcp-btn", tr("civitai_ui.load_onto_canvas", "Load onto canvas"));
         loadBtn.title = tr("civitai_ui.replace_the_current_canvas_with_this_example", "Replace the current canvas with this example's embedded ComfyUI workflow (Ctrl+Z undoes it).");
         loadBtn.addEventListener("click", () => { void loadOntoCanvas(wf.graph); });
         actions.appendChild(loadBtn);
       }
-      const saveBtn = el("button", "cmcp-btn", "Save workflow");
+      const saveBtn = el("button", "cmcp-btn", tr("civitai_ui.save_workflow", "Save workflow"));
       saveBtn.addEventListener("click", () => saveWorkflow(it, wf.graph));
       actions.appendChild(saveBtn);
     }
@@ -1110,6 +1157,12 @@ export function createCivitaiContent(ctx, shell, opts = {}) {
     }
   }
 
+  // NOT translated, deliberately: every line below is a PROMPT addressed to the
+  // agent, not UI copy. It is composed alongside English tool names and parameter
+  // labels ("Prompt:", "Steps", "CFG scale" straight off CivitAI's payload), and
+  // handing the model a half-translated instruction is a regression in the one
+  // thing it has to get right. Same rule as the monolith's own reconnect nudges.
+  // The human-facing confirmations around it (the toasts) ARE translated.
   function buildCaption(gen) {
     const m = gen.meta || {};
     const lines = [
@@ -1130,7 +1183,7 @@ export function createCivitaiContent(ctx, shell, opts = {}) {
       const name = `civitai_ref_${it.id}.${it.type === "video" ? "mp4" : "jpeg"}`;
       const ref = await ctx.uploadBlobToInput(blob, name);
       if (ctx.isMuted()) {
-        toast(`Saved ${name} to ComfyUI inputs.`);
+        toast(tr("civitai_ui.saved_to_comfyui_inputs", "Saved {name} to ComfyUI inputs.", { name }));
       } else {
         const caption = buildCaption(gen);
         ctx.sendUserMessage(
@@ -1138,22 +1191,24 @@ export function createCivitaiContent(ctx, shell, opts = {}) {
           undefined, [ref],
         );
         ctx.bringChatForward();
-        toast("Shared with the agent.");
+        toast(tr("civitai_ui.shared_with_the_agent", "Shared with the agent."));
       }
       // Hand-off is done (either variant) — close the explorer so the chat/agent
       // is visible. Only on SUCCESS; a failed share (below) leaves it open to
       // retry. The toast is body-mounted (survives the close) so the confirmation
       // stays on screen. close() is idempotent + tears down the lightbox/sheets.
       close();
-    } catch (e) { toast("Share failed: " + e.message); }
+    } catch (e) { toast(tr("civitai_ui.share_failed", "Share failed: {error}", { error: e.message })); }
   }
 
   async function saveWorkflow(it, graph) {
     try {
       const res = await ctx.callTool("save_workflow",
         { action: "save", filename: `civitai_${it.id}.json`, workflow: graph }, { timeout: 60000 });
-      toast(res.ok ? "Workflow saved to your machine." : "Save failed: " + (res.error || "?"));
-    } catch (e) { toast("Save failed: " + e.message); }
+      toast(res.ok
+        ? tr("civitai_ui.workflow_saved_to_your_machine", "Workflow saved to your machine.")
+        : tr("civitai_ui.save_failed", "Save failed: {error}", { error: res.error || "?" }));
+    } catch (e) { toast(tr("civitai_ui.save_failed", "Save failed: {error}", { error: e.message })); }
   }
 
   // ── load a UI-format workflow onto the live canvas ───────────────────
@@ -1168,24 +1223,29 @@ export function createCivitaiContent(ctx, shell, opts = {}) {
    *  Returns true when it loaded. */
   async function loadOntoCanvas(graph, beforeClose, opts = {}) {
     if (typeof ctx.loadGraph !== "function") {
-      toast("This panel build can't load onto the canvas.");
+      toast(tr("civitai_ui.this_panel_build_can_t_load_onto", "This panel build can't load onto the canvas."));
       return false;
     }
+    // Two keys joined by the blank line rather than one key holding "\n\n": a
+    // translator editing a single value is one stray keystroke away from losing the
+    // paragraph break, and the question and the warning translate independently.
     if (graphDirtyForConfirm(ctx) && !window.confirm(
-      "Load this workflow onto the canvas?\n\n" +
-      "Your current workflow has unsaved changes that will be replaced (Ctrl+Z undoes the load).",
+      tr("civitai_ui.load_this_workflow_onto_the_canvas", "Load this workflow onto the canvas?") + "\n\n" +
+      tr("civitai_ui.your_current_workflow_has_unsaved_changes_that",
+        "Your current workflow has unsaved changes that will be replaced (Ctrl+Z undoes the load)."),
     )) return false;
     let res;
     try {
       res = await ctx.loadGraph(graph);
     } catch (e) {
-      toast("Couldn't load workflow: " + (e.message || e));
+      toast(tr("civitai_ui.couldn_t_load_workflow", "Couldn't load workflow: {error}", { error: e.message || e }));
       return false;
     }
     // Defend against a silent no-op: if the load reported zero nodes the graph
     // didn't actually land — don't dismiss the explorer as if it succeeded.
     if (!res || !res.node_count) {
-      toast("The workflow loaded empty (0 nodes) — nothing was placed on the canvas.");
+      toast(tr("civitai_ui.the_workflow_loaded_empty_0_nodes_nothing",
+        "The workflow loaded empty (0 nodes) — nothing was placed on the canvas."));
       return false;
     }
     if (beforeClose) { try { beforeClose(); } catch { /* already gone */ } }
@@ -1193,7 +1253,12 @@ export function createCivitaiContent(ctx, shell, opts = {}) {
     // keepPanelOpen: the create-app-from-workflow flow hops to the Apps tab next,
     // so the side-panel must stay up; a plain load closes the whole explorer.
     if (!opts.keepPanelOpen) close();
-    toast(`Workflow loaded onto the canvas — ${res.node_count} node${res.node_count === 1 ? "" : "s"}. Ctrl+Z undoes it.`);
+    // Counted: `{count}` drives Intl.PluralRules, so Russian gets one/few/many and
+    // Korean a single form — neither is reachable from an inline `=== 1 ? "" : "s"`.
+    toast(tr("civitai_ui.workflow_loaded", {
+      one: "Workflow loaded onto the canvas — {count} node. Ctrl+Z undoes it.",
+      other: "Workflow loaded onto the canvas — {count} nodes. Ctrl+Z undoes it.",
+    }, { count: res.node_count }));
     return true;
   }
 
@@ -1210,9 +1275,9 @@ export function createCivitaiContent(ctx, shell, opts = {}) {
     if (!loaded) return; // load failed / was cancelled — stay put (toast already shown)
     try {
       if (typeof shell.switchTab === "function") shell.switchTab("apps", { view: "convert" });
-      else toast("This panel build can't open the Apps tab.");
+      else toast(tr("civitai_ui.this_panel_build_can_t_open_the", "This panel build can't open the Apps tab."));
     } catch (e) {
-      toast("Couldn't open the Apps tab: " + (e.message || e));
+      toast(tr("civitai_ui.couldn_t_open_the_apps_tab", "Couldn't open the Apps tab: {error}", { error: e.message || e }));
     }
   }
 
@@ -1228,7 +1293,7 @@ export function createCivitaiContent(ctx, shell, opts = {}) {
   async function loadVersionWorkflow(version, file, opts = {}) {
     const setStatus = opts.setStatus || (() => {});
     const say = (msg, kind = "err") => { setStatus(msg, kind); toast(msg); };
-    setStatus("Fetching workflow…", "info");
+    setStatus(tr("civitai_ui.fetching_workflow", "Fetching workflow…"), "info");
     let bytes;
     try {
       bytes = await client.downloadVersionFile(version.id, file);
@@ -1238,14 +1303,17 @@ export function createCivitaiContent(ctx, shell, opts = {}) {
         // redirects the download to /login). The account button is the way in;
         // offer it right here so the hint is actionable, not just informative.
         say(state.signedIn
-          ? "CivitAI refused this download — this file may need early access or a purchase. Try the account (👤) button to re-check your sign-in."
-          : "This workflow is gated — sign in to CivitAI (the account 👤 button) to download it, then try again.", "warn");
+          ? tr("civitai_ui.civitai_refused_this_download_this_file_may",
+            "CivitAI refused this download — this file may need early access or a purchase. Try the account (👤) button to re-check your sign-in.")
+          : tr("civitai_ui.this_workflow_is_gated_sign_in_to",
+            "This workflow is gated — sign in to CivitAI (the account 👤 button) to download it, then try again."), "warn");
         if (!state.signedIn && opts.signIn) {
-          setStatus("This workflow is gated — opening CivitAI sign-in…", "warn");
+          setStatus(tr("civitai_ui.this_workflow_is_gated_opening_civitai_sign",
+            "This workflow is gated — opening CivitAI sign-in…"), "warn");
           try { opts.signIn(); } catch { /* account flow unavailable */ }
         }
       } else {
-        say("Download failed: " + (e.message || e));
+        say(tr("civitai_ui.download_failed", "Download failed: {error}", { error: e.message || e }));
       }
       return;
     }
@@ -1263,15 +1331,19 @@ export function createCivitaiContent(ctx, shell, opts = {}) {
       // "not a zip" then really means "we got a login page, not the file".
       const notZip = /not a zip/i.test(String(e.message || e));
       say(notZip
-        ? "Couldn't read the download — CivitAI may require sign-in for this file (account 👤 button)."
-        : "Couldn't read the workflow file: " + (e.message || e), notZip ? "warn" : "err");
+        ? tr("civitai_ui.couldn_t_read_the_download_civitai_may",
+          "Couldn't read the download — CivitAI may require sign-in for this file (account 👤 button).")
+        : tr("civitai_ui.couldn_t_read_the_workflow_file",
+          "Couldn't read the workflow file: {error}", { error: e.message || e }), notZip ? "warn" : "err");
       return;
     }
     const uis = candidates.filter((c) => c.format === "ui");
     if (!uis.length) {
       say(candidates.length
-        ? "This file only holds an API-format graph — it can't load as an editable canvas workflow. Ask the agent to run it instead."
-        : "No ComfyUI workflow found in that file.", "warn");
+        ? tr("civitai_ui.this_file_only_holds_an_api_format",
+          "This file only holds an API-format graph — it can't load as an editable canvas workflow. Ask the agent to run it instead.")
+        : tr("civitai_ui.no_comfyui_workflow_found_in_that_file",
+          "No ComfyUI workflow found in that file."), "warn");
       return;
     }
     setStatus("", "info"); // clear before a successful load closes the explorer
@@ -1284,13 +1356,16 @@ export function createCivitaiContent(ctx, shell, opts = {}) {
     // several workflows in one archive — let the user pick.
     return await new Promise((resolve) => {
       let picking = false; // a pick is in flight — its closeSubModals teardown must not resolve false
-      const picker = openSubModal("Pick a workflow to load", () => { if (!picking) resolve(false); });
+      const picker = openSubModal(tr("civitai_ui.pick_a_workflow_to_load", "Pick a workflow to load"),
+        () => { if (!picking) resolve(false); });
       const list = el("div", "cmcp-cv-creators");
       list.style.maxHeight = "24rem";
       for (const c of uis) {
         const b = el("button", "cmcp-cv-creator");
         b.appendChild(el("span", null, c.name));
-        b.appendChild(el("span", "sub", `${c.graph.nodes.length} nodes`));
+        b.appendChild(el("span", "sub", tr("civitai_ui.n_nodes", {
+          one: "{count} node", other: "{count} nodes",
+        }, { count: c.graph.nodes.length })));
         b.addEventListener("click", () => {
           picking = true;
           loadOntoCanvas(c.graph, undefined, { keepPanelOpen }).then((ok) => {
@@ -1307,10 +1382,14 @@ export function createCivitaiContent(ctx, shell, opts = {}) {
   // ── model detail ─────────────────────────────────────────────────────
   async function openModelDetail(m) {
     const sheet = openSubModal(m.name);
-    sheet.body.appendChild(el("div", "cmcp-cv-loading", "Loading…"));
+    sheet.body.appendChild(el("div", "cmcp-cv-loading", tr("civitai_ui.loading", "Loading…")));
     let detail;
     try { detail = await client.fetchModelDetail(m.id, { levels: state.filters.browsingLevels }); }
-    catch (e) { sheet.body.innerHTML = ""; sheet.body.appendChild(el("div", null, "Error: " + e.message)); return; }
+    catch (e) {
+      sheet.body.innerHTML = "";
+      sheet.body.appendChild(el("div", null, tr("civitai_ui.error", "Error: {error}", { error: e.message })));
+      return;
+    }
     sheet.body.innerHTML = "";
     let version = detail.versions[0];
 
@@ -1325,8 +1404,10 @@ export function createCivitaiContent(ctx, shell, opts = {}) {
       const dl = el("div", "cmcp-cv-actions");
       const have = owned(version.fileName);
       const dlBtn = el("button", "cmcp-btn cmcp-btn-primary",
-        have ? "✓ In library — re-download"
-             : (ctx.isMuted() ? "Download to my machine" : "Ask agent to download"));
+        have ? tr("civitai_ui.in_library_re_download", "✓ In library — re-download")
+             : (ctx.isMuted()
+               ? tr("civitai_ui.download_to_my_machine", "Download to my machine")
+               : tr("civitai_ui.ask_agent_to_download", "Ask agent to download")));
       dlBtn.addEventListener("click", () => pickModel(detail, version));
       dl.appendChild(dlBtn);
       // Workflow files (.json, or the zip wrapper civitai puts around Workflows
@@ -1344,18 +1425,27 @@ export function createCivitaiContent(ctx, shell, opts = {}) {
       };
       for (const f of wfFiles) {
         const b = el("button", "cmcp-btn",
-          wfFiles.length > 1 ? `Load onto canvas — ${f.name}` : "Load workflow onto canvas");
+          wfFiles.length > 1
+            ? tr("civitai_ui.load_onto_canvas_named", "Load onto canvas — {name}", { name: f.name })
+            : tr("civitai_ui.load_workflow_onto_canvas", "Load workflow onto canvas"));
         const size = f.sizeKB != null
           ? (f.sizeKB >= 1024 ? (f.sizeKB / 1024).toFixed(1) + " MB" : Math.max(1, Math.round(f.sizeKB)) + " KB")
           : null;
-        b.title = `Download ${f.name}${size ? ` (${size})` : ""} and load it onto the canvas (Ctrl+Z undoes it).`;
+        // Filename and size compose OUTSIDE the sentence: both are literals CivitAI
+        // supplies, and a translator must be free to move `{file}` where their
+        // grammar puts an object without also owning the "name (size)" formatting.
+        const fileLabel = `${f.name}${size ? ` (${size})` : ""}`;
+        b.title = tr("civitai_ui.download_and_load_it_onto_the_canvas",
+          "Download {file} and load it onto the canvas (Ctrl+Z undoes it).", { file: fileLabel });
         b.addEventListener("click", () => { void loadVersionWorkflow(version, f, { setStatus, signIn: () => accountFlow() }); });
         dl.appendChild(b);
         // Same loadable-workflow condition as "Load onto canvas" (every wfFile is
         // loadable): load the SELECTED version's workflow with the panel kept open,
         // then hop to the Apps convert view seeded from the now-loaded canvas.
         const appB = el("button", "cmcp-btn",
-          wfFiles.length > 1 ? `Create App — ${f.name}` : "Create App from workflow");
+          wfFiles.length > 1
+            ? tr("civitai_ui.create_app_named", "Create App — {name}", { name: f.name })
+            : tr("civitai_ui.create_app_from_workflow", "Create App from workflow"));
         appB.title = tr("civitai_ui.download_this_workflow_load_it_onto_the", "Download this workflow, load it onto the canvas, and package it as a one-click app.");
         appB.addEventListener("click", () => {
           void createAppFromWorkflow(
@@ -1365,12 +1455,13 @@ export function createCivitaiContent(ctx, shell, opts = {}) {
         dl.appendChild(appB);
       }
       if (have) {
-        const note = el("span", null, "You already have this file locally.");
+        const note = el("span", null, tr("civitai_ui.you_already_have_this_file_locally", "You already have this file locally."));
         note.style.cssText = "font-size:.72rem;color:#4ade80;align-self:center";
         dl.appendChild(note);
       }
       if (detail.creator) {
-        const moreBtn = el("button", "cmcp-btn", `See more from @${detail.creator}`);
+        const moreBtn = el("button", "cmcp-btn",
+          tr("civitai_ui.see_more_from", "See more from @{creator}", { creator: detail.creator }));
         moreBtn.addEventListener("click", () => {
           sheet.close();
           seeMoreFromCreator(detail.creator, { toModelTab: true });
@@ -1396,7 +1487,7 @@ export function createCivitaiContent(ctx, shell, opts = {}) {
           c.addEventListener("click", () => showGenInfo(ex));
           carousel.appendChild(c);
         });
-        detailBody.appendChild(el("div", "cmcp-cv-flabel", "Examples"));
+        detailBody.appendChild(el("div", "cmcp-cv-flabel", tr("civitai_ui.examples", "Examples")));
         detailBody.appendChild(carousel);
       }
     };
@@ -1422,20 +1513,24 @@ export function createCivitaiContent(ctx, shell, opts = {}) {
   async function pickModel(detail, version) {
     const subfolder = SUBFOLDER[detail.type] || "checkpoints";
     if (ctx.isMuted()) {
-      toast("Downloading…");
+      toast(tr("civitai_ui.downloading", "Downloading…"));
       try {
         const res = await ctx.callTool("download_model",
           { action: "download_civitai", model_id: detail.id, model_version_id: version.id, target_subfolder: subfolder },
           { timeout: 20 * 60000 });
-        toast(res.ok ? "Downloaded to your machine." : "Download failed: " + (res.error || "?"));
-      } catch (e) { toast("Download error: " + e.message); }
+        toast(res.ok
+          ? tr("civitai_ui.downloaded_to_your_machine", "Downloaded to your machine.")
+          : tr("civitai_ui.download_failed", "Download failed: {error}", { error: res.error || "?" }));
+      } catch (e) { toast(tr("civitai_ui.download_error", "Download error: {error}", { error: e.message })); }
     } else {
+      // The request itself stays English — see buildCaption: it is a prompt for the
+      // agent, carrying wire ids and the API's own `detail.type` ("Checkpoint"/"LORA").
       ctx.sendUserMessage(
         `Please download the CivitAI ${detail.type} "${detail.name}"` +
         (version.name ? ` (version "${version.name}")` : "") +
         ` — model_id ${detail.id}, version ${version.id} — into ${subfolder}, then we'll use it.`);
       ctx.bringChatForward();
-      toast("Asked the agent to download it.");
+      toast(tr("civitai_ui.asked_the_agent_to_download_it", "Asked the agent to download it."));
     }
   }
 
@@ -1468,7 +1563,7 @@ export function createCivitaiContent(ctx, shell, opts = {}) {
     // cancel the pending debounce and invalidate any lookup already in
     // flight so its completion early-returns instead of touching the
     // detached nodes.
-    const sheet = openSubModal("Filters", () => {
+    const sheet = openSubModal(tr("civitai_ui.filters", "Filters"), () => {
       clearTimeout(crTimer); crTimer = null;
       crReq++;
     });
@@ -1486,14 +1581,18 @@ export function createCivitaiContent(ctx, shell, opts = {}) {
       const chipRow = (label, options, isOn, onToggle) =>
         filterChipRow(wrap, label, options, isOn, (v) => { onToggle(v); renderSheet(); update(); });
 
-      chipRow("Time period", PERIODS.map((p) => ({ label: p, value: p })),
+      // Only the ROW headings are translated. The chip labels are CivitAI's own query
+      // values echoed back as their own label (`{ label: p, value: p }`) — translating
+      // one would translate the other and send e.g. "주" as the `period` parameter.
+      chipRow(tr("civitai_ui.time_period", "Time period"), PERIODS.map((p) => ({ label: p, value: p })),
         (v) => f.period === v, (v) => { f.period = v; });
       const sorts = isModelTab() ? MODEL_SORTS : IMAGE_SORTS;
-      chipRow("Sort", sorts.map((s) => ({ label: s, value: s })),
+      chipRow(tr("civitai_ui.sort", "Sort"), sorts.map((s) => ({ label: s, value: s })),
         (v) => (isModelTab() ? f.modelSort : f.imageSort) === v,
         (v) => { if (isModelTab()) f.modelSort = v; else f.imageSort = v; });
-      // browsing levels — ALL selectable, no sign-in gate
-      chipRow("Browsing level", LEVELS.map((l) => ({ label: l.label, value: l.level })),
+      // browsing levels — ALL selectable, no sign-in gate. `l.label` is a content-rating
+      // code (PG / PG-13 / R / X / XXX); those are international and stay English.
+      chipRow(tr("civitai_ui.browsing_level", "Browsing level"), LEVELS.map((l) => ({ label: l.label, value: l.level })),
         (v) => f.browsingLevels.includes(v),
         (v) => {
           const i = f.browsingLevels.indexOf(v);
@@ -1502,7 +1601,7 @@ export function createCivitaiContent(ctx, shell, opts = {}) {
         });
 
       // base model omni-search
-      wrap.appendChild(el("div", "cmcp-cv-flabel", "Base model"));
+      wrap.appendChild(el("div", "cmcp-cv-flabel", tr("civitai_ui.base_model", "Base model")));
       const pills = el("div", "cmcp-cv-frow");
       // Rebuilt in place rather than via renderSheet(), so toggling a model
       // does not tear down the dropdown mid-selection (see toggleModel).
@@ -1586,9 +1685,11 @@ export function createCivitaiContent(ctx, shell, opts = {}) {
         listbox.setAttribute("aria-label", tr("civitai_ui.base_model", "Base model"));
         bmPanel.appendChild(listbox);
         const hits = BASE_MODELS.filter((x) => matchesBaseModel(x, query));
+        // Section headings, not values — the base-model NAMES inside each group are
+        // CivitAI's own spellings and stay as-is.
         const groups = [
-          ["Current", hits.filter((x) => ACTIVE_BASE_MODELS.has(x))],
-          ["Legacy", hits.filter((x) => !ACTIVE_BASE_MODELS.has(x))],
+          [tr("civitai_ui.current", "Current"), hits.filter((x) => ACTIVE_BASE_MODELS.has(x))],
+          [tr("civitai_ui.legacy", "Legacy"), hits.filter((x) => !ACTIVE_BASE_MODELS.has(x))],
         ];
         for (const [label, items] of groups) {
           if (!items.length) continue;
@@ -1626,7 +1727,9 @@ export function createCivitaiContent(ctx, shell, opts = {}) {
         }
         if (!bmOpts.length) {
           // Not an option — belongs in the panel, outside the listbox.
-          bmPanel.appendChild(el("div", "cmcp-cv-ddempty", `No base model matches “${bmSearch.value.trim()}”.`));
+          bmPanel.appendChild(el("div", "cmcp-cv-ddempty",
+            tr("civitai_ui.no_base_model_matches", "No base model matches “{query}”.",
+              { query: bmSearch.value.trim() })));
         }
         // Selected-count + clear, matching what ComfyUI's own multi-select
         // shows. With the list scrolled or filtered the chips above can be out
@@ -1634,9 +1737,12 @@ export function createCivitaiContent(ctx, shell, opts = {}) {
         // live — or to drop them without hunting each one down.
         if (f.baseModels.length) {
           const foot = el("div", "cmcp-cv-ddfoot");
-          foot.appendChild(el("span", null,
-            `${f.baseModels.length} selected`));
-          const clear = el("button", "cmcp-cv-ddclear", "Clear");
+          // English has one form here; Russian and Arabic do not, so it is counted.
+          foot.appendChild(el("span", null, tr("civitai_ui.n_selected", {
+            one: "{count} selected", other: "{count} selected",
+          }, { count: f.baseModels.length })));
+          // Reuses the panel-wide "Clear" — same word, already in the catalog.
+          const clear = el("button", "cmcp-cv-ddclear", tr("panel.clear", "Clear"));
           clear.type = "button";
           // Left button only — right-clicking "Clear" would otherwise wipe every
           // selected model before the context menu even appeared.
@@ -1695,7 +1801,7 @@ export function createCivitaiContent(ctx, shell, opts = {}) {
       // TOP-CREATORS leaderboard (ranked, with stats); typing runs a debounced
       // (300ms) /v1/creators username search. Picking one threads `username`
       // through every feed/search/model query; no selection = everyone.
-      wrap.appendChild(el("div", "cmcp-cv-flabel", "Creator"));
+      wrap.appendChild(el("div", "cmcp-cv-flabel", tr("civitai_ui.creator", "Creator")));
       if (tabDef().fav) {
         // Favorites are "images YOU liked", from every creator — the tRPC
         // favorites feed has no creator param, so render the filter visibly
@@ -1709,7 +1815,8 @@ export function createCivitaiContent(ctx, shell, opts = {}) {
           box.appendChild(pill);
         }
         box.appendChild(el("div", "cmcp-cv-lb-muted",
-          "Ignored on the Favorites tab — favorites are the images you liked, from every creator."));
+          tr("civitai_ui.ignored_on_the_favorites_tab_favorites_are",
+            "Ignored on the Favorites tab — favorites are the images you liked, from every creator.")));
         wrap.appendChild(box);
       } else {
         const crPills = el("div", "cmcp-cv-frow");
@@ -1721,8 +1828,8 @@ export function createCivitaiContent(ctx, shell, opts = {}) {
         }
         const crSearch = el("input", "cmcp-cv-search");
         crSearch.placeholder = f.username
-          ? "Switch creator…"
-          : "All creators — search, or pick from the top";
+          ? tr("civitai_ui.switch_creator", "Switch creator…")
+          : tr("civitai_ui.all_creators_search_or_pick_from_the", "All creators — search, or pick from the top");
         const crNote = el("div", "cmcp-cv-lb-muted");
         crNote.style.display = "none";
         const crList = el("div", "cmcp-cv-creators");
@@ -1732,12 +1839,22 @@ export function createCivitaiContent(ctx, shell, opts = {}) {
             const b = el("button", "cmcp-cv-creator");
             b.appendChild(el("span", null,
               c.position != null ? `#${c.position}  ${c.username}` : c.username));
+            // Counted, but the number the user READS is abbreviated ("1.2M"), and a
+            // plural category can't be derived from that string. So `count` carries the
+            // real total for Intl and `{n}` carries the abbreviation for display.
             const sub = c.position != null
               ? [
-                  c.downloads != null ? compactCount(c.downloads) + " downloads" : null,
-                  c.thumbsUp != null ? compactCount(c.thumbsUp) + " likes" : null,
+                  c.downloads != null
+                    ? tr("civitai_ui.n_downloads", { one: "{n} download", other: "{n} downloads" },
+                      { count: c.downloads, n: compactCount(c.downloads) })
+                    : null,
+                  c.thumbsUp != null
+                    ? tr("civitai_ui.n_likes", { one: "{n} like", other: "{n} likes" },
+                      { count: c.thumbsUp, n: compactCount(c.thumbsUp) })
+                    : null,
                 ].filter(Boolean).join(" · ")
-              : `${c.modelCount ?? 0} model${(c.modelCount ?? 0) === 1 ? "" : "s"}`;
+              : tr("civitai_ui.n_models", { one: "{count} model", other: "{count} models" },
+                { count: c.modelCount ?? 0 });
             if (sub) b.appendChild(el("span", "sub", sub));
             b.addEventListener("click", () => {
               setCreator(c.username);
@@ -1760,8 +1877,8 @@ export function createCivitaiContent(ctx, shell, opts = {}) {
               renderMatches(matches);
               crNote.style.display = matches.length ? "none" : "";
               crNote.textContent = cq
-                ? "No creators match."
-                : "Top creators unavailable right now.";
+                ? tr("civitai_ui.no_creators_match", "No creators match.")
+                : tr("civitai_ui.top_creators_unavailable_right_now", "Top creators unavailable right now.");
             })
             .catch(() => {
               // The leaderboard tRPC intermittently 401s bare user agents —
@@ -1770,8 +1887,8 @@ export function createCivitaiContent(ctx, shell, opts = {}) {
               crList.innerHTML = "";
               crNote.style.display = "";
               crNote.textContent = cq
-                ? "Creator search failed — try again."
-                : "Top creators unavailable right now.";
+                ? tr("civitai_ui.creator_search_failed_try_again", "Creator search failed — try again.")
+                : tr("civitai_ui.top_creators_unavailable_right_now", "Top creators unavailable right now.");
             });
         };
         crSearch.addEventListener("input", () => {
@@ -1785,7 +1902,7 @@ export function createCivitaiContent(ctx, shell, opts = {}) {
         wrap.append(crPills, crSearch, crNote, crList);
       }
 
-      const reset = el("button", "cmcp-btn", "Reset filters");
+      const reset = el("button", "cmcp-btn", tr("civitai_ui.reset_filters", "Reset filters"));
       reset.addEventListener("click", () => {
         state.filters = {
           ...DEFAULT_FILTERS,
@@ -1830,24 +1947,25 @@ export function createCivitaiContent(ctx, shell, opts = {}) {
     if (state.signedIn) {
       // Account sheet: the "default likes folder" (a CivitAI collection every
       // like also lands in) + sign out. Signed-in no longer instant-signs-out.
-      const sheet = openSubModal("CivitAI account");
+      const sheet = openSubModal(tr("civitai_ui.civitai_account", "CivitAI account"));
       const wrap = el("div", "cmcp-cv-filters");
-      wrap.appendChild(el("div", null, "Signed in ✓"));
-      wrap.appendChild(el("div", "cmcp-cv-flabel", "Default likes collection"));
+      wrap.appendChild(el("div", null, tr("civitai_ui.signed_in", "Signed in ✓")));
+      wrap.appendChild(el("div", "cmcp-cv-flabel", tr("civitai_ui.default_likes_collection", "Default likes collection")));
       wrap.appendChild(el("div", "cmcp-cv-lb-muted",
-        "Every like is also saved into this collection on your CivitAI account (and removed when you unlike)."));
+        tr("civitai_ui.every_like_is_also_saved_into_this",
+          "Every like is also saved into this collection on your CivitAI account (and removed when you unlike).")));
       const row = el("div", "cmcp-cv-frow");
       const sel = document.createElement("select");
       sel.className = "cmcp-cv-search";
       sel.disabled = true;
-      sel.appendChild(new Option("Loading collections…", ""));
-      const newBtn = el("button", "cmcp-btn", "+ New…");
+      sel.appendChild(new Option(tr("civitai_ui.loading_collections", "Loading collections…"), ""));
+      const newBtn = el("button", "cmcp-btn", tr("civitai_ui.new", "+ New…"));
       row.append(sel, newBtn);
       wrap.appendChild(row);
       let colCache = [];
       const fillSelect = () => {
         sel.innerHTML = "";
-        sel.appendChild(new Option("(none — likes only)", ""));
+        sel.appendChild(new Option(tr("civitai_ui.none_likes_only", "(none — likes only)"), ""));
         const cur = likesCollection();
         for (const c of colCache) {
           const o = new Option(c.name, String(c.id));
@@ -1860,19 +1978,22 @@ export function createCivitaiContent(ctx, shell, opts = {}) {
         .then((cols) => { colCache = cols; fillSelect(); })
         .catch((e) => {
           sel.innerHTML = "";
-          sel.appendChild(new Option("Couldn't load collections", ""));
+          sel.appendChild(new Option(tr("civitai_ui.couldn_t_load_collections", "Couldn't load collections"), ""));
           if (String(e.message || e).includes("403")) {
             wrap.appendChild(el("div", "cmcp-cv-lb-muted",
-              "Your sign-in predates the collection permissions — sign out and back in to grant them."));
+              tr("civitai_ui.your_sign_in_predates_the_collection_permissions",
+                "Your sign-in predates the collection permissions — sign out and back in to grant them.")));
           }
         });
       sel.addEventListener("change", () => {
         const c = colCache.find((x) => String(x.id) === sel.value);
         setLikesCollection(c || null);
-        toast(c ? `Likes will also go to "${c.name}".` : "Likes won't be added to a collection.");
+        toast(c
+          ? tr("civitai_ui.likes_will_also_go_to", "Likes will also go to \"{name}\".", { name: c.name })
+          : tr("civitai_ui.likes_won_t_be_added_to_a", "Likes won't be added to a collection."));
       });
       newBtn.addEventListener("click", async () => {
-        const name = window.prompt("Name for the new CivitAI collection:");
+        const name = window.prompt(tr("civitai_ui.name_for_the_new_civitai_collection", "Name for the new CivitAI collection:"));
         if (!name || !name.trim()) return;
         newBtn.disabled = true;
         try {
@@ -1881,17 +2002,20 @@ export function createCivitaiContent(ctx, shell, opts = {}) {
           fillSelect();
           sel.value = String(c.id);
           setLikesCollection(c);
-          toast(`Created "${c.name}" — it's now your likes collection.`);
+          toast(tr("civitai_ui.created_it_s_now_your_likes_collection",
+            "Created \"{name}\" — it's now your likes collection.", { name: c.name }));
         } catch (e) {
-          toast("Create failed: " + (e.message || e));
+          toast(tr("civitai_ui.create_failed", "Create failed: {error}", { error: e.message || e }));
         } finally {
           newBtn.disabled = false;
         }
       });
-      const out = el("button", "cmcp-btn", "Sign out");
+      // Reuses the panel-wide "Sign out" — same two words, already in the catalog.
+      const out = el("button", "cmcp-btn", tr("panel.sign_out", "Sign out"));
       out.addEventListener("click", async () => {
         await ctx.api.fetchApi("/comfyui_mcp_panel/civitai/oauth/logout", { method: "POST" });
-        await refreshAuth(); sheet.close(); toast("Signed out of CivitAI.");
+        await refreshAuth(); sheet.close();
+        toast(tr("civitai_ui.signed_out_of_civitai", "Signed out of CivitAI."));
       });
       wrap.appendChild(out);
       sheet.body.appendChild(wrap);
@@ -1912,10 +2036,13 @@ export function createCivitaiContent(ctx, shell, opts = {}) {
         if (!isOpen) { if (_oauthPollIv) { clearInterval(_oauthPollIv); _oauthPollIv = null; } return; }
         if (state.signedIn || ++tries > 120) {
           clearInterval(_oauthPollIv); _oauthPollIv = null;
-          if (state.signedIn) { toast("Signed in to CivitAI."); if (tabDef().fav) reload(); }
+          if (state.signedIn) {
+            toast(tr("civitai_ui.signed_in_to_civitai", "Signed in to CivitAI."));
+            if (tabDef().fav) reload();
+          }
         }
       }, 2000);
-    } catch (e) { toast("Sign-in failed: " + e.message); }
+    } catch (e) { toast(tr("civitai_ui.sign_in_failed", "Sign-in failed: {error}", { error: e.message })); }
   }
 
   // ── sub-modal + toast helpers ────────────────────────────────────────
@@ -2134,7 +2261,7 @@ export function createCivitaiContent(ctx, shell, opts = {}) {
   let _started = false;
   return {
     key: "civitai", label: tr("civitai_ui.civitai", "Civitai"), icon: "pi-images", driveKind: "civitai",
-    hasSearch: true, searchPlaceholder: "Search CivitAI…",
+    hasSearch: true, searchPlaceholder: tr("civitai_ui.search_civitai", "Search CivitAI…"),
     subnavExtras: () => [subTabsWrap, favChips, filterBtn, acctBtn],
     mount(bodyEl) {
       search.value = state.query;


### PR DESCRIPTION
Unit 6 of the panel i18n pass: `web/js/cmcp-civitai-ui.js`. Base is `feat/panel-i18n`, not `main`.

> [!IMPORTANT]
> **This PR cannot go green on its own, and neither can any sibling unit.** The catalog half is coordinator-owned. Two foundation defects are fixed here because they made this unit's plural work undeliverable. Please read "Coordinator actions" at the bottom before merging.

## Why these strings were missed

The extractor is deliberately high-precision — it only matches same-line attribute assignments (`.title =`, `placeholder:`, …). The CivitAI browser builds almost all of its text a different way, so ~100 strings never became candidates: `el(tag, cls, "TEXT")` (display text in the **third** argument), `toast(...)` / `say(...)` / `setStatus(...)`, `new Option("TEXT", value)`, a multi-line `window.confirm(...)`, a `window.prompt(...)`, and template literals with counts spliced in.

Set ComfyUI to Korean today and the entire CivitAI sidebar — every toast, every filter heading, the account sheet — is still English.

## What changed in the panel

103 new `civitai_ui.*` keys, English kept at the call site as the fallback. **No file under `locales/` is touched** (see below).

**Plurals, measured not assumed.** Six counted strings moved off inline `=== 1 ? "" : "s"`, which only ever produced English grammar. Probed against the real `tr()`:

```
RU  1 -> 1 модель   3 -> 3 модели   5 -> 5 моделей   21 -> 21 модель
KO  워크플로를 캔버스에 불러왔습니다 — 노드 1개. Ctrl+Z로 되돌립니다.   (single form, no stray "s")
EN  1 download | 1.2K downloads | 2.4M downloads
```

That last line is the subtle one: the leaderboard shows an **abbreviated** count, and no plural category can be derived from `"1.2M"`. The true total is passed as `count` (Intl picks the category) and the abbreviation separately as `{n}`. Residual named at the call site: above 1000 the category follows the true total, not the displayed numeral, so ru renders "1K загрузка" for 1001. Fixing that properly means locale-aware compact formatting, which would change the digits every existing row shows.

**Reuse, but not across surfaces.** Within CivitAI, existing keys are reused (`images`/`videos` for the favorites chips, `loading`, `base_model`, `civitai_account`). I initially borrowed `panel.clear` / `panel.sign_out` — review caught that this is wrong, and it is: `panel.clear` labels the credentials card's *"clear this API key"* button, and a translator given only that context can correctly render it ja "キーを消去" (*"clear the key"*), which would then mislabel the base-model filter's Clear. Sharing a key shares the context. Now `civitai_ui.clear` / `civitai_ui.sign_out`.

**Deliberately NOT translated**, each with the reason at the site:

- **Content-rating codes** (PG / PG-13 / R / X / XXX) — matches the base branch, which reverted `civitai.pg_13` for this reason.
- **The period and sort chips.** Their label *is* the query value (`{ label: p, value: p }`) — translating the label would send `"주"` as the `period` API parameter. Only the row headings are translated.
- **`buildCaption()` and `pickModel()`'s download request** — PROMPTS addressed to the agent, composed alongside English tool names and CivitAI's own parameter labels. Same rule the monolith already follows for its reconnect nudges. The human-facing toasts around them *are* translated.
- **`levelFilterNote` and the thrown drive errors** — agent-facing, not UI.

Every `el(tag, cls, txt)` call was read rather than swept: the second argument is a class in most of them (`el("span", "sub", sub)`, `el("span", "k", k)`), and `▶` / `‹` / `›` / `✓` are glyphs. A blind third-argument sweep would have shipped `class="Videos"`.

## Two foundation defects fixed (commit 2)

Both were invisible until a plural key existed — and this unit brings the panel its **first six** counted strings.

**1. Extraction dropped every plural site.** `readConverted` found the fallback object's end with `rest.indexOf('}')`, and the first `}` in a plural fallback is the one inside `{count}` — the placeholder that makes it a plural at all. Body truncated mid-string, form regex matched nothing, site vanished.

Measured before the fix: **6 plural call sites in the tree, 0 plural keys in the catalog, 0 failures reported anywhere.** It reported nothing because an unreadable site is missing from *both* sides of the round-trip comparison, so the gate written to catch exactly this stayed green. Isolated to one variable — the same call with the placeholder removed extracts fine; with `{count}` it yields nothing. Braces are now matched at depth, skipping string literals. All 12 variants now round-trip with placeholders intact.

**2. Two gates contradicted each other on plurals.** `scripts/i18n-check.mjs` deliberately checks plural siblings per-language against Intl (Korean takes `other` alone; Russian needs `few`/`many`). The unit test compared key sets literally, so it demanded zh carry `n_nodes_one` — the exact key the gate rejects as *"has `_one`, which zh never uses — remove it"*. Mutually unsatisfiable for any plural key.

Verified in both directions rather than argued: adding the `_one` siblings turns the test green and the gate red with **18** problems; removing them does the reverse. The test now applies the same Intl rule the gate documents.

Both new guards were mutation-tested — reverting each fix fails them with `got 0 for 6 sites` and `has categories zh never uses`.

## Coordinator actions

`npm run test:unit` is **3709/3710** here; the one failure is `regenerating English is a ROUND TRIP`, and it is **systemic, not specific to this unit** — I merged the new base into `feat/i18n-unit1-credentials` and it fails identically. Every unit PR will.

`locales/` is untouched on purpose. `locales/en/main.json` is a *generated* artifact whose correct value depends on **all** units being merged, so six PRs each committing their own version would conflict in a file that is 100% regenerable. And `i18n-check`'s `.strict()` schema means en and the translations must land together — a key cannot be added to ko before en has it.

The full recipe, run and verified locally:

```
npm run i18n:build          # 357 keys, including the 12 plural variants
# then fill ja/ko/zh with the new keys, expanding each plural base to
# exactly that language's Intl categories (ja/ko/zh: `other` only)
npm run test:unit           # 3710/3710, locales OK
```

I confirmed that reaches green, then **reverted it** — my fill copied English into `ko`, and that is strictly worse than leaving the key absent, because `tr()` already falls back to the English at the call site. Copying English in only satisfies the gate while making "71% translated" a false reading and hiding which strings still need a translator. The fill should be real translations.

Regeneration is lossless, measured: **0 keys lost, 0 texts changed**, 246 → 343 keys.

## Verification

- `npm run test:unit` — 3709/3710 (the one systemic failure above); **3710/3710** with the recipe applied
- `npm run typecheck` clean · `npm run test:e2e:list` — 68 tests in 29 files · `node --check` over all 124 `web/js` files — clean
- A placeholder/vars parity checker over all 25 interpolating calls found no mismatch, and was mutation-tested (renaming one `{error}` hole made it fire)
- Confirmed nothing branches on the translated display strings, and no test asserts on them
- Repo CI only triggers on PRs to `main`, so there are no checks here — I ran the CI job's steps locally instead. `scripts/check-tool-vocabulary.mjs` fails on this branch entirely from pre-existing `locales/` and `scripts/i18n-extract.mjs` content unrelated to this change.
- No live browser run: that needs the single shared ComfyUI on :8188. The consolidated pass is yours after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
