### PR TITLE
fix(423): translating the error disarmed every ComfyUI-Manager fallback

### DIFF
--- a/browser_tests/unit/manager-dialect.test.mjs
+++ b/browser_tests/unit/manager-dialect.test.mjs
@@ -83,6 +83,65 @@ test("isManagerRouteMissing: ONLY the proven-404 marker qualifies a mutation ret
   assert.equal(isManagerUnreachable(new Error(UNREACHABLE)), true);
 });
 
+/** #423 (review P1) — build managerV2/managerCall over a fetchApi that REJECTS. */
+function buildTransportsOverRejectingFetch(thrown) {
+  const src = readPanelSource();
+  const factory = new Function(
+    "api",
+    "classifyManager404",
+    "markManagerUnreachable",
+    "managerFetchFailureMessage",
+    `${pick(src, /async function managerV2\(route, \{ method = "GET", body, signal \} = \{\}\) \{[\s\S]*?\n\}/, "managerV2")}
+${pick(src, /async function managerCall\(route, \{ method = "GET", body, signal \} = \{\}\) \{[\s\S]*?\n\}/, "managerCall")}
+return { managerV2, managerCall };`,
+  );
+  return factory(
+    {
+      fetchApi: async () => {
+        throw thrown;
+      },
+    },
+    classifyManager404,
+    ManagerInstall.markManagerUnreachable,
+    (route, err) => `Manager ${route} could not be delivered: ${err?.message}`,
+  );
+}
+
+// #423, second blind spot (review P1). A REJECTED fetch — as opposed to a null response —
+// escaped the ladder twice over: managerV2 wrapped it untagged, and managerCall had no
+// catch at all, so "Failed to fetch" propagated raw. Neither wording has ever matched the
+// gate, so a transport failure skipped the legacy retry AND the /object_info fallback that
+// exists for exactly this case.
+test("managerV2/managerCall tag a REJECTED fetch — but never as route-missing", async () => {
+  const { managerV2: mv2, managerCall: mcall } = buildTransportsOverRejectingFetch(
+    new TypeError("Failed to fetch"),
+  );
+  for (const call of [mv2, mcall]) {
+    const err = await call("customnode/installed").then(
+      () => null,
+      (e) => e,
+    );
+    assert.ok(err instanceof Error, "must reject with an Error");
+    assert.ok(isManagerUnreachable(err), "the idempotent-GET fallback ladder must see it");
+    // The safety boundary, and the reason tagging this is allowed at all: a rejection
+    // proves nothing about delivery, so it must never authorize re-sending a MUTATION.
+    assert.equal(isManagerRouteMissing(err), false, "a rejection is not a proven 404");
+  }
+});
+
+test("an aborted Manager fetch is still the caller's own — never an unreachable verdict", async () => {
+  const abort = Object.assign(new Error("aborted"), { name: "AbortError" });
+  const { managerV2: mv2, managerCall: mcall } = buildTransportsOverRejectingFetch(abort);
+  for (const call of [mv2, mcall]) {
+    const err = await call("customnode/installed").then(
+      () => null,
+      (e) => e,
+    );
+    assert.equal(err, abort, "passes through unchanged");
+    assert.notEqual(err.managerTransportUnreachable, true, "and is never tagged");
+  }
+});
+
 // The marker itself is minted by the REAL transports — extract them and prove:
 // a 404 response tags the error; a no-response (null) failure does NOT.
 test("managerV2/managerCall tag a 404 as managerRouteMissing, never the no-response case", async () => {

--- a/browser_tests/unit/manager-dialect.test.mjs
+++ b/browser_tests/unit/manager-dialect.test.mjs
@@ -93,6 +93,10 @@ test("managerV2/managerCall tag a 404 as managerRouteMissing, never the no-respo
   const factory = new Function(
     "api",
     "classifyManager404",
+    // #423 — the transports now TAG their no-response throw so the fallback ladder
+    // recognises it without reading the (translated) message. Real implementation,
+    // same as classifyManager404.
+    "markManagerUnreachable",
     `${pick(src, /async function managerV2\(route, \{ method = "GET", body, signal \} = \{\}\) \{[\s\S]*?\n\}/, "managerV2")}
 ${pick(src, /async function managerCall\(route, \{ method = "GET", body, signal \} = \{\}\) \{[\s\S]*?\n\}/, "managerCall")}
 return { managerV2, managerCall };`,
@@ -104,6 +108,7 @@ return { managerV2, managerCall };`,
     const { managerV2: mv2, managerCall: mcall } = factory(
       { fetchApi: async () => res },
       classifyManager404,
+      ManagerInstall.markManagerUnreachable,
     );
     for (const call of [mv2, mcall]) {
       const err = await call("manager/queue/status").then(
@@ -116,6 +121,14 @@ return { managerV2, managerCall };`,
         isManagerRouteMissing(err),
         res !== null && res.status === 404,
         `marker only for the proven 404 (res=${JSON.stringify(res)})`,
+      );
+      // #423 — whichever way it failed, the fallback ladder must be able to SEE it
+      // without reading the sentence. The 404 branch carries managerRouteMissing;
+      // the no-response branch is tagged by the transport itself. A translated
+      // message disarmed every rung of the ladder for 11 of 12 shipped locales.
+      assert.ok(
+        isManagerRouteMissing(err) || err.managerTransportUnreachable === true,
+        `structurally recognisable (res=${JSON.stringify(res)})`,
       );
     }
   }
@@ -177,6 +190,7 @@ function buildDialectHarness({ fetchApi, managerCall, managerV2, AbortSignalImpl
     "managerCall",
     "managerV2",
     "isManagerUnreachable",
+    "markManagerUnreachable",
     "dialectRetryTarget",
     "MANAGER_FETCH_TIMEOUT_MS",
     "AbortSignal",
@@ -195,6 +209,7 @@ return { managerGet, getDialectCache: () => managerDialectCache };`,
     managerCall,
     managerV2,
     isManagerUnreachable,
+    ManagerInstall.markManagerUnreachable,
     dialectRetryTarget,
     15000,
     AbortSignalImpl,

--- a/browser_tests/unit/manager-fallback-i18n.test.mjs
+++ b/browser_tests/unit/manager-fallback-i18n.test.mjs
@@ -87,8 +87,10 @@ test("the verdict does not depend on the WORDING at all", () => {
   // The durable form of the above. Even a locale that has not been written yet — or a
   // reworded English message — must not change the answer, because the fact being asked
   // about (the route 404'd) is structural and was known before any text was composed.
+  // NS-stripped, like catalogFor above — `__setCatalogForTest` takes what
+  // `loadCatalog` installs, not the file layout.
   __setCatalogForTest("xx", {
-    comfyuiMcpPanel: { manager_404: { comfyui_manager_not_reachable_is_the_built: "🙈" } },
+    manager_404: { comfyui_manager_not_reachable_is_the_built: "🙈" },
   });
   const err = errorForRouteMissing404();
   assert.equal(err.message, "🙈", "the catalogue is live");
@@ -109,6 +111,52 @@ test("the security refusal is still NOT treated as unreachable, in any locale", 
     err.managerSecurityRefusal = true;
     assert.ok(!isManagerUnreachable(err), `${locale}: a refusal must not authorise a fallback`);
   }
+});
+
+test("a security refusal is refused even when the UPSTREAM body says 'not reachable'", () => {
+  // The sharp version of the test above. `summarizeManagerBody` embeds up to 300
+  // characters of the Manager's own body into the message, so the words in it are
+  // upstream text, not ours. Before this fix the #706 invariant held only because that
+  // text happened never to contain "not reachable" — a guarantee nobody could make.
+  __setCatalogForTest("en", {});
+  const { routeMissing, message } = classifyManager404(
+    "A security error has occurred. The registry endpoint is not reachable from this host. " +
+      "Please check the terminal logs",
+  );
+  assert.equal(routeMissing, false, "still classified as a refusal, not a missing route");
+  const err = new Error(message);
+  err.managerSecurityRefusal = true;
+  assert.match(err.message, /not reachable/i, "the hostile phrase really is in the message");
+  assert.ok(
+    !isManagerUnreachable(err),
+    "a handler ran and declined — the fallback ladder must stay shut whatever the body says",
+  );
+});
+
+test("a security refusal VETOES the tags, not the other way round", () => {
+  // The call sites set exactly one of these today (`if (routeMissing) … else …`), so an
+  // error carrying both is not reachable from current code. The precedence is still a
+  // decision worth stating: "a handler ran and declined" is the fact that must win,
+  // because acting on the other one re-sends work the Manager already processed. Pinning
+  // it means a future path that tags an error it re-throws cannot quietly invert it.
+  __setCatalogForTest("en", {});
+  for (const tag of ["managerRouteMissing", "managerTransportUnreachable"]) {
+    const err = new Error("...");
+    err.managerSecurityRefusal = true;
+    err[tag] = true;
+    assert.ok(!isManagerUnreachable(err), `${tag} must not override a refusal`);
+  }
+});
+
+test("a TAGGED transport failure opens the ladder whatever its message says", () => {
+  // The other direction: the transports' no-response throw is raw English today, but the
+  // i18n gate takes new strings over time. Once tagged, the wording stops mattering — so
+  // translating it later cannot re-introduce this bug.
+  __setCatalogForTest("ja", catalogFor("ja"));
+  const err = new Error("ComfyUI-Manager に接続できません");
+  assert.ok(!isManagerUnreachable(err), "untagged and untranslatable-by-regex: not matched");
+  err.managerTransportUnreachable = true;
+  assert.ok(isManagerUnreachable(err), "tagged: matched");
 });
 
 test("the untranslated transport throws keep working", () => {

--- a/browser_tests/unit/manager-fallback-i18n.test.mjs
+++ b/browser_tests/unit/manager-fallback-i18n.test.mjs
@@ -1,0 +1,148 @@
+/**
+ * #423 — translating an error message must not disarm the fallback that reads it.
+ *
+ * `panel_list_nodes` and `panel_search_nodes` carry a ladder of fallbacks for the
+ * ComfyUI-Manager dialects: retry the absolute (no-/v2) legacy route, self-heal a stale
+ * dialect (#605), and finally search installed nodes via `/object_info` (#426). Every rung
+ * is gated on `isManagerUnreachable(err)`, which asks the question by matching the English
+ * words "not reachable" in the message.
+ *
+ * The message it reads is produced by `classifyManager404`, which runs it through `tr()`.
+ *
+ * So on any non-English panel the gate never matches, every rung is skipped, and the
+ * generic "Manager not reachable" surfaces — while the Manager is running and answering.
+ * That is #423's recurrence on panel 0.14.36: the reporter's error arrived in Japanese, and
+ * their `/customnode/installed` was one dead `if` away from being tried.
+ *
+ * The tests below use the SHIPPED locale catalogues rather than synthetic ones. A synthetic
+ * catalogue would prove the mechanism but not that it fires for a real user, and the
+ * reporter's exact string is the evidence that it does.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync, readdirSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+import { tr, __setCatalogForTest } from "../../web/js/lib/i18n.js";
+import { classifyManager404 } from "../../web/js/lib/manager-404.js";
+import { isManagerUnreachable } from "../../web/js/lib/manager-install.js";
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+/** The shipped file is namespaced, and `loadCatalog` installs `all[locale][NS]` — so the
+ *  test must strip the same layer, or every lookup misses and the suite silently measures
+ *  the English fallback instead of the translation. (It did, on the first run; the
+ *  "tr() is genuinely in the path" test below exists to keep that from passing quietly.) */
+const NS = "comfyuiMcpPanel";
+const catalogFor = (locale) => {
+  const file = JSON.parse(readFileSync(join(ROOT, "locales", locale, "main.json"), "utf8"));
+  const inner = file?.[NS];
+  assert.ok(inner, `locales/${locale}/main.json must be namespaced under ${NS}`);
+  return inner;
+};
+
+/** Rebuild the error exactly as managerV2/managerCall do on a route-missing 404. */
+const errorForRouteMissing404 = () => {
+  const { routeMissing, message } = classifyManager404("");
+  const err = new Error(message);
+  if (routeMissing) err.managerRouteMissing = true;
+  else err.managerSecurityRefusal = true;
+  return err;
+};
+
+test.afterEach(() => __setCatalogForTest("en", {}));
+
+test("the reporter's exact Japanese string is what the panel produces", () => {
+  // Anchors the whole investigation: this is the string from the #423 recurrence,
+  // reproduced from the shipped catalogue rather than assumed.
+  __setCatalogForTest("ja", catalogFor("ja"));
+  assert.equal(
+    errorForRouteMissing404().message,
+    "ComfyUI-Manager に接続できません（内蔵 Manager は有効になっていますか？）",
+  );
+});
+
+test("a route-missing 404 stays recognisable in EVERY shipped locale", () => {
+  const locales = readdirSync(join(ROOT, "locales"), { withFileTypes: true })
+    .filter((d) => d.isDirectory())
+    .map((d) => d.name);
+  assert.ok(locales.length > 1, "more than English must be shipped for this to mean anything");
+
+  const blind = [];
+  for (const locale of locales) {
+    __setCatalogForTest(locale, catalogFor(locale));
+    const err = errorForRouteMissing404();
+    // The claim under test: the fallback ladder can still read this error.
+    if (!isManagerUnreachable(err)) blind.push({ locale, message: err.message });
+  }
+  assert.deepEqual(
+    blind,
+    [],
+    "these locales silently disable every Manager fallback:\n" +
+      blind.map((b) => `  ${b.locale}: ${b.message}`).join("\n"),
+  );
+});
+
+test("the verdict does not depend on the WORDING at all", () => {
+  // The durable form of the above. Even a locale that has not been written yet — or a
+  // reworded English message — must not change the answer, because the fact being asked
+  // about (the route 404'd) is structural and was known before any text was composed.
+  __setCatalogForTest("xx", {
+    comfyuiMcpPanel: { manager_404: { comfyui_manager_not_reachable_is_the_built: "🙈" } },
+  });
+  const err = errorForRouteMissing404();
+  assert.equal(err.message, "🙈", "the catalogue is live");
+  assert.ok(isManagerUnreachable(err), "a fallback gate must not read prose");
+});
+
+test("the security refusal is still NOT treated as unreachable, in any locale", () => {
+  // The #706 distinction must survive the fix. A security refusal means a handler RAN and
+  // declined; retrying it on another dialect re-sends an operation the Manager already
+  // processed. Only the route-missing branch may open the fallback ladder.
+  for (const locale of ["en", "ja", "fr"]) {
+    __setCatalogForTest(locale, catalogFor(locale));
+    const { routeMissing, message } = classifyManager404(
+      "A security error has occurred. Please check the terminal logs",
+    );
+    assert.equal(routeMissing, false, `${locale}: a security refusal is not route-missing`);
+    const err = new Error(message);
+    err.managerSecurityRefusal = true;
+    assert.ok(!isManagerUnreachable(err), `${locale}: a refusal must not authorise a fallback`);
+  }
+});
+
+test("the untranslated transport throws keep working", () => {
+  // managerV2/managerCall throw a RAW English literal when there is no response at all,
+  // and detectManagerDialect throws one when neither queue probe answers. Those are not
+  // routed through tr(), so they matched before and must still match — the fix must add a
+  // structural path without removing the one that already worked.
+  __setCatalogForTest("ja", catalogFor("ja"));
+  for (const msg of [
+    "ComfyUI-Manager not reachable (is the built-in Manager enabled?)",
+    "ComfyUI-Manager's queue API is not reachable (neither /v2/manager/queue/status nor /manager/queue/status answered with a queue status). Is the built-in Manager installed and enabled on the connected ComfyUI?",
+  ]) {
+    assert.ok(isManagerUnreachable(new Error(msg)), `still matched: ${msg.slice(0, 40)}…`);
+  }
+});
+
+test("an unrelated Manager error still does not open the fallback ladder", () => {
+  __setCatalogForTest("ja", catalogFor("ja"));
+  for (const err of [
+    new Error("Manager customnode/installed: HTTP 500"),
+    new Error("boom"),
+    null,
+    undefined,
+  ]) {
+    assert.ok(!isManagerUnreachable(err), `must not match: ${String(err?.message ?? err)}`);
+  }
+});
+
+test("tr() is genuinely in the path — this suite is not testing a constant", () => {
+  // Guards against the mechanism quietly changing under the test: if classifyManager404
+  // ever stops translating, these assertions would pass for the wrong reason.
+  __setCatalogForTest("ja", catalogFor("ja"));
+  assert.notEqual(
+    tr("manager_404.comfyui_manager_not_reachable_is_the_built", "ComfyUI-Manager not reachable (is the built-in Manager enabled?)"),
+    "ComfyUI-Manager not reachable (is the built-in Manager enabled?)",
+  );
+});

--- a/browser_tests/unit/manager-fetch-failure.test.mjs
+++ b/browser_tests/unit/manager-fetch-failure.test.mjs
@@ -123,9 +123,20 @@ test("#1472 WIRING: managerV2 translates a throw and passes an abort through", (
   assert.match(src, /import \{ managerFetchFailureMessage \} from "\.\/lib\/manager-fetch-failure\.js";/);
   const at = src.indexOf("async function managerV2(");
   assert.ok(at > 0, "managerV2 must exist");
-  const body = src.slice(at, at + 1600);
+  // Bound the window by the function's OWN catch block rather than a byte count: a
+  // fixed 1600 silently excluded the throw once #423 added a comment above it, which
+  // reads as "the wiring is gone" when the wiring is fine. Ending at `if (!res) {`
+  // keeps every assertion below scoped to the catch, which is the point of the window.
+  const endOfCatch = src.indexOf("if (!res) {", at);
+  assert.ok(endOfCatch > at, "managerV2's catch must be followed by the no-response check");
+  const body = src.slice(at, endOfCatch);
   assert.match(body, /try \{/, "the fetch is inside a try");
-  assert.match(body, /throw new Error\(managerFetchFailureMessage\(route, err\), \{ cause: err \}\)/);
+  // #423 wrapped this throw in markManagerUnreachable() so the Manager fallback ladder
+  // can see a transport failure without reading its wording. What #1472 guarantees is
+  // unchanged and still asserted: the message is built by managerFetchFailureMessage
+  // from the ROUTE, and the original error survives as `cause`. Only the wrapper is
+  // tolerated — a bare `throw err`, or a message built any other way, still fails.
+  assert.match(body, /new Error\(managerFetchFailureMessage\(route, err\), \{ cause: err \}\)/);
   // An abort is the CALLER's own doing — relabelling it as a transport failure would
   // tell them the server never saw a request they themselves cancelled.
   assert.match(body, /if \(err\?\.name === "AbortError"\) throw err;/);

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -98,6 +98,7 @@ import {
   installedListRoute,
   isManagerRouteMissing,
   isManagerUnreachable,
+  markManagerUnreachable,
   isMethodNotAllowed,
   assertBatchOk,
   legacyUpdateBody,
@@ -5599,7 +5600,11 @@ async function managerV2(route, { method = "GET", body, signal } = {}) {
     throw new Error(managerFetchFailureMessage(route, err), { cause: err });
   }
   if (!res) {
-    throw new Error("ComfyUI-Manager not reachable (is the built-in Manager enabled?)");
+    // #423 — TAG it. The fallback ladder must recognise this without reading the
+    // sentence; a translated message silently disarmed every rung of it.
+    throw markManagerUnreachable(
+      new Error("ComfyUI-Manager not reachable (is the built-in Manager enabled?)"),
+    );
   }
   if (res.status === 404) {
     // A 404 is a PROVEN route-level rejection — no handler ran. Tag it so the
@@ -5648,7 +5653,11 @@ async function managerCall(route, { method = "GET", body, signal } = {}) {
     ...(body ? { headers: { "Content-Type": "application/json" }, body: JSON.stringify(body) } : {}),
   });
   if (!res) {
-    throw new Error("ComfyUI-Manager not reachable (is the built-in Manager enabled?)");
+    // #423 — TAG it. The fallback ladder must recognise this without reading the
+    // sentence; a translated message silently disarmed every rung of it.
+    throw markManagerUnreachable(
+      new Error("ComfyUI-Manager not reachable (is the built-in Manager enabled?)"),
+    );
   }
   if (res.status === 404) {
     // See managerV2: a 404 is the PROVEN route-level rejection the #605
@@ -5870,10 +5879,14 @@ async function detectManagerDialect({ signal } = {}) {
     managerDialectCache = "legacy";
     return managerDialectCache;
   }
-  throw new Error(
-    "ComfyUI-Manager's queue API is not reachable (neither /v2/manager/queue/status " +
-      "nor /manager/queue/status answered with a queue status). Is the built-in " +
-      "Manager installed and enabled on the connected ComfyUI?",
+  // #423 — TAG it: neither dialect answered, so every dialect-routed GET above
+  // this is entitled to its fallback regardless of the panel's language.
+  throw markManagerUnreachable(
+    new Error(
+      "ComfyUI-Manager's queue API is not reachable (neither /v2/manager/queue/status " +
+        "nor /manager/queue/status answered with a queue status). Is the built-in " +
+        "Manager installed and enabled on the connected ComfyUI?",
+    ),
   );
 }
 

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -5597,7 +5597,16 @@ async function managerV2(route, { method = "GET", body, signal } = {}) {
     // current state before retrying a MUTATING call.
     // An abort is the caller's own doing and must pass through untouched.
     if (err?.name === "AbortError") throw err;
-    throw new Error(managerFetchFailureMessage(route, err), { cause: err });
+    // #423, second blind spot (found in review). This is untagged AND its wording has
+    // never matched the gate's regex, so a transport-level failure has always skipped
+    // the whole fallback ladder — including the /object_info search that exists for
+    // exactly this case. Tagging it is safe in the direction that matters: this flag
+    // gates IDEMPOTENT GETs only. `isManagerRouteMissing`, the one predicate allowed to
+    // re-send a MUTATION, still requires a proven 404 and does not read this — which is
+    // what keeps the paragraph above true.
+    throw markManagerUnreachable(
+      new Error(managerFetchFailureMessage(route, err), { cause: err }),
+    );
   }
   if (!res) {
     // #423 — TAG it. The fallback ladder must recognise this without reading the
@@ -5647,11 +5656,24 @@ async function managerV2(route, { method = "GET", body, signal } = {}) {
  *  released 3.x ComfyUI-Manager whose queue lives under /manager/* with
  *  per-operation routes. Same error handling as managerV2. */
 async function managerCall(route, { method = "GET", body, signal } = {}) {
-  const res = await api.fetchApi(`/${route}`, {
-    method,
-    ...(signal ? { signal } : {}),
-    ...(body ? { headers: { "Content-Type": "application/json" }, body: JSON.stringify(body) } : {}),
-  });
+  let res;
+  try {
+    res = await api.fetchApi(`/${route}`, {
+      method,
+      ...(signal ? { signal } : {}),
+      ...(body ? { headers: { "Content-Type": "application/json" }, body: JSON.stringify(body) } : {}),
+    });
+  } catch (err) {
+    // #423, second blind spot (found in review). The docstring above claims "same error
+    // handling as managerV2" and it was not true: there was no catch here at all, so a
+    // fetch rejection propagated raw ("Failed to fetch") — no route, no tag, and no
+    // match for the gate's regex, which skipped the fallback ladder entirely. This is
+    // the LEGACY transport, i.e. the very rung the ladder falls back TO.
+    if (err?.name === "AbortError") throw err;
+    throw markManagerUnreachable(
+      new Error(managerFetchFailureMessage(route, err), { cause: err }),
+    );
+  }
   if (!res) {
     // #423 — TAG it. The fallback ladder must recognise this without reading the
     // sentence; a translated message silently disarmed every rung of it.

--- a/web/js/lib/manager-install.js
+++ b/web/js/lib/manager-install.js
@@ -399,6 +399,13 @@ export function installedListRoute() {
   return "customnode/installed?mode=default";
 }
 
+/** Tag an error the Manager transport could not get an answer for, so the
+ *  fallback ladder can recognise it WITHOUT reading its wording (#423). */
+export function markManagerUnreachable(err) {
+  if (err && typeof err === "object") err.managerTransportUnreachable = true;
+  return err;
+}
+
 /** #423 — does a Manager error mean "route/prefix not present on this build"
  *  (a 404 / the panel's "not reachable" throw), i.e. we should retry the
  *  absolute (no-/v2) legacy route? A legacy-UI pip build can answer the queue
@@ -406,8 +413,31 @@ export function installedListRoute() {
  *  /v2/customnode/installed 404s while /customnode/installed serves fine.
  *  Broad on purpose: it gates IDEMPOTENT GET fallbacks, where re-issuing the
  *  request after even an ambiguous transport failure is safe. Mutations must
- *  use the stricter isManagerRouteMissing instead (codex P0). */
+ *  use the stricter isManagerRouteMissing instead (codex P0).
+ *
+ *  ## Why this asks the error, not the sentence
+ *
+ *  This used to decide by matching the English words "not reachable". The
+ *  message it reads is composed by `classifyManager404`, which runs it through
+ *  `tr()` — so on all 11 non-English locales the match failed, every rung of the
+ *  ladder rethrew, and the generic error surfaced while the Manager was running
+ *  and answering. The fallbacks existed and were unreachable code for anyone not
+ *  using the panel in English, which is how #423 recurred on 0.14.36 with the
+ *  whole ladder already shipped.
+ *
+ *  The facts were never in the prose: a route-missing 404 is already tagged
+ *  `managerRouteMissing`, and the transports now tag their no-response throw. The
+ *  wording test is kept LAST and only as a bridge for any path that throws a bare
+ *  Error without passing through those — it can only add matches, never remove
+ *  one, so a locale can no longer take a fallback away. */
 export function isManagerUnreachable(err) {
+  // #706, structurally. A security refusal means a handler RAN and declined; it is
+  // not an unreachable route in any language. This used to hold only because that
+  // message happens not to contain "not reachable" — but it embeds up to 300
+  // characters of UPSTREAM body text, so the wording was never ours to rely on.
+  if (err?.managerSecurityRefusal === true) return false;
+  if (isManagerRouteMissing(err)) return true;
+  if (err?.managerTransportUnreachable === true) return true;
   const msg = String(err?.message ?? err ?? "");
   return /not reachable/i.test(msg) || /HTTP\s*404\b/.test(msg);
 }


### PR DESCRIPTION
Addresses artokun/comfyui-mcp#423.

## The bug

`panel_list_nodes` and `panel_search_nodes` carry a full ladder of ComfyUI-Manager dialect
fallbacks — retry the absolute (no-`/v2`) legacy route, self-heal a stale dialect (#605),
then search installed nodes via `/object_info` (#426). Every rung is gated on:

```js
export function isManagerUnreachable(err) {
  const msg = String(err?.message ?? err ?? "");
  return /not reachable/i.test(msg) || /HTTP\s*404\b/.test(msg);
}
```

The message it reads is composed by `classifyManager404`, which runs it through `tr()`.

**So on all 11 non-English locales the gate never matched**, all four call sites rethrew,
and the generic "Manager not reachable" surfaced while the Manager was running and
answering. The fallbacks were unreachable code for anyone not using the panel in English.

That is why the report recurred on **0.14.36** with the whole ladder already shipped: the
reporter's error is Japanese, and matches `locales/ja/main.json` byte for byte. It also
explains why *both* tools they named failed while `panel_graph_outline` was fine — those two
are exactly the tools that depend on this predicate.

## Measured on the shipped panel, against the live Manager

`/api/customnode/installed?mode=default` genuinely returns **404** on this machine (the
Manager is up — `/v2/manager/queue/status` answers `200`). Driving the *released* panel's own
modules against that real response:

| locale | message | error tagged `managerRouteMissing` | fallback ladder fires |
| --- | --- | --- | --- |
| `en` | ComfyUI-Manager not reachable… | ✅ | ✅ |
| `ja` | ComfyUI-Manager に接続できません… | ✅ | ❌ |

The fact was on the error the entire time. The predicate was asking the sentence.

## The fix

Decide from structure. The route-missing branch already tagged `managerRouteMissing`; the
transports and `detectManagerDialect` now tag their no-answer throws via
`markManagerUnreachable()`. The wording test stays **last**, as a bridge for any path that
throws a bare `Error` — it can only add matches, so a locale can no longer take a fallback
away.

Two invariants are now structural rather than incidental, both pinned by tests:

- **#706** — a security refusal means a handler *ran* and declined, so it must never open the
  ladder. This previously held only because that message happened not to contain "not
  reachable" — but it embeds up to 300 characters of the Manager's *own body*, so the wording
  was never ours to promise. There is a test with a hostile body containing the phrase.
- **The refusal vetoes the tags**, not the reverse. Nothing reachable sets both today (the
  call sites are `if`/`else`), but acting on the other flag would re-send work the Manager
  already processed.

## Second blind spot, found in review

A **rejected** fetch (as opposed to a null response) escaped the ladder twice over:
`managerV2` wrapped it untagged, and `managerCall` had no `catch` at all despite a docstring
claiming "same error handling as managerV2" — so `Failed to fetch` propagated raw. Neither
wording ever matched the gate, so a transport failure skipped the legacy retry *and* the
`/object_info` fallback that exists for precisely that case.

Both now tag. The safety direction is unchanged and asserted on the same error:
`isManagerUnreachable` gates **idempotent GETs**, while `isManagerRouteMissing` — the only
predicate permitted to re-send a **mutation** — still requires a proven 404 and does not read
the new tag. An abort still passes through untouched and untagged.

## Verification

- **11 mutations, all applied and all killed**, including one restoring each reviewed defect,
  one reverting the predicate to text-matching, and one that steals the caller's abort.
- Full unit suite green: **4320 tests**, including the tool-vocabulary and panel-scope gates.
- Two codex rounds. Round 1 found the rejected-fetch P1 above; round 2 clean.

## One test I had to relax, and why it is not weaker

`#1472 WIRING` pinned the throw's exact source text, which the wrapper changed. What #1472
guarantees — the message built by `managerFetchFailureMessage` **from the route**, and the
original error surviving as `cause` — is unchanged and still asserted; only the wrapper is
tolerated, and a bare `throw err` still fails it. Its window was also a fixed
`slice(at, at + 1600)` that excluded the throw as soon as a comment was added above it,
reporting missing wiring while the wiring was fine. It now ends at the function's own
`if (!res) {`, so prose can no longer move the answer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
