### PR TITLE
feat(i18n): translate the transcript, media cards, and chat history (unit 4)

### DIFF
--- a/browser_tests/unit/stale-interactive-card.test.mjs
+++ b/browser_tests/unit/stale-interactive-card.test.mjs
@@ -31,16 +31,6 @@ import { tr } from "../../web/js/lib/i18n.js";
 const HERE = dirname(fileURLToPath(import.meta.url));
 const PANEL_JS = join(HERE, "../../web/js/comfyui-mcp-panel.js");
 
-/**
- * Strip the `tr("panel.key", ` prefix from a source excerpt, leaving the English literal.
- *
- * The SOURCE guards here are about which WORDS a card uses — "secret request" rather than
- * the question card's default — not about how those words are looked up. Unwrapping keeps
- * that question the one being asked: change the wording and the assertion still fails;
- * delete the string and it still fails. Only the lookup mechanism is made invisible.
- */
-const unwrapTr = (src) => src.replace(/\btr\(\s*"[\w.]+"\s*,\s*/g, "");
-
 function namedFunctionSource(src, name) {
   const start = src.indexOf(`function ${name}(`);
   if (start === -1) return null;
@@ -164,7 +154,12 @@ test("#952 (codex) a SECRET card is retired too, with secret-safe wording", () =
     /const unregisterSecret = paintedOnSocket == null \? \(\) => \{\} : registerInteractiveCard\(\{/,
     "registered at paint, and ONLY when a command painted it",
   );
-  assert.match(unwrapTr(paint), /what: "secret request"/);
+  // Either the bare literal or the translated form — but if it is translated, the KEY is
+  // pinned too, not just the English. A wildcard key would let `tr("panel.question",
+  // "secret request")` pass while every non-English locale renders the secret card with the
+  // question card's noun: the assertion stays green in the one language the author reads,
+  // and the "secret-safe wording" this test exists for is gone everywhere else.
+  assert.match(paint, /what: (?:tr\("panel\.secret_request",\s*)?"secret request"/);
   assert.match(paint, /Nothing was sent and nothing was stored/, "no false 'saved' impression survives");
   assert.match(paint, /do not paste the value into the chat/, "never redirect a secret into the transcript");
   assert.match(paint, /promise\.then\(unregisterSecret, unregisterSecret\)/);

--- a/browser_tests/unit/stale-interactive-card.test.mjs
+++ b/browser_tests/unit/stale-interactive-card.test.mjs
@@ -22,8 +22,24 @@ import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 
+// The SHIPPED translator, not a stub. No catalog is loaded in this process, which is
+// exactly the state `tr` is designed to survive: every call returns its English fallback
+// with `{holes}` filled. So the wording assertions below still read the English the panel
+// renders, and they still fail if that English changes.
+import { tr } from "../../web/js/lib/i18n.js";
+
 const HERE = dirname(fileURLToPath(import.meta.url));
 const PANEL_JS = join(HERE, "../../web/js/comfyui-mcp-panel.js");
+
+/**
+ * Strip the `tr("panel.key", ` prefix from a source excerpt, leaving the English literal.
+ *
+ * The SOURCE guards here are about which WORDS a card uses — "secret request" rather than
+ * the question card's default — not about how those words are looked up. Unwrapping keeps
+ * that question the one being asked: change the wording and the assertion still fails;
+ * delete the string and it still fails. Only the lookup mechanism is made invisible.
+ */
+const unwrapTr = (src) => src.replace(/\btr\(\s*"[\w.]+"\s*,\s*/g, "");
 
 function namedFunctionSource(src, name) {
   const start = src.indexOf(`function ${name}(`);
@@ -60,7 +76,7 @@ function loadRetire() {
   const document = {
     createElement: () => ({ className: "", style: { cssText: "" }, textContent: "" }),
   };
-  return new Function("document", `${fn}; return retireInteractiveCard;`)(document);
+  return new Function("document", "tr", `${fn}; return retireInteractiveCard;`)(document, tr);
 }
 
 const retire = loadRetire();
@@ -148,7 +164,7 @@ test("#952 (codex) a SECRET card is retired too, with secret-safe wording", () =
     /const unregisterSecret = paintedOnSocket == null \? \(\) => \{\} : registerInteractiveCard\(\{/,
     "registered at paint, and ONLY when a command painted it",
   );
-  assert.match(paint, /what: "secret request"/);
+  assert.match(unwrapTr(paint), /what: "secret request"/);
   assert.match(paint, /Nothing was sent and nothing was stored/, "no false 'saved' impression survives");
   assert.match(paint, /do not paste the value into the chat/, "never redirect a secret into the transcript");
   assert.match(paint, /promise\.then\(unregisterSecret, unregisterSecret\)/);

--- a/web/js/cmcp-a2ui.js
+++ b/web/js/cmcp-a2ui.js
@@ -661,7 +661,12 @@ export function renderA2UIFailCard(rawText, errors) {
   el.appendChild(t);
   const why = document.createElement("div");
   why.className = "cmcp-a2ui-text";
-  why.textContent = (errors && errors.length ? errors.slice(0, 3).join("; ") : "could not render") + " — tap to view raw";
+  // The validator's own `errors` stay in English on purpose — they name spec fields
+  // ("component.type must be a string"), which is the vocabulary of the JSON below, not
+  // prose. Only the two pieces of chrome around them are translated.
+  why.textContent =
+    (errors && errors.length ? errors.slice(0, 3).join("; ") : tr("a2ui.could_not_render", "could not render")) +
+    tr("a2ui.tap_to_view_raw", " — tap to view raw");
   why.style.cursor = "pointer";
   const pre = document.createElement("pre");
   pre.textContent = typeof rawText === "string" ? rawText : JSON.stringify(rawText, null, 2);

--- a/web/js/cmcp-a2ui.js
+++ b/web/js/cmcp-a2ui.js
@@ -664,9 +664,13 @@ export function renderA2UIFailCard(rawText, errors) {
   // The validator's own `errors` stay in English on purpose — they name spec fields
   // ("component.type must be a string"), which is the vocabulary of the JSON below, not
   // prose. Only the two pieces of chrome around them are translated.
-  why.textContent =
-    (errors && errors.length ? errors.slice(0, 3).join("; ") : tr("a2ui.could_not_render", "could not render")) +
-    tr("a2ui.tap_to_view_raw", " — tap to view raw");
+  //
+  // The reason is a `{reason}` HOLE rather than a separate string concatenated onto a
+  // leading " — ". Edge whitespace inside a catalog value is the kind of thing a translator
+  // (or a JSON round-trip) drops silently, and `i18n-check` only validates holes — so the
+  // separator lives in the sentence, where losing it is visible.
+  const reason = errors && errors.length ? errors.slice(0, 3).join("; ") : tr("a2ui.could_not_render", "could not render");
+  why.textContent = tr("a2ui.tap_to_view_raw", "{reason} — tap to view raw", { reason });
   why.style.cursor = "pointer";
   const pre = document.createElement("pre");
   pre.textContent = typeof rawText === "string" ? rawText : JSON.stringify(rawText, null, 2);

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -19921,7 +19921,12 @@ function buildPanel() {
   newMsgBtn.type = "button";
   newMsgBtn.className = "cmcp-newmsg";
   newMsgBtn.hidden = true;
-  newMsgBtn.innerHTML = '<i class="pi pi-arrow-down"></i> New messages';
+  // Icon + text node rather than innerHTML: the label is now catalog-sourced, and a
+  // translated string must never reach an HTML parser — a stray `<` in someone's
+  // translation would silently eat the rest of the pill.
+  const newMsgIcon = document.createElement("i");
+  newMsgIcon.className = "pi pi-arrow-down";
+  newMsgBtn.append(newMsgIcon, document.createTextNode(" " + tr("panel.new_messages", "New messages")));
   newMsgBtn.addEventListener("click", () => {
     stickToBottom = true;
     newMsgBtn.hidden = true;
@@ -21577,13 +21582,22 @@ function buildPanel() {
       historyPersistenceWarningCode = failure?.code || "history-persistence-unavailable";
       appendSystem(
         failure?.code === "history-canonical-unavailable-shadow-truncated"
-          ? "IndexedDB is unavailable. Only the newest 20 chats / 200 entries fit in the " +
-            "localStorage fallback; older history is still in this open tab but is not durably saved. " +
-            "Keep this tab open, restore browser storage, then send or edit once to retry."
+          ? tr(
+              "panel.indexeddb_is_unavailable_only_the_newest_20",
+              "IndexedDB is unavailable. Only the newest 20 chats / 200 entries fit in the " +
+                "localStorage fallback; older history is still in this open tab but is not durably saved. " +
+                "Keep this tab open, restore browser storage, then send or edit once to retry.",
+            )
           : failure?.code === "history-legacy-shadow-unavailable"
-            ? "Some legacy chat history has no IndexedDB copy and could not be saved to localStorage. " +
-              "Keep this tab open, free browser storage, then send or edit once to retry."
-            : "Chat history could not be saved. Keep this tab open, free browser storage, then send or edit once to retry.",
+            ? tr(
+                "panel.some_legacy_chat_history_has_no_indexeddb",
+                "Some legacy chat history has no IndexedDB copy and could not be saved to localStorage. " +
+                  "Keep this tab open, free browser storage, then send or edit once to retry.",
+              )
+            : tr(
+                "panel.chat_history_could_not_be_saved_keep",
+                "Chat history could not be saved. Keep this tab open, free browser storage, then send or edit once to retry.",
+              ),
       );
     },
   });
@@ -22004,6 +22018,19 @@ function buildPanel() {
     }
   }
 
+  /**
+   * "12 nodes" — the workflow-snapshot chip, shown on a user bubble and again on its
+   * history row. Counted, so it goes through the plural path: Russian needs four forms
+   * and Korean one, and `n === 1 ? "node" : "nodes"` is right in neither.
+   *
+   * A `function` declaration, not a `const` arrow: both callers are hoisted painters that
+   * the hydration path can reach before this line runs, and a TDZ error there would blank
+   * a bubble over a chip.
+   */
+  function nodeCountLabel(count) {
+    return tr("panel.nodes", { one: "{count} node", other: "{count} nodes" }, { count: Number(count) || 0 });
+  }
+
   function paintUser(text, opts = {}) {
     clearEmpty();
     const b = document.createElement("div");
@@ -22013,13 +22040,13 @@ function buildPanel() {
       const version = thread?.workflowVersions?.[opts.workflowVersion];
       const badge = document.createElement("span");
       badge.className = "cmcp-workflow-version";
-      badge.title = version?.path || version?.title || "Workflow snapshot";
+      badge.title = version?.path || version?.title || tr("panel.workflow_snapshot", "Workflow snapshot");
       badge.innerHTML = '<i class="pi pi-sitemap"></i>';
       badge.appendChild(
         document.createTextNode(
           version
-            ? `${version.nodeCount} nodes · ${version.hash}`
-            : `workflow · ${opts.workflowVersion}`,
+            ? `${nodeCountLabel(version.nodeCount)} · ${version.hash}`
+            : tr("panel.workflow", "workflow · {version}", { version: opts.workflowVersion }),
         ),
       );
       b.appendChild(badge);
@@ -22143,9 +22170,10 @@ function buildPanel() {
       b.type = "button"; b.className = cls; b.innerHTML = html; if (title) b.title = title;
       return b;
     };
-    const prevBtn = mkBtn("cmcp-lightbox-nav cmcp-lightbox-prev", "‹", "Previous");
-    const nextBtn = mkBtn("cmcp-lightbox-nav cmcp-lightbox-next", "›", "Next");
-    const closeBtn = mkBtn("cmcp-lightbox-close", "✕", "Close (Esc)");
+    // The glyphs are punctuation, not words — only the tooltips are translated.
+    const prevBtn = mkBtn("cmcp-lightbox-nav cmcp-lightbox-prev", "‹", tr("panel.previous", "Previous"));
+    const nextBtn = mkBtn("cmcp-lightbox-nav cmcp-lightbox-next", "›", tr("panel.next", "Next"));
+    const closeBtn = mkBtn("cmcp-lightbox-close", "✕", tr("panel.close_esc", "Close (Esc)"));
     const caption = document.createElement("div");
     caption.className = "cmcp-lightbox-caption";
     const openBtn = document.createElement("button");
@@ -22282,6 +22310,19 @@ function buildPanel() {
    * these same painters.
    */
   function attachMediaCollapse(card, { url, kind, name, tools, onCollapse }) {
+    // FOUR whole sentences rather than `${verb} this ${kind}`. Gluing a verb to a noun
+    // is an English-only sentence shape: German wants "Dieses Bild ausblenden", Korean
+    // "이 이미지 숨기기", and a translator handed the two halves separately cannot reorder
+    // them. Each combination gets its own key so each language writes its own sentence.
+    const showHideTitle = (collapsed) =>
+      collapsed
+        ? kind === "video"
+          ? tr("panel.show_this_video", "Show this video")
+          : tr("panel.show_this_image", "Show this image")
+        : kind === "video"
+          ? tr("panel.hide_this_video", "Hide this video")
+          : tr("panel.hide_this_image", "Hide this image");
+
     const btn = document.createElement("button");
     btn.type = "button";
     btn.className = "cmcp-media-collapse";
@@ -22294,13 +22335,15 @@ function buildPanel() {
     stub.className = "cmcp-media-stub";
     stub.setAttribute("role", "button");
     stub.tabIndex = 0;
-    stub.title = `Show this ${kind}`;
+    stub.title = showHideTitle(true);
     const icon = document.createElement("span");
     icon.setAttribute("aria-hidden", "true");
     icon.textContent = kind === "video" ? "🎬" : "🖼";
     const label = document.createElement("span");
     label.className = "cmcp-media-stub-name";
-    label.textContent = name || (kind === "video" ? "Video" : "Image");
+    // `name` is the agent's own caption/filename and stays exactly as it arrived; only
+    // the generic stand-in when there is no caption is ours to translate.
+    label.textContent = name || (kind === "video" ? tr("panel.video", "Video") : tr("panel.image", "Image"));
     const hint = document.createElement("span");
     hint.textContent = tr("panel.hidden_click_to_show", "· hidden, click to show");
     stub.append(icon, label, hint);
@@ -22309,9 +22352,9 @@ function buildPanel() {
     const apply = (collapsed) => {
       card.classList.toggle("cmcp-media-collapsed", collapsed);
       btn.textContent = collapsed ? "▸" : "▾";
-      const verb = collapsed ? "Show" : "Hide";
-      btn.title = `${verb} this ${kind}`;
-      btn.setAttribute("aria-label", `${verb} this ${kind}`);
+      const title = showHideTitle(collapsed);
+      btn.title = title;
+      btn.setAttribute("aria-label", title);
       btn.setAttribute("aria-expanded", collapsed ? "false" : "true");
       if (collapsed) {
         try {
@@ -22369,7 +22412,7 @@ function buildPanel() {
     const tools = mediaToolsFor(card);
     const img = document.createElement("img");
     img.src = url;
-    img.alt = name || "output";
+    img.alt = name || tr("panel.output", "output"); // read aloud by screen readers
     img.loading = "lazy";
     // NO inline `display` — it would outrank the collapsed rule in the stylesheet
     // and the card would never actually hide (#818). `.cmcp-imgcard > img` sets it.
@@ -22461,8 +22504,11 @@ function buildPanel() {
       // the only one, and the other codes get a narrower sentence that claims no cause.
       const unsupported = v.error?.code === 4;
       holder.textContent = unsupported
-        ? "This browser can't play this video's format. Re-encode as H.264 (yuv420p) or WebM."
-        : "This video could not be loaded.";
+        ? tr(
+            "panel.this_browser_can_t_play_this_video",
+            "This browser can't play this video's format. Re-encode as H.264 (yuv420p) or WebM.",
+          )
+        : tr("panel.this_video_could_not_be_loaded", "This video could not be loaded.");
       holder._preFailCss = holder.style.cssText;
       holder.style.cssText +=
         ";display:grid;place-items:center;padding:1rem;box-sizing:border-box;text-align:center;" +
@@ -22609,7 +22655,7 @@ function buildPanel() {
     a.target = "_blank";
     a.rel = "noopener noreferrer";
     if (name) a.download = name;
-    a.textContent = name || "Open file";
+    a.textContent = name || tr("panel.open_file", "Open file");
     card.appendChild(a);
     const hint = document.createElement("div");
     hint.style.cssText = "font-size:0.625rem;color:var(--p-text-muted-color,#a1a1aa);margin-top:0.25rem;";
@@ -22677,7 +22723,7 @@ function buildPanel() {
     const reply = coerceMessageText(text);
     appendUser(reply, {});
     const ok = client?.sendUserMessage?.(reply);
-    if (!ok) appendSystem("Card reply couldn't be sent — agent disconnected.");
+    if (!ok) appendSystem(tr("panel.card_reply_couldn_t_be_sent_agent", "Card reply couldn't be sent — agent disconnected."));
   }
 
   /**
@@ -22759,7 +22805,7 @@ function buildPanel() {
       }
       log.appendChild(renderA2UIInert(m.spec, m.choice));
     } catch {
-      log.appendChild(renderA2UIFailCard(m?.spec, ["stored card failed to render"]));
+      log.appendChild(renderA2UIFailCard(m?.spec, [tr("panel.stored_card_failed_to_render", "stored card failed to render")]));
     }
   }
 
@@ -22795,7 +22841,8 @@ function buildPanel() {
     }
     const q = document.createElement("div");
     q.style.cssText = "font-weight:600;margin:0.15rem 0 0.5rem;";
-    renderRichText(q, coerceMessageText(msg.question) || "Pick one:");
+    // The agent's own question is never translated — only our stand-in when it sent none.
+    renderRichText(q, coerceMessageText(msg.question) || tr("panel.pick_one", "Pick one:"));
     card.appendChild(q);
 
     const selected = new Set();
@@ -22826,7 +22873,7 @@ function buildPanel() {
       a.textContent = `✓ ${answerText}`;
       card.appendChild(a);
       // Record as a plain card so a reload restores it as static text, not a widget.
-      record({ role: "card", icon: "pi-check", text: questionText || "Choice", detail: answerText });
+      record({ role: "card", icon: "pi-check", text: questionText || tr("panel.choice", "Choice"), detail: answerText });
       scrollLog();
       resolveFn(answer);
     };
@@ -22884,7 +22931,7 @@ function buildPanel() {
     submit.style.cssText =
       "padding:0.35rem 0.7rem;border-radius:6px;border:none;cursor:pointer;font-size:0.8rem;" +
       "background:var(--p-primary-color,#3a7bd5);color:#fff;";
-    submit.textContent = multi ? "Submit" : "Send";
+    submit.textContent = multi ? tr("panel.submit", "Submit") : tr("panel.send", "Send");
     submit.addEventListener("click", () => {
       if (done) return;
       if (other.value.trim()) finish(other.value.trim());
@@ -22970,10 +23017,15 @@ function buildPanel() {
       const note = document.createElement("div");
       note.className = "cmcp-card-stale";
       note.style.cssText = "font-size:0.68rem;opacity:0.8;margin-top:0.4rem;";
+      // `what` and `detail` arrive already translated from the call sites — the caller
+      // knows which kind of card it is, and a `{what}` hole lets each language place the
+      // noun where its grammar wants it rather than mid-sentence as English does.
       note.textContent =
-        `The connection that asked this ${what ?? "question"} dropped, so an answer here can no ` +
-        `longer reach the agent. ` +
-        (detail ?? "If it asked again, answer the newer card.");
+        tr(
+          "panel.the_connection_that_asked_this_dropped_so",
+          "The connection that asked this {what} dropped, so an answer here can no longer reach the agent. ",
+          { what: what ?? tr("panel.question", "question") },
+        ) + (detail ?? tr("panel.if_it_asked_again_answer_the_newer", "If it asked again, answer the newer card."));
       card.appendChild(note);
     } catch {
       /* presentation only — never break a reconnect */
@@ -23001,14 +23053,20 @@ function buildPanel() {
     lock.className = "pi pi-lock";
     const t = document.createElement("span");
     t.style.fontWeight = "600";
-    t.textContent = msg.label || "Paste your token";
+    // `msg.label` / `msg.hint` are the agent's own words and pass through untouched; only
+    // the panel's stand-in for a card that supplied neither is translated.
+    t.textContent = msg.label || tr("panel.paste_your_token", "Paste your token");
     head.append(lock, t);
     card.appendChild(head);
 
     const hint = document.createElement("div");
     hint.style.cssText = "font-size:0.68rem;opacity:0.7;margin:0.2rem 0 0.4rem;";
     hint.textContent =
-      msg.hint || "Sent straight to your config — never shown to the agent and never saved to chat history.";
+      msg.hint ||
+      tr(
+        "panel.sent_straight_to_your_config_never_shown",
+        "Sent straight to your config — never shown to the agent and never saved to chat history.",
+      );
     card.appendChild(hint);
 
     let done = false;
@@ -23057,10 +23115,13 @@ function buildPanel() {
       const ok = document.createElement("div");
       ok.style.cssText = "font-size:0.75rem;color:var(--p-green-400,#4ade80);";
       const m = mask(value);
-      ok.textContent = value ? `🔒 Token saved: ${m}` : "Skipped — no token entered.";
+      ok.textContent = value
+        ? tr("panel.token_saved", "🔒 Token saved: {masked}", { masked: m })
+        : tr("panel.skipped_no_token_entered", "Skipped — no token entered.");
       card.appendChild(ok);
-      // Record ONLY the masked preview — never the full value.
-      record({ role: "card", icon: "pi-lock", text: msg.label || "Token", detail: value ? `saved ${m}` : "skipped" });
+      // Record ONLY the masked preview — never the full value. `detail` stays English:
+      // it is a machine-shaped audit note ("saved ab…yz"), not a sentence.
+      record({ role: "card", icon: "pi-lock", text: msg.label || tr("panel.token", "Token"), detail: value ? `saved ${m}` : "skipped" });
       scrollLog();
       resolveFn(value || "");
     };
@@ -23124,10 +23185,12 @@ function buildPanel() {
       retire: () =>
         retireInteractiveCard(card, {
           alreadyAnswered: () => done,
-          what: "secret request",
-          detail:
+          what: tr("panel.secret_request", "secret request"),
+          detail: tr(
+            "panel.nothing_was_sent_and_nothing_was_stored",
             "Nothing was sent and nothing was stored. Wait for the agent to ask again on " +
-            "the new connection — do not paste the value into the chat.",
+              "the new connection — do not paste the value into the chat.",
+          ),
         }),
     });
     promise.then(unregisterSecret, unregisterSecret);
@@ -23214,8 +23277,8 @@ function buildPanel() {
     if (!statusEl) return;
     statusEl.className = "cmcp-msg-status " + state;
     statusEl.replaceChildren(
-      iconAction("pi-pencil", "Edit — pull back to the composer", () => editMsg(mid)),
-      iconAction("pi-times", "Cancel this message", () => deleteMsg(mid)),
+      iconAction("pi-pencil", tr("panel.edit_pull_back_to_the_composer", "Edit — pull back to the composer"), () => editMsg(mid)),
+      iconAction("pi-times", tr("panel.cancel_this_message", "Cancel this message"), () => deleteMsg(mid)),
     );
   }
 
@@ -23380,7 +23443,7 @@ function buildPanel() {
       if (v.ok) appendA2UICard(v.spec);
       else {
         log.appendChild(renderA2UIFailCard(s.raw, v.errors));
-        record({ role: "card", icon: "pi-exclamation-triangle", text: "Unsupported card", detail: v.errors[0] || "invalid a2ui spec" });
+        record({ role: "card", icon: "pi-exclamation-triangle", text: tr("a2ui.unsupported_card", "Unsupported card"), detail: v.errors[0] || "invalid a2ui spec" });
         scrollLog();
       }
     }
@@ -23502,7 +23565,7 @@ function buildPanel() {
       kickStreams(s);
     } else if (phase === "text") {
       const s = ensureStreamBubble(id);
-      collapseThinking(s, "See thinking"); // reply began → tuck the reasoning away
+      collapseThinking(s, tr("panel.see_thinking", "See thinking")); // reply began → tuck the reasoning away
       s.replyTarget += delta;
       s.replyEl.classList.add("streaming-cursor");
       kickStreams(s);
@@ -23515,7 +23578,7 @@ function buildPanel() {
     animating.delete(s);
     streamBubbles.delete(s.id);
     s.replyEl.classList.remove("streaming-cursor");
-    collapseThinking(s, "See thinking");
+    collapseThinking(s, tr("panel.see_thinking", "See thinking"));
     renderRichText(s.replyEl, s.commitText); // streamed plain text → final markdown
     s.el.classList.remove("streaming");
     record({ role: "agent", text: s.commitText }); // thinking is ephemeral
@@ -23609,9 +23672,17 @@ function buildPanel() {
       box.dataset.testid = 'panel-whats-new';
       const head = document.createElement('div');
       head.className = 'cmcp-whatsnew-head';
+      // Only the heading is ours. The entries below come from changelog.json, which is
+      // written in English at release time and has no translated counterpart to fetch.
       head.textContent = lastSeen
-        ? `Updated to ${PANEL_VERSION} (you were on ${lastSeen}) — what changed:`
-        : `ComfyUI Agent Panel ${PANEL_VERSION} — recent changes:`;
+        ? tr(
+            "panel.updated_to_you_were_on_what_changed",
+            "Updated to {version} (you were on {lastSeen}) — what changed:",
+            { version: PANEL_VERSION, lastSeen },
+          )
+        : tr("panel.comfyui_agent_panel_recent_changes", "ComfyUI Agent Panel {version} — recent changes:", {
+            version: PANEL_VERSION,
+          });
       box.appendChild(head);
       const list = document.createElement('ul');
       list.className = 'cmcp-whatsnew-list';
@@ -23781,7 +23852,11 @@ function buildPanel() {
     if (!followsPanel && !isThreadInScope(t, scopeKey)) {
       detachInvalidCurrentThread({ scopeKey, rebind: true });
       appendSystem(
-        `Blocked a chat from another workflow. Open "${t?.workflowTitle || "its owning workflow"}" before resuming it.`,
+        tr(
+          "panel.blocked_a_chat_from_another_workflow_open",
+          'Blocked a chat from another workflow. Open "{workflow}" before resuming it.',
+          { workflow: t?.workflowTitle || tr("panel.its_owning_workflow", "its owning workflow") },
+        ),
       );
       return false;
     }
@@ -23844,9 +23919,18 @@ function buildPanel() {
     const initial = currentWorkflowId == null;
     if (!initial && chatScopeMode() === "ask") {
       const name = wf?.filename || wfkey || wfid;
+      // Two keys, not one: the OK/Cancel body is the same in both branches of every
+      // future scope prompt, and splitting it keeps the question (which interpolates a
+      // filename) apart from the fixed explanation of the two buttons.
       askModeFollowsPanel = window.confirm(
-        `Continue the current Agent Panel conversation on "${name}"?\n\n` +
-          "OK: carry this chat to the new canvas.\nCancel: open this workflow's separate chat history.",
+        tr("panel.continue_the_current_agent_panel_conversation_on", 'Continue the current Agent Panel conversation on "{name}"?', {
+          name,
+        }) +
+          "\n\n" +
+          tr(
+            "panel.ok_carry_this_chat_to_the_new",
+            "OK: carry this chat to the new canvas.\nCancel: open this workflow's separate chat history.",
+          ),
       );
     }
     const followsPanel = historyScopeFollowsPanel();
@@ -23971,7 +24055,9 @@ function buildPanel() {
             `Your panel_* graph tools operate on THIS graph now; re-read it (panel_graph_outline) before ` +
             `assuming or editing anything, since earlier turns may refer to a different workflow.`,
         );
-        appendSystem(`Canvas → ${name} (same conversation).`);
+        // The armContext line just above is AGENT-facing and stays English; this one is
+        // the transcript note the human reads, so only this one is translated.
+        appendSystem(tr("panel.canvas_same_conversation", "Canvas → {name} (same conversation).", { name }));
       }
       return;
     }
@@ -24069,9 +24155,9 @@ function buildPanel() {
     search.placeholder = tr("panel.search_chats", "Search chats…");
     search.setAttribute("aria-label", tr("panel.search_chat_history", "Search chat history"));
     search.dataset.testid = "history-search";
-    const exportBtn = iconBtn("pi-download", "Export all chat history");
+    const exportBtn = iconBtn("pi-download", tr("panel.export_all_chat_history", "Export all chat history"));
     exportBtn.dataset.testid = "history-export";
-    const importBtn = iconBtn("pi-upload", "Import chat history (merge)");
+    const importBtn = iconBtn("pi-upload", tr("panel.import_chat_history_merge", "Import chat history (merge)"));
     importBtn.dataset.testid = "history-import";
     const currentOnlyLabel = document.createElement("label");
     currentOnlyLabel.className = "cmcp-hist-filter";
@@ -24079,7 +24165,7 @@ function buildPanel() {
     currentOnly.type = "checkbox";
     currentOnly.checked = !historyScopeFollowsPanel();
     currentOnly.dataset.testid = "history-current-workflow";
-    currentOnlyLabel.append(currentOnly, document.createTextNode("Current workflow only"));
+    currentOnlyLabel.append(currentOnly, document.createTextNode(tr("panel.current_workflow_only", "Current workflow only")));
     tools.append(search, exportBtn, importBtn, currentOnlyLabel);
 
     const listEl = document.createElement("div");
@@ -24087,8 +24173,8 @@ function buildPanel() {
     histPop.append(tools, listEl);
 
     function friendlyWorkflowName(t) {
-      if (t.workflowKey === "panel:global") return "Panel-wide conversations";
-      return t.workflowTitle || t.workflowKey?.replace(/^workflow:|^wf:/, "") || "Unknown workflow";
+      if (t.workflowKey === "panel:global") return tr("panel.panel_wide_conversations", "Panel-wide conversations");
+      return t.workflowTitle || t.workflowKey?.replace(/^workflow:|^wf:/, "") || tr("panel.unknown_workflow", "Unknown workflow");
     }
 
     function rowAction(icon, titleText, onClick, extraClass = "") {
@@ -24154,7 +24240,9 @@ function buildPanel() {
         const none = document.createElement("div");
         none.className = "cmcp-sys";
         none.style.padding = "0.75rem";
-        none.textContent = q ? "No chats match this search." : "No past chats in this scope yet.";
+        none.textContent = q
+          ? tr("panel.no_chats_match_this_search", "No chats match this search.")
+          : tr("panel.no_past_chats_in_this_scope_yet", "No past chats in this scope yet.");
         listEl.appendChild(none);
         return;
       }
@@ -24196,13 +24284,13 @@ function buildPanel() {
       const lbl = document.createElement("span");
       lbl.className = "lbl";
       const firstUser = t.msgs.find((m) => m.role === "user");
-      lbl.textContent = (t.title || firstUser?.text || "(no messages)").slice(0, 80);
+      lbl.textContent = (t.title || firstUser?.text || tr("panel.no_messages", "(no messages)")).slice(0, 80);
       const sub = document.createElement("span");
       sub.className = "cmcp-hist-sub";
       const latestVersion = Object.values(t.workflowVersions || {}).sort(
         (a, b) => Number(b.capturedAt || 0) - Number(a.capturedAt || 0),
       )[0];
-      sub.textContent = [t.provider, t.model, latestVersion ? `${latestVersion.nodeCount} nodes · ${latestVersion.hash}` : null]
+      sub.textContent = [t.provider, t.model, latestVersion ? `${nodeCountLabel(latestVersion.nodeCount)} · ${latestVersion.hash}` : null]
         .filter(Boolean)
         .join(" · ");
       meta.append(lbl, sub);
@@ -24219,8 +24307,15 @@ function buildPanel() {
       const legacyReadonly = t.legacyShadow === true;
       if (foreignWorkflow) {
         item.disabled = true;
-        item.title = `Open ${friendlyWorkflowName(t)} before resuming this chat`;
-        item.setAttribute("aria-label", `${lbl.textContent} — open that workflow before resuming`);
+        item.title = tr("panel.open_before_resuming_this_chat", "Open {workflow} before resuming this chat", {
+          workflow: friendlyWorkflowName(t),
+        });
+        item.setAttribute(
+          "aria-label",
+          tr("panel.open_that_workflow_before_resuming", "{title} — open that workflow before resuming", {
+            title: lbl.textContent,
+          }),
+        );
         row.classList.add("foreign-workflow");
       } else if (legacyReadonly) {
         item.disabled = true;
@@ -24233,20 +24328,25 @@ function buildPanel() {
         loadThread(t);
       });
 
-      const pin = rowAction(t.pinned ? "pi-bookmark-fill" : "pi-bookmark", t.pinned ? "Unpin chat" : "Pin chat", () => {
+      const pin = rowAction(t.pinned ? "pi-bookmark-fill" : "pi-bookmark", t.pinned ? tr("panel.unpin_chat", "Unpin chat") : tr("panel.pin_chat", "Pin chat"), () => {
         historyStore.reviseThread(t, { pinned: !t.pinned });
         persistThreads();
         paintList();
       }, t.pinned ? "on" : "");
-      const rename = rowAction("pi-pencil", "Rename chat", () => {
-        const next = window.prompt("Chat title", t.title || firstUser?.text || "New chat");
+      const rename = rowAction("pi-pencil", tr("panel.rename_chat", "Rename chat"), () => {
+        // The PROMPT is translated; the pre-filled default is not. "New chat" is the
+        // title this thread is already STORED under (see the record() path above), so
+        // translating it here would hand the user a different string than the row shows
+        // and write a locale-specific title into IndexedDB on OK.
+        const next = window.prompt(tr("panel.chat_title", "Chat title"), t.title || firstUser?.text || "New chat");
         if (next == null) return;
         historyStore.reviseThread(t, { title: next.trim().slice(0, 160) || null });
         persistThreads();
         paintList();
       });
-      const del = rowAction("pi-trash", "Delete this chat", () => {
-        if (!window.confirm(`Delete chat "${t.title || firstUser?.text || "New chat"}"?`)) return;
+      const del = rowAction("pi-trash", tr("panel.delete_this_chat", "Delete this chat"), () => {
+        const title = t.title || firstUser?.text || "New chat";
+        if (!window.confirm(tr("panel.delete_chat", 'Delete chat "{title}"?', { title }))) return;
         const now = nextHistoryRevision();
         historyMeta.deletedThreads = historyMeta.deletedThreads || {};
         historyMeta.deletedThreads[t.id] = {
@@ -24293,7 +24393,9 @@ function buildPanel() {
         if (!file) return;
         try {
           if (file.size > CHAT_HISTORY_MAX_IMPORT_BYTES) {
-            throw new Error("Chat history import exceeds the 25 MB limit");
+            // Caught two lines below and shown to the user, so this message is UI text
+            // rather than a developer log — hence the translation.
+            throw new Error(tr("panel.chat_history_import_exceeds_the_25_mb", "Chat history import exceeds the 25 MB limit"));
           }
           const currentThreadId = thread?.id;
           const imported = historyStore.importPayload(await file.text(), threads, historyMeta);
@@ -24307,14 +24409,36 @@ function buildPanel() {
           }
           persistThreads();
           paintList();
+          // "chat(s)" / "alias(es)" was English hedging around a count. Both go through
+          // the plural path now, so a language with more (or fewer) forms than English
+          // gets a real sentence instead of a parenthesised suffix it cannot use.
           appendSystem(
-            `Merged ${imported.importedCount || 0} imported chat(s); existing history was preserved.` +
-            (imported.skippedAliasCount
-              ? ` ${imported.skippedAliasCount} extra workflow alias(es) were skipped at the storage limit.`
-              : ""),
+            tr(
+              "panel.merged_imported_chats_existing_history_was_preserved",
+              {
+                one: "Merged {count} imported chat; existing history was preserved.",
+                other: "Merged {count} imported chats; existing history was preserved.",
+              },
+              { count: imported.importedCount || 0 },
+            ) +
+              (imported.skippedAliasCount
+                ? " " +
+                  tr(
+                    "panel.extra_workflow_aliases_were_skipped_at_the",
+                    {
+                      one: "{count} extra workflow alias was skipped at the storage limit.",
+                      other: "{count} extra workflow aliases were skipped at the storage limit.",
+                    },
+                    { count: imported.skippedAliasCount },
+                  )
+                : ""),
           );
         } catch (error) {
-          appendSystem(`History import failed: ${coerceMessageText(error?.message || error)}`);
+          appendSystem(
+            tr("panel.history_import_failed", "History import failed: {error}", {
+              error: coerceMessageText(error?.message || error),
+            }),
+          );
         }
       }, { once: true });
       picker.click();
@@ -24342,9 +24466,13 @@ function buildPanel() {
     clear.addEventListener("click", async () => {
       if (!threads.length) return;
       const confirmed = globalThis.confirm?.(
-        "Clear all Agent Panel chat history from this browser?\n\n" +
-        "This affects every workflow and open ComfyUI tab. It cannot be undone. " +
-        "Your workflows and their stable identities will not be deleted.",
+        tr("panel.clear_all_agent_panel_chat_history_from", "Clear all Agent Panel chat history from this browser?") +
+          "\n\n" +
+          tr(
+            "panel.this_affects_every_workflow_and_open_comfyui",
+            "This affects every workflow and open ComfyUI tab. It cannot be undone. " +
+              "Your workflows and their stable identities will not be deleted.",
+          ),
       );
       if (!confirmed) return;
       clear.disabled = true;
@@ -24355,9 +24483,12 @@ function buildPanel() {
         clearLabel.textContent = tr("panel.clear_all_history", "Clear all history");
         appendSystem(
           result?.code === "history-clear-canonical-unavailable"
-            ? "Chat history could not be cleared because IndexedDB is unavailable or blocked. " +
-              "Close other ComfyUI tabs and retry; in permanent private-storage mode, clear this site's browser data."
-            : "Chat history could not be cleared. Keep this tab open and try again.",
+            ? tr(
+                "panel.chat_history_could_not_be_cleared_because",
+                "Chat history could not be cleared because IndexedDB is unavailable or blocked. " +
+                  "Close other ComfyUI tabs and retry; in permanent private-storage mode, clear this site's browser data.",
+              )
+            : tr("panel.chat_history_could_not_be_cleared_keep", "Chat history could not be cleared. Keep this tab open and try again."),
         );
         return;
       }
@@ -24381,7 +24512,7 @@ function buildPanel() {
       ctxLabel.textContent = "—";
       client?.sendFrame?.({ type: "new_session" });
       histPop.hidden = true;
-      appendSystem("Chat history was cleared from this browser.");
+      appendSystem(tr("panel.chat_history_was_cleared_from_this_browser", "Chat history was cleared from this browser."));
     });
     footer.append(note, clear);
     histPop.appendChild(footer);
@@ -24402,6 +24533,10 @@ function buildPanel() {
   // including silent tool work where nothing posts to the chat — so it never
   // looks idle right before a big reply lands. Whimsical status words cycle so
   // it's clearly alive.
+  // DELIBERATELY NOT TRANSLATED. These are nonsense-word jokes ("Flibbertigibbeting",
+  // "Reticulating splines" — a SimCity gag), and a per-word key would ask a translator to
+  // render a pun they have no source for. A language that wants its own set of jokes needs
+  // its own LIST, not twelve translations of one; that is a bigger change than this pass.
   const WORK_WORDS = [
     "Flibbertigibbeting",
     "Reticulating splines",
@@ -24509,11 +24644,14 @@ function buildPanel() {
     // words. A running tool clears the token meter (setThinkingAction), so the
     // action label wins during silent tool phases rather than a stale count.
     let base;
-    if (thinkingReconnecting) base = "Reconnecting… (turn still running)";
-    else if (thinkingTokens > 0) base = `Thinking… (${fmtThinkTokens(thinkingTokens)} tokens)`;
+    if (thinkingReconnecting) base = tr("panel.reconnecting_turn_still_running", "Reconnecting… (turn still running)");
+    else if (thinkingTokens > 0)
+      // NOT the plural path: `tokens` here is always a formatted string ("1.4k"), not a
+      // number, so there is no count for Intl to categorise.
+      base = tr("panel.thinking_tokens", "Thinking… ({tokens} tokens)", { tokens: fmtThinkTokens(thinkingTokens) });
     else if (thinkingAction) base = thinkingAction;
     else base = `${WORK_WORDS[workWordIdx % WORK_WORDS.length]}…`;
-    thinkingLabel.textContent = `${base} (Esc or Ctrl+C to stop)`;
+    thinkingLabel.textContent = tr("panel.esc_or_ctrl_c_to_stop", "{status} (Esc or Ctrl+C to stop)", { status: base });
     workWordIdx += 1;
   }
   // Live extended-thinking token meter (from the orchestrator's thinking frame).
@@ -24532,7 +24670,9 @@ function buildPanel() {
     let s = String(name || "").trim();
     s = s.split(".").pop() || s; // drop a "panel." (etc.) namespace prefix
     s = s.replace(/^panel_/, "").replace(/_/g, " ").trim();
-    return s ? `Using ${s}…` : "Working…";
+    // `{tool}` stays English — it is a tool NAME off the wire ("query graph"), and there
+    // is no catalog of tool names to translate it against. The frame around it is ours.
+    return s ? tr("panel.using", "Using {tool}…", { tool: s }) : tr("panel.working", "Working…");
   }
   function setThinkingAction(name) {
     thinkingAction = humanizeAction(name);
@@ -24972,7 +25112,7 @@ function buildPanel() {
         log.appendChild(renderA2UIFailCard(msg.spec, v.errors));
         scrollLog();
         // Record a plain card so the fail chip survives reload (matches the fence path).
-        record({ role: "card", icon: "pi-exclamation-triangle", text: "Unsupported card", detail: v.errors[0] || "invalid a2ui spec" });
+        record({ role: "card", icon: "pi-exclamation-triangle", text: tr("a2ui.unsupported_card", "Unsupported card"), detail: v.errors[0] || "invalid a2ui spec" });
         throw new Error(`invalid a2ui spec: ${v.errors.slice(0, 5).join("; ")}`);
       }
       const card_id = appendA2UICard(v.spec);

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -23020,12 +23020,19 @@ function buildPanel() {
       // `what` and `detail` arrive already translated from the call sites — the caller
       // knows which kind of card it is, and a `{what}` hole lets each language place the
       // noun where its grammar wants it rather than mid-sentence as English does.
-      note.textContent =
+      //
+      // The two sentences are JOINED here rather than the first one carrying a trailing
+      // space. Edge whitespace in a catalog value is silently droppable and `i18n-check`
+      // only validates holes, so a translator who trimmed it would glue two sentences
+      // together with no way to see why.
+      note.textContent = [
         tr(
           "panel.the_connection_that_asked_this_dropped_so",
-          "The connection that asked this {what} dropped, so an answer here can no longer reach the agent. ",
+          "The connection that asked this {what} dropped, so an answer here can no longer reach the agent.",
           { what: what ?? tr("panel.question", "question") },
-        ) + (detail ?? tr("panel.if_it_asked_again_answer_the_newer", "If it asked again, answer the newer card."));
+        ),
+        detail ?? tr("panel.if_it_asked_again_answer_the_newer", "If it asked again, answer the newer card."),
+      ].join(" ");
       card.appendChild(note);
     } catch {
       /* presentation only — never break a reconnect */
@@ -24338,6 +24345,12 @@ function buildPanel() {
         // title this thread is already STORED under (see the record() path above), so
         // translating it here would hand the user a different string than the row shows
         // and write a locale-specific title into IndexedDB on OK.
+        //
+        // Not the same case as a `record({ text })` card entry, which IS translated at the
+        // point it is written: a transcript row is a record of what was ON SCREEN at that
+        // moment, and freezing its language is correct. A thread TITLE is live metadata
+        // re-rendered on every repaint, so a frozen one goes stale the moment the user
+        // switches language.
         const next = window.prompt(tr("panel.chat_title", "Chat title"), t.title || firstUser?.text || "New chat");
         if (next == null) return;
         historyStore.reviseThread(t, { title: next.trim().slice(0, 160) || null });


### PR DESCRIPTION
Unit 4 of the panel i18n pass, on top of `feat/panel-i18n`. Everything a person reads in the message feed now goes through `tr(key, english)`: the transcript, the media cards and lightbox, the a2ui fail chip, the interactive question and secret cards, the chat-history popover, and the working indicator. **78 new keys**, all `panel.*` except two `a2ui.*`. No file under `locales/` was touched.

## ⚠️ Blocker for the whole i18n effort, not just this unit

**These 78 keys exist in no catalog, and the generator that would add them is broken.** `scripts/i18n-build-en.mjs` builds `locales/en/main.json` from `scripts/i18n-extract.mjs`, which matches **raw** literals in UI contexts (`/\.textContent\s*=\s*$/` and friends). A wrapped call no longer matches that anchor, so as strings get converted they *leave* the extractor's output:

```
$ node scripts/i18n-extract.mjs
1 candidates (1 distinct keys)
```

One candidate for the whole tree. Running `npm run i18n:build` today would rewrite `en/main.json` down to 1 key, after which `npm run i18n:check` fails hard — ja/ko/zh carry 246 keys the `.strict()` schema would then reject. The regression started in unit 1; this is just where it becomes load-bearing, because there is now no automated way to add keys and the build script's own header forbids hand-editing English.

Until that is fixed, **every unit in this effort ships zero user-visible translation** — each `tr()` falls back to its English argument, which is why the whole suite is green and why nothing catches it (`i18n-check` validates translations *against* en; it never checks code against en).

Also needed once the extractor understands `tr()`: **object-fallback plurals**. This unit adds three plural bases (`panel.nodes`, `panel.merged_imported_chats_existing_history_was_preserved`, `panel.extra_workflow_aliases_were_skipped_at_the`) which need `_one`/`_other` in English and per-CLDR categories elsewhere. `en/main.json` currently contains no plural keys at all.

## ⚠️ Overlap with unit 10 in `web/js/cmcp-a2ui.js`

Unit 10 appears to be converting the same two a2ui strings under the **same keys** (`a2ui.could_not_render`, `a2ui.tap_to_view_raw`). Mine are:

- `a2ui.could_not_render` = `"could not render"`
- `a2ui.tap_to_view_raw` = `"{reason} — tap to view raw"`

If unit 10's English for `a2ui.tap_to_view_raw` differs, `i18n-build-en.mjs` exits 1 with `key collision` — loud, not silent, but pick one deliberately rather than merging both.

## Three shapes that needed more than a wrapper

**Counted strings go through the plural path** with an object fallback. `"N nodes"`, `"Merged N imported chat(s)"` and `"N workflow alias(es)"` were English hedging around a number; Russian needs four forms and Korean one, and a parenthesised `(s)` is useless to both.

**`Show this ${kind}` became four whole sentences** (`show_this_image` / `show_this_video` / `hide_this_image` / `hide_this_video`). Gluing a verb to a noun is an English-only sentence shape — German wants *"Dieses Bild ausblenden"*, Korean *"이 이미지 숨기기"* — and a translator handed the two halves separately cannot reorder them. `kind` is only ever `"image"` or `"video"`, so the binary split loses nothing.

**The "New messages" pill stopped using `innerHTML`.** Its label is catalog-sourced now, and a translated string must not reach an HTML parser — a stray `<` would eat the rest of the pill. Icon element + text node instead; same DOM, same text.

## Deliberately left in English

| What | Why |
|---|---|
| `[panel] The user switched the open workflow…` | `armContext` — injected into the **model's** context, never shown |
| `[Workspace context: this chat is dedicated to…]` | same |
| `throw new Error(…)` in the bridge command handlers | become command replies to the agent, not UI |
| `console.info` / `console.warn` diagnostics | developer output |
| the a2ui validator's own `errors[]` | they name spec fields (`component.type must be a string`) — the vocabulary of the JSON below, not prose |
| `WORK_WORDS` (`"Flibbertigibbeting"`, `"Reticulating splines"`) | nonsense jokes with no source for a translator to render. A language that wants its own set needs its own **list**, not twelve translations of one — a bigger change than this pass. |
| the stored `"New chat"` thread title | it is **data**. Translating it writes a locale-specific title into IndexedDB that renders wrong after a language switch. The prompt *label* above it **is** translated. |

## AMBIGUOUS / not covered

Inside the 21600–25100 range but left alone, flagged so they are assigned rather than forgotten:

- **`~25188` `"Pairing failed"`** and **`~25200` the `🔒 {provider} token saved…` / `Couldn't save the {provider} key` system messages** — these read as unit 1 (credentials / remote pairing) rather than transcript. Just past the range boundary.
- **`~19710` `appendSystem("Command copied.")`** in the provider-onboarding block — onboarding, likely unit 1.
- **`renderRichText(q, … || tr("panel.pick_one", "Pick one:"))`** is the one translated string that reaches an HTML parser. It goes through `marked` + `DOMPurify`, so it is not an injection path, but a translation containing `*`, `_`, `#` or `[` will render as markdown. Deliberate — that element renders the agent's own markdown question — but worth knowing.

## English rendering changes

Byte-identical everywhere except the intentional plural fixes:

- `nodeCountLabel(1)` → `"1 node"` (was `"1 nodes"`); a null/undefined `nodeCount` → `"0 nodes"` (was `"undefined nodes"`)
- `"Merged 1 imported chat;"` (was `"chat(s)"`)
- `"1 extra workflow alias was skipped"` (was `"alias(es) were"`)

Checked explicitly for lost spacing at every concatenation: the a2ui chip, the retirement note, the `" " +` glue before the alias sentence, both `"\n\n"` `confirm()` joins, and the pill's leading space that replaces the one after `</i>`.

## Test changes

`browser_tests/unit/stale-interactive-card.test.mjs` asserts on panel **source** and evals `retireInteractiveCard` through `new Function`, so both halves needed updating — neither was loosened:

- The sandbox is handed the **shipped** `tr`, not a stub. No catalog is loaded in that process, which is precisely the state `tr` is built to survive: every call returns its English fallback with `{holes}` filled. The wording assertions still read the English the panel renders, and a renamed or deleted fallback still fails them.
- The `what: "secret request"` guard accepts the `tr(…)` form **with the key pinned**. A wildcard key would let `tr("panel.question", "secret request")` pass while every non-English locale rendered the secret card with the question card's noun — the exact regression that test exists for. Verified by mutation: swapping the key fails the guard; swapping the words fails it too.

## Verification

- `npm run test:unit` — **3707 pass / 0 fail** (includes the Zod locale gate: `locales OK`, ja/ko/zh 247 keys each)
- `npm run typecheck` — clean
- `npm run test:e2e:list` — 68 tests in 29 files discovered
- `node --check` on both edited sources
- Adversarial review pass; findings on the test-guard wildcard, two droppable edge spaces, and an over-broad claim about persisted text are fixed in the second commit.

No live browser run — per the coordinator, the single shared ComfyUI on :8188 gets one consolidated pass after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
