### PR TITLE
fix(1588): a subgraph is not a second unexplained difference

### DIFF
--- a/browser_tests/unit/open-rebind-proof.test.mjs
+++ b/browser_tests/unit/open-rebind-proof.test.mjs
@@ -360,6 +360,7 @@ test("describeGraphStateDifference: an unshapeable side reports NOT COMPARABLE, 
   assert.deepEqual(describeGraphStateDifference({ rootGraph: { serialize: () => null }, state }), {
     comparable: false,
     surfaces: [],
+    accountedSurfaces: [],
     nodeDifference: null,
   });
   assert.deepEqual(
@@ -371,27 +372,34 @@ test("describeGraphStateDifference: an unshapeable side reports NOT COMPARABLE, 
       },
       state,
     }),
-    { comparable: false, surfaces: [], nodeDifference: null },
+    { comparable: false, surfaces: [], accountedSurfaces: [], nodeDifference: null },
     "a THROWING serializer is an absent observation, not evidence of a mismatch",
   );
   assert.deepEqual(describeGraphStateDifference({ rootGraph: liveRoot(structuredClone(state)) }), {
     comparable: false,
     surfaces: [],
+    accountedSurfaces: [],
     nodeDifference: null,
   });
-  assert.deepEqual(describeGraphStateDifference(), { comparable: false, surfaces: [], nodeDifference: null });
+  assert.deepEqual(describeGraphStateDifference(), {
+    comparable: false,
+    surfaces: [],
+    accountedSurfaces: [],
+    nodeDifference: null,
+  });
 });
 
 test("describeGraphStateDifference: names the surfaces that disagreed, and only those", () => {
   const state = payload(NODES);
   const equal = describeGraphStateDifference({ rootGraph: liveRoot(structuredClone(state)), state });
-  assert.deepEqual(equal, { comparable: true, surfaces: [], nodeDifference: null });
+  assert.deepEqual(equal, { comparable: true, surfaces: [], accountedSurfaces: [], nodeDifference: null });
 
   const nodesDiffer = structuredClone(state);
   nodesDiffer.nodes = [nodesDiffer.nodes[0]];
   assert.deepEqual(describeGraphStateDifference({ rootGraph: liveRoot(nodesDiffer), state }), {
     comparable: true,
     surfaces: ["nodes"],
+    accountedSurfaces: [],
     // #825 — a DROPPED node: same-set must be false, and never "cosmetic".
     nodeDifference: { comparable: true, sameNodeSet: false, cosmeticOnly: false, fields: [] },
   });
@@ -401,6 +409,7 @@ test("describeGraphStateDifference: names the surfaces that disagreed, and only 
   assert.deepEqual(describeGraphStateDifference({ rootGraph: liveRoot(groupsDiffer), state }), {
     comparable: true,
     surfaces: ["groups"],
+    accountedSurfaces: [],
     // nodes agreed, so there is no node difference to explain.
     nodeDifference: null,
   });
@@ -413,6 +422,7 @@ test("describeGraphStateDifference: names the surfaces that disagreed, and only 
   assert.deepEqual(describeGraphStateDifference({ rootGraph: liveRoot(dialect), state }), {
     comparable: true,
     surfaces: [],
+    accountedSurfaces: [],
     nodeDifference: null,
     // A present-but-empty surface and a viewport are dialect, and this must agree
     // with graphRootMatchesState exactly — one normalization, two readings of it.

--- a/browser_tests/unit/open-subgraph-definitions-disclosure.test.mjs
+++ b/browser_tests/unit/open-subgraph-definitions-disclosure.test.mjs
@@ -1,0 +1,298 @@
+// artokun/comfyui-mcp#1588 — a faithful open of a workflow containing SUBGRAPHS was
+// disclosed with the maximal-alarm wording, because `definitions` counted as a second
+// unexplained surface even though the panel had already accounted for it.
+//
+// WHAT THE REPORTER SAW. Save-As a copy, open it immediately, and the tool errors:
+//
+//   "workflow_open RAN and the canvas IS bound to … but the graph on it does not match
+//    the state that was loaded … nodes, definitions … every node that was loaded IS on
+//    the canvas with the same id and type, and nothing extra appeared"
+//
+// — followed by the paragraph that names #1111/#1089, says the canvas may hold the
+// PREVIOUS workflow's graph, and prescribes reloading from disk after preserving
+// unsaved work to a NEW path with Save As. A follow-up panel_graph_outline showed the
+// expected 72-node graph. None of that recovery was needed.
+//
+// THE MECHANISM. `nodesOnly` (#825) tested the RAW surface list, requiring it to be
+// exactly ["nodes"]. #886 measured that loading a persisted workflow regenerates link
+// identity inside `definitions.subgraphs` — so `definitions` lands in that list on
+// EVERY faithful open of EVERY workflow with a subgraph. The presence of subgraphs
+// alone, not any observation about the graph, decided which paragraph the reader got.
+//
+// The content VERDICT already knew better: `graphRootReproducesStateContent` admits a
+// `definitions` surface when `definitionsDifferOnlyByLinkRenumber` accounts for the
+// whole of it. That judgement simply never reached the sentence.
+//
+// #825's narrowness is deliberate and is KEPT: a second surface that is genuinely
+// unexplained still falls back to "the panel cannot tell". What changed is that an
+// EXPLAINED surface stops counting as one.
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+import {
+  OPEN_REBIND_STATUS,
+  describeGraphStateDifference,
+  describeOpenRebindOutcome,
+  resolveOpenRebindVerdict,
+} from "../../web/js/lib/graph-binding.js";
+
+const PANEL_JS = fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url));
+
+const CONTENT_ONLY = resolveOpenRebindVerdict({
+  instanceStillTarget: true,
+  markerMatches: true,
+  identityMatches: true,
+  contentMatches: false,
+});
+
+/** The reporter's node observation: same set, cosmetic fields only. */
+const NODES_INTACT = { comparable: true, sameNodeSet: true, cosmeticOnly: true, fields: ["size", "pos"] };
+
+// ── the reporter's own message ───────────────────────────────────────────────
+
+test("the reporter's shape: an accounted `definitions` no longer blocks the reassurance", () => {
+  const msg = describeOpenRebindOutcome(CONTENT_ONLY, {
+    targetLabel: "QuadView_krea2_v1.json",
+    contentComparable: true,
+    contentSurfaces: ["nodes", "definitions"],
+    contentAccountedSurfaces: ["definitions"],
+    contentNodeDifference: NODES_INTACT,
+  });
+
+  assert.match(msg, /same widget values and links/i);
+  assert.match(msg, /no missing work to redo/i);
+  // The paragraph the reporter was sent into, and the destructive remedy it carries.
+  assert.doesNotMatch(msg, /partly applied/i);
+  assert.doesNotMatch(msg, /PREVIOUS workflow's graph/i);
+  assert.doesNotMatch(msg, /panel_load_workflow/, "no reload-from-disk is warranted here");
+  assert.doesNotMatch(msg, /Save As/i, "nor the preserve-your-work dance that goes with it");
+});
+
+test("the accounted surface is EXPLAINED, not silently dropped", () => {
+  // Suppressing it entirely would leave the reader with a message that says the graph
+  // differs on `nodes` while the verdict was reached over two surfaces. Name it, and
+  // say what accounts for it.
+  const msg = describeOpenRebindOutcome(CONTENT_ONLY, {
+    targetLabel: "QuadView_krea2_v1.json",
+    contentComparable: true,
+    contentSurfaces: ["nodes", "definitions"],
+    contentAccountedSurfaces: ["definitions"],
+    contentNodeDifference: NODES_INTACT,
+  });
+
+  assert.match(msg, /definitions/);
+  assert.match(msg, /link RENUMBERING/i);
+  assert.match(msg, /not a content change/i);
+});
+
+// ── the direction that costs something ───────────────────────────────────────
+
+test("a definitions difference that is NOT accounted for still blocks the reassurance", () => {
+  // `definitionsDifferOnlyByLinkRenumber` fails closed, so anything it cannot fully
+  // explain arrives here with an empty accounted list — and must read exactly as it
+  // did before this change.
+  const msg = describeOpenRebindOutcome(CONTENT_ONLY, {
+    targetLabel: "QuadView_krea2_v1.json",
+    contentComparable: true,
+    contentSurfaces: ["nodes", "definitions"],
+    contentAccountedSurfaces: [],
+    contentNodeDifference: NODES_INTACT,
+  });
+
+  assert.match(msg, /partly applied/i);
+  assert.doesNotMatch(msg, /no missing work to redo/i);
+});
+
+test("an accounted surface does not license a genuinely unexplained one", () => {
+  // #825's rule, unchanged: a group that disagrees is unexplained by anything the node
+  // set or the renumber check establishes.
+  const msg = describeOpenRebindOutcome(CONTENT_ONLY, {
+    targetLabel: "QuadView_krea2_v1.json",
+    contentComparable: true,
+    contentSurfaces: ["nodes", "groups", "definitions"],
+    contentAccountedSurfaces: ["definitions"],
+    contentNodeDifference: NODES_INTACT,
+  });
+
+  assert.match(msg, /partly applied/i);
+  assert.doesNotMatch(msg, /no missing work to redo/i);
+});
+
+test("only surfaces with a written account may be claimed as accounted", () => {
+  // This list SHRINKS what a reader is asked to worry about, so a wrong entry waves
+  // away a real difference. `groups` has no account anywhere in this file, and naming
+  // it here must change nothing.
+  const msg = describeOpenRebindOutcome(CONTENT_ONLY, {
+    targetLabel: "QuadView_krea2_v1.json",
+    contentComparable: true,
+    contentSurfaces: ["nodes", "groups"],
+    contentAccountedSurfaces: ["groups"],
+    contentNodeDifference: NODES_INTACT,
+  });
+
+  assert.match(msg, /partly applied/i);
+  assert.doesNotMatch(msg, /no missing work to redo/i);
+});
+
+test("a surface that did not differ cannot be used to shorten the list", () => {
+  const msg = describeOpenRebindOutcome(CONTENT_ONLY, {
+    targetLabel: "QuadView_krea2_v1.json",
+    contentComparable: true,
+    contentSurfaces: ["nodes", "groups"],
+    // `definitions` IS accountable, but it is not among the surfaces that differ, so
+    // it accounts for nothing and `groups` stays unexplained.
+    contentAccountedSurfaces: ["definitions"],
+    contentNodeDifference: NODES_INTACT,
+  });
+
+  assert.match(msg, /partly applied/i);
+  assert.doesNotMatch(msg, /no missing work to redo/i);
+});
+
+test("a surface that did not differ is never DESCRIBED as differing", () => {
+  // The membership gate earns its keep here rather than in the branch above: an
+  // accounted name that is not in `contentSurfaces` subtracts nothing from the
+  // unexplained list, so the gate's whole effect is on the sentence. Without it the
+  // message announces "its `definitions` also differ" about a surface that agreed —
+  // a fabricated observation inside the disclosure whose entire job is to report only
+  // what was observed.
+  const msg = describeOpenRebindOutcome(CONTENT_ONLY, {
+    targetLabel: "QuadView_krea2_v1.json",
+    contentComparable: true,
+    contentSurfaces: ["nodes"],
+    contentAccountedSurfaces: ["definitions"],
+    contentNodeDifference: NODES_INTACT,
+  });
+
+  assert.doesNotMatch(msg, /definitions/i, "nothing may be said about a surface that matched");
+  assert.doesNotMatch(msg, /also differ/i);
+  // …and the node-only reassurance is still reached, exactly as before this change.
+  assert.match(msg, /no missing work to redo/i);
+});
+
+test("an absent accounted list reproduces the pre-#1588 behaviour exactly", () => {
+  // An older caller states nothing, and an unstated account is not an account.
+  const msg = describeOpenRebindOutcome(CONTENT_ONLY, {
+    targetLabel: "QuadView_krea2_v1.json",
+    contentComparable: true,
+    contentSurfaces: ["nodes", "definitions"],
+    contentNodeDifference: NODES_INTACT,
+  });
+
+  assert.match(msg, /partly applied/i);
+  assert.doesNotMatch(msg, /no missing work to redo/i);
+});
+
+test("the verdict is untouched — this changes the sentence, not the answer", () => {
+  // The content guard's error directions are not symmetric (too lenient applies writes
+  // to the wrong graph), so nothing here softens it. `workflow_open` still throws.
+  assert.equal(CONTENT_ONLY.status, OPEN_REBIND_STATUS.CONTENT_UNVERIFIED);
+  assert.deepEqual(CONTENT_ONLY.unproven, ["content"]);
+});
+
+// ── the producer: does a REAL renumbered definitions block get accounted for? ─
+
+/** A subgraph definition, with link ids that renumbering may reassign. */
+function definitions(lastLinkId, linkIds) {
+  return {
+    subgraphs: [
+      {
+        id: "sub-1",
+        name: "Upscale",
+        state: { lastNodeId: 2, lastLinkId, lastGroupId: 0, lastRerouteId: 0 },
+        nodes: [
+          { id: 1, type: "LoadImage", outputs: [{ name: "IMAGE", type: "IMAGE", links: [linkIds[0]] }] },
+          { id: 2, type: "SaveImage", inputs: [{ name: "images", type: "IMAGE", link: linkIds[0] }] },
+        ],
+        links: [[linkIds[0], 1, 0, 2, 0, "IMAGE"]],
+        inputs: [],
+        outputs: [],
+      },
+    ],
+  };
+}
+
+const NODE = { id: 1, type: "KSampler", pos: [0, 0], size: [200, 100], widgets_values: [1] };
+
+function stateWith(defs, node = NODE) {
+  return { nodes: [structuredClone(node)], links: [], definitions: defs };
+}
+
+test("producer: a renumber-only definitions difference is reported as ACCOUNTED", () => {
+  const state = stateWith(definitions(2092, [7]));
+  const live = stateWith(definitions(2106, [21]));
+  live.nodes[0].size = [200, 140]; // the frontend re-measured the box
+
+  const diff = describeGraphStateDifference({ rootGraph: { serialize: () => live }, state });
+
+  assert.equal(diff.comparable, true);
+  assert.deepEqual(diff.surfaces.slice().sort(), ["definitions", "nodes"]);
+  assert.deepEqual(diff.accountedSurfaces, ["definitions"]);
+});
+
+test("producer: a RE-WIRED definitions difference is NOT accounted for", () => {
+  // The direction that must fail closed. Same link count, different endpoints — a
+  // re-wire, not a renumber, and `definitionsDifferOnlyByLinkRenumber` refuses it.
+  const state = stateWith(definitions(2092, [7]));
+  const live = stateWith(definitions(2106, [21]));
+  live.definitions.subgraphs[0].links = [[21, 2, 0, 1, 0, "IMAGE"]];
+
+  const diff = describeGraphStateDifference({ rootGraph: { serialize: () => live }, state });
+
+  assert.ok(diff.surfaces.includes("definitions"));
+  assert.deepEqual(diff.accountedSurfaces, []);
+});
+
+test("producer: a surface with no written account is never reported as accounted", () => {
+  const state = stateWith(definitions(2092, [7]));
+  const live = stateWith(definitions(2092, [7]));
+  live.groups = [{ title: "G", bounding: [0, 0, 10, 10] }];
+
+  const diff = describeGraphStateDifference({ rootGraph: { serialize: () => live }, state });
+
+  assert.deepEqual(diff.surfaces, ["groups"]);
+  assert.deepEqual(diff.accountedSurfaces, []);
+});
+
+// ── wiring: production must actually pass it ─────────────────────────────────
+
+test("wiring: the panel hands the accounted list to the message it feeds", () => {
+  // A green disclosure test proves the function behaves; it cannot prove the call site
+  // supplies the field. Without this the whole change is inert and every test above
+  // still passes.
+  const src = readFileSync(PANEL_JS, "utf8");
+
+  // Bounded by the ARGUMENT OBJECT of the one call, found by brace matching — never by
+  // a character window, which silently stops covering the field the moment the object
+  // grows a comment.
+  const callAt = src.indexOf("describeOpenRebindOutcome(verdict, {");
+  assert.notEqual(callAt, -1, "the disclosure call must still exist");
+  const openAt = src.indexOf("{", callAt + "describeOpenRebindOutcome(verdict,".length);
+  let depth = 0;
+  let closeAt = -1;
+  for (let i = openAt; i < src.length; i += 1) {
+    if (src[i] === "{") depth += 1;
+    else if (src[i] === "}") {
+      depth -= 1;
+      if (depth === 0) {
+        closeAt = i;
+        break;
+      }
+    }
+  }
+  assert.ok(closeAt > openAt, "the argument object must be brace-balanced");
+  const args = src.slice(openAt, closeAt + 1);
+
+  assert.match(args, /contentAccountedSurfaces:\s*contentDiff\.accountedSurfaces/);
+  // It must come from the SAME diff object as the surfaces it filters. Two different
+  // reads could disagree about what differed, and the filter would then subtract a
+  // surface from a list that never contained it.
+  assert.match(args, /contentSurfaces:\s*contentDiff\.surfaces/);
+
+  // The `contentMatches` shortcut object must carry the field too — an object missing
+  // it would reach the message as `undefined` on that branch alone.
+  assert.match(src, /\{\s*comparable:\s*true,\s*surfaces:\s*\[\],\s*accountedSurfaces:\s*\[\],/);
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -14676,7 +14676,7 @@ const GRAPH_TOOL_EXECUTORS = {
                 // which is the expensive part of the whole proof. It feeds the MESSAGE
                 // only — it decides nothing.
                 const contentDiff = contentMatches
-                  ? { comparable: true, surfaces: [], nodeDifference: null }
+                  ? { comparable: true, surfaces: [], accountedSurfaces: [], nodeDifference: null }
                   : describeGraphStateDifference({ rootGraph, state: repaintState });
                 rebindFailed = new Error(
                   describeOpenRebindOutcome(verdict, {
@@ -14688,6 +14688,12 @@ const GRAPH_TOOL_EXECUTORS = {
                     observedUuid: rootGraph?.extra?.[WORKFLOW_META_NAMESPACE]?.[WORKFLOW_UUID_FIELD] ?? null,
                     contentComparable: contentDiff.comparable,
                     contentSurfaces: contentDiff.surfaces,
+                    // #1588 — which of those the panel has already fully characterised
+                    // (today: a `definitions` difference that is pure link renumbering,
+                    // which every load of a workflow containing subgraphs produces).
+                    // Without this the disclosure counts an explained surface as a
+                    // second unexplained one and drops to the maximal-alarm wording.
+                    contentAccountedSurfaces: contentDiff.accountedSurfaces,
                     // #825 — within the `nodes` surface, whether anything was LOST
                     // or the frontend merely re-measured the boxes. Same three
                     // words otherwise, opposite meanings for the reader.

--- a/web/js/lib/graph-binding.js
+++ b/web/js/lib/graph-binding.js
@@ -728,7 +728,7 @@ export function classifyNodeDifference({ expectedNodes, actualNodes } = {}) {
  * happened — it is never evidence of a mismatch.
  */
 export function describeGraphStateDifference({ rootGraph, state } = {}) {
-  const NOT_COMPARABLE = { comparable: false, surfaces: [], nodeDifference: null };
+  const NOT_COMPARABLE = { comparable: false, surfaces: [], accountedSurfaces: [], nodeDifference: null };
   try {
     const expectedShape = buildGraphShape(state);
     let actualShape = null;
@@ -748,9 +748,32 @@ export function describeGraphStateDifference({ rootGraph, state } = {}) {
     const expected = canon(expectedShape);
     const actual = canon(actualShape);
     const surfaces = Object.keys(expected).filter((key) => expected[key] !== actual[key]);
+    // #1588 — WHICH OF THOSE SURFACES IS ALREADY EXPLAINED.
+    //
+    // `surfaces` answers "what disagreed". It cannot answer "and is that a difference
+    // anyone should act on", and treating the two as the same sentence is what made a
+    // faithful open of any workflow containing SUBGRAPHS read as possible data loss:
+    // the reporter's message named `nodes, definitions`, and the mere presence of a
+    // second surface sent it down the maximal-alarm path.
+    //
+    // `definitions` is the one surface with a hardened account of WHY it differs.
+    // #886 measured it on the rig: loading a persisted workflow regenerates link
+    // identity inside `definitions.subgraphs` (`state.lastLinkId` 2092 -> 2106) while
+    // node ids, types and topology stay identical. `definitionsDifferOnlyByLinkRenumber`
+    // is the predicate `graphRootReproducesStateContent` — the VERDICT — already trusts
+    // for exactly this, and it fails CLOSED: anything it cannot fully account for
+    // returns false, which is read as "not accounted for", never as "changed".
+    //
+    // So this reports the SAME judgement the verdict makes, to the sentence that had no
+    // access to it. It decides nothing new; it stops the disclosure from being blind to
+    // a difference the verdict has already characterised.
+    const accountedSurfaces = surfaces.filter(
+      (key) => key === "definitions" && definitionsDifferOnlyByLinkRenumber(state?.definitions, actualState?.definitions),
+    );
     return {
       comparable: true,
       surfaces,
+      accountedSurfaces,
       // Only when `nodes` is one of the disagreeing surfaces: otherwise there is
       // nothing about the nodes to explain, and an all-clear here would read as
       // one about the difference that actually fired.
@@ -1554,6 +1577,45 @@ function nodeSurfaceClause(observed = {}) {
   );
 }
 
+/** The only surfaces this file has a written account of. `definitions` differs on a
+ *  faithful open because loading a saved workflow regenerates link ids inside subgraph
+ *  definitions (#886, measured: state.lastLinkId 2092 -> 2106), and
+ *  `definitionsDifferOnlyByLinkRenumber` decides per-case whether THIS difference is
+ *  only that. Nothing else has such an account, so nothing else may be waved through. */
+const ACCOUNTABLE_CONTENT_SURFACES = new Set(["definitions"]);
+
+/**
+ * #1588 — the differing surfaces, split by whether anything ACCOUNTS for them.
+ *
+ * `contentAccountedSurfaces` is produced by `describeGraphStateDifference` from the
+ * same predicate the content VERDICT uses, so the disclosure and the verdict cannot
+ * disagree about what a `definitions` difference means. Absent (an older caller, or a
+ * comparison that never happened) it is an empty list, which reproduces the previous
+ * behaviour exactly — an unknown account is not an account.
+ */
+function accountedContentSurfaces(observed = {}) {
+  const accounted = observed.contentAccountedSurfaces;
+  if (!Array.isArray(accounted)) return [];
+  const surfaces = observed.contentSurfaces ?? [];
+  // TWO gates, and both are about the direction that costs something. This list
+  // SHRINKS the set of differences a reader is asked to worry about, so a wrong entry
+  // here waves away a real one.
+  //  • `ACCOUNTABLE_CONTENT_SURFACES` — only a surface with a written, hardened account
+  //    of WHY it differs may appear. Today that is `definitions` and nothing else; a
+  //    caller cannot use this channel to excuse `groups` or `links`, whose differences
+  //    nothing has characterised. Widening it means writing the account first.
+  //  • membership in `contentSurfaces` — a name that did not actually differ is not an
+  //    account of anything, and must not be able to shorten the unexplained list.
+  return accounted.filter(
+    (s) => typeof s === "string" && ACCOUNTABLE_CONTENT_SURFACES.has(s) && surfaces.includes(s),
+  );
+}
+
+function unexplainedContentSurfaces(observed = {}) {
+  const accounted = accountedContentSurfaces(observed);
+  return (observed.contentSurfaces ?? []).filter((s) => !accounted.includes(s));
+}
+
 /** One clause per failed part, naming the TWO VALUES that disagreed. A refusal
  *  that says only "the fence rejected" is not actionable; one that says which
  *  observation failed and what was seen instead is. */
@@ -1587,12 +1649,29 @@ function openRebindPartClause(part, observed = {}) {
       // (which tests `=== true`) correctly said the panel could not read the graph,
       // and one disclosure contradicted itself. Both now ask the same question, and
       // the burden sits on the CLAIM: only a positive "yes, compared" licenses it.
-      return contentWasCompared(observed)
-        ? `the graph on the canvas differs from what was loaded on: ` +
-            `${(observed.contentSurfaces ?? []).join(", ") || "an unnamed surface"}` +
-            nodeSurfaceClause(observed)
-        : `the panel could not compare the loaded graph with the canvas at all, so it is UNKNOWN — ` +
-            `not established — whether the whole graph landed`;
+      if (!contentWasCompared(observed)) {
+        return (
+          `the panel could not compare the loaded graph with the canvas at all, so it is UNKNOWN — ` +
+          `not established — whether the whole graph landed`
+        );
+      }
+      // #1588 — name the surfaces that are still UNEXPLAINED, and account for the rest
+      // separately. Listing an accounted-for `definitions` alongside a genuinely
+      // unexplained `nodes` invites the reader to weigh two differences when only one
+      // of them is a question.
+      const unexplained = unexplainedContentSurfaces(observed);
+      const accounted = accountedContentSurfaces(observed);
+      const named = unexplained.join(", ") || "an unnamed surface";
+      return (
+        `the graph on the canvas differs from what was loaded on: ${named}` +
+        nodeSurfaceClause(observed) +
+        (accounted.length
+          ? `. Its \`${accounted.join("`, `")}\` also differ, and that one IS accounted for: the ` +
+            `whole difference is link RENUMBERING — loading a saved workflow regenerates link ids ` +
+            `inside subgraph definitions while the wiring stays identical — so it is not a content ` +
+            `change and is not part of what is unconfirmed here`
+          : "")
+      );
     default:
       return `an unrecognized check (${part}) did not pass`;
   }
@@ -1642,8 +1721,22 @@ export function describeOpenRebindOutcome(verdict, observed = {}) {
     // reporter looking for work to redo that was never gone. Narrow on purpose —
     // any second differing surface is unexplained by a node-set observation, so
     // it falls back to the honest "cannot tell".
-    const nodesOnly =
-      (observed.contentSurfaces ?? []).length === 1 && (observed.contentSurfaces ?? [])[0] === "nodes";
+    //
+    // #1588 — UNEXPLAINED, not merely PRESENT, and the distinction is the whole bug.
+    // The gate above tested the raw surface list, so ANY workflow containing subgraphs
+    // failed it: #886 measured that loading one regenerates link ids inside
+    // `definitions.subgraphs`, which puts `definitions` in that list on every faithful
+    // open. The reporter's message named `nodes, definitions` and fell to the maximal-
+    // alarm paragraph — while the clause below it said every node had come through with
+    // the same id and type.
+    //
+    // The narrowness was right and is kept: what may not gate this is a surface the
+    // panel has already fully characterised with the same predicate the content VERDICT
+    // trusts. `definitionsDifferOnlyByLinkRenumber` fails closed, so a `definitions`
+    // difference that is anything more than renumbering is NOT accounted for and still
+    // sends this to the honest "cannot tell" — as does any other second surface.
+    const unexplained = unexplainedContentSurfaces(observed);
+    const nodesOnly = unexplained.length === 1 && unexplained[0] === "nodes";
     // #696 — this used to also require `cosmeticOnly`, i.e. that every differing
     // field be on an allowlist of names. That made the reassurance hostage to
     // guessing what a field MEANS: one unrecognised display flag from any node pack


### PR DESCRIPTION
Reported in artokun/comfyui-mcp#1588 — `panel_open_workflow` reports failure after a successful Save-As open.

## What the reporter saw

Save-As a copy, open it immediately, and the tool errors:

> workflow_open RAN and the canvas IS bound to … but the graph on it does not match the state that was loaded … **nodes, definitions** … every node that was loaded IS on the canvas with the same id and type, and nothing extra appeared

— followed by the paragraph that names #1111/#1089, says the canvas may hold the **previous** workflow's graph, and prescribes reloading from disk after preserving unsaved work to a **new** path with Save As. Their follow-up `panel_graph_outline` returned the expected 72-node graph. None of that recovery was needed.

## The mechanism, and it is not about their workflow

#825's reassuring disclosure is gated on the differing surfaces being exactly `["nodes"]`, tested against the **raw** list. #886 measured that loading a persisted workflow **regenerates link identity inside `definitions.subgraphs`** (`state.lastLinkId` 2092 → 2106) — so `definitions` is in that list on every faithful open of every workflow containing a subgraph. The presence of subgraphs, not any observation about the graph, decided which paragraph the caller read.

The content **verdict** already knew better: `graphRootReproducesStateContent` admits a `definitions` surface when `definitionsDifferOnlyByLinkRenumber` accounts for the whole of it. That judgement simply had no route to the sentence.

## The change

- `describeGraphStateDifference` reports `accountedSurfaces`, from the same hardened predicate the verdict uses.
- The disclosure gate asks whether a surface is **unexplained** rather than merely present.
- The accounted surface is **named and explained** rather than suppressed — the reader is told the `definitions` difference is link renumbering and is not a content change.

#825's narrowness is kept intact: a genuinely unexplained second surface still falls back to the honest "the panel cannot tell", and the renumber check fails closed.

## Fail-closed in the direction that costs

This list **shrinks** what a reader is asked to worry about, so a wrong entry waves away a real difference. Two gates: only surfaces with a **written account** may appear (`definitions` and nothing else — widening it means writing the account first), and only surfaces that **actually differ**. The second gate turns out to affect only the sentence, not the gate, and needed its own test to be killable: without it the message announces that a surface "also differs" when it matched.

## The verdict is unchanged

`workflow_open` still answers `CONTENT_UNVERIFIED` and still throws. The content guard's error directions are not symmetric — too lenient applies writes to the wrong graph — and nothing here softens it. The reporter's ask to downgrade to success-with-warning is **not** granted.

## What I did NOT do

- **I did not reproduce their session**, so I cannot state that *their* `definitions` difference was pure renumbering. If it was not, they still get the cautious paragraph — correctly.
- I did **not** touch the `#1111/#1089` stale-canvas paragraph. I first intended to claim it was refuted by its own "every node came through with the same id and type" clause, and dropped that: #1089 records that **Save-As preserves node ids**, so on a Save-As copy an identical node set cannot exclude the previous graph. The claim would have been wrong in the bug's own direction.
- I did not widen `RECOMPUTED_NODE_FIELDS`; `pos` and `order` stay out for the reasons already recorded there.

## Verified

- `npm run test:unit`: 4437 tests, **0 failures**, including the tool-vocabulary and panel-scope gates.
- 7 mutations applied (occurrence-verified) and **all 7 killed** — including one that restores the reported behaviour and one that deletes the call site so the whole change goes inert.
- The wiring assertion is bounded by **brace matching** over the disclosure call's argument object, never by a character window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
