### PR TITLE
i18n(training): the LoRA Training panel speaks the 12 languages ComfyUI ships

### DIFF
--- a/browser_tests/unit/i18n.test.mjs
+++ b/browser_tests/unit/i18n.test.mjs
@@ -191,7 +191,11 @@ test("module-scope config reads translations LAZILY, not at import time", () => 
     const rest = src.slice(start + 1);
     const endRel = rest.search(/\n(?:const|let|var|function|export|\/\*\*|\/\/ ─)/);
     const block = endRel === -1 ? rest : rest.slice(0, endRel);
-    const bare = block.split("\n").filter((l) => /\b(?:label|title|note|hint)\s*:\s*tr\(/.test(l));
+    // `desc` is in this list because FLOWS carries one: the field-name set has to track the
+    // fields these blocks actually declare, or an eager `desc: tr(...)` reads green.
+    // Scope, precisely: this catches the EAGER form. A field that stops calling tr() at all
+    // is not caught here — the backstop below only needs one getter anywhere in the block.
+    const bare = block.split("\n").filter((l) => /\b(?:label|title|note|hint|desc)\s*:\s*tr\(/.test(l));
     assert.deepEqual(
       bare,
       [],

--- a/web/js/cmcp-training-ui.js
+++ b/web/js/cmcp-training-ui.js
@@ -101,14 +101,16 @@ function injectCss() {
 }
 
 // Getters, not values — see the note in cmcp-sidepanel-ui.js. Module scope runs before the
-// catalog loads, so a plain `tr(...)` here captures English permanently.
+// catalog loads, so a plain `tr(...)` here captures English permanently. `desc` needs the
+// same treatment as `title` for exactly the same reason; the model names inside `models`
+// are identifiers, not prose, and are deliberately NOT translated.
 const FLOWS = [
-  { get title() { return tr("training_ui.image_character", "Image Character"); }, icon: "pi-user", models: ["FLUX.1-dev"], desc: "Train a person or character into an image model.", live: true },
-  { get title() { return tr("training_ui.image_edit", "Image Edit"); }, icon: "pi-pencil", models: ["Qwen Edit 2509"], desc: "Teach an edit model your custom transformation." },
-  { get title() { return tr("training_ui.image_style", "Image Style"); }, icon: "pi-palette", models: ["Krea2", "Flux2", "ZImg"], desc: "Capture an art style you can apply to any prompt." },
-  { get title() { return tr("training_ui.image_slider", "Image Slider"); }, icon: "pi-sliders-h", models: ["Krea2", "Flux2", "ZImg"], desc: "A concept slider with adjustable strength." },
-  { get title() { return tr("training_ui.video_character", "Video Character"); }, icon: "pi-video", models: ["LTX 2.3", "Wan 2.2"], desc: "Bring a character into video generation." },
-  { get title() { return tr("training_ui.video_action", "Video Action"); }, icon: "pi-forward", models: ["LTX 2.3", "Wan 2.2"], desc: "Teach a motion or action to a video model." },
+  { get title() { return tr("training_ui.image_character", "Image Character"); }, icon: "pi-user", models: ["FLUX.1-dev"], get desc() { return tr("training_ui.train_a_person_or_character_into_an", "Train a person or character into an image model."); }, live: true },
+  { get title() { return tr("training_ui.image_edit", "Image Edit"); }, icon: "pi-pencil", models: ["Qwen Edit 2509"], get desc() { return tr("training_ui.teach_an_edit_model_your_custom_transformation", "Teach an edit model your custom transformation."); } },
+  { get title() { return tr("training_ui.image_style", "Image Style"); }, icon: "pi-palette", models: ["Krea2", "Flux2", "ZImg"], get desc() { return tr("training_ui.capture_an_art_style_you_can_apply", "Capture an art style you can apply to any prompt."); } },
+  { get title() { return tr("training_ui.image_slider", "Image Slider"); }, icon: "pi-sliders-h", models: ["Krea2", "Flux2", "ZImg"], get desc() { return tr("training_ui.a_concept_slider_with_adjustable_strength", "A concept slider with adjustable strength."); } },
+  { get title() { return tr("training_ui.video_character", "Video Character"); }, icon: "pi-video", models: ["LTX 2.3", "Wan 2.2"], get desc() { return tr("training_ui.bring_a_character_into_video_generation", "Bring a character into video generation."); } },
+  { get title() { return tr("training_ui.video_action", "Video Action"); }, icon: "pi-forward", models: ["LTX 2.3", "Wan 2.2"], get desc() { return tr("training_ui.teach_a_motion_or_action_to_a", "Teach a motion or action to a video model."); } },
 ];
 
 const PRESETS = {
@@ -146,7 +148,17 @@ function el(tag, cls, text) {
   return e;
 }
 
-/** callTool envelope → parsed JSON (train_* tools return text-wrapped JSON). */
+/**
+ * callTool envelope → parsed JSON (train_* tools return text-wrapped JSON).
+ *
+ * The `throw new Error(...)` strings in here — and in the drive* handlers at the bottom of
+ * this file — are deliberately NOT translated. They have two audiences: the UI renders them
+ * inside a translated wrapper ("Could not load jobs: {error}"), but the agent-drive bridge
+ * also relays them verbatim to the agent, and to whatever issue report the user pastes them
+ * into. A locale-dependent error string makes the agent's behaviour and every bug report
+ * depend on the user's language setting, which costs more than the half-translated sentence
+ * it buys. If that trade is ever revisited, revisit it for BOTH sites at once.
+ */
 async function callJson(ctx, tool, args, opts) {
   if (!ctx.callTool) throw new Error("panel bridge not connected — start the comfyui-mcp orchestrator");
   const res = await ctx.callTool(tool, args, opts);
@@ -212,17 +224,61 @@ function sanitizeNameClient(name) {
   return cleaned;
 }
 
+/**
+ * Relative age for job/dataset rows.
+ *
+ * Counted, even though the English abbreviations ("5m ago") never inflect: the abbreviation
+ * is an English choice, and a translator who spells the unit out — ru "{count} день" vs
+ * "дня" vs "дней" — needs the plural slots to exist. Passing `{ count }` creates them; a
+ * plain `{n}` would leave that translator with nowhere to put the other three forms.
+ */
 function fmtAgo(iso) {
   const t = Date.parse(iso || "");
   if (!t) return "";
   const s = Math.max(0, (Date.now() - t) / 1000);
-  if (s < 60) return `${Math.floor(s)}s ago`;
-  if (s < 3600) return `${Math.floor(s / 60)}m ago`;
-  if (s < 86400) return `${Math.floor(s / 3600)}h ago`;
-  return `${Math.floor(s / 86400)}d ago`;
+  if (s < 60) return tr("training_ui.seconds_ago", { one: "{count}s ago", other: "{count}s ago" }, { count: Math.floor(s) });
+  if (s < 3600) return tr("training_ui.minutes_ago", { one: "{count}m ago", other: "{count}m ago" }, { count: Math.floor(s / 60) });
+  if (s < 86400) return tr("training_ui.hours_ago", { one: "{count}h ago", other: "{count}h ago" }, { count: Math.floor(s / 3600) });
+  return tr("training_ui.days_ago", { one: "{count}d ago", other: "{count}d ago" }, { count: Math.floor(s / 86400) });
 }
 
+// INTERPOLATION ORDER MATTERS — a file-wide rule, not a note about any one declaration.
+// Read it before adding a multi-var tr() call anywhere below.
+//
+// tr() substitutes `{name}` holes one variable at a time, in the order the vars object
+// declares them, over the string it has built so far. So a value that itself contains
+// `{something}` is re-scanned by every substitution that comes AFTER it. A user whose
+// trigger word is literally "{rank}" would otherwise see the LoRA rank rendered where
+// their trigger word belongs. The rule this file follows: any value the USER can type
+// (trigger words, file names) goes LAST in the vars object, after every internal value.
+// Single-variable calls are safe by construction and need no ordering care.
+
 const STATUS_BADGE = { running: "ok", queued: "warn", completed: "ok", failed: "err", cancelled: "warn" };
+
+/**
+ * Display text for a job status. The raw value stays the backend's enum everywhere it is
+ * USED as data (STATUS_BADGE lookups, the `terminal` test, wiz.job) — this only translates
+ * what is shown, because an English "running" sitting inside an otherwise Korean sentence
+ * is exactly the defect this whole change exists to remove. An unrecognised status falls
+ * through unchanged rather than rendering blank.
+ */
+const statusLabel = (status) => ({
+  running: tr("training_ui.status_running", "running"),
+  queued: tr("training_ui.status_queued", "queued"),
+  completed: tr("training_ui.status_completed", "completed"),
+  failed: tr("training_ui.status_failed", "failed"),
+  cancelled: tr("training_ui.status_cancelled", "cancelled"),
+}[status] ?? status);
+
+/** The four wizard step chips. A FUNCTION, not a const array, for the same reason FLOWS
+ *  uses getters: module scope runs at import time, before the catalog loads, so a frozen
+ *  array would render English forever. Called fresh by every show(). */
+const stepNames = () => [
+  tr("training_ui.1_dataset", "1 · Dataset"),
+  tr("training_ui.2_label", "2 · Label"),
+  tr("training_ui.3_launch", "3 · Launch"),
+  tr("training_ui.4_monitor", "4 · Monitor"),
+];
 
 /** Content-provider factory for the LoRA Training tab of the unified side panel.
  *  The shell owns the overlay/header/✕/dock/Escape; this builds the wizard body +
@@ -326,6 +382,15 @@ export function createTrainingContent(ctx = {}, shell, opts = {}) {
     return true;
   }
 
+  /** The refusal every "start a new run" entry point shows when resetWizardConfig()
+   *  declines (Flows/Jobs/Datasets/Monitor each guard on it). ONE key for four call
+   *  sites — the same sentence extracted four times would ask translators to write it
+   *  four times and let the four copies drift apart. */
+  const launchInFlightMsg = () => tr(
+    "training_ui.a_launch_is_still_in_flight_let",
+    "A launch is still in flight — let it settle (or cancel it from Jobs) before starting a new run.",
+  );
+
   /** Collision-free rerun name (codex finding: a fixed "-r2" suffix silently
    *  overwrites the previous rerun's LoRA — the name IS the .safetensors
    *  basename). Bumps -rN past every existing job sharing the base name. */
@@ -346,9 +411,9 @@ export function createTrainingContent(ctx = {}, shell, opts = {}) {
   }
 
   // Jobs + Datasets buttons → shell subnav (via subnavExtras). The shell owns the ✕/title.
-  const jobsBtn = el("button", "cmcp-tr-btn", "Jobs");
+  const jobsBtn = el("button", "cmcp-tr-btn", tr("training_ui.jobs", "Jobs"));
   jobsBtn.style.flex = "none";
-  const datasetsBtn = el("button", "cmcp-tr-btn", "Datasets");
+  const datasetsBtn = el("button", "cmcp-tr-btn", tr("training_ui.datasets", "Datasets"));
   datasetsBtn.style.flex = "none";
 
   // Step chips (carry data-ref) + the wizard body, mounted into the shell's
@@ -393,10 +458,10 @@ export function createTrainingContent(ctx = {}, shell, opts = {}) {
     else if (view === "jobs") { setSteps(null); renderJobs(); }
     else if (view === "datasets") { setSteps(null); renderDatasets(); }
     else if (view === "dataset-detail") { setSteps(null); renderDatasetDetail(); }
-    else if (view === "wizard-1") { setSteps(["1 · Dataset", "2 · Label", "3 · Launch", "4 · Monitor"], 0); renderGather(); }
-    else if (view === "wizard-2") { setSteps(["1 · Dataset", "2 · Label", "3 · Launch", "4 · Monitor"], 1); renderLabel(); }
-    else if (view === "wizard-3") { setSteps(["1 · Dataset", "2 · Label", "3 · Launch", "4 · Monitor"], 2); renderLaunch(); }
-    else if (view === "wizard-4") { setSteps(["1 · Dataset", "2 · Label", "3 · Launch", "4 · Monitor"], 3); renderMonitor(); }
+    else if (view === "wizard-1") { setSteps(stepNames(), 0); renderGather(); }
+    else if (view === "wizard-2") { setSteps(stepNames(), 1); renderLabel(); }
+    else if (view === "wizard-3") { setSteps(stepNames(), 2); renderLaunch(); }
+    else if (view === "wizard-4") { setSteps(stepNames(), 3); renderMonitor(); }
     // Re-glow after the new view's DOM exists (renderers can be async but stamp
     // their static refs synchronously; async content re-applies on its own).
     reapplyHighlight();
@@ -424,21 +489,22 @@ export function createTrainingContent(ctx = {}, shell, opts = {}) {
       const h = el("h3", null, f.title);
       const p = el("p", null, f.desc);
       if (f.live) {
-        const b = el("span", "cmcp-tr-badge ok", "Local · ready");
-        const start = el("button", "cmcp-tr-btn primary", "Start");
+        const b = el("span", "cmcp-tr-badge ok", tr("training_ui.local_ready", "Local · ready"));
+        const start = el("button", "cmcp-tr-btn primary", tr("training_ui.start", "Start"));
         start.onclick = () => {
-          if (!resetWizardConfig()) { alert("A launch is still in flight — let it settle (or cancel it from Jobs) before starting a new run."); return; }
+          if (!resetWizardConfig()) { alert(launchInFlightMsg()); return; }
           show("wizard-1");
         };
         card.append(icon, select, h, p, b, start);
       } else {
-        const b = el("span", "cmcp-tr-badge", "Coming soon (P2)");
+        const b = el("span", "cmcp-tr-badge", tr("training_ui.coming_soon_p2", "Coming soon (P2)"));
         card.append(icon, select, h, p, b);
       }
       grid.appendChild(card);
     }
     const foot = el("div", "cmcp-tr-foot",
-      "Character LoRAs train on this rig (ai-toolkit in a GPU container, FLUX.1-dev) — or on a connected RunPod pod via the Local/Pod switch on the Launch step. Style / edit / slider / video flows land in P2.");
+      tr("training_ui.character_loras_train_on_this_rig_ai",
+        "Character LoRAs train on this rig (ai-toolkit in a GPU container, FLUX.1-dev) — or on a connected RunPod pod via the Local/Pod switch on the Launch step. Style / edit / slider / video flows land in P2."));
     body.append(grid, foot);
   }
 
@@ -470,17 +536,18 @@ export function createTrainingContent(ctx = {}, shell, opts = {}) {
       if (capable) return;
       sec.textContent = "";
       const card = el("div", "cmcp-tr-card");
-      card.append(el("h3", null, "Trainer backend not available"));
+      card.append(el("h3", null, tr("training_ui.trainer_backend_not_available", "Trainer backend not available")));
       card.append(el("p", null,
-        "The connected orchestrator doesn't expose the train_* tools — it needs to run the comfyui-mcp release that includes the LoRA trainer (PR #237 or later), and the panel's bridge must point at it. Upgrade/restart the orchestrator, then reopen this wizard."));
-      const back2 = el("button", "cmcp-tr-btn", "← Flows");
+        tr("training_ui.the_connected_orchestrator_doesn_t_expose_the",
+          "The connected orchestrator doesn't expose the train_* tools — it needs to run the comfyui-mcp release that includes the LoRA trainer (PR #237 or later), and the panel's bridge must point at it. Upgrade/restart the orchestrator, then reopen this wizard.")));
+      const back2 = el("button", "cmcp-tr-btn", tr("training_ui.back_flows", "← Flows"));
       back2.onclick = () => show("flows");
       card.append(back2);
       sec.appendChild(card);
     });
 
     const nameRow = el("div", "cmcp-tr-row");
-    nameRow.append(el("label", null, "Dataset name"));
+    nameRow.append(el("label", null, tr("training_ui.dataset_name", "Dataset name")));
     const nameInput = el("input", null);
     nameInput.type = "text";
     nameInput.dataset.ref = "field:dataset_name";
@@ -490,7 +557,7 @@ export function createTrainingContent(ctx = {}, shell, opts = {}) {
     nameRow.appendChild(nameInput);
 
     const trigRow = el("div", "cmcp-tr-row");
-    trigRow.append(el("label", null, "Trigger word"));
+    trigRow.append(el("label", null, tr("training_ui.trigger_word", "Trigger word")));
     const trigInput = el("input", null);
     trigInput.type = "text";
     trigInput.dataset.ref = "field:trigger";
@@ -499,13 +566,15 @@ export function createTrainingContent(ctx = {}, shell, opts = {}) {
     trigInput.oninput = () => { wiz.trigger = trigInput.value.trim(); };
     trigRow.appendChild(trigInput);
     sec.append(nameRow, trigRow, el("p", "cmcp-tr-hint",
-      "10–30 varied images of the subject work best (angles, lighting, backgrounds). The trigger word goes in every caption."));
+      tr("training_ui.10_30_varied_images_of_the_subject",
+        "10–30 varied images of the subject work best (angles, lighting, backgrounds). The trigger word goes in every caption.")));
 
-    // Source tabs.
+    // Source tabs. NOTE for the next editor: `el("button", "active", …)` puts the CLASS in
+    // the second slot — only the THIRD argument is display text.
     const tabs = el("div", "cmcp-tr-seg");
     tabs.style.margin = "0";
-    const outTab = el("button", "active", "From outputs");
-    const upTab = el("button", null, "Upload");
+    const outTab = el("button", "active", tr("training_ui.from_outputs", "From outputs"));
+    const upTab = el("button", null, tr("training_ui.upload", "Upload"));
     tabs.append(outTab, upTab);
     const tabBody = el("div");
     sec.append(tabs, tabBody);
@@ -515,18 +584,30 @@ export function createTrainingContent(ctx = {}, shell, opts = {}) {
     const tray = el("div", "cmcp-tr-tray");
     const nav = el("div", "cmcp-tr-row");
     nav.style.marginTop = ".4rem";
-    const back = el("button", "cmcp-tr-btn", "← Flows");
+    const back = el("button", "cmcp-tr-btn", tr("training_ui.back_flows", "← Flows"));
     back.onclick = () => show("flows");
-    const next = el("button", "cmcp-tr-btn primary", "Next: label captions →");
+    const next = el("button", "cmcp-tr-btn primary", tr("training_ui.next_label_captions", "Next: label captions →"));
     next.onclick = () => show("wizard-2");
     nav.append(back, next);
     sec.append(trayLabel, tray, nav);
     body.appendChild(sec);
 
     function syncTray() {
-      trayLabel.textContent = wiz.images.length
-        ? `${wiz.images.length} selected${wiz.images.length < 6 ? " — add more for a usable LoRA (10–30 recommended)" : ""}`
-        : "Nothing selected yet.";
+      // Counted strings pass `{ count }` and an OBJECT fallback, even where English says
+      // the same thing for one and many: the plural slots are what let ko collapse to a
+      // single form and ru take its four, which no `n === 1` test in here could get right.
+      // The advice half is a SEPARATE, uncounted key rather than a second full sentence
+      // duplicated across every plural category — ru would otherwise need the whole
+      // sentence written four times here and four more times below, and the eight copies
+      // would drift.
+      if (!wiz.images.length) {
+        trayLabel.textContent = tr("training_ui.nothing_selected_yet", "Nothing selected yet.");
+      } else {
+        const selected = tr("training_ui.n_selected", { one: "{count} selected", other: "{count} selected" }, { count: wiz.images.length });
+        trayLabel.textContent = wiz.images.length < 6
+          ? `${selected} ${tr("training_ui.add_more_for_a_usable_lora", "— add more for a usable LoRA (10–30 recommended)")}`
+          : selected;
+      }
       tray.textContent = "";
       wiz.images.forEach((img, idx) => {
         const chip = el("div", "cmcp-tr-chip");
@@ -544,8 +625,15 @@ export function createTrainingContent(ctx = {}, shell, opts = {}) {
       // (action:"list_flows") resolves, advancing is blocked (codex finding: the gate was bypassable
       // while pending).
       next.disabled = !backendCapable || wiz.uploadsPending > 0 || !(wiz.images.length >= 1 && sanitizeNameClient(wiz.datasetName));
-      next.title = !backendCapable && !backendChecked ? "Checking trainer backend…"
-        : wiz.uploadsPending > 0 ? `Waiting for ${wiz.uploadsPending} upload(s)…` : "";
+      // "upload(s)" becomes a real plural here: the parenthesised-s dodge exists only
+      // because English had no plural machinery at this call site, and it translates
+      // badly (many languages have no such shorthand).
+      next.title = !backendCapable && !backendChecked ? tr("training_ui.checking_trainer_backend", "Checking trainer backend…")
+        : wiz.uploadsPending > 0
+          ? tr("training_ui.waiting_for_n_uploads",
+              { one: "Waiting for {count} upload…", other: "Waiting for {count} uploads…" },
+              { count: wiz.uploadsPending })
+          : "";
     }
 
     // Outputs tab. The filename filter is the shell's shared search box
@@ -557,16 +645,16 @@ export function createTrainingContent(ctx = {}, shell, opts = {}) {
       try { shell.searchEl.value = outputsFilter; } catch { /* not mounted */ }
       try { shell.syncSearch(); } catch { /* not mounted */ }
       const grid = el("div", "cmcp-tr-pickgrid");
-      const status = el("p", "cmcp-tr-hint", "Loading recent outputs…");
+      const status = el("p", "cmcp-tr-hint", tr("training_ui.loading_recent_outputs", "Loading recent outputs…"));
       tabBody.append(status, grid);
       let images = [];
       try {
         const res = await apiFetch(ctx, "/comfyui_mcp_panel/training/list-outputs?limit=120");
         const data = await res.json();
         images = data.images || [];
-        status.textContent = images.length ? "" : "No output images found — generate something first, or use Upload.";
+        status.textContent = images.length ? "" : tr("training_ui.no_output_images_found_generate_something_first", "No output images found — generate something first, or use Upload.");
       } catch (e) {
-        status.textContent = `Could not list outputs: ${e.message || e}`;
+        status.textContent = tr("training_ui.could_not_list_outputs", "Could not list outputs: {error}", { error: e.message || e });
         return;
       }
       const isSel = (img) => wiz.images.some((w) => w.ref.filename === img.filename && (w.ref.subfolder || "") === (img.subfolder || "") && w.ref.type === "output");
@@ -605,7 +693,7 @@ export function createTrainingContent(ctx = {}, shell, opts = {}) {
     // Upload tab.
     function renderUpload() {
       tabBody.textContent = "";
-      const drop = el("div", "cmcp-tr-drop", "Drop images here, or click to browse");
+      const drop = el("div", "cmcp-tr-drop", tr("training_ui.drop_images_here_or_click_to_browse", "Drop images here, or click to browse"));
       const picker = document.createElement("input");
       picker.type = "file";
       picker.accept = "image/png,image/jpeg,image/webp";
@@ -658,7 +746,8 @@ export function createTrainingContent(ctx = {}, shell, opts = {}) {
         wiz.uploadsPending += batch.length;
         syncNext();
         for (const f of batch) {
-          status.textContent = `Uploading ${f.name}… (${wiz.images.length} added)`;
+          // The file NAME is user-supplied, so it is substituted last (see fmtAgo's note).
+          status.textContent = tr("training_ui.uploading_added", "Uploading {name}… ({added} added)", { added: wiz.images.length, name: f.name });
           try {
             if (!(await looksLikeImage(f))) { notImage.push(f.name); continue; }
             const ref = await withTimeout(
@@ -684,9 +773,21 @@ export function createTrainingContent(ctx = {}, shell, opts = {}) {
         // Batch summary PERSISTS (codex finding: per-file errors were cleared
         // by the next success, hiding an incomplete dataset).
         const parts = [];
-        if (skipped) parts.push(`${skipped} skipped (png/jpg/webp only)`);
-        if (notImage.length) parts.push(`${notImage.length} skipped (not a real png/jpg/webp): ${notImage.join(", ")}`);
-        if (failed.length) parts.push(`${failed.length} FAILED: ${failed.join(", ")}`);
+        if (skipped) {
+          parts.push(tr("training_ui.n_skipped_wrong_extension",
+            { one: "{count} skipped (png/jpg/webp only)", other: "{count} skipped (png/jpg/webp only)" },
+            { count: skipped }));
+        }
+        if (notImage.length) {
+          parts.push(tr("training_ui.n_skipped_not_a_real_image",
+            { one: "{count} skipped (not a real png/jpg/webp): {names}", other: "{count} skipped (not a real png/jpg/webp): {names}" },
+            { count: notImage.length, names: notImage.join(", ") }));
+        }
+        if (failed.length) {
+          parts.push(tr("training_ui.n_failed",
+            { one: "{count} FAILED: {names}", other: "{count} FAILED: {names}" },
+            { count: failed.length, names: failed.join(", ") }));
+        }
         status.textContent = parts.join(" · ");
         status.style.color = failed.length || notImage.length ? "#ef4444" : "";
       }
@@ -714,7 +815,11 @@ export function createTrainingContent(ctx = {}, shell, opts = {}) {
   function renderLabel() {
     const sec = el("div", "cmcp-tr-section");
     const bulk = el("div", "cmcp-tr-row");
-    const prefixBtn = el("button", "cmcp-tr-btn", `Prefix "${wiz.trigger || "trigger"}" to all`);
+    const prefixBtn = el("button", "cmcp-tr-btn", tr(
+      "training_ui.prefix_to_all", 'Prefix "{trigger}" to all',
+      // The user's own trigger token is never translated; only the stand-in word is.
+      { trigger: wiz.trigger || tr("training_ui.trigger", "trigger") },
+    ));
     prefixBtn.onclick = () => {
       const t = wiz.trigger.trim();
       if (!t) return;
@@ -725,22 +830,22 @@ export function createTrainingContent(ctx = {}, shell, opts = {}) {
       });
       paint();
     };
-    const applyAllBtn = el("button", "cmcp-tr-btn", "Apply first caption to all");
+    const applyAllBtn = el("button", "cmcp-tr-btn", tr("training_ui.apply_first_caption_to_all", "Apply first caption to all"));
     applyAllBtn.onclick = () => {
       const first = (wiz.images[0]?.caption || "").trim();
       if (!first) return;
       wiz.images.forEach((img) => { img.caption = first; });
       paint();
     };
-    const clearBtn = el("button", "cmcp-tr-btn", "Clear all");
+    const clearBtn = el("button", "cmcp-tr-btn", tr("training_ui.clear_all", "Clear all"));
     clearBtn.onclick = () => { wiz.images.forEach((img) => { img.caption = ""; }); paint(); };
     bulk.append(prefixBtn, applyAllBtn, clearBtn);
     const countHint = el("p", "cmcp-tr-hint");
     const grid = el("div", "cmcp-tr-labelgrid");
     const nav = el("div", "cmcp-tr-row");
-    const back = el("button", "cmcp-tr-btn", "← Dataset");
+    const back = el("button", "cmcp-tr-btn", tr("training_ui.back_dataset", "← Dataset"));
     back.onclick = () => show("wizard-1");
-    const next = el("button", "cmcp-tr-btn primary", "Next: review & launch →");
+    const next = el("button", "cmcp-tr-btn primary", tr("training_ui.next_review_launch", "Next: review & launch →"));
     next.onclick = () => show("wizard-3");
     nav.append(back, next);
     sec.append(bulk, countHint, grid, nav);
@@ -748,7 +853,9 @@ export function createTrainingContent(ctx = {}, shell, opts = {}) {
 
     function syncHint() {
       const captioned = wiz.images.filter((i) => i.caption.trim()).length;
-      countHint.textContent = `${captioned}/${wiz.images.length} captioned — caption what CHANGES between images (pose, setting, clothing); the trigger word covers identity. Empty captions fall back to the trigger word.`;
+      countHint.textContent = tr("training_ui.captioned_caption_what_changes_between_images",
+        "{captioned}/{total} captioned — caption what CHANGES between images (pose, setting, clothing); the trigger word covers identity. Empty captions fall back to the trigger word.",
+        { captioned, total: wiz.images.length });
     }
     function paint() {
       grid.textContent = "";
@@ -763,7 +870,7 @@ export function createTrainingContent(ctx = {}, shell, opts = {}) {
         const thumb = el("div", "thumb");
         thumb.style.backgroundImage = `url("${img.thumb}")`;
         const ta = document.createElement("textarea");
-        ta.placeholder = wiz.trigger ? `${wiz.trigger} …` : "caption…";
+        ta.placeholder = wiz.trigger ? `${wiz.trigger} …` : tr("training_ui.caption", "caption…");
         ta.value = img.caption;
         ta.oninput = () => { img.caption = ta.value; syncHint(); };
         item.append(thumb, ta);
@@ -785,8 +892,10 @@ export function createTrainingContent(ctx = {}, shell, opts = {}) {
       const reuseBox = el("div", "cmcp-tr-card active");
       const rd = wiz.reuseDataset;
       reuseBox.append(el("p", null,
-        `Reusing staged dataset "${rd.name}" — already captioned and staged, so Launch starts training immediately (nothing is re-gathered or re-labeled).`));
-      const changeBtn = el("button", "cmcp-tr-btn", "Use a different dataset");
+        tr("training_ui.reusing_staged_dataset_already_captioned_and_staged",
+          'Reusing staged dataset "{name}" — already captioned and staged, so Launch starts training immediately (nothing is re-gathered or re-labeled).',
+          { name: rd.name })));
+      const changeBtn = el("button", "cmcp-tr-btn", tr("training_ui.use_a_different_dataset", "Use a different dataset"));
       changeBtn.onclick = () => { wiz.reuseDataset = null; show("wizard-1"); };
       reuseBox.appendChild(changeBtn);
       sec.appendChild(reuseBox);
@@ -795,9 +904,22 @@ export function createTrainingContent(ctx = {}, shell, opts = {}) {
     const summaryHint = el("p", "cmcp-tr-hint");
     const syncSummary = () => {
       const effRank = wiz.preset === "custom" ? (wiz.customParams?.rank ?? 16) : (PRESETS[wiz.preset].params?.rank ?? 16);
+      // The optional trigger clause is its own key rather than two near-identical variants
+      // of each sentence — a translator who has to reorder the clause can move `{trigger}`
+      // wherever their grammar wants it.
+      const trigger = wiz.trigger
+        ? tr("training_ui.trigger_clause", ', trigger "{trigger}"', { trigger: wiz.trigger })
+        : "";
+      // `trigger` holds the user's own token and therefore comes LAST in both vars objects
+      // (interpolation-order note near fmtAgo) — otherwise a trigger word of "{rank}" would
+      // be overwritten by the rank on the following substitution.
       summaryHint.textContent = wiz.reuseDataset
-        ? `Job name "${sanitizeNameClient(wiz.datasetName)}" (new run of staged set "${wiz.reuseDataset.name}")${wiz.trigger ? `, trigger "${wiz.trigger}"` : ""}. Model: FLUX.1-dev (quantized, rank ${effRank}).`
-        : `Dataset "${sanitizeNameClient(wiz.datasetName)}" — ${wiz.images.length} images, ${captioned} with custom captions${wiz.trigger ? `, trigger "${wiz.trigger}"` : ""}. Model: FLUX.1-dev (quantized, rank ${effRank}).`;
+        ? tr("training_ui.job_name_new_run_of_staged_set",
+            'Job name "{name}" (new run of staged set "{set}"){trigger}. Model: FLUX.1-dev (quantized, rank {rank}).',
+            { name: sanitizeNameClient(wiz.datasetName), set: wiz.reuseDataset.name, rank: effRank, trigger })
+        : tr("training_ui.dataset_images_with_custom_captions_model_flux",
+            'Dataset "{name}" — {images} images, {captioned} with custom captions{trigger}. Model: FLUX.1-dev (quantized, rank {rank}).',
+            { name: sanitizeNameClient(wiz.datasetName), images: wiz.images.length, captioned, rank: effRank, trigger });
     };
     syncSummary();
     sec.append(summaryHint);
@@ -832,7 +954,15 @@ export function createTrainingContent(ctx = {}, shell, opts = {}) {
     const PARAM_MIN = { resolution: 64 };
     const inBounds = (key, n) => Number.isFinite(n) && n > 0 && n <= PARAM_MAX[key];
     const resInBounds = (list) => !!list && list.every((r) => r >= PARAM_MIN.resolution && r <= PARAM_MAX.resolution);
-    for (const [key, label] of [["steps", "Steps"], ["lr", "Learning rate"], ["rank", "LoRA rank"], ["resolution", "Resolutions (comma)"]]) {
+    // `key` is the WIRE name (train_start's schema) and stays English; `label` is the
+    // visible caption and does not. Built inside the render, so a plain tr() is correct
+    // here — unlike FLOWS/PRESETS at module scope, this runs long after the catalog loads.
+    for (const [key, label] of [
+      ["steps", tr("training_ui.steps", "Steps")],
+      ["lr", tr("training_ui.learning_rate", "Learning rate")],
+      ["rank", tr("training_ui.lora_rank", "LoRA rank")],
+      ["resolution", tr("training_ui.resolutions_comma", "Resolutions (comma)")],
+    ]) {
       const l = el("label", null, label);
       l.style.minWidth = "auto";
       const inp = el("input", null);
@@ -840,8 +970,8 @@ export function createTrainingContent(ctx = {}, shell, opts = {}) {
       inp.dataset.ref = `param:${key}`;
       inp.style.flex = "0 1 110px";
       inp.title = key === "resolution"
-        ? `each ${PARAM_MIN.resolution}–${PARAM_MAX.resolution}`
-        : `max ${PARAM_MAX[key]}`;
+        ? tr("training_ui.each_min_max", "each {min}–{max}", { min: PARAM_MIN.resolution, max: PARAM_MAX.resolution })
+        : tr("training_ui.max_value", "max {max}", { max: PARAM_MAX[key] });
       const saved = wiz.customParams?.[key];
       inp.value = saved !== undefined
         ? (key === "resolution" ? saved.join(",") : String(saved))
@@ -901,11 +1031,13 @@ export function createTrainingContent(ctx = {}, shell, opts = {}) {
     // job runs on (codex finding).
     let targetBtns = [];
     const pre = el("div", "cmcp-tr-preflight");
-    pre.append(el("span", null, "Preflight: checking…"));
+    pre.append(el("span", null, tr("training_ui.preflight_checking", "Preflight: checking…")));
     sec.append(pre);
     const gpuLine = el("p", "cmcp-tr-hint");
     sec.append(gpuLine);
-    fetchGpuLabel(ctx.api).then((gpu) => { if (gpu) gpuLine.textContent = `Local GPU: ${gpu}`; });
+    // The GPU model name itself is an identifier ("RTX 4090 24GB") — only the label around
+    // it is translated.
+    fetchGpuLabel(ctx.api).then((gpu) => { if (gpu) gpuLine.textContent = tr("training_ui.local_gpu", "Local GPU: {gpu}", { gpu }); });
     const myDoctorGen = ++doctorGen;
     callJson(ctx, "train_doctor", { action: "doctor" }, { timeout: 180000 }).then((d) => {
       // A newer doctor (e.g. driveSetTarget's preflight) superseded this one —
@@ -922,9 +1054,10 @@ export function createTrainingContent(ctx = {}, shell, opts = {}) {
         const pod = wiz.podInfo;
         const targetSeg = el("div", "cmcp-tr-seg");
         targetSeg.style.margin = "0";
-        const localBtn = el("button", wiz.target !== "pod" ? "active" : null, "Local (docker)");
+        const localBtn = el("button", wiz.target !== "pod" ? "active" : null, tr("training_ui.local_docker", "Local (docker)"));
         localBtn.dataset.ref = "target:local";
-        const podBtn = el("button", wiz.target === "pod" ? "active" : null, `Pod (${pod.name || pod.id}${pod.gpu ? ` · ${pod.gpu}` : ""})`);
+        const podBtn = el("button", wiz.target === "pod" ? "active" : null,
+          tr("training_ui.pod", "Pod ({pod})", { pod: `${pod.name || pod.id}${pod.gpu ? ` · ${pod.gpu}` : ""}` }));
         podBtn.dataset.ref = "target:pod";
         if (!pod.ssh) podBtn.title = tr("training_ui.pod_has_no_working_ssh_endpoint", "pod has no working SSH endpoint");
         localBtn.onclick = () => { wiz.target = "local"; localBtn.classList.add("active"); podBtn.classList.remove("active"); syncLaunchEnabled(); syncSummary(); };
@@ -943,21 +1076,37 @@ export function createTrainingContent(ctx = {}, shell, opts = {}) {
         if (wiz.launching) targetBtns.forEach((b) => { b.disabled = true; });
         pre.before(targetSeg);
         const podNote = el("p", "cmcp-tr-hint",
-          `Pod training runs ai-toolkit natively ON the pod (no docker there). Fresh pods need a one-time bootstrap (~10 min) — run train_doctor (action:"bootstrap") (or ask the agent) once; it persists on the pod's volume. The pod bills GPU-time while it's up.`);
+          tr("training_ui.pod_training_runs_ai_toolkit_natively_on",
+            `Pod training runs ai-toolkit natively ON the pod (no docker there). Fresh pods need a one-time bootstrap (~10 min) — run train_doctor (action:"bootstrap") (or ask the agent) once; it persists on the pod's volume. The pod bills GPU-time while it's up.`));
         pre.after(podNote);
       }
       pre.textContent = "";
-      const mk = (label, ok) => el("span", null, `${label}: `);
-      for (const [label, ok] of [["docker", dd.docker], ["gpu", dd.gpu], ["image", dd.image], ["hf token", dd.hfTokenSet]]) {
-        const s = el("span");
-        s.innerHTML = `${label}: <b style="color:${ok ? "#22c55e" : "#ef4444"}">${ok ? "✓" : "✗"}</b>`;
+      // Built as DOM nodes rather than an innerHTML template. Same markup, but the label is
+      // now translated text, and interpolating catalog strings into innerHTML would make a
+      // locale file an HTML-injection surface for no benefit — `<b>` is the only tag here.
+      // The colon gets its own key because CJK writes it as "："; the SPACE after it lives
+      // in code, so a translator's editor trimming the value can't glue "docker:" to the ✓.
+      // Keys are prefixed `preflight_` deliberately: "image" alone would reach a translator
+      // as one context-free word and be read as "picture" rather than "the Docker image".
+      for (const [label, ok] of [
+        [tr("training_ui.preflight_docker", "docker"), dd.docker],
+        [tr("training_ui.preflight_gpu", "gpu"), dd.gpu],
+        [tr("training_ui.preflight_image", "image"), dd.image],
+        [tr("training_ui.preflight_hf_token", "hf token"), dd.hfTokenSet],
+      ]) {
+        const s = el("span", null, `${tr("training_ui.preflight_label", "{label}:", { label })} `);
+        const mark = el("b", null, ok ? "✓" : "✗");
+        mark.style.color = ok ? "#22c55e" : "#ef4444";
+        s.appendChild(mark);
         pre.appendChild(s);
       }
+      // `h` is the backend's own hint text — passed through, never translated here.
       (dd.hints || []).forEach((h) => sec.appendChild(el("p", "cmcp-tr-hint", `⚠ ${h}`)));
       if (dd.localFs === false) {
         preflightState = "remote";
         sec.appendChild(el("p", "cmcp-tr-hint",
-          "⚠ The orchestrator targets a REMOTE ComfyUI — dataset staging and the LoRA handoff need a ComfyUI local to the orchestrator's machine; launching from here would fail at staging. Point the orchestrator at this local ComfyUI first."));
+          tr("training_ui.the_orchestrator_targets_a_remote_comfyui_dataset",
+            "⚠ The orchestrator targets a REMOTE ComfyUI — dataset staging and the LoRA handoff need a ComfyUI local to the orchestrator's machine; launching from here would fail at staging. Point the orchestrator at this local ComfyUI first.")));
       } else if (!dd.docker || !dd.gpu || !dd.image) {
         // Missing prerequisites guarantee a rejected/failed run — keep Launch
         // disabled until the doctor passes (codex finding).
@@ -976,7 +1125,9 @@ export function createTrainingContent(ctx = {}, shell, opts = {}) {
       preflightState = "failed";
       syncLaunchEnabled();
       pre.textContent = "";
-      pre.appendChild(el("span", null, `Preflight unavailable: ${e.message}`));
+      // `e.message || e` matches every sibling catch in this file — a non-Error rejection
+      // would otherwise render "Preflight unavailable: undefined".
+      pre.appendChild(el("span", null, tr("training_ui.preflight_unavailable", "Preflight unavailable: {error}", { error: e.message || e })));
     });
 
     // Launch.
@@ -986,9 +1137,9 @@ export function createTrainingContent(ctx = {}, shell, opts = {}) {
     // different view is shown when they return here (codex finding).
     if (wiz.launchError) err.textContent = wiz.launchError;
     const nav = el("div", "cmcp-tr-row");
-    const back = el("button", "cmcp-tr-btn", "← Label");
+    const back = el("button", "cmcp-tr-btn", tr("training_ui.back_label", "← Label"));
     back.onclick = () => show("wizard-2");
-    const launch = el("button", "cmcp-tr-btn primary", "Launch training");
+    const launch = el("button", "cmcp-tr-btn primary", tr("training_ui.launch_training", "Launch training"));
     nav.append(back, launch);
     sec.append(err, nav);
     body.appendChild(sec);
@@ -1008,7 +1159,9 @@ export function createTrainingContent(ctx = {}, shell, opts = {}) {
         || (wiz.target === "pod" ? !podReady : preflightState !== "local" && preflightState !== "failed")
         || !syncCustomValidity();
       if (wiz.launching) launch.textContent = tr("training_ui.launching", "Launching…");
-      else launch.textContent = wiz.target === "pod" ? "Launch on pod" : "Launch training";
+      else launch.textContent = wiz.target === "pod"
+        ? tr("training_ui.launch_on_pod", "Launch on pod")
+        : tr("training_ui.launch_training", "Launch training");
       // Freeze the target choice while launching — the submitted job runs on the
       // target that was selected at click time (codex finding).
       targetBtns.forEach((b) => { b.disabled = wiz.launching; });
@@ -1114,7 +1267,7 @@ export function createTrainingContent(ctx = {}, shell, opts = {}) {
         if (currentView === "wizard-3") {
           err.textContent = wiz.launchError;
         } else {
-          alert(`Training launch failed: ${wiz.launchError}`);
+          alert(tr("training_ui.training_launch_failed", "Training launch failed: {error}", { error: wiz.launchError }));
         }
         syncLaunchEnabled();
       }
@@ -1130,9 +1283,12 @@ export function createTrainingContent(ctx = {}, shell, opts = {}) {
     // only, so a pod run never showed "· pod" while it was running).
     const status = job && typeof job === "object" ? job.status : job;
     const onPod = job && typeof job === "object" && job.target === "pod";
-    badgeEl.textContent = onPod ? `${status} · pod` : status;
+    // `status` stays the raw enum for the class lookup on the next line; only the rendered
+    // text goes through statusLabel().
+    const shown = statusLabel(status);
+    badgeEl.textContent = onPod ? tr("training_ui.status_on_pod", "{status} · pod", { status: shown }) : shown;
     badgeEl.className = `cmcp-tr-badge ${STATUS_BADGE[status] || ""}`;
-    badgeEl.title = onPod ? "Trained on a RunPod pod" : "";
+    badgeEl.title = onPod ? tr("training_ui.trained_on_a_runpod_pod", "Trained on a RunPod pod") : "";
   }
 
   function jobStatusBadge(job) {
@@ -1148,7 +1304,7 @@ export function createTrainingContent(ctx = {}, shell, opts = {}) {
     const myGen = ++pollGen;
     const sec = el("div", "cmcp-tr-section");
     const headRow = el("div", "cmcp-tr-row");
-    const nameEl = el("h3", null, wiz.job?.name || wiz.jobId || "job");
+    const nameEl = el("h3", null, wiz.job?.name || wiz.jobId || tr("training_ui.untitled_job", "job"));
     nameEl.style.margin = "0";
     const badge = el("span", "cmcp-tr-badge", "…");
     headRow.append(nameEl, badge);
@@ -1167,8 +1323,8 @@ export function createTrainingContent(ctx = {}, shell, opts = {}) {
     const metaBox = el("div", "cmcp-tr-section");
     metaBox.style.padding = "0";
     const nav = el("div", "cmcp-tr-row");
-    const cancelBtn = el("button", "cmcp-tr-btn danger", "Cancel run");
-    const jobsNavBtn = el("button", "cmcp-tr-btn", "All jobs");
+    const cancelBtn = el("button", "cmcp-tr-btn danger", tr("training_ui.cancel_run", "Cancel run"));
+    const jobsNavBtn = el("button", "cmcp-tr-btn", tr("training_ui.all_jobs", "All jobs"));
     jobsNavBtn.onclick = () => show("jobs");
     nav.append(cancelBtn, jobsNavBtn);
     sec.append(headRow, barWrap, statLine, samplesLabel, samples, metaBox, resultBox, logBox, nav);
@@ -1195,17 +1351,25 @@ export function createTrainingContent(ctx = {}, shell, opts = {}) {
           p.quantize != null ? (p.quantize ? "quantize on" : "quantize off") : null,
         ].filter(Boolean);
         metaBox.textContent = "";
-        if (bits.length) metaBox.append(el("p", "cmcp-tr-hint", `Settings: ${bits.join(" · ")}`));
+        // `bits` above are built from the train_start parameter names (steps / lr / rank /
+        // res / batch / save / sample / quantize), which the unit spec keeps in English as
+        // wire vocabulary. That leaves a little English prose riding along with them —
+        // "quantize on/off", the trailing "steps" — which is a deliberate consequence of
+        // that rule, not an oversight: splitting each bit into label + value to translate
+        // three words would make a compact one-line settings summary unreadable. Only the
+        // wrapper is translated.
+        if (bits.length) metaBox.append(el("p", "cmcp-tr-hint", tr("training_ui.settings", "Settings: {settings}", { settings: bits.join(" · ") })));
         if (cfg.datasetPath) {
           const dsName = cfg.datasetPath.replace(/\\/g, "/").split("/").pop();
           const dsRow = el("div", "cmcp-tr-row");
-          const dsLink = el("button", "cmcp-tr-btn", `Dataset: ${dsName}`);
-          dsLink.title = `${cfg.datasetPath} — see the labeled set this job trained on`;
+          const dsLink = el("button", "cmcp-tr-btn", tr("training_ui.dataset_link", "Dataset: {name}", { name: dsName }));
+          dsLink.title = tr("training_ui.see_the_labeled_set_this_job_trained",
+            "{path} — see the labeled set this job trained on", { path: cfg.datasetPath });
           dsLink.onclick = () => { wiz.datasetDetail = dsName; show("dataset-detail"); };
-          const againBtn = el("button", "cmcp-tr-btn", "Train again");
+          const againBtn = el("button", "cmcp-tr-btn", tr("training_ui.train_again", "Train again"));
           againBtn.title = tr("training_ui.run_another_job_from_this_dataset_settings", "Run another job from this dataset + settings");
           againBtn.onclick = async () => {
-            if (!resetWizardConfig()) { alert("A launch is still in flight — let it settle (or cancel it from Jobs) before starting a new run."); return; }
+            if (!resetWizardConfig()) { alert(launchInFlightMsg()); return; }
             await checkBackendCapable(); // a Jobs-first entry may never have probed (codex)
             wiz.reuseDataset = { name: dsName, datasetPath: cfg.datasetPath, params: p };
             wiz.datasetName = await uniqueRerunName(cfg.name);
@@ -1226,7 +1390,8 @@ export function createTrainingContent(ctx = {}, shell, opts = {}) {
 
     cancelBtn.onclick = async () => {
       if (!wiz.jobId) return;
-      if (!confirm("Cancel this training run? Saved checkpoints stay in the job's output dir; no LoRA is handed off.")) return;
+      if (!confirm(tr("training_ui.cancel_this_training_run_saved_checkpoints_stay",
+        "Cancel this training run? Saved checkpoints stay in the job's output dir; no LoRA is handed off."))) return;
       cancelBtn.disabled = true;
       try {
         await callJson(ctx, "train_start", { action: "cancel", id: wiz.jobId }, { timeout: 60000 });
@@ -1253,12 +1418,29 @@ export function createTrainingContent(ctx = {}, shell, opts = {}) {
           if (p.step !== undefined && lastStep !== null && p.step > lastStep) {
             const perSec = (Date.now() - lastStepAt) / (p.step - lastStep);
             const left = Math.round(((p.totalSteps - p.step) * perSec) / 1000);
-            if (left > 5) eta = ` · ~${Math.floor(left / 60)}m${left % 60 ? ` ${left % 60}s` : ""} left`;
+            // "12m 30s" is an abbreviated duration, not prose — kept out of the key so a
+            // translator localises "~{time} left" without having to rebuild the clock.
+            if (left > 5) {
+              const time = `${Math.floor(left / 60)}m${left % 60 ? ` ${left % 60}s` : ""}`;
+              eta = tr("training_ui.eta_left", "~{time} left", { time });
+            }
           }
           if (p.step !== lastStep) { lastStep = p.step; lastStepAt = Date.now(); }
-          statLine.textContent = `step ${p.step ?? "—"}/${p.totalSteps}${p.loss !== undefined ? ` · loss ${Number(p.loss).toFixed(4)}` : ""}${eta} · updated ${fmtAgo(job.updatedAt)}`;
+          // Assembled from independent segments joined by a separator this code owns, rather
+          // than one template with " · loss {loss}" style clauses baked into the catalog.
+          // Those clauses would carry LOAD-BEARING leading whitespace, and a translation
+          // tool that trims (most do) would silently glue "step 40/200" to "· loss 0.42"
+          // with nothing in the i18n gate able to see it — it compares placeholders, not
+          // spacing. Renders identically to the template it replaced.
+          const parts = [tr("training_ui.step_of_total", "step {step}/{total}", { step: p.step ?? "—", total: p.totalSteps })];
+          if (p.loss !== undefined) parts.push(tr("training_ui.loss", "loss {loss}", { loss: Number(p.loss).toFixed(4) }));
+          if (eta) parts.push(eta);
+          parts.push(tr("training_ui.updated_ago", "updated {ago}", { ago: fmtAgo(job.updatedAt) }));
+          statLine.textContent = parts.join(" · ");
         } else {
-          statLine.textContent = `${job.status} — model download / dataset caching can take several minutes on first run · updated ${fmtAgo(job.updatedAt)}`;
+          statLine.textContent = tr("training_ui.model_download_dataset_caching_can_take_several",
+            "{status} — model download / dataset caching can take several minutes on first run · updated {ago}",
+            { status: statusLabel(job.status), ago: fmtAgo(job.updatedAt) });
         }
         const s = p.samples || [];
         if (s.length) {
@@ -1271,9 +1453,11 @@ export function createTrainingContent(ctx = {}, shell, opts = {}) {
             samples.appendChild(img);
           }
         } else {
-          samplesLabel.textContent = job.status === "running" ? "Samples appear here as the run produces them." : "";
+          samplesLabel.textContent = job.status === "running"
+            ? tr("training_ui.samples_appear_here_as_the_run_produces", "Samples appear here as the run produces them.")
+            : "";
         }
-        logBox.textContent = (job.log || []).slice(-8).join("\n") || "(no log yet)";
+        logBox.textContent = (job.log || []).slice(-8).join("\n") || tr("training_ui.no_log_yet", "(no log yet)");
         logBox.scrollTop = logBox.scrollHeight;
         const terminal = ["completed", "failed", "cancelled"].includes(job.status);
         cancelBtn.style.display = terminal ? "none" : "";
@@ -1281,20 +1465,33 @@ export function createTrainingContent(ctx = {}, shell, opts = {}) {
         if (job.status === "completed") {
           stopPolling();
           const card = el("div", "cmcp-tr-card active");
-          card.append(el("h3", null, "LoRA ready ✓"));
-          card.append(el("p", null, `${job.result?.loraRelPath || "copied to models/loras"} — in the LoRA picker now. Load it with LoraLoaderModelOnly on FLUX.1-dev${job.trigger ? ` and prompt with "${job.trigger}"` : ""}.`));
+          card.append(el("h3", null, tr("training_ui.lora_ready", "LoRA ready ✓")));
+          // LoraLoaderModelOnly and FLUX.1-dev are node/model identifiers — they stay put
+          // inside the sentence; the user's own trigger token likewise. The separating
+          // space is concatenated here rather than led with inside the catalog value.
+          const prompt = job.trigger
+            ? ` ${tr("training_ui.and_prompt_with", 'and prompt with "{trigger}"', { trigger: job.trigger })}`
+            : "";
+          // `prompt` carries the user's trigger word, so it is substituted LAST — see the
+          // interpolation-order note near fmtAgo.
+          card.append(el("p", null, tr("training_ui.in_the_lora_picker_now_load_it",
+            "{path} — in the LoRA picker now. Load it with LoraLoaderModelOnly on FLUX.1-dev{prompt}.",
+            { path: job.result?.loraRelPath || tr("training_ui.copied_to_models_loras", "copied to models/loras"), prompt })));
           resultBox.appendChild(card);
         } else if (job.status === "failed") {
           stopPolling();
           const card = el("div", "cmcp-tr-card");
-          card.append(el("h3", null, "Run failed"));
+          card.append(el("h3", null, tr("training_ui.run_failed", "Run failed")));
           card.append(el("p", null, (job.error || "").slice(0, 600)));
           resultBox.appendChild(card);
         } else if (job.status === "cancelled") {
           stopPolling();
         }
       } catch (e) {
-        if (myGen === pollGen) statLine.textContent = `status poll failed (bridge?) — retrying… (${e.message || e})`;
+        if (myGen === pollGen) {
+          statLine.textContent = tr("training_ui.status_poll_failed_bridge_retrying",
+            "status poll failed (bridge?) — retrying… ({error})", { error: e.message || e });
+        }
       } finally {
         // Chained (never overlapping) scheduling: the next poll starts only
         // after this one settles — a slow bridge can't stack up requests or
@@ -1312,11 +1509,11 @@ export function createTrainingContent(ctx = {}, shell, opts = {}) {
   async function renderDatasets() {
     const sec = el("div", "cmcp-tr-section");
     const topRow = el("div", "cmcp-tr-row");
-    const backBtn = el("button", "cmcp-tr-btn", "All jobs");
+    const backBtn = el("button", "cmcp-tr-btn", tr("training_ui.all_jobs", "All jobs"));
     backBtn.onclick = () => show("jobs");
     topRow.appendChild(backBtn);
     const list = el("div");
-    list.append(el("p", "cmcp-tr-hint", "Loading datasets…"));
+    list.append(el("p", "cmcp-tr-hint", tr("training_ui.loading_datasets", "Loading datasets…")));
     sec.append(topRow, list);
     body.appendChild(sec);
     let datasets = [];
@@ -1325,20 +1522,24 @@ export function createTrainingContent(ctx = {}, shell, opts = {}) {
       datasets = d.datasets || [];
     } catch (e) {
       list.textContent = "";
-      list.append(el("p", "cmcp-tr-hint", `Could not load datasets: ${e.message || e}`));
+      list.append(el("p", "cmcp-tr-hint", tr("training_ui.could_not_load_datasets", "Could not load datasets: {error}", { error: e.message || e })));
       return;
     }
     list.textContent = "";
     if (!datasets.length) {
-      list.append(el("p", "cmcp-tr-hint", "No staged datasets yet — gather images in a new character LoRA run."));
+      list.append(el("p", "cmcp-tr-hint", tr("training_ui.no_staged_datasets_yet_gather_images_in", "No staged datasets yet — gather images in a new character LoRA run.")));
       return;
     }
     for (const ds of datasets) {
       const row = el("div", "cmcp-tr-jobrow");
       row.dataset.ref = `dataset:${ds.name}`;
       const name = el("span", "name", ds.name);
+      // The hand-rolled `image${n === 1 ? "" : "s"}` is exactly what the plural fallback
+      // replaces: it is right in English and wrong in ko (no plural) and ru (four forms).
       const meta = el("span", "meta",
-        `${ds.imageCount} image${ds.imageCount === 1 ? "" : "s"} · ${ds.captionedCount} captioned · ${fmtAgo(ds.modified)}`);
+        tr("training_ui.n_images_captioned_modified",
+          { one: "{count} image · {captioned} captioned · {ago}", other: "{count} images · {captioned} captioned · {ago}" },
+          { count: ds.imageCount, captioned: ds.captionedCount, ago: fmtAgo(ds.modified) }));
       row.append(name, meta);
       row.onclick = () => { wiz.datasetDetail = ds.name; show("dataset-detail"); };
       list.appendChild(row);
@@ -1351,12 +1552,12 @@ export function createTrainingContent(ctx = {}, shell, opts = {}) {
     const name = wiz.datasetDetail;
     const sec = el("div", "cmcp-tr-section");
     const topRow = el("div", "cmcp-tr-row");
-    const backBtn = el("button", "cmcp-tr-btn", "All datasets");
+    const backBtn = el("button", "cmcp-tr-btn", tr("training_ui.all_datasets", "All datasets"));
     backBtn.onclick = () => show("datasets");
     topRow.appendChild(backBtn);
-    const head = el("h3", null, name || "dataset");
+    const head = el("h3", null, name || tr("training_ui.untitled_dataset", "dataset"));
     head.style.margin = "0";
-    const sub = el("p", "cmcp-tr-hint", "Loading…");
+    const sub = el("p", "cmcp-tr-hint", tr("training_ui.loading", "Loading…"));
     const grid = el("div", "cmcp-tr-samples");
     sec.append(topRow, head, sub, grid);
     body.appendChild(sec);
@@ -1364,10 +1565,12 @@ export function createTrainingContent(ctx = {}, shell, opts = {}) {
     try {
       d = await callJson(ctx, "train_prepare_dataset", { action: "detail", name }, { timeout: 30000 });
     } catch (e) {
-      sub.textContent = `Could not load dataset: ${e.message || e}`;
+      sub.textContent = tr("training_ui.could_not_load_dataset", "Could not load dataset: {error}", { error: e.message || e });
       return;
     }
-    sub.textContent = `${d.imageCount} images · ${d.captionedCount} captioned · ${d.datasetPath}`;
+    sub.textContent = tr("training_ui.n_images_captioned_path",
+      { one: "{count} image · {captioned} captioned · {path}", other: "{count} images · {captioned} captioned · {path}" },
+      { count: d.imageCount, captioned: d.captionedCount, path: d.datasetPath });
     grid.textContent = "";
     // Thumbs ride train_prepare_dataset (action:"file") for inline bytes — NOT
     // the /training/file py route: that route only serves files under the
@@ -1385,7 +1588,7 @@ export function createTrainingContent(ctx = {}, shell, opts = {}) {
     for (const it of d.items || []) {
       const cell = el("div");
       cell.style.maxWidth = "180px";
-      const cap = el("p", "cmcp-tr-hint", it.caption || "(no caption)");
+      const cap = el("p", "cmcp-tr-hint", it.caption || tr("training_ui.no_caption", "(no caption)"));
       cap.style.fontSize = "11px";
       cell.appendChild(cap);
       grid.appendChild(cell);
@@ -1403,10 +1606,10 @@ export function createTrainingContent(ctx = {}, shell, opts = {}) {
     // Train again with THIS staged set: skip the gather/label staging entirely
     // (train_start takes datasetPath directly). Prefill a distinct job name so
     // the new run can't silently overwrite the previous LoRA.
-    const trainBtn = el("button", "cmcp-tr-btn primary", "Train with this dataset");
+    const trainBtn = el("button", "cmcp-tr-btn primary", tr("training_ui.train_with_this_dataset", "Train with this dataset"));
     trainBtn.dataset.ref = "train_with_dataset";
     trainBtn.onclick = async () => {
-      if (!resetWizardConfig()) { alert("A launch is still in flight — let it settle (or cancel it from Jobs) before starting a new run."); return; }
+      if (!resetWizardConfig()) { alert(launchInFlightMsg()); return; }
       await checkBackendCapable(); // a Datasets-first entry may never have probed (codex)
       wiz.reuseDataset = { name: d.name, datasetPath: d.datasetPath };
       wiz.datasetName = await uniqueRerunName(d.name);
@@ -1419,14 +1622,14 @@ export function createTrainingContent(ctx = {}, shell, opts = {}) {
   async function renderJobs() {
     const sec = el("div", "cmcp-tr-section");
     const topRow = el("div", "cmcp-tr-row");
-    const newBtn = el("button", "cmcp-tr-btn primary", "New character LoRA");
+    const newBtn = el("button", "cmcp-tr-btn primary", tr("training_ui.new_character_lora", "New character LoRA"));
     newBtn.onclick = () => {
-      if (!resetWizardConfig()) { alert("A launch is still in flight — let it settle (or cancel it from Jobs) before starting a new run."); return; }
+      if (!resetWizardConfig()) { alert(launchInFlightMsg()); return; }
       show("wizard-1");
     };
     topRow.appendChild(newBtn);
     const list = el("div");
-    list.append(el("p", "cmcp-tr-hint", "Loading jobs…"));
+    list.append(el("p", "cmcp-tr-hint", tr("training_ui.loading_jobs", "Loading jobs…")));
     sec.append(topRow, list);
     body.appendChild(sec);
     let jobs = [];
@@ -1435,12 +1638,12 @@ export function createTrainingContent(ctx = {}, shell, opts = {}) {
       jobs = d.jobs || [];
     } catch (e) {
       list.textContent = "";
-      list.append(el("p", "cmcp-tr-hint", `Could not load jobs: ${e.message || e}`));
+      list.append(el("p", "cmcp-tr-hint", tr("training_ui.could_not_load_jobs", "Could not load jobs: {error}", { error: e.message || e })));
       return;
     }
     list.textContent = "";
     if (!jobs.length) {
-      list.append(el("p", "cmcp-tr-hint", "No training runs yet."));
+      list.append(el("p", "cmcp-tr-hint", tr("training_ui.no_training_runs_yet", "No training runs yet.")));
       return;
     }
     for (const job of jobs) {
@@ -1577,10 +1780,15 @@ export function createTrainingContent(ctx = {}, shell, opts = {}) {
 
   // ── content provider (the shell owns the chrome; this owns the body) ──────
   return {
-    key: "training", label: tr("training_ui.training", "Training"), icon: "pi-bolt", driveKind: "training",
+    key: "training",
+    // Getters, matching TABS in cmcp-sidepanel-ui.js. This object outlives a single render
+    // (the shell holds it and re-reads searchPlaceholder on every syncSearch), so a plain
+    // value would freeze whatever the catalog said when the tab was first opened.
+    get label() { return tr("training_ui.training", "Training"); },
+    icon: "pi-bolt", driveKind: "training",
     // Search filters the outputs grid on the Dataset step only (decision B).
     hasSearch: () => currentView === "wizard-1" && outputsTabActive,
-    searchPlaceholder: "Filter outputs by filename…",
+    get searchPlaceholder() { return tr("training_ui.filter_outputs_by_filename", "Filter outputs by filename…"); },
     subnavExtras: () => [jobsBtn, datasetsBtn],
     mount(bodyEl) { bodyEl.append(stepsBar, body); },
     onActivate() {


### PR DESCRIPTION
Unit 7 of the panel i18n sweep. Targets `feat/panel-i18n`, not `main`.

Every human-facing string in the LoRA Training wizard now goes through
`tr(key, english, vars)`. A user whose ComfyUI is set to Korean stops getting an
English Training tab. 122 new `training_ui.*` keys, all with the English text kept
at the call site — an untranslated key renders exactly what it rendered before.

## Not translated, on purpose

- Model and node identifiers (`FLUX.1-dev`, `Qwen Edit 2509`, `LoraLoaderModelOnly`),
  example tokens (`ohwx`, `aria_character`), and the `train_start` parameter names
  (`steps` / `lr` / `rank` / `res` / `quantize`).
- Error strings thrown by `callJson()` and the `drive*` handlers. The UI renders them
  inside a translated wrapper, but the agent-drive bridge relays them verbatim to the
  agent and into whatever bug report the user pastes them into — making those depend
  on a language setting costs more than it buys. Documented at `callJson` so the two
  treatments read as a decision, not an oversight. **Cross-unit question for the
  coordinator: every unit with an agent-facing throw hits this; worth one policy.**

## Mechanics worth a look in review

- **`FLOWS.desc` uses `get desc()`**, matching `title`. Module scope runs at import
  time, before the catalog loads, so a plain `desc: tr(...)` captures English forever.
  The step-chip labels became a `stepNames()` function for the same reason.
- **The guard for that now covers `desc`.** `browser_tests/unit/i18n.test.mjs`
  enumerates the field names it checks; `desc` was not among them. Verified by
  mutation in both directions: with `desc` in the list, an eager `desc: tr(...)` fails
  the suite; with the old list, the same mutation passes 16/16. The comment states the
  guard's exact scope — it catches the eager form, not a field that stops calling
  `tr()` at all.
- **Plurals.** `image${n === 1 ? "" : "s"}` and `upload(s)` become `{ count }` with
  object fallbacks. Neither hand-rolled form can be right in ru (four categories) or
  ko (one). Where English says the same thing for one and many, both forms are still
  declared — the slots are what the translator needs.
- **Job statuses** render through `statusLabel()`; the raw enum still keys
  `STATUS_BADGE` and the terminal-state test, so only the display changes. Previously
  a Korean user read `running · pod` and `queued — 모델 다운로드…`.
- **The preflight row is DOM nodes, not `innerHTML`.** Same markup (`<b>` + colour),
  but now that the label is catalog text, interpolating it into an HTML template would
  make a locale file an injection surface for the sake of one tag.
- **No catalog value carries load-bearing whitespace.** The progress line is composed
  from segments joined by a code-owned `" · "` rather than a template with
  `" · loss {loss}"` clauses; the preflight colon's trailing space lives in code. A
  translation tool that trims (most do) would otherwise glue words together, and
  `i18n-check` compares placeholders, not spacing. English output is byte-identical.
- **Interpolation order.** `tr()` substitutes one variable at a time over the string
  built so far, so a value containing `{rank}` gets eaten by a later substitution. A
  user whose trigger word is literally `{rank}` saw the LoRA rank in its place. Fixed
  by putting user-typed values last, with the rule documented at the top of the file.
  This is the one behavioural regression the conversion introduced; it is closed.

## Blocker the coordinator needs before this ships translated

`locales/` is untouched, per the brief. But the two are not independent:
`npm run i18n:build` regenerates `locales/en/main.json` from `i18n-extract.mjs`, and
the extractor only matches raw literals in `.textContent =` / `.title =` / `label:`
contexts — it cannot see a string that is already an argument to `tr("key", "English")`.
Measured on this branch: the extractor now reports **0** candidates in
`cmcp-training-ui.js`, so running `i18n:build` would overwrite the catalog with near
nothing and `i18n-check` would then hard-fail every ja/ko/zh file. **The en catalog
needs a generator that reads `tr()` call sites** (including object plural fallbacks,
which the extractor has no concept of) before any unit's keys can actually be
translated. This affects all 7 units, not just this one.

Two smaller notes, left alone deliberately:
- `tr()` supports exactly one counted variable (`vars.count`), so strings with two
  counts (`{count} images · {captioned} captioned`) can only inflect the first.
- Back/next arrows (`← Flows`) are inside the translatable strings, so RTL translators
  must flip the glyph themselves. Matches the existing house style (`"Advanced ▸"`).

## Verification

- `npm run test:unit` — 3707/3707 pass, `i18n-check` reports `locales OK`
- `npm run test:e2e:list` — 68 tests / 29 files discovered; `training-wizard.spec.ts`
  compiles and its English assertions (`Launch training`, `docker:`, `step 40/200`,
  `LoRA ready ✓`) are unchanged
- `npm run typecheck` — clean
- English rendering spot-checked against the original templates through the real
  `tr()`, including the progress line, and the `{rank}`-as-trigger-word case

No live browser run — per the brief, the coordinator does one consolidated pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
