### PR TITLE
fix(1569): a widget the node computes from its own editor is not writable

### DIFF
--- a/browser_tests/unit/ideogram4-prompt-builder.test.mjs
+++ b/browser_tests/unit/ideogram4-prompt-builder.test.mjs
@@ -1,0 +1,136 @@
+/**
+ * comfyui-mcp#1569 — a write to `elements_data` on `Ideogram4PromptBuilderKJ` is refused,
+ * because it cannot reach the render.
+ *
+ * Established from the pack's own source (comfyui-kjnodes
+ * `web/js/ideogram4_prompt_builder.js`), not from the report: the widget installs a
+ * `serializeValue()` that returns `JSON.stringify(node._boxes)` and never reads
+ * `widget.value`, and ComfyUI's `graphToPrompt` queues `serializeValue()` when a widget
+ * defines one. `serialize()` then refreshes the widget FROM `node._boxes` on every editor
+ * commit, and `onConfigure` prefers the node's own saved blob over the widget on reload.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+import {
+  classifyIdeogram4PromptBuilderWrite,
+  ideogram4PromptBuilderRefusal,
+  IDEOGRAM4_PROMPT_BUILDER_TYPE,
+  IDEOGRAM4_ELEMENTS_WIDGET,
+} from "../../web/js/lib/ideogram4-prompt-builder.js";
+
+const TYPE = IDEOGRAM4_PROMPT_BUILDER_TYPE;
+
+/** A live node shaped like the pack builds it: the elements widget carries its own
+ *  serializer, the prompt fields do not. Mirrors the widget set in the krea2-combo
+ *  workflow that the report was filed against. */
+const builderNode = ({ withSerializer = true } = {}) => ({
+  id: 217,
+  type: TYPE,
+  widgets: [
+    { name: "high_level_description", value: "old subject" },
+    { name: "background", value: "old background" },
+    { name: "style", value: "photo" },
+    { name: "style_palette_data", value: "[]" },
+    {
+      name: IDEOGRAM4_ELEMENTS_WIDGET,
+      value: '[{"type":"obj","desc":"Margot Robbie portrait"}]',
+      ...(withSerializer ? { serializeValue: () => "[]" } : {}),
+    },
+  ],
+});
+
+test("#1569: the reported write is classified derived", () => {
+  assert.equal(classifyIdeogram4PromptBuilderWrite(builderNode(), IDEOGRAM4_ELEMENTS_WIDGET), "derived");
+  // A composite sub-field addresses the same widget and must not slip past the guard.
+  assert.equal(classifyIdeogram4PromptBuilderWrite(builderNode(), "elements_data.0"), "derived");
+});
+
+test("#1569: the node's ORDINARY prompt fields stay writable", () => {
+  // These are plain string widgets with no serializer of their own, which is exactly why
+  // the reporter's new strings DID apply. Refusing them would block real work.
+  for (const w of ["high_level_description", "background", "style", "aesthetics", "lighting", "medium"]) {
+    assert.equal(classifyIdeogram4PromptBuilderWrite(builderNode(), w), null, w);
+  }
+});
+
+test("#1569: style_palette_data is deliberately NOT refused", () => {
+  // The pack installs `serializeValue` on the elements widget and on no other, so this
+  // write DOES reach the queue for the run at hand. It is fragile — the next editor
+  // interaction refreshes it from `node._stylePalette` — but a write that reaches the
+  // render must not be refused.
+  assert.equal(classifyIdeogram4PromptBuilderWrite(builderNode(), "style_palette_data"), null);
+});
+
+test("#1569: `elements_data` on an UNRELATED node type is untouched", () => {
+  const other = { id: 3, type: "SomeOtherNode", widgets: [{ name: "elements_data", value: "[]", serializeValue: () => "[]" }] };
+  assert.equal(classifyIdeogram4PromptBuilderWrite(other, "elements_data"), null);
+});
+
+test("#1569: the guard is gated on the SERIALIZER, so it cannot outlive its proof", () => {
+  // The override is the fact that makes the write dead. A later KJNodes build that drops it
+  // and honours the assignment must stop being refused, with no change to this module.
+  assert.equal(
+    classifyIdeogram4PromptBuilderWrite(builderNode({ withSerializer: false }), IDEOGRAM4_ELEMENTS_WIDGET),
+    null,
+  );
+});
+
+test("#1569: an ABSENT widget is not classified", () => {
+  // The ordinary write path already reports an unresolved widget, and that message is more
+  // accurate than this one would be.
+  assert.equal(classifyIdeogram4PromptBuilderWrite({ id: 1, type: TYPE, widgets: [] }, IDEOGRAM4_ELEMENTS_WIDGET), null);
+  assert.equal(classifyIdeogram4PromptBuilderWrite({ id: 1, type: TYPE }, IDEOGRAM4_ELEMENTS_WIDGET), null);
+});
+
+test("#1569: a THROWING serializeValue accessor fails closed", () => {
+  const node = { id: 7, type: TYPE, widgets: [{ name: IDEOGRAM4_ELEMENTS_WIDGET }] };
+  Object.defineProperty(node.widgets[0], "serializeValue", {
+    get() {
+      throw new Error("poisoned accessor");
+    },
+  });
+  // Unreadable is not evidence the override is gone, and this is already the node type and
+  // widget the pack derives — so it must not hand back the silent success.
+  assert.equal(classifyIdeogram4PromptBuilderWrite(node, IDEOGRAM4_ELEMENTS_WIDGET), "derived");
+});
+
+test("#1569: malformed inputs are classified null, never thrown on", () => {
+  assert.equal(classifyIdeogram4PromptBuilderWrite(null, IDEOGRAM4_ELEMENTS_WIDGET), null);
+  assert.equal(classifyIdeogram4PromptBuilderWrite(undefined, IDEOGRAM4_ELEMENTS_WIDGET), null);
+  assert.equal(classifyIdeogram4PromptBuilderWrite(builderNode(), null), null);
+  assert.equal(classifyIdeogram4PromptBuilderWrite(builderNode(), 42), null);
+});
+
+test("#1569: the refusal names the mechanism and a remedy that works", () => {
+  const msg = ideogram4PromptBuilderRefusal(IDEOGRAM4_ELEMENTS_WIDGET, 217);
+  assert.match(msg, /panel_set_widget cannot drive "elements_data" on Ideogram4PromptBuilderKJ node 217/);
+  // The mechanism, so the caller does not retry the write three times.
+  assert.match(msg, /serializeValue/);
+  assert.match(msg, /#1569/);
+  // The remedies. `import_json` is the node's own programmatic entry point (declared
+  // force_input in its INPUT_TYPES), and the CLIPTextEncode bypass is the reporter's own
+  // verified workaround.
+  assert.match(msg, /import_json/);
+  assert.match(msg, /CLIPTextEncode/);
+  // It must not read as "this node is unwritable".
+  assert.match(msg, /still writable/);
+});
+
+test("#1569: the guard is WIRED into graph_set_widget, ahead of the generic write path", () => {
+  // A helper-only suite stays green when the call site is deleted, which is the whole
+  // failure this asserts against. The refusal has to run BEFORE runSetWidget, or the write
+  // lands and reports success before anyone asks whether it can reach the render.
+  const src = readFileSync(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8");
+  assert.match(src, /import \{\s*classifyIdeogram4PromptBuilderWrite,\s*ideogram4PromptBuilderRefusal,\s*\} from "\.\/lib\/ideogram4-prompt-builder\.js";/);
+
+  const handler = src.slice(src.indexOf("async graph_set_widget("));
+  assert.ok(handler.startsWith("async graph_set_widget("), "graph_set_widget handler not found");
+  const guardAt = handler.indexOf("classifyIdeogram4PromptBuilderWrite(node, widget)");
+  const writeAt = handler.indexOf("await runSetWidget(");
+  assert.ok(guardAt > 0, "the guard is not called from graph_set_widget");
+  assert.ok(writeAt > 0, "runSetWidget call site not found in graph_set_widget");
+  assert.ok(guardAt < writeAt, "the guard must run BEFORE runSetWidget");
+  assert.match(handler.slice(guardAt, writeAt), /throw new Error\(ideogram4PromptBuilderRefusal\(widget, node\.id\)\)/);
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -325,6 +325,10 @@ import {
   rgthreeFastGroupsRefusal,
 } from "./lib/rgthree-fast-groups.js";
 import {
+  classifyIdeogram4PromptBuilderWrite,
+  ideogram4PromptBuilderRefusal,
+} from "./lib/ideogram4-prompt-builder.js";
+import {
   controlAfterGenerateModes,
   controlAfterGenerateEntries,
 } from "./lib/control-after-generate.js";
@@ -11702,6 +11706,18 @@ const GRAPH_TOOL_EXECUTORS = {
     // why this refuses rather than driving the node's own toggle().
     if (classifyRgthreeFastGroupsWrite(node, widget) === "derived") {
       throw new Error(rgthreeFastGroupsRefusal(widget, node.id, node.type));
+    }
+    // comfyui-mcp#1569: KJNodes' Ideogram4PromptBuilderKJ holds its regions in the node's
+    // own in-browser editor and installs a `serializeValue()` on `elements_data` that builds
+    // the queued value from that state without ever reading the widget. ComfyUI queues
+    // `serializeValue()`, so a direct write showed a clean success AND showed up in
+    // panel_query_graph while the render kept using the old regions. Refused loudly, keyed to
+    // the node type, the widget name, AND the live presence of the serializer — so nothing
+    // else on the node is affected and the guard cannot outlive the pack behaviour that
+    // justifies it. See the lib for the four source facts and for why style_palette_data,
+    // which has no serializer of its own, is deliberately still writable.
+    if (classifyIdeogram4PromptBuilderWrite(node, widget) === "derived") {
+      throw new Error(ideogram4PromptBuilderRefusal(widget, node.id));
     }
     // #458: WAIT for the startup baseline history seed to land before authorizing, so a
     // write can never decide "never seen" against an un-seeded history — a pack present

--- a/web/js/lib/ideogram4-prompt-builder.js
+++ b/web/js/lib/ideogram4-prompt-builder.js
@@ -1,0 +1,151 @@
+// comfyui-mcp#1569 — a write to `elements_data` on KJNodes' `Ideogram4PromptBuilderKJ`
+// cannot reach the render, so it is refused rather than reported as a success.
+//
+// The reported shape, and the reason it was so hard to place: all THREE of these were
+// true at once. `panel_set_widget` reported success for every field. `panel_query_graph`
+// then showed the new values. And `panel_run` still rendered the OLD subject — the
+// Margot Robbie portrait that was in the previously-serialized `elements_data`.
+//
+// FOUR FACTS FROM THE PACK'S OWN SOURCE (comfyui-kjnodes
+// `web/js/ideogram4_prompt_builder.js` @ 95389ef, the build the pack pins), not inferred
+// from the report. The first is on its own enough:
+//
+//  1. The widget defines its own `serializeValue`, and NO branch of it reads
+//     `widget.value`:
+//
+//         elementsWidget.serializeValue = () => {
+//           const always = findW("import_mode")?.value === "always";
+//           if (importConnected() && (always || !node._boxes.length)) {
+//             return JSON.stringify({ _refresh: (node._serialSeq = (node._serialSeq || 0) + 1) });
+//           }
+//           return node._boxes.length ? JSON.stringify(node._boxes) : "";
+//         };
+//
+//     ComfyUI does not queue `widget.value`: `graphToPrompt` asks a widget for
+//     `serializeValue()` whenever it defines one. So the queued `elements_data` is
+//     built from `node._boxes` — the editor's in-memory region list — and an
+//     assignment to the widget is simply not part of that computation.
+//
+//  2. The widget value is a DERIVED WRITE-BACK of that same state, not an input to it:
+//
+//         function serialize() {
+//           if (elementsWidget) elementsWidget.value = node._boxes.length ? JSON.stringify(node._boxes) : "";
+//           ...
+//         }
+//
+//     `serialize()` runs from the editor's `commit()` and `touch()`, so the next
+//     interaction with the node's UI overwrites whatever was assigned.
+//
+//  3. A reload does not rescue it either. `onSerialize` stores the regions in the node's
+//     own blob (`o.ideo = { boxes: node._boxes, ... }`) and `onConfigure` prefers that
+//     blob over the widget, falling back to `_parseBoxes(elementsWidget.value)` only
+//     when the blob is absent.
+//
+//  4. The server really does read the queued value — `Ideogram4PromptBuilderKJ.execute()`
+//     does `boxes = _parse_json_list(elements_data)` — which is why fact 1 changes the
+//     IMAGE and not merely the display.
+//
+// So the value in the reply is real on the canvas and means nothing to the render. That
+// is exactly the silent-success shape `panel_set_widget` must not produce, and it is the
+// same defect class already refused for rgthree's Fast Groups toggle (#983) and for the
+// LTXDirector / PromptRelay derived timeline widgets (#314, #506).
+//
+// WHY A REFUSAL AND NOT A ROUTE. The LTXDirector route (#314) drives the node's own
+// `_applyLoadedTimeline`; this node exposes no equivalent. Its `commit()`, `serialize()`
+// and `rebuildStylePalette()` are closure-locals inside `onNodeCreated` and are not
+// reachable from the node object, so a route would have to assign `node._boxes` directly
+// and then also repair `_selection`, `_activeIdx` and the DOM editor that renders them —
+// guessing at a third-party node's internals, which is what makes the write unsound in
+// the first place. Refusing costs the caller one tool call and cannot corrupt a graph.
+//
+// WHY `style_palette_data` IS DELIBERATELY NOT REFUSED, even though facts 2 and 3 apply
+// to it as well: fact 1 does NOT. The pack installs `serializeValue` on the elements
+// widget and on no other (it is the only such assignment in the file), so a
+// `style_palette_data` write DOES reach the queue for the run at hand. It is fragile —
+// the next editor interaction refreshes it from `node._stylePalette` — but refusing a
+// write that reaches the render would block real work to prevent a misunderstanding.
+// The same goes for the ordinary prompt fields (`high_level_description`, `background`,
+// `style`, `aesthetics`, `lighting`, `medium`): plain string widgets with no serializer
+// of their own, which is why the reporter's new strings DID apply and only the regions
+// stayed stale.
+//
+// Dependency-free (no DOM, no LiteGraph). Unit-testable with plain fixtures.
+
+/** The KJNodes node type whose regions are derived from the editor's in-memory state. */
+export const IDEOGRAM4_PROMPT_BUILDER_TYPE = "Ideogram4PromptBuilderKJ";
+
+/** The one widget on it whose queued value is computed from `node._boxes`. */
+export const IDEOGRAM4_ELEMENTS_WIDGET = "elements_data";
+
+/** The base widget name a request addresses, with any composite sub-field removed, so
+ *  `"elements_data.0"` cannot slip past a guard that `"elements_data"` would catch.
+ *  Kept local, matching the sibling guard in `rgthree-fast-groups.js`: sharing three
+ *  lines would mean this node-specific module importing an rgthree-specific one. */
+function baseWidgetName(widgetName) {
+  if (typeof widgetName !== "string") return "";
+  const dot = widgetName.indexOf(".");
+  return dot === -1 ? widgetName : widgetName.slice(0, dot);
+}
+
+/**
+ * `"derived"` when this write targets the elements widget on a live prompt-builder node
+ * that actually installs the serializer, else null.
+ *
+ * Keyed on THREE things, and each one is load-bearing:
+ *
+ *   - the NODE TYPE, so the name `elements_data` on an unrelated node is untouched;
+ *   - the WIDGET NAME, so every other widget on this node keeps working exactly as it
+ *     does today (its prompt fields are ordinary string widgets and land fine);
+ *   - the LIVE PRESENCE of the widget's own `serializeValue`, which is the fact that
+ *     makes the write dead. Gating on the mechanism rather than on the type alone means
+ *     the refusal cannot outlive its proof: if a later KJNodes build drops the override
+ *     and honours the assignment, the write stops being refused with no change here.
+ *
+ * A widget that is ABSENT is not classified — the ordinary write path already reports an
+ * unresolved widget, and that message is more accurate than this one would be.
+ *
+ * @param {{type?: unknown, widgets?: unknown}} node
+ * @param {unknown} widgetName
+ * @returns {"derived"|null}
+ */
+export function classifyIdeogram4PromptBuilderWrite(node, widgetName) {
+  const type = node && typeof node === "object" ? node.type : undefined;
+  if (type !== IDEOGRAM4_PROMPT_BUILDER_TYPE) return null;
+  if (baseWidgetName(widgetName) !== IDEOGRAM4_ELEMENTS_WIDGET) return null;
+  const widgets = node && Array.isArray(node.widgets) ? node.widgets : [];
+  const widget = widgets.find((w) => w && w.name === IDEOGRAM4_ELEMENTS_WIDGET);
+  if (!widget) return null;
+  try {
+    return typeof widget.serializeValue === "function" ? "derived" : null;
+  } catch {
+    // A throwing accessor tells us nothing about the override — but this is already the
+    // node type and widget the pack is known to derive, so fail CLOSED for it rather than
+    // let an unreadable probe hand back the silent success this guard exists to prevent.
+    return "derived";
+  }
+}
+
+/**
+ * The refusal. Names what the widget actually is, why the write cannot reach the render,
+ * and three remedies that do work — including the one the reporter verified themselves.
+ */
+export function ideogram4PromptBuilderRefusal(widgetName, nodeId) {
+  return (
+    `panel_set_widget cannot drive "${widgetName}" on ${IDEOGRAM4_PROMPT_BUILDER_TYPE} node ` +
+    `${nodeId}: the regions are held in the node's own in-browser editor (\`node._boxes\`), and ` +
+    `the widget is a DERIVED WRITE-BACK of that state rather than an input to it (#1569). The ` +
+    `widget installs its own \`serializeValue()\`, which builds the queued value from the ` +
+    `editor's regions and never reads the widget — and ComfyUI queues \`serializeValue()\`, not ` +
+    `\`widget.value\`. So a direct write shows in the reply and in panel_query_graph, and the ` +
+    `render still uses the OLD regions; the node also refreshes the widget from its own state ` +
+    `on the next edit, and prefers its own saved blob on reload.\n` +
+    `Three things do work. Edit the regions in the node's editor UI, which is what updates the ` +
+    `state the queue reads. Or drive the node's \`import_json\` INPUT — it is declared ` +
+    `force_input, so wire a string source into that socket and the node loads it into the ` +
+    `editor and drives the output per \`import_mode\`. Or bypass the builder's conditioning ` +
+    `entirely by encoding your prompt with a CLIPTextEncode wired straight into the sampler.\n` +
+    `Every OTHER widget on this node is unaffected and still writable — its prompt fields ` +
+    `(high_level_description, background, style, aesthetics, lighting, medium) are ordinary ` +
+    `string widgets that reach the render normally.`
+  );
+}


### PR DESCRIPTION
Fixes the underlying cause of artokun/comfyui-mcp#1569.

## The report

`panel_set_widget` reported success for `elements_data` on KJNodes'
`Ideogram4PromptBuilderKJ`. `panel_query_graph` then showed the new value. And `panel_run`
still rendered the OLD subject — the Margot Robbie portrait from the previously serialized
regions. All three were true simultaneously, which is what made this hard to place: the
write really did land, and the render really did ignore it.

## Why

From the pack's own source (`comfyui-kjnodes/web/js/ideogram4_prompt_builder.js` @ `95389ef`),
not from the report. Any one of these is enough; the first on its own decides it:

1. The widget installs its own serializer, and **no branch of it reads `widget.value`**:

   ```js
   elementsWidget.serializeValue = () => {
     const always = findW("import_mode")?.value === "always";
     if (importConnected() && (always || !node._boxes.length)) {
       return JSON.stringify({ _refresh: (node._serialSeq = (node._serialSeq || 0) + 1) });
     }
     return node._boxes.length ? JSON.stringify(node._boxes) : "";
   };
   ```

   ComfyUI does not queue `widget.value` — `graphToPrompt` asks a widget for
   `serializeValue()` whenever it defines one. The queued `elements_data` is built from
   `node._boxes`, the editor's in-memory region list, and the assignment is simply not part
   of that computation.

2. The widget value is a **derived write-back** of that state, not an input to it:
   `serialize()` sets `elementsWidget.value` **from** `node._boxes`, and runs on every
   editor `commit()`/`touch()`.

3. A reload does not rescue it. `onSerialize` stores the regions in the node's own blob
   (`o.ideo.boxes`) and `onConfigure` prefers that blob over the widget.

4. The server really does read the queued value —
   `Ideogram4PromptBuilderKJ.execute()` does `boxes = _parse_json_list(elements_data)` —
   which is why fact 1 changed the image and not merely the display.

## The change

Refuse the write, loudly, naming the mechanism and three remedies that work: the node's own
editor UI, its `import_json` input (declared `force_input`, so it is the node's own
programmatic entry point), or the reporter's verified `CLIPTextEncode` bypass.

Same defect class, same treatment as rgthree Fast Groups (#983) and the LTXDirector /
PromptRelay derived timeline widgets (#314, #506).

**A route is deliberately not attempted.** The LTXDirector route drives the node's own
`_applyLoadedTimeline`; this node exposes no equivalent — `commit()`, `serialize()` and
`rebuildStylePalette()` are closure-locals inside `onNodeCreated`. Driving it would mean
assigning `node._boxes` directly and then repairing `_selection`, `_activeIdx` and the DOM
editor that renders them: guessing at a third-party node's internals, which is what makes
the write unsound to begin with.

## Scope, and what is deliberately left writable

Keyed on three things, each load-bearing: the **node type**, the **widget name**, and the
**live presence of the serializer**. That last one means the guard cannot outlive its proof
— if a later KJNodes build drops the override and honours the assignment, the write stops
being refused with no change here.

- `style_palette_data` is **not** refused. Facts 2 and 3 apply to it, but fact 1 does not:
  the pack installs a serializer on the elements widget and on no other, so that write
  *does* reach the queue for the run at hand. Refusing a write that reaches the render
  would block real work.
- The ordinary prompt fields (`high_level_description`, `background`, `style`, `aesthetics`,
  `lighting`, `medium`) are plain string widgets and are untouched — which is exactly why
  the reporter's new strings *did* apply and only the regions stayed stale.

## Verification

10 unit tests, and the fix was verified by **deleting** it:

- Deleting the call site in `graph_set_widget` fails the wiring test (the other 9 stay
  green — a helper-only suite would not have caught it). The test also asserts the guard
  runs **before** `runSetWidget`, since a refusal after the write is not a refusal.
- Removing the serializer from the fixture makes the classification `null`, pinning the
  "cannot outlive its proof" gate.
- Full panel unit suite: 4508 pass, 0 fail. `check-panel-scope` and `check-tool-vocabulary`
  both OK.

## History

This issue previously had three designs killed in review (comfyui-mcp-panel#1236), all of
them *general* — sampling `serializeValue()` before/after (upstream `RecordAudio` stops a
live recording from inside its serializer, and it is `async`), and warning whenever a widget
defines a serializer (ordinary `CLIPTextEncode` prompt widgets install one via
dynamic-prompts, so it would fire on the most common write in the product). This one is
node-specific, which is what the three shipped precedents for this defect class already do,
and it invokes nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)