### PR TITLE
fix(1623): an open where only presentation moved is not a failure

### DIFF
--- a/browser_tests/unit/definitions-renumber.test.mjs
+++ b/browser_tests/unit/definitions-renumber.test.mjs
@@ -126,11 +126,17 @@ test("#886 WIRING: the content proof consults it for a definitions surface", () 
   assert.match(src, /import \{ definitionsDifferOnlyByLinkRenumber \} from "\.\/definitions-renumber\.js";/);
   assert.match(src, /definitionsDifferOnlyByLinkRenumber\(state\?\.definitions, actualState\?\.definitions\)/);
   // The surface set must be a SUBSET of { nodes, definitions }; anything else refuses.
-  assert.match(src, /s !== "nodes" && s !== "definitions"\)\) return NOT_PROVEN;/);
+  // #1623 renamed the refusal value: every refusal AFTER the diff is computed now
+  // carries the separate presentation-only answer out with it instead of discarding
+  // it. What is pinned is unchanged — this surface set still refuses.
+  assert.match(src, /s !== "nodes" && s !== "definitions"\)\) return notProven;/);
+  // ...and `notProven` must be a REFUSAL of the content proof, not a second success
+  // door: a rename that made it `proven: true` would pass the line above.
+  assert.match(src, /const notProven = \{\r?\n\s*proven: false,/);
   // `nodes` must NOT be mandatory. Requiring it refused the reported case outright:
   // #886 is a graph where `definitions` is the ONLY differing surface, so the earlier
   // gate wired this fix into a branch its own bug report could never reach (review).
-  assert.doesNotMatch(src, /if \(!surfaces\.includes\("nodes"\)\) return NOT_PROVEN;/);
+  assert.doesNotMatch(src, /if \(!surfaces\.includes\("nodes"\)\) return (?:NOT_PROVEN|notProven);/);
   assert.match(src, /if \(!unique\.includes\("nodes"\)\)/);
 });
 

--- a/browser_tests/unit/open-content-proof.test.mjs
+++ b/browser_tests/unit/open-content-proof.test.mjs
@@ -96,6 +96,9 @@ test("#1001 a byte-identical repaint is still reported as exact", () => {
     proven: true,
     exact: true,
     fields: [],
+    // #1623 — a graph that matched has no difference to classify, so the weaker
+    // "nothing authored was lost" ground is not what carried it.
+    presentationOnly: false,
   });
 });
 
@@ -227,6 +230,10 @@ test("#1001 an unreadable root proves nothing — absence of comparison is not e
       proven: false,
       exact: false,
       fields: [],
+      // #1623 — and it must not answer the WEAKER question either. A root nobody
+      // could read supports "nothing authored was lost" exactly as little as it
+      // supports "the content was reproduced".
+      presentationOnly: false,
     });
   }
   assert.equal(graphRootReproducesStateContent({ rootGraph: rootOf(state), state: null }).proven, false);

--- a/browser_tests/unit/open-outcome.test.mjs
+++ b/browser_tests/unit/open-outcome.test.mjs
@@ -506,7 +506,18 @@ test("#721 P1: dirty rebind success requires the target UUID, never only a read-
   // throws, which withholds the fence). The predicate still refuses anything but a
   // nodes-only, same-set, geometry-only difference.
   assert.match(repaint, /graphRootReproducesStateContent\(\{ rootGraph, state: repaintState \}\)/);
-  assert.match(repaint, /const contentMatches = contentProof\.proven;/);
+  // #1623 — TWO grounds now, and BOTH must be named here. `proven` is the strict
+  // "the content was reproduced"; `presentationOnly` is the weaker "nothing authored
+  // was lost", which is the question the caller acts on and the one the panel's own
+  // disclosure already answered on the same observation. Pinning the expression
+  // rather than either half is deliberate: dropping `presentationOnly` restores the
+  // reported false error, and dropping `proven` silently narrows the #1001 fix.
+  assert.match(repaint, /const contentMatches = contentProof\.proven \|\| contentProof\.presentationOnly;/);
+  // The two disclosures stay SEPARATE. Folding the weaker case into
+  // `openGeometryRewritten` would attach a note asserting a characterised
+  // height-only rewrite to a difference where no such thing was established.
+  assert.match(repaint, /if \(contentProof\.proven && !contentProof\.exact\) \{\r?\n\s*openGeometryRewritten = contentProof\.fields;/);
+  assert.match(repaint, /if \(contentProof\.presentationOnly\) \{\r?\n\s*openPresentationRewritten = contentProof\.fields;/);
   // The ATTEMPT-scoped marker: a workflow uuid can be on the root from a previous load
   // or a rebind heal, so it cannot say that THIS load landed.
   assert.match(repaint, /\[OPEN_PROOF_FIELD\]: openProofMarker/, "the payload must carry a single-use marker");

--- a/browser_tests/unit/open-presentation-only.test.mjs
+++ b/browser_tests/unit/open-presentation-only.test.mjs
@@ -1,0 +1,337 @@
+/**
+ * #1623 — `panel_open_workflow` reported an ERROR on an open it had itself just
+ * described as fine.
+ *
+ * WHAT THE REPORTER GOT. Two consecutive workflow switches, on a library containing
+ * DOM/custom nodes (ComfySketch, MarkdownNote), each returning `isError: true` with a
+ * message that says:
+ *
+ *   "workflow_open RAN, the canvas IS bound to X, and every node that was loaded is
+ *    on it with the same id and type ... nothing extra appeared ... What differs is
+ *    per-node (size, order) ... the content is reported UNCONFIRMED rather than
+ *    failed ... You are on the right workflow and there is no missing work to redo."
+ *
+ * A reply cannot say "there is no missing work to redo" and fail. They took the
+ * failure at face value and spent a `panel_graph_outline` recovery read on a graph
+ * that was already correct.
+ *
+ * THE MECHANISM, and it is two lists that answer different questions:
+ *
+ *   RECOMPUTED_NODE_FIELDS  {size (height-only), inputs}   "is this difference
+ *                                                           explained by a rewrite
+ *                                                           this panel MEASURED?"
+ *   COSMETIC_NODE_FIELDS    {size, pos, order,             "could anything AUTHORED
+ *                            color, bgcolor}                have been lost?"
+ *
+ * The DISCLOSURE asks the second. The pass/fail asked the first. So `pos`, `order`,
+ * `color`, `bgcolor` — and a `size` whose WIDTH moved, which is what a DOM widget's
+ * box does — all failed the open while the sentence attached to the failure said
+ * nothing was lost.
+ *
+ * THE FIX. One shared predicate, `openContentDifferenceIsPresentationOnly`, used by
+ * BOTH. The open's pass/fail turns on the weaker question, because that is the one
+ * the caller acts on.
+ *
+ * WHAT IS NOT WIDENED, and these are the tests that matter most here.
+ * `widgets_values` stays outside both sets. `resolveOpenRebindVerdict` records why
+ * content blocks success at all: `loadGraphData` catches a mid-`configure()` throw
+ * and returns, leaving the node id/type set, the links and the marker over nodes
+ * that LOST their widget values and properties — indistinguishable from
+ * normalisation. That failure cannot present as presentation-only, because
+ * `configure()` writes widgets_values, properties, title, flags and mode in the same
+ * pass as the cosmetic five and every one of them is outside the cosmetic set.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import {
+  openContentDifferenceIsPresentationOnly,
+  graphRootReproducesStateContent,
+  describeOpenRebindOutcome,
+  resolveOpenRebindVerdict,
+  OPEN_REBIND_STATUS,
+} from "../../web/js/lib/graph-binding.js";
+
+const PANEL_JS = fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url));
+const GRAPH_BINDING_JS = fileURLToPath(new URL("../../web/js/lib/graph-binding.js", import.meta.url));
+
+const node = (id, type, extra = {}) => ({
+  id,
+  type,
+  pos: [0, 0],
+  size: [200, 100],
+  order: 0,
+  widgets_values: ["a"],
+  ...extra,
+});
+/** A root whose serialize() returns a JSON round-trip of this state — what a file gives. */
+const rootOf = (state) => ({ serialize: () => JSON.parse(JSON.stringify(state)) });
+const stateOf = (nodes) => ({ nodes, links: [], groups: [], config: {}, extra: {} });
+
+const cosmetic = (fields) => ({ comparable: true, sameNodeSet: true, cosmeticOnly: true, fields });
+
+// ── the predicate ────────────────────────────────────────────────────────────
+
+test("#1623 a nodes-only, same-set, cosmetic difference is presentation-only", () => {
+  assert.equal(
+    openContentDifferenceIsPresentationOnly({
+      comparable: true,
+      surfaces: ["nodes"],
+      nodeDifference: cosmetic(["order", "size"]),
+    }),
+    true,
+  );
+});
+
+test("#1623 a WIDGET VALUE difference is never presentation-only — #1111/#1089's guard is untouched", () => {
+  // The load that dies mid-`configure()` drops exactly this, and it is
+  // byte-identical to a frontend that normalized it. The open must keep failing.
+  assert.equal(
+    openContentDifferenceIsPresentationOnly({
+      comparable: true,
+      surfaces: ["nodes"],
+      nodeDifference: { comparable: true, sameNodeSet: true, cosmeticOnly: false, fields: ["widgets_values"] },
+    }),
+    false,
+  );
+});
+
+test("#1623 an UNKNOWN field is never presentation-only — the cosmetic set is a denylist", () => {
+  // A pack the panel has never seen makes the answer cautious. Inverting that would
+  // tell a caller "nothing was lost" about a surface nobody has characterised.
+  assert.equal(
+    openContentDifferenceIsPresentationOnly({
+      comparable: true,
+      surfaces: ["nodes"],
+      nodeDifference: { comparable: true, sameNodeSet: true, cosmeticOnly: false, fields: ["showAdvanced"] },
+    }),
+    false,
+  );
+});
+
+test("#1623 a changed node SET is never presentation-only", () => {
+  assert.equal(
+    openContentDifferenceIsPresentationOnly({
+      comparable: true,
+      surfaces: ["nodes"],
+      nodeDifference: { comparable: true, sameNodeSet: false, cosmeticOnly: false, fields: [] },
+    }),
+    false,
+  );
+});
+
+test("#1623 sameNodeSet is checked SEPARATELY, not inferred from cosmeticOnly", () => {
+  // Mutation-driven. `classifyNodeDifference` only computes `fields` once the sets
+  // match, so its own `cosmeticOnly:true` already implies `sameNodeSet:true` and
+  // deleting the set check changes nothing it produces — the mutation SURVIVED until
+  // this test existed. But the predicate is EXPORTED and takes a caller-supplied
+  // shape, and the two questions ("is this the same graph" / "can the panel name what
+  // moved") are answered by different classifiers that a later change may separate.
+  // An inconsistent shape must refuse rather than let a set difference through on the
+  // strength of a field list.
+  assert.equal(
+    openContentDifferenceIsPresentationOnly({
+      comparable: true,
+      surfaces: ["nodes"],
+      nodeDifference: { comparable: true, sameNodeSet: false, cosmeticOnly: true, fields: ["size"] },
+    }),
+    false,
+    "a named cosmetic field cannot vouch for a node set that differs",
+  );
+});
+
+test("#1623 a SECOND differing surface is never presentation-only", () => {
+  // #825's own rule, kept: a group, a link, a reroute or a definitions difference is
+  // unexplained by anything a node comparison establishes.
+  for (const surfaces of [
+    ["nodes", "groups"],
+    ["nodes", "links"],
+    ["nodes", "definitions"],
+    ["groups"],
+    [],
+  ]) {
+    assert.equal(
+      openContentDifferenceIsPresentationOnly({ comparable: true, surfaces, nodeDifference: cosmetic(["size"]) }),
+      false,
+      `surfaces ${JSON.stringify(surfaces)} must not license the claim`,
+    );
+  }
+});
+
+test("#1623 an absent comparison asserts nothing in EITHER direction", () => {
+  for (const observed of [
+    undefined,
+    {},
+    { comparable: false, surfaces: ["nodes"], nodeDifference: cosmetic(["size"]) },
+    { comparable: "true", surfaces: ["nodes"], nodeDifference: cosmetic(["size"]) },
+    { comparable: true, surfaces: ["nodes"], nodeDifference: null },
+    { comparable: true, surfaces: ["nodes"], nodeDifference: { comparable: false, sameNodeSet: true, cosmeticOnly: true, fields: ["size"] } },
+  ]) {
+    assert.equal(openContentDifferenceIsPresentationOnly(observed), false);
+  }
+});
+
+// ── the open's own verdict, off a real serialized graph ──────────────────────
+
+test("#1623 THE REPORT: a re-measured DOM node box no longer fails the open", () => {
+  // The reporter's own shape. `size` changed in BOTH dimensions, which is what a DOM
+  // widget's box does and what `sizeDifferenceIsHeightOnly` (rightly) refuses to call
+  // a measured rewrite — so the STRICT proof still says no...
+  const state = stateOf([node(1, "ComfySketch", { size: [400, 300] })]);
+  const live = stateOf([node(1, "ComfySketch", { size: [512, 384] })]);
+  const proof = graphRootReproducesStateContent({ rootGraph: rootOf(live), state });
+  assert.equal(proof.proven, false, "a width change is still not a characterised rewrite");
+  // ...and the weaker ground carries it, with the differing field NAMED.
+  assert.equal(proof.presentationOnly, true);
+  assert.deepEqual(proof.fields, ["size"]);
+});
+
+test("#1623 a changed `order` or `pos` no longer fails the open", () => {
+  for (const [field, before, after] of [
+    ["order", 0, 3],
+    ["pos", [0, 0], [120, 40]],
+    ["color", "#111", "#222"],
+  ]) {
+    const state = stateOf([node(1, "KSampler", { [field]: before })]);
+    const live = stateOf([node(1, "KSampler", { [field]: after })]);
+    const proof = graphRootReproducesStateContent({ rootGraph: rootOf(live), state });
+    assert.equal(proof.proven, false, `${field} is deliberately NOT a measured rewrite`);
+    assert.equal(proof.presentationOnly, true, `${field} cannot mean authored content was lost`);
+    assert.deepEqual(proof.fields, [field], "the reply must be able to name what moved");
+  }
+});
+
+test("#1623 a WIDGET VALUE difference still fails the open, on both grounds", () => {
+  const state = stateOf([node(1, "KSampler", { widgets_values: ["a", 42] })]);
+  const live = stateOf([node(1, "KSampler", { widgets_values: ["a", 7] })]);
+  const proof = graphRootReproducesStateContent({ rootGraph: rootOf(live), state });
+  assert.equal(proof.proven, false);
+  assert.equal(proof.presentationOnly, false, "this is the exact difference a partial load leaves");
+  assert.deepEqual(proof.fields, [], "an unaccounted difference must not be named as presentation");
+});
+
+test("#1623 a cosmetic difference ALONGSIDE a lost widget value still fails", () => {
+  // The mixed case is where a name-only allowlist would leak: the size moved AND a
+  // value went. Nothing may vouch for the second on the strength of the first.
+  const state = stateOf([node(1, "KSampler", { size: [200, 100], widgets_values: ["a", 42] })]);
+  const live = stateOf([node(1, "KSampler", { size: [200, 60], widgets_values: ["a"] })]);
+  const proof = graphRootReproducesStateContent({ rootGraph: rootOf(live), state });
+  assert.equal(proof.proven, false);
+  assert.equal(proof.presentationOnly, false);
+});
+
+test("#1623 a MISSING node still fails the open", () => {
+  const state = stateOf([node(1, "KSampler"), node(2, "VAEDecode")]);
+  const live = stateOf([node(1, "KSampler")]);
+  const proof = graphRootReproducesStateContent({ rootGraph: rootOf(live), state });
+  assert.equal(proof.proven, false);
+  assert.equal(proof.presentationOnly, false);
+});
+
+test("#1623 a cosmetic node difference PLUS a lost group still fails", () => {
+  const state = { ...stateOf([node(1, "KSampler", { size: [200, 100] })]), groups: [{ title: "g" }] };
+  const live = { ...stateOf([node(1, "KSampler", { size: [200, 60] })]), groups: [] };
+  const proof = graphRootReproducesStateContent({ rootGraph: rootOf(live), state });
+  assert.equal(proof.proven, false);
+  assert.equal(proof.presentationOnly, false, "geometry cannot vouch for a surface it does not describe");
+});
+
+test("#1623 the strict #1001 proof still wins where it applies, and does not claim the weaker ground", () => {
+  // A height-only size change is a CHARACTERISED rewrite: it stays `proven`, so the
+  // reply keeps `geometry_rewritten` and its stronger note. Both flags being true
+  // would let the two disclosures ship together and contradict each other.
+  const state = stateOf([node(1, "SaveVideo", { size: [300, 358] })]);
+  const live = stateOf([node(1, "SaveVideo", { size: [300, 126] })]);
+  const proof = graphRootReproducesStateContent({ rootGraph: rootOf(live), state });
+  assert.equal(proof.proven, true);
+  assert.equal(proof.exact, false);
+  assert.deepEqual(proof.fields, ["size"]);
+  assert.equal(proof.presentationOnly, false);
+});
+
+// ── the message and the verdict must ask the SAME question ───────────────────
+
+test("#1623 the disclosure's reassurance is the SAME predicate the verdict uses", () => {
+  // The defect was two spellings of one question drifting apart. `describeOpenRebindOutcome`
+  // is pure and still reachable if a live canvas moves between the verdict and the
+  // message, so the sentence stays — but it may not be computed independently.
+  const src = readFileSync(GRAPH_BINDING_JS, "utf8");
+  const at = src.indexOf("export function describeOpenRebindOutcome");
+  assert.notEqual(at, -1);
+  const body = src.slice(at, src.indexOf("\nexport ", at + 1));
+  assert.match(
+    body,
+    /const valuesMatched = openContentDifferenceIsPresentationOnly\(\{/,
+    "the sentence must not re-derive `cosmeticOnly` on its own",
+  );
+  // No independent READ of the field — the prose may still name it. A second reading
+  // of the same field is how the two answers drifted apart in the first place.
+  assert.doesNotMatch(body, /\.cosmeticOnly/, "the sentence must not read the classification itself");
+  assert.doesNotMatch(body, /COSMETIC_NODE_FIELDS/, "nor re-apply the set behind it");
+  // ...and the verdict path reads it too, off the SAME frozen snapshot the strict
+  // proof reads. A second serialization would reopen the hole the snapshot closes.
+  const proofAt = src.indexOf("export function graphRootReproducesStateContent");
+  const proofBody = src.slice(proofAt, src.indexOf("\n/**", proofAt + 1));
+  assert.match(proofBody, /const frozen = \{ serialize: \(\) => actualState \};/);
+  assert.match(proofBody, /openContentDifferenceIsPresentationOnly\(\{/);
+  assert.doesNotMatch(
+    proofBody.slice(proofBody.indexOf("const frozen")),
+    /rootGraph\?\.serialize/,
+    "one snapshot, and both questions read it",
+  );
+});
+
+test("#1623 the reassurance sentence itself is unchanged for what still fails", () => {
+  const CONTENT_ONLY = resolveOpenRebindVerdict({
+    instanceStillTarget: true,
+    markerMatches: true,
+    identityMatches: true,
+    contentMatches: false,
+  });
+  assert.equal(CONTENT_ONLY.status, OPEN_REBIND_STATUS.CONTENT_UNVERIFIED);
+  const msg = describeOpenRebindOutcome(CONTENT_ONLY, {
+    targetLabel: "origami.json",
+    contentComparable: true,
+    contentSurfaces: ["nodes"],
+    contentNodeDifference: { comparable: true, sameNodeSet: true, cosmeticOnly: false, fields: ["widgets_values"] },
+  });
+  assert.match(msg, /no node was lost/i);
+  assert.doesNotMatch(msg, /no missing work to redo/i, "a widget value that moved gets no all-clear");
+});
+
+// ── wiring: the panel must actually take its answer from this ────────────────
+
+test("#1623 wiring: the open's pass/fail reads BOTH grounds, and the disclosures stay separate", () => {
+  const src = readFileSync(PANEL_JS, "utf8");
+  // Deleting `|| contentProof.presentationOnly` restores the reported false error and
+  // this assertion is what notices. Deleting the whole line breaks the handler.
+  assert.match(src, /const contentMatches = contentProof\.proven \|\| contentProof\.presentationOnly;/);
+  // Two keys, two notes. The weaker ground must not borrow `geometry_rewritten`'s
+  // note, which asserts every difference is a height with the width unchanged —
+  // false of the very case this fix admits.
+  const presentationAt = src.indexOf("presentation_rewritten:");
+  const geometryAt = src.indexOf("geometry_rewritten:");
+  assert.notEqual(presentationAt, -1, "the caller must be told which fields moved");
+  assert.notEqual(geometryAt, -1);
+  assert.notEqual(presentationAt, geometryAt);
+  assert.match(src, /presentation_rewritten_note:/);
+  // The note may not repeat the height-only claim.
+  const noteAt = src.indexOf("presentation_rewritten_note:");
+  const note = src.slice(noteAt, src.indexOf("}", src.indexOf("`,", noteAt)));
+  assert.doesNotMatch(note, /width unchanged/i, "no height-only claim was established here");
+  assert.match(note, /#1623/);
+  // And the variable is only ever assigned from the presentation-only ground.
+  // Every assignment, not just the one we wrote — pinning a single known statement
+  // leaves the file free to grow a second one that sets it from somewhere else. The
+  // `let` initializer is excluded by the lookbehind, not by position.
+  const assignments = [...src.matchAll(/(?<!let )openPresentationRewritten = ([^;\n]+);/g)].map((m) => m[1]);
+  assert.deepEqual(assignments, ["contentProof.fields"]);
+  const guardAt = src.indexOf("if (contentProof.presentationOnly) {");
+  assert.notEqual(guardAt, -1);
+  assert.ok(
+    guardAt < src.indexOf("openPresentationRewritten = contentProof.fields;"),
+    "it must be gated on the ground that earned it",
+  );
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -14357,6 +14357,12 @@ const GRAPH_TOOL_EXECUTORS = {
     // and the reply says which fields moved rather than quietly deciding it did not
     // happen: the caller is the one who knows whether stored node sizes matter to them.
     let openGeometryRewritten = null;
+    // #1623 — the per-node PRESENTATION that differs on a load where nothing authored
+    // can have been lost. Distinct from `openGeometryRewritten`, which is the STRICT
+    // proof's disclosure and whose note asserts a characterised height-only rewrite:
+    // this one carries the weaker, differently-earned claim and must not borrow that
+    // sentence.
+    let openPresentationRewritten = null;
     // Hold the switch+reload critical section across the WHOLE mutating sequence. The canvas
     // freeze keeps the USER out; this keeps the BRIDGE out, so a concurrent graph_* command
     // can neither be overwritten by the reload nor be silently re-baselined as clean.
@@ -14661,9 +14667,29 @@ const GRAPH_TOOL_EXECUTORS = {
               // stale and the next command was refused as an instance mismatch. The
               // rewritten geometry is DISCLOSED on the reply rather than swallowed.
               const contentProof = graphRootReproducesStateContent({ rootGraph, state: repaintState });
-              const contentMatches = contentProof.proven;
+              // #1623 — TWO grounds, and they license different sentences.
+              //
+              // `proven` is "the content was reproduced": every difference fits a
+              // rewrite this panel has measured, field by field.
+              // `presentationOnly` is the weaker "nothing AUTHORED was lost": the node
+              // set is intact, `nodes` is the only differing surface, and every field
+              // that moved is one a difference in cannot mean lost content
+              // (`COSMETIC_NODE_FIELDS`). Widget values, properties, title, flags, mode
+              // and the link-bearing slots are all outside it, so the mid-`configure()`
+              // partial load that `resolveOpenRebindVerdict` refuses to guess at cannot
+              // reach here — it drops exactly those.
+              //
+              // The open's pass/fail turns on the WEAKER question, because that is the
+              // one the caller acts on, and because the panel's own disclosure already
+              // answered it: a reporter was told "you are on the right workflow and
+              // there is no missing work to redo" by a call reported as an ERROR, twice
+              // in a row, and re-read a graph that was already correct.
+              const contentMatches = contentProof.proven || contentProof.presentationOnly;
               if (contentProof.proven && !contentProof.exact) {
                 openGeometryRewritten = contentProof.fields;
+              }
+              if (contentProof.presentationOnly) {
+                openPresentationRewritten = contentProof.fields;
               }
               const verdict = resolveOpenRebindVerdict({
                 instanceStillTarget,
@@ -15072,6 +15098,28 @@ const GRAPH_TOOL_EXECUTORS = {
               `reproduced and the workflow_uuid is published rather than refused. It is still a ` +
               `real difference from what is on disk: saving from here writes the recomputed ` +
               `value (#1001).`,
+          }
+        : {}),
+      // #1623 — present only when the open was reported applied on the PRESENTATION-only
+      // ground rather than the strict content proof. Its own key and its own note: the
+      // two claims are different sizes, and letting this case borrow
+      // `geometry_rewritten_note` would tell the caller every difference is a height
+      // with the width unchanged, which is exactly what was NOT established here.
+      ...(openPresentationRewritten?.length
+        ? {
+            presentation_rewritten: openPresentationRewritten,
+            // States what was COMPARED and stops, like its neighbour. It does NOT say
+            // the frontend recomputed these: `color`/`bgcolor` are authored by the user
+            // and nothing here observed a cause, only a difference.
+            presentation_rewritten_note:
+              `Every node in this workflow came back with the same id and type, nothing extra ` +
+              `appeared, and every serialized field that can carry authored content — widget ` +
+              `values, properties, title, flags, mode, and the input/output slots — matched what ` +
+              `was loaded. What differs is per-node presentation: ${openPresentationRewritten.join(", ")}. ` +
+              `No node and no value was lost, so the open is reported APPLIED and the workflow_uuid ` +
+              `is published rather than refused (#1623). The panel observed the difference and not ` +
+              `its cause, and it is still a real difference from what is on disk: saving from here ` +
+              `writes the live values.`,
           }
         : {}),
       modified: !!target.isModified,

--- a/web/js/lib/graph-binding.js
+++ b/web/js/lib/graph-binding.js
@@ -883,8 +883,68 @@ function sizeDifferenceIsHeightOnly(expectedNodes, actualNodes) {
   }
 }
 
+/**
+ * Is the whole difference confined to PRESENTATION — i.e. can nothing AUTHORED have
+ * been lost? (#1623)
+ *
+ * THE DEFECT THIS ANSWERS. `workflow_open`'s pass/fail is taken from
+ * `graphRootReproducesStateContent`, whose `RECOMPUTED_NODE_FIELDS` answers a
+ * different question — "is this difference explained by a rewrite this panel has
+ * MEASURED" — and holds only `size` (height-only) and `inputs`. The DISCLOSURE asks
+ * the question the caller acts on, `cosmeticOnly`, and on the very same observation
+ * answers "you are on the right workflow and there is no missing work to redo".
+ *
+ * A reporter got exactly that sentence with the call reported as an ERROR, on two
+ * consecutive workflow switches, and went and re-read a graph that was already
+ * correct (#1623). One reply cannot say both things. So the sentence's own predicate
+ * is promoted to a shared function, and the VERDICT is taken from it too: two lists
+ * that agreed by accident and then stopped is what produced the contradiction.
+ *
+ * WHY THIS IS SAFE, against the reason `content` blocks success at all.
+ * `resolveOpenRebindVerdict` records the mechanism: `loadGraphData` catches a
+ * `configure()` throw and returns, leaving the complete node id/type set, the links
+ * and the panel's marker over nodes that silently LOST their widget values and
+ * properties — byte-identical to "the loader normalized the values", with no
+ * discriminator to separate them. That failure cannot present HERE.
+ * `widgets_values`, `properties`, `title`, `flags`, `mode`, `inputs` and `outputs`
+ * are every one of them OUTSIDE `COSMETIC_NODE_FIELDS`, and `configure()` writes
+ * them in the same pass as the cosmetic five — so a load that died mid-configure
+ * answers false on the first node it reached. The discriminator that comment says
+ * does not exist is WHICH FIELDS DIFFER, and the panel already computes it.
+ *
+ * It is deliberately NOT a widening of `RECOMPUTED_NODE_FIELDS`. That set licenses
+ * "the content was reproduced", which is why it demands a characterised rewrite per
+ * field; this one licenses only "nothing authored was lost", which is the weaker
+ * claim the open's pass/fail actually turns on. `widgets_values` stays outside BOTH,
+ * so the guard #1111 and #1089 exist for is untouched: a widget value that differs
+ * still fails the open, however plausibly a frontend might have normalized it.
+ */
+export function openContentDifferenceIsPresentationOnly({ comparable, surfaces, nodeDifference } = {}) {
+  // Never inferred from an absent comparison — `comparable:false` means no comparison
+  // happened, which is not evidence in either direction.
+  if (comparable !== true) return false;
+  const unique = Array.isArray(surfaces) ? [...new Set(surfaces)] : [];
+  // `nodes`, and NOTHING else. A group, a link, a reroute or a definitions difference
+  // is unexplained by anything a node comparison establishes — #825's own rule, kept.
+  if (unique.length !== 1 || unique[0] !== "nodes") return false;
+  // THESE TWO OVERLAP for anything `classifyNodeDifference` produces — it computes
+  // `fields` only once the sets match, so its `cosmeticOnly:true` already implies
+  // `sameNodeSet:true`, and deleting the set check kills no test off that classifier
+  // alone (measured: the mutation survived until a test was written for it). Both are
+  // kept because they answer different questions — "is this the same graph" and "can
+  // the panel name what moved" — and this predicate is EXPORTED, so it must refuse an
+  // inconsistent shape rather than let a set difference through on a field list.
+  return (
+    nodeDifference?.comparable === true &&
+    nodeDifference.sameNodeSet === true &&
+    // `cosmeticOnly` is itself false for an EMPTY field list, so this cannot pass on a
+    // `nodes` surface nobody could name a difference in.
+    nodeDifference.cosmeticOnly === true
+  );
+}
+
 export function graphRootReproducesStateContent({ rootGraph, state } = {}) {
-  const NOT_PROVEN = { proven: false, exact: false, fields: [] };
+  const NOT_PROVEN = { proven: false, exact: false, fields: [], presentationOnly: false };
   try {
     // ONE SNAPSHOT, and every check below reads it (codex r3). Serializing separately
     // per check let a synchronous serialization hook — a broken or hostile custom node —
@@ -894,11 +954,40 @@ export function graphRootReproducesStateContent({ rootGraph, state } = {}) {
     const actualState = rootGraph?.serialize?.();
     if (actualState == null) return NOT_PROVEN;
     const frozen = { serialize: () => actualState };
-    if (graphRootMatchesState({ rootGraph: frozen, state })) return { proven: true, exact: true, fields: [] };
+    if (graphRootMatchesState({ rootGraph: frozen, state })) {
+      return { proven: true, exact: true, fields: [], presentationOnly: false };
+    }
     const diff = describeGraphStateDifference({ rootGraph: frozen, state });
     // Never inferred from an absent comparison: `comparable:false` means no
     // comparison happened, which is not evidence either way.
     if (diff?.comparable !== true) return NOT_PROVEN;
+    // #1623 — the WEAKER question ("could anything authored have been lost"), asked
+    // off THE SAME SNAPSHOT the strict proof below reads. Answering it from a second
+    // serialization would reopen exactly the hole the frozen snapshot closes: a
+    // synchronous serialization hook could show a cosmetic-only difference here and a
+    // changed widget to the proof, and the open would be reported applied on content
+    // no single comparison ever saw.
+    //
+    // Every refusal BELOW this line is a refusal of the strict proof only, so each one
+    // carries this answer out rather than discarding it — the reporter's own case
+    // (`pos`/`order`, and a `size` whose WIDTH moved) is refused by the strict proof
+    // and is presentation-only, and returning the shared `NOT_PROVEN` there is what
+    // would have left the fix wired into a branch its own bug report cannot reach.
+    const presentationOnly = openContentDifferenceIsPresentationOnly({
+      comparable: true,
+      surfaces: diff.surfaces,
+      nodeDifference: diff.nodeDifference,
+    });
+    const notProven = {
+      proven: false,
+      exact: false,
+      // NAMED, so the reply can tell the caller which fields moved instead of asking
+      // them to guess — the same contract `geometry_rewritten` already has. Empty
+      // unless presentation-only, because on any other refusal these fields describe a
+      // difference nobody has accounted for.
+      fields: presentationOnly && Array.isArray(diff.nodeDifference?.fields) ? diff.nodeDifference.fields : [],
+      presentationOnly,
+    };
     const surfaces = Array.isArray(diff.surfaces) ? diff.surfaces : [];
     // ONE surface, and it must be `nodes`. A group or a link that disagrees is
     // unexplained by anything the node comparison establishes.
@@ -925,17 +1014,17 @@ export function graphRootReproducesStateContent({ rootGraph, state } = {}) {
     // differing surface, so requiring `nodes` refused exactly the case this exists to
     // prove — a fix wired into a branch its own bug report cannot reach.
     const unique = [...new Set(surfaces)];
-    if (!unique.length) return NOT_PROVEN;
-    if (unique.some((s) => s !== "nodes" && s !== "definitions")) return NOT_PROVEN;
+    if (!unique.length) return notProven;
+    if (unique.some((s) => s !== "nodes" && s !== "definitions")) return notProven;
     if (unique.includes("definitions")) {
       if (!definitionsDifferOnlyByLinkRenumber(state?.definitions, actualState?.definitions)) {
-        return NOT_PROVEN;
+        return notProven;
       }
     }
     // A definitions-only difference is fully accounted for once the renumber check
     // passes: there is no node difference to classify.
     if (!unique.includes("nodes")) {
-      return { proven: true, exact: false, fields: [] };
+      return { proven: true, exact: false, fields: [], presentationOnly: false };
     }
     const nodes = diff.nodeDifference;
     // THE NEXT TWO CHECKS DELIBERATELY OVERLAP, and neither can be killed alone by
@@ -945,14 +1034,14 @@ export function graphRootReproducesStateContent({ rootGraph, state } = {}) {
     // because they answer different questions — "is this the same graph" and "can the
     // panel name what moved" — and a later change to one classifier must not silently
     // remove the other's guarantee.
-    if (nodes?.comparable !== true || nodes.sameNodeSet !== true) return NOT_PROVEN;
+    if (nodes?.comparable !== true || nodes.sameNodeSet !== true) return notProven;
     const fields = Array.isArray(nodes.fields) ? nodes.fields : [];
     // WIDTH IS NOT MEASURED (codex r2). The evidence is a recomputed HEIGHT, and a
     // field-name allowlist admits any rewrite of the whole `[w, h]` pair — so a changed
     // width, or an arbitrary replacement, would have been PROVEN on the strength of a
     // measurement about something else. Every differing size must be height-only.
     if (fields.includes("size") && !sizeDifferenceIsHeightOnly(state?.nodes, actualState?.nodes)) {
-      return NOT_PROVEN;
+      return notProven;
     }
     // #1467 — `inputs` is REBUILT by the frontend, not restored, and admitting it
     // needs the same treatment `size` gets: characterise the rewrite and require
@@ -974,14 +1063,14 @@ export function graphRootReproducesStateContent({ rootGraph, state } = {}) {
       fields.includes("inputs") &&
       !nodeInputsDifferOnlyByDefinitionRebuild(state?.nodes, actualState?.nodes)
     ) {
-      return NOT_PROVEN;
+      return notProven;
     }
     // An empty field list with a differing `nodes` surface means the two disagreed
     // somewhere this classifier could not name — proving content off a difference
     // nobody can point at is exactly the fabricated all-clear to avoid.
-    if (!fields.length) return NOT_PROVEN;
-    if (!fields.every((field) => RECOMPUTED_NODE_FIELDS.has(field))) return NOT_PROVEN;
-    return { proven: true, exact: false, fields };
+    if (!fields.length) return notProven;
+    if (!fields.every((field) => RECOMPUTED_NODE_FIELDS.has(field))) return notProven;
+    return { proven: true, exact: false, fields, presentationOnly: false };
   } catch {
     return NOT_PROVEN;
   }
@@ -1659,7 +1748,20 @@ export function describeOpenRebindOutcome(verdict, observed = {}) {
     const nodeSetIntact =
       observed.contentNodeDifference?.comparable === true &&
       observed.contentNodeDifference?.sameNodeSet === true;
-    const valuesMatched = observed.contentNodeDifference?.cosmeticOnly === true;
+    // #1623 — the SHARED predicate, not a fourth spelling of it. This sentence and
+    // `workflow_open`'s pass/fail must not be able to disagree about the same
+    // observation, which is the defect that was reported: the caller was told "there
+    // is no missing work to redo" on a call reported as an error.
+    //
+    // The panel now reports that case APPLIED, so reaching this branch means the
+    // strict proof saw something else — a second serialization of a live canvas can
+    // move between the verdict and this message. The sentence stays for that, and it
+    // stays TRUE of what it is describing, because it asks the same question.
+    const valuesMatched = openContentDifferenceIsPresentationOnly({
+      comparable: compared,
+      surfaces: observed.contentSurfaces,
+      nodeDifference: observed.contentNodeDifference,
+    });
     if (compared && nodesOnly && nodeSetIntact) {
       // Two claims, and only the ones the comparison supports (codex). The node set
       // is proven in both branches. `cosmeticOnly` additionally establishes that the


### PR DESCRIPTION
Reported in artokun/comfyui-mcp#1623 — `panel_open_workflow` reports a false error when the frontend normalizes per-node fields.

## What the reporter got

Two consecutive workflow switches, on a library with DOM/custom nodes (ComfySketch, MarkdownNote), each returning `isError: true` with a message that ends:

> workflow_open RAN, the canvas IS bound to X, and every node that was loaded is on it with the same id and type … nothing extra appeared … the content is reported **UNCONFIRMED rather than failed** … You are on the right workflow and **there is no missing work to redo**.

A reply cannot say "no missing work to redo" and fail. They took the failure at face value and spent a `panel_graph_outline` recovery read on a graph that was already correct.

## The mechanism — two lists answering different questions

| set | question it answers | contents |
|---|---|---|
| `RECOMPUTED_NODE_FIELDS` | is this difference explained by a rewrite this panel **measured**? | `size` (height-only), `inputs` |
| `COSMETIC_NODE_FIELDS` | could anything **authored** have been lost? | `size`, `pos`, `order`, `color`, `bgcolor` |

The **disclosure** asks the second. The **pass/fail** asked the first. So `pos`, `order`, `color`, `bgcolor` — and a `size` whose **width** moved, which is exactly what a DOM widget's box does — failed the open while the sentence attached to that failure said nothing was lost. The two agreed by accident when the only cosmetic field anyone hit was a height, and stopped agreeing the moment one wasn't.

## The change

`openContentDifferenceIsPresentationOnly` is promoted to a single exported predicate — nodes is the only differing surface, the node set is intact, every differing field is in `COSMETIC_NODE_FIELDS` — and **both** the sentence and the verdict now read it. The open reports applied on that weaker ground, publishes `workflow_uuid`, and discloses the fields that moved under its own key (`presentation_rewritten`) with its own note.

It is asked off the **same frozen snapshot** the strict proof reads. Answering it from a second serialization would reopen the hole codex r3 closed: a synchronous serialization hook could show a cosmetic-only difference to one question and a changed widget to the other.

## What is NOT widened — this is the part to review hardest

`widgets_values` stays outside **both** sets, so the reporter's prescribed fix ("treat size/order/**widgets_values** as success") is **not** granted. `RECOMPUTED_NODE_FIELDS` is not touched at all.

`resolveOpenRebindVerdict` records why `content` blocks success in the first place: `loadGraphData` catches a mid-`configure()` throw and returns, leaving the complete node id/type set, the links and the panel's marker over nodes that silently **lost their widget values and properties** — byte-identical to "the loader normalized them", with no discriminator to separate the two.

That failure cannot present as presentation-only. `configure()` writes `widgets_values`, `properties`, `title`, `flags` and `mode` in the same pass as the cosmetic five, and every one of them is outside `COSMETIC_NODE_FIELDS` — so a load that died mid-configure answers false on the first node it reached, and the nodes it never got to answer false on everything. The discriminator that comment says does not exist **is which fields differ**, and the panel already computes it. The guard #1111 and #1089 exist for is untouched.

`COSMETIC_NODE_FIELDS` remains a **denylist**: an unknown field from any node pack reads as non-cosmetic and still fails the open. `color`/`bgcolor` are authored and a difference there IS an authoring difference — they ride along because the claim being licensed is only "no node and no value was lost", and the reply **names every field that moved** so a caller who stores colours finds out.

## Verified

- `npm run test:unit`: **4543 tests, 0 failures**, including the i18n, tool-vocabulary and panel-scope gates.
- **9 mutations applied, all 9 killed** — occurrence-verified (each `from` string must appear exactly once or the mutation is reported skipped, not silently passed). Including M1, which restores the reported behaviour by deleting `|| contentProof.presentationOnly`, and M6, which discards the answer at the strict proof's own refusal so the fix goes inert for the reporter's case.
- `sameNodeSet` in the predicate **survived** deletion at first — `classifyNodeDifference` computes `fields` only after the sets match, so its `cosmeticOnly:true` already implies it. The check is kept (the predicate is exported and takes a caller-supplied shape) and now has a test that kills the mutation, with the overlap written down rather than left as a coincidence.

## What I deliberately did NOT do

- **I did not reproduce the reporter's session.** If one of their two switches differed in `widgets_values` — the issue body lists it — that call still fails, correctly, and I say so on the issue. Admitting it needs the rewrite characterised the way `size` and `inputs` were, and I had no live frontend to measure against; guessing at it is what `RECOMPUTED_NODE_FIELDS`'s own growth rule forbids.
- I did not touch `describeOpenRebindOutcome`'s reassurance branch. It is still reachable — a live canvas can move between the verdict and the message — and it now asks the same question the verdict does, so it can no longer contradict it.
- I did not admit a `definitions` surface alongside `nodes` here. #1252 (open) is doing that accounting for the message; this stays on the narrow `["nodes"]` gate and will merge on top of whichever lands first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
