### PR TITLE
fix(1111): an open that detects the wrong graph must refuse, not just say so

### DIFF
--- a/browser_tests/unit/open-rebind-proof.test.mjs
+++ b/browser_tests/unit/open-rebind-proof.test.mjs
@@ -152,7 +152,13 @@ test("#604/#603/#616: the reported failure — a faithful repaint the frontend N
   // destroys it. Naming a destructive step as "the recovery" without saying so is
   // how a message meant to prevent data loss causes it.
   assert.match(text, /It loads from DISK/, "the cost of the recovery is stated");
-  assert.match(text, /save or export that FIRST/, "…and what to do before taking it");
+  assert.match(text, /preserve it FIRST/, "…and what to do before taking it");
+  // codex round 2, P1: a PLAIN save is itself destructive here. The active identity
+  // already names the requested workflow, so saving the stale graph writes it over
+  // exactly the file the user was trying to open — the safety advice creating a
+  // worse data-loss path than the one it was preventing.
+  assert.match(text, /To a NEW path, with Save As or an export/, "preservation must not overwrite");
+  assert.match(text, /a plain save would write it to a\.json/, "…and the trap is named explicitly");
   assert.match(text, /UNKNOWN/, "...while the unsettled half stays unknown");
   assert.match(text, /nodes/, "the disclosure must name WHICH surface disagreed");
 });

--- a/browser_tests/unit/open-rebind-proof.test.mjs
+++ b/browser_tests/unit/open-rebind-proof.test.mjs
@@ -126,7 +126,27 @@ test("#604/#603/#616: the reported failure — a faithful repaint the frontend N
     contentSurfaces: describeGraphStateDifference({ rootGraph, state: loaded }).surfaces,
   });
   assert.match(text, /canvas IS bound to a\.json/, "the settled half must be stated as settled");
-  assert.match(text, /You are NOT on the wrong workflow/, "the old message's worst implication is retracted");
+  // The retraction survives — the identity IS settled and must be stated as such —
+  // but it is now scoped to the identity (#1111/#1089). The old sentence read as
+  // "everything is fine except presentation", and two reporters proceeded on that
+  // while the PREVIOUS workflow's graph sat on the canvas.
+  assert.match(text, /The identity is settled/, "the old message's worst implication is retracted");
+  assert.match(text, /IS the active one/, "…and the settled half is still stated plainly");
+  assert.match(
+    text,
+    /not about the nodes/,
+    "…but it no longer implies the graph is this workflow's",
+  );
+  assert.match(
+    text,
+    /PREVIOUS workflow's graph still on the canvas/,
+    "the reported outcome is named, so a re-read is not taken at face value",
+  );
+  assert.match(
+    text,
+    /panel_load_workflow with this workflow's path reloads it/,
+    "and the recovery that actually worked for both reporters is named",
+  );
   assert.match(text, /UNKNOWN/, "...while the unsettled half stays unknown");
   assert.match(text, /nodes/, "the disclosure must name WHICH surface disagreed");
 });

--- a/browser_tests/unit/open-rebind-proof.test.mjs
+++ b/browser_tests/unit/open-rebind-proof.test.mjs
@@ -147,6 +147,12 @@ test("#604/#603/#616: the reported failure — a faithful repaint the frontend N
     /panel_load_workflow with this workflow's path reloads it/,
     "and the recovery that actually worked for both reporters is named",
   );
+  // codex review, P1: that recovery loads from DISK. If the stale canvas holds
+  // unsaved work — and if it is the previous workflow's, it may — reloading
+  // destroys it. Naming a destructive step as "the recovery" without saying so is
+  // how a message meant to prevent data loss causes it.
+  assert.match(text, /It loads from DISK/, "the cost of the recovery is stated");
+  assert.match(text, /save or export that FIRST/, "…and what to do before taking it");
   assert.match(text, /UNKNOWN/, "...while the unsettled half stays unknown");
   assert.match(text, /nodes/, "the disclosure must name WHICH surface disagreed");
 });

--- a/web/js/lib/graph-binding.js
+++ b/web/js/lib/graph-binding.js
@@ -1519,7 +1519,10 @@ export function describeOpenRebindOutcome(verdict, observed = {}) {
       `PREVIOUS workflow's graph still on the canvas, which a re-read then returns as if it were ` +
       `this workflow's. So compare what you read against what you expect, and if it is the wrong ` +
       `graph, panel_load_workflow with this workflow's path reloads it — that is what recovered ` +
-      `it for both reporters, and neither panel_graph_outline nor a fence refresh will.` +
+      `it for both reporters, and neither panel_graph_outline nor a fence refresh will. It loads ` +
+      `from DISK, so whatever is on the canvas right now is replaced: if the graph you are looking ` +
+      `at holds unsaved work — and if it is the previous workflow's, it may — save or export that ` +
+      `FIRST. Recovering the binding is not worth losing a graph to.` +
       FENCE_NOT_REFRESHED
     );
   }

--- a/web/js/lib/graph-binding.js
+++ b/web/js/lib/graph-binding.js
@@ -1521,8 +1521,11 @@ export function describeOpenRebindOutcome(verdict, observed = {}) {
       `graph, panel_load_workflow with this workflow's path reloads it — that is what recovered ` +
       `it for both reporters, and neither panel_graph_outline nor a fence refresh will. It loads ` +
       `from DISK, so whatever is on the canvas right now is replaced: if the graph you are looking ` +
-      `at holds unsaved work — and if it is the previous workflow's, it may — save or export that ` +
-      `FIRST. Recovering the binding is not worth losing a graph to.` +
+      `at holds unsaved work — and if it is the previous workflow's, it may — preserve it FIRST. ` +
+      `To a NEW path, with Save As or an export: a plain save would write it to ${workflow}, ` +
+      `because that is what the active identity already names, and the stale graph would land on ` +
+      `top of the workflow you were trying to open. Recovering the binding is not worth losing a ` +
+      `graph to, and neither is preserving one.` +
       FENCE_NOT_REFRESHED
     );
   }

--- a/web/js/lib/graph-binding.js
+++ b/web/js/lib/graph-binding.js
@@ -1514,7 +1514,13 @@ export function describeOpenRebindOutcome(verdict, observed = {}) {
         : `the panel could not READ the graph on it to compare against the state that was loaded, so ` +
           `whether the whole graph landed is unestablished — NOT established as wrong. `) +
       `Treat the canvas as UNKNOWN and re-read it (panel_graph_outline) before editing.${because} ` +
-      `You are NOT on the wrong workflow: ${workflow} IS the active one.` + FENCE_NOT_REFRESHED
+      `The identity is settled — ${workflow} IS the active one — but that is a statement about ` +
+      `the IDENTITY, not about the nodes: this outcome has been reported (#1111, #1089) with the ` +
+      `PREVIOUS workflow's graph still on the canvas, which a re-read then returns as if it were ` +
+      `this workflow's. So compare what you read against what you expect, and if it is the wrong ` +
+      `graph, panel_load_workflow with this workflow's path reloads it — that is what recovered ` +
+      `it for both reporters, and neither panel_graph_outline nor a fence refresh will.` +
+      FENCE_NOT_REFRESHED
     );
   }
   if (verdict?.status === OPEN_REBIND_STATUS.UNPROVEN) {


### PR DESCRIPTION
Closes #1111. Also covers the silent half reported as #1089.

`panel_open_workflow` moved the active workflow identity and title to the requested workflow while the canvas kept the previous graph — and `panel_graph_outline` then returned that previous graph, so reads and writes were both aimed at it. `panel_load_workflow(path)` recovered.

Two reports, same wrong end state, different warning:
- **#1111** — the open DID report a graph mismatch, and left the session on the wrong canvas anyway.
- **#1089** — a clean success, `modified: false`, correct uuid, no warning at all. Their next planned calls were `panel_remove_node`, and Save-As preserves ids, so those deletions would have landed.

So detection is not the gap: #1111 detected it. The gap is that detecting it changes nothing about what the session then operates on.

Draft while I establish what the open can verify about the graph READS will use, as distinct from the graph the loader produced — the four existing proofs are all taken against the latter.