### PR TITLE
fix(1520): bound the two drive waits on the CivitAI fetch

### DIFF
--- a/browser_tests/unit/civitai-reload-wait.test.mjs
+++ b/browser_tests/unit/civitai-reload-wait.test.mjs
@@ -1,0 +1,137 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import {
+  awaitReloadWithin,
+  RELOAD_WAIT_BUDGET_MS,
+} from "../../web/js/lib/civitai-reload-wait.js";
+
+/**
+ * comfyui-mcp#1520 — `driveGetResults` and `driveHighlight` awaited
+ * `state.activeReloadPromise` with no bound. That promise wraps a CivitAI fetch,
+ * so the panel's reply deadline was set by a third party: on a slow or 503-ing
+ * CivitAI the orchestrator's bridge timed out and the caller got an error
+ * carrying no information, from a panel that was working perfectly.
+ *
+ * These pin the adapter's semantics. It is a thin wrapper over the shared
+ * `withTimeout` primitive, which is itself well covered — but the ORDER of its
+ * two transforms is easy to invert, and inverting it produces a
+ * plausible-looking wrong answer rather than a crash.
+ *
+ * This imports the SAME module cmcp-civitai-ui.js imports. An earlier version
+ * mirrored the adapter's source into this file because the UI module pulls in
+ * the DOM on import; that tests a copy and lets the copy drift, so the adapter
+ * was extracted to lib/ instead.
+ */
+
+/** Fires the armed timer on demand, so no test has to sleep for a real budget. */
+function manualTimers() {
+  let fire = null;
+  return {
+    timers: {
+      setTimer: (fn) => {
+        fire = fn;
+        return 1;
+      },
+      clearTimer: () => {
+        fire = null;
+      },
+    },
+    expire: () => {
+      assert.ok(fire, "no timer was armed — the bound is not in effect");
+      fire();
+    },
+  };
+}
+
+test("a reload that settles in budget reports settled", async () => {
+  assert.equal(await awaitReloadWithin(Promise.resolve("page1"), 12000), true);
+});
+
+test("no reload in flight is settled, not pending", async () => {
+  // `state.activeReloadPromise` is null whenever nothing is loading. Reporting
+  // that as pending would make every quiet read look like a stalled fetch.
+  assert.equal(await awaitReloadWithin(null, 12000), true);
+});
+
+test("a reload that outruns the budget reports pending, and does so promptly", async () => {
+  const { timers, expire } = manualTimers();
+  const never = new Promise(() => {}); // the 503-and-retry case
+  const p = awaitReloadWithin(never, 12000, timers);
+  expire();
+  assert.equal(await p, false);
+});
+
+test("a FAILED reload is settled, not pending — the ordering that is easy to invert", async () => {
+  // withTimeout routes a rejection to the same fallback as a timeout, which is
+  // right for a step that yielded no result and wrong here: a failed fetch DID
+  // finish. It surfaces to the caller as `state.error`. Calling it pending would
+  // tell the agent to re-read and wait for an answer that already arrived.
+  //
+  // Passing the raw rejected promise to withTimeout is what produces the wrong
+  // answer, so this fails if the `.then(() => true, () => true)` is dropped.
+  const { timers } = manualTimers();
+  assert.equal(await awaitReloadWithin(Promise.reject(new Error("503")), 12000, timers), true);
+});
+
+test("a rejected reload never escapes as an unhandled rejection", async () => {
+  // The drive methods have no try/catch around this call any more; the original
+  // code did (`try { await … } catch {}`). If the adapter let a rejection
+  // through, the failure would be a broken command, not a wrong field.
+  const seen = [];
+  const onUnhandled = (e) => seen.push(e);
+  process.on("unhandledRejection", onUnhandled);
+  try {
+    await awaitReloadWithin(Promise.reject(new Error("boom")), 12000, manualTimers().timers);
+    await new Promise((r) => setImmediate(r));
+    await new Promise((r) => setImmediate(r));
+  } finally {
+    process.off("unhandledRejection", onUnhandled);
+  }
+  assert.deepEqual(seen, [], "a reload rejection escaped the adapter");
+});
+
+test("the budget stays clear of the orchestrator's 20s bridge bound", () => {
+  // If the budget ever meets or exceeds the bound, this whole change stops
+  // doing anything: the bridge times out first and the caller is back to an
+  // error carrying no information, with every test above still green.
+  assert.ok(RELOAD_WAIT_BUDGET_MS > 0, "a non-positive budget disables the bound entirely");
+  assert.ok(
+    RELOAD_WAIT_BUDGET_MS <= 15000,
+    `budget ${RELOAD_WAIT_BUDGET_MS}ms leaves too little headroom under the 20s bridge bound`,
+  );
+});
+
+test("BOTH drive methods actually go through the bound", async () => {
+  // Reachability, not behaviour. Everything above proves the helper works; none
+  // of it proves cmcp-civitai-ui.js calls it. Deleting either call site leaves
+  // this file entirely green, and the bug comes straight back.
+  const src = await readFile(new URL("../../web/js/cmcp-civitai-ui.js", import.meta.url), "utf8");
+
+  const bounded = src.match(/awaitReloadWithin\(state\.activeReloadPromise, RELOAD_WAIT_BUDGET_MS\)/g);
+  assert.equal(bounded?.length, 2, "expected driveGetResults AND driveHighlight to use the bound");
+
+  // The original unbounded await must be gone. A call site that kept it would
+  // satisfy the count above and still hand the deadline to CivitAI.
+  assert.equal(
+    /await state\.activeReloadPromise/.test(src),
+    false,
+    "an unbounded `await state.activeReloadPromise` is still present",
+  );
+});
+
+test("a late reload cannot flip an answer already given", async () => {
+  // The bound does not cancel the fetch. If a late fulfilment could still
+  // resolve the returned promise, the caller's reply would change after it was
+  // composed.
+  const { timers, expire } = manualTimers();
+  let release;
+  const slow = new Promise((r) => {
+    release = r;
+  });
+  const p = awaitReloadWithin(slow, 12000, timers);
+  expire();
+  assert.equal(await p, false);
+  release("page1");
+  assert.equal(await p, false, "a late fulfilment rewrote a settled answer");
+});

--- a/browser_tests/unit/civitai-reload-wait.test.mjs
+++ b/browser_tests/unit/civitai-reload-wait.test.mjs
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 import {
   awaitReloadWithin,
+  classifyHighlightOutcome,
   RELOAD_WAIT_BUDGET_MS,
 } from "../../web/js/lib/civitai-reload-wait.js";
 
@@ -100,6 +101,28 @@ test("the budget stays clear of the orchestrator's 20s bridge bound", () => {
     RELOAD_WAIT_BUDGET_MS <= 15000,
     `budget ${RELOAD_WAIT_BUDGET_MS}ms leaves too little headroom under the 20s bridge bound`,
   );
+});
+
+test("a superseded highlight is reported as superseded even when the budget also expired", () => {
+  // The case that matters, and the one the first version of this change got
+  // wrong: BOTH conditions hold. A slow reload outran the budget *and* the grid
+  // moved on underneath it.
+  //
+  // Precedence must be `superseded`, because the two answers ask for different
+  // things. `pending` says "these ids are still good, ask again" — and here they
+  // are not: they belong to the previous search and cannot match. Answering
+  // pending sends the agent back to re-issue ids that are guaranteed to miss,
+  // and hides a bail-out path that predates the bound.
+  assert.equal(
+    classifyHighlightOutcome({ revChanged: true, reloadSettled: false }),
+    "superseded",
+  );
+});
+
+test("each highlight outcome is reachable on its own", () => {
+  assert.equal(classifyHighlightOutcome({ revChanged: true, reloadSettled: true }), "superseded");
+  assert.equal(classifyHighlightOutcome({ revChanged: false, reloadSettled: false }), "pending");
+  assert.equal(classifyHighlightOutcome({ revChanged: false, reloadSettled: true }), "install");
 });
 
 test("BOTH drive methods actually go through the bound", async () => {

--- a/browser_tests/unit/civitai-reload-wait.test.mjs
+++ b/browser_tests/unit/civitai-reload-wait.test.mjs
@@ -28,13 +28,17 @@ import {
 /** Fires the armed timer on demand, so no test has to sleep for a real budget. */
 function manualTimers() {
   let fire = null;
+  let armed = false;
+  let didClear = false;
   return {
     timers: {
       setTimer: (fn) => {
         fire = fn;
+        armed = true;
         return 1;
       },
       clearTimer: () => {
+        didClear = true;
         fire = null;
       },
     },
@@ -42,6 +46,8 @@ function manualTimers() {
       assert.ok(fire, "no timer was armed — the bound is not in effect");
       fire();
     },
+    /** True only if a timer was actually armed AND later cleared. */
+    cleared: () => armed && didClear,
   };
 }
 
@@ -143,18 +149,15 @@ test("BOTH drive methods actually go through the bound", async () => {
   );
 });
 
-test("a late reload cannot flip an answer already given", async () => {
-  // The bound does not cancel the fetch. If a late fulfilment could still
-  // resolve the returned promise, the caller's reply would change after it was
-  // composed.
-  const { timers, expire } = manualTimers();
-  let release;
-  const slow = new Promise((r) => {
-    release = r;
-  });
-  const p = awaitReloadWithin(slow, 12000, timers);
-  expire();
-  assert.equal(await p, false);
-  release("page1");
-  assert.equal(await p, false, "a late fulfilment rewrote a settled answer");
+test("a reload that wins the race clears the armed timer", async () => {
+  // The panel is long-lived and these two commands are polled. A bound that
+  // armed a timer per call and never cleared the ones it did not need would
+  // accumulate them for as long as the tab is open.
+  //
+  // This replaced a test that asserted a late fulfilment could not change an
+  // already-returned answer. That one could not fail: a settled promise cannot
+  // re-resolve, so it was restating the promise contract. Review caught it.
+  const { timers, cleared } = manualTimers();
+  assert.equal(await awaitReloadWithin(Promise.resolve("page1"), 12000, timers), true);
+  assert.equal(cleared(), true, "the timer armed for the bound was left pending");
 });

--- a/web/js/cmcp-civitai-ui.js
+++ b/web/js/cmcp-civitai-ui.js
@@ -16,7 +16,11 @@ import {
   filtersDirty, bitmask, parseCreatorQuery, levelLabel,
 } from "./cmcp-civitai.js";
 import { summarizeSearchFilters } from "./lib/civitai-search-echo.js";
-import { awaitReloadWithin, RELOAD_WAIT_BUDGET_MS } from "./lib/civitai-reload-wait.js";
+import {
+  awaitReloadWithin,
+  classifyHighlightOutcome,
+  RELOAD_WAIT_BUDGET_MS,
+} from "./lib/civitai-reload-wait.js";
 import { openSidePanel } from "./cmcp-sidepanel-ui.js";
 import { openSubModal as openSubModalBase, toast } from "./cmcp-modal.js";
 import { chipRow as filterChipRow, makeFilterButton } from "./cmcp-filter.js";
@@ -2249,16 +2253,22 @@ export function createCivitaiContent(ctx, shell, opts = {}) {
     // before installing, so a retry is idempotent.
     const reloadSettled = await awaitReloadWithin(state.activeReloadPromise, RELOAD_WAIT_BUDGET_MS);
     _assertOpen();
-    if (!reloadSettled) {
-      return { highlighted: 0, missing: list, renderRev: state.renderRev, pending: true };
-    }
-    if (state.renderRev !== rev) {
-      // A reload/tab/filter superseded this highlight while we awaited: these ids
-      // belonged to the OLD search and MUST NOT be installed on the new
-      // generation (they'd glow same-id cards from a different query). Bail
-      // without touching the current set — the agent can re-issue against the
-      // new results (codex finding).
-      return { highlighted: 0, missing: list, renderRev: state.renderRev, superseded: true };
+    // A reload/tab/filter can supersede this highlight while we wait: those ids
+    // belonged to the OLD search and MUST NOT be installed on the new generation
+    // (they'd glow same-id cards from a different query). The bounded wait adds
+    // a second bail-out, and `superseded` takes precedence over `pending` — see
+    // classifyHighlightOutcome, where that precedence is pinned.
+    const outcome = classifyHighlightOutcome({
+      revChanged: state.renderRev !== rev,
+      reloadSettled,
+    });
+    if (outcome !== "install") {
+      return {
+        highlighted: 0,
+        missing: list,
+        renderRev: state.renderRev,
+        [outcome]: true, // superseded | pending — bail without touching the set
+      };
     }
     // Replacement: strip the prior set, install the new one, then paint.
     driveClearHighlight();

--- a/web/js/cmcp-civitai-ui.js
+++ b/web/js/cmcp-civitai-ui.js
@@ -16,6 +16,7 @@ import {
   filtersDirty, bitmask, parseCreatorQuery, levelLabel,
 } from "./cmcp-civitai.js";
 import { summarizeSearchFilters } from "./lib/civitai-search-echo.js";
+import { awaitReloadWithin, RELOAD_WAIT_BUDGET_MS } from "./lib/civitai-reload-wait.js";
 import { openSidePanel } from "./cmcp-sidepanel-ui.js";
 import { openSubModal as openSubModalBase, toast } from "./cmcp-modal.js";
 import { chipRow as filterChipRow, makeFilterButton } from "./cmcp-filter.js";
@@ -373,6 +374,7 @@ export function createCivitaiContent(ctx, shell, opts = {}) {
     activeReloadPromise: null,
     activeLoadPromise: null,
   };
+
   if (Array.isArray(opts.browsingLevels) && opts.browsingLevels.length) {
     state.filters = { ...state.filters, browsingLevels: [...opts.browsingLevels] };
   }
@@ -2181,7 +2183,13 @@ export function createCivitaiContent(ctx, shell, opts = {}) {
     //
     // `loading` is still reported below — this only removes the window where the
     // honest answer was available and we returned the empty one instead.
-    try { await state.activeReloadPromise; } catch { /* surfaces via state.error below */ }
+    //
+    // Bounded since comfyui-mcp#1520: the wait is on CivitAI, so an unbounded
+    // one hands our reply deadline to a third party and the caller gets a bridge
+    // timeout carrying nothing. On expiry we answer with what we have —
+    // `loading: true` plus `reloadPending: true` — which is the same honest
+    // interim answer panel#793 was fine with, just arriving on time.
+    const reloadSettled = await awaitReloadWithin(state.activeReloadPromise, RELOAD_WAIT_BUDGET_MS);
     _assertOpen();
     const model = isModelTab();
     const source = model ? state.models : state.items;
@@ -2192,6 +2200,12 @@ export function createCivitaiContent(ctx, shell, opts = {}) {
       done: !!state.done,
       renderRev: state.renderRev,
       truncated: source.length > ser.items.length,
+      // True when we gave up waiting on the in-flight fetch rather than seeing
+      // it finish (#1520). Distinguishes "a reload is still running and I waited
+      // as long as I safely could" from "loading just started" — both report
+      // `loading: true`, but only the first means re-reading shortly is the
+      // right move rather than a busy-poll.
+      reloadPending: !reloadSettled,
       // Disambiguate an empty grid (issues #190/#375): `error` is a non-null
       // upstream failure (retry, don't narrow filters); `authenticated` reflects
       // the CivitAI session; on the favorites tab `favoritesStatus` explains an
@@ -2223,8 +2237,21 @@ export function createCivitaiContent(ctx, shell, opts = {}) {
     _assertOpen();
     const list = (Array.isArray(ids) ? ids : (ids != null ? [ids] : [])).map((x) => String(x));
     const rev = state.renderRev;
-    try { await state.activeReloadPromise; } catch { /* fetch error surfaces elsewhere */ }
+    // Bounded since comfyui-mcp#1520 — see RELOAD_WAIT_BUDGET_MS. On expiry we
+    // install NOTHING and say so, following the `superseded` path directly
+    // below: this function already establishes that returning `highlighted: 0`
+    // with the set untouched is the right answer when it cannot safely act.
+    //
+    // Deliberately not installing late in the background. Today a bridge timeout
+    // here is a false failure — the caller is told the command failed and the
+    // glow lands anyway — and quietly applying after we reported `pending` would
+    // keep exactly that confusion. The caller re-issues; `driveHighlight` clears
+    // before installing, so a retry is idempotent.
+    const reloadSettled = await awaitReloadWithin(state.activeReloadPromise, RELOAD_WAIT_BUDGET_MS);
     _assertOpen();
+    if (!reloadSettled) {
+      return { highlighted: 0, missing: list, renderRev: state.renderRev, pending: true };
+    }
     if (state.renderRev !== rev) {
       // A reload/tab/filter superseded this highlight while we awaited: these ids
       // belonged to the OLD search and MUST NOT be installed on the new

--- a/web/js/lib/civitai-reload-wait.js
+++ b/web/js/lib/civitai-reload-wait.js
@@ -1,0 +1,57 @@
+// Bounding the drive methods' wait on an in-flight CivitAI fetch
+// (comfyui-mcp#1520).
+//
+// `driveGetResults` and `driveHighlight` await `state.activeReloadPromise` so
+// they don't answer from a grid that hasn't filled yet (panel#793). The await is
+// right; its lack of a bound is not. What it waits on is a third party, so the
+// panel's reply deadline was effectively set by CivitAI: on a slow or 503-ing
+// upstream the orchestrator's bridge timed out first and the caller got an error
+// carrying no information, from a panel that was working perfectly.
+//
+// Lives in lib/ so the drive methods and the tests share ONE implementation.
+// The previous version of this was inlined in cmcp-civitai-ui.js and mirrored
+// into the test file, which tests a copy and lets the copy drift.
+
+import { withTimeout } from "./bounded-step.js";
+
+/**
+ * How long a drive method waits on an in-flight fetch before answering anyway.
+ *
+ * The orchestrator bounds these two commands at BRIDGE_READ_DEFAULT_TIMEOUT_MS
+ * (20 s). This budget has to finish far enough inside that for the reply to
+ * still travel back, or the caller gets a bridge timeout instead of our honest
+ * interim answer — which is the exact failure #1520 is about. 12 s leaves 8 s.
+ *
+ * Drift between the two degrades gracefully: a budget shorter than the bridge
+ * bound just answers sooner, and one longer than it degrades to the old
+ * behaviour (bridge timeout) rather than to anything new. Keep it well below.
+ */
+export const RELOAD_WAIT_BUDGET_MS = 12000;
+
+/**
+ * Await an in-flight reload, but never longer than `budgetMs`.
+ *
+ * @param {Promise<any>|null|undefined} reload  `state.activeReloadPromise`
+ * @param {number} budgetMs
+ * @param {{setTimer?:Function, clearTimer?:Function}} [timers] injectable for tests
+ * @returns {Promise<boolean>} true if it settled (or none was in flight), false
+ *   if the budget expired first. Never rejects.
+ *
+ * A REJECTED reload maps to `true`, and doing that BEFORE `withTimeout` sees it
+ * is the whole subtlety. `withTimeout` routes a rejection to the same fallback
+ * as a timeout — correct for a step that produced no result, wrong here. A
+ * failed fetch DID settle: it is not still pending, and it reaches the caller as
+ * `state.error`. Reporting it as pending would tell an agent to re-read and wait
+ * for an answer that has already arrived.
+ */
+export function awaitReloadWithin(reload, budgetMs, timers) {
+  return withTimeout(
+    Promise.resolve(reload).then(
+      () => true,
+      () => true,
+    ),
+    budgetMs,
+    () => false,
+    timers,
+  );
+}

--- a/web/js/lib/civitai-reload-wait.js
+++ b/web/js/lib/civitai-reload-wait.js
@@ -44,6 +44,33 @@ export const RELOAD_WAIT_BUDGET_MS = 12000;
  * `state.error`. Reporting it as pending would tell an agent to re-read and wait
  * for an answer that has already arrived.
  */
+/**
+ * Which answer `driveHighlight` owes its caller once the bounded wait returns.
+ *
+ * Both conditions can hold at once — the results generation changed while a slow
+ * reload was still in flight — and the PRECEDENCE is load-bearing, because the
+ * two answers ask the agent to do different things:
+ *
+ *   - `superseded`: a reload/tab/filter moved the grid on. The ids belong to the
+ *     old search and can no longer match. Re-read results, then highlight again.
+ *   - `pending`: the ids are still good, we just could not confirm them inside
+ *     the budget. Ask again, unchanged.
+ *   - `install`: current generation, reload settled — do the work.
+ *
+ * `superseded` wins. Reporting `pending` for a superseded request sends the
+ * agent back with ids that cannot match, and buries a bail-out path that
+ * predates the bound. This function exists so that precedence is testable rather
+ * than a statement about line order inside a DOM-heavy module (#1520 review).
+ *
+ * @param {{revChanged: boolean, reloadSettled: boolean}} s
+ * @returns {"superseded"|"pending"|"install"}
+ */
+export function classifyHighlightOutcome({ revChanged, reloadSettled }) {
+  if (revChanged) return "superseded";
+  if (!reloadSettled) return "pending";
+  return "install";
+}
+
 export function awaitReloadWithin(reload, budgetMs, timers) {
   return withTimeout(
     Promise.resolve(reload).then(


### PR DESCRIPTION
Panel half of artokun/comfyui-mcp#1520. The orchestrator half is artokun/comfyui-mcp#1542, and this is dead code without it.

`driveGetResults` and `driveHighlight` both `await state.activeReloadPromise` with no bound, so their reply time is set by CivitAI rather than by us. The orchestrator now allows 20 s for them; this makes the panel answer *inside* that window instead of letting the bridge time out with nothing.

Keeps panel#793 intact for the case it was written for — a reload that settles quickly is still awaited, and the empty-but-honest answer is still not returned early. Only the tail changes.