### PR TITLE
fix(1084): name both ChatGPT routes, and stop the label map gating the handshake

### DIFF
--- a/browser_tests/unit/i18n.test.mjs
+++ b/browser_tests/unit/i18n.test.mjs
@@ -389,8 +389,13 @@ test("translating a combo changes only its TEXT, never the value that gets store
   assert.notEqual(at, -1, "the default-backend setting must still exist");
   const block = body.slice(at, body.indexOf("defaultValue:", at));
   const values = [...block.matchAll(/\{ value: "([^"]*)", text:/g)].map((m) => m[1]);
+  // `chatgpt` sits next to `codex` (#1084): they are two routes to the same ChatGPT
+  // subscription — a `codex app-server` subprocess and the direct Codex Responses OAuth
+  // API — and the panel named only the first, so the picker showed "ChatGPT" beside a raw
+  // "chatgpt". Both are ids on the wire and neither may ever be translated, which is what
+  // this list is here to hold.
   assert.deepEqual(values, [
-    "claude", "codex", "gemini", "antigravity", "pi", "grok", "kimi", "moonshot",
+    "claude", "codex", "chatgpt", "gemini", "antigravity", "pi", "grok", "kimi", "moonshot",
     "glm", "minimax", "ollama", "openrouter", "lmstudio", "llamacpp", "custom",
   ]);
   // Every one of those labels must go through tr() — a bare string here is a row that

--- a/locales/en/main.json
+++ b/locales/en/main.json
@@ -364,6 +364,7 @@
       "chat_title": "Chat title",
       "chatgpt": "ChatGPT",
       "chatgpt_codex": "ChatGPT (Codex)",
+      "chatgpt_direct_oauth": "ChatGPT (direct OAuth)",
       "checked_errors_none": "Checked errors — none",
       "checked_errors_none_unchecked_one": "Checked errors — none found ({count} node could not be checked)",
       "checked_errors_none_unchecked_other": "Checked errors — none found ({count} nodes could not be checked)",

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -3221,7 +3221,12 @@ const BACKEND_SECTION = {
 };
 // Backend display names at module scope (the Settings dialog's render-fns live
 // outside buildPanel's closure, so they need their own copy).
-const BACKEND_TEXT = { claude: "Claude", codex: "ChatGPT", gemini: "Gemini", antigravity: "Antigravity", pi: "Pi", grok: "Grok", kimi: "Kimi", moonshot: "Kimi K3", glm: "GLM (z.ai)", minimax: "MiniMax", ollama: "Ollama", openrouter: "OpenRouter", lmstudio: "LM Studio", llamacpp: "llama.cpp", custom: "Custom endpoint" };
+// Kept in step with BACKEND_LABELS (#1084). `chatgpt` and `copilot` were both absent, and
+// every read of this map below interpolates it with NO fallback — so the moment a settings
+// row exists for either, its description reads "the undefined background agent". No row does
+// today (they are instantiated one by one, not from this map), which is exactly why the gap
+// was invisible: the entries are added here so the next row added cannot ship that string.
+const BACKEND_TEXT = { claude: "Claude", codex: "ChatGPT (Codex)", chatgpt: "ChatGPT (direct OAuth)", gemini: "Gemini", antigravity: "Antigravity", pi: "Pi", grok: "Grok", kimi: "Kimi", moonshot: "Kimi K3", glm: "GLM (z.ai)", minimax: "MiniMax", ollama: "Ollama", openrouter: "OpenRouter", lmstudio: "LM Studio", llamacpp: "llama.cpp", custom: "Custom endpoint", copilot: "GitHub Copilot" };
 // The allowlisted secure-store keys (mirrors the orchestrator's #59 allowlist).
 const SECRET_SET_AT_PREFIX = "comfyui-mcp.panel.secretSetAt.";
 
@@ -3995,7 +4000,12 @@ function panelSettingsList() {
       get options() {
         return [
           { value: "claude", text: tr("panel.claude", "Claude") },
-          { value: "codex", text: tr("panel.chatgpt", "ChatGPT") },
+          // #1084 — the two ChatGPT routes are named apart here too, or this dropdown
+          // reproduces the picker's "ChatGPT vs chatgpt" confusion one dialog over. `codex`
+          // reuses `panel.chatgpt_codex`, which the panel ALREADY ships translated for the
+          // sign-in card, rather than minting a near-duplicate key for the same words.
+          { value: "codex", text: tr("panel.chatgpt_codex", "ChatGPT (Codex)") },
+          { value: "chatgpt", text: tr("panel.chatgpt_direct_oauth", "ChatGPT (direct OAuth)") },
           { value: "gemini", text: tr("panel.gemini", "Gemini") },
           { value: "antigravity", text: tr("panel.antigravity_google_subscription", "Antigravity (Google subscription)") },
           // Comma, not the middot this row used to carry: the panel already ships this exact
@@ -20364,7 +20374,14 @@ function buildPanel() {
   // ChatGPT). Clicking one asks the pack to ensure that backend's orchestrator is
   // running and returns the bridge URL to connect to — the user never types a
   // port. Populated from GET /comfyui_mcp_panel/backends when settings open.
-  const BACKEND_LABELS = { claude: "Claude", codex: "ChatGPT", gemini: "Gemini", antigravity: "Antigravity", pi: "Pi", grok: "Grok", kimi: "Kimi", moonshot: "Kimi K3", glm: "GLM (z.ai)", minimax: "MiniMax", ollama: "Ollama", openrouter: "OpenRouter", lmstudio: "LM Studio", llamacpp: "llama.cpp", custom: "Custom endpoint", copilot: "GitHub Copilot" };
+  // #1084 — `codex` and `chatgpt` are TWO ways to reach the same ChatGPT subscription, not a
+  // duplicate: `codex` runs it through a `codex app-server` subprocess, `chatgpt` speaks the
+  // Codex Responses OAuth API directly with no subprocess. The panel labelled only the first,
+  // as a bare "ChatGPT", so the second fell through to its raw id and the picker showed
+  // "ChatGPT" next to "chatgpt" — which reads as an accident and gives no basis for choosing.
+  // Both are named now; the orchestrator's own ready banner says "direct OAuth", so the panel
+  // matches that wording rather than inventing a second vocabulary for the same thing.
+  const BACKEND_LABELS = { claude: "Claude", codex: "ChatGPT (Codex)", chatgpt: "ChatGPT (direct OAuth)", gemini: "Gemini", antigravity: "Antigravity", pi: "Pi", grok: "Grok", kimi: "Kimi", moonshot: "Kimi K3", glm: "GLM (z.ai)", minimax: "MiniMax", ollama: "Ollama", openrouter: "OpenRouter", lmstudio: "LM Studio", llamacpp: "llama.cpp", custom: "Custom endpoint", copilot: "GitHub Copilot" };
   // Appends a visible "(experimental)" marker to a backend's display label when
   // the readiness data flags it (b.experimental, e.g. Copilot — device-code,
   // GitHub ToS risk). Keeps picking it a deliberate, informed act everywhere a
@@ -26797,7 +26814,19 @@ function buildPanel() {
       // AUTHORITATIVE source of which provider we're actually connected to. Resolve
       // the switch BEFORE applying the catalog, so the effort scale + nearest-level
       // mapping in applyModelCatalog uses the NEW backend's scale (fix #5).
-      const known = typeof backend === "string" && BACKEND_LABELS[backend];
+      // #1084 — a backend id the orchestrator reports on its own handshake is AUTHORITATIVE,
+      // whether or not this panel build happens to have a pretty name for it. This gate used
+      // to be `BACKEND_LABELS[backend]`, which quietly made the label map a registry of
+      // KNOWN backends — so the missing `chatgpt` entry did not merely look wrong in the
+      // picker, it skipped this whole block: `connectedBackend` was never updated from the
+      // handshake, the preference was never persisted, and the placeholder kept naming the
+      // previous provider. A panel connected to direct-OAuth ChatGPT did not know it.
+      //
+      // Adding the label fixes today's case; keying the gate on the id fixes the class,
+      // because the orchestrator can add a backend before the panel ships a name for it and
+      // that is a normal ordering, not an error. Every label read below falls back to the
+      // raw id, so an unnamed backend degrades to showing "chatgpt" rather than "undefined".
+      const known = typeof backend === "string" && !!backend;
       if (known) {
         // A real provider switch = the connected backend changed AND we were
         // already connected to something (not the first connect, not a re-pick).
@@ -26807,7 +26836,9 @@ function buildPanel() {
             tr(
               "panel.switched_to_sessions_aren_t_shared_across",
               "Switched to {backend} — sessions aren't shared across providers, so this starts a fresh chat.",
-              { backend: BACKEND_LABELS[backend] },
+              // Falls back to the raw id (#1084): with the gate above no longer requiring a
+              // label, an unnamed backend would otherwise render "Switched to undefined".
+              { backend: BACKEND_LABELS[backend] || backend },
             ),
           );
         }

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -3226,7 +3226,7 @@ const BACKEND_SECTION = {
 // row exists for either, its description reads "the undefined background agent". No row does
 // today (they are instantiated one by one, not from this map), which is exactly why the gap
 // was invisible: the entries are added here so the next row added cannot ship that string.
-const BACKEND_TEXT = { claude: "Claude", codex: "ChatGPT (Codex)", chatgpt: "ChatGPT (direct OAuth)", gemini: "Gemini", antigravity: "Antigravity", pi: "Pi", grok: "Grok", kimi: "Kimi", moonshot: "Kimi K3", glm: "GLM (z.ai)", minimax: "MiniMax", ollama: "Ollama", openrouter: "OpenRouter", lmstudio: "LM Studio", llamacpp: "llama.cpp", custom: "Custom endpoint", copilot: "GitHub Copilot" };
+const BACKEND_TEXT = /* null-prototype: see BACKEND_LABELS (#1084 codex) */ Object.assign(Object.create(null), { claude: "Claude", codex: "ChatGPT (Codex)", chatgpt: "ChatGPT (direct OAuth)", gemini: "Gemini", antigravity: "Antigravity", pi: "Pi", grok: "Grok", kimi: "Kimi", moonshot: "Kimi K3", glm: "GLM (z.ai)", minimax: "MiniMax", ollama: "Ollama", openrouter: "OpenRouter", lmstudio: "LM Studio", llamacpp: "llama.cpp", custom: "Custom endpoint", copilot: "GitHub Copilot" });
 // The allowlisted secure-store keys (mirrors the orchestrator's #59 allowlist).
 const SECRET_SET_AT_PREFIX = "comfyui-mcp.panel.secretSetAt.";
 
@@ -20381,7 +20381,13 @@ function buildPanel() {
   // "ChatGPT" next to "chatgpt" — which reads as an accident and gives no basis for choosing.
   // Both are named now; the orchestrator's own ready banner says "direct OAuth", so the panel
   // matches that wording rather than inventing a second vocabulary for the same thing.
-  const BACKEND_LABELS = { claude: "Claude", codex: "ChatGPT (Codex)", chatgpt: "ChatGPT (direct OAuth)", gemini: "Gemini", antigravity: "Antigravity", pi: "Pi", grok: "Grok", kimi: "Kimi", moonshot: "Kimi K3", glm: "GLM (z.ai)", minimax: "MiniMax", ollama: "Ollama", openrouter: "OpenRouter", lmstudio: "LM Studio", llamacpp: "llama.cpp", custom: "Custom endpoint", copilot: "GitHub Copilot" };
+  // NULL-PROTOTYPE, and it is load-bearing rather than tidiness (#1084 codex). Every read is
+  // `BACKEND_LABELS[id] || id`, and on a normal object literal that lookup walks the
+  // prototype chain: `BACKEND_LABELS["constructor"]` returns Object's constructor FUNCTION
+  // and `["__proto__"]` returns an object, so the `|| id` fallback never fires and a
+  // function would be interpolated into a sentence. Harmless while the gate below only let
+  // known ids through; reachable the moment it accepts an id this map has never seen.
+  const BACKEND_LABELS = Object.assign(Object.create(null), { claude: "Claude", codex: "ChatGPT (Codex)", chatgpt: "ChatGPT (direct OAuth)", gemini: "Gemini", antigravity: "Antigravity", pi: "Pi", grok: "Grok", kimi: "Kimi", moonshot: "Kimi K3", glm: "GLM (z.ai)", minimax: "MiniMax", ollama: "Ollama", openrouter: "OpenRouter", lmstudio: "LM Studio", llamacpp: "llama.cpp", custom: "Custom endpoint", copilot: "GitHub Copilot" });
   // Appends a visible "(experimental)" marker to a backend's display label when
   // the readiness data flags it (b.experimental, e.g. Copilot — device-code,
   // GitHub ToS risk). Keeps picking it a deliberate, informed act everywhere a
@@ -26826,7 +26832,16 @@ function buildPanel() {
       // because the orchestrator can add a backend before the panel ships a name for it and
       // that is a normal ordering, not an error. Every label read below falls back to the
       // raw id, so an unnamed backend degrades to showing "chatgpt" rather than "undefined".
-      const known = typeof backend === "string" && !!backend;
+      //
+      // SHAPE-CHECKED rather than merely non-empty (codex). This block persists the value to
+      // localStorage and keys a per-backend catalog cache on it, so accepting anything at all
+      // would let a malformed handshake — `" "`, or a stray sentence — become the saved
+      // provider preference and outlive the session that produced it. The pattern is
+      // deliberately permissive about WHICH id (that is the whole point of not using the
+      // label map) and strict only about it being id-SHAPED: a leading alphanumeric, then
+      // alphanumerics, hyphens or underscores. Every backend this panel has ever shipped
+      // matches, and so does one it has never heard of.
+      const known = typeof backend === "string" && /^[a-z0-9][a-z0-9_-]*$/i.test(backend);
       if (known) {
         // A real provider switch = the connected backend changed AND we were
         // already connected to something (not the first connect, not a re-pick).


### PR DESCRIPTION
Fixes #1084. The provider picker showed **`ChatGPT` next to a raw lowercase `chatgpt`**, which
reads as an accidental duplicate and gives no basis for choosing between them.

They are two intentionally different routes to the same ChatGPT subscription:

- `codex` — through a `codex app-server` subprocess
- `chatgpt` — the Codex Responses OAuth API directly, no subprocess

Only the first was named, so the second fell through to its id.

## The label was the smaller half

The report's aside — *"several panel paths treat only IDs present in `BACKEND_LABELS` as
known"* — turned out to be the substantive part. The handshake gate was literally:

```js
const known = typeof backend === "string" && BACKEND_LABELS[backend];
```

and that gate wraps the entire authoritative block. With `chatgpt` absent it did not merely
look wrong in the picker — it skipped updating `connectedBackend` from the orchestrator's own
report, skipped persisting the preference, skipped the placeholder, and skipped the chip
repaint. **A panel connected to direct-OAuth ChatGPT did not know which provider it was
talking to.**

Adding the label fixes today's case; keying the gate on the id fixes the class — the
orchestrator can ship a backend before the panel has a name for it, and that ordering is
normal rather than an error. Every label read on that path falls back to the raw id,
**including the switch notice**, which had no fallback and would otherwise have started
saying "Switched to undefined" the moment the gate stopped requiring a label.

## Naming taken from what already exists

Not invented: the orchestrator's own ready banner says *"direct OAuth"*, and the panel
**already ships** `panel.chatgpt_codex` — "ChatGPT (Codex)", translated in every locale — for
the sign-in card. So `codex` reuses that key in the settings dropdown rather than minting a
near-duplicate for the same words, and only `panel.chatgpt_direct_oauth` is new (one line in
`locales/en/main.json`).

## Also brought back in step

`BACKEND_TEXT` was missing `chatgpt` **and** `copilot`, and every read interpolates it with no
fallback — "the undefined background agent". No settings row reads it for either today, which
is exactly why the gap was invisible; the entries are added so the next row added cannot ship
that string.

## Tests

The i18n combo test locks the dropdown's value list, and it is right to: ComfyUI persists
`option.value` and displays `option.text`, so a translation reaching `value` would write a
display name into `comfy.settings.json` as a backend id — invisible until a Korean user's
panel refuses to connect. Updated for the new entry with the reason recorded, not just the
value.

3880 tests pass, `tsc --noEmit` clean, `node --check` OK, `i18n-check` locales OK.

Closes #1084
