### PR TITLE
chore(release): 0.14.22 — twelve languages, verified on the rig

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-agent-panel"
 description = "Autonomous AI agent in the ComfyUI sidebar - local-first, bring any LLM. Run it on your Claude or ChatGPT subscription (no API keys, no extra LLM costs), on a Kimi K3 / GLM / OpenRouter key, or fully offline on free local models via Ollama, LM Studio, or llama.cpp. The agent drives your live canvas at full parity: add, wire, move and tweak nodes with Ctrl+Z undo, load whole workflows and installer packs in one shot, generate images, video and audio, browse CivitAI, and run your workflow - asking before it spends paid API credits. The sidebar UI for comfyui-mcp, the local-first, agent-native control plane for ComfyUI."
-version = "0.14.21"
+version = "0.14.22"
 license = { file = "LICENSE" }
 requires-python = ">=3.9"
 # UI-only pack: no Python deps. The frontend floor guarantees

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -1044,7 +1044,7 @@ const DOCS_URL = "https://comfyui-mcp.artokun.io/docs";
 // Panel version — surfaced in the "Need help?" diagnostics blob. Bump via
 // `node scripts/set-version.mjs <v>` (updates this AND pyproject together); CI
 // and the publish gate FAIL if the two ever drift, so this can't go stale.
-const PANEL_VERSION = "0.14.21";
+const PANEL_VERSION = "0.14.22";
 
 // The connected orchestrator's console URL/token (captured off the `backends`
 // bridge message — see onBackends). Drives the "API Keys" credentials frame;


### PR DESCRIPTION
Cuts the release for the i18n batch. Bumps `pyproject.toml` and `PANEL_VERSION` together, which the publish workflow requires.

## What ships

Twelve languages, each carrying the exact key set `Intl.PluralRules` allows it — **zero keys missing against English** in all eleven translations:

| languages | keys | plural categories |
|---|---|---|
| `ja` `ko` `zh` `zh-TW` | 1021 | 1 |
| `tr` `fa` | 1075 | 2 |
| `fr` `es` `pt-BR` | 1129 | 3 |
| `ru` | 1183 | 4 |
| `ar` | 1291 | 6 |

Plus four defect fixes that came out of the translation work rather than the plan:

- **Status pill froze on "disconnected" during a healthy session** — `STATUS_LABEL` was declared in `createBridgeClient` and read in `buildPanel`, so `onStatus` threw `ReferenceError` on the first status frame and the pill, dot, Connect label and dead-bridge liveness fallback all silently stopped. Three more cross-scope `ReferenceError`s fixed alongside it, and `check-panel-scope.mjs` added so it cannot recur.
- **Undecoded escapes** — the extractor stored `\n` and `\"` as literal two-character sequences, painting a visible backslash in destructive-action confirms *including in English*. Fixed at the extractor and gated.
- **22 provider-readiness hints** were never translatable at all — the literal sat at a `return`, where no detector looks.
- **Those hints were truncated with no way to read them** — the actionable command is last in every one, and `item()` set no `title`.

## Verified on the rig, not by coverage

- `GET /i18n` serves **12/12 locales at full strength** through ComfyUI's own translation route.
- Arabic walk: `dir="rtl"` scoped to the panel root while `body` and the ComfyUI canvas stay `ltr`; **0** raw catalog keys, **0** unsubstituted placeholders, **0** bidi control characters; all four sub-panels (CivitAI, Apps, Training, RunPod) render translated — surfaces nobody had ever opened in a non-English locale.
- Japanese, Chinese and Korean walks equally clean; the only Latin strings remaining are brand names, shell names and user content.
- `npm run test:unit` → **4092 pass, 0 fail** (locale gate, render check, vocabulary gate, scope gate).