### PR TITLE
fix(1184): commit the backend switch only after the old session is invalidated

### DIFF
--- a/browser_tests/unit/backend-switch.test.mjs
+++ b/browser_tests/unit/backend-switch.test.mjs
@@ -181,3 +181,41 @@ test("#1184 the disclosure is honest only because nothing was committed", () => 
   const body = PANEL_SRC.slice(at, PANEL_SRC.indexOf("\n  }", at));
   assert.match(body, /panel\.the_old_session_could_not_be_invalidated/, "the abort must be disclosed, not silent");
 });
+
+test("#1184 the two aborts are disclosed differently — one message cannot be true for both", () => {
+  // A shared message would be false for one of them. INVALIDATE_FAILED means nothing
+  // committed and the switch did not happen, which is what hardRestart's line says.
+  // SUPERSEDED means a handshake landed mid-await, so the panel IS connected and coherent —
+  // `onModels` has already written connectedBackend, localStorage and repainted the chips.
+  // Printing "reconnect is paused" there would be flatly wrong: the session WAS invalidated
+  // and nothing is paused.
+  //
+  // Caught by reading rather than by a test, which is why it is pinned now: the module
+  // passes a reason and the first wiring ignored it.
+  const at = PANEL_SRC.indexOf("async function connectBackend(id) {");
+  const body = PANEL_SRC.slice(at, PANEL_SRC.indexOf("\n  }", at));
+  assert.match(
+    body,
+    /disclose: \(reason\) => \{[\s\S]{0,200}?if \(reason !== BACKEND_SWITCH\.INVALIDATE_FAILED\) return;/,
+    "the disclosure must branch on the reason, not print the invalidate line for every abort",
+  );
+});
+
+test("#1184 a superseded switch reports its own reason, distinct from a failed invalidate", async () => {
+  // The module's half of the same property: the caller cannot tell the two apart unless
+  // these are distinct values.
+  assert.notEqual(BACKEND_SWITCH.SUPERSEDED, BACKEND_SWITCH.INVALIDATE_FAILED);
+
+  const rec = recorder({ live: "claude" });
+  rec.effects.invalidate = async () => {
+    rec.log.push("invalidate");
+    rec.setLive("gemini");
+    return true;
+  };
+  await runBackendSwitch("codex", rec.effects);
+  assert.ok(
+    rec.log.includes(`disclose:${BACKEND_SWITCH.SUPERSEDED}`),
+    "a supersede must disclose as a supersede, so the panel can choose to stay quiet",
+  );
+  assert.ok(!rec.log.includes(`disclose:${BACKEND_SWITCH.INVALIDATE_FAILED}`));
+});

--- a/browser_tests/unit/backend-switch.test.mjs
+++ b/browser_tests/unit/backend-switch.test.mjs
@@ -39,8 +39,11 @@ function recorder({ live = "claude", picked = "claude", invalidate = async () =>
       log.push("invalidate");
       return invalidate();
     },
-    seedPrefs: () => log.push("seedPrefs"),
-    commitSelection: () => log.push("commitSelection"),
+    // ARGUMENTS RECORDED, not just names. A recorder that logs only the effect name lets
+    // the module hand the WRONG backend id to every commit while the whole suite passes —
+    // it would prove the order and nothing about what was ordered.
+    seedPrefs: (b) => log.push(`seedPrefs:${b}`),
+    commitSelection: (b) => log.push(`commitSelection:${b}`),
     endTurn: () => log.push("endTurn"),
     buildReplay: () => {
       log.push("buildReplay");
@@ -55,6 +58,9 @@ function recorder({ live = "claude", picked = "claude", invalidate = async () =>
 
 /** Every effect that COMMITS to the new backend. None may run before the switch is legal. */
 const COMMITS = ["seedPrefs", "commitSelection", "endTurn", "buildReplay", "armContext", "teardownAndConnect"];
+/** Effects are logged as `name` or `name:arg`; match on the name half. */
+const at = (log, name) => log.findIndex((e) => e === name || e.startsWith(`${name}:`));
+const ran = (log, name) => at(log, name) !== -1;
 
 test("#1184 a failed invalidate commits NOTHING — asserted on every effect, not a sample", async () => {
   const { log, effects } = recorder({ live: "claude", invalidate: async () => false });
@@ -65,7 +71,7 @@ test("#1184 a failed invalidate commits NOTHING — asserted on every effect, no
   assert.deepEqual(log, ["invalidate", `disclose:${BACKEND_SWITCH.INVALIDATE_FAILED}`]);
   // …and stated per effect, so a failure names the leak rather than a diff of two arrays.
   for (const effect of COMMITS) {
-    assert.ok(!log.includes(effect), `${effect} ran despite the switch being illegal`);
+    assert.ok(!ran(log, effect), `${effect} ran despite the switch being illegal`);
   }
 });
 
@@ -78,10 +84,14 @@ test("#1184 the invalidate happens BEFORE every commit, not after them", async (
   assert.deepEqual(result, { switched: true, reason: BACKEND_SWITCH.SWITCHED });
   assert.equal(log[0], "invalidate", "the legality check must come first");
   for (const effect of COMMITS) {
-    const at = log.indexOf(effect);
-    assert.ok(at > 0, `${effect} must run on a successful switch`);
-    assert.ok(at > log.indexOf("invalidate"), `${effect} committed BEFORE the invalidate — this is the defect`);
+    const i = at(log, effect);
+    assert.ok(i > 0, `${effect} must run on a successful switch`);
+    assert.ok(i > log.indexOf("invalidate"), `${effect} committed BEFORE the invalidate — this is the defect`);
   }
+  // …and every commit must be told the backend the CALLER asked for. Order without
+  // identity is half a proof: the module could commit a different id in the right order.
+  assert.ok(log.includes("commitSelection:codex"), `the selection committed was not codex: ${log}`);
+  assert.ok(log.includes("seedPrefs:codex"), `prefs were seeded for the wrong backend: ${log}`);
   assert.equal(log[log.length - 1], "teardownAndConnect", "the connect must be last");
 });
 
@@ -94,12 +104,12 @@ test("#1184 a NON-switch never consults the history store", async () => {
 
     assert.equal(result.switched, false, `${label}: not a switch`);
     assert.equal(result.reason, BACKEND_SWITCH.CONNECTED, `${label}: but it DID connect`);
-    assert.ok(!log.includes("invalidate"), `${label}: must not invalidate`);
-    assert.ok(log.includes("commitSelection"), `${label}: must still commit the selection`);
-    assert.ok(log.includes("teardownAndConnect"), `${label}: must still connect`);
+    assert.ok(!ran(log, "invalidate"), `${label}: must not invalidate`);
+    assert.ok(ran(log, "commitSelection"), `${label}: must still commit the selection`);
+    assert.ok(ran(log, "teardownAndConnect"), `${label}: must still connect`);
     // Session-scoped work belongs to a switch only.
-    assert.ok(!log.includes("endTurn"), `${label}: no turn to end`);
-    assert.ok(!log.includes("armContext"), `${label}: nothing to replay`);
+    assert.ok(!ran(log, "endTurn"), `${label}: no turn to end`);
+    assert.ok(!ran(log, "armContext"), `${label}: nothing to replay`);
   }
 });
 
@@ -118,7 +128,7 @@ test("#1184 a handshake landing during the invalidate supersedes the switch", as
 
   assert.deepEqual(result, { switched: false, reason: BACKEND_SWITCH.SUPERSEDED });
   for (const effect of COMMITS) {
-    assert.ok(!rec.log.includes(effect), `${effect} ran against a backend state that had already moved`);
+    assert.ok(!ran(rec.log, effect), `${effect} ran against a backend state that had already moved`);
   }
 });
 
@@ -126,28 +136,41 @@ test("#1184 the reseed predicate is preserved: reseed iff the target differs", a
   // Seeding from the new backend's group is what stops the post-handshake push carrying the
   // previous backend's model/effort. A re-pick must NOT reseed — that would clobber a
   // user's in-session model choice.
+  // `prevBackend` is `startedOn || pickedBackend()`, so BOTH halves need a case. Running
+  // every case with `live: null` leaves the `startedOn` half unexercised — deleting it
+  // would not fail anything, and it is the half that decides a real switch.
   const differs = recorder({ live: null, picked: "claude" });
   await runBackendSwitch("codex", differs.effects);
-  assert.ok(differs.log.includes("seedPrefs"), "a different target reseeds");
+  assert.ok(ran(differs.log, "seedPrefs"), "no live backend: the PICK differs, so reseed");
 
   const same = recorder({ live: null, picked: "codex" });
   await runBackendSwitch("codex", same.effects);
-  assert.ok(!same.log.includes("seedPrefs"), "a re-pick of the same backend must not reseed");
+  assert.ok(!ran(same.log, "seedPrefs"), "no live backend: the pick already matches, so do not reseed");
+
+  // The `startedOn` half: a LIVE backend wins over the pick when deciding what prefs
+  // currently reflect, because the handshake is authoritative and the pick may be stale.
+  const liveDiffers = recorder({ live: "claude", picked: "codex" });
+  await runBackendSwitch("codex", liveDiffers.effects);
+  assert.ok(
+    ran(liveDiffers.log, "seedPrefs"),
+    "live claude vs target codex is a real switch — prefs hold claude's model/effort and must be reseeded, " +
+      "even though the stale pick already said codex",
+  );
 });
 
 test("#1184 the replay is built AFTER the turn ends, and only armed when non-empty", async () => {
   const withReplay = recorder({ live: "claude", replay: "User: hi" });
   await runBackendSwitch("codex", withReplay.effects);
   assert.ok(
-    withReplay.log.indexOf("buildReplay") > withReplay.log.indexOf("endTurn"),
+    at(withReplay.log, "buildReplay") > at(withReplay.log, "endTurn"),
     "the transcript is captured after the turn is closed out",
   );
-  assert.ok(withReplay.log.includes("armContext"));
+  assert.ok(ran(withReplay.log, "armContext"));
 
   const empty = recorder({ live: "claude", replay: "" });
   await runBackendSwitch("codex", empty.effects);
-  assert.ok(empty.log.includes("buildReplay"), "it still asks");
-  assert.ok(!empty.log.includes("armContext"), "…but arming an empty preamble would send a header with no chat");
+  assert.ok(ran(empty.log, "buildReplay"), "it still asks");
+  assert.ok(!ran(empty.log, "armContext"), "…but arming an empty preamble would send a header with no chat");
 });
 
 test("#1184 WIRING: the panel delegates, and keeps no commit above the guard", () => {

--- a/browser_tests/unit/backend-switch.test.mjs
+++ b/browser_tests/unit/backend-switch.test.mjs
@@ -56,8 +56,16 @@ function recorder({ live = "claude", picked = "claude", invalidate = async () =>
   return { log, effects, setLive: (b) => { liveBackend = b; } };
 }
 
-/** Every effect that COMMITS to the new backend. None may run before the switch is legal. */
-const COMMITS = ["seedPrefs", "commitSelection", "endTurn", "buildReplay", "armContext", "teardownAndConnect"];
+/**
+ * Every effect that COMMITS to the NEW backend. None may run before the switch is legal.
+ *
+ * `endTurn` is deliberately NOT here. It is not a commit to the new backend — it retires a
+ * turn on the OLD one, and it has to run on the abort paths too, because
+ * `invalidateDurableAgentSession` destroys the session pointer BEFORE it reports whether it
+ * succeeded. A turn whose session id is already gone cannot resume, so leaving MID_TASK_KEY
+ * armed would make the mid-task nudge fire into a fresh empty session claiming full context.
+ */
+const COMMITS = ["seedPrefs", "commitSelection", "buildReplay", "armContext", "teardownAndConnect"];
 /** Effects are logged as `name` or `name:arg`; match on the name half. */
 const at = (log, name) => log.findIndex((e) => e === name || e.startsWith(`${name}:`));
 const ran = (log, name) => at(log, name) !== -1;
@@ -68,7 +76,9 @@ test("#1184 a failed invalidate commits NOTHING — asserted on every effect, no
 
   assert.deepEqual(result, { switched: false, reason: BACKEND_SWITCH.INVALIDATE_FAILED });
   // The exact sequence: ask, then say so. Nothing else.
-  assert.deepEqual(log, ["invalidate", `disclose:${BACKEND_SWITCH.INVALIDATE_FAILED}`]);
+  // endTurn between them, and that is the point: the invalidate already destroyed the
+  // session pointer, so the turn is unresumable whatever the boolean said.
+  assert.deepEqual(log, ["invalidate", "endTurn", `disclose:${BACKEND_SWITCH.INVALIDATE_FAILED}`]);
   // …and stated per effect, so a failure names the leak rather than a diff of two arrays.
   for (const effect of COMMITS) {
     assert.ok(!ran(log, effect), `${effect} ran despite the switch being illegal`);
@@ -130,6 +140,9 @@ test("#1184 a handshake landing during the invalidate supersedes the switch", as
   for (const effect of COMMITS) {
     assert.ok(!ran(rec.log, effect), `${effect} ran against a backend state that had already moved`);
   }
+  // …but the turn IS ended, for the same reason as the failed-invalidate path: the session
+  // pointer is gone by the time we know the switch will not proceed.
+  assert.ok(ran(rec.log, "endTurn"), "a destroyed session leaves no resumable turn, whichever abort we take");
 });
 
 test("#1184 the reseed predicate is preserved: reseed iff the target differs", async () => {
@@ -182,6 +195,34 @@ test("#1184 WIRING: the panel delegates, and keeps no commit above the guard", (
   const body = PANEL_SRC.slice(at, PANEL_SRC.indexOf("\n  }", at));
 
   assert.match(body, /runBackendSwitch\(id, \{/, "connectBackend must delegate the ordering to the module");
+
+  // THE REGION THAT MATTERS: everything BEFORE the delegation. Asserting only that the
+  // module is called proved nothing — the #1184 leak could be reinstated verbatim above the
+  // call (write `selectedBackend`, persist STORAGE_KEY_BACKEND, then delegate) and all ten
+  // tests stayed green. Verified by doing exactly that.
+  // CODE ONLY. The comment above the delegation NAMES these calls while explaining what the
+  // old order got wrong, so a raw text scan matched the prose and failed on correct code —
+  // the same trap that has bitten several assertions in this repo.
+  const preamble = body
+    .slice(0, body.indexOf("runBackendSwitch(id, {"))
+    .split(String.fromCharCode(10))
+    .filter((l) => !l.trim().startsWith("//"))
+    .join(String.fromCharCode(10));
+  const LEAKS = [
+    [/selectedBackend\s*=/, "the in-memory pick"],
+    [/localStorage\.setItem/, "the persisted pick — this one outlives the tab"],
+    [/renderBackendChips\(/, "the chip paint"],
+    [/endTurnLocally\(/, "the working indicator and MID_TASK_KEY"],
+    [/armContext\(/, "the one-shot replay, which client.stop() does NOT disarm"],
+    [/seedPrefsForBackendSwitch\(/, "the prefs reseed"],
+  ];
+  for (const [re, what] of LEAKS) {
+    assert.doesNotMatch(
+      preamble,
+      re,
+      `${what} is committed BEFORE the switch is known to be legal — that is #1184, reinstated`,
+    );
+  }
   // The commits may only appear as INJECTED effects, i.e. inside a callback the module
   // calls after the guard — never as statements the function runs on its own.
   assert.match(body, /commitSelection: \(next\) => \{/, "the selection writes must be an injected effect");

--- a/browser_tests/unit/backend-switch.test.mjs
+++ b/browser_tests/unit/backend-switch.test.mjs
@@ -1,0 +1,183 @@
+// #1184 — a backend switch must not commit anything until the switch is legal.
+//
+// `connectBackend()` committed the new backend to memory, to localStorage and to the UI and
+// only then checked whether the old provider's session could be durably invalidated. When
+// that check failed it returned, leaving the panel claiming a backend it never connected to
+// — and `STORAGE_KEY_BACKEND` outlives the tab, so a reload adopted the aborted choice for
+// good.
+//
+// THESE TESTS ASSERT ORDER, NOT JUST OUTCOME. That distinction is the whole point: the
+// buggy version reached the same final state on every successful switch, so any test that
+// only checks the end state passes against it. What it got wrong was WHEN each write
+// happened relative to the guard.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import { BACKEND_SWITCH, runBackendSwitch } from "../../web/js/lib/backend-switch.js";
+
+const PANEL_SRC = readFileSync(
+  fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url)),
+  "utf8",
+);
+
+/**
+ * Effects that record the ORDER they were called in.
+ *
+ * Every commit the panel performs is represented, because each is a distinct piece of
+ * leaked state and asserting on a sampled subset is how five of six leaks stay invisible.
+ */
+function recorder({ live = "claude", picked = "claude", invalidate = async () => true, replay = "prior chat" } = {}) {
+  const log = [];
+  let liveBackend = live;
+  const effects = {
+    liveBackend: () => liveBackend,
+    pickedBackend: () => picked,
+    invalidate: async () => {
+      log.push("invalidate");
+      return invalidate();
+    },
+    seedPrefs: () => log.push("seedPrefs"),
+    commitSelection: () => log.push("commitSelection"),
+    endTurn: () => log.push("endTurn"),
+    buildReplay: () => {
+      log.push("buildReplay");
+      return replay;
+    },
+    armContext: () => log.push("armContext"),
+    teardownAndConnect: () => log.push("teardownAndConnect"),
+    disclose: (reason) => log.push(`disclose:${reason}`),
+  };
+  return { log, effects, setLive: (b) => { liveBackend = b; } };
+}
+
+/** Every effect that COMMITS to the new backend. None may run before the switch is legal. */
+const COMMITS = ["seedPrefs", "commitSelection", "endTurn", "buildReplay", "armContext", "teardownAndConnect"];
+
+test("#1184 a failed invalidate commits NOTHING — asserted on every effect, not a sample", async () => {
+  const { log, effects } = recorder({ live: "claude", invalidate: async () => false });
+  const result = await runBackendSwitch("codex", effects);
+
+  assert.deepEqual(result, { switched: false, reason: BACKEND_SWITCH.INVALIDATE_FAILED });
+  // The exact sequence: ask, then say so. Nothing else.
+  assert.deepEqual(log, ["invalidate", `disclose:${BACKEND_SWITCH.INVALIDATE_FAILED}`]);
+  // …and stated per effect, so a failure names the leak rather than a diff of two arrays.
+  for (const effect of COMMITS) {
+    assert.ok(!log.includes(effect), `${effect} ran despite the switch being illegal`);
+  }
+});
+
+test("#1184 the invalidate happens BEFORE every commit, not after them", async () => {
+  // The regression test proper. The old order produced this same final state, so only the
+  // relative positions distinguish the fix from the bug.
+  const { log, effects } = recorder({ live: "claude" });
+  const result = await runBackendSwitch("codex", effects);
+
+  assert.deepEqual(result, { switched: true, reason: BACKEND_SWITCH.SWITCHED });
+  assert.equal(log[0], "invalidate", "the legality check must come first");
+  for (const effect of COMMITS) {
+    const at = log.indexOf(effect);
+    assert.ok(at > 0, `${effect} must run on a successful switch`);
+    assert.ok(at > log.indexOf("invalidate"), `${effect} committed BEFORE the invalidate — this is the defect`);
+  }
+  assert.equal(log[log.length - 1], "teardownAndConnect", "the connect must be last");
+});
+
+test("#1184 a NON-switch never consults the history store", async () => {
+  // A first connect and a re-pick of the live backend are not switches, and gating them on
+  // the history store would make an unrelated IndexedDB hiccup block connecting at all.
+  for (const [label, live] of [["first connect", null], ["re-pick of the live backend", "codex"]]) {
+    const { log, effects } = recorder({ live, invalidate: async () => false });
+    const result = await runBackendSwitch("codex", effects);
+
+    assert.equal(result.switched, false, `${label}: not a switch`);
+    assert.equal(result.reason, BACKEND_SWITCH.CONNECTED, `${label}: but it DID connect`);
+    assert.ok(!log.includes("invalidate"), `${label}: must not invalidate`);
+    assert.ok(log.includes("commitSelection"), `${label}: must still commit the selection`);
+    assert.ok(log.includes("teardownAndConnect"), `${label}: must still connect`);
+    // Session-scoped work belongs to a switch only.
+    assert.ok(!log.includes("endTurn"), `${label}: no turn to end`);
+    assert.ok(!log.includes("armContext"), `${label}: nothing to replay`);
+  }
+});
+
+test("#1184 a handshake landing during the invalidate supersedes the switch", async () => {
+  // Awaiting before committing opens a window the old order did not have: a handshake can
+  // write `connectedBackend` underneath us. Under the old order those writes overwrote our
+  // commits; under this one ours would land last and win against a backend the user did not
+  // pick from the state we decided on.
+  const rec = recorder({ live: "claude" });
+  rec.effects.invalidate = async () => {
+    rec.log.push("invalidate");
+    rec.setLive("gemini"); // a handshake completes mid-await
+    return true;
+  };
+  const result = await runBackendSwitch("codex", rec.effects);
+
+  assert.deepEqual(result, { switched: false, reason: BACKEND_SWITCH.SUPERSEDED });
+  for (const effect of COMMITS) {
+    assert.ok(!rec.log.includes(effect), `${effect} ran against a backend state that had already moved`);
+  }
+});
+
+test("#1184 the reseed predicate is preserved: reseed iff the target differs", async () => {
+  // Seeding from the new backend's group is what stops the post-handshake push carrying the
+  // previous backend's model/effort. A re-pick must NOT reseed — that would clobber a
+  // user's in-session model choice.
+  const differs = recorder({ live: null, picked: "claude" });
+  await runBackendSwitch("codex", differs.effects);
+  assert.ok(differs.log.includes("seedPrefs"), "a different target reseeds");
+
+  const same = recorder({ live: null, picked: "codex" });
+  await runBackendSwitch("codex", same.effects);
+  assert.ok(!same.log.includes("seedPrefs"), "a re-pick of the same backend must not reseed");
+});
+
+test("#1184 the replay is built AFTER the turn ends, and only armed when non-empty", async () => {
+  const withReplay = recorder({ live: "claude", replay: "User: hi" });
+  await runBackendSwitch("codex", withReplay.effects);
+  assert.ok(
+    withReplay.log.indexOf("buildReplay") > withReplay.log.indexOf("endTurn"),
+    "the transcript is captured after the turn is closed out",
+  );
+  assert.ok(withReplay.log.includes("armContext"));
+
+  const empty = recorder({ live: "claude", replay: "" });
+  await runBackendSwitch("codex", empty.effects);
+  assert.ok(empty.log.includes("buildReplay"), "it still asks");
+  assert.ok(!empty.log.includes("armContext"), "…but arming an empty preamble would send a header with no chat");
+});
+
+test("#1184 WIRING: the panel delegates, and keeps no commit above the guard", () => {
+  // Without this the module can be correct and dead. The panel is 1.7MB of IIFE, so this is
+  // a source assertion by necessity — but it is the specific one that matters: no write to
+  // the committed state may remain textually inside connectBackend.
+  const at = PANEL_SRC.indexOf("async function connectBackend(id) {");
+  assert.ok(at > 0, "connectBackend must be findable");
+  const body = PANEL_SRC.slice(at, PANEL_SRC.indexOf("\n  }", at));
+
+  assert.match(body, /runBackendSwitch\(id, \{/, "connectBackend must delegate the ordering to the module");
+  // The commits may only appear as INJECTED effects, i.e. inside a callback the module
+  // calls after the guard — never as statements the function runs on its own.
+  assert.match(body, /commitSelection: \(next\) => \{/, "the selection writes must be an injected effect");
+  assert.match(body, /invalidate: \(\) => invalidateDurableAgentSession\(\)/, "the guard must be injected too");
+  // The old shape, stated exactly so a revert is caught by name.
+  assert.doesNotMatch(
+    body,
+    /if \(!await invalidateDurableAgentSession\(\)\) return;/,
+    "the bare guarded return is the #1184 defect — the module decides the order now",
+  );
+});
+
+test("#1184 the disclosure is honest only because nothing was committed", () => {
+  // #1171 briefly added this same line at the old call site and it was withdrawn, correctly:
+  // saying "reconnect is paused" while the panel had already half-switched was a lie. The
+  // ordering fix is what makes the existing key true, which is why no new catalog string is
+  // minted here — the English catalog is frozen (#1135) and one new key means a pass over
+  // eleven locale files.
+  const at = PANEL_SRC.indexOf("async function connectBackend(id) {");
+  const body = PANEL_SRC.slice(at, PANEL_SRC.indexOf("\n  }", at));
+  assert.match(body, /panel\.the_old_session_could_not_be_invalidated/, "the abort must be disclosed, not silent");
+});

--- a/browser_tests/unit/backend-switch.test.mjs
+++ b/browser_tests/unit/backend-switch.test.mjs
@@ -123,26 +123,44 @@ test("#1184 a NON-switch never consults the history store", async () => {
   }
 });
 
-test("#1184 a handshake landing during the invalidate supersedes the switch", async () => {
-  // Awaiting before committing opens a window the old order did not have: a handshake can
-  // write `connectedBackend` underneath us. Under the old order those writes overwrote our
-  // commits; under this one ours would land last and win against a backend the user did not
-  // pick from the state we decided on.
+test("#1184 a handshake landing during the invalidate does NOT discard the user's pick", async () => {
+  // The first version of this guard ABORTED here, and that was worse than the race it
+  // guarded. By this point the invalidate has run, so the session is already destroyed —
+  // aborting left the user with a dead session, no connect, and their explicit click
+  // silently dropped. A handshake that merely happened to land during the await must not
+  // beat an explicit pick.
   const rec = recorder({ live: "claude" });
   rec.effects.invalidate = async () => {
     rec.log.push("invalidate");
-    rec.setLive("gemini"); // a handshake completes mid-await
+    rec.setLive("gemini"); // an unrelated handshake completes mid-await
     return true;
   };
   const result = await runBackendSwitch("codex", rec.effects);
 
-  assert.deepEqual(result, { switched: false, reason: BACKEND_SWITCH.SUPERSEDED });
-  for (const effect of COMMITS) {
-    assert.ok(!ran(rec.log, effect), `${effect} ran against a backend state that had already moved`);
-  }
-  // …but the turn IS ended, for the same reason as the failed-invalidate path: the session
-  // pointer is gone by the time we know the switch will not proceed.
-  assert.ok(ran(rec.log, "endTurn"), "a destroyed session leaves no resumable turn, whichever abort we take");
+  assert.deepEqual(result, { switched: true, reason: BACKEND_SWITCH.SWITCHED });
+  assert.ok(ran(rec.log, "commitSelection:codex"), "the pick the user made must still be committed");
+  assert.ok(ran(rec.log, "teardownAndConnect"), "…and it must actually connect, not strand the panel");
+  assert.ok(ran(rec.log, "endTurn"), "the destroyed session leaves no resumable turn");
+});
+
+test("#1184 a handshake that landed on the TARGET stops it being a switch", async () => {
+  // The case the re-read actually exists for. If the handshake landed on the very backend
+  // being asked for, the new provider already holds the conversation — arming the
+  // "continued in a fresh AI session" preamble against it would replay the whole transcript
+  // to the session that is already carrying it, which is the #1184 leak by another route.
+  const rec = recorder({ live: "claude", replay: "User: hi" });
+  rec.effects.invalidate = async () => {
+    rec.log.push("invalidate");
+    rec.setLive("codex"); // the handshake landed on the target
+    return true;
+  };
+  const result = await runBackendSwitch("codex", rec.effects);
+
+  assert.equal(result.switched, false, "already on codex — this is no longer a switch");
+  assert.equal(result.reason, BACKEND_SWITCH.CONNECTED);
+  assert.ok(!ran(rec.log, "armContext"), "the target already has the conversation");
+  assert.ok(ran(rec.log, "commitSelection:codex"), "the pick is still recorded");
+  assert.ok(ran(rec.log, "teardownAndConnect"), "and the connect still runs");
 });
 
 test("#1184 the reseed predicate is preserved: reseed iff the target differs", async () => {
@@ -263,23 +281,4 @@ test("#1184 the two aborts are disclosed differently — one message cannot be t
     /disclose: \(reason\) => \{[\s\S]{0,200}?if \(reason !== BACKEND_SWITCH\.INVALIDATE_FAILED\) return;/,
     "the disclosure must branch on the reason, not print the invalidate line for every abort",
   );
-});
-
-test("#1184 a superseded switch reports its own reason, distinct from a failed invalidate", async () => {
-  // The module's half of the same property: the caller cannot tell the two apart unless
-  // these are distinct values.
-  assert.notEqual(BACKEND_SWITCH.SUPERSEDED, BACKEND_SWITCH.INVALIDATE_FAILED);
-
-  const rec = recorder({ live: "claude" });
-  rec.effects.invalidate = async () => {
-    rec.log.push("invalidate");
-    rec.setLive("gemini");
-    return true;
-  };
-  await runBackendSwitch("codex", rec.effects);
-  assert.ok(
-    rec.log.includes(`disclose:${BACKEND_SWITCH.SUPERSEDED}`),
-    "a supersede must disclose as a supersede, so the panel can choose to stay quiet",
-  );
-  assert.ok(!rec.log.includes(`disclose:${BACKEND_SWITCH.INVALIDATE_FAILED}`));
 });

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -183,7 +183,10 @@ import { buildPanelFailureShell } from "./lib/panel-failure-shell.js";
 import { displayLabel, boundaryInputLabel, widgetLabelMap } from "./lib/slot-labels.js";
 import { createObjectInfoHistory, awaitHistoryBaseline } from "./lib/object-info-history.js";
 import { makeRefreshCoalescer } from "./lib/refresh-coalesce.js";
-import { describeNodeDefRefresh } from "./lib/node-def-refresh.js";
+import { describeNodeDefRefresh } from "./lib/node-def-refresh.js";
+// #1184 — the ORDER a backend switch commits in. A module because the defect is an
+// ordering property, and order cannot be asserted against the 1.7MB panel IIFE.
+import { runBackendSwitch } from "./lib/backend-switch.js";
 import { fetchNodeDefsWithRetry, OBJECT_INFO_RETRY_DELAYS_MS } from "./lib/object-info-retry.js";
 import { createObjectInfoCache, CACHE_OUTCOME } from "./lib/object-info-cache.js";
 import { fetchWholeObjectInfo, objectInfoOracleFailureNote } from "./lib/object-info-oracle.js";
@@ -29712,98 +29715,94 @@ function buildPanel() {
   }
 
   async function connectBackend(id) {
-    // CENTRALIZED per-backend seeding: every switch path routes through here — the
-    // backend chips, the model-popover provider row, AND the Settings backend combo
-    // (panelHooks.applyBackend). When the target backend differs from the one prefs
-    // currently reflect (connectedBackend if connected, else the last-picked
-    // selectedBackend), seed prefs from the NEW backend's group BEFORE connecting, so
-    // the post-handshake push uses the new backend's model/effort — never the
-    // previous backend's stale values. A re-pick of the same backend doesn't reseed.
-    const prevBackend = connectedBackend || selectedBackend;
-    if (id !== prevBackend) seedPrefsForBackendSwitch(id);
-    selectedBackend = id;
-    try {
-      window.localStorage.setItem(STORAGE_KEY_BACKEND, id);
-    } catch {
-      // localStorage unavailable — selection just won't persist.
-    }
-    // FIX 1 — do NOT write SETTING_BACKEND here. A live composer/chip backend switch
-    // is TEMPORARY/session-only and must NOT change the saved Settings default. The
-    // old setSetting(SETTING_BACKEND, id) re-entered through SETTING_BACKEND.onChange →
-    // applyBackend → connectBackend → setSetting → … (ComfyUI fires onChange async,
-    // AFTER setSetting's suppressSettingOnChange has already reset), so each switch
-    // overlapped multiple connects and the bridge's close-old-on-new-hello looped
-    // (the 9181 "ready"/"waiting" storm). The Settings "Default agent backend" now
-    // changes ONLY when the user edits it in the Settings dialog. Runtime selection
-    // still persists in STORAGE_KEY_BACKEND above (drives backendNow()'s timings).
-    renderBackendChips(
-      Array.from(backendChips.querySelectorAll(".cmcp-backend-chip")).map((el) => ({
-        backend: el.dataset.backend,
-        running: el.dataset.running === "1",
-      })),
-    );
-    // Switching to a DIFFERENT backend than we're connected to: agent sessions are
-    // NOT shareable across providers, so start FRESH for the new one (fix #2).
-    // Sending the saved (foreign) session id on hello makes the new orchestrator
-    // try to resume a session it doesn't own (stuck awaiting handshake +
-    // a spurious re-send). Mirror newChat()'s session-clear so getResume() → null;
-    // the visible chat log stays, only the agent session resets.
-    const switching = connectedBackend !== null && connectedBackend !== id;
-    if (switching) {
-      // Switching providers abandons the old agent session (not portable across
-      // backends). End the turn locally — like the Disconnect handler — so the
-      // working indicator doesn't outlive the session we're dropping (the client
-      // .stop() below sets closed=true, suppressing the onStatus that would hide).
-      endTurnLocally();
-      // Replay the visible transcript to the NEW provider as one-shot context so
-      // its fresh session has the conversation (session/thinking aren't portable
-      // across providers). Consumed by the next user message, then auto-cleared.
-      const replay = buildReplayTranscript();
-      if (replay) client.armContext(replay);
-      // The old provider's session must be durably invalid before any reconnect
-      // can observe it. If reconnect fails or the browser closes here, reload
-      // still starts fresh instead of restoring a foreign session.
-      //
-      // #1184 — THIS RETURN IS SILENT, AND SAYING SOMETHING HERE IS NOT THE FIX.
-      //
-      // #1171 briefly added hardRestart's "reconnect is paused" line here. Review showed
-      // that makes it worse rather than better: by this point `seedPrefsForBackendSwitch`,
-      // `selectedBackend`, `localStorage[STORAGE_KEY_BACKEND]`, the chips, `endTurnLocally()`
-      // and `client.armContext(replay)` have ALL committed to the new backend, while the
-      // OLD backend's socket is still open. "Paused" tells the user nothing happened, when
-      // in fact the panel is now half-switched — and the armed replay ships the entire prior
-      // conversation back to the provider that already has it on the next message.
-      //
-      // The exit is also more reachable than a genuine store failure: a capped IndexedDB
-      // open answers ok:false for any history past the local shadow's limits (measured — 400
-      // messages, or 30 threads), so a two-second disk hiccup lands here.
-      //
-      // The fix is to roll the commit back, or not to commit until this succeeds, and that
-      // decision belongs to #1184 rather than to a re-entrancy-guard change.
-      if (!await invalidateDurableAgentSession()) return;
-    }
-    // Reflect the picked backend in the composer placeholder immediately; onModels
-    // reaffirms it authoritatively from the handshake (fix #3).
-    setAskPlaceholder(id);
-    // CLEAN TEARDOWN before the (re)connect (fix #1). The old fromChip path bypassed
-    // the in-flight guard, so a chip pick could OVERLAP a sticky-reconnect already
-    // in flight — re-delivering the prior pending message (a visible duplicate) and
-    // starting a reconnect storm that trips the orchestrator's bounded-restart
-    // give-up ("the agent session keeps dropping"). Tearing the bridge down and
-    // clearing the guard first means EXACTLY ONE connect runs for the new backend.
-    client.stop();
-    connecting = false;
-    // FIX 2 — refresh the bridge URL (and the Advanced URL field) before
-    // reconnecting. Single-port now, so this is normally the same 9180 URL for
-    // every backend — it still matters when a custom Bridge URL override is set.
-    // /connect's returned bridge_url still applies on top. The client is stopped, so
-    // setUrl only updates its `url` here (its connect() no-ops while closed);
-    // connectAgent's client.start() opens it. urlInput has no settings onChange wired,
-    // so updating it can't re-enter the storm.
-    const nextUrl = configuredBridgeUrlFor(id);
-    urlInput.value = nextUrl;
-    if (client.currentUrl() !== nextUrl) client.setUrl(nextUrl);
-    void connectAgent({ fromChip: true });
+    // #1184 — the ORDER lives in lib/backend-switch.js, and it is an order rather than a
+    // repair. This function used to commit the new backend — prefs, `selectedBackend`,
+    // `localStorage`, the chips, `endTurnLocally()`, the armed replay — and only THEN check
+    // whether the old provider's session could be durably invalidated, returning silently
+    // when it could not. The panel was left claiming a backend it had never connected to,
+    // and `STORAGE_KEY_BACKEND` outlives the tab, so a reload adopted that choice for good.
+    //
+    // Committing later rather than rolling back: an undo would have to restore six pieces
+    // of state, and `armContext` has no disarm affordance at all.
+    const { switched } = await runBackendSwitch(id, {
+      liveBackend: () => connectedBackend,
+      pickedBackend: () => selectedBackend,
+      // The old provider's session must be durably invalid before any reconnect can observe
+      // it. If the reconnect fails or the browser closes, a reload must start fresh rather
+      // than restore a foreign session.
+      invalidate: () => invalidateDurableAgentSession(),
+      // CENTRALIZED per-backend seeding: every switch path routes through here — the backend
+      // chips, the model-popover provider row, AND the Settings backend combo
+      // (panelHooks.applyBackend). Seeding from the NEW backend's group before connecting is
+      // what stops the post-handshake push carrying the previous backend's stale
+      // model/effort. A re-pick of the same backend does not reseed; the caller decides.
+      seedPrefs: (next) => seedPrefsForBackendSwitch(next),
+      // ONE STEP, deliberately. `renderBackendChips` highlights on `selectedBackend` and
+      // `connectAgent` POSTs it, so these three writes have to land together and before the
+      // connect; splitting them silently connects to the previous backend.
+      commitSelection: (next) => {
+        selectedBackend = next;
+        try {
+          window.localStorage.setItem(STORAGE_KEY_BACKEND, next);
+        } catch {
+          // localStorage unavailable — the selection just won't persist.
+        }
+        // FIX 1 — do NOT write SETTING_BACKEND here. A live composer/chip switch is
+        // TEMPORARY/session-only and must not change the saved Settings default. The old
+        // setSetting(SETTING_BACKEND, id) re-entered through SETTING_BACKEND.onChange →
+        // applyBackend → connectBackend → setSetting → … (ComfyUI fires onChange async,
+        // AFTER suppressSettingOnChange has reset), so each switch overlapped multiple
+        // connects and the bridge's close-old-on-new-hello looped (the 9181
+        // "ready"/"waiting" storm). Runtime selection persists in STORAGE_KEY_BACKEND above.
+        renderBackendChips(
+          Array.from(backendChips.querySelectorAll(".cmcp-backend-chip")).map((el) => ({
+            backend: el.dataset.backend,
+            running: el.dataset.running === "1",
+          })),
+        );
+      },
+      // Like the Disconnect handler: the working indicator must not outlive the session
+      // being dropped (the client .stop() below sets closed=true, suppressing the onStatus
+      // that would hide it).
+      endTurn: () => endTurnLocally(),
+      // Agent sessions are NOT shareable across providers, so the new one starts fresh and
+      // the visible transcript is replayed to it as one-shot context (session/thinking are
+      // not portable). Consumed by the next user message, then auto-cleared.
+      buildReplay: () => buildReplayTranscript(),
+      armContext: (replay) => client.armContext(replay),
+      teardownAndConnect: (next) => {
+        // Reflect the picked backend in the composer placeholder immediately; onModels
+        // reaffirms it authoritatively from the handshake (fix #3).
+        setAskPlaceholder(next);
+        // CLEAN TEARDOWN before the (re)connect (fix #1). The old fromChip path bypassed the
+        // in-flight guard, so a chip pick could OVERLAP a sticky-reconnect already in flight
+        // — re-delivering the prior pending message (a visible duplicate) and starting a
+        // reconnect storm that trips the orchestrator's bounded-restart give-up. Tearing the
+        // bridge down and clearing the guard first means EXACTLY ONE connect runs.
+        client.stop();
+        connecting = false;
+        // FIX 2 — refresh the bridge URL (and the Advanced URL field) before reconnecting.
+        // Single-port now, so this is normally the same 9180 URL for every backend; it still
+        // matters when a custom Bridge URL override is set. /connect's returned bridge_url
+        // still applies on top. The client is stopped, so setUrl only updates its `url`
+        // here; connectAgent's client.start() opens it.
+        const nextUrl = configuredBridgeUrlFor(next);
+        urlInput.value = nextUrl;
+        if (client.currentUrl() !== nextUrl) client.setUrl(nextUrl);
+        void connectAgent({ fromChip: true });
+      },
+      // The same line hardRestart uses. It is honest HERE only because nothing has been
+      // committed by the time it runs — which was the objection that withdrew it last time.
+      disclose: () => {
+        appendSystem(
+          tr(
+            "panel.the_old_session_could_not_be_invalidated",
+            "The old session could not be invalidated durably; reconnect is paused to avoid restoring it.",
+          ),
+        );
+      },
+    });
+    return switched;
   }
 
   // Soft reload: pick up new code WITHOUT restarting ComfyUI, keeping this

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -22445,10 +22445,20 @@ function buildPanel() {
     // #43: the LAST RUNTIME pick (STORAGE_KEY_BACKEND, already in selectedBackend)
     // must survive a panel REMOUNT — navigating away and back was silently swapping
     // an active Codex session to the durable default (Claude) and dropping the
-    // conversation. A Settings-dialog change to the default already writes
-    // STORAGE_KEY_BACKEND (via applyBackend→connectBackend), so the two only diverge
-    // after a session-only chip pick — and then the runtime pick wins. Fall back to
-    // the durable default ONLY when there's no runtime pick yet (first-ever load).
+    // conversation. A Settings-dialog change to the default USUALLY writes
+    // STORAGE_KEY_BACKEND too (via applyBackend→connectBackend), so the two normally
+    // diverge only after a session-only chip pick — and then the runtime pick wins. Fall
+    // back to the durable default ONLY when there's no runtime pick yet (first-ever load).
+    //
+    // #1184 — "usually", not "always", and the exception is deliberate. A switch whose
+    // session invalidation fails now commits NOTHING, including this key, so the runtime
+    // pick keeps naming the backend the panel is actually connected to. The Settings value
+    // and the runtime pick then disagree, and this resolves in favour of the runtime pick,
+    // which is the correct half: it is the one backed by a live connection. Before that
+    // fix the key was written first and the divergence resolved the other way — a reload
+    // adopting a backend the panel had never reached, which is the bug #1184 reports.
+    // (ComfyUI persists the Settings value before notifying us at all, so the dialog will
+    // still show the un-taken choice; that half is #1198.)
     let runtimePick = null;
     try {
       runtimePick = window.localStorage.getItem(STORAGE_KEY_BACKEND);

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -29791,21 +29791,19 @@ function buildPanel() {
         if (client.currentUrl() !== nextUrl) client.setUrl(nextUrl);
         void connectAgent({ fromChip: true });
       },
-      // REASON-AWARE, because the two aborts are not the same event and one shared message
-      // would be false for one of them.
+      // REASON-AWARE, and there is only one reason left that warrants saying anything.
       //
-      // INVALIDATE_FAILED is the #1184 case: nothing committed, still on the old backend,
-      // and the switch genuinely did not happen. hardRestart's existing line says exactly
-      // that, and it is honest HERE only because nothing has been committed by the time it
-      // runs — which was the objection that withdrew it from this site last time.
+      // INVALIDATE_FAILED is the #1184 case: no backend state committed, still on the old
+      // provider, and the switch genuinely did not happen. hardRestart's existing line says
+      // that, and it is honest at this site only because the reorder means nothing has been
+      // committed by the time it runs. It is narrower than it looks, though: the SESSION is
+      // already invalid regardless (the invalidate destroys it before reporting), so this
+      // speaks for the switch and not for the session — #1198 tracks the rest.
       //
-      // SUPERSEDED says nothing, deliberately. A handshake landed while we were awaiting,
-      // which means the panel is CONNECTED and coherent: `onModels` has already written
-      // `connectedBackend`, `localStorage` and repainted the chips authoritatively, so the
-      // user can see which backend they are on. Printing the invalidate line there would be
-      // flatly wrong — the session WAS invalidated and nothing is paused. Saying something
-      // accurate instead would need a new catalog key, and English is frozen (#1135), so
-      // this defers to the chips rather than mint one.
+      // There used to be a second, SUPERSEDED, for a handshake landing mid-await. That path
+      // no longer aborts — dropping the user's explicit pick was worse than the race — so
+      // there is nothing left to disclose there. The guard on the reason stays, because a
+      // future outcome must opt IN to borrowing this string rather than inherit it.
       disclose: (reason) => {
         if (reason !== BACKEND_SWITCH.INVALIDATE_FAILED) return;
         appendSystem(

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -183,10 +183,10 @@ import { buildPanelFailureShell } from "./lib/panel-failure-shell.js";
 import { displayLabel, boundaryInputLabel, widgetLabelMap } from "./lib/slot-labels.js";
 import { createObjectInfoHistory, awaitHistoryBaseline } from "./lib/object-info-history.js";
 import { makeRefreshCoalescer } from "./lib/refresh-coalesce.js";
-import { describeNodeDefRefresh } from "./lib/node-def-refresh.js";
+import { describeNodeDefRefresh } from "./lib/node-def-refresh.js";
 // #1184 — the ORDER a backend switch commits in. A module because the defect is an
 // ordering property, and order cannot be asserted against the 1.7MB panel IIFE.
-import { runBackendSwitch } from "./lib/backend-switch.js";
+import { BACKEND_SWITCH, runBackendSwitch } from "./lib/backend-switch.js";
 import { fetchNodeDefsWithRetry, OBJECT_INFO_RETRY_DELAYS_MS } from "./lib/object-info-retry.js";
 import { createObjectInfoCache, CACHE_OUTCOME } from "./lib/object-info-cache.js";
 import { fetchWholeObjectInfo, objectInfoOracleFailureNote } from "./lib/object-info-oracle.js";
@@ -29791,9 +29791,23 @@ function buildPanel() {
         if (client.currentUrl() !== nextUrl) client.setUrl(nextUrl);
         void connectAgent({ fromChip: true });
       },
-      // The same line hardRestart uses. It is honest HERE only because nothing has been
-      // committed by the time it runs — which was the objection that withdrew it last time.
-      disclose: () => {
+      // REASON-AWARE, because the two aborts are not the same event and one shared message
+      // would be false for one of them.
+      //
+      // INVALIDATE_FAILED is the #1184 case: nothing committed, still on the old backend,
+      // and the switch genuinely did not happen. hardRestart's existing line says exactly
+      // that, and it is honest HERE only because nothing has been committed by the time it
+      // runs — which was the objection that withdrew it from this site last time.
+      //
+      // SUPERSEDED says nothing, deliberately. A handshake landed while we were awaiting,
+      // which means the panel is CONNECTED and coherent: `onModels` has already written
+      // `connectedBackend`, `localStorage` and repainted the chips authoritatively, so the
+      // user can see which backend they are on. Printing the invalidate line there would be
+      // flatly wrong — the session WAS invalidated and nothing is paused. Saying something
+      // accurate instead would need a new catalog key, and English is frozen (#1135), so
+      // this defers to the chips rather than mint one.
+      disclose: (reason) => {
+        if (reason !== BACKEND_SWITCH.INVALIDATE_FAILED) return;
         appendSystem(
           tr(
             "panel.the_old_session_could_not_be_invalidated",

--- a/web/js/lib/backend-switch.js
+++ b/web/js/lib/backend-switch.js
@@ -83,11 +83,28 @@ export async function runBackendSwitch(id, effects) {
     // THE ONLY AWAIT BEFORE A COMMIT, and the non-switching path must never reach it: a
     // first connect and a re-pick of the live backend stay fully synchronous, so neither is
     // ever gated on the history store's health.
-    if (!(await invalidate())) {
-      // Nothing has been committed, so "nothing happened" is now TRUE. That matters: an
-      // earlier attempt at disclosure here was withdrawn on the grounds that telling the
-      // user the switch was paused was a lie while the panel was already half-switched.
-      // Ordering the invalidate first is what makes the honest message available.
+    const invalidated = await invalidate();
+
+    // THE INVALIDATE IS DESTRUCTIVE BEFORE IT REPORTS, and an earlier version of this file
+    // claimed the opposite. `invalidateDurableAgentSession` clears the session key, nulls
+    // `thread.sessionId` and persists — and only THEN consults `flush()` for the boolean it
+    // returns. So "it failed, therefore nothing happened" was never true: by the time we
+    // learn the answer the old session's resume pointer is already gone, whatever it says.
+    //
+    // That is why the turn is ended HERE rather than with the commits below. The old order
+    // ended it before the invalidate, so a failure left the two consistent. Ending it only
+    // on success left MID_TASK_KEY armed against a session pointer that no longer exists,
+    // and the mid-task nudge would later fire into a brand-new empty session telling the
+    // agent it "resumed with full context" — the exact false-reassurance class this repo
+    // keeps fixing. A turn whose session id has been destroyed cannot resume, so it ends,
+    // and both abort paths below inherit that.
+    endTurn();
+
+    if (!invalidated) {
+      // Honest now in a narrower sense than the first draft of this comment claimed: no
+      // BACKEND state has been committed, so the panel is still on the old provider and
+      // "reconnect is paused" is true of the switch. It is not true of the session, which
+      // is already invalid — see #1198 for the part this ordering cannot fix.
       disclose(BACKEND_SWITCH.INVALIDATE_FAILED);
       return { switched: false, reason: BACKEND_SWITCH.INVALIDATE_FAILED };
     }
@@ -115,10 +132,10 @@ export async function runBackendSwitch(id, effects) {
   commitSelection(id);
 
   if (switching) {
-    // Switching providers abandons the old agent session — not portable across backends.
-    // End the turn locally so the working indicator does not outlive the session being
-    // dropped, then replay the visible transcript to the NEW provider as one-shot context.
-    endTurn();
+    // The turn was already ended above, as soon as the invalidate had run — see the note
+    // there. Only the replay belongs here: it is the one step that must NOT happen on an
+    // abort, because arming context against a provider we are not switching to is what
+    // shipped the whole prior transcript back to the backend that already had it.
     const replay = buildReplay();
     if (replay) armContext(replay);
   }

--- a/web/js/lib/backend-switch.js
+++ b/web/js/lib/backend-switch.js
@@ -74,11 +74,10 @@ export async function runBackendSwitch(id, effects) {
   } = effects;
 
   const startedOn = liveBackend();
-  const switching = startedOn !== null && startedOn !== id;
   // Computed from `connectedBackend`, which none of the commits below touch — it is written
   // only at its declaration and by the `onModels` handshake. That is what makes deciding
   // this before committing anything equivalent to deciding it after.
-  const prevBackend = startedOn || pickedBackend();
+  const switching = startedOn !== null && startedOn !== id;
 
   if (switching) {
     // THE ONLY AWAIT BEFORE A COMMIT, and the non-switching path must never reach it: a
@@ -104,6 +103,14 @@ export async function runBackendSwitch(id, effects) {
   }
 
   // From here everything commits, in the panel's original order.
+  //
+  // `pickedBackend()` is consulted ONLY when there is no live backend — and that is exactly
+  // the path with no await, so nothing can move underneath it. Reading it before or after
+  // the guard above is therefore unobservable, and it was briefly changed to a late read on
+  // the theory that the `backends` auto-pick (which writes `selectedBackend` WITHOUT
+  // `connectedBackend`, so it does slip past the supersede check) could stale it. It cannot:
+  // when that writer can run, this expression has already resolved to `startedOn`.
+  const prevBackend = startedOn || pickedBackend();
   if (id !== prevBackend) seedPrefs(id);
   commitSelection(id);
 

--- a/web/js/lib/backend-switch.js
+++ b/web/js/lib/backend-switch.js
@@ -1,0 +1,121 @@
+// #1184 — the ORDER in which a backend switch commits.
+//
+// `connectBackend()` used to commit the new backend to memory, to localStorage and to the
+// UI, and only then check whether the old provider's session could be durably invalidated.
+// When that check failed it returned — leaving the panel persistently claiming a backend it
+// had never connected to:
+//
+//   - `STORAGE_KEY_BACKEND` outlives the tab, and on reload the runtime pick WINS over the
+//     saved Settings default, so the aborted choice is adopted permanently;
+//   - the armed one-shot replay — the whole prior transcript under a "continued in a fresh
+//     AI session" preamble — stays armed against the OLD provider's still-live session,
+//     which already has that history. `client.stop()` does not clear it;
+//   - prefs hold the new backend's model/effort while the old socket is live, which is the
+//     stale cross-backend push the reseed exists to prevent;
+//   - `endTurnLocally()` has already cleared the working indicator and MID_TASK_KEY for a
+//     turn that may still be running on the old provider, and the `client.stop()` that
+//     normally accompanies that never runs on this path.
+//
+// COMMIT LATER, DO NOT ROLL BACK. Rollback would have to restore six pieces of state, and
+// `armContext` has no disarm affordance at all. Ordering the invalidate first leaves the
+// failure path with nothing to undo, which is why this module is an ORDER rather than a
+// repair.
+//
+// It is a module because the defect is an ordering property. Asserting order inside the
+// 1.7MB panel IIFE is not possible, and an outcome-only test passes against the buggy order
+// just as happily as against the fixed one.
+
+/** What a switch did, for the caller's disclosure and for tests. */
+export const BACKEND_SWITCH = Object.freeze({
+  SWITCHED: "switched",
+  /** Not a switch at all: a first connect, or a re-pick of the live backend. */
+  CONNECTED: "connected",
+  /** The old provider's session could not be durably invalidated; nothing was committed. */
+  INVALIDATE_FAILED: "invalidate_failed",
+  /** A handshake changed the live backend while we were awaiting the invalidate. */
+  SUPERSEDED: "superseded",
+});
+
+/**
+ * Run a backend switch in an order where nothing is committed until it is legal.
+ *
+ * Every effect is injected so the panel can pass closures over its real state and a test
+ * can pass recorders. The panel keeps its own intra-block ordering inside `commitSelection`
+ * — `renderBackendChips` highlights on `selectedBackend` and `connectAgent` POSTs it, so
+ * those writes must stay together and must precede the connect.
+ *
+ * @param {string} id the backend being switched to
+ * @param {{
+ *   liveBackend: () => string|null,   // `connectedBackend`, READ LATE (see below)
+ *   pickedBackend: () => string|null, // `selectedBackend`
+ *   invalidate: () => Promise<boolean>,
+ *   seedPrefs: (id: string) => void,
+ *   commitSelection: (id: string) => void,
+ *   endTurn: () => void,
+ *   buildReplay: () => string,
+ *   armContext: (replay: string) => void,
+ *   teardownAndConnect: (id: string) => void,
+ *   disclose: (reason: string) => void,
+ * }} effects
+ * @returns {Promise<{switched: boolean, reason: string}>}
+ */
+export async function runBackendSwitch(id, effects) {
+  const {
+    liveBackend,
+    pickedBackend,
+    invalidate,
+    seedPrefs,
+    commitSelection,
+    endTurn,
+    buildReplay,
+    armContext,
+    teardownAndConnect,
+    disclose,
+  } = effects;
+
+  const startedOn = liveBackend();
+  const switching = startedOn !== null && startedOn !== id;
+  // Computed from `connectedBackend`, which none of the commits below touch — it is written
+  // only at its declaration and by the `onModels` handshake. That is what makes deciding
+  // this before committing anything equivalent to deciding it after.
+  const prevBackend = startedOn || pickedBackend();
+
+  if (switching) {
+    // THE ONLY AWAIT BEFORE A COMMIT, and the non-switching path must never reach it: a
+    // first connect and a re-pick of the live backend stay fully synchronous, so neither is
+    // ever gated on the history store's health.
+    if (!(await invalidate())) {
+      // Nothing has been committed, so "nothing happened" is now TRUE. That matters: an
+      // earlier attempt at disclosure here was withdrawn on the grounds that telling the
+      // user the switch was paused was a lie while the panel was already half-switched.
+      // Ordering the invalidate first is what makes the honest message available.
+      disclose(BACKEND_SWITCH.INVALIDATE_FAILED);
+      return { switched: false, reason: BACKEND_SWITCH.INVALIDATE_FAILED };
+    }
+    // RE-READ, because awaiting opened a window this function did not have before. A
+    // handshake landing during the invalidate writes `connectedBackend` (and the chips, and
+    // localStorage) underneath us. Under the old order those writes overwrote our commits;
+    // under this one ours would land last and silently win against a backend the user did
+    // not pick from the state we decided on.
+    if (liveBackend() !== startedOn) {
+      disclose(BACKEND_SWITCH.SUPERSEDED);
+      return { switched: false, reason: BACKEND_SWITCH.SUPERSEDED };
+    }
+  }
+
+  // From here everything commits, in the panel's original order.
+  if (id !== prevBackend) seedPrefs(id);
+  commitSelection(id);
+
+  if (switching) {
+    // Switching providers abandons the old agent session — not portable across backends.
+    // End the turn locally so the working indicator does not outlive the session being
+    // dropped, then replay the visible transcript to the NEW provider as one-shot context.
+    endTurn();
+    const replay = buildReplay();
+    if (replay) armContext(replay);
+  }
+
+  teardownAndConnect(id);
+  return { switched: switching, reason: switching ? BACKEND_SWITCH.SWITCHED : BACKEND_SWITCH.CONNECTED };
+}

--- a/web/js/lib/backend-switch.js
+++ b/web/js/lib/backend-switch.js
@@ -32,8 +32,6 @@ export const BACKEND_SWITCH = Object.freeze({
   CONNECTED: "connected",
   /** The old provider's session could not be durably invalidated; nothing was committed. */
   INVALIDATE_FAILED: "invalidate_failed",
-  /** A handshake changed the live backend while we were awaiting the invalidate. */
-  SUPERSEDED: "superseded",
 });
 
 /**
@@ -78,6 +76,9 @@ export async function runBackendSwitch(id, effects) {
   // only at its declaration and by the `onModels` handshake. That is what makes deciding
   // this before committing anything equivalent to deciding it after.
   const switching = startedOn !== null && startedOn !== id;
+  // Which backend is live once the await (if any) is done. Same as `startedOn` unless a
+  // handshake landed underneath us.
+  let landedOn = startedOn;
 
   if (switching) {
     // THE ONLY AWAIT BEFORE A COMMIT, and the non-switching path must never reach it: a
@@ -108,16 +109,27 @@ export async function runBackendSwitch(id, effects) {
       disclose(BACKEND_SWITCH.INVALIDATE_FAILED);
       return { switched: false, reason: BACKEND_SWITCH.INVALIDATE_FAILED };
     }
-    // RE-READ, because awaiting opened a window this function did not have before. A
-    // handshake landing during the invalidate writes `connectedBackend` (and the chips, and
-    // localStorage) underneath us. Under the old order those writes overwrote our commits;
-    // under this one ours would land last and silently win against a backend the user did
-    // not pick from the state we decided on.
-    if (liveBackend() !== startedOn) {
-      disclose(BACKEND_SWITCH.SUPERSEDED);
-      return { switched: false, reason: BACKEND_SWITCH.SUPERSEDED };
-    }
+    // RE-READ, because awaiting opened a window this function did not have before: a
+    // handshake landing during the invalidate writes `connectedBackend` underneath us.
+    //
+    // PROCEED, DO NOT ABORT — the first version of this guard returned here, and that was
+    // worse than the race it was guarding. By this point the session has already been
+    // invalidated, so aborting left the user with a destroyed session, no connect, and their
+    // explicit pick silently dropped. An explicit click must not lose to a handshake that
+    // happened to land during it.
+    //
+    // What the re-read is actually FOR is `switching`, which was decided against a backend
+    // that may no longer be live. If the handshake landed on the very backend being asked
+    // for, this is no longer a switch: the replay must not be armed (the new provider
+    // already has the conversation) and the turn was already ended above. Recomputing is
+    // what keeps those two decisions honest; the commits below run either way.
+    landedOn = liveBackend();
   }
+  // `switching` governs only the REPLAY now — the turn ended above, and every commit below
+  // is unconditional. False here means "the live backend is already the one asked for", so
+  // arming a fresh-session preamble against it would replay the conversation to the provider
+  // that is already holding it.
+  const stillSwitching = switching && landedOn !== id;
 
   // From here everything commits, in the panel's original order.
   //
@@ -131,15 +143,15 @@ export async function runBackendSwitch(id, effects) {
   if (id !== prevBackend) seedPrefs(id);
   commitSelection(id);
 
-  if (switching) {
+  if (stillSwitching) {
     // The turn was already ended above, as soon as the invalidate had run — see the note
-    // there. Only the replay belongs here: it is the one step that must NOT happen on an
-    // abort, because arming context against a provider we are not switching to is what
-    // shipped the whole prior transcript back to the backend that already had it.
+    // there. Only the replay belongs here, and only when this is really still a switch:
+    // arming a fresh-session preamble against a provider that already holds the
+    // conversation is what shipped the whole transcript back to the backend that had it.
     const replay = buildReplay();
     if (replay) armContext(replay);
   }
 
   teardownAndConnect(id);
-  return { switched: switching, reason: switching ? BACKEND_SWITCH.SWITCHED : BACKEND_SWITCH.CONNECTED };
+  return { switched: stillSwitching, reason: stillSwitching ? BACKEND_SWITCH.SWITCHED : BACKEND_SWITCH.CONNECTED };
 }


### PR DESCRIPTION
Fixes #1184.

`connectBackend()` committed the new backend — prefs, `selectedBackend`, `localStorage`, the chips, `endTurnLocally()`, the armed replay — and only *then* checked whether the old provider's session could be durably invalidated, returning silently when it could not. `STORAGE_KEY_BACKEND` outlives the tab and beats the saved default on reload, so the aborted choice was adopted permanently.

The sharpest leak was the armed replay: `pendingContext` is cleared only when a send consumes it and `client.stop()` does not clear it, so after an abort the whole prior transcript rode the next message back to the **old** provider, which already had it.

## Approach

Commit later, not roll back — an undo would need to restore six pieces of state and `armContext` has no disarm affordance. The ordering lives in `web/js/lib/backend-switch.js` because the defect is an *ordering* property: the buggy version reached the same final state on every successful switch, so an outcome-only test passes against it, and order cannot be asserted inside the 1.7MB panel IIFE.

## Review found 10 issues, all CONFIRMED — 8 fixed here

Five were defects **this branch introduced** while fixing the original:

- **The invalidate is destructive before it reports.** It clears `SESSION_KEY` and nulls `thread.sessionId` *before* `flush()` decides its return value — so "it failed, therefore nothing happened" was never true, and that claim was the stated justification for the whole reorder.
- **`MID_TASK_KEY` left armed against a destroyed session.** Moving `endTurn` in with the commits meant it ran only on success; the mid-task nudge would later fire into a brand-new empty session telling the agent it *"resumed with full context"*. The old order didn't have this. The turn now ends as soon as the invalidate has run.
- **The supersede guard discarded the user's pick** after invalidating their session — worse than the race it guarded. It proceeds now; an explicit click shouldn't lose to a coincidence of timing.
- **`disclose` ignored its `reason`**, printing the invalidate-failure string for a different abort.
- **Three vacuous tests**, including a WIRING test I disproved by reinstating the exact #1184 leak through it with all ten tests green.

## Deferred, with reasons

- **Concurrent `connectBackend` clicks** — the guard structurally cannot see them. Real, but this branch doesn't worsen it in kind, and a latch risks the wedge shape #1171 fought. Needs a generation counter designed deliberately.
- **hardRestart's "reconnect is paused" string** overstates this abort. An accurate one needs a catalog key and English is frozen (#1135).

Also filed: #1198 — the Settings path commits the durable default before any guard can run, because ComfyUI persists then notifies.

## Verification

4175 tests. Mutations caught include the full old-order revert (3 red), `endTurn-only-on-success`, `abort-on-handshake`, `replay-ignores-landing`, `wrong-id-to-commits`, `drop-startedOn-half`, and the leak-above-delegation.

Two review claims **refuted** by checking the committed blob rather than the working tree: this branch does not rewrite the panel to CRLF (32,642 bare LF, 0 CRLF, identical in kind to main) and leaves no doubled CR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)