### PR TITLE
fix(1136): the status pill froze because onStatus threw on every status frame

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "description": "Dev-only Playwright e2e harness for the ComfyUI Agent Panel. NOT shipped with the pack (see .comfyignore).",
   "scripts": {
-    "test:unit": "node scripts/i18n-check.mjs && node scripts/i18n-render-check.mjs && node scripts/check-tool-vocabulary.mjs && node --test browser_tests/unit/*.test.mjs",
+    "test:unit": "node scripts/i18n-check.mjs && node scripts/i18n-render-check.mjs && node scripts/check-tool-vocabulary.mjs && node scripts/check-panel-scope.mjs && node --test browser_tests/unit/*.test.mjs",
+    "check:scope": "node scripts/check-panel-scope.mjs",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:list": "playwright test --list",

--- a/scripts/check-panel-scope.mjs
+++ b/scripts/check-panel-scope.mjs
@@ -1,0 +1,96 @@
+#!/usr/bin/env node
+/**
+ * Fail if the panel references a name that does not resolve.
+ *
+ *   node scripts/check-panel-scope.mjs
+ *
+ * ## Why this exists
+ *
+ * comfyui-mcp-panel#1136: the status pill sat on "disconnected" through a completely healthy
+ * session. The cause was one line — `STATUS_LABEL` was declared inside `createBridgeClient`
+ * and read inside `buildPanel`, which are sibling functions, so the name was never in scope
+ * and `onStatus` threw `ReferenceError` on the FIRST status frame. The socket connected
+ * normally and chat worked, so the only visible symptom was a frozen pill; everything after
+ * that line in the handler (the Connect button label, the dot class, the dead-bridge liveness
+ * fallback) silently never ran.
+ *
+ * The sweep that found it turned up three more of the same shape, one of them hidden inside a
+ * `try/catch` that was meant to guard something else entirely.
+ *
+ * ## Why it is tsc and not a regex
+ *
+ * Two hand-rolled detectors were written first and both were measured and thrown away:
+ *
+ *   - "an identifier declared in one top-level function and used in another" reported 494
+ *     findings on the buggy file and 493 on the fixed one. Common local names (`token`,
+ *     `nodes`, `rootGraph`) drown the signal completely.
+ *   - "ALL_CAPS constants must live at module scope" flags 57 constants that are correctly
+ *     function-local.
+ *
+ * Neither could separate the bug from the noise, because the question is genuinely about
+ * lexical scope and only a parser knows the answer. `tsc --checkJs` already does exactly this
+ * analysis; it just was not pointed at `web/js` (tsconfig covers only the TypeScript under
+ * browser_tests, plus the Playwright config).
+ * TS2304 "Cannot find name" is the whole signal — every other diagnostic is ignored, so this
+ * is not a typing gate and untyped JS stays untyped.
+ */
+import { execFileSync } from 'node:child_process';
+import path from 'node:path';
+
+const ROOT = path.resolve(import.meta.dirname, '..');
+
+/**
+ * Names that genuinely exist at runtime but that no type declaration describes.
+ * ComfyUI installs LiteGraph as a browser global; the vendored Lit bundle refers to its own
+ * internals across its minified chunks. Keep this list short — every entry is a name nothing
+ * can check for you.
+ */
+const ALLOWED = new Set(['LiteGraph', 'litPropertyMetadata']);
+
+/** Vendored bundles are third-party build output; we do not police their internals. */
+const IGNORED_PATH = /[\\/]vendor[\\/]/;
+
+const ENTRIES = ['web/js/comfyui-mcp-panel.js'];
+
+let raw = '';
+try {
+  execFileSync(
+    process.execPath,
+    [
+      path.join(ROOT, 'node_modules', 'typescript', 'bin', 'tsc'),
+      '--noEmit', '--allowJs', '--checkJs',
+      '--target', 'ES2022', '--module', 'ES2022', '--moduleResolution', 'bundler',
+      '--lib', 'ES2022,DOM,DOM.Iterable',
+      '--skipLibCheck',
+      ...ENTRIES,
+    ],
+    { cwd: ROOT, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] },
+  );
+} catch (e) {
+  // tsc exits non-zero whenever it emits ANY diagnostic, and this file is full of ordinary
+  // untyped-JS complaints. A non-zero exit is expected; the diagnostics are the payload.
+  raw = `${e.stdout ?? ''}${e.stderr ?? ''}`;
+}
+
+const findings = [];
+for (const line of raw.split('\n')) {
+  const m = line.match(/^(.*?)\((\d+),(\d+)\): error TS2304: Cannot find name '([^']+)'/);
+  if (!m) continue;
+  const [, file, ln, , name] = m;
+  if (IGNORED_PATH.test(file)) continue;
+  if (ALLOWED.has(name)) continue;
+  findings.push({ file, line: Number(ln), name });
+}
+
+if (findings.length) {
+  console.error(`[check-panel-scope] FAIL — ${findings.length} unresolved name(s):\n`);
+  for (const f of findings) console.error(`  ${f.file}:${f.line}  ${f.name}`);
+  console.error(
+    '\nEach of these throws ReferenceError the moment that line runs. The usual cause is a ' +
+      'declaration sitting in a sibling function rather than a shared scope — move it, or ' +
+      'import it. If the name is a real runtime global nothing declares, add it to ALLOWED ' +
+      'with a reason.',
+  );
+  process.exit(1);
+}
+console.log(`[check-panel-scope] OK — every name in ${ENTRIES.join(', ')} resolves.`);

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -62,6 +62,9 @@
 // shim can throw synchronously and deadlock the module loader. We grab them from
 // window.comfyAPI once it's ready instead (see registerExtensionWhenReady at the
 // bottom). Deferral approach contributed by @FreesoSaiFared.
+// Used by the unpack preflight's divergence scan. It was called without ever being imported,
+// so that path threw ReferenceError rather than refusing cleanly (#1136 sweep).
+import { resolvePromotedInnerTarget } from "./lib/widget-write.js";
 import { marked } from "./vendor/marked.esm.js";
 import DOMPurify from "./vendor/purify.es.js";
 import qrcodegen from "./vendor/qrcode.esm.js";
@@ -518,6 +521,30 @@ let armRunReconcileSweepRef = null;
 // no perpetual timer; a redundant sweep is harmless (reconcile is idempotent — the
 // delivered/terminal fences make double-delivery unreachable).
 const RUN_RECONCILE_SWEEP_MS = 20000;
+
+/**
+ * Display label per connection status. The KEY is the state token, which stays English because
+ * it is compared and keyed on all over the panel; only the VALUE is translated. Each value is a
+ * function so the catalog is read at paint time — a plain string here would capture the English
+ * fallback at import, before loadCatalog() has run, and freeze the pill in English forever.
+ *
+ * Every key is a literal so `i18n-extract` can see it. That is the whole point: the shape this
+ * replaced built the key at runtime, which no static scan can follow.
+ *
+ * MODULE SCOPE, deliberately (#1136). This was first written inside `createBridgeClient`, while
+ * its only reader — `onStatus` — lives in `buildPanel`. Those are sibling functions, so the name
+ * was never in scope at the point of use and `onStatus` threw `ReferenceError` on the FIRST
+ * status frame. The socket still connected and chat worked normally, so the visible symptom was
+ * a status pill frozen on "disconnected" during a perfectly healthy session — and everything
+ * below that line in the handler (the Connect button label, the dot class, the dead-bridge
+ * liveness fallback) silently never ran either. Keep this at module scope; the guard in
+ * browser_tests/unit/status-label-scope.test.mjs fails if it moves back inside a function.
+ */
+const STATUS_LABEL = {
+  connected: () => tr("panel.status_connected", "connected"),
+  connecting: () => tr("panel.status_connecting", "connecting"),
+  disconnected: () => tr("panel.status_disconnected", "disconnected"),
+};
 
 // Execution-error capture so graph_get_errors can report the most recent failure
 // even if it predates the agent's question. Wired once `api` is ready (via
@@ -17077,20 +17104,6 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
       void sendHello();
     }, ROUTE_REFUSAL_RETRY_MS);
   }
-  /**
-   * Display label per connection status. The KEY of this map is the state token, which stays
-   * English because it is compared (`s !== "connected"` below) and keyed on elsewhere; only
-   * the VALUE is translated. Lazily via a function because this sits at module-adjacent scope
-   * and would otherwise capture the fallback before the catalog loads.
-   *
-   * Every key is a literal so `i18n-extract` can see it. That is the whole point: the previous
-   * shape built the key at runtime, which no static scan can follow.
-   */
-  const STATUS_LABEL = {
-    connected: () => tr("panel.status_connected", "connected"),
-    connecting: () => tr("panel.status_connecting", "connecting"),
-    disconnected: () => tr("panel.status_disconnected", "disconnected"),
-  };
   function emitStatus(s) {
     if (s === lastStatus && s !== "connected") return;
     lastStatus = s;
@@ -17098,7 +17111,10 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
     // working), the provider-onboarding card is moot — hide it regardless of the
     // readiness probe, which can be wrong (e.g. a CLI the orchestrator's PATH
     // can't see). try/catch guards the case where the card isn't built yet.
-    if (s === "connected") { try { onboard.hidden = true; } catch {} }
+    // The onboarding card is hidden by the PANEL's own onStatus handler, which is where
+    // `onboard` actually lives. This used to reach for it from here — a sibling scope — so it
+    // threw ReferenceError on every connect, and the try/catch that was meant to guard "the
+    // card isn't built yet" swallowed that instead. The card simply never auto-hid.
     // #952 — the SOCKET this status is about. `"connected"` re-fires on every
     // re-handshake, so the string alone cannot distinguish a replacement connection
     // from the live one saying hello again; the id can, and a consumer that ignores
@@ -21120,6 +21136,11 @@ function buildPanel() {
     custom: { label: tr("panel.custom_endpoint_any_openai_compatible", "Custom endpoint (any OpenAI-compatible)"), install: "", login: tr("panel.set_the_base_url_and_api_key", "Set the base URL (and API key if needed) in Settings › Custom endpoint") },
   };
   let anyReady = false;
+  // The last connection status THIS panel was told about. The bridge client keeps its own
+  // `lastStatus` for de-duping, but that lives in `createBridgeClient` — a sibling scope — so
+  // reading it from here threw ReferenceError and took the whole provider-list render with it
+  // (#1136). The panel has to remember what it was handed.
+  let liveStatus = null;
   // (autoPickDone is module-scoped now — once per PAGE, not per mount, so workflow
   // switches can't re-arm the spurious provider fallback.)
   const onboard = document.createElement("div");
@@ -21225,7 +21246,7 @@ function buildPanel() {
     anyReady = typeof data?.any_ready === "boolean" ? data.any_ready : list.some((b) => b.ready);
     // Never show the setup card while connected — a live agent means a provider
     // works, whatever the probe reports.
-    if (list.length && !anyReady && lastStatus !== "connected") {
+    if (list.length && !anyReady && liveStatus !== "connected") {
       renderOnboard(list);
       onboard.hidden = false;
     } else {
@@ -26534,6 +26555,12 @@ function buildPanel() {
       // unknown status falls back to the raw token, which is the current behaviour anyway.
       // Described, not illustrated: writing the rejected form here would trip the guard.
       statusText.textContent = STATUS_LABEL[state]?.() ?? state;
+      liveStatus = state;
+      // Once the agent is up, a provider demonstrably works, so the setup card is moot
+      // whatever the readiness probe says. This side effect used to live in the client's
+      // emitStatus, which cannot see `onboard`. try/catch still guards the genuine case the
+      // original comment described: a status arriving before the card is built.
+      if (state === "connected") { try { onboard.hidden = true; } catch {} }
       // #952 — a card painted on a connection that has since been REPLACED can no longer
       // deliver an answer. The trigger is the socket's identity, not the status string:
       // `"connected"` re-fires on every re-handshake (each `models` frame, and a workflow


### PR DESCRIPTION
Reported as *"the connect button no longer changes from disconnected/connecting/connected — it's permanently stuck at disconnected even when I can chat with it no problem."*

Both halves of that sentence are the diagnosis: the socket was healthy, and the handler that paints the pill was dead.

```
ReferenceError: STATUS_LABEL is not defined
    at onStatus   (comfyui-mcp-panel.js:26477)
    at emitStatus (:17047)
    at connect    (:17286)
    at start      (:18444)
    at connectAgent (:28904)
```

`STATUS_LABEL` was declared inside `createBridgeClient` and read inside `buildPanel` — **sibling functions**, so the name was never in scope. `onStatus` threw on the *first* status frame, and everything below that line never ran: the pill, the dot class, the Connect button label, and the #1136 dead-bridge liveness fallback that exists to rescue precisely this user. The transport is independent of the handler, so chat kept working and nothing else looked wrong.

I introduced this in `d597551d` while fixing the pill's class-4 defect. The suite stayed green because nothing drives `onStatus` end-to-end and the pill's *initial* text is already correct. I also looked directly at a frozen pill during a live verification earlier today and rationalised it.

## Three more of the same shape, all pre-existing

| identifier | where | effect |
|---|---|---|
| `lastStatus` | read in `buildPanel`, declared in `createBridgeClient` | threw in the provider-list render |
| `onboard` | read in `createBridgeClient`, declared in `buildPanel` | "hide the setup card once connected" threw on every connect — and the `try/catch` meant to guard *"the card isn't built yet"* swallowed it, so the card never auto-hid |
| `resolvePromotedInnerTarget` | called twice, never imported (though `lib/widget-write.js` exports it) | the unpack preflight threw instead of refusing cleanly |

## Why the gate is `tsc` and not a regex

Two hand-rolled detectors were written first, measured, and thrown away:

- *"an identifier declared in one top-level function and used in another"* → **494** findings on the broken file, **493** on the fixed one. Common local names (`token`, `nodes`, `rootGraph`) drown the signal.
- *"ALL_CAPS constants must live at module scope"* → flags **57** constants that are correctly function-local.

Lexical scope is a parser's question. `tsconfig` only ever covered the TypeScript under `browser_tests`, so `tsc --checkJs` had never been pointed at this file. `scripts/check-panel-scope.mjs` runs it and fails **only** on `TS2304 Cannot find name` — it is not a typing gate, and untyped JS stays untyped. Two genuine runtime globals (`LiteGraph`, and the vendored Lit bundle's internals) are allowlisted; vendor paths are ignored.

## Verification

- **Mutation-proven**: clean tree → `OK`; moving `STATUS_LABEL` back inside `createBridgeClient` → `FAIL … web/js/comfyui-mcp-panel.js:26558 STATUS_LABEL`.
- `npm run test:unit` → **4033 pass, 0 fail**, with the scope gate wired in ahead of the test run.
- Locale gate, render check and vocabulary gate all clean.

## Note for the reporter

The frozen pill also masked a *second*, separate problem on this machine, which is what #1136 was originally about: `comfyui-mcp.bridgeUrl.claude` is `ws://127.0.0.1:52727`, which is **not listening**, while the live bridge is on **9180** (`bridgeUrl.single`, pid 60224). With `defaultBackend: claude` and `externalOrchestrator: true`, the panel dials the dead port and never self-heals. The liveness fallback added in #1137 is supposed to notice and switch — but it is invoked from `showExternalHintOnce`, which is reached *from the handler that was throwing*. With this fix in place that fallback can finally run.