### PR TITLE
chore(release): 0.14.29 — surface the twelve languages where they can actually be found

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,17 @@ Claude or ChatGPT (your own subscription, no API key).**
 
 **Stuck or have a question? [Join the Discord](https://discord.gg/cW9arBhzCu)** — or hit **🆘 Need help?** in the panel's Settings → About (it copies a diagnostics summary and opens the Discord for you).
 
+### 🌐 Speaks your language
+
+The whole panel — chat, settings, the CivitAI browser, the training wizard, the RunPod controls,
+every tooltip — is translated into **12 languages**, and it follows ComfyUI's own language setting
+automatically. Change it any time in **Settings → Panel language**.
+
+**English · 한국어 · 日本語 · 中文 (简体) · 中文 (繁體) · Русский · Français · Español · Português (BR) · Türkçe · العربية · فارسی**
+
+Arabic and Persian render right-to-left. Counted strings use each language's real plural rules —
+Russian's four forms and Arabic's six, not an English one/other pair bolted on.
+
 Pick a provider — **Claude** or **ChatGPT** — and the matching agent runs in the background on
 *your* subscription, sees the graph you're looking at, and edits it live. Every provider is
 **offered the same surface**: the same live-canvas tools, the same model knowledge, the same

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-agent-panel"
-description = "Autonomous AI agent in the ComfyUI sidebar - local-first, bring any LLM. Run it on your Claude or ChatGPT subscription (no API keys, no extra LLM costs), on a Kimi K3 / GLM / OpenRouter key, or fully offline on free local models via Ollama, LM Studio, or llama.cpp. The agent drives your live canvas at full parity: add, wire, move and tweak nodes with Ctrl+Z undo, load whole workflows and installer packs in one shot, generate images, video and audio, browse CivitAI, and run your workflow - asking before it spends paid API credits. The sidebar UI for comfyui-mcp, the local-first, agent-native control plane for ComfyUI."
-version = "0.14.28"
+description = "Autonomous AI agent in the ComfyUI sidebar - local-first, bring any LLM. Run it on your Claude or ChatGPT subscription (no API keys, no extra LLM costs), on a Kimi K3 / GLM / OpenRouter key, or fully offline on free local models via Ollama, LM Studio, or llama.cpp. The agent drives your live canvas at full parity: add, wire, move and tweak nodes with Ctrl+Z undo, load whole workflows and installer packs in one shot, generate images, video and audio, browse CivitAI, and run your workflow - asking before it spends paid API credits. The sidebar UI for comfyui-mcp, the local-first, agent-native control plane for ComfyUI. The panel speaks 12 languages, matching your ComfyUI language automatically: English, 한국어, 日本語, 中文 (简体), 中文 (繁體), Русский, Français, Español, Português (BR), Türkçe, العربية, فارسی."
+version = "0.14.29"
 license = { file = "LICENSE" }
 requires-python = ">=3.9"
 # UI-only pack: no Python deps. The frontend floor guarantees

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -1419,7 +1419,7 @@ const DOCS_URL = "https://comfyui-mcp.artokun.io/docs";
 // Panel version — surfaced in the "Need help?" diagnostics blob. Bump via
 // `node scripts/set-version.mjs <v>` (updates this AND pyproject together); CI
 // and the publish gate FAIL if the two ever drift, so this can't go stale.
-const PANEL_VERSION = "0.14.28";
+const PANEL_VERSION = "0.14.29";
 
 // The connected orchestrator's console URL/token (captured off the `backends`
 // bridge message — see onBackends). Drives the "API Keys" credentials frame;


### PR DESCRIPTION
## What I measured first

| surface | can it carry a localized signal? | evidence |
|---|---|---|
| Comfy Registry API | **No** — no locale field exists | schema is `description, tags, category, search_ranking…` |
| Registry search | **No** — `에이전트` / `エージェント` → **0 hits** | also `sidebar agent` → 0, `ai-agent` → 0, so it is substring matching |
| Registry tags | **Not indexed for anyone** | ours return `[]` — *and so do ComfyUI-Manager's and Impact Pack's* |
| **ComfyUI-Manager in-app search** | **Yes, incidentally** | `custom-nodes-manager.js:605` — `searchableColumns = ["title","author","description"]`, filtered client-side |

We already rank **#1** on the Registry for `mcp`, `claude` and `comfyui mcp`, and **#2** for `agent`, so English discovery was never the gap.

The gap is that a Korean or Japanese user has no way to learn the panel speaks their language until after installing it.

## The change

- `pyproject.toml` description gains the language names **in their own scripts** (~180 chars). That is the only localized signal any of these surfaces can hold, it renders on the Registry listing regardless of search, and per the Manager finding above it is very likely matchable in the app where most installs happen.
- `README.md` gains a language section — GitHub is where search traffic lands.
- **Version bumped to 0.14.29** because a description only reaches the Registry *via a publish*; 0.14.28 is already published with the old 624-character text.

## Verification

- `check-tool-vocabulary` **OK** — it scans `pyproject.toml` and `README.md` and rejects a non-ASCII letter inside an underscore-joined word, so the added text keeps whitespace between every script and any identifier.
- `pyproject.toml` re-parsed with `tomllib`: description 624 → **806 chars**, Korean/Arabic/Cyrillic all present in the parsed value (the console's `UnicodeEncodeError` when printing it is a Windows code-page limitation, not a parse failure).
- `PANEL_VERSION` and `pyproject` version bumped together, which the publish workflow requires.
- `npm run test:unit` → **4165 pass, 0 fail**, across two consecutive runs. One earlier run reported a single failure that did not reproduce; noting it rather than hiding it.

## Not done deliberately

Localizing the 115-page docs site. 115 × 11 = 1,265 pages that drift, and a stale translated install guide is worse than a correct English one. If we localize docs it should be the entry path only — index, quickstart, install.