### PR TITLE
feat(753): scale every panel font size from one CSS variable

### DIFF
--- a/browser_tests/unit/panel-ui-scale.test.mjs
+++ b/browser_tests/unit/panel-ui-scale.test.mjs
@@ -166,5 +166,9 @@ test("the tooltip names the knob that now DOES work, and what it does not cover"
   );
   // It scales TEXT. Spacing is still rem on purpose, and saying otherwise would have
   // users expect a denser panel that never arrives.
-  assert.match(entry, /does not scale spacing or icons/);
+  assert.match(entry, /does not scale spacing, icons, or/);
+  // ...and the fixed-pixel elements. A tooltip promising "every panel font size" would be
+  // wrong: a training caption and a few rules carry literal px (codex).
+  assert.match(entry, /fixed pixel size/);
+  assert.ok(!/scales every panel font/.test(entry), "no absolute claim");
 });

--- a/browser_tests/unit/panel-ui-scale.test.mjs
+++ b/browser_tests/unit/panel-ui-scale.test.mjs
@@ -151,11 +151,20 @@ test("onChange applies immediately and is NOT gated on settingsArmed", () => {
   );
 });
 
-test("the tooltip tells the user why their stylesheet override did not work", () => {
-  // The reported confusion was not just "text is small" — it was that the
-  // obvious fix silently does nothing. A setting that does not explain that
-  // leaves the next person to rediscover it.
+test("the tooltip names the knob that now DOES work, and what it does not cover", () => {
+  // The original confusion was that the obvious fix silently did nothing, and the
+  // tooltip existed to say so. #753 removed the trap: every inner font size is
+  // calc(var(--cmcp-fs) * k), so there is a working knob to name instead of a dead end
+  // to warn about. The warning must not survive the thing it warned about — a tooltip
+  // that still says overrides do not work is now the misleading one.
   const entry = PANEL.slice(PANEL.indexOf("id: SETTING_UI_SCALE"), PANEL.indexOf("id: SETTING_STALL_S"));
-  assert.match(entry, /rem/);
-  assert.match(entry, /font-size/);
+  assert.match(entry, /--cmcp-fs/, "names the variable");
+  assert.match(entry, /0\.8125rem/, "and its default, so a user can compute a target");
+  assert.ok(
+    !/does NOT \?" \+/.test(entry) && !/most text ignores it/.test(entry),
+    "the retracted claim that overrides cannot work is gone",
+  );
+  // It scales TEXT. Spacing is still rem on purpose, and saying otherwise would have
+  // users expect a denser panel that never arrives.
+  assert.match(entry, /does not scale spacing or icons/);
 });

--- a/web/js/cmcp-a2ui.js
+++ b/web/js/cmcp-a2ui.js
@@ -249,41 +249,41 @@ export const A2UI_CSS = `
 }
 .cmcp-a2ui { border: 1px solid var(--p-content-border-color, #3f3f46); border-left: 3px solid var(--p-primary-color, #3a7bd5);
   border-radius: 8px; padding: 0.6rem 0.7rem; margin: 0.35rem 0; background: var(--p-content-background, #1f1f23);
-  font-size: calc(var(--cmcp-fs) * 0.9846); position: relative; }
+  font-size: calc(var(--cmcp-fs, 0.8125rem) * 0.9846); position: relative; }
 .cmcp-a2ui.resolved { opacity: 0.85; }
-.cmcp-a2ui-title { font-weight: 600; font-size: calc(var(--cmcp-fs) * 0.8862); text-transform: uppercase; letter-spacing: 0.05em;
+.cmcp-a2ui-title { font-weight: 600; font-size: calc(var(--cmcp-fs, 0.8125rem) * 0.8862); text-transform: uppercase; letter-spacing: 0.05em;
   opacity: 0.7; margin-bottom: 0.4rem; padding-right: 1.2rem; }
 .cmcp-a2ui-x { position: absolute; top: 0.35rem; right: 0.4rem; background: none; border: none; cursor: pointer;
-  color: var(--p-text-muted-color, #a1a1aa); font-size: calc(var(--cmcp-fs) * 0.8615); line-height: 1; padding: 0.15rem; }
+  color: var(--p-text-muted-color, #a1a1aa); font-size: calc(var(--cmcp-fs, 0.8125rem) * 0.8615); line-height: 1; padding: 0.15rem; }
 .cmcp-a2ui-x:hover { color: var(--p-text-color, #e4e4e7); }
 .cmcp-a2ui-row { display: flex; flex-direction: row; gap: 0.4rem; flex-wrap: wrap; align-items: flex-start; }
 .cmcp-a2ui-col { display: flex; flex-direction: column; gap: 0.4rem; }
 .cmcp-a2ui-card { border: 1px solid var(--p-content-border-color, #3f3f46); border-radius: 6px; padding: 0.5rem;
   display: flex; flex-direction: column; gap: 0.4rem; background: var(--p-content-hover-background, #26262a); }
 .cmcp-a2ui-text { white-space: pre-wrap; overflow-wrap: anywhere; }
-.cmcp-a2ui h1, .cmcp-a2ui h2, .cmcp-a2ui h3 { margin: 0.1rem 0; font-size: calc(var(--cmcp-fs) * 1.1692); }
-.cmcp-a2ui h1 { font-size: calc(var(--cmcp-fs) * 1.2923); } .cmcp-a2ui h3 { font-size: calc(var(--cmcp-fs) * 1.0462); }
+.cmcp-a2ui h1, .cmcp-a2ui h2, .cmcp-a2ui h3 { margin: 0.1rem 0; font-size: calc(var(--cmcp-fs, 0.8125rem) * 1.1692); }
+.cmcp-a2ui h1 { font-size: calc(var(--cmcp-fs, 0.8125rem) * 1.2923); } .cmcp-a2ui h3 { font-size: calc(var(--cmcp-fs, 0.8125rem) * 1.0462); }
 .cmcp-a2ui hr { border: none; border-top: 1px solid var(--p-content-border-color, #3f3f46); margin: 0.3rem 0; width: 100%; }
 .cmcp-a2ui-btn { display: block; width: 100%; text-align: left; padding: 0.4rem 0.6rem; border-radius: 6px; cursor: pointer;
   border: 1px solid var(--p-content-border-color, #3f3f46); background: var(--p-content-hover-background, #26262a);
-  color: var(--p-text-color, #e4e4e7); font-size: calc(var(--cmcp-fs) * 0.96); }
+  color: var(--p-text-color, #e4e4e7); font-size: calc(var(--cmcp-fs, 0.8125rem) * 0.96); }
 .cmcp-a2ui-btn:hover:not(:disabled) { border-color: var(--p-primary-color, #3a7bd5); }
 .cmcp-a2ui-btn.primary { background: var(--p-primary-color, #3a7bd5); border-color: transparent; color: #fff; }
 .cmcp-a2ui-btn:disabled { opacity: 0.45; cursor: default; }
 .cmcp-a2ui-btn.chosen { border-color: var(--p-primary-color, #3a7bd5); box-shadow: 0 0 0 1px var(--p-primary-color, #3a7bd5) inset; opacity: 1; }
 .cmcp-a2ui-field { display: flex; flex-direction: column; gap: 0.2rem; }
-.cmcp-a2ui-field > span { font-size: calc(var(--cmcp-fs) * 0.8369); opacity: 0.75; }
+.cmcp-a2ui-field > span { font-size: calc(var(--cmcp-fs, 0.8125rem) * 0.8369); opacity: 0.75; }
 .cmcp-a2ui input[type="text"], .cmcp-a2ui select { background: var(--p-form-field-background, #18181b);
   border: 1px solid var(--p-content-border-color, #3f3f46); border-radius: 5px; color: inherit;
-  padding: 0.3rem 0.45rem; font-size: calc(var(--cmcp-fs) * 0.96); width: 100%; box-sizing: border-box; }
+  padding: 0.3rem 0.45rem; font-size: calc(var(--cmcp-fs, 0.8125rem) * 0.96); width: 100%; box-sizing: border-box; }
 .cmcp-a2ui-check { display: flex; align-items: center; gap: 0.4rem; cursor: pointer; }
 .cmcp-a2ui img { max-width: 100%; border-radius: 6px; display: block; }
-.cmcp-a2ui-cap { font-size: calc(var(--cmcp-fs) * 0.7692); color: var(--p-text-muted-color, #a1a1aa); margin-top: 0.15rem; }
+.cmcp-a2ui-cap { font-size: calc(var(--cmcp-fs, 0.8125rem) * 0.7692); color: var(--p-text-muted-color, #a1a1aa); margin-top: 0.15rem; }
 .cmcp-a2ui svg { max-width: 100%; height: auto; display: block; }
 .cmcp-a2ui-fail { border-left-color: var(--p-orange-400, #fb923c); }
-.cmcp-a2ui-fail pre { max-height: 12rem; overflow: auto; font-size: calc(var(--cmcp-fs) * 0.8369); background: var(--p-form-field-background, #18181b);
+.cmcp-a2ui-fail pre { max-height: 12rem; overflow: auto; font-size: calc(var(--cmcp-fs, 0.8125rem) * 0.8369); background: var(--p-form-field-background, #18181b);
   border-radius: 5px; padding: 0.4rem; margin: 0.3rem 0 0; white-space: pre-wrap; overflow-wrap: anywhere; }
-.cmcp-a2ui-choice { font-weight: 600; margin-top: 0.35rem; color: var(--p-primary-color, #6ea8fe); font-size: calc(var(--cmcp-fs) * 0.9231); }
+.cmcp-a2ui-choice { font-weight: 600; margin-top: 0.35rem; color: var(--p-primary-color, #6ea8fe); font-size: calc(var(--cmcp-fs, 0.8125rem) * 0.9231); }
 .cmcp-a2ui-lit-leaf { display: block; width: 100%; }
 .cmcp-a2ui-lit-leaf.chosen { outline: 2px solid var(--p-primary-color, #3a7bd5); outline-offset: 2px; border-radius: 6px; }
 .cmcp-a2ui-lit-leaf.cmcp-a2ui-lit-inert { opacity: 0.55; pointer-events: none; }

--- a/web/js/cmcp-a2ui.js
+++ b/web/js/cmcp-a2ui.js
@@ -249,41 +249,41 @@ export const A2UI_CSS = `
 }
 .cmcp-a2ui { border: 1px solid var(--p-content-border-color, #3f3f46); border-left: 3px solid var(--p-primary-color, #3a7bd5);
   border-radius: 8px; padding: 0.6rem 0.7rem; margin: 0.35rem 0; background: var(--p-content-background, #1f1f23);
-  font-size: 0.9846em; position: relative; }
+  font-size: calc(var(--cmcp-fs) * 0.9846); position: relative; }
 .cmcp-a2ui.resolved { opacity: 0.85; }
-.cmcp-a2ui-title { font-weight: 600; font-size: 0.9em; text-transform: uppercase; letter-spacing: 0.05em;
+.cmcp-a2ui-title { font-weight: 600; font-size: calc(var(--cmcp-fs) * 0.8862); text-transform: uppercase; letter-spacing: 0.05em;
   opacity: 0.7; margin-bottom: 0.4rem; padding-right: 1.2rem; }
 .cmcp-a2ui-x { position: absolute; top: 0.35rem; right: 0.4rem; background: none; border: none; cursor: pointer;
-  color: var(--p-text-muted-color, #a1a1aa); font-size: 0.875em; line-height: 1; padding: 0.15rem; }
+  color: var(--p-text-muted-color, #a1a1aa); font-size: calc(var(--cmcp-fs) * 0.8615); line-height: 1; padding: 0.15rem; }
 .cmcp-a2ui-x:hover { color: var(--p-text-color, #e4e4e7); }
 .cmcp-a2ui-row { display: flex; flex-direction: row; gap: 0.4rem; flex-wrap: wrap; align-items: flex-start; }
 .cmcp-a2ui-col { display: flex; flex-direction: column; gap: 0.4rem; }
 .cmcp-a2ui-card { border: 1px solid var(--p-content-border-color, #3f3f46); border-radius: 6px; padding: 0.5rem;
   display: flex; flex-direction: column; gap: 0.4rem; background: var(--p-content-hover-background, #26262a); }
 .cmcp-a2ui-text { white-space: pre-wrap; overflow-wrap: anywhere; }
-.cmcp-a2ui h1, .cmcp-a2ui h2, .cmcp-a2ui h3 { margin: 0.1rem 0; font-size: 1.1875em; }
-.cmcp-a2ui h1 { font-size: 1.3125em; } .cmcp-a2ui h3 { font-size: 1.0625em; }
+.cmcp-a2ui h1, .cmcp-a2ui h2, .cmcp-a2ui h3 { margin: 0.1rem 0; font-size: calc(var(--cmcp-fs) * 1.1692); }
+.cmcp-a2ui h1 { font-size: calc(var(--cmcp-fs) * 1.2923); } .cmcp-a2ui h3 { font-size: calc(var(--cmcp-fs) * 1.0462); }
 .cmcp-a2ui hr { border: none; border-top: 1px solid var(--p-content-border-color, #3f3f46); margin: 0.3rem 0; width: 100%; }
 .cmcp-a2ui-btn { display: block; width: 100%; text-align: left; padding: 0.4rem 0.6rem; border-radius: 6px; cursor: pointer;
   border: 1px solid var(--p-content-border-color, #3f3f46); background: var(--p-content-hover-background, #26262a);
-  color: var(--p-text-color, #e4e4e7); font-size: 0.975em; }
+  color: var(--p-text-color, #e4e4e7); font-size: calc(var(--cmcp-fs) * 0.96); }
 .cmcp-a2ui-btn:hover:not(:disabled) { border-color: var(--p-primary-color, #3a7bd5); }
 .cmcp-a2ui-btn.primary { background: var(--p-primary-color, #3a7bd5); border-color: transparent; color: #fff; }
 .cmcp-a2ui-btn:disabled { opacity: 0.45; cursor: default; }
 .cmcp-a2ui-btn.chosen { border-color: var(--p-primary-color, #3a7bd5); box-shadow: 0 0 0 1px var(--p-primary-color, #3a7bd5) inset; opacity: 1; }
 .cmcp-a2ui-field { display: flex; flex-direction: column; gap: 0.2rem; }
-.cmcp-a2ui-field > span { font-size: 0.85em; opacity: 0.75; }
+.cmcp-a2ui-field > span { font-size: calc(var(--cmcp-fs) * 0.8369); opacity: 0.75; }
 .cmcp-a2ui input[type="text"], .cmcp-a2ui select { background: var(--p-form-field-background, #18181b);
   border: 1px solid var(--p-content-border-color, #3f3f46); border-radius: 5px; color: inherit;
-  padding: 0.3rem 0.45rem; font-size: 0.975em; width: 100%; box-sizing: border-box; }
+  padding: 0.3rem 0.45rem; font-size: calc(var(--cmcp-fs) * 0.96); width: 100%; box-sizing: border-box; }
 .cmcp-a2ui-check { display: flex; align-items: center; gap: 0.4rem; cursor: pointer; }
 .cmcp-a2ui img { max-width: 100%; border-radius: 6px; display: block; }
-.cmcp-a2ui-cap { font-size: 0.7812em; color: var(--p-text-muted-color, #a1a1aa); margin-top: 0.15rem; }
+.cmcp-a2ui-cap { font-size: calc(var(--cmcp-fs) * 0.7692); color: var(--p-text-muted-color, #a1a1aa); margin-top: 0.15rem; }
 .cmcp-a2ui svg { max-width: 100%; height: auto; display: block; }
 .cmcp-a2ui-fail { border-left-color: var(--p-orange-400, #fb923c); }
-.cmcp-a2ui-fail pre { max-height: 12rem; overflow: auto; font-size: 0.85em; background: var(--p-form-field-background, #18181b);
+.cmcp-a2ui-fail pre { max-height: 12rem; overflow: auto; font-size: calc(var(--cmcp-fs) * 0.8369); background: var(--p-form-field-background, #18181b);
   border-radius: 5px; padding: 0.4rem; margin: 0.3rem 0 0; white-space: pre-wrap; overflow-wrap: anywhere; }
-.cmcp-a2ui-choice { font-weight: 600; margin-top: 0.35rem; color: var(--p-primary-color, #6ea8fe); font-size: 0.9375em; }
+.cmcp-a2ui-choice { font-weight: 600; margin-top: 0.35rem; color: var(--p-primary-color, #6ea8fe); font-size: calc(var(--cmcp-fs) * 0.9231); }
 .cmcp-a2ui-lit-leaf { display: block; width: 100%; }
 .cmcp-a2ui-lit-leaf.chosen { outline: 2px solid var(--p-primary-color, #3a7bd5); outline-offset: 2px; border-radius: 6px; }
 .cmcp-a2ui-lit-leaf.cmcp-a2ui-lit-inert { opacity: 0.55; pointer-events: none; }

--- a/web/js/cmcp-a2ui.js
+++ b/web/js/cmcp-a2ui.js
@@ -251,39 +251,39 @@ export const A2UI_CSS = `
   border-radius: 8px; padding: 0.6rem 0.7rem; margin: 0.35rem 0; background: var(--p-content-background, #1f1f23);
   font-size: 0.9846em; position: relative; }
 .cmcp-a2ui.resolved { opacity: 0.85; }
-.cmcp-a2ui-title { font-weight: 600; font-size: 0.8862em; text-transform: uppercase; letter-spacing: 0.05em;
+.cmcp-a2ui-title { font-weight: 600; font-size: 0.9em; text-transform: uppercase; letter-spacing: 0.05em;
   opacity: 0.7; margin-bottom: 0.4rem; padding-right: 1.2rem; }
 .cmcp-a2ui-x { position: absolute; top: 0.35rem; right: 0.4rem; background: none; border: none; cursor: pointer;
-  color: var(--p-text-muted-color, #a1a1aa); font-size: 0.8615em; line-height: 1; padding: 0.15rem; }
+  color: var(--p-text-muted-color, #a1a1aa); font-size: 0.875em; line-height: 1; padding: 0.15rem; }
 .cmcp-a2ui-x:hover { color: var(--p-text-color, #e4e4e7); }
 .cmcp-a2ui-row { display: flex; flex-direction: row; gap: 0.4rem; flex-wrap: wrap; align-items: flex-start; }
 .cmcp-a2ui-col { display: flex; flex-direction: column; gap: 0.4rem; }
 .cmcp-a2ui-card { border: 1px solid var(--p-content-border-color, #3f3f46); border-radius: 6px; padding: 0.5rem;
   display: flex; flex-direction: column; gap: 0.4rem; background: var(--p-content-hover-background, #26262a); }
 .cmcp-a2ui-text { white-space: pre-wrap; overflow-wrap: anywhere; }
-.cmcp-a2ui h1, .cmcp-a2ui h2, .cmcp-a2ui h3 { margin: 0.1rem 0; font-size: 1.1692em; }
-.cmcp-a2ui h1 { font-size: 1.2923em; } .cmcp-a2ui h3 { font-size: 1.0462em; }
+.cmcp-a2ui h1, .cmcp-a2ui h2, .cmcp-a2ui h3 { margin: 0.1rem 0; font-size: 1.1875em; }
+.cmcp-a2ui h1 { font-size: 1.3125em; } .cmcp-a2ui h3 { font-size: 1.0625em; }
 .cmcp-a2ui hr { border: none; border-top: 1px solid var(--p-content-border-color, #3f3f46); margin: 0.3rem 0; width: 100%; }
 .cmcp-a2ui-btn { display: block; width: 100%; text-align: left; padding: 0.4rem 0.6rem; border-radius: 6px; cursor: pointer;
   border: 1px solid var(--p-content-border-color, #3f3f46); background: var(--p-content-hover-background, #26262a);
-  color: var(--p-text-color, #e4e4e7); font-size: 0.96em; }
+  color: var(--p-text-color, #e4e4e7); font-size: 0.975em; }
 .cmcp-a2ui-btn:hover:not(:disabled) { border-color: var(--p-primary-color, #3a7bd5); }
 .cmcp-a2ui-btn.primary { background: var(--p-primary-color, #3a7bd5); border-color: transparent; color: #fff; }
 .cmcp-a2ui-btn:disabled { opacity: 0.45; cursor: default; }
 .cmcp-a2ui-btn.chosen { border-color: var(--p-primary-color, #3a7bd5); box-shadow: 0 0 0 1px var(--p-primary-color, #3a7bd5) inset; opacity: 1; }
 .cmcp-a2ui-field { display: flex; flex-direction: column; gap: 0.2rem; }
-.cmcp-a2ui-field > span { font-size: 0.8369em; opacity: 0.75; }
+.cmcp-a2ui-field > span { font-size: 0.85em; opacity: 0.75; }
 .cmcp-a2ui input[type="text"], .cmcp-a2ui select { background: var(--p-form-field-background, #18181b);
   border: 1px solid var(--p-content-border-color, #3f3f46); border-radius: 5px; color: inherit;
-  padding: 0.3rem 0.45rem; font-size: 0.96em; width: 100%; box-sizing: border-box; }
+  padding: 0.3rem 0.45rem; font-size: 0.975em; width: 100%; box-sizing: border-box; }
 .cmcp-a2ui-check { display: flex; align-items: center; gap: 0.4rem; cursor: pointer; }
 .cmcp-a2ui img { max-width: 100%; border-radius: 6px; display: block; }
-.cmcp-a2ui-cap { font-size: 0.7692em; color: var(--p-text-muted-color, #a1a1aa); margin-top: 0.15rem; }
+.cmcp-a2ui-cap { font-size: 0.7812em; color: var(--p-text-muted-color, #a1a1aa); margin-top: 0.15rem; }
 .cmcp-a2ui svg { max-width: 100%; height: auto; display: block; }
 .cmcp-a2ui-fail { border-left-color: var(--p-orange-400, #fb923c); }
-.cmcp-a2ui-fail pre { max-height: 12rem; overflow: auto; font-size: 0.8369em; background: var(--p-form-field-background, #18181b);
+.cmcp-a2ui-fail pre { max-height: 12rem; overflow: auto; font-size: 0.85em; background: var(--p-form-field-background, #18181b);
   border-radius: 5px; padding: 0.4rem; margin: 0.3rem 0 0; white-space: pre-wrap; overflow-wrap: anywhere; }
-.cmcp-a2ui-choice { font-weight: 600; margin-top: 0.35rem; color: var(--p-primary-color, #6ea8fe); font-size: 0.9231em; }
+.cmcp-a2ui-choice { font-weight: 600; margin-top: 0.35rem; color: var(--p-primary-color, #6ea8fe); font-size: 0.9375em; }
 .cmcp-a2ui-lit-leaf { display: block; width: 100%; }
 .cmcp-a2ui-lit-leaf.chosen { outline: 2px solid var(--p-primary-color, #3a7bd5); outline-offset: 2px; border-radius: 6px; }
 .cmcp-a2ui-lit-leaf.cmcp-a2ui-lit-inert { opacity: 0.55; pointer-events: none; }

--- a/web/js/cmcp-a2ui.js
+++ b/web/js/cmcp-a2ui.js
@@ -249,41 +249,41 @@ export const A2UI_CSS = `
 }
 .cmcp-a2ui { border: 1px solid var(--p-content-border-color, #3f3f46); border-left: 3px solid var(--p-primary-color, #3a7bd5);
   border-radius: 8px; padding: 0.6rem 0.7rem; margin: 0.35rem 0; background: var(--p-content-background, #1f1f23);
-  font-size: 0.8rem; position: relative; }
+  font-size: 0.9846em; position: relative; }
 .cmcp-a2ui.resolved { opacity: 0.85; }
-.cmcp-a2ui-title { font-weight: 600; font-size: 0.72rem; text-transform: uppercase; letter-spacing: 0.05em;
+.cmcp-a2ui-title { font-weight: 600; font-size: 0.8862em; text-transform: uppercase; letter-spacing: 0.05em;
   opacity: 0.7; margin-bottom: 0.4rem; padding-right: 1.2rem; }
 .cmcp-a2ui-x { position: absolute; top: 0.35rem; right: 0.4rem; background: none; border: none; cursor: pointer;
-  color: var(--p-text-muted-color, #a1a1aa); font-size: 0.7rem; line-height: 1; padding: 0.15rem; }
+  color: var(--p-text-muted-color, #a1a1aa); font-size: 0.8615em; line-height: 1; padding: 0.15rem; }
 .cmcp-a2ui-x:hover { color: var(--p-text-color, #e4e4e7); }
 .cmcp-a2ui-row { display: flex; flex-direction: row; gap: 0.4rem; flex-wrap: wrap; align-items: flex-start; }
 .cmcp-a2ui-col { display: flex; flex-direction: column; gap: 0.4rem; }
 .cmcp-a2ui-card { border: 1px solid var(--p-content-border-color, #3f3f46); border-radius: 6px; padding: 0.5rem;
   display: flex; flex-direction: column; gap: 0.4rem; background: var(--p-content-hover-background, #26262a); }
 .cmcp-a2ui-text { white-space: pre-wrap; overflow-wrap: anywhere; }
-.cmcp-a2ui h1, .cmcp-a2ui h2, .cmcp-a2ui h3 { margin: 0.1rem 0; font-size: 0.95rem; }
-.cmcp-a2ui h1 { font-size: 1.05rem; } .cmcp-a2ui h3 { font-size: 0.85rem; }
+.cmcp-a2ui h1, .cmcp-a2ui h2, .cmcp-a2ui h3 { margin: 0.1rem 0; font-size: 1.1692em; }
+.cmcp-a2ui h1 { font-size: 1.2923em; } .cmcp-a2ui h3 { font-size: 1.0462em; }
 .cmcp-a2ui hr { border: none; border-top: 1px solid var(--p-content-border-color, #3f3f46); margin: 0.3rem 0; width: 100%; }
 .cmcp-a2ui-btn { display: block; width: 100%; text-align: left; padding: 0.4rem 0.6rem; border-radius: 6px; cursor: pointer;
   border: 1px solid var(--p-content-border-color, #3f3f46); background: var(--p-content-hover-background, #26262a);
-  color: var(--p-text-color, #e4e4e7); font-size: 0.78rem; }
+  color: var(--p-text-color, #e4e4e7); font-size: 0.96em; }
 .cmcp-a2ui-btn:hover:not(:disabled) { border-color: var(--p-primary-color, #3a7bd5); }
 .cmcp-a2ui-btn.primary { background: var(--p-primary-color, #3a7bd5); border-color: transparent; color: #fff; }
 .cmcp-a2ui-btn:disabled { opacity: 0.45; cursor: default; }
 .cmcp-a2ui-btn.chosen { border-color: var(--p-primary-color, #3a7bd5); box-shadow: 0 0 0 1px var(--p-primary-color, #3a7bd5) inset; opacity: 1; }
 .cmcp-a2ui-field { display: flex; flex-direction: column; gap: 0.2rem; }
-.cmcp-a2ui-field > span { font-size: 0.68rem; opacity: 0.75; }
+.cmcp-a2ui-field > span { font-size: 0.8369em; opacity: 0.75; }
 .cmcp-a2ui input[type="text"], .cmcp-a2ui select { background: var(--p-form-field-background, #18181b);
   border: 1px solid var(--p-content-border-color, #3f3f46); border-radius: 5px; color: inherit;
-  padding: 0.3rem 0.45rem; font-size: 0.78rem; width: 100%; box-sizing: border-box; }
+  padding: 0.3rem 0.45rem; font-size: 0.96em; width: 100%; box-sizing: border-box; }
 .cmcp-a2ui-check { display: flex; align-items: center; gap: 0.4rem; cursor: pointer; }
 .cmcp-a2ui img { max-width: 100%; border-radius: 6px; display: block; }
-.cmcp-a2ui-cap { font-size: 0.625rem; color: var(--p-text-muted-color, #a1a1aa); margin-top: 0.15rem; }
+.cmcp-a2ui-cap { font-size: 0.7692em; color: var(--p-text-muted-color, #a1a1aa); margin-top: 0.15rem; }
 .cmcp-a2ui svg { max-width: 100%; height: auto; display: block; }
 .cmcp-a2ui-fail { border-left-color: var(--p-orange-400, #fb923c); }
-.cmcp-a2ui-fail pre { max-height: 12rem; overflow: auto; font-size: 0.68rem; background: var(--p-form-field-background, #18181b);
+.cmcp-a2ui-fail pre { max-height: 12rem; overflow: auto; font-size: 0.8369em; background: var(--p-form-field-background, #18181b);
   border-radius: 5px; padding: 0.4rem; margin: 0.3rem 0 0; white-space: pre-wrap; overflow-wrap: anywhere; }
-.cmcp-a2ui-choice { font-weight: 600; margin-top: 0.35rem; color: var(--p-primary-color, #6ea8fe); font-size: 0.75rem; }
+.cmcp-a2ui-choice { font-weight: 600; margin-top: 0.35rem; color: var(--p-primary-color, #6ea8fe); font-size: 0.9231em; }
 .cmcp-a2ui-lit-leaf { display: block; width: 100%; }
 .cmcp-a2ui-lit-leaf.chosen { outline: 2px solid var(--p-primary-color, #3a7bd5); outline-offset: 2px; border-radius: 6px; }
 .cmcp-a2ui-lit-leaf.cmcp-a2ui-lit-inert { opacity: 0.55; pointer-events: none; }

--- a/web/js/cmcp-apps-ui.js
+++ b/web/js/cmcp-apps-ui.js
@@ -125,8 +125,11 @@ function injectStyle() {
 .cmcp-deps-status{flex:0 0 auto;font-size:0.96em;display:flex;align-items:center;gap:0.4rem;max-width:55%;
   justify-content:flex-end;text-align:right;}
 .cmcp-deps-ok{color:var(--p-green-400,#4ade80);font-weight:600;white-space:nowrap;}
-.cmcp-deps-status .cmcp-btn{padding:0.28rem 0.6rem;font-size:0.9108em;}
-.cmcp-deps-muted{opacity:0.6;font-size:0.9108em;}
+/* #753 — parent .cmcp-deps-status is 12.48px, not the 13px root (codex). */
+.cmcp-deps-status .cmcp-btn{padding:0.28rem 0.6rem;font-size:0.9487em;}
+/* #753 — renders BOTH inside the 12.48px status element and directly in a row, so no
+   single em reproduces both. Absolute, like the other two-context rules (codex). */
+.cmcp-deps-muted{opacity:0.6;font-size:0.74rem;}
 .cmcp-deps-err{color:#f87171;font-size:0.8862em;}
 .cmcp-deps-note{font-size:0.8369em;opacity:0.6;line-height:1.4;}
 .cmcp-deps-spin{width:0.85rem;height:0.85rem;flex:0 0 auto;border:2px solid rgba(255,255,255,0.22);

--- a/web/js/cmcp-apps-ui.js
+++ b/web/js/cmcp-apps-ui.js
@@ -34,7 +34,7 @@ function injectStyle() {
 .cmcp-apps-toolbar .spacer{flex:1;}
 /* Buttons: primary pops, everything else reads as a quiet secondary so the
    hierarchy is legible (matches the CivitAI tab's chip/button vocabulary). */
-.cmcp-apps-body .cmcp-btn{align-self:auto;padding:0.4rem 0.75rem;border-radius:8px;font-size:0.8rem;}
+.cmcp-apps-body .cmcp-btn{align-self:auto;padding:0.4rem 0.75rem;border-radius:8px;font-size:0.9846em;}
 .cmcp-apps-body .cmcp-btn:not(.primary):not(.danger){background:var(--p-surface-800,#27272a);
   color:var(--p-text-color,#fafafa);border:1px solid var(--p-content-border-color,#3f3f46);font-weight:500;}
 .cmcp-apps-body .cmcp-btn:not(.primary):not(.danger):hover{border-color:var(--p-primary-color,#60a5fa);opacity:1;}
@@ -50,15 +50,15 @@ function injectStyle() {
 .cmcp-app-card:hover{border-color:var(--p-primary-color,#60a5fa);transform:translateY(-2px);
   box-shadow:0 6px 18px rgba(0,0,0,0.35);}
 .cmcp-app-card .thumb{aspect-ratio:16/9;background:linear-gradient(135deg,#1b1b20,#0c0c0e) center/cover no-repeat;
-  display:flex;align-items:center;justify-content:center;font-size:1.6rem;opacity:0.9;color:var(--p-text-muted-color,#a1a1aa);}
+  display:flex;align-items:center;justify-content:center;font-size:1.9692em;opacity:0.9;color:var(--p-text-muted-color,#a1a1aa);}
 .cmcp-app-card .meta{padding:0.5rem 0.6rem 0.55rem;display:flex;flex-direction:column;gap:0.2rem;}
-.cmcp-app-card .name{font-weight:600;font-size:0.83rem;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;}
-.cmcp-app-card .desc{font-size:0.71rem;line-height:1.35;opacity:0.62;display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical;overflow:hidden;}
+.cmcp-app-card .name{font-weight:600;font-size:1.0215em;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;}
+.cmcp-app-card .desc{font-size:0.8738em;line-height:1.35;opacity:0.62;display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical;overflow:hidden;}
 .cmcp-app-badges{display:flex;gap:0.3rem;margin-top:0.25rem;flex-wrap:wrap;}
-.cmcp-app-badge{font-size:0.62rem;padding:0.1rem 0.4rem;border-radius:99px;border:1px solid var(--p-content-border-color,#3f3f46);
+.cmcp-app-badge{font-size:0.7631em;padding:0.1rem 0.4rem;border-radius:99px;border:1px solid var(--p-content-border-color,#3f3f46);
   color:var(--p-text-muted-color,#a1a1aa);opacity:0.9;white-space:nowrap;}
 .cmcp-app-badge.hidden-wf{border-color:rgba(245,158,11,0.5);color:#f59e0b;}
-.cmcp-apps-empty{opacity:0.6;font-size:0.85rem;line-height:1.5;padding:2.5rem 1rem;text-align:center;grid-column:1/-1;}
+.cmcp-apps-empty{opacity:0.6;font-size:1.0462em;line-height:1.5;padding:2.5rem 1rem;text-align:center;grid-column:1/-1;}
 .cmcp-apps-more{grid-column:1/-1;justify-self:center;margin-top:0.4rem;}
 .cmcp-apps-back{align-self:flex-start;}
 .cmcp-apps-detail{display:flex;flex-direction:column;gap:0.8rem;overflow-y:auto;min-height:0;padding-bottom:0.4rem;}
@@ -66,20 +66,20 @@ function injectStyle() {
   border-bottom:1px solid var(--p-content-border-color,#3f3f46);}
 .cmcp-apps-detail-head .thumb{width:104px;height:58px;flex:0 0 auto;border-radius:10px;
   background:linear-gradient(135deg,#1b1b20,#0c0c0e) center/cover no-repeat;
-  display:flex;align-items:center;justify-content:center;font-size:1.3rem;color:var(--p-text-muted-color,#a1a1aa);}
+  display:flex;align-items:center;justify-content:center;font-size:1.6em;color:var(--p-text-muted-color,#a1a1aa);}
 .cmcp-apps-detail-head .titles{flex:1;min-width:0;}
-.cmcp-apps-detail-head h3{margin:0;font-size:1.05rem;}
-.cmcp-apps-detail-head .desc{font-size:0.78rem;opacity:0.7;margin-top:0.25rem;line-height:1.45;white-space:pre-wrap;}
+.cmcp-apps-detail-head h3{margin:0;font-size:1.2923em;}
+.cmcp-apps-detail-head .desc{font-size:0.96em;opacity:0.7;margin-top:0.25rem;line-height:1.45;white-space:pre-wrap;}
 .cmcp-apps-form{display:flex;flex-direction:column;gap:0.65rem;}
 .cmcp-apps-field{display:flex;flex-direction:column;gap:0.28rem;}
-.cmcp-apps-field>label{font-size:0.7rem;font-weight:600;opacity:0.8;text-transform:uppercase;letter-spacing:0.03em;}
+.cmcp-apps-field>label{font-size:0.8615em;font-weight:600;opacity:0.8;text-transform:uppercase;letter-spacing:0.03em;}
 .cmcp-apps-field input[type=text],.cmcp-apps-field input[type=number],.cmcp-apps-field textarea,.cmcp-apps-field select{
   padding:0.5rem 0.6rem;border-radius:8px;border:1px solid var(--p-content-border-color,#3f3f46);
-  background:var(--p-surface-950,#111113);color:var(--p-text-color,#fafafa);font-size:0.85rem;font-family:inherit;box-sizing:border-box;width:100%;}
+  background:var(--p-surface-950,#111113);color:var(--p-text-color,#fafafa);font-size:1.0462em;font-family:inherit;box-sizing:border-box;width:100%;}
 .cmcp-apps-field input:focus,.cmcp-apps-field textarea:focus,.cmcp-apps-field select:focus{outline:none;border-color:var(--p-primary-color,#60a5fa);}
-.cmcp-apps-field input[type=file]{font-size:0.78rem;}
+.cmcp-apps-field input[type=file]{font-size:0.96em;}
 .cmcp-apps-field textarea{min-height:64px;resize:vertical;}
-.cmcp-apps-hint{font-size:0.68rem;opacity:0.6;}
+.cmcp-apps-hint{font-size:0.8369em;opacity:0.6;}
 /* number-with-bounds slider + synced readout */
 .cmcp-apps-sliderrow{display:flex;gap:0.6rem;align-items:center;}
 .cmcp-apps-sliderrow input[type=range]{flex:1;min-width:0;accent-color:var(--p-primary-color,#60a5fa);}
@@ -91,22 +91,22 @@ function injectStyle() {
 .cmcp-apps-field input[type=color]{width:3rem;height:2rem;padding:0.15rem;border-radius:8px;
   border:1px solid var(--p-content-border-color,#3f3f46);background:var(--p-surface-950,#111113);cursor:pointer;}
 .cmcp-apps-runbar{display:flex;gap:0.5rem;align-items:center;flex-wrap:wrap;padding-top:0.15rem;}
-.cmcp-apps-status{font-size:0.8rem;opacity:0.85;min-height:1.1em;flex:1 1 8rem;}
+.cmcp-apps-status{font-size:0.9846em;opacity:0.85;min-height:1.1em;flex:1 1 8rem;}
 .cmcp-apps-status.err{color:#f87171;}
 .cmcp-apps-outputs{display:grid;grid-template-columns:repeat(auto-fill,minmax(160px,1fr));gap:0.5rem;}
 .cmcp-apps-outputs:empty{display:none;}
 .cmcp-apps-outputs img,.cmcp-apps-outputs video{width:100%;border-radius:10px;display:block;background:#0c0c0e;
   border:1px solid var(--p-content-border-color,#3f3f46);}
-.cmcp-apps-outputs .text-out{grid-column:1/-1;font-size:0.8rem;white-space:pre-wrap;background:rgba(255,255,255,0.04);
+.cmcp-apps-outputs .text-out{grid-column:1/-1;font-size:0.9846em;white-space:pre-wrap;background:rgba(255,255,255,0.04);
   border-radius:8px;padding:0.5rem 0.6rem;}
 .cmcp-apps-pick{display:flex;flex-direction:column;gap:0.1rem;max-height:240px;overflow-y:auto;
   border:1px solid var(--p-content-border-color,#3f3f46);border-radius:10px;padding:0.5rem;background:var(--p-surface-950,#111113);}
-.cmcp-apps-pick label{display:flex;gap:0.45rem;align-items:center;font-size:0.78rem;padding:0.22rem 0.3rem;
+.cmcp-apps-pick label{display:flex;gap:0.45rem;align-items:center;font-size:0.96em;padding:0.22rem 0.3rem;
   border-radius:6px;cursor:pointer;transition:background .12s;}
 .cmcp-apps-pick label:hover{background:rgba(255,255,255,0.05);}
-.cmcp-apps-pick .grp{font-size:0.66rem;font-weight:700;opacity:0.6;margin:0.45rem 0 0.15rem;text-transform:uppercase;letter-spacing:0.05em;}
+.cmcp-apps-pick .grp{font-size:0.8123em;font-weight:700;opacity:0.6;margin:0.45rem 0 0.15rem;text-transform:uppercase;letter-spacing:0.05em;}
 .cmcp-apps-pick .grp:first-child{margin-top:0.1rem;}
-.cmcp-apps-warn{font-size:0.75rem;line-height:1.45;color:#f59e0b;background:rgba(245,158,11,0.08);border:1px solid rgba(245,158,11,0.3);
+.cmcp-apps-warn{font-size:0.9231em;line-height:1.45;color:#f59e0b;background:rgba(245,158,11,0.08);border:1px solid rgba(245,158,11,0.3);
   border-radius:8px;padding:0.55rem 0.65rem;}
 /* Fallback for danger buttons rendered outside .cmcp-apps-body (defensive). */
 .cmcp-btn.danger{border-color:rgba(248,113,113,0.5);color:#f87171;}
@@ -114,21 +114,21 @@ function injectStyle() {
 .cmcp-deps{display:flex;flex-direction:column;gap:0.75rem;border:1px solid var(--p-content-border-color,#3f3f46);
   border-radius:10px;padding:0.6rem 0.7rem;background:var(--p-surface-950,#111113);flex:0 0 260px;}
 .cmcp-deps-sec{display:flex;flex-direction:column;}
-.cmcp-deps-h{font-size:0.7rem;font-weight:700;opacity:0.8;text-transform:uppercase;letter-spacing:0.04em;
+.cmcp-deps-h{font-size:0.8615em;font-weight:700;opacity:0.8;text-transform:uppercase;letter-spacing:0.04em;
   padding-bottom:0.25rem;}
 .cmcp-deps-row{display:flex;align-items:center;gap:0.6rem;padding:0.34rem 0.1rem;
   border-top:1px solid rgba(255,255,255,0.05);}
 .cmcp-deps-row:first-of-type{border-top:none;}
 .cmcp-deps-name{flex:1;min-width:0;display:flex;flex-direction:column;gap:0.1rem;}
-.cmcp-deps-name .n{font-size:0.8rem;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}
-.cmcp-deps-name .sub{font-size:0.66rem;opacity:0.55;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}
-.cmcp-deps-status{flex:0 0 auto;font-size:0.78rem;display:flex;align-items:center;gap:0.4rem;max-width:55%;
+.cmcp-deps-name .n{font-size:0.9846em;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}
+.cmcp-deps-name .sub{font-size:0.8123em;opacity:0.55;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}
+.cmcp-deps-status{flex:0 0 auto;font-size:0.96em;display:flex;align-items:center;gap:0.4rem;max-width:55%;
   justify-content:flex-end;text-align:right;}
 .cmcp-deps-ok{color:var(--p-green-400,#4ade80);font-weight:600;white-space:nowrap;}
-.cmcp-deps-status .cmcp-btn{padding:0.28rem 0.6rem;font-size:0.74rem;}
-.cmcp-deps-muted{opacity:0.6;font-size:0.74rem;}
-.cmcp-deps-err{color:#f87171;font-size:0.72rem;}
-.cmcp-deps-note{font-size:0.68rem;opacity:0.6;line-height:1.4;}
+.cmcp-deps-status .cmcp-btn{padding:0.28rem 0.6rem;font-size:0.9108em;}
+.cmcp-deps-muted{opacity:0.6;font-size:0.9108em;}
+.cmcp-deps-err{color:#f87171;font-size:0.8862em;}
+.cmcp-deps-note{font-size:0.8369em;opacity:0.6;line-height:1.4;}
 .cmcp-deps-spin{width:0.85rem;height:0.85rem;flex:0 0 auto;border:2px solid rgba(255,255,255,0.22);
   border-top-color:var(--p-primary-color,#60a5fa);border-radius:50%;display:inline-block;
   animation:cmcp-deps-spin 0.7s linear infinite;}
@@ -138,11 +138,11 @@ function injectStyle() {
 .cmcp-apps-main>.grow{flex:1;min-width:0;display:flex;flex-direction:column;gap:0.75rem;}
 @media (max-width:720px){.cmcp-apps-main{flex-direction:column;}.cmcp-deps{flex:1 1 auto;width:100%;}}
 .cmcp-apps-title-row{display:flex;align-items:center;gap:0.45rem;}
-.cmcp-apps-starbtn{border:none;background:none;color:inherit;font-size:1.05rem;cursor:pointer;padding:0 0.1rem;line-height:1;}
+.cmcp-apps-starbtn{border:none;background:none;color:inherit;font-size:1.2923em;cursor:pointer;padding:0 0.1rem;line-height:1;}
 .cmcp-apps-starbtn:hover{color:#facc15;}
 .cmcp-apps-starbtn.starred{color:#facc15;}
 .cmcp-apps-starbtn:disabled{opacity:0.4;cursor:default;}
-.cmcp-apps-starcount{font-size:0.78rem;opacity:0.7;}
+.cmcp-apps-starcount{font-size:0.96em;opacity:0.7;}
 `;
   const el = document.createElement("style");
   el.textContent = css;

--- a/web/js/cmcp-apps-ui.js
+++ b/web/js/cmcp-apps-ui.js
@@ -34,7 +34,7 @@ function injectStyle() {
 .cmcp-apps-toolbar .spacer{flex:1;}
 /* Buttons: primary pops, everything else reads as a quiet secondary so the
    hierarchy is legible (matches the CivitAI tab's chip/button vocabulary). */
-.cmcp-apps-body .cmcp-btn{align-self:auto;padding:0.4rem 0.75rem;border-radius:8px;font-size:calc(var(--cmcp-fs) * 0.9846);}
+.cmcp-apps-body .cmcp-btn{align-self:auto;padding:0.4rem 0.75rem;border-radius:8px;font-size:calc(var(--cmcp-fs, 0.8125rem) * 0.9846);}
 .cmcp-apps-body .cmcp-btn:not(.primary):not(.danger){background:var(--p-surface-800,#27272a);
   color:var(--p-text-color,#fafafa);border:1px solid var(--p-content-border-color,#3f3f46);font-weight:500;}
 .cmcp-apps-body .cmcp-btn:not(.primary):not(.danger):hover{border-color:var(--p-primary-color,#60a5fa);opacity:1;}
@@ -50,15 +50,15 @@ function injectStyle() {
 .cmcp-app-card:hover{border-color:var(--p-primary-color,#60a5fa);transform:translateY(-2px);
   box-shadow:0 6px 18px rgba(0,0,0,0.35);}
 .cmcp-app-card .thumb{aspect-ratio:16/9;background:linear-gradient(135deg,#1b1b20,#0c0c0e) center/cover no-repeat;
-  display:flex;align-items:center;justify-content:center;font-size:calc(var(--cmcp-fs) * 1.9692);opacity:0.9;color:var(--p-text-muted-color,#a1a1aa);}
+  display:flex;align-items:center;justify-content:center;font-size:calc(var(--cmcp-fs, 0.8125rem) * 1.9692);opacity:0.9;color:var(--p-text-muted-color,#a1a1aa);}
 .cmcp-app-card .meta{padding:0.5rem 0.6rem 0.55rem;display:flex;flex-direction:column;gap:0.2rem;}
-.cmcp-app-card .name{font-weight:600;font-size:calc(var(--cmcp-fs) * 1.0215);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;}
-.cmcp-app-card .desc{font-size:calc(var(--cmcp-fs) * 0.8738);line-height:1.35;opacity:0.62;display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical;overflow:hidden;}
+.cmcp-app-card .name{font-weight:600;font-size:calc(var(--cmcp-fs, 0.8125rem) * 1.0215);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;}
+.cmcp-app-card .desc{font-size:calc(var(--cmcp-fs, 0.8125rem) * 0.8738);line-height:1.35;opacity:0.62;display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical;overflow:hidden;}
 .cmcp-app-badges{display:flex;gap:0.3rem;margin-top:0.25rem;flex-wrap:wrap;}
-.cmcp-app-badge{font-size:calc(var(--cmcp-fs) * 0.7631);padding:0.1rem 0.4rem;border-radius:99px;border:1px solid var(--p-content-border-color,#3f3f46);
+.cmcp-app-badge{font-size:calc(var(--cmcp-fs, 0.8125rem) * 0.7631);padding:0.1rem 0.4rem;border-radius:99px;border:1px solid var(--p-content-border-color,#3f3f46);
   color:var(--p-text-muted-color,#a1a1aa);opacity:0.9;white-space:nowrap;}
 .cmcp-app-badge.hidden-wf{border-color:rgba(245,158,11,0.5);color:#f59e0b;}
-.cmcp-apps-empty{opacity:0.6;font-size:calc(var(--cmcp-fs) * 1.0462);line-height:1.5;padding:2.5rem 1rem;text-align:center;grid-column:1/-1;}
+.cmcp-apps-empty{opacity:0.6;font-size:calc(var(--cmcp-fs, 0.8125rem) * 1.0462);line-height:1.5;padding:2.5rem 1rem;text-align:center;grid-column:1/-1;}
 .cmcp-apps-more{grid-column:1/-1;justify-self:center;margin-top:0.4rem;}
 .cmcp-apps-back{align-self:flex-start;}
 .cmcp-apps-detail{display:flex;flex-direction:column;gap:0.8rem;overflow-y:auto;min-height:0;padding-bottom:0.4rem;}
@@ -66,20 +66,20 @@ function injectStyle() {
   border-bottom:1px solid var(--p-content-border-color,#3f3f46);}
 .cmcp-apps-detail-head .thumb{width:104px;height:58px;flex:0 0 auto;border-radius:10px;
   background:linear-gradient(135deg,#1b1b20,#0c0c0e) center/cover no-repeat;
-  display:flex;align-items:center;justify-content:center;font-size:calc(var(--cmcp-fs) * 1.6);color:var(--p-text-muted-color,#a1a1aa);}
+  display:flex;align-items:center;justify-content:center;font-size:calc(var(--cmcp-fs, 0.8125rem) * 1.6);color:var(--p-text-muted-color,#a1a1aa);}
 .cmcp-apps-detail-head .titles{flex:1;min-width:0;}
-.cmcp-apps-detail-head h3{margin:0;font-size:calc(var(--cmcp-fs) * 1.2923);}
-.cmcp-apps-detail-head .desc{font-size:calc(var(--cmcp-fs) * 0.96);opacity:0.7;margin-top:0.25rem;line-height:1.45;white-space:pre-wrap;}
+.cmcp-apps-detail-head h3{margin:0;font-size:calc(var(--cmcp-fs, 0.8125rem) * 1.2923);}
+.cmcp-apps-detail-head .desc{font-size:calc(var(--cmcp-fs, 0.8125rem) * 0.96);opacity:0.7;margin-top:0.25rem;line-height:1.45;white-space:pre-wrap;}
 .cmcp-apps-form{display:flex;flex-direction:column;gap:0.65rem;}
 .cmcp-apps-field{display:flex;flex-direction:column;gap:0.28rem;}
-.cmcp-apps-field>label{font-size:calc(var(--cmcp-fs) * 0.8615);font-weight:600;opacity:0.8;text-transform:uppercase;letter-spacing:0.03em;}
+.cmcp-apps-field>label{font-size:calc(var(--cmcp-fs, 0.8125rem) * 0.8615);font-weight:600;opacity:0.8;text-transform:uppercase;letter-spacing:0.03em;}
 .cmcp-apps-field input[type=text],.cmcp-apps-field input[type=number],.cmcp-apps-field textarea,.cmcp-apps-field select{
   padding:0.5rem 0.6rem;border-radius:8px;border:1px solid var(--p-content-border-color,#3f3f46);
-  background:var(--p-surface-950,#111113);color:var(--p-text-color,#fafafa);font-size:calc(var(--cmcp-fs) * 1.0462);font-family:inherit;box-sizing:border-box;width:100%;}
+  background:var(--p-surface-950,#111113);color:var(--p-text-color,#fafafa);font-size:calc(var(--cmcp-fs, 0.8125rem) * 1.0462);font-family:inherit;box-sizing:border-box;width:100%;}
 .cmcp-apps-field input:focus,.cmcp-apps-field textarea:focus,.cmcp-apps-field select:focus{outline:none;border-color:var(--p-primary-color,#60a5fa);}
-.cmcp-apps-field input[type=file]{font-size:calc(var(--cmcp-fs) * 0.96);}
+.cmcp-apps-field input[type=file]{font-size:calc(var(--cmcp-fs, 0.8125rem) * 0.96);}
 .cmcp-apps-field textarea{min-height:64px;resize:vertical;}
-.cmcp-apps-hint{font-size:calc(var(--cmcp-fs) * 0.8369);opacity:0.6;}
+.cmcp-apps-hint{font-size:calc(var(--cmcp-fs, 0.8125rem) * 0.8369);opacity:0.6;}
 /* number-with-bounds slider + synced readout */
 .cmcp-apps-sliderrow{display:flex;gap:0.6rem;align-items:center;}
 .cmcp-apps-sliderrow input[type=range]{flex:1;min-width:0;accent-color:var(--p-primary-color,#60a5fa);}
@@ -91,22 +91,22 @@ function injectStyle() {
 .cmcp-apps-field input[type=color]{width:3rem;height:2rem;padding:0.15rem;border-radius:8px;
   border:1px solid var(--p-content-border-color,#3f3f46);background:var(--p-surface-950,#111113);cursor:pointer;}
 .cmcp-apps-runbar{display:flex;gap:0.5rem;align-items:center;flex-wrap:wrap;padding-top:0.15rem;}
-.cmcp-apps-status{font-size:calc(var(--cmcp-fs) * 0.9846);opacity:0.85;min-height:1.1em;flex:1 1 8rem;}
+.cmcp-apps-status{font-size:calc(var(--cmcp-fs, 0.8125rem) * 0.9846);opacity:0.85;min-height:1.1em;flex:1 1 8rem;}
 .cmcp-apps-status.err{color:#f87171;}
 .cmcp-apps-outputs{display:grid;grid-template-columns:repeat(auto-fill,minmax(160px,1fr));gap:0.5rem;}
 .cmcp-apps-outputs:empty{display:none;}
 .cmcp-apps-outputs img,.cmcp-apps-outputs video{width:100%;border-radius:10px;display:block;background:#0c0c0e;
   border:1px solid var(--p-content-border-color,#3f3f46);}
-.cmcp-apps-outputs .text-out{grid-column:1/-1;font-size:calc(var(--cmcp-fs) * 0.9846);white-space:pre-wrap;background:rgba(255,255,255,0.04);
+.cmcp-apps-outputs .text-out{grid-column:1/-1;font-size:calc(var(--cmcp-fs, 0.8125rem) * 0.9846);white-space:pre-wrap;background:rgba(255,255,255,0.04);
   border-radius:8px;padding:0.5rem 0.6rem;}
 .cmcp-apps-pick{display:flex;flex-direction:column;gap:0.1rem;max-height:240px;overflow-y:auto;
   border:1px solid var(--p-content-border-color,#3f3f46);border-radius:10px;padding:0.5rem;background:var(--p-surface-950,#111113);}
-.cmcp-apps-pick label{display:flex;gap:0.45rem;align-items:center;font-size:calc(var(--cmcp-fs) * 0.96);padding:0.22rem 0.3rem;
+.cmcp-apps-pick label{display:flex;gap:0.45rem;align-items:center;font-size:calc(var(--cmcp-fs, 0.8125rem) * 0.96);padding:0.22rem 0.3rem;
   border-radius:6px;cursor:pointer;transition:background .12s;}
 .cmcp-apps-pick label:hover{background:rgba(255,255,255,0.05);}
-.cmcp-apps-pick .grp{font-size:calc(var(--cmcp-fs) * 0.8123);font-weight:700;opacity:0.6;margin:0.45rem 0 0.15rem;text-transform:uppercase;letter-spacing:0.05em;}
+.cmcp-apps-pick .grp{font-size:calc(var(--cmcp-fs, 0.8125rem) * 0.8123);font-weight:700;opacity:0.6;margin:0.45rem 0 0.15rem;text-transform:uppercase;letter-spacing:0.05em;}
 .cmcp-apps-pick .grp:first-child{margin-top:0.1rem;}
-.cmcp-apps-warn{font-size:calc(var(--cmcp-fs) * 0.9231);line-height:1.45;color:#f59e0b;background:rgba(245,158,11,0.08);border:1px solid rgba(245,158,11,0.3);
+.cmcp-apps-warn{font-size:calc(var(--cmcp-fs, 0.8125rem) * 0.9231);line-height:1.45;color:#f59e0b;background:rgba(245,158,11,0.08);border:1px solid rgba(245,158,11,0.3);
   border-radius:8px;padding:0.55rem 0.65rem;}
 /* Fallback for danger buttons rendered outside .cmcp-apps-body (defensive). */
 .cmcp-btn.danger{border-color:rgba(248,113,113,0.5);color:#f87171;}
@@ -114,21 +114,21 @@ function injectStyle() {
 .cmcp-deps{display:flex;flex-direction:column;gap:0.75rem;border:1px solid var(--p-content-border-color,#3f3f46);
   border-radius:10px;padding:0.6rem 0.7rem;background:var(--p-surface-950,#111113);flex:0 0 260px;}
 .cmcp-deps-sec{display:flex;flex-direction:column;}
-.cmcp-deps-h{font-size:calc(var(--cmcp-fs) * 0.8615);font-weight:700;opacity:0.8;text-transform:uppercase;letter-spacing:0.04em;
+.cmcp-deps-h{font-size:calc(var(--cmcp-fs, 0.8125rem) * 0.8615);font-weight:700;opacity:0.8;text-transform:uppercase;letter-spacing:0.04em;
   padding-bottom:0.25rem;}
 .cmcp-deps-row{display:flex;align-items:center;gap:0.6rem;padding:0.34rem 0.1rem;
   border-top:1px solid rgba(255,255,255,0.05);}
 .cmcp-deps-row:first-of-type{border-top:none;}
 .cmcp-deps-name{flex:1;min-width:0;display:flex;flex-direction:column;gap:0.1rem;}
-.cmcp-deps-name .n{font-size:calc(var(--cmcp-fs) * 0.9846);overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}
-.cmcp-deps-name .sub{font-size:calc(var(--cmcp-fs) * 0.8123);opacity:0.55;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}
-.cmcp-deps-status{flex:0 0 auto;font-size:calc(var(--cmcp-fs) * 0.96);display:flex;align-items:center;gap:0.4rem;max-width:55%;
+.cmcp-deps-name .n{font-size:calc(var(--cmcp-fs, 0.8125rem) * 0.9846);overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}
+.cmcp-deps-name .sub{font-size:calc(var(--cmcp-fs, 0.8125rem) * 0.8123);opacity:0.55;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}
+.cmcp-deps-status{flex:0 0 auto;font-size:calc(var(--cmcp-fs, 0.8125rem) * 0.96);display:flex;align-items:center;gap:0.4rem;max-width:55%;
   justify-content:flex-end;text-align:right;}
 .cmcp-deps-ok{color:var(--p-green-400,#4ade80);font-weight:600;white-space:nowrap;}
-.cmcp-deps-status .cmcp-btn{padding:0.28rem 0.6rem;font-size:calc(var(--cmcp-fs) * 0.9108);}
-.cmcp-deps-muted{opacity:0.6;font-size:calc(var(--cmcp-fs) * 0.9108);}
-.cmcp-deps-err{color:#f87171;font-size:calc(var(--cmcp-fs) * 0.8862);}
-.cmcp-deps-note{font-size:calc(var(--cmcp-fs) * 0.8369);opacity:0.6;line-height:1.4;}
+.cmcp-deps-status .cmcp-btn{padding:0.28rem 0.6rem;font-size:calc(var(--cmcp-fs, 0.8125rem) * 0.9108);}
+.cmcp-deps-muted{opacity:0.6;font-size:calc(var(--cmcp-fs, 0.8125rem) * 0.9108);}
+.cmcp-deps-err{color:#f87171;font-size:calc(var(--cmcp-fs, 0.8125rem) * 0.8862);}
+.cmcp-deps-note{font-size:calc(var(--cmcp-fs, 0.8125rem) * 0.8369);opacity:0.6;line-height:1.4;}
 .cmcp-deps-spin{width:0.85rem;height:0.85rem;flex:0 0 auto;border:2px solid rgba(255,255,255,0.22);
   border-top-color:var(--p-primary-color,#60a5fa);border-radius:50%;display:inline-block;
   animation:cmcp-deps-spin 0.7s linear infinite;}
@@ -138,11 +138,11 @@ function injectStyle() {
 .cmcp-apps-main>.grow{flex:1;min-width:0;display:flex;flex-direction:column;gap:0.75rem;}
 @media (max-width:720px){.cmcp-apps-main{flex-direction:column;}.cmcp-deps{flex:1 1 auto;width:100%;}}
 .cmcp-apps-title-row{display:flex;align-items:center;gap:0.45rem;}
-.cmcp-apps-starbtn{border:none;background:none;color:inherit;font-size:calc(var(--cmcp-fs) * 1.2923);cursor:pointer;padding:0 0.1rem;line-height:1;}
+.cmcp-apps-starbtn{border:none;background:none;color:inherit;font-size:calc(var(--cmcp-fs, 0.8125rem) * 1.2923);cursor:pointer;padding:0 0.1rem;line-height:1;}
 .cmcp-apps-starbtn:hover{color:#facc15;}
 .cmcp-apps-starbtn.starred{color:#facc15;}
 .cmcp-apps-starbtn:disabled{opacity:0.4;cursor:default;}
-.cmcp-apps-starcount{font-size:calc(var(--cmcp-fs) * 0.96);opacity:0.7;}
+.cmcp-apps-starcount{font-size:calc(var(--cmcp-fs, 0.8125rem) * 0.96);opacity:0.7;}
 `;
   const el = document.createElement("style");
   el.textContent = css;

--- a/web/js/cmcp-apps-ui.js
+++ b/web/js/cmcp-apps-ui.js
@@ -34,7 +34,7 @@ function injectStyle() {
 .cmcp-apps-toolbar .spacer{flex:1;}
 /* Buttons: primary pops, everything else reads as a quiet secondary so the
    hierarchy is legible (matches the CivitAI tab's chip/button vocabulary). */
-.cmcp-apps-body .cmcp-btn{align-self:auto;padding:0.4rem 0.75rem;border-radius:8px;font-size:0.9846em;}
+.cmcp-apps-body .cmcp-btn{align-self:auto;padding:0.4rem 0.75rem;border-radius:8px;font-size:calc(var(--cmcp-fs) * 0.9846);}
 .cmcp-apps-body .cmcp-btn:not(.primary):not(.danger){background:var(--p-surface-800,#27272a);
   color:var(--p-text-color,#fafafa);border:1px solid var(--p-content-border-color,#3f3f46);font-weight:500;}
 .cmcp-apps-body .cmcp-btn:not(.primary):not(.danger):hover{border-color:var(--p-primary-color,#60a5fa);opacity:1;}
@@ -50,15 +50,15 @@ function injectStyle() {
 .cmcp-app-card:hover{border-color:var(--p-primary-color,#60a5fa);transform:translateY(-2px);
   box-shadow:0 6px 18px rgba(0,0,0,0.35);}
 .cmcp-app-card .thumb{aspect-ratio:16/9;background:linear-gradient(135deg,#1b1b20,#0c0c0e) center/cover no-repeat;
-  display:flex;align-items:center;justify-content:center;font-size:1.9692em;opacity:0.9;color:var(--p-text-muted-color,#a1a1aa);}
+  display:flex;align-items:center;justify-content:center;font-size:calc(var(--cmcp-fs) * 1.9692);opacity:0.9;color:var(--p-text-muted-color,#a1a1aa);}
 .cmcp-app-card .meta{padding:0.5rem 0.6rem 0.55rem;display:flex;flex-direction:column;gap:0.2rem;}
-.cmcp-app-card .name{font-weight:600;font-size:1.0215em;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;}
-.cmcp-app-card .desc{font-size:0.8738em;line-height:1.35;opacity:0.62;display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical;overflow:hidden;}
+.cmcp-app-card .name{font-weight:600;font-size:calc(var(--cmcp-fs) * 1.0215);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;}
+.cmcp-app-card .desc{font-size:calc(var(--cmcp-fs) * 0.8738);line-height:1.35;opacity:0.62;display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical;overflow:hidden;}
 .cmcp-app-badges{display:flex;gap:0.3rem;margin-top:0.25rem;flex-wrap:wrap;}
-.cmcp-app-badge{font-size:0.7631em;padding:0.1rem 0.4rem;border-radius:99px;border:1px solid var(--p-content-border-color,#3f3f46);
+.cmcp-app-badge{font-size:calc(var(--cmcp-fs) * 0.7631);padding:0.1rem 0.4rem;border-radius:99px;border:1px solid var(--p-content-border-color,#3f3f46);
   color:var(--p-text-muted-color,#a1a1aa);opacity:0.9;white-space:nowrap;}
 .cmcp-app-badge.hidden-wf{border-color:rgba(245,158,11,0.5);color:#f59e0b;}
-.cmcp-apps-empty{opacity:0.6;font-size:1.0462em;line-height:1.5;padding:2.5rem 1rem;text-align:center;grid-column:1/-1;}
+.cmcp-apps-empty{opacity:0.6;font-size:calc(var(--cmcp-fs) * 1.0462);line-height:1.5;padding:2.5rem 1rem;text-align:center;grid-column:1/-1;}
 .cmcp-apps-more{grid-column:1/-1;justify-self:center;margin-top:0.4rem;}
 .cmcp-apps-back{align-self:flex-start;}
 .cmcp-apps-detail{display:flex;flex-direction:column;gap:0.8rem;overflow-y:auto;min-height:0;padding-bottom:0.4rem;}
@@ -66,20 +66,20 @@ function injectStyle() {
   border-bottom:1px solid var(--p-content-border-color,#3f3f46);}
 .cmcp-apps-detail-head .thumb{width:104px;height:58px;flex:0 0 auto;border-radius:10px;
   background:linear-gradient(135deg,#1b1b20,#0c0c0e) center/cover no-repeat;
-  display:flex;align-items:center;justify-content:center;font-size:1.6em;color:var(--p-text-muted-color,#a1a1aa);}
+  display:flex;align-items:center;justify-content:center;font-size:calc(var(--cmcp-fs) * 1.6);color:var(--p-text-muted-color,#a1a1aa);}
 .cmcp-apps-detail-head .titles{flex:1;min-width:0;}
-.cmcp-apps-detail-head h3{margin:0;font-size:1.2923em;}
-.cmcp-apps-detail-head .desc{font-size:0.96em;opacity:0.7;margin-top:0.25rem;line-height:1.45;white-space:pre-wrap;}
+.cmcp-apps-detail-head h3{margin:0;font-size:calc(var(--cmcp-fs) * 1.2923);}
+.cmcp-apps-detail-head .desc{font-size:calc(var(--cmcp-fs) * 0.96);opacity:0.7;margin-top:0.25rem;line-height:1.45;white-space:pre-wrap;}
 .cmcp-apps-form{display:flex;flex-direction:column;gap:0.65rem;}
 .cmcp-apps-field{display:flex;flex-direction:column;gap:0.28rem;}
-.cmcp-apps-field>label{font-size:0.8615em;font-weight:600;opacity:0.8;text-transform:uppercase;letter-spacing:0.03em;}
+.cmcp-apps-field>label{font-size:calc(var(--cmcp-fs) * 0.8615);font-weight:600;opacity:0.8;text-transform:uppercase;letter-spacing:0.03em;}
 .cmcp-apps-field input[type=text],.cmcp-apps-field input[type=number],.cmcp-apps-field textarea,.cmcp-apps-field select{
   padding:0.5rem 0.6rem;border-radius:8px;border:1px solid var(--p-content-border-color,#3f3f46);
-  background:var(--p-surface-950,#111113);color:var(--p-text-color,#fafafa);font-size:1.0462em;font-family:inherit;box-sizing:border-box;width:100%;}
+  background:var(--p-surface-950,#111113);color:var(--p-text-color,#fafafa);font-size:calc(var(--cmcp-fs) * 1.0462);font-family:inherit;box-sizing:border-box;width:100%;}
 .cmcp-apps-field input:focus,.cmcp-apps-field textarea:focus,.cmcp-apps-field select:focus{outline:none;border-color:var(--p-primary-color,#60a5fa);}
-.cmcp-apps-field input[type=file]{font-size:0.96em;}
+.cmcp-apps-field input[type=file]{font-size:calc(var(--cmcp-fs) * 0.96);}
 .cmcp-apps-field textarea{min-height:64px;resize:vertical;}
-.cmcp-apps-hint{font-size:0.8369em;opacity:0.6;}
+.cmcp-apps-hint{font-size:calc(var(--cmcp-fs) * 0.8369);opacity:0.6;}
 /* number-with-bounds slider + synced readout */
 .cmcp-apps-sliderrow{display:flex;gap:0.6rem;align-items:center;}
 .cmcp-apps-sliderrow input[type=range]{flex:1;min-width:0;accent-color:var(--p-primary-color,#60a5fa);}
@@ -91,22 +91,22 @@ function injectStyle() {
 .cmcp-apps-field input[type=color]{width:3rem;height:2rem;padding:0.15rem;border-radius:8px;
   border:1px solid var(--p-content-border-color,#3f3f46);background:var(--p-surface-950,#111113);cursor:pointer;}
 .cmcp-apps-runbar{display:flex;gap:0.5rem;align-items:center;flex-wrap:wrap;padding-top:0.15rem;}
-.cmcp-apps-status{font-size:0.9846em;opacity:0.85;min-height:1.1em;flex:1 1 8rem;}
+.cmcp-apps-status{font-size:calc(var(--cmcp-fs) * 0.9846);opacity:0.85;min-height:1.1em;flex:1 1 8rem;}
 .cmcp-apps-status.err{color:#f87171;}
 .cmcp-apps-outputs{display:grid;grid-template-columns:repeat(auto-fill,minmax(160px,1fr));gap:0.5rem;}
 .cmcp-apps-outputs:empty{display:none;}
 .cmcp-apps-outputs img,.cmcp-apps-outputs video{width:100%;border-radius:10px;display:block;background:#0c0c0e;
   border:1px solid var(--p-content-border-color,#3f3f46);}
-.cmcp-apps-outputs .text-out{grid-column:1/-1;font-size:0.9846em;white-space:pre-wrap;background:rgba(255,255,255,0.04);
+.cmcp-apps-outputs .text-out{grid-column:1/-1;font-size:calc(var(--cmcp-fs) * 0.9846);white-space:pre-wrap;background:rgba(255,255,255,0.04);
   border-radius:8px;padding:0.5rem 0.6rem;}
 .cmcp-apps-pick{display:flex;flex-direction:column;gap:0.1rem;max-height:240px;overflow-y:auto;
   border:1px solid var(--p-content-border-color,#3f3f46);border-radius:10px;padding:0.5rem;background:var(--p-surface-950,#111113);}
-.cmcp-apps-pick label{display:flex;gap:0.45rem;align-items:center;font-size:0.96em;padding:0.22rem 0.3rem;
+.cmcp-apps-pick label{display:flex;gap:0.45rem;align-items:center;font-size:calc(var(--cmcp-fs) * 0.96);padding:0.22rem 0.3rem;
   border-radius:6px;cursor:pointer;transition:background .12s;}
 .cmcp-apps-pick label:hover{background:rgba(255,255,255,0.05);}
-.cmcp-apps-pick .grp{font-size:0.8123em;font-weight:700;opacity:0.6;margin:0.45rem 0 0.15rem;text-transform:uppercase;letter-spacing:0.05em;}
+.cmcp-apps-pick .grp{font-size:calc(var(--cmcp-fs) * 0.8123);font-weight:700;opacity:0.6;margin:0.45rem 0 0.15rem;text-transform:uppercase;letter-spacing:0.05em;}
 .cmcp-apps-pick .grp:first-child{margin-top:0.1rem;}
-.cmcp-apps-warn{font-size:0.9231em;line-height:1.45;color:#f59e0b;background:rgba(245,158,11,0.08);border:1px solid rgba(245,158,11,0.3);
+.cmcp-apps-warn{font-size:calc(var(--cmcp-fs) * 0.9231);line-height:1.45;color:#f59e0b;background:rgba(245,158,11,0.08);border:1px solid rgba(245,158,11,0.3);
   border-radius:8px;padding:0.55rem 0.65rem;}
 /* Fallback for danger buttons rendered outside .cmcp-apps-body (defensive). */
 .cmcp-btn.danger{border-color:rgba(248,113,113,0.5);color:#f87171;}
@@ -114,24 +114,21 @@ function injectStyle() {
 .cmcp-deps{display:flex;flex-direction:column;gap:0.75rem;border:1px solid var(--p-content-border-color,#3f3f46);
   border-radius:10px;padding:0.6rem 0.7rem;background:var(--p-surface-950,#111113);flex:0 0 260px;}
 .cmcp-deps-sec{display:flex;flex-direction:column;}
-.cmcp-deps-h{font-size:0.8615em;font-weight:700;opacity:0.8;text-transform:uppercase;letter-spacing:0.04em;
+.cmcp-deps-h{font-size:calc(var(--cmcp-fs) * 0.8615);font-weight:700;opacity:0.8;text-transform:uppercase;letter-spacing:0.04em;
   padding-bottom:0.25rem;}
 .cmcp-deps-row{display:flex;align-items:center;gap:0.6rem;padding:0.34rem 0.1rem;
   border-top:1px solid rgba(255,255,255,0.05);}
 .cmcp-deps-row:first-of-type{border-top:none;}
 .cmcp-deps-name{flex:1;min-width:0;display:flex;flex-direction:column;gap:0.1rem;}
-.cmcp-deps-name .n{font-size:0.9846em;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}
-.cmcp-deps-name .sub{font-size:0.8123em;opacity:0.55;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}
-.cmcp-deps-status{flex:0 0 auto;font-size:0.96em;display:flex;align-items:center;gap:0.4rem;max-width:55%;
+.cmcp-deps-name .n{font-size:calc(var(--cmcp-fs) * 0.9846);overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}
+.cmcp-deps-name .sub{font-size:calc(var(--cmcp-fs) * 0.8123);opacity:0.55;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}
+.cmcp-deps-status{flex:0 0 auto;font-size:calc(var(--cmcp-fs) * 0.96);display:flex;align-items:center;gap:0.4rem;max-width:55%;
   justify-content:flex-end;text-align:right;}
 .cmcp-deps-ok{color:var(--p-green-400,#4ade80);font-weight:600;white-space:nowrap;}
-/* #753 — parent .cmcp-deps-status is 12.48px, not the 13px root (codex). */
-.cmcp-deps-status .cmcp-btn{padding:0.28rem 0.6rem;font-size:0.9487em;}
-/* #753 — renders BOTH inside the 12.48px status element and directly in a row, so no
-   single em reproduces both. Absolute, like the other two-context rules (codex). */
-.cmcp-deps-muted{opacity:0.6;font-size:0.74rem;}
-.cmcp-deps-err{color:#f87171;font-size:0.8862em;}
-.cmcp-deps-note{font-size:0.8369em;opacity:0.6;line-height:1.4;}
+.cmcp-deps-status .cmcp-btn{padding:0.28rem 0.6rem;font-size:calc(var(--cmcp-fs) * 0.9108);}
+.cmcp-deps-muted{opacity:0.6;font-size:calc(var(--cmcp-fs) * 0.9108);}
+.cmcp-deps-err{color:#f87171;font-size:calc(var(--cmcp-fs) * 0.8862);}
+.cmcp-deps-note{font-size:calc(var(--cmcp-fs) * 0.8369);opacity:0.6;line-height:1.4;}
 .cmcp-deps-spin{width:0.85rem;height:0.85rem;flex:0 0 auto;border:2px solid rgba(255,255,255,0.22);
   border-top-color:var(--p-primary-color,#60a5fa);border-radius:50%;display:inline-block;
   animation:cmcp-deps-spin 0.7s linear infinite;}
@@ -141,11 +138,11 @@ function injectStyle() {
 .cmcp-apps-main>.grow{flex:1;min-width:0;display:flex;flex-direction:column;gap:0.75rem;}
 @media (max-width:720px){.cmcp-apps-main{flex-direction:column;}.cmcp-deps{flex:1 1 auto;width:100%;}}
 .cmcp-apps-title-row{display:flex;align-items:center;gap:0.45rem;}
-.cmcp-apps-starbtn{border:none;background:none;color:inherit;font-size:1.2923em;cursor:pointer;padding:0 0.1rem;line-height:1;}
+.cmcp-apps-starbtn{border:none;background:none;color:inherit;font-size:calc(var(--cmcp-fs) * 1.2923);cursor:pointer;padding:0 0.1rem;line-height:1;}
 .cmcp-apps-starbtn:hover{color:#facc15;}
 .cmcp-apps-starbtn.starred{color:#facc15;}
 .cmcp-apps-starbtn:disabled{opacity:0.4;cursor:default;}
-.cmcp-apps-starcount{font-size:0.96em;opacity:0.7;}
+.cmcp-apps-starcount{font-size:calc(var(--cmcp-fs) * 0.96);opacity:0.7;}
 `;
   const el = document.createElement("style");
   el.textContent = css;

--- a/web/js/cmcp-civitai-ui.js
+++ b/web/js/cmcp-civitai-ui.js
@@ -174,7 +174,8 @@ function injectCss() {
     background: transparent; color: var(--p-text-color,#fafafa); cursor: pointer;
     text-align: left; font-size: 0.96em; }
   .cmcp-cv-creator:hover { background: var(--p-surface-800,#27272a); }
-  .cmcp-cv-creator .sub { margin-left: auto; font-size: 0.8369em; flex-shrink: 0;
+  /* #753 — parent .cmcp-cv-creator is 12.48px, not the 13px root (codex). */
+  .cmcp-cv-creator .sub { margin-left: auto; font-size: 0.8718em; flex-shrink: 0;
     color: var(--p-text-muted-color,#a1a1aa); }
   .cmcp-cv-dd { position: relative; width: 100%; }
   .cmcp-cv-ddpanel { position: absolute; z-index: 6; left: 0; right: 0; top: calc(100% + .25rem);
@@ -200,7 +201,8 @@ function injectCss() {
     font-size: 0.8862em; color: var(--p-text-muted-color,#a1a1aa);
     background: var(--p-surface-900,#18181b);
     border-top: 1px solid var(--p-content-border-color,#3f3f46); }
-  .cmcp-cv-ddclear { background: transparent; border: none; cursor: pointer; font-size: 0.8862em;
+  /* #753 — sits inside the 11.52px .cmcp-cv-ddfoot, so it matches its parent (codex). */
+  .cmcp-cv-ddclear { background: transparent; border: none; cursor: pointer; font-size: 1em;
     padding: 0; color: var(--p-primary-color,#3a7bd5); }
   .cmcp-cv-lb-prompt { font-size: 0.96em; white-space: pre-wrap; word-break: break-word;
     background: var(--p-surface-950,#111); border-radius: 8px; padding: .5rem;

--- a/web/js/cmcp-civitai-ui.js
+++ b/web/js/cmcp-civitai-ui.js
@@ -1052,6 +1052,10 @@ export function createCivitaiContent(ctx, shell, opts = {}) {
     stage.addEventListener("mousedown", (e) => { if (e.target === stage) closeLb(); });
     document.addEventListener("keydown", onKey, true);
     lb.append(stage, side);
+    // #753 — mounted on <body>, OUTSIDE .cmcp-root, so `em` inside it would resolve
+    // against the page's 16px rather than the panel's 13px. Anchor the root the same way
+    // .cmcp-root is anchored, in rem, so everything below renders as written.
+    lb.style.fontSize = "0.8125rem";
     document.body.appendChild(lb);
     lb.focus();
     render();

--- a/web/js/cmcp-civitai-ui.js
+++ b/web/js/cmcp-civitai-ui.js
@@ -86,12 +86,12 @@ function injectCss() {
     background: var(--p-surface-900, #18181b); aspect-ratio: .72; }
   .cmcp-cv-card img, .cmcp-cv-card video { width: 100%; height: 100%; object-fit: cover; display: block; }
   .cmcp-cv-cardfoot { position: absolute; left: 0; right: 0; bottom: 0; padding: .3rem .4rem;
-    font-size: calc(var(--cmcp-fs) * 0.8615); color: #fff; background: linear-gradient(transparent, rgba(0,0,0,.75)); }
+    font-size: calc(var(--cmcp-fs, 0.8125rem) * 0.8615); color: #fff; background: linear-gradient(transparent, rgba(0,0,0,.75)); }
   .cmcp-cv-badge { position: absolute; top: .3rem; left: .3rem; background: rgba(0,0,0,.6); color:#fff;
-    font-size: calc(var(--cmcp-fs) * 0.7385); padding: .1rem .3rem; border-radius: 4px; }
+    font-size: calc(var(--cmcp-fs, 0.8125rem) * 0.7385); padding: .1rem .3rem; border-radius: 4px; }
   /* Rating badge (top-right), colour-coded by browsing level. */
   .cmcp-cv-rating { position: absolute; top: .3rem; right: .3rem; z-index: 2; color:#fff;
-    font-size: calc(var(--cmcp-fs) * 0.7138); font-weight: 700; letter-spacing: .02em; padding: .1rem .32rem;
+    font-size: calc(var(--cmcp-fs, 0.8125rem) * 0.7138); font-weight: 700; letter-spacing: .02em; padding: .1rem .32rem;
     border-radius: 4px; text-shadow: 0 1px 2px rgba(0,0,0,.55); }
   .cmcp-cv-rating--pg   { background: #16a34a; } /* PG    → green  */
   .cmcp-cv-rating--pg13 { background: #2563eb; } /* PG-13 → blue   */
@@ -102,14 +102,14 @@ function injectCss() {
   .cmcp-cv-card.cmcp-cv-gated { background: #000; }
   .cmcp-cv-lb-stage.cmcp-cv-gated { background: #000; }
   .cmcp-cv-gatedlabel { position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%);
-    background: rgba(0,0,0,.6); color: #fff; font-weight: 700; font-size: calc(var(--cmcp-fs) * 1.1692); letter-spacing: .06em;
+    background: rgba(0,0,0,.6); color: #fff; font-weight: 700; font-size: calc(var(--cmcp-fs, 0.8125rem) * 1.1692); letter-spacing: .06em;
     padding: .28rem .6rem; border-radius: 6px; border: 1px solid var(--p-content-border-color,#3f3f46);
     pointer-events: none; }
-  .cmcp-cv-lb-stage .cmcp-cv-gatedlabel { font-size: calc(var(--cmcp-fs) * 2.4615); padding: .5rem 1.2rem; }
+  .cmcp-cv-lb-stage .cmcp-cv-gatedlabel { font-size: calc(var(--cmcp-fs, 0.8125rem) * 2.4615); padding: .5rem 1.2rem; }
   .cmcp-cv-add { position: absolute; top: .3rem; right: .3rem; background: rgba(0,0,0,.55); color:#fff;
     border: none; border-radius: 6px; width: 24px; height: 24px; cursor: pointer; }
   .cmcp-cv-owned { position: absolute; top: .3rem; right: .3rem; background: rgba(34,197,94,.92);
-    color: #04120a; font-size: calc(var(--cmcp-fs) * 0.7385); font-weight: 700; padding: .12rem .35rem; border-radius: 4px; }
+    color: #04120a; font-size: calc(var(--cmcp-fs, 0.8125rem) * 0.7385); font-weight: 700; padding: .12rem .35rem; border-radius: 4px; }
   .cmcp-cv-loading { text-align: center; padding: 1rem; color: var(--p-text-muted-color,#a1a1aa); }
   .cmcp-cv-progress { position: absolute; top: 0; left: 0; right: 0; height: 2px;
     background: var(--p-primary-color, #3a7bd5); opacity: .0; transition: opacity .2s; }
@@ -117,14 +117,14 @@ function injectCss() {
   @keyframes cmcp-cv-pulse { 0%,100%{opacity:.3} 50%{opacity:1} }
   .cmcp-cv-filters { display: flex; flex-direction: column; gap: .7rem; }
   .cmcp-cv-frow { display: flex; flex-wrap: wrap; gap: .3rem; align-items: center; }
-  .cmcp-cv-chip { padding: .25rem .5rem; border-radius: 999px; font-size: calc(var(--cmcp-fs) * 0.9231); cursor: pointer;
+  .cmcp-cv-chip { padding: .25rem .5rem; border-radius: 999px; font-size: calc(var(--cmcp-fs, 0.8125rem) * 0.9231); cursor: pointer;
     border: 1px solid var(--p-content-border-color,#3f3f46); background: transparent; color: var(--p-text-color,#fafafa); }
   .cmcp-cv-chip.on { background: var(--p-primary-color,#3a7bd5); border-color: transparent; color:#fff; }
-  .cmcp-cv-flabel { font-size: calc(var(--cmcp-fs) * 0.8615); text-transform: uppercase; letter-spacing: .04em;
+  .cmcp-cv-flabel { font-size: calc(var(--cmcp-fs, 0.8125rem) * 0.8615); text-transform: uppercase; letter-spacing: .04em;
     color: var(--p-text-muted-color,#a1a1aa); width: 100%; }
   .cmcp-cv-detail img, .cmcp-cv-detail video { border-radius: 8px; }
   .cmcp-cv-actions { display: flex; gap: .4rem; flex-wrap: wrap; margin-top: .5rem; }
-  .cmcp-cv-wfstatus { margin-top: .5rem; padding: .45rem .6rem; border-radius: 8px; font-size: calc(var(--cmcp-fs) * 0.96);
+  .cmcp-cv-wfstatus { margin-top: .5rem; padding: .45rem .6rem; border-radius: 8px; font-size: calc(var(--cmcp-fs, 0.8125rem) * 0.96);
     line-height: 1.35; background: var(--p-surface-800,#27272a); color: var(--p-text-color,#fafafa);
     border: 1px solid var(--p-content-border-color,#3f3f46); }
   .cmcp-cv-wfstatus.warn { border-color: #d97706; color: #fcd34d; }
@@ -134,7 +134,7 @@ function injectCss() {
   .cmcp-cv-viewer img, .cmcp-cv-viewer video { max-width: 100%; max-height: 100%; object-fit: contain; }
   .cmcp-cv-vtop { position: absolute; top: .5rem; right: .5rem; display: flex; gap: .4rem; z-index: 6; }
   .cmcp-cv-triggers { display: flex; flex-wrap: wrap; gap: .3rem; margin: .4rem 0; }
-  .cmcp-cv-trigger { font-size: calc(var(--cmcp-fs) * 0.8862); padding: .15rem .4rem; border-radius: 6px;
+  .cmcp-cv-trigger { font-size: calc(var(--cmcp-fs, 0.8125rem) * 0.8862); padding: .15rem .4rem; border-radius: 6px;
     background: var(--p-surface-800,#27272a); color: var(--p-text-color,#fafafa); }
   .cmcp-cv-lb { position: fixed; inset: 0; z-index: 10002; display: flex;
     background: rgba(0,0,0,.96); outline: none; }
@@ -146,10 +146,10 @@ function injectCss() {
     color: var(--p-text-color,#fafafa); display: flex; flex-direction: column; gap: .6rem; }
   .cmcp-cv-lb-nav { position: absolute; top: 50%; transform: translateY(-50%);
     background: rgba(0,0,0,.5); border: none; color: #fff; border-radius: 999px;
-    width: 40px; height: 40px; cursor: pointer; font-size: calc(var(--cmcp-fs) * 1.2308); z-index: 3; }
+    width: 40px; height: 40px; cursor: pointer; font-size: calc(var(--cmcp-fs, 0.8125rem) * 1.2308); z-index: 3; }
   .cmcp-cv-lb-nav:hover { background: rgba(0,0,0,.8); }
   .cmcp-cv-lb-close { position: absolute; top: .6rem; right: .6rem; z-index: 3; }
-  .cmcp-cv-lb-title { font-size: calc(var(--cmcp-fs) * 1.1077); font-weight: 600; display: flex; align-items: center;
+  .cmcp-cv-lb-title { font-size: calc(var(--cmcp-fs, 0.8125rem) * 1.1077); font-weight: 600; display: flex; align-items: center;
     gap: .5rem; padding-right: 2.2rem; }
   .cmcp-cv-like { margin-left: auto; }
   .cmcp-cv-like.on { color: #f43f5e; border-color: #f43f5e; }
@@ -166,15 +166,15 @@ function injectCss() {
     border: 3px solid rgba(255,255,255,.25); border-top-color: var(--p-primary-color,#3a7bd5);
     animation: cmcp-cv-spin .8s linear infinite; }
   @keyframes cmcp-cv-spin { to { transform: rotate(360deg); } }
-  .cmcp-cv-lb-muted { font-size: calc(var(--cmcp-fs) * 0.9108); color: var(--p-text-muted-color,#a1a1aa); }
+  .cmcp-cv-lb-muted { font-size: calc(var(--cmcp-fs, 0.8125rem) * 0.9108); color: var(--p-text-muted-color,#a1a1aa); }
   .cmcp-cv-creators { display: flex; flex-direction: column; gap: .2rem; width: 100%;
     max-height: 13rem; overflow-y: auto; }
   .cmcp-cv-creator { display: flex; align-items: baseline; gap: .5rem; padding: .3rem .5rem;
     border-radius: 8px; border: 1px solid var(--p-content-border-color,#3f3f46);
     background: transparent; color: var(--p-text-color,#fafafa); cursor: pointer;
-    text-align: left; font-size: calc(var(--cmcp-fs) * 0.96); }
+    text-align: left; font-size: calc(var(--cmcp-fs, 0.8125rem) * 0.96); }
   .cmcp-cv-creator:hover { background: var(--p-surface-800,#27272a); }
-  .cmcp-cv-creator .sub { margin-left: auto; font-size: calc(var(--cmcp-fs) * 0.8369); flex-shrink: 0;
+  .cmcp-cv-creator .sub { margin-left: auto; font-size: calc(var(--cmcp-fs, 0.8125rem) * 0.8369); flex-shrink: 0;
     color: var(--p-text-muted-color,#a1a1aa); }
   .cmcp-cv-dd { position: relative; width: 100%; }
   .cmcp-cv-ddpanel { position: absolute; z-index: 6; left: 0; right: 0; top: calc(100% + .25rem);
@@ -185,28 +185,28 @@ function injectCss() {
     box-shadow: 0 8px 24px rgba(0,0,0,.45); }
   .cmcp-cv-dd.open .cmcp-cv-ddpanel { display: flex; }
   .cmcp-cv-ddlist, .cmcp-cv-ddgroupwrap { display: flex; flex-direction: column; gap: .1rem; }
-  .cmcp-cv-ddgroup { font-size: calc(var(--cmcp-fs) * 0.7877); text-transform: uppercase; letter-spacing: .05em;
+  .cmcp-cv-ddgroup { font-size: calc(var(--cmcp-fs, 0.8125rem) * 0.7877); text-transform: uppercase; letter-spacing: .05em;
     color: var(--p-text-muted-color,#a1a1aa); padding: .35rem .5rem .15rem; }
   .cmcp-cv-ddopt { display: flex; align-items: center; gap: .45rem; padding: .3rem .5rem;
     border: none; border-radius: 6px; background: transparent; cursor: pointer;
-    color: var(--p-text-color,#fafafa); font-size: calc(var(--cmcp-fs) * 0.96); text-align: left; width: 100%; }
+    color: var(--p-text-color,#fafafa); font-size: calc(var(--cmcp-fs, 0.8125rem) * 0.96); text-align: left; width: 100%; }
   .cmcp-cv-ddopt:hover, .cmcp-cv-ddopt.active { background: var(--p-surface-800,#27272a); }
   .cmcp-cv-ddopt .tick { width: .9rem; flex-shrink: 0; opacity: 0; }
   .cmcp-cv-ddopt.on .tick { opacity: 1; color: var(--p-primary-color,#3a7bd5); }
-  .cmcp-cv-ddempty { padding: .4rem .5rem; font-size: calc(var(--cmcp-fs) * 0.9108);
+  .cmcp-cv-ddempty { padding: .4rem .5rem; font-size: calc(var(--cmcp-fs, 0.8125rem) * 0.9108);
     color: var(--p-text-muted-color,#a1a1aa); }
   .cmcp-cv-ddfoot { position: sticky; bottom: -.25rem; display: flex; align-items: center;
     justify-content: space-between; gap: .5rem; margin-top: .15rem; padding: .35rem .5rem;
-    font-size: calc(var(--cmcp-fs) * 0.8862); color: var(--p-text-muted-color,#a1a1aa);
+    font-size: calc(var(--cmcp-fs, 0.8125rem) * 0.8862); color: var(--p-text-muted-color,#a1a1aa);
     background: var(--p-surface-900,#18181b);
     border-top: 1px solid var(--p-content-border-color,#3f3f46); }
-  .cmcp-cv-ddclear { background: transparent; border: none; cursor: pointer; font-size: calc(var(--cmcp-fs) * 0.8862);
+  .cmcp-cv-ddclear { background: transparent; border: none; cursor: pointer; font-size: calc(var(--cmcp-fs, 0.8125rem) * 0.8862);
     padding: 0; color: var(--p-primary-color,#3a7bd5); }
-  .cmcp-cv-lb-prompt { font-size: calc(var(--cmcp-fs) * 0.96); white-space: pre-wrap; word-break: break-word;
+  .cmcp-cv-lb-prompt { font-size: calc(var(--cmcp-fs, 0.8125rem) * 0.96); white-space: pre-wrap; word-break: break-word;
     background: var(--p-surface-950,#111); border-radius: 8px; padding: .5rem;
     max-height: 14rem; overflow-y: auto; }
   .cmcp-cv-lb-params { display: grid; grid-template-columns: max-content 1fr; gap: .15rem .6rem;
-    font-size: calc(var(--cmcp-fs) * 0.9108); }
+    font-size: calc(var(--cmcp-fs, 0.8125rem) * 0.9108); }
   .cmcp-cv-lb-params .k { color: var(--p-text-muted-color,#a1a1aa); }
   @media (max-width: 760px) { .cmcp-cv-lb { flex-direction: column; }
     .cmcp-cv-lb-side { flex: 0 0 45%; max-width: none; border-left: none;
@@ -1095,12 +1095,12 @@ export function createCivitaiContent(ctx, shell, opts = {}) {
     sheet.body.appendChild(actions);
 
     for (const [k, val] of CivitaiClient.params(gen.meta)) {
-      const row = el("div"); row.style.cssText = "font-size:calc(var(--cmcp-fs) * 0.96);margin-top:.2rem";
+      const row = el("div"); row.style.cssText = "font-size:calc(var(--cmcp-fs, 0.8125rem) * 0.96);margin-top:.2rem";
       row.textContent = `${k}: ${val}`;
       sheet.body.appendChild(row);
     }
     if (gen.meta?.prompt) {
-      const p = el("div"); p.style.cssText = "font-size:calc(var(--cmcp-fs) * 0.96);margin-top:.5rem;white-space:pre-wrap";
+      const p = el("div"); p.style.cssText = "font-size:calc(var(--cmcp-fs, 0.8125rem) * 0.96);margin-top:.5rem;white-space:pre-wrap";
       p.textContent = "Prompt: " + coerceMessageText(gen.meta.prompt); sheet.body.appendChild(p);
     }
   }
@@ -1361,7 +1361,7 @@ export function createCivitaiContent(ctx, shell, opts = {}) {
       }
       if (have) {
         const note = el("span", null, "You already have this file locally.");
-        note.style.cssText = "font-size:calc(var(--cmcp-fs) * 0.8862);color:#4ade80;align-self:center";
+        note.style.cssText = "font-size:calc(var(--cmcp-fs, 0.8125rem) * 0.8862);color:#4ade80;align-self:center";
         dl.appendChild(note);
       }
       if (detail.creator) {
@@ -1376,7 +1376,7 @@ export function createCivitaiContent(ctx, shell, opts = {}) {
       if (wfFiles.length) detailBody.appendChild(wfStatus);
       if (version.descriptionHtml || detail.descriptionHtml) {
         const desc = el("div", "cmcp-cv-detail");
-        desc.style.cssText = "font-size:calc(var(--cmcp-fs) * 0.96);margin-top:.5rem";
+        desc.style.cssText = "font-size:calc(var(--cmcp-fs, 0.8125rem) * 0.96);margin-top:.5rem";
         // CivitAI descriptions are HTML — sanitize and render directly.
         desc.innerHTML = ctx.DOMPurify.sanitize(version.descriptionHtml || detail.descriptionHtml || "");
         detailBody.appendChild(desc);

--- a/web/js/cmcp-civitai-ui.js
+++ b/web/js/cmcp-civitai-ui.js
@@ -86,12 +86,12 @@ function injectCss() {
     background: var(--p-surface-900, #18181b); aspect-ratio: .72; }
   .cmcp-cv-card img, .cmcp-cv-card video { width: 100%; height: 100%; object-fit: cover; display: block; }
   .cmcp-cv-cardfoot { position: absolute; left: 0; right: 0; bottom: 0; padding: .3rem .4rem;
-    font-size: 0.8615em; color: #fff; background: linear-gradient(transparent, rgba(0,0,0,.75)); }
+    font-size: calc(var(--cmcp-fs) * 0.8615); color: #fff; background: linear-gradient(transparent, rgba(0,0,0,.75)); }
   .cmcp-cv-badge { position: absolute; top: .3rem; left: .3rem; background: rgba(0,0,0,.6); color:#fff;
-    font-size: 0.7385em; padding: .1rem .3rem; border-radius: 4px; }
+    font-size: calc(var(--cmcp-fs) * 0.7385); padding: .1rem .3rem; border-radius: 4px; }
   /* Rating badge (top-right), colour-coded by browsing level. */
   .cmcp-cv-rating { position: absolute; top: .3rem; right: .3rem; z-index: 2; color:#fff;
-    font-size: 0.7138em; font-weight: 700; letter-spacing: .02em; padding: .1rem .32rem;
+    font-size: calc(var(--cmcp-fs) * 0.7138); font-weight: 700; letter-spacing: .02em; padding: .1rem .32rem;
     border-radius: 4px; text-shadow: 0 1px 2px rgba(0,0,0,.55); }
   .cmcp-cv-rating--pg   { background: #16a34a; } /* PG    → green  */
   .cmcp-cv-rating--pg13 { background: #2563eb; } /* PG-13 → blue   */
@@ -102,14 +102,14 @@ function injectCss() {
   .cmcp-cv-card.cmcp-cv-gated { background: #000; }
   .cmcp-cv-lb-stage.cmcp-cv-gated { background: #000; }
   .cmcp-cv-gatedlabel { position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%);
-    background: rgba(0,0,0,.6); color: #fff; font-weight: 700; font-size: 1.1692em; letter-spacing: .06em;
+    background: rgba(0,0,0,.6); color: #fff; font-weight: 700; font-size: calc(var(--cmcp-fs) * 1.1692); letter-spacing: .06em;
     padding: .28rem .6rem; border-radius: 6px; border: 1px solid var(--p-content-border-color,#3f3f46);
     pointer-events: none; }
-  .cmcp-cv-lb-stage .cmcp-cv-gatedlabel { font-size: 2.4615em; padding: .5rem 1.2rem; }
+  .cmcp-cv-lb-stage .cmcp-cv-gatedlabel { font-size: calc(var(--cmcp-fs) * 2.4615); padding: .5rem 1.2rem; }
   .cmcp-cv-add { position: absolute; top: .3rem; right: .3rem; background: rgba(0,0,0,.55); color:#fff;
     border: none; border-radius: 6px; width: 24px; height: 24px; cursor: pointer; }
   .cmcp-cv-owned { position: absolute; top: .3rem; right: .3rem; background: rgba(34,197,94,.92);
-    color: #04120a; font-size: 0.7385em; font-weight: 700; padding: .12rem .35rem; border-radius: 4px; }
+    color: #04120a; font-size: calc(var(--cmcp-fs) * 0.7385); font-weight: 700; padding: .12rem .35rem; border-radius: 4px; }
   .cmcp-cv-loading { text-align: center; padding: 1rem; color: var(--p-text-muted-color,#a1a1aa); }
   .cmcp-cv-progress { position: absolute; top: 0; left: 0; right: 0; height: 2px;
     background: var(--p-primary-color, #3a7bd5); opacity: .0; transition: opacity .2s; }
@@ -117,14 +117,14 @@ function injectCss() {
   @keyframes cmcp-cv-pulse { 0%,100%{opacity:.3} 50%{opacity:1} }
   .cmcp-cv-filters { display: flex; flex-direction: column; gap: .7rem; }
   .cmcp-cv-frow { display: flex; flex-wrap: wrap; gap: .3rem; align-items: center; }
-  .cmcp-cv-chip { padding: .25rem .5rem; border-radius: 999px; font-size: 0.9231em; cursor: pointer;
+  .cmcp-cv-chip { padding: .25rem .5rem; border-radius: 999px; font-size: calc(var(--cmcp-fs) * 0.9231); cursor: pointer;
     border: 1px solid var(--p-content-border-color,#3f3f46); background: transparent; color: var(--p-text-color,#fafafa); }
   .cmcp-cv-chip.on { background: var(--p-primary-color,#3a7bd5); border-color: transparent; color:#fff; }
-  .cmcp-cv-flabel { font-size: 0.8615em; text-transform: uppercase; letter-spacing: .04em;
+  .cmcp-cv-flabel { font-size: calc(var(--cmcp-fs) * 0.8615); text-transform: uppercase; letter-spacing: .04em;
     color: var(--p-text-muted-color,#a1a1aa); width: 100%; }
   .cmcp-cv-detail img, .cmcp-cv-detail video { border-radius: 8px; }
   .cmcp-cv-actions { display: flex; gap: .4rem; flex-wrap: wrap; margin-top: .5rem; }
-  .cmcp-cv-wfstatus { margin-top: .5rem; padding: .45rem .6rem; border-radius: 8px; font-size: 0.96em;
+  .cmcp-cv-wfstatus { margin-top: .5rem; padding: .45rem .6rem; border-radius: 8px; font-size: calc(var(--cmcp-fs) * 0.96);
     line-height: 1.35; background: var(--p-surface-800,#27272a); color: var(--p-text-color,#fafafa);
     border: 1px solid var(--p-content-border-color,#3f3f46); }
   .cmcp-cv-wfstatus.warn { border-color: #d97706; color: #fcd34d; }
@@ -134,7 +134,7 @@ function injectCss() {
   .cmcp-cv-viewer img, .cmcp-cv-viewer video { max-width: 100%; max-height: 100%; object-fit: contain; }
   .cmcp-cv-vtop { position: absolute; top: .5rem; right: .5rem; display: flex; gap: .4rem; z-index: 6; }
   .cmcp-cv-triggers { display: flex; flex-wrap: wrap; gap: .3rem; margin: .4rem 0; }
-  .cmcp-cv-trigger { font-size: 0.8862em; padding: .15rem .4rem; border-radius: 6px;
+  .cmcp-cv-trigger { font-size: calc(var(--cmcp-fs) * 0.8862); padding: .15rem .4rem; border-radius: 6px;
     background: var(--p-surface-800,#27272a); color: var(--p-text-color,#fafafa); }
   .cmcp-cv-lb { position: fixed; inset: 0; z-index: 10002; display: flex;
     background: rgba(0,0,0,.96); outline: none; }
@@ -146,10 +146,10 @@ function injectCss() {
     color: var(--p-text-color,#fafafa); display: flex; flex-direction: column; gap: .6rem; }
   .cmcp-cv-lb-nav { position: absolute; top: 50%; transform: translateY(-50%);
     background: rgba(0,0,0,.5); border: none; color: #fff; border-radius: 999px;
-    width: 40px; height: 40px; cursor: pointer; font-size: 1.2308em; z-index: 3; }
+    width: 40px; height: 40px; cursor: pointer; font-size: calc(var(--cmcp-fs) * 1.2308); z-index: 3; }
   .cmcp-cv-lb-nav:hover { background: rgba(0,0,0,.8); }
   .cmcp-cv-lb-close { position: absolute; top: .6rem; right: .6rem; z-index: 3; }
-  .cmcp-cv-lb-title { font-size: 1.1077em; font-weight: 600; display: flex; align-items: center;
+  .cmcp-cv-lb-title { font-size: calc(var(--cmcp-fs) * 1.1077); font-weight: 600; display: flex; align-items: center;
     gap: .5rem; padding-right: 2.2rem; }
   .cmcp-cv-like { margin-left: auto; }
   .cmcp-cv-like.on { color: #f43f5e; border-color: #f43f5e; }
@@ -166,16 +166,15 @@ function injectCss() {
     border: 3px solid rgba(255,255,255,.25); border-top-color: var(--p-primary-color,#3a7bd5);
     animation: cmcp-cv-spin .8s linear infinite; }
   @keyframes cmcp-cv-spin { to { transform: rotate(360deg); } }
-  .cmcp-cv-lb-muted { font-size: 0.9108em; color: var(--p-text-muted-color,#a1a1aa); }
+  .cmcp-cv-lb-muted { font-size: calc(var(--cmcp-fs) * 0.9108); color: var(--p-text-muted-color,#a1a1aa); }
   .cmcp-cv-creators { display: flex; flex-direction: column; gap: .2rem; width: 100%;
     max-height: 13rem; overflow-y: auto; }
   .cmcp-cv-creator { display: flex; align-items: baseline; gap: .5rem; padding: .3rem .5rem;
     border-radius: 8px; border: 1px solid var(--p-content-border-color,#3f3f46);
     background: transparent; color: var(--p-text-color,#fafafa); cursor: pointer;
-    text-align: left; font-size: 0.96em; }
+    text-align: left; font-size: calc(var(--cmcp-fs) * 0.96); }
   .cmcp-cv-creator:hover { background: var(--p-surface-800,#27272a); }
-  /* #753 — parent .cmcp-cv-creator is 12.48px, not the 13px root (codex). */
-  .cmcp-cv-creator .sub { margin-left: auto; font-size: 0.8718em; flex-shrink: 0;
+  .cmcp-cv-creator .sub { margin-left: auto; font-size: calc(var(--cmcp-fs) * 0.8369); flex-shrink: 0;
     color: var(--p-text-muted-color,#a1a1aa); }
   .cmcp-cv-dd { position: relative; width: 100%; }
   .cmcp-cv-ddpanel { position: absolute; z-index: 6; left: 0; right: 0; top: calc(100% + .25rem);
@@ -186,29 +185,28 @@ function injectCss() {
     box-shadow: 0 8px 24px rgba(0,0,0,.45); }
   .cmcp-cv-dd.open .cmcp-cv-ddpanel { display: flex; }
   .cmcp-cv-ddlist, .cmcp-cv-ddgroupwrap { display: flex; flex-direction: column; gap: .1rem; }
-  .cmcp-cv-ddgroup { font-size: 0.7877em; text-transform: uppercase; letter-spacing: .05em;
+  .cmcp-cv-ddgroup { font-size: calc(var(--cmcp-fs) * 0.7877); text-transform: uppercase; letter-spacing: .05em;
     color: var(--p-text-muted-color,#a1a1aa); padding: .35rem .5rem .15rem; }
   .cmcp-cv-ddopt { display: flex; align-items: center; gap: .45rem; padding: .3rem .5rem;
     border: none; border-radius: 6px; background: transparent; cursor: pointer;
-    color: var(--p-text-color,#fafafa); font-size: 0.96em; text-align: left; width: 100%; }
+    color: var(--p-text-color,#fafafa); font-size: calc(var(--cmcp-fs) * 0.96); text-align: left; width: 100%; }
   .cmcp-cv-ddopt:hover, .cmcp-cv-ddopt.active { background: var(--p-surface-800,#27272a); }
   .cmcp-cv-ddopt .tick { width: .9rem; flex-shrink: 0; opacity: 0; }
   .cmcp-cv-ddopt.on .tick { opacity: 1; color: var(--p-primary-color,#3a7bd5); }
-  .cmcp-cv-ddempty { padding: .4rem .5rem; font-size: 0.9108em;
+  .cmcp-cv-ddempty { padding: .4rem .5rem; font-size: calc(var(--cmcp-fs) * 0.9108);
     color: var(--p-text-muted-color,#a1a1aa); }
   .cmcp-cv-ddfoot { position: sticky; bottom: -.25rem; display: flex; align-items: center;
     justify-content: space-between; gap: .5rem; margin-top: .15rem; padding: .35rem .5rem;
-    font-size: 0.8862em; color: var(--p-text-muted-color,#a1a1aa);
+    font-size: calc(var(--cmcp-fs) * 0.8862); color: var(--p-text-muted-color,#a1a1aa);
     background: var(--p-surface-900,#18181b);
     border-top: 1px solid var(--p-content-border-color,#3f3f46); }
-  /* #753 — sits inside the 11.52px .cmcp-cv-ddfoot, so it matches its parent (codex). */
-  .cmcp-cv-ddclear { background: transparent; border: none; cursor: pointer; font-size: 1em;
+  .cmcp-cv-ddclear { background: transparent; border: none; cursor: pointer; font-size: calc(var(--cmcp-fs) * 0.8862);
     padding: 0; color: var(--p-primary-color,#3a7bd5); }
-  .cmcp-cv-lb-prompt { font-size: 0.96em; white-space: pre-wrap; word-break: break-word;
+  .cmcp-cv-lb-prompt { font-size: calc(var(--cmcp-fs) * 0.96); white-space: pre-wrap; word-break: break-word;
     background: var(--p-surface-950,#111); border-radius: 8px; padding: .5rem;
     max-height: 14rem; overflow-y: auto; }
   .cmcp-cv-lb-params { display: grid; grid-template-columns: max-content 1fr; gap: .15rem .6rem;
-    font-size: 0.9108em; }
+    font-size: calc(var(--cmcp-fs) * 0.9108); }
   .cmcp-cv-lb-params .k { color: var(--p-text-muted-color,#a1a1aa); }
   @media (max-width: 760px) { .cmcp-cv-lb { flex-direction: column; }
     .cmcp-cv-lb-side { flex: 0 0 45%; max-width: none; border-left: none;
@@ -1054,10 +1052,6 @@ export function createCivitaiContent(ctx, shell, opts = {}) {
     stage.addEventListener("mousedown", (e) => { if (e.target === stage) closeLb(); });
     document.addEventListener("keydown", onKey, true);
     lb.append(stage, side);
-    // #753 — mounted on <body>, OUTSIDE .cmcp-root, so `em` inside it would resolve
-    // against the page's 16px rather than the panel's 13px. Anchor the root the same way
-    // .cmcp-root is anchored, in rem, so everything below renders as written.
-    lb.style.fontSize = "0.8125rem";
     document.body.appendChild(lb);
     lb.focus();
     render();
@@ -1101,12 +1095,12 @@ export function createCivitaiContent(ctx, shell, opts = {}) {
     sheet.body.appendChild(actions);
 
     for (const [k, val] of CivitaiClient.params(gen.meta)) {
-      const row = el("div"); row.style.cssText = "font-size:0.96em;margin-top:.2rem";
+      const row = el("div"); row.style.cssText = "font-size:calc(var(--cmcp-fs) * 0.96);margin-top:.2rem";
       row.textContent = `${k}: ${val}`;
       sheet.body.appendChild(row);
     }
     if (gen.meta?.prompt) {
-      const p = el("div"); p.style.cssText = "font-size:0.96em;margin-top:.5rem;white-space:pre-wrap";
+      const p = el("div"); p.style.cssText = "font-size:calc(var(--cmcp-fs) * 0.96);margin-top:.5rem;white-space:pre-wrap";
       p.textContent = "Prompt: " + coerceMessageText(gen.meta.prompt); sheet.body.appendChild(p);
     }
   }
@@ -1367,7 +1361,7 @@ export function createCivitaiContent(ctx, shell, opts = {}) {
       }
       if (have) {
         const note = el("span", null, "You already have this file locally.");
-        note.style.cssText = "font-size:0.8862em;color:#4ade80;align-self:center";
+        note.style.cssText = "font-size:calc(var(--cmcp-fs) * 0.8862);color:#4ade80;align-self:center";
         dl.appendChild(note);
       }
       if (detail.creator) {
@@ -1382,7 +1376,7 @@ export function createCivitaiContent(ctx, shell, opts = {}) {
       if (wfFiles.length) detailBody.appendChild(wfStatus);
       if (version.descriptionHtml || detail.descriptionHtml) {
         const desc = el("div", "cmcp-cv-detail");
-        desc.style.cssText = "font-size:0.96em;margin-top:.5rem";
+        desc.style.cssText = "font-size:calc(var(--cmcp-fs) * 0.96);margin-top:.5rem";
         // CivitAI descriptions are HTML — sanitize and render directly.
         desc.innerHTML = ctx.DOMPurify.sanitize(version.descriptionHtml || detail.descriptionHtml || "");
         detailBody.appendChild(desc);

--- a/web/js/cmcp-civitai-ui.js
+++ b/web/js/cmcp-civitai-ui.js
@@ -86,12 +86,12 @@ function injectCss() {
     background: var(--p-surface-900, #18181b); aspect-ratio: .72; }
   .cmcp-cv-card img, .cmcp-cv-card video { width: 100%; height: 100%; object-fit: cover; display: block; }
   .cmcp-cv-cardfoot { position: absolute; left: 0; right: 0; bottom: 0; padding: .3rem .4rem;
-    font-size: .7rem; color: #fff; background: linear-gradient(transparent, rgba(0,0,0,.75)); }
+    font-size: 0.8615em; color: #fff; background: linear-gradient(transparent, rgba(0,0,0,.75)); }
   .cmcp-cv-badge { position: absolute; top: .3rem; left: .3rem; background: rgba(0,0,0,.6); color:#fff;
-    font-size: .6rem; padding: .1rem .3rem; border-radius: 4px; }
+    font-size: 0.7385em; padding: .1rem .3rem; border-radius: 4px; }
   /* Rating badge (top-right), colour-coded by browsing level. */
   .cmcp-cv-rating { position: absolute; top: .3rem; right: .3rem; z-index: 2; color:#fff;
-    font-size: .58rem; font-weight: 700; letter-spacing: .02em; padding: .1rem .32rem;
+    font-size: 0.7138em; font-weight: 700; letter-spacing: .02em; padding: .1rem .32rem;
     border-radius: 4px; text-shadow: 0 1px 2px rgba(0,0,0,.55); }
   .cmcp-cv-rating--pg   { background: #16a34a; } /* PG    → green  */
   .cmcp-cv-rating--pg13 { background: #2563eb; } /* PG-13 → blue   */
@@ -102,14 +102,14 @@ function injectCss() {
   .cmcp-cv-card.cmcp-cv-gated { background: #000; }
   .cmcp-cv-lb-stage.cmcp-cv-gated { background: #000; }
   .cmcp-cv-gatedlabel { position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%);
-    background: rgba(0,0,0,.6); color: #fff; font-weight: 700; font-size: .95rem; letter-spacing: .06em;
+    background: rgba(0,0,0,.6); color: #fff; font-weight: 700; font-size: 1.1692em; letter-spacing: .06em;
     padding: .28rem .6rem; border-radius: 6px; border: 1px solid var(--p-content-border-color,#3f3f46);
     pointer-events: none; }
-  .cmcp-cv-lb-stage .cmcp-cv-gatedlabel { font-size: 2rem; padding: .5rem 1.2rem; }
+  .cmcp-cv-lb-stage .cmcp-cv-gatedlabel { font-size: 2.4615em; padding: .5rem 1.2rem; }
   .cmcp-cv-add { position: absolute; top: .3rem; right: .3rem; background: rgba(0,0,0,.55); color:#fff;
     border: none; border-radius: 6px; width: 24px; height: 24px; cursor: pointer; }
   .cmcp-cv-owned { position: absolute; top: .3rem; right: .3rem; background: rgba(34,197,94,.92);
-    color: #04120a; font-size: .6rem; font-weight: 700; padding: .12rem .35rem; border-radius: 4px; }
+    color: #04120a; font-size: 0.7385em; font-weight: 700; padding: .12rem .35rem; border-radius: 4px; }
   .cmcp-cv-loading { text-align: center; padding: 1rem; color: var(--p-text-muted-color,#a1a1aa); }
   .cmcp-cv-progress { position: absolute; top: 0; left: 0; right: 0; height: 2px;
     background: var(--p-primary-color, #3a7bd5); opacity: .0; transition: opacity .2s; }
@@ -117,14 +117,14 @@ function injectCss() {
   @keyframes cmcp-cv-pulse { 0%,100%{opacity:.3} 50%{opacity:1} }
   .cmcp-cv-filters { display: flex; flex-direction: column; gap: .7rem; }
   .cmcp-cv-frow { display: flex; flex-wrap: wrap; gap: .3rem; align-items: center; }
-  .cmcp-cv-chip { padding: .25rem .5rem; border-radius: 999px; font-size: .75rem; cursor: pointer;
+  .cmcp-cv-chip { padding: .25rem .5rem; border-radius: 999px; font-size: 0.9231em; cursor: pointer;
     border: 1px solid var(--p-content-border-color,#3f3f46); background: transparent; color: var(--p-text-color,#fafafa); }
   .cmcp-cv-chip.on { background: var(--p-primary-color,#3a7bd5); border-color: transparent; color:#fff; }
-  .cmcp-cv-flabel { font-size: .7rem; text-transform: uppercase; letter-spacing: .04em;
+  .cmcp-cv-flabel { font-size: 0.8615em; text-transform: uppercase; letter-spacing: .04em;
     color: var(--p-text-muted-color,#a1a1aa); width: 100%; }
   .cmcp-cv-detail img, .cmcp-cv-detail video { border-radius: 8px; }
   .cmcp-cv-actions { display: flex; gap: .4rem; flex-wrap: wrap; margin-top: .5rem; }
-  .cmcp-cv-wfstatus { margin-top: .5rem; padding: .45rem .6rem; border-radius: 8px; font-size: .78rem;
+  .cmcp-cv-wfstatus { margin-top: .5rem; padding: .45rem .6rem; border-radius: 8px; font-size: 0.96em;
     line-height: 1.35; background: var(--p-surface-800,#27272a); color: var(--p-text-color,#fafafa);
     border: 1px solid var(--p-content-border-color,#3f3f46); }
   .cmcp-cv-wfstatus.warn { border-color: #d97706; color: #fcd34d; }
@@ -134,7 +134,7 @@ function injectCss() {
   .cmcp-cv-viewer img, .cmcp-cv-viewer video { max-width: 100%; max-height: 100%; object-fit: contain; }
   .cmcp-cv-vtop { position: absolute; top: .5rem; right: .5rem; display: flex; gap: .4rem; z-index: 6; }
   .cmcp-cv-triggers { display: flex; flex-wrap: wrap; gap: .3rem; margin: .4rem 0; }
-  .cmcp-cv-trigger { font-size: .72rem; padding: .15rem .4rem; border-radius: 6px;
+  .cmcp-cv-trigger { font-size: 0.8862em; padding: .15rem .4rem; border-radius: 6px;
     background: var(--p-surface-800,#27272a); color: var(--p-text-color,#fafafa); }
   .cmcp-cv-lb { position: fixed; inset: 0; z-index: 10002; display: flex;
     background: rgba(0,0,0,.96); outline: none; }
@@ -146,10 +146,10 @@ function injectCss() {
     color: var(--p-text-color,#fafafa); display: flex; flex-direction: column; gap: .6rem; }
   .cmcp-cv-lb-nav { position: absolute; top: 50%; transform: translateY(-50%);
     background: rgba(0,0,0,.5); border: none; color: #fff; border-radius: 999px;
-    width: 40px; height: 40px; cursor: pointer; font-size: 1rem; z-index: 3; }
+    width: 40px; height: 40px; cursor: pointer; font-size: 1.2308em; z-index: 3; }
   .cmcp-cv-lb-nav:hover { background: rgba(0,0,0,.8); }
   .cmcp-cv-lb-close { position: absolute; top: .6rem; right: .6rem; z-index: 3; }
-  .cmcp-cv-lb-title { font-size: .9rem; font-weight: 600; display: flex; align-items: center;
+  .cmcp-cv-lb-title { font-size: 1.1077em; font-weight: 600; display: flex; align-items: center;
     gap: .5rem; padding-right: 2.2rem; }
   .cmcp-cv-like { margin-left: auto; }
   .cmcp-cv-like.on { color: #f43f5e; border-color: #f43f5e; }
@@ -166,15 +166,15 @@ function injectCss() {
     border: 3px solid rgba(255,255,255,.25); border-top-color: var(--p-primary-color,#3a7bd5);
     animation: cmcp-cv-spin .8s linear infinite; }
   @keyframes cmcp-cv-spin { to { transform: rotate(360deg); } }
-  .cmcp-cv-lb-muted { font-size: .74rem; color: var(--p-text-muted-color,#a1a1aa); }
+  .cmcp-cv-lb-muted { font-size: 0.9108em; color: var(--p-text-muted-color,#a1a1aa); }
   .cmcp-cv-creators { display: flex; flex-direction: column; gap: .2rem; width: 100%;
     max-height: 13rem; overflow-y: auto; }
   .cmcp-cv-creator { display: flex; align-items: baseline; gap: .5rem; padding: .3rem .5rem;
     border-radius: 8px; border: 1px solid var(--p-content-border-color,#3f3f46);
     background: transparent; color: var(--p-text-color,#fafafa); cursor: pointer;
-    text-align: left; font-size: .78rem; }
+    text-align: left; font-size: 0.96em; }
   .cmcp-cv-creator:hover { background: var(--p-surface-800,#27272a); }
-  .cmcp-cv-creator .sub { margin-left: auto; font-size: .68rem; flex-shrink: 0;
+  .cmcp-cv-creator .sub { margin-left: auto; font-size: 0.8369em; flex-shrink: 0;
     color: var(--p-text-muted-color,#a1a1aa); }
   .cmcp-cv-dd { position: relative; width: 100%; }
   .cmcp-cv-ddpanel { position: absolute; z-index: 6; left: 0; right: 0; top: calc(100% + .25rem);
@@ -185,28 +185,28 @@ function injectCss() {
     box-shadow: 0 8px 24px rgba(0,0,0,.45); }
   .cmcp-cv-dd.open .cmcp-cv-ddpanel { display: flex; }
   .cmcp-cv-ddlist, .cmcp-cv-ddgroupwrap { display: flex; flex-direction: column; gap: .1rem; }
-  .cmcp-cv-ddgroup { font-size: .64rem; text-transform: uppercase; letter-spacing: .05em;
+  .cmcp-cv-ddgroup { font-size: 0.7877em; text-transform: uppercase; letter-spacing: .05em;
     color: var(--p-text-muted-color,#a1a1aa); padding: .35rem .5rem .15rem; }
   .cmcp-cv-ddopt { display: flex; align-items: center; gap: .45rem; padding: .3rem .5rem;
     border: none; border-radius: 6px; background: transparent; cursor: pointer;
-    color: var(--p-text-color,#fafafa); font-size: .78rem; text-align: left; width: 100%; }
+    color: var(--p-text-color,#fafafa); font-size: 0.96em; text-align: left; width: 100%; }
   .cmcp-cv-ddopt:hover, .cmcp-cv-ddopt.active { background: var(--p-surface-800,#27272a); }
   .cmcp-cv-ddopt .tick { width: .9rem; flex-shrink: 0; opacity: 0; }
   .cmcp-cv-ddopt.on .tick { opacity: 1; color: var(--p-primary-color,#3a7bd5); }
-  .cmcp-cv-ddempty { padding: .4rem .5rem; font-size: .74rem;
+  .cmcp-cv-ddempty { padding: .4rem .5rem; font-size: 0.9108em;
     color: var(--p-text-muted-color,#a1a1aa); }
   .cmcp-cv-ddfoot { position: sticky; bottom: -.25rem; display: flex; align-items: center;
     justify-content: space-between; gap: .5rem; margin-top: .15rem; padding: .35rem .5rem;
-    font-size: .72rem; color: var(--p-text-muted-color,#a1a1aa);
+    font-size: 0.8862em; color: var(--p-text-muted-color,#a1a1aa);
     background: var(--p-surface-900,#18181b);
     border-top: 1px solid var(--p-content-border-color,#3f3f46); }
-  .cmcp-cv-ddclear { background: transparent; border: none; cursor: pointer; font-size: .72rem;
+  .cmcp-cv-ddclear { background: transparent; border: none; cursor: pointer; font-size: 0.8862em;
     padding: 0; color: var(--p-primary-color,#3a7bd5); }
-  .cmcp-cv-lb-prompt { font-size: .78rem; white-space: pre-wrap; word-break: break-word;
+  .cmcp-cv-lb-prompt { font-size: 0.96em; white-space: pre-wrap; word-break: break-word;
     background: var(--p-surface-950,#111); border-radius: 8px; padding: .5rem;
     max-height: 14rem; overflow-y: auto; }
   .cmcp-cv-lb-params { display: grid; grid-template-columns: max-content 1fr; gap: .15rem .6rem;
-    font-size: .74rem; }
+    font-size: 0.9108em; }
   .cmcp-cv-lb-params .k { color: var(--p-text-muted-color,#a1a1aa); }
   @media (max-width: 760px) { .cmcp-cv-lb { flex-direction: column; }
     .cmcp-cv-lb-side { flex: 0 0 45%; max-width: none; border-left: none;
@@ -1095,12 +1095,12 @@ export function createCivitaiContent(ctx, shell, opts = {}) {
     sheet.body.appendChild(actions);
 
     for (const [k, val] of CivitaiClient.params(gen.meta)) {
-      const row = el("div"); row.style.cssText = "font-size:.78rem;margin-top:.2rem";
+      const row = el("div"); row.style.cssText = "font-size:0.96em;margin-top:.2rem";
       row.textContent = `${k}: ${val}`;
       sheet.body.appendChild(row);
     }
     if (gen.meta?.prompt) {
-      const p = el("div"); p.style.cssText = "font-size:.78rem;margin-top:.5rem;white-space:pre-wrap";
+      const p = el("div"); p.style.cssText = "font-size:0.96em;margin-top:.5rem;white-space:pre-wrap";
       p.textContent = "Prompt: " + coerceMessageText(gen.meta.prompt); sheet.body.appendChild(p);
     }
   }
@@ -1361,7 +1361,7 @@ export function createCivitaiContent(ctx, shell, opts = {}) {
       }
       if (have) {
         const note = el("span", null, "You already have this file locally.");
-        note.style.cssText = "font-size:.72rem;color:#4ade80;align-self:center";
+        note.style.cssText = "font-size:0.8862em;color:#4ade80;align-self:center";
         dl.appendChild(note);
       }
       if (detail.creator) {
@@ -1376,7 +1376,7 @@ export function createCivitaiContent(ctx, shell, opts = {}) {
       if (wfFiles.length) detailBody.appendChild(wfStatus);
       if (version.descriptionHtml || detail.descriptionHtml) {
         const desc = el("div", "cmcp-cv-detail");
-        desc.style.cssText = "font-size:.78rem;margin-top:.5rem";
+        desc.style.cssText = "font-size:0.96em;margin-top:.5rem";
         // CivitAI descriptions are HTML — sanitize and render directly.
         desc.innerHTML = ctx.DOMPurify.sanitize(version.descriptionHtml || detail.descriptionHtml || "");
         detailBody.appendChild(desc);

--- a/web/js/cmcp-filter.js
+++ b/web/js/cmcp-filter.js
@@ -32,7 +32,7 @@ function injectFilterCss() {
   _cssInjected = true;
   const css = `
   .cmcp-cv-filters { display: flex; flex-direction: column; gap: .7rem; }
-  .cmcp-cv-flabel { font-size: calc(var(--cmcp-fs) * 0.8615); text-transform: uppercase; letter-spacing: .04em;
+  .cmcp-cv-flabel { font-size: calc(var(--cmcp-fs, 0.8125rem) * 0.8615); text-transform: uppercase; letter-spacing: .04em;
     color: var(--p-text-muted-color,#a1a1aa); width: 100%; }
   `;
   const style = document.createElement("style");

--- a/web/js/cmcp-filter.js
+++ b/web/js/cmcp-filter.js
@@ -32,7 +32,7 @@ function injectFilterCss() {
   _cssInjected = true;
   const css = `
   .cmcp-cv-filters { display: flex; flex-direction: column; gap: .7rem; }
-  .cmcp-cv-flabel { font-size: 0.8615em; text-transform: uppercase; letter-spacing: .04em;
+  .cmcp-cv-flabel { font-size: calc(var(--cmcp-fs) * 0.8615); text-transform: uppercase; letter-spacing: .04em;
     color: var(--p-text-muted-color,#a1a1aa); width: 100%; }
   `;
   const style = document.createElement("style");

--- a/web/js/cmcp-filter.js
+++ b/web/js/cmcp-filter.js
@@ -32,7 +32,7 @@ function injectFilterCss() {
   _cssInjected = true;
   const css = `
   .cmcp-cv-filters { display: flex; flex-direction: column; gap: .7rem; }
-  .cmcp-cv-flabel { font-size: .7rem; text-transform: uppercase; letter-spacing: .04em;
+  .cmcp-cv-flabel { font-size: 0.8615em; text-transform: uppercase; letter-spacing: .04em;
     color: var(--p-text-muted-color,#a1a1aa); width: 100%; }
   `;
   const style = document.createElement("style");

--- a/web/js/cmcp-modal.js
+++ b/web/js/cmcp-modal.js
@@ -41,6 +41,10 @@ export function openSubModal(title, onClose, tracker) {
   if (tracker) tracker.add(close2);
   x.addEventListener("click", close2);
   ov.addEventListener("mousedown", (e) => { if (e.target === ov) close2(); });
+  // #753 — mounted on <body>, OUTSIDE .cmcp-root, so `em` inside it would resolve
+  // against the page's 16px rather than the panel's 13px. Anchor the root the same way
+  // .cmcp-root is anchored, in rem, so everything below renders as written.
+  ov.style.fontSize = "0.8125rem";
   m.append(head2, x, b); ov.appendChild(m); document.body.appendChild(ov);
   return { body: b, close: close2 };
 }
@@ -55,7 +59,7 @@ export function toast(msg, { ms = 3500 } = {}) {
   // whole explorer just closed after a successful load).
   t.style.cssText = "position:fixed;bottom:1.25rem;left:50%;transform:translateX(-50%);" +
     "max-width:min(38rem,90vw);text-align:center;background:var(--p-surface-800,#27272a);" +
-    "color:#fafafa;padding:.55rem .9rem;border-radius:8px;z-index:10060;font-size:1.0092em;" +
+    "color:#fafafa;padding:.55rem .9rem;border-radius:8px;z-index:10060;font-size:.82rem;" +
     "box-shadow:0 4px 16px rgba(0,0,0,.5)";
   document.body.appendChild(t);
   setTimeout(() => t.remove(), ms);

--- a/web/js/cmcp-modal.js
+++ b/web/js/cmcp-modal.js
@@ -41,10 +41,6 @@ export function openSubModal(title, onClose, tracker) {
   if (tracker) tracker.add(close2);
   x.addEventListener("click", close2);
   ov.addEventListener("mousedown", (e) => { if (e.target === ov) close2(); });
-  // #753 — mounted on <body>, OUTSIDE .cmcp-root, so `em` inside it would resolve
-  // against the page's 16px rather than the panel's 13px. Anchor the root the same way
-  // .cmcp-root is anchored, in rem, so everything below renders as written.
-  ov.style.fontSize = "0.8125rem";
   m.append(head2, x, b); ov.appendChild(m); document.body.appendChild(ov);
   return { body: b, close: close2 };
 }
@@ -59,7 +55,7 @@ export function toast(msg, { ms = 3500 } = {}) {
   // whole explorer just closed after a successful load).
   t.style.cssText = "position:fixed;bottom:1.25rem;left:50%;transform:translateX(-50%);" +
     "max-width:min(38rem,90vw);text-align:center;background:var(--p-surface-800,#27272a);" +
-    "color:#fafafa;padding:.55rem .9rem;border-radius:8px;z-index:10060;font-size:.82rem;" +
+    "color:#fafafa;padding:.55rem .9rem;border-radius:8px;z-index:10060;font-size:calc(var(--cmcp-fs) * 1.0092);" +
     "box-shadow:0 4px 16px rgba(0,0,0,.5)";
   document.body.appendChild(t);
   setTimeout(() => t.remove(), ms);
@@ -71,12 +67,12 @@ function injectModalCss() {
   _mdlCss = true;
   const css = `
 .cmcp-mdl{display:flex;flex-direction:column;gap:.85rem;}
-.cmcp-mdl-msg{font-size:1.0462em;line-height:1.55;white-space:pre-wrap;color:var(--p-text-color,#fafafa);}
+.cmcp-mdl-msg{font-size:calc(var(--cmcp-fs) * 1.0462);line-height:1.55;white-space:pre-wrap;color:var(--p-text-color,#fafafa);}
 .cmcp-mdl-field{display:flex;flex-direction:column;gap:.3rem;}
-.cmcp-mdl-label{font-size:0.8862em;font-weight:600;opacity:.8;text-transform:uppercase;letter-spacing:.03em;}
+.cmcp-mdl-label{font-size:calc(var(--cmcp-fs) * 0.8862);font-weight:600;opacity:.8;text-transform:uppercase;letter-spacing:.03em;}
 .cmcp-mdl-field input,.cmcp-mdl-field textarea{padding:.5rem .6rem;border-radius:8px;
   border:1px solid var(--p-content-border-color,#3f3f46);background:var(--p-surface-950,#111113);
-  color:var(--p-text-color,#fafafa);font:inherit;font-size:1.0462em;box-sizing:border-box;width:100%;}
+  color:var(--p-text-color,#fafafa);font:inherit;font-size:calc(var(--cmcp-fs) * 1.0462);box-sizing:border-box;width:100%;}
 .cmcp-mdl-field input:focus,.cmcp-mdl-field textarea:focus{outline:none;border-color:var(--p-primary-color,#60a5fa);}
 .cmcp-mdl-field textarea{resize:vertical;min-height:4.5rem;}
 .cmcp-mdl-btns{display:flex;justify-content:flex-end;gap:.5rem;margin-top:.15rem;}

--- a/web/js/cmcp-modal.js
+++ b/web/js/cmcp-modal.js
@@ -55,7 +55,7 @@ export function toast(msg, { ms = 3500 } = {}) {
   // whole explorer just closed after a successful load).
   t.style.cssText = "position:fixed;bottom:1.25rem;left:50%;transform:translateX(-50%);" +
     "max-width:min(38rem,90vw);text-align:center;background:var(--p-surface-800,#27272a);" +
-    "color:#fafafa;padding:.55rem .9rem;border-radius:8px;z-index:10060;font-size:.82rem;" +
+    "color:#fafafa;padding:.55rem .9rem;border-radius:8px;z-index:10060;font-size:1.0092em;" +
     "box-shadow:0 4px 16px rgba(0,0,0,.5)";
   document.body.appendChild(t);
   setTimeout(() => t.remove(), ms);
@@ -67,12 +67,12 @@ function injectModalCss() {
   _mdlCss = true;
   const css = `
 .cmcp-mdl{display:flex;flex-direction:column;gap:.85rem;}
-.cmcp-mdl-msg{font-size:.85rem;line-height:1.55;white-space:pre-wrap;color:var(--p-text-color,#fafafa);}
+.cmcp-mdl-msg{font-size:1.0462em;line-height:1.55;white-space:pre-wrap;color:var(--p-text-color,#fafafa);}
 .cmcp-mdl-field{display:flex;flex-direction:column;gap:.3rem;}
-.cmcp-mdl-label{font-size:.72rem;font-weight:600;opacity:.8;text-transform:uppercase;letter-spacing:.03em;}
+.cmcp-mdl-label{font-size:0.8862em;font-weight:600;opacity:.8;text-transform:uppercase;letter-spacing:.03em;}
 .cmcp-mdl-field input,.cmcp-mdl-field textarea{padding:.5rem .6rem;border-radius:8px;
   border:1px solid var(--p-content-border-color,#3f3f46);background:var(--p-surface-950,#111113);
-  color:var(--p-text-color,#fafafa);font:inherit;font-size:.85rem;box-sizing:border-box;width:100%;}
+  color:var(--p-text-color,#fafafa);font:inherit;font-size:1.0462em;box-sizing:border-box;width:100%;}
 .cmcp-mdl-field input:focus,.cmcp-mdl-field textarea:focus{outline:none;border-color:var(--p-primary-color,#60a5fa);}
 .cmcp-mdl-field textarea{resize:vertical;min-height:4.5rem;}
 .cmcp-mdl-btns{display:flex;justify-content:flex-end;gap:.5rem;margin-top:.15rem;}

--- a/web/js/cmcp-modal.js
+++ b/web/js/cmcp-modal.js
@@ -55,7 +55,7 @@ export function toast(msg, { ms = 3500 } = {}) {
   // whole explorer just closed after a successful load).
   t.style.cssText = "position:fixed;bottom:1.25rem;left:50%;transform:translateX(-50%);" +
     "max-width:min(38rem,90vw);text-align:center;background:var(--p-surface-800,#27272a);" +
-    "color:#fafafa;padding:.55rem .9rem;border-radius:8px;z-index:10060;font-size:calc(var(--cmcp-fs) * 1.0092);" +
+    "color:#fafafa;padding:.55rem .9rem;border-radius:8px;z-index:10060;font-size:calc(var(--cmcp-fs, 0.8125rem) * 1.0092);" +
     "box-shadow:0 4px 16px rgba(0,0,0,.5)";
   document.body.appendChild(t);
   setTimeout(() => t.remove(), ms);
@@ -67,12 +67,12 @@ function injectModalCss() {
   _mdlCss = true;
   const css = `
 .cmcp-mdl{display:flex;flex-direction:column;gap:.85rem;}
-.cmcp-mdl-msg{font-size:calc(var(--cmcp-fs) * 1.0462);line-height:1.55;white-space:pre-wrap;color:var(--p-text-color,#fafafa);}
+.cmcp-mdl-msg{font-size:calc(var(--cmcp-fs, 0.8125rem) * 1.0462);line-height:1.55;white-space:pre-wrap;color:var(--p-text-color,#fafafa);}
 .cmcp-mdl-field{display:flex;flex-direction:column;gap:.3rem;}
-.cmcp-mdl-label{font-size:calc(var(--cmcp-fs) * 0.8862);font-weight:600;opacity:.8;text-transform:uppercase;letter-spacing:.03em;}
+.cmcp-mdl-label{font-size:calc(var(--cmcp-fs, 0.8125rem) * 0.8862);font-weight:600;opacity:.8;text-transform:uppercase;letter-spacing:.03em;}
 .cmcp-mdl-field input,.cmcp-mdl-field textarea{padding:.5rem .6rem;border-radius:8px;
   border:1px solid var(--p-content-border-color,#3f3f46);background:var(--p-surface-950,#111113);
-  color:var(--p-text-color,#fafafa);font:inherit;font-size:calc(var(--cmcp-fs) * 1.0462);box-sizing:border-box;width:100%;}
+  color:var(--p-text-color,#fafafa);font:inherit;font-size:calc(var(--cmcp-fs, 0.8125rem) * 1.0462);box-sizing:border-box;width:100%;}
 .cmcp-mdl-field input:focus,.cmcp-mdl-field textarea:focus{outline:none;border-color:var(--p-primary-color,#60a5fa);}
 .cmcp-mdl-field textarea{resize:vertical;min-height:4.5rem;}
 .cmcp-mdl-btns{display:flex;justify-content:flex-end;gap:.5rem;margin-top:.15rem;}

--- a/web/js/cmcp-runpod-ui.js
+++ b/web/js/cmcp-runpod-ui.js
@@ -37,12 +37,12 @@ function injectStyle() {
 .cmcp-rp-modal{max-width:min(480px,92vw)!important;width:auto;}
 .cmcp-rp-body{display:flex;flex-direction:column;gap:0.75rem;min-width:min(440px,90vw);max-width:520px;}
 .cmcp-rp-host{display:flex;align-items:center;gap:0.5rem;padding:0.55rem 0.7rem;border-radius:8px;
-  font-size:1.0462em;font-weight:600;border:1px solid var(--p-content-border-color,#3f3f46);}
+  font-size:calc(var(--cmcp-fs) * 1.0462);font-weight:600;border:1px solid var(--p-content-border-color,#3f3f46);}
 .cmcp-rp-host.local{background:rgba(34,197,94,0.10);color:#22c55e;border-color:rgba(34,197,94,0.35);}
 .cmcp-rp-host.pod{background:rgba(59,130,246,0.12);color:#60a5fa;border-color:rgba(59,130,246,0.40);}
 .cmcp-rp-dot{width:8px;height:8px;border-radius:50%;background:currentColor;flex:0 0 auto;}
 .cmcp-rp-card{border:1px solid var(--p-content-border-color,#3f3f46);border-radius:8px;padding:0.7rem;
-  display:flex;flex-direction:column;gap:0.35rem;font-size:1.0092em;}
+  display:flex;flex-direction:column;gap:0.35rem;font-size:calc(var(--cmcp-fs) * 1.0092);}
 .cmcp-rp-row{display:flex;justify-content:space-between;gap:0.75rem;}
 .cmcp-rp-row .k{opacity:0.6;}
 .cmcp-rp-row .v{font-variant-numeric:tabular-nums;text-align:right;}
@@ -52,19 +52,19 @@ function injectStyle() {
 .cmcp-rp-connect{display:flex;gap:0.4rem;}
 .cmcp-rp-connect input,.cmcp-rp-podselect{flex:1 1 auto;min-width:0;padding:0.4rem 0.55rem;border-radius:6px;
   border:1px solid var(--p-content-border-color,#3f3f46);background:var(--p-inputtext-background,#18181b);
-  color:inherit;font-size:1.0092em;}
+  color:inherit;font-size:calc(var(--cmcp-fs) * 1.0092);}
 .cmcp-rp-connect input{font-family:ui-monospace,monospace;}
 .cmcp-rp-podselect{cursor:pointer;}
 .cmcp-rp-refresh{flex:0 0 auto;min-width:auto;padding:0.4rem 0.6rem;}
-.cmcp-rp-log{font-size:0.96em;opacity:0.85;min-height:1.1em;white-space:pre-wrap;word-break:break-word;}
+.cmcp-rp-log{font-size:calc(var(--cmcp-fs) * 0.96);opacity:0.85;min-height:1.1em;white-space:pre-wrap;word-break:break-word;}
 .cmcp-rp-log.busy{opacity:0.6;}
 .cmcp-rp-log.err{color:#f87171;}
-.cmcp-rp-credit{font-size:0.8615em;opacity:0.5;}
+.cmcp-rp-credit{font-size:calc(var(--cmcp-fs) * 0.8615);opacity:0.5;}
 .cmcp-rp-credit a{color:inherit;}
-.cmcp-rp-muted{font-size:0.9231em;opacity:0.6;}
+.cmcp-rp-muted{font-size:calc(var(--cmcp-fs) * 0.9231);opacity:0.6;}
 /* The unified side-panel shell (cmcp-sidepanel-ui.js) owns the overlay + dock +
    slide; the Local tab centers this body in the shared card. */
-.cmcp-rp-title{font-weight:600;font-size:1.0462em;}
+.cmcp-rp-title{font-weight:600;font-size:calc(var(--cmcp-fs) * 1.0462);}
 `;
   const el = document.createElement("style");
   el.textContent = css;

--- a/web/js/cmcp-runpod-ui.js
+++ b/web/js/cmcp-runpod-ui.js
@@ -37,12 +37,12 @@ function injectStyle() {
 .cmcp-rp-modal{max-width:min(480px,92vw)!important;width:auto;}
 .cmcp-rp-body{display:flex;flex-direction:column;gap:0.75rem;min-width:min(440px,90vw);max-width:520px;}
 .cmcp-rp-host{display:flex;align-items:center;gap:0.5rem;padding:0.55rem 0.7rem;border-radius:8px;
-  font-size:0.85rem;font-weight:600;border:1px solid var(--p-content-border-color,#3f3f46);}
+  font-size:1.0462em;font-weight:600;border:1px solid var(--p-content-border-color,#3f3f46);}
 .cmcp-rp-host.local{background:rgba(34,197,94,0.10);color:#22c55e;border-color:rgba(34,197,94,0.35);}
 .cmcp-rp-host.pod{background:rgba(59,130,246,0.12);color:#60a5fa;border-color:rgba(59,130,246,0.40);}
 .cmcp-rp-dot{width:8px;height:8px;border-radius:50%;background:currentColor;flex:0 0 auto;}
 .cmcp-rp-card{border:1px solid var(--p-content-border-color,#3f3f46);border-radius:8px;padding:0.7rem;
-  display:flex;flex-direction:column;gap:0.35rem;font-size:0.82rem;}
+  display:flex;flex-direction:column;gap:0.35rem;font-size:1.0092em;}
 .cmcp-rp-row{display:flex;justify-content:space-between;gap:0.75rem;}
 .cmcp-rp-row .k{opacity:0.6;}
 .cmcp-rp-row .v{font-variant-numeric:tabular-nums;text-align:right;}
@@ -52,19 +52,19 @@ function injectStyle() {
 .cmcp-rp-connect{display:flex;gap:0.4rem;}
 .cmcp-rp-connect input,.cmcp-rp-podselect{flex:1 1 auto;min-width:0;padding:0.4rem 0.55rem;border-radius:6px;
   border:1px solid var(--p-content-border-color,#3f3f46);background:var(--p-inputtext-background,#18181b);
-  color:inherit;font-size:0.82rem;}
+  color:inherit;font-size:1.0092em;}
 .cmcp-rp-connect input{font-family:ui-monospace,monospace;}
 .cmcp-rp-podselect{cursor:pointer;}
 .cmcp-rp-refresh{flex:0 0 auto;min-width:auto;padding:0.4rem 0.6rem;}
-.cmcp-rp-log{font-size:0.78rem;opacity:0.85;min-height:1.1em;white-space:pre-wrap;word-break:break-word;}
+.cmcp-rp-log{font-size:0.96em;opacity:0.85;min-height:1.1em;white-space:pre-wrap;word-break:break-word;}
 .cmcp-rp-log.busy{opacity:0.6;}
 .cmcp-rp-log.err{color:#f87171;}
-.cmcp-rp-credit{font-size:0.7rem;opacity:0.5;}
+.cmcp-rp-credit{font-size:0.8615em;opacity:0.5;}
 .cmcp-rp-credit a{color:inherit;}
-.cmcp-rp-muted{font-size:0.75rem;opacity:0.6;}
+.cmcp-rp-muted{font-size:0.9231em;opacity:0.6;}
 /* The unified side-panel shell (cmcp-sidepanel-ui.js) owns the overlay + dock +
    slide; the Local tab centers this body in the shared card. */
-.cmcp-rp-title{font-weight:600;font-size:0.85rem;}
+.cmcp-rp-title{font-weight:600;font-size:1.0462em;}
 `;
   const el = document.createElement("style");
   el.textContent = css;

--- a/web/js/cmcp-runpod-ui.js
+++ b/web/js/cmcp-runpod-ui.js
@@ -37,12 +37,12 @@ function injectStyle() {
 .cmcp-rp-modal{max-width:min(480px,92vw)!important;width:auto;}
 .cmcp-rp-body{display:flex;flex-direction:column;gap:0.75rem;min-width:min(440px,90vw);max-width:520px;}
 .cmcp-rp-host{display:flex;align-items:center;gap:0.5rem;padding:0.55rem 0.7rem;border-radius:8px;
-  font-size:calc(var(--cmcp-fs) * 1.0462);font-weight:600;border:1px solid var(--p-content-border-color,#3f3f46);}
+  font-size:calc(var(--cmcp-fs, 0.8125rem) * 1.0462);font-weight:600;border:1px solid var(--p-content-border-color,#3f3f46);}
 .cmcp-rp-host.local{background:rgba(34,197,94,0.10);color:#22c55e;border-color:rgba(34,197,94,0.35);}
 .cmcp-rp-host.pod{background:rgba(59,130,246,0.12);color:#60a5fa;border-color:rgba(59,130,246,0.40);}
 .cmcp-rp-dot{width:8px;height:8px;border-radius:50%;background:currentColor;flex:0 0 auto;}
 .cmcp-rp-card{border:1px solid var(--p-content-border-color,#3f3f46);border-radius:8px;padding:0.7rem;
-  display:flex;flex-direction:column;gap:0.35rem;font-size:calc(var(--cmcp-fs) * 1.0092);}
+  display:flex;flex-direction:column;gap:0.35rem;font-size:calc(var(--cmcp-fs, 0.8125rem) * 1.0092);}
 .cmcp-rp-row{display:flex;justify-content:space-between;gap:0.75rem;}
 .cmcp-rp-row .k{opacity:0.6;}
 .cmcp-rp-row .v{font-variant-numeric:tabular-nums;text-align:right;}
@@ -52,19 +52,19 @@ function injectStyle() {
 .cmcp-rp-connect{display:flex;gap:0.4rem;}
 .cmcp-rp-connect input,.cmcp-rp-podselect{flex:1 1 auto;min-width:0;padding:0.4rem 0.55rem;border-radius:6px;
   border:1px solid var(--p-content-border-color,#3f3f46);background:var(--p-inputtext-background,#18181b);
-  color:inherit;font-size:calc(var(--cmcp-fs) * 1.0092);}
+  color:inherit;font-size:calc(var(--cmcp-fs, 0.8125rem) * 1.0092);}
 .cmcp-rp-connect input{font-family:ui-monospace,monospace;}
 .cmcp-rp-podselect{cursor:pointer;}
 .cmcp-rp-refresh{flex:0 0 auto;min-width:auto;padding:0.4rem 0.6rem;}
-.cmcp-rp-log{font-size:calc(var(--cmcp-fs) * 0.96);opacity:0.85;min-height:1.1em;white-space:pre-wrap;word-break:break-word;}
+.cmcp-rp-log{font-size:calc(var(--cmcp-fs, 0.8125rem) * 0.96);opacity:0.85;min-height:1.1em;white-space:pre-wrap;word-break:break-word;}
 .cmcp-rp-log.busy{opacity:0.6;}
 .cmcp-rp-log.err{color:#f87171;}
-.cmcp-rp-credit{font-size:calc(var(--cmcp-fs) * 0.8615);opacity:0.5;}
+.cmcp-rp-credit{font-size:calc(var(--cmcp-fs, 0.8125rem) * 0.8615);opacity:0.5;}
 .cmcp-rp-credit a{color:inherit;}
-.cmcp-rp-muted{font-size:calc(var(--cmcp-fs) * 0.9231);opacity:0.6;}
+.cmcp-rp-muted{font-size:calc(var(--cmcp-fs, 0.8125rem) * 0.9231);opacity:0.6;}
 /* The unified side-panel shell (cmcp-sidepanel-ui.js) owns the overlay + dock +
    slide; the Local tab centers this body in the shared card. */
-.cmcp-rp-title{font-weight:600;font-size:calc(var(--cmcp-fs) * 1.0462);}
+.cmcp-rp-title{font-weight:600;font-size:calc(var(--cmcp-fs, 0.8125rem) * 1.0462);}
 `;
   const el = document.createElement("style");
   el.textContent = css;

--- a/web/js/cmcp-sidepanel-ui.js
+++ b/web/js/cmcp-sidepanel-ui.js
@@ -47,10 +47,10 @@ function injectCss() {
   .cmcp-cv-head { display: flex; align-items: center; gap: .5rem; padding: .6rem .7rem;
     border-bottom: 1px solid var(--p-content-border-color, #3f3f46); flex-wrap: wrap; }
   .cmcp-cv-tabs { display: flex; gap: .25rem; flex-wrap: wrap; }
-  .cmcp-sp-title { font-weight: 600; font-size: calc(var(--cmcp-fs) * 1.0462); color: var(--p-text-color, #fafafa); padding: 0 .25rem; }
+  .cmcp-sp-title { font-weight: 600; font-size: calc(var(--cmcp-fs, 0.8125rem) * 1.0462); color: var(--p-text-color, #fafafa); padding: 0 .25rem; }
   .cmcp-cv-tab { display: inline-flex; align-items: center; gap: .3rem; padding: .3rem .55rem;
     border-radius: 8px; border: 1px solid transparent; background: transparent;
-    color: var(--p-text-muted-color, #a1a1aa); cursor: pointer; font-size: calc(var(--cmcp-fs) * 0.9846); }
+    color: var(--p-text-muted-color, #a1a1aa); cursor: pointer; font-size: calc(var(--cmcp-fs, 0.8125rem) * 0.9846); }
   /* Active tab uses the ComfyUI/PrimeVue theme primary so it inverts correctly in
      light + dark (precedent: .cmcp-btn primary). */
   .cmcp-cv-tab.active { background: var(--p-primary-color, #3a7bd5);
@@ -66,7 +66,7 @@ function injectCss() {
     background: var(--p-primary-color, #3a7bd5); }
   .cmcp-cv-body { position: relative; flex: 1; overflow-y: auto; padding: .6rem; }
   .cmcp-cv-frow { display: flex; flex-wrap: wrap; gap: .3rem; align-items: center; }
-  .cmcp-cv-chip { padding: .25rem .5rem; border-radius: 999px; font-size: calc(var(--cmcp-fs) * 0.9231); cursor: pointer;
+  .cmcp-cv-chip { padding: .25rem .5rem; border-radius: 999px; font-size: calc(var(--cmcp-fs, 0.8125rem) * 0.9231); cursor: pointer;
     border: 1px solid var(--p-content-border-color,#3f3f46); background: transparent; color: var(--p-text-color,#fafafa); }
   .cmcp-cv-chip.on { background: var(--p-primary-color,#3a7bd5); border-color: transparent; color:#fff; }
   /* Agent-driven "glow" — shared across every surface (steps, cards, fields). */

--- a/web/js/cmcp-sidepanel-ui.js
+++ b/web/js/cmcp-sidepanel-ui.js
@@ -165,6 +165,10 @@ export function openSidePanel(ctx = {}, opts = {}) {
 
   modal.append(head, subnav, body);
   overlay.appendChild(modal);
+  // #753 — mounted on <body>, OUTSIDE .cmcp-root, so `em` inside it would resolve
+  // against the page's 16px rather than the panel's 13px. Anchor the root the same way
+  // .cmcp-root is anchored, in rem, so everything below renders as written.
+  overlay.style.fontSize = "0.8125rem";
   document.body.appendChild(overlay);
 
   // ── lifecycle state ─────────────────────────────────────────────────────────

--- a/web/js/cmcp-sidepanel-ui.js
+++ b/web/js/cmcp-sidepanel-ui.js
@@ -47,10 +47,10 @@ function injectCss() {
   .cmcp-cv-head { display: flex; align-items: center; gap: .5rem; padding: .6rem .7rem;
     border-bottom: 1px solid var(--p-content-border-color, #3f3f46); flex-wrap: wrap; }
   .cmcp-cv-tabs { display: flex; gap: .25rem; flex-wrap: wrap; }
-  .cmcp-sp-title { font-weight: 600; font-size: .85rem; color: var(--p-text-color, #fafafa); padding: 0 .25rem; }
+  .cmcp-sp-title { font-weight: 600; font-size: 1.0462em; color: var(--p-text-color, #fafafa); padding: 0 .25rem; }
   .cmcp-cv-tab { display: inline-flex; align-items: center; gap: .3rem; padding: .3rem .55rem;
     border-radius: 8px; border: 1px solid transparent; background: transparent;
-    color: var(--p-text-muted-color, #a1a1aa); cursor: pointer; font-size: .8rem; }
+    color: var(--p-text-muted-color, #a1a1aa); cursor: pointer; font-size: 0.9846em; }
   /* Active tab uses the ComfyUI/PrimeVue theme primary so it inverts correctly in
      light + dark (precedent: .cmcp-btn primary). */
   .cmcp-cv-tab.active { background: var(--p-primary-color, #3a7bd5);
@@ -66,7 +66,7 @@ function injectCss() {
     background: var(--p-primary-color, #3a7bd5); }
   .cmcp-cv-body { position: relative; flex: 1; overflow-y: auto; padding: .6rem; }
   .cmcp-cv-frow { display: flex; flex-wrap: wrap; gap: .3rem; align-items: center; }
-  .cmcp-cv-chip { padding: .25rem .5rem; border-radius: 999px; font-size: .75rem; cursor: pointer;
+  .cmcp-cv-chip { padding: .25rem .5rem; border-radius: 999px; font-size: 0.9231em; cursor: pointer;
     border: 1px solid var(--p-content-border-color,#3f3f46); background: transparent; color: var(--p-text-color,#fafafa); }
   .cmcp-cv-chip.on { background: var(--p-primary-color,#3a7bd5); border-color: transparent; color:#fff; }
   /* Agent-driven "glow" — shared across every surface (steps, cards, fields). */

--- a/web/js/cmcp-sidepanel-ui.js
+++ b/web/js/cmcp-sidepanel-ui.js
@@ -47,10 +47,10 @@ function injectCss() {
   .cmcp-cv-head { display: flex; align-items: center; gap: .5rem; padding: .6rem .7rem;
     border-bottom: 1px solid var(--p-content-border-color, #3f3f46); flex-wrap: wrap; }
   .cmcp-cv-tabs { display: flex; gap: .25rem; flex-wrap: wrap; }
-  .cmcp-sp-title { font-weight: 600; font-size: 1.0462em; color: var(--p-text-color, #fafafa); padding: 0 .25rem; }
+  .cmcp-sp-title { font-weight: 600; font-size: calc(var(--cmcp-fs) * 1.0462); color: var(--p-text-color, #fafafa); padding: 0 .25rem; }
   .cmcp-cv-tab { display: inline-flex; align-items: center; gap: .3rem; padding: .3rem .55rem;
     border-radius: 8px; border: 1px solid transparent; background: transparent;
-    color: var(--p-text-muted-color, #a1a1aa); cursor: pointer; font-size: 0.9846em; }
+    color: var(--p-text-muted-color, #a1a1aa); cursor: pointer; font-size: calc(var(--cmcp-fs) * 0.9846); }
   /* Active tab uses the ComfyUI/PrimeVue theme primary so it inverts correctly in
      light + dark (precedent: .cmcp-btn primary). */
   .cmcp-cv-tab.active { background: var(--p-primary-color, #3a7bd5);
@@ -66,7 +66,7 @@ function injectCss() {
     background: var(--p-primary-color, #3a7bd5); }
   .cmcp-cv-body { position: relative; flex: 1; overflow-y: auto; padding: .6rem; }
   .cmcp-cv-frow { display: flex; flex-wrap: wrap; gap: .3rem; align-items: center; }
-  .cmcp-cv-chip { padding: .25rem .5rem; border-radius: 999px; font-size: 0.9231em; cursor: pointer;
+  .cmcp-cv-chip { padding: .25rem .5rem; border-radius: 999px; font-size: calc(var(--cmcp-fs) * 0.9231); cursor: pointer;
     border: 1px solid var(--p-content-border-color,#3f3f46); background: transparent; color: var(--p-text-color,#fafafa); }
   .cmcp-cv-chip.on { background: var(--p-primary-color,#3a7bd5); border-color: transparent; color:#fff; }
   /* Agent-driven "glow" — shared across every surface (steps, cards, fields). */
@@ -165,10 +165,6 @@ export function openSidePanel(ctx = {}, opts = {}) {
 
   modal.append(head, subnav, body);
   overlay.appendChild(modal);
-  // #753 — mounted on <body>, OUTSIDE .cmcp-root, so `em` inside it would resolve
-  // against the page's 16px rather than the panel's 13px. Anchor the root the same way
-  // .cmcp-root is anchored, in rem, so everything below renders as written.
-  overlay.style.fontSize = "0.8125rem";
   document.body.appendChild(overlay);
 
   // ── lifecycle state ─────────────────────────────────────────────────────────

--- a/web/js/cmcp-training-ui.js
+++ b/web/js/cmcp-training-ui.js
@@ -27,34 +27,34 @@ function injectCss() {
     .cmcp-tr-body { flex: 1; overflow-y: auto; min-height: 0; padding-bottom: 1rem; }
     .cmcp-tr-head { display:flex; align-items:center; gap:.75rem; padding:1rem 1.25rem .5rem;
       border-bottom: 1px solid var(--p-content-border-color, #3f3f46); }
-    .cmcp-tr-head h2 { margin:0; font-size:1.05rem; flex:1; }
-    .cmcp-tr-close { background:none; border:none; color:inherit; cursor:pointer; font-size:1.1rem; opacity:.7; }
+    .cmcp-tr-head h2 { margin:0; font-size:1.2923em; flex:1; }
+    .cmcp-tr-close { background:none; border:none; color:inherit; cursor:pointer; font-size:1.3538em; opacity:.7; }
     .cmcp-tr-close:hover { opacity:1; }
     .cmcp-tr-seg { display:flex; gap:0; margin:.75rem 1.25rem; border:1px solid var(--p-surface-500,#555); border-radius:999px; overflow:hidden; width:fit-content; flex:none; }
-    .cmcp-tr-seg button { border:none; background:transparent; color:inherit; padding:.4rem .9rem; cursor:pointer; font-size:.85rem; display:flex; align-items:center; gap:.4rem; }
+    .cmcp-tr-seg button { border:none; background:transparent; color:inherit; padding:.4rem .9rem; cursor:pointer; font-size:1.0462em; display:flex; align-items:center; gap:.4rem; }
     .cmcp-tr-seg button.active { background: var(--p-surface-700,#3f3f46); }
     .cmcp-tr-grid { display:grid; grid-template-columns:repeat(3,1fr); gap:.75rem; padding:0 1.25rem 1rem; }
     @media (max-width: 640px) { .cmcp-tr-grid { grid-template-columns:repeat(2,1fr); } }
     .cmcp-tr-card { background:var(--p-surface-800,#27272a); border:1px solid var(--p-surface-600,#3f3f46); border-radius:12px; padding:.75rem; display:flex; flex-direction:column; gap:.45rem; }
     .cmcp-tr-card.active { border-color: var(--p-primary-color,#94a3b8); }
-    .cmcp-tr-icon { aspect-ratio:1.6; border-radius:10px; background:color-mix(in srgb, currentColor 8%, transparent); display:flex; align-items:center; justify-content:center; font-size:1.6rem; opacity:.8; }
-    .cmcp-tr-card select { background:var(--p-surface-900,#18181b); color:inherit; border:1px solid var(--p-surface-600,#52525b); border-radius:6px; padding:.25rem .4rem; font-size:.8rem; width:100%; }
-    .cmcp-tr-card h3 { margin:0; font-size:.9rem; }
-    .cmcp-tr-card p { margin:0; font-size:.78rem; opacity:.65; line-height:1.35; flex:1; }
-    .cmcp-tr-badge { align-self:flex-start; font-size:.72rem; padding:.1rem .5rem; border-radius:999px; background:color-mix(in srgb, currentColor 10%, transparent); opacity:.75; }
+    .cmcp-tr-icon { aspect-ratio:1.6; border-radius:10px; background:color-mix(in srgb, currentColor 8%, transparent); display:flex; align-items:center; justify-content:center; font-size:1.9692em; opacity:.8; }
+    .cmcp-tr-card select { background:var(--p-surface-900,#18181b); color:inherit; border:1px solid var(--p-surface-600,#52525b); border-radius:6px; padding:.25rem .4rem; font-size:0.9846em; width:100%; }
+    .cmcp-tr-card h3 { margin:0; font-size:1.1077em; }
+    .cmcp-tr-card p { margin:0; font-size:0.96em; opacity:.65; line-height:1.35; flex:1; }
+    .cmcp-tr-badge { align-self:flex-start; font-size:0.8862em; padding:.1rem .5rem; border-radius:999px; background:color-mix(in srgb, currentColor 10%, transparent); opacity:.75; }
     .cmcp-tr-badge.ok { background: color-mix(in srgb, #22c55e 18%, transparent); opacity:1; }
     .cmcp-tr-badge.err { background: color-mix(in srgb, #ef4444 18%, transparent); opacity:1; }
     .cmcp-tr-badge.warn { background: color-mix(in srgb, #eab308 18%, transparent); opacity:1; }
-    .cmcp-tr-foot { padding:0 1.25rem 1rem; font-size:.8rem; opacity:.55; }
+    .cmcp-tr-foot { padding:0 1.25rem 1rem; font-size:0.9846em; opacity:.55; }
     .cmcp-tr-section { padding: .25rem 1.25rem; display:flex; flex-direction:column; gap:.6rem; }
     .cmcp-tr-row { display:flex; gap:.6rem; align-items:center; flex-wrap:wrap; }
-    .cmcp-tr-row > label { font-size:.8rem; opacity:.75; min-width:6.5rem; }
+    .cmcp-tr-row > label { font-size:0.9846em; opacity:.75; min-width:6.5rem; }
     .cmcp-tr-input, .cmcp-tr-section input[type=text], .cmcp-tr-section input[type=number] {
       background:var(--p-surface-800,#27272a); border:1px solid var(--p-surface-600,#52525b);
-      border-radius:8px; padding:.45rem .7rem; color:inherit; font-size:.85rem; flex:1; min-width:0; }
-    .cmcp-tr-hint { font-size:.75rem; opacity:.55; margin:0; }
+      border-radius:8px; padding:.45rem .7rem; color:inherit; font-size:1.0462em; flex:1; min-width:0; }
+    .cmcp-tr-hint { font-size:0.9231em; opacity:.55; margin:0; }
     .cmcp-tr-btn { background:var(--p-surface-700,#3f3f46); border:1px solid var(--p-surface-600,#52525b);
-      color:inherit; border-radius:8px; padding:.45rem .9rem; cursor:pointer; font-size:.85rem; }
+      color:inherit; border-radius:8px; padding:.45rem .9rem; cursor:pointer; font-size:1.0462em; }
     .cmcp-tr-btn:hover { filter:brightness(1.2); }
     .cmcp-tr-btn:disabled { opacity:.45; cursor:not-allowed; }
     .cmcp-tr-btn.primary { background:var(--p-primary-color,#64748b); border-color:transparent; color:#fff; }
@@ -63,30 +63,30 @@ function injectCss() {
     .cmcp-tr-pick { position:relative; aspect-ratio:1; border-radius:8px; overflow:hidden; cursor:pointer; border:2px solid transparent; background:var(--p-surface-900,#18181b); }
     .cmcp-tr-pick img { width:100%; height:100%; object-fit:cover; display:block; }
     .cmcp-tr-pick.sel { border-color: var(--p-primary-color,#94a3b8); }
-    .cmcp-tr-pick .mark { position:absolute; top:4px; right:4px; background:rgba(0,0,0,.65); border-radius:999px; width:20px; height:20px; display:flex; align-items:center; justify-content:center; font-size:.7rem; }
+    .cmcp-tr-pick .mark { position:absolute; top:4px; right:4px; background:rgba(0,0,0,.65); border-radius:999px; width:20px; height:20px; display:flex; align-items:center; justify-content:center; font-size:0.8615em; }
     .cmcp-tr-pick.sel .mark { background:var(--p-primary-color,#64748b); color:#fff; }
     .cmcp-tr-drop { border:2px dashed var(--p-surface-600,#52525b); border-radius:12px; padding:1.5rem; text-align:center; opacity:.8; cursor:pointer; }
     .cmcp-tr-drop.over { border-color: var(--p-primary-color,#94a3b8); opacity:1; }
     .cmcp-tr-tray { display:flex; gap:.4rem; flex-wrap:wrap; }
     .cmcp-tr-chip { position:relative; width:44px; height:44px; border-radius:6px; background-size:cover; background-position:center; }
-    .cmcp-tr-chip button { position:absolute; top:-6px; right:-6px; width:16px; height:16px; border-radius:999px; border:none; background:#ef4444; color:#fff; font-size:.65rem; line-height:1; cursor:pointer; }
+    .cmcp-tr-chip button { position:absolute; top:-6px; right:-6px; width:16px; height:16px; border-radius:999px; border:none; background:#ef4444; color:#fff; font-size:0.8em; line-height:1; cursor:pointer; }
     .cmcp-tr-labelgrid { display:grid; grid-template-columns:repeat(auto-fill,minmax(200px,1fr)); gap:.75rem; }
     .cmcp-tr-labelitem { background:var(--p-surface-800,#27272a); border-radius:10px; padding:.5rem; display:flex; flex-direction:column; gap:.4rem; }
     .cmcp-tr-labelitem .thumb { aspect-ratio:1; border-radius:8px; background-size:cover; background-position:center; }
-    .cmcp-tr-labelitem textarea { background:var(--p-surface-900,#18181b); border:1px solid var(--p-surface-600,#52525b); border-radius:6px; color:inherit; font-size:.78rem; padding:.35rem .5rem; resize:vertical; min-height:2.6rem; width:100%; box-sizing:border-box; }
+    .cmcp-tr-labelitem textarea { background:var(--p-surface-900,#18181b); border:1px solid var(--p-surface-600,#52525b); border-radius:6px; color:inherit; font-size:0.96em; padding:.35rem .5rem; resize:vertical; min-height:2.6rem; width:100%; box-sizing:border-box; }
     .cmcp-tr-steps { display:flex; gap:.35rem; margin:.6rem 1.25rem 0; flex:none; }
-    .cmcp-tr-steps span { font-size:.72rem; padding:.15rem .6rem; border-radius:999px; background:color-mix(in srgb, currentColor 8%, transparent); opacity:.55; }
+    .cmcp-tr-steps span { font-size:0.8862em; padding:.15rem .6rem; border-radius:999px; background:color-mix(in srgb, currentColor 8%, transparent); opacity:.55; }
     .cmcp-tr-steps span.on { opacity:1; background:var(--p-surface-700,#3f3f46); }
     .cmcp-tr-progress { height:10px; border-radius:999px; background:var(--p-surface-800,#27272a); overflow:hidden; }
     .cmcp-tr-progress > div { height:100%; background:var(--p-primary-color,#64748b); transition:width .4s; }
-    .cmcp-tr-log { background:var(--p-surface-900,#18181b); border-radius:8px; padding:.5rem .7rem; font-family:monospace; font-size:.72rem; max-height:140px; overflow-y:auto; white-space:pre-wrap; word-break:break-all; opacity:.85; }
+    .cmcp-tr-log { background:var(--p-surface-900,#18181b); border-radius:8px; padding:.5rem .7rem; font-family:monospace; font-size:0.8862em; max-height:140px; overflow-y:auto; white-space:pre-wrap; word-break:break-all; opacity:.85; }
     .cmcp-tr-samples { display:flex; gap:.5rem; flex-wrap:wrap; }
     .cmcp-tr-samples img { width:120px; height:120px; object-fit:cover; border-radius:8px; cursor:pointer; }
     .cmcp-tr-jobrow { display:flex; align-items:center; gap:.6rem; padding:.5rem .25rem; border-bottom:1px solid var(--p-surface-700,#3f3f46); cursor:pointer; }
     .cmcp-tr-jobrow:hover { background:color-mix(in srgb, currentColor 4%, transparent); }
-    .cmcp-tr-jobrow .name { flex:1; font-size:.85rem; }
-    .cmcp-tr-jobrow .meta { font-size:.75rem; opacity:.6; }
-    .cmcp-tr-preflight { display:flex; gap:1rem; flex-wrap:wrap; font-size:.78rem; }
+    .cmcp-tr-jobrow .name { flex:1; font-size:1.0462em; }
+    .cmcp-tr-jobrow .meta { font-size:0.9231em; opacity:.6; }
+    .cmcp-tr-preflight { display:flex; gap:1rem; flex-wrap:wrap; font-size:0.96em; }
     .cmcp-tr-preflight span b { font-weight:600; }
     /* Agent-driven "glow" — shared class name with the CivitAI modal; generic here
        so it applies to step chips + field wrappers, not just cards. */

--- a/web/js/cmcp-training-ui.js
+++ b/web/js/cmcp-training-ui.js
@@ -27,34 +27,34 @@ function injectCss() {
     .cmcp-tr-body { flex: 1; overflow-y: auto; min-height: 0; padding-bottom: 1rem; }
     .cmcp-tr-head { display:flex; align-items:center; gap:.75rem; padding:1rem 1.25rem .5rem;
       border-bottom: 1px solid var(--p-content-border-color, #3f3f46); }
-    .cmcp-tr-head h2 { margin:0; font-size:1.2923em; flex:1; }
-    .cmcp-tr-close { background:none; border:none; color:inherit; cursor:pointer; font-size:1.3538em; opacity:.7; }
+    .cmcp-tr-head h2 { margin:0; font-size:calc(var(--cmcp-fs) * 1.2923); flex:1; }
+    .cmcp-tr-close { background:none; border:none; color:inherit; cursor:pointer; font-size:calc(var(--cmcp-fs) * 1.3538); opacity:.7; }
     .cmcp-tr-close:hover { opacity:1; }
     .cmcp-tr-seg { display:flex; gap:0; margin:.75rem 1.25rem; border:1px solid var(--p-surface-500,#555); border-radius:999px; overflow:hidden; width:fit-content; flex:none; }
-    .cmcp-tr-seg button { border:none; background:transparent; color:inherit; padding:.4rem .9rem; cursor:pointer; font-size:1.0462em; display:flex; align-items:center; gap:.4rem; }
+    .cmcp-tr-seg button { border:none; background:transparent; color:inherit; padding:.4rem .9rem; cursor:pointer; font-size:calc(var(--cmcp-fs) * 1.0462); display:flex; align-items:center; gap:.4rem; }
     .cmcp-tr-seg button.active { background: var(--p-surface-700,#3f3f46); }
     .cmcp-tr-grid { display:grid; grid-template-columns:repeat(3,1fr); gap:.75rem; padding:0 1.25rem 1rem; }
     @media (max-width: 640px) { .cmcp-tr-grid { grid-template-columns:repeat(2,1fr); } }
     .cmcp-tr-card { background:var(--p-surface-800,#27272a); border:1px solid var(--p-surface-600,#3f3f46); border-radius:12px; padding:.75rem; display:flex; flex-direction:column; gap:.45rem; }
     .cmcp-tr-card.active { border-color: var(--p-primary-color,#94a3b8); }
-    .cmcp-tr-icon { aspect-ratio:1.6; border-radius:10px; background:color-mix(in srgb, currentColor 8%, transparent); display:flex; align-items:center; justify-content:center; font-size:1.9692em; opacity:.8; }
-    .cmcp-tr-card select { background:var(--p-surface-900,#18181b); color:inherit; border:1px solid var(--p-surface-600,#52525b); border-radius:6px; padding:.25rem .4rem; font-size:0.9846em; width:100%; }
-    .cmcp-tr-card h3 { margin:0; font-size:1.1077em; }
-    .cmcp-tr-card p { margin:0; font-size:0.96em; opacity:.65; line-height:1.35; flex:1; }
-    .cmcp-tr-badge { align-self:flex-start; font-size:0.8862em; padding:.1rem .5rem; border-radius:999px; background:color-mix(in srgb, currentColor 10%, transparent); opacity:.75; }
+    .cmcp-tr-icon { aspect-ratio:1.6; border-radius:10px; background:color-mix(in srgb, currentColor 8%, transparent); display:flex; align-items:center; justify-content:center; font-size:calc(var(--cmcp-fs) * 1.9692); opacity:.8; }
+    .cmcp-tr-card select { background:var(--p-surface-900,#18181b); color:inherit; border:1px solid var(--p-surface-600,#52525b); border-radius:6px; padding:.25rem .4rem; font-size:calc(var(--cmcp-fs) * 0.9846); width:100%; }
+    .cmcp-tr-card h3 { margin:0; font-size:calc(var(--cmcp-fs) * 1.1077); }
+    .cmcp-tr-card p { margin:0; font-size:calc(var(--cmcp-fs) * 0.96); opacity:.65; line-height:1.35; flex:1; }
+    .cmcp-tr-badge { align-self:flex-start; font-size:calc(var(--cmcp-fs) * 0.8862); padding:.1rem .5rem; border-radius:999px; background:color-mix(in srgb, currentColor 10%, transparent); opacity:.75; }
     .cmcp-tr-badge.ok { background: color-mix(in srgb, #22c55e 18%, transparent); opacity:1; }
     .cmcp-tr-badge.err { background: color-mix(in srgb, #ef4444 18%, transparent); opacity:1; }
     .cmcp-tr-badge.warn { background: color-mix(in srgb, #eab308 18%, transparent); opacity:1; }
-    .cmcp-tr-foot { padding:0 1.25rem 1rem; font-size:0.9846em; opacity:.55; }
+    .cmcp-tr-foot { padding:0 1.25rem 1rem; font-size:calc(var(--cmcp-fs) * 0.9846); opacity:.55; }
     .cmcp-tr-section { padding: .25rem 1.25rem; display:flex; flex-direction:column; gap:.6rem; }
     .cmcp-tr-row { display:flex; gap:.6rem; align-items:center; flex-wrap:wrap; }
-    .cmcp-tr-row > label { font-size:0.9846em; opacity:.75; min-width:6.5rem; }
+    .cmcp-tr-row > label { font-size:calc(var(--cmcp-fs) * 0.9846); opacity:.75; min-width:6.5rem; }
     .cmcp-tr-input, .cmcp-tr-section input[type=text], .cmcp-tr-section input[type=number] {
       background:var(--p-surface-800,#27272a); border:1px solid var(--p-surface-600,#52525b);
-      border-radius:8px; padding:.45rem .7rem; color:inherit; font-size:1.0462em; flex:1; min-width:0; }
-    .cmcp-tr-hint { font-size:0.9231em; opacity:.55; margin:0; }
+      border-radius:8px; padding:.45rem .7rem; color:inherit; font-size:calc(var(--cmcp-fs) * 1.0462); flex:1; min-width:0; }
+    .cmcp-tr-hint { font-size:calc(var(--cmcp-fs) * 0.9231); opacity:.55; margin:0; }
     .cmcp-tr-btn { background:var(--p-surface-700,#3f3f46); border:1px solid var(--p-surface-600,#52525b);
-      color:inherit; border-radius:8px; padding:.45rem .9rem; cursor:pointer; font-size:1.0462em; }
+      color:inherit; border-radius:8px; padding:.45rem .9rem; cursor:pointer; font-size:calc(var(--cmcp-fs) * 1.0462); }
     .cmcp-tr-btn:hover { filter:brightness(1.2); }
     .cmcp-tr-btn:disabled { opacity:.45; cursor:not-allowed; }
     .cmcp-tr-btn.primary { background:var(--p-primary-color,#64748b); border-color:transparent; color:#fff; }
@@ -63,30 +63,30 @@ function injectCss() {
     .cmcp-tr-pick { position:relative; aspect-ratio:1; border-radius:8px; overflow:hidden; cursor:pointer; border:2px solid transparent; background:var(--p-surface-900,#18181b); }
     .cmcp-tr-pick img { width:100%; height:100%; object-fit:cover; display:block; }
     .cmcp-tr-pick.sel { border-color: var(--p-primary-color,#94a3b8); }
-    .cmcp-tr-pick .mark { position:absolute; top:4px; right:4px; background:rgba(0,0,0,.65); border-radius:999px; width:20px; height:20px; display:flex; align-items:center; justify-content:center; font-size:0.8615em; }
+    .cmcp-tr-pick .mark { position:absolute; top:4px; right:4px; background:rgba(0,0,0,.65); border-radius:999px; width:20px; height:20px; display:flex; align-items:center; justify-content:center; font-size:calc(var(--cmcp-fs) * 0.8615); }
     .cmcp-tr-pick.sel .mark { background:var(--p-primary-color,#64748b); color:#fff; }
     .cmcp-tr-drop { border:2px dashed var(--p-surface-600,#52525b); border-radius:12px; padding:1.5rem; text-align:center; opacity:.8; cursor:pointer; }
     .cmcp-tr-drop.over { border-color: var(--p-primary-color,#94a3b8); opacity:1; }
     .cmcp-tr-tray { display:flex; gap:.4rem; flex-wrap:wrap; }
     .cmcp-tr-chip { position:relative; width:44px; height:44px; border-radius:6px; background-size:cover; background-position:center; }
-    .cmcp-tr-chip button { position:absolute; top:-6px; right:-6px; width:16px; height:16px; border-radius:999px; border:none; background:#ef4444; color:#fff; font-size:0.8em; line-height:1; cursor:pointer; }
+    .cmcp-tr-chip button { position:absolute; top:-6px; right:-6px; width:16px; height:16px; border-radius:999px; border:none; background:#ef4444; color:#fff; font-size:calc(var(--cmcp-fs) * 0.8); line-height:1; cursor:pointer; }
     .cmcp-tr-labelgrid { display:grid; grid-template-columns:repeat(auto-fill,minmax(200px,1fr)); gap:.75rem; }
     .cmcp-tr-labelitem { background:var(--p-surface-800,#27272a); border-radius:10px; padding:.5rem; display:flex; flex-direction:column; gap:.4rem; }
     .cmcp-tr-labelitem .thumb { aspect-ratio:1; border-radius:8px; background-size:cover; background-position:center; }
-    .cmcp-tr-labelitem textarea { background:var(--p-surface-900,#18181b); border:1px solid var(--p-surface-600,#52525b); border-radius:6px; color:inherit; font-size:0.96em; padding:.35rem .5rem; resize:vertical; min-height:2.6rem; width:100%; box-sizing:border-box; }
+    .cmcp-tr-labelitem textarea { background:var(--p-surface-900,#18181b); border:1px solid var(--p-surface-600,#52525b); border-radius:6px; color:inherit; font-size:calc(var(--cmcp-fs) * 0.96); padding:.35rem .5rem; resize:vertical; min-height:2.6rem; width:100%; box-sizing:border-box; }
     .cmcp-tr-steps { display:flex; gap:.35rem; margin:.6rem 1.25rem 0; flex:none; }
-    .cmcp-tr-steps span { font-size:0.8862em; padding:.15rem .6rem; border-radius:999px; background:color-mix(in srgb, currentColor 8%, transparent); opacity:.55; }
+    .cmcp-tr-steps span { font-size:calc(var(--cmcp-fs) * 0.8862); padding:.15rem .6rem; border-radius:999px; background:color-mix(in srgb, currentColor 8%, transparent); opacity:.55; }
     .cmcp-tr-steps span.on { opacity:1; background:var(--p-surface-700,#3f3f46); }
     .cmcp-tr-progress { height:10px; border-radius:999px; background:var(--p-surface-800,#27272a); overflow:hidden; }
     .cmcp-tr-progress > div { height:100%; background:var(--p-primary-color,#64748b); transition:width .4s; }
-    .cmcp-tr-log { background:var(--p-surface-900,#18181b); border-radius:8px; padding:.5rem .7rem; font-family:monospace; font-size:0.8862em; max-height:140px; overflow-y:auto; white-space:pre-wrap; word-break:break-all; opacity:.85; }
+    .cmcp-tr-log { background:var(--p-surface-900,#18181b); border-radius:8px; padding:.5rem .7rem; font-family:monospace; font-size:calc(var(--cmcp-fs) * 0.8862); max-height:140px; overflow-y:auto; white-space:pre-wrap; word-break:break-all; opacity:.85; }
     .cmcp-tr-samples { display:flex; gap:.5rem; flex-wrap:wrap; }
     .cmcp-tr-samples img { width:120px; height:120px; object-fit:cover; border-radius:8px; cursor:pointer; }
     .cmcp-tr-jobrow { display:flex; align-items:center; gap:.6rem; padding:.5rem .25rem; border-bottom:1px solid var(--p-surface-700,#3f3f46); cursor:pointer; }
     .cmcp-tr-jobrow:hover { background:color-mix(in srgb, currentColor 4%, transparent); }
-    .cmcp-tr-jobrow .name { flex:1; font-size:1.0462em; }
-    .cmcp-tr-jobrow .meta { font-size:0.9231em; opacity:.6; }
-    .cmcp-tr-preflight { display:flex; gap:1rem; flex-wrap:wrap; font-size:0.96em; }
+    .cmcp-tr-jobrow .name { flex:1; font-size:calc(var(--cmcp-fs) * 1.0462); }
+    .cmcp-tr-jobrow .meta { font-size:calc(var(--cmcp-fs) * 0.9231); opacity:.6; }
+    .cmcp-tr-preflight { display:flex; gap:1rem; flex-wrap:wrap; font-size:calc(var(--cmcp-fs) * 0.96); }
     .cmcp-tr-preflight span b { font-weight:600; }
     /* Agent-driven "glow" — shared class name with the CivitAI modal; generic here
        so it applies to step chips + field wrappers, not just cards. */

--- a/web/js/cmcp-training-ui.js
+++ b/web/js/cmcp-training-ui.js
@@ -27,34 +27,34 @@ function injectCss() {
     .cmcp-tr-body { flex: 1; overflow-y: auto; min-height: 0; padding-bottom: 1rem; }
     .cmcp-tr-head { display:flex; align-items:center; gap:.75rem; padding:1rem 1.25rem .5rem;
       border-bottom: 1px solid var(--p-content-border-color, #3f3f46); }
-    .cmcp-tr-head h2 { margin:0; font-size:calc(var(--cmcp-fs) * 1.2923); flex:1; }
-    .cmcp-tr-close { background:none; border:none; color:inherit; cursor:pointer; font-size:calc(var(--cmcp-fs) * 1.3538); opacity:.7; }
+    .cmcp-tr-head h2 { margin:0; font-size:calc(var(--cmcp-fs, 0.8125rem) * 1.2923); flex:1; }
+    .cmcp-tr-close { background:none; border:none; color:inherit; cursor:pointer; font-size:calc(var(--cmcp-fs, 0.8125rem) * 1.3538); opacity:.7; }
     .cmcp-tr-close:hover { opacity:1; }
     .cmcp-tr-seg { display:flex; gap:0; margin:.75rem 1.25rem; border:1px solid var(--p-surface-500,#555); border-radius:999px; overflow:hidden; width:fit-content; flex:none; }
-    .cmcp-tr-seg button { border:none; background:transparent; color:inherit; padding:.4rem .9rem; cursor:pointer; font-size:calc(var(--cmcp-fs) * 1.0462); display:flex; align-items:center; gap:.4rem; }
+    .cmcp-tr-seg button { border:none; background:transparent; color:inherit; padding:.4rem .9rem; cursor:pointer; font-size:calc(var(--cmcp-fs, 0.8125rem) * 1.0462); display:flex; align-items:center; gap:.4rem; }
     .cmcp-tr-seg button.active { background: var(--p-surface-700,#3f3f46); }
     .cmcp-tr-grid { display:grid; grid-template-columns:repeat(3,1fr); gap:.75rem; padding:0 1.25rem 1rem; }
     @media (max-width: 640px) { .cmcp-tr-grid { grid-template-columns:repeat(2,1fr); } }
     .cmcp-tr-card { background:var(--p-surface-800,#27272a); border:1px solid var(--p-surface-600,#3f3f46); border-radius:12px; padding:.75rem; display:flex; flex-direction:column; gap:.45rem; }
     .cmcp-tr-card.active { border-color: var(--p-primary-color,#94a3b8); }
-    .cmcp-tr-icon { aspect-ratio:1.6; border-radius:10px; background:color-mix(in srgb, currentColor 8%, transparent); display:flex; align-items:center; justify-content:center; font-size:calc(var(--cmcp-fs) * 1.9692); opacity:.8; }
-    .cmcp-tr-card select { background:var(--p-surface-900,#18181b); color:inherit; border:1px solid var(--p-surface-600,#52525b); border-radius:6px; padding:.25rem .4rem; font-size:calc(var(--cmcp-fs) * 0.9846); width:100%; }
-    .cmcp-tr-card h3 { margin:0; font-size:calc(var(--cmcp-fs) * 1.1077); }
-    .cmcp-tr-card p { margin:0; font-size:calc(var(--cmcp-fs) * 0.96); opacity:.65; line-height:1.35; flex:1; }
-    .cmcp-tr-badge { align-self:flex-start; font-size:calc(var(--cmcp-fs) * 0.8862); padding:.1rem .5rem; border-radius:999px; background:color-mix(in srgb, currentColor 10%, transparent); opacity:.75; }
+    .cmcp-tr-icon { aspect-ratio:1.6; border-radius:10px; background:color-mix(in srgb, currentColor 8%, transparent); display:flex; align-items:center; justify-content:center; font-size:calc(var(--cmcp-fs, 0.8125rem) * 1.9692); opacity:.8; }
+    .cmcp-tr-card select { background:var(--p-surface-900,#18181b); color:inherit; border:1px solid var(--p-surface-600,#52525b); border-radius:6px; padding:.25rem .4rem; font-size:calc(var(--cmcp-fs, 0.8125rem) * 0.9846); width:100%; }
+    .cmcp-tr-card h3 { margin:0; font-size:calc(var(--cmcp-fs, 0.8125rem) * 1.1077); }
+    .cmcp-tr-card p { margin:0; font-size:calc(var(--cmcp-fs, 0.8125rem) * 0.96); opacity:.65; line-height:1.35; flex:1; }
+    .cmcp-tr-badge { align-self:flex-start; font-size:calc(var(--cmcp-fs, 0.8125rem) * 0.8862); padding:.1rem .5rem; border-radius:999px; background:color-mix(in srgb, currentColor 10%, transparent); opacity:.75; }
     .cmcp-tr-badge.ok { background: color-mix(in srgb, #22c55e 18%, transparent); opacity:1; }
     .cmcp-tr-badge.err { background: color-mix(in srgb, #ef4444 18%, transparent); opacity:1; }
     .cmcp-tr-badge.warn { background: color-mix(in srgb, #eab308 18%, transparent); opacity:1; }
-    .cmcp-tr-foot { padding:0 1.25rem 1rem; font-size:calc(var(--cmcp-fs) * 0.9846); opacity:.55; }
+    .cmcp-tr-foot { padding:0 1.25rem 1rem; font-size:calc(var(--cmcp-fs, 0.8125rem) * 0.9846); opacity:.55; }
     .cmcp-tr-section { padding: .25rem 1.25rem; display:flex; flex-direction:column; gap:.6rem; }
     .cmcp-tr-row { display:flex; gap:.6rem; align-items:center; flex-wrap:wrap; }
-    .cmcp-tr-row > label { font-size:calc(var(--cmcp-fs) * 0.9846); opacity:.75; min-width:6.5rem; }
+    .cmcp-tr-row > label { font-size:calc(var(--cmcp-fs, 0.8125rem) * 0.9846); opacity:.75; min-width:6.5rem; }
     .cmcp-tr-input, .cmcp-tr-section input[type=text], .cmcp-tr-section input[type=number] {
       background:var(--p-surface-800,#27272a); border:1px solid var(--p-surface-600,#52525b);
-      border-radius:8px; padding:.45rem .7rem; color:inherit; font-size:calc(var(--cmcp-fs) * 1.0462); flex:1; min-width:0; }
-    .cmcp-tr-hint { font-size:calc(var(--cmcp-fs) * 0.9231); opacity:.55; margin:0; }
+      border-radius:8px; padding:.45rem .7rem; color:inherit; font-size:calc(var(--cmcp-fs, 0.8125rem) * 1.0462); flex:1; min-width:0; }
+    .cmcp-tr-hint { font-size:calc(var(--cmcp-fs, 0.8125rem) * 0.9231); opacity:.55; margin:0; }
     .cmcp-tr-btn { background:var(--p-surface-700,#3f3f46); border:1px solid var(--p-surface-600,#52525b);
-      color:inherit; border-radius:8px; padding:.45rem .9rem; cursor:pointer; font-size:calc(var(--cmcp-fs) * 1.0462); }
+      color:inherit; border-radius:8px; padding:.45rem .9rem; cursor:pointer; font-size:calc(var(--cmcp-fs, 0.8125rem) * 1.0462); }
     .cmcp-tr-btn:hover { filter:brightness(1.2); }
     .cmcp-tr-btn:disabled { opacity:.45; cursor:not-allowed; }
     .cmcp-tr-btn.primary { background:var(--p-primary-color,#64748b); border-color:transparent; color:#fff; }
@@ -63,30 +63,30 @@ function injectCss() {
     .cmcp-tr-pick { position:relative; aspect-ratio:1; border-radius:8px; overflow:hidden; cursor:pointer; border:2px solid transparent; background:var(--p-surface-900,#18181b); }
     .cmcp-tr-pick img { width:100%; height:100%; object-fit:cover; display:block; }
     .cmcp-tr-pick.sel { border-color: var(--p-primary-color,#94a3b8); }
-    .cmcp-tr-pick .mark { position:absolute; top:4px; right:4px; background:rgba(0,0,0,.65); border-radius:999px; width:20px; height:20px; display:flex; align-items:center; justify-content:center; font-size:calc(var(--cmcp-fs) * 0.8615); }
+    .cmcp-tr-pick .mark { position:absolute; top:4px; right:4px; background:rgba(0,0,0,.65); border-radius:999px; width:20px; height:20px; display:flex; align-items:center; justify-content:center; font-size:calc(var(--cmcp-fs, 0.8125rem) * 0.8615); }
     .cmcp-tr-pick.sel .mark { background:var(--p-primary-color,#64748b); color:#fff; }
     .cmcp-tr-drop { border:2px dashed var(--p-surface-600,#52525b); border-radius:12px; padding:1.5rem; text-align:center; opacity:.8; cursor:pointer; }
     .cmcp-tr-drop.over { border-color: var(--p-primary-color,#94a3b8); opacity:1; }
     .cmcp-tr-tray { display:flex; gap:.4rem; flex-wrap:wrap; }
     .cmcp-tr-chip { position:relative; width:44px; height:44px; border-radius:6px; background-size:cover; background-position:center; }
-    .cmcp-tr-chip button { position:absolute; top:-6px; right:-6px; width:16px; height:16px; border-radius:999px; border:none; background:#ef4444; color:#fff; font-size:calc(var(--cmcp-fs) * 0.8); line-height:1; cursor:pointer; }
+    .cmcp-tr-chip button { position:absolute; top:-6px; right:-6px; width:16px; height:16px; border-radius:999px; border:none; background:#ef4444; color:#fff; font-size:calc(var(--cmcp-fs, 0.8125rem) * 0.8); line-height:1; cursor:pointer; }
     .cmcp-tr-labelgrid { display:grid; grid-template-columns:repeat(auto-fill,minmax(200px,1fr)); gap:.75rem; }
     .cmcp-tr-labelitem { background:var(--p-surface-800,#27272a); border-radius:10px; padding:.5rem; display:flex; flex-direction:column; gap:.4rem; }
     .cmcp-tr-labelitem .thumb { aspect-ratio:1; border-radius:8px; background-size:cover; background-position:center; }
-    .cmcp-tr-labelitem textarea { background:var(--p-surface-900,#18181b); border:1px solid var(--p-surface-600,#52525b); border-radius:6px; color:inherit; font-size:calc(var(--cmcp-fs) * 0.96); padding:.35rem .5rem; resize:vertical; min-height:2.6rem; width:100%; box-sizing:border-box; }
+    .cmcp-tr-labelitem textarea { background:var(--p-surface-900,#18181b); border:1px solid var(--p-surface-600,#52525b); border-radius:6px; color:inherit; font-size:calc(var(--cmcp-fs, 0.8125rem) * 0.96); padding:.35rem .5rem; resize:vertical; min-height:2.6rem; width:100%; box-sizing:border-box; }
     .cmcp-tr-steps { display:flex; gap:.35rem; margin:.6rem 1.25rem 0; flex:none; }
-    .cmcp-tr-steps span { font-size:calc(var(--cmcp-fs) * 0.8862); padding:.15rem .6rem; border-radius:999px; background:color-mix(in srgb, currentColor 8%, transparent); opacity:.55; }
+    .cmcp-tr-steps span { font-size:calc(var(--cmcp-fs, 0.8125rem) * 0.8862); padding:.15rem .6rem; border-radius:999px; background:color-mix(in srgb, currentColor 8%, transparent); opacity:.55; }
     .cmcp-tr-steps span.on { opacity:1; background:var(--p-surface-700,#3f3f46); }
     .cmcp-tr-progress { height:10px; border-radius:999px; background:var(--p-surface-800,#27272a); overflow:hidden; }
     .cmcp-tr-progress > div { height:100%; background:var(--p-primary-color,#64748b); transition:width .4s; }
-    .cmcp-tr-log { background:var(--p-surface-900,#18181b); border-radius:8px; padding:.5rem .7rem; font-family:monospace; font-size:calc(var(--cmcp-fs) * 0.8862); max-height:140px; overflow-y:auto; white-space:pre-wrap; word-break:break-all; opacity:.85; }
+    .cmcp-tr-log { background:var(--p-surface-900,#18181b); border-radius:8px; padding:.5rem .7rem; font-family:monospace; font-size:calc(var(--cmcp-fs, 0.8125rem) * 0.8862); max-height:140px; overflow-y:auto; white-space:pre-wrap; word-break:break-all; opacity:.85; }
     .cmcp-tr-samples { display:flex; gap:.5rem; flex-wrap:wrap; }
     .cmcp-tr-samples img { width:120px; height:120px; object-fit:cover; border-radius:8px; cursor:pointer; }
     .cmcp-tr-jobrow { display:flex; align-items:center; gap:.6rem; padding:.5rem .25rem; border-bottom:1px solid var(--p-surface-700,#3f3f46); cursor:pointer; }
     .cmcp-tr-jobrow:hover { background:color-mix(in srgb, currentColor 4%, transparent); }
-    .cmcp-tr-jobrow .name { flex:1; font-size:calc(var(--cmcp-fs) * 1.0462); }
-    .cmcp-tr-jobrow .meta { font-size:calc(var(--cmcp-fs) * 0.9231); opacity:.6; }
-    .cmcp-tr-preflight { display:flex; gap:1rem; flex-wrap:wrap; font-size:calc(var(--cmcp-fs) * 0.96); }
+    .cmcp-tr-jobrow .name { flex:1; font-size:calc(var(--cmcp-fs, 0.8125rem) * 1.0462); }
+    .cmcp-tr-jobrow .meta { font-size:calc(var(--cmcp-fs, 0.8125rem) * 0.9231); opacity:.6; }
+    .cmcp-tr-preflight { display:flex; gap:1rem; flex-wrap:wrap; font-size:calc(var(--cmcp-fs, 0.8125rem) * 0.96); }
     .cmcp-tr-preflight span b { font-weight:600; }
     /* Agent-driven "glow" — shared class name with the CivitAI modal; generic here
        so it applies to step chips + field wrappers, not just cards. */

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -3220,7 +3220,7 @@ function makeSettingSelect() {
   sel.className = "p-inputtext p-component";
   sel.style.cssText =
     "padding:0.3rem 0.5rem;border-radius:6px;border:1px solid var(--p-surface-500,#555);" +
-    "background:var(--p-surface-900,#18181b);color:var(--p-text-color,#e4e4e7);font-size:calc(var(--cmcp-fs) * 0.9846);min-width:14rem;";
+    "background:var(--p-surface-900,#18181b);color:var(--p-text-color,#e4e4e7);font-size:calc(var(--cmcp-fs, 0.8125rem) * 0.9846);min-width:14rem;";
   return sel;
 }
 /** (Re)populate a backend's Default-model <select>: an "Auto" option, then that
@@ -3497,9 +3497,9 @@ function panelSettingsList() {
       btn.textContent = `Set ${friendly} ${noun}…`;
       btn.style.cssText =
         "padding:0.3rem 0.7rem;border-radius:6px;border:1px solid var(--p-surface-500,#555);" +
-        "background:var(--p-primary-color,#3a7bd5);color:#fff;cursor:pointer;font-size:calc(var(--cmcp-fs) * 0.9846);white-space:nowrap;";
+        "background:var(--p-primary-color,#3a7bd5);color:#fff;cursor:pointer;font-size:calc(var(--cmcp-fs, 0.8125rem) * 0.9846);white-space:nowrap;";
       const status = document.createElement("span");
-      status.style.cssText = "font-size:calc(var(--cmcp-fs) * 0.8862);opacity:0.8;";
+      status.style.cssText = "font-size:calc(var(--cmcp-fs, 0.8125rem) * 0.8862);opacity:0.8;";
       const refresh = () => {
         const at = lsGet(SECRET_SET_AT_PREFIX + envKey);
         if (at) {
@@ -3644,7 +3644,7 @@ function panelSettingsList() {
         a.style.cssText =
           "display:inline-flex;align-items:center;gap:0.4rem;padding:0.3rem 0.7rem;border-radius:6px;" +
           "border:1px solid var(--p-surface-500,#555);background:var(--p-surface-800,#27272a);" +
-          "color:var(--p-text-color,#e4e4e7);text-decoration:none;font-size:calc(var(--cmcp-fs) * 0.9846);white-space:nowrap;";
+          "color:var(--p-text-color,#e4e4e7);text-decoration:none;font-size:calc(var(--cmcp-fs, 0.8125rem) * 0.9846);white-space:nowrap;";
         return a;
       },
     },
@@ -3668,7 +3668,7 @@ function panelSettingsList() {
         b.style.cssText =
           "display:inline-flex;align-items:center;gap:0.4rem;padding:0.3rem 0.7rem;border-radius:6px;" +
           "border:1px solid var(--p-surface-500,#555);background:var(--p-surface-800,#27272a);" +
-          "color:var(--p-text-color,#e4e4e7);cursor:pointer;font-size:calc(var(--cmcp-fs) * 0.9846);white-space:nowrap;";
+          "color:var(--p-text-color,#e4e4e7);cursor:pointer;font-size:calc(var(--cmcp-fs, 0.8125rem) * 0.9846);white-space:nowrap;";
         b.addEventListener("click", () => {
           // Open the panel first — painting into a transcript the user cannot see is the
           // same failure as not painting at all. openSidebarTab() is the same activate the
@@ -3712,7 +3712,7 @@ function panelSettingsList() {
         a.style.cssText =
           "display:inline-flex;align-items:center;gap:0.4rem;padding:0.3rem 0.7rem;border-radius:6px;" +
           "border:1px solid var(--p-surface-500,#555);background:var(--p-surface-800,#27272a);" +
-          "color:var(--p-text-color,#e4e4e7);text-decoration:none;font-size:calc(var(--cmcp-fs) * 0.9846);white-space:nowrap;";
+          "color:var(--p-text-color,#e4e4e7);text-decoration:none;font-size:calc(var(--cmcp-fs, 0.8125rem) * 0.9846);white-space:nowrap;";
         return a;
       },
     },
@@ -3732,7 +3732,7 @@ function panelSettingsList() {
         a.style.cssText =
           "display:inline-flex;align-items:center;gap:0.4rem;padding:0.3rem 0.7rem;border-radius:6px;" +
           "border:1px solid var(--p-surface-500,#555);background:var(--p-surface-800,#27272a);" +
-          "color:var(--p-text-color,#e4e4e7);text-decoration:none;font-size:calc(var(--cmcp-fs) * 0.9846);white-space:nowrap;";
+          "color:var(--p-text-color,#e4e4e7);text-decoration:none;font-size:calc(var(--cmcp-fs, 0.8125rem) * 0.9846);white-space:nowrap;";
         return a;
       },
     },
@@ -3754,7 +3754,7 @@ function panelSettingsList() {
         btn.style.cssText =
           "display:inline-flex;align-items:center;gap:0.4rem;padding:0.3rem 0.7rem;border-radius:6px;" +
           "border:1px solid var(--p-primary-color,#8b5cf6);background:var(--p-primary-color,#8b5cf6);" +
-          "color:#fff;font-size:calc(var(--cmcp-fs) * 0.9846);white-space:nowrap;cursor:pointer;";
+          "color:#fff;font-size:calc(var(--cmcp-fs, 0.8125rem) * 0.9846);white-space:nowrap;cursor:pointer;";
         btn.addEventListener("click", async () => {
           const diag = [
             "--- comfyui-mcp panel diagnostics ---",
@@ -3932,7 +3932,7 @@ function panelSettingsList() {
         note.textContent =
           "⚠️ Beta — the app changes rapidly and builds may break between updates. " +
           "Enable the toggle above, install for your platform, then pair with the QR button in the panel header.";
-        note.style.cssText = "font-size:calc(var(--cmcp-fs) * 0.9231);opacity:0.75;line-height:1.35;";
+        note.style.cssText = "font-size:calc(var(--cmcp-fs, 0.8125rem) * 0.9231);opacity:0.75;line-height:1.35;";
         const row = document.createElement("div");
         row.style.cssText = "display:flex;gap:0.5rem;flex-wrap:wrap;";
         const linkBtn = (label, url) => {
@@ -3941,7 +3941,7 @@ function panelSettingsList() {
           a.style.cssText =
             "display:inline-flex;align-items:center;gap:0.4rem;padding:0.3rem 0.7rem;border-radius:6px;" +
             "border:1px solid var(--p-surface-500,#555);background:var(--p-surface-800,#27272a);" +
-            "color:var(--p-text-color,#e4e4e7);text-decoration:none;font-size:calc(var(--cmcp-fs) * 0.9846);white-space:nowrap;";
+            "color:var(--p-text-color,#e4e4e7);text-decoration:none;font-size:calc(var(--cmcp-fs, 0.8125rem) * 0.9846);white-space:nowrap;";
           if (url) {
             a.href = url;
             a.target = "_blank";
@@ -6924,7 +6924,7 @@ function makeShellCommandBlock(baseCmd) {
     b.className = "cmcp-btn";
     b.dataset.shell = s.key;
     b.textContent = s.label;
-    b.style.cssText = "font-size:calc(var(--cmcp-fs) * 0.8862);padding:0.12rem 0.45rem;";
+    b.style.cssText = "font-size:calc(var(--cmcp-fs, 0.8125rem) * 0.8862);padding:0.12rem 0.45rem;";
     b.addEventListener("click", () => { selected = s.key; render(); copy(forms[s.key]); });
     pills.appendChild(b);
   }
@@ -17927,7 +17927,7 @@ const PANEL_CSS = `
      both ways. Do not re-add it. */
   position: relative; /* positioning context for the rollback modal overlay */
   font-family: var(--font-inter, "Inter", ui-sans-serif, system-ui, sans-serif);
-  /* #753 — THE ONE KNOB. Every inner font size is calc(var(--cmcp-fs) * k), so a
+  /* #753 — THE ONE KNOB. Every inner font size is calc(var(--cmcp-fs, 0.8125rem) * k), so a
      change here scales all of them at once, at any nesting depth. An em unit was
      tried
      first and rejected: it resolves against the PARENT, so a rule inside a block
@@ -17935,7 +17935,7 @@ const PANEL_CSS = `
      different parents has no single correct value at all (measured: 529 drifted
      elements, ~25 nested sites, 5 inexpressible rules). A variable is flat. */
   --cmcp-fs: 0.8125rem;
-  font-size: var(--cmcp-fs); line-height: 1.5;
+  font-size: var(--cmcp-fs, 0.8125rem); line-height: 1.5;
   color: var(--p-text-color, #fff);
   background: var(--p-content-background, #18181b);
 }
@@ -17949,7 +17949,7 @@ const PANEL_CSS = `
    header actions on a narrow sidebar. */
 .cmcp-logo { height: 20px; width: auto; max-width: 148px; flex: none; object-fit: contain; display: block; }
 .cmcp-status { display: flex; align-items: center; gap: 0.375rem; margin-left: auto;
-  font-size: calc(var(--cmcp-fs) * 0.8462); color: var(--p-text-muted-color, #a1a1aa); }
+  font-size: calc(var(--cmcp-fs, 0.8125rem) * 0.8462); color: var(--p-text-muted-color, #a1a1aa); }
 .cmcp-dot { width: 8px; height: 8px; border-radius: 50%; background: var(--p-red-400, #f87171); flex: none; }
 .cmcp-dot.connected { background: var(--p-green-400, #4ade80); }
 .cmcp-dot.connecting { background: var(--p-yellow-400, #facc15); animation: cmcp-pulse 1.2s ease-in-out infinite; }
@@ -17970,12 +17970,12 @@ const PANEL_CSS = `
   background: transparent; border: none; cursor: pointer;
   border-radius: var(--p-border-radius-sm, 4px);
   padding: 0.25rem 0.5rem;
-  font: inherit; font-size: calc(var(--cmcp-fs) * 0.8462);
+  font: inherit; font-size: calc(var(--cmcp-fs, 0.8125rem) * 0.8462);
   color: var(--p-text-muted-color, #a1a1aa);
   transition: background 0.15s, color 0.15s;
 }
 .cmcp-toolbtn:hover { background: var(--p-surface-700, #3f3f46); color: var(--p-text-color, #fff); }
-.cmcp-toolbtn .pi { font-size: var(--cmcp-fs); }
+.cmcp-toolbtn .pi { font-size: var(--cmcp-fs, 0.8125rem); }
 .cmcp-toolbtn svg { width: 13px; height: 13px; display: block; }
 /* Icon-only variant (Deafen/Blind): the label span stays in the DOM — state
    copy still flows into it for screen readers / the find-icon logic — but is
@@ -17986,7 +17986,7 @@ const PANEL_CSS = `
   position: absolute; width: 1px; height: 1px; overflow: hidden;
   clip: rect(0 0 0 0); clip-path: inset(50%); white-space: nowrap;
 }
-.cmcp-toolbtn.cmcp-toolbtn-iconic .pi { font-size: calc(var(--cmcp-fs) * 1.1538); }
+.cmcp-toolbtn.cmcp-toolbtn-iconic .pi { font-size: calc(var(--cmcp-fs, 0.8125rem) * 1.1538); }
 .cmcp-toolbtn.cmcp-toolbtn-iconic svg { width: 15px; height: 15px; }
 /* Active tab: the four surface buttons ARE the tab bar (issue #124) — the open
    one gets the themed toggled state (inverts light/dark via the primary tokens). */
@@ -18023,13 +18023,13 @@ const PANEL_CSS = `
 }
 .cmcp-settings > summary {
   padding: 0.5rem 0.75rem; cursor: pointer; user-select: none;
-  font-size: calc(var(--cmcp-fs) * 0.9231); font-weight: 600; color: var(--p-text-muted-color, #a1a1aa);
+  font-size: calc(var(--cmcp-fs, 0.8125rem) * 0.9231); font-weight: 600; color: var(--p-text-muted-color, #a1a1aa);
   list-style: none; display: flex; align-items: center; gap: 0.375rem;
 }
 .cmcp-settings > summary::before { content: "▸"; transition: transform 0.15s; }
 .cmcp-settings[open] > summary::before { transform: rotate(90deg); }
 .cmcp-settings-body { padding: 0 0.75rem 0.75rem; display: flex; flex-direction: column; gap: 0.5rem; }
-.cmcp-label { font-size: calc(var(--cmcp-fs) * 0.8462); color: var(--p-text-muted-color, #a1a1aa); }
+.cmcp-label { font-size: calc(var(--cmcp-fs, 0.8125rem) * 0.8462); color: var(--p-text-muted-color, #a1a1aa); }
 .cmcp-input {
   width: 100%; box-sizing: border-box;
   padding: var(--p-form-field-padding-y, 0.5rem) var(--p-form-field-padding-x, 0.75rem);
@@ -18049,13 +18049,13 @@ const PANEL_CSS = `
 }
 .cmcp-btn:hover { opacity: 0.85; }
 .cmcp-btn:disabled { opacity: 0.4; cursor: default; }
-.cmcp-help { font-size: calc(var(--cmcp-fs) * 0.8462); color: var(--p-text-muted-color, #a1a1aa); line-height: 1.55; }
+.cmcp-help { font-size: calc(var(--cmcp-fs, 0.8125rem) * 0.8462); color: var(--p-text-muted-color, #a1a1aa); line-height: 1.55; }
 .cmcp-cmd {
   display: block; margin-top: 0.25rem; padding: 0.375rem 0.5rem;
   background: var(--p-form-field-background, #09090b);
   border: 1px solid var(--p-content-border-color, #3f3f46);
   border-radius: var(--p-border-radius-sm, 4px);
-  font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: calc(var(--cmcp-fs) * 0.8462);
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: calc(var(--cmcp-fs, 0.8125rem) * 0.8462);
   user-select: all; cursor: copy; color: var(--p-text-color, #fff);
   overflow-x: auto; white-space: nowrap;
 }
@@ -18074,12 +18074,12 @@ const PANEL_CSS = `
   margin: auto; text-align: center; max-width: 230px;
   color: var(--p-text-muted-color, #a1a1aa);
 }
-.cmcp-empty .pi { font-size: calc(var(--cmcp-fs) * 2.1538); display: block; margin-bottom: 0.5rem; opacity: 0.5; }
+.cmcp-empty .pi { font-size: calc(var(--cmcp-fs, 0.8125rem) * 2.1538); display: block; margin-bottom: 0.5rem; opacity: 0.5; }
 .cmcp-empty-title { font-weight: 600; color: var(--p-text-color, #fff); margin-bottom: 0.25rem; }
 .cmcp-examples { display: flex; flex-direction: column; gap: 0.375rem; margin-top: 0.875rem; text-align: left; }
 .cmcp-example {
   display: flex; align-items: center; gap: 0.5rem; width: 100%; box-sizing: border-box;
-  padding: 0.4375rem 0.625rem; cursor: pointer; font: inherit; font-size: calc(var(--cmcp-fs) * 0.9231);
+  padding: 0.4375rem 0.625rem; cursor: pointer; font: inherit; font-size: calc(var(--cmcp-fs, 0.8125rem) * 0.9231);
   color: var(--p-text-color, #fff); text-align: left;
   background: var(--p-surface-800, #27272a);
   border: 1px solid var(--p-content-border-color, #3f3f46);
@@ -18087,7 +18087,7 @@ const PANEL_CSS = `
   transition: border-color 0.15s, background 0.15s;
 }
 .cmcp-example:hover { border-color: var(--p-primary-color, #60a5fa); background: var(--p-surface-700, #3f3f46); }
-.cmcp-example .pi { font-size: var(--cmcp-fs); margin: 0; opacity: 1; color: var(--p-primary-color, #60a5fa); flex: none; }
+.cmcp-example .pi { font-size: var(--cmcp-fs, 0.8125rem); margin: 0; opacity: 1; color: var(--p-primary-color, #60a5fa); flex: none; }
 
 /* Provider onboarding card — shown only when NEITHER provider is signed in. */
 .cmcp-onboard {
@@ -18101,10 +18101,10 @@ const PANEL_CSS = `
    it or "onboard.hidden = true" won't actually hide the card. */
 .cmcp-onboard[hidden] { display: none; }
 .cmcp-onboard-title { font-weight: 600; color: var(--p-text-color, #fff); }
-.cmcp-onboard-sub { font-size: calc(var(--cmcp-fs) * 0.9231); color: var(--p-text-muted-color, #a1a1aa); line-height: 1.4; }
+.cmcp-onboard-sub { font-size: calc(var(--cmcp-fs, 0.8125rem) * 0.9231); color: var(--p-text-muted-color, #a1a1aa); line-height: 1.4; }
 .cmcp-onboard-col { display: flex; flex-direction: column; gap: 0.25rem; }
-.cmcp-onboard-prov { font-weight: 600; font-size: var(--cmcp-fs); color: var(--p-text-color, #fff); margin-top: 0.25rem; }
-.cmcp-onboard-step { font-size: calc(var(--cmcp-fs) * 0.8615); color: var(--p-text-muted-color, #a1a1aa); }
+.cmcp-onboard-prov { font-weight: 600; font-size: var(--cmcp-fs, 0.8125rem); color: var(--p-text-color, #fff); margin-top: 0.25rem; }
+.cmcp-onboard-step { font-size: calc(var(--cmcp-fs, 0.8125rem) * 0.8615); color: var(--p-text-muted-color, #a1a1aa); }
 
 .cmcp-bubble {
   padding: 0.5rem 0.75rem; max-width: 92%;
@@ -18126,7 +18126,7 @@ const PANEL_CSS = `
   display: flex; align-items: center; justify-content: center;
   border: 1px solid var(--p-content-border-color, #3f3f46);
   background: var(--p-surface-800, #27272a); color: var(--p-text-muted-color, #a1a1aa);
-  cursor: pointer; opacity: 0; transition: opacity 0.12s, color 0.12s; font-size: calc(var(--cmcp-fs) * 0.8615);
+  cursor: pointer; opacity: 0; transition: opacity 0.12s, color 0.12s; font-size: calc(var(--cmcp-fs, 0.8125rem) * 0.8615);
 }
 .cmcp-bubble.user:hover .cmcp-edit-btn { opacity: 1; }
 .cmcp-edit-btn:hover { color: var(--p-primary-color, #60a5fa); border-color: var(--p-primary-color, #60a5fa); }
@@ -18140,15 +18140,15 @@ const PANEL_CSS = `
   padding: 0.85rem; border-radius: 10px; background: var(--p-surface-900, #18181b);
   border: 1px solid var(--p-content-border-color, #3f3f46); box-shadow: 0 8px 30px rgba(0,0,0,0.5);
 }
-.cmcp-modal-title { font-weight: 600; font-size: calc(var(--cmcp-fs) * 1.0462); }
+.cmcp-modal-title { font-weight: 600; font-size: calc(var(--cmcp-fs, 0.8125rem) * 1.0462); }
 .cmcp-modal-text {
   width: 100%; box-sizing: border-box; resize: vertical; min-height: 3.5rem;
-  padding: 0.4rem 0.5rem; border-radius: 6px; font: inherit; font-size: calc(var(--cmcp-fs) * 0.9846);
+  padding: 0.4rem 0.5rem; border-radius: 6px; font: inherit; font-size: calc(var(--cmcp-fs, 0.8125rem) * 0.9846);
   background: var(--p-surface-950, #111113); color: inherit;
   border: 1px solid var(--p-surface-500, #555);
 }
 .cmcp-modal-scopes { display: flex; flex-direction: column; gap: 0.3rem; }
-.cmcp-modal-scope { display: flex; gap: 0.4rem; align-items: flex-start; font-size: calc(var(--cmcp-fs) * 0.8862); cursor: pointer; }
+.cmcp-modal-scope { display: flex; gap: 0.4rem; align-items: flex-start; font-size: calc(var(--cmcp-fs, 0.8125rem) * 0.8862); cursor: pointer; }
 .cmcp-modal-scope input { margin-top: 0.15rem; }
 .cmcp-modal-btns { display: flex; justify-content: flex-end; gap: 0.4rem; }
 .cmcp-btn-primary { background: var(--p-primary-color, #3a7bd5); color: #fff; border: none; }
@@ -18174,7 +18174,7 @@ const PANEL_CSS = `
 .cmcp-lightbox-nav {
   position: absolute; top: 50%; transform: translateY(-50%);
   width: 2.6rem; height: 2.6rem; border-radius: 50%; cursor: pointer;
-  font-size: calc(var(--cmcp-fs) * 1.9692); line-height: 1; display: flex; align-items: center; justify-content: center;
+  font-size: calc(var(--cmcp-fs, 0.8125rem) * 1.9692); line-height: 1; display: flex; align-items: center; justify-content: center;
   color: var(--p-text-color, #fafafa);
   background: rgba(0,0,0,0.45); border: 1px solid var(--p-content-border-color, #3f3f46);
 }
@@ -18184,7 +18184,7 @@ const PANEL_CSS = `
 .cmcp-lightbox-close {
   position: absolute; top: 0.75rem; right: 0.75rem;
   width: 2.2rem; height: 2.2rem; border-radius: 50%; cursor: pointer;
-  font-size: calc(var(--cmcp-fs) * 1.3538); line-height: 1; display: flex; align-items: center; justify-content: center;
+  font-size: calc(var(--cmcp-fs, 0.8125rem) * 1.3538); line-height: 1; display: flex; align-items: center; justify-content: center;
   color: var(--p-text-color, #fafafa);
   background: rgba(0,0,0,0.45); border: 1px solid var(--p-content-border-color, #3f3f46);
 }
@@ -18195,11 +18195,11 @@ const PANEL_CSS = `
   border-top: 1px solid var(--p-content-border-color, #3f3f46);
 }
 .cmcp-lightbox-caption {
-  font-size: calc(var(--cmcp-fs) * 0.9231); color: var(--p-text-muted-color, #a1a1aa);
+  font-size: calc(var(--cmcp-fs, 0.8125rem) * 0.9231); color: var(--p-text-muted-color, #a1a1aa);
   overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
 }
 .cmcp-lightbox-open {
-  flex: 0 0 auto; cursor: pointer; font-size: calc(var(--cmcp-fs) * 0.8862); padding: 0.3rem 0.6rem; border-radius: 6px;
+  flex: 0 0 auto; cursor: pointer; font-size: calc(var(--cmcp-fs, 0.8125rem) * 0.8862); padding: 0.3rem 0.6rem; border-radius: 6px;
   color: var(--p-text-color, #fafafa);
   background: var(--p-surface-800, #27272a); border: 1px solid var(--p-content-border-color, #3f3f46);
 }
@@ -18216,7 +18216,7 @@ const PANEL_CSS = `
 }
 .cmcp-media-expand, .cmcp-media-collapse {
   width: 1.8rem; height: 1.8rem; border-radius: 6px; cursor: pointer;
-  font-size: calc(var(--cmcp-fs) * 1.1692); line-height: 1; display: flex; align-items: center; justify-content: center;
+  font-size: calc(var(--cmcp-fs, 0.8125rem) * 1.1692); line-height: 1; display: flex; align-items: center; justify-content: center;
   color: #fff; background: rgba(0,0,0,0.5); border: 1px solid rgba(255,255,255,0.25);
   opacity: 0; transition: opacity 0.12s ease;
 }
@@ -18246,7 +18246,7 @@ const PANEL_CSS = `
 .cmcp-media-stub {
   display: none; align-items: center; gap: 0.4rem; cursor: pointer;
   min-height: 1.8rem; padding: 0.35rem 2.6rem 0.35rem 0.55rem; border-radius: 6px;
-  font-size: calc(var(--cmcp-fs) * 0.8615); color: var(--p-text-muted-color, #a1a1aa);
+  font-size: calc(var(--cmcp-fs, 0.8125rem) * 0.8615); color: var(--p-text-muted-color, #a1a1aa);
   background: var(--p-content-hover-background, #2a2a2e);
   border: 1px dashed var(--p-content-border-color, #3f3f46);
 }
@@ -18264,7 +18264,7 @@ const PANEL_CSS = `
   padding: 0.5rem 0.6rem; background: var(--p-surface-800, #27272a);
 }
 .cmcp-file-open {
-  color: var(--p-primary-color, #60a5fa); text-decoration: none; font-size: calc(var(--cmcp-fs) * 0.9846);
+  color: var(--p-primary-color, #60a5fa); text-decoration: none; font-size: calc(var(--cmcp-fs, 0.8125rem) * 0.9846);
   word-break: break-all;
 }
 .cmcp-file-open:hover { text-decoration: underline; }
@@ -18288,7 +18288,7 @@ const PANEL_CSS = `
 .cmcp-msg-status {
   align-self: flex-end; max-width: 92%;
   margin: 0.0625rem 0.125rem 0.125rem;
-  font-size: calc(var(--cmcp-fs) * 0.8462); color: var(--p-text-muted-color, #71717a);
+  font-size: calc(var(--cmcp-fs, 0.8125rem) * 0.8462); color: var(--p-text-muted-color, #71717a);
   display: flex; gap: 0.375rem; align-items: center;
 }
 .cmcp-msg-status:empty { display: none; }
@@ -18306,11 +18306,11 @@ const PANEL_CSS = `
   border-radius: var(--p-border-radius-sm, 4px);
   transition: color 0.12s, background 0.12s;
 }
-.cmcp-msg-action .pi { font-size: calc(var(--cmcp-fs) * 0.9231); }
+.cmcp-msg-action .pi { font-size: calc(var(--cmcp-fs, 0.8125rem) * 0.9231); }
 .cmcp-msg-action:hover { color: var(--p-text-color, #fff); background: var(--p-surface-700, #3f3f46); }
 .cmcp-msg-status.failed .cmcp-msg-action:hover { color: var(--p-red-300, #fca5a5); }
 .cmcp-bubble.agent code, .cmcp-bubble.user code {
-  font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: calc(var(--cmcp-fs) * 0.9231);
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: calc(var(--cmcp-fs, 0.8125rem) * 0.9231);
   background: var(--p-form-field-background, #09090b);
   padding: 0.0625rem 0.25rem; border-radius: var(--p-border-radius-sm, 4px);
 }
@@ -18325,10 +18325,10 @@ const PANEL_CSS = `
 .cmcp-bubble h4, .cmcp-bubble h5, .cmcp-bubble h6 {
   margin: 0.625rem 0 0.25rem; font-weight: 600; line-height: 1.3;
 }
-.cmcp-bubble h1 { font-size: calc(var(--cmcp-fs) * 1.2923); }
-.cmcp-bubble h2 { font-size: calc(var(--cmcp-fs) * 1.2308); }
-.cmcp-bubble h3 { font-size: calc(var(--cmcp-fs) * 1.1538); }
-.cmcp-bubble h4, .cmcp-bubble h5, .cmcp-bubble h6 { font-size: calc(var(--cmcp-fs) * 1.0769); }
+.cmcp-bubble h1 { font-size: calc(var(--cmcp-fs, 0.8125rem) * 1.2923); }
+.cmcp-bubble h2 { font-size: calc(var(--cmcp-fs, 0.8125rem) * 1.2308); }
+.cmcp-bubble h3 { font-size: calc(var(--cmcp-fs, 0.8125rem) * 1.1538); }
+.cmcp-bubble h4, .cmcp-bubble h5, .cmcp-bubble h6 { font-size: calc(var(--cmcp-fs, 0.8125rem) * 1.0769); }
 .cmcp-bubble a { color: var(--p-primary-color, #60a5fa); text-decoration: underline; }
 .cmcp-bubble blockquote {
   margin: 0.5rem 0; padding: 0.125rem 0 0.125rem 0.75rem;
@@ -18343,7 +18343,7 @@ const PANEL_CSS = `
   border: 1px solid var(--p-content-border-color, #3f3f46);
   border-radius: var(--p-border-radius-md, 6px);
   overflow-x: auto; max-height: 20rem; overflow-y: auto;
-  font-size: calc(var(--cmcp-fs) * 0.8462); line-height: 1.5; tab-size: 2;
+  font-size: calc(var(--cmcp-fs, 0.8125rem) * 0.8462); line-height: 1.5; tab-size: 2;
 }
 .cmcp-bubble.agent pre code, .cmcp-bubble.user pre code {
   background: none; padding: 0; border-radius: 0;
@@ -18369,7 +18369,7 @@ const PANEL_CSS = `
   transition: background 0.15s, color 0.15s;
 }
 .cmcp-code-tool:hover { background: var(--p-surface-700, #3f3f46); color: var(--p-text-color, #fff); }
-.cmcp-code-tool .pi { font-size: calc(var(--cmcp-fs) * 0.9846); }
+.cmcp-code-tool .pi { font-size: calc(var(--cmcp-fs, 0.8125rem) * 0.9846); }
 .cmcp-code-tool.ok { color: #4ade80; }
 .cmcp-wrap-btn.on { color: var(--p-primary-color, #60a5fa); }
 .cmcp-wrap-btn.on:hover { color: var(--p-primary-color, #60a5fa); }
@@ -18385,7 +18385,7 @@ const PANEL_CSS = `
   display: none; align-items: center; justify-content: center;
   background: var(--p-surface-700, #3f3f46); border: none; border-radius: 4px;
   color: var(--p-text-muted-color, #a1a1aa); cursor: pointer;
-  font-size: calc(var(--cmcp-fs) * 0.6769); line-height: 1; z-index: 2; box-shadow: 0 1px 3px rgba(0, 0, 0, 0.45);
+  font-size: calc(var(--cmcp-fs, 0.8125rem) * 0.6769); line-height: 1; z-index: 2; box-shadow: 0 1px 3px rgba(0, 0, 0, 0.45);
   transition: background 0.12s, color 0.12s;
 }
 .cmcp-bubble code.cmcp-inline-code:hover .cmcp-inline-copy { display: flex; }
@@ -18395,7 +18395,7 @@ const PANEL_CSS = `
   /* Real table layout (NOT display:block) so the header row stays aligned with
      the body; fit the panel width and let long cells wrap instead of scrolling. */
   display: table; width: 100%; table-layout: fixed;
-  border-collapse: collapse; margin: 0.5rem 0; font-size: calc(var(--cmcp-fs) * 0.8462);
+  border-collapse: collapse; margin: 0.5rem 0; font-size: calc(var(--cmcp-fs, 0.8125rem) * 0.8462);
 }
 .cmcp-bubble th, .cmcp-bubble td {
   border: 1px solid var(--p-content-border-color, #3f3f46);
@@ -18408,21 +18408,21 @@ const PANEL_CSS = `
   display: inline-flex; align-items: center; gap: 0.35rem;
   padding: 0.3rem 0.75rem; border-radius: 999px; border: none; cursor: pointer;
   background: var(--p-primary-color, #2563eb); color: var(--p-primary-contrast-color, #fff);
-  font: inherit; font-size: calc(var(--cmcp-fs) * 0.8615); box-shadow: 0 2px 10px rgba(0, 0, 0, 0.45);
+  font: inherit; font-size: calc(var(--cmcp-fs, 0.8125rem) * 0.8615); box-shadow: 0 2px 10px rgba(0, 0, 0, 0.45);
 }
-.cmcp-newmsg .pi { font-size: calc(var(--cmcp-fs) * 0.8615); }
+.cmcp-newmsg .pi { font-size: calc(var(--cmcp-fs, 0.8125rem) * 0.8615); }
 /* The base rule sets display, which beats the UA [hidden] rule — so re-assert
    it or "newMsgBtn.hidden = true" won't actually hide the pill. */
 .cmcp-newmsg[hidden] { display: none; }
 .cmcp-tray {
   flex: none; margin: 0 0.5rem 0.25rem; padding: 0.4rem 0.55rem;
   background: var(--p-surface-800, #27272a); border: 1px solid var(--p-content-border-color, #3f3f46);
-  border-radius: 8px; max-height: 9rem; overflow-y: auto; font-size: calc(var(--cmcp-fs) * 0.8615);
+  border-radius: 8px; max-height: 9rem; overflow-y: auto; font-size: calc(var(--cmcp-fs, 0.8125rem) * 0.8615);
 }
 .cmcp-tray[hidden] { display: none; }
-.cmcp-tray-head { font-size: calc(var(--cmcp-fs) * 0.7385); text-transform: uppercase; letter-spacing: 0.05em; opacity: 0.55; margin-bottom: 0.3rem; }
+.cmcp-tray-head { font-size: calc(var(--cmcp-fs, 0.8125rem) * 0.7385); text-transform: uppercase; letter-spacing: 0.05em; opacity: 0.55; margin-bottom: 0.3rem; }
 .cmcp-todo-item { display: flex; align-items: flex-start; gap: 0.4rem; padding: 0.12rem 0; line-height: 1.3; }
-.cmcp-todo-item .pi { font-size: calc(var(--cmcp-fs) * 0.8615); margin-top: 0.1rem; flex: none; }
+.cmcp-todo-item .pi { font-size: calc(var(--cmcp-fs, 0.8125rem) * 0.8615); margin-top: 0.1rem; flex: none; }
 .cmcp-todo-item.done { opacity: 0.55; }
 .cmcp-todo-item.done span { text-decoration: line-through; }
 .cmcp-todo-item.done .pi { color: var(--p-green-400, #4ade80); }
@@ -18437,11 +18437,11 @@ const PANEL_CSS = `
 .cmcp-pending-text { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .cmcp-pending-item.failed .cmcp-pending-text { color: var(--p-red-300, #fca5a5); }
 .cmcp-pending-act { flex: none; width: 1.2rem; height: 1.2rem; padding: 0; border: none; background: transparent;
-  color: var(--p-text-muted-color, #a1a1aa); cursor: pointer; border-radius: 4px; font-size: calc(var(--cmcp-fs) * 0.8615); }
+  color: var(--p-text-muted-color, #a1a1aa); cursor: pointer; border-radius: 4px; font-size: calc(var(--cmcp-fs, 0.8125rem) * 0.8615); }
 .cmcp-pending-act:hover { color: var(--p-primary-color, #60a5fa); background: var(--p-surface-700, #3f3f46); }
 .cmcp-pending-act.danger:hover { color: var(--p-red-300, #fca5a5); }
 .cmcp-pending-handle { flex: none; width: 1rem; height: 1.2rem; display: flex; align-items: center; justify-content: center;
-  color: var(--p-text-muted-color, #71717a); cursor: grab; font-size: calc(var(--cmcp-fs) * 0.8); opacity: 0.6; }
+  color: var(--p-text-muted-color, #71717a); cursor: grab; font-size: calc(var(--cmcp-fs, 0.8125rem) * 0.8); opacity: 0.6; }
 .cmcp-pending-handle:hover { opacity: 1; color: var(--p-primary-color, #60a5fa); }
 .cmcp-pending-handle:active { cursor: grabbing; }
 .cmcp-pending-item.dragging { opacity: 0.4; }
@@ -18451,7 +18451,7 @@ const PANEL_CSS = `
 .cmcp-dl-item { padding: 0.18rem 0; }
 .cmcp-dl-top { display: flex; justify-content: space-between; gap: 0.5rem; align-items: baseline; }
 .cmcp-dl-name { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.cmcp-dl-meta { flex: none; opacity: 0.7; font-size: calc(var(--cmcp-fs) * 0.7631); }
+.cmcp-dl-meta { flex: none; opacity: 0.7; font-size: calc(var(--cmcp-fs, 0.8125rem) * 0.7631); }
 .cmcp-dl-bar { height: 4px; border-radius: 999px; background: var(--p-surface-700, #3f3f46); overflow: hidden; margin-top: 0.2rem; }
 .cmcp-dl-fill { height: 100%; background: var(--p-primary-color, #3a7bd5); transition: width 0.3s ease; }
 .cmcp-dl-item.done .cmcp-dl-fill { background: var(--p-green-400, #4ade80); }
@@ -18459,7 +18459,7 @@ const PANEL_CSS = `
 .cmcp-dl-bar.indet .cmcp-dl-fill { width: 30%; animation: cmcp-indet 1.1s ease-in-out infinite; }
 @keyframes cmcp-indet { 0% { margin-left: -30%; } 100% { margin-left: 100%; } }
 .cmcp-sys {
-  align-self: center; font-size: calc(var(--cmcp-fs) * 0.8462); font-style: italic;
+  align-self: center; font-size: calc(var(--cmcp-fs, 0.8125rem) * 0.8462); font-style: italic;
   color: var(--p-text-muted-color, #a1a1aa);
   animation: cmcp-in 0.18s ease-out;
   /* Status lines quote URLs, paths and ids — strings with no spaces to break
@@ -18476,17 +18476,17 @@ const PANEL_CSS = `
   border: 1px solid var(--p-content-border-color, #3f3f46);
   border-left: 3px solid var(--p-primary-color, #60a5fa);
   border-radius: var(--p-border-radius-md, 6px);
-  font-size: calc(var(--cmcp-fs) * 0.9231);
+  font-size: calc(var(--cmcp-fs, 0.8125rem) * 0.9231);
   animation: cmcp-in 0.18s ease-out;
 }
 .cmcp-card.error { border-left-color: var(--p-red-400, #f87171); }
 .cmcp-card-head { display: flex; align-items: center; gap: 0.375rem; font-weight: 600; min-width: 0; }
-.cmcp-card-head .pi { font-size: calc(var(--cmcp-fs) * 0.9231); color: var(--p-primary-color, #60a5fa); flex: none; }
+.cmcp-card-head .pi { font-size: calc(var(--cmcp-fs, 0.8125rem) * 0.9231); color: var(--p-primary-color, #60a5fa); flex: none; }
 .cmcp-card-text { flex: 1 1 auto; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .cmcp-card.error .cmcp-card-head .pi { color: var(--p-red-400, #f87171); }
 .cmcp-card-detail {
   margin-top: 0.25rem; color: var(--p-text-muted-color, #a1a1aa);
-  font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: calc(var(--cmcp-fs) * 0.8462);
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: calc(var(--cmcp-fs, 0.8125rem) * 0.8462);
   overflow-x: auto; white-space: pre-wrap; word-break: break-word;
   max-height: 7.5rem; overflow-y: auto;
 }
@@ -18500,7 +18500,7 @@ const PANEL_CSS = `
   border: 2px dashed var(--p-primary-color, #3b82f6);
   border-radius: 10px;
   background: color-mix(in srgb, var(--p-primary-color, #3b82f6) 16%, var(--p-surface-900, #18181b));
-  color: var(--p-primary-color, #60a5fa); font-weight: 600; font-size: calc(var(--cmcp-fs) * 1.0462);
+  color: var(--p-primary-color, #60a5fa); font-weight: 600; font-size: calc(var(--cmcp-fs, 0.8125rem) * 1.0462);
   pointer-events: none; animation: cmcp-in 0.12s ease-out;
 }
 .cmcp-dropzone.cmcp-show { display: flex; }
@@ -18511,7 +18511,7 @@ const PANEL_CSS = `
   background: var(--p-surface-800, #27272a);
   border: 1px solid var(--p-content-border-color, #3f3f46);
   border-radius: var(--p-border-radius-lg, 8px);
-  color: var(--p-text-muted-color, #a1a1aa); font-size: calc(var(--cmcp-fs) * 0.9231);
+  color: var(--p-text-muted-color, #a1a1aa); font-size: calc(var(--cmcp-fs, 0.8125rem) * 0.9231);
   animation: cmcp-in 0.18s ease-out;
 }
 .cmcp-thinking-dots { display: inline-flex; gap: 3px; }
@@ -18537,19 +18537,19 @@ const PANEL_CSS = `
 }
 .cmcp-think > summary {
   list-style: none; cursor: pointer; user-select: none;
-  padding: 0.3125rem 0.5rem; font-size: calc(var(--cmcp-fs) * 0.8462); font-weight: 600;
+  padding: 0.3125rem 0.5rem; font-size: calc(var(--cmcp-fs, 0.8125rem) * 0.8462); font-weight: 600;
   color: var(--p-text-muted-color, #a1a1aa);
   display: flex; align-items: center; gap: 0.375rem;
 }
 .cmcp-think > summary::-webkit-details-marker { display: none; }
 .cmcp-think > summary::before {
-  content: "\\25b8"; font-size: calc(var(--cmcp-fs) * 0.7692); transition: transform 0.15s;
+  content: "\\25b8"; font-size: calc(var(--cmcp-fs, 0.8125rem) * 0.7692); transition: transform 0.15s;
 }
 .cmcp-think[open] > summary::before { transform: rotate(90deg); }
 .cmcp-think-body {
   max-height: 11rem; overflow-y: auto;
   padding: 0 0.5rem 0.4375rem 0.875rem;
-  font-size: calc(var(--cmcp-fs) * 0.8462); line-height: 1.45;
+  font-size: calc(var(--cmcp-fs, 0.8125rem) * 0.8462); line-height: 1.45;
   color: var(--p-text-muted-color, #8a8a93);
   white-space: pre-wrap; word-break: break-word;
   font-family: ui-monospace, "SFMono-Regular", Menlo, Consolas, monospace;
@@ -18594,19 +18594,19 @@ const PANEL_CSS = `
 .cmcp-iconbtn:hover { background: var(--p-surface-700, #3f3f46); color: var(--p-text-color, #fff); }
 .cmcp-iconbtn:disabled { opacity: 0.35; cursor: default; }
 .cmcp-iconbtn.active { color: var(--p-red-400, #f87171); }
-.cmcp-iconbtn .pi { font-size: calc(var(--cmcp-fs) * 1.0769); }
+.cmcp-iconbtn .pi { font-size: calc(var(--cmcp-fs, 0.8125rem) * 1.0769); }
 /* #758 — the update notice. Sits in the transcript as a system line, so it inherits
    the panel's scale and scroll rather than becoming a modal the user must dismiss. */
 .cmcp-whatsnew { border-left: 2px solid var(--p-primary-color, #3b82f6); padding-left: 0.55rem; }
 .cmcp-whatsnew-head { font-weight: 600; margin-bottom: 0.3rem; }
 .cmcp-whatsnew-list { margin: 0; padding-left: 0.9rem; display: flex; flex-direction: column; gap: 0.25rem; }
 .cmcp-whatsnew-list li { line-height: 1.45; }
-.cmcp-whatsnew-tag { display: inline-block; font-size: calc(var(--cmcp-fs) * 0.7138); text-transform: uppercase;
+.cmcp-whatsnew-tag { display: inline-block; font-size: calc(var(--cmcp-fs, 0.8125rem) * 0.7138); text-transform: uppercase;
   letter-spacing: 0.04em; opacity: 0.75; border: 1px solid currentColor; border-radius: 3px;
   padding: 0 0.22rem; margin-right: 0.15rem; vertical-align: baseline; }
-.cmcp-workflow-version { margin-top: 0.35rem; font-size: calc(var(--cmcp-fs) * 0.7138); opacity: 0.62;
+.cmcp-workflow-version { margin-top: 0.35rem; font-size: calc(var(--cmcp-fs, 0.8125rem) * 0.7138); opacity: 0.62;
   display: flex; gap: 0.3rem; align-items: center; }
-.cmcp-workflow-version .pi { font-size: calc(var(--cmcp-fs) * 0.7138); }
+.cmcp-workflow-version .pi { font-size: calc(var(--cmcp-fs, 0.8125rem) * 0.7138); }
 /* ---- sidebar tab badge (these live OUTSIDE .cmcp-root, on the toolbar) ---- */
 /* (.cmcp-tab-logo — the logo-mark tab glyph — is NOT here: it must exist the
    moment registerSidebarTab() paints the toolbar, before the panel ever
@@ -18630,7 +18630,7 @@ const PANEL_CSS = `
 .cmcp-chip {
   display: flex; align-items: center; gap: 0.25rem;
   border: none; background: transparent; cursor: pointer;
-  color: var(--p-text-muted-color, #a1a1aa); font: inherit; font-size: calc(var(--cmcp-fs) * 0.8462);
+  color: var(--p-text-muted-color, #a1a1aa); font: inherit; font-size: calc(var(--cmcp-fs, 0.8125rem) * 0.8462);
   padding: 0.125rem 0.375rem; border-radius: var(--p-border-radius-sm, 4px);
   white-space: nowrap; min-width: 0; overflow: hidden; flex: 0 1 auto;
 }
@@ -18652,13 +18652,13 @@ const PANEL_CSS = `
   background: var(--p-surface-700, #3f3f46);
   border: 1px solid var(--p-content-border-color, #52525b);
   border-radius: var(--p-border-radius-md, 6px);
-  color: var(--p-text-color, #fff); font: inherit; font-size: calc(var(--cmcp-fs) * 0.8462);
+  color: var(--p-text-color, #fff); font: inherit; font-size: calc(var(--cmcp-fs, 0.8125rem) * 0.8462);
   padding: 0.1875rem 0.25rem 0.1875rem 0.375rem; cursor: pointer;
   transition: background 0.15s, border-color 0.15s;
 }
 .cmcp-attach-chip:hover { background: var(--p-surface-600, #52525b); }
 .cmcp-attach-chip.open { border-color: var(--p-primary-color, #60a5fa); }
-.cmcp-attach-chip > .pi { font-size: calc(var(--cmcp-fs) * 0.9231); color: var(--p-text-muted-color, #a1a1aa); flex: none; }
+.cmcp-attach-chip > .pi { font-size: calc(var(--cmcp-fs, 0.8125rem) * 0.9231); color: var(--p-text-muted-color, #a1a1aa); flex: none; }
 .cmcp-attach-name { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .cmcp-attach-meta { color: var(--p-text-muted-color, #a1a1aa); flex: none; }
 .cmcp-attach-thumb { width: 1.125rem; height: 1.125rem; border-radius: 3px; object-fit: cover; flex: none; }
@@ -18668,7 +18668,7 @@ const PANEL_CSS = `
   border-radius: 3px; color: var(--p-text-muted-color, #a1a1aa);
 }
 .cmcp-attach-rm:hover { background: var(--p-surface-800, #27272a); color: var(--p-text-color, #fff); }
-.cmcp-attach-rm .pi { font-size: calc(var(--cmcp-fs) * 0.7692); }
+.cmcp-attach-rm .pi { font-size: calc(var(--cmcp-fs, 0.8125rem) * 0.7692); }
 .cmcp-attach-preview {
   background: var(--p-surface-900, #18181b);
   border: 1px solid var(--p-content-border-color, #3f3f46);
@@ -18678,10 +18678,10 @@ const PANEL_CSS = `
 .cmcp-attach-preview pre {
   margin: 0; white-space: pre-wrap; word-break: break-word;
   font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
-  font-size: calc(var(--cmcp-fs) * 0.8462); line-height: 1.45; color: var(--p-text-color, #e4e4e7);
+  font-size: calc(var(--cmcp-fs, 0.8125rem) * 0.8462); line-height: 1.45; color: var(--p-text-color, #e4e4e7);
 }
 .cmcp-attach-preview img { max-width: 100%; max-height: 12rem; border-radius: 4px; display: block; }
-.cmcp-ctx { font-size: calc(var(--cmcp-fs) * 0.7692); color: var(--p-text-muted-color, #a1a1aa); min-width: 1.75rem; }
+.cmcp-ctx { font-size: calc(var(--cmcp-fs, 0.8125rem) * 0.7692); color: var(--p-text-muted-color, #a1a1aa); min-width: 1.75rem; }
 .cmcp-ring { flex: none; margin: 0 0.125rem; transform: rotate(-90deg); }
 .cmcp-ring .bg { stroke: var(--p-surface-600, #52525b); }
 .cmcp-ring .fg { stroke: var(--p-primary-color, #60a5fa); transition: stroke-dashoffset 0.3s; }
@@ -18697,11 +18697,11 @@ const PANEL_CSS = `
 .cmcp-popover-item {
   display: flex; align-items: center; gap: 0.5rem; width: 100%; box-sizing: border-box;
   padding: 0.375rem 0.5rem; border: none; background: transparent; cursor: pointer;
-  text-align: left; color: var(--p-text-color, #fff); font: inherit; font-size: calc(var(--cmcp-fs) * 0.9231);
+  text-align: left; color: var(--p-text-color, #fff); font: inherit; font-size: calc(var(--cmcp-fs, 0.8125rem) * 0.9231);
   border-radius: var(--p-border-radius-sm, 4px);
 }
 .cmcp-popover-item.sel, .cmcp-popover-item:hover { background: var(--p-surface-700, #3f3f46); }
-.cmcp-popover-item .pi { font-size: calc(var(--cmcp-fs) * 0.9231); color: var(--p-text-muted-color, #a1a1aa); flex: none; }
+.cmcp-popover-item .pi { font-size: calc(var(--cmcp-fs, 0.8125rem) * 0.9231); color: var(--p-text-muted-color, #a1a1aa); flex: none; }
 .cmcp-popover-item small { margin-left: auto; color: var(--p-text-muted-color, #a1a1aa); flex: none; padding-left: 0.5rem; }
 .cmcp-popover-item .lbl { flex: 1 1 auto; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 /* Hover-to-read: while revealing, drop the ellipsis so the tail is legible, and
@@ -18734,12 +18734,12 @@ const PANEL_CSS = `
 .cmcp-hist-search {
   min-width: 0; border: 1px solid var(--p-form-field-border-color, #52525b);
   border-radius: var(--p-border-radius-sm, 4px); background: var(--p-form-field-background, #09090b);
-  color: var(--p-form-field-color, #fff); font: inherit; font-size: calc(var(--cmcp-fs) * 0.9231); padding: 0.35rem 0.45rem;
+  color: var(--p-form-field-color, #fff); font: inherit; font-size: calc(var(--cmcp-fs, 0.8125rem) * 0.9231); padding: 0.35rem 0.45rem;
 }
 .cmcp-hist-filter { grid-column: 1 / -1; display: flex; align-items: center; gap: 0.375rem;
-  color: var(--p-text-muted-color, #a1a1aa); font-size: calc(var(--cmcp-fs) * 0.8462); }
+  color: var(--p-text-muted-color, #a1a1aa); font-size: calc(var(--cmcp-fs, 0.8125rem) * 0.8462); }
 .cmcp-hist-list { max-height: min(58vh, 28rem); overflow-y: auto; padding: 0.25rem; }
-.cmcp-hist-group { padding: 0.35rem 0.5rem 0.2rem; font-size: calc(var(--cmcp-fs) * 0.7692); font-weight: 700;
+.cmcp-hist-group { padding: 0.35rem 0.5rem 0.2rem; font-size: calc(var(--cmcp-fs, 0.8125rem) * 0.7692); font-weight: 700;
   text-transform: uppercase; letter-spacing: 0.04em; color: var(--p-text-muted-color, #a1a1aa); }
 .cmcp-hist-row { display: flex; align-items: stretch; gap: 0.125rem; }
 .cmcp-hist-row.active { background: color-mix(in srgb, var(--p-primary-color, #60a5fa) 13%, transparent); border-radius: 4px; }
@@ -18748,7 +18748,7 @@ const PANEL_CSS = `
 .cmcp-hist-row.foreign-workflow .cmcp-hist-open { cursor: not-allowed; }
 .cmcp-hist-meta { display: flex; flex-direction: column; min-width: 0; flex: 1; }
 .cmcp-hist-meta .lbl { font-weight: 550; }
-.cmcp-hist-sub { color: var(--p-text-muted-color, #a1a1aa); font-size: calc(var(--cmcp-fs) * 0.7692);
+.cmcp-hist-sub { color: var(--p-text-muted-color, #a1a1aa); font-size: calc(var(--cmcp-fs, 0.8125rem) * 0.7692);
   overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .cmcp-hist-action {
   flex: none; width: 1.75rem; border: none; background: transparent; cursor: pointer;
@@ -18759,32 +18759,32 @@ const PANEL_CSS = `
 .cmcp-hist-action:focus-visible { opacity: 1; }
 .cmcp-hist-action:hover { background: var(--p-surface-700, #3f3f46); color: var(--p-text-color, #fff); }
 .cmcp-hist-action.danger:hover { color: var(--p-red-400, #f87171); }
-.cmcp-hist-action .pi { font-size: calc(var(--cmcp-fs) * 0.9231); }
+.cmcp-hist-action .pi { font-size: calc(var(--cmcp-fs, 0.8125rem) * 0.9231); }
 .cmcp-hist-footer {
   margin-top: 0.25rem; padding: 0.5rem 0.375rem 0.125rem;
   border-top: 1px solid var(--p-content-border-color, #3f3f46);
 }
 .cmcp-hist-note {
   margin: 0 0 0.375rem; color: var(--p-text-muted-color, #a1a1aa);
-  font-size: calc(var(--cmcp-fs) * 0.7692); line-height: 1.35;
+  font-size: calc(var(--cmcp-fs, 0.8125rem) * 0.7692); line-height: 1.35;
 }
 .cmcp-hist-clear {
   display: flex; align-items: center; justify-content: center; gap: 0.375rem;
   width: 100%; padding: 0.3125rem 0.5rem; border-radius: var(--p-border-radius-sm, 4px);
   border: 1px solid color-mix(in srgb, var(--p-red-400, #f87171) 45%, transparent);
   background: transparent; color: var(--p-red-400, #f87171); cursor: pointer;
-  font: inherit; font-size: calc(var(--cmcp-fs) * 0.8462);
+  font: inherit; font-size: calc(var(--cmcp-fs, 0.8125rem) * 0.8462);
 }
 .cmcp-hist-clear:hover:not(:disabled) { background: color-mix(in srgb, var(--p-red-400, #f87171) 12%, transparent); }
 .cmcp-hist-clear:disabled { opacity: 0.4; cursor: not-allowed; }
 
 /* Model/effort picker popover (anchored above the composer). */
-.cmcp-pop-section { padding: 0.25rem 0.5rem 0.125rem; font-size: calc(var(--cmcp-fs) * 0.7692); font-weight: 600;
+.cmcp-pop-section { padding: 0.25rem 0.5rem 0.125rem; font-size: calc(var(--cmcp-fs, 0.8125rem) * 0.7692); font-weight: 600;
   text-transform: uppercase; letter-spacing: 0.04em; color: var(--p-text-muted-color, #a1a1aa); }
 .cmcp-pop-section:not(:first-child) { margin-top: 0.25rem; border-top: 1px solid var(--p-content-border-color, #3f3f46); padding-top: 0.375rem; }
 .cmcp-popover-item .check { flex: none; width: 1rem; text-align: center; margin-left: 0.375rem; color: var(--p-primary-color, #60a5fa); visibility: hidden; }
 .cmcp-popover-item .check.on { visibility: visible; }
-.cmcp-chip .pi-angle-down { font-size: calc(var(--cmcp-fs) * 0.6923); opacity: 0.7; }
+.cmcp-chip .pi-angle-down { font-size: calc(var(--cmcp-fs, 0.8125rem) * 0.6923); opacity: 0.7; }
 .cmcp-chip .dim { opacity: 0.65; }
 /* Omni-search model picker (aggregates every connected provider's catalog into
    one virtualized, keyboard-navigable list). Row height is FIXED at 30px so the
@@ -18792,9 +18792,9 @@ const PANEL_CSS = `
 .cmcp-modelsearch { display: flex; flex-direction: column; }
 .cmcp-modelsearch-input { margin: 0.25rem 0.5rem; padding: 0.3rem 0.5rem; border-radius: 6px;
   border: 1px solid var(--p-content-border-color, #3f3f46); background: var(--p-surface-900, #18181b);
-  color: var(--p-text-color, #e4e4e7); font-size: calc(var(--cmcp-fs) * 0.9846); }
+  color: var(--p-text-color, #e4e4e7); font-size: calc(var(--cmcp-fs, 0.8125rem) * 0.9846); }
 .cmcp-modelsearch-input:focus { outline: none; border-color: var(--p-focus-ring-color, #60a5fa); }
-.cmcp-modelsearch-cap { padding: 0.125rem 0.5rem 0.25rem; font-size: calc(var(--cmcp-fs) * 0.7692); color: var(--p-text-muted-color, #a1a1aa); }
+.cmcp-modelsearch-cap { padding: 0.125rem 0.5rem 0.25rem; font-size: calc(var(--cmcp-fs, 0.8125rem) * 0.7692); color: var(--p-text-muted-color, #a1a1aa); }
 .cmcp-modelresults { position: relative; overflow-y: auto; max-height: 15rem; }
 .cmcp-modelsizer { position: relative; width: 100%; }
 .cmcp-modelrow { position: absolute; left: 0; right: 0; height: 30px; display: flex; align-items: center;
@@ -18802,19 +18802,19 @@ const PANEL_CSS = `
   text-align: left; cursor: pointer; box-sizing: border-box; }
 .cmcp-modelrow:hover, .cmcp-modelrow.active { background: var(--p-surface-700, #3f3f46); }
 .cmcp-modelrow .lbl { flex: 1 1 auto; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.cmcp-modelrow .sub { flex: none; color: var(--p-text-muted-color, #a1a1aa); font-size: calc(var(--cmcp-fs) * 0.8462); overflow: hidden;
+.cmcp-modelrow .sub { flex: none; color: var(--p-text-muted-color, #a1a1aa); font-size: calc(var(--cmcp-fs, 0.8125rem) * 0.8462); overflow: hidden;
   text-overflow: ellipsis; white-space: nowrap; max-width: 40%; }
-.cmcp-provtag { flex: none; font-size: calc(var(--cmcp-fs) * 0.6923); text-transform: uppercase; letter-spacing: 0.03em;
+.cmcp-provtag { flex: none; font-size: calc(var(--cmcp-fs, 0.8125rem) * 0.6923); text-transform: uppercase; letter-spacing: 0.03em;
   padding: 0.05rem 0.35rem; border-radius: 999px; background: var(--p-surface-800, #27272a);
   color: var(--p-text-muted-color, #a1a1aa); border: 1px solid var(--p-content-border-color, #3f3f46); }
 .cmcp-modelrow .check { flex: none; width: 1rem; text-align: center; color: var(--p-primary-color, #60a5fa); visibility: hidden; }
 .cmcp-modelrow .check.on { visibility: visible; }
-.cmcp-modelempty { padding: 0.5rem; font-size: calc(var(--cmcp-fs) * 0.9231); color: var(--p-text-muted-color, #a1a1aa); }
+.cmcp-modelempty { padding: 0.5rem; font-size: calc(var(--cmcp-fs, 0.8125rem) * 0.9231); color: var(--p-text-muted-color, #a1a1aa); }
 /* Recently-used section (non-virtualized; bounded to the last few picks). Rows
    flow normally (override the absolute positioning the virtualized list uses). */
 .cmcp-modelrecents .cmcp-modelrow { position: static; }
 .cmcp-modelrecent-x { flex: none; margin-left: 0.15rem; padding: 0 0.2rem; background: none; border: none;
-  color: var(--p-text-muted-color, #a1a1aa); cursor: pointer; opacity: 0.55; font-size: calc(var(--cmcp-fs) * 0.8615); line-height: 1; }
+  color: var(--p-text-muted-color, #a1a1aa); cursor: pointer; opacity: 0.55; font-size: calc(var(--cmcp-fs, 0.8125rem) * 0.8615); line-height: 1; }
 .cmcp-modelrecent-x:hover { opacity: 1; color: var(--p-text-color, #e4e4e7); }
 `;
 
@@ -21139,7 +21139,7 @@ function buildPanel() {
           const off = document.createElement("i");
           off.className = "pi pi-times";
           off.title = `Hide ${BACKEND_LABELS[id] || id} — you don't use it. Restore it from the "hidden" row below.`;
-          off.style.cssText = "margin-left:0.4rem;opacity:0.4;cursor:pointer;font-size:calc(var(--cmcp-fs) * 0.8615);flex:none;";
+          off.style.cssText = "margin-left:0.4rem;opacity:0.4;cursor:pointer;font-size:calc(var(--cmcp-fs, 0.8125rem) * 0.8615);flex:none;";
           off.addEventListener("mousedown", (mev) => {
             // Swallow the row's pick handler — this gesture only hides.
             mev.preventDefault();
@@ -22556,7 +22556,7 @@ function buildPanel() {
     if (name) {
       const cap = document.createElement("div");
       cap.className = "cmcp-media-caption";
-      cap.style.cssText = "font-size:calc(var(--cmcp-fs) * 0.7692);color:var(--p-text-muted-color,#a1a1aa);margin-top:0.25rem;";
+      cap.style.cssText = "font-size:calc(var(--cmcp-fs, 0.8125rem) * 0.7692);color:var(--p-text-muted-color,#a1a1aa);margin-top:0.25rem;";
       cap.textContent = name;
       card.appendChild(cap);
     }
@@ -22642,7 +22642,7 @@ function buildPanel() {
       holder._preFailCss = holder.style.cssText;
       holder.style.cssText +=
         ";display:grid;place-items:center;padding:1rem;box-sizing:border-box;text-align:center;" +
-        "color:var(--p-text-muted-color,#a1a1aa);font-size:calc(var(--cmcp-fs) * 0.9231);";
+        "color:var(--p-text-muted-color,#a1a1aa);font-size:calc(var(--cmcp-fs, 0.8125rem) * 0.9231);";
       // Release the decode buffers the way unmountHolderVideo does — detaching alone is
       // not deterministic release, and unmount will skip this element once `_video` is
       // null, so this is the last chance to do it (codex).
@@ -22716,7 +22716,7 @@ function buildPanel() {
     if (name) {
       const cap = document.createElement("div");
       cap.className = "cmcp-media-caption";
-      cap.style.cssText = "font-size:calc(var(--cmcp-fs) * 0.7692);color:var(--p-text-muted-color,#a1a1aa);margin-top:0.25rem;";
+      cap.style.cssText = "font-size:calc(var(--cmcp-fs, 0.8125rem) * 0.7692);color:var(--p-text-muted-color,#a1a1aa);margin-top:0.25rem;";
       cap.textContent = name;
       card.appendChild(cap);
     }
@@ -22753,7 +22753,7 @@ function buildPanel() {
     card.appendChild(audio);
     if (name) {
       const cap = document.createElement("div");
-      cap.style.cssText = "font-size:calc(var(--cmcp-fs) * 0.7692);color:var(--p-text-muted-color,#a1a1aa);margin-top:0.25rem;";
+      cap.style.cssText = "font-size:calc(var(--cmcp-fs, 0.8125rem) * 0.7692);color:var(--p-text-muted-color,#a1a1aa);margin-top:0.25rem;";
       cap.textContent = name;
       card.appendChild(cap);
     }
@@ -22788,7 +22788,7 @@ function buildPanel() {
     a.textContent = name || "Open file";
     card.appendChild(a);
     const hint = document.createElement("div");
-    hint.style.cssText = "font-size:calc(var(--cmcp-fs) * 0.7692);color:var(--p-text-muted-color,#a1a1aa);margin-top:0.25rem;";
+    hint.style.cssText = "font-size:calc(var(--cmcp-fs, 0.8125rem) * 0.7692);color:var(--p-text-muted-color,#a1a1aa);margin-top:0.25rem;";
     hint.textContent = "The panel can't preview this file type — open or download it.";
     card.appendChild(hint);
     log.appendChild(card);
@@ -22965,7 +22965,7 @@ function buildPanel() {
     if (msg.header) {
       const chip = document.createElement("div");
       chip.className = "cmcp-card-head";
-      chip.style.cssText = "text-transform:uppercase;font-size:calc(var(--cmcp-fs) * 0.7385);letter-spacing:0.05em;opacity:0.7;";
+      chip.style.cssText = "text-transform:uppercase;font-size:calc(var(--cmcp-fs, 0.8125rem) * 0.7385);letter-spacing:0.05em;opacity:0.7;";
       chip.textContent = coerceMessageText(msg.header);
       card.appendChild(chip);
     }
@@ -23009,7 +23009,7 @@ function buildPanel() {
       const answerText = coerceMessageText(answer);
       if (questionText) {
         const q = document.createElement("div");
-        q.style.cssText = "font-size:calc(var(--cmcp-fs) * 0.8862);opacity:0.65;";
+        q.style.cssText = "font-size:calc(var(--cmcp-fs, 0.8125rem) * 0.8862);opacity:0.65;";
         q.textContent = questionText;
         card.appendChild(q);
       }
@@ -23031,14 +23031,14 @@ function buildPanel() {
       b.className = "cmcp-opt";
       b.style.cssText =
         "text-align:left;padding:0.4rem 0.55rem;border-radius:6px;border:1px solid var(--p-surface-500,#555);" +
-        "background:var(--p-surface-800,#2a2a2a);color:inherit;cursor:pointer;font-size:calc(var(--cmcp-fs) * 0.9846);";
+        "background:var(--p-surface-800,#2a2a2a);color:inherit;cursor:pointer;font-size:calc(var(--cmcp-fs, 0.8125rem) * 0.9846);";
       const lbl = document.createElement("div");
       lbl.style.fontWeight = "600";
       lbl.textContent = coerceMessageText(opt.label ?? opt);
       b.appendChild(lbl);
       if (opt.description) {
         const d = document.createElement("div");
-        d.style.cssText = "font-size:calc(var(--cmcp-fs) * 0.8615);opacity:0.7;margin-top:0.1rem;";
+        d.style.cssText = "font-size:calc(var(--cmcp-fs, 0.8125rem) * 0.8615);opacity:0.7;margin-top:0.1rem;";
         d.textContent = coerceMessageText(opt.description);
         b.appendChild(d);
       }
@@ -23064,7 +23064,7 @@ function buildPanel() {
     other.placeholder = "Other… (type your own answer)";
     other.style.cssText =
       "flex:1;padding:0.35rem 0.5rem;border-radius:6px;border:1px solid var(--p-surface-500,#555);" +
-      "background:var(--p-surface-900,#1e1e1e);color:inherit;font-size:calc(var(--cmcp-fs) * 0.9846);";
+      "background:var(--p-surface-900,#1e1e1e);color:inherit;font-size:calc(var(--cmcp-fs, 0.8125rem) * 0.9846);";
     other.addEventListener("keydown", (e) => {
       if (isImeComposing(e)) return; // don't commit mid-IME-composition (#385)
       if (e.key === "Enter" && other.value.trim()) { e.preventDefault(); finish(other.value.trim()); }
@@ -23074,7 +23074,7 @@ function buildPanel() {
     const submit = document.createElement("button");
     submit.type = "button";
     submit.style.cssText =
-      "padding:0.35rem 0.7rem;border-radius:6px;border:none;cursor:pointer;font-size:calc(var(--cmcp-fs) * 0.9846);" +
+      "padding:0.35rem 0.7rem;border-radius:6px;border:none;cursor:pointer;font-size:calc(var(--cmcp-fs, 0.8125rem) * 0.9846);" +
       "background:var(--p-primary-color,#3a7bd5);color:#fff;";
     submit.textContent = multi ? "Submit" : "Send";
     submit.addEventListener("click", () => {
@@ -23176,7 +23176,7 @@ function buildPanel() {
       card.style.opacity = "0.6";
       const note = document.createElement("div");
       note.className = "cmcp-card-stale";
-      note.style.cssText = "font-size:calc(var(--cmcp-fs) * 0.8369);opacity:0.8;margin-top:0.4rem;";
+      note.style.cssText = "font-size:calc(var(--cmcp-fs, 0.8125rem) * 0.8369);opacity:0.8;margin-top:0.4rem;";
       note.textContent =
         `The connection that asked this ${what ?? "question"} dropped, so an answer here can no ` +
         `longer reach the agent. ` +
@@ -23213,7 +23213,7 @@ function buildPanel() {
     card.appendChild(head);
 
     const hint = document.createElement("div");
-    hint.style.cssText = "font-size:calc(var(--cmcp-fs) * 0.8369);opacity:0.7;margin:0.2rem 0 0.4rem;";
+    hint.style.cssText = "font-size:calc(var(--cmcp-fs, 0.8125rem) * 0.8369);opacity:0.7;margin:0.2rem 0 0.4rem;";
     hint.textContent =
       msg.hint || "Sent straight to your config — never shown to the agent and never saved to chat history.";
     card.appendChild(hint);
@@ -23262,7 +23262,7 @@ function buildPanel() {
     input.placeholder = "Paste token…";
     input.style.cssText =
       "flex:1 1 10rem;min-width:0;padding:0.35rem 0.5rem;border-radius:6px;border:1px solid var(--p-surface-500,#555);" +
-      "background:var(--p-surface-900,#1e1e1e);color:inherit;font-size:calc(var(--cmcp-fs) * 0.9846);";
+      "background:var(--p-surface-900,#1e1e1e);color:inherit;font-size:calc(var(--cmcp-fs, 0.8125rem) * 0.9846);";
 
     // Show/record only a masked preview (first 4 … last 4) so the user can
     // confirm WHICH token without ever exposing the full value.
@@ -23277,7 +23277,7 @@ function buildPanel() {
       card.replaceChildren();
       card.style.cssText = "border-left:3px solid var(--p-green-400,#4ade80);opacity:0.9;";
       const ok = document.createElement("div");
-      ok.style.cssText = "font-size:calc(var(--cmcp-fs) * 0.9231);color:var(--p-green-400,#4ade80);";
+      ok.style.cssText = "font-size:calc(var(--cmcp-fs, 0.8125rem) * 0.9231);color:var(--p-green-400,#4ade80);";
       const m = mask(value);
       ok.textContent = value ? `🔒 Token saved: ${m}` : "Skipped — no token entered.";
       card.appendChild(ok);
@@ -23310,7 +23310,7 @@ function buildPanel() {
     // group spill the card at 320/280px. Stating the intent stops a future
     // "everything gets min-width:0" sweep from supplying the missing half.
     submit.style.cssText =
-      "flex:none;padding:0.35rem 0.7rem;border-radius:6px;border:none;cursor:pointer;font-size:calc(var(--cmcp-fs) * 0.9846);" +
+      "flex:none;padding:0.35rem 0.7rem;border-radius:6px;border:none;cursor:pointer;font-size:calc(var(--cmcp-fs, 0.8125rem) * 0.9846);" +
       "background:var(--p-primary-color,#3a7bd5);color:#fff;";
     submit.textContent = "Save";
     submit.addEventListener("click", () => finish(input.value.trim()));
@@ -23320,7 +23320,7 @@ function buildPanel() {
     skip.type = "button";
     skip.style.cssText =
       "flex:none;padding:0.35rem 0.6rem;border-radius:6px;border:1px solid var(--p-surface-500,#555);" +
-      "background:transparent;color:inherit;cursor:pointer;font-size:calc(var(--cmcp-fs) * 0.9846);";
+      "background:transparent;color:inherit;cursor:pointer;font-size:calc(var(--cmcp-fs, 0.8125rem) * 0.9846);";
     skip.textContent = "Skip";
     skip.addEventListener("click", () => finish(""));
     btns.appendChild(skip);
@@ -28789,14 +28789,14 @@ function buildPanel() {
     canvas.style.cssText = "background:#fff;border-radius:8px;padding:8px;width:240px;height:240px;";
     canvas.hidden = true;
     const statusMsg = document.createElement("div");
-    statusMsg.style.cssText = "font-size:calc(var(--cmcp-fs) * 1.0462);opacity:0.85;text-align:center;";
+    statusMsg.style.cssText = "font-size:calc(var(--cmcp-fs, 0.8125rem) * 1.0462);opacity:0.85;text-align:center;";
     const urlLine = document.createElement("div");
     urlLine.style.cssText =
-      "font-size:calc(var(--cmcp-fs) * 0.8615);opacity:0.55;word-break:break-all;text-align:center;max-width:280px;";
+      "font-size:calc(var(--cmcp-fs, 0.8125rem) * 0.8615);opacity:0.55;word-break:break-all;text-align:center;max-width:280px;";
     // #749 — the durability of THIS url, rendered where the user is looking at it.
     const durabilityLine = document.createElement("div");
     durabilityLine.style.cssText =
-      "font-size:calc(var(--cmcp-fs) * 0.8862);line-height:1.35;text-align:left;max-width:280px;margin-top:0.15rem;";
+      "font-size:calc(var(--cmcp-fs, 0.8125rem) * 0.8862);line-height:1.35;text-align:left;max-width:280px;margin-top:0.15rem;";
     durabilityLine.hidden = true;
     qrWrap.append(canvas, statusMsg, urlLine, durabilityLine);
 

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -1411,10 +1411,6 @@ function cmcpOpenCredentialsFrame(client) {
   // Prime with whatever status the orchestrator already has.
   client?.sendFrame?.({ type: "oauth_status" });
 
-  // #753 — mounted on <body>, OUTSIDE .cmcp-root, so `em` inside it would resolve
-  // against the page's 16px rather than the panel's 13px. Anchor the root in rem,
-  // exactly as .cmcp-root is anchored, so everything below renders as written.
-  backdrop.style.fontSize = "0.8125rem";
   backdrop.appendChild(card);
   document.body.appendChild(backdrop);
 }
@@ -3224,7 +3220,7 @@ function makeSettingSelect() {
   sel.className = "p-inputtext p-component";
   sel.style.cssText =
     "padding:0.3rem 0.5rem;border-radius:6px;border:1px solid var(--p-surface-500,#555);" +
-    "background:var(--p-surface-900,#18181b);color:var(--p-text-color,#e4e4e7);font-size:0.9846em;min-width:14rem;";
+    "background:var(--p-surface-900,#18181b);color:var(--p-text-color,#e4e4e7);font-size:calc(var(--cmcp-fs) * 0.9846);min-width:14rem;";
   return sel;
 }
 /** (Re)populate a backend's Default-model <select>: an "Auto" option, then that
@@ -3501,9 +3497,9 @@ function panelSettingsList() {
       btn.textContent = `Set ${friendly} ${noun}…`;
       btn.style.cssText =
         "padding:0.3rem 0.7rem;border-radius:6px;border:1px solid var(--p-surface-500,#555);" +
-        "background:var(--p-primary-color,#3a7bd5);color:#fff;cursor:pointer;font-size:0.9846em;white-space:nowrap;";
+        "background:var(--p-primary-color,#3a7bd5);color:#fff;cursor:pointer;font-size:calc(var(--cmcp-fs) * 0.9846);white-space:nowrap;";
       const status = document.createElement("span");
-      status.style.cssText = "font-size:0.8862em;opacity:0.8;";
+      status.style.cssText = "font-size:calc(var(--cmcp-fs) * 0.8862);opacity:0.8;";
       const refresh = () => {
         const at = lsGet(SECRET_SET_AT_PREFIX + envKey);
         if (at) {
@@ -3648,7 +3644,7 @@ function panelSettingsList() {
         a.style.cssText =
           "display:inline-flex;align-items:center;gap:0.4rem;padding:0.3rem 0.7rem;border-radius:6px;" +
           "border:1px solid var(--p-surface-500,#555);background:var(--p-surface-800,#27272a);" +
-          "color:var(--p-text-color,#e4e4e7);text-decoration:none;font-size:0.9846em;white-space:nowrap;";
+          "color:var(--p-text-color,#e4e4e7);text-decoration:none;font-size:calc(var(--cmcp-fs) * 0.9846);white-space:nowrap;";
         return a;
       },
     },
@@ -3672,7 +3668,7 @@ function panelSettingsList() {
         b.style.cssText =
           "display:inline-flex;align-items:center;gap:0.4rem;padding:0.3rem 0.7rem;border-radius:6px;" +
           "border:1px solid var(--p-surface-500,#555);background:var(--p-surface-800,#27272a);" +
-          "color:var(--p-text-color,#e4e4e7);cursor:pointer;font-size:0.9846em;white-space:nowrap;";
+          "color:var(--p-text-color,#e4e4e7);cursor:pointer;font-size:calc(var(--cmcp-fs) * 0.9846);white-space:nowrap;";
         b.addEventListener("click", () => {
           // Open the panel first — painting into a transcript the user cannot see is the
           // same failure as not painting at all. openSidebarTab() is the same activate the
@@ -3716,7 +3712,7 @@ function panelSettingsList() {
         a.style.cssText =
           "display:inline-flex;align-items:center;gap:0.4rem;padding:0.3rem 0.7rem;border-radius:6px;" +
           "border:1px solid var(--p-surface-500,#555);background:var(--p-surface-800,#27272a);" +
-          "color:var(--p-text-color,#e4e4e7);text-decoration:none;font-size:0.9846em;white-space:nowrap;";
+          "color:var(--p-text-color,#e4e4e7);text-decoration:none;font-size:calc(var(--cmcp-fs) * 0.9846);white-space:nowrap;";
         return a;
       },
     },
@@ -3736,7 +3732,7 @@ function panelSettingsList() {
         a.style.cssText =
           "display:inline-flex;align-items:center;gap:0.4rem;padding:0.3rem 0.7rem;border-radius:6px;" +
           "border:1px solid var(--p-surface-500,#555);background:var(--p-surface-800,#27272a);" +
-          "color:var(--p-text-color,#e4e4e7);text-decoration:none;font-size:0.9846em;white-space:nowrap;";
+          "color:var(--p-text-color,#e4e4e7);text-decoration:none;font-size:calc(var(--cmcp-fs) * 0.9846);white-space:nowrap;";
         return a;
       },
     },
@@ -3758,7 +3754,7 @@ function panelSettingsList() {
         btn.style.cssText =
           "display:inline-flex;align-items:center;gap:0.4rem;padding:0.3rem 0.7rem;border-radius:6px;" +
           "border:1px solid var(--p-primary-color,#8b5cf6);background:var(--p-primary-color,#8b5cf6);" +
-          "color:#fff;font-size:0.9846em;white-space:nowrap;cursor:pointer;";
+          "color:#fff;font-size:calc(var(--cmcp-fs) * 0.9846);white-space:nowrap;cursor:pointer;";
         btn.addEventListener("click", async () => {
           const diag = [
             "--- comfyui-mcp panel diagnostics ---",
@@ -3936,7 +3932,7 @@ function panelSettingsList() {
         note.textContent =
           "⚠️ Beta — the app changes rapidly and builds may break between updates. " +
           "Enable the toggle above, install for your platform, then pair with the QR button in the panel header.";
-        note.style.cssText = "font-size:0.9231em;opacity:0.75;line-height:1.35;";
+        note.style.cssText = "font-size:calc(var(--cmcp-fs) * 0.9231);opacity:0.75;line-height:1.35;";
         const row = document.createElement("div");
         row.style.cssText = "display:flex;gap:0.5rem;flex-wrap:wrap;";
         const linkBtn = (label, url) => {
@@ -3945,7 +3941,7 @@ function panelSettingsList() {
           a.style.cssText =
             "display:inline-flex;align-items:center;gap:0.4rem;padding:0.3rem 0.7rem;border-radius:6px;" +
             "border:1px solid var(--p-surface-500,#555);background:var(--p-surface-800,#27272a);" +
-            "color:var(--p-text-color,#e4e4e7);text-decoration:none;font-size:0.9846em;white-space:nowrap;";
+            "color:var(--p-text-color,#e4e4e7);text-decoration:none;font-size:calc(var(--cmcp-fs) * 0.9846);white-space:nowrap;";
           if (url) {
             a.href = url;
             a.target = "_blank";
@@ -3974,12 +3970,10 @@ function panelSettingsList() {
       tooltip:
         "Scales the whole Agent sidebar — text, icons and spacing together. Raise it if the panel is hard " +
         "to read on a high-DPI or large display. 100% is the default; 100-250. Applies immediately, to " +
-        "every open panel. Since 0.13.3 the panel's inner FONT sizes are `em`, so overriding " +
-        "`.cmcp-root { font-size }` in a user stylesheet does now scale most panel text. Two things it " +
-        "still will not scale: spacing (padding and gaps are `rem` on purpose — as `em` they compound " +
-        "through nesting), and the surfaces that mount outside the panel root (the CivitAI explorer, " +
-        "Apps and their modals), which are anchored so they render correctly wherever they mount. This " +
-        "setting remains the supported way to scale the panel as a whole.",
+        "every open panel. For text only, the panel also exposes a CSS variable: setting `--cmcp-fs` " +
+        "(default 0.8125rem) on `:root` or `.cmcp-root` in a user stylesheet scales every panel font " +
+        "size, including the CivitAI, Apps and modal surfaces. It does not scale spacing or icons — " +
+        "this setting is still the supported way to scale the panel as a whole.",
       type: "slider",
       attrs: { min: PANEL_UI_SCALE_MIN, max: PANEL_UI_SCALE_MAX, step: 5 },
       defaultValue: 100,
@@ -6930,11 +6924,7 @@ function makeShellCommandBlock(baseCmd) {
     b.className = "cmcp-btn";
     b.dataset.shell = s.key;
     b.textContent = s.label;
-    // #753 — 1.0472em, not the 0.8862em the other `.cmcp-btn` sites use. These pills render
-    // inside the 11px code-block tools row rather than at the 13px root, and em resolves
-    // against the PARENT: the shared value rendered them at 9.75px instead of 11.52px.
-    // Measured on the page, not derived from the stylesheet.
-    b.style.cssText = "font-size:1.0472em;padding:0.12rem 0.45rem;";
+    b.style.cssText = "font-size:calc(var(--cmcp-fs) * 0.8862);padding:0.12rem 0.45rem;";
     b.addEventListener("click", () => { selected = s.key; render(); copy(forms[s.key]); });
     pills.appendChild(b);
   }
@@ -17920,6 +17910,13 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
 // ---------------------------------------------------------------------------
 
 const PANEL_CSS = `
+:root {
+  /* #753 — declared HERE as well as on .cmcp-root, because the sub-modal overlay,
+     the CivitAI lightbox and the media lightbox mount on <body>, OUTSIDE the panel
+     root. Without a :root declaration those surfaces resolve the variable to nothing
+     and drop every font-size that uses it. Override either one to scale the panel. */
+  --cmcp-fs: 0.8125rem;
+}
 .cmcp-root {
   display: flex; flex-direction: column; height: 100%; min-height: 0;
   /* #753 — a plain 100% is CORRECT under the UI-scale zoom, and dividing by the
@@ -17930,7 +17927,14 @@ const PANEL_CSS = `
      both ways. Do not re-add it. */
   position: relative; /* positioning context for the rollback modal overlay */
   font-family: var(--font-inter, "Inter", ui-sans-serif, system-ui, sans-serif);
-  font-size: 0.8125rem; line-height: 1.5;
+  /* #753 — THE ONE KNOB. Every inner font size is calc(var(--cmcp-fs) * k), so a
+     change here scales all of them at once, at any nesting depth. `em` was tried
+     first and rejected: it resolves against the PARENT, so a rule inside a block
+     that sets its own size needs a different multiplier, and a rule used under two
+     different parents has no single correct value at all (measured: 529 drifted
+     elements, ~25 nested sites, 5 inexpressible rules). A variable is flat. */
+  --cmcp-fs: 0.8125rem;
+  font-size: var(--cmcp-fs); line-height: 1.5;
   color: var(--p-text-color, #fff);
   background: var(--p-content-background, #18181b);
 }
@@ -17944,7 +17948,7 @@ const PANEL_CSS = `
    header actions on a narrow sidebar. */
 .cmcp-logo { height: 20px; width: auto; max-width: 148px; flex: none; object-fit: contain; display: block; }
 .cmcp-status { display: flex; align-items: center; gap: 0.375rem; margin-left: auto;
-  font-size: 1em; color: var(--p-text-muted-color, #a1a1aa); }
+  font-size: calc(var(--cmcp-fs) * 0.8462); color: var(--p-text-muted-color, #a1a1aa); }
 .cmcp-dot { width: 8px; height: 8px; border-radius: 50%; background: var(--p-red-400, #f87171); flex: none; }
 .cmcp-dot.connected { background: var(--p-green-400, #4ade80); }
 .cmcp-dot.connecting { background: var(--p-yellow-400, #facc15); animation: cmcp-pulse 1.2s ease-in-out infinite; }
@@ -17965,12 +17969,12 @@ const PANEL_CSS = `
   background: transparent; border: none; cursor: pointer;
   border-radius: var(--p-border-radius-sm, 4px);
   padding: 0.25rem 0.5rem;
-  font: inherit; font-size: 0.8462em;
+  font: inherit; font-size: calc(var(--cmcp-fs) * 0.8462);
   color: var(--p-text-muted-color, #a1a1aa);
   transition: background 0.15s, color 0.15s;
 }
 .cmcp-toolbtn:hover { background: var(--p-surface-700, #3f3f46); color: var(--p-text-color, #fff); }
-.cmcp-toolbtn .pi { font-size: 1.3636em; }
+.cmcp-toolbtn .pi { font-size: var(--cmcp-fs); }
 .cmcp-toolbtn svg { width: 13px; height: 13px; display: block; }
 /* Icon-only variant (Deafen/Blind): the label span stays in the DOM — state
    copy still flows into it for screen readers / the find-icon logic — but is
@@ -17981,7 +17985,7 @@ const PANEL_CSS = `
   position: absolute; width: 1px; height: 1px; overflow: hidden;
   clip: rect(0 0 0 0); clip-path: inset(50%); white-space: nowrap;
 }
-.cmcp-toolbtn.cmcp-toolbtn-iconic .pi { font-size: 1.3636em; }
+.cmcp-toolbtn.cmcp-toolbtn-iconic .pi { font-size: calc(var(--cmcp-fs) * 1.1538); }
 .cmcp-toolbtn.cmcp-toolbtn-iconic svg { width: 15px; height: 15px; }
 /* Active tab: the four surface buttons ARE the tab bar (issue #124) — the open
    one gets the themed toggled state (inverts light/dark via the primary tokens). */
@@ -18018,13 +18022,13 @@ const PANEL_CSS = `
 }
 .cmcp-settings > summary {
   padding: 0.5rem 0.75rem; cursor: pointer; user-select: none;
-  font-size: 0.9231em; font-weight: 600; color: var(--p-text-muted-color, #a1a1aa);
+  font-size: calc(var(--cmcp-fs) * 0.9231); font-weight: 600; color: var(--p-text-muted-color, #a1a1aa);
   list-style: none; display: flex; align-items: center; gap: 0.375rem;
 }
 .cmcp-settings > summary::before { content: "▸"; transition: transform 0.15s; }
 .cmcp-settings[open] > summary::before { transform: rotate(90deg); }
 .cmcp-settings-body { padding: 0 0.75rem 0.75rem; display: flex; flex-direction: column; gap: 0.5rem; }
-.cmcp-label { font-size: 0.8462em; color: var(--p-text-muted-color, #a1a1aa); }
+.cmcp-label { font-size: calc(var(--cmcp-fs) * 0.8462); color: var(--p-text-muted-color, #a1a1aa); }
 .cmcp-input {
   width: 100%; box-sizing: border-box;
   padding: var(--p-form-field-padding-y, 0.5rem) var(--p-form-field-padding-x, 0.75rem);
@@ -18044,13 +18048,13 @@ const PANEL_CSS = `
 }
 .cmcp-btn:hover { opacity: 0.85; }
 .cmcp-btn:disabled { opacity: 0.4; cursor: default; }
-.cmcp-help { font-size: 0.8462em; color: var(--p-text-muted-color, #a1a1aa); line-height: 1.55; }
+.cmcp-help { font-size: calc(var(--cmcp-fs) * 0.8462); color: var(--p-text-muted-color, #a1a1aa); line-height: 1.55; }
 .cmcp-cmd {
   display: block; margin-top: 0.25rem; padding: 0.375rem 0.5rem;
   background: var(--p-form-field-background, #09090b);
   border: 1px solid var(--p-content-border-color, #3f3f46);
   border-radius: var(--p-border-radius-sm, 4px);
-  font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 0.9999em;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: calc(var(--cmcp-fs) * 0.8462);
   user-select: all; cursor: copy; color: var(--p-text-color, #fff);
   overflow-x: auto; white-space: nowrap;
 }
@@ -18069,12 +18073,12 @@ const PANEL_CSS = `
   margin: auto; text-align: center; max-width: 230px;
   color: var(--p-text-muted-color, #a1a1aa);
 }
-.cmcp-empty .pi { font-size: 2.1538em; display: block; margin-bottom: 0.5rem; opacity: 0.5; }
+.cmcp-empty .pi { font-size: calc(var(--cmcp-fs) * 2.1538); display: block; margin-bottom: 0.5rem; opacity: 0.5; }
 .cmcp-empty-title { font-weight: 600; color: var(--p-text-color, #fff); margin-bottom: 0.25rem; }
 .cmcp-examples { display: flex; flex-direction: column; gap: 0.375rem; margin-top: 0.875rem; text-align: left; }
 .cmcp-example {
   display: flex; align-items: center; gap: 0.5rem; width: 100%; box-sizing: border-box;
-  padding: 0.4375rem 0.625rem; cursor: pointer; font: inherit; font-size: 0.9231em;
+  padding: 0.4375rem 0.625rem; cursor: pointer; font: inherit; font-size: calc(var(--cmcp-fs) * 0.9231);
   color: var(--p-text-color, #fff); text-align: left;
   background: var(--p-surface-800, #27272a);
   border: 1px solid var(--p-content-border-color, #3f3f46);
@@ -18082,7 +18086,7 @@ const PANEL_CSS = `
   transition: border-color 0.15s, background 0.15s;
 }
 .cmcp-example:hover { border-color: var(--p-primary-color, #60a5fa); background: var(--p-surface-700, #3f3f46); }
-.cmcp-example .pi { font-size: 1em; margin: 0; opacity: 1; color: var(--p-primary-color, #60a5fa); flex: none; }
+.cmcp-example .pi { font-size: var(--cmcp-fs); margin: 0; opacity: 1; color: var(--p-primary-color, #60a5fa); flex: none; }
 
 /* Provider onboarding card — shown only when NEITHER provider is signed in. */
 .cmcp-onboard {
@@ -18096,10 +18100,10 @@ const PANEL_CSS = `
    it or "onboard.hidden = true" won't actually hide the card. */
 .cmcp-onboard[hidden] { display: none; }
 .cmcp-onboard-title { font-weight: 600; color: var(--p-text-color, #fff); }
-.cmcp-onboard-sub { font-size: 0.9231em; color: var(--p-text-muted-color, #a1a1aa); line-height: 1.4; }
+.cmcp-onboard-sub { font-size: calc(var(--cmcp-fs) * 0.9231); color: var(--p-text-muted-color, #a1a1aa); line-height: 1.4; }
 .cmcp-onboard-col { display: flex; flex-direction: column; gap: 0.25rem; }
-.cmcp-onboard-prov { font-weight: 600; font-size: 1em; color: var(--p-text-color, #fff); margin-top: 0.25rem; }
-.cmcp-onboard-step { font-size: 0.8615em; color: var(--p-text-muted-color, #a1a1aa); }
+.cmcp-onboard-prov { font-weight: 600; font-size: var(--cmcp-fs); color: var(--p-text-color, #fff); margin-top: 0.25rem; }
+.cmcp-onboard-step { font-size: calc(var(--cmcp-fs) * 0.8615); color: var(--p-text-muted-color, #a1a1aa); }
 
 .cmcp-bubble {
   padding: 0.5rem 0.75rem; max-width: 92%;
@@ -18121,7 +18125,7 @@ const PANEL_CSS = `
   display: flex; align-items: center; justify-content: center;
   border: 1px solid var(--p-content-border-color, #3f3f46);
   background: var(--p-surface-800, #27272a); color: var(--p-text-muted-color, #a1a1aa);
-  cursor: pointer; opacity: 0; transition: opacity 0.12s, color 0.12s; font-size: 0.8615em;
+  cursor: pointer; opacity: 0; transition: opacity 0.12s, color 0.12s; font-size: calc(var(--cmcp-fs) * 0.8615);
 }
 .cmcp-bubble.user:hover .cmcp-edit-btn { opacity: 1; }
 .cmcp-edit-btn:hover { color: var(--p-primary-color, #60a5fa); border-color: var(--p-primary-color, #60a5fa); }
@@ -18135,15 +18139,15 @@ const PANEL_CSS = `
   padding: 0.85rem; border-radius: 10px; background: var(--p-surface-900, #18181b);
   border: 1px solid var(--p-content-border-color, #3f3f46); box-shadow: 0 8px 30px rgba(0,0,0,0.5);
 }
-.cmcp-modal-title { font-weight: 600; font-size: 1.0462em; }
+.cmcp-modal-title { font-weight: 600; font-size: calc(var(--cmcp-fs) * 1.0462); }
 .cmcp-modal-text {
   width: 100%; box-sizing: border-box; resize: vertical; min-height: 3.5rem;
-  padding: 0.4rem 0.5rem; border-radius: 6px; font: inherit; font-size: 0.9846em;
+  padding: 0.4rem 0.5rem; border-radius: 6px; font: inherit; font-size: calc(var(--cmcp-fs) * 0.9846);
   background: var(--p-surface-950, #111113); color: inherit;
   border: 1px solid var(--p-surface-500, #555);
 }
 .cmcp-modal-scopes { display: flex; flex-direction: column; gap: 0.3rem; }
-.cmcp-modal-scope { display: flex; gap: 0.4rem; align-items: flex-start; font-size: 0.8862em; cursor: pointer; }
+.cmcp-modal-scope { display: flex; gap: 0.4rem; align-items: flex-start; font-size: calc(var(--cmcp-fs) * 0.8862); cursor: pointer; }
 .cmcp-modal-scope input { margin-top: 0.15rem; }
 .cmcp-modal-btns { display: flex; justify-content: flex-end; gap: 0.4rem; }
 .cmcp-btn-primary { background: var(--p-primary-color, #3a7bd5); color: #fff; border: none; }
@@ -18169,7 +18173,7 @@ const PANEL_CSS = `
 .cmcp-lightbox-nav {
   position: absolute; top: 50%; transform: translateY(-50%);
   width: 2.6rem; height: 2.6rem; border-radius: 50%; cursor: pointer;
-  font-size: 1.9692em; line-height: 1; display: flex; align-items: center; justify-content: center;
+  font-size: calc(var(--cmcp-fs) * 1.9692); line-height: 1; display: flex; align-items: center; justify-content: center;
   color: var(--p-text-color, #fafafa);
   background: rgba(0,0,0,0.45); border: 1px solid var(--p-content-border-color, #3f3f46);
 }
@@ -18179,7 +18183,7 @@ const PANEL_CSS = `
 .cmcp-lightbox-close {
   position: absolute; top: 0.75rem; right: 0.75rem;
   width: 2.2rem; height: 2.2rem; border-radius: 50%; cursor: pointer;
-  font-size: 1.3538em; line-height: 1; display: flex; align-items: center; justify-content: center;
+  font-size: calc(var(--cmcp-fs) * 1.3538); line-height: 1; display: flex; align-items: center; justify-content: center;
   color: var(--p-text-color, #fafafa);
   background: rgba(0,0,0,0.45); border: 1px solid var(--p-content-border-color, #3f3f46);
 }
@@ -18190,11 +18194,11 @@ const PANEL_CSS = `
   border-top: 1px solid var(--p-content-border-color, #3f3f46);
 }
 .cmcp-lightbox-caption {
-  font-size: 0.9231em; color: var(--p-text-muted-color, #a1a1aa);
+  font-size: calc(var(--cmcp-fs) * 0.9231); color: var(--p-text-muted-color, #a1a1aa);
   overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
 }
 .cmcp-lightbox-open {
-  flex: 0 0 auto; cursor: pointer; font-size: 0.8862em; padding: 0.3rem 0.6rem; border-radius: 6px;
+  flex: 0 0 auto; cursor: pointer; font-size: calc(var(--cmcp-fs) * 0.8862); padding: 0.3rem 0.6rem; border-radius: 6px;
   color: var(--p-text-color, #fafafa);
   background: var(--p-surface-800, #27272a); border: 1px solid var(--p-content-border-color, #3f3f46);
 }
@@ -18211,7 +18215,7 @@ const PANEL_CSS = `
 }
 .cmcp-media-expand, .cmcp-media-collapse {
   width: 1.8rem; height: 1.8rem; border-radius: 6px; cursor: pointer;
-  font-size: 1.1692em; line-height: 1; display: flex; align-items: center; justify-content: center;
+  font-size: calc(var(--cmcp-fs) * 1.1692); line-height: 1; display: flex; align-items: center; justify-content: center;
   color: #fff; background: rgba(0,0,0,0.5); border: 1px solid rgba(255,255,255,0.25);
   opacity: 0; transition: opacity 0.12s ease;
 }
@@ -18241,7 +18245,7 @@ const PANEL_CSS = `
 .cmcp-media-stub {
   display: none; align-items: center; gap: 0.4rem; cursor: pointer;
   min-height: 1.8rem; padding: 0.35rem 2.6rem 0.35rem 0.55rem; border-radius: 6px;
-  font-size: 0.8615em; color: var(--p-text-muted-color, #a1a1aa);
+  font-size: calc(var(--cmcp-fs) * 0.8615); color: var(--p-text-muted-color, #a1a1aa);
   background: var(--p-content-hover-background, #2a2a2e);
   border: 1px dashed var(--p-content-border-color, #3f3f46);
 }
@@ -18259,7 +18263,7 @@ const PANEL_CSS = `
   padding: 0.5rem 0.6rem; background: var(--p-surface-800, #27272a);
 }
 .cmcp-file-open {
-  color: var(--p-primary-color, #60a5fa); text-decoration: none; font-size: 0.9846em;
+  color: var(--p-primary-color, #60a5fa); text-decoration: none; font-size: calc(var(--cmcp-fs) * 0.9846);
   word-break: break-all;
 }
 .cmcp-file-open:hover { text-decoration: underline; }
@@ -18283,7 +18287,7 @@ const PANEL_CSS = `
 .cmcp-msg-status {
   align-self: flex-end; max-width: 92%;
   margin: 0.0625rem 0.125rem 0.125rem;
-  font-size: 0.8462em; color: var(--p-text-muted-color, #71717a);
+  font-size: calc(var(--cmcp-fs) * 0.8462); color: var(--p-text-muted-color, #71717a);
   display: flex; gap: 0.375rem; align-items: center;
 }
 .cmcp-msg-status:empty { display: none; }
@@ -18301,11 +18305,11 @@ const PANEL_CSS = `
   border-radius: var(--p-border-radius-sm, 4px);
   transition: color 0.12s, background 0.12s;
 }
-.cmcp-msg-action .pi { font-size: 0.9231em; }
+.cmcp-msg-action .pi { font-size: calc(var(--cmcp-fs) * 0.9231); }
 .cmcp-msg-action:hover { color: var(--p-text-color, #fff); background: var(--p-surface-700, #3f3f46); }
 .cmcp-msg-status.failed .cmcp-msg-action:hover { color: var(--p-red-300, #fca5a5); }
 .cmcp-bubble.agent code, .cmcp-bubble.user code {
-  font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 0.75rem;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: calc(var(--cmcp-fs) * 0.9231);
   background: var(--p-form-field-background, #09090b);
   padding: 0.0625rem 0.25rem; border-radius: var(--p-border-radius-sm, 4px);
 }
@@ -18320,10 +18324,10 @@ const PANEL_CSS = `
 .cmcp-bubble h4, .cmcp-bubble h5, .cmcp-bubble h6 {
   margin: 0.625rem 0 0.25rem; font-weight: 600; line-height: 1.3;
 }
-.cmcp-bubble h1 { font-size: 1.2923em; }
-.cmcp-bubble h2 { font-size: 1.2308em; }
-.cmcp-bubble h3 { font-size: 1.1538em; }
-.cmcp-bubble h4, .cmcp-bubble h5, .cmcp-bubble h6 { font-size: 1.0769em; }
+.cmcp-bubble h1 { font-size: calc(var(--cmcp-fs) * 1.2923); }
+.cmcp-bubble h2 { font-size: calc(var(--cmcp-fs) * 1.2308); }
+.cmcp-bubble h3 { font-size: calc(var(--cmcp-fs) * 1.1538); }
+.cmcp-bubble h4, .cmcp-bubble h5, .cmcp-bubble h6 { font-size: calc(var(--cmcp-fs) * 1.0769); }
 .cmcp-bubble a { color: var(--p-primary-color, #60a5fa); text-decoration: underline; }
 .cmcp-bubble blockquote {
   margin: 0.5rem 0; padding: 0.125rem 0 0.125rem 0.75rem;
@@ -18338,7 +18342,7 @@ const PANEL_CSS = `
   border: 1px solid var(--p-content-border-color, #3f3f46);
   border-radius: var(--p-border-radius-md, 6px);
   overflow-x: auto; max-height: 20rem; overflow-y: auto;
-  font-size: 0.8462em; line-height: 1.5; tab-size: 2;
+  font-size: calc(var(--cmcp-fs) * 0.8462); line-height: 1.5; tab-size: 2;
 }
 .cmcp-bubble.agent pre code, .cmcp-bubble.user pre code {
   background: none; padding: 0; border-radius: 0;
@@ -18364,7 +18368,7 @@ const PANEL_CSS = `
   transition: background 0.15s, color 0.15s;
 }
 .cmcp-code-tool:hover { background: var(--p-surface-700, #3f3f46); color: var(--p-text-color, #fff); }
-.cmcp-code-tool .pi { font-size: 0.96em; }
+.cmcp-code-tool .pi { font-size: calc(var(--cmcp-fs) * 0.9846); }
 .cmcp-code-tool.ok { color: #4ade80; }
 .cmcp-wrap-btn.on { color: var(--p-primary-color, #60a5fa); }
 .cmcp-wrap-btn.on:hover { color: var(--p-primary-color, #60a5fa); }
@@ -18380,7 +18384,7 @@ const PANEL_CSS = `
   display: none; align-items: center; justify-content: center;
   background: var(--p-surface-700, #3f3f46); border: none; border-radius: 4px;
   color: var(--p-text-muted-color, #a1a1aa); cursor: pointer;
-  font-size: 0.55rem; line-height: 1; z-index: 2; box-shadow: 0 1px 3px rgba(0, 0, 0, 0.45);
+  font-size: calc(var(--cmcp-fs) * 0.6769); line-height: 1; z-index: 2; box-shadow: 0 1px 3px rgba(0, 0, 0, 0.45);
   transition: background 0.12s, color 0.12s;
 }
 .cmcp-bubble code.cmcp-inline-code:hover .cmcp-inline-copy { display: flex; }
@@ -18390,7 +18394,7 @@ const PANEL_CSS = `
   /* Real table layout (NOT display:block) so the header row stays aligned with
      the body; fit the panel width and let long cells wrap instead of scrolling. */
   display: table; width: 100%; table-layout: fixed;
-  border-collapse: collapse; margin: 0.5rem 0; font-size: 0.8462em;
+  border-collapse: collapse; margin: 0.5rem 0; font-size: calc(var(--cmcp-fs) * 0.8462);
 }
 .cmcp-bubble th, .cmcp-bubble td {
   border: 1px solid var(--p-content-border-color, #3f3f46);
@@ -18403,21 +18407,21 @@ const PANEL_CSS = `
   display: inline-flex; align-items: center; gap: 0.35rem;
   padding: 0.3rem 0.75rem; border-radius: 999px; border: none; cursor: pointer;
   background: var(--p-primary-color, #2563eb); color: var(--p-primary-contrast-color, #fff);
-  font: inherit; font-size: 0.8615em; box-shadow: 0 2px 10px rgba(0, 0, 0, 0.45);
+  font: inherit; font-size: calc(var(--cmcp-fs) * 0.8615); box-shadow: 0 2px 10px rgba(0, 0, 0, 0.45);
 }
-.cmcp-newmsg .pi { font-size: 1em; }
+.cmcp-newmsg .pi { font-size: calc(var(--cmcp-fs) * 0.8615); }
 /* The base rule sets display, which beats the UA [hidden] rule — so re-assert
    it or "newMsgBtn.hidden = true" won't actually hide the pill. */
 .cmcp-newmsg[hidden] { display: none; }
 .cmcp-tray {
   flex: none; margin: 0 0.5rem 0.25rem; padding: 0.4rem 0.55rem;
   background: var(--p-surface-800, #27272a); border: 1px solid var(--p-content-border-color, #3f3f46);
-  border-radius: 8px; max-height: 9rem; overflow-y: auto; font-size: 0.8615em;
+  border-radius: 8px; max-height: 9rem; overflow-y: auto; font-size: calc(var(--cmcp-fs) * 0.8615);
 }
 .cmcp-tray[hidden] { display: none; }
-.cmcp-tray-head { font-size: 0.7385em; text-transform: uppercase; letter-spacing: 0.05em; opacity: 0.55; margin-bottom: 0.3rem; }
+.cmcp-tray-head { font-size: calc(var(--cmcp-fs) * 0.7385); text-transform: uppercase; letter-spacing: 0.05em; opacity: 0.55; margin-bottom: 0.3rem; }
 .cmcp-todo-item { display: flex; align-items: flex-start; gap: 0.4rem; padding: 0.12rem 0; line-height: 1.3; }
-.cmcp-todo-item .pi { font-size: 0.8615em; margin-top: 0.1rem; flex: none; }
+.cmcp-todo-item .pi { font-size: calc(var(--cmcp-fs) * 0.8615); margin-top: 0.1rem; flex: none; }
 .cmcp-todo-item.done { opacity: 0.55; }
 .cmcp-todo-item.done span { text-decoration: line-through; }
 .cmcp-todo-item.done .pi { color: var(--p-green-400, #4ade80); }
@@ -18432,11 +18436,11 @@ const PANEL_CSS = `
 .cmcp-pending-text { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .cmcp-pending-item.failed .cmcp-pending-text { color: var(--p-red-300, #fca5a5); }
 .cmcp-pending-act { flex: none; width: 1.2rem; height: 1.2rem; padding: 0; border: none; background: transparent;
-  color: var(--p-text-muted-color, #a1a1aa); cursor: pointer; border-radius: 4px; font-size: 0.8615em; }
+  color: var(--p-text-muted-color, #a1a1aa); cursor: pointer; border-radius: 4px; font-size: calc(var(--cmcp-fs) * 0.8615); }
 .cmcp-pending-act:hover { color: var(--p-primary-color, #60a5fa); background: var(--p-surface-700, #3f3f46); }
 .cmcp-pending-act.danger:hover { color: var(--p-red-300, #fca5a5); }
 .cmcp-pending-handle { flex: none; width: 1rem; height: 1.2rem; display: flex; align-items: center; justify-content: center;
-  color: var(--p-text-muted-color, #71717a); cursor: grab; font-size: 0.8em; opacity: 0.6; }
+  color: var(--p-text-muted-color, #71717a); cursor: grab; font-size: calc(var(--cmcp-fs) * 0.8); opacity: 0.6; }
 .cmcp-pending-handle:hover { opacity: 1; color: var(--p-primary-color, #60a5fa); }
 .cmcp-pending-handle:active { cursor: grabbing; }
 .cmcp-pending-item.dragging { opacity: 0.4; }
@@ -18446,7 +18450,7 @@ const PANEL_CSS = `
 .cmcp-dl-item { padding: 0.18rem 0; }
 .cmcp-dl-top { display: flex; justify-content: space-between; gap: 0.5rem; align-items: baseline; }
 .cmcp-dl-name { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.cmcp-dl-meta { flex: none; opacity: 0.7; font-size: 0.7631em; }
+.cmcp-dl-meta { flex: none; opacity: 0.7; font-size: calc(var(--cmcp-fs) * 0.7631); }
 .cmcp-dl-bar { height: 4px; border-radius: 999px; background: var(--p-surface-700, #3f3f46); overflow: hidden; margin-top: 0.2rem; }
 .cmcp-dl-fill { height: 100%; background: var(--p-primary-color, #3a7bd5); transition: width 0.3s ease; }
 .cmcp-dl-item.done .cmcp-dl-fill { background: var(--p-green-400, #4ade80); }
@@ -18454,7 +18458,7 @@ const PANEL_CSS = `
 .cmcp-dl-bar.indet .cmcp-dl-fill { width: 30%; animation: cmcp-indet 1.1s ease-in-out infinite; }
 @keyframes cmcp-indet { 0% { margin-left: -30%; } 100% { margin-left: 100%; } }
 .cmcp-sys {
-  align-self: center; font-size: 0.8462em; font-style: italic;
+  align-self: center; font-size: calc(var(--cmcp-fs) * 0.8462); font-style: italic;
   color: var(--p-text-muted-color, #a1a1aa);
   animation: cmcp-in 0.18s ease-out;
   /* Status lines quote URLs, paths and ids — strings with no spaces to break
@@ -18471,17 +18475,17 @@ const PANEL_CSS = `
   border: 1px solid var(--p-content-border-color, #3f3f46);
   border-left: 3px solid var(--p-primary-color, #60a5fa);
   border-radius: var(--p-border-radius-md, 6px);
-  font-size: 0.9231em;
+  font-size: calc(var(--cmcp-fs) * 0.9231);
   animation: cmcp-in 0.18s ease-out;
 }
 .cmcp-card.error { border-left-color: var(--p-red-400, #f87171); }
 .cmcp-card-head { display: flex; align-items: center; gap: 0.375rem; font-weight: 600; min-width: 0; }
-.cmcp-card-head .pi { font-size: 1em; color: var(--p-primary-color, #60a5fa); flex: none; }
+.cmcp-card-head .pi { font-size: calc(var(--cmcp-fs) * 0.9231); color: var(--p-primary-color, #60a5fa); flex: none; }
 .cmcp-card-text { flex: 1 1 auto; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .cmcp-card.error .cmcp-card-head .pi { color: var(--p-red-400, #f87171); }
 .cmcp-card-detail {
   margin-top: 0.25rem; color: var(--p-text-muted-color, #a1a1aa);
-  font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 0.9166em;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: calc(var(--cmcp-fs) * 0.8462);
   overflow-x: auto; white-space: pre-wrap; word-break: break-word;
   max-height: 7.5rem; overflow-y: auto;
 }
@@ -18495,7 +18499,7 @@ const PANEL_CSS = `
   border: 2px dashed var(--p-primary-color, #3b82f6);
   border-radius: 10px;
   background: color-mix(in srgb, var(--p-primary-color, #3b82f6) 16%, var(--p-surface-900, #18181b));
-  color: var(--p-primary-color, #60a5fa); font-weight: 600; font-size: 1.0462em;
+  color: var(--p-primary-color, #60a5fa); font-weight: 600; font-size: calc(var(--cmcp-fs) * 1.0462);
   pointer-events: none; animation: cmcp-in 0.12s ease-out;
 }
 .cmcp-dropzone.cmcp-show { display: flex; }
@@ -18506,7 +18510,7 @@ const PANEL_CSS = `
   background: var(--p-surface-800, #27272a);
   border: 1px solid var(--p-content-border-color, #3f3f46);
   border-radius: var(--p-border-radius-lg, 8px);
-  color: var(--p-text-muted-color, #a1a1aa); font-size: 0.9231em;
+  color: var(--p-text-muted-color, #a1a1aa); font-size: calc(var(--cmcp-fs) * 0.9231);
   animation: cmcp-in 0.18s ease-out;
 }
 .cmcp-thinking-dots { display: inline-flex; gap: 3px; }
@@ -18532,19 +18536,19 @@ const PANEL_CSS = `
 }
 .cmcp-think > summary {
   list-style: none; cursor: pointer; user-select: none;
-  padding: 0.3125rem 0.5rem; font-size: 0.8462em; font-weight: 600;
+  padding: 0.3125rem 0.5rem; font-size: calc(var(--cmcp-fs) * 0.8462); font-weight: 600;
   color: var(--p-text-muted-color, #a1a1aa);
   display: flex; align-items: center; gap: 0.375rem;
 }
 .cmcp-think > summary::-webkit-details-marker { display: none; }
 .cmcp-think > summary::before {
-  content: "\\25b8"; font-size: 0.7692em; transition: transform 0.15s;
+  content: "\\25b8"; font-size: calc(var(--cmcp-fs) * 0.7692); transition: transform 0.15s;
 }
 .cmcp-think[open] > summary::before { transform: rotate(90deg); }
 .cmcp-think-body {
   max-height: 11rem; overflow-y: auto;
   padding: 0 0.5rem 0.4375rem 0.875rem;
-  font-size: 0.8462em; line-height: 1.45;
+  font-size: calc(var(--cmcp-fs) * 0.8462); line-height: 1.45;
   color: var(--p-text-muted-color, #8a8a93);
   white-space: pre-wrap; word-break: break-word;
   font-family: ui-monospace, "SFMono-Regular", Menlo, Consolas, monospace;
@@ -18589,19 +18593,19 @@ const PANEL_CSS = `
 .cmcp-iconbtn:hover { background: var(--p-surface-700, #3f3f46); color: var(--p-text-color, #fff); }
 .cmcp-iconbtn:disabled { opacity: 0.35; cursor: default; }
 .cmcp-iconbtn.active { color: var(--p-red-400, #f87171); }
-.cmcp-iconbtn .pi { font-size: 1.05em; }
+.cmcp-iconbtn .pi { font-size: calc(var(--cmcp-fs) * 1.0769); }
 /* #758 — the update notice. Sits in the transcript as a system line, so it inherits
    the panel's scale and scroll rather than becoming a modal the user must dismiss. */
 .cmcp-whatsnew { border-left: 2px solid var(--p-primary-color, #3b82f6); padding-left: 0.55rem; }
 .cmcp-whatsnew-head { font-weight: 600; margin-bottom: 0.3rem; }
 .cmcp-whatsnew-list { margin: 0; padding-left: 0.9rem; display: flex; flex-direction: column; gap: 0.25rem; }
 .cmcp-whatsnew-list li { line-height: 1.45; }
-.cmcp-whatsnew-tag { display: inline-block; font-size: 0.7138em; text-transform: uppercase;
+.cmcp-whatsnew-tag { display: inline-block; font-size: calc(var(--cmcp-fs) * 0.7138); text-transform: uppercase;
   letter-spacing: 0.04em; opacity: 0.75; border: 1px solid currentColor; border-radius: 3px;
   padding: 0 0.22rem; margin-right: 0.15rem; vertical-align: baseline; }
-.cmcp-workflow-version { margin-top: 0.35rem; font-size: 0.7138em; opacity: 0.62;
+.cmcp-workflow-version { margin-top: 0.35rem; font-size: calc(var(--cmcp-fs) * 0.7138); opacity: 0.62;
   display: flex; gap: 0.3rem; align-items: center; }
-.cmcp-workflow-version .pi { font-size: 1em; }
+.cmcp-workflow-version .pi { font-size: calc(var(--cmcp-fs) * 0.7138); }
 /* ---- sidebar tab badge (these live OUTSIDE .cmcp-root, on the toolbar) ---- */
 /* (.cmcp-tab-logo — the logo-mark tab glyph — is NOT here: it must exist the
    moment registerSidebarTab() paints the toolbar, before the panel ever
@@ -18625,7 +18629,7 @@ const PANEL_CSS = `
 .cmcp-chip {
   display: flex; align-items: center; gap: 0.25rem;
   border: none; background: transparent; cursor: pointer;
-  color: var(--p-text-muted-color, #a1a1aa); font: inherit; font-size: 0.8462em;
+  color: var(--p-text-muted-color, #a1a1aa); font: inherit; font-size: calc(var(--cmcp-fs) * 0.8462);
   padding: 0.125rem 0.375rem; border-radius: var(--p-border-radius-sm, 4px);
   white-space: nowrap; min-width: 0; overflow: hidden; flex: 0 1 auto;
 }
@@ -18647,13 +18651,13 @@ const PANEL_CSS = `
   background: var(--p-surface-700, #3f3f46);
   border: 1px solid var(--p-content-border-color, #52525b);
   border-radius: var(--p-border-radius-md, 6px);
-  color: var(--p-text-color, #fff); font: inherit; font-size: 0.8462em;
+  color: var(--p-text-color, #fff); font: inherit; font-size: calc(var(--cmcp-fs) * 0.8462);
   padding: 0.1875rem 0.25rem 0.1875rem 0.375rem; cursor: pointer;
   transition: background 0.15s, border-color 0.15s;
 }
 .cmcp-attach-chip:hover { background: var(--p-surface-600, #52525b); }
 .cmcp-attach-chip.open { border-color: var(--p-primary-color, #60a5fa); }
-.cmcp-attach-chip > .pi { font-size: 0.9231em; color: var(--p-text-muted-color, #a1a1aa); flex: none; }
+.cmcp-attach-chip > .pi { font-size: calc(var(--cmcp-fs) * 0.9231); color: var(--p-text-muted-color, #a1a1aa); flex: none; }
 .cmcp-attach-name { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .cmcp-attach-meta { color: var(--p-text-muted-color, #a1a1aa); flex: none; }
 .cmcp-attach-thumb { width: 1.125rem; height: 1.125rem; border-radius: 3px; object-fit: cover; flex: none; }
@@ -18663,7 +18667,7 @@ const PANEL_CSS = `
   border-radius: 3px; color: var(--p-text-muted-color, #a1a1aa);
 }
 .cmcp-attach-rm:hover { background: var(--p-surface-800, #27272a); color: var(--p-text-color, #fff); }
-.cmcp-attach-rm .pi { font-size: 0.7692em; }
+.cmcp-attach-rm .pi { font-size: calc(var(--cmcp-fs) * 0.7692); }
 .cmcp-attach-preview {
   background: var(--p-surface-900, #18181b);
   border: 1px solid var(--p-content-border-color, #3f3f46);
@@ -18673,10 +18677,10 @@ const PANEL_CSS = `
 .cmcp-attach-preview pre {
   margin: 0; white-space: pre-wrap; word-break: break-word;
   font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
-  font-size: 0.8462em; line-height: 1.45; color: var(--p-text-color, #e4e4e7);
+  font-size: calc(var(--cmcp-fs) * 0.8462); line-height: 1.45; color: var(--p-text-color, #e4e4e7);
 }
 .cmcp-attach-preview img { max-width: 100%; max-height: 12rem; border-radius: 4px; display: block; }
-.cmcp-ctx { font-size: 0.7692em; color: var(--p-text-muted-color, #a1a1aa); min-width: 1.75rem; }
+.cmcp-ctx { font-size: calc(var(--cmcp-fs) * 0.7692); color: var(--p-text-muted-color, #a1a1aa); min-width: 1.75rem; }
 .cmcp-ring { flex: none; margin: 0 0.125rem; transform: rotate(-90deg); }
 .cmcp-ring .bg { stroke: var(--p-surface-600, #52525b); }
 .cmcp-ring .fg { stroke: var(--p-primary-color, #60a5fa); transition: stroke-dashoffset 0.3s; }
@@ -18692,11 +18696,11 @@ const PANEL_CSS = `
 .cmcp-popover-item {
   display: flex; align-items: center; gap: 0.5rem; width: 100%; box-sizing: border-box;
   padding: 0.375rem 0.5rem; border: none; background: transparent; cursor: pointer;
-  text-align: left; color: var(--p-text-color, #fff); font: inherit; font-size: 0.9231em;
+  text-align: left; color: var(--p-text-color, #fff); font: inherit; font-size: calc(var(--cmcp-fs) * 0.9231);
   border-radius: var(--p-border-radius-sm, 4px);
 }
 .cmcp-popover-item.sel, .cmcp-popover-item:hover { background: var(--p-surface-700, #3f3f46); }
-.cmcp-popover-item .pi { font-size: 0.9231em; color: var(--p-text-muted-color, #a1a1aa); flex: none; }
+.cmcp-popover-item .pi { font-size: calc(var(--cmcp-fs) * 0.9231); color: var(--p-text-muted-color, #a1a1aa); flex: none; }
 .cmcp-popover-item small { margin-left: auto; color: var(--p-text-muted-color, #a1a1aa); flex: none; padding-left: 0.5rem; }
 .cmcp-popover-item .lbl { flex: 1 1 auto; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 /* Hover-to-read: while revealing, drop the ellipsis so the tail is legible, and
@@ -18729,12 +18733,12 @@ const PANEL_CSS = `
 .cmcp-hist-search {
   min-width: 0; border: 1px solid var(--p-form-field-border-color, #52525b);
   border-radius: var(--p-border-radius-sm, 4px); background: var(--p-form-field-background, #09090b);
-  color: var(--p-form-field-color, #fff); font: inherit; font-size: 0.9231em; padding: 0.35rem 0.45rem;
+  color: var(--p-form-field-color, #fff); font: inherit; font-size: calc(var(--cmcp-fs) * 0.9231); padding: 0.35rem 0.45rem;
 }
 .cmcp-hist-filter { grid-column: 1 / -1; display: flex; align-items: center; gap: 0.375rem;
-  color: var(--p-text-muted-color, #a1a1aa); font-size: 0.8462em; }
+  color: var(--p-text-muted-color, #a1a1aa); font-size: calc(var(--cmcp-fs) * 0.8462); }
 .cmcp-hist-list { max-height: min(58vh, 28rem); overflow-y: auto; padding: 0.25rem; }
-.cmcp-hist-group { padding: 0.35rem 0.5rem 0.2rem; font-size: 0.7692em; font-weight: 700;
+.cmcp-hist-group { padding: 0.35rem 0.5rem 0.2rem; font-size: calc(var(--cmcp-fs) * 0.7692); font-weight: 700;
   text-transform: uppercase; letter-spacing: 0.04em; color: var(--p-text-muted-color, #a1a1aa); }
 .cmcp-hist-row { display: flex; align-items: stretch; gap: 0.125rem; }
 .cmcp-hist-row.active { background: color-mix(in srgb, var(--p-primary-color, #60a5fa) 13%, transparent); border-radius: 4px; }
@@ -18743,7 +18747,7 @@ const PANEL_CSS = `
 .cmcp-hist-row.foreign-workflow .cmcp-hist-open { cursor: not-allowed; }
 .cmcp-hist-meta { display: flex; flex-direction: column; min-width: 0; flex: 1; }
 .cmcp-hist-meta .lbl { font-weight: 550; }
-.cmcp-hist-sub { color: var(--p-text-muted-color, #a1a1aa); font-size: 0.7692em;
+.cmcp-hist-sub { color: var(--p-text-muted-color, #a1a1aa); font-size: calc(var(--cmcp-fs) * 0.7692);
   overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .cmcp-hist-action {
   flex: none; width: 1.75rem; border: none; background: transparent; cursor: pointer;
@@ -18754,32 +18758,32 @@ const PANEL_CSS = `
 .cmcp-hist-action:focus-visible { opacity: 1; }
 .cmcp-hist-action:hover { background: var(--p-surface-700, #3f3f46); color: var(--p-text-color, #fff); }
 .cmcp-hist-action.danger:hover { color: var(--p-red-400, #f87171); }
-.cmcp-hist-action .pi { font-size: 0.9231em; }
+.cmcp-hist-action .pi { font-size: calc(var(--cmcp-fs) * 0.9231); }
 .cmcp-hist-footer {
   margin-top: 0.25rem; padding: 0.5rem 0.375rem 0.125rem;
   border-top: 1px solid var(--p-content-border-color, #3f3f46);
 }
 .cmcp-hist-note {
   margin: 0 0 0.375rem; color: var(--p-text-muted-color, #a1a1aa);
-  font-size: 0.7692em; line-height: 1.35;
+  font-size: calc(var(--cmcp-fs) * 0.7692); line-height: 1.35;
 }
 .cmcp-hist-clear {
   display: flex; align-items: center; justify-content: center; gap: 0.375rem;
   width: 100%; padding: 0.3125rem 0.5rem; border-radius: var(--p-border-radius-sm, 4px);
   border: 1px solid color-mix(in srgb, var(--p-red-400, #f87171) 45%, transparent);
   background: transparent; color: var(--p-red-400, #f87171); cursor: pointer;
-  font: inherit; font-size: 0.8462em;
+  font: inherit; font-size: calc(var(--cmcp-fs) * 0.8462);
 }
 .cmcp-hist-clear:hover:not(:disabled) { background: color-mix(in srgb, var(--p-red-400, #f87171) 12%, transparent); }
 .cmcp-hist-clear:disabled { opacity: 0.4; cursor: not-allowed; }
 
 /* Model/effort picker popover (anchored above the composer). */
-.cmcp-pop-section { padding: 0.25rem 0.5rem 0.125rem; font-size: 0.7692em; font-weight: 600;
+.cmcp-pop-section { padding: 0.25rem 0.5rem 0.125rem; font-size: calc(var(--cmcp-fs) * 0.7692); font-weight: 600;
   text-transform: uppercase; letter-spacing: 0.04em; color: var(--p-text-muted-color, #a1a1aa); }
 .cmcp-pop-section:not(:first-child) { margin-top: 0.25rem; border-top: 1px solid var(--p-content-border-color, #3f3f46); padding-top: 0.375rem; }
 .cmcp-popover-item .check { flex: none; width: 1rem; text-align: center; margin-left: 0.375rem; color: var(--p-primary-color, #60a5fa); visibility: hidden; }
 .cmcp-popover-item .check.on { visibility: visible; }
-.cmcp-chip .pi-angle-down { font-size: 0.8181em; opacity: 0.7; }
+.cmcp-chip .pi-angle-down { font-size: calc(var(--cmcp-fs) * 0.6923); opacity: 0.7; }
 .cmcp-chip .dim { opacity: 0.65; }
 /* Omni-search model picker (aggregates every connected provider's catalog into
    one virtualized, keyboard-navigable list). Row height is FIXED at 30px so the
@@ -18787,9 +18791,9 @@ const PANEL_CSS = `
 .cmcp-modelsearch { display: flex; flex-direction: column; }
 .cmcp-modelsearch-input { margin: 0.25rem 0.5rem; padding: 0.3rem 0.5rem; border-radius: 6px;
   border: 1px solid var(--p-content-border-color, #3f3f46); background: var(--p-surface-900, #18181b);
-  color: var(--p-text-color, #e4e4e7); font-size: 0.9846em; }
+  color: var(--p-text-color, #e4e4e7); font-size: calc(var(--cmcp-fs) * 0.9846); }
 .cmcp-modelsearch-input:focus { outline: none; border-color: var(--p-focus-ring-color, #60a5fa); }
-.cmcp-modelsearch-cap { padding: 0.125rem 0.5rem 0.25rem; font-size: 0.7692em; color: var(--p-text-muted-color, #a1a1aa); }
+.cmcp-modelsearch-cap { padding: 0.125rem 0.5rem 0.25rem; font-size: calc(var(--cmcp-fs) * 0.7692); color: var(--p-text-muted-color, #a1a1aa); }
 .cmcp-modelresults { position: relative; overflow-y: auto; max-height: 15rem; }
 .cmcp-modelsizer { position: relative; width: 100%; }
 .cmcp-modelrow { position: absolute; left: 0; right: 0; height: 30px; display: flex; align-items: center;
@@ -18797,19 +18801,19 @@ const PANEL_CSS = `
   text-align: left; cursor: pointer; box-sizing: border-box; }
 .cmcp-modelrow:hover, .cmcp-modelrow.active { background: var(--p-surface-700, #3f3f46); }
 .cmcp-modelrow .lbl { flex: 1 1 auto; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.cmcp-modelrow .sub { flex: none; color: var(--p-text-muted-color, #a1a1aa); font-size: 0.8462em; overflow: hidden;
+.cmcp-modelrow .sub { flex: none; color: var(--p-text-muted-color, #a1a1aa); font-size: calc(var(--cmcp-fs) * 0.8462); overflow: hidden;
   text-overflow: ellipsis; white-space: nowrap; max-width: 40%; }
-.cmcp-provtag { flex: none; font-size: 0.6923em; text-transform: uppercase; letter-spacing: 0.03em;
+.cmcp-provtag { flex: none; font-size: calc(var(--cmcp-fs) * 0.6923); text-transform: uppercase; letter-spacing: 0.03em;
   padding: 0.05rem 0.35rem; border-radius: 999px; background: var(--p-surface-800, #27272a);
   color: var(--p-text-muted-color, #a1a1aa); border: 1px solid var(--p-content-border-color, #3f3f46); }
 .cmcp-modelrow .check { flex: none; width: 1rem; text-align: center; color: var(--p-primary-color, #60a5fa); visibility: hidden; }
 .cmcp-modelrow .check.on { visibility: visible; }
-.cmcp-modelempty { padding: 0.5rem; font-size: 0.9231em; color: var(--p-text-muted-color, #a1a1aa); }
+.cmcp-modelempty { padding: 0.5rem; font-size: calc(var(--cmcp-fs) * 0.9231); color: var(--p-text-muted-color, #a1a1aa); }
 /* Recently-used section (non-virtualized; bounded to the last few picks). Rows
    flow normally (override the absolute positioning the virtualized list uses). */
 .cmcp-modelrecents .cmcp-modelrow { position: static; }
 .cmcp-modelrecent-x { flex: none; margin-left: 0.15rem; padding: 0 0.2rem; background: none; border: none;
-  color: var(--p-text-muted-color, #a1a1aa); cursor: pointer; opacity: 0.55; font-size: 0.8615em; line-height: 1; }
+  color: var(--p-text-muted-color, #a1a1aa); cursor: pointer; opacity: 0.55; font-size: calc(var(--cmcp-fs) * 0.8615); line-height: 1; }
 .cmcp-modelrecent-x:hover { opacity: 1; color: var(--p-text-color, #e4e4e7); }
 `;
 
@@ -21134,7 +21138,7 @@ function buildPanel() {
           const off = document.createElement("i");
           off.className = "pi pi-times";
           off.title = `Hide ${BACKEND_LABELS[id] || id} — you don't use it. Restore it from the "hidden" row below.`;
-          off.style.cssText = "margin-left:0.4rem;opacity:0.4;cursor:pointer;font-size:0.8615em;flex:none;";
+          off.style.cssText = "margin-left:0.4rem;opacity:0.4;cursor:pointer;font-size:calc(var(--cmcp-fs) * 0.8615);flex:none;";
           off.addEventListener("mousedown", (mev) => {
             // Swallow the row's pick handler — this gesture only hides.
             mev.preventDefault();
@@ -22402,10 +22406,6 @@ function buildPanel() {
     const bar = document.createElement("div");
     bar.className = "cmcp-lightbox-bar";
     bar.append(caption, openBtn);
-    // #753 — mounted on <body>, OUTSIDE .cmcp-root, so `em` inside it would resolve
-    // against the page's 16px rather than the panel's 13px. Anchor the root in rem,
-    // exactly as .cmcp-root is anchored, so everything below renders as written.
-    overlay.style.fontSize = "0.8125rem";
     overlay.append(stage, bar);
     document.body.appendChild(overlay);
     window.addEventListener("keydown", onKey, true);
@@ -22555,7 +22555,7 @@ function buildPanel() {
     if (name) {
       const cap = document.createElement("div");
       cap.className = "cmcp-media-caption";
-      cap.style.cssText = "font-size:0.7692em;color:var(--p-text-muted-color,#a1a1aa);margin-top:0.25rem;";
+      cap.style.cssText = "font-size:calc(var(--cmcp-fs) * 0.7692);color:var(--p-text-muted-color,#a1a1aa);margin-top:0.25rem;";
       cap.textContent = name;
       card.appendChild(cap);
     }
@@ -22641,7 +22641,7 @@ function buildPanel() {
       holder._preFailCss = holder.style.cssText;
       holder.style.cssText +=
         ";display:grid;place-items:center;padding:1rem;box-sizing:border-box;text-align:center;" +
-        "color:var(--p-text-muted-color,#a1a1aa);font-size:0.9231em;";
+        "color:var(--p-text-muted-color,#a1a1aa);font-size:calc(var(--cmcp-fs) * 0.9231);";
       // Release the decode buffers the way unmountHolderVideo does — detaching alone is
       // not deterministic release, and unmount will skip this element once `_video` is
       // null, so this is the last chance to do it (codex).
@@ -22715,7 +22715,7 @@ function buildPanel() {
     if (name) {
       const cap = document.createElement("div");
       cap.className = "cmcp-media-caption";
-      cap.style.cssText = "font-size:0.7692em;color:var(--p-text-muted-color,#a1a1aa);margin-top:0.25rem;";
+      cap.style.cssText = "font-size:calc(var(--cmcp-fs) * 0.7692);color:var(--p-text-muted-color,#a1a1aa);margin-top:0.25rem;";
       cap.textContent = name;
       card.appendChild(cap);
     }
@@ -22752,7 +22752,7 @@ function buildPanel() {
     card.appendChild(audio);
     if (name) {
       const cap = document.createElement("div");
-      cap.style.cssText = "font-size:0.7692em;color:var(--p-text-muted-color,#a1a1aa);margin-top:0.25rem;";
+      cap.style.cssText = "font-size:calc(var(--cmcp-fs) * 0.7692);color:var(--p-text-muted-color,#a1a1aa);margin-top:0.25rem;";
       cap.textContent = name;
       card.appendChild(cap);
     }
@@ -22787,7 +22787,7 @@ function buildPanel() {
     a.textContent = name || "Open file";
     card.appendChild(a);
     const hint = document.createElement("div");
-    hint.style.cssText = "font-size:0.7692em;color:var(--p-text-muted-color,#a1a1aa);margin-top:0.25rem;";
+    hint.style.cssText = "font-size:calc(var(--cmcp-fs) * 0.7692);color:var(--p-text-muted-color,#a1a1aa);margin-top:0.25rem;";
     hint.textContent = "The panel can't preview this file type — open or download it.";
     card.appendChild(hint);
     log.appendChild(card);
@@ -22964,7 +22964,7 @@ function buildPanel() {
     if (msg.header) {
       const chip = document.createElement("div");
       chip.className = "cmcp-card-head";
-      chip.style.cssText = "text-transform:uppercase;font-size:0.7385em;letter-spacing:0.05em;opacity:0.7;";
+      chip.style.cssText = "text-transform:uppercase;font-size:calc(var(--cmcp-fs) * 0.7385);letter-spacing:0.05em;opacity:0.7;";
       chip.textContent = coerceMessageText(msg.header);
       card.appendChild(chip);
     }
@@ -23008,7 +23008,7 @@ function buildPanel() {
       const answerText = coerceMessageText(answer);
       if (questionText) {
         const q = document.createElement("div");
-        q.style.cssText = "font-size:0.8862em;opacity:0.65;";
+        q.style.cssText = "font-size:calc(var(--cmcp-fs) * 0.8862);opacity:0.65;";
         q.textContent = questionText;
         card.appendChild(q);
       }
@@ -23030,14 +23030,14 @@ function buildPanel() {
       b.className = "cmcp-opt";
       b.style.cssText =
         "text-align:left;padding:0.4rem 0.55rem;border-radius:6px;border:1px solid var(--p-surface-500,#555);" +
-        "background:var(--p-surface-800,#2a2a2a);color:inherit;cursor:pointer;font-size:0.9846em;";
+        "background:var(--p-surface-800,#2a2a2a);color:inherit;cursor:pointer;font-size:calc(var(--cmcp-fs) * 0.9846);";
       const lbl = document.createElement("div");
       lbl.style.fontWeight = "600";
       lbl.textContent = coerceMessageText(opt.label ?? opt);
       b.appendChild(lbl);
       if (opt.description) {
         const d = document.createElement("div");
-        d.style.cssText = "font-size:0.8615em;opacity:0.7;margin-top:0.1rem;";
+        d.style.cssText = "font-size:calc(var(--cmcp-fs) * 0.8615);opacity:0.7;margin-top:0.1rem;";
         d.textContent = coerceMessageText(opt.description);
         b.appendChild(d);
       }
@@ -23063,7 +23063,7 @@ function buildPanel() {
     other.placeholder = "Other… (type your own answer)";
     other.style.cssText =
       "flex:1;padding:0.35rem 0.5rem;border-radius:6px;border:1px solid var(--p-surface-500,#555);" +
-      "background:var(--p-surface-900,#1e1e1e);color:inherit;font-size:0.9846em;";
+      "background:var(--p-surface-900,#1e1e1e);color:inherit;font-size:calc(var(--cmcp-fs) * 0.9846);";
     other.addEventListener("keydown", (e) => {
       if (isImeComposing(e)) return; // don't commit mid-IME-composition (#385)
       if (e.key === "Enter" && other.value.trim()) { e.preventDefault(); finish(other.value.trim()); }
@@ -23073,7 +23073,7 @@ function buildPanel() {
     const submit = document.createElement("button");
     submit.type = "button";
     submit.style.cssText =
-      "padding:0.35rem 0.7rem;border-radius:6px;border:none;cursor:pointer;font-size:0.9846em;" +
+      "padding:0.35rem 0.7rem;border-radius:6px;border:none;cursor:pointer;font-size:calc(var(--cmcp-fs) * 0.9846);" +
       "background:var(--p-primary-color,#3a7bd5);color:#fff;";
     submit.textContent = multi ? "Submit" : "Send";
     submit.addEventListener("click", () => {
@@ -23175,7 +23175,7 @@ function buildPanel() {
       card.style.opacity = "0.6";
       const note = document.createElement("div");
       note.className = "cmcp-card-stale";
-      note.style.cssText = "font-size:0.8369em;opacity:0.8;margin-top:0.4rem;";
+      note.style.cssText = "font-size:calc(var(--cmcp-fs) * 0.8369);opacity:0.8;margin-top:0.4rem;";
       note.textContent =
         `The connection that asked this ${what ?? "question"} dropped, so an answer here can no ` +
         `longer reach the agent. ` +
@@ -23212,7 +23212,7 @@ function buildPanel() {
     card.appendChild(head);
 
     const hint = document.createElement("div");
-    hint.style.cssText = "font-size:0.8369em;opacity:0.7;margin:0.2rem 0 0.4rem;";
+    hint.style.cssText = "font-size:calc(var(--cmcp-fs) * 0.8369);opacity:0.7;margin:0.2rem 0 0.4rem;";
     hint.textContent =
       msg.hint || "Sent straight to your config — never shown to the agent and never saved to chat history.";
     card.appendChild(hint);
@@ -23261,7 +23261,7 @@ function buildPanel() {
     input.placeholder = "Paste token…";
     input.style.cssText =
       "flex:1 1 10rem;min-width:0;padding:0.35rem 0.5rem;border-radius:6px;border:1px solid var(--p-surface-500,#555);" +
-      "background:var(--p-surface-900,#1e1e1e);color:inherit;font-size:0.9846em;";
+      "background:var(--p-surface-900,#1e1e1e);color:inherit;font-size:calc(var(--cmcp-fs) * 0.9846);";
 
     // Show/record only a masked preview (first 4 … last 4) so the user can
     // confirm WHICH token without ever exposing the full value.
@@ -23276,7 +23276,7 @@ function buildPanel() {
       card.replaceChildren();
       card.style.cssText = "border-left:3px solid var(--p-green-400,#4ade80);opacity:0.9;";
       const ok = document.createElement("div");
-      ok.style.cssText = "font-size:0.9231em;color:var(--p-green-400,#4ade80);";
+      ok.style.cssText = "font-size:calc(var(--cmcp-fs) * 0.9231);color:var(--p-green-400,#4ade80);";
       const m = mask(value);
       ok.textContent = value ? `🔒 Token saved: ${m}` : "Skipped — no token entered.";
       card.appendChild(ok);
@@ -23309,7 +23309,7 @@ function buildPanel() {
     // group spill the card at 320/280px. Stating the intent stops a future
     // "everything gets min-width:0" sweep from supplying the missing half.
     submit.style.cssText =
-      "flex:none;padding:0.35rem 0.7rem;border-radius:6px;border:none;cursor:pointer;font-size:0.9846em;" +
+      "flex:none;padding:0.35rem 0.7rem;border-radius:6px;border:none;cursor:pointer;font-size:calc(var(--cmcp-fs) * 0.9846);" +
       "background:var(--p-primary-color,#3a7bd5);color:#fff;";
     submit.textContent = "Save";
     submit.addEventListener("click", () => finish(input.value.trim()));
@@ -23319,7 +23319,7 @@ function buildPanel() {
     skip.type = "button";
     skip.style.cssText =
       "flex:none;padding:0.35rem 0.6rem;border-radius:6px;border:1px solid var(--p-surface-500,#555);" +
-      "background:transparent;color:inherit;cursor:pointer;font-size:0.9846em;";
+      "background:transparent;color:inherit;cursor:pointer;font-size:calc(var(--cmcp-fs) * 0.9846);";
     skip.textContent = "Skip";
     skip.addEventListener("click", () => finish(""));
     btns.appendChild(skip);
@@ -28788,14 +28788,14 @@ function buildPanel() {
     canvas.style.cssText = "background:#fff;border-radius:8px;padding:8px;width:240px;height:240px;";
     canvas.hidden = true;
     const statusMsg = document.createElement("div");
-    statusMsg.style.cssText = "font-size:1.0462em;opacity:0.85;text-align:center;";
+    statusMsg.style.cssText = "font-size:calc(var(--cmcp-fs) * 1.0462);opacity:0.85;text-align:center;";
     const urlLine = document.createElement("div");
     urlLine.style.cssText =
-      "font-size:0.8615em;opacity:0.55;word-break:break-all;text-align:center;max-width:280px;";
+      "font-size:calc(var(--cmcp-fs) * 0.8615);opacity:0.55;word-break:break-all;text-align:center;max-width:280px;";
     // #749 — the durability of THIS url, rendered where the user is looking at it.
     const durabilityLine = document.createElement("div");
     durabilityLine.style.cssText =
-      "font-size:0.8862em;line-height:1.35;text-align:left;max-width:280px;margin-top:0.15rem;";
+      "font-size:calc(var(--cmcp-fs) * 0.8862);line-height:1.35;text-align:left;max-width:280px;margin-top:0.15rem;";
     durabilityLine.hidden = true;
     qrWrap.append(canvas, statusMsg, urlLine, durabilityLine);
 

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -1411,6 +1411,10 @@ function cmcpOpenCredentialsFrame(client) {
   // Prime with whatever status the orchestrator already has.
   client?.sendFrame?.({ type: "oauth_status" });
 
+  // #753 — mounted on <body>, OUTSIDE .cmcp-root, so `em` inside it would resolve
+  // against the page's 16px rather than the panel's 13px. Anchor the root in rem,
+  // exactly as .cmcp-root is anchored, so everything below renders as written.
+  backdrop.style.fontSize = "0.8125rem";
   backdrop.appendChild(card);
   document.body.appendChild(backdrop);
 }
@@ -22395,6 +22399,10 @@ function buildPanel() {
     const bar = document.createElement("div");
     bar.className = "cmcp-lightbox-bar";
     bar.append(caption, openBtn);
+    // #753 — mounted on <body>, OUTSIDE .cmcp-root, so `em` inside it would resolve
+    // against the page's 16px rather than the panel's 13px. Anchor the root in rem,
+    // exactly as .cmcp-root is anchored, so everything below renders as written.
+    overlay.style.fontSize = "0.8125rem";
     overlay.append(stage, bar);
     document.body.appendChild(overlay);
     window.addEventListener("keydown", onKey, true);

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -3974,9 +3974,12 @@ function panelSettingsList() {
       tooltip:
         "Scales the whole Agent sidebar — text, icons and spacing together. Raise it if the panel is hard " +
         "to read on a high-DPI or large display. 100% is the default; 100-250. Applies immediately, to " +
-        "every open panel. Note that overriding `.cmcp-root { font-size }` in a user stylesheet does NOT " +
-        "work: the panel's inner sizes are `rem`, which resolve against the page root rather than the " +
-        "panel, so most text ignores it. This setting is the supported way to scale the panel.",
+        "every open panel. Since 0.13.3 the panel's inner FONT sizes are `em`, so overriding " +
+        "`.cmcp-root { font-size }` in a user stylesheet does now scale most panel text. Two things it " +
+        "still will not scale: spacing (padding and gaps are `rem` on purpose — as `em` they compound " +
+        "through nesting), and the surfaces that mount outside the panel root (the CivitAI explorer, " +
+        "Apps and their modals), which are anchored so they render correctly wherever they mount. This " +
+        "setting remains the supported way to scale the panel as a whole.",
       type: "slider",
       attrs: { min: PANEL_UI_SCALE_MIN, max: PANEL_UI_SCALE_MAX, step: 5 },
       defaultValue: 100,

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -3220,7 +3220,7 @@ function makeSettingSelect() {
   sel.className = "p-inputtext p-component";
   sel.style.cssText =
     "padding:0.3rem 0.5rem;border-radius:6px;border:1px solid var(--p-surface-500,#555);" +
-    "background:var(--p-surface-900,#18181b);color:var(--p-text-color,#e4e4e7);font-size:0.8rem;min-width:14rem;";
+    "background:var(--p-surface-900,#18181b);color:var(--p-text-color,#e4e4e7);font-size:0.9846em;min-width:14rem;";
   return sel;
 }
 /** (Re)populate a backend's Default-model <select>: an "Auto" option, then that
@@ -3497,9 +3497,9 @@ function panelSettingsList() {
       btn.textContent = `Set ${friendly} ${noun}…`;
       btn.style.cssText =
         "padding:0.3rem 0.7rem;border-radius:6px;border:1px solid var(--p-surface-500,#555);" +
-        "background:var(--p-primary-color,#3a7bd5);color:#fff;cursor:pointer;font-size:0.8rem;white-space:nowrap;";
+        "background:var(--p-primary-color,#3a7bd5);color:#fff;cursor:pointer;font-size:0.9846em;white-space:nowrap;";
       const status = document.createElement("span");
-      status.style.cssText = "font-size:0.72rem;opacity:0.8;";
+      status.style.cssText = "font-size:0.8862em;opacity:0.8;";
       const refresh = () => {
         const at = lsGet(SECRET_SET_AT_PREFIX + envKey);
         if (at) {
@@ -3644,7 +3644,7 @@ function panelSettingsList() {
         a.style.cssText =
           "display:inline-flex;align-items:center;gap:0.4rem;padding:0.3rem 0.7rem;border-radius:6px;" +
           "border:1px solid var(--p-surface-500,#555);background:var(--p-surface-800,#27272a);" +
-          "color:var(--p-text-color,#e4e4e7);text-decoration:none;font-size:0.8rem;white-space:nowrap;";
+          "color:var(--p-text-color,#e4e4e7);text-decoration:none;font-size:0.9846em;white-space:nowrap;";
         return a;
       },
     },
@@ -3668,7 +3668,7 @@ function panelSettingsList() {
         b.style.cssText =
           "display:inline-flex;align-items:center;gap:0.4rem;padding:0.3rem 0.7rem;border-radius:6px;" +
           "border:1px solid var(--p-surface-500,#555);background:var(--p-surface-800,#27272a);" +
-          "color:var(--p-text-color,#e4e4e7);cursor:pointer;font-size:0.8rem;white-space:nowrap;";
+          "color:var(--p-text-color,#e4e4e7);cursor:pointer;font-size:0.9846em;white-space:nowrap;";
         b.addEventListener("click", () => {
           // Open the panel first — painting into a transcript the user cannot see is the
           // same failure as not painting at all. openSidebarTab() is the same activate the
@@ -3712,7 +3712,7 @@ function panelSettingsList() {
         a.style.cssText =
           "display:inline-flex;align-items:center;gap:0.4rem;padding:0.3rem 0.7rem;border-radius:6px;" +
           "border:1px solid var(--p-surface-500,#555);background:var(--p-surface-800,#27272a);" +
-          "color:var(--p-text-color,#e4e4e7);text-decoration:none;font-size:0.8rem;white-space:nowrap;";
+          "color:var(--p-text-color,#e4e4e7);text-decoration:none;font-size:0.9846em;white-space:nowrap;";
         return a;
       },
     },
@@ -3732,7 +3732,7 @@ function panelSettingsList() {
         a.style.cssText =
           "display:inline-flex;align-items:center;gap:0.4rem;padding:0.3rem 0.7rem;border-radius:6px;" +
           "border:1px solid var(--p-surface-500,#555);background:var(--p-surface-800,#27272a);" +
-          "color:var(--p-text-color,#e4e4e7);text-decoration:none;font-size:0.8rem;white-space:nowrap;";
+          "color:var(--p-text-color,#e4e4e7);text-decoration:none;font-size:0.9846em;white-space:nowrap;";
         return a;
       },
     },
@@ -3754,7 +3754,7 @@ function panelSettingsList() {
         btn.style.cssText =
           "display:inline-flex;align-items:center;gap:0.4rem;padding:0.3rem 0.7rem;border-radius:6px;" +
           "border:1px solid var(--p-primary-color,#8b5cf6);background:var(--p-primary-color,#8b5cf6);" +
-          "color:#fff;font-size:0.8rem;white-space:nowrap;cursor:pointer;";
+          "color:#fff;font-size:0.9846em;white-space:nowrap;cursor:pointer;";
         btn.addEventListener("click", async () => {
           const diag = [
             "--- comfyui-mcp panel diagnostics ---",
@@ -3932,7 +3932,7 @@ function panelSettingsList() {
         note.textContent =
           "⚠️ Beta — the app changes rapidly and builds may break between updates. " +
           "Enable the toggle above, install for your platform, then pair with the QR button in the panel header.";
-        note.style.cssText = "font-size:0.75rem;opacity:0.75;line-height:1.35;";
+        note.style.cssText = "font-size:0.9231em;opacity:0.75;line-height:1.35;";
         const row = document.createElement("div");
         row.style.cssText = "display:flex;gap:0.5rem;flex-wrap:wrap;";
         const linkBtn = (label, url) => {
@@ -3941,7 +3941,7 @@ function panelSettingsList() {
           a.style.cssText =
             "display:inline-flex;align-items:center;gap:0.4rem;padding:0.3rem 0.7rem;border-radius:6px;" +
             "border:1px solid var(--p-surface-500,#555);background:var(--p-surface-800,#27272a);" +
-            "color:var(--p-text-color,#e4e4e7);text-decoration:none;font-size:0.8rem;white-space:nowrap;";
+            "color:var(--p-text-color,#e4e4e7);text-decoration:none;font-size:0.9846em;white-space:nowrap;";
           if (url) {
             a.href = url;
             a.target = "_blank";
@@ -6923,7 +6923,7 @@ function makeShellCommandBlock(baseCmd) {
     b.className = "cmcp-btn";
     b.dataset.shell = s.key;
     b.textContent = s.label;
-    b.style.cssText = "font-size:0.72rem;padding:0.12rem 0.45rem;";
+    b.style.cssText = "font-size:0.8862em;padding:0.12rem 0.45rem;";
     b.addEventListener("click", () => { selected = s.key; render(); copy(forms[s.key]); });
     pills.appendChild(b);
   }
@@ -17933,7 +17933,7 @@ const PANEL_CSS = `
    header actions on a narrow sidebar. */
 .cmcp-logo { height: 20px; width: auto; max-width: 148px; flex: none; object-fit: contain; display: block; }
 .cmcp-status { display: flex; align-items: center; gap: 0.375rem; margin-left: auto;
-  font-size: 0.6875rem; color: var(--p-text-muted-color, #a1a1aa); }
+  font-size: 1em; color: var(--p-text-muted-color, #a1a1aa); }
 .cmcp-dot { width: 8px; height: 8px; border-radius: 50%; background: var(--p-red-400, #f87171); flex: none; }
 .cmcp-dot.connected { background: var(--p-green-400, #4ade80); }
 .cmcp-dot.connecting { background: var(--p-yellow-400, #facc15); animation: cmcp-pulse 1.2s ease-in-out infinite; }
@@ -17954,12 +17954,12 @@ const PANEL_CSS = `
   background: transparent; border: none; cursor: pointer;
   border-radius: var(--p-border-radius-sm, 4px);
   padding: 0.25rem 0.5rem;
-  font: inherit; font-size: 0.6875rem;
+  font: inherit; font-size: 0.8462em;
   color: var(--p-text-muted-color, #a1a1aa);
   transition: background 0.15s, color 0.15s;
 }
 .cmcp-toolbtn:hover { background: var(--p-surface-700, #3f3f46); color: var(--p-text-color, #fff); }
-.cmcp-toolbtn .pi { font-size: 0.8125rem; }
+.cmcp-toolbtn .pi { font-size: 1.3636em; }
 .cmcp-toolbtn svg { width: 13px; height: 13px; display: block; }
 /* Icon-only variant (Deafen/Blind): the label span stays in the DOM — state
    copy still flows into it for screen readers / the find-icon logic — but is
@@ -17970,7 +17970,7 @@ const PANEL_CSS = `
   position: absolute; width: 1px; height: 1px; overflow: hidden;
   clip: rect(0 0 0 0); clip-path: inset(50%); white-space: nowrap;
 }
-.cmcp-toolbtn.cmcp-toolbtn-iconic .pi { font-size: 0.9375rem; }
+.cmcp-toolbtn.cmcp-toolbtn-iconic .pi { font-size: 1.3636em; }
 .cmcp-toolbtn.cmcp-toolbtn-iconic svg { width: 15px; height: 15px; }
 /* Active tab: the four surface buttons ARE the tab bar (issue #124) — the open
    one gets the themed toggled state (inverts light/dark via the primary tokens). */
@@ -18007,13 +18007,13 @@ const PANEL_CSS = `
 }
 .cmcp-settings > summary {
   padding: 0.5rem 0.75rem; cursor: pointer; user-select: none;
-  font-size: 0.75rem; font-weight: 600; color: var(--p-text-muted-color, #a1a1aa);
+  font-size: 0.9231em; font-weight: 600; color: var(--p-text-muted-color, #a1a1aa);
   list-style: none; display: flex; align-items: center; gap: 0.375rem;
 }
 .cmcp-settings > summary::before { content: "▸"; transition: transform 0.15s; }
 .cmcp-settings[open] > summary::before { transform: rotate(90deg); }
 .cmcp-settings-body { padding: 0 0.75rem 0.75rem; display: flex; flex-direction: column; gap: 0.5rem; }
-.cmcp-label { font-size: 0.6875rem; color: var(--p-text-muted-color, #a1a1aa); }
+.cmcp-label { font-size: 0.8462em; color: var(--p-text-muted-color, #a1a1aa); }
 .cmcp-input {
   width: 100%; box-sizing: border-box;
   padding: var(--p-form-field-padding-y, 0.5rem) var(--p-form-field-padding-x, 0.75rem);
@@ -18033,13 +18033,13 @@ const PANEL_CSS = `
 }
 .cmcp-btn:hover { opacity: 0.85; }
 .cmcp-btn:disabled { opacity: 0.4; cursor: default; }
-.cmcp-help { font-size: 0.6875rem; color: var(--p-text-muted-color, #a1a1aa); line-height: 1.55; }
+.cmcp-help { font-size: 0.8462em; color: var(--p-text-muted-color, #a1a1aa); line-height: 1.55; }
 .cmcp-cmd {
   display: block; margin-top: 0.25rem; padding: 0.375rem 0.5rem;
   background: var(--p-form-field-background, #09090b);
   border: 1px solid var(--p-content-border-color, #3f3f46);
   border-radius: var(--p-border-radius-sm, 4px);
-  font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 0.6875rem;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 0.9999em;
   user-select: all; cursor: copy; color: var(--p-text-color, #fff);
   overflow-x: auto; white-space: nowrap;
 }
@@ -18058,12 +18058,12 @@ const PANEL_CSS = `
   margin: auto; text-align: center; max-width: 230px;
   color: var(--p-text-muted-color, #a1a1aa);
 }
-.cmcp-empty .pi { font-size: 1.75rem; display: block; margin-bottom: 0.5rem; opacity: 0.5; }
+.cmcp-empty .pi { font-size: 2.1538em; display: block; margin-bottom: 0.5rem; opacity: 0.5; }
 .cmcp-empty-title { font-weight: 600; color: var(--p-text-color, #fff); margin-bottom: 0.25rem; }
 .cmcp-examples { display: flex; flex-direction: column; gap: 0.375rem; margin-top: 0.875rem; text-align: left; }
 .cmcp-example {
   display: flex; align-items: center; gap: 0.5rem; width: 100%; box-sizing: border-box;
-  padding: 0.4375rem 0.625rem; cursor: pointer; font: inherit; font-size: 0.75rem;
+  padding: 0.4375rem 0.625rem; cursor: pointer; font: inherit; font-size: 0.9231em;
   color: var(--p-text-color, #fff); text-align: left;
   background: var(--p-surface-800, #27272a);
   border: 1px solid var(--p-content-border-color, #3f3f46);
@@ -18071,7 +18071,7 @@ const PANEL_CSS = `
   transition: border-color 0.15s, background 0.15s;
 }
 .cmcp-example:hover { border-color: var(--p-primary-color, #60a5fa); background: var(--p-surface-700, #3f3f46); }
-.cmcp-example .pi { font-size: 0.8125rem; margin: 0; opacity: 1; color: var(--p-primary-color, #60a5fa); flex: none; }
+.cmcp-example .pi { font-size: 1em; margin: 0; opacity: 1; color: var(--p-primary-color, #60a5fa); flex: none; }
 
 /* Provider onboarding card — shown only when NEITHER provider is signed in. */
 .cmcp-onboard {
@@ -18085,10 +18085,10 @@ const PANEL_CSS = `
    it or "onboard.hidden = true" won't actually hide the card. */
 .cmcp-onboard[hidden] { display: none; }
 .cmcp-onboard-title { font-weight: 600; color: var(--p-text-color, #fff); }
-.cmcp-onboard-sub { font-size: 0.75rem; color: var(--p-text-muted-color, #a1a1aa); line-height: 1.4; }
+.cmcp-onboard-sub { font-size: 0.9231em; color: var(--p-text-muted-color, #a1a1aa); line-height: 1.4; }
 .cmcp-onboard-col { display: flex; flex-direction: column; gap: 0.25rem; }
-.cmcp-onboard-prov { font-weight: 600; font-size: 0.8125rem; color: var(--p-text-color, #fff); margin-top: 0.25rem; }
-.cmcp-onboard-step { font-size: 0.7rem; color: var(--p-text-muted-color, #a1a1aa); }
+.cmcp-onboard-prov { font-weight: 600; font-size: 1em; color: var(--p-text-color, #fff); margin-top: 0.25rem; }
+.cmcp-onboard-step { font-size: 0.8615em; color: var(--p-text-muted-color, #a1a1aa); }
 
 .cmcp-bubble {
   padding: 0.5rem 0.75rem; max-width: 92%;
@@ -18110,7 +18110,7 @@ const PANEL_CSS = `
   display: flex; align-items: center; justify-content: center;
   border: 1px solid var(--p-content-border-color, #3f3f46);
   background: var(--p-surface-800, #27272a); color: var(--p-text-muted-color, #a1a1aa);
-  cursor: pointer; opacity: 0; transition: opacity 0.12s, color 0.12s; font-size: 0.7rem;
+  cursor: pointer; opacity: 0; transition: opacity 0.12s, color 0.12s; font-size: 0.8615em;
 }
 .cmcp-bubble.user:hover .cmcp-edit-btn { opacity: 1; }
 .cmcp-edit-btn:hover { color: var(--p-primary-color, #60a5fa); border-color: var(--p-primary-color, #60a5fa); }
@@ -18124,15 +18124,15 @@ const PANEL_CSS = `
   padding: 0.85rem; border-radius: 10px; background: var(--p-surface-900, #18181b);
   border: 1px solid var(--p-content-border-color, #3f3f46); box-shadow: 0 8px 30px rgba(0,0,0,0.5);
 }
-.cmcp-modal-title { font-weight: 600; font-size: 0.85rem; }
+.cmcp-modal-title { font-weight: 600; font-size: 1.0462em; }
 .cmcp-modal-text {
   width: 100%; box-sizing: border-box; resize: vertical; min-height: 3.5rem;
-  padding: 0.4rem 0.5rem; border-radius: 6px; font: inherit; font-size: 0.8rem;
+  padding: 0.4rem 0.5rem; border-radius: 6px; font: inherit; font-size: 0.9846em;
   background: var(--p-surface-950, #111113); color: inherit;
   border: 1px solid var(--p-surface-500, #555);
 }
 .cmcp-modal-scopes { display: flex; flex-direction: column; gap: 0.3rem; }
-.cmcp-modal-scope { display: flex; gap: 0.4rem; align-items: flex-start; font-size: 0.72rem; cursor: pointer; }
+.cmcp-modal-scope { display: flex; gap: 0.4rem; align-items: flex-start; font-size: 0.8862em; cursor: pointer; }
 .cmcp-modal-scope input { margin-top: 0.15rem; }
 .cmcp-modal-btns { display: flex; justify-content: flex-end; gap: 0.4rem; }
 .cmcp-btn-primary { background: var(--p-primary-color, #3a7bd5); color: #fff; border: none; }
@@ -18158,7 +18158,7 @@ const PANEL_CSS = `
 .cmcp-lightbox-nav {
   position: absolute; top: 50%; transform: translateY(-50%);
   width: 2.6rem; height: 2.6rem; border-radius: 50%; cursor: pointer;
-  font-size: 1.6rem; line-height: 1; display: flex; align-items: center; justify-content: center;
+  font-size: 1.9692em; line-height: 1; display: flex; align-items: center; justify-content: center;
   color: var(--p-text-color, #fafafa);
   background: rgba(0,0,0,0.45); border: 1px solid var(--p-content-border-color, #3f3f46);
 }
@@ -18168,7 +18168,7 @@ const PANEL_CSS = `
 .cmcp-lightbox-close {
   position: absolute; top: 0.75rem; right: 0.75rem;
   width: 2.2rem; height: 2.2rem; border-radius: 50%; cursor: pointer;
-  font-size: 1.1rem; line-height: 1; display: flex; align-items: center; justify-content: center;
+  font-size: 1.3538em; line-height: 1; display: flex; align-items: center; justify-content: center;
   color: var(--p-text-color, #fafafa);
   background: rgba(0,0,0,0.45); border: 1px solid var(--p-content-border-color, #3f3f46);
 }
@@ -18179,11 +18179,11 @@ const PANEL_CSS = `
   border-top: 1px solid var(--p-content-border-color, #3f3f46);
 }
 .cmcp-lightbox-caption {
-  font-size: 0.75rem; color: var(--p-text-muted-color, #a1a1aa);
+  font-size: 0.9231em; color: var(--p-text-muted-color, #a1a1aa);
   overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
 }
 .cmcp-lightbox-open {
-  flex: 0 0 auto; cursor: pointer; font-size: 0.72rem; padding: 0.3rem 0.6rem; border-radius: 6px;
+  flex: 0 0 auto; cursor: pointer; font-size: 0.8862em; padding: 0.3rem 0.6rem; border-radius: 6px;
   color: var(--p-text-color, #fafafa);
   background: var(--p-surface-800, #27272a); border: 1px solid var(--p-content-border-color, #3f3f46);
 }
@@ -18200,7 +18200,7 @@ const PANEL_CSS = `
 }
 .cmcp-media-expand, .cmcp-media-collapse {
   width: 1.8rem; height: 1.8rem; border-radius: 6px; cursor: pointer;
-  font-size: 0.95rem; line-height: 1; display: flex; align-items: center; justify-content: center;
+  font-size: 1.1692em; line-height: 1; display: flex; align-items: center; justify-content: center;
   color: #fff; background: rgba(0,0,0,0.5); border: 1px solid rgba(255,255,255,0.25);
   opacity: 0; transition: opacity 0.12s ease;
 }
@@ -18230,7 +18230,7 @@ const PANEL_CSS = `
 .cmcp-media-stub {
   display: none; align-items: center; gap: 0.4rem; cursor: pointer;
   min-height: 1.8rem; padding: 0.35rem 2.6rem 0.35rem 0.55rem; border-radius: 6px;
-  font-size: 0.7rem; color: var(--p-text-muted-color, #a1a1aa);
+  font-size: 0.8615em; color: var(--p-text-muted-color, #a1a1aa);
   background: var(--p-content-hover-background, #2a2a2e);
   border: 1px dashed var(--p-content-border-color, #3f3f46);
 }
@@ -18248,7 +18248,7 @@ const PANEL_CSS = `
   padding: 0.5rem 0.6rem; background: var(--p-surface-800, #27272a);
 }
 .cmcp-file-open {
-  color: var(--p-primary-color, #60a5fa); text-decoration: none; font-size: 0.8rem;
+  color: var(--p-primary-color, #60a5fa); text-decoration: none; font-size: 0.9846em;
   word-break: break-all;
 }
 .cmcp-file-open:hover { text-decoration: underline; }
@@ -18272,7 +18272,7 @@ const PANEL_CSS = `
 .cmcp-msg-status {
   align-self: flex-end; max-width: 92%;
   margin: 0.0625rem 0.125rem 0.125rem;
-  font-size: 0.6875rem; color: var(--p-text-muted-color, #71717a);
+  font-size: 0.8462em; color: var(--p-text-muted-color, #71717a);
   display: flex; gap: 0.375rem; align-items: center;
 }
 .cmcp-msg-status:empty { display: none; }
@@ -18290,7 +18290,7 @@ const PANEL_CSS = `
   border-radius: var(--p-border-radius-sm, 4px);
   transition: color 0.12s, background 0.12s;
 }
-.cmcp-msg-action .pi { font-size: 0.75rem; }
+.cmcp-msg-action .pi { font-size: 0.9231em; }
 .cmcp-msg-action:hover { color: var(--p-text-color, #fff); background: var(--p-surface-700, #3f3f46); }
 .cmcp-msg-status.failed .cmcp-msg-action:hover { color: var(--p-red-300, #fca5a5); }
 .cmcp-bubble.agent code, .cmcp-bubble.user code {
@@ -18309,10 +18309,10 @@ const PANEL_CSS = `
 .cmcp-bubble h4, .cmcp-bubble h5, .cmcp-bubble h6 {
   margin: 0.625rem 0 0.25rem; font-weight: 600; line-height: 1.3;
 }
-.cmcp-bubble h1 { font-size: 1.05rem; }
-.cmcp-bubble h2 { font-size: 1rem; }
-.cmcp-bubble h3 { font-size: 0.9375rem; }
-.cmcp-bubble h4, .cmcp-bubble h5, .cmcp-bubble h6 { font-size: 0.875rem; }
+.cmcp-bubble h1 { font-size: 1.2923em; }
+.cmcp-bubble h2 { font-size: 1.2308em; }
+.cmcp-bubble h3 { font-size: 1.1538em; }
+.cmcp-bubble h4, .cmcp-bubble h5, .cmcp-bubble h6 { font-size: 1.0769em; }
 .cmcp-bubble a { color: var(--p-primary-color, #60a5fa); text-decoration: underline; }
 .cmcp-bubble blockquote {
   margin: 0.5rem 0; padding: 0.125rem 0 0.125rem 0.75rem;
@@ -18327,7 +18327,7 @@ const PANEL_CSS = `
   border: 1px solid var(--p-content-border-color, #3f3f46);
   border-radius: var(--p-border-radius-md, 6px);
   overflow-x: auto; max-height: 20rem; overflow-y: auto;
-  font-size: 0.6875rem; line-height: 1.5; tab-size: 2;
+  font-size: 0.8462em; line-height: 1.5; tab-size: 2;
 }
 .cmcp-bubble.agent pre code, .cmcp-bubble.user pre code {
   background: none; padding: 0; border-radius: 0;
@@ -18353,7 +18353,7 @@ const PANEL_CSS = `
   transition: background 0.15s, color 0.15s;
 }
 .cmcp-code-tool:hover { background: var(--p-surface-700, #3f3f46); color: var(--p-text-color, #fff); }
-.cmcp-code-tool .pi { font-size: 0.8rem; }
+.cmcp-code-tool .pi { font-size: 0.96em; }
 .cmcp-code-tool.ok { color: #4ade80; }
 .cmcp-wrap-btn.on { color: var(--p-primary-color, #60a5fa); }
 .cmcp-wrap-btn.on:hover { color: var(--p-primary-color, #60a5fa); }
@@ -18379,7 +18379,7 @@ const PANEL_CSS = `
   /* Real table layout (NOT display:block) so the header row stays aligned with
      the body; fit the panel width and let long cells wrap instead of scrolling. */
   display: table; width: 100%; table-layout: fixed;
-  border-collapse: collapse; margin: 0.5rem 0; font-size: 0.6875rem;
+  border-collapse: collapse; margin: 0.5rem 0; font-size: 0.8462em;
 }
 .cmcp-bubble th, .cmcp-bubble td {
   border: 1px solid var(--p-content-border-color, #3f3f46);
@@ -18392,21 +18392,21 @@ const PANEL_CSS = `
   display: inline-flex; align-items: center; gap: 0.35rem;
   padding: 0.3rem 0.75rem; border-radius: 999px; border: none; cursor: pointer;
   background: var(--p-primary-color, #2563eb); color: var(--p-primary-contrast-color, #fff);
-  font: inherit; font-size: 0.7rem; box-shadow: 0 2px 10px rgba(0, 0, 0, 0.45);
+  font: inherit; font-size: 0.8615em; box-shadow: 0 2px 10px rgba(0, 0, 0, 0.45);
 }
-.cmcp-newmsg .pi { font-size: 0.7rem; }
+.cmcp-newmsg .pi { font-size: 1em; }
 /* The base rule sets display, which beats the UA [hidden] rule — so re-assert
    it or "newMsgBtn.hidden = true" won't actually hide the pill. */
 .cmcp-newmsg[hidden] { display: none; }
 .cmcp-tray {
   flex: none; margin: 0 0.5rem 0.25rem; padding: 0.4rem 0.55rem;
   background: var(--p-surface-800, #27272a); border: 1px solid var(--p-content-border-color, #3f3f46);
-  border-radius: 8px; max-height: 9rem; overflow-y: auto; font-size: 0.7rem;
+  border-radius: 8px; max-height: 9rem; overflow-y: auto; font-size: 0.8615em;
 }
 .cmcp-tray[hidden] { display: none; }
-.cmcp-tray-head { font-size: 0.6rem; text-transform: uppercase; letter-spacing: 0.05em; opacity: 0.55; margin-bottom: 0.3rem; }
+.cmcp-tray-head { font-size: 0.7385em; text-transform: uppercase; letter-spacing: 0.05em; opacity: 0.55; margin-bottom: 0.3rem; }
 .cmcp-todo-item { display: flex; align-items: flex-start; gap: 0.4rem; padding: 0.12rem 0; line-height: 1.3; }
-.cmcp-todo-item .pi { font-size: 0.7rem; margin-top: 0.1rem; flex: none; }
+.cmcp-todo-item .pi { font-size: 0.8615em; margin-top: 0.1rem; flex: none; }
 .cmcp-todo-item.done { opacity: 0.55; }
 .cmcp-todo-item.done span { text-decoration: line-through; }
 .cmcp-todo-item.done .pi { color: var(--p-green-400, #4ade80); }
@@ -18421,11 +18421,11 @@ const PANEL_CSS = `
 .cmcp-pending-text { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .cmcp-pending-item.failed .cmcp-pending-text { color: var(--p-red-300, #fca5a5); }
 .cmcp-pending-act { flex: none; width: 1.2rem; height: 1.2rem; padding: 0; border: none; background: transparent;
-  color: var(--p-text-muted-color, #a1a1aa); cursor: pointer; border-radius: 4px; font-size: 0.7rem; }
+  color: var(--p-text-muted-color, #a1a1aa); cursor: pointer; border-radius: 4px; font-size: 0.8615em; }
 .cmcp-pending-act:hover { color: var(--p-primary-color, #60a5fa); background: var(--p-surface-700, #3f3f46); }
 .cmcp-pending-act.danger:hover { color: var(--p-red-300, #fca5a5); }
 .cmcp-pending-handle { flex: none; width: 1rem; height: 1.2rem; display: flex; align-items: center; justify-content: center;
-  color: var(--p-text-muted-color, #71717a); cursor: grab; font-size: 0.65rem; opacity: 0.6; }
+  color: var(--p-text-muted-color, #71717a); cursor: grab; font-size: 0.8em; opacity: 0.6; }
 .cmcp-pending-handle:hover { opacity: 1; color: var(--p-primary-color, #60a5fa); }
 .cmcp-pending-handle:active { cursor: grabbing; }
 .cmcp-pending-item.dragging { opacity: 0.4; }
@@ -18435,7 +18435,7 @@ const PANEL_CSS = `
 .cmcp-dl-item { padding: 0.18rem 0; }
 .cmcp-dl-top { display: flex; justify-content: space-between; gap: 0.5rem; align-items: baseline; }
 .cmcp-dl-name { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.cmcp-dl-meta { flex: none; opacity: 0.7; font-size: 0.62rem; }
+.cmcp-dl-meta { flex: none; opacity: 0.7; font-size: 0.7631em; }
 .cmcp-dl-bar { height: 4px; border-radius: 999px; background: var(--p-surface-700, #3f3f46); overflow: hidden; margin-top: 0.2rem; }
 .cmcp-dl-fill { height: 100%; background: var(--p-primary-color, #3a7bd5); transition: width 0.3s ease; }
 .cmcp-dl-item.done .cmcp-dl-fill { background: var(--p-green-400, #4ade80); }
@@ -18443,7 +18443,7 @@ const PANEL_CSS = `
 .cmcp-dl-bar.indet .cmcp-dl-fill { width: 30%; animation: cmcp-indet 1.1s ease-in-out infinite; }
 @keyframes cmcp-indet { 0% { margin-left: -30%; } 100% { margin-left: 100%; } }
 .cmcp-sys {
-  align-self: center; font-size: 0.6875rem; font-style: italic;
+  align-self: center; font-size: 0.8462em; font-style: italic;
   color: var(--p-text-muted-color, #a1a1aa);
   animation: cmcp-in 0.18s ease-out;
   /* Status lines quote URLs, paths and ids — strings with no spaces to break
@@ -18460,17 +18460,17 @@ const PANEL_CSS = `
   border: 1px solid var(--p-content-border-color, #3f3f46);
   border-left: 3px solid var(--p-primary-color, #60a5fa);
   border-radius: var(--p-border-radius-md, 6px);
-  font-size: 0.75rem;
+  font-size: 0.9231em;
   animation: cmcp-in 0.18s ease-out;
 }
 .cmcp-card.error { border-left-color: var(--p-red-400, #f87171); }
 .cmcp-card-head { display: flex; align-items: center; gap: 0.375rem; font-weight: 600; min-width: 0; }
-.cmcp-card-head .pi { font-size: 0.75rem; color: var(--p-primary-color, #60a5fa); flex: none; }
+.cmcp-card-head .pi { font-size: 1em; color: var(--p-primary-color, #60a5fa); flex: none; }
 .cmcp-card-text { flex: 1 1 auto; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .cmcp-card.error .cmcp-card-head .pi { color: var(--p-red-400, #f87171); }
 .cmcp-card-detail {
   margin-top: 0.25rem; color: var(--p-text-muted-color, #a1a1aa);
-  font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 0.6875rem;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 0.9166em;
   overflow-x: auto; white-space: pre-wrap; word-break: break-word;
   max-height: 7.5rem; overflow-y: auto;
 }
@@ -18484,7 +18484,7 @@ const PANEL_CSS = `
   border: 2px dashed var(--p-primary-color, #3b82f6);
   border-radius: 10px;
   background: color-mix(in srgb, var(--p-primary-color, #3b82f6) 16%, var(--p-surface-900, #18181b));
-  color: var(--p-primary-color, #60a5fa); font-weight: 600; font-size: 0.85rem;
+  color: var(--p-primary-color, #60a5fa); font-weight: 600; font-size: 1.0462em;
   pointer-events: none; animation: cmcp-in 0.12s ease-out;
 }
 .cmcp-dropzone.cmcp-show { display: flex; }
@@ -18495,7 +18495,7 @@ const PANEL_CSS = `
   background: var(--p-surface-800, #27272a);
   border: 1px solid var(--p-content-border-color, #3f3f46);
   border-radius: var(--p-border-radius-lg, 8px);
-  color: var(--p-text-muted-color, #a1a1aa); font-size: 0.75rem;
+  color: var(--p-text-muted-color, #a1a1aa); font-size: 0.9231em;
   animation: cmcp-in 0.18s ease-out;
 }
 .cmcp-thinking-dots { display: inline-flex; gap: 3px; }
@@ -18521,19 +18521,19 @@ const PANEL_CSS = `
 }
 .cmcp-think > summary {
   list-style: none; cursor: pointer; user-select: none;
-  padding: 0.3125rem 0.5rem; font-size: 0.6875rem; font-weight: 600;
+  padding: 0.3125rem 0.5rem; font-size: 0.8462em; font-weight: 600;
   color: var(--p-text-muted-color, #a1a1aa);
   display: flex; align-items: center; gap: 0.375rem;
 }
 .cmcp-think > summary::-webkit-details-marker { display: none; }
 .cmcp-think > summary::before {
-  content: "\\25b8"; font-size: 0.625rem; transition: transform 0.15s;
+  content: "\\25b8"; font-size: 0.7692em; transition: transform 0.15s;
 }
 .cmcp-think[open] > summary::before { transform: rotate(90deg); }
 .cmcp-think-body {
   max-height: 11rem; overflow-y: auto;
   padding: 0 0.5rem 0.4375rem 0.875rem;
-  font-size: 0.6875rem; line-height: 1.45;
+  font-size: 0.8462em; line-height: 1.45;
   color: var(--p-text-muted-color, #8a8a93);
   white-space: pre-wrap; word-break: break-word;
   font-family: ui-monospace, "SFMono-Regular", Menlo, Consolas, monospace;
@@ -18578,19 +18578,19 @@ const PANEL_CSS = `
 .cmcp-iconbtn:hover { background: var(--p-surface-700, #3f3f46); color: var(--p-text-color, #fff); }
 .cmcp-iconbtn:disabled { opacity: 0.35; cursor: default; }
 .cmcp-iconbtn.active { color: var(--p-red-400, #f87171); }
-.cmcp-iconbtn .pi { font-size: 0.875rem; }
+.cmcp-iconbtn .pi { font-size: 1.05em; }
 /* #758 — the update notice. Sits in the transcript as a system line, so it inherits
    the panel's scale and scroll rather than becoming a modal the user must dismiss. */
 .cmcp-whatsnew { border-left: 2px solid var(--p-primary-color, #3b82f6); padding-left: 0.55rem; }
 .cmcp-whatsnew-head { font-weight: 600; margin-bottom: 0.3rem; }
 .cmcp-whatsnew-list { margin: 0; padding-left: 0.9rem; display: flex; flex-direction: column; gap: 0.25rem; }
 .cmcp-whatsnew-list li { line-height: 1.45; }
-.cmcp-whatsnew-tag { display: inline-block; font-size: 0.58rem; text-transform: uppercase;
+.cmcp-whatsnew-tag { display: inline-block; font-size: 0.7138em; text-transform: uppercase;
   letter-spacing: 0.04em; opacity: 0.75; border: 1px solid currentColor; border-radius: 3px;
   padding: 0 0.22rem; margin-right: 0.15rem; vertical-align: baseline; }
-.cmcp-workflow-version { margin-top: 0.35rem; font-size: 0.58rem; opacity: 0.62;
+.cmcp-workflow-version { margin-top: 0.35rem; font-size: 0.7138em; opacity: 0.62;
   display: flex; gap: 0.3rem; align-items: center; }
-.cmcp-workflow-version .pi { font-size: 0.58rem; }
+.cmcp-workflow-version .pi { font-size: 1em; }
 /* ---- sidebar tab badge (these live OUTSIDE .cmcp-root, on the toolbar) ---- */
 /* (.cmcp-tab-logo — the logo-mark tab glyph — is NOT here: it must exist the
    moment registerSidebarTab() paints the toolbar, before the panel ever
@@ -18614,7 +18614,7 @@ const PANEL_CSS = `
 .cmcp-chip {
   display: flex; align-items: center; gap: 0.25rem;
   border: none; background: transparent; cursor: pointer;
-  color: var(--p-text-muted-color, #a1a1aa); font: inherit; font-size: 0.6875rem;
+  color: var(--p-text-muted-color, #a1a1aa); font: inherit; font-size: 0.8462em;
   padding: 0.125rem 0.375rem; border-radius: var(--p-border-radius-sm, 4px);
   white-space: nowrap; min-width: 0; overflow: hidden; flex: 0 1 auto;
 }
@@ -18636,13 +18636,13 @@ const PANEL_CSS = `
   background: var(--p-surface-700, #3f3f46);
   border: 1px solid var(--p-content-border-color, #52525b);
   border-radius: var(--p-border-radius-md, 6px);
-  color: var(--p-text-color, #fff); font: inherit; font-size: 0.6875rem;
+  color: var(--p-text-color, #fff); font: inherit; font-size: 0.8462em;
   padding: 0.1875rem 0.25rem 0.1875rem 0.375rem; cursor: pointer;
   transition: background 0.15s, border-color 0.15s;
 }
 .cmcp-attach-chip:hover { background: var(--p-surface-600, #52525b); }
 .cmcp-attach-chip.open { border-color: var(--p-primary-color, #60a5fa); }
-.cmcp-attach-chip > .pi { font-size: 0.75rem; color: var(--p-text-muted-color, #a1a1aa); flex: none; }
+.cmcp-attach-chip > .pi { font-size: 0.9231em; color: var(--p-text-muted-color, #a1a1aa); flex: none; }
 .cmcp-attach-name { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .cmcp-attach-meta { color: var(--p-text-muted-color, #a1a1aa); flex: none; }
 .cmcp-attach-thumb { width: 1.125rem; height: 1.125rem; border-radius: 3px; object-fit: cover; flex: none; }
@@ -18652,7 +18652,7 @@ const PANEL_CSS = `
   border-radius: 3px; color: var(--p-text-muted-color, #a1a1aa);
 }
 .cmcp-attach-rm:hover { background: var(--p-surface-800, #27272a); color: var(--p-text-color, #fff); }
-.cmcp-attach-rm .pi { font-size: 0.625rem; }
+.cmcp-attach-rm .pi { font-size: 0.7692em; }
 .cmcp-attach-preview {
   background: var(--p-surface-900, #18181b);
   border: 1px solid var(--p-content-border-color, #3f3f46);
@@ -18662,10 +18662,10 @@ const PANEL_CSS = `
 .cmcp-attach-preview pre {
   margin: 0; white-space: pre-wrap; word-break: break-word;
   font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
-  font-size: 0.6875rem; line-height: 1.45; color: var(--p-text-color, #e4e4e7);
+  font-size: 0.8462em; line-height: 1.45; color: var(--p-text-color, #e4e4e7);
 }
 .cmcp-attach-preview img { max-width: 100%; max-height: 12rem; border-radius: 4px; display: block; }
-.cmcp-ctx { font-size: 0.625rem; color: var(--p-text-muted-color, #a1a1aa); min-width: 1.75rem; }
+.cmcp-ctx { font-size: 0.7692em; color: var(--p-text-muted-color, #a1a1aa); min-width: 1.75rem; }
 .cmcp-ring { flex: none; margin: 0 0.125rem; transform: rotate(-90deg); }
 .cmcp-ring .bg { stroke: var(--p-surface-600, #52525b); }
 .cmcp-ring .fg { stroke: var(--p-primary-color, #60a5fa); transition: stroke-dashoffset 0.3s; }
@@ -18681,11 +18681,11 @@ const PANEL_CSS = `
 .cmcp-popover-item {
   display: flex; align-items: center; gap: 0.5rem; width: 100%; box-sizing: border-box;
   padding: 0.375rem 0.5rem; border: none; background: transparent; cursor: pointer;
-  text-align: left; color: var(--p-text-color, #fff); font: inherit; font-size: 0.75rem;
+  text-align: left; color: var(--p-text-color, #fff); font: inherit; font-size: 0.9231em;
   border-radius: var(--p-border-radius-sm, 4px);
 }
 .cmcp-popover-item.sel, .cmcp-popover-item:hover { background: var(--p-surface-700, #3f3f46); }
-.cmcp-popover-item .pi { font-size: 0.75rem; color: var(--p-text-muted-color, #a1a1aa); flex: none; }
+.cmcp-popover-item .pi { font-size: 0.9231em; color: var(--p-text-muted-color, #a1a1aa); flex: none; }
 .cmcp-popover-item small { margin-left: auto; color: var(--p-text-muted-color, #a1a1aa); flex: none; padding-left: 0.5rem; }
 .cmcp-popover-item .lbl { flex: 1 1 auto; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 /* Hover-to-read: while revealing, drop the ellipsis so the tail is legible, and
@@ -18718,12 +18718,12 @@ const PANEL_CSS = `
 .cmcp-hist-search {
   min-width: 0; border: 1px solid var(--p-form-field-border-color, #52525b);
   border-radius: var(--p-border-radius-sm, 4px); background: var(--p-form-field-background, #09090b);
-  color: var(--p-form-field-color, #fff); font: inherit; font-size: 0.75rem; padding: 0.35rem 0.45rem;
+  color: var(--p-form-field-color, #fff); font: inherit; font-size: 0.9231em; padding: 0.35rem 0.45rem;
 }
 .cmcp-hist-filter { grid-column: 1 / -1; display: flex; align-items: center; gap: 0.375rem;
-  color: var(--p-text-muted-color, #a1a1aa); font-size: 0.6875rem; }
+  color: var(--p-text-muted-color, #a1a1aa); font-size: 0.8462em; }
 .cmcp-hist-list { max-height: min(58vh, 28rem); overflow-y: auto; padding: 0.25rem; }
-.cmcp-hist-group { padding: 0.35rem 0.5rem 0.2rem; font-size: 0.625rem; font-weight: 700;
+.cmcp-hist-group { padding: 0.35rem 0.5rem 0.2rem; font-size: 0.7692em; font-weight: 700;
   text-transform: uppercase; letter-spacing: 0.04em; color: var(--p-text-muted-color, #a1a1aa); }
 .cmcp-hist-row { display: flex; align-items: stretch; gap: 0.125rem; }
 .cmcp-hist-row.active { background: color-mix(in srgb, var(--p-primary-color, #60a5fa) 13%, transparent); border-radius: 4px; }
@@ -18732,7 +18732,7 @@ const PANEL_CSS = `
 .cmcp-hist-row.foreign-workflow .cmcp-hist-open { cursor: not-allowed; }
 .cmcp-hist-meta { display: flex; flex-direction: column; min-width: 0; flex: 1; }
 .cmcp-hist-meta .lbl { font-weight: 550; }
-.cmcp-hist-sub { color: var(--p-text-muted-color, #a1a1aa); font-size: 0.625rem;
+.cmcp-hist-sub { color: var(--p-text-muted-color, #a1a1aa); font-size: 0.7692em;
   overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .cmcp-hist-action {
   flex: none; width: 1.75rem; border: none; background: transparent; cursor: pointer;
@@ -18743,32 +18743,32 @@ const PANEL_CSS = `
 .cmcp-hist-action:focus-visible { opacity: 1; }
 .cmcp-hist-action:hover { background: var(--p-surface-700, #3f3f46); color: var(--p-text-color, #fff); }
 .cmcp-hist-action.danger:hover { color: var(--p-red-400, #f87171); }
-.cmcp-hist-action .pi { font-size: 0.75rem; }
+.cmcp-hist-action .pi { font-size: 0.9231em; }
 .cmcp-hist-footer {
   margin-top: 0.25rem; padding: 0.5rem 0.375rem 0.125rem;
   border-top: 1px solid var(--p-content-border-color, #3f3f46);
 }
 .cmcp-hist-note {
   margin: 0 0 0.375rem; color: var(--p-text-muted-color, #a1a1aa);
-  font-size: 0.625rem; line-height: 1.35;
+  font-size: 0.7692em; line-height: 1.35;
 }
 .cmcp-hist-clear {
   display: flex; align-items: center; justify-content: center; gap: 0.375rem;
   width: 100%; padding: 0.3125rem 0.5rem; border-radius: var(--p-border-radius-sm, 4px);
   border: 1px solid color-mix(in srgb, var(--p-red-400, #f87171) 45%, transparent);
   background: transparent; color: var(--p-red-400, #f87171); cursor: pointer;
-  font: inherit; font-size: 0.6875rem;
+  font: inherit; font-size: 0.8462em;
 }
 .cmcp-hist-clear:hover:not(:disabled) { background: color-mix(in srgb, var(--p-red-400, #f87171) 12%, transparent); }
 .cmcp-hist-clear:disabled { opacity: 0.4; cursor: not-allowed; }
 
 /* Model/effort picker popover (anchored above the composer). */
-.cmcp-pop-section { padding: 0.25rem 0.5rem 0.125rem; font-size: 0.625rem; font-weight: 600;
+.cmcp-pop-section { padding: 0.25rem 0.5rem 0.125rem; font-size: 0.7692em; font-weight: 600;
   text-transform: uppercase; letter-spacing: 0.04em; color: var(--p-text-muted-color, #a1a1aa); }
 .cmcp-pop-section:not(:first-child) { margin-top: 0.25rem; border-top: 1px solid var(--p-content-border-color, #3f3f46); padding-top: 0.375rem; }
 .cmcp-popover-item .check { flex: none; width: 1rem; text-align: center; margin-left: 0.375rem; color: var(--p-primary-color, #60a5fa); visibility: hidden; }
 .cmcp-popover-item .check.on { visibility: visible; }
-.cmcp-chip .pi-angle-down { font-size: 0.5625rem; opacity: 0.7; }
+.cmcp-chip .pi-angle-down { font-size: 0.8181em; opacity: 0.7; }
 .cmcp-chip .dim { opacity: 0.65; }
 /* Omni-search model picker (aggregates every connected provider's catalog into
    one virtualized, keyboard-navigable list). Row height is FIXED at 30px so the
@@ -18776,9 +18776,9 @@ const PANEL_CSS = `
 .cmcp-modelsearch { display: flex; flex-direction: column; }
 .cmcp-modelsearch-input { margin: 0.25rem 0.5rem; padding: 0.3rem 0.5rem; border-radius: 6px;
   border: 1px solid var(--p-content-border-color, #3f3f46); background: var(--p-surface-900, #18181b);
-  color: var(--p-text-color, #e4e4e7); font-size: 0.8rem; }
+  color: var(--p-text-color, #e4e4e7); font-size: 0.9846em; }
 .cmcp-modelsearch-input:focus { outline: none; border-color: var(--p-focus-ring-color, #60a5fa); }
-.cmcp-modelsearch-cap { padding: 0.125rem 0.5rem 0.25rem; font-size: 0.625rem; color: var(--p-text-muted-color, #a1a1aa); }
+.cmcp-modelsearch-cap { padding: 0.125rem 0.5rem 0.25rem; font-size: 0.7692em; color: var(--p-text-muted-color, #a1a1aa); }
 .cmcp-modelresults { position: relative; overflow-y: auto; max-height: 15rem; }
 .cmcp-modelsizer { position: relative; width: 100%; }
 .cmcp-modelrow { position: absolute; left: 0; right: 0; height: 30px; display: flex; align-items: center;
@@ -18786,19 +18786,19 @@ const PANEL_CSS = `
   text-align: left; cursor: pointer; box-sizing: border-box; }
 .cmcp-modelrow:hover, .cmcp-modelrow.active { background: var(--p-surface-700, #3f3f46); }
 .cmcp-modelrow .lbl { flex: 1 1 auto; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.cmcp-modelrow .sub { flex: none; color: var(--p-text-muted-color, #a1a1aa); font-size: 0.6875rem; overflow: hidden;
+.cmcp-modelrow .sub { flex: none; color: var(--p-text-muted-color, #a1a1aa); font-size: 0.8462em; overflow: hidden;
   text-overflow: ellipsis; white-space: nowrap; max-width: 40%; }
-.cmcp-provtag { flex: none; font-size: 0.5625rem; text-transform: uppercase; letter-spacing: 0.03em;
+.cmcp-provtag { flex: none; font-size: 0.6923em; text-transform: uppercase; letter-spacing: 0.03em;
   padding: 0.05rem 0.35rem; border-radius: 999px; background: var(--p-surface-800, #27272a);
   color: var(--p-text-muted-color, #a1a1aa); border: 1px solid var(--p-content-border-color, #3f3f46); }
 .cmcp-modelrow .check { flex: none; width: 1rem; text-align: center; color: var(--p-primary-color, #60a5fa); visibility: hidden; }
 .cmcp-modelrow .check.on { visibility: visible; }
-.cmcp-modelempty { padding: 0.5rem; font-size: 0.75rem; color: var(--p-text-muted-color, #a1a1aa); }
+.cmcp-modelempty { padding: 0.5rem; font-size: 0.9231em; color: var(--p-text-muted-color, #a1a1aa); }
 /* Recently-used section (non-virtualized; bounded to the last few picks). Rows
    flow normally (override the absolute positioning the virtualized list uses). */
 .cmcp-modelrecents .cmcp-modelrow { position: static; }
 .cmcp-modelrecent-x { flex: none; margin-left: 0.15rem; padding: 0 0.2rem; background: none; border: none;
-  color: var(--p-text-muted-color, #a1a1aa); cursor: pointer; opacity: 0.55; font-size: 0.7rem; line-height: 1; }
+  color: var(--p-text-muted-color, #a1a1aa); cursor: pointer; opacity: 0.55; font-size: 0.8615em; line-height: 1; }
 .cmcp-modelrecent-x:hover { opacity: 1; color: var(--p-text-color, #e4e4e7); }
 `;
 
@@ -21123,7 +21123,7 @@ function buildPanel() {
           const off = document.createElement("i");
           off.className = "pi pi-times";
           off.title = `Hide ${BACKEND_LABELS[id] || id} — you don't use it. Restore it from the "hidden" row below.`;
-          off.style.cssText = "margin-left:0.4rem;opacity:0.4;cursor:pointer;font-size:0.7rem;flex:none;";
+          off.style.cssText = "margin-left:0.4rem;opacity:0.4;cursor:pointer;font-size:0.8615em;flex:none;";
           off.addEventListener("mousedown", (mev) => {
             // Swallow the row's pick handler — this gesture only hides.
             mev.preventDefault();
@@ -22540,7 +22540,7 @@ function buildPanel() {
     if (name) {
       const cap = document.createElement("div");
       cap.className = "cmcp-media-caption";
-      cap.style.cssText = "font-size:0.625rem;color:var(--p-text-muted-color,#a1a1aa);margin-top:0.25rem;";
+      cap.style.cssText = "font-size:0.7692em;color:var(--p-text-muted-color,#a1a1aa);margin-top:0.25rem;";
       cap.textContent = name;
       card.appendChild(cap);
     }
@@ -22626,7 +22626,7 @@ function buildPanel() {
       holder._preFailCss = holder.style.cssText;
       holder.style.cssText +=
         ";display:grid;place-items:center;padding:1rem;box-sizing:border-box;text-align:center;" +
-        "color:var(--p-text-muted-color,#a1a1aa);font-size:0.75rem;";
+        "color:var(--p-text-muted-color,#a1a1aa);font-size:0.9231em;";
       // Release the decode buffers the way unmountHolderVideo does — detaching alone is
       // not deterministic release, and unmount will skip this element once `_video` is
       // null, so this is the last chance to do it (codex).
@@ -22700,7 +22700,7 @@ function buildPanel() {
     if (name) {
       const cap = document.createElement("div");
       cap.className = "cmcp-media-caption";
-      cap.style.cssText = "font-size:0.625rem;color:var(--p-text-muted-color,#a1a1aa);margin-top:0.25rem;";
+      cap.style.cssText = "font-size:0.7692em;color:var(--p-text-muted-color,#a1a1aa);margin-top:0.25rem;";
       cap.textContent = name;
       card.appendChild(cap);
     }
@@ -22737,7 +22737,7 @@ function buildPanel() {
     card.appendChild(audio);
     if (name) {
       const cap = document.createElement("div");
-      cap.style.cssText = "font-size:0.625rem;color:var(--p-text-muted-color,#a1a1aa);margin-top:0.25rem;";
+      cap.style.cssText = "font-size:0.7692em;color:var(--p-text-muted-color,#a1a1aa);margin-top:0.25rem;";
       cap.textContent = name;
       card.appendChild(cap);
     }
@@ -22772,7 +22772,7 @@ function buildPanel() {
     a.textContent = name || "Open file";
     card.appendChild(a);
     const hint = document.createElement("div");
-    hint.style.cssText = "font-size:0.625rem;color:var(--p-text-muted-color,#a1a1aa);margin-top:0.25rem;";
+    hint.style.cssText = "font-size:0.7692em;color:var(--p-text-muted-color,#a1a1aa);margin-top:0.25rem;";
     hint.textContent = "The panel can't preview this file type — open or download it.";
     card.appendChild(hint);
     log.appendChild(card);
@@ -22949,7 +22949,7 @@ function buildPanel() {
     if (msg.header) {
       const chip = document.createElement("div");
       chip.className = "cmcp-card-head";
-      chip.style.cssText = "text-transform:uppercase;font-size:0.6rem;letter-spacing:0.05em;opacity:0.7;";
+      chip.style.cssText = "text-transform:uppercase;font-size:0.7385em;letter-spacing:0.05em;opacity:0.7;";
       chip.textContent = coerceMessageText(msg.header);
       card.appendChild(chip);
     }
@@ -22993,7 +22993,7 @@ function buildPanel() {
       const answerText = coerceMessageText(answer);
       if (questionText) {
         const q = document.createElement("div");
-        q.style.cssText = "font-size:0.72rem;opacity:0.65;";
+        q.style.cssText = "font-size:0.8862em;opacity:0.65;";
         q.textContent = questionText;
         card.appendChild(q);
       }
@@ -23015,14 +23015,14 @@ function buildPanel() {
       b.className = "cmcp-opt";
       b.style.cssText =
         "text-align:left;padding:0.4rem 0.55rem;border-radius:6px;border:1px solid var(--p-surface-500,#555);" +
-        "background:var(--p-surface-800,#2a2a2a);color:inherit;cursor:pointer;font-size:0.8rem;";
+        "background:var(--p-surface-800,#2a2a2a);color:inherit;cursor:pointer;font-size:0.9846em;";
       const lbl = document.createElement("div");
       lbl.style.fontWeight = "600";
       lbl.textContent = coerceMessageText(opt.label ?? opt);
       b.appendChild(lbl);
       if (opt.description) {
         const d = document.createElement("div");
-        d.style.cssText = "font-size:0.7rem;opacity:0.7;margin-top:0.1rem;";
+        d.style.cssText = "font-size:0.8615em;opacity:0.7;margin-top:0.1rem;";
         d.textContent = coerceMessageText(opt.description);
         b.appendChild(d);
       }
@@ -23048,7 +23048,7 @@ function buildPanel() {
     other.placeholder = "Other… (type your own answer)";
     other.style.cssText =
       "flex:1;padding:0.35rem 0.5rem;border-radius:6px;border:1px solid var(--p-surface-500,#555);" +
-      "background:var(--p-surface-900,#1e1e1e);color:inherit;font-size:0.8rem;";
+      "background:var(--p-surface-900,#1e1e1e);color:inherit;font-size:0.9846em;";
     other.addEventListener("keydown", (e) => {
       if (isImeComposing(e)) return; // don't commit mid-IME-composition (#385)
       if (e.key === "Enter" && other.value.trim()) { e.preventDefault(); finish(other.value.trim()); }
@@ -23058,7 +23058,7 @@ function buildPanel() {
     const submit = document.createElement("button");
     submit.type = "button";
     submit.style.cssText =
-      "padding:0.35rem 0.7rem;border-radius:6px;border:none;cursor:pointer;font-size:0.8rem;" +
+      "padding:0.35rem 0.7rem;border-radius:6px;border:none;cursor:pointer;font-size:0.9846em;" +
       "background:var(--p-primary-color,#3a7bd5);color:#fff;";
     submit.textContent = multi ? "Submit" : "Send";
     submit.addEventListener("click", () => {
@@ -23160,7 +23160,7 @@ function buildPanel() {
       card.style.opacity = "0.6";
       const note = document.createElement("div");
       note.className = "cmcp-card-stale";
-      note.style.cssText = "font-size:0.68rem;opacity:0.8;margin-top:0.4rem;";
+      note.style.cssText = "font-size:0.8369em;opacity:0.8;margin-top:0.4rem;";
       note.textContent =
         `The connection that asked this ${what ?? "question"} dropped, so an answer here can no ` +
         `longer reach the agent. ` +
@@ -23197,7 +23197,7 @@ function buildPanel() {
     card.appendChild(head);
 
     const hint = document.createElement("div");
-    hint.style.cssText = "font-size:0.68rem;opacity:0.7;margin:0.2rem 0 0.4rem;";
+    hint.style.cssText = "font-size:0.8369em;opacity:0.7;margin:0.2rem 0 0.4rem;";
     hint.textContent =
       msg.hint || "Sent straight to your config — never shown to the agent and never saved to chat history.";
     card.appendChild(hint);
@@ -23246,7 +23246,7 @@ function buildPanel() {
     input.placeholder = "Paste token…";
     input.style.cssText =
       "flex:1 1 10rem;min-width:0;padding:0.35rem 0.5rem;border-radius:6px;border:1px solid var(--p-surface-500,#555);" +
-      "background:var(--p-surface-900,#1e1e1e);color:inherit;font-size:0.8rem;";
+      "background:var(--p-surface-900,#1e1e1e);color:inherit;font-size:0.9846em;";
 
     // Show/record only a masked preview (first 4 … last 4) so the user can
     // confirm WHICH token without ever exposing the full value.
@@ -23261,7 +23261,7 @@ function buildPanel() {
       card.replaceChildren();
       card.style.cssText = "border-left:3px solid var(--p-green-400,#4ade80);opacity:0.9;";
       const ok = document.createElement("div");
-      ok.style.cssText = "font-size:0.75rem;color:var(--p-green-400,#4ade80);";
+      ok.style.cssText = "font-size:0.9231em;color:var(--p-green-400,#4ade80);";
       const m = mask(value);
       ok.textContent = value ? `🔒 Token saved: ${m}` : "Skipped — no token entered.";
       card.appendChild(ok);
@@ -23294,7 +23294,7 @@ function buildPanel() {
     // group spill the card at 320/280px. Stating the intent stops a future
     // "everything gets min-width:0" sweep from supplying the missing half.
     submit.style.cssText =
-      "flex:none;padding:0.35rem 0.7rem;border-radius:6px;border:none;cursor:pointer;font-size:0.8rem;" +
+      "flex:none;padding:0.35rem 0.7rem;border-radius:6px;border:none;cursor:pointer;font-size:0.9846em;" +
       "background:var(--p-primary-color,#3a7bd5);color:#fff;";
     submit.textContent = "Save";
     submit.addEventListener("click", () => finish(input.value.trim()));
@@ -23304,7 +23304,7 @@ function buildPanel() {
     skip.type = "button";
     skip.style.cssText =
       "flex:none;padding:0.35rem 0.6rem;border-radius:6px;border:1px solid var(--p-surface-500,#555);" +
-      "background:transparent;color:inherit;cursor:pointer;font-size:0.8rem;";
+      "background:transparent;color:inherit;cursor:pointer;font-size:0.9846em;";
     skip.textContent = "Skip";
     skip.addEventListener("click", () => finish(""));
     btns.appendChild(skip);
@@ -28773,14 +28773,14 @@ function buildPanel() {
     canvas.style.cssText = "background:#fff;border-radius:8px;padding:8px;width:240px;height:240px;";
     canvas.hidden = true;
     const statusMsg = document.createElement("div");
-    statusMsg.style.cssText = "font-size:0.85rem;opacity:0.85;text-align:center;";
+    statusMsg.style.cssText = "font-size:1.0462em;opacity:0.85;text-align:center;";
     const urlLine = document.createElement("div");
     urlLine.style.cssText =
-      "font-size:0.7rem;opacity:0.55;word-break:break-all;text-align:center;max-width:280px;";
+      "font-size:0.8615em;opacity:0.55;word-break:break-all;text-align:center;max-width:280px;";
     // #749 — the durability of THIS url, rendered where the user is looking at it.
     const durabilityLine = document.createElement("div");
     durabilityLine.style.cssText =
-      "font-size:0.72rem;line-height:1.35;text-align:left;max-width:280px;margin-top:0.15rem;";
+      "font-size:0.8862em;line-height:1.35;text-align:left;max-width:280px;margin-top:0.15rem;";
     durabilityLine.hidden = true;
     qrWrap.append(canvas, statusMsg, urlLine, durabilityLine);
 

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -6923,7 +6923,11 @@ function makeShellCommandBlock(baseCmd) {
     b.className = "cmcp-btn";
     b.dataset.shell = s.key;
     b.textContent = s.label;
-    b.style.cssText = "font-size:0.8862em;padding:0.12rem 0.45rem;";
+    // #753 — 1.0472em, not the 0.8862em the other `.cmcp-btn` sites use. These pills render
+    // inside the 11px code-block tools row rather than at the 13px root, and em resolves
+    // against the PARENT: the shared value rendered them at 9.75px instead of 11.52px.
+    // Measured on the page, not derived from the stylesheet.
+    b.style.cssText = "font-size:1.0472em;padding:0.12rem 0.45rem;";
     b.addEventListener("click", () => { selected = s.key; render(); copy(forms[s.key]); });
     pills.appendChild(b);
   }

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -17928,7 +17928,8 @@ const PANEL_CSS = `
   position: relative; /* positioning context for the rollback modal overlay */
   font-family: var(--font-inter, "Inter", ui-sans-serif, system-ui, sans-serif);
   /* #753 — THE ONE KNOB. Every inner font size is calc(var(--cmcp-fs) * k), so a
-     change here scales all of them at once, at any nesting depth. `em` was tried
+     change here scales all of them at once, at any nesting depth. An em unit was
+     tried
      first and rejected: it resolves against the PARENT, so a rule inside a block
      that sets its own size needs a different multiplier, and a rule used under two
      different parents has no single correct value at all (measured: 529 drifted

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -3970,10 +3970,11 @@ function panelSettingsList() {
       tooltip:
         "Scales the whole Agent sidebar — text, icons and spacing together. Raise it if the panel is hard " +
         "to read on a high-DPI or large display. 100% is the default; 100-250. Applies immediately, to " +
-        "every open panel. For text only, the panel also exposes a CSS variable: setting `--cmcp-fs` " +
-        "(default 0.8125rem) on `:root` or `.cmcp-root` in a user stylesheet scales every panel font " +
-        "size, including the CivitAI, Apps and modal surfaces. It does not scale spacing or icons — " +
-        "this setting is still the supported way to scale the panel as a whole.",
+        "every open panel. For text, the panel also exposes a CSS variable: setting `--cmcp-fs` " +
+        "(default 0.8125rem) on `:root` or `.cmcp-root` in a user stylesheet scales the panel's font " +
+        "sizes, including the CivitAI, Apps and modal surfaces. It does not scale spacing, icons, or " +
+        "the handful of elements that carry a fixed pixel size. This setting is still the supported " +
+        "way to scale the panel as a whole.",
       type: "slider",
       attrs: { min: PANEL_UI_SCALE_MIN, max: PANEL_UI_SCALE_MAX, step: 5 },
       defaultValue: 100,
@@ -19421,7 +19422,9 @@ function buildPanel() {
   statusText.textContent = "disconnected";
   const caret = document.createElement("i");
   caret.className = "pi pi-angle-down";
-  caret.style.fontSize = "0.625rem";
+  // #753 — assigned through style.fontSize rather than a `font-size:` declaration, so the
+  // conversion sweep could not see it (codex). 0.625/0.8125, same as every other value.
+  caret.style.fontSize = "calc(var(--cmcp-fs, 0.8125rem) * 0.7692)";
   status.append(dot, statusText, caret);
 
   function iconBtn(icon, titleText) {

--- a/web/js/lib/ui-scale.js
+++ b/web/js/lib/ui-scale.js
@@ -2,7 +2,7 @@
 //
 // THE REPORT. A user on Windows 11 found the sidebar text barely readable, and
 // the fix anyone would reach for does nothing: `.cmcp-root` sets
-// `font-size: 0.8125rem`, but the panel's inner rules are `rem`, which resolve
+// `font-size: 0.8125rem`. Historically the panel's inner rules were `rem`, resolving
 // against the PAGE root rather than against the panel. Overriding
 // `.cmcp-root { font-size }` in a user stylesheet therefore moves only the few
 // elements that inherit, and every rem-sized label stays exactly as it was.


### PR DESCRIPTION
Closes #753's option 2, by the route the evidence pointed at rather than the one it named.

## What this does

Every inner `font-size: Xrem` (214 values, 9 non-vendor files) becomes
`calc(var(--cmcp-fs, 0.8125rem) * k)`, k = X/0.8125, so each renders its original pixel
size at the default. `--cmcp-fs` is declared on **both** `:root` and `.cmcp-root`.

Setting `--cmcp-fs` in a user stylesheet now scales every panel font size at once —
including the CivitAI explorer, Apps and the modals.

## Why not `em`, which is what the issue asked for

This branch tried `em` first, and the record is in its commits. `em` resolves against the
**parent**, so a rule inside a block that sets its own size needs a different multiplier,
and a rule used under two different parents has no single correct value at all.

Measured, not predicted:

| | |
|---|---|
| elements drifted by the mechanical rescale | **529** |
| nested sites needing individual correction | ~25, across views that are expensive to render |
| rules with no expressible single value | **5** |
| independent sweeps that disagreed on values | 2 (mine and codex's, about what a parent renders at) |

A variable is flat: the multiplier is identical regardless of nesting depth. No per-parent
corrections, no multi-context exceptions, and no per-surface anchors — the `em` version
needed five, because the sub-modal overlay, CivitAI lightbox and media lightbox mount on
`<body>` outside `.cmcp-root` and would have rendered ~23% larger. `:root` reaches them.

## Verification

Measured on the live panel after the rewrite:

- **2471 elements compared** against a pre-change capture — **zero drift** beyond
  sub-0.01px rounding.
- Overriding `--cmcp-fs` to 1.5x moved **2104 elements by exactly 1.50**. The 367 that did
  not are PrimeIcons sized by ComfyUI's own CSS (331) plus a few of our rules that use
  literal `px`. For comparison, the `em` version moved 887 and left 1579 fixed.
- `var(--cmcp-fs, 0.8125rem)` everywhere, so a dropped custom property falls back to the
  panel's own default instead of erasing the declaration.

## Also

- The UI-scale tooltip named the trap; it now names the knob, and says plainly that it
  scales text but not spacing or icons. Its guard test asserted the warning, so it now
  asserts the working knob — a warning must not outlive the thing it warned about.
- One self-inflicted bug worth recording: a backtick inside a comment I added to the
  `PANEL_CSS` template literal closed the string, so the extension failed to register and
  the panel did not render at all. Neither the unit suite nor typecheck sees this — the
  tests read the panel as text and tsc does not cover `web/js`. `node --check` over every
  panel file reproduces it in a second and is now part of my routine here.

3722 tests, typecheck and tool-vocabulary clean.

Closes #753

🤖 Generated with [Claude Code](https://claude.com/claude-code)