### PR TITLE
fix(1062): core SaveGLB is addable — a 3D file union names formats nothing OUTPUTS

### DIFF
--- a/browser_tests/unit/node-widget-materialization.test.mjs
+++ b/browser_tests/unit/node-widget-materialization.test.mjs
@@ -824,6 +824,56 @@ test("#1062 #580 INTACT: the 3D waiver is a CLOSED list, not a FILE_3D_* prefix"
   );
 });
 
+test("#1062 #580 (codex): a bare `widgetType` is a WIDGET declaration, not a socket", () => {
+  // The false accept codex found. `widgetType` was missing from WIDGET_VALUE_CONFIG_KEYS,
+  // so an input declaring ONLY it — no default, no range — counted as socket-shaped. That
+  // was inert while an unproduced datatype could never clear `linkProven`; adding the
+  // core-3D proof removed that accidental second lock. Without this, the node below is
+  // added as a socket while genuinely being a STRING widget: neither value nor link.
+  const hint = { input: { required: { mesh: ["FILE_3D_GLTF", { widgetType: "STRING" }] } } };
+  assert.deepEqual(
+    unavailableRequiredCustomWidgetTypes(hint, {}, new Set(), hint),
+    ["FILE_3D_GLTF"],
+    "an input naming the widget it renders as is not a socket",
+  );
+  // Its own constructor still clears it, like any other widget.
+  assert.deepEqual(
+    unavailableRequiredCustomWidgetTypes(hint, { FILE_3D_GLTF: () => {} }, new Set(), hint),
+    [],
+  );
+  // And the same hint on a UNION is a widget too — the #788 ruling, now enforced by the
+  // key list rather than by that union happening to also carry `default`.
+  const union = {
+    input: { required: { mesh: ["MESH,FILE_3D_GLB", { widgetType: "STRING" }] } },
+  };
+  assert.deepEqual(unavailableRequiredCustomWidgetTypes(union, {}, new Set(["MESH"]), union), [
+    "MESH,FILE_3D_GLB",
+  ]);
+});
+
+test("#1062 #580 (codex): the core-3D set matches the DECLARED SPELLING, not a normalised one", () => {
+  // The other bypass. Every registry in this module keys on the spelling as declared — the
+  // widget-constructor lookup and knownSocketTypes both do — so a lower-case or
+  // space-padded name is a DIFFERENT identifier, and a custom type is free to use one.
+  // Normalising inside the core-3D check would have laundered exactly those.
+  const lower = { input: { required: { mesh: ["file_3d_gltf", {}] } } };
+  assert.deepEqual(
+    unavailableRequiredCustomWidgetTypes(lower, {}, new Set(), lower),
+    ["file_3d_gltf"],
+    "a lower-case custom type is not the core datatype",
+  );
+  const padded = { input: { required: { mesh: [" FILE_3D_GLTF ", {}] } } };
+  assert.deepEqual(
+    unavailableRequiredCustomWidgetTypes(padded, {}, new Set(), padded),
+    [" FILE_3D_GLTF "],
+    "a single (non-union) type is not trimmed by declaredTypeMembers, so it stays distinct",
+  );
+  // Sanity: the exact core spelling IS matched, so this is a spelling rule and not a
+  // regression that disabled the waiver.
+  const exact = { input: { required: { mesh: ["FILE_3D_GLTF", {}] } } };
+  assert.deepEqual(unavailableRequiredCustomWidgetTypes(exact, {}, new Set(), exact), []);
+});
+
 test("#1062: a core 3D file input declaring a WIDGET value still waits for its constructor", () => {
   // The type-level waiver never overrides the input-level bar. A declaration carrying
   // widget-value keys is a widget that ACCEPTS those links, not a socket — the same ruling

--- a/browser_tests/unit/node-widget-materialization.test.mjs
+++ b/browser_tests/unit/node-widget-materialization.test.mjs
@@ -830,24 +830,58 @@ test("#1062 #580 (codex): a bare `widgetType` is a WIDGET declaration, not a soc
   // was inert while an unproduced datatype could never clear `linkProven`; adding the
   // core-3D proof removed that accidental second lock. Without this, the node below is
   // added as a socket while genuinely being a STRING widget: neither value nor link.
-  const hint = { input: { required: { mesh: ["FILE_3D_GLTF", { widgetType: "STRING" }] } } };
+  // A NON-primitive hint needs a constructor no core frontend provides, and is the case
+  // that must fail closed. This is the actual false accept: without `widgetType` in the
+  // key list it was socket-shaped and waived as a link.
+  const custom = { input: { required: { mesh: ["FILE_3D_GLTF", { widgetType: "ACME_GALLERY" }] } } };
   assert.deepEqual(
-    unavailableRequiredCustomWidgetTypes(hint, {}, new Set(), hint),
+    unavailableRequiredCustomWidgetTypes(custom, {}, new Set(), custom),
     ["FILE_3D_GLTF"],
-    "an input naming the widget it renders as is not a socket",
+    "an input naming a CUSTOM widget it renders as is not a socket",
   );
-  // Its own constructor still clears it, like any other widget.
   assert.deepEqual(
-    unavailableRequiredCustomWidgetTypes(hint, { FILE_3D_GLTF: () => {} }, new Set(), hint),
+    unavailableRequiredCustomWidgetTypes(custom, { FILE_3D_GLTF: () => {} }, new Set(), custom),
     [],
+    "its own constructor still clears it, like any other widget",
   );
-  // And the same hint on a UNION is a widget too — the #788 ruling, now enforced by the
-  // key list rather than by that union happening to also carry `default`.
+  // The same hint on a UNION is a widget too — the #788 ruling, now enforced by the key
+  // list rather than by that union happening to also carry `default`.
   const union = {
-    input: { required: { mesh: ["MESH,FILE_3D_GLB", { widgetType: "STRING" }] } },
+    input: { required: { mesh: ["MESH,FILE_3D_GLB", { widgetType: "ACME_GALLERY" }] } },
   };
   assert.deepEqual(unavailableRequiredCustomWidgetTypes(union, {}, new Set(["MESH"]), union), [
     "MESH,FILE_3D_GLB",
+  ]);
+});
+
+test("#1062 (codex re-review): a PRIMITIVE `widgetType` hint resolves natively — never refused", () => {
+  // The over-correction the first fix introduced, caught on re-review. ComfyUI resolves
+  // `widgetType ?? type`, so this renders a NATIVE STRING widget. Nothing registers a
+  // constructor for FILE_3D_GLTF and nothing ever will, so refusing it waits on evidence
+  // that cannot arrive (#796) — the same failure #788 fixed, read off the hint instead of
+  // off the declared type.
+  const native = { input: { required: { mesh: ["FILE_3D_GLTF", { widgetType: "STRING" }] } } };
+  assert.deepEqual(
+    unavailableRequiredCustomWidgetTypes(native, {}, new Set(), native),
+    [],
+    "a native primitive widget needs no registration",
+  );
+  // Independent of the declared type entirely — an unproven CUSTOM type with a primitive
+  // hint resolves the same way, because the hint is the half that wins.
+  const acme = { input: { required: { thing: ["ZIPN_STYLE_GALLERY", { widgetType: "INT" }] } } };
+  assert.deepEqual(unavailableRequiredCustomWidgetTypes(acme, {}, new Set(), acme), []);
+  // "Every, not some": a sibling input on the same type that needs a REAL constructor is
+  // not waived by its native-hinted neighbour.
+  const mixed = {
+    input: {
+      required: {
+        a: ["ZIPN_STYLE_GALLERY", { widgetType: "INT" }],
+        b: ["ZIPN_STYLE_GALLERY", { default: "none" }],
+      },
+    },
+  };
+  assert.deepEqual(unavailableRequiredCustomWidgetTypes(mixed, {}, new Set(), mixed), [
+    "ZIPN_STYLE_GALLERY",
   ]);
 });
 

--- a/browser_tests/unit/node-widget-materialization.test.mjs
+++ b/browser_tests/unit/node-widget-materialization.test.mjs
@@ -885,6 +885,41 @@ test("#1062 (codex re-review): a PRIMITIVE `widgetType` hint resolves natively �
   ]);
 });
 
+test("#1062 (codex): the native-widget waiver takes the EXACT primitive spelling only", () => {
+  // The waiver is a claim that ComfyUI will resolve `widgetType` to a native widget, and
+  // ComfyUI looks that name up verbatim. `"string"` is not `"STRING"`, so waiving it would
+  // grant the waiver to a name that resolves to nothing — the same laundering the core-3D
+  // set is exact to avoid. Every one of these must stay refused.
+  const refused = [
+    { widgetType: "string" },
+    { widgetType: " STRING " },
+    { widgetType: "Int" },
+    { widgetType: "ACME_GALLERY" },
+    { widgetType: null },
+    { widgetType: 42 },
+    { widgetType: ["STRING"] },
+    { widgetType: { type: "STRING" } },
+    {},
+  ];
+  for (const config of refused) {
+    const def = { input: { required: { thing: ["ZIPN_STYLE_GALLERY", config] } } };
+    assert.deepEqual(
+      unavailableRequiredCustomWidgetTypes(def, {}, new Set(), def),
+      ["ZIPN_STYLE_GALLERY"],
+      `widgetType ${JSON.stringify(config.widgetType)} must not be waived as native`,
+    );
+  }
+  // Only the exact spellings resolve.
+  for (const widgetType of ["STRING", "INT", "FLOAT", "BOOLEAN"]) {
+    const def = { input: { required: { thing: ["ZIPN_STYLE_GALLERY", { widgetType }] } } };
+    assert.deepEqual(
+      unavailableRequiredCustomWidgetTypes(def, {}, new Set(), def),
+      [],
+      `widgetType "${widgetType}" resolves natively`,
+    );
+  }
+});
+
 test("#1062 #580 (codex): the core-3D set matches the DECLARED SPELLING, not a normalised one", () => {
   // The other bypass. Every registry in this module keys on the spelling as declared — the
   // widget-constructor lookup and knownSocketTypes both do — so a lower-case or

--- a/browser_tests/unit/node-widget-materialization.test.mjs
+++ b/browser_tests/unit/node-widget-materialization.test.mjs
@@ -744,22 +744,96 @@ test("#695/#1062: a socket-shaped union hiding an unproven CUSTOM member stays b
 });
 
 test("#695: a union with ONE unproven member still fails closed", () => {
-  // SaveGaussianSplat.model_3d = FILE_3D_SPLAT_ANY,FILE_3D_PLY,… — proving some members
-  // is not proving the type, so the guard is not weakened into "any member counts".
-  const def = { input: { required: { model_3d: ["FILE_3D_SPLAT_ANY,FILE_3D_PLY", {}] } } };
+  // Proving SOME members is not proving the type, so the guard is not weakened into "any
+  // member counts". #1062 re-targeted the EXAMPLE without touching the RULE: this used to
+  // use SaveGaussianSplat's ("FILE_3D_SPLAT_ANY,FILE_3D_PLY"), and both of those are now
+  // proven core 3D file datatypes — so the pair no longer demonstrates an unproven member.
+  // The quantifier under test is unchanged; only a genuinely unproven member can show it.
+  const def = { input: { required: { model_3d: ["ACME_SPLAT_ANY,ACME_PLY", {}] } } };
+  assert.deepEqual(unavailableRequiredCustomWidgetTypes(def, {}, new Set(["ACME_SPLAT_ANY"]), def), [
+    "ACME_SPLAT_ANY,ACME_PLY",
+  ]);
   assert.deepEqual(
-    unavailableRequiredCustomWidgetTypes(def, {}, new Set(["FILE_3D_SPLAT_ANY"]), def),
-    ["FILE_3D_SPLAT_ANY,FILE_3D_PLY"],
-  );
-  assert.deepEqual(
-    unavailableRequiredCustomWidgetTypes(
-      def,
-      {},
-      new Set(["FILE_3D_SPLAT_ANY", "FILE_3D_PLY"]),
-      def,
-    ),
+    unavailableRequiredCustomWidgetTypes(def, {}, new Set(["ACME_SPLAT_ANY", "ACME_PLY"]), def),
     [],
   );
+});
+
+test("#1062: core SaveGLB is addable — a 3D file union names formats nothing installed OUTPUTS", () => {
+  // The reported dead end, with the declaration read verbatim from a live ComfyUI
+  // /object_info. SaveGLB is the only core node that writes a .glb, so while this failed,
+  // no image-to-3D or text-to-3D graph could be built with panel tools at all.
+  //
+  // Only MESH is passed as output-proven here, and that is the real measurement rather
+  // than a convenience: on a live 4183-node install, seven of these members are emitted by
+  // some node and seven (GLTF, STL, USDZ, PLY, SPLAT, SPZ, KSPLAT) are emitted by nothing.
+  // The union is a list of formats ComfyUI can WRITE, not a list of things it produces.
+  const saveGlb = {
+    input: {
+      required: {
+        mesh: [
+          "MESH,FILE_3D_GLB,FILE_3D_GLTF,FILE_3D_OBJ,FILE_3D_FBX,FILE_3D_STL,FILE_3D_USDZ," +
+            "FILE_3D_PLY,FILE_3D_SPLAT,FILE_3D_SPZ,FILE_3D_KSPLAT,FILE_3D_SPLAT_ANY," +
+            "FILE_3D_POINT_CLOUD_ANY,FILE_3D",
+          { tooltip: "Mesh or 3D file to save" },
+        ],
+        filename_prefix: ["STRING", { default: "3d/ComfyUI", multiline: false }],
+      },
+    },
+  };
+  // `filename_prefix` is an ordinary STRING widget, so the live frontend's own constructor
+  // is supplied for it — that is what the real call site passes. Leaving it out would make
+  // this a test about STRING registration rather than about the union.
+  assert.deepEqual(
+    unavailableRequiredCustomWidgetTypes(saveGlb, { STRING: () => {} }, new Set(["MESH"]), saveGlb),
+    [],
+    "SaveGLB is addable without waiting for a widget that never registers",
+  );
+  // The union is what was blocking: with the SAME registry, an unproven CUSTOM member in
+  // its place still fails closed, so this is not passing because the registry got richer.
+  const custom = {
+    input: {
+      required: {
+        mesh: ["MESH,ZIPN_STYLE_GALLERY", { tooltip: "x" }],
+        filename_prefix: ["STRING", { default: "3d/ComfyUI", multiline: false }],
+      },
+    },
+  };
+  assert.deepEqual(
+    unavailableRequiredCustomWidgetTypes(custom, { STRING: () => {} }, new Set(["MESH"]), custom),
+    ["MESH,ZIPN_STYLE_GALLERY"],
+  );
+});
+
+test("#1062 #580 INTACT: the 3D waiver is a CLOSED list, not a FILE_3D_* prefix", () => {
+  // The whole risk of this fix is laundering: `FILE_3D_*` is NOT a reserved namespace the
+  // way `COMFY_*_V3` is, so a pack can invent one. A prefix rule would admit it and skip a
+  // widget that never registered — the exact #580 false accept the `every` quantifier
+  // exists to prevent. An invented member must therefore still block, even sitting beside
+  // a core sibling and a proven MESH.
+  const acme = { input: { required: { thing: ["MESH,FILE_3D_GLB,FILE_3D_ACME", {}] } } };
+  assert.deepEqual(
+    unavailableRequiredCustomWidgetTypes(acme, {}, new Set(["MESH"]), acme),
+    ["MESH,FILE_3D_GLB,FILE_3D_ACME"],
+    "an invented FILE_3D_ACME is not vouched for by its core-looking neighbours",
+  );
+  // Output proof still clears it, exactly as for any other custom datatype.
+  assert.deepEqual(
+    unavailableRequiredCustomWidgetTypes(acme, {}, new Set(["MESH", "FILE_3D_ACME"]), acme),
+    [],
+  );
+});
+
+test("#1062: a core 3D file input declaring a WIDGET value still waits for its constructor", () => {
+  // The type-level waiver never overrides the input-level bar. A declaration carrying
+  // widget-value keys is a widget that ACCEPTS those links, not a socket — the same ruling
+  // #626/#788 reached for ("FLOAT,INT", {widgetType, default, …}).
+  const widgetish = {
+    input: { required: { mesh: ["MESH,FILE_3D_GLB", { default: "none", options: ["none"] }] } },
+  };
+  assert.deepEqual(unavailableRequiredCustomWidgetTypes(widgetish, {}, new Set(["MESH"]), widgetish), [
+    "MESH,FILE_3D_GLB",
+  ]);
 });
 
 test("#695: the report names the stuck INPUT and which of the two causes it is", () => {

--- a/web/js/lib/node-widget-materialization.js
+++ b/web/js/lib/node-widget-materialization.js
@@ -472,7 +472,18 @@ function inputDeclaresNativeWidgetType(spec) {
   if (!Array.isArray(spec)) return false;
   const config = spec[1];
   if (!config || typeof config !== "object" || Array.isArray(config)) return false;
-  return isPrimitiveWidgetType(config.widgetType);
+  // EXACT match against the primitive set, deliberately NOT via isPrimitiveWidgetType
+  // (codex). That helper trims and upper-cases, which is right where it is used — the #788
+  // waiver feeds it union MEMBERS, and whitespace around a comma is the store's syntax
+  // rather than part of the identifier. Here the value is an identifier the frontend looks
+  // up verbatim, so normalising would waive `"string"` and `" STRING "` as native widgets
+  // when ComfyUI would resolve neither, granting the waiver to a name that is not the
+  // primitive. Same exact-spelling discipline as isCore3dFileType, and for the same reason.
+  //
+  // Left isPrimitiveWidgetType untouched rather than tightening it globally: it predates
+  // this and #788 depends on its current behaviour, so narrowing it here is the change that
+  // is actually justified by the evidence.
+  return typeof config.widgetType === "string" && PRIMITIVE_WIDGET_TYPES.has(config.widgetType);
 }
 
 export function inputDeclaredAsSocket(spec) {

--- a/web/js/lib/node-widget-materialization.js
+++ b/web/js/lib/node-widget-materialization.js
@@ -195,8 +195,16 @@ export function unavailableRequiredWidgetReport(
     if (!members.length) continue;
     // Every member is a datatype no widget constructor will ever appear for: a built-in
     // connection type, or one the CURRENT backend declares as some node's output.
+    // #1062 — `isCore3dFileType` is a THIRD way for a member to be proven a link datatype,
+    // alongside the built-in allowlist and the live output proof. It exists because the
+    // output proof cannot see a core datatype that no INSTALLED node happens to emit; see
+    // its own comment. The quantifier is still `every` — a proven member never vouches for
+    // an unproven one.
     const linkProven = members.every(
-      (member) => SAFE_SOCKET_TYPES.has(member) || knownSocketTypes?.has?.(member) === true,
+      (member) =>
+        SAFE_SOCKET_TYPES.has(member) ||
+        isCore3dFileType(member) ||
+        knownSocketTypes?.has?.(member) === true,
     );
     // A SINGLE built-in connection datatype is waived on the type alone. Unchanged from
     // before this fix, and sound for the same reason it was then: ComfyUI registers no
@@ -340,6 +348,66 @@ const CORE_DYNAMIC_V3_TYPE_RE = /^COMFY_[A-Z0-9]+_V3$/;
 
 export function isCoreDynamicV3Type(type) {
   return typeof type === "string" && CORE_DYNAMIC_V3_TYPE_RE.test(type);
+}
+
+/**
+ * #1062 — ComfyUI's core 3D FILE-FORMAT datatypes.
+ *
+ * These are link datatypes that OFTEN NOTHING INSTALLED OUTPUTS, which is the specific
+ * blind spot in the output-proof oracle: `knownSocketTypes` proves a type is a link
+ * datatype by finding some node that emits it, so a datatype that is real but simply has
+ * no producer on THIS install is indistinguishable from an unregistered custom widget.
+ *
+ * That is not hypothetical, it is the whole of #1062. Core `SaveGLB` declares
+ * `mesh: ("MESH,FILE_3D_GLB,FILE_3D_GLTF,FILE_3D_OBJ,FILE_3D_FBX,FILE_3D_STL,
+ * FILE_3D_USDZ,FILE_3D_PLY,FILE_3D_SPLAT,FILE_3D_SPZ,FILE_3D_KSPLAT,FILE_3D_SPLAT_ANY,
+ * FILE_3D_POINT_CLOUD_ANY,FILE_3D", {tooltip})`. Measured against a live ComfyUI 0.31 with
+ * 4183 node definitions: SEVEN of those members are emitted by some node
+ * (MESH, FILE_3D_GLB, FILE_3D_OBJ, FILE_3D_FBX, FILE_3D_SPLAT_ANY,
+ * FILE_3D_POINT_CLOUD_ANY, FILE_3D) and SEVEN are emitted by nothing at all
+ * (FILE_3D_GLTF, FILE_3D_STL, FILE_3D_USDZ, FILE_3D_PLY, FILE_3D_SPLAT, FILE_3D_SPZ,
+ * FILE_3D_KSPLAT) — a union naming formats ComfyUI can WRITE but that no installed node
+ * PRODUCES. So `linkProven` was false, and SaveGLB — the only core node that writes a
+ * .glb — could not be placed on the canvas at all.
+ *
+ * WHY NOT #1062'S OWN PROPOSED FIX (`every` -> `some` over the members): because a proven
+ * member must not vouch for an unproven one. An empty config counts as socket-shaped, so
+ * the input-level bar cannot catch `("MESH,ZIPN_STYLE_GALLERY", {})` — only `every` does,
+ * and `some` would admit that node while silently skipping a widget that never registered
+ * (#580's false accept). That invariant is pinned by its own test and is UNCHANGED here:
+ * the quantifier stays `every`. What changes is what a member can be proven BY.
+ *
+ * AN EXPLICIT SET, NOT A `FILE_3D_*` PREFIX — deliberately the opposite choice from
+ * `COMFY_*_V3` above, because the two namespaces have opposite ownership. `COMFY_*_V3` is
+ * ComfyUI's reserved prefix, so covering the family is right and enumerating it would rot.
+ * `FILE_3D_*` is not reserved: a pack is free to invent `FILE_3D_ACME`, and a prefix rule
+ * would launder exactly the unregistered custom member the invariant above exists to
+ * refuse. This is a closed list of the 13 members ComfyUI core ships — verified against the
+ * shipped 1.50.3 frontend, where all 13 appear in the `dataTypes` translation tables (one
+ * entry per locale) and NONE appears as a widget constructor. A future core format is a
+ * one-line addition and fails closed until then, which is the safe direction.
+ *
+ * The caller still requires the input to declare itself socket-shaped, so a node using one
+ * of these types while declaring widget-value keys keeps waiting for its constructor.
+ */
+const CORE_3D_FILE_TYPES = new Set([
+  "FILE_3D",
+  "FILE_3D_FBX",
+  "FILE_3D_GLB",
+  "FILE_3D_GLTF",
+  "FILE_3D_KSPLAT",
+  "FILE_3D_OBJ",
+  "FILE_3D_PLY",
+  "FILE_3D_POINT_CLOUD_ANY",
+  "FILE_3D_SPLAT",
+  "FILE_3D_SPLAT_ANY",
+  "FILE_3D_SPZ",
+  "FILE_3D_STL",
+  "FILE_3D_USDZ",
+]);
+
+export function isCore3dFileType(type) {
+  return typeof type === "string" && CORE_3D_FILE_TYPES.has(type.trim().toUpperCase());
 }
 
 /**

--- a/web/js/lib/node-widget-materialization.js
+++ b/web/js/lib/node-widget-materialization.js
@@ -175,15 +175,23 @@ export function unavailableRequiredWidgetReport(
   // reproduce the very error this fixes one level down.
   const socketDeclared = new Set();
   const widgetDeclared = new Set();
+  // #1062 (codex) — types for which EVERY carrying input resolves to a widget the core
+  // frontend builds natively (`widgetType ?? type` naming a primitive). Held to the same
+  // "every, not some" discipline as socketDeclared directly below, and for the same reason:
+  // one input's native hint must not waive a sibling that needs a real constructor.
+  const nativeWidgetDeclared = new Set();
+  const nonNativeDeclared = new Set();
   const inputsByType = new Map();
   for (const [name, spec] of Object.entries(required)) {
     const type = inputWidgetType(spec);
     if (!type) continue;
     (inputDeclaredAsSocket(spec) ? socketDeclared : widgetDeclared).add(type);
+    (inputDeclaresNativeWidgetType(spec) ? nativeWidgetDeclared : nonNativeDeclared).add(type);
     if (!inputsByType.has(type)) inputsByType.set(type, []);
     inputsByType.get(type).push(name);
   }
   for (const type of widgetDeclared) socketDeclared.delete(type);
+  for (const type of nonNativeDeclared) nativeWidgetDeclared.delete(type);
 
   const report = [];
   for (const [type, inputs] of inputsByType) {
@@ -191,6 +199,11 @@ export function unavailableRequiredWidgetReport(
     // ComfyUI's own `INT:seed` / `INT:noise_seed` keys and any union a pack chooses to
     // register — so the whole string is checked first, before it is decomposed.
     if (typeof widgetConstructors?.[type] === "function") continue;
+    // #1062 (codex) — a NATIVE widget hint resolves without any registration, so there is
+    // nothing here a retry could be waiting for. Checked before the member analysis because
+    // it is a statement about the INPUT's own resolution, independent of what the declared
+    // type's members are or whether anything outputs them.
+    if (nativeWidgetDeclared.has(type)) continue;
     const members = declaredTypeMembers(type);
     if (!members.length) continue;
     // Every member is a datatype no widget constructor will ever appear for: a built-in
@@ -435,6 +448,33 @@ export function isCore3dFileType(type) {
  * Deliberately NOT inferred from the type: the same datatype can be a widget on one node
  * and a socket on another, which is exactly why the output-side evidence was insufficient.
  */
+/**
+ * #1062 (codex re-review) — whether an input's `widgetType` hint names a widget the CORE
+ * FRONTEND IMPLEMENTS ITSELF.
+ *
+ * The companion to putting `widgetType` in WIDGET_VALUE_CONFIG_KEYS. That key correctly says
+ * "this input is a widget, not a socket", which is what stops an unregistered custom widget
+ * from being waived as a link. But it is not the whole ruling, and taking it as the whole
+ * ruling was a false REFUSAL — the exact mirror of the accept it fixed.
+ *
+ * ComfyUI resolves the widget as `widgetType ?? type`, so `("FILE_3D_GLTF", {widgetType:
+ * "STRING"})` renders a NATIVE STRING widget. Nothing registers a constructor for
+ * FILE_3D_GLTF and nothing ever will, so refusing it waits on evidence that cannot arrive
+ * (#796) — the same failure #788 fixed for `("FLOAT,INT", {widgetType: "FLOAT"})`, which
+ * this file already documents. The difference is only that #788 read the resolution off the
+ * declared TYPE and this reads it off the hint, which is the half that actually wins.
+ *
+ * A NON-primitive hint is unchanged and still fails closed: `{widgetType: "ACME_GALLERY"}`
+ * genuinely needs a constructor no core frontend provides, and that is the case the key-list
+ * addition exists to catch.
+ */
+function inputDeclaresNativeWidgetType(spec) {
+  if (!Array.isArray(spec)) return false;
+  const config = spec[1];
+  if (!config || typeof config !== "object" || Array.isArray(config)) return false;
+  return isPrimitiveWidgetType(config.widgetType);
+}
+
 export function inputDeclaredAsSocket(spec) {
   if (!Array.isArray(spec)) return false;
   // A legacy combo (choices as the first tuple item) is always a widget — it exists to

--- a/web/js/lib/node-widget-materialization.js
+++ b/web/js/lib/node-widget-materialization.js
@@ -406,8 +406,21 @@ const CORE_3D_FILE_TYPES = new Set([
   "FILE_3D_USDZ",
 ]);
 
+/**
+ * EXACT match, no normalisation (codex). Trimming and upper-casing looked like tidiness and
+ * was a hole in the closed-list claim above: every other registry here keys on the declared
+ * spelling verbatim — the widget-constructor lookup and `knownSocketTypes` both do — so a
+ * required input declared `file_3d_gltf`, or a single-member `" FILE_3D_GLTF "`, is a
+ * DIFFERENT identifier from the core type everywhere else in this module. Normalising here
+ * would have let those be waived as proven core sockets, which is precisely the laundering
+ * the explicit set exists to prevent, and would additionally have made the refusal text
+ * claim the backend declares that exact spelling as a link datatype when it does not.
+ *
+ * Union members arrive already trimmed from `declaredTypeMembers`; a single type does not,
+ * and that asymmetry is the store's, not ours to paper over.
+ */
 export function isCore3dFileType(type) {
-  return typeof type === "string" && CORE_3D_FILE_TYPES.has(type.trim().toUpperCase());
+  return typeof type === "string" && CORE_3D_FILE_TYPES.has(type);
 }
 
 /**
@@ -458,6 +471,21 @@ const WIDGET_VALUE_CONFIG_KEYS = [
   "video_upload",
   "audio_upload",
   "placeholder",
+  // #1062 (codex) — `widgetType` is the strongest widget declaration of all, and it was
+  // missing. It is not a value like the keys above; it is the input naming the widget it
+  // renders as, which the stock frontend resolves with `widgetType ?? type` (verified in
+  // the shipped bundle, and already documented by the #788 case
+  // `("FLOAT,INT", {widgetType: "FLOAT", …})`).
+  //
+  // Its absence was latent rather than harmless: an input declaring ONLY `widgetType` — no
+  // `default`, no range — counted as socket-shaped, so `socketDeclared` held it and the
+  // input-level bar waved it through. Nothing reached that state before, because such a
+  // type still had to clear `linkProven` and an unproduced datatype never did. Adding the
+  // core-3D proof removed that accidental second lock, which is what surfaced this:
+  // `("FILE_3D_GLTF", {widgetType: "STRING"})` would have been added as a socket while
+  // genuinely being a STRING widget — a node with neither a widget value nor a link, which
+  // is exactly #580's false accept.
+  "widgetType",
 ];
 
 /**


### PR DESCRIPTION
Fixes #1062. Core `SaveGLB` — the only core node that writes a `.glb` — could not be placed
on the canvas by an agent at all, which blocks building any image-to-3D or text-to-3D graph
with panel tools.

## The reported cause is not the cause

The report says the precheck "resolves that union as a single opaque type string … looks for
a node whose output type equals the FULL joined string". It does not: `declaredTypeMembers`
has split comma-joined unions since #695, and there is a test for it.

The real cause is one step further in and much narrower. The members **are** split, and then
**every** member must be proven a link datatype — either a built-in `SAFE_SOCKET_TYPES` entry
or something the current backend declares as some node's output. I measured SaveGLB's union
against a live ComfyUI with **4183 node definitions**:

| | members |
|---|---|
| emitted by some installed node | `MESH`, `FILE_3D_GLB`, `FILE_3D_OBJ`, `FILE_3D_FBX`, `FILE_3D_SPLAT_ANY`, `FILE_3D_POINT_CLOUD_ANY`, `FILE_3D` |
| **emitted by nothing at all** | `FILE_3D_GLTF`, `FILE_3D_STL`, `FILE_3D_USDZ`, `FILE_3D_PLY`, `FILE_3D_SPLAT`, `FILE_3D_SPZ`, `FILE_3D_KSPLAT` |

Seven of fourteen. The union lists formats ComfyUI can **write**, not things anything
**produces** — so the output-proof oracle can never clear it, on any install, no matter how
many packs are added. `panel_refresh_nodes` and a workflow switch could not help, which matches
the report.

The declaration itself is read verbatim from a live `/object_info`:

```json
"mesh": ["MESH,FILE_3D_GLB,…,FILE_3D", { "tooltip": "Mesh or 3D file to save" }]
```

Config is a tooltip only — so the input **is** socket-shaped, and `socketDeclared` already
held it. `linkProven` was the sole blocker.

## Not the fix the report asks for, and this repo already said why

The report proposes `every` → `some` ("treat the input as a SOCKET if ANY member matches").
That is unsafe, and there is already a test in this file spelling it out — recast by a
previous codex pass **specifically because #1062 made it look like an oversight**:

> a proven socket member must not LAUNDER an unregistered, output-unproven custom member into
> an accepted node. An EMPTY config makes it concrete, because `{}` counts as socket-shaped —
> so `socketDeclared` contains the union and the input-level bar cannot catch it. Only
> requiring EVERY member to be proven does.

`("MESH,ZIPN_STYLE_GALLERY", {})` is the counterexample: under `some`, `MESH` alone admits the
node and silently skips a widget that never registered — #580's false accept. I reached for
"`socketDeclared` does the real work" myself before reading that test; it doesn't, because
`{}` passes it.

**So the quantifier is unchanged.** What changes is what a member can be proven *by*:
`isCore3dFileType` is a third proof alongside the built-in allowlist and the live output
proof, and it exists because the output proof is structurally blind to a real datatype that no
*installed* node happens to emit.

## An explicit closed set, deliberately not a `FILE_3D_*` prefix

This is the opposite choice from the `COMFY_*_V3` rule directly above it in the same file, and
the asymmetry is the point: `COMFY_*_V3` is ComfyUI's **reserved** prefix, so covering the
family is right and enumerating it would rot. `FILE_3D_*` is **not** reserved — a pack can
invent `FILE_3D_ACME`, and a prefix rule would launder exactly the unregistered custom member
the invariant above exists to refuse.

The 13 members are verified against the shipped 1.50.3 frontend, where all 13 appear in the
`dataTypes` translation tables (one entry per locale) and **none** appears as a widget
constructor. A future core format is a one-line addition and fails closed until then.

I also checked whether this could be discovered at runtime instead of enumerated — ComfyUI's
backend `/i18n` route serves only `settingsCategories`, `nodeCategories`, `nodeDefs` and
`settings`; the `dataTypes` map is frontend-bundle only and not reachable from extension JS.

## Tests

- **SaveGLB is addable**, from the verbatim live declaration — and, with the same widget
  registry, an unproven custom member in its place still fails closed, so it is not passing
  because the registry got richer.
- **The waiver is a closed list**: `("MESH,FILE_3D_GLB,FILE_3D_ACME", {})` still blocks, so an
  invented member is not vouched for by its core-looking neighbours.
- **The input-level bar still wins**: a core 3D type declaring widget-value keys keeps waiting.
- One existing test changed its **example, not its rule**: it demonstrated the quantifier with
  `("FILE_3D_SPLAT_ANY,FILE_3D_PLY")`, and both are now proven by the new route, so that pair
  no longer shows an unproven member. Re-targeted to genuinely unproven types. The
  anti-laundering test it protects passes untouched.

3845 tests pass, `tsc --noEmit` clean.

Closes #1062
