### PR TITLE
fix(1339): rgthree seeds are invisible to the batch-repeat warning

### DIFF
--- a/browser_tests/unit/scoped-batch-seed.test.mjs
+++ b/browser_tests/unit/scoped-batch-seed.test.mjs
@@ -270,6 +270,17 @@ test("#1339 — an ARMED node with a degenerate random range still repeats", () 
   }
 });
 
+test("#1339 — a MUTED or BYPASSED seed node is not named", () => {
+  // rgthree's handler returns early for exactly these modes, so the node substitutes
+  // nothing and contributes nothing. Naming it points the user at a node that is not in
+  // the run, in a warning whose entire value is naming the right one.
+  for (const mode of [2, 4]) {
+    assert.deepEqual(findRgthreeSeedNodes([{ ...rgthreeSeed(649, 12345), mode }]), [], `mode ${mode}`);
+  }
+  // …and an ordinary mode (0 = ALWAYS) is still reported.
+  assert.equal(findRgthreeSeedNodes([{ ...rgthreeSeed(649, 12345), mode: 0 }]).length, 1);
+});
+
 test("#1339 — silent for a batch of one, where a repeated seed is not a surprise", () => {
   const found = findRgthreeSeedNodes([rgthreeSeed(649, 12345)]);
   assert.equal(rgthreeFixedSeedNote(found, 1), "");

--- a/browser_tests/unit/scoped-batch-seed.test.mjs
+++ b/browser_tests/unit/scoped-batch-seed.test.mjs
@@ -262,6 +262,26 @@ test("#1339 — an ARMED node with a degenerate random range still repeats", () 
   assert.match(note, /randomMin=5, randomMax=5/);
   assert.match(note, /randomMin\/randomMax/);
 
+  // A range that LOOKS healthy but cannot vary, because of the widget's step. rgthree
+  // divides by step/10, so randomRange <= 1 makes every draw return randomMin — measured
+  // as ONE distinct value across 200 draws at min=0, max=5, step=100, while `min < max`
+  // says nothing is wrong. Found by working the probe rather than waiting to be told.
+  const bigStep = {
+    ...rgthreeSeed(650, -1),
+    properties: { randomMin: 0, randomMax: 5 },
+    widgets: [{ name: "seed", value: -1, options: { step: 100 } }],
+  };
+  assert.equal(findRgthreeSeedNodes([bigStep])[0].varies, false);
+  assert.match(rgthreeFixedSeedNote(findRgthreeSeedNodes([bigStep]), 3), /at step 100/);
+
+  // …and the same narrow range at the ORDINARY step still varies (50 distinct values).
+  const okStep = {
+    ...rgthreeSeed(651, -1),
+    properties: { randomMin: 0, randomMax: 5 },
+    widgets: [{ name: "seed", value: -1, options: { step: 1 } }],
+  };
+  assert.equal(findRgthreeSeedNodes([okStep])[0].varies, true);
+
   // A NORMAL range keeps its silence — the defaults, and an explicit wide range.
   for (const properties of [undefined, { randomMin: 0, randomMax: 1125899906842624 }]) {
     const ok = { ...rgthreeSeed(649, -1), ...(properties ? { properties } : {}) };

--- a/browser_tests/unit/scoped-batch-seed.test.mjs
+++ b/browser_tests/unit/scoped-batch-seed.test.mjs
@@ -230,6 +230,20 @@ test("#1339 — an ARMED rgthree seed says NOTHING", () => {
   }
 });
 
+test("#1339 — a seed CONVERTED TO AN INPUT is not reported as fixed", () => {
+  // The widget keeps a stale number when the seed is driven by a link, so calling it
+  // "fixed for all N items" would be a confident wrong claim about a node that may well be
+  // varying — the same error, pointed at a different node.
+  const driven = {
+    ...rgthreeSeed(649, 12345),
+    inputs: [{ name: "seed", link: 42 }],
+  };
+  assert.deepEqual(findRgthreeSeedNodes([driven]), []);
+  // …and an UNLINKED input entry (the shape after disconnecting) still reads the widget.
+  const unlinked = { ...rgthreeSeed(649, 12345), inputs: [{ name: "seed", link: null }] };
+  assert.equal(findRgthreeSeedNodes([unlinked]).length, 1);
+});
+
 test("#1339 — silent for a batch of one, where a repeated seed is not a surprise", () => {
   const found = findRgthreeSeedNodes([rgthreeSeed(649, 12345)]);
   assert.equal(rgthreeFixedSeedNote(found, 1), "");

--- a/browser_tests/unit/scoped-batch-seed.test.mjs
+++ b/browser_tests/unit/scoped-batch-seed.test.mjs
@@ -202,7 +202,7 @@ test("#1339 — an rgthree seed node is invisible to the control_after_generate 
 test("#1339 — a FIXED rgthree seed is reported for a batch > 1", () => {
   const found = findRgthreeSeedNodes([rgthreeSeed(649, 12345)]);
   assert.deepEqual(found, [
-    { node_id: "649", node_type: "Seed (rgthree)", seed: 12345, armed: false },
+    { node_id: "649", node_type: "Seed (rgthree)", seed: 12345, armed: false, varies: false },
   ]);
   const note = rgthreeFixedSeedNote(found, 10);
   assert.match(note, /ALL 10 ITEMS/);
@@ -224,24 +224,50 @@ test("#1339 — an ARMED rgthree seed says NOTHING", () => {
   ]) {
     const found = findRgthreeSeedNodes([rgthreeSeed(649, sentinel)]);
     assert.deepEqual(found, [
-      { node_id: "649", node_type: "Seed (rgthree)", seed: sentinel, armed: true, mode },
+      { node_id: "649", node_type: "Seed (rgthree)", seed: sentinel, armed: true, varies: true, mode },
     ]);
     assert.equal(rgthreeFixedSeedNote(found, 10), "");
   }
 });
 
-test("#1339 — a seed CONVERTED TO AN INPUT is not reported as fixed", () => {
-  // The widget keeps a stale number when the seed is driven by a link, so calling it
-  // "fixed for all N items" would be a confident wrong claim about a node that may well be
-  // varying — the same error, pointed at a different node.
-  const driven = {
-    ...rgthreeSeed(649, 12345),
-    inputs: [{ name: "seed", link: 42 }],
+test("#1339 — a LINKED seed is still read from the widget, because rgthree overwrites it", () => {
+  // I added a guard here that declined when the seed was converted to an input, reasoning
+  // that the widget value would be stale. That is true of an ordinary node and FALSE of
+  // this one: rgthree's queue handler writes `outputInputs[seed] = getSeedToUse()` from
+  // its own widget regardless of any link. Declining suppressed the warning for a linked
+  // node holding a fixed number — a MISSED warning, which is the original bug rather than
+  // a new false claim (codex probe 2).
+  const driven = { ...rgthreeSeed(649, 12345), inputs: [{ name: "seed", link: 42 }] };
+  const found = findRgthreeSeedNodes([driven]);
+  assert.equal(found.length, 1);
+  assert.equal(found[0].varies, false);
+  assert.match(rgthreeFixedSeedNote(found, 10), /node 649/);
+});
+
+test("#1339 — an ARMED node with a degenerate random range still repeats", () => {
+  // codex P2. rgthree's randomMin/randomMax are node PROPERTIES the user can edit, and
+  // `generateRandomSeed` draws inside them — so a range admitting one value returns that
+  // value every time while the node looks armed. Silence there would recreate the exact
+  // surprise this warning exists for, and it is the more confusing case: they DID press
+  // the button.
+  const degenerate = {
+    ...rgthreeSeed(649, -1),
+    properties: { randomMin: 5, randomMax: 5 },
   };
-  assert.deepEqual(findRgthreeSeedNodes([driven]), []);
-  // …and an UNLINKED input entry (the shape after disconnecting) still reads the widget.
-  const unlinked = { ...rgthreeSeed(649, 12345), inputs: [{ name: "seed", link: null }] };
-  assert.equal(findRgthreeSeedNodes([unlinked]).length, 1);
+  const found = findRgthreeSeedNodes([degenerate]);
+  assert.equal(found[0].armed, true);
+  assert.equal(found[0].varies, false);
+  const note = rgthreeFixedSeedNote(found, 10);
+  assert.match(note, /armed to randomize/);
+  assert.match(note, /randomMin=5, randomMax=5/);
+  assert.match(note, /randomMin\/randomMax/);
+
+  // A NORMAL range keeps its silence — the defaults, and an explicit wide range.
+  for (const properties of [undefined, { randomMin: 0, randomMax: 1125899906842624 }]) {
+    const ok = { ...rgthreeSeed(649, -1), ...(properties ? { properties } : {}) };
+    assert.equal(findRgthreeSeedNodes([ok])[0].varies, true);
+    assert.equal(rgthreeFixedSeedNote(findRgthreeSeedNodes([ok]), 10), "");
+  }
 });
 
 test("#1339 — silent for a batch of one, where a repeated seed is not a surprise", () => {

--- a/browser_tests/unit/scoped-batch-seed.test.mjs
+++ b/browser_tests/unit/scoped-batch-seed.test.mjs
@@ -19,6 +19,8 @@ import { readFileSync } from "node:fs";
 import {
   findRepeatingControlWidgets,
   scopedBatchSeedNote,
+  findRgthreeSeedNodes,
+  rgthreeFixedSeedNote,
 } from "../../web/js/lib/scoped-batch-seed.js";
 
 /** The real KSampler widget order: the control sits immediately after the value. */
@@ -170,4 +172,94 @@ test("#988 (codex r3): the warning is NOT gated on Comfy.WidgetControlMode — m
   assert.equal(controls.length, 1, "detection does not consult any widget-control-mode setting");
   const note = scopedBatchSeedNote(controls, 3);
   assert.doesNotMatch(note, /WidgetControlMode|beforeQueued|afterQueued/, "and makes no claim about it");
+});
+
+/**
+ * #1339 — the same surprise from a node #988's scan cannot see.
+ *
+ * The widget shape here is taken from a LIVE `Seed (rgthree)` instance created in the
+ * browser, not from what the node looks like in my head: rgthree removes
+ * `control_after_generate` and leaves `seed` plus three buttons.
+ */
+const rgthreeSeed = (id, seedValue) => ({
+  id,
+  type: "Seed (rgthree)",
+  widgets: [
+    { name: "seed", value: seedValue },
+    { name: "🎲 Randomize Each Time", value: "" },
+    { name: "🎲 New Fixed Random", value: "" },
+    { name: "USE_LAST_SEED", value: "okay" },
+  ],
+});
+
+test("#1339 — an rgthree seed node is invisible to the control_after_generate scan", () => {
+  // The defect, stated as a test: this is why the reporter got no warning at all.
+  assert.deepEqual(findRepeatingControlWidgets([rgthreeSeed(649, 12345)]), []);
+  // …and the new scan does see it.
+  assert.equal(findRgthreeSeedNodes([rgthreeSeed(649, 12345)]).length, 1);
+});
+
+test("#1339 — a FIXED rgthree seed is reported for a batch > 1", () => {
+  const found = findRgthreeSeedNodes([rgthreeSeed(649, 12345)]);
+  assert.deepEqual(found, [
+    { node_id: "649", node_type: "Seed (rgthree)", seed: 12345, armed: false },
+  ]);
+  const note = rgthreeFixedSeedNote(found, 10);
+  assert.match(note, /ALL 10 ITEMS/);
+  assert.match(note, /node 649/);
+  assert.match(note, /12345/);
+  // The remedy is the button that arms it, named exactly as the node shows it.
+  assert.match(note, /Randomize Each Time/);
+});
+
+test("#1339 — an ARMED rgthree seed says NOTHING", () => {
+  // The direction that matters most. Measured: driving rgthree's handler three times with
+  // the sentinel posts three DIFFERENT seeds, and a scoped batch calls api.queuePrompt
+  // once per item — so an armed node genuinely varies, and warning about it would be a
+  // confident wrong sentence. This is also why the #988 note is not simply reused here.
+  for (const [sentinel, mode] of [
+    [-1, "randomize"],
+    [-2, "increment"],
+    [-3, "decrement"],
+  ]) {
+    const found = findRgthreeSeedNodes([rgthreeSeed(649, sentinel)]);
+    assert.deepEqual(found, [
+      { node_id: "649", node_type: "Seed (rgthree)", seed: sentinel, armed: true, mode },
+    ]);
+    assert.equal(rgthreeFixedSeedNote(found, 10), "");
+  }
+});
+
+test("#1339 — silent for a batch of one, where a repeated seed is not a surprise", () => {
+  const found = findRgthreeSeedNodes([rgthreeSeed(649, 12345)]);
+  assert.equal(rgthreeFixedSeedNote(found, 1), "");
+  assert.equal(rgthreeFixedSeedNote(found, undefined), "");
+});
+
+test("#1339 — other seed nodes are NOT claimed as rgthree", () => {
+  // The over-broad direction: this scan must not start describing nodes it knows nothing
+  // about, or it will confidently call a node "fixed" whose extension randomizes it by
+  // some other mechanism — which is the exact error this whole issue is about.
+  //
+  // A KSampler alone does not test that: its type has no "seed" in it, so dropping the
+  // rgthree requirement leaves it unmatched and the mutation survives. These are REAL node
+  // types from this machine's /object_info that do contain "seed".
+  const foreignSeed = (id, type) => ({
+    id,
+    type,
+    widgets: [{ name: "seed", value: 12345 }],
+  });
+  for (const type of ["SeedNode", "LatentBatchSeedBehavior", "SeedVR2Conditioning"]) {
+    assert.deepEqual(findRgthreeSeedNodes([foreignSeed(1, type)]), [], type);
+  }
+  assert.deepEqual(findRgthreeSeedNodes([ksampler(53, "randomize")]), []);
+  assert.deepEqual(findRgthreeSeedNodes([ksampler(53, "fixed")]), []);
+});
+
+test("#1339 — survives malformed nodes without taking down the run", () => {
+  assert.deepEqual(findRgthreeSeedNodes(null), []);
+  assert.deepEqual(findRgthreeSeedNodes([null, {}, { type: "Seed (rgthree)" }]), []);
+  // A seed widget that is not a number establishes nothing, so it is not reported as fixed.
+  assert.deepEqual(findRgthreeSeedNodes([rgthreeSeed(1, "not-a-number")]), []);
+  assert.equal(rgthreeFixedSeedNote(null, 5), "");
 });

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -159,7 +159,12 @@ import {
   disabledOutputsNote,
 } from "./lib/muted-subgraph-outputs.js";
 import { findStalePlaceholders, stalePlaceholderNote } from "./lib/stale-placeholders.js";
-import { findRepeatingControlWidgets, scopedBatchSeedNote } from "./lib/scoped-batch-seed.js";
+import {
+  findRepeatingControlWidgets,
+  scopedBatchSeedNote,
+  findRgthreeSeedNodes,
+  rgthreeFixedSeedNote,
+} from "./lib/scoped-batch-seed.js";
 import {
   materializePromotedValues,
   materializedValuesNote,
@@ -11835,6 +11840,21 @@ const GRAPH_TOOL_EXECUTORS = {
         repeatingControls = []; /* a warning must never take down the run */
       }
     }
+    // #1339 — rgthree seeds, on ANY batch > 1. NOT gated on `partialTargets`, unlike the
+    // scan above: #988 is about a scoped run skipping the queue-time widget hooks, while a
+    // FIXED rgthree seed is submitted verbatim for every item whether the run is scoped or
+    // not. Gating it the same way would have kept it invisible for exactly the unscoped
+    // batch a user reaches for when they want ten different images.
+    let rgthreeSeeds = [];
+    if (batch > 1) {
+      try {
+        rgthreeSeeds = findRgthreeSeedNodes(
+          collectAllGraphs(rootGraph).flatMap((g) => g?._nodes ?? []),
+        );
+      } catch {
+        rgthreeSeeds = []; /* a warning must never take down the run */
+      }
+    }
     if (!partialTargets) {
       // UNSCOPED full run — the historical single-shot path: capture wrap for
       // exactly the duration of the queuePrompt call, then restore.
@@ -11986,6 +12006,13 @@ const GRAPH_TOOL_EXECUTORS = {
     if (repeatingNote) {
       accept.repeating_controls = repeatingControls;
       accept.repeating_controls_note = repeatingNote;
+    }
+    // #1339 — the same class of surprise from a node the scan above cannot see, because
+    // rgthree deletes the `control_after_generate` widget it matches on.
+    const fixedSeedNote = rgthreeFixedSeedNote(rgthreeSeeds, batch);
+    if (fixedSeedNote) {
+      accept.fixed_seed_nodes = rgthreeSeeds.filter((s) => s && s.armed === false);
+      accept.fixed_seed_note = fixedSeedNote;
     }
     // #572 — TRUTHFUL drift-coverage note for a scoped run: the drift hash
     // excluded queue-time hook inputs (beforeQueued carriers + their linked,

--- a/web/js/lib/scoped-batch-seed.js
+++ b/web/js/lib/scoped-batch-seed.js
@@ -248,6 +248,15 @@ export function findRgthreeSeedNodes(nodes) {
   for (const node of nodes) {
     try {
       if (!isRgthreeSeedNode(node)) continue;
+      // MUTED / BYPASSED nodes are not participating, and rgthree's own handler returns
+      // early for exactly these two modes:
+      //
+      //     if (this.mode === LiteGraph.NEVER || this.mode === 4) return;
+      //
+      // So it substitutes nothing, the node contributes nothing, and naming it would point
+      // the user at a node that is not in the run — noise in a warning whose whole value is
+      // naming the right one. (LiteGraph: 2 = NEVER/mute, 4 = bypass.)
+      if (node?.mode === 2 || node?.mode === 4) continue;
       const widgets = Array.isArray(node?.widgets) ? node.widgets : [];
       const seedWidget = widgets.find((w) => w?.name === "seed");
       if (!seedWidget) continue;

--- a/web/js/lib/scoped-batch-seed.js
+++ b/web/js/lib/scoped-batch-seed.js
@@ -210,23 +210,39 @@ function isRgthreeSeedNode(node) {
  * `|| 1125899906842624` in `generateRandomSeed`), because that is what the node will
  * actually use, not as "unknown".
  */
-function rgthreeRandomRange(node) {
+function rgthreeRandomRange(node, seedWidget) {
   let min = 0;
   let max = 1125899906842624;
+  let step = 1;
   try {
     const props = node?.properties ?? {};
     min = Number(props.randomMin || 0);
     max = Number(props.randomMax || 1125899906842624);
+    step = Number(seedWidget?.options?.step) || 1;
   } catch {
     /* the defaults above are what rgthree would use anyway */
   }
-  if (!Number.isFinite(min) || !Number.isFinite(max)) {
+  if (!Number.isFinite(min) || !Number.isFinite(max) || !Number.isFinite(step)) {
     return { varies: true, reason: null };
   }
-  if (min >= max) {
+  // THE STEP IS PART OF THE CONDITION, and `min >= max` alone missed it. rgthree draws:
+  //
+  //     const randomRange = (randomMax - randomMin) / (step / 10);
+  //     let seed = Math.floor(Math.random() * randomRange) * (step / 10) + randomMin;
+  //
+  // so when `randomRange <= 1`, `Math.floor(Math.random() * randomRange)` is always 0 and
+  // every draw returns `randomMin`. Measured: min=0, max=5, step=100 gives ONE distinct
+  // value across 200 draws while min < max looks perfectly healthy. A range check that
+  // ignores the step reports that node as varying, which is the silence this whole fix is
+  // about.
+  const range = (max - min) / (step / 10);
+  if (!(range > 1)) {
     return {
       varies: false,
-      reason: `its random range is randomMin=${min}, randomMax=${max}, which admits a single value`,
+      reason:
+        `its random range is randomMin=${min}, randomMax=${max}` +
+        (step !== 1 ? ` at step ${step}` : "") +
+        `, which admits a single value`,
     };
   }
   return { varies: true, reason: null };
@@ -289,7 +305,7 @@ export function findRgthreeSeedNodes(nodes) {
       // number, and a degenerate range landing on a sentinel is coerced to 0. So an armed
       // node with randomMin === randomMax submits the SAME seed every item while looking
       // armed. Silence there would recreate the exact surprise this warning exists for.
-      const range = rgthreeRandomRange(node);
+      const range = rgthreeRandomRange(node, seedWidget);
       const varies = mode !== null && range.varies;
       found.push({
         node_id: node?.id != null ? String(node.id) : null,

--- a/web/js/lib/scoped-batch-seed.js
+++ b/web/js/lib/scoped-batch-seed.js
@@ -203,6 +203,36 @@ function isRgthreeSeedNode(node) {
 }
 
 /**
+ * Can this node's random draw produce more than one value?
+ *
+ * Only meaningful for an ARMED node — a fixed seed does not draw at all. Unreadable
+ * properties are treated as the DEFAULTS rgthree itself falls back to (`|| 0` and
+ * `|| 1125899906842624` in `generateRandomSeed`), because that is what the node will
+ * actually use, not as "unknown".
+ */
+function rgthreeRandomRange(node) {
+  let min = 0;
+  let max = 1125899906842624;
+  try {
+    const props = node?.properties ?? {};
+    min = Number(props.randomMin || 0);
+    max = Number(props.randomMax || 1125899906842624);
+  } catch {
+    /* the defaults above are what rgthree would use anyway */
+  }
+  if (!Number.isFinite(min) || !Number.isFinite(max)) {
+    return { varies: true, reason: null };
+  }
+  if (min >= max) {
+    return {
+      varies: false,
+      reason: `its random range is randomMin=${min}, randomMax=${max}, which admits a single value`,
+    };
+  }
+  return { varies: true, reason: null };
+}
+
+/**
  * rgthree seed nodes in this graph, and whether each will vary across a batch.
  *
  * Returns `[{ node_id, node_type, seed, armed, mode }]` — `armed` is the whole answer:
@@ -221,25 +251,45 @@ export function findRgthreeSeedNodes(nodes) {
       const widgets = Array.isArray(node?.widgets) ? node.widgets : [];
       const seedWidget = widgets.find((w) => w?.name === "seed");
       if (!seedWidget) continue;
-      // A SEED CONVERTED TO AN INPUT IS NOT THIS WIDGET'S VALUE. When the seed is driven
-      // by a link — a Primitive with its own control_after_generate, another extension's
-      // sampler-scheduler, anything — the widget keeps a stale number that says nothing
-      // about what will be submitted. Reporting that number as "fixed for all N items"
-      // would be a confident, checkable, WRONG claim about a node that is in fact varying,
-      // which is the error this whole issue is about. Nothing is established, so nothing
-      // is said.
-      const inputs = Array.isArray(node?.inputs) ? node.inputs : [];
-      const driven = inputs.some((inp) => inp?.name === "seed" && inp?.link != null);
-      if (driven) continue;
+      // NO LINK GUARD HERE, and that is deliberate — I added one and it was wrong.
+      //
+      // For an ordinary node, a seed converted to an input makes the widget value stale.
+      // Not for this one: rgthree's queue handler OVERWRITES the outgoing seed from its own
+      // widget regardless of any link —
+      //
+      //     const seedToUse = this.getSeedToUse();               // reads seedWidget.value
+      //     outputInputs[this.seedWidget.name || "seed"] = seedToUse;
+      //
+      // (`src_web/comfyui/seed.ts`, the `comfy-api-queue-prompt-before` handler.) So the
+      // widget IS what gets submitted, and declining on a link suppressed the warning for a
+      // linked node whose widget holds a fixed number — a MISSED warning, which is the
+      // original bug rather than a new false claim (codex).
       const raw = Number(seedWidget.value);
       if (!Number.isFinite(raw)) continue;
       const mode = RGTHREE_SPECIAL_SEEDS.get(raw) ?? null;
+      // ARMED IS NOT THE SAME AS VARYING (codex P2). rgthree's random range is a pair of
+      // node PROPERTIES the user can edit:
+      //
+      //     const randomMin = Number(this.properties["randomMin"] || 0);
+      //     const randomMax = Number(this.properties["randomMax"] || 1125899906842624);
+      //     const randomRange = (randomMax - randomMin) / (step / 10);
+      //     let seed = Math.floor(Math.random() * randomRange) * (step / 10) + randomMin;
+      //     if (SPECIAL_SEEDS.includes(seed)) seed = 0;
+      //
+      // A range that admits one value — min >= max — makes every "random" draw the same
+      // number, and a degenerate range landing on a sentinel is coerced to 0. So an armed
+      // node with randomMin === randomMax submits the SAME seed every item while looking
+      // armed. Silence there would recreate the exact surprise this warning exists for.
+      const range = rgthreeRandomRange(node);
+      const varies = mode !== null && range.varies;
       found.push({
         node_id: node?.id != null ? String(node.id) : null,
         node_type: node?.type ?? null,
         seed: raw,
         armed: mode !== null,
+        varies,
         ...(mode ? { mode } : {}),
+        ...(mode !== null && !range.varies ? { degenerate_range: range.reason } : {}),
       });
     } catch {
       /* one unreadable node costs its own entry, never the whole diagnosis */
@@ -261,21 +311,41 @@ export function findRgthreeSeedNodes(nodes) {
  */
 export function rgthreeFixedSeedNote(seeds, batchCount) {
   if (!Array.isArray(seeds) || !(Number(batchCount) > 1)) return "";
-  const fixed = seeds.filter((s) => s && s.armed === false);
-  if (!fixed.length) return "";
-  const which = fixed
+  // `varies === false` covers BOTH ways an rgthree seed repeats: a concrete number in the
+  // widget, and an armed node whose random range admits one value. Keying on `armed`
+  // alone missed the second (codex P2) — and an armed-but-degenerate node is the more
+  // confusing of the two, because the user did press the button.
+  const repeating = seeds.filter((s) => s && s.varies === false);
+  if (!repeating.length) return "";
+  const which = repeating
     .slice(0, 5)
-    .map((s) => `node ${s.node_id}${s.node_type ? ` (${s.node_type})` : ""} seed=${s.seed}`)
+    .map((s) => {
+      const where = `node ${s.node_id}${s.node_type ? ` (${s.node_type})` : ""}`;
+      return s.armed
+        ? `${where} is armed to ${s.mode}, but ${s.degenerate_range}`
+        : `${where} seed=${s.seed}`;
+    })
     .join("; ");
-  const more = fixed.length > 5 ? `, and ${fixed.length - 5} more` : "";
+  const more = repeating.length > 5 ? `, and ${repeating.length - 5} more` : "";
+  const anyFixed = repeating.some((s) => !s.armed);
+  const anyDegenerate = repeating.some((s) => s.armed);
   return (
     `ALL ${batchCount} ITEMS OF THIS BATCH WILL USE THE SAME SEED from ${which}${more}. ` +
-    `An rgthree Seed node only produces a new value per item while it is ARMED — its seed ` +
-    `widget holding -1 (randomize), -2 (increment) or -3 (decrement) — and these hold a ` +
-    `concrete number, so rgthree submits that number every time. That is the node behaving ` +
-    `as configured, not a fault: identical seeds mean identical prompts, which ComfyUI can ` +
-    `answer from cache, so the renders can come back pixel-identical (#1339). Press ` +
-    `"🎲 Randomize Each Time" on the node to arm it, or set a different seed between runs. ` +
-    `This is reported, not repaired — the panel does not rewrite your seeds.`
+    (anyFixed
+      ? `An rgthree Seed node only produces a new value per item while it is ARMED — its ` +
+        `seed widget holding -1 (randomize), -2 (increment) or -3 (decrement) — and a ` +
+        `concrete number is submitted verbatim every time. `
+      : "") +
+    (anyDegenerate
+      ? `An armed node still repeats when its randomMin/randomMax properties admit a ` +
+        `single value, which is why pressing the button did not help. `
+      : "") +
+    `That is the node behaving as configured, not a fault: identical seeds mean identical ` +
+    `prompts, which ComfyUI can answer from cache, so the renders can come back ` +
+    `pixel-identical (#1339). ` +
+    (anyFixed ? `Press "🎲 Randomize Each Time" on the node to arm it` : "") +
+    (anyFixed && anyDegenerate ? `, and widen ` : anyDegenerate ? `Widen ` : "") +
+    (anyDegenerate ? `randomMin/randomMax in its node properties` : "") +
+    `. This is reported, not repaired — the panel does not rewrite your seeds.`
   );
 }

--- a/web/js/lib/scoped-batch-seed.js
+++ b/web/js/lib/scoped-batch-seed.js
@@ -155,3 +155,117 @@ export function scopedBatchSeedNote(controls, batchCount) {
     `yourself between runs, or drop to_node_id so the run is unscoped and ComfyUI advances it.`
   );
 }
+
+/**
+ * #1339 — the same surprise, from a node this module could not see.
+ *
+ * A reporter ran `batch_count: 10` against a workflow whose seed comes from an rgthree
+ * Seed node set to "Randomize Each Time", got ten identical images, and was told
+ * `queued: true` with ten prompt ids and nothing else. The disclosure above could not
+ * fire, because rgthree DELETES the widget it looks for:
+ *
+ *     // Grab the already available widgets, and remove the built-in control_after_generate
+ *     } else if (w.name === "control_after_generate") { this.widgets.splice(i, 1); }
+ *
+ * A live `Seed (rgthree)` node carries `seed` plus three buttons and nothing else. So the
+ * most widely used custom seed node was invisible to the one warning about repeated seeds.
+ *
+ * WHAT IT DOES *NOT* SAY, and this is the point. It does not claim an rgthree seed repeats
+ * because the batch is scoped. MEASURED, driving rgthree's own handler three times on a
+ * node armed with the sentinel:
+ *
+ *     posted seeds  1028465986822020, 98533269447704, 557498712106716   (all differ)
+ *     widget after each call: -1 (still armed)
+ *
+ * …and a scoped batch of 3 was measured to call `api.queuePrompt` THREE times, so that
+ * handler fires per item. rgthree substitutes in its own `api.queuePrompt` patch rather
+ * than in the queue-time widget hooks a partial execution skips — so it is not subject to
+ * the #988 mechanism at all. Extending the warning above to cover it would have been a
+ * confident, checkable, WRONG sentence.
+ *
+ * What actually decides whether these ten renders differ is whether the node is ARMED:
+ * rgthree only substitutes when the seed widget holds one of its sentinels. A concrete
+ * number means every item of the batch uses that number — correct behaviour, and exactly
+ * what identical outputs look like from the outside.
+ */
+
+/** rgthree's sentinels: -1 random, -2 increment, -3 decrement (`src_web/comfyui/seed.ts`). */
+const RGTHREE_SPECIAL_SEEDS = new Map([
+  [-1, "randomize"],
+  [-2, "increment"],
+  [-3, "decrement"],
+]);
+
+/** A node is one of rgthree's seed nodes if it says so and carries the seed widget. */
+function isRgthreeSeedNode(node) {
+  const type = typeof node?.type === "string" ? node.type : "";
+  return /rgthree/i.test(type) && /seed/i.test(type);
+}
+
+/**
+ * rgthree seed nodes in this graph, and whether each will vary across a batch.
+ *
+ * Returns `[{ node_id, node_type, seed, armed, mode }]` — `armed` is the whole answer:
+ * true means rgthree swaps a fresh value into every submitted prompt, false means the
+ * concrete number in the widget is used for every item.
+ *
+ * Defensive for the same reason as the scan above: a warning must not be able to take
+ * down the run it is about.
+ */
+export function findRgthreeSeedNodes(nodes) {
+  const found = [];
+  if (!Array.isArray(nodes)) return found;
+  for (const node of nodes) {
+    try {
+      if (!isRgthreeSeedNode(node)) continue;
+      const widgets = Array.isArray(node?.widgets) ? node.widgets : [];
+      const seedWidget = widgets.find((w) => w?.name === "seed");
+      if (!seedWidget) continue;
+      const raw = Number(seedWidget.value);
+      if (!Number.isFinite(raw)) continue;
+      const mode = RGTHREE_SPECIAL_SEEDS.get(raw) ?? null;
+      found.push({
+        node_id: node?.id != null ? String(node.id) : null,
+        node_type: node?.type ?? null,
+        seed: raw,
+        armed: mode !== null,
+        ...(mode ? { mode } : {}),
+      });
+    } catch {
+      /* one unreadable node costs its own entry, never the whole diagnosis */
+    }
+  }
+  return found;
+}
+
+/**
+ * The disclosure for a batch whose rgthree seed is FIXED.
+ *
+ * Silent when the node is armed, because then it genuinely varies per item and there is
+ * nothing to warn about — saying something anyway would be the noise that trains people to
+ * ignore the useful case. Silent for a batch of one, where "every item uses this seed" is
+ * not a surprise.
+ *
+ * Unlike the scoped-batch note, this does NOT depend on the run being scoped: a fixed seed
+ * repeats in an unscoped batch too.
+ */
+export function rgthreeFixedSeedNote(seeds, batchCount) {
+  if (!Array.isArray(seeds) || !(Number(batchCount) > 1)) return "";
+  const fixed = seeds.filter((s) => s && s.armed === false);
+  if (!fixed.length) return "";
+  const which = fixed
+    .slice(0, 5)
+    .map((s) => `node ${s.node_id}${s.node_type ? ` (${s.node_type})` : ""} seed=${s.seed}`)
+    .join("; ");
+  const more = fixed.length > 5 ? `, and ${fixed.length - 5} more` : "";
+  return (
+    `ALL ${batchCount} ITEMS OF THIS BATCH WILL USE THE SAME SEED from ${which}${more}. ` +
+    `An rgthree Seed node only produces a new value per item while it is ARMED — its seed ` +
+    `widget holding -1 (randomize), -2 (increment) or -3 (decrement) — and these hold a ` +
+    `concrete number, so rgthree submits that number every time. That is the node behaving ` +
+    `as configured, not a fault: identical seeds mean identical prompts, which ComfyUI can ` +
+    `answer from cache, so the renders can come back pixel-identical (#1339). Press ` +
+    `"🎲 Randomize Each Time" on the node to arm it, or set a different seed between runs. ` +
+    `This is reported, not repaired — the panel does not rewrite your seeds.`
+  );
+}

--- a/web/js/lib/scoped-batch-seed.js
+++ b/web/js/lib/scoped-batch-seed.js
@@ -221,6 +221,16 @@ export function findRgthreeSeedNodes(nodes) {
       const widgets = Array.isArray(node?.widgets) ? node.widgets : [];
       const seedWidget = widgets.find((w) => w?.name === "seed");
       if (!seedWidget) continue;
+      // A SEED CONVERTED TO AN INPUT IS NOT THIS WIDGET'S VALUE. When the seed is driven
+      // by a link — a Primitive with its own control_after_generate, another extension's
+      // sampler-scheduler, anything — the widget keeps a stale number that says nothing
+      // about what will be submitted. Reporting that number as "fixed for all N items"
+      // would be a confident, checkable, WRONG claim about a node that is in fact varying,
+      // which is the error this whole issue is about. Nothing is established, so nothing
+      // is said.
+      const inputs = Array.isArray(node?.inputs) ? node.inputs : [];
+      const driven = inputs.some((inp) => inp?.name === "seed" && inp?.link != null);
+      if (driven) continue;
       const raw = Number(seedWidget.value);
       if (!Number.isFinite(raw)) continue;
       const mode = RGTHREE_SPECIAL_SEEDS.get(raw) ?? null;


### PR DESCRIPTION
Upstream half of artokun/comfyui-mcp#1339.

**Measured** on the live rig with `/prompt` intercepted so nothing queued ([full results](https://github.com/artokun/comfyui-mcp/issues/1339#issuecomment-5257682765)):

| run | posted seeds |
|---|---|
| `app.queuePrompt(0, 3)` | 742732484087382, 27923863108977, 114376582494196 — differ |
| `app.queuePrompt(0, 3, ["29"])` | 77161535712866 ×3 — repeat |
| rgthree handler driven 3× with `seed: -1` | 1028465986822020, 98533269447704, 557498712106716 — differ |

`findRepeatingControlWidgets` matches widgets named `control_after_generate`. **rgthree deletes that widget** — a live `Seed (rgthree)` node carries `seed` plus three buttons and nothing else — so the #988 disclosure is structurally blind to the most widely used custom seed node. The reporter ran `batch_count: 10`, got ten identical images, and was told `queued: true` with ten prompt ids.

**What this will NOT do:** claim an rgthree seed repeats because the batch is scoped. The measurement above says it does not — rgthree substitutes in its own `api.queuePrompt` patch, which fires per item even when scoped. Extending the existing warning to cover it would be a confident wrong sentence, which is the failure mode #988's module was written to avoid.

**What it should say instead** is the thing that actually distinguishes the two outcomes: an rgthree seed is *armed* (widget holds a `-1`/`-2`/`-3` sentinel → a fresh value per item) or *fixed* (a concrete number → every item uses it). For a batch of more than one, that is the fact the user needs and currently cannot see.

Refs artokun/comfyui-mcp#1339.

🤖 Generated with [Claude Code](https://claude.com/claude-code)