### PR TITLE
release: v0.14.42 - an rgthree Seed substituting at queue time is not graph drift (#1124)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+## [0.14.42] - 2026-08-15
+
+### Fixed
+- run-to-node is no longer permanently refused when an armed Seed (rgthree) substitutes its value at queue time — that substitution is not graph drift, and every retry used to fail identically (#1124)
+
+
 ## [0.14.41] - 2026-08-15
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-agent-panel"
 description = "Autonomous AI agent in the ComfyUI sidebar - local-first, bring any LLM. Run it on your Claude or ChatGPT subscription (no API keys, no extra LLM costs), on a Kimi K3 / GLM / OpenRouter key, or fully offline on free local models via Ollama, LM Studio, or llama.cpp. The agent drives your live canvas at full parity: add, wire, move and tweak nodes with Ctrl+Z undo, load whole workflows and installer packs in one shot, generate images, video and audio, browse CivitAI, and run your workflow - asking before it spends paid API credits. The sidebar UI for comfyui-mcp, the local-first, agent-native control plane for ComfyUI. The panel speaks 12 languages, matching your ComfyUI language automatically: English, 한국어, 日本語, 中文 (简体), 中文 (繁體), Русский, Français, Español, Português (BR), Türkçe, العربية, فارسی."
-version = "0.14.41"
+version = "0.14.42"
 license = { file = "LICENSE" }
 requires-python = ">=3.9"
 # UI-only pack: no Python deps. The frontend floor guarantees

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -1526,7 +1526,7 @@ const DOCS_URL = "https://comfyui-mcp.artokun.io/docs";
 // Panel version — surfaced in the "Need help?" diagnostics blob. Bump via
 // `node scripts/set-version.mjs <v>` (updates this AND pyproject together); CI
 // and the publish gate FAIL if the two ever drift, so this can't go stale.
-const PANEL_VERSION = "0.14.41";
+const PANEL_VERSION = "0.14.42";
 
 // The connected orchestrator's console URL/token (captured off the `backends`
 // bridge message — see onBackends). Drives the "API Keys" credentials frame;


### PR DESCRIPTION
Releases the #1124 fix merged in #1248.

## What users get

`run_to_node` was **permanently** refused on any workflow holding an armed `Seed (rgthree)`:

```
the workflow graph CHANGED between stamping and dispatch. The differing entry: 47 seed.
```

The #556 drift guard's only volatility signal was `typeof w.beforeQueued === "function"`. rgthree does not use that hook — it patches `api.queuePrompt` and rewrites the seed at queue time, leaving the widget at `-1`. So the pre- and post-stamp hashes always disagreed on that one input.

**It was permanent, not racy.** Each retry drew a new number and mismatched identically, which is exactly why the reporter's automatic retry also failed. No amount of waiting could have worked.

## Scope kept deliberately narrow

The exclusion requires an **armed** seed on an **exactly-matched** registered type:

```js
const RGTHREE_QUEUE_REWRITING_SEED_TYPES = new Set(["Seed (rgthree)"]);
```

That is the only type verified anywhere in this repo. Adding an entry is a capability claim that must be measured, not guessed from a plausible name — a look-alike node that does not install the queue-time rewrite must keep full drift coverage.

The gate keys on **ARMED**, not `varies`: the sibling helper reports `varies: false` for an armed node with a degenerate `randomMin/randomMax`, which is right for #1339's warning and wrong here, since such a node still substitutes.

**The shared `isRgthreeSeedNode` predicate was deliberately NOT tightened.** The two callers want opposite failure directions — a false positive costs #1339 one noisy sentence, while a false negative costs it the warning it exists for; for this guard those are reversed, since a false positive silently loses drift coverage. So the warning heuristic stays generous and the exclusion is strict, and both halves are pinned by a test named for that reasoning.

Fixed seeds, muted/bypassed nodes, sibling inputs and the rest of the graph keep full #556 coverage.

## Verification

- **4423 tests pass** (+15). The reporter's repro was driven end-to-end against the real `dispatchScopedRun` **before** any fix — reproducing their exact error — and again after: `dispatched`, `verified = 1`, prompt reaches the server.
- **9 mutations applied, all 9 killed.** M3 (remove the armed gate), M5 (drop the type check) and M8 (revert to the loose substring predicate) together answer the relaxation question from three directions — the exclusion cannot decay into a blanket seed exemption.
- Verified live after restart: the served bundle carries the exact-type set and the exported helper.

## Residual

If a future rgthree rewrote *other* nodes' inputs as well as its own, this would not cover it and the refusal returns — but the message now names the `api.queuePrompt`-patch cause, so the next reporter is recognisable rather than mystified.

The codex review was cancelled at 26 minutes when it stopped converging (the same call made on #813 and #1225 today). Merged on the mutation evidence above rather than on a clean review, recorded here so that is on the record.