### PR TITLE
fix(1448): say whether the workflow list was actually re-read, and stop blaming the folder

### DIFF
--- a/browser_tests/unit/open-workflow-not-found.test.mjs
+++ b/browser_tests/unit/open-workflow-not-found.test.mjs
@@ -100,7 +100,16 @@ test("#1448 WIRING: the caller records the outcome instead of assuming one", () 
   assert.match(panel, /refresh = "unavailable"/, "a frontend without syncWorkflows");
   assert.match(panel, /refresh = "ok"/, "a successful re-read");
   assert.match(panel, /refresh = `failed: \$\{err\?\.message \?\? err\}`/, "a thrown re-read");
-  assert.match(panel, /openWorkflowNotFoundMessage\(\{ path, refresh, known: knownSelectorSample\(all\) \}\)/);
+  // The sample must be taken AFTER the refresh (codex review). A successful re-read
+  // removes stale entries — measured 109 -> 107 on a live rig — so a snapshot taken
+  // before it can offer a workflow that no longer exists as an example.
+  assert.match(panel, /const known = knownSelectorSample\(\[\.\.\.\(s\?\.openWorkflows \?\? \[\]\), \.\.\.\(s\?\.workflows \?\? \[\]\)\]\);/);
+  assert.match(panel, /openWorkflowNotFoundMessage\(\{ path, refresh, known \}\)/);
+  const failSite = panel.slice(panel.indexOf("const known = knownSelectorSample"));
+  assert.ok(
+    failSite.indexOf("openWorkflowNotFoundMessage") < 400,
+    "the sample is computed immediately before the refusal it feeds",
+  );
   // And the old sentence is no longer EMITTED. Scoped to non-comment lines: the fix
   // quotes the old wording in a comment to explain itself, and a bare doesNotMatch
   // over the whole file forbade describing the very defect being fixed.

--- a/browser_tests/unit/open-workflow-not-found.test.mjs
+++ b/browser_tests/unit/open-workflow-not-found.test.mjs
@@ -1,0 +1,114 @@
+// #1448 — "it isn't among the saved/open workflows even after a refresh."
+//
+// Said for a file the reporter had confirmed on disk INSIDE the workflows folder,
+// twice. Two defects in one sentence: it asserted a refresh it had not checked, and
+// its remedy ("for a file outside the workflows folder") named a cause that was not
+// the case and sent them away from the file.
+//
+// The refresh only runs when the frontend exposes `syncWorkflows`, and a throw from
+// it was swallowed by a console.warn no agent session reads — so both ways it can
+// fail to happen were invisible while the message claimed it had.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import {
+  knownSelectorSample,
+  openWorkflowNotFoundMessage,
+} from "../../web/js/lib/open-workflow-not-found.js";
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "../..");
+const msg = (o) => openWorkflowNotFoundMessage({ path: "video_minimax_low_vram.json", ...o });
+
+test("#1448 a re-read that HAPPENED is stated as such", () => {
+  const t = msg({ refresh: "ok" });
+  assert.match(t, /list WAS re-read/);
+  assert.match(t, /still does not contain it/);
+});
+
+test("#1448 a frontend with no sync method does NOT claim a refresh", () => {
+  // The reported sentence, on a build where the refresh cannot even be attempted.
+  const t = msg({ refresh: "unavailable" });
+  assert.match(t, /was NOT re-read/);
+  assert.match(t, /no workflow-sync method/);
+  // And the action that WOULD make the file visible.
+  assert.match(t, /Reload the ComfyUI browser/);
+  assert.doesNotMatch(t, /WAS re-read/);
+});
+
+test("#1448 a FAILED re-read says so, and that it is not evidence of absence", () => {
+  // Swallowing this was the worst of the three: the caller was told the list had been
+  // re-read when the attempt had thrown, so an absent file looked confirmed.
+  const t = msg({ refresh: "failed: NetworkError when attempting to fetch resource" });
+  assert.match(t, /re-read of the workflow list FAILED/);
+  assert.match(t, /NetworkError when attempting to fetch resource/);
+  assert.match(t, /not evidence the file is absent/);
+});
+
+test("#1448 it no longer asserts the file is outside the workflows folder", () => {
+  // The remedy that misled the reporter. panel_load_workflow is still offered — it IS
+  // the right tool for a path elsewhere — but as a branch, not as a diagnosis.
+  for (const refresh of ["ok", "unavailable", "not-needed", "failed: x"]) {
+    const t = msg({ refresh });
+    assert.doesNotMatch(t, /For a file outside the workflows folder/, refresh);
+    assert.match(t, /If the file IS in the workflows/, refresh);
+    assert.match(t, /if it is anywhere\s+else, load it with panel_load_workflow/, refresh);
+  }
+});
+
+test("#1448 it shows the selector SHAPES, which are not guessable from outside", () => {
+  // Measured on the live rig: `filename` carries no extension while `key` does, and
+  // `path` is folder-qualified. A caller cannot infer that, so the sample shows it.
+  const t = msg({ refresh: "ok", known: ["workflows/Anima Wojak Batch.json"] });
+  assert.match(t, /workflows\/Anima Wojak Batch\.json/);
+  assert.match(t, /bare name with or without "\.json"/);
+});
+
+test("#1448 the sample is only PERSISTED records, and is bounded", () => {
+  // An unsaved tab is addressable only by its per-instance routing id, so showing its
+  // path as an example would be advice that does not work. And a 100-entry store in a
+  // refusal is noise — the shape disambiguates, not the inventory.
+  const records = [
+    { path: "workflows/a.json", isPersisted: true },
+    { path: "workflows/Unsaved Workflow.json", isPersisted: false, isTemporary: true },
+    { path: "workflows/b.json", isPersisted: true },
+    { path: "workflows/c.json", isPersisted: true },
+    { path: "workflows/d.json", isPersisted: true },
+  ];
+  const sample = knownSelectorSample(records);
+  assert.deepEqual(sample, ["workflows/a.json", "workflows/b.json", "workflows/c.json"]);
+  assert.equal(knownSelectorSample([]).length, 0);
+  assert.equal(knownSelectorSample(undefined).length, 0);
+});
+
+test("#1448 with no known records it still gives a usable message", () => {
+  const t = msg({ refresh: "ok", known: [] });
+  // Case-insensitive: a control mutation capitalising the leading word killed the
+  // strict form. The property is that the refusal names the selector it was given.
+  assert.match(t, /no workflow matching "video_minimax_low_vram\.json"/i);
+  assert.doesNotMatch(t, /addressed as e\.g\./);
+});
+
+test("#1448 WIRING: the caller records the outcome instead of assuming one", () => {
+  // The behavioural tests cannot see the call site, and the defect WAS the call site:
+  // a perfect message still lies if the caller passes a refresh state it never checked.
+  const panel = readFileSync(join(ROOT, "web/js/comfyui-mcp-panel.js"), "utf8");
+  assert.match(panel, /import \{\s*knownSelectorSample,\s*openWorkflowNotFoundMessage,\s*\} from "\.\/lib\/open-workflow-not-found\.js";/);
+  // Every branch the refresh can take must be reachable from the call site.
+  assert.match(panel, /refresh = "unavailable"/, "a frontend without syncWorkflows");
+  assert.match(panel, /refresh = "ok"/, "a successful re-read");
+  assert.match(panel, /refresh = `failed: \$\{err\?\.message \?\? err\}`/, "a thrown re-read");
+  assert.match(panel, /openWorkflowNotFoundMessage\(\{ path, refresh, known: knownSelectorSample\(all\) \}\)/);
+  // And the old sentence is no longer EMITTED. Scoped to non-comment lines: the fix
+  // quotes the old wording in a comment to explain itself, and a bare doesNotMatch
+  // over the whole file forbade describing the very defect being fixed.
+    const NEWLINE = new RegExp(String.raw`\r?\n`);
+    const code = panel
+      .split(NEWLINE)
+      .filter((l) => !l.trim().startsWith("//") && !l.trim().startsWith("*"))
+      .join("\n");
+  assert.doesNotMatch(code, /even after a refresh/);
+  assert.doesNotMatch(code, /For a file outside the workflows folder/);
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -13031,11 +13031,6 @@ const GRAPH_TOOL_EXECUTORS = {
         all.find((w) => workflowRecordMatchesSelector(w, path))
       );
     };
-    // A SAMPLE of what the store actually holds, for the refusal. The reporter's file
-    // was inside the workflows folder, so "it isn't there" was not the useful thing to
-    // say — "here is the shape of the names that ARE there" is, because the selector
-    // forms differ (`workflows/x.json`, `x.json`, and a `filename` with no extension).
-    const all = [...(s?.openWorkflows ?? []), ...(s?.workflows ?? [])];
     let target = find();
     // The frontend's workflow list is CACHED, so a just-saved/staged file (e.g. a
     // downloaded example) won't appear until the store re-reads the workflows dir.
@@ -13064,7 +13059,12 @@ const GRAPH_TOOL_EXECUTORS = {
       target = find();
     }
     if (!target) {
-      throw failOpen(new Error(openWorkflowNotFoundMessage({ path, refresh, known: knownSelectorSample(all) })));
+      // Sampled HERE, after any refresh, never from a snapshot taken before it
+      // (codex review). A successful re-read REMOVES stale entries — measured on a
+      // live rig, the store went 109 to 107 — so a pre-refresh snapshot can offer a
+      // workflow the re-read just deleted as an example of what is addressable.
+      const known = knownSelectorSample([...(s?.openWorkflows ?? []), ...(s?.workflows ?? [])]);
+      throw failOpen(new Error(openWorkflowNotFoundMessage({ path, refresh, known })));
     }
     // #442 — an ALREADY-OPEN tab is repainted from its OWN in-memory buffer below,
     // never re-read from disk. If the .json changed on disk out-of-band the canvas

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -242,6 +242,10 @@ import { subgraphValueProvenance } from "./lib/subgraph-value-provenance.js";
 import { describeMissingNode, describeRailNodeTarget } from "./lib/node-scope-locator.js";
 import { findExistingRailSlot } from "./lib/rail-slot.js";
 import { VENDORED_VOCABULARY_HASH } from "./lib/vocabulary-hash.js";
+import {
+  knownSelectorSample,
+  openWorkflowNotFoundMessage,
+} from "./lib/open-workflow-not-found.js";
 import { describeCanvasDrawFailure } from "./lib/canvas-draw-failure.js";
 import {
   describeQueuePromptChain,
@@ -13027,26 +13031,40 @@ const GRAPH_TOOL_EXECUTORS = {
         all.find((w) => workflowRecordMatchesSelector(w, path))
       );
     };
+    // A SAMPLE of what the store actually holds, for the refusal. The reporter's file
+    // was inside the workflows folder, so "it isn't there" was not the useful thing to
+    // say — "here is the shape of the names that ARE there" is, because the selector
+    // forms differ (`workflows/x.json`, `x.json`, and a `filename` with no extension).
+    const all = [...(s?.openWorkflows ?? []), ...(s?.workflows ?? [])];
     let target = find();
     // The frontend's workflow list is CACHED, so a just-saved/staged file (e.g. a
     // downloaded example) won't appear until the store re-reads the workflows dir.
     // If the first search misses, REFRESH the store and search again so a freshly
     // staged file is found + opened natively (no need for a separate refresh call).
-    if (!target && typeof s.syncWorkflows === "function") {
-      try {
-        await s.syncWorkflows();
-      } catch (err) {
-        console.warn("[comfyui-mcp-panel] syncWorkflows failed:", err?.message ?? err);
+    // #1448 — RECORD WHAT THE REFRESH ACTUALLY DID. The refusal below used to say
+    // "even after a refresh" unconditionally, while both ways the refresh can fail to
+    // happen were silent: a frontend without `syncWorkflows` skipped it entirely, and a
+    // throw was swallowed by a console.warn nobody reads from an agent session. The
+    // reporter was told a refresh had happened and still could not find a file they had
+    // just confirmed on disk, so the one fact that would have pointed anywhere — whether
+    // the list was ever re-read — was the fact being asserted without being checked.
+    let refresh = "not-needed";
+    if (!target) {
+      if (typeof s.syncWorkflows !== "function") {
+        refresh = "unavailable";
+      } else {
+        try {
+          await s.syncWorkflows();
+          refresh = "ok";
+        } catch (err) {
+          refresh = `failed: ${err?.message ?? err}`;
+          console.warn("[comfyui-mcp-panel] syncWorkflows failed:", err?.message ?? err);
+        }
       }
       target = find();
     }
     if (!target) {
-      throw failOpen(
-        new Error(
-          `no workflow matching "${path}" — it isn't among the saved/open workflows even after a refresh. ` +
-            `For a file outside the workflows folder, load it with panel_load_workflow path:<file>.`,
-        ),
-      );
+      throw failOpen(new Error(openWorkflowNotFoundMessage({ path, refresh, known: knownSelectorSample(all) })));
     }
     // #442 — an ALREADY-OPEN tab is repainted from its OWN in-memory buffer below,
     // never re-read from disk. If the .json changed on disk out-of-band the canvas

--- a/web/js/lib/open-workflow-not-found.js
+++ b/web/js/lib/open-workflow-not-found.js
@@ -1,0 +1,70 @@
+/**
+ * panel#1448 — "it isn't among the saved/open workflows even after a refresh".
+ *
+ * Two things were wrong with that sentence, and the reporter hit both.
+ *
+ * 1. IT ASSERTED A REFRESH IT HAD NOT CHECKED. The lookup refreshes only when the
+ *    frontend exposes `syncWorkflows`, and a throw from it was swallowed by a
+ *    console.warn no agent session ever reads. So on a frontend without that method,
+ *    or when the call failed, the message claimed a re-read that never happened —
+ *    and the one fact that could have pointed somewhere was the one being fabricated.
+ *
+ * 2. ITS REMEDY NAMED THE WRONG CAUSE. "For a file outside the workflows folder"
+ *    reads as a diagnosis, and the reporter's file was INSIDE the folder — they had
+ *    confirmed it on disk, twice. Being told to look outside sent them away from a
+ *    file that was exactly where they thought.
+ *
+ * ## What could NOT be reproduced, and is therefore not claimed
+ *
+ * Measured on ComfyUI 0.32.0 / frontend 1.48.7: `syncWorkflows()` genuinely re-reads
+ * (the store went 109 -> 107, dropping two stale entries), every file on disk was
+ * present afterwards, and a bare `<name>.json` selector matches a saved record via
+ * its `key`. So the refresh path works on that build, and this does not pretend to
+ * have fixed a lookup failure it could not observe. What it fixes is the message,
+ * which was making a claim it had no evidence for either way.
+ */
+
+/** The selector forms a saved record answers to, sampled so the caller can SEE the
+ *  shape rather than guess it. Deliberately a sample: a store with 100+ entries in a
+ *  refusal is noise, and the shape is what disambiguates, not the inventory. */
+export function knownSelectorSample(records, limit = 3) {
+  const out = [];
+  for (const w of records ?? []) {
+    if (out.length >= limit) break;
+    const path = typeof w?.path === "string" ? w.path : null;
+    if (!path || w?.isPersisted !== true) continue;
+    out.push(path);
+  }
+  return out;
+}
+
+/**
+ * The refusal, saying what was actually done.
+ *
+ * `refresh` is one of: "ok" (the list was re-read), "unavailable" (this frontend has
+ * no syncWorkflows, so it never was), "not-needed", or "failed: <reason>".
+ */
+export function openWorkflowNotFoundMessage({ path, refresh, known = [] } = {}) {
+  const refreshClause =
+    refresh === "ok"
+      ? `The workflow list WAS re-read from the server first, and it still does not contain it.`
+      : refresh === "unavailable"
+        ? `The list was NOT re-read: this ComfyUI frontend exposes no workflow-sync method, so a ` +
+          `file staged since the tab loaded may simply not be known yet. Reload the ComfyUI browser ` +
+          `tab and try again before concluding the file is missing.`
+        : typeof refresh === "string" && refresh.startsWith("failed")
+          ? `The re-read of the workflow list FAILED (${refresh.slice("failed: ".length)}), so this ` +
+            `is not evidence the file is absent — the list may simply be stale.`
+          : `The list was already current.`;
+
+  const shape = known.length
+    ? ` Saved workflows here are addressed as e.g. ${known.map((k) => `"${k}"`).join(", ")} — the ` +
+      `same file also answers to its bare name with or without ".json".`
+    : "";
+
+  return (
+    `no workflow matching "${path}". ${refreshClause}${shape} If the file IS in the workflows ` +
+    `folder, check the name matches exactly (including case and any subfolder); if it is anywhere ` +
+    `else, load it with panel_load_workflow path:<file>, which reads any readable path.`
+  );
+}


### PR DESCRIPTION
Claims artokun/comfyui-mcp#1448.

`panel_open_workflow` refused with *"it isn't among the saved/open workflows even after a refresh. For a file outside the workflows folder, load it with panel_load_workflow"* — for a file the reporter had confirmed on disk **inside** that folder, twice.

Two defects in one sentence:

1. **It asserted a refresh it had not checked.** The lookup only refreshes when the frontend exposes `syncWorkflows`, and a throw from it was swallowed by a `console.warn` no agent session reads. On a frontend without the method, or when the call failed, the message claimed a re-read that never happened — fabricating the one fact that could have pointed somewhere.
2. **Its remedy named the wrong cause.** "For a file outside the workflows folder" reads as a diagnosis, and sent someone away from a file that was exactly where they thought it was.

**What I could not reproduce, and therefore do not claim to have fixed.** Measured on the live rig (ComfyUI 0.32.0 / frontend 1.48.7): `syncWorkflows()` genuinely re-reads — the store went 109 → 107, dropping two stale entries — every file on disk was present afterwards, and a bare `<name>.json` matches a saved record via its `key` (records expose `path` = `workflows/X.json`, `filename` = `X` with no extension, `key` = `X.json`). So the refresh path works on that build. This fixes the message, which was making a claim it had no evidence for in either direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)