### PR TITLE
fix(1089): disclose the foreign source state on a FAILING open too

### DIFF
--- a/browser_tests/unit/open-outcome.test.mjs
+++ b/browser_tests/unit/open-outcome.test.mjs
@@ -473,8 +473,17 @@ test("#721 P1: an already-active workflow requires state even when empty, then p
   assert.ok(repaintAt !== -1 && proofAt > repaintAt && openedAt > proofAt, "must prove the repaint before success");
   // A failed/missing repaint is an honest unknown after s.openWorkflow may have
   // switched tabs, never the old fabricated {opened} receipt.
-  assert.match(body, /if \(rebindFailed\) throw failOpenRebindUnknown\(rebindFailed\);/);
+  // The throw itself, not the one-line `if` it used to be — #1089's follow-up wraps it
+  // in a block to append a foreign-source finding to the message. The guarantee is the
+  // same: a failed/missing repaint is an honest unknown, never a fabricated {opened}.
+  assert.match(body, /throw failOpenRebindUnknown\(rebindFailed\);/);
   assert.match(body, /workflow_open could not rebind the active canvas/);
+  // Whatever that block does, it may not turn a failure into a success.
+  const failAt = body.indexOf("if (rebindFailed) {");
+  if (failAt !== -1) {
+    const failBlock = body.slice(failAt, body.indexOf("throw failOpenRebindUnknown(rebindFailed);", failAt));
+    assert.doesNotMatch(failBlock, /applied: true/, "the failure path must never emit a success receipt");
+  }
 });
 
 test("#721 P1: dirty rebind success requires the target UUID, never only a read-shaped comparison", () => {
@@ -512,8 +521,19 @@ test("#721 P1: a failed rebind never re-baselines, reads disk, or reloads the st
   assert.match(successOnly, /await clearSpuriousOpenModified\(target, \{/);
   assert.match(successOnly, /await withDeadline\(/);
   assert.match(successOnly, /await app\.loadGraphData\(diskGraph/);
-  const unknownAt = body.indexOf("if (rebindFailed) throw failOpenRebindUnknown(rebindFailed);");
+  // Anchored on the THROW, not on the one-line `if` it used to be: #1089's follow-up
+  // wraps this in a block so a foreign-source finding can be appended to the message
+  // first. What must hold is unchanged â the unknown receipt is still emitted only
+  // after the guarded success-only work.
+  const unknownAt = body.indexOf("throw failOpenRebindUnknown(rebindFailed);");
+  assert.notEqual(unknownAt, -1);
   assert.ok(unknownAt > body.indexOf("if (!rebindFailed)"), "the unknown receipt is emitted only after the guarded success-only work");
+  // ...and nothing between the success-only block and that throw may re-baseline, read
+  // disk, or load: the appended message is the only thing allowed there.
+  const between = body.slice(body.indexOf("if (openFailed)"), unknownAt);
+  for (const forbidden of [/clearSpuriousOpenModified/, /withDeadline\(/, /loadGraphData\(/]) {
+    assert.doesNotMatch(between, forbidden, "the failure path must stay side-effect free");
+  }
 });
 
 test("#442 defect-2 wiring: the re-read is gated on a FRESH dirty re-check (no silent data loss)", () => {

--- a/browser_tests/unit/open-rebind-proof.test.mjs
+++ b/browser_tests/unit/open-rebind-proof.test.mjs
@@ -1066,3 +1066,34 @@ test("#1089: the outcome is disclosed on its own key, both when corrected and wh
   assert.doesNotMatch(block, /RE-READ FROM DISK/);
   assert.doesNotMatch(block, /was therefore/);
 });
+
+test("#1089 follow-up: the foreign-source finding rides a FAILING open too", () => {
+  // It was only on the success reply. That dropped it on the combination that matters
+  // most — an open that ALSO fails content verification — which is exactly what #1111
+  // reported: a mismatch WAS announced and the canvas was still the previous
+  // workflow's. The content warning says "re-read the graph"; without this it never
+  // says the state was another workflow's, which is what makes the re-read look
+  // plausible rather than alarming.
+  const src = readFileSync(PANEL_JS, "utf8");
+  const at = src.indexOf("if (rebindFailed) {");
+  assert.notEqual(at, -1, "the failure path must be a block, so the finding can be appended");
+  const block = src.slice(at, src.indexOf("throw failOpenRebindUnknown(rebindFailed);", at));
+  assert.match(block, /if \(sourceForeign\)/, "the failure path must consult the finding");
+  assert.match(block, /ALSO, AND SEPARATELY/, "it must read as a second, independent fact");
+  assert.match(block, /LIKELY answer/, "it must reframe the re-read the content warning already advises");
+  assert.match(block, /panel_load_workflow/, "the disk recovery is named");
+  assert.match(block, /#874/, "…with the node-written-values cost");
+  // The pure outcome helper must NOT learn about this: it knows only the four proof
+  // parts, and this is a fact about the payload the load was handed.
+  const gb = readFileSync(
+    fileURLToPath(new URL("../../web/js/lib/graph-binding.js", import.meta.url)),
+    "utf8",
+  );
+  const describeAt = gb.indexOf("export function describeOpenRebindOutcome");
+  assert.notEqual(describeAt, -1);
+  assert.doesNotMatch(
+    gb.slice(describeAt),
+    /sourceForeign/,
+    "describeOpenRebindOutcome must stay ignorant of the source-state question",
+  );
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -13730,7 +13730,34 @@ const GRAPH_TOOL_EXECUTORS = {
       releaseCanvasInteractionLock(priorInteraction, canvasView);
     }
     if (openFailed) throw failOpen(openFailed);
-    if (rebindFailed) throw failOpenRebindUnknown(rebindFailed);
+    if (rebindFailed) {
+      // #1089 follow-up — the foreign-source finding rides the FAILURE too.
+      //
+      // It was only on the success reply, and that dropped it on the combination that
+      // matters most: an open that ALSO fails content verification. #1111 is exactly
+      // that report — a mismatch WAS announced and the canvas was still the previous
+      // workflow's. The content warning tells the caller to re-read the graph; it does
+      // not tell them the state was another workflow's, which is the part that explains
+      // why the re-read will look perfectly plausible.
+      //
+      // Appended rather than folded into `describeOpenRebindOutcome`: that function is
+      // pure and knows only about the four proof parts, and this is a fact about the
+      // payload the load was handed. Keeping it out preserves that separation.
+      if (sourceForeign) {
+        rebindFailed = new Error(
+          `${coerceMessageText(rebindFailed.message ?? rebindFailed)} ALSO, AND SEPARATELY: this ` +
+            `tab's in-memory state carried a DIFFERENT open workflow's identity, and the repaint ` +
+            `read that state — so when you re-read the graph as advised above, treat "it does not ` +
+            `look like this workflow" as the LIKELY answer rather than a surprise, and compare ` +
+            `against what you expect this workflow to contain. panel_load_workflow with this ` +
+            `workflow's path loads the saved copy from disk, which is the one source that cannot ` +
+            `carry the other tab's graph. It REPLACES the canvas, and the modified flag does not ` +
+            `account for values a NODE wrote rather than you — a populated wildcard, a rolled seed ` +
+            `(#874) — so preserve anything you need to a NEW path first (#1089).`,
+        );
+      }
+      throw failOpenRebindUnknown(rebindFailed);
+    }
     const receipt = noteOpenAttempt({
       cmd: "workflow_open",
       rid,


### PR DESCRIPTION
Follow-up to #1110 (issue #1089), found while verifying that PR end to end against a live panel.

`foreign_source_state` is attached to the SUCCESS reply. When the open ALSO fails for another reason — `CONTENT_UNVERIFIED` being the common one — `rebindFailed` is set and the reply goes down the error path, which never reaches the reply builder. The foreign-source finding is silently dropped.

Measured on a live install (ComfyUI 0.32.0, frontend 1.48.7, panel 0.14.15): with a tab's stored state carrying another open workflow's identity, a PROVEN open correctly carries the disclosure, and the same poisoned state on a tab whose open lands `CONTENT_UNVERIFIED` carries nothing about it at all.

That combination is the worse one, and it is the one #1111 actually reported: an open that DID report a mismatch and was still left on the wrong canvas. The content warning tells the caller to re-read the graph; it does not tell them the state was another workflow's, which is the part that explains why the re-read will look plausible.

Draft while I wire it into the failure path.