### PR TITLE
fix(1114): a numeric from_output reuses the rail slot instead of minting one named "4"

### DIFF
--- a/browser_tests/unit/rail-slot.test.mjs
+++ b/browser_tests/unit/rail-slot.test.mjs
@@ -42,10 +42,10 @@ test("#1114 an out-of-range index is null — never a new slot's worth of null",
   assert.equal(findExistingRailSlot([], "0"), null);
 });
 
-test("#1114 a slot genuinely NAMED '4' wins over the index", () => {
-  // Renaming a rail input to a digit is legal, and a caller passing that name means
-  // it. Index-first would have connected them to the wrong slot silently — worse
-  // than the junk slot this fixes.
+test("#1114 a slot genuinely NAMED '4' resolves when no index competes", () => {
+  // Renaming a rail input to a digit is legal. There is no name-vs-index precedence
+  // here — a mutation swapping the two changed nothing, because a genuine conflict
+  // now refuses (below) and anything else has only one match to return.
   const named = [{ name: "zero", slot: 0 }, { name: "4", slot: 1 }, { name: "two", slot: 2 }];
   assert.equal(findExistingRailSlot(named, "4")?.slot, 1);
   // And a real NUMBER 4 finds it too, because the wire cannot tell the two apart:
@@ -121,4 +121,35 @@ test("#1114 WIRING: the panel uses the shared lookup and keeps no copy", () => {
   // Both rail branches must go through it: outputs (to_input) and inputs (from_output).
   const uses = panel.match(/findExistingRailSlot\(graph\.(inputs|outputs),/g) ?? [];
   assert.equal(uses.length, 2, "both rail branches resolve through it");
+});
+
+test("#1114 an AMBIGUOUS ref refuses instead of guessing (codex round 2)", () => {
+  // Digit-named slots out of index order: `from_output: 1` means either the slot
+  // NAMED "1" (index 0) or index 1 (named "0"). The wire cannot tell — coercion
+  // flattens 1 and "1" — so name-first would have connected to the wrong input
+  // silently, which is the failure this whole fix removes.
+  const crossed = [{ name: "1", slot: 0 }, { name: "0", slot: 1 }];
+  assert.throws(() => findExistingRailSlot(crossed, "1"), /ambiguous on this boundary rail/);
+  assert.throws(() => findExistingRailSlot(crossed, 1), /ambiguous on this boundary rail/);
+  // It names BOTH candidates and what to do about it.
+  try {
+    findExistingRailSlot(crossed, "1");
+    assert.fail("must throw");
+  } catch (e) {
+    assert.match(e.message, /NAMED "1" \(at index 0\)/);
+    assert.match(e.message, /index 1 is a different slot \(named "0"\)/);
+    assert.match(e.message, /Rename the digit-named slot/);
+  }
+});
+
+test("#1114 a digit-named slot AT its own index is not ambiguous", () => {
+  // name and index agree — one slot, no conflict, no refusal.
+  const aligned = [{ name: "0", slot: 0 }, { name: "1", slot: 1 }];
+  assert.equal(findExistingRailSlot(aligned, "1")?.slot, 1);
+  assert.equal(findExistingRailSlot(aligned, 1)?.slot, 1);
+});
+
+test("#1114 a digit name with NO matching index still resolves by name", () => {
+  const named = [{ name: "a", slot: 0 }, { name: "7", slot: 1 }];
+  assert.equal(findExistingRailSlot(named, "7")?.slot, 1); // index 7 does not exist
 });

--- a/browser_tests/unit/rail-slot.test.mjs
+++ b/browser_tests/unit/rail-slot.test.mjs
@@ -55,6 +55,14 @@ test("#1114 a slot genuinely NAMED '4' wins over the index", () => {
   assert.equal(findExistingRailSlot(named, 4)?.slot, 1);
 });
 
+test("#1114 a leading-zero name resolves by NAME when the slot exists", () => {
+  // "007" is a legal slot name. It must match that slot — and must NOT fall through
+  // to index 7 when no such slot exists.
+  const named = [{ name: "a", slot: 0 }, { name: "007", slot: 1 }];
+  assert.equal(findExistingRailSlot(named, "007")?.slot, 1);
+  assert.equal(findExistingRailSlot(RAIL, "007"), null); // no slot named "007" here
+});
+
 test("#1114 name matching stays case-insensitive", () => {
   assert.equal(findExistingRailSlot([{ name: "Prompt" }], "prompt")?.name, "Prompt");
   assert.equal(findExistingRailSlot([{ name: "prompt" }], "PROMPT")?.name, "prompt");
@@ -63,7 +71,10 @@ test("#1114 name matching stays case-insensitive", () => {
 test("#1114 the index parse is STRICT — a mistyped name must not hit an index", () => {
   // A loose parse would turn a typo into a silent connection to an unrelated slot,
   // which is a worse failure than the visible junk slot: nothing would look wrong.
-  for (const bad of [" 4 ", "4.0", "0x4", "+4", "4px", "-1", "", "  ", "1e1"]) {
+  // codex review, P1: "04"/"007" were accepted by /^\d+$/ — so a name-shaped "007"
+  // with no matching slot connected silently to index 7. My own list had exotic
+  // cases and missed the obvious one.
+  for (const bad of [" 4 ", "4.0", "0x4", "+4", "4px", "-1", "", "  ", "1e1", "04", "007", "00"]) {
     assert.equal(railSlotIndex(bad), null, JSON.stringify(bad));
     assert.equal(findExistingRailSlot(RAIL, bad), null, JSON.stringify(bad));
   }

--- a/browser_tests/unit/rail-slot.test.mjs
+++ b/browser_tests/unit/rail-slot.test.mjs
@@ -1,0 +1,113 @@
+// #1114 — a numeric from_output minted a junk rail slot instead of reusing one.
+//
+//   panel_connect({ from_node_id: -10, from_output: 4, to_node_id: 217, to_input: "prompt" })
+//     -> { "exposed": { "name": "4", "type": "STRING", "slot": 12, ... } }
+//
+// `exposed`, not `connected`: the lookup returned null, so graph_connect's
+// input-rail branch fell through to graph_expose_subgraph_input and created a rail
+// input literally named "4". Permanent, and visible as a junk slot on the parent
+// subgraph node too.
+//
+// The index branch was gated on `typeof ref === "number"` while MCP argument
+// coercion delivers `from_output: 4` as the string "4". A lookup that failed closed
+// would have been a refusal; this one edited the user's subgraph.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { findExistingRailSlot, railSlotIndex } from "../../web/js/lib/rail-slot.js";
+
+/** A rail with twelve slots, none of them named with digits — the reported shape. */
+const RAIL = Array.from({ length: 12 }, (_, i) => ({ name: `in_${i}`, type: "STRING", slot: i }));
+
+test("#1114 a numeric STRING index resolves the existing slot", () => {
+  // The exact reported call: from_output arrives as "4".
+  assert.equal(findExistingRailSlot(RAIL, "4")?.name, "in_4");
+  assert.equal(findExistingRailSlot(RAIL, "0")?.name, "in_0");
+  assert.equal(findExistingRailSlot(RAIL, "11")?.name, "in_11");
+});
+
+test("#1114 a real number still resolves, as it always did", () => {
+  assert.equal(findExistingRailSlot(RAIL, 4)?.name, "in_4");
+  assert.equal(findExistingRailSlot(RAIL, 0)?.name, "in_0");
+});
+
+test("#1114 an out-of-range index is null — never a new slot's worth of null", () => {
+  // Null is what the caller turns into "expose a new one", so the boundary matters:
+  // 12 slots means 11 is the last valid index.
+  assert.equal(findExistingRailSlot(RAIL, "12"), null);
+  assert.equal(findExistingRailSlot(RAIL, 12), null);
+  assert.equal(findExistingRailSlot([], "0"), null);
+});
+
+test("#1114 a slot genuinely NAMED '4' wins over the index", () => {
+  // Renaming a rail input to a digit is legal, and a caller passing that name means
+  // it. Index-first would have connected them to the wrong slot silently — worse
+  // than the junk slot this fixes.
+  const named = [{ name: "zero", slot: 0 }, { name: "4", slot: 1 }, { name: "two", slot: 2 }];
+  assert.equal(findExistingRailSlot(named, "4")?.slot, 1);
+  // And a real NUMBER 4 finds it too, because the wire cannot tell the two apart:
+  // MCP coercion turns numbers into strings, so "the caller passed a number" is not
+  // knowable here. Name-first is the safer rule either way — the alternative mints a
+  // SECOND slot also named "4", which is the corruption this fixes, doubled.
+  assert.equal(findExistingRailSlot(named, 4)?.slot, 1);
+});
+
+test("#1114 name matching stays case-insensitive", () => {
+  assert.equal(findExistingRailSlot([{ name: "Prompt" }], "prompt")?.name, "Prompt");
+  assert.equal(findExistingRailSlot([{ name: "prompt" }], "PROMPT")?.name, "prompt");
+});
+
+test("#1114 the index parse is STRICT — a mistyped name must not hit an index", () => {
+  // A loose parse would turn a typo into a silent connection to an unrelated slot,
+  // which is a worse failure than the visible junk slot: nothing would look wrong.
+  for (const bad of [" 4 ", "4.0", "0x4", "+4", "4px", "-1", "", "  ", "1e1"]) {
+    assert.equal(railSlotIndex(bad), null, JSON.stringify(bad));
+    assert.equal(findExistingRailSlot(RAIL, bad), null, JSON.stringify(bad));
+  }
+});
+
+test("#1114 negative and non-integer numbers are not indices", () => {
+  assert.equal(railSlotIndex(-1), null);
+  assert.equal(railSlotIndex(1.5), null);
+  assert.equal(railSlotIndex(Number.NaN), null);
+  assert.equal(railSlotIndex(Number.MAX_SAFE_INTEGER + 2), null);
+});
+
+test("#1114 null/undefined refs resolve to null rather than throwing", () => {
+  assert.equal(findExistingRailSlot(RAIL, null), null);
+  assert.equal(findExistingRailSlot(RAIL, undefined), null);
+  assert.equal(findExistingRailSlot(null, "4"), null);
+  assert.equal(findExistingRailSlot(undefined, 4), null);
+});
+
+test("#1114 slots without names do not break the name pass", () => {
+  const ragged = [{ slot: 0 }, { name: null, slot: 1 }, { name: "in_2", slot: 2 }];
+  assert.equal(findExistingRailSlot(ragged, "2")?.slot, 2); // falls through to index
+  assert.equal(findExistingRailSlot(ragged, "in_2")?.slot, 2);
+});
+
+test("#1114 WIRING: the panel uses the shared lookup and keeps no copy", () => {
+  // Removing the import leaves the panel referencing an undefined identifier, which
+  // typecheck did NOT catch — and the behavioural tests above cannot see the call
+  // site at all, so a mutation dropping it survived until this existed.
+  const panel = readFileSync(
+    join(dirname(fileURLToPath(import.meta.url)), "../../web/js/comfyui-mcp-panel.js"),
+    "utf8",
+  );
+  assert.match(
+    panel,
+    /import \{ findExistingRailSlot \} from "\.\/lib\/rail-slot\.js";/,
+    "the panel imports the shared lookup",
+  );
+  assert.doesNotMatch(
+    panel,
+    /function findExistingRailSlot\s*\(/,
+    "and keeps no local copy that would shadow it",
+  );
+  // Both rail branches must go through it: outputs (to_input) and inputs (from_output).
+  const uses = panel.match(/findExistingRailSlot\(graph\.(inputs|outputs),/g) ?? [];
+  assert.equal(uses.length, 2, "both rail branches resolve through it");
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -240,6 +240,7 @@ import {
 } from "./lib/thread-workflow-match.js";
 import { subgraphValueProvenance } from "./lib/subgraph-value-provenance.js";
 import { describeMissingNode, describeRailNodeTarget } from "./lib/node-scope-locator.js";
+import { findExistingRailSlot } from "./lib/rail-slot.js";
 import { describeCanvasDrawFailure } from "./lib/canvas-draw-failure.js";
 import {
   describeQueuePromptChain,
@@ -8192,15 +8193,6 @@ function isEmptyRailSlotRef(ref) {
 
 /** Find an EXISTING rail slot (SubgraphInput/SubgraphOutput) by name or index,
  *  or null if none matches. */
-function findExistingRailSlot(slots, ref) {
-  if (ref == null) return null;
-  if (typeof ref === "number" && Number.isInteger(ref)) {
-    return ref >= 0 && ref < (slots?.length ?? 0) ? slots[ref] : null;
-  }
-  const name = String(ref).toLowerCase();
-  return (slots ?? []).find((s) => s?.name?.toLowerCase() === name) ?? null;
-}
-
 // ---- Group boxes (LiteGraph LGraphGroup) helpers --------------------------
 
 /** Resolve a group box by id (with an index fallback for graphs whose groups

--- a/web/js/lib/rail-slot.js
+++ b/web/js/lib/rail-slot.js
@@ -21,7 +21,8 @@
 /**
  * A slot INDEX from a number or a canonical numeric string, else null.
  *
- * Deliberately strict: "4" yes, " 4 " no, "4.0" no, "0x4" no, "-1" no. A loose
+ * Deliberately strict: "4" yes; " 4 ", "4.0", "0x4", "-1" and leading-zero forms
+ * like "04"/"007" no — those are names, not indices. A loose
  * parse would turn a mistyped NAME into a silent index hit on an unrelated slot —
  * connecting to the wrong input, which is worse than the visible junk slot this
  * fixes.
@@ -32,7 +33,11 @@ export function railSlotIndex(ref) {
     // anything meaningfully, and it slipped through until a test asked.
     return Number.isSafeInteger(ref) && ref >= 0 ? ref : null;
   }
-  if (typeof ref !== "string" || !/^\d+$/.test(ref)) return null;
+  // CANONICAL, not merely digits (codex review): /^\d+$/ accepts "04" and "007",
+  // so a caller passing a name-shaped "007" with no slot of that name would have
+  // been silently connected to index 7 — the same class of silent wrong-target
+  // this fix exists to remove, in a narrower window.
+  if (typeof ref !== "string" || !/^(?:0|[1-9]\d*)$/.test(ref)) return null;
   const n = Number(ref);
   return Number.isSafeInteger(n) ? n : null;
 }

--- a/web/js/lib/rail-slot.js
+++ b/web/js/lib/rail-slot.js
@@ -43,17 +43,40 @@ export function railSlotIndex(ref) {
 }
 
 /**
- * The existing rail slot `ref` names, or null.
+ * The existing rail slot `ref` names, or null — and a THROW when it could be two.
  *
- * NAME FIRST, then index. A slot genuinely called "4" must still win — renaming a
- * rail input to a digit is legal, and a caller who passes that name means it.
+ * There is NO precedence between name and index, and saying "name first" would
+ * describe one that does not exist: when both match the SAME slot the order cannot
+ * matter, and when they match DIFFERENT slots this refuses rather than picking
+ * (codex review). A mutation swapping the two proved it — it changed nothing,
+ * which is the only honest reading of code that has no ordering left. A rail whose slots are digit-named out
+ * of index order — `[{name:"1"}, {name:"0"}]` — makes `from_output: 1` mean either
+ * the slot called "1" (index 0) or index 1 (called "0"), and the wire cannot tell
+ * which the caller meant: MCP coercion flattens the number 4 and the string "4" to
+ * the same value before this is reached.
+ *
+ * Guessing there is a silent connection to the wrong input, which is the failure
+ * class this whole fix exists to remove. A refusal is recoverable and says what to
+ * do; a wrong link is neither.
  */
 export function findExistingRailSlot(slots, ref) {
   if (ref == null) return null;
   const list = slots ?? [];
   const name = String(ref).toLowerCase();
   const byName = list.find((s) => s?.name?.toLowerCase() === name) ?? null;
-  if (byName) return byName;
   const idx = railSlotIndex(ref);
-  return idx !== null && idx < list.length ? list[idx] : null;
+  const byIndex = idx !== null && idx < list.length ? list[idx] : null;
+  if (byName && byIndex && byName !== byIndex) {
+    const namedIdx = list.indexOf(byName);
+    throw new Error(
+      `"${ref}" is ambiguous on this boundary rail: a slot is NAMED "${byName.name}" ` +
+        `(at index ${namedIdx}), and index ${idx} is a different slot ` +
+        `(named "${byIndex.name ?? "unnamed"}"). This rail has digit-named slots that do not ` +
+        `sit at the matching index, and nothing here can tell which one you meant — the value ` +
+        `arrives as a string either way. Rename the digit-named slot to something that is not ` +
+        `a number, and this becomes unambiguous for every caller.`,
+    );
+  }
+  // Whichever matched; they cannot disagree by the time we are here.
+  return byName ?? byIndex;
 }

--- a/web/js/lib/rail-slot.js
+++ b/web/js/lib/rail-slot.js
@@ -1,0 +1,54 @@
+/**
+ * #1114 — resolving a subgraph boundary-rail slot by NAME or INDEX.
+ *
+ * `panel_connect({ from_node_id: -10, from_output: 4, … })` inside a subgraph
+ * created a NEW rail input literally named "4" instead of reusing rail output 4.
+ * The reply even said `exposed` rather than `connected`, because the caller read
+ * "no such slot" and fell through to graph_expose_subgraph_input. The rail then
+ * permanently carried a bogus input, which also appeared as a junk slot on the
+ * parent subgraph node.
+ *
+ * The lookup gated its INDEX branch on `typeof ref === "number"`, and MCP argument
+ * coercion delivers `from_output: 4` as the string "4". So the index was never
+ * tried, the name lookup found nothing, and the caller minted a slot. A lookup that
+ * failed closed would have been a refusal; this one edited the user's subgraph.
+ *
+ * Extracted here so the rule is testable directly: the same defect in the id
+ * validator earlier (#1425) was only caught because the decision had somewhere to
+ * be asserted from.
+ */
+
+/**
+ * A slot INDEX from a number or a canonical numeric string, else null.
+ *
+ * Deliberately strict: "4" yes, " 4 " no, "4.0" no, "0x4" no, "-1" no. A loose
+ * parse would turn a mistyped NAME into a silent index hit on an unrelated slot —
+ * connecting to the wrong input, which is worse than the visible junk slot this
+ * fixes.
+ */
+export function railSlotIndex(ref) {
+  if (typeof ref === "number") {
+    // isSafeInteger, not isInteger: 2**53 is an "integer" that cannot index
+    // anything meaningfully, and it slipped through until a test asked.
+    return Number.isSafeInteger(ref) && ref >= 0 ? ref : null;
+  }
+  if (typeof ref !== "string" || !/^\d+$/.test(ref)) return null;
+  const n = Number(ref);
+  return Number.isSafeInteger(n) ? n : null;
+}
+
+/**
+ * The existing rail slot `ref` names, or null.
+ *
+ * NAME FIRST, then index. A slot genuinely called "4" must still win — renaming a
+ * rail input to a digit is legal, and a caller who passes that name means it.
+ */
+export function findExistingRailSlot(slots, ref) {
+  if (ref == null) return null;
+  const list = slots ?? [];
+  const name = String(ref).toLowerCase();
+  const byName = list.find((s) => s?.name?.toLowerCase() === name) ?? null;
+  if (byName) return byName;
+  const idx = railSlotIndex(ref);
+  return idx !== null && idx < list.length ? list[idx] : null;
+}


### PR DESCRIPTION
Closes #1114.

`panel_connect({ from_node_id: -10, from_output: 4, … })` inside a subgraph creates a NEW rail input literally named `"4"` instead of reusing rail output 4 — and the reply says `exposed`, not `connected`, because it fell through to `graph_expose_subgraph_input`. The rail then permanently carries a bogus 13th input, which also shows up as a junk slot on the parent subgraph node.

The reporter located it exactly: `findExistingRailSlot` only does index lookup when `typeof ref === "number"`, and MCP argument coercion delivers `from_output: 4` as the STRING `"4"`. The numeric branch is skipped, the name lookup finds nothing, and the caller mints a slot.

Same family as #1425 earlier today — a value the wire turns into a string, read by code expecting the number. This one is worse than a refusal: it edits the user's subgraph.

Draft while I check what a slot genuinely NAMED "4" should do, since that is the ambiguity a fix has to resolve rather than ignore.