### PR TITLE
fix(1138): a live-socket re-advertise must not read as a fresh connect

### DIFF
--- a/browser_tests/unit/session-rebind.test.mjs
+++ b/browser_tests/unit/session-rebind.test.mjs
@@ -4,6 +4,9 @@
 
 import test from "node:test";
 import assert from "node:assert/strict";
+// #1138 adds one structural test (the call site's polarity), which the rest of this
+// pure-logic file does not need.
+import { readFileSync } from "node:fs";
 
 import {
   shouldResumeAfterComfyReconnect,
@@ -601,4 +604,22 @@ test("#1138: the guard is INVERSION-SENSITIVE, unlike a source scan", () => {
   );
   assert.equal(neverDropped, false);
   assert.equal(realRestart, true);
+});
+
+test("#1138 wiring: the call site NEGATES the predicate and returns", () => {
+  // The predicate is tested by behaviour above; this covers the one thing a pure test
+  // cannot see — that the call site consults it in the right POLARITY. Dropping the
+  // negation would invert the fix into "nudge only when nothing dropped", which is worse
+  // than the original bug. An exact-substring claim on purpose: #1096's review proved by
+  // mutation that loose token-presence scans over this file assert nothing at all.
+  const src = readFileSync(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8");
+  assert.ok(
+    src.includes(
+      "if (!shouldNudgeAfterMidTaskReconnect({ bridgeDroppedAt: lastBridgeDownAt, now: Date.now() }))",
+    ),
+    "the ready-ack mid-task branch must NEGATE the predicate and read the live drop stamp",
+  );
+  // The reverted sessionStorage twin must not return without its own review: every
+  // confirmed leak on this branch came from persisting that timestamp.
+  assert.doesNotMatch(src, /BRIDGE_DOWN_AT_KEY/, "the persisted drop timestamp stays reverted");
 });

--- a/browser_tests/unit/session-rebind.test.mjs
+++ b/browser_tests/unit/session-rebind.test.mjs
@@ -8,6 +8,7 @@ import assert from "node:assert/strict";
 import {
   shouldResumeAfterComfyReconnect,
   shouldRehelloAfterCommand,
+  shouldNudgeAfterMidTaskReconnect,
   planSoftReloadRecovery,
   performSoftReloadRecovery,
   isTransientReconnectError,
@@ -519,4 +520,85 @@ test("#419: N open tabs each independently reconnect — no subset left dead", a
     assert.deepEqual(r.events, ["stop", "start"]); // this tab reconnected
     assert.equal(r.result.reconnect, true);
   }
+});
+
+// ── #1138: a mid-task "you dropped" nudge needs a drop to have happened ──────
+//
+// The nudge injects a user message and writes to the durable transcript. Both are false,
+// and the injection is harmful, unless the orchestrator really died: telling a working
+// agent to resume makes it restart or duplicate what it is doing.
+//
+// The gap heuristic was right; the sentinel's arithmetic betrayed it. lastBridgeDownAt is
+// 0 until the bridge socket CLOSES, and `Date.now() - 0` is ~56 years — the longest
+// possible gap, read as the strongest possible evidence of a real restart. So the guard
+// was inverted exactly where it mattered: the better established that nothing dropped, the
+// more confidently it nudged. Reachable on a live socket because `ready` repeats on one and
+// #310 re-advertises after every successful free_vram.
+
+test("#1138: NEVER dropped must not nudge, however long the session has run", () => {
+  // The reported shape: a live socket, a re-advertise, a ready ack, and no drop anywhere.
+  // A real Date.now() against the 0 sentinel is ~56 years, which the old guard passed.
+  assert.equal(
+    shouldNudgeAfterMidTaskReconnect({ bridgeDroppedAt: 0, now: Date.now() }),
+    false,
+  );
+  for (const noDrop of [undefined, null, 0, -1, NaN, Infinity, "0", "1700000000000", {}]) {
+    assert.equal(
+      shouldNudgeAfterMidTaskReconnect({ bridgeDroppedAt: noDrop, now: Date.now() }),
+      false,
+      `no recorded drop must never nudge: ${JSON.stringify(noDrop)}`,
+    );
+  }
+  assert.equal(shouldNudgeAfterMidTaskReconnect(), false, "no arguments must not nudge");
+});
+
+test("#1138: a REAL restart still nudges — the fix must not disable the feature", () => {
+  // The behaviour #278/#588 rely on: a long gap after an actual drop is a real restart.
+  const now = 1_700_000_000_000;
+  assert.equal(
+    shouldNudgeAfterMidTaskReconnect({ bridgeDroppedAt: now - 30_000, now }),
+    true,
+  );
+  // Exactly at the boundary counts as real (>= minGapMs), so the threshold is not
+  // silently exclusive.
+  assert.equal(
+    shouldNudgeAfterMidTaskReconnect({ bridgeDroppedAt: now - 6000, now }),
+    true,
+  );
+});
+
+test("#1138: a FAST reconnect after a real drop still does not nudge", () => {
+  // The pre-existing half of the rule, preserved: a sidebar remount or a brief WS blip
+  // means the orchestrator never died, so the turn kept running.
+  const now = 1_700_000_000_000;
+  assert.equal(shouldNudgeAfterMidTaskReconnect({ bridgeDroppedAt: now - 1, now }), false);
+  assert.equal(shouldNudgeAfterMidTaskReconnect({ bridgeDroppedAt: now - 5999, now }), false);
+  assert.equal(shouldNudgeAfterMidTaskReconnect({ bridgeDroppedAt: now, now }), false);
+});
+
+test("#1138: a NEGATIVE gap is not evidence of a long outage", () => {
+  // A wall-clock adjustment, or a drop stamped after this read, must not read as an
+  // ancient drop — the same class of mistake as the 0 sentinel, one step along.
+  const now = 1_700_000_000_000;
+  assert.equal(shouldNudgeAfterMidTaskReconnect({ bridgeDroppedAt: now + 60_000, now }), false);
+  assert.equal(shouldNudgeAfterMidTaskReconnect({ now, bridgeDroppedAt: now + 1 }), false);
+  // …and an unreadable clock decides nothing.
+  assert.equal(shouldNudgeAfterMidTaskReconnect({ bridgeDroppedAt: now - 30_000, now: NaN }), false);
+  assert.equal(shouldNudgeAfterMidTaskReconnect({ bridgeDroppedAt: now - 30_000, now: "later" }), false);
+});
+
+test("#1138: the guard is INVERSION-SENSITIVE, unlike a source scan", () => {
+  // #1096's review proved by mutation that a token-presence source scan stays green when
+  // the guard is inverted. This asserts the two sides disagree, so an inverted or dropped
+  // condition cannot pass: the never-dropped case and the real-restart case must differ.
+  const now = 1_700_000_000_000;
+  const neverDropped = shouldNudgeAfterMidTaskReconnect({ bridgeDroppedAt: 0, now });
+  const realRestart = shouldNudgeAfterMidTaskReconnect({ bridgeDroppedAt: now - 30_000, now });
+  assert.notEqual(
+    neverDropped,
+    realRestart,
+    "if these ever agree, the guard has stopped distinguishing no-drop from a real restart",
+  );
+  assert.equal(neverDropped, false);
+  assert.equal(realRestart, true);
 });

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -453,6 +453,7 @@ import {
 import {
   shouldResumeAfterComfyReconnect,
   shouldRehelloAfterCommand,
+  shouldNudgeAfterMidTaskReconnect,
   performSoftReloadRecovery,
   retryDuringReconnect,
   dedupeWorkflowTabRecords,
@@ -27249,7 +27250,28 @@ function buildPanel() {
         // the agent's turn kept running — so a "you dropped" nudge is false AND
         // would inject a spurious turn into a live session. A real ComfyUI restart
         // takes many seconds to come back, so a long gap since the drop = real.
-        if (Date.now() - lastBridgeDownAt < 6000) return;
+        //
+        // #1138 — AND the bridge must actually have dropped. `lastBridgeDownAt` is 0
+        // until the bridge socket closes, and 0 does not mean "no drop" to the
+        // subtraction below: `Date.now() - 0` is ~56 years, the LONGEST possible gap,
+        // which this heuristic reads as the most certain evidence of a real restart.
+        // So the guard was exactly inverted in the case it exists to catch — the
+        // better established it is that nothing dropped, the more confidently it
+        // nudged. The intent above was right from the start; only the sentinel's
+        // arithmetic betrayed it.
+        //
+        // Reachable on a LIVE socket because `ready` repeats on one (see the client's
+        // own note): a re-advertise draws a fresh handshake, and #310 re-advertises
+        // after every successful free_vram by design. So a user who freed VRAM
+        // mid-task could be told their connection had dropped — and the agent told to
+        // resume work it was still doing — with no drop anywhere in the session.
+        //
+        // The decision moved into session-rebind.js so it is unit-tested by BEHAVIOUR.
+        // A source-scan over this file could only assert the guard's tokens are present,
+        // and #1096's review demonstrated by mutation that such a test stays green when
+        // the guard is inverted — which is the one regression that matters here.
+        if (!shouldNudgeAfterMidTaskReconnect({ bridgeDroppedAt: lastBridgeDownAt, now: Date.now() }))
+          return;
         appendSystem(tr("panel.reconnected_picking_up_where_we_left_off", "Reconnected — picking up where we left off."));
         showThinking();
         client.sendUserMessage(

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -2831,6 +2831,10 @@ const RELOAD_POST_TIMEOUT_MS = 10000;
 // resumed session to continue where it left off. The REBOOT/SOFT_RELOAD cases
 // (deliberate, agent-known) are handled first and clear this so we don't double-nudge.
 const MID_TASK_KEY = "comfyui-mcp.panel.midTaskResume";
+// #1138 — the bridge-drop timestamp, persisted alongside MID_TASK_KEY so the two are read
+// symmetrically. The mid-task marker survives a page reload; without this the timestamp it
+// is weighed against would not, and a reload after a REAL restart would stop nudging.
+const BRIDGE_DOWN_AT_KEY = "comfyui-mcp.panel.lastBridgeDownAt";
 // Wall-clock (ms) of the last bridge drop — module-scoped so it survives panel
 // remounts. A FAST reconnect (panel swap / WS blip; orchestrator alive) vs a
 // SLOW one (real ComfyUI restart; orchestrator died + respawned) is how we tell
@@ -18144,6 +18148,20 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
       pendingCalls.clear();
       clearHandshake();
       lastBridgeDownAt = Date.now(); // for the fast-vs-slow reconnect heuristic
+      // #1138 — PERSISTED, because the flag it is weighed against is. MID_TASK_KEY lives
+      // in sessionStorage and so survives a page reload, while this timestamp is module
+      // state and does not. Requiring a recorded drop (the fix) would therefore have
+      // silently retired the nudge for "reloaded the browser after a real restart" — a
+      // case the nudge is genuinely for, and one users depend on (#278/#588). Writing it
+      // beside the marker keeps the two readings symmetric, so only a session that never
+      // observed a drop AT ALL suppresses — which is exactly the case where the panel
+      // cannot tell whether the agent kept running, and suppressing is the safe answer.
+      try {
+        ssSet(BRIDGE_DOWN_AT_KEY, String(lastBridgeDownAt));
+      } catch {
+        // sessionStorage unavailable ⇒ the module value still serves this page's own
+        // lifetime; only the across-reload case degrades, and it degrades to no nudge.
+      }
       if (!closed) {
         // FIX 1 — auto-reconnecting: keep the pill STEADY (scheduleReconnect picks
         // connecting-vs-terminal based on the patience window). Do NOT flip to
@@ -27270,7 +27288,24 @@ function buildPanel() {
         // A source-scan over this file could only assert the guard's tokens are present,
         // and #1096's review demonstrated by mutation that such a test stays green when
         // the guard is inverted — which is the one regression that matters here.
-        if (!shouldNudgeAfterMidTaskReconnect({ bridgeDroppedAt: lastBridgeDownAt, now: Date.now() }))
+        // The module value first (this page's own observation), falling back to the
+        // persisted one so a drop observed BEFORE a reload still counts — see
+        // BRIDGE_DOWN_AT_KEY. Number() of a null/absent value is NaN, which the predicate
+        // refuses, so an unreadable store means "no drop recorded" rather than 0-as-a-date.
+        const droppedAt = lastBridgeDownAt || Number(ssGet(BRIDGE_DOWN_AT_KEY));
+        // CONSUMED here, exactly like MID_TASK_KEY above, and for the same reason. A drop
+        // authorizes ONE nudge. Left standing, an hours-old timestamp would keep passing
+        // the long-gap test, so the next mid-task `ready` — a free_vram re-advertise draws
+        // one (#310) — would nudge on evidence from a drop already accounted for. That is
+        // the false positive this whole change removes, re-entering by the door the
+        // persistence opened, so the persistence has to close it.
+        lastBridgeDownAt = 0;
+        try {
+          ssSet(BRIDGE_DOWN_AT_KEY, null);
+        } catch {
+          /* best effort — the module value is already cleared */
+        }
+        if (!shouldNudgeAfterMidTaskReconnect({ bridgeDroppedAt: droppedAt, now: Date.now() }))
           return;
         appendSystem(tr("panel.reconnected_picking_up_where_we_left_off", "Reconnected — picking up where we left off."));
         showThinking();

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -2831,10 +2831,6 @@ const RELOAD_POST_TIMEOUT_MS = 10000;
 // resumed session to continue where it left off. The REBOOT/SOFT_RELOAD cases
 // (deliberate, agent-known) are handled first and clear this so we don't double-nudge.
 const MID_TASK_KEY = "comfyui-mcp.panel.midTaskResume";
-// #1138 — the bridge-drop timestamp, persisted alongside MID_TASK_KEY so the two are read
-// symmetrically. The mid-task marker survives a page reload; without this the timestamp it
-// is weighed against would not, and a reload after a REAL restart would stop nudging.
-const BRIDGE_DOWN_AT_KEY = "comfyui-mcp.panel.lastBridgeDownAt";
 // Wall-clock (ms) of the last bridge drop — module-scoped so it survives panel
 // remounts. A FAST reconnect (panel swap / WS blip; orchestrator alive) vs a
 // SLOW one (real ComfyUI restart; orchestrator died + respawned) is how we tell
@@ -18148,20 +18144,6 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
       pendingCalls.clear();
       clearHandshake();
       lastBridgeDownAt = Date.now(); // for the fast-vs-slow reconnect heuristic
-      // #1138 — PERSISTED, because the flag it is weighed against is. MID_TASK_KEY lives
-      // in sessionStorage and so survives a page reload, while this timestamp is module
-      // state and does not. Requiring a recorded drop (the fix) would therefore have
-      // silently retired the nudge for "reloaded the browser after a real restart" — a
-      // case the nudge is genuinely for, and one users depend on (#278/#588). Writing it
-      // beside the marker keeps the two readings symmetric, so only a session that never
-      // observed a drop AT ALL suppresses — which is exactly the case where the panel
-      // cannot tell whether the agent kept running, and suppressing is the safe answer.
-      try {
-        ssSet(BRIDGE_DOWN_AT_KEY, String(lastBridgeDownAt));
-      } catch {
-        // sessionStorage unavailable ⇒ the module value still serves this page's own
-        // lifetime; only the across-reload case degrades, and it degrades to no nudge.
-      }
       if (!closed) {
         // FIX 1 — auto-reconnecting: keep the pill STEADY (scheduleReconnect picks
         // connecting-vs-terminal based on the patience window). Do NOT flip to
@@ -27288,24 +27270,7 @@ function buildPanel() {
         // A source-scan over this file could only assert the guard's tokens are present,
         // and #1096's review demonstrated by mutation that such a test stays green when
         // the guard is inverted — which is the one regression that matters here.
-        // The module value first (this page's own observation), falling back to the
-        // persisted one so a drop observed BEFORE a reload still counts — see
-        // BRIDGE_DOWN_AT_KEY. Number() of a null/absent value is NaN, which the predicate
-        // refuses, so an unreadable store means "no drop recorded" rather than 0-as-a-date.
-        const droppedAt = lastBridgeDownAt || Number(ssGet(BRIDGE_DOWN_AT_KEY));
-        // CONSUMED here, exactly like MID_TASK_KEY above, and for the same reason. A drop
-        // authorizes ONE nudge. Left standing, an hours-old timestamp would keep passing
-        // the long-gap test, so the next mid-task `ready` — a free_vram re-advertise draws
-        // one (#310) — would nudge on evidence from a drop already accounted for. That is
-        // the false positive this whole change removes, re-entering by the door the
-        // persistence opened, so the persistence has to close it.
-        lastBridgeDownAt = 0;
-        try {
-          ssSet(BRIDGE_DOWN_AT_KEY, null);
-        } catch {
-          /* best effort — the module value is already cleared */
-        }
-        if (!shouldNudgeAfterMidTaskReconnect({ bridgeDroppedAt: droppedAt, now: Date.now() }))
+        if (!shouldNudgeAfterMidTaskReconnect({ bridgeDroppedAt: lastBridgeDownAt, now: Date.now() }))
           return;
         appendSystem(tr("panel.reconnected_picking_up_where_we_left_off", "Reconnected — picking up where we left off."));
         showThinking();

--- a/web/js/lib/session-rebind.js
+++ b/web/js/lib/session-rebind.js
@@ -37,6 +37,48 @@ export function shouldRehelloAfterCommand(cmd, reply) {
   return cmd === "free_vram" && Boolean(reply && reply.ok);
 }
 
+// #1138 — may a `ready` ack arriving mid-task nudge the agent to resume?
+//
+// The nudge injects a user message ("your connection dropped mid-task … continue exactly
+// what you were doing") and writes a line into the durable transcript. Both are false, and
+// the injection is actively harmful, unless the orchestrator really did die: a turn that
+// kept running does not need resuming, and telling a working agent to resume makes it
+// restart or duplicate what it is doing.
+//
+// The panel's existing rule is a gap heuristic — a real ComfyUI restart takes many seconds
+// to come back, so a LONG gap since the drop means the restart was real, while a fast
+// reconnect (a sidebar remount, a brief WS blip) means it was not. That rule is right.
+//
+// What it missed is that "no drop at all" is not the same as "a very old drop", and the
+// subtraction cannot tell them apart: the panel's `lastBridgeDownAt` is 0 until the bridge
+// socket closes, and `Date.now() - 0` is ~56 years — the LONGEST possible gap, which the
+// heuristic reads as the strongest possible evidence of a real restart. So the guard was
+// exactly inverted where it mattered most: the better established it was that nothing had
+// dropped, the more confidently it nudged.
+//
+// That is reachable on a LIVE socket, because `ready` repeats on one — a re-advertise draws
+// a fresh handshake, and #310 re-advertises after every successful free_vram by design. So
+// freeing VRAM mid-task could tell a user their connection had dropped when nothing had.
+//
+// `bridgeDroppedAt` is therefore required to be a positive timestamp: absent, zero or
+// unreadable means no drop was recorded, and no drop means no nudge.
+export function shouldNudgeAfterMidTaskReconnect({
+  bridgeDroppedAt = 0,
+  now = 0,
+  minGapMs = 6000,
+} = {}) {
+  if (typeof bridgeDroppedAt !== "number" || !Number.isFinite(bridgeDroppedAt)) return false;
+  // Not `> 0` by accident: a drop is stamped with Date.now(), so any real value is far
+  // above zero, and a non-positive one is the never-dropped sentinel or a corrupt clock.
+  if (bridgeDroppedAt <= 0) return false;
+  if (typeof now !== "number" || !Number.isFinite(now)) return false;
+  // A gap that reads NEGATIVE (a clock adjustment, or a drop stamped after this read)
+  // is not evidence of a long outage either — treat it as fast, i.e. no nudge.
+  const gap = now - bridgeDroppedAt;
+  if (gap < 0) return false;
+  return gap >= minGapMs;
+}
+
 // #332 — During the post-restart reconnect window a Manager-backed fetch (e.g.
 // panel_list_nodes) throws a bare transport error ("Failed to fetch") before any
 // HTTP status exists, so the usual 404/"unreachable" handling never fires. Match


### PR DESCRIPTION
Closes #1138. Unblocks #1096; fixes an exposure that exists on main today via #310.

A re-advertise is answered with a full handshake including a `ready` ack — the panel's own comment says `'ready' repeats on a live socket`. On a socket that never dropped, that drives three behaviours which only make sense for a fresh connection: the mid-task resume injection, the re-greeting #588 banned, and the `agentSessionEpoch` bump that throws away a working agent's canvas-tool proof.

The mid-task one is the sharp edge. Its only bridge-survived guard is `Date.now() - lastBridgeDownAt < 6000`, and `lastBridgeDownAt` is only stamped when the bridge socket **closes** — so on a surviving bridge it is still 0 and the guard cannot fire. A user who runs `free_vram` mid-task (which #310 correctly re-advertises after) can therefore have `✅ Your connection dropped mid-task…continue exactly what you were doing` injected into an agent that is still working, and read a claim about a drop that never happened.

Found while reviewing #1134, where I tried to use a re-advertise for #1096's dropped tab mapping and would have widened this from one trigger to every ComfyUI reconnect. Withdrawing that and fixing this first is the right order: the mapping repair needs a re-advertise, so the re-advertise has to be safe on a live session before anything else can use it.

## What I intend to establish first

**That the same session really does survive a re-advertise**, rather than assuming it. The orchestrator logs `same-socket re-hello … routing state carried; the shared session continues` (#884), which is why skipping the epoch bump looks correct — the agent the proof was taken against is the one still running. But #291 documents the opposite case: a hello with the session key cleared spawns a clean agent, and then the proof MUST reset. So the condition is not "is this a re-advertise" but "does this hello carry the same session id it was bound to", and I want that read off the payload rather than inferred from the call site.

**Whether the ready ack can be attributed reliably.** Suppressing the mid-task branch needs to distinguish an ack answering *this* re-advertise from one answering a genuine reconnect that raced it. If that cannot be done from what the panel holds, the honest fix is narrower — gate on the bridge never having dropped rather than on which hello it answers.

Draft while I read onAck's ready branch and the hello payload.