### PR TITLE
fix(1083): a host probe must not shrink an authoritative provider list

### DIFF
--- a/browser_tests/unit/provider-snapshot-merge.test.mjs
+++ b/browser_tests/unit/provider-snapshot-merge.test.mjs
@@ -101,12 +101,18 @@ test("#1083 (codex): the experimental guarantee is scoped to DESCRIBED providers
   // is no authoritative claim to prefer — and so does every entry when no authoritative
   // snapshot exists. Deliberate: of the two ways to be wrong, showing a warning that may
   // not apply is the safe one; hiding one that does is not.
+  //
+  // PRE-EXISTING WART this makes visible rather than introduces (codex): the chip's
+  // experimental tooltip is worded for Copilot specifically, so any provider carrying the
+  // flag shows GitHub-flavoured text. That is the renderer's, not the merge's, and changing
+  // it is out of scope here — noted so the next reader does not take this test as an
+  // endorsement of the wording.
   const probeOnly = mergeProviderSnapshots({
     authoritative: [{ backend: "claude", running: false, ready: true }],
-    probe: [{ backend: "claude", running: false }, { backend: "odd-one", experimental: true }],
+    probe: [{ backend: "claude", running: false }, { backend: "copilot", experimental: true }],
   });
   assert.equal(
-    probeOnly.find((b) => b.backend === "odd-one").experimental,
+    probeOnly.find((b) => b.backend === "copilot").experimental,
     true,
     "a probe-only provider carries its own flag — the warning is shown, not suppressed",
   );
@@ -128,11 +134,19 @@ test("#1083 (codex): a provider only the HOST reports is selectable even against
   assert.deepEqual(ids(merged), ["gone-provider", "brand-new"]);
 });
 
-test("#1083 (codex): an explicitly EMPTY authoritative snapshot is honoured", () => {
-  // `backends: []` is a provider report whose content is "none", not a frame that said
-  // nothing. Requiring non-empty left a dropped-to-zero orchestrator with its old list
-  // authoritative forever, so host probes kept re-asserting providers that no longer exist.
-  assert.deepEqual(ids(mergeProviderSnapshots({ authoritative: [], probe: HOST })), ids(HOST));
+test("#1083 (codex): an explicitly EMPTY authoritative snapshot CLEARS the baseline", () => {
+  // What `[]` buys, stated as the code actually behaves rather than as an earlier comment
+  // wished it did. It does NOT mean "render nothing" — it means there is no longer a
+  // baseline, so the merge falls through to pass-through and the host probe is the only
+  // source again. The value is in what STOPS happening: a dropped-to-zero orchestrator no
+  // longer leaves its previous list authoritative, re-asserted on every later probe.
+  const STALE = [{ backend: "gone-provider", running: false, ready: true }];
+  const beforeClear = mergeProviderSnapshots({ authoritative: STALE, probe: HOST });
+  assert.ok(ids(beforeClear).includes("gone-provider"), "stale entry survives while it is the baseline");
+
+  const afterClear = mergeProviderSnapshots({ authoritative: [], probe: HOST });
+  assert.deepEqual(ids(afterClear), ids(HOST), "and is gone once the orchestrator reports none");
+  assert.ok(!ids(afterClear).includes("gone-provider"));
 });
 
 test("#1083: a provider only the HOST knows about is ADDED, never dropped", () => {

--- a/browser_tests/unit/provider-snapshot-merge.test.mjs
+++ b/browser_tests/unit/provider-snapshot-merge.test.mjs
@@ -68,6 +68,47 @@ test("#1083 (codex): a SHARED provider's running state still follows the probe",
   assert.deepEqual(ids(idle), ids(ORCHESTRATOR));
 });
 
+test("#1083 (codex): the probe cannot erase or invent the EXPERIMENTAL safety disclosure", () => {
+  // `experimental` is what puts "(experimental)" in the chip label and the amber
+  // "signs in as VS Code, against GitHub's Copilot API terms" warning on it. The host's
+  // entries are sparse {backend, running}, so a catch-all overlay would delete the flag on
+  // the very next probe and quietly remove that warning.
+  const withCopilot = [{ backend: "copilot", running: false, ready: true, experimental: true }];
+  const sparse = mergeProviderSnapshots({
+    authoritative: withCopilot,
+    probe: [{ backend: "copilot", running: true }],
+  });
+  assert.equal(sparse[0].experimental, true, "the ToS warning survives a sparse probe");
+  assert.equal(sparse[0].running, true, "while liveness still refreshes");
+
+  // A probe explicitly contradicting it is refused in BOTH directions.
+  const contradicted = mergeProviderSnapshots({
+    authoritative: withCopilot,
+    probe: [{ backend: "copilot", running: false, experimental: false }],
+  });
+  assert.equal(contradicted[0].experimental, true, "the host cannot clear the disclosure");
+
+  const invented = mergeProviderSnapshots({
+    authoritative: [{ backend: "claude", running: false, ready: true }],
+    probe: [{ backend: "claude", running: false, experimental: true }],
+  });
+  assert.equal(invented[0].experimental, undefined, "nor invent it for a provider that is not");
+});
+
+test("#1083 (codex): a provider only the HOST reports is selectable even against a stale baseline", () => {
+  // Codex read this as unreachable during a reconnect window. It is not: a probe-only id is
+  // appended, so a provider the NEW orchestrator has and the retained baseline does not is
+  // still offered as soon as the host sees it. The residual really is the opposite —
+  // a stale EXTRA entry — which is why the baseline is not connection-scoped.
+  const staleBaseline = [{ backend: "gone-provider", running: false, ready: true }];
+  const merged = mergeProviderSnapshots({
+    authoritative: staleBaseline,
+    probe: [{ backend: "brand-new", running: true }],
+  });
+  assert.ok(ids(merged).includes("brand-new"), "the newly reported provider is selectable");
+  assert.deepEqual(ids(merged), ["gone-provider", "brand-new"]);
+});
+
 test("#1083 (codex): an explicitly EMPTY authoritative snapshot is honoured", () => {
   // `backends: []` is a provider report whose content is "none", not a frame that said
   // nothing. Requiring non-empty left a dropped-to-zero orchestrator with its old list

--- a/browser_tests/unit/provider-snapshot-merge.test.mjs
+++ b/browser_tests/unit/provider-snapshot-merge.test.mjs
@@ -1,0 +1,93 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { mergeProviderSnapshots } from "../../web/js/lib/provider-snapshot-merge.js";
+
+// The reported shape: the orchestrator supplies the full set, then the ComfyUI host's
+// shorter `_BACKEND_PORTS` response arrives and used to replace it wholesale.
+const ORCHESTRATOR = [
+  { backend: "claude", running: true, ready: true },
+  { backend: "chatgpt", running: false, ready: true },
+  { backend: "openrouter", running: false, ready: true },
+  { backend: "lmstudio", running: false, ready: true },
+  { backend: "llamacpp", running: false, ready: true },
+  { backend: "custom", running: false, ready: true },
+  { backend: "copilot", running: false, ready: true },
+];
+// The host knows nothing past openrouter.
+const HOST = [
+  { backend: "claude", running: false },
+  { backend: "chatgpt", running: false },
+  { backend: "openrouter", running: false },
+];
+
+const ids = (list) => list.map((b) => b.backend);
+
+test("#1083: a host probe cannot delete providers from an authoritative snapshot", () => {
+  const merged = mergeProviderSnapshots({ authoritative: ORCHESTRATOR, probe: HOST });
+  assert.deepEqual(ids(merged), ids(ORCHESTRATOR), "all seven providers survive the host refresh");
+  for (const id of ["lmstudio", "llamacpp", "custom", "copilot"]) {
+    assert.ok(
+      merged.some((b) => b.backend === id),
+      `${id} is still selectable — without this there is no UI path back to a Custom endpoint`,
+    );
+  }
+});
+
+test("#1083: the probe cannot DOWNGRADE a provider the orchestrator reported", () => {
+  // The same ruling applyReadiness already makes: the host cannot see the agent machine,
+  // so its view of a provider it half-knows is not an improvement. `claude` is running per
+  // the orchestrator and idle per the host; the orchestrator wins.
+  const merged = mergeProviderSnapshots({ authoritative: ORCHESTRATOR, probe: HOST });
+  const claude = merged.find((b) => b.backend === "claude");
+  assert.equal(claude.running, true, "orchestrator liveness is not overwritten by the host");
+  assert.equal(claude.ready, true, "orchestrator readiness is not overwritten by the host");
+});
+
+test("#1083: a provider only the HOST knows about is ADDED, never dropped", () => {
+  // Additive is safe — it cannot make the list shorter, which is the whole invariant.
+  const merged = mergeProviderSnapshots({
+    authoritative: ORCHESTRATOR,
+    probe: [...HOST, { backend: "brand-new", running: true }],
+  });
+  assert.deepEqual(ids(merged), [...ids(ORCHESTRATOR), "brand-new"]);
+});
+
+test("#1083: with NO authoritative snapshot the probe is used as-is (unchanged behaviour)", () => {
+  // A panel that has not connected yet has only the host to go on. This is the path that
+  // must not change, or a fresh panel would render nothing.
+  assert.deepEqual(ids(mergeProviderSnapshots({ authoritative: null, probe: HOST })), ids(HOST));
+  assert.deepEqual(ids(mergeProviderSnapshots({ authoritative: [], probe: HOST })), ids(HOST));
+  assert.deepEqual(ids(mergeProviderSnapshots({ probe: HOST })), ids(HOST));
+});
+
+test("#1083: malformed input never throws and never invents a provider", () => {
+  assert.deepEqual(mergeProviderSnapshots(), []);
+  assert.deepEqual(mergeProviderSnapshots({ authoritative: "nope", probe: "nope" }), []);
+  // Entries without a usable id are dropped rather than rendered as a nameless chip.
+  assert.deepEqual(
+    ids(mergeProviderSnapshots({ authoritative: null, probe: [null, {}, { backend: "" }, { backend: "ok" }] })),
+    ["ok"],
+  );
+});
+
+test("#1083: a duplicated id yields ONE chip, first writer wins", () => {
+  const merged = mergeProviderSnapshots({
+    authoritative: [
+      { backend: "custom", running: true },
+      { backend: "custom", running: false },
+    ],
+    probe: [{ backend: "custom", running: false }],
+  });
+  assert.equal(merged.length, 1);
+  assert.equal(merged[0].running, true);
+});
+
+test("#1083: merging is stable — repeated host refreshes converge, never grow or shrink", () => {
+  // loadBackends runs on a timer, so the merge is applied to its own output repeatedly.
+  let current = ORCHESTRATOR;
+  for (let i = 0; i < 5; i++) {
+    current = mergeProviderSnapshots({ authoritative: current, probe: HOST });
+  }
+  assert.deepEqual(ids(current), ids(ORCHESTRATOR), "no drift across repeated refreshes");
+});

--- a/browser_tests/unit/provider-snapshot-merge.test.mjs
+++ b/browser_tests/unit/provider-snapshot-merge.test.mjs
@@ -145,8 +145,12 @@ test("#1083 (codex): an explicitly EMPTY authoritative snapshot CLEARS the basel
   assert.ok(ids(beforeClear).includes("gone-provider"), "stale entry survives while it is the baseline");
 
   const afterClear = mergeProviderSnapshots({ authoritative: [], probe: HOST });
-  assert.deepEqual(ids(afterClear), ids(HOST), "and is gone once the orchestrator reports none");
+  assert.deepEqual(ids(afterClear), ids(HOST), "and is gone once the baseline is cleared");
   assert.ok(!ids(afterClear).includes("gone-provider"));
+  // SCOPE (codex): this exercises the merge helper, not the bridge-frame path. The frame
+  // handler repaints from `data.backends` directly, so an empty frame transiently shows the
+  // renderer's claude-only default until the next probe — see the comment at that call.
+  // Asserting that here would be asserting about a function this file does not import.
 });
 
 test("#1083: a provider only the HOST knows about is ADDED, never dropped", () => {

--- a/browser_tests/unit/provider-snapshot-merge.test.mjs
+++ b/browser_tests/unit/provider-snapshot-merge.test.mjs
@@ -95,6 +95,25 @@ test("#1083 (codex): the probe cannot erase or invent the EXPERIMENTAL safety di
   assert.equal(invented[0].experimental, undefined, "nor invent it for a provider that is not");
 });
 
+test("#1083 (codex): the experimental guarantee is scoped to DESCRIBED providers", () => {
+  // Pinning the limit of the rule above, because an earlier version of its comment
+  // overclaimed it. A provider only the PROBE reports keeps its own entry verbatim — there
+  // is no authoritative claim to prefer — and so does every entry when no authoritative
+  // snapshot exists. Deliberate: of the two ways to be wrong, showing a warning that may
+  // not apply is the safe one; hiding one that does is not.
+  const probeOnly = mergeProviderSnapshots({
+    authoritative: [{ backend: "claude", running: false, ready: true }],
+    probe: [{ backend: "claude", running: false }, { backend: "odd-one", experimental: true }],
+  });
+  assert.equal(
+    probeOnly.find((b) => b.backend === "odd-one").experimental,
+    true,
+    "a probe-only provider carries its own flag — the warning is shown, not suppressed",
+  );
+  // And the described provider is still protected, in the same call.
+  assert.equal(probeOnly.find((b) => b.backend === "claude").experimental, undefined);
+});
+
 test("#1083 (codex): a provider only the HOST reports is selectable even against a stale baseline", () => {
   // Codex read this as unreachable during a reconnect window. It is not: a probe-only id is
   // appended, so a provider the NEW orchestrator has and the retained baseline does not is

--- a/browser_tests/unit/provider-snapshot-merge.test.mjs
+++ b/browser_tests/unit/provider-snapshot-merge.test.mjs
@@ -95,6 +95,26 @@ test("#1083 (codex): the probe cannot erase or invent the EXPERIMENTAL safety di
   assert.equal(invented[0].experimental, undefined, "nor invent it for a provider that is not");
 });
 
+test("#1083 (codex): an authoritative REMOVAL does not persist against a host that still reports it", () => {
+  // The sequence the comment at the bridge frame now describes, made executable rather than
+  // asserted in prose. The orchestrator drops `openrouter`; the direct repaint renders the
+  // new list without it; then the next host probe merges against that baseline, finds an id
+  // the baseline lacks, and appends it again.
+  const afterDrop = ORCHESTRATOR.filter((b) => b.backend !== "openrouter");
+  const nextProbe = mergeProviderSnapshots({ authoritative: afterDrop, probe: HOST });
+  assert.ok(
+    ids(nextProbe).includes("openrouter"),
+    "the dropped provider returns on the following poll while the host still reports it",
+  );
+  // It comes back as a HOST entry, so it carries no orchestrator readiness — which is the
+  // honest representation: nothing authoritative vouches for it any more.
+  const returned = nextProbe.find((b) => b.backend === "openrouter");
+  assert.equal(returned.ready, undefined);
+  // A provider the host does NOT report stays gone, so this is not "removal never works".
+  const alsoDropped = ORCHESTRATOR.filter((b) => b.backend !== "custom");
+  assert.ok(!ids(mergeProviderSnapshots({ authoritative: alsoDropped, probe: HOST })).includes("custom"));
+});
+
 test("#1083 (codex): the experimental guarantee is scoped to DESCRIBED providers", () => {
   // Pinning the limit of the rule above, because an earlier version of its comment
   // overclaimed it. A provider only the PROBE reports keeps its own entry verbatim — there

--- a/browser_tests/unit/provider-snapshot-merge.test.mjs
+++ b/browser_tests/unit/provider-snapshot-merge.test.mjs
@@ -117,8 +117,8 @@ test("#1083 (codex): an authoritative REMOVAL does not persist against a host th
 
 test("#1083 (codex): the experimental guarantee is scoped to DESCRIBED providers", () => {
   // Pinning the limit of the rule above, because an earlier version of its comment
-  // overclaimed it. A provider only the PROBE reports keeps its own entry verbatim — there
-  // is no authoritative claim to prefer — and so does every entry when no authoritative
+  // overclaimed it. A provider only the PROBE reports keeps its own entry's flag — there is
+  // no authoritative claim to prefer — and so does every entry when no authoritative
   // snapshot exists. Deliberate: of the two ways to be wrong, showing a warning that may
   // not apply is the safe one; hiding one that does is not.
   //
@@ -182,7 +182,7 @@ test("#1083: a provider only the HOST knows about is ADDED, never dropped", () =
   assert.deepEqual(ids(merged), [...ids(ORCHESTRATOR), "brand-new"]);
 });
 
-test("#1083: with NO authoritative snapshot the probe is used as-is (unchanged behaviour)", () => {
+test("#1083: with NO authoritative snapshot the probe alone is returned (unchanged behaviour)", () => {
   // A panel that has not connected yet has only the host to go on. This is the path that
   // must not change, or a fresh panel would render nothing.
   assert.deepEqual(ids(mergeProviderSnapshots({ authoritative: null, probe: HOST })), ids(HOST));
@@ -229,10 +229,11 @@ test("#1083: merging is stable — repeated host refreshes converge, never grow 
 
 test("#1083 (codex): a HOST-ONLY provider keeps refreshing its running state", () => {
   // The regression the first draft introduced. A host-only entry is appended to the merged
-  // list; if that merged list is then reused as the next baseline, the entry is suddenly
-  // "authoritative" and the merge refuses to overwrite it — so a provider that later starts
-  // or stops shows stale liveness forever. `backendReady` cannot repair it: that map holds
-  // only cli/auth/ready, while the chip and the picker both read `b.running`.
+  // list; if that merged list is then reused as the next baseline, the entry becomes
+  // permanently "authoritative" and the merge will never drop it, so it outlives the host
+  // that reported it. (The helper's FIRST draft also froze its liveness, because it refused
+  // the probe's fields wholesale; the overlay is per-field now, so `running` does refresh —
+  // this test pins the fixed-baseline behaviour, not that older failure. codex)
   //
   // Keeping the baseline pinned to the ORCHESTRATOR snapshot is what fixes it — a host-only
   // provider is never in that baseline, so it is re-read from every probe.
@@ -263,7 +264,7 @@ test("#1083 (codex): a ready ack alone is not an authoritative provider list", (
   // at that moment, which is what the caller now passes.
   const DEFAULT_ONLY = [{ backend: "claude", running: false }];
   const duringWindow = mergeProviderSnapshots({ authoritative: null, probe: HOST });
-  assert.deepEqual(ids(duringWindow), ids(HOST), "the probe is used as-is, nothing is invented");
+  assert.deepEqual(ids(duringWindow), ids(HOST), "the probe alone is returned, nothing is invented");
   assert.ok(
     !ids(duringWindow).includes("custom") && ids(DEFAULT_ONLY).length === 1,
     "and no authoritative claim is manufactured from the default list",

--- a/browser_tests/unit/provider-snapshot-merge.test.mjs
+++ b/browser_tests/unit/provider-snapshot-merge.test.mjs
@@ -84,10 +84,58 @@ test("#1083: a duplicated id yields ONE chip, first writer wins", () => {
 });
 
 test("#1083: merging is stable — repeated host refreshes converge, never grow or shrink", () => {
-  // loadBackends runs on a timer, so the merge is applied to its own output repeatedly.
-  let current = ORCHESTRATOR;
+  // loadBackends runs on a timer, so the merge is applied repeatedly against the SAME
+  // fixed orchestrator baseline. Feeding the merge's own OUTPUT back in as the baseline is
+  // the mistake the caller must not make — see the host-only liveness test below.
+  let current = null;
   for (let i = 0; i < 5; i++) {
-    current = mergeProviderSnapshots({ authoritative: current, probe: HOST });
+    current = mergeProviderSnapshots({ authoritative: ORCHESTRATOR, probe: HOST });
   }
   assert.deepEqual(ids(current), ids(ORCHESTRATOR), "no drift across repeated refreshes");
+});
+
+test("#1083 (codex): a HOST-ONLY provider keeps refreshing its running state", () => {
+  // The regression the first draft introduced. A host-only entry is appended to the merged
+  // list; if that merged list is then reused as the next baseline, the entry is suddenly
+  // "authoritative" and the merge refuses to overwrite it — so a provider that later starts
+  // or stops shows stale liveness forever. `backendReady` cannot repair it: that map holds
+  // only cli/auth/ready, while the chip and the picker both read `b.running`.
+  //
+  // Keeping the baseline pinned to the ORCHESTRATOR snapshot is what fixes it — a host-only
+  // provider is never in that baseline, so it is re-read from every probe.
+  const idle = [...HOST, { backend: "host-only", running: false }];
+  const busy = [...HOST, { backend: "host-only", running: true }];
+
+  const first = mergeProviderSnapshots({ authoritative: ORCHESTRATOR, probe: idle });
+  assert.equal(first.find((b) => b.backend === "host-only").running, false);
+
+  const second = mergeProviderSnapshots({ authoritative: ORCHESTRATOR, probe: busy });
+  assert.equal(
+    second.find((b) => b.backend === "host-only").running,
+    true,
+    "host-only liveness follows the probe instead of freezing at first sight",
+  );
+
+  // And the reverse, so this is not passing on a one-way latch.
+  const third = mergeProviderSnapshots({ authoritative: ORCHESTRATOR, probe: idle });
+  assert.equal(third.find((b) => b.backend === "host-only").running, false);
+});
+
+test("#1083 (codex): a ready ack alone is not an authoritative provider list", () => {
+  // `readinessFromOrchestrator` is set by a bare `ready` ack that carries NO providers, and
+  // the surrounding code documents that such an ack can arrive BEFORE the backends frame.
+  // If list authority were inferred from it, a host probe landing in that window would be
+  // merged against the claude-only default and treated as authoritative — stranding the
+  // picker without the configured providers. Modelled here as the baseline still being null
+  // at that moment, which is what the caller now passes.
+  const DEFAULT_ONLY = [{ backend: "claude", running: false }];
+  const duringWindow = mergeProviderSnapshots({ authoritative: null, probe: HOST });
+  assert.deepEqual(ids(duringWindow), ids(HOST), "the probe is used as-is, nothing is invented");
+  assert.ok(
+    !ids(duringWindow).includes("custom") && ids(DEFAULT_ONLY).length === 1,
+    "and no authoritative claim is manufactured from the default list",
+  );
+  // Once the real frame lands, the full set is protected from the very next probe.
+  const afterFrame = mergeProviderSnapshots({ authoritative: ORCHESTRATOR, probe: HOST });
+  assert.deepEqual(ids(afterFrame), ids(ORCHESTRATOR));
 });

--- a/browser_tests/unit/provider-snapshot-merge.test.mjs
+++ b/browser_tests/unit/provider-snapshot-merge.test.mjs
@@ -34,14 +34,45 @@ test("#1083: a host probe cannot delete providers from an authoritative snapshot
   }
 });
 
-test("#1083: the probe cannot DOWNGRADE a provider the orchestrator reported", () => {
-  // The same ruling applyReadiness already makes: the host cannot see the agent machine,
-  // so its view of a provider it half-knows is not an improvement. `claude` is running per
-  // the orchestrator and idle per the host; the orchestrator wins.
-  const merged = mergeProviderSnapshots({ authoritative: ORCHESTRATOR, probe: HOST });
+test("#1083: the probe cannot downgrade a provider's READINESS", () => {
+  // The same ruling applyReadiness already makes: the host cannot see the agent machine, so
+  // its readiness for a provider it half-knows would false-flag a connected provider as
+  // "CLI not installed".
+  const merged = mergeProviderSnapshots({
+    authoritative: ORCHESTRATOR,
+    probe: [{ backend: "claude", running: false, ready: false, cli: false }],
+  });
   const claude = merged.find((b) => b.backend === "claude");
-  assert.equal(claude.running, true, "orchestrator liveness is not overwritten by the host");
-  assert.equal(claude.ready, true, "orchestrator readiness is not overwritten by the host");
+  assert.equal(claude.ready, true, "orchestrator readiness survives");
+  assert.equal(claude.cli, undefined, "and a host-invented cli flag is not adopted");
+});
+
+test("#1083 (codex): a SHARED provider's running state still follows the probe", () => {
+  // The second freeze codex found, one id-set over from the first. Refusing the probe's
+  // fields wholesale meant `claude` — present in BOTH snapshots — kept whatever liveness it
+  // had when the orchestrator frame landed, permanently. The chip and the model popup both
+  // read `b.running`, and the host probe is what re-reads it on a timer.
+  const idle = mergeProviderSnapshots({
+    authoritative: ORCHESTRATOR, // claude: running true
+    probe: [{ backend: "claude", running: false }],
+  });
+  assert.equal(idle.find((b) => b.backend === "claude").running, false, "stop is seen");
+
+  const busy = mergeProviderSnapshots({
+    authoritative: ORCHESTRATOR.map((b) => (b.backend === "claude" ? { ...b, running: false } : b)),
+    probe: [{ backend: "claude", running: true }],
+  });
+  assert.equal(busy.find((b) => b.backend === "claude").running, true, "start is seen too");
+
+  // Membership and position are still the authoritative snapshot's.
+  assert.deepEqual(ids(idle), ids(ORCHESTRATOR));
+});
+
+test("#1083 (codex): an explicitly EMPTY authoritative snapshot is honoured", () => {
+  // `backends: []` is a provider report whose content is "none", not a frame that said
+  // nothing. Requiring non-empty left a dropped-to-zero orchestrator with its old list
+  // authoritative forever, so host probes kept re-asserting providers that no longer exist.
+  assert.deepEqual(ids(mergeProviderSnapshots({ authoritative: [], probe: HOST })), ids(HOST));
 });
 
 test("#1083: a provider only the HOST knows about is ADDED, never dropped", () => {
@@ -71,16 +102,20 @@ test("#1083: malformed input never throws and never invents a provider", () => {
   );
 });
 
-test("#1083: a duplicated id yields ONE chip, first writer wins", () => {
+test("#1083: a duplicated id yields ONE chip", () => {
+  // A malformed authoritative snapshot must not paint the same provider twice; within it,
+  // the first entry wins. The probe then refreshes that single entry's live fields as it
+  // does for any shared id, so `running` follows the probe — see the shared-liveness test.
   const merged = mergeProviderSnapshots({
     authoritative: [
-      { backend: "custom", running: true },
-      { backend: "custom", running: false },
+      { backend: "custom", running: true, ready: true },
+      { backend: "custom", running: false, ready: false },
     ],
     probe: [{ backend: "custom", running: false }],
   });
-  assert.equal(merged.length, 1);
-  assert.equal(merged[0].running, true);
+  assert.equal(merged.length, 1, "one chip, not two");
+  assert.equal(merged[0].ready, true, "the FIRST authoritative entry won, not the second");
+  assert.equal(merged[0].running, false, "and the probe still refreshed its liveness");
 });
 
 test("#1083: merging is stable — repeated host refreshes converge, never grow or shrink", () => {

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -20408,10 +20408,14 @@ function buildPanel() {
   //    `knownBackends` happened to hold — possibly still the claude-only default — and
   //    strand the picker without the configured providers.
   //  * NOT `knownBackends`. That is the RENDERED list, so it also contains host-only
-  //    entries. Feeding it back in as authoritative would freeze those entries at their
-  //    first-seen value: a host-only provider that later starts or stops would keep showing
-  //    stale liveness forever, because the merge deliberately refuses to overwrite anything
-  //    it considers authoritative.
+  //    entries, and feeding it back in would make those entries permanently authoritative:
+  //    a host-only provider would keep its membership after the host stopped reporting it,
+  //    since the merge never removes an authoritative id. (An earlier version of this note
+  //    said it would also freeze that provider's LIVENESS. That was true of the helper's
+  //    first draft, which refused the probe's fields wholesale, and stopped being true when
+  //    the overlay became per-field — `running` refreshes for any shared id now. Corrected
+  //    rather than deleted because the stale reading is what this comment is here to
+  //    prevent, codex.)
   //
   // Set ONLY from a real bridge `backends` frame carrying an ARRAY — including an empty
   // one, which CLEARS a stale baseline rather than asserting "render nothing"; see the

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -348,6 +348,7 @@ import {
   canvasFileDivergence,
   canvasFileDivergenceNote,
 } from "./lib/canvas-file-divergence.js";
+import { mergeProviderSnapshots } from "./lib/provider-snapshot-merge.js";
 import {
   MOVE_CAUSES,
   createActiveWorkflowProvenance,
@@ -20511,7 +20512,19 @@ function buildPanel() {
       const res = await api.fetchApi("/comfyui_mcp_panel/backends");
       const data = await res.json().catch(() => ({}));
       if (Array.isArray(data?.backends)) {
-        renderBackendChips(data.backends);
+        // #1083 — MERGE, never replace, once the orchestrator has spoken. The host's
+        // `_BACKEND_PORTS` ends at `openrouter`, so a plain repaint here replaced the
+        // authoritative list with a shorter one and silently deleted `lmstudio`,
+        // `llamacpp`, `custom` and `copilot` from the picker — leaving no UI path back to
+        // a configured Custom endpoint. `applyReadiness` below already refuses this probe,
+        // but it ran one line too late: `renderBackendChips` assigns `knownBackends`
+        // wholesale, and the model popup rebuilds its Provider section from that.
+        renderBackendChips(
+          mergeProviderSnapshots({
+            authoritative: readinessFromOrchestrator ? knownBackends : null,
+            probe: data.backends,
+          }),
+        );
         applyReadiness(data);
       }
     } catch {

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -26835,12 +26835,17 @@ function buildPanel() {
       // runs the agents. Wins over the ComfyUI-side probe (which false-flags "CLI
       // not installed" behind a remote pod). Repaint the chips so hints refresh.
       applyReadiness(data, { fromOrchestrator: true });
-      // #1083 — THIS is the only thing that establishes an authoritative provider list:
-      // a real bridge frame carrying a non-empty array. Recorded before the repaint so a
-      // host probe racing this frame merges against it rather than against the rendered
-      // list. An empty/absent array leaves the previous baseline alone — it is a frame that
-      // told us nothing about providers, not one that told us there are none.
-      if (Array.isArray(data?.backends) && data.backends.length) orchestratorBackends = data.backends;
+      // #1083 — THIS is the only thing that establishes an authoritative provider list: a
+      // real bridge frame carrying an ARRAY. Recorded before the repaint so a host probe
+      // racing this frame merges against it rather than against the rendered list.
+      //
+      // A PRESENT array counts even when EMPTY (codex). An earlier draft required
+      // non-empty, reasoning that `[]` "told us nothing" — but the array's presence is what
+      // makes the frame a provider report, and its length is the report's content. Ignoring
+      // `[]` meant an orchestrator that had genuinely dropped to zero providers left the
+      // previous list authoritative forever, so later host probes kept re-asserting
+      // providers that no longer exist. The line directly below already reads it that way.
+      if (Array.isArray(data?.backends)) orchestratorBackends = data.backends;
       renderBackendChips(Array.isArray(data.backends) ? data.backends : knownBackends);
       // A sign-in/out that just landed pushes a fresh backends frame — nudge an
       // open credentials card to re-poll oauth_status (see cmcpOpenCredentialsFrame).

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -20396,6 +20396,27 @@ function buildPanel() {
   // PROVIDER section can render them (the switcher now lives there, not in
   // settings). Defaults to claude-only until discovery lands.
   let knownBackends = [{ backend: "claude", running: false }];
+  // #1083 — the ORCHESTRATOR's provider list, kept separate from `knownBackends` and from
+  // readiness. It is the merge baseline that stops a shorter ComfyUI-host probe from
+  // deleting `lmstudio`/`llamacpp`/`custom`/`copilot` from the picker.
+  //
+  // Two distinctions this must NOT collapse, both found in review (codex):
+  //
+  //  * NOT `readinessFromOrchestrator`. That flag means "readiness came from the agent
+  //    machine", and a bare `ready` ack sets it carrying NO provider list at all. Treating
+  //    it as proof of an authoritative list would merge a host probe against whatever
+  //    `knownBackends` happened to hold — possibly still the claude-only default — and
+  //    strand the picker without the configured providers.
+  //  * NOT `knownBackends`. That is the RENDERED list, so it also contains host-only
+  //    entries. Feeding it back in as authoritative would freeze those entries at their
+  //    first-seen value: a host-only provider that later starts or stops would keep showing
+  //    stale liveness forever, because the merge deliberately refuses to overwrite anything
+  //    it considers authoritative.
+  //
+  // Set ONLY from a real bridge `backends` frame carrying a non-empty array. Null until
+  // then, which is exactly the "no authoritative snapshot" case the merge passes through
+  // unchanged.
+  let orchestratorBackends = null;
   // Durable per-provider readiness (cli/auth/ready), keyed by backend id. Owned by
   // applyReadiness from GET /backends. Kept SEPARATE from knownBackends because
   // renderBackendChips is also called from connect/handshake paths that reconstruct
@@ -20519,11 +20540,12 @@ function buildPanel() {
         // a configured Custom endpoint. `applyReadiness` below already refuses this probe,
         // but it ran one line too late: `renderBackendChips` assigns `knownBackends`
         // wholesale, and the model popup rebuilds its Provider section from that.
+        // The baseline is `orchestratorBackends`, NOT `readinessFromOrchestrator` and NOT
+        // the rendered `knownBackends` — see the declaration for why each of those is
+        // wrong. Host-only providers are absent from the baseline by construction, so they
+        // are re-read from every probe and their liveness stays current.
         renderBackendChips(
-          mergeProviderSnapshots({
-            authoritative: readinessFromOrchestrator ? knownBackends : null,
-            probe: data.backends,
-          }),
+          mergeProviderSnapshots({ authoritative: orchestratorBackends, probe: data.backends }),
         );
         applyReadiness(data);
       }
@@ -26813,6 +26835,12 @@ function buildPanel() {
       // runs the agents. Wins over the ComfyUI-side probe (which false-flags "CLI
       // not installed" behind a remote pod). Repaint the chips so hints refresh.
       applyReadiness(data, { fromOrchestrator: true });
+      // #1083 — THIS is the only thing that establishes an authoritative provider list:
+      // a real bridge frame carrying a non-empty array. Recorded before the repaint so a
+      // host probe racing this frame merges against it rather than against the rendered
+      // list. An empty/absent array leaves the previous baseline alone — it is a frame that
+      // told us nothing about providers, not one that told us there are none.
+      if (Array.isArray(data?.backends) && data.backends.length) orchestratorBackends = data.backends;
       renderBackendChips(Array.isArray(data.backends) ? data.backends : knownBackends);
       // A sign-in/out that just landed pushes a fresh backends frame — nudge an
       // open credentials card to re-poll oauth_status (see cmcpOpenCredentialsFrame).

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -26841,10 +26841,19 @@ function buildPanel() {
       //
       // A PRESENT array counts even when EMPTY (codex). An earlier draft required
       // non-empty, reasoning that `[]` "told us nothing" — but the array's presence is what
-      // makes the frame a provider report, and its length is the report's content. Ignoring
-      // `[]` meant an orchestrator that had genuinely dropped to zero providers left the
-      // previous list authoritative forever, so later host probes kept re-asserting
-      // providers that no longer exist. The line directly below already reads it that way.
+      // makes the frame a provider report. Ignoring `[]` left an orchestrator that had
+      // genuinely dropped to zero with its PREVIOUS list still authoritative, so later host
+      // probes kept re-asserting providers that no longer exist.
+      //
+      // WHAT `[]` DOES, precisely — a second correction, because the first version of this
+      // comment claimed more than the code delivers (codex): it CLEARS the baseline. It does
+      // not assert "show nothing". With no baseline left, the merge falls through to its
+      // pass-through case and the host probe becomes the only source again, exactly as
+      // before any frame arrived. That is the whole intended effect: the stale
+      // orchestrator-only entries stop being re-asserted. Making `[]` mean "render nothing"
+      // would need a coherent answer for whether the host's own providers may still be
+      // appended, and there is no evidence-backed answer to that — an orchestrator reporting
+      // zero providers is not a shape observed in practice.
       if (Array.isArray(data?.backends)) orchestratorBackends = data.backends;
       renderBackendChips(Array.isArray(data.backends) ? data.backends : knownBackends);
       // A sign-in/out that just landed pushes a fresh backends frame — nudge an

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -20413,9 +20413,15 @@ function buildPanel() {
   //    stale liveness forever, because the merge deliberately refuses to overwrite anything
   //    it considers authoritative.
   //
-  // Set ONLY from a real bridge `backends` frame carrying a non-empty array. Null until
-  // then, which is exactly the "no authoritative snapshot" case the merge passes through
-  // unchanged.
+  // Set ONLY from a real bridge `backends` frame carrying an ARRAY — including an empty
+  // one, which CLEARS a stale baseline rather than asserting "render nothing"; see the
+  // assignment for why. Null until the first such frame, which is exactly the "no
+  // authoritative snapshot" case the merge passes through unchanged.
+  //
+  // (This sentence said "non-empty" for two commits after that stopped being true. Stale
+  // comments on a guard are how the earlier drafts of this fix went wrong, so it is worth
+  // the line: the merge's behaviour is not obvious from the call site, and a reader who
+  // trusts a description instead of the code is the exact failure mode being guarded.)
   let orchestratorBackends = null;
   // Durable per-provider readiness (cli/auth/ready), keyed by backend id. Owned by
   // applyReadiness from GET /backends. Kept SEPARATE from knownBackends because
@@ -26854,6 +26860,14 @@ function buildPanel() {
       // would need a coherent answer for whether the host's own providers may still be
       // appended, and there is no evidence-backed answer to that — an orchestrator reporting
       // zero providers is not a shape observed in practice.
+      //
+      // TRANSIENT STATE, named because it is not obvious from this line (codex): the repaint
+      // immediately below is passed `data.backends` DIRECTLY, not the merge. On an empty
+      // frame that is `renderBackendChips([])`, which falls back to its claude-only default
+      // — so the picker shows one chip until the next host probe repopulates it, rather than
+      // showing nothing. Deliberately left alone: routing this repaint through the merge
+      // would make an authoritative frame unable to REMOVE a provider, which is the one
+      // thing it should always be able to do.
       if (Array.isArray(data?.backends)) orchestratorBackends = data.backends;
       renderBackendChips(Array.isArray(data.backends) ? data.backends : knownBackends);
       // A sign-in/out that just landed pushes a fresh backends frame — nudge an

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -26861,13 +26861,24 @@ function buildPanel() {
       // appended, and there is no evidence-backed answer to that — an orchestrator reporting
       // zero providers is not a shape observed in practice.
       //
-      // TRANSIENT STATE, named because it is not obvious from this line (codex): the repaint
-      // immediately below is passed `data.backends` DIRECTLY, not the merge. On an empty
-      // frame that is `renderBackendChips([])`, which falls back to its claude-only default
-      // — so the picker shows one chip until the next host probe repopulates it, rather than
-      // showing nothing. Deliberately left alone: routing this repaint through the merge
-      // would make an authoritative frame unable to REMOVE a provider, which is the one
-      // thing it should always be able to do.
+      // THE REPAINT BELOW IS NOT MERGED, and what that does and does not buy (codex):
+      //
+      // It is passed `data.backends` DIRECTLY, so this frame renders exactly what the
+      // orchestrator just said — including dropping a provider it no longer lists. On an
+      // empty frame that is `renderBackendChips([])`, which falls back to the renderer's
+      // claude-only default, so the picker shows one chip rather than none.
+      //
+      // That removal is only good for THIS repaint, and an earlier version of this comment
+      // wrongly claimed otherwise. If the ComfyUI host keeps reporting the dropped provider,
+      // the next `loadBackends` probe merges against the new baseline, sees an id the
+      // baseline lacks, and appends it again. So a provider the orchestrator stops listing
+      // reappears on the following poll whenever the host still knows it.
+      //
+      // Left that way on purpose: suppressing it would require telling "the orchestrator
+      // deliberately dropped this" apart from "the orchestrator never knew about it", and
+      // nothing in either snapshot carries that. Re-appending a provider the host can see is
+      // also the benign direction — an extra entry the user may not need, versus the missing
+      // entry with no way back that this whole issue is about.
       if (Array.isArray(data?.backends)) orchestratorBackends = data.backends;
       renderBackendChips(Array.isArray(data.backends) ? data.backends : knownBackends);
       // A sign-in/out that just landed pushes a fresh backends frame — nudge an

--- a/web/js/lib/provider-snapshot-merge.js
+++ b/web/js/lib/provider-snapshot-merge.js
@@ -26,15 +26,31 @@
 // WHAT THE PROBE MAY AND MAY NOT DO, once an authoritative snapshot exists:
 //   * it may ADD a provider the authoritative snapshot did not mention — additive, and it
 //     cannot make the list shorter;
-//   * it may NOT remove one, and it may NOT overwrite the fields of one. That second
-//     restriction is the same ruling `applyReadiness` already makes: the probe cannot see
-//     the agent machine, so its `ready`/`running` for a provider it half-knows is not an
-//     improvement on what the orchestrator said.
+//   * it may NOT remove one;
+//   * it MAY refresh the live fields of one, but NOT its readiness.
+//
+// That last split is the correction to this helper's first draft, which refused the probe's
+// fields wholesale (codex). Refusing everything froze `running` for every provider the two
+// sources share — the chip and the model popup both read `b.running`, and the host probe is
+// what re-reads it on a timer — so a shared provider such as `claude` would have shown
+// whatever liveness it had at the moment the orchestrator frame landed, permanently. That
+// is the same freeze the first draft had for host-only providers, one id-set over.
+//
+// Readiness (`ready`/`cli`/`auth`) is the part that must NOT come from the probe, and only
+// that part: the host cannot see the agent machine, so its view would false-flag a
+// connected provider as "CLI not installed". This is the same ruling `applyReadiness`
+// already makes, and the panel does not actually depend on the entry for it — `notReadyHint`
+// reads the durable `backendReady` map FIRST and only falls back to the entry — so holding
+// these three keys back is belt-and-braces rather than the load-bearing guard.
 //
 // With NO authoritative snapshot yet, the probe is all there is and is used as-is —
 // unchanged behaviour for a panel that has not connected.
 //
 // Pure and dependency-free (no DOM), so the ordering bug this fixes is unit-testable.
+
+/** The fields the ComfyUI host must never supply for a provider the orchestrator described.
+ *  See the note above: the host cannot see the agent machine. */
+const READINESS_KEYS = ["ready", "cli", "auth"];
 
 /** A usable provider entry: an object naming a non-empty `backend` id. */
 function isProviderEntry(entry) {
@@ -54,19 +70,34 @@ export function mergeProviderSnapshots({ authoritative, probe } = {}) {
   // Nothing authoritative to protect — the probe is the only source of truth there is.
   if (!auth.length) return host;
 
-  const authIds = new Set();
-  const merged = [];
+  const order = [];
+  const byId = new Map();
   for (const entry of auth) {
     // First writer wins on a duplicated id, so a malformed authoritative snapshot cannot
     // produce two chips for one provider.
-    if (authIds.has(entry.backend)) continue;
-    authIds.add(entry.backend);
-    merged.push(entry);
+    if (byId.has(entry.backend)) continue;
+    byId.set(entry.backend, entry);
+    order.push(entry.backend);
   }
   for (const entry of host) {
-    if (authIds.has(entry.backend)) continue; // never overwrite, never remove
-    authIds.add(entry.backend);
-    merged.push(entry);
+    const known = byId.get(entry.backend);
+    if (!known) {
+      // Additive — a provider only the host knows about. It keeps its own entry, so its
+      // liveness follows every later probe.
+      byId.set(entry.backend, entry);
+      order.push(entry.backend);
+      continue;
+    }
+    // Shared id: keep the authoritative entry's membership and position, overlay the
+    // probe's live fields, and hold back readiness. Spread first, then restore the three
+    // readiness keys from the authoritative entry when it actually carried them — so a
+    // probe that omits them cannot blank them either.
+    const refreshed = { ...known, ...entry };
+    for (const key of READINESS_KEYS) {
+      if (key in known) refreshed[key] = known[key];
+      else delete refreshed[key];
+    }
+    byId.set(entry.backend, refreshed);
   }
-  return merged;
+  return order.map((id) => byId.get(id));
 }

--- a/web/js/lib/provider-snapshot-merge.js
+++ b/web/js/lib/provider-snapshot-merge.js
@@ -43,8 +43,10 @@
 // reads the durable `backendReady` map FIRST and only falls back to the entry — so holding
 // these three keys back is belt-and-braces rather than the load-bearing guard.
 //
-// With NO authoritative snapshot yet, the probe is all there is and is used as-is —
-// unchanged behaviour for a panel that has not connected.
+// With NO authoritative snapshot yet, the probe is all there is and is returned on its own
+// — unchanged behaviour for a panel that has not connected. Not literally untouched: both
+// snapshots are filtered for a usable `backend` id first, so a malformed entry is dropped
+// rather than rendered as a nameless chip.
 //
 // Pure and dependency-free (no DOM), so the ordering bug this fixes is unit-testable.
 
@@ -62,8 +64,9 @@
  *
  *  SCOPE OF THAT GUARANTEE, stated precisely because an earlier version of this comment
  *  overclaimed it (codex): it covers providers the AUTHORITATIVE snapshot describes. A
- *  provider only the probe reports keeps its own entry verbatim, flag included, and so does
- *  every entry when there is no authoritative snapshot at all. That is deliberate rather
+ *  provider only the probe reports keeps its OWN entry's flag — nothing overrides it — and so
+ *  does every entry when there is no authoritative snapshot at all. ("Its own entry" rather
+ *  than "verbatim": a probe that names the same id twice still collapses to one chip.) That is deliberate rather
  *  than an oversight — for a provider the orchestrator never described there is no better
  *  claim to fall back on, and of the two ways to be wrong, showing a warning that may not
  *  apply is the safe one and hiding one that does is not. */

--- a/web/js/lib/provider-snapshot-merge.js
+++ b/web/js/lib/provider-snapshot-merge.js
@@ -1,0 +1,72 @@
+// #1083 — a less complete provider snapshot must never SHRINK an authoritative one.
+//
+// The panel learns its provider list from two places, and they do not carry the same
+// truth:
+//
+//   * the ORCHESTRATOR, over the bridge. It runs on the machine that actually hosts the
+//     agents, so it knows about `lmstudio`, `llamacpp`, a configured `custom` endpoint and
+//     `copilot`. The panel already treats it as authoritative for readiness, for the reason
+//     written at `applyReadiness`: a later host probe must not downgrade a provider that is
+//     connected and working.
+//   * the ComfyUI HOST, over `GET /comfyui_mcp_panel/backends`. Its `_BACKEND_PORTS` map
+//     ends at `openrouter` and knows nothing about the four above.
+//
+// `renderBackendChips` assigns `knownBackends = list` wholesale, and the model popup
+// rebuilds its Provider section from `knownBackends`. So when the host probe landed after
+// the orchestrator had already spoken, it REPLACED the authoritative list with its own
+// shorter one and the four providers vanished from the picker — with no UI path back to a
+// configured Custom endpoint. `applyReadiness` refuses that probe correctly, but it runs
+// one line too late to matter: the list is already gone.
+//
+// WHY A MERGE RATHER THAN SKIPPING THE REPAINT. The one-line fix is to not repaint at all
+// once the orchestrator has spoken. That does stop the truncation, but the host probe is
+// also how a chip's live `running` state refreshes, so ignoring it outright trades a
+// disappearing provider for a permanently stale one. Merging keeps both.
+//
+// WHAT THE PROBE MAY AND MAY NOT DO, once an authoritative snapshot exists:
+//   * it may ADD a provider the authoritative snapshot did not mention — additive, and it
+//     cannot make the list shorter;
+//   * it may NOT remove one, and it may NOT overwrite the fields of one. That second
+//     restriction is the same ruling `applyReadiness` already makes: the probe cannot see
+//     the agent machine, so its `ready`/`running` for a provider it half-knows is not an
+//     improvement on what the orchestrator said.
+//
+// With NO authoritative snapshot yet, the probe is all there is and is used as-is —
+// unchanged behaviour for a panel that has not connected.
+//
+// Pure and dependency-free (no DOM), so the ordering bug this fixes is unit-testable.
+
+/** A usable provider entry: an object naming a non-empty `backend` id. */
+function isProviderEntry(entry) {
+  return !!entry && typeof entry === "object" && typeof entry.backend === "string" && !!entry.backend;
+}
+
+/**
+ * @param {{ authoritative?: unknown, probe?: unknown }} input
+ * @returns {Array<object>} the list to render
+ *
+ * `authoritative` is the current known-good snapshot (the orchestrator's), or empty/absent
+ * when none has arrived. `probe` is the host response.
+ */
+export function mergeProviderSnapshots({ authoritative, probe } = {}) {
+  const auth = Array.isArray(authoritative) ? authoritative.filter(isProviderEntry) : [];
+  const host = Array.isArray(probe) ? probe.filter(isProviderEntry) : [];
+  // Nothing authoritative to protect — the probe is the only source of truth there is.
+  if (!auth.length) return host;
+
+  const authIds = new Set();
+  const merged = [];
+  for (const entry of auth) {
+    // First writer wins on a duplicated id, so a malformed authoritative snapshot cannot
+    // produce two chips for one provider.
+    if (authIds.has(entry.backend)) continue;
+    authIds.add(entry.backend);
+    merged.push(entry);
+  }
+  for (const entry of host) {
+    if (authIds.has(entry.backend)) continue; // never overwrite, never remove
+    authIds.add(entry.backend);
+    merged.push(entry);
+  }
+  return merged;
+}

--- a/web/js/lib/provider-snapshot-merge.js
+++ b/web/js/lib/provider-snapshot-merge.js
@@ -49,8 +49,18 @@
 // Pure and dependency-free (no DOM), so the ordering bug this fixes is unit-testable.
 
 /** The fields the ComfyUI host must never supply for a provider the orchestrator described.
- *  See the note above: the host cannot see the agent machine. */
-const READINESS_KEYS = ["ready", "cli", "auth"];
+ *
+ *  `ready`/`cli`/`auth` — readiness, per the note above: the host cannot see the agent
+ *  machine, so its view would false-flag a connected provider as "CLI not installed".
+ *
+ *  `experimental` — a SAFETY DISCLOSURE, not metadata (codex). It is what puts "(experimental)"
+ *  in `backendDisplayLabel` and the amber outline plus the "signs in as VS Code, against
+ *  GitHub's Copilot API terms" tooltip on the chip, so picking a ToS-risk provider is a
+ *  deliberate, informed act. The host's entries are sparse `{backend, running}`, so a
+ *  catch-all overlay would silently DELETE the flag on the next probe and quietly remove
+ *  that warning — and, in the other direction, would let the host invent it. Neither is the
+ *  host's call to make. */
+const AUTHORITATIVE_ONLY_KEYS = ["ready", "cli", "auth", "experimental"];
 
 /** A usable provider entry: an object naming a non-empty `backend` id. */
 function isProviderEntry(entry) {
@@ -89,11 +99,11 @@ export function mergeProviderSnapshots({ authoritative, probe } = {}) {
       continue;
     }
     // Shared id: keep the authoritative entry's membership and position, overlay the
-    // probe's live fields, and hold back readiness. Spread first, then restore the three
-    // readiness keys from the authoritative entry when it actually carried them — so a
-    // probe that omits them cannot blank them either.
+    // probe's live fields, and hold back the authoritative-only keys. Spread first, then
+    // restore those keys from the authoritative entry when it actually carried them — and
+    // DELETE them when it did not, so a probe can neither blank one nor invent one.
     const refreshed = { ...known, ...entry };
-    for (const key of READINESS_KEYS) {
+    for (const key of AUTHORITATIVE_ONLY_KEYS) {
       if (key in known) refreshed[key] = known[key];
       else delete refreshed[key];
     }

--- a/web/js/lib/provider-snapshot-merge.js
+++ b/web/js/lib/provider-snapshot-merge.js
@@ -58,8 +58,15 @@
  *  GitHub's Copilot API terms" tooltip on the chip, so picking a ToS-risk provider is a
  *  deliberate, informed act. The host's entries are sparse `{backend, running}`, so a
  *  catch-all overlay would silently DELETE the flag on the next probe and quietly remove
- *  that warning — and, in the other direction, would let the host invent it. Neither is the
- *  host's call to make. */
+ *  that warning.
+ *
+ *  SCOPE OF THAT GUARANTEE, stated precisely because an earlier version of this comment
+ *  overclaimed it (codex): it covers providers the AUTHORITATIVE snapshot describes. A
+ *  provider only the probe reports keeps its own entry verbatim, flag included, and so does
+ *  every entry when there is no authoritative snapshot at all. That is deliberate rather
+ *  than an oversight — for a provider the orchestrator never described there is no better
+ *  claim to fall back on, and of the two ways to be wrong, showing a warning that may not
+ *  apply is the safe one and hiding one that does is not. */
 const AUTHORITATIVE_ONLY_KEYS = ["ready", "cli", "auth", "experimental"];
 
 /** A usable provider entry: an object naming a non-empty `backend` id. */


### PR DESCRIPTION
Fixes #1083. Connect to ChatGPT, reopen the model picker, and **LM Studio, llama.cpp, Custom
endpoint and Copilot are gone** — with no UI path back to a configured Custom endpoint.

The report's diagnosis is exact, including the line numbers, so this PR is mostly about the
one judgement call it left open.

## What was wrong

The panel learns its provider list from two sources that do not carry the same truth:

- the **orchestrator**, which runs on the machine hosting the agents and knows all four;
- the **ComfyUI host**, whose `_BACKEND_PORTS` map ends at `openrouter`.

`loadBackends()` called `renderBackendChips(data.backends)` and only *then*
`applyReadiness(data)`. `applyReadiness` refuses a host probe once the orchestrator has
spoken — but one line too late: `renderBackendChips` assigns `knownBackends` wholesale, and
the model popup rebuilds its Provider section from that. The list was already gone.

## Why not the one-line fix

The report offers:

```diff
-  renderBackendChips(data.backends);
+  if (!readinessFromOrchestrator) renderBackendChips(data.backends);
```

That does stop the truncation. But the host probe is also **how a chip's live `running`
state refreshes**, so ignoring it outright trades a disappearing provider for a permanently
stale one. The report names the merge as its own alternative and states the invariant
correctly — *a less complete snapshot cannot shrink an authoritative one* — so this
implements that rather than the shortcut.

Once an authoritative snapshot exists, the probe:

- **may ADD** a provider it did not mention (additive; it cannot shorten the list);
- **may not remove** one, and **may not overwrite** one's fields. That second restriction is
  the same ruling `applyReadiness` already makes: the host cannot see the agent machine, so
  its view of a provider it half-knows is not an improvement on what the orchestrator said.

With **no** authoritative snapshot the probe is used as-is, so a panel that has not connected
yet is completely unchanged.

## Tests

The merge is a pure, DOM-free helper precisely so this ordering bug is unit-testable — which
the report also asked for. Seven cases: the reported truncation; no downgrade of an
orchestrator-reported provider; host-only additions; the no-orchestrator path; malformed
input; duplicate ids; and **stability across repeated refreshes**, since `loadBackends` runs
on a timer and therefore re-merges its own output.

3872 tests pass, `tsc --noEmit` clean, `node --check` OK, and both changed files parse as
**true ES modules** (`node --check` alone parses them as CommonJS and would bless a panel the
browser cannot load).

Closes #1083

---

## Review history

Three codex adversarial rounds, each of which found something real. All findings are
addressed; a fourth confirming round is blocked by an intermittent Windows sandbox error
(`CreateProcessAsUserW failed: 5`) and it correctly refused to review without reading the
diff.

**Round 1 — 2 findings, both mine, both taken.**
- `readinessFromOrchestrator` is not an authoritative provider *list*. A bare `ready` ack
  sets it carrying no providers, and that ack can precede the backends frame — so a probe
  landing in that window merged against the claude-only default and was then treated as
  authoritative.
- `knownBackends` is the *rendered* list, so it contains host-only entries. Feeding it back
  as the baseline froze those entries' `running` at first sight. My "stability" test missed
  it by replaying an identical probe, which cannot observe a frozen field.

Fixed by pinning the baseline to a dedicated `orchestratorBackends`, set only from a real
bridge frame.

**Round 2 — 2 findings, both mine, both taken.**
- A *shared* provider's `running` froze — the same bug one id-set over, and my own test
  enshrined it. The merge is now per-field: membership and position stay authoritative,
  `running` comes from the probe.
- An explicitly empty `backends: []` was ignored. The array's *presence* makes the frame a
  provider report; its length is the content. The repaint on the next line already read it
  that way, so my guard was inconsistent with its own neighbour.

**Round 3 — 1 finding taken, 1 disputed with evidence.**
- **Taken:** `experimental` is a *safety disclosure*, not metadata — it drives the amber
  outline and the "signs in as VS Code, against GitHub's Copilot API terms" warning. A sparse
  host entry would have deleted it on the next probe. It now joins the authoritative-only
  set, refused in both directions (cannot be blanked, cannot be invented).
- **Disputed:** "a host probe after reconnect cannot add a probe-only provider." The host
  loop appends any id the baseline lacks, so it can. A test now drives that exact scenario
  rather than leaving it as an assertion in prose.

**Field audit** (round 3 asked for it; done directly): the provider entry supplies exactly
six consumed fields — `backend` (membership), `running` (probe-owned, refreshed every probe),
and `experimental` / `ready` / `cli` / `auth` (authoritative-only). There is no other field a
sparse probe could blank or forge.

**Known residual, deliberately not fixed:** the baseline is not scoped to a bridge connection
generation, so between a reconnect and its first backends frame the picker can show a stale
*extra* provider from the previous orchestrator. Extra rather than missing — the opposite of
this issue — and self-correcting once that frame lands, which is why it did not justify
threading connection generations through this path.
