### PR TITLE
release: v0.14.39 — a busy backend no longer refuses a safe widget edit (#1223)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+## [0.14.39] - 2026-08-14
+
+### Fixed
+- a widget edit is no longer refused just because the /object_info probe went silent while ComfyUI was busy rendering — it is authorized from the last whole schema observed on the same backend connection, which a restart always invalidates (#1223)
+
 ## [0.14.38] - 2026-08-14
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-agent-panel"
 description = "Autonomous AI agent in the ComfyUI sidebar - local-first, bring any LLM. Run it on your Claude or ChatGPT subscription (no API keys, no extra LLM costs), on a Kimi K3 / GLM / OpenRouter key, or fully offline on free local models via Ollama, LM Studio, or llama.cpp. The agent drives your live canvas at full parity: add, wire, move and tweak nodes with Ctrl+Z undo, load whole workflows and installer packs in one shot, generate images, video and audio, browse CivitAI, and run your workflow - asking before it spends paid API credits. The sidebar UI for comfyui-mcp, the local-first, agent-native control plane for ComfyUI. The panel speaks 12 languages, matching your ComfyUI language automatically: English, 한국어, 日本語, 中文 (简体), 中文 (繁體), Русский, Français, Español, Português (BR), Türkçe, العربية, فارسی."
-version = "0.14.38"
+version = "0.14.39"
 license = { file = "LICENSE" }
 requires-python = ">=3.9"
 # UI-only pack: no Python deps. The frontend floor guarantees

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -1523,7 +1523,7 @@ const DOCS_URL = "https://comfyui-mcp.artokun.io/docs";
 // Panel version — surfaced in the "Need help?" diagnostics blob. Bump via
 // `node scripts/set-version.mjs <v>` (updates this AND pyproject together); CI
 // and the publish gate FAIL if the two ever drift, so this can't go stale.
-const PANEL_VERSION = "0.14.38";
+const PANEL_VERSION = "0.14.39";
 
 // The connected orchestrator's console URL/token (captured off the `backends`
 // bridge message — see onBackends). Drives the "API Keys" credentials frame;


### PR DESCRIPTION
Releases the #1223 fix merged in #1232.

## What users get

`panel_set_widget` refused a live edit on a node that was right there on the canvas, whenever both `/object_info` probes timed out:

```
cannot verify the node type against the ComfyUI backend — no usable /object_info
schema was obtained ... Refusing to write ... (#458)
```

ComfyUI serves HTTP from the same process that runs the graph, so a heavy step — a VAE decode, a model load — blocks the event loop and `/object_info` waits behind it. That is a **busy** backend, not an absent one, and it is the ordinary condition *during a render*, which is exactly when an agent is editing widgets.

The edit is now authorized from the last whole schema observed on the **current backend connection**. A ComfyUI process cannot change the set of types it serves without restarting, and a restart drops the tab's websocket — so that provenance is something the stale LiteGraph registry cannot forge, which is precisely why #458 refuses to trust the registry but can trust this.

Four fail-closed conditions, all required: a whole map whose observer vouched for it, the socket up, no reconnect since the schema was **fetched**, and probes that went **silent** rather than answering something unusable. Anything else keeps the old refusal.

## Verified in the browser, on this machine

Not just unit tests — the shipped module driven in Chrome against the live backend (**4492 node types**, ComfyUI 0.33.1 / frontend 1.48.7):

- records a real whole `/object_info` and authorizes a type from it
- stored values are detached (`{}`) — no schema shapes, so no stale combo lists can leak downstream
- refuses on socket-down, on a reconnect, and when the backend answered badly
- a proxy **502** is denied, a **504** is granted
- panel extension `comfyui-mcp.agent-panel` registers cleanly; no module-resolution errors in the console

The restart mattered: panel assets are registered at ComfyUI **startup**, so without one the browser keeps serving the old bundle and any "pass" is meaningless. I confirmed the served bundle contained the new code before trusting the result.

## Review history

Five Codex rounds, the first four of which found real defects:

1. **The fix did not fire at all** — the startup seed is the only whole read on a normal boot, and it was not recording. Plus three ways to reopen #458.
2. Two P1s: a **502 is not silence** (nginx emits it when it *cannot connect* — the process is gone), and a **cache hit is not evidence**.
3. Two P2s: a provably-whole preload was being dropped, and the HTTP status was read twice.
4. Two P2s: two other whole-schema readers dropped what they read, and `add_node` stamped its epoch before an optional probe.
5. Clean.

**4369 tests · 37 mutations, 35 killed** (2 documented equivalent mutants).