### PR TITLE
fix(1448): the workflow-list refresh reports what it OBSERVED, not that it was asked for

### DIFF
--- a/browser_tests/unit/open-workflow-not-found.test.mjs
+++ b/browser_tests/unit/open-workflow-not-found.test.mjs
@@ -23,10 +23,15 @@ import {
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), "../..");
 const msg = (o) => openWorkflowNotFoundMessage({ path: "video_minimax_low_vram.json", ...o });
 
-test("#1448 a re-read that HAPPENED is stated as such", () => {
-  const t = msg({ refresh: "ok" });
-  assert.match(t, /list WAS re-read/);
-  assert.match(t, /still does not contain it/);
+test("#1448 r2 a CHANGED list is reported as a change, NOT as a successful read", () => {
+  // The claim this round had to retreat from. "The list changed" is an
+  // observation; "the server read succeeded" is a causal claim the panel cannot
+  // make — another writer can move the store while the sync silently fails.
+  const t = msg({ refresh: "changed" });
+  assert.match(t, /the list DID change/);
+  assert.match(t, /still does not contain a match/);
+  assert.doesNotMatch(t, /WAS re-read from the server/, "no causal claim about the read");
+  assert.match(t, /cannot see whether the server read itself succeeded/i);
 });
 
 test("#1448 r2 the re-read verdict is DECIDED from the store, both directions", () => {
@@ -40,29 +45,47 @@ test("#1448 r2 the re-read verdict is DECIDED from the store, both directions", 
   // Nothing moved: same counts, same array identities → cannot confirm.
   assert.equal(
     classifyWorkflowRefresh(fp("1/1", openA, savedA), fp("1/1", openA, savedA)),
-    "unconfirmed",
+    "unchanged",
   );
   // A count changed (the 109 → 107 case) → proof it ran.
   assert.equal(
     classifyWorkflowRefresh(fp("1/109", openA, savedA), fp("1/107", openA, savedA)),
-    "ok",
+    "changed",
   );
-  // Counts identical but the arrays were REPLACED → also proof it ran. Dropping
+  // Counts identical but the arrays were REPLACED → still a change. Dropping
   // this half is a mutation that survived a count-only comparison.
   assert.equal(
     classifyWorkflowRefresh(fp("1/1", openA, savedA), fp("1/1", [{ path: "a" }], [{ path: "b" }])),
-    "ok",
+    "changed",
+  );
+  // ...but identity is IGNORED when the caller says it carries no information.
+  // A reactive getter handing back a fresh array per access would otherwise
+  // report "changed" on every refresh — the original bug in new wording.
+  assert.equal(
+    classifyWorkflowRefresh(
+      fp("1/1", openA, savedA),
+      fp("1/1", [{ path: "a" }], [{ path: "b" }]),
+      { identityMeaningful: false },
+    ),
+    "unchanged",
+  );
+  // A real count move is still honoured with identity disabled.
+  assert.equal(
+    classifyWorkflowRefresh(fp("1/109", openA, savedA), fp("1/107", openA, savedA), {
+      identityMeaningful: false,
+    }),
+    "changed",
   );
   // A missing sample claims nothing rather than defaulting to confident.
-  assert.equal(classifyWorkflowRefresh(null, fp("1/1", openA, savedA)), "unconfirmed");
-  assert.equal(classifyWorkflowRefresh(fp("1/1", openA, savedA), null), "unconfirmed");
+  assert.equal(classifyWorkflowRefresh(null, fp("1/1", openA, savedA)), "unchanged");
+  assert.equal(classifyWorkflowRefresh(fp("1/1", openA, savedA), null), "unchanged");
 });
 
 test("#1448 r2 an UNCONFIRMED re-read never claims the list was refreshed", () => {
   // The state that did not exist before, and the one that is now almost always
   // right: syncWorkflows resolves whether or not the read succeeded, so unless
   // the store visibly changed we cannot say it happened.
-  const t = msg({ refresh: "unconfirmed" });
+  const t = msg({ refresh: "unchanged" });
   assert.doesNotMatch(t, /WAS re-read/, "it must not assert what it could not observe");
   assert.match(t, /cannot confirm/i);
   // …and it must not let the caller conclude the file is missing.
@@ -71,10 +94,13 @@ test("#1448 r2 an UNCONFIRMED re-read never claims the list was refreshed", () =
   assert.match(t, /swallows its own\s+errors/i);
 });
 
-test("#1448 r2 a CONFIRMED re-read still says so, and says why it is confident", () => {
-  const t = msg({ refresh: "ok" });
-  assert.match(t, /WAS re-read/);
-  assert.match(t, /the list changed/, "the claim now carries the evidence for itself");
+test("#1448 r2 NO refresh state claims the server read succeeded", () => {
+  // The invariant across the whole surface, not one branch of it. Every earlier
+  // version of this fix leaked a causal claim into at least one state.
+  for (const refresh of ["changed", "unchanged", "unavailable", "not-needed"]) {
+    const t = msg({ refresh });
+    assert.doesNotMatch(t, /WAS re-read from the server/, refresh);
+  }
 });
 
 test("#1448 a frontend with no sync method does NOT claim a refresh", () => {
@@ -99,7 +125,7 @@ test("#1448 a FAILED re-read says so, and that it is not evidence of absence", (
 test("#1448 it no longer asserts the file is outside the workflows folder", () => {
   // The remedy that misled the reporter. panel_load_workflow is still offered — it IS
   // the right tool for a path elsewhere — but as a branch, not as a diagnosis.
-  for (const refresh of ["ok", "unavailable", "not-needed", "failed: x"]) {
+  for (const refresh of ["changed", "unchanged", "unavailable", "not-needed", "failed: x"]) {
     const t = msg({ refresh });
     assert.doesNotMatch(t, /For a file outside the workflows folder/, refresh);
     assert.match(t, /If the file IS in the workflows/, refresh);
@@ -110,7 +136,7 @@ test("#1448 it no longer asserts the file is outside the workflows folder", () =
 test("#1448 it shows the selector SHAPES, which are not guessable from outside", () => {
   // Measured on the live rig: `filename` carries no extension while `key` does, and
   // `path` is folder-qualified. A caller cannot infer that, so the sample shows it.
-  const t = msg({ refresh: "ok", known: ["workflows/Anima Wojak Batch.json"] });
+  const t = msg({ refresh: "changed", known: ["workflows/Anima Wojak Batch.json"] });
   assert.match(t, /workflows\/Anima Wojak Batch\.json/);
   assert.match(t, /bare name with or without "\.json"/);
 });
@@ -133,7 +159,7 @@ test("#1448 the sample is only PERSISTED records, and is bounded", () => {
 });
 
 test("#1448 with no known records it still gives a usable message", () => {
-  const t = msg({ refresh: "ok", known: [] });
+  const t = msg({ refresh: "changed", known: [] });
   // Case-insensitive: a control mutation capitalising the leading word killed the
   // strict form. The property is that the refusal names the selector it was given.
   assert.match(t, /no workflow matching "video_minimax_low_vram\.json"/i);
@@ -176,8 +202,16 @@ test("#1448 WIRING: the caller records the outcome instead of assuming one", () 
   assert.match(panel, /const after = fingerprintStore\(\);/, "...and AFTER the re-read");
   assert.match(
     panel,
-    /refresh = classifyWorkflowRefresh\(before, after\);/,
+    /refresh = classifyWorkflowRefresh\(before, after, \{ identityMeaningful \}\);/,
     "the verdict comes from the shared decision, not an inline guess",
+  );
+  // The fresh-getter probe: two samples with NOTHING between them. Without it,
+  // a store that materialises a new array per access reports "changed" every
+  // time and the original bug returns in new wording (review, round 2).
+  assert.match(panel, /const control = fingerprintStore\(\);/, "identity is calibrated first");
+  assert.match(
+    panel,
+    /const identityMeaningful =\s*control\.open === before\.open && control\.saved === before\.saved;/,
   );
   // The sample must be taken AFTER the refresh (codex review). A successful re-read
   // removes stale entries — measured 109 -> 107 on a live rig — so a snapshot taken

--- a/browser_tests/unit/open-workflow-not-found.test.mjs
+++ b/browser_tests/unit/open-workflow-not-found.test.mjs
@@ -15,6 +15,7 @@ import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 import {
+  classifyWorkflowRefresh,
   knownSelectorSample,
   openWorkflowNotFoundMessage,
 } from "../../web/js/lib/open-workflow-not-found.js";
@@ -26,6 +27,54 @@ test("#1448 a re-read that HAPPENED is stated as such", () => {
   const t = msg({ refresh: "ok" });
   assert.match(t, /list WAS re-read/);
   assert.match(t, /still does not contain it/);
+});
+
+test("#1448 r2 the re-read verdict is DECIDED from the store, both directions", () => {
+  // Mutation found this gap: the message tests and the source-text wiring test
+  // could both pass while the comparison itself was inverted or halved. The
+  // decision lives in lib/ precisely so it can be driven here.
+  const openA = [{ path: "a" }];
+  const savedA = [{ path: "b" }];
+  const fp = (counts, open, saved) => ({ counts, open, saved });
+
+  // Nothing moved: same counts, same array identities → cannot confirm.
+  assert.equal(
+    classifyWorkflowRefresh(fp("1/1", openA, savedA), fp("1/1", openA, savedA)),
+    "unconfirmed",
+  );
+  // A count changed (the 109 → 107 case) → proof it ran.
+  assert.equal(
+    classifyWorkflowRefresh(fp("1/109", openA, savedA), fp("1/107", openA, savedA)),
+    "ok",
+  );
+  // Counts identical but the arrays were REPLACED → also proof it ran. Dropping
+  // this half is a mutation that survived a count-only comparison.
+  assert.equal(
+    classifyWorkflowRefresh(fp("1/1", openA, savedA), fp("1/1", [{ path: "a" }], [{ path: "b" }])),
+    "ok",
+  );
+  // A missing sample claims nothing rather than defaulting to confident.
+  assert.equal(classifyWorkflowRefresh(null, fp("1/1", openA, savedA)), "unconfirmed");
+  assert.equal(classifyWorkflowRefresh(fp("1/1", openA, savedA), null), "unconfirmed");
+});
+
+test("#1448 r2 an UNCONFIRMED re-read never claims the list was refreshed", () => {
+  // The state that did not exist before, and the one that is now almost always
+  // right: syncWorkflows resolves whether or not the read succeeded, so unless
+  // the store visibly changed we cannot say it happened.
+  const t = msg({ refresh: "unconfirmed" });
+  assert.doesNotMatch(t, /WAS re-read/, "it must not assert what it could not observe");
+  assert.match(t, /cannot confirm/i);
+  // …and it must not let the caller conclude the file is missing.
+  assert.match(t, /cannot treat the absence as proof|not.*proof the file is missing/i);
+  // The reason the panel is blind here is worth saying once, in place.
+  assert.match(t, /swallows its own\s+errors/i);
+});
+
+test("#1448 r2 a CONFIRMED re-read still says so, and says why it is confident", () => {
+  const t = msg({ refresh: "ok" });
+  assert.match(t, /WAS re-read/);
+  assert.match(t, /the list changed/, "the claim now carries the evidence for itself");
 });
 
 test("#1448 a frontend with no sync method does NOT claim a refresh", () => {
@@ -95,11 +144,41 @@ test("#1448 WIRING: the caller records the outcome instead of assuming one", () 
   // The behavioural tests cannot see the call site, and the defect WAS the call site:
   // a perfect message still lies if the caller passes a refresh state it never checked.
   const panel = readFileSync(join(ROOT, "web/js/comfyui-mcp-panel.js"), "utf8");
-  assert.match(panel, /import \{\s*knownSelectorSample,\s*openWorkflowNotFoundMessage,\s*\} from "\.\/lib\/open-workflow-not-found\.js";/);
+  // Members required, not an exact list: pinning the whole specifier meant that
+  // ADDING an import broke this test for no reason, which is churn rather than
+  // coverage. What matters is that each name comes from this module.
+  const spec = panel.match(
+    /import \{([\s\S]*?)\} from "\.\/lib\/open-workflow-not-found\.js";/,
+  );
+  assert.ok(spec, "the panel must import from lib/open-workflow-not-found.js");
+  for (const name of [
+    "knownSelectorSample",
+    "openWorkflowNotFoundMessage",
+    "classifyWorkflowRefresh",
+  ]) {
+    assert.ok(spec[1].includes(name), `the panel must import ${name} from that module`);
+  }
   // Every branch the refresh can take must be reachable from the call site.
   assert.match(panel, /refresh = "unavailable"/, "a frontend without syncWorkflows");
-  assert.match(panel, /refresh = "ok"/, "a successful re-read");
   assert.match(panel, /refresh = `failed: \$\{err\?\.message \?\? err\}`/, "a thrown re-read");
+  // #1448 r2 — "ok" must be EARNED, not assigned. This used to pin the literal
+  // `refresh = "ok"`, which was satisfied by the unconditional assignment that
+  // was the defect: syncWorkflows resolves even when the re-read failed, so
+  // every refusal claimed the list had been re-read. Pin the discrimination
+  // instead — both outcomes present, and the store observed to decide between
+  // them.
+  assert.doesNotMatch(
+    panel,
+    /await s\.syncWorkflows\(\);\s*\n\s*refresh = "ok";/,
+    "an unconditional 'ok' after the call is exactly the bug",
+  );
+  assert.match(panel, /const before = fingerprintStore\(\);/, "the store is sampled BEFORE");
+  assert.match(panel, /const after = fingerprintStore\(\);/, "...and AFTER the re-read");
+  assert.match(
+    panel,
+    /refresh = classifyWorkflowRefresh\(before, after\);/,
+    "the verdict comes from the shared decision, not an inline guess",
+  );
   // The sample must be taken AFTER the refresh (codex review). A successful re-read
   // removes stale entries — measured 109 -> 107 on a live rig — so a snapshot taken
   // before it can offer a workflow that no longer exists as an example.

--- a/browser_tests/unit/open-workflow-not-found.test.mjs
+++ b/browser_tests/unit/open-workflow-not-found.test.mjs
@@ -65,17 +65,39 @@ test("#1448 r2 the re-read verdict is DECIDED from the store, both directions", 
     classifyWorkflowRefresh(
       fp("1/1", openA, savedA),
       fp("1/1", [{ path: "a" }], [{ path: "b" }]),
-      { identityMeaningful: false },
+      { openIdentityMeaningful: false, savedIdentityMeaningful: false },
     ),
     "unchanged",
   );
   // A real count move is still honoured with identity disabled.
   assert.equal(
     classifyWorkflowRefresh(fp("1/109", openA, savedA), fp("1/107", openA, savedA), {
-      identityMeaningful: false,
+      openIdentityMeaningful: false,
+      savedIdentityMeaningful: false,
     }),
     "changed",
   );
+  // PER-LIST calibration: one fresh getter must not blind us to the other list.
+  // A single all-or-nothing flag threw away the stable list's signal (round 3).
+  assert.equal(
+    classifyWorkflowRefresh(
+      fp("1/1", openA, savedA),
+      fp("1/1", [{ path: "a" }], [{ path: "b" }]),
+      { openIdentityMeaningful: false, savedIdentityMeaningful: true },
+    ),
+    "changed",
+    "saved-list identity still counts when only the open list is fresh",
+  );
+  assert.equal(
+    classifyWorkflowRefresh(
+      fp("1/1", openA, savedA),
+      fp("1/1", [{ path: "a" }], savedA),
+      { openIdentityMeaningful: false, savedIdentityMeaningful: true },
+    ),
+    "unchanged",
+    "and the fresh list alone still proves nothing",
+  );
+
   // A missing sample claims nothing rather than defaulting to confident.
   assert.equal(classifyWorkflowRefresh(null, fp("1/1", openA, savedA)), "unchanged");
   assert.equal(classifyWorkflowRefresh(fp("1/1", openA, savedA), null), "unchanged");
@@ -202,17 +224,17 @@ test("#1448 WIRING: the caller records the outcome instead of assuming one", () 
   assert.match(panel, /const after = fingerprintStore\(\);/, "...and AFTER the re-read");
   assert.match(
     panel,
-    /refresh = classifyWorkflowRefresh\(before, after, \{ identityMeaningful \}\);/,
+    /refresh = classifyWorkflowRefresh\(before, after, \{\s*openIdentityMeaningful,\s*savedIdentityMeaningful,\s*\}\);/,
     "the verdict comes from the shared decision, not an inline guess",
   );
   // The fresh-getter probe: two samples with NOTHING between them. Without it,
   // a store that materialises a new array per access reports "changed" every
   // time and the original bug returns in new wording (review, round 2).
   assert.match(panel, /const control = fingerprintStore\(\);/, "identity is calibrated first");
-  assert.match(
-    panel,
-    /const identityMeaningful =\s*control\.open === before\.open && control\.saved === before\.saved;/,
-  );
+  // PER LIST — a single flag would disable identity for both the moment either
+  // getter is fresh, discarding a real signal from the stable one (round 3).
+  assert.match(panel, /const openIdentityMeaningful = control\.open === before\.open;/);
+  assert.match(panel, /const savedIdentityMeaningful = control\.saved === before\.saved;/);
   // The sample must be taken AFTER the refresh (codex review). A successful re-read
   // removes stale entries — measured 109 -> 107 on a live rig — so a snapshot taken
   // before it can offer a workflow that no longer exists as an example.

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -258,6 +258,7 @@ import {
   missingNodeRunRefusal,
 } from "./lib/missing-node-preflight.js";
 import {
+  classifyWorkflowRefresh,
   knownSelectorSample,
   openWorkflowNotFoundMessage,
 } from "./lib/open-workflow-not-found.js";
@@ -13651,10 +13652,38 @@ const GRAPH_TOOL_EXECUTORS = {
       if (typeof s.syncWorkflows !== "function") {
         refresh = "unavailable";
       } else {
+        // #1448 r2 — "ok" must mean OBSERVED, not "the call returned".
+        //
+        // `syncWorkflows` is a VueUse `useAsyncState` execute wrapper, and the
+        // workflow store builds it with only `{immediate:false}` — so
+        // `throwError` is undefined, a failed re-read is caught into a private
+        // `error` ref, and execute RESOLVES NORMALLY. The store never exposes
+        // that ref. So the catch below cannot fire on a real frontend, and the
+        // previous version set "ok" unconditionally and told the agent "the
+        // workflow list WAS re-read from the server first" — a claim stronger
+        // than the wording this issue was filed about, and one nothing checked.
+        //
+        // What IS observable is the store itself. A genuine re-read rebuilds the
+        // list: entries appear, disappear (measured on a live rig: 109 → 107),
+        // or the array identity changes. Seeing any of that PROVES the read ran.
+        // Seeing none of it does not prove failure — an unchanged directory
+        // re-reads to an identical list — so that case is reported as exactly
+        // what it is: unconfirmed.
+        const fingerprintStore = () => {
+          const open = s.openWorkflows ?? [];
+          const saved = s.workflows ?? [];
+          // Counts AND array identity: a rebuild usually replaces the arrays even
+          // when the contents happen to match. classifyWorkflowRefresh decides.
+          return { counts: `${open.length}/${saved.length}`, open, saved };
+        };
+        const before = fingerprintStore();
         try {
           await s.syncWorkflows();
-          refresh = "ok";
+          const after = fingerprintStore();
+          refresh = classifyWorkflowRefresh(before, after);
         } catch (err) {
+          // Kept for a frontend that DOES set throwError, and for a store that
+          // throws synchronously before ever reaching useAsyncState.
           refresh = `failed: ${err?.message ?? err}`;
           console.warn("[comfyui-mcp-panel] syncWorkflows failed:", err?.message ?? err);
         }

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -13676,11 +13676,20 @@ const GRAPH_TOOL_EXECUTORS = {
           // when the contents happen to match. classifyWorkflowRefresh decides.
           return { counts: `${open.length}/${saved.length}`, open, saved };
         };
+        // Is array IDENTITY informative on this frontend? A reactive getter that
+        // materialises a fresh array per access would make the identity test
+        // fire on every refresh, reporting "changed" unconditionally and putting
+        // the original bug back in new wording (review). Two reads with nothing
+        // between them answer it: if identity already differs, it carries no
+        // information and only counts are compared.
+        const control = fingerprintStore();
         const before = fingerprintStore();
+        const identityMeaningful =
+          control.open === before.open && control.saved === before.saved;
         try {
           await s.syncWorkflows();
           const after = fingerprintStore();
-          refresh = classifyWorkflowRefresh(before, after);
+          refresh = classifyWorkflowRefresh(before, after, { identityMeaningful });
         } catch (err) {
           // Kept for a frontend that DOES set throwError, and for a store that
           // throws synchronously before ever reaching useAsyncState.

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -13682,14 +13682,20 @@ const GRAPH_TOOL_EXECUTORS = {
         // the original bug back in new wording (review). Two reads with nothing
         // between them answer it: if identity already differs, it carries no
         // information and only counts are compared.
+        // Calibrated PER LIST: the store may expose one as a plain array and the
+        // other as a reactive getter, and a single flag would disable identity
+        // for both the moment either is fresh (review, round 2).
         const control = fingerprintStore();
         const before = fingerprintStore();
-        const identityMeaningful =
-          control.open === before.open && control.saved === before.saved;
+        const openIdentityMeaningful = control.open === before.open;
+        const savedIdentityMeaningful = control.saved === before.saved;
         try {
           await s.syncWorkflows();
           const after = fingerprintStore();
-          refresh = classifyWorkflowRefresh(before, after, { identityMeaningful });
+          refresh = classifyWorkflowRefresh(before, after, {
+            openIdentityMeaningful,
+            savedIdentityMeaningful,
+          });
         } catch (err) {
           // Kept for a frontend that DOES set throwError, and for a store that
           // throws synchronously before ever reaching useAsyncState.

--- a/web/js/lib/open-workflow-not-found.js
+++ b/web/js/lib/open-workflow-not-found.js
@@ -58,21 +58,24 @@ export function knownSelectorSample(records, limit = 3) {
  * "changed" or "unchanged". The caller's message must not upgrade either into a
  * statement about the server read.
  *
- * `identityMeaningful` is false when the store hands back a fresh array on every
- * access — the caller detects that by sampling twice with nothing in between —
- * in which case array identity carries no information and only counts are used.
+ * Identity is calibrated PER LIST, and separately, because the two need not
+ * behave alike: the store can expose one as a plain array and the other as a
+ * reactive getter that materialises a fresh array per access. A single
+ * all-or-nothing flag would disable identity for both the moment either one is
+ * fresh, throwing away a real signal from the stable list (review, round 2). The
+ * caller detects each by sampling twice with nothing in between.
  *
  * @param {{counts: string, open: unknown, saved: unknown}|null} before
  * @param {{counts: string, open: unknown, saved: unknown}|null} after
- * @param {{identityMeaningful?: boolean}} [opts]
+ * @param {{openIdentityMeaningful?: boolean, savedIdentityMeaningful?: boolean}} [opts]
  * @returns {"changed"|"unchanged"}
  */
 export function classifyWorkflowRefresh(before, after, opts = {}) {
   if (!before || !after) return "unchanged"; // nothing to compare — claim nothing
   if (before.counts !== after.counts) return "changed";
-  const identityMeaningful = opts.identityMeaningful !== false;
-  if (!identityMeaningful) return "unchanged";
-  return before.open !== after.open || before.saved !== after.saved ? "changed" : "unchanged";
+  const openMoved = opts.openIdentityMeaningful !== false && before.open !== after.open;
+  const savedMoved = opts.savedIdentityMeaningful !== false && before.saved !== after.saved;
+  return openMoved || savedMoved ? "changed" : "unchanged";
 }
 
 /**

--- a/web/js/lib/open-workflow-not-found.js
+++ b/web/js/lib/open-workflow-not-found.js
@@ -39,32 +39,40 @@ export function knownSelectorSample(records, limit = 3) {
 }
 
 /**
- * Did a workflow-list re-read demonstrably HAPPEN? (#1448 r2)
+ * What was OBSERVED about the workflow list across a re-read attempt (#1448 r2).
  *
- * `syncWorkflows` is a VueUse `useAsyncState` execute wrapper built without
- * `throwError`, so it resolves whether the read succeeded or failed and the
- * store never exposes the error. "The call returned" is therefore no evidence at
- * all, and treating it as evidence is what made every refusal claim the list had
- * been re-read.
+ * This deliberately says nothing about whether `syncWorkflows()` succeeded, and
+ * that restraint is the whole point. Two rounds of this fix tried to prove the
+ * read happened and both were wrong:
  *
- * What IS evidence is the store changing: a genuine re-read rebuilds the arrays,
- * so entries appear or disappear (measured on a live rig: 109 → 107) or the
- * array identity is replaced. Either proves it ran.
+ *   1. "the call resolved" — worthless. `syncWorkflows` is a VueUse
+ *      `useAsyncState` execute wrapper built without `throwError`, so a failed
+ *      read is caught into a private ref and execute resolves normally.
+ *   2. "the list changed, therefore the read worked" — a CAUSAL claim from a
+ *      CORRELATION (review). Another writer can change the store during the
+ *      await while the sync silently fails, and a reactive getter that
+ *      materialises a fresh array per access makes the identity test fire every
+ *      single time — which would restore the original bug wearing new wording.
  *
- * Seeing NEITHER proves nothing — an unchanged directory re-reads to an
- * identical list — hence "unconfirmed" rather than "failed". Lives here, out of
- * the DOM-bound panel module, so the decision is testable on its own; mutation
- * showed the message tests could not see it at all.
+ * So the verdict describes the LIST, which is the thing actually observed:
+ * "changed" or "unchanged". The caller's message must not upgrade either into a
+ * statement about the server read.
  *
- * @param {{counts: string, open: unknown, saved: unknown}} before
- * @param {{counts: string, open: unknown, saved: unknown}} after
- * @returns {"ok"|"unconfirmed"}
+ * `identityMeaningful` is false when the store hands back a fresh array on every
+ * access — the caller detects that by sampling twice with nothing in between —
+ * in which case array identity carries no information and only counts are used.
+ *
+ * @param {{counts: string, open: unknown, saved: unknown}|null} before
+ * @param {{counts: string, open: unknown, saved: unknown}|null} after
+ * @param {{identityMeaningful?: boolean}} [opts]
+ * @returns {"changed"|"unchanged"}
  */
-export function classifyWorkflowRefresh(before, after) {
-  if (!before || !after) return "unconfirmed"; // nothing to compare — claim nothing
-  const countsMoved = before.counts !== after.counts;
-  const arraysReplaced = before.open !== after.open || before.saved !== after.saved;
-  return countsMoved || arraysReplaced ? "ok" : "unconfirmed";
+export function classifyWorkflowRefresh(before, after, opts = {}) {
+  if (!before || !after) return "unchanged"; // nothing to compare — claim nothing
+  if (before.counts !== after.counts) return "changed";
+  const identityMeaningful = opts.identityMeaningful !== false;
+  if (!identityMeaningful) return "unchanged";
+  return before.open !== after.open || before.saved !== after.saved ? "changed" : "unchanged";
 }
 
 /**
@@ -85,10 +93,11 @@ export function classifyWorkflowRefresh(before, after) {
  */
 export function openWorkflowNotFoundMessage({ path, refresh, known = [] } = {}) {
   const refreshClause =
-    refresh === "ok"
-      ? `The workflow list WAS re-read from the server first (the list changed), and it still does ` +
-        `not contain it.`
-      : refresh === "unconfirmed"
+    refresh === "changed"
+      ? `A re-read of the workflow list was requested and the list DID change, and it still does ` +
+        `not contain a match. (The panel cannot see whether the server read itself succeeded — ` +
+        `this frontend's sync swallows its own errors — so this reports the list, not the read.)`
+      : refresh === "unchanged"
         ? `A re-read of the workflow list was requested and returned, but NOTHING in the list ` +
           `changed — so this panel cannot confirm the list was actually refreshed, and cannot ` +
           `treat the absence as proof the file is missing. (This frontend's sync swallows its own ` +

--- a/web/js/lib/open-workflow-not-found.js
+++ b/web/js/lib/open-workflow-not-found.js
@@ -39,23 +39,69 @@ export function knownSelectorSample(records, limit = 3) {
 }
 
 /**
+ * Did a workflow-list re-read demonstrably HAPPEN? (#1448 r2)
+ *
+ * `syncWorkflows` is a VueUse `useAsyncState` execute wrapper built without
+ * `throwError`, so it resolves whether the read succeeded or failed and the
+ * store never exposes the error. "The call returned" is therefore no evidence at
+ * all, and treating it as evidence is what made every refusal claim the list had
+ * been re-read.
+ *
+ * What IS evidence is the store changing: a genuine re-read rebuilds the arrays,
+ * so entries appear or disappear (measured on a live rig: 109 → 107) or the
+ * array identity is replaced. Either proves it ran.
+ *
+ * Seeing NEITHER proves nothing — an unchanged directory re-reads to an
+ * identical list — hence "unconfirmed" rather than "failed". Lives here, out of
+ * the DOM-bound panel module, so the decision is testable on its own; mutation
+ * showed the message tests could not see it at all.
+ *
+ * @param {{counts: string, open: unknown, saved: unknown}} before
+ * @param {{counts: string, open: unknown, saved: unknown}} after
+ * @returns {"ok"|"unconfirmed"}
+ */
+export function classifyWorkflowRefresh(before, after) {
+  if (!before || !after) return "unconfirmed"; // nothing to compare — claim nothing
+  const countsMoved = before.counts !== after.counts;
+  const arraysReplaced = before.open !== after.open || before.saved !== after.saved;
+  return countsMoved || arraysReplaced ? "ok" : "unconfirmed";
+}
+
+/**
  * The refusal, saying what was actually done.
  *
- * `refresh` is one of: "ok" (the list was re-read), "unavailable" (this frontend has
- * no syncWorkflows, so it never was), "not-needed", or "failed: <reason>".
+ * `refresh` is one of: "ok" (the re-read was OBSERVED to change the store),
+ * "unconfirmed" (the call resolved but nothing observable changed), "unavailable"
+ * (this frontend has no syncWorkflows, so it never was), "not-needed", or
+ * "failed: <reason>".
+ *
+ * "unconfirmed" exists because the previous three-way split collapsed to a single
+ * outcome in practice (#1448 r2): `syncWorkflows` is a VueUse `useAsyncState`
+ * execute wrapper built without `throwError`, so a failed re-read resolves
+ * normally and the panel cannot see it. Every refusal therefore claimed the list
+ * "WAS re-read" — a stronger assertion than the one this issue was filed about.
+ * The caller now proves the re-read by watching the store change, and says
+ * "unconfirmed" when it cannot.
  */
 export function openWorkflowNotFoundMessage({ path, refresh, known = [] } = {}) {
   const refreshClause =
     refresh === "ok"
-      ? `The workflow list WAS re-read from the server first, and it still does not contain it.`
-      : refresh === "unavailable"
-        ? `The list was NOT re-read: this ComfyUI frontend exposes no workflow-sync method, so a ` +
-          `file staged since the tab loaded may simply not be known yet. Reload the ComfyUI browser ` +
-          `tab and try again before concluding the file is missing.`
-        : typeof refresh === "string" && refresh.startsWith("failed")
-          ? `The re-read of the workflow list FAILED (${refresh.slice("failed: ".length)}), so this ` +
-            `is not evidence the file is absent — the list may simply be stale.`
-          : `The list was already current.`;
+      ? `The workflow list WAS re-read from the server first (the list changed), and it still does ` +
+        `not contain it.`
+      : refresh === "unconfirmed"
+        ? `A re-read of the workflow list was requested and returned, but NOTHING in the list ` +
+          `changed — so this panel cannot confirm the list was actually refreshed, and cannot ` +
+          `treat the absence as proof the file is missing. (This frontend's sync swallows its own ` +
+          `errors, so a silent failure looks exactly like a directory that did not change.) If the ` +
+          `file IS on disk, reload the ComfyUI browser tab and try again.`
+        : refresh === "unavailable"
+          ? `The list was NOT re-read: this ComfyUI frontend exposes no workflow-sync method, so a ` +
+            `file staged since the tab loaded may simply not be known yet. Reload the ComfyUI browser ` +
+            `tab and try again before concluding the file is missing.`
+          : typeof refresh === "string" && refresh.startsWith("failed")
+            ? `The re-read of the workflow list FAILED (${refresh.slice("failed: ".length)}), so this ` +
+              `is not evidence the file is absent — the list may simply be stale.`
+            : `The list was already current.`;
 
   const shape = known.length
     ? ` Saved workflows here are addressed as e.g. ${known.map((k) => `"${k}"`).join(", ")} — the ` +


### PR DESCRIPTION
Claims artokun/comfyui-mcp#1448 — specifically the half where the fix for it made the false claim **stronger**.

`panel_open_workflow` re-reads the workflow store when its first lookup misses, and records `refresh` as one of `not-needed` / `unavailable` / `ok` / `failed: …`. In practice it is **always `ok`** when the refusal fires:

- `not-needed` is set only when the first `find()` hits — in which case the open succeeds and no refusal is emitted.
- `unavailable` needs `typeof s.syncWorkflows !== "function"`, and it IS a function on comfyui_frontend_package 1.48.7.
- `failed:` is **unreachable**. `syncWorkflows` is a VueUse `useAsyncState` execute wrapper; the store constructs it with only `{immediate:false}`, so `throwError` is undefined and a failed re-read is caught, stored in a private `error` ref, and `execute` **resolves normally**. The store does not expose that ref, so the panel cannot see the failure at all.

So the refusal tells the agent *"The workflow list WAS re-read from the server first, and it still does not contain it"* — a stronger assertion than the "even after a refresh" wording this issue was filed about, and one the panel has no way to establish.

The fix is to report the OBSERVED effect: compare the store before and after, and only claim a re-read when something proves it happened. Otherwise say the re-read could not be confirmed.

**Not fixed here, and it should not close the issue:** the original defect — the lookup is a pure in-memory scan with no server-side existence check, so a file demonstrably on disk is still reported absent. That needs a `/userdata` probe and is a separate change.