### PR TITLE
fix(968): disclose when an open tab's canvas shares NO node ids with its own file

### DIFF
--- a/browser_tests/unit/canvas-file-divergence.test.mjs
+++ b/browser_tests/unit/canvas-file-divergence.test.mjs
@@ -98,8 +98,14 @@ test("#968 the note says what it compared and what it does NOT establish", () =>
   assert.match(note, /workflows\/B\.json/);
   assert.match(note, /3 node\(s\) on the canvas, 2 in the file, 0 in common/);
   // The alternative reading is NAMED, not dismissed — people do clear tabs and rebuild.
-  assert.match(note, /It is not proof/);
-  assert.match(note, /clearing this tab and building something new/);
+  assert.match(note, /It is NOT proof/);
+  // Codex named a second legitimate zero-overlap flow — pasting a whole graph in before
+  // saving — so the note names both rather than only the one I had thought of.
+  assert.match(note, /clearing this tab and rebuilding, or pasting an entire graph in/);
+  // Not an absolute claim about editing (codex): "usually keeps most ids", not "never
+  // replaces every id" — the mechanism does not establish the stronger form.
+  assert.match(note, /Incremental editing usually keeps most ids/);
+  assert.ok(!/does not replace every id/.test(note));
   // And the recovery that the reporter confirmed works.
   assert.match(note, /panel_load_workflow re-reads the file/);
   // It must not claim to know which workflow the canvas actually holds.

--- a/browser_tests/unit/canvas-file-divergence.test.mjs
+++ b/browser_tests/unit/canvas-file-divergence.test.mjs
@@ -1,0 +1,140 @@
+/**
+ * #968 — the canvas compared against the file it claims to be.
+ *
+ * The report that made this diagnosable: tab B was `modified:true`, its canvas held A's
+ * 44-node graph, and B on disk is a disjoint 40-node set. `panel_open_workflow(B)` asserted
+ * the canvas was bound to B, "differed only cosmetically", and there was "no missing work to
+ * redo". `panel_load_workflow(B)` — the one path that reads DISK — restored the right graph.
+ *
+ * Every check passed HONESTLY: the repaint loads from the tab's own state and the content
+ * proof compares the canvas against that state, while staleness compares the FILE against the
+ * tab's BASELINE. Nobody compared the file against the canvas, although that path had already
+ * read the file.
+ *
+ * DISCLOSURE, NOT PROOF — a user can clear a tab and build something new before saving, which
+ * is also disjoint. These tests pin that this never becomes a verdict.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+import {
+  canvasFileDivergence,
+  canvasFileDivergenceNote,
+} from "../../web/js/lib/canvas-file-divergence.js";
+
+const nodes = (...ids) => ids.map((id) => ({ id }));
+
+test("#968 THE REPORTED CASE: disjoint id sets are detected", () => {
+  const d = canvasFileDivergence({
+    diskNodes: nodes(...Array.from({ length: 40 }, (_, i) => 100 + i)),
+    canvasNodes: nodes(...Array.from({ length: 44 }, (_, i) => 1 + i)),
+  });
+  assert.equal(d.comparable, true);
+  assert.equal(d.disjoint, true);
+  assert.equal(d.shared, 0);
+  assert.equal(d.canvasCount, 44);
+  assert.equal(d.diskCount, 40);
+});
+
+test("#968 ORDINARY EDITING is not divergence — that is the false-positive to avoid", () => {
+  // Add two, delete one, move the rest: still overwhelmingly the same ids.
+  const d = canvasFileDivergence({
+    diskNodes: nodes(1, 2, 3, 4, 5),
+    canvasNodes: nodes(1, 2, 3, 5, 6, 7),
+  });
+  assert.equal(d.disjoint, false);
+  assert.equal(d.shared, 4);
+  assert.equal(d.canvasOnly, 2);
+  assert.equal(d.diskOnly, 1);
+  assert.equal(canvasFileDivergenceNote(d, "workflows/a.json"), null, "no note for an edited tab");
+});
+
+test("#968 numeric and string ids compare equal — a faithful round-trip is not divergence", () => {
+  // The canvas holds numbers; a file may hold either. Comparing types rather than values
+  // would report EVERY saved workflow as foreign, which is the worst possible false positive.
+  const d = canvasFileDivergence({ diskNodes: nodes("1", "2", "3"), canvasNodes: nodes(1, 2, 3) });
+  assert.equal(d.comparable, true);
+  assert.equal(d.disjoint, false);
+  assert.equal(d.shared, 3);
+});
+
+test("#968 an EMPTY side is not comparable — empty shares nothing with everything", () => {
+  // Without this, a brand-new empty tab and a genuinely empty file both read as "foreign".
+  for (const input of [
+    { diskNodes: nodes(1, 2), canvasNodes: [] },
+    { diskNodes: [], canvasNodes: nodes(1, 2) },
+    { diskNodes: [], canvasNodes: [] },
+  ]) {
+    const d = canvasFileDivergence(input);
+    assert.equal(d.comparable, false, JSON.stringify(input));
+    assert.equal(d.disjoint, false);
+  }
+});
+
+test("#968 an unreadable side is 'could not compare', never 'no nodes'", () => {
+  for (const bad of [null, undefined, {}, "nodes", 42]) {
+    assert.equal(canvasFileDivergence({ diskNodes: bad, canvasNodes: nodes(1) }).comparable, false);
+    assert.equal(canvasFileDivergence({ diskNodes: nodes(1), canvasNodes: bad }).comparable, false);
+  }
+  assert.equal(canvasFileDivergence().comparable, false);
+  assert.equal(canvasFileDivergence({}).comparable, false);
+});
+
+test("#968 nodes without usable ids are ignored rather than counted", () => {
+  const d = canvasFileDivergence({
+    diskNodes: [{ id: 1 }, { id: null }, {}, { id: "" }, { id: NaN }],
+    canvasNodes: [{ id: 1 }, { id: undefined }],
+  });
+  assert.equal(d.diskCount, 1);
+  assert.equal(d.canvasCount, 1);
+  assert.equal(d.disjoint, false);
+});
+
+test("#968 the note says what it compared and what it does NOT establish", () => {
+  const d = canvasFileDivergence({ diskNodes: nodes(9, 10), canvasNodes: nodes(1, 2, 3) });
+  const note = canvasFileDivergenceNote(d, "workflows/B.json");
+  assert.match(note, /shares NO node ids with its own file/);
+  assert.match(note, /workflows\/B\.json/);
+  assert.match(note, /3 node\(s\) on the canvas, 2 in the file, 0 in common/);
+  // The alternative reading is NAMED, not dismissed — people do clear tabs and rebuild.
+  assert.match(note, /It is not proof/);
+  assert.match(note, /clearing this tab and building something new/);
+  // And the recovery that the reporter confirmed works.
+  assert.match(note, /panel_load_workflow re-reads the file/);
+  // It must not claim to know which workflow the canvas actually holds.
+  assert.ok(!/the canvas holds workflow|this is workflow/i.test(note));
+});
+
+test("#968 no note unless the comparison actually ran and found nothing shared", () => {
+  assert.equal(canvasFileDivergenceNote(null, "p"), null);
+  assert.equal(canvasFileDivergenceNote({ comparable: false, disjoint: true }, "p"), null);
+  assert.equal(canvasFileDivergenceNote({ comparable: true, disjoint: false }, "p"), null);
+});
+
+test("#968 SOURCE: this decides nothing about whether a command may run", () => {
+  // The property that makes it safe to add while the CAUSE of the contamination is unknown.
+  // A refusal built on a heuristic that cannot tell "foreign graph" from "cleared and
+  // rebuilt" would be a wrong-graph refusal of its own.
+  const src = readFileSync(new URL("../../web/js/lib/canvas-file-divergence.js", import.meta.url), "utf8");
+  assert.match(src, /DISCLOSURE, NOT PROOF/);
+  const exported = [...src.matchAll(/^export function (\w+)/gm)].map((m) => m[1]).sort();
+  assert.deepEqual(exported, ["canvasFileDivergence", "canvasFileDivergenceNote"]);
+  assert.ok(!/\brefuse|\bthrow new Error|\bblock\b/i.test(src.slice(src.indexOf("export function"))));
+});
+
+test("#968 WIRED: the open path compares the file it already read against the canvas", () => {
+  const src = readFileSync(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8");
+  // Computed where onDiskContent is in hand — the whole point is that the read already
+  // happened and nobody used it for this.
+  assert.match(src, /canvasDivergence = canvasFileDivergence\(\{/);
+  assert.match(src, /diskNodes: diskParsed\?\.nodes,/);
+  assert.match(src, /canvasNodes: app\?\.graph\?\._nodes \?\? app\?\.graph\?\.nodes,/);
+  // Its OWN reply key: staleness is about the file changing, this is about the canvas not
+  // being that file's graph at all, and a caller can hit one without the other.
+  assert.match(src, /canvas_file_divergence: canvasFileDivergenceNote\(canvasDivergence, target\.path\)/);
+  // An unparseable file must not become a divergence claim.
+  const at = src.indexOf("canvasDivergence = canvasFileDivergence({");
+  const around = src.slice(at - 400, at + 700);
+  assert.match(around, /catch \{[\s\S]{0,300}?canvasDivergence = null;/);
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -339,6 +339,10 @@ import {
 import { pickRevertSnapshot, describeRevertOutcome, revertDidRestore } from "./lib/graph-revert.js";
 import { commandFingerprint, createCommandDedupeLedger } from "./lib/command-dedupe.js";
 import {
+  canvasFileDivergence,
+  canvasFileDivergenceNote,
+} from "./lib/canvas-file-divergence.js";
+import {
   MOVE_CAUSES,
   createActiveWorkflowProvenance,
 } from "./lib/active-workflow-provenance.js";
@@ -12771,6 +12775,7 @@ const GRAPH_TOOL_EXECUTORS = {
     let onDiskContent = null;
     let dirtyNow = false;
     let staleInfo = { stale: false, reload: false };
+    let canvasDivergence = null; // #968
     let reloaded = false;
     let reloadError = null;
     let openFailed = null;
@@ -13125,6 +13130,23 @@ const GRAPH_TOOL_EXECUTORS = {
         // and the reload decision below. (Interaction is frozen across this whole block, so
         // this is a belt-and-braces second line of defence, not the only one.)
         dirtyNow = !!target.isModified;
+        // #968 — the file is already read here, and nothing compared it to the CANVAS.
+        // decideOpenStaleness asks 'has the file changed since this tab loaded it?' by
+        // comparing disk against the tab's BASELINE; the content proof asks 'did the
+        // repaint reproduce the state it loaded?'. Both pass honestly when the tab's own
+        // state is carrying a DIFFERENT workflow's graph — which is the reported failure.
+        // Comparing the two artefacts already in hand is the one check nobody made.
+        try {
+          const diskParsed = typeof onDiskContent === "string" ? JSON.parse(onDiskContent) : onDiskContent;
+          canvasDivergence = canvasFileDivergence({
+            diskNodes: diskParsed?.nodes,
+            canvasNodes: app?.graph?._nodes ?? app?.graph?.nodes,
+          });
+        } catch {
+          // An unparseable file is 'could not compare', which the helper already means
+          // by leaving `comparable` false — never a divergence claim.
+          canvasDivergence = null;
+        }
         staleInfo = decideOpenStaleness({
           wasOpen,
           // EITHER signal counts as unsaved work: the flag as it reads NOW, and the snapshot
@@ -13332,6 +13354,12 @@ const GRAPH_TOOL_EXECUTORS = {
       // / no baseline) and must NOT claim fresh (codex P2). `reloaded` says whether this
       // call actually re-read the file: true = the canvas now shows the on-disk version;
       // false = it still shows the loaded version and the caller must act.
+      // #968 — a canvas that shares NO node ids with its own file. Its own key, not folded
+      // into stale_hint: staleness is about the FILE changing, this is about the CANVAS not
+      // being the file's graph at all, and a caller may hit one without the other.
+      ...(canvasFileDivergenceNote(canvasDivergence, target.path)
+        ? { canvas_file_divergence: canvasFileDivergenceNote(canvasDivergence, target.path) }
+        : {}),
       ...(staleInfo.stale === true
         ? {
             stale: true,

--- a/web/js/lib/canvas-file-divergence.js
+++ b/web/js/lib/canvas-file-divergence.js
@@ -1,0 +1,99 @@
+// #968 — the canvas and the file it claims to be, compared directly.
+//
+// The reported failure: a tab marked `modified` whose live canvas held a DIFFERENT
+// workflow's graph, while every check reported healthy. They all reported healthy honestly:
+//
+//   * `panel_open_workflow` repaints from the tab's own `activeState` and proves the result
+//     against THAT state — so a tab whose state is already carrying foreign content
+//     reproduces it faithfully and the proof passes;
+//   * `decideOpenStaleness` compares the FILE against the tab's BASELINE, answering "has the
+//     file changed since load?" — a different question;
+//   * nothing compared the file against the canvas, even though that path had already read
+//     the file.
+//
+// So this compares the two artefacts already in hand. The signal is node IDENTITY, not
+// content: edits move, add and delete nodes, they do not replace the entire id set. A dirty
+// tab whose canvas shares NO ids with its own file is not what editing looks like.
+//
+// DISCLOSURE, NOT PROOF, and the distinction is load-bearing. A user can clear a tab and
+// build something new before saving, which is also disjoint. So nothing here decides whether
+// a command may run — it exists so a reply stops claiming "no missing work to redo" about a
+// canvas it has just been shown to share nothing with. A refusal built on this would be a
+// wrong-graph refusal of its own.
+//
+// Dependency-free (no DOM, no LiteGraph). Unit-testable with plain fixtures.
+
+/** Node ids from a parsed workflow graph or a live root graph. Absent → null, which is
+ *  "could not compare", never "no nodes". */
+function nodeIdSet(nodes) {
+  if (!Array.isArray(nodes)) return null;
+  const ids = new Set();
+  for (const node of nodes) {
+    const id = node?.id;
+    // Ids are numbers on the canvas and may be numbers or numeric strings in a file. Compare
+    // them as strings so a faithful round-trip is never reported as divergence.
+    if (typeof id === "number" && Number.isFinite(id)) ids.add(String(id));
+    else if (typeof id === "string" && id) ids.add(id);
+  }
+  return ids;
+}
+
+/**
+ * @param {{ diskNodes?: unknown, canvasNodes?: unknown }} input
+ * @returns {{
+ *   comparable: boolean, disjoint: boolean,
+ *   shared: number, canvasOnly: number, diskOnly: number,
+ *   canvasCount: number, diskCount: number,
+ * }}
+ *
+ * `comparable:false` whenever either side is unreadable OR either is empty — an empty set
+ * shares nothing with everything, so calling that "disjoint" would flag every new tab and
+ * every genuinely-empty file as foreign.
+ */
+export function canvasFileDivergence({ diskNodes, canvasNodes } = {}) {
+  const disk = nodeIdSet(diskNodes);
+  const canvas = nodeIdSet(canvasNodes);
+  const none = {
+    comparable: false,
+    disjoint: false,
+    shared: 0,
+    canvasOnly: 0,
+    diskOnly: 0,
+    canvasCount: canvas ? canvas.size : 0,
+    diskCount: disk ? disk.size : 0,
+  };
+  if (!disk || !canvas || disk.size === 0 || canvas.size === 0) return none;
+
+  let shared = 0;
+  for (const id of canvas) if (disk.has(id)) shared += 1;
+  return {
+    comparable: true,
+    disjoint: shared === 0,
+    shared,
+    canvasOnly: canvas.size - shared,
+    diskOnly: disk.size - shared,
+    canvasCount: canvas.size,
+    diskCount: disk.size,
+  };
+}
+
+/**
+ * The sentence a reply carries when the two share nothing.
+ *
+ * States what was compared and what it does NOT establish. The alternative reading — that
+ * the user cleared this tab and built something new — is named rather than dismissed,
+ * because it is a real thing people do and the panel cannot tell the two apart.
+ */
+export function canvasFileDivergenceNote(divergence, path) {
+  if (!divergence || !divergence.comparable || !divergence.disjoint) return null;
+  const where = typeof path === "string" && path ? ` (${path})` : "";
+  return (
+    `WARNING — this canvas shares NO node ids with its own file${where}: ` +
+    `${divergence.canvasCount} node(s) on the canvas, ${divergence.diskCount} in the file, ` +
+    `0 in common. Editing moves, adds and deletes nodes; it does not replace every id, so ` +
+    `this is what a canvas holding a DIFFERENT workflow looks like. It is not proof — ` +
+    `clearing this tab and building something new before saving would look the same. ` +
+    `Before trusting a read or making an edit here, confirm which graph you have: ` +
+    `panel_load_workflow re-reads the file, and is the recovery reported to work.`
+  );
+}

--- a/web/js/lib/canvas-file-divergence.js
+++ b/web/js/lib/canvas-file-divergence.js
@@ -12,11 +12,12 @@
 //     the file.
 //
 // So this compares the two artefacts already in hand. The signal is node IDENTITY, not
-// content: edits move, add and delete nodes, they do not replace the entire id set. A dirty
-// tab whose canvas shares NO ids with its own file is not what editing looks like.
+// content: incremental editing usually keeps most ids, so a dirty tab whose canvas shares
+// NO ids with its own file is not what editing looks like. (Not an absolute — a whole-graph
+// paste before saving looks the same, which is why this discloses rather than decides.)
 //
 // DISCLOSURE, NOT PROOF, and the distinction is load-bearing. A user can clear a tab and
-// build something new before saving, which is also disjoint. So nothing here decides whether
+// rebuild, or paste an entire graph in, before saving — both are also disjoint (codex). So nothing here decides whether
 // a command may run — it exists so a reply stops claiming "no missing work to redo" about a
 // canvas it has just been shown to share nothing with. A refusal built on this would be a
 // wrong-graph refusal of its own.
@@ -90,9 +91,9 @@ export function canvasFileDivergenceNote(divergence, path) {
   return (
     `WARNING — this canvas shares NO node ids with its own file${where}: ` +
     `${divergence.canvasCount} node(s) on the canvas, ${divergence.diskCount} in the file, ` +
-    `0 in common. Editing moves, adds and deletes nodes; it does not replace every id, so ` +
-    `this is what a canvas holding a DIFFERENT workflow looks like. It is not proof — ` +
-    `clearing this tab and building something new before saving would look the same. ` +
+    `0 in common. Incremental editing usually keeps most ids, so zero overlap is what a ` +
+    `canvas holding a DIFFERENT workflow looks like. It is NOT proof — clearing this tab ` +
+    `and rebuilding, or pasting an entire graph in, before saving would look the same. ` +
     `Before trusting a read or making an edit here, confirm which graph you have: ` +
     `panel_load_workflow re-reads the file, and is the recovery reported to work.`
   );


### PR DESCRIPTION
The newest #968 report is the first with enough detail to diagnose the family, and it shows every existing check passing honestly while the canvas held another workflow's graph:

- tab B was `modified:true`, its canvas held A's 44 nodes, B on disk has a disjoint 40-node id set;
- `panel_open_workflow(B)` asserted the canvas was bound to B, differed only cosmetically, and there was "no missing work to redo";
- `panel_load_workflow(B)` — the one path that reads DISK — restored the correct graph.

**Why nothing caught it.** The repaint loads from the tab's own `activeState` and the content proof compares the canvas against *that*. If the tab's state is itself carrying foreign content, the repaint faithfully reproduces the wrong graph and the proof passes. Meanwhile `decideOpenStaleness` compares the FILE against the tab's BASELINE, never against the canvas.

**The evidence is already in hand.** That path already reads the file into `onDiskContent`. Nobody compares it to the live canvas.

**Planned:** when those two are both available, compare node id sets. A dirty tab whose canvas shares NO ids with its own file is not what editing looks like — edits move, add and delete nodes, they do not replace the whole id set.

**Disclosure, not refusal.** It is a strong indicator, not proof (a user can clear a tab and build something new before saving), so it changes no trust decision and cannot become a wrong-graph edit of its own. It stops the reply claiming "no missing work to redo" when it has just read a file that shares nothing with the canvas it is describing.

Draft first, per the loop. Codex review before merge.

Refs #968