### PR TITLE
fix(1088): a multi-word panel_search_nodes query finds the pack it names

### DIFF
--- a/browser_tests/unit/nodes-search-multi-word.test.mjs
+++ b/browser_tests/unit/nodes-search-multi-word.test.mjs
@@ -1,0 +1,118 @@
+/**
+ * #1088 — `panel_search_nodes` matched the query as ONE contiguous substring, so any
+ * multi-word query returned zero against a catalogue that plainly contains the pack.
+ *
+ * MEASURED against the reporter's own three packs (they saw 14 hits for "overlay",
+ * these are the three they named), on the map shape Manager serves:
+ *
+ *   "overlay"             -> 3   comfyui-textoverlay, ComfyUI-text-overlay, advanced-textoverlay
+ *   "text overlay"        -> 0
+ *   "Simple Text Overlay" -> 0
+ *
+ * The reason is entirely in the SEPARATOR. Pack identity lives in the repo name, which
+ * spells the same words `textoverlay` or `text-overlay`; a human types `text overlay`.
+ * `hay.includes("text overlay")` is false for both spellings, so a real pack reports as
+ * absent — and with `catalogue_size: 5583` alongside it, a 0 reads as "this pack does not
+ * exist", which is exactly the conflation #808 exists to prevent. The reporter nearly
+ * installed the wrong pack on the strength of it.
+ *
+ * THE MATCHER IS A SUPERSET, NOT A REPLACEMENT (the property that makes this safe to
+ * ship): every term of a query that matched contiguously is still a substring of the same
+ * haystack, so nothing that matched before can stop matching. That is asserted below
+ * rather than argued, because "more permissive" is the kind of claim that is easy to state
+ * and easy to get wrong.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { parseNodeMappings, parseObjectInfoSearch } from "../../web/js/lib/manager-install.js";
+
+/**
+ * The reporter's packs, in Manager's documented MAP shape. Titles deliberately carry the
+ * REPO spelling rather than a friendly space-separated one — that is what the live
+ * catalogue serves for these three, and a helpful title would hide the whole defect.
+ */
+const CATALOGUE = {
+  "https://github.com/Munkyfoot/comfyui-textoverlay": [
+    [],
+    { title: "comfyui-textoverlay", description: "Adds a node to overlay text on an image" },
+  ],
+  "https://github.com/mbrostami/ComfyUI-text-overlay": [
+    [],
+    { title: "ComfyUI-text-overlay", description: "Overlay node" },
+  ],
+  "https://github.com/z/advanced-textoverlay": [
+    [],
+    { title: "advanced-textoverlay", description: "advanced overlay tools" },
+  ],
+  "https://github.com/y/comfyui-impact-pack": [[], { title: "Impact Pack", description: "detailer nodes" }],
+};
+
+const titles = (r) => r.results.map((x) => x.title).sort();
+
+test("#1088 a multi-word query finds the packs a single token already found", () => {
+  // The single token is the control: this is the search that worked, and it must keep
+  // working identically.
+  assert.equal(parseNodeMappings(CATALOGUE, "overlay", 15).count, 3);
+
+  const twoWords = parseNodeMappings(CATALOGUE, "text overlay", 15);
+  assert.equal(twoWords.count, 3, '"text overlay" must reach the same three packs');
+  assert.deepEqual(titles(twoWords), ["ComfyUI-text-overlay", "advanced-textoverlay", "comfyui-textoverlay"]);
+});
+
+test("#1088 every term must match — AND, not OR", () => {
+  // OR would be a worse bug than the one being fixed: "impact overlay" would return
+  // everything and the caller could not tell a real hit from noise.
+  assert.equal(parseNodeMappings(CATALOGUE, "impact overlay", 15).count, 0);
+  assert.deepEqual(titles(parseNodeMappings(CATALOGUE, "impact pack", 15)), ["Impact Pack"]);
+});
+
+test("#1088 terms match across the id, title and description together", () => {
+  // "advanced" is in the id/title, "tools" only in the description. A term-wise matcher
+  // that required all terms in ONE field would miss this.
+  assert.deepEqual(titles(parseNodeMappings(CATALOGUE, "advanced tools", 15)), ["advanced-textoverlay"]);
+});
+
+test("#1088 surrounding and repeated whitespace is not part of the query", () => {
+  // The old matcher looked for the literal "  overlay  " and found nothing — a query the
+  // caller cannot see is padded, e.g. one assembled from a template.
+  assert.equal(parseNodeMappings(CATALOGUE, "  overlay  ", 15).count, 3);
+  assert.equal(parseNodeMappings(CATALOGUE, "text\t\noverlay", 15).count, 3);
+  // Whitespace-only carries no terms, so it filters nothing — the same answer the empty
+  // query already gave, rather than the empty result the literal match produced.
+  assert.equal(parseNodeMappings(CATALOGUE, "   ", 15).count, 4);
+  assert.equal(parseNodeMappings(CATALOGUE, "", 15).count, 4);
+});
+
+test("#1088 the term matcher is a SUPERSET — no contiguous match is lost", () => {
+  // The safety property, asserted rather than asserted-in-prose. Every haystack that
+  // contained the query contiguously still contains each of its terms.
+  const contiguous = ["impact", "impact pack", "overlay", "comfyui-textoverlay", "text-overlay", "advanced overlay"];
+  for (const q of contiguous) {
+    const hits = parseNodeMappings(CATALOGUE, q, 15).count;
+    assert.ok(hits > 0, `"${q}" matched contiguously before and must still match`);
+  }
+});
+
+test("#1088 catalogue_size is still reported alongside a multi-word miss", () => {
+  // #808's discriminator must survive: a genuine no-match still has to be
+  // distinguishable from an empty catalogue.
+  const miss = parseNodeMappings(CATALOGUE, "definitely not here", 15);
+  assert.equal(miss.count, 0);
+  assert.equal(miss.catalogue_size, 4);
+});
+
+test("#1088 the installed-node fallback tokenises the same way", () => {
+  // #426's /object_info search is the route taken when Manager is unreachable. It had the
+  // identical contiguous match, so a multi-word query failed there too — and that is the
+  // path with NO catalogue_size to hint that the search itself was the problem.
+  const objectInfo = {
+    SimpleTextOverlay: { display_name: "Simple Text Overlay", category: "image/text", description: "overlay text" },
+    KSampler: { display_name: "KSampler", category: "sampling", description: "sample a latent" },
+  };
+  assert.equal(parseObjectInfoSearch(objectInfo, "simple overlay", 15).count, 1);
+  assert.equal(parseObjectInfoSearch(objectInfo, "overlay text", 15).count, 1);
+  assert.equal(parseObjectInfoSearch(objectInfo, "sample latent", 15).count, 1);
+  // AND still discriminates on this route too.
+  assert.equal(parseObjectInfoSearch(objectInfo, "overlay sampling", 15).count, 0);
+});

--- a/web/js/lib/manager-install.js
+++ b/web/js/lib/manager-install.js
@@ -526,6 +526,54 @@ export function dialectRetryTarget(failed, fresh) {
 }
 
 /**
+ * #1088 — split a search query into lowercased TERMS, matched independently.
+ *
+ * The whole query used to be one contiguous substring to find, and that returned zero
+ * for packs the catalogue plainly contains, because the SEPARATOR differs between the
+ * two sides. Pack identity lives in the repo name and spells the same words
+ * `comfyui-textoverlay` or `ComfyUI-text-overlay`; a human types `text overlay`.
+ * Neither spelling contains `"text overlay"`, so all three of the reporter's packs
+ * reported absent while the single token `overlay` found them. Printed next to
+ * `catalogue_size: 5583`, that 0 reads as "this pack does not exist" — the #808
+ * conflation, arriving through the query instead of through an empty catalogue.
+ *
+ * Splitting on WHITESPACE only, and never on `-` or `_`: those are real characters in
+ * a pack id, and a term of `text` already matches `text-overlay` and `textoverlay`
+ * alike as a substring. Splitting the HAYSTACK too would be the change that needs
+ * justifying; this one only stops treating the user's spaces as literal.
+ *
+ * A whitespace-only query yields NO terms and therefore filters nothing — the same
+ * answer `""` already gave, rather than the empty result a literal match produced for
+ * a query the caller may not be able to see is padded.
+ */
+export function queryTerms(query) {
+  return String(query ?? "")
+    .toLowerCase()
+    .split(/\s+/)
+    .filter(Boolean);
+}
+
+/**
+ * Does `hay` contain EVERY term? AND, deliberately, not OR.
+ *
+ * OR would be a worse defect than the one being fixed: `impact overlay` would match
+ * every pack containing either word, and a caller reading a 40-row result cannot tell
+ * a real hit from noise — a search that answers everything is as useless as one that
+ * answers nothing, and unlike the zero it does not announce itself.
+ *
+ * This is a strict SUPERSET of the contiguous match it replaces: if a haystack
+ * contained the query as one substring, it contains each of the query's terms as a
+ * substring too. So no search that worked before can stop working — the property that
+ * makes this safe to ship, pinned by a test rather than left as an argument.
+ */
+export function matchesAllTerms(hay, terms) {
+  for (const t of terms) {
+    if (!hay.includes(t)) return false;
+  }
+  return true;
+}
+
+/**
  * Normalize a ComfyUI-Manager `/customnode/getmappings` payload into the
  * nodes_search result shape `{ count, results:[{id,title,description}] }`,
  * filtered by `query` and capped at `limit` (default 15, max 40). Pure so the
@@ -545,12 +593,12 @@ export function dialectRetryTarget(failed, fresh) {
  * display.
  */
 export function parseNodeMappings(data, query, limit) {
-  const q = String(query ?? "").toLowerCase();
+  const terms = queryTerms(query);
   const out = [];
   const push = (id, title, desc) => {
     if (!id) return;
     const hay = `${id} ${title ?? ""} ${desc ?? ""}`.toLowerCase();
-    if (!q || hay.includes(q)) {
+    if (matchesAllTerms(hay, terms)) {
       out.push({ id, title: title ?? id, description: String(desc ?? "").slice(0, 160) });
     }
   };
@@ -603,7 +651,7 @@ export function catalogueSize(data) {
  * installed, so no registry install id is needed.
  */
 export function parseObjectInfoSearch(objectInfo, query, limit) {
-  const q = String(query ?? "").toLowerCase();
+  const terms = queryTerms(query);
   const out = [];
   if (objectInfo && typeof objectInfo === "object") {
     for (const [cls, meta] of Object.entries(objectInfo)) {
@@ -611,7 +659,7 @@ export function parseObjectInfoSearch(objectInfo, query, limit) {
       const desc = meta?.description ?? "";
       const category = meta?.category ?? "";
       const hay = `${cls} ${title} ${category} ${desc}`.toLowerCase();
-      if (!q || hay.includes(q)) {
+      if (matchesAllTerms(hay, terms)) {
         out.push({ id: cls, title, description: String(desc).slice(0, 160), installed: true });
       }
     }


### PR DESCRIPTION
## The half of #1088 that is a fixable bug

`panel_search_nodes` matched the query as ONE contiguous substring, so any multi-word
query returned zero against a catalogue that plainly contains the pack.

Measured against the reporter's own three packs (the ones they saw under `overlay`), in
the map shape Manager serves:

| query | before | after |
|---|---|---|
| `overlay` | 3 | 3 |
| `text overlay` | **0** | **3** |
| `  overlay  ` | **0** | **3** |
| `impact overlay` | 0 | 0 (AND holds) |

And against a catalogue that contains the pack the reporter was hunting for, spelled the
way a repo is:

| query | before | after |
|---|---|---|
| `Simple Text Overlay` | **0** | **1** (`comfyui-simple-text-overlay`) |

(An earlier revision of this description put that last "after" number in the first table,
where it is 0 — none of those three packs is named "Simple". Two different catalogues;
corrected here.)

The separator is the whole defect: pack identity lives in the repo name, which spells the
words `comfyui-textoverlay`, `ComfyUI-text-overlay` or `comfyui-simple-text-overlay`,
while a human types `text overlay`. No such id contains `"text overlay"`. With
`catalogue_size: 5583` printed alongside, that 0 reads as "this pack does not exist" —
the conflation #808 exists to prevent, arriving through the query instead of through an
empty catalogue. The reporter says it nearly sent them to install the wrong pack.

## The fix

Split the query on **whitespace** and require **every** term (AND).

- **Whitespace only, never `-` or `_`** — those are real characters in a pack id, and a
  term of `text` already matches `text-overlay` and `textoverlay` alike as a substring.
  The haystack is untouched; only the user's spaces stop being literal.
- **AND, not OR.** `impact overlay` matching everything with either word is a worse
  defect than the zero, because a wrong 40-row result does not announce itself the way an
  empty one does.
- **Strict superset.** A haystack that contained the query contiguously contains each of
  its terms, so no search that worked before can stop working. Pinned by a test rather
  than left as an argument.
- **Both routes.** The Manager catalogue and #426's `/object_info` fallback had the
  identical contiguous match; the fallback is the route with no `catalogue_size` to hint
  that the query itself was the problem.

## Verification

- 7 new assertions. At the claim commit 4 fail; the 3 that pass are guard rails against
  the fix overshooting.
- **Verified by mutation**, both directions, each mutation confirmed applied at byte
  level before trusting its result:
  - query no longer split (`.split(/(?!)/)`, the pre-fix contiguous behaviour) → the same
    4 assertions go red.
  - AND broken (`terms.slice(0, 1)`, only the first term required) → the AND guard rail
    goes red.
- Full unit suite after rebasing onto #1255: **4525 pass, 0 fail**, `check-panel-scope` OK.
- Production path confirmed reached: `nodes_search` (`panel_search_nodes`) →
  `searchNodesVia` → `parseNodeMappings`.
- codex gate: **SHIP** (exit 0), re-run after the rebase.

## What this PR does NOT do

It does not touch `run-scope-guard.js`. The `app.queuePrompt` half of #1088 gets no code
change; the reasoning is written up on the issue. In short: the panel already degrades
correctly, and both candidate changes are unsound — skipping the shape retries after a
key-absent body would regress #752, and making the repair path match a native scoped run
would introduce the identical-seed behaviour #988 deliberately chose to report rather
than repair.

It also leaves the other contiguous-substring searches in the panel alone (graph node
search, workflow filter). Same class, not this report.

Refs #1088