### PR TITLE
fix(1223): a transient /object_info timeout must not refuse a safe widget edit

### DIFF
--- a/browser_tests/unit/add-node-socket-proof-scope.test.mjs
+++ b/browser_tests/unit/add-node-socket-proof-scope.test.mjs
@@ -204,6 +204,8 @@ function realGraphAddNode(comfy, overrides = {}) {
   const { app, LG, graph } = comfy;
   const context = { app, LG, graph, rootGraph: graph, workflow: { uuid: "wf" } };
   const calls = { single: [], whole: 0 };
+  // #1223 — what the add filed into the last-observed-schema snapshot, and with what epoch.
+  const snapshotFilings = [];
 
   const api = {
     // The whole-schema route. Counting it is how these tests prove #780's saving survives.
@@ -230,7 +232,11 @@ function realGraphAddNode(comfy, overrides = {}) {
     // #1223 — the last-observed-schema snapshot the add path files its WHOLE payload into,
     // and the connection epoch it stamps that with. Both are module scope in the real file,
     // so this rebuilt scope has to name them or the executor throws ReferenceError.
-    objectInfoSnapshot: { record: () => true, clear: () => {} },
+    //
+    // A RECORDING spy, not a stub: the add is one of the readers that must feed the
+    // fallback, and the epoch it stamps has to be the one at the WHOLE request — not the
+    // one before the optional per-class probe that may precede it.
+    objectInfoSnapshot: { record: (defs, opts) => (snapshotFilings.push({ defs, opts }), true), clear: () => {} },
     backendReconnectEpoch: 0,
     api,
     refreshComfyNodeDefs: async (defs) => app.registerNodesFromDefs(defs ?? backendObjectInfo()),
@@ -294,7 +300,7 @@ function realGraphAddNode(comfy, overrides = {}) {
      const executors = {${addNodeMatch[0]}};
      return executors.graph_add_node;`,
   );
-  return { graph_add_node: factory(...names.map((n) => deps[n])), calls };
+  return { graph_add_node: factory(...names.map((n) => deps[n])), calls, snapshotFilings };
 }
 
 // ---------------------------------------------------------------------------
@@ -681,4 +687,38 @@ test("#1180: the registration wait measures itself on the monotonic clock", () =
   assert.match(fn, /const startedAt = monotonicNow\(\);/, "the deadline must be taken on the monotonic clock");
   assert.match(fn, /while \(monotonicNow\(\) < deadline\)/, "…and the poll must read the SAME clock it was set on");
   assert.doesNotMatch(fn, /Date\.now\(\)/, "no wall-clock reading may survive in this function");
+});
+
+test("#1223: the add files a WHOLE schema, and never a single-class payload", async () => {
+  // graph_add_node is one of the readers that must feed the last-observed-schema fallback:
+  // an add that registers a new type is often the last thing to have read a whole map, and
+  // dropping it leaves the next render-time widget edit refused for want of it.
+  //
+  // UNREGISTERED type ⇒ the #780 fast path is skipped and the WHOLE schema is fetched.
+  const comfy = makeComfy();
+  delete comfy.LG.registered_node_types.SeedVR2VideoUpscaler;
+  const { graph_add_node, snapshotFilings } = realGraphAddNode(comfy);
+  await graph_add_node({ class_type: 'SeedVR2VideoUpscaler', workflow_uuid: 'wf' });
+
+  assert.equal(snapshotFilings.length, 1, 'one whole schema was fetched, so one is filed');
+  const [{ defs, opts }] = snapshotFilings;
+  assert.ok(Object.keys(defs).length > 1, 'the WHOLE map, not a single-class payload');
+  assert.equal(opts.whole, true, 'and the wholeness claim is stated');
+  assert.equal(
+    opts.observedAtEpoch,
+    opts.currentEpoch,
+    'the epoch must be read where the WHOLE request goes out — a reconnect during the ' +
+      'optional per-class probe before it would leave this stale and the record rejected',
+  );
+});
+
+test("#1223: an add that takes the single-class fast path files NOTHING", async () => {
+  // A one-entry /object_info/<Type> payload reaching the snapshot would make every other
+  // type read as absent, and the #458 ever-seen gate would diagnose the whole install as
+  // removed packs. The fast path only runs for an ALREADY-REGISTERED type.
+  const comfy = makeComfy();
+  const { graph_add_node, snapshotFilings, calls } = realGraphAddNode(comfy);
+  await graph_add_node({ class_type: 'SeedVR2VideoUpscaler', workflow_uuid: 'wf' });
+  assert.ok(calls.single.length > 0, 'the fast path ran');
+  assert.deepEqual(snapshotFilings, [], 'and nothing was filed from it');
 });

--- a/browser_tests/unit/add-node-socket-proof-scope.test.mjs
+++ b/browser_tests/unit/add-node-socket-proof-scope.test.mjs
@@ -227,6 +227,11 @@ function realGraphAddNode(comfy, overrides = {}) {
     awaitObjectInfoHistorySeed: async () => {},
     recordObjectInfoTypes: (defs) => defs,
     objectInfoHistory: { wasTypeEverDefined: () => false },
+    // #1223 — the last-observed-schema snapshot the add path files its WHOLE payload into,
+    // and the connection epoch it stamps that with. Both are module scope in the real file,
+    // so this rebuilt scope has to name them or the executor throws ReferenceError.
+    objectInfoSnapshot: { record: () => true, clear: () => {} },
+    backendReconnectEpoch: 0,
     api,
     refreshComfyNodeDefs: async (defs) => app.registerNodesFromDefs(defs ?? backendObjectInfo()),
     summarizeNode: (node) => ({

--- a/browser_tests/unit/add-node-upload-widget.test.mjs
+++ b/browser_tests/unit/add-node-upload-widget.test.mjs
@@ -225,6 +225,11 @@ function realGraphAddNode(comfy, overrides = {}) {
     awaitObjectInfoHistorySeed: async () => {},
     recordObjectInfoTypes: (defs) => defs,
     objectInfoHistory: { wasTypeEverDefined: () => false },
+    // #1223 — module state in the real file; this rebuilt scope has to name it or the
+    // executor throws ReferenceError. See the #700 tests below for why THIS harness cares:
+    // the payload the add files is the same map registerNodesFromDefs mutates in place.
+    objectInfoSnapshot: { record: () => true, clear: () => {} },
+    backendReconnectEpoch: 0,
     api: { getNodeDefs: async () => backendObjectInfo() },
     refreshComfyNodeDefs: async (defs) => app.registerNodesFromDefs(defs ?? backendObjectInfo()),
     summarizeNode: (node) => ({

--- a/browser_tests/unit/node-def-refresh.test.mjs
+++ b/browser_tests/unit/node-def-refresh.test.mjs
@@ -49,17 +49,12 @@ const makeBoundedGetNodeDefs = (apiValue) => (timeoutMs = NODE_DEFS_FETCH_TIMEOU
 let cacheInvalidations = 0;
 const cacheSpy = { invalidate: () => { cacheInvalidations += 1; }, read: async (f) => f() };
 
-/**
- * #1223 — the last-observed-schema snapshot the refresh run also clears and re-records.
- * A spy for the same reason cacheSpy is one: the run's contract is that a suspicion of
- * change RETIRES it and only a successful fetch puts one back, and that is assertable only
- * if the harness can see both calls.
- */
+/** #1223 — the last-observed-schema snapshot the refresh run also clears and re-records. */
 let snapshotClears = 0;
 const snapshotRecords = [];
 const snapshotSpy = {
   clear: () => { snapshotClears += 1; },
-  record: (defs, epoch) => { snapshotRecords.push({ defs, epoch }); return true; },
+  record: (defs, opts) => { snapshotRecords.push({ defs, opts }); return true; },
 };
 
 import {
@@ -419,10 +414,9 @@ function buildRegisterComfyNodeDefs({
     "monotonicNow",
     "NODE_DEFS_RETRY_DELAYS_MS",
     "objectInfoCache",
-    // #1223 — the snapshot the run retires and re-records, and the connection epoch it
-    // stamps a recording with. Both are module state in the panel, so the extracted body
-    // throws ReferenceError without them (the exact failure #1180's note above predicted
-    // for the next collaborator added to this function).
+    // #1223 — the snapshot the run retires and re-records, and the connection epoch a
+    // recording is stamped with. Both are module state in the panel, so the extracted
+    // body throws ReferenceError without them.
     "objectInfoSnapshot",
     "backendReconnectEpoch",
     `// #1180 — defined HERE, from the api this scope already has, so each factory site
@@ -468,12 +462,9 @@ function buildRegisterComfyNodeDefs({
     // #716 — the shipping function drops the widget-write burst cache after a successful
     // fetch. A spy, so the harness can prove that happens rather than merely tolerate it.
     cacheSpy,
-    // #1223 — same reasoning as cacheSpy: a spy, so a test can prove the run retires the
-    // last-observed schema and re-records only what it actually fetched.
+    // #1223 — a spy, so a test can prove the run retires the last-observed schema and
+    // re-records only a payload it fetched itself.
     snapshotSpy,
-    // The connection epoch a recording is stamped with. A fixed value here; the epoch's
-    // real job (refusing a snapshot from a replaced backend) is proved in
-    // object-info-snapshot.test.mjs, where it can be moved.
     7,
   );
 }
@@ -728,11 +719,11 @@ test("#1180: a real backend error outranks a synthesized timeout in the verdict"
 });
 
 test("#1180 EXECUTED: which error survives the retry, across every ordering", async () => {
-  // MIRRORS the panel's loop rather than driving it, which is worth being plain about:
-  // its value is enumerating many orderings cheaply, and the structural test above is what
-  // ties the mirror to the source. The ordering that drives the SHIPPED executor is "a REAL
-  // error survives a later stall" at the end of this file, on virtual timers.
-  //
+  // MIRRORS the panel's loop rather than driving it, which is worth being plain about:
+  // its value is enumerating many orderings cheaply, and the structural test above is what
+  // ties the mirror to the source. The ordering that drives the SHIPPED executor is "a REAL
+  // error survives a later stall" at the end of this file, on virtual timers.
+  //
   // This one runs the real
   // retry loop and shows what a user would actually be told, because "the last error wins"
   // plus "a timeout can be an error" silently changes the verdict for orderings nobody
@@ -754,7 +745,7 @@ test("#1180 EXECUTED: which error survives the retry, across every ordering", as
             if (o === "falsy") throw null; // a real failure whose VALUE is falsy
             result = o === "timeout" ? NO_ANSWER : { KSampler: {} };
           } catch (err) {
-            sawRealError = true;
+            sawRealError = true;
             lastRealError = err;
             throw err;
           }

--- a/browser_tests/unit/node-def-refresh.test.mjs
+++ b/browser_tests/unit/node-def-refresh.test.mjs
@@ -49,6 +49,19 @@ const makeBoundedGetNodeDefs = (apiValue) => (timeoutMs = NODE_DEFS_FETCH_TIMEOU
 let cacheInvalidations = 0;
 const cacheSpy = { invalidate: () => { cacheInvalidations += 1; }, read: async (f) => f() };
 
+/**
+ * #1223 — the last-observed-schema snapshot the refresh run also clears and re-records.
+ * A spy for the same reason cacheSpy is one: the run's contract is that a suspicion of
+ * change RETIRES it and only a successful fetch puts one back, and that is assertable only
+ * if the harness can see both calls.
+ */
+let snapshotClears = 0;
+const snapshotRecords = [];
+const snapshotSpy = {
+  clear: () => { snapshotClears += 1; },
+  record: (defs, epoch) => { snapshotRecords.push({ defs, epoch }); return true; },
+};
+
 import {
   describeNodeDefRefresh,
   NODE_DEF_REFRESH_REASONS,
@@ -406,6 +419,12 @@ function buildRegisterComfyNodeDefs({
     "monotonicNow",
     "NODE_DEFS_RETRY_DELAYS_MS",
     "objectInfoCache",
+    // #1223 — the snapshot the run retires and re-records, and the connection epoch it
+    // stamps a recording with. Both are module state in the panel, so the extracted body
+    // throws ReferenceError without them (the exact failure #1180's note above predicted
+    // for the next collaborator added to this function).
+    "objectInfoSnapshot",
+    "backendReconnectEpoch",
     `// #1180 — defined HERE, from the api this scope already has, so each factory site
      // gets its own stub without threading a helper through every call.
      const boundedGetNodeDefs = async (ms = NODE_DEFS_FETCH_TIMEOUT_MS) => {
@@ -449,6 +468,13 @@ function buildRegisterComfyNodeDefs({
     // #716 — the shipping function drops the widget-write burst cache after a successful
     // fetch. A spy, so the harness can prove that happens rather than merely tolerate it.
     cacheSpy,
+    // #1223 — same reasoning as cacheSpy: a spy, so a test can prove the run retires the
+    // last-observed schema and re-records only what it actually fetched.
+    snapshotSpy,
+    // The connection epoch a recording is stamped with. A fixed value here; the epoch's
+    // real job (refusing a snapshot from a replaced backend) is proved in
+    // object-info-snapshot.test.mjs, where it can be moved.
+    7,
   );
 }
 
@@ -702,11 +728,11 @@ test("#1180: a real backend error outranks a synthesized timeout in the verdict"
 });
 
 test("#1180 EXECUTED: which error survives the retry, across every ordering", async () => {
-  // MIRRORS the panel's loop rather than driving it, which is worth being plain about:
-  // its value is enumerating many orderings cheaply, and the structural test above is what
-  // ties the mirror to the source. The ordering that drives the SHIPPED executor is "a REAL
-  // error survives a later stall" at the end of this file, on virtual timers.
-  //
+  // MIRRORS the panel's loop rather than driving it, which is worth being plain about:
+  // its value is enumerating many orderings cheaply, and the structural test above is what
+  // ties the mirror to the source. The ordering that drives the SHIPPED executor is "a REAL
+  // error survives a later stall" at the end of this file, on virtual timers.
+  //
   // This one runs the real
   // retry loop and shows what a user would actually be told, because "the last error wins"
   // plus "a timeout can be an error" silently changes the verdict for orderings nobody
@@ -728,7 +754,7 @@ test("#1180 EXECUTED: which error survives the retry, across every ordering", as
             if (o === "falsy") throw null; // a real failure whose VALUE is falsy
             result = o === "timeout" ? NO_ANSWER : { KSampler: {} };
           } catch (err) {
-            sawRealError = true;
+            sawRealError = true;
             lastRealError = err;
             throw err;
           }

--- a/browser_tests/unit/object-info-oracle.test.mjs
+++ b/browser_tests/unit/object-info-oracle.test.mjs
@@ -165,7 +165,7 @@ test("#982 (codex) the fallback is consulted ONLY when the client returned nothi
   const clientBlock = src.slice(src.indexOf("if (typeof getNodeDefs === \"function\")"), src.indexOf("// SECOND TRANSPORT"));
   assert.match(
     clientBlock,
-    /if \(usableDefs\(defs\)\) return \{ \[CACHE_OUTCOME\]: true, defs, failures \};/,
+    /if \(usableDefs\(defs\)\) return \{ \[CACHE_OUTCOME\]: true, defs, failures, outcomes \};/,
     "a usable client answer returns",
   );
   // …and the measured equivalence is recorded rather than assumed.

--- a/browser_tests/unit/object-info-oracle.test.mjs
+++ b/browser_tests/unit/object-info-oracle.test.mjs
@@ -153,7 +153,13 @@ test("#982 source guard: the refusal states an observation, and the panel wires 
   );
   const panel = readFileSync(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8");
   assert.match(panel, /fetchWholeObjectInfo\(\{/, "the panel asks through the two-transport oracle");
-  assert.match(panel, /describeObjectInfoFailure: \(\) => objectInfoOracleFailureNote/, "and can report what failed");
+  // #1223 wrapped this across lines to append the snapshot's ineligibility reason AFTER
+  // the route note — deliberately outside `failures`, so "Tried N routes" stays honest.
+  assert.match(
+    panel,
+    /describeObjectInfoFailure: \(\) =>\s*objectInfoOracleFailureNote\(oracleFailures\)/,
+    "and can report what failed",
+  );
   // The burst cache still wraps it: two transports must not become two fetches per write.
   assert.match(panel, /await objectInfoCache\.read\(async \(\) => \{/, "still read through the #716 cache");
 });

--- a/browser_tests/unit/object-info-snapshot.test.mjs
+++ b/browser_tests/unit/object-info-snapshot.test.mjs
@@ -661,16 +661,18 @@ test("#1223 the snapshot is recorded ONLY where a WHOLE schema was fetched, and 
   const sites = [...PANEL_SRC.matchAll(/objectInfoSnapshot\.record\(/g)];
   assert.equal(
     sites.length,
-    4,
-    "startup seed, refresh run, set_widget oracle, add_node resolver — add one and justify it here",
+    6,
+    "startup seed, refresh run, set_widget oracle, add_node resolver, get_object_info, " +
+      "remove_widget — every reader that obtains a WHOLE schema files it, and adding one " +
+      "means justifying it here",
   );
   // The add_node site is gated on the panel's own record of WHICH question it asked. A
   // single-class /object_info/<Type> payload reaching the snapshot would make every other
   // type read as absent and the ever-seen gate diagnose the install as removed packs.
   assert.match(
     PANEL_SRC,
-    /if \(freshDefs && !freshDefsAreSingleClass\) \{\s*\n\s*objectInfoSnapshot\.record\(/,
-    "add_node files its payload only when it fetched the WHOLE schema",
+    /if \(freshDefs && !freshDefsAreSingleClass && addNodeObservedAtEpoch !== null\) \{\s*\n\s*objectInfoSnapshot\.record\(/,
+    "add_node files its payload only when it fetched the WHOLE schema, and only then",
   );
   for (const site of sites) {
     const call = PANEL_SRC.slice(site.index, site.index + 260);

--- a/browser_tests/unit/object-info-snapshot.test.mjs
+++ b/browser_tests/unit/object-info-snapshot.test.mjs
@@ -219,6 +219,34 @@ test("#1223 a 502 cannot license the fallback even when every other route went q
   );
 });
 
+test("#1223 an UNSTABLE status cannot classify as silence while reporting a disqualifying code", async () => {
+  // This module deliberately supports a monkey-patched fetchApi returning a proxied or
+  // getter-backed response — its own comments say so — and such a response can answer
+  // differently on each read. Two reads let a first value of 504 license the fallback while
+  // the second, 502, is what the reply names: the decision and the disclosure would then
+  // describe different responses, and the licensing one is invisible to the reader.
+  let reads = 0;
+  const flipflop = {
+    ok: false,
+    get status() {
+      reads += 1;
+      return reads === 1 ? 504 : 502;
+    },
+  };
+  const { outcomes, failures } = await fetchWholeObjectInfo({
+    deadlineMs: 40,
+    getNodeDefs: null,
+    fetchApi: async () => flipflop,
+  });
+  const reported = /status (\d+)/.exec(failures.join(" "))?.[1];
+  const silent = outcomes.at(-1).kind === TRANSPORT_OUTCOME.NO_ANSWER;
+  assert.equal(
+    silent,
+    reported === "504",
+    `classification and disclosure must describe the SAME response (reported ${reported}, silent=${silent})`,
+  );
+});
+
 test("#1223 the gateway refusal SAYS it was a proxy, not the backend", async () => {
   const { failures } = await fetchWholeObjectInfo({
     deadlineMs: 40,
@@ -631,7 +659,19 @@ test("#1223 the snapshot is recorded ONLY where a WHOLE schema was fetched, and 
   // Each CALL SITE is checked for its own claim. Counting `whole: true` across the file
   // instead counted the comment that documents the rule, which is not a call site.
   const sites = [...PANEL_SRC.matchAll(/objectInfoSnapshot\.record\(/g)];
-  assert.equal(sites.length, 3, "startup seed, refresh run, set_widget oracle — add one and justify it here");
+  assert.equal(
+    sites.length,
+    4,
+    "startup seed, refresh run, set_widget oracle, add_node resolver — add one and justify it here",
+  );
+  // The add_node site is gated on the panel's own record of WHICH question it asked. A
+  // single-class /object_info/<Type> payload reaching the snapshot would make every other
+  // type read as absent and the ever-seen gate diagnose the install as removed packs.
+  assert.match(
+    PANEL_SRC,
+    /if \(freshDefs && !freshDefsAreSingleClass\) \{\s*\n\s*objectInfoSnapshot\.record\(/,
+    "add_node files its payload only when it fetched the WHOLE schema",
+  );
   for (const site of sites) {
     const call = PANEL_SRC.slice(site.index, site.index + 260);
     assert.match(call, /whole: true/, `the record site at index ${site.index} states the wholeness claim`);

--- a/browser_tests/unit/object-info-snapshot.test.mjs
+++ b/browser_tests/unit/object-info-snapshot.test.mjs
@@ -652,8 +652,157 @@ test("#1223 SHIPPED: the ineligibility reason is NOT counted as a transport rout
 });
 
 // ---------------------------------------------------------------------------
-// The panel wiring, pinned at the source level
+// The OTHER whole-schema readers, extracted and driven
+//
+// A source-count assertion cannot pin these: wrapping a record site in `if (false)` leaves
+// the call text — and therefore the count — untouched. Mutation caught exactly that, in a
+// test written after learning the same lesson about the startup seed.
 // ---------------------------------------------------------------------------
+
+/** Balanced-brace extraction of a `async <name>(...) { ... }` executor from the panel. */
+function extractExecutor(name) {
+  const start = PANEL_SRC.indexOf(`async ${name}(`);
+  assert.notEqual(start, -1, `${name} not found`);
+  // Skip the PARAMETER LIST before looking for the body. These executors destructure their
+  // argument — `async graph_get_object_info({ if_none_match } = {})` — so the first `{` in
+  // the text is the parameter pattern, and a scanner that starts there closes on its own
+  // `}` and "extracts" 45 characters of signature.
+  const paren = PANEL_SRC.indexOf("(", start);
+  let parenDepth = 0;
+  let afterParams = -1;
+  for (let i = paren; i < PANEL_SRC.length; i += 1) {
+    if (PANEL_SRC[i] === "(") parenDepth += 1;
+    if (PANEL_SRC[i] === ")" && --parenDepth === 0) {
+      afterParams = i;
+      break;
+    }
+  }
+  assert.notEqual(afterParams, -1, `${name} parameter list is unterminated`);
+  const open = PANEL_SRC.indexOf("{", afterParams);
+  let depth = 0;
+  for (let i = open; i < PANEL_SRC.length; i += 1) {
+    const ch = PANEL_SRC[i];
+    if (ch === "/" && PANEL_SRC[i + 1] === "/") {
+      i = PANEL_SRC.indexOf("\n", i + 2);
+      if (i < 0) break;
+      continue;
+    }
+    if (ch === '"' || ch === "'" || ch === "`") {
+      const quote = ch;
+      for (i += 1; i < PANEL_SRC.length; i += 1) {
+        if (PANEL_SRC[i] === "\\") {
+          i += 1;
+          continue;
+        }
+        if (PANEL_SRC[i] === quote) break;
+      }
+      continue;
+    }
+    if (ch === "{") depth += 1;
+    if (ch === "}" && --depth === 0) return PANEL_SRC.slice(start, i + 1);
+  }
+  throw new Error(`unterminated ${name}`);
+}
+
+function buildExecutor(name, deps) {
+  const names = Object.keys(deps);
+  const factory = new Function(...names, `const executors = { ${extractExecutor(name)} };\nreturn executors.${name};`);
+  return factory(...names.map((n) => deps[n]));
+}
+
+test("#1223 SHIPPED get_object_info: a successful whole read IS filed", async () => {
+  // After a failed startup seed, or a reconnect that cleared the snapshot, this command can
+  // be the only thing that has successfully read a whole schema. Dropping it left the next
+  // render-time widget edit refused for want of the very map it had just read.
+  const snapshot = createObjectInfoSnapshot();
+  const get = buildExecutor("graph_get_object_info", {
+    fetchWholeObjectInfo: async () => ({ defs: SCHEMA, failures: [], outcomes: [] }),
+    objectInfoSnapshot: snapshot,
+    backendReconnectEpoch: 9,
+    api: { getNodeDefs: async () => SCHEMA },
+    pageComfyOrigin: () => "http://127.0.0.1:8188",
+    objectInfoOracleFailureNote: () => "",
+    objectInfoFingerprint: () => "fp",
+    objectInfoUnchanged: (etag) => etag === "fp",
+  });
+
+  const res = await get({});
+  assert.equal(res.ok, true);
+  assert.deepEqual(snapshot.peek(), { held: true, epoch: 9 }, "filed at the epoch it was read on");
+
+  // ...and the if_none_match early-return still keeps it fed, which is why the record sits
+  // above that branch: a caller polling with a fingerprint would otherwise never file one.
+  const snapshot2 = createObjectInfoSnapshot();
+  const get2 = buildExecutor("graph_get_object_info", {
+    fetchWholeObjectInfo: async () => ({ defs: SCHEMA, failures: [], outcomes: [] }),
+    objectInfoSnapshot: snapshot2,
+    backendReconnectEpoch: 9,
+    api: { getNodeDefs: async () => SCHEMA },
+    pageComfyOrigin: () => "http://127.0.0.1:8188",
+    objectInfoOracleFailureNote: () => "",
+    objectInfoFingerprint: () => "fp",
+    objectInfoUnchanged: (etag) => etag === "fp",
+  });
+  const unchanged = await get2({ if_none_match: "fp" });
+  assert.equal(unchanged.unchanged, true, "the early return still happens");
+  assert.equal(snapshot2.peek().held, true, "and the snapshot was still fed on the way there");
+});
+
+test("#1223 SHIPPED get_object_info: a FAILED read files nothing", async () => {
+  const snapshot = createObjectInfoSnapshot();
+  const get = buildExecutor("graph_get_object_info", {
+    fetchWholeObjectInfo: async () => ({ defs: null, failures: ["nope"], outcomes: [] }),
+    objectInfoSnapshot: snapshot,
+    backendReconnectEpoch: 9,
+    api: {},
+    pageComfyOrigin: () => "http://127.0.0.1:8188",
+    objectInfoOracleFailureNote: () => "",
+    objectInfoFingerprint: () => "fp",
+    objectInfoUnchanged: () => false,
+  });
+  const res = await get({});
+  assert.equal(res.ok, false);
+  assert.equal(snapshot.peek().held, false);
+});
+
+function buildRemoveWidget({ snapshot, epoch = 4, cache, defs = SCHEMA }) {
+  const node = { id: 3, type: "KSampler", comfyClass: "KSampler", widgets: [{ name: "seed" }] };
+  return buildExecutor("graph_remove_widget", {
+    getGraphCtx: () => ({ graph: {} }),
+    resolveNode: () => node,
+    objectInfoCache: cache,
+    fetchWholeObjectInfo: async () => ({ defs, failures: [], outcomes: [] }),
+    CACHE_OUTCOME,
+    objectInfoSnapshot: snapshot,
+    backendReconnectEpoch: epoch,
+    api: {},
+    recordObjectInfoTypes: (d) => d,
+    declaredInputNames: () => new Set(["seed"]),
+    objectInfoOracleFailureNote: () => "",
+    assertActiveWorkflowCommandTarget: () => {},
+    WORKFLOW_UUID_FIELD: "workflow_uuid",
+    runRemoveWidget: async () => ({ ok: true }),
+  });
+}
+
+test("#1223 SHIPPED remove_widget: the whole schema it paid for IS filed", async () => {
+  const snapshot = createObjectInfoSnapshot();
+  const remove = buildRemoveWidget({ snapshot, epoch: 4, cache: createObjectInfoCache() });
+  await remove({ node_id: 3, widget: "seed" });
+  assert.deepEqual(snapshot.peek(), { held: true, epoch: 4 });
+});
+
+test("#1223 SHIPPED remove_widget: a CACHE HIT is not filed", async () => {
+  // Same rule as set_widget: a cached payload may predate a reconnect, and this call cannot
+  // vouch for when it was issued.
+  const snapshot = createObjectInfoSnapshot();
+  const cache = createObjectInfoCache();
+  const remove = buildRemoveWidget({ snapshot, epoch: 4, cache });
+  await remove({ node_id: 3, widget: "seed" });
+  snapshot.clear();
+  await remove({ node_id: 3, widget: "seed" }); // within the TTL ⇒ served from store
+  assert.equal(snapshot.peek().held, false, "the second call never issued a request of its own");
+});
 
 test("#1223 the snapshot is recorded ONLY where a WHOLE schema was fetched, and vouched for", () => {
   // Each CALL SITE is checked for its own claim. Counting `whole: true` across the file

--- a/browser_tests/unit/object-info-snapshot.test.mjs
+++ b/browser_tests/unit/object-info-snapshot.test.mjs
@@ -644,14 +644,96 @@ test("#1223 the snapshot is recorded ONLY where a WHOLE schema was fetched, and 
   );
 });
 
-test("#1223 the STARTUP read is snapshotted — otherwise the reported case is still refused", () => {
-  // On a normal startup, seedObjectInfoHistory performs the ONLY whole /object_info read;
-  // registerComfyNodeDefs does not run. Without recording there, a first widget edit during
-  // a render found no snapshot and was refused exactly as before the fix.
-  const seed = PANEL_SRC.slice(PANEL_SRC.indexOf("function seedObjectInfoHistory("));
-  const body = seed.slice(0, seed.indexOf("\nasync function "));
-  assert.match(body, /const observedAtEpoch = backendReconnectEpoch;/, "the epoch is captured before the fetch");
-  assert.match(body, /objectInfoSnapshot\.record\(defs, \{/, "and the startup payload is recorded");
+/**
+ * The SHIPPED `seedObjectInfoHistory`, extracted and driven.
+ *
+ * A source-regex test was tried first and is not good enough: `if (false) record(...)` still
+ * MATCHES the pattern, so disabling the startup snapshot left the assertion green. Mutation
+ * caught that. A test for whether code RUNS has to run it.
+ */
+function buildShippedSeed({ api, epoch = 2, snapshot, epochDuringFetch = null }) {
+  const start = PANEL_SRC.indexOf("function seedObjectInfoHistory()");
+  assert.notEqual(start, -1, "seedObjectInfoHistory not found");
+  const open = PANEL_SRC.indexOf("{", start);
+  let depth = 0;
+  let body = null;
+  for (let i = open; i < PANEL_SRC.length; i += 1) {
+    const ch = PANEL_SRC[i];
+    if (ch === "/" && PANEL_SRC[i + 1] === "/") {
+      i = PANEL_SRC.indexOf("\n", i + 2);
+      if (i < 0) break;
+      continue;
+    }
+    if (ch === "{") depth += 1;
+    if (ch === "}" && --depth === 0) {
+      body = PANEL_SRC.slice(start, i + 1);
+      break;
+    }
+  }
+  assert.ok(body, "unterminated seedObjectInfoHistory");
+
+  const factory = new Function(
+    "api",
+    "objectInfoSnapshot",
+    "initialEpoch",
+    "epochDuringFetch",
+    "objectInfoHistory",
+    `let backendReconnectEpoch = initialEpoch;
+     let objectInfoHistorySeed = null;
+     const recorded = [];
+     let seeded = false;
+     const recordObjectInfoTypes = (defs) => { recorded.push(defs); return defs; };
+     const markObjectInfoHistorySeeded = () => { seeded = true; return true; };
+     ${body}
+     return {
+       run: () => seedObjectInfoHistory(),
+       readRecorded: () => recorded,
+       wasSeeded: () => seeded,
+       setEpoch: (n) => { backendReconnectEpoch = n; },
+     };`,
+  );
+  const built = factory(
+    {
+      getNodeDefs: async () => {
+        // Move the epoch WHILE the request is outstanding — the reconnect-mid-fetch hazard.
+        if (epochDuringFetch !== null) built.setEpoch(epochDuringFetch);
+        return api.defs;
+      },
+    },
+    snapshot,
+    epoch,
+    null,
+    { loseBaseline: () => {} },
+  );
+  return built;
+}
+
+test("#1223 SHIPPED STARTUP: the seed's whole read IS snapshotted", async () => {
+  // On a normal startup this is the ONLY whole /object_info read that happens —
+  // registerComfyNodeDefs does not run unless something triggers a refresh. Without this,
+  // the reported case (first widget edit during a render, both probes silent) finds no
+  // snapshot and is refused exactly as before the fix. That was the shipped v1 behaviour.
+  const snapshot = createObjectInfoSnapshot();
+  const seed = buildShippedSeed({ api: { defs: SCHEMA }, epoch: 2, snapshot });
+  await seed.run();
+  assert.equal(seed.wasSeeded(), true, "the history baseline still lands");
+  assert.deepEqual(seed.readRecorded(), [SCHEMA], "and the ever-seen history still takes it");
+  assert.deepEqual(snapshot.peek(), { held: true, epoch: 2 }, "and the snapshot is filed at the startup epoch");
+});
+
+test("#1223 SHIPPED STARTUP: a failed seed leaves no snapshot", async () => {
+  const snapshot = createObjectInfoSnapshot();
+  const seed = buildShippedSeed({ api: { defs: null }, epoch: 2, snapshot });
+  await seed.run();
+  assert.equal(snapshot.peek().held, false, "nothing observed, nothing filed");
+});
+
+test("#1223 SHIPPED STARTUP: a reconnect during the seed's fetch is not filed", async () => {
+  const snapshot = createObjectInfoSnapshot();
+  const seed = buildShippedSeed({ api: { defs: SCHEMA }, epoch: 2, snapshot, epochDuringFetch: 3 });
+  await seed.run();
+  assert.equal(seed.wasSeeded(), true, "the history is still seeded — that trust root is separate");
+  assert.equal(snapshot.peek().held, false, "but the payload describes the connection that was replaced");
 });
 
 test("#1223 the socket handlers clear the snapshot DIRECTLY, not by way of a refresh", () => {

--- a/browser_tests/unit/object-info-snapshot.test.mjs
+++ b/browser_tests/unit/object-info-snapshot.test.mjs
@@ -123,6 +123,52 @@ test("#1223 the oracle's real tags drive it — not a list hand-written in this 
   assert.equal(transportsWereSilent(notOk.outcomes), false, "a 503 is an answer");
 });
 
+test("#1223 EACH route's tag is pinned on its own, not through the aggregate", async () => {
+  // Mutation-driven. Asserting only `transportsWereSilent(...) === false` over a TWO-route
+  // failure lets one correct tag mask a wrong one: mistagging the client's THREW as
+  // silence survived, because the http route's own THREW still carried the verdict. The
+  // tag is the thing the fallback reads, so the tag is what has to be pinned.
+  const kinds = async (opts) => (await fetchWholeObjectInfo({ deadlineMs: 40, ...opts })).outcomes.map((o) => o.kind);
+
+  assert.deepEqual(
+    await kinds({
+      getNodeDefs: async () => {
+        throw new TypeError("Failed to fetch");
+      },
+      fetchApi: null,
+    }),
+    [TRANSPORT_OUTCOME.THREW, TRANSPORT_OUTCOME.NOT_ATTEMPTED],
+    "a refused connection on the client route is an ANSWER, never silence",
+  );
+
+  assert.deepEqual(
+    await kinds({ getNodeDefs: null, fetchApi: async () => ({ ok: false, status: 503 }) }),
+    [TRANSPORT_OUTCOME.NOT_ATTEMPTED, TRANSPORT_OUTCOME.ANSWERED_UNUSABLE],
+    "a non-OK status is an answer; an unwired client is a route nobody asked",
+  );
+
+  assert.deepEqual(
+    await kinds({
+      getNodeDefs: null,
+      fetchApi: async () => ({ ok: true, status: 200, json: () => new Promise(() => {}) }),
+    }),
+    [TRANSPORT_OUTCOME.NOT_ATTEMPTED, TRANSPORT_OUTCOME.ANSWERED_UNUSABLE],
+    "headers arrived, so the backend answered — a stalled BODY is not the silence this licenses",
+  );
+
+  assert.deepEqual(
+    await kinds({ getNodeDefs: async () => ({}), fetchApi: async () => ({ ok: true, json: async () => SCHEMA }) }),
+    [TRANSPORT_OUTCOME.ANSWERED_UNUSABLE],
+    "an EMPTY client schema is its answer (#982), and it short-circuits before the fallback",
+  );
+
+  assert.deepEqual(
+    await kinds({ getNodeDefs: () => new Promise(() => {}), fetchApi: null }),
+    [TRANSPORT_OUTCOME.NO_ANSWER, TRANSPORT_OUTCOME.NOT_ATTEMPTED],
+    "and a hung client with no fallback wired is the one shape that licenses",
+  );
+});
+
 test("#1223 a usable answer still returns its outcomes alongside the schema", async () => {
   const { defs, outcomes } = await fetchWholeObjectInfo({
     getNodeDefs: async () => SCHEMA,

--- a/browser_tests/unit/object-info-snapshot.test.mjs
+++ b/browser_tests/unit/object-info-snapshot.test.mjs
@@ -1,0 +1,460 @@
+/**
+ * #1223 — `panel_set_widget` refused a live edit on an existing `H3Keyframes` node because
+ * BOTH `/object_info` probes timed out, while the canvas was reachable and `panel_disconnect`
+ * mutations had succeeded moments earlier. ComfyUI serves HTTP from the process that runs
+ * the graph, so a render blocks the schema fetch: a BUSY backend, not an absent one.
+ *
+ * The fix authorizes from the last WHOLE schema observed on the CURRENT backend connection,
+ * under four conditions that all fail closed. These tests exist to keep each condition
+ * load-bearing — every one of them is the difference between this and re-opening #458.
+ *
+ * The last block drives the SHIPPED `getFreshObjectInfo` body extracted from the panel, not
+ * a re-implementation of it. A test that reasons about a copy of the wiring proves the copy.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+import {
+  createObjectInfoSnapshot,
+  transportsWereSilent,
+  snapshotAuthorizationNote,
+} from "../../web/js/lib/object-info-snapshot.js";
+import { TRANSPORT_OUTCOME, fetchWholeObjectInfo } from "../../web/js/lib/object-info-oracle.js";
+import { createObjectInfoCache, CACHE_OUTCOME } from "../../web/js/lib/object-info-cache.js";
+import { objectInfoOracleFailureNote } from "../../web/js/lib/object-info-oracle.js";
+
+const SCHEMA = { KSampler: { input: {} }, H3Keyframes: { input: {} } };
+const silence = [
+  { route: "client", kind: TRANSPORT_OUTCOME.NO_ANSWER },
+  { route: "http", kind: TRANSPORT_OUTCOME.NO_ANSWER },
+];
+
+// ---------------------------------------------------------------------------
+// Condition 4: SILENCE, not merely failure
+// ---------------------------------------------------------------------------
+
+test("#1223 both probes timing out is the silence this licenses", () => {
+  assert.equal(transportsWereSilent(silence), true);
+});
+
+test("#1223 a route that THREW disqualifies — a refused connection is a process that is gone", () => {
+  // `TypeError: Failed to fetch` is what ECONNREFUSED produces in a browser. That is the
+  // signature of a backend that is DOWN, and a down backend may be restarting — the one
+  // event that can change the type set. Silence is the signature of one that is busy.
+  assert.equal(
+    transportsWereSilent([
+      { route: "client", kind: TRANSPORT_OUTCOME.NO_ANSWER },
+      { route: "http", kind: TRANSPORT_OUTCOME.THREW },
+    ]),
+    false,
+  );
+});
+
+test("#1223 a route that ANSWERED something unusable disqualifies", () => {
+  // A non-OK status, an empty schema, a body that stalled after its headers arrived. All
+  // are a backend saying something, which is a different fault from the reported one.
+  assert.equal(
+    transportsWereSilent([
+      { route: "client", kind: TRANSPORT_OUTCOME.NO_ANSWER },
+      { route: "http", kind: TRANSPORT_OUTCOME.ANSWERED_UNUSABLE },
+    ]),
+    false,
+  );
+});
+
+test("#1223 never-contacted routes are neutral, but cannot license on their own", () => {
+  assert.equal(
+    transportsWereSilent([
+      { route: "client", kind: TRANSPORT_OUTCOME.NOT_ATTEMPTED },
+      { route: "http", kind: TRANSPORT_OUTCOME.NO_ANSWER },
+    ]),
+    true,
+    "one route silent, the other never asked — still the reported condition",
+  );
+  assert.equal(
+    transportsWereSilent([
+      { route: "client", kind: TRANSPORT_OUTCOME.NOT_ATTEMPTED },
+      { route: "http", kind: TRANSPORT_OUTCOME.NOT_ATTEMPTED },
+    ]),
+    false,
+    "nothing was ever asked, so nothing was observed to be silent",
+  );
+});
+
+test("#1223 an absent, empty, or unrecognised outcome list licenses nothing", () => {
+  // "We recorded nothing" is not evidence of silence. A caller that lost the outcomes — or
+  // one handing in a shape this module never produced — must get the refusal.
+  assert.equal(transportsWereSilent(undefined), false);
+  assert.equal(transportsWereSilent([]), false);
+  assert.equal(transportsWereSilent("no-answer"), false);
+  assert.equal(transportsWereSilent([{ route: "client", kind: "invented" }]), false);
+  assert.equal(transportsWereSilent([null, { kind: TRANSPORT_OUTCOME.NO_ANSWER }]), false);
+  assert.equal(transportsWereSilent(["no-answer", "no-answer"]), false, "bare strings are not outcomes");
+});
+
+test("#1223 the oracle's real tags drive it — not a list hand-written in this test", async () => {
+  // The tags and the prose must describe the SAME attempt. Pinning only hand-made lists
+  // would let the oracle stop emitting them, or emit the wrong one, with the suite green.
+  const timedOut = await fetchWholeObjectInfo({
+    getNodeDefs: () => new Promise(() => {}),
+    fetchApi: () => new Promise(() => {}),
+    deadlineMs: 20,
+  });
+  assert.equal(timedOut.defs, null);
+  assert.equal(transportsWereSilent(timedOut.outcomes), true, "two hung transports read as silence");
+  assert.equal(timedOut.outcomes.length, timedOut.failures.length, "one tag per recorded attempt");
+
+  const refused = await fetchWholeObjectInfo({
+    getNodeDefs: async () => {
+      throw new TypeError("Failed to fetch");
+    },
+    fetchApi: async () => {
+      throw new TypeError("Failed to fetch");
+    },
+  });
+  assert.equal(refused.defs, null);
+  assert.equal(transportsWereSilent(refused.outcomes), false, "a refused connection is not silence");
+
+  const notOk = await fetchWholeObjectInfo({
+    getNodeDefs: async () => null,
+    fetchApi: async () => ({ ok: false, status: 503 }),
+  });
+  assert.equal(transportsWereSilent(notOk.outcomes), false, "a 503 is an answer");
+});
+
+test("#1223 a usable answer still returns its outcomes alongside the schema", async () => {
+  const { defs, outcomes } = await fetchWholeObjectInfo({
+    getNodeDefs: async () => SCHEMA,
+    fetchApi: null,
+  });
+  assert.equal(defs, SCHEMA);
+  assert.deepEqual(outcomes, [], "the route that answered is not a failure, so nothing is tagged");
+});
+
+// ---------------------------------------------------------------------------
+// Conditions 1–3: a snapshot, an unbroken connection, the same process
+// ---------------------------------------------------------------------------
+
+test("#1223 the reported case: silent probes on an unbroken connection authorize", () => {
+  const snap = createObjectInfoSnapshot();
+  assert.equal(snap.record(SCHEMA, 3), true);
+  const { defs, reason } = snap.authorize({ epoch: 3, socketDown: false, outcomes: silence });
+  assert.equal(defs, SCHEMA, "the edit the reporter was refused is authorized");
+  assert.equal(reason, "");
+});
+
+test("#1223 a DOWN socket refuses — a restarting backend is the one thing that moves the type set", () => {
+  const snap = createObjectInfoSnapshot();
+  snap.record(SCHEMA, 3);
+  const { defs, reason } = snap.authorize({ epoch: 3, socketDown: true, outcomes: silence });
+  assert.equal(defs, null);
+  assert.match(reason, /socket is down/i);
+});
+
+test("#1223 a RECONNECT since the observation refuses — it describes a replaced process", () => {
+  const snap = createObjectInfoSnapshot();
+  snap.record(SCHEMA, 3);
+  const { defs, reason } = snap.authorize({ epoch: 4, socketDown: false, outcomes: silence });
+  assert.equal(defs, null);
+  assert.match(reason, /reconnected/i);
+  // Provenance, not freshness: the snapshot is refused outright rather than aged out, so
+  // there is no time bound here to get wrong.
+  assert.equal(
+    snap.authorize({ epoch: 3, socketDown: false, outcomes: silence }).defs,
+    SCHEMA,
+    "and the SAME epoch still authorizes — age alone was never the question",
+  );
+});
+
+test("#1223 an unreadable epoch refuses — a snapshot that cannot prove provenance is worse than none", () => {
+  const snap = createObjectInfoSnapshot();
+  snap.record(SCHEMA, 3);
+  for (const epoch of [undefined, null, NaN, Infinity, "3"]) {
+    assert.equal(snap.authorize({ epoch, socketDown: false, outcomes: silence }).defs, null, `epoch ${String(epoch)}`);
+  }
+});
+
+test("#1223 an epoch that cannot be compared later is never stored", () => {
+  const snap = createObjectInfoSnapshot();
+  assert.equal(snap.record(SCHEMA, undefined), false);
+  assert.equal(snap.record(SCHEMA, NaN), false);
+  assert.equal(snap.record(SCHEMA, "3"), false);
+  assert.equal(snap.peek().held, false);
+});
+
+test("#1223 nothing observed yet refuses, and SAYS that rather than blaming a reconnect", () => {
+  // #982's lesson: a caller told the wrong cause goes looking in the wrong place.
+  const snap = createObjectInfoSnapshot();
+  const { defs, reason } = snap.authorize({ epoch: 1, socketDown: false, outcomes: silence });
+  assert.equal(defs, null);
+  assert.match(reason, /no whole \/object_info has been observed/i);
+});
+
+test("#1223 a backend that ANSWERED is told apart from an empty snapshot in the reason", () => {
+  const snap = createObjectInfoSnapshot();
+  snap.record(SCHEMA, 1);
+  const { defs, reason } = snap.authorize({
+    epoch: 1,
+    socketDown: false,
+    outcomes: [{ route: "http", kind: TRANSPORT_OUTCOME.THREW }],
+  });
+  assert.equal(defs, null);
+  assert.match(reason, /ANSWERED/);
+});
+
+test("#1223 only a payload that could authorize anything is stored", () => {
+  const snap = createObjectInfoSnapshot();
+  for (const bad of [null, undefined, {}, [], "schema", 7, [SCHEMA]]) {
+    assert.equal(snap.record(bad, 1), false, `${JSON.stringify(bad) ?? String(bad)} is not a schema`);
+  }
+  assert.equal(snap.peek().held, false, "a failed fetch never displaces a good snapshot with nothing");
+});
+
+test("#1223 a payload whose own shape cannot be inspected is not stored", () => {
+  // `Object.keys` invokes a Proxy's ownKeys trap, which can throw — the same hazard the
+  // oracle's `usableDefs` guards. A diagnostic path must not raise an exception of its own.
+  const hostile = new Proxy(
+    {},
+    {
+      ownKeys() {
+        throw new Error("nope");
+      },
+    },
+  );
+  const snap = createObjectInfoSnapshot();
+  assert.doesNotThrow(() => snap.record(hostile, 1));
+  assert.equal(snap.record(hostile, 1), false);
+});
+
+test("#1223 a good snapshot is not displaced by a later failed fetch", () => {
+  const snap = createObjectInfoSnapshot();
+  snap.record(SCHEMA, 2);
+  snap.record(null, 2);
+  snap.record({}, 2);
+  assert.equal(snap.authorize({ epoch: 2, socketDown: false, outcomes: silence }).defs, SCHEMA);
+});
+
+test("#1223 clear() retires it — a suspicion of change outranks a stored schema", () => {
+  const snap = createObjectInfoSnapshot();
+  snap.record(SCHEMA, 2);
+  snap.clear();
+  assert.equal(snap.authorize({ epoch: 2, socketDown: false, outcomes: silence }).defs, null);
+  assert.equal(snap.peek().held, false);
+});
+
+test("#1223 a successful write authorized this way DISCLOSES it", () => {
+  // A write reported as SUCCEEDED and VERIFIED, verified against a schema nobody could
+  // re-fetch, is indistinguishable from a fully live authorization unless it says so.
+  const note = snapshotAuthorizationNote(" Tried 2 routes: a; b.");
+  assert.match(note, /SUCCEEDED/);
+  assert.match(note, /last whole \/object_info observed/);
+  assert.match(note, /#1223/);
+  assert.match(note, /Tried 2 routes/, "the routes that went silent ride along");
+});
+
+// ---------------------------------------------------------------------------
+// The SHIPPED wiring, extracted and driven — not a re-implementation
+// ---------------------------------------------------------------------------
+
+const PANEL_SRC = readFileSync(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8");
+
+/** Balanced-brace extraction of the set_widget oracle, by the marker above its body. */
+function extractSetWidgetOracle() {
+  const anchor = PANEL_SRC.indexOf("// #716 — READ THROUGH THE BURST CACHE.");
+  assert.notEqual(anchor, -1, "the set_widget oracle's marker comment moved");
+  const start = PANEL_SRC.lastIndexOf("getFreshObjectInfo: async () => {", anchor);
+  assert.notEqual(start, -1, "getFreshObjectInfo not found above its own marker");
+  const open = PANEL_SRC.indexOf("{", start);
+  let depth = 0;
+  for (let i = open; i < PANEL_SRC.length; i += 1) {
+    const ch = PANEL_SRC[i];
+    if (ch === "/" && PANEL_SRC[i + 1] === "/") {
+      i = PANEL_SRC.indexOf("\n", i + 2);
+      if (i < 0) break;
+      continue;
+    }
+    if (ch === '"' || ch === "'" || ch === "`") {
+      const quote = ch;
+      for (i += 1; i < PANEL_SRC.length; i += 1) {
+        if (PANEL_SRC[i] === "\\") {
+          i += 1;
+          continue;
+        }
+        if (PANEL_SRC[i] === quote) break;
+      }
+      continue;
+    }
+    if (ch === "{") depth += 1;
+    if (ch === "}" && --depth === 0) return PANEL_SRC.slice(open, i + 1);
+  }
+  throw new Error("unterminated getFreshObjectInfo");
+}
+
+/**
+ * Build the SHIPPED oracle body with doubles for the module state it closes over, so these
+ * cases run the production code path rather than a description of it.
+ */
+function buildShippedOracle({ api, socketDown = false, epoch = 5, snapshot }) {
+  const body = extractSetWidgetOracle();
+  const factory = new Function(
+    "api",
+    "objectInfoCache",
+    "fetchWholeObjectInfo",
+    "CACHE_OUTCOME",
+    "objectInfoSnapshot",
+    "backendReconnectEpoch",
+    "comfyBackendSocketDown",
+    "recordObjectInfoTypes",
+    "objectInfoOracleFailureNote",
+    `let oracleFailures = [];
+     let setWidgetSchemaFromSnapshot = null;
+     const historyRecorded = [];
+     const getFreshObjectInfo = async () => ${body};
+     return {
+       getFreshObjectInfo,
+       readFailures: () => oracleFailures,
+       readSnapshotNote: () => setWidgetSchemaFromSnapshot,
+       readHistory: () => historyRecorded,
+       recordHistory: (defs) => { historyRecorded.push(defs); return defs; },
+     };`,
+  );
+  const built = factory(
+    api,
+    createObjectInfoCache(),
+    // The SHIPPED oracle, on a budget a test can wait for. Only `deadlineMs` is
+    // substituted, so the tags these cases read are the ones production produces — the
+    // suite must not spend 20 real seconds per hung-transport case to learn that.
+    (opts) => fetchWholeObjectInfo({ ...opts, deadlineMs: 20 }),
+    CACHE_OUTCOME,
+    snapshot,
+    epoch,
+    socketDown,
+    (defs) => built.recordHistory(defs),
+    objectInfoOracleFailureNote,
+  );
+  return built;
+}
+
+const hungApi = { getNodeDefs: () => new Promise(() => {}), fetchApi: () => new Promise(() => {}) };
+
+test("#1223 SHIPPED: a live answer is returned and snapshotted", async () => {
+  const snapshot = createObjectInfoSnapshot();
+  const o = buildShippedOracle({ api: { getNodeDefs: async () => SCHEMA }, snapshot, epoch: 5 });
+  assert.equal(await o.getFreshObjectInfo(), SCHEMA);
+  assert.deepEqual(snapshot.peek(), { held: true, epoch: 5 }, "stamped with the connection it was read on");
+  assert.equal(o.readSnapshotNote(), null, "a live authorization discloses nothing, because there is nothing to disclose");
+  assert.deepEqual(o.readHistory(), [SCHEMA], "and it IS a real observation, so the ever-seen history takes it");
+});
+
+test("#1223 SHIPPED: the reported case — hung probes fall back and disclose", async () => {
+  const snapshot = createObjectInfoSnapshot();
+  snapshot.record(SCHEMA, 5);
+  const o = buildShippedOracle({ api: hungApi, snapshot, epoch: 5, socketDown: false });
+  assert.equal(await o.getFreshObjectInfo(), SCHEMA, "the H3Keyframes edit is no longer refused");
+  const note = o.readSnapshotNote();
+  assert.equal(typeof note, "string");
+  assert.match(note, /did not answer/, "and the reply can say which routes went silent");
+});
+
+test("#1223 SHIPPED: a snapshot re-read is NOT recorded as a new backend observation", async () => {
+  // Recording it would let a snapshot keep its own types "ever seen" after the backend
+  // stopped defining them — the #458 trust root feeding itself.
+  const snapshot = createObjectInfoSnapshot();
+  snapshot.record(SCHEMA, 5);
+  const o = buildShippedOracle({ api: hungApi, snapshot, epoch: 5 });
+  await o.getFreshObjectInfo();
+  assert.deepEqual(o.readHistory(), [], "nothing new was observed, so nothing is recorded");
+});
+
+test("#1223 SHIPPED: a DOWN socket still refuses, and the refusal says why", async () => {
+  const snapshot = createObjectInfoSnapshot();
+  snapshot.record(SCHEMA, 5);
+  const o = buildShippedOracle({ api: hungApi, snapshot, epoch: 5, socketDown: true });
+  assert.equal(await o.getFreshObjectInfo(), null, "fails closed exactly as before the fix");
+  assert.equal(o.readSnapshotNote(), null);
+  assert.match(objectInfoOracleFailureNote(o.readFailures()), /socket is down/i);
+});
+
+test("#1223 SHIPPED: a reconnect since the observation still refuses", async () => {
+  const snapshot = createObjectInfoSnapshot();
+  snapshot.record(SCHEMA, 4);
+  const o = buildShippedOracle({ api: hungApi, snapshot, epoch: 5 });
+  assert.equal(await o.getFreshObjectInfo(), null);
+  assert.match(objectInfoOracleFailureNote(o.readFailures()), /reconnected/i);
+});
+
+test("#1223 SHIPPED: a backend that ANSWERED badly still refuses — #458 is untouched", async () => {
+  const snapshot = createObjectInfoSnapshot();
+  snapshot.record(SCHEMA, 5);
+  const o = buildShippedOracle({
+    api: {
+      getNodeDefs: async () => {
+        throw new TypeError("Failed to fetch");
+      },
+      fetchApi: async () => ({ ok: false, status: 503 }),
+    },
+    snapshot,
+    epoch: 5,
+  });
+  assert.equal(await o.getFreshObjectInfo(), null, "a down/erroring backend authorizes nothing");
+});
+
+test("#1223 SHIPPED: with no snapshot at all, the pre-fix refusal is unchanged", async () => {
+  const o = buildShippedOracle({ api: hungApi, snapshot: createObjectInfoSnapshot(), epoch: 5 });
+  assert.equal(await o.getFreshObjectInfo(), null);
+  const note = objectInfoOracleFailureNote(o.readFailures());
+  assert.match(note, /did not answer/, "the routes it tried are still named (#982)");
+  assert.match(note, /no whole \/object_info has been observed/i);
+});
+
+// ---------------------------------------------------------------------------
+// The whole-schema-only contract, which `record` cannot enforce from the value
+// ---------------------------------------------------------------------------
+
+test("#1223 the snapshot is recorded ONLY where a WHOLE schema was fetched", () => {
+  // A per-class `/object_info/<Type>` payload reaching the snapshot would make every other
+  // type read as absent, and the #458 ever-seen gate would diagnose the whole install as
+  // removed packs. `recordObjectInfoTypes` legitimately receives such payloads (the
+  // add_node single-def path); the snapshot must not.
+  const sites = PANEL_SRC.match(/objectInfoSnapshot\.record\(/g) ?? [];
+  assert.equal(sites.length, 2, "exactly two whole-schema call sites — add one and justify it here");
+  assert.match(
+    PANEL_SRC,
+    /recordObjectInfoTypes\(defs\);[\s\S]{0,600}?objectInfoSnapshot\.record\(defs, backendReconnectEpoch\);/,
+    "the refresh run records the whole map it just fetched",
+  );
+  assert.match(
+    PANEL_SRC,
+    /objectInfoSnapshot\.record\(defs, backendReconnectEpoch\);\s*\n\s*return recordObjectInfoTypes\(defs\);/,
+    "and so does the set_widget oracle, on the whole-payload route",
+  );
+  assert.ok(
+    !/objectInfoSnapshot\.record\(\s*one\b/.test(PANEL_SRC),
+    "the single-def add_node payload never reaches the snapshot",
+  );
+});
+
+test("#1223 a suspicion of schema change retires the snapshot with the burst cache", () => {
+  // The refresh run drops the #716 cache at its START because a refresh that FAILS is when
+  // the schema is most likely to have moved. A snapshot that survived that suspicion would
+  // authorize writes the cache has already been told not to.
+  assert.match(
+    PANEL_SRC,
+    /objectInfoCache\.invalidate\(\);[\s\S]{0,600}?objectInfoSnapshot\.clear\(\);/,
+    "cleared on the same event, for the same reason",
+  );
+});
+
+test("#1223 the disclosure rides on its OWN field, never on `warning`", () => {
+  // `warning` is single-slot and priority-ordered (link-driven outranks
+  // control_after_generate). Appending here would silently displace a warning about what
+  // the write actually DOES — strictly worse than a separate field.
+  assert.match(PANEL_SRC, /schema_source: "last-observed", schema_note: snapshotAuthorizationNote\(/);
+  const setWidget = PANEL_SRC.slice(PANEL_SRC.indexOf("async graph_set_widget("));
+  const body = setWidget.slice(0, setWidget.indexOf("async graph_remove_widget("));
+  assert.ok(
+    !/warning:[^\n]*snapshotAuthorizationNote/.test(body),
+    "the provenance note never competes for the warning slot",
+  );
+});

--- a/browser_tests/unit/object-info-snapshot.test.mjs
+++ b/browser_tests/unit/object-info-snapshot.test.mjs
@@ -5,8 +5,14 @@
  * the graph, so a render blocks the schema fetch: a BUSY backend, not an absent one.
  *
  * The fix authorizes from the last WHOLE schema observed on the CURRENT backend connection,
- * under four conditions that all fail closed. These tests exist to keep each condition
- * load-bearing — every one of them is the difference between this and re-opening #458.
+ * under four conditions that all fail closed. These tests keep each condition load-bearing —
+ * every one is the difference between this and re-opening #458.
+ *
+ * SEVERAL OF THESE EXIST BECAUSE THE FIRST VERSION SHIPPED THE BUG THEY NOW PIN. Review
+ * found that the snapshot was never populated on a normal startup (so the reported case was
+ * still refused), that the epoch was read AFTER the fetch (so a pre-restart schema could be
+ * filed under post-restart provenance), and that the clear it relied on never ran because
+ * the reconnect's refresh is coalesced away. Those three have named tests below.
  *
  * The last block drives the SHIPPED `getFreshObjectInfo` body extracted from the panel, not
  * a re-implementation of it. A test that reasons about a copy of the wiring proves the copy.
@@ -17,25 +23,31 @@ import { readFileSync } from "node:fs";
 
 import {
   createObjectInfoSnapshot,
-  transportsWereSilent,
+  noBackendAnswerEstablished,
   snapshotAuthorizationNote,
 } from "../../web/js/lib/object-info-snapshot.js";
-import { TRANSPORT_OUTCOME, fetchWholeObjectInfo } from "../../web/js/lib/object-info-oracle.js";
+import {
+  TRANSPORT_OUTCOME,
+  fetchWholeObjectInfo,
+  objectInfoOracleFailureNote,
+} from "../../web/js/lib/object-info-oracle.js";
 import { createObjectInfoCache, CACHE_OUTCOME } from "../../web/js/lib/object-info-cache.js";
-import { objectInfoOracleFailureNote } from "../../web/js/lib/object-info-oracle.js";
 
 const SCHEMA = { KSampler: { input: {} }, H3Keyframes: { input: {} } };
 const silence = [
   { route: "client", kind: TRANSPORT_OUTCOME.NO_ANSWER },
   { route: "http", kind: TRANSPORT_OUTCOME.NO_ANSWER },
 ];
+/** The v2 record contract: an epoch captured before the fetch, unchanged since, and a claim. */
+const stored = (snap, defs = SCHEMA, epoch = 3) =>
+  snap.record(defs, { observedAtEpoch: epoch, currentEpoch: epoch, whole: true });
 
 // ---------------------------------------------------------------------------
-// Condition 4: SILENCE, not merely failure
+// Condition 4: the backend never ANSWERED
 // ---------------------------------------------------------------------------
 
 test("#1223 both probes timing out is the silence this licenses", () => {
-  assert.equal(transportsWereSilent(silence), true);
+  assert.equal(noBackendAnswerEstablished(silence), true);
 });
 
 test("#1223 a route that THREW disqualifies — a refused connection is a process that is gone", () => {
@@ -43,7 +55,7 @@ test("#1223 a route that THREW disqualifies — a refused connection is a proces
   // signature of a backend that is DOWN, and a down backend may be restarting — the one
   // event that can change the type set. Silence is the signature of one that is busy.
   assert.equal(
-    transportsWereSilent([
+    noBackendAnswerEstablished([
       { route: "client", kind: TRANSPORT_OUTCOME.NO_ANSWER },
       { route: "http", kind: TRANSPORT_OUTCOME.THREW },
     ]),
@@ -52,10 +64,8 @@ test("#1223 a route that THREW disqualifies — a refused connection is a proces
 });
 
 test("#1223 a route that ANSWERED something unusable disqualifies", () => {
-  // A non-OK status, an empty schema, a body that stalled after its headers arrived. All
-  // are a backend saying something, which is a different fault from the reported one.
   assert.equal(
-    transportsWereSilent([
+    noBackendAnswerEstablished([
       { route: "client", kind: TRANSPORT_OUTCOME.NO_ANSWER },
       { route: "http", kind: TRANSPORT_OUTCOME.ANSWERED_UNUSABLE },
     ]),
@@ -63,71 +73,57 @@ test("#1223 a route that ANSWERED something unusable disqualifies", () => {
   );
 });
 
+test("#1223 a client that returned NOTHING leaves the question unanswered, and licenses", () => {
+  // Review finding: tagging this ANSWERED_UNUSABLE contradicted the oracle's own stated
+  // semantics ("Only a client that returned NOTHING (null/undefined/non-object) or threw
+  // leaves the question unanswered") and made the whole fix inert on any frontend whose
+  // getNodeDefs swallows its failure and resolves undefined. It failed closed, so it was
+  // not dangerous — it just never fired.
+  assert.equal(
+    noBackendAnswerEstablished([
+      { route: "client", kind: TRANSPORT_OUTCOME.NOTHING_RETURNED },
+      { route: "http", kind: TRANSPORT_OUTCOME.NO_ANSWER },
+    ]),
+    true,
+  );
+  assert.equal(
+    noBackendAnswerEstablished([{ route: "client", kind: TRANSPORT_OUTCOME.NOTHING_RETURNED }]),
+    true,
+    "and on its own, when no fallback transport is wired",
+  );
+});
+
 test("#1223 never-contacted routes are neutral, but cannot license on their own", () => {
   assert.equal(
-    transportsWereSilent([
+    noBackendAnswerEstablished([
       { route: "client", kind: TRANSPORT_OUTCOME.NOT_ATTEMPTED },
       { route: "http", kind: TRANSPORT_OUTCOME.NO_ANSWER },
     ]),
     true,
-    "one route silent, the other never asked — still the reported condition",
   );
   assert.equal(
-    transportsWereSilent([
+    noBackendAnswerEstablished([
       { route: "client", kind: TRANSPORT_OUTCOME.NOT_ATTEMPTED },
       { route: "http", kind: TRANSPORT_OUTCOME.NOT_ATTEMPTED },
     ]),
     false,
-    "nothing was ever asked, so nothing was observed to be silent",
+    "nothing was ever asked, so nothing was observed",
   );
 });
 
 test("#1223 an absent, empty, or unrecognised outcome list licenses nothing", () => {
-  // "We recorded nothing" is not evidence of silence. A caller that lost the outcomes — or
-  // one handing in a shape this module never produced — must get the refusal.
-  assert.equal(transportsWereSilent(undefined), false);
-  assert.equal(transportsWereSilent([]), false);
-  assert.equal(transportsWereSilent("no-answer"), false);
-  assert.equal(transportsWereSilent([{ route: "client", kind: "invented" }]), false);
-  assert.equal(transportsWereSilent([null, { kind: TRANSPORT_OUTCOME.NO_ANSWER }]), false);
-  assert.equal(transportsWereSilent(["no-answer", "no-answer"]), false, "bare strings are not outcomes");
-});
-
-test("#1223 the oracle's real tags drive it — not a list hand-written in this test", async () => {
-  // The tags and the prose must describe the SAME attempt. Pinning only hand-made lists
-  // would let the oracle stop emitting them, or emit the wrong one, with the suite green.
-  const timedOut = await fetchWholeObjectInfo({
-    getNodeDefs: () => new Promise(() => {}),
-    fetchApi: () => new Promise(() => {}),
-    deadlineMs: 20,
-  });
-  assert.equal(timedOut.defs, null);
-  assert.equal(transportsWereSilent(timedOut.outcomes), true, "two hung transports read as silence");
-  assert.equal(timedOut.outcomes.length, timedOut.failures.length, "one tag per recorded attempt");
-
-  const refused = await fetchWholeObjectInfo({
-    getNodeDefs: async () => {
-      throw new TypeError("Failed to fetch");
-    },
-    fetchApi: async () => {
-      throw new TypeError("Failed to fetch");
-    },
-  });
-  assert.equal(refused.defs, null);
-  assert.equal(transportsWereSilent(refused.outcomes), false, "a refused connection is not silence");
-
-  const notOk = await fetchWholeObjectInfo({
-    getNodeDefs: async () => null,
-    fetchApi: async () => ({ ok: false, status: 503 }),
-  });
-  assert.equal(transportsWereSilent(notOk.outcomes), false, "a 503 is an answer");
+  assert.equal(noBackendAnswerEstablished(undefined), false);
+  assert.equal(noBackendAnswerEstablished([]), false);
+  assert.equal(noBackendAnswerEstablished("no-answer"), false);
+  assert.equal(noBackendAnswerEstablished([{ route: "client", kind: "invented" }]), false);
+  assert.equal(noBackendAnswerEstablished([null, { kind: TRANSPORT_OUTCOME.NO_ANSWER }]), false);
+  assert.equal(noBackendAnswerEstablished(["no-answer", "no-answer"]), false, "bare strings are not outcomes");
 });
 
 test("#1223 EACH route's tag is pinned on its own, not through the aggregate", async () => {
-  // Mutation-driven. Asserting only `transportsWereSilent(...) === false` over a TWO-route
-  // failure lets one correct tag mask a wrong one: mistagging the client's THREW as
-  // silence survived, because the http route's own THREW still carried the verdict. The
-  // tag is the thing the fallback reads, so the tag is what has to be pinned.
+  // Mutation-driven. Asserting only the aggregate over a TWO-route failure lets one correct
+  // tag mask a wrong one: mistagging the client's THREW as silence survived, because the
+  // http route's own THREW still carried the verdict.
   const kinds = async (opts) => (await fetchWholeObjectInfo({ deadlineMs: 40, ...opts })).outcomes.map((o) => o.kind);
 
   assert.deepEqual(
@@ -142,9 +138,9 @@ test("#1223 EACH route's tag is pinned on its own, not through the aggregate", a
   );
 
   assert.deepEqual(
-    await kinds({ getNodeDefs: null, fetchApi: async () => ({ ok: false, status: 503 }) }),
+    await kinds({ getNodeDefs: null, fetchApi: async () => ({ ok: false, status: 500 }) }),
     [TRANSPORT_OUTCOME.NOT_ATTEMPTED, TRANSPORT_OUTCOME.ANSWERED_UNUSABLE],
-    "a non-OK status is an answer; an unwired client is a route nobody asked",
+    "a 500 is ComfyUI answering; an unwired client is a route nobody asked",
   );
 
   assert.deepEqual(
@@ -153,7 +149,7 @@ test("#1223 EACH route's tag is pinned on its own, not through the aggregate", a
       fetchApi: async () => ({ ok: true, status: 200, json: () => new Promise(() => {}) }),
     }),
     [TRANSPORT_OUTCOME.NOT_ATTEMPTED, TRANSPORT_OUTCOME.ANSWERED_UNUSABLE],
-    "headers arrived, so the backend answered — a stalled BODY is not the silence this licenses",
+    "headers arrived, so the backend answered — a stalled BODY is not silence",
   );
 
   assert.deepEqual(
@@ -163,36 +159,118 @@ test("#1223 EACH route's tag is pinned on its own, not through the aggregate", a
   );
 
   assert.deepEqual(
+    await kinds({ getNodeDefs: async () => undefined, fetchApi: null }),
+    [TRANSPORT_OUTCOME.NOTHING_RETURNED, TRANSPORT_OUTCOME.NOT_ATTEMPTED],
+    "resolving undefined is NOT an answer — it is the question left unanswered",
+  );
+
+  assert.deepEqual(
     await kinds({ getNodeDefs: () => new Promise(() => {}), fetchApi: null }),
     [TRANSPORT_OUTCOME.NO_ANSWER, TRANSPORT_OUTCOME.NOT_ATTEMPTED],
-    "and a hung client with no fallback wired is the one shape that licenses",
+    "and a hung client with no fallback wired is the canonical shape",
   );
 });
 
-test("#1223 a usable answer still returns its outcomes alongside the schema", async () => {
-  const { defs, outcomes } = await fetchWholeObjectInfo({
-    getNodeDefs: async () => SCHEMA,
-    fetchApi: null,
+test("#1223 a PROXY gateway error is the backend not answering, not the backend answering", async () => {
+  // ComfyUI behind nginx/Caddy is the standard remote and RunPod shape. The proxy answers a
+  // hung upstream with 502/504 after its own read timeout — the same event as a bare
+  // timeout, arriving over HTTP. Counting it as an answer disabled the fix for every
+  // proxied install AND blamed the backend for a message it never sent.
+  const kinds = async (status) =>
+    (
+      await fetchWholeObjectInfo({
+        deadlineMs: 40,
+        getNodeDefs: () => new Promise(() => {}),
+        fetchApi: async () => ({ ok: false, status }),
+      })
+    ).outcomes.map((o) => o.kind);
+
+  for (const status of [502, 504]) {
+    assert.deepEqual(
+      await kinds(status),
+      [TRANSPORT_OUTCOME.NO_ANSWER, TRANSPORT_OUTCOME.NO_ANSWER],
+      `status ${status} is the proxy reporting silence`,
+    );
+  }
+  // 503 is deliberately NOT in the set: ComfyUI itself can serve it, so it is not
+  // unambiguously the proxy and this must not guess.
+  assert.deepEqual(
+    await kinds(503),
+    [TRANSPORT_OUTCOME.NO_ANSWER, TRANSPORT_OUTCOME.ANSWERED_UNUSABLE],
+    "503 stays an answer — it is not unambiguously a proxy",
+  );
+});
+
+test("#1223 the gateway refusal SAYS it was a proxy, not the backend", async () => {
+  const { failures } = await fetchWholeObjectInfo({
+    deadlineMs: 40,
+    getNodeDefs: null,
+    fetchApi: async () => ({ ok: false, status: 504 }),
   });
+  assert.match(failures.join(" "), /proxy in front of ComfyUI/i);
+});
+
+test("#1223 a usable answer still returns its outcomes alongside the schema", async () => {
+  const { defs, outcomes } = await fetchWholeObjectInfo({ getNodeDefs: async () => SCHEMA, fetchApi: null });
   assert.equal(defs, SCHEMA);
   assert.deepEqual(outcomes, [], "the route that answered is not a failure, so nothing is tagged");
 });
 
 // ---------------------------------------------------------------------------
-// Conditions 1–3: a snapshot, an unbroken connection, the same process
+// Conditions 1-3: a vouched-for whole map, an unbroken connection, the same process
 // ---------------------------------------------------------------------------
 
 test("#1223 the reported case: silent probes on an unbroken connection authorize", () => {
   const snap = createObjectInfoSnapshot();
-  assert.equal(snap.record(SCHEMA, 3), true);
+  assert.equal(stored(snap), true);
   const { defs, reason } = snap.authorize({ epoch: 3, socketDown: false, outcomes: silence });
-  assert.equal(defs, SCHEMA, "the edit the reporter was refused is authorized");
   assert.equal(reason, "");
+  assert.ok(defs, "the edit the reporter was refused is authorized");
+  assert.ok(Object.prototype.hasOwnProperty.call(defs, "H3Keyframes"), "and the reported node type is in it");
+});
+
+test("#1223 what is stored is DETACHED — registration hooks mutate defs in place", () => {
+  // `registerNodesFromDefs` runs `beforeRegisterNodeDef` hooks that mutate the definitions
+  // in place (Comfy's own upload hook adds an input the backend never declared). Retaining
+  // the payload by reference would hand frontend-mutated data back as backend evidence.
+  const live = { KSampler: { input: {} } };
+  const snap = createObjectInfoSnapshot();
+  stored(snap, live);
+  live.KSampler.input.image = ["IMAGE", { image_upload: true }];
+  live.InjectedByAnExtension = { input: {} };
+  const { defs } = snap.authorize({ epoch: 3, socketDown: false, outcomes: silence });
+  assert.equal(
+    Object.prototype.hasOwnProperty.call(defs, "InjectedByAnExtension"),
+    false,
+    "a type added after the observation is not in the snapshot",
+  );
+  assert.deepEqual(defs.KSampler, {}, "and the def's own shape is not carried at all");
+});
+
+test("#1223 the stored map answers MEMBERSHIP only, so it cannot supply stale combo lists", () => {
+  // The values being empty is what stops `refreshComboOptionsFromDefs` rewriting a live
+  // dropdown backwards to an older option list (it does `w.options.values = first.slice()`),
+  // and what makes `uploadInputConfig` / `serverDeclaresEmptyComboOptions` answer
+  // conservatively.
+  const snap = createObjectInfoSnapshot();
+  stored(snap, { CheckpointLoaderSimple: { input: { required: { ckpt_name: [["old.safetensors"], {}] } } } });
+  const { defs } = snap.authorize({ epoch: 3, socketDown: false, outcomes: silence });
+  assert.deepEqual(defs.CheckpointLoaderSimple, {}, "no option list survives into the snapshot");
+});
+
+test("#1223 a type named __proto__ cannot reach Object.prototype", () => {
+  // On a plain object `detached["__proto__"] = x` sets the prototype instead of creating an
+  // own property — losing the type AND poisoning every object in the page.
+  const snap = createObjectInfoSnapshot();
+  stored(snap, { __proto__: { input: {} }, KSampler: {} });
+  const { defs } = snap.authorize({ epoch: 3, socketDown: false, outcomes: silence });
+  assert.equal({}.polluted, undefined, "nothing was written to Object.prototype");
+  assert.ok(defs, "and the snapshot is still usable");
 });
 
 test("#1223 a DOWN socket refuses — a restarting backend is the one thing that moves the type set", () => {
   const snap = createObjectInfoSnapshot();
-  snap.record(SCHEMA, 3);
+  stored(snap);
   const { defs, reason } = snap.authorize({ epoch: 3, socketDown: true, outcomes: silence });
   assert.equal(defs, null);
   assert.match(reason, /socket is down/i);
@@ -200,37 +278,54 @@ test("#1223 a DOWN socket refuses — a restarting backend is the one thing that
 
 test("#1223 a RECONNECT since the observation refuses — it describes a replaced process", () => {
   const snap = createObjectInfoSnapshot();
-  snap.record(SCHEMA, 3);
+  stored(snap);
   const { defs, reason } = snap.authorize({ epoch: 4, socketDown: false, outcomes: silence });
   assert.equal(defs, null);
   assert.match(reason, /reconnected/i);
-  // Provenance, not freshness: the snapshot is refused outright rather than aged out, so
-  // there is no time bound here to get wrong.
-  assert.equal(
+  assert.ok(
     snap.authorize({ epoch: 3, socketDown: false, outcomes: silence }).defs,
-    SCHEMA,
     "and the SAME epoch still authorizes — age alone was never the question",
   );
 });
 
-test("#1223 an unreadable epoch refuses — a snapshot that cannot prove provenance is worse than none", () => {
+test("#1223 a reconnect DURING the fetch is refused at record time", () => {
+  // THE DEFECT THIS EXISTS FOR. The first version read the epoch at RECORD time, so a
+  // schema fetched before a ComfyUI restart was filed under post-restart provenance and
+  // would authorize a write to a type the new process no longer defines. The epoch must be
+  // captured before the request goes out and re-checked when the answer lands.
   const snap = createObjectInfoSnapshot();
-  snap.record(SCHEMA, 3);
-  for (const epoch of [undefined, null, NaN, Infinity, "3"]) {
-    assert.equal(snap.authorize({ epoch, socketDown: false, outcomes: silence }).defs, null, `epoch ${String(epoch)}`);
-  }
+  assert.equal(
+    snap.record(SCHEMA, { observedAtEpoch: 3, currentEpoch: 4, whole: true }),
+    false,
+    "the connection was replaced while this payload was in flight",
+  );
+  assert.equal(snap.peek().held, false);
+  assert.equal(snap.authorize({ epoch: 4, socketDown: false, outcomes: silence }).defs, null);
 });
 
-test("#1223 an epoch that cannot be compared later is never stored", () => {
+test("#1223 a payload nobody vouched for as WHOLE is refused", () => {
+  // A per-class /object_info/<Type> payload reaching the snapshot would make every other
+  // type read as absent and the ever-seen gate diagnose the whole install as removed packs.
+  // `record` cannot judge wholeness from the value, so it requires the claim.
   const snap = createObjectInfoSnapshot();
-  assert.equal(snap.record(SCHEMA, undefined), false);
-  assert.equal(snap.record(SCHEMA, NaN), false);
-  assert.equal(snap.record(SCHEMA, "3"), false);
+  assert.equal(snap.record(SCHEMA, { observedAtEpoch: 1, currentEpoch: 1 }), false);
+  assert.equal(snap.record(SCHEMA, { observedAtEpoch: 1, currentEpoch: 1, whole: false }), false);
+  assert.equal(snap.record(SCHEMA, { observedAtEpoch: 1, currentEpoch: 1, whole: "yes" }), false);
   assert.equal(snap.peek().held, false);
 });
 
+test("#1223 an unreadable epoch refuses, at record time and at authorize time", () => {
+  const snap = createObjectInfoSnapshot();
+  for (const bad of [undefined, null, NaN, Infinity, "3"]) {
+    assert.equal(snap.record(SCHEMA, { observedAtEpoch: bad, currentEpoch: bad, whole: true }), false, `record ${String(bad)}`);
+  }
+  stored(snap);
+  for (const bad of [undefined, null, NaN, Infinity, "3"]) {
+    assert.equal(snap.authorize({ epoch: bad, socketDown: false, outcomes: silence }).defs, null, `authorize ${String(bad)}`);
+  }
+});
+
 test("#1223 nothing observed yet refuses, and SAYS that rather than blaming a reconnect", () => {
-  // #982's lesson: a caller told the wrong cause goes looking in the wrong place.
   const snap = createObjectInfoSnapshot();
   const { defs, reason } = snap.authorize({ epoch: 1, socketDown: false, outcomes: silence });
   assert.equal(defs, null);
@@ -239,7 +334,7 @@ test("#1223 nothing observed yet refuses, and SAYS that rather than blaming a re
 
 test("#1223 a backend that ANSWERED is told apart from an empty snapshot in the reason", () => {
   const snap = createObjectInfoSnapshot();
-  snap.record(SCHEMA, 1);
+  stored(snap, SCHEMA, 1);
   const { defs, reason } = snap.authorize({
     epoch: 1,
     socketDown: false,
@@ -251,15 +346,19 @@ test("#1223 a backend that ANSWERED is told apart from an empty snapshot in the 
 
 test("#1223 only a payload that could authorize anything is stored", () => {
   const snap = createObjectInfoSnapshot();
+  // Called directly, NOT through `stored`: that helper defaults its payload, so passing
+  // `undefined` silently tested the good schema and the case passed for the wrong reason.
   for (const bad of [null, undefined, {}, [], "schema", 7, [SCHEMA]]) {
-    assert.equal(snap.record(bad, 1), false, `${JSON.stringify(bad) ?? String(bad)} is not a schema`);
+    assert.equal(
+      snap.record(bad, { observedAtEpoch: 3, currentEpoch: 3, whole: true }),
+      false,
+      `${String(bad)} is not a schema`,
+    );
   }
   assert.equal(snap.peek().held, false, "a failed fetch never displaces a good snapshot with nothing");
 });
 
 test("#1223 a payload whose own shape cannot be inspected is not stored", () => {
-  // `Object.keys` invokes a Proxy's ownKeys trap, which can throw — the same hazard the
-  // oracle's `usableDefs` guards. A diagnostic path must not raise an exception of its own.
   const hostile = new Proxy(
     {},
     {
@@ -269,29 +368,27 @@ test("#1223 a payload whose own shape cannot be inspected is not stored", () => 
     },
   );
   const snap = createObjectInfoSnapshot();
-  assert.doesNotThrow(() => snap.record(hostile, 1));
-  assert.equal(snap.record(hostile, 1), false);
+  assert.doesNotThrow(() => stored(snap, hostile));
+  assert.equal(stored(snap, hostile), false);
 });
 
 test("#1223 a good snapshot is not displaced by a later failed fetch", () => {
   const snap = createObjectInfoSnapshot();
-  snap.record(SCHEMA, 2);
-  snap.record(null, 2);
-  snap.record({}, 2);
-  assert.equal(snap.authorize({ epoch: 2, socketDown: false, outcomes: silence }).defs, SCHEMA);
+  stored(snap, SCHEMA, 2);
+  stored(snap, null, 2);
+  stored(snap, {}, 2);
+  assert.ok(snap.authorize({ epoch: 2, socketDown: false, outcomes: silence }).defs);
 });
 
 test("#1223 clear() retires it — a suspicion of change outranks a stored schema", () => {
   const snap = createObjectInfoSnapshot();
-  snap.record(SCHEMA, 2);
+  stored(snap, SCHEMA, 2);
   snap.clear();
   assert.equal(snap.authorize({ epoch: 2, socketDown: false, outcomes: silence }).defs, null);
   assert.equal(snap.peek().held, false);
 });
 
 test("#1223 a successful write authorized this way DISCLOSES it", () => {
-  // A write reported as SUCCEEDED and VERIFIED, verified against a schema nobody could
-  // re-fetch, is indistinguishable from a fully live authorization unless it says so.
   const note = snapshotAuthorizationNote(" Tried 2 routes: a; b.");
   assert.match(note, /SUCCEEDED/);
   assert.match(note, /last whole \/object_info observed/);
@@ -340,46 +437,60 @@ function extractSetWidgetOracle() {
 /**
  * Build the SHIPPED oracle body with doubles for the module state it closes over, so these
  * cases run the production code path rather than a description of it.
+ *
+ * `epochDuringFetch` lets a test move the connection epoch WHILE the read is in flight —
+ * the reconnect-mid-fetch hazard, which cannot be exercised any other way.
  */
-function buildShippedOracle({ api, socketDown = false, epoch = 5, snapshot }) {
+function buildShippedOracle({ api, socketDown = false, epoch = 5, snapshot, epochDuringFetch = null }) {
   const body = extractSetWidgetOracle();
   const factory = new Function(
     "api",
     "objectInfoCache",
-    "fetchWholeObjectInfo",
+    "realFetchWholeObjectInfo",
     "CACHE_OUTCOME",
     "objectInfoSnapshot",
-    "backendReconnectEpoch",
+    "initialEpoch",
+    "epochDuringFetch",
     "comfyBackendSocketDown",
-    "recordObjectInfoTypes",
     "objectInfoOracleFailureNote",
-    `let oracleFailures = [];
+    // `backendReconnectEpoch` MUST be a live mutable binding in the same scope as the
+    // extracted body, because the panel's is module state the body re-reads. An earlier
+    // version passed it as a frozen value, which made `observedAtEpoch` and the record-time
+    // read the same number by construction — the reconnect-mid-fetch case could not fail,
+    // and the test passed while proving nothing.
+    `let backendReconnectEpoch = initialEpoch;
+     let oracleFailures = [];
+     let snapshotIneligibility = "";
      let setWidgetSchemaFromSnapshot = null;
      const historyRecorded = [];
+     const recordObjectInfoTypes = (defs) => { historyRecorded.push(defs); return defs; };
+     // Declared HERE so it closes over the mutable epoch above and can move it the moment
+     // the read is issued — the panel's real hazard is a reconnect landing mid-fetch.
+     const fetchWholeObjectInfo = (opts) => {
+       const pending = realFetchWholeObjectInfo({ ...opts, deadlineMs: 20 });
+       if (epochDuringFetch !== null) backendReconnectEpoch = epochDuringFetch;
+       return pending;
+     };
      const getFreshObjectInfo = async () => ${body};
      return {
        getFreshObjectInfo,
+       readNote: () => setWidgetSchemaFromSnapshot,
+       readIneligibility: () => snapshotIneligibility,
        readFailures: () => oracleFailures,
-       readSnapshotNote: () => setWidgetSchemaFromSnapshot,
        readHistory: () => historyRecorded,
-       recordHistory: (defs) => { historyRecorded.push(defs); return defs; },
      };`,
   );
-  const built = factory(
+  return factory(
     api,
     createObjectInfoCache(),
-    // The SHIPPED oracle, on a budget a test can wait for. Only `deadlineMs` is
-    // substituted, so the tags these cases read are the ones production produces — the
-    // suite must not spend 20 real seconds per hung-transport case to learn that.
-    (opts) => fetchWholeObjectInfo({ ...opts, deadlineMs: 20 }),
+    fetchWholeObjectInfo,
     CACHE_OUTCOME,
     snapshot,
     epoch,
+    epochDuringFetch,
     socketDown,
-    (defs) => built.recordHistory(defs),
     objectInfoOracleFailureNote,
   );
-  return built;
 }
 
 const hungApi = { getNodeDefs: () => new Promise(() => {}), fetchApi: () => new Promise(() => {}) };
@@ -389,25 +500,39 @@ test("#1223 SHIPPED: a live answer is returned and snapshotted", async () => {
   const o = buildShippedOracle({ api: { getNodeDefs: async () => SCHEMA }, snapshot, epoch: 5 });
   assert.equal(await o.getFreshObjectInfo(), SCHEMA);
   assert.deepEqual(snapshot.peek(), { held: true, epoch: 5 }, "stamped with the connection it was read on");
-  assert.equal(o.readSnapshotNote(), null, "a live authorization discloses nothing, because there is nothing to disclose");
+  assert.equal(o.readNote(), null, "a live authorization discloses nothing, because there is nothing to disclose");
   assert.deepEqual(o.readHistory(), [SCHEMA], "and it IS a real observation, so the ever-seen history takes it");
+});
+
+test("#1223 SHIPPED: a reconnect DURING the read means the answer is not snapshotted", async () => {
+  // The burst cache deliberately returns a result to its waiter even after an invalidation
+  // has retired it from storage. Without the issuance-epoch check, that retired answer is
+  // promoted into a store with NO TTL, stamped with whatever epoch is current when it lands.
+  const snapshot = createObjectInfoSnapshot();
+  const o = buildShippedOracle({
+    api: { getNodeDefs: async () => SCHEMA },
+    snapshot,
+    epoch: 5,
+    epochDuringFetch: 6,
+  });
+  assert.equal(await o.getFreshObjectInfo(), SCHEMA, "the caller still gets its answer");
+  assert.equal(snapshot.peek().held, false, "but it is NOT filed as evidence about the new connection");
 });
 
 test("#1223 SHIPPED: the reported case — hung probes fall back and disclose", async () => {
   const snapshot = createObjectInfoSnapshot();
-  snapshot.record(SCHEMA, 5);
+  stored(snapshot, SCHEMA, 5);
   const o = buildShippedOracle({ api: hungApi, snapshot, epoch: 5, socketDown: false });
-  assert.equal(await o.getFreshObjectInfo(), SCHEMA, "the H3Keyframes edit is no longer refused");
-  const note = o.readSnapshotNote();
-  assert.equal(typeof note, "string");
-  assert.match(note, /did not answer/, "and the reply can say which routes went silent");
+  const defs = await o.getFreshObjectInfo();
+  assert.ok(defs && Object.prototype.hasOwnProperty.call(defs, "H3Keyframes"), "the edit is no longer refused");
+  assert.match(o.readNote(), /did not answer/, "and the reply can say which routes went silent");
 });
 
 test("#1223 SHIPPED: a snapshot re-read is NOT recorded as a new backend observation", async () => {
   // Recording it would let a snapshot keep its own types "ever seen" after the backend
   // stopped defining them — the #458 trust root feeding itself.
   const snapshot = createObjectInfoSnapshot();
-  snapshot.record(SCHEMA, 5);
+  stored(snapshot, SCHEMA, 5);
   const o = buildShippedOracle({ api: hungApi, snapshot, epoch: 5 });
   await o.getFreshObjectInfo();
   assert.deepEqual(o.readHistory(), [], "nothing new was observed, so nothing is recorded");
@@ -415,30 +540,30 @@ test("#1223 SHIPPED: a snapshot re-read is NOT recorded as a new backend observa
 
 test("#1223 SHIPPED: a DOWN socket still refuses, and the refusal says why", async () => {
   const snapshot = createObjectInfoSnapshot();
-  snapshot.record(SCHEMA, 5);
+  stored(snapshot, SCHEMA, 5);
   const o = buildShippedOracle({ api: hungApi, snapshot, epoch: 5, socketDown: true });
   assert.equal(await o.getFreshObjectInfo(), null, "fails closed exactly as before the fix");
-  assert.equal(o.readSnapshotNote(), null);
-  assert.match(objectInfoOracleFailureNote(o.readFailures()), /socket is down/i);
+  assert.equal(o.readNote(), null);
+  assert.match(o.readIneligibility(), /socket is down/i);
 });
 
 test("#1223 SHIPPED: a reconnect since the observation still refuses", async () => {
   const snapshot = createObjectInfoSnapshot();
-  snapshot.record(SCHEMA, 4);
+  stored(snapshot, SCHEMA, 4);
   const o = buildShippedOracle({ api: hungApi, snapshot, epoch: 5 });
   assert.equal(await o.getFreshObjectInfo(), null);
-  assert.match(objectInfoOracleFailureNote(o.readFailures()), /reconnected/i);
+  assert.match(o.readIneligibility(), /reconnected/i);
 });
 
 test("#1223 SHIPPED: a backend that ANSWERED badly still refuses — #458 is untouched", async () => {
   const snapshot = createObjectInfoSnapshot();
-  snapshot.record(SCHEMA, 5);
+  stored(snapshot, SCHEMA, 5);
   const o = buildShippedOracle({
     api: {
       getNodeDefs: async () => {
         throw new TypeError("Failed to fetch");
       },
-      fetchApi: async () => ({ ok: false, status: 503 }),
+      fetchApi: async () => ({ ok: false, status: 500 }),
     },
     snapshot,
     epoch: 5,
@@ -446,56 +571,66 @@ test("#1223 SHIPPED: a backend that ANSWERED badly still refuses — #458 is unt
   assert.equal(await o.getFreshObjectInfo(), null, "a down/erroring backend authorizes nothing");
 });
 
-test("#1223 SHIPPED: with no snapshot at all, the pre-fix refusal is unchanged", async () => {
+test("#1223 SHIPPED: the ineligibility reason is NOT counted as a transport route", async () => {
+  // objectInfoOracleFailureNote renders "Tried N routes:" from failures.length. Splicing a
+  // non-route entry in made a two-transport failure report THREE routes tried — #982's own
+  // defect (a refusal asserting something that did not happen).
   const o = buildShippedOracle({ api: hungApi, snapshot: createObjectInfoSnapshot(), epoch: 5 });
   assert.equal(await o.getFreshObjectInfo(), null);
-  const note = objectInfoOracleFailureNote(o.readFailures());
-  assert.match(note, /did not answer/, "the routes it tried are still named (#982)");
-  assert.match(note, /no whole \/object_info has been observed/i);
+  assert.equal(o.readFailures().length, 2, "two transports were tried");
+  assert.match(objectInfoOracleFailureNote(o.readFailures()), /Tried 2 routes/);
+  assert.match(o.readIneligibility(), /no whole \/object_info has been observed/i);
 });
 
 // ---------------------------------------------------------------------------
-// The whole-schema-only contract, which `record` cannot enforce from the value
+// The panel wiring, pinned at the source level
 // ---------------------------------------------------------------------------
 
-test("#1223 the snapshot is recorded ONLY where a WHOLE schema was fetched", () => {
-  // A per-class `/object_info/<Type>` payload reaching the snapshot would make every other
-  // type read as absent, and the #458 ever-seen gate would diagnose the whole install as
-  // removed packs. `recordObjectInfoTypes` legitimately receives such payloads (the
-  // add_node single-def path); the snapshot must not.
-  const sites = PANEL_SRC.match(/objectInfoSnapshot\.record\(/g) ?? [];
-  assert.equal(sites.length, 2, "exactly two whole-schema call sites — add one and justify it here");
+test("#1223 the snapshot is recorded ONLY where a WHOLE schema was fetched, and vouched for", () => {
+  // Each CALL SITE is checked for its own claim. Counting `whole: true` across the file
+  // instead counted the comment that documents the rule, which is not a call site.
+  const sites = [...PANEL_SRC.matchAll(/objectInfoSnapshot\.record\(/g)];
+  assert.equal(sites.length, 3, "startup seed, refresh run, set_widget oracle — add one and justify it here");
+  for (const site of sites) {
+    const call = PANEL_SRC.slice(site.index, site.index + 260);
+    assert.match(call, /whole: true/, `the record site at index ${site.index} states the wholeness claim`);
+    assert.match(call, /observedAtEpoch/, `the record site at index ${site.index} stamps the issuance epoch`);
+  }
   assert.match(
     PANEL_SRC,
-    /recordObjectInfoTypes\(defs\);[\s\S]{0,600}?objectInfoSnapshot\.record\(defs, backendReconnectEpoch\);/,
-    "the refresh run records the whole map it just fetched",
-  );
-  assert.match(
-    PANEL_SRC,
-    /objectInfoSnapshot\.record\(defs, backendReconnectEpoch\);\s*\n\s*return recordObjectInfoTypes\(defs\);/,
-    "and so does the set_widget oracle, on the whole-payload route",
-  );
-  assert.ok(
-    !/objectInfoSnapshot\.record\(\s*one\b/.test(PANEL_SRC),
-    "the single-def add_node payload never reaches the snapshot",
+    /if \(!preloadedDefs\) \{\s*\n\s*objectInfoSnapshot\.record\(/,
+    "the refresh run records only a payload it fetched itself — a caller-supplied one is not provably whole",
   );
 });
 
-test("#1223 a suspicion of schema change retires the snapshot with the burst cache", () => {
-  // The refresh run drops the #716 cache at its START because a refresh that FAILS is when
-  // the schema is most likely to have moved. A snapshot that survived that suspicion would
-  // authorize writes the cache has already been told not to.
+test("#1223 the STARTUP read is snapshotted — otherwise the reported case is still refused", () => {
+  // On a normal startup, seedObjectInfoHistory performs the ONLY whole /object_info read;
+  // registerComfyNodeDefs does not run. Without recording there, a first widget edit during
+  // a render found no snapshot and was refused exactly as before the fix.
+  const seed = PANEL_SRC.slice(PANEL_SRC.indexOf("function seedObjectInfoHistory("));
+  const body = seed.slice(0, seed.indexOf("\nasync function "));
+  assert.match(body, /const observedAtEpoch = backendReconnectEpoch;/, "the epoch is captured before the fetch");
+  assert.match(body, /objectInfoSnapshot\.record\(defs, \{/, "and the startup payload is recorded");
+});
+
+test("#1223 the socket handlers clear the snapshot DIRECTLY, not by way of a refresh", () => {
+  // The `reconnected` handler's refreshComfyNodeDefs() carries no payload and no force,
+  // which makeRefreshCoalescer resolves by joining an in-flight run and returning — so
+  // registerComfyNodeDefs, and the clear inside it, may never run for that reconnect.
+  for (const evt of ["reconnecting", "reconnected"]) {
+    const at = PANEL_SRC.indexOf(`api.addEventListener("${evt}"`);
+    assert.notEqual(at, -1, `${evt} handler not found`);
+    const handler = PANEL_SRC.slice(at, at + 1200);
+    assert.match(handler, /objectInfoSnapshot\.clear\(\);/, `${evt} retires the snapshot itself`);
+  }
   assert.match(
     PANEL_SRC,
-    /objectInfoCache\.invalidate\(\);[\s\S]{0,600}?objectInfoSnapshot\.clear\(\);/,
-    "cleared on the same event, for the same reason",
+    /objectInfoCache\.invalidate\(\);[\s\S]{0,700}?objectInfoSnapshot\.clear\(\);/,
+    "and the refresh run still clears it too, on the same suspicion that drops the burst cache",
   );
 });
 
 test("#1223 the disclosure rides on its OWN field, never on `warning`", () => {
-  // `warning` is single-slot and priority-ordered (link-driven outranks
-  // control_after_generate). Appending here would silently displace a warning about what
-  // the write actually DOES — strictly worse than a separate field.
   assert.match(PANEL_SRC, /schema_source: "last-observed", schema_note: snapshotAuthorizationNote\(/);
   const setWidget = PANEL_SRC.slice(PANEL_SRC.indexOf("async graph_set_widget("));
   const body = setWidget.slice(0, setWidget.indexOf("async graph_remove_widget("));
@@ -503,4 +638,13 @@ test("#1223 the disclosure rides on its OWN field, never on `warning`", () => {
     !/warning:[^\n]*snapshotAuthorizationNote/.test(body),
     "the provenance note never competes for the warning slot",
   );
+});
+
+test("#1223 no comment cites a symbol that does not exist", () => {
+  // A backticked identifier reads as a real export; the next reader greps for it and
+  // concludes the guard was deleted. `recordsWholeSchemaOnly` was exactly that.
+  const snapshotSrc = readFileSync(new URL("../../web/js/lib/object-info-snapshot.js", import.meta.url), "utf8");
+  for (const [name, src] of [["panel", PANEL_SRC], ["snapshot module", snapshotSrc]]) {
+    assert.ok(!/recordsWholeSchemaOnly/.test(src), `${name} still cites a phantom symbol`);
+  }
 });

--- a/browser_tests/unit/object-info-snapshot.test.mjs
+++ b/browser_tests/unit/object-info-snapshot.test.mjs
@@ -617,10 +617,14 @@ test("#1223 the socket handlers clear the snapshot DIRECTLY, not by way of a ref
   // The `reconnected` handler's refreshComfyNodeDefs() carries no payload and no force,
   // which makeRefreshCoalescer resolves by joining an in-flight run and returning — so
   // registerComfyNodeDefs, and the clear inside it, may never run for that reconnect.
-  for (const evt of ["reconnecting", "reconnected"]) {
+  // Each handler is bounded at the NEXT listener registration. A fixed-width slice ran past
+  // the end of `reconnecting` into `status` — which also clears — so deleting the clear from
+  // `reconnecting` left this test green. Found by mutation, not by reading.
+  for (const evt of ["reconnecting", "status", "reconnected"]) {
     const at = PANEL_SRC.indexOf(`api.addEventListener("${evt}"`);
     assert.notEqual(at, -1, `${evt} handler not found`);
-    const handler = PANEL_SRC.slice(at, at + 1200);
+    const next = PANEL_SRC.indexOf("api.addEventListener(", at + 1);
+    const handler = PANEL_SRC.slice(at, next === -1 ? PANEL_SRC.length : next);
     assert.match(handler, /objectInfoSnapshot\.clear\(\);/, `${evt} retires the snapshot itself`);
   }
   assert.match(

--- a/browser_tests/unit/object-info-snapshot.test.mjs
+++ b/browser_tests/unit/object-info-snapshot.test.mjs
@@ -185,19 +185,37 @@ test("#1223 a PROXY gateway error is the backend not answering, not the backend 
       })
     ).outcomes.map((o) => o.kind);
 
-  for (const status of [502, 504]) {
+  assert.deepEqual(
+    await kinds(504),
+    [TRANSPORT_OUTCOME.NO_ANSWER, TRANSPORT_OUTCOME.NO_ANSWER],
+    "504 Gateway Timeout: the proxy CONNECTED and the upstream did not answer in time",
+  );
+  // 502 is deliberately NOT in the set, and this is the correction review forced. nginx and
+  // Caddy emit it IMMEDIATELY when they cannot CONNECT to a stopped or restarting ComfyUI —
+  // evidence the process is GONE, the opposite of what this licenses on. Counting it as
+  // silence let a pre-restart schema authorize a write to a type the restart removed, on any
+  // frontend whose getNodeDefs swallows its own network error.
+  //
+  // 503 is excluded because ComfyUI itself can serve it, so it is not unambiguously a proxy.
+  for (const status of [502, 503, 500]) {
     assert.deepEqual(
       await kinds(status),
-      [TRANSPORT_OUTCOME.NO_ANSWER, TRANSPORT_OUTCOME.NO_ANSWER],
-      `status ${status} is the proxy reporting silence`,
+      [TRANSPORT_OUTCOME.NO_ANSWER, TRANSPORT_OUTCOME.ANSWERED_UNUSABLE],
+      `status ${status} is an ANSWER, not silence`,
     );
   }
-  // 503 is deliberately NOT in the set: ComfyUI itself can serve it, so it is not
-  // unambiguously the proxy and this must not guess.
-  assert.deepEqual(
-    await kinds(503),
-    [TRANSPORT_OUTCOME.NO_ANSWER, TRANSPORT_OUTCOME.ANSWERED_UNUSABLE],
-    "503 stays an answer — it is not unambiguously a proxy",
+});
+
+test("#1223 a 502 cannot license the fallback even when every other route went quiet", () => {
+  // The exact shape from review: a client that swallows its error and returns nothing, plus
+  // a proxy 502 arriving BEFORE the websocket-down event. Every gate except this one is
+  // satisfied, so the tag is the only thing standing between it and a #458 regression.
+  assert.equal(
+    noBackendAnswerEstablished([
+      { route: "client", kind: TRANSPORT_OUTCOME.NOTHING_RETURNED },
+      { route: "http", kind: TRANSPORT_OUTCOME.ANSWERED_UNUSABLE },
+    ]),
+    false,
   );
 });
 
@@ -474,6 +492,7 @@ function buildShippedOracle({ api, socketDown = false, epoch = 5, snapshot, epoc
      const getFreshObjectInfo = async () => ${body};
      return {
        getFreshObjectInfo,
+       setEpoch: (n) => { backendReconnectEpoch = n; },
        readNote: () => setWidgetSchemaFromSnapshot,
        readIneligibility: () => snapshotIneligibility,
        readFailures: () => oracleFailures,
@@ -517,6 +536,28 @@ test("#1223 SHIPPED: a reconnect DURING the read means the answer is not snapsho
   });
   assert.equal(await o.getFreshObjectInfo(), SCHEMA, "the caller still gets its answer");
   assert.equal(snapshot.peek().held, false, "but it is NOT filed as evidence about the new connection");
+});
+
+test("#1223 SHIPPED: a CACHE HIT is never filed as evidence — it can predate a reconnect", async () => {
+  // The burst cache serves a payload fetched up to a TTL ago. A reconnect can land in
+  // between, and the reconnect's own refresh is payload-less — so it is coalesced into any
+  // in-flight run and never reaches objectInfoCache.invalidate() either. Capturing the
+  // epoch outside the loader stamped that pre-reconnect schema as current and kept it with
+  // no TTL at all. Only the call that ISSUED the fetch may file the answer.
+  const snapshot = createObjectInfoSnapshot();
+  const o = buildShippedOracle({ api: { getNodeDefs: async () => SCHEMA }, snapshot, epoch: 5 });
+
+  await o.getFreshObjectInfo();
+  assert.deepEqual(snapshot.peek(), { held: true, epoch: 5 }, "the fetching call files it");
+
+  snapshot.clear(); // what a reconnect does
+  o.setEpoch(6); // ...and the epoch it bumps
+  assert.equal(await o.getFreshObjectInfo(), SCHEMA, "the cache still answers its waiter");
+  assert.equal(
+    snapshot.peek().held,
+    false,
+    "but a payload fetched before the reconnect is not evidence about the connection after it",
+  );
 });
 
 test("#1223 SHIPPED: the reported case — hung probes fall back and disclose", async () => {

--- a/browser_tests/unit/remove-widget.test.mjs
+++ b/browser_tests/unit/remove-widget.test.mjs
@@ -357,7 +357,13 @@ test("WIRING: the panel command routes through runRemoveWidget and refuses on an
   const src = readFileSync(join(here, "../../web/js/comfyui-mcp-panel.js"), "utf8");
   const idx = src.indexOf("async graph_remove_widget(");
   assert.ok(idx > 0, "graph_remove_widget handler is missing");
-  const block = src.slice(idx, idx + 2000);
+  // Bounded at the NEXT handler, not at a fixed width. A `slice(idx, idx + 2000)` silently
+  // stops covering the handler as soon as anything is added above the assertion it looks
+  // for — a comment is enough — so the test starts passing-by-not-looking rather than
+  // failing. That is the same trap a sibling test hit with a fixed slice over the socket
+  // listeners (#1223).
+  const next = src.indexOf("\n  async graph_", idx + 1);
+  const block = src.slice(idx, next === -1 ? src.length : next);
   assert.match(block, /runRemoveWidget\(/);
   // declaredNames must come from the FETCHED defs, not a literal.
   assert.match(block, /declaredNames,/);

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -10735,6 +10735,9 @@ const GRAPH_TOOL_EXECUTORS = {
     // schema — a sibling class is where a custom link datatype is produced. Remember
     // which payload we got, because a single-class map is not evidence about siblings.
     let freshDefsAreSingleClass = false;
+    // #1223 — the epoch before ANY fetch inside the resolver goes out, so a whole map it
+    // obtains can be filed with honest provenance below.
+    const addNodeObservedAtEpoch = backendReconnectEpoch;
     await assertAddNodeResolvableRefreshing(() => LG?.registered_node_types ?? {}, class_type, {
       getFreshObjectInfo: async () => {
         // #767 — ask about ONE type instead of re-downloading the whole schema.
@@ -10795,6 +10798,26 @@ const GRAPH_TOOL_EXECUTORS = {
       // pack that is not installed, and the refusal used to name only the latter.
       readImportFailures: () => readPackImportFailures(api),
     });
+    // #1223 — file the WHOLE map this resolver fetched, when it fetched one.
+    //
+    // AFTER the resolver, not inside it: when a type needs registering the resolver calls
+    // `refresh`, and `registerComfyNodeDefs` CLEARS the snapshot at the start of its run.
+    // Recording earlier would simply be wiped. Skipping it altogether — which the earlier
+    // `!preloadedDefs` rule did, since the resolver hands its payload in as `preloadedDefs`
+    // — left an add that registers a new type with NO snapshot at all, so the very next
+    // render-induced probe timeout reproduced the refusal this issue exists to remove.
+    //
+    // `freshDefsAreSingleClass` is the panel's OWN record of which question it asked, so it
+    // is the honest wholeness claim; the single-class fast path is only taken for an
+    // already-registered type, and it sets that flag. Mutation by a beforeRegisterNodeDef
+    // hook (#700) is irrelevant here because `record` copies out only the type NAMES.
+    if (freshDefs && !freshDefsAreSingleClass) {
+      objectInfoSnapshot.record(freshDefs, {
+        observedAtEpoch: addNodeObservedAtEpoch,
+        currentEpoch: backendReconnectEpoch,
+        whole: true,
+      });
+    }
     const nodeData = LG?.registered_node_types?.[class_type]?.nodeData;
     // A pack upgraded mid-session can add required inputs to an ALREADY
     // registered class; the resolver only refreshes absent classes, so

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -9401,10 +9401,25 @@ const GRAPH_TOOL_EXECUTORS = {
   // holds and gets `unchanged: true` with no payload when the TYPE SET still matches.
   // What that does and does not establish is stated in the reply, not implied.
   async graph_get_object_info({ if_none_match } = {}) {
+    // #1223 — the epoch at issuance. This command reads the WHOLE schema and does not go
+    // through the burst cache, so every success here is a first-hand observation of the
+    // connection it was issued on, and there is no cache hit to exclude.
+    const observedAtEpoch = backendReconnectEpoch;
     const { defs, failures } = await fetchWholeObjectInfo({
       getNodeDefs: typeof api?.getNodeDefs === "function" ? () => api.getNodeDefs() : null,
       fetchApi: typeof api?.fetchApi === "function" ? (route) => api.fetchApi(route) : null,
     });
+    // #1223 — file it. A reader that successfully obtains a whole schema and drops it on the
+    // floor leaves the next render-time widget edit refused for want of the very map this
+    // command just read. Recorded BEFORE the fingerprint/if_none_match early-returns below,
+    // so a caller polling with `if_none_match` still keeps the snapshot fed.
+    if (defs) {
+      objectInfoSnapshot.record(defs, {
+        observedAtEpoch,
+        currentEpoch: backendReconnectEpoch,
+        whole: true,
+      });
+    }
     // THE ORIGIN THAT ACTUALLY ANSWERED (codex). `comfyuiUrlForAgent()` prefers a
     // user-set Remote-URL override, but this fetch goes through the page's own `api`
     // client — so on an install where those differ, reporting the override would
@@ -10735,9 +10750,13 @@ const GRAPH_TOOL_EXECUTORS = {
     // schema — a sibling class is where a custom link datatype is produced. Remember
     // which payload we got, because a single-class map is not evidence about siblings.
     let freshDefsAreSingleClass = false;
-    // #1223 — the epoch before ANY fetch inside the resolver goes out, so a whole map it
-    // obtains can be filed with honest provenance below.
-    const addNodeObservedAtEpoch = backendReconnectEpoch;
+    // #1223 — the epoch at the moment the WHOLE fetch is issued, or null if this add never
+    // issued one. Set inside the branch below rather than out here: for an already-registered
+    // type the resolver first runs the per-class probe, and a reconnect landing during THAT
+    // probe would leave this holding the old epoch — so the later record would be rejected
+    // and the snapshot (already cleared by the reconnect) would stay empty, refusing the very
+    // next render-time widget edit. The epoch has to be read where the request goes out.
+    let addNodeObservedAtEpoch = null;
     await assertAddNodeResolvableRefreshing(() => LG?.registered_node_types ?? {}, class_type, {
       getFreshObjectInfo: async () => {
         // #767 — ask about ONE type instead of re-downloading the whole schema.
@@ -10784,6 +10803,8 @@ const GRAPH_TOOL_EXECUTORS = {
         // one that answered nothing: `recordObjectInfoTypes(null)` yields no defs, and the
         // add then fails closed on the same path an empty payload already takes, rather
         // than parking.
+        // #1223 — read the epoch HERE, immediately before the whole request is issued.
+        addNodeObservedAtEpoch = backendReconnectEpoch;
         const whole = await boundedGetNodeDefs();
         freshDefs = recordObjectInfoTypes(whole === NODE_DEFS_NO_ANSWER ? null : whole);
         freshDefsAreSingleClass = false;
@@ -10811,7 +10832,7 @@ const GRAPH_TOOL_EXECUTORS = {
     // is the honest wholeness claim; the single-class fast path is only taken for an
     // already-registered type, and it sets that flag. Mutation by a beforeRegisterNodeDef
     // hook (#700) is irrelevant here because `record` copies out only the type NAMES.
-    if (freshDefs && !freshDefsAreSingleClass) {
+    if (freshDefs && !freshDefsAreSingleClass && addNodeObservedAtEpoch !== null) {
       objectInfoSnapshot.record(freshDefs, {
         observedAtEpoch: addNodeObservedAtEpoch,
         currentEpoch: backendReconnectEpoch,
@@ -11851,14 +11872,30 @@ const GRAPH_TOOL_EXECUTORS = {
     const { graph } = getGraphCtx();
     const node = resolveNode(graph, node_id);
     let oracleFailures = [];
-    const outcome = await objectInfoCache.read(async () =>
-      fetchWholeObjectInfo({
+    // #1223 — the epoch at which THIS CALL fetched, or null if the burst cache answered from
+    // store or this read joined another call's request. Set inside the loader for the same
+    // reason graph_set_widget's is: only the caller that issued the request can say which
+    // connection the answer describes.
+    let observedAtEpoch = null;
+    const outcome = await objectInfoCache.read(async () => {
+      observedAtEpoch = backendReconnectEpoch;
+      return fetchWholeObjectInfo({
         getNodeDefs: typeof api?.getNodeDefs === "function" ? () => api.getNodeDefs() : null,
         fetchApi: typeof api?.fetchApi === "function" ? (route) => api.fetchApi(route) : null,
-      }),
-    );
+      });
+    });
     const defs = outcome && typeof outcome === "object" && outcome[CACHE_OUTCOME] === true ? outcome.defs : outcome;
     oracleFailures = defs ? [] : (outcome?.failures ?? []);
+    // #1223 — this command already paid for a WHOLE /object_info; dropping it leaves the
+    // next render-time widget edit refused for want of the map just read. Same argument the
+    // history note below already makes for its own trust root.
+    if (defs && observedAtEpoch !== null) {
+      objectInfoSnapshot.record(defs, {
+        observedAtEpoch,
+        currentEpoch: backendReconnectEpoch,
+        whole: true,
+      });
+    }
     // Feed the #458 observed-backend-history trust root. This command never consults that
     // history, so skipping it would be harmless HERE — but we just paid for a full
     // /object_info, and discarding the observation makes a LATER set_widget less able to

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -961,11 +961,12 @@ const objectInfoCache = createObjectInfoCache();
 // busy rendering. Consulted only AFTER the oracle has failed, and only under the four
 // fail-closed conditions in lib/object-info-snapshot.js.
 //
-// RECORDS WHOLE SCHEMAS ONLY (`recordsWholeSchemaOnly`, pinned by a test). Every call site
-// below hands it a full /object_info map. A per-class `/object_info/<Type>` payload — which
-// `recordObjectInfoTypes` legitimately also receives, from the add_node single-def path —
-// must NEVER reach it: one type present would make all 4300 others read as absent, and the
-// #458 ever-seen gate would then diagnose the whole install as removed packs.
+// RECORDS WHOLE SCHEMAS ONLY, and every call site must say `whole: true` to claim it. A
+// per-class /object_info/<Type> payload — which recordObjectInfoTypes legitimately also
+// receives, from the add_node single-def path — must NEVER reach it: one type present would
+// make all ~4300 others read as absent, and the #458 ever-seen gate would then diagnose the
+// whole install as removed packs. The three sites below are the startup seed, the refresh
+// run's own fetch, and the set_widget whole-payload route.
 const objectInfoSnapshot = createObjectInfoSnapshot();
 // Resolves once the STARTUP baseline seed attempt sequence has finished (success or all
 // retries exhausted). The graph tools AWAIT this (bounded) before authorizing.
@@ -979,9 +980,23 @@ function seedObjectInfoHistory() {
     for (let attempt = 0; attempt < 5; attempt++) {
       try {
         if (typeof api?.getNodeDefs === "function") {
+          // #1223 — the epoch BEFORE the request goes out. On a normal startup this is the
+          // ONLY whole /object_info read that happens: registerComfyNodeDefs does not run
+          // unless something triggers a refresh. Without recording here, the reported case
+          // — the first widget edit lands while ComfyUI is rendering and both probes time
+          // out — found no snapshot and was refused exactly as before the fix.
+          const observedAtEpoch = backendReconnectEpoch;
           const defs = await api.getNodeDefs();
           if (defs && typeof defs === "object" && Object.keys(defs).length > 0) {
             recordObjectInfoTypes(defs);
+            // A whole payload, and this is the only reader of it — nothing registers these
+            // defs, so no beforeRegisterNodeDef hook can have mutated them yet. `record`
+            // still copies out the type names rather than trusting that.
+            objectInfoSnapshot.record(defs, {
+              observedAtEpoch,
+              currentEpoch: backendReconnectEpoch,
+              whole: true,
+            });
             markObjectInfoHistorySeeded();
             return;
           }
@@ -1061,6 +1076,10 @@ async function registerComfyNodeDefs(preloadedDefs) {
   // not to. Re-recorded below if this run's fetch succeeds, so the cost of being wrong here
   // is one refused write during an outage, not a stale authorization.
   objectInfoSnapshot.clear();
+  // #1223 — the epoch this run STARTED on, captured before any fetch. The recording below
+  // is refused if a reconnect lands while the fetch is in flight, so a pre-restart schema
+  // can never be filed under post-restart provenance.
+  const runStartedAtEpoch = backendReconnectEpoch;
   let thrown = null;
   // Tracked separately from the caught VALUE: a library can throw a FALSY value
   // (throw null / 0 / "") and `if (thrown)` would then read a failed run as a
@@ -1210,11 +1229,23 @@ async function registerComfyNodeDefs(preloadedDefs) {
     // reason the deadline moves here rather than the floor being softened.
     const localWorkStartedAt = monotonicNow();
     recordObjectInfoTypes(defs);
-    // #1223 — a WHOLE map, freshly fetched, stamped with the connection it was read on.
-    // This is the payload a later widget write falls back to when the backend goes silent
-    // mid-render. `record` rejects an empty/non-object payload itself, so a failed fetch
-    // leaves the snapshot cleared above rather than replacing it with nothing usable.
-    objectInfoSnapshot.record(defs, backendReconnectEpoch);
+    // #1223 — the payload a later widget write falls back to when the backend goes silent
+    // mid-render. Recorded BEFORE registerNodesFromDefs runs below, and `record` copies out
+    // the type names, so a beforeRegisterNodeDef hook mutating these definitions in place
+    // (Comfy's upload hook adds an input the backend never declared) cannot reach it.
+    //
+    // ONLY WHEN THIS RUN FETCHED THE PAYLOAD ITSELF. A caller-supplied `preloadedDefs` is
+    // not provably whole: assertAddNodeResolvableRefreshing re-reads the registry across an
+    // await and can pass its SINGLE-CLASS defs to refresh(), and a one-type map recorded
+    // here would make every other type read as absent — the ever-seen gate would then
+    // report the entire install as removed packs.
+    if (!preloadedDefs) {
+      objectInfoSnapshot.record(defs, {
+        observedAtEpoch: runStartedAtEpoch,
+        currentEpoch: backendReconnectEpoch,
+        whole: true,
+      });
+    }
     // Re-register node definitions so newly installed/updated classes and their
     // current widget schemas are known to LiteGraph (#221/#171). defsRegistered
     // is set ONLY when the registration call actually ran — a frontend without
@@ -1437,12 +1468,14 @@ function setupListeners() {
     api.addEventListener("reconnecting", () => {
       nodeDefsRefreshConfirmed = false;
       comfyBackendSocketDown = true;
+      objectInfoSnapshot.clear(); // #1223 — see condition 3 in lib/object-info-snapshot.js.
     });
     api.addEventListener("status", (ev) => {
       // A null status payload is ComfyUI's "backend connection lost" signal.
       if (ev?.detail == null) {
         nodeDefsRefreshConfirmed = false;
         comfyBackendSocketDown = true;
+        objectInfoSnapshot.clear(); // #1223 — same reasoning as `reconnecting`.
       }
     });
     // ComfyUI's own socket to its backend re-establishing is the reliable
@@ -1450,6 +1483,7 @@ function setupListeners() {
     // stale node registry + combos then (#221/#171/#185/#181).
     api.addEventListener("reconnected", () => {
       comfyBackendSocketDown = false;
+      objectInfoSnapshot.clear(); // #1223 — see condition 3 in lib/object-info-snapshot.js.
       // #433: the frontend may now restore a stale/wrong active tab — bump the
       // epoch and arm the monotonic possibly-stale window. Bumping the epoch
       // invalidates any EARLIER resync so a pre-reconnect open can't clear this
@@ -11487,6 +11521,9 @@ const GRAPH_TOOL_EXECUTORS = {
     // reason `oracleFailures` is: a concurrent write must not make THIS reply claim a
     // provenance it did not have.
     let setWidgetSchemaFromSnapshot = null;
+    // #1223 — why the snapshot could not stand in, kept OFF the route list so the route
+    // count stays honest. Per-request for the same reason the other two are.
+    let snapshotIneligibility = "";
     // #314: the LTXDirector custom node owns its timeline widgets through an in-browser
     // TimelineEditor whose in-memory `this.timeline` is the source of truth. A raw widget
     // write "succeeds" (panel_query_graph shows it) but never reaches the editor/UI and is
@@ -11566,6 +11603,11 @@ const GRAPH_TOOL_EXECUTORS = {
       // after a restart-without-reload. Mirrors graph_add_node.
       getRegistry: () => LG?.registered_node_types ?? {},
       getFreshObjectInfo: async () => {
+        // #1223 — the epoch BEFORE the read is issued. The burst cache deliberately
+        // RETURNS a result to its waiter even after an invalidation has retired it from
+        // storage, so without this the retired answer could be promoted into a store with
+        // no TTL at all, stamped with whatever epoch happened to be current when it landed.
+        const observedAtEpoch = backendReconnectEpoch;
         // #716 — READ THROUGH THE BURST CACHE. 29 widget writes meant 29 full
         // /object_info downloads (5,413,770 bytes each on a 63-pack install, #767).
         // Still the WHOLE payload, so no question this fence asks changes scope —
@@ -11592,8 +11634,13 @@ const GRAPH_TOOL_EXECUTORS = {
         oracleFailures = defs ? [] : (outcome?.failures ?? []);
         if (defs) {
           // A WHOLE map (this route never asks the per-class one — see the #716/#821 note
-          // above), so it is the payload #1223's fallback is allowed to hold.
-          objectInfoSnapshot.record(defs, backendReconnectEpoch);
+          // above), so it is one #1223's fallback may hold. Refused if a reconnect landed
+          // while the read was in flight.
+          objectInfoSnapshot.record(defs, {
+            observedAtEpoch,
+            currentEpoch: backendReconnectEpoch,
+            whole: true,
+          });
           return recordObjectInfoTypes(defs);
         }
         // #1223 — the probe produced nothing. If it went SILENT (rather than answering
@@ -11618,12 +11665,20 @@ const GRAPH_TOOL_EXECUTORS = {
           // keep its own types "ever seen" after the backend stopped defining them.
           return fallback.defs;
         }
-        oracleFailures = [...oracleFailures, `the last-observed schema was not usable either — ${fallback.reason}`];
+        // NOT appended to `oracleFailures`. That array is the list of TRANSPORT ROUTES, and
+        // objectInfoOracleFailureNote renders "Tried N routes:" from its length — splicing
+        // a non-route entry in made a two-transport failure report three routes tried, which
+        // is #982's own defect (a refusal asserting something that did not happen) committed
+        // by the code written to avoid it.
+        snapshotIneligibility = fallback.reason;
         return recordObjectInfoTypes(defs);
       },
       // What the last oracle attempt observed, so a refusal can say which routes were
-      // tried and what each one did instead of asserting an unreachable backend.
-      describeObjectInfoFailure: () => objectInfoOracleFailureNote(oracleFailures),
+      // tried and what each one did instead of asserting an unreachable backend — then,
+      // separately, why the last-observed schema could not stand in for them either.
+      describeObjectInfoFailure: () =>
+        objectInfoOracleFailureNote(oracleFailures) +
+        (snapshotIneligibility ? ` The last-observed schema was not usable either — ${snapshotIneligibility}.` : ""),
       // #458 OBSERVED-BACKEND-HISTORY trust root: a type absent from the CURRENT
       // /object_info that the backend reported earlier this session is a REMOVED backend
       // node — refuse (non-forgeable; client shape/name/provenance can't prove this).

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -202,6 +202,7 @@ import { BACKEND_SWITCH, runBackendSwitch } from "./lib/backend-switch.js";
 import { fetchNodeDefsWithRetry, OBJECT_INFO_RETRY_DELAYS_MS } from "./lib/object-info-retry.js";
 import { createObjectInfoCache, CACHE_OUTCOME } from "./lib/object-info-cache.js";
 import { fetchWholeObjectInfo, objectInfoOracleFailureNote } from "./lib/object-info-oracle.js";
+import { createObjectInfoSnapshot, snapshotAuthorizationNote } from "./lib/object-info-snapshot.js";
 import { objectInfoFingerprint, objectInfoUnchanged } from "./lib/object-info-fingerprint.js";
 import { confirmCanvasNavigation } from "./lib/canvas-navigation.js";
 import {
@@ -955,6 +956,17 @@ const recordObjectInfoTypes = (defs) => objectInfoHistory.recordTypes(defs);
 const markObjectInfoHistorySeeded = () => objectInfoHistory.markSeeded();
 // #716 — one /object_info per BURST of widget writes, instead of one per write.
 const objectInfoCache = createObjectInfoCache();
+// #1223 — the last WHOLE /object_info observed on the CURRENT backend connection, so a
+// widget edit is not refused merely because the schema probe went silent while ComfyUI was
+// busy rendering. Consulted only AFTER the oracle has failed, and only under the four
+// fail-closed conditions in lib/object-info-snapshot.js.
+//
+// RECORDS WHOLE SCHEMAS ONLY (`recordsWholeSchemaOnly`, pinned by a test). Every call site
+// below hands it a full /object_info map. A per-class `/object_info/<Type>` payload — which
+// `recordObjectInfoTypes` legitimately also receives, from the add_node single-def path —
+// must NEVER reach it: one type present would make all 4300 others read as absent, and the
+// #458 ever-seen gate would then diagnose the whole install as removed packs.
+const objectInfoSnapshot = createObjectInfoSnapshot();
 // Resolves once the STARTUP baseline seed attempt sequence has finished (success or all
 // retries exhausted). The graph tools AWAIT this (bounded) before authorizing.
 let objectInfoHistorySeed = Promise.resolve();
@@ -1043,6 +1055,12 @@ async function registerComfyNodeDefs(preloadedDefs) {
   // have fetched and failed closed. Retiring it up front costs one extra fetch and cannot
   // be wrong in the dangerous direction.
   objectInfoCache.invalidate();
+  // #1223 — retire the last-observed snapshot on the SAME event and for the SAME reason.
+  // This function runs exactly when something suspects the schema moved, and a snapshot
+  // that survived a suspicion would authorize writes the burst cache has already been told
+  // not to. Re-recorded below if this run's fetch succeeds, so the cost of being wrong here
+  // is one refused write during an outage, not a stale authorization.
+  objectInfoSnapshot.clear();
   let thrown = null;
   // Tracked separately from the caught VALUE: a library can throw a FALSY value
   // (throw null / 0 / "") and `if (thrown)` would then read a failed run as a
@@ -1192,6 +1210,11 @@ async function registerComfyNodeDefs(preloadedDefs) {
     // reason the deadline moves here rather than the floor being softened.
     const localWorkStartedAt = monotonicNow();
     recordObjectInfoTypes(defs);
+    // #1223 — a WHOLE map, freshly fetched, stamped with the connection it was read on.
+    // This is the payload a later widget write falls back to when the backend goes silent
+    // mid-render. `record` rejects an empty/non-object payload itself, so a failed fetch
+    // leaves the snapshot cleared above rather than replacing it with nothing usable.
+    objectInfoSnapshot.record(defs, backendReconnectEpoch);
     // Re-register node definitions so newly installed/updated classes and their
     // current widget schemas are known to LiteGraph (#221/#171). defsRegistered
     // is set ONLY when the registration call actually ran — a frontend without
@@ -11459,6 +11482,11 @@ const GRAPH_TOOL_EXECUTORS = {
     // its refusal, so the message would name routes another call tried. Declared in the
     // handler's own scope, so each invocation reports what IT observed.
     let oracleFailures = [];
+    // #1223 — null while the authorization came from a LIVE probe; the oracle's failure
+    // note once it came from the last-observed snapshot instead. Per-request for the same
+    // reason `oracleFailures` is: a concurrent write must not make THIS reply claim a
+    // provenance it did not have.
+    let setWidgetSchemaFromSnapshot = null;
     // #314: the LTXDirector custom node owns its timeline widgets through an in-browser
     // TimelineEditor whose in-memory `this.timeline` is the source of truth. A raw widget
     // write "succeeds" (panel_query_graph shows it) but never reaches the editor/UI and is
@@ -11562,6 +11590,35 @@ const GRAPH_TOOL_EXECUTORS = {
         });
         const defs = outcome && typeof outcome === "object" && outcome[CACHE_OUTCOME] === true ? outcome.defs : outcome;
         oracleFailures = defs ? [] : (outcome?.failures ?? []);
+        if (defs) {
+          // A WHOLE map (this route never asks the per-class one — see the #716/#821 note
+          // above), so it is the payload #1223's fallback is allowed to hold.
+          objectInfoSnapshot.record(defs, backendReconnectEpoch);
+          return recordObjectInfoTypes(defs);
+        }
+        // #1223 — the probe produced nothing. If it went SILENT (rather than answering
+        // something unusable) and this backend connection has not been interrupted since a
+        // whole schema was last read, authorize from that snapshot instead of refusing a
+        // write the backend would accept. Every other cause still falls through to the
+        // unchanged #458 refusal below, which now also explains why the snapshot was not
+        // eligible — a caller told "no schema" when the real cause was a reconnect goes
+        // looking in the wrong place (#982).
+        const fallback = objectInfoSnapshot.authorize({
+          epoch: backendReconnectEpoch,
+          socketDown: comfyBackendSocketDown,
+          outcomes: outcome?.outcomes,
+        });
+        if (fallback.defs) {
+          // Held for the reply. The write is about to be reported as SUCCEEDED and VERIFIED,
+          // and it was verified against a schema nobody could re-fetch — an agent that is
+          // not told that cannot tell this apart from a fully live authorization.
+          setWidgetSchemaFromSnapshot = objectInfoOracleFailureNote(oracleFailures);
+          // NOT recorded into the ever-seen history: it is not a new observation of the
+          // backend, it is the old one being re-read. Recording it would let a snapshot
+          // keep its own types "ever seen" after the backend stopped defining them.
+          return fallback.defs;
+        }
+        oracleFailures = [...oracleFailures, `the last-observed schema was not usable either — ${fallback.reason}`];
         return recordObjectInfoTypes(defs);
       },
       // What the last oracle attempt observed, so a refusal can say which routes were
@@ -11670,6 +11727,13 @@ const GRAPH_TOOL_EXECUTORS = {
       if (stillActive) clearStaleRedFlag(node, { app, graph, rootGraph });
     } catch {
       /* best-effort visual cleanup — never fail the write over it */
+    }
+    // #1223 — DISCLOSE the provenance of the authorization, on a field of its own rather
+    // than in `warning`. That channel is single-slot and priority-ordered (link-driven
+    // outranks control_after_generate), so appending here would silently displace a warning
+    // about what the write actually DOES — a strictly worse trade than a separate field.
+    if (setWidgetSchemaFromSnapshot !== null && result && typeof result === "object") {
+      return { ...result, schema_source: "last-observed", schema_note: snapshotAuthorizationNote(setWidgetSchemaFromSnapshot) };
     }
     return result;
   },

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -11603,11 +11603,20 @@ const GRAPH_TOOL_EXECUTORS = {
       // after a restart-without-reload. Mirrors graph_add_node.
       getRegistry: () => LG?.registered_node_types ?? {},
       getFreshObjectInfo: async () => {
-        // #1223 — the epoch BEFORE the read is issued. The burst cache deliberately
-        // RETURNS a result to its waiter even after an invalidation has retired it from
-        // storage, so without this the retired answer could be promoted into a store with
-        // no TTL at all, stamped with whatever epoch happened to be current when it landed.
-        const observedAtEpoch = backendReconnectEpoch;
+        // #1223 — the epoch at which THIS CALL actually fetched, or null if it did not.
+        //
+        // Set INSIDE the loader, which the burst cache runs only on a miss. Capturing it
+        // out here instead was a defect: a CACHE HIT returns a payload fetched up to a TTL
+        // ago, and a reconnect can land in between — the reconnect's own refresh is
+        // payload-less and gets coalesced into any in-flight run, so it never reaches
+        // `objectInfoCache.invalidate()` either. The pre-reconnect schema would then be
+        // stamped with the post-reconnect epoch and retained with no TTL at all, which is
+        // precisely the #458 hole this file promises not to open.
+        //
+        // A JOINED read (another call's in-flight request) leaves this null for the same
+        // reason and is likewise not recorded: this call cannot vouch for when that fetch
+        // was issued. Only the call that actually asked may file the answer as evidence.
+        let observedAtEpoch = null;
         // #716 — READ THROUGH THE BURST CACHE. 29 widget writes meant 29 full
         // /object_info downloads (5,413,770 bytes each on a 63-pack install, #767).
         // Still the WHOLE payload, so no question this fence asks changes scope —
@@ -11625,6 +11634,9 @@ const GRAPH_TOOL_EXECUTORS = {
           // The OUTCOME rides through the cache, not just the schema (codex): a second
           // concurrent write JOINS this in-flight read and never runs its own loader, so
           // returning bare defs would leave that caller's refusal naming no routes at all.
+          // This body runs ONLY on a cache miss, so this is the moment the request is
+          // issued — the only epoch that can honestly be attributed to the answer.
+          observedAtEpoch = backendReconnectEpoch;
           return fetchWholeObjectInfo({
             getNodeDefs: typeof api?.getNodeDefs === "function" ? () => api.getNodeDefs() : null,
             fetchApi: typeof api?.fetchApi === "function" ? (route) => api.fetchApi(route) : null,
@@ -11634,13 +11646,15 @@ const GRAPH_TOOL_EXECUTORS = {
         oracleFailures = defs ? [] : (outcome?.failures ?? []);
         if (defs) {
           // A WHOLE map (this route never asks the per-class one — see the #716/#821 note
-          // above), so it is one #1223's fallback may hold. Refused if a reconnect landed
-          // while the read was in flight.
-          objectInfoSnapshot.record(defs, {
-            observedAtEpoch,
-            currentEpoch: backendReconnectEpoch,
-            whole: true,
-          });
+          // above), so it is one #1223's fallback may hold — but ONLY when this call issued
+          // the fetch itself, and only if no reconnect landed while it was in flight.
+          if (observedAtEpoch !== null) {
+            objectInfoSnapshot.record(defs, {
+              observedAtEpoch,
+              currentEpoch: backendReconnectEpoch,
+              whole: true,
+            });
+          }
           return recordObjectInfoTypes(defs);
         }
         // #1223 — the probe produced nothing. If it went SILENT (rather than answering

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -11648,6 +11648,13 @@ const GRAPH_TOOL_EXECUTORS = {
           // A WHOLE map (this route never asks the per-class one — see the #716/#821 note
           // above), so it is one #1223's fallback may hold — but ONLY when this call issued
           // the fetch itself, and only if no reconnect landed while it was in flight.
+          //
+          // This guard is DEFENCE IN DEPTH, and mutation testing reports removing it as a
+          // surviving mutant for that reason: `record` independently rejects a non-finite
+          // `observedAtEpoch`, which is exactly what a cache hit leaves here. It is kept
+          // because it states the rule at the point of decision — "only the caller that
+          // asked may file the answer" — rather than leaving it to be inferred from a
+          // validation two files away.
           if (observedAtEpoch !== null) {
             objectInfoSnapshot.record(defs, {
               observedAtEpoch,

--- a/web/js/lib/object-info-oracle.js
+++ b/web/js/lib/object-info-oracle.js
@@ -264,11 +264,38 @@ export const TRANSPORT_OUTCOME = Object.freeze({
   NO_ANSWER: "no-answer",
   /** Never contacted — the budget was gone, or no transport was wired. */
   NOT_ATTEMPTED: "not-attempted",
+  /**
+   * It settled with nothing — resolved null/undefined/a non-object.
+   *
+   * SEPARATE FROM ANSWERED_UNUSABLE, and the distinction is this file's own, stated five
+   * screens down: "Only a client that returned NOTHING (null/undefined/non-object) or threw
+   * LEAVES THE QUESTION UNANSWERED". Tagging it as an answer contradicted that and made the
+   * #1223 fallback dead on any frontend whose `getNodeDefs` swallows its own failure and
+   * resolves `undefined` — it fails closed, so it was not dangerous, merely inert.
+   *
+   * Note this is NOT the empty-`{}` case, which IS an answer (a client expressing deny-all)
+   * and keeps ANSWERED_UNUSABLE.
+   */
+  NOTHING_RETURNED: "nothing-returned",
   /** It threw. Something answered, or the connection was actively refused. */
   THREW: "threw",
   /** It answered, and the answer could not authorize anything (non-OK, empty, unusable). */
   ANSWERED_UNUSABLE: "answered-unusable",
 });
+
+/**
+ * Statuses that are the PROXY speaking, not ComfyUI.
+ *
+ * #1223 — ComfyUI behind nginx/Caddy is the standard remote and RunPod shape, and a proxy
+ * answers a hung upstream with a synthetic gateway error after its own read timeout. That
+ * is the SAME event as a bare timeout — the backend never answered — but it arrives as an
+ * HTTP response, so tagging it ANSWERED_UNUSABLE both disabled the fallback for every
+ * proxied install and blamed the backend for a message it never sent (#982's exact defect).
+ *
+ * 502 and 504 only. 503 is deliberately excluded: ComfyUI itself can serve it, so it is not
+ * unambiguously the proxy, and this must not guess.
+ */
+const GATEWAY_STATUSES = Object.freeze([502, 504]);
 
 /**
  * Fetch the whole `/object_info` schema, trying the frontend client first and the raw
@@ -533,7 +560,9 @@ export async function fetchWholeObjectInfo({
       }
       record(
         "client",
-        TRANSPORT_OUTCOME.ANSWERED_UNUSABLE,
+        // NOTHING_RETURNED, not ANSWERED_UNUSABLE — this branch IS the "returned NOTHING"
+        // case the note above reserves, so it leaves the question unanswered (#1223).
+        TRANSPORT_OUTCOME.NOTHING_RETURNED,
         describeFailure(
           "api.getNodeDefs() returned no usable schema",
           null,
@@ -579,8 +608,13 @@ export async function fetchWholeObjectInfo({
       // same input produced a failures entry and here produced a rejection.
       let responseOk = false;
       let responseStatus = "unknown";
+      // The NUMERIC status, kept apart from the sanitized display string: the gateway test
+      // is a decision and must not be made by pattern-matching a string built for a human.
+      let statusCode = null;
       try {
         responseOk = !!res && res.ok === true;
+        const raw = res?.status;
+        statusCode = typeof raw === "number" && Number.isFinite(raw) ? raw : null;
         // SANITIZE INSIDE THE GUARD. Reading `.status` is not the only operation that can
         // throw — INTERPOLATING it does too (`Object.create(null)` cannot convert to a
         // primitive), and that interpolation sits below this try. Verified against main,
@@ -595,10 +629,19 @@ export async function fetchWholeObjectInfo({
         return { [CACHE_OUTCOME]: true, defs: null, failures, outcomes };
       }
       if (!responseOk) {
+        const gateway = statusCode !== null && GATEWAY_STATUSES.includes(statusCode);
         record(
           "http",
-          TRANSPORT_OUTCOME.ANSWERED_UNUSABLE,
-          describeFailure("GET /object_info was not OK", null, ` (status ${responseStatus})`),
+          // A gateway error is the PROXY reporting that ComfyUI did not answer it — the
+          // same event as a bare timeout, arriving over HTTP (#1223).
+          gateway ? TRANSPORT_OUTCOME.NO_ANSWER : TRANSPORT_OUTCOME.ANSWERED_UNUSABLE,
+          describeFailure(
+            gateway
+              ? "GET /object_info got a GATEWAY error — a proxy in front of ComfyUI reporting the backend did not answer it"
+              : "GET /object_info was not OK",
+            null,
+            ` (status ${responseStatus})`,
+          ),
         );
       } else {
         // The BODY is a second I/O step, and it was inside the try/catch this bound

--- a/web/js/lib/object-info-oracle.js
+++ b/web/js/lib/object-info-oracle.js
@@ -245,12 +245,39 @@ async function runTransport(attempt, remainingMs, timers) {
 }
 
 /**
+ * #1223 — the MACHINE-READABLE half of `failures`, and the reason it exists.
+ *
+ * `failures` is prose, written to be read by a person in a refusal. A caller that needs to
+ * DECIDE something from what the transports did cannot parse those sentences (they are
+ * rewritten whenever the wording improves — twice already in #982 and #1161), so each
+ * attempt is also recorded as a tag here.
+ *
+ * The distinction the tags exist to carry: SILENCE is not the same evidence as an ANSWER.
+ * A route that times out establishes only that nothing came back in time; a route that
+ * THREW, returned a non-OK status, or handed back an unusable body establishes that
+ * something on the other end responded. `object-info-snapshot.js` licenses its fallback on
+ * exactly that difference, so the tags must stay a faithful record of the outcome rather
+ * than a summary of it. One tag per attempted route, in order, mirroring `failures`.
+ */
+export const TRANSPORT_OUTCOME = Object.freeze({
+  /** Ran out its whole grant without settling. Nothing was established. */
+  NO_ANSWER: "no-answer",
+  /** Never contacted — the budget was gone, or no transport was wired. */
+  NOT_ATTEMPTED: "not-attempted",
+  /** It threw. Something answered, or the connection was actively refused. */
+  THREW: "threw",
+  /** It answered, and the answer could not authorize anything (non-OK, empty, unusable). */
+  ANSWERED_UNUSABLE: "answered-unusable",
+});
+
+/**
  * Fetch the whole `/object_info` schema, trying the frontend client first and the raw
  * HTTP route second.
  *
- * Returns `{ defs, failures }` — `defs` is null unless one route returned a usable
- * payload, and `failures` names every route that did not, in order. An empty `failures`
- * with a null `defs` cannot happen: a route that answers nothing is itself a failure.
+ * Returns `{ defs, failures, outcomes }` — `defs` is null unless one route returned a
+ * usable payload, `failures` names every route that did not, in order, and `outcomes`
+ * carries the same list as TRANSPORT_OUTCOME tags (#1223). An empty `failures` with a null
+ * `defs` cannot happen: a route that answers nothing is itself a failure.
  */
 export async function fetchWholeObjectInfo({
   getNodeDefs,
@@ -447,6 +474,18 @@ export async function fetchWholeObjectInfo({
   const FALLBACK_RESPONSE_SHARE = 0.5;
   const BODY_SHARE = 1;
   const failures = [];
+  // #1223 — kept in lockstep with `failures` by pushing through ONE helper. Two arrays
+  // appended at eleven call sites drift the first time a branch is added to one of them,
+  // and a tag list that silently omits an attempt would license the snapshot fallback on
+  // evidence that route never gave.
+  const outcomes = [];
+  // The route is passed, never DERIVED FROM THE SENTENCE. Sniffing the prose for a prefix
+  // is the very coupling the tags exist to remove — it would re-break the moment a message
+  // is reworded, which is a thing this file's history shows happening.
+  const record = (route, kind, sentence) => {
+    failures.push(sentence);
+    outcomes.push({ route, kind });
+  };
 
   if (typeof getNodeDefs === "function") {
     const { outcome, grant: clientMs } = await runStep(getNodeDefs, CLIENT_ROUTE_SHARE);
@@ -456,7 +495,11 @@ export async function fetchWholeObjectInfo({
       // a false cause here: on a degenerate budget nothing had been drawn when this ran.
       // Naming a cause that did not happen is #982's original defect, and it is no more
       // acceptable in a branch that is hard to reach than in one that is not.
-      failures.push(`api.getNodeDefs() was not attempted — the ${budget}ms budget leaves it no time`);
+      record(
+        "client",
+        TRANSPORT_OUTCOME.NOT_ATTEMPTED,
+        `api.getNodeDefs() was not attempted — the ${budget}ms budget leaves it no time`,
+      );
     } else if (kind === "no-answer") {
       // The #1161 case. Recorded as a failure like any other, and — critically — execution
       // CONTINUES to the second transport, which is what this bound exists to reach.
@@ -465,22 +508,32 @@ export async function fetchWholeObjectInfo({
       // here told the reader it had waited 20000ms when it had waited 10000ms. Naming a
       // number that was never spent is the same defect as #982's "unreachable or the
       // fetch failed" — a refusal asserting something it did not establish.
-      failures.push(`api.getNodeDefs() did not answer within its ${Math.round(clientMs)}ms share of the ${budget}ms budget`);
+      record(
+        "client",
+        TRANSPORT_OUTCOME.NO_ANSWER,
+        `api.getNodeDefs() did not answer within its ${Math.round(clientMs)}ms share of the ${budget}ms budget`,
+      );
     } else if (kind === "threw") {
-      failures.push(describeFailure("api.getNodeDefs() threw", outcome.err));
+      record("client", TRANSPORT_OUTCOME.THREW, describeFailure("api.getNodeDefs() threw", outcome.err));
     } else {
       const defs = outcome.value;
-      if (usableDefs(defs)) return { [CACHE_OUTCOME]: true, defs, failures };
+      if (usableDefs(defs)) return { [CACHE_OUTCOME]: true, defs, failures, outcomes };
       // AN EMPTY MAP IS AN ANSWER, NOT AN ABSENCE (codex). A client that deliberately
       // filters could express deny-all as `{}`, and consulting the raw route would then
       // overrule it with a broader schema — the one direction this fallback must never
       // move. Only a client that returned NOTHING (null/undefined/non-object) or threw
       // leaves the question unanswered, and only that may be asked again elsewhere.
       if (defs && typeof defs === "object" && !Array.isArray(defs)) {
-        failures.push("api.getNodeDefs() returned an EMPTY schema — treated as its answer, not as an absence");
-        return { [CACHE_OUTCOME]: true, defs: null, failures };
+        record(
+          "client",
+          TRANSPORT_OUTCOME.ANSWERED_UNUSABLE,
+          "api.getNodeDefs() returned an EMPTY schema — treated as its answer, not as an absence",
+        );
+        return { [CACHE_OUTCOME]: true, defs: null, failures, outcomes };
       }
-      failures.push(
+      record(
+        "client",
+        TRANSPORT_OUTCOME.ANSWERED_UNUSABLE,
         describeFailure(
           "api.getNodeDefs() returned no usable schema",
           null,
@@ -489,7 +542,10 @@ export async function fetchWholeObjectInfo({
       );
     }
   } else {
-    failures.push("api.getNodeDefs is not a function on this frontend");
+    // NOT_ATTEMPTED, not ANSWERED_UNUSABLE: a transport this frontend does not have is a
+    // route that was never asked. Tagging an absent client as though it had answered would
+    // make "no transport is wired" read as evidence the backend responded (#1223).
+    record("client", TRANSPORT_OUTCOME.NOT_ATTEMPTED, "api.getNodeDefs is not a function on this frontend");
   }
 
   // SECOND TRANSPORT, same question. The reporter proved this route answers when the
@@ -501,11 +557,19 @@ export async function fetchWholeObjectInfo({
       // TRUTHFUL ABOUT WHAT WAS NOT DONE. Saying this route "did not answer" when no
       // request was ever sent is #982's original defect — a refusal asserting a cause it
       // never established. The reserve above exists so this stays unreachable in practice.
-      failures.push("GET /object_info was not attempted — the budget was spent before it was reached");
+      record(
+        "http",
+        TRANSPORT_OUTCOME.NOT_ATTEMPTED,
+        "GET /object_info was not attempted — the budget was spent before it was reached",
+      );
     } else if (kind === "no-answer") {
-      failures.push(`GET /object_info did not answer within its ${Math.round(fallbackMs)}ms share of the ${budget}ms budget`);
+      record(
+        "http",
+        TRANSPORT_OUTCOME.NO_ANSWER,
+        `GET /object_info did not answer within its ${Math.round(fallbackMs)}ms share of the ${budget}ms budget`,
+      );
     } else if (kind === "threw") {
-      failures.push(describeFailure("GET /object_info threw", outcome.err));
+      record("http", TRANSPORT_OUTCOME.THREW, describeFailure("GET /object_info threw", outcome.err));
     } else {
       const res = outcome.value;
       // #1161 — reading `ok`/`status` off the response is itself an operation that can
@@ -523,11 +587,19 @@ export async function fetchWholeObjectInfo({
         // which returned a failures entry where this rejected.
         responseStatus = sanitizeDetail(res?.status ?? "unknown") || "unknown";
       } catch (err) {
-        failures.push(describeFailure("GET /object_info returned an unreadable response", err));
-        return { [CACHE_OUTCOME]: true, defs: null, failures };
+        record(
+          "http",
+          TRANSPORT_OUTCOME.ANSWERED_UNUSABLE,
+          describeFailure("GET /object_info returned an unreadable response", err),
+        );
+        return { [CACHE_OUTCOME]: true, defs: null, failures, outcomes };
       }
       if (!responseOk) {
-        failures.push(describeFailure("GET /object_info was not OK", null, ` (status ${responseStatus})`));
+        record(
+          "http",
+          TRANSPORT_OUTCOME.ANSWERED_UNUSABLE,
+          describeFailure("GET /object_info was not OK", null, ` (status ${responseStatus})`),
+        );
       } else {
         // The BODY is a second I/O step, and it was inside the try/catch this bound
         // replaced — an existing #982 test caught the escape. Reading a 5MB schema over a
@@ -536,27 +608,44 @@ export async function fetchWholeObjectInfo({
         const { outcome: body, grant: bodyMs } = await runStep(() => res.json(), BODY_SHARE);
         const bodyKind = outcomeKind(body);
         if (bodyKind === "not-tried") {
-          failures.push("GET /object_info answered but its body was not read — the budget was spent");
+          // ANSWERED_UNUSABLE, not NOT_ATTEMPTED: the RESPONSE arrived — the backend
+          // demonstrably answered — and only the body read was skipped. The tag records
+          // what the backend did, not which of our own steps ran (#1223).
+          record(
+            "http",
+            TRANSPORT_OUTCOME.ANSWERED_UNUSABLE,
+            "GET /object_info answered but its body was not read — the budget was spent",
+          );
         } else if (bodyKind === "no-answer") {
-          failures.push(`GET /object_info answered but its body did not arrive within its ${Math.round(bodyMs)}ms share of the ${budget}ms budget`);
+          // Same reasoning: the response headers came back, so something is alive on the
+          // other end. A stalled BODY is not the silence the snapshot fallback licenses on.
+          record(
+            "http",
+            TRANSPORT_OUTCOME.ANSWERED_UNUSABLE,
+            `GET /object_info answered but its body did not arrive within its ${Math.round(bodyMs)}ms share of the ${budget}ms budget`,
+          );
         } else if (bodyKind === "threw") {
           // Deliberately the SAME wording as before. A parse failure used to surface
           // through this route's catch, and an existing #982 test pins the sentence a user
           // reads. This change is about bounding the waits, not about rewording refusals —
           // improving the phrasing here would be a separate, reviewable decision.
-          failures.push(describeFailure("GET /object_info threw", body.err));
+          record("http", TRANSPORT_OUTCOME.THREW, describeFailure("GET /object_info threw", body.err));
         } else {
           const defs = body.value;
-          if (usableDefs(defs)) return { [CACHE_OUTCOME]: true, defs, failures };
-          failures.push("GET /object_info returned no usable schema (an empty or non-object body)");
+          if (usableDefs(defs)) return { [CACHE_OUTCOME]: true, defs, failures, outcomes };
+          record(
+            "http",
+            TRANSPORT_OUTCOME.ANSWERED_UNUSABLE,
+            "GET /object_info returned no usable schema (an empty or non-object body)",
+          );
         }
       }
     }
   } else {
-    failures.push("no fetchApi is wired for the fallback route");
+    record("http", TRANSPORT_OUTCOME.NOT_ATTEMPTED, "no fetchApi is wired for the fallback route");
   }
 
-  return { [CACHE_OUTCOME]: true, defs: null, failures };
+  return { [CACHE_OUTCOME]: true, defs: null, failures, outcomes };
 }
 
 /**

--- a/web/js/lib/object-info-oracle.js
+++ b/web/js/lib/object-info-oracle.js
@@ -292,10 +292,22 @@ export const TRANSPORT_OUTCOME = Object.freeze({
  * HTTP response, so tagging it ANSWERED_UNUSABLE both disabled the fallback for every
  * proxied install and blamed the backend for a message it never sent (#982's exact defect).
  *
- * 502 and 504 only. 503 is deliberately excluded: ComfyUI itself can serve it, so it is not
- * unambiguously the proxy, and this must not guess.
+ * 504 ONLY, and the exclusions are the whole point:
+ *
+ *   - 502 Bad Gateway is what nginx and Caddy emit IMMEDIATELY when they cannot CONNECT to
+ *     the upstream — a stopped or restarting ComfyUI. That is evidence the process is GONE,
+ *     which is the opposite of the evidence this is looking for. Including it was a real
+ *     defect caught in review: on a frontend whose `getNodeDefs()` swallows its network
+ *     error and returns nothing, a 502 arriving BEFORE the websocket-down event produced an
+ *     all-silent outcome list, and the pre-restart schema would then authorize — and report
+ *     as successful — a write to a type the restart had removed.
+ *   - 503 can be served by ComfyUI itself, so it is not unambiguously the proxy.
+ *
+ * 504 Gateway Timeout is the one that means what this needs: the proxy CONNECTED and the
+ * upstream did not answer within its read timeout. Connected-but-quiet is a running
+ * process, which is the same event as a bare client-side timeout.
  */
-const GATEWAY_STATUSES = Object.freeze([502, 504]);
+const GATEWAY_STATUSES = Object.freeze([504]);
 
 /**
  * Fetch the whole `/object_info` schema, trying the frontend client first and the raw

--- a/web/js/lib/object-info-oracle.js
+++ b/web/js/lib/object-info-oracle.js
@@ -625,13 +625,21 @@ export async function fetchWholeObjectInfo({
       let statusCode = null;
       try {
         responseOk = !!res && res.ok === true;
+        // READ THE STATUS EXACTLY ONCE, and derive BOTH the decision and the display text
+        // from that one value (#1223). This code deliberately supports a monkey-patched
+        // fetchApi returning a proxied or getter-backed response — the two screens above
+        // say so — and such a response can answer differently on each read. Two reads let a
+        // first value of 504 classify the route as silence while the second, 502, is what
+        // the message reports: the fallback would then be licensed by a status that exists
+        // only in the classification, against a reply that names the status meant to
+        // disqualify it.
         const raw = res?.status;
         statusCode = typeof raw === "number" && Number.isFinite(raw) ? raw : null;
         // SANITIZE INSIDE THE GUARD. Reading `.status` is not the only operation that can
         // throw — INTERPOLATING it does too (`Object.create(null)` cannot convert to a
         // primitive), and that interpolation sits below this try. Verified against main,
         // which returned a failures entry where this rejected.
-        responseStatus = sanitizeDetail(res?.status ?? "unknown") || "unknown";
+        responseStatus = sanitizeDetail(raw ?? "unknown") || "unknown";
       } catch (err) {
         record(
           "http",

--- a/web/js/lib/object-info-snapshot.js
+++ b/web/js/lib/object-info-snapshot.js
@@ -194,6 +194,11 @@ export function createObjectInfoSnapshot() {
       const detached = Object.create(null);
       for (const key of keys) detached[key] = EMPTY_DEF;
       defs = Object.freeze(detached);
+      // `currentEpoch` and `observedAtEpoch` are provably equal here — the guard above
+      // returned false otherwise — so writing either is the same store. Mutation testing
+      // reports the swap as a SURVIVOR for exactly that reason; it is an equivalent mutant,
+      // not a hole in the suite, and it is recorded here so the next run does not re-chase
+      // it. `currentEpoch` is written because it is the one `authorize` compares against.
       epoch = currentEpoch;
       return true;
     },

--- a/web/js/lib/object-info-snapshot.js
+++ b/web/js/lib/object-info-snapshot.js
@@ -1,0 +1,203 @@
+/**
+ * #1223 — a TRANSIENT `/object_info` timeout must not refuse a safe widget edit.
+ *
+ * Reported: `panel_set_widget` refused a live edit on an existing `H3Keyframes` node
+ * because BOTH probes timed out — `api.getNodeDefs()` and `GET /object_info`. The canvas
+ * was reachable and `panel_disconnect` mutations had succeeded moments earlier, so nothing
+ * about the session was broken; the schema fetch simply did not come back in time. The
+ * refusal reads as "cannot verify the node type against the ComfyUI backend", which is
+ * true, and useless: the agent is told a write is unsafe when the only thing established
+ * is that a download was slow.
+ *
+ * WHY IT TIMES OUT AT ALL, since "the backend is fine" and "20s of silence" sound
+ * contradictory. ComfyUI serves HTTP from the same process that runs the graph, so a heavy
+ * step (a VAE decode, a model load) blocks the event loop and `/object_info` — megabytes on
+ * a large install — waits behind it. That is a BUSY backend, not an absent one, and it is
+ * the ordinary condition during a render.
+ *
+ * WHAT MUST NOT BE WEAKENED. `assertTypeAgainstFreshBackend` fails closed on a null map
+ * because of #458: the LiteGraph registry keeps a STALE POSITIVE for an uninstalled pack
+ * when the tab was never reloaded after a ComfyUI restart, so the registry is not a trust
+ * root and a write authorized from it fabricates success against a backend that no longer
+ * defines the type. Nothing here may re-open that.
+ *
+ * THE TRUST ROOT THIS USES INSTEAD, and why a stale cache cannot forge it. A ComfyUI
+ * process cannot change the set of types it serves without RESTARTING — `NODE_CLASS_MAPPINGS`
+ * is built at import time, and installing, uninstalling or disabling a pack (through the
+ * Manager or by hand) only takes effect on the next boot. A restart drops this tab's
+ * websocket. So a `/object_info` map observed on the CURRENT backend connection still
+ * describes the process that is answering now, and this authorizes from that map — never
+ * from the registry, which carries no such provenance.
+ *
+ * FOUR CONDITIONS, ALL REQUIRED, all fail-closed:
+ *
+ *   1. A WHOLE map was observed and stored. A per-class `/object_info/<Type>` payload must
+ *      never land here: it would make every OTHER type read as absent, and the ever-seen
+ *      gate would then diagnose the entire install as removed packs. `record` cannot
+ *      enforce "whole" from the value alone, so its callers are the contract — see
+ *      `recordsWholeSchemaOnly` in the panel and the test that pins it.
+ *   2. The socket is UP. `comfyBackendSocketDown` is set by ComfyUI's own `reconnecting`
+ *      and null-`status` events. A backend that is down may be restarting, and a restart is
+ *      the one event that can change the type set.
+ *   3. NO RECONNECT SINCE. `backendReconnectEpoch` is bumped on every `reconnected`. A
+ *      snapshot from an earlier epoch describes a process that has been replaced, so it is
+ *      refused outright rather than aged out — this is provenance, not freshness, and a
+ *      time bound would answer a question nobody asked.
+ *   4. THE PROBES WERE SILENT, not merely unsuccessful. This is the narrow one, and it is
+ *      deliberately narrower than "the fetch failed": only `no-answer` (and never-contacted)
+ *      outcomes license the snapshot. Anything that ANSWERED — threw, a non-OK status, an
+ *      empty schema, a body that stalled after its headers arrived — keeps the existing
+ *      refusal. `TypeError: Failed to fetch` is what a REFUSED connection produces, and a
+ *      refused connection is the signature of a process that is gone; silence is the
+ *      signature of one that is busy. Conflating them is exactly how this would re-open
+ *      #458 while looking like it only relaxed a timeout.
+ *
+ * WHAT THIS DOES NOT CLOSE, stated rather than glossed. Conditions 2 and 3 both rest on the
+ * tab NOTICING that the socket went away. A half-open TCP connection to a process that has
+ * already died does not report itself, and in that window the probes time out (condition 4
+ * is satisfied), the socket reads as up, and the epoch has not moved — so a snapshot could
+ * authorize a write to a type the NEXT process will not define. That requires the restart
+ * AND a pack removal across it AND a write to that exact type inside the window. The
+ * direction matters and is the same one `object-info-cache.js` records for its own 1.5s
+ * window: an INSTALL is harmless here (a type missing from the snapshot is still refused,
+ * which fails closed), only a REMOVAL can authorize something it should not, and the tab's
+ * own reconnect handler refuses everything from the moment it notices. This widens an
+ * existing race rather than opening a new class of hole, and it is written down so whoever
+ * weighs it next does not have to rediscover it.
+ */
+
+import { TRANSPORT_OUTCOME } from "./object-info-oracle.js";
+
+/**
+ * Does what the transports did license authorizing from a stored snapshot?
+ *
+ * TRUE only when at least one route was SILENT and no route ANSWERED. An empty or absent
+ * list is false: "we recorded nothing" is not evidence of silence, and a caller that lost
+ * the outcomes must get the refusal, not the fallback.
+ */
+export function transportsWereSilent(outcomes) {
+  if (!Array.isArray(outcomes) || outcomes.length === 0) return false;
+  let sawSilence = false;
+  for (const entry of outcomes) {
+    // An entry this module did not produce is not an outcome it can reason about. Reading
+    // an unknown tag as "not an answer" would let a caller license the fallback by handing
+    // in anything at all, so an unrecognised shape is disqualifying (codex-style guard).
+    const kind = entry && typeof entry === "object" ? entry.kind : undefined;
+    if (kind === TRANSPORT_OUTCOME.NO_ANSWER) {
+      sawSilence = true;
+      continue;
+    }
+    if (kind === TRANSPORT_OUTCOME.NOT_ATTEMPTED) continue;
+    return false;
+  }
+  return sawSilence;
+}
+
+/**
+ * The last WHOLE `/object_info` map observed on the current backend connection.
+ *
+ * Deliberately not a second cache. `object-info-cache.js` answers "may this payload be
+ * REUSED", on a 1.5s TTL, for the ordinary path. This answers a different question — "is
+ * there anything left to authorize from when the backend went quiet" — and it is consulted
+ * ONLY after the oracle has already failed.
+ */
+export function createObjectInfoSnapshot() {
+  let defs = null;
+  let epoch = null;
+
+  return {
+    /**
+     * Store a whole map observed at `atEpoch`.
+     *
+     * Rejects anything that could not authorize a write anyway (null, empty, an array, a
+     * non-object) and any epoch that is not a finite number — an unusable epoch cannot be
+     * compared later, and a snapshot that cannot prove its provenance is worse than none.
+     */
+    record(candidate, atEpoch) {
+      if (!Number.isFinite(atEpoch)) return false;
+      if (!candidate || typeof candidate !== "object" || Array.isArray(candidate)) return false;
+      let size = 0;
+      try {
+        // `Object.keys` invokes a Proxy's ownKeys trap, which can throw — the same hazard
+        // `usableDefs` guards in the oracle. A payload whose shape cannot be inspected is
+        // not one to authorize from.
+        size = Object.keys(candidate).length;
+      } catch {
+        return false;
+      }
+      if (size === 0) return false;
+      defs = candidate;
+      epoch = atEpoch;
+      return true;
+    },
+
+    /**
+     * The map to authorize from, or null with the reason it was refused.
+     *
+     * The reason is for the refusal message, so it names the condition that failed rather
+     * than the general shape of the rule — a caller told "no snapshot" when the real cause
+     * was a reconnect goes looking in the wrong place (#982's lesson).
+     */
+    authorize({ epoch: currentEpoch, socketDown, outcomes } = {}) {
+      if (!transportsWereSilent(outcomes)) {
+        return {
+          defs: null,
+          reason:
+            "the backend ANSWERED the schema probe with something unusable rather than going " +
+            "silent, so this is not the transient timeout the last-observed schema covers",
+        };
+      }
+      if (defs === null) {
+        return {
+          defs: null,
+          reason: "no whole /object_info has been observed on this backend connection yet",
+        };
+      }
+      if (socketDown) {
+        return {
+          defs: null,
+          reason:
+            "the ComfyUI socket is down — the backend may be restarting, which is the one " +
+            "event that can change the node types it defines",
+        };
+      }
+      if (!Number.isFinite(currentEpoch) || currentEpoch !== epoch) {
+        return {
+          defs: null,
+          reason:
+            "the backend reconnected since that schema was observed, so it describes a " +
+            "ComfyUI process that has been replaced",
+        };
+      }
+      return { defs, reason: "" };
+    },
+
+    /** Drop it — for anything that knows, or merely suspects, the schema moved. */
+    clear() {
+      defs = null;
+      epoch = null;
+    },
+
+    /** Test/diagnostic view. Never used to make a decision. */
+    peek() {
+      return { held: defs !== null, epoch };
+    },
+  };
+}
+
+/**
+ * The sentence a SUCCESSFUL write appends when it was authorized from the snapshot.
+ *
+ * A write that succeeded on a schema nobody could re-fetch must say so. The agent's next
+ * decision — retry, or trust this and move on — depends on knowing the backend went quiet,
+ * and a silent success is indistinguishable from a fully verified one.
+ */
+export function snapshotAuthorizationNote(failureNote = "") {
+  return (
+    `The write SUCCEEDED and was verified against the last whole /object_info observed on ` +
+    `this ComfyUI connection: the live schema probe went silent, so it was authorized from ` +
+    `that snapshot instead (#1223).${failureNote} The backend has not reconnected since that ` +
+    `schema was read, so it still describes the process answering now — but if the node type ` +
+    `matters to what happens next, re-read it once ComfyUI is responding again.`
+  );
+}

--- a/web/js/lib/object-info-snapshot.js
+++ b/web/js/lib/object-info-snapshot.js
@@ -31,26 +31,37 @@
  *
  * FOUR CONDITIONS, ALL REQUIRED, all fail-closed:
  *
- *   1. A WHOLE map was observed and stored. A per-class `/object_info/<Type>` payload must
- *      never land here: it would make every OTHER type read as absent, and the ever-seen
- *      gate would then diagnose the entire install as removed packs. `record` cannot
- *      enforce "whole" from the value alone, so its callers are the contract — see
- *      `recordsWholeSchemaOnly` in the panel and the test that pins it.
+ *   1. A WHOLE map was observed, and its observer SAID SO. A per-class `/object_info/<Type>`
+ *      payload must never land here: it would make every OTHER type read as absent, and the
+ *      ever-seen gate would then diagnose the entire install as removed packs. `record`
+ *      cannot judge "whole" from the value, so it requires the claim explicitly (`whole:
+ *      true`) and each call site states it. That is not paranoia about a hypothetical:
+ *      `assertAddNodeResolvableRefreshing` re-reads the registry across an await and can
+ *      hand its SINGLE-CLASS defs to `refresh`, which is the whole-schema path.
  *   2. The socket is UP. `comfyBackendSocketDown` is set by ComfyUI's own `reconnecting`
  *      and null-`status` events. A backend that is down may be restarting, and a restart is
  *      the one event that can change the type set.
- *   3. NO RECONNECT SINCE. `backendReconnectEpoch` is bumped on every `reconnected`. A
- *      snapshot from an earlier epoch describes a process that has been replaced, so it is
- *      refused outright rather than aged out — this is provenance, not freshness, and a
- *      time bound would answer a question nobody asked.
- *   4. THE PROBES WERE SILENT, not merely unsuccessful. This is the narrow one, and it is
- *      deliberately narrower than "the fetch failed": only `no-answer` (and never-contacted)
- *      outcomes license the snapshot. Anything that ANSWERED — threw, a non-OK status, an
- *      empty schema, a body that stalled after its headers arrived — keeps the existing
- *      refusal. `TypeError: Failed to fetch` is what a REFUSED connection produces, and a
- *      refused connection is the signature of a process that is gone; silence is the
- *      signature of one that is busy. Conflating them is exactly how this would re-open
- *      #458 while looking like it only relaxed a timeout.
+ *   3. NO RECONNECT SINCE — measured from when the schema was FETCHED, not when it was
+ *      filed. `backendReconnectEpoch` is bumped on every `reconnected`, and `record` takes
+ *      the epoch captured BEFORE the request went out, storing nothing if it has moved
+ *      since. Reading the epoch at record time instead was a real defect in the first
+ *      version of this file: a schema fetched before a restart was filed under post-restart
+ *      provenance, and the clear that should have caught it never ran, because the
+ *      `reconnected` handler's payload-less `refreshComfyNodeDefs()` is COALESCED into an
+ *      in-flight run (`refresh-coalesce.js`) and never reaches `registerComfyNodeDefs`.
+ *      That is why the socket handlers now clear this directly rather than trusting the
+ *      refresh path to do it. Provenance, not freshness — a snapshot from a replaced
+ *      process is refused outright rather than aged out, so there is no time bound to get
+ *      wrong.
+ *   4. THE BACKEND NEVER ANSWERED, not merely "the fetch failed". Only outcomes that leave
+ *      the question unanswered license the snapshot: a timeout, a client that returned
+ *      NOTHING, a proxy's gateway error (which is the proxy reporting the same silence over
+ *      HTTP). Anything that ANSWERED — threw, a non-gateway status, an empty schema, a body
+ *      that stalled after its headers arrived — keeps the existing refusal.
+ *      `TypeError: Failed to fetch` is what a REFUSED connection produces, and a refused
+ *      connection is the signature of a process that is gone; silence is the signature of
+ *      one that is busy. Conflating them is exactly how this would re-open #458 while
+ *      looking like it only relaxed a timeout.
  *
  * WHAT THIS DOES NOT CLOSE, stated rather than glossed. Conditions 2 and 3 both rest on the
  * tab NOTICING that the socket went away. A half-open TCP connection to a process that has
@@ -69,28 +80,44 @@
 import { TRANSPORT_OUTCOME } from "./object-info-oracle.js";
 
 /**
- * Does what the transports did license authorizing from a stored snapshot?
+ * The value stored against every type name.
  *
- * TRUE only when at least one route was SILENT and no route ANSWERED. An empty or absent
- * list is false: "we recorded nothing" is not evidence of silence, and a caller that lost
- * the outcomes must get the refusal, not the fallback.
+ * Frozen and shared: the snapshot answers MEMBERSHIP, and every helper that reads a def's
+ * shape treats this as "declares nothing", which is the conservative answer in each case.
+ * The map itself is null-prototype so a schema containing a type literally named
+ * `__proto__` cannot reach `Object.prototype` — on a plain object that assignment sets the
+ * prototype instead of creating an own property, which would both lose the type and poison
+ * every object in the page.
  */
-export function transportsWereSilent(outcomes) {
+const EMPTY_DEF = Object.freeze({});
+
+/**
+ * Did the probes fail WITHOUT establishing that the backend answered?
+ *
+ * TRUE only when at least one route was actually contacted and came back with nothing, and
+ * NO route established an answer. An empty or absent list is false: "we recorded nothing"
+ * is not evidence of silence, and a caller that lost the outcomes must get the refusal.
+ *
+ * NOT_ATTEMPTED is neutral — a route nobody asked establishes nothing in either direction,
+ * so it neither licenses nor disqualifies. A list of nothing but NOT_ATTEMPTED therefore
+ * licenses nothing, which is why the `contacted` flag exists separately.
+ */
+export function noBackendAnswerEstablished(outcomes) {
   if (!Array.isArray(outcomes) || outcomes.length === 0) return false;
-  let sawSilence = false;
+  let contacted = false;
   for (const entry of outcomes) {
     // An entry this module did not produce is not an outcome it can reason about. Reading
     // an unknown tag as "not an answer" would let a caller license the fallback by handing
     // in anything at all, so an unrecognised shape is disqualifying (codex-style guard).
     const kind = entry && typeof entry === "object" ? entry.kind : undefined;
-    if (kind === TRANSPORT_OUTCOME.NO_ANSWER) {
-      sawSilence = true;
+    if (kind === TRANSPORT_OUTCOME.NO_ANSWER || kind === TRANSPORT_OUTCOME.NOTHING_RETURNED) {
+      contacted = true;
       continue;
     }
     if (kind === TRANSPORT_OUTCOME.NOT_ATTEMPTED) continue;
     return false;
   }
-  return sawSilence;
+  return contacted;
 }
 
 /**
@@ -100,6 +127,9 @@ export function transportsWereSilent(outcomes) {
  * REUSED", on a 1.5s TTL, for the ordinary path. This answers a different question — "is
  * there anything left to authorize from when the backend went quiet" — and it is consulted
  * ONLY after the oracle has already failed.
+ *
+ * It holds TYPE NAMES, not the schema. See `record` for why that is the detachment as well
+ * as the point.
  */
 export function createObjectInfoSnapshot() {
   let defs = null;
@@ -107,27 +137,64 @@ export function createObjectInfoSnapshot() {
 
   return {
     /**
-     * Store a whole map observed at `atEpoch`.
+     * Store the type membership of a whole map that was OBSERVED at `observedAtEpoch`, if
+     * that is still the epoch we are on.
      *
-     * Rejects anything that could not authorize a write anyway (null, empty, an array, a
-     * non-object) and any epoch that is not a finite number — an unusable epoch cannot be
-     * compared later, and a snapshot that cannot prove its provenance is worse than none.
+     * THREE THINGS THIS REFUSES, each from a defect found in review:
+     *
+     * 1. AN EPOCH READ AFTER THE FETCH. `observedAtEpoch` must be captured BEFORE the
+     *    request is issued, and is only stored if `currentEpoch` still matches. The first
+     *    version stamped the payload with the epoch at RECORD time, so a schema fetched
+     *    before a ComfyUI restart was filed under post-restart provenance and would later
+     *    authorize a write to a type the new process no longer defines — #458, reopened by
+     *    the very field meant to prove it could not be. This is the same generation guard
+     *    `object-info-cache.js` uses, and for the same reason: that cache also refuses to
+     *    STORE a result issued before an invalidation while still returning it to its
+     *    waiter, so a caller passing that answer here must not be able to promote it into a
+     *    store with no TTL at all.
+     * 2. A PAYLOAD NOBODY VOUCHED FOR. `whole` must be passed explicitly. A per-class
+     *    `/object_info/<Type>` payload reaching here would make every other type read as
+     *    absent and the ever-seen gate diagnose the whole install as removed packs, and
+     *    that payload CAN reach the refresh path (`assertAddNodeResolvableRefreshing`
+     *    re-reads the registry across an await and may hand its single-class defs to
+     *    `refresh`). The flag makes each call site state the claim rather than imply it.
+     * 3. ANYTHING THAT COULD NOT AUTHORIZE A WRITE ANYWAY — null, empty, an array, a
+     *    non-object, or an unreadable shape.
+     *
+     * WHAT IS STORED IS A DETACHED MAP OF TYPE NAMES, never the payload. `registerNodesFromDefs`
+     * runs `beforeRegisterNodeDef` hooks that mutate definitions IN PLACE — Comfy's own
+     * upload hook adds an input the backend never declared — so retaining the payload by
+     * reference would let the snapshot hand back frontend-mutated data as backend evidence.
+     * Copying the key names is both the detachment and the whole of what this is for: the
+     * fence asks "does the backend define this type", nothing more. It also keeps a
+     * ~5.4MB schema from being pinned in memory for the life of a connection, and it means
+     * the values cannot supply stale combo option lists to anything downstream.
      */
-    record(candidate, atEpoch) {
-      if (!Number.isFinite(atEpoch)) return false;
+    record(candidate, { observedAtEpoch, currentEpoch, whole = false } = {}) {
+      if (whole !== true) return false;
+      if (!Number.isFinite(observedAtEpoch) || !Number.isFinite(currentEpoch)) return false;
+      if (observedAtEpoch !== currentEpoch) return false;
       if (!candidate || typeof candidate !== "object" || Array.isArray(candidate)) return false;
-      let size = 0;
+      let keys;
       try {
         // `Object.keys` invokes a Proxy's ownKeys trap, which can throw — the same hazard
         // `usableDefs` guards in the oracle. A payload whose shape cannot be inspected is
         // not one to authorize from.
-        size = Object.keys(candidate).length;
+        keys = Object.keys(candidate);
       } catch {
         return false;
       }
-      if (size === 0) return false;
-      defs = candidate;
-      epoch = atEpoch;
+      if (keys.length === 0) return false;
+      // One shared frozen value for every key. The fence reads membership via
+      // `hasOwnProperty`; the helpers that read a def's SHAPE (uploadInputConfig,
+      // serverDeclaresEmptyComboOptions, refreshComboOptionsFromDefs) all return
+      // null/false/no-op on this, which is the conservative answer and, for the combo
+      // refresh, the difference between "changes nothing" and "rewrites the live dropdown
+      // backwards to a stale list".
+      const detached = Object.create(null);
+      for (const key of keys) detached[key] = EMPTY_DEF;
+      defs = Object.freeze(detached);
+      epoch = currentEpoch;
       return true;
     },
 
@@ -139,12 +206,12 @@ export function createObjectInfoSnapshot() {
      * was a reconnect goes looking in the wrong place (#982's lesson).
      */
     authorize({ epoch: currentEpoch, socketDown, outcomes } = {}) {
-      if (!transportsWereSilent(outcomes)) {
+      if (!noBackendAnswerEstablished(outcomes)) {
         return {
           defs: null,
           reason:
-            "the backend ANSWERED the schema probe with something unusable rather than going " +
-            "silent, so this is not the transient timeout the last-observed schema covers",
+            "the backend ANSWERED the schema probe with something unusable rather than failing " +
+            "to answer at all, so this is not the transient silence the last-observed schema covers",
         };
       }
       if (defs === null) {


### PR DESCRIPTION
Fixes #1223 (related: #982, #458, #716, #1161).

## The report

`panel_set_widget` refused a live edit on an existing `H3Keyframes` node because *both* `/object_info` probes timed out. The graph was reachable — `panel_disconnect` mutations had succeeded moments before — and the node type was already identified on the live canvas.

## Why it times out while the backend is fine

ComfyUI serves HTTP from the same process that runs the graph, so a heavy step (a VAE decode, a model load) blocks the event loop and `/object_info` — megabytes on a large install — waits behind it. A **busy** backend, not an absent one, and it is the ordinary condition *during a render*, which is exactly when an agent is editing widgets.

## The trust root

A ComfyUI process **cannot change the set of types it serves without restarting** — `NODE_CLASS_MAPPINGS` is built at import time. A restart drops this tab's websocket. So a `/object_info` map observed on the **current backend connection** still describes the process answering now; that provenance is something the LiteGraph registry lacks, which is why #458 refuses to trust it.

`web/js/lib/object-info-snapshot.js` holds the type names of the last whole map observed, and authorizes from it only when **all four** hold:

1. **A whole map was observed, and its observer said so** (`whole: true`). A per-class `/object_info/<Type>` payload would make every other type read as absent and the ever-seen gate diagnose the install as removed packs — and that payload *can* reach the refresh path.
2. **The socket is up** (`comfyBackendSocketDown`).
3. **No reconnect since the schema was FETCHED** — the epoch is captured at issuance and re-checked when the answer lands.
4. **The backend never answered.** A timeout, a client that returned nothing, or a 504. Anything that answered — threw, a non-gateway status, an empty schema, a stalled body — keeps the existing refusal.

## Three review rounds, and what each one caught

This was rebuilt twice. Recording it because each defect looked correct when written.

**Round 1 — the fix did not fire, and could reopen #458.**
- On a normal startup `seedObjectInfoHistory()` performs the ONLY whole read; `registerComfyNodeDefs()` never runs. So the reported case found no snapshot and was refused exactly as before. **The fix was inert.**
- The epoch was read *after* the fetch, and the clear meant to catch that never ran: the `reconnected` handler's payload-less `refreshComfyNodeDefs()` is coalesced into any in-flight run (`refresh-coalesce.js:50-58`), so it never reaches `registerComfyNodeDefs`. A pre-restart schema could be filed under post-restart provenance.
- The payload was retained by reference, and `registerNodesFromDefs` runs `beforeRegisterNodeDef` hooks that mutate defs in place.
- Snapshot defs reached `refreshCombos`, which does `w.options.values = first.slice()` — rewriting a live dropdown *backwards*, persistently.
- The ineligibility reason was spliced into `failures`, so a two-transport failure reported "Tried **3** routes" (#982's own defect).
- A comment cited `recordsWholeSchemaOnly`, a symbol that does not exist.

**Round 2 — two more P1s.**
- **A 502 is not silence.** nginx/Caddy emit it *immediately* when they cannot CONNECT to a stopped ComfyUI — evidence the process is **gone**. Only 504 (connected, upstream quiet) now counts. Including 502 would have let a pre-restart schema authorize a write to a removed type.
- **A cache hit is not evidence.** The issuance epoch was captured before `objectInfoCache.read()`, but a hit returns a payload fetched up to a TTL earlier, and the reconnect in between never invalidates the cache. The epoch is now captured *inside* the loader, which runs only on a miss.

**Round 3 — two P2s.**
- The `!preloadedDefs` rule was too blunt: when `graph_add_node` hits an unregistered type it fetches a whole map, and `registerComfyNodeDefs` cleared the snapshot then declined to re-record it — so an add that registers a new type ended with **no snapshot**, reproducing the original refusal. The resolver now files its own payload, gated on `freshDefsAreSingleClass`.
- The HTTP status was read twice; a getter-backed response can answer differently each read, so 504 could classify as silence while 502 was reported.

## Storage is type NAMES, not the schema

Copying the key names is both the detachment and the whole of what this needs — the fence asks "does the backend define this type". It also keeps a ~5.4MB schema from being pinned for the life of a connection, and it means the values cannot supply stale combo lists to anything downstream. The map is null-prototype so a type named `__proto__` cannot reach `Object.prototype`.

## Disclosure

A write authorized this way returns `schema_source: "last-observed"` and a `schema_note`. On **its own fields, never `warning`** — that channel is single-slot and priority-ordered, so appending there would displace a warning about what the write actually *does*.

## What this does not close

Conditions 2 and 3 rest on the tab *noticing* the socket went away. A half-open TCP connection to an already-dead process does not report itself. Exploiting it needs the restart **and** a pack removal across it **and** a write to that exact type inside the window. An **install** is harmless (a type missing from the snapshot is still refused); only a **removal** can authorize something it should not. This widens the race `object-info-cache.js` already documents for its own 1.5s window rather than opening a new class of hole, and it is written into the module header.

## Verification

- **4363 unit tests pass** (44 new).
- **34 mutations applied, 32 killed.** The two survivors are equivalent mutants, documented in the source: one writes a provably-equal value, the other is defence-in-depth over a check `record` already performs.
- Mutation found two weak tests of mine. A source regex asserted `/objectInfoSnapshot\.record\(defs, \{/` — which `if (false) record(...)` still matches, so disabling the startup snapshot (the defect that made v1 inert) left it green. And a fixed-width slice from the `reconnecting` handler ran into `status`, which also clears. Both replaced with tests that execute the shipped code.
- The shipped `getFreshObjectInfo` and `seedObjectInfoHistory` bodies are extracted from the panel and driven directly, so the reporter's scenario runs the production path.
- The `node-def-refresh.test.mjs` diff is 17 lines. It was 1990 — that file is mixed CRLF/LF on `main` with no `.gitattributes`, so any editor normalises it and buries the real change; the additions were made as byte-preserving splices instead.