### PR TITLE
fix(1199): a completion recovered from history reports when it RENDERED, not when it was replayed

### DIFF
--- a/browser_tests/unit/run-reconcile-stale-age.test.mjs
+++ b/browser_tests/unit/run-reconcile-stale-age.test.mjs
@@ -361,6 +361,35 @@ test("#1199 presentation: a recovered MEDIA-LESS run still reports the no-media 
   assert.equal(frame.metadata[0].reconciled, true);
 });
 
+test("#1199 presentation: a recovered STILLS run stamps the real finish in per-output metadata", async () => {
+  // The per-output metadata block is a SECOND consumer of the finish time,
+  // independent of the note. Without this, `finishedAt ?? composedAt` could
+  // decay to the compose clock on the stills path with the whole suite still
+  // green — the machine-readable record would then disagree with the banner
+  // sitting directly above it.
+  const { deps } = makeFrameDeps();
+  const finishedAt = NOW - 2 * DAY;
+  const frame = await composeRunCompletionFrame(
+    {
+      promptId: "p-stills",
+      images: [{ filename: "final.png", type: "output" }],
+      videos: [],
+      durationMs: 20_000,
+      finishedAt,
+      reconciled: true,
+    },
+    deps,
+  );
+  assert.equal(
+    frame.metadata[0].finishedAt,
+    new Date(finishedAt).toISOString(),
+    "per-output metadata carries the REAL finish, not the compose clock",
+  );
+  // …and the human-readable bullet carries the full date, not a bare clock time.
+  assert.doesNotMatch(frame.note, /DELIVERY-CLOCK/);
+  assert.match(frame.note, /2 days ago/);
+});
+
 test("#1199 presentation: ages read at the right magnitude", async () => {
   const cases = [
     [30_000, /under a minute ago/],

--- a/browser_tests/unit/run-reconcile-stale-age.test.mjs
+++ b/browser_tests/unit/run-reconcile-stale-age.test.mjs
@@ -1,0 +1,420 @@
+/**
+ * Unit tests for #1199 — a completion recovered from /history must report when it
+ * RENDERED, not when the recovery happened.
+ *
+ * The reported failure: a reconcile edge (tab wake / reconnect) swept SEVEN prompt
+ * ids that had been sitting in the pending ledger since two nights earlier. The
+ * long-running ComfyUI still had all seven in `/history`, so all seven were
+ * delivered in one burst — each stamped `finishedAt: now()`, i.e. the delivery
+ * time. Every one announced "finished 7:45:29 AM" (the same second), and the agent
+ * told the user seven videos were ready whose files the user had moved out of the
+ * output directory days before.
+ *
+ * The replay itself is by design ("never lose a completion"). What was wrong is
+ * that a replay was indistinguishable from a fresh render. Three seams:
+ *
+ *   1. history-reconcile.js — the entry's own `execution_success` timestamp was
+ *      never read, so the real finish time was unavailable to anyone downstream.
+ *   2. run-completion.js — the reconciled flush stamped `now()`, and computed
+ *      `durationMs` as `now() - startTs`, which measures the RECONCILE GAP ("2
+ *      days") rather than the render.
+ *   3. comfyui-mcp-panel.js / run-completion-frame.js — the call site dropped
+ *      `finishedAt` and `reconciled` on the floor and the composer stamped its own
+ *      clock, so fixing (1) and (2) alone would have changed nothing observable.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import { createRunCompletionTracker } from "../../web/js/lib/run-completion.js";
+import { parseHistoryEntry } from "../../web/js/lib/history-reconcile.js";
+import { composeRunCompletionFrame } from "../../web/js/lib/run-completion-frame.js";
+
+const isVideo = (m) => /\.(mp4|webm|mov)$/i.test(String(m?.filename || ""));
+
+// A realistic wall clock. The tracker's real `now` is Date.now(), and the
+// future-skew rejection compares history timestamps against it — so a harness
+// pinned at 0 (the pattern in run-reconcile.test.mjs) would read every real epoch
+// as "impossibly far in the future". These tests are about wall-clock ages, so
+// they run on a wall-clock-shaped fake.
+const NOW = Date.parse("2026-08-14T07:45:29Z");
+const MINUTE = 60_000;
+const HOUR = 60 * MINUTE;
+const DAY = 24 * HOUR;
+
+/** Tracker harness on a wall-clock-shaped fake clock. */
+function makeHarness(opts = {}) {
+  let clock = NOW;
+  const timers = new Map();
+  let seq = 0;
+  const flushes = [];
+  const tracker = createRunCompletionTracker({
+    onFlush: (p) => flushes.push(p),
+    now: () => clock,
+    setTimer: (fn, ms) => {
+      const id = ++seq;
+      timers.set(id, { at: clock + ms, fn });
+      return id;
+    },
+    clearTimer: (id) => timers.delete(id),
+    debounceMs: 1500,
+    ...opts,
+  });
+  return {
+    tracker,
+    flushes,
+    setClock: (t) => {
+      clock = t;
+    },
+    advance: (ms) => {
+      clock += ms;
+    },
+  };
+}
+
+/**
+ * A terminal-success history entry carrying ComfyUI's real lifecycle messages.
+ * `[name, data]` with `data.timestamp` is exactly the shape ComfyUI records in
+ * `status.messages`.
+ */
+const entryWithTimes = (outputs, { startedAt, finishedAt, unit = "ms" } = {}) => {
+  const stamp = (ms) => (unit === "s" ? Math.floor(ms / 1000) : ms);
+  const messages = [];
+  if (startedAt != null) messages.push(["execution_start", { prompt_id: "p", timestamp: stamp(startedAt) }]);
+  if (finishedAt != null) messages.push(["execution_success", { prompt_id: "p", timestamp: stamp(finishedAt) }]);
+  return { outputs, status: { status_str: "success", completed: true, messages } };
+};
+
+const videoOutput = (filename) => ({ 10: { gifs: [{ filename, type: "output" }] } });
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 1. The parse recovers the run's own times
+// ─────────────────────────────────────────────────────────────────────────────
+
+test("#1199 parse: execution_success supplies the real finish time (epoch ms)", () => {
+  const finishedAt = NOW - 2 * DAY;
+  const startedAt = finishedAt - 134_000;
+  const parsed = parseHistoryEntry(
+    entryWithTimes(videoOutput("MiniMax_H3_00184_.mp4"), { startedAt, finishedAt }),
+    { isVideo, now: () => NOW },
+  );
+  assert.equal(parsed.finishedAt, finishedAt, "finish time comes from the entry, not the clock");
+  assert.equal(parsed.startedAt, startedAt, "start time comes from the entry too");
+});
+
+test("#1199 parse: epoch SECONDS are normalized to ms (ComfyUI builds differ)", () => {
+  const finishedAt = NOW - 6 * HOUR;
+  const parsed = parseHistoryEntry(
+    entryWithTimes(videoOutput("a.mp4"), { finishedAt, unit: "s" }),
+    { isVideo, now: () => NOW },
+  );
+  // Second-resolution round trip, so compare at second granularity.
+  assert.equal(parsed.finishedAt, Math.floor(finishedAt / 1000) * 1000);
+});
+
+test("#1199 parse: an entry with no lifecycle timestamps reports the finish time as UNKNOWN", () => {
+  const parsed = parseHistoryEntry(
+    { outputs: videoOutput("a.mp4"), status: { status_str: "success", completed: true, messages: [] } },
+    { isVideo, now: () => NOW },
+  );
+  assert.equal(parsed.finishedAt, null, "unknown, never guessed");
+  assert.equal(parsed.startedAt, null);
+});
+
+test("#1199 parse: a garbage or future timestamp is rejected rather than trusted", () => {
+  // A relative counter (not an epoch) and a stamp far ahead of our clock both
+  // yield null: a future finish time would compute to a NEGATIVE age and present
+  // an ancient render as one that just landed.
+  const counter = parseHistoryEntry(
+    entryWithTimes(videoOutput("a.mp4"), { finishedAt: 1500 }),
+    { isVideo, now: () => NOW },
+  );
+  assert.equal(counter.finishedAt, null, "a small relative counter is not an epoch");
+
+  const future = parseHistoryEntry(
+    entryWithTimes(videoOutput("a.mp4"), { finishedAt: NOW + 10 * DAY }),
+    { isVideo, now: () => NOW },
+  );
+  assert.equal(future.finishedAt, null, "a stamp far in the future is clock skew, not a finish");
+});
+
+test("#1199 parse: a malformed duplicate message does not shadow the well-formed one", () => {
+  const finishedAt = NOW - 3 * HOUR;
+  const parsed = parseHistoryEntry(
+    {
+      outputs: videoOutput("a.mp4"),
+      status: {
+        status_str: "success",
+        completed: true,
+        messages: [
+          ["execution_success", null],
+          ["execution_success", { timestamp: "not-a-number" }],
+          ["execution_success", { prompt_id: "p", timestamp: finishedAt }],
+        ],
+      },
+    },
+    { isVideo, now: () => NOW },
+  );
+  assert.equal(parsed.finishedAt, finishedAt);
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 2. The tracker's reconciled flush carries the real time, not the delivery time
+// ─────────────────────────────────────────────────────────────────────────────
+
+test("#1199 tracker: a two-day-old reconciled completion reports when it RENDERED", async () => {
+  const h = makeHarness();
+  const finishedAt = NOW - 2 * DAY;
+  const startedAt = finishedAt - 134_000;
+
+  // The prompt was queued and started two days ago, then the terminal event was
+  // missed — the id sat in the pending ledger ever since.
+  h.setClock(startedAt);
+  h.tracker.onExecutionStart("d24e79b9");
+  h.setClock(NOW); // …tab wakes two days later, reconcile sweeps
+
+  const history = {
+    d24e79b9: entryWithTimes(videoOutput("MiniMax_H3_00184_.mp4"), { startedAt, finishedAt }),
+  };
+  await h.tracker.reconcile({ fetchHistory: async (id) => history[id] ?? null, isVideo });
+
+  assert.equal(h.flushes.length, 1, "the completion is still delivered — replay is by design");
+  const f = h.flushes[0];
+  assert.equal(f.reconciled, true);
+  assert.equal(
+    f.finishedAt,
+    finishedAt,
+    "finishedAt is the run's execution_success time, NOT the moment of delivery",
+  );
+  assert.notEqual(f.finishedAt, NOW, "the delivery clock must not masquerade as the finish time");
+  assert.equal(
+    f.durationMs,
+    134_000,
+    "duration is the render span from history, not the two-day reconcile gap",
+  );
+});
+
+test("#1199 tracker: with no history timestamps the finish time is null, not the delivery clock", async () => {
+  const h = makeHarness();
+  h.setClock(NOW - 2 * DAY);
+  h.tracker.onExecutionStart("p-nots");
+  h.setClock(NOW);
+
+  const history = {
+    "p-nots": {
+      outputs: videoOutput("a.mp4"),
+      status: { status_str: "success", completed: true, messages: [] },
+    },
+  };
+  await h.tracker.reconcile({ fetchHistory: async (id) => history[id] ?? null, isVideo });
+
+  assert.equal(h.flushes.length, 1);
+  assert.equal(h.flushes[0].finishedAt, null, "unknown is reported as unknown");
+  assert.equal(
+    h.flushes[0].durationMs,
+    null,
+    "and the duration is NOT the reconcile gap — a made-up duration is not evidence (#986)",
+  );
+});
+
+test("#1199 tracker: the LIVE completion path is unchanged — it still stamps its own clock", () => {
+  const h = makeHarness();
+  h.tracker.onExecutionStart("live-1");
+  h.tracker.onExecuted("live-1", { images: [{ filename: "final.png", type: "output" }] });
+  h.advance(20_000);
+  h.tracker.onExecutionSuccess("live-1");
+
+  assert.equal(h.flushes.length, 1);
+  assert.equal(h.flushes[0].reconciled, undefined, "a live completion is not a recovery");
+  assert.equal(h.flushes[0].finishedAt, NOW + 20_000, "live runs still stamp the observed finish");
+  assert.equal(h.flushes[0].durationMs, 20_000);
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 3. Presentation — the agent is TOLD this is a recovery
+// ─────────────────────────────────────────────────────────────────────────────
+
+function makeFrameDeps(overrides = {}) {
+  const frames = [];
+  const deps = {
+    sendFrame: (f) => frames.push(f),
+    coerceMessageText: (v) => (v == null ? "" : typeof v === "string" ? v : String(v)),
+    formatDuration: (ms) => (ms == null ? null : `${Math.round(ms / 1000)}s`),
+    // The REAL formatClock is time-of-day only; this stub returns a fixed string
+    // so a test can prove which clock the composer read.
+    formatClock: () => "DELIVERY-CLOCK",
+    imageViewUrl: (m) => `view://${m?.filename ?? "x"}`,
+    fetchImageBytes: async () => 2048,
+    fetchImageDimensions: async () => ({ w: 512, h: 512 }),
+    humanizeBytes: (n) => (n == null ? null : `${n} B`),
+    buildVideoStoryboard: async () => null, // note-only fallback: the reported shape
+    uploadBlobToInput: async () => null,
+    storyboardFrameCount: () => 20,
+    paintImage: () => {},
+    videoStoryboardEnabled: true,
+    now: () => new Date(NOW),
+    warn: () => {},
+    ...overrides,
+  };
+  return { deps, frames };
+}
+
+test("#1199 presentation: a recovered video completion leads with the recovery and its real age", async () => {
+  const { deps, frames } = makeFrameDeps();
+  const finishedAt = NOW - 2 * DAY;
+  const frame = await composeRunCompletionFrame(
+    {
+      promptId: "d24e79b9",
+      images: [],
+      videos: [{ m: { filename: "MiniMax_H3_00184_.mp4", type: "output" }, nodeId: "10" }],
+      durationMs: 134_000,
+      finishedAt,
+      reconciled: true,
+    },
+    deps,
+  );
+
+  assert.equal(frames.length, 1, "still exactly one completion frame");
+  // The banner comes FIRST — it reframes the "tell the user it's ready" text below.
+  assert.match(frame.note, /^⏳ RECOVERED FROM HISTORY/, "the recovery leads the note");
+  assert.match(frame.note, /did NOT just finish/i);
+  assert.match(frame.note, /2 days ago/, "the real age is stated");
+  assert.match(
+    frame.note,
+    /moved, renamed, or overwritten/i,
+    "the agent is warned the named file may no longer exist",
+  );
+  // Machine-readable twin, at the TOP level: a video-only run has no per-output
+  // metadata entries, and video-only is the shape #1199 was reported from.
+  assert.equal(frame.reconciled, true);
+  assert.equal(frame.finishedAt, new Date(finishedAt).toISOString());
+  assert.equal(frame.recoveredAgeMs, 2 * DAY);
+  // The bullet must NOT read as a bare time-of-day from this morning.
+  assert.doesNotMatch(frame.note, /DELIVERY-CLOCK/, "the composer must not stamp its own clock");
+});
+
+test("#1199 presentation: a LIVE completion is untouched — no banner, no recovery fields", async () => {
+  const { deps, frames } = makeFrameDeps();
+  const frame = await composeRunCompletionFrame(
+    {
+      promptId: "live-1",
+      images: [],
+      videos: [{ m: { filename: "fresh.mp4", type: "output" }, nodeId: "10" }],
+      durationMs: 5000,
+    },
+    deps,
+  );
+  assert.equal(frames.length, 1);
+  assert.doesNotMatch(frame.note, /RECOVERED FROM HISTORY/);
+  assert.equal(frame.reconciled, undefined, "no recovery marker on a fresh render");
+  assert.match(frame.note, /DELIVERY-CLOCK/, "a live run still reports the composed clock");
+});
+
+test("#1199 presentation: an unknown finish time says so rather than implying 'just now'", async () => {
+  const { deps, frames } = makeFrameDeps();
+  const frame = await composeRunCompletionFrame(
+    {
+      promptId: "p-nots",
+      images: [],
+      videos: [{ m: { filename: "a.mp4", type: "output" }, nodeId: "10" }],
+      durationMs: null,
+      finishedAt: null,
+      reconciled: true,
+    },
+    deps,
+  );
+  assert.equal(frames.length, 1);
+  assert.match(frame.note, /RECOVERED FROM HISTORY/);
+  assert.match(frame.note, /age as unknown/i, "an unknown age is stated, never computed as zero");
+  assert.doesNotMatch(frame.note, /under a minute ago/, "unknown must not read as brand new");
+  assert.equal(frame.recoveredAgeMs, null);
+});
+
+test("#1199 presentation: a recovered MEDIA-LESS run still reports the no-media completion", async () => {
+  // Regression guard: the recovery banner is framing, not content. If it counted
+  // as "something to say", it would swallow the #356 no-media report — and the
+  // reconcile path sets `noMedia` and `reconciled` on the SAME payload, so this
+  // combination is reachable in production, not hypothetical.
+  const { deps, frames } = makeFrameDeps();
+  const frame = await composeRunCompletionFrame(
+    {
+      promptId: "p-empty",
+      images: [],
+      videos: [],
+      durationMs: null,
+      noMedia: true,
+      finishedAt: NOW - 3 * HOUR,
+      reconciled: true,
+    },
+    deps,
+  );
+  assert.equal(frames.length, 1, "the media-less completion is still delivered");
+  assert.match(frame.note, /RECOVERED FROM HISTORY/, "and it is still marked as a recovery");
+  assert.match(frame.note, /3 hours ago/);
+  assert.match(
+    frame.note,
+    /produced no image or video output/,
+    "the #356 no-media report survives the banner",
+  );
+  assert.equal(frame.metadata[0].reason, "no_media");
+  assert.equal(frame.metadata[0].reconciled, true);
+});
+
+test("#1199 presentation: ages read at the right magnitude", async () => {
+  const cases = [
+    [30_000, /under a minute ago/],
+    [5 * MINUTE, /5 minutes ago/],
+    [1 * HOUR, /1 hour ago/],
+    [26 * HOUR, /1 day ago/],
+    [7 * DAY, /7 days ago/],
+  ];
+  for (const [ageMs, expected] of cases) {
+    const { deps } = makeFrameDeps();
+    const frame = await composeRunCompletionFrame(
+      {
+        promptId: `p-${ageMs}`,
+        images: [],
+        videos: [{ m: { filename: "a.mp4", type: "output" }, nodeId: "10" }],
+        durationMs: null,
+        finishedAt: NOW - ageMs,
+        reconciled: true,
+      },
+      deps,
+    );
+    assert.match(frame.note, expected, `age ${ageMs}ms should read as ${expected}`);
+  }
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 4. Wiring — the seam that made the reported fix inert
+// ─────────────────────────────────────────────────────────────────────────────
+
+test("#1199 wiring: the panel call site forwards finishedAt AND reconciled to the composer", () => {
+  // The tracker has ALWAYS passed a finishedAt; this closure dropped it, so the
+  // composer stamped its own clock. Every behavioural test above hands the
+  // composer a payload by hand and therefore cannot see the real call site
+  // omitting the field — the same source-inspection pattern #609 uses.
+  const src = readFileSync(
+    fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url)),
+    "utf8",
+  ).replace(/\r\n/g, "\n");
+
+  const flushStart = src.indexOf("onFlush: ({");
+  assert.notEqual(flushStart, -1, "could not locate the tracker's onFlush handler");
+  const composeStart = src.indexOf("composeRunCompletionFrame(", flushStart);
+  assert.notEqual(composeStart, -1, "could not locate the composeRunCompletionFrame call site");
+  const composeEnd = src.indexOf(".then((frame)", composeStart);
+  assert.notEqual(composeEnd, -1, "could not locate the end of the call site");
+
+  // The handler must DESTRUCTURE both fields off the flush payload…
+  const handlerSignature = src.slice(flushStart, composeStart);
+  assert.match(handlerSignature, /\bfinishedAt\b/, "onFlush must destructure finishedAt");
+  assert.match(handlerSignature, /\breconciled\b/, "onFlush must destructure reconciled");
+
+  // …and PASS both into the composer's payload. Destructuring without forwarding
+  // is the exact half-fix that leaves the defect intact.
+  const payload = src.slice(composeStart, composeEnd);
+  assert.match(payload, /\bfinishedAt\b/, "the composer payload must carry finishedAt");
+  assert.match(payload, /\breconciled\b/, "the composer payload must carry reconciled");
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -29048,7 +29048,23 @@ function buildPanel() {
     // or a fast re-render it is cannot be proven, and losing a render the user waited
     // for would be worse than an extra message. The console line makes the annotation
     // visible without the agent having to infer it.
-    onFlush: ({ promptId, images: flImages, videos: flVideos, durationMs, noMedia, duplicateOf, looksCached }) => {
+    // #1199 — `finishedAt` and `reconciled` MUST be destructured here. The tracker
+    // has always passed a finish time, and this closure has always dropped it on the
+    // floor, so the composer stamped its own clock — which is why a completion
+    // recovered from /history days later announced itself as having finished in the
+    // second it was delivered. Fixing the tracker alone changes nothing observable;
+    // the value has to be forwarded to reach the agent.
+    onFlush: ({
+      promptId,
+      images: flImages,
+      videos: flVideos,
+      durationMs,
+      noMedia,
+      duplicateOf,
+      looksCached,
+      finishedAt,
+      reconciled,
+    }) => {
       // #370: track whether the composed completion frame actually reached the
       // agent. sendFrame returns false when the bridge socket is down — in that
       // case the completion is LOST, so we re-pend the prompt (markUndelivered) so
@@ -29068,7 +29084,17 @@ function buildPanel() {
         // no image or video. Without it the composer returns null, the call site
         // below reads that as "empty batch ⇒ already delivered", and the agent that
         // panel_run told to end its turn and wait is never told anything.
-        { promptId, images: flImages, videos: flVideos, durationMs, noMedia, duplicateOf, looksCached },
+        {
+          promptId,
+          images: flImages,
+          videos: flVideos,
+          durationMs,
+          noMedia,
+          duplicateOf,
+          looksCached,
+          finishedAt,
+          reconciled,
+        },
         {
           sendFrame: (frame) => {
             const ok = client.sendFrame(frame);

--- a/web/js/lib/history-reconcile.js
+++ b/web/js/lib/history-reconcile.js
@@ -20,11 +20,16 @@
  * @param {object}   [opts]
  * @param {(m:object)=>boolean} [opts.isVideo]  Classifies an output ref as video
  *   (else still image), matching the live path's classification.
+ * @param {() => number} [opts.now]  Clock (epoch ms) used ONLY to reject a
+ *   timestamp implausibly far in the future. Injectable for tests.
  * @returns {null | { terminal:boolean, status:("success"|"error"|"interrupted"|"unknown"),
- *   images:object[], videos:{m:object,nodeId:string}[] }}
- *   `null` when there's no usable entry.
+ *   images:object[], videos:{m:object,nodeId:string}[],
+ *   startedAt:(number|null), finishedAt:(number|null) }}
+ *   `null` when there's no usable entry. `startedAt`/`finishedAt` are epoch ms
+ *   recovered from the entry's own lifecycle messages, or null when this entry
+ *   records no trustworthy value (see historyMessageTimeMs).
  */
-export function parseHistoryEntry(entry, { isVideo } = {}) {
+export function parseHistoryEntry(entry, { isVideo, now = () => Date.now() } = {}) {
   if (!entry || typeof entry !== "object") return null;
 
   const status = entry.status && typeof entry.status === "object" ? entry.status : {};
@@ -68,12 +73,67 @@ export function parseHistoryEntry(entry, { isVideo } = {}) {
     }
   }
 
+  // #1199 — the run's OWN times, so a completion recovered from history can report
+  // when it actually rendered instead of when the recovery happened. Read here
+  // because this is the only place the raw entry is in scope.
+  const nowMs = typeof now === "function" ? now() : Date.now();
+  const startedAt = historyMessageTimeMs(messages, "execution_start", nowMs);
+  const finishedAt = historyMessageTimeMs(messages, "execution_success", nowMs);
+
   return {
     terminal,
     status: isError ? "error" : isInterrupted ? "interrupted" : isSuccess ? "success" : "unknown",
     images,
     videos,
+    startedAt,
+    finishedAt,
   };
+}
+
+// A timestamp more than this far AHEAD of our clock is not a finish time we can
+// trust — it is clock skew between ComfyUI's host and ours, or a counter that
+// isn't an epoch at all. Rejected rather than used: a "finished" stamp in the
+// future computes to a NEGATIVE age, which would present a days-old render as
+// one that just landed — precisely the #1199 defect this extraction prevents.
+const FUTURE_SKEW_TOLERANCE_MS = 60_000;
+
+/**
+ * Read a lifecycle message's `timestamp` from `status.messages` as epoch ms.
+ *
+ * ComfyUI records each execution message as `[name, data]` where `data.timestamp`
+ * is the moment it fired. Which UNIT depends on the ComfyUI version — some builds
+ * write epoch seconds, others milliseconds — so the magnitude decides, mirroring
+ * `normalizeEpochMs` in comfyui-mcp (`src/services/job-history.ts`) so both repos
+ * mean the same thing by "the run's real completion time".
+ *
+ * Scans rather than taking the first match positionally: a malformed duplicate
+ * message must not shadow a well-formed one later in the list.
+ *
+ * @param {any[]} messages  `entry.status.messages` (already array-guarded).
+ * @param {string} name     Lifecycle message name, e.g. "execution_success".
+ * @param {number} nowMs    Our clock, for the future-skew rejection.
+ * @returns {number|null}   Epoch ms, or null when no trustworthy value exists.
+ */
+function historyMessageTimeMs(messages, name, nowMs) {
+  for (const message of messages) {
+    if (!Array.isArray(message) || message[0] !== name) continue;
+    const data = message[1];
+    if (data === null || typeof data !== "object" || Array.isArray(data)) continue;
+    const ms = normalizeEpochMs(data.timestamp);
+    if (ms === null) continue;
+    if (Number.isFinite(nowMs) && ms > nowMs + FUTURE_SKEW_TOLERANCE_MS) continue;
+    return ms;
+  }
+  return null;
+}
+
+// Epoch SECONDS or MILLISECONDS by magnitude. Anything below the seconds
+// threshold (a relative counter, 0, a duration) is not an epoch at all ⇒ null.
+function normalizeEpochMs(ts) {
+  if (typeof ts !== "number" || !Number.isFinite(ts)) return null;
+  if (ts > 1_000_000_000_000) return ts; // already epoch ms
+  if (ts > 1_000_000_000) return ts * 1000; // epoch seconds
+  return null;
 }
 
 /**

--- a/web/js/lib/run-completion-frame.js
+++ b/web/js/lib/run-completion-frame.js
@@ -30,12 +30,25 @@ import { withTimeout } from "./bounded-step.js";
  * prompt. Resolves to the frame that was sent (for tests), or null when the
  * batch was empty (no frame emitted).
  *
- * @param {{promptId:(string|null), images?:any[], videos?:any[], durationMs:(number|null)}} payload
+ * @param {{promptId:(string|null), images?:any[], videos?:any[], durationMs:(number|null),
+ *   finishedAt?:(number|null), reconciled?:boolean}} payload
+ *   `finishedAt` is epoch ms of the run's REAL finish; `reconciled` marks a
+ *   completion recovered from /history rather than observed live (#1199).
  * @param {object} deps  Injected presentation helpers (see call site).
  * @returns {Promise<object|null>}
  */
 export async function composeRunCompletionFrame(
-  { promptId, images = [], videos = [], durationMs, noMedia = false, duplicateOf = null, looksCached = false },
+  {
+    promptId,
+    images = [],
+    videos = [],
+    durationMs,
+    noMedia = false,
+    duplicateOf = null,
+    looksCached = false,
+    finishedAt: finishedAtMs = null,
+    reconciled = false,
+  },
   deps,
 ) {
   const {
@@ -76,16 +89,58 @@ export async function composeRunCompletionFrame(
 
   // One clock read for the whole run so stills and videos report the SAME
   // finished time (they're one completion).
-  const finishedAt = now();
-  const finishedClock = formatClock(finishedAt);
+  const composedAt = now();
+  // #1199 — report when the run REALLY finished whenever the tracker knows it.
+  // A reconciled completion is delivered minutes-to-DAYS after it rendered, so
+  // stamping the compose clock presented seven two-day-old videos as "finished
+  // 7:45:29 AM" — the same second, all of them. Only a plausible epoch is
+  // honoured (the tracker's live paths pass Date.now(); a relative test counter
+  // is not a wall clock), otherwise the compose clock still stands.
+  const realFinishedAt = epochToDate(finishedAtMs);
+  const finishedAt = realFinishedAt ?? composedAt;
+  // A bare time-of-day is half of why the #1199 burst read as fresh: every
+  // metaSuffix line ends "finished 7:45:29 AM", which for a render from two days
+  // earlier looks like this morning. When the completion is a RECOVERY, the
+  // bullets carry the full local date and time so the file's real age is legible
+  // on the line that names the file.
+  const finishedClock =
+    reconciled && realFinishedAt ? formatStamp(realFinishedAt) : formatClock(finishedAt);
   const duration = durationMs != null ? formatDuration(durationMs) : null;
+  // Age of the completion at the moment we present it. Known ONLY when the real
+  // finish time is — with an unknown finish time the age is unknown too, and is
+  // said to be rather than computed as zero (which would read as "just now", the
+  // very claim this fix exists to stop making).
+  const recoveredAgeMs = realFinishedAt ? msBetween(realFinishedAt, composedAt) : null;
+  // Machine-readable twin of the banner below, so a consumer can key the wording
+  // on a FIELD instead of matching prose (#1199 asked for the flag to reach the
+  // agent notification). The note states the same facts, because the note is the
+  // part guaranteed to reach the agent whatever the orchestrator does with
+  // metadata — the flag is the durable seam, the prose is the delivery.
+  const recoveryMetadata = () =>
+    reconciled
+      ? {
+          reconciled: true,
+          finishedAt: realFinishedAt ? realFinishedAt.toISOString() : null,
+          recoveredAgeMs,
+        }
+      : {};
 
   const outImages = []; // consolidated images for the single frame
   const noteSections = []; // note segments joined into the single note
-  // #986 — FIRST section, because it changes how everything after it should be read:
-  // this exact output has already been delivered under another prompt id. It is never
-  // a reason to withhold the completion (see completion-dedupe.js), only to say so.
+  // #1199 — FIRST section, ahead of even the duplicate notice, because it reframes
+  // the entire completion: this run did NOT just finish. Everything below (including
+  // "tell the user it's ready") has to be read as a late recovery, or the agent
+  // announces files that may have been moved, renamed or overwritten days ago.
+  if (reconciled) noteSections.push(recoveredCompletionNote(realFinishedAt, recoveredAgeMs));
+  // #986 — this exact output has already been delivered under another prompt id. It is
+  // never a reason to withhold the completion (see completion-dedupe.js), only to say so.
   if (duplicateOf) noteSections.push(duplicateCompletionNote(duplicateOf, looksCached));
+  // Sections pushed ABOVE are framing, not content: they say how to read a
+  // completion, never that one happened. The media-less check below must measure
+  // only what the segments contribute, or a banner alone would count as "something
+  // to say" and swallow the #356 no-media report — reachable for real, since the
+  // reconcile path sets `noMedia` and `reconciled` on the SAME payload.
+  const leadingSectionCount = noteSections.length;
   let metadata = [];
 
   // ── Stills segment ─────────────────────────────────────────────────────
@@ -163,20 +218,24 @@ export async function composeRunCompletionFrame(
   // arriving any other way still returns null, so the call site's existing
   // "empty batch ⇒ treat as delivered" contract is unchanged for every path that
   // relied on it.
-  if (!outImages.length && !noteSections.length) {
+  if (!outImages.length && noteSections.length <= leadingSectionCount) {
     if (!noMedia) return null;
     const took = durationMs != null ? ` in ${formatDuration(durationMs)}` : "";
     const frame = {
       type: "agent_event",
       kind: "executed",
       images: [],
-      note:
+      // Keep the framing banners (recovery / duplicate) ahead of the report —
+      // a recovered media-less run is still a recovered run.
+      note: [
+        ...noteSections,
         `The run you queued finished successfully${took}, and produced no image or ` +
-        "video output. This IS the completion you were told to wait for — nothing " +
-        "further is coming, so do not keep waiting for media. If this workflow was " +
-        "meant to save a file, no output node produced one; if its results are text " +
-        "or other non-media outputs, read them from the run's history entry.",
-      metadata: [{ outputs: "none", reason: "no_media" }],
+          "video output. This IS the completion you were told to wait for — nothing " +
+          "further is coming, so do not keep waiting for media. If this workflow was " +
+          "meant to save a file, no output node produced one; if its results are text " +
+          "or other non-media outputs, read them from the run's history entry.",
+      ].join("\n\n"),
+      metadata: [{ outputs: "none", reason: "no_media", ...recoveryMetadata() }],
       ...(promptId != null ? { prompt_id: promptId } : {}),
     };
     sendFrame(frame);
@@ -192,9 +251,95 @@ export async function composeRunCompletionFrame(
     // Machine-readable attribution: which prompt this completion belongs to, so
     // a delayed prior-run flush can never be mistaken for the current run (#224).
     ...(promptId != null ? { prompt_id: promptId } : {}),
+    // #1199 — top level, not only inside `metadata`: a video-only run produces NO
+    // per-output metadata entries (those are built from stills), and that is
+    // exactly the shape the reported burst arrived in. A marker that vanishes on
+    // the one path the bug was reported from is not a marker.
+    ...recoveryMetadata(),
   };
   sendFrame(frame);
   return frame;
+}
+
+// An epoch below this is not a wall clock — it is a relative counter (a test
+// harness clock, a duration, 0). Sep 2001; every real Date.now() clears it.
+const MIN_PLAUSIBLE_EPOCH_MS = 1_000_000_000_000;
+
+/** Epoch ms → Date, or null when the value isn't a plausible wall clock (#1199). */
+function epochToDate(ms) {
+  if (typeof ms !== "number" || !Number.isFinite(ms) || ms < MIN_PLAUSIBLE_EPOCH_MS) return null;
+  const date = new Date(ms);
+  return Number.isFinite(date.getTime()) ? date : null;
+}
+
+/** Non-negative ms between two Dates, or null if either can't be read. */
+function msBetween(from, to) {
+  const a = from?.getTime?.();
+  const b = to?.getTime?.();
+  if (!Number.isFinite(a) || !Number.isFinite(b)) return null;
+  return Math.max(0, b - a);
+}
+
+/**
+ * Coarse age of a recovered completion, e.g. "2 days", "6 hours", "under a minute".
+ * Deliberately coarse: the point is the ORDER OF MAGNITUDE (is this minutes old or
+ * days old), and false precision on a recovered run would invite the agent to
+ * reason about a delay it cannot actually resolve that finely.
+ */
+function humanizeAge(ms) {
+  if (!Number.isFinite(ms) || ms < 0) return null;
+  const minutes = Math.floor(ms / 60_000);
+  if (minutes < 1) return "under a minute";
+  if (minutes < 60) return `${minutes} minute${minutes === 1 ? "" : "s"}`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours} hour${hours === 1 ? "" : "s"}`;
+  const days = Math.floor(hours / 24);
+  return `${days} day${days === 1 ? "" : "s"}`;
+}
+
+/** Absolute local date AND time — a bare time-of-day is what let a two-day-old
+ *  render read as "this morning" (#1199). */
+function formatStamp(date) {
+  try {
+    return date.toLocaleString();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * The leading note for a completion recovered from /history rather than observed
+ * live (#1199).
+ *
+ * The panel's "never lose a completion" reconcile is by design: a run whose
+ * terminal event was missed (tab asleep, bridge down, WS dropped) is replayed
+ * from ComfyUI's `/history` on the next reconcile edge. What was NOT by design is
+ * that the replay was indistinguishable from a fresh render — so a sweep that
+ * found seven prompts still pending from two nights earlier woke the agent seven
+ * times, each announcing a video "ready" whose file the user had long since moved
+ * out of the output directory.
+ *
+ * The note therefore leads with the recovery, states the real age, and explicitly
+ * withdraws the freshness claim the rest of the completion text still makes.
+ */
+function recoveredCompletionNote(realFinishedAt, ageMs) {
+  const age = humanizeAge(ageMs);
+  const stamp = realFinishedAt ? formatStamp(realFinishedAt) : null;
+  const when =
+    age && stamp
+      ? `It finished about ${age} ago (${stamp})`
+      : stamp
+        ? `It finished at ${stamp}`
+        : `The panel could not recover when it finished, so treat its age as unknown — possibly days`;
+  return (
+    `⏳ RECOVERED FROM HISTORY — this run did NOT just finish. ${when}, and the ` +
+    `completion is only reaching you now because the panel could not deliver it at ` +
+    `the time (tab asleep, bridge down, or the connection dropped). Do not announce ` +
+    `it as a fresh render: the output below may since have been moved, renamed, or ` +
+    `overwritten, and a file that no longer exists will still be named here. Say ` +
+    `plainly that this is a late completion for an earlier run, and confirm the file ` +
+    `is still there before telling the user it is ready.`
+  );
 }
 
 /**

--- a/web/js/lib/run-completion.js
+++ b/web/js/lib/run-completion.js
@@ -52,7 +52,11 @@ export const NO_PROMPT_KEY = "__no_prompt__";
 
 /**
  * @param {object} opts
- * @param {(payload:{key:string, promptId:(string|null), images:any[], videos:any[], durationMs:number|null, finishedAt:number}) => void} opts.onFlush
+ * @param {(payload:{key:string, promptId:(string|null), images:any[], videos:any[], durationMs:number|null, finishedAt:(number|null), reconciled?:boolean}) => void} opts.onFlush
+ *   `finishedAt` is epoch ms. On the LIVE paths it is the flush clock; on the
+ *   RECONCILED path (`reconciled:true`) it is the run's real execution_success
+ *   time recovered from /history, or **null** when that entry records none —
+ *   never the delivery time, which would present a stale replay as fresh (#1199).
  *   Called exactly once per completed prompt that buffered ≥1 image or video,
  *   with the FULL batch for that prompt_id, the correct start→finish duration,
  *   and the prompt_id (`key`/`promptId`) so the delivery can be attributed.
@@ -483,7 +487,9 @@ export function createRunCompletionTracker({
     if (delivered.has(k) || !pending.has(k)) return null;
 
     // parseHistoryEntry returns null for null/undefined/non-object entries.
-    const parsed = fetchThrew ? null : parseHistoryEntry(entry, { isVideo });
+    // `now` is threaded through so the future-skew rejection on the entry's own
+    // timestamps is measured against the SAME clock the tracker uses (#1199).
+    const parsed = fetchThrew ? null : parseHistoryEntry(entry, { isVideo, now });
 
     // ── NON-terminal outcomes (never deliver here; decide retry vs give-up) ──
     if (!parsed || !parsed.terminal) {
@@ -569,7 +575,28 @@ export function createRunCompletionTracker({
     // promise, so only that one is worth waking the agent for when it finished empty.
     const mediaLessQueued = !hasBatch && wasPanelQueued;
     if (hasBatch || mediaLessQueued) {
-      const durationMs = startTs != null ? now() - startTs : null;
+      // #1199 — a completion recovered from /history must report when the run
+      // REALLY finished, not when the recovery happened. `now()` here is the
+      // DELIVERY time: a reconcile edge (tab wake / reconnect) that swept seven
+      // days-old prompts stamped every one of them with the same second, so the
+      // agent announced long-since-moved files as "finished 7:45:29 AM". The
+      // entry's own execution_success message carries the truthful moment; null
+      // when this ComfyUI build records none, which the composer states as an
+      // unknown rather than papering over with its own clock.
+      const historyFinishedAt = parsed.finishedAt ?? null;
+      // Duration is derived ONLY from two truthful wall-clock endpoints. The old
+      // `now() - startTs` measured the RECONCILE GAP, not the render — for the
+      // #1199 burst it reads "rendered in 2 days". Prefer the entry's own
+      // start→success span; fall back to the start we OBSERVED only when a real
+      // finish time bounds it. With neither, the duration is genuinely unknown
+      // and is reported as unknown rather than invented (the #986 discipline:
+      // a duration the tracker made up is not evidence of anything).
+      const span = (from, to) =>
+        from != null && to != null && Number.isFinite(from) && Number.isFinite(to) && to >= from
+          ? to - from
+          : null;
+      const durationMs =
+        span(parsed.startedAt ?? null, historyFinishedAt) ?? span(startTs, historyFinishedAt);
       // Same async-delivery hold as flush(): the reconciled batch is composed and
       // sent by the caller, so it is not "delivered" until the caller says so.
       markDispatched(k);
@@ -586,7 +613,8 @@ export function createRunCompletionTracker({
         images: parsed.images,
         videos: parsed.videos,
         durationMs,
-        finishedAt: now(),
+        // Epoch ms of the REAL finish, or null when history records none (#1199).
+        finishedAt: historyFinishedAt,
         reconciled: true,
         ...(mediaLessQueued ? { noMedia: true } : {}),
       });


### PR DESCRIPTION
Fixes #1199.

## What was wrong

A reconcile edge (tab wake / reconnect) swept seven prompt ids that had been sitting in the pending ledger since two nights earlier. The long-running ComfyUI still had all seven in `/history`, so all seven were replayed in one burst — each stamped `finishedAt: now()`, the **delivery** time. Every one announced *"finished 7:45:29 AM"* (the same second), and the agent told the user seven videos were ready whose files had been moved out of `output/` days before.

The replay itself is by design ("never lose a completion"). What was wrong is that a replay was **indistinguishable from a fresh render**.

## The reported fix would have been inert

#1199 prescribes fixing `run-completion.js` ~589. That line is real, but fixing it alone changes nothing observable: the panel's `onFlush` closure never destructured `finishedAt`, and `composeRunCompletionFrame` stamped its own `now()` regardless. The tracker had *always* passed a finish time and the call site had *always* dropped it. Three seams had to move together:

1. **`web/js/lib/history-reconcile.js`** — `parseHistoryEntry` now reads the entry's own `execution_start` / `execution_success` timestamps. Epoch seconds vs milliseconds is decided by magnitude and a stamp far in the future is rejected as clock skew, mirroring `historyCompletionTimeMs` in comfyui-mcp (`src/services/job-history.ts`, #751) so both repos mean the same thing by "the run's real completion time".
2. **`web/js/lib/run-completion.js`** — the reconciled flush carries that time, or `null` when history records none. `durationMs` is derived from two truthful wall-clock endpoints or reported unknown; the old `now() - startTs` measured the **reconcile gap**, so the reported burst would have read "rendered in 2 days".
3. **`web/js/comfyui-mcp-panel.js` + `run-completion-frame.js`** — the call site forwards `finishedAt`/`reconciled`, and the composer leads with a `⏳ RECOVERED FROM HISTORY` banner stating the real age and warning the named file may since have been moved, renamed, or overwritten. Machine-readable `reconciled` / `finishedAt` / `recoveredAgeMs` ride at the **top level** of the frame (a video-only run — the reported shape — produces no per-output `metadata` entries, so a marker that lived only there would vanish on exactly the path this was reported from).

Bullet lines for a recovered run now carry the full local date, not a bare time-of-day: "finished 7:45:29 AM" for a two-day-old render is the symptom quoted in the issue.

**No orchestrator change is needed.** `panel-agent.ts:683` already relays a custom `note` verbatim into the agent text, and `CompletionPayload` is explicitly open (`[k: string]: unknown`, "the panel is free to add fields"), so the new fields cannot trip validation.

Live completion paths (`run-completion.js` 434 / 788) are untouched — verified by a test that pins the live stamp.

## Verification

`browser_tests/unit/run-reconcile-stale-age.test.mjs` — 14 tests. Full unit suite **4539 pass / 0 fail**; `check-panel-scope` OK (it catches the ReferenceError class the panel edit could introduce); `tsc --noEmit` clean.

Green tests prove nothing on their own, so **every seam was mutation-verified** — each mutation applied to the committed fix, suite re-run, then restored:

| Mutation | Result |
|---|---|
| M1 parse never extracts the finish time | RED (4) |
| M2 tracker stamps the delivery clock again | RED (2) |
| M3 duration = reconcile gap again | RED (2) |
| M4 composer ignores the supplied finish time | RED (3) |
| M5 composer drops the recovery banner | RED (4) |
| M6 banner masks the no-media report | RED (1) |
| M7 call site stops forwarding the fields | RED (1) |
| M8 top-level machine-readable marker dropped | RED (2) |
| M9 bare time-of-day for a recovered run | RED (1) |

All 9 caught. M7 is the one that matters most: it is the wiring change a helper-level test cannot see, so it is pinned by source inspection (the pattern #609 uses).

M6 guards a regression this fix could have introduced: the recovery banner is *framing*, not content, and if it counted as "something to say" it would have swallowed the #356 no-media report — reachable in production, since the reconcile path sets `noMedia` and `reconciled` on the same payload.

## Browser verification — NOT run

The Playwright suite requires a live ComfyUI at `localhost:8188`; nothing was listening on 8188 or 8000, and this run was allocated no ComfyUI and is not permitted to start one. **I have no browser coverage for this change and am not implying any.** What I could run: `npm run test:e2e:list` compiles all 70 specs across 29 files (exit 0), so nothing here breaks spec compilation. No existing e2e spec touches the completion-note path. The change is agent-facing — it alters the `note`/fields on an outbound `agent_event`, not panel-rendered DOM (`paintImage` is untouched).

## Deliberately not done

- **No age cap on the pending ledger** (issue's third point). Dropping pending ids on age would delete exactly the completions the "never lose a completion" design exists to preserve, and would do it silently. Every entry in a burst now states its true age instead, which fixes the *misrepresentation* without introducing a silent-loss path. An eviction policy is a product decision, not a P2 bug fix under the freeze.
- **No stale-batch burst summary.** The composer is per-prompt by construction; coalescing across prompts needs cross-frame state. Seven individually-honest completions are no longer misleading, only numerous.

## Gate disclosure

codex was unavailable (account exhausted until 2026-08-19); gated by an independent adversarial review instead, per the owner-authorised substitution.
