### PR TITLE
fix(1066): a URL-derived workflow directory is its own case, not an external file

### DIFF
--- a/browser_tests/unit/url-directory-save.test.mjs
+++ b/browser_tests/unit/url-directory-save.test.mjs
@@ -85,12 +85,24 @@ test("#1066 a bare colon is not a scheme — '//' is what makes it a URL", () =>
   }
 });
 
-test("#1066 opaque schemes are deliberately NOT matched, and the source says why", () => {
-  // Catching `blob:`/`data:` needs a bare `scheme:`, which would also hit real folder names.
-  // The reported shape is hierarchical, so the trade buys nothing.
-  assert.equal(isUrlDerived("blob:http://127.0.0.1:8188/abc"), true, "this one contains :// anyway");
-  assert.equal(isUrlDerived("data:application/json,{}"), false);
-  assert.match(SRC, /Opaque schemes \(`blob:`, `data:`\) are deliberately NOT/);
+test("#1066 what stays unmatched is narrower than 'opaque schemes'", () => {
+  // An earlier comment of mine claimed `blob:` was not matched. It IS — on its embedded
+  // hierarchical URL (codex). Only a form carrying no "://" at all stays out.
+  assert.equal(isUrlDerived("blob:http://127.0.0.1:8188/abc"), true, "matches on the embedded http://");
+  assert.equal(isUrlDerived("data:application/json,{}"), false, "no :// anywhere");
+});
+
+test("#1066 THE KNOWN FALSE POSITIVE, tested as behaviour rather than as prose", () => {
+  // A previous version of this test asserted that a comment existed, which proves nothing
+  // about what the code does (codex). On POSIX a managed directory can syntactically contain
+  // "://", and this predicate DOES match it — so such a tab's Save-As is redirected to the
+  // workflows root. That is the accepted cost: a redirected save is recoverable and visible,
+  // where the 500 it replaces left the tab unsaveable under any name.
+  assert.equal(isUrlDerived("workflows/notes://draft"), true, "a legal POSIX folder name matches");
+  assert.equal(isUrlDerived("workflows/a/b://c"), true);
+  // It cannot arise on Windows, where ":" is illegal in a filename — so the exposure is
+  // limited to POSIX deployments that use such a name deliberately.
+  assert.equal(isUrlDerived("workflows/notes-draft"), false, "the ordinary spelling is unaffected");
 });
 
 test("#1066 the directory redirect consumes it and sends the save to the workflows root", () => {
@@ -100,10 +112,3 @@ test("#1066 the directory redirect consumes it and sends the save to the workflo
   );
 });
 
-test("#1066 the POSIX false positive is acknowledged rather than discovered later", () => {
-  // A relative managed directory can syntactically contain "://" on POSIX. Accepted
-  // knowingly: such a directory cannot round-trip through /userdata anyway, and a save
-  // redirected to the root is recoverable where a 500 is not.
-  assert.match(SRC, /On POSIX a managed directory could syntactically contain/);
-  assert.match(SRC, /recoverable where a 500 is not/);
-});

--- a/browser_tests/unit/url-directory-save.test.mjs
+++ b/browser_tests/unit/url-directory-save.test.mjs
@@ -1,17 +1,18 @@
 /**
- * #1066 — a URL-shaped workflow DIRECTORY made a tab unsaveable under any name.
+ * #1066 — a URL-derived workflow directory made a tab unsaveable under any name.
  *
- * ComfyUI mints a temporary workflow whose `path` is the URL an asset was opened from:
+ * ComfyUI mints a TEMPORARY workflow whose path is the URL an asset was opened from:
  *
  *     workflows/http://127.0.0.1:8188/api/view?filename=x.png&type=output&subfolder=…
  *
- * Renaming that tab replaces only the FILENAME, so the URL survives as the tab's DIRECTORY.
- * `isExternalWorkflowPath()` redirected a Save-As to the workflows root for a drive letter
- * (`^[a-zA-Z]:`) or a leading separator — and a URL is neither: its colon sits at index 4 and
- * it has no leading slash. So the directory was accepted verbatim, the save built
- * `workflows/http://127.0.0.1:8188/api/Name.json`, and /userdata rejected it with a 500.
+ * Renaming that tab replaces only the FILENAME, so the URL survives as the tab's DIRECTORY —
+ * WITH the managed `workflows/` prefix still on the front. `directoryOf()` accepted it
+ * verbatim, the save built `workflows/http://127.0.0.1:8188/api/Name.json`, and /userdata
+ * rejected it with a 500.
  *
- * These exercise the classifier through the module's own source, since it is file-private.
+ * Every value below is the shape the code actually receives. An earlier version of this file
+ * passed a BARE `http://…`, which let an anchored regex look correct while missing the bug:
+ * the test agreed with the code and both disagreed with the report.
  */
 import test from "node:test";
 import assert from "node:assert/strict";
@@ -19,74 +20,90 @@ import { readFileSync } from "node:fs";
 
 const SRC = readFileSync(new URL("../../web/js/lib/workflow-save.js", import.meta.url), "utf8");
 
-/** The classifier, rebuilt from the shipped source so a drift in either is caught. */
-const isExternal = (() => {
-  const start = SRC.indexOf("function isExternalWorkflowPath(");
-  assert.ok(start > 0, "isExternalWorkflowPath not found");
+/** Rebuild a file-private predicate from the shipped source, brace-balanced past the
+ *  parameter list. */
+function rebuild(name) {
+  const start = SRC.indexOf(`function ${name}(`);
+  assert.ok(start > 0, `${name} not found`);
   const open = SRC.indexOf(") {", start) + 2;
   let depth = 0;
-  let end = -1;
   for (let i = open; i < SRC.length; i += 1) {
     if (SRC[i] === "{") depth += 1;
     if (SRC[i] === "}" && --depth === 0) {
-      end = i + 1;
-      break;
+      return new Function(`${SRC.slice(start, i + 1)}; return ${name};`)();
     }
   }
-  return new Function(`${SRC.slice(start, end)}; return isExternalWorkflowPath;`)();
-})();
+  throw new Error(`${name} body not balanced`);
+}
 
-test("#1066 THE REPORTED SHAPE: a URL directory is external", () => {
-  assert.equal(isExternal("http://127.0.0.1:8188/api/view?filename=x.png&type=output"), true);
-  assert.equal(isExternal("https://example.com/things"), true);
-  // A scheme, not the literal "http", so file: and any custom scheme are covered too.
-  for (const url of ["file:///C:/tmp/x.json", "ftp://host/dir", "x-custom+scheme.v2://host/path"]) {
-    assert.equal(isExternal(url), true, url);
-  }
-  // DELIBERATELY NOT COVERED: opaque schemes with no "//" — `blob:http://…`, `data:…`.
-  // Catching those means accepting a bare `scheme:`, which would also classify an ordinary
-  // folder named "notes:draft" as external and silently redirect its saves. ComfyUI mints
-  // these tabs from an asset URL, which is hierarchical, so the reported shape is covered;
-  // an opaque-scheme directory is unobserved and left failing the way it does today rather
-  // than traded for a false positive on a real folder name.
-  assert.equal(isExternal("blob:http://127.0.0.1:8188/abc"), false);
-  assert.equal(isExternal("data:application/json,{}"), false);
+const isUrlDerived = rebuild("isUrlDerivedWorkflowPath");
+const isExternal = rebuild("isExternalWorkflowPath");
+
+/** The directory the reporter's tab actually carries — managed prefix retained. */
+const REPORTED_DIR = "workflows/http://127.0.0.1:8188/api";
+const REPORTED_PATH =
+  "workflows/http://127.0.0.1:8188/api/view?filename=x.png&type=output&subfolder=anima%5Cpreset%5C10-framing-basic";
+
+test("#1066 THE VERBATIM REPORTED VALUE is recognised", () => {
+  // Not anchored: the `workflows/` prefix is still there. Anchoring is exactly how the first
+  // attempt missed this while its own test passed.
+  assert.equal(isUrlDerived(REPORTED_DIR), true);
+  assert.equal(isUrlDerived(REPORTED_PATH), true);
+  // A bare URL too, since a caller may have already stripped the prefix.
+  assert.equal(isUrlDerived("http://127.0.0.1:8188/api"), true);
 });
 
-test("#1066 the everyday managed path is untouched — that is the regression to avoid", () => {
-  // A managed store path is relative "workflows/…": no drive letter, no leading separator,
-  // no scheme. Redirecting one of these would break every ordinary Save-As.
-  for (const p of ["workflows", "workflows/sub", "workflows/deep/nested", "my folder", ""]) {
-    assert.equal(isExternal(p), false, JSON.stringify(p));
-  }
-});
-
-test("#1066 the two shapes this already caught still classify as external", () => {
-  for (const p of ["C:/packs/Foo.json", "C:Foo.json", "/packs/Foo.json", "\\packs\\Foo.json", "//server/share"]) {
+test("#1066 it is NOT folded into isExternalWorkflowPath — they mean different things", () => {
+  // isExternalWorkflowPath gates the low-level root-COPY route, whose premise is that the
+  // source is a REAL existing file: it records `save-as-copy` and refuses outright when the
+  // copy API is missing, to avoid moving or destroying the original. A URL source is not a
+  // file — there is nothing to copy and nothing to destroy — and classifying it as external
+  // kept the tab unsaveable by a different route. The reporter's first successful save came
+  // only from treating that source as never persisted (codex).
+  assert.equal(isExternal(REPORTED_DIR), false, "a URL directory is not an external FILE");
+  assert.equal(isExternal("http://127.0.0.1:8188/api"), false);
+  // The shapes it does own are untouched.
+  for (const p of ["C:/packs/Foo.json", "C:Foo.json", "/packs/Foo.json", "\\packs\\Foo.json"]) {
     assert.equal(isExternal(p), true, p);
   }
 });
 
-test("#1066 a bare colon is NOT a scheme — the '//' is what makes it a URL", () => {
-  // Without requiring "//", a Windows drive letter would match the new test as well as the
-  // old one (harmless), but so would an ordinary name containing a colon — and a folder
-  // called "notes:draft" is a managed directory, not somewhere unwritable.
-  assert.equal(isExternal("notes:draft"), false);
-  assert.equal(isExternal("workflows/a:b"), false);
-  // ...while a real scheme still resolves as external.
-  assert.equal(isExternal("x-custom+scheme.v2://host/path"), true);
+test("#1066 ordinary managed directories are untouched — the regression to avoid", () => {
+  for (const p of ["workflows", "workflows/sub", "workflows/deep/nested", "my folder", ""]) {
+    assert.equal(isUrlDerived(p), false, JSON.stringify(p));
+  }
 });
 
-test("#1066 the directory redirect is what consumes this, and it sends the copy to the root", () => {
-  // directoryOf() is the caller: an external directory becomes `${WORKFLOWS_ROOT}/`, so the
-  // Save-As copy lands somewhere writable instead of building an unwritable target path.
-  assert.match(SRC, /if \(!dir \|\| isExternalWorkflowPath\(dir\)\) return `\$\{WORKFLOWS_ROOT\}\/`;/);
+test("#1066 a bare colon is not a scheme — '//' is what makes it a URL", () => {
+  // Without requiring "//", a folder legitimately named "notes:draft" would be redirected.
+  assert.equal(isUrlDerived("notes:draft"), false);
+  assert.equal(isUrlDerived("workflows/a:b"), false);
+  assert.equal(isUrlDerived("C:/packs/Foo.json"), false, "a drive letter is not a scheme");
+  // ...while any real hierarchical scheme is caught, not just http.
+  for (const u of ["file:///C:/tmp/x.json", "ftp://host/dir", "x-custom+scheme.v2://host/p"]) {
+    assert.equal(isUrlDerived(u), true, u);
+  }
 });
 
-test("#1066 the comment records the shape and why both old tests missed it", () => {
-  const at = SRC.indexOf("function isExternalWorkflowPath(");
-  const body = SRC.slice(at - 1400, at + 1400);
-  assert.match(body, /#1066/);
-  assert.match(body, /colon sits at index 4/, "why the drive-letter test does not fire");
-  assert.match(body, /renaming that tab replaces\s*\r?\n?\s*\/\/ only the FILENAME/i, "how the URL survives as a directory");
+test("#1066 opaque schemes are deliberately NOT matched, and the source says why", () => {
+  // Catching `blob:`/`data:` needs a bare `scheme:`, which would also hit real folder names.
+  // The reported shape is hierarchical, so the trade buys nothing.
+  assert.equal(isUrlDerived("blob:http://127.0.0.1:8188/abc"), true, "this one contains :// anyway");
+  assert.equal(isUrlDerived("data:application/json,{}"), false);
+  assert.match(SRC, /Opaque schemes \(`blob:`, `data:`\) are deliberately NOT/);
+});
+
+test("#1066 the directory redirect consumes it and sends the save to the workflows root", () => {
+  assert.match(
+    SRC,
+    /if \(!dir \|\| isExternalWorkflowPath\(dir\) \|\| isUrlDerivedWorkflowPath\(dir\)\) return `\$\{WORKFLOWS_ROOT\}\/`;/,
+  );
+});
+
+test("#1066 the POSIX false positive is acknowledged rather than discovered later", () => {
+  // A relative managed directory can syntactically contain "://" on POSIX. Accepted
+  // knowingly: such a directory cannot round-trip through /userdata anyway, and a save
+  // redirected to the root is recoverable where a 500 is not.
+  assert.match(SRC, /On POSIX a managed directory could syntactically contain/);
+  assert.match(SRC, /recoverable where a 500 is not/);
 });

--- a/browser_tests/unit/url-directory-save.test.mjs
+++ b/browser_tests/unit/url-directory-save.test.mjs
@@ -1,0 +1,92 @@
+/**
+ * #1066 — a URL-shaped workflow DIRECTORY made a tab unsaveable under any name.
+ *
+ * ComfyUI mints a temporary workflow whose `path` is the URL an asset was opened from:
+ *
+ *     workflows/http://127.0.0.1:8188/api/view?filename=x.png&type=output&subfolder=…
+ *
+ * Renaming that tab replaces only the FILENAME, so the URL survives as the tab's DIRECTORY.
+ * `isExternalWorkflowPath()` redirected a Save-As to the workflows root for a drive letter
+ * (`^[a-zA-Z]:`) or a leading separator — and a URL is neither: its colon sits at index 4 and
+ * it has no leading slash. So the directory was accepted verbatim, the save built
+ * `workflows/http://127.0.0.1:8188/api/Name.json`, and /userdata rejected it with a 500.
+ *
+ * These exercise the classifier through the module's own source, since it is file-private.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const SRC = readFileSync(new URL("../../web/js/lib/workflow-save.js", import.meta.url), "utf8");
+
+/** The classifier, rebuilt from the shipped source so a drift in either is caught. */
+const isExternal = (() => {
+  const start = SRC.indexOf("function isExternalWorkflowPath(");
+  assert.ok(start > 0, "isExternalWorkflowPath not found");
+  const open = SRC.indexOf(") {", start) + 2;
+  let depth = 0;
+  let end = -1;
+  for (let i = open; i < SRC.length; i += 1) {
+    if (SRC[i] === "{") depth += 1;
+    if (SRC[i] === "}" && --depth === 0) {
+      end = i + 1;
+      break;
+    }
+  }
+  return new Function(`${SRC.slice(start, end)}; return isExternalWorkflowPath;`)();
+})();
+
+test("#1066 THE REPORTED SHAPE: a URL directory is external", () => {
+  assert.equal(isExternal("http://127.0.0.1:8188/api/view?filename=x.png&type=output"), true);
+  assert.equal(isExternal("https://example.com/things"), true);
+  // A scheme, not the literal "http", so file: and any custom scheme are covered too.
+  for (const url of ["file:///C:/tmp/x.json", "ftp://host/dir", "x-custom+scheme.v2://host/path"]) {
+    assert.equal(isExternal(url), true, url);
+  }
+  // DELIBERATELY NOT COVERED: opaque schemes with no "//" — `blob:http://…`, `data:…`.
+  // Catching those means accepting a bare `scheme:`, which would also classify an ordinary
+  // folder named "notes:draft" as external and silently redirect its saves. ComfyUI mints
+  // these tabs from an asset URL, which is hierarchical, so the reported shape is covered;
+  // an opaque-scheme directory is unobserved and left failing the way it does today rather
+  // than traded for a false positive on a real folder name.
+  assert.equal(isExternal("blob:http://127.0.0.1:8188/abc"), false);
+  assert.equal(isExternal("data:application/json,{}"), false);
+});
+
+test("#1066 the everyday managed path is untouched — that is the regression to avoid", () => {
+  // A managed store path is relative "workflows/…": no drive letter, no leading separator,
+  // no scheme. Redirecting one of these would break every ordinary Save-As.
+  for (const p of ["workflows", "workflows/sub", "workflows/deep/nested", "my folder", ""]) {
+    assert.equal(isExternal(p), false, JSON.stringify(p));
+  }
+});
+
+test("#1066 the two shapes this already caught still classify as external", () => {
+  for (const p of ["C:/packs/Foo.json", "C:Foo.json", "/packs/Foo.json", "\\packs\\Foo.json", "//server/share"]) {
+    assert.equal(isExternal(p), true, p);
+  }
+});
+
+test("#1066 a bare colon is NOT a scheme — the '//' is what makes it a URL", () => {
+  // Without requiring "//", a Windows drive letter would match the new test as well as the
+  // old one (harmless), but so would an ordinary name containing a colon — and a folder
+  // called "notes:draft" is a managed directory, not somewhere unwritable.
+  assert.equal(isExternal("notes:draft"), false);
+  assert.equal(isExternal("workflows/a:b"), false);
+  // ...while a real scheme still resolves as external.
+  assert.equal(isExternal("x-custom+scheme.v2://host/path"), true);
+});
+
+test("#1066 the directory redirect is what consumes this, and it sends the copy to the root", () => {
+  // directoryOf() is the caller: an external directory becomes `${WORKFLOWS_ROOT}/`, so the
+  // Save-As copy lands somewhere writable instead of building an unwritable target path.
+  assert.match(SRC, /if \(!dir \|\| isExternalWorkflowPath\(dir\)\) return `\$\{WORKFLOWS_ROOT\}\/`;/);
+});
+
+test("#1066 the comment records the shape and why both old tests missed it", () => {
+  const at = SRC.indexOf("function isExternalWorkflowPath(");
+  const body = SRC.slice(at - 1400, at + 1400);
+  assert.match(body, /#1066/);
+  assert.match(body, /colon sits at index 4/, "why the drive-letter test does not fire");
+  assert.match(body, /renaming that tab replaces\s*\r?\n?\s*\/\/ only the FILENAME/i, "how the URL survives as a directory");
+});

--- a/web/js/lib/workflow-save.js
+++ b/web/js/lib/workflow-save.js
@@ -1340,7 +1340,19 @@ function isExternalWorkflowPath(path) {
   // directory and is still outside the managed /userdata store. A managed store path is
   // always relative "workflows/…" (no drive letter, no leading separator), so this
   // never touches the everyday save path.
-  return /^[a-zA-Z]:/.test(raw) || /^[\\/]/.test(raw);
+  // #1066 — a URL is external too, and it was the one shape both tests missed. ComfyUI
+  // mints a TEMPORARY workflow whose path is the URL an asset was opened from
+  // (`workflows/http://127.0.0.1:8188/api/view?filename=…`), and renaming that tab replaces
+  // only the FILENAME — so the URL survives as the tab's DIRECTORY. It has no leading
+  // separator, and its colon sits at index 4 rather than 1, so neither test above fires:
+  // the directory was accepted verbatim and the save built
+  // `workflows/http://127.0.0.1:8188/api/Name.json`, which /userdata rejects with a 500.
+  // The tab could not be saved under ANY name.
+  //
+  // A scheme is checked rather than the literal "http", so file:, blob: and data: are
+  // covered by the same rule. Requiring "//" after the colon keeps this away from an
+  // ordinary Windows drive letter, which the first test already owns.
+  return /^[a-zA-Z]:/.test(raw) || /^[\\/]/.test(raw) || /^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//.test(raw);
 }
 
 /** Directory prefix (with trailing slash) that a new sibling file should live in,

--- a/web/js/lib/workflow-save.js
+++ b/web/js/lib/workflow-save.js
@@ -1340,19 +1340,33 @@ function isExternalWorkflowPath(path) {
   // directory and is still outside the managed /userdata store. A managed store path is
   // always relative "workflows/…" (no drive letter, no leading separator), so this
   // never touches the everyday save path.
-  // #1066 — a URL is external too, and it was the one shape both tests missed. ComfyUI
-  // mints a TEMPORARY workflow whose path is the URL an asset was opened from
-  // (`workflows/http://127.0.0.1:8188/api/view?filename=…`), and renaming that tab replaces
-  // only the FILENAME — so the URL survives as the tab's DIRECTORY. It has no leading
-  // separator, and its colon sits at index 4 rather than 1, so neither test above fires:
-  // the directory was accepted verbatim and the save built
-  // `workflows/http://127.0.0.1:8188/api/Name.json`, which /userdata rejects with a 500.
-  // The tab could not be saved under ANY name.
-  //
-  // A scheme is checked rather than the literal "http", so file:, blob: and data: are
-  // covered by the same rule. Requiring "//" after the colon keeps this away from an
-  // ordinary Windows drive letter, which the first test already owns.
-  return /^[a-zA-Z]:/.test(raw) || /^[\\/]/.test(raw) || /^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//.test(raw);
+  return /^[a-zA-Z]:/.test(raw) || /^[\\/]/.test(raw);
+}
+
+/** #1066 — a URL-DERIVED workflow path, which is a different thing from an external file.
+ *
+ *  ComfyUI mints a TEMPORARY workflow whose path is the URL an asset was opened from:
+ *  `workflows/http://127.0.0.1:8188/api/view?filename=x.png&type=output&…`. Renaming that
+ *  tab replaces only the FILENAME, so the URL survives as the tab's DIRECTORY — and the
+ *  managed `workflows/` prefix is RETAINED, which is why this is not anchored. An earlier
+ *  attempt anchored it at position 0 and therefore never fired on the reported value.
+ *
+ *  WHY A SEPARATE PREDICATE, rather than widening isExternalWorkflowPath (codex): that one
+ *  also gates the low-level root-copy route, whose whole premise is that the source is a
+ *  REAL existing file being copied — it records `save-as-copy` and refuses outright when the
+ *  copy API is missing, to avoid moving or destroying the original. A URL source is not a
+ *  file at all; there is nothing to copy and nothing to destroy. Classifying it as external
+ *  would keep the tab unsaveable by a different route, which is what the reporter observed:
+ *  their first successful save came only from treating the URL source as never persisted.
+ *
+ *  Requiring "//" keeps this off an ordinary Windows drive letter and off a folder
+ *  legitimately named "notes:draft". Opaque schemes (`blob:`, `data:`) are deliberately NOT
+ *  matched: catching them needs a bare `scheme:`, which would hit real folder names, and the
+ *  reported shape is hierarchical. On POSIX a managed directory could syntactically contain
+ *  "://" — accepted knowingly, because such a directory cannot round-trip through /userdata
+ *  anyway, and a save redirected to the workflows root is recoverable where a 500 is not. */
+function isUrlDerivedWorkflowPath(path) {
+  return /[a-zA-Z][a-zA-Z0-9+.-]*:\/\//.test(String(path || ""));
 }
 
 /** Directory prefix (with trailing slash) that a new sibling file should live in,
@@ -1361,7 +1375,10 @@ function isExternalWorkflowPath(path) {
  *  user workflows root (#285). Defaults to the workflows root. */
 function directoryOf(wf) {
   const dir = String(wf?.directory || "").replace(/[\\/]+$/, "");
-  if (!dir || isExternalWorkflowPath(dir)) return `${WORKFLOWS_ROOT}/`;
+  // #1066 — a URL-derived directory is redirected too. It is not a writable managed
+  // folder, and accepting it verbatim built `workflows/http://…/Name.json`, which
+  // /userdata rejects with a 500 — leaving the tab unsaveable under ANY name.
+  if (!dir || isExternalWorkflowPath(dir) || isUrlDerivedWorkflowPath(dir)) return `${WORKFLOWS_ROOT}/`;
   return `${dir}/`;
 }
 

--- a/web/js/lib/workflow-save.js
+++ b/web/js/lib/workflow-save.js
@@ -1360,11 +1360,18 @@ function isExternalWorkflowPath(path) {
  *  their first successful save came only from treating the URL source as never persisted.
  *
  *  Requiring "//" keeps this off an ordinary Windows drive letter and off a folder
- *  legitimately named "notes:draft". Opaque schemes (`blob:`, `data:`) are deliberately NOT
- *  matched: catching them needs a bare `scheme:`, which would hit real folder names, and the
- *  reported shape is hierarchical. On POSIX a managed directory could syntactically contain
- *  "://" — accepted knowingly, because such a directory cannot round-trip through /userdata
- *  anyway, and a save redirected to the workflows root is recoverable where a 500 is not. */
+ *  legitimately named "notes:draft".
+ *
+ *  What that leaves unmatched is narrower than "opaque schemes" (codex): `blob:http://…`
+ *  DOES match, on its embedded hierarchical URL. Only a form carrying no "://" at all —
+ *  `data:application/json,{}` — stays unmatched. Catching those needs a bare `scheme:`,
+ *  which would hit real folder names, and no reported shape needs it.
+ *
+ *  KNOWN FALSE POSITIVE: on POSIX a managed directory may syntactically contain "://"
+ *  (`workflows/notes://draft`), and this redirects its Save-As to the workflows root. Taken
+ *  knowingly rather than discovered later — a redirected save is recoverable and visible,
+ *  where the 500 it replaces left the tab unsaveable under any name. It cannot arise on
+ *  Windows, where ":" is illegal in a filename. */
 function isUrlDerivedWorkflowPath(path) {
   return /[a-zA-Z][a-zA-Z0-9+.-]*:\/\//.test(String(path || ""));
 }


### PR DESCRIPTION
**Do not merge. The fix misses the exact value the report describes, and my test hid that by
substituting a different one.**

## The miss

The reported path is `workflows/http://127.0.0.1:8188/api/view?filename=…`. The directory
derived from it therefore **retains the `workflows/` prefix** — it is
`workflows/http://127.0.0.1:8188/api`, not `http://…`.

My change anchors the scheme test at the START of the string, so it never fires on that
value. And my test passed a bare `http://127.0.0.1:8188/api/view?…`, which is not what
`directoryOf()` receives. The test agreed with the code and both disagreed with the bug.

That is the second time today a test of mine confirmed a shape I had assumed rather than the
one that was reported, and it is the more instructive half of this PR.

## Also found

- **`isExternalWorkflowPath` is not only a directory redirect.** The call at
  `workflow-save.js:565` selects the low-level root-copy route, bypasses source
  classification, and reports `save-as-copy` / `sourceExternal`. Widening the classifier
  therefore changes more than where a copy lands — that call site has to be assessed on its
  own terms before this moves.
- **A comment of mine is false**: it says `blob:` and `data:` are covered by the same rule.
  They are not — the regex requires `//`, and my own tests assert they stay `false`. The
  trade is right; the sentence describing it is wrong.
- **A residual false positive on POSIX**: a relative managed path may syntactically contain
  `scheme://` there (it cannot on Windows, where `:` is illegal in a filename). Detecting
  `://` anywhere — which is what fixing the miss above requires — makes that risk larger,
  not smaller, and the current tests do not cover it.

## What a correct fix needs

1. Match the scheme **anywhere** in the path, not just at position 0, since the managed
   prefix is retained.
2. Assess `:565` explicitly: is `sourceExternal` the right classification for a URL-derived
   temp tab, or does that route need its own predicate?
3. A test that feeds the **verbatim reported value**, not a normalised form of it.
4. A POSIX false-positive decision, taken deliberately rather than inherited.

Left open with the analysis. The classifier change on this branch is not wrong so much as
insufficient, and shipping it would close the issue without fixing it.

Refs #1066