### PR TITLE
fix(i18n): let a truncated provider hint be read on hover

### DIFF
--- a/browser_tests/unit/popover-item-title.test.mjs
+++ b/browser_tests/unit/popover-item-title.test.mjs
@@ -1,0 +1,55 @@
+// The provider/model popover row must expose its truncated secondary line on hover.
+//
+// `item({label, small})` renders `small` into a <small> whose CSS is
+// `overflow:hidden; text-overflow:ellipsis; white-space:nowrap`, and the row deliberately
+// truncates THAT line rather than the provider name. For a not-ready provider the same line
+// carries the recovery instruction, and the actionable part is terminal in every one of them
+// ("… — run: ollama serve", "… or run `pi` once and /login"), so the ellipsis removes exactly
+// the part the user needs. Without a title there is no way to read it at all.
+//
+// This asserts on the SOURCE because `item` is a closure nested inside buildPanel, which
+// cannot be constructed without ComfyUI's `app`. That makes the test only as good as its
+// anchor, so it is written to fail if the line is deleted — verified by deleting it.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const SRC = fs.readFileSync(path.join(ROOT, "web/js/comfyui-mcp-panel.js"), "utf8");
+
+/** The body of the popover `item` factory, bounded by its own arrow-function block. */
+function itemBody() {
+  const start = SRC.indexOf("const item = ({ label, small, cls }");
+  assert.notEqual(start, -1, "the popover item factory was renamed — update this test's anchor");
+  let depth = 0;
+  let i = SRC.indexOf("{", SRC.indexOf("=>", start));
+  const from = i;
+  for (; i < SRC.length; i++) {
+    if (SRC[i] === "{") depth++;
+    else if (SRC[i] === "}") {
+      depth--;
+      if (depth === 0) break;
+    }
+  }
+  return SRC.slice(from, i + 1);
+}
+
+test("a popover row's secondary line is readable on hover after it truncates", () => {
+  const body = itemBody();
+  // Scoped to the `if (small)` branch so a title set on some other element cannot satisfy it.
+  const branch = body.slice(body.indexOf("if (small)"));
+  assert.match(
+    branch,
+    /s\.title\s*=\s*small/,
+    "item() renders `small` into an ellipsis-truncated <small> with no title — the recovery " +
+      "instruction it carries for a not-ready provider becomes unreadable",
+  );
+});
+
+test("the truncation this depends on is still in force", () => {
+  // If the row ever stops truncating, the title becomes redundant rather than load-bearing,
+  // and this test should be revisited rather than silently kept.
+  assert.match(SRC, /text-overflow: ellipsis/, "expected the popover row CSS to still truncate");
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -22501,6 +22501,14 @@ function buildPanel() {
       if (small) {
         const s = document.createElement("small");
         s.textContent = small;
+        // The row deliberately truncates this line rather than the provider NAME (see the
+        // cmcp-provider call site), and the CSS is nowrap + ellipsis. For a not-ready
+        // provider this line carries the recovery instruction — and the actionable part is
+        // TERMINAL in every one of them ("… — run: ollama serve", "… or run `pi` once and
+        // /login"), so the ellipsis eats precisely what the user needs. With no title there
+        // was no way to recover it at all. Already true of the 109-character English string;
+        // translations run up to 40% longer. The chip path next door has always done this.
+        s.title = small;
         el.appendChild(s);
       }
       // Always render the check (visibility toggled) so the column is reserved


### PR DESCRIPTION
Found by the unit that translated those hints — by reading the rendered result, not the catalog.

## The problem

The provider row **deliberately** truncates its secondary line rather than the provider name. That is documented at the call site and it is the right trade — a long hint used to collapse "Ollama" to nothing.

But for a not-ready provider, that same line *is* the recovery instruction, and the actionable part is **terminal** in every one of them:

- `Ollama not running — run: ollama serve`
- `No provider configured — … or run \`pi\` once and \`/login\`.`
- `llama-server not running — llama-server -m model.gguf --jinja -c 16384`

With `overflow:hidden; text-overflow:ellipsis; white-space:nowrap` and no `title` on the element, the ellipsis removes exactly the part the user needs and there is no way to recover it.

This already bit the 109-character English string. The eleven translations merged in #1162 run up to **40% longer**.

## The fix

One line — `s.title = small` — matching what the chip path beside it has always done (`chip.title = hint`).

The alternative, trimming eleven catalogs to fit, would be shortening the message to suit a layout bug. Same anti-pattern as loosening a gate to make it pass.

## About the guard

`browser_tests/unit/popover-item-title.test.mjs` asserts on **source**, because `item` is a closure inside `buildPanel` and cannot be constructed without ComfyUI's `app`. A source assertion is only as good as its anchor, so it is scoped to the `if (small)` branch of the `item` factory (brace-matched, not grepped) and mutation-tested.

Worth recording: **the first mutation attempt survived.** The needle ended in a bare `\n` while the working tree is CRLF, so the edit silently changed nothing while printing "removed" — a green run that proved the opposite of what it looked like. Removing the line line-wise does kill the test:

```
lines removed: 1
after mutation, occurrences: 0
✖ a popover row's secondary line is readable on hover after it truncates
```

## Verification

`npm run test:unit` → **4092 pass, 0 fail** (locale gate, render check, vocabulary gate, scope gate).