### PR TITLE
feat(i18n): translate the Settings dialog's option labels and section headers

### DIFF
--- a/browser_tests/unit/docs-discoverability.test.mjs
+++ b/browser_tests/unit/docs-discoverability.test.mjs
@@ -41,7 +41,14 @@ test("#111 Settings → About has a docs row that opens the docs site", () => {
   const at = SRC.indexOf('id: "comfyui-mcp.readDocs"');
   assert.notEqual(at, -1, "the About section must have a docs row");
   const row = SRC.slice(at, at + 1200);
-  assert.match(row, /category: cat\("About"/, "it belongs to About, beside Star/Discord/Need-help");
+  // `get category()`, not `category:` — the section label is translated, and the Settings
+  // block is built before the locale catalog loads, so it has to be read lazily (see
+  // browser_tests/unit/i18n.test.mjs). The row's SECTION is what this asserts either way.
+  assert.match(
+    row,
+    /get category\(\)[\s\S]{0,80}?cat\(tr\("panel\.about"/,
+    "it belongs to About, beside Star/Discord/Need-help",
+  );
   // The tooltip names the DESTINATION, never the mechanism. This row renders into
   // ComfyUI's own Settings dialog, outside the sidebar root that wireExternalLinks
   // delegates on, so the anchor's native target=_blank is the whole mechanism —

--- a/browser_tests/unit/i18n.test.mjs
+++ b/browser_tests/unit/i18n.test.mjs
@@ -163,6 +163,159 @@ test("the language setting offers Detect plus every shipped language", () => {
   assert.match(row, /LOCALES\.map/, "options must derive from LOCALES, not a duplicate list");
 });
 
+/**
+ * Read a panel source with line endings NORMALISED. The working tree is CRLF here
+ * (core.autocrlf=true on Windows), so a `\n}\n` boundary silently never matches and every
+ * "is it inside this function?" check quietly widens to the rest of the file — a guard that
+ * still passes, while no longer testing what it names.
+ */
+const readSource = (p) => readFileSync(join(ROOT, p), "utf8").replace(/\r\n/g, "\n");
+
+/**
+ * Slice `function <name>() { ... }` out of a source file, bounded by the closing brace in
+ * column 0. Text-level, because the panel module registers itself on import and cannot be
+ * loaded in node — the same reason the startup test above reads source.
+ */
+function functionBody(src, name) {
+  const at = src.indexOf(`\nfunction ${name}() {`);
+  assert.notEqual(at, -1, `${name}() must still exist`);
+  const rest = src.slice(at + 1);
+  const end = rest.indexOf("\n}\n");
+  assert.notEqual(end, -1, `${name}() must end with a column-0 brace for this scan to be bounded`);
+  const body = rest.slice(0, end);
+  // A scan that silently captured the whole file would pass every "no eager X" check below
+  // for the wrong reason, and fail on unrelated code elsewhere.
+  assert.ok(body.length < src.length / 2, `${name}() scan is unbounded — it captured ${body.length} of ${src.length} chars`);
+  return body;
+}
+
+test("the Settings dialog's own labels are read LAZILY, not when the block is built", () => {
+  // WHY THIS IS NOT THE SAME AS THE MODULE-SCOPE GUARD BELOW: panelSettingsList() is a
+  // FUNCTION, so the usual rule ("inside a function, a plain tr() is fine — it runs after
+  // the catalog loads") reads as satisfied. It is not. This particular function is called
+  // while `app.registerExtension({ settings: panelSettingsList() })` is being constructed —
+  // synchronously, before that same extension's `async setup()` gets to await
+  // loadCatalog(). Anything translated eagerly in here is English for the life of the tab,
+  // and it looks completely correct to an English-reading reviewer.
+  //
+  // ComfyUI re-reads `setting.category` and `setting.options` when the dialog RENDERS
+  // (SettingGroup.vue, SettingItem.vue's `formItem` computed), so getters are both
+  // necessary and sufficient.
+  const src = readSource("web/js/comfyui-mcp-panel.js");
+  const body = functionBody(src, "panelSettingsList");
+
+  const eagerCategories = body.split("\n").filter((l) => /^\s*category:\s/.test(l));
+  assert.deepEqual(
+    eagerCategories,
+    [],
+    "every settings row must use `get category() { return cat(...) }` — a plain `category:` freezes English",
+  );
+
+  const eagerOptions = body.split("\n").filter((l) => /^\s*options:\s/.test(l));
+  assert.deepEqual(
+    eagerOptions,
+    [],
+    "every combo must use `get options() { return [...] }` — a plain `options:` freezes English",
+  );
+
+  // And the getters must actually be there: a block that simply stopped declaring
+  // categories/options would pass both checks above by having nothing to find.
+  assert.ok(
+    (body.match(/get category\(\) \{/g) || []).length >= 20,
+    "the settings rows should still declare their categories, via getters",
+  );
+  assert.ok(
+    (body.match(/get options\(\) \{/g) || []).length >= 4,
+    "the combo rows should still declare their options, via getters",
+  );
+
+  // No combo option may still carry a bare literal label. The getters above make a row
+  // CAPABLE of translating; this is what says every row in it actually does — including the
+  // one-off "Detect (follow ComfyUI)", which no per-setting test would otherwise cover.
+  const bareOptionLabels = body
+    .split("\n")
+    .map((l) => l.trim())
+    .filter((l) => /\{ value: .*, text: "/.test(l));
+  assert.deepEqual(bareOptionLabels, [], "combo option labels must go through tr()");
+
+  // The sub-category label must be read INSIDE the getter. `cat(BACKEND_SECTION.ollama, …)`
+  // written outside one would fire that getter at construction time and re-freeze English —
+  // the failure the getters exist to prevent, reintroduced one level up.
+  for (const line of body.split("\n")) {
+    if (!/BACKEND_SECTION\./.test(line)) continue;
+    assert.match(line, /get category\(\) \{/, `BACKEND_SECTION read outside a getter: ${line.trim()}`);
+  }
+});
+
+test("translating a combo changes only its TEXT, never the value that gets stored", () => {
+  // The one way this whole unit could corrupt data: ComfyUI persists `option.value` and
+  // shows `option.text`, so a translation that reached `value` would write "Ollama (로컬)"
+  // into comfy.settings.json as the backend id. Locked here as an exact list, because the
+  // damage is invisible until a Korean user's panel refuses to connect.
+  const src = readSource("web/js/comfyui-mcp-panel.js");
+  const body = functionBody(src, "panelSettingsList");
+  const at = body.indexOf("id: SETTING_BACKEND");
+  assert.notEqual(at, -1, "the default-backend setting must still exist");
+  const block = body.slice(at, body.indexOf("defaultValue:", at));
+  const values = [...block.matchAll(/\{ value: "([^"]*)", text:/g)].map((m) => m[1]);
+  assert.deepEqual(values, [
+    "claude", "codex", "gemini", "antigravity", "pi", "grok", "kimi", "moonshot",
+    "glm", "minimax", "ollama", "openrouter", "lmstudio", "llamacpp", "custom",
+  ]);
+  // Every one of those labels must go through tr() — a bare string here is a row that
+  // stays English in all 12 languages while its neighbours translate.
+  assert.equal((block.match(/text: tr\(/g) || []).length, values.length);
+});
+
+test("EVERY backend section label is a getter — not most of them", () => {
+  // BACKEND_SECTION deliberately does NOT go in MODULE_SCOPE_CONFIGS below: that guard
+  // looks for `label:`/`title:`-shaped fields and asserts the block contains *a* getter, so
+  // with 15 keys it stays green while 14 of them silently revert to eager strings. Measured
+  // per key instead — the failure this is protecting against is one provider going English,
+  // not the whole table.
+  const src = readSource("web/js/comfyui-mcp-panel.js");
+  const at = src.indexOf("\nconst BACKEND_SECTION = {");
+  assert.notEqual(at, -1, "BACKEND_SECTION must still be declared at module scope");
+  const block = src.slice(at + 1, src.indexOf("\n};", at) + 3);
+
+  const getters = [...block.matchAll(/^\s*get (\w+)\(\) \{ return tr\(/gm)].map((m) => m[1]);
+  assert.deepEqual(getters, [
+    "claude", "codex", "gemini", "antigravity", "pi", "grok", "kimi", "moonshot",
+    "glm", "minimax", "ollama", "openrouter", "lmstudio", "llamacpp", "custom",
+  ], "every backend must resolve its section label lazily, through tr()");
+
+  // Nothing may sneak back in as a plain property: `claude: "Claude"` or `claude: tr(...)`
+  // both evaluate at import time, when the catalog is still empty.
+  const eager = block.split("\n").filter((l) => /^\s*\w+:\s/.test(l));
+  assert.deepEqual(eager, [], "a plain property here is read at import time and freezes English");
+});
+
+test("a settings row's section label is still deferred one level down", () => {
+  // The composition the guard above enforces, proven to behave. `cat()` takes the sub-label
+  // as an ARGUMENT, so the whole point is that the argument is evaluated inside the getter
+  // and not when the row object is built.
+  const BACKEND_SECTION = {
+    get ollama() { return tr("panel.ollama_local", "Ollama (local)"); },
+  };
+  const cat = (sub, name) => [tr("panel.comfy_mcp_agent", "Comfy MCP Agent"), sub, name];
+
+  __setCatalogForTest("ko", {});
+  const row = {
+    id: "comfyui-mcp.ollama.api",
+    get category() { return cat(BACKEND_SECTION.ollama, "Endpoint type"); },
+    get options() { return [{ value: "ollama", text: tr("panel.ollama_local", "Ollama (local)") }]; },
+  };
+  // Built before the catalog exists — exactly when registerExtension() builds the real one.
+  assert.deepEqual(row.category, ["Comfy MCP Agent", "Ollama (local)", "Endpoint type"]);
+
+  __setCatalogForTest("ko", {
+    panel: { comfy_mcp_agent: "Comfy MCP 에이전트", ollama_local: "Ollama (로컬)" },
+  });
+  assert.deepEqual(row.category, ["Comfy MCP 에이전트", "Ollama (로컬)", "Endpoint type"]);
+  assert.equal(row.options[0].text, "Ollama (로컬)");
+  assert.equal(row.options[0].value, "ollama", "the stored value never moves");
+});
+
 test("module-scope config reads translations LAZILY, not at import time", () => {
   // The defect this guards: `const TABS = [{ label: tr("x", "Tabs") }]` at module scope runs
   // at IMPORT time — before setup() awaits loadCatalog() — so it captures the English

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -3081,7 +3081,34 @@ const SETTINGS_SEEDED_KEY = "comfyui-mcp.panel.settingsSeeded";
 // per-backend groups (runs independently of SETTINGS_SEEDED_KEY).
 const SETTINGS_GROUPS_MIGRATED_KEY = "comfyui-mcp.panel.settingsGroupsMigrated";
 // Section (sub-category) labels for the grouped Settings dialog, per backend.
-const BACKEND_SECTION = { claude: "Claude", codex: "ChatGPT (Codex)", gemini: "Gemini", antigravity: "Antigravity (Google)", pi: "Pi (pi.dev)", grok: "Grok", kimi: "Kimi", moonshot: "Kimi K3", glm: "GLM (z.ai)", minimax: "MiniMax", ollama: "Ollama (local)", openrouter: "OpenRouter", lmstudio: "LM Studio (local)", llamacpp: "llama.cpp (local)", custom: "Custom endpoint" };
+//
+// GETTERS, not values. This is module scope: it is evaluated at IMPORT time, long before
+// setup() has awaited loadCatalog(), so a plain `claude: tr(...)` would capture the English
+// fallback permanently and no catalog could ever change it. Reading through a getter defers
+// the lookup to the moment the label is actually needed — which, for every one of these, is
+// when the Settings dialog renders (see the `get category()` accessors in panelSettingsList).
+//
+// PRODUCT NAMES STAY IN LATIN SCRIPT in every language — "Claude", "Gemini", "Ollama",
+// "llama.cpp" are what the vendors call themselves and what a user searches for. Only the
+// parenthetical QUALIFIER ("local", "Google subscription") is translatable, matching the
+// convention already set in locales/ko/main.json ("Ollama (로컬, 무료 …)", "LM Studio (로컬…)").
+const BACKEND_SECTION = {
+  get claude() { return tr("panel.claude", "Claude"); },
+  get codex() { return tr("panel.chatgpt_codex", "ChatGPT (Codex)"); },
+  get gemini() { return tr("panel.gemini", "Gemini"); },
+  get antigravity() { return tr("panel.antigravity_google", "Antigravity (Google)"); },
+  get pi() { return tr("panel.pi_pi_dev", "Pi (pi.dev)"); },
+  get grok() { return tr("panel.grok", "Grok"); },
+  get kimi() { return tr("panel.kimi", "Kimi"); },
+  get moonshot() { return tr("panel.kimi_k3", "Kimi K3"); },
+  get glm() { return tr("panel.glm_z_ai", "GLM (z.ai)"); },
+  get minimax() { return tr("panel.minimax", "MiniMax"); },
+  get ollama() { return tr("panel.ollama_local", "Ollama (local)"); },
+  get openrouter() { return tr("panel.openrouter", "OpenRouter"); },
+  get lmstudio() { return tr("panel.lm_studio_local", "LM Studio (local)"); },
+  get llamacpp() { return tr("panel.llama_cpp_local", "llama.cpp (local)"); },
+  get custom() { return tr("panel.custom_endpoint", "Custom endpoint"); },
+};
 // Backend display names at module scope (the Settings dialog's render-fns live
 // outside buildPanel's closure, so they need their own copy).
 const BACKEND_TEXT = { claude: "Claude", codex: "ChatGPT", gemini: "Gemini", antigravity: "Antigravity", pi: "Pi", grok: "Grok", kimi: "Kimi", moonshot: "Kimi K3", glm: "GLM (z.ai)", minimax: "MiniMax", ollama: "Ollama", openrouter: "OpenRouter", lmstudio: "LM Studio", llamacpp: "llama.cpp", custom: "Custom endpoint" };
@@ -3215,7 +3242,7 @@ function populateModelSelect(sel, backend) {
 function effortComboOptions(backend) {
   const scale = BACKEND_EFFORTS[backend] || ALL_EFFORTS;
   return [
-    { value: "", text: "Model default" },
+    { value: "", text: tr("panel.model_default", "Model default") },
     ...scale.map((id) => ({ value: id, text: effortMeta(id).label })),
   ];
 }
@@ -3427,14 +3454,30 @@ function localComfyuiPathForAgent() {
 // Build the settings list registered on the extension. Defined as a function so
 // it can close over the module-level hooks/helpers above.
 function panelSettingsList() {
-  const cat = (sub, name) => ["Comfy MCP Agent", sub, name];
+  // The Settings dialog's grouping path: [category, subCategory, leaf]. ComfyUI reads only
+  // the first two (settingStore.getSettingInfo) — the third is a tree key nobody renders,
+  // so it stays in English on purpose rather than costing a translation key for nothing.
+  //
+  // WHY EVERY CALL SITE WRAPS THIS IN `get category()`: panelSettingsList() runs while
+  // app.registerExtension(...) is being CONSTRUCTED — synchronously, before the extension's
+  // own async setup() has awaited loadCatalog(). Anything translated eagerly here freezes in
+  // English for the life of the tab. ComfyUI re-reads `setting.category` when the dialog
+  // renders (SettingGroup.vue / useSettingUI.ts), which is always long after the catalog has
+  // landed, so a getter is both sufficient and the only thing that works.
+  const cat = (sub, name) => [tr("panel.comfy_mcp_agent", "Comfy MCP Agent"), sub, name];
   // A BUTTON-type setting: ComfyUI supports a custom `type` render function that
   // returns an HTMLElement (cg-use-everywhere uses the same trick for its About
   // row). We render a button + a masked set/not-set indicator.
-  const tokenSetting = (id, envKey, friendly, sortOrder, section = "API tokens", noun = "token") => ({
+  //
+  // `backendKey` names a BACKEND_SECTION entry rather than passing its label, because a
+  // label argument would read that getter here — at construction time — and re-freeze the
+  // English string the getters exist to avoid. Null means the shared "API tokens" section.
+  const tokenSetting = (id, envKey, friendly, sortOrder, backendKey = null, noun = "token") => ({
     id,
     name: `${friendly} ${noun}`,
-    category: cat(section, friendly),
+    get category() {
+      return cat(backendKey ? BACKEND_SECTION[backendKey] : tr("panel.api_tokens", "API tokens"), friendly);
+    },
     sortOrder,
     tooltip:
       `Securely store your ${friendly} API ${noun}. Opens a masked input; the value goes straight to the ` +
@@ -3500,7 +3543,7 @@ function panelSettingsList() {
   const modelSetting = (backend, sortOrder) => ({
     id: SETTING_MODEL[backend],
     name: "Default model",
-    category: cat(BACKEND_SECTION[backend], "Default model"),
+    get category() { return cat(BACKEND_SECTION[backend], "Default model"); },
     sortOrder,
     tooltip:
       `Default model for the ${BACKEND_TEXT[backend]} background agent, chosen from the models fetched for ` +
@@ -3538,7 +3581,7 @@ function panelSettingsList() {
   const effortSetting = (backend, sortOrder) => ({
     id: SETTING_EFFORT[backend],
     name: "Default reasoning effort",
-    category: cat(BACKEND_SECTION[backend], "Default reasoning effort"),
+    get category() { return cat(BACKEND_SECTION[backend], "Default reasoning effort"); },
     sortOrder,
     tooltip:
       ((BACKEND_EFFORTS[backend] || ALL_EFFORTS).length
@@ -3546,7 +3589,11 @@ function panelSettingsList() {
           `(${backend === "codex" ? "none–ultra" : "low–max"}). 'Model default' leaves it unset.`
         : `${BACKEND_TEXT[backend]} exposes no reasoning-effort control; leave this at 'Model default'.`),
     type: "combo",
-    options: effortComboOptions(backend),
+    // Lazy for the same reason as everything else here — and this one is load-bearing
+    // twice over: effortMeta()'s labels are ALREADY getter-backed (EFFORT_META), so
+    // calling effortComboOptions() eagerly at construction time would read every one of
+    // those getters before the catalog existed and silently undo them.
+    get options() { return effortComboOptions(backend); },
     defaultValue: "",
     onChange: (v) => {
       if (suppressSettingOnChange || !settingsArmed) return;
@@ -3562,7 +3609,7 @@ function panelSettingsList() {
   const bridgeUrlSetting = (backend, sortOrder) => ({
     id: SETTING_BRIDGE_URL[backend],
     name: "Bridge URL",
-    category: cat(BACKEND_SECTION[backend], "Bridge URL"),
+    get category() { return cat(BACKEND_SECTION[backend], "Bridge URL"); },
     sortOrder,
     tooltip:
       `WebSocket URL of the ${BACKEND_TEXT[backend]} panel orchestrator bridge. Default ` +
@@ -3583,7 +3630,7 @@ function panelSettingsList() {
       // trick as the token buttons); no persisted value.
       id: "comfyui-mcp.starGithub",
       name: "Star on GitHub",
-      category: cat("About", "Star on GitHub"),
+      get category() { return cat(tr("panel.about", "About"), "Star on GitHub"); },
       sortOrder: 200,
       tooltip:
         "Enjoying the ComfyUI Agent Panel? A GitHub star genuinely helps. Opens the repo in a new tab.",
@@ -3607,7 +3654,7 @@ function panelSettingsList() {
       // #758 — an in-product route to the release notes, not "go read a file on GitHub".
       id: "comfyui-mcp.whatsNew",
       name: "What's new",
-      category: cat("About", "What's new"),
+      get category() { return cat(tr("panel.about", "About"), "What's new"); },
       sortOrder: 199,
       tooltip:
         "Show recent changes in the panel transcript — what shipped in this version and the ones before it. " +
@@ -3644,7 +3691,7 @@ function panelSettingsList() {
     {
       id: "comfyui-mcp.readDocs",
       name: "Documentation",
-      category: cat("About", "Documentation"),
+      get category() { return cat(tr("panel.about", "About"), "Documentation"); },
       sortOrder: 199.5,
       // Names the DESTINATION, not the mechanism. This row renders into ComfyUI's
       // own Settings dialog, which is OUTSIDE the sidebar root that wireExternalLinks
@@ -3672,7 +3719,7 @@ function panelSettingsList() {
       // A link row — "💬 Join the Discord" (community). Same render-fn pattern.
       id: "comfyui-mcp.joinDiscord",
       name: "Community",
-      category: cat("About", "Community"),
+      get category() { return cat(tr("panel.about", "About"), "Community"); },
       sortOrder: 199,
       tooltip: tr("panel.join_the_comfyui_mcp_discord_announcements_tips", "Join the comfyui-mcp Discord — announcements, tips, and help. Opens in a new tab."),
       type: () => {
@@ -3695,7 +3742,7 @@ function panelSettingsList() {
       // remote pods). Distinct, warmer-colored button so it reads as "support".
       id: "comfyui-mcp.getHelp",
       name: "Need help?",
-      category: cat("About", "Need help?"),
+      get category() { return cat(tr("panel.about", "About"), "Need help?"); },
       sortOrder: 198,
       tooltip:
         "Stuck? This copies a short diagnostics summary (panel version, backend, ComfyUI, OS) to your clipboard and opens the Discord — paste it into your message so we can help fast.",
@@ -3738,7 +3785,7 @@ function panelSettingsList() {
     {
       id: SETTING_BACKEND,
       name: "Default agent backend",
-      category: cat("General", "Default agent backend"),
+      get category() { return cat(tr("panel.general", "General"), "Default agent backend"); },
       sortOrder: 150,
       tooltip:
         "Which background agent the panel connects to by default. Claude runs on your Claude subscription; " +
@@ -3746,23 +3793,34 @@ function panelSettingsList() {
         "panel's backend (and which group below seeds the runtime); you can still switch live in the model " +
         "picker (a live switch is session-only and does NOT change this default).",
       type: "combo",
-      options: [
-        { value: "claude", text: "Claude" },
-        { value: "codex", text: "ChatGPT" },
-        { value: "gemini", text: "Gemini" },
-        { value: "antigravity", text: "Antigravity (Google subscription)" },
-        { value: "pi", text: "Pi (pi.dev · multi-provider CLI)" },
-        { value: "grok", text: "Grok" },
-        { value: "kimi", text: "Kimi" },
-        { value: "moonshot", text: "Kimi K3" },
-        { value: "glm", text: "GLM (z.ai)" },
-        { value: "minimax", text: "MiniMax" },
-        { value: "ollama", text: "Ollama (local)" },
-        { value: "openrouter", text: "OpenRouter (1M · SOTA)" },
-        { value: "lmstudio", text: "LM Studio (local)" },
-        { value: "llamacpp", text: "llama.cpp (local)" },
-        { value: "custom", text: "Custom endpoint (OpenAI-compatible)" },
-      ],
+      // A GETTER for the same reason `category` is one: ComfyUI reads `setting.options`
+      // when the dialog renders (SettingItem.vue's `formItem` computed), so deferring the
+      // lookup is what lets these arrive translated. `value` is the WIRE value and is never
+      // touched — only `text` is displayed, so translating it cannot change what is stored.
+      get options() {
+        return [
+          { value: "claude", text: tr("panel.claude", "Claude") },
+          { value: "codex", text: tr("panel.chatgpt", "ChatGPT") },
+          { value: "gemini", text: tr("panel.gemini", "Gemini") },
+          { value: "antigravity", text: tr("panel.antigravity_google_subscription", "Antigravity (Google subscription)") },
+          // Comma, not the middot this row used to carry: the panel already ships this exact
+          // label — translated in every locale — for the same product elsewhere. Matching it
+          // reuses that translation instead of minting a near-duplicate key whose only
+          // difference is punctuation, which is a string translators would have to be told
+          // apart by eye.
+          { value: "pi", text: tr("panel.pi_pi_dev_multi_provider_cli", "Pi (pi.dev, multi-provider CLI)") },
+          { value: "grok", text: tr("panel.grok", "Grok") },
+          { value: "kimi", text: tr("panel.kimi", "Kimi") },
+          { value: "moonshot", text: tr("panel.kimi_k3", "Kimi K3") },
+          { value: "glm", text: tr("panel.glm_z_ai", "GLM (z.ai)") },
+          { value: "minimax", text: tr("panel.minimax", "MiniMax") },
+          { value: "ollama", text: tr("panel.ollama_local", "Ollama (local)") },
+          { value: "openrouter", text: tr("panel.openrouter_1m_sota", "OpenRouter (1M · SOTA)") },
+          { value: "lmstudio", text: tr("panel.lm_studio_local", "LM Studio (local)") },
+          { value: "llamacpp", text: tr("panel.llama_cpp_local", "llama.cpp (local)") },
+          { value: "custom", text: tr("panel.custom_endpoint_openai_compatible", "Custom endpoint (OpenAI-compatible)") },
+        ];
+      },
       defaultValue: "claude",
       onChange: (v) => {
         if (suppressSettingOnChange || !settingsArmed) return;
@@ -3772,18 +3830,20 @@ function panelSettingsList() {
     {
       id: SETTING_CHAT_SCOPE,
       name: "Chat conversation scope",
-      category: cat("General", "Chat conversation scope"),
+      get category() { return cat(tr("panel.general", "General"), "Chat conversation scope"); },
       sortOrder: 146,
       tooltip:
         "Panel: one conversation follows every canvas. Workflow: each saved workflow has its own persistent set of chats, " +
         "identified by an embedded UUID so renames keep history and copies separate. Ask: choose whether to carry the " +
         "current conversation whenever you switch workflows. All modes survive full ComfyUI/MCP restarts.",
       type: "combo",
-      options: [
-        { value: "panel", text: "Panel — one chat across workflows" },
-        { value: "workflow", text: "Workflow — separate chat histories" },
-        { value: "ask", text: "Ask whenever the workflow changes" },
-      ],
+      get options() {
+        return [
+          { value: "panel", text: tr("panel.panel_one_chat_across_workflows", "Panel — one chat across workflows") },
+          { value: "workflow", text: tr("panel.workflow_separate_chat_histories", "Workflow — separate chat histories") },
+          { value: "ask", text: tr("panel.ask_whenever_the_workflow_changes", "Ask whenever the workflow changes") },
+        ];
+      },
       defaultValue: getSetting(SETTING_SESSION_FOLLOWS_PANEL) === false ? "workflow" : "panel",
       onChange: (v) => {
         if (suppressSettingOnChange || !settingsArmed) return;
@@ -3793,7 +3853,7 @@ function panelSettingsList() {
     {
       id: SETTING_AUTOCONNECT,
       name: "Auto-connect on load",
-      category: cat("General", "Auto-connect on load"),
+      get category() { return cat(tr("panel.general", "General"), "Auto-connect on load"); },
       sortOrder: 145,
       tooltip:
         "Automatically connect the agent (starting the local orchestrator) when the panel opens, without clicking Connect. " +
@@ -3808,7 +3868,7 @@ function panelSettingsList() {
     {
       id: SETTING_LANGUAGE,
       name: "Panel language",
-      category: cat("General", "Panel language"),
+      get category() { return cat(tr("panel.general", "General"), "Panel language"); },
       sortOrder: 146,
       tooltip:
         "Language for the panel's own text. Detect follows ComfyUI's language setting, so changing ComfyUI's " +
@@ -3816,8 +3876,16 @@ function panelSettingsList() {
         "Takes effect when the panel is reopened or reloaded.",
       type: "combo",
       // Same codes and the same self-named labels ComfyUI uses, so the two dropdowns can
-      // never disagree about what "ko" means or read as two different products.
-      options: [{ value: "", text: "Detect (follow ComfyUI)" }, ...LOCALES.map((l) => ({ value: l.code, text: l.text }))],
+      // never disagree about what "ko" means or read as two different products. Only the
+      // Detect row is translated: LOCALES[].text is each language written in ITSELF, which
+      // is the whole point — a user who cannot read the current UI language still finds
+      // their own — so translating those would defeat the list.
+      get options() {
+        return [
+          { value: "", text: tr("panel.detect_follow_comfyui", "Detect (follow ComfyUI)") },
+          ...LOCALES.map((l) => ({ value: l.code, text: l.text })),
+        ];
+      },
       defaultValue: "",
       onChange: (v) => {
         if (suppressSettingOnChange || !settingsArmed) return;
@@ -3831,7 +3899,7 @@ function panelSettingsList() {
     {
       id: SETTING_MOBILE_BETA,
       name: "Control via Mobile app (beta)",
-      category: cat("Mobile app (beta)", "Control via Mobile app (beta)"),
+      get category() { return cat(tr("panel.mobile_app_beta", "Mobile app (beta)"), "Control via Mobile app (beta)"); },
       sortOrder: 144,
       tooltip:
         "Show the Remote-control pairing button (QR) in the panel header and the beta app download links below. " +
@@ -3847,7 +3915,7 @@ function panelSettingsList() {
     {
       id: SETTING_FLAG_APPS,
       name: "Show Apps",
-      category: cat("Features", "Show Apps"),
+      get category() { return cat(tr("panel.features", "Features"), "Show Apps"); },
       sortOrder: 147,
       tooltip:
         "Show the Apps button in the toolbar — the micro-app layer (convert a workflow into a one-click app, " +
@@ -3862,7 +3930,7 @@ function panelSettingsList() {
     {
       id: SETTING_FLAG_TRAINING,
       name: "Show Training",
-      category: cat("Features", "Show Training"),
+      get category() { return cat(tr("panel.features", "Features"), "Show Training"); },
       sortOrder: 148,
       tooltip:
         "Show the Training button in the toolbar — the LoRA training wizard (dataset gather/label/launch/monitor). " +
@@ -3877,7 +3945,7 @@ function panelSettingsList() {
     {
       id: SETTING_FLAG_RUNPOD,
       name: "Show RunPod / Local",
-      category: cat("Features", "Show RunPod / Local"),
+      get category() { return cat(tr("panel.features", "Features"), "Show RunPod / Local"); },
       sortOrder: 149,
       tooltip:
         "Show the RunPod / Local host button in the toolbar — deploy/start/stop/connect a cloud GPU pod, or switch " +
@@ -3895,7 +3963,7 @@ function panelSettingsList() {
       // channel's invite URL constant is still empty.
       id: "comfyui-mcp.mobileAppLinks",
       name: "Get the beta app",
-      category: cat("Mobile app (beta)", "Get the beta app"),
+      get category() { return cat(tr("panel.mobile_app_beta", "Mobile app (beta)"), "Get the beta app"); },
       sortOrder: 143,
       tooltip:
         "Tester downloads for the ComfyUI MCP mobile app. iOS installs via Apple TestFlight; Android via Firebase " +
@@ -3940,7 +4008,7 @@ function panelSettingsList() {
     {
       id: SETTING_UI_SCALE,
       name: "Panel UI scale (%)",
-      category: cat("General", "Panel UI scale (%)"),
+      get category() { return cat(tr("panel.general", "General"), "Panel UI scale (%)"); },
       sortOrder: 143,
       tooltip:
         "Scales the whole Agent sidebar — text, icons and spacing together. Raise it if the panel is hard " +
@@ -3962,7 +4030,7 @@ function panelSettingsList() {
     {
       id: SETTING_STALL_S,
       name: "Render stall warning (seconds)",
-      category: cat("General", "Render stall warning (seconds)"),
+      get category() { return cat(tr("panel.general", "General"), "Render stall warning (seconds)"); },
       sortOrder: 142,
       tooltip:
         "How long a ComfyUI render may make NO progress before the agent is warned its render looks stalled/wedged " +
@@ -3982,7 +4050,7 @@ function panelSettingsList() {
     {
       id: SETTING_REMOTE_URL,
       name: "Remote ComfyUI URL (advanced)",
-      category: cat("General", "Remote ComfyUI URL (advanced)"),
+      get category() { return cat(tr("panel.general", "General"), "Remote ComfyUI URL (advanced)"); },
       sortOrder: 143,
       tooltip:
         "Point the AGENT at a remote ComfyUI instead of this machine — e.g. a RunPod pod at " +
@@ -4004,7 +4072,7 @@ function panelSettingsList() {
       // now the only mode). Advanced: only needed for a non-default port.
       id: SETTING_BRIDGE,
       name: "Bridge URL (advanced)",
-      category: cat("General", "Bridge URL (advanced)"),
+      get category() { return cat(tr("panel.general", "General"), "Bridge URL (advanced)"); },
       sortOrder: 141,
       tooltip:
         "WebSocket URL of the panel orchestrator bridge — ONE bridge now serves every provider " +
@@ -4020,7 +4088,7 @@ function panelSettingsList() {
     {
       id: SETTING_FOCUS_FOLLOW,
       name: "Zoom to agent edits",
-      category: cat("General", "Zoom to agent edits"),
+      get category() { return cat(tr("panel.general", "General"), "Zoom to agent edits"); },
       sortOrder: 140,
       tooltip:
         "When the agent changes a node's value, smoothly zoom the canvas to that node (with padding) so you watch " +
@@ -4071,7 +4139,7 @@ function panelSettingsList() {
     {
       id: SETTING_PREFERRED_MODELS,
       name: "Preferred models",
-      category: cat(BACKEND_SECTION.ollama, "Preferred models"),
+      get category() { return cat(BACKEND_SECTION.ollama, "Preferred models"); },
       sortOrder: 68,
       tooltip:
         "Your own favorite models, comma-separated — Ollama tags (artokun/gemma4-comfyui-mcp:e4b — our ComfyUI fine-tune, gemma4:12b, qwen3:4b) and/or OpenRouter ids " +
@@ -4087,7 +4155,7 @@ function panelSettingsList() {
     {
       id: SETTING_OLLAMA_API,
       name: "Endpoint type",
-      category: cat(BACKEND_SECTION.ollama, "Endpoint type"),
+      get category() { return cat(BACKEND_SECTION.ollama, "Endpoint type"); },
       sortOrder: 66,
       tooltip:
         "How the Ollama backend talks to its endpoint. 'Ollama (local)' uses the native /api/chat on your local " +
@@ -4095,10 +4163,12 @@ function panelSettingsList() {
         "etc. (set the base URL below; the API key comes from the orchestrator's env, e.g. OPENROUTER_API_KEY). " +
         "Applies to NEW sessions — Disconnect then Connect after changing.",
       type: "combo",
-      options: [
-        { value: "ollama", text: "Ollama (local)" },
-        { value: "openai", text: "OpenAI-compatible (OpenRouter, vLLM, …)" },
-      ],
+      get options() {
+        return [
+          { value: "ollama", text: tr("panel.ollama_local", "Ollama (local)") },
+          { value: "openai", text: tr("panel.openai_compatible_openrouter_vllm", "OpenAI-compatible (OpenRouter, vLLM, …)") },
+        ];
+      },
       defaultValue: "ollama",
       onChange: () => {
         if (suppressSettingOnChange || !settingsArmed) return;
@@ -4108,7 +4178,7 @@ function panelSettingsList() {
     {
       id: SETTING_OLLAMA_BASE_URL,
       name: "Endpoint base URL",
-      category: cat(BACKEND_SECTION.ollama, "Endpoint base URL"),
+      get category() { return cat(BACKEND_SECTION.ollama, "Endpoint base URL"); },
       sortOrder: 64,
       tooltip:
         "Base URL for the endpoint above. Leave BLANK for local Ollama (http://127.0.0.1:11434). For " +
@@ -4125,12 +4195,12 @@ function panelSettingsList() {
     modelSetting("openrouter", 62),
     modelSetting("lmstudio", 63),
     modelSetting("llamacpp", 64),
-    tokenSetting(SETTING_TOKEN_OPENROUTER, "OPENROUTER_API_KEY", "OpenRouter", 61, BACKEND_SECTION.openrouter, "API key"),
+    tokenSetting(SETTING_TOKEN_OPENROUTER, "OPENROUTER_API_KEY", "OpenRouter", 61, "openrouter", "API key"),
     // ---- Custom endpoint (issue #162: any OpenAI-compatible server) ----
     {
       id: SETTING_CUSTOM_BASE_URL,
       name: "Endpoint base URL",
-      category: cat(BACKEND_SECTION.custom, "Endpoint base URL"),
+      get category() { return cat(BACKEND_SECTION.custom, "Endpoint base URL"); },
       sortOrder: 60,
       tooltip:
         "Any OpenAI-compatible endpoint — vLLM, DeepSeek, Together, Azure OpenAI, a llama-server on another " +
@@ -4144,7 +4214,7 @@ function panelSettingsList() {
       },
     },
     modelSetting("custom", 59),
-    tokenSetting(SETTING_TOKEN_CUSTOM, "COMFYUI_MCP_CUSTOM_API_KEY", "Custom endpoint", 58, BACKEND_SECTION.custom, "API key"),
+    tokenSetting(SETTING_TOKEN_CUSTOM, "COMFYUI_MCP_CUSTOM_API_KEY", "Custom endpoint", 58, "custom", "API key"),
     // ---- API tokens (LAST) ----
     tokenSetting(SETTING_TOKEN_CIVITAI, "CIVITAI_API_TOKEN", "CivitAI", 20),
     tokenSetting(SETTING_TOKEN_HF, "HUGGINGFACE_TOKEN", "HuggingFace", 15),


### PR DESCRIPTION
Unit 12 — settings options & category labels. Base: `feat/panel-i18n`.

## The research step, and what it found

**ComfyUI DOES support both catalog paths. I still routed through `tr()`. Here is the evidence for both halves, because the first half is a real finding others need.**

Measured against the **installed** frontend, `comfyui_frontend_package/static/assets` @ 1.48.7 (the source checkout at `reference/ComfyUI_frontend` agrees, and is quoted below because it is readable):

**Combo option labels — supported.** `SettingItem.vue`:

```js
function translateOptions(options) {
  return options.map((option) => ({
    text: t(`settings.${normalizeI18nKey(props.setting.id)}.options.${normalizeI18nKey(optionLabel)}`, optionLabel),
    value: optionValue
  }))
}
```

The lookup token is the option's **`text`**, not its `value`, and the second argument is the fallback. So the key would be `settings.comfyui-mcp_defaultBackend.options.Ollama (local)`.

**Category / section labels — supported.** `SettingGroup.vue` renders
`$t('settingsCategories.' + normalizeI18nKey(group.category), group.category)` for the top-level
category and the same for `group.label` (the sub-category), both with the raw label as fallback.
`getSettingInfo` is `category = parts[0]`, `subCategory = parts[1]` — so our `cat(sub, name)`
array's third element is a tree key nobody renders.

**Keys with spaces / parens / slashes are safe**, which was the thing most likely to bite.
`normalizeI18nKey` only maps `.` → `_` (hyphens preserved), and vue-i18n's path parser classifies
0x20 as an *identifier* character, not whitespace — from the shipped bundle:

```js
function getPathCharType(e){ ... case 9: case 10: case 13: case 160: case 65279: case 8232: case 8233: return `w` } return `i` }
```

Upstream relies on this itself: ComfyUI's own `en/settings.json` ships
`Comfy_Canvas_NavigationMode.options["Standard (New)"]` and `["Zoom in/out"]`, translated in
ko/ja/zh. And `src/i18n.ts` has `missingWarn: /^(?!settings\.Comfy_Locale\.options\.).+/` — an
explicit carve-out for the options path, which only exists because that path is live.

**Delivery, which is where it breaks down:**

| what | catalog file | reachable for us? |
|---|---|---|
| `settings.<id>.name` / `.tooltip` | `locales/<lang>/settings.json` | yes — that is unit 11 |
| `settings.<id>.options.<text>` | `locales/<lang>/settings.json`, **nested under the same top-level `<id>` object** | conflicts with unit 11 |
| `settingsCategories.<label>` | **top level of `locales/<lang>/main.json`** | not `settings.json` at all |

`build_translations` (ComfyUI `app/custom_node_manager.py`) maps `settings.json` → the `settings`
namespace and merges `main.json` at the language top level, so `settingsCategories` can only come
from `main.json` — which is generated (`scripts/i18n-build-en.mjs` writes the whole file as
`{ comfyuiMcpPanel: … }`) and which the brief puts off-limits.

And option keys land inside the *same* `{"comfyui-mcp_defaultBackend": {...}}` object unit 11 fills
with `name`/`tooltip`. That is the brief's own tie-breaker — *"if you would be editing the same JSON
objects as unit 11, prefer routing through `tr()`"* — so that is what this does. **Zero locale files
touched: this PR cannot conflict with unit 11.**

The consolation prize is real, though: `tr()` returns its **English fallback** for a locale we don't
ship, and ComfyUI then looks that English string up in `settingsCategories` itself. `About` and
`General` are already in ComfyUI's catalog in all 12 languages, so those two section headers come out
translated in ru/fr/es/… anyway, for free.

## The mechanical half: everything here had to become lazy

`panelSettingsList()` is a function, so the usual rule ("inside a function, a plain `tr()` is fine")
*reads* as satisfied. It isn't. It is called while `app.registerExtension({ settings: panelSettingsList() })`
is being constructed — synchronously, before that same extension's `async setup()` awaits
`loadCatalog()`. Anything translated eagerly in there is English for the life of the tab and looks
completely correct to an English-reading reviewer.

ComfyUI re-reads `setting.category` and `setting.options` when the dialog renders (`buildTree` in
`useSettingUI.ts`, `formItem` in `SettingItem.vue`), and `settingStore.addSetting` stores our object
**by reference** — so getters survive registration and fire at render time. Hence:

- every settings row → `get category() { return cat(...) }` (27 rows)
- every combo → `get options() { return [...] }` (5 combos)
- `BACKEND_SECTION` → 15 getters (module scope: evaluated at *import*)
- `tokenSetting(…, backendKey, …)` now takes a backend **key** instead of a section label, because a
  label argument would read the getter at construction time and re-freeze English one level up

**Latent bug fixed on the way:** `options: effortComboOptions(backend)` was evaluated at construction
time, which read `EFFORT_META`'s already-getter-backed labels before the catalog existed and silently
undid them. Now `get options()`.

## Product names

Latin script in every language — Claude, Gemini, Grok, MiniMax, Ollama, OpenRouter, LM Studio,
llama.cpp. Only the parenthetical qualifier translates ("local", "Google subscription"), matching what
`locales/ko/main.json` already does (`"Ollama (로컬, 무료 — …)"`, `"LM Studio (로컬, 무료)"`).

The Pi row's English changes `·` → `,` so it **reuses** the panel's existing, already-translated
`panel.pi_pi_dev_multi_provider_cli` rather than minting a `_2` key differing only in punctuation.
Five more labels (`panel.claude`, `panel.chatgpt`, `panel.chatgpt_codex`, `panel.gemini`, `panel.grok`,
`panel.kimi`, `panel.antigravity_google_subscription`) reuse existing translated keys as-is.

## ⚠️ Two things the coordinator needs to act on

**1. These 24 keys are new and have no catalog entry yet — in *any* locale, `en` included.** Per the
brief I did not touch `locales/*/main.json`. Until they are added the affected strings render their
English fallback in ko/ja/zh. Paste-ready values below (they nest under `comfyuiMcpPanel.panel`).

| key | en | ko | ja | zh |
|---|---|---|---|---|
| `comfy_mcp_agent` | Comfy MCP Agent | Comfy MCP 에이전트 | Comfy MCP エージェント | Comfy MCP 智能体 |
| `about` | About | 정보 | 情報 | 关于 |
| `general` | General | 일반 | 一般 | 常规 |
| `features` | Features | 기능 | 機能 | 功能 |
| `mobile_app_beta` | Mobile app (beta) | 모바일 앱 (베타) | モバイルアプリ（ベータ） | 移动端应用（测试版） |
| `api_tokens` | API tokens | API 토큰 | API トークン | API 令牌 |
| `antigravity_google` | Antigravity (Google) | Antigravity (Google) | Antigravity（Google） | Antigravity（Google） |
| `pi_pi_dev` | Pi (pi.dev) | Pi (pi.dev) | Pi（pi.dev） | Pi（pi.dev） |
| `kimi_k3` | Kimi K3 | Kimi K3 | Kimi K3 | Kimi K3 |
| `glm_z_ai` | GLM (z.ai) | GLM (z.ai) | GLM（z.ai） | GLM（z.ai） |
| `minimax` | MiniMax | MiniMax | MiniMax | MiniMax |
| `ollama_local` | Ollama (local) | Ollama (로컬) | Ollama（ローカル） | Ollama（本地） |
| `openrouter` | OpenRouter | OpenRouter | OpenRouter | OpenRouter |
| `lm_studio_local` | LM Studio (local) | LM Studio (로컬) | LM Studio（ローカル） | LM Studio（本地） |
| `llama_cpp_local` | llama.cpp (local) | llama.cpp (로컬) | llama.cpp（ローカル） | llama.cpp（本地） |
| `custom_endpoint` | Custom endpoint | 커스텀 엔드포인트 | カスタムエンドポイント | 自定义端点 |
| `openrouter_1m_sota` | OpenRouter (1M · SOTA) | OpenRouter (1M · SOTA) | OpenRouter（1M · SOTA） | OpenRouter（1M · SOTA） |
| `custom_endpoint_openai_compatible` | Custom endpoint (OpenAI-compatible) | 커스텀 엔드포인트 (OpenAI 호환) | カスタムエンドポイント（OpenAI 互換） | 自定义端点（OpenAI 兼容） |
| `panel_one_chat_across_workflows` | Panel — one chat across workflows | 패널 — 워크플로우 전체에서 하나의 대화 | パネル — ワークフロー横断で 1 つのチャット | 面板 — 所有工作流共用一个对话 |
| `workflow_separate_chat_histories` | Workflow — separate chat histories | 워크플로우 — 워크플로우별 대화 기록 | ワークフロー — ワークフローごとのチャット履歴 | 工作流 — 每个工作流独立的对话记录 |
| `ask_whenever_the_workflow_changes` | Ask whenever the workflow changes | 워크플로우가 바뀔 때마다 물어보기 | ワークフローが変わるたびに確認 | 每次切换工作流时询问 |
| `detect_follow_comfyui` | Detect (follow ComfyUI) | 자동 감지 (ComfyUI 따르기) | 自動検出（ComfyUI に従う） | 自动检测（跟随 ComfyUI） |
| `openai_compatible_openrouter_vllm` | OpenAI-compatible (OpenRouter, vLLM, …) | OpenAI 호환 (OpenRouter, vLLM, …) | OpenAI 互換（OpenRouter、vLLM、…） | OpenAI 兼容（OpenRouter、vLLM、…） |
| `model_default` | Model default | 모델 기본값 | モデルのデフォルト | 模型默认值 |

**2. `npm run i18n:build` no longer reproduces the catalog — it destroys it.** I measured this while
deciding where to put keys, and it affects the whole "English is regenerated from code after merge"
plan, not just this unit:

```
$ node scripts/i18n-extract.mjs --json   # 1 candidate
en/main.json today: 246 keys, of which the extractor produces 0
```

`i18n-extract.mjs`'s `UI_CONTEXT` matches `.textContent =`, `label:`, `tooltip:` etc. — the shapes
strings had *before* conversion. Once a literal becomes `tr("panel.x", "X")`, the text preceding it is
`tr("panel.x", ` and no context pattern matches, so the string vanishes from the candidate list.
Re-running `i18n:build` today rewrites `locales/en/main.json` down to **1 key**, after which
`i18n-check` fails with 246 "unknown key" errors against ko/ja/zh. The extractor needs a
`tr\(\s*["']([^"']+)["']\s*,` rule (reading key *and* fallback from the call site) before that
regeneration can be run. Deliberately not fixed here — it is shared tooling and every unit would
conflict on it.

## Also worth knowing

- **Split-locale interaction with unit 11.** Category/section headers follow the *panel's* language
  (`tr()`); names/tooltips will follow *ComfyUI's* locale (unit 11's `settings.json`). They agree
  whenever Panel language is left at its default "Detect", which is the overwhelming case; a user who
  sets the panel to Korean inside an English ComfyUI will see Korean headers over English rows until
  both are catalog-driven.
- **Not live-reactive.** The getters are read by Vue computeds that depend only on `settingsById`, so
  changing Panel language while the dialog is open leaves it in the old language until reload. That
  matches what the Panel-language tooltip already promises ("takes effect when the panel is reopened
  or reloaded").
- **`i18n-check`'s "% translated" will dip.** It counts `tr === en && /[a-z]{4}/` as untranslated, and
  `"MiniMax"`, `"OpenRouter"`, `"Kimi K3"` are correctly identical in every language. The number is
  the wrong thing to optimise here — transliterating a brand name is the failure, not the fix.

## Verification

- `npm run test:unit` — **3711 pass, 0 fail** (includes the Zod locale gate: `locales OK`)
- `npm run typecheck` — clean
- `npm run test:e2e:list` — 68 tests in 29 files (per the brief, no browser run; the coordinator does
  one consolidated pass)
- **Mutation-tested, 9/9 killed.** Each new guard was watched going red on the defect it claims to
  catch, then restored byte-for-byte: eager `category:`, eager `options:` on both the backend and the
  effort combo, `BACKEND_SECTION` read outside a getter, a drifted wire `value`, a de-translated
  option label, the Detect row losing `tr()`, one section getter reverted, and all of them reverted.
  The first pass found two blind guards, both now fixed: the `functionBody()` scan was silently
  unbounded (CRLF working tree, so `\n}\n` never matched and it captured 1.38 MB of the 1.5 MB file),
  and `BACKEND_SECTION` in `MODULE_SCOPE_CONFIGS` stayed green with 14 of 15 keys reverted — it is now
  checked per key against an enumerated list instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
