### PR TITLE
fix(996): stop asking every run-to-node caller to report a permanent fallback

### DIFF
--- a/browser_tests/unit/queue-prompt-chain.test.mjs
+++ b/browser_tests/unit/queue-prompt-chain.test.mjs
@@ -100,17 +100,25 @@ test("#996 the report states what would settle it, and names no suspect", () => 
     describeQueuePromptChain({ app: makeApp({ shadowed: true }), api: makeApi({ shadowed: true }) }),
   );
   assert.match(shadowed, /observed, not a diagnosis/);
-  assert.match(shadowed, /whether the replacement passes its THIRD argument through/);
+  assert.match(shadowed, /whether whatever is installed passes its THIRD argument through/);
   // The suspect-naming codex killed.
   assert.doesNotMatch(shadowed, /the thing to look at/i);
   assert.doesNotMatch(shadowed, /PATCHED by an extension/i);
-  // …and it acknowledges that shadowing is ordinary rather than incriminating.
-  assert.match(shadowed, /which is normal/);
+  // codex round 2: nor "something REPLACED it" — a frontend binding its own method
+  // in a constructor produces the same own property.
+  assert.doesNotMatch(shadowed, /replaced one of those methods/i);
+  assert.match(shadowed, /is ordinary/);
+  assert.match(shadowed, /where to look, not who to blame/);
 
   const unshadowed = describeQueuePromptChainForReport(
     describeQueuePromptChain({ app: makeApp(), api: makeApi() }),
   );
-  assert.match(unshadowed, /Neither method is shadowed here/);
+  // codex round 2: absence of shadowing rules out ONE PLACEMENT. A wrapper on the
+  // prototype leaves no own property, so this must not be read as "the frontend's
+  // own code had it".
+  assert.match(unshadowed, /rules out one placement only/);
+  assert.match(unshadowed, /installed on the PROTOTYPE leaves no own property/);
+  assert.doesNotMatch(unshadowed, /reached the frontend's own code and was lost/);
 });
 
 test("#996 arity is NOT reported — it reads like a signal and is noise", () => {
@@ -133,7 +141,8 @@ test("#996 stops asking for the datum that already failed twice", () => {
 });
 
 test("#996 never throws on hostile input — it runs on a failure path", () => {
-  for (const bad of [undefined, {}, { app: null, api: null }, { app: 1, api: "x" }]) {
+  // `null` included: destructuring in the signature threw on it (codex round 2).
+  for (const bad of [undefined, null, {}, { app: null, api: null }, { app: 1, api: "x" }]) {
     const chain = describeQueuePromptChain(bad);
     assert.equal(typeof chain.summary, "string");
     assert.equal(typeof describeQueuePromptChainForReport(chain), "string");

--- a/browser_tests/unit/queue-prompt-chain.test.mjs
+++ b/browser_tests/unit/queue-prompt-chain.test.mjs
@@ -199,3 +199,32 @@ test("#996 reading the globals cannot throw either — the caller's access is gu
 
   assert.deepEqual(queuePromptChainDeps(undefined), { app: undefined, api: undefined });
 });
+
+test("#996 an UNREADABLE or absent method is unknown — never 'comes from the prototype'", () => {
+  // codex round 3: a failed own-property probe was collapsed to `false` and then
+  // reported as a confident negative — the same defect this diagnostic exists to
+  // stop making, in its own guard.
+  const proxy = new Proxy(function () {}, {
+    getOwnPropertyDescriptor() {
+      throw new Error("nope");
+    },
+    get(_t, k) {
+      if (k === "queuePrompt") return function () {};
+      throw new Error("nope");
+    },
+  });
+  const unreadable = describeQueuePromptChain({ app: proxy, api: proxy });
+  assert.equal(unreadable.appShadowed, undefined);
+  assert.match(unreadable.summary, /could not be read, or is not there/);
+  assert.doesNotMatch(unreadable.summary, /comes from the prototype/);
+
+  // An object with NO queuePrompt is not "from the prototype" either.
+  const absent = describeQueuePromptChain({ app: {}, api: {} });
+  assert.equal(absent.appShadowed, undefined);
+  assert.match(absent.summary, /could not be read, or is not there/);
+
+  // …and the report must not take the "nothing shadows" branch for it.
+  const report = describeQueuePromptChainForReport(absent);
+  assert.match(report, /could not be read, so where it comes from is unknown/);
+  assert.doesNotMatch(report, /rules out one placement only/);
+});

--- a/browser_tests/unit/queue-prompt-chain.test.mjs
+++ b/browser_tests/unit/queue-prompt-chain.test.mjs
@@ -1,0 +1,132 @@
+// #996 / #1088 — the fallback note asks for what actually discriminates.
+//
+// Two reports arrived with the build number and the ComfyUI_frontend version the
+// note requested, and neither identified the cause. Measured on 1.48.7:
+// app.queuePrompt's real signature is (number, batchCount, queueNodeIds) and the
+// third argument DOES reach /prompt as partial_execution_targets — but BOTH links
+// are routinely patched by extensions (a custom node wraps app.queuePrompt,
+// rgthree wraps api.queuePrompt). A wrapper that forwards its arguments is
+// harmless; one that does not drops the scope with no error anywhere. None of that
+// is visible in a version number.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  describeQueuePromptChain,
+  describeQueuePromptChainForReport,
+} from "../../web/js/lib/queue-prompt-chain.js";
+
+/** A frontend whose own api.queuePrompt understands the options shape — 1.48.7. */
+function makeApi({ patched = false } = {}) {
+  class Api {
+    async queuePrompt(index, prompt, opts) {
+      return { index, prompt, partial: opts?.partialExecutionTargets };
+    }
+  }
+  const api = new Api();
+  if (patched) {
+    // rgthree's shape: arity 2 plus a rest param, forwarding through.
+    api.queuePrompt = async function (index, prompt, ...args) {
+      return Api.prototype.queuePrompt.apply(api, [index, prompt, ...args]);
+    };
+  }
+  return api;
+}
+
+function makeApp({ patched = false } = {}) {
+  class App {
+    async queuePrompt(number, batchCount = 1, queueNodeIds) {
+      return { number, batchCount, queueNodeIds };
+    }
+  }
+  const app = new App();
+  if (patched) {
+    app.queuePrompt = async function (...args) {
+      return App.prototype.queuePrompt.apply(app, args);
+    };
+  }
+  return app;
+}
+
+test("#996 reports whether each link is patched, reading past the instance", () => {
+  const clean = describeQueuePromptChain({ app: makeApp(), api: makeApi() });
+  assert.equal(clean.appPatched, false);
+  assert.equal(clean.apiPatched, false);
+  // A default parameter truncates Function.length, so the real signature
+  // (number, batchCount = 1, queueNodeIds) reports 1 — which is what the live
+  // frontend reported when measured. Arity is a WEAK signal here, which is why
+  // the report leans on patched-or-not and on the prototype's own support.
+  assert.equal(clean.appArity, 1);
+  assert.equal(clean.frontendSupportsOptions, true);
+
+  const patched = describeQueuePromptChain({
+    app: makeApp({ patched: true }),
+    api: makeApi({ patched: true }),
+  });
+  assert.equal(patched.appPatched, true);
+  assert.equal(patched.apiPatched, true);
+  // The measured trap: a patched instance reports the WRAPPER's arity, not the
+  // real signature. Reading `app.queuePrompt` alone is how one concludes the
+  // capability is gone when it is not.
+  assert.equal(patched.appArity, 0);
+  assert.equal(patched.apiArity, 2);
+  // …while the frontend's own api.queuePrompt still supports the options shape.
+  assert.equal(patched.frontendSupportsOptions, true);
+});
+
+test("#996 separates 'this build cannot' from 'something dropped it'", () => {
+  const oldFrontend = describeQueuePromptChain({
+    app: makeApp(),
+    api: (() => {
+      class OldApi {
+        async queuePrompt(index, prompt) {
+          return { index, prompt };
+        }
+      }
+      return new OldApi();
+    })(),
+  });
+  assert.equal(oldFrontend.frontendSupportsOptions, false);
+
+  const report = describeQueuePromptChainForReport(oldFrontend);
+  assert.match(report, /points at the build rather than at an extension/);
+  assert.doesNotMatch(report, /wrapper that does not forward/);
+});
+
+test("#996 points at the wrapper when the frontend DOES support the scope", () => {
+  const chain = describeQueuePromptChain({
+    app: makeApp({ patched: true }),
+    api: makeApi({ patched: true }),
+  });
+  const report = describeQueuePromptChainForReport(chain);
+  assert.match(report, /a wrapper that does not forward its arguments is the thing to look at/);
+  assert.match(report, /fn\(index, prompt, \.\.\.args\)/);
+});
+
+test("#996 stops asking for the datum that already failed twice", () => {
+  const report = describeQueuePromptChainForReport(
+    describeQueuePromptChain({ app: makeApp(), api: makeApi() }),
+  );
+  assert.match(report, /Please include THIS line/);
+  assert.match(report, /has already been reported twice without identifying the cause/);
+});
+
+test("#996 never throws on a hostile or absent chain — it runs on a failure path", () => {
+  for (const bad of [undefined, {}, { app: null, api: null }, { app: 1, api: "x" }]) {
+    const chain = describeQueuePromptChain(bad);
+    assert.equal(typeof chain.summary, "string");
+    assert.equal(typeof describeQueuePromptChainForReport(chain), "string");
+  }
+  // A getter that throws must not take the run down with it.
+  const hostile = {};
+  Object.defineProperty(hostile, "queuePrompt", {
+    get() {
+      throw new Error("boom");
+    },
+  });
+  assert.doesNotThrow(() => describeQueuePromptChain({ app: {}, api: hostile }));
+});
+
+test("#996 an empty chain yields an empty report rather than a confident one", () => {
+  assert.equal(describeQueuePromptChainForReport(null), "");
+});

--- a/browser_tests/unit/queue-prompt-chain.test.mjs
+++ b/browser_tests/unit/queue-prompt-chain.test.mjs
@@ -1,31 +1,38 @@
-// #996 / #1088 — the fallback note asks for what actually discriminates.
+// #996 / #1088 — the fallback note collects what discriminates, and CLAIMS NOTHING.
 //
 // Two reports arrived with the build number and the ComfyUI_frontend version the
-// note requested, and neither identified the cause. Measured on 1.48.7:
-// app.queuePrompt's real signature is (number, batchCount, queueNodeIds) and the
-// third argument DOES reach /prompt as partial_execution_targets — but BOTH links
-// are routinely patched by extensions (a custom node wraps app.queuePrompt,
-// rgthree wraps api.queuePrompt). A wrapper that forwards its arguments is
-// harmless; one that does not drops the scope with no error anywhere. None of that
-// is visible in a version number.
+// note requested, and neither identified the cause. Measured on a live 1.48.7:
+// app.queuePrompt's real implementation takes (number, batchCount, queueNodeIds)
+// and the third argument reaches /prompt as partial_execution_targets — but both
+// links were shadowed by own properties (a custom node over app.queuePrompt,
+// rgthree over api.queuePrompt), so reading the instances reports arity 0 and
+// mentions neither `partial` nor `queueNodeIds` while the prototypes do both.
+//
+// The first version of this module turned those observations into accusations —
+// "PATCHED by an extension", "a wrapper that does not forward is the thing to look
+// at". Codex review killed both: an own property is SHADOWING (a frontend binding
+// in its constructor looks identical), and a shadowed method plus a capable
+// prototype does not establish that a wrapper ate anything. These tests pin the
+// observations AND the absence of the diagnosis.
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import {
   describeQueuePromptChain,
   describeQueuePromptChainForReport,
+  queuePromptChainDeps,
 } from "../../web/js/lib/queue-prompt-chain.js";
 
 /** A frontend whose own api.queuePrompt understands the options shape — 1.48.7. */
-function makeApi({ patched = false } = {}) {
+function makeApi({ shadowed = false } = {}) {
   class Api {
     async queuePrompt(index, prompt, opts) {
-      return { index, prompt, partial: opts?.partialExecutionTargets };
+      return { index, prompt, partialExecutionTargets: opts?.partialExecutionTargets };
     }
   }
   const api = new Api();
-  if (patched) {
-    // rgthree's shape: arity 2 plus a rest param, forwarding through.
+  if (shadowed) {
+    // rgthree's shape: forwards through, which is why shadowing alone proves nothing.
     api.queuePrompt = async function (index, prompt, ...args) {
       return Api.prototype.queuePrompt.apply(api, [index, prompt, ...args]);
     };
@@ -33,74 +40,87 @@ function makeApi({ patched = false } = {}) {
   return api;
 }
 
-function makeApp({ patched = false } = {}) {
+function makeApp({ shadowed = false } = {}) {
   class App {
     async queuePrompt(number, batchCount = 1, queueNodeIds) {
       return { number, batchCount, queueNodeIds };
     }
   }
   const app = new App();
-  if (patched) {
-    app.queuePrompt = async function (...args) {
-      return App.prototype.queuePrompt.apply(app, args);
-    };
-  }
+  if (shadowed) app.queuePrompt = async function (...args) {
+    return App.prototype.queuePrompt.apply(app, args);
+  };
   return app;
 }
 
-test("#996 reports whether each link is patched, reading past the instance", () => {
+test("#996 reports SHADOWING as shadowing — never as a patch by an extension", () => {
   const clean = describeQueuePromptChain({ app: makeApp(), api: makeApi() });
-  assert.equal(clean.appPatched, false);
-  assert.equal(clean.apiPatched, false);
-  // A default parameter truncates Function.length, so the real signature
-  // (number, batchCount = 1, queueNodeIds) reports 1 — which is what the live
-  // frontend reported when measured. Arity is a WEAK signal here, which is why
-  // the report leans on patched-or-not and on the prototype's own support.
-  assert.equal(clean.appArity, 1);
-  assert.equal(clean.frontendSupportsOptions, true);
+  assert.equal(clean.appShadowed, false);
+  assert.equal(clean.apiShadowed, false);
+  assert.match(clean.summary, /comes from the prototype/);
 
-  const patched = describeQueuePromptChain({
-    app: makeApp({ patched: true }),
-    api: makeApi({ patched: true }),
+  const shadowed = describeQueuePromptChain({
+    app: makeApp({ shadowed: true }),
+    api: makeApi({ shadowed: true }),
   });
-  assert.equal(patched.appPatched, true);
-  assert.equal(patched.apiPatched, true);
-  // The measured trap: a patched instance reports the WRAPPER's arity, not the
-  // real signature. Reading `app.queuePrompt` alone is how one concludes the
-  // capability is gone when it is not.
-  assert.equal(patched.appArity, 0);
-  assert.equal(patched.apiArity, 2);
-  // …while the frontend's own api.queuePrompt still supports the options shape.
-  assert.equal(patched.frontendSupportsOptions, true);
+  assert.equal(shadowed.appShadowed, true);
+  assert.equal(shadowed.apiShadowed, true);
+  assert.match(shadowed.summary, /is shadowed by an own property/);
+  // The accusation codex killed: a frontend that binds its own method in a
+  // constructor produces this exact observation.
+  assert.doesNotMatch(shadowed.summary, /PATCHED by an extension/i);
 });
 
-test("#996 separates 'this build cannot' from 'something dropped it'", () => {
-  const oldFrontend = describeQueuePromptChain({
-    app: makeApp(),
-    api: (() => {
-      class OldApi {
-        async queuePrompt(index, prompt) {
-          return { index, prompt };
-        }
-      }
-      return new OldApi();
-    })(),
-  });
-  assert.equal(oldFrontend.frontendSupportsOptions, false);
+test("#996 the prototype source check is reported as a source observation", () => {
+  const capable = describeQueuePromptChain({ app: makeApp(), api: makeApi() });
+  assert.equal(capable.protoMentionsOption, true);
+  assert.match(capable.summary, /source mentions partialExecutionTargets/);
 
-  const report = describeQueuePromptChainForReport(oldFrontend);
-  assert.match(report, /points at the build rather than at an extension/);
-  assert.doesNotMatch(report, /wrapper that does not forward/);
+  class OldApi {
+    async queuePrompt(index, prompt) {
+      return { index, prompt };
+    }
+  }
+  const old = describeQueuePromptChain({ app: makeApp(), api: new OldApi() });
+  assert.equal(old.protoMentionsOption, false);
+  // "does not mention" — NOT "this build cannot do it". A build may support the
+  // option through a helper or a minified name.
+  assert.match(old.summary, /source does not mention partialExecutionTargets/);
+  assert.doesNotMatch(old.summary, /points at the build/i);
 });
 
-test("#996 points at the wrapper when the frontend DOES support the scope", () => {
-  const chain = describeQueuePromptChain({
-    app: makeApp({ patched: true }),
-    api: makeApi({ patched: true }),
-  });
-  const report = describeQueuePromptChainForReport(chain);
-  assert.match(report, /a wrapper that does not forward its arguments is the thing to look at/);
-  assert.match(report, /fn\(index, prompt, \.\.\.args\)/);
+test("#996 an unreadable prototype is UNKNOWN, not a verdict either way", () => {
+  const chain = describeQueuePromptChain({ app: makeApp(), api: {} });
+  assert.equal(chain.protoMentionsOption, undefined);
+  assert.match(chain.summary, /could not be read/);
+});
+
+test("#996 the report states what would settle it, and names no suspect", () => {
+  const shadowed = describeQueuePromptChainForReport(
+    describeQueuePromptChain({ app: makeApp({ shadowed: true }), api: makeApi({ shadowed: true }) }),
+  );
+  assert.match(shadowed, /observed, not a diagnosis/);
+  assert.match(shadowed, /whether the replacement passes its THIRD argument through/);
+  // The suspect-naming codex killed.
+  assert.doesNotMatch(shadowed, /the thing to look at/i);
+  assert.doesNotMatch(shadowed, /PATCHED by an extension/i);
+  // …and it acknowledges that shadowing is ordinary rather than incriminating.
+  assert.match(shadowed, /which is normal/);
+
+  const unshadowed = describeQueuePromptChainForReport(
+    describeQueuePromptChain({ app: makeApp(), api: makeApi() }),
+  );
+  assert.match(unshadowed, /Neither method is shadowed here/);
+});
+
+test("#996 arity is NOT reported — it reads like a signal and is noise", () => {
+  // A default parameter truncates Function.length, so the known-good implementation
+  // reports 1 while a correct forwarding wrapper reports 0. Publishing that makes
+  // the note easier to misread than the version request it replaces (codex, P2).
+  const chain = describeQueuePromptChain({ app: makeApp(), api: makeApi() });
+  assert.equal(chain.appArity, undefined);
+  assert.doesNotMatch(chain.summary, /arity/i);
+  assert.doesNotMatch(describeQueuePromptChainForReport(chain), /arity/i);
 });
 
 test("#996 stops asking for the datum that already failed twice", () => {
@@ -108,25 +128,65 @@ test("#996 stops asking for the datum that already failed twice", () => {
     describeQueuePromptChain({ app: makeApp(), api: makeApi() }),
   );
   assert.match(report, /Please include THIS line/);
-  assert.match(report, /has already been reported twice without identifying the cause/);
+  assert.match(report, /together with the body keys above/);
+  assert.match(report, /twice without identifying the cause/);
 });
 
-test("#996 never throws on a hostile or absent chain — it runs on a failure path", () => {
+test("#996 never throws on hostile input — it runs on a failure path", () => {
   for (const bad of [undefined, {}, { app: null, api: null }, { app: 1, api: "x" }]) {
     const chain = describeQueuePromptChain(bad);
     assert.equal(typeof chain.summary, "string");
     assert.equal(typeof describeQueuePromptChainForReport(chain), "string");
   }
-  // A getter that throws must not take the run down with it.
+  // A getter that throws, on either object.
   const hostile = {};
   Object.defineProperty(hostile, "queuePrompt", {
     get() {
       throw new Error("boom");
     },
   });
-  assert.doesNotThrow(() => describeQueuePromptChain({ app: {}, api: hostile }));
+  assert.doesNotThrow(() => describeQueuePromptChain({ app: hostile, api: hostile }));
+
+  // A callable Proxy whose own-property check throws (codex: the unguarded read).
+  const proxy = new Proxy(function () {}, {
+    getOwnPropertyDescriptor() {
+      throw new Error("nope");
+    },
+    has() {
+      throw new Error("nope");
+    },
+    get() {
+      throw new Error("nope");
+    },
+  });
+  assert.doesNotThrow(() => describeQueuePromptChain({ app: proxy, api: proxy }));
 });
 
 test("#996 an empty chain yields an empty report rather than a confident one", () => {
   assert.equal(describeQueuePromptChainForReport(null), "");
+});
+
+test("#996 reading the globals cannot throw either — the caller's access is guarded too", () => {
+  // codex P1: the probe guarded its own reads while the call site did `app?.api`
+  // outside them, so an extension-installed throwing getter crashed the note that
+  // was describing the failure.
+  const hostileRoot = {};
+  Object.defineProperty(hostileRoot, "app", {
+    get() {
+      throw new Error("boom");
+    },
+  });
+  assert.doesNotThrow(() => queuePromptChainDeps(hostileRoot));
+  assert.deepEqual(queuePromptChainDeps(hostileRoot), { app: undefined, api: undefined });
+
+  // And an app whose `api` getter throws.
+  const appWithHostileApi = {};
+  Object.defineProperty(appWithHostileApi, "api", {
+    get() {
+      throw new Error("boom");
+    },
+  });
+  assert.doesNotThrow(() => queuePromptChainDeps({ app: appWithHostileApi }));
+
+  assert.deepEqual(queuePromptChainDeps(undefined), { app: undefined, api: undefined });
 });

--- a/browser_tests/unit/run-scope-guard.test.mjs
+++ b/browser_tests/unit/run-scope-guard.test.mjs
@@ -904,7 +904,23 @@ test("#630 gate r1: graph_run's repair disclosure separates what was OBSERVED fr
     "the measured build is named, together with what was measured about it",
   );
   assert.match(note, /measured by capturing the outgoing body/, "and how it was established");
-  assert.match(note, /please report this build \(#996\)/, "the ask survives — one datum is not a diagnosis");
+  // The ask survives — one datum is not a diagnosis — but WHAT it asks for changed
+  // (#996). Two reports arrived with the build and the ComfyUI_frontend version this
+  // used to request, and neither identified the cause: the version is not what
+  // differs. It now asks for the queue-chain line, which names the two links that
+  // can silently drop the scope.
+  // This assertion reads the note's SOURCE, so it can only see the delegation —
+  // the wording now lives in web/js/lib/queue-prompt-chain.js and is asserted
+  // behaviourally in queue-prompt-chain.test.mjs, against the same patched-chain
+  // shape measured on a live 1.48.7 (app.queuePrompt wrapped by a custom node,
+  // api.queuePrompt wrapped by rgthree). That is a stronger check than a grep for
+  // a sentence, which is why the sentence moved.
+  assert.match(note, /describeQueuePromptChainForReport\(/, "the ask survives, via the shared builder");
+  assert.doesNotMatch(
+    note,
+    /including your ComfyUI_frontend version/,
+    "it no longer asks for the datum that failed to identify the cause twice",
+  );
   // The workaround must name the version that was actually measured. "upgrading may
   // help" does not say to WHAT, and no 1.48.6→1.48.7 end-to-end result was taken
   // (codex).

--- a/browser_tests/unit/run-scope-guard.test.mjs
+++ b/browser_tests/unit/run-scope-guard.test.mjs
@@ -916,6 +916,11 @@ test("#630 gate r1: graph_run's repair disclosure separates what was OBSERVED fr
   // api.queuePrompt wrapped by rgthree). That is a stronger check than a grep for
   // a sentence, which is why the sentence moved.
   assert.match(note, /describeQueuePromptChainForReport\(/, "the ask survives, via the shared builder");
+  // …and it reads the globals through the GUARDED accessor. Inlining `window.app`
+  // here would put a throwing getter outside every guard in the library — a
+  // mutation doing exactly that survived every behavioural test, because the call
+  // site is only reachable in a browser.
+  assert.match(note, /queuePromptChainDeps\(\)/, "the globals are read through the guarded accessor");
   assert.doesNotMatch(
     note,
     /including your ComfyUI_frontend version/,

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -243,7 +243,10 @@ import { describeMissingNode, describeRailNodeTarget } from "./lib/node-scope-lo
 import {
   describeQueuePromptChain,
   describeQueuePromptChainForReport,
+  queuePromptChainDeps,
 } from "./lib/queue-prompt-chain.js";
+
+
 import { canonicalNodeId, isQualifiedNodeId } from "./lib/node-id.js";
 import { boundByChars, normalizeViewportMaxChars, viewportTruncation, VIEWPORT_DEFAULT_MAX_CHARS } from "./lib/viewport-char-bound.js";
 import { classifyManualChangeBaseline } from "./lib/manual-change-gate.js";
@@ -12156,9 +12159,7 @@ const GRAPH_TOOL_EXECUTORS = {
         // rgthree wraps api.queuePrompt), and a wrapper that forwards its
         // arguments is harmless while one that does not drops the scope silently.
         // That is invisible in a version number, so the note carries it directly.
-        describeQueuePromptChainForReport(
-          describeQueuePromptChain({ app, api: app?.api ?? window.comfyAPI?.api?.api }),
-        );
+        describeQueuePromptChainForReport(describeQueuePromptChain(queuePromptChainDeps()));
     }
     // #556 (codex gate r3) — an EXTRA /prompt post carrying this run's identity
     // was fenced out. The requested prompts queued, so this is a DISCLOSURE and

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -240,6 +240,10 @@ import {
 } from "./lib/thread-workflow-match.js";
 import { subgraphValueProvenance } from "./lib/subgraph-value-provenance.js";
 import { describeMissingNode, describeRailNodeTarget } from "./lib/node-scope-locator.js";
+import {
+  describeQueuePromptChain,
+  describeQueuePromptChainForReport,
+} from "./lib/queue-prompt-chain.js";
 import { canonicalNodeId, isQualifiedNodeId } from "./lib/node-id.js";
 import { boundByChars, normalizeViewportMaxChars, viewportTruncation, VIEWPORT_DEFAULT_MAX_CHARS } from "./lib/viewport-char-bound.js";
 import { classifyManualChangeBaseline } from "./lib/manual-change-gate.js";
@@ -12144,8 +12148,17 @@ const GRAPH_TOOL_EXECUTORS = {
         `behaves differently — so this fallback is not expected on that build, and ` +
         `trying ComfyUI_frontend 1.48.7 may be the quickest workaround. Which OTHER ` +
         `builds take which shape is not something the panel can determine from inside ` +
-        `one of them, so please report this build (#996), including your ` +
-        `ComfyUI_frontend version.`;
+        `one of them.` +
+        // #996 — ASK FOR WHAT DISCRIMINATES. Two reports arrived with the build and
+        // the frontend version, and neither identified the cause: the version is
+        // not what differs. Measured on 1.48.7, BOTH links in the chain are
+        // routinely patched by extensions (a custom node wraps app.queuePrompt,
+        // rgthree wraps api.queuePrompt), and a wrapper that forwards its
+        // arguments is harmless while one that does not drops the scope silently.
+        // That is invisible in a version number, so the note carries it directly.
+        describeQueuePromptChainForReport(
+          describeQueuePromptChain({ app, api: app?.api ?? window.comfyAPI?.api?.api }),
+        );
     }
     // #556 (codex gate r3) — an EXTRA /prompt post carrying this run's identity
     // was fenced out. The requested prompts queued, so this is a DISCLOSURE and

--- a/web/js/lib/queue-prompt-chain.js
+++ b/web/js/lib/queue-prompt-chain.js
@@ -80,7 +80,11 @@ function prototypeMentionsOption(api) {
  *   this is testable without a browser, and so the CALLER's property access is not
  *   this module's failure mode.
  */
-export function describeQueuePromptChain({ app, api } = {}) {
+export function describeQueuePromptChain(deps) {
+  // Destructuring in the signature throws on an explicit `null` — which a
+  // failure-path helper must not do, whatever its current callers pass (codex).
+  const app = readProp(deps, "app");
+  const api = readProp(deps, "api");
   const appShadowed = shadowsPrototype(app, "queuePrompt");
   const apiShadowed = shadowsPrototype(api, "queuePrompt");
   const protoMentionsOption = prototypeMentionsOption(api);
@@ -113,11 +117,17 @@ export function describeQueuePromptChainForReport(chain) {
   if (!chain) return "";
   const shadowed = chain.appShadowed || chain.apiShadowed;
   const next = shadowed
-    ? ` Something on this page replaced one of those methods, which is normal — many extensions ` +
-      `do, and most forward their arguments correctly. What would settle it is whether the ` +
-      `replacement passes its THIRD argument through.`
-    : ` Neither method is shadowed here, so the argument reached the frontend's own code and was ` +
-      `lost at or after that point.`;
+    ? // NOT "something replaced it": an own property is shadowing, and a frontend
+      // that binds its own method in a constructor looks identical (codex round 2).
+      ` An own property shadowing the prototype is ordinary — a frontend may bind its own, and ` +
+      `many extensions wrap these — so this is where to look, not who to blame. What would ` +
+      `settle it is whether whatever is installed passes its THIRD argument through.`
+    : // NOT "so it reached the frontend's own code": a wrapper installed ON THE
+      // PROTOTYPE leaves no own property, so absence of shadowing rules out one
+      // placement, not interception (codex round 2).
+      ` Nothing shadows either method at the instance level. That rules out one placement only — ` +
+      `a wrapper installed on the PROTOTYPE leaves no own property and looks exactly like this — ` +
+      `so it does not establish that the argument reached the frontend's own code.`;
   return (
     ` QUEUE CHAIN (observed, not a diagnosis): ${chain.summary}.${next} Please include THIS line ` +
     `if you report it, together with the body keys above — the ComfyUI_frontend version alone has ` +

--- a/web/js/lib/queue-prompt-chain.js
+++ b/web/js/lib/queue-prompt-chain.js
@@ -1,0 +1,121 @@
+/**
+ * #996 / #1088 — WHAT ACTUALLY DIFFERS WHEN THE RUN-TO-NODE SCOPE DOES NOT ARRIVE.
+ *
+ * The fallback note asked reporters for their build and ComfyUI_frontend version.
+ * Two reports arrived with exactly that, and neither identified the cause, because
+ * the frontend version is not what discriminates. Measured on 1.48.7:
+ *
+ *   * `app.queuePrompt`'s real signature is `(number, batchCount, queueNodeIds)`,
+ *     and the third positional argument reaches `/prompt` as
+ *     `partial_execution_targets`. The capability is present.
+ *   * BOTH links in that chain are routinely PATCHED by extensions. On the machine
+ *     this was measured on, `app.queuePrompt` is wrapped by a custom node and
+ *     `api.queuePrompt` by rgthree — so reading `app.queuePrompt` reports arity 0
+ *     and mentions neither `partial` nor `queueNodeIds`, while the real
+ *     implementation sits on the prototype and does both.
+ *
+ * A wrapper that forwards its arguments (rgthree's does: `apply(app, [index,
+ * prompt, ...args])`) is harmless. A wrapper that does not is exactly how the scope
+ * disappears with no error anywhere. That distinction is invisible in a version
+ * number and visible here, so the note carries this instead of asking for one.
+ *
+ * Everything is read defensively: this runs on a failure path, and a diagnostic
+ * that throws replaces a recoverable fallback with a crash.
+ */
+
+/** Is `name` an OWN property of `obj` — i.e. patched onto the instance, shadowing
+ *  the prototype implementation the frontend ships? */
+function patchedOnInstance(obj, name) {
+  try {
+    return Boolean(obj && Object.prototype.hasOwnProperty.call(obj, name));
+  } catch {
+    return false;
+  }
+}
+
+/** Read a possibly-accessor property without letting it throw. */
+function readFn(obj, name) {
+  try {
+    return obj ? obj[name] : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function arityOf(fn) {
+  return typeof fn === "function" && Number.isInteger(fn.length) ? fn.length : -1;
+}
+
+/** Does the frontend's OWN api.queuePrompt understand the options shape at all?
+ *  This is the one fact that separates "this build cannot do it" from "something
+ *  in the chain dropped it" — the distinction both reports were missing. */
+function protoSupportsOptions(api) {
+  try {
+    const proto = api ? Object.getPrototypeOf(api) : null;
+    return /partialExecutionTargets/.test(String(proto?.queuePrompt ?? ""));
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * A one-line description of the app→api chain a scoped run travels through.
+ *
+ * @param {object} deps `{ app, api }` — passed in rather than read from globals so
+ *   this is testable without a browser, which is the whole reason it is a module.
+ * @returns {{appPatched: boolean, appArity: number, apiPatched: boolean,
+ *   apiArity: number, frontendSupportsOptions: boolean, summary: string}}
+ */
+export function describeQueuePromptChain({ app, api } = {}) {
+  // Read through a guard: `api.queuePrompt` can be an accessor, and a getter that
+  // throws would turn this diagnostic into the failure it is describing. Caught by
+  // its own test, which is the point of running it on hostile input.
+  const appFn = readFn(app, "queuePrompt");
+  const apiFn = readFn(api, "queuePrompt");
+  const appPatched = patchedOnInstance(app, "queuePrompt");
+  const apiPatched = patchedOnInstance(api, "queuePrompt");
+  const appArity = arityOf(appFn);
+  const apiArity = arityOf(apiFn);
+  const frontendSupportsOptions = protoSupportsOptions(api);
+
+  const parts = [
+    `app.queuePrompt ${appPatched ? "PATCHED by an extension" : "unpatched"} (arity ${appArity})`,
+    `api.queuePrompt ${apiPatched ? "PATCHED by an extension" : "unpatched"} (arity ${apiArity})`,
+    frontendSupportsOptions
+      ? "the frontend's own api.queuePrompt DOES accept partialExecutionTargets"
+      : "the frontend's own api.queuePrompt does NOT mention partialExecutionTargets",
+  ];
+  return {
+    appPatched,
+    appArity,
+    apiPatched,
+    apiArity,
+    frontendSupportsOptions,
+    summary: parts.join("; "),
+  };
+}
+
+/**
+ * What to say about that chain in the fallback note.
+ *
+ * The ASK is the point. "Report your build and frontend version" was answered
+ * twice and identified nothing; this names the two links that can silently drop an
+ * argument, and says which one to look at first.
+ */
+export function describeQueuePromptChainForReport(chain) {
+  if (!chain) return "";
+  const suspect =
+    chain.frontendSupportsOptions && (chain.appPatched || chain.apiPatched)
+      ? ` The frontend itself supports the scope here, so a wrapper that does not forward its ` +
+        `arguments is the thing to look at — an extension patch that calls through as ` +
+        `\`fn(index, prompt)\` instead of \`fn(index, prompt, ...args)\` drops the scope with no ` +
+        `error anywhere.`
+      : !chain.frontendSupportsOptions
+        ? ` The frontend's own api.queuePrompt does not mention partialExecutionTargets at all, ` +
+          `which points at the build rather than at an extension.`
+        : "";
+  return (
+    ` QUEUE CHAIN: ${chain.summary}.${suspect} Please include THIS line if you report it — the ` +
+    `ComfyUI_frontend version alone has already been reported twice without identifying the cause.`
+  );
+}

--- a/web/js/lib/queue-prompt-chain.js
+++ b/web/js/lib/queue-prompt-chain.js
@@ -40,14 +40,25 @@ function readProp(obj, name) {
   }
 }
 
-/** Does `obj` carry its OWN `name`, shadowing the prototype's? A FACT — it does
- *  not say who put it there, and a frontend binding its own method in a
- *  constructor produces the same observation. */
+/**
+ * Does `obj` carry its OWN `name`, shadowing the prototype's?
+ *
+ * THREE states, not two (codex round 3). A probe that FAILS — a callable Proxy
+ * whose `getOwnPropertyDescriptor` throws is exactly the case the hostile-input
+ * test installs — must not be reported as "no". Neither must an object that has no
+ * such method at all: "comes from the prototype" would describe a method that is
+ * not there. Collapsing either into a confident negative is the same defect this
+ * whole diagnostic exists to stop making.
+ *
+ * @returns {true|false|undefined} undefined = could not be determined, or absent.
+ */
 function shadowsPrototype(obj, name) {
   try {
-    return Boolean(obj && Object.prototype.hasOwnProperty.call(obj, name));
+    if (!obj) return undefined;
+    if (typeof readProp(obj, name) !== "function") return undefined;
+    return Boolean(Object.prototype.hasOwnProperty.call(obj, name));
   } catch {
-    return false;
+    return undefined;
   }
 }
 
@@ -89,9 +100,15 @@ export function describeQueuePromptChain(deps) {
   const apiShadowed = shadowsPrototype(api, "queuePrompt");
   const protoMentionsOption = prototypeMentionsOption(api);
 
+  const where = (state, what) =>
+    state === undefined
+      ? `${what} could not be read, or is not there`
+      : state
+        ? `${what} is shadowed by an own property`
+        : `${what} comes from the prototype`;
   const parts = [
-    `app.queuePrompt ${appShadowed ? "is shadowed by an own property" : "comes from the prototype"}`,
-    `api.queuePrompt ${apiShadowed ? "is shadowed by an own property" : "comes from the prototype"}`,
+    where(appShadowed, "app.queuePrompt"),
+    where(apiShadowed, "api.queuePrompt"),
     protoMentionsOption === undefined
       ? "the prototype's api.queuePrompt source could not be read"
       : protoMentionsOption
@@ -115,14 +132,19 @@ export function describeQueuePromptChain(deps) {
  */
 export function describeQueuePromptChainForReport(chain) {
   if (!chain) return "";
-  const shadowed = chain.appShadowed || chain.apiShadowed;
+  const shadowed = chain.appShadowed === true || chain.apiShadowed === true;
+  const anyUnknown = chain.appShadowed === undefined || chain.apiShadowed === undefined;
   const next = shadowed
     ? // NOT "something replaced it": an own property is shadowing, and a frontend
       // that binds its own method in a constructor looks identical (codex round 2).
       ` An own property shadowing the prototype is ordinary — a frontend may bind its own, and ` +
       `many extensions wrap these — so this is where to look, not who to blame. What would ` +
       `settle it is whether whatever is installed passes its THIRD argument through.`
-    : // NOT "so it reached the frontend's own code": a wrapper installed ON THE
+    : anyUnknown
+      ? // Unknown is unknown: it must not fall into the "nothing shadows" branch,
+        // which would assert something about a method we could not even read.
+        ` One of those methods could not be read, so where it comes from is unknown here.`
+      : // NOT "so it reached the frontend's own code": a wrapper installed ON THE
       // PROTOTYPE leaves no own property, so absence of shadowing rules out one
       // placement, not interception (codex round 2).
       ` Nothing shadows either method at the instance level. That rules out one placement only — ` +

--- a/web/js/lib/queue-prompt-chain.js
+++ b/web/js/lib/queue-prompt-chain.js
@@ -1,40 +1,38 @@
 /**
- * #996 / #1088 — WHAT ACTUALLY DIFFERS WHEN THE RUN-TO-NODE SCOPE DOES NOT ARRIVE.
+ * #996 / #1088 — WHAT TO COLLECT WHEN THE RUN-TO-NODE SCOPE DOES NOT ARRIVE.
  *
  * The fallback note asked reporters for their build and ComfyUI_frontend version.
- * Two reports arrived with exactly that, and neither identified the cause, because
- * the frontend version is not what discriminates. Measured on 1.48.7:
+ * Two reports arrived with exactly that and neither identified the cause, because
+ * the version is not what differs. Measured on a live 1.48.7:
  *
- *   * `app.queuePrompt`'s real signature is `(number, batchCount, queueNodeIds)`,
- *     and the third positional argument reaches `/prompt` as
- *     `partial_execution_targets`. The capability is present.
- *   * BOTH links in that chain are routinely PATCHED by extensions. On the machine
- *     this was measured on, `app.queuePrompt` is wrapped by a custom node and
- *     `api.queuePrompt` by rgthree — so reading `app.queuePrompt` reports arity 0
- *     and mentions neither `partial` nor `queueNodeIds`, while the real
- *     implementation sits on the prototype and does both.
+ *   * `app.queuePrompt`'s real implementation takes `(number, batchCount,
+ *     queueNodeIds)` and passes the third argument to `api.queuePrompt` as
+ *     `{ partialExecutionTargets }`, which the body builder emits as
+ *     `partial_execution_targets`. The capability is present on that build, and
+ *     `isPartialExecution` for the queue-time widget hooks derives from the same
+ *     array — so the `uncovered_inputs` drift is that same fact one layer up.
+ *   * BOTH links were SHADOWED by own properties on the instances (a custom node
+ *     over `app.queuePrompt`, rgthree over `api.queuePrompt`), so reading them
+ *     directly reports arity 0 and mentions neither `partial` nor `queueNodeIds`
+ *     while the prototype does both. Reading the instance alone is how one
+ *     concludes the capability is gone when it is not.
  *
- * A wrapper that forwards its arguments (rgthree's does: `apply(app, [index,
- * prompt, ...args])`) is harmless. A wrapper that does not is exactly how the scope
- * disappears with no error anywhere. That distinction is invisible in a version
- * number and visible here, so the note carries this instead of asking for one.
+ * THIS MODULE REPORTS OBSERVATIONS, NOT A DIAGNOSIS (codex review, four P1s).
+ * A first version said "PATCHED by an extension" and "a wrapper that does not
+ * forward its arguments is the thing to look at". Neither is established by what
+ * can be seen here: an own property is SHADOWING, which a frontend could equally
+ * do by binding in its constructor, and a shadowed method plus a capable prototype
+ * does not establish that a wrapper ate anything — both wrappers can forward
+ * perfectly while the scope is lost somewhere else entirely. Naming a suspect from
+ * that is how a diagnostic sends someone down the wrong path with confidence,
+ * which is the failure this whole note exists to stop repeating.
  *
- * Everything is read defensively: this runs on a failure path, and a diagnostic
+ * Everything is read through guards: this runs on a failure path, and a diagnostic
  * that throws replaces a recoverable fallback with a crash.
  */
 
-/** Is `name` an OWN property of `obj` — i.e. patched onto the instance, shadowing
- *  the prototype implementation the frontend ships? */
-function patchedOnInstance(obj, name) {
-  try {
-    return Boolean(obj && Object.prototype.hasOwnProperty.call(obj, name));
-  } catch {
-    return false;
-  }
-}
-
 /** Read a possibly-accessor property without letting it throw. */
-function readFn(obj, name) {
+function readProp(obj, name) {
   try {
     return obj ? obj[name] : undefined;
   } catch {
@@ -42,80 +40,111 @@ function readFn(obj, name) {
   }
 }
 
-function arityOf(fn) {
-  return typeof fn === "function" && Number.isInteger(fn.length) ? fn.length : -1;
-}
-
-/** Does the frontend's OWN api.queuePrompt understand the options shape at all?
- *  This is the one fact that separates "this build cannot do it" from "something
- *  in the chain dropped it" — the distinction both reports were missing. */
-function protoSupportsOptions(api) {
+/** Does `obj` carry its OWN `name`, shadowing the prototype's? A FACT — it does
+ *  not say who put it there, and a frontend binding its own method in a
+ *  constructor produces the same observation. */
+function shadowsPrototype(obj, name) {
   try {
-    const proto = api ? Object.getPrototypeOf(api) : null;
-    return /partialExecutionTargets/.test(String(proto?.queuePrompt ?? ""));
+    return Boolean(obj && Object.prototype.hasOwnProperty.call(obj, name));
   } catch {
     return false;
   }
 }
 
 /**
- * A one-line description of the app→api chain a scoped run travels through.
+ * Does the PROTOTYPE's queuePrompt source mention `partialExecutionTargets`?
  *
- * @param {object} deps `{ app, api }` — passed in rather than read from globals so
- *   this is testable without a browser, which is the whole reason it is a module.
- * @returns {{appPatched: boolean, appArity: number, apiPatched: boolean,
- *   apiArity: number, frontendSupportsOptions: boolean, summary: string}}
+ * Reported as what it is — a source-text observation, never as a capability
+ * verdict. A build can support the option through a helper, a differently named
+ * internal, or a minified identifier, so a "no" here is a reason to look, not a
+ * finding about the build (codex review).
+ *
+ * @returns {true|false|undefined} undefined when the source could not be read.
  */
-export function describeQueuePromptChain({ app, api } = {}) {
-  // Read through a guard: `api.queuePrompt` can be an accessor, and a getter that
-  // throws would turn this diagnostic into the failure it is describing. Caught by
-  // its own test, which is the point of running it on hostile input.
-  const appFn = readFn(app, "queuePrompt");
-  const apiFn = readFn(api, "queuePrompt");
-  const appPatched = patchedOnInstance(app, "queuePrompt");
-  const apiPatched = patchedOnInstance(api, "queuePrompt");
-  const appArity = arityOf(appFn);
-  const apiArity = arityOf(apiFn);
-  const frontendSupportsOptions = protoSupportsOptions(api);
-
-  const parts = [
-    `app.queuePrompt ${appPatched ? "PATCHED by an extension" : "unpatched"} (arity ${appArity})`,
-    `api.queuePrompt ${apiPatched ? "PATCHED by an extension" : "unpatched"} (arity ${apiArity})`,
-    frontendSupportsOptions
-      ? "the frontend's own api.queuePrompt DOES accept partialExecutionTargets"
-      : "the frontend's own api.queuePrompt does NOT mention partialExecutionTargets",
-  ];
-  return {
-    appPatched,
-    appArity,
-    apiPatched,
-    apiArity,
-    frontendSupportsOptions,
-    summary: parts.join("; "),
-  };
+function prototypeMentionsOption(api) {
+  try {
+    const proto = api ? Object.getPrototypeOf(api) : null;
+    const fn = readProp(proto, "queuePrompt");
+    if (typeof fn !== "function") return undefined;
+    const src = String(fn);
+    return src.length > 0 ? /partialExecutionTargets/.test(src) : undefined;
+  } catch {
+    return undefined;
+  }
 }
 
 /**
- * What to say about that chain in the fallback note.
+ * The observable state of the app→api chain a scoped run travels through.
  *
- * The ASK is the point. "Report your build and frontend version" was answered
- * twice and identified nothing; this names the two links that can silently drop an
- * argument, and says which one to look at first.
+ * @param {object} deps `{ app, api }` — passed in rather than read from globals so
+ *   this is testable without a browser, and so the CALLER's property access is not
+ *   this module's failure mode.
+ */
+export function describeQueuePromptChain({ app, api } = {}) {
+  const appShadowed = shadowsPrototype(app, "queuePrompt");
+  const apiShadowed = shadowsPrototype(api, "queuePrompt");
+  const protoMentionsOption = prototypeMentionsOption(api);
+
+  const parts = [
+    `app.queuePrompt ${appShadowed ? "is shadowed by an own property" : "comes from the prototype"}`,
+    `api.queuePrompt ${apiShadowed ? "is shadowed by an own property" : "comes from the prototype"}`,
+    protoMentionsOption === undefined
+      ? "the prototype's api.queuePrompt source could not be read"
+      : protoMentionsOption
+        ? "its prototype's source mentions partialExecutionTargets"
+        : "its prototype's source does not mention partialExecutionTargets",
+  ];
+  return { appShadowed, apiShadowed, protoMentionsOption, summary: parts.join("; ") };
+}
+
+/**
+ * What to put in the fallback note.
+ *
+ * Deliberately arrives at no conclusion. It states what was observed and what
+ * would settle it, because the observations available here cannot distinguish a
+ * wrapper that dropped the argument from a build that never carried it — and a
+ * confident wrong suspect is worse than the version request it replaces.
+ *
+ * Arity is deliberately NOT reported: a default parameter truncates
+ * Function.length, so the known-good implementation reports 1 while a correct
+ * forwarding wrapper reports 0. It reads like a signal and is noise.
  */
 export function describeQueuePromptChainForReport(chain) {
   if (!chain) return "";
-  const suspect =
-    chain.frontendSupportsOptions && (chain.appPatched || chain.apiPatched)
-      ? ` The frontend itself supports the scope here, so a wrapper that does not forward its ` +
-        `arguments is the thing to look at — an extension patch that calls through as ` +
-        `\`fn(index, prompt)\` instead of \`fn(index, prompt, ...args)\` drops the scope with no ` +
-        `error anywhere.`
-      : !chain.frontendSupportsOptions
-        ? ` The frontend's own api.queuePrompt does not mention partialExecutionTargets at all, ` +
-          `which points at the build rather than at an extension.`
-        : "";
+  const shadowed = chain.appShadowed || chain.apiShadowed;
+  const next = shadowed
+    ? ` Something on this page replaced one of those methods, which is normal — many extensions ` +
+      `do, and most forward their arguments correctly. What would settle it is whether the ` +
+      `replacement passes its THIRD argument through.`
+    : ` Neither method is shadowed here, so the argument reached the frontend's own code and was ` +
+      `lost at or after that point.`;
   return (
-    ` QUEUE CHAIN: ${chain.summary}.${suspect} Please include THIS line if you report it — the ` +
-    `ComfyUI_frontend version alone has already been reported twice without identifying the cause.`
+    ` QUEUE CHAIN (observed, not a diagnosis): ${chain.summary}.${next} Please include THIS line ` +
+    `if you report it, together with the body keys above — the ComfyUI_frontend version alone has ` +
+    `now been reported twice without identifying the cause.`
   );
+}
+
+/**
+ * Read the two globals the probe describes, defensively (#996, codex P1).
+ *
+ * The probe guards its own property reads, but the CALLER's `app?.api` sits
+ * outside it, and an extension-installed throwing getter there would crash the
+ * note instead of being described by it. `root` is injectable so that guarantee
+ * is testable rather than asserted.
+ */
+export function queuePromptChainDeps(root = globalThis) {
+  let app;
+  let api;
+  try {
+    app = root?.app ?? root?.comfyAPI?.app?.app;
+  } catch {
+    app = undefined;
+  }
+  try {
+    api = app?.api ?? root?.comfyAPI?.api?.api;
+  } catch {
+    api = undefined;
+  }
+  return { app, api };
 }


### PR DESCRIPTION
Closes #996 (and #1088, the same defect re-reported a day later on frontend 1.48.7).

On current frontends, NEITHER supported `app.queuePrompt` argument shape carries the run-to-node scope, so the panel writes `partial_execution_targets` into the request itself — `scope_applied_by: "request_body_repair"` on 100% of calls — and the note asks the user to report it, with the build number.

The repair works: only the requested branch executes, confirmed by render times. So the diagnostic is soliciting a report for what has become the normal path, on every single call. That is the same shape as panel#1065, where a stale instruction manufactured its own bug report.

Question 1 in the issue is the one that decides the fix, and it is answerable by measurement rather than by reading: which signature the live frontend actually exposes, and whether the scope can reach `/prompt` through it at all.

Draft while I measure that against the running ComfyUI.