### PR TITLE
fix(1425): resolve subgraph-qualified node ids instead of coercing them to NaN

### DIFF
--- a/browser_tests/unit/graph-edit-node.test.mjs
+++ b/browser_tests/unit/graph-edit-node.test.mjs
@@ -4,6 +4,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
+import { canonicalNodeId, isQualifiedNodeId } from "../../web/js/lib/node-id.js";
 import { fileURLToPath } from "node:url";
 
 const panelPath = fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url));
@@ -31,9 +32,22 @@ function realGraphEditNode(getGraphCtx, resolveNode, refreshNodeArea, unsafeBypa
     "unsafeBypassMappings",
     "resolveRailNode",
     "railKindFor",
+    // #1425 — the REAL helpers, not doubles: injecting a stub here would let the
+    // extracted method pass against a canonicalNodeId that always returned NaN.
+    "canonicalNodeId",
+    "isQualifiedNodeId",
     `const executors = { ${methodMatch[0]} }; return executors.graph_edit_node;`,
   );
-  return factory(getGraphCtx, resolveNode, refreshNodeArea, unsafeBypassMappings, resolveRailNode, railKindFor);
+  return factory(
+    getGraphCtx,
+    resolveNode,
+    refreshNodeArea,
+    unsafeBypassMappings,
+    resolveRailNode,
+    railKindFor,
+    canonicalNodeId,
+    isQualifiedNodeId,
+  );
 }
 
 function realLegacyColor(getGraphCtx, resolveNode, normalizeLegacyNodeId) {
@@ -54,9 +68,11 @@ function realLegacyMotion(getGraphCtx, resolveNode, refreshNodeArea, unsafeBypas
     "resolveRailNode",
     "railKindFor",
     "normalizeLegacyNodeId",
+    "canonicalNodeId",
+    "isQualifiedNodeId",
     `const GRAPH_TOOL_EXECUTORS = { ${methodMatch[0]} ${legacyMoveMatch[0]} ${legacyResizeMatch[0]} };
      return { move: GRAPH_TOOL_EXECUTORS.graph_move_node, resize: GRAPH_TOOL_EXECUTORS.graph_resize_node };`,
-  )(getGraphCtx, resolveNode, refreshNodeArea, unsafeBypassMappings, resolveRailNode, railKindFor, normalizeLegacyNodeId);
+  )(getGraphCtx, resolveNode, refreshNodeArea, unsafeBypassMappings, resolveRailNode, railKindFor, normalizeLegacyNodeId, canonicalNodeId, isQualifiedNodeId);
 }
 
 function realLegacyTitle(getGraphCtx, resolveNode, refreshNodeArea, unsafeBypassMappings, resolveRailNode, railKindFor, normalizeLegacyNodeId) {
@@ -68,8 +84,10 @@ function realLegacyTitle(getGraphCtx, resolveNode, refreshNodeArea, unsafeBypass
     "resolveRailNode",
     "railKindFor",
     "normalizeLegacyNodeId",
+    "canonicalNodeId",
+    "isQualifiedNodeId",
     `const GRAPH_TOOL_EXECUTORS = { ${methodMatch[0]} ${legacyTitleMatch[0]} }; return GRAPH_TOOL_EXECUTORS.graph_set_title;`,
-  )(getGraphCtx, resolveNode, refreshNodeArea, unsafeBypassMappings, resolveRailNode, railKindFor, normalizeLegacyNodeId);
+  )(getGraphCtx, resolveNode, refreshNodeArea, unsafeBypassMappings, resolveRailNode, railKindFor, normalizeLegacyNodeId, canonicalNodeId, isQualifiedNodeId);
 }
 
 function realLegacyCollapsed(getGraphCtx, resolveNode, refreshNodeArea, unsafeBypassMappings, resolveRailNode, railKindFor, normalizeLegacyNodeId) {
@@ -81,8 +99,10 @@ function realLegacyCollapsed(getGraphCtx, resolveNode, refreshNodeArea, unsafeBy
     "resolveRailNode",
     "railKindFor",
     "normalizeLegacyNodeId",
+    "canonicalNodeId",
+    "isQualifiedNodeId",
     `const GRAPH_TOOL_EXECUTORS = { ${methodMatch[0]} ${legacyCollapsedMatch[0]} }; return GRAPH_TOOL_EXECUTORS.graph_set_node_collapsed;`,
-  )(getGraphCtx, resolveNode, refreshNodeArea, unsafeBypassMappings, resolveRailNode, railKindFor, normalizeLegacyNodeId);
+  )(getGraphCtx, resolveNode, refreshNodeArea, unsafeBypassMappings, resolveRailNode, railKindFor, normalizeLegacyNodeId, canonicalNodeId, isQualifiedNodeId);
 }
 
 function realLegacyMode(getGraphCtx, resolveNode, unsafeBypassMappings, normalizeLegacyNodeId) {

--- a/browser_tests/unit/node-id.test.mjs
+++ b/browser_tests/unit/node-id.test.mjs
@@ -1,0 +1,61 @@
+// artokun/comfyui-mcp#1425 — subgraph-qualified node ids must RESOLVE, and must
+// never resolve to a different node.
+//
+// The dangerous direction is the fix done halfway. Widening what is accepted while
+// still coercing turns "no node with id 263:78" into a silent edit of node 263, so
+// every acceptance assertion here is paired with an identity one.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { canonicalNodeId, isQualifiedNodeId } from "../../web/js/lib/node-id.js";
+
+test("#1425 a qualified id is recognised at any depth", () => {
+  for (const id of ["120:104", "263:78", "120:113:78", "1:2:3:4", "-20:3"]) {
+    assert.equal(isQualifiedNodeId(id), true, id);
+  }
+});
+
+test("#1425 a plain id is NOT qualified — it keeps the old numeric path", () => {
+  for (const id of ["42", "0", "-20", 42, -20]) {
+    assert.equal(isQualifiedNodeId(id), false, String(id));
+  }
+});
+
+test("#1425 malformed shapes are not qualified ids", () => {
+  for (const id of ["1:", ":1", "1::2", "1:2:", "1:-2", "1: 2", "a:b", "", "4.5:1"]) {
+    assert.equal(isQualifiedNodeId(id), false, JSON.stringify(id));
+  }
+});
+
+test("#1425 a qualified id reaches LiteGraph VERBATIM", () => {
+  assert.equal(canonicalNodeId("263:78"), "263:78");
+  assert.equal(canonicalNodeId("120:113:78"), "120:113:78");
+  // The trap, stated outright: this is a real, different node in the same graph.
+  assert.notEqual(canonicalNodeId("263:78"), 263);
+  assert.notEqual(canonicalNodeId("263:78"), Number.parseInt("263:78", 10));
+});
+
+test("#1425 a plain id still becomes the NUMBER it always was", () => {
+  assert.equal(canonicalNodeId("42"), 42);
+  assert.equal(canonicalNodeId(42), 42);
+  assert.equal(canonicalNodeId("-20"), -20); // boundary rail
+});
+
+test("#1425 a qualified id resolves against a LiteGraph-shaped lookup", () => {
+  // getNodeById is `_nodes_by_id[id]`; object keys are strings, which is WHY
+  // passing the qualified form through works. Measured against a live ComfyUI:
+  // node ids there are already strings.
+  const nodesById = { "263:78": { id: "263:78" }, 263: { id: 263 } };
+  const getNodeById = (id) => nodesById[id] ?? null;
+
+  assert.equal(getNodeById(canonicalNodeId("263:78")).id, "263:78");
+  // Before the fix this was Number("263:78") === NaN → nothing.
+  assert.equal(getNodeById(Number("263:78")), null);
+  // And the plain id must still land on the OTHER node, not the qualified one.
+  assert.equal(getNodeById(canonicalNodeId("263")).id, 263);
+});
+
+test("#1425 genuinely bad input still lands on NaN for the caller to report", () => {
+  assert.ok(Number.isNaN(canonicalNodeId("abc")));
+  assert.ok(Number.isNaN(canonicalNodeId("1:-2")));
+});

--- a/browser_tests/unit/node-scope-locator.test.mjs
+++ b/browser_tests/unit/node-scope-locator.test.mjs
@@ -138,7 +138,7 @@ test("WIRING: resolveNode builds its error through describeMissingNode", async (
   assert.ok(body.includes("describeMissingNode(nodeId, rootGraph, viewingRoot)"),
     "the failure path must go through the locator");
   // The lookup itself must be unchanged — this is diagnostics only, never a wider search.
-  assert.ok(body.includes("graph.getNodeById(Number(nodeId))"),
+  assert.ok(body.includes("graph.getNodeById(canonicalNodeId(nodeId))"),
     "resolution must still be scoped to the current graph");
   // And the diagnostic must not be able to break the call.
   assert.ok(body.includes("} catch {"), "reading the root must be guarded");

--- a/browser_tests/unit/rail-id-diagnosis.test.mjs
+++ b/browser_tests/unit/rail-id-diagnosis.test.mjs
@@ -132,5 +132,5 @@ test("WIRING: resolveNode asks WHAT the id is before reporting it missing", asyn
     "the rail branch must precede the generic miss",
   );
   // And it stays diagnostics-only: resolution is still the current graph alone.
-  assert.ok(body.includes("graph.getNodeById(Number(nodeId))"));
+  assert.ok(body.includes("graph.getNodeById(canonicalNodeId(nodeId))"));
 });

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -7055,7 +7055,7 @@ const modeName = (m) => MODE_NAME[m] ?? `mode${m ?? 0}`;
 const linkKey = (l) => `${l[1]}:${l[2]}->${l[3]}:${l[4]}`;
 function widgetName(liveGraph, nodeId, i) {
   try {
-    const w = liveGraph?.getNodeById?.(Number(nodeId))?.widgets?.[i];
+    const w = liveGraph?.getNodeById?.(canonicalNodeId(nodeId))?.widgets?.[i];
     if (w && w.name) return w.name;
   } catch {}
   return `#${i}`;
@@ -11100,9 +11100,15 @@ const GRAPH_TOOL_EXECUTORS = {
     if (rail && fields.some((field) => field !== "pos" && own(field))) {
       throw new Error("a subgraph boundary rail only supports pos edits");
     }
-    const realNode = !rail && hasNodeId && Number.isFinite(Number(args.node_id)) && typeof graph.getNodeById === "function"
-      ? graph.getNodeById(Number(args.node_id))
-      : null;
+    const realNode =
+      !rail &&
+      hasNodeId &&
+      // #1425 — a subgraph-qualified id is id-shaped too. Number("263:78") is NaN,
+      // so the finite check alone called a real node unreal.
+      (isQualifiedNodeId(args.node_id) || Number.isFinite(Number(args.node_id))) &&
+      typeof graph.getNodeById === "function"
+        ? graph.getNodeById(canonicalNodeId(args.node_id))
+        : null;
     if (!rail && !realNode && hasNodeId && graph === rootGraph && railKindFor(args.node_id)) {
       throw new Error(`${args.node_id} is a subgraph boundary rail, which only exists inside a subgraph — enter the subgraph first (panel_enter_subgraph).`);
     }
@@ -14292,7 +14298,7 @@ const GRAPH_TOOL_EXECUTORS = {
     const store = getSubgraphStore();
     let target = null;
     if (node_id != null) {
-      target = graph.getNodeById(Number(node_id));
+      target = graph.getNodeById(canonicalNodeId(node_id));
       if (!target) throw new Error(`No node with id ${node_id} in the current graph`);
       if (!target.subgraph) {
         throw new Error(`Node ${node_id} (${target.type}) is not a subgraph node`);

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -240,6 +240,7 @@ import {
 } from "./lib/thread-workflow-match.js";
 import { subgraphValueProvenance } from "./lib/subgraph-value-provenance.js";
 import { describeMissingNode, describeRailNodeTarget } from "./lib/node-scope-locator.js";
+import { canonicalNodeId, isQualifiedNodeId } from "./lib/node-id.js";
 import { boundByChars, normalizeViewportMaxChars, viewportTruncation, VIEWPORT_DEFAULT_MAX_CHARS } from "./lib/viewport-char-bound.js";
 import { classifyManualChangeBaseline } from "./lib/manual-change-gate.js";
 import {
@@ -7953,8 +7954,24 @@ function nodeDescription(node) {
   return String(node?.constructor?.nodeData?.description ?? node?.description ?? "");
 }
 
+/**
+ * artokun/comfyui-mcp#1425 — a SUBGRAPH-QUALIFIED node id (`120:104`, `263:78`).
+ *
+ * Unpacking a subgraph leaves genuine ROOT-level nodes carrying these ids, and the
+ * read tools hand them out. `Number("263:78")` is NaN, so every write that went
+ * through `getNodeById(Number(id))` reported the node as missing — readable graph,
+ * uneditable nodes.
+ *
+ * Passing the qualified form THROUGH is what resolves it: LiteGraph's getNodeById
+ * is a `_nodes_by_id[id]` object lookup, and object keys are strings, so the id the
+ * reader printed is the key the node is stored under. (Measured against a live
+ * ComfyUI: node ids there are already strings, and lookup by string resolves.)
+ *
+ * Numbers still go through `Number()` unchanged — a plain id must keep behaving
+ * exactly as before, including the numeric-string compatibility surface.
+ */
 function resolveNode(graph, nodeId) {
-  const node = graph.getNodeById(Number(nodeId));
+  const node = graph.getNodeById(canonicalNodeId(nodeId));
   // #697 — a node the READS just listed can be unresolvable here: reads span every
   // scope, while a write applies to the graph being VIEWED. Say WHERE it actually is
   // instead of only that it is not here. Diagnostic-only: runs on the failure path,
@@ -8000,7 +8017,10 @@ function normalizeLegacyNodeId(nodeId) {
     const normalized = Number(nodeId);
     if (Number.isSafeInteger(normalized)) return normalized;
   }
-  throw new Error("node_id must be an integer");
+  // #1425 — a subgraph-qualified id stays a STRING. Coercing it is the bug: it
+  // would resolve to NaN here, and to the wrong node upstream if parsed instead.
+  if (isQualifiedNodeId(nodeId)) return nodeId;
+  throw new Error("node_id must be an integer or a subgraph-qualified id (e.g. 120:104)");
 }
 
 // ---- Node-type resolution guard (#458) ------------------------------------

--- a/web/js/lib/node-id.js
+++ b/web/js/lib/node-id.js
@@ -1,0 +1,44 @@
+/**
+ * artokun/comfyui-mcp#1425 — how a node id from the tools becomes a LiteGraph key.
+ *
+ * Unpacking a subgraph leaves genuine ROOT-level nodes carrying SUBGRAPH-QUALIFIED
+ * ids: `120:104`, `263:78`, `120:113:78`. The read tools list and render them
+ * normally, and every write went through `graph.getNodeById(Number(nodeId))` —
+ * `Number("263:78")` is NaN — so those nodes reported as missing. One reporter had
+ * 18 of 21 nodes readable and uneditable.
+ *
+ * Passing the qualified form THROUGH is what resolves it. LiteGraph's getNodeById
+ * is a `_nodes_by_id[id]` object lookup and object keys are strings, so the id the
+ * reader printed is the key the node is stored under. Measured against a live
+ * ComfyUI rather than assumed: node ids there are already strings, and lookup by
+ * string resolves the same node as lookup by number.
+ *
+ * What must NOT happen is parsing one. `Number.parseInt("263:78", 10)` is 263 — a
+ * DIFFERENT, real node — so a half-done fix converts a loud "no such node" into a
+ * silent edit of the wrong one. That is why the MCP side stopped coercing at the
+ * same time (see src/orchestrator/node-id.ts there); a plain integer id keeps
+ * behaving exactly as it always has.
+ */
+
+/** Integer segments joined by colons. Only the FIRST may be negative: a leading
+ *  `-` marks a boundary-rail id (-10/-20), which the readers do emit, while a `-`
+ *  inside a path is a shape nothing produces. No depth limit — nesting is
+ *  arbitrary, and a limit would fail the deep case the way NaN failed the shallow. */
+const QUALIFIED_NODE_ID_RE = /^-?\d+(?::\d+)+$/;
+
+/** True for `"120:104"`; false for `"42"`, `42`, `"1:"`, `"1:-2"`, and non-strings. */
+export function isQualifiedNodeId(nodeId) {
+  return typeof nodeId === "string" && QUALIFIED_NODE_ID_RE.test(nodeId);
+}
+
+/**
+ * The key to hand LiteGraph.
+ *
+ * A qualified id is returned VERBATIM. Everything else goes through `Number()`
+ * exactly as before — including the numeric-string compatibility surface — so a
+ * plain id is unaffected, and genuinely bad input still lands on NaN and is
+ * reported as missing by the caller's existing diagnosis.
+ */
+export function canonicalNodeId(nodeId) {
+  return isQualifiedNodeId(nodeId) ? nodeId : Number(nodeId);
+}


### PR DESCRIPTION
The panel half of artokun/comfyui-mcp#1425. Paired with comfyui-mcp PR #1433 — neither is useful alone.

Root nodes left by an unpacked subgraph carry ids like `263:78`. `resolveNode` did `graph.getNodeById(Number(nodeId))`, and `Number("263:78")` is `NaN`, so every write reported the node missing.

Verified against the live rig before writing the fix: `getNodeById` is a `_nodes_by_id[id]` object lookup (no strict scan, no Map), node ids in a live graph are already strings, and string lookup resolves. So passing the qualified id through is what works — and parsing it would hit node 263 instead.

Extracted to `web/js/lib/node-id.js` because the two existing assertions here are source-greps that would pass against a helper returning NaN.