### PR TITLE
fix(1171): hold the reload guard across hardRestart's tail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,16 +6,19 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
-### Fixed
+### Changed
 
-- **Restarting the agent can no longer overlap with a second restart or a reload (#1171).**
+- **Restarting the agent holds its exclusion flag until the reconnect (#1171).**
   The panel keeps one flag so that restarting the agent and reloading it cannot run at the
-  same time — but the restart released that flag as soon as the request came back, while it
-  was still finishing: ending the current turn, clearing the markers that say a turn is in
-  flight, invalidating the old session, and reconnecting. Anything started in that window
-  ran straight through the middle of it, tearing down the same state twice.
-  The flag is now held until the reconnect, which is what the reload path already did, so
-  the two finally agree.
+  same time, but the restart released it as soon as the request came back — while it was
+  still ending the current turn, clearing the markers that say a turn is in flight,
+  invalidating the old session, and reconnecting. The flag is now held until the reconnect,
+  which is what the reload path already did, so the two agree.
+  **No visible change when the panel manages ComfyUI's agent the usual way**: this
+  distribution's restart route always answers "not restarted" (the orchestrator runs
+  out-of-band), so the work this now protects is skipped anyway. It matters for setups
+  whose restart route really does restart the agent, and it removes the window before one
+  of those hits it.
 
 ## [0.14.25] - 2026-08-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,21 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
-## [0.14.25] - 2026-08-13
+### Fixed
+
+- **Restarting the agent can no longer overlap with a second restart or a reload (#1171).**
+  The panel keeps one flag so that restarting the agent and reloading it cannot run at the
+  same time — but the restart released that flag as soon as the request came back, while it
+  was still finishing: ending the current turn, clearing the markers that say a turn is in
+  flight, invalidating the old session, and reconnecting. Anything started in that window
+  ran straight through the middle of it, tearing down the same state twice.
+  The flag is now held until the reconnect, which is what the reload path already did, so
+  the two finally agree.
+- **Switching to a different agent backend no longer fails silently (#1171).**
+  If the old provider's session could not be invalidated, the switch stopped with nothing
+  said: no message, and the previously selected backend still showing. It now says the same
+  thing a restart says when it pauses for the same reason. (The panel can still be left
+  showing a backend it did not finish switching to — that is tracked separately in #1184.)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,11 +16,8 @@ All notable changes to this project are documented here. This project adheres to
   ran straight through the middle of it, tearing down the same state twice.
   The flag is now held until the reconnect, which is what the reload path already did, so
   the two finally agree.
-- **Switching to a different agent backend no longer fails silently (#1171).**
-  If the old provider's session could not be invalidated, the switch stopped with nothing
-  said: no message, and the previously selected backend still showing. It now says the same
-  thing a restart says when it pauses for the same reason. (The panel can still be left
-  showing a backend it did not finish switching to — that is tracked separately in #1184.)
+
+## [0.14.25] - 2026-08-13
 
 ### Fixed
 

--- a/browser_tests/unit/chat-history-store.test.mjs
+++ b/browser_tests/unit/chat-history-store.test.mjs
@@ -2182,3 +2182,37 @@ test('a canonical commit cannot hide failure to save a legacyShadow only-copy tr
   )
   store.close()
 })
+
+test('#1171 flush() SETTLES even when IndexedDB never answers, and reports success', async () => {
+  // Relied on by the panel: hardRestart holds the reload re-entrancy guard across
+  // `invalidateDurableAgentSession()`, which awaits this. If flush() could hang, that guard
+  // would latch for the rest of the session — no further restart, no soft reload, and no
+  // affordance to clear it. A bound was added in the panel for that fear and removed again
+  // once this property was established, so the property belongs here, tested behaviourally.
+  //
+  // The worst slow store there is: an `open` request that fires NO handler at all.
+  const hungIndexedDb = {
+    open: () => ({
+      set onsuccess(_) {},
+      set onerror(_) {},
+      set onblocked(_) {},
+      set onupgradeneeded(_) {}
+    })
+  }
+  const store = new ChatHistoryStore({
+    storage: createMemoryStorage(),
+    indexedDb: hungIndexedDb,
+    broadcastFactory: null
+  })
+  store.persist([{ id: 't1', ts: 1, title: 'hung', msgs: [] }], {}, { maxThreads: 10, maxMessages: 10 })
+  const started = Date.now()
+  const result = await store.flush()
+  const elapsed = Date.now() - started
+  // Settles on the store's OWN open cap rather than waiting forever.
+  assert.ok(elapsed < 10000, `flush() took ${elapsed}ms — it must settle on IDB_OPEN_TIMEOUT_MS, not hang`)
+  // And reports SUCCESS: a capped open yields null from idbMergeWrite, the write chain
+  // passes that null through, and flush() maps a null result to true. This is why a slow
+  // store does NOT drive the panel's "could not be invalidated durably" pause.
+  assert.equal(result, true, 'a capped open must not read as a failed write')
+  store.close?.()
+})

--- a/browser_tests/unit/chat-history-store.test.mjs
+++ b/browser_tests/unit/chat-history-store.test.mjs
@@ -2210,9 +2210,46 @@ test('#1171 flush() SETTLES even when IndexedDB never answers, and reports succe
   const elapsed = Date.now() - started
   // Settles on the store's OWN open cap rather than waiting forever.
   assert.ok(elapsed < 10000, `flush() took ${elapsed}ms — it must settle on IDB_OPEN_TIMEOUT_MS, not hang`)
-  // And reports SUCCESS: a capped open yields null from idbMergeWrite, the write chain
-  // passes that null through, and flush() maps a null result to true. This is why a slow
-  // store does NOT drive the panel's "could not be invalidated durably" pause.
-  assert.equal(result, true, 'a capped open must not read as a failed write')
+  // For a SMALL history it also reports success: a capped open yields null from
+  // idbMergeWrite, the write chain passes that null through, and flush() maps null to true.
+  // That is only half the story — see the next test for what a real history does.
+  assert.equal(result, true, 'a capped open must not read as a failed write for a small history')
   store.close?.()
+})
+
+test('#1171 a capped IndexedDB open DOES report failure once history exceeds the local shadow', async () => {
+  // The other half, and the one a first probe missed by testing a five-message thread and
+  // generalising from it. A capped open makes idbMergeWrite yield null, so persist() falls
+  // back to the LOCAL SHADOW's completeness — and the shadow is deliberately partial past
+  // LOCAL_SHADOW_THREADS (20) and LOCAL_SHADOW_MESSAGES (200). So for any user with real
+  // history, a two-second disk hiccup answers ok:false.
+  //
+  // That is not a store fault. It matters because the panel's
+  // invalidateDurableAgentSession() maps this to "could not invalidate durably", and its
+  // callers must treat that as "could not CONFIRM" rather than "the store is broken" —
+  // which the backend-switch caller currently does not (#1184).
+  const hungIndexedDb = {
+    open: () => ({
+      set onsuccess(_) {},
+      set onerror(_) {},
+      set onblocked(_) {},
+      set onupgradeneeded(_) {}
+    })
+  }
+  const cases = [
+    ['400 messages in one thread', [{ id: 't1', ts: 1, title: 'heavy', msgs: Array.from({ length: 400 }, (_, i) => ({ id: 'm' + i, role: 'user', text: 'x' })) }]],
+    ['30 threads', Array.from({ length: 30 }, (_, t) => ({ id: 't' + t, ts: t, title: 't' + t, msgs: [{ id: t + '-0', role: 'user', text: 'x' }] }))]
+  ]
+  for (const [label, threads] of cases) {
+    const store = new ChatHistoryStore({
+      storage: createMemoryStorage(),
+      indexedDb: hungIndexedDb,
+      broadcastFactory: null
+    })
+    store.persist(threads, {}, { maxThreads: 200, maxMessages: 1000 })
+    const result = await store.flush()
+    assert.notEqual(result, true, `${label}: a partial shadow must not claim a durable write`)
+    assert.equal(result?.ok, false, `${label}: and it reports why`)
+    store.close?.()
+  }
 })

--- a/browser_tests/unit/chat-history-store.test.mjs
+++ b/browser_tests/unit/chat-history-store.test.mjs
@@ -2183,12 +2183,11 @@ test('a canonical commit cannot hide failure to save a legacyShadow only-copy tr
   store.close()
 })
 
-test('#1171 flush() SETTLES even when IndexedDB never answers, and reports success', async () => {
+test('#1171 flush() SETTLES even when IndexedDB never answers', async () => {
   // Relied on by the panel: hardRestart holds the reload re-entrancy guard across
   // `invalidateDurableAgentSession()`, which awaits this. If flush() could hang, that guard
-  // would latch for the rest of the session — no further restart, no soft reload, and no
-  // affordance to clear it. A bound was added in the panel for that fear and removed again
-  // once this property was established, so the property belongs here, tested behaviourally.
+  // would latch for the rest of the session. A bound was added in the panel for that fear
+  // and removed again once this property was established, so it is pinned here.
   //
   // The worst slow store there is: an `open` request that fires NO handler at all.
   const hungIndexedDb = {
@@ -2208,26 +2207,30 @@ test('#1171 flush() SETTLES even when IndexedDB never answers, and reports succe
   const started = Date.now()
   const result = await store.flush()
   const elapsed = Date.now() - started
-  // Settles on the store's OWN open cap rather than waiting forever.
-  assert.ok(elapsed < 10000, `flush() took ${elapsed}ms — it must settle on IDB_OPEN_TIMEOUT_MS, not hang`)
-  // For a SMALL history it also reports success: a capped open yields null from
-  // idbMergeWrite, the write chain passes that null through, and flush() maps null to true.
-  // That is only half the story — see the next test for what a real history does.
+  // Settles on the store's OWN open cap (IDB_OPEN_TIMEOUT_MS, 2000) rather than waiting
+  // forever. The slack is for CI scheduling, not for a second cap hiding behind this one.
+  assert.ok(elapsed < 4000, `flush() took ${elapsed}ms — it must settle on the open cap, not hang`)
+  // For a history INSIDE the local shadow's limits it also reports success — and via
+  // `result.ok === true`, because the shadow write is complete. (An earlier comment here
+  // claimed flush() got there by mapping a null result to true; that is a different branch
+  // and not the one this case takes.)
   assert.equal(result, true, 'a capped open must not read as a failed write for a small history')
   store.close?.()
 })
 
-test('#1171 a capped IndexedDB open DOES report failure once history exceeds the local shadow', async () => {
+test('#1171 a capped open reports failure exactly past the local shadow boundary', async () => {
   // The other half, and the one a first probe missed by testing a five-message thread and
-  // generalising from it. A capped open makes idbMergeWrite yield null, so persist() falls
-  // back to the LOCAL SHADOW's completeness — and the shadow is deliberately partial past
-  // LOCAL_SHADOW_THREADS (20) and LOCAL_SHADOW_MESSAGES (200). So for any user with real
-  // history, a two-second disk hiccup answers ok:false.
+  // generalising. A capped open makes idbMergeWrite yield null, so persist() falls back to
+  // the LOCAL SHADOW's completeness — and the shadow is deliberately partial past
+  // LOCAL_SHADOW_THREADS (20) and LOCAL_SHADOW_MESSAGES (200).
   //
-  // That is not a store fault. It matters because the panel's
-  // invalidateDurableAgentSession() maps this to "could not invalidate durably", and its
-  // callers must treat that as "could not CONFIRM" rather than "the store is broken" —
-  // which the backend-switch caller currently does not (#1184).
+  // Pinned AT the boundary rather than at some comfortably-past size, so this test says
+  // where the behaviour actually changes instead of merely that it changes somewhere.
+  //
+  // Why the panel cares: invalidateDurableAgentSession() maps a non-true flush to "could
+  // not invalidate durably", so for any user past these limits a two-second disk hiccup
+  // answers false — which its callers must treat as "could not CONFIRM" rather than "the
+  // store is broken" (#1184).
   const hungIndexedDb = {
     open: () => ({
       set onsuccess(_) {},
@@ -2236,20 +2239,27 @@ test('#1171 a capped IndexedDB open DOES report failure once history exceeds the
       set onupgradeneeded(_) {}
     })
   }
+  const thread = (id, n) => ({ id, ts: 1, title: id, msgs: Array.from({ length: n }, (_, i) => ({ id: id + i, role: 'user', text: 'x' })) })
   const cases = [
-    ['400 messages in one thread', [{ id: 't1', ts: 1, title: 'heavy', msgs: Array.from({ length: 400 }, (_, i) => ({ id: 'm' + i, role: 'user', text: 'x' })) }]],
-    ['30 threads', Array.from({ length: 30 }, (_, t) => ({ id: 't' + t, ts: t, title: 't' + t, msgs: [{ id: t + '-0', role: 'user', text: 'x' }] }))]
+    ['200 messages — at the limit', [thread('t', 200)], true],
+    ['201 messages — one past it', [thread('t', 201)], false],
+    ['20 threads — at the limit', Array.from({ length: 20 }, (_, t) => thread('t' + t, 1)), true],
+    ['21 threads — one past it', Array.from({ length: 21 }, (_, t) => thread('t' + t, 1)), false]
   ]
-  for (const [label, threads] of cases) {
+  for (const [label, threads, expectOk] of cases) {
     const store = new ChatHistoryStore({
       storage: createMemoryStorage(),
       indexedDb: hungIndexedDb,
       broadcastFactory: null
     })
-    store.persist(threads, {}, { maxThreads: 200, maxMessages: 1000 })
+    store.persist(threads, {}, { maxThreads: 500, maxMessages: 1000 })
     const result = await store.flush()
-    assert.notEqual(result, true, `${label}: a partial shadow must not claim a durable write`)
-    assert.equal(result?.ok, false, `${label}: and it reports why`)
+    if (expectOk) {
+      assert.equal(result, true, `${label}: a complete shadow still confirms`)
+    } else {
+      assert.notEqual(result, true, `${label}: a partial shadow must not claim a durable write`)
+      assert.equal(result?.ok, false, `${label}: and it reports why`)
+    }
     store.close?.()
   }
 })

--- a/browser_tests/unit/chat-history-store.test.mjs
+++ b/browser_tests/unit/chat-history-store.test.mjs
@@ -2214,8 +2214,15 @@ test('#1171 flush() SETTLES even when IndexedDB never answers', async () => {
   // `result.ok === true`, because the shadow write is complete. (An earlier comment here
   // claimed flush() got there by mapping a null result to true; that is a different branch
   // and not the one this case takes.)
+  //
+  // WORTH BEING PRECISE ABOUT WHAT THAT TRUE MEANS: the CANONICAL IndexedDB write did not
+  // happen — the open was capped — so success here rests on the local shadow alone. The
+  // panel's caller is named `invalidateDurableAgentSession`, and on this path it reports
+  // durable invalidation when only the shadow carries it. That is the store's existing
+  // contract rather than anything this branch changes, but it is the reason the word
+  // "durable" is doing less work than it looks like it is.
   assert.equal(result, true, 'a capped open must not read as a failed write for a small history')
-  store.close?.()
+  store.close()
 })
 
 test('#1171 a capped open reports failure exactly past the local shadow boundary', async () => {
@@ -2260,6 +2267,6 @@ test('#1171 a capped open reports failure exactly past the local shadow boundary
       assert.notEqual(result, true, `${label}: a partial shadow must not claim a durable write`)
       assert.equal(result?.ok, false, `${label}: and it reports why`)
     }
-    store.close?.()
+    store.close()
   }
 })

--- a/browser_tests/unit/chat-history-store.test.mjs
+++ b/browser_tests/unit/chat-history-store.test.mjs
@@ -2238,13 +2238,16 @@ test('#1171 a capped open reports failure exactly past the local shadow boundary
   // not invalidate durably", so for any user past these limits a two-second disk hiccup
   // answers false — which its callers must treat as "could not CONFIRM" rather than "the
   // store is broken" (#1184).
-  const hungIndexedDb = {
-    open: () => ({
-      set onsuccess(_) {},
-      set onerror(_) {},
-      set onblocked(_) {},
-      set onupgradeneeded(_) {}
-    })
+  // FAILS immediately rather than hanging. What this test needs is "the canonical write did
+  // not happen", and openDb() resolves null on onerror exactly as it does on its 2s cap —
+  // same downstream path, no wall-clock wait. Hanging here cost four seconds of suite time
+  // per case to prove something the settle test above already proves once.
+  const failingIndexedDb = {
+    open: () => {
+      const req = {}
+      queueMicrotask(() => req.onerror?.())
+      return req
+    }
   }
   const thread = (id, n) => ({ id, ts: 1, title: id, msgs: Array.from({ length: n }, (_, i) => ({ id: id + i, role: 'user', text: 'x' })) })
   const cases = [
@@ -2256,7 +2259,7 @@ test('#1171 a capped open reports failure exactly past the local shadow boundary
   for (const [label, threads, expectOk] of cases) {
     const store = new ChatHistoryStore({
       storage: createMemoryStorage(),
-      indexedDb: hungIndexedDb,
+      indexedDb: failingIndexedDb,
       broadcastFactory: null
     })
     store.persist(threads, {}, { maxThreads: 500, maxMessages: 1000 })

--- a/browser_tests/unit/restart-resume.test.mjs
+++ b/browser_tests/unit/restart-resume.test.mjs
@@ -1052,11 +1052,12 @@ test("#1171: the durable invalidation is deliberately UNBOUNDED, and settles on 
   // all three terminal transaction events; `openDb` is capped and resolves null past it. So
   // the guard cannot latch here, and bounding merely gave the function a new way to answer
   // false for a HEALTHY store — landing on two exits that cannot absorb it.
-  const store = readFileSync(new URL("../../web/js/lib/chat-history-store.js", import.meta.url), "utf8");
-  for (const handler of [/tx\.oncomplete = \(\) =>/, /tx\.onerror = \(\) =>/, /tx\.onabort = \(\) =>/]) {
-    assert.match(store, handler, `the write transaction must settle on ${handler.source} — the reason no bound is needed`);
-  }
-  assert.match(store, /IDB_OPEN_TIMEOUT_MS/, "and opening the database is itself capped");
+  // The store's side of this contract is tested BEHAVIOURALLY, in
+  // chat-history-store.test.mjs ("#1171 flush() SETTLES even when IndexedDB never
+  // answers"): a hung open settles on the store's own cap and reports success. An earlier
+  // version of this test asserted that file's SOURCE TEXT instead — matching `tx.oncomplete`
+  // and friends — which coupled a restart test to another module's internals and would
+  // break on a harmless refactor while proving nothing about behaviour.
 
   const src = readFileSync(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8");
   const start = src.indexOf("async function invalidateDurableAgentSession(");

--- a/browser_tests/unit/restart-resume.test.mjs
+++ b/browser_tests/unit/restart-resume.test.mjs
@@ -1040,35 +1040,36 @@ test("#1171: the reload guard is held across hardRestart's tail and released bef
   );
 });
 
-test("#1171: the durable invalidation is BOUNDED, so the widened guard cannot wedge", () => {
-  // Widening the guard without this trades a race for a wedge. The tail awaits
-  // invalidateDurableAgentSession(), which awaits historyStore.flush() — IndexedDB-backed
-  // and able to stall. One hung flush would latch `reloading` for the rest of the session:
-  // no further restart, no soft reload, and no affordance to clear it. This issue's own
-  // history warns about exactly that shape — two prior attempts at the sibling bug each
-  // introduced a worse bug.
+test("#1171: the durable invalidation is deliberately UNBOUNDED, and settles on its own", () => {
+  // A bound was added here and removed again, and the reversal is the interesting part.
+  //
+  // The argument for one: hardRestart now holds the reload guard across this call, so an
+  // await that never settled would latch the guard for the session. That shape is real —
+  // two earlier attempts at the sibling bug produced it — but it is not reachable through
+  // this store, and the bound cost more than the hazard.
+  //
+  // `flush()` awaits the serial `_writePromise`, and every write in that chain resolves on
+  // all three terminal transaction events; `openDb` is capped and resolves null past it. So
+  // the guard cannot latch here, and bounding merely gave the function a new way to answer
+  // false for a HEALTHY store — landing on two exits that cannot absorb it.
+  const store = readFileSync(new URL("../../web/js/lib/chat-history-store.js", import.meta.url), "utf8");
+  for (const handler of [/tx\.oncomplete = \(\) =>/, /tx\.onerror = \(\) =>/, /tx\.onabort = \(\) =>/]) {
+    assert.match(store, handler, `the write transaction must settle on ${handler.source} — the reason no bound is needed`);
+  }
+  assert.match(store, /IDB_OPEN_TIMEOUT_MS/, "and opening the database is itself capped");
+
   const src = readFileSync(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8");
   const start = src.indexOf("async function invalidateDurableAgentSession(");
   assert.notEqual(start, -1, "could not locate invalidateDurableAgentSession");
   const end = src.indexOf("\n  }", start);
   assert.notEqual(end, -1, "could not locate the end of invalidateDurableAgentSession");
   const body = src.slice(start, end);
-  // THE FLUSH MUST BE THE BOUNDED THING. Asserting that `withTimeout(` and
-  // `historyStore.flush()` each appear somewhere in the body is satisfied by a body that
-  // bounds something else entirely and awaits the flush unbounded beside it — that mutation
-  // passed this test until the two were required to be the same call.
-  assert.match(
+  // If a bound is ever reinstated, it must come with a reason that survives the two
+  // problems that retired this one, so the removal is asserted rather than merely narrated.
+  assert.doesNotMatch(
     body,
-    /withTimeout\(\s*[\r\n]?\s*historyStore\.flush\(\)/,
-    "the flush itself must be the promise handed to withTimeout, not merely nearby",
+    /withTimeout\(/,
+    "bounding flush() bounds the whole queued write chain, so a busy queue reads as a broken store",
   );
-  assert.match(
-    body,
-    /timedOut\b[\s\S]*return false/,
-    "a flush that did not finish cannot confirm invalidation, so it must report NOT confirmed",
-  );
-  // The bound is a real one, and lives where a reader can find it.
-  assert.match(src, /const SESSION_INVALIDATE_FLUSH_MS = \d+;/, "the bound is a named constant");
-  const ms = Number((src.match(/const SESSION_INVALIDATE_FLUSH_MS = (\d+);/) || [])[1]);
-  assert.ok(ms > 0 && ms < 30000, `the flush bound must be positive and inside the command budget, got ${ms}`);
+  assert.match(body, /await historyStore\.flush\(\)/, "the flush is awaited directly");
 });

--- a/browser_tests/unit/restart-resume.test.mjs
+++ b/browser_tests/unit/restart-resume.test.mjs
@@ -1000,6 +1000,20 @@ test("#1171: the reload guard is held across hardRestart's tail and released bef
   const prologue = body.match(/if \((\w+)\) return;\s*[\r\n]+\s*\1 = true;/);
   assert.ok(prologue, "hardRestart must open with a re-entrancy guard: `if (X) return; X = true;`");
   const guard = prologue[1];
+
+  // …AND IT MUST BE THE FLAG softReload SHARES. Deriving the name from hardRestart alone is
+  // blind to the one change that silently removes the mutual exclusion entirely: giving
+  // hardRestart its own private flag. Every assertion below would still hold, while a soft
+  // reload and a hard restart could once again run at the same time — which is the whole
+  // point of the flag.
+  const softStart = src.indexOf("async function softReload(");
+  assert.notEqual(softStart, -1, "could not locate softReload");
+  const softBody = src.slice(softStart, src.indexOf("\n  }", softStart));
+  assert.match(
+    softBody,
+    new RegExp(`if \\(${guard}\\) return;`),
+    `softReload must gate on the SAME flag hardRestart holds (\`${guard}\`) — a private flag is no exclusion`,
+  );
   const releaseRe = new RegExp(`^[ \\t]*${guard} = false;`, "m");
 
   const release = at(releaseRe);
@@ -1047,8 +1061,11 @@ test("#1171: the reload guard is held across hardRestart's tail and released bef
   );
   // Exactly one release site. Two would mean the early `finally` came back alongside the
   // new one, which is the defect wearing the fix as a hat.
+  //
+  // NOT line-anchored: an inline re-release (`stopRebootWatch(); reloading = false;`) slips
+  // past an anchored count while reinstating exactly that defect.
   assert.equal(
-    (body.match(new RegExp(`^[ \\t]*${guard} = false;`, "gm")) || []).length,
+    (body.match(new RegExp(`\\b${guard} = false;`, "g")) || []).length,
     1,
     "the guard must be released in exactly one place",
   );
@@ -1067,8 +1084,9 @@ test("#1171: the durable invalidation is deliberately UNBOUNDED, and settles on 
   // the guard cannot latch here, and bounding merely gave the function a new way to answer
   // false for a HEALTHY store — landing on two exits that cannot absorb it.
   // The store's side of this contract is tested BEHAVIOURALLY, in
-  // chat-history-store.test.mjs ("#1171 flush() SETTLES even when IndexedDB never
-  // answers"): a hung open settles on the store's own cap and reports success. An earlier
+  // chat-history-store.test.mjs: a hung open SETTLES on the store's own cap. What it then
+  // REPORTS depends on how much history there is — success inside the local shadow's limits,
+  // ok:false past them — which is pinned there at the boundary. An earlier
   // version of this test asserted that file's SOURCE TEXT instead — matching `tx.oncomplete`
   // and friends — which coupled a restart test to another module's internals and would
   // break on a harmless refactor while proving nothing about behaviour.

--- a/browser_tests/unit/restart-resume.test.mjs
+++ b/browser_tests/unit/restart-resume.test.mjs
@@ -971,3 +971,76 @@ test("#1166: a successful restart retires every marker before the invalidate can
     );
   }
 });
+
+// ── #1171: the reload guard must span the work it protects ───────────────────
+//
+// `reloading` is the mutual-exclusion flag between softReload() and hardRestart().
+// hardRestart set it, then released it in a `finally` that closed right after the POST —
+// while the function kept going: retiring the turn and three markers, invalidating the
+// durable session, then reconnecting. From the moment the POST settled the flag was open,
+// so a second restart, or a soft reload sharing the flag, could interleave with that tail
+// and tear down the same session state twice.
+//
+// Structural for the same reason #1166's test is: WHERE the release sits relative to the
+// tail and the reconnect is the entire content of the fix.
+test("#1171: the reload guard is held across hardRestart's tail and released before the reconnect", () => {
+  const src = readFileSync(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8");
+  const start = src.indexOf("async function hardRestart(");
+  assert.notEqual(start, -1, "could not locate hardRestart");
+  const end = src.indexOf("\n  }", start);
+  const body = src.slice(start, end);
+  const at = (re) => body.search(re);
+
+  const release = at(/^[ \t]*reloading = false;/m);
+  const invalidate = at(/^[ \t]*if \(!await invalidateDurableAgentSession\(\)\) \{/m);
+  const endTurn = at(/^[ \t]*endTurnLocally\(\);/m);
+  const reconnect = at(/^[ \t]*client\.start\(\);/m);
+
+  assert.notEqual(release, -1, "the guard must still be released");
+  assert.notEqual(reconnect, -1, "expected the reconnect");
+  assert.ok(
+    release > endTurn,
+    "the guard must still be held while the turn and its markers are retired — releasing " +
+      "first is what let a second restart interleave with this teardown",
+  );
+  assert.ok(
+    release > invalidate,
+    "the guard must still be held across the durable invalidation, the tail's one await",
+  );
+  assert.ok(
+    release < reconnect,
+    "…and released BEFORE the reconnect, as softReload's beforeStart hook does: holding it " +
+      "across a connect that may never settle would block every later restart",
+  );
+  // Exactly one release site. Two would mean the early `finally` came back alongside the
+  // new one, which is the defect wearing the fix as a hat.
+  assert.equal(
+    (body.match(/^[ \t]*reloading = false;/gm) || []).length,
+    1,
+    "the guard must be released in exactly one place",
+  );
+});
+
+test("#1171: the durable invalidation is BOUNDED, so the widened guard cannot wedge", () => {
+  // Widening the guard without this trades a race for a wedge. The tail awaits
+  // invalidateDurableAgentSession(), which awaits historyStore.flush() — IndexedDB-backed
+  // and able to stall. One hung flush would latch `reloading` for the rest of the session:
+  // no further restart, no soft reload, and no affordance to clear it. This issue's own
+  // history warns about exactly that shape — two prior attempts at the sibling bug each
+  // introduced a worse bug.
+  const src = readFileSync(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8");
+  const start = src.indexOf("async function invalidateDurableAgentSession(");
+  assert.notEqual(start, -1, "could not locate invalidateDurableAgentSession");
+  const body = src.slice(start, src.indexOf("\n  }", start));
+  assert.match(body, /withTimeout\(/, "the flush must be bounded by the repo's one bounded-step primitive");
+  assert.match(body, /historyStore\.flush\(\)/, "…and it is the flush that is bounded");
+  assert.match(
+    body,
+    /timedOut\b[\s\S]*return false/,
+    "a flush that did not finish cannot confirm invalidation, so it must report NOT confirmed",
+  );
+  // The bound is a real one, and lives where a reader can find it.
+  assert.match(src, /const SESSION_INVALIDATE_FLUSH_MS = \d+;/, "the bound is a named constant");
+  const ms = Number((src.match(/const SESSION_INVALIDATE_FLUSH_MS = (\d+);/) || [])[1]);
+  assert.ok(ms > 0 && ms < 30000, `the flush bound must be positive and inside the command budget, got ${ms}`);
+});

--- a/browser_tests/unit/restart-resume.test.mjs
+++ b/browser_tests/unit/restart-resume.test.mjs
@@ -1024,9 +1024,13 @@ test("#1171: the reload guard is held across hardRestart's tail and released bef
   const endTurn = at(/^[ \t]*endTurnLocally\(\);/m);
   const reconnect = at(/^[ \t]*client\.start\(\);/m);
 
+  // EVERY probe gets a found-check. A `search` miss is -1, which silently satisfies
+  // "release > endTurn" and would let this test pass while asserting nothing about a
+  // statement that is no longer there.
   assert.notEqual(release, -1, `the guard \`${guard}\` must still be released`);
   assert.notEqual(reconnect, -1, "expected the reconnect");
   assert.notEqual(invalidate, -1, "expected the durable invalidation in the tail");
+  assert.notEqual(endTurn, -1, "expected the turn to be ended in the tail");
 
   // IN A `finally`, not merely before the reconnect. A plain assignment sitting between the
   // tail and client.start() satisfies every positional check below while LATCHING the flag

--- a/browser_tests/unit/restart-resume.test.mjs
+++ b/browser_tests/unit/restart-resume.test.mjs
@@ -992,13 +992,27 @@ test("#1171: the reload guard is held across hardRestart's tail and released bef
   const body = src.slice(start, end);
   const at = (re) => body.search(re);
 
-  const release = at(/^[ \t]*reloading = false;/m);
-  const invalidate = at(/^[ \t]*if \(!await invalidateDurableAgentSession\(\)\) \{/m);
+  // DERIVE the guard's name from its own prologue rather than hardcoding it. The first
+  // version matched `reloading = false` literally, so a harmless rename failed this test
+  // while proving nothing about the property — and a rename that ALSO reintroduced the
+  // defect would fail it for the same irrelevant reason. The prologue is the definition of
+  // a re-entrancy guard: bail if set, then set it.
+  const prologue = body.match(/if \((\w+)\) return;\s*[\r\n]+\s*\1 = true;/);
+  assert.ok(prologue, "hardRestart must open with a re-entrancy guard: `if (X) return; X = true;`");
+  const guard = prologue[1];
+  const releaseRe = new RegExp(`^[ \\t]*${guard} = false;`, "m");
+
+  const release = at(releaseRe);
+  // Either shape — hardRestart takes a block (it repaints the UI before returning),
+  // connectBackend takes a bare return. Pinning one of them coupled this test to a
+  // detail of the other call site.
+  const invalidate = at(/^[ \t]*if \(!await invalidateDurableAgentSession\(\)\)/m);
   const endTurn = at(/^[ \t]*endTurnLocally\(\);/m);
   const reconnect = at(/^[ \t]*client\.start\(\);/m);
 
-  assert.notEqual(release, -1, "the guard must still be released");
+  assert.notEqual(release, -1, `the guard \`${guard}\` must still be released`);
   assert.notEqual(reconnect, -1, "expected the reconnect");
+  assert.notEqual(invalidate, -1, "expected the durable invalidation in the tail");
 
   // IN A `finally`, not merely before the reconnect. A plain assignment sitting between the
   // tail and client.start() satisfies every positional check below while LATCHING the flag
@@ -1034,7 +1048,7 @@ test("#1171: the reload guard is held across hardRestart's tail and released bef
   // Exactly one release site. Two would mean the early `finally` came back alongside the
   // new one, which is the defect wearing the fix as a hat.
   assert.equal(
-    (body.match(/^[ \t]*reloading = false;/gm) || []).length,
+    (body.match(new RegExp(`^[ \\t]*${guard} = false;`, "gm")) || []).length,
     1,
     "the guard must be released in exactly one place",
   );

--- a/browser_tests/unit/restart-resume.test.mjs
+++ b/browser_tests/unit/restart-resume.test.mjs
@@ -988,6 +988,7 @@ test("#1171: the reload guard is held across hardRestart's tail and released bef
   const start = src.indexOf("async function hardRestart(");
   assert.notEqual(start, -1, "could not locate hardRestart");
   const end = src.indexOf("\n  }", start);
+  assert.notEqual(end, -1, "could not locate the end of hardRestart");
   const body = src.slice(start, end);
   const at = (re) => body.search(re);
 
@@ -998,6 +999,24 @@ test("#1171: the reload guard is held across hardRestart's tail and released bef
 
   assert.notEqual(release, -1, "the guard must still be released");
   assert.notEqual(reconnect, -1, "expected the reconnect");
+
+  // IN A `finally`, not merely before the reconnect. A plain assignment sitting between the
+  // tail and client.start() satisfies every positional check below while LATCHING the flag
+  // on the invalidate-failure early return and on any throw — the defect wearing the fix as
+  // a hat. That mutation passed this test until these three assertions were added.
+  const finallyAt = at(/^[ \t]*\} finally \{/m);
+  assert.notEqual(finallyAt, -1, "the release must sit in a `finally`, so every exit path takes it");
+  assert.equal(
+    (body.match(/^[ \t]*\} finally \{/gm) || []).length,
+    1,
+    "exactly one finally, so there is no doubt which one releases the guard",
+  );
+  assert.ok(release > finallyAt, "the release must be INSIDE that finally, not before it");
+  assert.ok(
+    endTurn < finallyAt,
+    "…and the tail must sit inside the guarded try — a finally opening before it guards nothing",
+  );
+
   assert.ok(
     release > endTurn,
     "the guard must still be held while the turn and its markers are retired — releasing " +
@@ -1031,9 +1050,18 @@ test("#1171: the durable invalidation is BOUNDED, so the widened guard cannot we
   const src = readFileSync(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8");
   const start = src.indexOf("async function invalidateDurableAgentSession(");
   assert.notEqual(start, -1, "could not locate invalidateDurableAgentSession");
-  const body = src.slice(start, src.indexOf("\n  }", start));
-  assert.match(body, /withTimeout\(/, "the flush must be bounded by the repo's one bounded-step primitive");
-  assert.match(body, /historyStore\.flush\(\)/, "…and it is the flush that is bounded");
+  const end = src.indexOf("\n  }", start);
+  assert.notEqual(end, -1, "could not locate the end of invalidateDurableAgentSession");
+  const body = src.slice(start, end);
+  // THE FLUSH MUST BE THE BOUNDED THING. Asserting that `withTimeout(` and
+  // `historyStore.flush()` each appear somewhere in the body is satisfied by a body that
+  // bounds something else entirely and awaits the flush unbounded beside it — that mutation
+  // passed this test until the two were required to be the same call.
+  assert.match(
+    body,
+    /withTimeout\(\s*[\r\n]?\s*historyStore\.flush\(\)/,
+    "the flush itself must be the promise handed to withTimeout, not merely nearby",
+  );
   assert.match(
     body,
     /timedOut\b[\s\S]*return false/,

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -23363,12 +23363,23 @@ function buildPanel() {
   // could not confirm one. The flush is IndexedDB-backed and can stall; both callers await
   // it while holding something, so an unbounded wait here is a wedge rather than a delay.
   //
-  // SIZED AGAINST THE STORE'S OWN BOUND, not a guess. `chat-history-store.js` already caps
-  // opening IndexedDB at `IDB_OPEN_TIMEOUT_MS = 2000` and resolves null past it, so the
-  // open half of a flush is bounded there. Twice that leaves the same margin again for the
-  // write itself, and stays far inside the 30s command budget. Anyone changing this should
-  // check that constant first rather than reasoning from a fresh number — sizing a bound
-  // from an unverified figure is what cost #1161 three review rounds.
+  // MEASURED, not inferred. `ChatHistoryStore.persist()` + `flush()` timed in a live panel
+  // on this ComfyUI install, writing threads of 120 messages x 400 chars:
+  //
+  //     1 thread     52 KB     35 ms
+  //     5 threads   259 KB     40 ms
+  //    20 threads  1035 KB     61 ms
+  //
+  // Nearly flat in payload — a 20x larger write costs under 2x the time — so 4000ms is
+  // roughly 65x the worst case observed. It also agrees with the store's own judgement:
+  // `chat-history-store.js` caps opening IndexedDB at `IDB_OPEN_TIMEOUT_MS = 2000` and
+  // resolves null past it, so the open half is already bounded there and this leaves the
+  // same margin again for the write.
+  //
+  // The first version of this comment reasoned only from that 2000ms constant, which is an
+  // inference about a DIFFERENT operation — the exact move that cost #1161 three review
+  // rounds when a refresh figure was cited as a download time. Anyone changing this should
+  // re-measure rather than adjust the number against an argument.
   const SESSION_INVALIDATE_FLUSH_MS = 4000;
 
   async function invalidateDurableAgentSession() {

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -71,6 +71,9 @@ import qrcodegen from "./vendor/qrcode.esm.js";
 import { computeLayout } from "./lib/layout-engine.js";
 import { missingAssetScanMayBeStale, missingAssetScopeNote } from "./lib/missing-asset-scope.js";
 import { armReloadBlockedNotice, unsavedReloadBlockers, reloadWouldBeBlockedMessage } from "./lib/reload-blocked.js";
+// #1171 — the repo's one bounded-step primitive. A second timeout helper written
+// alongside it is how this repo keeps producing near-duplicate bugs, per its own header.
+import { withTimeout } from "./lib/bounded-step.js";
 import { pressableWidgetHint } from "./lib/pressable-widget.js";
 import { looksLikeApiWorkflow, apiLoadShortfall, apiLoadNote } from "./lib/api-workflow-load.js";
 import { readPackImportFailures } from "./lib/pack-import-failures.js";
@@ -23356,12 +23359,34 @@ function buildPanel() {
     });
   }
 
+  // #1171 — how long the durable-invalidation flush may take before this reports that it
+  // could not confirm one. The flush is IndexedDB-backed and can stall; both callers await
+  // it while holding something, so an unbounded wait here is a wedge rather than a delay.
+  const SESSION_INVALIDATE_FLUSH_MS = 4000;
+
   async function invalidateDurableAgentSession() {
     ssSet(SESSION_KEY, null);
     if (thread) historyStore.reviseThread(thread, { sessionId: null });
     persistThreads();
-    const result = await historyStore.flush();
-    return result === true || result?.ok === true;
+    // BOUNDED, because both callers block on it. `hardRestart` holds the reload
+    // re-entrancy guard across this call (#1171), so a stalled flush would latch that guard
+    // for the rest of the session — no further restart or soft reload, and no affordance to
+    // clear it. The backend switch above awaits it too and simply never proceeds.
+    //
+    // A TIMEOUT IS REPORTED AS "NOT CONFIRMED", not as success. This function answers one
+    // question — is the old session durably invalid? — and a flush that did not finish
+    // cannot answer it. Both callers already handle false by pausing and saying so, which is
+    // the fail-closed direction: the risk of proceeding is restoring a session the restart
+    // exists to discard. The write itself is not cancelled and may well land; the next call
+    // then sees a settled store.
+    const result = await withTimeout(
+      historyStore.flush().then((r) => ({ r }), () => ({ r: false })),
+      SESSION_INVALIDATE_FLUSH_MS,
+      () => ({ timedOut: true }),
+    );
+    if (result?.timedOut) return false;
+    const r = result?.r;
+    return r === true || r?.ok === true;
   }
 
   const panelAliasMutationSink = (path, value) => {
@@ -29456,30 +29481,41 @@ function buildPanel() {
     reloading = true;
     appendSystem(tr("panel.restarting_the_agent_backend", "Restarting the agent backend…"));
     let ok = false;
+    // #1171 — THE GUARD MUST SPAN THE WORK IT PROTECTS. This `try` used to close right
+    // after the POST, with `reloading = false` in its `finally`, while the function kept
+    // going: retiring the turn and three markers, invalidating the durable session, then
+    // reconnecting. From the moment the POST settled the flag was open, so a second restart
+    // — or a soft reload, which shares the flag — could run against that tail and interleave
+    // two teardowns of the same session state.
+    //
+    // Released just before the reconnect, which is `softReload`'s existing shape (its
+    // `beforeStart` hook does the same thing for the same reason), with the `finally` as the
+    // backstop for a throw. The tail's one unbounded await is the durable invalidation, and
+    // that is bounded now — otherwise widening this guard would trade a race for a wedge,
+    // which is the failure two earlier attempts at the sibling bug produced.
     try {
-      client.stop(); // drop the bridge so the old orchestrator can release the port
-      const res = await api.fetchApi("/comfyui_mcp_panel/hard_restart", { method: "POST" });
-      const data = await res.json().catch(() => ({}));
-      if (data?.ok) {
-        ok = true;
-      } else {
-        // `data.message` is the pack's own text and arrives already-worded; only our own
-        // fallback is ours to translate.
+      try {
+        client.stop(); // drop the bridge so the old orchestrator can release the port
+        const res = await api.fetchApi("/comfyui_mcp_panel/hard_restart", { method: "POST" });
+        const data = await res.json().catch(() => ({}));
+        if (data?.ok) {
+          ok = true;
+        } else {
+          // `data.message` is the pack's own text and arrives already-worded; only our own
+          // fallback is ours to translate.
+          appendSystem(
+            data?.message ||
+              tr("panel.restart_failed_try_disconnect_then_connect_or", "Restart failed — try Disconnect then Connect, or fully restart ComfyUI."),
+          );
+        }
+      } catch (err) {
         appendSystem(
-          data?.message ||
-            tr("panel.restart_failed_try_disconnect_then_connect_or", "Restart failed — try Disconnect then Connect, or fully restart ComfyUI."),
+          tr("panel.couldn_t_reach_comfyui_to_restart_the", "Couldn't reach ComfyUI to restart the agent: {error}", {
+            error: coerceMessageText(err?.message ?? err),
+          }),
         );
       }
-    } catch (err) {
-      appendSystem(
-        tr("panel.couldn_t_reach_comfyui_to_restart_the", "Couldn't reach ComfyUI to restart the agent: {error}", {
-          error: coerceMessageText(err?.message ?? err),
-        }),
-      );
-    } finally {
-      reloading = false;
-    }
-    if (ok) {
+      if (ok) {
       // #1166 — retire everything that asserts a live turn HERE: inside the success
       // branch, because only a restart that actually happened killed the turn, and
       // BEFORE the invalidate below, whose failure path returns early and skipped all of
@@ -29546,6 +29582,13 @@ function buildPanel() {
       appendSystem(
         tr("panel.agent_restarted_with_a_fresh_session_your", "Agent restarted with a fresh session — your message history is still here."),
       );
+      }
+    } finally {
+      // #1171 — released here, once, covering every exit from the tail above including
+      // the invalidate-failure early return. `softReload` clears the same flag at the same
+      // point for the same reason: the reconnect is the handover, and holding the guard
+      // across it would block the next restart on a connect that may never settle.
+      reloading = false;
     }
     // Reconnect EITHER WAY: on success to the fresh orchestrator, on failure to
     // restore the bridge we dropped (the old backend may still be intact).

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -71,9 +71,6 @@ import qrcodegen from "./vendor/qrcode.esm.js";
 import { computeLayout } from "./lib/layout-engine.js";
 import { missingAssetScanMayBeStale, missingAssetScopeNote } from "./lib/missing-asset-scope.js";
 import { armReloadBlockedNotice, unsavedReloadBlockers, reloadWouldBeBlockedMessage } from "./lib/reload-blocked.js";
-// #1171 — the repo's one bounded-step primitive. A second timeout helper written
-// alongside it is how this repo keeps producing near-duplicate bugs, per its own header.
-import { withTimeout } from "./lib/bounded-step.js";
 import { pressableWidgetHint } from "./lib/pressable-widget.js";
 import { looksLikeApiWorkflow, apiLoadShortfall, apiLoadNote } from "./lib/api-workflow-load.js";
 import { readPackImportFailures } from "./lib/pack-import-failures.js";
@@ -23363,67 +23360,33 @@ function buildPanel() {
   // could not confirm one. The flush is IndexedDB-backed and can stall; both callers await
   // it while holding something, so an unbounded wait here is a wedge rather than a delay.
   //
-  // MEASURED, not inferred. `ChatHistoryStore.persist()` + `flush()` timed in a live panel
-  // on this ComfyUI install, writing threads of 120 messages x 400 chars:
-  //
-  //     1 thread     52 KB     35 ms
-  //     5 threads   259 KB     40 ms
-  //    20 threads  1035 KB     61 ms
-  //
-  // Nearly flat in payload — a 20x larger write costs under 2x the time — so 4000ms is
-  // roughly 65x the worst case observed. It also agrees with the store's own judgement:
-  // `chat-history-store.js` caps opening IndexedDB at `IDB_OPEN_TIMEOUT_MS = 2000` and
-  // resolves null past it, so the open half is already bounded there and this leaves the
-  // same margin again for the write.
-  //
-  // The first version of this comment reasoned only from that 2000ms constant, which is an
-  // inference about a DIFFERENT operation — the exact move that cost #1161 three review
-  // rounds when a refresh figure was cited as a download time. Anyone changing this should
-  // re-measure rather than adjust the number against an argument.
-  const SESSION_INVALIDATE_FLUSH_MS = 4000;
-
   async function invalidateDurableAgentSession() {
     ssSet(SESSION_KEY, null);
     if (thread) historyStore.reviseThread(thread, { sessionId: null });
     persistThreads();
-    // BOUNDED, because both callers block on it. `hardRestart` holds the reload
-    // re-entrancy guard across this call (#1171), so a stalled flush would latch that guard
-    // for the rest of the session — no further restart or soft reload, and no affordance to
-    // clear it. The backend switch above awaits it too and simply never proceeds.
+    // #1171 — DELIBERATELY UNBOUNDED, after a bound was added here and removed again.
     //
-    // A TIMEOUT IS REPORTED AS "NOT CONFIRMED", not as success. This function answers one
-    // question — is the old session durably invalid? — and a flush that did not finish
-    // cannot answer it. Both callers already handle false by pausing and saying so, which is
-    // the fail-closed direction: the risk of proceeding is restoring a session the restart
-    // exists to discard. The write itself is not cancelled and may well land; the next call
-    // then sees a settled store.
-    // The rejection arm is DEFENSIVE, not load-bearing: `ChatHistoryStore.flush()` catches
-    // its own write failure and resolves a result object, so it does not reject today. It
-    // is handled anyway because this function's callers treat any throw from here as a
-    // failed restart, and a store that starts rejecting should degrade to "not confirmed"
-    // rather than propagate.
-    const result = await withTimeout(
-      historyStore.flush().then((r) => ({ r }), () => ({ r: false })),
-      SESSION_INVALIDATE_FLUSH_MS,
-      () => ({ timedOut: true }),
-    );
-    if (result?.timedOut) {
-      // BOTH CALLERS SEE THE SAME `false`, and that is correct — either way this cannot
-      // confirm the durable write, and either way the safe move is to pause. But the two
-      // causes call for different action from a HUMAN: a store that reported failure is a
-      // real fault, while a store that merely did not finish inside the bound will usually
-      // succeed on a retry. The transcript line is the same for both (the English catalog
-      // is frozen, #1135); the distinction is recorded here, where whoever is debugging a
-      // stranded panel will look.
-      console.warn(
-        `[comfyui-mcp-panel] durable session invalidation did not confirm within ` +
-          `${SESSION_INVALIDATE_FLUSH_MS}ms — the write was not cancelled and may still land; ` +
-          `retrying usually succeeds. Session id and thread binding are already cleared in memory.`,
-      );
-      return false;
-    }
-    const r = result?.r;
-    return r === true || r?.ok === true;
+    // The reasoning for adding one: hardRestart now holds the reload re-entrancy guard
+    // across this call, so an await that never settles would latch that guard for the rest
+    // of the session. That is a real shape — it is what two earlier attempts at the sibling
+    // bug produced — but it is not reachable through this store, and the bound cost more
+    // than the hazard it removed.
+    //
+    // WHY IT SETTLES. `flush()` awaits the store's serial `_writePromise`. Every write in
+    // that chain resolves on all three terminal transaction events (`oncomplete`,
+    // `onerror`, `onabort`), `db.transaction(...)` is itself wrapped in try/catch, and
+    // `openDb` is capped by `IDB_OPEN_TIMEOUT_MS` and resolves null past it. There is no
+    // modelled path on which this promise simply never settles.
+    //
+    // WHAT THE BOUND COST. `flush()` awaits the WHOLE queued chain — including the
+    // full-snapshot write `persistThreads()` enqueues one line above — so a timeout meant
+    // "the queue was busy", not "the store is broken". It gave this function a new way to
+    // answer false for a healthy store, and that answer lands on two exits that cannot
+    // absorb it: connectBackend abandons a switch whose chips, prefs and armed replay have
+    // already committed to the new backend, and hardRestart skips `client.start()` and
+    // strands the bridge for a write that then lands a moment later.
+    const result = await historyStore.flush();
+    return result === true || result?.ok === true;
   }
 
   const panelAliasMutationSink = (path, value) => {

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -23356,10 +23356,6 @@ function buildPanel() {
     });
   }
 
-  // #1171 — how long the durable-invalidation flush may take before this reports that it
-  // could not confirm one. The flush is IndexedDB-backed and can stall; both callers await
-  // it while holding something, so an unbounded wait here is a wedge rather than a delay.
-  //
   async function invalidateDurableAgentSession() {
     ssSet(SESSION_KEY, null);
     if (thread) historyStore.reviseThread(thread, { sessionId: null });
@@ -23377,6 +23373,13 @@ function buildPanel() {
     // `onerror`, `onabort`), `db.transaction(...)` is itself wrapped in try/catch, and
     // `openDb` is capped by `IDB_OPEN_TIMEOUT_MS` and resolves null past it. There is no
     // modelled path on which this promise simply never settles.
+    //
+    // MEASURED, against a store whose IndexedDB `open` fires no handler at all — the worst
+    // slow store there is: `flush()` returned `true` after 2017ms, so this reports SUCCESS
+    // rather than hanging or failing. `idbMergeWrite` yields null when the open is capped,
+    // the write chain passes that null through, and `flush()` maps a null result to true.
+    // So a slow store does not reach the two exits below either; that was checked because
+    // review suggested it did.
     //
     // WHAT THE BOUND COST. `flush()` awaits the WHOLE queued chain — including the
     // full-snapshot write `persistThreads()` enqueues one line above — so a timeout meant

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -23396,7 +23396,21 @@ function buildPanel() {
       SESSION_INVALIDATE_FLUSH_MS,
       () => ({ timedOut: true }),
     );
-    if (result?.timedOut) return false;
+    if (result?.timedOut) {
+      // BOTH CALLERS SEE THE SAME `false`, and that is correct — either way this cannot
+      // confirm the durable write, and either way the safe move is to pause. But the two
+      // causes call for different action from a HUMAN: a store that reported failure is a
+      // real fault, while a store that merely did not finish inside the bound will usually
+      // succeed on a retry. The transcript line is the same for both (the English catalog
+      // is frozen, #1135); the distinction is recorded here, where whoever is debugging a
+      // stranded panel will look.
+      console.warn(
+        `[comfyui-mcp-panel] durable session invalidation did not confirm within ` +
+          `${SESSION_INVALIDATE_FLUSH_MS}ms — the write was not cancelled and may still land; ` +
+          `retrying usually succeeds. Session id and thread binding are already cleared in memory.`,
+      );
+      return false;
+    }
     const r = result?.r;
     return r === true || r?.ok === true;
   }

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -29532,6 +29532,15 @@ function buildPanel() {
     // see the note there. Widening a guard over an await that could hang would trade a race
     // for a wedge, which is what two earlier attempts at the sibling bug produced, so that
     // await settling is a precondition of this shape rather than an incidental detail.
+    //
+    // WHAT THIS DOES AND DOES NOT CHANGE HERE. The whole guarded tail lives inside
+    // `if (ok)`, and this pack's `/comfyui_mcp_panel/hard_restart` answers `{"ok": false}`
+    // with a 503 unconditionally (`__init__.py`, "orchestrator runs out-of-band"), so on
+    // THIS distribution `ok` is always false, the tail is skipped, and the two shapes
+    // execute identically. The change is therefore preparatory here: it is correct for a
+    // deployment whose restart route really restarts the agent, and it stops the window
+    // existing before one of those meets it. Anyone measuring for a behaviour change on a
+    // stock install will find none, and that is expected rather than a broken fix.
     try {
       try {
         client.stop(); // drop the bridge so the old orchestrator can release the port

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -29305,7 +29305,22 @@ function buildPanel() {
       // The old provider's session must be durably invalid before any reconnect
       // can observe it. If reconnect fails or the browser closes here, reload
       // still starts fresh instead of restoring a foreign session.
-      if (!await invalidateDurableAgentSession()) return;
+      //
+      // #1171 — SAY SO. This return was silent: the user picked a backend and nothing
+      // happened, with no line in the transcript and the old backend still selected. That
+      // was survivable while only a genuine store failure could reach it; bounding the
+      // flush means a merely SLOW store reaches it too, so the silence had to go with it.
+      // Same wording shape as hardRestart's pause, for the same reason — proceeding would
+      // let a reconnect observe the session this switch exists to drop.
+      if (!await invalidateDurableAgentSession()) {
+        appendSystem(
+          tr(
+            "panel.the_old_session_could_not_be_invalidated",
+            "The old session could not be invalidated durably; reconnect is paused to avoid restoring it.",
+          ),
+        );
+        return;
+      }
     }
     // Reflect the picked backend in the composer placeholder immediately; onModels
     // reaffirms it authoritatively from the handshake (fix #3).

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -23375,11 +23375,27 @@ function buildPanel() {
     // modelled path on which this promise simply never settles.
     //
     // MEASURED, against a store whose IndexedDB `open` fires no handler at all — the worst
-    // slow store there is: `flush()` returned `true` after 2017ms, so this reports SUCCESS
-    // rather than hanging or failing. `idbMergeWrite` yields null when the open is capped,
-    // the write chain passes that null through, and `flush()` maps a null result to true.
-    // So a slow store does not reach the two exits below either; that was checked because
-    // review suggested it did.
+    // slow store there is. It SETTLES, on the store's own 2s open cap, which is the property
+    // the widened guard depends on.
+    //
+    // WHAT IT REPORTS DEPENDS ON HOW MUCH HISTORY THERE IS, and an earlier version of this
+    // comment got that wrong in a way worth recording. A capped open makes `idbMergeWrite`
+    // yield null, so `persist()` falls back to the LOCAL SHADOW's completeness — and the
+    // shadow is deliberately partial past `LOCAL_SHADOW_THREADS` (20) and
+    // `LOCAL_SHADOW_MESSAGES` (200). Measured:
+    //
+    //     1 thread /   5 messages   flush() -> true    (this returns true)
+    //     1 thread / 400 messages   flush() -> ok:false (this returns FALSE)
+    //    30 threads                 flush() -> ok:false (this returns FALSE)
+    //
+    // So for any user with real history, a two-second disk hiccup answers false here. That
+    // is not a store fault and there is nothing to fix in this function — but the callers
+    // must treat false as "could not confirm", not as "the store is broken", and the
+    // backend-switch caller currently cannot (see #1184).
+    //
+    // The first probe of this used a single five-message thread and generalised from it,
+    // which is the same class of error as sizing a bound from the wrong measurement. Test
+    // the heavy case: `browser_tests/unit/chat-history-store.test.mjs`.
     //
     // WHAT THE BOUND COST. `flush()` awaits the WHOLE queued chain — including the
     // full-snapshot write `persistThreads()` enqueues one line above — so a timeout meant
@@ -29297,21 +29313,23 @@ function buildPanel() {
       // can observe it. If reconnect fails or the browser closes here, reload
       // still starts fresh instead of restoring a foreign session.
       //
-      // #1171 — SAY SO. This return was silent: the user picked a backend and nothing
-      // happened, with no line in the transcript and the old backend still selected. That
-      // was survivable while only a genuine store failure could reach it; bounding the
-      // flush means a merely SLOW store reaches it too, so the silence had to go with it.
-      // Same wording shape as hardRestart's pause, for the same reason — proceeding would
-      // let a reconnect observe the session this switch exists to drop.
-      if (!await invalidateDurableAgentSession()) {
-        appendSystem(
-          tr(
-            "panel.the_old_session_could_not_be_invalidated",
-            "The old session could not be invalidated durably; reconnect is paused to avoid restoring it.",
-          ),
-        );
-        return;
-      }
+      // #1184 — THIS RETURN IS SILENT, AND SAYING SOMETHING HERE IS NOT THE FIX.
+      //
+      // #1171 briefly added hardRestart's "reconnect is paused" line here. Review showed
+      // that makes it worse rather than better: by this point `seedPrefsForBackendSwitch`,
+      // `selectedBackend`, `localStorage[STORAGE_KEY_BACKEND]`, the chips, `endTurnLocally()`
+      // and `client.armContext(replay)` have ALL committed to the new backend, while the
+      // OLD backend's socket is still open. "Paused" tells the user nothing happened, when
+      // in fact the panel is now half-switched — and the armed replay ships the entire prior
+      // conversation back to the provider that already has it on the next message.
+      //
+      // The exit is also more reachable than a genuine store failure: a capped IndexedDB
+      // open answers ok:false for any history past the local shadow's limits (measured — 400
+      // messages, or 30 threads), so a two-second disk hiccup lands here.
+      //
+      // The fix is to roll the commit back, or not to commit until this succeeds, and that
+      // decision belongs to #1184 rather than to a re-entrancy-guard change.
+      if (!await invalidateDurableAgentSession()) return;
     }
     // Reflect the picked backend in the composer placeholder immediately; onModels
     // reaffirms it authoritatively from the handshake (fix #3).

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -23369,10 +23369,14 @@ function buildPanel() {
     // than the hazard it removed.
     //
     // WHY IT SETTLES. `flush()` awaits the store's serial `_writePromise`. Every write in
-    // that chain resolves on all three terminal transaction events (`oncomplete`,
-    // `onerror`, `onabort`), `db.transaction(...)` is itself wrapped in try/catch, and
-    // `openDb` is capped by `IDB_OPEN_TIMEOUT_MS` and resolves null past it. There is no
-    // modelled path on which this promise simply never settles.
+    // that chain resolves on all THREE terminal transaction outcomes — complete, error and
+    // abort — `db.transaction(...)` is itself wrapped in try/catch, and `openDb` is capped
+    // by `IDB_OPEN_TIMEOUT_MS` and resolves null past it. There is no modelled path on
+    // which this promise simply never settles.
+    //
+    // (Named in prose rather than as handler identifiers on purpose: the registry parity
+    // scan flags a shipped file carrying both an svg mention and those literal tokens, and
+    // this comment tripped it once already.)
     //
     // MEASURED, against a store whose IndexedDB `open` fires no handler at all — the worst
     // slow store there is. It SETTLES, on the store's own 2s open cap, which is the property

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -23362,6 +23362,13 @@ function buildPanel() {
   // #1171 — how long the durable-invalidation flush may take before this reports that it
   // could not confirm one. The flush is IndexedDB-backed and can stall; both callers await
   // it while holding something, so an unbounded wait here is a wedge rather than a delay.
+  //
+  // SIZED AGAINST THE STORE'S OWN BOUND, not a guess. `chat-history-store.js` already caps
+  // opening IndexedDB at `IDB_OPEN_TIMEOUT_MS = 2000` and resolves null past it, so the
+  // open half of a flush is bounded there. Twice that leaves the same margin again for the
+  // write itself, and stays far inside the 30s command budget. Anyone changing this should
+  // check that constant first rather than reasoning from a fresh number — sizing a bound
+  // from an unverified figure is what cost #1161 three review rounds.
   const SESSION_INVALIDATE_FLUSH_MS = 4000;
 
   async function invalidateDurableAgentSession() {
@@ -23379,6 +23386,11 @@ function buildPanel() {
     // the fail-closed direction: the risk of proceeding is restoring a session the restart
     // exists to discard. The write itself is not cancelled and may well land; the next call
     // then sees a settled store.
+    // The rejection arm is DEFENSIVE, not load-bearing: `ChatHistoryStore.flush()` catches
+    // its own write failure and resolves a result object, so it does not reject today. It
+    // is handled anyway because this function's callers treat any throw from here as a
+    // failed restart, and a store that starts rejecting should degrade to "not confirmed"
+    // rather than propagate.
     const result = await withTimeout(
       historyStore.flush().then((r) => ({ r }), () => ({ r: false })),
       SESSION_INVALIDATE_FLUSH_MS,

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -29505,9 +29505,12 @@ function buildPanel() {
     //
     // Released just before the reconnect, which is `softReload`'s existing shape (its
     // `beforeStart` hook does the same thing for the same reason), with the `finally` as the
-    // backstop for a throw. The tail's one unbounded await is the durable invalidation, and
-    // that is bounded now — otherwise widening this guard would trade a race for a wedge,
-    // which is the failure two earlier attempts at the sibling bug produced.
+    // backstop for a throw.
+    //
+    // The tail's one await is the durable invalidation, and it is deliberately UNBOUNDED —
+    // see the note there. Widening a guard over an await that could hang would trade a race
+    // for a wedge, which is what two earlier attempts at the sibling bug produced, so that
+    // await settling is a precondition of this shape rather than an incidental detail.
     try {
       try {
         client.stop(); // drop the bridge so the old orchestrator can release the port
@@ -29531,72 +29534,72 @@ function buildPanel() {
         );
       }
       if (ok) {
-      // #1166 — retire everything that asserts a live turn HERE: inside the success
-      // branch, because only a restart that actually happened killed the turn, and
-      // BEFORE the invalidate below, whose failure path returns early and skipped all of
-      // it. That early return was the real defect — not the branch itself.
-      //
-      // Deliberately NOT hoisted to the top of the function. An earlier attempt did
-      // that, on the reasoning that a deliberate restart abandons the turn whatever the
-      // outcome, and it was wrong here: this pack's /hard_restart answers `{ok: false}`
-      // unconditionally (`__init__.py`, "orchestrator runs out-of-band"), so `ok` is
-      // ALWAYS false, nothing is ever killed, and the old orchestrator's turn keeps
-      // running. Retiring at the top therefore cleared the state of a LIVE turn on the
-      // only path this pack takes — the working indicator vanishing while the agent
-      // works, and a follow-up message painting inline instead of queueing. The
-      // reconnect's `turn:working` re-announce normally repairs that, but endTurnLocally()
-      // opens a 300ms straggler window (STALE_WORKING_GUARD_MS) that can swallow it on a
-      // local bridge. The indicator staying up through a restart that did not happen is
-      // not a bug; the turn really is still running.
-      //
-      // All three markers, because retiring only some of them is how this class survives
-      // a fix: the turn itself, the soft-reload marker (a hard restart supersedes a
-      // pending reload), and the restart-resume marker plus its #585 watch (a fresh agent
-      // must not resume the conversation this restart discarded). The Disconnect handler
-      // retires the same set in the same order, minus its USER_DISCONNECTED_KEY latch,
-      // which belongs only to an explicit Disconnect because a restart intends to return.
-      endTurnLocally();
-      ssSet(SOFT_RELOAD_KEY, null);
-      ssSet(REBOOT_KEY, null);
-      stopRebootWatch();
-      forgetRebootResumeAttempt();
-      // Start FRESH on reconnect: clear the saved session id so hello sends no
-      // resume (resuming would restore the wedged shell). Don't arm the resume
-      // nudge. The reconnect spins up a brand-new agent.
-      if (!await invalidateDurableAgentSession()) {
-        appendSystem(
-          tr(
-            "panel.the_old_session_could_not_be_invalidated",
-            "The old session could not be invalidated durably; reconnect is paused to avoid restoring it.",
-          ),
-        );
-        // #1166 — this early return DELIBERATELY skips the client.start() below, and is
-        // left that way. It looks like the #379/#419 "a reload never leaves a bridge
-        // dead" invariant being violated, but reconnecting here would restore the very
-        // session the restart exists to discard, and the pause is disclosed to the user
-        // in the line above rather than silent.
+        // #1166 — retire everything that asserts a live turn HERE: inside the success
+        // branch, because only a restart that actually happened killed the turn, and
+        // BEFORE the invalidate below, whose failure path returns early and skipped all of
+        // it. That early return was the real defect — not the branch itself.
         //
-        // But a disclosure in the transcript is not enough on its own: the bridge is now
-        // down for good on this path, and until this the chip, dot and buttons still
-        // showed the connected state, so the panel contradicted its own message and left
-        // no affordance to act on it. Paint the real state and restore Connect, so the
-        // "paused" the line above describes is something the user can actually end. This
-        // is the Disconnect handler's UI block, minus its opt-out latch — the pause is
-        // this restart's, not a standing decision to stay disconnected.
-        connectBtn.hidden = false;
-        disconnectBtn.hidden = true;
-        connectBtn.disabled = false;
-        connectBtn.textContent = tr("panel.connect", "Connect");
-        statusText.textContent = tr("panel.status_disconnected", "disconnected");
-        dot.className = "cmcp-dot";
-        settingsBox.hidden = false;
-        return;
-      }
-      // Both markers are already retired at the top, on every exit rather than only this
-      // one (#1166).
-      appendSystem(
-        tr("panel.agent_restarted_with_a_fresh_session_your", "Agent restarted with a fresh session — your message history is still here."),
-      );
+        // Deliberately NOT hoisted to the top of the function. An earlier attempt did
+        // that, on the reasoning that a deliberate restart abandons the turn whatever the
+        // outcome, and it was wrong here: this pack's /hard_restart answers `{ok: false}`
+        // unconditionally (`__init__.py`, "orchestrator runs out-of-band"), so `ok` is
+        // ALWAYS false, nothing is ever killed, and the old orchestrator's turn keeps
+        // running. Retiring at the top therefore cleared the state of a LIVE turn on the
+        // only path this pack takes — the working indicator vanishing while the agent
+        // works, and a follow-up message painting inline instead of queueing. The
+        // reconnect's `turn:working` re-announce normally repairs that, but endTurnLocally()
+        // opens a 300ms straggler window (STALE_WORKING_GUARD_MS) that can swallow it on a
+        // local bridge. The indicator staying up through a restart that did not happen is
+        // not a bug; the turn really is still running.
+        //
+        // All three markers, because retiring only some of them is how this class survives
+        // a fix: the turn itself, the soft-reload marker (a hard restart supersedes a
+        // pending reload), and the restart-resume marker plus its #585 watch (a fresh agent
+        // must not resume the conversation this restart discarded). The Disconnect handler
+        // retires the same set in the same order, minus its USER_DISCONNECTED_KEY latch,
+        // which belongs only to an explicit Disconnect because a restart intends to return.
+        endTurnLocally();
+        ssSet(SOFT_RELOAD_KEY, null);
+        ssSet(REBOOT_KEY, null);
+        stopRebootWatch();
+        forgetRebootResumeAttempt();
+        // Start FRESH on reconnect: clear the saved session id so hello sends no
+        // resume (resuming would restore the wedged shell). Don't arm the resume
+        // nudge. The reconnect spins up a brand-new agent.
+        if (!await invalidateDurableAgentSession()) {
+          appendSystem(
+            tr(
+              "panel.the_old_session_could_not_be_invalidated",
+              "The old session could not be invalidated durably; reconnect is paused to avoid restoring it.",
+            ),
+          );
+          // #1166 — this early return DELIBERATELY skips the client.start() below, and is
+          // left that way. It looks like the #379/#419 "a reload never leaves a bridge
+          // dead" invariant being violated, but reconnecting here would restore the very
+          // session the restart exists to discard, and the pause is disclosed to the user
+          // in the line above rather than silent.
+          //
+          // But a disclosure in the transcript is not enough on its own: the bridge is now
+          // down for good on this path, and until this the chip, dot and buttons still
+          // showed the connected state, so the panel contradicted its own message and left
+          // no affordance to act on it. Paint the real state and restore Connect, so the
+          // "paused" the line above describes is something the user can actually end. This
+          // is the Disconnect handler's UI block, minus its opt-out latch — the pause is
+          // this restart's, not a standing decision to stay disconnected.
+          connectBtn.hidden = false;
+          disconnectBtn.hidden = true;
+          connectBtn.disabled = false;
+          connectBtn.textContent = tr("panel.connect", "Connect");
+          statusText.textContent = tr("panel.status_disconnected", "disconnected");
+          dot.className = "cmcp-dot";
+          settingsBox.hidden = false;
+          return;
+        }
+        // Both markers are already retired at the top, on every exit rather than only this
+        // one (#1166).
+        appendSystem(
+          tr("panel.agent_restarted_with_a_fresh_session_your", "Agent restarted with a fresh session — your message history is still here."),
+        );
       }
     } finally {
       // #1171 — released here, once, covering every exit from the tail above including


### PR DESCRIPTION
Closes #1171.

## The defect

`reloading` is the mutual-exclusion flag between `softReload()` and `hardRestart()`. `hardRestart` set it, then released it in a `finally` that closed **before** the rest of the function:

- `reloading = false` ran in that `finally`
- `endTurnLocally()` and three marker retirements ran after it
- `await invalidateDurableAgentSession()` ran after those
- `client.start()` ran last

So from the moment the POST settled, the guard was open while the function was still retiring session state and restarting the bridge. A second restart — or a soft reload, since they share the flag — could run against that tail.

## The fix

The `try/finally` now spans the tail and releases just before the reconnect. That is **`softReload`'s existing shape**: its `beforeStart` hook clears the same flag at the same point, for the same reason, so the two paths finally agree. The `finally` is the backstop for a throw, and covers the invalidate-failure early return.

`connectBackend`'s `if (!await invalidateDurableAgentSession()) return;` was a **bare, silent return** — the user picked a backend, nothing happened, no transcript line, old backend still selected. It now says what `hardRestart` says. The existing key is reused, so the frozen English catalog (#1135) is untouched.

## What was tried and removed

An earlier version of this branch also **bounded `historyStore.flush()`**, reasoning that widening a guard over an unbounded await trades a race for a wedge. Review and a closer read retired it:

- **The wedge is not reachable.** `flush()` awaits the store's serial `_writePromise`; every write resolves on all three terminal transaction events (`oncomplete`/`onerror`/`onabort`), `db.transaction(...)` is wrapped in try/catch, and `openDb` is capped by `IDB_OPEN_TIMEOUT_MS` and resolves `null`. No modelled path leaves it unsettled.
- **The bound cost real behaviour.** `flush()` awaits the *whole queued chain*, including the full-snapshot write `persistThreads()` enqueues one line earlier — so a timeout meant "the queue was busy", not "the store is broken". That gave the function a new way to answer `false` for a healthy store, and landed on two exits that cannot absorb it: `connectBackend` abandons a switch whose chips, prefs, `STORAGE_KEY_BACKEND`, `endTurnLocally()` and armed replay have **already** committed to the new backend, and `hardRestart` skips `client.start()` and strands the bridge for a write that lands a moment later.

My own measurement did not catch that: I timed persist+flush on a **fresh store with an empty queue** (35/40/61ms across 52KB–1MB), which is not the quantity the bound covered. The removal is asserted by a test, so reinstating a bound has to come with a reason that survives both problems.

## Verified

- `reloading` released in exactly one place, inside a `finally`, after the tail and before the reconnect — asserted structurally, and the mutation that drops the `finally` (latching the flag on the early-return path) fails the suite.
- Nothing in the tail can re-enter the guard: `reloading` has exactly two readers, and the tail is synchronous flag sets, `sessionStorage` writes, a `clearInterval` and two variable nulls, plus the one await.
- **A throw in the tail leaving the bridge stopped is pre-existing, not a regression** — compared against `main`, which also wraps neither the tail nor `client.start()` in a `catch`. Worth its own look under the #379/#419 "a reload never leaves a bridge dead" invariant; deliberately not folded in here.
- Panel loads and registers cleanly (`comfyui-mcp.agent-panel` present in `app.extensions`), no panel errors in console.
- Suite 4132 pass / 0 fail; scope check and typecheck clean.

## Why the tests are structural

This pack's `/comfyui_mcp_panel/hard_restart` answers `{"ok": false}` unconditionally — the orchestrator runs out-of-band — so the `if (ok)` tail never executes locally and the interleaving cannot be raced on this machine. Same approach #1166's test takes for the same function: *where* the release sits relative to the tail and the reconnect is the entire content of the fix.
