### PR TITLE
fix(1089): a successful open must not report a canvas it did not verify

### DIFF
--- a/browser_tests/unit/open-rebind-proof.test.mjs
+++ b/browser_tests/unit/open-rebind-proof.test.mjs
@@ -986,6 +986,14 @@ test("#1089: the refusal is wired BEFORE loadGraphData, and says the canvas was 
   // workflow's with its own unsaved work, which the disk load replaces.
   assert.match(guardBlock, /the tab had no unsaved edits/);
   assert.match(guardBlock, /it replaces what is on the canvas/);
+  // #932/#702 — the recovery must be REACHABLE. A refused open publishes no
+  // workflow_uuid, and panel_load_workflow is not canvas-targetless, so a stamped
+  // load is refused as an instance mismatch. Naming it without naming the exempt
+  // probe first is the circularity #932's own header warns about: "the refusal text
+  // advertising a recovery that was itself refused for the same reason."
+  assert.match(guardBlock, /panel_list_workflows BEFORE the load/);
+  assert.match(guardBlock, /carries no fence refresh/);
+  assert.match(guardBlock, /Reloading the panel is NOT required/);
   // And it must be a REFUSAL, not a disclosure riding a success.
   assert.match(guardBlock, /rebindFailed = new Error\(/);
 });

--- a/browser_tests/unit/open-rebind-proof.test.mjs
+++ b/browser_tests/unit/open-rebind-proof.test.mjs
@@ -796,6 +796,7 @@ test("#1089: a state owned by another OPEN workflow is foreign — the open must
       targetUuid: UUID_A,
       targetClaimsTag: CLAIMS_NOTHING,
       tagOwnedByOtherOpenWorkflow: OTHER_OPEN,
+      targetTabIsClean: true,
     }),
     "foreign",
   );
@@ -842,9 +843,44 @@ test("#1089: a mismatch alone is NOT foreign — a predecessor's uuid residue mu
       targetClaimsTag: CLAIMS_NOTHING,
       // registered to nobody currently open — residue, not another tab's graph
       tagOwnedByOtherOpenWorkflow: NO_OWNER,
+      targetTabIsClean: true,
     }),
     "unknown",
   );
+});
+
+test("#1089: a DIRTY tab is never refused — the #817 false-positive codex found, and its cost", () => {
+  // codex NO-SHIP, round 1. The tag cannot prove the GRAPH is foreign. #817: a tab
+  // switch leaves the previous workflow's tag on the reused app.graph, and the
+  // guard's rebind re-stamps that root on CONTENT proof
+  // (rootContentProvesActiveWorkflow), not on a claimed tag. stampGraphRootWorkflowUuid
+  // writes rootGraph.extra and nothing else, so a capture taken before the heal leaves
+  // this tab's OWN content under the other tab's meta block — and the whole
+  // comfyui_mcp block travels together, so no field in it separates that from a
+  // genuinely foreign graph.
+  //
+  // The refusal is therefore justified by its COST, not by proof. On a clean tab a
+  // wrong refusal costs one extra panel_load_workflow and loses nothing, because the
+  // file IS the tab's content. On a dirty tab that same advice discards unsaved work,
+  // so a dirty tab repaints exactly as it does today.
+  const foreignTagArgs = {
+    state: taggedState("workflow-B"),
+    targetUuid: UUID_A,
+    targetClaimsTag: CLAIMS_NOTHING,
+    tagOwnedByOtherOpenWorkflow: OTHER_OPEN,
+  };
+  assert.equal(describeRepaintSourceBinding({ ...foreignTagArgs, targetTabIsClean: false }), "unknown");
+  // Compared against `true` explicitly: an unreadable dirty flag is not a clean tab.
+  for (const notClean of [undefined, null, 0, "", "true", 1, {}]) {
+    assert.equal(
+      describeRepaintSourceBinding({ ...foreignTagArgs, targetTabIsClean: notClean }),
+      "unknown",
+      `a non-true cleanliness reading must not license the refusal: ${JSON.stringify(notClean)}`,
+    );
+  }
+  // ...and the clean tab still is refused, so the gate narrows the refusal without
+  // removing it. #1089's own tab reported modified:false.
+  assert.equal(describeRepaintSourceBinding({ ...foreignTagArgs, targetTabIsClean: true }), "foreign");
 });
 
 test("#1089: absent evidence changes nothing — the #968 residual stays a residual, not a refusal", () => {
@@ -866,6 +902,9 @@ test("#1089: absent evidence changes nothing — the #968 residual stays a resid
         ...args,
         targetClaimsTag: CLAIMS_NOTHING,
         tagOwnedByOtherOpenWorkflow: OTHER_OPEN,
+        // clean, so `unknown` here is the ABSENT EVIDENCE talking and not the
+        // cleanliness gate standing in for it
+        targetTabIsClean: true,
       }),
       "unknown",
       `inconclusive input must answer unknown: ${JSON.stringify(args.state)}`,
@@ -883,6 +922,7 @@ test("#1089: a predicate that throws is inconclusive, never a refusal", () => {
         throw new Error("owner map unreadable");
       },
       tagOwnedByOtherOpenWorkflow: OTHER_OPEN,
+      targetTabIsClean: true,
     }),
     "unknown",
   );
@@ -894,12 +934,17 @@ test("#1089: a predicate that throws is inconclusive, never a refusal", () => {
       tagOwnedByOtherOpenWorkflow: () => {
         throw new Error("openWorkflows unreadable");
       },
+      targetTabIsClean: true,
     }),
     "unknown",
   );
   // Missing predicates are the same story — an unasked question is not an answer.
   assert.equal(
-    describeRepaintSourceBinding({ state: taggedState("workflow-B"), targetUuid: UUID_A }),
+    describeRepaintSourceBinding({
+      state: taggedState("workflow-B"),
+      targetUuid: UUID_A,
+      targetTabIsClean: true,
+    }),
     "unknown",
   );
 });
@@ -926,10 +971,21 @@ test("#1089: the refusal is wired BEFORE loadGraphData, and says the canvas was 
   // OPEN, not merely registered — the predecessor-residue escape (see the helper).
   assert.match(guardBlock, /openWorkflows/);
   assert.match(guardBlock, /sameWorkflowObject\(w, owner\)/);
+  // Cleanliness comes from the PRE-AWAIT snapshot, not a live re-read:
+  // clearSpuriousOpenModified force-clears isModified, so `target.isModified` here
+  // would read clean for a tab that arrived dirty and license the refusal whose cost
+  // is only bounded when the tab really is clean (#442/codex).
+  assert.match(guardBlock, /targetTabIsClean: !wasDirty/);
+  assert.doesNotMatch(guardBlock, /targetTabIsClean: !target\.isModified/);
   // The message: nothing was loaded, and the recovery that works, with its trap.
   assert.match(guardBlock, /nothing was overwritten/, "it must say the canvas was left alone");
   assert.match(guardBlock, /panel_load_workflow/, "it must name the recovery that reads from disk");
-  assert.match(guardBlock, /NOT save first/, "it must name the save-over trap");
+  assert.match(guardBlock, /NOT plain-save first/, "it must name the save-over trap");
+  // The recovery is safe for THIS workflow precisely because the tab was clean, and
+  // the message must not overstate that into "safe" — the CANVAS may be another
+  // workflow's with its own unsaved work, which the disk load replaces.
+  assert.match(guardBlock, /the tab had no unsaved edits/);
+  assert.match(guardBlock, /it replaces what is on the canvas/);
   // And it must be a REFUSAL, not a disclosure riding a success.
   assert.match(guardBlock, /rebindFailed = new Error\(/);
 });

--- a/browser_tests/unit/open-rebind-proof.test.mjs
+++ b/browser_tests/unit/open-rebind-proof.test.mjs
@@ -796,7 +796,6 @@ test("#1089: a state owned by another OPEN workflow is foreign — the open must
       targetUuid: UUID_A,
       targetClaimsTag: CLAIMS_NOTHING,
       tagOwnedByOtherOpenWorkflow: OTHER_OPEN,
-      targetTabIsClean: true,
     }),
     "foreign",
   );
@@ -843,44 +842,57 @@ test("#1089: a mismatch alone is NOT foreign — a predecessor's uuid residue mu
       targetClaimsTag: CLAIMS_NOTHING,
       // registered to nobody currently open — residue, not another tab's graph
       tagOwnedByOtherOpenWorkflow: NO_OWNER,
-      targetTabIsClean: true,
     }),
     "unknown",
   );
 });
 
-test("#1089: a DIRTY tab is never refused — the #817 false-positive codex found, and its cost", () => {
-  // codex NO-SHIP, round 1. The tag cannot prove the GRAPH is foreign. #817: a tab
-  // switch leaves the previous workflow's tag on the reused app.graph, and the
-  // guard's rebind re-stamps that root on CONTENT proof
-  // (rootContentProvesActiveWorkflow), not on a claimed tag. stampGraphRootWorkflowUuid
-  // writes rootGraph.extra and nothing else, so a capture taken before the heal leaves
-  // this tab's OWN content under the other tab's meta block — and the whole
-  // comfyui_mcp block travels together, so no field in it separates that from a
-  // genuinely foreign graph.
+test("#1089: the tab's dirty flag is NOT an input — it is wrong in both directions", () => {
+  // A `targetTabIsClean` gate existed here across two attempts and is gone. Both
+  // stronger remedies it was gating are gone with it, and the reason is that
+  // `isModified` cannot answer the question either of them needed:
   //
-  // The refusal is therefore justified by its COST, not by proof. On a clean tab a
-  // wrong refusal costs one extra panel_load_workflow and loses nothing, because the
-  // file IS the tab's content. On a dirty tab that same advice discards unsaved work,
-  // so a dirty tab repaints exactly as it does today.
+  //   spuriously FALSE — #874: ChangeTracker captures on USER INPUT events only, so a
+  //   value a NODE wrote (a populated wildcard, a rolled seed) is on the canvas, never
+  //   marks the tab modified, and was never saved. An auto-correct from disk gated on
+  //   "clean" would silently replace exactly what an agent just generated.
+  //
+  //   spuriously TRUE — a first-time open never runs clearSpuriousOpenModified (it is
+  //   gated on the freeze, and the freeze is scoped to wasOpen), so a cold-opened tab
+  //   reads modified for its whole life. Gating on it would have disarmed this guard
+  //   for that entire population — the #1089 report, unprevented.
+  //
+  // So the classification is evidence-only and the flag is not consulted. Passing one
+  // must change nothing, in either direction.
   const foreignTagArgs = {
     state: taggedState("workflow-B"),
     targetUuid: UUID_A,
     targetClaimsTag: CLAIMS_NOTHING,
     tagOwnedByOtherOpenWorkflow: OTHER_OPEN,
   };
-  assert.equal(describeRepaintSourceBinding({ ...foreignTagArgs, targetTabIsClean: false }), "unknown");
-  // Compared against `true` explicitly: an unreadable dirty flag is not a clean tab.
-  for (const notClean of [undefined, null, 0, "", "true", 1, {}]) {
+  assert.equal(describeRepaintSourceBinding(foreignTagArgs), "foreign");
+  for (const stray of [true, false, undefined, null, 0, "", 1, {}]) {
     assert.equal(
-      describeRepaintSourceBinding({ ...foreignTagArgs, targetTabIsClean: notClean }),
-      "unknown",
-      `a non-true cleanliness reading must not license the refusal: ${JSON.stringify(notClean)}`,
+      describeRepaintSourceBinding({ ...foreignTagArgs, targetTabIsClean: stray }),
+      "foreign",
+      `a stray cleanliness reading must not change the answer: ${JSON.stringify(stray)}`,
     );
   }
-  // ...and the clean tab still is refused, so the gate narrows the refusal without
-  // removing it. #1089's own tab reported modified:false.
-  assert.equal(describeRepaintSourceBinding({ ...foreignTagArgs, targetTabIsClean: true }), "foreign");
+});
+
+test("#1089: the panel source does not gate this on the dirty flag anywhere", () => {
+  // Belt-and-braces for the above: the helper ignoring the input is only half of it if
+  // the call site re-introduces the gate with an `if`.
+  const src = readFileSync(PANEL_JS, "utf8");
+  assert.doesNotMatch(src, /targetTabIsClean/, "the removed gate must not come back");
+  const guardAt = src.indexOf("describeRepaintSourceBinding({");
+  const callEnd = src.indexOf('}) === "foreign"', guardAt);
+  assert.ok(callEnd > guardAt);
+  assert.doesNotMatch(
+    src.slice(guardAt, callEnd),
+    /wasDirty|isModified/,
+    "the classification must not consult the dirty flag",
+  );
 });
 
 test("#1089: absent evidence changes nothing — the #968 residual stays a residual, not a refusal", () => {
@@ -904,7 +916,6 @@ test("#1089: absent evidence changes nothing — the #968 residual stays a resid
         tagOwnedByOtherOpenWorkflow: OTHER_OPEN,
         // clean, so `unknown` here is the ABSENT EVIDENCE talking and not the
         // cleanliness gate standing in for it
-        targetTabIsClean: true,
       }),
       "unknown",
       `inconclusive input must answer unknown: ${JSON.stringify(args.state)}`,
@@ -922,7 +933,6 @@ test("#1089: a predicate that throws is inconclusive, never a refusal", () => {
         throw new Error("owner map unreadable");
       },
       tagOwnedByOtherOpenWorkflow: OTHER_OPEN,
-      targetTabIsClean: true,
     }),
     "unknown",
   );
@@ -934,7 +944,6 @@ test("#1089: a predicate that throws is inconclusive, never a refusal", () => {
       tagOwnedByOtherOpenWorkflow: () => {
         throw new Error("openWorkflows unreadable");
       },
-      targetTabIsClean: true,
     }),
     "unknown",
   );
@@ -943,57 +952,117 @@ test("#1089: a predicate that throws is inconclusive, never a refusal", () => {
     describeRepaintSourceBinding({
       state: taggedState("workflow-B"),
       targetUuid: UUID_A,
-      targetTabIsClean: true,
     }),
     "unknown",
   );
 });
 
-test("#1089: the refusal is wired BEFORE loadGraphData, and says the canvas was left alone", () => {
+test("#1089: the open CORRECTS the source instead of refusing — refusing wedges the session", () => {
+  // codex NO-SHIP, round 1 (second finding, and the one that killed the approach).
+  // Refusing before loadGraphData removes the repaint's root re-stamp, which is the
+  // ONE documented heal for a conflicting root tag. The pointer is already on the
+  // target while app.graph carries the OTHER workflow's uuid, and there
+  // assertGraphBoundToActiveWorkflow refuses every graph_* command — including the
+  // panel_load_workflow the refusal recommended (graph_load is a MUTATION, and
+  // rootContentProvesActiveWorkflow is false because sealProofExclusive is killed by
+  // the real owner being open and clean with a state matching the root). It throws
+  // [root-workflow-uuid-mismatch], whose own remedy is "re-open the active workflow
+  // tab", which re-enters the refusal. A hard loop, on true positives too.
   const src = readFileSync(PANEL_JS, "utf8");
   const guardAt = src.indexOf("describeRepaintSourceBinding({");
   assert.notEqual(guardAt, -1, "the open path must classify the state it repaints from");
-  // BEFORE the load. Every other rebind failure is detected after loadGraphData,
-  // which is fine for this tab's own payload; here the load is the step that paints
-  // the foreign graph and stamps this workflow's identity onto it.
   const loadAt = src.indexOf("await app.loadGraphData(repaintState, true, true, target)");
   assert.notEqual(loadAt, -1);
-  assert.ok(guardAt < loadAt, "the source must be classified before the graph is loaded");
-  // The refusal branch ONLY — the repaint's own `else` follows it and legitimately
-  // does use the embedding resolver, so slicing to the load would prove nothing.
-  const branchEnd = src.indexOf("} else {", guardAt);
-  assert.ok(branchEnd > guardAt && branchEnd < loadAt, "the refusal must be its own branch");
-  const guardBlock = src.slice(guardAt, branchEnd);
-  // It must NOT be the embedding resolver: `{ embed: true }` writes the identity
-  // stamp, which belongs to a repaint that is about to be refused.
-  assert.doesNotMatch(guardBlock, /workflowStableUuid\(target, \{ embed: true \}\)/);
-  assert.match(guardBlock, /workflowObjectUuid\(target\) \|\| workflowStableUuid\(target\)/);
+  assert.ok(guardAt < loadAt, "the source is classified before the load...");
+
+  // ...but the classification must NOT gate the load. The whole defect above is that
+  // a refusal here strands the root tag, so this branch may never set rebindFailed.
+  // Anchored on the block's own comment, not on the call: the assignment precedes the
+  // call, so a slice starting at the call would miss it and pass vacuously.
+  const classifyAt = src.indexOf("#1089 — is the state we are about to repaint FROM");
+  assert.notEqual(classifyAt, -1);
+  assert.ok(classifyAt < loadAt);
+  const classifyBlock = src.slice(classifyAt, loadAt);
+  assert.doesNotMatch(
+    classifyBlock,
+    /rebindFailed = new Error\(/,
+    "a foreign source must never refuse the open — that removes the root re-stamp and wedges every graph command",
+  );
+  assert.match(classifyBlock, /sourceForeign =/, "it records the fact instead");
+
+  // The CALL's arguments only. The classification now shares a block with the repaint,
+  // which legitimately does use the embedding resolver, so the wider slice cannot carry
+  // these assertions.
+  const callEnd = src.indexOf('}) === "foreign"', guardAt);
+  assert.ok(callEnd > guardAt, "the classification must be a single expression");
+  const callBlock = src.slice(guardAt, callEnd);
+  // NOT the embedding resolver: `{ embed: true }` writes the identity stamp, which
+  // belongs to the repaint, not to a question about the payload it is handed.
+  assert.doesNotMatch(callBlock, /workflowStableUuid\(target, \{ embed: true \}\)/);
+  assert.match(callBlock, /workflowObjectUuid\(target\) \|\| workflowStableUuid\(target\)/);
   // OPEN, not merely registered — the predecessor-residue escape (see the helper).
-  assert.match(guardBlock, /openWorkflows/);
-  assert.match(guardBlock, /sameWorkflowObject\(w, owner\)/);
-  // Cleanliness comes from the PRE-AWAIT snapshot, not a live re-read:
-  // clearSpuriousOpenModified force-clears isModified, so `target.isModified` here
-  // would read clean for a tab that arrived dirty and license the refusal whose cost
-  // is only bounded when the tab really is clean (#442/codex).
-  assert.match(guardBlock, /targetTabIsClean: !wasDirty/);
-  assert.doesNotMatch(guardBlock, /targetTabIsClean: !target\.isModified/);
-  // The message: nothing was loaded, and the recovery that works, with its trap.
-  assert.match(guardBlock, /nothing was overwritten/, "it must say the canvas was left alone");
-  assert.match(guardBlock, /panel_load_workflow/, "it must name the recovery that reads from disk");
-  assert.match(guardBlock, /NOT plain-save first/, "it must name the save-over trap");
-  // The recovery is safe for THIS workflow precisely because the tab was clean, and
-  // the message must not overstate that into "safe" — the CANVAS may be another
-  // workflow's with its own unsaved work, which the disk load replaces.
-  assert.match(guardBlock, /the tab had no unsaved edits/);
-  assert.match(guardBlock, /it replaces what is on the canvas/);
-  // #932/#702 — the recovery must be REACHABLE. A refused open publishes no
-  // workflow_uuid, and panel_load_workflow is not canvas-targetless, so a stamped
-  // load is refused as an instance mismatch. Naming it without naming the exempt
-  // probe first is the circularity #932's own header warns about: "the refusal text
-  // advertising a recovery that was itself refused for the same reason."
-  assert.match(guardBlock, /panel_list_workflows BEFORE the load/);
-  assert.match(guardBlock, /carries no fence refresh/);
-  assert.match(guardBlock, /Reloading the panel is NOT required/);
-  // And it must be a REFUSAL, not a disclosure riding a success.
-  assert.match(guardBlock, /rebindFailed = new Error\(/);
+  assert.match(callBlock, /openWorkflows/);
+  assert.match(callBlock, /sameWorkflowObject\(w, owner\)/);
+  // Cleanliness is the PRE-AWAIT snapshot, not a live re-read: clearSpuriousOpenModified
+  // force-clears isModified, so `target.isModified` would read clean for a tab that
+  // arrived dirty and would authorize the destructive disk re-read over real work.
+});
+
+test("#1089: a foreign source must NOT trigger an automatic disk re-read", () => {
+  // The second removed remedy. It reused #442's re-read — freeze, section ownership,
+  // __cmcpKeepInstance, all of it — and was still wrong, because #442's trigger is
+  // "the FILE provably changed since this tab loaded it", which is independent evidence
+  // that the disk copy is the newer one. A foreign source tag is no evidence about the
+  // file at all, and #874's user-input-only capture means a tab reporting no unsaved
+  // edits can still hold node-written values that only exist on the canvas.
+  const src = readFileSync(PANEL_JS, "utf8");
+  assert.doesNotMatch(src, /reloadWanted/, "the combined reload trigger must be gone");
+  assert.doesNotMatch(src, /reloadForForeignSource/);
+  // #442's own three branches must be back on their own trigger, untouched.
+  assert.match(src, /if \(staleInfo\.reload && !dirtyNow && !wasDirty && priorInteraction === null\)/);
+  assert.match(src, /staleInfo\.reload &&\r?\n\s*!dirtyNow &&\r?\n\s*!wasDirty &&\r?\n\s*!ownsWorkflowReloadGuard/);
+  assert.match(src, /\} else if \(staleInfo\.reload && !dirtyNow && !wasDirty\) \{/);
+  // And `sourceForeign` must reach the reply only — never a load, never a refusal.
+  const decl = src.indexOf("sourceForeign =");
+  assert.notEqual(decl, -1);
+  for (const forbidden of [/sourceForeign[^;\n]*loadGraphData/, /sourceForeign[^;\n]*rebindFailed/]) {
+    assert.doesNotMatch(src, forbidden, "a foreign source may neither load nor refuse");
+  }
+});
+
+test("#1089: the outcome is disclosed on its own key, both when corrected and when not", () => {
+  const src = readFileSync(PANEL_JS, "utf8");
+  const keyAt = src.indexOf("foreign_source_state:");
+  assert.notEqual(keyAt, -1, "the caller must be told the state was another workflow's");
+  // Its OWN key, OUTSIDE the stale branch. `reloaded` is only surfaced inside
+  // `stale === true`, so a re-read triggered by this condition while the file never
+  // changed would set it and surface nothing at all — folding this into stale_hint
+  // would report a bare success for exactly the case being fixed.
+  const staleBranchAt = src.indexOf("...(staleInfo.stale === true");
+  assert.notEqual(staleBranchAt, -1);
+  assert.ok(keyAt < staleBranchAt, "it must not live inside the stale === true branch");
+  // `stale_hint` occurs earlier in the file for unrelated commands, so bound the slice
+  // by the next one AFTER this key rather than the first in the file.
+  const block = src.slice(keyAt, src.indexOf("stale_hint:", keyAt));
+  assert.ok(block.length > 0);
+  // It must say what to DO, and the action is a comparison the caller can make — the
+  // panel cannot make it (see below), so telling them to verify is the whole remedy.
+  assert.match(block, /VERIFY THE GRAPH BEFORE EDITING/);
+  assert.match(block, /panel_graph_outline/, "it must name the read that lets them check");
+  // It must explain why nothing else on the reply warned. Those fields are TRUE of the
+  // tab; that is exactly why the reporter proceeded on them.
+  assert.match(block, /is TRUE\b/, "the other fields are true, not broken");
+  // MAY, not IS — #817 residue is indistinguishable from a foreign graph, so a definite
+  // claim would be an overclaim, and an overclaim here sends people to a destructive load.
+  assert.match(block, /MAY be, not IS/);
+  assert.match(block, /#817/);
+  // The recovery is named WITH its cost, including the #874 trap that a clean-looking
+  // tab can still lose node-written values to it.
+  assert.match(block, /panel_load_workflow/);
+  assert.match(block, /REPLACES the canvas/);
+  assert.match(block, /#874/, "the node-written-values trap must be named");
+  assert.match(block, /a plain save/, "…and the save-over-the-target trap");
+  // It must NOT claim the panel corrected anything: it did not.
+  assert.doesNotMatch(block, /RE-READ FROM DISK/);
+  assert.doesNotMatch(block, /was therefore/);
 });

--- a/browser_tests/unit/open-rebind-proof.test.mjs
+++ b/browser_tests/unit/open-rebind-proof.test.mjs
@@ -37,6 +37,7 @@ import { fileURLToPath } from "node:url";
 import {
   describeGraphStateDifference,
   describeOpenRebindOutcome,
+  describeRepaintSourceBinding,
   graphRootCarriesOpenProof,
   graphRootMatchesState,
   graphRootWorkflowUuidMatches,
@@ -759,4 +760,176 @@ test("#702: the fence note is ONLY on the content-unverified outcome", () => {
   // probe would otherwise be invited against a binding that was never proven.
   assert.doesNotMatch(unproven, /Reloading the panel is NOT required/);
   assert.match(unproven, /reload the panel before graph edits/);
+});
+
+// ---------------------------------------------------------------------------
+// #1089 — the SOURCE of the repaint, which no post-load proof looks at.
+//
+// The reporter got a clean success: right path, right filename, right
+// workflow_uuid, modified:false — and the PREVIOUS workflow's graph on the
+// canvas. Their next calls were panel_remove_node, and Save-As preserves ids,
+// so those deletions would largely have LANDED on the wrong workflow.
+//
+// Nothing was fooled. All four parts of resolveOpenRebindVerdict are taken
+// against the root the loader produced, so each was a true statement about a
+// poisoned SOURCE state. #968 closed the writer this repo owns and recorded
+// that an untagged root is still captured; a state already poisoned still
+// reaches the load, and the load is what makes it durable — it stamps the
+// target's identity onto the foreign graph, so a later save writes it to the
+// target's file.
+// ---------------------------------------------------------------------------
+
+/** A serialized tab state carrying the panel's durable workflow tag. */
+const taggedState = (uuid) => ({
+  nodes: [{ id: 1, type: "KSampler" }],
+  extra: uuid ? { [PANEL_GRAPH_META_KEY]: { workflow_uuid: uuid } } : {},
+});
+
+const OTHER_OPEN = () => true;
+const NO_OWNER = () => false;
+const CLAIMS_NOTHING = () => false;
+
+test("#1089: a state owned by another OPEN workflow is foreign — the open must not repaint from it", () => {
+  assert.equal(
+    describeRepaintSourceBinding({
+      state: taggedState("workflow-B"),
+      targetUuid: UUID_A,
+      targetClaimsTag: CLAIMS_NOTHING,
+      tagOwnedByOtherOpenWorkflow: OTHER_OPEN,
+    }),
+    "foreign",
+  );
+});
+
+test("#1089: the tab's own state is bound and repaints exactly as before", () => {
+  assert.equal(
+    describeRepaintSourceBinding({
+      state: taggedState(UUID_A),
+      targetUuid: UUID_A,
+      // Neither predicate is consulted on the matching path. Throwing proves it:
+      // a match is decided by the tags alone.
+      targetClaimsTag: () => {
+        throw new Error("must not be consulted");
+      },
+      tagOwnedByOtherOpenWorkflow: () => {
+        throw new Error("must not be consulted");
+      },
+    }),
+    "bound",
+  );
+});
+
+test("#1089: a mismatch alone is NOT foreign — a predecessor's uuid residue must not refuse a good open", () => {
+  // workflowOwnsRootUuidTag's own header: a lagging activeState can carry a
+  // REPLACED PREDECESSOR's uuid, "indistinguishable from the genuine lineage
+  // stamp". Refusing on the bare mismatch would send that caller to a disk load,
+  // which discards the unsaved work on the canvas — so the false refusal is
+  // destructive too, and there is no safe default. Both escapes are asserted.
+  assert.equal(
+    describeRepaintSourceBinding({
+      state: taggedState("workflow-B"),
+      targetUuid: UUID_A,
+      // the target's own lineage claims the conflicting tag (#545/#557 drift)
+      targetClaimsTag: (tag) => tag === "workflow-B",
+      tagOwnedByOtherOpenWorkflow: OTHER_OPEN,
+    }),
+    "unknown",
+  );
+  assert.equal(
+    describeRepaintSourceBinding({
+      state: taggedState("workflow-B"),
+      targetUuid: UUID_A,
+      targetClaimsTag: CLAIMS_NOTHING,
+      // registered to nobody currently open — residue, not another tab's graph
+      tagOwnedByOtherOpenWorkflow: NO_OWNER,
+    }),
+    "unknown",
+  );
+});
+
+test("#1089: absent evidence changes nothing — the #968 residual stays a residual, not a refusal", () => {
+  // An UNTAGGED state is the case #968 left open, and this must not manufacture a
+  // verdict for it: older frontends and never-stamped canvases behave as before.
+  for (const args of [
+    { state: taggedState(null), targetUuid: UUID_A },
+    { state: { nodes: [] }, targetUuid: UUID_A },
+    { state: null, targetUuid: UUID_A },
+    { state: undefined, targetUuid: UUID_A },
+    // no resolvable identity for the TARGET is equally inconclusive
+    { state: taggedState("workflow-B"), targetUuid: null },
+    { state: taggedState("workflow-B"), targetUuid: "" },
+    // a non-string tag is not a tag
+    { state: { extra: { [PANEL_GRAPH_META_KEY]: { workflow_uuid: 7 } } }, targetUuid: UUID_A },
+  ]) {
+    assert.equal(
+      describeRepaintSourceBinding({
+        ...args,
+        targetClaimsTag: CLAIMS_NOTHING,
+        tagOwnedByOtherOpenWorkflow: OTHER_OPEN,
+      }),
+      "unknown",
+      `inconclusive input must answer unknown: ${JSON.stringify(args.state)}`,
+    );
+  }
+  assert.equal(describeRepaintSourceBinding(), "unknown", "no arguments at all is inconclusive");
+});
+
+test("#1089: a predicate that throws is inconclusive, never a refusal", () => {
+  assert.equal(
+    describeRepaintSourceBinding({
+      state: taggedState("workflow-B"),
+      targetUuid: UUID_A,
+      targetClaimsTag: () => {
+        throw new Error("owner map unreadable");
+      },
+      tagOwnedByOtherOpenWorkflow: OTHER_OPEN,
+    }),
+    "unknown",
+  );
+  assert.equal(
+    describeRepaintSourceBinding({
+      state: taggedState("workflow-B"),
+      targetUuid: UUID_A,
+      targetClaimsTag: CLAIMS_NOTHING,
+      tagOwnedByOtherOpenWorkflow: () => {
+        throw new Error("openWorkflows unreadable");
+      },
+    }),
+    "unknown",
+  );
+  // Missing predicates are the same story — an unasked question is not an answer.
+  assert.equal(
+    describeRepaintSourceBinding({ state: taggedState("workflow-B"), targetUuid: UUID_A }),
+    "unknown",
+  );
+});
+
+test("#1089: the refusal is wired BEFORE loadGraphData, and says the canvas was left alone", () => {
+  const src = readFileSync(PANEL_JS, "utf8");
+  const guardAt = src.indexOf("describeRepaintSourceBinding({");
+  assert.notEqual(guardAt, -1, "the open path must classify the state it repaints from");
+  // BEFORE the load. Every other rebind failure is detected after loadGraphData,
+  // which is fine for this tab's own payload; here the load is the step that paints
+  // the foreign graph and stamps this workflow's identity onto it.
+  const loadAt = src.indexOf("await app.loadGraphData(repaintState, true, true, target)");
+  assert.notEqual(loadAt, -1);
+  assert.ok(guardAt < loadAt, "the source must be classified before the graph is loaded");
+  // The refusal branch ONLY — the repaint's own `else` follows it and legitimately
+  // does use the embedding resolver, so slicing to the load would prove nothing.
+  const branchEnd = src.indexOf("} else {", guardAt);
+  assert.ok(branchEnd > guardAt && branchEnd < loadAt, "the refusal must be its own branch");
+  const guardBlock = src.slice(guardAt, branchEnd);
+  // It must NOT be the embedding resolver: `{ embed: true }` writes the identity
+  // stamp, which belongs to a repaint that is about to be refused.
+  assert.doesNotMatch(guardBlock, /workflowStableUuid\(target, \{ embed: true \}\)/);
+  assert.match(guardBlock, /workflowObjectUuid\(target\) \|\| workflowStableUuid\(target\)/);
+  // OPEN, not merely registered — the predecessor-residue escape (see the helper).
+  assert.match(guardBlock, /openWorkflows/);
+  assert.match(guardBlock, /sameWorkflowObject\(w, owner\)/);
+  // The message: nothing was loaded, and the recovery that works, with its trap.
+  assert.match(guardBlock, /nothing was overwritten/, "it must say the canvas was left alone");
+  assert.match(guardBlock, /panel_load_workflow/, "it must name the recovery that reads from disk");
+  assert.match(guardBlock, /NOT save first/, "it must name the save-over trap");
+  // And it must be a REFUSAL, not a disclosure riding a success.
+  assert.match(guardBlock, /rebindFailed = new Error\(/);
 });

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -13333,7 +13333,12 @@ const GRAPH_TOOL_EXECUTORS = {
                 "— but it replaces what is on the canvas, and the canvas may be another workflow's " +
                 "with ITS unsaved work on it. So do NOT plain-save first: the active identity already " +
                 "names the workflow you asked for, so a save would write that other graph over it. " +
-                "Preserve it to a NEW path (Save As or an export) if you need it, then load.",
+                "Preserve it to a NEW path (Save As or an export) if you need it, then load. Call " +
+                "panel_list_workflows BEFORE the load: this reply carries no fence refresh — a refused " +
+                "open publishes no workflow_uuid — and panel_load_workflow is NOT exempt from the " +
+                "fence, so a command stamped from an older identity is refused as a workflow instance " +
+                "mismatch. panel_list_workflows is exempt (#932) and republishes the active identity, " +
+                "which permits the load. Reloading the panel is NOT required (#702).",
             );
           } else {
             // A graph shape is not ownership proof: two dirty tabs can have the same

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -13089,6 +13089,10 @@ const GRAPH_TOOL_EXECUTORS = {
     let dirtyNow = false;
     let staleInfo = { stale: false, reload: false };
     let canvasDivergence = null; // #968
+    // #1089 — the tab's own in-memory state provably carried ANOTHER open workflow's
+    // identity, so the repaint below reproduced a graph that is not this workflow's.
+    // Drives the disk re-read that corrects it, and is disclosed either way.
+    let sourceForeign = false;
     let reloaded = false;
     let reloadError = null;
     let openFailed = null;
@@ -13290,57 +13294,48 @@ const GRAPH_TOOL_EXECUTORS = {
               "workflow_open could not rebind the active canvas because this frontend does not expose " +
                 "loadGraphData. The open may have switched the active workflow; reload the panel before graph edits.",
             );
-          } else if (
-            describeRepaintSourceBinding({
-              state: st,
-              // The pair #708 resolves ownership with, and for the same reason: the
-              // live object's own uuid first, and the root-blind resolver only as the
-              // fallback, so the stale root this is trying to detect can never supply
-              // the answer. NOT `{ embed: true }` — the embedding stamp belongs to the
-              // repaint below, which must not happen at all if the source is foreign.
-              targetUuid: workflowObjectUuid(target) || workflowStableUuid(target),
-              targetClaimsTag: (tag) => workflowOwnsRootUuidTag(target, tag),
-              tagOwnedByOtherOpenWorkflow: (tag) => {
-                const owner = workflowUuidOwner(tag);
-                if (!owner || sameWorkflowObject(owner, target)) return false;
-                // OPEN, not merely registered: a replaced predecessor stays in the
-                // owner map, and its uuid residue in a lagging `activeState` is the
-                // documented look-alike this must not refuse on (see the helper).
-                const openNow = app?.extensionManager?.workflow?.openWorkflows;
-                return Array.isArray(openNow) && openNow.some((w) => sameWorkflowObject(w, owner));
-              },
-              // The snapshot taken before any await (#442/codex), which is the only
-              // reading that survives `clearSpuriousOpenModified`. It is what bounds
-              // the cost of a wrong refusal to one extra call — see the helper.
-              targetTabIsClean: !wasDirty,
-            }) === "foreign"
-          ) {
-            // #1089 — REFUSE BEFORE THE LOAD. Every other rebind failure below is
-            // detected after `loadGraphData`, which is fine when the payload is this
-            // tab's own; here it is another tab's graph, and the load is the step that
-            // makes the damage durable: it paints the foreign graph and stamps the
-            // target's identity onto it, so a later save writes it to the target's
-            // file. Nothing is loaded, so the canvas is exactly as the caller left it.
-            rebindFailed = new Error(
-              "workflow_open did NOT repaint the canvas: this tab's in-memory state carries the " +
-                "identity of a DIFFERENT open workflow, so repainting from it risked putting that " +
-                "workflow's nodes on the canvas under this workflow's identity and reporting a clean " +
-                "success — which is #1089, where the caller's next node deletions would have landed on " +
-                "the wrong workflow. Nothing was loaded and nothing was overwritten: the canvas still " +
-                "holds whatever it held before this call, and the active workflow pointer HAS moved to " +
-                "the requested one. Recover with panel_load_workflow on this workflow's path. That is " +
-                "safe for THIS workflow — the tab had no unsaved edits, so its file is its own content " +
-                "— but it replaces what is on the canvas, and the canvas may be another workflow's " +
-                "with ITS unsaved work on it. So do NOT plain-save first: the active identity already " +
-                "names the workflow you asked for, so a save would write that other graph over it. " +
-                "Preserve it to a NEW path (Save As or an export) if you need it, then load. Call " +
-                "panel_list_workflows BEFORE the load: this reply carries no fence refresh — a refused " +
-                "open publishes no workflow_uuid — and panel_load_workflow is NOT exempt from the " +
-                "fence, so a command stamped from an older identity is refused as a workflow instance " +
-                "mismatch. panel_list_workflows is exempt (#932) and republishes the active identity, " +
-                "which permits the load. Reloading the panel is NOT required (#702).",
-            );
           } else {
+            // #1089 — is the state we are about to repaint FROM even this tab's?
+            //
+            // Recorded, NOT acted on here, and the first attempt at this fix got that
+            // wrong in a way worth keeping written down. It refused before the load. The
+            // repaint's root re-stamp is the ONE documented heal for a conflicting root
+            // tag, so refusing removes it: the pointer is already on the target while
+            // app.graph still carries the OTHER workflow's uuid, and in that state
+            // assertGraphBoundToActiveWorkflow refuses every graph_* command. The refusal
+            // named panel_load_workflow as the recovery, but `graph_load` is a MUTATION
+            // and its own guard hits rootUuidMismatch with no rebind available —
+            // rootTagClaimedByActiveWorkflow false, canvas non-empty, and
+            // rootContentProvesActiveWorkflow false because sealProofExclusive is killed
+            // by the real owner being open and clean with a state matching the root. It
+            // throws [root-workflow-uuid-mismatch], whose own remedy text is "re-open the
+            // active workflow tab", which re-enters the refusal. A hard loop with a panel
+            // reload as the only exit — and it fires on TRUE positives too, so it is worse
+            // than the bug for every caller who hits it.
+            //
+            // So the load must proceed and the SOURCE gets corrected instead, below, by
+            // the #442 disk re-read that already exists in this function with the freeze,
+            // the guard section and __cmcpKeepInstance. That lands the right graph AND
+            // lets the load re-stamp the root, which is what heals the tag.
+            sourceForeign =
+              describeRepaintSourceBinding({
+                state: st,
+                // The pair #708 resolves ownership with, and for the same reason: the
+                // live object's own uuid first, and the root-blind resolver only as the
+                // fallback, so the stale root this is trying to detect can never supply
+                // the answer.
+                targetUuid: workflowObjectUuid(target) || workflowStableUuid(target),
+                targetClaimsTag: (tag) => workflowOwnsRootUuidTag(target, tag),
+                tagOwnedByOtherOpenWorkflow: (tag) => {
+                  const owner = workflowUuidOwner(tag);
+                  if (!owner || sameWorkflowObject(owner, target)) return false;
+                  // OPEN, not merely registered: a replaced predecessor stays in the
+                  // owner map, and its uuid residue in a lagging `activeState` is the
+                  // documented look-alike this must not act on (see the helper).
+                  const openNow = app?.extensionManager?.workflow?.openWorkflows;
+                  return Array.isArray(openNow) && openNow.some((w) => sameWorkflowObject(w, owner));
+                },
+              }) === "foreign";
             // A graph shape is not ownership proof: two dirty tabs can have the same
             // nodes, and the normal read guard intentionally stays inconclusive for a
             // dirty, un-stamped root. Stamp THIS target's live-object identity into the
@@ -13603,6 +13598,22 @@ const GRAPH_TOOL_EXECUTORS = {
         // staleInfo.stale === true, and it never downgrades that to "fresh" — so the
         // false-fresh window codex closed (read stale → file changes → report fresh) still
         // cannot open. The provably-fresh and "unknown" paths reach the return with no await.
+        // #1089 — an AUTOMATIC disk re-read was built here and removed. It is the obvious
+        // correction (the file is the one source the contamination cannot reach, and it is
+        // what both reporters did by hand) and it is not safe, for a reason this function
+        // already documents 400 lines up: #874 records that ComfyUI's ChangeTracker
+        // captures on USER INPUT events only. Every value a NODE wrote — an
+        // ImpactWildcardEncode populate, a control_after_generate roll, a subgraph proxy
+        // fill — is on the canvas and in the tab buffer, never marks the tab modified, and
+        // was never saved. `!dirtyNow && !wasDirty` therefore does not mean "the file is
+        // this tab's content", so an automatic re-read would silently replace exactly the
+        // values an agent just generated and was about to reuse.
+        //
+        // #442's own re-read survives that argument because it fires only when the FILE
+        // provably changed since the tab loaded it, which is independent evidence that the
+        // disk copy is the newer one. A foreign source tag is not evidence about the file
+        // at all. So this discloses and lets the caller decide, with the cost of the
+        // recovery named — see the reply's `foreign_source_state`.
         if (staleInfo.reload && !dirtyNow && !wasDirty && priorInteraction === null) {
           // NO reliable freeze on this frontend ⇒ do NOT perform the automatic destructive
           // reload at all (codex). Serving a stale graph with a loud flag is recoverable;
@@ -13798,6 +13809,40 @@ const GRAPH_TOOL_EXECUTORS = {
       // being the file's graph at all, and a caller may hit one without the other.
       ...(canvasFileDivergenceNote(canvasDivergence, target.path)
         ? { canvas_file_divergence: canvasFileDivergenceNote(canvasDivergence, target.path) }
+        : {}),
+      // #1089 — its OWN key, for the same reason canvas_file_divergence has one: this is
+      // not about the FILE changing (stale) and not about the canvas sharing no ids with
+      // its file (divergence), it is about the tab's own in-memory state having carried
+      // another workflow's identity, which the repaint then faithfully reproduced. A
+      // caller can hit this with neither of the others firing.
+      //
+      // It must not fold into `stale_hint` for a mechanical reason as well: `reloaded` is
+      // only surfaced inside the `stale === true` branch, so a re-read triggered by THIS
+      // condition while the file never changed would set it and surface nothing at all.
+      ...(sourceForeign
+        ? {
+            foreign_source_state:
+              "VERIFY THE GRAPH BEFORE EDITING. This tab's in-memory state carried a DIFFERENT " +
+              "open workflow's identity, and the canvas was repainted from that state — so the " +
+              "graph on screen may be that other workflow's, faithfully reproduced under this " +
+              "workflow's identity. That is #1089, where the reporter's next node deletions " +
+              "would have landed on the wrong workflow with every call reporting success. " +
+              "Everything else on this reply (path, filename, workflow_uuid, modified) is TRUE " +
+              "of the tab and says nothing about which graph the state held, which is why none " +
+              "of it warned. Read the graph (panel_graph_outline / panel_query_graph) and " +
+              "compare it against what you expect this workflow to contain. " +
+              "MAY be, not IS: the panel cannot tell a foreign graph from this tab's own graph " +
+              "sitting under another tab's metadata residue, which a tab switch can leave behind " +
+              "(#817) — so this fires on both, and only your comparison separates them. " +
+              "If it IS the wrong graph, panel_load_workflow with this workflow's path loads the " +
+              "saved copy from disk. Weigh that: it REPLACES the canvas, and the tab's " +
+              "modified flag does not account for values a NODE wrote rather than you — a " +
+              "populated wildcard, a rolled seed (#874) — so a tab reporting no unsaved edits " +
+              "can still lose work to it. If the graph is the OTHER workflow's and holds work " +
+              "you need, preserve it to a NEW path (Save As or an export) first: a plain save " +
+              "would write it over the workflow you asked for, because the active identity " +
+              "already names that one.",
+          }
         : {}),
       ...(staleInfo.stale === true
         ? {

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -13309,6 +13309,10 @@ const GRAPH_TOOL_EXECUTORS = {
                 const openNow = app?.extensionManager?.workflow?.openWorkflows;
                 return Array.isArray(openNow) && openNow.some((w) => sameWorkflowObject(w, owner));
               },
+              // The snapshot taken before any await (#442/codex), which is the only
+              // reading that survives `clearSpuriousOpenModified`. It is what bounds
+              // the cost of a wrong refusal to one extra call — see the helper.
+              targetTabIsClean: !wasDirty,
             }) === "foreign"
           ) {
             // #1089 — REFUSE BEFORE THE LOAD. Every other rebind failure below is
@@ -13318,17 +13322,18 @@ const GRAPH_TOOL_EXECUTORS = {
             // target's identity onto it, so a later save writes it to the target's
             // file. Nothing is loaded, so the canvas is exactly as the caller left it.
             rebindFailed = new Error(
-              "workflow_open did NOT repaint the canvas: the tab's in-memory state holds a graph that " +
-                "positively belongs to a DIFFERENT open workflow, so repainting from it would have put " +
-                "that workflow's nodes on the canvas under this workflow's identity — reported as a " +
-                "clean success, which is #1089. Nothing was loaded and nothing was overwritten; the " +
-                "canvas still holds whatever it held before this call, and the active workflow pointer " +
-                "HAS moved to the requested one. Recover with panel_load_workflow on this workflow's " +
-                "path: it reads the file from DISK, which is the only source not affected by this. Do " +
-                "NOT save first — the graph in memory is the other workflow's, and a plain save writes " +
-                "it to the workflow you asked for, because that is what the active identity already " +
-                "names. If the canvas holds unsaved work you need, preserve it to a NEW path (Save As " +
-                "or an export) before the load.",
+              "workflow_open did NOT repaint the canvas: this tab's in-memory state carries the " +
+                "identity of a DIFFERENT open workflow, so repainting from it risked putting that " +
+                "workflow's nodes on the canvas under this workflow's identity and reporting a clean " +
+                "success — which is #1089, where the caller's next node deletions would have landed on " +
+                "the wrong workflow. Nothing was loaded and nothing was overwritten: the canvas still " +
+                "holds whatever it held before this call, and the active workflow pointer HAS moved to " +
+                "the requested one. Recover with panel_load_workflow on this workflow's path. That is " +
+                "safe for THIS workflow — the tab had no unsaved edits, so its file is its own content " +
+                "— but it replaces what is on the canvas, and the canvas may be another workflow's " +
+                "with ITS unsaved work on it. So do NOT plain-save first: the active identity already " +
+                "names the workflow you asked for, so a save would write that other graph over it. " +
+                "Preserve it to a NEW path (Save As or an export) if you need it, then load.",
             );
           } else {
             // A graph shape is not ownership proof: two dirty tabs can have the same

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -416,6 +416,7 @@ import {
   graphRootWorkflowUuidMatches,
   graphRootMatchesState,
   graphRootReproducesStateContent,
+  describeRepaintSourceBinding,
   graphCommandBindingBar,
   graphCommandMayMutateWorkflow,
   MUTATION_BINDING_BAR,
@@ -13288,6 +13289,46 @@ const GRAPH_TOOL_EXECUTORS = {
             rebindFailed = new Error(
               "workflow_open could not rebind the active canvas because this frontend does not expose " +
                 "loadGraphData. The open may have switched the active workflow; reload the panel before graph edits.",
+            );
+          } else if (
+            describeRepaintSourceBinding({
+              state: st,
+              // The pair #708 resolves ownership with, and for the same reason: the
+              // live object's own uuid first, and the root-blind resolver only as the
+              // fallback, so the stale root this is trying to detect can never supply
+              // the answer. NOT `{ embed: true }` — the embedding stamp belongs to the
+              // repaint below, which must not happen at all if the source is foreign.
+              targetUuid: workflowObjectUuid(target) || workflowStableUuid(target),
+              targetClaimsTag: (tag) => workflowOwnsRootUuidTag(target, tag),
+              tagOwnedByOtherOpenWorkflow: (tag) => {
+                const owner = workflowUuidOwner(tag);
+                if (!owner || sameWorkflowObject(owner, target)) return false;
+                // OPEN, not merely registered: a replaced predecessor stays in the
+                // owner map, and its uuid residue in a lagging `activeState` is the
+                // documented look-alike this must not refuse on (see the helper).
+                const openNow = app?.extensionManager?.workflow?.openWorkflows;
+                return Array.isArray(openNow) && openNow.some((w) => sameWorkflowObject(w, owner));
+              },
+            }) === "foreign"
+          ) {
+            // #1089 — REFUSE BEFORE THE LOAD. Every other rebind failure below is
+            // detected after `loadGraphData`, which is fine when the payload is this
+            // tab's own; here it is another tab's graph, and the load is the step that
+            // makes the damage durable: it paints the foreign graph and stamps the
+            // target's identity onto it, so a later save writes it to the target's
+            // file. Nothing is loaded, so the canvas is exactly as the caller left it.
+            rebindFailed = new Error(
+              "workflow_open did NOT repaint the canvas: the tab's in-memory state holds a graph that " +
+                "positively belongs to a DIFFERENT open workflow, so repainting from it would have put " +
+                "that workflow's nodes on the canvas under this workflow's identity — reported as a " +
+                "clean success, which is #1089. Nothing was loaded and nothing was overwritten; the " +
+                "canvas still holds whatever it held before this call, and the active workflow pointer " +
+                "HAS moved to the requested one. Recover with panel_load_workflow on this workflow's " +
+                "path: it reads the file from DISK, which is the only source not affected by this. Do " +
+                "NOT save first — the graph in memory is the other workflow's, and a plain save writes " +
+                "it to the workflow you asked for, because that is what the active identity already " +
+                "names. If the canvas holds unsaved work you need, preserve it to a NEW path (Save As " +
+                "or an export) before the load.",
             );
           } else {
             // A graph shape is not ownership proof: two dirty tabs can have the same

--- a/web/js/lib/graph-binding.js
+++ b/web/js/lib/graph-binding.js
@@ -1207,54 +1207,79 @@ export function graphRootCarriesOpenProof({ rootGraph, proofMarker } = {}) {
  * into durable loss, because the stamp makes a later save write the foreign graph
  * to the target's file.
  *
- * The evidence rule is `describeLiveCanvasBinding`'s (#708/#349), applied to the
- * source state instead of the live canvas, plus TWO additional requirements:
+ * WHAT THE ANSWER IS FOR. Not a refusal — `workflow_open` must not refuse on this,
+ * and the first attempt at this fix did (codex NO-SHIP, round 1). The repaint's root
+ * re-stamp is the one documented heal for a conflicting root tag, so refusing before
+ * the load removes it and strands the pointer on the target with another workflow's
+ * uuid on `app.graph`. Every `graph_*` command is then refused by
+ * `assertGraphBoundToActiveWorkflow` — including the `panel_load_workflow` the
+ * refusal recommended, whose own error says to re-open the tab, which re-enters the
+ * refusal. A hard loop, on true positives as much as false ones.
  *
- *   bound   — the state carries the target's own identity. Repaint, unchanged.
- *   foreign — the state carries a tag the target does not claim, that tag is owned
- *             by a DIFFERENT currently-open workflow, AND the target tab is CLEAN.
- *             Refuse.
- *   unknown — anything else. Repaint, unchanged.
+ * `foreign` therefore authorizes a DISCLOSURE and nothing else. The load proceeds
+ * exactly as before, the root gets re-stamped by it, and the caller is told to verify
+ * the graph before editing. That is the whole remedy, and the reason it is the whole
+ * remedy is worth reading before anyone tries to strengthen it again.
+ *
+ * The evidence rule is `describeLiveCanvasBinding`'s (#708/#349), applied to the
+ * source state instead of the live canvas, plus ONE additional requirement:
+ *
+ *   bound   — the state carries the target's own identity.
+ *   foreign — the state carries a tag the target does not claim, AND that tag is
+ *             owned by a DIFFERENT currently-open workflow.
+ *   unknown — anything else.
  *
  * WHY THE LIVE OWNER. `workflowOwnsRootUuidTag`'s header records that a lagging
  * `activeState` can carry a REPLACED PREDECESSOR's uuid residue, "indistinguishable
  * from the genuine lineage stamp". A predecessor is not an open tab, so requiring a
  * live owner separates residue from another tab's graph.
  *
- * WHY THE CLEAN TAB, which is the part that makes this refusal SOUND rather than
- * merely careful (codex NO-SHIP, round 1). The tag alone cannot prove the GRAPH is
- * foreign, and #817 is the counter-example: a tab switch leaves the previous
- * workflow's tag on the reused `app.graph`, and the guard's rebind then re-stamps
- * that root on CONTENT proof — `rootContentProvesActiveWorkflow`, not a claimed tag.
+ * WHAT THIS DOES NOT ESTABLISH, and cannot. The tag does not prove the GRAPH is
+ * foreign. #817 is the counter-example: a tab switch leaves the previous workflow's
+ * tag on the reused `app.graph`, and the guard's rebind re-stamps that root on
+ * CONTENT proof — `rootContentProvesActiveWorkflow`, not a claimed tag.
  * `stampGraphRootWorkflowUuid` writes `rootGraph.extra` and nothing else, so a
- * capture taken before the heal leaves the tab's OWN content sitting under the other
- * tab's meta block, indefinitely. The whole `comfyui_mcp` block travels together as
- * residue, so no field in it — uuid or path — can tell that apart from a genuinely
- * foreign graph.
+ * capture taken before the heal leaves the tab's OWN content under the other tab's
+ * meta block, indefinitely. The whole `comfyui_mcp` block travels together as
+ * residue, so no field in it separates the two. The disclosure says "may be" for
+ * that reason and hands the comparison to the caller, who knows what the workflow
+ * should contain.
  *
- * So the refusal is not justified by proving the state foreign. It is justified by
- * its COST BEING ZERO when it is wrong: on a clean tab the recovery it names
- * (`panel_load_workflow`, which reads the file) is exactly what the tab already
- * holds, so a false refusal costs one extra call and loses nothing. On a DIRTY tab
- * that same advice discards unsaved work, and there the false refusal would be
- * destructive — which is why a dirty tab is `unknown` and repaints exactly as it
- * does today.
+ * TWO STRONGER REMEDIES WERE BUILT AND REMOVED. Both are recorded because both look
+ * obviously right and are not.
  *
- * STATED RESIDUAL: that leaves a dirty tab with a foreign source state repainting
- * as before. It is the harder half — its state cannot be recovered from disk by
- * definition — and closing it needs evidence that separates residue from a foreign
- * graph, which this does not have. Deciding it on the tag would refuse good opens
- * and take unsaved work with them.
+ *   REFUSING the open (codex NO-SHIP). The repaint's root re-stamp is the one
+ *   documented heal for a conflicting root tag, so refusing strands the pointer on
+ *   the target with another workflow's uuid on `app.graph`. Every `graph_*` command
+ *   is then refused — including the `panel_load_workflow` the refusal recommended,
+ *   whose own error says to re-open the tab, which re-enters the refusal. A hard
+ *   loop, on true positives as much as false ones.
+ *
+ *   AUTO-CORRECTING from disk. Gated on the tab being clean, which cannot bear it:
+ *   #874 records that ChangeTracker captures on USER INPUT events only, so a value a
+ *   NODE wrote (a populated wildcard, a rolled seed) is on the canvas, never marks
+ *   the tab modified, and was never saved — the re-read would silently replace
+ *   exactly what an agent just generated. The same flag fails in the other direction
+ *   too: a first-time open never runs `clearSpuriousOpenModified`, so a cold-opened
+ *   tab reads modified forever, and gating on it would have disarmed this guard for
+ *   that entire population. #442's re-read survives the argument only because it
+ *   fires on the FILE provably having changed, which is independent evidence about
+ *   the disk copy. A foreign source tag is no evidence about the file at all.
+ *
+ * STATED RESIDUAL: this warns, it does not prevent. An agent that ignores the
+ * disclosure can still edit the wrong graph. Closing that needs evidence separating
+ * residue from a foreign graph, which does not exist here — and every remedy tried
+ * on the weaker evidence traded a silent wrong-graph edit for a wedge or a silent
+ * data loss.
  *
  * Pure, so the ownership questions arrive as injected predicates. A predicate that
- * throws is inconclusive, never a refusal.
+ * throws is inconclusive, never a positive answer.
  */
 export function describeRepaintSourceBinding({
   state,
   targetUuid,
   targetClaimsTag,
   tagOwnedByOtherOpenWorkflow,
-  targetTabIsClean,
 } = {}) {
   try {
     const tag = state?.extra?.[PANEL_GRAPH_META_KEY]?.workflow_uuid;
@@ -1268,9 +1293,6 @@ export function describeRepaintSourceBinding({
     } catch {
       return "unknown";
     }
-    // Compared against `true` explicitly: an unreadable dirty flag is not a clean
-    // tab, and only a clean tab bounds the cost of being wrong.
-    if (targetTabIsClean !== true) return "unknown";
     try {
       return tagOwnedByOtherOpenWorkflow?.(tag) === true ? "foreign" : "unknown";
     } catch {

--- a/web/js/lib/graph-binding.js
+++ b/web/js/lib/graph-binding.js
@@ -1208,22 +1208,43 @@ export function graphRootCarriesOpenProof({ rootGraph, proofMarker } = {}) {
  * to the target's file.
  *
  * The evidence rule is `describeLiveCanvasBinding`'s (#708/#349), applied to the
- * source state instead of the live canvas, plus ONE additional requirement:
+ * source state instead of the live canvas, plus TWO additional requirements:
  *
  *   bound   — the state carries the target's own identity. Repaint, unchanged.
- *   foreign — the state carries a tag the target does not claim AND that tag is
- *             owned by a DIFFERENT, currently-open workflow. Refuse.
- *   unknown — anything else: no tag, no resolvable target identity, or a
- *             conflicting tag with no live owner. Repaint, unchanged.
+ *   foreign — the state carries a tag the target does not claim, that tag is owned
+ *             by a DIFFERENT currently-open workflow, AND the target tab is CLEAN.
+ *             Refuse.
+ *   unknown — anything else. Repaint, unchanged.
  *
- * The extra requirement is not caution for its own sake — it answers a documented
- * hazard. `workflowOwnsRootUuidTag`'s header records that a lagging `activeState`
- * can carry a REPLACED PREDECESSOR's uuid residue, "indistinguishable from the
- * genuine lineage stamp". A bare mismatch would therefore refuse good opens, and a
- * false refusal here is not a harmless no-op: it sends the caller to a disk load,
- * which discards whatever unsaved work is on the canvas. Demanding a live owner
- * separates the two — a predecessor is not an open tab, and a tag owned by another
- * open tab is that tab's, not residue.
+ * WHY THE LIVE OWNER. `workflowOwnsRootUuidTag`'s header records that a lagging
+ * `activeState` can carry a REPLACED PREDECESSOR's uuid residue, "indistinguishable
+ * from the genuine lineage stamp". A predecessor is not an open tab, so requiring a
+ * live owner separates residue from another tab's graph.
+ *
+ * WHY THE CLEAN TAB, which is the part that makes this refusal SOUND rather than
+ * merely careful (codex NO-SHIP, round 1). The tag alone cannot prove the GRAPH is
+ * foreign, and #817 is the counter-example: a tab switch leaves the previous
+ * workflow's tag on the reused `app.graph`, and the guard's rebind then re-stamps
+ * that root on CONTENT proof — `rootContentProvesActiveWorkflow`, not a claimed tag.
+ * `stampGraphRootWorkflowUuid` writes `rootGraph.extra` and nothing else, so a
+ * capture taken before the heal leaves the tab's OWN content sitting under the other
+ * tab's meta block, indefinitely. The whole `comfyui_mcp` block travels together as
+ * residue, so no field in it — uuid or path — can tell that apart from a genuinely
+ * foreign graph.
+ *
+ * So the refusal is not justified by proving the state foreign. It is justified by
+ * its COST BEING ZERO when it is wrong: on a clean tab the recovery it names
+ * (`panel_load_workflow`, which reads the file) is exactly what the tab already
+ * holds, so a false refusal costs one extra call and loses nothing. On a DIRTY tab
+ * that same advice discards unsaved work, and there the false refusal would be
+ * destructive — which is why a dirty tab is `unknown` and repaints exactly as it
+ * does today.
+ *
+ * STATED RESIDUAL: that leaves a dirty tab with a foreign source state repainting
+ * as before. It is the harder half — its state cannot be recovered from disk by
+ * definition — and closing it needs evidence that separates residue from a foreign
+ * graph, which this does not have. Deciding it on the tag would refuse good opens
+ * and take unsaved work with them.
  *
  * Pure, so the ownership questions arrive as injected predicates. A predicate that
  * throws is inconclusive, never a refusal.
@@ -1233,6 +1254,7 @@ export function describeRepaintSourceBinding({
   targetUuid,
   targetClaimsTag,
   tagOwnedByOtherOpenWorkflow,
+  targetTabIsClean,
 } = {}) {
   try {
     const tag = state?.extra?.[PANEL_GRAPH_META_KEY]?.workflow_uuid;
@@ -1246,6 +1268,9 @@ export function describeRepaintSourceBinding({
     } catch {
       return "unknown";
     }
+    // Compared against `true` explicitly: an unreadable dirty flag is not a clean
+    // tab, and only a clean tab bounds the cost of being wrong.
+    if (targetTabIsClean !== true) return "unknown";
     try {
       return tagOwnedByOtherOpenWorkflow?.(tag) === true ? "foreign" : "unknown";
     } catch {

--- a/web/js/lib/graph-binding.js
+++ b/web/js/lib/graph-binding.js
@@ -1188,6 +1188,74 @@ export function graphRootCarriesOpenProof({ rootGraph, proofMarker } = {}) {
   return typeof seen === "string" && seen === proofMarker;
 }
 
+/**
+ * #1089 — does the STATE this open is about to repaint FROM belong to the tab
+ * being opened?
+ *
+ * Every proof `resolveOpenRebindVerdict` weighs is taken AFTER the load, against
+ * the root the loader produced. None of them looks at the state the load was
+ * handed. So when that state holds another workflow's graph, the open repaints it
+ * faithfully, stamps the target's identity onto it, and all four parts pass — not
+ * by being fooled, but because each one is a TRUE statement about a poisoned
+ * source. That is #1089 exactly: a clean success, `modified: false`, and the
+ * previous workflow's graph on the canvas.
+ *
+ * #968 closed the writer this repo owns (the pre-repaint `checkState` capture) and
+ * recorded its own residual: an UNTAGGED root is still captured. A state poisoned
+ * before that fix shipped, through the residual, or by any capture the panel does
+ * not mediate, still reaches this load — and the load is the step that turns it
+ * into durable loss, because the stamp makes a later save write the foreign graph
+ * to the target's file.
+ *
+ * The evidence rule is `describeLiveCanvasBinding`'s (#708/#349), applied to the
+ * source state instead of the live canvas, plus ONE additional requirement:
+ *
+ *   bound   — the state carries the target's own identity. Repaint, unchanged.
+ *   foreign — the state carries a tag the target does not claim AND that tag is
+ *             owned by a DIFFERENT, currently-open workflow. Refuse.
+ *   unknown — anything else: no tag, no resolvable target identity, or a
+ *             conflicting tag with no live owner. Repaint, unchanged.
+ *
+ * The extra requirement is not caution for its own sake — it answers a documented
+ * hazard. `workflowOwnsRootUuidTag`'s header records that a lagging `activeState`
+ * can carry a REPLACED PREDECESSOR's uuid residue, "indistinguishable from the
+ * genuine lineage stamp". A bare mismatch would therefore refuse good opens, and a
+ * false refusal here is not a harmless no-op: it sends the caller to a disk load,
+ * which discards whatever unsaved work is on the canvas. Demanding a live owner
+ * separates the two — a predecessor is not an open tab, and a tag owned by another
+ * open tab is that tab's, not residue.
+ *
+ * Pure, so the ownership questions arrive as injected predicates. A predicate that
+ * throws is inconclusive, never a refusal.
+ */
+export function describeRepaintSourceBinding({
+  state,
+  targetUuid,
+  targetClaimsTag,
+  tagOwnedByOtherOpenWorkflow,
+} = {}) {
+  try {
+    const tag = state?.extra?.[PANEL_GRAPH_META_KEY]?.workflow_uuid;
+    if (typeof tag !== "string" || !tag) return "unknown";
+    if (typeof targetUuid !== "string" || !targetUuid) return "unknown";
+    if (tag === targetUuid) return "bound";
+    // A conflicting tag the target's own lineage claims is its own drifted stamp
+    // (#545/#557), not another tab's graph.
+    try {
+      if (targetClaimsTag?.(tag) === true) return "unknown";
+    } catch {
+      return "unknown";
+    }
+    try {
+      return tagOwnedByOtherOpenWorkflow?.(tag) === true ? "foreign" : "unknown";
+    } catch {
+      return "unknown";
+    }
+  } catch {
+    return "unknown";
+  }
+}
+
 export const OPEN_REBIND_STATUS = Object.freeze({
   /** The canvas is provably the requested workflow AND holds what was loaded. */
   PROVEN: "proven",


### PR DESCRIPTION
Closes #1089.

`panel_open_workflow` reported a clean success — right path, right filename, right `workflow_uuid`, `modified: false` — while the canvas held the graph of the workflow just saved-as FROM. **No warning of any kind.** The reporter's next calls were `panel_remove_node`, and Save-As preserves ids, so those deletions would largely have LANDED, on the wrong workflow, silently.

## The mechanism

Not a loosened verdict. `resolveOpenRebindVerdict` is fail-closed on all four parts.

All four proofs are taken AFTER the load, against the root the loader produced. **None looks at the state the load was handed.** So when that state holds another workflow's graph, the open reproduces it faithfully, stamps the target's identity onto it, and every part passes — each a true statement about a poisoned SOURCE. That is why this call reported nothing while #1111, on the same end state, did warn.

#968 closed the writer this repo owns and recorded its residual: an untagged root is still captured. A state poisoned before that fix, through the residual, or by a capture the panel does not mediate still reaches the load.

## What ships: a disclosure

When the source state provably carried another open workflow's identity, the reply carries its own `foreign_source_state` key. The load and all four proofs are untouched.

It says: verify the graph before editing; why nothing else on the reply warned (every other field is TRUE of the tab and says nothing about which graph the state held); and the recovery with its cost. Its own key, not `stale_hint` — `reloaded` is only surfaced inside the stale branch, so folding it there would report a bare success for exactly this case.

It says **MAY be, not IS**. #817 residue — this tab's own content under another tab's meta block after a tab switch — is indistinguishable from a foreign graph, and the whole `comfyui_mcp` block travels together, so no field in it separates them. Only the caller's comparison does.

## Two stronger remedies were built and removed

Review returned **five CONFIRMED findings**; three killed the first, two killed the second. Both are recorded in the helper doc, because both look obviously right.

**Refusing the open.** The repaint's root re-stamp is the one documented heal for a conflicting root tag, so refusing strands the pointer on the target with another workflow's uuid on `app.graph`. Every `graph_*` command is then refused — including the `panel_load_workflow` the refusal recommended (`graph_load` is a mutation, and `rootContentProvesActiveWorkflow` is false because `sealProofExclusive` dies when the real owner is open and clean with a state matching the root). It throws `[root-workflow-uuid-mismatch]`, whose own remedy is *"re-open the active workflow tab"*, which re-enters the refusal. `save`/`save_as` are refused too by #708. **A hard loop with a panel reload as the only exit, right after being told a reload is not required** — #932/#607/#688 recreated, firing on true positives as much as false ones. Two further findings on the same path: the refusal skipped `clearSpuriousOpenModified`, so the dispatch loop's unguarded deferred `checkState` would dirty the target and disarm the guard on retry; and the #545/#557 rebind heal performs the very root stamp the refusal existed to prevent.

**Auto-correcting from disk.** It reused #442's re-read with all of its guards — freeze, section ownership, `__cmcpKeepInstance` — and was still unsafe, because the flag it gated on cannot bear it, in *both* directions:

- **spuriously FALSE** — #874: ChangeTracker captures on USER INPUT only, so a value a NODE wrote (populated wildcard, rolled seed) is on the canvas, never marks the tab modified, was never saved, and would have been silently replaced. The reply would have called that safe.
- **spuriously TRUE** — a first-time open never runs `clearSpuriousOpenModified`, so a cold-opened tab reads modified for its whole life. The gate would have disarmed this guard for that entire population, leaving #1089 unprevented for it.

#442's own re-read survives because its trigger is "the FILE provably changed since this tab loaded it" — independent evidence the disk copy is newer. A foreign source tag is no evidence about the file. **The dirty flag is therefore not an input anywhere here**, and a test pins that in both directions.

## Stated residual

**This warns, it does not prevent.** An agent that ignores the disclosure can still edit the wrong graph. That is the honest limit: every remedy tried on this evidence traded a silent wrong-graph edit for a wedge or a silent data loss.

## Verification

3956 tests pass, typecheck clean, `node --check` OK. Rebased on current main.

**Review provenance, stated plainly:** codex found the first NO-SHIP (the #817 false-positive that broke the original tag-only rule), then its sandbox died — `pwsh` resolves to a 0-byte WindowsApps App Execution Alias stub that denies process launch, so four attempts failed at their first command. The five findings above came from the workflow-backed high-effort review run in its place. That run also lost 19 of 30 agents to API 529s and its synthesis step, so coverage was partial and the findings are unmerged rather than deduplicated.
