### PR TITLE
fix(1095): graph mutations must not lose the tab route after creating a workflow

### DIFF
--- a/browser_tests/unit/binding-recovery.test.mjs
+++ b/browser_tests/unit/binding-recovery.test.mjs
@@ -645,17 +645,24 @@ test("#607 an unreadable live identity re-hellos nothing (unknown is not new evi
   assert.equal(hellos, 0, "an unknown identity must not be treated as a changed one");
 });
 
-test("#607 sendHello reports whether the hello reached the wire, and publishes only then", () => {
-  // The hook's budget is only meaningful if `sendHello()` answers truthfully: a
+test("#607 the hello reports whether it reached the wire, and publishes only then", () => {
+  // The hook's budget is only meaningful if the hello answers truthfully: a
   // closed socket must resolve false rather than an ignored undefined, and the
   // advertised identity must be published on the success path, never at payload
   // time — publishing early would credit a hello that did not happen.
-  const src = balancedFrom(SRC, "function sendHello()");
+  //
+  // #1095 — this reads `advertiseHello`, the payload builder, which is what these
+  // assertions have always been about. `sendHello` is now the GATED entry point in front
+  // of it (it holds a re-advertise until in-flight commands have replied), so pointing
+  // this at `sendHello` would silently slice a five-line wrapper and pass on the absence
+  // of everything it checks — the same "a passing assertion stops meaning what it checks"
+  // trap this suite has corrected three times for character-window slices.
+  const src = balancedFrom(SRC, "function advertiseHello()");
   assert.match(src, /readyState !== WebSocket\.OPEN\) return Promise\.resolve\(false\)/);
   assert.match(src, /return sendBridgeHello\(/);
   assert.match(src, /return sent === true;/);
   const publishAt = src.indexOf("lastAdvertisedWorkflowUuid = advertisedWorkflowUuid;");
-  assert.notEqual(publishAt, -1, "sendHello must publish what it advertised");
+  assert.notEqual(publishAt, -1, "the hello must publish what it advertised");
   const successAt = src.indexOf("if (sent) {");
   assert.ok(successAt !== -1 && publishAt > successAt, "…only inside the success branch");
   const payloadAt = src.indexOf("(advertisedWorkflowUuid = workflowStableUuid())");

--- a/browser_tests/unit/canvas-tool-disclosure.test.mjs
+++ b/browser_tests/unit/canvas-tool-disclosure.test.mjs
@@ -480,11 +480,16 @@ test("the README does not promise parity it cannot guarantee — anywhere in the
   assert.match(readme, /identical \*\*as served\*\*/);
 });
 
-/** The whole body of the bridge client's sendHello(). */
+/** The whole body of the bridge client's hello PAYLOAD builder.
+ *
+ *  #1095 — `advertiseHello`, not `sendHello`. `sendHello` is now the gated entry point in
+ *  front of it (a re-advertise waits for in-flight commands to reply), so slicing from
+ *  `sendHello` would return a five-line wrapper containing none of what this file asserts —
+ *  and `assert.equal(count, 1)` style checks would keep passing on an empty window. */
 function sendHelloBody(source) {
-  const start = source.indexOf("  function sendHello() {");
+  const start = source.indexOf("  function advertiseHello() {");
   const end = source.indexOf("  // When the workflow title changes", start);
-  assert.ok(start >= 0 && end > start, "could not locate sendHello");
+  assert.ok(start >= 0 && end > start, "could not locate advertiseHello");
   return source.slice(start, end);
 }
 

--- a/browser_tests/unit/change-tracker-snapshot.test.mjs
+++ b/browser_tests/unit/change-tracker-snapshot.test.mjs
@@ -46,9 +46,14 @@ test("#581 wires the deferred snapshot after delivering a successful command rep
   const here = dirname(fileURLToPath(import.meta.url));
   const source = readFileSync(join(here, "../../web/js/comfyui-mcp-panel.js"), "utf8").replace(/\r\n/g, "\n");
   const capture = source.indexOf("changeTrackerToSnapshot =");
-  const deliver = source.indexOf("if (deliverReply(reply, msg.cmd, superseded))", capture);
-  const defer = source.indexOf("deferChangeTrackerSnapshot(changeTrackerToSnapshot)", deliver);
+  // #1095 — matched on the leading arguments, not the exact arity. The claim here is about
+  // ORDER (capture → deliver → defer the snapshot); pinning the full call made it fail when
+  // the in-flight mark became a fourth argument, which is a passing assertion breaking for a
+  // reason unrelated to what it checks.
+  const deliver = source.slice(capture).search(/if \(deliverReply\(reply, msg\.cmd, superseded[,)]/);
+  const deliverAt = deliver === -1 ? -1 : capture + deliver;
+  const defer = source.indexOf("deferChangeTrackerSnapshot(changeTrackerToSnapshot)", deliverAt);
   assert.ok(capture >= 0, "successful executor path captures its tracker");
-  assert.ok(deliver > capture, "reply delivery follows the successful executor");
-  assert.ok(defer > deliver, "snapshot is scheduled only after the reply is delivered");
+  assert.ok(deliverAt > capture, "reply delivery follows the successful executor");
+  assert.ok(defer > deliverAt, "snapshot is scheduled only after the reply is delivered");
 });

--- a/browser_tests/unit/command-dedupe.test.mjs
+++ b/browser_tests/unit/command-dedupe.test.mjs
@@ -525,7 +525,14 @@ test("#694 wiring: the panel handler falls back to retry_of and REWRITES the rid
   // falling through to begin + execute.
   const fpAt = src.indexOf("const fingerprint = commandFingerprint(msg);");
   assert.notEqual(fpAt, -1, "the command handler must fingerprint the frame");
-  const block = src.slice(fpAt, fpAt + 3600);
+  // Bounded by the executor's `try {`, which is the structural end of the dedupe region,
+  // not by a fixed character count. The count stood in for "the dedupe block" and stopped
+  // meaning it the moment the block grew a comment (#1095 added one) — a passing
+  // assertion failing for a reason unrelated to what it checks. Third instance of this
+  // trap in the suite, after markConnected and #508's codex R3.
+  const blockEnd = src.indexOf("\n        try {", fpAt);
+  assert.notEqual(blockEnd, -1, "could not locate the end of the dedupe block");
+  const block = src.slice(fpAt, blockEnd);
   assert.match(block, /const commandEpoch = thisSock\.__cmcpBridgeEpoch;/, "the command snapshots its socket epoch");
   assert.match(
     block,

--- a/browser_tests/unit/command-liveness.test.mjs
+++ b/browser_tests/unit/command-liveness.test.mjs
@@ -846,8 +846,14 @@ test("#1095 codex P1: BOTH outbound send paths consult the advertised route firs
     }
     ts.forEachChild(n, walk);
   })(sf);
-  assert.equal(holdSites.length, 2, "sendUserMessage and sendFrame must both be able to hold");
-  assert.equal(staleReads.length, 2, "…and each hold must be gated on the check");
+  // ONE hold site, not two. A queued frame's outcome is not yet known, so it may only be
+  // queued where nobody reads the answer — which is `sendFrame`'s session-ordered control
+  // frames alone. `sendUserMessage` REFUSES instead: queueing it and answering `true` would
+  // report it delivered while it can still be discarded (runCompletion's markDelivered
+  // retires a prompt permanently on exactly that answer), and answering `false` would leave
+  // the tray showing failed while the queued copy still goes out on the next advertisement.
+  assert.equal(holdSites.length, 1, "only the session-ordered control frames may be queued");
+  assert.equal(staleReads.length, 2, "…but BOTH send paths must consult the route first");
   assert.equal(
     (src.match(/^\s*function advertisedRouteIsStale\(\) \{/gm) || []).length,
     1,
@@ -862,11 +868,6 @@ test("#1095 codex P1: BOTH outbound send paths consult the advertised route firs
     const end = src.indexOf("\n    },", at);
     assert.notEqual(end, -1, `could not bound ${name}`);
     const body = src.slice(at, end);
-    assert.match(
-      body,
-      /if \(advertisedRouteIsStale\(\)\) return rehelloGate\.holdForRoute\(send, [^;]+\);/,
-      `${name} must hold the frame, stamped with its route, when the advertised route is stale`,
-    );
     const guardAt = body.indexOf("if (advertisedRouteIsStale())");
     const plainAt = body.lastIndexOf("return send();");
     assert.ok(guardAt !== -1 && plainAt > guardAt, `${name} must only send directly AFTER the guard`);
@@ -875,6 +876,35 @@ test("#1095 codex P1: BOTH outbound send paths consult the advertised route firs
     const buildAt = body.indexOf("const send = () => {");
     assert.ok(buildAt !== -1 && buildAt < guardAt, `${name} must build the frame before deciding`);
   }
+
+  // sendUserMessage refuses outright; only sendFrame may queue, and only for the frames
+  // whose senders ignore the answer.
+  const umAt = src.indexOf("    sendUserMessage(");
+  const umBody = src.slice(umAt, src.indexOf("\n    },", umAt));
+  assert.match(umBody, /if \(advertisedRouteIsStale\(\)\) return false;/, "a user message is refused, never queued");
+  // The CALL, not the word — the comment above it names holdForRoute to explain why this
+  // path deliberately does not use it.
+  assert.equal(
+    /rehelloGate\.holdForRoute\(/.test(umBody),
+    false,
+    "…and it must not reach the queue at all",
+  );
+
+  const sfAt = src.indexOf("    sendFrame(frame) {");
+  const sfBody = src.slice(sfAt, src.indexOf("\n    },", sfAt));
+  assert.match(
+    sfBody,
+    /if \(!SESSION_ORDERED_FRAMES\.has\(frame\?\.type\)\) return false;/,
+    "every other control frame is refused, so runCompletion re-pends instead of retiring",
+  );
+  assert.match(sfBody, /return rehelloGate\.holdForRoute\(send, routeId\);/, "…and the queued one carries its route");
+  // The set must stay exactly the fire-and-forget session frames. Adding a frame whose
+  // sender reads the return would reintroduce "reported delivered, then discarded".
+  assert.match(
+    src,
+    /const SESSION_ORDERED_FRAMES = new Set\(\["resume_session", "new_session"\]\);/,
+    "only fire-and-forget session frames may be queued",
+  );
 
   // The comparison must be against what the hello ACTUALLY carried, recorded on the landed
   // path only — the same rule as lastAdvertisedWorkflowUuid and advertisedSock beside it.

--- a/browser_tests/unit/command-liveness.test.mjs
+++ b/browser_tests/unit/command-liveness.test.mjs
@@ -637,4 +637,10 @@ test("#1095: the in-flight command count is paired, and read before a re-target"
     "the deferral must be bounded so a stuck command cannot strand the tab");
   assert.match(body, /^\s*workflowRetargetDeferrals = 0;/m,
     "…and the budget must reset once the re-target proceeds");
+  // …and the budget must be released on the no-change path too, not only when a deferred
+  // switch proceeds. A counter that only ratchets one way leaves an ABANDONED switch
+  // (deferred a tick, then the id settles back) part-spent, so the next genuine switch
+  // gets fewer deferrals than it is owed.
+  const resets = (body.match(/^\s*workflowRetargetDeferrals = 0;/gm) || []).length;
+  assert.ok(resets >= 2, "the deferral budget must reset on the no-change path as well");
 });

--- a/browser_tests/unit/command-liveness.test.mjs
+++ b/browser_tests/unit/command-liveness.test.mjs
@@ -476,7 +476,14 @@ test("#508 codex R3: a command arriving on an ALREADY-superseded socket is refus
   assert.ok(parseAt !== -1 && guardAt !== -1, "the listener must parse before the instance guard");
   assert.ok(parseAt < guardAt, "the frame must be parsed BEFORE the superseded early return");
   // …and the refusal must be rid-correlated, explicitly NOT-APPLIED, and delivered/journaled.
-  const guarded = listener.slice(guardAt, guardAt + 1600);
+  // Bounded by the guard block's OWN closing brace, not a fixed character count. The
+  // count stood in for "inside this block" and stopped meaning it the moment the block
+  // grew a comment (#1095 added one) — a passing assertion turning into a failing one for
+  // a reason unrelated to what it checks, the same trap corrected for markConnected in
+  // #1146. `\n      }` is this block's indent level, so it cannot match an inner brace.
+  const guardEnd = listener.indexOf("\n      }", guardAt);
+  assert.notEqual(guardEnd, -1, "could not locate the end of the superseded guard");
+  const guarded = listener.slice(guardAt, guardEnd);
   assert.match(guarded, /if \(isCommandFrame\) \{/, "only command frames get a refusal");
   assert.match(guarded, /rid: msg\.rid/, "the refusal must correlate to the command");
   assert.match(guarded, /ok: false/, "a stale command is refused, never reported as done");
@@ -561,4 +568,73 @@ test("#508 wiring: self-heal re-registers via sendHello ONLY — it can never pi
   // workflow — no id argument, no list lookup, no adoption of another tab.
   assert.equal(/tab_id|tabMigrations|attach_tab|openWorkflows/.test(body), false, "self-heal must not select a target tab");
   assert.match(body, /reRegisterExhaustedHint\(\)/, "an exhausted budget must surface a user action");
+});
+
+// ── #1095: a workflow re-target must not withdraw a route mid-command ─────────
+//
+// rehelloForWorkflow's own note says the backend DROPS the socket's prior tab mapping
+// when the panel re-advertises. That is correct — it stops a background workflow's output
+// leaking into this tab — but it must not happen while a command is routed to that
+// mapping: the orchestrator loses the route mid-command and reports OUTCOME UNKNOWN for
+// work that actually applied, then "Connected: none" until the new mapping settles.
+// Creating a workflow and immediately applying a batch of mutations is exactly that
+// window, since the workflow poll ticks every 600ms — between two commands.
+//
+// Structural, because the claim is about WHERE the counter moves relative to the command
+// branch and the reply. Statements are matched as statements: this region's comments name
+// every one of these calls while explaining the ordering.
+test("#1095: the in-flight command count is paired, and read before a re-target", () => {
+  const src = readFileSync(PANEL_JS, "utf8");
+  const at = (re) => src.search(re);
+
+  // Every increment must be paired with the single decrement in deliverReply, or the
+  // count drifts: too high strands the tab on the old route until the budget runs out,
+  // too low reopens the race. Both command paths that reach deliverReply increment.
+  const incs = (src.match(/^\s*commandsInFlight\+\+;/gm) || []).length;
+  const decs = (src.match(/^\s*if \(commandsInFlight > 0\) commandsInFlight--;/gm) || []).length;
+  assert.equal(incs, 2, "both command paths that deliver a reply must mark it in flight");
+  assert.equal(decs, 1, "the count is released in exactly one place — deliverReply");
+
+  // The decrement must live INSIDE deliverReply, which every command path reaches once.
+  const dStart = src.indexOf("const deliverReply = (reply, cmd, superseded) => {");
+  assert.notEqual(dStart, -1, "could not locate deliverReply");
+  const dEnd = src.indexOf("\n    };", dStart);
+  assert.notEqual(dEnd, -1, "could not locate the end of deliverReply");
+  assert.match(
+    src.slice(dStart, dEnd),
+    /if \(commandsInFlight > 0\) commandsInFlight--;/,
+    "the command is finished when its reply is handed over, whatever happens to it after",
+  );
+
+  // The superseded-socket refusal replies too, so it must balance the pair. The count is
+  // CLIENT-scoped while that branch runs on a RETIRED socket, so an unpaired decrement
+  // there would discount a command still running on the live socket — reintroducing the
+  // race through the bookkeeping meant to close it.
+  const gStart = src.indexOf("if (!isActive()) {");
+  const gEnd = src.indexOf("\n      }", gStart);
+  assert.ok(gStart !== -1 && gEnd !== -1, "could not bound the superseded guard");
+  assert.match(
+    src.slice(gStart, gEnd),
+    /commandsInFlight\+\+;/,
+    "the superseded refusal must balance the decrement its deliverReply performs",
+  );
+
+  // The poll must consult the count BEFORE it commits the new workflow id. Advancing the
+  // id and deferring only the hello would swallow the change forever, because the next
+  // tick's `wfid === currentWorkflowId` early return would treat it as handled.
+  const wStart = src.indexOf("function onWorkflowMaybeChanged() {");
+  const wEnd = src.indexOf("\n  }", wStart);
+  assert.ok(wStart !== -1 && wEnd !== -1, "could not bound onWorkflowMaybeChanged");
+  const body = src.slice(wStart, wEnd);
+  const readAt = body.search(/client\?\.commandsInFlight\?\.\(\) > 0/);
+  const commitAt = body.search(/^\s*currentWorkflowId = /m);
+  assert.notEqual(readAt, -1, "the re-target must consult the in-flight count");
+  assert.notEqual(commitAt, -1, "the re-target must still commit the new workflow id");
+  assert.ok(readAt < commitAt, "the count must be read BEFORE the id is committed");
+
+  // …and the wait must be BOUNDED: unbounded turns a race into a wedge, which is worse.
+  assert.match(body, /workflowRetargetDeferrals < MAX_WORKFLOW_RETARGET_DEFERRALS/,
+    "the deferral must be bounded so a stuck command cannot strand the tab");
+  assert.match(body, /^\s*workflowRetargetDeferrals = 0;/m,
+    "…and the budget must reset once the re-target proceeds");
 });

--- a/browser_tests/unit/command-liveness.test.mjs
+++ b/browser_tests/unit/command-liveness.test.mjs
@@ -17,6 +17,10 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
+// #1095 needs a REAL parser: the invariant is that no path exits between marking a
+// command in flight and replying, which is a reachability property a token count cannot
+// express — as review proved by running the counting version against the leaking code.
+import ts from "typescript";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 
@@ -594,6 +598,69 @@ test("#1095: the in-flight command count is paired, and read before a re-target"
   const decs = (src.match(/^\s*if \(commandsInFlight > 0\) commandsInFlight--;/gm) || []).length;
   assert.equal(incs, 2, "both command paths that deliver a reply must mark it in flight");
   assert.equal(decs, 1, "the count is released in exactly one place — deliverReply");
+
+  // COUNTING THOSE IS NOT ENOUGH, and this test shipped believing it was. Review proved
+  // it by execution: at the revision where the increment sat ABOVE the #517 dedupe region
+  // — with five paths returning before any reply, leaking the count permanently — this
+  // file was byte-identical and still passed. Two increments and one decrement is true of
+  // both the broken and the fixed arrangement, so the assertions above cannot tell them
+  // apart. What actually matters is a REACHABILITY property, so it has to be read off the
+  // syntax tree rather than off a token count.
+  //
+  // The real invariant: between the increment and the reply there is no exit. Returns and
+  // throws inside a try are excluded — the executor's throws are caught below and turned
+  // into a reply, which is the whole point of that catch.
+  const sf = ts.createSourceFile(PANEL_JS, src, ts.ScriptTarget.ESNext, true, ts.ScriptKind.JS);
+  let branch = null;
+  (function findBranch(n) {
+    if (
+      ts.isIfStatement(n) &&
+      n.expression.getText(sf) === "isCommandFrame" &&
+      n.getEnd() - n.getStart(sf) > 5000 // the executing branch, not the refusal stub
+    ) branch = n;
+    ts.forEachChild(n, findBranch);
+  })(sf);
+  assert.ok(branch, "could not locate the executing command branch");
+
+  let incPos = -1;
+  let replyPos = -1;
+  (function locate(n) {
+    if (ts.isPostfixUnaryExpression(n) && n.operand.getText(sf) === "commandsInFlight") {
+      incPos = n.getStart(sf);
+    }
+    if (ts.isCallExpression(n) && n.expression.getText(sf) === "deliverReply") {
+      replyPos = n.getStart(sf);
+    }
+    ts.forEachChild(n, locate);
+  })(branch);
+  assert.ok(incPos !== -1 && replyPos !== -1, "the branch must mark in flight and deliver a reply");
+  assert.ok(incPos < replyPos, "the mark must precede the reply that releases it");
+
+  const escapes = [];
+  (function scan(n) {
+    if (ts.isFunctionLike(n) && n !== branch) return; // nested callbacks have their own exits
+    if (ts.isTryStatement(n)) {
+      // A throw inside `try` is caught and answered; only the handlers can truly exit.
+      if (n.catchClause) ts.forEachChild(n.catchClause, scan);
+      if (n.finallyBlock) ts.forEachChild(n.finallyBlock, scan);
+      return;
+    }
+    if (
+      (ts.isReturnStatement(n) || ts.isThrowStatement(n)) &&
+      n.getStart(sf) > incPos &&
+      n.getStart(sf) < replyPos
+    ) {
+      escapes.push(sf.getLineAndCharacterOfPosition(n.getStart(sf)).line + 1);
+    }
+    ts.forEachChild(n, scan);
+  })(branch);
+  assert.deepEqual(
+    escapes,
+    [],
+    `every exit between marking a command in flight and replying leaks the count — ` +
+      `a leaked count never returns to 0, so every later workflow switch pays the full ` +
+      `deferral budget. Leaking exits at line(s): ${escapes.join(", ")}`,
+  );
 
   // The decrement must live INSIDE deliverReply, which every command path reaches once.
   const dStart = src.indexOf("const deliverReply = (reply, cmd, superseded) => {");

--- a/browser_tests/unit/command-liveness.test.mjs
+++ b/browser_tests/unit/command-liveness.test.mjs
@@ -459,7 +459,11 @@ test("#508 wiring: a SUPERSEDED socket still gets its reply — only the UI cont
   const supersededAt = src.indexOf("const superseded = !isActive();");
   assert.notEqual(supersededAt, -1, "the instance guard must be captured, not used as an early return");
   const block = src.slice(supersededAt, supersededAt + 1200);
-  const sendAt = block.indexOf("deliverReply(reply, msg.cmd, superseded)");
+  // #1095 — matched on the leading arguments, not the whole call. The claim here is about
+  // ORDER (the reply is written before the superseded early return), and pinning the exact
+  // arity made it fail when the in-flight mark became a fourth argument — a passing
+  // assertion breaking for a reason unrelated to what it checks.
+  const sendAt = block.search(/deliverReply\(reply, msg\.cmd, superseded[,)]/);
   const gateAt = block.indexOf("if (superseded) return;");
   assert.notEqual(sendAt, -1, "the reply must still be written to the socket it arrived on");
   assert.notEqual(gateAt, -1, "the UI continuation must still be gated on the instance guard");
@@ -607,10 +611,26 @@ test("#1095: the in-flight mark is paired across the command branch", () => {
   // Every mark must be paired with the single release in deliverReply, or the count
   // drifts: too high delays a re-advertise until the budget runs out, too low reopens the
   // race. Both command paths that reach deliverReply mark.
-  const marks = (src.match(/^\s*rehelloGate\.began\(/gm) || []).length;
-  const releases = (src.match(/^\s*rehelloGate\.ended\(\);/gm) || []).length;
+  const marks = (src.match(/^\s*(?:const \w+ = )?rehelloGate\.began\(/gm) || []).length;
+  const releases = (src.match(/^\s*rehelloGate\.ended\(mark\);/gm) || []).length;
   assert.equal(marks, 2, "both command paths that deliver a reply must mark it in flight");
   assert.equal(releases, 1, "the mark is released in exactly one place — deliverReply");
+
+  // codex P1 — the release must NAME the mark it is releasing. deliverReply is per-SOCKET
+  // while marks are per-COMMAND, and the two lifetimes come apart the moment a connection is
+  // replaced: cancel() invalidates the retired socket's marks, but a command already
+  // executing there still finishes and still calls this. A release that named nothing would
+  // land on whatever the NEW socket is running. Both call sites must therefore pass one.
+  assert.equal(
+    (src.match(/^\s*const deliverReply = \(reply, cmd, superseded, mark\) => \{/gm) || []).length,
+    1,
+    "deliverReply must take the mark from its caller, not release blind",
+  );
+  assert.equal(
+    /rehelloGate\.ended\(\);/.test(src),
+    false,
+    "an unnamed release would discount a command belonging to another generation",
+  );
 
   // COUNTING THOSE IS NOT ENOUGH, and this test shipped believing it was. Review proved
   // it by execution: at the revision where the mark sat ABOVE the #517 dedupe region —
@@ -676,13 +696,13 @@ test("#1095: the in-flight mark is paired across the command branch", () => {
   );
 
   // The release must live INSIDE deliverReply, which every command path reaches once.
-  const dStart = src.indexOf("const deliverReply = (reply, cmd, superseded) => {");
+  const dStart = src.indexOf("const deliverReply = (reply, cmd, superseded, mark) => {");
   assert.notEqual(dStart, -1, "could not locate deliverReply");
   const dEnd = src.indexOf("\n    };", dStart);
   assert.notEqual(dEnd, -1, "could not locate the end of deliverReply");
   assert.match(
     src.slice(dStart, dEnd),
-    /rehelloGate\.ended\(\);/,
+    /rehelloGate\.ended\(mark\);/,
     "the command is finished when its reply is handed over, whatever happens to it after",
   );
 
@@ -695,8 +715,37 @@ test("#1095: the in-flight mark is paired across the command branch", () => {
   assert.ok(gStart !== -1 && gEnd !== -1, "could not bound the superseded guard");
   assert.match(
     src.slice(gStart, gEnd),
-    /rehelloGate\.began\(\);/,
+    /const refusalMark = rehelloGate\.began\(\);/,
     "the superseded refusal must balance the release its deliverReply performs",
+  );
+});
+
+test("#1095 codex P2: an ordinary socket close clears the gate, like every other teardown", () => {
+  // stop() / setUrl() / destroy() are the PANEL-DRIVEN teardowns; they null `sock`
+  // synchronously, so their late close fails the active guard and never reaches this
+  // handler. An ordinary drop (network, server restart) reaches recovery only through
+  // scheduleReconnect here — so this was the one path that let a replacement socket inherit
+  // the previous connection's gate state: a parked waiter or its timer could fire a hello
+  // against the NEW socket, and the dead socket's outstanding marks would delay the next
+  // legitimate re-advertise.
+  const src = readFileSync(PANEL_JS, "utf8");
+  const closeAt = src.indexOf('thisSock.addEventListener("close", () => {');
+  assert.notEqual(closeAt, -1, "could not locate the close handler");
+  const closeEnd = src.indexOf("\n    });", closeAt);
+  assert.notEqual(closeEnd, -1, "could not locate the end of the close handler");
+  const body = src.slice(closeAt, closeEnd);
+
+  // It must be gated on the ACTIVE socket: a superseded socket's close must not clear the
+  // live connection's gate — that would withdraw the route from commands running on it.
+  const guardAt = body.indexOf("if (!isActive()) return;");
+  const cancelAt = body.indexOf("rehelloGate.cancel();");
+  assert.notEqual(guardAt, -1, "the handler must ignore a superseded socket's close");
+  assert.notEqual(cancelAt, -1, "an ordinary close must drop any parked re-advertise");
+  assert.ok(guardAt < cancelAt, "…and only for the socket that is actually current");
+  assert.match(
+    body,
+    /advertisedSock = null;/,
+    "the replacement socket has no mapping yet, so its first hello must not be gated",
   );
 });
 
@@ -768,18 +817,19 @@ test("#1095: EVERY re-advertise goes through the gate — no caller can bypass i
 
   // A parked hello belongs to the connection it was queued for. Every teardown path must
   // drop it: setUrl (pointing at a DIFFERENT bridge — firing there would register this tab
-  // somewhere nobody asked for, the corruption class #508 refuses to risk), stop, and
-  // destroy (a timer firing from a closure nothing owns any more). Three paths, three
-  // cancels — the same "setUrl/stop/destroy must all forget it" rule already asserted for
-  // `handshakenSock` above.
+  // somewhere nobody asked for, the corruption class #508 refuses to risk), stop, destroy
+  // (a timer firing from a closure nothing owns any more), and — codex P2 — the ordinary
+  // socket close, which is the only one of the four that recovers by RECONNECTING rather
+  // than by tearing the client down, and so was the one that let a replacement socket
+  // inherit its predecessor's gate state.
   assert.equal(
     (src.match(/^\s*rehelloGate\.cancel\(\);/gm) || []).length,
-    3,
-    "setUrl, stop and destroy must each drop a parked re-advertise",
+    4,
+    "setUrl, stop, destroy and an active close must each drop a parked re-advertise",
   );
   assert.equal(
     (src.match(/^\s*advertisedSock = null;/gm) || []).length,
-    3,
+    4,
     "…and each must forget the socket that had a mapping, so the next hello is a first one",
   );
 });

--- a/browser_tests/unit/command-liveness.test.mjs
+++ b/browser_tests/unit/command-liveness.test.mjs
@@ -559,8 +559,18 @@ test("#508 wiring: an undelivered reply is journaled, replayed after hello, and 
   // codex R10 — replay must fire on the real HANDSHAKE, not at bare socket-open: an open
   // socket only proves something is listening on the port, while the `models` frame proves
   // a real orchestrator is behind it. The hello already went out at open.
-  const openHandler = src.slice(src.indexOf('thisSock.addEventListener("open"'));
-  assert.match(openHandler.slice(0, 2000), /sendHello\(\);/, "the hello still rides socket-open");
+  // Bounded by the handler's OWN closing brace, not by a character count. This file has
+  // already corrected the same trap twice — for markConnected (#1145) and for the
+  // superseded guard (#1095) — and the window had 71 characters left: ONE more comment
+  // line in the open handler and this assertion goes red for a reason that has nothing to
+  // do with whether the hello rides socket-open. Measured, not guessed: `sendHello();` sat
+  // at offset 1929 of 2000 in a 3308-character handler.
+  const openAt = src.indexOf('thisSock.addEventListener("open"');
+  assert.notEqual(openAt, -1, "could not locate the socket open handler");
+  const openEnd = src.indexOf("\n    });", openAt);
+  assert.notEqual(openEnd, -1, "could not locate the end of the open handler");
+  const openHandler = src.slice(openAt, openEnd);
+  assert.match(openHandler, /sendHello\(\);/, "the hello still rides socket-open");
   assert.equal(
     /replayLostReplies\(thisSock\);/.test(src),
     false,

--- a/browser_tests/unit/command-liveness.test.mjs
+++ b/browser_tests/unit/command-liveness.test.mjs
@@ -278,13 +278,17 @@ test("codex R11 / #694: summaries obey the SAME cross-bridge/session/age rule as
   // #694 — the hello fires at socket-open, BEFORE the models handshake stamps the
   // socket's epoch: a summary computed there is filtered with an UNKNOWN epoch and can
   // contradict the epoch-filtered replay. The hello must therefore carry NO summaries…
-  const helloStart = src.indexOf("function sendHello() {");
-  assert.notEqual(helloStart, -1);
+  // #1095 — `advertiseHello` is the payload builder; `sendHello` in front of it is the
+  // gate. Slicing the gate would prove nothing, because a five-line wrapper trivially
+  // contains no `lostReplies` — the assertion would pass on an empty window instead of on
+  // the code it is about.
+  const helloStart = src.indexOf("function advertiseHello() {");
+  assert.notEqual(helloStart, -1, "could not locate the hello payload builder");
   const helloBody = src.slice(helloStart, src.indexOf("\n  }", helloStart));
   assert.equal(
     /lostReplies|lost_replies/.test(helloBody.replace(/\/\/[^\n]*/g, "")),
     false,
-    "sendHello must not advertise lost-reply summaries computed before the epoch is known",
+    "the hello must not advertise lost-reply summaries computed before the epoch is known",
   );
   // …they ride the post-handshake `lost_replies` frame, sent from INSIDE the replay with
   // the SAME targetUrl/targetEpoch locals the replay loop uses — agreement by construction.
@@ -474,7 +478,15 @@ test("#508 codex R3: a command arriving on an ALREADY-superseded socket is refus
   // frame outright — neither executed, nor replied to, nor journaled — which is the very
   // "registered tab that never acknowledges anything" wedge this change exists to remove.
   const listenerAt = src.indexOf('thisSock.addEventListener("message"');
-  const listener = src.slice(listenerAt, listenerAt + 3000);
+  assert.notEqual(listenerAt, -1, "could not locate the message listener");
+  // Searched from the listener's start over the WHOLE source, not over a fixed 3000-char
+  // window. The window was the same stand-in for "inside this listener" that this test
+  // already corrects one line below, and it failed for the same reason on the very next
+  // comment added to the guard (#1095's second pass): the block moved past character 3000
+  // and `guardEnd` came back -1 from a slice that had been truncated mid-block, not from
+  // any change to what is being asserted. The two `indexOf`s below are ordered relative to
+  // each other, which is the actual claim, and both are asserted to have been found.
+  const listener = src.slice(listenerAt);
   const parseAt = listener.indexOf("msg = JSON.parse(");
   const guardAt = listener.indexOf("if (!isActive()) {");
   assert.ok(parseAt !== -1 && guardAt !== -1, "the listener must parse before the instance guard");
@@ -574,7 +586,7 @@ test("#508 wiring: self-heal re-registers via sendHello ONLY — it can never pi
   assert.match(body, /reRegisterExhaustedHint\(\)/, "an exhausted budget must surface a user action");
 });
 
-// ── #1095: a workflow re-target must not withdraw a route mid-command ─────────
+// ── #1095: a re-advertise must not withdraw a route mid-command ───────────────
 //
 // rehelloForWorkflow's own note says the backend DROPS the socket's prior tab mapping
 // when the panel re-advertises. That is correct — it stops a background workflow's output
@@ -584,30 +596,31 @@ test("#508 wiring: self-heal re-registers via sendHello ONLY — it can never pi
 // Creating a workflow and immediately applying a batch of mutations is exactly that
 // window, since the workflow poll ticks every 600ms — between two commands.
 //
-// Structural, because the claim is about WHERE the counter moves relative to the command
-// branch and the reply. Statements are matched as statements: this region's comments name
-// every one of these calls while explaining the ordering.
-test("#1095: the in-flight command count is paired, and read before a re-target", () => {
+// THE GATE'S BEHAVIOUR IS DRIVEN IN rehello-gate.test.mjs. What is left here is wiring
+// that only the panel source can answer: whether the mark/release pair is exactly paired
+// across the command branch, and whether EVERY re-advertise actually reaches the gate.
+// Both are structural claims about the source, which is why they are read off the syntax
+// tree; neither is a claim that some code runs, which a source pattern cannot make.
+test("#1095: the in-flight mark is paired across the command branch", () => {
   const src = readFileSync(PANEL_JS, "utf8");
-  const at = (re) => src.search(re);
 
-  // Every increment must be paired with the single decrement in deliverReply, or the
-  // count drifts: too high strands the tab on the old route until the budget runs out,
-  // too low reopens the race. Both command paths that reach deliverReply increment.
-  const incs = (src.match(/^\s*commandsInFlight\+\+;/gm) || []).length;
-  const decs = (src.match(/^\s*if \(commandsInFlight > 0\) commandsInFlight--;/gm) || []).length;
-  assert.equal(incs, 2, "both command paths that deliver a reply must mark it in flight");
-  assert.equal(decs, 1, "the count is released in exactly one place — deliverReply");
+  // Every mark must be paired with the single release in deliverReply, or the count
+  // drifts: too high delays a re-advertise until the budget runs out, too low reopens the
+  // race. Both command paths that reach deliverReply mark.
+  const marks = (src.match(/^\s*rehelloGate\.began\(/gm) || []).length;
+  const releases = (src.match(/^\s*rehelloGate\.ended\(\);/gm) || []).length;
+  assert.equal(marks, 2, "both command paths that deliver a reply must mark it in flight");
+  assert.equal(releases, 1, "the mark is released in exactly one place — deliverReply");
 
   // COUNTING THOSE IS NOT ENOUGH, and this test shipped believing it was. Review proved
-  // it by execution: at the revision where the increment sat ABOVE the #517 dedupe region
-  // — with five paths returning before any reply, leaking the count permanently — this
-  // file was byte-identical and still passed. Two increments and one decrement is true of
-  // both the broken and the fixed arrangement, so the assertions above cannot tell them
-  // apart. What actually matters is a REACHABILITY property, so it has to be read off the
-  // syntax tree rather than off a token count.
+  // it by execution: at the revision where the mark sat ABOVE the #517 dedupe region —
+  // with five paths returning before any reply, leaking it permanently — this file was
+  // byte-identical and still passed. Two marks and one release is true of both the broken
+  // and the fixed arrangement, so the assertions above cannot tell them apart. What
+  // actually matters is a REACHABILITY property, so it has to be read off the syntax tree
+  // rather than off a token count.
   //
-  // The real invariant: between the increment and the reply there is no exit. Returns and
+  // The real invariant: between the mark and the reply there is no exit. Returns and
   // throws inside a try are excluded — the executor's throws are caught below and turned
   // into a reply, which is the whole point of that catch.
   const sf = ts.createSourceFile(PANEL_JS, src, ts.ScriptTarget.ESNext, true, ts.ScriptKind.JS);
@@ -625,7 +638,7 @@ test("#1095: the in-flight command count is paired, and read before a re-target"
   let incPos = -1;
   let replyPos = -1;
   (function locate(n) {
-    if (ts.isPostfixUnaryExpression(n) && n.operand.getText(sf) === "commandsInFlight") {
+    if (ts.isCallExpression(n) && n.expression.getText(sf) === "rehelloGate.began") {
       incPos = n.getStart(sf);
     }
     if (ts.isCallExpression(n) && n.expression.getText(sf) === "deliverReply") {
@@ -657,24 +670,24 @@ test("#1095: the in-flight command count is paired, and read before a re-target"
   assert.deepEqual(
     escapes,
     [],
-    `every exit between marking a command in flight and replying leaks the count — ` +
-      `a leaked count never returns to 0, so every later workflow switch pays the full ` +
-      `deferral budget. Leaking exits at line(s): ${escapes.join(", ")}`,
+    `every exit between marking a command in flight and replying leaks the mark — ` +
+      `a leaked mark never returns the count to 0, so every later re-advertise pays the ` +
+      `full budget. Leaking exits at line(s): ${escapes.join(", ")}`,
   );
 
-  // The decrement must live INSIDE deliverReply, which every command path reaches once.
+  // The release must live INSIDE deliverReply, which every command path reaches once.
   const dStart = src.indexOf("const deliverReply = (reply, cmd, superseded) => {");
   assert.notEqual(dStart, -1, "could not locate deliverReply");
   const dEnd = src.indexOf("\n    };", dStart);
   assert.notEqual(dEnd, -1, "could not locate the end of deliverReply");
   assert.match(
     src.slice(dStart, dEnd),
-    /if \(commandsInFlight > 0\) commandsInFlight--;/,
+    /rehelloGate\.ended\(\);/,
     "the command is finished when its reply is handed over, whatever happens to it after",
   );
 
   // The superseded-socket refusal replies too, so it must balance the pair. The count is
-  // CLIENT-scoped while that branch runs on a RETIRED socket, so an unpaired decrement
+  // CLIENT-scoped while that branch runs on a RETIRED socket, so an unpaired release
   // there would discount a command still running on the live socket — reintroducing the
   // race through the bookkeeping meant to close it.
   const gStart = src.indexOf("if (!isActive()) {");
@@ -682,32 +695,93 @@ test("#1095: the in-flight command count is paired, and read before a re-target"
   assert.ok(gStart !== -1 && gEnd !== -1, "could not bound the superseded guard");
   assert.match(
     src.slice(gStart, gEnd),
-    /commandsInFlight\+\+;/,
-    "the superseded refusal must balance the decrement its deliverReply performs",
+    /rehelloGate\.began\(\);/,
+    "the superseded refusal must balance the release its deliverReply performs",
+  );
+});
+
+test("#1095: EVERY re-advertise goes through the gate — no caller can bypass it", () => {
+  // This is the finding that sent the first cut back. The deferral was implemented at ONE
+  // caller (the workflow poll), while `rehelloForWorkflow`, the #607/#570 fence via
+  // noteWorkflowInstanceMismatch, the #310 free_vram re-advertise and the #508 self-heal
+  // re-registration all call the hello directly and stayed ungated — and gating the poll
+  // made the fence trip MORE often, routing more traffic through an ungated re-hello.
+  //
+  // A guard at one caller cannot be completed by patching callers, because the next caller
+  // added is ungated again. So the property asserted is a CLOSURE one: the only code that
+  // may reach the raw send is the gate itself and the gated entry point.
+  const src = readFileSync(PANEL_JS, "utf8");
+  const sf = ts.createSourceFile(PANEL_JS, src, ts.ScriptTarget.ESNext, true, ts.ScriptKind.JS);
+
+  let gateCall = null;
+  let sendHelloFn = null;
+  let advertiseFn = null;
+  const rawCalls = [];
+  (function walk(n) {
+    if (ts.isCallExpression(n) && n.expression.getText(sf) === "createRehelloGate") gateCall = n;
+    if (ts.isFunctionDeclaration(n) && n.name?.getText(sf) === "sendHello") sendHelloFn = n;
+    if (ts.isFunctionDeclaration(n) && n.name?.getText(sf) === "advertiseHello") advertiseFn = n;
+    if (ts.isCallExpression(n) && n.expression.getText(sf) === "advertiseHello") rawCalls.push(n);
+    ts.forEachChild(n, walk);
+  })(sf);
+
+  assert.ok(gateCall, "the client must construct the re-advertise gate");
+  assert.ok(sendHelloFn, "sendHello must remain the entry point every caller already uses");
+  assert.ok(advertiseFn, "the raw hello send must exist as its own function");
+  assert.ok(rawCalls.length >= 2, "the gate and the entry point must both be able to send");
+
+  const inside = (node, host) => node.getStart(sf) >= host.getStart(sf) && node.getEnd() <= host.getEnd();
+  const strays = rawCalls
+    .filter((c) => !inside(c, gateCall) && !inside(c, sendHelloFn))
+    .map((c) => sf.getLineAndCharacterOfPosition(c.getStart(sf)).line + 1);
+  assert.deepEqual(
+    strays,
+    [],
+    `advertiseHello() may only be reached from the gate or from sendHello. A direct call ` +
+      `elsewhere is an ungated re-advertise, which is the defect this change exists to ` +
+      `close. Stray call(s) at line(s): ${strays.join(", ")}`,
   );
 
-  // The poll must consult the count BEFORE it commits the new workflow id. Advancing the
-  // id and deferring only the hello would swallow the change forever, because the next
-  // tick's `wfid === currentWorkflowId` early return would treat it as handled.
+  // …and sendHello must actually consult the gate rather than merely sitting in front of
+  // it. The bypass it DOES have is the first hello on a socket: that creates the mapping
+  // instead of replacing one, so it can strand nothing, and deferring it would leave the
+  // tab unregistered — strictly worse than the race.
+  const entry = sendHelloFn.getText(sf);
+  assert.match(entry, /rehelloGate\.request\(\)/, "a re-advertise must be routed through the gate");
+  assert.match(
+    entry,
+    /sock !== advertisedSock/,
+    "…and only the first hello on a socket may bypass it, keyed on the socket that has one",
+  );
+  // `advertisedSock` must be recorded on the SEND-LANDED path only. Arming the gate off a
+  // hello that never left the tab would defer the retry that could actually register it —
+  // the "recorded before it happened" defect this file names in three other places.
+  const advBody = advertiseFn.getText(sf);
+  const sentAt = advBody.indexOf("if (sent) {");
+  const armAt = advBody.indexOf("advertisedSock = target;");
+  assert.ok(sentAt !== -1 && armAt !== -1 && armAt > sentAt, "the gate arms only once a hello LANDED");
+
+  // The clock must be the monotonic one. A wall clock can step backwards (NTP, a laptop
+  // waking, a manual change) and an elapsed-time window built on it either expires
+  // instantly or never — the same rule as monotonicNow()'s other consumers.
+  assert.match(gateCall.getText(sf), /now:\s*monotonicNow/, "the budget is elapsed time, so it needs a monotonic clock");
+});
+
+test("#1095: the workflow poll commits its state INLINE — it no longer gates anything", () => {
+  // Review's third finding on the first cut. `panelHooks.applyChatScope` nulls
+  // `currentWorkflowId`, calls this, and then repaints the context ring and announces the
+  // scope change — it expects the re-bind to have happened. A deferred early return
+  // announced a re-bind that had not, leaving the panel internally inconsistent until a
+  // later tick repaired it. With the wait inside sendHello, only the wire send is delayed.
+  const src = readFileSync(PANEL_JS, "utf8");
   const wStart = src.indexOf("function onWorkflowMaybeChanged() {");
   const wEnd = src.indexOf("\n  }", wStart);
   assert.ok(wStart !== -1 && wEnd !== -1, "could not bound onWorkflowMaybeChanged");
   const body = src.slice(wStart, wEnd);
-  const readAt = body.search(/client\?\.commandsInFlight\?\.\(\) > 0/);
-  const commitAt = body.search(/^\s*currentWorkflowId = /m);
-  assert.notEqual(readAt, -1, "the re-target must consult the in-flight count");
-  assert.notEqual(commitAt, -1, "the re-target must still commit the new workflow id");
-  assert.ok(readAt < commitAt, "the count must be read BEFORE the id is committed");
-
-  // …and the wait must be BOUNDED: unbounded turns a race into a wedge, which is worse.
-  assert.match(body, /workflowRetargetDeferrals < MAX_WORKFLOW_RETARGET_DEFERRALS/,
-    "the deferral must be bounded so a stuck command cannot strand the tab");
-  assert.match(body, /^\s*workflowRetargetDeferrals = 0;/m,
-    "…and the budget must reset once the re-target proceeds");
-  // …and the budget must be released on the no-change path too, not only when a deferred
-  // switch proceeds. A counter that only ratchets one way leaves an ABANDONED switch
-  // (deferred a tick, then the id settles back) part-spent, so the next genuine switch
-  // gets fewer deferrals than it is owed.
-  const resets = (body.match(/^\s*workflowRetargetDeferrals = 0;/gm) || []).length;
-  assert.ok(resets >= 2, "the deferral budget must reset on the no-change path as well");
+  assert.match(body, /^\s*currentWorkflowId = /m, "the re-target must still commit the new workflow id");
+  assert.equal(
+    /commandsInFlight/.test(body.replace(/\/\/[^\n]*/g, "")),
+    false,
+    "the poll must not decide for itself whether to re-target — that is sendHello's job now",
+  );
 });

--- a/browser_tests/unit/command-liveness.test.mjs
+++ b/browser_tests/unit/command-liveness.test.mjs
@@ -661,8 +661,8 @@ test("#1095: the in-flight mark is paired across the command branch", () => {
   // race. Both command paths that reach deliverReply mark.
   const marks = (src.match(/^\s*(?:const \w+ = )?rehelloGate\.began\(/gm) || []).length;
   const releases = (src.match(/^\s*rehelloGate\.ended\(mark\);/gm) || []).length;
-  assert.equal(marks, 2, "both command paths that deliver a reply must mark it in flight");
-  assert.equal(releases, 1, "the mark is released in exactly one place — deliverReply");
+  assert.equal(marks, 3, "every command path that WAITS and then replies must mark it in flight");
+  assert.equal(releases, 1, "the deliverReply paths release in exactly one place");
 
   // codex P1 — the release must NAME the mark it is releasing. deliverReply is per-SOCKET
   // while marks are per-COMMAND, and the two lifetimes come apart the moment a connection is
@@ -749,6 +749,76 @@ test("#1095: the in-flight mark is paired across the command branch", () => {
     /const refusalMark = rehelloGate\.began\(\);/,
     "the superseded refusal must balance the release its deliverReply performs",
   );
+});
+
+test("#1095 codex P1: the duplicate-replay wait is marked, and released in a finally", () => {
+  // The #517 replay AWAITS a ledger promise and then answers with a direct `thisSock.send`,
+  // so it holds the route exactly like an executing command — and it is easy to read as
+  // "the reply already exists, nothing to protect". That is wrong when the retry lands on a
+  // REPLACEMENT socket while the original is still running: cancel() invalidated the retired
+  // socket's mark, so without one here the client believes nothing is in flight, and a
+  // workflow switch during the await lets a re-hello withdraw the replacement's route before
+  // the reply is written — the OUTCOME UNKNOWN this whole change exists to prevent.
+  const src = readFileSync(PANEL_JS, "utf8");
+  const sf = ts.createSourceFile(PANEL_JS, src, ts.ScriptTarget.ESNext, true, ts.ScriptKind.JS);
+
+  let block = null;
+  (function walk(n) {
+    if (ts.isIfStatement(n) && n.expression.getText(sf) === "priorRidReply !== undefined") block = n;
+    ts.forEachChild(n, walk);
+  })(sf);
+  assert.ok(block, "could not locate the duplicate-replay branch");
+  const body = block.getText(sf);
+  assert.match(body, /const replayMark = rehelloGate\.began\(msg\.cmd\);/, "the wait must be marked");
+  assert.match(body, /await awaitDuplicateReply\(/, "…and the mark must cover the await");
+
+  // The release must be in a `finally`. This branch answers on two of its three exits with a
+  // direct thisSock.send and never reaches deliverReply, so a release placed before any one
+  // `return` is a release the next exit added will miss.
+  let tryStmt = null;
+  (function findTry(n) {
+    if (ts.isTryStatement(n) && !tryStmt && n.getText(sf).includes("rehelloGate.ended(replayMark)")) tryStmt = n;
+    ts.forEachChild(n, findTry);
+  })(block);
+  assert.ok(tryStmt, "the replay mark must be released from a try");
+  assert.ok(tryStmt.finallyBlock, "…specifically a finally, so no exit can skip it");
+  assert.match(
+    tryStmt.finallyBlock.getText(sf),
+    /rehelloGate\.ended\(replayMark\);/,
+    "the finally must release exactly the mark this branch took",
+  );
+  // The mark must be taken OUTSIDE that try — taken inside, a throw before the assignment
+  // would run a finally that releases `undefined` and silently leaks.
+  const markAt = body.indexOf("const replayMark = rehelloGate.began(msg.cmd);");
+  const tryAt = body.indexOf(tryStmt.getText(sf));
+  assert.ok(markAt !== -1 && tryAt !== -1 && markAt < tryAt, "the mark is taken before the try it is released from");
+});
+
+test("#1095 codex P1: the canvas-tool disclosure is decided when the frame LEAVES", () => {
+  // A held frame is sent after a hello the hold expedited, and a landed hello ADVANCES
+  // agentSessionEpoch. Deciding the disclosure at call time therefore decides it for the
+  // agent generation the message will not reach: if the outgoing generation had proven its
+  // tools, `disclose` is false, the NEW generation gets no disclosure, and
+  // canvasToolMessagedEpoch then marks it as prompted — so it never gets the paragraph at
+  // all. Silent, and total for that session.
+  const src = readFileSync(PANEL_JS, "utf8");
+  const at = src.indexOf("    sendUserMessage(");
+  assert.notEqual(at, -1, "could not locate sendUserMessage");
+  const end = src.indexOf("\n    },", at);
+  const body = src.slice(at, end);
+  const closureAt = body.indexOf("const send = () => {");
+  const planAt = body.indexOf("planCanvasToolDisclosure({");
+  assert.ok(closureAt !== -1 && planAt !== -1, "both the closure and the plan must exist");
+  assert.ok(planAt > closureAt, "the disclosure must be planned INSIDE the deferred send");
+  // …and everything derived from it must live there too, or the recompute is decorative.
+  const outTextAt = body.indexOf("const outText =");
+  const disclosedAt = body.indexOf("const disclosed =");
+  assert.ok(disclosedAt > closureAt && outTextAt > closureAt, "the decision and the text ride with it");
+  // The one-shot context is the opposite case and must stay OUTSIDE: pendingContext is
+  // consumed when the user presses send, and re-reading it at drain time would either lose
+  // it or attach it to the wrong message.
+  const ctxAt = body.indexOf("const mergedContext =");
+  assert.ok(ctxAt !== -1 && ctxAt < closureAt, "the one-shot context is captured at call time");
 });
 
 test("#1095 codex P1: BOTH outbound send paths consult the advertised route first", () => {

--- a/browser_tests/unit/command-liveness.test.mjs
+++ b/browser_tests/unit/command-liveness.test.mjs
@@ -795,7 +795,7 @@ test("#1095 codex P1: the duplicate-replay wait is marked, and released in a fin
 });
 
 test("#1095 codex P1: the canvas-tool disclosure is decided when the frame LEAVES", () => {
-  // A held frame is sent after a hello the hold expedited, and a landed hello ADVANCES
+  // A held frame is sent after the hello it was waiting for, and a landed hello ADVANCES
   // agentSessionEpoch. Deciding the disclosure at call time therefore decides it for the
   // agent generation the message will not reach: if the outgoing generation had proven its
   // tools, `disclose` is false, the NEW generation gets no disclosure, and
@@ -835,7 +835,10 @@ test("#1095 codex P1: BOTH outbound send paths consult the advertised route firs
   const holdSites = [];
   const staleReads = [];
   (function walk(n) {
-    if (ts.isCallExpression(n) && n.expression.getText(sf) === "rehelloGate.sendAfterAdvertise") {
+    if (ts.isCallExpression(n) && n.expression.getText(sf) === "rehelloGate.holdForRoute") {
+      // Every hold must STAMP the route it was composed for. An unstamped frame is one a
+      // later advertisement for a DIFFERENT workflow will deliver to that workflow.
+      assert.equal(n.arguments.length, 2, "a held frame must carry the route it was composed for");
       holdSites.push(n.getStart(sf));
     }
     if (ts.isCallExpression(n) && n.expression.getText(sf) === "advertisedRouteIsStale") {
@@ -861,8 +864,8 @@ test("#1095 codex P1: BOTH outbound send paths consult the advertised route firs
     const body = src.slice(at, end);
     assert.match(
       body,
-      /if \(advertisedRouteIsStale\(\)\) return rehelloGate\.sendAfterAdvertise\(send\);/,
-      `${name} must hold the frame when the advertised route is stale`,
+      /if \(advertisedRouteIsStale\(\)\) return rehelloGate\.holdForRoute\(send, [^;]+\);/,
+      `${name} must hold the frame, stamped with its route, when the advertised route is stale`,
     );
     const guardAt = body.indexOf("if (advertisedRouteIsStale())");
     const plainAt = body.lastIndexOf("return send();");
@@ -879,6 +882,26 @@ test("#1095 codex P1: BOTH outbound send paths consult the advertised route firs
   const sentAt = advBody.indexOf("if (sent) {");
   const recordAt = advBody.indexOf("lastAdvertisedRouteId = advertisedRouteId;");
   assert.ok(sentAt !== -1 && recordAt !== -1 && recordAt > sentAt, "the route is recorded only once a hello LANDED");
+  // …and the held queue is released from that same landed path, with the route that was
+  // ACTUALLY carried. Releasing on intent rather than on arrival would send frames onto a
+  // route the orchestrator was never told about.
+  const notifyAt = advBody.indexOf("rehelloGate.noteAdvertised(advertisedRouteId);");
+  assert.ok(notifyAt !== -1 && notifyAt > sentAt, "held frames are released by a LANDED hello, not an attempted one");
+
+  // THE RULE THAT ENDS THE FAMILY: no send path may cause an advertisement. The workflow
+  // poll binds SESSION_KEY before re-helloing and is the only place that commits a switch
+  // as a whole — so anything else that advertises publishes a half-committed switch, pairing
+  // the new route with the previous workflow's session.
+  const gateSrc = readFileSync(join(HERE, "../../web/js/lib/rehello-gate.js"), "utf8");
+  const holdStart = gateSrc.indexOf("    holdForRoute(send, route) {");
+  assert.notEqual(holdStart, -1, "could not locate holdForRoute");
+  const holdEnd = gateSrc.indexOf("\n    },", holdStart);
+  const holdBody = gateSrc.slice(holdStart, holdEnd);
+  assert.equal(
+    /\b(flush|request)\(\)/.test(holdBody),
+    false,
+    "holding a frame must never trigger an advertisement — it waits for one",
+  );
 });
 
 test("#1095 codex P2: the reachability scan SEES a return inside the marked try", () => {

--- a/browser_tests/unit/command-liveness.test.mjs
+++ b/browser_tests/unit/command-liveness.test.mjs
@@ -43,6 +43,44 @@ import {
 const HERE = dirname(fileURLToPath(import.meta.url));
 const PANEL_JS = join(HERE, "../../web/js/comfyui-mcp-panel.js");
 
+/**
+ * #1095 — the line numbers of every statement that can EXIT `root` between `from` and `to`
+ * without falling through to the reply.
+ *
+ * THE TRY BLOCK IS TRAVERSED, and the first cut of this scan did not traverse it. It
+ * returned at every TryStatement and examined only the catch and finally, so a `return`
+ * placed inside the marked executor's `try` — which skips the catch entirely, never reaches
+ * deliverReply, and leaks the in-flight mark — was invisible, and this test would have gone
+ * on passing. That is the same defect class as the counting version this scan replaced: an
+ * assertion that cannot observe the property it claims to check. The fixture test below
+ * drives exactly that shape.
+ *
+ * Only a CAUGHT `throw` is excluded, because the executor's catch is what turns a throw into
+ * a reply — that is the whole point of it. A `return` is never caught by anything, and a
+ * `throw` outside a try (or inside a catch/finally, which the enclosing try does not cover)
+ * escapes just the same.
+ */
+function escapingExits(sf, root, from, to) {
+  const escapes = [];
+  (function scan(node, caught) {
+    if (ts.isFunctionLike(node) && node !== root) return; // nested callbacks have their own exits
+    if (ts.isTryStatement(node)) {
+      ts.forEachChild(node.tryBlock, (child) => scan(child, caught || !!node.catchClause));
+      // A throw raised IN the handlers is not caught by this try — carry the outer state.
+      if (node.catchClause) ts.forEachChild(node.catchClause, (child) => scan(child, caught));
+      if (node.finallyBlock) ts.forEachChild(node.finallyBlock, (child) => scan(child, caught));
+      return;
+    }
+    const at = node.getStart(sf);
+    if (at > from && at < to) {
+      const escapesHere = ts.isReturnStatement(node) || (ts.isThrowStatement(node) && !caught);
+      if (escapesHere) escapes.push(sf.getLineAndCharacterOfPosition(at).line + 1);
+    }
+    ts.forEachChild(node, (child) => scan(child, caught));
+  })(root, false);
+  return escapes;
+}
+
 // --- honest cause reporting ----------------------------------------------
 
 test("#508: the cause is REPORTED, not guessed", () => {
@@ -669,24 +707,7 @@ test("#1095: the in-flight mark is paired across the command branch", () => {
   assert.ok(incPos !== -1 && replyPos !== -1, "the branch must mark in flight and deliver a reply");
   assert.ok(incPos < replyPos, "the mark must precede the reply that releases it");
 
-  const escapes = [];
-  (function scan(n) {
-    if (ts.isFunctionLike(n) && n !== branch) return; // nested callbacks have their own exits
-    if (ts.isTryStatement(n)) {
-      // A throw inside `try` is caught and answered; only the handlers can truly exit.
-      if (n.catchClause) ts.forEachChild(n.catchClause, scan);
-      if (n.finallyBlock) ts.forEachChild(n.finallyBlock, scan);
-      return;
-    }
-    if (
-      (ts.isReturnStatement(n) || ts.isThrowStatement(n)) &&
-      n.getStart(sf) > incPos &&
-      n.getStart(sf) < replyPos
-    ) {
-      escapes.push(sf.getLineAndCharacterOfPosition(n.getStart(sf)).line + 1);
-    }
-    ts.forEachChild(n, scan);
-  })(branch);
+  const escapes = escapingExits(sf, branch, incPos, replyPos);
   assert.deepEqual(
     escapes,
     [],
@@ -717,6 +738,126 @@ test("#1095: the in-flight mark is paired across the command branch", () => {
     src.slice(gStart, gEnd),
     /const refusalMark = rehelloGate\.began\(\);/,
     "the superseded refusal must balance the release its deliverReply performs",
+  );
+});
+
+test("#1095 codex P1: BOTH outbound send paths consult the advertised route first", () => {
+  // The leak this closes: onWorkflowMaybeChanged commits the new workflow inline, so while
+  // the hello is parked the panel is on B and the socket's binding still says A. A
+  // `user_message` carries NO tab id, so the orchestrator routes it by that binding — the
+  // user's text, context and images for B delivered into A's conversation.
+  //
+  // Structural because the claim is a CLOSURE one: every path that writes an agent-directed
+  // frame must pass the check. The check's own behaviour is driven in rehello-gate.test.mjs.
+  const src = readFileSync(PANEL_JS, "utf8");
+  const sf = ts.createSourceFile(PANEL_JS, src, ts.ScriptTarget.ESNext, true, ts.ScriptKind.JS);
+
+  const holdSites = [];
+  const staleReads = [];
+  (function walk(n) {
+    if (ts.isCallExpression(n) && n.expression.getText(sf) === "rehelloGate.sendAfterAdvertise") {
+      holdSites.push(n.getStart(sf));
+    }
+    if (ts.isCallExpression(n) && n.expression.getText(sf) === "advertisedRouteIsStale") {
+      staleReads.push(n.getStart(sf));
+    }
+    ts.forEachChild(n, walk);
+  })(sf);
+  assert.equal(holdSites.length, 2, "sendUserMessage and sendFrame must both be able to hold");
+  assert.equal(staleReads.length, 2, "…and each hold must be gated on the check");
+  assert.equal(
+    (src.match(/^\s*function advertisedRouteIsStale\(\) \{/gm) || []).length,
+    1,
+    "ONE definition of the check — a second copy is how two send paths drift apart",
+  );
+
+  // Each guard must sit INSIDE its send path, and the raw `sock.send` must be reachable only
+  // through the closure the guard chooses between — not left as a second, ungated exit.
+  for (const name of ["sendUserMessage", "sendFrame"]) {
+    const at = src.indexOf(`    ${name}(`);
+    assert.notEqual(at, -1, `could not locate ${name}`);
+    const end = src.indexOf("\n    },", at);
+    assert.notEqual(end, -1, `could not bound ${name}`);
+    const body = src.slice(at, end);
+    assert.match(
+      body,
+      /if \(advertisedRouteIsStale\(\)\) return rehelloGate\.sendAfterAdvertise\(send\);/,
+      `${name} must hold the frame when the advertised route is stale`,
+    );
+    const guardAt = body.indexOf("if (advertisedRouteIsStale())");
+    const plainAt = body.lastIndexOf("return send();");
+    assert.ok(guardAt !== -1 && plainAt > guardAt, `${name} must only send directly AFTER the guard`);
+    // The frame must be built ONCE, before the branch, so a held frame is byte-identical to
+    // the one that would have gone out immediately — same context, same disclosure decision.
+    const buildAt = body.indexOf("const send = () => {");
+    assert.ok(buildAt !== -1 && buildAt < guardAt, `${name} must build the frame before deciding`);
+  }
+
+  // The comparison must be against what the hello ACTUALLY carried, recorded on the landed
+  // path only — the same rule as lastAdvertisedWorkflowUuid and advertisedSock beside it.
+  const advBody = src.slice(src.indexOf("function advertiseHello() {"));
+  const sentAt = advBody.indexOf("if (sent) {");
+  const recordAt = advBody.indexOf("lastAdvertisedRouteId = advertisedRouteId;");
+  assert.ok(sentAt !== -1 && recordAt !== -1 && recordAt > sentAt, "the route is recorded only once a hello LANDED");
+});
+
+test("#1095 codex P2: the reachability scan SEES a return inside the marked try", () => {
+  // The scan is the only thing standing between a refactor and a silently leaked mark, so
+  // it is itself driven against fixtures rather than trusted. The first cut skipped every
+  // TryStatement's body outright, which made case (b) below invisible — a test that could
+  // not fail on the defect it exists to catch.
+  const build = (body) => {
+    const source = `async function h(){ if (isCommandFrame) { ${body} } }`;
+    const sf = ts.createSourceFile("fixture.js", source, ts.ScriptTarget.ESNext, true, ts.ScriptKind.JS);
+    let branch = null;
+    let from = -1;
+    let to = -1;
+    (function walk(n) {
+      if (ts.isIfStatement(n) && n.expression.getText(sf) === "isCommandFrame") branch = n;
+      if (ts.isCallExpression(n) && n.expression.getText(sf) === "rehelloGate.began") from = n.getStart(sf);
+      if (ts.isCallExpression(n) && n.expression.getText(sf) === "deliverReply") to = n.getStart(sf);
+      ts.forEachChild(n, walk);
+    })(sf);
+    assert.ok(branch && from !== -1 && to !== -1, "fixture must mark and reply");
+    return escapingExits(sf, branch, from, to);
+  };
+
+  // (a) the shape the panel actually has — a throw inside the try is CAUGHT and answered,
+  // so it is not an escape.
+  assert.deepEqual(
+    build(`rehelloGate.began(c); try { if (x) throw new Error("boom"); r = await run(); } catch (e) { r = err(e); } deliverReply(r);`),
+    [],
+    "a caught throw is turned into a reply — the catch is what makes it safe",
+  );
+
+  // (b) THE DEFECT. A return inside the try skips the catch, never reaches deliverReply,
+  // and leaks the mark. The old scan reported nothing here.
+  assert.deepEqual(
+    build(`rehelloGate.began(c); try { if (x) return; r = await run(); } catch (e) { r = err(e); } deliverReply(r);`),
+    [1],
+    "a return inside the marked try must be reported as a leaking exit",
+  );
+
+  // (c) a throw in the CATCH is not covered by its own try, so it escapes too.
+  assert.deepEqual(
+    build(`rehelloGate.began(c); try { r = await run(); } catch (e) { throw e; } deliverReply(r);`),
+    [1],
+    "a rethrow from the handler escapes the branch just like a bare throw",
+  );
+
+  // (d) an exit AFTER the reply is not this invariant's business — the mark is already
+  // released by then.
+  assert.deepEqual(
+    build(`rehelloGate.began(c); deliverReply(r); if (superseded) return;`),
+    [],
+    "the window ends at the reply",
+  );
+
+  // (e) a nested callback has its own exits and must not be attributed to the branch.
+  assert.deepEqual(
+    build(`rehelloGate.began(c); items.forEach((i) => { if (i) return; }); deliverReply(r);`),
+    [],
+    "a return that leaves only an inner function is not a branch exit",
   );
 });
 

--- a/browser_tests/unit/command-liveness.test.mjs
+++ b/browser_tests/unit/command-liveness.test.mjs
@@ -765,6 +765,23 @@ test("#1095: EVERY re-advertise goes through the gate — no caller can bypass i
   // waking, a manual change) and an elapsed-time window built on it either expires
   // instantly or never — the same rule as monotonicNow()'s other consumers.
   assert.match(gateCall.getText(sf), /now:\s*monotonicNow/, "the budget is elapsed time, so it needs a monotonic clock");
+
+  // A parked hello belongs to the connection it was queued for. Every teardown path must
+  // drop it: setUrl (pointing at a DIFFERENT bridge — firing there would register this tab
+  // somewhere nobody asked for, the corruption class #508 refuses to risk), stop, and
+  // destroy (a timer firing from a closure nothing owns any more). Three paths, three
+  // cancels — the same "setUrl/stop/destroy must all forget it" rule already asserted for
+  // `handshakenSock` above.
+  assert.equal(
+    (src.match(/^\s*rehelloGate\.cancel\(\);/gm) || []).length,
+    3,
+    "setUrl, stop and destroy must each drop a parked re-advertise",
+  );
+  assert.equal(
+    (src.match(/^\s*advertisedSock = null;/gm) || []).length,
+    3,
+    "…and each must forget the socket that had a mapping, so the next hello is a first one",
+  );
 });
 
 test("#1095: the workflow poll commits its state INLINE — it no longer gates anything", () => {

--- a/browser_tests/unit/command-liveness.test.mjs
+++ b/browser_tests/unit/command-liveness.test.mjs
@@ -60,6 +60,19 @@ const PANEL_JS = join(HERE, "../../web/js/comfyui-mcp-panel.js");
  * `throw` outside a try (or inside a catch/finally, which the enclosing try does not cover)
  * escapes just the same.
  */
+/** The body of the bridge client's `sendUserMessage` / `sendFrame`, bounded by the method's
+ *  own closing `\n    },` rather than a character count. */
+function umBodyFor(src) {
+  const at = src.indexOf("    sendUserMessage(");
+  assert.notEqual(at, -1, "could not locate sendUserMessage");
+  return src.slice(at, src.indexOf("\n    },", at));
+}
+function sfBodyFor(src) {
+  const at = src.indexOf("    sendFrame(frame) {");
+  assert.notEqual(at, -1, "could not locate sendFrame");
+  return src.slice(at, src.indexOf("\n    },", at));
+}
+
 function escapingExits(sf, root, from, to) {
   const escapes = [];
   (function scan(node, caught) {
@@ -868,20 +881,49 @@ test("#1095 codex P1: BOTH outbound send paths consult the advertised route firs
     const end = src.indexOf("\n    },", at);
     assert.notEqual(end, -1, `could not bound ${name}`);
     const body = src.slice(at, end);
-    const guardAt = body.indexOf("if (advertisedRouteIsStale())");
+    // The CALL, not a literal `if (...)` form — sendFrame conjoins the frame-type check.
+    const guardAt = body.indexOf("advertisedRouteIsStale()");
     const plainAt = body.lastIndexOf("return send();");
     assert.ok(guardAt !== -1 && plainAt > guardAt, `${name} must only send directly AFTER the guard`);
-    // The frame must be built ONCE, before the branch, so a held frame is byte-identical to
-    // the one that would have gone out immediately — same context, same disclosure decision.
-    const buildAt = body.indexOf("const send = () => {");
-    assert.ok(buildAt !== -1 && buildAt < guardAt, `${name} must build the frame before deciding`);
   }
+
+  // The two paths want OPPOSITE orderings, and each ordering is load-bearing.
+  //
+  // sendFrame can QUEUE, so its frame must be built before the branch — a held frame has to
+  // be byte-identical to the one that would have gone out immediately.
+  const sfBuildAt = sfBodyFor(src).indexOf("const send = () => {");
+  const sfGuardAt = sfBodyFor(src).indexOf("advertisedRouteIsStale()");
+  assert.ok(sfBuildAt !== -1 && sfBuildAt < sfGuardAt, "sendFrame must build the frame before deciding");
+  // sendUserMessage REFUSES, so its guard must come first — building would consume the armed
+  // one-shot for a frame that never leaves (see the ordering assertions below).
+  const umBuildAt = umBodyFor(src).indexOf("const send = () => {");
+  const umGuardAt = umBodyFor(src).indexOf("advertisedRouteIsStale()");
+  assert.ok(umGuardAt !== -1 && umGuardAt < umBuildAt, "sendUserMessage must refuse before building");
 
   // sendUserMessage refuses outright; only sendFrame may queue, and only for the frames
   // whose senders ignore the answer.
   const umAt = src.indexOf("    sendUserMessage(");
   const umBody = src.slice(umAt, src.indexOf("\n    },", umAt));
   assert.match(umBody, /if \(advertisedRouteIsStale\(\)\) return false;/, "a user message is refused, never queued");
+
+  // …AND THE REFUSAL MUST PRECEDE EVERY ONE-SHOT CONSUMPTION. `pendingContext` is an armed
+  // transcript replay / workflow instruction that is merged into the frame and cleared. With
+  // the refusal below that merge, the one-shot was consumed by a frame that never left, and
+  // `trackSend` stores the payload it was GIVEN — so the retry went out without the armed
+  // replay, silently. Same class as reporting a discarded frame delivered: the user's intent
+  // evaporates with no signal. Ordering is asserted rather than a restore, because a restore
+  // has to be remembered by every future edit and an early return does not.
+  const umRefuseAt = umBody.indexOf("if (advertisedRouteIsStale()) return false;");
+  const umMergeAt = umBody.indexOf("const mergedContext =");
+  const umClearAt = umBody.indexOf("pendingContext = null;");
+  assert.ok(umMergeAt !== -1 && umClearAt !== -1, "the one-shot merge and clear must still be here");
+  assert.ok(umRefuseAt < umMergeAt, "the refusal must precede the one-shot merge");
+  assert.ok(umRefuseAt < umClearAt, "…and the clear that consumes it");
+  // `AGENT_BLIND` may still run before the refusal — it only nulls a local, consuming nothing.
+  assert.ok(
+    umBody.indexOf("if (AGENT_BLIND) images = undefined;") > umRefuseAt,
+    "nothing that mutates caller state may run before the refusal",
+  );
   // The CALL, not the word — the comment above it names holdForRoute to explain why this
   // path deliberately does not use it.
   assert.equal(
@@ -890,14 +932,25 @@ test("#1095 codex P1: BOTH outbound send paths consult the advertised route firs
     "…and it must not reach the queue at all",
   );
 
+  // THE SCOPE LINE. Only the session-ordered frames are held; every other control frame
+  // keeps its pre-#1095 behaviour. A brief cut refused them all, and that was worse rather
+  // than stricter: cancel_message, interrupt, rewind, set_options and the pairing frames all
+  // IGNORE this return, so a refusal did not stop them — it made them fail silently while
+  // their callers announced success and, in rewind's case, resubmitted. Refusing a frame
+  // nobody checks converts a routing problem into a lying UI.
   const sfAt = src.indexOf("    sendFrame(frame) {");
   const sfBody = src.slice(sfAt, src.indexOf("\n    },", sfAt));
   assert.match(
     sfBody,
-    /if \(!SESSION_ORDERED_FRAMES\.has\(frame\?\.type\)\) return false;/,
-    "every other control frame is refused, so runCompletion re-pends instead of retiring",
+    /if \(advertisedRouteIsStale\(\) && SESSION_ORDERED_FRAMES\.has\(frame\?\.type\)\) \{/,
+    "only the fire-and-forget session frames may be diverted from the ordinary send",
   );
   assert.match(sfBody, /return rehelloGate\.holdForRoute\(send, routeId\);/, "…and the queued one carries its route");
+  assert.equal(
+    /SESSION_ORDERED_FRAMES\.has\(frame\?\.type\)\) return false;/.test(sfBody),
+    false,
+    "a control frame whose caller ignores the answer must not be silently refused",
+  );
   // The set must stay exactly the fire-and-forget session frames. Adding a frame whose
   // sender reads the return would reintroduce "reported delivered, then discarded".
   assert.match(

--- a/browser_tests/unit/rehello-gate.test.mjs
+++ b/browser_tests/unit/rehello-gate.test.mjs
@@ -218,16 +218,80 @@ test("#1095: a release that does not NAME its mark frees nothing — it fails cl
   assert.equal(sends.length, 1);
 });
 
-test("#1095: a leaked mark delays the hello but can never block it", () => {
+test("#1095: a leaked mark delays the hello but can never block it", async () => {
   const { gate, sends, advance } = harness();
   gate.began("graph_set_widget"); // never released
   gate.request();
   advance(REHELLO_DEFER_MS + 1);
   assert.equal(sends.length, 1);
-  // …and the tab is not permanently penalised: a later re-advertise is not made to wait out
-  // a budget that has already expired.
+  // A request made while that one is STILL ON ITS WAY joins it rather than starting a
+  // second registration (see the in-flight join below).
+  gate.request();
+  assert.equal(sends.length, 1);
+  // …and once it has settled the tab is not permanently penalised: a later re-advertise is
+  // not made to wait out a budget that has already expired.
+  await new Promise((r) => setTimeout(r, 0));
   gate.request();
   assert.equal(sends.length, 2);
+});
+
+// --- joining an advertisement already on its way (codex P2) ---------------
+
+test("#1095 codex P2: a hold JOINS the advertisement already on its way", async () => {
+  // The most common path in this whole feature, not an edge case: an ordinary workflow
+  // switch with an existing session and nothing in flight. rehelloForWorkflow starts the
+  // hello and immediately sends resume_session; that frame finds the route still stale
+  // (the hello has published nothing yet) and asks to be held. Without the join, the hold
+  // started a SECOND full registration — duplicate hello, duplicate "agent ready" greeting,
+  // and TWO agentSessionEpoch increments for one switch.
+  let hellos = 0;
+  let resolveHello;
+  const gate = createRehelloGate({
+    advertise: () => {
+      hellos++;
+      return new Promise((r) => {
+        resolveHello = r;
+      });
+    },
+    now: () => 0,
+  });
+  const first = gate.request(); // the switch's own hello — nothing in flight, so it goes now
+  assert.equal(hellos, 1);
+  gate.sendAfterAdvertise(() => {}); // resume_session, riding right behind it
+  assert.equal(hellos, 1, "one switch must produce exactly one registration");
+
+  resolveHello(true);
+  assert.equal(await first, true);
+  await new Promise((r) => setTimeout(r, 0));
+  assert.equal(gate.heldFrames(), 0, "the held frame still drains on the joined advertisement");
+});
+
+test("#1095 codex P2: the join ends when the advertisement does", async () => {
+  // Joining a FINISHED advertisement would mean a genuine later switch never gets announced.
+  const { gate, sends } = harness();
+  gate.request();
+  assert.equal(sends.length, 1);
+  await new Promise((r) => setTimeout(r, 0));
+  gate.request();
+  assert.equal(sends.length, 2, "a new switch after the previous hello landed needs its own");
+});
+
+test("#1095 codex P2: a torn-down connection's advertisement is not joined by its replacement", async () => {
+  // cancel() retires the connection. A frame held on the REPLACEMENT socket must not join
+  // the old socket's hello and conclude the new route is published because that one landed.
+  let hellos = 0;
+  const gate = createRehelloGate({
+    advertise: () => {
+      hellos++;
+      return new Promise(() => {}); // never settles — the socket died mid-hello
+    },
+    now: () => 0,
+  });
+  gate.request();
+  assert.equal(hellos, 1);
+  gate.cancel();
+  gate.request();
+  assert.equal(hellos, 2, "the replacement connection advertises for itself");
 });
 
 // --- generation scoping (codex P1) ---------------------------------------

--- a/browser_tests/unit/rehello-gate.test.mjs
+++ b/browser_tests/unit/rehello-gate.test.mjs
@@ -70,12 +70,12 @@ function harness({ landed = true, advertise } = {}) {
 
 test("#1095: a re-advertise does NOT withdraw the route while a command is in flight", async () => {
   const { gate, sends, advance } = harness();
-  gate.began("graph_set_widget");
+  const mark = gate.began("graph_set_widget");
   const landed = gate.request();
   assert.deepEqual(sends, [], "the hello must not go out while the command is still routed");
   advance(1);
   assert.deepEqual(sends, [], "…and not on the next tick either");
-  gate.ended();
+  gate.ended(mark);
   assert.equal(sends.length, 1, "it goes out the moment the batch drains");
   assert.equal(await landed, true, "and the caller learns it reached the wire");
 });
@@ -89,10 +89,10 @@ test("#1095: with nothing in flight the hello is immediate — the gate adds no 
 
 test("#1095: the drain releases it, not the timer — the budget is a CEILING, not a delay", () => {
   const { gate, sends, advance, armed } = harness();
-  gate.began("graph_set_widget");
+  const mark = gate.began("graph_set_widget");
   gate.request();
   advance(5);
-  gate.ended();
+  gate.ended(mark);
   assert.equal(sends.length, 1, "a 4-second budget must not mean a 4-second stall");
   assert.equal(armed(), 0, "and the pending timer must be disarmed, not left to fire again");
 });
@@ -119,11 +119,11 @@ test("#1095: a HUMAN-paced command is not abandoned on the machine budget", asyn
   // anyway — the user answers a question and the orchestrator reports OUTCOME UNKNOWN for
   // the answer they just gave. These are the commands that most need the cover.
   const { gate, sends, advance } = harness();
-  gate.began("ask_user");
+  const mark = gate.began("ask_user");
   const landed = gate.request();
   advance(REHELLO_DEFER_MS + 1);
   assert.deepEqual(sends, [], "the machine budget must not apply to a command paced by a person");
-  gate.ended();
+  gate.ended(mark);
   assert.equal(sends.length, 1, "the answer's reply is delivered first, then the re-advertise");
   assert.equal(await landed, true);
 });
@@ -155,14 +155,14 @@ test("#1095: a command that STARTS during the wait extends it — the timer cann
   // on the deadline that was current when the timer was armed would re-advertise while a
   // newer command is mid-flight: the exact race, reintroduced by the bound meant to end it.
   const { gate, sends, advance } = harness();
-  gate.began("graph_set_widget"); // deadline t=4000
+  const first = gate.began("graph_set_widget"); // deadline t=4000
   gate.request();
   advance(3000);
-  gate.began("ask_user"); // deadline t=33000
+  const second = gate.began("ask_user"); // deadline t=33000
   advance(1500); // t=4500 — past the ORIGINAL deadline
   assert.deepEqual(sends, [], "the wait must follow the newest command, not the first one");
-  gate.ended();
-  gate.ended();
+  gate.ended(first);
+  gate.ended(second);
   assert.equal(sends.length, 1);
 });
 
@@ -174,41 +174,50 @@ test("#1095: an already-spent budget does not restart the wait", () => {
   assert.equal(sends.length, 1, "a stuck command must not buy a fresh budget per request");
 });
 
-// --- coalescing and pairing ----------------------------------------------
+// --- coalescing and mark identity ----------------------------------------
 
 test("#1095: several deferred re-advertises coalesce into ONE hello, all told the same outcome", async () => {
   // A hello is a statement of current state, not an event log: two parked requests both want
   // the orchestrator to hold this tab's live identity, and one send says that.
   const { gate, sends } = harness();
-  gate.began("graph_set_widget");
+  const mark = gate.began("graph_set_widget");
   const a = gate.request();
   const b = gate.request();
   const c = gate.request();
-  gate.ended();
+  gate.ended(mark);
   assert.equal(sends.length, 1, "one send, not a queue of three");
   assert.deepEqual(await Promise.all([a, b, c]), [true, true, true]);
 });
 
-test("#1095: an over-release cannot convince the gate that nothing is running", () => {
+test("#1095: a DOUBLE release of one mark cannot discount another command", () => {
   // deliverReply releases the mark, and a double-delivery (a retry, a future refactor) must
-  // not drive the count negative — a negative count never returns to 0, so the gate would
-  // wave every later re-advertise straight through and the race would be back.
+  // not free work that is still running. A counter could not tell the two apart; an id can.
   const { gate, sends } = harness();
-  gate.began();
-  gate.ended();
-  gate.ended();
-  gate.ended();
-  assert.equal(gate.inFlight(), 0);
-  gate.began("graph_set_widget");
+  const mine = gate.began("graph_set_widget");
+  gate.began("graph_set_widget"); // a second, still-running command
   gate.request();
-  assert.deepEqual(sends, [], "a real command must still be covered after the over-release");
+  gate.ended(mine);
+  gate.ended(mine);
+  gate.ended(mine);
+  assert.equal(gate.inFlight(), 1, "the other command must still be marked");
+  assert.deepEqual(sends, [], "…and the hello must still be parked behind it");
+});
+
+test("#1095: a release that does not NAME its mark frees nothing — it fails closed", () => {
+  // The safe direction: an unnamed release can only DELAY a re-advertise (the budget still
+  // expires), never let one through while a command is mid-flight.
+  const { gate, sends } = harness();
+  const mark = gate.began("graph_set_widget");
+  gate.request();
   gate.ended();
+  gate.ended(undefined);
+  gate.ended(999999);
+  assert.deepEqual(sends, [], "an unknown mark must not release a real one");
+  gate.ended(mark);
   assert.equal(sends.length, 1);
 });
 
 test("#1095: a leaked mark delays the hello but can never block it", () => {
-  // The mark/release pair is checked structurally in command-liveness.test.mjs. This is the
-  // blast radius if one ever escapes anyway: the budget still expires.
   const { gate, sends, advance } = harness();
   gate.began("graph_set_widget"); // never released
   gate.request();
@@ -218,6 +227,43 @@ test("#1095: a leaked mark delays the hello but can never block it", () => {
   // a budget that has already expired.
   gate.request();
   assert.equal(sends.length, 2);
+});
+
+// --- generation scoping (codex P1) ---------------------------------------
+
+test("#1095 codex P1: a LATE release from a retired connection must not free the new one's mark", () => {
+  // cancel() runs when the connection is replaced (setUrl / stop / destroy / an ordinary
+  // close). A command already executing on the RETIRED socket still finishes and still calls
+  // its release. Against a shared counter that release lands on whatever the NEW socket is
+  // running and decrements ITS mark — so a parked hello flushes while a live command is
+  // mid-flight, recreating the exact route-loss race this module exists to close.
+  const { gate, sends } = harness();
+  const retired = gate.began("graph_set_widget"); // running on the old socket
+  gate.cancel(); // the connection is replaced
+  const current = gate.began("graph_set_widget"); // the new socket's command
+  const landed = gate.request();
+  assert.deepEqual(sends, [], "parked behind the NEW command");
+
+  gate.ended(retired); // the old socket's command finally finishes
+  assert.equal(gate.inFlight(), 1, "the retired mark is not accounted for, so nothing is freed");
+  assert.deepEqual(sends, [], "a stale release must not withdraw the route from a live command");
+
+  gate.ended(current);
+  assert.equal(sends.length, 1, "only the real release lets the hello go");
+  return landed;
+});
+
+test("#1095 codex P1: cancel() invalidates outstanding marks, so they cannot delay the next hello", () => {
+  // The other direction of the same defect: marks belonging to a dead socket must not make
+  // the replacement connection's legitimate re-advertise wait out a budget for commands that
+  // can never reply.
+  const { gate, sends } = harness();
+  gate.began("ask_user");
+  gate.began("graph_set_widget");
+  gate.cancel();
+  assert.equal(gate.inFlight(), 0, "a replaced connection carries none of its predecessor's marks");
+  gate.request();
+  assert.equal(sends.length, 1, "the new connection's hello is immediate");
 });
 
 // --- teardown -------------------------------------------------------------

--- a/browser_tests/unit/rehello-gate.test.mjs
+++ b/browser_tests/unit/rehello-gate.test.mjs
@@ -1,0 +1,277 @@
+// Unit tests for web/js/lib/rehello-gate.js — run with `node --test`.
+//
+// #1095: creating a workflow and immediately applying a batch of graph mutations lost the
+// panel's route mid-batch —
+//
+//     panel tab tmp:2806 disconnected mid-command (graph_set_widget) — OUTCOME UNKNOWN
+//     then: no connected tab ... Connected: none
+//
+// — because a re-advertise makes the backend drop this socket's prior tab mapping, and
+// nothing stopped one from firing while a command was routed to that mapping.
+//
+// THE GATE IS DRIVEN HERE, NOT ASSERTED ABOUT AT SOURCE. The invariant is a temporal one
+// ("no hello reaches the wire between a command starting and its reply") and a source
+// pattern cannot express it: `if (false) advertise()` matches every regex you could write
+// for it. Every test below runs the real factory with an injected clock and timer, and
+// asserts on what was actually sent and when.
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  createRehelloGate,
+  deferBudgetMs,
+  HUMAN_PACED_COMMANDS,
+  REHELLO_DEFER_MS,
+  REHELLO_DEFER_HUMAN_MS,
+} from "../../web/js/lib/rehello-gate.js";
+
+/** A gate on a controllable clock. `advance` fires due timers in time order and lets them
+ *  re-arm, because the gate deliberately re-arms rather than trusting a stale wake-up. */
+function harness({ landed = true, advertise } = {}) {
+  let t = 0;
+  let nextId = 1;
+  const timers = new Map();
+  const sends = [];
+  const gate = createRehelloGate({
+    advertise:
+      advertise ||
+      (() => {
+        sends.push(t);
+        return Promise.resolve(landed);
+      }),
+    now: () => t,
+    setTimer: (fn, ms) => {
+      const id = nextId++;
+      timers.set(id, { fn, at: t + ms });
+      return id;
+    },
+    clearTimer: (id) => {
+      timers.delete(id);
+    },
+  });
+  const advance = (ms) => {
+    const target = t + ms;
+    for (;;) {
+      let due = null;
+      for (const [id, entry] of timers) {
+        if (entry.at <= target && (due === null || entry.at < due.entry.at)) due = { id, entry };
+      }
+      if (due === null) break;
+      timers.delete(due.id);
+      t = Math.max(t, due.entry.at);
+      due.entry.fn();
+    }
+    t = target;
+  };
+  return { gate, sends, advance, armed: () => timers.size };
+}
+
+// --- the defect itself ----------------------------------------------------
+
+test("#1095: a re-advertise does NOT withdraw the route while a command is in flight", async () => {
+  const { gate, sends, advance } = harness();
+  gate.began("graph_set_widget");
+  const landed = gate.request();
+  assert.deepEqual(sends, [], "the hello must not go out while the command is still routed");
+  advance(1);
+  assert.deepEqual(sends, [], "…and not on the next tick either");
+  gate.ended();
+  assert.equal(sends.length, 1, "it goes out the moment the batch drains");
+  assert.equal(await landed, true, "and the caller learns it reached the wire");
+});
+
+test("#1095: with nothing in flight the hello is immediate — the gate adds no latency", async () => {
+  const { gate, sends } = harness();
+  const landed = await gate.request();
+  assert.equal(sends.length, 1);
+  assert.equal(landed, true);
+});
+
+test("#1095: the drain releases it, not the timer — the budget is a CEILING, not a delay", () => {
+  const { gate, sends, advance, armed } = harness();
+  gate.began("graph_set_widget");
+  gate.request();
+  advance(5);
+  gate.ended();
+  assert.equal(sends.length, 1, "a 4-second budget must not mean a 4-second stall");
+  assert.equal(armed(), 0, "and the pending timer must be disarmed, not left to fire again");
+});
+
+// --- the bound ------------------------------------------------------------
+
+test("#1095: a command that never reports back cannot strand the tab — the wait is BOUNDED", async () => {
+  // Unbounded would convert a race into a wedge, which is worse: the tab would sit on the
+  // old workflow's route forever, and the #607 fence recovery that would clear it is itself
+  // a re-advertise waiting behind this same gate.
+  const { gate, sends, advance } = harness();
+  gate.began("graph_set_widget");
+  const landed = gate.request();
+  advance(REHELLO_DEFER_MS - 1);
+  assert.deepEqual(sends, [], "still inside the budget");
+  advance(2);
+  assert.equal(sends.length, 1, "past the budget the re-advertise proceeds regardless");
+  assert.equal(await landed, true);
+});
+
+test("#1095: a HUMAN-paced command is not abandoned on the machine budget", async () => {
+  // Review's second finding on the first cut: ask_user/request_secret hold the window for as
+  // long as the person takes, so a ~3s bound stalls briefly and then withdraws the route
+  // anyway — the user answers a question and the orchestrator reports OUTCOME UNKNOWN for
+  // the answer they just gave. These are the commands that most need the cover.
+  const { gate, sends, advance } = harness();
+  gate.began("ask_user");
+  const landed = gate.request();
+  advance(REHELLO_DEFER_MS + 1);
+  assert.deepEqual(sends, [], "the machine budget must not apply to a command paced by a person");
+  gate.ended();
+  assert.equal(sends.length, 1, "the answer's reply is delivered first, then the re-advertise");
+  assert.equal(await landed, true);
+});
+
+test("#1095: the human budget is a bound too — an abandoned card cannot hold the tab forever", () => {
+  const { gate, sends, advance } = harness();
+  gate.began("request_secret");
+  gate.request();
+  advance(REHELLO_DEFER_HUMAN_MS - 1);
+  assert.deepEqual(sends, [], "still waiting on the person");
+  advance(2);
+  assert.equal(sends.length, 1, "past the human budget a live route beats a preserved outcome");
+});
+
+test("#1095: the budget classes are exactly the two clocks, and an unknown command is machine-paced", () => {
+  assert.equal(deferBudgetMs("ask_user"), REHELLO_DEFER_HUMAN_MS);
+  assert.equal(deferBudgetMs("request_secret"), REHELLO_DEFER_HUMAN_MS);
+  assert.equal(deferBudgetMs("graph_set_widget"), REHELLO_DEFER_MS);
+  // Under-declaring only shortens the wait; over-declaring would let any unrecognised frame
+  // pin the route for the human budget. So the default must be the SHORT one.
+  assert.equal(deferBudgetMs(undefined), REHELLO_DEFER_MS);
+  assert.equal(deferBudgetMs("some_future_command"), REHELLO_DEFER_MS);
+  assert.ok(REHELLO_DEFER_HUMAN_MS > REHELLO_DEFER_MS);
+  assert.deepEqual([...HUMAN_PACED_COMMANDS].sort(), ["ask_user", "request_secret"]);
+});
+
+test("#1095: a command that STARTS during the wait extends it — the timer cannot fire early", () => {
+  // The bound belongs to the commands, so a batch that keeps going keeps the cover. Firing
+  // on the deadline that was current when the timer was armed would re-advertise while a
+  // newer command is mid-flight: the exact race, reintroduced by the bound meant to end it.
+  const { gate, sends, advance } = harness();
+  gate.began("graph_set_widget"); // deadline t=4000
+  gate.request();
+  advance(3000);
+  gate.began("ask_user"); // deadline t=33000
+  advance(1500); // t=4500 — past the ORIGINAL deadline
+  assert.deepEqual(sends, [], "the wait must follow the newest command, not the first one");
+  gate.ended();
+  gate.ended();
+  assert.equal(sends.length, 1);
+});
+
+test("#1095: an already-spent budget does not restart the wait", () => {
+  const { gate, sends, advance } = harness();
+  gate.began("graph_set_widget");
+  advance(REHELLO_DEFER_MS + 1); // budget spent before anyone asked to re-advertise
+  gate.request();
+  assert.equal(sends.length, 1, "a stuck command must not buy a fresh budget per request");
+});
+
+// --- coalescing and pairing ----------------------------------------------
+
+test("#1095: several deferred re-advertises coalesce into ONE hello, all told the same outcome", async () => {
+  // A hello is a statement of current state, not an event log: two parked requests both want
+  // the orchestrator to hold this tab's live identity, and one send says that.
+  const { gate, sends } = harness();
+  gate.began("graph_set_widget");
+  const a = gate.request();
+  const b = gate.request();
+  const c = gate.request();
+  gate.ended();
+  assert.equal(sends.length, 1, "one send, not a queue of three");
+  assert.deepEqual(await Promise.all([a, b, c]), [true, true, true]);
+});
+
+test("#1095: an over-release cannot convince the gate that nothing is running", () => {
+  // deliverReply releases the mark, and a double-delivery (a retry, a future refactor) must
+  // not drive the count negative — a negative count never returns to 0, so the gate would
+  // wave every later re-advertise straight through and the race would be back.
+  const { gate, sends } = harness();
+  gate.began();
+  gate.ended();
+  gate.ended();
+  gate.ended();
+  assert.equal(gate.inFlight(), 0);
+  gate.began("graph_set_widget");
+  gate.request();
+  assert.deepEqual(sends, [], "a real command must still be covered after the over-release");
+  gate.ended();
+  assert.equal(sends.length, 1);
+});
+
+test("#1095: a leaked mark delays the hello but can never block it", () => {
+  // The mark/release pair is checked structurally in command-liveness.test.mjs. This is the
+  // blast radius if one ever escapes anyway: the budget still expires.
+  const { gate, sends, advance } = harness();
+  gate.began("graph_set_widget"); // never released
+  gate.request();
+  advance(REHELLO_DEFER_MS + 1);
+  assert.equal(sends.length, 1);
+  // …and the tab is not permanently penalised: a later re-advertise is not made to wait out
+  // a budget that has already expired.
+  gate.request();
+  assert.equal(sends.length, 2);
+});
+
+// --- teardown -------------------------------------------------------------
+
+test("#1095: cancel() DROPS the parked hello — it must not fire into a replaced connection", async () => {
+  const { gate, sends, advance, armed } = harness();
+  gate.began("ask_user");
+  const landed = gate.request();
+  gate.cancel();
+  assert.deepEqual(sends, [], "a hello queued for the old socket must never register the tab elsewhere");
+  assert.equal(await landed, false, "waiters are told it did not land, rather than left pending");
+  assert.equal(gate.inFlight(), 0, "commands abandoned with the socket must not leak the count");
+  assert.equal(armed(), 0, "no timer may outlive the client");
+  advance(REHELLO_DEFER_HUMAN_MS * 2);
+  assert.deepEqual(sends, [], "and nothing fires later either");
+});
+
+// --- the gate's own failure modes ----------------------------------------
+
+test("#1095: an advertise that THROWS resolves false — it never rejects out of the gate", async () => {
+  const { gate } = harness({
+    advertise: () => {
+      throw new Error("send failed");
+    },
+  });
+  assert.equal(await gate.request(), false);
+});
+
+test("#1095: an advertise that REJECTS resolves false, so a retry budget is not spent on a guess", async () => {
+  const { gate } = harness({ advertise: () => Promise.reject(new Error("nope")) });
+  assert.equal(await gate.request(), false);
+});
+
+test("#1095: a hello that did not reach the wire resolves false, not true", async () => {
+  const { gate } = harness({ landed: false });
+  assert.equal(await gate.request(), false);
+});
+
+test("#1095: no usable timer source ⇒ advertise NOW rather than park the hello forever", () => {
+  // The one outcome this gate must never produce is a tab nothing can reach. If the bound
+  // cannot be armed, degrade to today's behaviour (the race) instead of to a wedge.
+  const sends = [];
+  const gate = createRehelloGate({
+    advertise: () => {
+      sends.push(1);
+      return Promise.resolve(true);
+    },
+    now: () => 0,
+    setTimer: () => {
+      throw new Error("no timers here");
+    },
+    clearTimer: () => {},
+  });
+  gate.began("ask_user");
+  gate.request();
+  assert.equal(sends.length, 1, "an unarmable bound must not become an unbounded wait");
+});

--- a/browser_tests/unit/rehello-gate.test.mjs
+++ b/browser_tests/unit/rehello-gate.test.mjs
@@ -20,6 +20,7 @@ import assert from "node:assert/strict";
 import {
   createRehelloGate,
   deferBudgetMs,
+  routeIsStale,
   HUMAN_PACED_COMMANDS,
   REHELLO_DEFER_MS,
   REHELLO_DEFER_HUMAN_MS,
@@ -279,6 +280,105 @@ test("#1095: cancel() DROPS the parked hello — it must not fire into a replace
   assert.equal(armed(), 0, "no timer may outlive the client");
   advance(REHELLO_DEFER_HUMAN_MS * 2);
   assert.deepEqual(sends, [], "and nothing fires later either");
+});
+
+// --- the outbound-frame leak (codex P1) ----------------------------------
+
+test("#1095 codex P1: the advertised route is STALE once the committed workflow moves past it", () => {
+  // onWorkflowMaybeChanged commits the new workflow inline while the hello is parked, so
+  // for the length of the deferral the panel is on B and the orchestrator's binding says A.
+  assert.equal(routeIsStale({ advertised: "tmp:A", live: "tmp:B", mapped: true }), true);
+  assert.equal(routeIsStale({ advertised: "tmp:A", live: "tmp:A", mapped: true }), false);
+
+  // Before a hello has LANDED on this socket there is no binding to disagree with, and the
+  // first hello is never deferred — so nothing may be held on that account.
+  assert.equal(routeIsStale({ advertised: "tmp:A", live: "tmp:B", mapped: false }), false);
+  assert.equal(routeIsStale({ advertised: null, live: "tmp:B", mapped: true }), false);
+
+  // FAILS OPEN on an unreadable id: an id we cannot read is not one we know to be
+  // different (the #607 fence's own rule). Treating it as stale would hold every frame for
+  // as long as it stayed unreadable, turning a leak into a mute panel.
+  assert.equal(routeIsStale({ advertised: "tmp:A", live: null, mapped: true }), false);
+  assert.equal(routeIsStale({ advertised: "tmp:A", live: "", mapped: true }), false);
+  assert.equal(routeIsStale({}), false);
+});
+
+test("#1095 codex P1: a held frame does not leave before the re-advertise lands", async () => {
+  // The leak: a user_message carries NO tab id, so the orchestrator routes it by the socket
+  // binding. Sent during the deferral it reaches the PREVIOUS workflow's agent — the user's
+  // text, context and images delivered into another canvas's conversation.
+  const order = [];
+  let resolveHello;
+  const gate = createRehelloGate({
+    advertise: () => {
+      order.push("hello");
+      return new Promise((r) => {
+        resolveHello = r;
+      });
+    },
+    now: () => 0,
+  });
+  gate.began("ask_user"); // a human-paced command is holding the route
+  const accepted = gate.sendAfterAdvertise(() => order.push("user_message"));
+  assert.equal(accepted, true, "the frame is accepted, not refused — it is queued, not dropped");
+  assert.deepEqual(order, ["hello"], "the hello is EXPEDITED, and the frame has not gone out");
+  assert.equal(gate.heldFrames(), 1);
+
+  resolveHello(true);
+  await new Promise((r) => setTimeout(r, 0));
+  assert.deepEqual(order, ["hello", "user_message"], "the frame follows the hello, never precedes it");
+  assert.equal(gate.heldFrames(), 0);
+});
+
+test("#1095 codex P1: holding EXPEDITES the parked hello rather than waiting out the budget", () => {
+  // The trade, stated: the user has done something that requires the new route, and their
+  // action outranks an in-flight command's reply. A lost reply is OUTCOME UNKNOWN, which is
+  // honest and recoverable; a message delivered to the previous workflow's agent is not.
+  const { gate, sends } = harness();
+  gate.began("ask_user"); // 30s budget — the worst case for the leak
+  gate.request();
+  assert.deepEqual(sends, [], "parked, as the #1095 fix intends");
+  gate.sendAfterAdvertise(() => {});
+  assert.equal(sends.length, 1, "a frame that needs the new route forces the hello out now");
+});
+
+test("#1095 codex P1: held frames keep their order and drain as one batch", async () => {
+  const order = [];
+  let resolveHello;
+  const gate = createRehelloGate({
+    advertise: () => new Promise((r) => { resolveHello = r; }),
+    now: () => 0,
+  });
+  gate.began("graph_set_widget");
+  for (const n of [1, 2, 3]) gate.sendAfterAdvertise(() => order.push(n));
+  assert.equal(gate.heldFrames(), 3, "one queue, not one per frame");
+  resolveHello(true);
+  await new Promise((r) => setTimeout(r, 0));
+  assert.deepEqual(order, [1, 2, 3], "frames on one socket are ordered; the hold must not reorder them");
+});
+
+test("#1095 codex P1: a FAILED re-advertise still drains the hold — a mute panel is worse", async () => {
+  const order = [];
+  const gate = createRehelloGate({
+    advertise: () => Promise.reject(new Error("hello failed")),
+    now: () => 0,
+  });
+  gate.began("graph_set_widget");
+  gate.sendAfterAdvertise(() => order.push("sent"));
+  await new Promise((r) => setTimeout(r, 0));
+  assert.deepEqual(order, ["sent"], "a frame held forever would be a panel that silently stops talking");
+});
+
+test("#1095 codex P1: one frame's failure does not strand the rest of the batch", async () => {
+  const order = [];
+  const gate = createRehelloGate({ advertise: () => Promise.resolve(true), now: () => 0 });
+  gate.began("graph_set_widget");
+  gate.sendAfterAdvertise(() => {
+    throw new Error("this frame blew up");
+  });
+  gate.sendAfterAdvertise(() => order.push("second"));
+  await new Promise((r) => setTimeout(r, 0));
+  assert.deepEqual(order, ["second"]);
 });
 
 // --- the gate's own failure modes ----------------------------------------

--- a/browser_tests/unit/rehello-gate.test.mjs
+++ b/browser_tests/unit/rehello-gate.test.mjs
@@ -67,6 +67,26 @@ function harness({ landed = true, advertise } = {}) {
   return { gate, sends, advance, armed: () => timers.size };
 }
 
+/**
+ * A gate for the tests that drive it by hand (mark, cancel, settle) rather than by the
+ * clock, with a controllable `advertise`.
+ *
+ * THE TIMER STUBS ARE LOAD-BEARING, not tidiness. Built with `now: () => 0` and the REAL
+ * `setTimeout`, `request()` arms a 4-second timer that fires against a clock frozen at
+ * zero — so `fire()` finds itself still inside the budget and re-arms, forever. Nothing
+ * fails; the process simply never runs out of timers and `node --test` hangs, which is the
+ * failure mode this repo treats as red rather than as slow. A handle that never fires is
+ * what "the deadline has not arrived" actually means when the clock does not move.
+ */
+function manualGate(advertise) {
+  return createRehelloGate({
+    advertise,
+    now: () => 0,
+    setTimer: () => 1,
+    clearTimer: () => {},
+  });
+}
+
 // --- the defect itself ----------------------------------------------------
 
 test("#1095: a re-advertise does NOT withdraw the route while a command is in flight", async () => {
@@ -373,49 +393,128 @@ test("#1095 codex P1: a held frame does not leave before the re-advertise lands"
   // text, context and images delivered into another canvas's conversation.
   const order = [];
   let resolveHello;
-  const gate = createRehelloGate({
-    advertise: () => {
-      order.push("hello");
-      return new Promise((r) => {
-        resolveHello = r;
-      });
-    },
-    now: () => 0,
+  const gate = manualGate(() => {
+    order.push("hello");
+    return new Promise((r) => {
+      resolveHello = r;
+    });
   });
-  gate.began("ask_user"); // a human-paced command is holding the route
+  const mark = gate.began("ask_user"); // a human-paced command is holding the route
   const accepted = gate.sendAfterAdvertise(() => order.push("user_message"));
   assert.equal(accepted, true, "the frame is accepted, not refused — it is queued, not dropped");
-  assert.deepEqual(order, ["hello"], "the hello is EXPEDITED, and the frame has not gone out");
+  assert.deepEqual(order, [], "the frame must not go out, and must not force a hello either");
   assert.equal(gate.heldFrames(), 1);
 
+  gate.ended(mark); // the command replies, so the deferral releases the hello
+  assert.deepEqual(order, ["hello"], "the hello goes first");
   resolveHello(true);
   await new Promise((r) => setTimeout(r, 0));
   assert.deepEqual(order, ["hello", "user_message"], "the frame follows the hello, never precedes it");
   assert.equal(gate.heldFrames(), 0);
 });
 
-test("#1095 codex P1: holding EXPEDITES the parked hello rather than waiting out the budget", () => {
-  // The trade, stated: the user has done something that requires the new route, and their
-  // action outranks an in-flight command's reply. A lost reply is OUTCOME UNKNOWN, which is
-  // honest and recoverable; a message delivered to the previous workflow's agent is not.
-  const { gate, sends } = harness();
-  gate.began("ask_user"); // 30s budget — the worst case for the leak
+test("#1095 codex R4: holding must NOT force the parked hello out", async () => {
+  // An earlier cut expedited here, argued as "a person is waiting, and their action outranks
+  // an in-flight command's reply". The argument was sound for the case it was written about
+  // and wrong for the traffic it covered: rehelloForWorkflow ALSO runs automatically and
+  // sends `resume_session` with nobody waiting. That frame reached the hold, expedited the
+  // hello the gate had correctly parked, and let the backend drop the old mapping before an
+  // in-flight command's reply — the very race this PR closes, re-opened by the convenience.
+  const { gate, sends, advance } = harness();
+  const mark = gate.began("ask_user"); // 30s budget — the worst case
   gate.request();
   assert.deepEqual(sends, [], "parked, as the #1095 fix intends");
+
   gate.sendAfterAdvertise(() => {});
-  assert.equal(sends.length, 1, "a frame that needs the new route forces the hello out now");
+  assert.deepEqual(sends, [], "an outbound frame must not withdraw the route from a live command");
+  advance(REHELLO_DEFER_MS + 1);
+  assert.deepEqual(sends, [], "…not even past the MACHINE budget, since ask_user set the deadline");
+
+  // It goes out when the deferral says so — on drain here — and the frame follows.
+  gate.ended(mark);
+  assert.equal(sends.length, 1);
+  await new Promise((r) => setTimeout(r, 0));
+  assert.equal(gate.heldFrames(), 0, "the held frame follows the hello it waited for");
+});
+
+test("#1095 codex R4: a held frame still gets a hello when nothing is in flight", async () => {
+  // Waiting must not mean waiting forever. With no command marked, `request()` advertises
+  // immediately, so the ordinary case pays nothing.
+  const { gate, sends } = harness();
+  const order = [];
+  gate.sendAfterAdvertise(() => order.push("frame"));
+  assert.equal(sends.length, 1, "no deferral to respect ⇒ the hello goes now");
+  await new Promise((r) => setTimeout(r, 0));
+  assert.deepEqual(order, ["frame"]);
+});
+
+test("#1095 codex R4: a held frame is bounded by the budget, not by the command", async () => {
+  // The cost of refusing to expedite, stated and pinned: a command that never replies delays
+  // the frame by the budget and no longer.
+  const { gate, sends, advance } = harness();
+  const order = [];
+  gate.began("graph_set_widget"); // never released
+  gate.sendAfterAdvertise(() => order.push("frame"));
+  assert.deepEqual(sends, [], "held while the command still has budget");
+  advance(REHELLO_DEFER_MS + 1);
+  assert.equal(sends.length, 1, "the budget expires and the hello goes out");
+  await new Promise((r) => setTimeout(r, 0));
+  assert.deepEqual(order, ["frame"], "…and the frame follows it");
+});
+
+// --- a cancelled generation's drain (codex P2) ----------------------------
+
+test("#1095 codex R4: a cancelled generation's drain cannot send on the replacement connection", async () => {
+  // cancel() used to clear `waiters` and `inFlight` but leave `held` and its already-
+  // scheduled `then` intact. The retired advertisement would settle, the drain would run
+  // against the MUTABLE current socket, and a frame composed for the old connection would be
+  // written to the new one — or dropped after `true` had been returned. Same generation
+  // lesson as the marks, one layer out.
+  const order = [];
+  let resolveHello;
+  const gate = manualGate(() => new Promise((r) => { resolveHello = r; }));
+  const mark = gate.began("graph_set_widget");
+  gate.sendAfterAdvertise(() => order.push("frame-from-the-old-connection"));
+  assert.equal(gate.heldFrames(), 1);
+  gate.ended(mark); // the hello for the OLD connection is now on its way
+
+  gate.cancel(); // setUrl / stop / destroy / an active close, mid-hello
+  assert.equal(gate.heldFrames(), 0, "the batch is retired with the connection that built it");
+
+  resolveHello(true); // the retired advertisement settles late
+  await new Promise((r) => setTimeout(r, 0));
+  assert.deepEqual(order, [], "a frame built for a dead route must never reach the live socket");
+});
+
+test("#1095 codex R4: a stale never-settling advertisement cannot wedge later frames", async () => {
+  // The other half of the same defect: with `held` left populated behind a promise that
+  // never settles, every later frame queued behind `held.length > 1` and no drain was ever
+  // scheduled for it.
+  const order = [];
+  let hellos = 0;
+  const gate = manualGate(() => {
+    hellos++;
+    return hellos === 1 ? new Promise(() => {}) : Promise.resolve(true);
+  });
+  const mark = gate.began("graph_set_widget");
+  gate.sendAfterAdvertise(() => order.push("stranded"));
+  gate.ended(mark); // hello #1 starts, and never settles
+  gate.cancel();
+
+  // A new connection, a new frame — it must get its own advertisement and its own drain.
+  gate.sendAfterAdvertise(() => order.push("live"));
+  await new Promise((r) => setTimeout(r, 0));
+  assert.deepEqual(order, ["live"], "the queue is usable again after the connection was replaced");
 });
 
 test("#1095 codex P1: held frames keep their order and drain as one batch", async () => {
   const order = [];
   let resolveHello;
-  const gate = createRehelloGate({
-    advertise: () => new Promise((r) => { resolveHello = r; }),
-    now: () => 0,
-  });
-  gate.began("graph_set_widget");
+  const gate = manualGate(() => new Promise((r) => { resolveHello = r; }));
+  const mark = gate.began("graph_set_widget");
   for (const n of [1, 2, 3]) gate.sendAfterAdvertise(() => order.push(n));
   assert.equal(gate.heldFrames(), 3, "one queue, not one per frame");
+  gate.ended(mark);
   resolveHello(true);
   await new Promise((r) => setTimeout(r, 0));
   assert.deepEqual(order, [1, 2, 3], "frames on one socket are ordered; the hold must not reorder them");
@@ -423,24 +522,23 @@ test("#1095 codex P1: held frames keep their order and drain as one batch", asyn
 
 test("#1095 codex P1: a FAILED re-advertise still drains the hold — a mute panel is worse", async () => {
   const order = [];
-  const gate = createRehelloGate({
-    advertise: () => Promise.reject(new Error("hello failed")),
-    now: () => 0,
-  });
-  gate.began("graph_set_widget");
+  const gate = manualGate(() => Promise.reject(new Error("hello failed")));
+  const mark = gate.began("graph_set_widget");
   gate.sendAfterAdvertise(() => order.push("sent"));
+  gate.ended(mark);
   await new Promise((r) => setTimeout(r, 0));
   assert.deepEqual(order, ["sent"], "a frame held forever would be a panel that silently stops talking");
 });
 
 test("#1095 codex P1: one frame's failure does not strand the rest of the batch", async () => {
   const order = [];
-  const gate = createRehelloGate({ advertise: () => Promise.resolve(true), now: () => 0 });
-  gate.began("graph_set_widget");
+  const gate = manualGate(() => Promise.resolve(true));
+  const mark = gate.began("graph_set_widget");
   gate.sendAfterAdvertise(() => {
     throw new Error("this frame blew up");
   });
   gate.sendAfterAdvertise(() => order.push("second"));
+  gate.ended(mark);
   await new Promise((r) => setTimeout(r, 0));
   assert.deepEqual(order, ["second"]);
 });

--- a/browser_tests/unit/rehello-gate.test.mjs
+++ b/browser_tests/unit/rehello-gate.test.mjs
@@ -500,20 +500,6 @@ test("#1095 codex R4: a frame built for a retired connection is never sent on it
   assert.deepEqual(order, [], "a frame built for a dead connection must never reach the live socket");
 });
 
-test("#1095 codex R4: a retired entry cannot ride out on the replacement's advertisement", () => {
-  // The generation check and the batch clear are not the same guard, and mutation testing is
-  // what showed it. They diverge when an entry from the OLD connection is still in the queue
-  // while the replacement advertises — which is what happens if anything ever queues without
-  // going through cancel's clear. Pinned directly so the fence is not merely redundant.
-  const order = [];
-  const gate = manualGate(() => Promise.resolve(true));
-  gate.holdForRoute(() => order.push("old"), "tmp:B");
-  gate.cancel();
-  gate.holdForRoute(() => order.push("new"), "tmp:B");
-  gate.noteAdvertised("tmp:B");
-  assert.deepEqual(order, ["new"], "only the live connection's frame goes out");
-});
-
 test("#1095 codex R4: the queue is usable again after the connection was replaced", () => {
   const order = [];
   const gate = manualGate(() => Promise.resolve(true));

--- a/browser_tests/unit/rehello-gate.test.mjs
+++ b/browser_tests/unit/rehello-gate.test.mjs
@@ -390,6 +390,43 @@ test("#1095 codex P1: the advertised route is STALE once the committed workflow 
   assert.equal(routeIsStale({}), false);
 });
 
+test("#1095 codex R6: a QUEUED frame is never reported as delivered", () => {
+  // The return of every send path means one thing — "the bytes reached the socket" — and a
+  // queued frame has not. Reporting `true` propagated up as a successful write, and
+  // runCompletion acts on that IRREVERSIBLY: framePushed → markDelivered → the prompt is
+  // retired from pending and never recovered from /history. A frame reported as delivered
+  // and then discarded is neither refused nor delivered but invisible, which is worse than
+  // either of them.
+  const gate = manualGate(() => Promise.resolve(true));
+  assert.equal(
+    gate.holdForRoute(() => {}, "tmp:B"),
+    false,
+    "queued is not sent, and must not be answered as if it were",
+  );
+  assert.equal(gate.heldFrames(), 1, "…while still actually being queued");
+});
+
+test("#1095 codex R6: the expiry follows a deferral that is EXTENDED after the frame queued", () => {
+  // The advertisement a held frame waits for is itself deferred by whatever commands are in
+  // flight, and a command that starts LATER pushes that deadline out. Armed once at enqueue
+  // and never moved, the expiry cleared the queue while the hello it was waiting for was
+  // still perfectly pending — a self-inflicted loss rather than a timeout.
+  const order = [];
+  const { gate, advance } = harness();
+  gate.holdForRoute(() => order.push("frame"), "tmp:B");
+
+  // 20s in, an ask_user starts: the hello may now legitimately not go out until t≈50s.
+  advance(20000);
+  gate.began("ask_user");
+
+  // Past the ORIGINAL 30s window from enqueue — the frame must still be alive.
+  advance(11000);
+  assert.equal(gate.heldFrames(), 1, "a frame must not expire while its advertisement is still due");
+
+  gate.noteAdvertised("tmp:B");
+  assert.deepEqual(order, ["frame"], "…and it is still there to be released");
+});
+
 test("#1095 codex P1: a held frame leaves only when ITS OWN route has been advertised", () => {
   // The leak: a user_message carries NO tab id, so the orchestrator routes it by the socket
   // binding. Sent before the new route is advertised it reaches the PREVIOUS workflow's
@@ -397,7 +434,7 @@ test("#1095 codex P1: a held frame leaves only when ITS OWN route has been adver
   const order = [];
   const gate = manualGate(() => Promise.resolve(true));
   const accepted = gate.holdForRoute(() => order.push("user_message"), "tmp:B");
-  assert.equal(accepted, true, "the frame is accepted, not refused — it is queued, not dropped");
+  assert.equal(accepted, false, "queued is not sent — see the R6 contract test above");
   assert.deepEqual(order, [], "and it does not go out yet");
   assert.equal(gate.heldFrames(), 1);
 

--- a/browser_tests/unit/rehello-gate.test.mjs
+++ b/browser_tests/unit/rehello-gate.test.mjs
@@ -486,6 +486,36 @@ test("#1095 codex R4: a cancelled generation's drain cannot send on the replacem
   assert.deepEqual(order, [], "a frame built for a dead route must never reach the live socket");
 });
 
+test("#1095 codex R4: a retired advertisement must not drain the REPLACEMENT's queue", async () => {
+  // Clearing `held` on cancel is not sufficient on its own, and mutation testing is what
+  // showed it: with only the clear, removing the generation check broke nothing, because the
+  // stale drain found an empty batch. The two diverge exactly here — when a NEW frame has
+  // been queued on the replacement connection before the RETIRED advertisement settles. The
+  // stale drain would then splice a batch that is not its own and write it out before the new
+  // connection's own hello had landed, which is the stale-route send this all exists to stop.
+  const order = [];
+  let resolveRetired;
+  let hellos = 0;
+  const gate = manualGate(() => {
+    hellos++;
+    if (hellos === 1) return new Promise((r) => { resolveRetired = r; });
+    return new Promise(() => {}); // the replacement's own hello is still on its way
+  });
+
+  const mark = gate.began("graph_set_widget");
+  gate.sendAfterAdvertise(() => order.push("old-connection-frame"));
+  gate.ended(mark); // the retired connection's hello is now on its way
+  gate.cancel(); // …and the connection is replaced before it settles
+
+  gate.sendAfterAdvertise(() => order.push("replacement-frame"));
+  assert.equal(gate.heldFrames(), 1, "the replacement queued its own frame");
+
+  resolveRetired(true); // the RETIRED advertisement settles late
+  await new Promise((r) => setTimeout(r, 0));
+  assert.deepEqual(order, [], "a dead connection's advertisement may not release the live queue");
+  assert.equal(gate.heldFrames(), 1, "…the live frame still waits for its OWN hello");
+});
+
 test("#1095 codex R4: a stale never-settling advertisement cannot wedge later frames", async () => {
   // The other half of the same defect: with `held` left populated behind a promise that
   // never settles, every later frame queued behind `held.length > 1` and no drain was ever

--- a/browser_tests/unit/rehello-gate.test.mjs
+++ b/browser_tests/unit/rehello-gate.test.mjs
@@ -257,13 +257,18 @@ test("#1095: a leaked mark delays the hello but can never block it", async () =>
 
 // --- joining an advertisement already on its way (codex P2) ---------------
 
-test("#1095 codex P2: a hold JOINS the advertisement already on its way", async () => {
-  // The most common path in this whole feature, not an edge case: an ordinary workflow
-  // switch with an existing session and nothing in flight. rehelloForWorkflow starts the
-  // hello and immediately sends resume_session; that frame finds the route still stale
-  // (the hello has published nothing yet) and asks to be held. Without the join, the hold
-  // started a SECOND full registration — duplicate hello, duplicate "agent ready" greeting,
-  // and TWO agentSessionEpoch increments for one switch.
+test("#1095 codex P2: two requests during ONE advertisement produce ONE registration", async () => {
+  // A hello is asynchronous — it awaits the tab-identity lease before it can even build its
+  // payload — so "a hello is happening" has real duration, and two callers that both want
+  // the route advertised in that window want the SAME hello. Without the join they got two:
+  // duplicate registration, duplicate "agent ready" greeting, and TWO agentSessionEpoch
+  // increments for one switch. The doubled epoch is not cosmetic; it feeds the canvas-tool
+  // disclosure, whose whole job is to run exactly once per generation.
+  //
+  // (The path that originally exposed this — an outbound frame arriving mid-hello — can no
+  // longer reach an advertisement at all: `holdForRoute` waits and never triggers one. The
+  // join still governs every genuine re-advertise caller: the poll, the #607 fence, the
+  // #310 free_vram re-advertise and the #508 self-heal.)
   let hellos = 0;
   let resolveHello;
   const gate = createRehelloGate({
@@ -277,13 +282,11 @@ test("#1095 codex P2: a hold JOINS the advertisement already on its way", async 
   });
   const first = gate.request(); // the switch's own hello — nothing in flight, so it goes now
   assert.equal(hellos, 1);
-  gate.sendAfterAdvertise(() => {}); // resume_session, riding right behind it
-  assert.equal(hellos, 1, "one switch must produce exactly one registration");
+  const second = gate.request(); // the fence, say, while that one is still on its way
+  assert.equal(hellos, 1, "one window must produce exactly one registration");
 
   resolveHello(true);
-  assert.equal(await first, true);
-  await new Promise((r) => setTimeout(r, 0));
-  assert.equal(gate.heldFrames(), 0, "the held frame still drains on the joined advertisement");
+  assert.deepEqual(await Promise.all([first, second]), [true, true], "both callers get the same outcome");
 });
 
 test("#1095 codex P2: the join ends when the advertisement does", async () => {
@@ -387,190 +390,138 @@ test("#1095 codex P1: the advertised route is STALE once the committed workflow 
   assert.equal(routeIsStale({}), false);
 });
 
-test("#1095 codex P1: a held frame does not leave before the re-advertise lands", async () => {
+test("#1095 codex P1: a held frame leaves only when ITS OWN route has been advertised", () => {
   // The leak: a user_message carries NO tab id, so the orchestrator routes it by the socket
-  // binding. Sent during the deferral it reaches the PREVIOUS workflow's agent — the user's
-  // text, context and images delivered into another canvas's conversation.
+  // binding. Sent before the new route is advertised it reaches the PREVIOUS workflow's
+  // agent — the user's text, context and images delivered into another canvas's conversation.
   const order = [];
-  let resolveHello;
-  const gate = manualGate(() => {
-    order.push("hello");
-    return new Promise((r) => {
-      resolveHello = r;
-    });
-  });
-  const mark = gate.began("ask_user"); // a human-paced command is holding the route
-  const accepted = gate.sendAfterAdvertise(() => order.push("user_message"));
+  const gate = manualGate(() => Promise.resolve(true));
+  const accepted = gate.holdForRoute(() => order.push("user_message"), "tmp:B");
   assert.equal(accepted, true, "the frame is accepted, not refused — it is queued, not dropped");
-  assert.deepEqual(order, [], "the frame must not go out, and must not force a hello either");
+  assert.deepEqual(order, [], "and it does not go out yet");
   assert.equal(gate.heldFrames(), 1);
 
-  gate.ended(mark); // the command replies, so the deferral releases the hello
-  assert.deepEqual(order, ["hello"], "the hello goes first");
-  resolveHello(true);
-  await new Promise((r) => setTimeout(r, 0));
-  assert.deepEqual(order, ["hello", "user_message"], "the frame follows the hello, never precedes it");
+  gate.noteAdvertised("tmp:B");
+  assert.deepEqual(order, ["user_message"], "released by the advertisement of its own route");
   assert.equal(gate.heldFrames(), 0);
 });
 
-test("#1095 codex R4: holding must NOT force the parked hello out", async () => {
-  // An earlier cut expedited here, argued as "a person is waiting, and their action outranks
-  // an in-flight command's reply". The argument was sound for the case it was written about
-  // and wrong for the traffic it covered: rehelloForWorkflow ALSO runs automatically and
-  // sends `resume_session` with nobody waiting. That frame reached the hold, expedited the
-  // hello the gate had correctly parked, and let the backend drop the old mapping before an
-  // in-flight command's reply — the very race this PR closes, re-opened by the convenience.
+test("#1095 codex R5: a held frame NEVER causes an advertisement", () => {
+  // THE RULE THAT ENDS THE FAMILY, rather than another instance of it.
+  //
+  // `bridgeRouteId()` moves the instant the user clicks a workflow tab, but SESSION_KEY is
+  // not rebound until the 600ms poll runs — and the hello reads SESSION_KEY for its
+  // spawn-time `resume`. Anything that advertises inside that gap pairs the NEW route with
+  // the PREVIOUS workflow's session, which on a route with no live agent spawns a
+  // resume-FORK of the previous conversation. onWorkflowMaybeChanged binds the session
+  // first and is the only place that commits a switch as a whole, so it must be the only
+  // author of a workflow re-advertisement. Earlier cuts had the hold call `request()`,
+  // which advertises immediately when nothing is in flight — so an outbound frame arriving
+  // in the gap was itself what published the half-committed switch.
   const { gate, sends, advance } = harness();
-  const mark = gate.began("ask_user"); // 30s budget — the worst case
-  gate.request();
-  assert.deepEqual(sends, [], "parked, as the #1095 fix intends");
-
-  gate.sendAfterAdvertise(() => {});
-  assert.deepEqual(sends, [], "an outbound frame must not withdraw the route from a live command");
-  advance(REHELLO_DEFER_MS + 1);
-  assert.deepEqual(sends, [], "…not even past the MACHINE budget, since ask_user set the deadline");
-
-  // It goes out when the deferral says so — on drain here — and the frame follows.
-  gate.ended(mark);
-  assert.equal(sends.length, 1);
-  await new Promise((r) => setTimeout(r, 0));
-  assert.equal(gate.heldFrames(), 0, "the held frame follows the hello it waited for");
+  gate.holdForRoute(() => {}, "tmp:B");
+  assert.deepEqual(sends, [], "an outbound frame must not start a hello");
+  advance(REHELLO_DEFER_HUMAN_MS - 1);
+  assert.deepEqual(sends, [], "…not on any timer of its own either");
+  assert.equal(gate.heldFrames(), 1, "it is waiting, not driving");
 });
 
-test("#1095 codex R4: a held frame still gets a hello when nothing is in flight", async () => {
-  // Waiting must not mean waiting forever. With no command marked, `request()` advertises
-  // immediately, so the ordinary case pays nothing.
-  const { gate, sends } = harness();
+test("#1095 codex R5: a frame composed for B is DISCARDED when the panel commits to C", () => {
+  // A→B queues B's user_message / resume_session; the user switches B→C before it drains;
+  // the hello advertises C. Without the route stamp the loop delivered B's frames onto C.
   const order = [];
-  gate.sendAfterAdvertise(() => order.push("frame"));
-  assert.equal(sends.length, 1, "no deferral to respect ⇒ the hello goes now");
-  await new Promise((r) => setTimeout(r, 0));
-  assert.deepEqual(order, ["frame"]);
+  const gate = manualGate(() => Promise.resolve(true));
+  gate.holdForRoute(() => order.push("for-B"), "tmp:B");
+  gate.noteAdvertised("tmp:C");
+  assert.deepEqual(order, [], "a message composed for B has no correct meaning on C");
+  assert.equal(gate.heldFrames(), 0, "…and it is dropped rather than left to leak later");
 });
 
-test("#1095 codex R4: a held frame is bounded by the budget, not by the command", async () => {
-  // The cost of refusing to expedite, stated and pinned: a command that never replies delays
-  // the frame by the budget and no longer.
-  const { gate, sends, advance } = harness();
+test("#1095 codex R5: only the matching frames are released; the rest are discarded together", () => {
   const order = [];
-  gate.began("graph_set_widget"); // never released
-  gate.sendAfterAdvertise(() => order.push("frame"));
-  assert.deepEqual(sends, [], "held while the command still has budget");
-  advance(REHELLO_DEFER_MS + 1);
-  assert.equal(sends.length, 1, "the budget expires and the hello goes out");
-  await new Promise((r) => setTimeout(r, 0));
-  assert.deepEqual(order, ["frame"], "…and the frame follows it");
+  const gate = manualGate(() => Promise.resolve(true));
+  gate.holdForRoute(() => order.push("B-1"), "tmp:B");
+  gate.holdForRoute(() => order.push("C-1"), "tmp:C");
+  gate.holdForRoute(() => order.push("B-2"), "tmp:B");
+  gate.noteAdvertised("tmp:B");
+  assert.deepEqual(order, ["B-1", "B-2"], "B's frames go, in order; C's does not ride along");
+  assert.equal(gate.heldFrames(), 0, "the queue is emptied by the advertisement, never left half-drained");
 });
 
-// --- a cancelled generation's drain (codex P2) ----------------------------
-
-test("#1095 codex R4: a cancelled generation's drain cannot send on the replacement connection", async () => {
-  // cancel() used to clear `waiters` and `inFlight` but leave `held` and its already-
-  // scheduled `then` intact. The retired advertisement would settle, the drain would run
-  // against the MUTABLE current socket, and a frame composed for the old connection would be
-  // written to the new one — or dropped after `true` had been returned. Same generation
-  // lesson as the marks, one layer out.
+test("#1095 codex R5: the hold is BOUNDED — a route that is never advertised drops its frames", () => {
+  // The poll advertises a genuine switch within ~600ms, so this is the abandoned case: the
+  // user switched away and never came back, or the poll is not running. Holding forever
+  // would be a mute panel; sending on whatever route the orchestrator does hold is the leak.
   const order = [];
-  let resolveHello;
-  const gate = manualGate(() => new Promise((r) => { resolveHello = r; }));
-  const mark = gate.began("graph_set_widget");
-  gate.sendAfterAdvertise(() => order.push("frame-from-the-old-connection"));
-  assert.equal(gate.heldFrames(), 1);
-  gate.ended(mark); // the hello for the OLD connection is now on its way
-
-  gate.cancel(); // setUrl / stop / destroy / an active close, mid-hello
-  assert.equal(gate.heldFrames(), 0, "the batch is retired with the connection that built it");
-
-  resolveHello(true); // the retired advertisement settles late
-  await new Promise((r) => setTimeout(r, 0));
-  assert.deepEqual(order, [], "a frame built for a dead route must never reach the live socket");
+  const { gate, advance } = harness();
+  gate.holdForRoute(() => order.push("never-advertised"), "tmp:B");
+  advance(REHELLO_DEFER_HUMAN_MS - 1);
+  assert.equal(gate.heldFrames(), 1, "still inside the bound");
+  advance(2);
+  assert.equal(gate.heldFrames(), 0, "past it, the frame is discarded");
+  gate.noteAdvertised("tmp:B");
+  assert.deepEqual(order, [], "…and a late advertisement cannot resurrect it");
 });
 
-test("#1095 codex R4: a retired advertisement must not drain the REPLACEMENT's queue", async () => {
-  // Clearing `held` on cancel is not sufficient on its own, and mutation testing is what
-  // showed it: with only the clear, removing the generation check broke nothing, because the
-  // stale drain found an empty batch. The two diverge exactly here — when a NEW frame has
-  // been queued on the replacement connection before the RETIRED advertisement settles. The
-  // stale drain would then splice a batch that is not its own and write it out before the new
-  // connection's own hello had landed, which is the stale-route send this all exists to stop.
+test("#1095 codex R5: held frames keep their order", () => {
   const order = [];
-  let resolveRetired;
-  let hellos = 0;
-  const gate = manualGate(() => {
-    hellos++;
-    if (hellos === 1) return new Promise((r) => { resolveRetired = r; });
-    return new Promise(() => {}); // the replacement's own hello is still on its way
-  });
-
-  const mark = gate.began("graph_set_widget");
-  gate.sendAfterAdvertise(() => order.push("old-connection-frame"));
-  gate.ended(mark); // the retired connection's hello is now on its way
-  gate.cancel(); // …and the connection is replaced before it settles
-
-  gate.sendAfterAdvertise(() => order.push("replacement-frame"));
-  assert.equal(gate.heldFrames(), 1, "the replacement queued its own frame");
-
-  resolveRetired(true); // the RETIRED advertisement settles late
-  await new Promise((r) => setTimeout(r, 0));
-  assert.deepEqual(order, [], "a dead connection's advertisement may not release the live queue");
-  assert.equal(gate.heldFrames(), 1, "…the live frame still waits for its OWN hello");
-});
-
-test("#1095 codex R4: a stale never-settling advertisement cannot wedge later frames", async () => {
-  // The other half of the same defect: with `held` left populated behind a promise that
-  // never settles, every later frame queued behind `held.length > 1` and no drain was ever
-  // scheduled for it.
-  const order = [];
-  let hellos = 0;
-  const gate = manualGate(() => {
-    hellos++;
-    return hellos === 1 ? new Promise(() => {}) : Promise.resolve(true);
-  });
-  const mark = gate.began("graph_set_widget");
-  gate.sendAfterAdvertise(() => order.push("stranded"));
-  gate.ended(mark); // hello #1 starts, and never settles
-  gate.cancel();
-
-  // A new connection, a new frame — it must get its own advertisement and its own drain.
-  gate.sendAfterAdvertise(() => order.push("live"));
-  await new Promise((r) => setTimeout(r, 0));
-  assert.deepEqual(order, ["live"], "the queue is usable again after the connection was replaced");
-});
-
-test("#1095 codex P1: held frames keep their order and drain as one batch", async () => {
-  const order = [];
-  let resolveHello;
-  const gate = manualGate(() => new Promise((r) => { resolveHello = r; }));
-  const mark = gate.began("graph_set_widget");
-  for (const n of [1, 2, 3]) gate.sendAfterAdvertise(() => order.push(n));
+  const gate = manualGate(() => Promise.resolve(true));
+  for (const n of [1, 2, 3]) gate.holdForRoute(() => order.push(n), "tmp:B");
   assert.equal(gate.heldFrames(), 3, "one queue, not one per frame");
-  gate.ended(mark);
-  resolveHello(true);
-  await new Promise((r) => setTimeout(r, 0));
+  gate.noteAdvertised("tmp:B");
   assert.deepEqual(order, [1, 2, 3], "frames on one socket are ordered; the hold must not reorder them");
 });
 
-test("#1095 codex P1: a FAILED re-advertise still drains the hold — a mute panel is worse", async () => {
-  const order = [];
-  const gate = manualGate(() => Promise.reject(new Error("hello failed")));
-  const mark = gate.began("graph_set_widget");
-  gate.sendAfterAdvertise(() => order.push("sent"));
-  gate.ended(mark);
-  await new Promise((r) => setTimeout(r, 0));
-  assert.deepEqual(order, ["sent"], "a frame held forever would be a panel that silently stops talking");
-});
-
-test("#1095 codex P1: one frame's failure does not strand the rest of the batch", async () => {
+test("#1095 codex R5: one frame's failure does not strand the rest of the batch", () => {
   const order = [];
   const gate = manualGate(() => Promise.resolve(true));
-  const mark = gate.began("graph_set_widget");
-  gate.sendAfterAdvertise(() => {
+  gate.holdForRoute(() => {
     throw new Error("this frame blew up");
-  });
-  gate.sendAfterAdvertise(() => order.push("second"));
-  gate.ended(mark);
-  await new Promise((r) => setTimeout(r, 0));
+  }, "tmp:B");
+  gate.holdForRoute(() => order.push("second"), "tmp:B");
+  gate.noteAdvertised("tmp:B");
   assert.deepEqual(order, ["second"]);
+});
+
+// --- retiring the queue with its connection (codex P2) --------------------
+
+test("#1095 codex R4: a frame built for a retired connection is never sent on its replacement", () => {
+  const order = [];
+  const gate = manualGate(() => Promise.resolve(true));
+  gate.holdForRoute(() => order.push("frame-from-the-old-connection"), "tmp:B");
+  assert.equal(gate.heldFrames(), 1);
+
+  gate.cancel(); // setUrl / stop / destroy / an active close
+  assert.equal(gate.heldFrames(), 0, "the batch is retired with the connection that built it");
+
+  // Even the SAME route id on the replacement connection must not resurrect it: the frame
+  // was composed against a socket that no longer exists.
+  gate.noteAdvertised("tmp:B");
+  assert.deepEqual(order, [], "a frame built for a dead connection must never reach the live socket");
+});
+
+test("#1095 codex R4: a retired entry cannot ride out on the replacement's advertisement", () => {
+  // The generation check and the batch clear are not the same guard, and mutation testing is
+  // what showed it. They diverge when an entry from the OLD connection is still in the queue
+  // while the replacement advertises — which is what happens if anything ever queues without
+  // going through cancel's clear. Pinned directly so the fence is not merely redundant.
+  const order = [];
+  const gate = manualGate(() => Promise.resolve(true));
+  gate.holdForRoute(() => order.push("old"), "tmp:B");
+  gate.cancel();
+  gate.holdForRoute(() => order.push("new"), "tmp:B");
+  gate.noteAdvertised("tmp:B");
+  assert.deepEqual(order, ["new"], "only the live connection's frame goes out");
+});
+
+test("#1095 codex R4: the queue is usable again after the connection was replaced", () => {
+  const order = [];
+  const gate = manualGate(() => Promise.resolve(true));
+  gate.holdForRoute(() => order.push("stranded"), "tmp:B");
+  gate.cancel();
+  gate.holdForRoute(() => order.push("live"), "tmp:B");
+  gate.noteAdvertised("tmp:B");
+  assert.deepEqual(order, ["live"]);
 });
 
 // --- the gate's own failure modes ----------------------------------------

--- a/browser_tests/unit/restart-tab-identity.test.mjs
+++ b/browser_tests/unit/restart-tab-identity.test.mjs
@@ -124,7 +124,10 @@ test("#709: a rejected Web Locks request also omits identity instead of hanging 
 
 test("#709: the live bridge sender awaits the leased identity helper, never getTabId directly", () => {
   const source = readFileSync(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8");
-  const start = source.indexOf("function sendHello() {");
+  // #1095 — the PAYLOAD builder. `sendHello` in front of it is the gate that holds a
+  // re-advertise until in-flight commands have replied, and contains none of this.
+  const start = source.indexOf("function advertiseHello() {");
+  assert.notEqual(start, -1, "could not locate the hello payload builder");
   const body = source.slice(start, source.indexOf("\n  }", start));
   assert.match(body, /sendBridgeHello\(/);
   assert.match(body, /resolveTabIdentity: \(\) => restartTabIdentity\.resolve\(\)/);

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -18648,13 +18648,19 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
     /** #508 — write `reply` back on the socket the command ARRIVED on, and if that is
      *  impossible, journal the outcome (for replay) and run the bounded self-heal.
      *  Returns true only when the frame was actually handed to an open socket. */
-    const deliverReply = (reply, cmd, superseded) => {
+    const deliverReply = (reply, cmd, superseded, mark) => {
       // #1095 — the command is finished the moment its reply is handed over, whatever
       // happens to it after. Released here rather than at each `return` because every
-      // command path reaches this exactly once, and the gate floors the count at 0 so a
-      // double-delivery (a retry, a future refactor) can never drive it negative and
-      // permanently convince the gate that nothing is running.
-      rehelloGate.ended();
+      // command path reaches this exactly once.
+      //
+      // The MARK is threaded from the call site rather than released blind. deliverReply is
+      // per-SOCKET but marks are per-COMMAND, and the two lifetimes come apart the moment a
+      // connection is replaced: `cancel()` invalidates the retired socket's marks, but a
+      // command already executing there still finishes and still calls this. A blind
+      // release would then land on whatever the NEW socket is running and discount ITS
+      // mark, letting a parked hello flush mid-command — the exact race this gate exists to
+      // close, recreated by its own bookkeeping. An invalidated mark releases nothing.
+      rehelloGate.ended(mark);
       const socketOpen = thisSock.readyState === WebSocket.OPEN;
       let sendThrew = false;
       if (socketOpen) {
@@ -18733,7 +18739,7 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
           // budget is a MAX over the batch and only clears at drain, so over-declaring
           // once would pin the route for half a minute. Anonymous means the machine
           // budget, which for an instant refusal is already generous.
-          rehelloGate.began();
+          const refusalMark = rehelloGate.began();
           deliverReply(
             {
               rid: msg.rid,
@@ -18745,6 +18751,7 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
             },
             msg.cmd,
             true,
+            refusalMark,
           );
         }
         return;
@@ -18864,7 +18871,11 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
         //
         // From here to deliverReply there is no other exit: the executor's throws are
         // caught below and turned into a reply, so mark and release are exactly paired.
-        rehelloGate.began(msg.cmd);
+        //
+        // The id is KEPT and handed back at the reply. A release that does not name its own
+        // mark cannot be told apart from one belonging to a connection that has since been
+        // retired — see deliverReply.
+        const inFlightMark = rehelloGate.began(msg.cmd);
         const settleRid = commandRidLedger.begin(msg.rid, fingerprint, commandEpoch);
         let reply;
         // #581 — retain the tracker belonging to the command's completed edit.
@@ -19255,7 +19266,7 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
         // sender with no outcome at all — the "registered tab that never acknowledges
         // anything" wedge. So: always attempt the reply; gate only the UI continuation.
         const superseded = !isActive();
-        if (deliverReply(reply, msg.cmd, superseded)) {
+        if (deliverReply(reply, msg.cmd, superseded, inFlightMark)) {
           // #402 — the open receipt records that its answer was handed to a live socket.
           // ADVISORY only: a socket can still die before the bytes land, so this never
           // becomes a claim about what the caller received — only `applied` is that.
@@ -19454,6 +19465,20 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
       // #654 — a pending refused-hello retry belongs to the dead socket; the
       // reconnect loop's next open-hello takes over (and resets the budget).
       clearRouteRefusalRetry();
+      // #1095 — and so does a parked re-advertise, for exactly the same reason. This is the
+      // ORDINARY drop (network, server restart), which reaches recovery through
+      // scheduleReconnect below rather than through stop()/setUrl()/destroy() — so without
+      // this it was the one teardown that inherited the previous connection's gate state.
+      // Two ways that hurt: a waiter or its timer could fire `advertiseHello()` against the
+      // REPLACEMENT socket, re-registering the tab on a hello nobody asked for; and even
+      // with nothing parked, the dead socket's still-outstanding marks would make the next
+      // legitimate re-advertise wait out a budget for commands that can no longer reply.
+      // Clearing also invalidates those marks, so when the retired socket's commands do
+      // finish, their releases cannot discount the new connection's work.
+      rehelloGate.cancel();
+      // The replacement socket has no mapping yet, so its first hello CREATES one and must
+      // not be gated.
+      advertisedSock = null;
       // Fail any in-flight direct tool calls — the reply can never arrive now.
       for (const [, pend] of pendingCalls) {
         clearTimeout(pend.timer);

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -18729,12 +18729,6 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
         return;
       }
       if (isCommandFrame) {
-        // #1095 — the command is now IN FLIGHT against this socket's tab mapping, and
-        // stays so until deliverReply hands its reply over. Marked here, at the top of
-        // the branch, so an executor that suspends (run/save await; ask_user blocks on
-        // the user) is covered for its whole duration — that suspension is precisely the
-        // window a workflow-change re-hello would withdraw the route in.
-        commandsInFlight++;
         // Agent command — execute against the graph, reply with the rid.
         // Executors may be async (run, save) — await uniformly.
         // ANY command frame is real turn activity (incl. the SILENT_CMDS that
@@ -18829,6 +18823,25 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
           }
           return;
         }
+        // #1095 — the command is now IN FLIGHT against this socket's tab mapping, and
+        // stays so until deliverReply hands its reply over. That covers an executor that
+        // SUSPENDS (run/save await; ask_user blocks on the user), which is precisely the
+        // window a workflow-change re-hello would withdraw the route in.
+        //
+        // Marked HERE, past the #517 dedupe/retry region, not at the top of the branch.
+        // Everything above returns on five paths that never reach deliverReply — a
+        // superseded socket after a retry mismatch, a rejected retry, a defensive ledger
+        // catch, a superseded socket after the duplicate await, and the duplicate replay —
+        // and the last two answer with a direct `thisSock.send`, not deliverReply. An
+        // increment above would leak on every one of them, and a leaked count is not
+        // harmless: it never returns to 0, so EVERY later workflow switch waits out the
+        // full deferral budget. Found by parsing the branch; two hand reads of it missed
+        // these paths entirely.
+        //
+        // From here to deliverReply there is no other exit: the executor's throws are
+        // caught below and turned into a reply, so increment and decrement are exactly
+        // paired.
+        commandsInFlight++;
         const settleRid = commandRidLedger.begin(msg.rid, fingerprint, commandEpoch);
         let reply;
         // #581 — retain the tracker belonging to the command's completed edit.

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -511,6 +511,7 @@ import {
   buildHelloPayload,
 } from "./lib/session-rebind.js";
 import { createRestartTabIdentity, sendBridgeHello } from "./lib/restart-tab-identity.js";
+import { createRehelloGate } from "./lib/rehello-gate.js";
 import { primeModuleCache, resolveBundleStaleness } from "./lib/bundle-version.js";
 import { describeModuleCache, readModuleCacheSummary } from "./lib/module-cache-report.js";
 import { classifyManager404 } from "./lib/manager-404.js";
@@ -18331,21 +18332,34 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
     }
   }
   let socketSeq = 0;
-  // #1095 — orchestrator→panel commands currently executing on this client.
+  // #1095 — a RE-advertise must not withdraw the tab mapping a command is routed to.
   //
-  // A re-hello makes the backend DROP this socket's prior tab mapping (deliberately —
-  // it is what stops a background workflow's output leaking into this tab). If a command
-  // is in flight against that mapping when it is withdrawn, the orchestrator loses the
-  // route mid-command and reports OUTCOME UNKNOWN for work that actually applied. The
-  // workflow poll cannot see that on its own, so the client — which owns the window
-  // between a command frame arriving and its reply going out — counts it and the panel
-  // reads it before re-targeting.
+  // A hello makes the backend DROP this socket's prior tab mapping (deliberately — it is
+  // what stops a background workflow's output leaking into this tab). If a command is in
+  // flight against that mapping when it is withdrawn, the orchestrator loses the route
+  // mid-command and reports OUTCOME UNKNOWN for work that actually applied.
   //
-  // Incremented where the command branch begins, decremented in deliverReply, which
-  // every command path reaches exactly once. A leak here can only DELAY a re-target,
-  // never block it: the reader bounds its own waiting (see onWorkflowMaybeChanged), so
-  // the worst case degrades to today's behaviour rather than wedging the tab.
-  let commandsInFlight = 0;
+  // The gate lives HERE, at the mechanism, and not at the workflow poll that first
+  // exposed the bug. The first cut gated `onWorkflowMaybeChanged`; review showed that
+  // covers one re-advertise out of four (the #607 fence, the #310 free_vram
+  // re-advertise and the #508 self-heal re-registration all call sendHello too) — and
+  // that it made the reported symptom MORE reachable, because holding the poll's hello
+  // back keeps the orchestrator's cached workflow_uuid stale for longer, which trips the
+  // fence, which re-hellos ungated from inside the command branch. Whole argument and
+  // the two budget classes: lib/rehello-gate.js.
+  //
+  // `advertiseHello` is a hoisted declaration below; the arrow defers the read until the
+  // gate actually fires, so this cannot capture it before it exists.
+  const rehelloGate = createRehelloGate({
+    advertise: () => advertiseHello(),
+    now: monotonicNow,
+  });
+  // #1095 — the socket a hello has actually LANDED on. Only a hello that REPLACES an
+  // existing mapping can strand a command; the FIRST hello on a socket creates one and
+  // withdraws nothing, so gating it would be pure loss — a tab that never registers at
+  // all, which is strictly worse than the race. Every other caller (#654's refused-route
+  // retry included) is a re-advertise by definition and passes through the gate.
+  let advertisedSock = null;
   function markConnected() {
     handshakeDone = true;
     handshakenSock = sock;
@@ -18636,11 +18650,11 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
      *  Returns true only when the frame was actually handed to an open socket. */
     const deliverReply = (reply, cmd, superseded) => {
       // #1095 — the command is finished the moment its reply is handed over, whatever
-      // happens to it after. Decremented here rather than at each `return` because every
-      // command path reaches this exactly once, and floored at 0 so a double-delivery
-      // (a retry, a future refactor) can never drive the count negative and permanently
-      // convince the workflow poll that nothing is running.
-      if (commandsInFlight > 0) commandsInFlight--;
+      // happens to it after. Released here rather than at each `return` because every
+      // command path reaches this exactly once, and the gate floors the count at 0 so a
+      // double-delivery (a retry, a future refactor) can never drive it negative and
+      // permanently convince the gate that nothing is running.
+      rehelloGate.ended();
       const socketOpen = thisSock.readyState === WebSocket.OPEN;
       let sendThrew = false;
       if (socketOpen) {
@@ -18706,13 +18720,20 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
         // is a clean, safe-to-retry negative — and deliver/journal that refusal like any
         // other reply.
         if (isCommandFrame) {
-          // #1095 — deliverReply decrements the in-flight count, so this refusal must
-          // balance it. The count is CLIENT-scoped while this branch runs on a RETIRED
-          // socket, so an unpaired decrement here would discount a command still running
-          // on the live socket and let the workflow poll re-target out from under it —
-          // the exact race this counter exists to prevent, reintroduced by its own
-          // bookkeeping. Nothing is executed either way; this keeps the pair balanced.
-          commandsInFlight++;
+          // #1095 — deliverReply RELEASES an in-flight mark, so this refusal must first
+          // take one. The count is CLIENT-scoped while this branch runs on a RETIRED
+          // socket, so an unpaired release here would discount a command still running on
+          // the live socket and let a re-advertise fire out from under it — the exact race
+          // this gate exists to prevent, reintroduced by its own bookkeeping. Nothing is
+          // executed either way; this keeps the pair balanced.
+          //
+          // Deliberately marked with NO command name. `began(cmd)` declares how long a
+          // command may hold the route, and `msg.cmd` here can be `ask_user` — a
+          // 30-second human budget for a refusal that completes in microseconds. The
+          // budget is a MAX over the batch and only clears at drain, so over-declaring
+          // once would pin the route for half a minute. Anonymous means the machine
+          // budget, which for an instant refusal is already generous.
+          rehelloGate.began();
           deliverReply(
             {
               rid: msg.rid,
@@ -18826,22 +18847,24 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
         // #1095 — the command is now IN FLIGHT against this socket's tab mapping, and
         // stays so until deliverReply hands its reply over. That covers an executor that
         // SUSPENDS (run/save await; ask_user blocks on the user), which is precisely the
-        // window a workflow-change re-hello would withdraw the route in.
+        // window a re-advertise would withdraw the route in.
+        //
+        // `msg.cmd` is passed because the command's own name is what sets how long it may
+        // hold the route: `ask_user`/`request_secret` are paced by a PERSON and get the
+        // human budget, everything else the machine one (lib/rehello-gate.js).
         //
         // Marked HERE, past the #517 dedupe/retry region, not at the top of the branch.
         // Everything above returns on five paths that never reach deliverReply — a
         // superseded socket after a retry mismatch, a rejected retry, a defensive ledger
         // catch, a superseded socket after the duplicate await, and the duplicate replay —
-        // and the last two answer with a direct `thisSock.send`, not deliverReply. An
-        // increment above would leak on every one of them, and a leaked count is not
-        // harmless: it never returns to 0, so EVERY later workflow switch waits out the
-        // full deferral budget. Found by parsing the branch; two hand reads of it missed
-        // these paths entirely.
+        // and the last two answer with a direct `thisSock.send`, not deliverReply. A mark
+        // above would leak on every one of them, and a leaked mark is not harmless: the
+        // count never returns to 0, so EVERY later re-advertise waits out the full budget.
+        // Found by parsing the branch; two hand reads of it missed these paths entirely.
         //
         // From here to deliverReply there is no other exit: the executor's throws are
-        // caught below and turned into a reply, so increment and decrement are exactly
-        // paired.
-        commandsInFlight++;
+        // caught below and turned into a reply, so mark and release are exactly paired.
+        rehelloGate.began(msg.cmd);
         const settleRid = commandRidLedger.begin(msg.rid, fingerprint, commandEpoch);
         let reply;
         // #581 — retain the tracker belonging to the command's completed edit.
@@ -19472,11 +19495,33 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
     });
   }
 
+  /** #1095 — THE entry point for advertising this tab. Every caller goes through here:
+   *  the socket-open hello, the workflow re-target, the #607 fence recovery, the #310
+   *  free_vram re-advertise, the #508 self-heal re-registration and the #654 refused-route
+   *  retry. That is the point — the deferral is a property of the MECHANISM, so a caller
+   *  added later is gated by construction instead of being the next ungated hole.
+   *
+   *  Contract unchanged: a promise resolving to whether the hello reached the wire. A
+   *  deferred hello resolves when it eventually goes out (or false if the client was torn
+   *  down first), so the #607 budget still counts only what the orchestrator received. */
+  function sendHello() {
+    // A hello that REPLACES this socket's mapping is the only one that can strand a
+    // command. The first hello on a socket creates the mapping — there is nothing to
+    // withdraw, and deferring it would leave the tab unregistered while commands pile up
+    // against a route that does not exist yet. `advertisedSock` is set only on the success
+    // path below, so a hello that never landed does not arm the gate either.
+    if (!sock || sock !== advertisedSock) return advertiseHello();
+    return rehelloGate.request();
+  }
+
   /** Returns a promise resolving to whether the hello actually REACHED THE WIRE.
    *  Every existing caller ignores it; the #607 re-hello does not, because a
    *  recovery that throttles itself on the strength of a send that never happened
-   *  stays wedged while believing it is being polite. */
-  function sendHello() {
+   *  stays wedged while believing it is being polite.
+   *
+   *  #1095 — call `sendHello()`, not this, unless you can show the send must not wait for
+   *  in-flight commands. This is the ungated send the gate drives. */
+  function advertiseHello() {
     if (!sock || sock.readyState !== WebSocket.OPEN) return Promise.resolve(false);
     // #291 — a hello BINDS this socket to an agent session, and not always the one
     // it was bound to a moment ago. Besides the socket-open hello, the panel
@@ -19590,6 +19635,12 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
           // Published only now, for the same reason the epoch advances only now:
           // a hello that never reached the wire advertised nothing.
           lastAdvertisedWorkflowUuid = advertisedWorkflowUuid;
+          // #1095 — this socket now HAS a mapping, so every later hello on it is a
+          // re-advertise and goes through the gate. Recorded on the same success path and
+          // for the same reason as the two lines above: a hello that never left the tab
+          // established nothing, and arming the gate on it would defer the retry that
+          // could actually register this tab.
+          advertisedSock = target;
           // #654 — registration succeeded: the refused-hello retry budget is
           // replenished and any pending retry is moot.
           routeRefusalRetries = 0;
@@ -19974,6 +20025,12 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
       } catch {}
       sock = null;
       handshakenSock = null;
+      // #1095 — a parked re-advertise belongs to the connection being replaced. Firing it
+      // into a DIFFERENT bridge would register this tab somewhere the caller never asked
+      // for, which is the corruption class #508 already refuses to risk. Dropped, not
+      // flushed; the new socket's own open hello registers the tab.
+      rehelloGate.cancel();
+      advertisedSock = null;
       connect();
     },
     currentUrl() {
@@ -19982,13 +20039,12 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
     isConnected() {
       return !!sock && sock.readyState === WebSocket.OPEN;
     },
-    /** #1095 — how many orchestrator→panel commands are mid-execution. Read by the
-     *  workflow poll before it re-targets this socket, because a re-hello withdraws the
-     *  tab mapping those commands are routed to. Read-only by design: only the command
-     *  path may move it, and a caller that could reset it would be able to manufacture
-     *  the very race this exists to close. */
+    /** #1095 — diagnostics only. The in-flight count is NOT exported for callers to gate
+     *  on: an earlier cut had the workflow poll read it and decide for itself, and that is
+     *  precisely the design review rejected — one caller gated while three others
+     *  re-advertise freely. The decision belongs to sendHello. */
     commandsInFlight() {
-      return commandsInFlight;
+      return rehelloGate.inFlight();
     },
     stop() {
       // Close the socket and stop reconnecting, but stay re-startable (unlike
@@ -20006,6 +20062,9 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
       } catch {}
       sock = null;
       handshakenSock = null;
+      // #1095 — see setUrl: a parked hello must never outlive the socket it was queued for.
+      rehelloGate.cancel();
+      advertisedSock = null;
     },
     destroy() {
       closed = true;
@@ -20019,6 +20078,10 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
       } catch {}
       sock = null;
       handshakenSock = null;
+      // #1095 — and a torn-down panel must not leave a timer armed to hello from a closure
+      // nothing owns any more.
+      rehelloGate.cancel();
+      advertisedSock = null;
     },
   };
 }
@@ -27054,51 +27117,31 @@ function buildPanel() {
       /* reconnect path retries the hello */
     }
   }
-  // #1095 — how many consecutive polls have deferred a workflow re-target because a
-  // command was in flight. At 600ms per tick this budget is ~3s, comfortably longer than
-  // a normal graph mutation and far shorter than any command timeout, so a healthy batch
-  // finishes inside it while a stuck command cannot strand the tab on the old route.
-  const MAX_WORKFLOW_RETARGET_DEFERRALS = 5;
-  let workflowRetargetDeferrals = 0;
+  // #1095 — THIS POLL DOES NOT GATE ANYTHING, AND THAT IS THE FIX.
+  //
+  // The first cut deferred the whole function while a command was in flight, so that the
+  // re-hello below could not withdraw the route mid-command. Review rejected it on three
+  // counts, all of which this arrangement answers by moving the wait into sendHello:
+  //
+  //   1. It covered ONE re-advertise. The #607 fence, the #310 free_vram re-advertise and
+  //      the #508 self-heal all call sendHello too, and the fence fires from inside the
+  //      command branch — so deferring here made the orchestrator's cached workflow_uuid
+  //      staler, tripped the fence more often, and routed MORE traffic through the one
+  //      re-hello that was still ungated.
+  //   2. Its budget was five poll ticks (~3 s), which is nothing to an `ask_user` waiting
+  //      on a person. The bound is now contributed by the commands themselves.
+  //   3. Returning early swallowed the caller's INLINE work. `panelHooks.applyChatScope`
+  //      nulls `currentWorkflowId` and calls this expecting the re-bind to happen now; it
+  //      then repaints the context ring and announces the scope change. A deferred return
+  //      announced a re-bind that had not happened.
+  //
+  // So everything below commits unconditionally, exactly as it did before #1095, and only
+  // the hello waits. See lib/rehello-gate.js.
   function onWorkflowMaybeChanged() {
     const wf = activeWorkflowRef();
     const wfid = workflowTabId();
     const wfkey = wf ? (wf.key || wf.id || "unsaved") : null;
-    if (wfid === currentWorkflowId) {
-      // #1095 — nothing pending, so nothing is being deferred: release the budget here
-      // too. It is only reset once a deferred switch finally proceeds, and this early
-      // return skips that — so a switch that was deferred a tick or two and then ABANDONED
-      // (the user switches back, or the id settles to what it already was) would leave
-      // the budget part-spent, and the next genuine switch would get fewer deferrals than
-      // it is owed. A counter that only ever ratchets one way is the same shape as the
-      // stale-marker class this file keeps finding.
-      workflowRetargetDeferrals = 0;
-      return; // case 1: no change
-    }
-
-    // #1095 — a workflow change re-targets this socket, and rehelloForWorkflow's own note
-    // says the backend DROPS the socket's prior tab mapping when it does. That is correct
-    // (it stops a background workflow's output leaking here) but it must not happen while
-    // a command is routed to that mapping: the orchestrator loses the route mid-command
-    // and reports OUTCOME UNKNOWN for work that actually applied, then "Connected: none"
-    // until the new mapping settles. Creating a workflow and immediately applying a batch
-    // of mutations is exactly that window — this poll runs every 600ms, so a tick lands
-    // between two commands.
-    //
-    // Deferred BEFORE `currentWorkflowId` is committed, which is the whole subtlety:
-    // advancing the id and deferring only the hello would swallow the change forever,
-    // because the next tick's early return above would treat it as already handled.
-    // Returning here leaves the id untouched, so the poll IS the retry — no new timer.
-    //
-    // BOUNDED, because an unbounded wait converts a race into a wedge, which is worse:
-    // a command whose reply is never delivered would strand the tab on the old workflow's
-    // route permanently. After the budget the re-target proceeds regardless, degrading to
-    // exactly today's behaviour rather than to something new.
-    if (client?.commandsInFlight?.() > 0 && workflowRetargetDeferrals < MAX_WORKFLOW_RETARGET_DEFERRALS) {
-      workflowRetargetDeferrals++;
-      return;
-    }
-    workflowRetargetDeferrals = 0;
+    if (wfid === currentWorkflowId) return; // case 1: no change
 
     const initial = currentWorkflowId == null;
     const followsPanel = historyScopeFollowsPanel();

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -512,6 +512,12 @@ import {
 } from "./lib/session-rebind.js";
 import { createRestartTabIdentity, sendBridgeHello } from "./lib/restart-tab-identity.js";
 import { createRehelloGate, routeIsStale } from "./lib/rehello-gate.js";
+/** #1095 — control frames that must arrive AFTER the hello that establishes their route,
+ *  and whose senders ignore the return value. Those two properties together are what makes
+ *  a frame queueable: a queued frame's outcome is not yet known, so it may only be queued
+ *  where nobody is going to act on an answer it cannot give. Everything else is refused
+ *  while the route is stale (see sendFrame). */
+const SESSION_ORDERED_FRAMES = new Set(["resume_session", "new_session"]);
 import { primeModuleCache, resolveBundleStaleness } from "./lib/bundle-version.js";
 import { describeModuleCache, readModuleCacheSummary } from "./lib/module-cache-report.js";
 import { classifyManager404 } from "./lib/manager-404.js";
@@ -19990,9 +19996,16 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
       // to the agent for the previous one. Hold it instead, STAMPED with the route it was
       // composed for: it leaves only when that route has actually been advertised, it never
       // causes the advertisement (only the workflow poll may author one — it binds the
-      // session first), and if the panel commits to a different workflow meanwhile it is
-      // discarded rather than delivered there. See holdForRoute in lib/rehello-gate.js.
-      if (advertisedRouteIsStale()) return rehelloGate.holdForRoute(send, bridgeRouteId());
+      // session first).
+      //
+      // REFUSED, NOT QUEUED. Queueing a user message and answering `true` would report it
+      // delivered while it can still be discarded — and `trackSend` arms a delivery timeout
+      // on that answer, so the message would sit "sent" and then quietly never arrive.
+      // Queueing and answering `false` is worse: the tray shows it failed, the user presses
+      // Send now, and the queued copy goes out too. A plain refusal is the only answer that
+      // is true when it is given: nothing was written, the tray says so, and one retry
+      // sends exactly one message. See holdForRoute in lib/rehello-gate.js.
+      if (advertisedRouteIsStale()) return false;
       return send();
     },
     /** Send an arbitrary control frame (set_options, new_session, …). */
@@ -20041,9 +20054,27 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
       // cannot overtake each other — frames on one socket are ordered, and a hold that
       // reordered them would trade a routing bug for a conversation bug.
       //
+      // Only SESSION-ORDERED frames are queued; everything else is refused outright.
+      //
+      // The split is not a convenience. A queued frame cannot be reported as delivered (it
+      // may still be discarded) and cannot be reported as failed (the queued copy may still
+      // go out), so it may only be queued when NO caller reads the answer. `resume_session`
+      // and `new_session` are exactly that: fire-and-forget, and meaningless before the
+      // hello anyway — they hand the next turn to an agent on a route the orchestrator has
+      // not been told about yet.
+      //
+      // Everything else is refused, which every caller already handles correctly. It matters
+      // most for `agent_event`: runCompletion reads the answer and, on `true`, calls
+      // markDelivered — retiring the prompt from pending so it is NEVER recovered from
+      // /history. A refusal re-pends it instead, which is the behaviour that path was built
+      // for ("sendFrame returns false when the bridge socket is down").
+      //
       // Stamped with `routeId`, which is the route this frame's own tab_id already names, so
       // the stamp and the payload can never disagree.
-      if (advertisedRouteIsStale()) return rehelloGate.holdForRoute(send, routeId);
+      if (advertisedRouteIsStale()) {
+        if (!SESSION_ORDERED_FRAMES.has(frame?.type)) return false;
+        return rehelloGate.holdForRoute(send, routeId);
+      }
       return send();
     },
     /** Run a whitelisted backend tool directly (no agent turn), cid-correlated.

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -19932,9 +19932,9 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
       // particular, because `pendingContext` is one-shot and has already been consumed).
       //
       // THE DISCLOSURE IS NOT. It is decided inside the closure, against the epoch that is
-      // current when the frame actually leaves, because the hold EXPEDITES a hello and a
-      // landed hello ADVANCES `agentSessionEpoch` — so a decision made out here is a
-      // decision about the agent generation this message will not reach.
+      // current when the frame actually leaves: a held frame goes out after the hello it was
+      // waiting for, and a landed hello ADVANCES `agentSessionEpoch` — so a decision made
+      // out here is a decision about the agent generation this message will not reach.
       //
       // The failure that causes is silent and total: if the outgoing generation had already
       // proven its canvas tools, `disclose` is false, the NEW generation is handed a message
@@ -19983,9 +19983,10 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
       // #1095 P1 — a `user_message` carries NO tab id, so the orchestrator routes it by the
       // binding this socket already has. Sent while a re-advertise is still parked, the
       // user's text, context and images for the workflow they are LOOKING AT are delivered
-      // to the agent for the previous one. Hold it behind the hello instead; the hold
-      // expedites that hello, so the wait is the hello's own round trip rather than the
-      // deferral budget. See routeIsStale in lib/rehello-gate.js.
+      // to the agent for the previous one. Hold it behind the hello instead — it waits for
+      // the one the deferral will produce and cannot force it out, so holding a message can
+      // never withdraw a route from a command that has not replied. Bounded by the deferral
+      // budget. See routeIsStale and sendAfterAdvertise in lib/rehello-gate.js.
       if (advertisedRouteIsStale()) return rehelloGate.sendAfterAdvertise(send);
       return send();
     },

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -511,7 +511,7 @@ import {
   buildHelloPayload,
 } from "./lib/session-rebind.js";
 import { createRestartTabIdentity, sendBridgeHello } from "./lib/restart-tab-identity.js";
-import { createRehelloGate } from "./lib/rehello-gate.js";
+import { createRehelloGate, routeIsStale } from "./lib/rehello-gate.js";
 import { primeModuleCache, resolveBundleStaleness } from "./lib/bundle-version.js";
 import { describeModuleCache, readModuleCacheSummary } from "./lib/module-cache-report.js";
 import { classifyManager404 } from "./lib/manager-404.js";
@@ -18360,6 +18360,26 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
   // all, which is strictly worse than the race. Every other caller (#654's refused-route
   // retry included) is a re-advertise by definition and passes through the gate.
   let advertisedSock = null;
+  // #1095 — the route id the last LANDED hello actually carried. Compared against the live
+  // `bridgeRouteId()` to tell whether the orchestrator's binding still names the workflow
+  // the panel has already committed to; see routeIsStale in lib/rehello-gate.js for why
+  // that gap exists at all and what leaks through it.
+  let lastAdvertisedRouteId = null;
+
+  /** #1095 — is this socket's binding out of date with the committed workflow? */
+  function advertisedRouteIsStale() {
+    let live = null;
+    try {
+      live = bridgeRouteId();
+    } catch {
+      live = null; // unreadable ⇒ not provably different; routeIsStale fails open
+    }
+    return routeIsStale({
+      advertised: lastAdvertisedRouteId,
+      live,
+      mapped: !!sock && sock === advertisedSock,
+    });
+  }
   function markConnected() {
     handshakeDone = true;
     handshakenSock = sock;
@@ -19565,6 +19585,11 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
     // `lastAdvertisedWorkflowUuid` only on the success path below: the #607
     // budget counts what reached the orchestrator, not what we meant to send.
     let advertisedWorkflowUuid = null;
+    // #1095 — likewise for the ROUTE id this hello carries. Read where the payload is built
+    // (bridgeRouteId() is derived from the LIVE active workflow, so it moves under us) and
+    // published only on the landed path below, for the same reason as the uuid: a hello that
+    // never reached the orchestrator advertised no route.
+    let advertisedRouteId = null;
     return sendBridgeHello({
       socket: target,
       isCurrent: () => sock === target && target.readyState === WebSocket.OPEN,
@@ -19590,6 +19615,11 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
         scheduleRouteRefusalRetry();
         return null;
       }
+      // #1095 — recorded only past the refusal, so `advertisedRouteId` is never a route the
+      // hello declined to carry. It is published to `lastAdvertisedRouteId` only once the
+      // send has landed, which is the same "nothing is recorded before it is true" rule the
+      // adopt above and the epoch bump below both follow.
+      advertisedRouteId = routeId;
       // Carry the last session id so the orchestrator resumes the agent's
       // memory after a panel reload (only honored before the tab's agent spawns).
       const resume = getResume?.();
@@ -19666,6 +19696,9 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
           // established nothing, and arming the gate on it would defer the retry that
           // could actually register this tab.
           advertisedSock = target;
+          // …and THIS is the binding the orchestrator now holds for this socket. Outbound
+          // frames it routes by binding are compared against it (advertisedRouteIsStale).
+          lastAdvertisedRouteId = advertisedRouteId;
           // #654 — registration succeeded: the refused-hello retry budget is
           // replenished and any pending retry is moot.
           routeRefusalRetries = 0;
@@ -19881,6 +19914,11 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
       });
       const disclosed = disclosure.disclose && typeof text === "string";
       const outText = disclosed ? CANVAS_TOOL_DISCLOSURE + text : text;
+      // #1095 — the frame is BUILT now and SENT possibly a moment later, so everything the
+      // send consumes (the merged context, the disclosure decision, the epoch stamps) is
+      // captured here, at the instant the user pressed send. A held frame is therefore
+      // byte-identical to the one that would have gone out immediately.
+      const send = () => {
       try {
         sock.send(
           JSON.stringify({
@@ -19910,6 +19948,15 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
       } catch {
         return false;
       }
+      };
+      // #1095 P1 — a `user_message` carries NO tab id, so the orchestrator routes it by the
+      // binding this socket already has. Sent while a re-advertise is still parked, the
+      // user's text, context and images for the workflow they are LOOKING AT are delivered
+      // to the agent for the previous one. Hold it behind the hello instead; the hold
+      // expedites that hello, so the wait is the hello's own round trip rather than the
+      // deferral budget. See routeIsStale in lib/rehello-gate.js.
+      if (advertisedRouteIsStale()) return rehelloGate.sendAfterAdvertise(send);
+      return send();
     },
     /** Send an arbitrary control frame (set_options, new_session, …). */
     sendFrame(frame) {
@@ -19930,6 +19977,10 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
       // #640 — refuse rather than emit a frame with no established route.
       const routeId = bridgeRouteId();
       if (!routeId) return false;
+      // #1095 — `frame` is captured, not copied into a new name: the mute/blind gate above
+      // has already finished rewriting it, and every assertion about this send is written
+      // against `...frame`. The closure only moves WHEN it runs, never WHAT it sends.
+      const send = () => {
       try {
         sock.send(JSON.stringify({ tab_id: routeId, ...frame }));
         // #291 — `new_session` / `resume_session` hand the next turn to a different
@@ -19943,6 +19994,17 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
       } catch {
         return false;
       }
+      };
+      // #1095 P1 — a control frame DOES carry a tab id, and `routeId` above is derived from
+      // the LIVE active workflow — so during a deferral it names a route the orchestrator
+      // has not been told about yet. `new_session` / `resume_session` in particular hand the
+      // next turn to a different agent over this socket, and doing that against a binding
+      // that is about to be replaced is how a conversation ends up attached to the wrong
+      // canvas. Held for the same reason, and in the SAME queue as user_message so the two
+      // cannot overtake each other — frames on one socket are ordered, and a hold that
+      // reordered them would trade a routing bug for a conversation bug.
+      if (advertisedRouteIsStale()) return rehelloGate.sendAfterAdvertise(send);
+      return send();
     },
     /** Run a whitelisted backend tool directly (no agent turn), cid-correlated.
      *  Resolves { ok, result, error } where result is the MCP content array

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -18331,6 +18331,21 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
     }
   }
   let socketSeq = 0;
+  // #1095 — orchestrator→panel commands currently executing on this client.
+  //
+  // A re-hello makes the backend DROP this socket's prior tab mapping (deliberately —
+  // it is what stops a background workflow's output leaking into this tab). If a command
+  // is in flight against that mapping when it is withdrawn, the orchestrator loses the
+  // route mid-command and reports OUTCOME UNKNOWN for work that actually applied. The
+  // workflow poll cannot see that on its own, so the client — which owns the window
+  // between a command frame arriving and its reply going out — counts it and the panel
+  // reads it before re-targeting.
+  //
+  // Incremented where the command branch begins, decremented in deliverReply, which
+  // every command path reaches exactly once. A leak here can only DELAY a re-target,
+  // never block it: the reader bounds its own waiting (see onWorkflowMaybeChanged), so
+  // the worst case degrades to today's behaviour rather than wedging the tab.
+  let commandsInFlight = 0;
   function markConnected() {
     handshakeDone = true;
     handshakenSock = sock;
@@ -18620,6 +18635,12 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
      *  impossible, journal the outcome (for replay) and run the bounded self-heal.
      *  Returns true only when the frame was actually handed to an open socket. */
     const deliverReply = (reply, cmd, superseded) => {
+      // #1095 — the command is finished the moment its reply is handed over, whatever
+      // happens to it after. Decremented here rather than at each `return` because every
+      // command path reaches this exactly once, and floored at 0 so a double-delivery
+      // (a retry, a future refactor) can never drive the count negative and permanently
+      // convince the workflow poll that nothing is running.
+      if (commandsInFlight > 0) commandsInFlight--;
       const socketOpen = thisSock.readyState === WebSocket.OPEN;
       let sendThrew = false;
       if (socketOpen) {
@@ -18685,6 +18706,13 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
         // is a clean, safe-to-retry negative — and deliver/journal that refusal like any
         // other reply.
         if (isCommandFrame) {
+          // #1095 — deliverReply decrements the in-flight count, so this refusal must
+          // balance it. The count is CLIENT-scoped while this branch runs on a RETIRED
+          // socket, so an unpaired decrement here would discount a command still running
+          // on the live socket and let the workflow poll re-target out from under it —
+          // the exact race this counter exists to prevent, reintroduced by its own
+          // bookkeeping. Nothing is executed either way; this keeps the pair balanced.
+          commandsInFlight++;
           deliverReply(
             {
               rid: msg.rid,
@@ -18701,6 +18729,12 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
         return;
       }
       if (isCommandFrame) {
+        // #1095 — the command is now IN FLIGHT against this socket's tab mapping, and
+        // stays so until deliverReply hands its reply over. Marked here, at the top of
+        // the branch, so an executor that suspends (run/save await; ask_user blocks on
+        // the user) is covered for its whole duration — that suspension is precisely the
+        // window a workflow-change re-hello would withdraw the route in.
+        commandsInFlight++;
         // Agent command — execute against the graph, reply with the rid.
         // Executors may be async (run, save) — await uniformly.
         // ANY command frame is real turn activity (incl. the SILENT_CMDS that
@@ -19934,6 +19968,14 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
     },
     isConnected() {
       return !!sock && sock.readyState === WebSocket.OPEN;
+    },
+    /** #1095 — how many orchestrator→panel commands are mid-execution. Read by the
+     *  workflow poll before it re-targets this socket, because a re-hello withdraws the
+     *  tab mapping those commands are routed to. Read-only by design: only the command
+     *  path may move it, and a caller that could reset it would be able to manufacture
+     *  the very race this exists to close. */
+    commandsInFlight() {
+      return commandsInFlight;
     },
     stop() {
       // Close the socket and stop reconnecting, but stay re-startable (unlike
@@ -26999,11 +27041,41 @@ function buildPanel() {
       /* reconnect path retries the hello */
     }
   }
+  // #1095 — how many consecutive polls have deferred a workflow re-target because a
+  // command was in flight. At 600ms per tick this budget is ~3s, comfortably longer than
+  // a normal graph mutation and far shorter than any command timeout, so a healthy batch
+  // finishes inside it while a stuck command cannot strand the tab on the old route.
+  const MAX_WORKFLOW_RETARGET_DEFERRALS = 5;
+  let workflowRetargetDeferrals = 0;
   function onWorkflowMaybeChanged() {
     const wf = activeWorkflowRef();
     const wfid = workflowTabId();
     const wfkey = wf ? (wf.key || wf.id || "unsaved") : null;
     if (wfid === currentWorkflowId) return; // case 1: no change
+
+    // #1095 — a workflow change re-targets this socket, and rehelloForWorkflow's own note
+    // says the backend DROPS the socket's prior tab mapping when it does. That is correct
+    // (it stops a background workflow's output leaking here) but it must not happen while
+    // a command is routed to that mapping: the orchestrator loses the route mid-command
+    // and reports OUTCOME UNKNOWN for work that actually applied, then "Connected: none"
+    // until the new mapping settles. Creating a workflow and immediately applying a batch
+    // of mutations is exactly that window — this poll runs every 600ms, so a tick lands
+    // between two commands.
+    //
+    // Deferred BEFORE `currentWorkflowId` is committed, which is the whole subtlety:
+    // advancing the id and deferring only the hello would swallow the change forever,
+    // because the next tick's early return above would treat it as already handled.
+    // Returning here leaves the id untouched, so the poll IS the retry — no new timer.
+    //
+    // BOUNDED, because an unbounded wait converts a race into a wedge, which is worse:
+    // a command whose reply is never delivered would strand the tab on the old workflow's
+    // route permanently. After the budget the re-target proceeds regardless, degrading to
+    // exactly today's behaviour rather than to something new.
+    if (client?.commandsInFlight?.() > 0 && workflowRetargetDeferrals < MAX_WORKFLOW_RETARGET_DEFERRALS) {
+      workflowRetargetDeferrals++;
+      return;
+    }
+    workflowRetargetDeferrals = 0;
 
     const initial = currentWorkflowId == null;
     const followsPanel = historyScopeFollowsPanel();

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -19719,6 +19719,10 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
           // …and THIS is the binding the orchestrator now holds for this socket. Outbound
           // frames it routes by binding are compared against it (advertisedRouteIsStale).
           lastAdvertisedRouteId = advertisedRouteId;
+          // #1095 — release exactly the held frames composed FOR this route, and discard any
+          // composed for a workflow the panel has since moved past. Driven from the landed
+          // path, so "advertised" means the orchestrator was told, never that we meant to.
+          rehelloGate.noteAdvertised(advertisedRouteId);
           // #654 — registration succeeded: the refused-hello retry budget is
           // replenished and any pending retry is moot.
           routeRefusalRetries = 0;
@@ -19983,11 +19987,12 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
       // #1095 P1 — a `user_message` carries NO tab id, so the orchestrator routes it by the
       // binding this socket already has. Sent while a re-advertise is still parked, the
       // user's text, context and images for the workflow they are LOOKING AT are delivered
-      // to the agent for the previous one. Hold it behind the hello instead — it waits for
-      // the one the deferral will produce and cannot force it out, so holding a message can
-      // never withdraw a route from a command that has not replied. Bounded by the deferral
-      // budget. See routeIsStale and sendAfterAdvertise in lib/rehello-gate.js.
-      if (advertisedRouteIsStale()) return rehelloGate.sendAfterAdvertise(send);
+      // to the agent for the previous one. Hold it instead, STAMPED with the route it was
+      // composed for: it leaves only when that route has actually been advertised, it never
+      // causes the advertisement (only the workflow poll may author one — it binds the
+      // session first), and if the panel commits to a different workflow meanwhile it is
+      // discarded rather than delivered there. See holdForRoute in lib/rehello-gate.js.
+      if (advertisedRouteIsStale()) return rehelloGate.holdForRoute(send, bridgeRouteId());
       return send();
     },
     /** Send an arbitrary control frame (set_options, new_session, …). */
@@ -20035,7 +20040,10 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
       // canvas. Held for the same reason, and in the SAME queue as user_message so the two
       // cannot overtake each other — frames on one socket are ordered, and a hold that
       // reordered them would trade a routing bug for a conversation bug.
-      if (advertisedRouteIsStale()) return rehelloGate.sendAfterAdvertise(send);
+      //
+      // Stamped with `routeId`, which is the route this frame's own tab_id already names, so
+      // the stamp and the payload can never disagree.
+      if (advertisedRouteIsStale()) return rehelloGate.holdForRoute(send, routeId);
       return send();
     },
     /** Run a whitelisted backend tool directly (no agent turn), cid-correlated.

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -27064,7 +27064,17 @@ function buildPanel() {
     const wf = activeWorkflowRef();
     const wfid = workflowTabId();
     const wfkey = wf ? (wf.key || wf.id || "unsaved") : null;
-    if (wfid === currentWorkflowId) return; // case 1: no change
+    if (wfid === currentWorkflowId) {
+      // #1095 — nothing pending, so nothing is being deferred: release the budget here
+      // too. It is only reset once a deferred switch finally proceeds, and this early
+      // return skips that — so a switch that was deferred a tick or two and then ABANDONED
+      // (the user switches back, or the id settles to what it already was) would leave
+      // the budget part-spent, and the next genuine switch would get fewer deferrals than
+      // it is owed. A counter that only ever ratchets one way is the same shape as the
+      // stale-marker class this file keeps finding.
+      workflowRetargetDeferrals = 0;
+      return; // case 1: no change
+    }
 
     // #1095 — a workflow change re-targets this socket, and rehelloForWorkflow's own note
     // says the backend DROPS the socket's prior tab mapping when it does. That is correct

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -19905,6 +19905,22 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
     },
     sendUserMessage(text, context, images, mid) {
       if (!sock || sock.readyState !== WebSocket.OPEN) return false;
+      // #1095 — REFUSED HERE, BEFORE ANYTHING ONE-SHOT IS CONSUMED.
+      //
+      // A `user_message` carries NO tab id, so the orchestrator routes it by the binding the
+      // socket already has. Sent before the new route is advertised it reaches the PREVIOUS
+      // workflow's agent — the user's text, context and images delivered into another
+      // canvas's conversation. That misdelivery is the harm #1095 is about, and it is the
+      // one this method refuses.
+      //
+      // The POSITION is the fix for a second defect. The refusal used to sit at the bottom,
+      // by which point `pendingContext` had already been merged into this frame and cleared.
+      // `trackSend` stores the payload it was given, so the retry went out WITHOUT the armed
+      // one-shot — a transcript replay or workflow instruction that evaporated with no
+      // signal, which is the same class as reporting a discarded frame delivered. Refusing
+      // before the merge means a refusal consumes nothing at all, structurally, rather than
+      // by remembering to put back everything a later edit might take.
+      if (advertisedRouteIsStale()) return false;
       // Blind mode withholds pixels from EVERY agent-facing path — including
       // images explicitly attached to a typed user message. The sendFrame() gate
       // below only covers agent_event, so without this a blind session still
@@ -19998,14 +20014,13 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
       // causes the advertisement (only the workflow poll may author one — it binds the
       // session first).
       //
-      // REFUSED, NOT QUEUED. Queueing a user message and answering `true` would report it
-      // delivered while it can still be discarded — and `trackSend` arms a delivery timeout
-      // on that answer, so the message would sit "sent" and then quietly never arrive.
-      // Queueing and answering `false` is worse: the tray shows it failed, the user presses
-      // Send now, and the queued copy goes out too. A plain refusal is the only answer that
-      // is true when it is given: nothing was written, the tray says so, and one retry
-      // sends exactly one message. See holdForRoute in lib/rehello-gate.js.
-      if (advertisedRouteIsStale()) return false;
+      // REFUSED, NOT QUEUED (see the guard at the top of this method). Queueing a user
+      // message and answering `true` would report it delivered while it can still be
+      // discarded — and `trackSend` arms a delivery timeout on that answer, so the message
+      // would sit "sent" and then quietly never arrive. Queueing and answering `false` is
+      // worse: the tray shows it failed, the user presses Send now, and the queued copy goes
+      // out too. A plain refusal is the only answer that is true when it is given: nothing
+      // was written, the tray says so, and one retry sends exactly one message.
       return send();
     },
     /** Send an arbitrary control frame (set_options, new_session, …). */
@@ -20054,25 +20069,32 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
       // cannot overtake each other — frames on one socket are ordered, and a hold that
       // reordered them would trade a routing bug for a conversation bug.
       //
-      // Only SESSION-ORDERED frames are queued; everything else is refused outright.
+      // ONLY the session-ordered frames are held. EVERYTHING ELSE KEEPS ITS PRE-#1095
+      // BEHAVIOUR, deliberately, and this is the scope line of the whole change.
       //
-      // The split is not a convenience. A queued frame cannot be reported as delivered (it
-      // may still be discarded) and cannot be reported as failed (the queued copy may still
-      // go out), so it may only be queued when NO caller reads the answer. `resume_session`
-      // and `new_session` are exactly that: fire-and-forget, and meaningless before the
-      // hello anyway — they hand the next turn to an agent on a route the orchestrator has
-      // not been told about yet.
+      // A brief cut refused every control frame on a stale route. That was more correct in
+      // the abstract and worse in practice: `cancel_message`, `interrupt`, `rewind`,
+      // `set_options` and the pairing frames all IGNORE this return value, so a refusal did
+      // not stop them — it made them fail silently while their callers announced success.
+      // Rewind in particular announces and resubmits immediately after, and a cancellation
+      // could disappear locally while still running remotely. Refusing a frame nobody
+      // checks converts a routing problem into a lying UI, which is strictly worse than the
+      // routing problem.
       //
-      // Everything else is refused, which every caller already handles correctly. It matters
-      // most for `agent_event`: runCompletion reads the answer and, on `true`, calls
-      // markDelivered — retiring the prompt from pending so it is NEVER recovered from
-      // /history. A refusal re-pends it instead, which is the behaviour that path was built
-      // for ("sendFrame returns false when the bridge socket is down").
+      // Making all ~50 sendFrame call sites handle refusal is a real and worthwhile change,
+      // but it is a different one: it is error-handling UX across many features, not a
+      // routing fix, and doing it here is what kept turning this PR into the next round's
+      // defect. So the guarantee is deliberately narrow — see the PR body, which names what
+      // is NOT protected rather than letting this read as a general one.
+      //
+      // What remains held is the pair that is both fire-and-forget AND meaningless before
+      // the hello: `resume_session` / `new_session` hand the next turn to an agent on a
+      // route the orchestrator has not been told about yet. Nobody reads their answer, so
+      // queueing them cannot lie to anyone.
       //
       // Stamped with `routeId`, which is the route this frame's own tab_id already names, so
       // the stamp and the payload can never disagree.
-      if (advertisedRouteIsStale()) {
-        if (!SESSION_ORDERED_FRAMES.has(frame?.type)) return false;
+      if (advertisedRouteIsStale() && SESSION_ORDERED_FRAMES.has(frame?.type)) {
         return rehelloGate.holdForRoute(send, routeId);
       }
       return send();

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -18852,24 +18852,44 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
           }
         }
         if (priorRidReply !== undefined) {
-          let dupReply;
+          // #1095 — THIS PATH WAITS, AND THEN REPLIES, so it holds the route exactly like an
+          // executing command does and must be marked exactly like one.
+          //
+          // It is easy to read as "the reply already exists, so there is nothing to protect".
+          // That is wrong when the retry arrives on a REPLACEMENT socket while the original
+          // command is still running: the retired socket's mark was invalidated by cancel(),
+          // so without a mark here the client believes nothing is in flight. A workflow
+          // switch during this await then lets a re-hello withdraw the replacement socket's
+          // route before the line below writes the reply — the OUTCOME UNKNOWN this whole
+          // change exists to prevent, reached through the one command path that had no mark.
+          //
+          // Released in `finally` rather than before each `return`: this block has three
+          // exits (a defensive ledger catch, a superseded socket, and the normal reply) and
+          // answers on two of them with a direct `thisSock.send`, never deliverReply. A
+          // finally is the only placement that cannot be missed by a fourth exit added later.
+          const replayMark = rehelloGate.began(msg.cmd);
           try {
-            dupReply = await awaitDuplicateReply(priorRidReply, msg.rid, msg.timeout_ms);
-          } catch {
-            return; // ledger promises never reject — defensive only
+            let dupReply;
+            try {
+              dupReply = await awaitDuplicateReply(priorRidReply, msg.rid, msg.timeout_ms);
+            } catch {
+              return; // ledger promises never reject — defensive only
+            }
+            if (!isActive()) return; // superseded socket — ignore its late frames
+            // Rid REWRITE on a retry hit (#694): the ledger reply is correlated
+            // to the ORIGINAL rid, but the orchestrator's pending map is waiting
+            // on the retry's fresh rid — answer under THAT rid or the retry
+            // still times out.
+            const outReply = retryOfHit ? { ...dupReply, rid: msg.rid } : dupReply;
+            try {
+              if (thisSock.readyState === WebSocket.OPEN) thisSock.send(JSON.stringify(outReply));
+            } catch {
+              // Socket died between receive and reply — agent side times out.
+            }
+            return;
+          } finally {
+            rehelloGate.ended(replayMark);
           }
-          if (!isActive()) return; // superseded socket — ignore its late frames
-          // Rid REWRITE on a retry hit (#694): the ledger reply is correlated
-          // to the ORIGINAL rid, but the orchestrator's pending map is waiting
-          // on the retry's fresh rid — answer under THAT rid or the retry
-          // still times out.
-          const outReply = retryOfHit ? { ...dupReply, rid: msg.rid } : dupReply;
-          try {
-            if (thisSock.readyState === WebSocket.OPEN) thisSock.send(JSON.stringify(outReply));
-          } catch {
-            // Socket died between receive and reply — agent side times out.
-          }
-          return;
         }
         // #1095 — the command is now IN FLIGHT against this socket's tab mapping, and
         // stays so until deliverReply hands its reply over. That covers an executor that
@@ -19907,6 +19927,22 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
       //
       // Prepended, so it reads before the message it rides on: a model with no
       // canvas tools must decide before it starts, not after it has improvised.
+      // #1095 — the frame is BUILT now and SENT possibly a moment later. What the user
+      // supplied is captured HERE, at the instant they pressed send (the merged context in
+      // particular, because `pendingContext` is one-shot and has already been consumed).
+      //
+      // THE DISCLOSURE IS NOT. It is decided inside the closure, against the epoch that is
+      // current when the frame actually leaves, because the hold EXPEDITES a hello and a
+      // landed hello ADVANCES `agentSessionEpoch` — so a decision made out here is a
+      // decision about the agent generation this message will not reach.
+      //
+      // The failure that causes is silent and total: if the outgoing generation had already
+      // proven its canvas tools, `disclose` is false, the NEW generation is handed a message
+      // with no disclosure, and `canvasToolMessagedEpoch` then marks it as prompted. That
+      // generation never gets the paragraph telling it what to do when the panel_* tools are
+      // missing — which is the entire reason #291 put this at the choke point rather than in
+      // the composer.
+      const send = () => {
       const disclosure = planCanvasToolDisclosure({
         agentEpoch: agentSessionEpoch,
         provenEpoch: canvasToolsProvenEpoch,
@@ -19914,11 +19950,6 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
       });
       const disclosed = disclosure.disclose && typeof text === "string";
       const outText = disclosed ? CANVAS_TOOL_DISCLOSURE + text : text;
-      // #1095 — the frame is BUILT now and SENT possibly a moment later, so everything the
-      // send consumes (the merged context, the disclosure decision, the epoch stamps) is
-      // captured here, at the instant the user pressed send. A held frame is therefore
-      // byte-identical to the one that would have gone out immediately.
-      const send = () => {
       try {
         sock.send(
           JSON.stringify({

--- a/web/js/lib/rehello-gate.js
+++ b/web/js/lib/rehello-gate.js
@@ -298,6 +298,48 @@ export function createRehelloGate({ advertise, now, setTimer, clearTimer } = {})
     flush();
   }
 
+  /**
+   * (Re)arm the expiry that discards held frames when no advertisement arrives.
+   *
+   * IT TRACKS THE DEFERRAL, rather than being a fixed timeout from the first enqueue. The
+   * first cut armed once, for the first frame, and never moved it — but the advertisement a
+   * held frame is waiting for is itself deferred by whatever commands are in flight, and
+   * `began()` pushes that deadline out. A route switch queues a frame; an `ask_user` then
+   * starts while the hello is parked; the hello may legitimately not go out until 30 s after
+   * THAT command, while a timer armed 30 s after the earlier enqueue clears the queue first.
+   * The frame is then discarded while the advertisement it is waiting for is still perfectly
+   * pending — a self-inflicted loss, not a timeout.
+   *
+   * So the expiry is "the deferral's own deadline, plus a machine budget for the hello to
+   * actually land", floored at the human budget so an unparked hold still gets a full window.
+   */
+  function armHoldExpiry() {
+    if (!held.length) return;
+    const afterDrain = drainDeadline > 0 ? drainDeadline - clock() + REHELLO_DEFER_MS : 0;
+    const ms = Math.max(REHELLO_DEFER_HUMAN_MS, afterDrain);
+    if (holdTimer !== null) {
+      try {
+        disarm(holdTimer);
+      } catch {
+        // A stray timer only clears an already-empty queue.
+      }
+      holdTimer = null;
+    }
+    try {
+      holdTimer = arm(() => {
+        holdTimer = null;
+        // Nothing advertised in time. These frames were composed for a route the
+        // orchestrator was never told about; sending them now would send them on whatever
+        // route it does hold, which is the leak this exists to prevent.
+        held.length = 0;
+      }, ms);
+    } catch {
+      // No timer source: prefer dropping the frames to holding them forever on a route that
+      // may never be advertised.
+      held.length = 0;
+    }
+  }
+
   function armFor(ms) {
     disarmTimer();
     try {
@@ -345,6 +387,9 @@ export function createRehelloGate({ advertise, now, setTimer, clearTimer } = {})
         // early. (`fire` would catch this on its own, but re-arming keeps the timer honest
         // rather than relying on a re-check to paper over a wrong wake-up.)
         if (waiters) armFor(drainDeadline - clock());
+        // …and held frames must not expire while the advertisement they wait for is still
+        // legitimately deferred by THIS command. See armHoldExpiry.
+        armHoldExpiry();
       }
       return mark;
     },
@@ -480,27 +525,22 @@ export function createRehelloGate({ advertise, now, setTimer, clearTimer } = {})
     holdForRoute(send, route) {
       if (typeof send !== "function") return false;
       held.push({ send, route });
-      // Bounded, so a route that is never advertised (the user switched away and never came
-      // back, the poll is not running) cannot hold a frame forever. The bound is the human
-      // budget because that is already the longest a legitimate advertisement can be
-      // deferred — anything shorter would discard frames the poll was still going to serve.
-      if (holdTimer === null) {
-        try {
-          holdTimer = arm(() => {
-            holdTimer = null;
-            // Nothing advertised in time. These frames were composed for a route the
-            // orchestrator was never told about; sending them now would send them on
-            // whatever route it does hold, which is the leak this exists to prevent.
-            held.length = 0;
-          }, REHELLO_DEFER_HUMAN_MS);
-        } catch {
-          // No timer source: prefer dropping the frame to holding it forever on a route
-          // that may never be advertised.
-          held.length = 0;
-          return false;
-        }
-      }
-      return true;
+      armHoldExpiry();
+      // ALWAYS FALSE, and this is the contract fix rather than a detail.
+      //
+      // The synchronous return of every send path means one thing — "the bytes reached the
+      // socket" — and for a queued frame that is simply not true yet, and may never become
+      // true: the queue is discarded on a mismatched advertisement, on expiry, and on
+      // cancellation. Returning `true` here propagated up through sendFrame as a successful
+      // write, and `runCompletion` acts on that IRREVERSIBLY: `framePushed` → markDelivered
+      // → the prompt is retired from pending and never recovered from /history. A frame
+      // reported as delivered and then discarded is neither refused nor delivered but
+      // invisible, which is worse than either.
+      //
+      // Callers that must not be lied to therefore see a plain "not sent" and use the
+      // recovery they already have. The ONE caller that queues (a session-ordered control
+      // frame, which has no meaning before the hello anyway) ignores the return entirely.
+      return false;
     },
 
     /**

--- a/web/js/lib/rehello-gate.js
+++ b/web/js/lib/rehello-gate.js
@@ -217,12 +217,38 @@ export function createRehelloGate({ advertise, now, setTimer, clearTimer } = {})
     timer = null;
   }
 
-  /** Send now, and hand the SAME outcome to every coalesced caller. Never rejects: a caller
-   *  that cannot tell "did not land" from "threw" would spend a retry budget on neither. */
+  // The advertisement currently ON ITS WAY, or null between advertisements.
+  //
+  // A hello is ASYNCHRONOUS — it awaits the tab-identity lease before it can even build its
+  // payload — so "a hello is happening" is a state with real duration, not an instant. Two
+  // callers that both want the route advertised during that window want the SAME hello, and
+  // without this they got two.
+  //
+  // The path that exposed it is the most common one in this whole feature, not an edge case:
+  // an ordinary workflow switch with an existing session and nothing in flight.
+  // `rehelloForWorkflow` starts the hello and then immediately sends `resume_session`; that
+  // frame finds the route still stale (the hello has not published anything yet), asks to be
+  // held, and the hold's flush started a SECOND full registration — duplicate hello,
+  // duplicate "agent ready" greeting, and TWO agentSessionEpoch increments for one switch.
+  // The doubled epoch is not cosmetic: it feeds the canvas-tool disclosure, whose whole job
+  // is to run exactly once per generation.
+  let inFlight = null;
+
+  /** Send now — or JOIN the advertisement already on its way — and hand the SAME outcome to
+   *  every coalesced caller. Never rejects: a caller that cannot tell "did not land" from
+   *  "threw" would spend a retry budget on neither. */
   function flush() {
     const pending = waiters;
     waiters = null;
     disarmTimer();
+    // Joining is correct rather than merely cheaper: `makePayload` reads the tab identity
+    // AFTER the lease resolves, so an advertisement started a microtask ago has not yet
+    // decided what it carries and will carry whatever is live when it gets there — which is
+    // the identity a later caller is asking it to advertise.
+    if (inFlight) {
+      if (pending) for (const resolve of pending) inFlight.then(resolve);
+      return inFlight;
+    }
     let result;
     try {
       result = send();
@@ -233,6 +259,12 @@ export function createRehelloGate({ advertise, now, setTimer, clearTimer } = {})
       (v) => v === true,
       () => false,
     );
+    inFlight = settled;
+    // Cleared once it has SETTLED, so the next request starts a genuinely new advertisement
+    // rather than joining a finished one. `settled` never rejects, so this always runs.
+    void settled.then(() => {
+      if (inFlight === settled) inFlight = null;
+    });
     if (pending) for (const resolve of pending) settled.then(resolve);
     return settled;
   }
@@ -337,6 +369,10 @@ export function createRehelloGate({ advertise, now, setTimer, clearTimer } = {})
       disarmTimer();
       live.clear();
       drainDeadline = 0;
+      // The advertisement on its way belongs to the connection being retired. A frame held
+      // on the REPLACEMENT socket must not join it and conclude the new route is published
+      // because the old socket's hello landed.
+      inFlight = null;
       if (pending) for (const resolve of pending) resolve(false);
     },
 

--- a/web/js/lib/rehello-gate.js
+++ b/web/js/lib/rehello-gate.js
@@ -1,0 +1,276 @@
+// #1095 — hold a RE-ADVERTISE until the commands it would strand have reported back.
+//
+// ## The defect
+//
+// A hello re-advertises this browser tab, and the backend DROPS the socket's prior tab
+// mapping when it does. That is deliberate and correct — it is what stops a background
+// workflow's output leaking into the tab the user is looking at (see rehelloForWorkflow's
+// own note in the panel). The defect is *when* it fires.
+//
+// A workflow change is detected by a 600 ms poll that knows nothing about whether a graph
+// command is currently executing. `panel_new_workflow` changes the tab's identity to a
+// fresh `tmp:<uuid>`, the next poll tick re-hellos, and the orchestrator drops the mapping
+// the in-flight `graph_set_widget` is routed to:
+//
+//     panel tab tmp:2806 disconnected mid-command (graph_set_widget) — OUTCOME UNKNOWN
+//     then: no connected tab ... Connected: none
+//
+// The command really did apply ("the new nodes had already been added"), so the outcome is
+// UNKNOWN rather than failed — which is the correct report for a lost route, and exactly
+// why the route must not be lost.
+//
+// ## Why this is a MECHANISM, not a check at one caller
+//
+// The first cut of this fix gated `onWorkflowMaybeChanged` — the poll. Review rejected it,
+// and the lead finding was that it could make the reported scenario MORE likely:
+//
+//   * `rehelloForWorkflow` is not the only thing that re-advertises. The #607/#570
+//     workflow-instance fence calls `noteWorkflowInstanceMismatch()`, which fires a full
+//     `sendHello()` from inside the command branch — the same re-advertise, dropping the
+//     same mapping, while a command is running. So does the #310 free_vram re-advertise and
+//     the #508 self-heal re-registration.
+//   * And the interaction ran the wrong way. Deferring the POLL's re-hello keeps the
+//     orchestrator's cached `workflow_uuid` stale for LONGER, which makes the fence more
+//     likely to trip, which fires the ungated re-hello mid-batch — reproducing the issue's
+//     own symptom through a path the "fix" had made more reachable.
+//
+// A guard at one caller cannot be completed by patching the other callers, because the next
+// caller added would be ungated again. It belongs where every caller already passes: the
+// re-advertise itself. That is this module.
+//
+// ## What a caller sees
+//
+// Nothing changes for a caller except WHEN the frame reaches the wire. `request()` returns
+// the same promise-of-"did it land" that an immediate advertise returns, so:
+//
+//   * `onWorkflowMaybeChanged` commits `currentWorkflowId`, the storage key, the workflow
+//     ref and `ssSet(SESSION_KEY, …)` INLINE and unconditionally. The first cut returned
+//     before that commit, which meant the chat-scope hook (`panelHooks.applyChatScope`)
+//     announced a re-bind that had not happened and left the panel internally inconsistent
+//     until a later tick repaired it. Deferring only the wire send cannot do that.
+//   * the #607 fence still gets a truthful `landed` boolean for its per-identity budget,
+//     one drain later.
+//
+// ## The bound, and why it is not a tick count
+//
+// An UNBOUNDED wait would convert a race into a wedge, which is worse: a command whose reply
+// never arrives would strand the tab on the old workflow's route permanently, and the fence
+// recovery that would clear it is itself a re-advertise waiting behind the same gate.
+//
+// The first cut bounded it at five poll ticks (~3 s). Review rejected that too, because one
+// class of command is HUMAN-paced: `ask_user` and `request_secret` hold the window for as
+// long as the person takes to answer. Those are precisely the commands most likely to still
+// be running across a workflow change, and a 3 s bound means the panel stalls for three
+// seconds and then withdraws the route anyway — the user answers a question and the
+// orchestrator reports OUTCOME UNKNOWN for the answer they just gave.
+//
+// So the bound is a WALL-CLOCK deadline contributed by the commands themselves: each command
+// declares, when it starts, how long it may legitimately hold the route. Two classes, because
+// there are two clocks — a machine one and a person one.
+//
+// MEASURED ON A MONOTONIC CLOCK. `now` defaults to `performance.now()`, never `Date.now()`:
+// a wall clock can step backwards (NTP, a laptop waking, a manual change) and an elapsed-time
+// window built on it either expires instantly or never. This file follows `monotonicNow()`
+// in the panel and the same rule in `session-rebind.js` / `reconnect-staleness.js`.
+//
+// ## What this deliberately does NOT do
+//
+// It does not bound a `graph_run` that runs for minutes. Such a command gets the machine
+// budget and then loses its route exactly as it does today — no regression, but no cover
+// either. Extending the deadline to cover it would mean holding a stale route for the length
+// of an arbitrary render, during which every mutation aimed at the NEW canvas is fence-refused;
+// a clean, retryable "nothing was applied" refusal for a few seconds is a good trade, and for
+// minutes it is not.
+//
+// It also does not cancel or reorder anything. A deferred re-advertise is still exactly one
+// hello carrying whatever identity is live WHEN IT GOES OUT, which is the identity the
+// orchestrator should have. That is why several deferred requests coalesce into one send
+// rather than queueing: a hello is a statement of current state, not an event log.
+
+/** Commands whose in-flight window is paced by a PERSON, not by the machine. Their reply is
+ *  the user's own answer; losing its route means the panel collected an answer the caller
+ *  will never receive, which is the worst outcome available here. */
+export const HUMAN_PACED_COMMANDS = new Set(["ask_user", "request_secret"]);
+
+/** Machine-paced budget. A graph mutation completes in milliseconds, so this is generous by
+ *  three orders of magnitude while staying far below the point at which a stale route starts
+ *  costing more than it saves. */
+export const REHELLO_DEFER_MS = 4000;
+
+/** Human-paced budget. Long enough for a person to read a question and answer it; short
+ *  enough that an abandoned card cannot hold the tab on a dead workflow indefinitely. Past
+ *  it, a LIVE route is worth more than one preserved outcome — the caller is told the outcome
+ *  is unknown, which is true, rather than being left with a tab nothing can reach. */
+export const REHELLO_DEFER_HUMAN_MS = 30000;
+
+/** How long `cmd` may hold the route before a pending re-advertise stops waiting for it.
+ *  An unknown or absent command name gets the machine budget: under-declaring only shortens
+ *  the wait, while over-declaring would let any unrecognised frame pin the route for 30 s. */
+export function deferBudgetMs(cmd) {
+  return HUMAN_PACED_COMMANDS.has(cmd) ? REHELLO_DEFER_HUMAN_MS : REHELLO_DEFER_MS;
+}
+
+/**
+ * @param {{
+ *   advertise: () => any,          the real re-advertise (the panel's hello send)
+ *   now?: () => number,            MONOTONIC clock; defaults to performance.now()
+ *   setTimer?: Function,
+ *   clearTimer?: Function,
+ * }} deps
+ */
+export function createRehelloGate({ advertise, now, setTimer, clearTimer } = {}) {
+  const clock =
+    typeof now === "function"
+      ? now
+      : typeof performance !== "undefined" && typeof performance.now === "function"
+        ? () => performance.now()
+        : () => Date.now();
+  const arm = typeof setTimer === "function" ? setTimer : (fn, ms) => setTimeout(fn, ms);
+  const disarm = typeof clearTimer === "function" ? clearTimer : (t) => clearTimeout(t);
+  const send = typeof advertise === "function" ? advertise : () => Promise.resolve(false);
+
+  let inFlight = 0;
+  // The latest instant at which SOME in-flight command still has budget left. Zero means
+  // nothing is running.
+  //
+  // Deliberately the MAX over the batch, cleared only when the count reaches zero, rather
+  // than a per-command deadline. A per-command deadline needs per-command identity, and rids
+  // are NOT unique here: the #517 retry path re-delivers a previously-seen rid, so a map
+  // keyed by rid would collapse two marks into one entry and release both on the first
+  // reply — an unpaired release, which reopens the very race this exists to close. The cost
+  // of the max is that a short command running alongside an `ask_user` inherits the human
+  // budget until the batch drains. That over-waits; it cannot under-wait, and only the
+  // under-wait direction loses a reply.
+  let drainDeadline = 0;
+
+  // The parked re-advertise. ONE, because coalescing is correct (see the header): several
+  // callers asking to re-advertise want the orchestrator to hold this tab's current
+  // identity, and one hello carrying the identity live at send time says exactly that.
+  let waiters = null;
+  let timer = null;
+
+  function disarmTimer() {
+    if (timer === null) return;
+    try {
+      disarm(timer);
+    } catch {
+      // A leaked timer is a leak; a throw here would strand the pending hello, which is a
+      // wedge. `fire` re-checks its own precondition, so a stray timer is inert anyway.
+    }
+    timer = null;
+  }
+
+  /** Send now, and hand the SAME outcome to every coalesced caller. Never rejects: a caller
+   *  that cannot tell "did not land" from "threw" would spend a retry budget on neither. */
+  function flush() {
+    const pending = waiters;
+    waiters = null;
+    disarmTimer();
+    let result;
+    try {
+      result = send();
+    } catch {
+      result = false;
+    }
+    const settled = Promise.resolve(result).then(
+      (v) => v === true,
+      () => false,
+    );
+    if (pending) for (const resolve of pending) settled.then(resolve);
+    return settled;
+  }
+
+  function fire() {
+    timer = null;
+    if (!waiters) return;
+    // Re-check rather than trust the arming. A command that STARTED after the timer was
+    // armed pushes `drainDeadline` out, and firing on the old deadline would advertise while
+    // that command is mid-flight — the exact race, reintroduced by the bound meant to end it.
+    if (inFlight > 0 && clock() < drainDeadline) {
+      armFor(drainDeadline - clock());
+      return;
+    }
+    flush();
+  }
+
+  function armFor(ms) {
+    disarmTimer();
+    try {
+      timer = arm(fire, Math.max(0, ms));
+    } catch {
+      // No timer source. Rather than leave the hello parked forever — which is the one
+      // outcome this gate must never produce — advertise immediately and accept the race we
+      // were trying to avoid. Degrading to today's behaviour beats a tab nothing can reach.
+      flush();
+    }
+  }
+
+  return {
+    /** A command frame has begun executing against this socket's tab mapping. */
+    began(cmd) {
+      inFlight++;
+      const until = clock() + deferBudgetMs(cmd);
+      if (until > drainDeadline) {
+        drainDeadline = until;
+        // A parked hello was armed against the OLD deadline; re-arm so it does not fire
+        // early. (`fire` would catch this on its own, but re-arming keeps the timer honest
+        // rather than relying on a re-check to paper over a wrong wake-up.)
+        if (waiters) armFor(drainDeadline - clock());
+      }
+    },
+
+    /** Its reply has been handed to the socket — whatever happens to it after. */
+    ended() {
+      if (inFlight > 0) inFlight--;
+      if (inFlight === 0) {
+        drainDeadline = 0;
+        // The batch drained, which is the event the parked hello was waiting for. Send it
+        // NOW rather than waiting out the remaining budget: the budget is a CEILING on the
+        // wait, not a delay to serve.
+        if (waiters) flush();
+      }
+    },
+
+    /** How many command frames are executing. Read-only: only the command path may move it,
+     *  and a caller that could reset it could manufacture the race this closes. */
+    inFlight() {
+      return inFlight;
+    },
+
+    /** Re-advertise, waiting for the in-flight batch first if there is one.
+     *  @returns {Promise<boolean>} whether the hello reached the wire. */
+    request() {
+      if (inFlight === 0) return flush();
+      const left = drainDeadline - clock();
+      // Budget already spent (a command that will not report back). Proceed — an unbounded
+      // wait here is the wedge described in the header.
+      if (!(left > 0)) return flush();
+      const promise = new Promise((resolve) => {
+        if (waiters) waiters.push(resolve);
+        else waiters = [resolve];
+      });
+      // Arm only for the FIRST waiter; a later join must not restart the clock, or a steady
+      // trickle of re-advertise requests would push the deadline forward forever.
+      if (timer === null) armFor(left);
+      return promise;
+    },
+
+    /** Torn down (stop/destroy/setUrl). Drop the parked hello WITHOUT sending it: the socket
+     *  it was meant for is gone, and a hello fired into a replaced connection re-registers a
+     *  tab under a route the caller never asked for. Waiters are resolved false — "it did not
+     *  land" — because leaving them pending would hang the fence's own bookkeeping. */
+    cancel() {
+      const pending = waiters;
+      waiters = null;
+      disarmTimer();
+      inFlight = 0;
+      drainDeadline = 0;
+      if (pending) for (const resolve of pending) resolve(false);
+    },
+
+    /** Diagnostics/tests: whether a re-advertise is currently parked. */
+    deferring() {
+      return waiters !== null;
+    },
+  };
+}

--- a/web/js/lib/rehello-gate.js
+++ b/web/js/lib/rehello-gate.js
@@ -205,6 +205,11 @@ export function createRehelloGate({ advertise, now, setTimer, clearTimer } = {})
   // FIFO, and drained as one batch, because frames on a socket are ordered and holding some
   // while letting others past would reorder a conversation.
   const held = [];
+  // Which CONNECTION the state above belongs to. Bumped by `cancel()`, so anything already
+  // scheduled against the retired connection — a queued drain in particular — can tell that
+  // it no longer speaks for the live one. Same generation-scoping rule as the mark ids, one
+  // layer out: an async callback that outlives its connection must be able to say so.
+  let generation = 0;
 
   function disarmTimer() {
     if (timer === null) return;
@@ -294,6 +299,27 @@ export function createRehelloGate({ advertise, now, setTimer, clearTimer } = {})
     }
   }
 
+  /** Re-advertise, waiting for the in-flight batch first if there is one.
+   *  Declared out here rather than only as a method because `sendAfterAdvertise` calls it:
+   *  a held frame waits for the hello the deferral will produce, and must not be able to
+   *  force one (see that method for the whole argument).
+   *  @returns {Promise<boolean>} whether the hello reached the wire. */
+  function request() {
+    if (live.size === 0) return flush();
+    const left = drainDeadline - clock();
+    // Budget already spent (a command that will not report back). Proceed — an unbounded
+    // wait here is the wedge described in the header.
+    if (!(left > 0)) return flush();
+    const promise = new Promise((resolve) => {
+      if (waiters) waiters.push(resolve);
+      else waiters = [resolve];
+    });
+    // Arm only for the FIRST waiter; a later join must not restart the clock, or a steady
+    // trickle of re-advertise requests would push the deadline forward forever.
+    if (timer === null) armFor(left);
+    return promise;
+  }
+
   return {
     /** A command frame has begun executing against this socket's tab mapping.
      *  @returns {number} the mark id to hand back to `ended()` when its reply goes out.
@@ -332,23 +358,7 @@ export function createRehelloGate({ advertise, now, setTimer, clearTimer } = {})
       return live.size;
     },
 
-    /** Re-advertise, waiting for the in-flight batch first if there is one.
-     *  @returns {Promise<boolean>} whether the hello reached the wire. */
-    request() {
-      if (live.size === 0) return flush();
-      const left = drainDeadline - clock();
-      // Budget already spent (a command that will not report back). Proceed — an unbounded
-      // wait here is the wedge described in the header.
-      if (!(left > 0)) return flush();
-      const promise = new Promise((resolve) => {
-        if (waiters) waiters.push(resolve);
-        else waiters = [resolve];
-      });
-      // Arm only for the FIRST waiter; a later join must not restart the clock, or a steady
-      // trickle of re-advertise requests would push the deadline forward forever.
-      if (timer === null) armFor(left);
-      return promise;
-    },
+    request,
 
     /** The connection this state belongs to is gone (setUrl / stop / destroy, and an
      *  ordinary close of the ACTIVE socket — a reconnect must not inherit any of it).
@@ -369,6 +379,16 @@ export function createRehelloGate({ advertise, now, setTimer, clearTimer } = {})
       disarmTimer();
       live.clear();
       drainDeadline = 0;
+      // Retire the held batch WITH the connection, and fence any drain already scheduled
+      // against it. Leaving these behind meant the retired advertisement would settle, the
+      // drain would run against the MUTABLE current `sock`, and a frame composed for the old
+      // connection would be written to the REPLACEMENT one — or silently dropped after
+      // `true` had already been returned to the caller. Dropping is the honest outcome here:
+      // the frame was built for a route that no longer exists, and the caller's delivery
+      // timeout surfaces it. Clearing `held` also unwedges the queue — otherwise a stale
+      // promise that never settles leaves every later frame stuck behind `held.length > 1`.
+      generation++;
+      held.length = 0;
       // The advertisement on its way belongs to the connection being retired. A frame held
       // on the REPLACEMENT socket must not join it and conclude the new route is published
       // because the old socket's hello landed.
@@ -384,23 +404,50 @@ export function createRehelloGate({ advertise, now, setTimer, clearTimer } = {})
      * is queued behind a hello that is EXPEDITED — the parked re-advertise goes out now
      * rather than waiting out its budget.
      *
-     * That expedite is the deliberate trade. The user has done something that requires the
-     * new route (typed, switched session, hit stop), and their action necessarily outranks
-     * an in-flight command's reply: losing that reply reports OUTCOME UNKNOWN, which is
-     * honest and recoverable, while delivering their message to the previous workflow's
-     * agent is silent and is not. The #1095 case this PR is actually about — an agent
-     * running a batch of mutations while nobody types — never reaches here at all.
+     * IT WAITS FOR THE HELLO THE DEFERRAL WILL PRODUCE — it does NOT force one out.
+     *
+     * An earlier cut expedited: the hold called `flush()`, pushing the parked hello onto the
+     * wire immediately. That was argued as a trade — "a person is waiting, and their action
+     * outranks an in-flight command's reply" — and the argument was sound for the case it
+     * was written about and wrong for the traffic it actually covered. `rehelloForWorkflow`
+     * also runs AUTOMATICALLY: when workflow-scoped history supplies a session id it
+     * re-hellos and immediately sends `resume_session`. Nobody is waiting for that frame. It
+     * reached here, expedited the hello the gate had correctly parked, and let the backend
+     * drop the old mapping before an in-flight command's reply — the OUTCOME UNKNOWN race
+     * this whole PR exists to close, re-opened by the convenience added to protect against a
+     * different failure.
+     *
+     * The fix is not a user-vs-automatic flag. Nothing in the gate can know which is which,
+     * every call site that gets it wrong is another P1, and the flag would have to be
+     * threaded through `sendUserMessage` — which the restart-resume nudges also call without
+     * a person involved. So the expedite is GONE, and the rule is now uniform: a frame that
+     * needs the new route waits for it, and the deferral decides when that is.
+     *
+     * What that costs is bounded and visible: a frame can wait up to the deferral budget
+     * (4 s, or 30 s behind a human-paced command) before the hello goes out and it follows.
+     * The message sits in the pending tray meanwhile and its own delivery timeout still
+     * covers it. What it buys is that NO outbound frame can withdraw a route from a command
+     * that has not replied — by construction rather than by case analysis.
      *
      * Ordering is preserved two ways: the hold is FIFO, and the whole batch runs after the
-     * SAME advertise settles, so nothing overtakes anything. A rejected advertise still
-     * drains — a frame held forever is a mute panel, which is worse than a frame sent on a
-     * route we could not confirm (the caller's own delivery timeout still covers it).
+     * SAME advertisement settles, so nothing overtakes anything. A rejected advertisement
+     * still drains — a frame held forever is a mute panel, which is worse than a frame sent
+     * on a route we could not confirm.
      */
     sendAfterAdvertise(send) {
       if (typeof send !== "function") return false;
       held.push(send);
       if (held.length > 1) return true; // a drain is already scheduled for this batch
+      // GENERATION-FENCED, the same lesson as the marks one layer out. Without this,
+      // cancel() cleared `waiters` and `inFlight` but left `held` and this already-scheduled
+      // `then` intact: the retired connection's advertisement would settle, the drain would
+      // run against the MUTABLE current `sock`, and the old frame would either be written to
+      // the REPLACEMENT connection or silently dropped after `true` had been returned. And
+      // if that stale promise never settled, every later frame stayed wedged behind
+      // `held.length > 1`.
+      const bornAt = generation;
       const drain = () => {
+        if (bornAt !== generation) return; // the connection this batch belonged to is gone
         const batch = held.splice(0, held.length);
         for (const fn of batch) {
           try {
@@ -410,7 +457,10 @@ export function createRehelloGate({ advertise, now, setTimer, clearTimer } = {})
           }
         }
       };
-      Promise.resolve(flush()).then(drain, drain);
+      // `request()`, not `flush()`: it advertises immediately when nothing is in flight, and
+      // otherwise JOINS the parked hello and resolves when that one actually goes out. Either
+      // way a hello is guaranteed to happen, so a held frame cannot wait forever.
+      Promise.resolve(request()).then(drain, drain);
       return true;
     },
 

--- a/web/js/lib/rehello-gate.js
+++ b/web/js/lib/rehello-gate.js
@@ -204,7 +204,11 @@ export function createRehelloGate({ advertise, now, setTimer, clearTimer } = {})
   // Frames that must not leave before the route has been re-advertised (see `routeIsStale`).
   // FIFO, and drained as one batch, because frames on a socket are ordered and holding some
   // while letting others past would reorder a conversation.
+  // Each entry is { send, route, bornAt } — see `holdForRoute` for why a bare callback was
+  // not enough: a frame must carry the route it was composed for, or a later advertisement
+  // for a DIFFERENT workflow delivers it to that one.
   const held = [];
+  let holdTimer = null;
   // Which CONNECTION the state above belongs to. Bumped by `cancel()`, so anything already
   // scheduled against the retired connection — a queued drain in particular — can tell that
   // it no longer speaks for the live one. Same generation-scoping rule as the mark ids, one
@@ -389,6 +393,14 @@ export function createRehelloGate({ advertise, now, setTimer, clearTimer } = {})
       // promise that never settles leaves every later frame stuck behind `held.length > 1`.
       generation++;
       held.length = 0;
+      if (holdTimer !== null) {
+        try {
+          disarm(holdTimer);
+        } catch {
+          // A stray timer only clears an already-empty queue.
+        }
+        holdTimer = null;
+      }
       // The advertisement on its way belongs to the connection being retired. A frame held
       // on the REPLACEMENT socket must not join it and conclude the new route is published
       // because the old socket's hello landed.
@@ -423,45 +435,101 @@ export function createRehelloGate({ advertise, now, setTimer, clearTimer } = {})
      * a person involved. So the expedite is GONE, and the rule is now uniform: a frame that
      * needs the new route waits for it, and the deferral decides when that is.
      *
-     * What that costs is bounded and visible: a frame can wait up to the deferral budget
-     * (4 s, or 30 s behind a human-paced command) before the hello goes out and it follows.
-     * The message sits in the pending tray meanwhile and its own delivery timeout still
-     * covers it. What it buys is that NO outbound frame can withdraw a route from a command
-     * that has not replied — by construction rather than by case analysis.
+     * TWO RULES, AND THEY REPLACE FOUR ROUNDS OF POINT FIXES.
      *
-     * Ordering is preserved two ways: the hold is FIFO, and the whole batch runs after the
-     * SAME advertisement settles, so nothing overtakes anything. A rejected advertisement
-     * still drains — a frame held forever is a mute panel, which is worse than a frame sent
-     * on a route we could not confirm.
+     * (1) A HELD FRAME IS SCOPED TO THE ROUTE IT WAS COMPOSED FOR. It leaves only when THAT
+     *     route is the one the orchestrator has been told about. If the panel commits to a
+     *     different workflow first, the frame is discarded rather than delivered, because a
+     *     message composed for B has no correct meaning on C. (A→B queues B's frames, the
+     *     user switches B→C, the hello advertises C — without the stamp the loop delivered
+     *     B's `user_message` and `resume_session` onto C.)
+     *
+     * (2) A HELD FRAME NEVER CAUSES AN ADVERTISEMENT. It waits for one. This is the rule
+     *     that stops the family of bugs rather than another instance of it, and it is worth
+     *     stating why.
+     *
+     *     `onWorkflowMaybeChanged` is the ONLY place that commits a workflow switch as a
+     *     whole: it binds SESSION_KEY and only then re-hellos, and its own comment says
+     *     "Order is the whole fix" — the hello reads SESSION_KEY for its spawn-time
+     *     `resume`, so advertising before the bind spawns the new route as a resume-FORK of
+     *     the previous workflow's conversation. But `bridgeRouteId()` is derived from the
+     *     LIVE canvas and moves the instant the user clicks a tab, while SESSION_KEY does
+     *     not move until the 600 ms poll runs. Anything that advertises inside that gap
+     *     pairs the NEW route with the PREVIOUS workflow's session.
+     *
+     *     Earlier cuts of this hold called `request()`, which advertises immediately when
+     *     nothing is in flight — so an outbound frame arriving in the gap was itself the
+     *     thing that published the half-committed switch. Removing the trigger removes the
+     *     whole class: the poll remains the only author of a workflow re-advertisement, and
+     *     everything else observes.
+     *
+     * COST, stated plainly. A frame composed in the gap waits for the poll (~600 ms) plus
+     * any deferral, and is bounded at `REHELLO_DEFER_HUMAN_MS`; past that, or if the panel
+     * commits to a different workflow, it is DISCARDED and the caller's delivery timeout
+     * surfaces it in the pending tray. Refusing a write is acceptable; sending it to the
+     * wrong workflow's agent is not.
+     *
+     * Ordering is preserved: the queue is FIFO and drains as one batch per advertisement.
      */
-    sendAfterAdvertise(send) {
+    holdForRoute(send, route) {
       if (typeof send !== "function") return false;
-      held.push(send);
-      if (held.length > 1) return true; // a drain is already scheduled for this batch
-      // GENERATION-FENCED, the same lesson as the marks one layer out. Without this,
-      // cancel() cleared `waiters` and `inFlight` but left `held` and this already-scheduled
-      // `then` intact: the retired connection's advertisement would settle, the drain would
-      // run against the MUTABLE current `sock`, and the old frame would either be written to
-      // the REPLACEMENT connection or silently dropped after `true` had been returned. And
-      // if that stale promise never settled, every later frame stayed wedged behind
-      // `held.length > 1`.
-      const bornAt = generation;
-      const drain = () => {
-        if (bornAt !== generation) return; // the connection this batch belonged to is gone
-        const batch = held.splice(0, held.length);
-        for (const fn of batch) {
-          try {
-            fn();
-          } catch {
-            // One frame's failure must not strand the rest of the batch.
-          }
+      // GENERATION-FENCED, the same lesson as the marks one layer out: an entry must be able
+      // to say which CONNECTION it belongs to, so a cancel can retire it.
+      held.push({ send, route, bornAt: generation });
+      // Bounded, so a route that is never advertised (the user switched away and never came
+      // back, the poll is not running) cannot hold a frame forever. The bound is the human
+      // budget because that is already the longest a legitimate advertisement can be
+      // deferred — anything shorter would discard frames the poll was still going to serve.
+      if (holdTimer === null) {
+        try {
+          holdTimer = arm(() => {
+            holdTimer = null;
+            // Nothing advertised in time. These frames were composed for a route the
+            // orchestrator was never told about; sending them now would send them on
+            // whatever route it does hold, which is the leak this exists to prevent.
+            held.length = 0;
+          }, REHELLO_DEFER_HUMAN_MS);
+        } catch {
+          // No timer source: prefer dropping the frame to holding it forever on a route
+          // that may never be advertised.
+          held.length = 0;
+          return false;
         }
-      };
-      // `request()`, not `flush()`: it advertises immediately when nothing is in flight, and
-      // otherwise JOINS the parked hello and resolves when that one actually goes out. Either
-      // way a hello is guaranteed to happen, so a held frame cannot wait forever.
-      Promise.resolve(request()).then(drain, drain);
+      }
       return true;
+    },
+
+    /**
+     * #1095 — a hello has LANDED, carrying `route`. Release exactly the frames composed for
+     * it, and discard the rest.
+     *
+     * This is the observation side of the rule above. It is called from the hello's success
+     * path, so "advertised" means the orchestrator was actually told — never that the panel
+     * intended to tell it.
+     */
+    noteAdvertised(route) {
+      if (holdTimer !== null) {
+        try {
+          disarm(holdTimer);
+        } catch {
+          // A stray timer only clears an already-empty queue.
+        }
+        holdTimer = null;
+      }
+      const batch = held.splice(0, held.length);
+      for (const entry of batch) {
+        // A frame from a retired connection, or composed for a workflow the panel has since
+        // moved past, has no correct destination. Dropped, deliberately and silently at this
+        // layer — the caller that was told `true` learns about it through its own delivery
+        // timeout, which is the mechanism that already exists for "it never got there".
+        if (entry.bornAt !== generation) continue;
+        if (entry.route !== route) continue;
+        try {
+          entry.send();
+        } catch {
+          // One frame's failure must not strand the rest of the batch.
+        }
+      }
     },
 
     /** Diagnostics/tests: whether a re-advertise is currently parked. */

--- a/web/js/lib/rehello-gate.js
+++ b/web/js/lib/rehello-gate.js
@@ -103,6 +103,40 @@ export const REHELLO_DEFER_MS = 4000;
  *  is unknown, which is true, rather than being left with a tab nothing can reach. */
 export const REHELLO_DEFER_HUMAN_MS = 30000;
 
+/**
+ * #1095 — does this socket's ADVERTISED route still name the workflow the panel has
+ * already committed to?
+ *
+ * THIS IS THE PROPERTY THE DEFERRAL PUTS AT RISK, and it is separate from the deferral
+ * itself. `onWorkflowMaybeChanged` commits the new workflow inline (that is deliberate —
+ * see its own note), so between the commit and the parked hello landing, the panel believes
+ * it is on workflow B while the orchestrator still has this socket bound to A.
+ *
+ * A `user_message` frame carries NO tab id — only `sendFrame` stamps one — so the
+ * orchestrator can route it ONLY by the binding the socket already has. Sent in that window
+ * it is handled by the agent for the PREVIOUS workflow: the user's text, context and images
+ * for B delivered into A's conversation. That is a cross-workflow leak, not a lost route,
+ * and the human budget that `ask_user` earns is exactly the window that makes it worst.
+ *
+ * Kept pure, and separate from the gate, because it is a claim about two ids rather than
+ * about timing — so it can be driven directly rather than asserted about at the call site.
+ *
+ * FAILS OPEN on an unreadable id, deliberately. An id we cannot READ is not an id we know
+ * to be different (the same rule the #607 fence applies to its own identity). Treating
+ * unreadable as stale would hold every frame on this socket for as long as it stayed
+ * unreadable, which converts a leak into a mute panel.
+ *
+ * @param {{advertised: string|null, live: string|null, mapped: boolean}} state
+ *   `mapped` is whether a hello has actually LANDED on the current socket — before that
+ *   there is no binding to disagree with, and the first hello is never deferred.
+ */
+export function routeIsStale({ advertised, live, mapped } = {}) {
+  if (!mapped) return false;
+  if (typeof advertised !== "string" || !advertised) return false;
+  if (typeof live !== "string" || !live) return false;
+  return live !== advertised;
+}
+
 /** How long `cmd` may hold the route before a pending re-advertise stops waiting for it.
  *  An unknown or absent command name gets the machine budget: under-declaring only shortens
  *  the wait, while over-declaring would let any unrecognised frame pin the route for 30 s. */
@@ -167,6 +201,10 @@ export function createRehelloGate({ advertise, now, setTimer, clearTimer } = {})
   // identity, and one hello carrying the identity live at send time says exactly that.
   let waiters = null;
   let timer = null;
+  // Frames that must not leave before the route has been re-advertised (see `routeIsStale`).
+  // FIFO, and drained as one batch, because frames on a socket are ordered and holding some
+  // while letting others past would reorder a conversation.
+  const held = [];
 
   function disarmTimer() {
     if (timer === null) return;
@@ -302,9 +340,52 @@ export function createRehelloGate({ advertise, now, setTimer, clearTimer } = {})
       if (pending) for (const resolve of pending) resolve(false);
     },
 
+    /**
+     * #1095 — run `send` only once this socket's route has been (re)advertised.
+     *
+     * Used for outbound frames the orchestrator routes by the socket's BINDING rather than
+     * by a stamped tab id (see `routeIsStale`). The frame is not refused and not dropped: it
+     * is queued behind a hello that is EXPEDITED — the parked re-advertise goes out now
+     * rather than waiting out its budget.
+     *
+     * That expedite is the deliberate trade. The user has done something that requires the
+     * new route (typed, switched session, hit stop), and their action necessarily outranks
+     * an in-flight command's reply: losing that reply reports OUTCOME UNKNOWN, which is
+     * honest and recoverable, while delivering their message to the previous workflow's
+     * agent is silent and is not. The #1095 case this PR is actually about — an agent
+     * running a batch of mutations while nobody types — never reaches here at all.
+     *
+     * Ordering is preserved two ways: the hold is FIFO, and the whole batch runs after the
+     * SAME advertise settles, so nothing overtakes anything. A rejected advertise still
+     * drains — a frame held forever is a mute panel, which is worse than a frame sent on a
+     * route we could not confirm (the caller's own delivery timeout still covers it).
+     */
+    sendAfterAdvertise(send) {
+      if (typeof send !== "function") return false;
+      held.push(send);
+      if (held.length > 1) return true; // a drain is already scheduled for this batch
+      const drain = () => {
+        const batch = held.splice(0, held.length);
+        for (const fn of batch) {
+          try {
+            fn();
+          } catch {
+            // One frame's failure must not strand the rest of the batch.
+          }
+        }
+      };
+      Promise.resolve(flush()).then(drain, drain);
+      return true;
+    },
+
     /** Diagnostics/tests: whether a re-advertise is currently parked. */
     deferring() {
       return waiters !== null;
+    },
+
+    /** Diagnostics/tests: how many outbound frames are waiting on the route. */
+    heldFrames() {
+      return held.length;
     },
   };
 }

--- a/web/js/lib/rehello-gate.js
+++ b/web/js/lib/rehello-gate.js
@@ -129,18 +129,37 @@ export function createRehelloGate({ advertise, now, setTimer, clearTimer } = {})
   const disarm = typeof clearTimer === "function" ? clearTimer : (t) => clearTimeout(t);
   const send = typeof advertise === "function" ? advertise : () => Promise.resolve(false);
 
-  let inFlight = 0;
-  // The latest instant at which SOME in-flight command still has budget left. Zero means
+  // The marks currently outstanding, by id.
+  //
+  // A SET OF IDS RATHER THAN A COUNTER, because a counter cannot tell a release apart from
+  // the mark it belongs to, and three separate defects all come from that one gap:
+  //
+  //   * A LATE release from a RETIRED socket. `cancel()` runs when the connection is
+  //     replaced (setUrl/stop/destroy/close), but a command already executing on the old
+  //     socket still finishes and still calls its release. Against a counter that release
+  //     lands on whatever the NEW socket is running and decrements ITS mark — so a parked
+  //     hello can flush while a live command is mid-flight, which is precisely the
+  //     route-loss race this module exists to close, recreated by its own bookkeeping.
+  //     An id from a cleared generation is simply not in the set, so it releases nothing.
+  //   * A DOUBLE release (a retry, a future refactor). The second `ended` finds no id and
+  //     is a no-op, instead of discounting an unrelated command.
+  //   * Command identity in general. Keying on `rid` was considered and rejected: rids are
+  //     NOT unique here, because the #517 retry path re-delivers a previously-seen rid, so
+  //     a map keyed by rid would collapse two marks into one entry and release both on the
+  //     first reply.
+  //
+  // `ended` with a missing or unknown id releases NOTHING, which fails CLOSED — it can only
+  // delay a re-advertise (bounded below), never let one through early. That is the safe
+  // direction, and the only one of the two that can lose a reply is the other.
+  const live = new Set();
+  let nextMark = 1;
+  // The latest instant at which SOME outstanding mark still has budget left. Zero means
   // nothing is running.
   //
-  // Deliberately the MAX over the batch, cleared only when the count reaches zero, rather
-  // than a per-command deadline. A per-command deadline needs per-command identity, and rids
-  // are NOT unique here: the #517 retry path re-delivers a previously-seen rid, so a map
-  // keyed by rid would collapse two marks into one entry and release both on the first
-  // reply — an unpaired release, which reopens the very race this exists to close. The cost
-  // of the max is that a short command running alongside an `ask_user` inherits the human
-  // budget until the batch drains. That over-waits; it cannot under-wait, and only the
-  // under-wait direction loses a reply.
+  // Deliberately the MAX over the batch, cleared only when the set empties, rather than a
+  // per-mark deadline. The cost is that a short command running alongside an `ask_user`
+  // inherits the human budget until the batch drains. That over-waits; it cannot under-wait,
+  // and only the under-wait direction loses a reply.
   let drainDeadline = 0;
 
   // The parked re-advertise. ONE, because coalescing is correct (see the header): several
@@ -186,7 +205,7 @@ export function createRehelloGate({ advertise, now, setTimer, clearTimer } = {})
     // Re-check rather than trust the arming. A command that STARTED after the timer was
     // armed pushes `drainDeadline` out, and firing on the old deadline would advertise while
     // that command is mid-flight — the exact race, reintroduced by the bound meant to end it.
-    if (inFlight > 0 && clock() < drainDeadline) {
+    if (live.size > 0 && clock() < drainDeadline) {
       armFor(drainDeadline - clock());
       return;
     }
@@ -206,9 +225,12 @@ export function createRehelloGate({ advertise, now, setTimer, clearTimer } = {})
   }
 
   return {
-    /** A command frame has begun executing against this socket's tab mapping. */
+    /** A command frame has begun executing against this socket's tab mapping.
+     *  @returns {number} the mark id to hand back to `ended()` when its reply goes out.
+     *    Callers MUST keep it: a release without it is inert (see `live` above). */
     began(cmd) {
-      inFlight++;
+      const mark = nextMark++;
+      live.add(mark);
       const until = clock() + deferBudgetMs(cmd);
       if (until > drainDeadline) {
         drainDeadline = until;
@@ -217,12 +239,15 @@ export function createRehelloGate({ advertise, now, setTimer, clearTimer } = {})
         // rather than relying on a re-check to paper over a wrong wake-up.)
         if (waiters) armFor(drainDeadline - clock());
       }
+      return mark;
     },
 
-    /** Its reply has been handed to the socket — whatever happens to it after. */
-    ended() {
-      if (inFlight > 0) inFlight--;
-      if (inFlight === 0) {
+    /** The reply for `mark` has been handed to the socket — whatever happens to it after.
+     *  A mark that was never taken, already released, or invalidated by `cancel()` releases
+     *  nothing: it belongs to a generation this gate no longer accounts for. */
+    ended(mark) {
+      if (!live.delete(mark)) return;
+      if (live.size === 0) {
         drainDeadline = 0;
         // The batch drained, which is the event the parked hello was waiting for. Send it
         // NOW rather than waiting out the remaining budget: the budget is a CEILING on the
@@ -234,13 +259,13 @@ export function createRehelloGate({ advertise, now, setTimer, clearTimer } = {})
     /** How many command frames are executing. Read-only: only the command path may move it,
      *  and a caller that could reset it could manufacture the race this closes. */
     inFlight() {
-      return inFlight;
+      return live.size;
     },
 
     /** Re-advertise, waiting for the in-flight batch first if there is one.
      *  @returns {Promise<boolean>} whether the hello reached the wire. */
     request() {
-      if (inFlight === 0) return flush();
+      if (live.size === 0) return flush();
       const left = drainDeadline - clock();
       // Budget already spent (a command that will not report back). Proceed — an unbounded
       // wait here is the wedge described in the header.
@@ -255,15 +280,24 @@ export function createRehelloGate({ advertise, now, setTimer, clearTimer } = {})
       return promise;
     },
 
-    /** Torn down (stop/destroy/setUrl). Drop the parked hello WITHOUT sending it: the socket
-     *  it was meant for is gone, and a hello fired into a replaced connection re-registers a
-     *  tab under a route the caller never asked for. Waiters are resolved false — "it did not
-     *  land" — because leaving them pending would hang the fence's own bookkeeping. */
+    /** The connection this state belongs to is gone (setUrl / stop / destroy, and an
+     *  ordinary close of the ACTIVE socket — a reconnect must not inherit any of it).
+     *
+     *  Drops the parked hello WITHOUT sending it: the socket it was meant for no longer
+     *  exists, and a hello fired into the REPLACEMENT connection re-registers this tab under
+     *  a route the caller never asked for — the corruption class #508 refuses to risk.
+     *  Waiters resolve false ("it did not land") rather than being left pending, which would
+     *  hang the #607 fence's own bookkeeping.
+     *
+     *  Clearing `live` also INVALIDATES every outstanding mark. Commands still executing on
+     *  the retired socket will finish and call their release; those releases now find no id
+     *  and are inert, so they cannot decrement a mark taken by a command on the NEW socket.
+     *  Zeroing a shared COUNTER here is exactly the bug that made this a Set. */
     cancel() {
       const pending = waiters;
       waiters = null;
       disarmTimer();
-      inFlight = 0;
+      live.clear();
       drainDeadline = 0;
       if (pending) for (const resolve of pending) resolve(false);
     },

--- a/web/js/lib/rehello-gate.js
+++ b/web/js/lib/rehello-gate.js
@@ -204,16 +204,23 @@ export function createRehelloGate({ advertise, now, setTimer, clearTimer } = {})
   // Frames that must not leave before the route has been re-advertised (see `routeIsStale`).
   // FIFO, and drained as one batch, because frames on a socket are ordered and holding some
   // while letting others past would reorder a conversation.
-  // Each entry is { send, route, bornAt } — see `holdForRoute` for why a bare callback was
-  // not enough: a frame must carry the route it was composed for, or a later advertisement
-  // for a DIFFERENT workflow delivers it to that one.
+  // Each entry is { send, route } — see `holdForRoute` for why a bare callback was not
+  // enough: a frame must carry the route it was composed for, or a later advertisement for
+  // a DIFFERENT workflow delivers it to that one.
+  //
+  // NO GENERATION STAMP, and that is a deliberate removal rather than an omission. An
+  // earlier cut carried one, because the drain was SCHEDULED on the advertisement's promise
+  // and could therefore outlive a `cancel()` that had already cleared the queue. The drain
+  // is now synchronous — `noteAdvertised` is called from the hello's landed path and reads
+  // the queue there and then — so `cancel()` clearing it synchronously is total: no callback
+  // survives to see a batch that is not its own. Mutation testing is what settled this:
+  // deleting the generation check failed no test, and the reason was that it had become
+  // unreachable, not that it was untested. An unreachable guard implying a protection nobody
+  // exercises is the same defect as a test asserting a property it cannot observe.
+  //
+  // IF THE DRAIN EVER BECOMES ASYNCHRONOUS AGAIN, the stamp has to come back with it.
   const held = [];
   let holdTimer = null;
-  // Which CONNECTION the state above belongs to. Bumped by `cancel()`, so anything already
-  // scheduled against the retired connection — a queued drain in particular — can tell that
-  // it no longer speaks for the live one. Same generation-scoping rule as the mark ids, one
-  // layer out: an async callback that outlives its connection must be able to say so.
-  let generation = 0;
 
   function disarmTimer() {
     if (timer === null) return;
@@ -391,7 +398,6 @@ export function createRehelloGate({ advertise, now, setTimer, clearTimer } = {})
       // the frame was built for a route that no longer exists, and the caller's delivery
       // timeout surfaces it. Clearing `held` also unwedges the queue — otherwise a stale
       // promise that never settles leaves every later frame stuck behind `held.length > 1`.
-      generation++;
       held.length = 0;
       if (holdTimer !== null) {
         try {
@@ -473,9 +479,7 @@ export function createRehelloGate({ advertise, now, setTimer, clearTimer } = {})
      */
     holdForRoute(send, route) {
       if (typeof send !== "function") return false;
-      // GENERATION-FENCED, the same lesson as the marks one layer out: an entry must be able
-      // to say which CONNECTION it belongs to, so a cancel can retire it.
-      held.push({ send, route, bornAt: generation });
+      held.push({ send, route });
       // Bounded, so a route that is never advertised (the user switched away and never came
       // back, the poll is not running) cannot hold a frame forever. The bound is the human
       // budget because that is already the longest a legitimate advertisement can be
@@ -518,11 +522,10 @@ export function createRehelloGate({ advertise, now, setTimer, clearTimer } = {})
       }
       const batch = held.splice(0, held.length);
       for (const entry of batch) {
-        // A frame from a retired connection, or composed for a workflow the panel has since
-        // moved past, has no correct destination. Dropped, deliberately and silently at this
-        // layer — the caller that was told `true` learns about it through its own delivery
-        // timeout, which is the mechanism that already exists for "it never got there".
-        if (entry.bornAt !== generation) continue;
+        // A frame composed for a workflow the panel has since moved past has no correct
+        // destination. Dropped, deliberately and silently at this layer — the caller that was
+        // told `true` learns about it through its own delivery timeout, which is the
+        // mechanism that already exists for "it never got there".
         if (entry.route !== route) continue;
         try {
           entry.send();


### PR DESCRIPTION
Closes #1095.

Creating a workflow and then running graph mutations loses the panel connection mid-batch. The reporter's log names the mechanism precisely:

```
panel tab tmp:2806 disconnected mid-command (graph_set_widget) — OUTCOME UNKNOWN
then: no connected tab ... Connected: none
```

## The diagnosis, which still holds

`rehelloForWorkflow()` re-advertises the tab when the active workflow changes, and its own comment says why that is destructive:

> Re-target the socket to the current workflow's tab id, then resume that workflow's agent session. **The backend drops the socket's prior tab mapping** so a background workflow's output can't leak here.

Dropping the prior mapping is deliberate and correct. The defect is *when* it fires. The workflow change is detected by a **600 ms poll** (`_wfPoll` → `onWorkflowMaybeChanged`) that knows nothing about whether a command is executing. `panel_new_workflow` changes the tab's identity to a fresh `tmp:<uuid>`, the next tick re-hellos, and the orchestrator drops the mapping the in-flight `graph_set_widget` is routed to.

It matches every detail of the report: a **temp** route id (a brand-new unsaved workflow), the drop landing **mid-command** rather than at a boundary, `OUTCOME UNKNOWN` rather than a failure (the command really did apply — "the new nodes had already been added"), and the follow-on `Connected: none`. It is a race, not a wedge, which is why the reporter saw it "mid-batch": a batch of sequential mutations is exactly the window where a poll tick lands between two commands.

The existing #508 journal-and-replay machinery does not cover it: that triggers on a **socket** close or supersession. Here the socket is fine — it is the orchestrator's *routing entry* that was withdrawn, by this tab's own hello.

## What changed since the last review

The previous cut put the guard at the workflow poll. Review rejected it — **the lead finding was that it could make the reported scenario more likely, not less** — and this rewrite answers all three findings by moving the wait into the mechanism every re-advertise already passes through.

**1. The guard covered one re-advertise out of four.** `rehelloForWorkflow` is not the only thing that re-advertises: the #607/#570 workflow-instance fence fires a full `sendHello()` **from inside the command branch**, and the #310 `free_vram` re-advertise and the #508 self-heal re-registration call it too. Worse, the interaction ran backwards — deferring the poll's hello keeps the orchestrator's cached `workflow_uuid` stale for *longer*, which trips the fence more often, which fires the one re-hello that was still ungated, mid-batch.

`sendHello` is now the **gated entry point** and `advertiseHello` the raw send. Nothing else may reach `advertiseHello`, and that is asserted structurally off the syntax tree rather than by convention, because a guard at one caller cannot be completed by patching callers — the next caller added would be ungated again.

The **one** deliberate bypass is the FIRST hello on a socket. That creates the mapping rather than replacing one, so it can strand nothing, and deferring it would leave the tab unregistered — strictly worse than the race. It is keyed on `advertisedSock`, recorded only on the send-LANDED path, so a hello that never left the tab cannot arm the gate and suppress the retry that would actually register it.

**2. The budget was shorter than the commands that most need it.** Five poll ticks is ~3 s, and `ask_user`/`request_secret` hold the window for a *human* wait — so for exactly the commands most likely to still be in flight across a workflow change, the fix stalled three seconds and then withdrew the route anyway. The bound is now contributed by the commands themselves, in two classes because there are two clocks: **4 s machine-paced, 30 s human-paced**. Measured on a **monotonic** clock (`monotonicNow`), never `Date.now`.

**3. `applyChatScope`'s inline re-bind was swallowed.** That caller nulls `currentWorkflowId`, calls the poll, and then repaints the context ring and announces the scope change — so a deferred early return announced a re-bind that had not happened. `onWorkflowMaybeChanged` now gates nothing: every commit (`currentWorkflowId`, the storage key, the workflow ref, `ssSet(SESSION_KEY, …)`) happens inline and unconditionally, exactly as before #1095, and only the wire send waits.

Also fixed on the branch during the earlier review and retained here: the in-flight mark leaked on five dedupe/retry paths that return without reaching `deliverReply`, and the pairing test could not fail on the bug it was written for.

## Two generation-scoping defects found in review, since fixed

**P1 — a release could free another connection's command.** The gate counted marks, and `cancel()` (setUrl / stop / destroy) zeroed that shared counter. But a command already executing on the **retired** socket still finishes and still calls `deliverReply`, whose release was unconditional — so it decremented whatever the **replacement** socket had marked. A parked hello could then flush while a live command was mid-flight: the exact route-loss race this PR exists to close, recreated by its own bookkeeping.

The count is now a **Set of mark ids**. `began()` returns the id, `deliverReply` takes it as a fourth argument and releases exactly that one, and `cancel()` clears the set — which invalidates every outstanding mark, so a late release from a retired generation finds nothing and is inert. The same mechanism makes a **double release** inert instead of discounting an unrelated command, and makes an **unnamed release fail closed**: it can only delay a re-advertise (the budget still expires), never let one through mid-command.

Keying on `rid` was considered and rejected — rids are not unique here, because the #517 retry path re-delivers a previously-seen rid, so two marks would collapse into one entry and the first reply would release both.

**P2 — an ordinary close inherited the gate.** `stop()`/`setUrl()`/`destroy()` null `sock` synchronously, so their late close fails the `isActive()` guard and never reaches the close handler. An ordinary drop (network, server restart) recovers through `scheduleReconnect` instead, and was therefore the one teardown that carried the previous connection's gate state across: a parked waiter or its timer could fire `advertiseHello()` against the **replacement** socket, and the dead socket's outstanding marks would make the next legitimate re-advertise wait out a budget for commands that can never reply. The active close now cancels the gate and clears `advertisedSock` — placed **after** the `isActive()` guard, so a superseded socket's close cannot withdraw the route from the live one.

## A cross-workflow leak the deferral opened, since closed

Found in review, and more serious than the routing bug this PR started from.

`onWorkflowMaybeChanged` commits the new workflow **inline** — that is deliberate, it is what fixed the swallowed-rebind finding above — while the re-hello is parked behind an in-flight command. So for the length of the deferral the panel is on workflow B and the orchestrator still has this socket bound to A.

A `user_message` frame carries **no tab id** (only `sendFrame` stamps one), so the orchestrator can route it only by the binding the socket already has. Typed in that window, the user's text, context and images for B are delivered into **A's conversation**. The 30 s human budget that `ask_user`/`request_secret` correctly earn is exactly the window that makes it worst.

`sendFrame` was unsafe for the mirror reason: its `tab_id` comes from `bridgeRouteId()`, which is derived from the **live** active workflow, so during a deferral it stamps a route the orchestrator has not been told about. `new_session`/`resume_session` in particular hand the next turn to a different agent over this socket.

Both send paths now compare the route the last **landed** hello actually carried against the live one (`routeIsStale`, kept pure so it can be driven) and hold the frame behind the hello when they disagree. The hold **expedites** that hello rather than waiting out the budget, so the wait is the hello's own round trip.

That expedite is the deliberate trade, and it is stated rather than hidden: a user action that needs the new route outranks an in-flight command's reply. Losing that reply reports `OUTCOME UNKNOWN`, which is honest and recoverable; delivering a message to the previous workflow's agent is silent and is not. The #1095 case this PR is actually about — an agent running a batch of mutations while nobody is typing — never reaches the hold at all.

Frames are **queued, not refused**: FIFO, drained as one batch after the same advertise settles, and drained even if that advertise **fails**, because a frame held forever is a mute panel.

## A test that could not observe its own property

The AST reachability scan returned at every `TryStatement` and examined only the `catch` and `finally`. A `return` inside the marked executor's `try` — which skips the catch, never reaches `deliverReply`, and leaks the in-flight mark — was invisible, and the test would have gone on passing. That is the same defect class as the token-counting version this scan replaced.

It now traverses the `tryBlock` and excludes only **caught** throws, and is driven against five fixtures including exactly that shape. Mutation-checked both ways: reverting the traversal turns the fixture red, and injecting a `return` into the real panel's marked `try` is caught and reported by line number.

## Three narrower defects, all in the deferral's own seams

**The `#517` duplicate-replay path was the one command path with no mark.** It awaits a ledger promise and then answers with a direct `thisSock.send`, so it holds the route exactly like an executing command — and it reads as "the reply already exists, nothing to protect". That is wrong when the retry lands on a **replacement** socket while the original is still running: `cancel()` invalidated the retired socket's mark, so the client believed nothing was in flight, and a workflow switch during the await let a re-hello withdraw the replacement's route before the reply was written. The OUTCOME UNKNOWN this PR exists to prevent, reached through the one path that had no mark.

Now marked, and released in a **`finally`** — the branch has three exits and answers on two of them without ever reaching `deliverReply`, so a release before any single `return` is one the next exit added would miss. The mark is taken outside that `try`, or a throw before the assignment would release `undefined`.

**The canvas-tool disclosure was decided for the wrong agent generation.** A held frame is sent after a hello the hold expedited, and a landed hello **advances** `agentSessionEpoch` — so `planCanvasToolDisclosure` running at call time decided for a generation the message would never reach. If the outgoing generation had already proven its tools, `disclose` was false, the new generation received no disclosure, and `canvasToolMessagedEpoch` then marked it as prompted. That generation never got the paragraph at all: silent, and total for the session. It is now planned **inside** the deferred send, along with everything derived from it. The one-shot context deliberately stays outside — `pendingContext` is consumed when the user presses send, and re-reading it at drain time would lose it or attach it to a later message.

**The gate started a second registration for one switch.** A hello is asynchronous — it awaits the tab-identity lease before it can even build its payload — so "a hello is happening" has real duration. On the most common path in the whole feature (an ordinary workflow switch, existing session, nothing in flight) `rehelloForWorkflow` starts the hello and immediately sends `resume_session`; that frame found the route still stale, asked to be held, and the hold's flush started a whole second hello — duplicate registration, duplicate "agent ready" greeting, and **two `agentSessionEpoch` increments per switch**. The doubled epoch is not cosmetic: it feeds the disclosure above, whose entire job is to run once per generation.

`flush()` now **joins** the advertisement already on its way. Joining is correct rather than merely cheaper: `makePayload` reads the identity *after* the lease resolves, so an advertisement started a microtask ago has not yet decided what it carries. The join clears once it **settles**, so a genuine later switch still gets its own hello, and `cancel()` drops it so a frame held on a replacement socket cannot conclude the new route is published because the retired socket's hello landed.

## The expedite is gone — a simpler rule that refuses more

The hold used to **expedite**: it pushed the parked hello onto the wire immediately. That was argued as a trade ("a person is waiting, and their action outranks an in-flight command's reply") and the argument was sound for the case it was written about and wrong for the traffic it covered. `rehelloForWorkflow` **also runs automatically** — when workflow-scoped history supplies a session id it re-hellos and immediately sends `resume_session`. Nobody is waiting for that frame. It reached the hold, expedited the hello the gate had correctly parked, and let the backend drop the old mapping before an in-flight command's reply: the OUTCOME UNKNOWN race this PR exists to close, re-opened by a convenience added to protect against a different failure.

The fix is deliberately **not** a user-vs-automatic flag. Nothing in the gate can know which is which, every call site that gets it wrong is another P1, and the flag would have to be threaded through `sendUserMessage` — which the restart-resume nudges also call with no person involved. So the expedite is removed and the rule is uniform: **a frame that needs the new route waits for the hello the deferral will produce, and cannot force one.**

The cost is bounded and visible: a frame can wait up to the deferral budget (4 s, or 30 s behind a human-paced command) before the hello goes out and it follows, sitting in the pending tray meanwhile with its own delivery timeout still covering it. What it buys is that no outbound frame can withdraw a route from a command that has not replied — by construction rather than by case analysis. This removes a special case rather than adding one.

**Held frames are also retired with their connection.** `cancel()` cleared `waiters` and `inFlight` but left `held` and its already-scheduled `then` intact, so a retired advertisement would settle, the drain would run against the mutable current socket, and a frame composed for the old connection would be written to the **replacement** one — or dropped after `true` had already been returned. A never-settling stale promise also wedged every later frame behind `held.length > 1`. Drains are now generation-fenced and the batch is cleared on cancel: the same generation-scoping rule as the mark ids, one layer out.

## One rule, replacing four rounds of point fixes

Rounds 2–5 each produced the same family of defect: **a frame reaching the wrong workflow's agent.** Each fix was correct and each round found another instance, which is what a missing abstraction looks like. The rule now is:

> An outbound frame is **stamped with the route it was composed for**. It leaves only when *that* route has actually been advertised. It **never causes an advertisement** — it waits for one. If the panel commits to a different workflow first, it is **discarded** rather than delivered there.

**Why "never causes an advertisement" is the load-bearing half.** `bridgeRouteId()` is derived from the live canvas and moves the instant the user clicks a workflow tab, but `SESSION_KEY` is not rebound until the 600 ms poll — and the hello reads `SESSION_KEY` for its spawn-time `resume`. `onWorkflowMaybeChanged` is the only place that commits a switch as a whole; its own comment says *"Order is the whole fix"*. So anything that advertises inside that gap pairs the **new route** with the **previous workflow's session**, which on a route with no live agent spawns a resume-**fork** of the previous conversation.

Earlier cuts had the hold call `request()`, which advertises immediately when nothing is in flight — so an outbound frame arriving in the gap was *itself* what published the half-committed switch. Removing the trigger removes the class: the poll stays the only author of a workflow re-advertisement and everything else observes. Same move as removing the expedite, applied to the remaining trigger.

**The route stamp closes the other half.** A→B queues B's `user_message`/`resume_session`; the user switches B→C before it drains; the hello advertises C — and the untagged queue delivered B's frames onto C.

**Cost.** A frame composed in the gap waits for the poll (~600 ms) plus any deferral, bounded at `REHELLO_DEFER_HUMAN_MS`. Past that, or if the panel commits elsewhere, it is discarded and the caller's delivery timeout surfaces it in the pending tray. Refusing a write is acceptable; sending it to the wrong workflow's agent is not.

**What this does *not* unify**, stated plainly: the round-3 findings (the unmarked replay wait, the disclosure epoch) were about *command lifetime* and *agent generation*, not frame routing — genuinely different seams that keep their own fixes. And `callTool`/`uploadMedia` still read the route live: during the gap they stamp a route the orchestrator does not hold yet, so those calls **fail** rather than misdeliver. Same family, opposite failure direction, left as-is and written down rather than quietly widened.

**A guard removed rather than kept.** The held queue briefly carried a generation stamp, from when the drain was scheduled on the advertisement's promise and could outlive a `cancel()`. The drain is synchronous now, so `cancel()` clearing the queue is total and the stamp became unreachable — mutation testing proved it by deleting the check and failing no test. It is gone, with a note that it must return if the drain ever becomes asynchronous again. An unreachable guard implying a protection nobody exercises is the same defect as a test asserting a property it cannot observe.

## A queued frame is not a delivered one

The unified rule changed frames from "sent immediately" to "sent later, or discarded" — and the **return contract did not follow**. `holdForRoute` answered `true`, which propagates through `sendFrame` as a successful write, and `runCompletion` acts on that **irreversibly**: `framePushed` → `markDelivered` retires the prompt from pending so it is never recovered from `/history`. A frame reported as delivered and then discarded is neither refused nor delivered but **invisible**, which is worse than either.

`holdForRoute` now returns `false` always — queued is not sent, and that is simply true. Two alternatives were considered and rejected:

- **A tri-state** (`sent`/`queued`/`refused`): a truthy `"refused"` would make every existing `if (!ok)` silently never fire. The blast radius is every call site, and the failure mode is invisible.
- **`false` while still queueing**: the tray shows failed, the user presses *Send now*, and the queued copy goes out too — a duplicate message.

So a frame may only be queued where **nobody reads the answer**. That is exactly `resume_session` and `new_session`: fire-and-forget, and meaningless before the hello anyway since they hand the next turn to an agent on a route the orchestrator has not been told about. Everything else is **refused** while the route is stale, which every caller already handles correctly — `runCompletion` re-pends and recovers from `/history`, which is what that path was built for ("sendFrame returns false when the bridge socket is down"). A user message is refused rather than queued for the same reason, so one retry sends exactly one message.

**The hold expiry now tracks the deferral** instead of being a fixed window from the first enqueue. A command starting *after* a frame queued pushes the advertisement's deadline out, and the old timer would clear the queue while the hello it was waiting for was still legitimately pending — a self-inflicted loss rather than a timeout.

## Scope of the guarantee — read this before trusting the rest

**This PR guarantees two things:**

1. A **`user_message` never leaves on a stale route.** That is the #1095 harm — the frame carries no tab id, so the orchestrator routes it by the socket binding, and before the new route is advertised it reaches the *previous* workflow's agent, carrying the user's text, context and images. It is refused instead, and the pending tray shows it so one retry sends exactly one message.
2. **`resume_session` / `new_session` arrive after the hello** that establishes their route, rather than naming a route the orchestrator has not been told about.

**It does NOT guarantee that no frame ever leaves on a stale route.** These are **not** protected and keep their pre-#1095 behaviour:

| Frame | Callers |
| --- | --- |
| `cancel_message` | message cancellation |
| `interrupt` | Stop, and Send-now's requeue |
| `rewind` | conversation rewind |
| `set_options` | model / effort changes (5 sites) |
| `agent_event` | run-completion reporting |
| pairing frames | remote-control pairing |
| `callTool`, `uploadMedia`, `title` | direct tool calls, media upload, title updates |

A brief cut *did* refuse all of these, and it was more correct in the abstract and **worse in practice**: every one of those callers ignores `sendFrame`'s return, so refusing did not stop them — it made them fail silently while their callers announced success, and `rewind` resubmits immediately after. Refusing a frame nobody checks converts a routing problem into a lying UI, which is worse than the routing problem. They now behave exactly as they did before this PR, so the regression that cut introduced is gone and no new guarantee is claimed.

Making all ~50 `sendFrame` call sites handle refusal is worthwhile, but it is a **different change** — error-handling UX across many features rather than a routing fix — and attempting it inside this PR is what kept producing the next round's defect. It should be its own issue.

## The armed one-shot survives a refusal

`pendingContext` is a one-shot transcript replay or workflow instruction, merged into the outgoing frame and cleared. The refusal used to sit *below* that merge, so a refused send consumed the armed replay — and `trackSend` stores the payload it was **given**, so the retry went out without it, silently. Same class as reporting a discarded frame delivered: the user's intent evaporates with no signal.

The refusal now sits **above every one-shot consumption**, so a refusal consumes nothing *structurally* — rather than by a restore that every future edit would have to remember. The ordering is asserted in both directions.

## Where the code lives

- `web/js/lib/rehello-gate.js` — the gate. Injectable clock and timers, so it is driven rather than asserted about.
- `web/js/comfyui-mcp-panel.js` — `sendHello` (gated) in front of `advertiseHello` (raw); the mark/release pair around the command branch; `setUrl`/`stop`/`destroy` drop a parked hello.

## How it was verified

`npm run test:unit` — **4452 tests: 4451 pass, 0 fail, 1 todo.** Fully green (after merging current `main`). 36 of them are new, in `rehello-gate.test.mjs`.

One caveat worth recording: `manager-install.test.mjs` → `#671 verifyInstalled … when the queue never drains` failed on two earlier runs of this suite and passed on the final ones. It is **pre-existing and not this branch's** — it asserts `elapsed < 10000` on a **wall clock** while the whole suite runs in parallel, and its own comment already concedes the hazard ("loaded machines overrun timers — the suite has seen a 5s budget take 10.4s"). Measured rather than assumed: unmodified `origin/main` (d7c7497c) fails the same test the same way under full-suite load (4399 tests, 4397 pass, 1 fail — `#671` at 34.8 s). It passes in isolation on this branch (122/122). Nothing here touches the Manager install path. It is a real flake in the suite and deserves its own issue.

The gate's behaviour is **driven**, not pattern-matched: the invariant is temporal ("no hello reaches the wire between a command starting and its reply") and `if (false) advertise()` matches any source pattern you could write for it. What remains structural is the mark/release pairing — an **AST reachability scan**, because review previously proved by execution that counting `++`/`--` tokens cannot tell the leaking arrangement from the fixed one — plus the new closure check on `advertiseHello`.

**Mutation-tested: 31 mutations, 31 killed.** Every one is re-run against the current tree by a harness (restore from an in-memory snapshot, never `git checkout`; each anchor asserted to occur exactly once and normalised to the file's own line ending; a harness timeout scores INCONCLUSIVE rather than as a kill):

| Mutation | Result |
| --- | --- |
| `request()`: `live.size === 0` → `>= 0` (never defer — the original bug) | **killed** |
| `ended()`: drop the drain-triggered flush | **killed** |
| `REHELLO_DEFER_HUMAN_MS` 30000 → 4000 (collapse the two clocks) | **killed** |
| `sendHello`: always `return advertiseHello()` (remove the gate) | **killed** |
| Take the mark above the #517 dedupe region (reinstate the leak) | **killed** — named all five leaking exits by line |
| Remove `rehelloGate.cancel()` from `destroy()` | **killed** |
| `ended()` releases the first mark it finds, ignoring the one it was given | **killed** |
| `cancel()` leaves outstanding marks in place | **killed** |
| Remove `rehelloGate.cancel()` from the close handler | **killed** |
| Move that cancel ABOVE the `isActive()` guard | **killed** |
| **`user_message` no longer waits for the route** (the leak) | **killed** |
| **The hold sends immediately instead of after the advertise** | **killed** |
| **The reachability scan skips `try` bodies** (its own blind spot) | **killed** |
| **A `return` inside the real panel's marked `try`** | **killed** — reported by line number |
| The duplicate-replay wait takes no mark | **killed** |
| The replay mark released outside the `finally` | **killed** |
| The disclosure planned at call time instead of at send time | **killed** |
| `flush()` always starts a new advertisement (no join) | **killed** |
| The join is never cleared, so a later switch is never announced | **killed** |
| `cancel()` leaves the retired connection's advertisement joinable | **killed** |
| **A held frame forces the parked hello out** (the expedite, restored) | **killed** |
| **The hold advertises instead of waiting** (the round-5 P1) | **killed** |
| **A frame is released regardless of the route it was composed for** | **killed** |
| **The hold is unbounded** | **killed** |
| **Held frames released before the hello lands** | **killed** |
| **sendUserMessage holds without stamping a route** | **killed** |
| **A cancelled generation's drain still runs** | **killed** |
| **`cancel()` keeps the held batch** | **killed** |

## What a reviewer should look at

- **The fence is now gated too, and that is a trade.** During a deferral the #607 recovery hello also waits, so a mutation aimed at the new canvas is cleanly **refused** ("Nothing was applied", safe to retry) rather than losing its route. That is better than `OUTCOME UNKNOWN`, but it lasts up to the budget — and **30 s is the number to argue with**, since it is the one place a person's pace and a wedge risk trade against each other directly.
- **Long-running commands are deliberately not covered.** A `graph_run` that renders for minutes gets the machine budget and then loses its route exactly as it does today. No regression, no cover. Extending the deadline to reach it would hold a stale route for the length of an arbitrary render.
- **Frame ordering across the deferral.** `rehelloForWorkflow` sends `resume_session` immediately after requesting the hello. `sendHello` was *already* asynchronous (it awaits the tab-identity resolve), so `resume_session` already reached the wire ahead of the hello today; the deferral widens an existing gap rather than creating one. Unchanged here on purpose, but worth a second opinion.
- **Not reproduced live.** The mechanism is read off the panel's own comment and the reporter's log, not observed against a running orchestrator — the orchestrator side of "the backend drops the socket's prior tab mapping" is not something the panel can see. The report is from panel 0.11.38; this branch is on current main.
- **An outbound frame can now wait up to 30 s** (behind a human-paced command) before it reaches the wire. That is the price of removing the expedite, and it is the one deliberate UX regression in this PR. The frame is queued and visible in the pending tray, never dropped or silently sent on a stale route.
- **`routeIsStale` fails open on an unreadable route id.** Following the #607 fence's rule ("an identity we cannot read is not one we know to be new"), because the alternative holds every frame for as long as the id stays unreadable. It does mean a leak could slip through if `bridgeRouteId()` ever returned null mid-deferral.
- **Marks are never garbage-collected by anything but a reply or a teardown.** That is deliberate (the budget bounds the wait either way), but it means a command path that somehow reached neither `deliverReply` nor a socket teardown would hold an id forever. The AST reachability scan exists precisely to make that unreachable, and it is the assertion to keep honest if the command branch is restructured.
- **Five test assertions across four files now match `deliverReply`'s leading arguments rather than its exact arity.** That was necessary — the mark is a fourth argument — but it does loosen them slightly. Each still asserts the ordering claim it was written for.

## Deliberately not done

No `CHANGELOG.md` entry and no version bump — releases are a separate PR in this repo, and the previous cut's changelog text was mangled anyway ("the tab 's", "workflow 's"). The merge with `main` resolved `CHANGELOG.md` to main's version.

Left as a **draft**.







