### PR TITLE
feat(757): panel_set_widget can create an rgthree lora_N slot

### DIFF
--- a/browser_tests/unit/rgthree-lora-row.test.mjs
+++ b/browser_tests/unit/rgthree-lora-row.test.mjs
@@ -1,0 +1,217 @@
+/**
+ * #757 — `panel_set_widget` could not CREATE an rgthree Power Lora Loader row.
+ *
+ * The rows exist only after the user clicks "➕ Add Lora", a DOM-only control an agent
+ * cannot activate, so every write to `lora_1` on a fresh node was refused for a widget no
+ * tool could bring into existence.
+ *
+ * The load-bearing constraint is what this must NOT become. The panel deliberately refuses
+ * to auto-press a pressable control, because a generic "press this node's button" rule
+ * would mutate the graph on an ordinary TYPO — the overwhelmingly common reason a widget
+ * name misses. Most of these tests exist to pin that the route cannot be reached by
+ * anything but the real case.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  isRgthreeLoraRowCreation,
+  createRgthreeLoraRow,
+  POWER_LORA_LOADER_TYPE,
+} from "../../web/js/lib/rgthree-lora-row.js";
+
+const SLOT = { on: true, lora: "x.safetensors", strength: 0.5, strengthTwo: null };
+
+/** A Power Lora Loader as it looks fresh from panel_add_node: no rows yet. */
+function loader({ counter = 1, addNew = true, widgets = null } = {}) {
+  const node = {
+    id: 153,
+    type: POWER_LORA_LOADER_TYPE,
+    widgets: widgets ?? [
+      { name: "divider" },
+      { name: "PowerLoraLoaderHeaderWidget" },
+      { name: "divider" },
+      { name: "➕ Add Lora" },
+    ],
+    removeWidget(w) {
+      const i = node.widgets.indexOf(w);
+      if (i >= 0) node.widgets.splice(i, 1);
+    },
+  };
+  if (addNew) {
+    // rgthree's real behaviour: a MONOTONIC counter, so names are not positional.
+    node.addNewLoraWidget = () => {
+      node.widgets.push({ name: `lora_${counter++}`, value: { on: true, lora: null, strength: 1, strengthTwo: null } });
+    };
+  }
+  return node;
+}
+
+// ---------------------------------------------------------------------------
+// The classifier — three independent facts, all required
+// ---------------------------------------------------------------------------
+
+test("#757 the reported case classifies: right type, lora_N name, slot-shaped value", () => {
+  assert.equal(isRgthreeLoraRowCreation(loader(), "lora_1", SLOT), true);
+});
+
+test("#757 a TYPO does not reach the creation route", () => {
+  // The whole reason the panel refuses to auto-press a button. `strenght` or `lora1` or
+  // `seed` must all get the ordinary refusal (and its pressable hint), never a new row.
+  for (const name of ["lora1", "loras_1", "lora_", "seed", "strenght", "LORA_1", ""]) {
+    assert.equal(isRgthreeLoraRowCreation(loader(), name, SLOT), false, `name ${JSON.stringify(name)}`);
+  }
+});
+
+test("#757 another node type never reaches it, even with a lora_N name and a slot value", () => {
+  const other = { ...loader(), type: "LoraLoader" };
+  assert.equal(isRgthreeLoraRowCreation(other, "lora_1", SLOT), false);
+  const noType = { ...loader(), type: undefined, comfyClass: undefined };
+  assert.equal(isRgthreeLoraRowCreation(noType, "lora_1", SLOT), false);
+});
+
+test("#757 a value that is not a lora slot never reaches it", () => {
+  // A slot is minted to receive a row. Growing the node for a value the writer would then
+  // refuse leaves a stray row behind and reports a failure — worse than refusing up front.
+  for (const value of [null, undefined, 5, "x.safetensors", [], { on: true }, { on: true, lora: "a", strength: 1, extra: 1 }]) {
+    assert.equal(isRgthreeLoraRowCreation(loader(), "lora_1", value), false, `value ${JSON.stringify(value)}`);
+  }
+});
+
+test("#757 an EXISTING row is left to the ordinary write path", () => {
+  const n = loader();
+  n.widgets.push({ name: "lora_1", value: { on: false, lora: null, strength: 1, strengthTwo: null } });
+  assert.equal(isRgthreeLoraRowCreation(n, "lora_1", SLOT), false, "minting over it would duplicate the row");
+});
+
+test("#757 the classifier is total — a hostile node answers false, never throws", () => {
+  const hostile = {
+    get type() {
+      throw new TypeError("disposed");
+    },
+  };
+  assert.doesNotThrow(() => isRgthreeLoraRowCreation(hostile, "lora_1", SLOT));
+  assert.equal(isRgthreeLoraRowCreation(hostile, "lora_1", SLOT), false);
+});
+
+// ---------------------------------------------------------------------------
+// Creation, and the post-verify that makes a pack-private call safe
+// ---------------------------------------------------------------------------
+
+test("#757 the reported case: the row is created and named", () => {
+  const n = loader();
+  const events = [];
+  const r = createRgthreeLoraRow(n, "lora_1", {
+    beforeChange: () => events.push("before"),
+    afterChange: () => events.push("after"),
+    setDirty: () => events.push("dirty"),
+  });
+  assert.deepEqual(r, { created: "lora_1" });
+  assert.ok(n.widgets.some((w) => w.name === "lora_1"), "the row now exists for the write that follows");
+  assert.deepEqual(events, ["before", "after", "dirty"], "the mutation is bracketed for undo");
+});
+
+test("#757 a pack without addNewLoraWidget refuses LOUDLY, and changes nothing", () => {
+  // Feature detection, as ltx-director.js does for its own pack-private entry point. A
+  // renamed or dropped method must produce an actionable refusal, never a silent no-op.
+  const n = loader({ addNew: false });
+  const before = n.widgets.length;
+  assert.throws(() => createRgthreeLoraRow(n, "lora_1", {}), /does not expose addNewLoraWidget/);
+  assert.equal(n.widgets.length, before);
+});
+
+test("#757 a call that adds NOTHING is caught — the effect is verified, not the call", () => {
+  // The probe that motivated this file found pack callbacks that accept a call and create
+  // nothing. Only comparing the widget list catches that.
+  const n = loader();
+  n.addNewLoraWidget = () => {};
+  assert.throws(() => createRgthreeLoraRow(n, "lora_1", {}), /ran but added no widget/);
+});
+
+test("#757 a pack method that THROWS is attributed to the pack", () => {
+  const n = loader();
+  n.addNewLoraWidget = () => {
+    throw new Error("rgthree exploded");
+  };
+  assert.throws(() => createRgthreeLoraRow(n, "lora_1", {}), /rgthree pack's own addNewLoraWidget\(\) threw \(rgthree exploded\)/);
+});
+
+test("#757 afterChange still runs when the pack method throws", () => {
+  const n = loader();
+  n.addNewLoraWidget = () => {
+    throw new Error("boom");
+  };
+  const events = [];
+  assert.throws(() =>
+    createRgthreeLoraRow(n, "lora_1", {
+      beforeChange: () => events.push("before"),
+      afterChange: () => events.push("after"),
+    }),
+  );
+  assert.deepEqual(events, ["before", "after"], "an unclosed beforeChange would corrupt the undo stack");
+});
+
+test("#757 a MONOTONIC counter: the wrong row is taken back out and the real name is named", () => {
+  // rgthree's loraWidgetsCounter only ever increases, so after a row is removed the next
+  // created row is NOT the removed name. A refusal that left the stray row behind could not
+  // be safely retried.
+  const n = loader({ counter: 7 });
+  const before = n.widgets.length;
+  assert.throws(
+    () => createRgthreeLoraRow(n, "lora_1", {}),
+    /this node's next row is "lora_7", not "lora_1"[\s\S]*has been removed again/,
+  );
+  assert.equal(n.widgets.length, before, "nothing is left behind");
+  assert.ok(!n.widgets.some((w) => w.name === "lora_7"), "including the row it minted");
+});
+
+test("#757 the stray row is removed even on a node with no removeWidget method", () => {
+  const n = loader({ counter: 9 });
+  delete n.removeWidget;
+  const before = n.widgets.length;
+  assert.throws(() => createRgthreeLoraRow(n, "lora_2", {}), /next row is "lora_9"/);
+  assert.equal(n.widgets.length, before, "the splice fallback still cleans up");
+});
+
+test("#757 consecutive creates work: lora_1 then lora_2", () => {
+  const n = loader();
+  assert.deepEqual(createRgthreeLoraRow(n, "lora_1", {}), { created: "lora_1" });
+  assert.deepEqual(createRgthreeLoraRow(n, "lora_2", {}), { created: "lora_2" });
+  assert.deepEqual(
+    n.widgets.map((w) => w.name).filter((x) => x.startsWith("lora_")),
+    ["lora_1", "lora_2"],
+  );
+});
+
+// ---------------------------------------------------------------------------
+// The panel wiring
+// ---------------------------------------------------------------------------
+
+import { readFileSync } from "node:fs";
+const PANEL_SRC = readFileSync(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8");
+
+test("#757 creation runs AFTER the history seed and BEFORE runSetWidget", () => {
+  // The seed is what makes the #458 authorization meaningful, and growing a node is a
+  // mutation: it must not happen on a call authorization is about to refuse.
+  const seed = PANEL_SRC.indexOf("await awaitObjectInfoHistorySeed();", PANEL_SRC.indexOf("async graph_set_widget("));
+  const create = PANEL_SRC.indexOf("createRgthreeLoraRow(node, widget, {");
+  const run = PANEL_SRC.indexOf("const result = await runSetWidget(");
+  assert.ok(seed > 0 && create > seed, "creation is after the history seed");
+  assert.ok(run > create, "…and before the write");
+});
+
+test("#757 the uuid fence brackets the creation", () => {
+  // The user can switch workflows during the awaits above; a row must never be grown on a
+  // canvas the caller did not address (#570/#718).
+  const at = PANEL_SRC.indexOf("if (isRgthreeLoraRowCreation(node, widget, value)) {");
+  assert.notEqual(at, -1);
+  const block = PANEL_SRC.slice(at, PANEL_SRC.indexOf("createRgthreeLoraRow(node, widget, {", at));
+  assert.match(block, /assertActiveWorkflowCommandTarget\(\{/, "the fence runs before the mutation");
+});
+
+test("#757 the created row is disclosed on its own field, not in `warning`", () => {
+  assert.match(PANEL_SRC, /created_widget: createdLoraRow/);
+  const sw = PANEL_SRC.slice(PANEL_SRC.indexOf("async graph_set_widget("));
+  const body = sw.slice(0, sw.indexOf("async graph_remove_widget("));
+  assert.ok(!/warning:[^\n]*createdLoraRow/.test(body), "it must not displace a warning about the write");
+});

--- a/browser_tests/unit/rgthree-lora-row.test.mjs
+++ b/browser_tests/unit/rgthree-lora-row.test.mjs
@@ -477,6 +477,28 @@ test("#757 remove() never throws, whatever the node does", () => {
   assert.doesNotThrow(() => made.remove(), "an undo on an error path must not replace the refusal");
 });
 
+test("#757 the mismatch refusal CONFIRMS the rewind instead of assuming it", () => {
+  // ROUND-5 P2. `restoreRowCounter` reports whether it ran an assignment, not whether the
+  // assignment took. A counter that accepts `++` but silently ignores writes back — a
+  // getter-only property, a clamping pack, a proxy — made it return true while the number
+  // stayed spent, and the refusal then printed the remedy that only works if it came back:
+  // "Set lora_2 instead", when lora_2 is already gone too.
+  const n = loader({ nextRow: 1 });
+  let frozen = 0;
+  Object.defineProperty(n, "loraWidgetsCounter", {
+    get: () => frozen,
+    set: (v) => {
+      if (v > frozen) frozen = v; // accepts the mint, ignores the rewind
+    },
+    configurable: true,
+  });
+  assert.throws(
+    () => createRgthreeLoraRow(n, "lora_9", {}),
+    /could not be rewound, so "lora_1" is now used up/,
+    "an unrewound counter must not be advertised as rewound",
+  );
+});
+
 test("#757 remove() reports a rollback it completed as clean", () => {
   // The other side of the rule below — the honest "nothing is left over" must stay reachable,
   // or every refused write would start carrying a scary sentence it has not earned.
@@ -551,7 +573,7 @@ test("#757 NO AWAIT separates the creation from the write", () => {
   const body = SET_WIDGET_LIB_SRC.slice(start, end);
   assert.match(body, /prepareWriteTarget\(\)/, "the creation hook is invoked here");
   assert.match(body, /applyWidgetWrite\(/, "…and the write immediately follows it");
-  assert.match(body, /prepared\?\.undo\?\.\(\)/, "…and the undo is in the same stretch");
+  assert.match(body, /prepared\.undo\?\.\(\)/, "…and the undo is in the same stretch");
   // Comments in this block DISCUSS the await that used to be here, so judge the code only.
   const code = body.replace(/^\s*\/\/.*$/gm, "");
   assert.ok(!/\bawait\b/.test(code), `no await may appear between them:\n${code}`);
@@ -743,6 +765,46 @@ function historyProbe(node) {
   return probe;
 }
 
+test("#757 boundary: a value the CAPTURE rewrites is caught, exactly as on an existing row", async () => {
+  // ROUND-5 P1, and the rule the creating path now rests on: creation must report whatever an
+  // ordinary write reports for the same value.
+  //
+  // applyWidgetWrite verifies AFTER its own afterChange fires, deliberately, because that is
+  // when ComfyUI serializes the graph for the undo capture — and serialization runs each
+  // node's own `serializeValue`. An rgthree loader in Separate Model & Clip mode rewrites
+  // `strengthTwo: null` to 1 right there. Wrapping applyWidgetWrite in an OUTER envelope
+  // stops its close from reaching zero, so the capture (and that rewrite) happens after the
+  // last verification and the drift is never seen — the creating path reported plain success
+  // where an existing-row write reported a normalization.
+  //
+  // The probe mutates at DEPTH ZERO only, which is exactly where a capture happens.
+  const node = { id: 7, type: "KSampler", widgets: [] };
+  const target = { name: "made", type: "text", value: "" };
+  const probe = historyProbe(node);
+  const capturing = {
+    beforeChange: probe.beforeChange,
+    afterChange: () => {
+      probe.afterChange();
+      // The serialize step the capture performs, rewriting the value behind our back.
+      if (probe.depth === 0) target.value = "rewritten-by-serializeValue";
+    },
+  };
+  await assert.rejects(
+    () =>
+      runSetWidget(node, "made", "hello", {
+        registry: BOUNDARY_REGISTRY,
+        ...boundaryOracle,
+        ...capturing,
+        prepareWriteTarget: () => {
+          node.widgets.push(target);
+          return { undo: () => { node.widgets = node.widgets.filter((w) => w !== target); } };
+        },
+      }),
+    /did not retain the requested value/,
+    "a rewrite during the capture must be caught on the creating path too, not silently accepted",
+  );
+});
+
 test("#757 boundary: a POST-ASSIGNMENT refusal captures no history with the row still in it", async () => {
   // ROUND-4 P2. applyWidgetWrite closes its own envelope BEFORE the #240 read-back verifies,
   // and rolls a bad value back in an envelope of its own — so a value the widget's setter
@@ -779,8 +841,74 @@ test("#757 boundary: a POST-ASSIGNMENT refusal captures no history with the row 
   );
   assert.equal(undone, 1, "the refusal rolled the preparation back");
   assert.equal(probe.depth, 0, "every envelope opened is closed — an unclosed one wedges the tracker");
-  assert.equal(probe.captures.length, 1, "exactly one capture, at the outermost close");
-  assert.deepEqual(probe.captures[0], [], "…and it holds the graph AFTER the cleanup, not the refused row");
+  // The NEWEST snapshot is what a Ctrl+Z steps back from, and it must describe the graph that
+  // actually exists. Earlier the cleanup ran with nothing open, so the newest snapshot still
+  // held the refused row.
+  assert.deepEqual(
+    probe.captures.at(-1),
+    [],
+    "the newest capture is the graph AFTER the cleanup, not a row-present snapshot of a refused command",
+  );
+  // NOT asserted: that this is the ONLY capture. applyWidgetWrite captures its write and then
+  // captures its rollback in a second envelope, so an ORDINARY refused write already leaves
+  // intermediate snapshots too. Demanding fewer here is what produced the round-5 P1: the only
+  // way to suppress them is to hold one envelope across the verification, which moves the
+  // capture — and every pack serializeValue it runs — past the last check.
+  assert.ok(probe.captures.length >= 1, "the write path keeps the captures it has always taken");
+});
+
+test("#757 boundary: a throwing history OPEN still gets the row back out", async () => {
+  // ROUND-5 P2. The cleanup's envelope is opened by the graph's own hook, and a pack or
+  // extension can make that throw. If it escapes, the cleanup never runs: the row AND the row
+  // name it spent are left behind while the caller is handed an error — mutate-then-refuse,
+  // caused by the bookkeeping rather than by the write.
+  const { node, seen, prepareWriteTarget } = boundaryFixture({
+    name: "made",
+    type: "combo",
+    options: { values: ["a"] },
+    value: "a",
+  });
+  await assert.rejects(
+    () =>
+      runSetWidget(node, "made", "nope", {
+        registry: BOUNDARY_REGISTRY,
+        ...boundaryOracle,
+        prepareWriteTarget,
+        beforeChange: () => {
+          throw new Error("onBeforeChange blew up");
+        },
+        afterChange: () => {},
+      }),
+    /panel_set_widget refused "made"/,
+    "the caller still hears why the WRITE was refused",
+  );
+  assert.equal(seen.undone, 1, "the cleanup ran anyway");
+  assert.deepEqual(node.widgets, [], "and the node is as it was found");
+});
+
+test("#757 boundary: a throwing history CLOSE does not replace the refusal", async () => {
+  const { node, seen, prepareWriteTarget } = boundaryFixture({
+    name: "made",
+    type: "combo",
+    options: { values: ["a"] },
+    value: "a",
+  });
+  await assert.rejects(
+    () =>
+      runSetWidget(node, "made", "nope", {
+        registry: BOUNDARY_REGISTRY,
+        ...boundaryOracle,
+        prepareWriteTarget,
+        beforeChange: () => {},
+        afterChange: () => {
+          throw new Error("onAfterChange blew up");
+        },
+      }),
+    /panel_set_widget refused "made"/,
+    "a failed history hook must never become the reason the caller is given",
+  );
+  assert.equal(seen.undone, 1);
+  assert.deepEqual(node.widgets, []);
 });
 
 test("#757 boundary: a SUCCESSFUL creating write is still one capture, with the row in it", async () => {

--- a/browser_tests/unit/rgthree-lora-row.test.mjs
+++ b/browser_tests/unit/rgthree-lora-row.test.mjs
@@ -17,9 +17,9 @@ import assert from "node:assert/strict";
 import {
   isRgthreeLoraRowCreation,
   createRgthreeLoraRow,
-  noteRgthreeLoraRowWritten,
   POWER_LORA_LOADER_TYPE,
 } from "../../web/js/lib/rgthree-lora-row.js";
+import { runSetWidget } from "../../web/js/lib/set-widget.js";
 
 const SLOT = { on: true, lora: "x.safetensors", strength: 0.5, strengthTwo: null };
 
@@ -420,6 +420,40 @@ test("#757 a pack method that throws PART-WAY is cleaned up, not just reported",
   assert.equal(n.loraWidgetsCounter, 0, "and the number it had already spent was returned");
 });
 
+test("#757 an UNKNOWN counter is reported as an incomplete rollback, not a clean one", () => {
+  // A pack that exposes no readable counter still has one, and the shipped method increments
+  // it BEFORE it constructs — so a throw has probably already spent a row name. Saying
+  // "nothing was changed" there tells the caller a retry is safe when it is not, which is
+  // exactly the unfollowable advice the mismatch refusal already had to stop giving.
+  const n = loader({ nextRow: 1, trackCounter: false });
+  n.addNewLoraWidget = () => {
+    throw new Error("boom"); // a private counter may already have moved
+  };
+  assert.throws(
+    () => createRgthreeLoraRow(n, "lora_1", {}),
+    /row counter could not be read, so it may have consumed a row name before it threw/,
+  );
+});
+
+test("#757 an UNKNOWN counter also makes 'added no widget' an incomplete rollback", () => {
+  const n = loader({ nextRow: 1, trackCounter: false });
+  n.addNewLoraWidget = () => {}; // accepted the call, added nothing, counter unknowable
+  assert.throws(
+    () => createRgthreeLoraRow(n, "lora_1", {}),
+    /ran but added no widget[\s\S]*could not be read, so the call may still have consumed a row name/,
+  );
+});
+
+test("#757 a KNOWN counter that came back really does report a clean rollback", () => {
+  // The other side of the same rule — the honest "nothing was changed" must still be reachable.
+  const n = loader({ nextRow: 1 });
+  n.addNewLoraWidget = () => {
+    n.loraWidgetsCounter += 1; // spent, but we can see it and put it back
+  };
+  assert.throws(() => createRgthreeLoraRow(n, "lora_1", {}), /ran but added no widget\. Nothing was changed\./);
+  assert.equal(n.loraWidgetsCounter, 0);
+});
+
 test("#757 a pack throw whose damage could NOT be undone says so", () => {
   const n = loader({ nextRow: 1 });
   n.addNewLoraWidget = () => {
@@ -430,7 +464,7 @@ test("#757 a pack throw whose damage could NOT be undone says so", () => {
   n.removeWidget = () => {}; // and the node will not give the row up
   assert.throws(
     () => createRgthreeLoraRow(n, "lora_1", {}),
-    /had already changed the node before it threw, and that could not be fully undone \(lora_1\)/,
+    /had already changed the node before it threw, and that could not be fully undone \(lora_1 is still on the node\)/,
   );
 });
 
@@ -450,23 +484,243 @@ test("#757 remove() never throws, whatever the node does", () => {
 import { readFileSync } from "node:fs";
 const PANEL_SRC = readFileSync(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8");
 
-test("#757 creation runs AFTER the history seed and BEFORE runSetWidget", () => {
-  // The seed is what makes the #458 authorization meaningful, and growing a node is a
-  // mutation: it must not happen on a call authorization is about to refuse.
-  const seed = PANEL_SRC.indexOf("await awaitObjectInfoHistorySeed();", PANEL_SRC.indexOf("async graph_set_widget("));
-  const create = PANEL_SRC.indexOf("createRgthreeLoraRow(node, widget, {");
-  const run = PANEL_SRC.indexOf("await runSetWidget(");
-  assert.ok(seed > 0 && create > seed, "creation is after the history seed");
-  assert.ok(run > create, "…and before the write");
+const SET_WIDGET_LIB_SRC = readFileSync(new URL("../../web/js/lib/set-widget.js", import.meta.url), "utf8");
+
+test("#757 NO AWAIT separates the creation from the write", () => {
+  // The rule the whole feature now rests on. `write()` is runSetWidget's synchronous
+  // boundary: fence, then prepareWriteTarget, then applyWidgetWrite, then the undo on
+  // failure — with nothing awaited in between. An `await` anywhere in that stretch reopens
+  // every window this design closes: a transient row visible to an undo capture, to a
+  // concurrent command frame, and to the user's own hands.
+  const start = SET_WIDGET_LIB_SRC.indexOf("const write = (extra = {}) => {");
+  assert.notEqual(start, -1, "could not locate the write boundary");
+  const end = SET_WIDGET_LIB_SRC.indexOf("\n  };", start);
+  const body = SET_WIDGET_LIB_SRC.slice(start, end);
+  assert.match(body, /prepareWriteTarget\(\)/, "the creation hook is invoked here");
+  assert.match(body, /applyWidgetWrite\(/, "…and the write immediately follows it");
+  assert.match(body, /prepared\?\.undo\?\.\(\)/, "…and the undo is in the same stretch");
+  // Comments in this block DISCUSS the await that used to be here, so judge the code only.
+  const code = body.replace(/^\s*\/\/.*$/gm, "");
+  assert.ok(!/\bawait\b/.test(code), `no await may appear between them:\n${code}`);
 });
 
-test("#757 the uuid fence brackets the creation", () => {
-  // The user can switch workflows during the awaits above; a row must never be grown on a
-  // canvas the caller did not address (#570/#718).
-  const at = PANEL_SRC.indexOf("if (isRgthreeLoraRowCreation(node, widget, value)) {");
-  assert.notEqual(at, -1);
-  const block = PANEL_SRC.slice(at, PANEL_SRC.indexOf("createRgthreeLoraRow(node, widget, {", at));
-  assert.match(block, /assertActiveWorkflowCommandTarget\(\{/, "the fence runs before the mutation");
+test("#757 the creation runs AFTER the workflow fence", () => {
+  // A row must never be grown on a canvas the caller did not address (#570/#718). The fence
+  // is runSetWidget's own, re-checked at the write boundary, so the creation is now behind
+  // the SAME check the write is.
+  const start = SET_WIDGET_LIB_SRC.indexOf("const write = (extra = {}) => {");
+  const body = SET_WIDGET_LIB_SRC.slice(start, SET_WIDGET_LIB_SRC.indexOf("\n  };", start));
+  const fence = body.indexOf("assertTargetStillCurrentNow()");
+  const mint = body.indexOf("prepareWriteTarget()");
+  // Both anchors must EXIST before their order means anything: `indexOf` returns -1 for a
+  // line that was deleted, and -1 < anything reads exactly like a pass. A fence that is gone
+  // is a worse failure than a fence in the wrong place.
+  assert.notEqual(fence, -1, "the write boundary still re-checks the workflow fence");
+  assert.notEqual(mint, -1, "the write boundary still invokes the creation hook");
+  assert.ok(fence < mint, "the fence runs before the mutation");
+});
+
+// ---------------------------------------------------------------------------
+// The write boundary itself — the REAL runSetWidget, driven
+// ---------------------------------------------------------------------------
+//
+// The executor tests above stub runSetWidget, so they verify the panel's HALF of the
+// contract against a model of the other half. That model could agree with a set-widget.js
+// that no longer honours it. These drive the shipped runSetWidget directly, the way
+// set-widget-refresh.test.mjs does, so the hook's actual ordering, its rollback and its
+// behaviour across the retry await are verified rather than assumed.
+
+const BOUNDARY_REGISTRY = { KSampler: {} };
+const boundaryOracle = { getFreshObjectInfo: async () => ({ KSampler: {} }) };
+
+/**
+ * A node whose write target DOES NOT EXIST until the hook mints it — the shape #757 needs.
+ * `prepareWriteTarget` is the only thing that can bring "made" into existence, so any write
+ * that lands proves the hook ran first, and any surviving widget proves it was not undone.
+ */
+function boundaryFixture(widget = { name: "made", type: "text", value: "" }) {
+  const node = { id: 7, type: "KSampler", widgets: [] };
+  const seen = { prepared: 0, undone: 0 };
+  const prepareWriteTarget = () => {
+    // Idempotent exactly as the panel's hook is: the classifier there requires the row to be
+    // ABSENT, and a retry re-enters this after the first attempt undid its work.
+    if (node.widgets.includes(widget)) return null;
+    seen.prepared += 1;
+    node.widgets.push(widget);
+    return {
+      undo: () => {
+        seen.undone += 1;
+        node.widgets = node.widgets.filter((w) => w !== widget);
+      },
+    };
+  };
+  return { node, widget, seen, prepareWriteTarget };
+}
+
+test("#757 boundary: the hook mints the target and the write lands on it", async () => {
+  const { node, seen, prepareWriteTarget } = boundaryFixture();
+  const res = await runSetWidget(node, "made", "hello", {
+    registry: BOUNDARY_REGISTRY,
+    ...boundaryOracle,
+    prepareWriteTarget,
+  });
+  assert.equal(seen.prepared, 1);
+  assert.equal(seen.undone, 0, "a write that succeeded is never rolled back");
+  assert.equal(res.set.value, "hello");
+  assert.equal(node.widgets[0].value, "hello", "the write landed on the widget the hook created");
+});
+
+test("#757 boundary: the fence refuses BEFORE the hook can mint anything", async () => {
+  // The user switched workflow tabs while /object_info was in flight. The refusal must
+  // arrive over a node this command never touched. End-to-end, and therefore satisfied by
+  // whichever fence fires first — the isolating version is the next test.
+  const { node, seen, prepareWriteTarget } = boundaryFixture();
+  await assert.rejects(
+    () =>
+      runSetWidget(node, "made", "hello", {
+        registry: BOUNDARY_REGISTRY,
+        ...boundaryOracle,
+        prepareWriteTarget,
+        assertTargetStillCurrent: () => {
+          throw new Error("the workflow changed while this write was in flight");
+        },
+      }),
+    /the workflow changed/,
+  );
+  assert.equal(seen.prepared, 0, "nothing was minted on the stale canvas");
+  assert.deepEqual(node.widgets, [], "and the node is exactly as it was found");
+});
+
+test("#757 boundary: the write boundary re-checks the fence on its OWN account", async () => {
+  // WHY THE TEST ABOVE IS NOT ENOUGH. A direct node ALWAYS reconciles
+  // (preflightSetWidgetTarget returns `{reconcile: true}` for any node without a `subgraph`),
+  // and reconcile runs a fence check of its own well before the write boundary. A fence that
+  // throws on sight is therefore caught by that earlier check, and deleting the boundary's
+  // own re-check would leave the previous test green while reopening the exact #718 window
+  // the re-check exists for.
+  //
+  // So the user is still on the right canvas when reconcile asks, and has switched tabs by
+  // the time the write boundary asks. Only a fence AT the boundary refuses this.
+  const { node, seen, prepareWriteTarget } = boundaryFixture();
+  let fenceCalls = 0;
+  await assert.rejects(
+    () =>
+      runSetWidget(node, "made", "hello", {
+        registry: BOUNDARY_REGISTRY,
+        ...boundaryOracle,
+        prepareWriteTarget,
+        assertTargetStillCurrent: () => {
+          fenceCalls += 1;
+          if (fenceCalls > 1) throw new Error("the workflow changed while this write was in flight");
+        },
+      }),
+    /the workflow changed/,
+  );
+  assert.equal(fenceCalls, 2, "the write boundary asked again, on its own account");
+  assert.equal(seen.prepared, 0, "and nothing was minted on the canvas the user had left");
+  assert.deepEqual(node.widgets, [], "…so the refusal arrives over an untouched node");
+});
+
+test("#757 boundary: a REFUSED write undoes what the hook prepared", async () => {
+  // A combo value the list does not contain, with no refresh wired: applyWidgetWrite refuses,
+  // and the refusal must be reported over the node the command started from.
+  const { node, seen, prepareWriteTarget } = boundaryFixture({
+    name: "made",
+    type: "combo",
+    options: { values: ["a"] },
+    value: "a",
+  });
+  await assert.rejects(
+    () =>
+      runSetWidget(node, "made", "nope", {
+        registry: BOUNDARY_REGISTRY,
+        ...boundaryOracle,
+        prepareWriteTarget,
+      }),
+    /panel_set_widget refused "made"/,
+  );
+  assert.equal(seen.prepared, 1);
+  assert.equal(seen.undone, 1, "the refusal took the prepared target back out");
+  assert.deepEqual(node.widgets, [], "and left the node as it found it");
+});
+
+test("#757 boundary: an undo that THROWS never replaces the refusal that caused it", async () => {
+  const node = { id: 7, type: "KSampler", widgets: [] };
+  await assert.rejects(
+    () =>
+      runSetWidget(node, "made", "nope", {
+        registry: BOUNDARY_REGISTRY,
+        ...boundaryOracle,
+        prepareWriteTarget: () => {
+          node.widgets.push({ name: "made", type: "combo", options: { values: ["a"] }, value: "a" });
+          return {
+            undo: () => {
+              throw new Error("the undo itself blew up");
+            },
+          };
+        },
+      }),
+    /panel_set_widget refused "made"/,
+    "the caller hears why the WRITE was refused, not why the cleanup failed",
+  );
+});
+
+test("#757 boundary: nothing the hook made survives ACROSS the retry await", async () => {
+  // THE RULE, stated where it can actually be broken. The stale-combo recovery awaits
+  // `refreshCombos` between two write attempts. If the first attempt's creation were not
+  // undone before that await, a transient widget would sit in the live graph across a network
+  // request — the exact window that produced every P1 this feature has had. So the first
+  // attempt must roll back, the node must be EMPTY while the refresh is in flight, and the
+  // retry must mint it again from scratch.
+  const { node, widget, seen, prepareWriteTarget } = boundaryFixture({
+    name: "made",
+    type: "combo",
+    options: { values: ["a"] },
+    value: "a",
+  });
+  let widgetsDuringRefresh = null;
+  const res = await runSetWidget(node, "made", "b", {
+    registry: BOUNDARY_REGISTRY,
+    ...boundaryOracle,
+    prepareWriteTarget,
+    // The authoritative list now carries "b". Written through the captured widget rather than
+    // by looking it up on the node, BECAUSE the node no longer has it — the first attempt's
+    // rollback is exactly what this test is asserting.
+    refreshCombos: async () => {
+      widgetsDuringRefresh = node.widgets.map((w) => w.name);
+      await Promise.resolve();
+      widget.options.values.push("b");
+    },
+  });
+  assert.deepEqual(widgetsDuringRefresh, [], "no half-made target may sit in the graph across the await");
+  assert.equal(seen.undone, 1, "the first attempt rolled its creation back");
+  assert.equal(seen.prepared, 2, "and the retry minted it again inside its own synchronous stretch");
+  assert.equal(res.set.value, "b");
+  assert.equal(res.refreshed, true);
+});
+
+test("#757 the panel mints the row ONLY inside the write-boundary hook", () => {
+  // The regression that produced three separate P1s. A creation reached from the executor's
+  // OWN statements runs before `await runSetWidget(...)` and therefore before
+  // `await getFreshObjectInfo()` — a live graph mutation left sitting across a network
+  // request. Textual order cannot express that (the options object is written above the call
+  // it is passed to), so the rule is stated structurally instead: the single creation site
+  // lives inside `prepareWriteTarget`, which only runSetWidget's synchronous write boundary
+  // ever calls. Anything outside that hook is the old shape coming back.
+  const sw = PANEL_SRC.slice(PANEL_SRC.indexOf("async graph_set_widget("));
+  const body = sw.slice(0, sw.indexOf("async graph_remove_widget("));
+  assert.equal(body.split("createRgthreeLoraRow(").length - 1, 1, "exactly one creation site in the command");
+  const hookStart = body.indexOf("      prepareWriteTarget: () => {");
+  assert.notEqual(hookStart, -1, "could not locate the write-boundary hook");
+  const hookEnd = body.indexOf("\n      },", hookStart);
+  assert.ok(hookEnd > hookStart, "could not locate the end of the hook");
+  const hook = body.slice(hookStart, hookEnd);
+  assert.match(hook, /createRgthreeLoraRow\(node, widget, \{/, "the creation is inside the hook");
+  const outsideTheHook = body.slice(0, hookStart) + body.slice(hookEnd);
+  assert.ok(
+    !outsideTheHook.includes("createRgthreeLoraRow("),
+    "createRgthreeLoraRow may only be reached from prepareWriteTarget, never from the command's own flow",
+  );
 });
 
 test("#757 the created row is disclosed on its own field, not in `warning`", () => {
@@ -507,7 +761,6 @@ const EXECUTOR_DEPS = [
   "awaitObjectInfoHistorySeed",
   "isRgthreeLoraRowCreation",
   "createRgthreeLoraRow",
-  "noteRgthreeLoraRowWritten",
   "assertActiveWorkflowCommandTarget",
   "WORKFLOW_UUID_FIELD",
   "runSetWidget",
@@ -592,18 +845,33 @@ function trackedGraph(node) {
   return g;
 }
 
-/** Stands in for runSetWidget, including the beforeChange/afterChange pair it opens itself. */
+/**
+ * Stands in for runSetWidget, modelling the shape that matters: an AWAITED authorization
+ * phase, then a synchronous write boundary where `prepareWriteTarget` mints a missing target,
+ * the write runs inside its own beforeChange/afterChange pair, and a refusal undoes the
+ * preparation before it propagates.
+ */
 function stubRunSetWidget({ fail = null, result = { ok: true } } = {}) {
   const fn = async (n, widgetName, v, opts) => {
     fn.calls.push({ node: n, widget: widgetName, value: v });
+    await Promise.resolve(); // the /object_info fetch
+    // A preparation that REFUSES propagates from here without the write ever being attempted,
+    // exactly as it does in the real one (the hook is called before applyWidgetWrite's try).
+    const prepared = opts.prepareWriteTarget?.() ?? null;
+    fn.writes += 1;
     // The real one brackets its write and fires afterChange BEFORE the #240 read-back
     // verification that can still reject — so a refusal arrives with its own pair closed.
     opts.beforeChange?.();
     opts.afterChange?.();
-    if (fail) throw fail;
+    if (fail) {
+      prepared?.undo?.();
+      throw fail;
+    }
     return result;
   };
   fn.calls = [];
+  /** Write ATTEMPTS — the calls that got past `prepareWriteTarget`, not merely into the body. */
+  fn.writes = 0;
   return fn;
 }
 
@@ -616,11 +884,10 @@ function executor(node, overrides = {}) {
     classifyPromptRelayTimelineWrite: () => null,
     classifyRgthreeFastGroupsWrite: () => null,
     awaitObjectInfoHistorySeed: async () => {},
-    // The REAL classifier, creator and claim-release: a double here would let the executor
-    // pass against a route that never fires, which is precisely the defect under test.
+    // The REAL classifier and creator: a double here would let the executor pass against a
+    // route that never fires, which is precisely the defect under test.
     isRgthreeLoraRowCreation,
     createRgthreeLoraRow,
-    noteRgthreeLoraRowWritten,
     assertActiveWorkflowCommandTarget: () => {},
     WORKFLOW_UUID_FIELD: "workflow_uuid",
     runSetWidget: overrides.runSetWidget ?? stubRunSetWidget(),
@@ -657,19 +924,43 @@ test("#757 executor: create + assign is ONE undo step", async () => {
   assert.ok(graph.tracker.captures[0].includes("lora_1"), "and the one undo step covers the created row");
 });
 
+test("#757 executor: the row does not exist while the write is still awaiting", async () => {
+  // THE RULE THE WHOLE DESIGN RESTS ON. Creating the row before runSetWidget left a live
+  // graph mutation sitting across a network request, and all three of this feature's P1s
+  // came out of that one window: an undo transaction that could never be closed if the user
+  // switched tabs, a concurrent frame whose write got rolled back under it, and a user's own
+  // hand-edit exposed to an unrelated rollback. A row visible HERE is that window reopening.
+  const node = loader();
+  let rowDuringAwait = null;
+  const runSetWidget = async (n, w, v, opts) => {
+    rowDuringAwait = node.widgets.some((x) => x.name === "lora_1");
+    await Promise.resolve(); // the /object_info fetch
+    const prepared = opts.prepareWriteTarget?.() ?? null;
+    opts.beforeChange?.();
+    opts.afterChange?.();
+    assert.ok(prepared, "the creation happens at the write boundary, not before the call");
+    return { ok: true };
+  };
+  const { run } = executor(node, { runSetWidget });
+  const reply = await run({ node_id: 153, widget: "lora_1", value: SLOT_JSON, workflow_uuid: "u" });
+  assert.equal(rowDuringAwait, false, "no transient row may sit in the graph across the await");
+  assert.equal(reply.created_widget, "lora_1", "and it is created by the time the write runs");
+});
+
 test("#757 executor: a workflow switch during the await cannot wedge the undo history", async () => {
-  // THE REGRESSION THIS GUARDS IS WORSE THAN #757 ITSELF. LiteGraph delivers beforeChange /
-  // afterChange through ATTACHED canvases. Holding a transaction across the /object_info
-  // await means that if the user switches workflow tabs mid-flight, the close reaches no
-  // canvas at all and the tracker sits at 1 forever — `--this.changeCount || capture()` never
-  // returns to zero, so NO further edit in that workflow is ever captured for undo, for the
-  // rest of the session. Nothing in this command may open a transaction it then awaits across.
+  // LiteGraph delivers beforeChange / afterChange through ATTACHED canvases, so a
+  // transaction opened before the /object_info await and closed after it reaches no canvas
+  // at all once the user switches tabs — and the tracker then sits at 1 forever, so NO
+  // further edit in that workflow is ever captured for undo, for the rest of the session.
+  // Nothing in this command may open a transaction it awaits across.
   const node = loader();
   const graph = trackedGraph(node);
   const runSetWidget = async (n, w, v, opts) => {
     graph.detachCanvas(); // the user switched tabs while /object_info was in flight
+    const prepared = opts.prepareWriteTarget?.() ?? null;
     opts.beforeChange?.();
     opts.afterChange?.();
+    prepared?.undo?.();
     throw new Error("the workflow changed while this write was in flight");
   };
   const { run } = executor(node, { graph, runSetWidget });
@@ -679,6 +970,20 @@ test("#757 executor: a workflow switch during the await cannot wedge the undo hi
     0,
     "a tracker left above zero stops capturing undo snapshots for the whole session",
   );
+});
+
+test("#757 executor: a fence that refuses at the write boundary creates nothing", async () => {
+  // The creation sits behind runSetWidget's own workflow fence. If the user switched tabs
+  // during the fetch, the refusal must arrive over an untouched node.
+  const node = loader();
+  const before = node.widgets.map((w) => w.name);
+  const runSetWidget = async (n, w, v, opts) => {
+    await Promise.resolve();
+    throw new Error("the workflow changed"); // the fence fires before prepareWriteTarget
+  };
+  const { run } = executor(node, { runSetWidget });
+  await assert.rejects(() => run({ node_id: 153, widget: "lora_1", value: SLOT_JSON, workflow_uuid: "u" }));
+  assert.deepEqual(node.widgets.map((w) => w.name), before, "nothing was grown on the stale canvas");
 });
 
 test("#757 executor: a REFUSED write takes the row back out", async () => {
@@ -742,65 +1047,50 @@ test("#757 executor: creation that REFUSES opens no transaction, and never reach
   );
   assert.equal(graph.tracker.changeCount, 0, "an unclosed transaction would swallow the next command's undo entry");
   assert.deepEqual(graph.log, [], "a refusal that changed nothing has no bookkeeping to do");
-  assert.equal(runSetWidget.calls.length, 0, "the write is never attempted for a row that does not exist");
+  // runSetWidget IS entered now — the creation lives at its write boundary, so a refusal to
+  // create can only be raised from inside it. What must not happen is the WRITE: the refusal
+  // has to arrive before applyWidgetWrite, over a node nothing touched.
+  assert.equal(runSetWidget.calls.length, 1, "the refusal is raised from inside the call, at the write boundary");
+  assert.equal(runSetWidget.writes, 0, "the write is never attempted for a row that does not exist");
 });
 
-test("#757 executor: a CONCURRENT write's row is never rolled back under it", async () => {
-  // Command frames run concurrently. Request A mints lora_1 and parks in its write; request B
-  // arrives, sees a row that now exists, writes it and reports SUCCESS; A then fails. An
-  // unconditional rollback would delete the row B was just told it had written — a reported
-  // success that no longer matches the graph, which is worse than the stray row the rollback
-  // exists to prevent.
+test("#757 executor: two overlapping requests for the same missing row both come out right", async () => {
+  // Command frames run concurrently, and this used to be a P1: A minted the row and parked
+  // in its write, B saw a row that now existed and wrote it, and A's rollback then deleted
+  // the row B had been told it wrote. With both the creation and the write behind the same
+  // synchronous boundary, the interleaving that made that possible cannot occur — each
+  // request's create-and-write is uninterruptible, so exactly one of them creates.
   const node = loader();
-  let releaseA;
-  const parked = new Promise((_, reject) => {
-    releaseA = reject;
-  });
   const graph = trackedGraph(node);
-  const a = executor(node, {
-    graph,
-    runSetWidget: async (n, w, v, opts) => {
-      opts.beforeChange?.();
-      opts.afterChange?.();
-      return parked; // A is still in flight
-    },
-  });
-  const aDone = assert.rejects(
-    () => a.run({ node_id: 153, widget: "lora_1", value: SLOT_JSON, workflow_uuid: "u" }),
-    /A lost its race/,
-  );
-  await Promise.resolve(); // let A get as far as its await, with the row created
-
-  assert.ok(node.widgets.some((w) => w.name === "lora_1"), "A created the row");
-  // B: an ordinary write to a row that already exists. It must report success and keep it.
-  const b = executor(node, { graph });
-  const bReply = await b.run({ node_id: 153, widget: "lora_1", value: SLOT_JSON, workflow_uuid: "u" });
-  assert.equal(bReply.created_widget, undefined, "B did not create anything — the row was there");
-
-  releaseA(new Error("A lost its race"));
-  await aDone;
-  assert.ok(
-    node.widgets.some((w) => w.name === "lora_1"),
-    "B was told the write succeeded; A's rollback must not delete the row out from under it",
+  const request = () =>
+    executor(node, { graph }).run({ node_id: 153, widget: "lora_1", value: SLOT_JSON, workflow_uuid: "u" });
+  const [a, b] = await Promise.all([request(), request()]);
+  const created = [a, b].filter((r) => r.created_widget === "lora_1");
+  assert.equal(created.length, 1, "exactly one of the two created the row; the other wrote the existing one");
+  assert.equal(
+    node.widgets.filter((w) => w.name === "lora_1").length,
+    1,
+    "and the node carries exactly one lora_1, not a duplicate",
   );
 });
 
-test("#757 executor: a refused write that could NOT roll back still says the row exists", async () => {
-  // The other half of the concurrency rule: when the row survives because somebody else wrote
-  // it, the reply must not go on claiming nothing was created.
+test("#757 executor: a failing request cannot roll back a row the OTHER request wrote", async () => {
+  // The same interleaving, with the loser failing. Because the winner's create-and-write is
+  // synchronous and complete before the loser's boundary runs, the loser never created
+  // anything and so has nothing to undo — the surviving row belongs to the request that was
+  // told it succeeded.
   const node = loader();
   const graph = trackedGraph(node);
-  const { run } = executor(node, {
-    graph,
-    runSetWidget: async (n, w, v, opts) => {
-      opts.beforeChange?.();
-      opts.afterChange?.();
-      noteRgthreeLoraRowWritten(node, "lora_1"); // somebody else's write landed
-      throw new Error("this one still failed");
-    },
+  const ok = await executor(node, { graph }).run({
+    node_id: 153,
+    widget: "lora_1",
+    value: SLOT_JSON,
+    workflow_uuid: "u",
   });
-  await assert.rejects(() => run({ node_id: 153, widget: "lora_1", value: SLOT_JSON, workflow_uuid: "u" }));
-  assert.ok(node.widgets.some((w) => w.name === "lora_1"), "the claimed-by-someone-else row stays");
+  assert.equal(ok.created_widget, "lora_1");
+  const loser = executor(node, { graph, runSetWidget: stubRunSetWidget({ fail: new Error("too late") }) });
+  await assert.rejects(() => loser.run({ node_id: 153, widget: "lora_1", value: SLOT_JSON, workflow_uuid: "u" }));
+  assert.ok(node.widgets.some((w) => w.name === "lora_1"), "the successful request's row is still there");
 });
 
 test("#757 executor: the write is handed the row that was just created", async () => {

--- a/browser_tests/unit/rgthree-lora-row.test.mjs
+++ b/browser_tests/unit/rgthree-lora-row.test.mjs
@@ -22,8 +22,17 @@ import {
 
 const SLOT = { on: true, lora: "x.safetensors", strength: 0.5, strengthTwo: null };
 
-/** A Power Lora Loader as it looks fresh from panel_add_node: no rows yet. */
-function loader({ counter = 1, addNew = true, widgets = null } = {}) {
+/**
+ * A Power Lora Loader as it looks fresh from panel_add_node: no rows yet.
+ *
+ * Modelled on the pack's SHIPPED source (`rgthree-comfy/web/comfyui/power_lora_loader.js`),
+ * which increments `this.loraWidgetsCounter` and only then derives the row name from it: the
+ * increment happens first and is never undone by removing the row. `nextRow` says which row
+ * the next mint produces; the counter itself therefore starts one BELOW it.
+ *
+ * `trackCounter: false` stands in for a pack build that keeps no counter we can read.
+ */
+function loader({ nextRow = 1, addNew = true, widgets = null, trackCounter = true } = {}) {
   const node = {
     id: 153,
     type: POWER_LORA_LOADER_TYPE,
@@ -38,10 +47,15 @@ function loader({ counter = 1, addNew = true, widgets = null } = {}) {
       if (i >= 0) node.widgets.splice(i, 1);
     },
   };
+  let shadow = nextRow - 1; // used when the node exposes no readable counter
+  if (trackCounter) node.loraWidgetsCounter = nextRow - 1;
   if (addNew) {
     // rgthree's real behaviour: a MONOTONIC counter, so names are not positional.
     node.addNewLoraWidget = () => {
-      node.widgets.push({ name: `lora_${counter++}`, value: { on: true, lora: null, strength: 1, strengthTwo: null } });
+      let n;
+      if (trackCounter) n = ++node.loraWidgetsCounter;
+      else n = ++shadow;
+      node.widgets.push({ name: `lora_${n}`, value: { on: true, lora: null, strength: 1, strengthTwo: null } });
     };
   }
   return node;
@@ -155,7 +169,7 @@ test("#757 a MONOTONIC counter: the wrong row is taken back out and the real nam
   // rgthree's loraWidgetsCounter only ever increases, so after a row is removed the next
   // created row is NOT the removed name. A refusal that left the stray row behind could not
   // be safely retried.
-  const n = loader({ counter: 7 });
+  const n = loader({ nextRow: 7 });
   const before = n.widgets.length;
   assert.throws(
     () => createRgthreeLoraRow(n, "lora_1", {}),
@@ -165,8 +179,60 @@ test("#757 a MONOTONIC counter: the wrong row is taken back out and the real nam
   assert.ok(!n.widgets.some((w) => w.name === "lora_7"), "including the row it minted");
 });
 
+test("#757 the refusal's remedy actually WORKS — the row counter is rewound too", () => {
+  // The defect this pins: `addNewLoraWidget` increments the counter BEFORE it names the row,
+  // and removing the row does not undo the increment. Rolling back only the widget left a
+  // refusal that said `nothing was changed. Set "lora_7" instead` having already moved the
+  // next name to lora_8 — so obeying it refused again, one name further along, forever.
+  // Measured before it was fixed; this is the assertion that would have caught it.
+  const n = loader({ nextRow: 7 });
+  let named = null;
+  try {
+    createRgthreeLoraRow(n, "lora_1", {});
+    assert.fail("expected a refusal");
+  } catch (err) {
+    named = err.message.match(/next row is "(lora_\d+)"/)?.[1];
+    assert.match(err.message, /counter was rewound/);
+  }
+  assert.equal(named, "lora_7");
+  assert.equal(n.loraWidgetsCounter, 6, "the increment the refusal undid");
+  // Doing exactly what the refusal said must succeed. A remedy that cannot be obeyed is
+  // worse than no remedy: it reads as actionable and costs a row name on every attempt.
+  assert.deepEqual(createRgthreeLoraRow(n, named, {}), { created: "lora_7" });
+});
+
+test("#757 a call that adds nothing does not silently burn a row name either", () => {
+  const n = loader({ nextRow: 4 });
+  n.addNewLoraWidget = () => {
+    n.loraWidgetsCounter++; // incremented, then whatever appends the row failed
+  };
+  assert.throws(() => createRgthreeLoraRow(n, "lora_4", {}), /ran but added no widget/);
+  assert.equal(n.loraWidgetsCounter, 3, "'nothing was changed' includes the counter");
+});
+
+test("#757 a pack with no readable counter is told the truth, not an unusable remedy", () => {
+  // Nothing can be rewound here, so `lora_9` really is used up. Promising "set lora_9
+  // instead" would be advice that cannot work — name the state instead.
+  const n = loader({ nextRow: 9, trackCounter: false });
+  assert.throws(
+    () => createRgthreeLoraRow(n, "lora_2", {}),
+    /next row is "lora_9"[\s\S]*could not be rewound[\s\S]*"lora_9" is now used up/,
+  );
+  assert.ok(!("loraWidgetsCounter" in n), "no counter was invented on the node");
+});
+
+test("#757 the counter is NOT rewound while the stray row is still on the node", () => {
+  // Rewinding past a name a surviving row still holds would point the next mint at a
+  // duplicate — a worse outcome than the burnt name.
+  const n = loader({ nextRow: 5 });
+  n.removeWidget = () => {}; // a node that protects its rows
+  assert.throws(() => createRgthreeLoraRow(n, "lora_1", {}), /could not be rewound/);
+  assert.equal(n.loraWidgetsCounter, 5, "left alone, because lora_5 is still there");
+  assert.ok(n.widgets.some((w) => w.name === "lora_5"));
+});
+
 test("#757 the stray row is removed even on a node with no removeWidget method", () => {
-  const n = loader({ counter: 9 });
+  const n = loader({ nextRow: 9 });
   delete n.removeWidget;
   const before = n.widgets.length;
   assert.throws(() => createRgthreeLoraRow(n, "lora_2", {}), /next row is "lora_9"/);

--- a/browser_tests/unit/rgthree-lora-row.test.mjs
+++ b/browser_tests/unit/rgthree-lora-row.test.mjs
@@ -92,6 +92,68 @@ test("#757 a value that is not a lora slot never reaches it", () => {
   }
 });
 
+// ---------------------------------------------------------------------------
+// The shape the TOOL sends — a JSON string, not an object
+// ---------------------------------------------------------------------------
+//
+// This is the defect that made the whole route dead code, and the reason it survived the
+// first round of tests: `panel_set_widget` carries scalar values and `coerceWidgetValue`
+// parses the composite at widget-write.js:508-512, well AFTER this classifier runs. Every
+// test above hands in an OBJECT — the shape the tests chose, not the shape production uses.
+// So each of these drives the STRING form deliberately.
+
+test("#757 the value as the TOOL actually sends it — a JSON string — classifies", () => {
+  assert.equal(
+    isRgthreeLoraRowCreation(loader(), "lora_1", JSON.stringify(SLOT)),
+    true,
+    "this is the production shape; with it rejected the feature never fired at all",
+  );
+});
+
+test("#757 every slot spelling the writer accepts also classifies as a string", () => {
+  for (const slot of [
+    { on: true, lora: "x.safetensors", strength: 0.5, strengthTwo: null },
+    { on: false, lora: "nested/dir/y.safetensors", strength: 1, strengthTwo: 0.8 },
+    { on: true, lora: "z.safetensors", strength: 0 },
+  ]) {
+    const asString = JSON.stringify(slot);
+    assert.equal(
+      isRgthreeLoraRowCreation(loader(), "lora_1", asString),
+      isRgthreeLoraRowCreation(loader(), "lora_1", slot),
+      `the string and object forms must agree for ${asString}`,
+    );
+    assert.equal(isRgthreeLoraRowCreation(loader(), "lora_1", asString), true, asString);
+  }
+});
+
+test("#757 parsing does not WIDEN what counts as a slot", () => {
+  // The string form is normalized, not trusted. Anything whose PARSE is not a slot is still
+  // not a creation request — otherwise "any JSON string" would become a fourth way in, and
+  // the typo guard is only as strong as its narrowest fact.
+  for (const value of [
+    "not json at all",
+    "",
+    "null",
+    "5",
+    '"x.safetensors"',
+    "[]",
+    '{"on":true}',
+    '{"on":true,"lora":"a","strength":1,"extra":1}',
+    '{"on":true,"lora":"a","strength":1,"strengthTwo":null,',
+  ]) {
+    assert.equal(isRgthreeLoraRowCreation(loader(), "lora_1", value), false, `value ${JSON.stringify(value)}`);
+  }
+});
+
+test("#757 a STRING value does not bypass the other two facts either", () => {
+  const asString = JSON.stringify(SLOT);
+  assert.equal(isRgthreeLoraRowCreation({ ...loader(), type: "LoraLoader" }, "lora_1", asString), false, "wrong type");
+  assert.equal(isRgthreeLoraRowCreation(loader(), "strenght", asString), false, "typo name");
+  const existing = loader();
+  existing.widgets.push({ name: "lora_1", value: { on: false, lora: null, strength: 1, strengthTwo: null } });
+  assert.equal(isRgthreeLoraRowCreation(existing, "lora_1", asString), false, "row already present");
+});
+
 test("#757 an EXISTING row is left to the ordinary write path", () => {
   const n = loader();
   n.widgets.push({ name: "lora_1", value: { on: false, lora: null, strength: 1, strengthTwo: null } });
@@ -120,7 +182,8 @@ test("#757 the reported case: the row is created and named", () => {
     afterChange: () => events.push("after"),
     setDirty: () => events.push("dirty"),
   });
-  assert.deepEqual(r, { created: "lora_1" });
+  assert.equal(r.created, "lora_1");
+  assert.equal(typeof r.remove, "function", "the caller must be able to take the row back out again");
   assert.ok(n.widgets.some((w) => w.name === "lora_1"), "the row now exists for the write that follows");
   assert.deepEqual(events, ["before", "after", "dirty"], "the mutation is bracketed for undo");
 });
@@ -198,7 +261,7 @@ test("#757 the refusal's remedy actually WORKS — the row counter is rewound to
   assert.equal(n.loraWidgetsCounter, 6, "the increment the refusal undid");
   // Doing exactly what the refusal said must succeed. A remedy that cannot be obeyed is
   // worse than no remedy: it reads as actionable and costs a row name on every attempt.
-  assert.deepEqual(createRgthreeLoraRow(n, named, {}), { created: "lora_7" });
+  assert.equal(createRgthreeLoraRow(n, named, {}).created, "lora_7");
 });
 
 test("#757 a call that adds nothing does not silently burn a row name either", () => {
@@ -241,12 +304,67 @@ test("#757 the stray row is removed even on a node with no removeWidget method",
 
 test("#757 consecutive creates work: lora_1 then lora_2", () => {
   const n = loader();
-  assert.deepEqual(createRgthreeLoraRow(n, "lora_1", {}), { created: "lora_1" });
-  assert.deepEqual(createRgthreeLoraRow(n, "lora_2", {}), { created: "lora_2" });
+  assert.equal(createRgthreeLoraRow(n, "lora_1", {}).created, "lora_1");
+  assert.equal(createRgthreeLoraRow(n, "lora_2", {}).created, "lora_2");
   assert.deepEqual(
     n.widgets.map((w) => w.name).filter((x) => x.startsWith("lora_")),
     ["lora_1", "lora_2"],
   );
+});
+
+// ---------------------------------------------------------------------------
+// `remove` — the undo the caller needs when the write it made room for refuses
+// ---------------------------------------------------------------------------
+
+test("#757 remove() takes the created row back out", () => {
+  const n = loader();
+  const before = n.widgets.map((w) => w.name);
+  createRgthreeLoraRow(n, "lora_1", {}).remove();
+  assert.deepEqual(n.widgets.map((w) => w.name), before, "the node is back to what it was");
+});
+
+test("#757 remove() rewinds the row counter as well as the row", () => {
+  // The same trap the mismatch refusal hit: addNewLoraWidget increments BEFORE it names, so
+  // dropping only the widget leaves the number spent and the next mint lands further along.
+  // A rolled-back write must not cost the node a row name.
+  const n = loader({ nextRow: 1 });
+  assert.equal(n.loraWidgetsCounter, 0);
+  createRgthreeLoraRow(n, "lora_1", {}).remove();
+  assert.equal(n.loraWidgetsCounter, 0, "the increment the rollback undid");
+  // And the proof that it matters: the next create must be able to mint lora_1 again.
+  assert.equal(createRgthreeLoraRow(n, "lora_1", {}).created, "lora_1");
+});
+
+test("#757 remove() will not rewind past a row that is still there", () => {
+  // Rewinding while the name is still held would point the next mint at a duplicate.
+  const n = loader({ nextRow: 3 });
+  const made = createRgthreeLoraRow(n, "lora_3", {});
+  n.removeWidget = () => {}; // a node that refuses to give the row up
+  made.remove();
+  assert.equal(n.loraWidgetsCounter, 3, "left alone, because lora_3 survived");
+  assert.ok(n.widgets.some((w) => w.name === "lora_3"));
+});
+
+test("#757 remove() targets the row BY IDENTITY, not by name", () => {
+  // rgthree's configure() re-mints rows from serialized order, so `lora_1` after an undo is
+  // not necessarily the widget this call grew. Removing by name would take out a stranger.
+  const n = loader();
+  const made = createRgthreeLoraRow(n, "lora_1", {});
+  const mine = n.widgets.find((w) => w.name === "lora_1");
+  n.widgets = n.widgets.filter((w) => w !== mine);
+  const impostor = { name: "lora_1", value: { on: true, lora: "someone-elses.safetensors", strength: 1 } };
+  n.widgets.push(impostor);
+  made.remove();
+  assert.ok(n.widgets.includes(impostor), "the row that answers to the name now is not ours to remove");
+});
+
+test("#757 remove() never throws, whatever the node does", () => {
+  const n = loader();
+  const made = createRgthreeLoraRow(n, "lora_1", {});
+  n.removeWidget = () => {
+    throw new Error("disposed");
+  };
+  assert.doesNotThrow(() => made.remove(), "an undo on an error path must not replace the refusal");
 });
 
 // ---------------------------------------------------------------------------
@@ -261,7 +379,7 @@ test("#757 creation runs AFTER the history seed and BEFORE runSetWidget", () => 
   // mutation: it must not happen on a call authorization is about to refuse.
   const seed = PANEL_SRC.indexOf("await awaitObjectInfoHistorySeed();", PANEL_SRC.indexOf("async graph_set_widget("));
   const create = PANEL_SRC.indexOf("createRgthreeLoraRow(node, widget, {");
-  const run = PANEL_SRC.indexOf("const result = await runSetWidget(");
+  const run = PANEL_SRC.indexOf("await runSetWidget(");
   assert.ok(seed > 0 && create > seed, "creation is after the history seed");
   assert.ok(run > create, "…and before the write");
 });
@@ -280,4 +398,230 @@ test("#757 the created row is disclosed on its own field, not in `warning`", () 
   const sw = PANEL_SRC.slice(PANEL_SRC.indexOf("async graph_set_widget("));
   const body = sw.slice(0, sw.indexOf("async graph_remove_widget("));
   assert.ok(!/warning:[^\n]*createdLoraRow/.test(body), "it must not displace a warning about the write");
+});
+
+// ---------------------------------------------------------------------------
+// The executor itself — the SHIPPED method, extracted and run
+// ---------------------------------------------------------------------------
+//
+// Source-text assertions cannot answer the two questions review actually asked: does a
+// REFUSED write leave the row behind, and is create+assign ONE undo step? Both are about
+// what happens at runtime across a rejected await. So the real `graph_set_widget` is pulled
+// out of the panel and run against doubles, the way graph-edit-node.test.mjs does — the
+// implementation is verified, never a copy of it.
+
+const SET_WIDGET_SRC = (() => {
+  const m = PANEL_SRC.match(/ {2}async graph_set_widget\(\{ node_id, widget, value, workflow_uuid \}\) \{[\s\S]*?\n {2}\},/);
+  assert.ok(m, "could not locate graph_set_widget in the panel source");
+  return m[0];
+})();
+
+/** Every free name the extracted method can reach. Injected, so nothing resolves to a global. */
+const EXECUTOR_DEPS = [
+  "getGraphCtx",
+  "resolveNode",
+  "classifyLtxTimelineWrite",
+  "derivedTimelineRefusal",
+  "applyLtxTimelineWrite",
+  "classifyPromptRelayTimelineWrite",
+  "promptRelayDerivedRefusal",
+  "applyPromptRelayTimelineWrite",
+  "classifyRgthreeFastGroupsWrite",
+  "rgthreeFastGroupsRefusal",
+  "awaitObjectInfoHistorySeed",
+  "isRgthreeLoraRowCreation",
+  "createRgthreeLoraRow",
+  "assertActiveWorkflowCommandTarget",
+  "WORKFLOW_UUID_FIELD",
+  "runSetWidget",
+  "objectInfoCache",
+  "CACHE_OUTCOME",
+  "fetchWholeObjectInfo",
+  "api",
+  "backendReconnectEpoch",
+  "objectInfoSnapshot",
+  "recordObjectInfoTypes",
+  "objectInfoOracleFailureNote",
+  "comfyBackendSocketDown",
+  "objectInfoHistory",
+  "sourceForSubgraphInput",
+  "refreshComboOptionsFromDefs",
+  "refreshComfyNodeDefs",
+  "clearStaleRedFlag",
+  "snapshotAuthorizationNote",
+];
+
+/**
+ * A graph that keeps score the way ComfyUI's ChangeTracker does.
+ *
+ * Verified against the shipped frontend bundle: `beforeChange(){this.changeCount++}` and
+ * `afterChange(){--this.changeCount||this.captureCanvasState()}`, reached from
+ * `LGraph.beforeChange` via `canvasAction(c => c.onBeforeChange?.(this))`. So nested pairs
+ * collapse into ONE captured state — and an unmatched close drives the count to -1, which is
+ * truthy, so the capture never fires and the command vanishes from undo history entirely.
+ * That second failure mode is why `afterChange` here throws rather than going negative.
+ */
+function trackedGraph(node) {
+  const g = {
+    node,
+    changeCount: 0,
+    /** One entry per undo step the tracker would record: the widget names at that moment. */
+    captures: [],
+    log: [],
+    beforeChange() {
+      g.log.push("before");
+      g.changeCount += 1;
+    },
+    afterChange() {
+      g.log.push("after");
+      g.changeCount -= 1;
+      if (g.changeCount < 0) {
+        throw new Error("afterChange() without a matching beforeChange() — the undo entry would be lost");
+      }
+      if (g.changeCount === 0) g.captures.push(g.node.widgets.map((w) => w.name));
+    },
+    setDirtyCanvas() {
+      g.log.push("dirty");
+    },
+  };
+  return g;
+}
+
+/** Stands in for runSetWidget, including the beforeChange/afterChange pair it opens itself. */
+function stubRunSetWidget({ fail = null, result = { ok: true } } = {}) {
+  const fn = async (n, widgetName, v, opts) => {
+    fn.calls.push({ node: n, widget: widgetName, value: v });
+    // The real one brackets its write and fires afterChange BEFORE the #240 read-back
+    // verification that can still reject — so a refusal arrives with its own pair closed.
+    opts.beforeChange?.();
+    opts.afterChange?.();
+    if (fail) throw fail;
+    return result;
+  };
+  fn.calls = [];
+  return fn;
+}
+
+function executor(node, overrides = {}) {
+  const graph = overrides.graph ?? trackedGraph(node);
+  const deps = {
+    getGraphCtx: () => ({ app: { canvas: null }, graph, LG: { registered_node_types: {} }, rootGraph: graph }),
+    resolveNode: () => node,
+    classifyLtxTimelineWrite: () => null,
+    classifyPromptRelayTimelineWrite: () => null,
+    classifyRgthreeFastGroupsWrite: () => null,
+    awaitObjectInfoHistorySeed: async () => {},
+    // The REAL classifier and the REAL creator: a double here would let the executor pass
+    // against a route that never fires, which is precisely the defect under test.
+    isRgthreeLoraRowCreation,
+    createRgthreeLoraRow,
+    assertActiveWorkflowCommandTarget: () => {},
+    WORKFLOW_UUID_FIELD: "workflow_uuid",
+    runSetWidget: overrides.runSetWidget ?? stubRunSetWidget(),
+    clearStaleRedFlag: () => {},
+    objectInfoHistory: { wasTypeEverDefined: () => true },
+    ...overrides,
+  };
+  const factory = new Function(
+    ...EXECUTOR_DEPS,
+    `const GRAPH_TOOL_EXECUTORS = { ${SET_WIDGET_SRC} }; return GRAPH_TOOL_EXECUTORS.graph_set_widget;`,
+  );
+  const run = factory(...EXECUTOR_DEPS.map((name) => deps[name]));
+  return { run, graph, runSetWidget: deps.runSetWidget };
+}
+
+/** The production value shape: a JSON string, not an object. */
+const SLOT_JSON = JSON.stringify(SLOT);
+
+test("#757 executor: create + assign is ONE undo step", async () => {
+  const node = loader();
+  const { run, graph } = executor(node);
+  const reply = await run({ node_id: 153, widget: "lora_1", value: SLOT_JSON, workflow_uuid: "u" });
+  assert.equal(reply.created_widget, "lora_1", "the structural change is disclosed");
+  assert.ok(node.widgets.some((w) => w.name === "lora_1"));
+  assert.equal(graph.changeCount, 0, "the transaction is balanced");
+  assert.equal(
+    graph.captures.length,
+    1,
+    "two captures would be two Ctrl+Z, the first of which leaves a default row behind",
+  );
+  assert.ok(graph.captures[0].includes("lora_1"), "and the one undo step covers the created row");
+});
+
+test("#757 executor: a REFUSED write takes the row back out", async () => {
+  // runSetWidget can still refuse after the row exists — a removed pack, invalid slot fields,
+  // a workflow switched mid-await, the #240 read-back rollback. Reporting that over a graph
+  // this command had already grown is mutate-then-refuse, and every retry adds another row.
+  const node = loader();
+  const before = node.widgets.map((w) => w.name);
+  const refusal = new Error("value is not a valid option");
+  const { run, graph } = executor(node, { runSetWidget: stubRunSetWidget({ fail: refusal }) });
+  await assert.rejects(
+    () => run({ node_id: 153, widget: "lora_1", value: SLOT_JSON, workflow_uuid: "u" }),
+    /value is not a valid option/,
+    "the refusal reaches the caller unchanged",
+  );
+  assert.deepEqual(node.widgets.map((w) => w.name), before, "and the node is back to what it was");
+});
+
+test("#757 executor: a refused write rewinds the row counter too", async () => {
+  // The counter is the half of the mutation that is easy to miss: addNewLoraWidget increments
+  // BEFORE it names the row, so removing the widget alone still spends the name and the next
+  // attempt lands on lora_2 — the retry loop the mismatch refusal already had to fix.
+  const node = loader({ nextRow: 1 });
+  assert.equal(node.loraWidgetsCounter, 0);
+  const { run } = executor(node, { runSetWidget: stubRunSetWidget({ fail: new Error("nope") }) });
+  await assert.rejects(() => run({ node_id: 153, widget: "lora_1", value: SLOT_JSON, workflow_uuid: "u" }));
+  assert.equal(node.loraWidgetsCounter, 0, "the refused attempt cost the node nothing");
+  // The retry the caller will actually make must now succeed under the SAME name.
+  const second = executor(node);
+  const reply = await second.run({ node_id: 153, widget: "lora_1", value: SLOT_JSON, workflow_uuid: "u" });
+  assert.equal(reply.created_widget, "lora_1", "retrying the same request works, rather than drifting to lora_2");
+});
+
+test("#757 executor: a refused write leaves NO undo step to step through", async () => {
+  const node = loader();
+  const before = node.widgets.map((w) => w.name);
+  const { run, graph } = executor(node, { runSetWidget: stubRunSetWidget({ fail: new Error("nope") }) });
+  await assert.rejects(() => run({ node_id: 153, widget: "lora_1", value: SLOT_JSON, workflow_uuid: "u" }));
+  assert.equal(graph.changeCount, 0, "the transaction is closed exactly once, even on the error path");
+  assert.equal(graph.captures.length, 1, "closed once — not zero times, and not twice");
+  assert.deepEqual(
+    graph.captures[0],
+    before,
+    "and the state it captured is the state the command started from, so nothing is recorded",
+  );
+});
+
+test("#757 executor: an ordinary write opens no transaction of its own", async () => {
+  // Everything that is not a creation must be untouched by this route — including the undo
+  // bookkeeping, which runSetWidget owns on that path.
+  const node = loader();
+  node.widgets.push({ name: "lora_1", value: { on: false, lora: null, strength: 1, strengthTwo: null } });
+  const { run, graph } = executor(node);
+  const reply = await run({ node_id: 153, widget: "lora_1", value: SLOT_JSON, workflow_uuid: "u" });
+  assert.equal(reply.created_widget, undefined, "nothing was created, so nothing is disclosed");
+  assert.deepEqual(graph.log, ["before", "after"], "exactly one pair, and it is runSetWidget's");
+  assert.equal(graph.captures.length, 1);
+});
+
+test("#757 executor: creation that REFUSES closes its transaction and never reaches the write", async () => {
+  const node = loader({ addNew: false }); // a pack build with no addNewLoraWidget
+  const { run, graph, runSetWidget } = executor(node);
+  await assert.rejects(
+    () => run({ node_id: 153, widget: "lora_1", value: SLOT_JSON, workflow_uuid: "u" }),
+    /does not expose addNewLoraWidget/,
+  );
+  assert.equal(graph.changeCount, 0, "an unclosed transaction would swallow the next command's undo entry");
+  assert.equal(graph.captures.length, 1, "closed exactly once");
+  assert.equal(runSetWidget.calls.length, 0, "the write is never attempted for a row that does not exist");
+});
+
+test("#757 executor: the write is handed the row that was just created", async () => {
+  const node = loader();
+  const { run, runSetWidget } = executor(node);
+  await run({ node_id: 153, widget: "lora_1", value: SLOT_JSON, workflow_uuid: "u" });
+  assert.equal(runSetWidget.calls.length, 1);
+  assert.equal(runSetWidget.calls[0].widget, "lora_1");
+  assert.equal(runSetWidget.calls[0].value, SLOT_JSON, "the value is passed through untouched, string and all");
 });

--- a/browser_tests/unit/rgthree-lora-row.test.mjs
+++ b/browser_tests/unit/rgthree-lora-row.test.mjs
@@ -553,6 +553,216 @@ test("#757 remove() reports a row it could not take back out", () => {
 });
 
 // ---------------------------------------------------------------------------
+// THE SETTLING PERIOD — a new row is not an existing row until it has been drawn
+// ---------------------------------------------------------------------------
+//
+// The widget below is modelled on the SHIPPED one, because the defect lives entirely in the
+// gap between construction and the first draw:
+//
+//   constructor:    this.showModelAndClip = null;
+//   draw:           this.showModelAndClip =
+//                     node.properties["Show Strengths"] === "Separate Model & Clip";
+//   serializeValue: const v = {...this.value};
+//                   if (!this.showModelAndClip) delete v.strengthTwo;
+//                   else { this.value.strengthTwo = this.value.strengthTwo ?? 1; … }
+//
+// `null` is falsy, so an UNDRAWN row serializes down the first branch and quietly drops
+// strengthTwo. A human never meets this — clicking "➕ Add Lora" repaints before they touch
+// anything. An agent creating and writing in one synchronous command does.
+
+/** The pack's row widget, with the two behaviours that matter reproduced verbatim. */
+function powerLoraRowWidget(name) {
+  return {
+    name,
+    showModelAndClip: null, // set only by draw()
+    value: { on: true, lora: null, strength: 1, strengthTwo: null },
+    serializeValue() {
+      const v = { ...this.value };
+      if (!this.showModelAndClip) {
+        delete v.strengthTwo;
+      } else {
+        this.value.strengthTwo = this.value.strengthTwo ?? 1; // MUTATES the live value
+        v.strengthTwo = this.value.strengthTwo;
+      }
+      return v;
+    },
+  };
+}
+
+function powerLoraNode({ separate = false, drawnRows = [] } = {}) {
+  const node = {
+    id: 153,
+    type: POWER_LORA_LOADER_TYPE,
+    properties: { "Show Strengths": separate ? "Separate Model & Clip" : "Single Strength" },
+    widgets: [{ name: "divider" }, { name: "PowerLoraLoaderHeaderWidget" }, { name: "divider" }, { name: "➕ Add Lora" }],
+    loraWidgetsCounter: 0,
+    size: [200, 60],
+    computeSize: () => [200, 60 + 20 * node.widgets.filter((w) => /^lora_\d+$/.test(w?.name ?? "")).length],
+    removeWidget(w) {
+      const i = node.widgets.indexOf(w);
+      if (i >= 0) node.widgets.splice(i, 1);
+    },
+    addNewLoraWidget() {
+      node.widgets.push(powerLoraRowWidget(`lora_${++node.loraWidgetsCounter}`));
+    },
+  };
+  for (const name of drawnRows) {
+    node.addNewLoraWidget();
+    // An existing row has been drawn at least once, so its mode is already synchronised.
+    node.widgets.at(-1).showModelAndClip = separate;
+  }
+  return node;
+}
+
+const LORA_REGISTRY = { [POWER_LORA_LOADER_TYPE]: {} };
+const loraOracle = { getFreshObjectInfo: async () => ({ [POWER_LORA_LOADER_TYPE]: {} }) };
+
+/**
+ * Drive the REAL runSetWidget over the fixture, with a capture that SERIALIZES.
+ *
+ * ChangeTracker captures by serializing the graph, which is what runs each widget's
+ * `serializeValue` — so a probe that does not serialize cannot see this class of defect at all.
+ */
+async function loraWriteThrough(node, { create }) {
+  let depth = 0;
+  const serializeAll = () => {
+    for (const w of node.widgets) {
+      try {
+        w.serializeValue?.(node, 0);
+      } catch {
+        /* the capture swallows a widget that cannot serialize */
+      }
+    }
+  };
+  const opts = {
+    registry: LORA_REGISTRY,
+    ...loraOracle,
+    beforeChange: () => {
+      depth += 1;
+    },
+    afterChange: () => {
+      depth -= 1;
+      if (depth === 0) serializeAll();
+    },
+    ...(create
+      ? {
+          prepareWriteTarget: () => {
+            const made = createRgthreeLoraRow(node, "lora_1", {});
+            return { undo: () => made.remove().incomplete };
+          },
+        }
+      : {}),
+  };
+  try {
+    return { ok: true, result: await runSetWidget(node, "lora_1", SLOT_JSON, opts) };
+  } catch (err) {
+    return { ok: false, message: err.message };
+  }
+}
+
+test("#757 a Separate Model & Clip CREATION reports what an existing-row write reports", async () => {
+  // ROUND-7 P1, and the invariant the whole feature is judged on. In Separate mode the pack's
+  // serializeValue rewrites `strengthTwo: null` to 1 during the capture — before the write is
+  // verified — so an EXISTING-row write is refused for a value that did not stick. A newly
+  // created row, still undrawn, took the other branch and silently dropped strengthTwo, so the
+  // write verified clean and the value changed at the NEXT queue or save instead.
+  const created = await loraWriteThrough(powerLoraNode({ separate: true }), { create: true });
+  const existing = await loraWriteThrough(powerLoraNode({ separate: true, drawnRows: ["lora_1"] }), { create: false });
+  assert.equal(
+    created.ok,
+    existing.ok,
+    `creation reported ok=${created.ok} where an existing row reported ok=${existing.ok}`,
+  );
+  assert.equal(created.ok, false, "the pack overrides strengthTwo in this mode, so both must refuse");
+  assert.match(created.message, /did not retain the requested value/);
+  assert.match(existing.message, /did not retain the requested value/);
+});
+
+test("#757 a Single Strength creation still SUCCEEDS — the originally reported case", async () => {
+  // The other side of the settle: getting the mode wrong in this direction would refuse the
+  // very case #757 exists to fix, because the pack drops strengthTwo from the serialized form
+  // here by design and touches nothing.
+  const node = powerLoraNode({ separate: false });
+  const created = await loraWriteThrough(node, { create: true });
+  assert.equal(created.ok, true, created.message);
+  const row = node.widgets.find((w) => w.name === "lora_1");
+  assert.equal(row.value.lora, "x.safetensors", "and the requested value is on the row");
+  assert.equal(row.value.strengthTwo, null, "untouched, because this mode does not use it");
+});
+
+test("#757 the created row is settled to the SAME mode an existing row has", async () => {
+  for (const separate of [true, false]) {
+    const node = powerLoraNode({ separate });
+    createRgthreeLoraRow(node, "lora_1", {});
+    const row = node.widgets.find((w) => w.name === "lora_1");
+    assert.equal(row.showModelAndClip, separate, `mode ${separate} must be synchronised at creation`);
+  }
+});
+
+test("#757 a pack build with no such mode is left exactly as it was", () => {
+  // `showModelAndClip` ABSENT (not merely null) is an older/other build with nothing to settle.
+  // Inventing the field would hand its serializeValue a branch it never had.
+  const node = powerLoraNode({ separate: true });
+  node.addNewLoraWidget = () => {
+    const w = powerLoraRowWidget(`lora_${++node.loraWidgetsCounter}`);
+    delete w.showModelAndClip;
+    node.widgets.push(w);
+  };
+  createRgthreeLoraRow(node, "lora_1", {});
+  const row = node.widgets.find((w) => w.name === "lora_1");
+  assert.ok(!("showModelAndClip" in row), "no field was invented on a build that does not have one");
+});
+
+test("#757 an unreadable node leaves the row as the pack made it, without throwing", () => {
+  const node = powerLoraNode({ separate: true });
+  Object.defineProperty(node, "properties", {
+    get() {
+      throw new Error("properties is hostile");
+    },
+    configurable: true,
+  });
+  assert.doesNotThrow(() => createRgthreeLoraRow(node, "lora_1", {}));
+  assert.equal(node.widgets.find((w) => w.name === "lora_1").showModelAndClip, null, "left untouched");
+});
+
+test("#757 a throwing setDirty does not strand the row (round-7 P2)", () => {
+  // The repaint hint is cosmetic, exactly as the resize is. What must NOT happen is the
+  // creation failing after the row, the row NAME and the height are already committed, with
+  // the caller holding no handle to undo any of it.
+  const node = powerLoraNode({ separate: false });
+  const made = createRgthreeLoraRow(node, "lora_1", {
+    setDirty: () => {
+      throw new Error("setDirtyCanvas blew up");
+    },
+  });
+  assert.equal(made.created, "lora_1", "a cosmetic failure is not a gate");
+  assert.ok(node.widgets.some((w) => w.name === "lora_1"));
+});
+
+test("#757 anything else that throws in the tail rolls the creation back (round-7 P2)", () => {
+  // `remove` is only handed back at the END of the helper, and runSetWidget evaluates the whole
+  // preparation BEFORE entering the try that would clean up — so a throw in the tail had no
+  // undo available anywhere and stranded the row, its name and the grown height.
+  const node = powerLoraNode({ separate: true });
+  const sizeBefore = [...node.size];
+  node.addNewLoraWidget = () => {
+    const w = powerLoraRowWidget(`lora_${++node.loraWidgetsCounter}`);
+    Object.defineProperty(w, "showModelAndClip", {
+      get: () => null,
+      set: () => {
+        throw new Error("this widget refuses the mode");
+      },
+      configurable: true,
+    });
+    node.widgets.push(w);
+  };
+  assert.throws(() => createRgthreeLoraRow(node, "lora_1", {}), /refuses the mode/);
+  assert.ok(!node.widgets.some((w) => w.name === "lora_1"), "the row was taken back out");
+  assert.equal(node.loraWidgetsCounter, 0, "and the name it spent was returned");
+  assert.deepEqual([...node.size], sizeBefore, "and the height it grew was put back");
+});
+
+// ---------------------------------------------------------------------------
 // The panel wiring
 // ---------------------------------------------------------------------------
 

--- a/browser_tests/unit/rgthree-lora-row.test.mjs
+++ b/browser_tests/unit/rgthree-lora-row.test.mjs
@@ -477,6 +477,59 @@ test("#757 remove() never throws, whatever the node does", () => {
   assert.doesNotThrow(() => made.remove(), "an undo on an error path must not replace the refusal");
 });
 
+test("#757 remove() reports a rollback it completed as clean", () => {
+  // The other side of the rule below — the honest "nothing is left over" must stay reachable,
+  // or every refused write would start carrying a scary sentence it has not earned.
+  const n = loader({ nextRow: 1 });
+  const undone = createRgthreeLoraRow(n, "lora_1", {}).remove();
+  assert.equal(undone.removed, true);
+  assert.equal(undone.incomplete, null, "row gone and counter back — there is nothing to disclose");
+});
+
+test("#757 remove() DISCLOSES a row name it could not give back", () => {
+  // A pack that exposes addNewLoraWidget but hides its counter. The row goes back out, but
+  // the NAME stays spent — and a caller told only that its value was invalid will retry the
+  // same lora_1, mint a later row and be refused a second time on the name instead.
+  const n = loader({ nextRow: 1, trackCounter: false });
+  const undone = createRgthreeLoraRow(n, "lora_1", {}).remove();
+  assert.equal(undone.removed, true, "the row itself did go");
+  assert.match(undone.incomplete, /row counter could not be read, so that name is used up/);
+  assert.match(undone.incomplete, /asking for "lora_1" again will create a differently-named row/);
+});
+
+test("#757 remove() discloses a FROZEN counter too, not just an unreadable one", () => {
+  // Readable but unwritable — the assignment is swallowed, so the rewind silently did not
+  // happen. Asking the NODE afterwards is what tells the two apart from a real rewind.
+  const n = loader({ nextRow: 1 });
+  const made = createRgthreeLoraRow(n, "lora_1", {});
+  let frozen = n.loraWidgetsCounter;
+  Object.defineProperty(n, "loraWidgetsCounter", { get: () => frozen, set: () => {}, configurable: true });
+  const undone = made.remove();
+  assert.equal(undone.removed, true);
+  assert.match(undone.incomplete, /could not be rewound, so that name is used up/);
+});
+
+test("#757 remove() discloses a name spent because SOMEBODY ELSE advanced the counter", () => {
+  // The round-2 rule stands — winding back past another row's increment would re-issue names
+  // that are taken — but declining to rewind still leaves this call's name spent, and the
+  // caller has to hear that rather than be told the rollback was clean.
+  const n = loader({ nextRow: 1 });
+  const made = createRgthreeLoraRow(n, "lora_1", {});
+  n.addNewLoraWidget(); // an unrelated addition while our write was in flight
+  const undone = made.remove();
+  assert.equal(n.loraWidgetsCounter, 2, "still not rewound past the row that is not ours");
+  assert.match(undone.incomplete, /could not be rewound, so that name is used up/);
+});
+
+test("#757 remove() reports a row it could not take back out", () => {
+  const n = loader({ nextRow: 1 });
+  const made = createRgthreeLoraRow(n, "lora_1", {});
+  n.removeWidget = () => {}; // a node that refuses to give the row up
+  const undone = made.remove();
+  assert.equal(undone.removed, false);
+  assert.match(undone.incomplete, /could not be removed again and is still on the node/);
+});
+
 // ---------------------------------------------------------------------------
 // The panel wiring
 // ---------------------------------------------------------------------------
@@ -663,6 +716,150 @@ test("#757 boundary: an undo that THROWS never replaces the refusal that caused 
     /panel_set_widget refused "made"/,
     "the caller hears why the WRITE was refused, not why the cleanup failed",
   );
+});
+
+/**
+ * ChangeTracker's counting rule, which is the whole reason the outer envelope matters:
+ *
+ *   `beforeChange(){ this.changeCount++ }`
+ *   `afterChange(){ --this.changeCount || this.captureCanvasState() }`
+ *
+ * A close that reaches ZERO captures. So nested envelopes yield ONE capture, at the outermost
+ * close — and whatever the graph looks like at that moment is what the undo history gets.
+ */
+function historyProbe(node) {
+  const probe = {
+    depth: 0,
+    captures: [],
+    beforeChange: () => {
+      probe.depth += 1;
+    },
+    afterChange: () => {
+      probe.depth -= 1;
+      if (probe.depth < 0) throw new Error("afterChange() without a matching beforeChange()");
+      if (probe.depth === 0) probe.captures.push(node.widgets.map((w) => w.name));
+    },
+  };
+  return probe;
+}
+
+test("#757 boundary: a POST-ASSIGNMENT refusal captures no history with the row still in it", async () => {
+  // ROUND-4 P2. applyWidgetWrite closes its own envelope BEFORE the #240 read-back verifies,
+  // and rolls a bad value back in an envelope of its own — so a value the widget's setter
+  // normalizes away is refused only after up to two captures have already been taken. Without
+  // an outer envelope those captures hold the created row and the rejected value, and the
+  // cleanup then removes the row with nothing open and nothing captured: the tracker's newest
+  // snapshot is a graph that no longer exists, and the next Ctrl+Z restores the very command
+  // that was refused. A refusal has to be a no-op in the undo history too.
+  const node = { id: 7, type: "KSampler", widgets: [] };
+  // A widget that ACCEPTS the assignment and keeps its old value — the read-back rejects it
+  // after the write envelope has already closed.
+  const swallowing = { name: "made", type: "text", get value() { return ""; }, set value(_v) {} };
+  const probe = historyProbe(node);
+  let undone = 0;
+  await assert.rejects(
+    () =>
+      runSetWidget(node, "made", "hello", {
+        registry: BOUNDARY_REGISTRY,
+        ...boundaryOracle,
+        beforeChange: probe.beforeChange,
+        afterChange: probe.afterChange,
+        prepareWriteTarget: () => {
+          node.widgets.push(swallowing);
+          return {
+            undo: () => {
+              undone += 1;
+              node.widgets = node.widgets.filter((w) => w !== swallowing);
+              return null;
+            },
+          };
+        },
+      }),
+    /did not retain the requested value/,
+  );
+  assert.equal(undone, 1, "the refusal rolled the preparation back");
+  assert.equal(probe.depth, 0, "every envelope opened is closed — an unclosed one wedges the tracker");
+  assert.equal(probe.captures.length, 1, "exactly one capture, at the outermost close");
+  assert.deepEqual(probe.captures[0], [], "…and it holds the graph AFTER the cleanup, not the refused row");
+});
+
+test("#757 boundary: a SUCCESSFUL creating write is still one capture, with the row in it", async () => {
+  // The same envelope on the success path: one undo step, and it covers create + assign.
+  const { node, seen, prepareWriteTarget } = boundaryFixture();
+  const probe = historyProbe(node);
+  await runSetWidget(node, "made", "hello", {
+    registry: BOUNDARY_REGISTRY,
+    ...boundaryOracle,
+    beforeChange: probe.beforeChange,
+    afterChange: probe.afterChange,
+    prepareWriteTarget,
+  });
+  assert.equal(seen.prepared, 1);
+  assert.equal(probe.depth, 0);
+  assert.equal(probe.captures.length, 1, "one undo step for the whole command");
+  assert.deepEqual(probe.captures[0], ["made"], "and it covers the creation and the assign together");
+});
+
+test("#757 boundary: an INCOMPLETE rollback is disclosed on the refusal the caller sees", async () => {
+  // ROUND-4 P2, the other half. The undo may report that it could not put everything back —
+  // a consumed row name that the pack's hidden counter will not give up. That has to reach
+  // the caller ATTACHED TO THE REFUSAL, because the refusal is all it gets.
+  const { node, prepareWriteTarget: mint } = boundaryFixture({
+    name: "made",
+    type: "combo",
+    options: { values: ["a"] },
+    value: "a",
+  });
+  const prepareWriteTarget = () => {
+    const prepared = mint();
+    if (!prepared) return null;
+    return {
+      undo: () => {
+        prepared.undo();
+        return "The name it used up could not be given back.";
+      },
+    };
+  };
+  await assert.rejects(
+    () => runSetWidget(node, "made", "nope", { registry: BOUNDARY_REGISTRY, ...boundaryOracle, prepareWriteTarget }),
+    (err) => {
+      assert.match(err.message, /is not a valid option/, "the reason the write was refused");
+      assert.match(err.message, /could not be given back/, "…and what the rollback could not undo");
+      return true;
+    },
+  );
+});
+
+test("#757 boundary: the disclosure does not cost a combo miss its retry", async () => {
+  // The annotation is applied IN PLACE precisely so the error keeps its type and its `combo`
+  // flag. Rethrowing a wrapped error here would turn every recoverable stale-combo miss into
+  // a hard refusal — a far bigger regression than the disclosure is worth.
+  const { node, widget, prepareWriteTarget: mint } = boundaryFixture({
+    name: "made",
+    type: "combo",
+    options: { values: ["a"] },
+    value: "a",
+  });
+  const prepareWriteTarget = () => {
+    const prepared = mint();
+    if (!prepared) return null;
+    return {
+      undo: () => {
+        prepared.undo();
+        return "a note that must not break the recovery";
+      },
+    };
+  };
+  const res = await runSetWidget(node, "made", "b", {
+    registry: BOUNDARY_REGISTRY,
+    ...boundaryOracle,
+    prepareWriteTarget,
+    refreshCombos: async () => {
+      widget.options.values.push("b");
+    },
+  });
+  assert.equal(res.set.value, "b", "the stale-combo recovery still ran and the write landed");
+  assert.equal(res.refreshed, true);
 });
 
 test("#757 boundary: nothing the hook made survives ACROSS the retry await", async () => {
@@ -859,15 +1056,29 @@ function stubRunSetWidget({ fail = null, result = { ok: true } } = {}) {
     // exactly as it does in the real one (the hook is called before applyWidgetWrite's try).
     const prepared = opts.prepareWriteTarget?.() ?? null;
     fn.writes += 1;
-    // The real one brackets its write and fires afterChange BEFORE the #240 read-back
-    // verification that can still reject — so a refusal arrives with its own pair closed.
-    opts.beforeChange?.();
-    opts.afterChange?.();
-    if (fail) {
-      prepared?.undo?.();
-      throw fail;
+    // A grown target puts the write AND its cleanup inside ONE OUTER envelope, so the tracker
+    // captures once — at the end, over the graph as it really finished. Opened only when
+    // something was actually prepared, exactly as the real one does.
+    if (prepared) opts.beforeChange?.();
+    try {
+      // The real one brackets its write and fires afterChange BEFORE the #240 read-back
+      // verification that can still reject — so a refusal arrives with its own pair closed.
+      opts.beforeChange?.();
+      opts.afterChange?.();
+      if (fail) {
+        // The real one ANNOTATES the refusal in place with whatever the undo could not put
+        // back, so the caller is not told only why its value was rejected while a resource
+        // the preparation consumed stays consumed.
+        const note = prepared?.undo?.();
+        if (typeof note === "string" && note && typeof fail?.message === "string") {
+          fail.message = `${fail.message} ${note}`;
+        }
+        throw fail;
+      }
+      return result;
+    } finally {
+      if (prepared) opts.afterChange?.();
     }
-    return result;
   };
   fn.calls = [];
   /** Write ATTEMPTS — the calls that got past `prepareWriteTarget`, not merely into the body. */
@@ -1000,6 +1211,43 @@ test("#757 executor: a REFUSED write takes the row back out", async () => {
     "the refusal reaches the caller unchanged",
   );
   assert.deepEqual(node.widgets.map((w) => w.name), before, "and the node is back to what it was");
+});
+
+test("#757 executor: a refused write over a HIDDEN counter says the row name is spent", async () => {
+  // ROUND-4 P2, end to end through the shipped wiring: the pack exposes addNewLoraWidget but
+  // keeps its counter private, so the row goes back out and the NAME does not. The caller
+  // gets one message and it has to carry both facts — otherwise the obvious next move,
+  // retrying the corrected value under the same lora_1, mints a later row and is refused a
+  // second time for a reason the first refusal never mentioned.
+  const node = loader({ nextRow: 1, trackCounter: false });
+  const { run } = executor(node, {
+    runSetWidget: stubRunSetWidget({ fail: new Error('"strength" must be a number') }),
+  });
+  await assert.rejects(
+    () => run({ node_id: 153, widget: "lora_1", value: SLOT_JSON, workflow_uuid: "u" }),
+    (err) => {
+      assert.match(err.message, /"strength" must be a number/, "why the write was refused");
+      assert.match(err.message, /row counter could not be read, so that name is used up/, "…and what it cost");
+      return true;
+    },
+  );
+  assert.ok(!node.widgets.some((w) => w.name === "lora_1"), "the row itself did go back out");
+});
+
+test("#757 executor: a refused write that rolled back CLEANLY says nothing extra", async () => {
+  // The counterpart: a readable counter that came back leaves nothing to confess, and the
+  // refusal must not start carrying a warning it has not earned.
+  const node = loader({ nextRow: 1 });
+  const { run } = executor(node, {
+    runSetWidget: stubRunSetWidget({ fail: new Error('"strength" must be a number') }),
+  });
+  await assert.rejects(
+    () => run({ node_id: 153, widget: "lora_1", value: SLOT_JSON, workflow_uuid: "u" }),
+    (err) => {
+      assert.equal(err.message, '"strength" must be a number', "the refusal is exactly what the write said");
+      return true;
+    },
+  );
 });
 
 test("#757 executor: a refused write rewinds the row counter too", async () => {

--- a/browser_tests/unit/rgthree-lora-row.test.mjs
+++ b/browser_tests/unit/rgthree-lora-row.test.mjs
@@ -17,6 +17,7 @@ import assert from "node:assert/strict";
 import {
   isRgthreeLoraRowCreation,
   createRgthreeLoraRow,
+  noteRgthreeLoraRowWritten,
   POWER_LORA_LOADER_TYPE,
 } from "../../web/js/lib/rgthree-lora-row.js";
 
@@ -45,6 +46,13 @@ function loader({ nextRow = 1, addNew = true, widgets = null, trackCounter = tru
     removeWidget(w) {
       const i = node.widgets.indexOf(w);
       if (i >= 0) node.widgets.splice(i, 1);
+    },
+    // The pack sizes its node from the row count, and `addNewLoraWidget` does NOT resize —
+    // rgthree's own button recomputes the height right after calling it. Modelled so the
+    // resize step (and its rollback) can be asserted rather than assumed.
+    size: [200, 60],
+    computeSize() {
+      return [200, 60 + 20 * node.widgets.filter((w) => /^lora_\d+$/.test(w?.name ?? "")).length];
     },
   };
   let shadow = nextRow - 1; // used when the node exposes no readable counter
@@ -358,6 +366,74 @@ test("#757 remove() targets the row BY IDENTITY, not by name", () => {
   assert.ok(n.widgets.includes(impostor), "the row that answers to the name now is not ours to remove");
 });
 
+test("#757 the node GROWS to fit the row, as the pack's own button does", () => {
+  // `addNewLoraWidget` only mints, appends and reorders. rgthree's ➕ Add Lora callback
+  // recomputes the height itself right afterwards; marking the canvas dirty just repaints, so
+  // without this the new row is clipped or drawn over the button until some later edit.
+  const n = loader();
+  const heightBefore = n.size[1];
+  createRgthreeLoraRow(n, "lora_1", {});
+  assert.ok(n.size[1] > heightBefore, `the node grew (${heightBefore} -> ${n.size[1]})`);
+  assert.equal(n.size[1], n.computeSize()[1], "to exactly what the pack would compute");
+});
+
+test("#757 the node's size is put back when the creation is rolled back", () => {
+  const n = loader();
+  const sizeBefore = [...n.size];
+  createRgthreeLoraRow(n, "lora_1", {}).remove();
+  assert.deepEqual([...n.size], sizeBefore, "a rolled-back creation leaves no stretched node behind");
+});
+
+test("#757 a node that cannot measure itself is still created on", () => {
+  const n = loader();
+  delete n.computeSize;
+  assert.equal(createRgthreeLoraRow(n, "lora_1", {}).created, "lora_1", "the resize is best-effort, not a gate");
+});
+
+test("#757 remove() will not rewind past a counter somebody else advanced", () => {
+  // Create lora_1, let another edit add lora_2, then roll back. Rewinding to `counterBefore`
+  // would re-issue lora_1 AND lora_2 — the second a DUPLICATE of a row still on the node.
+  const n = loader({ nextRow: 1 });
+  const made = createRgthreeLoraRow(n, "lora_1", {});
+  n.addNewLoraWidget(); // an unrelated addition while our write was in flight
+  assert.equal(n.loraWidgetsCounter, 2);
+  made.remove();
+  assert.equal(n.loraWidgetsCounter, 2, "the counter now covers a row that is not ours to un-name");
+  n.addNewLoraWidget();
+  const names = n.widgets.map((w) => w.name).filter((x) => /^lora_/.test(x));
+  assert.equal(new Set(names).size, names.length, `no duplicate row names: ${names.join(", ")}`);
+});
+
+test("#757 a pack method that throws PART-WAY is cleaned up, not just reported", () => {
+  // The shipped method is `loraWidgetsCounter++` FIRST, then construct, append and move. A
+  // throw in any later step can burn the number and leave the row. Saying "nothing was added"
+  // without looking would be asserting something never checked.
+  const n = loader({ nextRow: 1 });
+  n.addNewLoraWidget = () => {
+    n.loraWidgetsCounter += 1;
+    n.widgets.push({ name: `lora_${n.loraWidgetsCounter}`, value: { on: true, lora: null, strength: 1 } });
+    throw new Error("moveArrayItem blew up");
+  };
+  const namesBefore = n.widgets.map((w) => w.name);
+  assert.throws(() => createRgthreeLoraRow(n, "lora_1", {}), /addNewLoraWidget\(\) threw \(moveArrayItem blew up\)/);
+  assert.deepEqual(n.widgets.map((w) => w.name), namesBefore, "the half-added row was taken back out");
+  assert.equal(n.loraWidgetsCounter, 0, "and the number it had already spent was returned");
+});
+
+test("#757 a pack throw whose damage could NOT be undone says so", () => {
+  const n = loader({ nextRow: 1 });
+  n.addNewLoraWidget = () => {
+    n.loraWidgetsCounter += 1;
+    n.widgets.push({ name: `lora_${n.loraWidgetsCounter}`, value: { on: true, lora: null, strength: 1 } });
+    throw new Error("boom");
+  };
+  n.removeWidget = () => {}; // and the node will not give the row up
+  assert.throws(
+    () => createRgthreeLoraRow(n, "lora_1", {}),
+    /had already changed the node before it threw, and that could not be fully undone \(lora_1\)/,
+  );
+});
+
 test("#757 remove() never throws, whatever the node does", () => {
   const n = loader();
   const made = createRgthreeLoraRow(n, "lora_1", {});
@@ -431,6 +507,7 @@ const EXECUTOR_DEPS = [
   "awaitObjectInfoHistorySeed",
   "isRgthreeLoraRowCreation",
   "createRgthreeLoraRow",
+  "noteRgthreeLoraRowWritten",
   "assertActiveWorkflowCommandTarget",
   "WORKFLOW_UUID_FIELD",
   "runSetWidget",
@@ -452,36 +529,64 @@ const EXECUTOR_DEPS = [
 ];
 
 /**
- * A graph that keeps score the way ComfyUI's ChangeTracker does.
+ * A graph that delivers undo bookkeeping the way LiteGraph and ChangeTracker really do.
  *
- * Verified against the shipped frontend bundle: `beforeChange(){this.changeCount++}` and
- * `afterChange(){--this.changeCount||this.captureCanvasState()}`, reached from
- * `LGraph.beforeChange` via `canvasAction(c => c.onBeforeChange?.(this))`. So nested pairs
- * collapse into ONE captured state — and an unmatched close drives the count to -1, which is
- * truthy, so the capture never fires and the command vanishes from undo history entirely.
- * That second failure mode is why `afterChange` here throws rather than going negative.
+ * Both halves are modelled from the shipped frontend bundle, because the interesting failure
+ * lives in the seam between them:
+ *
+ *   LGraph:        `beforeChange(){ …; this.canvasAction(c => c.onBeforeChange?.(this)) }`
+ *                  `canvasAction(cb){ const l = this.list_of_graphcanvas; if (l) for (const c of l) cb(c) }`
+ *   ChangeTracker: `beforeChange(){ this.changeCount++ }`
+ *                  `afterChange(){ --this.changeCount || this.captureCanvasState() }`
+ *
+ * So the hooks reach the tracker only through ATTACHED canvases. Detach the graph — which is
+ * exactly what switching workflow tabs or leaving a subgraph does — and a close reaches
+ * nobody, leaving the tracker at 1 forever: `--this.changeCount` never returns 0 again and NO
+ * later edit in that workflow is ever captured. `detachCanvas()` reproduces it.
+ *
+ * Nested pairs collapse into one captured state, and an unmatched close would drive the count
+ * negative — which is truthy, so the capture never fires at all. That is why `onAfterChange`
+ * throws rather than going below zero.
  */
 function trackedGraph(node) {
-  const g = {
-    node,
+  const tracker = {
     changeCount: 0,
     /** One entry per undo step the tracker would record: the widget names at that moment. */
     captures: [],
+    onBeforeChange() {
+      tracker.changeCount += 1;
+    },
+    onAfterChange() {
+      tracker.changeCount -= 1;
+      if (tracker.changeCount < 0) {
+        throw new Error("afterChange() without a matching beforeChange() — the undo entry would be lost");
+      }
+      if (tracker.changeCount === 0) tracker.captures.push(g.node.widgets.map((w) => w.name));
+    },
+  };
+  const canvas = {
+    onBeforeChange: () => tracker.onBeforeChange(),
+    onAfterChange: () => tracker.onAfterChange(),
+  };
+  const g = {
+    node,
+    tracker,
+    list_of_graphcanvas: [canvas],
     log: [],
     beforeChange() {
       g.log.push("before");
-      g.changeCount += 1;
+      for (const c of g.list_of_graphcanvas) c.onBeforeChange?.(g);
     },
     afterChange() {
       g.log.push("after");
-      g.changeCount -= 1;
-      if (g.changeCount < 0) {
-        throw new Error("afterChange() without a matching beforeChange() — the undo entry would be lost");
-      }
-      if (g.changeCount === 0) g.captures.push(g.node.widgets.map((w) => w.name));
+      for (const c of g.list_of_graphcanvas) c.onAfterChange?.(g);
     },
     setDirtyCanvas() {
       g.log.push("dirty");
+    },
+    /** The user switched workflow tabs, or left the subgraph. */
+    detachCanvas() {
+      g.list_of_graphcanvas = [];
     },
   };
   return g;
@@ -511,10 +616,11 @@ function executor(node, overrides = {}) {
     classifyPromptRelayTimelineWrite: () => null,
     classifyRgthreeFastGroupsWrite: () => null,
     awaitObjectInfoHistorySeed: async () => {},
-    // The REAL classifier and the REAL creator: a double here would let the executor pass
-    // against a route that never fires, which is precisely the defect under test.
+    // The REAL classifier, creator and claim-release: a double here would let the executor
+    // pass against a route that never fires, which is precisely the defect under test.
     isRgthreeLoraRowCreation,
     createRgthreeLoraRow,
+    noteRgthreeLoraRowWritten,
     assertActiveWorkflowCommandTarget: () => {},
     WORKFLOW_UUID_FIELD: "workflow_uuid",
     runSetWidget: overrides.runSetWidget ?? stubRunSetWidget(),
@@ -534,18 +640,45 @@ function executor(node, overrides = {}) {
 const SLOT_JSON = JSON.stringify(SLOT);
 
 test("#757 executor: create + assign is ONE undo step", async () => {
+  // The creation is deliberately NOT bracketed. ChangeTracker captures whole-graph snapshots,
+  // not deltas, so the pair runSetWidget opens for the write closes with the row already
+  // present — and that single entry covers the creation and the assign together.
   const node = loader();
   const { run, graph } = executor(node);
   const reply = await run({ node_id: 153, widget: "lora_1", value: SLOT_JSON, workflow_uuid: "u" });
   assert.equal(reply.created_widget, "lora_1", "the structural change is disclosed");
   assert.ok(node.widgets.some((w) => w.name === "lora_1"));
-  assert.equal(graph.changeCount, 0, "the transaction is balanced");
+  assert.equal(graph.tracker.changeCount, 0, "the transaction is balanced");
   assert.equal(
-    graph.captures.length,
+    graph.tracker.captures.length,
     1,
     "two captures would be two Ctrl+Z, the first of which leaves a default row behind",
   );
-  assert.ok(graph.captures[0].includes("lora_1"), "and the one undo step covers the created row");
+  assert.ok(graph.tracker.captures[0].includes("lora_1"), "and the one undo step covers the created row");
+});
+
+test("#757 executor: a workflow switch during the await cannot wedge the undo history", async () => {
+  // THE REGRESSION THIS GUARDS IS WORSE THAN #757 ITSELF. LiteGraph delivers beforeChange /
+  // afterChange through ATTACHED canvases. Holding a transaction across the /object_info
+  // await means that if the user switches workflow tabs mid-flight, the close reaches no
+  // canvas at all and the tracker sits at 1 forever — `--this.changeCount || capture()` never
+  // returns to zero, so NO further edit in that workflow is ever captured for undo, for the
+  // rest of the session. Nothing in this command may open a transaction it then awaits across.
+  const node = loader();
+  const graph = trackedGraph(node);
+  const runSetWidget = async (n, w, v, opts) => {
+    graph.detachCanvas(); // the user switched tabs while /object_info was in flight
+    opts.beforeChange?.();
+    opts.afterChange?.();
+    throw new Error("the workflow changed while this write was in flight");
+  };
+  const { run } = executor(node, { graph, runSetWidget });
+  await assert.rejects(() => run({ node_id: 153, widget: "lora_1", value: SLOT_JSON, workflow_uuid: "u" }));
+  assert.equal(
+    graph.tracker.changeCount,
+    0,
+    "a tracker left above zero stops capturing undo snapshots for the whole session",
+  );
 });
 
 test("#757 executor: a REFUSED write takes the row back out", async () => {
@@ -579,18 +712,13 @@ test("#757 executor: a refused write rewinds the row counter too", async () => {
   assert.equal(reply.created_widget, "lora_1", "retrying the same request works, rather than drifting to lora_2");
 });
 
-test("#757 executor: a refused write leaves NO undo step to step through", async () => {
+test("#757 executor: a refused write is balanced and leaves the graph as it found it", async () => {
   const node = loader();
   const before = node.widgets.map((w) => w.name);
   const { run, graph } = executor(node, { runSetWidget: stubRunSetWidget({ fail: new Error("nope") }) });
   await assert.rejects(() => run({ node_id: 153, widget: "lora_1", value: SLOT_JSON, workflow_uuid: "u" }));
-  assert.equal(graph.changeCount, 0, "the transaction is closed exactly once, even on the error path");
-  assert.equal(graph.captures.length, 1, "closed once — not zero times, and not twice");
-  assert.deepEqual(
-    graph.captures[0],
-    before,
-    "and the state it captured is the state the command started from, so nothing is recorded",
-  );
+  assert.equal(graph.tracker.changeCount, 0, "every transaction opened is closed, even on the error path");
+  assert.deepEqual(node.widgets.map((w) => w.name), before, "and the row is gone again");
 });
 
 test("#757 executor: an ordinary write opens no transaction of its own", async () => {
@@ -602,19 +730,77 @@ test("#757 executor: an ordinary write opens no transaction of its own", async (
   const reply = await run({ node_id: 153, widget: "lora_1", value: SLOT_JSON, workflow_uuid: "u" });
   assert.equal(reply.created_widget, undefined, "nothing was created, so nothing is disclosed");
   assert.deepEqual(graph.log, ["before", "after"], "exactly one pair, and it is runSetWidget's");
-  assert.equal(graph.captures.length, 1);
+  assert.equal(graph.tracker.captures.length, 1);
 });
 
-test("#757 executor: creation that REFUSES closes its transaction and never reaches the write", async () => {
+test("#757 executor: creation that REFUSES opens no transaction, and never reaches the write", async () => {
   const node = loader({ addNew: false }); // a pack build with no addNewLoraWidget
   const { run, graph, runSetWidget } = executor(node);
   await assert.rejects(
     () => run({ node_id: 153, widget: "lora_1", value: SLOT_JSON, workflow_uuid: "u" }),
     /does not expose addNewLoraWidget/,
   );
-  assert.equal(graph.changeCount, 0, "an unclosed transaction would swallow the next command's undo entry");
-  assert.equal(graph.captures.length, 1, "closed exactly once");
+  assert.equal(graph.tracker.changeCount, 0, "an unclosed transaction would swallow the next command's undo entry");
+  assert.deepEqual(graph.log, [], "a refusal that changed nothing has no bookkeeping to do");
   assert.equal(runSetWidget.calls.length, 0, "the write is never attempted for a row that does not exist");
+});
+
+test("#757 executor: a CONCURRENT write's row is never rolled back under it", async () => {
+  // Command frames run concurrently. Request A mints lora_1 and parks in its write; request B
+  // arrives, sees a row that now exists, writes it and reports SUCCESS; A then fails. An
+  // unconditional rollback would delete the row B was just told it had written — a reported
+  // success that no longer matches the graph, which is worse than the stray row the rollback
+  // exists to prevent.
+  const node = loader();
+  let releaseA;
+  const parked = new Promise((_, reject) => {
+    releaseA = reject;
+  });
+  const graph = trackedGraph(node);
+  const a = executor(node, {
+    graph,
+    runSetWidget: async (n, w, v, opts) => {
+      opts.beforeChange?.();
+      opts.afterChange?.();
+      return parked; // A is still in flight
+    },
+  });
+  const aDone = assert.rejects(
+    () => a.run({ node_id: 153, widget: "lora_1", value: SLOT_JSON, workflow_uuid: "u" }),
+    /A lost its race/,
+  );
+  await Promise.resolve(); // let A get as far as its await, with the row created
+
+  assert.ok(node.widgets.some((w) => w.name === "lora_1"), "A created the row");
+  // B: an ordinary write to a row that already exists. It must report success and keep it.
+  const b = executor(node, { graph });
+  const bReply = await b.run({ node_id: 153, widget: "lora_1", value: SLOT_JSON, workflow_uuid: "u" });
+  assert.equal(bReply.created_widget, undefined, "B did not create anything — the row was there");
+
+  releaseA(new Error("A lost its race"));
+  await aDone;
+  assert.ok(
+    node.widgets.some((w) => w.name === "lora_1"),
+    "B was told the write succeeded; A's rollback must not delete the row out from under it",
+  );
+});
+
+test("#757 executor: a refused write that could NOT roll back still says the row exists", async () => {
+  // The other half of the concurrency rule: when the row survives because somebody else wrote
+  // it, the reply must not go on claiming nothing was created.
+  const node = loader();
+  const graph = trackedGraph(node);
+  const { run } = executor(node, {
+    graph,
+    runSetWidget: async (n, w, v, opts) => {
+      opts.beforeChange?.();
+      opts.afterChange?.();
+      noteRgthreeLoraRowWritten(node, "lora_1"); // somebody else's write landed
+      throw new Error("this one still failed");
+    },
+  });
+  await assert.rejects(() => run({ node_id: 153, widget: "lora_1", value: SLOT_JSON, workflow_uuid: "u" }));
+  assert.ok(node.widgets.some((w) => w.name === "lora_1"), "the claimed-by-someone-else row stays");
 });
 
 test("#757 executor: the write is handed the row that was just created", async () => {

--- a/browser_tests/unit/rgthree-lora-row.test.mjs
+++ b/browser_tests/unit/rgthree-lora-row.test.mjs
@@ -1293,6 +1293,8 @@ const EXECUTOR_DEPS = [
   "applyPromptRelayTimelineWrite",
   "classifyRgthreeFastGroupsWrite",
   "rgthreeFastGroupsRefusal",
+  "classifyIdeogram4PromptBuilderWrite",
+  "ideogram4PromptBuilderRefusal",
   "awaitObjectInfoHistorySeed",
   "isRgthreeLoraRowCreation",
   "createRgthreeLoraRow",
@@ -1432,6 +1434,10 @@ function executor(node, overrides = {}) {
     classifyLtxTimelineWrite: () => null,
     classifyPromptRelayTimelineWrite: () => null,
     classifyRgthreeFastGroupsWrite: () => null,
+    // #1569 guard, added to the extracted method after this harness was written. The rgthree
+    // stand-in is never an Ideogram4PromptBuilderKJ, so it classifies nothing — same as the
+    // other pack classifiers above.
+    classifyIdeogram4PromptBuilderWrite: () => null,
     awaitObjectInfoHistorySeed: async () => {},
     // The REAL classifier and creator: a double here would let the executor pass against a
     // route that never fires, which is precisely the defect under test.

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -215,7 +215,7 @@ import { fetchNodeDefsWithRetry, OBJECT_INFO_RETRY_DELAYS_MS } from "./lib/objec
 import { createObjectInfoCache, CACHE_OUTCOME } from "./lib/object-info-cache.js";
 import { fetchWholeObjectInfo, objectInfoOracleFailureNote } from "./lib/object-info-oracle.js";
 import { createObjectInfoSnapshot, snapshotAuthorizationNote } from "./lib/object-info-snapshot.js";
-import { isRgthreeLoraRowCreation, createRgthreeLoraRow } from "./lib/rgthree-lora-row.js";
+import { isRgthreeLoraRowCreation, createRgthreeLoraRow, noteRgthreeLoraRowWritten } from "./lib/rgthree-lora-row.js";
 import { objectInfoFingerprint, objectInfoUnchanged } from "./lib/object-info-fingerprint.js";
 import { confirmCanvasNavigation } from "./lib/canvas-navigation.js";
 import {
@@ -12067,30 +12067,32 @@ const GRAPH_TOOL_EXECUTORS = {
     // VALUE, all three. That is what keeps it away from the deliberate refusal to auto-press
     // a control on an ordinary typo — see lib/rgthree-lora-row.js.
     //
-    // ONE UNDO STEP, AND NO ROW LEFT BEHIND BY A REFUSED WRITE. Two review defects, both of
-    // them about the fact that creation must run BEFORE the write but is not the write:
-    //   - creation opened and closed its OWN beforeChange/afterChange, so a successful
-    //     command took TWO Ctrl+Z to undo and the first one left behind a default row that
-    //     had not existed before the command;
-    //   - `runSetWidget` can still refuse after the row exists (fresh /object_info says the
-    //     pack was removed, the slot's own fields fail validation, the workflow switched
-    //     during an await, the #240 read-back rolls the value back). The command then
-    //     reported failure over a CHANGED graph — the mutate-then-refuse contract the rest
-    //     of this file works to avoid, and each retry would add another row.
-    // So the transaction is opened HERE and closed once below, and a refused write takes the
-    // row back out inside it.
+    // NO ROW LEFT BEHIND BY A REFUSED WRITE, AND STILL ONE UNDO STEP. `runSetWidget` can
+    // refuse after the row exists (fresh /object_info says the pack was removed, the slot's
+    // own fields fail validation, the workflow switched during an await, the #240 read-back
+    // rolls the value back). Reporting failure over a CHANGED graph is the mutate-then-refuse
+    // contract the rest of this file works to avoid, and each retry would add another row —
+    // so a refused write undoes the creation below.
+    //
+    // THE CREATION IS DELIBERATELY NOT BRACKETED, and no transaction is held across the
+    // await. An earlier version opened graph.beforeChange() here and closed it after the
+    // write, which was wrong in a way far worse than the bug it fixed. LiteGraph delivers
+    // these hooks through ATTACHED canvases — `canvasAction(cb){for (const c of
+    // this.list_of_graphcanvas) cb(c)}` — so if the user switches workflow tabs or leaves the
+    // subgraph while runSetWidget awaits /object_info, the graph we opened on has no canvas
+    // left and the close reaches nobody. ComfyUI's ChangeTracker then sits at changeCount 1
+    // for the rest of the session (`afterChange(){--this.changeCount||this.captureCanvasState()}`
+    // never reaches zero again), so NO further edit in that workflow is ever captured for
+    // undo. A session-wide dead undo history is not a trade worth one Ctrl+Z.
+    //
+    // Leaving the creation unbracketed still yields ONE undo step, because ChangeTracker
+    // captures whole-graph SNAPSHOTS rather than deltas: nothing is captured while the row is
+    // minted, and the pair runSetWidget opens for the write itself closes with the row
+    // already present — so the single entry it records covers the creation and the assign
+    // together. It also means every transaction in this command is opened and closed inside
+    // one synchronous stretch, which is the rule the rest of this file already follows.
     let createdLoraRow = null;
     let undoLoraRow = null;
-    // TRUE between OUR graph.beforeChange() and the single afterChange() that closes it. A
-    // separate flag rather than `createdLoraRow !== null` on purpose: a refused write CLEARS
-    // that name (the command created nothing, as far as any reader is concerned) while the
-    // transaction it opened is still open and must still be closed — exactly once. ComfyUI's
-    // ChangeTracker counts the pairs (`beforeChange(){this.changeCount++}` /
-    // `afterChange(){--this.changeCount||this.captureCanvasState()}`), so nesting is safe and
-    // collapses to one undo entry, but an EXTRA close drives the count to -1, which is
-    // TRUTHY: the capture never fires and the whole command disappears from undo history
-    // rather than merely splitting in two.
-    let loraRowTxnOpen = false;
     if (isRgthreeLoraRowCreation(node, widget, value)) {
       // The uuid fence brackets the mutation, as graph_remove_widget does: the user can
       // switch workflows during the awaits above, and a row must never be grown on a canvas
@@ -12099,23 +12101,11 @@ const GRAPH_TOOL_EXECUTORS = {
         cmd: "graph_set_widget",
         [WORKFLOW_UUID_FIELD]: workflow_uuid,
       });
-      graph.beforeChange();
-      loraRowTxnOpen = true;
-      try {
-        const made = createRgthreeLoraRow(node, widget, {
-          // No brackets of its own: the envelope lives here now, and the write below has to
-          // land inside the same one. runSetWidget's own pair nests within it.
-          setDirty: () => graph.setDirtyCanvas(true, true),
-        });
-        createdLoraRow = made.created;
-        undoLoraRow = made.remove;
-      } catch (err) {
-        // Never leave the history transaction open on a refusal — and clear the flag FIRST,
-        // so nothing downstream can close it a second time.
-        loraRowTxnOpen = false;
-        graph.afterChange();
-        throw err;
-      }
+      const made = createRgthreeLoraRow(node, widget, {
+        setDirty: () => graph.setDirtyCanvas(true, true),
+      });
+      createdLoraRow = made.created;
+      undoLoraRow = made.remove;
     }
     // Delegate to the shared handler body (web/js/lib/set-widget.js) so this
     // production path and the unit tests run the IDENTICAL ordering: preflight →
@@ -12359,35 +12349,34 @@ const GRAPH_TOOL_EXECUTORS = {
       // path to resolve it), but the write can still refuse afterwards. Undoing it here is
       // what keeps this command all-or-nothing.
       //
-      // Removed INSIDE the still-open transaction — a catch runs before its finally — so the
-      // state ChangeTracker captures when the transaction closes is the state the command
-      // started from, and the failed attempt leaves no undo entry to step through either.
-      // `remove` also rewinds rgthree's row counter, so a refused write does not silently
-      // spend a row name (see lib/rgthree-lora-row.js: addNewLoraWidget increments BEFORE it
-      // names, and dropping the widget does not undo that).
+      // `remove` rewinds rgthree's row counter and the node's height along with the row, and
+      // it declines when another concurrent request has already written the row — a success
+      // somebody has been told about outranks this refusal's tidiness. It reports whether the
+      // row actually went, so the disclosure below can stay honest either way.
       if (undoLoraRow) {
+        let undone = false;
         try {
-          undoLoraRow();
+          undone = undoLoraRow() !== false;
           graph.setDirtyCanvas(true, true);
         } catch {
           /* best-effort: never replace the refusal with an error about undoing it */
         }
         undoLoraRow = null;
-        // The caller is about to receive an exception, but clear the name anyway so no later
-        // reader can attribute a created row to a command that ended up creating none.
-        createdLoraRow = null;
+        // Only claim nothing was created when nothing is left. A row that survived because
+        // another request wrote it is still on the node, and saying otherwise would be the
+        // same fabrication this route exists to avoid.
+        if (undone) createdLoraRow = null;
       }
       throw err;
-    } finally {
-      // ONE UNDO STEP. The create and the assign both live in the transaction opened above,
-      // and it is closed here EXACTLY once — on success, on refusal, and not at all on the
-      // path where creation never ran (runSetWidget owns its own pair in that case). Its
-      // injected beforeChange/afterChange nest inside this one; ChangeTracker counts the
-      // pairs, so only this outermost close captures state.
-      if (loraRowTxnOpen) {
-        loraRowTxnOpen = false;
-        graph.afterChange();
-      }
+    }
+    // #757 — the row now belongs to the graph, not to whichever call minted it. A concurrent
+    // creation that goes on to refuse must NOT roll back a row this write has landed on.
+    // Called for EVERY successful write, not just a creating one: the request that saves the
+    // row is usually somebody else's.
+    try {
+      noteRgthreeLoraRowWritten(node, widget);
+    } catch {
+      /* bookkeeping only — never fail a completed write over it */
     }
 
     // #418: LiteGraph's `has_errors` red flag is STICKY — repointing a widget from a

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -215,7 +215,7 @@ import { fetchNodeDefsWithRetry, OBJECT_INFO_RETRY_DELAYS_MS } from "./lib/objec
 import { createObjectInfoCache, CACHE_OUTCOME } from "./lib/object-info-cache.js";
 import { fetchWholeObjectInfo, objectInfoOracleFailureNote } from "./lib/object-info-oracle.js";
 import { createObjectInfoSnapshot, snapshotAuthorizationNote } from "./lib/object-info-snapshot.js";
-import { isRgthreeLoraRowCreation, createRgthreeLoraRow, noteRgthreeLoraRowWritten } from "./lib/rgthree-lora-row.js";
+import { isRgthreeLoraRowCreation, createRgthreeLoraRow } from "./lib/rgthree-lora-row.js";
 import { objectInfoFingerprint, objectInfoUnchanged } from "./lib/object-info-fingerprint.js";
 import { confirmCanvasNavigation } from "./lib/canvas-navigation.js";
 import {
@@ -12057,56 +12057,29 @@ const GRAPH_TOOL_EXECUTORS = {
     // refused for a widget no tool could bring into existence. Writing an EXISTING row
     // already worked; this is the creation half.
     //
-    // AFTER the history seed and BEFORE runSetWidget, deliberately. The seed is what makes
-    // the #458 authorization meaningful, and creating a row is a mutation — it must not
-    // happen on a call that authorization is about to refuse. runSetWidget then resolves the
-    // now-present widget through the ordinary path, so the composite merge and the #240
-    // verify are unchanged.
-    //
     // The classifier is keyed on node TYPE + the `lora_<n>` name shape + a lora-slot-shaped
     // VALUE, all three. That is what keeps it away from the deliberate refusal to auto-press
     // a control on an ordinary typo — see lib/rgthree-lora-row.js.
     //
-    // NO ROW LEFT BEHIND BY A REFUSED WRITE, AND STILL ONE UNDO STEP. `runSetWidget` can
-    // refuse after the row exists (fresh /object_info says the pack was removed, the slot's
-    // own fields fail validation, the workflow switched during an await, the #240 read-back
-    // rolls the value back). Reporting failure over a CHANGED graph is the mutate-then-refuse
-    // contract the rest of this file works to avoid, and each retry would add another row —
-    // so a refused write undoes the creation below.
+    // NOT CREATED HERE. The row is minted by the `prepareWriteTarget` hook below, which
+    // runSetWidget invokes at its synchronous write boundary — after the history seed that
+    // makes the #458 authorization meaningful, after the fresh-/object_info await, after the
+    // workflow fence, immediately before applyWidgetWrite, with no await between the
+    // creation, the write and the undo. The now-present widget then resolves through the
+    // ordinary path, so the composite merge and the #240 verify are unchanged.
     //
-    // THE CREATION IS DELIBERATELY NOT BRACKETED, and no transaction is held across the
-    // await. An earlier version opened graph.beforeChange() here and closed it after the
-    // write, which was wrong in a way far worse than the bug it fixed. LiteGraph delivers
-    // these hooks through ATTACHED canvases — `canvasAction(cb){for (const c of
-    // this.list_of_graphcanvas) cb(c)}` — so if the user switches workflow tabs or leaves the
-    // subgraph while runSetWidget awaits /object_info, the graph we opened on has no canvas
-    // left and the close reaches nobody. ComfyUI's ChangeTracker then sits at changeCount 1
-    // for the rest of the session (`afterChange(){--this.changeCount||this.captureCanvasState()}`
-    // never reaches zero again), so NO further edit in that workflow is ever captured for
-    // undo. A session-wide dead undo history is not a trade worth one Ctrl+Z.
+    // Creating it at THIS point instead — before runSetWidget is even entered — is what
+    // produced every serious defect this feature has had, because it left a live graph
+    // mutation sitting across a network request: an undo transaction that could never be
+    // closed if the user switched tabs, a concurrent frame whose write got rolled back
+    // under it, and a user's own hand-edit exposed to a rollback that had nothing to do
+    // with them. Moving the mutation past the await removes the window rather than
+    // guarding it, so the guards those defects each needed are gone.
     //
-    // Leaving the creation unbracketed still yields ONE undo step, because ChangeTracker
-    // captures whole-graph SNAPSHOTS rather than deltas: nothing is captured while the row is
-    // minted, and the pair runSetWidget opens for the write itself closes with the row
-    // already present — so the single entry it records covers the creation and the assign
-    // together. It also means every transaction in this command is opened and closed inside
-    // one synchronous stretch, which is the rule the rest of this file already follows.
+    // It is still ONE undo step: ChangeTracker captures whole-graph SNAPSHOTS rather than
+    // deltas, and the pair runSetWidget opens for the write now closes with the row already
+    // present, so the single entry it records covers the creation and the assign together.
     let createdLoraRow = null;
-    let undoLoraRow = null;
-    if (isRgthreeLoraRowCreation(node, widget, value)) {
-      // The uuid fence brackets the mutation, as graph_remove_widget does: the user can
-      // switch workflows during the awaits above, and a row must never be grown on a canvas
-      // the caller did not address (#570/#718).
-      assertActiveWorkflowCommandTarget({
-        cmd: "graph_set_widget",
-        [WORKFLOW_UUID_FIELD]: workflow_uuid,
-      });
-      const made = createRgthreeLoraRow(node, widget, {
-        setDirty: () => graph.setDirtyCanvas(true, true),
-      });
-      createdLoraRow = made.created;
-      undoLoraRow = made.remove;
-    }
     // Delegate to the shared handler body (web/js/lib/set-widget.js) so this
     // production path and the unit tests run the IDENTICAL ordering: preflight →
     // reconcile-only-a-resolved-node → applyWidgetWrite with the resolved-target
@@ -12274,6 +12247,34 @@ const GRAPH_TOOL_EXECUTORS = {
       beforeChange: () => graph.beforeChange(),
       afterChange: () => graph.afterChange(),
       setDirty: () => graph.setDirtyCanvas(true, true),
+      // #757 — MINT a missing rgthree `lora_N` row, at the write boundary and nowhere else.
+      // runSetWidget calls this synchronously after its workflow fence and immediately
+      // before applyWidgetWrite, and calls the returned `undo` if the write refuses — so
+      // the creation, the write and its rollback are one uninterruptible stretch.
+      //
+      // Idempotent by construction, and RE-ENTERED PER ATTEMPT: runSetWidget's stale-combo
+      // and upload-asset recoveries undo this preparation before their await and call it
+      // again on the retry, so the classifier's requirement that the row be ABSENT is
+      // satisfied each time and no second row is ever minted.
+      //
+      // `createdLoraRow` therefore tracks the LAST attempt: set when the row really exists,
+      // cleared when an undo really removed it. The clearing is belt-and-braces today —
+      // every refusal in this command throws, so the disclosure below is only reached after
+      // an attempt that SUCCEEDED — and it is what keeps the field in step with the graph if
+      // a future path ever returns a result over an undone creation instead.
+      prepareWriteTarget: () => {
+        if (!isRgthreeLoraRowCreation(node, widget, value)) return null;
+        const made = createRgthreeLoraRow(node, widget, {
+          setDirty: () => graph.setDirtyCanvas(true, true),
+        });
+        createdLoraRow = made.created;
+        return {
+          undo: () => {
+            if (made.remove() !== false) createdLoraRow = null;
+            graph.setDirtyCanvas(true, true);
+          },
+        };
+      },
       // #718: the first command-handler fence ran before awaitObjectInfoHistorySeed()
       // and the fresh /object_info request. A user can switch workflows while either
       // promise is pending, so re-read the ACTIVE uuid at the exact shared write
@@ -12339,45 +12340,9 @@ const GRAPH_TOOL_EXECUTORS = {
         }
       },
     };
-    let result;
-    try {
-      result = await runSetWidget(node, widget, value, setWidgetOptions);
-    } catch (err) {
-      // #757 — A REFUSED WRITE MUST NOT LEAVE THE ROW BEHIND.
-      //
-      // The row had to be created before the write (the widget must exist for the ordinary
-      // path to resolve it), but the write can still refuse afterwards. Undoing it here is
-      // what keeps this command all-or-nothing.
-      //
-      // `remove` rewinds rgthree's row counter and the node's height along with the row, and
-      // it declines when another concurrent request has already written the row — a success
-      // somebody has been told about outranks this refusal's tidiness. It reports whether the
-      // row actually went, so the disclosure below can stay honest either way.
-      if (undoLoraRow) {
-        let undone = false;
-        try {
-          undone = undoLoraRow() !== false;
-          graph.setDirtyCanvas(true, true);
-        } catch {
-          /* best-effort: never replace the refusal with an error about undoing it */
-        }
-        undoLoraRow = null;
-        // Only claim nothing was created when nothing is left. A row that survived because
-        // another request wrote it is still on the node, and saying otherwise would be the
-        // same fabrication this route exists to avoid.
-        if (undone) createdLoraRow = null;
-      }
-      throw err;
-    }
-    // #757 — the row now belongs to the graph, not to whichever call minted it. A concurrent
-    // creation that goes on to refuse must NOT roll back a row this write has landed on.
-    // Called for EVERY successful write, not just a creating one: the request that saves the
-    // row is usually somebody else's.
-    try {
-      noteRgthreeLoraRowWritten(node, widget);
-    } catch {
-      /* bookkeeping only — never fail a completed write over it */
-    }
+    // The creation and its rollback both live inside this call now, at the synchronous write
+    // boundary — see `prepareWriteTarget` above. There is nothing to undo out here.
+    const result = await runSetWidget(node, widget, value, setWidgetOptions);
 
     // #418: LiteGraph's `has_errors` red flag is STICKY — repointing a widget from a
     // missing asset (or an invalid value) to a valid one drops the missing-asset

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -12099,7 +12099,7 @@ const GRAPH_TOOL_EXECUTORS = {
     // try/catch/finally below without re-indenting ~180 lines of unrelated option literal,
     // and so the #757 transaction bookkeeping is readable AT the call rather than stranded
     // past the end of a very long argument.
-    const setWidgetOptions = {
+    const setWidgetOpts = {
       registry: LG?.registered_node_types ?? {},
       // Fresh-backend type authorization (#458 set_widget gap): the go/no-go for the
       // resolved target node's TYPE is decided against the CURRENT /object_info — NOT
@@ -12218,14 +12218,14 @@ const GRAPH_TOOL_EXECUTORS = {
       },
       // The ORDINARY entry: read through the #716 burst cache.
       getFreshObjectInfo: async () =>
-        setWidgetOptions.readObjectInfo((loader, opts) => objectInfoCache.readWithProvenance(loader, opts)),
+        setWidgetOpts.readObjectInfo((loader, opts) => objectInfoCache.readWithProvenance(loader, opts)),
       // #1126 — the LAST-RESORT entry: force a genuinely fresh read when the provenance is not
       // live. `readFresh` bypasses only the stored entry and coalesces concurrent rereads, so
       // two writes reaching this path together share one request instead of each globally
       // invalidating — which used to retire the other's just-issued request and refuse a write
       // that was perfectly valid.
       refetchObjectInfoLive: async () =>
-        setWidgetOptions.readObjectInfo((loader, opts) => objectInfoCache.readFresh(loader, opts)),
+        setWidgetOpts.readObjectInfo((loader, opts) => objectInfoCache.readFresh(loader, opts)),
       // What the last oracle attempt observed, so a refusal can say which routes were
       // tried and what each one did instead of asserting an unreachable backend — then,
       // separately, why the last-observed schema could not stand in for them either.
@@ -12348,7 +12348,7 @@ const GRAPH_TOOL_EXECUTORS = {
     };
     // The creation and its rollback both live inside this call now, at the synchronous write
     // boundary — see `prepareWriteTarget` above. There is nothing to undo out here.
-    const result = await runSetWidget(node, widget, value, setWidgetOptions);
+    const result = await runSetWidget(node, widget, value, setWidgetOpts);
 
     // #418: LiteGraph's `has_errors` red flag is STICKY — repointing a widget from a
     // missing asset (or an invalid value) to a valid one drops the missing-asset

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -12269,9 +12269,15 @@ const GRAPH_TOOL_EXECUTORS = {
         });
         createdLoraRow = made.created;
         return {
+          // Returns the row-creation's own disclosure when the rollback was INCOMPLETE (the
+          // pack hides or freezes its counter, so the row name stayed spent), which
+          // runSetWidget appends to the refusal. A caller told only "that value is invalid"
+          // would retry the same `lora_N` and hit a differently-named row.
           undo: () => {
-            if (made.remove() !== false) createdLoraRow = null;
+            const undone = made.remove();
+            if (undone.removed) createdLoraRow = null;
             graph.setDirtyCanvas(true, true);
+            return undone.incomplete;
           },
         };
       },

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -12066,7 +12066,31 @@ const GRAPH_TOOL_EXECUTORS = {
     // The classifier is keyed on node TYPE + the `lora_<n>` name shape + a lora-slot-shaped
     // VALUE, all three. That is what keeps it away from the deliberate refusal to auto-press
     // a control on an ordinary typo — see lib/rgthree-lora-row.js.
+    //
+    // ONE UNDO STEP, AND NO ROW LEFT BEHIND BY A REFUSED WRITE. Two review defects, both of
+    // them about the fact that creation must run BEFORE the write but is not the write:
+    //   - creation opened and closed its OWN beforeChange/afterChange, so a successful
+    //     command took TWO Ctrl+Z to undo and the first one left behind a default row that
+    //     had not existed before the command;
+    //   - `runSetWidget` can still refuse after the row exists (fresh /object_info says the
+    //     pack was removed, the slot's own fields fail validation, the workflow switched
+    //     during an await, the #240 read-back rolls the value back). The command then
+    //     reported failure over a CHANGED graph — the mutate-then-refuse contract the rest
+    //     of this file works to avoid, and each retry would add another row.
+    // So the transaction is opened HERE and closed once below, and a refused write takes the
+    // row back out inside it.
     let createdLoraRow = null;
+    let undoLoraRow = null;
+    // TRUE between OUR graph.beforeChange() and the single afterChange() that closes it. A
+    // separate flag rather than `createdLoraRow !== null` on purpose: a refused write CLEARS
+    // that name (the command created nothing, as far as any reader is concerned) while the
+    // transaction it opened is still open and must still be closed — exactly once. ComfyUI's
+    // ChangeTracker counts the pairs (`beforeChange(){this.changeCount++}` /
+    // `afterChange(){--this.changeCount||this.captureCanvasState()}`), so nesting is safe and
+    // collapses to one undo entry, but an EXTRA close drives the count to -1, which is
+    // TRUTHY: the capture never fires and the whole command disappears from undo history
+    // rather than merely splitting in two.
+    let loraRowTxnOpen = false;
     if (isRgthreeLoraRowCreation(node, widget, value)) {
       // The uuid fence brackets the mutation, as graph_remove_widget does: the user can
       // switch workflows during the awaits above, and a row must never be grown on a canvas
@@ -12075,11 +12099,23 @@ const GRAPH_TOOL_EXECUTORS = {
         cmd: "graph_set_widget",
         [WORKFLOW_UUID_FIELD]: workflow_uuid,
       });
-      createdLoraRow = createRgthreeLoraRow(node, widget, {
-        beforeChange: () => graph.beforeChange(),
-        afterChange: () => graph.afterChange(),
-        setDirty: () => graph.setDirtyCanvas(true, true),
-      }).created;
+      graph.beforeChange();
+      loraRowTxnOpen = true;
+      try {
+        const made = createRgthreeLoraRow(node, widget, {
+          // No brackets of its own: the envelope lives here now, and the write below has to
+          // land inside the same one. runSetWidget's own pair nests within it.
+          setDirty: () => graph.setDirtyCanvas(true, true),
+        });
+        createdLoraRow = made.created;
+        undoLoraRow = made.remove;
+      } catch (err) {
+        // Never leave the history transaction open on a refusal — and clear the flag FIRST,
+        // so nothing downstream can close it a second time.
+        loraRowTxnOpen = false;
+        graph.afterChange();
+        throw err;
+      }
     }
     // Delegate to the shared handler body (web/js/lib/set-widget.js) so this
     // production path and the unit tests run the IDENTICAL ordering: preflight →
@@ -12095,7 +12131,12 @@ const GRAPH_TOOL_EXECUTORS = {
     // #284/#304, keeping #240 strictness).
     // #1126 round-5 — bound to a name so the two cache entry points below can share the one
     // oracle body (`readObjectInfo`) instead of each keeping a copy that would drift.
-    const setWidgetOpts = {
+    //
+    // The options are HOISTED into a const so the call itself can sit inside the
+    // try/catch/finally below without re-indenting ~180 lines of unrelated option literal,
+    // and so the #757 transaction bookkeeping is readable AT the call rather than stranded
+    // past the end of a very long argument.
+    const setWidgetOptions = {
       registry: LG?.registered_node_types ?? {},
       // Fresh-backend type authorization (#458 set_widget gap): the go/no-go for the
       // resolved target node's TYPE is decided against the CURRENT /object_info — NOT
@@ -12214,14 +12255,14 @@ const GRAPH_TOOL_EXECUTORS = {
       },
       // The ORDINARY entry: read through the #716 burst cache.
       getFreshObjectInfo: async () =>
-        setWidgetOpts.readObjectInfo((loader, opts) => objectInfoCache.readWithProvenance(loader, opts)),
+        setWidgetOptions.readObjectInfo((loader, opts) => objectInfoCache.readWithProvenance(loader, opts)),
       // #1126 — the LAST-RESORT entry: force a genuinely fresh read when the provenance is not
       // live. `readFresh` bypasses only the stored entry and coalesces concurrent rereads, so
       // two writes reaching this path together share one request instead of each globally
       // invalidating — which used to retire the other's just-issued request and refuse a write
       // that was perfectly valid.
       refetchObjectInfoLive: async () =>
-        setWidgetOpts.readObjectInfo((loader, opts) => objectInfoCache.readFresh(loader, opts)),
+        setWidgetOptions.readObjectInfo((loader, opts) => objectInfoCache.readFresh(loader, opts)),
       // What the last oracle attempt observed, so a refusal can say which routes were
       // tried and what each one did instead of asserting an unreachable backend — then,
       // separately, why the last-observed schema could not stand in for them either.
@@ -12308,7 +12349,46 @@ const GRAPH_TOOL_EXECUTORS = {
         }
       },
     };
-    const result = await runSetWidget(node, widget, value, setWidgetOpts);
+    let result;
+    try {
+      result = await runSetWidget(node, widget, value, setWidgetOptions);
+    } catch (err) {
+      // #757 — A REFUSED WRITE MUST NOT LEAVE THE ROW BEHIND.
+      //
+      // The row had to be created before the write (the widget must exist for the ordinary
+      // path to resolve it), but the write can still refuse afterwards. Undoing it here is
+      // what keeps this command all-or-nothing.
+      //
+      // Removed INSIDE the still-open transaction — a catch runs before its finally — so the
+      // state ChangeTracker captures when the transaction closes is the state the command
+      // started from, and the failed attempt leaves no undo entry to step through either.
+      // `remove` also rewinds rgthree's row counter, so a refused write does not silently
+      // spend a row name (see lib/rgthree-lora-row.js: addNewLoraWidget increments BEFORE it
+      // names, and dropping the widget does not undo that).
+      if (undoLoraRow) {
+        try {
+          undoLoraRow();
+          graph.setDirtyCanvas(true, true);
+        } catch {
+          /* best-effort: never replace the refusal with an error about undoing it */
+        }
+        undoLoraRow = null;
+        // The caller is about to receive an exception, but clear the name anyway so no later
+        // reader can attribute a created row to a command that ended up creating none.
+        createdLoraRow = null;
+      }
+      throw err;
+    } finally {
+      // ONE UNDO STEP. The create and the assign both live in the transaction opened above,
+      // and it is closed here EXACTLY once — on success, on refusal, and not at all on the
+      // path where creation never ran (runSetWidget owns its own pair in that case). Its
+      // injected beforeChange/afterChange nest inside this one; ChangeTracker counts the
+      // pairs, so only this outermost close captures state.
+      if (loraRowTxnOpen) {
+        loraRowTxnOpen = false;
+        graph.afterChange();
+      }
+    }
 
     // #418: LiteGraph's `has_errors` red flag is STICKY — repointing a widget from a
     // missing asset (or an invalid value) to a valid one drops the missing-asset

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -215,6 +215,7 @@ import { fetchNodeDefsWithRetry, OBJECT_INFO_RETRY_DELAYS_MS } from "./lib/objec
 import { createObjectInfoCache, CACHE_OUTCOME } from "./lib/object-info-cache.js";
 import { fetchWholeObjectInfo, objectInfoOracleFailureNote } from "./lib/object-info-oracle.js";
 import { createObjectInfoSnapshot, snapshotAuthorizationNote } from "./lib/object-info-snapshot.js";
+import { isRgthreeLoraRowCreation, createRgthreeLoraRow } from "./lib/rgthree-lora-row.js";
 import { objectInfoFingerprint, objectInfoUnchanged } from "./lib/object-info-fingerprint.js";
 import { confirmCanvasNavigation } from "./lib/canvas-navigation.js";
 import {
@@ -12050,6 +12051,36 @@ const GRAPH_TOOL_EXECUTORS = {
     // seed keeps running, so a late response still establishes the baseline and the next
     // call authorizes normally — ordinary latency must never burn the session.
     await awaitObjectInfoHistorySeed();
+    // #757 — MINT an rgthree Power Lora Loader row when the write targets one that does not
+    // exist yet. Those rows are created only by the node's own "➕ Add Lora" button, a
+    // DOM-only control an agent cannot click, so every write to `lora_1` on a fresh node was
+    // refused for a widget no tool could bring into existence. Writing an EXISTING row
+    // already worked; this is the creation half.
+    //
+    // AFTER the history seed and BEFORE runSetWidget, deliberately. The seed is what makes
+    // the #458 authorization meaningful, and creating a row is a mutation — it must not
+    // happen on a call that authorization is about to refuse. runSetWidget then resolves the
+    // now-present widget through the ordinary path, so the composite merge and the #240
+    // verify are unchanged.
+    //
+    // The classifier is keyed on node TYPE + the `lora_<n>` name shape + a lora-slot-shaped
+    // VALUE, all three. That is what keeps it away from the deliberate refusal to auto-press
+    // a control on an ordinary typo — see lib/rgthree-lora-row.js.
+    let createdLoraRow = null;
+    if (isRgthreeLoraRowCreation(node, widget, value)) {
+      // The uuid fence brackets the mutation, as graph_remove_widget does: the user can
+      // switch workflows during the awaits above, and a row must never be grown on a canvas
+      // the caller did not address (#570/#718).
+      assertActiveWorkflowCommandTarget({
+        cmd: "graph_set_widget",
+        [WORKFLOW_UUID_FIELD]: workflow_uuid,
+      });
+      createdLoraRow = createRgthreeLoraRow(node, widget, {
+        beforeChange: () => graph.beforeChange(),
+        afterChange: () => graph.afterChange(),
+        setDirty: () => graph.setDirtyCanvas(true, true),
+      }).created;
+    }
     // Delegate to the shared handler body (web/js/lib/set-widget.js) so this
     // production path and the unit tests run the IDENTICAL ordering: preflight →
     // reconcile-only-a-resolved-node → applyWidgetWrite with the resolved-target
@@ -12310,10 +12341,18 @@ const GRAPH_TOOL_EXECUTORS = {
     // than in `warning`. That channel is single-slot and priority-ordered (link-driven
     // outranks control_after_generate), so appending here would silently displace a warning
     // about what the write actually DOES — a strictly worse trade than a separate field.
+    // #757 — DISCLOSE that the row did not exist and was minted. The caller asked to set a
+    // widget and the panel also GREW the node, which is a structural change to the graph;
+    // reporting only the value write would hide it. Its own field, for the same reason the
+    // #1223 provenance note has one: `warning` is single-slot and priority-ordered.
+    const withCreation = (r) =>
+      createdLoraRow !== null && r && typeof r === "object"
+        ? { ...r, created_widget: createdLoraRow }
+        : r;
     if (setWidgetSchemaFromSnapshot !== null && result && typeof result === "object") {
-      return { ...result, schema_source: "last-observed", schema_note: snapshotAuthorizationNote(setWidgetSchemaFromSnapshot) };
+      return withCreation({ ...result, schema_source: "last-observed", schema_note: snapshotAuthorizationNote(setWidgetSchemaFromSnapshot) });
     }
-    return result;
+    return withCreation(result);
   },
 
   // artokun/comfyui-mcp#938: remove ONE dynamic widget row (rgthree Power Lora Loader

--- a/web/js/lib/rgthree-lora-row.js
+++ b/web/js/lib/rgthree-lora-row.js
@@ -355,8 +355,15 @@ export function createRgthreeLoraRow(node, widgetName, { beforeChange, afterChan
     // would point the next mint at a duplicate. `removeCreatedRow` is best-effort, so ask
     // the node rather than assuming the call worked.
     const rowIsGone = !created || !(node.widgets ?? []).includes(created);
-    const rewound = rowIsGone && restoreRowCounter(node, counterBefore);
+    if (rowIsGone) restoreRowCounter(node, counterBefore);
     if (rowIsGone) restoreNodeSize(node, sizeBefore);
+    // ASK THE NODE, do not trust the attempt. `restoreRowCounter` reports whether it ran an
+    // assignment, not whether the assignment TOOK: a counter that accepts `++` but silently
+    // ignores writes back — a getter-only property, a pack that clamps, a proxy — returns
+    // true from it while the number stays spent. The remedy below is only truthful if the
+    // counter now READS BACK at the value this call started from, which is the same rule the
+    // two refusal branches above and `remove()` below all use.
+    const rewound = rowIsGone && counterBefore !== null && readRowCounter(node) === counterBefore;
     const real = appended.join(", ");
     // The remedy is only truthful if the counter went back. When it did not — an older pack
     // with no readable counter, or one that refuses the write — `real` is the name this

--- a/web/js/lib/rgthree-lora-row.js
+++ b/web/js/lib/rgthree-lora-row.js
@@ -1,0 +1,177 @@
+/**
+ * #757 — `panel_set_widget` could not CREATE an rgthree Power Lora Loader row.
+ *
+ * Reported: a freshly added `Power Lora Loader (rgthree)` carries only
+ * `divider, PowerLoraLoaderHeaderWidget, divider, ➕ Add Lora`. The `lora_1`, `lora_2`, …
+ * rows do not exist until the user clicks **➕ Add Lora**, a DOM-only control an agent
+ * cannot activate — so every write to `lora_1` on a new node was refused for a widget that
+ * could not be brought into existence by any tool. Writing an EXISTING row already works
+ * (the composite schema and dotted sub-fields shipped earlier), so this is creation only.
+ *
+ * WHY THIS LIVES HERE. rgthree mints a row only from `node.addNewLoraWidget()`. The
+ * maintainer probed the generic contract on a live canvas and found `callback`,
+ * `onMouseClick` and `mouseClickCallback` all ACCEPT the call and create nothing — so any
+ * fix written against the widget contract silently no-ops. Only this repo runs in the
+ * browser and holds that node object, which is why the capability cannot be added upstream.
+ * The mirror image already shipped: `panel_remove_widget` (comfyui-mcp#938) removes these
+ * same rows by calling the node's own method and then verifying the list changed.
+ *
+ * WHAT IS DELIBERATELY NOT BEING DONE — the guard this must not become. The panel REFUSES
+ * to auto-press a pressable control (`pressable-widget.js`), and that refusal is correct: a
+ * generic "this node has one button, press it" rule would mutate the graph on an ordinary
+ * TYPO, which is the overwhelmingly common reason a widget name misses. So this route is
+ * keyed on THREE independent facts, all required:
+ *
+ *   1. the node TYPE is Power Lora Loader (rgthree);
+ *   2. the requested name is `lora_<n>` and is ABSENT from the node;
+ *   3. the VALUE is a lora-slot object the existing writer already accepts.
+ *
+ * A typo cannot satisfy all three, and `pressableWidgetHint` stays the answer for every
+ * other node and every other missing name.
+ *
+ * POST-VERIFY, BECAUSE THE METHOD IS PACK-PRIVATE. `addNewLoraWidget` is not ours and is
+ * version-dependent. It is feature-detected (a loud refusal when absent, as
+ * `ltx-director.js` does for its own private entry point) and its EFFECT is verified after
+ * the call, because a silent no-op is exactly what the probe found on the generic
+ * callbacks. Same discipline `remove-widget.js` applies to the removal half.
+ *
+ * NAMES ARE NOT POSITIONAL. rgthree's `loraWidgetsCounter` is monotonic and `configure()`
+ * re-mints rows from serialized ORDER, so after removing `lora_1` the next created row is
+ * NOT necessarily `lora_1`. When the row that appears is not the one asked for, it is
+ * removed again and the refusal names the row that WOULD be created — leaving nothing
+ * behind is what makes a refusal safe to retry.
+ */
+
+import { isLoraSlotObject } from "./widget-write.js";
+
+/** The one node type this route may touch. */
+export const POWER_LORA_LOADER_TYPE = "Power Lora Loader (rgthree)";
+
+/** `lora_1`, `lora_12`, … — the row names rgthree mints. */
+const LORA_ROW_NAME = /^lora_\d+$/;
+
+/** Every widget name currently on the node, as a plain array. Never throws. */
+function widgetNames(node) {
+  try {
+    return (node?.widgets ?? []).map((w) => {
+      try {
+        return w?.name;
+      } catch {
+        return undefined;
+      }
+    });
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Should this write MINT a row first?
+ *
+ * Pure and total — it never throws and never mutates, so a caller can ask before it has
+ * decided to do anything. All three facts must hold; see the header for why.
+ */
+export function isRgthreeLoraRowCreation(node, widgetName, value) {
+  try {
+    const type = node?.type ?? node?.comfyClass;
+    if (type !== POWER_LORA_LOADER_TYPE) return false;
+    if (typeof widgetName !== "string" || !LORA_ROW_NAME.test(widgetName)) return false;
+    // ABSENT only. An existing row is written by the ordinary path, which already handles
+    // the composite merge — minting over it would duplicate the row.
+    if (widgetNames(node).includes(widgetName)) return false;
+    return isLoraSlotObject(value);
+  } catch {
+    return false; // an unreadable node is not one this route may mutate
+  }
+}
+
+/** Drop a widget the node grew but that we are not keeping. Best-effort, never throws. */
+function removeCreatedRow(node, widget) {
+  try {
+    if (typeof node.removeWidget === "function") node.removeWidget(widget);
+    else {
+      const i = (node.widgets ?? []).indexOf(widget);
+      if (i >= 0) node.widgets.splice(i, 1);
+    }
+  } catch {
+    /* reported by the caller's message, never raised over the refusal it explains */
+  }
+}
+
+/**
+ * Create the requested `lora_N` row on an rgthree Power Lora Loader.
+ *
+ * Call ONLY when `isRgthreeLoraRowCreation` is true. Returns `{ created }` naming the row
+ * that now exists; throws with an actionable message otherwise, having left the node as it
+ * found it.
+ */
+export function createRgthreeLoraRow(node, widgetName, { beforeChange, afterChange, setDirty } = {}) {
+  // FEATURE-DETECT, and refuse loudly. A pack that renamed or dropped this method must
+  // produce a refusal a reader can act on, never a silent no-op that reports success.
+  if (typeof node?.addNewLoraWidget !== "function") {
+    throw new Error(
+      `Cannot create "${widgetName}" on node ${node?.id} (${POWER_LORA_LOADER_TYPE}): this ` +
+        `version of the rgthree pack does not expose addNewLoraWidget(), which is the only ` +
+        `way its lora rows are created. Ask the user to click "➕ Add Lora" on the node in ` +
+        `the ComfyUI tab and then set the row — writing an existing row works normally.`,
+    );
+  }
+
+  const before = widgetNames(node);
+
+  beforeChange?.();
+  try {
+    node.addNewLoraWidget();
+  } catch (err) {
+    // The pack's own callback threw. Attribute it rather than letting a raw pack error
+    // surface as though the panel had failed.
+    const detail = (() => {
+      try {
+        return err?.message ? String(err.message) : String(err);
+      } catch {
+        return "the reason could not be rendered";
+      }
+    })();
+    throw new Error(
+      `Cannot create "${widgetName}" on node ${node?.id}: the rgthree pack's own ` +
+        `addNewLoraWidget() threw (${detail}). Nothing was added.`,
+    );
+  } finally {
+    afterChange?.();
+  }
+
+  const after = widgetNames(node);
+  // THE EFFECT, NOT THE CALL. The probe that motivated this file found pack callbacks that
+  // accept a call and create nothing; only comparing the list catches that.
+  const appended = [];
+  const seen = [...before];
+  for (const name of after) {
+    const at = seen.indexOf(name);
+    if (at >= 0) seen.splice(at, 1);
+    else appended.push(name);
+  }
+
+  if (appended.length === 0) {
+    throw new Error(
+      `Cannot create "${widgetName}" on node ${node?.id}: addNewLoraWidget() ran but added ` +
+        `no widget. Nothing was changed.`,
+    );
+  }
+
+  if (!appended.includes(widgetName)) {
+    // rgthree's counter is monotonic, so the row it minted may not be the name asked for.
+    // Take it back out — a refusal that leaves a stray row behind cannot be safely retried.
+    const created = (node.widgets ?? []).find((w) => appended.includes(w?.name));
+    if (created) removeCreatedRow(node, created);
+    const real = appended.join(", ");
+    throw new Error(
+      `Cannot create "${widgetName}" on node ${node?.id}: this node's next row is "${real}", ` +
+        `not "${widgetName}" (rgthree numbers rows from a counter that only ever increases, ` +
+        `so a removed row's name is not reused). The row that was created has been removed ` +
+        `again — nothing was changed. Set "${real}" instead.`,
+    );
+  }
+
+  setDirty?.();
+  return { created: widgetName };
+}

--- a/web/js/lib/rgthree-lora-row.js
+++ b/web/js/lib/rgthree-lora-row.js
@@ -206,6 +206,67 @@ function restoreNodeSize(node, previous) {
   }
 }
 
+// A NEW ROW HAS A SETTLING PERIOD; AN EXISTING ONE DOES NOT. This is the difference that
+// produced two separate P1s, and it is worth stating exactly once, here.
+//
+// `new PowerLoraLoaderWidget()` sets `showModelAndClip = null`, and the field is only
+// synchronised with the node in `draw()` — read verbatim from the pack:
+//
+//     // PowerLoraLoaderWidget.draw
+//     let currentShowModelAndClip =
+//       node.properties[PROP_LABEL_SHOW_STRENGTHS] === PROP_VALUE_SHOW_STRENGTHS_SEPARATE;
+//     if (this.showModelAndClip !== currentShowModelAndClip) {
+//       let oldShowModelAndClip = this.showModelAndClip;
+//       this.showModelAndClip = currentShowModelAndClip;
+//       …
+//     }
+//
+//     // PowerLoraLoaderWidget.serializeValue
+//     const v = { ...this.value };
+//     if (!this.showModelAndClip) { delete v.strengthTwo; }
+//     else { this.value.strengthTwo = this.value.strengthTwo ?? 1; v.strengthTwo = …; }
+//
+// (rgthree-comfy/web/comfyui/power_lora_loader.js.) So a row that has not been DRAWN yet has
+// `showModelAndClip === null`, which is falsy — every serialization takes the first branch and
+// simply drops `strengthTwo`. A human never sees this: they click "➕ Add Lora", the canvas
+// repaints, and the row is settled long before they touch a value. An agent creating and
+// writing in one synchronous command gets no frame in between, so it writes into an unsettled
+// row: the write verifies (nothing touched the value), and the FIRST draw afterwards flips
+// `showModelAndClip` to true, at which point `serializeValue` rewrites `strengthTwo: null` to
+// 1. A verified success that changes later, which is the one thing this file exists to prevent.
+//
+// The fix is to do what the first draw would have done, at creation time. Only the
+// synchronisation is copied — NOT the value adjustment beside it, which the pack itself skips
+// on a first draw (`oldShowModelAndClip != null` is false for a row that has never been drawn).
+// That keeps a created row byte-identical to the same row created by the button and drawn once.
+const RGTHREE_SHOW_STRENGTHS_PROP = "Show Strengths";
+const RGTHREE_SHOW_STRENGTHS_SEPARATE = "Separate Model & Clip";
+
+/**
+ * Put a just-minted row into the state its first canvas draw would have left it in.
+ *
+ * Deliberately NARROW: one named field, mirroring one specific line of the pack's `draw`.
+ * A blanket "copy everything a sibling has" would carry `value` and `name` across and corrupt
+ * the row, and a general "simulate a draw" is not available without a canvas context.
+ *
+ * Best-effort on READS — a node whose `properties` throws simply leaves the row as it was, and
+ * the caller's own verification still applies — but an assignment that throws propagates, so
+ * the creation is rolled back rather than left half-settled.
+ */
+function settleCreatedRow(node, widget) {
+  if (!widget) return;
+  // Absent (not merely null) means this pack build has no such mode: nothing to settle.
+  if (!("showModelAndClip" in widget)) return;
+  if (widget.showModelAndClip !== null && widget.showModelAndClip !== undefined) return;
+  let separate;
+  try {
+    separate = node?.properties?.[RGTHREE_SHOW_STRENGTHS_PROP] === RGTHREE_SHOW_STRENGTHS_SEPARATE;
+  } catch {
+    return; // an unreadable node tells us nothing; leave the row exactly as the pack made it
+  }
+  widget.showModelAndClip = separate;
+}
+
 /** Drop a widget the node grew but that we are not keeping. Best-effort, never throws. */
 function removeCreatedRow(node, widget) {
   try {
@@ -382,9 +443,6 @@ export function createRgthreeLoraRow(node, widgetName, { beforeChange, afterChan
     );
   }
 
-  // GROW THE NODE, as the pack's own button does. Marking the canvas dirty only repaints.
-  fitNodeToRows(node);
-  setDirty?.();
   // The row OBJECT, captured now — see `remove` below.
   const createdWidget = (() => {
     try {
@@ -393,6 +451,29 @@ export function createRgthreeLoraRow(node, widgetName, { beforeChange, afterChan
       return null;
     }
   })();
+  // EVERYTHING BELOW MUTATES A ROW THAT IS ALREADY ON THE NODE while the caller still has no
+  // way to undo it — `remove` is only handed back at the very end, and runSetWidget evaluates
+  // this whole function BEFORE it enters the try that would clean up. So a throw in any of
+  // these steps (a hostile `computeSize`, an injected `setDirty` that raises, a widget whose
+  // mode field has a throwing setter) used to strand the row, the row NAME it had spent and
+  // the height it had grown, while the command reported a failure that had changed the graph.
+  // The tail therefore undoes itself before it rethrows.
+  try {
+    // SETTLE THE ROW BEFORE ANYTHING READS IT. See `settleCreatedRow`.
+    settleCreatedRow(node, createdWidget);
+    // GROW THE NODE, as the pack's own button does. Marking the canvas dirty only repaints.
+    fitNodeToRows(node);
+    try {
+      setDirty?.();
+    } catch {
+      /* a repaint hint is cosmetic — it must never fail a creation that otherwise worked */
+    }
+  } catch (err) {
+    if (createdWidget) removeCreatedRow(node, createdWidget);
+    restoreRowCounter(node, counterBefore);
+    restoreNodeSize(node, sizeBefore);
+    throw err;
+  }
   // The counter as it stands with THIS row's increment and no other. `remove` refuses to
   // rewind unless it still reads exactly this, because anything else means the number it
   // would rewind past is not only ours. See the note on the rollback below.

--- a/web/js/lib/rgthree-lora-row.js
+++ b/web/js/lib/rgthree-lora-row.js
@@ -166,6 +166,83 @@ function restoreRowCounter(node, previous) {
   return false;
 }
 
+/**
+ * Grow the node to fit a row that was just added.
+ *
+ * `addNewLoraWidget` only mints, appends and reorders — it does NOT resize. rgthree's own
+ * "➕ Add Lora" button does the resize itself, right after calling it:
+ *
+ *     this.addNewLoraWidget(value);
+ *     const computed = this.computeSize();
+ *     const tempHeight = this._tempHeight ?? 15;
+ *     this.size[1] = Math.max(tempHeight, computed[1]);
+ *     this.setDirtyCanvas(true, true);
+ *
+ * (rgthree-comfy/web/comfyui/power_lora_loader.js, `addNonLoraWidgets`.) Marking the canvas
+ * dirty is not the same thing: a fresh loader keeps its old height, so the new row can be
+ * clipped or drawn over the button until some unrelated edit resizes the node. Only the
+ * HEIGHT is touched, exactly as the pack does — widening a node the user sized is not ours
+ * to do. Best-effort: a stand-in without `computeSize` simply keeps its size.
+ */
+function fitNodeToRows(node) {
+  try {
+    if (typeof node?.computeSize !== "function" || !Array.isArray(node.size)) return;
+    const computed = node.computeSize();
+    const tempHeight = node._tempHeight ?? 15;
+    node.size[1] = Math.max(tempHeight, computed[1]);
+  } catch {
+    /* a node that cannot measure itself keeps the size it had */
+  }
+}
+
+/** Put a node's size back after a creation is rolled back. Best-effort, never throws. */
+function restoreNodeSize(node, previous) {
+  try {
+    if (!previous || !Array.isArray(node?.size)) return;
+    node.size[0] = previous[0];
+    node.size[1] = previous[1];
+  } catch {
+    /* the row removal is what matters; a stale height is cosmetic */
+  }
+}
+
+/**
+ * Rows this module created and that NOBODY ELSE has written to yet.
+ *
+ * WHY A CLAIM IS NEEDED AT ALL. Websocket command frames run concurrently, so two
+ * `panel_set_widget` calls for the same missing `lora_1` interleave like this: A classifies
+ * it as a creation, mints the row and parks inside the value write; B arrives, sees a row
+ * that now EXISTS, writes it through the ordinary path and reports success; A's write then
+ * fails validation and rolls back. An unconditional rollback deletes the very row B just
+ * wrote and reported — B's success no longer matches the graph, which is a worse outcome
+ * than the stray row the rollback exists to prevent.
+ *
+ * So the rollback is CONDITIONAL: it removes the row only while this call's claim on it is
+ * still standing. Any successful write to the row drops the claim (`noteRgthreeLoraRowWritten`
+ * below), and from that moment the row belongs to the graph, not to this call.
+ *
+ * Keyed on the widget OBJECT and held weakly, so a node that goes away takes its entries
+ * with it and nothing here can keep a widget alive.
+ */
+const rowClaims = new WeakMap();
+
+/**
+ * Record that a write LANDED on `widgetName`, so a concurrent creation will not roll it back.
+ *
+ * Called by `graph_set_widget` after any successful write, not just a creating one — the
+ * whole point is that the write which saves the row is usually somebody ELSE'S request.
+ * Total and silent: a node it cannot read simply has no claims to drop.
+ */
+export function noteRgthreeLoraRowWritten(node, widgetName) {
+  try {
+    for (const w of node?.widgets ?? []) {
+      if (w?.name === widgetName) rowClaims.delete(w);
+    }
+  } catch {
+    /* nothing to drop */
+  }
+}
+
 /** Drop a widget the node grew but that we are not keeping. Best-effort, never throws. */
 function removeCreatedRow(node, widget) {
   try {
@@ -206,6 +283,26 @@ export function createRgthreeLoraRow(node, widgetName, { beforeChange, afterChan
   // Snapshot the counter BEFORE the mint, so either refusal below can put it back and mean
   // it when it says nothing was changed. See `restoreRowCounter`.
   const counterBefore = readRowCounter(node);
+  // …and the size, so a rollback puts back the height the creation grew. See `fitNodeToRows`.
+  const sizeBefore = (() => {
+    try {
+      return Array.isArray(node?.size) ? [node.size[0], node.size[1]] : null;
+    } catch {
+      return null;
+    }
+  })();
+
+  /** Rows on the node now that were not there before this call. */
+  const appendedSince = () => {
+    const grown = [];
+    const seen = [...before];
+    for (const name of widgetNames(node)) {
+      const at = seen.indexOf(name);
+      if (at >= 0) seen.splice(at, 1);
+      else grown.push(name);
+    }
+    return grown;
+  };
 
   beforeChange?.();
   try {
@@ -220,29 +317,44 @@ export function createRgthreeLoraRow(node, widgetName, { beforeChange, afterChan
         return "the reason could not be rendered";
       }
     })();
+    // A THROW IS NOT A NO-OP. The shipped method is
+    //   `this.loraWidgetsCounter++; const w = this.addCustomWidget(new PowerLoraLoaderWidget(...));
+    //    if (lora) w.setLora(lora); moveArrayItem(this.widgets, w, ...)`
+    // so the counter is spent FIRST and the widget is appended SECOND. A throw in any later
+    // step leaves the number burnt and can leave the row on the node — reporting "nothing was
+    // added" without looking would be asserting something we never checked. Clean up whatever
+    // did land, and say which of the two it was.
+    const stranded = appendedSince();
+    for (const name of stranded) {
+      const w = (node.widgets ?? []).find((x) => x?.name === name);
+      if (w) removeCreatedRow(node, w);
+    }
+    const rowsGone = appendedSince().length === 0;
+    const rewound = rowsGone && restoreRowCounter(node, counterBefore);
+    if (rowsGone) restoreNodeSize(node, sizeBefore);
+    const cleaned = rowsGone && (rewound || counterBefore === null || readRowCounter(node) === counterBefore);
     throw new Error(
       `Cannot create "${widgetName}" on node ${node?.id}: the rgthree pack's own ` +
-        `addNewLoraWidget() threw (${detail}). Nothing was added.`,
+        `addNewLoraWidget() threw (${detail}). ` +
+        (cleaned
+          ? `Anything it had already added was removed again, so nothing was changed.`
+          : `It had already changed the node before it threw, and that could not be fully ` +
+            `undone${stranded.length ? ` (${stranded.join(", ")})` : ""} — inspect the node ` +
+            `before retrying.`),
     );
   } finally {
     afterChange?.();
   }
 
-  const after = widgetNames(node);
   // THE EFFECT, NOT THE CALL. The probe that motivated this file found pack callbacks that
   // accept a call and create nothing; only comparing the list catches that.
-  const appended = [];
-  const seen = [...before];
-  for (const name of after) {
-    const at = seen.indexOf(name);
-    if (at >= 0) seen.splice(at, 1);
-    else appended.push(name);
-  }
+  const appended = appendedSince();
 
   if (appended.length === 0) {
     // No row appeared, but the counter may still have been bumped before whatever went
     // wrong. Put it back, or this failed attempt silently costs the node a row name.
     restoreRowCounter(node, counterBefore);
+    restoreNodeSize(node, sizeBefore);
     throw new Error(
       `Cannot create "${widgetName}" on node ${node?.id}: addNewLoraWidget() ran but added ` +
         `no widget. Nothing was changed.`,
@@ -259,6 +371,7 @@ export function createRgthreeLoraRow(node, widgetName, { beforeChange, afterChan
     // the node rather than assuming the call worked.
     const rowIsGone = !created || !(node.widgets ?? []).includes(created);
     const rewound = rowIsGone && restoreRowCounter(node, counterBefore);
+    if (rowIsGone) restoreNodeSize(node, sizeBefore);
     const real = appended.join(", ");
     // The remedy is only truthful if the counter went back. When it did not — an older pack
     // with no readable counter, or one that refuses the write — `real` is the name this
@@ -277,6 +390,8 @@ export function createRgthreeLoraRow(node, widgetName, { beforeChange, afterChan
     );
   }
 
+  // GROW THE NODE, as the pack's own button does. Marking the canvas dirty only repaints.
+  fitNodeToRows(node);
   setDirty?.();
   // The row OBJECT, captured now — see `remove` below.
   const createdWidget = (() => {
@@ -286,6 +401,19 @@ export function createRgthreeLoraRow(node, widgetName, { beforeChange, afterChan
       return null;
     }
   })();
+  // The counter as it stands with THIS row's increment and no other. `remove` refuses to
+  // rewind unless it still reads exactly this, because anything else means the number it
+  // would rewind past is not only ours. See the note on the rollback below.
+  const counterAfter = readRowCounter(node);
+  // Claim the row until somebody's write lands on it. See `rowClaims`.
+  const claim = {};
+  if (createdWidget) {
+    try {
+      rowClaims.set(createdWidget, claim);
+    } catch {
+      /* an unclaimable widget simply cannot be rolled back — checked in `remove` */
+    }
+  }
   return {
     created: widgetName,
     /**
@@ -300,19 +428,44 @@ export function createRgthreeLoraRow(node, widgetName, { beforeChange, afterChan
      * answers to that name then, which after an intervening `configure()` — rgthree re-mints
      * rows from serialized order — is not necessarily the widget this call grew.
      *
+     * ONLY WHILE THE CLAIM STANDS. Command frames run concurrently: another request can see
+     * the row this call created, write it, and report success while this call is still
+     * awaiting. Deleting it then would contradict a success somebody has already been told
+     * about — worse than the stray row this rollback exists to prevent. So a row that has
+     * been written by anyone is left alone, and the refusal simply says so. See `rowClaims`.
+     *
      * BOTH HALVES, for the reason `restoreRowCounter` exists: `addNewLoraWidget` increments
      * before it names, so dropping only the widget leaves the number spent and the next mint
-     * lands further along. Rewound only once the row is confirmed gone, never while the name
-     * is still held. Never throws — an undo running on an error path must not replace the
-     * refusal with an error about the undo.
+     * lands further along.
+     *
+     * BUT NEVER PAST SOMEBODY ELSE'S INCREMENT. The counter is rewound only when it still
+     * reads exactly what this call left it at. If another row was added in the meantime the
+     * counter includes that one too, and winding back to `counterBefore` would re-issue names
+     * that are already taken — create lora_1, add lora_2, roll back, and the next two mints
+     * are lora_1 and a DUPLICATE lora_2. A burnt number is recoverable; two rows with the
+     * same name are not.
+     *
+     * Returns true when the row was actually taken back out. Never throws — an undo running
+     * on an error path must not replace the refusal with an error about the undo.
      */
     remove: () => {
       try {
+        if (!createdWidget) return false;
+        // Somebody else's write landed here first; the row is the graph's now, not ours.
+        if (rowClaims.get(createdWidget) !== claim) return false;
+        rowClaims.delete(createdWidget);
         removeCreatedRow(node, createdWidget);
-        const rowIsGone = !createdWidget || !(node.widgets ?? []).includes(createdWidget);
-        if (rowIsGone) restoreRowCounter(node, counterBefore);
+        const rowIsGone = !(node.widgets ?? []).includes(createdWidget);
+        if (!rowIsGone) return false;
+        // Only when the counter is still exactly this call's increment.
+        if (counterAfter !== null && readRowCounter(node) === counterAfter) {
+          restoreRowCounter(node, counterBefore);
+        }
+        restoreNodeSize(node, sizeBefore);
+        return true;
       } catch {
         /* best-effort: the refusal this is undoing is the message that reaches the caller */
+        return false;
       }
     },
   };

--- a/web/js/lib/rgthree-lora-row.js
+++ b/web/js/lib/rgthree-lora-row.js
@@ -423,24 +423,57 @@ export function createRgthreeLoraRow(node, widgetName, { beforeChange, afterChan
      * are lora_1 and a DUPLICATE lora_2. A burnt number is recoverable; two rows with the
      * same name are not.
      *
-     * Returns true when the row was actually taken back out. Never throws — an undo running
-     * on an error path must not replace the refusal with an error about the undo.
+     * Returns `{ removed, incomplete }`. `removed` says whether the row itself went;
+     * `incomplete` is a sentence for the caller to disclose when the rollback could NOT put
+     * everything back, or null when it could. Never throws — an undo running on an error path
+     * must not replace the refusal with an error about the undo.
+     *
+     * WHY AN UNRESTORED COUNTER IS A REPORTABLE OUTCOME AND NOT A SHRUG. A pack that exposes
+     * `addNewLoraWidget` but hides or freezes `loraWidgetsCounter` lets this call mint a row,
+     * lets the write refuse it (a slot with an invalid field type), and then takes the row
+     * back out — but the NAME stays spent. Returning a bare success there told the caller
+     * only that its value was invalid, so the obvious retry (same `lora_N`, corrected value)
+     * mints a LATER row and refuses again on the name, which is the same unfollowable advice
+     * the mismatch refusal already had to stop giving.
      */
     remove: () => {
       try {
-        if (!createdWidget) return false;
+        if (!createdWidget) return { removed: false, incomplete: null };
         removeCreatedRow(node, createdWidget);
         const rowIsGone = !(node.widgets ?? []).includes(createdWidget);
-        if (!rowIsGone) return false;
+        if (!rowIsGone) {
+          return {
+            removed: false,
+            incomplete:
+              `The row "${widgetName}" this call had added could not be removed again and is ` +
+              `still on the node — inspect the node before retrying.`,
+          };
+        }
         // Only when the counter is still exactly this call's increment.
         if (counterAfter !== null && readRowCounter(node) === counterAfter) {
           restoreRowCounter(node, counterBefore);
         }
         restoreNodeSize(node, sizeBefore);
-        return true;
+        // DID IT COME BACK? Asked of the NODE, not of the attempt — the same rule the two
+        // refusal branches above use. `restoreRowCounter` reports false both when it could
+        // not write and when there was nothing to undo, so its return cannot tell those
+        // apart; reading the counter can. A counter that never moved is clean, an unreadable
+        // or unwritable one is not, and a counter another row has since advanced is not ours
+        // to wind back and leaves this name spent all the same.
+        const counterBack = counterBefore !== null && readRowCounter(node) === counterBefore;
+        return {
+          removed: true,
+          incomplete: counterBack
+            ? null
+            : `The row "${widgetName}" it had created was removed again, but this node's row ` +
+              `counter could not be ${counterBefore === null ? "read" : "rewound"}, so that name ` +
+              `is used up: the next row will be numbered later than you expect. Read the node ` +
+              `with panel_query_graph before retrying — asking for "${widgetName}" again will ` +
+              `create a differently-named row and refuse a second time.`,
+        };
       } catch {
         /* best-effort: the refusal this is undoing is the message that reaches the caller */
-        return false;
+        return { removed: false, incomplete: null };
       }
     },
   };

--- a/web/js/lib/rgthree-lora-row.js
+++ b/web/js/lib/rgthree-lora-row.js
@@ -206,43 +206,6 @@ function restoreNodeSize(node, previous) {
   }
 }
 
-/**
- * Rows this module created and that NOBODY ELSE has written to yet.
- *
- * WHY A CLAIM IS NEEDED AT ALL. Websocket command frames run concurrently, so two
- * `panel_set_widget` calls for the same missing `lora_1` interleave like this: A classifies
- * it as a creation, mints the row and parks inside the value write; B arrives, sees a row
- * that now EXISTS, writes it through the ordinary path and reports success; A's write then
- * fails validation and rolls back. An unconditional rollback deletes the very row B just
- * wrote and reported — B's success no longer matches the graph, which is a worse outcome
- * than the stray row the rollback exists to prevent.
- *
- * So the rollback is CONDITIONAL: it removes the row only while this call's claim on it is
- * still standing. Any successful write to the row drops the claim (`noteRgthreeLoraRowWritten`
- * below), and from that moment the row belongs to the graph, not to this call.
- *
- * Keyed on the widget OBJECT and held weakly, so a node that goes away takes its entries
- * with it and nothing here can keep a widget alive.
- */
-const rowClaims = new WeakMap();
-
-/**
- * Record that a write LANDED on `widgetName`, so a concurrent creation will not roll it back.
- *
- * Called by `graph_set_widget` after any successful write, not just a creating one — the
- * whole point is that the write which saves the row is usually somebody ELSE'S request.
- * Total and silent: a node it cannot read simply has no claims to drop.
- */
-export function noteRgthreeLoraRowWritten(node, widgetName) {
-  try {
-    for (const w of node?.widgets ?? []) {
-      if (w?.name === widgetName) rowClaims.delete(w);
-    }
-  } catch {
-    /* nothing to drop */
-  }
-}
-
 /** Drop a widget the node grew but that we are not keeping. Best-effort, never throws. */
 function removeCreatedRow(node, widget) {
   try {
@@ -330,17 +293,29 @@ export function createRgthreeLoraRow(node, widgetName, { beforeChange, afterChan
       if (w) removeCreatedRow(node, w);
     }
     const rowsGone = appendedSince().length === 0;
-    const rewound = rowsGone && restoreRowCounter(node, counterBefore);
+    restoreRowCounter(node, counterBefore);
     if (rowsGone) restoreNodeSize(node, sizeBefore);
-    const cleaned = rowsGone && (rewound || counterBefore === null || readRowCounter(node) === counterBefore);
+    // AN UNKNOWN COUNTER IS AN INCOMPLETE ROLLBACK, not a clean one. When the pack exposes
+    // no readable `loraWidgetsCounter` we cannot see whether the throw happened after the
+    // private increment — and it happens FIRST in the shipped method, so it probably did.
+    // Treating `counterBefore === null` as "nothing changed" told the caller a retry was
+    // safe when a row name had in fact been consumed, which is the same unfollowable advice
+    // the mismatch refusal already had to stop giving. Only a counter we can READ and that
+    // now READS BACK unchanged counts as restored.
+    const counterRestored = counterBefore !== null && readRowCounter(node) === counterBefore;
     throw new Error(
       `Cannot create "${widgetName}" on node ${node?.id}: the rgthree pack's own ` +
         `addNewLoraWidget() threw (${detail}). ` +
-        (cleaned
+        (rowsGone && counterRestored
           ? `Anything it had already added was removed again, so nothing was changed.`
-          : `It had already changed the node before it threw, and that could not be fully ` +
-            `undone${stranded.length ? ` (${stranded.join(", ")})` : ""} — inspect the node ` +
-            `before retrying.`),
+          : !rowsGone
+            ? `It had already changed the node before it threw, and that could not be fully ` +
+              `undone (${stranded.join(", ")} is still on the node) — inspect the node before ` +
+              `retrying.`
+            : `The row it had started to add was removed again, but this node's row counter ` +
+              `could not be ${counterBefore === null ? "read" : "rewound"}, so it may have ` +
+              `consumed a row name before it threw — the next row could be numbered later ` +
+              `than you expect. Read the node before retrying.`),
     );
   } finally {
     afterChange?.();
@@ -355,9 +330,19 @@ export function createRgthreeLoraRow(node, widgetName, { beforeChange, afterChan
     // wrong. Put it back, or this failed attempt silently costs the node a row name.
     restoreRowCounter(node, counterBefore);
     restoreNodeSize(node, sizeBefore);
+    // Same rule as the throw path above: only a counter we can read, and that reads back
+    // unchanged, licenses "nothing was changed". A pack that hides its counter may well have
+    // advanced it — the increment comes first in the shipped method — and a caller told
+    // nothing changed will retry into a row name that has already moved.
+    const counterRestored = counterBefore !== null && readRowCounter(node) === counterBefore;
     throw new Error(
       `Cannot create "${widgetName}" on node ${node?.id}: addNewLoraWidget() ran but added ` +
-        `no widget. Nothing was changed.`,
+        `no widget. ` +
+        (counterRestored
+          ? `Nothing was changed.`
+          : `This node's row counter could not be ${counterBefore === null ? "read" : "rewound"}, ` +
+            `so the call may still have consumed a row name — the next row could be numbered ` +
+            `later than you expect. Read the node before retrying.`),
     );
   }
 
@@ -405,15 +390,6 @@ export function createRgthreeLoraRow(node, widgetName, { beforeChange, afterChan
   // rewind unless it still reads exactly this, because anything else means the number it
   // would rewind past is not only ours. See the note on the rollback below.
   const counterAfter = readRowCounter(node);
-  // Claim the row until somebody's write lands on it. See `rowClaims`.
-  const claim = {};
-  if (createdWidget) {
-    try {
-      rowClaims.set(createdWidget, claim);
-    } catch {
-      /* an unclaimable widget simply cannot be rolled back — checked in `remove` */
-    }
-  }
   return {
     created: widgetName,
     /**
@@ -428,11 +404,13 @@ export function createRgthreeLoraRow(node, widgetName, { beforeChange, afterChan
      * answers to that name then, which after an intervening `configure()` — rgthree re-mints
      * rows from serialized order — is not necessarily the widget this call grew.
      *
-     * ONLY WHILE THE CLAIM STANDS. Command frames run concurrently: another request can see
-     * the row this call created, write it, and report success while this call is still
-     * awaiting. Deleting it then would contradict a success somebody has already been told
-     * about — worse than the stray row this rollback exists to prevent. So a row that has
-     * been written by anyone is left alone, and the refusal simply says so. See `rowClaims`.
+     * CALLED IN THE SAME SYNCHRONOUS STRETCH AS THE CREATION, from runSetWidget's write
+     * boundary. That is what makes it safe to remove the row unconditionally: no other
+     * command frame, user gesture or undo capture can run between the two, so the row can
+     * only be the one this call grew and untouched since. An earlier version created the row
+     * before an awaited /object_info fetch and needed a claim to avoid deleting a row a
+     * concurrent request had written; moving the creation past the await removed the window
+     * instead, and the claim with it.
      *
      * BOTH HALVES, for the reason `restoreRowCounter` exists: `addNewLoraWidget` increments
      * before it names, so dropping only the widget leaves the number spent and the next mint
@@ -451,9 +429,6 @@ export function createRgthreeLoraRow(node, widgetName, { beforeChange, afterChan
     remove: () => {
       try {
         if (!createdWidget) return false;
-        // Somebody else's write landed here first; the row is the graph's now, not ours.
-        if (rowClaims.get(createdWidget) !== claim) return false;
-        rowClaims.delete(createdWidget);
         removeCreatedRow(node, createdWidget);
         const rowIsGone = !(node.widgets ?? []).includes(createdWidget);
         if (!rowIsGone) return false;

--- a/web/js/lib/rgthree-lora-row.js
+++ b/web/js/lib/rgthree-lora-row.js
@@ -24,7 +24,8 @@
  *
  *   1. the node TYPE is Power Lora Loader (rgthree);
  *   2. the requested name is `lora_<n>` and is ABSENT from the node;
- *   3. the VALUE is a lora-slot object the existing writer already accepts.
+ *   3. the VALUE is a lora-slot object the existing writer already accepts — read through
+ *      `slotValue`, because in production it arrives as a JSON STRING.
  *
  * A typo cannot satisfy all three, and `pressableWidgetHint` stays the answer for every
  * other node and every other missing name.
@@ -74,6 +75,34 @@ function widgetNames(node) {
 }
 
 /**
+ * The slot object a caller actually sent, or null.
+ *
+ * A LORA ROW ARRIVES AS A JSON STRING IN PRODUCTION, and missing that made the first version
+ * of this file DEAD CODE. `panel_set_widget` carries scalar values, and `coerceWidgetValue`
+ * is what turns the string into an object — at `widget-write.js:508-512`, well AFTER this
+ * classifier runs. So testing the raw argument with `isLoraSlotObject` answered "not a slot"
+ * for every real request: the route never fired and the reported refusal stood, while the
+ * unit tests passed because they handed in objects. That is the shape the tests chose, not
+ * the shape the tool sends.
+ *
+ * Parsed with the same tolerance the writer uses: a string that is not valid JSON, or that
+ * parses to something which is not a slot, is simply not a creation request. Nothing here
+ * widens what counts as a slot — `isLoraSlotObject` remains the only judge, and it is asked
+ * about the parsed value rather than about a string it would always reject.
+ */
+function slotValue(value) {
+  if (isLoraSlotObject(value)) return value;
+  if (typeof value !== "string") return null;
+  let parsed;
+  try {
+    parsed = JSON.parse(value);
+  } catch {
+    return null;
+  }
+  return isLoraSlotObject(parsed) ? parsed : null;
+}
+
+/**
  * Should this write MINT a row first?
  *
  * Pure and total — it never throws and never mutates, so a caller can ask before it has
@@ -87,7 +116,7 @@ export function isRgthreeLoraRowCreation(node, widgetName, value) {
     // ABSENT only. An existing row is written by the ordinary path, which already handles
     // the composite merge — minting over it would duplicate the row.
     if (widgetNames(node).includes(widgetName)) return false;
-    return isLoraSlotObject(value);
+    return slotValue(value) !== null;
   } catch {
     return false; // an unreadable node is not one this route may mutate
   }
@@ -140,6 +169,9 @@ function restoreRowCounter(node, previous) {
 /** Drop a widget the node grew but that we are not keeping. Best-effort, never throws. */
 function removeCreatedRow(node, widget) {
   try {
+    // Nothing to remove is a successful no-op, not a call with a missing argument: a node's
+    // `removeWidget(undefined)` is pack code this file does not control.
+    if (!widget) return;
     if (typeof node.removeWidget === "function") node.removeWidget(widget);
     else {
       const i = (node.widgets ?? []).indexOf(widget);
@@ -153,9 +185,10 @@ function removeCreatedRow(node, widget) {
 /**
  * Create the requested `lora_N` row on an rgthree Power Lora Loader.
  *
- * Call ONLY when `isRgthreeLoraRowCreation` is true. Returns `{ created }` naming the row
- * that now exists; throws with an actionable message otherwise, having left the node as it
- * found it.
+ * Call ONLY when `isRgthreeLoraRowCreation` is true. Returns `{ created, remove }` — the name
+ * of the row that now exists, and the undo for it, which the caller MUST run if the write it
+ * made room for goes on to refuse. Throws with an actionable message otherwise, having left
+ * the node as it found it.
  */
 export function createRgthreeLoraRow(node, widgetName, { beforeChange, afterChange, setDirty } = {}) {
   // FEATURE-DETECT, and refuse loudly. A pack that renamed or dropped this method must
@@ -245,5 +278,42 @@ export function createRgthreeLoraRow(node, widgetName, { beforeChange, afterChan
   }
 
   setDirty?.();
-  return { created: widgetName };
+  // The row OBJECT, captured now — see `remove` below.
+  const createdWidget = (() => {
+    try {
+      return (node.widgets ?? []).find((w) => w?.name === widgetName) ?? null;
+    } catch {
+      return null;
+    }
+  })();
+  return {
+    created: widgetName,
+    /**
+     * Take this creation back out again.
+     *
+     * The caller needs it because creation has to happen BEFORE the value write (the widget
+     * must exist for the ordinary path to resolve it) while the write can still refuse
+     * afterwards. Reporting that refusal over a node this command had already GROWN is the
+     * mutate-then-refuse shape the panel works to avoid, and every retry would add a row.
+     *
+     * BY IDENTITY, not by name. Re-finding `lora_N` at undo time would remove whatever
+     * answers to that name then, which after an intervening `configure()` — rgthree re-mints
+     * rows from serialized order — is not necessarily the widget this call grew.
+     *
+     * BOTH HALVES, for the reason `restoreRowCounter` exists: `addNewLoraWidget` increments
+     * before it names, so dropping only the widget leaves the number spent and the next mint
+     * lands further along. Rewound only once the row is confirmed gone, never while the name
+     * is still held. Never throws — an undo running on an error path must not replace the
+     * refusal with an error about the undo.
+     */
+    remove: () => {
+      try {
+        removeCreatedRow(node, createdWidget);
+        const rowIsGone = !createdWidget || !(node.widgets ?? []).includes(createdWidget);
+        if (rowIsGone) restoreRowCounter(node, counterBefore);
+      } catch {
+        /* best-effort: the refusal this is undoing is the message that reaches the caller */
+      }
+    },
+  };
 }

--- a/web/js/lib/rgthree-lora-row.js
+++ b/web/js/lib/rgthree-lora-row.js
@@ -38,8 +38,16 @@
  * NAMES ARE NOT POSITIONAL. rgthree's `loraWidgetsCounter` is monotonic and `configure()`
  * re-mints rows from serialized ORDER, so after removing `lora_1` the next created row is
  * NOT necessarily `lora_1`. When the row that appears is not the one asked for, it is
- * removed again and the refusal names the row that WOULD be created — leaving nothing
- * behind is what makes a refusal safe to retry.
+ * removed again and the refusal names the row that WOULD be created.
+ *
+ * AND THE COUNTER IS REWOUND WITH IT, which is the part that makes that refusal usable.
+ * `addNewLoraWidget` increments before it names, and removing the row does not undo the
+ * increment — so a refusal that only removed the widget would say `the next row is
+ * "lora_7" … nothing was changed. Set "lora_7" instead` while having already moved the next
+ * name to `lora_8`. Following the advice refuses again, one name further along, forever.
+ * That was measured, not reasoned about. Undoing the mutation means undoing BOTH halves of
+ * it; when the counter cannot be rewound the message stops promising a retry that would not
+ * work. Leaving nothing behind is what makes a refusal safe to retry.
  */
 
 import { isLoraSlotObject } from "./widget-write.js";
@@ -85,6 +93,50 @@ export function isRgthreeLoraRowCreation(node, widgetName, value) {
   }
 }
 
+/**
+ * rgthree's monotonic row counter, when this node exposes a readable one.
+ *
+ * Read so a refusal can put it BACK — see `restoreRowCounter`. Never used to DECIDE
+ * anything: the name that appeared is established by comparing the widget list, because a
+ * pack-private field is not a contract and the whole point of the post-verify is that the
+ * call's effect is the only thing worth trusting.
+ */
+function readRowCounter(node) {
+  try {
+    const n = node?.loraWidgetsCounter;
+    return typeof n === "number" && Number.isFinite(n) ? n : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Put the counter back after a refusal removed the row that advanced it.
+ *
+ * WITHOUT THIS THE REFUSAL IS A TRAP. `addNewLoraWidget` does `loraWidgetsCounter++` before
+ * it names the row, and removing the row does not undo the increment. So a refusal that
+ * says `the next row is "lora_7" … nothing was changed. Set "lora_7" instead` was wrong on
+ * BOTH counts the moment it was printed: something *had* changed, and the very next call
+ * mints `lora_8`. Following the advice refuses again, one name further along, forever —
+ * measured on a faithful stand-in before this was written.
+ *
+ * Best-effort and narrow: only ever lowers a counter this call raised, never touches one it
+ * cannot read, and the caller only asks once the row is confirmed gone — restoring while a
+ * row still holds the name would hand the next mint a duplicate.
+ */
+function restoreRowCounter(node, previous) {
+  if (previous === null) return false;
+  try {
+    if (typeof node.loraWidgetsCounter === "number" && node.loraWidgetsCounter > previous) {
+      node.loraWidgetsCounter = previous;
+      return true;
+    }
+  } catch {
+    /* an unwritable counter is reported by the caller's wording, never raised */
+  }
+  return false;
+}
+
 /** Drop a widget the node grew but that we are not keeping. Best-effort, never throws. */
 function removeCreatedRow(node, widget) {
   try {
@@ -118,6 +170,9 @@ export function createRgthreeLoraRow(node, widgetName, { beforeChange, afterChan
   }
 
   const before = widgetNames(node);
+  // Snapshot the counter BEFORE the mint, so either refusal below can put it back and mean
+  // it when it says nothing was changed. See `restoreRowCounter`.
+  const counterBefore = readRowCounter(node);
 
   beforeChange?.();
   try {
@@ -152,6 +207,9 @@ export function createRgthreeLoraRow(node, widgetName, { beforeChange, afterChan
   }
 
   if (appended.length === 0) {
+    // No row appeared, but the counter may still have been bumped before whatever went
+    // wrong. Put it back, or this failed attempt silently costs the node a row name.
+    restoreRowCounter(node, counterBefore);
     throw new Error(
       `Cannot create "${widgetName}" on node ${node?.id}: addNewLoraWidget() ran but added ` +
         `no widget. Nothing was changed.`,
@@ -163,12 +221,26 @@ export function createRgthreeLoraRow(node, widgetName, { beforeChange, afterChan
     // Take it back out — a refusal that leaves a stray row behind cannot be safely retried.
     const created = (node.widgets ?? []).find((w) => appended.includes(w?.name));
     if (created) removeCreatedRow(node, created);
+    // ONLY once the row is really gone: restoring the counter while the name is still held
+    // would point the next mint at a duplicate. `removeCreatedRow` is best-effort, so ask
+    // the node rather than assuming the call worked.
+    const rowIsGone = !created || !(node.widgets ?? []).includes(created);
+    const rewound = rowIsGone && restoreRowCounter(node, counterBefore);
     const real = appended.join(", ");
+    // The remedy is only truthful if the counter went back. When it did not — an older pack
+    // with no readable counter, or one that refuses the write — `real` is the name this
+    // attempt CONSUMED, and the next one lands further along. Say which world we are in
+    // rather than printing advice that cannot work; a wrong remedy costs a name per retry.
+    const remedy = rewound
+      ? `The row that was created has been removed again and the row counter was rewound — ` +
+        `nothing was changed. Set "${real}" instead.`
+      : `The row that was created has been removed again, but this node's row counter could ` +
+        `not be rewound, so "${real}" is now used up and the next row will be named later ` +
+        `still. Ask the user to click "➕ Add Lora" on the node and then set the row it adds.`;
     throw new Error(
       `Cannot create "${widgetName}" on node ${node?.id}: this node's next row is "${real}", ` +
         `not "${widgetName}" (rgthree numbers rows from a counter that only ever increases, ` +
-        `so a removed row's name is not reused). The row that was created has been removed ` +
-        `again — nothing was changed. Set "${real}" instead.`,
+        `so a removed row's name is not reused). ${remedy}`,
     );
   }
 

--- a/web/js/lib/set-widget.js
+++ b/web/js/lib/set-widget.js
@@ -42,6 +42,23 @@ import {
   serverDeclaresEmptyComboOptions,
 } from "./input-asset.js";
 
+/**
+ * Fire an undo-history hook that can never escape.
+ *
+ * Mirrors widget-write.js's own `safeBefore`/`safeAfter`: history bookkeeping is best-effort,
+ * and a throwing `graph.onBeforeChange` / `onAfterChange` must never decide the outcome it is
+ * merely bracketing. Used around the created-target cleanup, where an escaping OPEN would
+ * skip the cleanup entirely (leaving the row and the row name it spent) and an escaping CLOSE
+ * would replace the refusal the caller actually needs to read.
+ */
+function safeHistoryHook(hook) {
+  try {
+    hook?.();
+  } catch {
+    /* history hook is best-effort */
+  }
+}
+
 /** A never-throwing rendering of an advisory failure. Used on the POST-WRITE path, where
  *  a second exception (a getter on `message`, a null throw) must not escape either. */
 function coerceAdvisoryMessage(err) {
@@ -479,46 +496,49 @@ export async function runSetWidget(
     //   - a concurrent command frame could write the row and be told it succeeded, only
     //     for the original call's rollback to delete it.
     // Placed here, none of those windows exist: `applyWidgetWrite` is synchronous, so
-    // nothing — no other command frame, no user gesture, no capture — can run between the
+    // nothing — no other command frame, no user gesture, no user edit — can run between the
     // creation, the write and the undo below. The guards those three defects each needed
     // are removed rather than kept, because the interleaving they defended against is now
-    // unreachable.
+    // unreachable. (The one thing that DOES happen in between is applyWidgetWrite's own
+    // history capture, which is the same one every ordinary write takes — see below.)
     //
     // AFTER the fence, so a workflow switch during the fetch refuses before the mutation.
     // Called once per attempt and expected to be idempotent: the stale-combo and upload
     // retries re-enter `write`, and by then the target it created already exists.
     //
-    // ONE HISTORY TRANSACTION AROUND THE WHOLE TRIPLE. applyWidgetWrite opens and CLOSES its
-    // own undo envelope — two of them on the failure path, since it rolls a bad value back in
-    // an envelope of its own — and a close that reaches zero is what makes ComfyUI's
-    // ChangeTracker CAPTURE. So a post-assignment refusal (the #240 read-back rejecting a
-    // value the widget's setter normalized) captured a snapshot with the created target and
-    // the rejected value still in it, and the cleanup below then removed that target with no
-    // envelope open and nothing captured. The tracker's newest snapshot was a graph that no
-    // longer existed, so the next Ctrl+Z restored the refused command instead of stepping
-    // over it — the refusal was supposed to be a no-op.
+    // THE CLEANUP GETS ITS OWN ENVELOPE, AND THE WRITE KEEPS ITS OWN VERIFICATION ORDER.
     //
-    // An OUTER envelope keeps the inner closes from ever reaching zero, so exactly one
-    // capture happens: at the end, over the graph as it really finished, cleanup included.
+    // An earlier version wrapped preparation, write and cleanup in ONE outer envelope so that
+    // a refused creating write took no capture until the very end. That inverted something
+    // load-bearing. `applyWidgetWrite` deliberately verifies AFTER its own afterChange has
+    // fired — see widget-write.js: "an afterChange hook can itself re-stale a widget or
+    // change the promotion topology, and that must be caught too". Nesting its envelope
+    // inside another one means its close never reaches zero, so the CAPTURE — and every pack
+    // `serializeValue` that the capture's serialization runs — happens after the last
+    // verification. An rgthree loader in Separate Model & Clip mode rewrites
+    // `strengthTwo: null` to 1 exactly there, and the creating path then reported plain
+    // success for a value an EXISTING-row write would have reported as normalized.
     //
-    // THIS IS NOT THE ROUND-2 DEFECT COMING BACK. That one held a transaction across an
-    // AWAIT, where a workflow switch could detach the canvas before the close and wedge the
-    // tracker at changeCount 1 for the session. Everything between these two calls is
-    // synchronous and cannot yield — which is exactly the property that moving the creation
-    // here established. Keep it that way: no await may be introduced inside this bracket.
+    // THE ASYMMETRY WAS THE TELL. Creation must report whatever an ordinary write reports for
+    // the same value, and the only way it can is by being verified the same way. So
+    // applyWidgetWrite is called with nothing wrapped around it, exactly as every other write
+    // path calls it, and only the CLEANUP is bracketed.
     //
-    // OPENED THE MOMENT THERE IS SOMETHING TO PROTECT, AND NOT BEFORE. The envelope wraps the
-    // write and the cleanup; the preparation itself sits just outside it, deliberately.
-    // Opening first would mean bracketing a graph that never changed whenever the preparation
-    // REFUSES (a pack with no addNewLoraWidget), and whether an unchanged capture becomes a
-    // no-op undo entry is ComfyUI's business, not something this file can verify — so a
-    // refusal that changed nothing keeps doing no bookkeeping at all, as it does today.
-    // Nothing is lost by that: the capture is a WHOLE-GRAPH snapshot taken at the close, so
-    // it contains the created target regardless of which side of the open it was minted on,
-    // and no capture can occur in between because only a close that reaches zero captures.
+    // What the cleanup's own envelope buys is the sound half of that earlier finding: the
+    // NEWEST capture is the graph as it really finished, instead of a row-present snapshot of
+    // a command that was refused.
+    //
+    // WHAT IT DELIBERATELY DOES NOT BUY, because no write path can: a refused write is not a
+    // no-op in the undo history. applyWidgetWrite captures its write, then captures its
+    // rollback in a second envelope of its own, so an ORDINARY refused write already leaves
+    // two snapshots a Ctrl+Z can step back into. A refused creating write now leaves three and
+    // behaves the same way. Suppressing those intermediate captures is only reachable by
+    // holding one envelope across the verification — i.e. by reintroducing the defect above.
+    // Symmetry with the ordinary write is the property worth having; being better than the
+    // shared write path is not on offer, and pretending otherwise is what cost a round.
     const prepared = typeof prepareWriteTarget === "function" ? prepareWriteTarget() : null;
-    const doWrite = () =>
-      applyWidgetWrite(node, widgetName, value, {
+    try {
+      return applyWidgetWrite(node, widgetName, value, {
         resolveSource,
         canvas,
         beforeChange,
@@ -528,18 +548,18 @@ export async function runSetWidget(
         promotedResolution,
         ...extra,
       });
-    // Nothing was grown, so there is no cleanup to keep company: leave the bookkeeping
-    // exactly as applyWidgetWrite has always owned it.
-    if (!prepared) return doWrite();
-    beforeChange?.();
-    try {
-      try {
-        return doWrite();
-      } catch (err) {
-        // The write refused over a target this attempt had just created. Undo it in the same
-        // synchronous stretch, so the graph the refusal is reported over is the graph the
-        // command started from — and so a retry below starts from a clean node rather than
-        // finding a row it would then decline to create again.
+    } catch (err) {
+      // The write refused over a target this attempt had just created. Undo it in the same
+      // synchronous stretch, so the graph the refusal is reported over is the graph the
+      // command started from — and so a retry below starts from a clean node rather than
+      // finding a row it would then decline to create again.
+      if (prepared) {
+        // BOTH HOOKS ARE BEST-EFFORT, mirroring widget-write's own safeBefore/safeAfter. A
+        // graph whose onBeforeChange throws must not cost us the cleanup — the row AND the
+        // row name it spent would be left behind while an error was returned. And a throwing
+        // close must never replace the refusal that is the entire reason we are here: the
+        // caller needs to know why its write was rejected, not that a history hook failed.
+        safeHistoryHook(beforeChange);
         try {
           // An undo that could NOT put everything back RETURNS A STRING SAYING SO, and the
           // refusal carries it. Without this the caller hears only why the value was
@@ -550,17 +570,17 @@ export async function runSetWidget(
           // Annotated IN PLACE rather than rethrown as a new error: the recovery paths below
           // dispatch on `instanceof WidgetWriteError` and on `.combo` / `.emptyOptions`, and
           // wrapping would strip all three and turn a retryable combo miss into a hard fail.
-          const note = prepared?.undo?.();
+          const note = prepared.undo?.();
           if (typeof note === "string" && note && typeof err?.message === "string") {
             err.message = `${err.message} ${note}`;
           }
         } catch {
           /* an undo that fails must never replace the refusal that caused it */
+        } finally {
+          safeHistoryHook(afterChange);
         }
-        throw err;
       }
-    } finally {
-      afterChange?.();
+      throw err;
     }
   };
 

--- a/web/js/lib/set-widget.js
+++ b/web/js/lib/set-widget.js
@@ -129,6 +129,12 @@ export async function runSetWidget(
     // OUTCOME the ladder needs — a fresh answer — and leaves the cache to decide how to get
     // one without disturbing anybody else.
     refetchObjectInfoLive,
+    // #757 — SYNCHRONOUS target preparation. Some write targets do not exist until
+    // something creates them (an rgthree Power Lora Loader `lora_N` row is minted only by
+    // the node's own method), and the creation is a graph MUTATION. Injected here, rather
+    // than done by the caller before this function, so the mutation lands at the write
+    // boundary below where NO await follows it — see the note at `write`.
+    prepareWriteTarget,
   } = {},
 ) {
   // Never re-derived, and never cached: the oracle may not have run yet when this closure is
@@ -459,16 +465,52 @@ export async function runSetWidget(
     // flight therefore refuses before touching either canvas; retry and upload
     // recovery use this same boundary too.
     assertTargetStillCurrentNow();
-    return applyWidgetWrite(node, widgetName, value, {
-      resolveSource,
-      canvas,
-      beforeChange,
-      afterChange,
-      setDirty,
-      assertTargetWritable: (targetNode) => assertResolvedTargetRegistered(liveRegistry(), targetNode),
-      promotedResolution,
-      ...extra,
-    });
+    // #757 — CREATE A MISSING TARGET HERE, INSIDE THE SAME SYNCHRONOUS STRETCH.
+    //
+    // A target that must be minted before it can be written (an rgthree `lora_N` row) used
+    // to be created by the CALLER, before `runSetWidget` was even entered. That put a live
+    // graph mutation on the far side of `await getFreshObjectInfo()`, and everything that
+    // went wrong with this feature came from that one gap:
+    //   - the row sat in the graph across a network request, so any ChangeTracker capture
+    //     in that window recorded a transient row and split the command's undo in two;
+    //   - a user hand-editing the node during the window could have their edit rolled back
+    //     by a failure that had nothing to do with them — losing a manual edit is worse
+    //     than the missing-widget refusal this feature exists to remove;
+    //   - a concurrent command frame could write the row and be told it succeeded, only
+    //     for the original call's rollback to delete it.
+    // Placed here, none of those windows exist: `applyWidgetWrite` is synchronous, so
+    // nothing — no other command frame, no user gesture, no capture — can run between the
+    // creation, the write and the undo below. The guards those three defects each needed
+    // are removed rather than kept, because the interleaving they defended against is now
+    // unreachable.
+    //
+    // AFTER the fence, so a workflow switch during the fetch refuses before the mutation.
+    // Called once per attempt and expected to be idempotent: the stale-combo and upload
+    // retries re-enter `write`, and by then the target it created already exists.
+    const prepared = typeof prepareWriteTarget === "function" ? prepareWriteTarget() : null;
+    try {
+      return applyWidgetWrite(node, widgetName, value, {
+        resolveSource,
+        canvas,
+        beforeChange,
+        afterChange,
+        setDirty,
+        assertTargetWritable: (targetNode) => assertResolvedTargetRegistered(liveRegistry(), targetNode),
+        promotedResolution,
+        ...extra,
+      });
+    } catch (err) {
+      // The write refused over a target this attempt had just created. Undo it in the same
+      // synchronous stretch, so the graph the refusal is reported over is the graph the
+      // command started from — and so a retry below starts from a clean node rather than
+      // finding a row it would then decline to create again.
+      try {
+        prepared?.undo?.();
+      } catch {
+        /* an undo that fails must never replace the refusal that caused it */
+      }
+      throw err;
+    }
   };
 
   // #558: the value widget being written may be governed by a non-`fixed`

--- a/web/js/lib/set-widget.js
+++ b/web/js/lib/set-widget.js
@@ -487,9 +487,38 @@ export async function runSetWidget(
     // AFTER the fence, so a workflow switch during the fetch refuses before the mutation.
     // Called once per attempt and expected to be idempotent: the stale-combo and upload
     // retries re-enter `write`, and by then the target it created already exists.
+    //
+    // ONE HISTORY TRANSACTION AROUND THE WHOLE TRIPLE. applyWidgetWrite opens and CLOSES its
+    // own undo envelope — two of them on the failure path, since it rolls a bad value back in
+    // an envelope of its own — and a close that reaches zero is what makes ComfyUI's
+    // ChangeTracker CAPTURE. So a post-assignment refusal (the #240 read-back rejecting a
+    // value the widget's setter normalized) captured a snapshot with the created target and
+    // the rejected value still in it, and the cleanup below then removed that target with no
+    // envelope open and nothing captured. The tracker's newest snapshot was a graph that no
+    // longer existed, so the next Ctrl+Z restored the refused command instead of stepping
+    // over it — the refusal was supposed to be a no-op.
+    //
+    // An OUTER envelope keeps the inner closes from ever reaching zero, so exactly one
+    // capture happens: at the end, over the graph as it really finished, cleanup included.
+    //
+    // THIS IS NOT THE ROUND-2 DEFECT COMING BACK. That one held a transaction across an
+    // AWAIT, where a workflow switch could detach the canvas before the close and wedge the
+    // tracker at changeCount 1 for the session. Everything between these two calls is
+    // synchronous and cannot yield — which is exactly the property that moving the creation
+    // here established. Keep it that way: no await may be introduced inside this bracket.
+    //
+    // OPENED THE MOMENT THERE IS SOMETHING TO PROTECT, AND NOT BEFORE. The envelope wraps the
+    // write and the cleanup; the preparation itself sits just outside it, deliberately.
+    // Opening first would mean bracketing a graph that never changed whenever the preparation
+    // REFUSES (a pack with no addNewLoraWidget), and whether an unchanged capture becomes a
+    // no-op undo entry is ComfyUI's business, not something this file can verify — so a
+    // refusal that changed nothing keeps doing no bookkeeping at all, as it does today.
+    // Nothing is lost by that: the capture is a WHOLE-GRAPH snapshot taken at the close, so
+    // it contains the created target regardless of which side of the open it was minted on,
+    // and no capture can occur in between because only a close that reaches zero captures.
     const prepared = typeof prepareWriteTarget === "function" ? prepareWriteTarget() : null;
-    try {
-      return applyWidgetWrite(node, widgetName, value, {
+    const doWrite = () =>
+      applyWidgetWrite(node, widgetName, value, {
         resolveSource,
         canvas,
         beforeChange,
@@ -499,17 +528,39 @@ export async function runSetWidget(
         promotedResolution,
         ...extra,
       });
-    } catch (err) {
-      // The write refused over a target this attempt had just created. Undo it in the same
-      // synchronous stretch, so the graph the refusal is reported over is the graph the
-      // command started from — and so a retry below starts from a clean node rather than
-      // finding a row it would then decline to create again.
+    // Nothing was grown, so there is no cleanup to keep company: leave the bookkeeping
+    // exactly as applyWidgetWrite has always owned it.
+    if (!prepared) return doWrite();
+    beforeChange?.();
+    try {
       try {
-        prepared?.undo?.();
-      } catch {
-        /* an undo that fails must never replace the refusal that caused it */
+        return doWrite();
+      } catch (err) {
+        // The write refused over a target this attempt had just created. Undo it in the same
+        // synchronous stretch, so the graph the refusal is reported over is the graph the
+        // command started from — and so a retry below starts from a clean node rather than
+        // finding a row it would then decline to create again.
+        try {
+          // An undo that could NOT put everything back RETURNS A STRING SAYING SO, and the
+          // refusal carries it. Without this the caller hears only why the value was
+          // rejected, while a resource the preparation consumed stays consumed — and the
+          // obvious next move, retrying the corrected value under the same name, fails a
+          // second time for a reason the first message never mentioned.
+          //
+          // Annotated IN PLACE rather than rethrown as a new error: the recovery paths below
+          // dispatch on `instanceof WidgetWriteError` and on `.combo` / `.emptyOptions`, and
+          // wrapping would strip all three and turn a retryable combo miss into a hard fail.
+          const note = prepared?.undo?.();
+          if (typeof note === "string" && note && typeof err?.message === "string") {
+            err.message = `${err.message} ${note}`;
+          }
+        } catch {
+          /* an undo that fails must never replace the refusal that caused it */
+        }
+        throw err;
       }
-      throw err;
+    } finally {
+      afterChange?.();
     }
   };
 

--- a/web/js/lib/widget-write.js
+++ b/web/js/lib/widget-write.js
@@ -268,7 +268,11 @@ const RGTHREE_LORA_SLOT_SCHEMA = {
 // the row is repaired-forward — never fall back to inferring a type from a corrupt value,
 // which would accept a further wrong-type write and deepen the corruption.
 const RGTHREE_LORA_SLOT_KEYS = new Set(["on", "lora", "strength", "strengthTwo"]);
-function isLoraSlotObject(obj) {
+// EXPORTED for #757's creation route (`rgthree-lora-row.js`), which must decide whether an
+// incoming value is a lora row before it will mint a slot for it. Exported rather than
+// re-implemented there: two copies of a shape test drift, and the drift would show up as a
+// slot created for a value the writer then refuses.
+export function isLoraSlotObject(obj) {
   if (obj == null || typeof obj !== "object" || Array.isArray(obj)) return false;
   const keys = Object.keys(obj);
   if (keys.length === 0) return false;


### PR DESCRIPTION
Closes #757.

> **Status: draft, with a two-round cap.** After round 6 the user decided this PR gets **two more review rounds** (7 and 8). If round 8 still finds a creating-path-only defect, it is parked as a draft. Round 7 is done; **this is the last round before that call.**
>
> **A prediction in this PR was falsified, and the record should say so.** After round 5 I predicted that further findings would be about the *shared* write path rather than creation-only. Round 6 found a creating-path-only defect, and round 7 found another. The correct model is the one the reviewer proposed: **a newly created row has a settling period an existing row does not**, and both defects lived inside it. See round 7 for what that means and what it costs.

A freshly added `Power Lora Loader (rgthree)` carries only `divider, PowerLoraLoaderHeaderWidget, divider, ➕ Add Lora`. The `lora_1`, `lora_2`, … rows do not exist until the user clicks **➕ Add Lora**, a DOM-only control an agent cannot activate — so every write to `lora_1` on a new node was refused for a widget that no tool could bring into existence. Writing an *existing* row already worked, so this is the creation half only.

## Read this first: four rounds of review, one root cause

Every serious defect this PR has had came from the **same seam**: the row was created *before* `runSetWidget`, which yields at `await getFreshObjectInfo()` on a cache miss. A live graph mutation therefore sat in the graph across a network request, and each round found a different thing that could happen in that window:

| Round | What the window allowed |
| --- | --- |
| 1 | a refused write left the row behind |
| 2 | an undo transaction held across it could **wedge ComfyUI's ChangeTracker for the whole session** |
| 2 | a concurrent frame's write could be rolled back under it |
| 3 | a **user's own hand-edit** during the window could be rolled back by an unrelated failure |

Rounds 1 and 2 each added a guard. **Round 3 removed the window instead**, and the guards with it. That is the shape change worth reviewing: creation now happens at `runSetWidget`'s *synchronous write boundary*, so no `await` separates the creation, the write and the rollback, and nothing — no other command frame, no user gesture, no undo capture — can run in between.

**Round 4 found no P1s** and confirmed the mutation-ordering class closed. **Round 5 found one P1 — caused by round 4's own fix** — and it settles a question worth stating up front:

> A refused write is **not a no-op in the undo history**, and cannot be made one. `applyWidgetWrite` captures its write and then captures its rollback in a second envelope of its own, so an *ordinary* refused write already leaves two snapshots a Ctrl+Z can step back into. Round 4 asked the creating path to do better; the only way to do better is to hold one envelope across the verification, and that moves the capture — and every pack `serializeValue` the capture runs — past the last check.

Round 4 chose the better history and lost the verification. Round 5 restores the verification and accepts the same history every other write has. **Symmetry with the ordinary write is the invariant**; being better than the shared write path was never on offer.

## How the route is kept away from the typo guard

The panel deliberately refuses to auto-press a pressable control (`pressable-widget.js`), because a generic "this node has one button, press it" rule would mutate the graph on an ordinary **typo** — overwhelmingly the most common reason a widget name misses. So creation is keyed on three independent facts, all required:

1. the node **type** is `Power Lora Loader (rgthree)`;
2. the requested name matches `lora_<n>` and is **absent** from the node;
3. the **value** is a lora-slot the existing writer already accepts.

A typo cannot satisfy all three, and `pressableWidgetHint` stays the answer for every other node and every other missing name.

`addNewLoraWidget` is pack-private and version-dependent, so it is feature-detected (a loud, actionable refusal when absent) and its **effect** is verified by comparing the widget list afterwards — the maintainer's live probe found generic callbacks (`callback`, `onMouseClick`, `mouseClickCallback`) that accept the call and create nothing.

---

## Review round 3 — the restructure

### 1. (P1) Create the row at the synchronous post-authorization write boundary

**The defect.** Creating before `runSetWidget` put the mutation on the far side of an awaited `/object_info` fetch. A user edit landing in that window is captured by ChangeTracker together with the transient row (splitting create-and-assign across undo steps), and if the request then fails, the rollback can delete a row **the user edited by hand**. Losing a manual edit is worse than the bug this feature fixes.

**The fix.** `runSetWidget` takes an injected `prepareWriteTarget` hook and calls it inside `write()` — after the workflow fence, immediately before `applyWidgetWrite`, with the rollback in the same `try/catch`:

```js
assertTargetStillCurrentNow();
const prepared = typeof prepareWriteTarget === "function" ? prepareWriteTarget() : null;
try {
  return applyWidgetWrite(node, widgetName, value, { … });
} catch (err) {
  try { prepared?.undo?.(); } catch { /* never replace the refusal */ }
  throw err;
}
```

`applyWidgetWrite` is synchronous, so the create → write → rollback triple is uninterruptible. The stale-combo and upload-asset retries re-enter `write()`, and each attempt rolls its own preparation back **before** the await that follows — so no half-made target spans `refreshCombos` or the asset probe either.

**What this deletes.** The `rowClaims` `WeakMap`, `noteRgthreeLoraRowWritten`, the panel's `assertActiveWorkflowCommandTarget` call on the creation path (the fence is now `runSetWidget`'s own, re-checked at the boundary), and the panel's `try/catch/undo` around the call. Net **−131 lines** in the panel.

### 2. (P2) An unknown row counter is an *incomplete* rollback, not a clean one

When a pack exposes no readable `loraWidgetsCounter`, `counterBefore === null` was treated as "nothing changed". But the shipped `addNewLoraWidget` **increments first and constructs second**, so a throw has probably already spent a row name — the caller was told a retry was safe when a name had in fact been consumed. Only a counter we can *read* and that now *reads back unchanged* licenses "nothing was changed". Both refusal branches made the unconditional claim (the pack-throw path and the added-no-widget path below it); both now disclose it.

---

## Review round 4 — two P2s, no P1s

### 1. (P2) The cleanup has to happen inside the undo envelope

**The defect.** `applyWidgetWrite` closes its own envelope *before* the #240 read-back verifies, and rolls a rejected value back inside a second envelope of its own. Every close that reaches zero makes ChangeTracker capture. So a **post-assignment** refusal — a widget setter that normalizes the value away, so the read-back rejects what was written — captured a snapshot holding the created row and the rejected value, and the cleanup then removed the row with nothing open and nothing captured. The tracker's newest snapshot was a graph that no longer existed, and the next Ctrl+Z restored the command that had just been refused. A refusal is supposed to be a no-op in the undo history too.

> **Superseded in round 5.** The mechanism below — one outer envelope around the whole triple — is what produced round 5's P1. Only the *cleanup* is bracketed now. The finding was half right, and the half that survives is "the newest capture must describe the graph that exists"; see round 5.

**The fix as it stood in round 4.** The write and its cleanup share ONE outer envelope, so the inner closes never reach zero and exactly one capture happens — at the end, over the graph as it really finished:

```js
const prepared = typeof prepareWriteTarget === "function" ? prepareWriteTarget() : null;
if (!prepared) return doWrite();          // nothing grown: bookkeeping unchanged
beforeChange?.();
try {
  try { return doWrite(); }
  catch (err) { /* undo + disclose */ throw err; }
} finally { afterChange?.(); }
```

**This is not the round-2 defect returning.** That one held a transaction across an `await`, where a workflow switch could detach the canvas before the close and wedge the tracker at `changeCount === 1` for the session. Everything inside this bracket is synchronous and cannot yield — the property moving the creation here established in the first place. A mutation that reopens the envelope across a deferred cleanup is in the suite.

**One deliberate deviation from the review's wording.** The review asked for preparation, application and cleanup in one envelope; the envelope here opens once there *is* something to protect, leaving the preparation just outside it. Opening first would bracket a graph that never changed whenever the preparation **refuses** (a pack with no `addNewLoraWidget`), and whether an unchanged capture becomes a no-op undo entry is ComfyUI's business — not something this file can verify from here. So a refusal that changed nothing keeps doing no bookkeeping at all, which is an already-tested property. Nothing is lost: the capture is a whole-graph snapshot taken at the close, so it contains the created row regardless of which side of the open it was minted on, and no capture can occur in between because only a close that reaches zero captures.

### 2. (P2) A refusal must report a row name it could not give back

This is the residual the previous round flagged and deliberately did not fix; the reviewer found it independently, which is the mandate to do it properly.

A pack that exposes `addNewLoraWidget` but **hides or freezes** `loraWidgetsCounter` let a slot-shaped request with an invalid field create a row, be rejected by `applyWidgetWrite`, and have the row taken back out — while the **name stayed spent**. `remove()` still reported plain success, so the caller heard only that its value was invalid. Retrying the corrected value under the same `lora_N` then minted a *later* row and was refused a second time on the name — the same unfollowable advice the mismatch refusal already had to stop giving.

`remove()` now returns `{ removed, incomplete }`. Whether the counter was restored is decided by **reading it back off the node**, not by trusting `restoreRowCounter`'s return — that function reports `false` both when it could not write and when there was nothing to undo, so its return cannot tell those apart, and a frozen counter it "restored" reports `true` while nothing moved. `runSetWidget` appends the disclosure to the refusal **in place**, so the error keeps its type and its `combo` / `emptyOptions` flags and a recoverable stale-combo miss still retries.

---

## Review round 5 — one P1 (from round 4's fix) and two P2s

### 1. (P1) Verify the creating write the same way an ordinary write is verified

**The defect.** `applyWidgetWrite` verifies **after** its own `afterChange` has fired — deliberately, and the source says why: *"an afterChange hook can itself re-stale a widget or change the promotion topology, and that must be caught too"*. That close is also when ComfyUI serializes the graph for the undo capture, and serialization runs every node's own `serializeValue`.

Round 4's outer envelope stopped `applyWidgetWrite`'s close from reaching zero. The capture — and every `serializeValue` it runs — therefore moved *past* the last verification. An rgthree loader in **Separate Model & Clip** mode rewrites `strengthTwo: null` to `1` exactly there, so the creating path reported plain success for a value an existing-row write would have reported as normalized (#805).

**The fix.** `applyWidgetWrite` is called with nothing wrapped around it, exactly as every other write path calls it. Only the cleanup is bracketed:

```js
const prepared = typeof prepareWriteTarget === "function" ? prepareWriteTarget() : null;
try {
  return applyWidgetWrite(node, widgetName, value, { … });   // verifies after its own capture
} catch (err) {
  if (prepared) {
    safeHistoryHook(beforeChange);                            // the cleanup gets its own envelope
    try { /* undo + disclose */ } finally { safeHistoryHook(afterChange); }
  }
  throw err;
}
```

The test for it is pack-independent: a history probe that rewrites the widget value **at capture depth**, which is where a `serializeValue` runs. Re-nesting the write in an outer envelope is in the mutation set and is killed by it.

### 2. (P2) Exception-safe history hooks around the cleanup

The cleanup's envelope is opened by the graph's own hook, and a pack or extension can make that throw. An escaping **open** skipped the cleanup entirely — the row *and* the row name it spent left behind while the caller got an error, i.e. mutate-then-refuse caused by the bookkeeping rather than the write. An escaping **close** could replace the refusal the caller actually needs to read. Both are now routed through `safeHistoryHook`, mirroring `widget-write.js`'s own `safeBefore`/`safeAfter`.

### 3. (P2) Confirm the mismatched-row counter actually rewound

`restoreRowCounter` reports whether it ran an assignment, not whether the assignment **took**. A counter that accepts `++` but silently ignores writes back — a getter-only property, a clamping pack, a proxy — was advertised as rewound, and the remedy the refusal printed (*"set `lora_2` instead"*) only works if the number really came back. The mismatch branch now reads the counter back off the node, the same rule the two round-3 branches and `remove()` already use.

---

## Review round 7 — the settling period

Rounds 6 and 7 both found **creating-path-only** defects, which is what falsified the symmetry prediction. The model that explains both:

> A row created by the pack's own **➕ Add Lora** button is unsettled for exactly as long as it takes the canvas to repaint — microseconds, and always before a human can touch it. A row created by an agent is written to **in the same synchronous command**, with no frame in between. Anything the pack defers to first-draw is therefore still unset when our write is verified.

### 1. (P1) Initialize the new row's strength mode before the capture

Read from the shipped pack (`rgthree-comfy/web/comfyui/power_lora_loader.js`, located on the dev machine rather than inferred):

```js
constructor:    this.showModelAndClip = null;
draw:           this.showModelAndClip =
                  node.properties["Show Strengths"] === "Separate Model & Clip";
serializeValue: const v = { ...this.value };
                if (!this.showModelAndClip) { delete v.strengthTwo; }
                else { this.value.strengthTwo = this.value.strengthTwo ?? 1; … }
```

`null` is **falsy**, so an undrawn row serializes down the *first* branch and silently drops `strengthTwo` instead of normalizing it. The write therefore verified clean — nothing had touched the value — and the first draw afterwards flipped `showModelAndClip` to `true`, at which point `serializeValue` rewrote `strengthTwo: null` to `1`. A verified success that changes at the next queue or save.

Creation now performs the same synchronisation the first draw would, and **only** that: the value adjustment sitting beside it in `draw()` is skipped, exactly as the pack skips it when `oldShowModelAndClip` is `null`. A created row is byte-identical to the same row created by the button and drawn once.

The test is the invariant, not the mechanism: **a Separate Model & Clip creation must report what an existing-row write reports.** Both now refuse with "did not retain the requested value", because in that mode the pack overrides `strengthTwo` for either path. Symmetry is the pass condition — not success.

### 2. (P2) Roll back when the tail throws

The helper's tail mutates a row that is already on the node while the caller still holds no handle to undo it: `remove` is only returned at the very end, and `runSetWidget` evaluates the whole preparation *before* entering the try that would clean up. A throw there — a hostile `computeSize`, a raising `setDirty`, a widget rejecting the mode assignment — stranded the row, the name it spent and the height it grew, while the command reported a failure that had changed the graph. The tail now undoes itself before rethrowing, and `setDirty` is best-effort, matching the resize beside it.

### What this costs, stated plainly

The settle is **one named field, mirroring one line of one pack's `draw`**. It is correct and verified against the shipped source, but it is not a general mechanism: `settleCreatedRow` is the place where the *next* draw-deferred field would go, not a guarantee that none exists. The general form of this problem — "make the row fully settled before anything reads it" — has no synchronous solution, because settling is defined by a canvas frame that a single command cannot wait for without reintroducing the mutation-across-await class that rounds 1–3 closed.

The shape that removes the settling period entirely is **creation as its own committed step**, with the value write issued afterwards as an ordinary existing-row write. That is a tool-surface decision, not a bug fix, and it is the honest alternative if round 8 finds a third field.

---

## Rounds 1 and 2 (for history)

<details>
<summary>The nine earlier findings, and which of them round 3 superseded</summary>

**1. (P1) The route was dead code — values arrive as JSON strings.** `coerceWidgetValue` turns the string into an object at `widget-write.js:508-512`, *after* the classifier ran, so `isLoraSlotObject(rawValue)` answered "not a slot" for every real request. `slotValue()` now parses a JSON string before the shape test; `isLoraSlotObject` remains the only judge, so nothing about what counts as a slot is widened.

**2. (P2) The monotonic counter made the refusal's remedy unfollowable.** `addNewLoraWidget()` increments before it names, and removing the row does not undo the increment — so `set "lora_7" instead` had already moved the next name to `lora_8`. Undoing means undoing both halves; when the counter cannot be rewound the message names the state instead of promising a retry that would not work.

**3. (P1) A refused write left the row behind.** `createRgthreeLoraRow` returns `{ created, remove }`. *Round 3 moved the caller of `remove()` from the panel into the write boundary.*

**4/5. (P1) The transaction must not span the await across canvas detachment.** Round 1's fix — bracketing creation and write in one `graph.beforeChange()`/`afterChange()` pair — was worse than the bug it fixed. LiteGraph delivers those hooks through *attached* canvases (`canvasAction(cb) { … for (const c of this.list_of_graphcanvas) cb(c) }`), so a tab switch mid-await leaves the close reaching nobody and ChangeTracker stuck at `changeCount === 1` for the rest of the session. The creation is not bracketed at all; one undo step still results, because ChangeTracker captures whole-graph *snapshots* and the pair `runSetWidget` opens for the write closes with the row already present.

**6. (P1) A rollback must not delete a row another request has written.** Round 2 added a claim (`WeakMap` keyed on the widget object) so a rollback only removed a row nobody else had written. **Round 3 deleted this entirely** — with create and write in one synchronous stretch, the interleaving it defended against is unreachable, so exactly one of two overlapping requests can create. Do not look for `rowClaims`; it is gone.

**7. (P2) Resize the loader after adding a row.** rgthree's own button resizes right after calling `addNewLoraWidget`; marking the canvas dirty only repaints. Height only — widening a node the user sized is not ours to do — and the prior size is restored on rollback.

**8. (P2) Do not rewind a counter advanced by later edits.** Create `lora_1`, add `lora_2`, roll back, and an unconditional rewind mints `lora_1` and a **duplicate** `lora_2`. The rewind requires the counter to still read exactly this call's increment.

**9. (P2) Roll back partial effects when the pack method throws.** The exception path removes whatever landed, rewinds the counter and the size, and says plainly when it could not undo it all.

</details>

---

## Verification

Both mechanisms were read out of the shipped sources rather than reasoned about: `rgthree-comfy/web/comfyui/power_lora_loader.js` for the increment-then-append order and the resize step, and the ComfyUI frontend bundle for `LGraph.beforeChange` → `canvasAction` → `ChangeTracker`.

Testing is at three levels, deliberately:

- the **shipped `graph_set_widget`** is extracted from the panel and run against doubles (the `graph-edit-node.test.mjs` pattern), because source-text assertions cannot answer "does a refused write leave the row behind" or "is this one undo step";
- the **real `runSetWidget`** is driven directly (the `set-widget-refresh.test.mjs` pattern) for the new hook — the executor tests stub `runSetWidget`, so on their own they verify the panel's half of the contract against a *model* of the other half that could drift from it;
- source-text assertions pin the two structural rules (no `await` in the write stretch; the panel reaches `createRgthreeLoraRow` only from inside the hook).

Results:

- `npm run test:unit`: **4489 tests, 4488 pass, 0 fail, 1 todo** (i18n, i18n-render, tool-vocabulary and `check-panel-scope` gates all green).
- **59 mutations, every one killed.** Round 7 added the P1 itself (*the new row is never settled* — killed by the asymmetry test, which reports `creation ok=true where an existing row reported ok=false`), *the settle reads the mode backwards*, *the settle reads the wrong node property*, *the settle invents the field on a build that never had it*, *an unreadable node fails the creation*, *a throw in the tail strands the row*, and *setDirty stops being best-effort*. Round 5 added the P1 itself (*the write is nested in an outer envelope again*), both P2s, and the two unguarded-history-hook variants.
- **One mutation was deliberately removed rather than killed.** Closing and reopening the cleanup's envelope — adding an extra intermediate capture — *survives*, and correctly so: the only property claimed is that the newest capture describes the graph that exists. Killing it would mean asserting the minimal-history property that round 5 established is unavailable to any write path. A mutation kept alive by a pretend assertion is worse than no mutation.
- Earlier rounds: Round 3 added: *the target is minted before the `/object_info` await again* (killed behaviourally — nothing may be minted on a stale canvas, and nothing may survive across the retry await); *minted before the workflow fence*; *the boundary drops its own fence re-check*; *the rollback is deferred out of the synchronous stretch* (`setTimeout`, invisible to the source-text assertions); *an unknown counter is called a clean rollback again*, once per branch; and *a genuinely clean rollback is never reported as clean*, so the honest message stays reachable. Round 4 added both P2s themselves plus *the envelope closes before the cleanup*, *the envelope never closes* (the round-2 defect, as a mutation), *the disclosure is thrown as a NEW error, losing the combo retry*, and *the panel swallows the disclosure*.
- **One round-4 mutation LIVED on its first run** — *the panel swallows the row-creation's disclosure* — exposing a real gap: nothing connected the panel's hook to the text the caller actually reads, because the executor tests stubbed the layer that does the joining. Closed with an end-to-end executor test over a counter-hiding pack, and the stub now models the annotation as well.
- The harness restores from an in-memory snapshot rather than `git checkout` (the work was uncommitted), and treats a needle matching anything other than exactly once as a **survivor** — on this CRLF checkout an LF-authored multi-line anchor that silently missed would otherwise read exactly like a kill.

## Notes for the reviewer

- **Is the P1 class closed?** For this feature, yes, and by construction rather than by guard: there is no yield point between the fence, the creation, the write and the rollback, and the retry paths roll back before their awaits. The mutation that puts the creation back before the fetch is killed by two *runtime* tests, not only by the source-text rule. Round 4 reviewed this path and found no P1s.
- **The residual flagged in round 3 is now fixed.** A rollback that cannot put everything back — a surviving row, or a spent row name — is disclosed on the refusal itself. The cross-layer signal it needed is a single optional string returned by the hook's `undo()`, which `set-widget.js` appends without knowing anything about lora rows.
- **The undo-history question is settled, and the answer is "same as every other write".** A refused creating write leaves intermediate captures, exactly as a refused ordinary write does; what is guaranteed is that the *newest* capture describes the graph that exists. Making it a true no-op requires holding an envelope across the verification, which is what round 5's P1 was.
- **Where the remaining risk actually sits — corrected.** After round 5 this section predicted that further findings would be about the *shared* write path. That was wrong: rounds 6 and 7 were both creating-path-only, and both sat in the newly created row's **settling period** — the window between `addNewLoraWidget()` and the first canvas draw, in which pack state the draw is responsible for is still unset. Round 7 closes the one field that affects serialization (`showModelAndClip`, verified against the shipped pack source). It does not prove there is no second field, and no synchronous mechanism can, because settling is defined by a frame this command cannot wait for.
- **The alternative shape, if round 8 finds a third.** Make creation its own committed step and let the caller issue the value write as an ordinary existing-row write. That removes the settling period by construction rather than fixing its symptoms, at the cost of two calls and a refused write leaving an empty row behind. It is a tool-surface decision, and the evidence for it is now two rounds of findings rather than a hunch.
- **Disclosure.** The reply carries `created_widget` on a field of its own, not in `warning`: that channel is single-slot and priority-ordered, so appending would displace a warning about what the write actually does.
- **Shape.** `prepareWriteTarget` is a generic "the target may not exist yet" hook, and the only implementation is rgthree's. That is deliberate: it is the same shape `reconcileUnknownWidgetNames` already has in this file (mutate the node so the caller's name resolves, post-authorization, behind the fence). If a *second* growable target ever wants this hook, that is the moment to promote it to an explicit `panel_add_widget_slot` the caller invokes deliberately rather than a side effect of a write.
- **Scope.** Keyed strictly to the one node type. `panel_remove_widget` (comfyui-mcp#938) already removes these same rows by the mirror-image mechanism.
