### PR TITLE
fix(236): advertise the vendored tool vocabulary in the hello

### DIFF
--- a/browser_tests/unit/vocabulary-hash.test.mjs
+++ b/browser_tests/unit/vocabulary-hash.test.mjs
@@ -1,0 +1,59 @@
+// #236 — the panel advertises WHICH tool vocabulary it vendored, at connect.
+//
+// The panel calls MCP tool names as bare string literals and validates them against
+// vendor/tool-vocabulary.json. That proves the literals match the vendored copy; it
+// cannot prove the copy matches the SERVER. When they disagree, the failure surfaced
+// at CALL time as "unknown tool" — which reads as a broken panel and gives an agent
+// nothing to act on. The orchestrator half of this landed in comfyui-mcp; without
+// this half it has nothing to compare and every panel reads "unverified".
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { buildHelloPayload } from "../../web/js/lib/session-rebind.js";
+import { VENDORED_VOCABULARY_HASH } from "../../web/js/lib/vocabulary-hash.js";
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "../..");
+
+test("#236 the hello carries the vendored vocabulary hash", () => {
+  const hello = buildHelloPayload({
+    tabId: "wf:x",
+    title: "t",
+    panelVersion: "0.14.13",
+    vocabularyHash: VENDORED_VOCABULARY_HASH,
+  });
+  assert.equal(hello.vocabulary_hash, VENDORED_VOCABULARY_HASH);
+  assert.match(hello.vocabulary_hash, /^[0-9a-f]{64}$/);
+});
+
+test("#236 an omitted hash is ABSENT, not an empty string", () => {
+  // The orchestrator reads a non-empty string as the panel's claim and anything else
+  // as "unverified". An empty string would be a claim of nothing — it must not look
+  // like one, and it must never read as disagreement.
+  const hello = buildHelloPayload({ tabId: "wf:x", title: "t", panelVersion: "0.14.13" });
+  assert.equal(hello.vocabulary_hash, undefined);
+});
+
+test("#236 the baked constant matches the artefact it claims to identify", () => {
+  // The constant is a deliberate DUPLICATE: vendor/ is not served to the browser
+  // (WEB_DIRECTORY is ./web), so the panel cannot read the artefact at runtime. A
+  // duplicate is only honest with a check on it — a stale one would make the
+  // orchestrator report a mismatch that is not real, which is worse than no handshake
+  // and indistinguishable from a genuine skew.
+  //
+  // scripts/check-tool-vocabulary.mjs enforces this in CI too; this asserts it here so
+  // the failure names the cause instead of arriving as a mystery skew on a live rig.
+  const vocab = JSON.parse(readFileSync(join(ROOT, "vendor/tool-vocabulary.json"), "utf8"));
+  assert.equal(VENDORED_VOCABULARY_HASH, vocab.vocabularyHash);
+});
+
+test("#236 WIRING: the panel actually passes the constant to the hello", () => {
+  // buildHelloPayload takes the hash as a PARAMETER, so a correct constant and a
+  // correct builder still advertise nothing if the call site omits it — and no
+  // behavioural test above can see that.
+  const panel = readFileSync(join(ROOT, "web/js/comfyui-mcp-panel.js"), "utf8");
+  assert.match(panel, /import \{ VENDORED_VOCABULARY_HASH \} from "\.\/lib\/vocabulary-hash\.js";/);
+  assert.match(panel, /vocabularyHash: VENDORED_VOCABULARY_HASH,/);
+});

--- a/scripts/check-tool-vocabulary.mjs
+++ b/scripts/check-tool-vocabulary.mjs
@@ -84,7 +84,35 @@ const vocab = JSON.parse(readFileSync(join(root, "vendor", "tool-vocabulary.json
 // orchestrator would report a mismatch that is not real — worse than no handshake at
 // all, and indistinguishable from a genuine skew.
 {
-  const baked = readFileSync(join(root, "web", "js", "lib", "vocabulary-hash.js"), "utf8");
+  // Read defensively (codex review, P2). A packaging or re-vendor change that drops
+  // this file must produce the checker's own FAIL — an uncaught ENOENT reads as the
+  // gate crashing, which is exactly the state where someone shrugs and reruns CI
+  // rather than noticing the pack is incomplete.
+  const bakedPath = join(root, "web", "js", "lib", "vocabulary-hash.js");
+  let baked;
+  try {
+    baked = readFileSync(bakedPath, "utf8");
+  } catch (err) {
+    console.error(
+      `
+[check-tool-vocabulary] FAIL
+
+` +
+        `Could not read web/js/lib/vocabulary-hash.js (${err?.code ?? err?.message ?? err}).
+
+` +
+        `The panel advertises this hash in its hello so the orchestrator can detect a
+` +
+        `tool-surface skew at connect (#236). Without the file the panel advertises
+` +
+        `nothing and every connection reads "unverified". Restore it with:
+
+` +
+        `  export const VENDORED_VOCABULARY_HASH = "${vocab.vocabularyHash}";
+`,
+    );
+    process.exit(1);
+  }
   const m = baked.match(/VENDORED_VOCABULARY_HASH\s*=\s*"([0-9a-f]{64})"/);
   if (!m) {
     console.error(

--- a/scripts/check-tool-vocabulary.mjs
+++ b/scripts/check-tool-vocabulary.mjs
@@ -75,6 +75,38 @@ const vocab = JSON.parse(readFileSync(join(root, "vendor", "tool-vocabulary.json
     process.exit(1);
   }
 }
+// #236 — the BAKED copy of the hash must still match the artefact.
+//
+// web/js/lib/vocabulary-hash.js duplicates `vocabularyHash` because `vendor/` is not
+// served to the browser (WEB_DIRECTORY is ./web), so the panel cannot read the artefact
+// at runtime. A duplicated constant is only honest with a gate on it: without this, a
+// re-vendor would leave the panel advertising the PREVIOUS vocabulary, and the
+// orchestrator would report a mismatch that is not real — worse than no handshake at
+// all, and indistinguishable from a genuine skew.
+{
+  const baked = readFileSync(join(root, "web", "js", "lib", "vocabulary-hash.js"), "utf8");
+  const m = baked.match(/VENDORED_VOCABULARY_HASH\s*=\s*"([0-9a-f]{64})"/);
+  if (!m) {
+    console.error(
+      `\n[check-tool-vocabulary] FAIL\n\n` +
+        `web/js/lib/vocabulary-hash.js does not declare a readable VENDORED_VOCABULARY_HASH.\n` +
+        `Expected a 64-character hex literal — the panel advertises it in its hello (#236).\n`,
+    );
+    process.exit(1);
+  }
+  if (m[1] !== vocab.vocabularyHash) {
+    console.error(
+      `\n[check-tool-vocabulary] FAIL\n\n` +
+        `The vocabulary hash the panel ADVERTISES is stale.\n\n` +
+        `  web/js/lib/vocabulary-hash.js  ${m[1]}\n` +
+        `  vendor/tool-vocabulary.json    ${vocab.vocabularyHash}\n\n` +
+        `Left as is, every connection reports a vocabulary mismatch that is not real\n` +
+        `(#236). Fix by replacing the constant with:\n\n` +
+        `  export const VENDORED_VOCABULARY_HASH = "${vocab.vocabularyHash}";\n`,
+    );
+    process.exit(1);
+  }
+}
 const CORE = new Set(vocab.core);
 const PANEL = new Set(vocab.panel);
 const DEAD = new Map(vocab.dead.map((d) => [d.name, d]));

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -241,6 +241,7 @@ import {
 import { subgraphValueProvenance } from "./lib/subgraph-value-provenance.js";
 import { describeMissingNode, describeRailNodeTarget } from "./lib/node-scope-locator.js";
 import { findExistingRailSlot } from "./lib/rail-slot.js";
+import { VENDORED_VOCABULARY_HASH } from "./lib/vocabulary-hash.js";
 import { describeCanvasDrawFailure } from "./lib/canvas-draw-failure.js";
 import {
   describeQueuePromptChain,
@@ -18063,6 +18064,8 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
             // Our build version, so the orchestrator can auto-stamp it into the
             // agent's ENV block (bug reports get version-pinned without digging).
             panelVersion: PANEL_VERSION,
+            // #236 — lets the orchestrator detect a tool-surface skew at CONNECT.
+            vocabularyHash: VENDORED_VOCABULARY_HASH,
             backend,
             // Blind content mode (issue #90): the orchestrator spawns this tab's
             // comfyui tool server with pixel-withholding env when true.

--- a/web/js/lib/session-rebind.js
+++ b/web/js/lib/session-rebind.js
@@ -291,6 +291,7 @@ export function buildHelloPayload({
   tabId,
   title,
   panelVersion,
+  vocabularyHash,
   backend,
   blind = false,
   comfyuiUrl,
@@ -305,6 +306,22 @@ export function buildHelloPayload({
     tab_id: tabId,
     title,
     panel_version: panelVersion,
+    // #236 — the tool vocabulary THIS build vendored, so the orchestrator can compare
+    // it against its own AT CONNECT rather than letting the skew surface one failed
+    // tool call at a time as "unknown tool".
+    //
+    // A version string cannot do this job: two builds of one version can carry
+    // different vocabularies, and two versions can carry identical ones. A hash of the
+    // vocabulary changes exactly when the thing it identifies changes.
+    //
+    // Safe in both directions of skew. An orchestrator predating the check ignores an
+    // unknown hello field; one that has it treats an ABSENT hash as UNVERIFIED, never
+    // as disagreeing — so neither an old panel nor an old server is ever reported as
+    // wrong on the strength of a field it does not send.
+    //
+    // Passed IN rather than imported, like panelVersion: this module stays free of the
+    // panel bundle so its unit tests can build a hello without one.
+    vocabulary_hash: vocabularyHash,
     backend: backend || "claude",
     blind: Boolean(blind),
     // #570 P0c — advertise that THIS panel build enforces the per-command workflow-instance

--- a/web/js/lib/vocabulary-hash.js
+++ b/web/js/lib/vocabulary-hash.js
@@ -1,0 +1,30 @@
+/**
+ * The identity of the tool vocabulary THIS panel build vendored (#236).
+ *
+ * The panel calls MCP tool names as bare string literals and validates them against
+ * `vendor/tool-vocabulary.json`. That is a self-consistency check: it proves the
+ * literals match the vendored copy, never that the copy matches the SERVER being
+ * talked to. When the two disagree, the failure surfaced at CALL time as "unknown
+ * tool" — which reads to a user as a broken panel and gives an agent nothing to act
+ * on (panel #236, and #683 in the other direction).
+ *
+ * Advertising this in the hello lets the orchestrator compare the two AT CONNECT and
+ * say so once, in a sentence that names the remedy, instead of leaving it to be
+ * discovered one failed tool call at a time.
+ *
+ * ## Why it is a baked constant and not a read of the artefact
+ *
+ * `vendor/` is not served to the browser — the pack's WEB_DIRECTORY is `./web`, so
+ * nothing under the pack root is fetchable from panel JS. A copy under `web/` would
+ * be a second artefact free to drift from the first.
+ *
+ * So the value is duplicated here deliberately, and `scripts/check-tool-vocabulary.mjs`
+ * FAILS when it stops matching `vendor/tool-vocabulary.json` — the same gate that
+ * already runs in CI and already refuses a hand-edited artefact. A duplicated constant
+ * with a gate is honest; one without a gate is the drift this whole handshake exists
+ * to catch, reproduced inside the thing catching it.
+ *
+ * GENERATED VALUE — do not hand-edit. Re-vendor and run `npm run check:tool-vocabulary`,
+ * which prints the replacement line when this goes stale.
+ */
+export const VENDORED_VOCABULARY_HASH = "0d805152a369dc0bfcc8bd2b96cdcbbe2f139d5b46e71857701e2ea132f5f05e";


### PR DESCRIPTION
The panel half of the #236 handshake. Orchestrator half: artokun/comfyui-mcp#1455 (merged).

The orchestrator now compares the vocabulary a connected panel vendored against its own at connect — but nothing sent one, so every panel read `unverified`. This sends it.

- `buildHelloPayload` gains `vocabularyHash`, passed in like `panelVersion` so the module stays free of the panel bundle.
- `web/js/lib/vocabulary-hash.js` bakes the value, because `vendor/` is not served to the browser (`WEB_DIRECTORY = ./web`) and a copy under `web/` would be a second artefact free to drift.
- `check-tool-vocabulary.mjs` fails when the baked constant and the artefact diverge, printing the replacement line. Verified by mutation: exit 1 on drift, exit 1 on a malformed literal, exit 0 clean.

Three-state is preserved end to end: an omitted hash stays `undefined` rather than becoming an empty-string claim, and the orchestrator reads absence as UNVERIFIED, never as disagreement.

Mutations: dropping the call-site argument, dropping the builder parameter, and turning absence into `""` all fail; a control comment survives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)