### PR TITLE
release: v0.14.38 — the Manager fallbacks work in every language (#423)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+## [0.14.38] - 2026-08-14
+
+### Fixed
+- translating the error disarmed every ComfyUI-Manager fallback (#1230)
+
+
 ## [0.14.37] - 2026-08-14
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-agent-panel"
 description = "Autonomous AI agent in the ComfyUI sidebar - local-first, bring any LLM. Run it on your Claude or ChatGPT subscription (no API keys, no extra LLM costs), on a Kimi K3 / GLM / OpenRouter key, or fully offline on free local models via Ollama, LM Studio, or llama.cpp. The agent drives your live canvas at full parity: add, wire, move and tweak nodes with Ctrl+Z undo, load whole workflows and installer packs in one shot, generate images, video and audio, browse CivitAI, and run your workflow - asking before it spends paid API credits. The sidebar UI for comfyui-mcp, the local-first, agent-native control plane for ComfyUI. The panel speaks 12 languages, matching your ComfyUI language automatically: English, 한국어, 日本語, 中文 (简体), 中文 (繁體), Русский, Français, Español, Português (BR), Türkçe, العربية, فارسی."
-version = "0.14.37"
+version = "0.14.38"
 license = { file = "LICENSE" }
 requires-python = ">=3.9"
 # UI-only pack: no Python deps. The frontend floor guarantees

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -1466,7 +1466,7 @@ const DOCS_URL = "https://comfyui-mcp.artokun.io/docs";
 // Panel version — surfaced in the "Need help?" diagnostics blob. Bump via
 // `node scripts/set-version.mjs <v>` (updates this AND pyproject together); CI
 // and the publish gate FAIL if the two ever drift, so this can't go stale.
-const PANEL_VERSION = "0.14.37";
+const PANEL_VERSION = "0.14.38";
 
 // The connected orchestrator's console URL/token (captured off the `backends`
 // bridge message — see onBackends). Drives the "API Keys" credentials frame;


### PR DESCRIPTION
Release v0.14.38.

Ships the fix for artokun/comfyui-mcp#423 (PR #1230).

`panel_list_nodes` and `panel_search_nodes` returned a generic "ComfyUI-Manager not
reachable" for every user whose panel was not in English — while their Manager was running
and answering other routes.

The ComfyUI-Manager dialect fallbacks were all present. Each was gated on a predicate that
decided by matching the English words "not reachable" in the error message, and that message
is composed through `tr()`. So on **11 of the 12 shipped locales** the gate never matched and
every rung was skipped. The predicate now reads the error's structure instead. A rejected
fetch — which escaped the ladder for a separate, older reason — is covered too.

The #706 invariant is preserved and is now structural rather than incidental: a Manager
security refusal means a handler ran and declined, so it still never opens the fallback
ladder, in any language, even when the Manager's own body contains the phrase.

Verified on the shipped panel against a real 404 from the Manager on this machine: before,
only English opened the ladder; after, all six locales tested do, from six distinct messages.
11 mutations killed; 4320 unit tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
