### PR TITLE
fix(1124): an rgthree Seed is not graph drift

### DIFF
--- a/browser_tests/unit/run-scope-guard.test.mjs
+++ b/browser_tests/unit/run-scope-guard.test.mjs
@@ -2094,18 +2094,24 @@ const RGTHREE_DRAWS = [1028465986822020, 98533269447704, 557498712106716];
  * `alsoEdit` mutates the outgoing prompt further, standing in for a REAL user
  * edit landing in the same window — the case that must still be refused.
  */
-function makeRgthreeFrontend({ apiTarget, seedWidgetValue = -1, alsoEdit = null }) {
+function makeRgthreeFrontend({ apiTarget, seedWidgetValue = -1, alsoEdit = null, nodeType = "Seed (rgthree)" }) {
   let draw = 0;
   const stamp = () => {
     const out = structuredClone(RGTHREE_STAMP);
     out["47"].inputs.seed = seedWidgetValue;
+    out["47"].class_type = nodeType;
     return out;
   };
   const app = {
     queueItems: [],
     posted: [],
     // The panel's live root (production shape, r8) — no beforeQueued anywhere.
-    graph: { _nodes: [rgthreeSeedNode(47, seedWidgetValue), { id: 3, widgets: [{ name: "steps", value: 20 }] }] },
+    graph: {
+      _nodes: [
+        { ...rgthreeSeedNode(47, seedWidgetValue), type: nodeType },
+        { id: 3, widgets: [{ name: "steps", value: 20 }] },
+      ],
+    },
     graphToPrompt: async () => ({ output: stamp(), workflow: {} }),
     queuePrompt: async (number, batch, arg) => {
       const targets = Array.isArray(arg) ? arg : arg?.queueNodeIds;
@@ -2170,6 +2176,35 @@ test("#1124 integration: a FIXED rgthree Seed keeps full drift coverage — a bo
     assert.match(result.error, /47 seed/, "and the refusal still names what differed");
     assert.equal(server.calls.length, 0, "the drifted prompt never left the tab");
     assert.deepEqual(result.volatileInputs, [], "a fixed node excludes nothing");
+  } finally {
+    stop();
+  }
+});
+
+test("#1124 integration: a LOOK-ALIKE node type does NOT buy a drift exemption — its seed edit is still refused", async () => {
+  const stop = keepAlive();
+  try {
+    // codex r1 P2, at the level that matters: the exclusion is keyed on the exact
+    // registered type, so a foreign node whose type merely contains "rgthree" and
+    // "seed" keeps FULL drift coverage. If this ever passes as "dispatched", the
+    // guard has been silently disarmed for every graph containing such a node.
+    const server = makeServer();
+    const apiTarget = { fetchApi: server };
+    const app = makeRgthreeFrontend({
+      apiTarget,
+      nodeType: "Seed Generator (rgthree-style)",
+      // Armed sentinel + a changed seed in the body: the exact shape the real
+      // rgthree node gets forgiven for. This node must NOT be forgiven.
+      alsoEdit: (output) => { output["47"].inputs.seed = 4242; },
+    });
+    const result = await dispatchScopedRun({
+      app, apiTarget, execIds: ["122"], batch: 1, toNodeId: 122, verifyTimeoutMs: 500,
+    });
+    assert.equal(result.outcome, "refused", "a look-alike type is NOT exempt from drift detection");
+    assert.match(result.error, /graph CHANGED/i);
+    assert.match(result.error, /47 seed/);
+    assert.equal(server.calls.length, 0, "the drifted prompt never left the tab");
+    assert.deepEqual(result.volatileInputs, [], "and nothing was excluded for it");
   } finally {
     stop();
   }

--- a/browser_tests/unit/run-scope-guard.test.mjs
+++ b/browser_tests/unit/run-scope-guard.test.mjs
@@ -345,6 +345,78 @@ test("#572 collectVolatileInputs: the linked-target exclusion reaches nested sub
   assert.ok(pairs.has("10:15 noise_seed"), "nested target pairs line up with the flattened prompt keys");
 });
 
+// ---------------------------------------------------------------------------
+// #1124 — the SECOND volatility mechanism: an extension that rewrites the
+// outgoing prompt in its own api.queuePrompt patch, with no widget hook at all.
+//
+// The widget shape below is the repo's measured `Seed (rgthree)` instance
+// (scoped-batch-seed.test.mjs): rgthree SPLICES OUT control_after_generate and
+// leaves `seed` plus three buttons. Note what is absent — there is no
+// `beforeQueued` anywhere on it, which is exactly why the hook scan found
+// nothing and every scoped run on such a graph was refused as "graph CHANGED".
+// ---------------------------------------------------------------------------
+
+const rgthreeSeedNode = (id, seedValue, extra = {}) => ({
+  id,
+  type: "Seed (rgthree)",
+  mode: 0,
+  widgets: [
+    { name: "seed", value: seedValue },
+    { name: "🎲 Randomize Each Time", value: "" },
+    { name: "🎲 New Fixed Random", value: "" },
+    { name: "USE_LAST_SEED", value: "okay" },
+  ],
+  ...extra,
+});
+
+test("#1124 collectVolatileInputs: an ARMED rgthree Seed node is volatile despite carrying NO beforeQueued hook", () => {
+  const root = {
+    _nodes: [
+      rgthreeSeedNode(47, -1),
+      { id: 3, widgets: [{ name: "steps", value: 20 }] },
+    ],
+  };
+  // Proof the OLD signal could not have found it: nothing on this node is a hook.
+  for (const w of root._nodes[0].widgets) {
+    assert.equal(typeof w.beforeQueued, "undefined", `${w.name} carries no beforeQueued`);
+  }
+  assert.deepEqual([...collectVolatileInputs(root)].sort(), ["47 seed"]);
+});
+
+test("#1124 collectVolatileInputs: a FIXED rgthree Seed excludes nothing — the graph stays fully drift-covered", () => {
+  const root = { _nodes: [rgthreeSeedNode(47, 12345)] };
+  assert.equal(collectVolatileInputs(root).size, 0);
+});
+
+test("#1124 collectVolatileInputs: the rgthree exclusion reaches nested subgraphs with the colon-path execId", () => {
+  const root = {
+    _nodes: [{ id: 10, widgets: [], subgraph: { _nodes: [rgthreeSeedNode(15, -1)] } }],
+  };
+  assert.ok(collectVolatileInputs(root).has("10:15 seed"), "nested pairs line up with the flattened prompt keys");
+});
+
+test("#1124 promptContentHash: rgthree's substitution is not drift, but an edit to ANY other input of the SAME node still is", () => {
+  // The narrowness check. Only the one input rgthree rewrites is dropped; the
+  // node's other inputs, and every other node, keep full coverage.
+  const graph = { _nodes: [rgthreeSeedNode(47, -1)] };
+  const volatileInputs = collectVolatileInputs(graph);
+  const stamped = { "47": { class_type: "Seed (rgthree)", inputs: { seed: -1, extra: 7 } } };
+  const atHash = promptContentHash(stamped, volatileInputs);
+  const body = (inputs) => JSON.stringify({ prompt: { "47": { class_type: "Seed (rgthree)", inputs } } });
+  // rgthree's own measured draw, substituted at queue time ⇒ still OUR dispatch.
+  assert.equal(
+    promptContentHashFromBody(body({ seed: 1028465986822020, extra: 7 }), volatileInputs),
+    atHash,
+    "the queue-time substitution is the exclusion's purpose",
+  );
+  // A sibling input on the SAME node ⇒ real drift, still refused.
+  assert.notEqual(
+    promptContentHashFromBody(body({ seed: 1028465986822020, extra: 8 }), volatileInputs),
+    atHash,
+    "a sibling input of the seed node is NOT covered by the exclusion",
+  );
+});
+
 test("#572 promptContentHash: the narrowed exclusion tolerates ONLY the hook's own input — a seed edit is the documented residual, an edit to any OTHER input of the same node refuses", () => {
   const control = { name: "control_after_generate", value: "randomize", beforeQueued() {} };
   const seed = { name: "seed", value: 111, linkedWidgets: [control] };
@@ -1988,6 +2060,146 @@ test("#556 r8 integration: an edit to a NON-hook node's same-named input is STIL
     assert.equal(result.outcome, "refused");
     assert.match(result.error, /graph CHANGED/i);
     assert.equal(server.calls.length, 0, "the edited workflow never left the tab");
+  } finally {
+    stop();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// #1124 integration — the reporter's exact sequence, driven through the REAL
+// dispatchScopedRun.
+//
+// A `Seed (rgthree)` node (id 47) armed with the -1 sentinel feeds two KSampler
+// seed inputs; the run is scoped to a downstream SaveImage (122). rgthree's
+// `comfy-api-queue-prompt-before` handler fires INSIDE api.queuePrompt — after
+// our pre-dispatch stamp, before the fetch — and overwrites the node's own seed
+// input in the outgoing prompt. The widget itself stays at -1 (measured, see
+// scoped-batch-seed.js), which is why the panel's single retry drew a DIFFERENT
+// number and failed identically: the refusal was permanent, not racy.
+// ---------------------------------------------------------------------------
+
+/** The reporter's graph as graphToPrompt serializes it. */
+const RGTHREE_STAMP = {
+  "47": { class_type: "Seed (rgthree)", inputs: { seed: -1 } },
+  "3": { class_type: "KSampler", inputs: { seed: ["47", 0], steps: 20 } },
+  "5": { class_type: "KSampler", inputs: { seed: ["47", 0], steps: 25 } },
+  "122": { class_type: "SaveImage", inputs: { images: ["3", 0] } },
+};
+
+/** rgthree's own measured draws (recorded in scoped-batch-seed.js). */
+const RGTHREE_DRAWS = [1028465986822020, 98533269447704, 557498712106716];
+
+/**
+ * A frontend whose api.queuePrompt substitutes like rgthree's patch does.
+ * `alsoEdit` mutates the outgoing prompt further, standing in for a REAL user
+ * edit landing in the same window — the case that must still be refused.
+ */
+function makeRgthreeFrontend({ apiTarget, seedWidgetValue = -1, alsoEdit = null }) {
+  let draw = 0;
+  const stamp = () => {
+    const out = structuredClone(RGTHREE_STAMP);
+    out["47"].inputs.seed = seedWidgetValue;
+    return out;
+  };
+  const app = {
+    queueItems: [],
+    posted: [],
+    // The panel's live root (production shape, r8) — no beforeQueued anywhere.
+    graph: { _nodes: [rgthreeSeedNode(47, seedWidgetValue), { id: 3, widgets: [{ name: "steps", value: 20 }] }] },
+    graphToPrompt: async () => ({ output: stamp(), workflow: {} }),
+    queuePrompt: async (number, batch, arg) => {
+      const targets = Array.isArray(arg) ? arg : arg?.queueNodeIds;
+      const output = stamp();
+      // rgthree: `outputInputs[this.seedWidget.name || "seed"] = seedToUse;`
+      // — only when the widget holds a sentinel, which is what arms the node.
+      if ([-1, -2, -3].includes(seedWidgetValue)) {
+        output["47"].inputs.seed = RGTHREE_DRAWS[draw++ % RGTHREE_DRAWS.length];
+      }
+      if (alsoEdit) alsoEdit(output);
+      const body = frontendBody({ output, number, targets: targets?.length ? targets : null });
+      app.posted.push(body);
+      await apiTarget.fetchApi(...promptPost(body));
+      return true;
+    },
+  };
+  return app;
+}
+
+test("#1124 integration: an ARMED rgthree Seed substituting its own seed at queue time is OUR dispatch — the scoped run reaches ComfyUI instead of being permanently refused", async () => {
+  const stop = keepAlive();
+  try {
+    const server = makeServer();
+    const apiTarget = { fetchApi: server };
+    const app = makeRgthreeFrontend({ apiTarget });
+    const ids = [];
+    const result = await dispatchScopedRun({
+      app, apiTarget, execIds: ["122"], batch: 1, toNodeId: 122,
+      verifyTimeoutMs: 500,
+      onPromptId: (p) => ids.push(p),
+    });
+    assert.equal(result.outcome, "dispatched", "the reported refusal is gone");
+    assert.equal(result.verified, 1);
+    assert.deepEqual(ids, ["srv-1"]);
+    assert.equal(server.calls.length, 1, "the scoped prompt actually reached ComfyUI");
+    // The scope is still delivered — this fix must not cost the guarantee #556 exists for.
+    assert.deepEqual(JSON.parse(server.calls[0].options.body).partial_execution_targets, ["122"]);
+    // The gap is DISCLOSED, never silent: graph_run turns this into drift_coverage.
+    assert.deepEqual(result.volatileInputs, ["47 seed"]);
+  } finally {
+    stop();
+  }
+});
+
+test("#1124 integration: a FIXED rgthree Seed keeps full drift coverage — a body whose seed differs is STILL refused", async () => {
+  const stop = keepAlive();
+  try {
+    const server = makeServer();
+    const apiTarget = { fetchApi: server };
+    // Not armed ⇒ rgthree substitutes nothing ⇒ nothing is excluded. Something
+    // ELSE changed that seed, and that is exactly the drift #556 must catch.
+    const app = makeRgthreeFrontend({
+      apiTarget,
+      seedWidgetValue: 12345,
+      alsoEdit: (output) => { output["47"].inputs.seed = 999; },
+    });
+    const result = await dispatchScopedRun({
+      app, apiTarget, execIds: ["122"], batch: 1, toNodeId: 122, verifyTimeoutMs: 500,
+    });
+    assert.equal(result.outcome, "refused", "a fixed seed node is NOT drift-blind");
+    assert.match(result.error, /graph CHANGED/i);
+    assert.match(result.error, /47 seed/, "and the refusal still names what differed");
+    assert.equal(server.calls.length, 0, "the drifted prompt never left the tab");
+    assert.deepEqual(result.volatileInputs, [], "a fixed node excludes nothing");
+  } finally {
+    stop();
+  }
+});
+
+test("#1124 integration: the exclusion is ONE input — an armed rgthree Seed does NOT let a real edit elsewhere ride along", async () => {
+  const stop = keepAlive();
+  try {
+    // The guard-relaxation check, and the reason this fix is not a widening of
+    // #556 into uselessness: rgthree substitutes AND the user rewires/edits
+    // something in the same window. The run must still be refused.
+    for (const [label, edit] of [
+      ["a widget value elsewhere", (o) => { o["3"].inputs.steps = 25; }],
+      ["a link rewired", (o) => { o["122"].inputs.images = ["5", 0]; }],
+      ["a node added", (o) => { o["77"] = { class_type: "SaveImage", inputs: {} }; }],
+    ]) {
+      const server = makeServer();
+      const apiTarget = { fetchApi: server };
+      const app = makeRgthreeFrontend({ apiTarget, alsoEdit: edit });
+      const result = await dispatchScopedRun({
+        app, apiTarget, execIds: ["122"], batch: 1, toNodeId: 122, verifyTimeoutMs: 500,
+      });
+      assert.equal(result.outcome, "refused", `${label} is still drift`);
+      assert.match(result.error, /graph CHANGED/i, label);
+      assert.equal(server.calls.length, 0, `${label}: the edited workflow never left the tab`);
+      // The seed itself must NOT appear in the drift list — it was excluded — so
+      // the refusal names the REAL change instead of the red herring the reporter
+      // was handed.
+      assert.doesNotMatch(result.error, /47 seed/, `${label}: the substituted seed is no longer blamed`);
+    }
   } finally {
     stop();
   }

--- a/browser_tests/unit/scoped-batch-seed.test.mjs
+++ b/browser_tests/unit/scoped-batch-seed.test.mjs
@@ -21,6 +21,7 @@ import {
   scopedBatchSeedNote,
   findRgthreeSeedNodes,
   rgthreeFixedSeedNote,
+  rgthreeQueueTimeSeedInput,
 } from "../../web/js/lib/scoped-batch-seed.js";
 
 /** The real KSampler widget order: the control sits immediately after the value. */
@@ -333,4 +334,69 @@ test("#1339 — survives malformed nodes without taking down the run", () => {
   // A seed widget that is not a number establishes nothing, so it is not reported as fixed.
   assert.deepEqual(findRgthreeSeedNodes([rgthreeSeed(1, "not-a-number")]), []);
   assert.equal(rgthreeFixedSeedNote(null, 5), "");
+});
+
+// ---------------------------------------------------------------------------
+// #1124 — the same measured rgthree behaviour, read by the #556 drift guard.
+//
+// The guard stamps the graph before dispatch and compares it against the POSTED
+// body. rgthree substitutes the seed AFTER that stamp, inside its own
+// api.queuePrompt patch, and carries no `beforeQueued` hook for the guard to
+// notice — so every scoped run on a workflow with an armed Seed (rgthree) was
+// refused as "the graph CHANGED". This helper is what tells the guard which
+// single input to stop hashing.
+// ---------------------------------------------------------------------------
+
+test("#1124 — an ARMED rgthree seed names the input rgthree will rewrite", () => {
+  for (const sentinel of [-1, -2, -3]) {
+    assert.equal(rgthreeQueueTimeSeedInput(rgthreeSeed(47, sentinel)), "seed", `sentinel ${sentinel}`);
+  }
+});
+
+test("#1124 — a FIXED rgthree seed excludes NOTHING, so a mid-window edit to it is still drift", () => {
+  // The gate, in the same direction as collectVolatileInputs' `value === "fixed"`
+  // rule for the stock control_after_generate carrier. `getSeedToUse()` returns a
+  // non-sentinel `inputSeed` unchanged, so the body carries exactly what the stamp
+  // saw — nothing mutates, and dropping it from the hash would blind the guard to
+  // a real edit for no benefit.
+  assert.equal(rgthreeQueueTimeSeedInput(rgthreeSeed(47, 12345)), null);
+  assert.equal(rgthreeQueueTimeSeedInput(rgthreeSeed(47, 0)), null);
+});
+
+test("#1124 — ARMED is the gate, NOT `varies`: a degenerate random range still substitutes", () => {
+  // The distinction that a reviewer will reach for, so it is pinned here.
+  // findRgthreeSeedNodes reports `varies: false` for an armed node whose
+  // randomMin/randomMax admit one value — correct for the #1339 warning, wrong
+  // for the drift guard. Such a node still REPLACES the -1 sentinel in the body
+  // with that single value, so the input still differs between the two
+  // serializations and must still be excluded. Keying this on `varies` would have
+  // left exactly the degenerate-range workflows refused.
+  const degenerate = { ...rgthreeSeed(47, -1), properties: { randomMin: 5, randomMax: 5 } };
+  assert.equal(findRgthreeSeedNodes([degenerate])[0].varies, false, "the #1339 warning says it repeats");
+  assert.equal(rgthreeQueueTimeSeedInput(degenerate), "seed", "…and the drift guard still excludes it");
+});
+
+test("#1124 — a MUTED or BYPASSED node substitutes nothing, so it excludes nothing", () => {
+  // rgthree: `if (this.mode === LiteGraph.NEVER || this.mode === 4) return;`
+  for (const mode of [2, 4]) {
+    assert.equal(rgthreeQueueTimeSeedInput({ ...rgthreeSeed(47, -1), mode }), null, `mode ${mode}`);
+  }
+  assert.equal(rgthreeQueueTimeSeedInput({ ...rgthreeSeed(47, -1), mode: 0 }), "seed");
+});
+
+test("#1124 — foreign seed nodes and malformed nodes exclude NOTHING (fail toward detecting drift)", () => {
+  // The over-broad direction is the dangerous one here: a false exclusion silently
+  // drops an input from the drift check for every run on that graph. These are the
+  // same real /object_info types the #1339 scan is guarded against claiming.
+  for (const type of ["SeedNode", "LatentBatchSeedBehavior", "SeedVR2Conditioning"]) {
+    assert.equal(rgthreeQueueTimeSeedInput({ id: 1, type, widgets: [{ name: "seed", value: -1 }] }), null, type);
+  }
+  assert.equal(rgthreeQueueTimeSeedInput(ksampler(53, "randomize")), null);
+  assert.equal(rgthreeQueueTimeSeedInput(null), null);
+  assert.equal(rgthreeQueueTimeSeedInput({}), null);
+  assert.equal(rgthreeQueueTimeSeedInput({ type: "Seed (rgthree)" }), null, "no widgets ⇒ no exclusion");
+  assert.equal(rgthreeQueueTimeSeedInput(rgthreeSeed(47, "not-a-number")), null);
+  // A throwing accessor must not escape onto the dispatch path.
+  const hostile = { type: "Seed (rgthree)", get widgets() { throw new Error("boom"); } };
+  assert.equal(rgthreeQueueTimeSeedInput(hostile), null);
 });

--- a/browser_tests/unit/scoped-batch-seed.test.mjs
+++ b/browser_tests/unit/scoped-batch-seed.test.mjs
@@ -384,6 +384,41 @@ test("#1124 — a MUTED or BYPASSED node substitutes nothing, so it excludes not
   assert.equal(rgthreeQueueTimeSeedInput({ ...rgthreeSeed(47, -1), mode: 0 }), "seed");
 });
 
+test("#1124 — a LOOK-ALIKE foreign node whose type merely CONTAINS 'rgthree' and 'seed' is NOT excluded", () => {
+  // The defect this exact-type match exists to prevent (codex r1 P2). The #1339
+  // scan's predicate is two substring tests, so all of these satisfy it — and each
+  // carries a `seed` widget armed with a real rgthree sentinel, so every other gate
+  // in the function passes too. If the exclusion used that predicate, these nodes'
+  // seeds would be dropped from BOTH hashes despite installing no queue-time
+  // rewrite, and a genuine deferred edit to one would bypass the #556 guard
+  // silently, for every scoped run on that graph.
+  const lookAlikes = [
+    "Seed Generator (rgthree-style)",
+    "rgthree Seed Helper",
+    "Advanced Seed (rgthree compatible)",
+    "seed (rgthree)", // lowercase — not the registered type
+    "Seed (rgthree) ", // trailing space — not the registered type
+  ];
+  for (const type of lookAlikes) {
+    const node = { id: 47, type, mode: 0, widgets: [{ name: "seed", value: -1 }] };
+    // It DOES satisfy the loose #1339 predicate — that is what makes it dangerous…
+    assert.equal(findRgthreeSeedNodes([node]).length, 1, `${type} matches the loose #1339 scan`);
+    // …and it must STILL be fully drift-covered.
+    assert.equal(rgthreeQueueTimeSeedInput(node), null, `${type} must NOT be excluded`);
+  }
+  // The registered type, unchanged, still is.
+  assert.equal(rgthreeQueueTimeSeedInput(rgthreeSeed(47, -1)), "seed");
+});
+
+test("#1124 — the #1339 warning predicate is deliberately NOT tightened along with the exclusion", () => {
+  // The two callers want opposite failure directions, so the split is the point:
+  // over-warning is noise, over-excluding is lost drift coverage. Pinned so a
+  // later "consolidate these two predicates" cleanup has to read the reason first.
+  const variant = { id: 47, type: "Seed Generator (rgthree-style)", mode: 0, widgets: [{ name: "seed", value: 12345 }] };
+  assert.equal(findRgthreeSeedNodes([variant]).length, 1, "#1339 still warns generously");
+  assert.equal(rgthreeQueueTimeSeedInput(variant), null, "#1124 still excludes strictly");
+});
+
 test("#1124 — foreign seed nodes and malformed nodes exclude NOTHING (fail toward detecting drift)", () => {
   // The over-broad direction is the dangerous one here: a false exclusion silently
   // drops an input from the drift check for every run on that graph. These are the

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -13133,23 +13133,31 @@ const GRAPH_TOOL_EXECUTORS = {
       accept.fixed_seed_nodes = rgthreeSeeds.filter((s) => s && s.armed === false);
       accept.fixed_seed_note = fixedSeedNote;
     }
-    // #572 — TRUTHFUL drift-coverage note for a scoped run: the drift hash
-    // excluded queue-time hook inputs (beforeQueued carriers + their linked,
-    // serialized targets — e.g. a control_after_generate seed reroll). A user
-    // edit to exactly THOSE inputs during the queue window is indistinguishable
-    // from the hook's own mutation (accepted residual), so the result names the
-    // uncovered inputs instead of implying full-graph drift proof. Every other
-    // input was covered.
+    // #572/#1124 — TRUTHFUL drift-coverage note for a scoped run: the drift hash
+    // excluded the inputs that mutate at queue time by either known mechanism —
+    // beforeQueued carriers + their linked, serialized targets (e.g. a
+    // control_after_generate seed reroll), and the seed of an ARMED rgthree Seed
+    // node, which carries no hook at all because rgthree substitutes it inside
+    // its own api.queuePrompt patch. A user edit to exactly THOSE inputs during
+    // the queue window is indistinguishable from the queue-time mutation
+    // (accepted residual), so the result names the uncovered inputs instead of
+    // implying full-graph drift proof. Every other input was covered.
+    //
+    // The note does not say WHICH mechanism excluded which input: the panel
+    // knows, but the reader's question is "what was not checked", and a
+    // per-input attribution would be a second claim to keep true.
     const uncovered = runScopeResult?.volatileInputs;
     if (partialTargets && Array.isArray(uncovered) && uncovered.length) {
       accept.drift_coverage = {
         covered: "partial",
         uncovered_inputs: uncovered,
         note:
-          "These queue-time hook inputs (beforeQueued, e.g. a control_after_generate seed " +
-          "reroll) were excluded from this run's graph-drift check: a user edit to exactly " +
-          "these inputs during the queue window is indistinguishable from the hook's own " +
-          "mutation and would NOT have been caught. Every other input was drift-covered.",
+          "These inputs mutate at queue time — a beforeQueued hook (e.g. a " +
+          "control_after_generate seed reroll), or an extension that rewrites the prompt in " +
+          "its own api.queuePrompt patch (an armed Seed (rgthree) node) — so they were " +
+          "excluded from this run's graph-drift check: a user edit to exactly these inputs " +
+          "during the queue window is indistinguishable from that mutation and would NOT " +
+          "have been caught. Every other input was drift-covered.",
       };
     }
     // #556 — DISCLOSE how the scope actually reached ComfyUI. When both

--- a/web/js/lib/run-scope-guard.js
+++ b/web/js/lib/run-scope-guard.js
@@ -1,4 +1,10 @@
 import { tr } from "./i18n.js";
+// #1124 — rgthree's Seed node mutates the outgoing prompt WITHOUT a beforeQueued
+// hook, so collectVolatileInputs needs a second volatility signal. The measured
+// facts about that pack (sentinels, node predicate, mute/bypass early-return, the
+// input its handler overwrites) already live in scoped-batch-seed.js; this file
+// imports the verdict rather than restating them.
+import { rgthreeQueueTimeSeedInput } from "./scoped-batch-seed.js";
 // #556 — panel_run's to_node_id ("run to node") must NEVER silently fall through
 // to a FULL-graph execution. A scoped run can fail open on two channels:
 //
@@ -66,9 +72,11 @@ import { tr } from "./i18n.js";
 //
 //  - The prompt CONTENT HASH (r7) must be computable BEFORE dispatch: a
 //    stable hash of the full queued prompt — node ids, class types, links,
-//    every input/widget value — excluding ONLY (a) the inputs that self-mutate
+//    every input/widget value — excluding ONLY (a) the inputs that mutate
 //    at queue time (beforeQueued hooks: seed widgets re-rolled by their linked
-//    control_after_generate, and the hook widgets themselves), which change
+//    control_after_generate, and the hook widgets themselves; plus prompts
+//    rewritten by an extension's own api.queuePrompt patch, which carry no hook
+//    at all — rgthree's armed Seed node, #1124), which change
 //    between any two serializations of the SAME graph by design (#572: the
 //    exclusion must reach the hook's serialized TARGET, not just the
 //    unserialized control the hook hangs on), and (b) inputs whose value the
@@ -206,9 +214,11 @@ const fnv1aHex = (s) =>
  * the in-memory `graphToPrompt().output` object (pre-dispatch) and the parsed
  * POST /prompt body (post-time serialization after a JSON round-trip):
  *
- *  1. VOLATILE INPUTS — inputs that self-mutate at queue time (a
- *     `beforeQueued` hook — stock seed widgets re-rolled by their linked
- *     control_after_generate, third-party hook widgets, etc.): those change
+ *  1. VOLATILE INPUTS — inputs that mutate at queue time, by either mechanism
+ *     collectVolatileInputs knows about: a `beforeQueued` hook (stock seed
+ *     widgets re-rolled by their linked control_after_generate, third-party hook
+ *     widgets), or an extension rewriting the outgoing prompt in its own
+ *     `api.queuePrompt` patch (rgthree's armed Seed node, #1124). Those change
  *     between any two serializations of the SAME graph by design, so hashing
  *     them would refuse our own dispatch. Exclusions are PER-NODE pairs
  *     (prompt node id + input name, r8): an edit to a NON-hook node's
@@ -386,9 +396,14 @@ export function promptContentHashFromBody(bodyText, volatileInputs = null) {
 }
 
 /**
- * The "execId inputName" pairs whose owning widgets SELF-MUTATE at queue time
- * (a `beforeQueued` hook), collected from the live root graph and every nested
- * subgraph. execId is the flattened prompt id: String(node.id) at root, the
+ * The "execId inputName" pairs whose values MUTATE AT QUEUE TIME — after our
+ * pre-dispatch stamp and before the POST body is built — collected from the live
+ * root graph and every nested subgraph. TWO signals, because there are two
+ * mechanisms (#1124): a widget-level `beforeQueued` hook, and an extension that
+ * patches `api.queuePrompt` and rewrites the outgoing prompt directly. The
+ * second is invisible to any widget scan, so it is matched by node identity
+ * instead (rgthree's armed Seed node — see rgthreeQueueTimeSeedInput).
+ * execId is the flattened prompt id: String(node.id) at root, the
  * colon-joined subgraph-instance path for nested nodes ("10:15:359") — the
  * same path buildNodeExecutionId produces, so pairs line up with the keys of
  * the API prompt. These are the ONLY values the content hash excludes —
@@ -454,6 +469,26 @@ export function collectVolatileInputs(rootGraph) {
           }
         }
       }
+      // #1124 — THE SECOND VOLATILITY SIGNAL. `beforeQueued` is not the only way
+      // an input mutates between our stamp and the POST: a pack can patch
+      // `api.queuePrompt` itself and rewrite the serialized prompt on its way out,
+      // which happens AFTER graphToPrompt and is invisible to any widget-hook
+      // scan. rgthree's Seed node does exactly that — and it SPLICES OUT the
+      // control_after_generate widget the stock hook would have ridden on, so the
+      // loop above finds nothing on it. Every scoped run on a workflow containing
+      // an armed Seed (rgthree) was therefore refused as "the graph CHANGED",
+      // naming the seed input, with nothing queued and the retry failing
+      // identically (the widget stays armed, so each attempt draws a new number).
+      //
+      // NARROW BY CONSTRUCTION, and it must stay that way: this excludes exactly
+      // ONE input on nodes that self-identify as rgthree seed nodes AND are armed
+      // with one of rgthree's sentinels. A fixed seed, a muted or bypassed node,
+      // and every other node in the graph keep full drift coverage —
+      // rgthreeQueueTimeSeedInput returns null for all of them. #556 still catches
+      // a graph that genuinely changed under a stamped run; what it no longer does
+      // is call another extension's documented queue-time substitution a user edit.
+      const rgthreeSeedInput = rgthreeQueueTimeSeedInput(node);
+      if (rgthreeSeedInput != null) addPair(execId, rgthreeSeedInput);
       if (node.subgraph) walk(node.subgraph, execId);
     }
   };
@@ -754,17 +789,27 @@ export function scopeDroppedError({ toNodeId, verdict }) {
     // WHAT rewrote the value, or even that a "rewrite" happened at all (a
     // nondeterministic widget serializer — a serializeValue emitting a
     // timestamp — produces this same refusal on an untouched graph).
+    // #1124 added the FOURTH candidate, and it is the one that had been missing:
+    // an extension that patches `api.queuePrompt` and rewrites the serialized
+    // prompt on its way out. That happens after graphToPrompt and carries no
+    // widget hook, so no scan of the live graph can see it coming. rgthree's Seed
+    // node is the measured instance and is now excluded by name
+    // (collectVolatileInputs); it stays listed here because the NEXT pack doing
+    // the same thing will land on this message, and naming the shape is what lets
+    // a reporter recognise it.
     const causeText = drift
       ? `If you did not edit ${drift.length === 1 ? "it" : "these"} between queueing and ` +
         `dispatch, the two serializations differ for a reason the panel cannot identify from ` +
-        `here — candidates: a queue-time widget hook (e.g. control_after_generate), a ` +
+        `here — candidates: a queue-time widget hook (e.g. control_after_generate), an ` +
+        `extension that rewrites the prompt inside its own api.queuePrompt patch, a ` +
         `dynamic-input node reshaping its slots, or a nondeterministic widget serializer. ` +
         `Please report this with the differing list above. `
       : `If this recurs without any edit in between, the two serializations differ for a ` +
         `reason the panel cannot identify from here — candidates: a queue-time widget hook ` +
         `mutating values between serialization and dispatch (e.g. a control_after_generate ` +
         `widget with WidgetControlMode "before" — switch it to "after" or fix the target ` +
-        `widget's value), or a nondeterministic widget serializer. `;
+        `widget's value), an extension that rewrites the prompt inside its own ` +
+        `api.queuePrompt patch, or a nondeterministic widget serializer. `;
     return (
       `run-to-node scope for node ${toNodeId} was NOT applied: the workflow graph ` +
       `CHANGED after the run was queued — the deferred dispatch would render a ` +
@@ -1426,8 +1471,10 @@ export async function dispatchScopedRun({
   }
   // The CONTENT HASH that (with the queue mark) attributes a POST /prompt
   // body to THIS run: the full prompt we are about to queue — ids, class
-  // types, links, widget values — minus only the self-mutating (beforeQueued)
-  // inputs that change between any two serializations by design, and the
+  // types, links, widget values — minus only the queue-time-mutating inputs
+  // (beforeQueued hooks, and prompts an extension rewrites in its own
+  // api.queuePrompt patch — #1124) that change between any two
+  // serializations by design, and the
   // JSON-invisible values that cannot survive the POST body at all (#659).
   // No hash ⇒ no attribution ⇒ fail closed BEFORE dispatch. The canonical
   // form is RETAINED (contentCanon) so a graph_changed refusal can say WHAT
@@ -1450,8 +1497,9 @@ export async function dispatchScopedRun({
   if (!contentHash) {
     return { outcome: "unverifiable", queueMark: mark, error: scopeUnattributableError({ toNodeId }) };
   }
-  // #572 — the inputs this run does NOT drift-cover (queue-time hook inputs:
-  // hook carriers plus their linked, serialized targets). Surfaced on every
+  // #572/#1124 — the inputs this run does NOT drift-cover (queue-time hook
+  // carriers plus their linked, serialized targets; and an armed rgthree Seed
+  // node's own seed input). Surfaced on every
   // post-hash outcome so the caller can report the coverage gap truthfully
   // instead of implying full-graph drift proof (see collectVolatileInputs'
   // ACCEPTED RESIDUAL note).

--- a/web/js/lib/scoped-batch-seed.js
+++ b/web/js/lib/scoped-batch-seed.js
@@ -324,16 +324,30 @@ export function findRgthreeSeedNodes(nodes) {
 }
 
 /**
+ * Node types whose queue-time prompt rewrite has actually been MEASURED — the
+ * capability claim behind the #1124 drift exclusion, stated as data.
+ *
+ * EXACT registered type, not a substring test, and the set holds exactly what has
+ * been verified. `Seed (rgthree)` is the type on the live instance this repo's
+ * fixtures were taken from; nothing else has been observed rewriting the prompt in
+ * an `api.queuePrompt` patch, so nothing else is listed. Adding a type here is a
+ * claim that THAT node substitutes at queue time — it must be measured first, not
+ * guessed from a plausible-looking name.
+ */
+const RGTHREE_QUEUE_REWRITING_SEED_TYPES = new Set(["Seed (rgthree)"]);
+
+/**
  * #1124 — the input rgthree will REWRITE in the outgoing prompt, or null when it
  * rewrites nothing. Returns the input NAME so the caller can build a per-node
  * exclusion pair; the drift guard (run-scope-guard.js) is the only consumer.
  *
- * WHY IT LIVES IN THIS MODULE rather than in the guard. Everything it needs is
- * already measured and written down HERE — the sentinel set, the node predicate,
- * the mute/bypass early-return, and the quoted handler line that says WHICH input
- * gets overwritten. Restating any of that next to the guard would create a second
- * copy of a measured fact about someone else's pack, and the two would drift the
- * first time rgthree changed. The guard imports; nothing is duplicated.
+ * WHY IT LIVES IN THIS MODULE rather than in the guard. Almost everything it needs
+ * is already measured and written down HERE — the sentinel set, the mute/bypass
+ * early-return, and the quoted handler line that says WHICH input gets overwritten.
+ * Restating any of that next to the guard would create a second copy of a measured
+ * fact about someone else's pack, and the two would drift the first time rgthree
+ * changed. The guard imports; nothing is duplicated. (The node-type match is the
+ * one thing this function does NOT share with the #1339 scan — see below.)
  *
  * WHAT IT IS FOR. The #556 drift guard stamps the graph before dispatch and
  * compares that stamp against the POSTED body. Its only volatility signal was
@@ -363,12 +377,35 @@ export function findRgthreeSeedNodes(nodes) {
  * refused. Same for a MUTED or BYPASSED node: rgthree's handler returns early for
  * both, so it substitutes nothing.
  *
+ * IT DOES NOT SHARE `isRgthreeSeedNode` WITH THE #1339 WARNING, and that is a
+ * deliberate split rather than an oversight (codex r1 P2). That predicate is two
+ * substring tests — `/rgthree/i && /seed/i` — so a foreign custom node whose type
+ * happens to contain both words, carrying a `seed` widget holding -1/-2/-3, would
+ * have had its seed dropped from BOTH hashes despite installing no queue-time
+ * rewrite at all. A real deferred edit to that node would then sail past the #556
+ * guard. The two callers want OPPOSITE failure directions, so one predicate cannot
+ * serve both:
+ *
+ *   #1339 (warning)      a false positive is NOISE — one extra sentence about a
+ *                        node that may not repeat. A false NEGATIVE is the bug
+ *                        that issue was filed for (a missed warning), so a loose,
+ *                        generous match is the right trade there and is left
+ *                        exactly as it was.
+ *   #1124 (drift guard)  a false positive SILENTLY REMOVES drift coverage for the
+ *                        life of every scoped run on that graph. Fail-closed is
+ *                        the only acceptable direction, so the match is an exact
+ *                        registered type from a measured set.
+ *
+ * Tightening the shared predicate would have traded a real #1339 regression (a
+ * genuinely-rgthree seed node with a variant type going unwarned) for a cosmetic
+ * saving of one constant. So the warning heuristic stays; the exclusion is strict.
+ *
  * Defensive like the rest of this module: an unreadable node yields null (no
  * exclusion), which fails TOWARD detecting drift.
  */
 export function rgthreeQueueTimeSeedInput(node) {
   try {
-    if (!isRgthreeSeedNode(node)) return null;
+    if (!RGTHREE_QUEUE_REWRITING_SEED_TYPES.has(node?.type)) return null;
     // rgthree: `if (this.mode === LiteGraph.NEVER || this.mode === 4) return;`
     if (node?.mode === 2 || node?.mode === 4) return null;
     const widgets = Array.isArray(node?.widgets) ? node.widgets : [];

--- a/web/js/lib/scoped-batch-seed.js
+++ b/web/js/lib/scoped-batch-seed.js
@@ -324,6 +324,70 @@ export function findRgthreeSeedNodes(nodes) {
 }
 
 /**
+ * #1124 — the input rgthree will REWRITE in the outgoing prompt, or null when it
+ * rewrites nothing. Returns the input NAME so the caller can build a per-node
+ * exclusion pair; the drift guard (run-scope-guard.js) is the only consumer.
+ *
+ * WHY IT LIVES IN THIS MODULE rather than in the guard. Everything it needs is
+ * already measured and written down HERE — the sentinel set, the node predicate,
+ * the mute/bypass early-return, and the quoted handler line that says WHICH input
+ * gets overwritten. Restating any of that next to the guard would create a second
+ * copy of a measured fact about someone else's pack, and the two would drift the
+ * first time rgthree changed. The guard imports; nothing is duplicated.
+ *
+ * WHAT IT IS FOR. The #556 drift guard stamps the graph before dispatch and
+ * compares that stamp against the POSTED body. Its only volatility signal was
+ * `typeof w.beforeQueued === "function"` — and rgthree does not use that hook at
+ * all. It SPLICES OUT the `control_after_generate` widget the frontend would have
+ * hung the hook on (see the #1339 block above) and substitutes the seed inside its
+ * own `api.queuePrompt` patch instead, after our stamp and before the fetch. So the
+ * stamp recorded `-1`, the body carried a fresh random, and every scoped run on a
+ * workflow containing an armed Seed (rgthree) was refused as "the workflow graph
+ * CHANGED" with `47 seed` named as the differing entry — permanently, because the
+ * widget stays armed at `-1` and each retry draws a different number (#1124).
+ *
+ * ARMED IS THE GATE, AND `varies` IS DELIBERATELY NOT.
+ * `findRgthreeSeedNodes` reports `varies: false` for an armed node whose
+ * randomMin/randomMax admit a single value — the right answer for the #1339
+ * warning, and the WRONG one here. Such a node still SUBSTITUTES: it replaces the
+ * `-1` sentinel in the body with that single value (or with 0, when the degenerate
+ * draw lands on a sentinel). The input therefore still changes between the two
+ * serializations, so it is still volatile. Keying this on `varies` would have left
+ * exactly the degenerate-range workflows refused, which is the bug.
+ *
+ * A NON-ARMED NODE EXCLUDES NOTHING, mirroring the `value === "fixed"` gate the
+ * stock control_after_generate carrier already uses in collectVolatileInputs. A
+ * concrete seed is submitted verbatim (`getSeedToUse` returns `inputSeed` when it
+ * is not a sentinel), so the input does not mutate at queue time and MUST stay
+ * drift-covered — a mid-window user edit to a fixed seed is real drift and is still
+ * refused. Same for a MUTED or BYPASSED node: rgthree's handler returns early for
+ * both, so it substitutes nothing.
+ *
+ * Defensive like the rest of this module: an unreadable node yields null (no
+ * exclusion), which fails TOWARD detecting drift.
+ */
+export function rgthreeQueueTimeSeedInput(node) {
+  try {
+    if (!isRgthreeSeedNode(node)) return null;
+    // rgthree: `if (this.mode === LiteGraph.NEVER || this.mode === 4) return;`
+    if (node?.mode === 2 || node?.mode === 4) return null;
+    const widgets = Array.isArray(node?.widgets) ? node.widgets : [];
+    const seedWidget = widgets.find((w) => w?.name === "seed");
+    if (!seedWidget) return null;
+    const raw = Number(seedWidget.value);
+    if (!Number.isFinite(raw)) return null;
+    // Only a sentinel makes `getSeedToUse()` draw a NEW number; anything else is
+    // returned unchanged and lands in the body exactly as the stamp saw it.
+    if (!RGTHREE_SPECIAL_SEEDS.has(raw)) return null;
+    // The handler writes `outputInputs[this.seedWidget.name || "seed"]`, and the
+    // widget was found BY that name, so the rewritten input is this one.
+    return seedWidget.name;
+  } catch {
+    return null;
+  }
+}
+
+/**
  * The disclosure for a batch whose rgthree seed is FIXED.
  *
  * Silent when the node is armed, because then it genuinely varies per item and there is


### PR DESCRIPTION
Fixes #1124

Draft — implementation and verification complete; review and merge are the maintainer's.

## The mechanism (triage diagnosis confirmed, reproduced end to end)

The #556 drift guard stamps the graph before dispatch and compares that stamp against the POSTED `/prompt` body. Its only volatility signal was `typeof w.beforeQueued === "function"` — a widget-level hook.

rgthree does not use that hook. Its Seed node **splices out** the `control_after_generate` widget the frontend would have hung the hook on, and substitutes the seed inside its own `api.queuePrompt` patch — after our stamp, before the fetch. So the stamp recorded the `-1` sentinel, the body carried a fresh random, and the guard concluded the graph drifted.

Reproduced by driving the real `dispatchScopedRun` on the reporter's graph (Seed (rgthree) id 47 armed at `-1`, feeding two KSampler seeds, run scoped to SaveImage 122). Before the fix:

```
collectVolatileInputs(live rgthree graph) = []
outcome = refused   verified = 0   reached server = 0
"…the workflow graph CHANGED after the run was queued… The differing entry: 47 seed."
```

That is the reporter's error verbatim. It was **permanent, not racy**: the widget stays armed at `-1`, so the panel's single retry drew a *different* number and failed identically — which is exactly what the report describes.

After the fix: `outcome = dispatched`, `verified = 1`, the scoped prompt reaches ComfyUI with `partial_execution_targets: ["122"]`.

## The change

`collectVolatileInputs` now carries a **second volatility signal**, because there are two mechanisms and no widget scan can see the second one. It is matched by node identity instead:

- **Narrow by construction.** Exactly one input, on nodes that self-identify as rgthree seed nodes **and** are armed with one of rgthree's sentinels (`-1`/`-2`/`-3`). A fixed seed, a muted or bypassed node, that node's *sibling* inputs, and every other node in the graph keep full drift coverage. #556 still refuses a graph that genuinely changed under a stamped run — the three integration cases below prove it.
- **ARMED is the gate, deliberately not `varies`.** `findRgthreeSeedNodes` reports `varies: false` for an armed node whose `randomMin`/`randomMax` admit one value — right for the #1339 warning, wrong here: such a node still *substitutes* (it replaces `-1` with that single value), so the input still differs between the two serializations. Keying on `varies` would have left exactly those workflows refused.
- **Fixed excludes nothing**, mirroring the existing `value === "fixed"` gate for the stock `control_after_generate` carrier: a concrete seed is submitted verbatim, so a mid-window edit to it is real drift and is still caught.
- **Exact registered node type, from an explicit measured set** (codex r1 P2 — see below). Not a substring test.
- **No duplicated facts.** The measured rgthree behaviour already lives in `scoped-batch-seed.js` from #1339 (sentinels, the mute/bypass early-return, the quoted handler line naming the overwritten input). The guard imports the verdict via a new `rgthreeQueueTimeSeedInput` rather than restating any of it.

### Round 2 — codex r1 P2: exact type match

The exclusion originally reused `isRgthreeSeedNode`, which is two substring tests (`/rgthree/i && /seed/i`). A foreign custom node whose type merely contains both words, carrying a `seed` widget armed with `-1`/`-2`/`-3`, satisfied every gate and had its seed dropped from **both** hashes despite installing no queue-time rewrite — so a genuine deferred edit to it would bypass the #556 guard silently, for every scoped run on that graph.

It now requires an exact type from `RGTHREE_QUEUE_REWRITING_SEED_TYPES`, which holds exactly `Seed (rgthree)` — the type on the live instance this repo's fixtures came from. Nothing else has been observed rewriting the prompt in an `api.queuePrompt` patch, so nothing else is listed; a set rather than a literal states the capability claim plainly and is trivial to extend once another type is actually *measured*.

**The shared #1339 predicate is deliberately left alone.** The two callers want opposite failure directions, so one predicate cannot serve both:

| | false positive | false negative |
|---|---|---|
| #1339 warning | one noisy sentence | **the missed warning #1339 was filed for** |
| #1124 drift guard | **silently lost drift coverage** | a refused run — visible, retryable |

Tightening the shared predicate would have traded a real #1339 regression (a genuinely-rgthree seed node with a variant type going unwarned) for saving one constant. Both halves of the split are now pinned by tests, so a later "consolidate these two predicates" cleanup has to read the reason first.

Also updated, because they asserted `beforeQueued` was the only mechanism: the `graph_changed` refusal message and `graph_run`'s `drift_coverage` note now name this fourth cause ("an extension that rewrites the prompt inside its own api.queuePrompt patch"), so the *next* pack doing this is recognisable instead of "a reason the panel cannot identify".

**Accepted residual** (same shape as #572's, and disclosed the same way): a user edit to the armed seed input itself during the queue window is indistinguishable from rgthree's own substitution and is tolerated. It is never silent — the input is listed in the run result's `drift_coverage.uncovered_inputs`.

## Verification

`npm run test:unit` — **4424 tests, 4423 pass, 0 fail, 1 todo** (baseline before this change: 4409 / 4408 / 0 / 1; +15 tests).

Tests **drive** the extracted functions and the real `dispatchScopedRun` orchestration; none assert on source text.

Mutation testing — committed first, then broke the fix one way at a time, restoring from an in-memory snapshot (never `git checkout`). Every anchor asserted to occur exactly once, to rule out a CRLF miss reading as a kill. Baseline green at 133, post-restore green at 133 and both files byte-identical:

| # | Mutation | Result |
|---|---|---|
| M1 | delete the wiring — `collectVolatileInputs` never records the rgthree seed | **RED** — 5 failed |
| M2 | invert the ARMED gate — exclude fixed seeds, cover armed ones | **RED** — 12 failed |
| M3 | remove the ARMED gate — widen to *every* rgthree seed node | **RED** — 3 failed |
| M4 | drop the mute/bypass early-return | **RED** — 1 failed |
| M5 | drop the node-type check — claim every node's seed is volatile | **RED** — 3 failed |
| M6 | return the wrong input name — the exclusion pair misses `seed` | **RED** — 9 failed |
| M7 | zero the sentinel set — nothing is ever considered armed | **RED** — 11 failed |
| M8 | **revert to the loose substring predicate — a look-alike foreign node gets exempted (the codex r1 P2 defect itself)** | **RED** — 2 failed |
| M9 | empty the measured type set — the real `Seed (rgthree)` stops being excluded | **RED** — 9 failed |

M3, M5 and M8 are the ones that matter for the guard-relaxation question: widening the exclusion beyond "armed, exactly-typed rgthree Seed node" is caught in all three directions, so this cannot silently decay into a blanket seed exemption.

## For the reviewer

- **Scope of rgthree's rewrite.** The in-repo measured record has rgthree writing only its *own* node's seed input (`outputInputs[this.seedWidget.name || "seed"]`); downstream KSamplers receive it as a link, so they are unaffected. If a future rgthree version also rewrote other nodes' inputs, this fix would not cover that and the refusal would return — with the new message naming the api.queuePrompt-patch candidate.
- **The type set is a capability claim.** Adding an entry asserts that node substitutes at queue time. It should be measured before it is added, not inferred from a plausible name — the comment above the set says so.
- No version, CHANGELOG, or i18n-catalogue edits — separate PRs in this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
