### PR TITLE
fix(646): bound a duplicate's wait at the caller's own deadline

### DIFF
--- a/browser_tests/unit/duplicate-await-bound.test.mjs
+++ b/browser_tests/unit/duplicate-await-bound.test.mjs
@@ -37,25 +37,25 @@ function namedFunctionSource(src, name) {
 const buildHelper = () => {
   const fn = namedFunctionSource(SRC, "awaitDuplicateReply");
   assert.ok(fn, "awaitDuplicateReply not found");
-  const ms = SRC.match(/const DUPLICATE_AWAIT_MS = (\d+);/);
-  assert.ok(ms, "DUPLICATE_AWAIT_MS not found");
-  // Rebuilt with a tiny bound so the timeout path is testable in milliseconds.
-  return new Function(`const DUPLICATE_AWAIT_MS = 20; ${fn}; return awaitDuplicateReply;`)();
+  const margin = SRC.match(/const DUPLICATE_AWAIT_MARGIN_MS = (\d+);/);
+  assert.ok(margin, "DUPLICATE_AWAIT_MARGIN_MS not found");
+  // Rebuilt with a tiny margin so a millisecond-scale caller deadline still leaves a budget.
+  return new Function(`const DUPLICATE_AWAIT_MARGIN_MS = 5; ${fn}; return awaitDuplicateReply;`)();
 };
 
 test("#646 a settled original is returned UNCHANGED — the bound never rewrites a real reply", async () => {
   const awaitDuplicateReply = buildHelper();
   const settled = { rid: "orig", ok: true, result: { node_id: 7 } };
-  assert.equal(await awaitDuplicateReply(settled, "dup"), settled, "same object, not a copy");
+  assert.equal(await awaitDuplicateReply(settled, "dup", 50), settled, "same object, not a copy");
   // And an in-flight one that DOES settle in time still wins the race.
   const soon = new Promise((r) => setTimeout(() => r(settled), 1));
-  assert.equal(await awaitDuplicateReply(soon, "dup"), settled);
+  assert.equal(await awaitDuplicateReply(soon, "dup", 50), settled);
 });
 
 test("#646 an original that never settles yields an HONEST reply instead of silence", async () => {
   const awaitDuplicateReply = buildHelper();
   const never = new Promise(() => {}); // the stranded in-flight entry
-  const reply = await awaitDuplicateReply(never, "dup-rid");
+  const reply = await awaitDuplicateReply(never, "dup-rid", 25);
 
   assert.equal(reply.rid, "dup-rid", "correlated to the DUPLICATE's rid, which is what the caller waits on");
   assert.equal(reply.ok, false);
@@ -79,10 +79,10 @@ test("#646 the ORIGINAL entry is never settled by the bound", async () => {
     // Nothing calls this — the point is that the helper does not either.
     settledWith = resolve;
   });
-  await awaitDuplicateReply(never, "dup");
+  await awaitDuplicateReply(never, "dup", 25);
   assert.ok(typeof settledWith === "function", "the original's resolver was captured");
   // Still pending: racing it again with a short timer must time out a second time.
-  const again = await awaitDuplicateReply(never, "dup2");
+  const again = await awaitDuplicateReply(never, "dup2", 25);
   assert.equal(again.rid, "dup2");
   assert.equal(again.ok, false);
 });
@@ -92,7 +92,7 @@ test("#646 the handler keeps the statement shape #508 and #694 pin", () => {
   // so the handler still has one await followed by the existing rid-rewrite and send. An
   // earlier attempt put a still-in-flight BRANCH in that region and failed both guards —
   // correctly, since #508 exists so a superseded early-return cannot precede the reply write.
-  assert.match(SRC, /dupReply = await awaitDuplicateReply\(priorRidReply, msg\.rid\);/);
+  assert.match(SRC, /dupReply = await awaitDuplicateReply\(priorRidReply, msg\.rid, msg\.timeout_ms\);/);
   const at = SRC.indexOf("dupReply = await awaitDuplicateReply");
   const after = SRC.slice(at, at + 700);
   // No branch introduced between the await and the reply write.
@@ -100,12 +100,32 @@ test("#646 the handler keeps the statement shape #508 and #694 pin", () => {
   assert.match(after, /const outReply = retryOfHit \? \{ \.\.\.dupReply, rid: msg\.rid \} : dupReply;/);
 });
 
-test("#646 the bound is longer than a fast reply and shorter than silence", () => {
-  const ms = Number(SRC.match(/const DUPLICATE_AWAIT_MS = (\d+);/)[1]);
-  // Above the orchestrator's short command timeouts (6s was in the report), so a merely SLOW
-  // duplicate still receives the real reply rather than this notice...
-  assert.ok(ms > 6000, `bound ${ms}ms must exceed a short command timeout`);
-  // ...and at or under the long ones (20s in the report), so a wedged executor produces an
-  // error rather than the silence this fixes.
-  assert.ok(ms >= 20000 && ms <= 30000, `bound ${ms}ms must land in the wedge-detecting range`);
+test("#646 NO GUESS: with no deadline in the frame, the await is exactly as unbounded as before", async () => {
+  // The defect that killed the first version: a fixed 25s bound could not rescue a caller who
+  // gives up at 20s, and a lower one would report "still running" for a merely slow command.
+  // The panel cannot see the caller's deadline — the orchestrator computes it
+  // (ui-bridge.ts:3632) and does not put it in the frame (:4003) — so absent that field this
+  // must change NOTHING rather than guess.
+  const awaitDuplicateReply = buildHelper();
+  const never = new Promise(() => {});
+  const raced = await Promise.race([
+    awaitDuplicateReply(never, "dup", undefined).then(() => "answered"),
+    new Promise((r) => setTimeout(() => r("still waiting"), 40)),
+  ]);
+  assert.equal(raced, "still waiting", "no deadline → no bound → today's behaviour");
+  for (const bad of [null, 0, -1, NaN, "20000", {}]) {
+    const r = await Promise.race([
+      awaitDuplicateReply(never, "dup", bad).then(() => "answered"),
+      new Promise((res) => setTimeout(() => res("still waiting"), 30)),
+    ]);
+    assert.equal(r, "still waiting", `unusable deadline ${String(bad)} must not synthesize a bound`);
+  }
+});
+
+test("#646 the bound is the CALLER's deadline minus a margin, not a number of our own", () => {
+  assert.match(SRC, /const DUPLICATE_AWAIT_MARGIN_MS = \d+;/);
+  assert.ok(!/DUPLICATE_AWAIT_MS/.test(SRC), "no fixed bound survives");
+  assert.match(SRC, /callerTimeoutMs - DUPLICATE_AWAIT_MARGIN_MS/);
+  // Reads the frame's field, so it activates the moment the orchestrator sends it.
+  assert.match(SRC, /msg\.timeout_ms/);
 });

--- a/browser_tests/unit/duplicate-await-bound.test.mjs
+++ b/browser_tests/unit/duplicate-await-bound.test.mjs
@@ -129,3 +129,27 @@ test("#646 the bound is the CALLER's deadline minus a margin, not a number of ou
   // Reads the frame's field, so it activates the moment the orchestrator sends it.
   assert.match(SRC, /msg\.timeout_ms/);
 });
+
+test("#646 (codex) a deadline AT OR BELOW the margin is still bounded", async () => {
+  // The gap this closes: a 1000ms timeout is neither absent nor invalid, so falling through
+  // to unbounded would leave the caller with silence exactly where they give up soonest.
+  // Below the margin the budget is half the deadline, which still lands before it.
+  const awaitDuplicateReply = buildHelper(); // margin 5ms in the rebuilt copy
+  const never = new Promise(() => {});
+  for (const deadline of [4, 5, 2]) {
+    const reply = await Promise.race([
+      awaitDuplicateReply(never, "dup", deadline),
+      new Promise((r) => setTimeout(() => r("still waiting"), 60)),
+    ]);
+    assert.notEqual(reply, "still waiting", `deadline ${deadline}ms must still produce a reply`);
+    assert.equal(reply.ok, false);
+    assert.equal(reply.rid, "dup");
+  }
+});
+
+test("#646 (codex) the ask_user claim is scoped to whose contract it is", () => {
+  // The comment used to assert that ask_user/request_secret "carry long or absent deadlines".
+  // Nothing in this file establishes that — there is no command-specific guard here — so it
+  // now names the orchestrator as the party that holds that contract.
+  assert.match(SRC, /That is the\s*\r?\n?\s*\/\/ ORCHESTRATOR's contract, not something this file enforces or can verify/);
+});

--- a/browser_tests/unit/duplicate-await-bound.test.mjs
+++ b/browser_tests/unit/duplicate-await-bound.test.mjs
@@ -1,0 +1,111 @@
+/**
+ * #646 — a duplicate delivery must not wait forever on an executor that never settles.
+ *
+ * The newest report in that thread is the first ABOVE the previous fix line (panel 0.11.78
+ * vs 0.11.42 for #677), and its shape is commands TIMING OUT WITH NO REPLY — which is a
+ * different failure from commands being refused.
+ *
+ * The mechanism: the rid ledger records a command IN-FLIGHT at `begin()` and completes it at
+ * `settleRid()`. In-flight entries are never evicted, deliberately — dropping an unsettled
+ * command would let its replay double-apply a mutation. So an executor that never returns
+ * leaves a redelivery awaiting a promise that can never resolve, and the panel sends nothing.
+ *
+ * What is bounded is the DUPLICATE's wait. The original entry is never settled by this:
+ * answering "failed" for a command that may still be running is how a caller retries into the
+ * double-apply the ledger exists to prevent.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const SRC = readFileSync(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8");
+
+/** Brace-balanced, anchored past the parameter list — see the note in
+ *  active-workflow-provenance.test.mjs about the naive `indexOf("{")` form. */
+function namedFunctionSource(src, name) {
+  const start = src.indexOf(`function ${name}(`);
+  if (start === -1) return null;
+  const open = src.indexOf(") {", start) + 2;
+  let depth = 0;
+  for (let i = open; i < src.length; i += 1) {
+    if (src[i] === "{") depth += 1;
+    if (src[i] === "}" && --depth === 0) return src.slice(start, i + 1);
+  }
+  return null;
+}
+
+const buildHelper = () => {
+  const fn = namedFunctionSource(SRC, "awaitDuplicateReply");
+  assert.ok(fn, "awaitDuplicateReply not found");
+  const ms = SRC.match(/const DUPLICATE_AWAIT_MS = (\d+);/);
+  assert.ok(ms, "DUPLICATE_AWAIT_MS not found");
+  // Rebuilt with a tiny bound so the timeout path is testable in milliseconds.
+  return new Function(`const DUPLICATE_AWAIT_MS = 20; ${fn}; return awaitDuplicateReply;`)();
+};
+
+test("#646 a settled original is returned UNCHANGED — the bound never rewrites a real reply", async () => {
+  const awaitDuplicateReply = buildHelper();
+  const settled = { rid: "orig", ok: true, result: { node_id: 7 } };
+  assert.equal(await awaitDuplicateReply(settled, "dup"), settled, "same object, not a copy");
+  // And an in-flight one that DOES settle in time still wins the race.
+  const soon = new Promise((r) => setTimeout(() => r(settled), 1));
+  assert.equal(await awaitDuplicateReply(soon, "dup"), settled);
+});
+
+test("#646 an original that never settles yields an HONEST reply instead of silence", async () => {
+  const awaitDuplicateReply = buildHelper();
+  const never = new Promise(() => {}); // the stranded in-flight entry
+  const reply = await awaitDuplicateReply(never, "dup-rid");
+
+  assert.equal(reply.rid, "dup-rid", "correlated to the DUPLICATE's rid, which is what the caller waits on");
+  assert.equal(reply.ok, false);
+  // The two things the caller must not conclude: that it failed, or that it should retry.
+  assert.match(reply.error, /STILL RUNNING/);
+  assert.match(reply.error, /DO NOT RETRY/);
+  assert.match(reply.error, /nothing was applied twice/);
+  // ...and what they can actually do about it.
+  assert.match(reply.error, /Read the graph to see whether it took effect/);
+  // It must never claim the command failed — it did not, it has not finished.
+  assert.ok(!/failed|error occurred/i.test(reply.error.replace(/DO NOT RETRY/, "")));
+});
+
+test("#646 the ORIGINAL entry is never settled by the bound", async () => {
+  // The property that keeps the double-apply guarantee: the helper races against the promise
+  // it was handed and cannot resolve it. If a timeout could settle the ledger entry, a caller
+  // told "failed" would retry while the first mutation was still in flight.
+  const awaitDuplicateReply = buildHelper();
+  let settledWith = null;
+  const never = new Promise((resolve) => {
+    // Nothing calls this — the point is that the helper does not either.
+    settledWith = resolve;
+  });
+  await awaitDuplicateReply(never, "dup");
+  assert.ok(typeof settledWith === "function", "the original's resolver was captured");
+  // Still pending: racing it again with a short timer must time out a second time.
+  const again = await awaitDuplicateReply(never, "dup2");
+  assert.equal(again.rid, "dup2");
+  assert.equal(again.ok, false);
+});
+
+test("#646 the handler keeps the statement shape #508 and #694 pin", () => {
+  // The seam is the whole design: the bound lives in a helper that returns an ORDINARY reply,
+  // so the handler still has one await followed by the existing rid-rewrite and send. An
+  // earlier attempt put a still-in-flight BRANCH in that region and failed both guards —
+  // correctly, since #508 exists so a superseded early-return cannot precede the reply write.
+  assert.match(SRC, /dupReply = await awaitDuplicateReply\(priorRidReply, msg\.rid\);/);
+  const at = SRC.indexOf("dupReply = await awaitDuplicateReply");
+  const after = SRC.slice(at, at + 700);
+  // No branch introduced between the await and the reply write.
+  assert.ok(!/DUPLICATE_STILL_IN_FLIGHT/.test(SRC), "no sentinel branch survives");
+  assert.match(after, /const outReply = retryOfHit \? \{ \.\.\.dupReply, rid: msg\.rid \} : dupReply;/);
+});
+
+test("#646 the bound is longer than a fast reply and shorter than silence", () => {
+  const ms = Number(SRC.match(/const DUPLICATE_AWAIT_MS = (\d+);/)[1]);
+  // Above the orchestrator's short command timeouts (6s was in the report), so a merely SLOW
+  // duplicate still receives the real reply rather than this notice...
+  assert.ok(ms > 6000, `bound ${ms}ms must exceed a short command timeout`);
+  // ...and at or under the long ones (20s in the report), so a wedged executor produces an
+  // error rather than the silence this fixes.
+  assert.ok(ms >= 20000 && ms <= 30000, `bound ${ms}ms must land in the wedge-detecting range`);
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -16246,8 +16246,23 @@ function redactBridgeUrl(u) {
 //
 // The ORIGINAL entry is never settled by this. Answering "failed" for a command that may
 // still be running is how a caller retries into the double-apply the ledger exists to stop.
-const DUPLICATE_AWAIT_MS = 25000;
-function awaitDuplicateReply(prior, rid) {
+// The margin subtracted from the caller's OWN deadline, so the reply lands before they
+// give up rather than after. Small relative to any real command timeout.
+const DUPLICATE_AWAIT_MARGIN_MS = 1500;
+function awaitDuplicateReply(prior, rid, callerTimeoutMs) {
+  // NO GUESS. A bound is applied only when the frame told us how long the caller will wait
+  // (codex): the orchestrator computes a per-command timeout at ui-bridge.ts:3632 but does
+  // not put it in the frame at :4003, so today this is usually absent and the await stays
+  // exactly as unbounded as it is on main. Any fixed number would be a guess about another
+  // process's contract — and a guess that is too high changes nothing (25s cannot rescue a
+  // 20s deadline), while one that is too low reports 'still running' for a merely slow
+  // command. It also disposes of ask_user/request_secret without a special case: they carry
+  // long or absent deadlines, so a short bound never fires for them.
+  const budget =
+    Number.isFinite(callerTimeoutMs) && callerTimeoutMs > DUPLICATE_AWAIT_MARGIN_MS
+      ? callerTimeoutMs - DUPLICATE_AWAIT_MARGIN_MS
+      : null;
+  if (budget === null) return Promise.resolve(prior);
   return Promise.race([
     Promise.resolve(prior),
     new Promise((resolve) =>
@@ -16258,12 +16273,12 @@ function awaitDuplicateReply(prior, rid) {
             ok: false,
             error:
               "This request id is STILL RUNNING in the panel and has not produced an outcome after " +
-              Math.round(DUPLICATE_AWAIT_MS / 1000) +
+              Math.round(budget / 1000) +
               "s. This delivery was a DUPLICATE of it, so nothing new was started and nothing was " +
               "applied twice. DO NOT RETRY: the original may still complete, and re-issuing it is how " +
               "one mutation becomes two. Read the graph to see whether it took effect.",
           }),
-        DUPLICATE_AWAIT_MS,
+        budget,
       ),
     ),
   ]);
@@ -16880,7 +16895,7 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
         if (priorRidReply !== undefined) {
           let dupReply;
           try {
-            dupReply = await awaitDuplicateReply(priorRidReply, msg.rid);
+            dupReply = await awaitDuplicateReply(priorRidReply, msg.rid, msg.timeout_ms);
           } catch {
             return; // ledger promises never reject — defensive only
           }

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -16257,11 +16257,17 @@ function awaitDuplicateReply(prior, rid, callerTimeoutMs) {
   // process's contract — and a guess that is too high changes nothing (25s cannot rescue a
   // 20s deadline), while one that is too low reports 'still running' for a merely slow
   // command. It also disposes of ask_user/request_secret without a special case: they carry
-  // long or absent deadlines, so a short bound never fires for them.
-  const budget =
-    Number.isFinite(callerTimeoutMs) && callerTimeoutMs > DUPLICATE_AWAIT_MARGIN_MS
+  // deadlines long enough that a bound derived from them does not fire early. That is the
+  // ORCHESTRATOR's contract, not something this file enforces or can verify (codex).
+  // EVERY usable deadline gets a bound, including one at or below the margin (codex): a
+  // 1000ms timeout is neither absent nor invalid, and falling through to unbounded there
+  // would be a silent gap exactly where the caller gives up soonest. Below the margin the
+  // budget is half the deadline, which still lands before it.
+  const budget = !Number.isFinite(callerTimeoutMs) || callerTimeoutMs <= 0
+    ? null
+    : callerTimeoutMs > DUPLICATE_AWAIT_MARGIN_MS
       ? callerTimeoutMs - DUPLICATE_AWAIT_MARGIN_MS
-      : null;
+      : Math.floor(callerTimeoutMs / 2);
   if (budget === null) return Promise.resolve(prior);
   return Promise.race([
     Promise.resolve(prior),

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -16232,6 +16232,42 @@ function redactBridgeUrl(u) {
 // stamped on its receiving socket: a retained predecessor-process rid is
 // unknown in the new epoch and therefore fails open instead of replaying or
 // rejecting a prior session's command.
+// #646 — a duplicate delivery must not wait FOREVER on an in-flight original.
+//
+// The ledger records a command IN-FLIGHT at begin() and completes it at settleRid(). An
+// in-flight entry is never evicted, deliberately: dropping an unsettled command would let
+// its replay double-apply a mutation. So an executor that never returns leaves a redelivery
+// awaiting a promise that can never resolve, and the panel sends NOTHING — the caller sees
+// a timeout instead of an error, which is the reported shape.
+//
+// Bounded HERE, in a helper that returns an ordinary reply, so the handler keeps exactly the
+// statement shape #508 and #694 pin: one await, then the existing rid-rewrite and send. A
+// new branch in that region is what those guards forbid, and they are right to.
+//
+// The ORIGINAL entry is never settled by this. Answering "failed" for a command that may
+// still be running is how a caller retries into the double-apply the ledger exists to stop.
+const DUPLICATE_AWAIT_MS = 25000;
+function awaitDuplicateReply(prior, rid) {
+  return Promise.race([
+    Promise.resolve(prior),
+    new Promise((resolve) =>
+      setTimeout(
+        () =>
+          resolve({
+            rid,
+            ok: false,
+            error:
+              "This request id is STILL RUNNING in the panel and has not produced an outcome after " +
+              Math.round(DUPLICATE_AWAIT_MS / 1000) +
+              "s. This delivery was a DUPLICATE of it, so nothing new was started and nothing was " +
+              "applied twice. DO NOT RETRY: the original may still complete, and re-issuing it is how " +
+              "one mutation becomes two. Read the graph to see whether it took effect.",
+          }),
+        DUPLICATE_AWAIT_MS,
+      ),
+    ),
+  ]);
+}
 const commandRidLedger = createCommandDedupeLedger(200, (m) => console.warn(m));
 
 // #968 — WHAT last moved the active workflow. A stale binding and a fresh one are the same
@@ -16844,7 +16880,7 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
         if (priorRidReply !== undefined) {
           let dupReply;
           try {
-            dupReply = await priorRidReply;
+            dupReply = await awaitDuplicateReply(priorRidReply, msg.rid);
           } catch {
             return; // ledger promises never reject — defensive only
           }


### PR DESCRIPTION
**Do not merge.** The mechanism is sound and the double-apply guarantee holds, but the bound
is set above the deadline it exists to beat — which makes the whole change a no-op for the
reported failure.

## What survived review

- **Double-apply: PASS.** The helper races `Promise.resolve(prior)` against a timer and holds
  no ledger or resolver reference. A losing timer, or the original settling after the timer
  fired, only resolves its own race participant. The entry is still settled solely by
  `settleRid`, which is once-only.
- **Reply shape: PASS.** `{rid, ok:false, error}` composes with the retry-rid rewrite, and the
  synthetic reply carries no user payload, so redaction would pass it through if journaled.
- **No false execution result.** The original still settles and replies on its own rid; if its
  socket died that reply is journaled and replayed through the existing liveness path.

## P0 — the bound is 25s and the caller's deadline is 20s

The report this is built on shows `workflow_list` timing out at **6000 ms** and `graph_query`
at **20000 ms**. A duplicate does not receive the synthesized reply until **25000 ms**. The
caller has already given up. This preserves the exact failure it was written to remove.

Worse, my own test encoded the contradiction: it asserts the bound must be *"at or under the
long ones (20s)"* and then accepts anything up to 30s. That is a false claim I wrote and did
not catch — recorded rather than quietly corrected, because it is the reason this got as far
as review.

## P1 — the bound mislabels commands that legitimately block on a human

Dedupe runs before dispatch, and `ask_user` / `request_secret` await human input
indefinitely. After 25s their duplicate receives a graph-oriented "still running, read the
graph" notice, when the truthful answer is "a person has not answered yet".

## What it actually needs

1. **A bound below the relevant caller deadline** — or an honest admission that the panel does
   not know the caller's deadline, and a mechanism that does not depend on guessing it.
2. **Interactive commands excluded**, or given a message that matches what they are waiting
   for.

(1) is the real design question: the panel cannot see the orchestrator's per-command timeout,
so any fixed number is a guess about someone else's contract. A protocol-level progress or
result-follow-up signal is the alternative codex names, and it is a larger change than this.

Refs #646