### PR TITLE
fix(1582): an unserializable graph refuses with a reason, not a TypeError

### DIFF
--- a/browser_tests/unit/graph-to-prompt-failure.test.mjs
+++ b/browser_tests/unit/graph-to-prompt-failure.test.mjs
@@ -1,0 +1,86 @@
+// #1582 — a full-graph run whose graph cannot be serialized fails with a bare TypeError.
+//
+// On a 317-node community workflow referencing packs that are not installed:
+//
+//   panel_run {}                      → "Cannot read properties of undefined (reading 'workflow')"
+//   panel_run { to_node_id: 2934 }    → "the prompt could not be fingerprinted (graphToPrompt
+//                                        failed) … Nothing was queued rather than risk a
+//                                        full-graph execution (#556)."
+//
+// Same root cause, two very different answers. The first names nothing, reads like an internal
+// panel crash, and gave the reporter no reason to suspect their graph — they only learned the
+// truth by chance, retrying with `to_node_id`.
+//
+// The TypeError itself comes from ComfyUI's own `queuePrompt`, which dereferences `.workflow`
+// on the `graphToPrompt()` result. Our pre-flight runs first and lets it through:
+// `unrunnableNodeIds(undefined)` answers `[]` — no offenders — because a result that does not
+// exist has no unrunnable entries in it. Absence of evidence, read as evidence of absence.
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  unrunnableNodeIds,
+  graphToPromptUnusable,
+  unserializableGraphRefusal,
+} from "../../web/js/lib/missing-node-preflight.js";
+
+test("#1582 unrunnableNodeIds cannot speak for a result that does not exist", () => {
+  // Not a defect in this function — it is answering a different question. Pinned so the
+  // reason the pre-flight needs a SEPARATE check stays visible.
+  assert.deepEqual(unrunnableNodeIds(undefined), []);
+  assert.deepEqual(unrunnableNodeIds(null), []);
+});
+
+test("#1582 an absent or malformed graphToPrompt result is recognised", () => {
+  for (const bad of [undefined, null, {}, { output: undefined }, { output: null }, "nope", 7]) {
+    assert.equal(graphToPromptUnusable(bad), true, JSON.stringify(bad) ?? String(bad));
+  }
+});
+
+test("#1582 a USABLE result is not flagged", () => {
+  // The direction that would break every run: a healthy prompt must sail through. An empty
+  // output object is legitimate (an empty graph), and is not this failure.
+  for (const ok of [
+    { output: { 1: { class_type: "KSampler", inputs: {} } }, workflow: {} },
+    { output: {}, workflow: {} },
+  ]) {
+    assert.equal(graphToPromptUnusable(ok), false, JSON.stringify(ok));
+  }
+});
+
+test("#1582 the refusal says WHAT failed and that nothing was queued", () => {
+  const msg = unserializableGraphRefusal([]);
+  // The two things the bare TypeError did not say.
+  assert.match(msg, /graphToPrompt/);
+  assert.match(msg, /nothing was queued|not queued/i);
+  // And it must not read as a panel crash, which is what sent the reporter looking in the
+  // wrong place.
+  assert.doesNotMatch(msg, /Cannot read properties/);
+});
+
+test("#1582 the refusal NAMES the node types the frontend could not resolve", () => {
+  // The reporter's item 2. "Serialization failed" still leaves them guessing which of the
+  // 317 nodes is at fault; the panel already knows the unresolved types.
+  const msg = unserializableGraphRefusal(["LCKreaSampler", "Florence2Run", "SAM_SmartInpainter"]);
+  assert.match(msg, /LCKreaSampler/);
+  assert.match(msg, /Florence2Run/);
+  assert.match(msg, /SAM_SmartInpainter/);
+});
+
+test("#1582 with no types identified it still refuses, without inventing a cause", () => {
+  // Serialization can fail for reasons other than a missing pack. Naming one anyway would
+  // send the user to install something they already have.
+  const msg = unserializableGraphRefusal([]);
+  assert.doesNotMatch(msg, /missing (custom )?node|install the/i);
+  assert.match(msg, /graphToPrompt/);
+});
+
+test("#1582 a long type list is bounded", () => {
+  // The reported graph has ~35 LC* nodes alone. An unbounded list buries the instruction
+  // underneath it.
+  const many = Array.from({ length: 60 }, (_, i) => `LCNode${i}`);
+  const msg = unserializableGraphRefusal(many);
+  assert.ok(msg.length < 1200, `refusal must stay readable, was ${msg.length} chars`);
+  assert.match(msg, /LCNode0/);
+  assert.match(msg, /more|…|\.\.\./);
+});

--- a/browser_tests/unit/graph-to-prompt-failure.test.mjs
+++ b/browser_tests/unit/graph-to-prompt-failure.test.mjs
@@ -22,6 +22,7 @@ import {
   unrunnableNodeIds,
   graphToPromptUnusable,
   unserializableGraphRefusal,
+  unresolvedNodeTypes,
 } from "../../web/js/lib/missing-node-preflight.js";
 
 test("#1582 unrunnableNodeIds cannot speak for a result that does not exist", () => {
@@ -139,6 +140,12 @@ async function buildPreflight({ graphToPrompt, nodes = [], registry = {} }) {
     "missingNodeRunRefusal",
     "graphToPromptUnusable",
     "unserializableGraphRefusal",
+    // #1582 review: the block became ROOT-scoped, so the harness has to supply the root
+    // graph and the walker. Not injecting them made the extracted body throw a
+    // ReferenceError that the pre-flight catch swallows — which is exactly the silent
+    // failure this file exists to stop, one layer down.
+    "rootGraph",
+    "unresolvedNodeTypes",
     `return async function preflight() {\n${body}\n};`,
   );
   return factory(
@@ -150,6 +157,8 @@ async function buildPreflight({ graphToPrompt, nodes = [], registry = {} }) {
     mod.missingNodeRunRefusal,
     mod.graphToPromptUnusable,
     mod.unserializableGraphRefusal,
+    { _nodes: nodes },
+    mod.unresolvedNodeTypes,
   );
 }
 
@@ -208,4 +217,119 @@ test("#1582 BEHAVIOUR: the #1460 unrunnable-node refusal still fires", async () 
   assert.match(msg, /^NOT queued:/);
   assert.match(msg, /cannot be executed by the server/);
   assert.match(msg, /GoneNode/);
+});
+
+// ── ROOT SCOPE (review, P1). graphToPrompt serializes the WHOLE workflow, so naming
+//    offenders from the currently VIEWED graph misses a missing pack inside a subgraph —
+//    or at the root while the user is inside one. The first extraction test modelled a
+//    single flat graph and passed despite exactly that scope bug.
+
+test("#1582 unresolved types are collected from NESTED subgraphs", () => {
+  const root = {
+    _nodes: [
+      { id: 1, type: "KSampler" },
+      { id: 2, type: "SubgraphNode", subgraph: { _nodes: [{ id: 3, type: "LCKreaSampler" }] } },
+    ],
+  };
+  const types = unresolvedNodeTypes(root, { KSampler: {}, SubgraphNode: {} });
+  assert.deepEqual(types, ["LCKreaSampler"]);
+});
+
+test("#1582 …and from a subgraph nested inside a subgraph", () => {
+  const root = {
+    _nodes: [
+      {
+        id: 1,
+        type: "SubgraphNode",
+        subgraph: {
+          _nodes: [
+            { id: 2, type: "SubgraphNode", subgraph: { _nodes: [{ id: 3, type: "DeepMissing" }] } },
+          ],
+        },
+      },
+    ],
+  };
+  assert.deepEqual(unresolvedNodeTypes(root, { SubgraphNode: {} }), ["DeepMissing"]);
+});
+
+test("#1582 a CYCLE cannot spin the walk", () => {
+  // A subgraph referencing an ancestor must terminate. Without the seen-set this hangs the
+  // panel at the exact moment it is trying to explain a failure.
+  const root = { _nodes: [{ id: 1, type: "Missing1" }] };
+  root._nodes.push({ id: 2, type: "SubgraphNode", subgraph: root });
+  const types = unresolvedNodeTypes(root, { SubgraphNode: {} });
+  assert.deepEqual(types, ["Missing1"]);
+});
+
+test("#1582 duplicates across subgraphs are reported once", () => {
+  const root = {
+    _nodes: [
+      { id: 1, type: "LCKreaSampler" },
+      { id: 2, type: "SubgraphNode", subgraph: { _nodes: [{ id: 3, type: "LCKreaSampler" }] } },
+    ],
+  };
+  assert.deepEqual(unresolvedNodeTypes(root, { SubgraphNode: {} }), ["LCKreaSampler"]);
+});
+
+test("#1582 a fully-registered workflow yields nothing", () => {
+  const root = {
+    _nodes: [
+      { id: 1, type: "KSampler" },
+      { id: 2, type: "SubgraphNode", subgraph: { _nodes: [{ id: 3, type: "CLIPTextEncode" }] } },
+    ],
+  };
+  assert.deepEqual(unresolvedNodeTypes(root, { KSampler: {}, SubgraphNode: {}, CLIPTextEncode: {} }), []);
+});
+
+test("#1582 junk graphs answer nothing rather than throwing", () => {
+  // This runs while composing a failure message. Throwing here would replace a useful
+  // refusal with a second, unrelated error.
+  for (const junk of [null, undefined, 42, "graph", {}, { _nodes: null }, { _nodes: [null, 7] }]) {
+    assert.deepEqual(unresolvedNodeTypes(junk, {}), [], String(junk));
+  }
+});
+
+test("#1582 BEHAVIOUR: the refusal names a type from a SUBGRAPH", async () => {
+  const preflight = await buildPreflight({
+    graphToPrompt: async () => undefined,
+    nodes: [
+      { id: 1, type: "KSampler" },
+      { id: 2, type: "SubgraphNode", subgraph: { _nodes: [{ id: 3, type: "LCKreaSampler" }] } },
+    ],
+    registry: { KSampler: {}, SubgraphNode: {} },
+  });
+  // The pre-flight reads rootGraph; buildPreflight wires graph as both, so nest there.
+  const msg = await (async () => {
+    try {
+      await preflight();
+      return "__NO_REFUSAL__";
+    } catch (err) {
+      return err instanceof Error ? err.message : String(err);
+    }
+  })();
+  assert.match(msg, /^NOT queued:/);
+  assert.match(msg, /LCKreaSampler/, "a type that only exists inside a subgraph must be named");
+});
+
+test("#1582 a cycle is visited ONCE, not re-walked to the depth cap", () => {
+  // Termination alone is not the property. The depth cap already guarantees that, so a
+  // missing seen-set does not hang — it re-walks the cycle at every level, which for a wide
+  // graph is combinatorial work while the panel is trying to explain a failure.
+  //
+  // Counted rather than timed: `_nodes` is a getter, so the number of reads IS the number
+  // of visits, and the assertion cannot flake on a slow machine.
+  let reads = 0;
+  const root = {
+    get _nodes() {
+      reads += 1;
+      return nodes;
+    },
+  };
+  const nodes = [
+    { id: 1, type: "Missing1" },
+    { id: 2, type: "SubgraphNode", subgraph: root },
+  ];
+  const types = unresolvedNodeTypes(root, { SubgraphNode: {} });
+  assert.deepEqual(types, ["Missing1"]);
+  assert.equal(reads, 1, `the cyclic graph must be walked once, was walked ${reads} times`);
 });

--- a/browser_tests/unit/graph-to-prompt-failure.test.mjs
+++ b/browser_tests/unit/graph-to-prompt-failure.test.mjs
@@ -84,3 +84,128 @@ test("#1582 a long type list is bounded", () => {
   assert.match(msg, /LCNode0/);
   assert.match(msg, /more|…|\.\.\./);
 });
+
+// ── WIRING. The helpers are useless if the run path never consults them, and the guard is
+//    a few lines inside a 30k-line file that a refactor could drop with every unit test
+//    still green.
+
+test("#1582 the run path guards graphToPrompt BEFORE reading offenders", async () => {
+  const { readFileSync } = await import("node:fs");
+  const src = readFileSync(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf-8");
+  const at = src.indexOf("const built = await app.graphToPrompt();");
+  assert.ok(at > 0, "the pre-flight's graphToPrompt call must still be recognisable");
+  const block = src.slice(at, at + 1800);
+  const guard = block.indexOf("graphToPromptUnusable(built)");
+  const offenders = block.indexOf("unrunnableNodeIds(built)");
+  assert.ok(guard > -1, "the unusable-result guard must exist");
+  assert.ok(offenders > -1, "the offender check must still exist");
+  // ORDER is the fix. Asking for offenders first answers `[]` for an absent result and
+  // lets it through to queuePrompt, which is the reported TypeError.
+  assert.ok(guard < offenders, "the guard must run BEFORE the offender check");
+  assert.match(block, /unserializableGraphRefusal\(/);
+});
+
+test("#1582 the refusal keeps the prefix its own catch requires", async () => {
+  // The pre-flight is wrapped in a try whose catch re-throws ONLY /^NOT queued:/ — anything
+  // else is swallowed so a broken pre-flight cannot become a new failure mode. A refusal
+  // without that prefix would be silently discarded and the run would proceed into the
+  // TypeError, with every helper test still passing.
+  assert.match(unserializableGraphRefusal([]), /^NOT queued:/);
+  assert.match(unserializableGraphRefusal(["LCKreaSampler"]), /^NOT queued:/);
+});
+
+// ── BEHAVIOUR, from the REAL source. The wiring tests above pin that the guard exists and
+//    runs first; they cannot see whether it actually refuses. Extracting the pre-flight
+//    block and driving it against stubs proves the reported call now fails with a reason —
+//    the same real-source extraction pattern manager-dialect.test.mjs uses.
+
+/** Pull the pre-flight try/catch out of the monolith and run it with injected deps. */
+async function buildPreflight({ graphToPrompt, nodes = [], registry = {} }) {
+  const { readFileSync } = await import("node:fs");
+  const src = readFileSync(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf-8");
+  const marker = src.indexOf("      // Inspect the SERIALIZED prompt");
+  assert.ok(marker > 0, "the pre-flight comment must still be recognisable");
+  const start = src.lastIndexOf("try {", marker);
+  const endMark = src.indexOf("if (err instanceof Error && /^NOT queued:/.test(err.message)) throw err;", start);
+  assert.ok(endMark > start, "the pre-flight catch must still be recognisable");
+  const body = src.slice(start, src.indexOf("\n", endMark)) + "\n    }";
+  const mod = await import("../../web/js/lib/missing-node-preflight.js");
+  const factory = new Function(
+    "app",
+    "graph",
+    "LG",
+    "unrunnableNodeIds",
+    "describeUnrunnable",
+    "missingNodeRunRefusal",
+    "graphToPromptUnusable",
+    "unserializableGraphRefusal",
+    `return async function preflight() {\n${body}\n};`,
+  );
+  return factory(
+    { graphToPrompt },
+    { _nodes: nodes },
+    { registered_node_types: registry },
+    mod.unrunnableNodeIds,
+    mod.describeUnrunnable,
+    mod.missingNodeRunRefusal,
+    mod.graphToPromptUnusable,
+    mod.unserializableGraphRefusal,
+  );
+}
+
+const runPreflight = async (opts) => {
+  const preflight = await buildPreflight(opts);
+  try {
+    await preflight();
+    return "__NO_REFUSAL__";
+  } catch (err) {
+    return err instanceof Error ? err.message : String(err);
+  }
+};
+
+test("#1582 BEHAVIOUR: an undefined graphToPrompt result refuses, naming the packs", async () => {
+  // The reported call, end to end through the real pre-flight source.
+  const msg = await runPreflight({
+    graphToPrompt: async () => undefined,
+    nodes: [
+      { id: 1, type: "KSampler" },
+      { id: 2, type: "LCKreaSampler" },
+      { id: 3, type: "Florence2Run" },
+    ],
+    registry: { KSampler: {} },
+  });
+  assert.notEqual(msg, "__NO_REFUSAL__", "an unserializable graph must not reach queuePrompt");
+  assert.match(msg, /^NOT queued:/);
+  assert.match(msg, /graphToPrompt/);
+  assert.match(msg, /LCKreaSampler/);
+  assert.match(msg, /Florence2Run/);
+  // Only the UNREGISTERED ones. Naming a type the frontend has would send the user to
+  // reinstall something that is already working.
+  assert.doesNotMatch(msg, /KSampler\b(?!.*could not)/);
+});
+
+test("#1582 BEHAVIOUR: a healthy prompt passes the pre-flight untouched", async () => {
+  const msg = await runPreflight({
+    graphToPrompt: async () => ({
+      output: { 1: { class_type: "KSampler", inputs: {} } },
+      workflow: {},
+    }),
+    nodes: [{ id: 1, type: "KSampler" }],
+    registry: { KSampler: {} },
+  });
+  assert.equal(msg, "__NO_REFUSAL__", "a runnable graph must not be refused");
+});
+
+test("#1582 BEHAVIOUR: the #1460 unrunnable-node refusal still fires", async () => {
+  // The check this guard was inserted above. It must keep working — a serialized prompt
+  // that EXISTS but carries a node with no class_type is a different failure with its own
+  // (more specific) message.
+  const msg = await runPreflight({
+    graphToPrompt: async () => ({ output: { 7: { inputs: {} } }, workflow: {} }),
+    nodes: [{ id: 7, type: "GoneNode" }],
+    registry: {},
+  });
+  assert.match(msg, /^NOT queued:/);
+  assert.match(msg, /cannot be executed by the server/);
+  assert.match(msg, /GoneNode/);
+});

--- a/browser_tests/unit/graph-to-prompt-failure.test.mjs
+++ b/browser_tests/unit/graph-to-prompt-failure.test.mjs
@@ -95,7 +95,13 @@ test("#1582 the run path guards graphToPrompt BEFORE reading offenders", async (
   const src = readFileSync(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf-8");
   const at = src.indexOf("const built = await app.graphToPrompt();");
   assert.ok(at > 0, "the pre-flight's graphToPrompt call must still be recognisable");
-  const block = src.slice(at, at + 1800);
+  // Bounded by the pre-flight's OWN catch, not a byte count. A fixed 1800 truncated
+  // `unrunnableNodeIds(built)` the moment the guard's comment grew — which is the third
+  // time today a fixed window in this repo reported missing wiring that was present
+  // (#1472, #1460, here). The block ends where its catch begins; say that instead.
+  const endOfTry = src.indexOf("} catch (err) {", at);
+  assert.ok(endOfTry > at, "the pre-flight try block must still be recognisable");
+  const block = src.slice(at, endOfTry);
   const guard = block.indexOf("graphToPromptUnusable(built)");
   const offenders = block.indexOf("unrunnableNodeIds(built)");
   assert.ok(guard > -1, "the unusable-result guard must exist");
@@ -121,7 +127,7 @@ test("#1582 the refusal keeps the prefix its own catch requires", async () => {
 //    the same real-source extraction pattern manager-dialect.test.mjs uses.
 
 /** Pull the pre-flight try/catch out of the monolith and run it with injected deps. */
-async function buildPreflight({ graphToPrompt, nodes = [], registry = {} }) {
+async function buildPreflight({ graphToPrompt, nodes = [], viewedNodes, registry = {} }) {
   const { readFileSync } = await import("node:fs");
   const src = readFileSync(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf-8");
   const marker = src.indexOf("      // Inspect the SERIALIZED prompt");
@@ -146,11 +152,20 @@ async function buildPreflight({ graphToPrompt, nodes = [], registry = {} }) {
     // failure this file exists to stop, one layer down.
     "rootGraph",
     "unresolvedNodeTypes",
+    // The block reads LiteGraph off `window` (`LG` is a local in other functions and is
+    // NOT in scope there — the panel-scope gate caught that). Node has no `window`, so
+    // without this the extracted body throws a ReferenceError that the pre-flight catch
+    // swallows, and the test sees no refusal at all.
+    "window",
     `return async function preflight() {\n${body}\n};`,
   );
+  // The VIEWED graph is deliberately a DIFFERENT object from the root when the caller
+  // supplies one: the pre-flight must read the ROOT (serialization is root-scoped), and a
+  // harness that passes the same object for both cannot tell the two apart — a mutation
+  // swapping rootGraph for graph survived exactly that way.
   return factory(
     { graphToPrompt },
-    { _nodes: nodes },
+    { _nodes: viewedNodes ?? nodes },
     { registered_node_types: registry },
     mod.unrunnableNodeIds,
     mod.describeUnrunnable,
@@ -159,6 +174,7 @@ async function buildPreflight({ graphToPrompt, nodes = [], registry = {} }) {
     mod.unserializableGraphRefusal,
     { _nodes: nodes },
     mod.unresolvedNodeTypes,
+    { LiteGraph: { registered_node_types: registry } },
   );
 }
 
@@ -332,4 +348,21 @@ test("#1582 a cycle is visited ONCE, not re-walked to the depth cap", () => {
   const types = unresolvedNodeTypes(root, { SubgraphNode: {} });
   assert.deepEqual(types, ["Missing1"]);
   assert.equal(reads, 1, `the cyclic graph must be walked once, was walked ${reads} times`);
+});
+
+test("#1582 BEHAVIOUR: the scan reads the ROOT graph, not the one on screen", async () => {
+  // The user is inside a subgraph, so the viewed graph holds nothing interesting. The
+  // missing pack is at the root — and serialization is root-scoped, so it is what broke.
+  const preflight = await buildPreflight({
+    graphToPrompt: async () => undefined,
+    nodes: [{ id: 1, type: "LCKreaSampler" }], // root
+    viewedNodes: [{ id: 9, type: "KSampler" }], // what is on screen
+    registry: { KSampler: {} },
+  });
+  const msg = await preflight().then(
+    () => "__NO_REFUSAL__",
+    (e) => (e instanceof Error ? e.message : String(e)),
+  );
+  assert.match(msg, /^NOT queued:/);
+  assert.match(msg, /LCKreaSampler/, "a root-level missing type must be named while viewing a subgraph");
 });

--- a/browser_tests/unit/missing-node-preflight.test.mjs
+++ b/browser_tests/unit/missing-node-preflight.test.mjs
@@ -122,7 +122,13 @@ test("#1460 WIRING: the preflight reads the SERIALIZED prompt, not the canvas", 
   assert.match(src, /import \{[\s\S]*?unrunnableNodeIds,[\s\S]*?\} from "\.\/lib\/missing-node-preflight\.js";/);
   const at = src.indexOf("const built = await app.graphToPrompt();");
   assert.ok(at > 0, "the preflight must serialize the prompt itself");
-  const block = src.slice(at, at + 600);
+  // Bounded by the pre-flight's OWN catch rather than a byte count. A fixed 600 excluded
+  // `unrunnableNodeIds(built)` as soon as #1582 added a guard above it — reporting missing
+  // wiring while the wiring was fine. The window exists to keep this assertion scoped to
+  // the pre-flight block, and that block ends at its catch.
+  const endOfTry = src.indexOf("} catch (err) {", at);
+  assert.ok(endOfTry > at, "the pre-flight's try block must still be recognisable");
+  const block = src.slice(at, endOfTry);
   assert.match(block, /unrunnableNodeIds\(built\)/);
   // The refuted approach must be gone entirely.
   assert.equal((src.match(/findUnregisteredTypes/g) ?? []).length, 0);

--- a/scripts/check-panel-scope.mjs
+++ b/scripts/check-panel-scope.mjs
@@ -35,6 +35,7 @@
  * is not a typing gate and untyped JS stays untyped.
  */
 import { execFileSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
 import path from 'node:path';
 
 const ROOT = path.resolve(import.meta.dirname, '..');
@@ -52,12 +53,38 @@ const IGNORED_PATH = /[\\/]vendor[\\/]/;
 
 const ENTRIES = ['web/js/comfyui-mcp-panel.js'];
 
+/**
+ * The checker must be RUNNABLE, and its absence must be loud.
+ *
+ * This gate lived on a `catch` that harvests tsc's diagnostics — because tsc exits non-zero
+ * whenever it emits any, which for this file is always. A tsc that could not START lands in
+ * the same catch with empty stdout, produces zero findings, and prints OK. So in any
+ * checkout without `node_modules/typescript` — a fresh git worktree, most obviously — the
+ * gate reported "every name resolves" while checking nothing.
+ *
+ * Found by probing it with a name I knew was undefined: it passed. CI, which has the
+ * dependency, was failing on a real ReferenceError (`LG`, comfyui-mcp#1582) at the same
+ * time the local run said OK.
+ */
+const TSC = path.join(ROOT, 'node_modules', 'typescript', 'bin', 'tsc');
+if (!existsSync(TSC)) {
+  console.error(
+    `[check-panel-scope] CANNOT RUN — TypeScript is not installed at ${TSC}.\n\n` +
+      'This gate is the only thing that catches a name resolving in a sibling function ' +
+      'instead of this one, which throws ReferenceError the moment that line runs. It ' +
+      'used to print OK in this situation, which is worse than not running at all. ' +
+      'Run `npm install` here (a fresh git worktree does not inherit node_modules).',
+  );
+  process.exit(2);
+}
+
 let raw = '';
+let ran = false;
 try {
   execFileSync(
     process.execPath,
     [
-      path.join(ROOT, 'node_modules', 'typescript', 'bin', 'tsc'),
+      TSC,
       '--noEmit', '--allowJs', '--checkJs',
       '--target', 'ES2022', '--module', 'ES2022', '--moduleResolution', 'bundler',
       '--lib', 'ES2022,DOM,DOM.Iterable',
@@ -66,10 +93,25 @@ try {
     ],
     { cwd: ROOT, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] },
   );
+  ran = true;
 } catch (e) {
   // tsc exits non-zero whenever it emits ANY diagnostic, and this file is full of ordinary
   // untyped-JS complaints. A non-zero exit is expected; the diagnostics are the payload.
   raw = `${e.stdout ?? ''}${e.stderr ?? ''}`;
+  // …but a tsc that never STARTED (ENOENT, EACCES, a corrupt install) lands in this same
+  // catch with nothing to parse. Zero output is not zero findings.
+  if (!raw.trim()) {
+    console.error(
+      `[check-panel-scope] CANNOT RUN — tsc produced no output (${e.code ?? e.message}). ` +
+        'Refusing to report a pass for a check that did not run.',
+    );
+    process.exit(2);
+  }
+  ran = true;
+}
+if (!ran) {
+  console.error('[check-panel-scope] CANNOT RUN — the checker did not execute.');
+  process.exit(2);
 }
 
 const findings = [];

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -275,6 +275,7 @@ import {
   missingNodeRunRefusal,
   graphToPromptUnusable,
   unserializableGraphRefusal,
+  unresolvedNodeTypes,
 } from "./lib/missing-node-preflight.js";
 import {
   classifyWorkflowRefresh,
@@ -12480,20 +12481,16 @@ const GRAPH_TOOL_EXECUTORS = {
       // their graph. The run-to-node path has always refused this properly (#556); the
       // full-graph path did not.
       if (graphToPromptUnusable(built)) {
-        const liveNodes = Array.isArray(graph?._nodes) ? graph._nodes : [];
-        const registry = LG?.registered_node_types ?? {};
-        // Name what the FRONTEND could not resolve. Types only, from the canvas, because
-        // the serialized prompt is what failed to exist — and only unregistered ones, so
-        // a graph that failed to serialize for some other reason reports no cause rather
-        // than a wrong one.
-        const unresolved = [
-          ...new Set(
-            liveNodes
-              .map((n) => (typeof n?.type === "string" ? n.type : null))
-              .filter((t) => t && !Object.prototype.hasOwnProperty.call(registry, t)),
+        // Name what the FRONTEND could not resolve, from the ROOT graph — serialization is
+        // root-scoped, so scanning the currently VIEWED graph would miss a missing pack that
+        // lives in a subgraph, or lives at the root while the user is inside one (review).
+        // Types only, and only unregistered ones: a graph that failed to serialize for some
+        // other reason reports no cause rather than a wrong one.
+        throw new Error(
+          unserializableGraphRefusal(
+            unresolvedNodeTypes(rootGraph ?? graph, LG?.registered_node_types ?? {}),
           ),
-        ];
-        throw new Error(unserializableGraphRefusal(unresolved));
+        );
       }
       const badIds = unrunnableNodeIds(built);
       if (badIds.length) {

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -273,6 +273,8 @@ import {
   unrunnableNodeIds,
   describeUnrunnable,
   missingNodeRunRefusal,
+  graphToPromptUnusable,
+  unserializableGraphRefusal,
 } from "./lib/missing-node-preflight.js";
 import {
   classifyWorkflowRefresh,
@@ -12468,6 +12470,31 @@ const GRAPH_TOOL_EXECUTORS = {
       // None of that applies here: no network, no cap, and the bytes inspected are
       // the bytes that would have been POSTed.
       const built = await app.graphToPrompt();
+      // comfyui-mcp#1582 — SERIALIZATION ITSELF CAN FAIL, and this is where that has to
+      // be caught. `unrunnableNodeIds(undefined)` answers `[]` — correctly, since a
+      // result that does not exist has no unrunnable entries in it — and the check below
+      // reads `[]` as "the graph is fine". The undefined then reaches ComfyUI's own
+      // queuePrompt, which dereferences `.workflow` on it, and the caller gets
+      // "Cannot read properties of undefined (reading 'workflow')": a message that names
+      // nothing, reads like a panel crash, and gave the reporter no reason to suspect
+      // their graph. The run-to-node path has always refused this properly (#556); the
+      // full-graph path did not.
+      if (graphToPromptUnusable(built)) {
+        const liveNodes = Array.isArray(graph?._nodes) ? graph._nodes : [];
+        const registry = LG?.registered_node_types ?? {};
+        // Name what the FRONTEND could not resolve. Types only, from the canvas, because
+        // the serialized prompt is what failed to exist — and only unregistered ones, so
+        // a graph that failed to serialize for some other reason reports no cause rather
+        // than a wrong one.
+        const unresolved = [
+          ...new Set(
+            liveNodes
+              .map((n) => (typeof n?.type === "string" ? n.type : null))
+              .filter((t) => t && !Object.prototype.hasOwnProperty.call(registry, t)),
+          ),
+        ];
+        throw new Error(unserializableGraphRefusal(unresolved));
+      }
       const badIds = unrunnableNodeIds(built);
       if (badIds.length) {
         const liveNodes = Array.isArray(graph?._nodes) ? graph._nodes : [];

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -12488,7 +12488,13 @@ const GRAPH_TOOL_EXECUTORS = {
         // other reason reports no cause rather than a wrong one.
         throw new Error(
           unserializableGraphRefusal(
-            unresolvedNodeTypes(rootGraph ?? graph, LG?.registered_node_types ?? {}),
+            // `LG` is a local in other functions, NOT in scope here — the panel-scope gate
+            // caught it as a live ReferenceError on CI. Read LiteGraph the same way those
+            // locals are initialised.
+            unresolvedNodeTypes(
+              rootGraph ?? graph,
+              (window.LiteGraph ?? globalThis.LiteGraph)?.registered_node_types ?? {},
+            ),
           ),
         );
       }

--- a/web/js/lib/missing-node-preflight.js
+++ b/web/js/lib/missing-node-preflight.js
@@ -57,6 +57,58 @@ export function unrunnableNodeIds(prompt) {
 }
 
 /**
+ * #1582 — did `graphToPrompt()` fail to produce anything we can reason about?
+ *
+ * A DIFFERENT question from `unrunnableNodeIds`, and the whole defect is that the two were
+ * conflated. That one asks "which entries in this prompt are unrunnable?" and answers `[]`
+ * for a result that does not exist — correctly, because a thing that is not there has no
+ * unrunnable entries. The pre-flight then read `[]` as "the graph is fine" and handed an
+ * undefined result to ComfyUI's `queuePrompt`, which dereferences `.workflow` on it and
+ * throws `Cannot read properties of undefined (reading 'workflow')`.
+ *
+ * Absence of evidence, read as evidence of absence.
+ *
+ * A usable result must carry an `output` OBJECT. An empty one is fine — an empty graph
+ * serializes to no nodes and is not this failure.
+ */
+export function graphToPromptUnusable(built) {
+  if (!built || typeof built !== "object" || Array.isArray(built)) return true;
+  const output = built.output;
+  return !output || typeof output !== "object" || Array.isArray(output);
+}
+
+/**
+ * The refusal for a graph that could not be serialized at all.
+ *
+ * Mirrors what the run-to-node path has always said (#556) so the two paths stop giving
+ * wildly different answers to the same failure — the reporter learned the real cause only
+ * because they happened to retry with `to_node_id`.
+ *
+ * `types` is the node types the frontend could not resolve, when we know them. When we do
+ * NOT, this says so and stops: serialization can fail for reasons that have nothing to do
+ * with missing packs, and naming one anyway sends the user to install something they
+ * already have.
+ */
+export function unserializableGraphRefusal(types) {
+  const list = [...new Set((Array.isArray(types) ? types : []).filter((t) => typeof t === "string" && t))];
+  const shown = list.slice(0, 10);
+  const more = list.length > shown.length ? `, and ${list.length - shown.length} more` : "";
+  const cause = list.length
+    ? `The frontend could not resolve these node types, which is the usual cause: ` +
+      `${shown.join(", ")}${more}. Install the pack that provides them ` +
+      `(list_packs / install_custom_node) and restart ComfyUI so the frontend registers ` +
+      `them, or delete/bypass those nodes. `
+    : `The panel could not identify which nodes are responsible, so this does not ` +
+      `establish that a pack is missing — serialization can fail for other reasons. `;
+  return (
+    `NOT queued: this workflow could not be serialized into a prompt (graphToPrompt failed), ` +
+    `so there was nothing to send. ${cause}` +
+    `Nothing was queued and the queue is untouched. ` +
+    `panel_get_errors lists the node types this ComfyUI does not recognise.`
+  );
+}
+
+/**
  * Name the offending nodes using the live graph, which still knows their types.
  *
  * The serialized entry has lost the type — that is precisely why it is unrunnable — so

--- a/web/js/lib/missing-node-preflight.js
+++ b/web/js/lib/missing-node-preflight.js
@@ -78,6 +78,45 @@ export function graphToPromptUnusable(built) {
 }
 
 /**
+ * #1582 — every node type in the workflow the frontend cannot resolve, ROOT-SCOPED.
+ *
+ * Serialization is root-scoped: `graphToPrompt` walks the whole workflow, including every
+ * nested subgraph, whichever one the user happens to be looking at. Naming the offenders
+ * from the CURRENTLY VIEWED graph therefore misses them whenever the missing pack lives in
+ * a subgraph — or lives at the root while the user is inside one — leaving the generic
+ * refusal on exactly the large workflows this matters most for (review). The reported graph
+ * has 317 nodes.
+ *
+ * Bounded and cycle-safe: a `seen` set over graph objects, so a subgraph that references an
+ * ancestor cannot spin, and a depth cap in case something exotic slips past that.
+ */
+export function unresolvedNodeTypes(rootGraph, registry) {
+  const reg = registry && typeof registry === "object" ? registry : {};
+  const out = new Set();
+  const seen = new Set();
+  const walk = (g, depth) => {
+    if (!g || typeof g !== "object" || depth > 12 || seen.has(g)) return;
+    seen.add(g);
+    // Read each accessor ONCE. `_nodes` can be a getter, and testing it with isArray and
+    // then reading it again invokes that getter twice — harmless here, but it makes "how
+    // many times was this graph visited?" unanswerable, which is the property the cycle
+    // guard is judged on.
+    const own = g._nodes;
+    const alt = own === undefined ? g.nodes : undefined;
+    const nodes = Array.isArray(own) ? own : Array.isArray(alt) ? alt : [];
+    for (const n of nodes) {
+      const type = typeof n?.type === "string" ? n.type : null;
+      if (type && !Object.prototype.hasOwnProperty.call(reg, type)) out.add(type);
+      // A SubgraphNode carries its definition; both shapes appear across frontend versions.
+      walk(n?.subgraph, depth + 1);
+    }
+    for (const sub of Array.isArray(g.subgraphs) ? g.subgraphs : []) walk(sub, depth + 1);
+  };
+  walk(rootGraph, 0);
+  return [...out];
+}
+
+/**
  * The refusal for a graph that could not be serialized at all.
  *
  * Mirrors what the run-to-node path has always said (#556) so the two paths stop giving


### PR DESCRIPTION
Addresses artokun/comfyui-mcp#1582.

## The bug

```
panel_run {}                    → Cannot read properties of undefined (reading 'workflow')
panel_run { to_node_id: 2934 }  → the prompt could not be fingerprinted (graphToPrompt failed),
                                  … Nothing was queued rather than risk a full-graph execution.
```

Same graph, same root cause, two very different answers. The first names nothing and reads
like a panel crash; the reporter only learned the truth by chance, retrying the other way.

The `TypeError` is **not ours** — it comes from ComfyUI's own `queuePrompt`, which
dereferences `.workflow` on the `graphToPrompt()` result. But we call `queuePrompt`, and the
pre-flight immediately before it was in a position to catch this:

```js
const built = await app.graphToPrompt();
const badIds = unrunnableNodeIds(built);   // → [] when `built` is undefined
```

`unrunnableNodeIds(undefined)` answering `[]` is not a bug in it — it answers a different
question. The bug is the pre-flight reading "no offenders" as "the graph is fine", so a
result that does not exist looks identical to a clean one. **Absence of evidence read as
evidence of absence**, then straight into the dereference.

## The fix

`graphToPromptUnusable()` asks the missing question first, and the refusal mirrors what the
run-to-node path has always said (#556) — naming the node types the frontend could not
resolve, so the message says *which* packs are missing rather than only that serialization
failed. Unregistered types only: a graph that failed for some other reason reports **no**
cause rather than a wrong one.

The `NOT queued:` prefix is load-bearing rather than decoration — the pre-flight's own catch
re-throws only that, so a refusal without it would be silently swallowed and the run would
proceed into the TypeError with every helper test still green. There is a test for the prefix
alone.

## What review changed

**P1 — the scan was viewed-graph scoped while serialization is root-scoped.** A missing pack
inside a subgraph, or at the root while the user is inside one, fell back to the generic
refusal — on exactly the large workflows where naming the packs matters most (the reported
graph has 317 nodes). `unresolvedNodeTypes()` now walks the root and every nested subgraph,
cycle-safe and depth-capped. Review also caught that my extraction test modelled **one flat
graph**, so it passed against the scope bug; it nests now.

## Verification

- **12 mutations, all applied and all killed**, including one that restores the viewed-graph
  scope, one that makes the guard unable to catch `undefined`, and one that drops the
  `NOT queued:` prefix.
- 4340 tests green.
- The pre-flight is **extracted from the real source** and driven against stubs, because two
  mutations survived the source-level wiring tests: a guard that cannot catch `undefined`, and
  dropping the unregistered filter. Both were invisible while nothing exercised the monolith's
  pre-flight behaviourally.
- The cycle-guard mutation survived at first too — the depth cap already terminates, so
  removing the seen-set does not hang, it re-walks combinatorially. The test counts **visits**
  through a getter rather than timing anything. Writing it exposed that the walk read `_nodes`
  twice per graph.

## Also repaired

#1460's own wiring test sliced a fixed 600 chars from the `graphToPrompt` call, so inserting a
guard above the offender check pushed it out of the window — reporting missing wiring while
the wiring was fine. Bounded by the pre-flight's own catch instead. Same defect as the #1472
window earlier today; a fixed byte count around code that grows is a recurring trap here.

## Not in this PR

The reporter's **item 3** — promoting genuinely-absent backend types out of `unchecked_nodes`
into a real `missing_node_types` on `panel_get_errors`, excluding frontend-virtual types — is
a separate, larger change and deserves its own tests. Worth noting `unresolvedNodeTypes()`
gives it most of the machinery, and the orchestrator's `FRONTEND_ONLY_NODE_TYPES` union from
#1400 is the natural exclusion list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
