### PR TITLE
fix(1493): the storyboard builder names WHICH failure it hit, so the reply stops guessing

### DIFF
--- a/browser_tests/unit/media-preview.test.mjs
+++ b/browser_tests/unit/media-preview.test.mjs
@@ -282,27 +282,7 @@ test("EVERY failure exit in the builder names itself — no bare `return null` s
   // the honest instrument for "this function contains no unnamed exit" is the
   // source itself — bounded to the function body, not a fixed-size window that
   // silently stops covering what it checks.
-  const src = panelSource();
-  const start = src.indexOf("async function buildVideoStoryboard(");
-  assert.ok(start > 0, "could not locate buildVideoStoryboard");
-  // Walk braces from the function's opening `{` to its matching close.
-  const open = src.indexOf("{", start);
-  let depth = 0;
-  let end = open;
-  for (let i = open; i < src.length; i++) {
-    const c = src[i];
-    if (c === "{") depth++;
-    else if (c === "}") {
-      depth--;
-      if (depth === 0) {
-        end = i;
-        break;
-      }
-    }
-  }
-  assert.ok(end > open, "could not bound the function body");
-  const body = src.slice(open, end);
-
+  const body = functionBody("async function buildVideoStoryboard(");
   const bare = body.match(/return null\s*;/g) ?? [];
   assert.deepEqual(
     bare,
@@ -353,6 +333,47 @@ test("a builder that returns a bare null STILL invents no cause", async () => {
   assert.match(reply.note, /the panel is not told which/);
   assert.doesNotMatch(reply.note, /could not be seeked/);
   assert.doesNotMatch(reply.note, /VP9/);
+});
+
+test("nothing that is not sheet-shaped is ever uploaded", async () => {
+  // Success is recognised POSITIVELY (a numeric `size`, which is what a Blob has
+  // and what the doubles model). Two earlier versions inferred FAILURE instead
+  // and both leaked: keying on the reason's type uploaded `{reason:{…}}`, and
+  // keying on its presence uploaded every other truthy value (review finding).
+  for (const shape of [[], {}, "a string", 42, true, { paintedFrames: 3 }]) {
+    const h = harness({ buildVideoStoryboard: async () => shape });
+    const reply = await composeShowMediaReply([VIDEO_REF], h.deps);
+    assert.equal(
+      h.calls.uploads.length,
+      0,
+      `a ${JSON.stringify(shape)} must not reach uploadBlobToInput`,
+    );
+    assert.equal(reply.previews.length, 0);
+    assert.match(reply.note, /no sampled preview could be built/);
+  }
+});
+
+test("a sheet-shaped result that ALSO carries a reason is read as the failure", async () => {
+  // The ambiguous shape the code comments call out. It is not one the builder
+  // produces, so the question is only which way to be wrong: preferring the
+  // explanation over silently uploading something that announced its own
+  // failure. Documented behaviour deserves a test — mutation showed that
+  // dropping the guard changed nothing observable without one.
+  const h = harness({
+    buildVideoStoryboard: async () => ({ size: 4096, reason: "no usable duration" }),
+  });
+  const reply = await composeShowMediaReply([VIDEO_REF], h.deps);
+
+  assert.equal(h.calls.uploads.length, 0);
+  assert.match(reply.note, /no usable duration/);
+});
+
+test("a sheet-shaped result is still uploaded — the positive check did not break success", async () => {
+  // The other direction, and the one a stricter check is most likely to break.
+  const h = harness({ buildVideoStoryboard: async () => ({ size: 4096, paintedFrames: 20 }) });
+  const reply = await composeShowMediaReply([VIDEO_REF], h.deps);
+  assert.equal(h.calls.uploads.length, 1);
+  assert.equal(reply.previews.length, 1);
 });
 
 test("a non-string reason is ignored rather than interpolated", async () => {
@@ -1172,6 +1193,44 @@ test("a mixed batch reports each kind's outcome separately (#710)", async () => 
 const panelSource = () =>
   readFileSync(fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url)), "utf8");
 
+/**
+ * The body of a named function, bounded by its OWN braces.
+ *
+ * Replaces the fixed-size `slice(i, i + N)` these source tests used to take. A
+ * fixed window has a cliff: #1493 grew the storyboard builder past 4000 chars
+ * and the assertion below silently stopped covering the line it checked. Raising
+ * the number only moves the cliff (review finding), so bound the real thing.
+ *
+ * Not a JS parser, and it does not need to be — but a brace counter that reads
+ * braces inside STRINGS and COMMENTS can mis-bound and then validate the wrong
+ * region entirely (also a review finding), which is worse than no check. So mask
+ * those first, preserving length so offsets still line up with the original.
+ */
+function functionBody(signature) {
+  const src = panelSource();
+  const start = src.indexOf(signature);
+  assert.ok(start > 0, `could not locate ${signature}`);
+
+  const blank = (m) => m.replace(/[^\n]/g, " "); // keep newlines, drop content
+  const masked = src
+    .replace(/\/\*[\s\S]*?\*\//g, blank) // block comments
+    .replace(/\/\/[^\n]*/g, blank) // line comments
+    .replace(/"(?:\\.|[^"\\\n])*"/g, blank) // "…"
+    .replace(/'(?:\\.|[^'\\\n])*'/g, blank) // '…'
+    .replace(/`(?:\\.|[^`\\])*`/g, blank); // `…` (may span lines)
+
+  const open = masked.indexOf("{", start);
+  assert.ok(open > start, `could not find the opening brace of ${signature}`);
+  let depth = 0;
+  for (let i = open; i < masked.length; i++) {
+    if (masked[i] === "{") depth++;
+    else if (masked[i] === "}" && --depth === 0) {
+      return src.slice(open, i); // the ORIGINAL text, precisely bounded
+    }
+  }
+  assert.fail(`could not bound the body of ${signature}`);
+}
+
 test("the show_media dispatcher answers with the handler's reply, not a fixed acknowledgement", () => {
   const src = panelSource();
   assert.match(
@@ -1221,14 +1280,10 @@ test("the panel's storyboard builder carries the count it ACTUALLY drew", () => 
   // Without this, media-preview has only the grid capacity to go on and every
   // partially-sampled sheet is described as a full one — 19 blank cells
   // presented to the agent as 19 observations.
-  const src = panelSource();
-  const i = src.indexOf("async function buildVideoStoryboard(");
-  assert.ok(i > 0, "could not locate buildVideoStoryboard");
-  // 6000, not 4000: #1493 gave each failure branch a named reason and the body
-  // outgrew the old window, which made this assert on text it could no longer
-  // see. A window that silently stops covering what it checks is the failure
-  // mode of every source-scanning test.
-  const fn = src.slice(i, i + 6000);
+  // Brace-bounded, not a fixed window. #1493 grew this function past the old
+  // 4000-char slice and the assertion below stopped covering the line it
+  // checks; bumping the number would only move that cliff.
+  const fn = functionBody("async function buildVideoStoryboard(");
   assert.match(fn, /blob\.paintedFrames = painted;/);
   // A sheet that will not encode must still not be reported as a sheet. This
   // used to pin the literal `if (!blob) return null;`; comfyui-mcp#1493 replaced

--- a/browser_tests/unit/media-preview.test.mjs
+++ b/browser_tests/unit/media-preview.test.mjs
@@ -271,6 +271,101 @@ test("a sampler that returns nothing degrades with a remedy and NO invented caus
   assert.match(reply.note, /call get_image with filename "reference_clip\.mp4"/);
 });
 
+// comfyui-mcp#1493 — the builder knew which of its six failures it hit and threw
+// that away, so the reply had to say "the panel is not told which". It can now
+// hand back `{reason}`, and only then may the reply name a cause.
+test("EVERY failure exit in the builder names itself — no bare `return null` survives", () => {
+  // The consumer tests below all STUB buildVideoStoryboard, so none of them can
+  // see the builder's own branches: mutation showed the duration branch could be
+  // reverted to a bare `null` with the whole suite still green. The real builder
+  // needs a DOM (video + canvas + seeking) that these node tests do not have, so
+  // the honest instrument for "this function contains no unnamed exit" is the
+  // source itself — bounded to the function body, not a fixed-size window that
+  // silently stops covering what it checks.
+  const src = panelSource();
+  const start = src.indexOf("async function buildVideoStoryboard(");
+  assert.ok(start > 0, "could not locate buildVideoStoryboard");
+  // Walk braces from the function's opening `{` to its matching close.
+  const open = src.indexOf("{", start);
+  let depth = 0;
+  let end = open;
+  for (let i = open; i < src.length; i++) {
+    const c = src[i];
+    if (c === "{") depth++;
+    else if (c === "}") {
+      depth--;
+      if (depth === 0) {
+        end = i;
+        break;
+      }
+    }
+  }
+  assert.ok(end > open, "could not bound the function body");
+  const body = src.slice(open, end);
+
+  const bare = body.match(/return null\s*;/g) ?? [];
+  assert.deepEqual(
+    bare,
+    [],
+    `every failure exit must name its cause; found ${bare.length} bare \`return null\``,
+  );
+  // …and the named exits are actually there (a body that returns nothing at all
+  // would trivially satisfy the assertion above).
+  const named = body.match(/return storyboardFailure\(/g) ?? [];
+  assert.ok(named.length >= 5, `expected the 5 failure branches to be named, saw ${named.length}`);
+});
+
+test("a NAMED sampler failure is passed through, not flattened to the generic note", async () => {
+  const h = harness({
+    buildVideoStoryboard: async () => ({
+      reason: "the browser reported no usable duration for it (its codec may not be decodable here — VP9/AV1 .webm is the usual case)",
+    }),
+  });
+  const reply = await composeShowMediaReply([VIDEO_REF], h.deps);
+
+  assert.equal(reply.previews.length, 0);
+  assert.match(reply.note, /no usable duration/);
+  assert.match(reply.note, /VP9\/AV1/);
+  // The generic "not told which" line must be GONE — we were told which.
+  assert.doesNotMatch(reply.note, /the panel is not told which/);
+  // Still actionable, and the user still got the player.
+  assert.match(reply.note, /call get_image with filename "reference_clip\.mp4"/);
+  assert.equal(h.calls.paintedVideos.length, 1);
+});
+
+test("a named failure is never uploaded as if it were a sheet", async () => {
+  // `{reason}` is TRUTHY. A consumer that only checked `if (!blob)` would sail
+  // past it and hand the explanation to uploadBlobToInput as a PNG.
+  const h = harness({ buildVideoStoryboard: async () => ({ reason: "no usable duration" }) });
+  const reply = await composeShowMediaReply([VIDEO_REF], h.deps);
+
+  assert.equal(h.calls.uploads.length, 0, "an explanation must never be uploaded");
+  assert.equal(reply.previews.length, 0);
+});
+
+test("a builder that returns a bare null STILL invents no cause", async () => {
+  // The rule the pre-existing test holds, restated against the new code path: a
+  // sampler that reports nothing tells us nothing, and naming a cause for it
+  // would be a diagnosis nothing made. Only a SUPPLIED reason is repeated.
+  const h = harness({ buildVideoStoryboard: async () => null });
+  const reply = await composeShowMediaReply([VIDEO_REF], h.deps);
+
+  assert.match(reply.note, /the panel is not told which/);
+  assert.doesNotMatch(reply.note, /could not be seeked/);
+  assert.doesNotMatch(reply.note, /VP9/);
+});
+
+test("a non-string reason is ignored rather than interpolated", async () => {
+  // A malformed object must degrade to the generic note, not print
+  // "[object Object]" at the agent — the serialization failure this repo keeps
+  // rediscovering.
+  const h = harness({ buildVideoStoryboard: async () => ({ reason: { nested: true } }) });
+  const reply = await composeShowMediaReply([VIDEO_REF], h.deps);
+
+  assert.doesNotMatch(reply.note, /\[object Object\]/);
+  assert.match(reply.note, /the panel is not told which/);
+});
+
 test("the 'ask the user' remedy is withheld when the user cannot see it either", async () => {
   // Telling the caller to ask a person who was never shown the video sends it
   // somewhere that does not work from where it is.
@@ -1129,9 +1224,18 @@ test("the panel's storyboard builder carries the count it ACTUALLY drew", () => 
   const src = panelSource();
   const i = src.indexOf("async function buildVideoStoryboard(");
   assert.ok(i > 0, "could not locate buildVideoStoryboard");
-  const fn = src.slice(i, i + 4000);
+  // 6000, not 4000: #1493 gave each failure branch a named reason and the body
+  // outgrew the old window, which made this assert on text it could no longer
+  // see. A window that silently stops covering what it checks is the failure
+  // mode of every source-scanning test.
+  const fn = src.slice(i, i + 6000);
   assert.match(fn, /blob\.paintedFrames = painted;/);
-  assert.match(fn, /if \(!blob\) return null;/);
+  // A sheet that will not encode must still not be reported as a sheet. This
+  // used to pin the literal `if (!blob) return null;`; comfyui-mcp#1493 replaced
+  // the bare null with a NAMED failure, so pin the property that matters — the
+  // encode branch does not fall through — rather than the exact wording, which
+  // was only ever incidental to this test's point.
+  assert.match(fn, /if \(!blob\) return storyboardFailure\(/);
 });
 
 test("onShowMedia routes through composeShowMediaReply with the storyboard pipeline wired", () => {

--- a/browser_tests/unit/media-preview.test.mjs
+++ b/browser_tests/unit/media-preview.test.mjs
@@ -1203,8 +1203,22 @@ const panelSource = () =>
  *
  * Not a JS parser, and it does not need to be — but a brace counter that reads
  * braces inside STRINGS and COMMENTS can mis-bound and then validate the wrong
- * region entirely (also a review finding), which is worse than no check. So mask
- * those first, preserving length so offsets still line up with the original.
+ * region entirely, which is worse than no check. So mask those first, preserving
+ * length so offsets still line up with the original.
+ *
+ * STRINGS ARE MASKED BEFORE COMMENTS, and the order is load-bearing: a `//` or
+ * `/*` inside a string literal would otherwise start a comment that runs to the
+ * end of the line (or to the next close) and blank out real code, moving the
+ * bound (review, round 3). Masking strings first removes those characters before
+ * anything can read them as a comment opener.
+ *
+ * ACCEPTED LIMITS, stated rather than implied: regex literals are NOT masked, so
+ * a regex containing an unbalanced brace inside this function would mis-bound
+ * it, and nested template literals are matched only to their first unescaped
+ * backtick. Both are absent from the function this is used on, and the
+ * assertions here fail loudly rather than silently passing if the bound moves —
+ * a body that no longer contains `storyboardFailure(` trips the >= 5 check. Buy
+ * a real parser if this helper ever gets pointed at arbitrary code.
  */
 function functionBody(signature) {
   const src = panelSource();
@@ -1213,11 +1227,11 @@ function functionBody(signature) {
 
   const blank = (m) => m.replace(/[^\n]/g, " "); // keep newlines, drop content
   const masked = src
+    .replace(/"(?:\\.|[^"\\\n])*"/g, blank) // "…"  ─┐ strings FIRST, so a `//`
+    .replace(/'(?:\\.|[^'\\\n])*'/g, blank) // '…'   │ inside one cannot open a
+    .replace(/`(?:\\.|[^`\\])*`/g, blank) //  `…`   ─┘ comment that eats real code
     .replace(/\/\*[\s\S]*?\*\//g, blank) // block comments
-    .replace(/\/\/[^\n]*/g, blank) // line comments
-    .replace(/"(?:\\.|[^"\\\n])*"/g, blank) // "…"
-    .replace(/'(?:\\.|[^'\\\n])*'/g, blank) // '…'
-    .replace(/`(?:\\.|[^`\\])*`/g, blank); // `…` (may span lines)
+    .replace(/\/\/[^\n]*/g, blank); // line comments
 
   const open = masked.indexOf("{", start);
   assert.ok(open > start, `could not find the opening brace of ${signature}`);

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -6170,6 +6170,30 @@ function awaitMediaEvent(el, name, timeoutMs) {
  * Same-origin /view means the canvas is NOT tainted, so toBlob works. Returns a
  * PNG Blob, or null if the video can't be decoded/sampled. Never throws.
  */
+/**
+ * A storyboard attempt that failed, and WHY (comfyui-mcp#1493).
+ *
+ * The builder used to answer every failure with a bare `null`: an undecodable
+ * codec, a canvas it could not get, frames that never painted, and a sheet that
+ * would not encode all looked identical to the caller. The reply then had to say
+ * "the panel is not told which" — which was honest, and useless, because the
+ * builder knew exactly and threw it away.
+ *
+ * THIS IS TRUTHY, so a caller must test `.reason` BEFORE treating the result as
+ * a sheet — `if (!sheet)` alone would sail past it and try to upload a plain
+ * object. `produceSheet` is the only consumer and does exactly that. Said
+ * plainly because the tempting summary — "existing checks keep working" — is
+ * false, and a wrong reassurance in a comment outlives the person who wrote it.
+ *
+ * What it DOES preserve is the meaning of `null`: a builder that returns nothing
+ * still reports nothing, so a test double of `async () => null` keeps meaning
+ * what it means today. That is why the existing "NO invented cause" test stays
+ * valid instead of being rewritten to accommodate this change.
+ */
+function storyboardFailure(reason) {
+  return { reason };
+}
+
 async function buildVideoStoryboard(url) {
   const video = document.createElement("video");
   video.muted = true;
@@ -6197,7 +6221,16 @@ async function buildVideoStoryboard(url) {
     const duration = Number(video.duration);
     const vw = video.videoWidth;
     const vh = video.videoHeight;
-    if (!isFinite(duration) || duration <= 0 || !vw || !vh) return null;
+    if (!isFinite(duration) || duration <= 0 || !vw || !vh) {
+      // #1493 — say WHICH. A caller that only sees `null` cannot tell a codec
+      // the browser will not decode from a frame it could not paint, and the
+      // two need different advice.
+      return storyboardFailure(
+        !isFinite(duration) || duration <= 0
+          ? "the browser reported no usable duration for it (its codec may not be decodable here — VP9/AV1 .webm is the usual case)"
+          : "the browser reported zero video dimensions for it (its codec may not be decodable here)",
+      );
+    }
 
     const n = storyboardFrameCount();
     const cellW = STORYBOARD.CELL_W;
@@ -6211,7 +6244,7 @@ async function buildVideoStoryboard(url) {
     canvas.width = pad * 2 + cols * cellW + (cols - 1) * gap;
     canvas.height = pad * 2 + rows * cellH + (rows - 1) * gap;
     const ctx = canvas.getContext("2d");
-    if (!ctx) return null;
+    if (!ctx) return storyboardFailure("this browser refused a 2D canvas context, so no sheet could be drawn");
     ctx.fillStyle = "#111114";
     ctx.fillRect(0, 0, canvas.width, canvas.height);
 
@@ -6248,10 +6281,10 @@ async function buildVideoStoryboard(url) {
         ctx.fillText(String(i + 1).padStart(2, "0"), x + 4, y + 4);
       }
     }
-    if (!painted) return null;
+    if (!painted) return storyboardFailure("its metadata loaded but not one of the sampled frames could be painted (seeking never produced an image)");
 
     const blob = await new Promise((resolve) => canvas.toBlob(resolve, "image/png"));
-    if (!blob) return null;
+    if (!blob) return storyboardFailure("the contact sheet was drawn but the canvas would not encode it to PNG (a cross-origin frame taints the canvas)");
     // #648 — the grid has COLS*ROWS CELLS, but a video with unseekable frames
     // paints fewer and leaves the rest blank. storyboardFrameCount() reports the
     // capacity, not the sample count, so a caller reading only that would tell
@@ -6266,7 +6299,12 @@ async function buildVideoStoryboard(url) {
     }
     return blob;
   } catch {
-    return null; // decode/seek/metadata failure → caller falls back to video-only
+    // The metadata wait itself timed out, or decode/seek threw.
+    return storyboardFailure(
+      "the browser never delivered its metadata within " +
+        Math.round(STORYBOARD.META_TIMEOUT_MS / 1000) +
+        "s, or decoding threw (its codec may not be decodable here)",
+    );
   } finally {
     cleanup();
   }

--- a/web/js/lib/media-preview.js
+++ b/web/js/lib/media-preview.js
@@ -876,15 +876,23 @@ async function produceSheet(job, deps) {
     // #1493 — the builder may hand back `{reason}` instead of a sheet. That is
     // TRUTHY, so it has to be recognised before the `!blob` check below, or an
     // explanation would be uploaded to ComfyUI as if it were a PNG.
-    // Detect the FAILURE SHAPE by the presence of `reason`, and interpolate only
-    // when it is a string. Keying "is this a failure?" on the reason's TYPE was
-    // wrong in the dangerous direction: a malformed `{reason: {...}}` is truthy,
-    // failed the string test, and was then treated as a Blob — uploaded to
-    // ComfyUI, and announced as a sheet the panel could not count. Caught by the
-    // malformed-reason test below, which is why it exists.
-    const isFailure = produced != null && typeof produced === "object" && "reason" in produced;
-    const named = isFailure && typeof produced.reason === "string" ? produced.reason : null;
-    const blob = isFailure ? null : produced;
+    // Recognise SUCCESS positively; treat everything else as a failure.
+    //
+    // Two earlier versions inferred failure instead, and both were wrong in the
+    // direction that uploads garbage: keying on the reason's TYPE let a
+    // malformed `{reason:{…}}` through as a sheet, and keying on the PRESENCE of
+    // `reason` still uploaded any other truthy value — `[]`, `{}`, a string
+    // (review finding). A sheet is the thing with a numeric `size`, which is
+    // what a Blob has and what every test double models; nothing else may reach
+    // `uploadBlobToInput`.
+    //
+    // A hypothetical Blob carrying its own string `reason` is therefore read as
+    // a failure. That is a shape the builder never produces, and preferring the
+    // explanation over a silent upload is the safe way to be wrong about it.
+    const asObject = produced != null && typeof produced === "object" ? produced : null;
+    const named = asObject && typeof asObject.reason === "string" ? asObject.reason : null;
+    const looksLikeSheet = asObject != null && typeof asObject.size === "number";
+    const blob = looksLikeSheet && !named ? produced : null;
     if (!blob) {
       warn("[cmcp] show_media: could not sample frames from", job.name);
       return {

--- a/web/js/lib/media-preview.js
+++ b/web/js/lib/media-preview.js
@@ -872,19 +872,32 @@ async function buildSampledPreview(job, deps) {
 async function produceSheet(job, deps) {
   const { buildVideoStoryboard, uploadBlobToInput, storyboardFrameCount, warn } = deps;
   try {
-    const blob = await buildVideoStoryboard(job.url);
+    const produced = await buildVideoStoryboard(job.url);
+    // #1493 — the builder may hand back `{reason}` instead of a sheet. That is
+    // TRUTHY, so it has to be recognised before the `!blob` check below, or an
+    // explanation would be uploaded to ComfyUI as if it were a PNG.
+    // Detect the FAILURE SHAPE by the presence of `reason`, and interpolate only
+    // when it is a string. Keying "is this a failure?" on the reason's TYPE was
+    // wrong in the dangerous direction: a malformed `{reason: {...}}` is truthy,
+    // failed the string test, and was then treated as a Blob — uploaded to
+    // ComfyUI, and announced as a sheet the panel could not count. Caught by the
+    // malformed-reason test below, which is why it exists.
+    const isFailure = produced != null && typeof produced === "object" && "reason" in produced;
+    const named = isFailure && typeof produced.reason === "string" ? produced.reason : null;
+    const blob = isFailure ? null : produced;
     if (!blob) {
       warn("[cmcp] show_media: could not sample frames from", job.name);
       return {
         ref: null,
         frames: null,
         cells: null,
-        // Deliberately non-diagnostic. The builder returns nothing when the
-        // metadata never arrives, when the dimensions are unusable, when no
-        // frame could be captured, AND when the finished sheet fails to encode
-        // — and it does not report which. Naming one of them would hand the
-        // agent a cause nothing observed.
-        why: "the sampler returned no contact sheet (its metadata, its frames or the sheet's own encoding failed — the panel is not told which)",
+        // Name the cause ONLY when the builder supplied one. A sampler that
+        // returns a bare `null` still reports nothing, and inventing a diagnosis
+        // for it would hand the agent a cause nothing observed — the rule the
+        // "NO invented cause" test exists to hold, and which still holds.
+        why: named
+          ? `the sampler could not build a contact sheet: ${named}`
+          : "the sampler returned no contact sheet (its metadata, its frames or the sheet's own encoding failed — the panel is not told which)",
       };
     }
     const base = job.name.replace(/\.[^.]+$/, "") || "video";


### PR DESCRIPTION
Claims artokun/comfyui-mcp#1493. The whole failing path is in this repo, so a patch to the orchestrator would have been a no-op for the reporter.

`buildVideoStoryboard` funnels **six** distinct failures into one `return null`:

| | |
|---|---|
| `:6200` | non-finite / zero duration, or zero `videoWidth`/`videoHeight` |
| `:6214` | no 2D context |
| `:6251` | zero painted frames after the seek attempts |
| `:6254` | `toBlob` returned null (a tainted canvas encodes to nothing) |
| `:6269` | decode / seek / metadata failure |
| — | `loadedmetadata` timeout |

Both call sites turn that into a note saying a sheet could not be built and that **the panel is not told which**.

**That note is currently correct, and there is a test asserting it** — `media-preview.test.mjs`: *"a sampler that returns nothing degrades with a remedy and NO invented cause"*, whose comment reads *"Naming one of them is a diagnosis nothing made."*

That is right about the interface, not about the world: the builder knows exactly which branch it took and throws the information away. So the fix is **not** to make the reply guess harder — it is to have the builder report the reason, and only then let the reply name it. The existing test's premise stops holding at that point, and it should become: name the cause when one is supplied, still invent nothing when it is not.

Deliberately in scope: the reason only. No change to the timeout budgets, and no attempt to make VP9 decode where it currently cannot.