### PR TITLE
release: v0.14.43 — an empty sidebar stops being silent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+## [0.14.43] - 2026-08-15
+
+### Fixed
+- a sidebar tab that is SELECTED but never paints now says so, once, with what was observed — the panel used to just look empty, with no way to tell a broken extension from a frontend that dropped the tab (#779)
+- the conversation is always panel-owned: the workflow/ask chat scopes are retired, so a session can no longer be scoped to anything but the orchestrator (mcp#884)
+
+
 ## [0.14.42] - 2026-08-15
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-agent-panel"
 description = "Autonomous AI agent in the ComfyUI sidebar - local-first, bring any LLM. Run it on your Claude or ChatGPT subscription (no API keys, no extra LLM costs), on a Kimi K3 / GLM / OpenRouter key, or fully offline on free local models via Ollama, LM Studio, or llama.cpp. The agent drives your live canvas at full parity: add, wire, move and tweak nodes with Ctrl+Z undo, load whole workflows and installer packs in one shot, generate images, video and audio, browse CivitAI, and run your workflow - asking before it spends paid API credits. The sidebar UI for comfyui-mcp, the local-first, agent-native control plane for ComfyUI. The panel speaks 12 languages, matching your ComfyUI language automatically: English, 한국어, 日本語, 中文 (简体), 中文 (繁體), Русский, Français, Español, Português (BR), Türkçe, العربية, فارسی."
-version = "0.14.42"
+version = "0.14.43"
 license = { file = "LICENSE" }
 requires-python = ">=3.9"
 # UI-only pack: no Python deps. The frontend floor guarantees

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -1530,7 +1530,7 @@ const DOCS_URL = "https://comfyui-mcp.artokun.io/docs";
 // Panel version — surfaced in the "Need help?" diagnostics blob. Bump via
 // `node scripts/set-version.mjs <v>` (updates this AND pyproject together); CI
 // and the publish gate FAIL if the two ever drift, so this can't go stale.
-const PANEL_VERSION = "0.14.42";
+const PANEL_VERSION = "0.14.43";
 
 // The connected orchestrator's console URL/token (captured off the `backends`
 // bridge message — see onBackends). Drives the "API Keys" credentials frame;


### PR DESCRIPTION
Release cut carrying artokun/comfyui-mcp-panel#779 (PR #804) and the chat-scope retirement (PR #680).

**#779** — a selected sidebar tab whose content never paints now says so once, with what was observed. The detector watches the **document**, not the rail: ComfyUI destroys and recreates that rail on focus / linear / builder transitions (verified `v-if`-gated on 1.47.12, 1.48.7, 1.50.3, 1.51.5; linear mode mounts a second instance), so a rail-pinned observer went deaf after any of them — the exact silence the watchdog exists to break. A pre-merge review caught that; the fix was re-reviewed and cleared.

**#680** — the conversation is always panel-owned; the workflow/ask chat scopes are retired, so a session cannot be scoped to anything but the orchestrator.

Suite green at 4444. The one failure in the full run was the known `manager-install` wall-clock flake under load — 122/122 in isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)