### PR TITLE
fix(1145): stamp the outage once, not every failed retry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,40 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- **The mid-task resume nudge now measures the outage instead of one backoff step, so a
+  ComfyUI restart that comes back quickly keeps its nudge (#1145).** The nudge tells a
+  resumed agent its connection dropped mid-task and to continue what it was doing, and it
+  fires only for a REAL restart — judged by how long the bridge was gone. But the panel
+  assigns its socket before the connection resolves, so a REFUSED reconnect attempt is
+  still the active socket and ran the close handler in full, re-stamping the drop time.
+  With backoff doubling, the retries land near one, three, seven and fifteen seconds, so
+  the attempt that finally connected was separated from the previous failed close by only
+  that attempt's delay. The guard weighed its own retry cadence, not the outage: a genuine
+  restart returning inside about seven seconds measured roughly four and lost its nudge,
+  leaving the agent idle with a resumed session and no pending turn — after exactly the
+  event the nudge exists for. The outage is now stamped once, by the first close that
+  begins it, and its duration measured at the handshake that ends it.
+  A second reading of the same guard is closed with it: a drop stamp answers "how long
+  since the last drop, whenever that was", and kept answering after the outage it
+  described had ended — so a `ready` repeating on a live socket (the panel re-advertises
+  after every successful `free_vram`, #310) could be told about a drop from ten minutes
+  and two reconnects earlier. That is #1138's defect with a real timestamp in place of the
+  zero sentinel. What the guard reads is now a measured duration, scoped to the turn now
+  running, and a handshake that ended no outage records nothing rather than inheriting the
+  previous one.
+  The accounting moved into a tracker with unit tests that drive it through the real
+  sequence — drop, refused retry, refused retry, handshake — because no single call can
+  distinguish a drop from the third refused attempt, and a source scan over the panel
+  could not have caught this (a review previously proved by mutation that such scans stay
+  green through an inversion). Each guard was mutation-checked against those tests.
+  The two sibling `ready`-ack branches were audited for the same class and are clean: the
+  reboot-resume branch already decides on an observed drop rather than elapsed time
+  ("elapsed time is not evidence of a new connection; an observed drop is"), and the
+  soft-reload branch reads a marker it sets and clears itself. The mid-task branch was the
+  only one deriving a restart from a clock.
+
 ## [0.14.21] - 2026-08-12
 
 ### Added

--- a/browser_tests/unit/command-liveness.test.mjs
+++ b/browser_tests/unit/command-liveness.test.mjs
@@ -501,8 +501,15 @@ test("#508 wiring: an undelivered reply is journaled, replayed after hello, and 
     false,
     "replay must not fire at bare socket-open",
   );
-  const markConnected = src.slice(src.indexOf("function markConnected() {"));
-  assert.match(markConnected.slice(0, 1600), /replayLostReplies\(sock\);/, "replay rides the handshake");
+  // Bound to markConnected's actual BODY, the way the #508 R6 test below bounds
+  // handleUndeliveredReply's. A fixed character window stood in for "inside this
+  // function" and stopped meaning that the moment the function grew a comment
+  // (#1145 added one) — a passing assertion turning into a failing one for a reason
+  // unrelated to what it checks.
+  const mcStart = src.indexOf("function markConnected() {");
+  assert.notEqual(mcStart, -1, "could not locate markConnected in the panel source");
+  const markConnected = src.slice(mcStart, src.indexOf("\n  }", mcStart));
+  assert.match(markConnected, /replayLostReplies\(sock\);/, "replay rides the handshake");
 });
 
 test("#508 codex R6: an outcome journaled AFTER the replacement socket replayed is delivered anyway", () => {

--- a/browser_tests/unit/command-liveness.test.mjs
+++ b/browser_tests/unit/command-liveness.test.mjs
@@ -508,7 +508,12 @@ test("#508 wiring: an undelivered reply is journaled, replayed after hello, and 
   // unrelated to what it checks.
   const mcStart = src.indexOf("function markConnected() {");
   assert.notEqual(mcStart, -1, "could not locate markConnected in the panel source");
-  const markConnected = src.slice(mcStart, src.indexOf("\n  }", mcStart));
+  // Both ends are asserted: a -1 from either indexOf would slice a window that is not
+  // the function — an unfound END silently degrades `slice` into a near-whole-file scan,
+  // which would pass no matter where replayLostReplies actually sits.
+  const mcEnd = src.indexOf("\n  }", mcStart);
+  assert.notEqual(mcEnd, -1, "could not locate the end of markConnected");
+  const markConnected = src.slice(mcStart, mcEnd);
   assert.match(markConnected, /replayLostReplies\(sock\);/, "replay rides the handshake");
 });
 

--- a/browser_tests/unit/interactive-card-fence.test.mjs
+++ b/browser_tests/unit/interactive-card-fence.test.mjs
@@ -32,6 +32,10 @@ import {
   classifyInteractiveCard,
   refusedInteractiveCardError,
 } from "../../web/js/lib/interactive-card-fence.js";
+// #1145 — the shipped onTurn("working") body scopes the mid-task nudge's outage
+// evidence to the turn it starts, so the lifecycle harness below has to supply the
+// real tracker along with the rest of onTurn's closure.
+import { createBridgeOutageTracker } from "../../web/js/lib/session-rebind.js";
 
 const panelPath = fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url));
 const panelSrc = readFileSync(panelPath, "utf8").replace(/\r\n/g, "\n");
@@ -551,7 +555,7 @@ function buildLifecycle() {
     const { classifyInteractiveCard, refusedInteractiveCardError, paintQuestion, paintSecret,
             bumpThinking, noteActivity, lsSet, SECRET_SET_AT_PREFIX, console,
             showThinking, hideThinking, ssSet, MID_TASK_KEY, getGraphCtx, workflowStableUuid,
-            STALE_WORKING_GUARD_MS, now } = deps;
+            STALE_WORKING_GUARD_MS, now, bridgeOutage } = deps;
     let agentWorking = false;
     let liveTurnThreadId = null;
     let lastMintedThreadId = null;
@@ -606,6 +610,11 @@ function buildLifecycle() {
     workflowStableUuid: () => "wf-1",
     STALE_WORKING_GUARD_MS: guardMs,
     now: () => clock,
+    // #1145 — onTurn("working") scopes the mid-task nudge's outage evidence to the turn
+    // it is starting. The REAL tracker, on this harness's clock, so the injected surface
+    // stays the shipped one rather than a stub that would keep passing if the call
+    // changed shape (this section exists to run the shipped lifecycle, not a copy of it).
+    bridgeOutage: createBridgeOutageTracker({ now: () => clock }),
   });
   return { ...built, painted, tick: (ms) => { clock += ms; }, at: () => clock };
 }

--- a/browser_tests/unit/session-rebind.test.mjs
+++ b/browser_tests/unit/session-rebind.test.mjs
@@ -615,6 +615,16 @@ test("#1138 wiring: the call site NEGATES the predicate and returns", () => {
   // The reverted sessionStorage twin must not return without its own review: every
   // confirmed leak on this branch came from persisting that timestamp.
   assert.doesNotMatch(src, /BRIDGE_DOWN_AT_KEY/, "the persisted drop timestamp stays reverted");
+  // #1145 — and the tracker measures on the MONOTONIC clock. This is the one part a
+  // behavioural test over the module cannot see: the tracker's own default is
+  // `Date.now()` (it must stay usable standalone), so which clock the PANEL measures
+  // with is decided at the construction site and nowhere else. reconnect-staleness.js
+  // already fixed this rule for elapsed-window state after a prior review; a wall clock
+  // here lets an NTP/DST correction inside a reconnect invent or erase an outage.
+  assert.ok(
+    src.includes("createBridgeOutageTracker({ now: monotonicNow })"),
+    "the panel's outage tracker must measure on the monotonic clock",
+  );
 });
 
 // ── #1145: the interval must be the OUTAGE, not one backoff step ─────────────
@@ -764,6 +774,59 @@ test("#1145: a backwards clock cannot manufacture or corrupt an outage", () => {
   broken.noteHandshake();
   assert.equal(broken.outageMs(), 0);
   assert.equal(broken.isDown(), false, "an untimed outage must still be closed out");
+});
+
+test("#1145: a `ready` ack that beats the models handshake still measures the outage", () => {
+  // THE ORDERING THIS NEARLY GOT WRONG. The reader is the ready ack, and ready does not
+  // wait for the handshake that closes an outage: the orchestrator pushes its models
+  // frame from an async continuation (`void ensureModels(backend).then(…)`) while the
+  // ready ack goes out synchronously once hello is processed. For any backend whose
+  // model discovery costs a probe, ready arrives FIRST — so at read time the outage is
+  // still open. Reporting the last CLOSED outage there would answer 0 and swallow the
+  // nudge on exactly the real restart this issue exists to restore.
+  const { clock, tracker } = trackerAt();
+  tracker.noteTurnStarted();
+  tracker.noteBridgeClosed(); // ComfyUI restarts
+  clock.t += 30_000; // socket is back and hello processed; models still discovering
+  assert.equal(tracker.isDown(), true, "the handshake has not closed the outage yet");
+  assert.equal(
+    tracker.outageMs(),
+    30_000,
+    "an outage still in progress must read live, not as the last closed one",
+  );
+  assert.equal(shouldNudgeAfterMidTaskReconnect({ outageMs: tracker.outageMs() }), true);
+
+  // …and the models frame landing moments later agrees, rather than revising it.
+  clock.t += 40;
+  tracker.noteHandshake();
+  assert.equal(tracker.outageMs(), 30_040);
+});
+
+test("#1145: a LIVE reading still measures the outage, not the last backoff step", () => {
+  // The live path must not be a back door to the original defect: refused retries during
+  // the outage must leave its start alone here too.
+  const { clock, tracker } = trackerAt();
+  const t0 = clock.t;
+  tracker.noteTurnStarted();
+  tracker.noteBridgeClosed();
+  for (const t of [1000, 3000]) {
+    clock.t = t0 + t;
+    tracker.noteBridgeClosed(); // refused attempts
+  }
+  clock.t = t0 + 7000; // the ready ack arrives before models
+  assert.equal(tracker.outageMs(), 7000, "live reading measures the outage, not 7000-3000");
+  assert.equal(shouldNudgeAfterMidTaskReconnect({ outageMs: tracker.outageMs() }), true);
+});
+
+test("#1145: a never-dropped bridge reads 0 live, not the age of the session", () => {
+  // The #1138 case against the live path: with no outage open, the live branch must not
+  // engage at all. If it measured from a 0 start it would report the whole session as an
+  // outage — the ~56-year sentinel bug, reintroduced through the new reading.
+  const { clock, tracker } = trackerAt();
+  clock.t += 3_600_000; // an hour of uptime, never a drop
+  assert.equal(tracker.isDown(), false);
+  assert.equal(tracker.outageMs(), 0);
+  assert.equal(shouldNudgeAfterMidTaskReconnect({ outageMs: tracker.outageMs() }), false);
 });
 
 test("#1145: a second outage measures itself, not the gap since the first", () => {

--- a/browser_tests/unit/session-rebind.test.mjs
+++ b/browser_tests/unit/session-rebind.test.mjs
@@ -625,6 +625,19 @@ test("#1138 wiring: the call site NEGATES the predicate and returns", () => {
     src.includes("createBridgeOutageTracker({ now: monotonicNow })"),
     "the panel's outage tracker must measure on the monotonic clock",
   );
+  // #1145 — and the two WRITE sites, not just the read. The tracker's behaviour is
+  // covered above, but a tracker nothing feeds answers 0 forever and every one of these
+  // tests still passes: deleting `noteBridgeClosed()` from the close handler silently
+  // restores "no drop was ever recorded", which is the bug #1138 fixed. Each site is
+  // pinned by exact substring for #1096's reason — loose token scans over this file
+  // assert nothing.
+  for (const [site, snippet] of [
+    ["the socket close handler must open the outage", "bridgeOutage.noteBridgeClosed();"],
+    ["the models handshake must close it", "bridgeOutage.noteHandshake();"],
+    ["a turn start must scope the evidence to that turn", "bridgeOutage.noteTurnStarted();"],
+  ]) {
+    assert.ok(src.includes(snippet), site);
+  }
 });
 
 // ── #1145: the interval must be the OUTAGE, not one backoff step ─────────────

--- a/browser_tests/unit/session-rebind.test.mjs
+++ b/browser_tests/unit/session-rebind.test.mjs
@@ -12,6 +12,7 @@ import {
   shouldResumeAfterComfyReconnect,
   shouldRehelloAfterCommand,
   shouldNudgeAfterMidTaskReconnect,
+  createBridgeOutageTracker,
   planSoftReloadRecovery,
   performSoftReloadRecovery,
   isTransientReconnectError,
@@ -531,72 +532,64 @@ test("#419: N open tabs each independently reconnect — no subset left dead", a
 // and the injection is harmful, unless the orchestrator really died: telling a working
 // agent to resume makes it restart or duplicate what it is doing.
 //
-// The gap heuristic was right; the sentinel's arithmetic betrayed it. lastBridgeDownAt is
-// 0 until the bridge socket CLOSES, and `Date.now() - 0` is ~56 years — the longest
+// The gap heuristic was right; the sentinel's arithmetic betrayed it. The drop stamp was
+// 0 until the bridge socket CLOSED, and `Date.now() - 0` is ~56 years — the longest
 // possible gap, read as the strongest possible evidence of a real restart. So the guard
 // was inverted exactly where it mattered: the better established that nothing dropped, the
 // more confidently it nudged. Reachable on a live socket because `ready` repeats on one and
 // #310 re-advertises after every successful free_vram.
+//
+// #1145 restated the predicate's input as a MEASURED OUTAGE rather than a timestamp to
+// subtract from `now` (see the module note). The #1138 rule is unchanged and still locked
+// below — "no drop was recorded" is now the honest value 0 instead of a sentinel that
+// subtracted like 1970.
 
 test("#1138: NEVER dropped must not nudge, however long the session has run", () => {
   // The reported shape: a live socket, a re-advertise, a ready ack, and no drop anywhere.
-  // A real Date.now() against the 0 sentinel is ~56 years, which the old guard passed.
-  assert.equal(
-    shouldNudgeAfterMidTaskReconnect({ bridgeDroppedAt: 0, now: Date.now() }),
-    false,
-  );
-  for (const noDrop of [undefined, null, 0, -1, NaN, Infinity, "0", "1700000000000", {}]) {
+  // The old guard subtracted the 0 sentinel from a real clock and passed on ~56 years;
+  // an unmeasured outage is now simply 0 ms, which cannot be mistaken for a long one.
+  assert.equal(shouldNudgeAfterMidTaskReconnect({ outageMs: 0 }), false);
+  for (const noDrop of [undefined, null, 0, -1, NaN, Infinity, "0", "30000", {}]) {
     assert.equal(
-      shouldNudgeAfterMidTaskReconnect({ bridgeDroppedAt: noDrop, now: Date.now() }),
+      shouldNudgeAfterMidTaskReconnect({ outageMs: noDrop }),
       false,
-      `no recorded drop must never nudge: ${JSON.stringify(noDrop)}`,
+      `no measured outage must never nudge: ${JSON.stringify(noDrop)}`,
     );
   }
   assert.equal(shouldNudgeAfterMidTaskReconnect(), false, "no arguments must not nudge");
 });
 
 test("#1138: a REAL restart still nudges — the fix must not disable the feature", () => {
-  // The behaviour #278/#588 rely on: a long gap after an actual drop is a real restart.
-  const now = 1_700_000_000_000;
-  assert.equal(
-    shouldNudgeAfterMidTaskReconnect({ bridgeDroppedAt: now - 30_000, now }),
-    true,
-  );
-  // Exactly at the boundary counts as real (>= minGapMs), so the threshold is not
+  // The behaviour #278/#588 rely on: a long outage is a real restart.
+  assert.equal(shouldNudgeAfterMidTaskReconnect({ outageMs: 30_000 }), true);
+  // Exactly at the boundary counts as real (>= minOutageMs), so the threshold is not
   // silently exclusive.
-  assert.equal(
-    shouldNudgeAfterMidTaskReconnect({ bridgeDroppedAt: now - 6000, now }),
-    true,
-  );
+  assert.equal(shouldNudgeAfterMidTaskReconnect({ outageMs: 6000 }), true);
 });
 
 test("#1138: a FAST reconnect after a real drop still does not nudge", () => {
   // The pre-existing half of the rule, preserved: a sidebar remount or a brief WS blip
   // means the orchestrator never died, so the turn kept running.
-  const now = 1_700_000_000_000;
-  assert.equal(shouldNudgeAfterMidTaskReconnect({ bridgeDroppedAt: now - 1, now }), false);
-  assert.equal(shouldNudgeAfterMidTaskReconnect({ bridgeDroppedAt: now - 5999, now }), false);
-  assert.equal(shouldNudgeAfterMidTaskReconnect({ bridgeDroppedAt: now, now }), false);
+  assert.equal(shouldNudgeAfterMidTaskReconnect({ outageMs: 1 }), false);
+  assert.equal(shouldNudgeAfterMidTaskReconnect({ outageMs: 5999 }), false);
 });
 
-test("#1138: a NEGATIVE gap is not evidence of a long outage", () => {
-  // A wall-clock adjustment, or a drop stamped after this read, must not read as an
-  // ancient drop — the same class of mistake as the 0 sentinel, one step along.
-  const now = 1_700_000_000_000;
-  assert.equal(shouldNudgeAfterMidTaskReconnect({ bridgeDroppedAt: now + 60_000, now }), false);
-  assert.equal(shouldNudgeAfterMidTaskReconnect({ now, bridgeDroppedAt: now + 1 }), false);
-  // …and an unreadable clock decides nothing.
-  assert.equal(shouldNudgeAfterMidTaskReconnect({ bridgeDroppedAt: now - 30_000, now: NaN }), false);
-  assert.equal(shouldNudgeAfterMidTaskReconnect({ bridgeDroppedAt: now - 30_000, now: "later" }), false);
+test("#1138: a NEGATIVE duration is not evidence of a long outage", () => {
+  // A wall-clock adjustment must not read as an ancient drop — the same class of mistake
+  // as the 0 sentinel, one step along.
+  assert.equal(shouldNudgeAfterMidTaskReconnect({ outageMs: -60_000 }), false);
+  assert.equal(shouldNudgeAfterMidTaskReconnect({ outageMs: -1 }), false);
+  // …and an unreadable threshold decides nothing either.
+  assert.equal(shouldNudgeAfterMidTaskReconnect({ outageMs: 30_000, minOutageMs: NaN }), false);
+  assert.equal(shouldNudgeAfterMidTaskReconnect({ outageMs: 30_000, minOutageMs: "6s" }), false);
 });
 
 test("#1138: the guard is INVERSION-SENSITIVE, unlike a source scan", () => {
   // #1096's review proved by mutation that a token-presence source scan stays green when
   // the guard is inverted. This asserts the two sides disagree, so an inverted or dropped
   // condition cannot pass: the never-dropped case and the real-restart case must differ.
-  const now = 1_700_000_000_000;
-  const neverDropped = shouldNudgeAfterMidTaskReconnect({ bridgeDroppedAt: 0, now });
-  const realRestart = shouldNudgeAfterMidTaskReconnect({ bridgeDroppedAt: now - 30_000, now });
+  const neverDropped = shouldNudgeAfterMidTaskReconnect({ outageMs: 0 });
+  const realRestart = shouldNudgeAfterMidTaskReconnect({ outageMs: 30_000 });
   assert.notEqual(
     neverDropped,
     realRestart,
@@ -615,11 +608,177 @@ test("#1138 wiring: the call site NEGATES the predicate and returns", () => {
   const src = readFileSync(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8");
   assert.ok(
     src.includes(
-      "if (!shouldNudgeAfterMidTaskReconnect({ bridgeDroppedAt: lastBridgeDownAt, now: Date.now() }))",
+      "if (!shouldNudgeAfterMidTaskReconnect({ outageMs: bridgeOutage.outageMs() })) return;",
     ),
-    "the ready-ack mid-task branch must NEGATE the predicate and read the live drop stamp",
+    "the ready-ack mid-task branch must NEGATE the predicate and read the measured outage",
   );
   // The reverted sessionStorage twin must not return without its own review: every
   // confirmed leak on this branch came from persisting that timestamp.
   assert.doesNotMatch(src, /BRIDGE_DOWN_AT_KEY/, "the persisted drop timestamp stays reverted");
+});
+
+// ── #1145: the interval must be the OUTAGE, not one backoff step ─────────────
+//
+// `connect()` assigns `sock` before the connection resolves, so a REFUSED attempt during
+// a restart is still the active socket and runs the close handler in full. The old code
+// re-stamped the drop time there, and with backoff doubling from RECONNECT_BASE_MS the
+// retries land near t=1s/3s/7s/15s — so the successful attempt was separated from the
+// previous failed close by only THAT attempt's delay. The guard weighed one backoff step,
+// and a genuine restart returning inside ~7s measured ~4s and lost its nudge: the session
+// resumed with full context and no pending turn, leaving the agent idle after exactly the
+// event the nudge exists for.
+//
+// These drive the tracker through the real ORDER of events, which is the only way to see
+// it: no single call distinguishes "the drop" from "the third refused retry".
+
+/** A tracker over a hand-driven clock: `clock.t` is the wall time it reads. */
+function trackerAt(t0 = 1_700_000_000_000) {
+  const clock = { t: t0 };
+  return { clock, tracker: createBridgeOutageTracker({ now: () => clock.t }) };
+}
+
+test("#1145: refused retries during a restart must not reset the outage clock", () => {
+  // The reported sequence, to scale: the bridge drops, three reconnect attempts are
+  // refused at the backoff delays, and the fourth connects — a 7s outage.
+  const { clock, tracker } = trackerAt();
+  const t0 = clock.t;
+  tracker.noteTurnStarted(); // a turn is in flight; this is the mid-task case
+  tracker.noteBridgeClosed(); // t=0 — the real drop
+  for (const t of [1000, 3000]) {
+    clock.t = t0 + t;
+    tracker.noteBridgeClosed(); // a REFUSED attempt closes exactly like a drop
+  }
+  clock.t = t0 + 7000;
+  tracker.noteHandshake(); // the attempt at ~7s connects
+
+  assert.equal(
+    tracker.outageMs(),
+    7000,
+    "the measured interval must be the whole outage, not the last backoff step",
+  );
+  assert.equal(
+    shouldNudgeAfterMidTaskReconnect({ outageMs: tracker.outageMs() }),
+    true,
+    "a genuine restart that returns in ~7s must keep its nudge",
+  );
+});
+
+test("#1145: the old per-attempt stamp would have measured one step and lost the nudge", () => {
+  // The counterfactual, asserted rather than described: had the final refused close reset
+  // the clock (the defect), the interval would have been 7000-3000=4000ms — under the 6s
+  // threshold, so no nudge. This is what must never come back.
+  const lastBackoffStep = 7000 - 3000;
+  assert.equal(shouldNudgeAfterMidTaskReconnect({ outageMs: lastBackoffStep }), false);
+  assert.notEqual(
+    shouldNudgeAfterMidTaskReconnect({ outageMs: 7000 }),
+    shouldNudgeAfterMidTaskReconnect({ outageMs: lastBackoffStep }),
+    "outage and backoff-step must not agree, or the regression is invisible",
+  );
+});
+
+test("#1145: a genuinely fast reconnect still measures fast", () => {
+  // The other half of the rule: measuring the outage must not turn every blip into a
+  // restart. One close, reconnected in 2s, is still a blip.
+  const { clock, tracker } = trackerAt();
+  tracker.noteBridgeClosed();
+  clock.t += 2000;
+  tracker.noteHandshake();
+  assert.equal(tracker.outageMs(), 2000);
+  assert.equal(shouldNudgeAfterMidTaskReconnect({ outageMs: tracker.outageMs() }), false);
+});
+
+test("#1145: a handshake that ended NO outage inherits nothing", () => {
+  // `ready`/`models` repeat on a LIVE socket — #310 re-advertises after every successful
+  // free_vram. A re-advertise must record nothing rather than adopting the previous
+  // outage; adopting it is how a settled drop gets reported as "your connection dropped".
+  const { clock, tracker } = trackerAt();
+  tracker.noteBridgeClosed();
+  clock.t += 30_000;
+  tracker.noteHandshake(); // a real 30s outage ends
+  assert.equal(tracker.outageMs(), 30_000);
+
+  clock.t += 600_000; // ten quiet minutes on the same live socket
+  tracker.noteHandshake(); // a free_vram re-advertise draws a fresh handshake
+  assert.equal(
+    tracker.outageMs(),
+    30_000,
+    "a re-advertise must not restate the elapsed time as a NEW outage",
+  );
+  assert.equal(tracker.isDown(), false);
+});
+
+test("#1145: an outage that ended BEFORE this turn is not this turn's evidence", () => {
+  // #1138 fixed a stale 0 reading as ~56 years. A stale POSITIVE duration is the same
+  // defect one step along: a real 30s outage, settled two turns ago, must not be re-read
+  // by a `ready` that merely repeats on the live socket during the turn running now.
+  const { clock, tracker } = trackerAt();
+  tracker.noteBridgeClosed();
+  clock.t += 30_000;
+  tracker.noteHandshake();
+  assert.equal(shouldNudgeAfterMidTaskReconnect({ outageMs: tracker.outageMs() }), true);
+
+  clock.t += 300_000;
+  tracker.noteTurnStarted(); // a NEW turn begins — the old outage is not about it
+  assert.equal(tracker.outageMs(), 0);
+  assert.equal(
+    shouldNudgeAfterMidTaskReconnect({ outageMs: tracker.outageMs() }),
+    false,
+    "a settled outage must not nudge a turn that started after it",
+  );
+});
+
+test("#1145: a drop DURING the turn is still this turn's evidence", () => {
+  // The complement of the test above — turn-scoping must not swallow the case the nudge
+  // exists for. A turn starts, THEN the bridge drops for 30s and comes back.
+  const { clock, tracker } = trackerAt();
+  tracker.noteTurnStarted();
+  clock.t += 5000;
+  tracker.noteBridgeClosed();
+  clock.t += 30_000;
+  tracker.noteHandshake();
+  assert.equal(tracker.outageMs(), 30_000);
+  assert.equal(shouldNudgeAfterMidTaskReconnect({ outageMs: tracker.outageMs() }), true);
+});
+
+test("#1145: a fresh tracker has seen no outage", () => {
+  // The #1138 case at the source: a page load / panel mount that never saw a drop reports
+  // 0, not a sentinel that subtracts like 1970.
+  const { tracker } = trackerAt();
+  assert.equal(tracker.outageMs(), 0);
+  assert.equal(tracker.isDown(), false);
+  assert.equal(shouldNudgeAfterMidTaskReconnect({ outageMs: tracker.outageMs() }), false);
+});
+
+test("#1145: a backwards clock cannot manufacture or corrupt an outage", () => {
+  // A wall-clock adjustment mid-outage must not yield a negative duration, and an
+  // unreadable clock must withhold the nudge rather than invent one — a missed nudge
+  // leaves an idle agent, an invented one derails a working agent.
+  const { clock, tracker } = trackerAt();
+  tracker.noteBridgeClosed();
+  clock.t -= 60_000; // the clock jumps backwards during the outage
+  tracker.noteHandshake();
+  assert.equal(tracker.outageMs(), 0);
+
+  const broken = createBridgeOutageTracker({ now: () => NaN });
+  broken.noteBridgeClosed();
+  broken.noteHandshake();
+  assert.equal(broken.outageMs(), 0);
+  assert.equal(broken.isDown(), false, "an untimed outage must still be closed out");
+});
+
+test("#1145: a second outage measures itself, not the gap since the first", () => {
+  // The outage must close cleanly, or the NEXT drop measures from the previous one's
+  // start and every later reconnect reads as a longer and longer restart.
+  const { clock, tracker } = trackerAt();
+  tracker.noteBridgeClosed();
+  clock.t += 30_000;
+  tracker.noteHandshake();
+
+  clock.t += 600_000;
+  tracker.noteTurnStarted();
+  tracker.noteBridgeClosed(); // a SECOND, brief outage
+  clock.t += 1500;
+  tracker.noteHandshake();
+  assert.equal(tracker.outageMs(), 1500, "the second outage is 1.5s, not 10 minutes");
+  assert.equal(shouldNudgeAfterMidTaskReconnect({ outageMs: tracker.outageMs() }), false);
 });

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -463,6 +463,7 @@ import {
   shouldResumeAfterComfyReconnect,
   shouldRehelloAfterCommand,
   shouldNudgeAfterMidTaskReconnect,
+  createBridgeOutageTracker,
   performSoftReloadRecovery,
   retryDuringReconnect,
   dedupeWorkflowTabRecords,
@@ -2865,11 +2866,29 @@ const RELOAD_POST_TIMEOUT_MS = 10000;
 // resumed session to continue where it left off. The REBOOT/SOFT_RELOAD cases
 // (deliberate, agent-known) are handled first and clear this so we don't double-nudge.
 const MID_TASK_KEY = "comfyui-mcp.panel.midTaskResume";
-// Wall-clock (ms) of the last bridge drop — module-scoped so it survives panel
-// remounts. A FAST reconnect (panel swap / WS blip; orchestrator alive) vs a
-// SLOW one (real ComfyUI restart; orchestrator died + respawned) is how we tell
-// a spurious bounce from a real one — only the slow case fires the resume nudge.
-let lastBridgeDownAt = 0;
+// The OUTAGE the mid-task nudge weighs. A FAST reconnect (panel swap / WS blip;
+// orchestrator alive) vs a SLOW one (real ComfyUI restart; orchestrator died +
+// respawned) is how we tell a spurious bounce from a real one — only the slow case
+// fires the resume nudge. Module-scoped so it survives panel remounts.
+//
+// #1145 — this used to be a single "last drop" stamp rewritten by every close, and a
+// close is NOT once per outage. `connect()` assigns `sock` before the socket opens, so
+// a REFUSED retry during a restart is still the active socket and runs the close
+// handler in full. With backoff doubling from RECONNECT_BASE_MS the retries land near
+// t=1s/3s/7s/15s, so the successful attempt was separated from the previous failed
+// close by only THAT attempt's delay: the guard weighed one backoff step instead of the
+// outage, and a genuine restart returning inside ~7s lost its nudge.
+//
+// The accounting lives in session-rebind.js because the defect is a SEQUENCE — four
+// closes in a row, each resetting the clock — and only a sequence can demonstrate it.
+// A tracker there is driven through the real order of events by unit tests; a source
+// scan over THIS file could not have caught it (#1096 proved such scans stay green
+// through an inversion). It distinguishes the first close of an outage from the refused
+// retries that follow, the handshake that ends one from a re-advertise that ends
+// nothing, and scopes what it measured to the turn now running — so an outage that
+// ended before this turn began is not re-read as this turn's (the #1138 defect with a
+// stale timestamp in place of the 0 sentinel).
+const bridgeOutage = createBridgeOutageTracker();
 // One-shot flag set right before a frontend (page) reload WE trigger, so that
 // after the reload we re-activate our own sidebar tab. ComfyUI restores the
 // last active tab BEFORE our extension re-registers it, so it can't reopen ours
@@ -17180,6 +17199,12 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
     handshakeDone = true;
     handshakenSock = sock;
     clearHandshake();
+    // #1145 — a real handshake is where an outage ENDS and its duration is finally
+    // known. Here and not at bare socket-open for the same reason the replay below is:
+    // an open socket only proves something holds the port, a `models` frame proves an
+    // orchestrator is behind it. A handshake that ended no outage records nothing (see
+    // the tracker in session-rebind.js).
+    bridgeOutage.noteHandshake();
     // Remember the user wants the agent connected, so we auto-reconnect after a
     // ComfyUI reboot / panel reopen (until they explicitly Disconnect). Mirror it
     // into the "Auto-connect on load" setting so the toggle reflects reality.
@@ -18217,7 +18242,13 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
       }
       pendingCalls.clear();
       clearHandshake();
-      lastBridgeDownAt = Date.now(); // for the fast-vs-slow reconnect heuristic
+      // #1145 — the OUTAGE begins at the FIRST close of a sequence and every close
+      // after it belongs to the same outage. A refused reconnect attempt reaches here
+      // exactly like a real drop does (`sock` is assigned at construction, so a socket
+      // that never opened is still the active one), and re-stamping on those reset the
+      // clock to the last backoff step. The tracker ignores all but the first; the
+      // outage stands until markConnected() ends it.
+      bridgeOutage.noteBridgeClosed();
       if (!closed) {
         // FIX 1 — auto-reconnecting: keep the pill STEADY (scheduleReconnect picks
         // connecting-vs-terminal based on the patience window). Do NOT flip to
@@ -26958,6 +26989,14 @@ function buildPanel() {
         showThinking();
         noteActivity(); // turn start = real activity → seed the silence clock
         ssSet(MID_TASK_KEY, "1"); // a turn is in flight — arm the resume nudge
+        // #1145 — and arm it against THIS turn's outages only. The nudge tells the agent
+        // its connection dropped mid-task; an outage that ended before the turn began is
+        // not evidence about the turn now running, and leaving it standing is how a
+        // `ready` that merely repeats on a live socket (a #310 free_vram re-advertise,
+        // say) would read a long-settled drop as this turn's and nudge a working agent.
+        // Same defect #1138 fixed for the never-dropped sentinel, one step along: there
+        // the stale value was 0, here it is a real duration from an earlier outage.
+        bridgeOutage.noteTurnStarted();
       } else if (state === "done") {
         agentWorking = false;
         // Turn over: drop the owner so a later reconnect re-push (which has no
@@ -27381,12 +27420,12 @@ function buildPanel() {
         // would inject a spurious turn into a live session. A real ComfyUI restart
         // takes many seconds to come back, so a long gap since the drop = real.
         //
-        // #1138 — AND the bridge must actually have dropped. `lastBridgeDownAt` is 0
-        // until the bridge socket closes, and 0 does not mean "no drop" to the
-        // subtraction below: `Date.now() - 0` is ~56 years, the LONGEST possible gap,
+        // #1138 — AND the bridge must actually have dropped. The drop stamp this used to
+        // read was 0 until the bridge socket closed, and 0 did not mean "no drop" to the
+        // subtraction it fed: `Date.now() - 0` is ~56 years, the LONGEST possible gap,
         // which this heuristic reads as the most certain evidence of a real restart.
         // So the guard was exactly inverted in the case it exists to catch — the
-        // better established it is that nothing dropped, the more confidently it
+        // better established it was that nothing dropped, the more confidently it
         // nudged. The intent above was right from the start; only the sentinel's
         // arithmetic betrayed it.
         //
@@ -27396,12 +27435,16 @@ function buildPanel() {
         // mid-task could be told their connection had dropped — and the agent told to
         // resume work it was still doing — with no drop anywhere in the session.
         //
+        // #1145 — and the interval weighed is the OUTAGE this turn saw, measured once at
+        // the handshake that ended it, not `Date.now()` minus a stamp every failed retry
+        // rewrote. A stamp read at this moment answers "how long since the last drop,
+        // whenever that was"; the question here is "how long was THIS connection gone".
+        //
         // The decision moved into session-rebind.js so it is unit-tested by BEHAVIOUR.
         // A source-scan over this file could only assert the guard's tokens are present,
         // and #1096's review demonstrated by mutation that such a test stays green when
         // the guard is inverted — which is the one regression that matters here.
-        if (!shouldNudgeAfterMidTaskReconnect({ bridgeDroppedAt: lastBridgeDownAt, now: Date.now() }))
-          return;
+        if (!shouldNudgeAfterMidTaskReconnect({ outageMs: bridgeOutage.outageMs() })) return;
         appendSystem(tr("panel.reconnected_picking_up_where_we_left_off", "Reconnected — picking up where we left off."));
         showThinking();
         client.sendUserMessage(

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -2888,7 +2888,16 @@ const MID_TASK_KEY = "comfyui-mcp.panel.midTaskResume";
 // nothing, and scopes what it measured to the turn now running — so an outage that
 // ended before this turn began is not re-read as this turn's (the #1138 defect with a
 // stale timestamp in place of the 0 sentinel).
-const bridgeOutage = createBridgeOutageTracker();
+//
+// On the MONOTONIC clock, not the wall clock. This measures an elapsed window, and
+// `web/js/lib/reconnect-staleness.js` already fixed the rule for that class after a
+// prior review ("monotonic timestamp (performance.now) … codex P1"); `monotonicNow()`
+// exists for it. With `Date.now()` an NTP or DST correction landing inside a reconnect
+// decides the answer: a forward jump turns a two-second blip into a long outage and
+// nudges an agent whose turn never stopped, a backward jump erases a real restart and
+// leaves it idle. Both are the failure this issue is about, arriving through the clock
+// instead of through the backoff.
+const bridgeOutage = createBridgeOutageTracker({ now: monotonicNow });
 // One-shot flag set right before a frontend (page) reload WE trigger, so that
 // after the reload we re-activate our own sidebar tab. ComfyUI restores the
 // last active tab BEFORE our extension re-registers it, so it can't reopen ours

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -18257,6 +18257,14 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
       // that never opened is still the active one), and re-stamping on those reset the
       // clock to the last backoff step. The tracker ignores all but the first; the
       // outage stands until markConnected() ends it.
+      //
+      // A panel-DRIVEN teardown never reaches here, and that is deliberate rather than
+      // a gap: stop() nulls `sock` synchronously, so the late close fails the isActive()
+      // guard above and no outage opens. Every such path — Disconnect, provider switch,
+      // soft reload — routes through endTurnLocally() or its own ready-ack branch and
+      // clears MID_TASK_KEY, so there is no mid-task nudge left to decide. Opening an
+      // outage for them would only invent evidence about a drop the user asked for. The
+      // pre-#1145 stamp sat behind this same guard, so this is unchanged behaviour.
       bridgeOutage.noteBridgeClosed();
       if (!closed) {
         // FIX 1 — auto-reconnecting: keep the pill STEADY (scheduleReconnect picks

--- a/web/js/lib/session-rebind.js
+++ b/web/js/lib/session-rebind.js
@@ -148,8 +148,30 @@ export function createBridgeOutageTracker({ now = () => Date.now() } = {}) {
     noteTurnStarted() {
       outageMs = 0;
     },
-    /** The outage the current turn has seen, in ms (0 = none). */
-    outageMs: () => outageMs,
+    /** The outage the current turn has seen, in ms (0 = none).
+     *
+     *  While the bridge is still marked DOWN this measures LIVE from the outage start
+     *  instead of reporting the last closed one. That is not a nicety — the reader is
+     *  the `ready` ack, and `ready` does not wait for the handshake that closes an
+     *  outage. The orchestrator pushes its models frame from an async continuation
+     *  (`void ensureModels(backend).then(…)`) while the ready ack goes out
+     *  synchronously once hello is processed, so for any backend whose model discovery
+     *  costs a probe, `ready` arrives FIRST. Reporting the closed value there would
+     *  answer 0 for an outage still in progress and swallow the nudge on exactly the
+     *  real restart this exists to catch — a fresh way to lose it, in the change that
+     *  fixed the old one. Measuring live is also what the pre-#1145 code did: a stamp
+     *  can be subtracted from at any moment, and that property has to survive.
+     *
+     *  This does NOT reintroduce the backoff-step defect: `startedAt` is still written
+     *  once, by the first close, so a live reading measures from the outage's start and
+     *  not from the most recent refused retry. */
+    outageMs() {
+      if (!startedAt) return outageMs;
+      const t = readClock();
+      // Clamped for the same reason noteHandshake clamps: a clock that ran backwards
+      // reports no outage rather than a negative one.
+      return t === null ? outageMs : Math.max(0, t - startedAt);
+    },
     /** True while the bridge is down — the outage has begun but not yet ended. */
     isDown: () => startedAt > 0,
   };

--- a/web/js/lib/session-rebind.js
+++ b/web/js/lib/session-rebind.js
@@ -118,8 +118,16 @@ export function shouldNudgeAfterMidTaskReconnect({ outageMs = 0, minOutageMs = 6
 //     drop from being re-read later as this turn's — the #1138 defect with a stale
 //     timestamp in place of the 0 sentinel.
 export function createBridgeOutageTracker({ now = () => Date.now() } = {}) {
-  // When the current outage began; 0 whenever the bridge is up.
-  let startedAt = 0;
+  // When the current outage began; NULL whenever the bridge is up.
+  //
+  // Null rather than 0, and tested with `=== null` rather than for truthiness, because
+  // 0 is a LEGITIMATE reading here: the panel measures on `monotonicNow()`
+  // (performance.now), whose origin is page load, so an early enough close genuinely
+  // stamps a near-zero value. A falsy-0 sentinel would read that as "no outage open" —
+  // the outage would never close, every later close would re-stamp it, and the backoff
+  // step would be back. That is #1138's mistake exactly: a sentinel sharing a value
+  // with real data.
+  let startedAt = null;
   // The outage the current turn has seen, in ms; 0 means "no drop during this turn".
   let outageMs = 0;
   const readClock = () => {
@@ -128,22 +136,22 @@ export function createBridgeOutageTracker({ now = () => Date.now() } = {}) {
   };
   return {
     noteBridgeClosed() {
-      if (startedAt) return; // already inside an outage — this close is not a new one
+      if (startedAt !== null) return; // inside an outage already — not a new one
       const t = readClock();
-      // An unreadable clock cannot start an outage. Leaving startedAt at 0 means the
+      // An unreadable clock cannot start an outage. Leaving startedAt null means the
       // handshake records no duration, so the nudge is withheld — the safe direction:
       // a missed nudge leaves an idle agent, an invented one derails a working agent.
       if (t !== null) startedAt = t;
     },
     noteHandshake() {
-      if (!startedAt) return; // ended no outage — records nothing
+      if (startedAt === null) return; // ended no outage — records nothing
       const t = readClock();
-      // Clamped at 0: a backwards wall-clock adjustment mid-outage must not hand the
+      // Clamped at 0: a backwards clock adjustment mid-outage must not hand the
       // predicate a negative duration to reason about.
       if (t !== null) outageMs = Math.max(0, t - startedAt);
       // Closed either way — an outage whose end could not be timed is still over, and
       // leaving it open would let the NEXT drop measure from this one's start.
-      startedAt = 0;
+      startedAt = null;
     },
     noteTurnStarted() {
       outageMs = 0;
@@ -166,14 +174,16 @@ export function createBridgeOutageTracker({ now = () => Date.now() } = {}) {
      *  once, by the first close, so a live reading measures from the outage's start and
      *  not from the most recent refused retry. */
     outageMs() {
-      if (!startedAt) return outageMs;
+      if (startedAt === null) return outageMs;
       const t = readClock();
       // Clamped for the same reason noteHandshake clamps: a clock that ran backwards
       // reports no outage rather than a negative one.
       return t === null ? outageMs : Math.max(0, t - startedAt);
     },
-    /** True while the bridge is down — the outage has begun but not yet ended. */
-    isDown: () => startedAt > 0,
+    /** True while the bridge is down — the outage has begun but not yet ended.
+     *  Read by the tests that pin the open/closed transitions; the panel decides on
+     *  outageMs() alone, so this stays a state ACCESSOR and never a second predicate. */
+    isDown: () => startedAt !== null,
   };
 }
 

--- a/web/js/lib/session-rebind.js
+++ b/web/js/lib/session-rebind.js
@@ -50,8 +50,8 @@ export function shouldRehelloAfterCommand(cmd, reply) {
 // reconnect (a sidebar remount, a brief WS blip) means it was not. That rule is right.
 //
 // What it missed is that "no drop at all" is not the same as "a very old drop", and the
-// subtraction cannot tell them apart: the panel's `lastBridgeDownAt` is 0 until the bridge
-// socket closes, and `Date.now() - 0` is ~56 years — the LONGEST possible gap, which the
+// subtraction cannot tell them apart: the panel's drop stamp was 0 until the bridge
+// socket closed, and `Date.now() - 0` is ~56 years — the LONGEST possible gap, which the
 // heuristic reads as the strongest possible evidence of a real restart. So the guard was
 // exactly inverted where it mattered most: the better established it was that nothing had
 // dropped, the more confidently it nudged.
@@ -60,23 +60,99 @@ export function shouldRehelloAfterCommand(cmd, reply) {
 // a fresh handshake, and #310 re-advertises after every successful free_vram by design. So
 // freeing VRAM mid-task could tell a user their connection had dropped when nothing had.
 //
-// `bridgeDroppedAt` is therefore required to be a positive timestamp: absent, zero or
-// unreadable means no drop was recorded, and no drop means no nudge.
-export function shouldNudgeAfterMidTaskReconnect({
-  bridgeDroppedAt = 0,
-  now = 0,
-  minGapMs = 6000,
-} = {}) {
-  if (typeof bridgeDroppedAt !== "number" || !Number.isFinite(bridgeDroppedAt)) return false;
-  // Not `> 0` by accident: a drop is stamped with Date.now(), so any real value is far
-  // above zero, and a non-positive one is the never-dropped sentinel or a corrupt clock.
-  if (bridgeDroppedAt <= 0) return false;
-  if (typeof now !== "number" || !Number.isFinite(now)) return false;
-  // A gap that reads NEGATIVE (a clock adjustment, or a drop stamped after this read)
-  // is not evidence of a long outage either — treat it as fast, i.e. no nudge.
-  const gap = now - bridgeDroppedAt;
-  if (gap < 0) return false;
-  return gap >= minGapMs;
+// #1145 — and the interval must be the OUTAGE, which is why this takes a measured
+// duration rather than a timestamp to subtract from `now`.
+//
+// The caller used to pass the last drop stamp and let this compute `now - stamp`. That
+// made the predicate's answer only as good as the stamp's meaning, and the stamp meant
+// the wrong thing twice. It was rewritten by every close, and a close is not once per
+// outage: the panel assigns its socket before the connection resolves, so each REFUSED
+// retry during a restart re-stamped it, and with backoff doubling the successful attempt
+// was separated from the previous failed close by one backoff step. A genuine restart
+// that returned inside ~7s therefore measured ~4s and lost its nudge — the guard reading
+// its own retry cadence instead of the outage.
+//
+// A duration also removes the second reading a bare timestamp allows. `now - stamp` is
+// "time since the last drop, whenever that was", which keeps answering after the outage
+// it described has long ended — so a `ready` repeating on a live socket could be told
+// about a drop from ten minutes and two reconnects ago. What this needs to know is how
+// long THIS connection was gone, and a duration cannot be silently reinterpreted as
+// anything else. The caller measures it once, at the handshake that ended the outage,
+// and reports 0 when a handshake ended no outage.
+//
+// `outageMs` is therefore required to be a positive, finite number of milliseconds:
+// absent, zero, negative or unreadable all mean no outage was measured, and no outage
+// means no nudge.
+export function shouldNudgeAfterMidTaskReconnect({ outageMs = 0, minOutageMs = 6000 } = {}) {
+  if (typeof outageMs !== "number" || !Number.isFinite(outageMs)) return false;
+  // Not `> 0` by accident: a measured outage is a real elapsed duration, so a
+  // non-positive one is the never-dropped sentinel, an ended-and-consumed outage, or a
+  // clock that ran backwards — none of which is evidence that the orchestrator died.
+  if (outageMs <= 0) return false;
+  if (typeof minOutageMs !== "number" || !Number.isFinite(minOutageMs)) return false;
+  return outageMs >= minOutageMs;
+}
+
+// #1145 — the accounting that produces the `outageMs` above.
+//
+// It lives here, as a tracker over injected time, because the defect it fixes is a
+// SEQUENCE and only a sequence can demonstrate it: one close is indistinguishable from
+// another, and what went wrong was that four of them in a row each reset the clock.
+// Nothing about that is visible in a single call, and a source scan over the panel is
+// not an option — #1096's review proved by mutation that token-presence scans over that
+// file stay green when the logic under them is inverted. A tracker can be driven through
+// the real order of events (drop, refused retry, refused retry, handshake) and asked
+// what it measured, which is the one question the bug got wrong.
+//
+// The three events it distinguishes:
+//   noteBridgeClosed()  — a socket closed. The FIRST one opens an outage; every one
+//     after it belongs to the same outage and must not move its start. The panel assigns
+//     its socket at construction, before the connection resolves, so a refused reconnect
+//     attempt arrives here exactly like a genuine drop does.
+//   noteHandshake()     — a real orchestrator handshake landed, which is where an open
+//     outage ENDS and its duration is finally known. A handshake with no outage open is
+//     a re-advertise on a live socket (#310 does one after every free_vram) and records
+//     nothing rather than inheriting the previous outage as if it were its own.
+//   noteTurnStarted()   — a new agent turn began, so outages that ended before it are no
+//     longer evidence about the turn now running. This is what stops a real but settled
+//     drop from being re-read later as this turn's — the #1138 defect with a stale
+//     timestamp in place of the 0 sentinel.
+export function createBridgeOutageTracker({ now = () => Date.now() } = {}) {
+  // When the current outage began; 0 whenever the bridge is up.
+  let startedAt = 0;
+  // The outage the current turn has seen, in ms; 0 means "no drop during this turn".
+  let outageMs = 0;
+  const readClock = () => {
+    const t = now();
+    return typeof t === "number" && Number.isFinite(t) ? t : null;
+  };
+  return {
+    noteBridgeClosed() {
+      if (startedAt) return; // already inside an outage — this close is not a new one
+      const t = readClock();
+      // An unreadable clock cannot start an outage. Leaving startedAt at 0 means the
+      // handshake records no duration, so the nudge is withheld — the safe direction:
+      // a missed nudge leaves an idle agent, an invented one derails a working agent.
+      if (t !== null) startedAt = t;
+    },
+    noteHandshake() {
+      if (!startedAt) return; // ended no outage — records nothing
+      const t = readClock();
+      // Clamped at 0: a backwards wall-clock adjustment mid-outage must not hand the
+      // predicate a negative duration to reason about.
+      if (t !== null) outageMs = Math.max(0, t - startedAt);
+      // Closed either way — an outage whose end could not be timed is still over, and
+      // leaving it open would let the NEXT drop measure from this one's start.
+      startedAt = 0;
+    },
+    noteTurnStarted() {
+      outageMs = 0;
+    },
+    /** The outage the current turn has seen, in ms (0 = none). */
+    outageMs: () => outageMs,
+    /** True while the bridge is down — the outage has begun but not yet ended. */
+    isDown: () => startedAt > 0,
+  };
 }
 
 // #332 — During the post-restart reconnect window a Manager-backed fetch (e.g.


### PR DESCRIPTION
Closes #1145. Follow-up to #1138 (shipped in 0.14.18), which fixed a different defect in the same guard.

The mid-task nudge decides "real restart vs blip" from how long the bridge was gone. The interval it weighed was not that.

## What the investigation established

**The re-stamp is per-attempt, not per-outage — confirmed at the source, not inferred.** `connect()` does `sock = thisSock` immediately after `new WebSocket(url)`, before the connection resolves (`web/js/comfyui-mcp-panel.js`). `isActive()` is `sock === thisSock`, so a REFUSED attempt is still the active socket: its close handler runs in full and re-stamped the drop time. A failed WebSocket handshake fires `error` and then `close` (code 1006) — `close` is not conditional on the connection ever having opened, so the path is reached on every refused retry, not just some. With backoff doubling from `RECONNECT_BASE_MS`, retries land near t=1s/3s/7s/15s and the successful one is separated from the previous failed close by only that attempt's delay. The guard read its own retry cadence.

**Where the outage begins — a clean definition was available.** The first close of a sequence begins it; the handshake that ends it is `markConnected()`, the `models` frame. That is the same line the replay already draws: an open socket only proves something holds the port, a `models` frame proves an orchestrator is behind it. No definition of "when the sequence ends" is needed that depends on the thing being measured — the end is an event, not a timeout. So the honest alternative floated in the draft (drop the clock entirely) was not needed here.

**A second reading of the same guard, found while defining the first.** `Date.now() - stamp` answers "how long since the last drop, whenever that was", and it kept answering after the outage it described had ended. `ready` repeats on a live socket and the panel re-advertises after every successful `free_vram` (#310) — so a turn running ten minutes and two reconnects after a real drop could be told its connection had just dropped. That is #1138's defect with a real timestamp in place of the `0` sentinel; requiring the stamp to be positive does not catch it. Closed here rather than deferred, because it is the same read of the same variable.

**The sibling branches, as a class — audited, and clean.** The reboot-resume branch already decides on an observed drop rather than elapsed time, and says so: *"Elapsed time is not evidence of a new connection; an observed drop is."* The soft-reload branch reads a marker it sets and clears itself, with no clock at all. The mid-task branch was the only one deriving a restart from a clock, so the class turns out to be one instance — this change brings the odd branch in line with the pattern the other two already use.

## The change

`createBridgeOutageTracker()` in `web/js/lib/session-rebind.js`, wired at three points:

| event | wiring | rule |
|---|---|---|
| socket `close` | `noteBridgeClosed()` | the FIRST close opens the outage; refused retries after it do not move its start |
| `markConnected()` | `noteHandshake()` | measures the outage that ENDED here; a handshake that ended none records nothing |
| `onTurn("working")` | `noteTurnStarted()` | evidence is scoped to the turn now running |

`shouldNudgeAfterMidTaskReconnect` now takes a measured `outageMs` instead of `{bridgeDroppedAt, now}`. A duration cannot be silently reinterpreted as "time since something", which is what let one variable mean the wrong thing twice.

## Why a tracker, and why tests over it

The defect is a SEQUENCE — four closes in a row, each resetting the clock. No single call distinguishes the drop from the third refused attempt, so nothing about it is visible in a pure per-call predicate, and a source scan over the panel could not have caught it: #1096's review proved by mutation that token-presence scans over that file stay green when the logic under them is inverted. The tracker is driven through the real order of events and asked what it measured.

Each guard was mutation-checked — the mutant is named, and the test that dies with it:

- re-stamp on every close → *refused retries during a restart must not reset the outage clock*
- a re-advertise inherits the previous outage → *a handshake that ended NO outage inherits nothing*
- turn start stops clearing settled evidence → *an outage that ended BEFORE this turn is not this turn's evidence*
- the outage is never closed out → *a second outage measures itself, not the gap since the first*

## Verification

- `npm run test:unit` — 4012 pass, 0 fail (14 new tests)
- `npm run typecheck` — clean
- `node --check` over all of `web/js/**/*.js`, plus the panel copied to `.mjs` and re-checked as a module (the check the file's own header asks for)
- `python -m py_compile __init__.py`

One neighbouring assertion was bounded to `markConnected`'s BODY rather than a fixed 1600-character window: the window stood in for "inside this function" and stopped meaning that the moment the function grew a comment — a passing assertion turning into a failing one for a reason unrelated to what it checks.
