### PR TITLE
fix(1066): defect (2) — scope the #226 guard to the hazard it names

### DIFF
--- a/browser_tests/unit/workflow-save.test.mjs
+++ b/browser_tests/unit/workflow-save.test.mjs
@@ -605,8 +605,81 @@ test('disk-existence backstop catches a low-level copy that moves a persisted so
 
   await assert.rejects(
     () => saveActiveWorkflow(svc, 'zz226b-copy', { existsOnDisk }),
-    /moved the original workflow .* instead of copying it/
+    /was on disk when this save began and is GONE now/
   )
+})
+
+test('#1066/codex: the backstop catches a ROGUE moving saveAs even when the source was UNKNOWN', async () => {
+  // The route exemption that lets an unprovable source be copied is DUCK-TYPED — it
+  // checks for three method NAMES, not that saveAs is the move-free one verified
+  // against the real frontend. This is the case that exemption cannot check for
+  // itself: a frontend whose saveAs moves, on a source no oracle could classify.
+  //
+  // The backstop is what covers it, which is why it now runs for "unknown" and not
+  // only "persisted". Without that widening this save would report SUCCESS while the
+  // source was destroyed.
+  const active = {
+    path: 'workflows/zz226b-orig.json',
+    filename: 'zz226b-orig.json',
+    directory: 'workflows',
+    isPersisted: false, // drifted ⇒ in-memory lookup cannot prove absence
+    isTemporary: true
+  }
+  const svc = makeFaithfulService({ files: [active.path], active })
+  // Disk oracle answers honestly about existence but the in-memory oracle returns the
+  // drifted object, so classifySource lands on... let's force UNKNOWN outright by
+  // making the CLASSIFICATION probe indeterminate while the BACKSTOP probes truthfully.
+  let classified = false
+  const existsOnDisk = async (p) => {
+    if (!classified) {
+      classified = true
+      return null // classification probe: indeterminate ⇒ cls === "unknown"
+    }
+    return svc.disk.has(p) // pre/post-copy probes: truthful 200 → 404
+  }
+  const origSaveAs = svc.saveAs
+  svc.saveAs = (wf, path) => {
+    svc.disk.delete(wf.path) // ROGUE: consumes (moves) the source
+    return origSaveAs(wf, path)
+  }
+
+  await assert.rejects(
+    () => saveActiveWorkflow(svc, 'zz226b-copy', { existsOnDisk }),
+    /was on disk when this save began and is GONE now/
+  )
+})
+
+test('#1066/codex: the backstop reports DISAPPEARANCE, not causation — it names both causes', async () => {
+  // Two probes cannot separate "this save moved it" from "something else deleted it
+  // mid-save"; /userdata exposes no per-file version or actor. The message must
+  // therefore not assert causation. This pins that wording, because the alternative
+  // (the old text) blamed the save for a deletion it may not have performed — the
+  // false-attribution codex flagged when the backstop was widened to "unknown".
+  const active = {
+    path: 'workflows/zz226b-orig.json',
+    filename: 'zz226b-orig.json',
+    directory: 'workflows',
+    isPersisted: true,
+    isTemporary: false
+  }
+  const svc = makeFaithfulService({ files: [active.path], active })
+  const existsOnDisk = async (p) => svc.disk.has(p)
+  const origSaveWorkflow = svc.saveWorkflow.bind(svc)
+  svc.saveWorkflow = async (wf) => {
+    // A THIRD PARTY deletes the source during the awaited persist — this save is
+    // move-free and did not touch it.
+    svc.disk.delete('workflows/zz226b-orig.json')
+    return origSaveWorkflow(wf)
+  }
+
+  const err = await saveActiveWorkflow(svc, 'zz226b-copy', { existsOnDisk }).then(
+    () => null,
+    (e) => e
+  )
+  assert.ok(err, 'a vanished source is surfaced, never silently swallowed')
+  assert.match(err.message, /disappeared across the save/, 'states what was observed')
+  assert.match(err.message, /can\s+also mean something else deleted it/, 'names the other cause')
+  assert.ok(svc.disk.has('workflows/zz226b-copy.json'), 'the copy WAS written — reported as such')
 })
 
 test('P0 round-5: no-name save of a persisted workflow with an EMPTY filename refuses — never moves Orig.json → .json (#226)', async () => {
@@ -1055,6 +1128,10 @@ test('1.47: a drifted-temporary REAL file (on disk) is COPIED, never moved — d
   assert.ok(svc.disk.has('workflows/Real.json'), 'real source preserved')
   assert.ok(svc.disk.has('workflows/Copy.json'), 'copy created')
   assert.ok(!svc.calls.some((c) => c[0] === 'renameWorkflow'), 'never renamed')
+  assert.ok(
+    svc.openWorkflows.some((w) => w.path === 'workflows/Real.json'),
+    'persisted source tab NOT consumed — a Save-As copy leaves the original tab open'
+  )
 })
 
 test('1.47: a drifted-temporary path with an UNKNOWN disk oracle copies without claiming absence (#226)', async () => {
@@ -1078,6 +1155,19 @@ test('1.47: a drifted-temporary path with an UNKNOWN disk oracle copies without 
   assert.equal(saved, 'Copy')
   assert.ok(svc.disk.has('workflows/Real.json'), 'source preserved')
   assert.ok(!svc.calls.some((c) => c[0] === 'renameWorkflow'), 'never renamed')
+  // The OTHER right that "unknown" must withhold (codex): #566 predecessor
+  // consumption purges the source's in-memory record, and only a PROVEN
+  // never-persisted source licenses it. Guarding a widened consumption condition,
+  // which disk assertions alone would not catch.
+  assert.ok(
+    svc.openWorkflows.some((w) => w.path === 'workflows/Real.json'),
+    'unknown source tab NOT consumed — still in the open tab strip'
+  )
+  assert.equal(
+    svc.getWorkflowByPath('workflows/Real.json'),
+    active,
+    'unknown source record NOT purged from the store lookup'
+  )
 })
 
 test('1.47: saveAs+saveWorkflow but NO openWorkflow ⇒ refuse, never persist null content (#226)', async () => {

--- a/browser_tests/unit/workflow-save.test.mjs
+++ b/browser_tests/unit/workflow-save.test.mjs
@@ -437,10 +437,18 @@ function makeFaithfulService({ files = [], active } = {}) {
   return svc
 }
 
-test('refuses save-as when an on-disk source is mis-flagged temporary — never moves it (#226)', async () => {
+test('an on-disk source mis-flagged temporary COPIES via the move-free trio — never moved (#226/#1066)', async () => {
   // The reproduced drift: panel_open_workflow left a PERSISTED workflow flagged
   // temporary (isTemporary === true), but its file is on disk. Delegating to the
-  // frontend saveWorkflowAs here would MOVE (destroy) the original.
+  // frontend saveWorkflowAs here would MOVE (destroy) the original — so the panel
+  // does not delegate to it, and has not for some time.
+  //
+  // #1066 defect 2: this used to REFUSE outright. The refusal named a move, and this
+  // frontend exposes the move-free trio, so the move it protected against could not
+  // happen. What #226 actually demands is asserted below and holds: the original file
+  // is still on disk, renameWorkflow was never called, and saveWorkflowAs — which is
+  // present on this double precisely so a wrong delegation would be visible — was not
+  // invoked. The user gets the copy they asked for.
   const active = {
     path: 'workflows/zz226b-orig.json',
     filename: 'zz226b-orig.json',
@@ -450,13 +458,48 @@ test('refuses save-as when an on-disk source is mis-flagged temporary — never 
   }
   const svc = makeFaithfulService({ files: [active.path], active })
 
-  await assert.rejects(
-    () => saveActiveWorkflow(svc, 'zz226b-copy', {}),
-    /could MOVE \(destroy\) the original/
+  const saved = await saveActiveWorkflow(svc, 'zz226b-copy', {})
+
+  assert.equal(saved, 'zz226b-copy')
+  assert.ok(svc.disk.has('workflows/zz226b-orig.json'), 'ORIGINAL PRESERVED — the #226 invariant')
+  assert.ok(svc.disk.has('workflows/zz226b-copy.json'), 'copy created')
+  assert.ok(!svc.calls.some((c) => c[0] === 'renameWorkflow'), 'never renamed')
+  assert.ok(!svc.calls.some((c) => c[0] === 'saveWorkflowAs'), 'never delegated a move')
+  assert.ok(svc.calls.some((c) => c[0] === 'saveAs'), 'used the move-free store saveAs')
+})
+
+test('#1066 defect 2: a URL-derived temporary tab saves — unprovable source, move-free route', async () => {
+  // The reported dead end. ComfyUI mints a TEMPORARY workflow whose path is the URL an
+  // asset was opened from, so the tab's source can be classified by NOTHING: the
+  // in-memory lookup returns the tab itself (not proof of absence), and ComfyUI's
+  // /userdata answers a URL-shaped path with a 500, not a 404 (measured against a live
+  // 0.24.0 on Windows — os.makedirs on the illegal parent throws before the existence
+  // check runs), so the disk oracle is null. cls is therefore "unknown" forever, and the
+  // tab was unsaveable under ANY name, from the panel or from ComfyUI's own Save-As.
+  //
+  // Nothing here proves the source absent — that is the point. The save is authorised by
+  // the ROUTE being move-free, not by a claim about the path.
+  const urlPath =
+    'workflows/http://127.0.0.1:8188/api/view?filename=x.png&type=output&subfolder=a'
+  const active = {
+    path: urlPath,
+    filename: 'view?filename=x.png',
+    directory: 'workflows/http://127.0.0.1:8188/api',
+    isPersisted: false,
+    isTemporary: true
+  }
+  const svc = makeFaithfulService({ files: [], active })
+  const existsOnDisk = async () => null // /userdata 500 ⇒ indeterminate
+
+  const saved = await saveActiveWorkflow(svc, 'AnimaPltMg001', { existsOnDisk })
+
+  assert.equal(saved, 'AnimaPltMg001')
+  // Defect (1)'s redirect puts it in the workflows ROOT, never under the URL directory.
+  assert.ok(svc.disk.has('workflows/AnimaPltMg001.json'), 'saved into the workflows root')
+  assert.ok(
+    ![...svc.disk].some((p) => p.includes('http://')),
+    'nothing written under a URL directory'
   )
-  // Original stands, nothing was moved, saveWorkflowAs was never even invoked.
-  assert.ok(svc.disk.has('workflows/zz226b-orig.json'), 'original preserved')
-  assert.ok(!svc.disk.has('workflows/zz226b-copy.json'), 'no rogue copy')
   assert.ok(!svc.calls.some((c) => c[0] === 'renameWorkflow'), 'never renamed')
   assert.ok(!svc.calls.some((c) => c[0] === 'saveWorkflowAs'), 'never delegated a move')
 })
@@ -481,10 +524,16 @@ test('a correctly-flagged persisted workflow still COPIES via the faithful front
   assert.equal(saved, 'zz226b-copy')
 })
 
-test('item 1: an oracle that THROWS is NOT proof of absence ⇒ unknown ⇒ REFUSE (#226)', async () => {
+test('item 1: an oracle that THROWS is still NOT proof of absence — it copies, never moves (#226)', async () => {
   // A drifted-temporary doc with a real path, whose getWorkflowByPath lookup
-  // throws. A thrown lookup proves nothing about the disk — it must NOT be read
-  // as "no file here" and must refuse rather than move.
+  // throws. A thrown lookup proves nothing about the disk, so the classification
+  // stays "unknown" — that part is unchanged and must never become "absent".
+  //
+  // #1066 defect 2: "unknown" no longer means REFUSE, it means "do not take a move
+  // path and do not consume the source". The trio does neither, so the save runs
+  // and the source is untouched. Note the copy adapter itself fails closed on a
+  // throwing lookup for the TARGET (a separate check), which is why the target
+  // collision re-check is restored below before the save.
   const active = {
     path: 'workflows/zz226b-orig.json',
     filename: 'zz226b-orig.json',
@@ -493,16 +542,21 @@ test('item 1: an oracle that THROWS is NOT proof of absence ⇒ unknown ⇒ REFU
     isTemporary: true // drifted
   }
   const svc = makeFaithfulService({ files: [active.path], active })
-  svc.getWorkflowByPath = () => {
-    throw new Error('store not ready')
+  const realLookup = svc.getWorkflowByPath.bind(svc)
+  let thrown = 0
+  svc.getWorkflowByPath = (path) => {
+    // Throw for the SOURCE classification only; the adapter's target re-check is a
+    // different guard with its own fail-closed behaviour and is not what this asserts.
+    if (path === active.path && thrown++ === 0) throw new Error('store not ready')
+    return realLookup(path)
   }
 
-  await assert.rejects(
-    () => saveActiveWorkflow(svc, 'zz226b-copy', {}),
-    /cannot be proven absent from disk/
-  )
+  const saved = await saveActiveWorkflow(svc, 'zz226b-copy', {})
+
+  assert.equal(saved, 'zz226b-copy')
   assert.ok(svc.disk.has('workflows/zz226b-orig.json'), 'source preserved')
   assert.ok(!svc.calls.some((c) => c[0] === 'renameWorkflow'), 'never renamed')
+  assert.ok(!svc.calls.some((c) => c[0] === 'saveWorkflowAs'), 'never delegated a move')
 })
 
 test('item 2: a genuine NEW workflow with NO path grounds/saves (never refused) (#226)', async () => {
@@ -629,7 +683,7 @@ test('round-6: a THROWING post-save probe does NOT false-alarm — a valid copy 
   assert.equal(saved, 'zz226b-copy', 'reported success, not a false "moved" error')
 })
 
-test('P0 round-4: oracle returns the DRIFTED non-persisted wf for an on-disk path ⇒ unknown ⇒ REFUSE (#226)', async () => {
+test('P0 round-4: oracle returns the DRIFTED non-persisted wf for an on-disk path ⇒ unknown ⇒ COPY, never move (#226)', async () => {
   // Source IS on disk, but its in-memory object is mis-flagged temporary. The
   // store's getWorkflowByPath returns that same non-persisted object. A RETURNED
   // object is NOT proof of absence — classifying it never-persisted would move
@@ -646,10 +700,13 @@ test('P0 round-4: oracle returns the DRIFTED non-persisted wf for an on-disk pat
   assert.equal(svc.getWorkflowByPath('workflows/zz226b-orig.json'), active)
   assert.equal(active.isPersisted, false)
 
-  await assert.rejects(
-    () => saveActiveWorkflow(svc, 'zz226b-copy', {}),
-    /cannot be proven absent from disk/
-  )
+  const saved = await saveActiveWorkflow(svc, 'zz226b-copy', {})
+
+  // #1066 defect 2: a RETURNED object is still not proof of absence, so this is still
+  // "unknown" — and "unknown" still forbids a move and forbids consuming the source.
+  // On the move-free trio neither can happen, so the copy proceeds and the real file
+  // is exactly where it was.
+  assert.equal(saved, 'zz226b-copy')
   assert.ok(svc.disk.has('workflows/zz226b-orig.json'), 'real source preserved')
   assert.ok(!svc.calls.some((c) => c[0] === 'renameWorkflow'), 'never renamed')
   assert.ok(!svc.calls.some((c) => c[0] === 'saveWorkflowAs'), 'never delegated a move')
@@ -690,7 +747,7 @@ test('P0 round-4: a LIST-miss is not proof of absence ⇒ unknown ⇒ REFUSE (#2
   assert.equal(calls.length, 0, 'nothing was called — no move')
 })
 
-test('P0-a: no existence oracle + mis-flagged temporary + real name ⇒ REFUSE, never move (#226)', async () => {
+test('P0-a: no existence oracle + mis-flagged temporary + real name ⇒ COPY, never move (#226)', async () => {
   // The most dangerous drift: the doc has a REAL filename and is flagged
   // temporary, but there is NO existence API/list to prove whether a file backs
   // it. Existence is UNKNOWN, which must FAIL SAFE (refuse) — the old code
@@ -706,22 +763,28 @@ test('P0-a: no existence oracle + mis-flagged temporary + real name ⇒ REFUSE, 
   // ⇒ no existence oracle ⇒ classification is UNKNOWN.
   const svc = makeService({ files: [active.path], active })
 
-  await assert.rejects(
-    () => saveActiveWorkflow(svc, 'zz226b-copy', {}),
-    /cannot be proven absent from disk/
-  )
-  // Source untouched; saveWorkflowAs never delegated a move.
+  const saved = await saveActiveWorkflow(svc, 'zz226b-copy', {})
+
+  // #1066 defect 2: existence is still UNKNOWN — nothing here proves the file absent,
+  // and nothing pretends to. The save is authorised by the route, which cannot move.
+  assert.equal(saved, 'zz226b-copy')
   assert.ok(svc.disk.has('workflows/zz226b-orig.json'), 'original preserved')
-  assert.equal(svc.calls.length, 0, 'nothing was called')
+  assert.ok(!svc.calls.some((c) => c[0] === 'renameWorkflow'), 'never renamed')
+  assert.ok(!svc.calls.some((c) => c[0] === 'saveWorkflowAs'), 'never delegated a move')
 })
 
 for (const realName of ['Untitled 2026-07-24', 'Unsaved Workflow 3']) {
-  test(`P0 name-vs-proof: a REAL on-disk "${realName}" drifted temporary + NO oracle ⇒ REFUSE, never moved (#226)`, async () => {
+  test(`P0 name-vs-proof: a REAL on-disk "${realName}" drifted temporary + NO oracle is COPIED, never moved (#226)`, async () => {
     // The exact collision: a user really can have "workflows/Untitled ….json"
     // (or "Unsaved Workflow 3.json") ON DISK. If its flags drift temporary and
     // there is no existence oracle, the placeholder NAME must NOT be treated as
-    // proof of absence — that would classify a real file as never-persisted and
-    // then MOVE (destroy) it. With no oracle to confirm absence ⇒ unknown ⇒ refuse.
+    // proof of absence — that would classify a real file as never-persisted, and
+    // never-persisted is what licenses CONSUMING the source tab (#566).
+    //
+    // #1066 defect 2: the classification is unchanged — still "unknown", still not
+    // never-persisted, so the source is neither moved nor consumed. What changed is
+    // that "unknown" no longer blocks the copy, because the route cannot move. The
+    // file the placeholder name was protecting is asserted still present below.
     const active = {
       path: `workflows/${realName}.json`,
       filename: `${realName}.json`,
@@ -729,14 +792,13 @@ for (const realName of ['Untitled 2026-07-24', 'Unsaved Workflow 3']) {
       isPersisted: false, // drifted
       isTemporary: true // drifted
     }
-    // makeService ⇒ NO getWorkflowByPath, NO lists ⇒ no existence oracle.
     const svc = makeService({ files: [active.path], active })
 
-    await assert.rejects(
-      () => saveActiveWorkflow(svc, 'a-copy', {}),
-      /cannot be proven absent from disk/
-    )
+    const saved = await saveActiveWorkflow(svc, 'a-copy', {})
+
+    assert.equal(saved, 'a-copy')
     assert.ok(svc.disk.has(`workflows/${realName}.json`), 'real source preserved')
+    assert.ok(svc.disk.has('workflows/a-copy.json'), 'copy created')
     assert.ok(!svc.calls.some((c) => c[0] === 'renameWorkflow'), 'never renamed')
     assert.ok(!svc.calls.some((c) => c[0] === 'saveWorkflowAs'), 'never delegated a move')
   })
@@ -967,11 +1029,15 @@ test('1.47: a persisted workflow Save-As COPIES via saveAs+saveWorkflow, source 
   assert.equal(saved, 'Bar')
 })
 
-test('1.47: a drifted-temporary REAL file (on disk) is NEVER moved — refuse via disk oracle (#226/#215)', async () => {
+test('1.47: a drifted-temporary REAL file (on disk) is COPIED, never moved — disk oracle (#226/#215)', async () => {
   // The exact #226 hole the #268 fix must not reopen: a PERSISTED file left
   // flagged temporary. getWorkflowByPath returns that same non-persisted object
   // (can't prove absence); only the /userdata oracle can — and it says the file
-  // EXISTS, so the classifier must say "persisted" → refuse, never copy/move.
+  // EXISTS, so the classifier says "persisted".
+  //
+  // #1066 defect 2: "persisted" means COPY, which is what a Save-As of a real file
+  // is supposed to do — it does not mean refuse. The hole stays shut where it
+  // actually was: no renameWorkflow, and the source file is still on disk after.
   const active = {
     path: 'workflows/Real.json',
     filename: 'Real.json',
@@ -983,20 +1049,20 @@ test('1.47: a drifted-temporary REAL file (on disk) is NEVER moved — refuse vi
   // Sanity: the in-memory oracle returns the SAME non-persisted object.
   assert.equal(svc.getWorkflowByPath('workflows/Real.json'), active)
 
-  await assert.rejects(
-    () => saveActiveWorkflow(svc, 'Copy', { existsOnDisk }),
-    /exists on disk/
-  )
+  const saved = await saveActiveWorkflow(svc, 'Copy', { existsOnDisk })
+
+  assert.equal(saved, 'Copy')
   assert.ok(svc.disk.has('workflows/Real.json'), 'real source preserved')
-  assert.ok(!svc.disk.has('workflows/Copy.json'), 'no rogue copy')
+  assert.ok(svc.disk.has('workflows/Copy.json'), 'copy created')
   assert.ok(!svc.calls.some((c) => c[0] === 'renameWorkflow'), 'never renamed')
-  assert.ok(!svc.calls.some((c) => c[0] === 'saveWorkflow'), 'never persisted a move')
 })
 
-test('1.47: a drifted-temporary path with an UNKNOWN disk oracle still refuses (fail safe, #226)', async () => {
-  // If /userdata is unreachable (oracle returns null), a flagged-temporary doc
-  // whose in-memory lookup is inconclusive stays "unknown" → refuse. Grounding
-  // only ever happens on a PROVEN 404.
+test('1.47: a drifted-temporary path with an UNKNOWN disk oracle copies without claiming absence (#226)', async () => {
+  // If /userdata is unreachable (oracle returns null), a flagged-temporary doc whose
+  // in-memory lookup is inconclusive stays "unknown". That is still not "absent", and
+  // the two decisions that need proof still read it correctly: the source is not
+  // consumed and no move is taken. Grounding — which DOES require proof — still only
+  // ever happens on a PROVEN 404 (see the grounding tests).
   const active = {
     path: 'workflows/Real.json',
     filename: 'Real.json',
@@ -1007,13 +1073,11 @@ test('1.47: a drifted-temporary path with an UNKNOWN disk oracle still refuses (
   const { svc } = makeStore147Service({ files: [active.path], active })
   const existsOnDisk = async () => null // oracle unreachable ⇒ unknown
 
-  await assert.rejects(
-    () => saveActiveWorkflow(svc, 'Copy', { existsOnDisk }),
-    /cannot be proven absent from disk/
-  )
+  const saved = await saveActiveWorkflow(svc, 'Copy', { existsOnDisk })
+
+  assert.equal(saved, 'Copy')
   assert.ok(svc.disk.has('workflows/Real.json'), 'source preserved')
   assert.ok(!svc.calls.some((c) => c[0] === 'renameWorkflow'), 'never renamed')
-  assert.ok(!svc.calls.some((c) => c[0] === 'saveWorkflow'), 'never persisted a move')
 })
 
 test('1.47: saveAs+saveWorkflow but NO openWorkflow ⇒ refuse, never persist null content (#226)', async () => {

--- a/web/js/lib/workflow-save.js
+++ b/web/js/lib/workflow-save.js
@@ -698,6 +698,22 @@ export async function saveActiveWorkflow(
       // 200 before and a CONFIRMED 404 after. For the URL-derived tab this issue is about,
       // both probes are 500 ⇒ null ⇒ "unverified" ⇒ no-op. Only never-persisted skips it,
       // and only because a proven-absent source has nothing to lose.
+      //
+      // It is also the mitigation for the one thing the route exemption above cannot
+      // check: that exemption is DUCK-TYPED (three method names), so a frontend whose
+      // `saveAs` is not the move-free one verified against 1.50.3 would take the copy
+      // path with nothing having proven it move-free. This probe observes the OUTCOME
+      // rather than trusting the shape, and an unknown source is precisely the case with
+      // no other evidence — so it is the one that most needs observing (codex).
+      //
+      // ACCEPTED RESIDUAL (codex): two probes establish DISAPPEARANCE, not CAUSATION. A
+      // source deleted by something ELSE during the awaited persist trips this too, and no
+      // client-side check can separate the two — /userdata exposes no per-file version or
+      // actor. That is why the message below reports what was OBSERVED and names both
+      // causes instead of asserting this save moved it. The residual is inherited rather
+      // than introduced: the identical race already applied to a "persisted" source before
+      // this condition was widened. Erring toward a loud, accurate report is deliberate —
+      // the alternative is silence about a file that really is gone.
       if (cls !== "never-persisted") {
         const sourceOnDiskAfter = await probeSourceOnDisk(existsOnDisk, sourceNorm);
         if (
@@ -705,8 +721,11 @@ export async function saveActiveWorkflow(
           "lost"
         ) {
           throw new Error(
-            `save moved the original workflow "${sourcePath}" instead of copying it — ` +
-              `the source no longer exists on disk (issue #226)`,
+            `the original workflow "${sourcePath}" was on disk when this save began and is GONE ` +
+              `now — the copy "${finalTargetPath}" was written, but the source disappeared across ` +
+              `the save. Most likely this save moved it instead of copying it (issue #226); it can ` +
+              `also mean something else deleted it mid-save, which these two probes cannot tell ` +
+              `apart. Check the source before relying on it.`,
           );
         }
       }
@@ -1299,7 +1318,13 @@ async function classifySource(svc, wf, rawPath, existsOnDisk) {
   // call that SUCCEEDS: `persisted` if it shows a persisted workflow here,
   // `confirmedAbsent` only if a successful lookup shows none. An oracle that
   // THROWS proves nothing (a thrown lookup is not proof of absence, #226) — we
-  // leave both false so the result stays "unknown" → refuse.
+  // leave both false so the result stays "unknown".
+  //
+  // What "unknown" COSTS is no longer a blanket refusal (#1066 defect 2, codex): it
+  // withholds the two rights that need proof — taking a MOVE path, and CONSUMING the
+  // source tab (#566) — while a provably move-free copy may still proceed. So this
+  // function's job is unchanged and its strictness matters just as much; only the
+  // consequence downstream is narrower than "refuse".
   let persisted = false;
   let confirmedAbsent = false;
 
@@ -1343,9 +1368,9 @@ async function classifySource(svc, wf, rawPath, existsOnDisk) {
   // real file (#226/#215). They are indistinguishable in memory; only the disk
   // can tell them apart. Consult the authoritative filesystem oracle: a proven
   // ABSENCE (404) means there is no backing file to destroy → never-persisted
-  // (safe to ground); a proven PRESENCE means a real file → persisted (refuse).
-  // Unknown/failure changes nothing (stays "unknown" → refuse), so this only
-  // ever ADDS safe grounds to save and never weakens the #226 refusal.
+  // (safe to ground); a proven PRESENCE means a real file → persisted (copy it,
+  // never move it). Unknown/failure changes nothing (stays "unknown"), so this
+  // only ever ADDS safe grounds and never weakens the #226 invariant.
   if (typeof existsOnDisk === "function" && wf?.isPersisted !== true) {
     let exists = null;
     try {

--- a/web/js/lib/workflow-save.js
+++ b/web/js/lib/workflow-save.js
@@ -587,18 +587,9 @@ export async function saveActiveWorkflow(
 
     const cls = await classifySource(svc, wf, sourcePath, existsOnDisk);
 
-    // #226 CLASSIFICATION GUARD (hoisted so it applies regardless of which copy API
-    // is used) — a source ACTING temporary that isn't PROVABLY never-persisted must
-    // not be relocated: it might be a real on-disk file a relocate could move or
-    // destroy. This is about the SOURCE, not the write mechanism. A correctly-opened
-    // persisted workflow (isTemporary === false) hits the copy path below.
-    if (wf.isTemporary === true && cls !== "never-persisted") {
-      throw new Error(
-        `refusing to save: the active workflow is flagged unsaved but its source "${sourcePath}" ` +
-          `${cls === "persisted" ? "exists on disk" : "cannot be proven absent from disk"} — ` +
-          `saving now could MOVE (destroy) the original (issue #226). Re-open the workflow and try again.`,
-      );
-    }
+    // The #226 CLASSIFICATION GUARD lives just below, AFTER the write route is
+    // resolved, because the hazard it names belongs to the route and not to the
+    // source. See the comment at that check (#1066 defect 2).
 
     // #226/#309 P1-1 — a relocating Save-As can COLLIDE with an existing file, and a
     // non-atomic HEAD pre-check can NEVER make an OVERWRITING write safe (a target can
@@ -628,13 +619,57 @@ export async function saveActiveWorkflow(
     // evidence; a mid-trio switch to a foreign tab must thread/consume NOTHING).
     const producedRecord = {};
     const atomicCopy = resolveSaveAsCopy(svc, { reconcileSavedCopy, producedRecord, canvasBinding, assertCanvasNotForeign });
+
+    // #226 CLASSIFICATION GUARD, scoped to the hazard it actually names (#1066 defect 2).
+    //
+    // A source ACTING temporary that isn't PROVABLY never-persisted must not be MOVED:
+    // it might be a real on-disk file a relocate would destroy. That is the invariant,
+    // and it is unchanged. What changed is where it can be violated.
+    //
+    // The guard used to run BEFORE the route was chosen, on the reasoning that it is
+    // "about the SOURCE, not the write mechanism". That was true when a moving route
+    // existed: the frontend's `saveWorkflowAs` branches on `isTemporary` and MOVES a
+    // temporary via renameWorkflow. It is no longer reachable — `saveWorkflowAs` and
+    // `renameWorkflow` now appear in this module only in comments, and every non-atomic
+    // relocation throws (see the refusal below this block). The one surviving relocating
+    // route is the atomic trio, and it is move-free BY CONSTRUCTION, verified against the
+    // real frontend rather than inferred: `workflowStore.saveAs(existing, path)` builds a
+    // NEW ComfyWorkflow from a deep copy of `existing.activeState`, inserts it at
+    // `workflowLookup[path]`, and returns it — it never reads `existing.path`, never calls
+    // /userdata, and never deletes. `saveWorkflow(copy)` then POSTs the COPY with
+    // `overwrite: copy.isPersisted` → false (a fresh copy has `size === -1`), so the
+    // target is server-guarded too. The source file is untouchable from this path.
+    //
+    // So on the trio the refusal could only ever be a FALSE one — and #1066 is what that
+    // costs a user: a URL-derived temporary tab whose source can be classified by nothing
+    // (the in-memory oracle returns the tab itself; ComfyUI's /userdata answers a URL-shaped
+    // path with a 500, not a 404 — measured, see the issue) was unsaveable under ANY name,
+    // by the panel or by ComfyUI's own Save-As.
+    //
+    // FAILS CLOSED: the exemption is conditioned on the move-free route being the one that
+    // will actually run, so reintroducing any moving fallback re-arms the guard rather than
+    // silently inheriting the exemption. Without a move-free route we still refuse here,
+    // with the message naming the SOURCE — which is the more useful of the two refusals
+    // available, and the reason this is not simply deleted in favour of the generic
+    // "atomic Save-As is unavailable" throw below.
+    if (wf.isTemporary === true && cls !== "never-persisted" && !atomicCopy) {
+      throw new Error(
+        `refusing to save: the active workflow is flagged unsaved but its source "${sourcePath}" ` +
+          `${cls === "persisted" ? "exists on disk" : "cannot be proven absent from disk"} — ` +
+          `saving now could MOVE (destroy) the original (issue #226). Re-open the workflow and try again.`,
+      );
+    }
+
     if (atomicCopy) {
       assertExpect(); // #330: still the workflow we probed?
       // Authoritative outcome: a "never-persisted" source (a temp / new_workflow tab
       // with no backing file) is a FIRST SAVE (panel#363 — no original to preserve);
       // a "persisted" source is a Save-As COPY of a real file that stays put (#579).
-      // (cls is only ever "persisted" or "never-persisted" here — the #226 guard above
-      // has already thrown for a temporary source that isn't provably never-persisted.)
+      // An "unknown" source (#1066 defect 2) reports as a COPY too, and that is the
+      // honest label rather than a fallback: the trio copied, and we cannot claim the
+      // "no original to preserve" that "first-save" asserts. Under-claiming here also
+      // keeps the two decisions that DO turn on proof — predecessor consumption and the
+      // move backstop — reading "not never-persisted", which is what they must see.
       recordOutcome(details, cls === "never-persisted" ? "first-save" : "save-as-copy", {
         sourcePath,
         targetPath: finalTargetPath,
@@ -655,7 +690,15 @@ export async function saveActiveWorkflow(
       // (disk 200) was present and is now CONFIRMED absent (disk 404) — classifyOriginalOnDisk
       // "lost". Every indeterminate case (no oracle / unknown pre or post / in-memory-only
       // signal) is a NO-OP, never a false "moved" (#226).
-      if (cls === "persisted") {
+      //
+      // Runs for an UNKNOWN source as well as a persisted one (#1066 defect 2). An
+      // unknown source is exactly the case where we could not establish what is on disk,
+      // so it is the one that most needs the observed check afterwards — and the check
+      // costs nothing when the answer stays unknown, because "lost" demands a CONFIRMED
+      // 200 before and a CONFIRMED 404 after. For the URL-derived tab this issue is about,
+      // both probes are 500 ⇒ null ⇒ "unverified" ⇒ no-op. Only never-persisted skips it,
+      // and only because a proven-absent source has nothing to lose.
+      if (cls !== "never-persisted") {
         const sourceOnDiskAfter = await probeSourceOnDisk(existsOnDisk, sourceNorm);
         if (
           classifyOriginalOnDisk({ preExisted: sourceOnDiskBefore, postExists: sourceOnDiskAfter }) ===


### PR DESCRIPTION
Fixes defect (2) of #1066 — a URL-derived temporary tab was unsaveable under **any** name,
from the panel or from ComfyUI's own Save-As. Defect (1) shipped in 0.13.9.

## The open question from the last attempt is answered, and it rules that approach out

[#1073](https://github.com/artokun/comfyui-mcp-panel/pull/1073) (reverted) closed by proposing
the oracle: if `/userdata` answers a URL-shaped path with a 400/404-class status, `existsOnDisk`
could return a genuine **observed** absence and the existing logic would authorise the save.

Measured against a live ComfyUI 0.24.0 on Windows, `encodeURIComponent`'d exactly as
`workflowExistsOnDisk` sends it:

| path | status |
|---|---|
| `workflows/__probe_absent__.json` | 404 |
| `workflows/notes:draft.json` | 404 |
| `workflows/what?.json` | 404 |
| `workflows/http://127.0.0.1:8188/api/view?filename=x.png&…` | **500** |
| `workflows/notes://draft/Foo.json` | **500** |

**500, not 404** — indeterminate, and `diskExistenceFromStatus(500) → null` is already correct.
The cause explains the table's shape: `get_request_user_filepath` runs `os.makedirs` on the
target's **parent** before checking existence (`app/user_manager.py`, `create_dir=True`).
`notes:draft.json` sits in the existing `workflows/` dir, so no `makedirs` runs and the check
answers honestly. A URL path has a non-existent parent containing illegal characters, so
`makedirs` raises `OSError` and aiohttp returns 500 before any existence check. Platform-split:
on POSIX those characters are legal, so `makedirs` would **succeed** — creating literal `http:`
and `127.0.0.1:8188` directories as a side effect of a read probe — then 404.

So three signals are now eliminated for proving this source absent:

1. the path shape (`://`) — refuted by `workflows/notes://draft`, a legal POSIX directory;
2. `wf.isTemporary` — persisted files can be flagged temporary after the open race;
3. the disk oracle — 500, on the platform where the bug was reported.

## This does not add a fourth. It asks whether the decision needs proof of absence at all

The guard's own error names its hazard: *"saving now could MOVE (destroy) the original"*. That
was reachable when the frontend's `saveWorkflowAs` — which branches on `isTemporary` and moves a
temporary via `renameWorkflow` — was the copy route. **It is not reachable now.**

- `saveWorkflowAs` and `renameWorkflow` appear in `workflow-save.js` **only in comments**; every
  non-atomic relocation already throws.
- The one surviving relocating route is the atomic trio, and it is move-free by construction —
  verified against the **real 1.50.3 frontend source** (extracted from the shipped source maps),
  not inferred from our own comment:

  ```ts
  const saveAs = (existingWorkflow: ComfyWorkflow, path: string): ComfyWorkflow => {
    const state = JSON.parse(JSON.stringify(existingWorkflow.activeState))
    state.id = generateUUID()
    const workflow = new (existingWorkflow.constructor)({ path, modified: Date.now(), size: -1 })
    workflow.originalContent = workflow.content = JSON.stringify(state)
    workflowLookup.value[workflow.path] = workflow
    return workflow
  }
  ```

  It never reads `existingWorkflow.path`, never calls `/userdata`, never deletes. `saveWorkflow(copy)`
  then POSTs the **copy** with `overwrite: copy.isPersisted` → `false` (`size === -1`), so the
  target is server-guarded too.

So the guard now runs **after** the route is resolved and refuses only when no move-free route
exists. **It fails closed**: reintroducing any moving fallback re-arms it rather than silently
inheriting the exemption. Without a move-free route we still refuse, with the message naming the
source — the more useful of the two available refusals.

## Verification

Ran every previously-refused scenario against a model of the 1.47 store. All four — oracle says
present, oracle unreachable, no oracle at all, and the #1066 URL tab — now save via
`saveAs → openWorkflow → saveWorkflow` with **the source file still on disk and `renameWorkflow`
never called**.

Eight tests asserted the refusal. Every one also asserted the property that actually matters —
source preserved, never renamed, `saveWorkflowAs` never delegated — and **all of those assertions
still hold**, now against a completed save. The one test whose double exposes no trio (the
LIST-miss case) still refuses, unchanged.

## Codex review

Reviewed adversarially, asked to refute the central claim. It could not: no traced route where
the trio, `withConflictRollback`, #566 predecessor consumption or post-write cleanup can move,
delete or overwrite the source for `unknown`/`persisted`; no bypass of #309, #708, #442 or
grounding; no consumer that mistakes `unknown` for `never-persisted`. It found one real defect
and two gaps, all fixed in `bd8b3b1`:

- **False attribution (confirmed defect).** The widened backstop asserted *"save moved the
  original"*, but two probes establish **disappearance, not causation** — a third party deleting
  the source mid-persist trips the same 200 → 404. The message now reports what was observed and
  names both causes. The residual is inherited, not introduced: the identical race already
  applied to a `persisted` source.
- **Why the widening stays.** Codex's other concern is that the exemption is **duck-typed** —
  three method names, nothing proving the installed `saveAs` is the one verified above. The
  backstop is precisely that mitigation, and `unknown` is the case with no other evidence. A new
  test drives a **rogue moving `saveAs` on an unknown source** and asserts it is caught; without
  the widening that save would report success while destroying the source.
- **Coverage.** The modified tests asserted disk preservation but never that the unknown source
  was not **consumed** from memory, leaving a widened consumption condition undetectable. Both
  1.47 tests now assert the source stays in the open tab strip and the store lookup.
- **Drift.** Three `classifySource` comments still described `unknown` as "refuse".

## Gate

3793 tests pass, `tsc --noEmit` clean, both changed files verified to import **as ES modules**
(`node --check` parses a bare `.js` as CommonJS and would bless a panel the browser cannot load).

Closes #1066
