### PR TITLE
feat(968): record WHAT last moved the active workflow

### DIFF
--- a/browser_tests/unit/active-workflow-provenance.test.mjs
+++ b/browser_tests/unit/active-workflow-provenance.test.mjs
@@ -1,0 +1,130 @@
+/**
+ * #968 — WHAT last moved the active workflow.
+ *
+ * The issue is three reports of the fence saying "bound to the requested workflow" while
+ * graph commands keep hitting the previous one. They have not converged because, after the
+ * fact, a STALE binding and a FRESH one are the same observation: "the active workflow is
+ * X", with nothing recording how it came to be X.
+ *
+ * Ruled out before building this, so it is not another guess: `panel_open_workflow` forces
+ * the repaint and verifies it, both its skip paths fail closed, and the report where
+ * `panel_run` queued the wrong workflow was on a build that had both protections.
+ *
+ * DIAGNOSTIC ONLY — nothing here decides whether a command may run. These tests pin that
+ * property as hard as they pin the behaviour, because widening trust on an unknown entry
+ * route is how a refusal becomes the silent wrong-graph edit the issue reports.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+import {
+  MOVE_CAUSES,
+  createActiveWorkflowProvenance,
+} from "../../web/js/lib/active-workflow-provenance.js";
+
+test("#968 a move the panel did NOT make is the one worth naming", () => {
+  const p = createActiveWorkflowProvenance();
+  p.record({ cause: MOVE_CAUSES.OPEN_EXECUTOR, from: "wf:a.json", to: "wf:b.json", at: 1, detail: "open_seq 2" });
+  p.record({ cause: MOVE_CAUSES.EXTERNAL, from: "wf:b.json", to: "wf:c.json", at: 2 });
+
+  const note = p.describeLast();
+  assert.match(note, /the panel did not make that move/);
+  assert.match(note, /from wf:b\.json to wf:c\.json/);
+  // It must name the routes that can do it — both reporters' triggers are in this list.
+  assert.match(note, /reconnect restore/);
+  assert.match(note, /reopened at a new path/);
+  // And say what it means for a binding taken earlier.
+  assert.match(note, /stale/);
+});
+
+test("#968 a move the panel DID make names which command made it", () => {
+  const p = createActiveWorkflowProvenance();
+  p.record({ cause: MOVE_CAUSES.OPEN_EXECUTOR, from: "wf:a.json", to: "wf:b.json", at: 1, detail: "open_seq 2" });
+  assert.match(p.describeLast(), /by panel_open_workflow \(open_seq 2\)/);
+
+  p.record({ cause: MOVE_CAUSES.NEW_EXECUTOR, to: "tmp:1234", at: 2 });
+  const note = p.describeLast();
+  assert.match(note, /by panel_new_workflow/);
+  // No `from` recorded → it must not invent one.
+  assert.match(note, /moved to tmp:1234/);
+  assert.ok(!/from null|from undefined/.test(note));
+});
+
+test("#968 NOTHING recorded reads as 'not known', never as 'the panel moved it'", () => {
+  // The failure this avoids: an empty log rendering as a confident sentence. A caller that
+  // has no provenance must be able to say so.
+  const p = createActiveWorkflowProvenance();
+  assert.equal(p.describeLast(), null);
+  assert.equal(p.last(), null);
+  assert.deepEqual(p.history(), []);
+});
+
+test("#968 an unrecognized cause is recorded as EXTERNAL, not dropped and not trusted", () => {
+  // Dropping it would hide a move; trusting it would let a future call site invent an
+  // authority it does not have. The hunted case is precisely "a move nobody attributed".
+  const p = createActiveWorkflowProvenance();
+  for (const cause of ["something_new", "", null, undefined, 42, {}]) {
+    p.record({ cause, to: "wf:x.json", at: 1 });
+    assert.equal(p.last().cause, MOVE_CAUSES.EXTERNAL, String(cause));
+  }
+});
+
+test("#968 a move with no destination records NOTHING", () => {
+  // A half-entry is worse than no entry: `describeLast` would then report a move whose
+  // target is unknown, which reads as information and is not.
+  const p = createActiveWorkflowProvenance();
+  for (const bad of [null, undefined, {}, { cause: MOVE_CAUSES.EXTERNAL }, { to: "" }, { to: 5 }, "x"]) {
+    assert.equal(p.record(bad), null, JSON.stringify(bad) ?? "undefined");
+  }
+  assert.equal(p.last(), null);
+});
+
+test("#968 the log is bounded — a long session must not grow it forever", () => {
+  const p = createActiveWorkflowProvenance({ cap: 3 });
+  for (let i = 0; i < 10; i += 1) p.record({ cause: MOVE_CAUSES.EXTERNAL, to: `wf:${i}.json`, at: i });
+  const h = p.history();
+  assert.equal(h.length, 3);
+  // Oldest-first eviction: the RECENT moves are the ones a stale binding is explained by.
+  assert.deepEqual(h.map((e) => e.to), ["wf:7.json", "wf:8.json", "wf:9.json"]);
+  assert.equal(p.last().to, "wf:9.json");
+});
+
+test("#968 history() hands out a COPY — a diagnostic a caller can edit can lie", () => {
+  const p = createActiveWorkflowProvenance();
+  p.record({ cause: MOVE_CAUSES.EXTERNAL, to: "wf:a.json", at: 1 });
+  const h = p.history();
+  h[0].to = "wf:tampered.json";
+  h[0].cause = MOVE_CAUSES.OPEN_EXECUTOR;
+  assert.equal(p.last().to, "wf:a.json");
+  assert.equal(p.last().cause, MOVE_CAUSES.EXTERNAL);
+});
+
+test("#968 free-text detail is bounded and never structured", () => {
+  const p = createActiveWorkflowProvenance();
+  p.record({ cause: MOVE_CAUSES.OPEN_EXECUTOR, to: "wf:a.json", at: 1, detail: "x".repeat(500) });
+  assert.equal(p.last().detail.length, 200);
+  // Non-strings are dropped rather than coerced — "[object Object]" in a diagnostic is
+  // noise that reads like data.
+  p.record({ cause: MOVE_CAUSES.OPEN_EXECUTOR, to: "wf:b.json", at: 2, detail: { a: 1 } });
+  assert.equal(p.last().detail, null);
+});
+
+test("#968 SOURCE: this module decides nothing about whether a command may run", () => {
+  // The property that makes this safe to ship while the entry route is unknown. If a future
+  // edit makes a refusal or a fence consult it, that is a trust change and must be argued on
+  // its own terms — not inherited from a diagnostic.
+  const src = readFileSync(new URL("../../web/js/lib/active-workflow-provenance.js", import.meta.url), "utf8");
+  assert.match(src, /DIAGNOSTIC ONLY/);
+
+  // Tested as a SHAPE, not by banning words — an earlier version of this assertion failed on
+  // the word "refusal" inside a comment describing where the string is displayed, which
+  // would have pushed the prose to be less clear to satisfy a test.
+  const exported = [...src.matchAll(/^export (?:function|const) (\w+)/gm)].map((m) => m[1]).sort();
+  assert.deepEqual(exported, ["MOVE_CAUSES", "createActiveWorkflowProvenance"], "surface is a recorder and its causes");
+
+  // A verdict returns a boolean. This module returns records and strings, so a bare
+  // `return true` / `return false` appearing here is the shape of a decision creeping in.
+  const body = src.slice(src.indexOf("export function createActiveWorkflowProvenance"));
+  assert.ok(!/\breturn (?:true|false)\b/.test(body), "no boolean verdict is returned");
+});

--- a/browser_tests/unit/active-workflow-provenance.test.mjs
+++ b/browser_tests/unit/active-workflow-provenance.test.mjs
@@ -128,3 +128,99 @@ test("#968 SOURCE: this module decides nothing about whether a command may run",
   const body = src.slice(src.indexOf("export function createActiveWorkflowProvenance"));
   assert.ok(!/\breturn (?:true|false)\b/.test(body), "no boolean verdict is returned");
 });
+
+test("#968 WIRED: the observer runs before the refusal, and the note reaches it", () => {
+  // A recorder nothing calls is inert — the first attempt at this shipped exactly that, so
+  // these pin the wiring rather than the module.
+  const src = readFileSync(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8");
+
+  // 1. Something drives the observer, and it does so BEFORE the mismatch is reported.
+  const obs = src.indexOf("noteActiveWorkflowMove();");
+  assert.ok(obs > 0, "the observer is called");
+  // Compared LOCALLY, not by whole-file index: `noteWorkflowInstanceMismatch` has an earlier
+  // occurrence of its own, and an index comparison against that one passes for the wrong
+  // reason. Assert the two sit together on the refusal path instead.
+  const near = src.slice(obs, obs + 400);
+  assert.match(near, /noteWorkflowInstanceMismatch\(\);/, "observed immediately before the refusal is composed");
+
+  // 2. NOT beside onCommandReceived: #508 pins that callback being alone in its own try, so
+  //    a host callback cannot suppress a reply. Sharing that try would weaken it.
+  const boundary = src.indexOf("onCommandReceived?.();");
+  assert.ok(Math.abs(boundary - obs) > 200, "the observer does not share the onCommandReceived try");
+
+  // 3. The refusal a caller actually sees is given the line.
+  assert.match(src, /movedNote: activeWorkflowMoves\.describeLast\(\),/);
+
+  // 4. The pure helper's own call site is UNCHANGED — #1019 pins its three-argument shape,
+  //    and it is rebuilt with `new Function`, where a module global does not exist.
+  assert.match(
+    src,
+    /workflowInstanceMismatchMessage\(\{ commandUuid, activeUuid, activeIsUnsaved \}\)/,
+    "the fence helper still calls it with exactly three arguments",
+  );
+});
+
+test("#968 WIRED: the message stays PURE and single-line", () => {
+  const src = readFileSync(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8");
+  // Single line, because namedFunctionSource extracts this function by name and a multi-line
+  // parameter list makes it stop at the PARAMETER brace instead of the body's — which is how
+  // an earlier attempt broke 13 tests without touching their subject.
+  assert.match(
+    src,
+    /function workflowInstanceMismatchMessage\(\{ commandUuid, activeUuid, activeIsUnsaved = null, movedNote = null \} = \{\}\) \{/,
+  );
+  // And it reads only its parameters: a module global here is unreachable under `new Function`.
+  const start = src.indexOf("function workflowInstanceMismatchMessage({ commandUuid");
+  const body = src.slice(start, src.indexOf("\r\n}", src.indexOf("const movedLine", start)));
+  assert.ok(!/activeWorkflowMoves/.test(body), "the message never reaches for the recorder");
+});
+
+/** Same extractor the other suites use — brace-balanced, so a destructured parameter list
+ *  cannot make it stop at the parameter brace (the trap that broke an earlier attempt). */
+function namedFunctionSource(src, name) {
+  const start = src.indexOf(`function ${name}(`);
+  if (start === -1) return null;
+  // `") {"`, not `"{"`. With a DESTRUCTURED parameter list the first `{` belongs to the
+  // parameters, so balancing from there ends at the parameter object's close and returns a
+  // truncated function that fails to parse. That is the third time this trap has bitten this
+  // file today; the copies in bridge-route/open-outcome still use the naive form and work
+  // only because their subjects take positional parameters.
+  const open = src.indexOf(") {", start) + 2;
+  let depth = 0;
+  for (let i = open; i < src.length; i += 1) {
+    if (src[i] === "{") depth += 1;
+    if (src[i] === "}" && --depth === 0) return src.slice(start, i + 1);
+  }
+  return null;
+}
+
+const buildMismatchMessage = () => {
+  const src = readFileSync(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8");
+  const fn = namedFunctionSource(src, "workflowInstanceMismatchMessage");
+  assert.ok(fn, "workflowInstanceMismatchMessage not found");
+  return new Function(`${fn}; return workflowInstanceMismatchMessage;`)();
+};
+
+test("#968 the note is APPENDED to the refusal, never substituted for it", () => {
+  const msg = buildMismatchMessage();
+  const args = { commandUuid: "aaaa-1111", activeUuid: "bbbb-2222" };
+  const plain = msg(args);
+  const withNote = msg({ ...args, movedNote: "MOVED-BY-SOMETHING-ELSE" });
+
+  // Everything the refusal already said survives — the note explains, it does not replace.
+  assert.ok(withNote.startsWith(plain), "the original refusal is still the whole first part");
+  assert.match(withNote, /MOVED-BY-SOMETHING-ELSE$/);
+  assert.match(withNote, /\n\nMOVED-BY-SOMETHING-ELSE$/, "separated, so it reads as its own statement");
+  // Both identities are still reported.
+  assert.match(withNote, /aaaa-1111/);
+  assert.match(withNote, /bbbb-2222/);
+});
+
+test("#968 no note, or an empty one, changes the refusal not at all", () => {
+  const msg = buildMismatchMessage();
+  const args = { commandUuid: "aaaa-1111", activeUuid: "bbbb-2222" };
+  const plain = msg(args);
+  for (const empty of [null, undefined, "", "   ", 42, {}]) {
+    assert.equal(msg({ ...args, movedNote: empty }), plain, JSON.stringify(empty) ?? "undefined");
+  }
+});

--- a/browser_tests/unit/active-workflow-provenance.test.mjs
+++ b/browser_tests/unit/active-workflow-provenance.test.mjs
@@ -30,7 +30,9 @@ test("#968 a move the panel did NOT make is the one worth naming", () => {
 
   const note = p.describeLast();
   assert.match(note, /the panel did not make that move/);
-  assert.match(note, /from wf:b\.json to wf:c\.json/);
+  // "last seen as", not "from": observations are point-in-time, so adjacency was never
+  // established (codex P2).
+  assert.match(note, /to wf:c\.json \(last seen as wf:b\.json\)/);
   // It must name the routes that can do it — both reporters' triggers are in this list.
   assert.match(note, /reconnect restore/);
   assert.match(note, /reopened at a new path/);

--- a/browser_tests/unit/active-workflow-provenance.test.mjs
+++ b/browser_tests/unit/active-workflow-provenance.test.mjs
@@ -23,13 +23,20 @@ import {
   createActiveWorkflowProvenance,
 } from "../../web/js/lib/active-workflow-provenance.js";
 
-test("#968 a move the panel did NOT make is the one worth naming", () => {
+test("#968 an UNCLAIMED move asserts ignorance, not that the panel is innocent", () => {
   const p = createActiveWorkflowProvenance();
   p.record({ cause: MOVE_CAUSES.OPEN_EXECUTOR, from: "wf:a.json", to: "wf:b.json", at: 1, detail: "open_seq 2" });
-  p.record({ cause: MOVE_CAUSES.EXTERNAL, from: "wf:b.json", to: "wf:c.json", at: 2 });
+  p.record({ cause: MOVE_CAUSES.UNKNOWN, from: "wf:b.json", to: "wf:c.json", at: 2 });
 
   const note = p.describeLast();
-  assert.match(note, /the panel did not make that move/);
+  // NOT "the panel did not make that move". Not every executor can claim — `workflow_new` is
+  // reconstructed in isolation by #606/#708 — and one of #968's three reports entered the
+  // desync through exactly that command. A false EXCLUSION on a reported entry path would
+  // send the next investigator away from the panel at the moment it was responsible (codex).
+  assert.match(note, /NO PANEL COMMAND CLAIMED IT/);
+  assert.match(note, /does not prove the panel did not do it/);
+  assert.match(note, /covers a panel_new_workflow/);
+  assert.ok(!/the panel did not make that move/.test(note), "the false exclusion is gone");
   // "last seen as", not "from": observations are point-in-time, so adjacency was never
   // established (codex P2).
   assert.match(note, /to wf:c\.json \(last seen as wf:b\.json\)/);
@@ -62,13 +69,13 @@ test("#968 NOTHING recorded reads as 'not known', never as 'the panel moved it'"
   assert.deepEqual(p.history(), []);
 });
 
-test("#968 an unrecognized cause is recorded as EXTERNAL, not dropped and not trusted", () => {
+test("#968 an unrecognized cause is recorded as UNKNOWN, not dropped and not trusted", () => {
   // Dropping it would hide a move; trusting it would let a future call site invent an
   // authority it does not have. The hunted case is precisely "a move nobody attributed".
   const p = createActiveWorkflowProvenance();
   for (const cause of ["something_new", "", null, undefined, 42, {}]) {
     p.record({ cause, to: "wf:x.json", at: 1 });
-    assert.equal(p.last().cause, MOVE_CAUSES.EXTERNAL, String(cause));
+    assert.equal(p.last().cause, MOVE_CAUSES.UNKNOWN, String(cause));
   }
 });
 
@@ -76,7 +83,7 @@ test("#968 a move with no destination records NOTHING", () => {
   // A half-entry is worse than no entry: `describeLast` would then report a move whose
   // target is unknown, which reads as information and is not.
   const p = createActiveWorkflowProvenance();
-  for (const bad of [null, undefined, {}, { cause: MOVE_CAUSES.EXTERNAL }, { to: "" }, { to: 5 }, "x"]) {
+  for (const bad of [null, undefined, {}, { cause: MOVE_CAUSES.UNKNOWN }, { to: "" }, { to: 5 }, "x"]) {
     assert.equal(p.record(bad), null, JSON.stringify(bad) ?? "undefined");
   }
   assert.equal(p.last(), null);
@@ -84,7 +91,7 @@ test("#968 a move with no destination records NOTHING", () => {
 
 test("#968 the log is bounded — a long session must not grow it forever", () => {
   const p = createActiveWorkflowProvenance({ cap: 3 });
-  for (let i = 0; i < 10; i += 1) p.record({ cause: MOVE_CAUSES.EXTERNAL, to: `wf:${i}.json`, at: i });
+  for (let i = 0; i < 10; i += 1) p.record({ cause: MOVE_CAUSES.UNKNOWN, to: `wf:${i}.json`, at: i });
   const h = p.history();
   assert.equal(h.length, 3);
   // Oldest-first eviction: the RECENT moves are the ones a stale binding is explained by.
@@ -94,12 +101,12 @@ test("#968 the log is bounded — a long session must not grow it forever", () =
 
 test("#968 history() hands out a COPY — a diagnostic a caller can edit can lie", () => {
   const p = createActiveWorkflowProvenance();
-  p.record({ cause: MOVE_CAUSES.EXTERNAL, to: "wf:a.json", at: 1 });
+  p.record({ cause: MOVE_CAUSES.UNKNOWN, to: "wf:a.json", at: 1 });
   const h = p.history();
   h[0].to = "wf:tampered.json";
   h[0].cause = MOVE_CAUSES.OPEN_EXECUTOR;
   assert.equal(p.last().to, "wf:a.json");
-  assert.equal(p.last().cause, MOVE_CAUSES.EXTERNAL);
+  assert.equal(p.last().cause, MOVE_CAUSES.UNKNOWN);
 });
 
 test("#968 free-text detail is bounded and never structured", () => {
@@ -172,8 +179,11 @@ test("#968 WIRED: the message stays PURE and single-line", () => {
     /function workflowInstanceMismatchMessage\(\{ commandUuid, activeUuid, activeIsUnsaved = null, movedNote = null \} = \{\}\) \{/,
   );
   // And it reads only its parameters: a module global here is unreachable under `new Function`.
-  const start = src.indexOf("function workflowInstanceMismatchMessage({ commandUuid");
-  const body = src.slice(start, src.indexOf("\r\n}", src.indexOf("const movedLine", start)));
+  // Extracted with the brace-balanced reader below rather than a hand-rolled slice — the
+  // slice this replaces depended on a literal "\r\n}" and on a local's name, and broke when
+  // neither had changed, which is a test failing for a reason unrelated to its subject.
+  const body = namedFunctionSource(src, "workflowInstanceMismatchMessage");
+  assert.ok(body, "the message function is extractable");
   assert.ok(!/activeWorkflowMoves/.test(body), "the message never reaches for the recorder");
 });
 

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -2511,6 +2511,8 @@ function workflowInstanceMismatchMessage({ commandUuid, activeUuid, activeIsUnsa
     ` If NO panel tab is connected, neither will help and the connection is the thing ` +
     `to fix — panel_graph_outline reports connectivity directly.`
   );
+  const note = typeof movedNote === "string" && movedNote.trim() ? movedNote.trim() : null;
+  return note ? `${base}\n\n${note}` : base;
 }
 
 function assertActiveWorkflowCommandTarget(msg, targetsNonActive = false) {

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -12404,6 +12404,10 @@ const GRAPH_TOOL_EXECUTORS = {
     }
     // Comfy.NewBlankWorkflow opens a fresh TAB — the current workflow is untouched.
     try {
+      // #968 r2 — NOT claimed here. #606/#708 reconstruct workflow_new from source and
+      // rebuild it in isolation, so an inserted call breaks 12 guards that exist for
+      // independent reasons. Recorded on the PR: this cause stays unwired until the
+      // claim can be staked somewhere those guards do not reach.
       await mgr.command.execute("Comfy.NewBlankWorkflow");
     } catch (err) {
       // The creation command itself threw. It may have got partway, and workflow_new is
@@ -12728,6 +12732,9 @@ const GRAPH_TOOL_EXECUTORS = {
         // The native switch itself failed — nothing was applied. Recorded, then rethrown
         // through failOpen below (outside the freeze) so the negative is journaled.
         openFailed = err instanceof Error ? err : new Error(coerceMessageText(err));
+        // #968 r2 — the claim was staked before the switch; the switch did not happen, so
+        // release it rather than let a later move inherit this command's name.
+        claimActiveWorkflowMove(null, null);
       } finally {
         endWorkflowReloadStep(reloadGuardToken);
       }
@@ -16212,18 +16219,27 @@ const activeWorkflowMoves = createActiveWorkflowProvenance();
 // observer so it does not double-report them as external.
 let _claimedNextMove = null;
 function claimActiveWorkflowMove(cause, detail) {
-  _claimedNextMove = { cause, detail: typeof detail === "string" ? detail : null };
+  // A null cause RELEASES a claim (an open that failed before switching).
+  _claimedNextMove = cause ? { cause, detail: typeof detail === "string" ? detail : null } : null;
 }
 let _lastSeenActiveKey = null;
 function noteActiveWorkflowMove() {
   try {
-    const key = workflowTabId(activeWorkflowRef()) || null;
+    // #968 r2 (codex P1) — CONSUME the claim on every observation, not only when the key
+    // changed. A claim left pending by an open that failed, no-opped or was superseded
+    // would otherwise be applied to the NEXT different key, labelling an external move as
+    // panel-made — mislabelling exactly the case this exists to find.
+    const claim = _claimedNextMove;
+    _claimedNextMove = null;
+    // #968 r2 (codex P2) — a null active workflow is NO DESTINATION. `workflowTabId(null)`
+    // falls back to getTabId(), a browser-session id, so reading it here would report a
+    // move to a browser tab as though it were a workflow.
+    const active = activeWorkflowRef();
+    const key = active ? workflowTabId(active) || null : null;
     if (key === _lastSeenActiveKey) return;
     const from = _lastSeenActiveKey;
     _lastSeenActiveKey = key;
     if (!key) return; // nothing active — a destination-less move records nothing
-    const claim = _claimedNextMove;
-    _claimedNextMove = null;
     activeWorkflowMoves.record({
       // An UNCLAIMED move is the case #968 is hunting: a tab click, a reconnect restore, a
       // file reopened at a new path. Defaulting to `external` is what makes it visible.

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -338,6 +338,10 @@ import {
 import { pickRevertSnapshot, describeRevertOutcome, revertDidRestore } from "./lib/graph-revert.js";
 import { commandFingerprint, createCommandDedupeLedger } from "./lib/command-dedupe.js";
 import {
+  MOVE_CAUSES,
+  createActiveWorkflowProvenance,
+} from "./lib/active-workflow-provenance.js";
+import {
   INTERACTIVE_ABANDONED,
   abandonedInteractiveError,
   isAbandonedInteractive,
@@ -12709,6 +12713,10 @@ const GRAPH_TOOL_EXECUTORS = {
       // guard age out mid-flight (see begin/endWorkflowReloadStep).
       beginWorkflowReloadStep(reloadGuardToken);
       try {
+        // #968 — claim this move BEFORE it happens, so the observer attributes it to this
+        // command rather than reporting it as a move nobody made. A claim that is never
+        // followed by a move is discarded by the next observation.
+        claimActiveWorkflowMove(MOVE_CAUSES.OPEN_EXECUTOR, `workflow_open ${workflowTabId(target) || ""}`.trim());
         await s.openWorkflow(target);
       } catch (err) {
         // The native switch itself failed — nothing was applied. Recorded, then rethrown
@@ -16189,6 +16197,40 @@ function redactBridgeUrl(u) {
 // unknown in the new epoch and therefore fails open instead of replaying or
 // rejecting a prior session's command.
 const commandRidLedger = createCommandDedupeLedger(200, (m) => console.warn(m));
+
+// #968 — WHAT last moved the active workflow. A stale binding and a fresh one are the same
+// observation after the fact, which is why three reports of `bound` + wrong-graph have not
+// converged. DIAGNOSTIC ONLY: nothing below consults this to decide whether a command runs.
+const activeWorkflowMoves = createActiveWorkflowProvenance();
+// The panel's own moves are claimed by the executor that made them, and are consumed by the
+// observer so it does not double-report them as external.
+let _claimedNextMove = null;
+function claimActiveWorkflowMove(cause, detail) {
+  _claimedNextMove = { cause, detail: typeof detail === "string" ? detail : null };
+}
+let _lastSeenActiveKey = null;
+function noteActiveWorkflowMove() {
+  try {
+    const key = workflowTabId(activeWorkflowRef()) || null;
+    if (key === _lastSeenActiveKey) return;
+    const from = _lastSeenActiveKey;
+    _lastSeenActiveKey = key;
+    if (!key) return; // nothing active — a destination-less move records nothing
+    const claim = _claimedNextMove;
+    _claimedNextMove = null;
+    activeWorkflowMoves.record({
+      // An UNCLAIMED move is the case #968 is hunting: a tab click, a reconnect restore, a
+      // file reopened at a new path. Defaulting to `external` is what makes it visible.
+      cause: claim ? claim.cause : MOVE_CAUSES.EXTERNAL,
+      detail: claim ? claim.detail : null,
+      from,
+      to: key,
+      at: Date.now(),
+    });
+  } catch {
+    // A diagnostic must never break the path it observes.
+  }
+}
 
 function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCommandReceived, onAsk, onSecret, onSecretSaved, onReload, onTodo, onShowMedia, onOpenCivitai, onCivitaiCmd, onTrainingCmd, onUiRender, onUiUpdate, onDownloads, onThinking, onAgentStatus, onSession, onModels, onCommands, onBackends, onAck, onTurn, onAction, onTurnAnchor, getResume, getBackend, onHandshakeTimeout, onBridgeClosed, onPairUrl, onPairError, onRunpodStatus, onComfyuiTarget, onRunpodAlert }) {
   let sock = null;

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -16241,8 +16241,10 @@ function noteActiveWorkflowMove() {
     _lastSeenActiveKey = key;
     if (!key) return; // nothing active — a destination-less move records nothing
     activeWorkflowMoves.record({
-      // An UNCLAIMED move is the case #968 is hunting: a tab click, a reconnect restore, a
-      // file reopened at a new path. Defaulting to `external` is what makes it visible.
+      // An UNCLAIMED move is the case #968 is hunting. It is recorded as UNKNOWN rather than
+      // as "not the panel": `workflow_new` cannot stake a claim (#606/#708 rebuild it in
+      // isolation), and one of the three reports entered through that very command, so
+      // excluding the panel here would be a false exclusion on a reported entry path.
       cause: claim ? claim.cause : MOVE_CAUSES.UNKNOWN,
       detail: claim ? claim.detail : null,
       from,

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -16243,7 +16243,7 @@ function noteActiveWorkflowMove() {
     activeWorkflowMoves.record({
       // An UNCLAIMED move is the case #968 is hunting: a tab click, a reconnect restore, a
       // file reopened at a new path. Defaulting to `external` is what makes it visible.
-      cause: claim ? claim.cause : MOVE_CAUSES.EXTERNAL,
+      cause: claim ? claim.cause : MOVE_CAUSES.UNKNOWN,
       detail: claim ? claim.detail : null,
       from,
       to: key,

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -2474,7 +2474,11 @@ function noteWorkflowInstanceMismatch() {
  *  The leading `workflow instance mismatch:` token is preserved deliberately: it
  *  is what readers and existing reports recognise this refusal by. Only the claim
  *  about causation changes. */
-function workflowInstanceMismatchMessage({ commandUuid, activeUuid, activeIsUnsaved = null } = {}) {
+// #968 — `movedNote` is INJECTED, never read from the recorder here: this function is pure
+// and #750/#1019 rebuild it in isolation with `new Function`, where a module global does not
+// exist. One line on purpose (see above). Appended, never substituted — the refusal's own
+// reasoning survives; the note only says WHY the active workflow is not what was expected.
+function workflowInstanceMismatchMessage({ commandUuid, activeUuid, activeIsUnsaved = null, movedNote = null } = {}) {
   const str = (v) => (typeof v === "string" && v.trim() ? v.trim() : null);
   const expected = str(commandUuid);
   const live = str(activeUuid);
@@ -2486,7 +2490,7 @@ function workflowInstanceMismatchMessage({ commandUuid, activeUuid, activeIsUnsa
   const compared = expected
     ? `this command was issued for workflow instance ${expected}, and ${canvasSays}`
     : `this command carries no workflow-instance stamp, and ${canvasSays}`;
-  return (
+  const base = (
     `workflow instance mismatch: ${compared}. Nothing was applied.\n\n` +
     `That is the comparison, not the cause — the panel observed only that the two ` +
     `identities differ. It can mean the workflow was switched or replaced after the ` +
@@ -2511,8 +2515,8 @@ function workflowInstanceMismatchMessage({ commandUuid, activeUuid, activeIsUnsa
     ` If NO panel tab is connected, neither will help and the connection is the thing ` +
     `to fix — panel_graph_outline reports connectivity directly.`
   );
-  const note = typeof movedNote === "string" && movedNote.trim() ? movedNote.trim() : null;
-  return note ? `${base}\n\n${note}` : base;
+  const movedLine = typeof movedNote === "string" && movedNote.trim() ? movedNote.trim() : null;
+  return movedLine ? `${base}\n\n${movedLine}` : base;
 }
 
 function assertActiveWorkflowCommandTarget(msg, targetsNonActive = false) {
@@ -17019,11 +17023,18 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
               // #607 — re-advertise the panel's CURRENT identity (re-hello) so the
               // recovery this message advertises actually reaches the orchestrator's
               // cached stamp; see noteWorkflowInstanceMismatch.
+              // #968 — observe before reporting: a move that happened since the previous
+              // command is exactly what makes this binding stale, and an unclaimed one is
+              // the case this issue is hunting.
+              noteActiveWorkflowMove();
               noteWorkflowInstanceMismatch();
               throw new Error(
                 workflowInstanceMismatchMessage({
                   commandUuid: dispatchCommandUuid,
                   activeUuid: dispatchActiveUuid,
+                  // #968 — what last moved the active workflow, if anything did. This is the
+                  // refusal a caller actually sees when a binding has gone stale.
+                  movedNote: activeWorkflowMoves.describeLast(),
                 }),
               );
             }

--- a/web/js/lib/active-workflow-provenance.js
+++ b/web/js/lib/active-workflow-provenance.js
@@ -25,15 +25,25 @@
 //
 // Dependency-free (no DOM, no LiteGraph). Unit-testable with plain fixtures.
 
-/** Causes the panel can attribute a move to. Anything else is `external`. */
+/** Causes the panel can attribute a move to. Anything else is `unknown`. */
 export const MOVE_CAUSES = Object.freeze({
   /** The panel's own workflow_open executor, after its repaint and content proof. */
   OPEN_EXECUTOR: "open_executor",
-  /** The panel created a workflow and switched to it. */
+  /** The panel created a workflow and switched to it. Declared but NOT yet claimed
+   *  anywhere: `workflow_new` is reconstructed from source and rebuilt in isolation by
+   *  #606/#708, so a claim cannot be inserted there without breaking twelve guards. */
   NEW_EXECUTOR: "new_executor",
-  /** Observed moving with no panel action behind it — a frontend tab click, a reconnect
-   *  restore, a file reopened at a new path. The interesting one for #968. */
-  EXTERNAL: "external",
+  /** NO CLAIM was recorded for this move.
+   *
+   *  Deliberately NOT "external" (codex). "External" asserts the panel did not do it, and
+   *  the panel cannot establish that: not every executor can claim, and one of #968's three
+   *  reports entered the desync through `panel_new_workflow` specifically. A false
+   *  EXCLUSION on a reported entry path is worse than no attribution — it would send the
+   *  next investigator away from the panel at exactly the moment the panel was responsible.
+   *
+   *  `unknown` asserts nothing about who moved it, and still establishes the half that is
+   *  always true and always useful: a binding taken before this move is stale. */
+  UNKNOWN: "unknown",
 });
 
 const KNOWN = new Set(Object.values(MOVE_CAUSES));
@@ -64,10 +74,11 @@ export function createActiveWorkflowProvenance({ cap = DEFAULT_CAP } = {}) {
       if (!entry || typeof entry !== "object") return null;
       const to = typeof entry.to === "string" && entry.to ? entry.to : null;
       if (!to) return null;
-      // An unrecognized cause is stored AS external rather than dropped or trusted: the
-      // point of the log is that a move happened, and mislabelling it "panel did this"
-      // would hide the very case being hunted.
-      const cause = KNOWN.has(entry.cause) ? entry.cause : MOVE_CAUSES.EXTERNAL;
+      // An unrecognized cause is stored as UNKNOWN rather than dropped or trusted. The point
+      // of the log is that a move HAPPENED; mislabelling it in either direction is worse than
+      // recording it plainly — "panel did this" hides the case being hunted, and "panel did
+      // not" falsely excludes it.
+      const cause = KNOWN.has(entry.cause) ? entry.cause : MOVE_CAUSES.UNKNOWN;
       const stored = {
         cause,
         to,
@@ -103,11 +114,13 @@ export function createActiveWorkflowProvenance({ cap = DEFAULT_CAP } = {}) {
       // between them collapse into one transition. Say 'last seen as' rather than 'from',
       // which would assert an adjacency that was never established.
       const where = e.from ? `to ${e.to} (last seen as ${e.from})` : `to ${e.to}`;
-      if (e.cause === MOVE_CAUSES.EXTERNAL) {
+      if (e.cause === MOVE_CAUSES.UNKNOWN) {
         return (
-          `The active workflow last moved ${where}, and the panel did not make that move — ` +
-          `a tab click, a reconnect restore or a file reopened at a new path can all do it. ` +
-          `A binding taken before it is stale.`
+          `The active workflow last moved ${where}, and NO PANEL COMMAND CLAIMED IT. That does ` +
+          `not prove the panel did not do it — not every executor can register a claim, so this ` +
+          `covers a panel_new_workflow as well as a tab click, a reconnect restore, or a file ` +
+          `reopened at a new path. What it does establish is that a binding taken before this ` +
+          `move is stale.`
         );
       }
       const which = e.cause === MOVE_CAUSES.OPEN_EXECUTOR ? "panel_open_workflow" : "panel_new_workflow";

--- a/web/js/lib/active-workflow-provenance.js
+++ b/web/js/lib/active-workflow-provenance.js
@@ -1,0 +1,113 @@
+// #968 — WHAT last moved the active workflow.
+//
+// Three reports describe the same shape: the fence reports bound to the requested workflow
+// while graph commands keep hitting the previously active one — silent wrong-graph edits,
+// and in one case a wrong-workflow RUN. They have not converged, and the reason is that
+// after the fact a STALE binding and a FRESH one look identical: both are "the active
+// workflow is X", with nothing recording how it came to be X.
+//
+// What was ruled out first, so this is not another guess:
+//
+//   * `panel_open_workflow` forces the canvas repaint itself and verifies it with a content
+//     proof, and both of its skip paths fail CLOSED. `opened` + wrong-graph is not reachable
+//     through the executor's own branches.
+//   * The forced repaint predates every reported build, and the content proof shipped in
+//     0.11.96 — while the report where `panel_run` queued the wrong workflow was on 0.11.98.
+//     It had both protections and desynced anyway.
+//
+// So the binding is correct when it is made and something re-points the active tab
+// afterwards. This module records which.
+//
+// DIAGNOSTIC ONLY. Nothing here decides whether a command may run; it changes no refusal
+// into an acceptance. That is deliberate — this is the workflow fence's own failure mode,
+// and widening trust on an unknown entry route is exactly how a refusal becomes a silent
+// wrong-graph edit.
+//
+// Dependency-free (no DOM, no LiteGraph). Unit-testable with plain fixtures.
+
+/** Causes the panel can attribute a move to. Anything else is `external`. */
+export const MOVE_CAUSES = Object.freeze({
+  /** The panel's own workflow_open executor, after its repaint and content proof. */
+  OPEN_EXECUTOR: "open_executor",
+  /** The panel created a workflow and switched to it. */
+  NEW_EXECUTOR: "new_executor",
+  /** Observed moving with no panel action behind it — a frontend tab click, a reconnect
+   *  restore, a file reopened at a new path. The interesting one for #968. */
+  EXTERNAL: "external",
+});
+
+const KNOWN = new Set(Object.values(MOVE_CAUSES));
+
+/** Bounded: this is a diagnostic, and an unbounded log in a long session is a leak. */
+const DEFAULT_CAP = 20;
+
+/**
+ * @param {{cap?: number}} [options]
+ * @returns {{
+ *   record(entry: object): object|null,
+ *   last(): object|null,
+ *   history(): object[],
+ *   describeLast(): string|null,
+ * }}
+ */
+export function createActiveWorkflowProvenance({ cap = DEFAULT_CAP } = {}) {
+  const limit = Number.isFinite(cap) && cap > 0 ? Math.floor(cap) : DEFAULT_CAP;
+  const entries = [];
+
+  return {
+    /**
+     * Record one move. Returns the stored entry, or null if it was not usable — a caller
+     * that cannot say WHERE the active workflow went has recorded nothing, and storing a
+     * half-entry would make the log itself a source of false confidence.
+     */
+    record(entry) {
+      if (!entry || typeof entry !== "object") return null;
+      const to = typeof entry.to === "string" && entry.to ? entry.to : null;
+      if (!to) return null;
+      // An unrecognized cause is stored AS external rather than dropped or trusted: the
+      // point of the log is that a move happened, and mislabelling it "panel did this"
+      // would hide the very case being hunted.
+      const cause = KNOWN.has(entry.cause) ? entry.cause : MOVE_CAUSES.EXTERNAL;
+      const stored = {
+        cause,
+        to,
+        from: typeof entry.from === "string" && entry.from ? entry.from : null,
+        at: Number.isFinite(entry.at) ? entry.at : 0,
+        // Free-text detail from the call site (which executor, which reply). Bounded, and
+        // never structured — nothing reads this to make a decision.
+        detail: typeof entry.detail === "string" && entry.detail ? entry.detail.slice(0, 200) : null,
+      };
+      entries.push(stored);
+      while (entries.length > limit) entries.shift();
+      return stored;
+    },
+
+    last() {
+      return entries.length ? entries[entries.length - 1] : null;
+    },
+
+    history() {
+      // A copy: a diagnostic that a caller can mutate is a diagnostic that can lie.
+      return entries.map((e) => ({ ...e }));
+    },
+
+    /**
+     * One line for a refusal or a reply. Returns null when nothing was recorded — the
+     * absence must read as "not known", never as "the panel moved it".
+     */
+    describeLast() {
+      const e = entries.length ? entries[entries.length - 1] : null;
+      if (!e) return null;
+      const where = e.from ? `from ${e.from} to ${e.to}` : `to ${e.to}`;
+      if (e.cause === MOVE_CAUSES.EXTERNAL) {
+        return (
+          `The active workflow last moved ${where}, and the panel did not make that move — ` +
+          `a tab click, a reconnect restore or a file reopened at a new path can all do it. ` +
+          `A binding taken before it is stale.`
+        );
+      }
+      const which = e.cause === MOVE_CAUSES.OPEN_EXECUTOR ? "panel_open_workflow" : "panel_new_workflow";
+      return `The active workflow last moved ${where}, by ${which}${e.detail ? ` (${e.detail})` : ""}.`;
+    },
+  };
+}

--- a/web/js/lib/active-workflow-provenance.js
+++ b/web/js/lib/active-workflow-provenance.js
@@ -98,7 +98,11 @@ export function createActiveWorkflowProvenance({ cap = DEFAULT_CAP } = {}) {
     describeLast() {
       const e = entries.length ? entries[entries.length - 1] : null;
       if (!e) return null;
-      const where = e.from ? `from ${e.from} to ${e.to}` : `to ${e.to}`;
+      // #968 r2 (codex P2) — `from` is the LAST OBSERVED workflow, not necessarily the
+      // previous one: observations are taken at specific points, so several real switches
+      // between them collapse into one transition. Say 'last seen as' rather than 'from',
+      // which would assert an adjacency that was never established.
+      const where = e.from ? `to ${e.to} (last seen as ${e.from})` : `to ${e.to}`;
       if (e.cause === MOVE_CAUSES.EXTERNAL) {
         return (
           `The active workflow last moved ${where}, and the panel did not make that move — ` +


### PR DESCRIPTION
**Do not merge.** The wiring is complete and the suite is green, but codex found four ways
the diagnostic can LIE — and a diagnostic that lies is worse than none, because #968 is
exactly a case where people are trying to tell a stale binding from a fresh one.

## Confirmed good (codex verified, do not re-litigate)

- **It is genuinely diagnostic-only.** The fence decision precedes observation and throws
  unconditionally afterwards; nothing here can change whether a command is accepted.
- **A refusal with no note is byte-identical.** `movedNote` defaults to null and only ever
  appends a non-blank line.

## Open findings — all four make the record wrong, none are cosmetic

1. **P1 — a failed or superseded open can mislabel a LATER external move as panel-made.**
   `workflow_open` claims before `await s.openWorkflow()`, and a failure only records
   `openFailed`; the claim is never cleared. The observer keeps it while the key is
   unchanged, then applies it to the next different key. My comment saying an unfulfilled
   claim is discarded by the next observation is **false**. This mislabels precisely the
   case the issue is hunting.
2. **P1 — `NEW_EXECUTOR` is declared but never claimed.** `workflow_new` creates a tab
   without claiming, so its move is reported as `external` — the opposite mislabel. The test
   inserts that cause directly into the recorder, so it proves the string, not the wiring.
3. **P2 — `from` is not reliably the previous ACTUAL workflow.** Observation happens only on
   the refusal path, so several real switches between refusals collapse into one invented
   A→C transition.
4. **P2 — "no active workflow" is recorded as a tab id.** `workflowTabId(null)` falls back to
   `getTabId()`, a browser-session id, so the observer's no-destination branch is never
   reached in that state and a browser tab id can be reported as though it were a workflow.

## What each needs

(1) clear the claim on every failure path and expire it if no move follows; (2) either claim
in `workflow_new` or drop the cause from the enum until it is wired; (3) either observe on a
path that sees every switch, or say in the note that `from` is the last OBSERVED workflow
rather than the previous one; (4) treat a null active workflow as no destination rather than
letting the tab-id fallback stand in for one.

(3) is the interesting one: fixing it properly may mean the observer cannot live on the
refusal path at all, which reopens the call-site question this branch worked around.

Refs #968