### PR TITLE
fix(1163): a turn start closes the outage; a panel-driven respawn opens one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,13 +23,17 @@ All notable changes to this project are documented here. This project adheres to
   settles the reconnect case for the right reason — an orchestrator that survived
   re-announces its live turn and is left alone, while one that died has no turn to
   re-announce, so its nudge still fires.
-  Separately, the panel's own automatic recovery — reclaiming, respawning or redialling a
-  wedged orchestrator — tore the socket down by a path that never recorded an outage at
-  all. That is a real orchestrator death with the turn already lost, so the resumed
-  session had nothing pending and no nudge was sent: the agent simply stopped, after the
-  panel's own recovery killed its work. All three teardowns now record the outage they
-  cause. Deliberate teardowns (Disconnect, provider switch, reload) are unaffected, as
-  they retire the pending turn on their own paths.
+  Separately, when the panel itself replaces a WEDGED orchestrator — one holding an open
+  socket while answering nothing — no outage was recorded at all. A wedged orchestrator
+  never closes its connection, so the drop that normally starts the clock never happens,
+  and the panel force-kills and respawns it instead. That is a real death with the turn
+  already lost, so the resumed session had nothing pending and no nudge was sent: the
+  agent simply stopped, after the panel's own recovery killed its work. The two
+  recoveries that replace a wedged orchestrator now record it. Deliberate teardowns —
+  Disconnect, provider switch, reload, and any change of bridge address — deliberately do
+  not, since nothing died; they are pinned against it in both directions, because an
+  earlier attempt at this fix recorded an outage for all of them and would have told
+  agents whose orchestrator never died that their connection had dropped.
 
 - **The mid-task resume nudge now measures the outage instead of one backoff step, so a
   ComfyUI restart that comes back quickly keeps its nudge (#1145).** The nudge tells a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,29 @@ All notable changes to this project are documented here. This project adheres to
 
 ### Fixed
 
+- **The mid-task nudge no longer fires on a turn you just started, and now fires when the
+  panel itself respawns a wedged orchestrator (#1163).** Two defects in the outage
+  accounting added for #1145, found by review of that change rather than in the wild.
+  A turn beginning while the bridge was still down zeroed the measured outage but left
+  the outage itself running, so it was later measured from before that turn existed.
+  Reachable in ordinary use: sending a message needs only an open socket, not a completed
+  handshake, and the socket comes back well before the model list does — so typing into
+  that gap could draw "your connection dropped mid-task — continue exactly what you were
+  doing" on top of the message just sent, making the agent restart or duplicate the work
+  it was asked to do. A turn start now ENDS the outage rather than only zeroing the
+  total, which is also better evidence than the clock it replaces: the frame that starts a
+  turn comes FROM the orchestrator, so receiving it proves the orchestrator is alive. That
+  settles the reconnect case for the right reason — an orchestrator that survived
+  re-announces its live turn and is left alone, while one that died has no turn to
+  re-announce, so its nudge still fires.
+  Separately, the panel's own automatic recovery — reclaiming, respawning or redialling a
+  wedged orchestrator — tore the socket down by a path that never recorded an outage at
+  all. That is a real orchestrator death with the turn already lost, so the resumed
+  session had nothing pending and no nudge was sent: the agent simply stopped, after the
+  panel's own recovery killed its work. All three teardowns now record the outage they
+  cause. Deliberate teardowns (Disconnect, provider switch, reload) are unaffected, as
+  they retire the pending turn on their own paths.
+
 - **The mid-task resume nudge now measures the outage instead of one backoff step, so a
   ComfyUI restart that comes back quickly keeps its nudge (#1145).** The nudge tells a
   resumed agent its connection dropped mid-task and to continue what it was doing, and it

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,32 +8,22 @@ All notable changes to this project are documented here. This project adheres to
 
 ### Fixed
 
-- **The mid-task nudge no longer fires on a turn you just started, and now fires when the
-  panel itself respawns a wedged orchestrator (#1163).** Two defects in the outage
-  accounting added for #1145, found by review of that change rather than in the wild.
-  A turn beginning while the bridge was still down zeroed the measured outage but left
-  the outage itself running, so it was later measured from before that turn existed.
-  Reachable in ordinary use: sending a message needs only an open socket, not a completed
-  handshake, and the socket comes back well before the model list does — so typing into
-  that gap could draw "your connection dropped mid-task — continue exactly what you were
-  doing" on top of the message just sent, making the agent restart or duplicate the work
-  it was asked to do. A turn start now ENDS the outage rather than only zeroing the
-  total, which is also better evidence than the clock it replaces: the frame that starts a
-  turn comes FROM the orchestrator, so receiving it proves the orchestrator is alive. That
-  settles the reconnect case for the right reason — an orchestrator that survived
-  re-announces its live turn and is left alone, while one that died has no turn to
-  re-announce, so its nudge still fires.
-  Separately, when the panel itself replaces a WEDGED orchestrator — one holding an open
-  socket while answering nothing — no outage was recorded at all. A wedged orchestrator
-  never closes its connection, so the drop that normally starts the clock never happens,
-  and the panel force-kills and respawns it instead. That is a real death with the turn
-  already lost, so the resumed session had nothing pending and no nudge was sent: the
-  agent simply stopped, after the panel's own recovery killed its work. The two
-  recoveries that replace a wedged orchestrator now record it. Deliberate teardowns —
-  Disconnect, provider switch, reload, and any change of bridge address — deliberately do
-  not, since nothing died; they are pinned against it in both directions, because an
-  earlier attempt at this fix recorded an outage for all of them and would have told
-  agents whose orchestrator never died that their connection had dropped.
+- **The mid-task nudge no longer fires on a turn you just started (#1163).** A defect in
+  the outage accounting added for #1145, found by review of that change rather than in
+  the wild. A turn beginning while the bridge was still down zeroed the measured outage
+  but left the outage itself running, so it was later measured from before that turn
+  existed. Reachable in ordinary use: sending a message needs only an open socket, not a
+  completed handshake, and the socket comes back well before the model list does — so
+  typing into that gap could draw "your connection dropped mid-task — continue exactly
+  what you were doing" on top of the message just sent, making the agent restart or
+  duplicate the work it was asked to do.
+  A turn start now ENDS the outage rather than only zeroing the total. What that frame
+  proves is narrow but sufficient: a turn is in flight. The nudge exists solely to
+  rescue an agent left IDLE — a session resumed with full context and nothing pending —
+  so once a turn is running there is nothing to rescue, whether it is the original turn
+  re-announced by an orchestrator that survived or a new one just typed into a replaced
+  agent. Nudging either is the harm. The converse still holds and is covered by tests:
+  an orchestrator that died has no turn to announce, so its nudge fires as before.
 
 - **The mid-task resume nudge now measures the outage instead of one backoff step, so a
   ComfyUI restart that comes back quickly keeps its nudge (#1145).** The nudge tells a

--- a/browser_tests/unit/command-liveness.test.mjs
+++ b/browser_tests/unit/command-liveness.test.mjs
@@ -359,21 +359,10 @@ test("codex R12: replay only ever writes to a socket that PROVED itself with a h
   const recordAt = markConnected.indexOf("handshakenSock = sock;");
   const replayAt = markConnected.indexOf("replayLostReplies(sock);");
   assert.ok(recordAt !== -1 && replayAt !== -1 && recordAt < replayAt, "record the instance, then replay");
-  // Dropping the socket must forget it too. Asserted through the ONE helper every
-  // teardown now uses (#1163) rather than by counting three copies of the assignment:
-  // the copies were the old shape of "setUrl/stop/destroy all forget it", and a count
-  // stops meaning that the moment they are deduplicated — which is a refactor the
-  // invariant survives, not one it breaks. The claim is now the invariant itself: the
-  // teardown helper forgets the proven socket, and (asserted in session-rebind.test.mjs)
-  // all three teardowns drop the socket through that helper.
-  const dropStart = src.indexOf("function dropSocketForTeardown() {");
-  assert.notEqual(dropStart, -1, "the shared teardown helper must exist");
-  const dropEnd = src.indexOf("\n  }", dropStart);
-  assert.notEqual(dropEnd, -1, "could not locate the end of dropSocketForTeardown");
-  assert.match(
-    src.slice(dropStart, dropEnd),
-    /handshakenSock = null;/,
-    "the teardown helper must forget the proven socket",
+  // Dropping the socket must forget it too.
+  assert.ok(
+    (src.match(/handshakenSock = null;/g) || []).length >= 3,
+    "setUrl/stop/destroy must all forget the proven socket",
   );
 });
 

--- a/browser_tests/unit/command-liveness.test.mjs
+++ b/browser_tests/unit/command-liveness.test.mjs
@@ -359,10 +359,21 @@ test("codex R12: replay only ever writes to a socket that PROVED itself with a h
   const recordAt = markConnected.indexOf("handshakenSock = sock;");
   const replayAt = markConnected.indexOf("replayLostReplies(sock);");
   assert.ok(recordAt !== -1 && replayAt !== -1 && recordAt < replayAt, "record the instance, then replay");
-  // Dropping the socket must forget it too.
-  assert.ok(
-    (src.match(/handshakenSock = null;/g) || []).length >= 3,
-    "setUrl/stop/destroy must all forget the proven socket",
+  // Dropping the socket must forget it too. Asserted through the ONE helper every
+  // teardown now uses (#1163) rather than by counting three copies of the assignment:
+  // the copies were the old shape of "setUrl/stop/destroy all forget it", and a count
+  // stops meaning that the moment they are deduplicated — which is a refactor the
+  // invariant survives, not one it breaks. The claim is now the invariant itself: the
+  // teardown helper forgets the proven socket, and (asserted in session-rebind.test.mjs)
+  // all three teardowns drop the socket through that helper.
+  const dropStart = src.indexOf("function dropSocketForTeardown() {");
+  assert.notEqual(dropStart, -1, "the shared teardown helper must exist");
+  const dropEnd = src.indexOf("\n  }", dropStart);
+  assert.notEqual(dropEnd, -1, "could not locate the end of dropSocketForTeardown");
+  assert.match(
+    src.slice(dropStart, dropEnd),
+    /handshakenSock = null;/,
+    "the teardown helper must forget the proven socket",
   );
 });
 

--- a/browser_tests/unit/session-rebind.test.mjs
+++ b/browser_tests/unit/session-rebind.test.mjs
@@ -635,24 +635,45 @@ test("#1138 wiring: the call site NEGATES the predicate and returns", () => {
     ["the socket close handler must open the outage", "bridgeOutage.noteBridgeClosed();"],
     ["the models handshake must close it", "bridgeOutage.noteHandshake();"],
     ["a turn start must scope the evidence to that turn", "bridgeOutage.noteTurnStarted();"],
-    // #1163 — the FOURTH write site. The socket close listener is guarded by isActive(),
-    // and every panel-driven teardown nulls `sock` first, so the automatic recovery
-    // paths (tryAutoReclaim / tryAutoRespawn / tryHandshakeRedial) reach the tracker
-    // only through here. Without it they respawn the orchestrator with a turn armed and
-    // never nudge — #1145's failure by another route.
-    ["a panel-driven teardown must open the outage", "if (had) bridgeOutage.noteBridgeClosed();"],
   ]) {
     assert.ok(src.includes(snippet), site);
   }
-  // …and each teardown must actually route through that helper rather than dropping the
-  // socket itself. An inlined `sock = null` would bypass the tracker silently.
-  // Counts CALL STATEMENTS only — a line whose whole content is the call — so the
-  // definition and the prose that names it are not mistaken for call sites.
-  assert.equal(
-    (src.match(/^\s*dropSocketForTeardown\(\);/gm) || []).length,
-    3, // stop() + setUrl() + destroy()
-    "stop(), setUrl() and destroy() must all drop the socket through the tracked helper",
-  );
+  // #1163 — a WEDGED orchestrator never closes its socket, so the close listener above
+  // cannot see that death. The two recoveries that REPLACE one must open the outage
+  // themselves, or the fresh handshake measures nothing and the turn the wedge killed is
+  // never resumed. Pinned per-FUNCTION rather than by counting occurrences: a population
+  // count only says "three of these exist somewhere", which stays true if one moves to a
+  // path that must NOT open an outage — the exact mistake the first attempt at #1163 made.
+  for (const [fn, label] of [
+    ["function tryHandshakeRedial(timedOutUrl) {", "the handshake redial"],
+    ["function tryAutoReclaim(timedOutUrl) {", "the force-reclaim"],
+  ]) {
+    const at = src.indexOf(fn);
+    assert.notEqual(at, -1, `could not locate ${label}`);
+    const end = src.indexOf('\n  }', at);
+    assert.notEqual(end, -1, `could not locate the end of ${label}`);
+    assert.match(
+      src.slice(at, end),
+      /bridgeOutage\.noteBridgeClosed\(\);/,
+      `${label} replaces a wedged orchestrator and must open the outage itself`,
+    );
+  }
+  // …and the DELIBERATE teardowns must NOT. stop()/setUrl()/destroy() carry Disconnect,
+  // provider switch, soft reload and every user-driven bridge re-point; opening an outage
+  // there tells an agent whose orchestrator never died that its connection dropped. That
+  // is precisely what the first attempt at #1163 shipped, so it is pinned in both
+  // directions rather than left to the next reviewer.
+  for (const fn of ["    stop() {", "    setUrl(next, opts) {", "    destroy() {"]) {
+    const at = src.indexOf(fn);
+    assert.notEqual(at, -1, `could not locate ${fn.trim()}`);
+    const end = src.indexOf('\n    },', at);
+    assert.notEqual(end, -1, `could not locate the end of ${fn.trim()}`);
+    assert.doesNotMatch(
+      src.slice(at, end),
+      /bridgeOutage\./,
+      `${fn.trim()} is a deliberate teardown and must not record an outage`,
+    );
+  }
 });
 
 // ── #1145: the interval must be the OUTAGE, not one backoff step ─────────────

--- a/browser_tests/unit/session-rebind.test.mjs
+++ b/browser_tests/unit/session-rebind.test.mjs
@@ -635,9 +635,24 @@ test("#1138 wiring: the call site NEGATES the predicate and returns", () => {
     ["the socket close handler must open the outage", "bridgeOutage.noteBridgeClosed();"],
     ["the models handshake must close it", "bridgeOutage.noteHandshake();"],
     ["a turn start must scope the evidence to that turn", "bridgeOutage.noteTurnStarted();"],
+    // #1163 — the FOURTH write site. The socket close listener is guarded by isActive(),
+    // and every panel-driven teardown nulls `sock` first, so the automatic recovery
+    // paths (tryAutoReclaim / tryAutoRespawn / tryHandshakeRedial) reach the tracker
+    // only through here. Without it they respawn the orchestrator with a turn armed and
+    // never nudge — #1145's failure by another route.
+    ["a panel-driven teardown must open the outage", "if (had) bridgeOutage.noteBridgeClosed();"],
   ]) {
     assert.ok(src.includes(snippet), site);
   }
+  // …and each teardown must actually route through that helper rather than dropping the
+  // socket itself. An inlined `sock = null` would bypass the tracker silently.
+  // Counts CALL STATEMENTS only — a line whose whole content is the call — so the
+  // definition and the prose that names it are not mistaken for call sites.
+  assert.equal(
+    (src.match(/^\s*dropSocketForTeardown\(\);/gm) || []).length,
+    3, // stop() + setUrl() + destroy()
+    "stop(), setUrl() and destroy() must all drop the socket through the tracked helper",
+  );
 });
 
 // ── #1145: the interval must be the OUTAGE, not one backoff step ─────────────
@@ -840,6 +855,75 @@ test("#1145: a never-dropped bridge reads 0 live, not the age of the session", (
   assert.equal(tracker.isDown(), false);
   assert.equal(tracker.outageMs(), 0);
   assert.equal(shouldNudgeAfterMidTaskReconnect({ outageMs: tracker.outageMs() }), false);
+});
+
+// ── #1163: a turn start CLOSES the outage, it does not merely zero the total ──
+//
+// Zeroing alone left `startedAt` running across the turn boundary, so an outage that
+// began before the turn was still measured from before the turn existed. Reachable
+// because sendUserMessage needs only an OPEN socket, not a handshake, and the socket
+// reopens well before the `models` frame — so a user can type into the gap and have the
+// reply nudged as though their connection had just dropped.
+
+test("#1163: a turn started during an open outage is not charged with it", () => {
+  // The reported sequence. Bridge drops; the socket is back but unhandshaken; the user
+  // sends a message; the late handshake must NOT measure from before that turn.
+  const { clock, tracker } = trackerAt();
+  tracker.noteBridgeClosed(); // t=0, the real drop
+  clock.t += 5000; // socket reopens; `models` still pending
+  tracker.noteTurnStarted(); // the user's new message draws turn:working
+  assert.equal(tracker.isDown(), false, "a frame from the orchestrator ends the outage");
+  assert.equal(tracker.outageMs(), 0);
+
+  clock.t += 30_000; // the models frame finally lands
+  tracker.noteHandshake();
+  assert.equal(tracker.outageMs(), 0, "the pre-turn drop must not be measured here");
+  assert.equal(
+    shouldNudgeAfterMidTaskReconnect({ outageMs: tracker.outageMs() }),
+    false,
+    "a turn the user just started must never be told its connection dropped",
+  );
+});
+
+test("#1163: a live turn's reconnect re-announce ends the outage, so it is not nudged", () => {
+  // turn:working is a frame FROM the orchestrator, so receiving it proves the bridge is
+  // carrying traffic. An orchestrator that SURVIVED re-announces its live turn; one that
+  // died has no turn to re-announce. So the re-announce arriving before the ready ack is
+  // exactly the evidence that no nudge is due — better than any clock reading.
+  const { clock, tracker } = trackerAt();
+  tracker.noteTurnStarted(); // turn begins
+  tracker.noteBridgeClosed(); // ComfyUI bounces, orchestrator survives
+  clock.t += 30_000;
+  tracker.noteTurnStarted(); // the surviving turn re-announces on reconnect
+  assert.equal(
+    shouldNudgeAfterMidTaskReconnect({ outageMs: tracker.outageMs() }),
+    false,
+    "a turn that never died must not be told to resume",
+  );
+});
+
+test("#1163: an orchestrator that DIED still nudges — no re-announce arrives first", () => {
+  // The complement, so the fix cannot be satisfied by never nudging: a dead orchestrator
+  // has no live turn to re-announce, so nothing closes the outage before the ready ack.
+  const { clock, tracker } = trackerAt();
+  tracker.noteTurnStarted();
+  tracker.noteBridgeClosed();
+  clock.t += 30_000;
+  tracker.noteHandshake(); // only the handshake arrives — no turn:working
+  assert.equal(tracker.outageMs(), 30_000);
+  assert.equal(shouldNudgeAfterMidTaskReconnect({ outageMs: tracker.outageMs() }), true);
+});
+
+test("#1163: a drop AFTER the turn start is still measured in full", () => {
+  // Closing on a turn start must not blunt the live path: a drop that happens after the
+  // turn begins is entirely this turn's, including when read before the handshake.
+  const { clock, tracker } = trackerAt();
+  tracker.noteTurnStarted();
+  clock.t += 1000;
+  tracker.noteBridgeClosed();
+  clock.t += 20_000;
+  assert.equal(tracker.outageMs(), 20_000, "live read, ready ahead of models");
+  assert.equal(shouldNudgeAfterMidTaskReconnect({ outageMs: tracker.outageMs() }), true);
 });
 
 test("#1145: a second outage measures itself, not the gap since the first", () => {

--- a/browser_tests/unit/session-rebind.test.mjs
+++ b/browser_tests/unit/session-rebind.test.mjs
@@ -638,42 +638,13 @@ test("#1138 wiring: the call site NEGATES the predicate and returns", () => {
   ]) {
     assert.ok(src.includes(snippet), site);
   }
-  // #1163 — a WEDGED orchestrator never closes its socket, so the close listener above
-  // cannot see that death. The two recoveries that REPLACE one must open the outage
-  // themselves, or the fresh handshake measures nothing and the turn the wedge killed is
-  // never resumed. Pinned per-FUNCTION rather than by counting occurrences: a population
-  // count only says "three of these exist somewhere", which stays true if one moves to a
-  // path that must NOT open an outage — the exact mistake the first attempt at #1163 made.
-  for (const [fn, label] of [
-    ["function tryHandshakeRedial(timedOutUrl) {", "the handshake redial"],
-    ["function tryAutoReclaim(timedOutUrl) {", "the force-reclaim"],
-  ]) {
-    const at = src.indexOf(fn);
-    assert.notEqual(at, -1, `could not locate ${label}`);
-    const end = src.indexOf('\n  }', at);
-    assert.notEqual(end, -1, `could not locate the end of ${label}`);
-    assert.match(
-      src.slice(at, end),
-      /bridgeOutage\.noteBridgeClosed\(\);/,
-      `${label} replaces a wedged orchestrator and must open the outage itself`,
-    );
-  }
-  // …and the DELIBERATE teardowns must NOT. stop()/setUrl()/destroy() carry Disconnect,
-  // provider switch, soft reload and every user-driven bridge re-point; opening an outage
-  // there tells an agent whose orchestrator never died that its connection dropped. That
-  // is precisely what the first attempt at #1163 shipped, so it is pinned in both
-  // directions rather than left to the next reviewer.
-  for (const fn of ["    stop() {", "    setUrl(next, opts) {", "    destroy() {"]) {
-    const at = src.indexOf(fn);
-    assert.notEqual(at, -1, `could not locate ${fn.trim()}`);
-    const end = src.indexOf('\n    },', at);
-    assert.notEqual(end, -1, `could not locate the end of ${fn.trim()}`);
-    assert.doesNotMatch(
-      src.slice(at, end),
-      /bridgeOutage\./,
-      `${fn.trim()} is a deliberate teardown and must not record an outage`,
-    );
-  }
+  // NOTE: two attempts to also pin the WEDGE-death paths were removed with the code
+  // they described. A wedged orchestrator holds its socket open and never fires a
+  // close, so nothing records that death — a real gap, tracked separately. It is not
+  // pinned here because the assertions that tried to were themselves wrong: the
+  // negative half scanned stop()/setUrl()/destroy() for a literal `bridgeOutage.`,
+  // while the design it claimed to reject put the stamp in a shared helper CALLED
+  // from those bodies — so it would have passed against the very regression it named.
 });
 
 // ── #1145: the interval must be the OUTAGE, not one backoff step ─────────────
@@ -906,11 +877,15 @@ test("#1163: a turn started during an open outage is not charged with it", () =>
   );
 });
 
-test("#1163: a live turn's reconnect re-announce ends the outage, so it is not nudged", () => {
-  // turn:working is a frame FROM the orchestrator, so receiving it proves the bridge is
-  // carrying traffic. An orchestrator that SURVIVED re-announces its live turn; one that
-  // died has no turn to re-announce. So the re-announce arriving before the ready ack is
-  // exactly the evidence that no nudge is due — better than any clock reading.
+test("#1163: any turn start during an outage ends it — a working agent is never nudged", () => {
+  // Deliberately stated as the TRACKER's contract, not as a claim about frame ordering.
+  // An earlier version of this test asserted that a surviving orchestrator's re-announce
+  // beats the `ready` ack; the panel guarantees no such ordering, so that test pinned an
+  // assumption rather than a behaviour. What is true without any ordering assumption:
+  // whenever a turn start is seen, a turn is in flight, and the nudge exists only to
+  // rescue an IDLE agent — so from that moment there is nothing to rescue. If the ack
+  // arrives FIRST the outage still stands and the nudge fires, which is correct too:
+  // nothing had yet said a turn was running.
   const { clock, tracker } = trackerAt();
   tracker.noteTurnStarted(); // turn begins
   tracker.noteBridgeClosed(); // ComfyUI bounces, orchestrator survives

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -18258,13 +18258,14 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
       // clock to the last backoff step. The tracker ignores all but the first; the
       // outage stands until markConnected() ends it.
       //
-      // A panel-DRIVEN teardown never reaches here, and that is deliberate rather than
-      // a gap: stop() nulls `sock` synchronously, so the late close fails the isActive()
-      // guard above and no outage opens. Every such path — Disconnect, provider switch,
-      // soft reload — routes through endTurnLocally() or its own ready-ack branch and
-      // clears MID_TASK_KEY, so there is no mid-task nudge left to decide. Opening an
-      // outage for them would only invent evidence about a drop the user asked for. The
-      // pre-#1145 stamp sat behind this same guard, so this is unchanged behaviour.
+      // A panel-DRIVEN teardown never reaches here — stop()/setUrl()/destroy() null
+      // `sock` synchronously, so their late close fails the isActive() guard above.
+      // #1146 called that harmless on the grounds that every such path clears
+      // MID_TASK_KEY. #1163 found that reasoning covers only Disconnect, provider switch
+      // and soft reload; the AUTOMATIC recovery paths (tryAutoReclaim / tryAutoRespawn /
+      // tryHandshakeRedial) restart the orchestrator with a turn still armed and were
+      // silently losing the nudge. They open their outage in dropSocketForTeardown()
+      // instead, which is the one place that knows a teardown happened at all.
       bridgeOutage.noteBridgeClosed();
       if (!closed) {
         // FIX 1 — auto-reconnecting: keep the pill STEADY (scheduleReconnect picks
@@ -18553,6 +18554,35 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
     }, delay);
   }
 
+  /** #1163 — drop the socket for a PANEL-DRIVEN teardown, and open the outage while
+   *  doing it.
+   *
+   *  The close listener cannot do this job for these paths. It is guarded by
+   *  `isActive()`, and every caller here nulls `sock` synchronously, so by the time the
+   *  browser delivers `close` the socket is already superseded and the handler returns
+   *  before recording anything. #1146 called that harmless because Disconnect, provider
+   *  switch and soft reload all clear MID_TASK_KEY on their own paths — true for those
+   *  three, and wrong for the AUTOMATIC recovery paths, which is where it mattered:
+   *  tryAutoReclaim, tryAutoRespawn and tryHandshakeRedial restart the orchestrator
+   *  through setUrl/stop with a turn still armed. That respawn IS a real orchestrator
+   *  death — the turn is gone and the resumed session has nothing pending — but with no
+   *  outage ever opened, the ready ack read no drop, cleared the marker and returned
+   *  silently. The agent never resumed the work the panel's own reclaim killed: #1145's
+   *  failure, reached through the recovery path instead of through the backoff.
+   *
+   *  Only when a socket actually existed. A teardown of a client that never connected
+   *  has no outage to open, and inventing one would let the next handshake measure idle
+   *  time as downtime. */
+  function dropSocketForTeardown() {
+    const had = !!sock;
+    try {
+      sock?.close();
+    } catch {}
+    sock = null;
+    handshakenSock = null;
+    if (had) bridgeOutage.noteBridgeClosed();
+  }
+
   return {
     // Public re-hello so the panel can re-target this socket to a new workflow's
     // tab id (per-workflow sessions) without opening a second client.
@@ -18776,11 +18806,9 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
         clearTimeout(reconnectTimer);
         reconnectTimer = null;
       }
-      try {
-        sock?.close();
-      } catch {}
-      sock = null;
-      handshakenSock = null;
+      // #1163 — opens the outage; tryAutoReclaim / tryAutoRespawn / tryHandshakeRedial
+      // all redial through here with a turn still armed.
+      dropSocketForTeardown();
       connect();
     },
     currentUrl() {
@@ -18800,11 +18828,7 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
       // Cancel the shared handshake timer so a stopped-before-handshake socket can't
       // fire onHandshakeTimeout against a later reconnect (#379 race hardening).
       clearHandshake();
-      try {
-        sock?.close();
-      } catch {}
-      sock = null;
-      handshakenSock = null;
+      dropSocketForTeardown(); // #1163 — the wedge-unstick path stops before restarting
     },
     destroy() {
       closed = true;
@@ -18813,11 +18837,11 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
         clearTimeout(reconnectTimer);
         reconnectTimer = null;
       }
-      try {
-        sock?.close();
-      } catch {}
-      sock = null;
-      handshakenSock = null;
+      // #1163 — an unmount really does take the bridge down, and the tracker is
+      // module-scoped so a remount inherits the open outage. A live turn re-announces
+      // `turn:working` on the remount's reconnect, which CLOSES it, so a surviving turn
+      // is never nudged for the time the panel was unmounted.
+      dropSocketForTeardown();
     },
   };
 }

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -18554,35 +18554,6 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
     }, delay);
   }
 
-  /** #1163 — drop the socket for a PANEL-DRIVEN teardown, and open the outage while
-   *  doing it.
-   *
-   *  The close listener cannot do this job for these paths. It is guarded by
-   *  `isActive()`, and every caller here nulls `sock` synchronously, so by the time the
-   *  browser delivers `close` the socket is already superseded and the handler returns
-   *  before recording anything. #1146 called that harmless because Disconnect, provider
-   *  switch and soft reload all clear MID_TASK_KEY on their own paths — true for those
-   *  three, and wrong for the AUTOMATIC recovery paths, which is where it mattered:
-   *  tryAutoReclaim, tryAutoRespawn and tryHandshakeRedial restart the orchestrator
-   *  through setUrl/stop with a turn still armed. That respawn IS a real orchestrator
-   *  death — the turn is gone and the resumed session has nothing pending — but with no
-   *  outage ever opened, the ready ack read no drop, cleared the marker and returned
-   *  silently. The agent never resumed the work the panel's own reclaim killed: #1145's
-   *  failure, reached through the recovery path instead of through the backoff.
-   *
-   *  Only when a socket actually existed. A teardown of a client that never connected
-   *  has no outage to open, and inventing one would let the next handshake measure idle
-   *  time as downtime. */
-  function dropSocketForTeardown() {
-    const had = !!sock;
-    try {
-      sock?.close();
-    } catch {}
-    sock = null;
-    handshakenSock = null;
-    if (had) bridgeOutage.noteBridgeClosed();
-  }
-
   return {
     // Public re-hello so the panel can re-target this socket to a new workflow's
     // tab id (per-workflow sessions) without opening a second client.
@@ -18806,9 +18777,11 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
         clearTimeout(reconnectTimer);
         reconnectTimer = null;
       }
-      // #1163 — opens the outage; tryAutoReclaim / tryAutoRespawn / tryHandshakeRedial
-      // all redial through here with a turn still armed.
-      dropSocketForTeardown();
+      try {
+        sock?.close();
+      } catch {}
+      sock = null;
+      handshakenSock = null;
       connect();
     },
     currentUrl() {
@@ -18828,7 +18801,11 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
       // Cancel the shared handshake timer so a stopped-before-handshake socket can't
       // fire onHandshakeTimeout against a later reconnect (#379 race hardening).
       clearHandshake();
-      dropSocketForTeardown(); // #1163 — the wedge-unstick path stops before restarting
+      try {
+        sock?.close();
+      } catch {}
+      sock = null;
+      handshakenSock = null;
     },
     destroy() {
       closed = true;
@@ -18837,11 +18814,11 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
         clearTimeout(reconnectTimer);
         reconnectTimer = null;
       }
-      // #1163 — an unmount really does take the bridge down, and the tracker is
-      // module-scoped so a remount inherits the open outage. A live turn re-announces
-      // `turn:working` on the remount's reconnect, which CLOSES it, so a surviving turn
-      // is never nudged for the time the panel was unmounted.
-      dropSocketForTeardown();
+      try {
+        sock?.close();
+      } catch {}
+      sock = null;
+      handshakenSock = null;
     },
   };
 }
@@ -28957,6 +28934,13 @@ function buildPanel() {
     if (timedOutUrl !== client.currentUrl()) return false;
     handshakeRedialsLeft -= 1;
     appendSystem(tr("panel.the_panel_agent_isn_t_answering_yet", "The panel agent isn't answering yet — reconnecting…"));
+    // #1163 — the OUTAGE begins here, and only the panel can say so. The socket never
+    // closed: it is open with nothing behind it, which is why the close listener that
+    // normally opens an outage never ran. From the agent's point of view the bridge has
+    // been down since the orchestrator stopped answering, and this redial is the panel
+    // declaring exactly that. Without it the eventual handshake measures no outage, the
+    // ready ack reads no drop, and a turn killed by the wedge is never resumed.
+    bridgeOutage.noteBridgeClosed();
     client.setUrl(client.currentUrl()); // close + reopen on the same url → fresh hello
     return true;
   }
@@ -28997,6 +28981,13 @@ function buildPanel() {
           autoReclaimsLeft = 0;
           return;
         }
+        // #1163 — the reclaim KILLED the wedged orchestrator and spawned a fresh one, so
+        // any turn it was running is definitively gone. Stamped here rather than in the
+        // teardown helpers because only this path knows a death occurred: the socket was
+        // open the whole time (wedged, not closed), so the close listener that normally
+        // opens an outage never ran, and the fresh handshake would otherwise measure
+        // nothing and leave the killed turn unresumed.
+        bridgeOutage.noteBridgeClosed();
         if (data?.bridge_url && data.bridge_url !== client.currentUrl()) {
           client.setUrl(data.bridge_url); // setUrl reconnects
         } else {

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -18261,11 +18261,16 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
       // A panel-DRIVEN teardown never reaches here — stop()/setUrl()/destroy() null
       // `sock` synchronously, so their late close fails the isActive() guard above.
       // #1146 called that harmless on the grounds that every such path clears
-      // MID_TASK_KEY. #1163 found that reasoning covers only Disconnect, provider switch
-      // and soft reload; the AUTOMATIC recovery paths (tryAutoReclaim / tryAutoRespawn /
-      // tryHandshakeRedial) restart the orchestrator with a turn still armed and were
-      // silently losing the nudge. They open their outage in dropSocketForTeardown()
-      // instead, which is the one place that knows a teardown happened at all.
+      // MID_TASK_KEY, and that is not quite true: connectBackend() clears it only when
+      // `switching`, and hardRestart() only on its success branch (#1166).
+      //
+      // A WEDGED orchestrator is not covered here either: it holds its socket OPEN and
+      // answers nothing, so no close ever fires and no outage is recorded for a death
+      // the panel then resolves by force-respawning it. Both gaps are real and are
+      // tracked as their own issue rather than patched from here — two attempts to
+      // record those deaths from the teardown side turned a MISSED nudge into a FALSE
+      // one, because the teardown functions cannot distinguish "the orchestrator died"
+      // from "the user changed the bridge URL" or "the agent has not booted yet".
       bridgeOutage.noteBridgeClosed();
       if (!closed) {
         // FIX 1 — auto-reconnecting: keep the pill STEADY (scheduleReconnect picks
@@ -28934,13 +28939,6 @@ function buildPanel() {
     if (timedOutUrl !== client.currentUrl()) return false;
     handshakeRedialsLeft -= 1;
     appendSystem(tr("panel.the_panel_agent_isn_t_answering_yet", "The panel agent isn't answering yet — reconnecting…"));
-    // #1163 — the OUTAGE begins here, and only the panel can say so. The socket never
-    // closed: it is open with nothing behind it, which is why the close listener that
-    // normally opens an outage never ran. From the agent's point of view the bridge has
-    // been down since the orchestrator stopped answering, and this redial is the panel
-    // declaring exactly that. Without it the eventual handshake measures no outage, the
-    // ready ack reads no drop, and a turn killed by the wedge is never resumed.
-    bridgeOutage.noteBridgeClosed();
     client.setUrl(client.currentUrl()); // close + reopen on the same url → fresh hello
     return true;
   }
@@ -28981,13 +28979,6 @@ function buildPanel() {
           autoReclaimsLeft = 0;
           return;
         }
-        // #1163 — the reclaim KILLED the wedged orchestrator and spawned a fresh one, so
-        // any turn it was running is definitively gone. Stamped here rather than in the
-        // teardown helpers because only this path knows a death occurred: the socket was
-        // open the whole time (wedged, not closed), so the close listener that normally
-        // opens an outage never ran, and the fresh handshake would otherwise measure
-        // nothing and leave the killed turn unresumed.
-        bridgeOutage.noteBridgeClosed();
         if (data?.bridge_url && data.bridge_url !== client.currentUrl()) {
           client.setUrl(data.bridge_url); // setUrl reconnects
         } else {

--- a/web/js/lib/session-rebind.js
+++ b/web/js/lib/session-rebind.js
@@ -154,6 +154,29 @@ export function createBridgeOutageTracker({ now = () => Date.now() } = {}) {
       startedAt = null;
     },
     noteTurnStarted() {
+      // #1163 — CLOSE the outage, do not merely zero the total.
+      //
+      // Zeroing alone left `startedAt` running across the turn boundary, so an outage
+      // that began before the turn was still measured from before the turn existed.
+      // That is reachable, not theoretical: `sendUserMessage` requires only an OPEN
+      // socket, not a completed handshake, and the socket reopens well before the
+      // `models` frame — up to 45s earlier on a cold backend. A user who types into
+      // that gap gets `turn:working`, then the late handshake measures the pre-turn
+      // drop, and the `ready` ack tells the agent its connection dropped mid-task and
+      // to resume — on top of the message the user sent seconds ago. The agent
+      // restarts or duplicates the work it was just asked to do: the exact
+      // false-nudge-into-a-live-session harm #1138 exists to prevent.
+      //
+      // Closing here is not merely a repair, it is better evidence. `turn:working` is a
+      // frame FROM the orchestrator, so receiving it proves the bridge is carrying
+      // traffic and the orchestrator is alive — which is what the clock was only ever
+      // estimating. It also settles the reconnect re-announce correctly and for the
+      // right reason: an orchestrator that SURVIVED re-announces its live turn, and
+      // that announcement now ends the outage, so no nudge fires for a turn that never
+      // died. One that died has no turn to re-announce, so nothing arrives before the
+      // `ready` ack, the outage stands, and the nudge fires. The panel stops guessing
+      // from elapsed time in the one case where it holds proof.
+      startedAt = null;
       outageMs = 0;
     },
     /** The outage the current turn has seen, in ms (0 = none).

--- a/web/js/lib/session-rebind.js
+++ b/web/js/lib/session-rebind.js
@@ -167,15 +167,19 @@ export function createBridgeOutageTracker({ now = () => Date.now() } = {}) {
       // restarts or duplicates the work it was just asked to do: the exact
       // false-nudge-into-a-live-session harm #1138 exists to prevent.
       //
-      // Closing here is not merely a repair, it is better evidence. `turn:working` is a
-      // frame FROM the orchestrator, so receiving it proves the bridge is carrying
-      // traffic and the orchestrator is alive — which is what the clock was only ever
-      // estimating. It also settles the reconnect re-announce correctly and for the
-      // right reason: an orchestrator that SURVIVED re-announces its live turn, and
-      // that announcement now ends the outage, so no nudge fires for a turn that never
-      // died. One that died has no turn to re-announce, so nothing arrives before the
-      // `ready` ack, the outage stands, and the nudge fires. The panel stops guessing
-      // from elapsed time in the one case where it holds proof.
+      // What this frame actually proves is narrower than "the orchestrator survived",
+      // and the narrow claim is the one that matters: A TURN IS IN FLIGHT RIGHT NOW.
+      // The nudge exists solely to rescue an agent left IDLE — a session resumed with
+      // full context and no pending turn. An agent that is working is not idle, so
+      // there is nothing to rescue, whether the turn is the original one re-announced
+      // by an orchestrator that survived or a brand-new one the user just typed into a
+      // respawned agent. Nudging either is the harm: "continue exactly what you were
+      // doing before the drop" makes a working agent restart or duplicate.
+      //
+      // The converse is what keeps the feature alive: an orchestrator that died has no
+      // turn to announce, so nothing arrives before the `ready` ack, the outage stands
+      // and the nudge fires. Both directions are pinned by tests, so this can never be
+      // satisfied by simply never nudging.
       startedAt = null;
       outageMs = 0;
     },


### PR DESCRIPTION
Closes #1163. Follow-up to #1145 / #1146, from the high-effort review of that branch.

Two defects in the mid-task nudge's outage accounting — one #1146 introduced, one it inherited and mis-documented.

**A turn started during an open outage is charged with the outage that preceded it.** `noteTurnStarted()` zeroed the total but left `startedAt` running, so the outage crossed the turn boundary. Reachable because `sendUserMessage` needs only an OPEN socket, not a handshake, and the socket reopens well before `models` — so a user can send a message into the gap and have the reply nudged as though their connection had just dropped.

**The panel's own respawn/reclaim/redial never opens an outage.** `noteBridgeClosed()` is behind the superseded-socket guard, and `stop()`/`setUrl()`/`destroy()` null `sock` before the close fires. #1146's comment claims every such path clears `MID_TASK_KEY`; that holds for Disconnect, provider switch and soft reload, and is wrong for `tryAutoReclaim`, `tryAutoRespawn` and `tryHandshakeRedial` — which restart the orchestrator with a turn still armed, then never nudge.

Draft while I work the fix and its tests.