### PR TITLE
fix(983): refuse a write to rgthree's Fast Groups toggle — it is a derived readout

### DIFF
--- a/browser_tests/unit/rgthree-fast-groups.test.mjs
+++ b/browser_tests/unit/rgthree-fast-groups.test.mjs
@@ -1,0 +1,75 @@
+/**
+ * #983 — a write to rgthree's Fast Groups toggle row is refused, because it cannot land.
+ *
+ * Established from the pack's own source (rgthree-comfy `src_web/comfyui/`), not from the
+ * report: `BaseFastGroupsModeChanger` declares `serialize_widgets = false` (so the value never
+ * reaches the workflow), the node's refresh loop overwrites `widget.toggled` from
+ * `group.rgthree_hasAnyActiveNode` (so it is a readout), and only the widget's own `toggle()`
+ * changes anything because it also calls `doModeChange()` (so a raw assignment does nothing).
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  classifyRgthreeFastGroupsWrite,
+  rgthreeFastGroupsRefusal,
+  RGTHREE_TOGGLE_WIDGET,
+} from "../../web/js/lib/rgthree-fast-groups.js";
+
+const BYPASSER = "Fast Groups Bypasser (rgthree)";
+const MUTER = "Fast Groups Muter (rgthree)";
+
+test("#983: the reported write is classified derived", () => {
+  // The exact address from the report, including the composite sub-field.
+  assert.equal(
+    classifyRgthreeFastGroupsWrite({ type: BYPASSER }, "RGTHREE_TOGGLE_AND_NAV.toggled"),
+    "derived",
+  );
+  // And the bare widget name, which addresses the same widget.
+  assert.equal(classifyRgthreeFastGroupsWrite({ type: BYPASSER }, RGTHREE_TOGGLE_WIDGET), "derived");
+});
+
+test("#983: the Muter is covered too — it is the same base class", () => {
+  // FastGroupsBypasser extends BaseFastGroupsModeChanger, which is where serialize_widgets =
+  // false and the refresh-overwrite live, so both node types have the identical problem.
+  assert.equal(classifyRgthreeFastGroupsWrite({ type: MUTER }, "RGTHREE_TOGGLE_AND_NAV.toggled"), "derived");
+});
+
+test("#983: ANOTHER widget on the same node is NOT refused", () => {
+  // Keyed on type AND widget name. The type alone would refuse a legitimate write to some
+  // other widget these nodes carry or later gain.
+  assert.equal(classifyRgthreeFastGroupsWrite({ type: BYPASSER }, "matchTitle"), null);
+  assert.equal(classifyRgthreeFastGroupsWrite({ type: BYPASSER }, "matchColors"), null);
+});
+
+test("#983: the SAME widget name on an unrelated node is NOT refused", () => {
+  // The widget name alone would refuse it anywhere the name is reused.
+  assert.equal(classifyRgthreeFastGroupsWrite({ type: "KSampler" }, "RGTHREE_TOGGLE_AND_NAV.toggled"), null);
+  assert.equal(classifyRgthreeFastGroupsWrite({ type: "SomeOtherPackNode" }, RGTHREE_TOGGLE_WIDGET), null);
+});
+
+test("#983: a name that merely STARTS with the widget name is not it", () => {
+  // Splitting on the first dot must not turn a different widget into this one.
+  assert.equal(classifyRgthreeFastGroupsWrite({ type: BYPASSER }, "RGTHREE_TOGGLE_AND_NAV_EXTRA"), null);
+  assert.equal(classifyRgthreeFastGroupsWrite({ type: BYPASSER }, "prefix_RGTHREE_TOGGLE_AND_NAV"), null);
+});
+
+test("#983: malformed input never throws and never classifies", () => {
+  for (const node of [null, undefined, {}, { type: 42 }, "nope"]) {
+    assert.equal(classifyRgthreeFastGroupsWrite(node, "RGTHREE_TOGGLE_AND_NAV.toggled"), null);
+  }
+  for (const w of [null, undefined, 42, {}]) {
+    assert.equal(classifyRgthreeFastGroupsWrite({ type: BYPASSER }, w), null);
+  }
+});
+
+test("#983: the refusal says what it is, why it cannot land, and what to do", () => {
+  const msg = rgthreeFastGroupsRefusal("RGTHREE_TOGGLE_AND_NAV.toggled", 12, BYPASSER);
+  assert.match(msg, /DERIVED READOUT/, "names what the widget actually is");
+  assert.match(msg, /serialize_widgets = false/, "cites the fact that makes persistence impossible");
+  assert.match(msg, /reverts/, "explains the reported symptom");
+  assert.match(msg, /Set the TARGET NODES' modes instead/, "gives the reporter's verified remedy");
+  assert.match(msg, /per MATCHED GROUP/i, "warns that the name is ambiguous across groups");
+  assert.match(msg, /node 12/, "names the node");
+  assert.match(msg, new RegExp(BYPASSER.replace(/[()]/g, "\\$&")), "names the node type");
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -262,6 +262,10 @@ import {
   recordPreLoadPromptRelayEditors,
 } from "./lib/prompt-relay-timeline.js";
 import {
+  classifyRgthreeFastGroupsWrite,
+  rgthreeFastGroupsRefusal,
+} from "./lib/rgthree-fast-groups.js";
+import {
   controlAfterGenerateModes,
   controlAfterGenerateEntries,
 } from "./lib/control-after-generate.js";
@@ -10780,6 +10784,16 @@ const GRAPH_TOOL_EXECUTORS = {
         afterChange: () => graph.afterChange(),
         setDirty: () => graph.setDirtyCanvas(true, true),
       });
+    }
+    // #983: rgthree's Fast Groups Muter/Bypasser toggle rows are DERIVED READOUTS of whether
+    // the matched group has an active node — the node re-reads each one from the group on
+    // every refresh and declares `serialize_widgets = false`, so a write is reverted and
+    // never reaches the workflow. The reported shape was a clean success followed immediately
+    // by the old value. Refused loudly, keyed to BOTH the node type and the widget name so
+    // nothing else on those nodes is affected. See the lib for the three source facts and for
+    // why this refuses rather than driving the node's own toggle().
+    if (classifyRgthreeFastGroupsWrite(node, widget) === "derived") {
+      throw new Error(rgthreeFastGroupsRefusal(widget, node.id, node.type));
     }
     // #458: WAIT for the startup baseline history seed to land before authorizing, so a
     // write can never decide "never seen" against an un-seeded history — a pack present

--- a/web/js/lib/rgthree-fast-groups.js
+++ b/web/js/lib/rgthree-fast-groups.js
@@ -1,0 +1,105 @@
+// #983 — rgthree's Fast Groups Muter/Bypasser toggle is DERIVED, and a widget write to it
+// cannot take effect. Refused loudly rather than reported as a success that silently reverts.
+//
+// The reported shape: `panel_set_widget` on `RGTHREE_TOGGLE_AND_NAV.toggled = false` returned
+// a clean success showing `{"toggled": false}`, and the very next `panel_query_graph` showed
+// `{"toggled": true}` again, with the target node still active.
+//
+// THREE FACTS FROM THE PACK'S OWN SOURCE (rgthree-comfy `src_web/comfyui/`), any one of which
+// is enough on its own — this is not inferred from the report:
+//
+//  1. `BaseFastGroupsModeChanger` sets `override serialize_widgets = false`
+//     (fast_groups_muter.ts). Both Muter and Bypasser extend it, so these nodes NEVER
+//     serialize widget values into the workflow. A write cannot persist even in principle.
+//
+//  2. The node's own refresh loop OVERWRITES the value from the live graph:
+//
+//         if (group.rgthree_hasAnyActiveNode != null &&
+//             widget.toggled != group.rgthree_hasAnyActiveNode) {
+//           widget.toggled = group.rgthree_hasAnyActiveNode;
+//         }
+//
+//     `toggled` REPORTS whether the matched group currently has an active node. It is a
+//     readout, not a setting, so a raw write is reverted on the next refresh tick.
+//
+//  3. The only path that changes anything is the widget's own `toggle()`:
+//
+//         toggle(value) {
+//           if (value !== this.toggled) { this.value.toggled = value; this.doModeChange(); }
+//         }
+//
+//     `doModeChange()` is what actually mutes/bypasses the group's nodes. Assigning
+//     `widget.value.toggled` directly — which is what a widget write does — skips it, so no
+//     node mode changes and there is nothing for the readout to keep.
+//
+// So the value the caller sees in the reply is real for an instant and means nothing. That is
+// precisely the silent-success shape `panel_set_widget` must not produce.
+//
+// WHY A REFUSAL AND NOT A ROUTE. The natural next step is to drive the node's own `toggle()`,
+// the way the LTXDirector route drives `_applyLoadedTimeline` (#314). That is better UX and it
+// is deliberately NOT done here: `toggle()` calls `doModeChange()`, which mutates the MODE OF
+// EVERY NODE in the matched group — a much larger effect than "set a widget" — and this issue
+// has already been reverted twice for shipping ahead of what could be verified. Refusing costs
+// the caller one tool call and cannot corrupt a graph; routing wrongly can. The route is worth
+// revisiting once it can be exercised against a live canvas.
+//
+// A SECOND reason a write here is unsound, worth stating because it survives any pack change:
+// these nodes carry ONE `RGTHREE_TOGGLE_AND_NAV` widget PER MATCHED GROUP, all sharing that
+// name and distinguished only by `label`. Addressing one by name is ambiguous whenever more
+// than one group matches, so even a working write could not say which group it meant.
+//
+// Dependency-free (no DOM, no LiteGraph). Unit-testable with plain fixtures.
+
+/** The rgthree node types whose toggle rows are derived readouts. `addRgthree()` in the pack's
+ *  constants.ts appends " (rgthree)" to every name, which is what reaches `node.type`. */
+const FAST_GROUPS_TYPES = new Set(["Fast Groups Muter (rgthree)", "Fast Groups Bypasser (rgthree)"]);
+
+/** The widget name the pack gives every toggle row. */
+export const RGTHREE_TOGGLE_WIDGET = "RGTHREE_TOGGLE_AND_NAV";
+
+/** The base widget name a request addresses, with any composite sub-field removed:
+ *  `"RGTHREE_TOGGLE_AND_NAV.toggled"` and `"RGTHREE_TOGGLE_AND_NAV"` both name the same widget. */
+function baseWidgetName(widgetName) {
+  if (typeof widgetName !== "string") return "";
+  const dot = widgetName.indexOf(".");
+  return dot === -1 ? widgetName : widgetName.slice(0, dot);
+}
+
+/**
+ * `"derived"` when this write targets a Fast Groups toggle row, else null.
+ *
+ * Keyed on BOTH the node type and the widget name, deliberately. Either alone would be
+ * wrong: the type alone would refuse a legitimate write to some other widget these nodes may
+ * gain, and the widget name alone would refuse it on an unrelated node that happens to reuse
+ * the name. Anything else on these nodes is untouched, exactly as it is today.
+ *
+ * @param {{type?: unknown}} node
+ * @param {unknown} widgetName
+ * @returns {"derived"|null}
+ */
+export function classifyRgthreeFastGroupsWrite(node, widgetName) {
+  const type = node && typeof node === "object" ? node.type : undefined;
+  if (typeof type !== "string" || !FAST_GROUPS_TYPES.has(type)) return null;
+  return baseWidgetName(widgetName) === RGTHREE_TOGGLE_WIDGET ? "derived" : null;
+}
+
+/**
+ * The refusal. Names what the widget actually is, why the write cannot land, and the remedy
+ * the reporter verified themselves — set the group's node modes directly, which is not a
+ * workaround but the mechanism the toggle merely reports on.
+ */
+export function rgthreeFastGroupsRefusal(widgetName, nodeId, nodeType) {
+  return (
+    `panel_set_widget cannot drive "${widgetName}" on ${nodeType} node ${nodeId}: the toggle row ` +
+    `is a DERIVED READOUT of whether its matched group currently has an active node, not a stored ` +
+    `setting (#983). The node re-reads it from the group on every refresh, and it declares ` +
+    `serialize_widgets = false so the value never reaches the workflow at all — a direct write ` +
+    `shows in the reply and in panel_query_graph for an instant, then reverts, and no node ever ` +
+    `changes mode. Only the widget's own toggle() changes anything, because it also runs the ` +
+    `group mode change that this value reports on.\n` +
+    `Set the TARGET NODES' modes instead — mute or bypass the nodes in that group directly — ` +
+    `and the toggle will follow, because it is reporting on them. (These nodes also carry one ` +
+    `toggle row PER MATCHED GROUP, all named "${RGTHREE_TOGGLE_WIDGET}", so addressing one by ` +
+    `name cannot say which group you meant.)`
+  );
+}


### PR DESCRIPTION
Fixes #983. `panel_set_widget` on `RGTHREE_TOGGLE_AND_NAV.toggled = false` returned a clean
success showing `{"toggled": false}`, and the very next `panel_query_graph` showed
`{"toggled": true}` again with the target node still active.

**Two previous attempts at this were reverted**, both for the same reason: they went after a
*general* persistence signal — "did this write land, for any node and any widget" — and both
died on the path every widget write goes through. The thread's own conclusion was that a third
attempt needs "a persistence signal that does not invoke node-owned serialization", and that
none exists.

## It needed no signal at all

The rgthree pack is installed on this machine, so the question was answerable from its own
source rather than by probing at runtime. Three facts, any one sufficient:

1. **`BaseFastGroupsModeChanger` declares `override serialize_widgets = false`.** Both Muter
   and Bypasser extend it, so these nodes **never** serialize widget values into the workflow.
   The write cannot persist even in principle.
2. **The node's refresh loop overwrites the value from the live graph:**
   ```js
   if (group.rgthree_hasAnyActiveNode != null && widget.toggled != group.rgthree_hasAnyActiveNode) {
     widget.toggled = group.rgthree_hasAnyActiveNode;
   }
   ```
   `toggled` **reports** whether the matched group currently has an active node. It is a
   readout, not a setting.
3. **Only the widget's own `toggle()` changes anything**, because it also calls
   `doModeChange()` — the group mode change the readout reports on:
   ```js
   toggle(value) { if (value !== this.toggled) { this.value.toggled = value; this.doModeChange(); } }
   ```
   Assigning `widget.value.toggled` directly — which is what a widget write does — skips it.

So the value in the reply is real for an instant and means nothing. That is exactly the
silent-success shape `panel_set_widget` must not produce.

## The fix

A refusal, in the same shape as the two node-type-keyed routes already at the top of this
function — LTXDirector (#314) and PromptRelayEncodeTimeline (#506), both of which exist for the
identical *"shows in `panel_query_graph` but is silently reverted"* problem.

Keyed on **both** the node type and the widget name. Either alone would be wrong: the type
alone would refuse a legitimate write to another widget these nodes carry, and the name alone
would refuse it on any node that reuses the name.

## What it deliberately does not do

Route the write through the node's own `toggle()`. That is better UX and is the obvious next
step — but it calls `doModeChange()`, which mutates **the mode of every node in the matched
group**, far larger than "set a widget", and ComfyUI is not running here to verify it. Given
this issue has already been reverted twice for shipping ahead of the evidence, refusing costs
the caller one tool call and cannot corrupt a graph; routing wrongly can. Recorded in the lib
as the follow-up.

## One more reason a write here is unsound

Independent of everything above, and it survives any pack change: these nodes carry **one
toggle row per matched group**, all named `RGTHREE_TOGGLE_AND_NAV` and distinguished only by
`label`. Addressing one by name cannot say which group was meant whenever more than one
matches. The refusal says so.

## Gate

3914 tests pass (7 new), `tsc --noEmit` clean, `node --check` OK, tool-vocabulary gate OK.

**Not releasing on merge:** ComfyUI is down on this machine, so the loop's browser-verification
step cannot run. The behaviour here is a refusal computed from `node.type` and the widget name,
fully covered by unit tests, but I am holding the release rather than skipping the gate.

Closes #983
