### PR TITLE
fix(1489): an UNCONFIRMABLE run is not a failed one

### DIFF
--- a/browser_tests/unit/giveup-not-an-error.test.mjs
+++ b/browser_tests/unit/giveup-not-an-error.test.mjs
@@ -1,0 +1,121 @@
+// comfyui-mcp#1489 (defect 3) — an UNCONFIRMABLE run is not a failed one.
+//
+// `onReconcileGiveUp` fires when the tracker could not confirm a prompt's outcome after
+// its bounded retries: the server has no `/history` for it. It used to send
+// `kind: "run_error"` while its own text said "could not be confirmed … likely cancelled
+// … safe to requeue".
+//
+// The orchestrator routes every run_error through `injectRunError`, which INTERRUPTS the
+// live turn, front-queues it ("hey, look at me"), and tells the agent "The user's workflow
+// run just ERRORED … diagnose it (panel_get_errors has the details)". Cancelling a
+// 26-prompt batch therefore produced 26 interrupts asserting a failure the panel never
+// observed. #1507 stopped them compounding across turns; they were still 26 urgent errors
+// for 26 unknowns.
+//
+// The correct pattern is the sibling branch, whose comment already argues this case:
+// `executed` with a note is the existing NON-URGENT protocol and claims no output.
+// Interrupted KNOWS the run was cancelled; give-up knows only that it cannot tell.
+//
+// The callback bodies live in the monolith, so these pin the WIRING; the end-to-end
+// behaviour is verified against the running ComfyUI after merge.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const PANEL = readFileSync(
+  join(dirname(fileURLToPath(import.meta.url)), "../../web/js/comfyui-mcp-panel.js"),
+  "utf8",
+).replace(/\r\n/g, "\n");
+
+/**
+ * CODE ONLY — comment lines are stripped.
+ *
+ * The first version of this scan did not, and the comment above the fix quotes the old
+ * `kind: "run_error"` while explaining why it is gone. The test then failed against
+ * correct code, which is the benign direction of a scanner that reads prose; the
+ * dangerous direction is a scan that PASSES because the property it wants happens to be
+ * mentioned in a sentence.
+ */
+function stripComments(src) {
+  return src
+    .split("\n")
+    .filter((l) => !/^\s*(\/\/|\*|\/\*)/.test(l))
+    .join("\n");
+}
+
+/** The give-up callback body, bounded by the close of the handler map that follows it. */
+function giveUpBody() {
+  const start = PANEL.indexOf("onReconcileGiveUp: ({ promptId }) => {");
+  assert.notEqual(start, -1, "the give-up callback must still be recognisable");
+  const end = PANEL.indexOf("\n  });", start);
+  assert.ok(end > start, "the end of the handler map must still be recognisable");
+  return stripComments(PANEL.slice(start, end));
+}
+
+function interruptedBody() {
+  const start = PANEL.indexOf("onReconcileInterrupted: ({ promptId }) => {");
+  assert.notEqual(start, -1, "the interrupted callback must still be recognisable");
+  const end = PANEL.indexOf("onReconcileGiveUp:", start);
+  assert.ok(end > start);
+  return stripComments(PANEL.slice(start, end));
+}
+
+test("#1489 give-up delivers a NEUTRAL event, not run_error", () => {
+  const body = giveUpBody();
+  assert.match(body, /kind: "executed"/, "the non-urgent protocol");
+  assert.doesNotMatch(
+    body,
+    /kind: "run_error"/,
+    "run_error interrupts the turn and asserts a failure this path never observed",
+  );
+});
+
+test("#1489 it carries a NOTE, which is what makes an executed event describe itself", () => {
+  // A note-only `executed` replaces the default "produced N output image(s)" wording
+  // entirely. Without one, this would announce a finished render that never happened.
+  const body = giveUpBody();
+  assert.match(body, /note:/, "the event must carry its own wording");
+  assert.doesNotMatch(body, /images:/, "and must not attach outputs");
+});
+
+test("#1489 the note states the UNKNOWN honestly — no failure, no output", () => {
+  const body = giveUpBody();
+  assert.match(body, /could NOT be confirmed/i, "says the outcome is unknown");
+  assert.match(body, /not a reported failure/i, "and explicitly is not a failure claim");
+  assert.match(body, /no output was produced/i, "and does not imply a render landed");
+  assert.match(body, /Re-queue it if you still need it/i, "and names the action");
+});
+
+test("#1489 everything else on the give-up path is unchanged", () => {
+  // The classification was the defect. The bookkeeping around it was not, and silently
+  // dropping any of it would trade one bug for a worse one — a run that reads as settled
+  // when its only frame was never delivered (#585), or a suppressed restart-resume
+  // waiting forever on a run that can never settle.
+  const body = giveUpBody();
+  assert.match(body, /markDeliveryUnconfirmed\(promptId\)/, "#585 delivery flag intact");
+  assert.match(body, /pruneRebootMarker\(\)/, "reboot marker still pruned");
+  assert.match(body, /appendSystem\(/, "the one-time panel surfacing is intact");
+  assert.match(body, /!sent && !AGENT_MUTED/, "the unsent/muted gate is intact");
+});
+
+test("#1489 the sibling INTERRUPTED path is untouched", () => {
+  // It was already correct, and is the precedent this change follows.
+  const body = interruptedBody();
+  assert.match(body, /kind: "executed"/);
+  assert.doesNotMatch(body, /kind: "run_error"/);
+});
+
+test("#1489 run_error is STILL used where a failure is actually known", () => {
+  // The direction that would be catastrophic to lose. `run_error` is the only channel
+  // that interrupts the agent, and a real render failure must keep using it — a change
+  // that simply deleted the urgent class everywhere would pass every assertion above
+  // while making genuine errors silent.
+  const errorSends = [...PANEL.matchAll(/kind: "run_error"/g)].length;
+  assert.ok(
+    errorSends > 0,
+    "at least one path must still report a KNOWN failure as urgent, or errors go unnoticed",
+  );
+});

--- a/browser_tests/unit/giveup-not-an-error.test.mjs
+++ b/browser_tests/unit/giveup-not-an-error.test.mjs
@@ -81,12 +81,22 @@ test("#1489 it carries a NOTE, which is what makes an executed event describe it
   assert.doesNotMatch(body, /images:/, "and must not attach outputs");
 });
 
-test("#1489 the note states the UNKNOWN honestly — no failure, no output", () => {
+test("#1489 the note states the UNKNOWN honestly, in BOTH directions", () => {
   const body = giveUpBody();
   assert.match(body, /could NOT be confirmed/i, "says the outcome is unknown");
-  assert.match(body, /not a reported failure/i, "and explicitly is not a failure claim");
-  assert.match(body, /no output was produced/i, "and does not imply a render landed");
-  assert.match(body, /Re-queue it if you still need it/i, "and names the action");
+  assert.match(body, /NOT a reported failure/i, "and is explicitly not a failure claim");
+
+  // Review, P1 — and this test blessed the defect a moment ago. The first version
+  // asserted "no output was produced", which is a claim this path CANNOT substantiate:
+  // a run that emitted outputs before the connection dropped, then was cancelled before
+  // its terminal status, reaches give-up with real artifacts on disk. Telling the agent
+  // nothing was produced invites re-queueing an expensive or side-effecting run.
+  //
+  // That is the same error the fix is about, pointed the other way: I replaced one
+  // unsubstantiated claim ("it ERRORED") with another ("nothing was produced").
+  assert.doesNotMatch(body, /no output was produced/i, "must not claim an absence it cannot see");
+  assert.match(body, /not proof nothing was produced/i, "says so explicitly");
+  assert.match(body, /get_history/, "and names the reader that CAN answer it");
 });
 
 test("#1489 everything else on the give-up path is unchanged", () => {
@@ -113,7 +123,13 @@ test("#1489 run_error is STILL used where a failure is actually known", () => {
   // that interrupts the agent, and a real render failure must keep using it — a change
   // that simply deleted the urgent class everywhere would pass every assertion above
   // while making genuine errors silent.
-  const errorSends = [...PANEL.matchAll(/kind: "run_error"/g)].length;
+  //
+  // STRIPPED, and review had to point that out: the first version scanned the raw
+  // monolith, and the comments THIS COMMIT ADDED quote `kind: "run_error"` while
+  // explaining why give-up no longer uses it. So the guard would have passed with every
+  // executable urgent send downgraded — a test that reads prose and reports PASS, which
+  // is the dangerous direction of exactly the mistake it was written to prevent.
+  const errorSends = [...stripComments(PANEL).matchAll(/kind: "run_error"/g)].length;
   assert.ok(
     errorSends > 0,
     "at least one path must still report a KNOWN failure as urgent, or errors go unnoticed",

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -28492,12 +28492,33 @@ function buildPanel() {
     // cancelled/disconnected). It's been evicted from the ledger; surface a
     // one-time "status unknown, safe to requeue" notice so the agent stops waiting.
     onReconcileGiveUp: ({ promptId }) => {
+      // comfyui-mcp#1489 (defect 3) — AN UNCONFIRMABLE RUN IS NOT A FAILED ONE.
+      //
+      // This used to send `kind: "run_error"`, whose own text said the outcome "could
+      // not be confirmed … likely cancelled … safe to requeue" — while the orchestrator
+      // routes any run_error through `injectRunError`, which INTERRUPTS the live turn,
+      // front-queues it, and tells the agent "The user's workflow run just ERRORED …
+      // diagnose it". Cancel a 26-prompt batch and that is 26 interrupts asserting a
+      // failure this panel never observed. #1507 stopped them compounding across turns;
+      // they were still 26 urgent errors for 26 unknowns.
+      //
+      // The correct pattern is the sibling branch above, and its comment already argues
+      // this case: `executed` with a note is the existing NON-URGENT event protocol and
+      // does not claim an output was produced. Interrupted knows the run was cancelled;
+      // give-up knows only that it cannot tell — and "cannot tell" is further from "it
+      // failed", not closer. `run_error` has to keep meaning WE KNOW IT FAILED, or the
+      // agent cannot act on it.
+      //
+      // Everything else this path does is unchanged: the delivery-unconfirmed flag
+      // (#585), the reboot-marker prune, and the one-time surfacing below.
       const sent = client.sendFrame({
         type: "agent_event",
-        kind: "run_error",
-        error:
-          `Render status for prompt ${promptId} could not be confirmed after reconnecting ` +
-          `(no history for it) — it was likely cancelled or interrupted. Safe to requeue.`,
+        kind: "executed",
+        note:
+          `The outcome of your queued run (prompt ${promptId}) could NOT be confirmed after ` +
+          `reconnecting — the server has no history for it, which is what a cancelled or ` +
+          `interrupted run looks like. This is not a reported failure: nothing was observed ` +
+          `going wrong, and no output was produced. Re-queue it if you still need it.`,
       });
       appendSystem(
         tr("panel.render_status_unknown_for_prompt_safe_to", "Render status unknown for prompt {promptId} — safe to requeue.", { promptId }),

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -28517,8 +28517,10 @@ function buildPanel() {
         note:
           `The outcome of your queued run (prompt ${promptId}) could NOT be confirmed after ` +
           `reconnecting — the server has no history for it, which is what a cancelled or ` +
-          `interrupted run looks like. This is not a reported failure: nothing was observed ` +
-          `going wrong, and no output was produced. Re-queue it if you still need it.`,
+          `interrupted run looks like. This is NOT a reported failure: nothing was observed ` +
+          `going wrong. It is also not proof nothing was produced — if the connection dropped ` +
+          `mid-run, any outputs it did write are simply not recorded here, so check ` +
+          `get_history (action:"list") before re-queueing anything expensive.`,
       });
       appendSystem(
         tr("panel.render_status_unknown_for_prompt_safe_to", "Render status unknown for prompt {promptId} — safe to requeue.", { promptId }),


### PR DESCRIPTION
Refs comfyui-mcp#1489 (defect 3 — the one my last comment called "the half worth doing next"). **Draft.**

## The contradiction

`onReconcileGiveUp` fires when the run tracker could not confirm a prompt's outcome after its bounded retries — its `/history` never appeared. It sends:

```js
kind: "run_error",
error: `Render status for prompt ${id} could not be confirmed after reconnecting
        (no history for it) — it was likely cancelled or interrupted. Safe to requeue.`
```

The **text** says: outcome unknown, probably cancelled, safe to requeue.
The **classification** says: `run_error` — which the orchestrator routes into a "⚠️ … STOP — do not carry on as if it succeeded" paragraph.

Cancel a 26-prompt batch and you get 26 of those. #1507 stopped them compounding across turns; they are still 26 urgent errors for something the panel never observed failing.

## The correct pattern is one branch above, with its reasoning already written

`onReconcileInterrupted` sends `kind: "executed"` with a note, and says why in its own comment:

> Deliver a neutral event, not run_error: the orchestrator treats `run_error` as urgent and tells the agent to diagnose/panel_get_errors. `executed` with a note is the existing non-urgent event protocol, and does not claim an output was produced.

Every word of that applies to give-up. The difference is that interrupted *knows* the run was cancelled, while give-up knows only that it cannot tell — and "cannot tell" is further from "it failed", not closer.

## Why this is a panel-only change

My earlier comment scoped this as "a panel-repo change plus an orchestrator-side marker", on the theory that the panel must learn which prompts were deliberately cancelled before it can stop calling them errors.

That framing was wrong, and cheaper than it needs to be. `run_error` should mean **we know it failed**. A give-up is by construction a state where the panel knows nothing — so the miscalibration is not "we lack the cancel marker", it is that an *unconfirmable* outcome is being asserted as a *failure*. Fixing the classification needs no bookkeeping at all; the cancelled-prompt marker would only let the message say "cancelled" instead of "unknown", which is a wording improvement on top, not the fix.

## What this deliberately keeps

Everything the give-up path does beyond the classification: the delivery-unconfirmed flag (#585), the reboot-marker prune, and the one-time surfacing. Only the `kind` and the sentence change.
