### PR TITLE
fix(1188): bound the remaining unbounded network awaits

### DIFF
--- a/browser_tests/unit/attachment-upload.test.mjs
+++ b/browser_tests/unit/attachment-upload.test.mjs
@@ -110,10 +110,19 @@ test("#756 WIRING: both upload paths record the status and the exception", () =>
   // The helper being right proves nothing if the call sites still discard. Pin the
   // two sites that had the defect, and that neither bare form survives.
   const src = readFileSync(PANEL_JS, "utf8");
+  // #1188 moved the exchange inside a bounded callback, so the non-200 description is now
+  // BUILT there and assigned by the caller. Same contract — the status must still be
+  // captured on both paths — pinned at both ends of the new shape so neither half can be
+  // dropped: a `failure:` nobody reads, or an `att.uploadError` fed by something else.
   assert.equal(
-    (src.match(/att\.uploadError = describeUploadFailure\(\{\s*\r?\n?\s*status: res\.status/g) || []).length,
+    (src.match(/failure: describeUploadFailure\(\{\s*\r?\n?\s*status: res\.status/g) || []).length,
     2,
     "both upload paths must record a non-200 status",
+  );
+  assert.equal(
+    (src.match(/att\.uploadError = outcome\.failure;/g) || []).length,
+    2,
+    "…and both must surface it as the attachment's error",
   );
   assert.equal(
     (src.match(/catch \(err\) \{[\s\S]{0,200}?att\.uploadError = describeUploadFailure\(\{ error: err/g) || []).length,

--- a/browser_tests/unit/attachment-upload.test.mjs
+++ b/browser_tests/unit/attachment-upload.test.mjs
@@ -124,10 +124,21 @@ test("#756 WIRING: both upload paths record the status and the exception", () =>
     2,
     "…and both must surface it as the attachment's error",
   );
+  // Window widened from 200 to 500: #1188 added a defensive re-read of the file's
+  // measurements inside each catch, which pushed the assignment further from `catch (err) {`.
+  // The contract is unchanged — the caught exception must still be what gets reported.
   assert.equal(
-    (src.match(/catch \(err\) \{[\s\S]{0,200}?att\.uploadError = describeUploadFailure\(\{ error: err/g) || []).length,
+    (src.match(/catch \(err\) \{[\s\S]{0,500}?att\.uploadError = describeUploadFailure\(\{ error: err/g) || []).length,
     2,
     "both upload paths must record the caught exception",
+  );
+  // #1188 — and neither catch may read `file.size`/`file.type` directly. A throwing getter
+  // there throws a SECOND time while reporting the first failure, escapes the handler, and
+  // rejects `att.ready` — which the send path awaits and cannot handle.
+  assert.equal(
+    (src.match(/catch \(err\) \{[\s\S]{0,500}?describeUploadFailure\(\{ error: err, name, size: file\.size/g) || []).length,
+    0,
+    "the reporting catch must not re-read a property that may be what threw",
   );
   assert.ok(
     !src.includes("/* upload failed — the chip still references it by name as a fallback */"),

--- a/browser_tests/unit/cmcp-secrets-bound.test.mjs
+++ b/browser_tests/unit/cmcp-secrets-bound.test.mjs
@@ -1,0 +1,104 @@
+// #1188 — the credentials console's three requests, bounded.
+//
+// Same failure as #1161 and #1180: after a ComfyUI or orchestrator restart the tab can hold
+// a half-open connection where a request neither answers nor fails, so there is nothing for
+// `try/catch` to catch. Here it wedges the UI rather than a command — the button stays
+// disabled reading "Saving…" forever, and because the panel only re-enables it in the
+// catch, the user cannot retry without reopening the frame.
+//
+// These are SOURCE assertions. The credentials frame is built inside the 1.7MB panel IIFE
+// from DOM handlers that cannot be constructed here, so what is pinned is the shape the
+// runtime behaviour depends on. Each assertion below corresponds to a mutation that passed
+// before it existed.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+const SRC = readFileSync(
+  fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url)),
+  "utf8",
+);
+
+/** The helper's body, anchored at both ends so prose cannot drift the window. */
+function helperBody() {
+  const at = SRC.indexOf("async function cmcpSecretsRequest(init) {");
+  assert.ok(at > 0, "cmcpSecretsRequest must be findable");
+  const end = SRC.indexOf("\n}", at);
+  assert.ok(end > at, "…and terminated");
+  // CODE ONLY. The comments in this helper NAME the calls they explain — `resp.json()`,
+  // `withTimeout`, `throw` — so a raw scan matches the prose and a mutation that moves real
+  // code into a comment slips through. One did: replacing the throw with a return while
+  // leaving `// was: throw new Error(` behind passed every assertion.
+  return SRC.slice(at, end)
+    .split(String.fromCharCode(10))
+    .filter((l) => !l.trim().startsWith("//"))
+    .join(String.fromCharCode(10));
+}
+
+test("#1188 no credentials request bypasses the bounded helper", () => {
+  // The whole fix in one line: if a raw fetch to that endpoint survives anywhere, the site
+  // it is on is still unbounded no matter how good the helper is.
+  const raw = SRC.split("\n").filter(
+    (l) => !l.trim().startsWith("//") && /await\s+fetch\(cmcpApiBase\(\)/.test(l),
+  );
+  assert.deepEqual(raw, [], `these call sites still bypass the bound:\n${raw.join("\n")}`);
+  // …and all three go through it.
+  const uses = (SRC.match(/await cmcpSecretsRequest\(/g) || []).length;
+  assert.equal(uses, 3, `expected the save, clear and load sites to be bounded, saw ${uses}`);
+});
+
+test("#1188 the bound covers the BODY, not just the response head", () => {
+  // `fetch` resolves as soon as the head arrives; the bytes stream afterwards inside
+  // `json()`. Bounding the request alone leaves the part that actually waits unbounded —
+  // which is exactly what shipped in #1180's first attempt at the log read, and passed its
+  // tests because they stalled the handshake rather than the body.
+  const body = helperBody();
+  assert.match(
+    body,
+    /const resp = await \(init \? fetch\(cmcpApiBase\(\), init\) : fetch\(cmcpApiBase\(\)\)\);\s*\n\s*return \{ resp, body: await resp\.json\(\) \};/,
+    "the response read must sit INSIDE the bounded promise, alongside the request",
+  );
+  const wrapped = body.indexOf("withTimeout(");
+  const json = body.indexOf("resp.json()");
+  assert.ok(wrapped >= 0 && wrapped < json, "…and withTimeout must enclose it, not follow it");
+});
+
+test("#1188 the bound is a real, named, positive number", () => {
+  // `withTimeout` treats a non-positive ms as NO bound and returns the promise unchanged, so
+  // passing 0 here silently restores the hang while every other assertion still holds. That
+  // exact mutation survived on #1180 until it was asserted for.
+  assert.match(
+    helperBody(),
+    /CMCP_SECRETS_TIMEOUT_MS,/,
+    "the bound must be the named constant — an inline 0 arms no timer at all",
+  );
+  const ms = Number((SRC.match(/const CMCP_SECRETS_TIMEOUT_MS = (\d+);/) || [])[1]);
+  assert.ok(ms > 0, "a non-positive bound is the same as no bound");
+  // A user-initiated write to a possibly-remote console: long enough not to refuse work that
+  // would have succeeded, short enough that a wedged console does not look like a dead panel.
+  assert.ok(ms >= 3000 && ms <= 15000, `${ms}ms is outside the range this call was sized for`);
+});
+
+test("#1188 a timeout REJECTS, so it lands in the handler that re-enables the button", () => {
+  // The reason nothing new had to be written in the UI: both call sites already catch, show
+  // the message and restore the button. Resolving a sentinel instead would fall through to
+  // `!resp.ok` on an undefined `resp` and throw a TypeError whose text is meaningless to a
+  // user — a worse message than the one it replaced.
+  const body = helperBody();
+  assert.match(body, /if \(settled === CMCP_SECRETS_NO_ANSWER\) \{[\s\S]{0,600}?throw new Error\(/, "a stall must throw");
+  assert.match(body, /if \("err" in settled\) throw settled\.err;/, "a real failure must keep its own cause");
+  // The sentinel must be a Symbol: a string or object could collide with a real body.
+  assert.match(SRC, /const CMCP_SECRETS_NO_ANSWER = Symbol\(/, "the sentinel must be unforgeable");
+});
+
+test("#1188 the stall message does not mint a catalog key", () => {
+  // The English catalog is frozen (#1135) and English is GENERATED from the code, so a new
+  // `tr()` key means a pass over eleven locale files. This path already renders the
+  // orchestrator's own untranslated `d.error` text through the same `showErr`, so a plain
+  // English sentence is consistent with what ships today rather than a coverage regression.
+  const body = helperBody();
+  assert.doesNotMatch(body, /\btr\(\s*"panel\./, "no new catalog key may be introduced here");
+  assert.match(body, /did not respond/, "…but the user must still be told what happened");
+});

--- a/browser_tests/unit/upload-bound.test.mjs
+++ b/browser_tests/unit/upload-bound.test.mjs
@@ -261,13 +261,21 @@ test("#1188 a genuine no-answer still reads as a transport timeout", () => {
     assert.match(msg, /did not COMPLETE/, `status ${String(status)} was treated as real`);
     assert.doesNotMatch(msg, /REFUSED/, `status ${String(status)} produced an invented refusal`);
   }
-  // …while every shape a real Response can present IS honoured.
-  for (const status of [100, 200, 404, 413, 500, 599, "413"]) {
+  // …while a status that genuinely denotes a refusal IS honoured, in either representation.
+  for (const status of [400, 404, 413, 500, 599, "413"]) {
     assert.match(
       describeTimedOutUpload({ observed: { status }, name: "x" }),
       /REFUSED/,
-      `a real status ${String(status)} was thrown away`,
+      `a real refusal status ${String(status)} was thrown away`,
     );
+  }
+  // A 1xx/2xx/3xx is a status but NOT a refusal, and describeUploadFailure's status branch
+  // words itself as "upload REFUSED … Nothing was written to input/" — a lie about a 200.
+  // A 200 whose body never finished streaming is a timeout, and reads as one.
+  for (const status of [100, 200, 201, 204, 302, 399]) {
+    const msg = describeTimedOutUpload({ observed: { status }, name: "x", size: 10 });
+    assert.match(msg, /did not COMPLETE/, `status ${status} should not read as a refusal`);
+    assert.doesNotMatch(msg, /REFUSED|Nothing was written/, `status ${status} fabricated a refusal`);
   }
 });
 
@@ -323,11 +331,22 @@ test("#1188 every uploadBlobToInput caller branches on the null it can now retur
     ["web/js/lib/run-completion-frame.js", /const ref = await uploadBlobToInput\(/],
   ];
   for (const [rel, call] of sites) {
-    const src = readFileSync(fileURLToPath(new URL(`../../${rel}`, import.meta.url)), "utf8");
-    assert.match(src, call, `${rel} no longer calls uploadBlobToInput — update this list`);
-    // Each site must test the ref before using it. The shapes differ by call site, so this
-    // asserts that SOME null test exists rather than one exact spelling.
-    assert.match(src, /if \(!ref\)|!ref\b|ref \?|ref &&|typeof ref/, `${rel} does not branch on a null ref`);
+    const raw = readFileSync(fileURLToPath(new URL(`../../${rel}`, import.meta.url)), "utf8");
+    // Measure CODE distance, not text distance. This repo writes long explanatory comments,
+    // and one of them sits between civitai's call and its guard — a raw character window
+    // put the guard out of range and failed a site that is actually correct.
+    const src = raw.split("\n").filter((l) => !l.trim().startsWith("//")).join("\n");
+    const at = src.search(call);
+    assert.ok(at >= 0, `${rel} no longer calls uploadBlobToInput — update this list`);
+    // SCOPED to the 400 code-characters after the call. An unscoped search over the whole
+    // file was vacuous: media-preview.js has unrelated `!ref`/`ref ?` expressions ~340 lines
+    // above its upload, so the assertion passed even with the real guard deleted. A test
+    // that cannot fail is worse than no test, because it reads as coverage.
+    assert.match(
+      src.slice(at, at + 400),
+      /if \(!ref\)|!ref\b|ref \?|ref &&|typeof ref/,
+      `${rel} does not branch on a null ref within 400 code-chars of the call`,
+    );
   }
   // …and the civitai path specifically, because it is the one that was wrong.
   const civitai = readFileSync(fileURLToPath(new URL("../../web/js/cmcp-civitai-ui.js", import.meta.url)), "utf8");
@@ -338,9 +357,10 @@ test("#1188 every uploadBlobToInput caller branches on the null it can now retur
 });
 
 test("#1188 uploadBlobToInput still answers null, so no caller learns a new shape", () => {
-  // Four callers branch on a null ref today (the apps, civitai and training wizards, and the
-  // storyboard pipeline). Returning the sentinel to them instead would make `!ref` false and
-  // send a Symbol into `viewUrl`.
+  // FIVE callers, enumerated and asserted in the test above — this comment said "four" until
+  // a review counted them, which is the same unchecked claim the source comment carried.
+  // Returning the sentinel to them instead would make `!ref` false and send a Symbol into
+  // `viewUrl`.
   assert.match(
     CODE,
     /return out === UPLOAD_NO_ANSWER \? null : out;/,

--- a/browser_tests/unit/upload-bound.test.mjs
+++ b/browser_tests/unit/upload-bound.test.mjs
@@ -309,6 +309,34 @@ test("#1188 each upload site's body read sits INSIDE the bounded callback", () =
   }
 });
 
+test("#1188 every uploadBlobToInput caller branches on the null it can now return", () => {
+  // The claim "all callers already branch on a null ref" was made in a comment before it was
+  // checked, and it was false on both halves: there are FIVE sites, not four, and civitai's
+  // did not branch at all. Muted, it announced "Saved {name} to ComfyUI inputs." for an
+  // upload that wrote nothing; unmuted, it dereferenced `ref.filename`. Counted here so the
+  // claim cannot rot back into a guess.
+  const sites = [
+    ["web/js/cmcp-apps-ui.js", /const ref = await uploadBlobToInput\(/],
+    ["web/js/cmcp-civitai-ui.js", /const ref = await ctx\.uploadBlobToInput\(/],
+    ["web/js/cmcp-training-ui.js", /ctx\.uploadBlobToInput\(/],
+    ["web/js/lib/media-preview.js", /const ref = await uploadBlobToInput\(/],
+    ["web/js/lib/run-completion-frame.js", /const ref = await uploadBlobToInput\(/],
+  ];
+  for (const [rel, call] of sites) {
+    const src = readFileSync(fileURLToPath(new URL(`../../${rel}`, import.meta.url)), "utf8");
+    assert.match(src, call, `${rel} no longer calls uploadBlobToInput — update this list`);
+    // Each site must test the ref before using it. The shapes differ by call site, so this
+    // asserts that SOME null test exists rather than one exact spelling.
+    assert.match(src, /if \(!ref\)|!ref\b|ref \?|ref &&|typeof ref/, `${rel} does not branch on a null ref`);
+  }
+  // …and the civitai path specifically, because it is the one that was wrong.
+  const civitai = readFileSync(fileURLToPath(new URL("../../web/js/cmcp-civitai-ui.js", import.meta.url)), "utf8");
+  const at = civitai.indexOf("const ref = await ctx.uploadBlobToInput(");
+  const guard = civitai.indexOf("if (!ref)", at);
+  const muted = civitai.indexOf("ctx.isMuted()", at);
+  assert.ok(guard > at && guard < muted, "civitai must refuse a null ref BEFORE announcing a save");
+});
+
 test("#1188 uploadBlobToInput still answers null, so no caller learns a new shape", () => {
   // Four callers branch on a null ref today (the apps, civitai and training wizards, and the
   // storyboard pipeline). Returning the sentinel to them instead would make `!ref` false and

--- a/browser_tests/unit/upload-bound.test.mjs
+++ b/browser_tests/unit/upload-bound.test.mjs
@@ -20,6 +20,7 @@ import {
   uploadBoundMs,
   boundedUpload,
   describeUploadTimeout,
+  describeTimedOutUpload,
   readFileFacts,
   readErrorBody,
   UPLOAD_NO_ANSWER,
@@ -214,6 +215,45 @@ test("#1188 a timeout is described as the transport failure it is a species of",
   assert.match(msg, /Whether any bytes reached the server is unknown/);
 });
 
+test("#1188 a status observed before the OUTER bound fires is still reported", async () => {
+  // The race the first fix missed. Giving the body its own shorter bound is not enough,
+  // because that bound runs INSIDE the outer one: a response head arriving near the outer
+  // deadline with a body that then stalls lets the OUTER bound fire first, and a known
+  // HTTP 413 was about to be reported as "no response". Evidence already gathered must
+  // outrank the bound's verdict — the bound knows only that IT stopped waiting.
+  const observed = {};
+  const outcome = await boundedUpload(
+    async () => {
+      // head arrives just under the outer deadline…
+      await new Promise((r) => setTimeout(r, 25));
+      observed.status = 413;
+      observed.statusText = "Payload Too Large";
+      observed.body = await readErrorBody({ text: () => new Promise(() => {}) }, withTimeout, 5000);
+      return { failure: "unreachable — the outer bound fires first" };
+    },
+    { size: 1, withTimeout, boundMs: 40 },
+  );
+  assert.equal(outcome, UPLOAD_NO_ANSWER, "the outer bound must win this race — otherwise nothing is proven");
+  const msg = describeTimedOutUpload({ observed, name: "big.png", size: 4096, mediaType: "image/png" });
+  assert.match(msg, /HTTP 413/, "the status we already held must survive the outer timeout");
+  assert.match(msg, /Payload Too Large/);
+  assert.doesNotMatch(msg, /no response within/, "…and must NOT be downgraded to a transport timeout");
+  // A body that never arrived degrades to the existing body-less refusal wording.
+  assert.match(msg, /sent no body explaining it/);
+});
+
+test("#1188 a genuine no-answer still reads as a transport timeout", () => {
+  // The floor case for the assertion above: with nothing observed, the timeout wording is
+  // still correct. Without this, describeTimedOutUpload could report "HTTP undefined".
+  const msg = describeTimedOutUpload({ observed: {}, name: "x.png", size: 10, mediaType: "image/png", boundMs: 30000 });
+  assert.match(msg, /did not COMPLETE/);
+  assert.doesNotMatch(msg, /HTTP/);
+  // And a malformed record must not be mistaken for a real status.
+  for (const bad of [{ status: undefined }, { status: null }, { status: "nope" }, { status: NaN }]) {
+    assert.match(describeTimedOutUpload({ observed: bad, name: "x" }), /did not COMPLETE/);
+  }
+});
+
 // ── the three monolith call sites ───────────────────────────────────────────────────
 
 /** Source with comment lines removed. The comments here NAME the calls they explain, so a
@@ -280,9 +320,9 @@ test("#1188 a refusal's body is bounded separately from the upload", () => {
   // Otherwise a stalled explanation drags a KNOWN status into the outer bound and it gets
   // reported as "no response" — #756's defect, reintroduced by #1188's own fix.
   assert.equal(
-    (CODE.match(/body: await readErrorBody\(res, withTimeout\),/g) || []).length,
+    (CODE.match(/body: \(observed\.body = await readErrorBody\(res, withTimeout\)\),/g) || []).length,
     2,
-    "both composer sites must bound the error body on its own",
+    "both composer sites must bound the error body on its own, recording it as they go",
   );
   assert.equal(
     (CODE.match(/body: await res\.text\(\)\.catch\(\(\) => null\),/g) || []).length,
@@ -296,6 +336,27 @@ test("#1188 the composer's two sites report the timeout instead of silently succ
   // `outcome.info` on an undefined `info` and throw a TypeError the user cannot act on.
   const guards = (CODE.match(/if \(outcome === UPLOAD_NO_ANSWER\) \{/g) || []).length;
   assert.equal(guards, 2, `both composer sites must branch on the sentinel, saw ${guards}`);
-  const reported = (CODE.match(/att\.uploadError = describeUploadTimeout\(/g) || []).length;
+  // describeTimedOutUpload, NOT describeUploadTimeout: the timeout branch must consult the
+  // status the callback recorded before falling back to the transport wording.
+  const reported = (CODE.match(/att\.uploadError = describeTimedOutUpload\(\{ observed,/g) || []).length;
   assert.equal(reported, 2, `…and both must say so, saw ${reported}`);
+  assert.equal(
+    (CODE.match(/att\.uploadError = describeUploadTimeout\(/g) || []).length,
+    0,
+    "no site may report a timeout without first checking what was observed",
+  );
+});
+
+test("#1188 both composer sites record the status before awaiting the body", () => {
+  // Order matters: recording after the body read would leave the record empty in exactly
+  // the race it exists for.
+  const sites = CODE.split('await boundedUpload(').slice(1);
+  const composer = sites.filter((c) => c.includes('observed.status = res.status;'));
+  assert.equal(composer.length, 2, `both composer sites must record the status, saw ${composer.length}`);
+  for (const body of composer) {
+    const rec = body.indexOf('observed.status = res.status;');
+    const read = body.indexOf('readErrorBody(');
+    assert.ok(rec >= 0 && read > rec, 'the status must be recorded BEFORE the body is awaited');
+  }
+  assert.equal((CODE.match(/const observed = {};/g) || []).length, 2, 'each site needs its own record');
 });

--- a/browser_tests/unit/upload-bound.test.mjs
+++ b/browser_tests/unit/upload-bound.test.mjs
@@ -1,0 +1,212 @@
+// #1188 — the three `/upload/image` sites, bounded.
+//
+// Same failure as #1161/#1180: after a ComfyUI restart the tab can hold a half-open
+// connection where a request neither answers nor fails, so there is nothing for the
+// existing `try/catch` to catch. Here it wedges the composer: `att.ready` catches
+// everything internally so it never REJECTS — it simply never settles — and the send path
+// awaits `Promise.all(pending.map((a) => a.ready))`. The user cannot send at all.
+//
+// Unlike the credentials frame (cmcp-secrets-bound.test.mjs), the logic here lives in an
+// importable module, so most of this is BEHAVIOURAL. Source assertions are used only for
+// the three monolith call sites, which cannot be constructed outside the panel IIFE.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import { withTimeout } from "../../web/js/lib/bounded-step.js";
+import {
+  uploadBoundMs,
+  boundedUpload,
+  describeUploadTimeout,
+  UPLOAD_NO_ANSWER,
+  UPLOAD_STALL_FLOOR_MS,
+  UPLOAD_MIN_BYTES_PER_MS,
+} from "../../web/js/lib/attachment-upload.js";
+
+const SRC = readFileSync(
+  fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url)),
+  "utf8",
+);
+
+/** A promise that never settles — the half-open connection, modelled. */
+const NEVER = () => new Promise(() => {});
+
+// ── the bound itself ────────────────────────────────────────────────────────────────
+
+test("#1188 uploadBoundMs never returns a non-positive number", () => {
+  // `withTimeout` treats a non-positive ms as NO BOUND and returns the promise unchanged
+  // (bounded-step.js:71), so any input that drove this to 0 or below would silently restore
+  // the hang while every other assertion here still passed. That exact class of mutation
+  // survived on #1180 until it was asserted for.
+  for (const size of [0, -1, -99999, null, undefined, "", NaN, Infinity, -Infinity, "abc", {}, []]) {
+    const ms = uploadBoundMs(size);
+    assert.ok(Number.isFinite(ms) && ms > 0, `uploadBoundMs(${String(size)}) returned ${ms}`);
+  }
+  // A caller cannot disable the bound through the options object either.
+  assert.ok(uploadBoundMs(1024, { floorMs: 0, bytesPerMs: 0 }) > 0, "a zeroed floor must not disarm it");
+  assert.ok(uploadBoundMs(1024, { floorMs: -5, bytesPerMs: -5 }) > 0, "…nor a negative one");
+});
+
+test("#1188 an unknown size yields the floor rather than a fabricated allowance", () => {
+  // describeSize's rule: an unmeasured value must be ABSENT, not zero. Coercing null to 0
+  // here would produce the floor anyway, but by accident — pin the intent.
+  assert.equal(uploadBoundMs(null), UPLOAD_STALL_FLOOR_MS);
+  assert.equal(uploadBoundMs(undefined), UPLOAD_STALL_FLOOR_MS);
+  assert.equal(uploadBoundMs(""), UPLOAD_STALL_FLOOR_MS);
+});
+
+test("#1188 the bound scales with the payload, so video is not cut off", () => {
+  // The reason this is not a flat number: handleMediaUpload exists specifically for video.
+  // A flat bound either refuses a legitimate large upload or waits absurdly long for a
+  // small one.
+  const small = uploadBoundMs(100 * 1024); // 100 KB
+  const large = uploadBoundMs(500 * 1024 * 1024); // 500 MB
+  assert.ok(large > small, "a larger payload must get a larger allowance");
+  assert.ok(small >= UPLOAD_STALL_FLOOR_MS, "…and nothing may fall below the floor");
+  // The allowance is exactly the floor plus the transfer time at the throughput floor.
+  assert.equal(uploadBoundMs(1000), UPLOAD_STALL_FLOOR_MS + Math.ceil(1000 / UPLOAD_MIN_BYTES_PER_MS));
+  // A pathological size must stay a finite number, not become Infinity/NaN — those are
+  // non-positive-adjacent failures that would reach withTimeout and arm setTimeout(fn, NaN),
+  // which fires immediately and would refuse every upload.
+  assert.ok(Number.isFinite(uploadBoundMs(Number.MAX_SAFE_INTEGER)), "a huge size must stay finite");
+});
+
+// ── the bounded exchange ────────────────────────────────────────────────────────────
+
+test("#1188 a request that never answers resolves the sentinel, not a hang", async () => {
+  const out = await boundedUpload(NEVER, { size: 1, withTimeout, boundMs: 20 });
+  assert.equal(out, UPLOAD_NO_ANSWER);
+});
+
+test("#1188 the bound covers the BODY, not just the response head", async () => {
+  // `fetch` resolves as soon as the head arrives; the bytes stream afterwards inside
+  // `json()`. Bounding the request alone leaves the part that actually waits unbounded —
+  // exactly what shipped in #1180's first attempt at the log read, and it passed review
+  // because the test stalled the HANDSHAKE rather than the body.
+  let headArrived = false;
+  const out = await boundedUpload(
+    async () => {
+      const res = { status: 200, json: NEVER }; // head fine, body never streams
+      headArrived = true;
+      return { info: await res.json() };
+    },
+    { size: 1, withTimeout, boundMs: 20 },
+  );
+  assert.ok(headArrived, "the request half must have completed — otherwise this proves nothing");
+  assert.equal(out, UPLOAD_NO_ANSWER, "a body that never streams must still hit the bound");
+});
+
+test("#1188 a real failure keeps its own cause instead of becoming a timeout", async () => {
+  // REIFY BEFORE BOUNDING. `withTimeout` never rejects by contract — it degrades a rejection
+  // through onTimeout() exactly as it does a timeout — so handing it run() directly would
+  // collapse "it threw" into "it never answered" and lose the error. #756's tests pin the
+  // wording that describeUploadFailure({ error }) produces from that cause.
+  const boom = new TypeError("Failed to fetch");
+  await assert.rejects(
+    () => boundedUpload(async () => { throw boom; }, { size: 1, withTimeout, boundMs: 5000 }),
+    (err) => err === boom,
+  );
+});
+
+test("#1188 a value that resolves in time passes through untouched", async () => {
+  const ref = { filename: "a.png", subfolder: undefined, type: "input" };
+  const out = await boundedUpload(async () => ref, { size: 1, withTimeout, boundMs: 5000 });
+  assert.equal(out, ref, "the happy path must be byte-identical to the unbounded original");
+  // null is a legitimate return here (uploadBlobToInput's non-200 branch) and must NOT be
+  // confused with the sentinel.
+  assert.equal(await boundedUpload(async () => null, { size: 1, withTimeout, boundMs: 5000 }), null);
+});
+
+test("#1188 the sentinel is unforgeable", () => {
+  // A string or plain object could collide with a real upload result. ComfyUI's /upload/image
+  // answers with arbitrary JSON.
+  assert.equal(typeof UPLOAD_NO_ANSWER, "symbol");
+});
+
+test("#1188 a missing withTimeout fails loudly instead of running unbounded", async () => {
+  // Degrading to an unbounded run would be the one outcome this exists to prevent, arriving
+  // through the mechanism meant to prevent it — the failure #1191 recorded as "a guard can
+  // cause what it reports".
+  await assert.rejects(() => boundedUpload(NEVER, { size: 1 }), /requires withTimeout/);
+  await assert.rejects(() => boundedUpload(NEVER, { size: 1, withTimeout: null }), /requires withTimeout/);
+});
+
+test("#1188 the ms handed to withTimeout is positive for every caller shape", async () => {
+  // The bound-zero mutation, caught at the boundary rather than inferred from behaviour.
+  const seen = [];
+  const spy = (p, ms, onTimeout) => { seen.push(ms); return withTimeout(p, ms, onTimeout); };
+  for (const size of [undefined, null, 0, -1, 12, 5 * 1024 * 1024]) {
+    await boundedUpload(async () => "ok", { size, withTimeout: spy });
+  }
+  assert.ok(seen.length === 6, `expected 6 bounded calls, saw ${seen.length}`);
+  for (const ms of seen) assert.ok(Number.isFinite(ms) && ms > 0, `withTimeout received ${ms}`);
+});
+
+test("#1188 a timeout is described as the transport failure it is a species of", () => {
+  const msg = describeUploadTimeout({ name: "clip.mp4", size: 4096, mediaType: "video/mp4", boundMs: 30000 });
+  // Routed through describeUploadFailure's `error` branch so it reads with the same shape as
+  // #756's transport text — including the part that is precisely true here: the bound does
+  // not cancel, so whether bytes reached the server is genuinely unknown.
+  assert.match(msg, /did not COMPLETE/);
+  assert.match(msg, /clip\.mp4/);
+  assert.match(msg, /30s/, "the user must be told how long was waited");
+  assert.match(msg, /Whether any bytes reached the server is unknown/);
+});
+
+// ── the three monolith call sites ───────────────────────────────────────────────────
+
+/** Source with comment lines removed. The comments here NAME the calls they explain, so a
+ *  raw scan matches prose and a mutation that moves real code into a comment slips through.
+ *  One did on #1180: replacing a throw with a return while leaving `// was: throw …` behind
+ *  passed every assertion. */
+const CODE = SRC.split("\n").filter((l) => !l.trim().startsWith("//")).join("\n");
+
+test("#1188 no /upload/image call site bypasses the bound", () => {
+  // The whole fix in one line: if a raw request to that endpoint survives outside a bounded
+  // callback, that site is still unbounded no matter how good the helper is.
+  const calls = CODE.split("\n").filter((l) => /await api\.fetchApi\("\/upload\/image"/.test(l));
+  assert.equal(calls.length, 3, `expected exactly 3 upload sites, saw ${calls.length}`);
+  const bounded = (CODE.match(/await boundedUpload\(/g) || []).length;
+  assert.equal(bounded, 3, `expected all 3 to go through boundedUpload, saw ${bounded}`);
+});
+
+test("#1188 each upload site's body read sits INSIDE the bounded callback", () => {
+  // Same trap as the credentials helper: bounding the request while awaiting res.json()
+  // afterwards leaves the waiting part unbounded and still passes a handshake-stalling test.
+  // Anchored on the options argument rather than on closing-brace indentation: the three
+  // sites sit at different nesting depths, and an indentation-coupled window silently
+  // matched the wrong span for two of them.
+  const sites = CODE.split("await boundedUpload(").slice(1).map((chunk) => {
+    const end = chunk.indexOf("{ size:");
+    assert.ok(end > 0, "each bounded call must pass its options object");
+    return chunk.slice(0, end);
+  });
+  assert.equal(sites.length, 3, `expected 3 bounded callbacks, matched ${sites.length}`);
+  for (const body of sites) {
+    assert.match(body, /async \(\) => \{/, "the exchange must be a callback, not a bare promise");
+    assert.match(body, /await api\.fetchApi\("\/upload\/image"/, "the request must be inside");
+    assert.match(body, /await res\.json\(\)/, "…and so must the body read");
+  }
+});
+
+test("#1188 uploadBlobToInput still answers null, so no caller learns a new shape", () => {
+  // Four callers branch on a null ref today (the apps, civitai and training wizards, and the
+  // storyboard pipeline). Returning the sentinel to them instead would make `!ref` false and
+  // send a Symbol into `viewUrl`.
+  assert.match(
+    CODE,
+    /return out === UPLOAD_NO_ANSWER \? null : out;/,
+    "the sentinel must be collapsed to the existing failure value",
+  );
+});
+
+test("#1188 the composer's two sites report the timeout instead of silently succeeding", () => {
+  // A sentinel falling through to the success branch would set att.inputRef from
+  // `outcome.info` on an undefined `info` and throw a TypeError the user cannot act on.
+  const guards = (CODE.match(/if \(outcome === UPLOAD_NO_ANSWER\) \{/g) || []).length;
+  assert.equal(guards, 2, `both composer sites must branch on the sentinel, saw ${guards}`);
+  const reported = (CODE.match(/att\.uploadError = describeUploadTimeout\(/g) || []).length;
+  assert.equal(reported, 2, `…and both must say so, saw ${reported}`);
+});

--- a/browser_tests/unit/upload-bound.test.mjs
+++ b/browser_tests/unit/upload-bound.test.mjs
@@ -248,9 +248,26 @@ test("#1188 a genuine no-answer still reads as a transport timeout", () => {
   const msg = describeTimedOutUpload({ observed: {}, name: "x.png", size: 10, mediaType: "image/png", boundMs: 30000 });
   assert.match(msg, /did not COMPLETE/);
   assert.doesNotMatch(msg, /HTTP/);
-  // And a malformed record must not be mistaken for a real status.
-  for (const bad of [{ status: undefined }, { status: null }, { status: "nope" }, { status: NaN }]) {
-    assert.match(describeTimedOutUpload({ observed: bad, name: "x" }), /did not COMPLETE/);
+  // And a malformed record must not be mistaken for a real status. The check is "is it a
+  // status", not "does it coerce to a number": 0, false and [] all coerce finitely and were
+  // rendering as `HTTP 0`, `HTTP false` and a blank status — invented server answers from
+  // the function whose job is to tell an answer from silence.
+  const notStatuses = [
+    undefined, null, "", "   ", NaN, Infinity, -1, 0, 99, 600, 1000, 4.5,
+    false, true, [], {}, "nope", "413 Payload Too Large", () => 413,
+  ];
+  for (const status of notStatuses) {
+    const msg = describeTimedOutUpload({ observed: { status }, name: "x", size: 10 });
+    assert.match(msg, /did not COMPLETE/, `status ${String(status)} was treated as real`);
+    assert.doesNotMatch(msg, /REFUSED/, `status ${String(status)} produced an invented refusal`);
+  }
+  // …while every shape a real Response can present IS honoured.
+  for (const status of [100, 200, 404, 413, 500, 599, "413"]) {
+    assert.match(
+      describeTimedOutUpload({ observed: { status }, name: "x" }),
+      /REFUSED/,
+      `a real status ${String(status)} was thrown away`,
+    );
   }
 });
 

--- a/browser_tests/unit/upload-bound.test.mjs
+++ b/browser_tests/unit/upload-bound.test.mjs
@@ -20,9 +20,12 @@ import {
   uploadBoundMs,
   boundedUpload,
   describeUploadTimeout,
+  readFileFacts,
+  readErrorBody,
   UPLOAD_NO_ANSWER,
   UPLOAD_STALL_FLOOR_MS,
   UPLOAD_MIN_BYTES_PER_MS,
+  MAX_TIMER_MS,
 } from "../../web/js/lib/attachment-upload.js";
 
 const SRC = readFileSync(
@@ -71,6 +74,62 @@ test("#1188 the bound scales with the payload, so video is not cut off", () => {
   // non-positive-adjacent failures that would reach withTimeout and arm setTimeout(fn, NaN),
   // which fires immediately and would refuse every upload.
   assert.ok(Number.isFinite(uploadBoundMs(Number.MAX_SAFE_INTEGER)), "a huge size must stay finite");
+});
+
+test("#1188 the bound stays inside what setTimeout can actually hold", () => {
+  // Above 2^31-1 ms setTimeout overflows a 32-bit signed int and coerces the delay to 1ms,
+  // so an allowance so generous it should never fire becomes a bound that refuses EVERY
+  // upload instantly — the failure arriving through the mechanism meant to prevent it.
+  // Measured directly rather than asserted from the spec: node reports _idleTimeout 1 for
+  // a delay of MAX_SAFE_INTEGER.
+  for (const size of [Number.MAX_SAFE_INTEGER, Number.MAX_VALUE, 1e30]) {
+    const ms = uploadBoundMs(size);
+    assert.ok(ms > 0 && ms <= MAX_TIMER_MS, `uploadBoundMs(${size}) = ${ms} is not a usable delay`);
+  }
+  // The options object is caller-reachable and can otherwise produce Infinity.
+  const viaOptions = uploadBoundMs(Number.MAX_VALUE, { floorMs: Number.MAX_VALUE, bytesPerMs: 1 });
+  assert.ok(Number.isFinite(viaOptions) && viaOptions <= MAX_TIMER_MS, `options produced ${viaOptions}`);
+  assert.ok(Number.isFinite(uploadBoundMs(1, { bytesPerMs: Number.MIN_VALUE })), "a tiny rate must not overflow");
+});
+
+// ── measurements that may themselves fail ───────────────────────────────────────────
+
+test("#1188 readFileFacts survives a File whose getters throw", () => {
+  // The trap this closes: the bare reads throw at the top of the upload path, and then throw
+  // AGAIN inside the catch that reports the failure, because that catch describes the file.
+  // The exception escapes the handler and `att.ready` REJECTS — which the send path awaits
+  // via Promise.all and is not built to handle.
+  const hostile = {
+    get size() { throw new Error("revoked"); },
+    get type() { throw new Error("revoked"); },
+  };
+  const facts = readFileFacts(hostile);
+  assert.equal(facts.size, undefined, "an unreadable size must be ABSENT, not a fabricated 0");
+  assert.equal(facts.mediaType, "");
+  // A half-hostile file still yields the half that reads.
+  const partial = { size: 4096, get type() { throw new Error("revoked"); } };
+  assert.equal(readFileFacts(partial).size, 4096);
+  // …and the absent size flows through to a description that simply omits it, rather than
+  // claiming "0 B" — describeSize's rule.
+  assert.doesNotMatch(describeUploadTimeout({ name: "x.png", ...readFileFacts(hostile) }), /0 B/);
+  for (const bad of [null, undefined, 0, "", false]) {
+    assert.doesNotThrow(() => readFileFacts(bad), `readFileFacts(${String(bad)}) threw`);
+  }
+});
+
+test("#1188 a stalled error body never costs us the status we already have", async () => {
+  // #756's whole point was that "the status was in hand and thrown away". A body read that
+  // stalls inside the OUTER upload bound would do exactly that by a new route: the outer
+  // bound fires and a known HTTP 413 is reported to the user as "no response".
+  const stalled = { text: () => new Promise(() => {}) };
+  assert.equal(await readErrorBody(stalled, withTimeout, 20), null, "a stalled body must give up");
+  // A body that arrives is still read.
+  assert.equal(await readErrorBody({ text: async () => "too large" }, withTimeout, 5000), "too large");
+  // A body that rejects degrades the same way, not into a throw the caller must catch.
+  assert.equal(await readErrorBody({ text: async () => { throw new Error("x"); } }, withTimeout, 5000), null);
+  // A response object that is not one at all must not throw either.
+  assert.equal(await readErrorBody({}, withTimeout, 5000), null);
+  assert.equal(await readErrorBody(null, withTimeout, 5000), null);
 });
 
 // ── the bounded exchange ────────────────────────────────────────────────────────────
@@ -178,8 +237,10 @@ test("#1188 each upload site's body read sits INSIDE the bounded callback", () =
   // Anchored on the options argument rather than on closing-brace indentation: the three
   // sites sit at different nesting depths, and an indentation-coupled window silently
   // matched the wrong span for two of them.
+  // "{ size" matches both the explicit `{ size: blob?.size, … }` and the shorthand
+  // `{ size, … }` the composer sites use after hoisting the read.
   const sites = CODE.split("await boundedUpload(").slice(1).map((chunk) => {
-    const end = chunk.indexOf("{ size:");
+    const end = chunk.indexOf("{ size");
     assert.ok(end > 0, "each bounded call must pass its options object");
     return chunk.slice(0, end);
   });
@@ -199,6 +260,34 @@ test("#1188 uploadBlobToInput still answers null, so no caller learns a new shap
     CODE,
     /return out === UPLOAD_NO_ANSWER \? null : out;/,
     "the sentinel must be collapsed to the existing failure value",
+  );
+});
+
+test("#1188 the composer reads each file's measurements once, defensively", () => {
+  // Passing the size to the bound added a read on the HAPPY path, where the original only
+  // read it on the non-200 branch — widening a throwing-getter trap from rare to universal.
+  const hoisted = (CODE.match(/const \{ size, mediaType \} = readFileFacts\(file\);/g) || []).length;
+  assert.equal(hoisted, 2, `both composer sites must hoist the read, saw ${hoisted}`);
+  // And the bound must be given that hoisted value, not a fresh `file.size` read.
+  assert.equal(
+    (CODE.match(/\{ size, withTimeout \},/g) || []).length,
+    2,
+    "both bounded calls must use the hoisted size",
+  );
+});
+
+test("#1188 a refusal's body is bounded separately from the upload", () => {
+  // Otherwise a stalled explanation drags a KNOWN status into the outer bound and it gets
+  // reported as "no response" — #756's defect, reintroduced by #1188's own fix.
+  assert.equal(
+    (CODE.match(/body: await readErrorBody\(res, withTimeout\),/g) || []).length,
+    2,
+    "both composer sites must bound the error body on its own",
+  );
+  assert.equal(
+    (CODE.match(/body: await res\.text\(\)\.catch\(\(\) => null\),/g) || []).length,
+    0,
+    "no site may read a refusal body under the outer bound alone",
   );
 });
 

--- a/web/js/cmcp-civitai-ui.js
+++ b/web/js/cmcp-civitai-ui.js
@@ -1194,6 +1194,18 @@ export function createCivitaiContent(ctx, shell, opts = {}) {
       const blob = await (await fetch(it.fullUrl)).blob();
       const name = `civitai_ref_${it.id}.${it.type === "video" ? "mp4" : "jpeg"}`;
       const ref = await ctx.uploadBlobToInput(blob, name);
+      // #1188 — `uploadBlobToInput` answers null for EVERY failure, and neither branch below
+      // checked. Muted, that announced "Saved {name} to ComfyUI inputs." for an upload that
+      // wrote nothing; unmuted, `ref.filename` threw a TypeError whose message ("Cannot read
+      // properties of null") told the user nothing about the upload. Pre-existing, but #1188
+      // makes null reachable by a new route — a bounded upload that gives up now returns it
+      // where the call previously hung — so the fabricated success is left no wider than it
+      // was found. `close()` is deliberately not called: a failed share leaves the explorer
+      // open to retry, exactly as the catch below does.
+      if (!ref) {
+        toast(tr("civitai_ui.share_failed", "Share failed: {error}", { error: name }));
+        return;
+      }
       if (ctx.isMuted()) {
         toast(tr("civitai_ui.saved_to_comfyui_inputs", "Saved {name} to ComfyUI inputs.", { name }));
       } else {

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -81,6 +81,7 @@ import { pairDurabilityView } from "./lib/pair-durability-view.js";
 import {
   describeUploadFailure,
   describeUploadTimeout,
+  describeTimedOutUpload,
   attachmentSummaryLine,
   boundedUpload,
   readFileFacts,
@@ -30801,10 +30802,17 @@ function buildPanel() {
         // everything internally so it never REJECTS — it simply never settles, and the
         // composer awaits `Promise.all(pending.map((a) => a.ready))` before sending. The
         // user is then unable to send the message at all, with nothing on screen saying why.
+        const observed = {};
         const outcome = await boundedUpload(
           async () => {
             const res = await api.fetchApi("/upload/image", { method: "POST", body: fd });
             if (res.status === 200) return { info: await res.json() };
+            // #1188 — record the status the INSTANT it is known. The body has its own,
+            // shorter bound, but that bound runs INSIDE the outer one: a head arriving near
+            // the outer deadline with a stalling body would otherwise let the outer bound
+            // report an answered-and-REFUSED upload as "no response".
+            observed.status = res.status;
+            observed.statusText = res.statusText;
             // #756 — a non-200 had NO else at all. The status was in hand and thrown
             // away, leaving "upload failed" as the whole of what anyone could learn.
             // The body gets its OWN shorter bound: a refusal we can already name must not
@@ -30813,7 +30821,7 @@ function buildPanel() {
               failure: describeUploadFailure({
                 status: res.status,
                 statusText: res.statusText,
-                body: await readErrorBody(res, withTimeout),
+                body: (observed.body = await readErrorBody(res, withTimeout)),
                 name,
                 size,
                 mediaType,
@@ -30823,7 +30831,7 @@ function buildPanel() {
           { size, withTimeout },
         );
         if (outcome === UPLOAD_NO_ANSWER) {
-          att.uploadError = describeUploadTimeout({ name, size, mediaType });
+          att.uploadError = describeTimedOutUpload({ observed, name, size, mediaType });
         } else if (outcome?.failure) {
           att.uploadError = outcome.failure;
         } else {
@@ -30874,10 +30882,17 @@ function buildPanel() {
         // would either cut off a legitimate large upload or wait absurdly long for a small
         // one. Same wedge as the image path above — a never-settling `att.ready` blocks the
         // composer's `Promise.all` on send.
+        const observed = {};
         const outcome = await boundedUpload(
           async () => {
             const res = await api.fetchApi("/upload/image", { method: "POST", body: fd });
             if (res.status === 200) return { info: await res.json() };
+            // #1188 — record the status the INSTANT it is known. The body has its own,
+            // shorter bound, but that bound runs INSIDE the outer one: a head arriving near
+            // the outer deadline with a stalling body would otherwise let the outer bound
+            // report an answered-and-REFUSED upload as "no response".
+            observed.status = res.status;
+            observed.statusText = res.statusText;
             // #756 — a non-200 had NO else at all. The status was in hand and thrown
             // away, leaving "upload failed" as the whole of what anyone could learn.
             // The body gets its OWN shorter bound: a refusal we can already name must not
@@ -30886,7 +30901,7 @@ function buildPanel() {
               failure: describeUploadFailure({
                 status: res.status,
                 statusText: res.statusText,
-                body: await readErrorBody(res, withTimeout),
+                body: (observed.body = await readErrorBody(res, withTimeout)),
                 name,
                 size,
                 mediaType,
@@ -30896,7 +30911,7 @@ function buildPanel() {
           { size, withTimeout },
         );
         if (outcome === UPLOAD_NO_ANSWER) {
-          att.uploadError = describeUploadTimeout({ name, size, mediaType });
+          att.uploadError = describeTimedOutUpload({ observed, name, size, mediaType });
         } else if (outcome?.failure) {
           att.uploadError = outcome.failure;
         } else {

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -28124,8 +28124,15 @@ function buildPanel() {
       if (type) fd.append("type", type);
       // #1188 — bounded, request AND body. On timeout this resolves the sentinel and falls
       // through to the SAME `null` this function already returns for every other failure,
-      // so no caller learns a new shape: all four (the apps, civitai and training wizards,
-      // and the storyboard pipeline) already branch on a null ref today.
+      // so no caller learns a new shape.
+      //
+      // FIVE call sites, counted rather than remembered: cmcp-apps-ui.js:1697,
+      // cmcp-civitai-ui.js:1196, cmcp-training-ui.js:754, lib/media-preview.js:893 and
+      // lib/run-completion-frame.js:407. An earlier version of this comment said "all four
+      // already branch on a null ref today" and was wrong on both halves — there were five,
+      // and civitai's did not branch at all: muted it announced a save that never happened,
+      // unmuted it dereferenced `ref.filename`. That is fixed at the site. The claim is only
+      // safe to make BECAUSE it was checked, which is the reason it now names each one.
       const out = await boundedUpload(
         async () => {
           const res = await api.fetchApi("/upload/image", { method: "POST", body: fd });

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -78,7 +78,13 @@ import { pressableWidgetHint } from "./lib/pressable-widget.js";
 import { looksLikeApiWorkflow, apiLoadShortfall, apiLoadNote } from "./lib/api-workflow-load.js";
 import { readPackImportFailures } from "./lib/pack-import-failures.js";
 import { pairDurabilityView } from "./lib/pair-durability-view.js";
-import { describeUploadFailure, attachmentSummaryLine } from "./lib/attachment-upload.js";
+import {
+  describeUploadFailure,
+  describeUploadTimeout,
+  attachmentSummaryLine,
+  boundedUpload,
+  UPLOAD_NO_ANSWER,
+} from "./lib/attachment-upload.js";
 import {
   buildInstallRequest,
   classifyInstallOutcome,
@@ -28113,10 +28119,20 @@ function buildPanel() {
       const fd = new FormData();
       fd.append("image", blob, name);
       if (type) fd.append("type", type);
-      const res = await api.fetchApi("/upload/image", { method: "POST", body: fd });
-      if (res.status !== 200) return null;
-      const info = await res.json();
-      return { filename: info.name, subfolder: info.subfolder || undefined, type: info.type || type || "input" };
+      // #1188 — bounded, request AND body. On timeout this resolves the sentinel and falls
+      // through to the SAME `null` this function already returns for every other failure,
+      // so no caller learns a new shape: all four (the apps, civitai and training wizards,
+      // and the storyboard pipeline) already branch on a null ref today.
+      const out = await boundedUpload(
+        async () => {
+          const res = await api.fetchApi("/upload/image", { method: "POST", body: fd });
+          if (res.status !== 200) return null;
+          const info = await res.json();
+          return { filename: info.name, subfolder: info.subfolder || undefined, type: info.type || type || "input" };
+        },
+        { size: blob?.size, withTimeout },
+      );
+      return out === UPLOAD_NO_ANSWER ? null : out;
     } catch {
       return null;
     }
@@ -30773,22 +30789,38 @@ function buildPanel() {
       try {
         const fd = new FormData();
         fd.append("image", file, name);
-        const res = await api.fetchApi("/upload/image", { method: "POST", body: fd });
-        if (res.status === 200) {
-          const info = await res.json();
+        // #1188 — bounded, request AND body. Without this a half-open connection after a
+        // ComfyUI restart leaves `att.ready` pending forever. `att.ready` catches
+        // everything internally so it never REJECTS — it simply never settles, and the
+        // composer awaits `Promise.all(pending.map((a) => a.ready))` before sending. The
+        // user is then unable to send the message at all, with nothing on screen saying why.
+        const outcome = await boundedUpload(
+          async () => {
+            const res = await api.fetchApi("/upload/image", { method: "POST", body: fd });
+            if (res.status === 200) return { info: await res.json() };
+            // #756 — a non-200 had NO else at all. The status was in hand and thrown
+            // away, leaving "upload failed" as the whole of what anyone could learn.
+            return {
+              failure: describeUploadFailure({
+                status: res.status,
+                statusText: res.statusText,
+                body: await res.text().catch(() => null),
+                name,
+                size: file.size,
+                mediaType: file.type,
+              }),
+            };
+          },
+          { size: file?.size, withTimeout },
+        );
+        if (outcome === UPLOAD_NO_ANSWER) {
+          att.uploadError = describeUploadTimeout({ name, size: file.size, mediaType: file.type });
+        } else if (outcome?.failure) {
+          att.uploadError = outcome.failure;
+        } else {
+          const info = outcome.info;
           att.inputRef = (info.subfolder ? `${info.subfolder}/` : "") + info.name;
           att.ref = { filename: info.name, subfolder: info.subfolder || undefined, type: info.type || "input" };
-        } else {
-          // #756 — a non-200 had NO else at all. The status was in hand and thrown
-          // away, leaving "upload failed" as the whole of what anyone could learn.
-          att.uploadError = describeUploadFailure({
-            status: res.status,
-            statusText: res.statusText,
-            body: await res.text().catch(() => null),
-            name,
-            size: file.size,
-            mediaType: file.type,
-          });
         }
       } catch (err) {
         // #756 — the bare catch swallowed transport failures identically.
@@ -30821,22 +30853,38 @@ function buildPanel() {
         const fd = new FormData();
         // ComfyUI's /upload/image writes ANY uploaded file verbatim into input/.
         fd.append("image", file, name);
-        const res = await api.fetchApi("/upload/image", { method: "POST", body: fd });
-        if (res.status === 200) {
-          const info = await res.json();
+        // #1188 — bounded, request AND body. This path is the reason the bound is sized by
+        // payload rather than flat: it exists specifically for video, so a fixed number
+        // would either cut off a legitimate large upload or wait absurdly long for a small
+        // one. Same wedge as the image path above — a never-settling `att.ready` blocks the
+        // composer's `Promise.all` on send.
+        const outcome = await boundedUpload(
+          async () => {
+            const res = await api.fetchApi("/upload/image", { method: "POST", body: fd });
+            if (res.status === 200) return { info: await res.json() };
+            // #756 — a non-200 had NO else at all. The status was in hand and thrown
+            // away, leaving "upload failed" as the whole of what anyone could learn.
+            return {
+              failure: describeUploadFailure({
+                status: res.status,
+                statusText: res.statusText,
+                body: await res.text().catch(() => null),
+                name,
+                size: file.size,
+                mediaType: file.type,
+              }),
+            };
+          },
+          { size: file?.size, withTimeout },
+        );
+        if (outcome === UPLOAD_NO_ANSWER) {
+          att.uploadError = describeUploadTimeout({ name, size: file.size, mediaType: file.type });
+        } else if (outcome?.failure) {
+          att.uploadError = outcome.failure;
+        } else {
+          const info = outcome.info;
           att.inputRef = (info.subfolder ? `${info.subfolder}/` : "") + info.name;
           att.ref = { filename: info.name, subfolder: info.subfolder || undefined, type: info.type || "input" };
-        } else {
-          // #756 — a non-200 had NO else at all. The status was in hand and thrown
-          // away, leaving "upload failed" as the whole of what anyone could learn.
-          att.uploadError = describeUploadFailure({
-            status: res.status,
-            statusText: res.statusText,
-            body: await res.text().catch(() => null),
-            name,
-            size: file.size,
-            mediaType: file.type,
-          });
         }
       } catch (err) {
         // #756 — the bare catch swallowed transport failures identically.

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -1463,6 +1463,60 @@ let cmcpOauthOnBackendsPush = null;
 function cmcpApiBase() {
   return `${cmcpConsoleUrl}/api/secrets?token=${encodeURIComponent(cmcpConsoleToken)}`;
 }
+
+/**
+ * #1188 — how long a credentials-console request may take before it gives up.
+ *
+ * Longer than the 2s status probes because this one is a user-initiated write to a
+ * possibly-remote orchestrator console, not a startup nicety: giving up early on a save
+ * that would have succeeded is worse here than waiting a moment longer.
+ */
+const CMCP_SECRETS_TIMEOUT_MS = 8000;
+
+/** Sentinel: this call did not answer, as distinct from anything it could return. */
+const CMCP_SECRETS_NO_ANSWER = Symbol("cmcp-secrets-timeout");
+
+/**
+ * The credentials console's three requests, bounded — headers AND body.
+ *
+ * #1188, same failure as #1161/#1180: after a ComfyUI or orchestrator restart the tab can
+ * hold a half-open connection where a request neither answers nor fails, so there is
+ * nothing for `try/catch` to catch. Here that wedges the UI rather than a command — the
+ * button stays disabled reading "Saving…" or "Clearing…" forever, and because the panel
+ * only re-enables it in the catch, the user cannot even retry without reopening the frame.
+ *
+ * BOTH HALVES, because `fetch` resolves as soon as the response head arrives and the bytes
+ * stream afterwards inside `json()`. Bounding the request alone leaves the part that
+ * actually waits unbounded — exactly what shipped in #1180's first attempt at the log read.
+ *
+ * Rejects on timeout rather than resolving a sentinel, so it lands in the SAME catch that
+ * already handles a failed save: the error is shown and the button is re-enabled. No new
+ * branch, and no new catalog string for a frozen catalog (#1135).
+ *
+ * @returns {Promise<any>} the parsed body
+ */
+async function cmcpSecretsRequest(init) {
+  const settled = await withTimeout(
+    Promise.resolve()
+      .then(async () => {
+        const resp = await (init ? fetch(cmcpApiBase(), init) : fetch(cmcpApiBase()));
+        return { resp, body: await resp.json() };
+      })
+      .then((value) => ({ value }), (err) => ({ err })),
+    CMCP_SECRETS_TIMEOUT_MS,
+    () => CMCP_SECRETS_NO_ANSWER,
+  );
+  if (settled === CMCP_SECRETS_NO_ANSWER) {
+    // NOT a `tr()` key. The English catalog is frozen (#1135) and English is GENERATED from
+    // the code, so a new key here means a pass over eleven locale files. This message goes
+    // through `showErr`, which already renders the orchestrator's own untranslated `d.error`
+    // text the same way — so an English sentence here is consistent with what that path
+    // shows today rather than a regression in coverage.
+    throw new Error("The credentials console did not respond — check that the orchestrator is still running, then try again.");
+  }
+  if ("err" in settled) throw settled.err;
+  return settled.value;
+}
 function cmcpOpenCredentialsFrame(client) {
   if (!cmcpConsoleUrl || !cmcpConsoleToken) {
     alert(tr("panel.connect_the_panel_first_the_credentials_console", "Connect the panel first — the credentials console isn't available yet."));
@@ -1522,11 +1576,10 @@ function cmcpOpenCredentialsFrame(client) {
       showErr("");
       btn.disabled = true; btn.textContent = tr("panel.saving", "Saving…");
       try {
-        const resp = await fetch(cmcpApiBase(), {
+        const { resp, body: d } = await cmcpSecretsRequest({
           method: "POST", headers: { "content-type": "application/json" },
           body: JSON.stringify({ slot: s.id, value }),
         });
-        const d = await resp.json();
         // `d.error` is the orchestrator's own (English) reason; only OUR fallback is ours to
         // translate — the server text is passed through untouched, as it always has been.
         if (!resp.ok || !d.ok) throw new Error(d.error || tr("panel.save_failed", "save failed"));
@@ -1552,11 +1605,10 @@ function cmcpOpenCredentialsFrame(client) {
       showErr("");
       clearBtn.disabled = true; clearBtn.textContent = tr("panel.clearing", "Clearing…");
       try {
-        const resp = await fetch(cmcpApiBase(), {
+        const { resp, body: d } = await cmcpSecretsRequest({
           method: "POST", headers: { "content-type": "application/json" },
           body: JSON.stringify({ slot: s.id, clear: true }),
         });
-        const d = await resp.json();
         if (!resp.ok || !d.ok) throw new Error(d.error || tr("panel.clear_failed", "clear failed"));
         badge.textContent = tr("panel.not_set", "not set");
         input.placeholder = tr("panel.paste_key", "paste key");
@@ -1572,8 +1624,7 @@ function cmcpOpenCredentialsFrame(client) {
 
   (async () => {
     try {
-      const resp = await fetch(cmcpApiBase());
-      const d = await resp.json();
+      const { resp, body: d } = await cmcpSecretsRequest();
       if (!resp.ok || !d.ok) throw new Error(d.error || tr("panel.could_not_load", "could not load"));
       list.innerHTML = "";
       for (const s of (d.slots || [])) list.appendChild(row(s));

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -83,6 +83,8 @@ import {
   describeUploadTimeout,
   attachmentSummaryLine,
   boundedUpload,
+  readFileFacts,
+  readErrorBody,
   UPLOAD_NO_ANSWER,
 } from "./lib/attachment-upload.js";
 import {
@@ -30789,6 +30791,11 @@ function buildPanel() {
       try {
         const fd = new FormData();
         fd.append("image", file, name);
+        // #1188 — read the measurements ONCE, before anything can fail on them. A `size` or
+        // `type` that throws would otherwise throw AGAIN inside the catch that reports it,
+        // escape the handler, and REJECT `att.ready` — which the send path awaits and is
+        // not built to have reject.
+        const { size, mediaType } = readFileFacts(file);
         // #1188 — bounded, request AND body. Without this a half-open connection after a
         // ComfyUI restart leaves `att.ready` pending forever. `att.ready` catches
         // everything internally so it never REJECTS — it simply never settles, and the
@@ -30800,21 +30807,23 @@ function buildPanel() {
             if (res.status === 200) return { info: await res.json() };
             // #756 — a non-200 had NO else at all. The status was in hand and thrown
             // away, leaving "upload failed" as the whole of what anyone could learn.
+            // The body gets its OWN shorter bound: a refusal we can already name must not
+            // be downgraded to "no response" just because ComfyUI's explanation stalls.
             return {
               failure: describeUploadFailure({
                 status: res.status,
                 statusText: res.statusText,
-                body: await res.text().catch(() => null),
+                body: await readErrorBody(res, withTimeout),
                 name,
-                size: file.size,
-                mediaType: file.type,
+                size,
+                mediaType,
               }),
             };
           },
-          { size: file?.size, withTimeout },
+          { size, withTimeout },
         );
         if (outcome === UPLOAD_NO_ANSWER) {
-          att.uploadError = describeUploadTimeout({ name, size: file.size, mediaType: file.type });
+          att.uploadError = describeUploadTimeout({ name, size, mediaType });
         } else if (outcome?.failure) {
           att.uploadError = outcome.failure;
         } else {
@@ -30823,8 +30832,11 @@ function buildPanel() {
           att.ref = { filename: info.name, subfolder: info.subfolder || undefined, type: info.type || "input" };
         }
       } catch (err) {
-        // #756 — the bare catch swallowed transport failures identically.
-        att.uploadError = describeUploadFailure({ error: err, name, size: file.size, mediaType: file.type });
+        // #756 — the bare catch swallowed transport failures identically. The measurements
+        // are re-read defensively here too: this catch also runs for a throw raised BEFORE
+        // readFileFacts, so it cannot assume those locals exist.
+        const facts = readFileFacts(file);
+        att.uploadError = describeUploadFailure({ error: err, name, size: facts.size, mediaType: facts.mediaType });
       }
     })();
     att.ready.then(renderAttachmentChips, () => {}); // refresh once the thumb loads
@@ -30853,6 +30865,10 @@ function buildPanel() {
         const fd = new FormData();
         // ComfyUI's /upload/image writes ANY uploaded file verbatim into input/.
         fd.append("image", file, name);
+        // #1188 — read the measurements ONCE. Same reason as the image path above: a
+        // throwing `size`/`type` getter would throw again inside the reporting catch and
+        // reject `att.ready`.
+        const { size, mediaType } = readFileFacts(file);
         // #1188 — bounded, request AND body. This path is the reason the bound is sized by
         // payload rather than flat: it exists specifically for video, so a fixed number
         // would either cut off a legitimate large upload or wait absurdly long for a small
@@ -30864,21 +30880,23 @@ function buildPanel() {
             if (res.status === 200) return { info: await res.json() };
             // #756 — a non-200 had NO else at all. The status was in hand and thrown
             // away, leaving "upload failed" as the whole of what anyone could learn.
+            // The body gets its OWN shorter bound: a refusal we can already name must not
+            // be downgraded to "no response" just because ComfyUI's explanation stalls.
             return {
               failure: describeUploadFailure({
                 status: res.status,
                 statusText: res.statusText,
-                body: await res.text().catch(() => null),
+                body: await readErrorBody(res, withTimeout),
                 name,
-                size: file.size,
-                mediaType: file.type,
+                size,
+                mediaType,
               }),
             };
           },
-          { size: file?.size, withTimeout },
+          { size, withTimeout },
         );
         if (outcome === UPLOAD_NO_ANSWER) {
-          att.uploadError = describeUploadTimeout({ name, size: file.size, mediaType: file.type });
+          att.uploadError = describeUploadTimeout({ name, size, mediaType });
         } else if (outcome?.failure) {
           att.uploadError = outcome.failure;
         } else {
@@ -30887,8 +30905,11 @@ function buildPanel() {
           att.ref = { filename: info.name, subfolder: info.subfolder || undefined, type: info.type || "input" };
         }
       } catch (err) {
-        // #756 — the bare catch swallowed transport failures identically.
-        att.uploadError = describeUploadFailure({ error: err, name, size: file.size, mediaType: file.type });
+        // #756 — the bare catch swallowed transport failures identically. The measurements
+        // are re-read defensively here too: this catch also runs for a throw raised BEFORE
+        // readFileFacts, so it cannot assume those locals exist.
+        const facts = readFileFacts(file);
+        att.uploadError = describeUploadFailure({ error: err, name, size: facts.size, mediaType: facts.mediaType });
       }
     })();
   }

--- a/web/js/lib/attachment-upload.js
+++ b/web/js/lib/attachment-upload.js
@@ -269,6 +269,44 @@ export async function boundedUpload(run, { size, withTimeout, boundMs } = {}) {
  * one key means a pass over eleven locale files, and this string reaches the agent and the
  * chip through the same untranslated path #756 already established.
  */
+/**
+ * What to report when the OUTER upload bound fires.
+ *
+ * Giving the refusal body its own shorter bound was not enough on its own. The inner bound
+ * runs *inside* the outer one, so a response head that arrives near the outer deadline — say
+ * at 29.9s of a 30s allowance — with a body that then stalls lets the OUTER bound fire
+ * first. The upload was answered and refused, we hold the status, and it was still about to
+ * be reported as "no response". That is #756's defect ("the status was in hand and thrown
+ * away") surviving the first attempt to fix it.
+ *
+ * So the status is recorded the instant it is known, and a timeout consults that record
+ * before falling back to the transport wording. Evidence already gathered outranks the
+ * bound's own verdict: the bound knows only that IT stopped waiting, which is not the same
+ * as nothing having been observed.
+ *
+ * `observed.body` is deliberately optional. If the outer bound fired while the body was
+ * still arriving, there is no body — and `describeUploadFailure` already has wording for a
+ * refusal that came without one.
+ */
+export function describeTimedOutUpload({ observed, name, size, mediaType, boundMs } = {}) {
+  // ABSENT before COERCED, exactly as `describeSize` insists. `Number(null)` and `Number("")`
+  // are both 0, which is finite — so a coerce-first check turns "no status was ever observed"
+  // into a confident `HTTP null`, fabricating a server answer inside the one function whose
+  // whole job is to distinguish an answer from silence. A first version of this did that.
+  const status = observed?.status;
+  if (status !== null && status !== undefined && status !== "" && Number.isFinite(Number(status))) {
+    return describeUploadFailure({
+      status: observed.status,
+      statusText: observed.statusText,
+      body: observed.body ?? null,
+      name,
+      size,
+      mediaType,
+    });
+  }
+  return describeUploadTimeout({ name, size, mediaType, boundMs });
+}
+
 export function describeUploadTimeout({ name, size, mediaType, boundMs } = {}) {
   const secs = Math.round((Number(boundMs) || uploadBoundMs(size)) / 1000);
   return describeUploadFailure({

--- a/web/js/lib/attachment-upload.js
+++ b/web/js/lib/attachment-upload.js
@@ -270,6 +270,22 @@ export async function boundedUpload(run, { size, withTimeout, boundMs } = {}) {
  * chip through the same untranslated path #756 already established.
  */
 /**
+ * Is this a status a server could actually have answered with?
+ *
+ * Deliberately stricter than "coerces to a number". A status is an integer in the range HTTP
+ * defines; `0`, `false`, `[]` and `""` are not, however cleanly they coerce. Strings are
+ * accepted because a status arriving as `"413"` is the same observation as `413` — but a
+ * string that merely starts with digits is not, which `Number()` handles correctly (it
+ * yields NaN for `"413 Payload Too Large"`, unlike `parseInt`).
+ */
+function isHttpStatus(value) {
+  if (typeof value !== "number" && typeof value !== "string") return false;
+  if (typeof value === "string" && value.trim() === "") return false;
+  const n = Number(value);
+  return Number.isInteger(n) && n >= 100 && n <= 599;
+}
+
+/**
  * What to report when the OUTER upload bound fires.
  *
  * Giving the refusal body its own shorter bound was not enough on its own. The inner bound
@@ -289,12 +305,20 @@ export async function boundedUpload(run, { size, withTimeout, boundMs } = {}) {
  * refusal that came without one.
  */
 export function describeTimedOutUpload({ observed, name, size, mediaType, boundMs } = {}) {
-  // ABSENT before COERCED, exactly as `describeSize` insists. `Number(null)` and `Number("")`
-  // are both 0, which is finite — so a coerce-first check turns "no status was ever observed"
-  // into a confident `HTTP null`, fabricating a server answer inside the one function whose
-  // whole job is to distinguish an answer from silence. A first version of this did that.
-  const status = observed?.status;
-  if (status !== null && status !== undefined && status !== "" && Number.isFinite(Number(status))) {
+  // ABSENT before COERCED, exactly as `describeSize` insists — and then narrower still.
+  //
+  // `Number(null)` and `Number("")` are both 0, which is finite, so a coerce-first check
+  // turns "no status was ever observed" into a confident `HTTP null`: a fabricated server
+  // answer produced by the one function whose whole job is to tell an answer from silence.
+  // A first version of this did exactly that.
+  //
+  // Excluding the absent values alone is still not enough. `0`, `false` and `[]` all coerce
+  // to a finite number and would render as `HTTP 0`, `HTTP false` and a blank status. None
+  // is a thing a server can answer, so the test is not "does it look like a number" but
+  // "is it a status": an integer in the range HTTP defines. A real `Response.status` always
+  // is, so nothing legitimate is turned away, and every non-status degrades to the truthful
+  // timeout wording rather than to an invented refusal.
+  if (isHttpStatus(observed?.status)) {
     return describeUploadFailure({
       status: observed.status,
       statusText: observed.statusText,

--- a/web/js/lib/attachment-upload.js
+++ b/web/js/lib/attachment-upload.js
@@ -89,6 +89,124 @@ export function describeUploadFailure({ status, statusText, body, error, name, s
   );
 }
 
+/**
+ * #1188 — the bound for a POST to `/upload/image`, and why it is sized by payload.
+ *
+ * Same failure as #1161/#1180: after a ComfyUI restart the tab can hold a half-open
+ * connection where a request neither answers nor fails, so there is nothing for the
+ * existing `try/catch` to catch. Here it wedges the UI rather than a command. The panel
+ * awaits `Promise.all(pending.map((a) => a.ready))` before sending a message
+ * (`comfyui-mcp-panel.js:31607`), and `att.ready` catches everything internally, so it
+ * never rejects — it simply never settles. The composer is then unable to send, forever.
+ * The training wizard hit the same await from the other side and worked around it locally
+ * (`cmcp-training-ui.js:704-719`): "ONE hung upload left uploadsPending > 0 permanently and
+ * deadlocked wizard navigation".
+ *
+ * WHY NOT A FLAT BOUND. The other #1188 sites carry a fixed number because their payload is
+ * a token or a small JSON body. This endpoint takes whatever the user dropped on it —
+ * `handleMediaUpload` exists specifically for video — so any flat number both cuts off
+ * legitimate large uploads and waits absurdly long for small ones. The bound is therefore a
+ * floor plus an allowance derived from the payload, which fires only when throughput falls
+ * below `UPLOAD_MIN_BYTES_PER_MS`, i.e. far below any link that is actually moving bytes.
+ *
+ * WHAT THIS IS NOT. It is a DURATION bound, not a STALL bound, and the difference matters
+ * for the honest case: a transfer that dies halfway through a 2 GB file still waits out the
+ * whole allowance. Detecting that needs upload progress events, which `fetch` does not
+ * emit — it would mean moving this path to `XMLHttpRequest` (`upload.onprogress`). That is
+ * a larger change than #1188's scope and is NOT done here. What this does guarantee is that
+ * the wedge is finite, which is the property the composer's `Promise.all` needs.
+ */
+export const UPLOAD_STALL_FLOOR_MS = 30000;
+
+/** ~50 KB/s. A floor, not an expectation: any working link clears it by orders of
+ *  magnitude, so the bound cannot fire on a transfer that is genuinely progressing. */
+export const UPLOAD_MIN_BYTES_PER_MS = 50;
+
+/**
+ * How long an upload of `size` bytes may take before the caller stops waiting.
+ *
+ * NEVER returns a non-positive number. `withTimeout` treats those as NO BOUND (see
+ * `bounded-step.js:20`), so a zero or negative result would silently restore the very hang
+ * this exists to prevent — the same trap `nodeDefsBudgetLeft` guards against by clamping to
+ * 1ms. An unknown or unusable size yields the floor rather than a fabricated allowance,
+ * matching `describeSize`'s rule that an unmeasured value must be absent, not zero.
+ */
+export function uploadBoundMs(size, {
+  floorMs = UPLOAD_STALL_FLOOR_MS,
+  bytesPerMs = UPLOAD_MIN_BYTES_PER_MS,
+} = {}) {
+  const floor = Number.isFinite(floorMs) && floorMs > 0 ? Math.ceil(floorMs) : UPLOAD_STALL_FLOOR_MS;
+  const rate = Number.isFinite(bytesPerMs) && bytesPerMs > 0 ? bytesPerMs : UPLOAD_MIN_BYTES_PER_MS;
+  if (size === null || size === undefined || size === "") return floor;
+  const n = Number(size);
+  if (!Number.isFinite(n) || n <= 0) return floor;
+  return Math.max(1, floor + Math.ceil(n / rate));
+}
+
+/** Sentinel: the upload did not answer, as distinct from anything it could return. */
+export const UPLOAD_NO_ANSWER = Symbol("cmcp-upload-timeout");
+
+/**
+ * Run one `/upload/image` exchange under a payload-sized bound.
+ *
+ * BOTH HALVES. `run` is the caller's whole exchange — the request AND whichever body read
+ * it performs — because `fetch` resolves as soon as the response head arrives and the bytes
+ * stream afterwards inside `json()`/`text()`. Bounding the request alone leaves the part
+ * that actually waits unbounded, which is exactly what shipped in #1180's first attempt at
+ * the log read and passed review because the test stalled the handshake rather than the body.
+ *
+ * REIFY BEFORE BOUNDING. `withTimeout` never rejects by contract — it degrades a rejection
+ * through `onTimeout()` exactly as it does a timeout — so handing it `run()` directly would
+ * collapse "it threw" into "it never answered" and lose the error. Both upload paths render
+ * a throw through `describeUploadFailure({ error })` with its detail, and #756's tests pin
+ * that wording. Settling into `{ value }`/`{ err }` first keeps the two apart, so a real
+ * transport failure propagates exactly as it did before this bound existed.
+ *
+ * DOES NOT CANCEL, by inheritance from `withTimeout`. An abandoned upload keeps running and
+ * may still land in ComfyUI's `input/`. The caller has stopped waiting; it has not undone
+ * the write. No caller here retries, so abandoned attempts cannot stack.
+ *
+ * @returns {Promise<any>} whatever `run` resolved, or `UPLOAD_NO_ANSWER` at the bound
+ */
+export async function boundedUpload(run, { size, withTimeout, boundMs } = {}) {
+  const ms = Number.isFinite(boundMs) && boundMs > 0 ? boundMs : uploadBoundMs(size);
+  // A missing helper must not silently REMOVE the bound. Running unbounded is the one
+  // outcome this exists to prevent, so an unusable `withTimeout` is a programming error
+  // worth failing loudly on rather than a condition to degrade through.
+  if (typeof withTimeout !== "function") throw new TypeError("boundedUpload requires withTimeout");
+  const settled = await withTimeout(
+    Promise.resolve()
+      .then(() => run())
+      .then((value) => ({ value }), (err) => ({ err })),
+    ms,
+    () => UPLOAD_NO_ANSWER,
+  );
+  if (settled === UPLOAD_NO_ANSWER) return UPLOAD_NO_ANSWER;
+  if ("err" in settled) throw settled.err;
+  return settled.value;
+}
+
+/**
+ * The failure text for an upload that never answered.
+ *
+ * Routed through `describeUploadFailure`'s `error` branch rather than a new sentence of its
+ * own, so a timeout reads with the same shape as the transport failure it is a species of —
+ * "the request to /upload/image threw … Whether any bytes reached the server is unknown",
+ * which is precisely true here: the bound does not cancel, so the write may yet land.
+ * Not a `tr()` key: the English catalog is frozen (#1135) and is GENERATED from the code, so
+ * one key means a pass over eleven locale files, and this string reaches the agent and the
+ * chip through the same untranslated path #756 already established.
+ */
+export function describeUploadTimeout({ name, size, mediaType, boundMs } = {}) {
+  const secs = Math.round((Number(boundMs) || uploadBoundMs(size)) / 1000);
+  return describeUploadFailure({
+    error: new Error(`no response within ${secs}s — the upload neither completed nor failed`),
+    name,
+    size,
+    mediaType,
+  });
+}
+
 /** The chip/agent line for one attachment. Success keeps its existing shape so a
  *  reader (and the transcript) sees no change on the happy path. */
 export function attachmentSummaryLine(att) {

--- a/web/js/lib/attachment-upload.js
+++ b/web/js/lib/attachment-upload.js
@@ -318,7 +318,13 @@ export function describeTimedOutUpload({ observed, name, size, mediaType, boundM
   // "is it a status": an integer in the range HTTP defines. A real `Response.status` always
   // is, so nothing legitimate is turned away, and every non-status degrades to the truthful
   // timeout wording rather than to an invented refusal.
-  if (isHttpStatus(observed?.status)) {
+  // …and a status is not automatically a REFUSAL. `describeUploadFailure`'s status branch
+  // words its answer as "upload REFUSED by ComfyUI … Nothing was written to input/", which is
+  // a lie about a 2xx. Only a status that actually denotes failure may be reported that way;
+  // anything else falls back to the timeout wording, which is what a 200 whose body never
+  // finished streaming genuinely is. Unreachable from the composers today — they record only
+  // non-200 — but this function is exported and must not depend on its callers' discipline.
+  if (isHttpStatus(observed?.status) && Number(observed.status) >= 400) {
     return describeUploadFailure({
       status: observed.status,
       statusText: observed.statusText,

--- a/web/js/lib/attachment-upload.js
+++ b/web/js/lib/attachment-upload.js
@@ -123,13 +123,28 @@ export const UPLOAD_STALL_FLOOR_MS = 30000;
 export const UPLOAD_MIN_BYTES_PER_MS = 50;
 
 /**
+ * The largest delay `setTimeout` can actually hold.
+ *
+ * Above 2^31-1 ms the delay overflows a 32-bit signed int and is coerced to **1ms** — so an
+ * allowance so generous it should never fire becomes a bound that fires immediately and
+ * refuses every upload. A bound that big is unreachable in practice (it needs a ~107 GB
+ * payload), but the failure direction is the dangerous one: not "waits too long" but
+ * "refuses instantly", and it would arrive through the mechanism meant to prevent refusals.
+ * Clamping also absorbs an `Infinity` reachable through the options object, which no
+ * production caller passes but which the exported signature permits.
+ */
+export const MAX_TIMER_MS = 2147483647;
+
+/**
  * How long an upload of `size` bytes may take before the caller stops waiting.
  *
- * NEVER returns a non-positive number. `withTimeout` treats those as NO BOUND (see
- * `bounded-step.js:20`), so a zero or negative result would silently restore the very hang
- * this exists to prevent — the same trap `nodeDefsBudgetLeft` guards against by clamping to
- * 1ms. An unknown or unusable size yields the floor rather than a fabricated allowance,
- * matching `describeSize`'s rule that an unmeasured value must be absent, not zero.
+ * ALWAYS returns a delay a timer can actually hold: finite, and within [1, MAX_TIMER_MS].
+ * Both ends matter, and they fail in opposite directions. Below 1, `withTimeout` treats the
+ * value as NO BOUND (see `bounded-step.js:20`) and silently restores the very hang this
+ * exists to prevent — the trap `nodeDefsBudgetLeft` guards against the same way. Above
+ * `MAX_TIMER_MS`, `setTimeout` coerces the delay to 1ms and the bound refuses every upload
+ * instantly. An unknown or unusable size yields the floor rather than a fabricated
+ * allowance, matching `describeSize`'s rule that an unmeasured value must be absent, not zero.
  */
 export function uploadBoundMs(size, {
   floorMs = UPLOAD_STALL_FLOOR_MS,
@@ -137,10 +152,67 @@ export function uploadBoundMs(size, {
 } = {}) {
   const floor = Number.isFinite(floorMs) && floorMs > 0 ? Math.ceil(floorMs) : UPLOAD_STALL_FLOOR_MS;
   const rate = Number.isFinite(bytesPerMs) && bytesPerMs > 0 ? bytesPerMs : UPLOAD_MIN_BYTES_PER_MS;
-  if (size === null || size === undefined || size === "") return floor;
+  const clamp = (ms) => Math.min(MAX_TIMER_MS, Math.max(1, ms));
+  if (size === null || size === undefined || size === "") return clamp(floor);
   const n = Number(size);
-  if (!Number.isFinite(n) || n <= 0) return floor;
-  return Math.max(1, floor + Math.ceil(n / rate));
+  if (!Number.isFinite(n) || n <= 0) return clamp(floor);
+  return clamp(floor + Math.ceil(n / rate));
+}
+
+/**
+ * A file's measurements, read ONCE and defensively.
+ *
+ * A `File`/`Blob` whose `size` or `type` is a throwing getter (or a revoked Proxy) makes the
+ * bare reads throw at the top of the upload path — and then throw AGAIN inside the `catch`
+ * that reports the failure, because that catch reads the same properties to describe the
+ * file. The exception escapes the handler entirely and `att.ready` REJECTS, which the send
+ * path is not built for: it awaits `Promise.all(pending.map((a) => a.ready))`, so one
+ * unreadable file would break sending rather than mark that attachment failed.
+ *
+ * The unbounded original had this trap only on the non-200 branch. Passing the size to the
+ * bound would have widened it to EVERY upload, so the read is hoisted here instead. An
+ * unreadable measurement is reported as absent — `describeSize`'s rule — never as zero.
+ */
+export function readFileFacts(file) {
+  const facts = { size: undefined, mediaType: "" };
+  try {
+    facts.size = file?.size;
+  } catch {
+    /* unreadable — stays absent rather than becoming a fabricated 0 */
+  }
+  try {
+    facts.mediaType = file?.type;
+  } catch {
+    /* unreadable — an absent MIME type simply drops out of the description */
+  }
+  return facts;
+}
+
+/** How long ComfyUI's own explanation of a refusal may take to arrive. Short, because the
+ *  status is ALREADY in hand by this point and is worth reporting without it. */
+export const UPLOAD_ERROR_BODY_MS = 5000;
+
+/**
+ * Read a refusal's body without letting it cost us the status.
+ *
+ * #756's whole point was that "the status was in hand and thrown away". A body read that
+ * stalls inside the outer upload bound would do exactly that again by a new route: the
+ * outer bound fires, the sentinel is returned, and a KNOWN `HTTP 413` is reported to the
+ * user as "no response". Bounding the body separately and shorter means a stalled
+ * explanation costs only the explanation — the status still gets reported, with the same
+ * "the server sent no body explaining it" wording a body-less refusal already produces.
+ */
+export async function readErrorBody(res, withTimeout, ms = UPLOAD_ERROR_BODY_MS) {
+  if (typeof withTimeout !== "function") return null;
+  try {
+    return await withTimeout(
+      Promise.resolve().then(() => res.text()).then((t) => t, () => null),
+      ms,
+      () => null,
+    );
+  } catch {
+    return null;
+  }
 }
 
 /** Sentinel: the upload did not answer, as distinct from anything it could return. */


### PR DESCRIPTION
Works #1188. **Scoped — this does not close it.**

Continuation of #1161 (the `/object_info` oracle) and #1180 (the sibling `getNodeDefs` sites and the log read). Same failure: after a ComfyUI restart the tab can hold a half-open connection where a request neither answers nor fails, so `try/catch` cannot help and a bare `await` parks until the caller's 30s timeout.

## What #1180 taught that this must not repeat

- **`withTimeout` treats a non-positive `ms` as NO bound**, so passing `0` silently restores the hang.
- **It does not cancel.** An abandoned attempt keeps running, so bounds that retry can stack concurrent downloads.
- **Per-site bounds do not compose.** Sizing each one alone produced a path summing to ~39.6s against a 20s read default. Where several run in sequence, they need one shared deadline.
- **Bound the whole read, not the handshake.** `fetch` resolves when headers arrive; the stall lives in `res.json()`.
- **A guard can cause what it reports** — a diagnostic added during #1191 dropped the changelog base to the first commit.

## Work in progress

- [x] re-derive the site list against current `main` rather than trusting the issue's count
- [x] bound a scoped subset, stating which and why
- [x] tests that fail when each bound is removed *and* when it is passed `0`
- [x] verify by mutation

## The site list, re-derived

The issue's figure of 34 is wrong, and so was this PR's first correction of it. Counting **request awaits only** across `web/js` (excluding `vendor/`) gives **39 sites, 29 of them with no bounding primitive in scope**. Counting body reads as well — which is the honest unit, since `fetch` resolves at the head and the stall lives in `json()`/`text()` — gives **92 sites, 71 unbounded**.

This is recorded as a **heuristic, not a measurement**: the detector treats "a bounding primitive within ±40 lines" as bounded, and proximity does not prove coverage. Two were hand-verified in the earlier commit. The number is here to size the remaining work, not to be quoted as a count.

Bounded so far across this branch: **6** — the credentials console's three, and the three `/upload/image` sites below.

## This commit: the three `/upload/image` sites

Chosen because they share one endpoint, one failure, and one already-documented symptom.

**The wedge.** The composer awaits `Promise.all(pending.map((a) => a.ready))` before sending (`comfyui-mcp-panel.js:31607`). `att.ready` catches everything internally, so it never **rejects** — it simply never settles. After a restart leaves a half-open connection, the user cannot send a message at all and nothing on screen says why. The training wizard already hit this from the other side and worked around it locally (`cmcp-training-ui.js:704-719`): *"ONE hung upload left `uploadsPending > 0` permanently and deadlocked wizard navigation"*.

**Sized by payload, not flat.** The other #1188 sites carry a fixed number because their payload is a token or a small JSON body. This endpoint takes whatever the user dropped on it — `handleMediaUpload` exists specifically for video — so a flat bound either cuts off a legitimate large upload or waits absurdly long for a small one. The bound is a 30s floor plus an allowance at a 50 KB/s throughput floor, so it cannot fire on a transfer that is actually moving bytes.

**Stated plainly: this is a DURATION bound, not a STALL bound.** A transfer that dies halfway through a 2 GB file still waits out the whole allowance. Detecting that needs upload progress events, which `fetch` does not emit — it would mean moving the path to `XMLHttpRequest` (`upload.onprogress`), which is larger than #1188's scope and is **not** done here. What this does guarantee is that the wedge is finite, which is the property the composer's `Promise.all` needs.

**Each site keeps its own failure contract**, so no branch is added. `uploadBlobToInput` collapses the sentinel to the `null` it already returns for every other failure. There are **five** callers — `cmcp-apps-ui.js:1697`, `cmcp-civitai-ui.js:1196`, `cmcp-training-ui.js:754`, `lib/media-preview.js:893`, `lib/run-completion-frame.js:407` — and an earlier draft of this sentence said "all four … branch on that today", which was wrong on both halves. See the review record below; CivitAI's missing branch was a real bug and is fixed. The two composer sites report through `describeUploadFailure`'s `error` branch, whose #756 wording — *"Whether any bytes reached the server is unknown"* — is precisely true here, because the bound does not cancel.

**Composition, checked rather than assumed.** The storyboard pipeline already bounds the whole `sample → upload → HEAD` sequence at `MEDIA_PREVIEW_TIMEOUT_MS` (20s), so the inner bound is not what saves that path; it gives the other three callers, which have no outer bound, a specific failure instead of a hang.

**Placement.** Lands in `lib/attachment-upload.js` rather than the monolith: that module already owns upload failure semantics, it is unit-testable directly, and it holds the monolith diff to the three call sites while five other PRs contend for that file.

## #756's wiring test was updated, not relaxed

Moving the exchange into a bounded callback changed the expression that test pinned. The same contract is now pinned at **both ends** of the new shape — the description is built **and** surfaced — so neither half can be dropped silently.

## Mutations, all caught

Nineteen, listed in the review record below.

Two harness notes worth keeping, because both make a harness lie in the *safe-looking* direction: the working tree is CRLF, so multi-line anchors written with `\n` never match and a missed anchor reads exactly like a caught mutation; and the `missing-withTimeout` mutation makes the suite **hang** rather than fail, because the tests feed it a never-settling promise on purpose. Both are now reported as distinct outcomes.

## Recorded, not fixed here

`cmcp-training-ui.js:711` defines a **second `withTimeout`** with an incompatible contract — it rejects rather than degrading, and it does not guard a non-positive `ms`. `bounded-step.js`'s own header warns that *"a second timeout helper written alongside the first is how this repo keeps producing near-duplicate bugs"*. Its 30s outer bound is now redundant for this path but harmless; retiring it is a separate change.

## Scope boundary

#1188 as re-derived covers **HTTP-level** awaits (`fetch` / `api.fetchApi`). `graph_run`'s `graphToPrompt()` and `queuePrompt()` awaits are unbounded awaits of the same class but are **frontend-API**, not HTTP, and belong to #1175/#1192.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Review record

Five Codex passes. Four returned NO-SHIP, and every one of them found something real — including three defects where **the bound cost more than the hang it replaced**, which is the specific way this class of fix goes wrong.

| # | Finding | Resolution |
|---|---|---|
| 1 | A `File` whose `size`/`type` getter throws threw *again* inside the reporting catch, escaped the handler, and **rejected `att.ready`** — breaking the send path for every attachment, not just the bad one | `readFileFacts()` reads each once, defensively |
| 1 | A stalled refusal body dragged a **known HTTP status** past the outer bound and reported it as "no response" — #756's own defect, reintroduced | `readErrorBody()` bounds the body separately and shorter |
| 1 | `setTimeout` coerces delays above 2³¹−1 ms to **1 ms**, so an over-generous allowance became an *instant* refusal | clamped to `MAX_TIMER_MS` |
| 1 | Slow-but-progressing uploads can be cut off | **Argued, not changed** — accepted as sound in pass 2 |
| 2 | The body's bound runs *inside* the outer one, so a head arriving near the outer deadline still lost the status | status recorded the instant it is known; `describeTimedOutUpload` consults it first |
| 3 | The new guard still fabricated refusals: `0`, `false`, `[]` rendered as `HTTP 0` / `HTTP false` / blank | `isHttpStatus()` — an integer in [100, 599] |
| 3 | The comment claiming "all four callers branch on null" was **false on both halves** — five callers, and CivitAI's did not branch at all | comment names all five with file:line; CivitAI's real bug fixed |
| 4 | A `2xx` is a status but not a refusal — `"200"` produced "upload REFUSED … Nothing was written" | refusal wording gated on `>= 400` |
| 4 | The caller-coverage test was **vacuous** — an unscoped search matched unrelated `!ref` ~340 lines away and passed with the guard deleted | scoped to 400 comment-stripped chars; verified red at all five sites |

Two of those are worth calling out because they are about *this repo's own stated rules*, broken in the act of enforcing them:

- `Number(null)` is `0`, which is finite — so "no status was ever observed" rendered as a confident `HTTP null`. That is `describeSize`'s ABSENT-before-COERCED rule, violated three functions below where it is written down.
- The false "four callers" comment had **already been read back as established fact** by a later review before anyone counted. It now names each site with file:line, and a test counts them so the claim cannot rot back into a guess.

`check-panel-scope` also caught two `ReferenceError`s from an import a CRLF-mangled patch had skipped — which all 4208 unit tests walked straight past.

## Verification

- **19 mutations, all confirmed red.** Two harness traps are recorded in the commits because both make a harness lie in the *safe-looking* direction: CRLF makes multi-line anchors silently miss (a missed anchor reads exactly like a caught mutation), and removing a bound makes the suite **hang** rather than fail.
- Full unit suite green: **4209 tests, 0 failures**.
