### PR TITLE
fix(803): an empty baseline is not proof of a different graph, and say what actually recovers

### DIFF
--- a/browser_tests/unit/empty-baseline-deadend.test.mjs
+++ b/browser_tests/unit/empty-baseline-deadend.test.mjs
@@ -1,0 +1,111 @@
+// comfyui-mcp#803 — after a ComfyUI reconnect the agent was left with NO working
+// recovery path.
+//
+//   panel_graph_outline  -> "the workflow reports 0 node(s), but the canvas is bound to
+//                            a different graph ... Re-open the active workflow tab"
+//   panel_list_workflows -> healthy: active_confirmed: true, active: true, persisted: true
+//   panel_open_workflow  -> "could not prove that the active canvas was rebound"
+//
+// One tool says broken, one says fine, and the repair the error recommends is refused.
+// The loop is documented in graph-binding.js for #701: the captured state is refreshed
+// only after a command SUCCEEDS, so the refusal blocks the thing that would clear it.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import {
+  isEmptyBaselineMismatch,
+  emptyBaselineNote,
+  emptyBaselineRemedy,
+} from "../../web/js/lib/empty-baseline-deadend.js";
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "../..");
+
+test("#803 the reporter's shape is recognised", () => {
+  assert.equal(isEmptyBaselineMismatch({ expected: 0, live: 14 }), true);
+});
+
+test("#803 a NON-empty baseline is not this case", () => {
+  // A real size disagreement between two populated graphs keeps the existing wording;
+  // this fix must not swallow it.
+  assert.equal(isEmptyBaselineMismatch({ expected: 3, live: 14 }), false);
+  assert.equal(isEmptyBaselineMismatch({ expected: 14, live: 3 }), false);
+});
+
+test("#803 an empty CANVAS is not this case either", () => {
+  // 0 live nodes means the canvas is empty; that is the opposite situation and the
+  // empty-baseline reasoning does not apply.
+  assert.equal(isEmptyBaselineMismatch({ expected: 0, live: 0 }), false);
+  assert.equal(isEmptyBaselineMismatch({ expected: 5, live: 0 }), false);
+});
+
+test("#803 unmeasured sizes never trigger it", () => {
+  for (const bad of [
+    { expected: undefined, live: 14 },
+    { expected: 0, live: undefined },
+    { expected: null, live: 14 },
+    { expected: 0, live: Number.NaN },
+    {},
+    undefined,
+  ]) {
+    assert.equal(isEmptyBaselineMismatch(bad), false, JSON.stringify(bad));
+  }
+});
+
+test("#803 the note does NOT assert a different canvas", () => {
+  // The whole defect: "cannot determine" was being rendered as "is not the case".
+  const n = emptyBaselineNote(14);
+  assert.doesNotMatch(n, /bound to a different graph/);
+  assert.match(n, /does NOT establish a different canvas/);
+  assert.match(n, /indistinguishable from here/);
+});
+
+test("#803 the note still says the command was not applied", () => {
+  // Softening the claim must not soften the OUTCOME — nothing ran.
+  assert.match(emptyBaselineNote(14), /was NOT applied/);
+});
+
+test("#803 the note names the real cause and the live count", () => {
+  const n = emptyBaselineNote(14);
+  assert.match(n, /14 node\(s\)/);
+  assert.match(n, /captures a workflow's ?\n? ?state on user input/);
+  assert.match(n, /reconnect or a ComfyUI restart/);
+});
+
+test("#803 the remedy names the step that WORKS", () => {
+  const r = emptyBaselineRemedy();
+  assert.match(r, /Reload the panel/);
+  assert.match(r, /known to clear this/);
+});
+
+test("#803 the remedy warns that re-opening may not clear it", () => {
+  // Recommending only that is what made this a dead end.
+  const r = emptyBaselineRemedy();
+  assert.match(r, /Re-opening the workflow may NOT/);
+  assert.match(r, /only after a command SUCCEEDS/);
+  assert.match(r, /the repair\s+that would refresh it is itself blocked/);
+});
+
+test("#803 the remedy still allows for a genuinely wrong canvas", () => {
+  // The refusal may be correct. If a reload does not clear it, say what that means
+  // rather than leaving the reader believing the tool is simply broken.
+  assert.match(emptyBaselineRemedy(), /really is bound elsewhere/);
+});
+
+test("#803 WIRING: the empty-baseline branch replaces claim AND remedy", () => {
+  const src = readFileSync(join(ROOT, "web/js/lib/graph-binding.js"), "utf8");
+  assert.match(src, /import \{[\s\S]*?isEmptyBaselineMismatch,[\s\S]*?\} from "\.\/empty-baseline-deadend\.js";/);
+  assert.match(src, /const emptyBaseline = sizesDisagree && isEmptyBaselineMismatch\(\{ expected, live \}\)/);
+  assert.match(src, /emptyBaseline\s*\n?\s*\? emptyBaselineNote\(live\)/);
+  // The remedy must be REPLACED, not appended — the standing advice is the dead end.
+  assert.match(src, /const finalRemedy = emptyBaseline \? emptyBaselineRemedy\(\) : remedy;/);
+});
+
+test("#803 WIRING: the ordinary size-disagreement wording survives", () => {
+  // This fix is scoped to expected === 0. A real mismatch between two populated graphs
+  // must still say what it always said.
+  const src = readFileSync(join(ROOT, "web/js/lib/graph-binding.js"), "utf8");
+  assert.match(src, /it is bound to a `? ?\+?\s*`?different graph/);
+});

--- a/browser_tests/unit/empty-baseline-deadend.test.mjs
+++ b/browser_tests/unit/empty-baseline-deadend.test.mjs
@@ -76,7 +76,7 @@ test("#803 the note names the real cause and the live count", () => {
 
 test("#803 the remedy names the step that WORKS", () => {
   const r = emptyBaselineRemedy();
-  assert.match(r, /Reload the panel/);
+  assert.match(r, /reload the panel/i);
   assert.match(r, /known to clear this/);
 });
 
@@ -88,10 +88,24 @@ test("#803 the remedy warns that re-opening may not clear it", () => {
   assert.match(r, /the repair\s+that would refresh it is itself blocked/);
 });
 
-test("#803 the remedy still allows for a genuinely wrong canvas", () => {
-  // The refusal may be correct. If a reload does not clear it, say what that means
-  // rather than leaving the reader believing the tool is simply broken.
-  assert.match(emptyBaselineRemedy(), /really is bound elsewhere/);
+test("#803 the remedy warns about unsaved work BEFORE advising a reload", () => {
+  // Review caught this as a data-loss risk, and it is: a reload discards unsaved graph
+  // edits, and this is a READ refusing — nothing here is worth losing work over.
+  const r = emptyBaselineRemedy();
+  assert.match(r, /SAVE ANY UNSAVED CANVAS WORK FIRST/);
+  assert.match(r, /discards unsaved graph edits/);
+  // The warning must come before the instruction, not as a trailing footnote.
+  assert.ok(r.indexOf("SAVE ANY UNSAVED") < r.indexOf("reload the panel"));
+});
+
+test("#803 the remedy does not swap one over-claim for another", () => {
+  // The first cut removed "bound to a different graph" and then asserted "the canvas
+  // really IS bound elsewhere" if a reload did not help — the same defect, in the fix
+  // for it. A reload can fail to re-capture for other reasons.
+  const r = emptyBaselineRemedy();
+  assert.doesNotMatch(r, /really is bound elsewhere/);
+  assert.match(r, /no longer\s+the likely explanation/);
+  assert.match(r, /does not prove the canvas is bound elsewhere/);
 });
 
 test("#803 WIRING: the empty-baseline branch replaces claim AND remedy", () => {

--- a/browser_tests/unit/empty-baseline-deadend.test.mjs
+++ b/browser_tests/unit/empty-baseline-deadend.test.mjs
@@ -123,3 +123,19 @@ test("#803 WIRING: the ordinary size-disagreement wording survives", () => {
   const src = readFileSync(join(ROOT, "web/js/lib/graph-binding.js"), "utf8");
   assert.match(src, /it is bound to a `? ?\+?\s*`?different graph/);
 });
+
+test("#803 WIRING: interpolated content is not reflowed", () => {
+  // The empty `cause` in this branch was absorbed with a global whitespace collapse,
+  // which also rewrote verdict.reason and the existing remedy — a disclosure regression
+  // outside this change's stated scope (review). Non-empty parts are joined instead.
+  //
+  // Asserted with plain string containment: a regex spanning a line break here is how
+  // this test got written wrong twice.
+  const src = readFileSync(join(ROOT, "web/js/lib/graph-binding.js"), "utf8");
+  assert.ok(
+    !src.includes('.replace(\n    /\\s+/g,'),
+    "the whole-message whitespace collapse must be gone",
+  );
+  assert.ok(src.includes("const parts = [emptyBaseline ? expectation :"));
+  assert.ok(src.includes('parts.join(" ")'));
+});

--- a/web/js/lib/empty-baseline-deadend.js
+++ b/web/js/lib/empty-baseline-deadend.js
@@ -1,0 +1,90 @@
+/**
+ * comfyui-mcp#803 — after a ComfyUI reconnect the agent was left with NO working
+ * recovery path.
+ *
+ * The reported sequence:
+ *
+ *   panel_graph_outline  -> "the workflow reports 0 node(s), but the canvas is bound
+ *                            to a different graph ... Re-open the active workflow tab
+ *                            (panel_open_workflow) or reload the panel"
+ *   panel_list_workflows -> healthy: active_confirmed: true, the workflow present in
+ *                            open[] with active: true, persisted: true
+ *   panel_open_workflow  -> "could not prove that the active canvas was rebound"
+ *
+ * One tool says broken, one says fine, and the repair the error itself recommends is
+ * refused. That is worse than any single wrong answer: there is no exit.
+ *
+ * ## Why the two tools disagree
+ *
+ * They read different sources. `panel_list_workflows` reads the workflow store, which
+ * was genuinely healthy. The refusal compares ChangeTracker's `activeState` against the
+ * live root graph — and ChangeTracker captures on USER INPUT, so after a restart it can
+ * hold an EMPTY baseline for a workflow whose canvas is fully populated.
+ *
+ * ## What is not earned
+ *
+ * With `expected = 0` and a populated canvas on a CLEAN tab, "it is bound to a
+ * different graph" is a conclusion the evidence does not support. An empty baseline and
+ * a wrong canvas look identical from here, and the far more common cause after a
+ * reconnect is the baseline. Stating the conclusion is the #796 shape: "cannot
+ * determine" rendered as "is not the case".
+ *
+ * ## Why the remedy made it a dead end
+ *
+ * This file already documents the loop, for #701: the tracker re-baselines only after a
+ * command SUCCEEDS. So the refusal blocks the very thing that would refresh the
+ * baseline; `workflow_open`'s repaint re-runs the same hook, so its own proof fails;
+ * and the retried read fails identically. Its note ends: "Only a page reload broke the
+ * loop." The refusal was recommending the two levers that cannot work while omitting
+ * the one that does.
+ *
+ * ## Scope
+ *
+ * DISCLOSURE ONLY. What gets refused is unchanged — #565 deliberately rejected a
+ * blanket zero-node skip, because a zero-node state can still carry real content
+ * (subgraphs, groups, reroutes, links), and relitigating that without a measurement is
+ * how a binding guard stops guarding. This changes what the refusal CLAIMS, and what it
+ * tells the reader to do.
+ */
+
+/** Is this the empty-baseline shape: nothing captured, but a populated canvas? */
+export function isEmptyBaselineMismatch({ expected, live } = {}) {
+  return (
+    Number.isFinite(expected) && Number.isFinite(live) && expected === 0 && live > 0
+  );
+}
+
+/**
+ * What the refusal should SAY when the baseline is empty.
+ *
+ * Deliberately does not assert which of the two causes it is — that is the whole point
+ * — and names the recovery that is known to work, plus the reason the obvious ones
+ * may not.
+ */
+export function emptyBaselineNote(live) {
+  return (
+    `the workflow's last captured state is EMPTY while the live canvas holds ${live} ` +
+    `node(s). That does NOT establish a different canvas: the panel captures a workflow's ` +
+    `state on user input, so a reconnect or a ComfyUI restart can leave the captured ` +
+    `state empty for a canvas that is perfectly correct. An empty baseline and a wrong ` +
+    `canvas are indistinguishable from here, so this command was NOT applied.`
+  );
+}
+
+/**
+ * The remedy for that case.
+ *
+ * `panel_open_workflow` is named as something that MAY not clear it, because the
+ * re-baseline only happens after a command succeeds — so recommending it alone is what
+ * turned this into a loop (#803, mechanism recorded under #701).
+ */
+export function emptyBaselineRemedy() {
+  return (
+    `Reload the panel (or the browser tab) to rebuild the captured state — that is the ` +
+    `step known to clear this. Re-opening the workflow may NOT: the captured state is ` +
+    `refreshed only after a command SUCCEEDS, so while this refusal stands, the repair ` +
+    `that would refresh it is itself blocked (comfyui-mcp#803). If a reload does not ` +
+    `clear it, the canvas really is bound elsewhere — check which workflow tab is ` +
+    `active before retrying.`
+  );
+}

--- a/web/js/lib/empty-baseline-deadend.js
+++ b/web/js/lib/empty-baseline-deadend.js
@@ -80,11 +80,15 @@ export function emptyBaselineNote(live) {
  */
 export function emptyBaselineRemedy() {
   return (
-    `Reload the panel (or the browser tab) to rebuild the captured state — that is the ` +
-    `step known to clear this. Re-opening the workflow may NOT: the captured state is ` +
-    `refreshed only after a command SUCCEEDS, so while this refusal stands, the repair ` +
-    `that would refresh it is itself blocked (comfyui-mcp#803). If a reload does not ` +
-    `clear it, the canvas really is bound elsewhere — check which workflow tab is ` +
-    `active before retrying.`
+    `SAVE ANY UNSAVED CANVAS WORK FIRST, then reload the panel (or the browser tab) to ` +
+    `rebuild the captured state — that is the step known to clear this. The save warning ` +
+    `is not boilerplate: a reload discards unsaved graph edits, and this is a READ ` +
+    `refusing, so nothing here is worth losing work over. Re-opening the workflow may ` +
+    `NOT clear it: the captured state is refreshed only after a command SUCCEEDS, so ` +
+    `while this refusal stands, the repair that would refresh it is itself blocked ` +
+    `(comfyui-mcp#803). If a reload does not clear it, the empty baseline is no longer ` +
+    `the likely explanation — check which workflow tab is actually active before ` +
+    `retrying, but note a reload can also fail to re-capture for other reasons, so this ` +
+    `still does not prove the canvas is bound elsewhere.`
   );
 }

--- a/web/js/lib/graph-binding.js
+++ b/web/js/lib/graph-binding.js
@@ -1,4 +1,9 @@
 import { definitionsDifferOnlyByLinkRenumber } from "./definitions-renumber.js";
+import {
+  isEmptyBaselineMismatch,
+  emptyBaselineNote,
+  emptyBaselineRemedy,
+} from "./empty-baseline-deadend.js";
 /**
  * Detect a graph READ that is out of sync with the ACTIVE workflow (panel#389).
  *
@@ -2279,7 +2284,16 @@ export function graphBindingRefusalMessage(verdict) {
       `session, it does not rebind the canvas.`
     );
   }
-  const expectation = sizesDisagree
+  // #803 — an EMPTY baseline against a populated canvas is not evidence of a different
+  // graph. The panel captures a workflow's state on user input, so a reconnect or a
+  // ComfyUI restart can leave it empty for a canvas that is perfectly correct. Asserting
+  // "bound to a different graph" here is the #796 shape: cannot-determine rendered as
+  // is-not-the-case. What gets REFUSED is unchanged (#565 rejected a zero-node skip);
+  // only the claim is.
+  const emptyBaseline = sizesDisagree && isEmptyBaselineMismatch({ expected, live });
+  const expectation = emptyBaseline
+    ? emptyBaselineNote(live)
+    : sizesDisagree
     ? `the workflow reports ${expected} node(s) but the live canvas holds ${live} — it is bound to a ` +
       `different graph`
     : measured && expected > 0
@@ -2295,13 +2309,24 @@ export function graphBindingRefusalMessage(verdict) {
   // disagreement at equal size does not even establish that much: it is exactly
   // the ambiguity above, and resolving it in the text is how this message misled
   // three readers.
-  const cause = sizesDisagree
+  const cause = emptyBaseline
+    ? ""
+    : sizesDisagree
     ? `The canvas therefore holds a graph other than the one the workflow describes, so this ` +
       `command was NOT applied. A load, tab switch or reconnect leaving the command on the wrong ` +
       `canvas is the usual explanation — the panel observed the mismatch, not the event.`
     : `The panel cannot tell whether this is a DIFFERENT workflow's canvas or this workflow's own ` +
       `canvas drifted from the state it last captured, so it was NOT applied.`;
-  return `[${verdict.reason}] The live graph is out of sync with the active workflow: ${expectation}. ${cause} ${remedy}`;
+  // #803 — the remedy is REPLACED for the empty-baseline case, not appended to. The
+  // standing advice ("re-open the active workflow tab") is what turned this into a
+  // dead end: the captured state is refreshed only after a command SUCCEEDS, so while
+  // this refusal stands the repair that would refresh it is itself blocked, and the
+  // retry fails identically. A reload is the step known to break the loop.
+  const finalRemedy = emptyBaseline ? emptyBaselineRemedy() : remedy;
+  return `[${verdict.reason}] The live graph is out of sync with the active workflow: ${expectation} ${cause} ${finalRemedy}`.replace(
+    /\s+/g,
+    " ",
+  );
 }
 
 /**

--- a/web/js/lib/graph-binding.js
+++ b/web/js/lib/graph-binding.js
@@ -2323,10 +2323,16 @@ export function graphBindingRefusalMessage(verdict) {
   // this refusal stands the repair that would refresh it is itself blocked, and the
   // retry fails identically. A reload is the step known to break the loop.
   const finalRemedy = emptyBaseline ? emptyBaselineRemedy() : remedy;
-  return `[${verdict.reason}] The live graph is out of sync with the active workflow: ${expectation} ${cause} ${finalRemedy}`.replace(
-    /\s+/g,
-    " ",
+  // Join the non-empty parts rather than collapsing whitespace across the whole
+  // string. The collapse was only there to absorb the empty `cause` in this branch,
+  // and review was right that it overreached: it rewrote INTERPOLATED content too
+  // (verdict.reason, the existing remedy), so a value carrying meaningful newlines or
+  // repeated spaces would have been silently reflowed. This change is scoped to the
+  // claim and the remedy; it has no business touching either of those.
+  const parts = [emptyBaseline ? expectation : `${expectation}.`, cause, finalRemedy].filter(
+    (s) => typeof s === "string" && s.trim() !== "",
   );
+  return `[${verdict.reason}] The live graph is out of sync with the active workflow: ${parts.join(" ")}`;
 }
 
 /**


### PR DESCRIPTION
Claims comfyui-mcp#803 — the oldest open bug, and a recovery **dead end** rather than a single wrong answer.

After a ComfyUI restart mid-session:
1. `panel_graph_outline` refuses: *the workflow reports 0 node(s), but the canvas is bound to a different graph* — and tells the agent to run `panel_open_workflow`.
2. `panel_list_workflows` reports a healthy state: `active_confirmed: true`, present in `open[]` with `active: true, persisted: true`.
3. The suggested repair fails too: *workflow_open could not prove that the active canvas was rebound*.

So one tool says broken, one says fine, and the documented recovery is refused. There is no exit.

**Located.** `graph-binding.js` compares ChangeTracker's `activeState.nodes` against `rootGraph._nodes`; a size disagreement asserts *"it is bound to a different graph"*. With `expected = 0` that assertion is not earned — a 0-node baseline on a CLEAN tab is far more likely one the tracker never captured after the restart than a genuinely different canvas.

The dead end is documented in this file already, for #701: the tracker re-baselines only after a command SUCCEEDS, so the refusal blocks the very thing that would refresh it, `workflow_open`'s own proof fails identically, and *"only a page reload broke the loop"*.

**Scope: disclosure only.** This does NOT change what is refused — #565 explicitly rejected a blanket zero-node skip, and I am not relitigating that without a measurement. It changes what the refusal CLAIMS and what it tells you to do, so the reader is not sent into a loop by the error itself.

Note: I opened comfyui-mcp#1485 for this earlier, which was the wrong repo — the code is panel-side. That PR will be closed and pointed here.