### PR TITLE
fix(1108): panel_screenshot stops throwing when a node has no type

### DIFF
--- a/browser_tests/unit/canvas-draw-failure.test.mjs
+++ b/browser_tests/unit/canvas-draw-failure.test.mjs
@@ -7,7 +7,9 @@
 // LTX render), so the one tool that could have shown them the state is the one that
 // failed, with a message that reads like a panel bug.
 //
-// It is not a panel bug. It is NOT, however, safe to say it is not the graph: a node
+// It is not obviously a panel bug — though this path sets the canvas transform to a
+// computed fit before drawing, so the zoom it chose could be what exposes the fault.
+// It is NOT safe to say it is not the graph either: a node
 // or widget the renderer cannot draw throws here while panel_graph_outline reads that
 // same node perfectly well — which is exactly what the reporter observed, and the
 // likeliest lead. The first version of this message excluded the graph outright.
@@ -76,7 +78,10 @@ test("#1108 it names the remedy and admits the panel cannot apply it", () => {
   // codex round 2, P1: "then the cause is in the graph" was a false dichotomy — a
   // persistent frontend issue, an extension, or other browser state survives a
   // reload without the graph being at fault.
-  assert.match(text, /not \(only\) stale render state/);
+  // codex round 3, P2: surviving a reload proves less than it looks — a render that
+  // is still running can recreate the bad state immediately.
+  assert.match(text, /proves less than it looks/);
+  assert.match(text, /try it with the queue idle/);
   assert.match(text, /any extension that draws on the canvas/);
   assert.doesNotMatch(text, /the cause is in the graph rather than/);
   // And a refresh discards unsaved work, which must be said BEFORE they do it.

--- a/browser_tests/unit/canvas-draw-failure.test.mjs
+++ b/browser_tests/unit/canvas-draw-failure.test.mjs
@@ -44,6 +44,9 @@ test("#1108 it says where the throw came from WITHOUT excluding the graph", () =
   // The two tools that DID work for the reporter, named so the next one uses them.
   assert.match(text, /panel_graph_outline/);
   assert.match(text, /panel_get_errors/);
+  // codex round 5, P2: an outline names nodes regardless of fault, so "if either
+  // names a node, look at it" pointed at every node in the graph.
+  assert.match(text, /an outline names nodes whether or not one is at fault/);
 });
 
 test("#1108 it connects the failed screenshot to the frozen canvas", () => {
@@ -90,7 +93,13 @@ test("#1108 it names the remedy and admits the panel cannot apply it", () => {
   assert.doesNotMatch(text, /are what is left to look at/);
   assert.doesNotMatch(text, /the cause is in the graph rather than/);
   // And a refresh discards unsaved work, which must be said BEFORE they do it.
-  assert.match(text, /a refresh discards unsaved canvas work, so offer the user a save FIRST/);
+  // codex round 5, P1: the warning used to sit AFTER the F5 recommendation, so a
+  // reader acting top-to-bottom could refresh before reaching it.
+  assert.match(text, /SAVE FIRST/);
+  assert.ok(
+    text.indexOf("SAVE FIRST") < text.indexOf("(F5)"),
+    "the data-loss warning must precede the step that causes it",
+  );
 });
 
 test("#1108 it does not key on the message shape it happened to see", () => {

--- a/browser_tests/unit/canvas-draw-failure.test.mjs
+++ b/browser_tests/unit/canvas-draw-failure.test.mjs
@@ -83,6 +83,11 @@ test("#1108 it names the remedy and admits the panel cannot apply it", () => {
   assert.match(text, /proves less than it looks/);
   assert.match(text, /try it with the queue idle/);
   assert.match(text, /any extension that draws on the canvas/);
+  // codex round 4, P2: naming those two as "what is left" was still an exhaustive
+  // diagnosis — a stock ComfyUI or browser rendering defect produces this without
+  // either being at fault.
+  assert.match(text, /none of that is a shortlist, only a place to start/);
+  assert.doesNotMatch(text, /are what is left to look at/);
   assert.doesNotMatch(text, /the cause is in the graph rather than/);
   // And a refresh discards unsaved work, which must be said BEFORE they do it.
   assert.match(text, /a refresh discards unsaved canvas work, so offer the user a save FIRST/);

--- a/browser_tests/unit/canvas-draw-failure.test.mjs
+++ b/browser_tests/unit/canvas-draw-failure.test.mjs
@@ -1,0 +1,95 @@
+// #1108 — the screenshot that failed while diagnosing a frozen canvas.
+//
+// `graph_screenshot` fits the view and calls `canvas.draw(true, true)` — a
+// synchronous redraw inside LiteGraph. When that threw, the panel surfaced the raw
+// exception: "Cannot read properties of undefined (reading 'name')". The reporter
+// was trying to screenshot a canvas that had frozen (pan/zoom/clicks dead during an
+// LTX render), so the one tool that could have shown them the state is the one that
+// failed, with a message that reads like a panel bug.
+//
+// It is not one, and it is not the graph or the backend: panel_get_errors and
+// panel_graph_outline both answered correctly at that moment.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import {
+  describeCanvasDrawFailure,
+  isCanvasDrawFailure,
+} from "../../web/js/lib/canvas-draw-failure.js";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const PANEL_JS = join(HERE, "../../web/js/comfyui-mcp-panel.js");
+
+const REPORTED = new TypeError("Cannot read properties of undefined (reading 'name')");
+
+test("#1108 the raw exception is preserved, not swallowed", () => {
+  // The message is the only clue anyone has about WHICH draw failed; hiding it
+  // behind a friendlier sentence would cost the next investigation.
+  const text = describeCanvasDrawFailure(REPORTED);
+  assert.match(text, /Cannot read properties of undefined \(reading 'name'\)/);
+});
+
+test("#1108 it says where the throw came from, and what still works", () => {
+  const text = describeCanvasDrawFailure(REPORTED);
+  assert.match(text, /threw while REDRAWING itself/);
+  assert.match(text, /not from the graph or the backend/);
+  // The two tools that DID work for the reporter, named so the next one uses them.
+  assert.match(text, /panel_graph_outline/);
+  assert.match(text, /panel_get_errors/);
+});
+
+test("#1108 it connects the failed screenshot to the frozen canvas", () => {
+  // The reporter worked this out themselves, twice, before calling the tool. The
+  // tool should not make them.
+  const text = describeCanvasDrawFailure(REPORTED, { canvasReportedFrozen: true });
+  assert.match(text, /same fault seen from two directions, not two problems/);
+  assert.match(text, /That is what was reported here/);
+
+  // …and when nobody has reported a freeze, it offers the connection conditionally
+  // rather than asserting it.
+  const unreported = describeCanvasDrawFailure(REPORTED);
+  assert.match(unreported, /If the user reports that too/);
+  assert.doesNotMatch(unreported, /That is what was reported here/);
+});
+
+test("#1108 it names the remedy and admits the panel cannot apply it", () => {
+  const text = describeCanvasDrawFailure(REPORTED);
+  assert.match(text, /hard refresh of the ComfyUI browser tab/);
+  assert.match(text, /cannot repair the frontend's render state from here/);
+  // Retrying is explicitly ruled out — the reporter would otherwise try it.
+  assert.match(text, /will fail the same way until the tab is reloaded/);
+  // And a refresh discards unsaved work, which must be said BEFORE they do it.
+  assert.match(text, /Unsaved canvas work survives a refresh only if it was saved/);
+});
+
+test("#1108 it does not key on the message shape it happened to see", () => {
+  // "reading 'name'" is one shape of this. Matching on it would let the next shape
+  // through as an opaque TypeError again — which is the whole bug.
+  assert.equal(isCanvasDrawFailure(new Error("something else entirely")), true);
+  assert.equal(isCanvasDrawFailure("a string throw"), true);
+  const other = describeCanvasDrawFailure(new Error("ctx.measureText is not a function"));
+  assert.match(other, /ctx\.measureText is not a function/);
+  assert.match(other, /threw while REDRAWING itself/);
+});
+
+test("#1108 an empty or absent throw still produces a usable message", () => {
+  for (const bad of [undefined, null, new Error("")]) {
+    const text = describeCanvasDrawFailure(bad);
+    assert.match(text, /could not be taken/);
+    assert.match(text, /hard refresh/);
+  }
+});
+
+test("#1108 WIRING: the synchronous redraw is actually wrapped", () => {
+  // The message is worthless if graph_screenshot still lets the raw throw out. The
+  // behavioural tests above cannot see the call site, so this asserts it.
+  const src = readFileSync(PANEL_JS, "utf8");
+  const i = src.indexOf("graph_screenshot({ padding } = {}) {");
+  assert.ok(i > 0, "graph_screenshot must exist");
+  const body = src.slice(i, i + 6000);
+  assert.match(body, /try \{\s*\n\s*canvas\.draw\(true, true\);/, "the redraw is inside a try");
+  assert.match(body, /throw new Error\(describeCanvasDrawFailure\(err\)\)/, "and its throw is translated");
+});

--- a/browser_tests/unit/canvas-draw-failure.test.mjs
+++ b/browser_tests/unit/canvas-draw-failure.test.mjs
@@ -73,6 +73,12 @@ test("#1108 it names the remedy and admits the panel cannot apply it", () => {
   assert.doesNotMatch(text, /will clear it|this will fix|guaranteed/i, "no promise is made");
   assert.match(text, /unlikely to succeed before then/, "retrying is discouraged, not forbidden");
   assert.match(text, /If a refresh does NOT clear it/, "and the informative case is named");
+  // codex round 2, P1: "then the cause is in the graph" was a false dichotomy — a
+  // persistent frontend issue, an extension, or other browser state survives a
+  // reload without the graph being at fault.
+  assert.match(text, /not \(only\) stale render state/);
+  assert.match(text, /any extension that draws on the canvas/);
+  assert.doesNotMatch(text, /the cause is in the graph rather than/);
   // And a refresh discards unsaved work, which must be said BEFORE they do it.
   assert.match(text, /a refresh discards unsaved canvas work, so offer the user a save FIRST/);
 });
@@ -107,5 +113,15 @@ test("#1108 WIRING: the synchronous redraw is actually wrapped", () => {
     body,
     /throw new Error\(describeCanvasDrawFailure\(err\), \{ cause: err \}\)/,
     "its throw is translated, and the original is kept as `cause`",
+  );
+  // codex round 2, P1: the fit above moved the user's view, and the restore that
+  // undoes it sits further down — so a throw jumped over it and a FAILED screenshot
+  // left them zoomed into the framing it had chosen.
+  const catchStart = body.indexOf("} catch (err) {");
+  assert.ok(catchStart > 0, "the catch must exist");
+  const catchBlock = body.slice(catchStart, catchStart + 900);
+  assert.ok(
+    catchBlock.includes("ds.scale = saved.scale"),
+    "the user's view is restored before the failure is reported",
   );
 });

--- a/browser_tests/unit/canvas-draw-failure.test.mjs
+++ b/browser_tests/unit/canvas-draw-failure.test.mjs
@@ -7,18 +7,17 @@
 // LTX render), so the one tool that could have shown them the state is the one that
 // failed, with a message that reads like a panel bug.
 //
-// It is not one, and it is not the graph or the backend: panel_get_errors and
-// panel_graph_outline both answered correctly at that moment.
+// It is not a panel bug. It is NOT, however, safe to say it is not the graph: a node
+// or widget the renderer cannot draw throws here while panel_graph_outline reads that
+// same node perfectly well — which is exactly what the reporter observed, and the
+// likeliest lead. The first version of this message excluded the graph outright.
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
-import {
-  describeCanvasDrawFailure,
-  isCanvasDrawFailure,
-} from "../../web/js/lib/canvas-draw-failure.js";
+import { describeCanvasDrawFailure } from "../../web/js/lib/canvas-draw-failure.js";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const PANEL_JS = join(HERE, "../../web/js/comfyui-mcp-panel.js");
@@ -32,10 +31,14 @@ test("#1108 the raw exception is preserved, not swallowed", () => {
   assert.match(text, /Cannot read properties of undefined \(reading 'name'\)/);
 });
 
-test("#1108 it says where the throw came from, and what still works", () => {
+test("#1108 it says where the throw came from WITHOUT excluding the graph", () => {
+  // codex review, P1: "not from the graph or the backend" is unsupported — a node or
+  // widget the renderer cannot draw throws here while a graph READ of that same node
+  // succeeds, which is the likeliest lead and the one that sentence sent you away from.
   const text = describeCanvasDrawFailure(REPORTED);
   assert.match(text, /threw while REDRAWING itself/);
-  assert.match(text, /not from the graph or the backend/);
+  assert.match(text, /does NOT rule out the graph as its cause/);
+  assert.doesNotMatch(text, /not from the graph or the backend/);
   // The two tools that DID work for the reporter, named so the next one uses them.
   assert.match(text, /panel_graph_outline/);
   assert.match(text, /panel_get_errors/);
@@ -45,31 +48,40 @@ test("#1108 it connects the failed screenshot to the frozen canvas", () => {
   // The reporter worked this out themselves, twice, before calling the tool. The
   // tool should not make them.
   const text = describeCanvasDrawFailure(REPORTED, { canvasReportedFrozen: true });
-  assert.match(text, /same fault seen from two directions, not two problems/);
-  assert.match(text, /That is what was reported here/);
+  assert.match(text, /worth treating as one fault rather than two/);
+  // codex review, P1: shared timing is not a shared cause, and saying "the same
+  // fault" asserted one.
+  assert.match(text, /shared timing is not proof of a shared cause/);
+  assert.doesNotMatch(text, /not two problems\./);
 
-  // …and when nobody has reported a freeze, it offers the connection conditionally
-  // rather than asserting it.
   const unreported = describeCanvasDrawFailure(REPORTED);
   assert.match(unreported, /If the user reports that too/);
-  assert.doesNotMatch(unreported, /That is what was reported here/);
+  assert.doesNotMatch(unreported, /That was reported here/);
 });
 
 test("#1108 it names the remedy and admits the panel cannot apply it", () => {
   const text = describeCanvasDrawFailure(REPORTED);
   assert.match(text, /hard refresh of the ComfyUI browser tab/);
   assert.match(text, /cannot repair the frontend's render state from here/);
-  // Retrying is explicitly ruled out — the reporter would otherwise try it.
-  assert.match(text, /will fail the same way until the tab is reloaded/);
+  // codex review, P2: offered as what cleared it, not as a promise — and the case
+  // where it does NOT clear is named, because that is the informative one.
+  //
+  // Asserted on MEANING, not on the sentence. A literal match here ("the one report
+  // of this") was tried and removed: a control mutation that changed nothing but
+  // "report"→"reports" killed it, which is a test that punishes rewording rather
+  // than protecting behaviour.
+  assert.doesNotMatch(text, /will clear it|this will fix|guaranteed/i, "no promise is made");
+  assert.match(text, /unlikely to succeed before then/, "retrying is discouraged, not forbidden");
+  assert.match(text, /If a refresh does NOT clear it/, "and the informative case is named");
   // And a refresh discards unsaved work, which must be said BEFORE they do it.
-  assert.match(text, /Unsaved canvas work survives a refresh only if it was saved/);
+  assert.match(text, /a refresh discards unsaved canvas work, so offer the user a save FIRST/);
 });
 
 test("#1108 it does not key on the message shape it happened to see", () => {
   // "reading 'name'" is one shape of this. Matching on it would let the next shape
-  // through as an opaque TypeError again — which is the whole bug.
-  assert.equal(isCanvasDrawFailure(new Error("something else entirely")), true);
-  assert.equal(isCanvasDrawFailure("a string throw"), true);
+  // through as an opaque TypeError again — which is the whole bug. (A predicate that
+  // "classified" throws was written and REMOVED: it returned true for anything and
+  // would have misled a reader into thinking something was being distinguished.)
   const other = describeCanvasDrawFailure(new Error("ctx.measureText is not a function"));
   assert.match(other, /ctx\.measureText is not a function/);
   assert.match(other, /threw while REDRAWING itself/);
@@ -91,5 +103,9 @@ test("#1108 WIRING: the synchronous redraw is actually wrapped", () => {
   assert.ok(i > 0, "graph_screenshot must exist");
   const body = src.slice(i, i + 6000);
   assert.match(body, /try \{\s*\n\s*canvas\.draw\(true, true\);/, "the redraw is inside a try");
-  assert.match(body, /throw new Error\(describeCanvasDrawFailure\(err\)\)/, "and its throw is translated");
+  assert.match(
+    body,
+    /throw new Error\(describeCanvasDrawFailure\(err\), \{ cause: err \}\)/,
+    "its throw is translated, and the original is kept as `cause`",
+  );
 });

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -240,6 +240,7 @@ import {
 } from "./lib/thread-workflow-match.js";
 import { subgraphValueProvenance } from "./lib/subgraph-value-provenance.js";
 import { describeMissingNode, describeRailNodeTarget } from "./lib/node-scope-locator.js";
+import { describeCanvasDrawFailure } from "./lib/canvas-draw-failure.js";
 import {
   describeQueuePromptChain,
   describeQueuePromptChainForReport,
@@ -15417,7 +15418,16 @@ const GRAPH_TOOL_EXECUTORS = {
       ds.offset[0] = fit.offsetX;
       ds.offset[1] = fit.offsetY;
       canvas.setDirty?.(true, true);
-      canvas.draw(true, true); // synchronous redraw at the fitted transform
+      // #1108 — a THROW from here is the frontend's render path, not ours. Raw, it
+      // surfaced as "Cannot read properties of undefined (reading 'name')" to a
+      // reporter who was trying to screenshot a frozen canvas: the one tool that
+      // could have shown them the problem, failing with a message that reads like a
+      // panel bug. Say what it is, what still works, and what clears it.
+      try {
+        canvas.draw(true, true); // synchronous redraw at the fitted transform
+      } catch (err) {
+        throw new Error(describeCanvasDrawFailure(err));
+      }
       const MAXW = 1600;
       if (cv.width > MAXW) {
         const s = MAXW / cv.width;

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -15426,6 +15426,19 @@ const GRAPH_TOOL_EXECUTORS = {
       try {
         canvas.draw(true, true); // synchronous redraw at the fitted transform
       } catch (err) {
+        // Put the user's view back BEFORE failing (codex review). The fit above moved
+        // it, the restore that normally undoes that is further down, and a throw
+        // jumps over it — so a failed screenshot silently left them zoomed into the
+        // framing it had chosen. Values only: re-drawing here would very likely throw
+        // again, and the frontend repaints on its own once it can.
+        try {
+          ds.scale = saved.scale;
+          ds.offset[0] = saved.ox;
+          ds.offset[1] = saved.oy;
+          canvas.setDirty?.(true, true);
+        } catch {
+          /* best-effort: never replace the draw failure with a restore failure */
+        }
         // `cause` keeps the original type and stack: the draw-site frames are the
         // only thing that says WHICH draw failed (codex review).
         throw new Error(describeCanvasDrawFailure(err), { cause: err });

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -15426,7 +15426,9 @@ const GRAPH_TOOL_EXECUTORS = {
       try {
         canvas.draw(true, true); // synchronous redraw at the fitted transform
       } catch (err) {
-        throw new Error(describeCanvasDrawFailure(err));
+        // `cause` keeps the original type and stack: the draw-site frames are the
+        // only thing that says WHICH draw failed (codex review).
+        throw new Error(describeCanvasDrawFailure(err), { cause: err });
       }
       const MAXW = 1600;
       if (cv.width > MAXW) {

--- a/web/js/lib/canvas-draw-failure.js
+++ b/web/js/lib/canvas-draw-failure.js
@@ -12,9 +12,12 @@
  * during an LTX render — so the one tool that could have shown them what they were
  * looking at is the one that failed, with a message that reads like a panel bug.
  *
- * It is not a panel bug, and it is not a graph or backend problem: in that same
- * moment `panel_get_errors` and `panel_graph_outline` both answered correctly. The
- * fault is in the frontend's own draw path, and the panel is only the caller.
+ * It is not a panel bug — the panel is the caller, and the throw came out of the
+ * frontend's draw path. It is NOT safe to go further and call it "not a graph
+ * problem", which the first version of this did: a node or widget the renderer
+ * cannot draw throws exactly here while `panel_graph_outline` reads that same node
+ * perfectly well, which is what the reporter observed. Where it threw is known;
+ * what caused it is not.
  *
  * So the panel says what it saw. It cannot repair LiteGraph's render loop, and it
  * must not pretend to know more than where the throw came from — see the function
@@ -51,8 +54,8 @@ export function describeCanvasDrawFailure(err, opts = {}) {
     `WHAT TO TRY: a hard refresh of the ComfyUI browser tab (F5) is what cleared it for the one ` +
     `report of this, and the panel cannot repair the frontend's render state from here, so ` +
     `re-taking the screenshot is unlikely to succeed before then. If a refresh does NOT clear it, ` +
-    `the cause is in the graph rather than in the render state and will still be there ` +
-    `afterwards. Either way a refresh discards unsaved canvas work, so offer the user a save ` +
+    `then it is not (only) stale render state: look at the graph, and at any extension ` +
+    `that draws on the canvas, because whatever it is survives a reload. Either way a refresh discards unsaved canvas work, so offer the user a save ` +
     `FIRST.`
   );
 }

--- a/web/js/lib/canvas-draw-failure.js
+++ b/web/js/lib/canvas-draw-failure.js
@@ -1,0 +1,59 @@
+/**
+ * #1108 — WHEN THE CANVAS ITSELF CANNOT DRAW.
+ *
+ * `graph_screenshot` fits the view and then calls `canvas.draw(true, true)` — a
+ * SYNCHRONOUS redraw inside LiteGraph. If that throws, the panel surfaced the raw
+ * exception:
+ *
+ *     Error: Cannot read properties of undefined (reading 'name')
+ *
+ * which says nothing about what happened or what to do. The reporter hit it while
+ * trying to screenshot a canvas that had frozen — pan, zoom and clicks all dead
+ * during an LTX render — so the one tool that could have shown them what they were
+ * looking at is the one that failed, with a message that reads like a panel bug.
+ *
+ * It is not a panel bug, and it is not a graph or backend problem: in that same
+ * moment `panel_get_errors` and `panel_graph_outline` both answered correctly. The
+ * fault is in the frontend's own draw path, and the panel is only the caller.
+ *
+ * So the panel says that. It cannot repair LiteGraph's render loop, and it must not
+ * pretend the failure came from somewhere it can act on — but it can name the one
+ * thing that reliably clears it, and it can point out that a frozen canvas and a
+ * failed screenshot are the SAME fault rather than two problems.
+ */
+
+/** A draw failure inside LiteGraph, as opposed to a panel-side precondition. */
+export function isCanvasDrawFailure(err) {
+  // Anything thrown out of canvas.draw() qualifies: the panel has already checked
+  // its own preconditions (canvas present, scope resolvable) before reaching it, so
+  // a throw from here is the renderer's. Deliberately NOT pattern-matched on the
+  // message — "reading 'name'" is one shape of it, and keying on that would let the
+  // next shape through as an opaque TypeError again.
+  return err instanceof Error || typeof err === "string";
+}
+
+/**
+ * What to say when the redraw throws.
+ *
+ * States what failed, what is known to be healthy, what it means for the canvas the
+ * user is looking at, and the one remedy that is known to work. It claims nothing
+ * about the cause beyond where the throw came from.
+ */
+export function describeCanvasDrawFailure(err, opts = {}) {
+  const raw = err instanceof Error ? err.message : String(err ?? "");
+  const alsoFrozen = opts.canvasReportedFrozen === true;
+  return (
+    `The screenshot could not be taken: the ComfyUI canvas threw while REDRAWING itself ` +
+    `(${raw || "no message"}). That throw comes from the frontend's own render path, not from ` +
+    `the graph or the backend — a graph read (panel_graph_outline) and the error surface ` +
+    `(panel_get_errors) are unaffected and worth using instead right now.\n\n` +
+    `WHAT IT MEANS FOR THE CANVAS: a render loop that cannot complete a draw is also what a ` +
+    `frozen canvas looks like from the user's side — no pan, no zoom, clicks dead. ` +
+    `${alsoFrozen ? "That is what was reported here, and " : "If the user reports that too, "}` +
+    `they are the same fault seen from two directions, not two problems.\n\n` +
+    `WHAT CLEARS IT: a hard refresh of the ComfyUI browser tab (F5). The panel cannot repair ` +
+    `the frontend's render state from here, and re-taking the screenshot will fail the same ` +
+    `way until the tab is reloaded. Unsaved canvas work survives a refresh only if it was ` +
+    `saved — offer that to the user before they reload.`
+  );
+}

--- a/web/js/lib/canvas-draw-failure.js
+++ b/web/js/lib/canvas-draw-failure.js
@@ -12,9 +12,11 @@
  * during an LTX render — so the one tool that could have shown them what they were
  * looking at is the one that failed, with a message that reads like a panel bug.
  *
- * It is not a panel bug — the panel is the caller, and the throw came out of the
- * frontend's draw path. It is NOT safe to go further and call it "not a graph
- * problem", which the first version of this did: a node or widget the renderer
+ * The throw comes out of the frontend's draw path, with the panel as the caller —
+ * which is NOT the same as "not a panel bug" (codex round 3): this path sets the
+ * canvas transform to a computed fit before drawing, so an extreme zoom or offset
+ * it chose could be what exposes the renderer's fault. Nor is it safe to call it
+ * "not a graph problem", which the first version of this did: a node or widget the renderer
  * cannot draw throws exactly here while `panel_graph_outline` reads that same node
  * perfectly well, which is what the reporter observed. Where it threw is known;
  * what caused it is not.
@@ -54,8 +56,10 @@ export function describeCanvasDrawFailure(err, opts = {}) {
     `WHAT TO TRY: a hard refresh of the ComfyUI browser tab (F5) is what cleared it for the one ` +
     `report of this, and the panel cannot repair the frontend's render state from here, so ` +
     `re-taking the screenshot is unlikely to succeed before then. If a refresh does NOT clear it, ` +
-    `then it is not (only) stale render state: look at the graph, and at any extension ` +
-    `that draws on the canvas, because whatever it is survives a reload. Either way a refresh discards unsaved canvas work, so offer the user a save ` +
-    `FIRST.`
+    `that is worth knowing but proves less than it looks: a render that is still running can ` +
+    `recreate the same state immediately, so try it with the queue idle before concluding ` +
+    `anything. If it still returns with nothing running, the graph and any extension that draws ` +
+    `on the canvas are what is left to look at. Either way a refresh discards unsaved canvas ` +
+    `work, so offer the user a save FIRST.`
   );
 }

--- a/web/js/lib/canvas-draw-failure.js
+++ b/web/js/lib/canvas-draw-failure.js
@@ -50,17 +50,24 @@ export function describeCanvasDrawFailure(err, opts = {}) {
     `(${raw || "no message"}). The throw is from the frontend's render path, which does NOT rule ` +
     `out the graph as its cause: a node or widget the renderer cannot draw throws here while ` +
     `panel_graph_outline still reads that same graph perfectly well. Use panel_graph_outline and ` +
-    `panel_get_errors now — if either names a node, that node is the first thing to look at.\n\n` +
+    `panel_get_errors now: an outline names nodes whether or not one is at fault, but a node ` +
+    `panel_get_errors flags is worth looking at first.\n\n` +
     `WHAT IT MAY MEAN FOR THE CANVAS: a render loop that cannot complete a draw is also what a ` +
     `frozen canvas looks like from the user's side — no pan, no zoom, clicks dead. ${freeze}\n\n` +
-    `WHAT TO TRY: a hard refresh of the ComfyUI browser tab (F5) is what cleared it for the one ` +
-    `report of this, and the panel cannot repair the frontend's render state from here, so ` +
-    `re-taking the screenshot is unlikely to succeed before then. If a refresh does NOT clear it, ` +
-    `that is worth knowing but proves less than it looks: a render that is still running can ` +
-    `recreate the same state immediately, so try it with the queue idle before concluding ` +
-    `anything. If it still returns with nothing running, the graph and any extension that draws ` +
-    `on the canvas are worth checking — though a stock ComfyUI or browser rendering defect ` +
-    `produces this too, so none of that is a shortlist, only a place to start. Either way a refresh discards unsaved canvas ` +
-    `work, so offer the user a save FIRST.`
+    // The data-loss warning comes FIRST (codex round 5, P1). It used to sit at the
+    // end, after the F5 recommendation — a reader acting top-to-bottom could refresh
+    // before reaching it, which is the loss it exists to prevent.
+    `WHAT TO TRY — BUT SAVE FIRST: the step below reloads the ComfyUI tab and discards ` +
+    `unsaved canvas work, so offer the user a save before suggesting it.
+
+` +
+    `A hard refresh of the ComfyUI browser tab (F5) is what cleared it for the one report of ` +
+    `this, and the panel cannot repair the frontend's render state from here, so re-taking the ` +
+    `screenshot is unlikely to succeed before then. If a refresh does NOT clear it, that is ` +
+    `worth knowing but proves less than it looks: a render that is still running can recreate ` +
+    `the same state immediately, so try it with the queue idle before concluding anything. If ` +
+    `it still returns with nothing running, the graph and any extension that draws on the ` +
+    `canvas are worth checking — though a stock ComfyUI or browser rendering defect produces ` +
+    `this too, so none of that is a shortlist, only a place to start.`
   );
 }

--- a/web/js/lib/canvas-draw-failure.js
+++ b/web/js/lib/canvas-draw-failure.js
@@ -59,7 +59,8 @@ export function describeCanvasDrawFailure(err, opts = {}) {
     `that is worth knowing but proves less than it looks: a render that is still running can ` +
     `recreate the same state immediately, so try it with the queue idle before concluding ` +
     `anything. If it still returns with nothing running, the graph and any extension that draws ` +
-    `on the canvas are what is left to look at. Either way a refresh discards unsaved canvas ` +
+    `on the canvas are worth checking — though a stock ComfyUI or browser rendering defect ` +
+    `produces this too, so none of that is a shortlist, only a place to start. Either way a refresh discards unsaved canvas ` +
     `work, so offer the user a save FIRST.`
   );
 }

--- a/web/js/lib/canvas-draw-failure.js
+++ b/web/js/lib/canvas-draw-failure.js
@@ -16,44 +16,43 @@
  * moment `panel_get_errors` and `panel_graph_outline` both answered correctly. The
  * fault is in the frontend's own draw path, and the panel is only the caller.
  *
- * So the panel says that. It cannot repair LiteGraph's render loop, and it must not
- * pretend the failure came from somewhere it can act on — but it can name the one
- * thing that reliably clears it, and it can point out that a frozen canvas and a
- * failed screenshot are the SAME fault rather than two problems.
+ * So the panel says what it saw. It cannot repair LiteGraph's render loop, and it
+ * must not pretend to know more than where the throw came from — see the function
+ * below for what was claimed and then retracted.
  */
-
-/** A draw failure inside LiteGraph, as opposed to a panel-side precondition. */
-export function isCanvasDrawFailure(err) {
-  // Anything thrown out of canvas.draw() qualifies: the panel has already checked
-  // its own preconditions (canvas present, scope resolvable) before reaching it, so
-  // a throw from here is the renderer's. Deliberately NOT pattern-matched on the
-  // message — "reading 'name'" is one shape of it, and keying on that would let the
-  // next shape through as an opaque TypeError again.
-  return err instanceof Error || typeof err === "string";
-}
 
 /**
  * What to say when the redraw throws.
  *
- * States what failed, what is known to be healthy, what it means for the canvas the
- * user is looking at, and the one remedy that is known to work. It claims nothing
- * about the cause beyond where the throw came from.
+ * It says what it saw and no more (codex review). It does NOT exclude the graph as
+ * the cause — a node or widget the renderer cannot draw throws here while a graph
+ * READ of that same node succeeds, so "not the graph" would have sent someone away
+ * from the likeliest lead. It does not assert that the freeze and the failed draw
+ * are one fault; shared timing is not a shared cause. And it offers the refresh as
+ * the thing that cleared it for the one report of this, not as a remedy the panel
+ * can promise.
  */
 export function describeCanvasDrawFailure(err, opts = {}) {
   const raw = err instanceof Error ? err.message : String(err ?? "");
   const alsoFrozen = opts.canvasReportedFrozen === true;
+  const freeze = alsoFrozen
+    ? `That was reported here, so it is worth treating as one fault rather than two — though ` +
+      `shared timing is not proof of a shared cause.`
+    : `If the user reports that too, they may be one fault seen from two directions rather than ` +
+      `two problems.`;
   return (
     `The screenshot could not be taken: the ComfyUI canvas threw while REDRAWING itself ` +
-    `(${raw || "no message"}). That throw comes from the frontend's own render path, not from ` +
-    `the graph or the backend — a graph read (panel_graph_outline) and the error surface ` +
-    `(panel_get_errors) are unaffected and worth using instead right now.\n\n` +
-    `WHAT IT MEANS FOR THE CANVAS: a render loop that cannot complete a draw is also what a ` +
-    `frozen canvas looks like from the user's side — no pan, no zoom, clicks dead. ` +
-    `${alsoFrozen ? "That is what was reported here, and " : "If the user reports that too, "}` +
-    `they are the same fault seen from two directions, not two problems.\n\n` +
-    `WHAT CLEARS IT: a hard refresh of the ComfyUI browser tab (F5). The panel cannot repair ` +
-    `the frontend's render state from here, and re-taking the screenshot will fail the same ` +
-    `way until the tab is reloaded. Unsaved canvas work survives a refresh only if it was ` +
-    `saved — offer that to the user before they reload.`
+    `(${raw || "no message"}). The throw is from the frontend's render path, which does NOT rule ` +
+    `out the graph as its cause: a node or widget the renderer cannot draw throws here while ` +
+    `panel_graph_outline still reads that same graph perfectly well. Use panel_graph_outline and ` +
+    `panel_get_errors now — if either names a node, that node is the first thing to look at.\n\n` +
+    `WHAT IT MAY MEAN FOR THE CANVAS: a render loop that cannot complete a draw is also what a ` +
+    `frozen canvas looks like from the user's side — no pan, no zoom, clicks dead. ${freeze}\n\n` +
+    `WHAT TO TRY: a hard refresh of the ComfyUI browser tab (F5) is what cleared it for the one ` +
+    `report of this, and the panel cannot repair the frontend's render state from here, so ` +
+    `re-taking the screenshot is unlikely to succeed before then. If a refresh does NOT clear it, ` +
+    `the cause is in the graph rather than in the render state and will still be there ` +
+    `afterwards. Either way a refresh discards unsaved canvas work, so offer the user a save ` +
+    `FIRST.`
   );
 }


### PR DESCRIPTION
Closes #1108 (the screenshot half).

`panel_screenshot` threw `Cannot read properties of undefined (reading 'name')` from inside `graph_screenshot()`, at the exact moment the reporter was trying to diagnose a frozen canvas — so the one tool that could have shown them what they were looking at is the one that failed.

`panel_get_errors` and `panel_graph_outline` both worked at that moment, so the graph and backend were healthy; the fault is in the draw path.

The freeze itself (pan/zoom dead during an LTX render, cleared by F5) is the other half and is very likely the frontend's own render loop rather than panel code — I will say so with evidence rather than fold the two together.

Draft while I find the unguarded read.