### PR TITLE
release: v0.14.40 — a group of collapsed nodes moves instead of refusing (#813)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+## [0.14.40] - 2026-08-14
+
+### Fixed
+- a group whose members are COLLAPSED nodes now moves, instead of being refused after those members positions had already been written (#813)
+
 ## [0.14.39] - 2026-08-14
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-agent-panel"
 description = "Autonomous AI agent in the ComfyUI sidebar - local-first, bring any LLM. Run it on your Claude or ChatGPT subscription (no API keys, no extra LLM costs), on a Kimi K3 / GLM / OpenRouter key, or fully offline on free local models via Ollama, LM Studio, or llama.cpp. The agent drives your live canvas at full parity: add, wire, move and tweak nodes with Ctrl+Z undo, load whole workflows and installer packs in one shot, generate images, video and audio, browse CivitAI, and run your workflow - asking before it spends paid API credits. The sidebar UI for comfyui-mcp, the local-first, agent-native control plane for ComfyUI. The panel speaks 12 languages, matching your ComfyUI language automatically: English, 한국어, 日本語, 中文 (简体), 中文 (繁體), Русский, Français, Español, Português (BR), Türkçe, العربية, فارسی."
-version = "0.14.39"
+version = "0.14.40"
 license = { file = "LICENSE" }
 requires-python = ">=3.9"
 # UI-only pack: no Python deps. The frontend floor guarantees

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -1526,7 +1526,7 @@ const DOCS_URL = "https://comfyui-mcp.artokun.io/docs";
 // Panel version — surfaced in the "Need help?" diagnostics blob. Bump via
 // `node scripts/set-version.mjs <v>` (updates this AND pyproject together); CI
 // and the publish gate FAIL if the two ever drift, so this can't go stale.
-const PANEL_VERSION = "0.14.39";
+const PANEL_VERSION = "0.14.40";
 
 // The connected orchestrator's console URL/token (captured off the `backends`
 // bridge message — see onBackends). Drives the "API Keys" credentials frame;


### PR DESCRIPTION
Releases the #813 fix merged in #1239.

## What users get

`panel_move_group` moved a group, then refused because four **collapsed** nodes "would not accept a new position" — *after* their positions had already been written, and told the caller to press Ctrl+Z, which an agent driving the panel cannot do. The reporter repositioned the same nodes one-by-one with `panel_move_node` without trouble.

The stuck verdict never came from the position write. It came from comparing the cached rect against the panel's collapsed **pill** model (`_collapsed_width || 80`, `h = 0`) while the engine's own `updateArea()` had just written its own extents back — two models that disagree by construction for a collapsed node. The rect now gets one more chance to be put on the panel's convention.

## Verified in the browser, on this machine

The same script run against the shipped bundle before and after, with the restart in between:

| | moved | stuck |
|---|---|---|
| **v0.14.39** | 0 | `[24, 25, 26, 28]` |
| **this build** | **4** | `[]` |

Positions land correctly and the rects come back on the pill convention. Both guards confirmed intact in the same run: a **frozen rect still refuses** (#408 — a rect that cannot track its node would report it in a group it has left), and an **expanded node's authoritative extents are preserved** (never overwritten with the generic model).

## Review

One Codex round, which found two P2s — both fixed before merge:

- the rect repair was **ungated**, so an expanded node whose `updateArea()` legitimately computes extents beyond `size` would have had them overwritten with the generic footprint and reported as success;
- it trusted `syncNodeArea`'s own verdict, but `boundingRect` can be an accessor whose getter returns a **fresh array per read** — the shape this file already documents for `pos` in `writePoint` — so the sync would mutate a throwaway copy, report success, and leave the real rect stale.

A second round was cancelled after 25 minutes: it had stopped converging and was calling unrelated MCP tools rather than examining a one-line diff. Merged on the first round's findings plus mutation evidence.

**4398 tests · 10 mutations, 9 killed** (one documented equivalent mutant: flipping the unreadable-`flags` fallback changes nothing, because `syncNodeArea` reads the same throwing accessor and fails anyway).