### PR TITLE
release: v0.14.41 - graph_load reports the identity it loaded into (#1478)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+## [0.14.41] - 2026-08-15
+
+### Fixed
+- graph_load now reports the workflow identity it actually loaded into on BOTH reply paths, including the API-format load the report came from (#1478)
+
+
 ## [0.14.40] - 2026-08-14
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-agent-panel"
 description = "Autonomous AI agent in the ComfyUI sidebar - local-first, bring any LLM. Run it on your Claude or ChatGPT subscription (no API keys, no extra LLM costs), on a Kimi K3 / GLM / OpenRouter key, or fully offline on free local models via Ollama, LM Studio, or llama.cpp. The agent drives your live canvas at full parity: add, wire, move and tweak nodes with Ctrl+Z undo, load whole workflows and installer packs in one shot, generate images, video and audio, browse CivitAI, and run your workflow - asking before it spends paid API credits. The sidebar UI for comfyui-mcp, the local-first, agent-native control plane for ComfyUI. The panel speaks 12 languages, matching your ComfyUI language automatically: English, 한국어, 日本語, 中文 (简体), 中文 (繁體), Русский, Français, Español, Português (BR), Türkçe, العربية, فارسی."
-version = "0.14.40"
+version = "0.14.41"
 license = { file = "LICENSE" }
 requires-python = ">=3.9"
 # UI-only pack: no Python deps. The frontend floor guarantees

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -1526,7 +1526,7 @@ const DOCS_URL = "https://comfyui-mcp.artokun.io/docs";
 // Panel version — surfaced in the "Need help?" diagnostics blob. Bump via
 // `node scripts/set-version.mjs <v>` (updates this AND pyproject together); CI
 // and the publish gate FAIL if the two ever drift, so this can't go stale.
-const PANEL_VERSION = "0.14.40";
+const PANEL_VERSION = "0.14.41";
 
 // The connected orchestrator's console URL/token (captured off the `backends`
 // bridge message — see onBackends). Drives the "API Keys" credentials frame;


### PR DESCRIPTION
Releases the #1478 identity-reporting fix merged in #1225.

## What changed

`graph_load`'s reply now carries the workflow identity it actually loaded into, on **both** return paths. That is the part the earlier attempt missed: `graph_load` returns twice, the field landed only on the UI-format tail, and the report came from the **API-format** branch, which returns early and never reached it.

## The held caveat was wrong, and that is why this can ship

A prior session could not reproduce the reporter's mismatch and held the PR. That conclusion rested on a measurement error: it observed `afterIsSameObject: true` on an API load and inferred the instance identity never moves. **Object sameness is not identity sameness.** The panel's own creation-boundary wrapper is what separates them - an API/prompt JSON carries no `extra`, so `incomingUuid` is undefined, `shouldForkInPlaceReload` returns true, and the wrapper deletes the cached uuid and mints a fresh one **onto the same object**. The object survives while its identity moves, which is exactly why the reporter's fence went stale deterministically.

## Scope, stated honestly

This does **not** close #1478 on its own. The field is inert until the orchestrator consumes it for `graph_load`, which is a change in the other repo. Defect 2 (the read-only `panel_get_errors` refusal) is untouched. #1478 stays open - but now because the other half is unwritten, not because the mechanism was unexplained.

## Verification

- 4408 tests pass, `check-panel-scope` green.
- **8 mutations applied, all 8 killed** - including dropping the field from each reply path independently, capturing the API target *after* the load, dropping the object-identity gate, and neutering `shouldForkInPlaceReload`. That last one is load-bearing: it recreates the world the earlier investigation believed it was in, and the root-cause test goes red.
- A race the branch's own test caught: the first placement left a live `await readPackImportFailures(api)` between the identity check and the reply. The read now happens last on both paths.
- Verified live after restart: the served bundle contains `loadLandedWorkflowUuid`.

The codex review was cancelled at 23 minutes when it stopped converging (same call made on #813 earlier today). Merged on the mutation evidence above rather than on a clean review, and this note is here so that is on the record.