### PR TITLE
fix(1606): a Manager that CANNOT report a failure stops reading as one reporting none

### DIFF
--- a/browser_tests/unit/install-terminal-failure.test.mjs
+++ b/browser_tests/unit/install-terminal-failure.test.mjs
@@ -116,6 +116,10 @@ function buildVerifyInstalled({ routes, calls = [], budgetMs }) {
     INSTALL_VERIFY_BUDGET_MS: budgetMs ?? 4000,
     AbortSignal,
     setTimeout,
+    // comfyui-mcp#1606 — the capture the verifier now also consults. EMPTY here
+    // on purpose: these tests pin the HTTP history path, and an empty log proves
+    // the capture cannot short-circuit or alter it.
+    managerTaskResults: ManagerInstall.createManagerTaskResultLog(),
   };
   const factory = new Function(
     ...Object.keys(deps),

--- a/browser_tests/unit/manager-dialect.test.mjs
+++ b/browser_tests/unit/manager-dialect.test.mjs
@@ -971,6 +971,10 @@ function nodesInstallDeps(overrides) {
     reProbeManagerDialect: async () => "v2",
     managerQueueControl: async () => {},
     verifyInstalled: async () => ({ state: "installed", status: QUEUE_STATUS }),
+    // comfyui-mcp#1606 — the ui_id ↔ pack correlation the handler records so a
+    // captured Manager failure can name what it was installing. A REAL log, so
+    // a regression in that call surfaces here instead of hitting a no-op stub.
+    managerTaskResults: ManagerInstall.createManagerTaskResultLog(),
     ...overrides,
   };
 }

--- a/browser_tests/unit/manager-install.test.mjs
+++ b/browser_tests/unit/manager-install.test.mjs
@@ -860,6 +860,10 @@ function loadNodesInstall({ budgetMs, detect, reProbe, managerV2, managerCall, m
     "MANAGER_FETCH_TIMEOUT_MS",
     "NODES_INSTALL_COMMAND_BUDGET_MS",
     "AbortSignal",
+    // comfyui-mcp#1606 — the handler correlates its ui_id with the pack, so the
+    // Manager's completion broadcast can name what failed. A real log, not a
+    // stub: an injected no-op would let the correlation regress unnoticed here.
+    "managerTaskResults",
     `${stallMatch[0]}\nconst handler = { ${body} };\nreturn handler.nodes_install;`,
   );
   return factory(
@@ -878,6 +882,7 @@ function loadNodesInstall({ budgetMs, detect, reProbe, managerV2, managerCall, m
     15000,
     budgetMs,
     AbortSignal,
+    ManagerInstall.createManagerTaskResultLog(),
   );
 }
 

--- a/browser_tests/unit/manager-task-broadcast.test.mjs
+++ b/browser_tests/unit/manager-task-broadcast.test.mjs
@@ -549,6 +549,10 @@ test("#1606: the blind note never asserts that anything failed", () => {
   }
   assert.match(taskHistoryBlindNote("legacy"), /deletes each task's result/);
   assert.match(taskHistoryBlindNote("v2"), /transient error/);
+  // An unknown dialect must not borrow 3.x's explanation — we did not identify
+  // the build, so we cannot state how it behaves.
+  assert.match(taskHistoryBlindNote(undefined), /could not determine which ComfyUI-Manager/);
+  assert.doesNotMatch(taskHistoryBlindNote(undefined), /deletes each task's result/);
   assert.equal(dialectServesTaskHistory("legacy"), false);
   assert.equal(dialectServesTaskHistory("v2-batch"), false);
   assert.equal(dialectServesTaskHistory("v2"), true);

--- a/browser_tests/unit/manager-task-broadcast.test.mjs
+++ b/browser_tests/unit/manager-task-broadcast.test.mjs
@@ -1,0 +1,555 @@
+// artokun/comfyui-mcp#1606 — `panel_install_node` on a legacy ComfyUI-Manager 3.x
+// returned `queued: true, pending: true` with no failure, `panel_node_queue_status`
+// then reported an EMPTY IDLE QUEUE, and the pack was absent. Nothing anywhere
+// said why, so the reporter fell back to a manual source install.
+//
+// #1539 gave install the Manager's own verdict by reading
+// /v2/manager/queue/history?ui_id=. Released 3.x registers no such route, so
+// there it reads nothing — and the record is not merely unexposed, it is
+// DELETED. From ComfyUI-Manager 3.41's glob/manager_server.py, `task_worker`:
+//
+//     PromptServer.instance.send_sync("cm-queue-status",
+//         {'status': 'done', 'nodepack_result': nodepack_result, …})
+//     nodepack_result = {}
+//     task_queue = queue.Queue()
+//
+// `queue/status` derives done_count from `len(nodepack_result)`, so the line
+// AFTER the broadcast is what makes total/done/in_progress read 0 — the
+// reporter's empty idle queue is produced by the task finishing. The broadcast
+// is therefore the only statement of the outcome that ever exists, and a panel
+// living in the ComfyUI page is already a client of it (`send_sync` with no sid
+// goes to every client; ComfyUI-Manager's own UI reads it the same way).
+//
+// These tests pin: the frame's meaning, the bounded log that keeps it, that the
+// REAL verifier reaches it and turns it into a failure verdict, that it is
+// correlated by ui_id so a neighbour's failure is never borrowed, and that the
+// queue poll reports it instead of an idle-looking silence.
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import * as ManagerInstall from "../../web/js/lib/manager-install.js";
+const {
+  classifyInstallOutcome,
+  collectRecentTaskFailures,
+  createManagerTaskResultLog,
+  dialectServesTaskHistory,
+  looksLikeTaskHistory,
+  parseTaskHistoryItem,
+  queueDrained,
+  queueEventFailureReason,
+  queueEventTaskResults,
+  taskFailureReason,
+  taskHistoryBlindNote,
+  unlistedGitUrlAdvice,
+} = ManagerInstall;
+
+const UI_ID = "u-1606";
+const TARGET = "comfyui-reactor"; // the reporter's pack, a plain registry id
+// What 3.41's `do_install` returns when `resolve_node_spec` comes back None —
+// verbatim from its source, and the class of message that was being thrown away.
+const REASON = "Cannot resolve install target: 'comfyui-reactor@latest'";
+
+/** The drain frame 3.41 broadcasts, with our task's outcome in it. */
+const doneFrame = (results) => ({
+  status: "done",
+  nodepack_result: results,
+  model_result: {},
+  total_count: Object.keys(results).length,
+  done_count: Object.keys(results).length,
+});
+
+/** The per-task frame it emits BEFORE that one. Names the task; says nothing
+ *  about how it went. */
+const IN_PROGRESS_FRAME = {
+  status: "in_progress",
+  target: UI_ID,
+  ui_target: "nodepack_manager",
+  total_count: 1,
+  done_count: 0,
+};
+
+/** What /manager/queue/status answers once the worker has cleared its map —
+ *  the reporter's "empty idle queue", which reads as positively DRAINED. */
+const EMPTIED = { total_count: 0, done_count: 0, in_progress_count: 0, is_processing: false };
+/** The pack is NOT in the installed list — the install never happened. */
+const INSTALLED_LIST = { "some-other-pack": { ver: "1.0", cnr_id: "some-other-pack" } };
+
+// ---------------------------------------------------------------------------
+// The frame's meaning
+// ---------------------------------------------------------------------------
+
+test("#1606: the drain frame's per-task result is extracted, keyed by ui_id", () => {
+  const results = queueEventTaskResults(doneFrame({ [UI_ID]: REASON, other: "success" }));
+  assert.deepEqual(results, [
+    { ui_id: UI_ID, result: REASON },
+    { ui_id: "other", result: "success" },
+  ]);
+});
+
+test("#1606: an in_progress frame carries NO outcome", () => {
+  // It names the task that just finished but never says how it went. Reading it
+  // as a result would record every task with an unknown outcome — and unknown is
+  // indistinguishable from a failure string here.
+  assert.deepEqual(queueEventTaskResults(IN_PROGRESS_FRAME), []);
+});
+
+test("#1606: an unrecognised payload adds nothing", () => {
+  for (const junk of [null, undefined, "done", 7, [], {}, { status: "done" }, { status: "done", nodepack_result: [] }]) {
+    assert.deepEqual(queueEventTaskResults(junk), [], `should ignore ${JSON.stringify(junk)}`);
+  }
+});
+
+test("#1606: 'update-main' stores the whole record — its .msg is the result", () => {
+  // 3.41 stores `msg['msg']` for kind 'update' but the bare {msg,url,title} dict
+  // for 'update-main'.
+  const results = queueEventTaskResults(
+    doneFrame({ [UI_ID]: { msg: "An error occurred while updating 'X'.", url: "u", title: "X" } }),
+  );
+  assert.deepEqual(results, [{ ui_id: UI_ID, result: "An error occurred while updating 'X'." }]);
+});
+
+test("#1606: the success vocabulary is not a failure; anything else IS the reason", () => {
+  for (const ok of ["success", "skip", "skipped", "SUCCESS", " success ", "success-stable-v0.3.40"]) {
+    assert.equal(queueEventFailureReason(ok), null, `${ok} is a success`);
+  }
+  assert.equal(queueEventFailureReason(REASON), REASON);
+  // Never manufactures a verdict from something it cannot read.
+  for (const unknown of [null, undefined, "", "   ", 42, {}]) {
+    assert.equal(queueEventFailureReason(unknown), null);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// The log that keeps it
+// ---------------------------------------------------------------------------
+
+test("#1606: a captured failure is readable by the ui_id that submitted it", () => {
+  const log = createManagerTaskResultLog();
+  log.note(UI_ID, { target: TARGET, kind: "install" });
+  assert.equal(log.record(doneFrame({ [UI_ID]: REASON })), 1);
+  assert.equal(log.failureFor(UI_ID), REASON);
+  assert.deepEqual(log.recentFailures(), [
+    { ui_id: UI_ID, kind: "install", id: TARGET, result: REASON },
+  ]);
+});
+
+test("#1606: a neighbouring task's failure is never attributed to ours", () => {
+  const log = createManagerTaskResultLog();
+  log.note(UI_ID, { target: TARGET, kind: "install" });
+  log.record(doneFrame({ "someone-elses-task": REASON, [UI_ID]: "success" }));
+  assert.equal(log.failureFor(UI_ID), null, "our task succeeded");
+  assert.equal(log.failureFor("someone-elses-task"), REASON, "theirs is still reported");
+});
+
+test("#1606: a later SUCCESS for the same pack retires the earlier failure", () => {
+  // Otherwise a reinstall that worked leaves the defeat sitting in the log and
+  // the next poll reports a failure that has already been undone.
+  const log = createManagerTaskResultLog();
+  log.note("first", { target: TARGET, kind: "install" });
+  log.record(doneFrame({ first: REASON }));
+  assert.equal(log.recentFailures().length, 1);
+  log.note("second", { target: TARGET, kind: "install" });
+  log.record(doneFrame({ second: "success" }));
+  assert.deepEqual(log.recentFailures(), [], "the pack installed — nothing to report");
+  // A DIFFERENT pack succeeding must not clear it.
+  const other = createManagerTaskResultLog();
+  other.note("a", { target: TARGET });
+  other.record(doneFrame({ a: REASON }));
+  other.note("b", { target: "another-pack" });
+  other.record(doneFrame({ b: "success" }));
+  assert.equal(other.recentFailures().length, 1);
+});
+
+test("#1606: a stale capture ages out of the poll surface", () => {
+  let now = 1_000_000;
+  const log = createManagerTaskResultLog({ now: () => now });
+  log.note(UI_ID, { target: TARGET });
+  log.record(doneFrame({ [UI_ID]: REASON }));
+  assert.equal(log.recentFailures({ maxAgeMs: 60_000 }).length, 1);
+  now += 61_000;
+  assert.deepEqual(log.recentFailures({ maxAgeMs: 60_000 }), [], "too old to be what a poll is asking about");
+  // The ui_id-correlated read is NOT age-bounded: an install verifying its own
+  // task asks about a result it is waiting for right now.
+  assert.equal(log.failureFor(UI_ID), REASON);
+});
+
+test("#1606: the log is bounded — a tab open for days cannot grow it without limit", () => {
+  const log = createManagerTaskResultLog({ limit: 3 });
+  for (let i = 0; i < 10; i += 1) log.record(doneFrame({ [`u-${i}`]: REASON }));
+  assert.equal(log.size(), 3);
+  assert.equal(log.failureFor("u-9"), REASON, "the newest is kept");
+  assert.equal(log.failureFor("u-0"), null, "the oldest was evicted");
+});
+
+// ---------------------------------------------------------------------------
+// Real-source harness: the ACTUAL waitForQueueDrain + verifyInstalled, extracted
+// from comfyui-mcp-panel.js. Driving the real source is the point — a
+// helper-only test passes just as happily with the call site never passing
+// `capturedFailure` at all.
+// ---------------------------------------------------------------------------
+
+function readPanelSource() {
+  return readFileSync(
+    fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url)),
+    "utf8",
+  );
+}
+
+function pick(src, re, name) {
+  const m = src.match(re);
+  assert.ok(m, `could not locate ${name} in panel source`);
+  return m[0];
+}
+
+function buildVerifyInstalled({ routes, calls = [], managerTaskResults }) {
+  const src = readPanelSource();
+  const get = async (route) => {
+    calls.push(route);
+    for (const [prefix, handler] of Object.entries(routes)) {
+      if (route.startsWith(prefix)) {
+        const out = typeof handler === "function" ? handler(route) : handler;
+        if (out instanceof Error) throw out;
+        return out;
+      }
+    }
+    throw new Error(`unstubbed route: ${route}`);
+  };
+  const deps = {
+    managerGet: get,
+    managerV2: get,
+    managerCall: get,
+    queueDrained,
+    taskFailureReason,
+    parseTaskHistoryItem,
+    classifyInstallOutcome,
+    managerTaskResults,
+    MANAGER_FETCH_TIMEOUT_MS: 15000,
+    INSTALL_VERIFY_BUDGET_MS: 4000,
+    AbortSignal,
+    setTimeout,
+  };
+  const factory = new Function(
+    ...Object.keys(deps),
+    `${pick(src, /function boundedDelay\(ms, deadline\) \{[\s\S]*?\n\}/, "boundedDelay")}
+${pick(src, /async function waitForQueueDrain\(\{[\s\S]*?\n\}/, "waitForQueueDrain")}
+${pick(src, /async function verifyInstalled\(target, dialect, \{[\s\S]*?\n\}/, "verifyInstalled")}
+return { verifyInstalled, waitForQueueDrain };`,
+  );
+  return factory(...Object.values(deps));
+}
+
+/** The legacy Manager as the reporter met it: no history route at all, a queue
+ *  that has emptied itself, and the pack absent. */
+const LEGACY_ROUTES = {
+  "manager/queue/history": new Error("Manager manager/queue/history: HTTP 404"),
+  "manager/queue/status": EMPTIED,
+  "customnode/installed": INSTALLED_LIST,
+};
+
+test("#1606: the reported case — a legacy install now reports the Manager's OWN reason", async () => {
+  const log = createManagerTaskResultLog();
+  log.note(UI_ID, { target: TARGET, kind: "install" });
+  // The broadcast the panel heard while the install was queued.
+  log.record(doneFrame({ [UI_ID]: REASON }));
+
+  const calls = [];
+  const { verifyInstalled } = buildVerifyInstalled({
+    calls,
+    routes: LEGACY_ROUTES,
+    managerTaskResults: log,
+  });
+  const outcome = await verifyInstalled(TARGET, "legacy", { budgetMs: 4000, ui_id: UI_ID });
+
+  // BEFORE: "unverified" — which nodes_install returns as queued:true,
+  // installed:false, verified:false, pending:true. Exactly the reporter's reply.
+  assert.equal(outcome.state, "failed");
+  assert.ok(outcome.message.includes(REASON), "the caller gets the Manager's real reason");
+  assert.match(outcome.message, /install FAILED/);
+  assert.doesNotMatch(outcome.message, /could NOT be confirmed/, "a verdict, not a hedge");
+  assert.ok(
+    !calls.some((r) => r.startsWith("customnode/installed")),
+    "a settled verdict should not spend budget on evidence that cannot change it",
+  );
+});
+
+test("#1606: WITHOUT the capture the same install is only 'unverified' (the bug)", async () => {
+  // The mutation check for the test above: an empty log is the pre-fix world.
+  const { verifyInstalled } = buildVerifyInstalled({
+    routes: LEGACY_ROUTES,
+    managerTaskResults: createManagerTaskResultLog(),
+  });
+  const outcome = await verifyInstalled(TARGET, "legacy", { budgetMs: 4000, ui_id: UI_ID });
+  assert.equal(outcome.state, "unverified");
+  assert.doesNotMatch(outcome.message, /install FAILED/);
+});
+
+test("#1606: a capture for ANOTHER task never fails this install", async () => {
+  const log = createManagerTaskResultLog();
+  log.note(UI_ID, { target: TARGET, kind: "install" });
+  log.record(doneFrame({ "a-different-task": REASON }));
+  const { verifyInstalled } = buildVerifyInstalled({
+    routes: LEGACY_ROUTES,
+    managerTaskResults: log,
+  });
+  const outcome = await verifyInstalled(TARGET, "legacy", { budgetMs: 4000, ui_id: UI_ID });
+  assert.equal(outcome.state, "unverified", "our task has no verdict — do not borrow one");
+});
+
+test("#1606: a captured SUCCESS is not turned into a failure", async () => {
+  const log = createManagerTaskResultLog();
+  log.note(UI_ID, { target: TARGET, kind: "install" });
+  log.record(doneFrame({ [UI_ID]: "success" }));
+  const { verifyInstalled } = buildVerifyInstalled({
+    routes: {
+      ...LEGACY_ROUTES,
+      "customnode/installed": { [TARGET]: { ver: "1.0", cnr_id: TARGET } },
+    },
+    managerTaskResults: log,
+  });
+  const outcome = await verifyInstalled(TARGET, "legacy", { budgetMs: 4000, ui_id: UI_ID });
+  assert.equal(outcome.state, "installed");
+});
+
+test("#1606: a captured failure ends the wait even if the queue never drains", async () => {
+  const log = createManagerTaskResultLog();
+  log.note(UI_ID, { target: TARGET, kind: "install" });
+  log.record(doneFrame({ [UI_ID]: REASON }));
+  const { verifyInstalled } = buildVerifyInstalled({
+    routes: { ...LEGACY_ROUTES, "manager/queue/status": { total_count: 3, done_count: 1, is_processing: true } },
+    managerTaskResults: log,
+  });
+  const started = Date.now();
+  const outcome = await verifyInstalled(TARGET, "legacy", { budgetMs: 8000, ui_id: UI_ID });
+  assert.equal(outcome.state, "failed");
+  assert.ok(Date.now() - started < 6000, "must return on the record, not burn the budget");
+});
+
+test("#1606: the v4 history read still works, and is not disturbed by an empty log", async () => {
+  // The #1539 path must keep its behaviour on a build that DOES serve history.
+  const V4_REASON = "Node 'x@nightly' not found in [ManagerChannel.dev, ManagerDatabaseSource.cache]";
+  const { verifyInstalled } = buildVerifyInstalled({
+    routes: {
+      "manager/queue/history": {
+        history: { ui_id: UI_ID, kind: "install", status: { status_str: "error", completed: true, messages: [V4_REASON] } },
+      },
+      "manager/queue/status": EMPTIED,
+      "customnode/installed": INSTALLED_LIST,
+    },
+    managerTaskResults: createManagerTaskResultLog(),
+  });
+  const outcome = await verifyInstalled(TARGET, "v2", { budgetMs: 4000, ui_id: UI_ID, renameProne: true });
+  assert.equal(outcome.state, "failed");
+  assert.ok(outcome.message.includes(V4_REASON));
+});
+
+// ---------------------------------------------------------------------------
+// The subscription — the one line that makes any of the above reachable
+// ---------------------------------------------------------------------------
+
+function buildSubscribe(log) {
+  const src = readPanelSource();
+  const factory = new Function(
+    "managerTaskResults",
+    "api",
+    `${pick(src, /function subscribeManagerTaskResults\(target = api, log = managerTaskResults\) \{[\s\S]*?\n\}/, "subscribeManagerTaskResults")}
+return subscribeManagerTaskResults;`,
+  );
+  return factory(log, null);
+}
+
+test("#1606: the subscription puts a real broadcast into the log", () => {
+  const log = createManagerTaskResultLog();
+  const subscribe = buildSubscribe(log);
+  const listeners = new Map();
+  const fakeApi = {
+    addEventListener: (type, cb) => listeners.set(type, cb),
+    emit: (type, detail) => listeners.get(type)?.({ detail }),
+  };
+
+  assert.equal(subscribe(fakeApi, log), true);
+  assert.ok(listeners.has("cm-queue-status"), "ComfyUI only dispatches a type something REGISTERED for");
+
+  log.note(UI_ID, { target: TARGET, kind: "install" });
+  fakeApi.emit("cm-queue-status", doneFrame({ [UI_ID]: REASON }));
+  assert.equal(log.failureFor(UI_ID), REASON);
+  // A frame with nothing readable in it must not throw out of the listener.
+  assert.doesNotThrow(() => fakeApi.emit("cm-queue-status", undefined));
+});
+
+test("#1606: no api (panel loaded outside a live ComfyUI) is a no-op, not a crash", () => {
+  const log = createManagerTaskResultLog();
+  const subscribe = buildSubscribe(log);
+  assert.equal(subscribe(null, log), false);
+  assert.equal(subscribe({}, log), false);
+});
+
+test("#1606: setupListeners actually SUBSCRIBES, at panel load", () => {
+  // The capture is one call in one function; a helper-level test cannot see it
+  // missing. Assert on the source, inside setupListeners — not merely present
+  // in the file — and at load rather than per-install, because a task that
+  // fails fast drains before an install-time listener could exist.
+  const src = readPanelSource();
+  const setup = pick(src, /function setupListeners\(\) \{[\s\S]*?\r?\n\}/, "setupListeners");
+  assert.match(setup, /subscribeManagerTaskResults\(\)/);
+});
+
+test("#1606: the install path correlates its ui_id and passes the captured read", () => {
+  const src = readPanelSource();
+  const install = pick(src, /  async nodes_install\(args\) \{[\s\S]*?\r?\n  \},/, "nodes_install");
+  assert.match(install, /managerTaskResults\.note\(ui_id, \{ target/);
+  const verify = pick(src, /async function verifyInstalled\(target, dialect, \{[\s\S]*?\n\}/, "verifyInstalled");
+  assert.match(verify, /capturedFailure: ui_id \? \(\) => managerTaskResults\.failureFor\(ui_id\) : undefined/);
+});
+
+// ---------------------------------------------------------------------------
+// The queue poll — where the reporter looked and found nothing
+// ---------------------------------------------------------------------------
+
+function buildQueueStatus({ dialect, routes, managerTaskResults }) {
+  const src = readPanelSource();
+  const get = async (route) => {
+    for (const [prefix, handler] of Object.entries(routes)) {
+      if (route.startsWith(prefix)) {
+        const out = typeof handler === "function" ? handler(route) : handler;
+        if (out instanceof Error) throw out;
+        return out;
+      }
+    }
+    throw new Error(`unstubbed route: ${route}`);
+  };
+  const deps = {
+    detectManagerDialect: async () => dialect,
+    managerGet: get,
+    collectRecentTaskFailures,
+    dialectServesTaskHistory,
+    looksLikeTaskHistory,
+    taskHistoryBlindNote,
+    unlistedGitUrlAdvice,
+    managerTaskResults,
+    CAPTURED_FAILURE_TTL_MS: 30 * 60 * 1000,
+    MANAGER_FETCH_TIMEOUT_MS: 15000,
+    AbortSignal,
+  };
+  const factory = new Function(
+    ...Object.keys(deps),
+    `const tools = {
+${pick(src, /  async nodes_queue_status\(\) \{[\s\S]*?\n  \},/, "nodes_queue_status")}
+};
+return () => tools.nodes_queue_status();`,
+  );
+  return factory(...Object.values(deps));
+}
+
+test("#1606: the poll the reporter made now reports the failure it could not see", async () => {
+  const log = createManagerTaskResultLog();
+  log.note(UI_ID, { target: TARGET, kind: "install" });
+  log.record(doneFrame({ [UI_ID]: REASON }));
+  const queueStatus = buildQueueStatus({
+    dialect: "legacy",
+    routes: LEGACY_ROUTES,
+    managerTaskResults: log,
+  });
+
+  const out = await queueStatus();
+  assert.deepEqual(out.status, EMPTIED, "the queue really is idle and empty");
+  assert.deepEqual(out.recent_failures, [
+    { ui_id: UI_ID, kind: "install", id: TARGET, result: REASON },
+  ]);
+  assert.match(out.note, /FAILED/);
+  assert.equal(out.failure_reporting, "partial", "real, but this build cannot promise the list is complete");
+});
+
+test("#1606: an idle legacy queue with nothing captured says so, instead of looking clean", async () => {
+  const queueStatus = buildQueueStatus({
+    dialect: "legacy",
+    routes: LEGACY_ROUTES,
+    managerTaskResults: createManagerTaskResultLog(),
+  });
+  const out = await queueStatus();
+  assert.equal(out.failure_reporting, "unavailable");
+  assert.match(out.note, /A FAILED TASK MAY NOT BE VISIBLE HERE/);
+  assert.match(out.note, /panel_list_nodes/);
+});
+
+test("#1606: a v4 that served its history is reported as COMPLETE, with no hedge", async () => {
+  const queueStatus = buildQueueStatus({
+    dialect: "v2",
+    routes: { "manager/queue/status": EMPTIED, "manager/queue/history": { history: {} } },
+    managerTaskResults: createManagerTaskResultLog(),
+  });
+  const out = await queueStatus();
+  assert.equal(out.failure_reporting, "complete");
+  assert.equal(out.note, undefined, "nothing to warn about — the record was read and it was empty");
+});
+
+test("#1606: a v4 whose history read FAILED does not read as a clean queue", async () => {
+  const queueStatus = buildQueueStatus({
+    dialect: "v2",
+    routes: {
+      "manager/queue/status": EMPTIED,
+      "manager/queue/history": new Error("Manager manager/queue/history: HTTP 500"),
+    },
+    managerTaskResults: createManagerTaskResultLog(),
+  });
+  const out = await queueStatus();
+  assert.equal(out.failure_reporting, "unavailable");
+  assert.match(out.note, /could not be read just now/);
+});
+
+test("#1606: ComfyUI's SPA index answering an absent route is not a readable history", () => {
+  // An UNREGISTERED GET can answer 200 with HTML, and an empty body parses to
+  // null — both would otherwise traverse to zero failures and be reported as
+  // "nothing failed".
+  assert.equal(looksLikeTaskHistory("<!DOCTYPE html><html>…"), false);
+  assert.equal(looksLikeTaskHistory(null), false);
+  assert.equal(looksLikeTaskHistory({}), false, "a bare {} says nothing about any queue");
+  assert.equal(looksLikeTaskHistory({ history: {} }), true, "an empty envelope IS an answer");
+  assert.equal(looksLikeTaskHistory([]), true);
+  assert.equal(looksLikeTaskHistory({ history: { a: { ui_id: "a", kind: "install" } } }), true);
+  assert.equal(
+    looksLikeTaskHistory({ history: { ui_id: "a", kind: "install", status: { status_str: "error" } } }),
+    true,
+    "the single ui_id-queried record",
+  );
+});
+
+test("#1606: a v4 failure served by history is not double-listed by the capture", async () => {
+  const log = createManagerTaskResultLog();
+  log.note(UI_ID, { target: TARGET, kind: "install" });
+  log.record(doneFrame({ [UI_ID]: REASON }));
+  const queueStatus = buildQueueStatus({
+    dialect: "v2",
+    routes: {
+      "manager/queue/status": EMPTIED,
+      "manager/queue/history": {
+        history: {
+          [UI_ID]: {
+            ui_id: UI_ID,
+            kind: "install",
+            status: { status_str: "error", completed: true, messages: [REASON] },
+            params: { id: TARGET },
+          },
+        },
+      },
+    },
+    managerTaskResults: log,
+  });
+  const out = await queueStatus();
+  assert.equal(out.recent_failures.length, 1, "one task, one entry");
+  assert.equal(out.failure_reporting, "complete");
+});
+
+test("#1606: the blind note never asserts that anything failed", () => {
+  for (const dialect of ["legacy", "v2-batch", "v2", undefined]) {
+    const note = taskHistoryBlindNote(dialect);
+    assert.match(note, /MAY NOT BE VISIBLE/);
+    assert.doesNotMatch(note, /\bdid fail\b|\bhas failed\b/);
+  }
+  assert.match(taskHistoryBlindNote("legacy"), /deletes each task's result/);
+  assert.match(taskHistoryBlindNote("v2"), /transient error/);
+  assert.equal(dialectServesTaskHistory("legacy"), false);
+  assert.equal(dialectServesTaskHistory("v2-batch"), false);
+  assert.equal(dialectServesTaskHistory("v2"), true);
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -93,7 +93,11 @@ import {
   classifyInstallOutcome,
   classifyUpdateOutcome,
   collectRecentTaskFailures,
+  createManagerTaskResultLog,
   dialectRetryTarget,
+  dialectServesTaskHistory,
+  looksLikeTaskHistory,
+  taskHistoryBlindNote,
   installGitUrl,
   installedListRoute,
   isManagerRouteMissing,
@@ -1465,6 +1469,11 @@ let seenDoneDownloads = new Set();
 function setupListeners() {
   if (!api) return;
   try {
+    // comfyui-mcp#1606 — subscribed HERE, at panel load, and not when an install
+    // is dispatched: the Manager broadcasts a task's result as the queue drains,
+    // and a fast failure drains before the install call has anything to attach a
+    // listener to.
+    subscribeManagerTaskResults();
     api.addEventListener("execution_error", (ev) => {
       lastExecFailure = { ...(ev.detail ?? {}), ts: new Date().toISOString() };
     });
@@ -6094,6 +6103,41 @@ function boundedDelay(ms, deadline) {
   return new Promise((r) => setTimeout(r, budget));
 }
 
+/** comfyui-mcp#1606 — Manager task outcomes heard on the ComfyUI socket. On
+ *  released 3.x this is the ONLY place a task's result is ever stated: the
+ *  worker broadcasts the whole result map as the queue drains and deletes it on
+ *  the next line, which is what leaves a poll looking at an idle queue holding
+ *  nothing. See manager-install.js for the source it was read from. */
+const managerTaskResults = createManagerTaskResultLog();
+
+/** How long a captured failure stays reportable on a queue poll. A defeat from
+ *  hours ago is not what "is my install done?" is asking, and repeating it reads
+ *  as a fresh one. */
+const CAPTURED_FAILURE_TTL_MS = 30 * 60 * 1000;
+
+/**
+ * Subscribe to the Manager's task-completion broadcast (comfyui-mcp#1606).
+ *
+ * ComfyUI's api dispatches an unknown socket message type only to listeners that
+ * have REGISTERED for it (`_registered.has(type)` guards the default arm of its
+ * socket handler), so this call is what makes the frame observable at all —
+ * ComfyUI-Manager's own UI subscribes the same way. Registered once from
+ * setupListeners, at panel load, because the frame arrives when the queue
+ * drains: a listener attached at install time would already be too late for a
+ * task that failed fast.
+ *
+ * Parameterised for the unit harness, and defensive about `api` for the same
+ * reason setupListeners is — a panel loaded outside a live ComfyUI has none.
+ * Returns whether the subscription was actually made.
+ */
+function subscribeManagerTaskResults(target = api, log = managerTaskResults) {
+  if (!target || typeof target.addEventListener !== "function") return false;
+  target.addEventListener("cm-queue-status", (ev) => {
+    log.record(ev?.detail);
+  });
+  return true;
+}
+
 /** Poll the Manager queue/status until it POSITIVELY drains (queueDrained) or
  *  the deadline passes. Each status fetch is bounded by an AbortSignal so a
  *  stalled request cannot run past the deadline, and the initial settle-sleep
@@ -6113,10 +6157,17 @@ function boundedDelay(ms, deadline) {
  *  `renameProne`). Correlated by the ui_id THIS command submitted, so a
  *  neighbouring task's failure can never be attributed to it.
  *
+ *  comfyui-mcp#1606 — `capturedFailure` is the same verdict for the build that
+ *  serves no history at all: a SYNCHRONOUS read of what the Manager's own
+ *  `cm-queue-status` broadcast already said about this ui_id. Checked first at
+ *  every point the HTTP record is, because it costs no fetch and no budget, and
+ *  on released 3.x it is the only per-task verdict in existence (the worker
+ *  deletes the record as it drains — see manager-install.js).
+ *
  *  Returns { status, taskFailure } — taskFailure is the Manager's own reason
  *  string, or null when there is no positive failure record (absent, unreadable
  *  or not-yet-terminal all stay null, never a verdict). */
-async function waitForQueueDrain({ timeoutMs = 120000, intervalMs = 1500, get = managerGet, ui_id } = {}) {
+async function waitForQueueDrain({ timeoutMs = 120000, intervalMs = 1500, get = managerGet, ui_id, capturedFailure } = {}) {
   const deadline = Date.now() + timeoutMs;
   let status = null;
   // Cap an individual fetch by whatever budget remains.
@@ -6126,6 +6177,9 @@ async function waitForQueueDrain({ timeoutMs = 120000, intervalMs = 1500, get = 
   // return null, so this can only ever ADD a positive failure verdict — it can
   // never manufacture one, and never downgrades a success.
   const readTaskFailure = async () => {
+    // #1606 — the broadcast we already heard, before any fetch.
+    const captured = typeof capturedFailure === "function" ? capturedFailure() : null;
+    if (captured) return captured;
     if (!ui_id) return null;
     try {
       const resp = await get(`manager/queue/history?ui_id=${encodeURIComponent(ui_id)}`, {
@@ -6210,13 +6264,20 @@ async function verifyInstalled(target, dialect, { batchFailed, renameProne, budg
   // --enable-manager-legacy-ui mode ("v2-batch") serves only BATCH history keyed
   // by `id` and REJECTS a ui_id query — polling either would burn the command
   // budget and still learn nothing. A v2-batch failure is already caught
-  // synchronously via its `failed[]` (→ batchFailed). Legacy's blind spot is
-  // artokun/comfyui-mcp#1606, a genuinely different problem: there is no record
-  // to read, whereas on v4 the record exists and we were simply not reading it.
+  // synchronously via its `failed[]` (→ batchFailed).
+  //
+  // comfyui-mcp#1606 — legacy's blind spot is closed from the OTHER side. There
+  // is no record to fetch there because the 3.x worker broadcasts each task's
+  // result and deletes it in the same breath; `capturedFailure` reads what that
+  // broadcast said, which this panel has been listening for since it loaded. It
+  // is passed on EVERY dialect, not just legacy: it is correlated by the ui_id
+  // this command submitted, so it cannot pick up a neighbour's failure, and on a
+  // build that never emits the frame there is simply nothing to read.
   const { status, taskFailure } = await waitForQueueDrain({
     timeoutMs: budget,
     get,
     ui_id: dialect === "v2" ? ui_id : undefined,
+    capturedFailure: ui_id ? () => managerTaskResults.failureFor(ui_id) : undefined,
   });
   let installed = null;
   let listError = false;
@@ -17409,6 +17470,11 @@ const GRAPH_TOOL_EXECUTORS = {
         { signal: AbortSignal.timeout(bounded(MANAGER_FETCH_TIMEOUT_MS)) },
       );
       const { target, batchFailed } = submitted;
+      // comfyui-mcp#1606 — tie our ui_id to WHAT it installs before any result can
+      // arrive. The Manager's broadcast carries only ui_id → result, so this is
+      // what lets a captured failure name the pack on a later queue poll (and
+      // what lets a successful reinstall retire the earlier failure for it).
+      managerTaskResults.note(ui_id, { target, kind: "install" });
       // Resolve the true outcome. Throw ONLY on positive failure evidence; an
       // inconclusive result returns an honest unverified status (never a silent
       // success, never a false failure). #232 + codex rounds 1-2. The verify
@@ -17668,6 +17734,19 @@ const GRAPH_TOOL_EXECUTORS = {
   },
 
   async nodes_queue_status() {
+    // comfyui-mcp#1606 — resolve the dialect BEFORE the reads, never after. On
+    // the cached path this costs nothing (managerGet's first act is this same
+    // detection), but asking afterwards could cost the whole reply: a history
+    // read that fails invalidates the cached dialect (#605), so a later
+    // detection starts fresh probes against a backend that is already not
+    // answering and the reply misses the orchestrator's 20s window. A detection
+    // failure is swallowed — the read below raises the real error.
+    let dialect;
+    try {
+      dialect = await detectManagerDialect();
+    } catch {
+      /* unknown ⇒ treated as "cannot report", below */
+    }
     const status = await managerGet("manager/queue/status");
     // #364: the aggregate status cannot reveal a FAILED task — a crashed
     // do_update still counts toward done_count and looks "done". Surface the
@@ -17675,19 +17754,39 @@ const GRAPH_TOOL_EXECUTORS = {
     // of an idle queue does not read a silent "done" over a task that errored.
     // Best-effort: a legacy Manager without /v2 history (or a transient error)
     // just returns the status alone, exactly as before.
-    let recentFailures = [];
+    let history = null;
     try {
-      const hist = await managerGet("manager/queue/history?max_items=20", {
+      history = await managerGet("manager/queue/history?max_items=20", {
         signal: AbortSignal.timeout(MANAGER_FETCH_TIMEOUT_MS),
       });
-      recentFailures = collectRecentTaskFailures(hist);
     } catch {
-      /* history endpoint absent/transient — status alone */
+      /* history endpoint absent/transient — null is not readable, see below */
     }
+    const historyFailures = collectRecentTaskFailures(history);
+    // comfyui-mcp#1606 — and the failures this panel HEARD. On released 3.x the
+    // Manager deletes each task's result as the queue drains, so by the time
+    // anyone polls there is nothing left to fetch; the completion broadcast is
+    // the only statement of it, and this is where the poll finally gets to say
+    // what it said. Deduped by ui_id so a v4 that serves both never lists one
+    // failure twice.
+    const seen = new Set(historyFailures.map((f) => f?.ui_id).filter(Boolean));
+    const captured = managerTaskResults
+      .recentFailures({ maxAgeMs: CAPTURED_FAILURE_TTL_MS })
+      .filter((f) => !f.ui_id || !seen.has(f.ui_id));
+    const recentFailures = [...historyFailures, ...captured];
+    // Can an EMPTY list be read as "nothing failed"? Only when this build keeps
+    // a per-task history AND we positively read it. Anything else — no such
+    // record, a read that threw, a payload we do not recognise — means we did
+    // not look successfully, and silence is then not evidence. That equivalence
+    // is the reported bug: a legacy Manager returned a bare `{status}` that was
+    // byte-identical to a v4 with nothing to report.
+    const canReportFailures = dialectServesTaskHistory(dialect) && looksLikeTaskHistory(history);
+    const blindNote = canReportFailures ? "" : taskHistoryBlindNote(dialect);
     if (recentFailures.length) {
       return {
         status,
         recent_failures: recentFailures,
+        failure_reporting: canReportFailures ? "complete" : "partial",
         note:
           `${recentFailures.length} recent ComfyUI-Manager task(s) FAILED (see recent_failures). ` +
           `A drained queue that shows "done" does NOT mean every task succeeded — check these ` +
@@ -17695,10 +17794,17 @@ const GRAPH_TOOL_EXECUTORS = {
           // #920 — a registry-lookup miss reads like a lookup bug and sends people to
           // re-check spelling and channels. On a stock v4 an unlisted git URL is simply
           // not installable, and saying so beats echoing a name the caller never supplied.
-          unlistedGitUrlAdvice(recentFailures.map((f) => f?.result ?? "").join(" ")),
+          unlistedGitUrlAdvice(recentFailures.map((f) => f?.result ?? "").join(" ")) +
+          // A build we cannot fully read can still hand us a positively-failed
+          // record. Those are real, but the list is not exhaustive — say so,
+          // rather than let a partial list be taken for the whole story.
+          (blindNote ? `\n\n${blindNote}` : ""),
       };
     }
-    return { status };
+    if (!canReportFailures) {
+      return { status, failure_reporting: "unavailable", note: blindNote };
+    }
+    return { status, failure_reporting: "complete" };
   },
 
   // #851 — every branch below names the TARGET as well as the route, via

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -1473,7 +1473,16 @@ function setupListeners() {
     // is dispatched: the Manager broadcasts a task's result as the queue drains,
     // and a fast failure drains before the install call has anything to attach a
     // listener to.
-    subscribeManagerTaskResults();
+    //
+    // In its OWN try: everything below this line is load-bearing (backend-down
+    // detection, the reconnect resync), and they share one catch. A diagnostic
+    // capture must not be able to preempt them by throwing first — and being
+    // registered first is what makes it see a drain that lands during startup.
+    try {
+      subscribeManagerTaskResults();
+    } catch (err) {
+      console.warn("[comfyui-mcp-panel] Manager task-result capture unavailable:", err);
+    }
     api.addEventListener("execution_error", (ev) => {
       lastExecFailure = { ...(ev.detail ?? {}), ts: new Date().toISOString() };
     });

--- a/web/js/lib/manager-install.js
+++ b/web/js/lib/manager-install.js
@@ -1344,13 +1344,22 @@ export function dialectServesTaskHistory(dialect) {
  * that on this build silence is not evidence either way. The live capture is
  * named because it is the one thing that CAN answer here, and its limit stated:
  * it only sees tasks that finished while this browser tab was open.
+ *
+ * THREE causes, not two. An UNKNOWN dialect (detection failed) must not borrow
+ * 3.x's explanation: "this build keeps no history" is a claim about a build we
+ * did not identify, and asserting the mechanism we happen to have written about
+ * is how a plausible sentence becomes a false one. It gets its own arm.
  */
 export function taskHistoryBlindNote(dialect) {
-  const cause = dialectServesTaskHistory(dialect)
-    ? "this Manager's per-task history could not be read just now (a transient error, or a " +
-      "response this panel did not recognise)"
-    : "this ComfyUI-Manager build keeps NO readable per-task history (released 3.x deletes each " +
-      "task's result the moment the queue drains)";
+  const cause =
+    dialect === undefined || dialect === null || dialect === ""
+      ? "this panel could not determine which ComfyUI-Manager generation is running, so it " +
+        "cannot say whether a per-task record even exists here"
+      : dialectServesTaskHistory(dialect)
+        ? "this Manager's per-task history could not be read just now (a transient error, or a " +
+          "response this panel did not recognise)"
+        : "this ComfyUI-Manager build keeps NO readable per-task history (released 3.x deletes " +
+          "each task's result the moment the queue drains)";
   return (
     `NOTE — A FAILED TASK MAY NOT BE VISIBLE HERE: ${cause}. Any failure listed above was ` +
     `captured live from the Manager's completion broadcast, which this panel only hears for ` +

--- a/web/js/lib/manager-install.js
+++ b/web/js/lib/manager-install.js
@@ -1103,6 +1103,265 @@ export function collectRecentTaskFailures(resp, { limit = 20 } = {}) {
   return out.slice(-limit);
 }
 
+// ---------------------------------------------------------------------------
+// comfyui-mcp#1606 — a per-task result on the build that keeps NO task history
+// ---------------------------------------------------------------------------
+//
+// #1539 gave install the Manager's own terminal verdict by reading
+// /v2/manager/queue/history?ui_id=. Released 3.x ("legacy") registers no such
+// route, so there it reads nothing and the install falls back to the drain +
+// name-presence proxies. The reporter's install drained and left no trace at
+// all: panel_node_queue_status showed an idle queue with NOTHING in it, and the
+// pack was absent.
+//
+// The record is not missing — it is DELETED. Read out of ComfyUI-Manager 3.41's
+// glob/manager_server.py: `task_worker` accumulates every task's outcome in
+// `nodepack_result[ui_id]` (do_install returns the literal string 'success', or
+// the error text — "Cannot resolve install target: …", the failed
+// `install_by_id` res.msg, a traceback summary). When the queue empties it
+// broadcasts that whole map and then throws it away:
+//
+//     PromptServer.instance.send_sync("cm-queue-status",
+//         {'status': 'done', 'nodepack_result': nodepack_result, …})
+//     nodepack_result = {}
+//     task_queue = queue.Queue()
+//
+// `queue/status` derives done_count from `len(nodepack_result)`, so the line
+// after the broadcast is what makes total/done/in_progress all read 0 — the
+// reporter's "empty idle queue", produced BY the task finishing. `queue/start`
+// clears the map too. No later HTTP read can recover the outcome.
+//
+// So the broadcast is the only place 3.x ever states it — and a panel living in
+// the ComfyUI page is already a client of it. `send_sync` with no sid goes to
+// every connected client, and ComfyUI-Manager's own UI reads it exactly this
+// way (`api.addEventListener("cm-queue-status", …)` in js/custom-nodes-manager.js).
+// The helpers below turn that frame into records the same shape the history
+// reader produces, so the verdict path above needs no new branch: a captured
+// failure is fed in as `taskFailure` and classifies identically.
+
+/**
+ * The per-task outcomes carried by ONE `cm-queue-status` payload.
+ *
+ * Only the DRAIN frame ('done') carries outcomes. The per-task 'in_progress'
+ * frame names the task that just finished (`target`) but never says how it went,
+ * so reading it as a result would record every task as an unknown one — and an
+ * unknown result is indistinguishable from a failure string here.
+ *
+ * Unknown/foreign shapes yield []: this is additive evidence, so a payload we do
+ * not recognise must add nothing rather than guess. That is also what keeps it
+ * safe on a Manager generation that emits a same-named event of its own.
+ *
+ * @returns {{ui_id: string, result: string}[]}
+ */
+export function queueEventTaskResults(detail) {
+  if (!detail || typeof detail !== "object" || Array.isArray(detail)) return [];
+  if (detail.status !== "done") return [];
+  const out = [];
+  for (const key of ["nodepack_result", "model_result"]) {
+    const map = detail[key];
+    if (!map || typeof map !== "object" || Array.isArray(map)) continue;
+    for (const [ui_id, raw] of Object.entries(map)) {
+      const result = taskResultText(raw);
+      if (ui_id && result !== undefined) out.push({ ui_id, result });
+    }
+  }
+  return out;
+}
+
+/** A `nodepack_result` value as the 3.41 worker writes it: the worker's return
+ *  value, which is a STRING for install/uninstall/disable/fix and for 'update'
+ *  (it stores `msg['msg']`), but the whole `{msg, url, title}` record for
+ *  'update-main'. Anything else is not a result this can read. */
+function taskResultText(raw) {
+  if (typeof raw === "string") return raw.trim() || undefined;
+  if (raw && typeof raw === "object" && typeof raw.msg === "string") return raw.msg.trim() || undefined;
+  return undefined;
+}
+
+/**
+ * Is a captured result a FAILURE, and what did the Manager say?
+ *
+ * The 3.x worker writes a fixed success vocabulary and returns the ERROR TEXT
+ * itself for everything else, so "not one of the success words" is the failure
+ * test and the value IS the reason. The Manager's ComfyUI self-update task also
+ * answers "success-stable-<tag>", hence the prefix arm — a version-tagged
+ * success is still a success.
+ *
+ * Returns null for a success and for anything unreadable: this may only ever ADD
+ * a positive failure verdict, never manufacture one.
+ */
+export function queueEventFailureReason(result) {
+  if (typeof result !== "string") return null;
+  const v = result.trim();
+  if (!v) return null;
+  const lower = v.toLowerCase();
+  if (TASK_SUCCESS_STATUS.has(lower)) return null;
+  if (/^success[-:\s]/.test(lower)) return null;
+  return v;
+}
+
+/** How many captured task records to keep. Bounds the log in a tab that stays
+ *  open for days; the reads below are all "the recent ones" anyway. */
+const TASK_RESULT_LOG_LIMIT = 50;
+
+/**
+ * A bounded log of Manager task outcomes captured from `cm-queue-status`.
+ *
+ * Kept in this module rather than the panel so it is unit-testable without a
+ * browser: the panel owns the subscription (one `api.addEventListener`), this
+ * owns what the frames MEAN.
+ *
+ * Insertion-ordered by ui_id, so eviction is oldest-first and re-recording a
+ * ui_id moves it to the newest position.
+ *
+ * @param {{limit?: number, now?: () => number}} [opts]
+ */
+export function createManagerTaskResultLog({ limit = TASK_RESULT_LOG_LIMIT, now = () => Date.now() } = {}) {
+  /** @type {Map<string, {ui_id: string, target?: string, kind?: string, result?: string, at?: number}>} */
+  const byUiId = new Map();
+
+  const touch = (ui_id, patch) => {
+    const prev = byUiId.get(ui_id);
+    byUiId.delete(ui_id); // re-insert so Map order stays newest-last
+    byUiId.set(ui_id, { ...(prev ?? {}), ui_id, ...patch });
+    while (byUiId.size > limit) byUiId.delete(byUiId.keys().next().value);
+  };
+
+  return {
+    /** Correlate a ui_id we are about to submit with WHAT it acts on. The
+     *  broadcast carries only ui_id → result, so without this a captured
+     *  failure could name no pack. Optional: an uncorrelated failure is still
+     *  reported, just without an `id`. */
+    note(ui_id, { target, kind } = {}) {
+      if (typeof ui_id !== "string" || !ui_id) return;
+      touch(ui_id, { target, kind });
+    },
+
+    /** Ingest one `cm-queue-status` payload. Returns how many outcomes it carried. */
+    record(detail) {
+      const results = queueEventTaskResults(detail);
+      for (const { ui_id, result } of results) {
+        touch(ui_id, { result, at: now() });
+        // A later SUCCESS retires an earlier failure for the SAME pack. Without
+        // this, a reinstall that worked leaves the original failure sitting in
+        // the log, and the next queue poll reports a defeat that has already
+        // been undone — the stale-verdict failure mode this whole area is about.
+        const rec = byUiId.get(ui_id);
+        if (rec && rec.target && !queueEventFailureReason(rec.result)) {
+          for (const [key, other] of byUiId) {
+            if (key !== ui_id && other.target === rec.target && queueEventFailureReason(other.result)) {
+              byUiId.delete(key);
+            }
+          }
+        }
+      }
+      return results.length;
+    },
+
+    /** The Manager's own failure text for THIS ui_id, or null. Correlated by the
+     *  id we submitted, so a neighbouring task's failure is never attributed to
+     *  it — the same rule the history read follows. */
+    failureFor(ui_id) {
+      const rec = typeof ui_id === "string" ? byUiId.get(ui_id) : undefined;
+      return rec ? queueEventFailureReason(rec.result) : null;
+    },
+
+    /**
+     * Captured FAILURES, in the `{ui_id, kind, id, result}` shape
+     * collectRecentTaskFailures produces so both sources merge without a second
+     * format.
+     *
+     * `maxAgeMs` bounds how long a capture stays reportable. A failure from
+     * hours ago is not what a poll is asking about, and re-reporting it reads as
+     * a fresh one; a record with no timestamp (noted but never resolved) is not
+     * a failure and never appears here anyway.
+     */
+    recentFailures({ limit: cap = 20, maxAgeMs } = {}) {
+      const cutoff = typeof maxAgeMs === "number" ? now() - maxAgeMs : undefined;
+      const out = [];
+      for (const rec of byUiId.values()) {
+        const reason = queueEventFailureReason(rec.result);
+        if (!reason) continue;
+        if (cutoff !== undefined && !(typeof rec.at === "number" && rec.at >= cutoff)) continue;
+        out.push({ ui_id: rec.ui_id, kind: rec.kind, id: rec.target, result: reason });
+      }
+      return out.slice(-cap);
+    },
+
+    /** Records held, for tests and for bounding assertions. */
+    size() {
+      return byUiId.size;
+    },
+  };
+}
+
+/**
+ * Did a history fetch POSITIVELY return a task-history document?
+ *
+ * A missing history route does not reliably THROW: ComfyUI answers an
+ * UNREGISTERED GET with its SPA index, and an empty body parses to null — the
+ * same trap looksLikeQueueStatus guards dialect detection against. Both would
+ * otherwise traverse to zero failures and be reported as "nothing failed".
+ *
+ * Accepts the `{history: …}` envelope in item, map or array form, and a bare
+ * array/map. An empty ARRAY or an empty envelope is a real answer ("no tasks");
+ * a bare `{}` is not — it says nothing about any queue.
+ */
+export function looksLikeTaskHistory(resp) {
+  if (!resp || typeof resp !== "object") return false;
+  const hasKey = !Array.isArray(resp) && "history" in resp;
+  const history = hasKey ? resp.history : resp;
+  if (!history || typeof history !== "object") return false;
+  const items = Array.isArray(history) ? history : Object.values(history);
+  if (items.length === 0) return hasKey || Array.isArray(history);
+  if (items.every((v) => !!v && typeof v === "object")) return true;
+  // The single-record (ui_id-queried) shape: the task's own fields, so its
+  // values are strings rather than records.
+  return isTaskHistoryItem(history);
+}
+
+/**
+ * Does this Manager dialect serve a PER-TASK terminal record over HTTP?
+ *
+ * Established by #364 and already relied on by the update path: released 3.x
+ * ("legacy") has no per-task history route, and the bundled 3.x server behind
+ * --enable-manager-legacy-ui ("v2-batch") serves only BATCH history keyed by
+ * `id` and rejects a ui_id query. Only the pip Manager v4 ("v2") records a
+ * task's outcome where a later read can find it.
+ *
+ * This is what `nodes_queue_status` was missing: on the other two builds it asked
+ * for a history that cannot exist, got nothing, and returned a bare status —
+ * byte-identical to a v4 that served its history and had nothing to report.
+ */
+export function dialectServesTaskHistory(dialect) {
+  return dialect === "v2";
+}
+
+/**
+ * What to tell a queue poll that could not read per-task outcomes over HTTP.
+ *
+ * Says only what is known, and does NOT claim anything failed — the point is
+ * that on this build silence is not evidence either way. The live capture is
+ * named because it is the one thing that CAN answer here, and its limit stated:
+ * it only sees tasks that finished while this browser tab was open.
+ */
+export function taskHistoryBlindNote(dialect) {
+  const cause = dialectServesTaskHistory(dialect)
+    ? "this Manager's per-task history could not be read just now (a transient error, or a " +
+      "response this panel did not recognise)"
+    : "this ComfyUI-Manager build keeps NO readable per-task history (released 3.x deletes each " +
+      "task's result the moment the queue drains)";
+  return (
+    `NOTE — A FAILED TASK MAY NOT BE VISIBLE HERE: ${cause}. Any failure listed above was ` +
+    `captured live from the Manager's completion broadcast, which this panel only hears for ` +
+    `tasks that finish while this browser tab is open — so an EMPTY list is not proof that ` +
+    `nothing failed. A drained/idle queue is not proof either: the Manager counts a task it ` +
+    `aborted as "done" exactly like one it completed. VERIFY the pack with panel_list_nodes ` +
+    `before restarting or reporting success; if it is absent, the reason is in the ComfyUI ` +
+    `server log (security_level gating is a common cause).`
+  );
+}
+
 /**
  * Decide the TRUE outcome of an UPDATE after it was queued+started (#364). Pure,
  * unit-testable. Precedence guarantees neither a false success nor a false


### PR DESCRIPTION
Fixes artokun/comfyui-mcp#1606.

## What the reporter saw

On ComfyUI-Manager 3.x legacy, `panel_install_node comfyui-reactor` returned
`queued:true, installed:false, verified:false, pending:true` with **no failure**.
`panel_node_queue_status` immediately showed an **empty idle queue**, and
`panel_list_nodes` confirmed the pack was absent. Nothing anywhere said why, so
they fell back to a manual source install.

## Why nothing said why

#1539 gave install the Manager's own terminal verdict by reading
`/v2/manager/queue/history?ui_id=`. Released 3.x registers no such route — and
the record is not merely unexposed, it is **deleted**. From ComfyUI-Manager
**3.41**'s `glob/manager_server.py` (read off this machine's own install, the
exact build the report names), `task_worker`:

```python
nodepack_result[ui_id] = msg          # do_install returns 'success', or the error text
...
PromptServer.instance.send_sync("cm-queue-status",
    {'status': 'done', 'nodepack_result': nodepack_result, ...})
nodepack_result = {}                  # <-- and it is gone
task_queue = queue.Queue()
```

`/manager/queue/status` derives `done_count` from `len(nodepack_result)`, so the
line **after** the broadcast is what makes total/done/in_progress all read 0.
The reporter's "empty idle queue" is produced *by the task finishing*, and it
looks identical whether the task succeeded or failed. No later HTTP read can
recover the outcome.

So the broadcast is the only statement of the outcome that ever exists — and a
panel living in the ComfyUI page is already a client of it. `send_sync` with no
`sid` goes to every connected client, and ComfyUI-Manager's own UI reads it the
same way (`api.addEventListener("cm-queue-status", …)` in
`js/custom-nodes-manager.js`). ComfyUI's frontend dispatches an unknown socket
type only to listeners that registered for it (`_registered.has(t.type)` guards
the `default:` arm of its socket handler), which is what makes the subscription
load-bearing rather than decorative.

## What this does

- **Subscribe at panel load** (`setupListeners`, in its own try so a diagnostic
  capture can never preempt the backend-down/reconnect listeners it sits above)
  and keep what the frame says in a bounded, insertion-ordered log.
- **`verifyInstalled` passes it as `capturedFailure`**, correlated by the `ui_id`
  *this* command submitted. It feeds `classifyInstallOutcome`'s existing
  `taskFailure` branch, so no new verdict logic: the reported install now fails
  with the Manager's own words — `Cannot resolve install target:
  'comfyui-reactor@latest'` — instead of reporting pending.
- **`nodes_queue_status` lists captured failures**, and stops returning a bare
  `{status}` that a build with no history cannot be distinguished from a v4 with
  nothing to report. `failure_reporting` is now `complete` / `partial` /
  `unavailable`, and an unreadable history says so rather than reading as a
  clean queue.
- A later **success for the same pack retires** the earlier failure, and captures
  **age out** (30 min) of the poll surface, so a defeat that has been undone is
  not re-reported.

Additive in both directions: a build that never emits the frame reads exactly as
it does on main today, and the capture can only ever *add* a positive failure —
`queueEventFailureReason` returns null for anything it cannot read.

## Proof

`npm run test:unit` — **4552 pass, 0 fail** (27 new, in
`browser_tests/unit/manager-task-broadcast.test.mjs`). The install/verify tests
drive the **real extracted `waitForQueueDrain` + `verifyInstalled` +
`nodes_queue_status`** from the panel source, not helper copies.

Three mutations, each killed:

| deleted | fails |
|---|---|
| `capturedFailure:` in `verifyInstalled` | 3 tests |
| `subscribeManagerTaskResults()` in `setupListeners` | 1 test |
| `managerTaskResults.note(ui_id, …)` in `nodes_install` | 1 test |

There is also a permanent negative control in the suite: *"WITHOUT the capture
the same install is only 'unverified' (the bug)"* runs the same legacy scenario
against an empty log and asserts the pre-fix verdict.

## Not verified here

The chain is read from source at every link — Manager 3.41's worker, ComfyUI's
`send_sync` broadcast, the frontend's `_registered` dispatch guard — but **not
run end-to-end on a live legacy ComfyUI**: no instance was running for this
session and this run was not allocated one. If the frame never arrives, the
behaviour degrades to main's, plus the honest `failure_reporting: unavailable`
note. A live legacy install of a bogus id is the check that would close that gap.

> Codex gate: **INDETERMINATE** — the codex account's usage limit is exhausted
> until Aug 19. Per autopilot rules an indeterminate gate is not a pass, so this
> is **held, not merged**.
