### PR TITLE
fix(1571): a subgraph conversion that broke the graph stops reporting success

### DIFF
--- a/browser_tests/unit/scope-fingerprint-cause.test.mjs
+++ b/browser_tests/unit/scope-fingerprint-cause.test.mjs
@@ -1,0 +1,114 @@
+// comfyui-mcp#1571, second half — `panel_run { to_node_id: 183 }` refused with:
+//
+//   "run-to-node scope for node 183 cannot be dispatched safely: the prompt could not be
+//    fingerprinted (graphToPrompt failed)"
+//
+// The refusal is correct: no fingerprint means the panel cannot tell its own dispatch from
+// unrelated queue traffic, so it fails closed (#556). What was wrong is that it threw the
+// reason away. `dispatchScopedRun` wrapped `app.graphToPrompt()` in `try { … } catch { }`
+// with an empty binding, so ComfyUI's own `InvalidLinkError: No link found in parent graph
+// for id [302:192] slot [0] conditioning` — which names the offending node outright — was
+// caught and discarded one line before the message that needed it.
+//
+// The cost is visible in the report itself: the reporter titled it "nested run-to-node
+// cannot fingerprint" and asked for "fingerprinting nested output targets" to be
+// supported. Nesting was never involved. Their graph had been left unserializable by a
+// subgraph conversion, and a FULL `panel_run` on the same graph failed the same way.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+import {
+  scopeUnattributableError,
+  describeFingerprintFailure,
+} from "../../web/js/lib/run-scope-guard.js";
+
+/** The error ComfyUI_frontend 1.48.7 actually throws for the reported graph. */
+const INVALID_LINK = new Error(
+  "No link found in parent graph for id [302:192] slot [0] conditioning",
+);
+INVALID_LINK.name = "InvalidLinkError";
+
+test("#1571 the serializer's own message reaches the caller", () => {
+  const msg = scopeUnattributableError({ toNodeId: 183, cause: INVALID_LINK });
+  assert.match(msg, /No link found in parent graph for id \[302:192\] slot \[0\] conditioning/);
+  // …and the refusal it is embedded in is unchanged: still fail-closed, still #556.
+  assert.match(msg, /run-to-node scope for node 183 cannot be dispatched safely/);
+  assert.match(msg, /Nothing was queued/);
+  assert.match(msg, /#556/);
+});
+
+test("#1571 the quote is attributed, so it does not read as the panel's own diagnosis", () => {
+  const msg = scopeUnattributableError({ toNodeId: 183, cause: INVALID_LINK });
+  assert.match(msg, /ComfyUI's serializer failed with/);
+  assert.match(msg, /the frontend's own error, not the panel's diagnosis/);
+});
+
+test("#1571 the refusal contradicts the theory the silence created", () => {
+  // The reporter's conclusion was that run-to-node cannot handle NESTED targets. Whatever
+  // else this message says, it has to say that much is not the cause.
+  const msg = scopeUnattributableError({ toNodeId: 183, cause: INVALID_LINK });
+  assert.match(msg, /not specific to run-to-node or to nesting/);
+});
+
+test("#1571 with nothing thrown, no cause is invented", () => {
+  // This path also fires when nothing threw at all — a frontend with no `graphToPrompt`,
+  // or a prompt that canonicalizes to nothing. Attaching a cause there would be the same
+  // defect pointed the other way: a reporter sent to fix a graph that is fine.
+  for (const nothing of [undefined, null, "", "   ", new Error(""), 42, {}]) {
+    const msg = scopeUnattributableError({ toNodeId: 7, cause: nothing });
+    assert.match(msg, /could not be fingerprinted/, String(nothing));
+    assert.doesNotMatch(msg, /ComfyUI's serializer failed with/, String(nothing));
+    assert.doesNotMatch(msg, /No link found/, String(nothing));
+  }
+  // The historical call shape — no argument at all — must still produce the old message.
+  assert.match(scopeUnattributableError({ toNodeId: 7 }), /cannot be dispatched safely/);
+  assert.doesNotMatch(scopeUnattributableError({ toNodeId: 7 }), /serializer failed with/);
+});
+
+test("#1571 a string cause is accepted as well as an Error", () => {
+  // Not every layer that can fail here throws an Error object.
+  assert.match(describeFingerprintFailure("boom from an extension"), /boom from an extension/);
+});
+
+test("#1571 a runaway serializer message cannot bury the instruction", () => {
+  const huge = new Error("x".repeat(5000));
+  const msg = scopeUnattributableError({ toNodeId: 1, cause: huge });
+  assert.ok(msg.length < 1500, `refusal must stay readable, was ${msg.length} chars`);
+  assert.match(msg, /…/, "a truncated quote must show that it was truncated");
+  assert.match(msg, /Nothing was queued/, "the instruction must survive the quote");
+});
+
+test("#1571 a multi-line stack-ish message is flattened, not pasted raw", () => {
+  const cause = new Error("InvalidLinkError:\n  at resolveInput\n\n  at getInnerNodes");
+  const msg = describeFingerprintFailure(cause);
+  assert.doesNotMatch(msg, /\n/);
+  assert.match(msg, /InvalidLinkError: at resolveInput at getInnerNodes/);
+});
+
+// ── WIRING. `describeFingerprintFailure` is inert unless the catch that swallows the error
+//    actually binds it and passes it on. That is a `catch {` → `catch (err) {` change and a
+//    single argument — invisible to every assertion above.
+
+const guardSrc = () =>
+  readFileSync(new URL("../../web/js/lib/run-scope-guard.js", import.meta.url), "utf8");
+
+test("#1571 the fingerprint catch BINDS what was thrown", () => {
+  const s = guardSrc();
+  const at = s.indexOf("contentCanon = canonicalizePrompt((await app.graphToPrompt())?.output");
+  assert.ok(at > 0, "the fingerprint call must still be recognisable");
+  // Bounded by the refusal it feeds, not by a byte count (#1472/#1460/#1582: fixed windows
+  // in this repo have reported missing wiring that was present three separate times).
+  const end = s.indexOf("scopeUnattributableError({", at);
+  assert.ok(end > at, "the unattributable refusal must still follow the fingerprint");
+  const block = s.slice(at, end);
+  assert.doesNotMatch(block, /\}\s*catch\s*\{/, "the catch must not discard the error again");
+  assert.match(block, /catch \(err\) \{/);
+  assert.match(block, /fingerprintCause = err;/);
+});
+
+test("#1571 the bound error is PASSED to the refusal", () => {
+  // Capturing it and not forwarding it is the same as not capturing it.
+  assert.match(guardSrc(), /scopeUnattributableError\(\{ toNodeId, cause: fingerprintCause \}\)/);
+});

--- a/browser_tests/unit/subgraph-conversion-integrity.test.mjs
+++ b/browser_tests/unit/subgraph-conversion-integrity.test.mjs
@@ -28,6 +28,8 @@ import { readFileSync } from "node:fs";
 import {
   readLinkIds,
   danglingInputLinks,
+  fatalDanglingInputLinks,
+  bypassResolvedInputSlots,
   disconnectedBoundaryInputs,
   brokenConversionRefusal,
 } from "../../web/js/lib/subgraph-conversion-integrity.js";
@@ -36,10 +38,10 @@ const src = () =>
   readFileSync(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8");
 
 /** The reported node, as it appears in packs/krea2-combo/workflow.json. */
-const rbg = (link) => ({
+const rbg = (link, mode = 4) => ({
   id: 192,
   type: "RBG_Smart_Seed_Variance",
-  mode: 4,
+  mode,
   inputs: [{ name: "conditioning", type: "CONDITIONING", link }],
   outputs: [{ name: "conditioning", type: "CONDITIONING", links: [473, 474] }],
 });
@@ -86,7 +88,123 @@ test("#1571 the reported corruption is detected, and names the node the run erro
     name: "conditioning",
     link_id: 505,
     bypassed: true,
+    muted: false,
+    fatal: true,
   });
+});
+
+// ── WHICH dangling inputs the serializer actually reaches (codex gate, P1) ──────────
+//
+// `graphToPrompt` skips a node entirely before touching its inputs:
+//   if (node.isVirtualNode || node.mode === NEVER || node.mode === BYPASS) continue
+// and `resolveOutput` returns immediately for NEVER ("Muted nodes produce no output").
+// Refusing on an input nothing resolves would un-ship the tool for graphs that run.
+
+test("#1571 P1 a MUTED node's dangling input is reported but never fatal", () => {
+  const g = brokenSubgraph();
+  g._nodes = [rbg(505, 2)];
+  const [entry] = danglingInputLinks(g);
+  assert.equal(entry.muted, true);
+  assert.equal(entry.fatal, false, "a muted node is never asked for its inputs, so it still queues");
+  assert.deepEqual(fatalDanglingInputLinks(g), [], "and it must not reach the refusal");
+});
+
+test("#1571 P1 a VIRTUAL node's dangling input is reported but never fatal", () => {
+  const g = brokenSubgraph();
+  g._nodes = [{ id: 5, type: "Reroute", mode: 0, isVirtualNode: true, inputs: [{ name: "", link: 505 }] }];
+  const [entry] = danglingInputLinks(g);
+  assert.equal(entry.fatal, false);
+});
+
+test("#1571 P1 an ORDINARY node's dangling input is always fatal", () => {
+  // The mode the reported graph did NOT have, and the one with the widest blast radius:
+  // every input of a live node is resolved.
+  const g = brokenSubgraph();
+  g._nodes = [{ id: 9, type: "KSampler", mode: 0, inputs: [{ name: "positive", type: "CONDITIONING", link: 999 }] }];
+  assert.equal(danglingInputLinks(g)[0].fatal, true);
+  // …and a node with no `mode` at all is an ordinary node.
+  g._nodes = [{ id: 9, type: "KSampler", inputs: [{ name: "positive", link: 999 }] }];
+  assert.equal(danglingInputLinks(g)[0].fatal, true);
+});
+
+test("#1571 P1 a bypassed node's UNSELECTED input is not fatal", () => {
+  // `_getBypassSlotIndex` picks ONE input per output slot. A MASK input on a node whose
+  // only output is IMAGE is never resolved, so its dangling link cannot throw.
+  const g = brokenSubgraph();
+  g._nodes = [
+    {
+      id: 42,
+      type: "ImageBlend",
+      mode: 4,
+      inputs: [
+        { name: "image", type: "IMAGE", link: 473 },
+        { name: "mask", type: "MASK", link: 998 },
+      ],
+      outputs: [{ name: "IMAGE", type: "IMAGE", links: [474] }],
+    },
+  ];
+  const [entry] = danglingInputLinks(g);
+  assert.equal(entry.name, "mask");
+  assert.equal(entry.fatal, false, "no output type selects the MASK input");
+});
+
+test("#1571 P1 a bypassed node with NO connected output reaches nothing", () => {
+  // Bypass is only ever entered THROUGH a consumer. Nothing consumes an unlinked output.
+  const g = brokenSubgraph();
+  const node = rbg(505);
+  node.outputs = [{ name: "conditioning", type: "CONDITIONING", links: [] }];
+  g._nodes = [node];
+  assert.equal(danglingInputLinks(g)[0].fatal, false);
+});
+
+test("#1571 P1 the bypass slot selection mirrors _getBypassSlotIndex", () => {
+  const sel = (node) => [...bypassResolvedInputSlots(node)].sort((a, b) => a - b);
+  // Same-index input, compatible type → that slot.
+  assert.deepEqual(
+    sel({
+      inputs: [{ type: "IMAGE" }, { type: "MASK" }],
+      outputs: [{ type: "IMAGE", links: [1] }],
+    }),
+    [0],
+  );
+  // Same index incompatible → first exact type match.
+  assert.deepEqual(
+    sel({
+      inputs: [{ type: "MASK" }, { type: "IMAGE" }],
+      outputs: [{ type: "IMAGE", links: [1] }],
+    }),
+    [1],
+  );
+  // The same-slot preference BEATS the first exact match, and only a graph with two
+  // equally-typed inputs can tell the two rules apart. Getting this backwards marks the
+  // wrong input fatal in both directions — a false refusal on input 0 and silence on the
+  // one that actually breaks.
+  assert.deepEqual(
+    sel({
+      inputs: [{ type: "IMAGE" }, { type: "IMAGE" }],
+      outputs: [{ type: "LATENT", links: [] }, { type: "IMAGE", links: [1] }],
+    }),
+    [1],
+  );
+  // A wildcard output matches the same index, falling back to slot 0.
+  assert.deepEqual(sel({ inputs: [{ type: "MASK" }], outputs: [{ type: "*", links: [1] }] }), [0]);
+  // A wildcard INPUT is compatible with anything.
+  assert.deepEqual(sel({ inputs: [{ type: "*" }], outputs: [{ type: "LATENT", links: [1] }] }), [0]);
+  // Types are compared case-insensitively, as strings.
+  assert.deepEqual(sel({ inputs: [{ type: "image" }], outputs: [{ type: "IMAGE", links: [1] }] }), [0]);
+  // Unconnected outputs select nothing at all.
+  assert.deepEqual(sel({ inputs: [{ type: "IMAGE" }], outputs: [{ type: "IMAGE", links: [] }] }), []);
+  // Every connected output contributes its own selection.
+  assert.deepEqual(
+    sel({
+      inputs: [{ type: "IMAGE" }, { type: "MASK" }],
+      outputs: [{ type: "IMAGE", links: [1] }, { type: "MASK", links: [2] }],
+    }),
+    [0, 1],
+  );
+  // Junk is silent rather than throwing.
+  assert.deepEqual(sel({}), []);
+  assert.deepEqual(sel({ inputs: null, outputs: "nope" }), []);
 });
 
 test("#1571 a correctly converted subgraph yields nothing", () => {
@@ -302,12 +420,15 @@ test("#1571 BOTH conversion paths assert serializability, AFTER the node landed"
   }
 });
 
-test("#1571 the advisory slots reach the reported payload on both paths", () => {
+test("#1571 the advisory findings reach the reported payload on both paths", () => {
   // A finding computed and then dropped on the floor is the same as no finding. This is a
   // one-line spread that no helper test can see.
   const s = src();
-  const occurrences = s.match(/unfed_boundary_inputs: unfedInputs/g) ?? [];
-  assert.equal(occurrences.length, 2, "both conversion tools must report the unfed slots");
+  const occurrences = s.match(/\.\.\.subgraphConversionAdvisories\(advisories\)/g) ?? [];
+  assert.equal(occurrences.length, 2, "both conversion tools must report the advisories");
+  // …and only the FATAL findings may refuse (codex gate P1).
+  assert.match(s, /const fatal = dangling\.filter\(\(entry\) => entry\.fatal\);/);
+  assert.match(s, /if \(fatal\.length\) \{/);
 });
 
 test("#1571 the guard is imported, not shadowed by a local stub", () => {
@@ -332,7 +453,10 @@ function realExecutor(name, args, convertToSubgraph, wrapper) {
   const serializable = s.match(
     /function assertSubgraphConversionSerializable\(res, node, what\) \{[\s\S]*?\r?\n\}/,
   );
-  assert.ok(landed && serializable, "both conversion guards must be locatable in the source");
+  const advisories = s.match(
+    /function subgraphConversionAdvisories\(\{ disconnected, dormant \}\) \{[\s\S]*?\r?\n\}/,
+  );
+  assert.ok(landed && serializable && advisories, "the conversion guards must be locatable in the source");
   const graph = {
     _nodes: [wrapper],
     getNodeById: (id) => ({ id: Number(id) }),
@@ -350,6 +474,7 @@ function realExecutor(name, args, convertToSubgraph, wrapper) {
     "clearStaleRedFlagsAfterSubgraphConversion",
     "assertSubgraphNodeLanded",
     "assertSubgraphConversionSerializable",
+    "subgraphConversionAdvisories",
     `const executors = { ${body[0]} }; return executors.${name.replace(/^async /, "")};`,
   )(
     () => ({ app: {}, graph, canvas, rootGraph: graph }),
@@ -364,6 +489,7 @@ function realExecutor(name, args, convertToSubgraph, wrapper) {
       "brokenConversionRefusal",
       `return ${serializable[0]};`,
     )(danglingInputLinks, disconnectedBoundaryInputs, brokenConversionRefusal),
+    new Function(`return ${advisories[0]};`)(),
   );
 }
 
@@ -424,6 +550,43 @@ test("#1571 BEHAVIOUR: a fully healthy conversion carries no advisory key at all
   );
   const out = group({ group: "COMBOS VARIANCE" });
   assert.ok(!("unfed_boundary_inputs" in out.subgraph), "a clean conversion reports no advisory");
+});
+
+test("#1571 P1 BEHAVIOUR: a conversion whose only breakage is MUTED still succeeds", () => {
+  // The over-refusal the gate caught, driven through the real executor. This graph queues
+  // today, so the tool must report it — with the finding attached, not swallowed.
+  const wrapper = wrapperNode(505);
+  const muted = brokenSubgraph();
+  muted._nodes = [rbg(505, 2)];
+  const group = realExecutor(
+    "graph_subgraph_group",
+    "\\{ group \\}",
+    () => ({ node: wrapper, subgraph: muted }),
+    wrapper,
+  );
+  const out = group({ group: "COMBOS VARIANCE" });
+  assert.equal(out.subgraph.node_id, 302, "a runnable graph must not be refused");
+  assert.equal(out.subgraph.dangling_inputs_not_reached.length, 1);
+  assert.equal(out.subgraph.dangling_inputs_not_reached[0].node_id, 192);
+  assert.ok(!("unfed_boundary_inputs" in out.subgraph));
+});
+
+test("#1571 P1 the refusal separates what is broken NOW from what is only latent", () => {
+  const g = brokenSubgraph();
+  g._nodes = [rbg(505), { id: 77, type: "Note", mode: 2, inputs: [{ name: "text", link: 997 }] }];
+  const all = danglingInputLinks(g);
+  const msg = brokenConversionRefusal({
+    what: "panel_subgraph_group",
+    subgraphNodeId: 302,
+    dangling: all.filter((e) => e.fatal),
+    dormant: all.filter((e) => !e.fatal),
+    disconnected: [],
+  });
+  assert.match(msg, /1 input inside the new subgraph still references/, "only the fatal one counts");
+  assert.doesNotMatch(msg, /2 inputs inside/, "the dormant one must not inflate the breakage");
+  assert.match(msg, /NOT reached by the serializer today/);
+  assert.match(msg, /Note node 77 \(muted\)/);
+  assert.match(msg, /re-enabled or rewired/);
 });
 
 test("#1571 BEHAVIOUR: panel_create_subgraph refuses the same corruption", () => {

--- a/browser_tests/unit/subgraph-conversion-integrity.test.mjs
+++ b/browser_tests/unit/subgraph-conversion-integrity.test.mjs
@@ -316,3 +316,126 @@ test("#1571 the guard is imported, not shadowed by a local stub", () => {
     /import \{\s*danglingInputLinks,\s*disconnectedBoundaryInputs,\s*brokenConversionRefusal,\s*\} from "\.\/lib\/subgraph-conversion-integrity\.js";/,
   );
 });
+
+// ── BEHAVIOUR, through the REAL shipped executor. The wiring tests above prove the calls
+//    are written down; they cannot prove the tool actually refuses. This extracts
+//    `graph_subgraph_group` from the monolith and drives it with a convertToSubgraph that
+//    returns exactly what the reporter's did — the same real-source extraction pattern
+//    subgraph-stale-outline.test.mjs uses on these two executors.
+
+/** Build the shipped executor with injected deps, exactly as the panel wires them. */
+function realExecutor(name, args, convertToSubgraph, wrapper) {
+  const s = src();
+  const body = s.match(new RegExp(`${name}\\(${args}\\) \\{[\\s\\S]*?\\n  \\},`));
+  assert.ok(body, `could not locate ${name} in panel source`);
+  const landed = s.match(/function assertSubgraphNodeLanded\(res, graph, what\) \{[\s\S]*?\r?\n\}/);
+  const serializable = s.match(
+    /function assertSubgraphConversionSerializable\(res, node, what\) \{[\s\S]*?\r?\n\}/,
+  );
+  assert.ok(landed && serializable, "both conversion guards must be locatable in the source");
+  const graph = {
+    _nodes: [wrapper],
+    getNodeById: (id) => ({ id: Number(id) }),
+    beforeChange() {},
+    afterChange() {},
+    convertToSubgraph,
+    setDirtyCanvas() {},
+  };
+  const canvas = { selectedItems: [], selectItems(items) { canvas.selectedItems = items; } };
+  return new Function(
+    "getGraphCtx",
+    "resolveGroupRef",
+    "syncGraphNodeAreas",
+    "groupMemberNodes",
+    "clearStaleRedFlagsAfterSubgraphConversion",
+    "assertSubgraphNodeLanded",
+    "assertSubgraphConversionSerializable",
+    `const executors = { ${body[0]} }; return executors.${name.replace(/^async /, "")};`,
+  )(
+    () => ({ app: {}, graph, canvas, rootGraph: graph }),
+    () => ({ id: 22, title: "COMBOS VARIANCE" }),
+    () => {},
+    () => [{ id: 192 }, { id: 265 }, { id: 273 }],
+    () => {},
+    new Function(`return ${landed[0]};`)(),
+    new Function(
+      "danglingInputLinks",
+      "disconnectedBoundaryInputs",
+      "brokenConversionRefusal",
+      `return ${serializable[0]};`,
+    )(danglingInputLinks, disconnectedBoundaryInputs, brokenConversionRefusal),
+  );
+}
+
+/** The subgraph node convertToSubgraph put on the canvas, boundary input unfed. */
+const wrapperNode = (link) => ({
+  id: 302,
+  type: "3be9b3b8-5e79-4bd1-acc6-015115c03be5",
+  inputs: [{ name: "conditioning", type: "CONDITIONING", link }],
+});
+
+test("#1571 BEHAVIOUR: panel_subgraph_group REFUSES the reported conversion", () => {
+  const wrapper = wrapperNode(null);
+  const group = realExecutor(
+    "graph_subgraph_group",
+    "\\{ group \\}",
+    () => ({ node: wrapper, subgraph: brokenSubgraph() }),
+    wrapper,
+  );
+  assert.throws(
+    () => group({ group: "COMBOS VARIANCE" }),
+    (err) => {
+      assert.match(err.message, /panel_subgraph_group created subgraph node 302/);
+      assert.match(err.message, /RBG_Smart_Seed_Variance node 192 \(bypassed\) input 0 "conditioning" → link 505/);
+      assert.match(err.message, /No link found in parent graph for id \[302:192\]/);
+      return true;
+    },
+    "the tool that reported success must now refuse",
+  );
+});
+
+test("#1571 BEHAVIOUR: a healthy conversion still reports success, with the unfed slot named", () => {
+  // The direction that would break the tool for everyone. Same executor, same wrapper —
+  // only the subgraph's link table differs.
+  const wrapper = wrapperNode(null);
+  const group = realExecutor(
+    "graph_subgraph_group",
+    "\\{ group \\}",
+    () => ({ node: wrapper, subgraph: healthySubgraph() }),
+    wrapper,
+  );
+  const out = group({ group: "COMBOS VARIANCE" });
+  assert.equal(out.subgraph.node_id, 302);
+  assert.deepEqual(out.subgraph.from_nodes, [192, 265, 273]);
+  // The advisory tier: reported, never fatal.
+  assert.deepEqual(out.subgraph.unfed_boundary_inputs, [
+    { slot: 0, name: "conditioning", type: "CONDITIONING" },
+  ]);
+});
+
+test("#1571 BEHAVIOUR: a fully healthy conversion carries no advisory key at all", () => {
+  // An `unfed_boundary_inputs: []` on every clean conversion would read as a finding.
+  const wrapper = wrapperNode(505);
+  const group = realExecutor(
+    "graph_subgraph_group",
+    "\\{ group \\}",
+    () => ({ node: wrapper, subgraph: healthySubgraph() }),
+    wrapper,
+  );
+  const out = group({ group: "COMBOS VARIANCE" });
+  assert.ok(!("unfed_boundary_inputs" in out.subgraph), "a clean conversion reports no advisory");
+});
+
+test("#1571 BEHAVIOUR: panel_create_subgraph refuses the same corruption", () => {
+  const wrapper = wrapperNode(null);
+  const create = realExecutor(
+    "graph_create_subgraph",
+    "\\{ node_ids \\}",
+    () => ({ node: wrapper, subgraph: brokenSubgraph() }),
+    wrapper,
+  );
+  assert.throws(
+    () => create({ node_ids: [192, 265, 273] }),
+    /panel_create_subgraph created subgraph node 302/,
+  );
+});

--- a/browser_tests/unit/subgraph-conversion-integrity.test.mjs
+++ b/browser_tests/unit/subgraph-conversion-integrity.test.mjs
@@ -1,0 +1,318 @@
+// comfyui-mcp#1571 — `panel_subgraph_group` reported a clean conversion and the workflow
+// could not be run afterwards.
+//
+//   panel_subgraph_group { group: "…T2I…" }  → { subgraph: { node_id: 302, … } }   ← "success"
+//   panel_run {}                             → "No link found in parent graph for id
+//                                               [302:192] slot [0] conditioning"
+//   panel_run { to_node_id: 183 }            → "the prompt could not be fingerprinted
+//                                               (graphToPrompt failed)"
+//
+// Three answers to one broken graph, and the only one that named anything named a
+// flattened id the caller had never seen. The reporter concluded that run-to-node "cannot
+// fingerprint nested output targets" — a theory about NESTING, which had nothing to do
+// with it — repaired the graph by hand, and filed both halves as one issue.
+//
+// ## The fixture is not invented
+//
+// Node 192 / `RBG_Smart_Seed_Variance` / `mode: 4` / input `conditioning` / `link: 505`,
+// feeding KSamplers 265 and 273, with SaveImage 183 downstream, are read verbatim out of
+// `packs/krea2-combo/workflow.json` in the mcp repo — the workflow the report names. The
+// corruption shape (an input whose link id is absent from its own graph's link table) is
+// read out of ComfyUI_frontend 1.48.7's `ExecutableNodeDTO.resolveInput`, which throws
+// `InvalidLinkError` on precisely that and nothing else.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+import {
+  readLinkIds,
+  danglingInputLinks,
+  disconnectedBoundaryInputs,
+  brokenConversionRefusal,
+} from "../../web/js/lib/subgraph-conversion-integrity.js";
+
+const src = () =>
+  readFileSync(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8");
+
+/** The reported node, as it appears in packs/krea2-combo/workflow.json. */
+const rbg = (link) => ({
+  id: 192,
+  type: "RBG_Smart_Seed_Variance",
+  mode: 4,
+  inputs: [{ name: "conditioning", type: "CONDITIONING", link }],
+  outputs: [{ name: "conditioning", type: "CONDITIONING", links: [473, 474] }],
+});
+
+const ksampler = (id, condLink) => ({
+  id,
+  type: "KSampler",
+  mode: 0,
+  inputs: [
+    { name: "model", type: "MODEL", link: 491 },
+    { name: "positive", type: "CONDITIONING", link: condLink },
+  ],
+});
+
+/** The subgraph as convertToSubgraph left it: link 505 was never written into it. */
+const brokenSubgraph = () => ({
+  name: "New Subgraph",
+  _nodes: [rbg(505), ksampler(265, 473), ksampler(273, 474)],
+  links: new Map([
+    // The MODEL rail crossed the same boundary and survived — which is why the conversion
+    // looked fine. Only the bypassed node's CONDITIONING link (505) went missing.
+    [491, { id: 491, origin_id: -10, origin_slot: 0, target_id: 265, target_slot: 0 }],
+    [473, { id: 473, origin_id: 192, origin_slot: 0, target_id: 265, target_slot: 1 }],
+    [474, { id: 474, origin_id: 192, origin_slot: 0, target_id: 273, target_slot: 1 }],
+  ]),
+});
+
+/** The same conversion, done right: 505 exists, re-origined onto the input rail. */
+const healthySubgraph = () => {
+  const g = brokenSubgraph();
+  g.links.set(505, { id: 505, origin_id: -10, origin_slot: 0, target_id: 192, target_slot: 0 });
+  return g;
+};
+
+// ── The fatal signal ────────────────────────────────────────────────────────────────
+
+test("#1571 the reported corruption is detected, and names the node the run error hid", () => {
+  const found = danglingInputLinks(brokenSubgraph());
+  assert.equal(found.length, 1, "exactly the one broken input");
+  assert.deepEqual(found[0], {
+    node_id: 192,
+    node_type: "RBG_Smart_Seed_Variance",
+    slot: 0,
+    name: "conditioning",
+    link_id: 505,
+    bypassed: true,
+  });
+});
+
+test("#1571 a correctly converted subgraph yields nothing", () => {
+  // The direction that would break every conversion. Same nodes, same link ids — the only
+  // difference is that 505 is present, which is what a healthy conversion produces.
+  assert.deepEqual(danglingInputLinks(healthySubgraph()), []);
+});
+
+test("#1571 an unconnected input is not a dangling one", () => {
+  // `resolveInput` returns early on `linkId == null`. A node with nothing plugged in is
+  // ordinary, and flagging it would refuse conversions of any graph with a spare socket.
+  const g = brokenSubgraph();
+  g._nodes = [rbg(null), { id: 7, type: "Note", inputs: [{ name: "x", link: undefined }] }];
+  assert.deepEqual(danglingInputLinks(g), []);
+});
+
+test("#1571 link ids are compared by VALUE, not by type", () => {
+  // Serialized graphs carry numeric ids; some frontend paths stringify them. A `1 !== "1"`
+  // mismatch here would report every input in the graph as dangling and refuse every
+  // conversion — the worst possible failure direction for this guard.
+  const g = brokenSubgraph();
+  g.links = new Map([["505", {}], ["491", {}], ["473", {}], ["474", {}]]);
+  assert.deepEqual(danglingInputLinks(g), []);
+});
+
+test("#1571 an unreadable link table produces NO findings", () => {
+  // The safety property. This gates the report of a mutation that already happened, so a
+  // graph shape we do not recognise must be silent, never a graph-wide accusation.
+  for (const links of [undefined, null, 42, "links", () => {}]) {
+    const g = brokenSubgraph();
+    g.links = links;
+    assert.deepEqual(danglingInputLinks(g), [], String(links));
+  }
+  assert.equal(readLinkIds({ links: null }), null);
+  assert.equal(readLinkIds(undefined), null);
+});
+
+test("#1571 every link-table shape a frontend ships is read", () => {
+  // Live litegraph uses a Map; the serialized form is tuples or objects; some builds hand
+  // back a plain id-keyed object. Reading only one of them turns the others into a
+  // false accusation.
+  assert.deepEqual([...readLinkIds({ links: new Map([[505, {}]]) })], ["505"]);
+  assert.deepEqual([...readLinkIds({ links: [[505, 274, 2, 192, 0, "CONDITIONING"]] })], ["505"]);
+  assert.deepEqual([...readLinkIds({ links: [{ id: 505 }] })], ["505"]);
+  assert.deepEqual([...readLinkIds({ links: { 505: {} } })], ["505"]);
+  // An EMPTY table is readable and means what it says — a conversion with no links at all.
+  assert.deepEqual([...readLinkIds({ links: new Map() })], []);
+});
+
+test("#1571 an unreadable node list produces no findings", () => {
+  for (const nodes of [undefined, null, 5, "nodes"]) {
+    assert.deepEqual(danglingInputLinks({ links: new Map(), _nodes: nodes }), [], String(nodes));
+  }
+  // …and a serialized graph exposing `nodes` instead of `_nodes` is still read.
+  assert.equal(
+    danglingInputLinks({ links: [], nodes: [rbg(505)] }).length,
+    1,
+    "the serialized shape must be read too",
+  );
+});
+
+test("#1571 junk nodes cannot throw while a failure is being explained", () => {
+  const g = { links: new Map(), _nodes: [null, 7, {}, { inputs: null }, { inputs: [null, 3] }] };
+  assert.deepEqual(danglingInputLinks(g), []);
+});
+
+test("#1571 the walk stays at ONE level", () => {
+  // A nested subgraph NODE that moved inside brings a definition shared with every other
+  // instance of it. Descending would blame this conversion for something it never touched.
+  const inner = { _nodes: [rbg(505)], links: new Map() };
+  const g = { _nodes: [{ id: 300, type: "SubgraphNode", inputs: [], subgraph: inner }], links: new Map() };
+  assert.deepEqual(danglingInputLinks(g), []);
+});
+
+// ── The advisory signal ─────────────────────────────────────────────────────────────
+
+test("#1571 an unfed boundary input on the new node is reported", () => {
+  // The reporter's own words: "avoid exposing a disconnected boundary input". Every slot
+  // on a fresh subgraph node exists because an external link fed it.
+  const node = {
+    id: 302,
+    inputs: [
+      { name: "conditioning", type: "CONDITIONING", link: null },
+      { name: "model", type: "MODEL", link: 491 },
+    ],
+  };
+  assert.deepEqual(disconnectedBoundaryInputs(node), [
+    { slot: 0, name: "conditioning", type: "CONDITIONING" },
+  ]);
+});
+
+test("#1571 a fully fed subgraph node reports nothing, and junk is silent", () => {
+  assert.deepEqual(disconnectedBoundaryInputs({ inputs: [{ name: "a", link: 1 }] }), []);
+  for (const junk of [undefined, null, {}, { inputs: null }, { inputs: 3 }]) {
+    assert.deepEqual(disconnectedBoundaryInputs(junk), [], String(junk));
+  }
+});
+
+// ── The refusal ─────────────────────────────────────────────────────────────────────
+
+const refusal = () =>
+  brokenConversionRefusal({
+    what: "panel_subgraph_group",
+    subgraphNodeId: 302,
+    dangling: danglingInputLinks(brokenSubgraph()),
+    disconnected: [{ slot: 0, name: "conditioning", type: "CONDITIONING" }],
+  });
+
+test("#1571 the refusal says the subgraph EXISTS — the opposite of its sibling", () => {
+  // assertSubgraphNodeLanded's message says "nothing is being reported as created". Reusing
+  // that wording here would send the caller to retry and wrap the same nodes a second time,
+  // leaving two subgraph nodes on the canvas.
+  const msg = refusal();
+  assert.match(msg, /created subgraph node 302/);
+  assert.match(msg, /on the canvas/);
+  assert.match(msg, /Nothing has been undone/);
+  assert.doesNotMatch(msg, /Nothing is being reported as created/);
+});
+
+test("#1571 the refusal names the node, the slot and the link", () => {
+  const msg = refusal();
+  assert.match(msg, /RBG_Smart_Seed_Variance node 192/);
+  assert.match(msg, /input 0 "conditioning"/);
+  assert.match(msg, /link 505/);
+  assert.match(msg, /bypassed/, "the mode matters — a bypassed node is resolved THROUGH");
+});
+
+test("#1571 the refusal connects itself to the error the run would have shown", () => {
+  // The whole cost of the bug: `[302:192]` appeared for the first time at run time, with
+  // nothing tying it to the conversion. Printing it here is what closes that gap.
+  assert.match(refusal(), /No link found in parent graph for id \[302:192\] slot \[0\]/);
+});
+
+test("#1571 the refusal offers both recoveries and does not claim to have repaired anything", () => {
+  const msg = refusal();
+  assert.match(msg, /Ctrl\+Z|undo/i);
+  assert.match(msg, /panel_enter_subgraph/);
+  assert.match(msg, /panel_expose_subgraph_input/);
+  assert.doesNotMatch(msg, /has been (repaired|fixed|reconnected)/i);
+});
+
+test("#1571 the refusal attributes the cause to the frontend, without hiding behind it", () => {
+  const msg = refusal();
+  assert.match(msg, /convertToSubgraph produced this/);
+  assert.match(msg, /comfyui-mcp#1571/);
+});
+
+test("#1571 the unfed boundary slots ride along in the refusal", () => {
+  assert.match(refusal(), /input slot\(s\) that nothing in the parent graph feeds/);
+  // …and are omitted entirely when there are none, rather than printed as "0".
+  const none = brokenConversionRefusal({
+    what: "panel_create_subgraph",
+    subgraphNodeId: 9,
+    dangling: danglingInputLinks(brokenSubgraph()),
+    disconnected: [],
+  });
+  assert.doesNotMatch(none, /input slot\(s\) that nothing/);
+});
+
+test("#1571 a long list of broken inputs stays readable", () => {
+  const many = Array.from({ length: 40 }, (_, i) => ({
+    node_id: i,
+    node_type: `Node${i}`,
+    slot: 0,
+    name: "in",
+    link_id: 1000 + i,
+    bypassed: false,
+  }));
+  const msg = brokenConversionRefusal({
+    what: "panel_subgraph_group",
+    subgraphNodeId: 302,
+    dangling: many,
+    disconnected: [],
+  });
+  assert.ok(msg.length < 2000, `refusal must stay readable, was ${msg.length} chars`);
+  assert.match(msg, /and 32 more/);
+});
+
+test("#1571 the refusal survives entries it cannot fully describe", () => {
+  // It is composed while explaining a failure; throwing here would replace a useful
+  // refusal with a second, unrelated error.
+  const msg = brokenConversionRefusal({
+    what: "panel_subgraph_group",
+    subgraphNodeId: undefined,
+    dangling: [{ node_id: null, node_type: null, slot: 2, name: null, link_id: 9, bypassed: false }],
+    disconnected: null,
+  });
+  assert.match(msg, /link 9/);
+  assert.match(msg, /input 2/);
+});
+
+// ── WIRING. The helpers above are inert unless both conversion tools consult them, and
+//    that is two lines inside a 30k-line file. Deleting either one leaves every test
+//    above green — which is exactly how #1571 shipped in the first place.
+
+test("#1571 BOTH conversion paths assert serializability, AFTER the node landed", () => {
+  const s = src();
+  for (const tool of ["panel_create_subgraph", "panel_subgraph_group"]) {
+    const landed = s.indexOf(`assertSubgraphNodeLanded(res, graph, "${tool}")`);
+    const serializable = s.indexOf(`assertSubgraphConversionSerializable(res, `);
+    assert.ok(landed > 0, `${tool} must still assert the node landed`);
+    const call = new RegExp(
+      `assertSubgraphConversionSerializable\\(res, \\w+, "${tool}"\\)`,
+    );
+    assert.match(s, call, `${tool} must assert the conversion is serializable`);
+    assert.ok(serializable > 0);
+    // ORDER: the serializability check reads the node the landing check returned, so a
+    // conversion that produced nothing must fail with the sibling's clearer message.
+    assert.ok(
+      s.search(call) > landed,
+      `${tool} must check the node landed BEFORE checking it serializes`,
+    );
+  }
+});
+
+test("#1571 the advisory slots reach the reported payload on both paths", () => {
+  // A finding computed and then dropped on the floor is the same as no finding. This is a
+  // one-line spread that no helper test can see.
+  const s = src();
+  const occurrences = s.match(/unfed_boundary_inputs: unfedInputs/g) ?? [];
+  assert.equal(occurrences.length, 2, "both conversion tools must report the unfed slots");
+});
+
+test("#1571 the guard is imported, not shadowed by a local stub", () => {
+  assert.match(
+    src(),
+    /import \{\s*danglingInputLinks,\s*disconnectedBoundaryInputs,\s*brokenConversionRefusal,\s*\} from "\.\/lib\/subgraph-conversion-integrity\.js";/,
+  );
+});

--- a/browser_tests/unit/subgraph-conversion-integrity.test.mjs
+++ b/browser_tests/unit/subgraph-conversion-integrity.test.mjs
@@ -20,6 +20,15 @@
 // corruption shape (an input whose link id is absent from its own graph's link table) is
 // read out of ComfyUI_frontend 1.48.7's `ExecutableNodeDTO.resolveInput`, which throws
 // `InvalidLinkError` on precisely that and nothing else.
+//
+// ## Two claims, deliberately different in strength
+//
+// "These links are gone" is measured. "Therefore the workflow cannot run" is NOT, unless
+// the node is one `graphToPrompt` resolves unconditionally — muted, bypassed and virtual
+// nodes are skipped and reached only through a consumer chain that only ComfyUI's own
+// resolver can walk. Three review rounds killed three attempts to walk it from here, so
+// the module stopped claiming it. Both tiers are pinned below, including the direction
+// that matters most: an unproven finding must never refuse.
 
 import test from "node:test";
 import assert from "node:assert/strict";
@@ -29,9 +38,9 @@ import {
   readLinkIds,
   danglingInputLinks,
   fatalDanglingInputLinks,
-  bypassResolvedInputSlots,
   disconnectedBoundaryInputs,
   brokenConversionRefusal,
+  brokenConversionWarning,
 } from "../../web/js/lib/subgraph-conversion-integrity.js";
 
 const src = () =>
@@ -76,7 +85,14 @@ const healthySubgraph = () => {
   return g;
 };
 
-// ── The fatal signal ────────────────────────────────────────────────────────────────
+/** A dangling input on an ORDINARY node — the provable tier. */
+const certainlyBrokenSubgraph = () => {
+  const g = healthySubgraph();
+  g._nodes = [ksampler(265, 997)]; // 997 is in no link table
+  return g;
+};
+
+// ── Detection ───────────────────────────────────────────────────────────────────────
 
 test("#1571 the reported corruption is detected, and names the node the run error hid", () => {
   const found = danglingInputLinks(brokenSubgraph());
@@ -89,122 +105,10 @@ test("#1571 the reported corruption is detected, and names the node the run erro
     link_id: 505,
     bypassed: true,
     muted: false,
-    fatal: true,
+    virtual: false,
+    // Bypassed ⇒ reached only through a consumer chain ⇒ not ours to call fatal.
+    certainly_reached: false,
   });
-});
-
-// ── WHICH dangling inputs the serializer actually reaches (codex gate, P1) ──────────
-//
-// `graphToPrompt` skips a node entirely before touching its inputs:
-//   if (node.isVirtualNode || node.mode === NEVER || node.mode === BYPASS) continue
-// and `resolveOutput` returns immediately for NEVER ("Muted nodes produce no output").
-// Refusing on an input nothing resolves would un-ship the tool for graphs that run.
-
-test("#1571 P1 a MUTED node's dangling input is reported but never fatal", () => {
-  const g = brokenSubgraph();
-  g._nodes = [rbg(505, 2)];
-  const [entry] = danglingInputLinks(g);
-  assert.equal(entry.muted, true);
-  assert.equal(entry.fatal, false, "a muted node is never asked for its inputs, so it still queues");
-  assert.deepEqual(fatalDanglingInputLinks(g), [], "and it must not reach the refusal");
-});
-
-test("#1571 P1 a VIRTUAL node's dangling input is reported but never fatal", () => {
-  const g = brokenSubgraph();
-  g._nodes = [{ id: 5, type: "Reroute", mode: 0, isVirtualNode: true, inputs: [{ name: "", link: 505 }] }];
-  const [entry] = danglingInputLinks(g);
-  assert.equal(entry.fatal, false);
-});
-
-test("#1571 P1 an ORDINARY node's dangling input is always fatal", () => {
-  // The mode the reported graph did NOT have, and the one with the widest blast radius:
-  // every input of a live node is resolved.
-  const g = brokenSubgraph();
-  g._nodes = [{ id: 9, type: "KSampler", mode: 0, inputs: [{ name: "positive", type: "CONDITIONING", link: 999 }] }];
-  assert.equal(danglingInputLinks(g)[0].fatal, true);
-  // …and a node with no `mode` at all is an ordinary node.
-  g._nodes = [{ id: 9, type: "KSampler", inputs: [{ name: "positive", link: 999 }] }];
-  assert.equal(danglingInputLinks(g)[0].fatal, true);
-});
-
-test("#1571 P1 a bypassed node's UNSELECTED input is not fatal", () => {
-  // `_getBypassSlotIndex` picks ONE input per output slot. A MASK input on a node whose
-  // only output is IMAGE is never resolved, so its dangling link cannot throw.
-  const g = brokenSubgraph();
-  g._nodes = [
-    {
-      id: 42,
-      type: "ImageBlend",
-      mode: 4,
-      inputs: [
-        { name: "image", type: "IMAGE", link: 473 },
-        { name: "mask", type: "MASK", link: 998 },
-      ],
-      outputs: [{ name: "IMAGE", type: "IMAGE", links: [474] }],
-    },
-  ];
-  const [entry] = danglingInputLinks(g);
-  assert.equal(entry.name, "mask");
-  assert.equal(entry.fatal, false, "no output type selects the MASK input");
-});
-
-test("#1571 P1 a bypassed node with NO connected output reaches nothing", () => {
-  // Bypass is only ever entered THROUGH a consumer. Nothing consumes an unlinked output.
-  const g = brokenSubgraph();
-  const node = rbg(505);
-  node.outputs = [{ name: "conditioning", type: "CONDITIONING", links: [] }];
-  g._nodes = [node];
-  assert.equal(danglingInputLinks(g)[0].fatal, false);
-});
-
-test("#1571 P1 the bypass slot selection mirrors _getBypassSlotIndex", () => {
-  const sel = (node) => [...bypassResolvedInputSlots(node)].sort((a, b) => a - b);
-  // Same-index input, compatible type → that slot.
-  assert.deepEqual(
-    sel({
-      inputs: [{ type: "IMAGE" }, { type: "MASK" }],
-      outputs: [{ type: "IMAGE", links: [1] }],
-    }),
-    [0],
-  );
-  // Same index incompatible → first exact type match.
-  assert.deepEqual(
-    sel({
-      inputs: [{ type: "MASK" }, { type: "IMAGE" }],
-      outputs: [{ type: "IMAGE", links: [1] }],
-    }),
-    [1],
-  );
-  // The same-slot preference BEATS the first exact match, and only a graph with two
-  // equally-typed inputs can tell the two rules apart. Getting this backwards marks the
-  // wrong input fatal in both directions — a false refusal on input 0 and silence on the
-  // one that actually breaks.
-  assert.deepEqual(
-    sel({
-      inputs: [{ type: "IMAGE" }, { type: "IMAGE" }],
-      outputs: [{ type: "LATENT", links: [] }, { type: "IMAGE", links: [1] }],
-    }),
-    [1],
-  );
-  // A wildcard output matches the same index, falling back to slot 0.
-  assert.deepEqual(sel({ inputs: [{ type: "MASK" }], outputs: [{ type: "*", links: [1] }] }), [0]);
-  // A wildcard INPUT is compatible with anything.
-  assert.deepEqual(sel({ inputs: [{ type: "*" }], outputs: [{ type: "LATENT", links: [1] }] }), [0]);
-  // Types are compared case-insensitively, as strings.
-  assert.deepEqual(sel({ inputs: [{ type: "image" }], outputs: [{ type: "IMAGE", links: [1] }] }), [0]);
-  // Unconnected outputs select nothing at all.
-  assert.deepEqual(sel({ inputs: [{ type: "IMAGE" }], outputs: [{ type: "IMAGE", links: [] }] }), []);
-  // Every connected output contributes its own selection.
-  assert.deepEqual(
-    sel({
-      inputs: [{ type: "IMAGE" }, { type: "MASK" }],
-      outputs: [{ type: "IMAGE", links: [1] }, { type: "MASK", links: [2] }],
-    }),
-    [0, 1],
-  );
-  // Junk is silent rather than throwing.
-  assert.deepEqual(sel({}), []);
-  assert.deepEqual(sel({ inputs: null, outputs: "nope" }), []);
 });
 
 test("#1571 a correctly converted subgraph yields nothing", () => {
@@ -279,7 +183,78 @@ test("#1571 the walk stays at ONE level", () => {
   assert.deepEqual(danglingInputLinks(g), []);
 });
 
-// ── The advisory signal ─────────────────────────────────────────────────────────────
+// ── WHICH findings may refuse (codex gate rounds 1–3) ───────────────────────────────
+//
+// `graphToPrompt` skips whole nodes before touching their inputs:
+//   if (node.isVirtualNode || node.mode === NEVER || node.mode === BYPASS) continue
+//   for (const [i, input] of node.inputs.entries()) node.resolveInput(i)   // ALL of them
+//
+// So a node it does NOT skip has every input resolved unconditionally — no type matching,
+// no consumer analysis, nothing to model. That, and only that, may refuse.
+
+test("#1571 an ORDINARY node's dangling input is provably reached", () => {
+  const g = certainlyBrokenSubgraph();
+  const [entry] = danglingInputLinks(g);
+  assert.equal(entry.certainly_reached, true);
+  assert.equal(fatalDanglingInputLinks(g).length, 1, "and it is what the refusal acts on");
+  // …and a node with no `mode` at all is an ordinary node: an unrecognised shape must err
+  // toward reporting a real break, not toward hiding one.
+  g._nodes = [{ id: 9, type: "KSampler", inputs: [{ name: "positive", link: 997 }] }];
+  assert.equal(danglingInputLinks(g)[0].certainly_reached, true);
+});
+
+test("#1571 a MUTED node's dangling input is reported but never refuses", () => {
+  // `resolveOutput` returns immediately for NEVER ("Muted nodes produce no output"), so
+  // neither the node nor its consumers reach the input. Refusing would un-ship the tool
+  // for a graph that queues perfectly well.
+  const g = brokenSubgraph();
+  g._nodes = [rbg(505, 2)];
+  const [entry] = danglingInputLinks(g);
+  assert.equal(entry.muted, true);
+  assert.equal(entry.certainly_reached, false);
+  assert.deepEqual(fatalDanglingInputLinks(g), [], "it must not reach the refusal");
+});
+
+test("#1571 a VIRTUAL node's dangling input is reported but never refuses", () => {
+  const g = brokenSubgraph();
+  g._nodes = [{ id: 5, type: "Reroute", mode: 0, isVirtualNode: true, inputs: [{ name: "", link: 505 }] }];
+  const [entry] = danglingInputLinks(g);
+  assert.equal(entry.virtual, true);
+  assert.equal(entry.certainly_reached, false);
+});
+
+test("#1571 a BYPASSED node's dangling input is reported but never refuses", () => {
+  // The reported case, and the whole point of round 3. Bypass reachability depends on the
+  // CONSUMER's type (`resolveOutput(link.origin_slot, type ?? input.type)`), on whether
+  // that consumer is itself skipped, and on LiteGraph's union-type matching. This module
+  // does not attempt to decide it, so it reports and does not refuse.
+  const g = brokenSubgraph();
+  assert.equal(danglingInputLinks(g)[0].bypassed, true);
+  assert.deepEqual(fatalDanglingInputLinks(g), []);
+});
+
+test("#1571 the refusal tier is decided by the SKIP LIST alone", () => {
+  // Pinned as a table so a future 'improvement' that reintroduces type or consumer
+  // reasoning has to change this test and explain itself.
+  const probe = (node) => {
+    const g = { links: new Map(), _nodes: [{ id: 1, inputs: [{ name: "in", link: 9 }], ...node }] };
+    return danglingInputLinks(g)[0].certainly_reached;
+  };
+  assert.equal(probe({ mode: 0 }), true, "ALWAYS");
+  assert.equal(probe({ mode: 1 }), true, "ON_EVENT");
+  assert.equal(probe({ mode: 3 }), true, "ON_TRIGGER");
+  assert.equal(probe({}), true, "no mode at all");
+  assert.equal(probe({ mode: 2 }), false, "NEVER");
+  assert.equal(probe({ mode: 4 }), false, "BYPASS");
+  assert.equal(probe({ mode: 0, isVirtualNode: true }), false, "virtual");
+  // Type and connectivity must make NO difference — the moment they do, the module is
+  // modelling the resolver again.
+  assert.equal(probe({ mode: 4, outputs: [{ type: "IMAGE", links: [1] }] }), false);
+  assert.equal(probe({ mode: 4, outputs: [] }), false);
+  assert.equal(probe({ mode: 0, outputs: [] }), true);
+});
+
+// ── The boundary signal ─────────────────────────────────────────────────────────────
 
 test("#1571 an unfed boundary input on the new node is reported", () => {
   // The reporter's own words: "avoid exposing a disconnected boundary input". Every slot
@@ -303,62 +278,88 @@ test("#1571 a fully fed subgraph node reports nothing, and junk is silent", () =
   }
 });
 
-// ── The refusal ─────────────────────────────────────────────────────────────────────
+// ── The two messages ────────────────────────────────────────────────────────────────
 
 const refusal = () =>
   brokenConversionRefusal({
+    what: "panel_subgraph_group",
+    subgraphNodeId: 302,
+    dangling: danglingInputLinks(certainlyBrokenSubgraph()),
+    disconnected: [{ slot: 0, name: "conditioning", type: "CONDITIONING" }],
+  });
+
+const warning = () =>
+  brokenConversionWarning({
     what: "panel_subgraph_group",
     subgraphNodeId: 302,
     dangling: danglingInputLinks(brokenSubgraph()),
     disconnected: [{ slot: 0, name: "conditioning", type: "CONDITIONING" }],
   });
 
-test("#1571 the refusal says the subgraph EXISTS — the opposite of its sibling", () => {
+test("#1571 both messages say the subgraph EXISTS — the opposite of their sibling", () => {
   // assertSubgraphNodeLanded's message says "nothing is being reported as created". Reusing
   // that wording here would send the caller to retry and wrap the same nodes a second time,
   // leaving two subgraph nodes on the canvas.
-  const msg = refusal();
-  assert.match(msg, /created subgraph node 302/);
-  assert.match(msg, /on the canvas/);
-  assert.match(msg, /Nothing has been undone/);
-  assert.doesNotMatch(msg, /Nothing is being reported as created/);
+  for (const msg of [refusal(), warning()]) {
+    assert.match(msg, /subgraph node 302/);
+    assert.match(msg, /Nothing has been undone/);
+    assert.doesNotMatch(msg, /Nothing is being reported as created/);
+  }
 });
 
-test("#1571 the refusal names the node, the slot and the link", () => {
-  const msg = refusal();
-  assert.match(msg, /RBG_Smart_Seed_Variance node 192/);
-  assert.match(msg, /input 0 "conditioning"/);
-  assert.match(msg, /link 505/);
-  assert.match(msg, /bypassed/, "the mode matters — a bypassed node is resolved THROUGH");
+test("#1571 both messages name the node, the slot and the link", () => {
+  assert.match(refusal(), /KSampler node 265 input 1 "positive" → link 997/);
+  const w = warning();
+  assert.match(w, /RBG_Smart_Seed_Variance node 192 \(bypassed\) input 0 "conditioning" → link 505/);
+  assert.match(w, /bypassed/, "the mode matters — it is why the verdict is withheld");
 });
 
-test("#1571 the refusal connects itself to the error the run would have shown", () => {
+test("#1571 both messages connect themselves to the error the run would show", () => {
   // The whole cost of the bug: `[302:192]` appeared for the first time at run time, with
   // nothing tying it to the conversion. Printing it here is what closes that gap.
-  assert.match(refusal(), /No link found in parent graph for id \[302:192\] slot \[0\]/);
+  assert.match(refusal(), /No link found in parent graph for id \[302:265\] slot \[1\]/);
+  assert.match(warning(), /No link found in parent graph for id \[302:192\] slot \[0\]/);
 });
 
-test("#1571 the refusal offers both recoveries and does not claim to have repaired anything", () => {
-  const msg = refusal();
-  assert.match(msg, /Ctrl\+Z|undo/i);
-  assert.match(msg, /panel_enter_subgraph/);
-  assert.match(msg, /panel_expose_subgraph_input/);
-  assert.doesNotMatch(msg, /has been (repaired|fixed|reconnected)/i);
+test("#1571 the REFUSAL asserts the workflow cannot run; the WARNING does not", () => {
+  // The distinction the third gate round was about. Overstating the warning is exactly the
+  // failure the refusal tier was narrowed to avoid.
+  assert.match(refusal(), /UNSERIALIZABLE/);
+  assert.match(refusal(), /cannot be run or queued/);
+  assert.match(refusal(), /resolves unconditionally/);
+
+  const w = warning();
+  assert.doesNotMatch(w, /cannot be run or queued/);
+  assert.doesNotMatch(w, /UNSERIALIZABLE/);
+  assert.match(w, /not something the panel can decide/);
+  assert.match(w, /a warning, not a refusal/);
+  assert.match(w, /reported as created/);
+  // And it names who CAN decide, plus the fact that answer is now visible (#1571's other
+  // half) rather than being swallowed.
+  assert.match(w, /Run the workflow to get the authoritative answer/);
+  assert.match(w, /passes that through verbatim/);
 });
 
-test("#1571 the refusal attributes the cause to the frontend, without hiding behind it", () => {
-  const msg = refusal();
-  assert.match(msg, /convertToSubgraph produced this/);
-  assert.match(msg, /comfyui-mcp#1571/);
+test("#1571 both messages offer the recoveries and claim no repair", () => {
+  for (const msg of [refusal(), warning()]) {
+    assert.match(msg, /Ctrl\+Z|undo/i);
+    assert.match(msg, /panel_enter_subgraph/);
+    assert.match(msg, /panel_expose_subgraph_input/);
+    assert.doesNotMatch(msg, /has been (repaired|fixed|reconnected)/i);
+    assert.match(msg, /convertToSubgraph produced this/);
+    assert.match(msg, /comfyui-mcp#1571/);
+  }
 });
 
-test("#1571 the unfed boundary slots ride along in the refusal", () => {
-  assert.match(refusal(), /input slot\(s\) that nothing in the parent graph feeds/);
+test("#1571 the unfed boundary slots ride along in both messages", () => {
+  for (const msg of [refusal(), warning()]) {
+    assert.match(msg, /input slot\(s\) that nothing in the parent graph feeds/);
+  }
   // …and are omitted entirely when there are none, rather than printed as "0".
   const none = brokenConversionRefusal({
     what: "panel_create_subgraph",
     subgraphNodeId: 9,
-    dangling: danglingInputLinks(brokenSubgraph()),
+    dangling: danglingInputLinks(certainlyBrokenSubgraph()),
     disconnected: [],
   });
   assert.doesNotMatch(none, /input slot\(s\) that nothing/);
@@ -371,70 +372,71 @@ test("#1571 a long list of broken inputs stays readable", () => {
     slot: 0,
     name: "in",
     link_id: 1000 + i,
-    bypassed: false,
+    certainly_reached: true,
   }));
-  const msg = brokenConversionRefusal({
-    what: "panel_subgraph_group",
-    subgraphNodeId: 302,
-    dangling: many,
-    disconnected: [],
-  });
-  assert.ok(msg.length < 2000, `refusal must stay readable, was ${msg.length} chars`);
-  assert.match(msg, /and 32 more/);
+  for (const compose of [brokenConversionRefusal, brokenConversionWarning]) {
+    const msg = compose({
+      what: "panel_subgraph_group",
+      subgraphNodeId: 302,
+      dangling: many,
+      disconnected: [],
+    });
+    assert.ok(msg.length < 2200, `message must stay readable, was ${msg.length} chars`);
+    assert.match(msg, /and 32 more/);
+  }
 });
 
-test("#1571 the refusal survives entries it cannot fully describe", () => {
-  // It is composed while explaining a failure; throwing here would replace a useful
-  // refusal with a second, unrelated error.
-  const msg = brokenConversionRefusal({
-    what: "panel_subgraph_group",
-    subgraphNodeId: undefined,
-    dangling: [{ node_id: null, node_type: null, slot: 2, name: null, link_id: 9, bypassed: false }],
-    disconnected: null,
-  });
-  assert.match(msg, /link 9/);
-  assert.match(msg, /input 2/);
+test("#1571 the messages survive entries they cannot fully describe", () => {
+  // They are composed while explaining a failure; throwing here would replace a useful
+  // report with a second, unrelated error.
+  for (const compose of [brokenConversionRefusal, brokenConversionWarning]) {
+    const msg = compose({
+      what: "panel_subgraph_group",
+      subgraphNodeId: undefined,
+      dangling: [{ node_id: null, node_type: null, slot: 2, name: null, link_id: 9 }],
+      disconnected: null,
+    });
+    assert.match(msg, /link 9/);
+    assert.match(msg, /input 2/);
+  }
 });
 
 // ── WIRING. The helpers above are inert unless both conversion tools consult them, and
-//    that is two lines inside a 30k-line file. Deleting either one leaves every test
+//    that is a few lines inside a 30k-line file. Deleting any of them leaves every test
 //    above green — which is exactly how #1571 shipped in the first place.
 
 test("#1571 BOTH conversion paths assert serializability, AFTER the node landed", () => {
   const s = src();
   for (const tool of ["panel_create_subgraph", "panel_subgraph_group"]) {
     const landed = s.indexOf(`assertSubgraphNodeLanded(res, graph, "${tool}")`);
-    const serializable = s.indexOf(`assertSubgraphConversionSerializable(res, `);
     assert.ok(landed > 0, `${tool} must still assert the node landed`);
-    const call = new RegExp(
-      `assertSubgraphConversionSerializable\\(res, \\w+, "${tool}"\\)`,
-    );
+    const call = new RegExp(`assertSubgraphConversionSerializable\\(res, \\w+, "${tool}"\\)`);
     assert.match(s, call, `${tool} must assert the conversion is serializable`);
-    assert.ok(serializable > 0);
     // ORDER: the serializability check reads the node the landing check returned, so a
     // conversion that produced nothing must fail with the sibling's clearer message.
-    assert.ok(
-      s.search(call) > landed,
-      `${tool} must check the node landed BEFORE checking it serializes`,
-    );
+    assert.ok(s.search(call) > landed, `${tool} must check it landed BEFORE checking it serializes`);
   }
+});
+
+test("#1571 only the PROVABLE tier refuses, and the rest becomes a warning", () => {
+  const s = src();
+  assert.match(s, /const certain = dangling\.filter\(\(entry\) => entry\.certainly_reached\);/);
+  assert.match(s, /const unproven = dangling\.filter\(\(entry\) => !entry\.certainly_reached\);/);
+  assert.match(s, /if \(certain\.length\) \{/);
+  assert.match(s, /brokenConversionWarning\(\{ what, subgraphNodeId: node\?\.id, dangling: unproven/);
 });
 
 test("#1571 the advisory findings reach the reported payload on both paths", () => {
   // A finding computed and then dropped on the floor is the same as no finding. This is a
   // one-line spread that no helper test can see.
-  const s = src();
-  const occurrences = s.match(/\.\.\.subgraphConversionAdvisories\(advisories\)/g) ?? [];
+  const occurrences = src().match(/\.\.\.subgraphConversionAdvisories\(advisories\)/g) ?? [];
   assert.equal(occurrences.length, 2, "both conversion tools must report the advisories");
-  // …and only the FATAL findings may refuse (codex gate P1).
-  assert.match(s, /const fatal = dangling\.filter\(\(entry\) => entry\.fatal\);/);
-  assert.match(s, /if \(fatal\.length\) \{/);
 });
 
 test("#1571 the guard is imported, not shadowed by a local stub", () => {
   assert.match(
     src(),
-    /import \{\s*danglingInputLinks,\s*disconnectedBoundaryInputs,\s*brokenConversionRefusal,\s*\} from "\.\/lib\/subgraph-conversion-integrity\.js";/,
+    /import \{\s*danglingInputLinks,\s*disconnectedBoundaryInputs,\s*brokenConversionRefusal,\s*brokenConversionWarning,\s*\} from "\.\/lib\/subgraph-conversion-integrity\.js";/,
   );
 });
 
@@ -454,9 +456,9 @@ function realExecutor(name, args, convertToSubgraph, wrapper) {
     /function assertSubgraphConversionSerializable\(res, node, what\) \{[\s\S]*?\r?\n\}/,
   );
   const advisories = s.match(
-    /function subgraphConversionAdvisories\(\{ disconnected, dormant \}\) \{[\s\S]*?\r?\n\}/,
+    /function subgraphConversionAdvisories\(\{ disconnected, dangling, warning \}\) \{[\s\S]*?\r?\n\}/,
   );
-  assert.ok(landed && serializable && advisories, "the conversion guards must be locatable in the source");
+  assert.ok(landed && serializable && advisories, "the conversion guards must be locatable");
   const graph = {
     _nodes: [wrapper],
     getNodeById: (id) => ({ id: Number(id) }),
@@ -487,8 +489,9 @@ function realExecutor(name, args, convertToSubgraph, wrapper) {
       "danglingInputLinks",
       "disconnectedBoundaryInputs",
       "brokenConversionRefusal",
+      "brokenConversionWarning",
       `return ${serializable[0]};`,
-    )(danglingInputLinks, disconnectedBoundaryInputs, brokenConversionRefusal),
+    )(danglingInputLinks, disconnectedBoundaryInputs, brokenConversionRefusal, brokenConversionWarning),
     new Function(`return ${advisories[0]};`)(),
   );
 }
@@ -500,101 +503,57 @@ const wrapperNode = (link) => ({
   inputs: [{ name: "conditioning", type: "CONDITIONING", link }],
 });
 
-test("#1571 BEHAVIOUR: panel_subgraph_group REFUSES the reported conversion", () => {
-  const wrapper = wrapperNode(null);
-  const group = realExecutor(
-    "graph_subgraph_group",
-    "\\{ group \\}",
-    () => ({ node: wrapper, subgraph: brokenSubgraph() }),
-    wrapper,
-  );
-  assert.throws(
-    () => group({ group: "COMBOS VARIANCE" }),
-    (err) => {
-      assert.match(err.message, /panel_subgraph_group created subgraph node 302/);
-      assert.match(err.message, /RBG_Smart_Seed_Variance node 192 \(bypassed\) input 0 "conditioning" → link 505/);
-      assert.match(err.message, /No link found in parent graph for id \[302:192\]/);
-      return true;
-    },
-    "the tool that reported success must now refuse",
-  );
-});
+const runGroup = (subgraph, wrapper) =>
+  realExecutor("graph_subgraph_group", "\\{ group \\}", () => ({ node: wrapper, subgraph }), wrapper)({
+    group: "COMBOS VARIANCE",
+  });
 
-test("#1571 BEHAVIOUR: a healthy conversion still reports success, with the unfed slot named", () => {
-  // The direction that would break the tool for everyone. Same executor, same wrapper —
-  // only the subgraph's link table differs.
+test("#1571 BEHAVIOUR: the reported conversion succeeds, carrying the finding it used to hide", () => {
+  // The reported node is bypassed, so the honest answer is a warning, not a refusal — and
+  // the caller learns the node, slot and link at the moment of the conversion, which is
+  // precisely what they lacked.
   const wrapper = wrapperNode(null);
-  const group = realExecutor(
-    "graph_subgraph_group",
-    "\\{ group \\}",
-    () => ({ node: wrapper, subgraph: healthySubgraph() }),
-    wrapper,
-  );
-  const out = group({ group: "COMBOS VARIANCE" });
+  const out = runGroup(brokenSubgraph(), wrapper);
   assert.equal(out.subgraph.node_id, 302);
   assert.deepEqual(out.subgraph.from_nodes, [192, 265, 273]);
-  // The advisory tier: reported, never fatal.
+  assert.equal(out.subgraph.dangling_inputs.length, 1);
+  assert.equal(out.subgraph.dangling_inputs[0].node_id, 192);
+  assert.equal(out.subgraph.dangling_inputs[0].link_id, 505);
+  assert.match(out.subgraph.warning, /RBG_Smart_Seed_Variance node 192/);
   assert.deepEqual(out.subgraph.unfed_boundary_inputs, [
     { slot: 0, name: "conditioning", type: "CONDITIONING" },
   ]);
 });
 
-test("#1571 BEHAVIOUR: a fully healthy conversion carries no advisory key at all", () => {
-  // An `unfed_boundary_inputs: []` on every clean conversion would read as a finding.
-  const wrapper = wrapperNode(505);
-  const group = realExecutor(
-    "graph_subgraph_group",
-    "\\{ group \\}",
-    () => ({ node: wrapper, subgraph: healthySubgraph() }),
-    wrapper,
+test("#1571 BEHAVIOUR: a PROVABLY broken conversion is refused", () => {
+  const wrapper = wrapperNode(null);
+  assert.throws(
+    () => runGroup(certainlyBrokenSubgraph(), wrapper),
+    (err) => {
+      assert.match(err.message, /panel_subgraph_group created subgraph node 302/);
+      assert.match(err.message, /UNSERIALIZABLE/);
+      assert.match(err.message, /KSampler node 265 input 1 "positive" → link 997/);
+      return true;
+    },
   );
-  const out = group({ group: "COMBOS VARIANCE" });
-  assert.ok(!("unfed_boundary_inputs" in out.subgraph), "a clean conversion reports no advisory");
 });
 
-test("#1571 P1 BEHAVIOUR: a conversion whose only breakage is MUTED still succeeds", () => {
-  // The over-refusal the gate caught, driven through the real executor. This graph queues
-  // today, so the tool must report it — with the finding attached, not swallowed.
-  const wrapper = wrapperNode(505);
-  const muted = brokenSubgraph();
-  muted._nodes = [rbg(505, 2)];
-  const group = realExecutor(
-    "graph_subgraph_group",
-    "\\{ group \\}",
-    () => ({ node: wrapper, subgraph: muted }),
-    wrapper,
-  );
-  const out = group({ group: "COMBOS VARIANCE" });
-  assert.equal(out.subgraph.node_id, 302, "a runnable graph must not be refused");
-  assert.equal(out.subgraph.dangling_inputs_not_reached.length, 1);
-  assert.equal(out.subgraph.dangling_inputs_not_reached[0].node_id, 192);
-  assert.ok(!("unfed_boundary_inputs" in out.subgraph));
+test("#1571 BEHAVIOUR: a healthy conversion carries no advisory key at all", () => {
+  // The direction that would break the tool for everyone. An `unfed_boundary_inputs: []`
+  // or a `warning: null` on every clean conversion reads as a finding.
+  const out = runGroup(healthySubgraph(), wrapperNode(505));
+  assert.equal(out.subgraph.node_id, 302);
+  for (const key of ["unfed_boundary_inputs", "dangling_inputs", "warning"]) {
+    assert.ok(!(key in out.subgraph), `a clean conversion must not report ${key}`);
+  }
 });
 
-test("#1571 P1 the refusal separates what is broken NOW from what is only latent", () => {
-  const g = brokenSubgraph();
-  g._nodes = [rbg(505), { id: 77, type: "Note", mode: 2, inputs: [{ name: "text", link: 997 }] }];
-  const all = danglingInputLinks(g);
-  const msg = brokenConversionRefusal({
-    what: "panel_subgraph_group",
-    subgraphNodeId: 302,
-    dangling: all.filter((e) => e.fatal),
-    dormant: all.filter((e) => !e.fatal),
-    disconnected: [],
-  });
-  assert.match(msg, /1 input inside the new subgraph still references/, "only the fatal one counts");
-  assert.doesNotMatch(msg, /2 inputs inside/, "the dormant one must not inflate the breakage");
-  assert.match(msg, /NOT reached by the serializer today/);
-  assert.match(msg, /Note node 77 \(muted\)/);
-  assert.match(msg, /re-enabled or rewired/);
-});
-
-test("#1571 BEHAVIOUR: panel_create_subgraph refuses the same corruption", () => {
+test("#1571 BEHAVIOUR: panel_create_subgraph refuses the same provable corruption", () => {
   const wrapper = wrapperNode(null);
   const create = realExecutor(
     "graph_create_subgraph",
     "\\{ node_ids \\}",
-    () => ({ node: wrapper, subgraph: brokenSubgraph() }),
+    () => ({ node: wrapper, subgraph: certainlyBrokenSubgraph() }),
     wrapper,
   );
   assert.throws(

--- a/browser_tests/unit/subgraph-stale-outline.test.mjs
+++ b/browser_tests/unit/subgraph-stale-outline.test.mjs
@@ -62,6 +62,11 @@ const assertSubgraphConversionSerializable = new Function(
   "brokenConversionRefusal",
   `return ${serializableMatch[0]};`,
 )(danglingInputLinks, disconnectedBoundaryInputs, brokenConversionRefusal);
+const advisoriesMatch = panelSrc.match(
+  /function subgraphConversionAdvisories\(\{ disconnected, dormant \}\) \{[\s\S]*?\r?\n\}/,
+);
+assert.ok(advisoriesMatch, "could not locate subgraphConversionAdvisories in panel source");
+const subgraphConversionAdvisories = new Function(`return ${advisoriesMatch[0]};`)();
 
 function realCreate(getGraphCtx, clearStaleRedFlagsAfterSubgraphConversion) {
   return new Function(
@@ -69,12 +74,14 @@ function realCreate(getGraphCtx, clearStaleRedFlagsAfterSubgraphConversion) {
     "clearStaleRedFlagsAfterSubgraphConversion",
     "assertSubgraphNodeLanded",
     "assertSubgraphConversionSerializable",
+    "subgraphConversionAdvisories",
     `const executors = { ${createSource} }; return executors.graph_create_subgraph;`,
   )(
     getGraphCtx,
     clearStaleRedFlagsAfterSubgraphConversion,
     assertSubgraphNodeLanded,
     assertSubgraphConversionSerializable,
+    subgraphConversionAdvisories,
   );
 }
 
@@ -93,6 +100,7 @@ function realGroup(
     "clearStaleRedFlagsAfterSubgraphConversion",
     "assertSubgraphNodeLanded",
     "assertSubgraphConversionSerializable",
+    "subgraphConversionAdvisories",
     `const executors = { ${groupSource} }; return executors.graph_subgraph_group;`,
   )(
     getGraphCtx,
@@ -102,6 +110,7 @@ function realGroup(
     clearStaleRedFlagsAfterSubgraphConversion,
     assertSubgraphNodeLanded,
     assertSubgraphConversionSerializable,
+    subgraphConversionAdvisories,
   );
 }
 

--- a/browser_tests/unit/subgraph-stale-outline.test.mjs
+++ b/browser_tests/unit/subgraph-stale-outline.test.mjs
@@ -13,6 +13,7 @@ import {
   danglingInputLinks,
   disconnectedBoundaryInputs,
   brokenConversionRefusal,
+  brokenConversionWarning,
 } from "../../web/js/lib/subgraph-conversion-integrity.js";
 
 const panelPath = fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url));
@@ -60,10 +61,11 @@ const assertSubgraphConversionSerializable = new Function(
   "danglingInputLinks",
   "disconnectedBoundaryInputs",
   "brokenConversionRefusal",
+  "brokenConversionWarning",
   `return ${serializableMatch[0]};`,
-)(danglingInputLinks, disconnectedBoundaryInputs, brokenConversionRefusal);
+)(danglingInputLinks, disconnectedBoundaryInputs, brokenConversionRefusal, brokenConversionWarning);
 const advisoriesMatch = panelSrc.match(
-  /function subgraphConversionAdvisories\(\{ disconnected, dormant \}\) \{[\s\S]*?\r?\n\}/,
+  /function subgraphConversionAdvisories\(\{ disconnected, dangling, warning \}\) \{[\s\S]*?\r?\n\}/,
 );
 assert.ok(advisoriesMatch, "could not locate subgraphConversionAdvisories in panel source");
 const subgraphConversionAdvisories = new Function(`return ${advisoriesMatch[0]};`)();

--- a/browser_tests/unit/subgraph-stale-outline.test.mjs
+++ b/browser_tests/unit/subgraph-stale-outline.test.mjs
@@ -9,6 +9,11 @@ import {
   collectMissingNodeTypeReasons,
   nodeRedFlagIsStale,
 } from "../../web/js/lib/asset-staleness.js";
+import {
+  danglingInputLinks,
+  disconnectedBoundaryInputs,
+  brokenConversionRefusal,
+} from "../../web/js/lib/subgraph-conversion-integrity.js";
 
 const panelPath = fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url));
 const panelSrc = readFileSync(panelPath, "utf8");
@@ -42,13 +47,35 @@ const assertSubgraphNodeLanded = new Function(
   `return ${landedMatch[0]};`,
 )();
 
+// #1571 — and the same again for the serializability guard the two executors now run
+// after the landing check. Injected from the REAL source with the REAL lib helpers, for
+// the same reason: a stub here would hide a regression in the shipped guard. Both
+// helpers answer "no findings" for the deliberately minimal graphs below (no readable
+// link table, no inputs on the wrapper), which is the fail-silent property they promise.
+const serializableMatch = panelSrc.match(
+  /function assertSubgraphConversionSerializable\(res, node, what\) \{[\s\S]*?\r?\n\}/,
+);
+assert.ok(serializableMatch, "could not locate assertSubgraphConversionSerializable in panel source");
+const assertSubgraphConversionSerializable = new Function(
+  "danglingInputLinks",
+  "disconnectedBoundaryInputs",
+  "brokenConversionRefusal",
+  `return ${serializableMatch[0]};`,
+)(danglingInputLinks, disconnectedBoundaryInputs, brokenConversionRefusal);
+
 function realCreate(getGraphCtx, clearStaleRedFlagsAfterSubgraphConversion) {
   return new Function(
     "getGraphCtx",
     "clearStaleRedFlagsAfterSubgraphConversion",
     "assertSubgraphNodeLanded",
+    "assertSubgraphConversionSerializable",
     `const executors = { ${createSource} }; return executors.graph_create_subgraph;`,
-  )(getGraphCtx, clearStaleRedFlagsAfterSubgraphConversion, assertSubgraphNodeLanded);
+  )(
+    getGraphCtx,
+    clearStaleRedFlagsAfterSubgraphConversion,
+    assertSubgraphNodeLanded,
+    assertSubgraphConversionSerializable,
+  );
 }
 
 function realGroup(
@@ -65,6 +92,7 @@ function realGroup(
     "groupMemberNodes",
     "clearStaleRedFlagsAfterSubgraphConversion",
     "assertSubgraphNodeLanded",
+    "assertSubgraphConversionSerializable",
     `const executors = { ${groupSource} }; return executors.graph_subgraph_group;`,
   )(
     getGraphCtx,
@@ -73,6 +101,7 @@ function realGroup(
     groupMemberNodes,
     clearStaleRedFlagsAfterSubgraphConversion,
     assertSubgraphNodeLanded,
+    assertSubgraphConversionSerializable,
   );
 }
 

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -283,6 +283,11 @@ import {
   unresolvedNodeTypes,
 } from "./lib/missing-node-preflight.js";
 import {
+  danglingInputLinks,
+  disconnectedBoundaryInputs,
+  brokenConversionRefusal,
+} from "./lib/subgraph-conversion-integrity.js";
+import {
   classifyWorkflowRefresh,
   knownSelectorSample,
   openWorkflowNotFoundMessage,
@@ -8301,6 +8306,29 @@ function assertSubgraphNodeLanded(res, graph, what) {
   return node;
 }
 
+/** Confirm the subgraph `convertToSubgraph` produced can actually be SERIALIZED.
+ *
+ *  #1571 — the sibling above answers "did a node land?". A conversion can answer yes to
+ *  that and still leave the new subgraph holding an input that references a link id the
+ *  subgraph does not contain, which is the one condition ComfyUI's own
+ *  `ExecutableNodeDTO.resolveInput` throws `InvalidLinkError` on. The tool reported
+ *  success; the workflow could not be run afterwards, and the run's error named a
+ *  flattened id (`[302:192]`) with no visible connection to this call.
+ *
+ *  Returns the advisory (never fatal) list of unfed boundary input slots so the caller
+ *  can report them on a conversion that is otherwise fine. See
+ *  lib/subgraph-conversion-integrity.js for why the two signals have different weights. */
+function assertSubgraphConversionSerializable(res, node, what) {
+  const dangling = danglingInputLinks(res?.subgraph);
+  const disconnected = disconnectedBoundaryInputs(node);
+  if (dangling.length) {
+    throw new Error(
+      brokenConversionRefusal({ what, subgraphNodeId: node?.id, dangling, disconnected }),
+    );
+  }
+  return disconnected;
+}
+
 function clearStaleRedFlagsAfterSubgraphConversion(res, { app, graph, rootGraph }) {
   try {
     for (const id of collectLinkedNeighborNodeIds(res?.node, graph?.links)) {
@@ -15270,11 +15298,15 @@ const GRAPH_TOOL_EXECUTORS = {
     // `node_id: null` inside a `subgraph:` payload reads as a success with a missing
     // field, not as a failure. Refuse instead — see assertSubgraphNodeLanded.
     const created = assertSubgraphNodeLanded(res, graph, "panel_create_subgraph");
+    // #1571: a node that LANDED can still be unserializable. Refuse rather than report a
+    // success the next run will contradict — see assertSubgraphConversionSerializable.
+    const unfedInputs = assertSubgraphConversionSerializable(res, created, "panel_create_subgraph");
     return {
       subgraph: {
         node_id: created.id,
         name: res?.subgraph?.name ?? null,
         from_nodes: ns.map((n) => n.id),
+        ...(unfedInputs.length ? { unfed_boundary_inputs: unfedInputs } : {}),
       },
     };
   },
@@ -15315,12 +15347,16 @@ const GRAPH_TOOL_EXECUTORS = {
     // Same guard as panel_create_subgraph: a conversion that produced no node must
     // not report a subgraph with a null id.
     const grouped = assertSubgraphNodeLanded(res, graph, "panel_subgraph_group");
+    // #1571 was reported through THIS path: the group held a bypassed node whose input
+    // link did not survive the conversion, and the tool said "subgraph created".
+    const unfedInputs = assertSubgraphConversionSerializable(res, grouped, "panel_subgraph_group");
     return {
       subgraph: {
         node_id: grouped.id,
         name: res?.subgraph?.name ?? null,
         from_group: g.title ?? null,
         from_nodes: ns.map((n) => n.id),
+        ...(unfedInputs.length ? { unfed_boundary_inputs: unfedInputs } : {}),
       },
     };
   },

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -286,6 +286,7 @@ import {
   danglingInputLinks,
   disconnectedBoundaryInputs,
   brokenConversionRefusal,
+  brokenConversionWarning,
 } from "./lib/subgraph-conversion-integrity.js";
 import {
   classifyWorkflowRefresh,
@@ -8315,39 +8316,42 @@ function assertSubgraphNodeLanded(res, graph, what) {
  *  success; the workflow could not be run afterwards, and the run's error named a
  *  flattened id (`[302:192]`) with no visible connection to this call.
  *
- *  ONLY the dangling inputs the serializer actually reaches refuse (codex gate P1): a
- *  muted node is never asked for its inputs, and a bypassed node resolves only the one
- *  input its output type selects, so refusing on those would break conversions of graphs
- *  that queue perfectly well.
+ *  It REFUSES only where the break is provable with no modelling at all — a dangling
+ *  input on a node the serializer does not skip, whose every input it therefore resolves
+ *  unconditionally. Corruption on a muted, bypassed or virtual node is reached only
+ *  through a consumer chain that ComfyUI's resolver alone can walk (three review rounds
+ *  killed three attempts to walk it from here), so that tier is reported as a WARNING on
+ *  the success payload instead of refusing a workflow that may run perfectly well.
  *
- *  Returns the ADVISORY (never fatal) findings so the caller can report them on a
- *  conversion that is otherwise fine. See lib/subgraph-conversion-integrity.js for why
- *  the three signals have different weights. */
+ *  Returns the advisory findings so the caller can report them on a conversion that is
+ *  not refused. See lib/subgraph-conversion-integrity.js for the whole argument. */
 function assertSubgraphConversionSerializable(res, node, what) {
   const dangling = danglingInputLinks(res?.subgraph);
-  const fatal = dangling.filter((entry) => entry.fatal);
-  const dormant = dangling.filter((entry) => !entry.fatal);
+  const certain = dangling.filter((entry) => entry.certainly_reached);
+  const unproven = dangling.filter((entry) => !entry.certainly_reached);
   const disconnected = disconnectedBoundaryInputs(node);
-  if (fatal.length) {
+  if (certain.length) {
     throw new Error(
-      brokenConversionRefusal({
-        what,
-        subgraphNodeId: node?.id,
-        dangling: fatal,
-        disconnected,
-        dormant,
-      }),
+      brokenConversionRefusal({ what, subgraphNodeId: node?.id, dangling: certain, disconnected }),
     );
   }
-  return { disconnected, dormant };
+  const warning = unproven.length
+    ? brokenConversionWarning({ what, subgraphNodeId: node?.id, dangling: unproven, disconnected })
+    : null;
+  return { disconnected, dangling: unproven, warning };
 }
 
-/** The advisory keys a CLEAN conversion reports, omitted entirely when empty — an
- *  `unfed_boundary_inputs: []` on every healthy conversion reads as a finding. */
-function subgraphConversionAdvisories({ disconnected, dormant }) {
+/** The advisory keys a conversion reports, omitted entirely when empty — an
+ *  `unfed_boundary_inputs: []` on every healthy conversion reads as a finding.
+ *
+ *  `warning` carries the same findings as PROSE. A caller that reads only the message
+ *  and a caller that reads only the structured list must both learn about the
+ *  corruption; shipping it in one form alone is how a finding goes unnoticed. */
+function subgraphConversionAdvisories({ disconnected, dangling, warning }) {
   return {
     ...(disconnected.length ? { unfed_boundary_inputs: disconnected } : {}),
-    ...(dormant.length ? { dangling_inputs_not_reached: dormant } : {}),
+    ...(dangling.length ? { dangling_inputs: dangling } : {}),
+    ...(warning ? { warning } : {}),
   };
 }
 

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -8315,18 +8315,40 @@ function assertSubgraphNodeLanded(res, graph, what) {
  *  success; the workflow could not be run afterwards, and the run's error named a
  *  flattened id (`[302:192]`) with no visible connection to this call.
  *
- *  Returns the advisory (never fatal) list of unfed boundary input slots so the caller
- *  can report them on a conversion that is otherwise fine. See
- *  lib/subgraph-conversion-integrity.js for why the two signals have different weights. */
+ *  ONLY the dangling inputs the serializer actually reaches refuse (codex gate P1): a
+ *  muted node is never asked for its inputs, and a bypassed node resolves only the one
+ *  input its output type selects, so refusing on those would break conversions of graphs
+ *  that queue perfectly well.
+ *
+ *  Returns the ADVISORY (never fatal) findings so the caller can report them on a
+ *  conversion that is otherwise fine. See lib/subgraph-conversion-integrity.js for why
+ *  the three signals have different weights. */
 function assertSubgraphConversionSerializable(res, node, what) {
   const dangling = danglingInputLinks(res?.subgraph);
+  const fatal = dangling.filter((entry) => entry.fatal);
+  const dormant = dangling.filter((entry) => !entry.fatal);
   const disconnected = disconnectedBoundaryInputs(node);
-  if (dangling.length) {
+  if (fatal.length) {
     throw new Error(
-      brokenConversionRefusal({ what, subgraphNodeId: node?.id, dangling, disconnected }),
+      brokenConversionRefusal({
+        what,
+        subgraphNodeId: node?.id,
+        dangling: fatal,
+        disconnected,
+        dormant,
+      }),
     );
   }
-  return disconnected;
+  return { disconnected, dormant };
+}
+
+/** The advisory keys a CLEAN conversion reports, omitted entirely when empty — an
+ *  `unfed_boundary_inputs: []` on every healthy conversion reads as a finding. */
+function subgraphConversionAdvisories({ disconnected, dormant }) {
+  return {
+    ...(disconnected.length ? { unfed_boundary_inputs: disconnected } : {}),
+    ...(dormant.length ? { dangling_inputs_not_reached: dormant } : {}),
+  };
 }
 
 function clearStaleRedFlagsAfterSubgraphConversion(res, { app, graph, rootGraph }) {
@@ -15300,13 +15322,13 @@ const GRAPH_TOOL_EXECUTORS = {
     const created = assertSubgraphNodeLanded(res, graph, "panel_create_subgraph");
     // #1571: a node that LANDED can still be unserializable. Refuse rather than report a
     // success the next run will contradict — see assertSubgraphConversionSerializable.
-    const unfedInputs = assertSubgraphConversionSerializable(res, created, "panel_create_subgraph");
+    const advisories = assertSubgraphConversionSerializable(res, created, "panel_create_subgraph");
     return {
       subgraph: {
         node_id: created.id,
         name: res?.subgraph?.name ?? null,
         from_nodes: ns.map((n) => n.id),
-        ...(unfedInputs.length ? { unfed_boundary_inputs: unfedInputs } : {}),
+        ...subgraphConversionAdvisories(advisories),
       },
     };
   },
@@ -15349,14 +15371,14 @@ const GRAPH_TOOL_EXECUTORS = {
     const grouped = assertSubgraphNodeLanded(res, graph, "panel_subgraph_group");
     // #1571 was reported through THIS path: the group held a bypassed node whose input
     // link did not survive the conversion, and the tool said "subgraph created".
-    const unfedInputs = assertSubgraphConversionSerializable(res, grouped, "panel_subgraph_group");
+    const advisories = assertSubgraphConversionSerializable(res, grouped, "panel_subgraph_group");
     return {
       subgraph: {
         node_id: grouped.id,
         name: res?.subgraph?.name ?? null,
         from_group: g.title ?? null,
         from_nodes: ns.map((n) => n.id),
-        ...(unfedInputs.length ? { unfed_boundary_inputs: unfedInputs } : {}),
+        ...subgraphConversionAdvisories(advisories),
       },
     };
   },

--- a/web/js/lib/run-scope-guard.js
+++ b/web/js/lib/run-scope-guard.js
@@ -848,13 +848,54 @@ export function scopeDroppedError({ toNodeId, verdict }) {
  * (graphToPrompt failed before dispatch). Without a signature our dispatch
  * can't be told apart from a stranger's, so a scoped run must NOT dispatch at
  * all — fail closed, nothing queued.
+ *
+ * #1571 — `cause` is the error `graphToPrompt` actually threw, and dropping it was
+ * expensive. The reporter's graph had been left unserializable by a subgraph
+ * conversion; ComfyUI threw `InvalidLinkError: No link found in parent graph for id
+ * [302:192] slot [0] conditioning`, which names the offending node outright. This
+ * refusal caught it, discarded it, and said only "graphToPrompt failed" — so the
+ * reporter concluded that run-to-node "cannot fingerprint NESTED output targets".
+ * Nesting had nothing to do with it. The panel knew the real reason and did not say it.
+ *
+ * The cause is quoted, never interpreted: this path cannot tell a corrupt graph from a
+ * missing pack from an extension throwing inside its own serializer, and guessing
+ * between them is how a reporter gets sent to fix the wrong thing. `cause` is optional
+ * because the refusal also fires with nothing thrown at all — a frontend with no
+ * `graphToPrompt`, or a prompt that canonicalizes to nothing — and inventing a cause
+ * for those would be the same defect pointed the other way.
  */
-export function scopeUnattributableError({ toNodeId }) {
+export function scopeUnattributableError({ toNodeId, cause } = {}) {
+  const reason = describeFingerprintFailure(cause);
   return (
     `run-to-node scope for node ${toNodeId} cannot be dispatched safely: the ` +
     `prompt could not be fingerprinted (graphToPrompt failed), so the panel ` +
     `cannot distinguish its own dispatch from unrelated queue traffic. ` +
+    `${reason}` +
     `Nothing was queued rather than risk a full-graph execution (#556).`
+  );
+}
+
+/** How many characters of a thrown serializer error are worth quoting verbatim. */
+const FINGERPRINT_CAUSE_CAP = 400;
+
+/**
+ * The `cause` clause for {@link scopeUnattributableError}: the serializer's own words,
+ * bounded, or nothing at all when there were none.
+ *
+ * Deliberately says WHERE the text came from. An unattributed sentence in the middle of
+ * a panel refusal reads as the panel's own diagnosis, and this one is a third party's —
+ * ComfyUI's serializer, or whatever extension is patched into it.
+ */
+export function describeFingerprintFailure(cause) {
+  const raw = cause instanceof Error ? cause.message : typeof cause === "string" ? cause : "";
+  const text = raw.trim().replace(/\s+/g, " ");
+  if (!text) return "";
+  const quoted = text.length > FINGERPRINT_CAUSE_CAP ? `${text.slice(0, FINGERPRINT_CAUSE_CAP)}…` : text;
+  return (
+    `ComfyUI's serializer failed with: "${quoted}" — that is the frontend's own error, ` +
+    `not the panel's diagnosis of it. A graph left unserializable by an earlier edit ` +
+    `(comfyui-mcp#1571: a subgraph conversion that dropped a boundary link) fails here ` +
+    `whatever node you scope to, so this is not specific to run-to-node or to nesting. `
   );
 }
 
@@ -1482,6 +1523,10 @@ export async function dispatchScopedRun({
   let contentHash = null;
   let contentCanon = null;
   let volatileInputs = null;
+  // #1571 — KEEP what was thrown. The refusal below is the only thing the caller sees,
+  // and without this the serializer's own message (which names the offending node) was
+  // discarded at exactly the moment it was needed.
+  let fingerprintCause = null;
   try {
     if (typeof app.graphToPrompt === "function") {
       // This panel's live root is app.graph (r8) — app.rootGraph only as a
@@ -1490,12 +1535,17 @@ export async function dispatchScopedRun({
       contentCanon = canonicalizePrompt((await app.graphToPrompt())?.output, volatileInputs);
       contentHash = contentCanon ? fnv1aHex(JSON.stringify(contentCanon)) : null;
     }
-  } catch {
+  } catch (err) {
     contentHash = null;
     contentCanon = null;
+    fingerprintCause = err;
   }
   if (!contentHash) {
-    return { outcome: "unverifiable", queueMark: mark, error: scopeUnattributableError({ toNodeId }) };
+    return {
+      outcome: "unverifiable",
+      queueMark: mark,
+      error: scopeUnattributableError({ toNodeId, cause: fingerprintCause }),
+    };
   }
   // #572/#1124 — the inputs this run does NOT drift-cover (queue-time hook
   // carriers plus their linked, serialized targets; and an armed rgthree Seed

--- a/web/js/lib/subgraph-conversion-integrity.js
+++ b/web/js/lib/subgraph-conversion-integrity.js
@@ -1,0 +1,218 @@
+/**
+ * comfyui-mcp#1571 — `panel_subgraph_group` reported a clean conversion, and every
+ * later run of that workflow failed.
+ *
+ * ## What was measured
+ *
+ * The reported graph is `packs/krea2-combo`. Node 192 is `RBG_Smart_Seed_Variance`
+ * with `mode: 4` (BYPASS), one input `conditioning` carrying `link: 505`, and one
+ * output feeding two KSamplers (links 473/474). Wrapping the surrounding group with
+ * `panel_subgraph_group` produced subgraph node 302 and reported success. The next
+ * `panel_run` failed with:
+ *
+ *     No link found in parent graph for id [302:192] slot [0] conditioning
+ *
+ * That string comes from ComfyUI_frontend itself — `ExecutableNodeDTO.resolveInput`,
+ * read out of the shipped 1.48.7 bundle:
+ *
+ *     const i = this.inputs.at(slot)
+ *     if (!i) throw new SlotIndexError(...)
+ *     if (i.linkId == null) return                       // unconnected: fine
+ *     const link = this.graph.getLink(i.linkId)
+ *     if (!link) throw new InvalidLinkError(
+ *       `No link found in parent graph for id [${this.id}] slot [${slot}] ${i.name}`)
+ *
+ * `this.graph` there is the node's OWN graph — for a node that now lives inside a
+ * subgraph, that is the Subgraph. So the failure states one precise fact: an input
+ * still references a link id that does not exist in the graph the node is now in.
+ *
+ * ## Why the panel has to look
+ *
+ * The conversion is `LGraph.convertToSubgraph`, which is the frontend's code, not
+ * ours — and it does not verify its own output. `getBoundaryLinks` skips any input
+ * link it cannot resolve (`console.warn('Failed to resolve link ID […]')` and
+ * `continue`), and `mapSubgraphInputsAndLinks` skips a whole connection group whose
+ * first resolved connection has no `input`, while the reconnect loop that follows
+ * indexes `subgraphNode.inputs[i - 1]` off a counter incremented for EVERY group. A
+ * node can therefore be cloned into the new subgraph carrying an input link id that
+ * was never written into the new subgraph's link table.
+ *
+ * We cannot stop the frontend doing that. We can stop reporting it as a success. The
+ * cost of not looking is the whole of #1571: the tool said "subgraph created", the
+ * corruption was invisible until the next run, and the run's error named a flattened
+ * id (`[302:192]`) that has no connection to the tool call that caused it.
+ *
+ * ## Two tiers, deliberately
+ *
+ *  - DANGLING INPUT LINK — fatal. The graph provably cannot be serialized: the exact
+ *    condition `resolveInput` throws on. This refuses.
+ *  - DISCONNECTED BOUNDARY INPUT — reported, never fatal. Every input slot on a fresh
+ *    subgraph node exists BECAUSE an external link fed it, so an unconnected one right
+ *    after conversion is anomalous (it is what the `!output || !outputNode` branch
+ *    above leaves behind). But "anomalous" is not "provably broken", and a false
+ *    positive must cost a line of text, not a refused mutation.
+ *
+ * Everything here fails toward SILENCE on an input it cannot read. This gates the
+ * report of a mutation that already happened; a graph shape we do not recognise must
+ * never become a refusal.
+ */
+
+/**
+ * The set of link ids present in `graph`, or `null` when the link table cannot be
+ * read at all.
+ *
+ * `null` is the whole safety property: an unfamiliar frontend, or a graph object we
+ * were handed by mistake, must produce NO findings rather than a graph-wide "every
+ * link is missing". Live litegraph uses a `Map`; the serialized form is an array of
+ * either `[id, origin_id, origin_slot, target_id, target_slot, type]` tuples or
+ * `{id, …}` objects; some builds expose a plain object keyed by id. All four are
+ * accepted, anything else is unreadable.
+ */
+export function readLinkIds(graph) {
+  const links = graph?.links;
+  if (!links) return null;
+  const ids = new Set();
+  if (links instanceof Map) {
+    for (const key of links.keys()) ids.add(String(key));
+    return ids;
+  }
+  if (Array.isArray(links)) {
+    for (const link of links) {
+      if (Array.isArray(link)) {
+        if (link[0] != null) ids.add(String(link[0]));
+      } else if (link && typeof link === "object" && link.id != null) {
+        ids.add(String(link.id));
+      }
+    }
+    return ids;
+  }
+  if (typeof links === "object") {
+    for (const key of Object.keys(links)) ids.add(String(key));
+    return ids;
+  }
+  return null;
+}
+
+/**
+ * Every input in `graph` that references a link id the graph's own link table does
+ * not contain — the exact condition `ExecutableNodeDTO.resolveInput` throws
+ * `InvalidLinkError` on, so each entry is one guaranteed serialization failure.
+ *
+ * ONE LEVEL ONLY, on purpose. `convertToSubgraph` clones nodes into the graph it just
+ * created; a nested subgraph NODE that moved inside brings its own definition along
+ * untouched, and that definition is shared with every other instance of it. Walking
+ * into it would attribute a pre-existing problem to this conversion.
+ *
+ * Returns `[]` for an unreadable graph or an unreadable link table.
+ */
+export function danglingInputLinks(graph) {
+  const known = readLinkIds(graph);
+  if (!known) return [];
+  const nodes = Array.isArray(graph?._nodes)
+    ? graph._nodes
+    : Array.isArray(graph?.nodes)
+      ? graph.nodes
+      : null;
+  if (!nodes) return [];
+  const found = [];
+  for (const node of nodes) {
+    const inputs = Array.isArray(node?.inputs) ? node.inputs : [];
+    for (const [slot, input] of inputs.entries()) {
+      const link = input?.link;
+      if (link == null) continue;
+      if (known.has(String(link))) continue;
+      found.push({
+        node_id: node?.id ?? null,
+        node_type: typeof node?.type === "string" ? node.type : null,
+        slot,
+        name: typeof input?.name === "string" ? input.name : null,
+        link_id: link,
+        // #1571's node was bypassed, and that is not incidental: a bypassed node is
+        // resolved THROUGH at serialization time, so its dangling input is reached
+        // by its consumers even though the node itself contributes no prompt entry.
+        bypassed: node?.mode === 4,
+      });
+    }
+  }
+  return found;
+}
+
+/**
+ * Input slots on the freshly created subgraph NODE that nothing in the parent graph
+ * feeds.
+ *
+ * Advisory only (see the header). Returns `[]` for anything unreadable.
+ */
+export function disconnectedBoundaryInputs(subgraphNode) {
+  const inputs = Array.isArray(subgraphNode?.inputs) ? subgraphNode.inputs : null;
+  if (!inputs) return [];
+  const found = [];
+  for (const [slot, input] of inputs.entries()) {
+    if (!input || typeof input !== "object") continue;
+    if (input.link != null) continue;
+    found.push({
+      slot,
+      name: typeof input.name === "string" ? input.name : null,
+      type: typeof input.type === "string" ? input.type : null,
+    });
+  }
+  return found;
+}
+
+/** `RBG_Smart_Seed_Variance node 192 input 0 "conditioning" → link 505` */
+function describeDangling(entry) {
+  const who = entry.node_type ? `${entry.node_type} node ${entry.node_id}` : `node ${entry.node_id}`;
+  const slot = entry.name ? `input ${entry.slot} "${entry.name}"` : `input ${entry.slot}`;
+  const bypassed = entry.bypassed ? " (bypassed)" : "";
+  return `${who}${bypassed} ${slot} → link ${entry.link_id}`;
+}
+
+/** `input 0 "conditioning" (CONDITIONING)` */
+function describeBoundary(entry) {
+  const named = entry.name ? `input ${entry.slot} "${entry.name}"` : `input ${entry.slot}`;
+  return entry.type ? `${named} (${entry.type})` : named;
+}
+
+const MAX_LISTED = 8;
+
+function listOf(entries, describe) {
+  const shown = entries.slice(0, MAX_LISTED).map(describe);
+  const more = entries.length > shown.length ? `, and ${entries.length - shown.length} more` : "";
+  return `${shown.join("; ")}${more}`;
+}
+
+/**
+ * The refusal for a conversion that produced an unserializable subgraph.
+ *
+ * This is NOT `assertSubgraphNodeLanded`'s message and must not be confused with it.
+ * There, nothing was created and the canvas is untouched. Here the subgraph EXISTS —
+ * saying "nothing happened" would send the caller to retry and wrap the same nodes a
+ * second time. The message therefore leads with what is on the canvas, then with what
+ * is broken about it, then with the two recoveries.
+ */
+export function brokenConversionRefusal({ what, subgraphNodeId, dangling, disconnected }) {
+  const bad = Array.isArray(dangling) ? dangling : [];
+  const loose = Array.isArray(disconnected) ? disconnected : [];
+  const plural = bad.length === 1 ? "" : "s";
+  const boundary = loose.length
+    ? `The new subgraph node also has ${loose.length} input slot(s) that nothing in the ` +
+      `parent graph feeds — ${listOf(loose, describeBoundary)} — which is the outer half of ` +
+      `the same broken boundary. `
+    : "";
+  return (
+    `${what} created subgraph node ${subgraphNodeId}, and it is on the canvas — but the ` +
+    `conversion left it UNSERIALIZABLE, so this workflow cannot be run or queued as it ` +
+    `stands. ${bad.length} input${plural} inside the new subgraph still reference a link ` +
+    `that does not exist in it: ${listOf(bad, describeDangling)}. ComfyUI's own serializer ` +
+    `throws on exactly this ("No link found in parent graph for id [${subgraphNodeId}:` +
+    `${bad[0]?.node_id ?? "?"}] slot [${bad[0]?.slot ?? 0}]"), which is why the failure ` +
+    `would otherwise have surfaced later, on the next run, naming an id that has no obvious ` +
+    `connection to this call. ${boundary}` +
+    `The frontend's convertToSubgraph produced this; the panel is reporting it, not causing ` +
+    `it (comfyui-mcp#1571). Nothing has been undone — the subgraph is still there. To ` +
+    `recover: undo the conversion in ComfyUI (Ctrl+Z) and wrap a selection that does not ` +
+    `cross that link, or enter the subgraph (panel_enter_subgraph) and reconnect the listed ` +
+    `input(s) — panel_expose_subgraph_input can re-create the boundary slot, or delete the ` +
+    `node that owns the input if it was bypassed and is not needed.`
+  );
+}

--- a/web/js/lib/subgraph-conversion-integrity.js
+++ b/web/js/lib/subgraph-conversion-integrity.js
@@ -57,30 +57,48 @@
  * its consumers do not reach through it either. A muted node with a dangling input
  * queues perfectly well. Refusing on it would un-ship the tool for a graph that runs.
  *
- * A BYPASSED node is skipped by that loop as well, and is reached only THROUGH its
- * consumers: `resolveOutput` calls `_getBypassSlotIndex(slot, type)`, which picks ONE
- * input per output slot — the same-index input if its type is compatible, else the
- * first exact type match, else the first compatible one — and resolves only that. Its
- * other inputs are never touched. #1571's node is bypassed and its one CONDITIONING
- * input is exactly the slot that selection lands on, which is why it broke.
+ * A BYPASSED or VIRTUAL node is skipped by that loop too, and is reached only THROUGH
+ * its consumers — and THAT is not decidable from here. Three rounds of the review gate
+ * killed three successive attempts to decide it:
  *
- * `bypassResolvedInputSlots` reproduces that selection. It cannot reproduce
- * `LiteGraph.isValidConnection` without importing litegraph, so it treats a wildcard
- * (`*` or empty) as compatible and otherwise requires the type strings to match — a
- * conservative reading that can only ever select FEWER slots than the frontend does,
- * which is the safe direction for a check that refuses.
+ *   1. `_getBypassSlotIndex(slot, type)` is driven by the CONSUMER's type, not the
+ *      output's: `resolveOutput(link.origin_slot, type ?? input.type)`. A wildcard
+ *      consumer short-circuits the whole type check and selects the same-index input
+ *      whatever its type is.
+ *   2. A connected output whose only consumer is itself muted reaches nothing.
+ *   3. `LiteGraph.isValidConnection` accepts comma-delimited union types (`IMAGE,MASK`),
+ *      which a string comparison does not.
+ *
+ * Each fix was a closer approximation of the resolver, and each one was still wrong,
+ * because an approximation of a resolver is not the resolver. The honest position is
+ * that reachability THROUGH a bypassed node cannot be established from outside
+ * ComfyUI's own resolver, and this module does not claim to establish it.
+ *
+ * The obvious alternative — call `app.graphToPrompt()` and see whether it throws —
+ * is deliberately NOT taken. It runs `applyToGraph()` on every virtual node, so
+ * probing with it mutates the graph as a side effect of asking a question about it.
+ * A diagnostic must not do that.
  *
  * ## Three tiers
  *
- *  - DANGLING INPUT THE SERIALIZER REACHES — fatal. The exact condition `resolveInput`
- *    throws on, on a node the serializer provably visits. This refuses.
- *  - DANGLING INPUT IT DOES NOT REACH — reported, never fatal. Harmless today, and it
- *    breaks the moment the node is un-muted or rewired, so it is worth saying out loud.
+ *  - DANGLING INPUT ON AN ORDINARY NODE — fatal, and provably so with no modelling at
+ *    all: the loop above resolves EVERY input of a node it does not skip, with no type
+ *    matching and no consumer analysis. This refuses.
+ *  - DANGLING INPUT ON A SKIPPED NODE (muted, bypassed, virtual) — reported, never
+ *    fatal. Real corruption, reachability unknown. #1571's own node is in this tier, and
+ *    that is the right answer: the report gives the caller the node, slot and link at
+ *    the moment of the conversion, which is exactly what they lacked, without asserting
+ *    a verdict this code cannot support.
  *  - DISCONNECTED BOUNDARY INPUT — reported, never fatal. Every input slot on a fresh
  *    subgraph node exists BECAUSE an external link fed it, so an unconnected one right
  *    after conversion is anomalous (it is what the `!output || !outputNode` branch
  *    above leaves behind). But "anomalous" is not "provably broken", and a false
  *    positive must cost a line of text, not a refused mutation.
+ *
+ * The authoritative fatal verdict already exists and comes from the only component that
+ * can give it: when the run is attempted, ComfyUI's serializer either throws or does
+ * not, and #1571's other half makes that error visible verbatim instead of discarding
+ * it. This module's job is to say what the conversion DID, at the moment it did it.
  *
  * Everything here fails toward SILENCE on an input it cannot read. This gates the
  * report of a mutation that already happened; a graph shape we do not recognise must
@@ -92,69 +110,22 @@ const MODE_NEVER = 2;
 /** `LGraphEventMode.BYPASS` — resolved THROUGH by consumers, one input per output slot. */
 const MODE_BYPASS = 4;
 
-/** Litegraph compares slot types as strings; `*` and `""` are the wildcards. */
-function normType(type) {
-  if (type == null) return "";
-  return String(type).trim().toUpperCase();
-}
-
-function typesConnect(a, b) {
-  const A = normType(a);
-  const B = normType(b);
-  if (!A || !B || A === "*" || B === "*") return true;
-  return A === B;
-}
-
 /**
- * The input slot indices a BYPASSED node would actually resolve, mirroring
- * `ExecutableNodeDTO._getBypassSlotIndex` per output slot.
+ * Is this node one `graphToPrompt` resolves EVERY input of?
  *
- * Only outputs that are CONNECTED are considered: nothing asks an unconnected output
- * for a value, so no input is reached through it. Deliberately conservative — see the
- * module header on why selecting too few is the safe direction here.
- */
-export function bypassResolvedInputSlots(node) {
-  const inputs = Array.isArray(node?.inputs) ? node.inputs : [];
-  const outputs = Array.isArray(node?.outputs) ? node.outputs : [];
-  const used = new Set();
-  for (const [slot, output] of outputs.entries()) {
-    if (!Array.isArray(output?.links) || !output.links.length) continue;
-    const type = normType(output?.type);
-    // "Any type short circuit - match slot ID, fallback to first slot".
-    if (!type || type === "*") {
-      used.add(slot < inputs.length ? slot : 0);
-      continue;
-    }
-    // "Prefer input with the same slot ID".
-    if (inputs[slot] && typesConnect(inputs[slot].type, type)) {
-      used.add(slot);
-      continue;
-    }
-    // "use exact match first", then the first compatible one.
-    const exact = inputs.findIndex((input) => normType(input?.type) === type);
-    if (exact !== -1) {
-      used.add(exact);
-      continue;
-    }
-    const first = inputs.findIndex((input) => typesConnect(input?.type, type));
-    if (first !== -1) used.add(first);
-  }
-  return used;
-}
-
-/**
- * Would `graphToPrompt` resolve this input, and therefore throw on it?
+ * A direct read of the skip list in executionUtil.ts and nothing more — no type
+ * matching, no consumer analysis, no model of the resolver. `true` means the
+ * serializer provably reaches every input on this node; `false` means only that it
+ * does not reach them THAT way, never that they are safe.
  *
- * `bypassSlots` is {@link bypassResolvedInputSlots} for this node, computed once by the
- * caller. Anything unrecognisable answers `true` only for the ordinary case: a node with
- * no `mode` at all is an ordinary node, and ordinary nodes have every input resolved.
+ * A node with no `mode` at all is an ordinary node: ordinary nodes have every input
+ * resolved, which is the answer that makes an unrecognised shape err toward reporting
+ * a real break rather than hiding one.
  */
-function serializerReachesInput(node, slot, bypassSlots) {
+function serializerResolvesEveryInput(node) {
   if (node?.isVirtualNode === true) return false;
   const mode = node?.mode;
-  if (mode === MODE_NEVER) return false;
-  if (mode === MODE_BYPASS) return bypassSlots.has(slot);
-  return true;
+  return mode !== MODE_NEVER && mode !== MODE_BYPASS;
 }
 
 /**
@@ -197,10 +168,11 @@ export function readLinkIds(graph) {
  * Every input in `graph` that references a link id the graph's own link table does
  * not contain.
  *
- * Each entry carries `fatal`: whether `graphToPrompt` actually resolves that input and
- * would therefore throw `InvalidLinkError` on it (see the module header — muted nodes,
- * virtual nodes and a bypassed node's unselected inputs are never reached). Only the
- * fatal ones may refuse; the rest are worth reporting and nothing more.
+ * Every entry is real corruption. `certainly_reached` says whether `graphToPrompt`
+ * PROVABLY resolves that input — true only for a node the serializer does not skip, in
+ * which case it resolves every input unconditionally. `false` does NOT mean safe: it
+ * means the input is reached only through a consumer chain this module deliberately
+ * does not model (see the header). Only `certainly_reached` entries may refuse.
  *
  * ONE LEVEL ONLY, on purpose. `convertToSubgraph` clones nodes into the graph it just
  * created; a nested subgraph NODE that moved inside brings its own definition along
@@ -222,8 +194,7 @@ export function danglingInputLinks(graph) {
   for (const node of nodes) {
     const inputs = Array.isArray(node?.inputs) ? node.inputs : [];
     if (!inputs.length) continue;
-    // Computed once per node, and only for the mode that needs it.
-    const bypassSlots = node?.mode === MODE_BYPASS ? bypassResolvedInputSlots(node) : EMPTY_SLOTS;
+    const reached = serializerResolvesEveryInput(node);
     for (const [slot, input] of inputs.entries()) {
       const link = input?.link;
       if (link == null) continue;
@@ -234,23 +205,21 @@ export function danglingInputLinks(graph) {
         slot,
         name: typeof input?.name === "string" ? input.name : null,
         link_id: link,
-        // #1571's node was bypassed, and that is not incidental: a bypassed node is
-        // resolved THROUGH at serialization time, so its dangling input is reached
-        // by its consumers even though the node itself contributes no prompt entry.
+        // Why the serializer skips the node, when it does — the caller needs this to
+        // judge the finding, and #1571's own node is `bypassed`.
         bypassed: node?.mode === MODE_BYPASS,
         muted: node?.mode === MODE_NEVER,
-        fatal: serializerReachesInput(node, slot, bypassSlots),
+        virtual: node?.isVirtualNode === true,
+        certainly_reached: reached,
       });
     }
   }
   return found;
 }
 
-const EMPTY_SLOTS = new Set();
-
 /** The subset of {@link danglingInputLinks} that provably breaks serialization. */
 export function fatalDanglingInputLinks(graph) {
-  return danglingInputLinks(graph).filter((entry) => entry.fatal);
+  return danglingInputLinks(graph).filter((entry) => entry.certainly_reached);
 }
 
 /**
@@ -275,11 +244,17 @@ export function disconnectedBoundaryInputs(subgraphNode) {
   return found;
 }
 
-/** `RBG_Smart_Seed_Variance node 192 (bypassed) input 0 "conditioning" → link 505` */
+/** `RBG_Smart_Seed_Variance node 192 (bypassed) input 0 "conditioning" -> link 505` */
 function describeDangling(entry) {
   const who = entry.node_type ? `${entry.node_type} node ${entry.node_id}` : `node ${entry.node_id}`;
   const slot = entry.name ? `input ${entry.slot} "${entry.name}"` : `input ${entry.slot}`;
-  const mode = entry.bypassed ? " (bypassed)" : entry.muted ? " (muted)" : "";
+  const mode = entry.bypassed
+    ? " (bypassed)"
+    : entry.muted
+      ? " (muted)"
+      : entry.virtual
+        ? " (virtual)"
+        : "";
   return `${who}${mode} ${slot} → link ${entry.link_id}`;
 }
 
@@ -297,50 +272,86 @@ function listOf(entries, describe) {
   return `${shown.join("; ")}${more}`;
 }
 
+/** How the caller repairs either tier. Shared so the refusal and the warning cannot
+ *  drift into offering different recoveries for the same corruption. */
+function recoveryAdvice() {
+  return (
+    `The frontend's convertToSubgraph produced this; the panel is reporting it, not ` +
+    `causing it (comfyui-mcp#1571). Nothing has been undone — the subgraph is still ` +
+    `there. To recover: undo the conversion in ComfyUI (Ctrl+Z) and wrap a selection that ` +
+    `does not cross that link, or enter the subgraph (panel_enter_subgraph) and reconnect ` +
+    `the listed input(s) — panel_expose_subgraph_input can re-create the boundary slot, ` +
+    `or delete the node that owns the input if it was bypassed and is not needed.`
+  );
+}
+
+function boundaryNote(loose) {
+  if (!loose.length) return "";
+  return (
+    `The new subgraph node also has ${loose.length} input slot(s) that nothing in the ` +
+    `parent graph feeds — ${listOf(loose, describeBoundary)} — which is the outer ` +
+    `half of the same broken boundary. `
+  );
+}
+
 /**
- * The refusal for a conversion that produced an unserializable subgraph.
+ * The refusal for a conversion that PROVABLY produced an unserializable subgraph.
  *
  * This is NOT `assertSubgraphNodeLanded`'s message and must not be confused with it.
  * There, nothing was created and the canvas is untouched. Here the subgraph EXISTS —
  * saying "nothing happened" would send the caller to retry and wrap the same nodes a
  * second time. The message therefore leads with what is on the canvas, then with what
- * is broken about it, then with the two recoveries.
+ * is broken about it, then with the recoveries.
  *
- * `dangling` is the FATAL subset only — the entries the serializer actually reaches.
- * `dormant` is the rest (muted/virtual/unselected bypass slots): broken in the same way
- * but not reached today, so it is context, never a reason. Listing the two together
- * without distinguishing them would overstate the damage on a graph that still runs.
+ * `dangling` is the `certainly_reached` subset ONLY. Anything whose reachability runs
+ * through a consumer chain belongs in {@link brokenConversionWarning}, because this
+ * message asserts the workflow cannot run, and that assertion has to be true.
  */
-export function brokenConversionRefusal({ what, subgraphNodeId, dangling, disconnected, dormant }) {
+export function brokenConversionRefusal({ what, subgraphNodeId, dangling, disconnected }) {
   const bad = Array.isArray(dangling) ? dangling : [];
   const loose = Array.isArray(disconnected) ? disconnected : [];
-  const quiet = Array.isArray(dormant) ? dormant : [];
   const plural = bad.length === 1 ? "" : "s";
-  const boundary = loose.length
-    ? `The new subgraph node also has ${loose.length} input slot(s) that nothing in the ` +
-      `parent graph feeds — ${listOf(loose, describeBoundary)} — which is the outer half of ` +
-      `the same broken boundary. `
-    : "";
-  const dormantNote = quiet.length
-    ? `${quiet.length} further input(s) lost their link the same way but are NOT reached by ` +
-      `the serializer today — ${listOf(quiet, describeDangling)} — because a muted or ` +
-      `virtual node is skipped, and a bypassed node resolves only the input its output type ` +
-      `selects. Those will break if the node is re-enabled or rewired. `
-    : "";
   return (
     `${what} created subgraph node ${subgraphNodeId}, and it is on the canvas — but the ` +
     `conversion left it UNSERIALIZABLE, so this workflow cannot be run or queued as it ` +
-    `stands. ${bad.length} input${plural} inside the new subgraph still reference${plural ? "" : "s"} ` +
-    `a link that does not exist in it: ${listOf(bad, describeDangling)}. ComfyUI's own serializer ` +
-    `throws on exactly this ("No link found in parent graph for id [${subgraphNodeId}:` +
-    `${bad[0]?.node_id ?? "?"}] slot [${bad[0]?.slot ?? 0}]"), which is why the failure ` +
-    `would otherwise have surfaced later, on the next run, naming an id that has no obvious ` +
-    `connection to this call. ${boundary}${dormantNote}` +
-    `The frontend's convertToSubgraph produced this; the panel is reporting it, not causing ` +
-    `it (comfyui-mcp#1571). Nothing has been undone — the subgraph is still there. To ` +
-    `recover: undo the conversion in ComfyUI (Ctrl+Z) and wrap a selection that does not ` +
-    `cross that link, or enter the subgraph (panel_enter_subgraph) and reconnect the listed ` +
-    `input(s) — panel_expose_subgraph_input can re-create the boundary slot, or delete the ` +
-    `node that owns the input if it was bypassed and is not needed.`
+    `stands. ${bad.length} input${plural} inside the new subgraph still ` +
+    `reference${plural ? "" : "s"} a link that does not exist in it: ` +
+    `${listOf(bad, describeDangling)}. Every one of those is on a node ComfyUI's serializer ` +
+    `resolves unconditionally, and it throws on exactly this ` +
+    `("No link found in parent graph for id [${subgraphNodeId}:${bad[0]?.node_id ?? "?"}] ` +
+    `slot [${bad[0]?.slot ?? 0}]") — which is why the failure would otherwise have ` +
+    `surfaced later, on the next run, naming an id that has no obvious connection to this ` +
+    `call. ${boundaryNote(loose)}${recoveryAdvice()}`
+  );
+}
+
+/**
+ * The WARNING for corruption whose fatality this module cannot establish.
+ *
+ * Same defect, weaker claim. The links are provably gone; whether serialization trips
+ * over them depends on a consumer chain that only ComfyUI's own resolver can walk (see
+ * the header — three review rounds killed three attempts to walk it from here). So this
+ * states what was measured, states plainly that the verdict is not ours to give, and
+ * names the one thing that WILL give it: running the workflow.
+ *
+ * Returned on the SUCCESS payload, because the conversion did happen and the graph may
+ * well be fine. It never refuses.
+ */
+export function brokenConversionWarning({ what, subgraphNodeId, dangling, disconnected }) {
+  const bad = Array.isArray(dangling) ? dangling : [];
+  const loose = Array.isArray(disconnected) ? disconnected : [];
+  const plural = bad.length === 1 ? "" : "s";
+  return (
+    `${what} created subgraph node ${subgraphNodeId}, but the conversion also left ` +
+    `${bad.length} input${plural} inside it referencing a link that does not exist there: ` +
+    `${listOf(bad, describeDangling)}. Those links are gone — that part is measured. ` +
+    `Whether it STOPS the workflow running is not something the panel can decide: ComfyUI ` +
+    `skips muted, bypassed and virtual nodes when serializing and reaches them only ` +
+    `through their consumers, and only its own resolver can walk that chain. So this is ` +
+    `a warning, not a refusal, and the subgraph is reported as created. Run the workflow ` +
+    `to get the authoritative answer — if it is fatal, ComfyUI will say ` +
+    `"No link found in parent graph for id [${subgraphNodeId}:${bad[0]?.node_id ?? "?"}] ` +
+    `slot [${bad[0]?.slot ?? 0}]" and the panel now passes that through verbatim. ` +
+    `${boundaryNote(loose)}${recoveryAdvice()}`
   );
 }

--- a/web/js/lib/subgraph-conversion-integrity.js
+++ b/web/js/lib/subgraph-conversion-integrity.js
@@ -42,10 +42,40 @@
  * corruption was invisible until the next run, and the run's error named a flattened
  * id (`[302:192]`) that has no connection to the tool call that caused it.
  *
- * ## Two tiers, deliberately
+ * ## Which dangling inputs are actually FATAL (codex gate, P1)
  *
- *  - DANGLING INPUT LINK — fatal. The graph provably cannot be serialized: the exact
- *    condition `resolveInput` throws on. This refuses.
+ * The first version refused on every dangling input, and that over-refuses. A dangling
+ * reference only breaks serialization if the serializer ever RESOLVES that input, and
+ * `graphToPrompt` (executionUtil.ts, same 1.48.7 bundle) skips whole nodes first:
+ *
+ *     for (const node of nodeDtoMap.values()) {
+ *       if (node.isVirtualNode || node.mode === NEVER || node.mode === BYPASS) continue
+ *       for (const [i, input] of node.inputs.entries()) node.resolveInput(i)
+ *
+ * So a MUTED (`mode === 2`) node is never asked for its inputs at all — and
+ * `resolveOutput` returns immediately for it too ("Muted nodes produce no output"), so
+ * its consumers do not reach through it either. A muted node with a dangling input
+ * queues perfectly well. Refusing on it would un-ship the tool for a graph that runs.
+ *
+ * A BYPASSED node is skipped by that loop as well, and is reached only THROUGH its
+ * consumers: `resolveOutput` calls `_getBypassSlotIndex(slot, type)`, which picks ONE
+ * input per output slot — the same-index input if its type is compatible, else the
+ * first exact type match, else the first compatible one — and resolves only that. Its
+ * other inputs are never touched. #1571's node is bypassed and its one CONDITIONING
+ * input is exactly the slot that selection lands on, which is why it broke.
+ *
+ * `bypassResolvedInputSlots` reproduces that selection. It cannot reproduce
+ * `LiteGraph.isValidConnection` without importing litegraph, so it treats a wildcard
+ * (`*` or empty) as compatible and otherwise requires the type strings to match — a
+ * conservative reading that can only ever select FEWER slots than the frontend does,
+ * which is the safe direction for a check that refuses.
+ *
+ * ## Three tiers
+ *
+ *  - DANGLING INPUT THE SERIALIZER REACHES — fatal. The exact condition `resolveInput`
+ *    throws on, on a node the serializer provably visits. This refuses.
+ *  - DANGLING INPUT IT DOES NOT REACH — reported, never fatal. Harmless today, and it
+ *    breaks the moment the node is un-muted or rewired, so it is worth saying out loud.
  *  - DISCONNECTED BOUNDARY INPUT — reported, never fatal. Every input slot on a fresh
  *    subgraph node exists BECAUSE an external link fed it, so an unconnected one right
  *    after conversion is anomalous (it is what the `!output || !outputNode` branch
@@ -56,6 +86,76 @@
  * report of a mutation that already happened; a graph shape we do not recognise must
  * never become a refusal.
  */
+
+/** `LGraphEventMode.NEVER` — muted. Produces no output and is never asked for inputs. */
+const MODE_NEVER = 2;
+/** `LGraphEventMode.BYPASS` — resolved THROUGH by consumers, one input per output slot. */
+const MODE_BYPASS = 4;
+
+/** Litegraph compares slot types as strings; `*` and `""` are the wildcards. */
+function normType(type) {
+  if (type == null) return "";
+  return String(type).trim().toUpperCase();
+}
+
+function typesConnect(a, b) {
+  const A = normType(a);
+  const B = normType(b);
+  if (!A || !B || A === "*" || B === "*") return true;
+  return A === B;
+}
+
+/**
+ * The input slot indices a BYPASSED node would actually resolve, mirroring
+ * `ExecutableNodeDTO._getBypassSlotIndex` per output slot.
+ *
+ * Only outputs that are CONNECTED are considered: nothing asks an unconnected output
+ * for a value, so no input is reached through it. Deliberately conservative — see the
+ * module header on why selecting too few is the safe direction here.
+ */
+export function bypassResolvedInputSlots(node) {
+  const inputs = Array.isArray(node?.inputs) ? node.inputs : [];
+  const outputs = Array.isArray(node?.outputs) ? node.outputs : [];
+  const used = new Set();
+  for (const [slot, output] of outputs.entries()) {
+    if (!Array.isArray(output?.links) || !output.links.length) continue;
+    const type = normType(output?.type);
+    // "Any type short circuit - match slot ID, fallback to first slot".
+    if (!type || type === "*") {
+      used.add(slot < inputs.length ? slot : 0);
+      continue;
+    }
+    // "Prefer input with the same slot ID".
+    if (inputs[slot] && typesConnect(inputs[slot].type, type)) {
+      used.add(slot);
+      continue;
+    }
+    // "use exact match first", then the first compatible one.
+    const exact = inputs.findIndex((input) => normType(input?.type) === type);
+    if (exact !== -1) {
+      used.add(exact);
+      continue;
+    }
+    const first = inputs.findIndex((input) => typesConnect(input?.type, type));
+    if (first !== -1) used.add(first);
+  }
+  return used;
+}
+
+/**
+ * Would `graphToPrompt` resolve this input, and therefore throw on it?
+ *
+ * `bypassSlots` is {@link bypassResolvedInputSlots} for this node, computed once by the
+ * caller. Anything unrecognisable answers `true` only for the ordinary case: a node with
+ * no `mode` at all is an ordinary node, and ordinary nodes have every input resolved.
+ */
+function serializerReachesInput(node, slot, bypassSlots) {
+  if (node?.isVirtualNode === true) return false;
+  const mode = node?.mode;
+  if (mode === MODE_NEVER) return false;
+  if (mode === MODE_BYPASS) return bypassSlots.has(slot);
+  return true;
+}
 
 /**
  * The set of link ids present in `graph`, or `null` when the link table cannot be
@@ -95,8 +195,12 @@ export function readLinkIds(graph) {
 
 /**
  * Every input in `graph` that references a link id the graph's own link table does
- * not contain — the exact condition `ExecutableNodeDTO.resolveInput` throws
- * `InvalidLinkError` on, so each entry is one guaranteed serialization failure.
+ * not contain.
+ *
+ * Each entry carries `fatal`: whether `graphToPrompt` actually resolves that input and
+ * would therefore throw `InvalidLinkError` on it (see the module header — muted nodes,
+ * virtual nodes and a bypassed node's unselected inputs are never reached). Only the
+ * fatal ones may refuse; the rest are worth reporting and nothing more.
  *
  * ONE LEVEL ONLY, on purpose. `convertToSubgraph` clones nodes into the graph it just
  * created; a nested subgraph NODE that moved inside brings its own definition along
@@ -117,6 +221,9 @@ export function danglingInputLinks(graph) {
   const found = [];
   for (const node of nodes) {
     const inputs = Array.isArray(node?.inputs) ? node.inputs : [];
+    if (!inputs.length) continue;
+    // Computed once per node, and only for the mode that needs it.
+    const bypassSlots = node?.mode === MODE_BYPASS ? bypassResolvedInputSlots(node) : EMPTY_SLOTS;
     for (const [slot, input] of inputs.entries()) {
       const link = input?.link;
       if (link == null) continue;
@@ -130,11 +237,20 @@ export function danglingInputLinks(graph) {
         // #1571's node was bypassed, and that is not incidental: a bypassed node is
         // resolved THROUGH at serialization time, so its dangling input is reached
         // by its consumers even though the node itself contributes no prompt entry.
-        bypassed: node?.mode === 4,
+        bypassed: node?.mode === MODE_BYPASS,
+        muted: node?.mode === MODE_NEVER,
+        fatal: serializerReachesInput(node, slot, bypassSlots),
       });
     }
   }
   return found;
+}
+
+const EMPTY_SLOTS = new Set();
+
+/** The subset of {@link danglingInputLinks} that provably breaks serialization. */
+export function fatalDanglingInputLinks(graph) {
+  return danglingInputLinks(graph).filter((entry) => entry.fatal);
 }
 
 /**
@@ -159,12 +275,12 @@ export function disconnectedBoundaryInputs(subgraphNode) {
   return found;
 }
 
-/** `RBG_Smart_Seed_Variance node 192 input 0 "conditioning" → link 505` */
+/** `RBG_Smart_Seed_Variance node 192 (bypassed) input 0 "conditioning" → link 505` */
 function describeDangling(entry) {
   const who = entry.node_type ? `${entry.node_type} node ${entry.node_id}` : `node ${entry.node_id}`;
   const slot = entry.name ? `input ${entry.slot} "${entry.name}"` : `input ${entry.slot}`;
-  const bypassed = entry.bypassed ? " (bypassed)" : "";
-  return `${who}${bypassed} ${slot} → link ${entry.link_id}`;
+  const mode = entry.bypassed ? " (bypassed)" : entry.muted ? " (muted)" : "";
+  return `${who}${mode} ${slot} → link ${entry.link_id}`;
 }
 
 /** `input 0 "conditioning" (CONDITIONING)` */
@@ -189,25 +305,37 @@ function listOf(entries, describe) {
  * saying "nothing happened" would send the caller to retry and wrap the same nodes a
  * second time. The message therefore leads with what is on the canvas, then with what
  * is broken about it, then with the two recoveries.
+ *
+ * `dangling` is the FATAL subset only — the entries the serializer actually reaches.
+ * `dormant` is the rest (muted/virtual/unselected bypass slots): broken in the same way
+ * but not reached today, so it is context, never a reason. Listing the two together
+ * without distinguishing them would overstate the damage on a graph that still runs.
  */
-export function brokenConversionRefusal({ what, subgraphNodeId, dangling, disconnected }) {
+export function brokenConversionRefusal({ what, subgraphNodeId, dangling, disconnected, dormant }) {
   const bad = Array.isArray(dangling) ? dangling : [];
   const loose = Array.isArray(disconnected) ? disconnected : [];
+  const quiet = Array.isArray(dormant) ? dormant : [];
   const plural = bad.length === 1 ? "" : "s";
   const boundary = loose.length
     ? `The new subgraph node also has ${loose.length} input slot(s) that nothing in the ` +
       `parent graph feeds — ${listOf(loose, describeBoundary)} — which is the outer half of ` +
       `the same broken boundary. `
     : "";
+  const dormantNote = quiet.length
+    ? `${quiet.length} further input(s) lost their link the same way but are NOT reached by ` +
+      `the serializer today — ${listOf(quiet, describeDangling)} — because a muted or ` +
+      `virtual node is skipped, and a bypassed node resolves only the input its output type ` +
+      `selects. Those will break if the node is re-enabled or rewired. `
+    : "";
   return (
     `${what} created subgraph node ${subgraphNodeId}, and it is on the canvas — but the ` +
     `conversion left it UNSERIALIZABLE, so this workflow cannot be run or queued as it ` +
-    `stands. ${bad.length} input${plural} inside the new subgraph still reference a link ` +
-    `that does not exist in it: ${listOf(bad, describeDangling)}. ComfyUI's own serializer ` +
+    `stands. ${bad.length} input${plural} inside the new subgraph still reference${plural ? "" : "s"} ` +
+    `a link that does not exist in it: ${listOf(bad, describeDangling)}. ComfyUI's own serializer ` +
     `throws on exactly this ("No link found in parent graph for id [${subgraphNodeId}:` +
     `${bad[0]?.node_id ?? "?"}] slot [${bad[0]?.slot ?? 0}]"), which is why the failure ` +
     `would otherwise have surfaced later, on the next run, naming an id that has no obvious ` +
-    `connection to this call. ${boundary}` +
+    `connection to this call. ${boundary}${dormantNote}` +
     `The frontend's convertToSubgraph produced this; the panel is reporting it, not causing ` +
     `it (comfyui-mcp#1571). Nothing has been undone — the subgraph is still there. To ` +
     `recover: undo the conversion in ComfyUI (Ctrl+Z) and wrap a selection that does not ` +


### PR DESCRIPTION
Fixes artokun/comfyui-mcp#1571

## What was reported

`panel_subgraph_group` wrapped a group containing a **bypassed** `RBG_Smart_Seed_Variance`, reported `{subgraph: {node_id: 302, …}}`, and the workflow could not be run afterwards. One broken graph, three different answers:

| call | answer |
| --- | --- |
| `panel_subgraph_group` | `{subgraph: {node_id: 302, …}}` — success |
| `panel_run {}` | `No link found in parent graph for id [302:192] slot [0] conditioning` |
| `panel_run {to_node_id: 183}` | `the prompt could not be fingerprinted (graphToPrompt failed)` |

Only one named anything, and what it named (`[302:192]`) is a flattened id the caller had never seen. The reporter repaired the graph by hand and filed both halves as one issue — concluding, from the third answer, that run-to-node "cannot fingerprint **nested** output targets". Nesting was never involved.

## Where the corruption comes from

`ExecutableNodeDTO.resolveInput`, read out of the shipped ComfyUI_frontend bundle:

```js
if (i.linkId == null) return                    // unconnected: fine
const link = this.graph.getLink(i.linkId)
if (!link) throw new InvalidLinkError(
  `No link found in parent graph for id [${this.id}] slot [${slot}] ${i.name}`)
```

`this.graph` there is the node's **own** graph — for a node that now lives inside a subgraph, that is the Subgraph. So the error states one precise fact: an input references a link id that does not exist in the graph the node is now in. Worth recording against the report: the reporter described this as "a disconnected boundary input", and it is not. A boundary input with no link is handled gracefully by that same function (`if (linkId == null) … return`). What throws is a **dangling link id** — a reference to a link that was never written into the new subgraph's link table.

`LGraph.convertToSubgraph` can produce exactly that and does not check. `getBoundaryLinks` skips any input link it cannot resolve (`console.warn('Failed to resolve link ID […]')`, `continue`), and `mapSubgraphInputsAndLinks` skips a whole connection group whose first resolved connection has no `input` — while the reconnect loop that follows indexes `subgraphNode.inputs[i - 1]` off a counter incremented for **every** group.

That is the frontend's code, not ours. We cannot fix it here. We can stop reporting it as a success.

## What changed

**1. Both conversion tools verify their own output.** New `web/js/lib/subgraph-conversion-integrity.js`, reporting in two tiers:

- **dangling input on a node the serializer does not skip → refuses.** Provably unserializable with no modelling at all: `graphToPrompt` skips virtual / muted / bypassed nodes and then resolves **every** input of the ones it keeps, unconditionally — no type matching, no consumer analysis. The refusal names the node, slot and link, prints the `[302:192]`-shaped error the run would otherwise have shown first, and says the subgraph **is still on the canvas** — the opposite of the sibling `assertSubgraphNodeLanded` message, so the caller does not retry and wrap the same nodes twice.
- **dangling input on a skipped node, and unfed boundary slots → reported, never fatal.** Surfaced as a `warning` string plus structured `dangling_inputs` / `unfed_boundary_inputs`.

**#1571's own node is in the second tier, and that is the point.** It is bypassed, so the reported conversion now *succeeds*, carrying the finding it used to hide. Three rounds of the review gate killed three successive attempts to decide reachability *through* a bypassed node, each a closer approximation of `_getBypassSlotIndex` and each still wrong:

1. it is driven by the **consumer's** type, not the output's, so a wildcard consumer short-circuits the type check entirely;
2. a connected output whose only consumer is itself muted reaches nothing;
3. `LiteGraph.isValidConnection` accepts comma-delimited union types (`IMAGE,MASK`), which a string comparison does not.

An approximation of a resolver is not the resolver. That modelling is gone. The links are provably missing — that part is measured and reported; whether serialization trips over them is stated as ComfyUI's verdict to give, not the panel's, and the message says so and names what gives it.

The obvious shortcut — call `app.graphToPrompt()` and see whether it throws — is deliberately **not** taken: it runs `applyToGraph()` on every virtual node, so probing with it mutates the graph as a side effect of asking a question about it.

Everything in the module fails toward **silence** on an input it cannot read: it gates the report of a mutation that already happened, so an unfamiliar graph shape must produce no findings rather than a graph-wide accusation.

**2. The scoped-run fingerprint stops discarding the cause.** `dispatchScopedRun` wrapped `app.graphToPrompt()` in `try { … } catch { }` with an *empty binding*, so ComfyUI's `InvalidLinkError` — which names the offending node outright — was caught and thrown away one line before the message that needed it. The cause is now quoted verbatim, attributed to the frontend ("that is the frontend's own error, not the panel's diagnosis of it"), bounded at 400 chars, whitespace-flattened, and **omitted entirely when nothing threw** — this path also fires with no `graphToPrompt` at all, and inventing a cause there would be the same defect pointed the other way.

## Evidence

The fixture is not invented. Node 192 / `RBG_Smart_Seed_Variance` / `mode: 4` / input `conditioning` / `link: 505`, feeding KSamplers 265 and 273 with SaveImage 183 downstream, are read verbatim from `packs/krea2-combo/workflow.json` in the mcp repo — the workflow the report names. The corruption shape is read from `ExecutableNodeDTO`.

- **41 new tests** (32 conversion-integrity + 9 scope-fingerprint-cause) and 4 added to `subgraph-stale-outline`, including wiring assertions on both call sites and behaviour tests driving the real `graph_subgraph_group` / `graph_create_subgraph` executors — a helper the tool never consults is the shape that shipped this bug in the first place.
- Full panel unit suite: **4540 passed, 0 failed** (includes `check-panel-scope`, `check-tool-vocabulary`, both i18n checks).
- **19/19 mutations killed**, including: delete either call site; drop either advisory key; refuse on everything (the rounds 1–3 over-refusal); refuse on nothing; reclassify muted / bypassed / virtual / ordinary nodes; compare link ids by identity; treat an unreadable link table as empty; walk into nested subgraph definitions; make the warning assert the workflow cannot run; and — the original defect — restore the empty `catch {}` in the fingerprint path.

## Deliberately not done

- **No auto-repair.** The dangling reference could be cleared to make the graph serializable again, but that silently drops a connection the user still wants, and re-deriving the lost boundary link from the parent's link table is graph surgery this cannot verify live. Report, name both recoveries, mutate nothing.
- **The frontend bug itself is untouched** — it belongs upstream in ComfyUI_frontend.
- **No live-rig verification.** No ComfyUI was running for this run, so the behaviour tests drive the real executors against fixtures rather than a live canvas.
