### PR TITLE
feat(i18n): translate the strings the extractor could not see (small modules)

### DIFF
--- a/web/js/cmcp-a2ui.js
+++ b/web/js/cmcp-a2ui.js
@@ -42,6 +42,14 @@ const capped = (v, n) => str(v) && v.length <= n;
 /**
  * Validate + normalize a raw card spec. Returns { ok:true, spec } with defaults
  * applied, or { ok:false, errors:[...] }. Never throws.
+ *
+ * NOT TRANSLATED, deliberately. These read as user-facing because
+ * renderA2UIFailCard puts them on screen, but every one of them names a field of
+ * the A2UI wire schema (`components array is required`, `duplicate id "x"`) and
+ * the audience is whoever is writing the agent that emitted the bad card. They are
+ * also the text a user pastes into a bug report; translating them would mean the
+ * maintainer receives a Korean rendering of a schema violation and cannot grep for
+ * it. The card's own chrome around them (title, "tap to view raw") IS translated.
  */
 export function validateA2UISpec(raw) {
   const errors = [];
@@ -661,7 +669,19 @@ export function renderA2UIFailCard(rawText, errors) {
   el.appendChild(t);
   const why = document.createElement("div");
   why.className = "cmcp-a2ui-text";
-  why.textContent = (errors && errors.length ? errors.slice(0, 3).join("; ") : "could not render") + " — tap to view raw";
+  // `{reason}` rather than translating " — tap to view raw" as a trailing
+  // fragment: the panel ships ar/fa, and an RTL sentence does not necessarily put
+  // the affordance AFTER the reason. Interpolating lets the translator place both
+  // halves; concatenating would have pinned the order to English's.
+  //
+  // The reason itself is either validateA2UISpec's developer diagnostics (left in
+  // English on purpose — see the note on those messages) or this generic stand-in
+  // for the case where the card failed with no errors to report.
+  const reason =
+    errors && errors.length
+      ? errors.slice(0, 3).join("; ")
+      : tr("a2ui.could_not_render", "could not render");
+  why.textContent = tr("a2ui.tap_to_view_raw", "{reason} — tap to view raw", { reason });
   why.style.cursor = "pointer";
   const pre = document.createElement("pre");
   pre.textContent = typeof rawText === "string" ? rawText : JSON.stringify(rawText, null, 2);

--- a/web/js/cmcp-civitai.js
+++ b/web/js/cmcp-civitai.js
@@ -497,8 +497,22 @@ const _ADVICE = {
  *  Returns `{ message, detail, retryable }`: `message` is the whole sentence for
  *  the error card, `detail` is the bounded upstream text ALONE (so the UI and the
  *  agent-facing error state can use it without re-parsing prose), and `retryable`
- *  is true / false / null. Pure, and exported for unit tests. */
-export function describeUpstreamFailure({ status, statusText, bodyText, label = "CivitAI API" }) {
+ *  is true / false / null. Exported for unit tests. Pure with respect to its
+ *  ARGUMENTS; since `label` defaults through tr() it also reads the loaded
+ *  translation catalog, so the same inputs render in the user's language. */
+// `label` is a DEFAULT PARAMETER, which is why the string extractor missed it: it
+// matches assignment contexts, not destructuring defaults. It heads the sentence
+// on the error card ("CivitAI API 503: …") — "CivitAI" is the brand and stays,
+// "API" is the translatable noun. Evaluated per call, so the catalog is loaded
+// long before any request can fail.
+//
+// `message` has a SECOND audience: civitaiErrorState carries it into
+// panel_civitai_results as `error`, so under a non-English locale the agent reads
+// a partly-translated status line. That is accepted, not overlooked — the same is
+// already true of the tr()'d download label below, the status code and the quoted
+// upstream detail are untouched, and the user seeing their own language on the
+// card is what #705 was about. Do not, however, ever compare this string.
+export function describeUpstreamFailure({ status, statusText, bodyText, label = tr("civitai.civitai_api", "CivitAI API") }) {
   const { text, shape, fromProxy, proxyRetryable } = extractUpstreamDetail(bodyText);
   // A proxy-authored reply carries OUR status, so upstreamFailureClass would be
   // reading a number that says nothing about CivitAI. Honour what the proxy

--- a/web/js/cmcp-filter.js
+++ b/web/js/cmcp-filter.js
@@ -13,7 +13,21 @@
 // cmcp-cv-filters / cmcp-cv-flabel / cmcp-cv-frow / cmcp-cv-chip) so CivitAI's
 // filter panel + its Playwright/agent-drive specs keep working unchanged.
 
+// TRANSLATION: both "Filters" literals are DEFAULT PARAMETERS, which is why the
+// string extractor never proposed them — it matches `title:`-style assignment
+// contexts, and a default lives in a destructuring pattern instead. Defaults
+// evaluate per CALL, not at module load, so tr() here resolves against whatever
+// catalog is loaded by the time a filter button or sheet is built.
+//
+// Be aware of what this does NOT cover: today BOTH defaults are dead. Apps passes
+// its own "Filter apps" to each (cmcp-apps-ui.js), and CivitAI passes title:null
+// for a deliberately tooltip-less button and titles its sheet from its own
+// openSubModal("Filters") call (cmcp-civitai-ui.js). Those literals belong to
+// those files and are converted with them. What is translated here is the
+// contract this module publishes for a caller that omits the argument.
+
 import { openSubModal as openSubModalBase } from "./cmcp-modal.js";
+import { tr } from "./lib/i18n.js";
 
 const el = (tag, cls, txt) => {
   const n = document.createElement(tag);
@@ -64,7 +78,7 @@ export function chipRow(container, label, options, isOn, onPick) {
  *  layout). `title` is applied only when truthy — CivitAI passes null to stay
  *  byte-identical to its original title-less button. Returns { btn, dot,
  *  setActive }. */
-export function makeFilterButton({ onOpen, title = "Filters", marginLeftAuto = true } = {}) {
+export function makeFilterButton({ onOpen, title = tr("filter.filters", "Filters"), marginLeftAuto = true } = {}) {
   const btn = el("button", "cmcp-cv-iconbtn");
   if (marginLeftAuto) btn.style.marginLeft = "auto";
   if (title) btn.title = title;
@@ -84,7 +98,7 @@ export function makeFilterButton({ onOpen, title = "Filters", marginLeftAuto = t
  *  re-invokes render after a chip toggles so its pressed state flips immediately
  *  (the pattern CivitAI's sheet uses). `onClose` runs on any dismissal. Returns
  *  the sheet handle ({ body, close }). */
-export function openFilterPanel({ openModal = openSubModalBase, title = "Filters", onClose, render } = {}) {
+export function openFilterPanel({ openModal = openSubModalBase, title = tr("filter.filters", "Filters"), onClose, render } = {}) {
   injectFilterCss();
   const sheet = openModal(title, onClose);
   const rerender = () => {

--- a/web/js/cmcp-modal.js
+++ b/web/js/cmcp-modal.js
@@ -14,6 +14,23 @@
 //   formModal   ({title,fields[],submitLabel,cancelLabel})        -> Promise<values|null>
 //
 // All user text goes through textContent (el() below) — no HTML injection.
+//
+// TRANSLATION: every word this module supplies itself ("Confirm"/"Cancel"/
+// "Save"/"OK") lives in a DEFAULT PARAMETER, which is why the string extractor
+// never proposed them — it matches `label:`-style assignment contexts, and a
+// default sits in a destructuring pattern instead. Defaults are evaluated per
+// CALL, not at module load, so tr() here resolves against whatever catalog is
+// loaded by the time a sheet actually opens; there is no ordering hazard with
+// loadCatalog().
+//
+// Only `cancelLabel` is currently reached: no caller anywhere passes one, while
+// every live call site overrides title/confirmLabel/submitLabel with its own
+// wording (cmcp-apps-ui.js). Those literals are that file's to translate. The
+// rest are the contract this module publishes for a caller that omits them, and
+// a dead default that renders English the day someone stops passing one is the
+// bug this is here to prevent.
+
+import { tr } from "./lib/i18n.js";
 
 const el = (tag, cls, txt) => {
   const n = document.createElement(tag);
@@ -90,10 +107,10 @@ function injectModalCss() {
 /** Yes/No confirmation. Resolves true only when the confirm button is clicked;
  *  ✕ / backdrop / cancel all resolve false. */
 export function confirmModal({
-  title = "Confirm",
+  title = tr("modal.confirm", "Confirm"),
   message = "",
-  confirmLabel = "Confirm",
-  cancelLabel = "Cancel",
+  confirmLabel = tr("modal.confirm", "Confirm"),
+  cancelLabel = tr("panel.cancel", "Cancel"),
   danger = false,
 } = {}) {
   injectModalCss();
@@ -121,7 +138,12 @@ export function confirmModal({
 
 /** Multi-field form modal. `fields` = [{key,label,value,placeholder,type,multiline,rows}].
  *  Resolves a { key: value } object on submit, or null when dismissed. */
-export function formModal({ title = "", fields = [], submitLabel = "Save", cancelLabel = "Cancel" } = {}) {
+export function formModal({
+  title = "",
+  fields = [],
+  submitLabel = tr("panel.save", "Save"),
+  cancelLabel = tr("panel.cancel", "Cancel"),
+} = {}) {
   injectModalCss();
   return new Promise((resolve) => {
     let settled = false;
@@ -180,8 +202,8 @@ export function promptModal({
   value = "",
   placeholder = "",
   multiline = false,
-  submitLabel = "OK",
-  cancelLabel = "Cancel",
+  submitLabel = tr("modal.ok", "OK"),
+  cancelLabel = tr("panel.cancel", "Cancel"),
 } = {}) {
   return formModal({
     title,

--- a/web/js/lib/panel-failure-shell.js
+++ b/web/js/lib/panel-failure-shell.js
@@ -47,22 +47,41 @@ export function panelFailureReport(err, info = {}) {
       ? `${err.name}: ${err.message}`
       : typeof err === "string" && err
         ? err
-        : "(the failure produced no message)";
+        : tr("panel_failure_shell.the_failure_produced_no_message", "(the failure produced no message)");
   const stack = err instanceof Error && typeof err.stack === "string" ? err.stack : "";
+  // `body` and `where` are the two sentences that actually do the work of #779 —
+  // ruling out the reinstall, and saying where to send it — so they are the last
+  // text that should stay English for a Korean user staring at a dead tab. The
+  // extractor could not see them: it reads ONE quoted literal at a time and these
+  // are multi-line `+` concatenations, so no single literal is the string. Each
+  // keeps its whole sentence as the fallback, concatenation and all; only `title:`
+  // (a single literal) had been converted before.
   return {
     title: tr("panel_failure_shell.the_agent_panel_could_not_start", "The agent panel could not start."),
-    body:
+    body: tr(
+      "panel_failure_shell.building_the_panel_threw_so_nothing_was",
       "Building the panel threw, so nothing was rendered. This is a fault in the panel " +
-      "itself — it is NOT a connection problem, and reinstalling ComfyUI or the pack will " +
-      "not change it. The details below are what was actually observed; nothing here is a " +
-      "diagnosis of the cause.",
+        "itself — it is NOT a connection problem, and reinstalling ComfyUI or the pack will " +
+        "not change it. The details below are what was actually observed; nothing here is a " +
+        "diagnosis of the cause.",
+    ),
     message,
     stack,
     panelVersion: info.panelVersion || "unknown",
     frontendVersion: info.frontendVersion || "unknown",
-    where:
-      "Please report this at https://github.com/artokun/comfyui-mcp-panel/issues with the " +
-      "text above, your ComfyUI frontend version, and your browser.",
+    // `{url}` rather than baking the address into the sentence, because the gate
+    // can police a hole and cannot police a literal: i18n-check.mjs extracts
+    // `{name}` runs from English and from each target and hard-fails on a
+    // mismatch, so a translation that loses or mistypes the placeholder is caught
+    // in CI. A pasted URL is checked by nobody — and this is the one sentence in
+    // #779 whose whole job is telling the user where to send the report, so
+    // losing it re-creates the defect for every language but English.
+    where: tr(
+      "panel_failure_shell.please_report_this_at_with_the_text",
+      "Please report this at {url} with the text above, your ComfyUI frontend " +
+        "version, and your browser.",
+      { url: "https://github.com/artokun/comfyui-mcp-panel/issues" },
+    ),
   };
 }
 


### PR DESCRIPTION
Unit 10 of the panel translation effort. Base is `feat/panel-i18n`, not `main`.

The theme of this unit is **default parameter values**. `scripts/i18n-extract.mjs` matches *assignment* contexts (`title:`, `.textContent =`, `label:`), and a default lives in a destructuring pattern — so none of these were ever proposed as candidates. Same reason the two multi-line `+` concatenations in `panel-failure-shell.js` were missed: the extractor reads one quoted literal at a time, and no single literal is the sentence.

## What changed — 9 new keys across 5 files

| File | Strings | Keys |
|---|---|---|
| `web/js/cmcp-modal.js` | Confirm ×2, Cancel ×3, Save, OK | `modal.confirm`, `modal.ok`, reuses `panel.cancel` / `panel.save` |
| `web/js/cmcp-filter.js` | Filters ×2 (button tooltip + sheet heading) | `filter.filters` |
| `web/js/cmcp-a2ui.js` | "could not render", " — tap to view raw" | `a2ui.could_not_render`, `a2ui.tap_to_view_raw` |
| `web/js/cmcp-civitai.js` | the "CivitAI API" error-card label | `civitai.civitai_api` |
| `web/js/lib/panel-failure-shell.js` | the `body:` and `where:` sentences, "(the failure produced no message)" | 3 keys |

`cmcp-modal.js` had **zero** `tr()` calls before this. `cmcp-civitai.js` already imported `tr`, so no duplicate import was added. Nothing under `locales/` was touched.

"Cancel" and "Save" reuse the existing `panel.cancel` / `panel.save` rather than minting `modal.*` duplicates — both exist in `locales/en/main.json` with exactly that English.

## AMBIGUOUS — flagged for the coordinator, deliberately left English

**`validateA2UISpec`'s errors (`cmcp-a2ui.js` ~51–191): "spec must be an object", `duplicate id "${c.id}"`, "components array is required", "root (component id) is required", the caps messages, "reference cycle through …", etc.** They render on the failure card so they read as user-facing, but every one names a field of the A2UI **wire schema** and its audience is whoever wrote the agent that emitted the bad card. They are also the text a user pastes into a bug report — translating them means a maintainer receives a Korean rendering of a schema violation and cannot grep for it. The card's own chrome around them (title, "tap to view raw") **is** translated. Reversible in one place if you disagree: they all flow through the single `err()` helper.

**`modal.confirm` does double duty** as the dialog title and the confirm button label (same English, same file — which is exactly what the extractor's own de-dup rule produces). Some languages want a noun heading and an imperative button. Moot while both are dead defaults (below); worth splitting the day a caller stops passing them.

## One deliberate deviation from "fallback is the current English text"

The #779 report URL is now a **`{url}` var**, not baked into the sentence:

```js
where: tr(
  "panel_failure_shell.please_report_this_at_with_the_text",
  "Please report this at {url} with the text above, your ComfyUI frontend version, and your browser.",
  { url: "https://github.com/artokun/comfyui-mcp-panel/issues" },
),
```

`scripts/i18n-check.mjs` extracts `{name}` runs from English and from every target and hard-fails on a mismatch. It **cannot** check a pasted literal URL. So the hole is the form CI can actually defend, and this is the one sentence in #779 whose entire job is telling the user where to send the report — losing it re-creates the original defect for every language but English. Rendered English is unchanged.

## Verification

- `npm run test:unit` — **3707 pass / 0 fail**, `locales OK` (ja/ko/zh, 247 keys).
- `npm run test:e2e:list` — 68 tests in 29 files, compiles clean. No live browser run (shared ComfyUI on :8188).
- **English is byte-identical.** Diffed `panelFailureReport` old-vs-new across 8 input classes (Error / TypeError / string / "" / null / undefined / object / 0) on all 7 fields, and the a2ui fail card across 10 error shapes including `undefined`, `[]`, >3 errors, and an error containing a literal `{reason}`. Zero differences.
- **The defaults are proven lazy, not frozen at import.** Imported each module, probed under `en`, installed a fake `ko` catalog *after* import, probed again: every one of the 11 rendered strings flips, the report URL survives into the translated sentence, and the validator diagnostics stay English. A default that had been evaluated at module load would have passed every other check and silently shipped English.
- `title: null` still means "no tooltip": defaults apply only to `undefined`, so `cmcp-civitai-ui.js:459`'s deliberately tooltip-less filter button is unchanged.

## Notes for the coordinator (all pre-existing, none introduced here)

1. **`npm run i18n:build` is now a footgun.** `node scripts/i18n-extract.mjs --json` currently returns **1** candidate, because nearly everything is already converted and a `tr(` call site matches no `UI_CONTEXT` regex. `i18n-build-en.mjs` writes `locales/en/main.json` from exactly that list, so running the documented build would rewrite en down to 1 key, dropping 246 — after which `i18n-check.mjs` fails ja/ko/zh with 246 "unknown key(s)". **The 9 keys from this PR must be hand-added.**

2. **A translated string is used as an `===` sentinel on the base branch — real bug, non-English locales only.** `web/js/comfyui-mcp-panel.js:19428` sets `chip.title = tr("panel.running", "Running")`, and `:25338` / `:27129` read it back as `running: el.title === "Running"`. `panel.running` is translated in every shipped catalog (`ko` `"실행 중"`, `ja` `"実行中"`, `zh` `"运行中"`), so the comparison is permanently false and every backend chip's `running` flag is silently lost when `renderBackendChips` reconstructs its input from the DOM. Not in this unit's files; worth its own issue.

3. **`locales/en/main.json` carries a stale `civitai.pg_13 = "PG-13"`.** No `tr()` call references it — the extractor picked up `{ label: "PG-13", level: 2 }` at `cmcp-civitai.js:23` before conversion. Since content-rating codes are deliberately left English, a translator will otherwise translate a key that renders nowhere. I could not remove it (`locales/` is off-limits to this unit).

4. **Six of the eight modal/filter defaults are unreachable today** — every live call site in `cmcp-apps-ui.js` / `cmcp-civitai-ui.js` overrides `title` / `confirmLabel` / `submitLabel` with its own wording, and those literals belong to units 6 and 8. Only `cancelLabel` is actually reached (no caller passes one). The conversions still stand as the contract these modules publish, and the call-site comments now say so plainly rather than implying more coverage than exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
