### PR TITLE
fix(1448): ask the SERVER whether the workflow exists before refusing

### DIFF
--- a/browser_tests/unit/open-workflow-not-found.test.mjs
+++ b/browser_tests/unit/open-workflow-not-found.test.mjs
@@ -239,7 +239,11 @@ test("#1448 WIRING: the caller records the outcome instead of assuming one", () 
   // removes stale entries — measured 109 -> 107 on a live rig — so a snapshot taken
   // before it can offer a workflow that no longer exists as an example.
   assert.match(panel, /const known = knownSelectorSample\(\[\.\.\.\(s\?\.openWorkflows \?\? \[\]\), \.\.\.\(s\?\.workflows \?\? \[\]\)\]\);/);
-  assert.match(panel, /openWorkflowNotFoundMessage\(\{ path, refresh, known \}\)/);
+  // `disk` is required, not optional (#1448 — the half the reporter filed). Omitting
+  // it compiles and reads fine, and silently restores the defect: the refusal goes
+  // back to asserting absence from an in-memory scan that was MEASURED to lag disk in
+  // both directions.
+  assert.match(panel, /openWorkflowNotFoundMessage\(\{ path, refresh, known, disk \}\)/);
   const failSite = panel.slice(panel.indexOf("const known = knownSelectorSample"));
   assert.ok(
     failSite.indexOf("openWorkflowNotFoundMessage") < 400,

--- a/browser_tests/unit/workflow-disk-probe.test.mjs
+++ b/browser_tests/unit/workflow-disk-probe.test.mjs
@@ -1,0 +1,156 @@
+// comfyui-mcp#1448 — the half the reporter actually filed.
+//
+// The open lookup is a pure in-memory scan of the frontend's workflow store, so a
+// `.json` staged into user/default/workflows out-of-band reads as absent. Both
+// directions of that staleness were REPRODUCED on a live rig (ComfyUI 0.33.1 /
+// frontend 1.48.7), which is why the probe exists at all:
+//
+//   staged out-of-band, before syncWorkflows() → on disk YES, in store NO
+//   deleted out-of-band, before syncWorkflows() → on disk NO,  in store YES
+//
+// `GET /api/userdata?dir=workflows&recurse=true&split=false` answered 200 with a flat
+// array of strings relative to the workflows dir ("Anima Wojak Batch.json").
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  canonicalWorkflowPath,
+  classifyDiskProbe,
+  diskListingEntryFor,
+} from "../../web/js/lib/workflow-disk-probe.js";
+import { openWorkflowNotFoundMessage } from "../../web/js/lib/open-workflow-not-found.js";
+
+/** The measured listing shape. */
+const LISTING = [
+  "Anima Wojak Batch.json",
+  "Artokun Flow v1.json",
+  "video_minimax_low_vram.json",
+  "sub/Nested Thing.json",
+];
+
+test("#1448 the reporter's selector matches the file the server lists", () => {
+  assert.equal(diskListingEntryFor(LISTING, "video_minimax_low_vram.json"), "video_minimax_low_vram.json");
+});
+
+test("#1448 every selector form the store accepts also matches on disk", () => {
+  // A saved record answers to `workflows/X.json`, `X.json` and `X` — measured. The
+  // probe must not disagree with the store about what names a file, or it would
+  // report "not on disk" for a selector the store itself would have matched.
+  for (const sel of [
+    "video_minimax_low_vram.json",
+    "video_minimax_low_vram",
+    "workflows/video_minimax_low_vram.json",
+    "workflows\\video_minimax_low_vram.json",
+    "./video_minimax_low_vram.json",
+  ]) {
+    assert.equal(diskListingEntryFor(LISTING, sel), "video_minimax_low_vram.json", sel);
+  }
+});
+
+test("#1448 matching is case-insensitive — the reporter is on Windows", () => {
+  // A listing that differs only in case names the SAME file there. Answering "not on
+  // disk" for it would reproduce this bug with better wording.
+  assert.equal(diskListingEntryFor(LISTING, "VIDEO_MINIMAX_LOW_VRAM.JSON"), "video_minimax_low_vram.json");
+});
+
+test("#1448 a bare name finds a file in a SUBFOLDER", () => {
+  assert.equal(diskListingEntryFor(LISTING, "Nested Thing"), "sub/Nested Thing.json");
+});
+
+test("#1448 an AMBIGUOUS bare name is not resolved to a guess", () => {
+  // Two subfolders holding the same filename: picking one arbitrarily could send the
+  // caller to the wrong workflow, which is worse than the refusal being improved.
+  // First match wins only because the caller never acts on it — it is a hint in a
+  // message, and the message names the entry it found.
+  const ambiguous = ["a/Same.json", "b/Same.json"];
+  const hit = diskListingEntryFor(ambiguous, "Same");
+  assert.ok(hit === "a/Same.json" || hit === "b/Same.json");
+  // A FULLY-QUALIFIED selector is exact and must not fall back to the other folder.
+  assert.equal(diskListingEntryFor(ambiguous, "b/Same.json"), "b/Same.json");
+  assert.equal(diskListingEntryFor(ambiguous, "c/Same.json"), null);
+});
+
+test("#1448 a file genuinely absent answers null", () => {
+  assert.equal(diskListingEntryFor(LISTING, "not-here.json"), null);
+});
+
+test("#1448 canonicalWorkflowPath rejects junk instead of coercing it", () => {
+  for (const junk of [null, undefined, 42, "", "   ", {}, []]) {
+    assert.equal(canonicalWorkflowPath(junk), null, String(junk));
+  }
+});
+
+// ── FAIL OPEN. Every previous round of this issue shipped a claim stronger than
+//    its evidence; a probe that turned a stale list into a confident "your file does
+//    not exist" would be the same bug with more authority.
+
+test("#1448 an unreachable or unhappy /userdata answers UNKNOWN, never absent", () => {
+  for (const res of [
+    null,
+    undefined,
+    { ok: false, status: 404 },
+    { ok: false, status: 500 },
+    { ok: true, body: "not an array" },
+    { ok: true, body: { files: [] } },
+    { ok: true, body: null },
+  ]) {
+    assert.equal(classifyDiskProbe(res, "x.json").onDisk, "unknown", JSON.stringify(res));
+  }
+});
+
+test("#1448 a good response decides both ways", () => {
+  assert.deepEqual(classifyDiskProbe({ ok: true, body: LISTING }, "video_minimax_low_vram.json"), {
+    onDisk: "yes",
+    entry: "video_minimax_low_vram.json",
+  });
+  assert.deepEqual(classifyDiskProbe({ ok: true, body: LISTING }, "nope.json"), { onDisk: "no" });
+  // An EMPTY folder is a real answer, not an inconclusive one.
+  assert.deepEqual(classifyDiskProbe({ ok: true, body: [] }, "nope.json"), { onDisk: "no" });
+});
+
+// ── The message the probe exists to change ─────────────────────────────────────
+
+test("#1448 ON DISK produces a different refusal entirely — reload, not rename", () => {
+  const t = openWorkflowNotFoundMessage({
+    path: "video_minimax_low_vram.json",
+    refresh: "unchanged",
+    known: ["workflows/Other.json"],
+    disk: { onDisk: "yes", entry: "video_minimax_low_vram.json" },
+  });
+  assert.match(t, /IS on disk in the workflows folder/);
+  assert.match(t, /RELOAD THE COMFYUI BROWSER TAB/);
+  assert.match(t, /The file is not missing/);
+  // It must NOT tell them to check the name — that is what sent the reporter hunting
+  // for a file that was exactly where they left it.
+  assert.doesNotMatch(t, /check the name matches exactly/);
+  assert.doesNotMatch(t, /no workflow matching/);
+});
+
+test("#1448 NOT on disk finally gives the refusal EVIDENCE for its claim", () => {
+  const t = openWorkflowNotFoundMessage({
+    path: "typo.json",
+    refresh: "changed",
+    disk: { onDisk: "no" },
+  });
+  assert.match(t, /no workflow matching "typo\.json"/);
+  assert.match(t, /workflows folder on disk does NOT contain it either/);
+  assert.match(t, /not a stale-list problem/);
+});
+
+test("#1448 an UNKNOWN probe weakens the claim rather than strengthening it", () => {
+  const t = openWorkflowNotFoundMessage({
+    path: "x.json",
+    refresh: "changed",
+    disk: { onDisk: "unknown", why: "HTTP 404" },
+  });
+  assert.match(t, /could not be asked whether the file is on disk \(HTTP 404\)/);
+  assert.match(t, /not by itself proof the file is missing/);
+});
+
+test("#1448 with NO probe result the message is exactly what it was before", () => {
+  // The fail-open contract at the message layer: an omitted probe must not add a
+  // clause, so a caller that cannot probe is no worse off than today.
+  const before = openWorkflowNotFoundMessage({ path: "x.json", refresh: "changed" });
+  assert.doesNotMatch(before, /on disk/i);
+  assert.match(before, /no workflow matching "x\.json"/);
+});

--- a/browser_tests/unit/workflow-disk-probe.test.mjs
+++ b/browser_tests/unit/workflow-disk-probe.test.mjs
@@ -57,17 +57,36 @@ test("#1448 a bare name finds a file in a SUBFOLDER", () => {
   assert.equal(diskListingEntryFor(LISTING, "Nested Thing"), "sub/Nested Thing.json");
 });
 
-test("#1448 an AMBIGUOUS bare name is not resolved to a guess", () => {
-  // Two subfolders holding the same filename: picking one arbitrarily could send the
-  // caller to the wrong workflow, which is worse than the refusal being improved.
-  // First match wins only because the caller never acts on it — it is a hint in a
-  // message, and the message names the entry it found.
+test("#1448 an AMBIGUOUS bare name is REPORTED, never resolved to a guess", () => {
+  // Review, P1 — and this test previously blessed the defect. Returning the first
+  // base-name hit made the refusal say the requested file "IS on disk" while naming a
+  // file the caller may not have meant, and prescribing a reload that would not help.
+  // The comment claimed it was "deliberately not resolved to a guess" while the code
+  // did exactly that.
   const ambiguous = ["a/Same.json", "b/Same.json"];
-  const hit = diskListingEntryFor(ambiguous, "Same");
-  assert.ok(hit === "a/Same.json" || hit === "b/Same.json");
-  // A FULLY-QUALIFIED selector is exact and must not fall back to the other folder.
+  assert.equal(diskListingEntryFor(ambiguous, "Same"), null, "no single answer exists");
+  const verdict = classifyDiskProbe({ ok: true, body: ambiguous }, "Same");
+  assert.equal(verdict.onDisk, "ambiguous");
+  assert.deepEqual(verdict.candidates, ["a/Same.json", "b/Same.json"]);
+
+  // A FULLY-QUALIFIED selector names one file even when the bare name fans out.
   assert.equal(diskListingEntryFor(ambiguous, "b/Same.json"), "b/Same.json");
+  assert.equal(classifyDiskProbe({ ok: true, body: ambiguous }, "b/Same.json").onDisk, "yes");
   assert.equal(diskListingEntryFor(ambiguous, "c/Same.json"), null);
+  assert.equal(classifyDiskProbe({ ok: true, body: ambiguous }, "c/Same.json").onDisk, "no");
+});
+
+test("#1448 the ambiguous refusal lists the candidates and how to disambiguate", () => {
+  const t = openWorkflowNotFoundMessage({
+    path: "Same",
+    refresh: "changed",
+    disk: { onDisk: "ambiguous", candidates: ["a/Same.json", "b/Same.json"] },
+  });
+  assert.match(t, /is ambiguous/);
+  assert.match(t, /"a\/Same\.json", "b\/Same\.json"/);
+  assert.match(t, /Qualify it with the subfolder/);
+  // It must not tell them to reload — the list is not the problem here.
+  assert.doesNotMatch(t, /RELOAD THE COMFYUI BROWSER TAB/);
 });
 
 test("#1448 a file genuinely absent answers null", () => {
@@ -153,4 +172,45 @@ test("#1448 with NO probe result the message is exactly what it was before", () 
   const before = openWorkflowNotFoundMessage({ path: "x.json", refresh: "changed" });
   assert.doesNotMatch(before, /on disk/i);
   assert.match(before, /no workflow matching "x\.json"/);
+});
+
+// ── WIRING. The lib can be perfect and never called (mutation found exactly that:
+//    replacing the fetch with `undefined` killed nothing, because every failure mode
+//    fails open to the same "unknown" the absent call produces).
+
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const PANEL = readFileSync(
+  join(dirname(fileURLToPath(import.meta.url)), "../../web/js/comfyui-mcp-panel.js"),
+  "utf8",
+).replace(/\r\n/g, "\n");
+
+test("#1448 wiring: the refusal path actually ASKS the server", () => {
+  assert.match(
+    PANEL,
+    /api\.fetchApi\("\/userdata\?dir=workflows&recurse=true&split=false"\)/,
+    "the probe must call the listing endpoint — a fail-open probe that never runs is invisible",
+  );
+  assert.match(PANEL, /classifyDiskProbe\(/, "and classify its answer");
+});
+
+test("#1448 wiring: the probe is BOUNDED, so a hung /userdata cannot eat the refusal", () => {
+  // Review, P1: fetchApi + .json() had no deadline. A server that accepts the request
+  // and never answers would hang panel_open_workflow forever — a wrong message
+  // replaced by no message.
+  const site = PANEL.slice(PANEL.indexOf("ASK THE SERVER before asserting"));
+  assert.match(site.slice(0, 1800), /withTimeout\(/, "the probe runs under a wall-clock bound");
+  assert.match(PANEL, /const WORKFLOW_DISK_PROBE_MS = \d+;/, "with a named bound");
+  assert.match(site.slice(0, 2400), /onDisk: "unknown", why: `no answer within/, "timeout fails OPEN");
+});
+
+test("#1448 wiring: a target that appears WHILE the probe runs is opened, not refused", () => {
+  // Review, P2: the probe added an await to a path that had none, widening the window
+  // for another sync to land the target in the store. Refusing after that would be a
+  // verdict that went stale while it was being proven.
+  const site = PANEL.slice(PANEL.indexOf("ASK THE SERVER before asserting"));
+  assert.match(site.slice(0, 2600), /const late = find\(\);/);
+  assert.match(site.slice(0, 2700), /if \(late\) \{\s*\n\s*target = late;/);
 });

--- a/browser_tests/unit/workflow-disk-probe.test.mjs
+++ b/browser_tests/unit/workflow-disk-probe.test.mjs
@@ -190,7 +190,7 @@ const PANEL = readFileSync(
 test("#1448 wiring: the refusal path actually ASKS the server", () => {
   assert.match(
     PANEL,
-    /api\.fetchApi\("\/userdata\?dir=workflows&recurse=true&split=false"\)/,
+    /api\.fetchApi\("\/userdata\?dir=workflows&recurse=true&split=false",/,
     "the probe must call the listing endpoint — a fail-open probe that never runs is invisible",
   );
   assert.match(PANEL, /classifyDiskProbe\(/, "and classify its answer");
@@ -201,9 +201,24 @@ test("#1448 wiring: the probe is BOUNDED, so a hung /userdata cannot eat the ref
   // and never answers would hang panel_open_workflow forever — a wrong message
   // replaced by no message.
   const site = PANEL.slice(PANEL.indexOf("ASK THE SERVER before asserting"));
-  assert.match(site.slice(0, 1800), /withTimeout\(/, "the probe runs under a wall-clock bound");
+  assert.match(site.slice(0, 2400), /withTimeout\(/, "the probe runs under a wall-clock bound");
   assert.match(PANEL, /const WORKFLOW_DISK_PROBE_MS = \d+;/, "with a named bound");
-  assert.match(site.slice(0, 2400), /onDisk: "unknown", why: `no answer within/, "timeout fails OPEN");
+  assert.match(site.slice(0, 3000), /onDisk: "unknown", why: `no answer within/, "timeout fails OPEN");
+});
+
+test("#1448 wiring: the timed-out request is ABORTED, not merely abandoned", () => {
+  // Review r2: withTimeout stops us WAITING but cannot cancel the request. A server
+  // that accepts and never answers would leave one live fetch per failed open, which
+  // accumulates until the browser's connection pool is exhausted.
+  //
+  // These two assertions were written once and SILENTLY DID NOT LAND — a scripted
+  // edit no-op'd, and both abort mutations then survived, which is the only reason
+  // the gap was visible at all. Re-added deliberately.
+  const site = PANEL.slice(PANEL.indexOf("ASK THE SERVER before asserting"), PANEL.length);
+  assert.match(site.slice(0, 2400), /probeCtrl\.abort\(\)/, "the pending request is cancelled");
+  assert.match(site.slice(0, 2400), /signal: probeCtrl\.signal/, "and the fetch honours the signal");
+  // The timer must be cleared on the happy path, or every refusal leaks one.
+  assert.match(site.slice(0, 3200), /clearTimeout\(probeTimer\)/, "the abort timer is cleared");
 });
 
 test("#1448 wiring: a target that appears WHILE the probe runs is opened, not refused", () => {
@@ -211,6 +226,6 @@ test("#1448 wiring: a target that appears WHILE the probe runs is opened, not re
   // for another sync to land the target in the store. Refusing after that would be a
   // verdict that went stale while it was being proven.
   const site = PANEL.slice(PANEL.indexOf("ASK THE SERVER before asserting"));
-  assert.match(site.slice(0, 2600), /const late = find\(\);/);
-  assert.match(site.slice(0, 2700), /if \(late\) \{\s*\n\s*target = late;/);
+  assert.match(site.slice(0, 3400), /const late = find\(\);/);
+  assert.match(site.slice(0, 3400), /if \(late\) \{\s*\n\s*target = late;/);
 });

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -278,6 +278,7 @@ import {
   knownSelectorSample,
   openWorkflowNotFoundMessage,
 } from "./lib/open-workflow-not-found.js";
+import { classifyDiskProbe } from "./lib/workflow-disk-probe.js";
 import { describeCanvasDrawFailure } from "./lib/canvas-draw-failure.js";
 import {
   describeQueuePromptChain,
@@ -13810,8 +13811,35 @@ const GRAPH_TOOL_EXECUTORS = {
       // (codex review). A successful re-read REMOVES stale entries — measured on a
       // live rig, the store went 109 to 107 — so a pre-refresh snapshot can offer a
       // workflow the re-read just deleted as an example of what is addressable.
+      // #1448 — ASK THE SERVER before asserting the file is not there. Everything
+      // above this line is an in-memory scan of the frontend's store, and that store
+      // was MEASURED to lag disk in both directions: a file staged into the
+      // workflows folder out-of-band is on disk and absent from the store until a
+      // sync lands, and a file deleted out-of-band stays in the store after it is
+      // gone. The panel cannot even tell whether the sync succeeded. So this is the
+      // only step in the path that can contradict a stale list with evidence.
+      //
+      // Runs only on the refusal path — never on a successful open — so the extra
+      // round-trip costs nothing in the normal case.
+      let disk;
+      try {
+        const reply = await api.fetchApi("/userdata?dir=workflows&recurse=true&split=false");
+        disk = classifyDiskProbe(
+          {
+            ok: reply?.ok === true,
+            status: reply?.status,
+            body: reply?.ok ? await reply.json() : undefined,
+          },
+          path,
+        );
+      } catch (err) {
+        // FAIL OPEN. Every earlier round of this issue shipped a message that claimed
+        // more than it knew; a probe that turned a stale list into a confident "your
+        // file does not exist" would be the same bug with more authority.
+        disk = { onDisk: "unknown", why: err?.message ?? String(err) };
+      }
       const known = knownSelectorSample([...(s?.openWorkflows ?? []), ...(s?.workflows ?? [])]);
-      throw failOpen(new Error(openWorkflowNotFoundMessage({ path, refresh, known })));
+      throw failOpen(new Error(openWorkflowNotFoundMessage({ path, refresh, known, disk })));
     }
     // #442 — an ALREADY-OPEN tab is repainted from its OWN in-memory buffer below,
     // never re-read from disk. If the .json changed on disk out-of-band the canvas

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -13829,10 +13829,18 @@ const GRAPH_TOOL_EXECUTORS = {
       // the request and never answers would hang panel_open_workflow forever, turning a
       // wrong message into no message at all. withTimeout never rejects, so the timeout
       // lands in the same fail-open "unknown" as every other failure.
+      // ABORTED, not merely abandoned (review r2). withTimeout stops us WAITING but
+      // cannot cancel the request, so a server that accepts and never answers would
+      // leave one live fetch per failed open, accumulating until the browser's
+      // connection pool is exhausted. Same idiom as fetchImageBytes.
+      const probeCtrl = new AbortController();
+      const probeTimer = setTimeout(() => probeCtrl.abort(), WORKFLOW_DISK_PROBE_MS);
       const disk = await withTimeout(
         (async () => {
           try {
-            const reply = await api.fetchApi("/userdata?dir=workflows&recurse=true&split=false");
+            const reply = await api.fetchApi("/userdata?dir=workflows&recurse=true&split=false", {
+              signal: probeCtrl.signal,
+            });
             return classifyDiskProbe(
               {
                 ok: reply?.ok === true,
@@ -13852,6 +13860,7 @@ const GRAPH_TOOL_EXECUTORS = {
         WORKFLOW_DISK_PROBE_MS,
         () => ({ onDisk: "unknown", why: `no answer within ${WORKFLOW_DISK_PROBE_MS}ms` }),
       );
+      clearTimeout(probeTimer);
       // The probe added an await to a path that previously had none, which widens the
       // window for another sync or command to land the target in the store (codex P2).
       // Re-check once: if it is addressable now, OPEN it rather than refusing with a

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -279,6 +279,9 @@ import {
   openWorkflowNotFoundMessage,
 } from "./lib/open-workflow-not-found.js";
 import { classifyDiskProbe } from "./lib/workflow-disk-probe.js";
+/** #1448 — wall-clock bound on the refusal-path /userdata probe. Generous: it only
+ *  ever runs when the open is already failing, and a slow answer still beats none. */
+const WORKFLOW_DISK_PROBE_MS = 4000;
 import { describeCanvasDrawFailure } from "./lib/canvas-draw-failure.js";
 import {
   describeQueuePromptChain,
@@ -13821,25 +13824,45 @@ const GRAPH_TOOL_EXECUTORS = {
       //
       // Runs only on the refusal path — never on a successful open — so the extra
       // round-trip costs nothing in the normal case.
-      let disk;
-      try {
-        const reply = await api.fetchApi("/userdata?dir=workflows&recurse=true&split=false");
-        disk = classifyDiskProbe(
-          {
-            ok: reply?.ok === true,
-            status: reply?.status,
-            body: reply?.ok ? await reply.json() : undefined,
-          },
-          path,
-        );
-      } catch (err) {
-        // FAIL OPEN. Every earlier round of this issue shipped a message that claimed
-        // more than it knew; a probe that turned a stale list into a confident "your
-        // file does not exist" would be the same bug with more authority.
-        disk = { onDisk: "unknown", why: err?.message ?? String(err) };
+      //
+      // BOUNDED (codex P1). The refusal path had no deadline: a /userdata that accepts
+      // the request and never answers would hang panel_open_workflow forever, turning a
+      // wrong message into no message at all. withTimeout never rejects, so the timeout
+      // lands in the same fail-open "unknown" as every other failure.
+      const disk = await withTimeout(
+        (async () => {
+          try {
+            const reply = await api.fetchApi("/userdata?dir=workflows&recurse=true&split=false");
+            return classifyDiskProbe(
+              {
+                ok: reply?.ok === true,
+                status: reply?.status,
+                body: reply?.ok ? await reply.json() : undefined,
+              },
+              path,
+            );
+          } catch (err) {
+            // FAIL OPEN. Every earlier round of this issue shipped a message that
+            // claimed more than it knew; a probe that turned a stale list into a
+            // confident "your file does not exist" would be that bug with more
+            // authority.
+            return { onDisk: "unknown", why: err?.message ?? String(err) };
+          }
+        })(),
+        WORKFLOW_DISK_PROBE_MS,
+        () => ({ onDisk: "unknown", why: `no answer within ${WORKFLOW_DISK_PROBE_MS}ms` }),
+      );
+      // The probe added an await to a path that previously had none, which widens the
+      // window for another sync or command to land the target in the store (codex P2).
+      // Re-check once: if it is addressable now, OPEN it rather than refusing with a
+      // verdict that went stale while we were proving it.
+      const late = find();
+      if (late) {
+        target = late;
+      } else {
+        const known = knownSelectorSample([...(s?.openWorkflows ?? []), ...(s?.workflows ?? [])]);
+        throw failOpen(new Error(openWorkflowNotFoundMessage({ path, refresh, known, disk })));
       }
-      const known = knownSelectorSample([...(s?.openWorkflows ?? []), ...(s?.workflows ?? [])]);
-      throw failOpen(new Error(openWorkflowNotFoundMessage({ path, refresh, known, disk })));
     }
     // #442 — an ALREADY-OPEN tab is repainted from its OWN in-memory buffer below,
     // never re-read from disk. If the .json changed on disk out-of-band the canvas

--- a/web/js/lib/open-workflow-not-found.js
+++ b/web/js/lib/open-workflow-not-found.js
@@ -94,7 +94,29 @@ export function classifyWorkflowRefresh(before, after, opts = {}) {
  * The caller now proves the re-read by watching the store change, and says
  * "unconfirmed" when it cannot.
  */
-export function openWorkflowNotFoundMessage({ path, refresh, known = [] } = {}) {
+export function openWorkflowNotFoundMessage({ path, refresh, known = [], disk } = {}) {
+  // #1448 (the half the reporter actually filed) — the SERVER was asked whether the
+  // file exists, and when it says yes this is a different failure entirely. Handled
+  // first and returned early: none of the list-refresh reasoning below applies once
+  // the file is known to be on disk, and appending it would bury the one fact that
+  // decides what the caller should do next.
+  //
+  // The two cases need OPPOSITE actions — reload the tab vs fix the name — and were
+  // previously the same sentence, which is why the reporter went looking for a file
+  // that was exactly where they left it.
+  if (disk?.onDisk === "yes") {
+    return (
+      `"${path}" IS on disk in the workflows folder (the server lists it as ` +
+      `"${disk.entry}"), but this ComfyUI frontend's workflow list does not contain it. ` +
+      `The file is not missing — the list is stale, and a re-read did not pick it up ` +
+      `(this frontend's sync swallows its own errors, so a silent failure is invisible ` +
+      `from here). RELOAD THE COMFYUI BROWSER TAB and try again; the entry appears once ` +
+      `the frontend re-reads the folder. To open it right now without reloading, use ` +
+      `panel_load_workflow path:<file> — it reads the file directly, though the tab ` +
+      `lands unsaved rather than as a saved library entry.`
+    );
+  }
+
   const refreshClause =
     refresh === "changed"
       ? `A re-read of the workflow list was requested and the list DID change, and it still does ` +
@@ -120,9 +142,21 @@ export function openWorkflowNotFoundMessage({ path, refresh, known = [] } = {}) 
       `same file also answers to its bare name with or without ".json".`
     : "";
 
+  // What the SERVER said, when it could be asked. "no" is the first evidence this
+  // refusal has ever had for the absence it asserts; "unknown" keeps the old,
+  // unevidenced wording rather than inventing a stronger claim (#1448).
+  const diskClause =
+    disk?.onDisk === "no"
+      ? ` The server was also asked directly: the workflows folder on disk does NOT contain ` +
+        `it either, so this is not a stale-list problem.`
+      : disk?.onDisk === "unknown"
+        ? ` The server could not be asked whether the file is on disk (${disk.why ?? "probe failed"}), ` +
+          `so absence from the list is not by itself proof the file is missing.`
+        : "";
+
   return (
-    `no workflow matching "${path}". ${refreshClause}${shape} If the file IS in the workflows ` +
-    `folder, check the name matches exactly (including case and any subfolder); if it is anywhere ` +
-    `else, load it with panel_load_workflow path:<file>, which reads any readable path.`
+    `no workflow matching "${path}". ${refreshClause}${diskClause}${shape} If the file IS in the ` +
+    `workflows folder, check the name matches exactly (including case and any subfolder); if it is ` +
+    `anywhere else, load it with panel_load_workflow path:<file>, which reads any readable path.`
   );
 }

--- a/web/js/lib/open-workflow-not-found.js
+++ b/web/js/lib/open-workflow-not-found.js
@@ -117,6 +117,18 @@ export function openWorkflowNotFoundMessage({ path, refresh, known = [], disk } 
     );
   }
 
+  // Several files on disk answer to that bare name. Naming one and telling the caller
+  // to reload would send them to a file they may not have meant (review, P1), so the
+  // refusal reports the fan-out and the action that resolves it.
+  if (disk?.onDisk === "ambiguous") {
+    const list = (disk.candidates ?? []).map((c) => `"${c}"`).join(", ");
+    return (
+      `"${path}" is ambiguous: the workflows folder on disk holds more than one file with ` +
+      `that name — ${list}. Qualify it with the subfolder (e.g. panel_open_workflow ` +
+      `path:"<subfolder>/<name>.json") so this opens the one you mean.`
+    );
+  }
+
   const refreshClause =
     refresh === "changed"
       ? `A re-read of the workflow list was requested and the list DID change, and it still does ` +

--- a/web/js/lib/workflow-disk-probe.js
+++ b/web/js/lib/workflow-disk-probe.js
@@ -79,25 +79,43 @@ function withoutJson(p) {
  * @returns {string|null} the listing entry that matched, or null.
  */
 export function diskListingEntryFor(listing, selector) {
-  if (!Array.isArray(listing)) return null;
+  const found = matchDiskListing(listing, selector);
+  return found.matches.length === 1 ? found.matches[0] : null;
+}
+
+/**
+ * The full result: every entry the selector could name.
+ *
+ * AMBIGUITY IS REPORTED, NOT RESOLVED (review, P1). An earlier version returned the
+ * first base-name hit and the refusal then said the requested file "IS on disk",
+ * naming a file the caller may not have meant and prescribing a reload that would not
+ * help. Worse, the comment claimed it was "deliberately not resolved to a guess"
+ * while the code did exactly that — the reassurance was the tell.
+ *
+ * An EXACT path match is unambiguous by construction and wins outright: `b/Same.json`
+ * names one file even when `a/Same.json` exists. Only a BARE name can fan out, and
+ * when it does the caller is told which folders hold it rather than being sent to one
+ * of them.
+ *
+ * @returns {{matches: string[], exact: boolean}}
+ */
+export function matchDiskListing(listing, selector) {
+  const none = { matches: [], exact: false };
+  if (!Array.isArray(listing)) return none;
   const want = canonicalWorkflowPath(selector);
-  if (!want) return null;
+  if (!want) return none;
   const wantNoExt = withoutJson(want).toLowerCase();
   const wantBase = wantNoExt.split("/").pop();
+  const qualified = wantNoExt.includes("/");
+  const byBase = [];
   for (const raw of listing) {
     const entry = canonicalWorkflowPath(typeof raw === "string" ? raw : raw?.[0]);
     if (!entry) continue;
     const entryNoExt = withoutJson(entry).toLowerCase();
-    if (entryNoExt === wantNoExt) return entry;
-    // A BARE name may address a file in a subfolder — but only when it is
-    // unambiguous. Deliberately not resolved here: two subfolders holding the same
-    // filename would make this pick one arbitrarily, and picking the wrong workflow
-    // is worse than the refusal this is trying to improve. Exact-path matches above
-    // are the only positive answer; the base-name case only ever DOWNGRADES to a
-    // hint, below.
-    if (entryNoExt.split("/").pop() === wantBase && !wantNoExt.includes("/")) return entry;
+    if (entryNoExt === wantNoExt) return { matches: [entry], exact: true };
+    if (!qualified && entryNoExt.split("/").pop() === wantBase) byBase.push(entry);
   }
-  return null;
+  return { matches: byBase, exact: false };
 }
 
 /**
@@ -119,6 +137,12 @@ export function classifyDiskProbe(response, selector) {
     return { onDisk: "unknown", why: response?.status ? `HTTP ${response.status}` : "no response" };
   }
   if (!Array.isArray(response.body)) return { onDisk: "unknown", why: "unrecognised listing shape" };
-  const entry = diskListingEntryFor(response.body, selector);
-  return entry ? { onDisk: "yes", entry } : { onDisk: "no" };
+  const { matches } = matchDiskListing(response.body, selector);
+  if (matches.length === 1) return { onDisk: "yes", entry: matches[0] };
+  // Several files share that bare name. Saying "yes" here would name one of them and
+  // tell the caller to reload for a file they may not have meant (review, P1); saying
+  // "no" would be false. The honest answer is that the name is under-specified, and
+  // the caller can act on it — qualify the folder.
+  if (matches.length > 1) return { onDisk: "ambiguous", candidates: matches };
+  return { onDisk: "no" };
 }

--- a/web/js/lib/workflow-disk-probe.js
+++ b/web/js/lib/workflow-disk-probe.js
@@ -1,0 +1,124 @@
+/**
+ * comfyui-mcp#1448 — ask the SERVER whether the workflow exists, before refusing.
+ *
+ * The open lookup is a pure in-memory scan of the frontend's workflow store. Nothing
+ * in the path ever asks the server, so a `.json` staged into `user/default/workflows/`
+ * out-of-band — unzipped from a CivitAI bundle, in the reporter's case — is reported
+ * as "no workflow matching" while sitting exactly where they said it was.
+ *
+ * ## Both halves of that staleness were REPRODUCED on a live rig
+ *
+ * ComfyUI 0.33.1 / frontend 1.48.7. A file written directly into the workflows folder,
+ * with the tab already open:
+ *
+ *   before syncWorkflows()  → on disk: YES, in store: NO   ← the reporter's failure
+ *   after  syncWorkflows()  → on disk: YES, in store: YES
+ *
+ * and the mirror, after deleting it out-of-band:
+ *
+ *   before syncWorkflows()  → on disk: NO,  in store: YES  ← the reporter's other
+ *   after  syncWorkflows()  → on disk: NO,  in store: NO      symptom, a listed
+ *                                                             workflow not on disk
+ *
+ * So the store lags disk in BOTH directions, and `/userdata` answers correctly at the
+ * exact moment the refusal is being written. On that build the sync did close the gap
+ * — which is why this does not claim to fix a lookup failure it could not observe.
+ * What it fixes is that the refusal can finally tell the two cases apart: a file that
+ * is genuinely absent, and a file that is on disk while the list is stale. Those need
+ * opposite actions from the caller and were previously the same sentence.
+ *
+ * The panel cannot detect a silently-failed sync (that store's `syncWorkflows` is a
+ * VueUse `useAsyncState` execute wrapper built without `throwError`, so a failed read
+ * resolves normally — see open-workflow-not-found.js). This probe is the only thing in
+ * the path that can contradict a stale list with evidence.
+ *
+ * ## Measured response shape
+ *
+ * `GET /api/userdata?dir=workflows&recurse=true&split=false` → 200, a flat array of
+ * STRINGS relative to the workflows dir, e.g. `"Anima Wojak Batch.json"`,
+ * `"sub/Nested.json"`. The bare `/userdata` prefix answers identically. `split=true`
+ * returns `[path, path]` pairs instead, which this does not use.
+ */
+
+/**
+ * Canonical form for comparing a workflow selector against a disk listing.
+ *
+ * Store records carry `workflows/X.json` while the listing returns `X.json`, so the
+ * prefix is stripped; separators are normalised because Windows answers with both.
+ * The extension is NOT stripped here — `hasSelector` compares with and without it,
+ * so `X`, `X.json` and `workflows/X.json` all resolve to the same file without this
+ * function having to guess which form it was handed.
+ */
+export function canonicalWorkflowPath(value) {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  return trimmed
+    .replace(/\\/g, "/")
+    .replace(/^\.\//, "")
+    .replace(/^workflows\//i, "")
+    .replace(/^\/+/, "");
+}
+
+/** The same value without a trailing `.json`, for extension-insensitive matching. */
+function withoutJson(p) {
+  return p.replace(/\.json$/i, "");
+}
+
+/**
+ * Does the server's listing contain this selector?
+ *
+ * Matches the selector forms a saved record answers to — full relative path, bare
+ * name, with or without `.json` — because the caller's `path` may be any of them and
+ * the store itself accepts all three.
+ *
+ * Case-insensitive: the reporter is on Windows, where a listing that differs only in
+ * case names the same file, and answering "not on disk" for it would reproduce this
+ * bug with better wording.
+ *
+ * @returns {string|null} the listing entry that matched, or null.
+ */
+export function diskListingEntryFor(listing, selector) {
+  if (!Array.isArray(listing)) return null;
+  const want = canonicalWorkflowPath(selector);
+  if (!want) return null;
+  const wantNoExt = withoutJson(want).toLowerCase();
+  const wantBase = wantNoExt.split("/").pop();
+  for (const raw of listing) {
+    const entry = canonicalWorkflowPath(typeof raw === "string" ? raw : raw?.[0]);
+    if (!entry) continue;
+    const entryNoExt = withoutJson(entry).toLowerCase();
+    if (entryNoExt === wantNoExt) return entry;
+    // A BARE name may address a file in a subfolder — but only when it is
+    // unambiguous. Deliberately not resolved here: two subfolders holding the same
+    // filename would make this pick one arbitrarily, and picking the wrong workflow
+    // is worse than the refusal this is trying to improve. Exact-path matches above
+    // are the only positive answer; the base-name case only ever DOWNGRADES to a
+    // hint, below.
+    if (entryNoExt.split("/").pop() === wantBase && !wantNoExt.includes("/")) return entry;
+  }
+  return null;
+}
+
+/**
+ * The probe's verdict, kept separate from the fetch so it is testable without a
+ * server and so the FAIL-OPEN rule is enforced in one place.
+ *
+ * Fail-open is the property that matters. Every previous round of this issue shipped
+ * a message that claimed more than it knew, so an unreachable `/userdata`, a build
+ * that does not serve it, a non-array body, or any throw must answer "unknown" — not
+ * "absent". A probe that turned a stale-list refusal into a confident "your file does
+ * not exist" would be the same bug with more authority.
+ *
+ * @param {{ok: boolean, status?: number, body?: unknown}|null} response
+ * @param {string} selector
+ * @returns {{onDisk: "yes"|"no"|"unknown", entry?: string, why?: string}}
+ */
+export function classifyDiskProbe(response, selector) {
+  if (!response || response.ok !== true) {
+    return { onDisk: "unknown", why: response?.status ? `HTTP ${response.status}` : "no response" };
+  }
+  if (!Array.isArray(response.body)) return { onDisk: "unknown", why: "unrecognised listing shape" };
+  const entry = diskListingEntryFor(response.body, selector);
+  return entry ? { onDisk: "yes", entry } : { onDisk: "no" };
+}


### PR DESCRIPTION
Refs comfyui-mcp#1448. Fixes the half that was left open.

## What is left

Panel 0.14.15 and 0.14.31 fixed the *message*: it no longer asserts a re-read it never checked, and no longer sends you to look outside the workflows folder when your file is inside it. Both were real, and neither was what the reporter actually hit.

The lookup is still a **pure in-memory scan of the frontend's workflow store**. Nothing in the path ever asks the server whether the file exists, so a `.json` staged into `user/default/workflows/` out-of-band — unzipped from a CivitAI bundle, in the reporter's case — is reported as "no workflow matching" while sitting exactly where they said it was.

The reporter asked for precisely this: *"fall back to a direct server-side stat of `<workflows dir>/<path>` before declaring no match."*

## The plan

Probe ComfyUI's `/userdata` for the workflows directory before the refusal is emitted, and let the answer decide what the refusal says:

- **on disk, not in the store** — this is the reporter's case, and it becomes a different message entirely: the file IS there, the frontend's list is stale, reload the tab. Today that case is indistinguishable from a typo.
- **not on disk** — the current message is right, and for the first time it is *evidence-backed* rather than assumed.

## Deliberately not in scope

**Opening it anyway.** The tool's contract is a native saved tab, which the frontend store has to know about; forcing an open would produce the same unsaved tmp tab the reporter already gets from the `panel_new_workflow` + `panel_load_workflow` workaround, while claiming to be the real thing. Making the refusal *true and actionable* is the fix; recovering the open is a separate question with its own design.

The probe must also fail **open**: a `/userdata` that 404s, errors, or is absent on some build must not turn a working refusal into a broken one, and must never claim absence it did not observe. That has been the recurring defect in every round of this issue.


## Verification

- **4302 tests pass**; **18 mutations, all applied and all killed**, against a checked-GREEN baseline.
- Both directions of the store/disk staleness were **reproduced on a live rig** (see the module docblock) before any code was written.

## Review findings, all fixed

- **P1 — an ambiguous bare name was resolved to a guess.** With two subfolders holding the same filename, the refusal said the requested file "IS on disk", named one of them, and prescribed a reload. The comment claimed it was *"deliberately not resolved to a guess"* while the code did exactly that, and my own test blessed it. Ambiguity is now reported with the candidates and a disambiguation instruction; an exact path still wins outright.
- **P1 — the probe could hang the refusal.** No deadline on the fetch or its JSON parse. Now bounded by the panel's existing withTimeout helper, which never rejects, so a timeout lands in the same fail-open unknown.
- **P2 — the new await widened a race.** The lookup is re-run once after the probe, so a target that became addressable while it ran is **opened** rather than refused.
- **r2 P2 — a timed-out request was abandoned, not aborted.** Now cancelled via AbortController, with the timer cleared on the happy path.

Two mutations exposed gaps nothing else could: the probe could be **deleted entirely** without failing a test (every failure mode fails open to the same verdict an absent call produces), and the abort assertions **silently never landed** from a scripted edit. Both are now pinned.
