### PR TITLE
fix(1161): bound each /object_info transport so a hung route falls through to the one that works

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- **Setting a widget no longer hangs for 30 seconds after a ComfyUI restart (#1161).**
+  Once ComfyUI had been restarted mid-session, setting any widget on any node timed out,
+  every time, while every other panel command answered instantly — reading the graph,
+  renaming a node, listing workflows, queueing a run. Setting a widget is the one action
+  that reads the backend's node definitions before it writes, and a restart can leave the
+  browser holding a connection that never answers and never fails, so that read waited
+  forever.
+  The panel already had a second way to ask — a direct request that keeps working when
+  the first route does not — but it was never reached, because nothing gave up on the
+  first one. Each route is now given a few seconds, so a route that stops answering falls
+  through to the one that does and the write simply succeeds. If neither answers, the
+  refusal names both attempts instead of leaving the command to time out silently.
+
 ## [0.14.24] - 2026-08-12
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,12 @@ All notable changes to this project are documented here. This project adheres to
   forever.
   The panel already had a second way to ask — a direct request that keeps working when
   the first route does not — but it was never reached, because nothing gave up on the
-  first one. Each route is now given a few seconds, so a route that stops answering falls
-  through to the one that does and the write simply succeeds. If neither answers, the
-  refusal names both attempts instead of leaving the command to time out silently.
+  first one. The lookup now has an overall time budget, so a route that stops answering falls
+  through to the one that does and the write simply succeeds. The budget is shared across
+  the whole lookup rather than given to each step, so the wait cannot stack, and it is
+  sized against the real payload — several megabytes on a large install — rather than
+  against a fast local reply. If nothing answers, the refusal names every attempt instead
+  of leaving the command to time out silently.
 
 ## [0.14.24] - 2026-08-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,12 +20,14 @@ All notable changes to this project are documented here. This project adheres to
   first one. The lookup now has an overall time budget, so a route that stops answering falls
   through to the one that does and the write simply succeeds. The budget covers the whole
   lookup rather than being handed to each step in turn, so the wait cannot stack — but the
-  second route is also guaranteed its own share of it, because a first route that stops
-  answering would otherwise use the budget up and leave nothing for the route that still
-  works. The budget is sized against the real payload — several megabytes on a large
-  install — rather than against a fast local reply. If nothing answers, the refusal names
-  every attempt, and says how long each one was actually given rather than quoting a wait
-  it never spent.
+  second route is also guaranteed a share of it, because a first route that stops answering
+  would otherwise use the budget up and leave nothing for the route that still works. A
+  route that answers quickly hands back the time it did not use, so a slow install still
+  gets the whole budget to finish in.
+  The budget is twenty seconds, which is generous rather than tight: fetching the whole
+  node-definition document was measured at well under a second even on a large install with
+  sixty-odd node packs. If nothing answers, the refusal names every attempt and says how
+  long each one was actually given, rather than quoting a wait it never spent.
 
 ## [0.14.24] - 2026-08-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,11 +18,14 @@ All notable changes to this project are documented here. This project adheres to
   The panel already had a second way to ask — a direct request that keeps working when
   the first route does not — but it was never reached, because nothing gave up on the
   first one. The lookup now has an overall time budget, so a route that stops answering falls
-  through to the one that does and the write simply succeeds. The budget is shared across
-  the whole lookup rather than given to each step, so the wait cannot stack, and it is
-  sized against the real payload — several megabytes on a large install — rather than
-  against a fast local reply. If nothing answers, the refusal names every attempt instead
-  of leaving the command to time out silently.
+  through to the one that does and the write simply succeeds. The budget covers the whole
+  lookup rather than being handed to each step in turn, so the wait cannot stack — but the
+  second route is also guaranteed its own share of it, because a first route that stops
+  answering would otherwise use the budget up and leave nothing for the route that still
+  works. The budget is sized against the real payload — several megabytes on a large
+  install — rather than against a fast local reply. If nothing answers, the refusal names
+  every attempt, and says how long each one was actually given rather than quoting a wait
+  it never spent.
 
 ## [0.14.24] - 2026-08-12
 

--- a/browser_tests/unit/media-preview.test.mjs
+++ b/browser_tests/unit/media-preview.test.mjs
@@ -1419,3 +1419,27 @@ test("a late fulfilment after the bound fired does not overwrite the fallback", 
   settle("too late");
   assert.equal(await p, "fallback");
 });
+
+test("#1161 withTimeout: a `timers` object that cannot be READ is treated as absent, never a rejection", async () => {
+  // bounded-step.js's own header argues that every injected guard is an operation that can
+  // fail, and wraps `onTimeout` and `clearTimer` accordingly — but READING the injected
+  // object was itself unguarded. A throwing getter, or a Proxy whose get trap throws, threw
+  // synchronously before the returned promise existed, so withTimeout REJECTED out of a
+  // function documented three lines above its signature as never rejecting. The
+  // /object_info oracle passes this object straight through, and two panel commands await
+  // that oracle with no catch of their own.
+  const hostile = [
+    { get setTimer() { throw new Error("hostile getter"); } },
+    new Proxy({}, { get() { throw new Error("proxy trap"); } }),
+    { setTimer: 5, clearTimer: "no" }, // present, but not callable
+  ];
+  for (const timers of hostile) {
+    const value = await withTimeout(Promise.resolve("answered"), 1000, () => "timed out", timers);
+    assert.equal(value, "answered", "an unreadable timers object must fall back to the real timer");
+  }
+  // …and the bound must still WORK through that fallback, not merely avoid throwing.
+  const timedOut = await withTimeout(new Promise(() => {}), 1, () => "timed out", {
+    get setTimer() { throw new Error("hostile getter"); },
+  });
+  assert.equal(timedOut, "timed out", "the real timer still bounds the step");
+});

--- a/browser_tests/unit/object-info-oracle.test.mjs
+++ b/browser_tests/unit/object-info-oracle.test.mjs
@@ -302,3 +302,122 @@ test("#982 (codex r4) blank entries: the slice-first order is documented, not ac
   assert.equal(objectInfoOracleFailureNote(["", "", "", "", "x"]), "", "four blanks consume the window");
   assert.match(objectInfoOracleFailureNote(["x", "", "", "", ""]), /Tried 5 routes: x \(and 1 more not shown\)\./);
 });
+
+// ── #1161: a transport that never ANSWERS must not park the whole oracle ─────
+//
+// The P1. After a ComfyUI restart the tab can hold a half-open connection, so
+// `api.getNodeDefs()` never settles — it does not throw, it simply never answers. Both
+// awaits here were unbounded, so the oracle parked on the first transport and the second
+// route — added by #982 for exactly this failure — was never asked. Every command that
+// consults it hung until its caller timed out at 30s.
+//
+// The bound is not a way to fail faster. Its point is that the SECOND route usually
+// answers, so the write SUCCEEDS. That is why it belongs here and not around the cache,
+// where three attempts on #1178 could only choose how to give up.
+//
+// Timers are injected and fired by hand, so nothing here waits on a real clock and a
+// regression fails with a named assertion rather than wedging `node --test`.
+function harness() {
+  const timers = new Set();
+  return {
+    timers: {
+      setTimer: (fn, ms) => { const t = { fn, ms }; timers.add(t); return t; },
+      clearTimer: (t) => timers.delete(t),
+    },
+    armed: () => timers.size,
+    fire: () => [...timers].forEach((t) => { timers.delete(t); t.fn(); }),
+  };
+}
+const DEFS_1161 = { KSampler: {} };
+// Never await an oracle call unbounded: node --test has no default timeout, so a
+// regression would wedge the suite instead of naming itself. The previous branch was
+// caught doing exactly this.
+const settled = (p, what) =>
+  Promise.race([
+    p,
+    new Promise((_, reject) =>
+      setTimeout(() => reject(new Error(`${what} never settled — a transport was not bounded`)), 250),
+    ),
+  ]);
+// Let the oracle reach its next await and arm THAT timer before firing. A macrotask
+// flushes every pending microtask, which counting ticks does not reliably do — an earlier
+// draft fired the response timer before it had unwrapped and timed out the wrong stage.
+const tick = () => new Promise((r) => setTimeout(r, 0));
+const never = () => new Promise(() => {});
+
+test("#1161: a hung client route falls through to the fallback, which ANSWERS", async () => {
+  // The whole point: not a faster refusal — a successful write.
+  const h = harness();
+  const out = fetchWholeObjectInfo({
+    getNodeDefs: never,
+    fetchApi: async () => ({ ok: true, json: async () => DEFS_1161 }),
+    waitMs: 6000,
+    timers: h.timers,
+  });
+  await tick();
+  h.fire(); // the client route gives up
+  const result = await settled(out, "the oracle call");
+  assert.deepEqual(result.defs, DEFS_1161, "the fallback answered, so the caller is authorized");
+  assert.match(result.failures.join(" | "), /api\.getNodeDefs\(\) did not answer within 6000ms/);
+});
+
+test("#1161: the timeout is reported as a timeout, not as a throw", async () => {
+  // withTimeout never rejects by contract, so a naive wrap would collapse "it threw" into
+  // "it timed out" and the refusal would name the wrong cause — the trap that bit #1178.
+  const h = harness();
+  const out = fetchWholeObjectInfo({
+    getNodeDefs: async () => { throw new Error("client exploded"); },
+    fetchApi: never,
+    waitMs: 6000,
+    timers: h.timers,
+  });
+  await tick();
+  h.fire();
+  const result = await settled(out, "the oracle call");
+  const note = result.failures.join(" | ");
+  assert.match(note, /api\.getNodeDefs\(\) threw: client exploded/, "a throw keeps its own cause");
+  assert.match(note, /GET \/object_info did not answer within 6000ms/, "…and a hang keeps its own");
+});
+
+test("#1161: both transports hanging still returns, and names both", async () => {
+  const h = harness();
+  const out = fetchWholeObjectInfo({ getNodeDefs: never, fetchApi: never, waitMs: 6000, timers: h.timers });
+  await tick();
+  h.fire();
+  await tick();
+  h.fire();
+  const result = await settled(out, "the oracle call");
+  assert.equal(result.defs, null, "nothing answered, so nothing is authorized — still fail-closed");
+  assert.equal(result.failures.length, 2, "each route reports for itself");
+  for (const f of result.failures) assert.match(f, /did not answer within 6000ms/);
+});
+
+test("#1161: a hung BODY is bounded too — the response is not the body", async () => {
+  // res.json() is a second I/O step and was inside the try/catch the bound replaced. A 5MB
+  // schema over a half-open connection can stall after the headers arrive.
+  const h = harness();
+  const out = fetchWholeObjectInfo({
+    getNodeDefs: async () => null,
+    fetchApi: async () => ({ ok: true, json: never }),
+    waitMs: 6000,
+    timers: h.timers,
+  });
+  await tick();
+  h.fire();
+  const result = await settled(out, "the oracle call");
+  assert.equal(result.defs, null);
+  assert.match(result.failures.join(" | "), /body did not arrive within 6000ms/);
+});
+
+test("#1161: a healthy client route is untouched by the bound", async () => {
+  const h = harness();
+  const result = await fetchWholeObjectInfo({
+    getNodeDefs: async () => DEFS_1161,
+    fetchApi: () => { throw new Error("must not be consulted"); },
+    waitMs: 6000,
+    timers: h.timers,
+  });
+  assert.deepEqual(result.defs, DEFS_1161);
+  assert.deepEqual(result.failures, [], "a route that answers records no failure");
+  assert.equal(h.armed(), 0, "and leaves no timer armed");
+});

--- a/browser_tests/unit/object-info-oracle.test.mjs
+++ b/browser_tests/unit/object-info-oracle.test.mjs
@@ -959,8 +959,22 @@ test("#1161: the DEFAULT clock is the monotonic one — the property everything 
   // A source guard, in the idiom this suite already uses for the #982 refusal wording,
   // because the choice is a default the tests otherwise always override.
   const src = readFileSync(new URL("../../web/js/lib/object-info-oracle.js", import.meta.url), "utf8");
-  assert.match(src, /performance\.now\(\)/, "the default reading must be the monotonic clock");
-  const dateNowUses = src.split("\n").filter((l) => /Date\.now\(\)/.test(l) && !/^\s*(\/\/|\*)/.test(l));
+  // Pin the ARM, not merely the appearance of the identifier. "performance.now" also occurs
+  // in the rationale comment and in the capability check just above the selection, so the
+  // first version of this guard — a bare match on that identifier — stayed true for the
+  // exact mutation its own comment names, and was vacuous.
+  assert.match(src, /\?\s*\(\)\s*=>\s*performance\.now\(\)/, "the default arm must BE the monotonic clock");
+  // Strip comments before counting Date.now uses: the first filter only skipped lines
+  // STARTING with a marker, so a trailing same-line comment counted as a use.
+  //
+  // SPLIT ON /\r?\n/. This file is CRLF, so a line ends "…\r" — and `//.*$` never matches
+  // there, because `.` excludes the carriage return and `$` sits after it. The strip
+  // silently did nothing and the assertion failed on unmutated source.
+  const code = src
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .split(/\r?\n/)
+    .map((l) => l.replace(/\/\/.*$/, ""));
+  const dateNowUses = code.filter((l) => /Date\.now\(\)/.test(l));
   assert.equal(dateNowUses.length, 1, `Date.now may appear only as the last-resort fallback, found: ${dateNowUses.join(" | ")}`);
   assert.match(dateNowUses[0], /=>\s*Date\.now\(\)/, "and only as the fallback arm of the clock selection");
 });
@@ -996,5 +1010,91 @@ test("#1161: a budget beyond the timer's range cannot silently become no bound",
     for (const ms of granted) {
       assert.ok(ms <= 2 ** 31 - 1, `granted ${ms}ms, which a timer cannot express and fires at 1ms`);
     }
+    // PIN THE BOUNDARY ITSELF. Grants alone cannot see it: at a budget of exactly 2**31 the
+    // largest grant still lands a millisecond or two under the ceiling, so setting the cap
+    // to 2**31 survived every grant assertion. The refusal quotes the budget in force, so
+    // it is the one observable that distinguishes the two.
+    const refused = await fetchWholeObjectInfo({
+      getNodeDefs: () => new Promise(() => {}),
+      fetchApi: () => new Promise(() => {}),
+      deadlineMs,
+      timers: { setTimer: (fn) => { fn(); return {}; }, clearTimer: () => {} },
+    });
+    assert.match(
+      refused.failures.join(" | "),
+      /share of the 2147483647ms budget/,
+      "the budget in force must be exactly the largest a timer can express",
+    );
+  }
+});
+
+test("#1161: a hung step really is charged, so it cannot leave the next one the whole budget", async () => {
+  // Deleting the timeout charge entirely left the whole suite green — including the test
+  // rewritten specifically to see that overrun. The observable consequence is simple: if a
+  // hung client route costs nothing, the fallback draws the FULL budget rather than what is
+  // left, and the total is no longer bounded by anything.
+  const granted = [];
+  const armed = [];
+  const out = fetchWholeObjectInfo({
+    getNodeDefs: never,
+    fetchApi: async () => ({ ok: true, json: async () => DEFS_1161 }),
+    deadlineMs: 20000,
+    timers: {
+      setTimer: (fn, ms) => { granted.push(ms); const t = { fn, ms }; armed.push(t); return t; },
+      clearTimer: (t) => { const i = armed.indexOf(t); if (i >= 0) armed.splice(i, 1); },
+    },
+    now: () => 0, // a clock that reveals nothing: only the timeout charge can bound this
+  });
+  await tick();
+  armed.shift().fn();
+  await settled(out, "the oracle call");
+  assert.equal(granted[0], 10000, "the client route's share");
+  assert.ok(
+    granted[1] <= 10000,
+    `the fallback was granted ${granted[1]}ms — a hung step that costs nothing leaves the budget unspent`,
+  );
+});
+
+test("#1161: BOTH fallback shares are pinned, not just the body's", async () => {
+  // BODY_SHARE was re-pinned after it survived a mutation; FALLBACK_RESPONSE_SHARE was left
+  // free, and 0.5 -> 0.9 survived the suite. Pin the response's share the same way, on the
+  // path where the client route has already spent its half so the arithmetic is unambiguous.
+  const granted = [];
+  const armed = [];
+  const out = fetchWholeObjectInfo({
+    getNodeDefs: never,
+    fetchApi: async () => ({ ok: true, json: async () => DEFS_1161 }),
+    deadlineMs: 20000,
+    timers: {
+      setTimer: (fn, ms) => { granted.push(ms); const t = { fn, ms }; armed.push(t); return t; },
+      clearTimer: (t) => { const i = armed.indexOf(t); if (i >= 0) armed.splice(i, 1); },
+    },
+    now: () => 0,
+  });
+  await tick();
+  armed.shift().fn(); // the client route burns its 10s
+  await settled(out, "the oracle call");
+  assert.equal(granted[1], 5000, "the response takes half of what the client route left, not more");
+});
+
+test("#1161: a Number-coercible clock keeps the reclaim, it does not silently disable it", async () => {
+  // Demanding `typeof === "number"` rejected every clock the subtraction itself would have
+  // accepted — a Date, or a numeric string — so those charged the full grant and the
+  // reclaim vanished, restoring the 10000/5000/5000 shape that round 8 proved refuses
+  // payloads main serves. The guard must coerce exactly as the arithmetic would.
+  for (const make of [
+    () => { let t = 0; return () => new Date((t += 100)); },
+    () => { let t = 0; return () => String((t += 100)); },
+    () => { let t = 0; return () => (t += 100); },
+  ]) {
+    const granted = [];
+    await fetchWholeObjectInfo({
+      getNodeDefs: async () => null,
+      fetchApi: async () => ({ ok: true, json: async () => DEFS_1161 }),
+      deadlineMs: 20000,
+      now: make(),
+      timers: { setTimer: (fn, ms) => { granted.push(ms); return { fn, ms }; }, clearTimer: () => {} },
+    });
+    assert.ok(granted[2] > 15000, `the body kept ${granted[2]}ms — the reclaim must survive this clock`);
   }
 });

--- a/browser_tests/unit/object-info-oracle.test.mjs
+++ b/browser_tests/unit/object-info-oracle.test.mjs
@@ -24,7 +24,12 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 
-import { fetchWholeObjectInfo, objectInfoOracleFailureNote } from "../../web/js/lib/object-info-oracle.js";
+import {
+  fetchWholeObjectInfo,
+  objectInfoOracleFailureNote,
+  // The SHIPPED budget, so a test cannot pass against a value the panel does not use.
+  OBJECT_INFO_DEADLINE_MS,
+} from "../../web/js/lib/object-info-oracle.js";
 
 const SCHEMA = { KSampler: { input: {} }, VAELoader: { input: {} } };
 const okResponse = (body) => ({ ok: true, status: 200, json: async () => body });
@@ -351,14 +356,14 @@ test("#1161: a hung client route falls through to the fallback, which ANSWERS", 
   const out = fetchWholeObjectInfo({
     getNodeDefs: never,
     fetchApi: async () => ({ ok: true, json: async () => DEFS_1161 }),
-    waitMs: 6000,
+    deadlineMs: 6000,
     timers: h.timers,
   });
   await tick();
   h.fire(); // the client route gives up
   const result = await settled(out, "the oracle call");
   assert.deepEqual(result.defs, DEFS_1161, "the fallback answered, so the caller is authorized");
-  assert.match(result.failures.join(" | "), /api\.getNodeDefs\(\) did not answer within 6000ms/);
+  assert.match(result.failures.join(" | "), /api\.getNodeDefs\(\) did not answer within the 6000ms budget/);
 });
 
 test("#1161: the timeout is reported as a timeout, not as a throw", async () => {
@@ -368,7 +373,7 @@ test("#1161: the timeout is reported as a timeout, not as a throw", async () => 
   const out = fetchWholeObjectInfo({
     getNodeDefs: async () => { throw new Error("client exploded"); },
     fetchApi: never,
-    waitMs: 6000,
+    deadlineMs: 6000,
     timers: h.timers,
   });
   await tick();
@@ -376,12 +381,12 @@ test("#1161: the timeout is reported as a timeout, not as a throw", async () => 
   const result = await settled(out, "the oracle call");
   const note = result.failures.join(" | ");
   assert.match(note, /api\.getNodeDefs\(\) threw: client exploded/, "a throw keeps its own cause");
-  assert.match(note, /GET \/object_info did not answer within 6000ms/, "…and a hang keeps its own");
+  assert.match(note, /GET \/object_info did not answer within the 6000ms budget/, "…and a hang keeps its own");
 });
 
 test("#1161: both transports hanging still returns, and names both", async () => {
   const h = harness();
-  const out = fetchWholeObjectInfo({ getNodeDefs: never, fetchApi: never, waitMs: 6000, timers: h.timers });
+  const out = fetchWholeObjectInfo({ getNodeDefs: never, fetchApi: never, deadlineMs: 6000, timers: h.timers });
   await tick();
   h.fire();
   await tick();
@@ -389,7 +394,7 @@ test("#1161: both transports hanging still returns, and names both", async () =>
   const result = await settled(out, "the oracle call");
   assert.equal(result.defs, null, "nothing answered, so nothing is authorized — still fail-closed");
   assert.equal(result.failures.length, 2, "each route reports for itself");
-  for (const f of result.failures) assert.match(f, /did not answer within 6000ms/);
+  for (const f of result.failures) assert.match(f, /did not answer within the 6000ms budget/);
 });
 
 test("#1161: a hung BODY is bounded too — the response is not the body", async () => {
@@ -399,14 +404,14 @@ test("#1161: a hung BODY is bounded too — the response is not the body", async
   const out = fetchWholeObjectInfo({
     getNodeDefs: async () => null,
     fetchApi: async () => ({ ok: true, json: never }),
-    waitMs: 6000,
+    deadlineMs: 6000,
     timers: h.timers,
   });
   await tick();
   h.fire();
   const result = await settled(out, "the oracle call");
   assert.equal(result.defs, null);
-  assert.match(result.failures.join(" | "), /body did not arrive within 6000ms/);
+  assert.match(result.failures.join(" | "), /body did not arrive within the 6000ms budget/);
 });
 
 test("#1161: a healthy client route is untouched by the bound", async () => {
@@ -414,10 +419,82 @@ test("#1161: a healthy client route is untouched by the bound", async () => {
   const result = await fetchWholeObjectInfo({
     getNodeDefs: async () => DEFS_1161,
     fetchApi: () => { throw new Error("must not be consulted"); },
-    waitMs: 6000,
+    deadlineMs: 6000,
     timers: h.timers,
   });
   assert.deepEqual(result.defs, DEFS_1161);
   assert.deepEqual(result.failures, [], "a route that answers records no failure");
   assert.equal(h.armed(), 0, "and leaves no timer armed");
+});
+
+test("#1161: the SHIPPED budget is a real bound, sized for the payload not a ping", async () => {
+  // Every other #1161 test injects its own budget, so none of them would notice the
+  // shipped constant being set to 0 — which disables the bound entirely by withTimeout's
+  // contract and reinstates the P1 with a green suite. Review caught that gap twice.
+  assert.ok(OBJECT_INFO_DEADLINE_MS > 0, "a non-positive budget disables the bound");
+  // The bounded work is a ~5.4MB download, measured at ~14.5s in this repo (#610) — not
+  // the ~167ms LAN response an earlier version of this bound was mistakenly sized from.
+  assert.ok(
+    OBJECT_INFO_DEADLINE_MS >= 15000,
+    "below the measured payload time this refuses ordinary installs, and pays for a second download doing it",
+  );
+  // …and it must still land inside the bridge's 30s command timeout, so the caller sees
+  // this oracle's own answer rather than a bare timeout with no routes named.
+  assert.ok(OBJECT_INFO_DEADLINE_MS < 30000, "past the command budget the refusal never reaches the caller");
+});
+
+test("#1161: an unreadable response is a failure, never a rejection", async () => {
+  // The contract this module states two screens up: "every failure path returns defs:
+  // null". Replacing the try/catch with a bound re-protected only the awaits, so reading
+  // `ok`/`status` off a proxied or lazily-evaluated response rejected instead. Two callers
+  // await this with no try/catch of their own.
+  const hostile = { get ok() { throw new Error("wrapped api"); } };
+  const result = await fetchWholeObjectInfo({
+    getNodeDefs: async () => null,
+    fetchApi: async () => hostile,
+    deadlineMs: 6000,
+  });
+  assert.equal(result.defs, null);
+  assert.match(result.failures.join(" | "), /unreadable response: wrapped api/);
+});
+
+test("#1161: a payload whose own shape cannot be inspected is a failure, never a rejection", async () => {
+  // Object.keys invokes a Proxy's ownKeys trap, which can throw — same contract, different
+  // entry point, and also proven against main by the review.
+  const trapped = new Proxy({}, { ownKeys() { throw new Error("proxy"); } });
+  const result = await fetchWholeObjectInfo({
+    getNodeDefs: async () => trapped,
+    fetchApi: async () => ({ ok: true, json: async () => ({ KSampler: {} }) }),
+    deadlineMs: 6000,
+  });
+  // Nothing rejected — that is the contract this asserts, and the whole point.
+  //
+  // The OUTCOME is `defs: null` rather than the fallback's schema, and that is correct
+  // rather than a shortfall: an uninspectable object still satisfies the "is an object,
+  // is not an array" test, so it takes the deliberate-empty branch and is treated as the
+  // client's own answer. That is the direction this module already chose for an empty
+  // map — the fallback must never widen an answer the client gave — and it fails closed,
+  // which is the safe reading of "I could not tell what it said".
+  assert.equal(result.defs, null);
+});
+
+test("#1161: the budget is shared, so three steps cannot each spend it", async () => {
+  // A per-step bound multiplies: three 6s bounds is an 18s worst case nobody chose,
+  // stacked on the 8s startup seed wait. One budget makes the worst case one number.
+  const h = harness();
+  let clock = 0;
+  const out = fetchWholeObjectInfo({
+    getNodeDefs: never,
+    fetchApi: never,
+    deadlineMs: 6000,
+    timers: h.timers,
+    now: () => clock,
+  });
+  await tick();
+  clock = 6000; // the first step consumed the whole budget
+  h.fire();
+  const result = await settled(out, "the oracle call");
+  assert.equal(result.defs, null);
+  assert.equal(h.armed(), 0, "with no budget left the second step must not arm a timer at all");
+  assert.equal(result.failures.length, 2, "…and must still report for itself");
 });

--- a/browser_tests/unit/object-info-oracle.test.mjs
+++ b/browser_tests/unit/object-info-oracle.test.mjs
@@ -322,15 +322,33 @@ test("#982 (codex r4) blank entries: the slice-first order is documented, not ac
 //
 // Timers are injected and fired by hand, so nothing here waits on a real clock and a
 // regression fails with a named assertion rather than wedging `node --test`.
+//
+// THE CLOCK ADVANCES WHEN A TIMER FIRES, and that is not a detail. The first version of
+// this harness fired the injected timer while leaving `now()` at 0, so every test ran with
+// the full budget still unspent — a state production CANNOT reach, since a timer armed for
+// `ms` only fires once `ms` has passed. Under that harness the flagship test below passed
+// while the shipped code never issued the fallback at all (`fetchApi` call count 0). The
+// clock is therefore owned here and moved by `fire()`, so a test cannot assert an outcome
+// the real clock would not produce.
 function harness() {
   const timers = new Set();
+  const armedMs = [];
+  let clock = 0;
   return {
     timers: {
-      setTimer: (fn, ms) => { const t = { fn, ms }; timers.add(t); return t; },
+      setTimer: (fn, ms) => { const t = { fn, ms }; timers.add(t); armedMs.push(ms); return t; },
       clearTimer: (t) => timers.delete(t),
     },
+    now: () => clock,
     armed: () => timers.size,
-    fire: () => [...timers].forEach((t) => { timers.delete(t); t.fn(); }),
+    armedMs: () => armedMs.slice(),
+    at: () => clock,
+    fire: () => {
+      const due = [...timers];
+      // Firing a timer means its full duration elapsed — the longest one pins the clock.
+      clock += due.reduce((max, t) => Math.max(max, t.ms), 0);
+      due.forEach((t) => { timers.delete(t); t.fn(); });
+    },
   };
 }
 const DEFS_1161 = { KSampler: {} };
@@ -353,17 +371,49 @@ const never = () => new Promise(() => {});
 test("#1161: a hung client route falls through to the fallback, which ANSWERS", async () => {
   // The whole point: not a faster refusal — a successful write.
   const h = harness();
+  let fetchCalls = 0;
   const out = fetchWholeObjectInfo({
     getNodeDefs: never,
-    fetchApi: async () => ({ ok: true, json: async () => DEFS_1161 }),
+    fetchApi: async () => { fetchCalls += 1; return { ok: true, json: async () => DEFS_1161 }; },
     deadlineMs: 6000,
     timers: h.timers,
+    now: h.now,
   });
   await tick();
-  h.fire(); // the client route gives up
+  h.fire(); // the client route gives up, and the clock moves to when it did
   const result = await settled(out, "the oracle call");
+  // ASSERT THE REQUEST WAS ACTUALLY SENT, not merely that the outcome looks right. This is
+  // the fact the earlier version of this branch got wrong while its suite stayed green: the
+  // client route consumed the entire shared budget, so the fallback was skipped unsent
+  // (call count 0) and the refusal then named a route nothing had contacted. An outcome
+  // assertion alone cannot see that; a call count can.
+  assert.equal(fetchCalls, 1, "the fallback must be ISSUED — a reserved floor is what guarantees it");
   assert.deepEqual(result.defs, DEFS_1161, "the fallback answered, so the caller is authorized");
   assert.match(result.failures.join(" | "), /api\.getNodeDefs\(\) did not answer within the 6000ms budget/);
+});
+
+test("#1161: no route is ever REPORTED as timing out when it was never sent", async () => {
+  // #982's original defect was a refusal naming a cause it had not established. A step
+  // reached with no budget left must say so in its own words rather than borrow the
+  // timeout's, or the fix reintroduces the bug it was written to remove.
+  const h = harness();
+  let fetchCalls = 0;
+  const out = fetchWholeObjectInfo({
+    getNodeDefs: never,
+    fetchApi: async () => { fetchCalls += 1; return { ok: true, json: async () => DEFS_1161 }; },
+    deadlineMs: 6000,
+    timers: h.timers,
+    // A clock that has ALREADY overrun the deadline when the fallback is reached — the
+    // state the unreserved version of this code put every hung client route into.
+    now: () => (fetchCalls === 0 && h.at() >= 3000 ? 99999 : h.at()),
+  });
+  await tick();
+  h.fire();
+  const result = await settled(out, "the oracle call");
+  const note = result.failures.join(" | ");
+  assert.equal(fetchCalls, 0, "this test only means something if the route really was skipped");
+  assert.doesNotMatch(note, /GET \/object_info did not answer/, "an unsent request cannot have failed to answer");
+  assert.match(note, /GET \/object_info was not attempted/, "…it reports what actually happened instead");
 });
 
 test("#1161: the timeout is reported as a timeout, not as a throw", async () => {
@@ -375,6 +425,7 @@ test("#1161: the timeout is reported as a timeout, not as a throw", async () => 
     fetchApi: never,
     deadlineMs: 6000,
     timers: h.timers,
+    now: h.now,
   });
   await tick();
   h.fire();
@@ -386,7 +437,7 @@ test("#1161: the timeout is reported as a timeout, not as a throw", async () => 
 
 test("#1161: both transports hanging still returns, and names both", async () => {
   const h = harness();
-  const out = fetchWholeObjectInfo({ getNodeDefs: never, fetchApi: never, deadlineMs: 6000, timers: h.timers });
+  const out = fetchWholeObjectInfo({ getNodeDefs: never, fetchApi: never, deadlineMs: 6000, timers: h.timers, now: h.now });
   await tick();
   h.fire();
   await tick();
@@ -406,6 +457,7 @@ test("#1161: a hung BODY is bounded too — the response is not the body", async
     fetchApi: async () => ({ ok: true, json: never }),
     deadlineMs: 6000,
     timers: h.timers,
+    now: h.now,
   });
   await tick();
   h.fire();
@@ -421,6 +473,7 @@ test("#1161: a healthy client route is untouched by the bound", async () => {
     fetchApi: () => { throw new Error("must not be consulted"); },
     deadlineMs: 6000,
     timers: h.timers,
+    now: h.now,
   });
   assert.deepEqual(result.defs, DEFS_1161);
   assert.deepEqual(result.failures, [], "a route that answers records no failure");
@@ -481,20 +534,75 @@ test("#1161: a payload whose own shape cannot be inspected is a failure, never a
 test("#1161: the budget is shared, so three steps cannot each spend it", async () => {
   // A per-step bound multiplies: three 6s bounds is an 18s worst case nobody chose,
   // stacked on the 8s startup seed wait. One budget makes the worst case one number.
+  //
+  // But SHARING ALONE IS NOT ENOUGH, which is the correction this test now carries. A
+  // purely first-come budget lets step one take all of it, and then the fallback — the
+  // entire reason this oracle exists — is skipped rather than merely hurried. So the
+  // invariant has two halves: the total never exceeds the deadline, AND no single step can
+  // reduce a later one to nothing.
   const h = harness();
-  let clock = 0;
   const out = fetchWholeObjectInfo({
     getNodeDefs: never,
     fetchApi: never,
     deadlineMs: 6000,
     timers: h.timers,
-    now: () => clock,
+    now: h.now,
   });
   await tick();
-  clock = 6000; // the first step consumed the whole budget
+  h.fire(); // the client route hangs for everything it was given
+  await tick();
+  const budgets = h.armedMs();
+  assert.ok(budgets.length >= 2, "both transports were bounded");
+  assert.ok(budgets[0] <= 3000, "the first step may not take more than its share");
+  assert.ok(budgets[1] > 0, "the fallback is left a real budget — a zero here is the P1 back");
   h.fire();
   const result = await settled(out, "the oracle call");
   assert.equal(result.defs, null);
-  assert.equal(h.armed(), 0, "with no budget left the second step must not arm a timer at all");
-  assert.equal(result.failures.length, 2, "…and must still report for itself");
+  assert.equal(result.failures.length, 2, "each route reports for itself");
+  assert.ok(h.at() <= 6000, "and the whole question still costs no more than the one deadline");
+});
+
+test("#1161: the reserve holds when the client route hangs for its FULL share", async () => {
+  // The production shape of the P1, at the shipped constant rather than a test one: a
+  // half-open socket that never settles. The fallback must still be sent.
+  const h = harness();
+  let fetchCalls = 0;
+  const out = fetchWholeObjectInfo({
+    getNodeDefs: never,
+    fetchApi: async () => { fetchCalls += 1; return { ok: true, json: async () => DEFS_1161 }; },
+    deadlineMs: OBJECT_INFO_DEADLINE_MS,
+    timers: h.timers,
+    now: h.now,
+  });
+  await tick();
+  h.fire();
+  const result = await settled(out, "the oracle call");
+  assert.equal(fetchCalls, 1, "the shipped budget must reserve room for the fallback too");
+  assert.deepEqual(result.defs, DEFS_1161);
+});
+
+test("#1161: a status that cannot be STRINGIFIED is a failure, never a rejection", async () => {
+  // Guarding the property READ was not enough: `${responseStatus}` interpolates it below
+  // the try, and `Object.create(null)` has no toString to convert with. Proven by running
+  // this input against the previous commit, which rejected with a TypeError where two
+  // callers have no catch of their own.
+  const result = await fetchWholeObjectInfo({
+    getNodeDefs: async () => null,
+    fetchApi: async () => ({ ok: false, status: Object.create(null) }),
+  });
+  assert.equal(result.defs, null);
+  assert.match(result.failures.join(" | "), /GET \/object_info was not OK/);
+});
+
+test("#1161: a thrown value that cannot be stringified is a failure, never a rejection", async () => {
+  // describeFailure called String(err) OUTSIDE every guard, so a rejection value with a
+  // throwing toString escaped the module — the same contract break by a third entry point.
+  // The sanitizer already handled this; the defect was stringifying before reaching it.
+  const result = await fetchWholeObjectInfo({
+    getNodeDefs: async () => { throw { toString() { throw new Error("unprintable"); } }; },
+    fetchApi: async () => ({ ok: true, json: async () => DEFS_1161 }),
+  });
+  // And because it is only a FAILURE, the fallback still runs and the write is authorized.
+  assert.deepEqual(result.defs, DEFS_1161, "a hostile error value must not cost the user their answer");
+  assert.match(result.failures.join(" | "), /api\.getNodeDefs\(\) threw: \(an unprintable value\)/);
 });

--- a/browser_tests/unit/object-info-oracle.test.mjs
+++ b/browser_tests/unit/object-info-oracle.test.mjs
@@ -991,12 +991,16 @@ test("#1161: an unreadable elapsed reading charges the FULL grant, never zero", 
   );
 });
 
-test("#1161: a budget beyond the timer's range cannot silently become no bound", async () => {
-  // setTimeout coerces a delay above 2^31-1 to 1ms. An unclamped budget therefore hands
-  // every step a grant whose timer fires almost immediately — the bound inverting into no
-  // bound, which is precisely the hang this module exists to remove, reached by asking for
-  // MORE time rather than less.
-  for (const deadlineMs of [3e9, Number.MAX_SAFE_INTEGER, 2 ** 31]) {
+test("#1161: a budget beyond the timer's range takes the default, and does not park", async () => {
+  // setTimeout coerces a delay above 2^31-1 to 1ms, so an over-range budget hands every step
+  // a grant whose timer fires immediately — the bound silently becoming no bound.
+  //
+  // CLAMPING to 2^31-1 was the first fix and was worse: it turns the nonsense input into a
+  // ~24.8-day grant, so a hung client route PARKS instead of failing fast. Measured on real
+  // timers at deadlineMs 5e9, the clamped version never returned at all with fetchApi call
+  // count 0 — the canonical #1161 signature, reintroduced by a guard written to prevent it.
+  // Both halves are pinned here so neither fix can be undone in favour of the other.
+  for (const deadlineMs of [2 ** 31, 5e9, Number.MAX_SAFE_INTEGER, Infinity, NaN]) {
     const granted = [];
     let calls = 0;
     const result = await fetchWholeObjectInfo({
@@ -1007,24 +1011,42 @@ test("#1161: a budget beyond the timer's range cannot silently become no bound",
     });
     assert.equal(calls, 1, `deadlineMs=${deadlineMs}: the fallback is still issued`);
     assert.deepEqual(result.defs, DEFS_1161);
-    for (const ms of granted) {
-      assert.ok(ms <= 2 ** 31 - 1, `granted ${ms}ms, which a timer cannot express and fires at 1ms`);
-    }
-    // PIN THE BOUNDARY ITSELF. Grants alone cannot see it: at a budget of exactly 2**31 the
-    // largest grant still lands a millisecond or two under the ceiling, so setting the cap
-    // to 2**31 survived every grant assertion. The refusal quotes the budget in force, so
-    // it is the one observable that distinguishes the two.
+    assert.equal(
+      granted[0],
+      OBJECT_INFO_DEADLINE_MS / 2,
+      `deadlineMs=${deadlineMs}: an unusable budget must take the DEFAULT, not a multi-day clamp`,
+    );
+  }
+  // A hung route on an over-range budget must fail fast rather than park for days.
+  {
+    let calls = 0;
     const refused = await fetchWholeObjectInfo({
       getNodeDefs: () => new Promise(() => {}),
-      fetchApi: () => new Promise(() => {}),
-      deadlineMs,
+      fetchApi: async () => { calls += 1; return { ok: true, json: async () => DEFS_1161 }; },
+      deadlineMs: 5e9,
       timers: { setTimer: (fn) => { fn(); return {}; }, clearTimer: () => {} },
     });
+    // Timers fire immediately here, so every step times out by construction — the point is
+    // not that it answers, but that it REACHES the fallback and reports, rather than sitting
+    // on a multi-day grant with the raw route never contacted.
+    assert.equal(calls, 1, "the fallback is reached instead of the call parking");
+    assert.equal(refused.defs, null, "with every timer firing at once nothing can answer");
     assert.match(
       refused.failures.join(" | "),
-      /share of the 2147483647ms budget/,
-      "the budget in force must be exactly the largest a timer can express",
+      new RegExp(`share of the ${OBJECT_INFO_DEADLINE_MS}ms budget`),
+      "and the refusal quotes the budget actually in force, not a nine-digit one",
     );
+  }
+  // A budget AT the ceiling is expressible, so it is honoured rather than overridden.
+  {
+    const granted = [];
+    await fetchWholeObjectInfo({
+      getNodeDefs: async () => null,
+      fetchApi: async () => ({ ok: true, json: async () => DEFS_1161 }),
+      deadlineMs: 2 ** 31 - 1,
+      timers: { setTimer: (fn, ms) => { granted.push(ms); return { fn, ms }; }, clearTimer: () => {} },
+    });
+    assert.equal(granted[0], Math.floor((2 ** 31 - 1) / 2), "an expressible budget is the caller's to choose");
   }
 });
 

--- a/browser_tests/unit/object-info-oracle.test.mjs
+++ b/browser_tests/unit/object-info-oracle.test.mjs
@@ -788,3 +788,66 @@ test("#1161: outcomeKind names all four outcomes, including both Symbols", () =>
     assert.ok(kind === "not-tried" || kind === "no-answer", `a sentinel must be named, got ${kind}`);
   }
 });
+
+test("#1161: the shares are the ones documented — 10s / 5s / 5s on the shipped budget", async () => {
+  // Review found BODY_SHARE 1 -> 0.5 and FALLBACK_RESPONSE_SHARE 0.5 -> 0.4 both left the
+  // suite green: the split the module documents in three places was asserted nowhere, so
+  // the numbers a reader checks could drift from the numbers that run.
+  const granted = [];
+  await fetchWholeObjectInfo({
+    getNodeDefs: async () => null,
+    fetchApi: async () => ({ ok: true, json: async () => DEFS_1161 }),
+    deadlineMs: OBJECT_INFO_DEADLINE_MS,
+    timers: { setTimer: (fn, ms) => { granted.push(ms); return { fn, ms }; }, clearTimer: () => {} },
+  });
+  assert.deepEqual(granted, [10000, 5000, 5000], "client route, then the response and body of the fallback");
+  assert.equal(granted.reduce((a, b) => a + b, 0), OBJECT_INFO_DEADLINE_MS, "and they are exactly the budget");
+});
+
+test("#1161: a refusal quotes the budget in force, not the argument it was given", async () => {
+  // Reverting the three failure strings from `${budget}` to `${deadlineMs}` survived the
+  // whole suite. It matters because the two now DIFFER: a value that cannot be a budget is
+  // replaced by the default, and a refusal saying "within its 10000ms share of the
+  // Infinityms budget" states something that was never true.
+  const result = await fetchWholeObjectInfo({
+    getNodeDefs: () => new Promise(() => {}),
+    fetchApi: () => new Promise(() => {}),
+    deadlineMs: Infinity,
+    timers: { setTimer: (fn) => { fn(); return {}; }, clearTimer: () => {} },
+  });
+  const note = result.failures.join(" | ");
+  assert.match(note, new RegExp(`share of the ${OBJECT_INFO_DEADLINE_MS}ms budget`), "the budget actually in force");
+  assert.doesNotMatch(note, /Infinity/, "never the uninterpretable argument");
+});
+
+test("#1161: a tiny budget still ISSUES the fallback rather than attempting nothing", async () => {
+  // `Math.floor(left * share)` truncates to 0 on a small budget, and a zero grant is not a
+  // short wait — it is the step never being attempted. Verified before the fix: deadlineMs
+  // of 1 or 2 gave fetchApi call count 0, the exact signature this change exists to remove.
+  for (const deadlineMs of [2, 3, 5, 50]) {
+    let calls = 0;
+    await fetchWholeObjectInfo({
+      getNodeDefs: async () => null,
+      fetchApi: async () => { calls += 1; return { ok: true, json: async () => DEFS_1161 }; },
+      deadlineMs,
+    });
+    assert.equal(calls, 1, `deadlineMs=${deadlineMs}: the fallback must still be issued`);
+  }
+  // At 1ms there is genuinely nothing to divide across three steps. It must still fail
+  // CLOSED and, critically, must not claim a budget was "already spent" when none was.
+  const one = await fetchWholeObjectInfo({ getNodeDefs: async () => null, fetchApi: async () => ({ ok: true }), deadlineMs: 1 });
+  assert.equal(one.defs, null);
+  assert.doesNotMatch(one.failures.join(" | "), /already spent/, "nothing had been spent when the first step ran");
+});
+
+test("#1161: an explicitly NULL timers object is not a rejection", async () => {
+  // `timers: null` is not `timers: undefined`, and only the latter reaches withTimeout's own
+  // default — an explicit null read `.setTimer` off null and rejected out of a module whose
+  // header promises every failure path returns `defs: null`, to callers with no catch.
+  const result = await fetchWholeObjectInfo({
+    getNodeDefs: async () => null,
+    fetchApi: async () => ({ ok: true, json: async () => DEFS_1161 }),
+    timers: null,
+  });
+  assert.deepEqual(result.defs, DEFS_1161);
+});

--- a/browser_tests/unit/object-info-oracle.test.mjs
+++ b/browser_tests/unit/object-info-oracle.test.mjs
@@ -396,24 +396,38 @@ test("#1161: no route is ever REPORTED as timing out when it was never sent", as
   // #982's original defect was a refusal naming a cause it had not established. A step
   // reached with no budget left must say so in its own words rather than borrow the
   // timeout's, or the fix reintroduces the bug it was written to remove.
-  const h = harness();
+  // A zero budget is the one input that still reaches this branch, now that the floor
+  // makes a hung client route unable to starve the fallback. It is a REAL path — the
+  // caller injects the budget — and it pins the wording for whatever else reaches it.
   let fetchCalls = 0;
-  const out = fetchWholeObjectInfo({
+  const result = await fetchWholeObjectInfo({
     getNodeDefs: never,
     fetchApi: async () => { fetchCalls += 1; return { ok: true, json: async () => DEFS_1161 }; },
-    deadlineMs: 6000,
-    timers: h.timers,
-    // A clock that has ALREADY overrun the deadline when the fallback is reached — the
-    // state the unreserved version of this code put every hung client route into.
-    now: () => (fetchCalls === 0 && h.at() >= 3000 ? 99999 : h.at()),
+    deadlineMs: 0,
   });
-  await tick();
-  h.fire();
-  const result = await settled(out, "the oracle call");
   const note = result.failures.join(" | ");
   assert.equal(fetchCalls, 0, "this test only means something if the route really was skipped");
-  assert.doesNotMatch(note, /GET \/object_info did not answer/, "an unsent request cannot have failed to answer");
+  assert.equal(result.defs, null, "and nothing unasked-for is authorized");
+  assert.doesNotMatch(note, /did not answer within/, "an unsent request cannot have failed to answer");
   assert.match(note, /GET \/object_info was not attempted/, "…it reports what actually happened instead");
+  assert.match(note, /api\.getNodeDefs\(\) was not attempted/, "both routes speak for themselves");
+});
+
+test("#1161: the fallback's budget is a FLOOR, not merely what the first step left over", async () => {
+  // Subtracting a reserve makes the fallback depend on the client route finishing on time.
+  // Measured: at small deadlines the per-step overhead alone overran the subtraction and
+  // the fallback was skipped again — the exact defect being fixed, back by another door.
+  // Taking the max() instead makes the guarantee independent of the first step entirely.
+  for (const deadlineMs of [5, 10, 50, 200]) {
+    let fetchCalls = 0;
+    const result = await fetchWholeObjectInfo({
+      getNodeDefs: never,
+      fetchApi: async () => { fetchCalls += 1; return { ok: true, json: async () => DEFS_1161 }; },
+      deadlineMs,
+    });
+    assert.equal(fetchCalls, 1, `deadlineMs=${deadlineMs}: the fallback must still be issued`);
+    assert.deepEqual(result.defs, DEFS_1161, `deadlineMs=${deadlineMs}: and its answer used`);
+  }
 });
 
 test("#1161: the timeout is reported as a timeout, not as a throw", async () => {

--- a/browser_tests/unit/object-info-oracle.test.mjs
+++ b/browser_tests/unit/object-info-oracle.test.mjs
@@ -29,6 +29,8 @@ import {
   objectInfoOracleFailureNote,
   // The SHIPPED budget, so a test cannot pass against a value the panel does not use.
   OBJECT_INFO_DEADLINE_MS,
+  outcomeKind,
+  TRANSPORT_SENTINELS,
 } from "../../web/js/lib/object-info-oracle.js";
 
 const SCHEMA = { KSampler: { input: {} }, VAELoader: { input: {} } };
@@ -691,78 +693,98 @@ test("#1161: a timer that fires LATE cannot starve the fallback", async () => {
   }
 });
 
-test("#1161: no clock behaviour can make the granted total exceed the deadline", async () => {
-  // Date.now is this module's default clock and it steps backwards for ordinary reasons:
-  // an NTP correction, a manual or DST change, a VM suspend/resume. The first attempt at
-  // this clamped each negative READING to zero, which silently refunded everything already
-  // spent — measured at -60s against a 20000ms deadline, one call ran to wall t=49900ms,
-  // past the bridge's 30s command timeout, which is the symptom this oracle replaces.
+test("#1161: the budget is divided WITHOUT consulting a clock at all", async () => {
+  // The structural version of an invariant that three previous designs asserted in prose
+  // and none actually held. Each of those tried to make an untrustworthy `Date.now()` safe:
+  // clamping negative readings refunded everything spent (one call ran ~50s against a 20s
+  // deadline); a high-water ratchet only sampled at step boundaries, and its test passed
+  // with AND without it; charging measured elapsed let a stalled clock refund real time.
   //
-  // A high-water ratchet was tried next and is ALSO not enough: it only samples at step
-  // boundaries, so a jump between two samples still refunds, and a test for it passes with
-  // or without the ratchet — which is how the second attempt was caught.
+  // A clock that THROWS proves the property that replaced them. If this resolves, the
+  // accounting provably never read it — no reasoning required, and no future edit can
+  // reintroduce a clock read without failing here.
+  const exploding = () => { throw new Error("the clock is not to be trusted"); };
+  const granted = [];
+  const result = await fetchWholeObjectInfo({
+    getNodeDefs: async () => null,
+    fetchApi: async () => ({ ok: true, json: async () => DEFS_1161 }),
+    deadlineMs: 20000,
+    now: exploding,
+    timers: { setTimer: (fn, ms) => { granted.push(ms); return { fn, ms }; }, clearTimer: () => {} },
+  });
+  assert.deepEqual(result.defs, DEFS_1161, "a hostile clock cannot cost the user their answer");
+  assert.ok(
+    granted.reduce((a, b) => a + b, 0) <= 20000,
+    `granted ${granted.join("+")}ms against a 20000ms budget`,
+  );
+});
+
+test("#1161: every step is reserved a real share, so none can be starved", async () => {
+  // The property that REPLACED the starvation branch. Reserving for the fallback but not
+  // for its BODY was the same defect one level down: a response that used everything left
+  // the body unreadable, and a body that cannot be read authorizes nothing.
+  const granted = [];
+  const result = await fetchWholeObjectInfo({
+    getNodeDefs: async () => null,
+    fetchApi: async () => ({ ok: true, json: async () => DEFS_1161 }),
+    deadlineMs: 20000,
+    timers: { setTimer: (fn, ms) => { granted.push(ms); return { fn, ms }; }, clearTimer: () => {} },
+  });
+  assert.deepEqual(result.defs, DEFS_1161);
+  assert.equal(granted.length, 3, "client route, response and body are each bounded");
+  for (const [i, ms] of granted.entries()) {
+    assert.ok(ms > 0, `step ${i} was granted ${ms}ms — a zero grant is a starved step`);
+  }
+  assert.ok(granted.reduce((a, b) => a + b, 0) <= 20000, "and the shares sum to one budget");
+});
+
+test("#1161: a non-finite budget cannot poison the arithmetic", async () => {
+  // `deadlineMs: Infinity` made `consumed` infinite, `budget - consumed` NaN, and every
+  // later grant NaN — and `Math.max(0, NaN)` is NaN rather than 0, so the fallback was
+  // SKIPPED ENTIRELY (call count 0) on an input the unbounded original handled fine.
   //
-  // So the property under test is not about the clock at all. A step cannot outlast the
-  // grant its TIMER enforces, so bounding the SUM OF GRANTS bounds the call in real time
-  // whatever now() reports. That is what this asserts, under a clock behaving as badly as
-  // it can: backwards, stalled, and jumping forward.
-  for (const clocks of [
-    [0, -60_000, -120_000, -180_000],
-    [0, 0, 0, 0],
-    [0, 5_000_000, -5_000_000, 0],
-    [0, NaN, 1000, NaN],
-  ]) {
-    const armed = [];
-    // REAL time, not granted time: a step that HANGS costs exactly the grant its timer
-    // enforces, and a step that answers early costs nothing. Summing grants instead would
-    // charge for time a fast step handed back, and pass or fail for the wrong reason.
-    let elapsedReal = 0;
-    const timers = {
-      setTimer: (fn, ms) => { const t = { fn, ms }; armed.push(t); return t; },
-      clearTimer: (t) => { const i = armed.indexOf(t); if (i >= 0) armed.splice(i, 1); },
-    };
-    let step = 0;
-    const out = fetchWholeObjectInfo({
-      getNodeDefs: never,
-      fetchApi: async () => ({ ok: true, json: never }),
-      deadlineMs: 6000,
-      timers,
-      now: () => clocks[Math.min(step, clocks.length - 1)],
+  // The first fix normalised such a budget to zero, which merely relocated the damage: the
+  // oracle then attempted nothing at all. A value that cannot be a budget takes the shipped
+  // default instead, so a caller passing garbage still gets a working oracle.
+  for (const deadlineMs of [Infinity, -Infinity, NaN, undefined]) {
+    let calls = 0;
+    const result = await fetchWholeObjectInfo({
+      getNodeDefs: async () => null,
+      fetchApi: async () => { calls += 1; return { ok: true, json: async () => DEFS_1161 }; },
+      deadlineMs,
     });
-    for (let i = 0; i < 8; i++) {
-      await tick();
-      const t = armed.shift();
-      if (!t) continue; // the step answered on its own; its timer was cleared
-      step += 1;
-      elapsedReal += t.ms; // it hung for exactly as long as it was allowed to
-      t.fn();
-    }
-    const result = await settled(out, `the oracle call (${clocks.join(",")})`);
-    assert.equal(result.defs, null, "nothing answered, so nothing is authorized");
-    assert.ok(
-      elapsedReal <= 6000,
-      `ran ${elapsedReal}ms against a 6000ms deadline under clock ${clocks.join(",")} — the budget was refunded`,
-    );
+    assert.equal(calls, 1, `deadlineMs=${String(deadlineMs)}: the fallback must still be ISSUED`);
+    assert.deepEqual(result.defs, DEFS_1161, `deadlineMs=${String(deadlineMs)}: and answer`);
+  }
+  // An explicit non-positive NUMBER is a real choice, and is obeyed rather than overridden.
+  for (const deadlineMs of [0, -1]) {
+    let calls = 0;
+    const result = await fetchWholeObjectInfo({
+      getNodeDefs: async () => null,
+      fetchApi: async () => { calls += 1; return { ok: true, json: async () => DEFS_1161 }; },
+      deadlineMs,
+    });
+    assert.equal(calls, 0, `deadlineMs=${deadlineMs}: nothing may be attempted`);
+    assert.equal(result.defs, null, "…and nothing is authorized");
+    assert.match(result.failures.join(" | "), /was not attempted/, "…and it says so plainly");
   }
 });
 
-test("#1161: the BODY's not-attempted branch is real, and reports rather than throwing", async () => {
-  // The one NOT_TRIED branch no test reached: a response that lands exactly as the
-  // fallback's end time arrives leaves the body with nothing. Deleting this branch left
-  // the whole suite green, and without it the Symbol reaches the `in` test and rejects out
-  // of a module two callers await with no catch of their own.
-  let clock = 0;
-  const result = await fetchWholeObjectInfo({
-    getNodeDefs: async () => null,
-    // Answering consumes the whole fallback window, so the body step has none left.
-    fetchApi: async () => { clock = 6000; return { ok: true, json: async () => DEFS_1161 }; },
-    deadlineMs: 6000,
-    now: () => clock,
-  });
-  assert.equal(result.defs, null, "no budget to read the body means no authorization — fail closed");
-  assert.match(
-    result.failures.join(" | "),
-    /GET \/object_info answered but its body was not read/,
-    "and it says the body was not read, rather than claiming the route did not answer",
-  );
+test("#1161: outcomeKind names all four outcomes, including both Symbols", () => {
+  // The share-based budget makes "not-tried" unreachable through the public function on a
+  // usable budget — every step is reserved a share, so none can be starved to a zero grant.
+  // The branch is still live code, and an untested branch here does not misbehave quietly:
+  // `"err" in outcome` on a Symbol is a TypeError out of a module documented to always
+  // resolve, which two callers await with no catch. That bug shipped once during this issue
+  // when a patch replaced a branch instead of adding beside it, so the demux is pinned here
+  // directly rather than through a path that can stop reaching it.
+  assert.equal(outcomeKind({ err: new Error("boom") }), "threw");
+  assert.equal(outcomeKind({ value: { KSampler: {} } }), "value");
+  assert.equal(outcomeKind({ value: undefined }), "value", "an undefined payload is still an answer");
+  assert.equal(outcomeKind({ err: undefined }), "threw", "presence of `err`, not its truthiness");
+  // Both sentinels are Symbols, and neither may reach the `in` test.
+  for (const sentinel of TRANSPORT_SENTINELS) {
+    const kind = outcomeKind(sentinel);
+    assert.ok(kind === "not-tried" || kind === "no-answer", `a sentinel must be named, got ${kind}`);
+  }
 });

--- a/browser_tests/unit/object-info-oracle.test.mjs
+++ b/browser_tests/unit/object-info-oracle.test.mjs
@@ -758,7 +758,10 @@ test("#1161: a hung route is CAPPED at its share; a fast one hands the rest back
   assert.equal(fast.length, 3, "client route, response and body are each bounded");
   assert.equal(fast[0], 10000, "the cap on the client route is unchanged");
   assert.ok(fast[1] > 9000, `the response kept ${fast[1]}ms the client route did not use`);
-  assert.ok(fast[2] > 9000, `and the body kept ${fast[2]}ms — main gave it ~19.5s, not 5s`);
+  // Bound tightly enough to SEE the share: with BODY_SHARE at 1 the body keeps what the
+  // response left (~20s); at 0.5 it would keep ~10s, which a looser bound accepted — that
+  // mutation survived the suite until this assertion was tightened.
+  assert.ok(fast[2] > 15000, `the body kept ${fast[2]}ms — main gave it ~19.5s, not 5s or 10s`);
   for (const [i, ms] of fast.entries()) assert.ok(ms > 0, `step ${i} was granted ${ms}ms`);
 });
 
@@ -913,4 +916,20 @@ test("#1161: a forward clock jump during a step cannot starve the steps after it
   });
   assert.equal(calls, 1, "the fallback must still be issued — a step cannot spend more than it was granted");
   assert.deepEqual(result.defs, DEFS_1161);
+});
+
+test("#1161: a clock returning a non-number cannot reject out of this module", async () => {
+  // Guarding the clock CALL was not enough: `readClock() - startedStep` is its own
+  // operation, and it throws for a Symbol ("Cannot convert a Symbol value to a number") and
+  // for a null-prototype object. This is the third time in this issue a guarded read was
+  // undone by an unguarded use of the same value, after `${responseStatus}` and
+  // `String(err)` — so the reading is normalised at the source instead.
+  for (const now of [() => Symbol("t"), () => Object.create(null), () => 1n, () => "later", () => ({}), () => null]) {
+    const result = await fetchWholeObjectInfo({
+      getNodeDefs: async () => null,
+      fetchApi: async () => ({ ok: true, json: async () => DEFS_1161 }),
+      now,
+    });
+    assert.deepEqual(result.defs, DEFS_1161, `now returning ${String(typeof now())} must not cost the answer`);
+  }
 });

--- a/browser_tests/unit/object-info-oracle.test.mjs
+++ b/browser_tests/unit/object-info-oracle.test.mjs
@@ -693,7 +693,7 @@ test("#1161: a timer that fires LATE cannot starve the fallback", async () => {
   }
 });
 
-test("#1161: the budget is divided WITHOUT consulting a clock at all", async () => {
+test("#1161: an injected clock that THROWS cannot reject out of this module", async () => {
   // The structural version of an invariant that three previous designs asserted in prose
   // and none actually held. Each of those tried to make an untrustworthy `Date.now()` safe:
   // clamping negative readings refunded everything spent (one call ran ~50s against a 20s
@@ -719,23 +719,81 @@ test("#1161: the budget is divided WITHOUT consulting a clock at all", async () 
   );
 });
 
-test("#1161: every step is reserved a real share, so none can be starved", async () => {
-  // The property that REPLACED the starvation branch. Reserving for the fallback but not
-  // for its BODY was the same defect one level down: a response that used everything left
-  // the body unreadable, and a body that cannot be read authorizes nothing.
+test("#1161: a hung route is CAPPED at its share; a fast one hands the rest back", async () => {
+  // BOTH halves matter, and each was broken on its own during this issue.
+  //
+  // The CAP stops a hung client route consuming the budget and starving the fallback — the
+  // original P1, fetchApi call count 0. The RECLAIM stops a client route that answers
+  // instantly from spending 10s it never used: charging the full grant there was a shipped
+  // regression that refused a 5.4MB payload at 5.5s which both the parent and main
+  // delivered at 7.5s.
   const granted = [];
-  const result = await fetchWholeObjectInfo({
+  const armed = [];
+  const timers = {
+    setTimer: (fn, ms) => { granted.push(ms); const t = { fn, ms }; armed.push(t); return t; },
+    clearTimer: (t) => { const i = armed.indexOf(t); if (i >= 0) armed.splice(i, 1); },
+  };
+  const out = fetchWholeObjectInfo({
+    getNodeDefs: never,
+    fetchApi: async () => ({ ok: true, json: async () => DEFS_1161 }),
+    deadlineMs: OBJECT_INFO_DEADLINE_MS,
+    timers,
+  });
+  await tick();
+  armed.shift().fn(); // only the CLIENT route hangs; the fallback answers normally
+  const result = await settled(out, "the oracle call");
+  assert.deepEqual(result.defs, DEFS_1161, "the fallback still answers after the cap fires");
+  assert.equal(granted[0], 10000, "the client route is capped at its half — this is the P1 fix");
+  assert.ok(granted[1] <= 10000, `the fallback got ${granted[1]}ms, which cannot exceed what was left`);
+  assert.ok(granted[1] > 0, "and it is a real budget, not a token one");
+
+  // Now the reclaim: a client route that answers immediately must cost almost nothing.
+  const fast = [];
+  await fetchWholeObjectInfo({
     getNodeDefs: async () => null,
     fetchApi: async () => ({ ok: true, json: async () => DEFS_1161 }),
-    deadlineMs: 20000,
-    timers: { setTimer: (fn, ms) => { granted.push(ms); return { fn, ms }; }, clearTimer: () => {} },
+    deadlineMs: OBJECT_INFO_DEADLINE_MS,
+    timers: { setTimer: (fn, ms) => { fast.push(ms); return { fn, ms }; }, clearTimer: () => {} },
   });
-  assert.deepEqual(result.defs, DEFS_1161);
-  assert.equal(granted.length, 3, "client route, response and body are each bounded");
-  for (const [i, ms] of granted.entries()) {
-    assert.ok(ms > 0, `step ${i} was granted ${ms}ms — a zero grant is a starved step`);
+  assert.equal(fast.length, 3, "client route, response and body are each bounded");
+  assert.equal(fast[0], 10000, "the cap on the client route is unchanged");
+  assert.ok(fast[1] > 9000, `the response kept ${fast[1]}ms the client route did not use`);
+  assert.ok(fast[2] > 9000, `and the body kept ${fast[2]}ms — main gave it ~19.5s, not 5s`);
+  for (const [i, ms] of fast.entries()) assert.ok(ms > 0, `step ${i} was granted ${ms}ms`);
+});
+
+test("#1161: REAL elapsed stays inside the budget however the steps behave", async () => {
+  // The invariant is about real time, NOT about the sum of grants — a step that answers
+  // early hands its remainder back, so later grants can legitimately exceed what is
+  // nominally "left". What must never happen is the CALL outlasting its budget, which is
+  // what overran to 49,998ms while a clock was being trusted to say otherwise.
+  const armed = [];
+  let elapsedReal = 0;
+  const timers = {
+    setTimer: (fn, ms) => { const t = { fn, ms }; armed.push(t); return t; },
+    clearTimer: (t) => { const i = armed.indexOf(t); if (i >= 0) armed.splice(i, 1); },
+  };
+  const out = fetchWholeObjectInfo({
+    getNodeDefs: never,
+    fetchApi: async () => ({ ok: true, json: never }),
+    deadlineMs: OBJECT_INFO_DEADLINE_MS,
+    timers,
+    // A clock frozen at a constant — the reading that broke the previous two designs.
+    now: () => 0,
+  });
+  for (let i = 0; i < 8; i++) {
+    await tick();
+    const t = armed.shift();
+    if (!t) continue;
+    elapsedReal += t.ms; // a step that hangs costs exactly the grant its timer enforces
+    t.fn();
   }
-  assert.ok(granted.reduce((a, b) => a + b, 0) <= 20000, "and the shares sum to one budget");
+  const result = await settled(out, "the oracle call");
+  assert.equal(result.defs, null, "nothing answered, so nothing is authorized");
+  assert.ok(
+    elapsedReal <= OBJECT_INFO_DEADLINE_MS,
+    `ran ${elapsedReal}ms against a ${OBJECT_INFO_DEADLINE_MS}ms budget on a frozen clock`,
+  );
 });
 
 test("#1161: a non-finite budget cannot poison the arithmetic", async () => {
@@ -789,21 +847,6 @@ test("#1161: outcomeKind names all four outcomes, including both Symbols", () =>
   }
 });
 
-test("#1161: the shares are the ones documented — 10s / 5s / 5s on the shipped budget", async () => {
-  // Review found BODY_SHARE 1 -> 0.5 and FALLBACK_RESPONSE_SHARE 0.5 -> 0.4 both left the
-  // suite green: the split the module documents in three places was asserted nowhere, so
-  // the numbers a reader checks could drift from the numbers that run.
-  const granted = [];
-  await fetchWholeObjectInfo({
-    getNodeDefs: async () => null,
-    fetchApi: async () => ({ ok: true, json: async () => DEFS_1161 }),
-    deadlineMs: OBJECT_INFO_DEADLINE_MS,
-    timers: { setTimer: (fn, ms) => { granted.push(ms); return { fn, ms }; }, clearTimer: () => {} },
-  });
-  assert.deepEqual(granted, [10000, 5000, 5000], "client route, then the response and body of the fallback");
-  assert.equal(granted.reduce((a, b) => a + b, 0), OBJECT_INFO_DEADLINE_MS, "and they are exactly the budget");
-});
-
 test("#1161: a refusal quotes the budget in force, not the argument it was given", async () => {
   // Reverting the three failure strings from `${budget}` to `${deadlineMs}` survived the
   // whole suite. It matters because the two now DIFFER: a value that cannot be a budget is
@@ -849,5 +892,25 @@ test("#1161: an explicitly NULL timers object is not a rejection", async () => {
     fetchApi: async () => ({ ok: true, json: async () => DEFS_1161 }),
     timers: null,
   });
+  assert.deepEqual(result.defs, DEFS_1161);
+});
+
+test("#1161: a forward clock jump during a step cannot starve the steps after it", async () => {
+  // The reclaim charges what a step actually used, which means a clock that leaps FORWARD
+  // mid-step reports a spend far larger than the grant that step was even allowed. Without
+  // clamping to the grant, that overcharge exhausts the budget and the fallback is skipped
+  // — the fetchApi-call-count-0 signature again, arriving through the reclaim rather than
+  // through the cap. `performance.now()` should never do this, but `now` is injectable and
+  // the Date.now fallback exists, so the clamp is what makes the direction safe.
+  let calls = 0;
+  let reading = 0;
+  const result = await fetchWholeObjectInfo({
+    // Answers immediately, but the clock leaps a billion ms while it does.
+    getNodeDefs: async () => { reading = 1e9; return null; },
+    fetchApi: async () => { calls += 1; return { ok: true, json: async () => DEFS_1161 }; },
+    deadlineMs: 20000,
+    now: () => reading,
+  });
+  assert.equal(calls, 1, "the fallback must still be issued — a step cannot spend more than it was granted");
   assert.deepEqual(result.defs, DEFS_1161);
 });

--- a/browser_tests/unit/object-info-oracle.test.mjs
+++ b/browser_tests/unit/object-info-oracle.test.mjs
@@ -961,3 +961,25 @@ test("#1161: an unreadable elapsed reading charges the FULL grant, never zero", 
     "unmeasurable elapsed must fall back to the whole grant, not to nothing",
   );
 });
+
+test("#1161: a budget beyond the timer's range cannot silently become no bound", async () => {
+  // setTimeout coerces a delay above 2^31-1 to 1ms. An unclamped budget therefore hands
+  // every step a grant whose timer fires almost immediately — the bound inverting into no
+  // bound, which is precisely the hang this module exists to remove, reached by asking for
+  // MORE time rather than less.
+  for (const deadlineMs of [3e9, Number.MAX_SAFE_INTEGER, 2 ** 31]) {
+    const granted = [];
+    let calls = 0;
+    const result = await fetchWholeObjectInfo({
+      getNodeDefs: async () => null,
+      fetchApi: async () => { calls += 1; return { ok: true, json: async () => DEFS_1161 }; },
+      deadlineMs,
+      timers: { setTimer: (fn, ms) => { granted.push(ms); return { fn, ms }; }, clearTimer: () => {} },
+    });
+    assert.equal(calls, 1, `deadlineMs=${deadlineMs}: the fallback is still issued`);
+    assert.deepEqual(result.defs, DEFS_1161);
+    for (const ms of granted) {
+      assert.ok(ms <= 2 ** 31 - 1, `granted ${ms}ms, which a timer cannot express and fires at 1ms`);
+    }
+  }
+});

--- a/browser_tests/unit/object-info-oracle.test.mjs
+++ b/browser_tests/unit/object-info-oracle.test.mjs
@@ -653,3 +653,40 @@ test("#1161: a refusal quotes the budget the step ACTUALLY got, not the whole de
   assert.match(client, /within its 3000ms share of the 6000ms budget/, "half the deadline, said plainly");
   assert.doesNotMatch(client, /within the 6000ms budget/, "the un-spent whole must not be quoted as the wait");
 });
+
+test("#1161: a timer that fires LATE cannot starve the fallback", async () => {
+  // Chrome clamps hidden-tab timers to ~1/min after five minutes backgrounded; laptop
+  // sleep/resume and an NTP forward jump do the same. `spent()` clamps a BACKWARD jump but
+  // must not clamp a forward one — that would be lying about elapsed time — so the timer
+  // can fire long after its bound and leave the deadline already overrun.
+  //
+  // Under a subtracted reserve that produced fetchApi call count 0: the P1 exactly, in a
+  // tab that was merely in the background. The floor is what makes it survivable, because
+  // the fallback's budget stops depending on when the first step finished.
+  for (const lateBy of [0, 10_000, 60_000, 600_000]) {
+    const pending = [];
+    let clock = 0;
+    const timers = {
+      setTimer: (fn, ms) => { const t = { fn, ms }; pending.push(t); return t; },
+      clearTimer: (t) => { const i = pending.indexOf(t); if (i >= 0) pending.splice(i, 1); },
+    };
+    let calls = 0;
+    const out = fetchWholeObjectInfo({
+      getNodeDefs: never,
+      fetchApi: async () => { calls += 1; return { ok: true, json: async () => DEFS_1161 }; },
+      deadlineMs: OBJECT_INFO_DEADLINE_MS,
+      timers,
+      now: () => clock,
+    });
+    for (let i = 0; i < 8 && pending.length; i++) {
+      await tick();
+      const t = pending.shift();
+      if (!t) break;
+      clock += t.ms + lateBy; // the timer fires late, and the clock says so
+      t.fn();
+    }
+    const result = await settled(out, `the oracle call (lateBy=${lateBy})`);
+    assert.equal(calls, 1, `lateBy=${lateBy}: the fallback must still be issued`);
+    assert.deepEqual(result.defs, DEFS_1161, `lateBy=${lateBy}: and its answer used`);
+  }
+});

--- a/browser_tests/unit/object-info-oracle.test.mjs
+++ b/browser_tests/unit/object-info-oracle.test.mjs
@@ -389,7 +389,7 @@ test("#1161: a hung client route falls through to the fallback, which ANSWERS", 
   // assertion alone cannot see that; a call count can.
   assert.equal(fetchCalls, 1, "the fallback must be ISSUED — a reserved floor is what guarantees it");
   assert.deepEqual(result.defs, DEFS_1161, "the fallback answered, so the caller is authorized");
-  assert.match(result.failures.join(" | "), /api\.getNodeDefs\(\) did not answer within the 6000ms budget/);
+  assert.match(result.failures.join(" | "), /api\.getNodeDefs\(\) did not answer within its \d+ms share of the 6000ms budget/);
 });
 
 test("#1161: no route is ever REPORTED as timing out when it was never sent", async () => {
@@ -446,7 +446,7 @@ test("#1161: the timeout is reported as a timeout, not as a throw", async () => 
   const result = await settled(out, "the oracle call");
   const note = result.failures.join(" | ");
   assert.match(note, /api\.getNodeDefs\(\) threw: client exploded/, "a throw keeps its own cause");
-  assert.match(note, /GET \/object_info did not answer within the 6000ms budget/, "…and a hang keeps its own");
+  assert.match(note, /GET \/object_info did not answer within its \d+ms share of the 6000ms budget/, "…and a hang keeps its own");
 });
 
 test("#1161: both transports hanging still returns, and names both", async () => {
@@ -459,7 +459,7 @@ test("#1161: both transports hanging still returns, and names both", async () =>
   const result = await settled(out, "the oracle call");
   assert.equal(result.defs, null, "nothing answered, so nothing is authorized — still fail-closed");
   assert.equal(result.failures.length, 2, "each route reports for itself");
-  for (const f of result.failures) assert.match(f, /did not answer within the 6000ms budget/);
+  for (const f of result.failures) assert.match(f, /did not answer within its \d+ms share of the 6000ms budget/);
 });
 
 test("#1161: a hung BODY is bounded too — the response is not the body", async () => {
@@ -477,7 +477,7 @@ test("#1161: a hung BODY is bounded too — the response is not the body", async
   h.fire();
   const result = await settled(out, "the oracle call");
   assert.equal(result.defs, null);
-  assert.match(result.failures.join(" | "), /body did not arrive within the 6000ms budget/);
+  assert.match(result.failures.join(" | "), /body did not arrive within its \d+ms share of the 6000ms budget/);
 });
 
 test("#1161: a healthy client route is untouched by the bound", async () => {
@@ -619,4 +619,28 @@ test("#1161: a thrown value that cannot be stringified is a failure, never a rej
   // And because it is only a FAILURE, the fallback still runs and the write is authorized.
   assert.deepEqual(result.defs, DEFS_1161, "a hostile error value must not cost the user their answer");
   assert.match(result.failures.join(" | "), /api\.getNodeDefs\(\) threw: \(an unprintable value\)/);
+});
+
+test("#1161: a refusal quotes the budget the step ACTUALLY got, not the whole deadline", async () => {
+  // Browser-verified against a live 4304-type install: the client route is capped at half
+  // the deadline, but the message quoted the deadline — telling the reader it had waited
+  // 20000ms when it had waited 10000ms. Naming a number that was never spent is the same
+  // defect as #982's "unreachable or the fetch failed": a refusal asserting what it did
+  // not establish. Both numbers appear, so the share and the whole are each readable.
+  const h = harness();
+  const out = fetchWholeObjectInfo({
+    getNodeDefs: never,
+    fetchApi: never,
+    deadlineMs: 6000,
+    timers: h.timers,
+    now: h.now,
+  });
+  await tick();
+  h.fire();
+  await tick();
+  h.fire();
+  const result = await settled(out, "the oracle call");
+  const client = result.failures.find((f) => f.startsWith("api.getNodeDefs()"));
+  assert.match(client, /within its 3000ms share of the 6000ms budget/, "half the deadline, said plainly");
+  assert.doesNotMatch(client, /within the 6000ms budget/, "the un-spent whole must not be quoted as the wait");
 });

--- a/browser_tests/unit/object-info-oracle.test.mjs
+++ b/browser_tests/unit/object-info-oracle.test.mjs
@@ -499,11 +499,20 @@ test("#1161: the SHIPPED budget is a real bound, sized for the payload not a pin
   // shipped constant being set to 0 — which disables the bound entirely by withTimeout's
   // contract and reinstates the P1 with a green suite. Review caught that gap twice.
   assert.ok(OBJECT_INFO_DEADLINE_MS > 0, "a non-positive budget disables the bound");
-  // The bounded work is a ~5.4MB download, measured at ~14.5s in this repo (#610) — not
-  // the ~167ms LAN response an earlier version of this bound was mistakenly sized from.
+  // WHAT THE MEASUREMENT IS. The bounded work is one GET of the whole document: 5,413,770
+  // bytes / 167ms on a 63-pack install (#767), cited independently in object-info-cache.js
+  // and single-node-def.js, and measured live at ~450ms on a 4304-type install. The ~14.5s
+  // figure from #610 measures "/object_info + combo refresh" — the download PLUS
+  // registerNodesFromDefs plus rebuilding every combo widget — which this oracle does not
+  // do. An earlier revision of this file asserted 14.5s here as the download time, and
+  // three review rounds then cited that assertion back as the repo's measurement.
+  //
+  // So the floor is set against the real figure with room to spare: the smallest share any
+  // single step gets is half the deadline, which must still clear the measured download by
+  // a wide margin rather than merely exceed it.
   assert.ok(
-    OBJECT_INFO_DEADLINE_MS >= 15000,
-    "below the measured payload time this refuses ordinary installs, and pays for a second download doing it",
+    OBJECT_INFO_DEADLINE_MS / 2 >= 5000,
+    "a step's own share must clear the ~167ms measured download by a wide margin, not merely exceed it",
   );
   // …and it must still land inside the bridge's 30s command timeout, so the caller sees
   // this oracle's own answer rather than a bare timeout with no routes named.

--- a/browser_tests/unit/object-info-oracle.test.mjs
+++ b/browser_tests/unit/object-info-oracle.test.mjs
@@ -700,9 +700,10 @@ test("#1161: an injected clock that THROWS cannot reject out of this module", as
   // deadline); a high-water ratchet only sampled at step boundaries, and its test passed
   // with AND without it; charging measured elapsed let a stalled clock refund real time.
   //
-  // A clock that THROWS proves the property that replaced them. If this resolves, the
-  // accounting provably never read it — no reasoning required, and no future edit can
-  // reintroduce a clock read without failing here.
+  // A clock that THROWS must not cost the caller their answer. The accounting DOES read a
+  // clock now — on `performance.now()`, which is monotonic — but `now` is an injected seam,
+  // and this module's header promises every failure path returns `defs: null` to two
+  // callers that await it with no catch of their own.
   const exploding = () => { throw new Error("the clock is not to be trusted"); };
   const granted = [];
   const result = await fetchWholeObjectInfo({
@@ -932,4 +933,31 @@ test("#1161: a clock returning a non-number cannot reject out of this module", a
     });
     assert.deepEqual(result.defs, DEFS_1161, `now returning ${String(typeof now())} must not cost the answer`);
   }
+});
+
+test("#1161: the DEFAULT clock is the monotonic one — the property everything rests on", () => {
+  // Nothing pinned this: swapping the default to Date.now left the whole suite green, while
+  // being the single choice the current design depends on. Every scenario that broke the
+  // three earlier clock-based designs — an NTP step, a DST or manual change, a VM
+  // suspend/resume, a frozen reading — is a WALL-CLOCK hazard specifically.
+  //
+  // A source guard, in the idiom this suite already uses for the #982 refusal wording,
+  // because the choice is a default the tests otherwise always override.
+  const src = readFileSync(new URL("../../web/js/lib/object-info-oracle.js", import.meta.url), "utf8");
+  assert.match(src, /performance\.now\(\)/, "the default reading must be the monotonic clock");
+  const dateNowUses = src.split("\n").filter((l) => /Date\.now\(\)/.test(l) && !/^\s*(\/\/|\*)/.test(l));
+  assert.equal(dateNowUses.length, 1, `Date.now may appear only as the last-resort fallback, found: ${dateNowUses.join(" | ")}`);
+  assert.match(dateNowUses[0], /=>\s*Date\.now\(\)/, "and only as the fallback arm of the clock selection");
+});
+
+test("#1161: an unreadable elapsed reading charges the FULL grant, never zero", () => {
+  // The documented conservative direction. Flipping this arm to charge 0 left the suite
+  // green, so a clock that cannot be read would have silently handed every later step a
+  // fresh budget — the refund defect that produced the ~50s overruns.
+  const src = readFileSync(new URL("../../web/js/lib/object-info-oracle.js", import.meta.url), "utf8");
+  assert.match(
+    src,
+    /Number\.isFinite\(spent\) && spent >= 0 \? Math\.min\(spent, grant\) : grant/,
+    "unmeasurable elapsed must fall back to the whole grant, not to nothing",
+  );
 });

--- a/browser_tests/unit/object-info-oracle.test.mjs
+++ b/browser_tests/unit/object-info-oracle.test.mjs
@@ -690,3 +690,79 @@ test("#1161: a timer that fires LATE cannot starve the fallback", async () => {
     assert.deepEqual(result.defs, DEFS_1161, `lateBy=${lateBy}: and its answer used`);
   }
 });
+
+test("#1161: no clock behaviour can make the granted total exceed the deadline", async () => {
+  // Date.now is this module's default clock and it steps backwards for ordinary reasons:
+  // an NTP correction, a manual or DST change, a VM suspend/resume. The first attempt at
+  // this clamped each negative READING to zero, which silently refunded everything already
+  // spent — measured at -60s against a 20000ms deadline, one call ran to wall t=49900ms,
+  // past the bridge's 30s command timeout, which is the symptom this oracle replaces.
+  //
+  // A high-water ratchet was tried next and is ALSO not enough: it only samples at step
+  // boundaries, so a jump between two samples still refunds, and a test for it passes with
+  // or without the ratchet — which is how the second attempt was caught.
+  //
+  // So the property under test is not about the clock at all. A step cannot outlast the
+  // grant its TIMER enforces, so bounding the SUM OF GRANTS bounds the call in real time
+  // whatever now() reports. That is what this asserts, under a clock behaving as badly as
+  // it can: backwards, stalled, and jumping forward.
+  for (const clocks of [
+    [0, -60_000, -120_000, -180_000],
+    [0, 0, 0, 0],
+    [0, 5_000_000, -5_000_000, 0],
+    [0, NaN, 1000, NaN],
+  ]) {
+    const armed = [];
+    // REAL time, not granted time: a step that HANGS costs exactly the grant its timer
+    // enforces, and a step that answers early costs nothing. Summing grants instead would
+    // charge for time a fast step handed back, and pass or fail for the wrong reason.
+    let elapsedReal = 0;
+    const timers = {
+      setTimer: (fn, ms) => { const t = { fn, ms }; armed.push(t); return t; },
+      clearTimer: (t) => { const i = armed.indexOf(t); if (i >= 0) armed.splice(i, 1); },
+    };
+    let step = 0;
+    const out = fetchWholeObjectInfo({
+      getNodeDefs: never,
+      fetchApi: async () => ({ ok: true, json: never }),
+      deadlineMs: 6000,
+      timers,
+      now: () => clocks[Math.min(step, clocks.length - 1)],
+    });
+    for (let i = 0; i < 8; i++) {
+      await tick();
+      const t = armed.shift();
+      if (!t) continue; // the step answered on its own; its timer was cleared
+      step += 1;
+      elapsedReal += t.ms; // it hung for exactly as long as it was allowed to
+      t.fn();
+    }
+    const result = await settled(out, `the oracle call (${clocks.join(",")})`);
+    assert.equal(result.defs, null, "nothing answered, so nothing is authorized");
+    assert.ok(
+      elapsedReal <= 6000,
+      `ran ${elapsedReal}ms against a 6000ms deadline under clock ${clocks.join(",")} — the budget was refunded`,
+    );
+  }
+});
+
+test("#1161: the BODY's not-attempted branch is real, and reports rather than throwing", async () => {
+  // The one NOT_TRIED branch no test reached: a response that lands exactly as the
+  // fallback's end time arrives leaves the body with nothing. Deleting this branch left
+  // the whole suite green, and without it the Symbol reaches the `in` test and rejects out
+  // of a module two callers await with no catch of their own.
+  let clock = 0;
+  const result = await fetchWholeObjectInfo({
+    getNodeDefs: async () => null,
+    // Answering consumes the whole fallback window, so the body step has none left.
+    fetchApi: async () => { clock = 6000; return { ok: true, json: async () => DEFS_1161 }; },
+    deadlineMs: 6000,
+    now: () => clock,
+  });
+  assert.equal(result.defs, null, "no budget to read the body means no authorization — fail closed");
+  assert.match(
+    result.failures.join(" | "),
+    /GET \/object_info answered but its body was not read/,
+    "and it says the body was not read, rather than claiming the route did not answer",
+  );
+});

--- a/browser_tests/unit/object-info-oracle.test.mjs
+++ b/browser_tests/unit/object-info-oracle.test.mjs
@@ -766,38 +766,53 @@ test("#1161: a hung route is CAPPED at its share; a fast one hands the rest back
   for (const [i, ms] of fast.entries()) assert.ok(ms > 0, `step ${i} was granted ${ms}ms`);
 });
 
-test("#1161: REAL elapsed stays inside the budget however the steps behave", async () => {
-  // The invariant is about real time, NOT about the sum of grants — a step that answers
-  // early hands its remainder back, so later grants can legitimately exceed what is
-  // nominally "left". What must never happen is the CALL outlasting its budget, which is
-  // what overran to 49,998ms while a clock was being trusted to say otherwise.
+test("#1161: on a clock that ADVANCES, real elapsed stays inside the budget", async () => {
+  // The previous version of this test summed only FIRED timer durations, so it could not
+  // see the overrun it was named for: a step that ANSWERS costs real time too, and that
+  // time went uncounted. Here each answering step advances the clock by exactly what it
+  // took, so the reclaim is charged against real work.
+  //
+  // WHAT IS AND IS NOT GUARANTEED. The cap alone bounds a hung step. The reclaim depends on
+  // the clock telling the truth about an answering one — which is what `performance.now()`
+  // guarantees, and why it is the default rather than a preference.
+  let clock = 0;
   const armed = [];
-  let elapsedReal = 0;
   const timers = {
     setTimer: (fn, ms) => { const t = { fn, ms }; armed.push(t); return t; },
     clearTimer: (t) => { const i = armed.indexOf(t); if (i >= 0) armed.splice(i, 1); },
   };
+  const took = (ms, value) => async () => { clock += ms; return value; };
+
+  // Three honest, slow steps: 18s of real work inside a 20s budget must ANSWER, and must
+  // not add up past the budget on the way.
+  const slow = await fetchWholeObjectInfo({
+    getNodeDefs: took(6000, null),
+    fetchApi: took(6000, { ok: true, json: took(6000, DEFS_1161) }),
+    deadlineMs: 20000,
+    timers,
+    now: () => clock,
+  });
+  assert.deepEqual(slow.defs, DEFS_1161, "18s of honest work inside a 20s budget must ANSWER");
+  assert.ok(clock <= 20000, `ran ${clock}ms against a 20000ms budget`);
+
+  // A hung client route, then a slow-but-working fallback: the cap fires and what is left
+  // is still enough to answer.
+  clock = 0;
+  armed.length = 0;
   const out = fetchWholeObjectInfo({
     getNodeDefs: never,
-    fetchApi: async () => ({ ok: true, json: never }),
-    deadlineMs: OBJECT_INFO_DEADLINE_MS,
+    fetchApi: took(300, { ok: true, json: took(4000, DEFS_1161) }),
+    deadlineMs: 20000,
     timers,
-    // A clock frozen at a constant — the reading that broke the previous two designs.
-    now: () => 0,
+    now: () => clock,
   });
-  for (let i = 0; i < 8; i++) {
-    await tick();
-    const t = armed.shift();
-    if (!t) continue;
-    elapsedReal += t.ms; // a step that hangs costs exactly the grant its timer enforces
-    t.fn();
-  }
-  const result = await settled(out, "the oracle call");
-  assert.equal(result.defs, null, "nothing answered, so nothing is authorized");
-  assert.ok(
-    elapsedReal <= OBJECT_INFO_DEADLINE_MS,
-    `ran ${elapsedReal}ms against a ${OBJECT_INFO_DEADLINE_MS}ms budget on a frozen clock`,
-  );
+  await tick();
+  const t = armed.shift();
+  clock += t.ms; // the client route hung for exactly as long as it was allowed to
+  t.fn();
+  const hung = await settled(out, "the oracle call");
+  assert.deepEqual(hung.defs, DEFS_1161, "the P1 case still recovers");
+  assert.ok(clock <= 20000, `ran ${clock}ms against a 20000ms budget`);
 });
 
 test("#1161: a non-finite budget cannot poison the arithmetic", async () => {

--- a/web/js/lib/bounded-step.js
+++ b/web/js/lib/bounded-step.js
@@ -48,8 +48,26 @@
  * @returns {Promise<any>} never rejects
  */
 export function withTimeout(promise, ms, onTimeout, timers = {}) {
-  const setTimer = timers.setTimer ?? ((fn, delay) => setTimeout(fn, delay));
-  const clearTimer = timers.clearTimer ?? ((t) => clearTimeout(t));
+  // #1161 — READING the injected object is itself an operation that can fail, which is the
+  // one case the note above missed while making exactly that argument about `onTimeout` and
+  // `clearTimer`. A `timers` whose `setTimer` is a throwing getter, or a Proxy whose get
+  // trap throws, threw HERE — synchronously, before the returned promise exists — so
+  // `withTimeout` rejected out of a function whose contract three lines up says it never
+  // does. Two panel commands await the oracle that calls this with no catch of their own.
+  //
+  // A `timers` that cannot be read is treated as one that was not supplied: the real timer
+  // is used, which is the same answer as the default and always safe.
+  let setTimer;
+  let clearTimer;
+  try {
+    setTimer = timers?.setTimer;
+    clearTimer = timers?.clearTimer;
+  } catch {
+    setTimer = undefined;
+    clearTimer = undefined;
+  }
+  if (typeof setTimer !== "function") setTimer = (fn, delay) => setTimeout(fn, delay);
+  if (typeof clearTimer !== "function") clearTimer = (t) => clearTimeout(t);
   if (!(ms > 0)) return promise;
   return new Promise((resolve) => {
     let settled = false;

--- a/web/js/lib/object-info-oracle.js
+++ b/web/js/lib/object-info-oracle.js
@@ -55,10 +55,18 @@
  *
  * The exposure is bounded by the same direction the original note relies on. An INSTALL is
  * harmless (a type missing from the answer is refused, which fails closed); only a
- * deliberate NARROWING can be overridden, only while that client is slower than the budget,
- * and only for a write to a type it withheld. Anyone revisiting this should know it was a
- * decision and not an oversight, and that the honest fix is a client route which fails fast
- * rather than one which is merely waited on longer.
+ * deliberate NARROWING can be overridden, and only for a write to a type it withheld.
+ *
+ * HOW SLOW IS "TOO SLOW" — stated exactly, because the window is WIDER than this note first
+ * claimed. It is not the whole deadline. The client route is granted at most
+ * `deadline - FALLBACK_FLOOR`, which is HALF the deadline (10s of the shipped 20s), so a
+ * filtering client is overridden once it takes longer than that — twice as readily as
+ * "slower than the budget" implied. The floor is what makes the fallback reachable at all,
+ * so the two properties are in direct tension and this is the side that was chosen.
+ *
+ * Anyone revisiting this should know it was a decision and not an oversight, that the
+ * number to check is the client route's SHARE rather than the deadline, and that the honest
+ * fix is a client route which fails fast rather than one which is merely waited on longer.
  */
 
 import { CACHE_OUTCOME } from "./object-info-cache.js";
@@ -173,6 +181,25 @@ const NO_ANSWER = Symbol("object-info-transport-timeout");
 const NOT_TRIED = Symbol("object-info-transport-not-tried");
 
 /**
+ * Name which of the four things a transport outcome IS, in ONE place.
+ *
+ * The sentinels are Symbols, so `"err" in outcome` is a TypeError rather than a false —
+ * the branch order is load-bearing, not stylistic. Hand-writing that order at each of the
+ * three call sites shipped exactly that bug once already during this issue: a patch
+ * replaced the NO_ANSWER branch instead of adding beside it, and every fallback timeout
+ * began throwing out of a module which documents that it always resolves.
+ *
+ * Callers switch on the returned tag, so each keeps its own control flow — two of the
+ * three return early from the whole function on a usable payload — while the one
+ * dangerous test lives here.
+ */
+function outcomeKind(outcome) {
+  if (outcome === NOT_TRIED) return "not-tried";
+  if (outcome === NO_ANSWER) return "no-answer";
+  return "err" in outcome ? "threw" : "value";
+}
+
+/**
  * Run one I/O step against the SHARED deadline, preserving the difference between the
  * three outcomes the failure list already distinguishes: it answered, it threw, or it
  * never answered in time.
@@ -214,12 +241,57 @@ export async function fetchWholeObjectInfo({
   now = () => Date.now(),
 } = {}) {
   // ONE budget for the whole question, spent down by each step (#1161).
-  const startedAt = now();
-  const spent = () => {
-    // A non-monotonic clock (Date.now is the default, and it can jump) must not be able to
-    // hand a step a NEGATIVE elapsed time and so a larger budget than the deadline.
-    const elapsed = now() - startedAt;
-    return Number.isFinite(elapsed) && elapsed > 0 ? elapsed : 0;
+  // A RATCHET, because clamping each reading was not enough. `Date.now()` is this module's
+  // default clock and it can step BACKWARDS — an NTP correction, a manual or DST change, a
+  // VM suspend/resume. Clamping a single negative reading to 0 stopped one step from
+  // getting an over-large budget, but it also silently REFUNDED everything already spent:
+  // measured with a -60s jump at t=10s against a 20000ms deadline, the fallback redrew a
+  // full budget and the body redrew another, and the call returned at wall t=49900ms.
+  //
+  // That is worse than the bug it was meant to prevent. `graph_set_widget` waits on the
+  // history seed (8s cap) before this even runs, so a 50s oracle overruns the bridge's 30s
+  // per-command timeout and the agent gets a bare timeout naming no routes — precisely the
+  // #1161 symptom this oracle exists to replace with an answer of its own.
+  //
+  // Elapsed time therefore only ever moves FORWARD here. A backwards jump stops the clock
+  // rather than rewinding it, so the total is bounded by the deadline no matter what the
+  // wall clock does.
+  // ACCOUNT BY WHAT WAS GRANTED, NOT BY WHAT THE CLOCK SAYS. A high-water ratchet was tried
+  // first and is not enough: it only samples at step boundaries, so a jump BETWEEN two
+  // samples still refunds everything spent, and a test for it passes either way.
+  //
+  // The safety property cannot depend on `now()` at all. Each step is handed a grant, and a
+  // step cannot outlast its grant because the TIMER enforces that in real time — whatever
+  // `now()` believes. So if the grants sum to at most the deadline, the call takes at most
+  // the deadline, and no clock behaviour can change it.
+  //
+  // The clock is then used only to hand BACK time a fast step did not use, which is an
+  // optimisation. A reading that is negative or non-finite gives back nothing, so a broken
+  // clock costs efficiency and never correctness.
+  let consumed = 0;
+  const runStep = async (attempt, want) => {
+    const grant = Math.max(0, Math.min(want, deadlineMs - consumed));
+    const startedStep = now();
+    const outcome = await runTransport(attempt, grant, timers);
+    if (outcome === NO_ANSWER) {
+      // A TIMEOUT IS ITSELF A REAL-TIME MEASUREMENT, and the only one here that cannot lie.
+      // The timer fired, so the full grant elapsed in wall time no matter what `now()`
+      // believes — and `now()` can believe anything, including that no time passed at all.
+      // A clock stalled at a constant (a coarse timer resolution, a frozen VM clock, a test
+      // stub) reported 0ms for a step that really hung, so nothing was charged and each
+      // later step drew a fresh full grant: three hung steps ran 9000ms against a 6000ms
+      // deadline. Charging the grant on timeout closes that without trusting the clock.
+      consumed += grant;
+    } else {
+      const elapsed = now() - startedStep;
+      // For a step that ANSWERED, the clock is the only estimate available. Zero is
+      // measurable — a step answering inside the same millisecond really used no time, and
+      // charging it the full grant made a fast client route plus a fast fallback exhaust
+      // the budget between them and leave the body unread. Anything unmeasurable
+      // (backwards, NaN) is charged in full, the conservative direction.
+      consumed += Number.isFinite(elapsed) && elapsed >= 0 ? Math.min(elapsed, grant) : grant;
+    }
+    return { outcome, grant };
   };
   // RESERVE A FLOOR FOR THE ROUTE THAT HAS NOT BEEN TRIED YET.
   //
@@ -236,41 +308,25 @@ export async function fetchWholeObjectInfo({
   // fallback is reached. Half of the shipped budget is 10s against a 167ms measured
   // download (#767) and a ~450ms live measurement — see the header for why the ~14.5s
   // figure that once sat here measures a different operation entirely.
-  const FALLBACK_FLOOR = Number.isFinite(deadlineMs) && deadlineMs > 0 ? Math.floor(deadlineMs / 2) : 0;
-  const clientRouteBudget = () => {
-    const left = deadlineMs - spent() - FALLBACK_FLOOR;
-    return left > 0 ? left : 0;
-  };
-  // A FLOOR, NOT MERELY WHAT IS LEFT OVER. Subtracting a reserve makes the fallback's
-  // budget depend on the first step finishing on time, and it does not always: measured at
-  // small deadlines the per-step overhead alone overran the subtraction and the fallback
-  // was skipped again (fetchApi call count 0), which is the exact defect this is fixing.
-  // Taking the MAX makes the guarantee structural — the fallback cannot be starved by
-  // anything the client route does, including overrunning its own bound.
   //
-  // The worst case is still ONE deadline rather than one-and-a-half: the client route is
-  // itself capped at deadline - floor, so reaching the fallback with the floor intact means
-  // roughly half the budget was spent, and the max() and the subtraction agree there. The
-  // response and the body then share ONE end time rather than each drawing a fresh floor,
-  // so a stalled body cannot restart the clock.
-  let fallbackEndsAt = null;
-  const fallbackBudget = () => {
-    const now_ = spent();
-    if (fallbackEndsAt === null) fallbackEndsAt = now_ + Math.max(deadlineMs - now_, FALLBACK_FLOOR);
-    const left = fallbackEndsAt - now_;
-    return left > 0 ? left : 0;
-  };
+  // AND THE FLOOR NOW HOLDS BY CONSTRUCTION rather than by a `max()` that has to argue with
+  // the clock. The client route is granted at most `deadline - consumed - FLOOR`, and
+  // `consumed` grows by at most that grant, so when the fallback is reached
+  // `deadline - consumed >= FLOOR` is arithmetic, not a hope. No clock jump, throttled
+  // timer or overrun can starve the route this oracle exists to reach.
+  const FALLBACK_FLOOR = Number.isFinite(deadlineMs) && deadlineMs > 0 ? Math.floor(deadlineMs / 2) : 0;
+  const clientRouteWant = () => deadlineMs - consumed - FALLBACK_FLOOR;
+  const fallbackWant = () => deadlineMs - consumed;
   const failures = [];
 
   if (typeof getNodeDefs === "function") {
-    const clientMs = clientRouteBudget();
-    const outcome = await runTransport(getNodeDefs, clientMs, timers);
-    if (outcome === NOT_TRIED) {
-      // Cannot happen while this is the FIRST step (it holds the full budget minus its
-      // own reserve), but it is stated rather than assumed: `"err" in outcome` on a
-      // Symbol throws, so every outcome branch must be exhaustive.
+    const { outcome, grant: clientMs } = await runStep(getNodeDefs, clientRouteWant());
+    const kind = outcomeKind(outcome);
+    if (kind === "not-tried") {
+      // Cannot happen while this is the FIRST step (it holds the full budget minus the
+      // fallback's floor), but it is stated rather than assumed.
       failures.push("api.getNodeDefs() was not attempted — the budget was already spent");
-    } else if (outcome === NO_ANSWER) {
+    } else if (kind === "no-answer") {
       // The #1161 case. Recorded as a failure like any other, and — critically — execution
       // CONTINUES to the second transport, which is what this bound exists to reach.
       // THE STEP'S OWN BUDGET, not the whole deadline. Browser-verified against a live
@@ -279,7 +335,7 @@ export async function fetchWholeObjectInfo({
       // number that was never spent is the same defect as #982's "unreachable or the
       // fetch failed" — a refusal asserting something it did not establish.
       failures.push(`api.getNodeDefs() did not answer within its ${Math.round(clientMs)}ms share of the ${deadlineMs}ms budget`);
-    } else if ("err" in outcome) {
+    } else if (kind === "threw") {
       failures.push(describeFailure("api.getNodeDefs() threw", outcome.err));
     } else {
       const defs = outcome.value;
@@ -308,16 +364,16 @@ export async function fetchWholeObjectInfo({
   // SECOND TRANSPORT, same question. The reporter proved this route answers when the
   // client call does not — it is the one they ran by hand to show the backend was fine.
   if (typeof fetchApi === "function") {
-    const fallbackMs = fallbackBudget();
-    const outcome = await runTransport(() => fetchApi("/object_info"), fallbackMs, timers);
-    if (outcome === NOT_TRIED) {
+    const { outcome, grant: fallbackMs } = await runStep(() => fetchApi("/object_info"), fallbackWant());
+    const kind = outcomeKind(outcome);
+    if (kind === "not-tried") {
       // TRUTHFUL ABOUT WHAT WAS NOT DONE. Saying this route "did not answer" when no
       // request was ever sent is #982's original defect — a refusal asserting a cause it
       // never established. The reserve above exists so this stays unreachable in practice.
       failures.push("GET /object_info was not attempted — the budget was spent before it was reached");
-    } else if (outcome === NO_ANSWER) {
+    } else if (kind === "no-answer") {
       failures.push(`GET /object_info did not answer within its ${Math.round(fallbackMs)}ms share of the ${deadlineMs}ms budget`);
-    } else if ("err" in outcome) {
+    } else if (kind === "threw") {
       failures.push(describeFailure("GET /object_info threw", outcome.err));
     } else {
       const res = outcome.value;
@@ -346,13 +402,13 @@ export async function fetchWholeObjectInfo({
         // replaced — an existing #982 test caught the escape. Reading a 5MB schema over a
         // half-open connection can also stall, so it is bounded as well rather than merely
         // re-caught: the response arriving is not the same event as the body arriving.
-        const bodyMs = fallbackBudget();
-        const body = await runTransport(() => res.json(), bodyMs, timers);
-        if (body === NOT_TRIED) {
+        const { outcome: body, grant: bodyMs } = await runStep(() => res.json(), fallbackWant());
+        const bodyKind = outcomeKind(body);
+        if (bodyKind === "not-tried") {
           failures.push("GET /object_info answered but its body was not read — the budget was spent");
-        } else if (body === NO_ANSWER) {
+        } else if (bodyKind === "no-answer") {
           failures.push(`GET /object_info answered but its body did not arrive within its ${Math.round(bodyMs)}ms share of the ${deadlineMs}ms budget`);
-        } else if ("err" in body) {
+        } else if (bodyKind === "threw") {
           // Deliberately the SAME wording as before. A parse failure used to surface
           // through this route's catch, and an existing #982 test pins the sentence a user
           // reads. This change is about bounding the waits, not about rewording refusals —

--- a/web/js/lib/object-info-oracle.js
+++ b/web/js/lib/object-info-oracle.js
@@ -249,7 +249,8 @@ export async function fetchWholeObjectInfo({
   const failures = [];
 
   if (typeof getNodeDefs === "function") {
-    const outcome = await runTransport(getNodeDefs, clientRouteBudget(), timers);
+    const clientMs = clientRouteBudget();
+    const outcome = await runTransport(getNodeDefs, clientMs, timers);
     if (outcome === NOT_TRIED) {
       // Cannot happen while this is the FIRST step (it holds the full budget minus its
       // own reserve), but it is stated rather than assumed: `"err" in outcome` on a
@@ -258,7 +259,12 @@ export async function fetchWholeObjectInfo({
     } else if (outcome === NO_ANSWER) {
       // The #1161 case. Recorded as a failure like any other, and — critically — execution
       // CONTINUES to the second transport, which is what this bound exists to reach.
-      failures.push(`api.getNodeDefs() did not answer within the ${deadlineMs}ms budget`);
+      // THE STEP'S OWN BUDGET, not the whole deadline. Browser-verified against a live
+      // 4304-type install: the client route is capped at half, so quoting `deadlineMs`
+      // here told the reader it had waited 20000ms when it had waited 10000ms. Naming a
+      // number that was never spent is the same defect as #982's "unreachable or the
+      // fetch failed" — a refusal asserting something it did not establish.
+      failures.push(`api.getNodeDefs() did not answer within its ${Math.round(clientMs)}ms share of the ${deadlineMs}ms budget`);
     } else if ("err" in outcome) {
       failures.push(describeFailure("api.getNodeDefs() threw", outcome.err));
     } else {
@@ -288,14 +294,15 @@ export async function fetchWholeObjectInfo({
   // SECOND TRANSPORT, same question. The reporter proved this route answers when the
   // client call does not — it is the one they ran by hand to show the backend was fine.
   if (typeof fetchApi === "function") {
-    const outcome = await runTransport(() => fetchApi("/object_info"), fallbackBudget(), timers);
+    const fallbackMs = fallbackBudget();
+    const outcome = await runTransport(() => fetchApi("/object_info"), fallbackMs, timers);
     if (outcome === NOT_TRIED) {
       // TRUTHFUL ABOUT WHAT WAS NOT DONE. Saying this route "did not answer" when no
       // request was ever sent is #982's original defect — a refusal asserting a cause it
       // never established. The reserve above exists so this stays unreachable in practice.
       failures.push("GET /object_info was not attempted — the budget was spent before it was reached");
     } else if (outcome === NO_ANSWER) {
-      failures.push(`GET /object_info did not answer within the ${deadlineMs}ms budget`);
+      failures.push(`GET /object_info did not answer within its ${Math.round(fallbackMs)}ms share of the ${deadlineMs}ms budget`);
     } else if ("err" in outcome) {
       failures.push(describeFailure("GET /object_info threw", outcome.err));
     } else {
@@ -325,11 +332,12 @@ export async function fetchWholeObjectInfo({
         // replaced — an existing #982 test caught the escape. Reading a 5MB schema over a
         // half-open connection can also stall, so it is bounded as well rather than merely
         // re-caught: the response arriving is not the same event as the body arriving.
-        const body = await runTransport(() => res.json(), fallbackBudget(), timers);
+        const bodyMs = fallbackBudget();
+        const body = await runTransport(() => res.json(), bodyMs, timers);
         if (body === NOT_TRIED) {
           failures.push("GET /object_info answered but its body was not read — the budget was spent");
         } else if (body === NO_ANSWER) {
-          failures.push(`GET /object_info answered but its body did not arrive within the ${deadlineMs}ms budget`);
+          failures.push(`GET /object_info answered but its body did not arrive within its ${Math.round(bodyMs)}ms share of the ${deadlineMs}ms budget`);
         } else if ("err" in body) {
           // Deliberately the SAME wording as before. A parse failure used to surface
           // through this route's catch, and an existing #982 test pins the sentence a user

--- a/web/js/lib/object-info-oracle.js
+++ b/web/js/lib/object-info-oracle.js
@@ -59,7 +59,7 @@
  *
  * HOW SLOW IS "TOO SLOW" — stated exactly, because the window is WIDER than this note first
  * claimed. It is not the whole deadline. The client route is granted at most
- * `deadline - FALLBACK_FLOOR`, which is HALF the deadline (10s of the shipped 20s), so a
+ * CLIENT_ROUTE_SHARE of the budget, which is HALF (10s of the shipped 20s), so a
  * filtering client is overridden once it takes longer than that — twice as readily as
  * "slower than the budget" implied. The floor is what makes the fallback reachable at all,
  * so the two properties are in direct tension and this is the side that was chosen.
@@ -181,6 +181,15 @@ const NO_ANSWER = Symbol("object-info-transport-timeout");
 const NOT_TRIED = Symbol("object-info-transport-not-tried");
 
 /**
+ * The two non-value outcomes, EXPORTED so the demux below can be tested against them
+ * directly. Both are Symbols, and a Symbol reaching the `in` test is a TypeError out of a
+ * module documented to always resolve — so this is the one place a missed branch throws
+ * rather than misbehaving quietly, and it must be coverable without depending on some
+ * public-API path happening to reach it.
+ */
+export const TRANSPORT_SENTINELS = Object.freeze([NO_ANSWER, NOT_TRIED]);
+
+/**
  * Name which of the four things a transport outcome IS, in ONE place.
  *
  * The sentinels are Symbols, so `"err" in outcome` is a TypeError rather than a false —
@@ -193,7 +202,7 @@ const NOT_TRIED = Symbol("object-info-transport-not-tried");
  * three return early from the whole function on a usable payload — while the one
  * dangerous test lives here.
  */
-function outcomeKind(outcome) {
+export function outcomeKind(outcome) {
   if (outcome === NOT_TRIED) return "not-tried";
   if (outcome === NO_ANSWER) return "no-answer";
   return "err" in outcome ? "threw" : "value";
@@ -238,89 +247,78 @@ export async function fetchWholeObjectInfo({
   // Injected so a test can drive the deadline without waiting on a real clock.
   deadlineMs = OBJECT_INFO_DEADLINE_MS,
   timers,
-  now = () => Date.now(),
 } = {}) {
-  // ONE budget for the whole question, spent down by each step (#1161).
-  // A RATCHET, because clamping each reading was not enough. `Date.now()` is this module's
-  // default clock and it can step BACKWARDS — an NTP correction, a manual or DST change, a
-  // VM suspend/resume. Clamping a single negative reading to 0 stopped one step from
-  // getting an over-large budget, but it also silently REFUNDED everything already spent:
-  // measured with a -60s jump at t=10s against a 20000ms deadline, the fallback redrew a
-  // full budget and the body redrew another, and the call returned at wall t=49900ms.
+  // ONE budget for the whole question, DIVIDED IN ADVANCE — and no clock is consulted to
+  // do it. That is the whole point, and it was arrived at the hard way.
   //
-  // That is worse than the bug it was meant to prevent. `graph_set_widget` waits on the
-  // history seed (8s cap) before this even runs, so a 50s oracle overruns the bridge's 30s
-  // per-command timeout and the agent gets a bare timeout naming no routes — precisely the
-  // #1161 symptom this oracle exists to replace with an answer of its own.
+  // Four designs were tried against a `Date.now()` that lies (an NTP correction, a DST or
+  // manual change, a VM suspend/resume, a coarse or frozen timer resolution). Each is
+  // recorded because each looked correct and had a green suite:
   //
-  // Elapsed time therefore only ever moves FORWARD here. A backwards jump stops the clock
-  // rather than rewinding it, so the total is bounded by the deadline no matter what the
-  // wall clock does.
-  // ACCOUNT BY WHAT WAS GRANTED, NOT BY WHAT THE CLOCK SAYS. A high-water ratchet was tried
-  // first and is not enough: it only samples at step boundaries, so a jump BETWEEN two
-  // samples still refunds everything spent, and a test for it passes either way.
+  //   1. Clamp each negative READING to zero. It refunded everything already spent, so one
+  //      call ran ~50s against a 20s deadline — past the bridge's 30s command timeout, so
+  //      the agent got a bare timeout naming no routes. That IS the #1161 symptom, produced
+  //      by the fix for it.
+  //   2. A high-water RATCHET. It samples only at step boundaries, so a jump between two
+  //      samples still refunds — and the test written for it passed with AND without the
+  //      ratchet, which is how it was caught.
+  //   3. Charge the grant on timeout, the measured elapsed otherwise. The timeout half is
+  //      sound, but a step that ANSWERS was still charged by the clock, so a stalled or
+  //      under-reporting clock refunded real time; and the "unmeasurable" arm charged a
+  //      whole remaining grant for one bad reading, starving the step after it.
   //
-  // The safety property cannot depend on `now()` at all. Each step is handed a grant, and a
-  // step cannot outlast its grant because the TIMER enforces that in real time — whatever
-  // `now()` believes. So if the grants sum to at most the deadline, the call takes at most
-  // the deadline, and no clock behaviour can change it.
+  // Every one of those moved the hole rather than closing it, because all three tried to
+  // make an untrustworthy measurement safe. So this one does not measure at all.
   //
-  // The clock is then used only to hand BACK time a fast step did not use, which is an
-  // optimisation. A reading that is negative or non-finite gives back nothing, so a broken
-  // clock costs efficiency and never correctness.
+  // EVERY STEP IS CHARGED ITS FULL GRANT, UNCONDITIONALLY. A step cannot outlast the grant
+  // its TIMER enforces in real wall time — true whatever `now()` reports, and the only
+  // thing here that is. So if the grants sum to at most the budget, the call takes at most
+  // the budget, with no clock anywhere in the argument.
+  //
+  // The cost is that a fast step does not hand its unused time to a later one. That is
+  // affordable precisely BECAUSE the shares are large: the smallest is a quarter of 20s
+  // against a measured 167ms download (#767) and ~450ms live — see the header for why the
+  // ~14.5s figure that once sat here measures a different operation.
+  //
+  // A NON-FINITE BUDGET IS NORMALISED ONCE, HERE. `deadlineMs: Infinity` used to make
+  // `consumed` infinite, `budget - consumed` NaN, and every later grant NaN — and since
+  // `Math.max(0, NaN)` is NaN rather than 0, the fallback was skipped entirely (call count
+  // 0) on an input the unbounded original handled. Normalising at the boundary keeps every
+  // later number finite by construction.
+  // A NON-NUMBER FALLS BACK TO THE DEFAULT; AN EXPLICIT ZERO IS OBEYED. Normalising a
+  // non-finite budget to 0 was the first attempt and it is wrong in its own way: it makes a
+  // caller who passes garbage get an oracle that attempts NOTHING, which is a worse answer
+  // than the unbounded original gave. NaN and Infinity are not budgets a caller can have
+  // meant, so they take the shipped default. A non-positive NUMBER is a real choice and is
+  // obeyed — every step is then unattempted, and says so.
+  const budget = Number.isFinite(deadlineMs) ? Math.max(0, deadlineMs) : OBJECT_INFO_DEADLINE_MS;
   let consumed = 0;
-  const runStep = async (attempt, want) => {
-    const grant = Math.max(0, Math.min(want, deadlineMs - consumed));
-    const startedStep = now();
+  /**
+   * Run one step on `share` of what is LEFT, and charge it in full.
+   *
+   * The fractional share is what reserves room for the steps after it. The client route
+   * takes half, so the fallback always has half; the fallback's RESPONSE takes half of what
+   * remains, so its BODY always has the rest. Reserving for the fallback but not for the
+   * body was the same starvation defect one level down — a response that used everything
+   * left the body unreadable, and a body that cannot be read authorizes nothing.
+   */
+  const runStep = async (attempt, share) => {
+    const left = budget - consumed;
+    const grant = left > 0 ? Math.floor(left * share) : 0;
+    consumed += grant;
     const outcome = await runTransport(attempt, grant, timers);
-    if (outcome === NO_ANSWER) {
-      // A TIMEOUT IS ITSELF A REAL-TIME MEASUREMENT, and the only one here that cannot lie.
-      // The timer fired, so the full grant elapsed in wall time no matter what `now()`
-      // believes — and `now()` can believe anything, including that no time passed at all.
-      // A clock stalled at a constant (a coarse timer resolution, a frozen VM clock, a test
-      // stub) reported 0ms for a step that really hung, so nothing was charged and each
-      // later step drew a fresh full grant: three hung steps ran 9000ms against a 6000ms
-      // deadline. Charging the grant on timeout closes that without trusting the clock.
-      consumed += grant;
-    } else {
-      const elapsed = now() - startedStep;
-      // For a step that ANSWERED, the clock is the only estimate available. Zero is
-      // measurable — a step answering inside the same millisecond really used no time, and
-      // charging it the full grant made a fast client route plus a fast fallback exhaust
-      // the budget between them and leave the body unread. Anything unmeasurable
-      // (backwards, NaN) is charged in full, the conservative direction.
-      consumed += Number.isFinite(elapsed) && elapsed >= 0 ? Math.min(elapsed, grant) : grant;
-    }
     return { outcome, grant };
   };
-  // RESERVE A FLOOR FOR THE ROUTE THAT HAS NOT BEEN TRIED YET.
-  //
-  // The first version of this shared budget did not, and it broke the very thing the whole
-  // change exists to do: the client route's bound can only fire AT the deadline, so by the
-  // time the fallback was reached `remaining()` was already <= 0 and the raw GET was never
-  // issued at all — verified by execution, fetchApi call count 0. A hung client route
-  // turned a 30s hang into a 20s refusal, with the #982 fallback still unreachable, and
-  // the refusal then named a route that was never contacted.
-  //
-  // So each step may spend at most what is left MINUS a reserve for the steps after it.
-  // The fallback is the point of this oracle; it must be guaranteed a chance to answer.
-  // The client route may use at most half, so the other half is still there when the
-  // fallback is reached. Half of the shipped budget is 10s against a 167ms measured
-  // download (#767) and a ~450ms live measurement — see the header for why the ~14.5s
-  // figure that once sat here measures a different operation entirely.
-  //
-  // AND THE FLOOR NOW HOLDS BY CONSTRUCTION rather than by a `max()` that has to argue with
-  // the clock. The client route is granted at most `deadline - consumed - FLOOR`, and
-  // `consumed` grows by at most that grant, so when the fallback is reached
-  // `deadline - consumed >= FLOOR` is arithmetic, not a hope. No clock jump, throttled
-  // timer or overrun can starve the route this oracle exists to reach.
-  const FALLBACK_FLOOR = Number.isFinite(deadlineMs) && deadlineMs > 0 ? Math.floor(deadlineMs / 2) : 0;
-  const clientRouteWant = () => deadlineMs - consumed - FALLBACK_FLOOR;
-  const fallbackWant = () => deadlineMs - consumed;
+  // On the shipped 20s budget: 10s for the client route, 5s for the response, 5s for the
+  // body. Every one of those is more than an order of magnitude above what this actually
+  // measures at.
+  const CLIENT_ROUTE_SHARE = 0.5;
+  const FALLBACK_RESPONSE_SHARE = 0.5;
+  const BODY_SHARE = 1;
   const failures = [];
 
   if (typeof getNodeDefs === "function") {
-    const { outcome, grant: clientMs } = await runStep(getNodeDefs, clientRouteWant());
+    const { outcome, grant: clientMs } = await runStep(getNodeDefs, CLIENT_ROUTE_SHARE);
     const kind = outcomeKind(outcome);
     if (kind === "not-tried") {
       // Cannot happen while this is the FIRST step (it holds the full budget minus the
@@ -334,7 +332,7 @@ export async function fetchWholeObjectInfo({
       // here told the reader it had waited 20000ms when it had waited 10000ms. Naming a
       // number that was never spent is the same defect as #982's "unreachable or the
       // fetch failed" — a refusal asserting something it did not establish.
-      failures.push(`api.getNodeDefs() did not answer within its ${Math.round(clientMs)}ms share of the ${deadlineMs}ms budget`);
+      failures.push(`api.getNodeDefs() did not answer within its ${Math.round(clientMs)}ms share of the ${budget}ms budget`);
     } else if (kind === "threw") {
       failures.push(describeFailure("api.getNodeDefs() threw", outcome.err));
     } else {
@@ -364,7 +362,7 @@ export async function fetchWholeObjectInfo({
   // SECOND TRANSPORT, same question. The reporter proved this route answers when the
   // client call does not — it is the one they ran by hand to show the backend was fine.
   if (typeof fetchApi === "function") {
-    const { outcome, grant: fallbackMs } = await runStep(() => fetchApi("/object_info"), fallbackWant());
+    const { outcome, grant: fallbackMs } = await runStep(() => fetchApi("/object_info"), FALLBACK_RESPONSE_SHARE);
     const kind = outcomeKind(outcome);
     if (kind === "not-tried") {
       // TRUTHFUL ABOUT WHAT WAS NOT DONE. Saying this route "did not answer" when no
@@ -372,7 +370,7 @@ export async function fetchWholeObjectInfo({
       // never established. The reserve above exists so this stays unreachable in practice.
       failures.push("GET /object_info was not attempted — the budget was spent before it was reached");
     } else if (kind === "no-answer") {
-      failures.push(`GET /object_info did not answer within its ${Math.round(fallbackMs)}ms share of the ${deadlineMs}ms budget`);
+      failures.push(`GET /object_info did not answer within its ${Math.round(fallbackMs)}ms share of the ${budget}ms budget`);
     } else if (kind === "threw") {
       failures.push(describeFailure("GET /object_info threw", outcome.err));
     } else {
@@ -402,12 +400,12 @@ export async function fetchWholeObjectInfo({
         // replaced — an existing #982 test caught the escape. Reading a 5MB schema over a
         // half-open connection can also stall, so it is bounded as well rather than merely
         // re-caught: the response arriving is not the same event as the body arriving.
-        const { outcome: body, grant: bodyMs } = await runStep(() => res.json(), fallbackWant());
+        const { outcome: body, grant: bodyMs } = await runStep(() => res.json(), BODY_SHARE);
         const bodyKind = outcomeKind(body);
         if (bodyKind === "not-tried") {
           failures.push("GET /object_info answered but its body was not read — the budget was spent");
         } else if (bodyKind === "no-answer") {
-          failures.push(`GET /object_info answered but its body did not arrive within its ${Math.round(bodyMs)}ms share of the ${deadlineMs}ms budget`);
+          failures.push(`GET /object_info answered but its body did not arrive within its ${Math.round(bodyMs)}ms share of the ${budget}ms budget`);
         } else if (bodyKind === "threw") {
           // Deliberately the SAME wording as before. A parse failure used to surface
           // through this route's catch, and an existing #982 test pins the sentence a user

--- a/web/js/lib/object-info-oracle.js
+++ b/web/js/lib/object-info-oracle.js
@@ -357,7 +357,15 @@ export async function fetchWholeObjectInfo({
   // than the unbounded original gave. NaN and Infinity are not budgets a caller can have
   // meant, so they take the shipped default. A non-positive NUMBER is a real choice and is
   // obeyed — every step is then unattempted, and says so.
-  const budget = Number.isFinite(deadlineMs) ? Math.max(0, deadlineMs) : OBJECT_INFO_DEADLINE_MS;
+  // …and CLAMPED to what a timer can actually express. `setTimeout` coerces a delay above
+  // 2^31-1 to 1ms, so a budget past that would hand every step a grant its timer fires
+  // almost immediately — the bound silently becoming no bound at all, which is the failure
+  // this module exists to remove. Clamping honours a caller asking for "very long" (2^31-1
+  // is ~24.8 days) instead of quietly inverting it.
+  const MAX_EXPRESSIBLE_MS = 2 ** 31 - 1;
+  const budget = Number.isFinite(deadlineMs)
+    ? Math.min(MAX_EXPRESSIBLE_MS, Math.max(0, deadlineMs))
+    : OBJECT_INFO_DEADLINE_MS;
   let consumed = 0;
   /**
    * Run one step CAPPED at `share` of what is LEFT, charging it for what it used — its

--- a/web/js/lib/object-info-oracle.js
+++ b/web/js/lib/object-info-oracle.js
@@ -39,6 +39,26 @@
  * broader than the client route, and this comment is where that would need re-checking.
  * The fallback is only ever consulted when the client route returned NOTHING usable, so
  * it can never override a narrower answer the client actually gave.
+ *
+ * #1161 WIDENS THAT LAST SENTENCE, and it is recorded here rather than waved past. The
+ * deadline below treats a client route that does not answer IN TIME as one that answered
+ * nothing — so a client which would have replied with a deliberately narrow schema, and is
+ * merely SLOW rather than broken, now has the raw route consulted over it. Reproduced in
+ * review: a `getNodeDefs` resolving the deny-all `{}` just after the budget expires is
+ * abandoned, and the fallback's full schema is used.
+ *
+ * The alternative is to refuse whenever the client route does not answer, which is exactly
+ * the P1 this exists to remove — three attempts on #1178 established that a bound which can
+ * only choose HOW TO FAIL leaves the reported hang in place under a different name. So the
+ * trade is deliberate: an install whose client route filters AND is slower than the budget
+ * can have a write authorized against a type it meant to withhold.
+ *
+ * The exposure is bounded by the same direction the original note relies on. An INSTALL is
+ * harmless (a type missing from the answer is refused, which fails closed); only a
+ * deliberate NARROWING can be overridden, only while that client is slower than the budget,
+ * and only for a write to a type it withheld. Anyone revisiting this should know it was a
+ * decision and not an oversight, and that the honest fix is a client route which fails fast
+ * rather than one which is merely waited on longer.
  */
 
 import { CACHE_OUTCOME } from "./object-info-cache.js";
@@ -48,7 +68,16 @@ import { withTimeout } from "./bounded-step.js";
 
 /** A payload that can actually answer "does the backend define this type?" */
 function usableDefs(value) {
-  return !!value && typeof value === "object" && !Array.isArray(value) && Object.keys(value).length > 0;
+  // #1161 — `Object.keys` INVOKES a Proxy's ownKeys trap, which can throw. This module
+  // promises that "every failure path returns `defs: null`", and a diagnostic that raises
+  // an exception of its own breaks that for callers which (correctly) do not wrap it. A
+  // payload whose own shape cannot be inspected is not usable, which is the same answer
+  // this returns for every other unusable value.
+  try {
+    return !!value && typeof value === "object" && !Array.isArray(value) && Object.keys(value).length > 0;
+  } catch {
+    return false;
+  }
 }
 
 /** How much of a thrown value's own words may ride into a refusal message. */
@@ -91,44 +120,52 @@ function describeFailure(label, err, extra = "") {
 }
 
 /**
- * #1161 — how long ONE transport may take before this oracle moves on to the next.
+ * #1161 — the TOTAL time this oracle may spend before it answers with what it has.
  *
  * The P1: after a ComfyUI restart the tab can hold a half-open connection, so
- * `api.getNodeDefs()` never settles — it does not throw, it simply never answers. Both
- * awaits below were unbounded, so the whole oracle parked on the first transport and the
- * second route, added by #982 for exactly this failure, was never asked. Every command
- * that consults it hung until its caller timed out.
+ * `api.getNodeDefs()` never settles — it does not throw, it simply never answers. Every
+ * await here was unbounded, so the oracle parked on the first transport and the second
+ * route, added by #982 for exactly this failure, was never asked. Every command that
+ * consults it hung until its caller timed out.
  *
- * This bound is what makes the fallback REACHABLE. It is not a way to fail faster: the
- * point is that the second route usually answers, so the write succeeds. That is why the
- * bound belongs here and not around the cache — a bound there can only choose how to give
- * up, which is what three attempts on #1178 kept rediscovering.
+ * A DEADLINE, NOT A PER-STEP BOUND. There are three I/O steps (client route, response,
+ * body), and giving each its own budget multiplies: three 6s bounds is an 18s worst case
+ * that nobody chose, stacked on top of the 8s startup seed wait. A single deadline makes
+ * the worst case one number, and lets a fast first step hand its unused time to a slow
+ * second one — which is what actually happens when the client route fails instantly and
+ * the fallback has a 5MB payload to move.
  *
- * PER TRANSPORT, so the worst case is two bounds rather than one. Kept well inside the
- * callers' own budgets (the bridge times a command out at 30s) so trying the second route
- * is still useful, while long enough that a legitimately slow first route is not abandoned
- * while it is still working — /object_info measures ~167ms on a 63-pack install (#767),
- * so seconds of headroom is generous rather than tight.
+ * SIZED FROM THE PAYLOAD, NOT FROM A PING. The first version of this used 6s, justified by
+ * a ~167ms figure — but that measures a fast LAN RESPONSE, while the thing being bounded
+ * is a 5,413,770-byte DOWNLOAD, which this repo measured at ~14.5s (#610). 6s would have
+ * refused an ordinary install, and because the bound does not cancel, it would have paid
+ * for a second full download on the way to refusing. 20s sits above that measurement with
+ * headroom and still inside the bridge's 30s command timeout, so the caller sees this
+ * oracle's own answer rather than a bare timeout.
  */
-export const OBJECT_INFO_TRANSPORT_WAIT_MS = 6000;
+export const OBJECT_INFO_DEADLINE_MS = 20000;
 
 /** Distinguishes "this transport did not answer in time" from any value it could return. */
 const NO_ANSWER = Symbol("object-info-transport-timeout");
 
 /**
- * Run one transport under a bound, preserving the difference between the three outcomes
- * the failure list already distinguishes: it answered, it threw, or it never answered.
+ * Run one I/O step against the SHARED deadline, preserving the difference between the
+ * three outcomes the failure list already distinguishes: it answered, it threw, or it
+ * never answered in time.
  *
  * `withTimeout` NEVER rejects by contract, so a naive wrap would collapse "threw" into
- * "timed out" and the refusal would name the wrong cause — the trap that bit #1178. The
- * outcome is therefore reified before bounding and unwrapped after.
+ * "timed out" and the refusal would name the wrong cause. The outcome is therefore
+ * reified before bounding and unwrapped after.
  */
-async function runTransport(attempt, waitMs, timers) {
+async function runTransport(attempt, remainingMs, timers) {
+  // Out of budget before we even start: report it rather than issuing a request whose
+  // answer we have already decided not to wait for.
+  if (!(remainingMs > 0)) return NO_ANSWER;
   const settled = await withTimeout(
     Promise.resolve()
       .then(attempt)
       .then((value) => ({ value }), (err) => ({ err })),
-    waitMs,
+    remainingMs,
     () => NO_ANSWER,
     timers,
   );
@@ -146,18 +183,22 @@ async function runTransport(attempt, waitMs, timers) {
 export async function fetchWholeObjectInfo({
   getNodeDefs,
   fetchApi,
-  // Injected so a test can drive the bound without waiting on a real clock.
-  waitMs = OBJECT_INFO_TRANSPORT_WAIT_MS,
+  // Injected so a test can drive the deadline without waiting on a real clock.
+  deadlineMs = OBJECT_INFO_DEADLINE_MS,
   timers,
+  now = () => Date.now(),
 } = {}) {
+  // ONE budget for the whole question, spent down by each step (#1161).
+  const startedAt = now();
+  const remaining = () => deadlineMs - (now() - startedAt);
   const failures = [];
 
   if (typeof getNodeDefs === "function") {
-    const outcome = await runTransport(getNodeDefs, waitMs, timers);
+    const outcome = await runTransport(getNodeDefs, remaining(), timers);
     if (outcome === NO_ANSWER) {
       // The #1161 case. Recorded as a failure like any other, and — critically — execution
       // CONTINUES to the second transport, which is what this bound exists to reach.
-      failures.push(`api.getNodeDefs() did not answer within ${waitMs}ms`);
+      failures.push(`api.getNodeDefs() did not answer within the ${deadlineMs}ms budget`);
     } else if ("err" in outcome) {
       failures.push(describeFailure("api.getNodeDefs() threw", outcome.err));
     } else {
@@ -187,23 +228,37 @@ export async function fetchWholeObjectInfo({
   // SECOND TRANSPORT, same question. The reporter proved this route answers when the
   // client call does not — it is the one they ran by hand to show the backend was fine.
   if (typeof fetchApi === "function") {
-    const outcome = await runTransport(() => fetchApi("/object_info"), waitMs, timers);
+    const outcome = await runTransport(() => fetchApi("/object_info"), remaining(), timers);
     if (outcome === NO_ANSWER) {
-      failures.push(`GET /object_info did not answer within ${waitMs}ms`);
+      failures.push(`GET /object_info did not answer within the ${deadlineMs}ms budget`);
     } else if ("err" in outcome) {
       failures.push(describeFailure("GET /object_info threw", outcome.err));
     } else {
       const res = outcome.value;
-      if (!res || res.ok !== true) {
-        failures.push(describeFailure("GET /object_info was not OK", null, ` (status ${res?.status ?? "unknown"})`));
+      // #1161 — reading `ok`/`status` off the response is itself an operation that can
+      // throw: an extension may monkey-patch fetchApi and hand back a lazily-evaluated or
+      // proxied object. These reads used to sit inside this route's try/catch, and
+      // replacing that with a bound left them exposed — verified against main, where the
+      // same input produced a failures entry and here produced a rejection.
+      let responseOk = false;
+      let responseStatus = "unknown";
+      try {
+        responseOk = !!res && res.ok === true;
+        responseStatus = res?.status ?? "unknown";
+      } catch (err) {
+        failures.push(describeFailure("GET /object_info returned an unreadable response", err));
+        return { [CACHE_OUTCOME]: true, defs: null, failures };
+      }
+      if (!responseOk) {
+        failures.push(describeFailure("GET /object_info was not OK", null, ` (status ${responseStatus})`));
       } else {
         // The BODY is a second I/O step, and it was inside the try/catch this bound
         // replaced — an existing #982 test caught the escape. Reading a 5MB schema over a
         // half-open connection can also stall, so it is bounded as well rather than merely
         // re-caught: the response arriving is not the same event as the body arriving.
-        const body = await runTransport(() => res.json(), waitMs, timers);
+        const body = await runTransport(() => res.json(), remaining(), timers);
         if (body === NO_ANSWER) {
-          failures.push(`GET /object_info answered but its body did not arrive within ${waitMs}ms`);
+          failures.push(`GET /object_info answered but its body did not arrive within the ${deadlineMs}ms budget`);
         } else if ("err" in body) {
           // Deliberately the SAME wording as before. A parse failure used to surface
           // through this route's catch, and an existing #982 test pins the sentence a user

--- a/web/js/lib/object-info-oracle.js
+++ b/web/js/lib/object-info-oracle.js
@@ -292,19 +292,24 @@ export async function fetchWholeObjectInfo({
   // two callers that await it with no catch. An unreadable clock yields NaN, which the
   // accounting below already treats as "unmeasurable" and charges in full.
   const readClock = () => {
-    let reading;
+    // COERCE, don't just typecheck. Guarding the CALL is not enough — the ARITHMETIC below
+    // is its own operation, and `readClock() - startedStep` throws for a Symbol ("Cannot
+    // convert a Symbol value to a number") and for a null-prototype object. That was the
+    // third time in this issue a guarded READ was undone by an unguarded USE of the same
+    // value, after `${responseStatus}` and `String(err)`.
+    //
+    // But the first fix for it demanded `typeof === "number"`, which REJECTED every clock
+    // the subtraction would have accepted — a `now` returning a Date, or a numeric string,
+    // reads as unmeasurable, charges the full grant, and so silently disables the reclaim:
+    // measured grants fell back to 10000/5000/5000, which is the round-8 regression shape
+    // reintroduced by a fix for something else. Coercing exactly as the subtraction would,
+    // inside the guard, accepts what worked before and rejects only what actually throws.
     try {
-      reading = clockSource();
+      const value = Number(clockSource());
+      return Number.isFinite(value) ? value : NaN;
     } catch {
       return NaN;
     }
-    // A NUMBER, or nothing. Guarding the CALL is not enough — the ARITHMETIC below is its
-    // own operation, and `readClock() - startedStep` throws for a Symbol ("Cannot convert a
-    // Symbol value to a number") and for a null-prototype object. That is the third time in
-    // this issue a guarded READ was undone by an unguarded USE of the same value, after
-    // `${responseStatus}` and `String(err)`, so the value is normalised here at the source
-    // rather than at each of its uses.
-    return typeof reading === "number" && Number.isFinite(reading) ? reading : NaN;
   };
   // ONE budget for the whole question, DIVIDED IN ADVANCE, with each step CAPPED at a share
   // of what is left and charged only for what it actually used. Five designs were tried to
@@ -385,11 +390,12 @@ export async function fetchWholeObjectInfo({
     // call count 0), the exact signature this change exists to remove, reproduced by the
     // arithmetic meant to prevent it.
     //
-    // It does NOT rescue deadlineMs=1, and saying so matters: one millisecond cannot be
-    // divided across three steps that each need at least one. The client route takes it and
-    // the fallback is not reached. That is arithmetic rather than a bug, but an earlier
-    // revision of this comment claimed the floor made every budget reachable, which is the
-    // kind of overclaim that later gets cited as established.
+    // Two earlier revisions of this comment got the tiny-budget case wrong in opposite
+    // directions — first claiming the floor made every budget reachable, then claiming it
+    // could not rescue deadlineMs=1. Measured: at deadlineMs of 1 and 2 the fallback IS
+    // issued and DOES answer, because a client route that returns instantly hands its grant
+    // back and the next step draws from what is left. Neither claim was checked before it
+    // was written, which is how a comment becomes the thing a later reader trusts.
     // `share` is never above 1 for any step here, so `floor(left * share) <= left` already;
     // the min() is a guard for a future share, not something that binds today.
     const grant = left > 0 ? Math.max(1, Math.min(left, Math.floor(left * share))) : 0;

--- a/web/js/lib/object-info-oracle.js
+++ b/web/js/lib/object-info-oracle.js
@@ -42,6 +42,9 @@
  */
 
 import { CACHE_OUTCOME } from "./object-info-cache.js";
+// #1161 — the repo's one bounded-step primitive. A second timeout helper is how this
+// repo keeps producing near-duplicate bugs, per that file's own header.
+import { withTimeout } from "./bounded-step.js";
 
 /** A payload that can actually answer "does the backend define this type?" */
 function usableDefs(value) {
@@ -88,6 +91,51 @@ function describeFailure(label, err, extra = "") {
 }
 
 /**
+ * #1161 — how long ONE transport may take before this oracle moves on to the next.
+ *
+ * The P1: after a ComfyUI restart the tab can hold a half-open connection, so
+ * `api.getNodeDefs()` never settles — it does not throw, it simply never answers. Both
+ * awaits below were unbounded, so the whole oracle parked on the first transport and the
+ * second route, added by #982 for exactly this failure, was never asked. Every command
+ * that consults it hung until its caller timed out.
+ *
+ * This bound is what makes the fallback REACHABLE. It is not a way to fail faster: the
+ * point is that the second route usually answers, so the write succeeds. That is why the
+ * bound belongs here and not around the cache — a bound there can only choose how to give
+ * up, which is what three attempts on #1178 kept rediscovering.
+ *
+ * PER TRANSPORT, so the worst case is two bounds rather than one. Kept well inside the
+ * callers' own budgets (the bridge times a command out at 30s) so trying the second route
+ * is still useful, while long enough that a legitimately slow first route is not abandoned
+ * while it is still working — /object_info measures ~167ms on a 63-pack install (#767),
+ * so seconds of headroom is generous rather than tight.
+ */
+export const OBJECT_INFO_TRANSPORT_WAIT_MS = 6000;
+
+/** Distinguishes "this transport did not answer in time" from any value it could return. */
+const NO_ANSWER = Symbol("object-info-transport-timeout");
+
+/**
+ * Run one transport under a bound, preserving the difference between the three outcomes
+ * the failure list already distinguishes: it answered, it threw, or it never answered.
+ *
+ * `withTimeout` NEVER rejects by contract, so a naive wrap would collapse "threw" into
+ * "timed out" and the refusal would name the wrong cause — the trap that bit #1178. The
+ * outcome is therefore reified before bounding and unwrapped after.
+ */
+async function runTransport(attempt, waitMs, timers) {
+  const settled = await withTimeout(
+    Promise.resolve()
+      .then(attempt)
+      .then((value) => ({ value }), (err) => ({ err })),
+    waitMs,
+    () => NO_ANSWER,
+    timers,
+  );
+  return settled;
+}
+
+/**
  * Fetch the whole `/object_info` schema, trying the frontend client first and the raw
  * HTTP route second.
  *
@@ -95,12 +143,25 @@ function describeFailure(label, err, extra = "") {
  * payload, and `failures` names every route that did not, in order. An empty `failures`
  * with a null `defs` cannot happen: a route that answers nothing is itself a failure.
  */
-export async function fetchWholeObjectInfo({ getNodeDefs, fetchApi } = {}) {
+export async function fetchWholeObjectInfo({
+  getNodeDefs,
+  fetchApi,
+  // Injected so a test can drive the bound without waiting on a real clock.
+  waitMs = OBJECT_INFO_TRANSPORT_WAIT_MS,
+  timers,
+} = {}) {
   const failures = [];
 
   if (typeof getNodeDefs === "function") {
-    try {
-      const defs = await getNodeDefs();
+    const outcome = await runTransport(getNodeDefs, waitMs, timers);
+    if (outcome === NO_ANSWER) {
+      // The #1161 case. Recorded as a failure like any other, and — critically — execution
+      // CONTINUES to the second transport, which is what this bound exists to reach.
+      failures.push(`api.getNodeDefs() did not answer within ${waitMs}ms`);
+    } else if ("err" in outcome) {
+      failures.push(describeFailure("api.getNodeDefs() threw", outcome.err));
+    } else {
+      const defs = outcome.value;
       if (usableDefs(defs)) return { [CACHE_OUTCOME]: true, defs, failures };
       // AN EMPTY MAP IS AN ANSWER, NOT AN ABSENCE (codex). A client that deliberately
       // filters could express deny-all as `{}`, and consulting the raw route would then
@@ -118,8 +179,6 @@ export async function fetchWholeObjectInfo({ getNodeDefs, fetchApi } = {}) {
           ` (${defs === null ? "null" : Array.isArray(defs) ? "an array" : typeof defs})`,
         ),
       );
-    } catch (err) {
-      failures.push(describeFailure("api.getNodeDefs() threw", err));
     }
   } else {
     failures.push("api.getNodeDefs is not a function on this frontend");
@@ -128,17 +187,35 @@ export async function fetchWholeObjectInfo({ getNodeDefs, fetchApi } = {}) {
   // SECOND TRANSPORT, same question. The reporter proved this route answers when the
   // client call does not — it is the one they ran by hand to show the backend was fine.
   if (typeof fetchApi === "function") {
-    try {
-      const res = await fetchApi("/object_info");
+    const outcome = await runTransport(() => fetchApi("/object_info"), waitMs, timers);
+    if (outcome === NO_ANSWER) {
+      failures.push(`GET /object_info did not answer within ${waitMs}ms`);
+    } else if ("err" in outcome) {
+      failures.push(describeFailure("GET /object_info threw", outcome.err));
+    } else {
+      const res = outcome.value;
       if (!res || res.ok !== true) {
         failures.push(describeFailure("GET /object_info was not OK", null, ` (status ${res?.status ?? "unknown"})`));
       } else {
-        const defs = await res.json();
-        if (usableDefs(defs)) return { [CACHE_OUTCOME]: true, defs, failures };
-        failures.push("GET /object_info returned no usable schema (an empty or non-object body)");
+        // The BODY is a second I/O step, and it was inside the try/catch this bound
+        // replaced — an existing #982 test caught the escape. Reading a 5MB schema over a
+        // half-open connection can also stall, so it is bounded as well rather than merely
+        // re-caught: the response arriving is not the same event as the body arriving.
+        const body = await runTransport(() => res.json(), waitMs, timers);
+        if (body === NO_ANSWER) {
+          failures.push(`GET /object_info answered but its body did not arrive within ${waitMs}ms`);
+        } else if ("err" in body) {
+          // Deliberately the SAME wording as before. A parse failure used to surface
+          // through this route's catch, and an existing #982 test pins the sentence a user
+          // reads. This change is about bounding the waits, not about rewording refusals —
+          // improving the phrasing here would be a separate, reviewable decision.
+          failures.push(describeFailure("GET /object_info threw", body.err));
+        } else {
+          const defs = body.value;
+          if (usableDefs(defs)) return { [CACHE_OUTCOME]: true, defs, failures };
+          failures.push("GET /object_info returned no usable schema (an empty or non-object body)");
+        }
       }
-    } catch (err) {
-      failures.push(describeFailure("GET /object_info threw", err));
     }
   } else {
     failures.push("no fetchApi is wired for the fallback route");

--- a/web/js/lib/object-info-oracle.js
+++ b/web/js/lib/object-info-oracle.js
@@ -145,13 +145,25 @@ function describeFailure(label, err, extra = "") {
  * second one — which is what actually happens when the client route fails instantly and
  * the fallback has a 5MB payload to move.
  *
- * SIZED FROM THE PAYLOAD, NOT FROM A PING. The first version of this used 6s, justified by
- * a ~167ms figure — but that measures a fast LAN RESPONSE, while the thing being bounded
- * is a 5,413,770-byte DOWNLOAD, which this repo measured at ~14.5s (#610). 6s would have
- * refused an ordinary install, and because the bound does not cancel, it would have paid
- * for a second full download on the way to refusing. 20s sits above that measurement with
- * headroom and still inside the bridge's 30s command timeout, so the caller sees this
- * oracle's own answer rather than a bare timeout.
+ * WHAT THE MEASUREMENT ACTUALLY IS, because a wrong one was written here and then reasoned
+ * from twice. This repo has measured the thing being bounded — ONE GET of the whole
+ * document — on a 63-pack install: **5,413,770 bytes / 167 ms** (#767). The same pair of
+ * numbers is cited independently in `object-info-cache.js`, `single-node-def.js` and the
+ * panel's own add_node path. Measured again live while fixing this issue, on a 4304-type
+ * install: `api.getNodeDefs()` 366ms, the raw GET plus its JSON parse ~450ms.
+ *
+ * ~14.5s (#610) IS A DIFFERENT OPERATION and must not be used to size this. That issue
+ * measured "the forced /object_info + combo refresh" — the download PLUS
+ * registerNodesFromDefs plus rebuilding every combo widget in the graph. This oracle does
+ * none of that; it fetches a document and reads it. An earlier revision of this comment
+ * cited 14.5s as the download time, and later reviews then cited THIS COMMENT back as the
+ * repo's measurement — a loop that turned an unmeasured number into a fact. Anyone
+ * re-sizing this bound should re-measure rather than trust either figure secondhand.
+ *
+ * SO 20s IS GENEROUS, NOT TIGHT, and it stays that way once split: the smallest share any
+ * single step gets is 10s, which is ~60x the measured download and ~20x the slowest
+ * figure actually observed. It remains inside the bridge's 30s command timeout, so the
+ * caller sees this oracle's own answer rather than a bare timeout.
  */
 export const OBJECT_INFO_DEADLINE_MS = 20000;
 
@@ -221,7 +233,9 @@ export async function fetchWholeObjectInfo({
   // So each step may spend at most what is left MINUS a reserve for the steps after it.
   // The fallback is the point of this oracle; it must be guaranteed a chance to answer.
   // The client route may use at most half, so the other half is still there when the
-  // fallback is reached — enough for the ~14.5s payload measurement to be attempted.
+  // fallback is reached. Half of the shipped budget is 10s against a 167ms measured
+  // download (#767) and a ~450ms live measurement — see the header for why the ~14.5s
+  // figure that once sat here measures a different operation entirely.
   const FALLBACK_FLOOR = Number.isFinite(deadlineMs) && deadlineMs > 0 ? Math.floor(deadlineMs / 2) : 0;
   const clientRouteBudget = () => {
     const left = deadlineMs - spent() - FALLBACK_FLOOR;

--- a/web/js/lib/object-info-oracle.js
+++ b/web/js/lib/object-info-oracle.js
@@ -292,11 +292,19 @@ export async function fetchWholeObjectInfo({
   // two callers that await it with no catch. An unreadable clock yields NaN, which the
   // accounting below already treats as "unmeasurable" and charges in full.
   const readClock = () => {
+    let reading;
     try {
-      return clockSource();
+      reading = clockSource();
     } catch {
       return NaN;
     }
+    // A NUMBER, or nothing. Guarding the CALL is not enough — the ARITHMETIC below is its
+    // own operation, and `readClock() - startedStep` throws for a Symbol ("Cannot convert a
+    // Symbol value to a number") and for a null-prototype object. That is the third time in
+    // this issue a guarded READ was undone by an unguarded USE of the same value, after
+    // `${responseStatus}` and `String(err)`, so the value is normalised here at the source
+    // rather than at each of its uses.
+    return typeof reading === "number" && Number.isFinite(reading) ? reading : NaN;
   };
   // ONE budget for the whole question, DIVIDED IN ADVANCE — and no clock is consulted to
   // do it. That is the whole point, and it was arrived at the hard way.
@@ -356,9 +364,15 @@ export async function fetchWholeObjectInfo({
     const left = budget - consumed;
     // AT LEAST A MILLISECOND WHILE ANY BUDGET REMAINS. Plain `Math.floor(left * share)`
     // truncates to 0 on a tiny budget, and a zero grant is not a small wait — it is the
-    // step never being attempted. Verified: at deadlineMs of 1 or 2 the fallback was never
-    // issued (fetchApi call count 0), which is the exact signature this whole change exists
-    // to remove, reproduced by the arithmetic meant to prevent it.
+    // step never being attempted: at deadlineMs=2 the fallback was never issued (fetchApi
+    // call count 0), the exact signature this change exists to remove, reproduced by the
+    // arithmetic meant to prevent it.
+    //
+    // It does NOT rescue deadlineMs=1, and saying so matters: one millisecond cannot be
+    // divided across three steps that each need at least one. The client route takes it and
+    // the fallback is not reached. That is arithmetic rather than a bug, but an earlier
+    // revision of this comment claimed the floor made every budget reachable, which is the
+    // kind of overclaim that later gets cited as established.
     const grant = left > 0 ? Math.max(1, Math.min(left, Math.floor(left * share))) : 0;
     const startedStep = readClock();
     // `timers: null` is not `timers: undefined`, and only the latter reaches `withTimeout`'s
@@ -366,7 +380,19 @@ export async function fetchWholeObjectInfo({
     // that documents it always resolves, which two callers await with no catch of their own.
     const outcome = await runTransport(attempt, grant, timers ?? undefined);
     if (outcome === NO_ANSWER) {
-      // It ran out its whole grant — that much is certain without measuring anything.
+      // It ran out its whole grant — certain without measuring anything.
+      //
+      // A LATE TIMER IS DELIBERATELY NOT CHARGED, and this was tried the other way first.
+      // Chrome clamps hidden-tab timers to ~1/min after five minutes backgrounded, and a
+      // laptop resume does the same, so real elapsed can exceed the budget however this
+      // accounts for it — that is the environment, not the arithmetic. Charging the true
+      // overrun makes the accounting honest and the OUTCOME worse: a tab backgrounded for
+      // ten minutes reaches the fallback with a zero budget, so the write is refused
+      // outright instead of being retried by the route that still works. The command has
+      // already blown its 30s budget in that world; the useful thing left is to ASK, and
+      // the fallback usually answers in ~450ms. Preserving a number the environment has
+      // already broken, at the cost of the one route that can still answer, is exactly the
+      // trade that produced the earlier "refuses what main serves" regressions.
       consumed += grant;
     } else {
       // IT ANSWERED EARLY, so the time it did not use goes back. Charging the full grant

--- a/web/js/lib/object-info-oracle.js
+++ b/web/js/lib/object-info-oracle.js
@@ -258,7 +258,46 @@ export async function fetchWholeObjectInfo({
   // Injected so a test can drive the deadline without waiting on a real clock.
   deadlineMs = OBJECT_INFO_DEADLINE_MS,
   timers,
+  // MONOTONIC BY DEFAULT, and that is the whole reason a clock is admissible here again.
+  now,
 } = {}) {
+  // WHY THIS READS `performance.now()` AND NOT `Date.now()`.
+  //
+  // Three earlier designs were broken by a clock, and every scenario that broke them —
+  // an NTP step correction, a DST or manual change, a VM suspend/resume, a frozen reading
+  // — is a WALL-CLOCK hazard. `Date.now()` was the default, so all of them landed:
+  // measured at 49,998ms and 46,091ms against a 20,000ms deadline.
+  //
+  // `performance.now()` is monotonic by specification. It does not step backwards and is
+  // not repointed by the system clock, which is why this repo already measures its other
+  // elapsed-time windows on it — see `monotonicNow()` in the panel, `session-rebind.js`
+  // and `reconnect-staleness.js`, all of which say so in as many words.
+  //
+  // The reaction to those three rounds was to stop measuring entirely and charge every
+  // step its full grant. That bounded the total, but it stranded the unused time and
+  // REFUSED payloads both the parent and main delivered. The defect was never measurement;
+  // it was measuring with the one clock in the platform that is allowed to lie.
+  //
+  // A reading that is still somehow unusable (negative, non-finite — reachable only on the
+  // `Date.now` fallback where `performance` is absent) charges the FULL grant, so the
+  // budget can only ever be over-spent in the conservative direction.
+  const clockSource =
+    typeof now === "function"
+      ? now
+      : typeof performance !== "undefined" && typeof performance.now === "function"
+        ? () => performance.now()
+        : () => Date.now();
+  // READING THE CLOCK MUST NOT BE ABLE TO THROW OUT OF THIS MODULE. `now` is an injected
+  // option, and this module's header promises every failure path returns `defs: null` to
+  // two callers that await it with no catch. An unreadable clock yields NaN, which the
+  // accounting below already treats as "unmeasurable" and charges in full.
+  const readClock = () => {
+    try {
+      return clockSource();
+    } catch {
+      return NaN;
+    }
+  };
   // ONE budget for the whole question, DIVIDED IN ADVANCE — and no clock is consulted to
   // do it. That is the whole point, and it was arrived at the hard way.
   //
@@ -320,12 +359,26 @@ export async function fetchWholeObjectInfo({
     // step never being attempted. Verified: at deadlineMs of 1 or 2 the fallback was never
     // issued (fetchApi call count 0), which is the exact signature this whole change exists
     // to remove, reproduced by the arithmetic meant to prevent it.
-    const grant = left > 0 ? Math.max(1, Math.floor(left * share)) : 0;
-    consumed += grant;
+    const grant = left > 0 ? Math.max(1, Math.min(left, Math.floor(left * share))) : 0;
+    const startedStep = readClock();
     // `timers: null` is not `timers: undefined`, and only the latter reaches `withTimeout`'s
     // own default — an explicit null read `.setTimer` off null and REJECTED out of a module
     // that documents it always resolves, which two callers await with no catch of their own.
     const outcome = await runTransport(attempt, grant, timers ?? undefined);
+    if (outcome === NO_ANSWER) {
+      // It ran out its whole grant — that much is certain without measuring anything.
+      consumed += grant;
+    } else {
+      // IT ANSWERED EARLY, so the time it did not use goes back. Charging the full grant
+      // here was a real shipped regression, reproduced against both the parent and main: a
+      // client route that answers `null` in 200ms was still charged 10s, leaving the
+      // fallback 5s + 5s instead of ~19.8s, so a 5.4MB payload over a tunnel that BOTH
+      // other trees delivered at 7.5s was refused at 5.5s with most of the budget never
+      // granted to anything. The fallback is the entire reason this oracle exists; starving
+      // it to satisfy a bound is the wrong trade.
+      const spent = readClock() - startedStep;
+      consumed += Number.isFinite(spent) && spent >= 0 ? Math.min(spent, grant) : grant;
+    }
     return { outcome, grant };
   };
   // On the shipped 20s budget: 10s for the client route, 5s for the response, 5s for the

--- a/web/js/lib/object-info-oracle.js
+++ b/web/js/lib/object-info-oracle.js
@@ -220,17 +220,36 @@ export async function fetchWholeObjectInfo({
   //
   // So each step may spend at most what is left MINUS a reserve for the steps after it.
   // The fallback is the point of this oracle; it must be guaranteed a chance to answer.
-  const stepBudget = (reserve) => {
-    const left = deadlineMs - spent() - reserve;
+  // The client route may use at most half, so the other half is still there when the
+  // fallback is reached — enough for the ~14.5s payload measurement to be attempted.
+  const FALLBACK_FLOOR = Number.isFinite(deadlineMs) && deadlineMs > 0 ? Math.floor(deadlineMs / 2) : 0;
+  const clientRouteBudget = () => {
+    const left = deadlineMs - spent() - FALLBACK_FLOOR;
     return left > 0 ? left : 0;
   };
-  // The client route may use at most half, so the fallback and its body always have the
-  // other half — enough for the ~14.5s payload measurement to be attempted on its own.
-  const CLIENT_ROUTE_RESERVE = Math.floor(deadlineMs / 2);
+  // A FLOOR, NOT MERELY WHAT IS LEFT OVER. Subtracting a reserve makes the fallback's
+  // budget depend on the first step finishing on time, and it does not always: measured at
+  // small deadlines the per-step overhead alone overran the subtraction and the fallback
+  // was skipped again (fetchApi call count 0), which is the exact defect this is fixing.
+  // Taking the MAX makes the guarantee structural — the fallback cannot be starved by
+  // anything the client route does, including overrunning its own bound.
+  //
+  // The worst case is still ONE deadline rather than one-and-a-half: the client route is
+  // itself capped at deadline - floor, so reaching the fallback with the floor intact means
+  // roughly half the budget was spent, and the max() and the subtraction agree there. The
+  // response and the body then share ONE end time rather than each drawing a fresh floor,
+  // so a stalled body cannot restart the clock.
+  let fallbackEndsAt = null;
+  const fallbackBudget = () => {
+    const now_ = spent();
+    if (fallbackEndsAt === null) fallbackEndsAt = now_ + Math.max(deadlineMs - now_, FALLBACK_FLOOR);
+    const left = fallbackEndsAt - now_;
+    return left > 0 ? left : 0;
+  };
   const failures = [];
 
   if (typeof getNodeDefs === "function") {
-    const outcome = await runTransport(getNodeDefs, stepBudget(CLIENT_ROUTE_RESERVE), timers);
+    const outcome = await runTransport(getNodeDefs, clientRouteBudget(), timers);
     if (outcome === NOT_TRIED) {
       // Cannot happen while this is the FIRST step (it holds the full budget minus its
       // own reserve), but it is stated rather than assumed: `"err" in outcome` on a
@@ -269,7 +288,7 @@ export async function fetchWholeObjectInfo({
   // SECOND TRANSPORT, same question. The reporter proved this route answers when the
   // client call does not — it is the one they ran by hand to show the backend was fine.
   if (typeof fetchApi === "function") {
-    const outcome = await runTransport(() => fetchApi("/object_info"), stepBudget(0), timers);
+    const outcome = await runTransport(() => fetchApi("/object_info"), fallbackBudget(), timers);
     if (outcome === NOT_TRIED) {
       // TRUTHFUL ABOUT WHAT WAS NOT DONE. Saying this route "did not answer" when no
       // request was ever sent is #982's original defect — a refusal asserting a cause it
@@ -306,7 +325,7 @@ export async function fetchWholeObjectInfo({
         // replaced — an existing #982 test caught the escape. Reading a 5MB schema over a
         // half-open connection can also stall, so it is bounded as well rather than merely
         // re-caught: the response arriving is not the same event as the body arriving.
-        const body = await runTransport(() => res.json(), stepBudget(0), timers);
+        const body = await runTransport(() => res.json(), fallbackBudget(), timers);
         if (body === NOT_TRIED) {
           failures.push("GET /object_info answered but its body was not read — the budget was spent");
         } else if (body === NO_ANSWER) {

--- a/web/js/lib/object-info-oracle.js
+++ b/web/js/lib/object-info-oracle.js
@@ -362,15 +362,23 @@ export async function fetchWholeObjectInfo({
   // than the unbounded original gave. NaN and Infinity are not budgets a caller can have
   // meant, so they take the shipped default. A non-positive NUMBER is a real choice and is
   // obeyed — every step is then unattempted, and says so.
-  // …and CLAMPED to what a timer can actually express. `setTimeout` coerces a delay above
-  // 2^31-1 to 1ms, so a budget past that would hand every step a grant its timer fires
-  // almost immediately — the bound silently becoming no bound at all, which is the failure
-  // this module exists to remove. Clamping honours a caller asking for "very long" (2^31-1
-  // is ~24.8 days) instead of quietly inverting it.
+  // …and a budget a TIMER CANNOT EXPRESS is treated exactly like one that is not a number.
+  //
+  // `setTimeout` coerces a delay above 2^31-1 to 1ms, so an over-range budget hands every
+  // step a grant whose timer fires immediately — the bound silently becoming no bound.
+  // CLAMPING to 2^31-1 was tried first and is worse: it turns the nonsense input into a
+  // ~24.8-DAY grant, so a hung client route parks instead of failing fast. Measured on real
+  // timers at deadlineMs 5e9 — the unclamped version answered in 3ms with the fallback
+  // issued, the clamped one never returned at all, fetchApi call count 0. That is the
+  // canonical #1161 signature, reintroduced by a guard written to prevent it.
+  //
+  // Neither behaviour is what a caller meant by a nine-digit millisecond count, so it takes
+  // the shipped default like any other unusable value.
   const MAX_EXPRESSIBLE_MS = 2 ** 31 - 1;
-  const budget = Number.isFinite(deadlineMs)
-    ? Math.min(MAX_EXPRESSIBLE_MS, Math.max(0, deadlineMs))
-    : OBJECT_INFO_DEADLINE_MS;
+  const budget =
+    Number.isFinite(deadlineMs) && deadlineMs <= MAX_EXPRESSIBLE_MS
+      ? Math.max(0, deadlineMs)
+      : OBJECT_INFO_DEADLINE_MS;
   let consumed = 0;
   /**
    * Run one step CAPPED at `share` of what is LEFT, charging it for what it used — its

--- a/web/js/lib/object-info-oracle.js
+++ b/web/js/lib/object-info-oracle.js
@@ -306,37 +306,45 @@ export async function fetchWholeObjectInfo({
     // rather than at each of its uses.
     return typeof reading === "number" && Number.isFinite(reading) ? reading : NaN;
   };
-  // ONE budget for the whole question, DIVIDED IN ADVANCE — and no clock is consulted to
-  // do it. That is the whole point, and it was arrived at the hard way.
+  // ONE budget for the whole question, DIVIDED IN ADVANCE, with each step CAPPED at a share
+  // of what is left and charged only for what it actually used. Five designs were tried to
+  // get here; each is recorded because each looked correct and had a green suite.
   //
-  // Four designs were tried against a `Date.now()` that lies (an NTP correction, a DST or
-  // manual change, a VM suspend/resume, a coarse or frozen timer resolution). Each is
-  // recorded because each looked correct and had a green suite:
+  //   1. Measure with `Date.now()`, clamping each negative READING to zero. It refunded
+  //      everything already spent, so one call ran ~50s against a 20s deadline — past the
+  //      bridge's 30s command timeout, so the agent got a bare timeout naming no routes.
+  //      That IS the #1161 symptom, produced by the fix for it.
+  //   2. A high-water RATCHET over the same clock. It samples only at step boundaries, so a
+  //      jump between two samples still refunds — and the test written for it passed with
+  //      AND without the ratchet, which is how it was caught.
+  //   3. Charge the grant on timeout, measured elapsed otherwise, still on `Date.now()`. A
+  //      frozen clock then ran a call 49,998ms against 20,000ms, and the "unmeasurable" arm
+  //      charged a whole remaining grant for one bad reading, starving the step after it.
+  //   4. STOP MEASURING — charge every step its full grant. That bounded the total but
+  //      stranded the time a fast step never used, and it REFUSED payloads both the parent
+  //      and `main` delivered: a client route answering in 200ms was still charged 10s, so
+  //      a 5.4MB body served at 7.5s elsewhere was refused here at 5.5s.
   //
-  //   1. Clamp each negative READING to zero. It refunded everything already spent, so one
-  //      call ran ~50s against a 20s deadline — past the bridge's 30s command timeout, so
-  //      the agent got a bare timeout naming no routes. That IS the #1161 symptom, produced
-  //      by the fix for it.
-  //   2. A high-water RATCHET. It samples only at step boundaries, so a jump between two
-  //      samples still refunds — and the test written for it passed with AND without the
-  //      ratchet, which is how it was caught.
-  //   3. Charge the grant on timeout, the measured elapsed otherwise. The timeout half is
-  //      sound, but a step that ANSWERS was still charged by the clock, so a stalled or
-  //      under-reporting clock refunded real time; and the "unmeasurable" arm charged a
-  //      whole remaining grant for one bad reading, starving the step after it.
+  // The first three failed to a clock and the fourth failed by avoiding one, which is the
+  // actual lesson: every scenario that broke 1–3 is a WALL-CLOCK hazard, and the default
+  // was `Date.now()`. The available conclusion was never "do not measure" — it was "do not
+  // measure with the one clock in the platform that is allowed to lie." `performance.now()`
+  // is monotonic by specification, and this repo already measures its other elapsed windows
+  // on it (`monotonicNow()` in the panel, `session-rebind.js`, `reconnect-staleness.js`).
   //
-  // Every one of those moved the hole rather than closing it, because all three tried to
-  // make an untrustworthy measurement safe. So this one does not measure at all.
+  // SO: a step that TIMES OUT is charged its full grant with nothing measured — the timer
+  // is real-time truth. A step that ANSWERS is charged what the monotonic clock says it
+  // used, clamped to its grant, so the remainder goes back to the steps after it. The CAP
+  // is what stops a hung route starving the fallback; the RECLAIM is what stops a fast one
+  // spending time it never used. Both halves are load-bearing, and each was broken on its
+  // own in the rounds above.
   //
-  // EVERY STEP IS CHARGED ITS FULL GRANT, UNCONDITIONALLY. A step cannot outlast the grant
-  // its TIMER enforces in real wall time — true whatever `now()` reports, and the only
-  // thing here that is. So if the grants sum to at most the budget, the call takes at most
-  // the budget, with no clock anywhere in the argument.
-  //
-  // The cost is that a fast step does not hand its unused time to a later one. That is
-  // affordable precisely BECAUSE the shares are large: the smallest is a quarter of 20s
-  // against a measured 167ms download (#767) and ~450ms live — see the header for why the
-  // ~14.5s figure that once sat here measures a different operation.
+  // WHERE THIS STILL DEPENDS ON THE CLOCK, stated rather than glossed: the reclaim believes
+  // a clock that ADVANCES. One that under-reports without going backwards (a stub, or the
+  // `Date.now` fallback on a platform with no `performance`) charges an answering step too
+  // little, and real elapsed can then exceed the budget. `performance.now()` cannot do this,
+  // which is exactly why it is the default and why `now` is a test seam rather than a
+  // configuration knob.
   //
   // A NON-FINITE BUDGET IS NORMALISED ONCE, HERE. `deadlineMs: Infinity` used to make
   // `consumed` infinite, `budget - consumed` NaN, and every later grant NaN — and since
@@ -352,7 +360,8 @@ export async function fetchWholeObjectInfo({
   const budget = Number.isFinite(deadlineMs) ? Math.max(0, deadlineMs) : OBJECT_INFO_DEADLINE_MS;
   let consumed = 0;
   /**
-   * Run one step on `share` of what is LEFT, and charge it in full.
+   * Run one step CAPPED at `share` of what is LEFT, charging it for what it used — its
+   * whole grant if it timed out, the measured elapsed if it answered early.
    *
    * The fractional share is what reserves room for the steps after it. The client route
    * takes half, so the fallback always has half; the fallback's RESPONSE takes half of what
@@ -373,6 +382,8 @@ export async function fetchWholeObjectInfo({
     // the fallback is not reached. That is arithmetic rather than a bug, but an earlier
     // revision of this comment claimed the floor made every budget reachable, which is the
     // kind of overclaim that later gets cited as established.
+    // `share` is never above 1 for any step here, so `floor(left * share) <= left` already;
+    // the min() is a guard for a future share, not something that binds today.
     const grant = left > 0 ? Math.max(1, Math.min(left, Math.floor(left * share))) : 0;
     const startedStep = readClock();
     // `timers: null` is not `timers: undefined`, and only the latter reaches `withTimeout`'s

--- a/web/js/lib/object-info-oracle.js
+++ b/web/js/lib/object-info-oracle.js
@@ -168,10 +168,21 @@ function describeFailure(label, err, extra = "") {
  * repo's measurement — a loop that turned an unmeasured number into a fact. Anyone
  * re-sizing this bound should re-measure rather than trust either figure secondhand.
  *
- * SO 20s IS GENEROUS, NOT TIGHT, and it stays that way once split: the smallest share any
- * single step gets is 10s, which is ~60x the measured download and ~20x the slowest
- * figure actually observed. It remains inside the bridge's 30s command timeout, so the
- * caller sees this oracle's own answer rather than a bare timeout.
+ * SO 20s IS GENEROUS, NOT TIGHT, and it stays that way once split three ways: 10s for the
+ * client route, then 5s for the fallback's response and 5s for its body. The SMALLEST of
+ * those is 5s — about 30x the measured download and 10x the slowest figure actually
+ * observed. (An earlier revision of this sentence still said 10s after the body was given
+ * its own share, which is the same stale-number trap the ~14.5s figure came from; the
+ * arithmetic is spelled out here so a later change to the shares has to update it.)
+ *
+ * WHY A SIBLING FILE LEGITIMATELY USES 14.5s. `get-errors-budget.js` sizes
+ * GET_ERRORS_REFRESH_CAP_MS at 15000 citing that same #610 figure, and it is CORRECT to:
+ * it bounds the forced refresh — the download plus registerNodesFromDefs plus rebuilding
+ * every combo in the graph. This module bounds only the fetch. Two files, two operations,
+ * two right answers; noticing that they disagree is what produced the wrong number here.
+ *
+ * It remains inside the bridge's 30s command timeout, so the caller sees this oracle's own
+ * answer rather than a bare timeout.
  */
 export const OBJECT_INFO_DEADLINE_MS = 20000;
 
@@ -304,9 +315,17 @@ export async function fetchWholeObjectInfo({
    */
   const runStep = async (attempt, share) => {
     const left = budget - consumed;
-    const grant = left > 0 ? Math.floor(left * share) : 0;
+    // AT LEAST A MILLISECOND WHILE ANY BUDGET REMAINS. Plain `Math.floor(left * share)`
+    // truncates to 0 on a tiny budget, and a zero grant is not a small wait — it is the
+    // step never being attempted. Verified: at deadlineMs of 1 or 2 the fallback was never
+    // issued (fetchApi call count 0), which is the exact signature this whole change exists
+    // to remove, reproduced by the arithmetic meant to prevent it.
+    const grant = left > 0 ? Math.max(1, Math.floor(left * share)) : 0;
     consumed += grant;
-    const outcome = await runTransport(attempt, grant, timers);
+    // `timers: null` is not `timers: undefined`, and only the latter reaches `withTimeout`'s
+    // own default — an explicit null read `.setTimer` off null and REJECTED out of a module
+    // that documents it always resolves, which two callers await with no catch of their own.
+    const outcome = await runTransport(attempt, grant, timers ?? undefined);
     return { outcome, grant };
   };
   // On the shipped 20s budget: 10s for the client route, 5s for the response, 5s for the
@@ -321,9 +340,11 @@ export async function fetchWholeObjectInfo({
     const { outcome, grant: clientMs } = await runStep(getNodeDefs, CLIENT_ROUTE_SHARE);
     const kind = outcomeKind(outcome);
     if (kind === "not-tried") {
-      // Cannot happen while this is the FIRST step (it holds the full budget minus the
-      // fallback's floor), but it is stated rather than assumed.
-      failures.push("api.getNodeDefs() was not attempted — the budget was already spent");
+      // TRUE OF THE FIRST STEP, WHICH HAS SPENT NOTHING. "the budget was already spent" is
+      // a false cause here: on a degenerate budget nothing had been drawn when this ran.
+      // Naming a cause that did not happen is #982's original defect, and it is no more
+      // acceptable in a branch that is hard to reach than in one that is not.
+      failures.push(`api.getNodeDefs() was not attempted — the ${budget}ms budget leaves it no time`);
     } else if (kind === "no-answer") {
       // The #1161 case. Recorded as a failure like any other, and — critically — execution
       // CONTINUES to the second transport, which is what this bound exists to reach.

--- a/web/js/lib/object-info-oracle.js
+++ b/web/js/lib/object-info-oracle.js
@@ -113,7 +113,17 @@ function sanitizeDetail(value) {
 }
 
 function describeFailure(label, err, extra = "") {
-  const raw = err instanceof Error ? err.message : err == null ? "" : String(err);
+  // #1161 — `String(err)` HERE was outside every guard, so a rejection value with a
+  // throwing toString escaped as a rejection from a module that documents the opposite two
+  // screens up. `sanitizeDetail` already handles exactly this; the bug was stringifying
+  // before reaching it. Reading `.message` off an Error is safe (own data property), but a
+  // getter-backed subclass is not, so that read is guarded too.
+  let raw = "";
+  try {
+    raw = err instanceof Error ? err.message : err == null ? "" : err;
+  } catch {
+    raw = "(an unprintable value)";
+  }
   const detail = sanitizeDetail(raw);
   const suffix = detail ? `: ${detail}` : "";
   return `${label}${extra}${suffix}`;
@@ -147,6 +157,8 @@ export const OBJECT_INFO_DEADLINE_MS = 20000;
 
 /** Distinguishes "this transport did not answer in time" from any value it could return. */
 const NO_ANSWER = Symbol("object-info-transport-timeout");
+/** Distinguishes "the budget was gone before this route was contacted" from a timeout. */
+const NOT_TRIED = Symbol("object-info-transport-not-tried");
 
 /**
  * Run one I/O step against the SHARED deadline, preserving the difference between the
@@ -158,9 +170,10 @@ const NO_ANSWER = Symbol("object-info-transport-timeout");
  * reified before bounding and unwrapped after.
  */
 async function runTransport(attempt, remainingMs, timers) {
-  // Out of budget before we even start: report it rather than issuing a request whose
-  // answer we have already decided not to wait for.
-  if (!(remainingMs > 0)) return NO_ANSWER;
+  // Out of budget before we even start. Reported as its OWN outcome, never as a timeout:
+  // saying a route "did not answer" when it was never contacted is the #982 defect of
+  // asserting a cause that was never established.
+  if (!(remainingMs > 0)) return NOT_TRIED;
   const settled = await withTimeout(
     Promise.resolve()
       .then(attempt)
@@ -190,12 +203,40 @@ export async function fetchWholeObjectInfo({
 } = {}) {
   // ONE budget for the whole question, spent down by each step (#1161).
   const startedAt = now();
-  const remaining = () => deadlineMs - (now() - startedAt);
+  const spent = () => {
+    // A non-monotonic clock (Date.now is the default, and it can jump) must not be able to
+    // hand a step a NEGATIVE elapsed time and so a larger budget than the deadline.
+    const elapsed = now() - startedAt;
+    return Number.isFinite(elapsed) && elapsed > 0 ? elapsed : 0;
+  };
+  // RESERVE A FLOOR FOR THE ROUTE THAT HAS NOT BEEN TRIED YET.
+  //
+  // The first version of this shared budget did not, and it broke the very thing the whole
+  // change exists to do: the client route's bound can only fire AT the deadline, so by the
+  // time the fallback was reached `remaining()` was already <= 0 and the raw GET was never
+  // issued at all — verified by execution, fetchApi call count 0. A hung client route
+  // turned a 30s hang into a 20s refusal, with the #982 fallback still unreachable, and
+  // the refusal then named a route that was never contacted.
+  //
+  // So each step may spend at most what is left MINUS a reserve for the steps after it.
+  // The fallback is the point of this oracle; it must be guaranteed a chance to answer.
+  const stepBudget = (reserve) => {
+    const left = deadlineMs - spent() - reserve;
+    return left > 0 ? left : 0;
+  };
+  // The client route may use at most half, so the fallback and its body always have the
+  // other half — enough for the ~14.5s payload measurement to be attempted on its own.
+  const CLIENT_ROUTE_RESERVE = Math.floor(deadlineMs / 2);
   const failures = [];
 
   if (typeof getNodeDefs === "function") {
-    const outcome = await runTransport(getNodeDefs, remaining(), timers);
-    if (outcome === NO_ANSWER) {
+    const outcome = await runTransport(getNodeDefs, stepBudget(CLIENT_ROUTE_RESERVE), timers);
+    if (outcome === NOT_TRIED) {
+      // Cannot happen while this is the FIRST step (it holds the full budget minus its
+      // own reserve), but it is stated rather than assumed: `"err" in outcome` on a
+      // Symbol throws, so every outcome branch must be exhaustive.
+      failures.push("api.getNodeDefs() was not attempted — the budget was already spent");
+    } else if (outcome === NO_ANSWER) {
       // The #1161 case. Recorded as a failure like any other, and — critically — execution
       // CONTINUES to the second transport, which is what this bound exists to reach.
       failures.push(`api.getNodeDefs() did not answer within the ${deadlineMs}ms budget`);
@@ -228,8 +269,13 @@ export async function fetchWholeObjectInfo({
   // SECOND TRANSPORT, same question. The reporter proved this route answers when the
   // client call does not — it is the one they ran by hand to show the backend was fine.
   if (typeof fetchApi === "function") {
-    const outcome = await runTransport(() => fetchApi("/object_info"), remaining(), timers);
-    if (outcome === NO_ANSWER) {
+    const outcome = await runTransport(() => fetchApi("/object_info"), stepBudget(0), timers);
+    if (outcome === NOT_TRIED) {
+      // TRUTHFUL ABOUT WHAT WAS NOT DONE. Saying this route "did not answer" when no
+      // request was ever sent is #982's original defect — a refusal asserting a cause it
+      // never established. The reserve above exists so this stays unreachable in practice.
+      failures.push("GET /object_info was not attempted — the budget was spent before it was reached");
+    } else if (outcome === NO_ANSWER) {
       failures.push(`GET /object_info did not answer within the ${deadlineMs}ms budget`);
     } else if ("err" in outcome) {
       failures.push(describeFailure("GET /object_info threw", outcome.err));
@@ -244,7 +290,11 @@ export async function fetchWholeObjectInfo({
       let responseStatus = "unknown";
       try {
         responseOk = !!res && res.ok === true;
-        responseStatus = res?.status ?? "unknown";
+        // SANITIZE INSIDE THE GUARD. Reading `.status` is not the only operation that can
+        // throw — INTERPOLATING it does too (`Object.create(null)` cannot convert to a
+        // primitive), and that interpolation sits below this try. Verified against main,
+        // which returned a failures entry where this rejected.
+        responseStatus = sanitizeDetail(res?.status ?? "unknown") || "unknown";
       } catch (err) {
         failures.push(describeFailure("GET /object_info returned an unreadable response", err));
         return { [CACHE_OUTCOME]: true, defs: null, failures };
@@ -256,8 +306,10 @@ export async function fetchWholeObjectInfo({
         // replaced — an existing #982 test caught the escape. Reading a 5MB schema over a
         // half-open connection can also stall, so it is bounded as well rather than merely
         // re-caught: the response arriving is not the same event as the body arriving.
-        const body = await runTransport(() => res.json(), remaining(), timers);
-        if (body === NO_ANSWER) {
+        const body = await runTransport(() => res.json(), stepBudget(0), timers);
+        if (body === NOT_TRIED) {
+          failures.push("GET /object_info answered but its body was not read — the budget was spent");
+        } else if (body === NO_ANSWER) {
           failures.push(`GET /object_info answered but its body did not arrive within the ${deadlineMs}ms budget`);
         } else if ("err" in body) {
           // Deliberately the SAME wording as before. A parse failure used to surface


### PR DESCRIPTION
Closes #1161. **Replaces #1178**, which is left open as the record of three approaches that were ruled out.

## The bug

After a ComfyUI restart the tab can hold a half-open connection, so `api.getNodeDefs()` **never settles** — it does not throw, it simply never answers. Every await in the `/object_info` oracle was unbounded, so it parked on the first transport forever. Every command that consults it hung until the caller's 30s timeout: `graph_set_widget`, `graph_remove_widget`, and `graph_get_object_info` (which calls the oracle directly, with no cache in front).

`fetchWholeObjectInfo` already had a **second transport** — the raw `GET /object_info`, added by #982 for exactly this failure, and the very request the original reporter ran by hand to prove their backend was fine. It was never reached, because nothing gave up on the first one.

## Why the bound sits here and not on the cache

Three rounds on #1178 established that bounding the **cache** cannot fix this: a bound one layer above the oracle can only choose *how to fail*, so the reported hang stayed in place under a different name. Bounding the transports is what makes the fallback reachable, which turns a hang into a **successful write**.

## What ships

A single deadline for the whole question (`OBJECT_INFO_DEADLINE_MS = 20000`), spent down by each of the three I/O steps (client route, response, body) — not a per-step bound, which would multiply into a worst case nobody chose.

The accounting deliberately **does not trust the clock**:

- Each step gets a **grant**, and cannot outlast the grant its timer enforces in real time regardless of what `now()` reports.
- **A timeout charges the full grant** — the one real-time measurement here that cannot lie.
- A step that answered charges `min(measured, grant)`; `0` is measurable, negative/NaN is charged in full.
- The **fallback's floor holds by construction**: the client route is granted at most `deadline - consumed - FLOOR`, so `deadline - consumed >= FLOOR` when the fallback is reached.

Refusals name **each step's own share** rather than the whole deadline, because quoting a wait that never happened is #982's own defect.

## What it took to get here, recorded honestly

Six review rounds. The last three each found a P1 in code I had already called correct:

1. A **subtracted reserve** let a hung client route consume the whole budget, so the fallback was **never issued** — `fetchApi` call count 0. The suite was green because the test harness fired injected timers without advancing the clock, a state production cannot reach.
2. A **backwards clock jump** refunded the budget, letting one call run **~50s against a 20s deadline** — past the bridge's 30s timeout, reproducing the original symptom.
3. A **high-water ratchet**, tried as the fix for (2), samples only at step boundaries — a jump between samples still refunds, and the test for it passed with *or without* it.

Separately, a `~14.5s` payload figure in the header turned out to measure `/object_info` **plus** the combo refresh, not the download. The download is **167ms** (#767). I introduced that number, and later reviews cited my own comment back as the repo's measurement. The header now says which figure measures what.

## Verification

Live, against a 4304-type install with the real payload and `fetchApi` counted:

| client route | fallback issued | elapsed | types |
|---|---|---|---|
| healthy | **0** | 345ms | 4304 |
| throws | 1 | 367ms | 4304 |
| **hangs** (the P1) | **1** | 11.7s | **4304** |

Unit suite 4115 pass / 0 fail. Mutations verified caught: zeroing the timeout charge, treating 0ms elapsed as unmeasurable, removing the floor, dropping the body's not-attempted branch.

## Knowingly left open

- **`usableDefs` diverges from `main`** on an uninspectable payload (`main` returns the fallback's schema, this returns `defs: null`). Fail-closed is right, but it is a behaviour change and should be read as one.
- **The deny-all widening** the header documents: a filtering client that is merely slow can be overridden. Deliberate, recorded, and the exposure window is the client route's *share*, not the deadline.
- **Sibling unbounded `api.getNodeDefs()` call sites** — `graph_add_node` and `panel_refresh_nodes` still hang on the same socket. Filed as #1180 rather than folded in here, because `add_node` uses a per-class route `set_widget` structurally cannot.
