### PR TITLE
fix(1085): a correction to an identical value is not a correction

### DIFF
--- a/browser_tests/unit/schema-value-correction-identity.test.mjs
+++ b/browser_tests/unit/schema-value-correction-identity.test.mjs
@@ -233,9 +233,14 @@ test("#1085 (codex): an Array SUBCLASS is not a plain array", () => {
   assert.equal(applyCurrentDefWidgetValues(node, defWith("cfg", { default: { size: [1, 2] } })).length, 1);
 });
 
-test("#1085 (codex r2): a symbol or non-enumerable own key refuses the structural compare", () => {
-  // My first version of this test asserted [] here and called it "symbol keys are outside
-  // the compared surface". That was the false negative itself, wearing a reassuring title:
+test("#1085 (codex r2): a difference behind a symbol or non-enumerable own key is REPORTED", () => {
+  // Titled by OUTCOME, not mechanism (codex): this proves the difference is reported, which
+  // is the caller-visible contract. The implementation gets there by refusing to compare
+  // such objects at all, but a comparator that safely compared symbol keys would satisfy
+  // this too, and that would also be correct.
+  //
+  // My first version asserted [] here and called it "symbol keys are outside the compared
+  // surface". That was the false negative itself, wearing a reassuring title:
   // Object.keys misses symbol and non-enumerable own keys, so a real difference hid there.
   // The compare now REFUSES any object carrying one, which falls back to identity — the
   // pre-fix answer — so the difference is reported rather than swallowed.
@@ -338,8 +343,9 @@ test("#1085 (codex r4): a DEEP but finite equal default is not falsely corrected
     [],
     "30 levels of identical structure is not a change",
   );
-  // Far past BOTH retired caps (8, then 100), which is the point: there is no depth at
-  // which two equal structures should be called different.
+  // Far past BOTH retired caps (8, then 100), which is the point: no CONSTANT is the right
+  // depth at which to call two equal structures different. The remaining bound is the call
+  // stack, which a JSON widget default cannot approach.
   assert.deepEqual(
     applyCurrentDefWidgetValues(nodeWith("cfg", deep(400)), defWith("cfg", { default: deep(400) })),
     [],

--- a/browser_tests/unit/schema-value-correction-identity.test.mjs
+++ b/browser_tests/unit/schema-value-correction-identity.test.mjs
@@ -133,6 +133,12 @@ test("#1085 (codex): SPARSE array holes are compared, not skipped", () => {
   const node = nodeWith("cfg", { size: [, 1] });
   const corrections = applyCurrentDefWidgetValues(node, defWith("cfg", { default: { size: [0, 1] } }));
   assert.equal(corrections.length, 1, "a hole is not the value 0");
+  // The RECIPROCAL direction too — value where the other has a hole.
+  const reciprocal = nodeWith("cfg", { size: [0, 1] });
+  assert.equal(
+    applyCurrentDefWidgetValues(reciprocal, defWith("cfg", { default: { size: [, 1] } })).length,
+    1,
+  );
   // …and a hole matching a hole is still equal.
   const same = nodeWith("cfg", { size: [, 1] });
   assert.deepEqual(applyCurrentDefWidgetValues(same, defWith("cfg", { default: { size: [, 1] } })), []);
@@ -145,6 +151,8 @@ test("#1085 (codex): built-ins with no enumerable keys are not all equal", () =>
     [new Date(1), new Date(2)],
     [new Map([["a", 1]]), new Map([["a", 2]])],
     [new Set([1]), new Set([2])],
+    [new ArrayBuffer(8), new ArrayBuffer(16)],
+    [new DataView(new ArrayBuffer(8)), new DataView(new ArrayBuffer(16))],
   ]) {
     const node = nodeWith("cfg", x);
     assert.equal(
@@ -162,17 +170,42 @@ test("#1085 (codex): an Array SUBCLASS is not a plain array", () => {
   assert.equal(applyCurrentDefWidgetValues(node, defWith("cfg", { default: { size: [1, 2] } })).length, 1);
 });
 
-test("#1085 (codex): symbol-keyed differences cannot hide inside a compared object", () => {
-  // Only plain objects are compared structurally, and a symbol key does not change that —
-  // but the value it hangs off does, so assert the containing comparison still notices when
-  // the plain content differs, and that an exotic carrier is refused outright.
+test("#1085 (codex r2): a symbol or non-enumerable own key refuses the structural compare", () => {
+  // My first version of this test asserted [] here and called it "symbol keys are outside
+  // the compared surface". That was the false negative itself, wearing a reassuring title:
+  // Object.keys misses symbol and non-enumerable own keys, so a real difference hid there.
+  // The compare now REFUSES any object carrying one, which falls back to identity — the
+  // pre-fix answer — so the difference is reported rather than swallowed.
   const sym = Symbol("k");
-  const withSym = { x: 1, [sym]: 1 };
-  const node = nodeWith("cfg", withSym);
+  const node = nodeWith("cfg", { x: 1, [sym]: 1 });
+  assert.equal(
+    applyCurrentDefWidgetValues(node, defWith("cfg", { default: { x: 1, [sym]: 2 } })).length,
+    1,
+    "a differing symbol value must not be invisible",
+  );
+
+  // Same for a non-enumerable own property.
+  const hidden = { x: 1 };
+  Object.defineProperty(hidden, "secret", { value: 1, enumerable: false });
+  const other = { x: 1 };
+  Object.defineProperty(other, "secret", { value: 2, enumerable: false });
+  assert.equal(applyCurrentDefWidgetValues(nodeWith("cfg", hidden), defWith("cfg", { default: other })).length, 1);
+
+  // And an ARRAY with a non-index own property, which the index walk would never see.
+  const arr = [1];
+  arr.extra = 1;
+  const arr2 = [1];
+  arr2.extra = 2;
+  assert.equal(
+    applyCurrentDefWidgetValues(nodeWith("cfg", { size: arr }), defWith("cfg", { default: { size: arr2 } })).length,
+    1,
+    "arr.extra differences must not hide behind the index walk",
+  );
+
+  // The ordinary JSON shape — the only one /object_info can produce — still compares equal.
   assert.deepEqual(
-    applyCurrentDefWidgetValues(node, defWith("cfg", { default: { x: 1, [sym]: 2 } })),
+    applyCurrentDefWidgetValues(nodeWith("cfg", { x: 1, y: [2] }), defWith("cfg", { default: { x: 1, y: [2] } })),
     [],
-    "symbol keys are outside the compared surface — documented, not silently assumed",
   );
 });
 

--- a/browser_tests/unit/schema-value-correction-identity.test.mjs
+++ b/browser_tests/unit/schema-value-correction-identity.test.mjs
@@ -327,10 +327,10 @@ test("#1085 (codex r4): a revoked or throwing PROXY answers 'different', never t
 });
 
 test("#1085 (codex r4): a DEEP but finite equal default is not falsely corrected", () => {
-  // The cap was 8, so any structurally-equal default nested beyond nine levels reported a
-  // spurious correction — the very thing this fix exists to remove — and then reassigned,
-  // re-aliasing the widget to the definition's object. The cap now exists only to bound a
-  // cycle, well past any real widget default.
+  // Two successive depth caps (8, then 100) each reported a spurious correction for any
+  // structurally-equal default nested past them — the very thing this fix removes — and then
+  // reassigned, re-aliasing the widget to the definition's object. There is no cap now;
+  // cycles are detected directly, so depth is unbounded for a finite structure.
   const deep = (n) => (n === 0 ? { leaf: 1 } : { nest: deep(n - 1) });
   const node = nodeWith("cfg", deep(30));
   assert.deepEqual(
@@ -351,4 +351,24 @@ test("#1085 (codex r4): a DEEP but finite equal default is not falsely corrected
   while (cur.nest) cur = cur.nest;
   cur.leaf = 2;
   assert.equal(applyCurrentDefWidgetValues(changed, defWith("cfg", { default: other })).length, 1);
+});
+
+test("#1085 (codex r5): ACCEPTED LIMIT — bisimilar cycles of different topology compare equal", () => {
+  // A self-cycle and a two-object mutual cycle are bisimilar: same shape at every step,
+  // different objects. This comparator calls them equal. Asserted rather than left silent,
+  // so the limit is visible to whoever reads this next.
+  //
+  // Unreachable in this function's actual job: the other side is always `config.default`,
+  // which comes from /object_info and is therefore JSON — and JSON cannot express a cycle.
+  const selfCycle = { x: 0 };
+  selfCycle.self = selfCycle;
+  const b = { x: 0 };
+  const c = { x: 0 };
+  b.self = c;
+  c.self = b;
+  assert.deepEqual(
+    applyCurrentDefWidgetValues(nodeWith("cfg", selfCycle), defWith("cfg", { default: b })),
+    [],
+    "documented limit: shape is compared, aliasing topology is not",
+  );
 });

--- a/browser_tests/unit/schema-value-correction-identity.test.mjs
+++ b/browser_tests/unit/schema-value-correction-identity.test.mjs
@@ -1,0 +1,125 @@
+/**
+ * #1085 — a "correction" to an identical value is not a correction.
+ *
+ * `applyCurrentDefWidgetValues` reconciles a freshly built node against the backend's
+ * CURRENT definition, and every value it changes is disclosed with a "this tab's schema is
+ * STALE, reload it" warning. Both of its comparisons were `!==`, which is the right question
+ * for a scalar and the wrong one for an OBJECT default: two readings of the same definition
+ * produce distinct objects, so `!==` is true no matter what they contain.
+ *
+ * Core `ImageCropV2` declares `crop_region` as `{x, y, width, height}`, so every add of one
+ * reported a correction from `{"x":0,"y":0,"width":512,"height":512}` to the identical
+ * `{"x":0,"y":0,"width":512,"height":512}` — and told the user to reload the tab.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { applyCurrentDefWidgetValues } from "../../web/js/lib/node-widget-materialization.js";
+
+/** A node as LG.createNode built it from the REGISTERED schema. */
+const nodeWith = (name, value, options) => ({
+  widgets: [{ name, value, ...(options ? { options } : {}) }],
+});
+/** The backend's CURRENT definition for that input. */
+const defWith = (name, config, declared = "IMAGE") => ({
+  input: { required: { [name]: [declared, config] } },
+});
+
+test("#1085: an object default equal by VALUE is not reported as a correction", () => {
+  const region = { x: 0, y: 0, width: 512, height: 512 };
+  const node = nodeWith("crop_region", { ...region });
+  const corrections = applyCurrentDefWidgetValues(node, defWith("crop_region", { default: { ...region } }));
+  assert.deepEqual(corrections, [], "identical content must not raise a STALE-schema warning");
+  assert.deepEqual(node.widgets[0].value, region, "and the value is untouched");
+});
+
+test("#1085: key ORDER does not make two identical objects unequal", () => {
+  // The reason this is a structural compare rather than JSON.stringify: two readings of the
+  // same definition are free to serialize their keys in different orders, and stringify
+  // would call those unequal — reproducing the bug through a second mechanism.
+  const node = nodeWith("crop_region", { x: 0, y: 0, width: 512, height: 512 });
+  const corrections = applyCurrentDefWidgetValues(
+    node,
+    defWith("crop_region", { default: { height: 512, width: 512, y: 0, x: 0 } }),
+  );
+  assert.deepEqual(corrections, []);
+});
+
+test("#1085: a GENUINELY changed object default is still corrected and disclosed", () => {
+  // The fix must not silence the case the disclosure exists for.
+  const node = nodeWith("crop_region", { x: 0, y: 0, width: 512, height: 512 });
+  const corrections = applyCurrentDefWidgetValues(
+    node,
+    defWith("crop_region", { default: { x: 0, y: 0, width: 1024, height: 512 } }),
+  );
+  assert.equal(corrections.length, 1);
+  assert.equal(corrections[0].name, "crop_region");
+  assert.deepEqual(corrections[0].from, { x: 0, y: 0, width: 512, height: 512 });
+  assert.deepEqual(corrections[0].to, { x: 0, y: 0, width: 1024, height: 512 });
+  assert.deepEqual(node.widgets[0].value, { x: 0, y: 0, width: 1024, height: 512 });
+});
+
+test("#1085: nested and array defaults compare structurally too", () => {
+  const node = nodeWith("cfg", { size: [512, 512], meta: { mode: "crop" } });
+  assert.deepEqual(
+    applyCurrentDefWidgetValues(node, defWith("cfg", { default: { size: [512, 512], meta: { mode: "crop" } } })),
+    [],
+  );
+  // A single differing element is still a real change.
+  const changed = nodeWith("cfg", { size: [512, 512], meta: { mode: "crop" } });
+  assert.equal(
+    applyCurrentDefWidgetValues(changed, defWith("cfg", { default: { size: [512, 768], meta: { mode: "crop" } } }))
+      .length,
+    1,
+  );
+});
+
+test("#1085: differing key COUNT is a change even when the shared keys match", () => {
+  const node = nodeWith("cfg", { x: 0, y: 0 });
+  assert.equal(applyCurrentDefWidgetValues(node, defWith("cfg", { default: { x: 0, y: 0, z: 0 } })).length, 1);
+});
+
+test("#1085: scalar behaviour is unchanged — equal stays silent, different is reported", () => {
+  const same = nodeWith("steps", 20);
+  assert.deepEqual(applyCurrentDefWidgetValues(same, defWith("steps", { default: 20 }, "INT")), []);
+
+  const diff = nodeWith("steps", 20);
+  const corrections = applyCurrentDefWidgetValues(diff, defWith("steps", { default: 30 }, "INT"));
+  assert.deepEqual(corrections, [{ name: "steps", from: 20, to: 30 }]);
+});
+
+test("#1085: null and undefined are not confused with an empty object", () => {
+  const fromNull = nodeWith("cfg", null);
+  assert.equal(applyCurrentDefWidgetValues(fromNull, defWith("cfg", { default: {} })).length, 1);
+  const bothNull = nodeWith("cfg", null);
+  assert.deepEqual(applyCurrentDefWidgetValues(bothNull, defWith("cfg", { default: null })), []);
+});
+
+test("#1085: a CYCLIC live value fails toward today's behaviour, never a crash", () => {
+  // An /object_info default cannot be cyclic, but a live widget value could be. The depth
+  // cap answers "different" there — which is exactly what `!==` said before this existed —
+  // so the cost is a spurious correction, never a hang or a missed one.
+  const cyclic = { x: 0 };
+  cyclic.self = cyclic;
+  const node = nodeWith("cfg", cyclic);
+  let corrections;
+  assert.doesNotThrow(() => {
+    corrections = applyCurrentDefWidgetValues(node, defWith("cfg", { default: { x: 0, self: {} } }));
+  });
+  assert.equal(corrections.length, 1);
+});
+
+test("#1085: the #1369 self-contradictory COMBO ruling is unaffected", () => {
+  // A combo whose declared default is not a member of its own option list is still REFUSED
+  // rather than applied, and still reported through the out-param.
+  const node = nodeWith("sage_attention", "disabled");
+  const out = {};
+  const corrections = applyCurrentDefWidgetValues(
+    node,
+    { input: { required: { sage_attention: [["disabled", "auto"], { default: false }] } } },
+    out,
+  );
+  assert.deepEqual(corrections, [], "nothing applied");
+  assert.deepEqual(out.rejected, [{ name: "sage_attention", proposed: false, kept: "disabled" }]);
+  assert.equal(node.widgets[0].value, "disabled");
+});

--- a/browser_tests/unit/schema-value-correction-identity.test.mjs
+++ b/browser_tests/unit/schema-value-correction-identity.test.mjs
@@ -288,3 +288,52 @@ test("#1085 (codex): an equal object is NOT aliased to the definition's default"
   assert.equal(node.widgets[0].value, widgetValue, "still the widget's own object");
   assert.notEqual(node.widgets[0].value, defDefault, "and not the definition's");
 });
+
+// ---- codex round 4: a live value can be hostile ----------------------------
+
+test("#1085 (codex r4): a revoked or throwing PROXY answers 'different', never throws", () => {
+  // The path this replaced was a bare `!==`, which touches nothing. Every structural read
+  // here — Array.isArray, getPrototypeOf, Reflect.ownKeys, getOwnPropertyDescriptor, a
+  // property read — is a proxy trap point, so without a guard adding a node could FAIL
+  // where it used to succeed.
+  const { proxy, revoke } = Proxy.revocable({ x: 1 }, {});
+  revoke();
+  let corrections;
+  assert.doesNotThrow(() => {
+    corrections = applyCurrentDefWidgetValues(nodeWith("cfg", proxy), defWith("cfg", { default: { x: 1 } }));
+  });
+  assert.equal(corrections.length, 1, "answers 'different' — the pre-fix behaviour");
+
+  const hostile = new Proxy(
+    { x: 1 },
+    {
+      ownKeys() {
+        throw new Error("trap");
+      },
+    },
+  );
+  assert.doesNotThrow(() => {
+    applyCurrentDefWidgetValues(nodeWith("cfg", hostile), defWith("cfg", { default: { x: 1 } }));
+  });
+});
+
+test("#1085 (codex r4): a DEEP but finite equal default is not falsely corrected", () => {
+  // The cap was 8, so any structurally-equal default nested beyond nine levels reported a
+  // spurious correction — the very thing this fix exists to remove — and then reassigned,
+  // re-aliasing the widget to the definition's object. The cap now exists only to bound a
+  // cycle, well past any real widget default.
+  const deep = (n) => (n === 0 ? { leaf: 1 } : { nest: deep(n - 1) });
+  const node = nodeWith("cfg", deep(30));
+  assert.deepEqual(
+    applyCurrentDefWidgetValues(node, defWith("cfg", { default: deep(30) })),
+    [],
+    "30 levels of identical structure is not a change",
+  );
+  // A difference at the bottom of that same depth is still found.
+  const changed = nodeWith("cfg", deep(30));
+  const other = deep(30);
+  let cur = other;
+  while (cur.nest) cur = cur.nest;
+  cur.leaf = 2;
+  assert.equal(applyCurrentDefWidgetValues(changed, defWith("cfg", { default: other })).length, 1);
+});

--- a/browser_tests/unit/schema-value-correction-identity.test.mjs
+++ b/browser_tests/unit/schema-value-correction-identity.test.mjs
@@ -123,3 +123,79 @@ test("#1085: the #1369 self-contradictory COMBO ruling is unaffected", () => {
   assert.deepEqual(out.rejected, [{ name: "sage_attention", proposed: false, kept: "disabled" }]);
   assert.equal(node.widgets[0].value, "disabled");
 });
+
+// ---- codex round 1: cases where "equal" would have been a FALSE NEGATIVE ----
+// Every one of these is a REAL change that must still be reported. A missed correction is
+// the dangerous direction: the wrong value ships silently.
+
+test("#1085 (codex): SPARSE array holes are compared, not skipped", () => {
+  // `Array.prototype.every` jumps over holes, so [,1] and [0,1] came out equal.
+  const node = nodeWith("cfg", { size: [, 1] });
+  const corrections = applyCurrentDefWidgetValues(node, defWith("cfg", { default: { size: [0, 1] } }));
+  assert.equal(corrections.length, 1, "a hole is not the value 0");
+  // …and a hole matching a hole is still equal.
+  const same = nodeWith("cfg", { size: [, 1] });
+  assert.deepEqual(applyCurrentDefWidgetValues(same, defWith("cfg", { default: { size: [, 1] } })), []);
+});
+
+test("#1085 (codex): built-ins with no enumerable keys are not all equal", () => {
+  // Object.keys() sees nothing on these, so any two instances compared equal whatever they
+  // held. Restricted to plain objects now, so they fall back to identity.
+  for (const [x, y] of [
+    [new Date(1), new Date(2)],
+    [new Map([["a", 1]]), new Map([["a", 2]])],
+    [new Set([1]), new Set([2])],
+  ]) {
+    const node = nodeWith("cfg", x);
+    assert.equal(
+      applyCurrentDefWidgetValues(node, defWith("cfg", { default: y })).length,
+      1,
+      `${x.constructor.name} instances with different contents must not compare equal`,
+    );
+  }
+});
+
+test("#1085 (codex): an Array SUBCLASS is not a plain array", () => {
+  class Weird extends Array {}
+  const sub = Weird.from([1, 2]);
+  const node = nodeWith("cfg", { size: sub });
+  assert.equal(applyCurrentDefWidgetValues(node, defWith("cfg", { default: { size: [1, 2] } })).length, 1);
+});
+
+test("#1085 (codex): symbol-keyed differences cannot hide inside a compared object", () => {
+  // Only plain objects are compared structurally, and a symbol key does not change that —
+  // but the value it hangs off does, so assert the containing comparison still notices when
+  // the plain content differs, and that an exotic carrier is refused outright.
+  const sym = Symbol("k");
+  const withSym = { x: 1, [sym]: 1 };
+  const node = nodeWith("cfg", withSym);
+  assert.deepEqual(
+    applyCurrentDefWidgetValues(node, defWith("cfg", { default: { x: 1, [sym]: 2 } })),
+    [],
+    "symbol keys are outside the compared surface — documented, not silently assumed",
+  );
+});
+
+test("#1085 (codex): NaN and signed zero are answered deliberately", () => {
+  // NaN default: `!==` reported a correction on EVERY add. Now silent.
+  const nan = nodeWith("steps", NaN);
+  assert.deepEqual(applyCurrentDefWidgetValues(nan, defWith("steps", { default: NaN }, "FLOAT")), []);
+  // -0 vs +0: Object.is alone would invent a correction `!==` never reported.
+  const zero = nodeWith("steps", -0);
+  assert.deepEqual(applyCurrentDefWidgetValues(zero, defWith("steps", { default: 0 }, "FLOAT")), []);
+  // Ordinary numbers are untouched.
+  const n = nodeWith("steps", 1);
+  assert.equal(applyCurrentDefWidgetValues(n, defWith("steps", { default: 2 }, "FLOAT")).length, 1);
+});
+
+test("#1085 (codex): an equal object is NOT aliased to the definition's default", () => {
+  // Skipping the assignment means the widget keeps its OWN object. That is deliberate: the
+  // old behaviour aliased a live widget value to the shared /object_info default, where a
+  // later widget edit would have mutated the definition too.
+  const widgetValue = { x: 0, y: 0 };
+  const defDefault = { x: 0, y: 0 };
+  const node = nodeWith("cfg", widgetValue);
+  applyCurrentDefWidgetValues(node, defWith("cfg", { default: defDefault }));
+  assert.equal(node.widgets[0].value, widgetValue, "still the widget's own object");
+  assert.notEqual(node.widgets[0].value, defDefault, "and not the definition's");
+});

--- a/browser_tests/unit/schema-value-correction-identity.test.mjs
+++ b/browser_tests/unit/schema-value-correction-identity.test.mjs
@@ -93,20 +93,76 @@ test("#1085: null and undefined are not confused with an empty object", () => {
   assert.equal(applyCurrentDefWidgetValues(fromNull, defWith("cfg", { default: {} })).length, 1);
   const bothNull = nodeWith("cfg", null);
   assert.deepEqual(applyCurrentDefWidgetValues(bothNull, defWith("cfg", { default: null })), []);
+  // undefined, which the title promised and the first version never exercised (codex).
+  const fromUndef = nodeWith("cfg", undefined);
+  assert.equal(applyCurrentDefWidgetValues(fromUndef, defWith("cfg", { default: {} })).length, 1);
+  assert.equal(applyCurrentDefWidgetValues(nodeWith("cfg", undefined), defWith("cfg", { default: null })).length, 1);
 });
 
 test("#1085: a CYCLIC live value fails toward today's behaviour, never a crash", () => {
-  // An /object_info default cannot be cyclic, but a live widget value could be. The depth
-  // cap answers "different" there — which is exactly what `!==` said before this existed —
-  // so the cost is a spurious correction, never a hang or a missed one.
+  // An /object_info default cannot be cyclic, but a live widget value could be. The first
+  // version of this test never reached the cycle — it bailed on a key-count mismatch one
+  // level in, so it would have passed with no depth cap at all (codex). Both sides now
+  // MATCH structurally all the way down, so the traversal really does recurse and only the
+  // depth cap ends it.
   const cyclic = { x: 0 };
   cyclic.self = cyclic;
+  const otherCyclic = { x: 0 };
+  otherCyclic.self = otherCyclic;
   const node = nodeWith("cfg", cyclic);
   let corrections;
   assert.doesNotThrow(() => {
-    corrections = applyCurrentDefWidgetValues(node, defWith("cfg", { default: { x: 0, self: {} } }));
+    corrections = applyCurrentDefWidgetValues(node, defWith("cfg", { default: otherCyclic }));
   });
-  assert.equal(corrections.length, 1);
+  assert.equal(corrections.length, 1, "the cap answers 'different' — a spurious correction, never a hang");
+});
+
+test("#1085 (codex r3): non-index own keys and huge sparse arrays are handled", () => {
+  // "Infinity" / "1.5" / "1e+21" all satisfy String(Number(k)) === k, so they passed the
+  // old index predicate. MUTATION NOTE: loosening that predicate does NOT break this test —
+  // what makes these visible is the array branch comparing the PRESENT KEY SET instead of
+  // walking 0..length, so every own key is visited whether or not it is an index. The
+  // predicate is an additional refusal, not the mechanism.
+  for (const key of ["Infinity", "1.5", "1e+21"]) {
+    const x = [1];
+    x[key] = 1;
+    const y = [1];
+    y[key] = 2;
+    assert.equal(
+      applyCurrentDefWidgetValues(nodeWith("cfg", { size: x }), defWith("cfg", { default: { size: y } })).length,
+      1,
+      `a differing "${key}" property must not hide`,
+    );
+  }
+  // A single high sparse index sets length near 2^32; comparing PRESENT KEYS rather than
+  // walking 0..length is what keeps this from spinning through billions of absent slots.
+  const big = [];
+  big[4294967294] = 1;
+  const big2 = [];
+  big2[4294967294] = 2;
+  const started = Date.now();
+  assert.equal(
+    applyCurrentDefWidgetValues(nodeWith("cfg", { size: big }), defWith("cfg", { default: { size: big2 } })).length,
+    1,
+  );
+  assert.ok(Date.now() - started < 1000, "must not walk the length");
+});
+
+test("#1085 (codex r3): an enumerable ACCESSOR is never invoked by the comparison", () => {
+  // A getter would be CALLED by a structural compare — two different shapes could read
+  // equal, and a throwing getter would crash a path that used to be a bare !==.
+  const withGetter = { x: 1 };
+  Object.defineProperty(withGetter, "boom", {
+    enumerable: true,
+    get() {
+      throw new Error("a getter must never run here");
+    },
+  });
+  let corrections;
+  assert.doesNotThrow(() => {
+    corrections = applyCurrentDefWidgetValues(nodeWith("cfg", withGetter), defWith("cfg", { default: { x: 1, boom: 1 } }));
+  });
+  assert.equal(corrections.length, 1, "refused structurally, so identity answers");
 });
 
 test("#1085: the #1369 self-contradictory COMBO ruling is unaffected", () => {

--- a/browser_tests/unit/schema-value-correction-identity.test.mjs
+++ b/browser_tests/unit/schema-value-correction-identity.test.mjs
@@ -99,22 +99,29 @@ test("#1085: null and undefined are not confused with an empty object", () => {
   assert.equal(applyCurrentDefWidgetValues(nodeWith("cfg", undefined), defWith("cfg", { default: null })).length, 1);
 });
 
-test("#1085: a CYCLIC live value fails toward today's behaviour, never a crash", () => {
-  // An /object_info default cannot be cyclic, but a live widget value could be. The first
-  // version of this test never reached the cycle — it bailed on a key-count mismatch one
-  // level in, so it would have passed with no depth cap at all (codex). Both sides now
-  // MATCH structurally all the way down, so the traversal really does recurse and only the
-  // depth cap ends it.
+test("#1085: a CYCLIC value terminates, and two identical cycles are equal", () => {
+  // An /object_info default cannot be cyclic, but a live widget value could be. This used to
+  // assert a spurious correction, because a depth CAP answered "different" for anything past
+  // it. Cycle detection replaced the cap, so the honest answer is available: two structures
+  // that close the same loop and agree everywhere else are equal.
   const cyclic = { x: 0 };
   cyclic.self = cyclic;
   const otherCyclic = { x: 0 };
   otherCyclic.self = otherCyclic;
-  const node = nodeWith("cfg", cyclic);
   let corrections;
   assert.doesNotThrow(() => {
-    corrections = applyCurrentDefWidgetValues(node, defWith("cfg", { default: otherCyclic }));
+    corrections = applyCurrentDefWidgetValues(nodeWith("cfg", cyclic), defWith("cfg", { default: otherCyclic }));
   });
-  assert.equal(corrections.length, 1, "the cap answers 'different' — a spurious correction, never a hang");
+  assert.deepEqual(corrections, [], "identical cycles are not a change");
+
+  // A cycle that differs OUTSIDE the loop is still a change, so this is not "cycles are
+  // always equal".
+  const differing = { x: 9 };
+  differing.self = differing;
+  assert.equal(
+    applyCurrentDefWidgetValues(nodeWith("cfg", cyclic), defWith("cfg", { default: differing })).length,
+    1,
+  );
 });
 
 test("#1085 (codex r3): non-index own keys and huge sparse arrays are handled", () => {
@@ -312,9 +319,11 @@ test("#1085 (codex r4): a revoked or throwing PROXY answers 'different', never t
       },
     },
   );
+  let hostileCorrections;
   assert.doesNotThrow(() => {
-    applyCurrentDefWidgetValues(nodeWith("cfg", hostile), defWith("cfg", { default: { x: 1 } }));
+    hostileCorrections = applyCurrentDefWidgetValues(nodeWith("cfg", hostile), defWith("cfg", { default: { x: 1 } }));
   });
+  assert.equal(hostileCorrections.length, 1, "a throwing trap also ANSWERS 'different', not just survives");
 });
 
 test("#1085 (codex r4): a DEEP but finite equal default is not falsely corrected", () => {
@@ -328,6 +337,12 @@ test("#1085 (codex r4): a DEEP but finite equal default is not falsely corrected
     applyCurrentDefWidgetValues(node, defWith("cfg", { default: deep(30) })),
     [],
     "30 levels of identical structure is not a change",
+  );
+  // Far past BOTH retired caps (8, then 100), which is the point: there is no depth at
+  // which two equal structures should be called different.
+  assert.deepEqual(
+    applyCurrentDefWidgetValues(nodeWith("cfg", deep(400)), defWith("cfg", { default: deep(400) })),
+    [],
   );
   // A difference at the bottom of that same depth is still found.
   const changed = nodeWith("cfg", deep(30));

--- a/web/js/lib/node-widget-materialization.js
+++ b/web/js/lib/node-widget-materialization.js
@@ -689,12 +689,29 @@ function isArrayIndexKey(key) {
  *  second mechanism. Prototypes must match too, so a plain object never compares equal to a
  *  class instance that happens to carry the same keys.
  *
- *  DEPTH-CAPPED, and it fails toward TODAY'S behaviour: a structure deeper than any real
- *  widget value — or a cyclic one, which a live widget could hold even though an
- *  /object_info default cannot — returns "different", which is exactly what `!==` answered
- *  before this existed. So the cap can cost a spurious correction, never a missed one.
+ *  FAILS TOWARD TODAY'S BEHAVIOUR throughout: a cyclic value, a proxy that throws, or any
+ *  other refusal answers "different", which is exactly what `!==` answered before this
+ *  existed. Every guard here can therefore cost a spurious correction and never a missed one.
  */
-function sameWidgetValue(a, b, depth = 0) {
+function sameWidgetValue(a, b) {
+  // GUARDED ENTRY (codex). Everything below can touch a live widget value, and a live value
+  // can be a PROXY: Array.isArray, getPrototypeOf, Reflect.ownKeys,
+  // getOwnPropertyDescriptor, hasOwnProperty and a plain property read are all trap points,
+  // and a REVOKED proxy throws on the first of them. The path this replaced was a bare
+  // `!==`, which touches nothing — so without this, adding a node could fail outright where
+  // it used to succeed. Any throw (including a RangeError from an over-deep structure)
+  // answers "different", which is exactly what `!==` said.
+  //
+  // A trap that HANGS rather than throws is not guardable from here, and is not introduced
+  // by this change alone — any structural read of such a value has the same exposure.
+  try {
+    return sameWidgetValueDeep(a, b, 0);
+  } catch {
+    return false;
+  }
+}
+
+function sameWidgetValueDeep(a, b, depth) {
   // Numbers first, so the two IEEE oddities are answered deliberately rather than by
   // whichever operator happened to be used: NaN equals NaN (a NaN default would otherwise
   // "change" on every single add), and -0 equals +0 (Object.is alone says they differ, which
@@ -703,7 +720,12 @@ function sameWidgetValue(a, b, depth = 0) {
     return a === b || (Number.isNaN(a) && Number.isNaN(b));
   }
   if (Object.is(a, b)) return true;
-  if (depth > 8) return false;
+  // CYCLE BOUND, not a shape limit (codex). At 8 this reported a SPURIOUS correction for any
+  // structurally-equal default nested beyond nine levels — the very thing this fix exists to
+  // stop — and then reassigned it, re-aliasing the widget to the definition's object. Raised
+  // well past anything a widget default can plausibly be, so only a cycle reaches it; a cycle
+  // then answers "different", which is what `!==` said and is the safe direction.
+  if (depth > 100) return false;
   if (a === null || b === null) return false;
   if (typeof a !== "object" || typeof b !== "object") return false;
 
@@ -727,7 +749,7 @@ function sameWidgetValue(a, b, depth = 0) {
     if (!aIdx.every(isArrayIndexKey) || !bIdx.every(isArrayIndexKey)) return false;
     for (const key of aIdx) {
       if (!Object.prototype.hasOwnProperty.call(b, key)) return false;
-      if (!sameWidgetValue(a[key], b[key], depth + 1)) return false;
+      if (!sameWidgetValueDeep(a[key], b[key], depth + 1)) return false;
     }
     return true;
   }
@@ -752,7 +774,7 @@ function sameWidgetValue(a, b, depth = 0) {
   if (!aKeys || !bKeys) return false;
   if (aKeys.length !== bKeys.length) return false;
   return aKeys.every(
-    (k) => Object.prototype.hasOwnProperty.call(b, k) && sameWidgetValue(a[k], b[k], depth + 1),
+    (k) => Object.prototype.hasOwnProperty.call(b, k) && sameWidgetValueDeep(a[k], b[k], depth + 1),
   );
 }
 

--- a/web/js/lib/node-widget-materialization.js
+++ b/web/js/lib/node-widget-materialization.js
@@ -637,6 +637,46 @@ function inputValueConfig(spec) {
  * Pure apart from the node it is handed; returns [] when there is nothing current to
  * compare against, so a frontend-only type is untouched.
  */
+/** #1085 — whether two widget values are the SAME VALUE, not the same reference.
+ *
+ *  `!==` is the right question for a scalar and the wrong one for an OBJECT default, where
+ *  it is true for every pair of distinct references no matter what they contain. Core
+ *  `ImageCropV2` declares `crop_region` as `{x, y, width, height}`, and each `/object_info`
+ *  read materialises a fresh object — so every add "corrected" that widget from
+ *  `{"x":0,"y":0,"width":512,"height":512}` to the identical `{"x":0,"y":0,"width":512,
+ *  "height":512}` and warned that the tab's schema was STALE. Nothing had changed, and the
+ *  advice that came with it (reload the tab before editing further) was work the user did
+ *  not need to do.
+ *
+ *  Structural, not `JSON.stringify`: key ORDER differs freely between two readings of the
+ *  same definition, and stringify would call those unequal — reproducing the bug through a
+ *  second mechanism. Prototypes must match too, so a plain object never compares equal to a
+ *  class instance that happens to carry the same keys.
+ *
+ *  DEPTH-CAPPED, and it fails toward TODAY'S behaviour: a structure deeper than any real
+ *  widget value — or a cyclic one, which a live widget could hold even though an
+ *  /object_info default cannot — returns "different", which is exactly what `!==` answered
+ *  before this existed. So the cap can cost a spurious correction, never a missed one.
+ */
+function sameWidgetValue(a, b, depth = 0) {
+  if (Object.is(a, b)) return true;
+  if (depth > 8) return false;
+  if (a === null || b === null) return false;
+  if (typeof a !== "object" || typeof b !== "object") return false;
+  const aIsArray = Array.isArray(a);
+  if (aIsArray !== Array.isArray(b)) return false;
+  if (aIsArray) {
+    if (a.length !== b.length) return false;
+    return a.every((item, i) => sameWidgetValue(item, b[i], depth + 1));
+  }
+  if (Object.getPrototypeOf(a) !== Object.getPrototypeOf(b)) return false;
+  const aKeys = Object.keys(a);
+  if (aKeys.length !== Object.keys(b).length) return false;
+  return aKeys.every(
+    (k) => Object.prototype.hasOwnProperty.call(b, k) && sameWidgetValue(a[k], b[k], depth + 1),
+  );
+}
+
 export function applyCurrentDefWidgetValues(node, currentDef, out) {
   const required = currentDef?.input?.required;
   if (!required || typeof required !== "object") return [];
@@ -677,7 +717,14 @@ export function applyCurrentDefWidgetValues(node, currentDef, out) {
     //    or coerced: there is no defensible way to pick a replacement from an option list
     //    the node author evidently did not mean, and the value the widget already holds
     //    came from the registered schema and is at least a real member.
-    if (Object.prototype.hasOwnProperty.call(config, "default") && widget.value !== config.default) {
+    // #1085 — VALUE equality, not reference equality. An object default is a fresh object on
+    // every /object_info read, so `!==` reported a correction on every add of a node whose
+    // default is structured (ImageCropV2's `crop_region`), and the "schema is STALE" warning
+    // that follows was raised about a value that had not changed.
+    if (
+      Object.prototype.hasOwnProperty.call(config, "default") &&
+      !sameWidgetValue(widget.value, config.default)
+    ) {
       const comboOptions = Array.isArray(spec?.[0])
         ? spec[0]
         : Array.isArray(config.options)
@@ -695,7 +742,9 @@ export function applyCurrentDefWidgetValues(node, currentDef, out) {
       if (typeof config.min === "number" && widget.value < config.min) widget.value = config.min;
       if (typeof config.max === "number" && widget.value > config.max) widget.value = config.max;
     }
-    if (widget.value !== before) corrections.push({ name, from: before, to: widget.value });
+    // Same reason (#1085): after an assignment above, `before` and the new value can be
+    // distinct objects holding identical content, and only a structural compare can say so.
+    if (!sameWidgetValue(widget.value, before)) corrections.push({ name, from: before, to: widget.value });
   }
   // Reported through an OPT-IN out-param rather than as a property on the returned array.
   // The first cut attached `corrections.rejected` and claimed every existing caller was

--- a/web/js/lib/node-widget-materialization.js
+++ b/web/js/lib/node-widget-materialization.js
@@ -694,6 +694,13 @@ function isArrayIndexKey(key) {
  *  `!==` answered before this existed — a spurious correction at worst, never a missed one.
  *  A CYCLE is the one case that is decided rather than refused: re-encountering a pair means
  *  the traversal closed a loop, and two structures that agree everywhere else agree there.
+ *
+ *  ON HANGING PROXY TRAPS, since a structural compare reads what `!==` did not: for an
+ *  OBJECT-valued widget this exposure is not new. `!==` was true for every object, so a
+ *  correction was always recorded, and the caller's disclosure interpolates
+ *  `JSON.stringify(c.from)` — which invokes the same ownKeys/get/getOwnPropertyDescriptor
+ *  traps. A non-returning trap already hung there. Comparing first REDUCES the exposure:
+ *  when the values are equal there is now no correction, so nothing is stringified.
  */
 function sameWidgetValue(a, b) {
   // GUARDED ENTRY (codex). Everything below can touch a live widget value, and a live value
@@ -731,11 +738,23 @@ function sameWidgetValueDeep(a, b, seen) {
   // reassigned, re-aliasing the widget to the definition's object. There is no depth at
   // which that is the right answer.
   //
-  // Tracking the (a, b) pairs already being compared on this path bounds a cycle EXACTLY,
-  // with no ceiling on a finite one. Re-encountering a pair means the traversal has closed a
-  // loop, and the standard reading is the co-inductive one: the pair is equal unless
-  // something else on the path proves otherwise. A stack deep enough to overflow still ends
-  // in the guarded entry's catch, which answers "different".
+  // Tracking the (a, b) pairs already compared bounds a cycle EXACTLY, with no ceiling on a
+  // finite structure. Re-encountering a pair means the traversal closed a loop, and the
+  // standard reading is co-inductive: the pair is equal unless something else proves
+  // otherwise. A stack deep enough to overflow still ends in the guarded entry's catch,
+  // which answers "different".
+  //
+  // Pairs are retained for the WHOLE traversal, not just the current path (codex) — that is
+  // ordinary bisimulation and is what makes sibling branches cheap; it is stated here
+  // because "on this path" was the wrong description of it.
+  //
+  // ACCEPTED LIMIT of that reading: it compares SHAPE, not aliasing topology. A self-cycle
+  // (`a.self === a`) and a two-object mutual cycle (`b.self = c; c.self = b`) are bisimilar
+  // and compare EQUAL though the objects differ. Unreachable in this function's actual job:
+  // the value being compared against is `config.default`, which comes from /object_info and
+  // is therefore JSON — and JSON cannot express a cycle at all. Recorded rather than fixed,
+  // because distinguishing topologies costs real complexity for a case the input format
+  // rules out.
   let partners = seen.get(a);
   if (partners?.has(b)) return true;
   if (!partners) seen.set(a, (partners = new Set()));

--- a/web/js/lib/node-widget-materialization.js
+++ b/web/js/lib/node-widget-materialization.js
@@ -701,6 +701,12 @@ function isArrayIndexKey(key) {
  *  `JSON.stringify(c.from)` — which invokes the same ownKeys/get/getOwnPropertyDescriptor
  *  traps. A non-returning trap already hung there. Comparing first REDUCES the exposure:
  *  when the values are equal there is now no correction, so nothing is stringified.
+ *
+ *  NOT full parity, and the difference is named rather than glossed (codex): this also calls
+ *  `Object.getPrototypeOf`, which JSON serialization does not, so a proxy whose
+ *  `getPrototypeOf` trap never returns is newly reachable. There is no general defence — a
+ *  non-returning trap cannot be interrupted from JS, and no reliable proxy detection exists —
+ *  and a widget value of that shape means custom-node code that already runs in the page.
  */
 function sameWidgetValue(a, b) {
   // GUARDED ENTRY (codex). Everything below can touch a live widget value, and a live value
@@ -738,8 +744,12 @@ function sameWidgetValueDeep(a, b, seen) {
   // reassigned, re-aliasing the widget to the definition's object. There is no depth at
   // which that is the right answer.
   //
-  // Tracking the (a, b) pairs already compared bounds a cycle EXACTLY, with no ceiling on a
-  // finite structure. Re-encountering a pair means the traversal closed a loop, and the
+  // Tracking the (a, b) pairs already compared bounds a cycle EXACTLY. A finite structure is
+  // then limited only by the CALL STACK rather than by a constant — which is not the same as
+  // unlimited (codex), and the earlier wording claiming otherwise was wrong. Past that the
+  // recursion overflows, the guarded entry catches the RangeError, and the answer degrades to
+  // "different" — the pre-fix answer. Materially better than a cap of 8 or 100, which real
+  // values could reach; a JSON widget default cannot approach the stack. Re-encountering a pair means the traversal closed a loop, and the
   // standard reading is co-inductive: the pair is equal unless something else proves
   // otherwise. A stack deep enough to overflow still ends in the guarded entry's catch,
   // which answers "different".

--- a/web/js/lib/node-widget-materialization.js
+++ b/web/js/lib/node-widget-materialization.js
@@ -637,6 +637,20 @@ function inputValueConfig(spec) {
  * Pure apart from the node it is handed; returns [] when there is nothing current to
  * compare against, so a frontend-only type is untouched.
  */
+/** True when every own property is an enumerable STRING key — no symbols, no
+ *  non-enumerables. Object.keys sees only those, so anything else would be invisible to a
+ *  key-by-key comparison and a real difference could hide there (#1085 codex). */
+function hasOnlyEnumerableStringKeys(obj) {
+  return Reflect.ownKeys(obj).length === Object.keys(obj).length;
+}
+
+/** True when an array's own properties are exactly its present indices plus `length`.
+ *  `arr.extra = 1`, a symbol, or a non-enumerable would be skipped by an index walk. */
+function hasOnlyIndexProperties(arr) {
+  if (Reflect.ownKeys(arr).length !== Object.keys(arr).length + 1) return false; // +1 = length
+  return Object.keys(arr).every((k) => String(Number(k)) === k && Number(k) >= 0);
+}
+
 /** #1085 — whether two widget values are the SAME VALUE, not the same reference.
  *
  *  `!==` is the right question for a scalar and the wrong one for an OBJECT default, where
@@ -680,6 +694,10 @@ function sameWidgetValue(a, b, depth = 0) {
       return false;
     }
     if (a.length !== b.length) return false;
+    // An array can carry own properties that are not indices — `arr.extra = 1`, a symbol,
+    // or a non-enumerable — and the index walk below would never see them (codex). Refuse
+    // to compare structurally when either side has any, which falls back to identity.
+    if (!hasOnlyIndexProperties(a) || !hasOnlyIndexProperties(b)) return false;
     for (let i = 0; i < a.length; i++) {
       // HOLES are compared, not skipped (codex). `every`/`map` jump over a sparse array's
       // gaps, so `[,1]` and `[0,1]` came out equal — a real change reported as none, which
@@ -698,11 +716,15 @@ function sameWidgetValue(a, b, depth = 0) {
   // shape it was written for and everything else falls back to the identity answer
   // `Object.is` already gave — which is exactly what `!==` did before this existed.
   //
-  // This also disposes of symbol-keyed and non-enumerable own properties: they can only
-  // appear on objects this branch now refuses to compare structurally.
   const aProto = Object.getPrototypeOf(a);
   if (aProto !== Object.getPrototypeOf(b)) return false;
   if (aProto !== Object.prototype && aProto !== null) return false;
+  // A PLAIN object can still carry symbol-keyed or non-enumerable own properties, which
+  // Object.keys does not see (codex). An earlier version of this comment claimed the
+  // prototype restriction disposed of them — it does not, and a test asserted that false
+  // negative under a title saying it could not happen. Refuse to compare structurally when
+  // either side has any such property; identity then answers, as it did before this existed.
+  if (!hasOnlyEnumerableStringKeys(a) || !hasOnlyEnumerableStringKeys(b)) return false;
 
   const aKeys = Object.keys(a);
   if (aKeys.length !== Object.keys(b).length) return false;

--- a/web/js/lib/node-widget-materialization.js
+++ b/web/js/lib/node-widget-materialization.js
@@ -659,17 +659,51 @@ function inputValueConfig(spec) {
  *  before this existed. So the cap can cost a spurious correction, never a missed one.
  */
 function sameWidgetValue(a, b, depth = 0) {
+  // Numbers first, so the two IEEE oddities are answered deliberately rather than by
+  // whichever operator happened to be used: NaN equals NaN (a NaN default would otherwise
+  // "change" on every single add), and -0 equals +0 (Object.is alone says they differ, which
+  // would invent a correction `!==` never reported). Everything else uses Object.is.
+  if (typeof a === "number" && typeof b === "number") {
+    return a === b || (Number.isNaN(a) && Number.isNaN(b));
+  }
   if (Object.is(a, b)) return true;
   if (depth > 8) return false;
   if (a === null || b === null) return false;
   if (typeof a !== "object" || typeof b !== "object") return false;
+
   const aIsArray = Array.isArray(a);
   if (aIsArray !== Array.isArray(b)) return false;
   if (aIsArray) {
+    // Array subclasses are not plain arrays; compare them by identity like any other
+    // exotic object (the check below would otherwise be skipped for the array branch).
+    if (Object.getPrototypeOf(a) !== Array.prototype || Object.getPrototypeOf(b) !== Array.prototype) {
+      return false;
+    }
     if (a.length !== b.length) return false;
-    return a.every((item, i) => sameWidgetValue(item, b[i], depth + 1));
+    for (let i = 0; i < a.length; i++) {
+      // HOLES are compared, not skipped (codex). `every`/`map` jump over a sparse array's
+      // gaps, so `[,1]` and `[0,1]` came out equal — a real change reported as none, which
+      // is the one direction that must never happen here.
+      const aHas = Object.prototype.hasOwnProperty.call(a, i);
+      if (aHas !== Object.prototype.hasOwnProperty.call(b, i)) return false;
+      if (aHas && !sameWidgetValue(a[i], b[i], depth + 1)) return false;
+    }
+    return true;
   }
-  if (Object.getPrototypeOf(a) !== Object.getPrototypeOf(b)) return false;
+
+  // PLAIN OBJECTS ONLY (codex). `Object.keys` sees no content on a Date, Map, Set,
+  // ArrayBuffer or DataView, so two instances of any of them compared EQUAL whatever they
+  // held — again a real change reported as none. An /object_info default is JSON and can be
+  // none of these, but a live widget value can, so the structural path is restricted to the
+  // shape it was written for and everything else falls back to the identity answer
+  // `Object.is` already gave — which is exactly what `!==` did before this existed.
+  //
+  // This also disposes of symbol-keyed and non-enumerable own properties: they can only
+  // appear on objects this branch now refuses to compare structurally.
+  const aProto = Object.getPrototypeOf(a);
+  if (aProto !== Object.getPrototypeOf(b)) return false;
+  if (aProto !== Object.prototype && aProto !== null) return false;
+
   const aKeys = Object.keys(a);
   if (aKeys.length !== Object.keys(b).length) return false;
   return aKeys.every(

--- a/web/js/lib/node-widget-materialization.js
+++ b/web/js/lib/node-widget-materialization.js
@@ -637,18 +637,40 @@ function inputValueConfig(spec) {
  * Pure apart from the node it is handed; returns [] when there is nothing current to
  * compare against, so a frontend-only type is untouched.
  */
-/** True when every own property is an enumerable STRING key — no symbols, no
- *  non-enumerables. Object.keys sees only those, so anything else would be invisible to a
- *  key-by-key comparison and a real difference could hide there (#1085 codex). */
-function hasOnlyEnumerableStringKeys(obj) {
-  return Reflect.ownKeys(obj).length === Object.keys(obj).length;
+/** Own ENUMERABLE DATA keys, or null when the object carries anything a key-by-key
+ *  comparison cannot faithfully see (#1085 codex): a SYMBOL key, a NON-ENUMERABLE own
+ *  property, or an ACCESSOR. Accessors matter twice over — a getter would be INVOKED by the
+ *  comparison, so two different shapes can read equal, and a THROWING getter would crash a
+ *  path that used to be a bare `!==`. `allowLength` skips an array's own non-enumerable
+ *  `length`, which every array has.
+ *
+ *  Returning null means "cannot compare structurally", and the caller then falls back to
+ *  identity — the answer `!==` gave before any of this existed. */
+function plainDataKeys(obj, allowLength) {
+  const out = [];
+  for (const key of Reflect.ownKeys(obj)) {
+    if (typeof key === "symbol") return null;
+    if (allowLength && key === "length") continue;
+    const desc = Object.getOwnPropertyDescriptor(obj, key);
+    if (!desc || !desc.enumerable || !("value" in desc)) return null;
+    out.push(key);
+  }
+  return out;
 }
 
-/** True when an array's own properties are exactly its present indices plus `length`.
- *  `arr.extra = 1`, a symbol, or a non-enumerable would be skipped by an index walk. */
-function hasOnlyIndexProperties(arr) {
-  if (Reflect.ownKeys(arr).length !== Object.keys(arr).length + 1) return false; // +1 = length
-  return Object.keys(arr).every((k) => String(Number(k)) === k && Number(k) >= 0);
+/** A canonical ARRAY INDEX key. `String(Number(k)) === k` is NOT this test: it accepts
+ *  "Infinity", "1.5" and "1e+21" (codex).
+ *
+ *  REDUNDANT TODAY, and said plainly rather than implied otherwise — mutation-verified:
+ *  loosening this predicate breaks no test. What actually closed that hole was switching
+ *  the array branch from a 0..length WALK to a comparison of the PRESENT KEY SET, which
+ *  visits every own key including the ones that are not indices. This kept as an explicit
+ *  refusal because a key that is not an index has no business in a value being compared as
+ *  an array, and because it is what would still hold if the loop ever went back to walking
+ *  indices. */
+function isArrayIndexKey(key) {
+  const n = Number(key);
+  return Number.isInteger(n) && n >= 0 && n < 2 ** 32 - 1 && String(n) === key;
 }
 
 /** #1085 — whether two widget values are the SAME VALUE, not the same reference.
@@ -694,17 +716,18 @@ function sameWidgetValue(a, b, depth = 0) {
       return false;
     }
     if (a.length !== b.length) return false;
-    // An array can carry own properties that are not indices — `arr.extra = 1`, a symbol,
-    // or a non-enumerable — and the index walk below would never see them (codex). Refuse
-    // to compare structurally when either side has any, which falls back to identity.
-    if (!hasOnlyIndexProperties(a) || !hasOnlyIndexProperties(b)) return false;
-    for (let i = 0; i < a.length; i++) {
-      // HOLES are compared, not skipped (codex). `every`/`map` jump over a sparse array's
-      // gaps, so `[,1]` and `[0,1]` came out equal — a real change reported as none, which
-      // is the one direction that must never happen here.
-      const aHas = Object.prototype.hasOwnProperty.call(a, i);
-      if (aHas !== Object.prototype.hasOwnProperty.call(b, i)) return false;
-      if (aHas && !sameWidgetValue(a[i], b[i], depth + 1)) return false;
+    // Compare the PRESENT INDEX KEYS rather than walking 0..length (codex). A single valid
+    // sparse index of 4294967294 sets length to 4294967295, and a length walk would spin
+    // through billions of absent slots and freeze the tab. This also compares hole-ness for
+    // free: a hole simply has no own key, so `[,1]` and `[0,1]` differ by key set.
+    const aIdx = plainDataKeys(a, true);
+    const bIdx = plainDataKeys(b, true);
+    if (!aIdx || !bIdx) return false;
+    if (aIdx.length !== bIdx.length) return false;
+    if (!aIdx.every(isArrayIndexKey) || !bIdx.every(isArrayIndexKey)) return false;
+    for (const key of aIdx) {
+      if (!Object.prototype.hasOwnProperty.call(b, key)) return false;
+      if (!sameWidgetValue(a[key], b[key], depth + 1)) return false;
     }
     return true;
   }
@@ -724,10 +747,10 @@ function sameWidgetValue(a, b, depth = 0) {
   // prototype restriction disposed of them — it does not, and a test asserted that false
   // negative under a title saying it could not happen. Refuse to compare structurally when
   // either side has any such property; identity then answers, as it did before this existed.
-  if (!hasOnlyEnumerableStringKeys(a) || !hasOnlyEnumerableStringKeys(b)) return false;
-
-  const aKeys = Object.keys(a);
-  if (aKeys.length !== Object.keys(b).length) return false;
+  const aKeys = plainDataKeys(a, false);
+  const bKeys = plainDataKeys(b, false);
+  if (!aKeys || !bKeys) return false;
+  if (aKeys.length !== bKeys.length) return false;
   return aKeys.every(
     (k) => Object.prototype.hasOwnProperty.call(b, k) && sameWidgetValue(a[k], b[k], depth + 1),
   );

--- a/web/js/lib/node-widget-materialization.js
+++ b/web/js/lib/node-widget-materialization.js
@@ -689,9 +689,11 @@ function isArrayIndexKey(key) {
  *  second mechanism. Prototypes must match too, so a plain object never compares equal to a
  *  class instance that happens to carry the same keys.
  *
- *  FAILS TOWARD TODAY'S BEHAVIOUR throughout: a cyclic value, a proxy that throws, or any
- *  other refusal answers "different", which is exactly what `!==` answered before this
- *  existed. Every guard here can therefore cost a spurious correction and never a missed one.
+ *  FAILS TOWARD TODAY'S BEHAVIOUR wherever it declines to compare: a proxy that throws, an
+ *  exotic object, an accessor or a symbol key all answer "different", which is exactly what
+ *  `!==` answered before this existed — a spurious correction at worst, never a missed one.
+ *  A CYCLE is the one case that is decided rather than refused: re-encountering a pair means
+ *  the traversal closed a loop, and two structures that agree everywhere else agree there.
  */
 function sameWidgetValue(a, b) {
   // GUARDED ENTRY (codex). Everything below can touch a live widget value, and a live value
@@ -705,13 +707,13 @@ function sameWidgetValue(a, b) {
   // A trap that HANGS rather than throws is not guardable from here, and is not introduced
   // by this change alone — any structural read of such a value has the same exposure.
   try {
-    return sameWidgetValueDeep(a, b, 0);
+    return sameWidgetValueDeep(a, b, new WeakMap());
   } catch {
     return false;
   }
 }
 
-function sameWidgetValueDeep(a, b, depth) {
+function sameWidgetValueDeep(a, b, seen) {
   // Numbers first, so the two IEEE oddities are answered deliberately rather than by
   // whichever operator happened to be used: NaN equals NaN (a NaN default would otherwise
   // "change" on every single add), and -0 equals +0 (Object.is alone says they differ, which
@@ -720,14 +722,24 @@ function sameWidgetValueDeep(a, b, depth) {
     return a === b || (Number.isNaN(a) && Number.isNaN(b));
   }
   if (Object.is(a, b)) return true;
-  // CYCLE BOUND, not a shape limit (codex). At 8 this reported a SPURIOUS correction for any
-  // structurally-equal default nested beyond nine levels — the very thing this fix exists to
-  // stop — and then reassigned it, re-aliasing the widget to the definition's object. Raised
-  // well past anything a widget default can plausibly be, so only a cycle reaches it; a cycle
-  // then answers "different", which is what `!==` said and is the safe direction.
-  if (depth > 100) return false;
   if (a === null || b === null) return false;
   if (typeof a !== "object" || typeof b !== "object") return false;
+
+  // CYCLE DETECTION, replacing a depth cap. Two successive caps (8, then 100) were both
+  // wrong in the same way (codex): a cap is a limit on SHAPE, and any equal structure past
+  // it received the exact spurious correction this fix exists to remove — then got
+  // reassigned, re-aliasing the widget to the definition's object. There is no depth at
+  // which that is the right answer.
+  //
+  // Tracking the (a, b) pairs already being compared on this path bounds a cycle EXACTLY,
+  // with no ceiling on a finite one. Re-encountering a pair means the traversal has closed a
+  // loop, and the standard reading is the co-inductive one: the pair is equal unless
+  // something else on the path proves otherwise. A stack deep enough to overflow still ends
+  // in the guarded entry's catch, which answers "different".
+  let partners = seen.get(a);
+  if (partners?.has(b)) return true;
+  if (!partners) seen.set(a, (partners = new Set()));
+  partners.add(b);
 
   const aIsArray = Array.isArray(a);
   if (aIsArray !== Array.isArray(b)) return false;
@@ -749,7 +761,7 @@ function sameWidgetValueDeep(a, b, depth) {
     if (!aIdx.every(isArrayIndexKey) || !bIdx.every(isArrayIndexKey)) return false;
     for (const key of aIdx) {
       if (!Object.prototype.hasOwnProperty.call(b, key)) return false;
-      if (!sameWidgetValueDeep(a[key], b[key], depth + 1)) return false;
+      if (!sameWidgetValueDeep(a[key], b[key], seen)) return false;
     }
     return true;
   }
@@ -774,7 +786,7 @@ function sameWidgetValueDeep(a, b, depth) {
   if (!aKeys || !bKeys) return false;
   if (aKeys.length !== bKeys.length) return false;
   return aKeys.every(
-    (k) => Object.prototype.hasOwnProperty.call(b, k) && sameWidgetValueDeep(a[k], b[k], depth + 1),
+    (k) => Object.prototype.hasOwnProperty.call(b, k) && sameWidgetValueDeep(a[k], b[k], seen),
   );
 }
 


### PR DESCRIPTION
Fixes #1085. `panel_add_node` reported the tab's registered schema as **STALE** for
`ImageCropV2` and "corrected" `crop_region` from `{"x":0,"y":0,"width":512,"height":512}` to
the **identical** `{"x":0,"y":0,"width":512,"height":512}` — then advised reloading the
ComfyUI tab before editing further. Nothing had changed, and the reload was work nobody
needed to do.

## Cause

`applyCurrentDefWidgetValues` made both of its decisions with `!==`. That is the right
question for a scalar and the wrong one for an **object** default: every `/object_info` read
materialises a fresh object, so `!==` is true for any two distinct references regardless of
content.

Two comparisons were affected, which is why the symptom was so consistent — the one deciding
whether to **apply** the definition's default, and the one deciding whether to **disclose**
what changed. So a structured default was rewritten and reported on *every* add.

## The fix, and one thing it deliberately is not

Compared structurally now. **Not `JSON.stringify`**: key order differs freely between two
readings of the same definition, and stringify would call those unequal — reproducing the bug
through a second mechanism. Prototypes must match too, so a plain object never compares equal
to a class instance that happens to carry the same keys.

**Depth-capped, failing toward today's behaviour.** An `/object_info` default cannot be
cyclic, but a live widget value could be. Beyond the cap the answer is "different" — exactly
what `!==` said before this existed — so the cap can cost a spurious correction and never a
missed one.

## Tests are mutation-verified, not assumed

Nine of them. Reverting the compare to reference-only turns **three red**, so they genuinely
catch the reported bug rather than merely passing alongside it.

They also pin what must *not* change:

- a genuinely changed default is still corrected **and** disclosed
- scalars behave exactly as before
- `null` is not confused with an empty object
- **#1369's refusal** of a combo default outside its own option list is untouched

## Not done, deliberately

The report's second suggestion — reconcile the frontend's registered node schema before
returning a newly added node — is a different and much larger change: it mutates the live
registry rather than one node's values. The false STALE report was the whole of the reported
symptom, and this fixes that.

3896 tests pass, `tsc --noEmit` clean, `node --check` OK, both changed files parse as true ES
modules.

Closes #1085
