### PR TITLE
fix(1539): a Manager task that terminally errored is not a queued install

### DIFF
--- a/browser_tests/unit/install-terminal-failure.test.mjs
+++ b/browser_tests/unit/install-terminal-failure.test.mjs
@@ -1,0 +1,380 @@
+// artokun/comfyui-mcp#1539 — `panel_install_node` returned `queued: true,
+// pending: true` for an install the Manager had already REJECTED.
+//
+// The reporter passed a git URL for an unlisted pack. Manager v4 resolves the
+// install by `id` against its registry even when `repository` is supplied and
+// `selected_version` is `nightly`, so it failed the task with:
+//
+//   Node 'comfyui-anima-ipadapter@nightly' not found in
+//   [ManagerChannel.dev, ManagerDatabaseSource.cache]
+//
+// That is UPSTREAM and the request we send is correct — both settled by a live
+// probe against ComfyUI-Manager V4.2.2 (see the issue thread). What was OURS is
+// that the failure was invisible to the caller: verifyInstalled resolved the
+// outcome from queue-drain + the installed-nodes list ONLY, and never read the
+// per-task history record where the Manager had written the error.
+//
+// Worse, for this exact input the list-based path can never conclude "failed":
+// a git URL is `renameProne`, which suppresses the queueFailureSignal branch
+// (a git pack may install under a directory name the match cannot see, so
+// absence is not proof). So the honest-but-useless "unverified" was the ONLY
+// reachable verdict for a git URL, however loudly the Manager had failed it.
+//
+// The per-task poll #364 added lives on the UPDATE path and was never wired into
+// install. These tests pin the read, its correlation by ui_id, its dialect
+// scoping, and — most importantly — that install actually REACHES it.
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import * as ManagerInstall from "../../web/js/lib/manager-install.js";
+const { classifyInstallOutcome, taskFailureReason, parseTaskHistoryItem, queueDrained } =
+  ManagerInstall;
+
+// The reporter's error, verbatim from the live V4.2.2 probe.
+const REGISTRY_MISS =
+  "Node 'comfyui-anima-ipadapter@nightly' not found in " +
+  "[ManagerChannel.dev, ManagerDatabaseSource.cache]";
+
+const GIT_URL = "https://github.com/Wenaka2004/comfyui-anima-ipadapter";
+const TARGET = "comfyui-anima-ipadapter"; // gitRepoName(GIT_URL) — what we send as `id`
+const UI_ID = "u-1539";
+
+/** The record the v4 worker writes for a registry-lookup rejection: status_str
+ *  "error" with the message, under the ui_id we submitted. Shape mirrors the
+ *  live records already pinned by manager-update-verify.test.mjs. */
+const FAILED_ITEM = {
+  ui_id: UI_ID,
+  client_id: "comfyui-mcp-panel",
+  kind: "install",
+  result: "Exception: ('install', QueueTaskItem(...))",
+  status: { status_str: "error", completed: true, messages: [REGISTRY_MISS] },
+  params: { id: TARGET, selected_version: "nightly", repository: GIT_URL },
+};
+
+const SUCCESS_ITEM = {
+  ui_id: UI_ID,
+  kind: "install",
+  result: "success",
+  status: { status_str: "success", completed: true, messages: [] },
+  params: { id: TARGET },
+};
+
+const DRAINED = { total_count: 1, done_count: 1, is_processing: false };
+const BUSY = { total_count: 2, done_count: 1, is_processing: true };
+// The pack is NOT in the installed list — the install never happened.
+const INSTALLED_LIST = { "some-other-pack": { ver: "1.0", cnr_id: "some-other-pack" } };
+
+// ---------------------------------------------------------------------------
+// Real-source harness: the ACTUAL waitForQueueDrain + verifyInstalled, extracted
+// from comfyui-mcp-panel.js and run against a stubbed Manager. Driving the real
+// source is the point: a helper-only test would pass just as happily with the
+// call site never passing ui_id at all.
+// ---------------------------------------------------------------------------
+
+function readPanelSource() {
+  return readFileSync(
+    fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url)),
+    "utf8",
+  );
+}
+
+function pick(src, re, name) {
+  const m = src.match(re);
+  assert.ok(m, `could not locate ${name} in panel source`);
+  return m[0];
+}
+
+/**
+ * `routes` maps a route PREFIX to a handler (or throws). Every GET the verifier
+ * makes is recorded in `calls` so the dialect-scoping tests can assert that a
+ * route was never touched.
+ */
+function buildVerifyInstalled({ routes, calls = [], budgetMs }) {
+  const src = readPanelSource();
+  const get = async (route) => {
+    calls.push(route);
+    for (const [prefix, handler] of Object.entries(routes)) {
+      if (route.startsWith(prefix)) {
+        const out = typeof handler === "function" ? handler(route) : handler;
+        if (out instanceof Error) throw out;
+        return out;
+      }
+    }
+    throw new Error(`unstubbed route: ${route}`);
+  };
+  const deps = {
+    managerGet: get,
+    managerV2: get,
+    managerCall: get,
+    queueDrained,
+    taskFailureReason,
+    parseTaskHistoryItem,
+    classifyInstallOutcome,
+    MANAGER_FETCH_TIMEOUT_MS: 15000,
+    INSTALL_VERIFY_BUDGET_MS: budgetMs ?? 4000,
+    AbortSignal,
+    setTimeout,
+  };
+  const factory = new Function(
+    ...Object.keys(deps),
+    `${pick(src, /function boundedDelay\(ms, deadline\) \{[\s\S]*?\n\}/, "boundedDelay")}
+${pick(src, /async function waitForQueueDrain\(\{[\s\S]*?\n\}/, "waitForQueueDrain")}
+${pick(src, /async function verifyInstalled\(target, dialect, \{[\s\S]*?\n\}/, "verifyInstalled")}
+return { verifyInstalled, waitForQueueDrain };`,
+  );
+  return factory(...Object.values(deps));
+}
+
+// ---------------------------------------------------------------------------
+// The reported case, through the real verifier
+// ---------------------------------------------------------------------------
+
+test("#1539: a v4 task that terminally errored is FAILED, not queued-and-pending", async () => {
+  const calls = [];
+  const { verifyInstalled } = buildVerifyInstalled({
+    calls,
+    routes: {
+      "manager/queue/history": { history: FAILED_ITEM },
+      "manager/queue/status": DRAINED,
+      "customnode/installed": INSTALLED_LIST,
+    },
+  });
+
+  const outcome = await verifyInstalled(TARGET, "v2", {
+    renameProne: true, // a git URL — the case the list-based path can never fail
+    budgetMs: 4000,
+    ui_id: UI_ID,
+  });
+
+  // BEFORE the fix this was state "unverified" with "was queued but could NOT be
+  // confirmed installed", which the panel returns as queued:true / pending:true —
+  // exactly what the reporter saw and reasonably read as success.
+  assert.equal(outcome.state, "failed", "the Manager's own terminal record says failed");
+  assert.match(outcome.message, /install FAILED/);
+  assert.ok(
+    outcome.message.includes(REGISTRY_MISS),
+    "the caller gets the Manager's REAL reason, not a bare status",
+  );
+  assert.doesNotMatch(
+    outcome.message,
+    /could NOT be confirmed/,
+    "must not also hedge — this is a positive failure verdict",
+  );
+});
+
+test("#1539: the registry-miss reply names the workaround that actually works (#920)", async () => {
+  const { verifyInstalled } = buildVerifyInstalled({
+    routes: {
+      "manager/queue/history": { history: FAILED_ITEM },
+      "manager/queue/status": DRAINED,
+      "customnode/installed": INSTALLED_LIST,
+    },
+  });
+  const outcome = await verifyInstalled(TARGET, "v2", {
+    renameProne: true,
+    budgetMs: 4000,
+    ui_id: UI_ID,
+  });
+  // The reporter verified this workaround themselves. Attaching it to the install
+  // reply means the caller does not have to know to poll for the advice.
+  assert.match(outcome.message, /install_custom_node/);
+  assert.match(outcome.message, /NODE REGISTRY lookup/);
+});
+
+test("#1539: a terminal failure ends the wait even if the queue never drains", async () => {
+  // A neighbouring task can keep the queue busy indefinitely. Gating the failure
+  // read on drain would make the verdict hostage to unrelated work — and on a
+  // short budget would report pending for an install that already failed.
+  const calls = [];
+  const { verifyInstalled } = buildVerifyInstalled({
+    calls,
+    routes: {
+      "manager/queue/history": { history: FAILED_ITEM },
+      "manager/queue/status": BUSY, // never drains
+      "customnode/installed": INSTALLED_LIST,
+    },
+  });
+  const started = Date.now();
+  const outcome = await verifyInstalled(TARGET, "v2", {
+    renameProne: true,
+    budgetMs: 8000,
+    ui_id: UI_ID,
+  });
+  assert.equal(outcome.state, "failed");
+  assert.ok(
+    Date.now() - started < 6000,
+    "must return on the terminal record, not burn the whole budget",
+  );
+  assert.ok(
+    !calls.some((r) => r.startsWith("customnode/installed")),
+    "a settled verdict should not spend budget on evidence that cannot change it",
+  );
+});
+
+// ---------------------------------------------------------------------------
+// The read must not INVENT failures
+// ---------------------------------------------------------------------------
+
+test("#1539: another task's failure is NEVER attributed to this install", async () => {
+  // The map-shaped history carries every recent task. Correlating by the ui_id we
+  // submitted is what keeps a neighbouring pack's crash from failing our install.
+  const { verifyInstalled } = buildVerifyInstalled({
+    routes: {
+      "manager/queue/history": {
+        history: { "someone-elses-task": { ...FAILED_ITEM, ui_id: "someone-elses-task" } },
+      },
+      "manager/queue/status": DRAINED,
+      "customnode/installed": INSTALLED_LIST,
+    },
+  });
+  const outcome = await verifyInstalled(TARGET, "v2", {
+    renameProne: true,
+    budgetMs: 4000,
+    ui_id: UI_ID,
+  });
+  assert.equal(outcome.state, "unverified", "not our task — no verdict borrowed from it");
+});
+
+test("#1539: a task that SUCCEEDED still reports installed (no downgrade)", async () => {
+  const { verifyInstalled } = buildVerifyInstalled({
+    routes: {
+      "manager/queue/history": { history: SUCCESS_ITEM },
+      "manager/queue/status": DRAINED,
+      "customnode/installed": { [TARGET]: { ver: "1.0", cnr_id: TARGET } },
+    },
+  });
+  const outcome = await verifyInstalled(TARGET, "v2", {
+    renameProne: true,
+    budgetMs: 4000,
+    ui_id: UI_ID,
+  });
+  assert.equal(outcome.state, "installed");
+});
+
+test("#1539: an absent/erroring history endpoint degrades to today's behaviour", async () => {
+  // Best-effort in both directions. A Manager that 404s the history route must
+  // land on exactly the pre-fix verdict, never a failure invented from a fetch
+  // error.
+  for (const history of [new Error("HTTP 404"), {}, { history: null }, "junk"]) {
+    const { verifyInstalled } = buildVerifyInstalled({
+      routes: {
+        "manager/queue/history": history,
+        "manager/queue/status": DRAINED,
+        "customnode/installed": INSTALLED_LIST,
+      },
+    });
+    const outcome = await verifyInstalled(TARGET, "v2", {
+      renameProne: true,
+      budgetMs: 4000,
+      ui_id: UI_ID,
+    });
+    assert.equal(outcome.state, "unverified", `history=${JSON.stringify(history)}`);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Dialect scoping — the record only exists on the real pip v4 ("v2")
+// ---------------------------------------------------------------------------
+
+test("#1539: legacy and v2-batch never poll a per-task history that cannot serve them", async () => {
+  // Released 3.x has no per-task history route; the bundled 3.x server serves
+  // BATCH history keyed by id and rejects a ui_id query. Polling either would
+  // burn the command budget and learn nothing. (Legacy's blind spot is #1606 —
+  // a different problem: there is no record to read at all.)
+  for (const dialect of ["legacy", "v2-batch"]) {
+    const calls = [];
+    const { verifyInstalled } = buildVerifyInstalled({
+      calls,
+      routes: {
+        "manager/queue/status": DRAINED,
+        "customnode/installed": INSTALLED_LIST,
+      },
+    });
+    const outcome = await verifyInstalled(TARGET, dialect, {
+      renameProne: true,
+      budgetMs: 4000,
+      ui_id: UI_ID,
+    });
+    assert.ok(
+      !calls.some((r) => r.startsWith("manager/queue/history")),
+      `${dialect} must not poll per-task history`,
+    );
+    assert.equal(outcome.state, "unverified", `${dialect} keeps its existing verdict`);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// REACHABILITY — the call site, not just the mechanism
+// ---------------------------------------------------------------------------
+
+test("#1539: nodes_install THREADS its ui_id into verifyInstalled", () => {
+  // Without this the whole read above is dead code: verifyInstalled defaults
+  // ui_id to undefined and silently falls back to drain + name-presence. A
+  // helper-level test cannot see that, which is exactly how a one-line wiring
+  // change ships broken.
+  const src = readPanelSource();
+  const method = pick(src, /async nodes_install\(args\) \{[\s\S]*?\n  \},\r?\n/, "nodes_install");
+  const call = pick(method, /verifyInstalled\([\s\S]*?\);/, "the verifyInstalled call");
+  assert.match(call, /\bui_id\b/, "nodes_install must pass ui_id to verifyInstalled");
+});
+
+test("#1539: the ui_id passed to the Manager is the one the history is polled under", async () => {
+  // Correlation is only worth anything if BOTH sides use the same id. Assert the
+  // history route actually carries it rather than trusting the plumbing.
+  const calls = [];
+  const { verifyInstalled } = buildVerifyInstalled({
+    calls,
+    routes: {
+      "manager/queue/history": { history: FAILED_ITEM },
+      "manager/queue/status": DRAINED,
+      "customnode/installed": INSTALLED_LIST,
+    },
+  });
+  await verifyInstalled(TARGET, "v2", { renameProne: true, budgetMs: 4000, ui_id: UI_ID });
+  assert.ok(
+    calls.some((r) => r === `manager/queue/history?ui_id=${UI_ID}`),
+    `history must be queried for our ui_id; saw ${JSON.stringify(calls)}`,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// The pure classifier
+// ---------------------------------------------------------------------------
+
+test("#1539: classifyInstallOutcome ranks a terminal record above every proxy", () => {
+  // Not drained: a terminal record is conclusive regardless of queue state.
+  assert.equal(
+    classifyInstallOutcome({
+      target: TARGET, dialect: "v2", status: BUSY, installed: INSTALLED_LIST,
+      renameProne: true, taskFailure: REGISTRY_MISS,
+    }).state,
+    "failed",
+  );
+  // Even a name-match "present" does not outrank OUR task's own error — the dir
+  // may predate this install, the record cannot.
+  assert.equal(
+    classifyInstallOutcome({
+      target: TARGET, dialect: "v2", status: DRAINED,
+      installed: { [TARGET]: { ver: "1.0", cnr_id: TARGET } },
+      renameProne: true, taskFailure: REGISTRY_MISS,
+    }).state,
+    "failed",
+  );
+  // Absent → every pre-existing verdict is untouched.
+  assert.equal(
+    classifyInstallOutcome({
+      target: TARGET, dialect: "v2", status: DRAINED, installed: INSTALLED_LIST,
+      renameProne: true,
+    }).state,
+    "unverified",
+  );
+  assert.equal(
+    classifyInstallOutcome({
+      target: TARGET, dialect: "v2", status: DRAINED,
+      installed: { [TARGET]: { ver: "1.0", cnr_id: TARGET } },
+    }).state,
+    "installed",
+  );
+});

--- a/browser_tests/unit/manager-install.test.mjs
+++ b/browser_tests/unit/manager-install.test.mjs
@@ -619,12 +619,34 @@ test("waitForQueueDrain (real panel source) returns a drained status without Ref
     "MANAGER_FETCH_TIMEOUT_MS",
     "boundedDelay",
     "AbortSignal",
+    // #1539 — the per-task read closes over these two. This call passes no ui_id
+    // so they are never evaluated, but binding them keeps the extraction honest:
+    // without them a future ui_id case here would fail as a harness gap rather
+    // than as the product behaviour under test.
+    "taskFailureReason",
+    "parseTaskHistoryItem",
     `${fnMatch[0]}\nreturn waitForQueueDrain;`,
   );
-  const realWait = factory(queueDrained, managerGet, MANAGER_FETCH_TIMEOUT_MS, boundedDelay, AbortSignal);
+  const realWait = factory(
+    queueDrained,
+    managerGet,
+    MANAGER_FETCH_TIMEOUT_MS,
+    boundedDelay,
+    AbortSignal,
+    ManagerInstall.taskFailureReason,
+    ManagerInstall.parseTaskHistoryItem,
+  );
 
-  const status = await realWait({ timeoutMs: 5000, intervalMs: 10 });
+  // #1539 — the drain wait now reports { status, taskFailure } rather than a bare
+  // status: the aggregate status cannot express "this task errored", so the
+  // per-task verdict rides alongside it.
+  const { status, taskFailure } = await realWait({ timeoutMs: 5000, intervalMs: 10 });
   assert.equal(queueDrained(status), true, "should return a positively-drained status");
+  assert.equal(
+    taskFailure,
+    null,
+    "no ui_id was passed, so no per-task record was read — and none may be invented",
+  );
   assert.ok(polls >= 2, "should have polled until drained");
   // The delays are now observable rather than merely endured, so the loop's own
   // pacing is asserted instead of being taken on trust: a warm-up before the first
@@ -765,8 +787,13 @@ test("#671 nodes_install threads ONE sub-30s command budget through every phase 
   // fixed budget that could stack past the relay window on top of slow calls.
   assert.match(
     body,
-    /verifyInstalled\(target, dialect, \{\s*batchFailed, renameProne, budgetMs: remaining\(\)\s*\}\)/,
-    "verifyInstalled must receive the remaining command budget",
+    /verifyInstalled\(target, dialect, \{\s*batchFailed, renameProne, budgetMs: remaining\(\), ui_id,\s*\}\)/,
+    // #1539 added ui_id to this call. Pinned in the SAME assertion rather than a
+    // looser regex: budgetMs threading (#671) and ui_id threading (#1539) are
+    // both one-line properties of this one call, and both die silently if
+    // dropped — the budget by stacking past the relay window, the ui_id by
+    // reporting a rejected install as queued/pending.
+    "verifyInstalled must receive the remaining command budget AND the task ui_id",
   );
   // A budget-exhausted stall is reworded per phase, never reported raw.
   assert.match(body, /translateStall\(err, phase\)/, "stalls past the budget must be translated");

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -6102,27 +6102,63 @@ function boundedDelay(ms, deadline) {
  *  from it via queueDrained, so a null/malformed status is never a false drain
  *  (codex round 2 #1). `get` defaults to the dialect-routed managerGet; the
  *  install verifier passes a dialect-PINNED getter so a post-#485-fallback verify
- *  reads the SAME routes the install actually landed on (codex P1). */
-async function waitForQueueDrain({ timeoutMs = 120000, intervalMs = 1500, get = managerGet } = {}) {
+ *  reads the SAME routes the install actually landed on (codex P1).
+ *
+ *  #1539 — when `ui_id` is passed, each poll ALSO reads the per-task history
+ *  record for THAT id, and a terminal FAILURE ends the wait immediately. The
+ *  aggregate status cannot express "this task errored" (a failed task still
+ *  counts toward done_count and the queue simply drains), so without this read
+ *  the only failure evidence install ever had was the pack's absence by name —
+ *  which is suppressed for exactly the reporting case (see classifyInstallOutcome
+ *  `renameProne`). Correlated by the ui_id THIS command submitted, so a
+ *  neighbouring task's failure can never be attributed to it.
+ *
+ *  Returns { status, taskFailure } — taskFailure is the Manager's own reason
+ *  string, or null when there is no positive failure record (absent, unreadable
+ *  or not-yet-terminal all stay null, never a verdict). */
+async function waitForQueueDrain({ timeoutMs = 120000, intervalMs = 1500, get = managerGet, ui_id } = {}) {
   const deadline = Date.now() + timeoutMs;
   let status = null;
+  // Cap an individual fetch by whatever budget remains.
+  const perFetch = () => Math.max(1000, Math.min(MANAGER_FETCH_TIMEOUT_MS, deadline - Date.now()));
+  // #1539 — OUR task's terminal record. Best-effort in BOTH directions: a
+  // missing route (legacy), a transient error, or an unrecognized shape all
+  // return null, so this can only ever ADD a positive failure verdict — it can
+  // never manufacture one, and never downgrades a success.
+  const readTaskFailure = async () => {
+    if (!ui_id) return null;
+    try {
+      const resp = await get(`manager/queue/history?ui_id=${encodeURIComponent(ui_id)}`, {
+        signal: AbortSignal.timeout(perFetch()),
+      });
+      return taskFailureReason(parseTaskHistoryItem(resp, ui_id));
+    } catch {
+      return null;
+    }
+  };
   // Give the queue a beat to register the task before the first poll, so we
   // don't read a stale is_processing=false from before queue/start.
   await boundedDelay(1000, deadline);
   while (Date.now() < deadline) {
-    // Cap this individual fetch by whatever budget remains.
-    const perFetch = Math.max(1000, Math.min(MANAGER_FETCH_TIMEOUT_MS, deadline - Date.now()));
+    const failed = await readTaskFailure();
+    if (failed) return { status, taskFailure: failed };
     try {
       status = await get("manager/queue/status", {
-        signal: AbortSignal.timeout(perFetch),
+        signal: AbortSignal.timeout(perFetch()),
       });
     } catch {
-      return status; // unreadable/aborted — inconclusive (not drained)
+      return { status, taskFailure: null }; // unreadable/aborted — inconclusive (not drained)
     }
-    if (queueDrained(status)) return status;
+    if (queueDrained(status)) {
+      // The worker writes its terminal record and THEN the queue reports drained,
+      // so the failure can land between the two reads above. One last look before
+      // giving up on it — otherwise the very case this exists for (a fast registry
+      // rejection) races past and still reports pending.
+      return { status, taskFailure: await readTaskFailure() };
+    }
     await boundedDelay(intervalMs, deadline);
   }
-  return status; // deadline hit
+  return { status, taskFailure: null }; // deadline hit
 }
 
 /** Default budget for the post-enqueue install verification (#671), used only
@@ -6155,7 +6191,7 @@ const INSTALL_VERIFY_BUDGET_MS = 15000;
  * defaulting to INSTALL_VERIFY_BUDGET_MS), or the reply — success or honest
  * "pending" — never reaches the caller.
  */
-async function verifyInstalled(target, dialect, { batchFailed, renameProne, budgetMs } = {}) {
+async function verifyInstalled(target, dialect, { batchFailed, renameProne, budgetMs, ui_id } = {}) {
   // Pin the status/list reads to the dialect the install ACTUALLY landed on. In
   // the normal case this equals managerGet's cached detection; after the #485
   // legacy fallback the cache still holds the detected v2 dialect, so re-deriving
@@ -6166,19 +6202,42 @@ async function verifyInstalled(target, dialect, { batchFailed, renameProne, budg
     dialect === "legacy" ? managerCall(route, opts) : managerV2(route, opts);
   const budget = Math.max(0, budgetMs ?? INSTALL_VERIFY_BUDGET_MS);
   const deadline = Date.now() + budget;
-  const status = await waitForQueueDrain({ timeoutMs: budget, get });
+  // #1539 — the per-task terminal record is only reachable on the real pip
+  // Manager v4 (the "v2" dialect), whose /v2/manager/queue/history?ui_id=
+  // returns the task by id. This is the SAME dialect scoping #364 applies to the
+  // update path, and for the same reasons: released 3.x ("legacy") has no
+  // per-task history endpoint at all, and the bundled 3.x server used in
+  // --enable-manager-legacy-ui mode ("v2-batch") serves only BATCH history keyed
+  // by `id` and REJECTS a ui_id query — polling either would burn the command
+  // budget and still learn nothing. A v2-batch failure is already caught
+  // synchronously via its `failed[]` (→ batchFailed). Legacy's blind spot is
+  // artokun/comfyui-mcp#1606, a genuinely different problem: there is no record
+  // to read, whereas on v4 the record exists and we were simply not reading it.
+  const { status, taskFailure } = await waitForQueueDrain({
+    timeoutMs: budget,
+    get,
+    ui_id: dialect === "v2" ? ui_id : undefined,
+  });
   let installed = null;
   let listError = false;
-  try {
-    installed = await get("customnode/installed", {
-      signal: AbortSignal.timeout(
-        Math.max(1000, Math.min(MANAGER_FETCH_TIMEOUT_MS, deadline - Date.now())),
-      ),
-    });
-  } catch {
-    listError = true;
+  // A terminal failure record already settles the outcome, so skip the list read
+  // rather than spend budget on evidence that cannot change the verdict. Leaving
+  // `installed` null is the SAFE default if that verdict ever stops winning:
+  // an unreadable list classifies as "unverified", never as a false success.
+  if (!taskFailure) {
+    try {
+      installed = await get("customnode/installed", {
+        signal: AbortSignal.timeout(
+          Math.max(1000, Math.min(MANAGER_FETCH_TIMEOUT_MS, deadline - Date.now())),
+        ),
+      });
+    } catch {
+      listError = true;
+    }
   }
-  return classifyInstallOutcome({ target, dialect, status, installed, listError, batchFailed, renameProne });
+  return classifyInstallOutcome({
+    target, dialect, status, installed, listError, batchFailed, renameProne, taskFailure,
+  });
 }
 
 /** Budget for the post-enqueue update verification (#364). Bounded well under
@@ -17355,7 +17414,12 @@ const GRAPH_TOOL_EXECUTORS = {
       // success, never a false failure). #232 + codex rounds 1-2. The verify
       // draws on whatever the command budget has LEFT (#671).
       phase = "verify";
-      const outcome = await verifyInstalled(target, dialect, { batchFailed, renameProne, budgetMs: remaining() });
+      // #1539 — `ui_id` is what makes the Manager's own terminal verdict for THIS
+      // task readable. Without it the verifier is back to drain + name-presence,
+      // and a v4 registry rejection of a git URL reports queued/pending.
+      const outcome = await verifyInstalled(target, dialect, {
+        batchFailed, renameProne, budgetMs: remaining(), ui_id,
+      });
       if (outcome.state === "failed") throw new Error(outcome.message);
       if (outcome.state === "installed") {
         return {

--- a/web/js/lib/manager-install.js
+++ b/web/js/lib/manager-install.js
@@ -324,7 +324,39 @@ export function classifyInstallOutcome({
   listError = false,
   batchFailed,
   renameProne = false,
+  taskFailure = null,
 }) {
+  // #1539 — the Manager's OWN terminal verdict for the task we submitted (keyed
+  // by our ui_id) outranks every proxy below, and is checked before the
+  // not-drained early return: a terminal record is conclusive whether or not the
+  // queue has drained (a neighbouring task can keep it busy indefinitely).
+  //
+  // Everything below is a proxy — "the queue drained and the pack is not there".
+  // For a git URL those proxies can NEVER conclude failure, because renameProne
+  // suppresses the queueFailureSignal branch (a git pack may install under a
+  // directory the name-match cannot see, so absence is not proof). That is
+  // exactly the reported bug: v4 rejects an unlisted repo by REGISTRY LOOKUP —
+  // `Node '<name>@nightly' not found in [ManagerChannel.dev,
+  // ManagerDatabaseSource.cache]` — records the error, drains, and the install
+  // reported `queued: true, pending: true`. The record said "failed" the whole
+  // time; nothing read it.
+  if (taskFailure) {
+    return {
+      state: "failed",
+      status,
+      message:
+        `"${target}" install FAILED: the ComfyUI-Manager task terminated with an error` +
+        (dialect ? ` (dialect ${dialect})` : "") +
+        `: ${taskFailure}. The install did NOT complete — check the ComfyUI server log ` +
+        `for the full traceback.` +
+        // The registry-miss case has a specific, verified way forward (#920), and
+        // it is worth far more HERE than on a later poll: this is the reply to the
+        // install call itself, so the caller learns it without having to know to
+        // ask again. Empty for every other failure.
+        unlistedGitUrlAdvice(taskFailure),
+    };
+  }
+
   const drained = queueDrained(status);
   const listReadable = !listError && isReadableInstalledList(installed);
 


### PR DESCRIPTION
Fixes the still-live half of artokun/comfyui-mcp#1539.

## What was already settled (and is NOT what this changes)

A live probe against **ComfyUI-Manager V4.2.2** established that v4 resolves an install by `id` against its registry *even when* `repository` is supplied and `selected_version` is `nightly` — the exact case its own schema documents as "repository required if selected_version is nightly". An unlisted git URL fails with:

```
Node '<name>@nightly' not found in [ManagerChannel.dev, ManagerDatabaseSource.cache]
```

The request we send is correct, the limitation is upstream, and mcp 0.51.46 already narrowed the tool description to stop promising a git URL installs.

## What was still ours

The other half of the report: *"Do not return queued success for a registry lookup that cannot accept the URL."*

The Manager records that error in its per-task history. **Nothing on the install path ever read it.** `verifyInstalled` resolved the outcome from queue-drain + the installed-nodes list only — and for this input those proxies can *never* conclude failure, because a git URL is `renameProne`, which suppresses the `queueFailureSignal` branch (a git pack may install under a directory the name-match cannot see, so absence is not proof).

So `unverified` was the **only reachable verdict** for a git URL, however loudly the Manager had failed it. The caller got `queued: true, pending: true` and had to poll to discover the rejection — exactly what the reporter saw.

The per-task poll #364 added lives on the **update** path. Install never got it.

## The change

- `waitForQueueDrain` takes a `ui_id` and reads that task's history record each poll, returning `{ status, taskFailure }`. A terminal failure ends the wait immediately, so the verdict isn't hostage to a queue another task keeps busy. One last read after a positive drain catches the record landing between the two reads.
- `classifyInstallOutcome` ranks that record above every proxy **and above the not-drained early return**. That position is load-bearing: the early-exit path returns before any status read, so demoting the guard flips the reported case straight back to `unverified`.
- The reply carries the Manager's real reason plus, for a registry miss, the #920 advice naming `install_custom_node` — the workaround the reporter verified — at the install call rather than only on a later poll.

Scoped to the `v2` dialect (same scoping #364 uses): released 3.x has no per-task history route, and the bundled 3.x server serves batch history keyed by `id` and rejects a ui_id query. Legacy's blind spot is artokun/comfyui-mcp#1606 — a genuinely different problem, where **no record exists to read at all**.

Best-effort in both directions: an absent route, transient error or unrecognized shape all yield null, so this can only ever *add* a positive failure verdict — never manufacture one, never downgrade a success. Correlated by the ui_id this command submitted, so a neighbour's failure is never attributed to this install.

## Verification

Proved by **deleting the fix**, not by green tests:

| mutation | result |
|---|---|
| revert both source files to `origin/main` | **6 of 10** new tests fail |
| remove the single `ui_id` argument at the call site | **2** tests fail (incl. the #671 wiring pin) |
| demote the `taskFailure` guard below the drain check | **4** tests fail |

The 4 that pass either way are the no-false-failure and dialect-scoping fences — they assert behaviour is *unchanged*, so passing both ways is correct for them.

Full suite: **4509 tests, 0 failures**, `check-panel-scope` and `check-tool-vocabulary` OK.

Two existing assertions pinned the old call shape and drain return; both updated to the new contract with intent preserved and **strengthened** — the #671 budget regex now pins `ui_id` alongside `budgetMs: remaining()`.

Codex gate: **SHIP**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)