### PR TITLE
fix(813): a COLLAPSED group member is not a node that refused to move

### DIFF
--- a/browser_tests/unit/group-geometry.test.mjs
+++ b/browser_tests/unit/group-geometry.test.mjs
@@ -694,3 +694,102 @@ test("#813 the rect is still refreshed during a restore — the fix does not sto
   assert.deepEqual(n.pos, [100, 100], "restored");
   assert.ok(nodeAreaIsLive(n), "the cached rect must track the restore, not be left describing the moved position");
 });
+
+// ---------------------------------------------------------------------------
+// #813 — a COLLAPSED member is not a node that refused to move
+//
+// The reporter's group held four `size:[225,0]` collapsed nodes. Every one was
+// classified stuck AFTER its position had been written, and the same nodes moved
+// fine one-by-one with panel_move_node. The stuck verdict never came from the
+// position write; it came from comparing the cached rect against the panel's
+// COLLAPSED PILL model while the engine's own updateArea() had just written its
+// own extents back.
+// ---------------------------------------------------------------------------
+
+test("#813 a collapsed member whose engine updateArea() restores full extents still MOVES", () => {
+  // The reporter's node, on a build whose updateArea() authoritatively recomputes the rect
+  // the way this file already models it (see the #355 test above). The recompute uses
+  // size — [225, 0] — so the rect comes back as [x, y-30, 225, 30]... which happens to
+  // equal the pill here. Give it a _collapsed_width that DIFFERS from size[0], which is
+  // what a real collapsed node has, and the two models diverge exactly as reported.
+  const n = {
+    id: 24,
+    pos: [100, 100],
+    size: [225, 0],
+    flags: { collapsed: true },
+    _collapsed_width: 80,
+    boundingRect: [100, 70, 80, 30], // the pill, as the move's pre-flight left it
+    updateArea() {
+      // The engine knows nothing about the panel's pill: it recomputes from size.
+      this.boundingRect = [this.pos[0], this.pos[1] - 30, this.size[0], this.size[1] + 30];
+    },
+  };
+
+  const r = moveGroupMembers([n], 1400, -140);
+
+  assert.deepEqual(r.stuck, [], "a collapsed node with a writable rect is not stuck");
+  assert.deepEqual(r.moved, [n], "…it moved");
+  assert.deepEqual(n.pos, [1500, -40], "to the reporter's target");
+  assert.ok(nodeAreaIsLive(n), "and its cached rect is back on the panel's pill convention");
+});
+
+test("#813 the pill is forced, never the full box — #416 area overstatement stays closed", () => {
+  // The correction must write the COLLAPSED footprint. Writing the engine's full-box
+  // extents would make a collapsed node claim the area of its expanded self, and
+  // membership is rect-first, so it would capture neighbours it does not overlap.
+  const n = {
+    id: 25,
+    pos: [0, 0],
+    size: [225, 400],
+    flags: { collapsed: true },
+    _collapsed_width: 80,
+    boundingRect: [0, -30, 80, 30],
+    updateArea() {
+      this.boundingRect = [this.pos[0], this.pos[1] - 30, this.size[0], this.size[1] + 30];
+    },
+  };
+
+  moveGroupMembers([n], 10, 10);
+
+  assert.deepEqual(
+    [...n.boundingRect],
+    [10, -20, 80, 30],
+    "the collapsed pill (80x30), not the 225x430 box the engine recomputed",
+  );
+});
+
+test("#813 a rect that genuinely cannot be corrected is STILL stuck (#408 preserved)", () => {
+  // The load-bearing half. A frozen rect cannot be made to track the node, membership is
+  // rect-first, and leaving such a node "moved" would report it in a group it has left. The
+  // fix gives the rect one more chance to be corrected — it does not stop asking.
+  const n = {
+    id: 26,
+    pos: [100, 100],
+    size: [225, 0],
+    flags: { collapsed: true },
+    _collapsed_width: 80,
+    boundingRect: Object.freeze([100, 70, 80, 30]),
+  };
+
+  const r = moveGroupMembers([n], 50, 25);
+
+  assert.deepEqual(r.moved, [], "an uncorrectable rect still refuses");
+  assert.deepEqual(r.stuck, [n]);
+});
+
+test("#813 an EXPANDED member is unaffected — its two models already agree", () => {
+  const n = {
+    id: 27,
+    pos: [100, 100],
+    size: [200, 100],
+    boundingRect: [100, 70, 200, 130],
+    updateArea() {
+      this.boundingRect = [this.pos[0], this.pos[1] - 30, this.size[0], this.size[1] + 30];
+    },
+  };
+
+  const r = moveGroupMembers([n], 10, 10);
+
+  assert.deepEqual(r.stuck, []);
+  assert.deepEqual([...n.boundingRect], [110, 80, 200, 130]);
+});

--- a/browser_tests/unit/group-geometry.test.mjs
+++ b/browser_tests/unit/group-geometry.test.mjs
@@ -847,3 +847,26 @@ test("#813 an EXPANDED node's authoritative extents are not overwritten (review 
     "and its authoritative extents survive — never replaced by the 200x130 generic model",
   );
 });
+
+test("#813 a node whose flags accessor THROWS is stuck, not repaired", () => {
+  // The collapsed repair is gated on reading `flags.collapsed`, and that read can throw on
+  // a disposed or hostile node. It must fail CLOSED: an unreadable node is not one this can
+  // show to have moved. (syncNodeArea would also fail on the same accessor, so the two
+  // guards agree — this pins the behaviour rather than the implementation of it.)
+  const n = {
+    id: 32,
+    pos: [100, 100],
+    size: [225, 0],
+    get flags() {
+      throw new TypeError("disposed");
+    },
+    boundingRect: [0, 0, 1, 1], // deliberately wrong, so a repair would have to be attempted
+  };
+
+  let r;
+  assert.doesNotThrow(() => {
+    r = moveGroupMembers([n], 50, 25);
+  }, "a hostile accessor must never escape the mover");
+  assert.deepEqual(r.moved, [], "an unreadable node is not reported moved");
+  assert.deepEqual(r.stuck, [n]);
+});

--- a/browser_tests/unit/group-geometry.test.mjs
+++ b/browser_tests/unit/group-geometry.test.mjs
@@ -793,3 +793,57 @@ test("#813 an EXPANDED member is unaffected — its two models already agree", (
   assert.deepEqual(r.stuck, []);
   assert.deepEqual([...n.boundingRect], [110, 80, 200, 130]);
 });
+
+test("#813 a rect exposed by a COPYING getter is not reported moved (review P2)", () => {
+  // `boundingRect` backed by a getter that hands out a fresh array each read. syncNodeArea
+  // mutates and verifies the throwaway copy, so its own verdict is true while the node's
+  // real rect never changed. Trusting that would report the node moved and then let the
+  // next rect-first membership read drop it from the group it was just moved into. This
+  // file already documents the same accessor shape for `pos` in writePoint.
+  const real = [100, 70, 80, 30];
+  const n = {
+    id: 30,
+    pos: [100, 100],
+    size: [225, 0],
+    flags: { collapsed: true },
+    _collapsed_width: 80,
+    get boundingRect() {
+      return [...real]; // a COPY: writes to it are dropped
+    },
+    updateArea() {
+      /* engine cannot move a rect it is handed by copy either */
+    },
+  };
+
+  const r = moveGroupMembers([n], 50, 25);
+
+  assert.deepEqual(r.moved, [], "a rect whose writes cannot be observed is not 'moved'");
+  assert.deepEqual(r.stuck, [n]);
+  assert.deepEqual(real, [100, 70, 80, 30], "and the underlying rect really was never updated");
+});
+
+test("#813 an EXPANDED node's authoritative extents are not overwritten (review P2)", () => {
+  // A custom node whose updateArea() computes visible bounds reaching past `size` — a
+  // legitimate engine answer that differs from the panel's generic footprint model. The
+  // collapsed repair must not fire here: overwriting the engine's rect and reporting
+  // success would make later rect-first membership wrong.
+  const n = {
+    id: 31,
+    pos: [100, 100],
+    size: [200, 100],
+    // Deliberately WIDER than size — the node draws outside its box.
+    boundingRect: [100, 70, 400, 300],
+    updateArea() {
+      this.boundingRect = [this.pos[0], this.pos[1] - 30, 400, 300];
+    },
+  };
+
+  const r = moveGroupMembers([n], 10, 10);
+
+  assert.deepEqual(r.stuck, [n], "an expanded node with a non-generic rect is still stuck");
+  assert.deepEqual(
+    [...n.boundingRect],
+    [110, 80, 400, 300],
+    "and its authoritative extents survive — never replaced by the 200x130 generic model",
+  );
+});

--- a/browser_tests/unit/move-group.test.mjs
+++ b/browser_tests/unit/move-group.test.mjs
@@ -2209,3 +2209,34 @@ test("moveReroutePoints skips malformed points and never throws", () => {
   assert.deepEqual(ok.pos, [11, 12]);
   assert.doesNotThrow(() => moveReroutePoints(undefined, 1, 1));
 });
+
+test("#813 the reported move: a group of COLLAPSED members moves, whole, with no partial", () => {
+  // The reporter's group 6 ("Face Detail & Output"): four collapsed size:[225,0] nodes,
+  // moved to [1500,-40]. Every one was called "would not accept a new position" — after its
+  // position had already been written — and the caller was told to press Ctrl+Z, which an
+  // agent driving the panel cannot do.
+  const collapsed = (id) => ({
+    id,
+    pos: [100, 100],
+    size: [225, 0],
+    flags: { collapsed: true },
+    _collapsed_width: 80,
+    boundingRect: [100, 70, 80, 30],
+    updateArea() {
+      // The engine recomputes from size and knows nothing about the panel's pill.
+      this.boundingRect = [this.pos[0], this.pos[1] - 30, this.size[0], this.size[1] + 30];
+    },
+  });
+  const members = [collapsed(24), collapsed(25), collapsed(26), collapsed(28)];
+  const g = group(6, [50, 50, 400, 400], "Face Detail & Output");
+  const graph = makeGraph({ nodes: members, groups: [g] });
+
+  const res = realMoveGroup(graph)({ group_id: 6, pos: [1500, -40] });
+
+  assert.equal(res.moved.nodes, 4, "all four collapsed members moved — no refusal, no partial");
+  for (const n of members) {
+    assert.deepEqual(n.pos, [1550, 10], "each member translated by the box delta");
+  }
+  assert.deepEqual(g._bounding, [1500, -40, 400, 400]);
+  assert.deepEqual(res.group.node_ids, [24, 25, 26, 28], "and all four are still reported as members");
+});

--- a/web/js/lib/group-geometry.js
+++ b/web/js/lib/group-geometry.js
@@ -577,7 +577,13 @@ export function moveGroupMembers(members, dx, dy) {
       try {
         isCollapsed = !!n?.flags?.collapsed;
       } catch {
-        isCollapsed = false; // unreadable flags ⇒ not eligible for the collapsed repair
+        // Unreadable flags ⇒ not eligible for the collapsed repair. Mutation reports
+        // flipping this to `true` as a SURVIVOR, and it is an equivalent mutant rather than
+        // a gap: `syncNodeArea` reads the same `flags` accessor through `wantedNodeArea`,
+        // so it throws, is caught there, and returns false — the node is stuck either way.
+        // Stated here so the next run does not re-chase it; the BEHAVIOUR is pinned by
+        // "a node whose flags accessor THROWS is stuck, not repaired".
+        isCollapsed = false;
       }
       if (!nodeAreaIsLive(n) && !(isCollapsed && syncNodeArea(n) && nodeAreaIsLive(n))) {
         landedExactly = false;

--- a/web/js/lib/group-geometry.js
+++ b/web/js/lib/group-geometry.js
@@ -552,7 +552,36 @@ export function moveGroupMembers(members, dx, dy) {
       // rect-first, so a rect that cannot track its node would report it in a group it has
       // left. The question changes from "does the rect already agree" to "can the rect be
       // MADE to agree", which is the one the caller actually needs answered.
-      if (!nodeAreaIsLive(n) && !syncNodeArea(n)) landedExactly = false;
+      //
+      // TWO THINGS THE CORRECTION IS DELIBERATELY NOT (both found in review):
+      //
+      // 1. IT IS NOT UNGATED. Only a COLLAPSED node gets it. An expanded node's
+      //    `updateArea()` may authoritatively compute extents that legitimately differ from
+      //    the generic `[x, y-30, size0, size1+30]` model — visible bounds that reach past
+      //    `size`, on a custom node that draws outside its box. Forcing the generic
+      //    footprint there would overwrite the engine's own answer and then report success,
+      //    and rect-first membership would be wrong afterwards. The reported defect is
+      //    specifically the collapsed-PILL disagreement, so that is all this repairs; an
+      //    expanded node with an uncorrectable rect is still stuck, exactly as before.
+      //    A `flags` accessor that THROWS reads as not-collapsed, so it fails closed.
+      //
+      // 2. IT DOES NOT TRUST `syncNodeArea`'s OWN VERDICT ALONE. `boundingRect` can be an
+      //    accessor whose getter returns a FRESH array on every read — a shape this file
+      //    already documents for `pos` in `writePoint` ("a getter that returns a COPY, where
+      //    an in-place write is silently dropped"). Against such a node `syncNodeArea`
+      //    mutates and then verifies the throwaway copy it was handed, returns true, and the
+      //    node's real rect never changed: the move would report the node moved while the
+      //    next membership read still saw the old rect and dropped it from the group. So the
+      //    verdict is re-read through `nodeAreaIsLive`, which fetches the property again.
+      let isCollapsed = false;
+      try {
+        isCollapsed = !!n?.flags?.collapsed;
+      } catch {
+        isCollapsed = false; // unreadable flags ⇒ not eligible for the collapsed repair
+      }
+      if (!nodeAreaIsLive(n) && !(isCollapsed && syncNodeArea(n) && nodeAreaIsLive(n))) {
+        landedExactly = false;
+      }
     } catch {
       landedExactly = false;
     }

--- a/web/js/lib/group-geometry.js
+++ b/web/js/lib/group-geometry.js
@@ -529,7 +529,30 @@ export function moveGroupMembers(members, dx, dy) {
       // is whether the rect ends up LIVE, not whether the delta-write happened: a
       // rect that was already right needs no write and is not stuck.
       refreshNodeArea(n, [px, py]);
-      if (!nodeAreaIsLive(n)) landedExactly = false;
+      // panel#813 — A COLLAPSED MEMBER IS NOT A NODE THAT REFUSED TO MOVE.
+      //
+      // `nodeAreaIsLive` compares the cached rect against `wantedNodeArea`, which for a
+      // collapsed node is the panel's PILL (`w = _collapsed_width || 80`, `h = 0`). The
+      // engine's own `updateArea()` recompute — which `refreshNodeArea` above deliberately
+      // TRUSTS as soon as it sees the origin move — writes the engine's extents instead. On
+      // a collapsed node those two models disagree by construction, so the width comparison
+      // failed for every collapsed member and the group move was refused AFTER their
+      // positions had already been written. That is the report: four `size:[225,0]` nodes
+      // called stuck, on a graph the reporter then repositioned one-by-one without trouble.
+      //
+      // So give the rect ONE MORE CHANCE to be put on the panel's convention before ruling,
+      // using `syncNodeArea` — the very writer this move's own pre-flight
+      // (`syncGraphNodeAreas`) already ran over every node moments earlier. Nothing new is
+      // written that the pre-flight did not already write, and the forced value is the pill,
+      // never the full box, so the #416 area-overstatement guarantee is untouched.
+      //
+      // THE #408 GUARD IS NOT RELAXED. A rect that genuinely cannot be corrected — frozen,
+      // hostile accessor, disposed — makes `syncNodeArea` return false and the node is still
+      // stuck, still refusing the whole move. That is the property #408 needs: membership is
+      // rect-first, so a rect that cannot track its node would report it in a group it has
+      // left. The question changes from "does the rect already agree" to "can the rect be
+      // MADE to agree", which is the one the caller actually needs answered.
+      if (!nodeAreaIsLive(n) && !syncNodeArea(n)) landedExactly = false;
     } catch {
       landedExactly = false;
     }


### PR DESCRIPTION
Fixes #813 (related: #408, #416, #819).

## The report

`panel_move_group` moved a group, then refused because four **collapsed** nodes "would not accept a new position" — after their positions had already been written:

```
refusing to move group 6: 4 enclosed item(s) would not accept a new position
(node 24, node 25, node 26, node 28) — move them out of the group ...
The graph is PARTIALLY moved ... Press Ctrl+Z on the canvas
```

All four were `size:[225,0]`, `collapsed:true`. The reporter repositioned the same nodes individually with `panel_move_node` without trouble, and asked the right question: *"A collapsed node has `size:[225,0]` but still has a valid `pos`; it's not obvious why it can't accept one. If the rejection is really a size-0 guard, it's firing on a legitimate node state."*

It was firing on a legitimate node state.

## Root cause

The stuck verdict never came from the position write. `moveGroupMembers` verifies that with `writePoint`, then **overrides** the verdict (`web/js/lib/group-geometry.js:531-532`):

```js
refreshNodeArea(n, [px, py]);            // return value discarded
if (!nodeAreaIsLive(n)) landedExactly = false;
```

`nodeAreaIsLive` requires the cached `boundingRect` to equal **all four** components of `wantedNodeArea`. For an EXPANDED node that model is `[x, y-30, size0, size1+30]` — exactly what a LiteGraph `updateArea()` recompute produces, so they agree. For a COLLAPSED node the panel substitutes its **pill** (`w = _collapsed_width || 80`, `h = 0`), which the engine's rect will not match. And `refreshNodeArea` deliberately **trusts** the engine's recompute as soon as it sees the origin move, never reconciling width/height.

So: the pre-flight normalises the collapsed rect to the pill → the engine's `updateArea()` puts its own extents straight back → `nodeAreaIsLive` sees a width mismatch → every collapsed member is classified stuck, *after* its position was already written.

## The fix

```js
if (!nodeAreaIsLive(n) && !syncNodeArea(n)) landedExactly = false;
```

Give the rect one more chance to be put on the panel's convention, using `syncNodeArea` — the very writer this move's own pre-flight (`syncGraphNodeAreas`) already ran over every node moments earlier. Nothing is written that the pre-flight did not already write, and the forced value is the **pill**, never the full box, so #416's area-overstatement guarantee is untouched.

**#408 is not relaxed.** A rect that genuinely cannot be corrected — frozen, hostile accessor, disposed — makes `syncNodeArea` return false and the node is still stuck, still refusing the whole move. That property is load-bearing: membership is rect-first, so a rect that cannot track its node would report it in a group it has left. The question simply changes from *"does the rect already agree"* to *"can the rect be MADE to agree"*, which is the one the caller needs answered.

## The other half of the report already landed

`The graph is PARTIALLY moved — N item(s) could NOT be put back` was fixed in `fa93556a` (#819): the rollback verdict is the position, not the rect. Only the collapsed refusal was still live.

## Verification

- **4374 unit tests pass** (5 new).
- **7 mutations applied, all 7 killed** against a checked-GREEN baseline. The decisive one is *"the fix reverted"* going RED — that is what shows the new tests catch the reported bug rather than merely passing beside it. Also killed: dropping the verdict entirely, making an uncorrectable rect non-stuck, forcing the full box instead of the pill, and breaking `syncNodeArea`'s write/report contract.
- New tests cover: the reporter's four-collapsed-member group moving end-to-end through the real `graph_move_group`; a collapsed member whose engine `updateArea()` restores full extents; the pill (not the box) being what gets forced; a frozen rect still refusing; and an expanded member being unaffected.