### PR TITLE
fix(968): don't capture another workflow's canvas into the tab being opened

### DIFF
--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -13056,9 +13056,6 @@ const GRAPH_TOOL_EXECUTORS = {
     let dirtyNow = false;
     let staleInfo = { stale: false, reload: false };
     let canvasDivergence = null; // #968
-    // #968 — the workflow whose graph is painted on the canvas at the moment we switch.
-    // Set synchronously immediately before `s.openWorkflow(target)`; see the note there.
-    let canvasOwnerBeforeSwitch = null;
     let reloaded = false;
     let reloadError = null;
     let openFailed = null;
@@ -13083,14 +13080,6 @@ const GRAPH_TOOL_EXECUTORS = {
         // command rather than reporting it as a move nobody made. A claim that is never
         // followed by a move is discarded by the next observation.
         claimActiveWorkflowMove(MOVE_CAUSES.OPEN_EXECUTOR, `workflow_open ${workflowTabId(target) || ""}`.trim());
-        // #968 — WHOSE canvas is mounted, read SYNCHRONOUSLY before the pointer moves.
-        // After the await, `activeWorkflow` is the target and this fact is unrecoverable:
-        // the store keeps no "what was painted" pointer. The capture below needs it,
-        // because a switch leaves the PREVIOUS tab's graph on the canvas and capturing it
-        // into the target writes another workflow's graph into this one. Identity is
-        // compared through the store's reactive proxies, so match on the tab id / path
-        // rather than `===` (a raw object is not `===` its own proxy).
-        canvasOwnerBeforeSwitch = s?.activeWorkflow ?? null;
         await s.openWorkflow(target);
       } catch (err) {
         // The native switch itself failed — nothing was applied. Recorded, then rethrown
@@ -13198,24 +13187,45 @@ const GRAPH_TOOL_EXECUTORS = {
           // this only ever REMOVES a capture we can prove is reading someone else's canvas.
           // When the target IS already the painted tab (the `wasOpen`/already-current case
           // #874 was written for) the binding is "bound" and the capture runs unchanged.
-          // TWO independent refusals, because they cover different gaps.
+          // The question is ONLY "is the mounted canvas this target's graph?", and it must
+          // be answered with POSITIVE proof, because BOTH answers can destroy data:
+          // capturing a foreign canvas writes another workflow's graph into this one
+          // (#968), and skipping a legitimate capture lets the repaint below overwrite live
+          // canvas work with a stale snapshot (#874). There is no safe default, so this
+          // never guesses from "did the pointer move" — that says nothing about who owns
+          // the canvas, and an earlier draft of this fix got both directions wrong with it
+          // (codex).
           //
-          // (a) the PRE-SWITCH OWNER is decisive and needs no tagging: if some OTHER
-          //     workflow was active when we moved the pointer, its graph is what is
-          //     mounted, full stop. This is the case the #708 oracle cannot always see —
-          //     it reads a uuid tag off the root graph, and an untagged canvas yields
-          //     "unknown", which captures. Comparing tab ids avoids the raw-vs-proxy
-          //     identity trap the store's reactivity sets.
-          // (b) the #708 oracle still runs, and catches a canvas that drifted while the
-          //     pointer never moved — the pre-switch owner would say "same tab" there and
-          //     see nothing wrong.
-          const priorOwnerId = canvasOwnerBeforeSwitch
-            ? workflowTabId(canvasOwnerBeforeSwitch) || canvasOwnerBeforeSwitch.path || null
-            : null;
-          const targetOwnerId = workflowTabId(target) || target.path || null;
-          const switchedTabs = !!priorOwnerId && !!targetOwnerId && priorOwnerId !== targetOwnerId;
+          //   "bound"   — the root graph carries THIS workflow's identity tag. Proof. This
+          //               is the already-current case #874 was written for, and it captures
+          //               exactly as it always did.
+          //   "foreign" — the root positively belongs to another workflow. Skip.
+          //   "unknown" — no usable tag. Fall back to node IDENTITY, the same comparison
+          //               the divergence disclosure uses: a canvas sharing ids with this
+          //               target's own state is this target's canvas. Incremental editing
+          //               keeps most ids, so overlap is strong evidence of ownership.
+          //
+          // `comparable:false` (either side empty) is NOT ownership, so it skips: an empty
+          // target with a populated canvas is precisely the reproduction — the empty tab
+          // came back holding the other workflow's seven nodes.
+          //
+          // KNOWN RESIDUAL, stated rather than hidden: an untagged root whose ids have
+          // ALL turned over — clearing a tab and rebuilding it from scratch before saving —
+          // reads as unowned, so its capture is skipped and the repaint restores the older
+          // state. That needs no tag AND a total id turnover AND an unsaved rebuild, and it
+          // is the same shape the divergence helper documents as indistinguishable. The
+          // alternative is keeping a capture that writes a foreign graph into the tab.
           const captureBinding = describeLiveCanvasBinding(target);
-          if (!switchedTabs && captureBinding !== "foreign") {
+          let canvasIsTargets = captureBinding === "bound";
+          if (captureBinding === "unknown") {
+            const targetState = target.changeTracker?.activeState ?? target.activeState;
+            const overlap = canvasFileDivergence({
+              diskNodes: targetState?.nodes,
+              canvasNodes: app?.graph?._nodes ?? app?.graph?.nodes,
+            });
+            canvasIsTargets = overlap.comparable && !overlap.disjoint;
+          }
+          if (canvasIsTargets) {
             try {
               // AWAITED (codex). A frontend whose tracker captures asynchronously would
               // otherwise have `activeState` read before the capture landed — the silent

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -13056,6 +13056,9 @@ const GRAPH_TOOL_EXECUTORS = {
     let dirtyNow = false;
     let staleInfo = { stale: false, reload: false };
     let canvasDivergence = null; // #968
+    // #968 — the workflow whose graph is painted on the canvas at the moment we switch.
+    // Set synchronously immediately before `s.openWorkflow(target)`; see the note there.
+    let canvasOwnerBeforeSwitch = null;
     let reloaded = false;
     let reloadError = null;
     let openFailed = null;
@@ -13080,6 +13083,14 @@ const GRAPH_TOOL_EXECUTORS = {
         // command rather than reporting it as a move nobody made. A claim that is never
         // followed by a move is discarded by the next observation.
         claimActiveWorkflowMove(MOVE_CAUSES.OPEN_EXECUTOR, `workflow_open ${workflowTabId(target) || ""}`.trim());
+        // #968 — WHOSE canvas is mounted, read SYNCHRONOUSLY before the pointer moves.
+        // After the await, `activeWorkflow` is the target and this fact is unrecoverable:
+        // the store keeps no "what was painted" pointer. The capture below needs it,
+        // because a switch leaves the PREVIOUS tab's graph on the canvas and capturing it
+        // into the target writes another workflow's graph into this one. Identity is
+        // compared through the store's reactive proxies, so match on the tab id / path
+        // rather than `===` (a raw object is not `===` its own proxy).
+        canvasOwnerBeforeSwitch = s?.activeWorkflow ?? null;
         await s.openWorkflow(target);
       } catch (err) {
         // The native switch itself failed — nothing was applied. Recorded, then rethrown
@@ -13150,16 +13161,72 @@ const GRAPH_TOOL_EXECUTORS = {
           //
           // Best-effort. A frontend without `checkState` behaves exactly as before —
           // this must never be the thing that fails an open.
-          try {
-            // AWAITED (codex). A frontend whose tracker captures asynchronously would
-            // otherwise have `activeState` read before the capture landed — the silent
-            // revert intact, and a late rejection escaping this try/catch to become an
-            // unhandled rejection. Awaiting a non-promise is free, so the synchronous
-            // trackers this ships against are unaffected.
-            await target.changeTracker?.checkState?.();
-          } catch {
-            // A tracker that refuses to capture leaves the stale snapshot in place,
-            // which is today's behaviour, not a new failure.
+          // #968 — ONLY when the canvas is PROVEN to be this workflow's. This capture is
+          // the silent wrong-graph edit, and it is worth being exact about why, because
+          // the intent above is right and only the PLACEMENT is wrong.
+          //
+          // We arrive here having just moved the pointer (`s.openWorkflow(target)`) and
+          // NOT yet repainted — the repaint reads `activeState` a few lines below. So on
+          // a switch FROM another tab the configuration is:
+          //
+          //   activeWorkflow      = target          (the pointer moved)
+          //   app.rootGraph       = the OTHER tab   (nothing has repainted yet)
+          //
+          // `checkState()` calls ComfyUI's `captureCanvasState()`, which serializes
+          // `app.rootGraph` into the ACTIVE tracker's `activeState`. Its two guards both
+          // assume the pointer and the canvas agree: `ChangeTracker.isLoadingGraph` is
+          // false (nothing is loading — this is our own switch, not `loadGraphData`), and
+          // `isActiveTracker(target)` is true (target genuinely IS active). Both pass, and
+          // the previous tab's graph lands in TARGET's state.
+          //
+          // The repaint below then faithfully reproduces that state, and the content proof
+          // compares the canvas against the same poisoned state and PASSES. Every binding
+          // surface afterwards reports healthy and is telling the truth — the canvas really
+          // does match the workflow object's state. The object's state is what is wrong.
+          // Only a read of the FILE disagrees, which is why `panel_load_workflow` was the
+          // one recovery reporters found.
+          //
+          // Reproduced live: pointer moved to an empty tab while a 7-node canvas was
+          // mounted, one `checkState()`, and the empty tab came back holding 7 nodes,
+          // `isModified: true`, and the OTHER workflow's `activeState.id`. No reconnect, no
+          // concurrency — which is what the reports without a reconnect storm were telling
+          // us all along.
+          //
+          // The guard is the #708 oracle, already used for exactly this hazard on the SAVE
+          // path: a positive, durable identity conflict refuses the capture. "unknown"
+          // still captures, so older frontends and first observation behave as before —
+          // this only ever REMOVES a capture we can prove is reading someone else's canvas.
+          // When the target IS already the painted tab (the `wasOpen`/already-current case
+          // #874 was written for) the binding is "bound" and the capture runs unchanged.
+          // TWO independent refusals, because they cover different gaps.
+          //
+          // (a) the PRE-SWITCH OWNER is decisive and needs no tagging: if some OTHER
+          //     workflow was active when we moved the pointer, its graph is what is
+          //     mounted, full stop. This is the case the #708 oracle cannot always see —
+          //     it reads a uuid tag off the root graph, and an untagged canvas yields
+          //     "unknown", which captures. Comparing tab ids avoids the raw-vs-proxy
+          //     identity trap the store's reactivity sets.
+          // (b) the #708 oracle still runs, and catches a canvas that drifted while the
+          //     pointer never moved — the pre-switch owner would say "same tab" there and
+          //     see nothing wrong.
+          const priorOwnerId = canvasOwnerBeforeSwitch
+            ? workflowTabId(canvasOwnerBeforeSwitch) || canvasOwnerBeforeSwitch.path || null
+            : null;
+          const targetOwnerId = workflowTabId(target) || target.path || null;
+          const switchedTabs = !!priorOwnerId && !!targetOwnerId && priorOwnerId !== targetOwnerId;
+          const captureBinding = describeLiveCanvasBinding(target);
+          if (!switchedTabs && captureBinding !== "foreign") {
+            try {
+              // AWAITED (codex). A frontend whose tracker captures asynchronously would
+              // otherwise have `activeState` read before the capture landed — the silent
+              // revert intact, and a late rejection escaping this try/catch to become an
+              // unhandled rejection. Awaiting a non-promise is free, so the synchronous
+              // trackers this ships against are unaffected.
+              await target.changeTracker?.checkState?.();
+            } catch {
+              // A tracker that refuses to capture leaves the stale snapshot in place,
+              // which is today's behaviour, not a new failure.
+            }
           }
           // `activeWorkflowNodeCount` deliberately accepts both tracker-owned and flat
           // activeState shapes. Use that SAME state source here: otherwise a frontend

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -13200,32 +13200,31 @@ const GRAPH_TOOL_EXECUTORS = {
           //               is the already-current case #874 was written for, and it captures
           //               exactly as it always did.
           //   "foreign" — the root positively belongs to another workflow. Skip.
-          //   "unknown" — no usable tag. Fall back to node IDENTITY, the same comparison
-          //               the divergence disclosure uses: a canvas sharing ids with this
-          //               target's own state is this target's canvas. Incremental editing
-          //               keeps most ids, so overlap is strong evidence of ownership.
+          //   "unknown" — cannot tell. CAPTURES, exactly as it does today.
           //
-          // `comparable:false` (either side empty) is NOT ownership, so it skips: an empty
-          // target with a populated canvas is precisely the reproduction — the empty tab
-          // came back holding the other workflow's seven nodes.
+          // "unknown" deliberately changes NOTHING, which is the same discipline #708
+          // already applies with this oracle: only a POSITIVE, durable identity conflict
+          // refuses, so older frontends and a first observation behave as they always have.
+          // This fix therefore closes the provable case and introduces no regression
+          // anywhere else — it can only ever REMOVE a capture proven to be reading another
+          // workflow's canvas.
           //
-          // KNOWN RESIDUAL, stated rather than hidden: an untagged root whose ids have
-          // ALL turned over — clearing a tab and rebuilding it from scratch before saving —
-          // reads as unowned, so its capture is skipped and the repaint restores the older
-          // state. That needs no tag AND a total id turnover AND an unsaved rebuild, and it
-          // is the same shape the divergence helper documents as indistinguishable. The
-          // alternative is keeping a capture that writes a foreign graph into the tab.
+          // I tried to do better and the attempt was unsound, so it is recorded here rather
+          // than repeated: falling back to node-id OVERLAP against the target's own state
+          // (via canvasFileDivergence) looks like ownership evidence and is not. ComfyUI
+          // assigns node ids as small integers from 1, so any two non-trivial graphs share
+          // ids 1..n — overlap would have answered "yours" for almost every foreign canvas,
+          // making the fallback worse than useless. That helper is built for the opposite
+          // reading (DISJOINT is suspicious) and its own header warns that a refusal built
+          // on it would be a wrong-graph refusal of its own (codex).
+          //
+          // KNOWN RESIDUAL, stated rather than hidden: an UNTAGGED root graph is still
+          // captured, so the contamination remains reachable on a canvas the panel has
+          // never stamped. Closing that needs ownership evidence that does not exist yet —
+          // not a guess dressed as one — and the reported cases are saved, panel-driven
+          // workflows whose roots carry the tag, which is the case this does close.
           const captureBinding = describeLiveCanvasBinding(target);
-          let canvasIsTargets = captureBinding === "bound";
-          if (captureBinding === "unknown") {
-            const targetState = target.changeTracker?.activeState ?? target.activeState;
-            const overlap = canvasFileDivergence({
-              diskNodes: targetState?.nodes,
-              canvasNodes: app?.graph?._nodes ?? app?.graph?.nodes,
-            });
-            canvasIsTargets = overlap.comparable && !overlap.disjoint;
-          }
-          if (canvasIsTargets) {
+          if (captureBinding !== "foreign") {
             try {
               // AWAITED (codex). A frontend whose tracker captures asynchronously would
               // otherwise have `activeState` read before the capture landed — the silent


### PR DESCRIPTION
Fixes the silent wrong-graph edit in #968 — traced to one call in this repo's own code and
reproduced live with no reconnect, no drops and no concurrency.

## The mechanism

`panel_open_workflow` moves the pointer (`s.openWorkflow(target)` — ComfyUI's workflow
**store**, which does not repaint) and repaints a few lines later from `target`'s
`activeState`. Between those two steps the #874 capture runs. At that moment:

```
activeWorkflow = target          (the pointer moved)
app.rootGraph  = the OTHER tab   (nothing has repainted yet)
```

`checkState()` calls ComfyUI's `captureCanvasState()`, which serializes `app.rootGraph` into
the **active** tracker. Its two guards both assume the pointer and the canvas agree —
`ChangeTracker.isLoadingGraph` is false (nothing is loading; this is our own switch, not
`loadGraphData`) and `isActiveTracker(target)` is true (target genuinely *is* active). Both
pass honestly, and the previous tab's graph lands in **target's** `activeState`.

The repaint then faithfully reproduces that state, and the content proof compares the canvas
against the same poisoned state and **passes**. Every binding surface afterwards reports
healthy and is telling the truth — the canvas really does match the workflow object's state.
The object's state is what is wrong. Only a read of the **file** disagrees, which is why
`panel_load_workflow` was the one recovery reporters found.

## Reproduced

On a live install: pointer moved to an empty tab while a 7-node canvas was mounted, one
`checkState()`, and the empty tab came back with 7 nodes, `isModified: true`, and
`activeState.id` equal to the other workflow's graph id — not a graph resembling it, the same
graph. The origin tab was unharmed, matching every report: origin fine, destination poisoned.

This also explains the reports with **no reconnect storm and no concurrency**, which re-framed
this thread earlier. Those were not weaker instances of a race. There is no race.

## The fix

#874's intent is right and only its **placement** is wrong: on a switch, the values it exists
to capture are not on the canvas at all, because the canvas is not the target's. So the
capture is skipped when the canvas is *positively proven* to belong to another workflow:

```js
const captureBinding = describeLiveCanvasBinding(target);
if (captureBinding !== "foreign") { /* capture, unchanged */ }
```

`"bound"` and `"unknown"` both capture exactly as before — the same discipline #708 already
applies with this oracle, so older frontends and first observation are untouched. This can
only ever **remove** a capture proven to be reading another workflow's canvas.

**Known residual, stated rather than hidden:** an untagged root graph is still captured, so
the contamination stays reachable on a canvas the panel has never stamped. The reported cases
are saved, panel-driven workflows whose roots carry the tag.

## Two rejected attempts, recorded so they are not retried

- **A pre-switch pointer snapshot** (`switchedTabs`). Asks "did the pointer move during this
  call", which says nothing about who owns the canvas. It failed in *both* directions — a
  retry where the pointer was already on the target captured a foreign graph, and a stale
  pointer made it skip a legitimate capture (which is not merely losing #874's benefit: the
  repaint then overwrites live work and `clearSpuriousOpenModified` re-baselines the result
  as clean, making the loss durable). It also called `workflowTabId()`, which **mints** a
  `tmp:` id — this repo documents that helper as not a pure read, in a comment I had already
  read this session.
- **A node-id overlap fallback for `"unknown"`.** Unsound: ComfyUI assigns node ids as small
  integers from 1, so any two non-trivial graphs share ids `1..n` — overlap would have
  answered "yours" for nearly every foreign canvas. It also inverted `canvasFileDivergence`,
  which is built for the opposite reading (*disjoint* is suspicious) and whose own header
  warns that a refusal built on it would be a wrong-graph refusal of its own. My live check
  missed it because the target was empty, so `comparable:false` skipped for an unrelated
  reason and the id collision never surfaced.

## Gate

3865 tests pass, `tsc --noEmit` clean, `node --check` OK, and the file parses as a **true ES
module** (`node --check` alone parses it as CommonJS and would bless a panel the browser
cannot load).

**Not merged: the codex review gate could not run.** It reviewed the first draft and returned
NO-SHIP with four defects — all addressed above, three by deleting the mechanism they were
about — but re-review is now blocked by a Windows sandbox error
(`CreateProcessAsUserW failed: 5`) and it correctly refused to review without being able to
read the diff. Leaving this for a clean review rather than self-certifying a data-corruption
fix.

Refs #968
