### PR TITLE
fix(1166): a successful restart retires every marker before the invalidate can bail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,16 +8,25 @@ All notable changes to this project are documented here. This project adheres to
 
 ### Fixed
 
-- **A failed agent restart no longer leaves the panel showing a turn that will never
-  finish (#1166).** Restarting the agent backend retired the in-flight turn only when the
+- **A failed agent restart no longer leaves stale state behind, and says so on screen
+  (#1166).** Restarting the agent backend retired the in-flight turn only when the
   restart SUCCEEDED. Every other outcome — the pack refusing, ComfyUI being unreachable,
-  or the old session failing to invalidate — skipped it, so the panel went on asserting a
-  pending turn that nothing would ever complete. The working indicator could spin
+  or the old session failing to invalidate — skipped it, so the panel went on asserting
+  a pending turn that nothing would ever complete. The working indicator could spin
   indefinitely, because dropping the bridge suppresses the status change that would
   normally hide it, and the mid-task marker stayed armed as standing evidence of a live
-  turn for the next reconnect to act on. The turn is now retired the moment the restart
-  is requested, before any of it can fail, which is what the Disconnect button has always
-  done for the same reason.
+  turn for the next reconnect to act on.
+  The same was true of the other two markers a restart is supposed to retire: a stale
+  soft-reload marker announced that the agent had reloaded and the session was resumed,
+  for a restart that never happened, and a surviving restart-resume marker would resume
+  the very conversation the restart exists to discard. All three are now retired the
+  moment the restart is requested, before any of it can fail — which is what the
+  Disconnect button has always done, for the same reason.
+  One failure is deliberately not recovered: when the old session cannot be invalidated,
+  the reconnect stays paused rather than restoring the session the restart was meant to
+  throw away. That pause was previously invisible — the status chip, dot and buttons
+  still showed a live connection, so the panel contradicted its own message and offered
+  no way to act on it. It now shows the real state and restores the Connect button.
 
 ## [0.14.23] - 2026-08-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- **A failed agent restart no longer leaves the panel showing a turn that will never
+  finish (#1166).** Restarting the agent backend retired the in-flight turn only when the
+  restart SUCCEEDED. Every other outcome — the pack refusing, ComfyUI being unreachable,
+  or the old session failing to invalidate — skipped it, so the panel went on asserting a
+  pending turn that nothing would ever complete. The working indicator could spin
+  indefinitely, because dropping the bridge suppresses the status change that would
+  normally hide it, and the mid-task marker stayed armed as standing evidence of a live
+  turn for the next reconnect to act on. The turn is now retired the moment the restart
+  is requested, before any of it can fail, which is what the Disconnect button has always
+  done for the same reason.
+
 ## [0.14.23] - 2026-08-12
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,25 +8,20 @@ All notable changes to this project are documented here. This project adheres to
 
 ### Fixed
 
-- **A failed agent restart no longer leaves stale state behind, and says so on screen
-  (#1166).** Restarting the agent backend retired the in-flight turn only when the
-  restart SUCCEEDED. Every other outcome — the pack refusing, ComfyUI being unreachable,
-  or the old session failing to invalidate — skipped it, so the panel went on asserting
-  a pending turn that nothing would ever complete. The working indicator could spin
-  indefinitely, because dropping the bridge suppresses the status change that would
-  normally hide it, and the mid-task marker stayed armed as standing evidence of a live
-  turn for the next reconnect to act on.
-  The same was true of the other two markers a restart is supposed to retire: a stale
-  soft-reload marker announced that the agent had reloaded and the session was resumed,
-  for a restart that never happened, and a surviving restart-resume marker would resume
-  the very conversation the restart exists to discard. All three are now retired the
-  moment the restart is requested, before any of it can fail — which is what the
-  Disconnect button has always done, for the same reason.
-  One failure is deliberately not recovered: when the old session cannot be invalidated,
-  the reconnect stays paused rather than restoring the session the restart was meant to
-  throw away. That pause was previously invisible — the status chip, dot and buttons
-  still showed a live connection, so the panel contradicted its own message and offered
-  no way to act on it. It now shows the real state and restores the Connect button.
+- **A successful agent restart no longer leaves the old turn's state armed against a
+  fresh agent (#1166).** When a restart genuinely replaces the agent, the panel retires
+  the markers that say a turn is in flight. Those clears all sat after a step that can
+  bail out — if the old session could not be invalidated durably, the restart returned
+  early and skipped every one of them. The killed turn, a pending soft-reload marker and
+  the restart-resume marker were all left armed against an agent that no longer existed,
+  so the next reconnect could announce a reload that never happened, or resume the very
+  conversation the restart was meant to discard. They are now retired before that step,
+  so nothing it does can skip them.
+  That pause itself is deliberate and stays: reconnecting there would restore the session
+  the restart exists to throw away. What it did not do was say so — the status chip, dot
+  and buttons still showed a live connection, so the panel contradicted its own message
+  and left no way to act on it. It now shows the real state and restores the Connect
+  button.
 
 ## [0.14.23] - 2026-08-12
 

--- a/browser_tests/unit/restart-resume.test.mjs
+++ b/browser_tests/unit/restart-resume.test.mjs
@@ -980,4 +980,18 @@ test("#1166: hardRestart retires the turn BEFORE any I/O, so no exit can leave i
     /ssSet\((?:MID_TASK_KEY|SOFT_RELOAD_KEY), null\);/,
     "the success branch must not re-retire what the top already retired",
   );
+  // The THIRD marker, found only after the first two were fixed. A hard restart discards
+  // the session, so a surviving restart-resume marker would resume the very conversation
+  // it exists to throw away, and the #585 watch would keep re-evaluating a revoked
+  // marker. All three are asserted together because the defect here was never one
+  // marker — it was retiring SOME of them.
+  for (const [re, what] of [
+    [/^[ \t]*ssSet\(REBOOT_KEY, null\);/m, "the restart-resume marker"],
+    [/^[ \t]*stopRebootWatch\(\);/m, "the restart-resume watch"],
+    [/^[ \t]*forgetRebootResumeAttempt\(\);/m, "the in-flight resume attempt"],
+  ]) {
+    const site = at(re);
+    assert.notEqual(site, -1, `a deliberate restart must retire ${what}`);
+    assert.ok(site < okBranchAt, `${what} must be retired on every exit, not only on success`);
+  }
 });

--- a/browser_tests/unit/restart-resume.test.mjs
+++ b/browser_tests/unit/restart-resume.test.mjs
@@ -1,5 +1,8 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+// #1166 adds one structural test over the panel source (where a call sits relative to
+// the restart's I/O), which the rest of this pure-logic file does not need.
+import { readFileSync } from "node:fs";
 
 import {
   adoptRebootRuns,
@@ -906,4 +909,57 @@ test("#585: an unavailable tracker reports every watched run as owed — never n
 test("#585: run ids normalize to strings so a numeric prompt_id survives the sessionStorage round-trip", () => {
   const raw = encodeRebootMarker({ at: 1, runs: [7, "7", null, undefined, 8] });
   assert.deepEqual(decodeRebootMarker(raw).runs, ["7", "8"]);
+});
+
+// ── #1166: a deliberate restart retires the turn on EVERY exit ────────────────
+//
+// hardRestart() cleared MID_TASK_KEY inside its `if (ok)` branch, so every failure exit
+// left the marker armed — the pack refusing, the POST throwing, and the invalidate path
+// that returns early all skipped it. The panel was then asserting a pending turn that
+// nothing would complete or retire, and because client.stop() sets closed=true (so the
+// socket's onclose suppresses the onStatus that hides the indicator) the working
+// indicator could spin forever too. The Disconnect handler already calls endTurnLocally()
+// immediately after its own client.stop(), for exactly this reason.
+//
+// Structural on purpose: the claim is about WHERE the call sits relative to the restart's
+// I/O, which is the whole content of the fix. Bounded to hardRestart's own body, with
+// both ends asserted — an unfound end silently turns `slice` into a near-whole-file scan
+// that passes wherever the tokens happen to sit (the trap corrected in #1146/#1163).
+test("#1166: hardRestart retires the turn BEFORE any I/O, so no exit can leave it armed", () => {
+  const src = readFileSync(
+    new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url),
+    "utf8",
+  );
+  const start = src.indexOf("async function hardRestart(");
+  assert.notEqual(start, -1, "could not locate hardRestart");
+  const end = src.indexOf("\n  }", start);
+  assert.notEqual(end, -1, "could not locate the end of hardRestart");
+  const body = src.slice(start, end);
+
+  // Matched as STATEMENTS (a line whose whole content is the call), never as bare
+  // tokens: this function's comments name `client.stop()` and `endTurnLocally()` while
+  // explaining the ordering, and a token search happily matches the prose — which is how
+  // the first draft of this very test passed the wrong claim. Same defect a reviewer
+  // found in the #1163 wiring assertions.
+  const at = (re) => body.search(re);
+  const retireAt = at(/^[ \t]*endTurnLocally\(\);/m);
+  const stopAt = at(/^[ \t]*client\.stop\(\);/m);
+  const tryAt = at(/^[ \t]*try \{/m);
+  assert.notEqual(retireAt, -1, "a deliberate restart must retire the turn locally");
+  assert.notEqual(stopAt, -1, "hardRestart must still drop the bridge");
+  assert.ok(
+    retireAt < stopAt,
+    "the turn must be retired BEFORE client.stop(), so a throw from stop() cannot skip it",
+  );
+  assert.ok(
+    retireAt < tryAt,
+    "…and before the try, so every failure exit has already retired it",
+  );
+  // The marker must NOT be retired only on the success branch, which is the defect.
+  const okBranchAt = at(/^[ \t]*if \(ok\) \{/m);
+  assert.notEqual(okBranchAt, -1, "expected the success branch to still exist");
+  assert.ok(
+    retireAt < okBranchAt,
+    "retiring the turn only inside `if (ok)` is the #1166 defect — every failure exit skips it",
+  );
 });

--- a/browser_tests/unit/restart-resume.test.mjs
+++ b/browser_tests/unit/restart-resume.test.mjs
@@ -962,4 +962,22 @@ test("#1166: hardRestart retires the turn BEFORE any I/O, so no exit can leave i
     retireAt < okBranchAt,
     "retiring the turn only inside `if (ok)` is the #1166 defect — every failure exit skips it",
   );
+  // The TWIN marker, held to the same rule. Review caught SOFT_RELOAD_KEY still being
+  // cleared only on success — the identical defect one line from the one being fixed,
+  // which is how this class survives a fix. A stale soft-reload marker sends the next
+  // `ready` ack down the reload branch, announcing a reload that never happened.
+  const softReloadAt = at(/^[ \t]*ssSet\(SOFT_RELOAD_KEY, null\);/m);
+  assert.notEqual(softReloadAt, -1, "hardRestart must still retire the soft-reload marker");
+  assert.ok(
+    softReloadAt < okBranchAt,
+    "SOFT_RELOAD_KEY must be retired on every exit too, not only on success",
+  );
+  // Neither marker may ALSO be set inside the success branch — a leftover write there
+  // would mean the pair had drifted back apart without either assertion above noticing.
+  const successBranch = body.slice(okBranchAt);
+  assert.doesNotMatch(
+    successBranch,
+    /ssSet\((?:MID_TASK_KEY|SOFT_RELOAD_KEY), null\);/,
+    "the success branch must not re-retire what the top already retired",
+  );
 });

--- a/browser_tests/unit/restart-resume.test.mjs
+++ b/browser_tests/unit/restart-resume.test.mjs
@@ -911,21 +911,27 @@ test("#585: run ids normalize to strings so a numeric prompt_id survives the ses
   assert.deepEqual(decodeRebootMarker(raw).runs, ["7", "8"]);
 });
 
-// ── #1166: a deliberate restart retires the turn on EVERY exit ────────────────
+// ── #1166: a successful restart retires its markers BEFORE it can bail ────────
 //
-// hardRestart() cleared MID_TASK_KEY inside its `if (ok)` branch, so every failure exit
-// left the marker armed — the pack refusing, the POST throwing, and the invalidate path
-// that returns early all skipped it. The panel was then asserting a pending turn that
-// nothing would complete or retire, and because client.stop() sets closed=true (so the
-// socket's onclose suppresses the onStatus that hides the indicator) the working
-// indicator could spin forever too. The Disconnect handler already calls endTurnLocally()
-// immediately after its own client.stop(), for exactly this reason.
+// hardRestart's success branch clears the markers that assert a live turn, but the
+// invalidate-failure path returns early — and every clear sat AFTER that return, so a
+// restart that killed the agent and then failed to invalidate left the turn, the
+// soft-reload marker and the restart-resume marker all armed against an agent that no
+// longer existed.
 //
-// Structural on purpose: the claim is about WHERE the call sits relative to the restart's
-// I/O, which is the whole content of the fix. Bounded to hardRestart's own body, with
-// both ends asserted — an unfound end silently turns `slice` into a near-whole-file scan
-// that passes wherever the tokens happen to sit (the trap corrected in #1146/#1163).
-test("#1166: hardRestart retires the turn BEFORE any I/O, so no exit can leave it armed", () => {
+// The clears belong inside `if (ok)`, NOT at the top of the function. An earlier
+// attempt hoisted them, reasoning that a deliberate restart abandons the turn whatever
+// happens. That is wrong for this pack: `/comfyui_mcp_panel/hard_restart` answers
+// `{"ok": false}` unconditionally ("orchestrator runs out-of-band"), so nothing is ever
+// killed and the old turn keeps running — hoisting cleared a LIVE turn's state on the
+// only path that actually runs.
+//
+// Structural because the claim is structural: WHERE the clears sit relative to the
+// branch and the early return is the whole content of the fix. Statements are matched
+// as statements, never as bare tokens — this function's comments name every one of
+// these calls while explaining the ordering, and an earlier draft of this test matched
+// the prose and asserted the wrong thing.
+test("#1166: a successful restart retires every marker before the invalidate can bail", () => {
   const src = readFileSync(
     new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url),
     "utf8",
@@ -935,63 +941,33 @@ test("#1166: hardRestart retires the turn BEFORE any I/O, so no exit can leave i
   const end = src.indexOf("\n  }", start);
   assert.notEqual(end, -1, "could not locate the end of hardRestart");
   const body = src.slice(start, end);
-
-  // Matched as STATEMENTS (a line whose whole content is the call), never as bare
-  // tokens: this function's comments name `client.stop()` and `endTurnLocally()` while
-  // explaining the ordering, and a token search happily matches the prose — which is how
-  // the first draft of this very test passed the wrong claim. Same defect a reviewer
-  // found in the #1163 wiring assertions.
   const at = (re) => body.search(re);
-  const retireAt = at(/^[ \t]*endTurnLocally\(\);/m);
-  const stopAt = at(/^[ \t]*client\.stop\(\);/m);
-  const tryAt = at(/^[ \t]*try \{/m);
-  assert.notEqual(retireAt, -1, "a deliberate restart must retire the turn locally");
-  assert.notEqual(stopAt, -1, "hardRestart must still drop the bridge");
-  assert.ok(
-    retireAt < stopAt,
-    "the turn must be retired BEFORE client.stop(), so a throw from stop() cannot skip it",
-  );
-  assert.ok(
-    retireAt < tryAt,
-    "…and before the try, so every failure exit has already retired it",
-  );
-  // The marker must NOT be retired only on the success branch, which is the defect.
+
   const okBranchAt = at(/^[ \t]*if \(ok\) \{/m);
-  assert.notEqual(okBranchAt, -1, "expected the success branch to still exist");
-  assert.ok(
-    retireAt < okBranchAt,
-    "retiring the turn only inside `if (ok)` is the #1166 defect — every failure exit skips it",
-  );
-  // The TWIN marker, held to the same rule. Review caught SOFT_RELOAD_KEY still being
-  // cleared only on success — the identical defect one line from the one being fixed,
-  // which is how this class survives a fix. A stale soft-reload marker sends the next
-  // `ready` ack down the reload branch, announcing a reload that never happened.
-  const softReloadAt = at(/^[ \t]*ssSet\(SOFT_RELOAD_KEY, null\);/m);
-  assert.notEqual(softReloadAt, -1, "hardRestart must still retire the soft-reload marker");
-  assert.ok(
-    softReloadAt < okBranchAt,
-    "SOFT_RELOAD_KEY must be retired on every exit too, not only on success",
-  );
-  // Neither marker may ALSO be set inside the success branch — a leftover write there
-  // would mean the pair had drifted back apart without either assertion above noticing.
-  const successBranch = body.slice(okBranchAt);
-  assert.doesNotMatch(
-    successBranch,
-    /ssSet\((?:MID_TASK_KEY|SOFT_RELOAD_KEY), null\);/,
-    "the success branch must not re-retire what the top already retired",
-  );
-  // The THIRD marker, found only after the first two were fixed. A hard restart discards
-  // the session, so a surviving restart-resume marker would resume the very conversation
-  // it exists to throw away, and the #585 watch would keep re-evaluating a revoked
-  // marker. All three are asserted together because the defect here was never one
-  // marker — it was retiring SOME of them.
+  const invalidateAt = at(/^[ \t]*if \(!await invalidateDurableAgentSession\(\)\) \{/m);
+  assert.notEqual(okBranchAt, -1, "expected the success branch");
+  assert.notEqual(invalidateAt, -1, "expected the invalidate guard");
+
+  // Every marker a restart retires, held to the same rule. Asserted together because
+  // the defect was never one marker — it was retiring SOME of them: three separate
+  // review rounds each found another that had been left behind.
   for (const [re, what] of [
+    [/^[ \t]*endTurnLocally\(\);/m, "the in-flight turn"],
+    [/^[ \t]*ssSet\(SOFT_RELOAD_KEY, null\);/m, "the soft-reload marker"],
     [/^[ \t]*ssSet\(REBOOT_KEY, null\);/m, "the restart-resume marker"],
     [/^[ \t]*stopRebootWatch\(\);/m, "the restart-resume watch"],
     [/^[ \t]*forgetRebootResumeAttempt\(\);/m, "the in-flight resume attempt"],
   ]) {
     const site = at(re);
-    assert.notEqual(site, -1, `a deliberate restart must retire ${what}`);
-    assert.ok(site < okBranchAt, `${what} must be retired on every exit, not only on success`);
+    assert.notEqual(site, -1, `a successful restart must retire ${what}`);
+    assert.ok(
+      site > okBranchAt,
+      `${what} must be retired only when the restart SUCCEEDED — this pack's ` +
+        `/hard_restart always answers ok:false, so retiring unconditionally clears a live turn`,
+    );
+    assert.ok(
+      site < invalidateAt,
+      `${what} must be retired BEFORE the invalidate, whose failure path returns early`,
+    );
   }
 });

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -29455,41 +29455,6 @@ function buildPanel() {
     if (reloading) return;
     reloading = true;
     appendSystem(tr("panel.restarting_the_agent_backend", "Restarting the agent backend…"));
-    // #1166 — retire the turn HERE, before any I/O, because a deliberate restart
-    // abandons it whatever the outcome. It used to be retired inside the `if (ok)`
-    // branch, which left every failure exit asserting a pending turn that nothing would
-    // ever complete: the pack refusing, the POST throwing, and the invalidate path that
-    // returns early all skipped it. Two things then went wrong at once — the working
-    // indicator span forever, because `client.stop()` sets closed=true and the socket's
-    // onclose suppresses the onStatus that would hide it (the same reason the Disconnect
-    // handler calls this immediately after its own stop()), and MID_TASK_KEY stayed armed
-    // as standing evidence of a live turn for the next reconnect to act on.
-    //
-    // Before the stop, not after, so a throw from stop() cannot skip it — the marker must
-    // not outlive the decision to restart, and this is the decision.
-    //
-    // Safe against the fresh agent's first turn: endTurnLocally() opens a 300ms
-    // straggler window (STALE_WORKING_GUARD_MS) to ignore a dying turn's late
-    // `turn:working`, and a backend restart cannot complete inside it.
-    endTurnLocally();
-    // …and its TWIN, for the same reason. A hard restart supersedes any pending soft
-    // reload, and this was cleared only on the success branch — the identical defect one
-    // line apart, which is worth saying plainly because fixing one marker and leaving the
-    // other is exactly how this class survives a fix. A stale soft-reload marker sends
-    // the next `ready` ack down the reload branch, announcing "Agent reloaded — session
-    // resumed" for a restart that never happened.
-    ssSet(SOFT_RELOAD_KEY, null);
-    // …and the THIRD, which review found after the first two: nothing here touched the
-    // restart-resume marker or its watch. A hard restart deliberately discards the
-    // session — that is its entire purpose — so a surviving REBOOT_KEY would resume the
-    // conversation this restart exists to throw away, and the #585 watch would keep
-    // re-evaluating a marker the restart just revoked. The Disconnect handler already
-    // retires all three together for the same reason, in the same order; this is that
-    // sequence minus the USER_DISCONNECTED_KEY latch, which belongs only to an explicit
-    // Disconnect (a restart intends to come back).
-    ssSet(REBOOT_KEY, null);
-    stopRebootWatch();
-    forgetRebootResumeAttempt();
     let ok = false;
     try {
       client.stop(); // drop the bridge so the old orchestrator can release the port
@@ -29515,6 +29480,35 @@ function buildPanel() {
       reloading = false;
     }
     if (ok) {
+      // #1166 — retire everything that asserts a live turn HERE: inside the success
+      // branch, because only a restart that actually happened killed the turn, and
+      // BEFORE the invalidate below, whose failure path returns early and skipped all of
+      // it. That early return was the real defect — not the branch itself.
+      //
+      // Deliberately NOT hoisted to the top of the function. An earlier attempt did
+      // that, on the reasoning that a deliberate restart abandons the turn whatever the
+      // outcome, and it was wrong here: this pack's /hard_restart answers `{ok: false}`
+      // unconditionally (`__init__.py`, "orchestrator runs out-of-band"), so `ok` is
+      // ALWAYS false, nothing is ever killed, and the old orchestrator's turn keeps
+      // running. Retiring at the top therefore cleared the state of a LIVE turn on the
+      // only path this pack takes — the working indicator vanishing while the agent
+      // works, and a follow-up message painting inline instead of queueing. The
+      // reconnect's `turn:working` re-announce normally repairs that, but endTurnLocally()
+      // opens a 300ms straggler window (STALE_WORKING_GUARD_MS) that can swallow it on a
+      // local bridge. The indicator staying up through a restart that did not happen is
+      // not a bug; the turn really is still running.
+      //
+      // All three markers, because retiring only some of them is how this class survives
+      // a fix: the turn itself, the soft-reload marker (a hard restart supersedes a
+      // pending reload), and the restart-resume marker plus its #585 watch (a fresh agent
+      // must not resume the conversation this restart discarded). The Disconnect handler
+      // retires the same set in the same order, minus its USER_DISCONNECTED_KEY latch,
+      // which belongs only to an explicit Disconnect because a restart intends to return.
+      endTurnLocally();
+      ssSet(SOFT_RELOAD_KEY, null);
+      ssSet(REBOOT_KEY, null);
+      stopRebootWatch();
+      forgetRebootResumeAttempt();
       // Start FRESH on reconnect: clear the saved session id so hello sends no
       // resume (resuming would restore the wedged shell). Don't arm the resume
       // nudge. The reconnect spins up a brand-new agent.

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -18262,7 +18262,7 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
       // `sock` synchronously, so their late close fails the isActive() guard above.
       // #1146 called that harmless on the grounds that every such path clears
       // MID_TASK_KEY, and that is not quite true: connectBackend() clears it only when
-      // `switching`, and hardRestart() only on its success branch (#1166).
+      // `switching`. (hardRestart() had the same hole and no longer does — #1166.)
       //
       // A WEDGED orchestrator is not covered here either: it holds its socket OPEN and
       // answers nothing, so no close ever fires and no outage is recorded for a death
@@ -29472,6 +29472,13 @@ function buildPanel() {
     // straggler window (STALE_WORKING_GUARD_MS) to ignore a dying turn's late
     // `turn:working`, and a backend restart cannot complete inside it.
     endTurnLocally();
+    // …and its TWIN, for the same reason. A hard restart supersedes any pending soft
+    // reload, and this was cleared only on the success branch — the identical defect one
+    // line apart, which is worth saying plainly because fixing one marker and leaving the
+    // other is exactly how this class survives a fix. A stale soft-reload marker sends
+    // the next `ready` ack down the reload branch, announcing "Agent reloaded — session
+    // resumed" for a restart that never happened.
+    ssSet(SOFT_RELOAD_KEY, null);
     let ok = false;
     try {
       client.stop(); // drop the bridge so the old orchestrator can release the port
@@ -29515,9 +29522,8 @@ function buildPanel() {
         // the marker outliving it, and that is now retired at the top.
         return;
       }
-      ssSet(SOFT_RELOAD_KEY, null);
-      // MID_TASK_KEY is already retired by the endTurnLocally() above, on every exit
-      // rather than only this one (#1166).
+      // Both markers are already retired at the top, on every exit rather than only this
+      // one (#1166).
       appendSystem(
         tr("panel.agent_restarted_with_a_fresh_session_your", "Agent restarted with a fresh session — your message history is still here."),
       );

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -29455,6 +29455,23 @@ function buildPanel() {
     if (reloading) return;
     reloading = true;
     appendSystem(tr("panel.restarting_the_agent_backend", "Restarting the agent backend…"));
+    // #1166 — retire the turn HERE, before any I/O, because a deliberate restart
+    // abandons it whatever the outcome. It used to be retired inside the `if (ok)`
+    // branch, which left every failure exit asserting a pending turn that nothing would
+    // ever complete: the pack refusing, the POST throwing, and the invalidate path that
+    // returns early all skipped it. Two things then went wrong at once — the working
+    // indicator span forever, because `client.stop()` sets closed=true and the socket's
+    // onclose suppresses the onStatus that would hide it (the same reason the Disconnect
+    // handler calls this immediately after its own stop()), and MID_TASK_KEY stayed armed
+    // as standing evidence of a live turn for the next reconnect to act on.
+    //
+    // Before the stop, not after, so a throw from stop() cannot skip it — the marker must
+    // not outlive the decision to restart, and this is the decision.
+    //
+    // Safe against the fresh agent's first turn: endTurnLocally() opens a 300ms
+    // straggler window (STALE_WORKING_GUARD_MS) to ignore a dying turn's late
+    // `turn:working`, and a backend restart cannot complete inside it.
+    endTurnLocally();
     let ok = false;
     try {
       client.stop(); // drop the bridge so the old orchestrator can release the port
@@ -29490,10 +29507,17 @@ function buildPanel() {
             "The old session could not be invalidated durably; reconnect is paused to avoid restoring it.",
           ),
         );
+        // #1166 — this early return DELIBERATELY skips the client.start() below, and is
+        // left that way. It looks like the #379/#419 "a reload never leaves a bridge
+        // dead" invariant being violated, but reconnecting here would restore the very
+        // session the restart exists to discard, and the pause is disclosed to the user
+        // in the line above rather than silent. What was actually wrong on this path was
+        // the marker outliving it, and that is now retired at the top.
         return;
       }
       ssSet(SOFT_RELOAD_KEY, null);
-      ssSet(MID_TASK_KEY, null);
+      // MID_TASK_KEY is already retired by the endTurnLocally() above, on every exit
+      // rather than only this one (#1166).
       appendSystem(
         tr("panel.agent_restarted_with_a_fresh_session_your", "Agent restarted with a fresh session — your message history is still here."),
       );

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -29479,6 +29479,17 @@ function buildPanel() {
     // the next `ready` ack down the reload branch, announcing "Agent reloaded — session
     // resumed" for a restart that never happened.
     ssSet(SOFT_RELOAD_KEY, null);
+    // …and the THIRD, which review found after the first two: nothing here touched the
+    // restart-resume marker or its watch. A hard restart deliberately discards the
+    // session — that is its entire purpose — so a surviving REBOOT_KEY would resume the
+    // conversation this restart exists to throw away, and the #585 watch would keep
+    // re-evaluating a marker the restart just revoked. The Disconnect handler already
+    // retires all three together for the same reason, in the same order; this is that
+    // sequence minus the USER_DISCONNECTED_KEY latch, which belongs only to an explicit
+    // Disconnect (a restart intends to come back).
+    ssSet(REBOOT_KEY, null);
+    stopRebootWatch();
+    forgetRebootResumeAttempt();
     let ok = false;
     try {
       client.stop(); // drop the bridge so the old orchestrator can release the port
@@ -29518,8 +29529,22 @@ function buildPanel() {
         // left that way. It looks like the #379/#419 "a reload never leaves a bridge
         // dead" invariant being violated, but reconnecting here would restore the very
         // session the restart exists to discard, and the pause is disclosed to the user
-        // in the line above rather than silent. What was actually wrong on this path was
-        // the marker outliving it, and that is now retired at the top.
+        // in the line above rather than silent.
+        //
+        // But a disclosure in the transcript is not enough on its own: the bridge is now
+        // down for good on this path, and until this the chip, dot and buttons still
+        // showed the connected state, so the panel contradicted its own message and left
+        // no affordance to act on it. Paint the real state and restore Connect, so the
+        // "paused" the line above describes is something the user can actually end. This
+        // is the Disconnect handler's UI block, minus its opt-out latch — the pause is
+        // this restart's, not a standing decision to stay disconnected.
+        connectBtn.hidden = false;
+        disconnectBtn.hidden = true;
+        connectBtn.disabled = false;
+        connectBtn.textContent = tr("panel.connect", "Connect");
+        statusText.textContent = tr("panel.status_disconnected", "disconnected");
+        dot.className = "cmcp-dot";
+        settingsBox.hidden = false;
         return;
       }
       // Both markers are already retired at the top, on every exit rather than only this


### PR DESCRIPTION
Closes #1166. Found by review of #1164; pre-existing, independent of #1145/#1163.

`hardRestart()` clears `MID_TASK_KEY` only inside its `if (ok)` branch, so every failure exit leaves the marker armed — asserting a pending turn that nothing will complete or retire. One path additionally returns before `client.start()`, leaving the bridge stopped with no auto-recovery, which is the #379/#419 no-dead-bridge invariant.

Draft while I read the restart paths and work out where the marker (and the reconnect) actually belong.