### PR TITLE
fix(1168): a wedged orchestrator's death is recorded where the panel concludes it

### DIFF
--- a/browser_tests/unit/session-rebind.test.mjs
+++ b/browser_tests/unit/session-rebind.test.mjs
@@ -608,7 +608,7 @@ test("#1138 wiring: the call site NEGATES the predicate and returns", () => {
   const src = readFileSync(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8");
   assert.ok(
     src.includes(
-      "if (!shouldNudgeAfterMidTaskReconnect({ outageMs: bridgeOutage.outageMs() })) return;",
+      "if (!shouldNudgeAfterMidTaskReconnect({ outageMs: bridgeOutage.outageMs()",
     ),
     "the ready-ack mid-task branch must NEGATE the predicate and read the measured outage",
   );
@@ -638,13 +638,15 @@ test("#1138 wiring: the call site NEGATES the predicate and returns", () => {
   ]) {
     assert.ok(src.includes(snippet), site);
   }
-  // NOTE: two attempts to also pin the WEDGE-death paths were removed with the code
-  // they described. A wedged orchestrator holds its socket open and never fires a
-  // close, so nothing records that death — a real gap, tracked separately. It is not
-  // pinned here because the assertions that tried to were themselves wrong: the
-  // negative half scanned stop()/setUrl()/destroy() for a literal `bridgeOutage.`,
-  // while the design it claimed to reject put the stamp in a shared helper CALLED
-  // from those bodies — so it would have passed against the very regression it named.
+  // The WEDGE-death path is a FOURTH write site and is pinned separately, at the end of
+  // this file (#1168). It is not listed here because it is not a close: a wedged
+  // orchestrator holds its socket open and never fires one, so the event it records is
+  // the panel's own conclusion rather than a socket transition. Two earlier attempts to
+  // pin it here were removed with the code they described — the negative half scanned
+  // stop()/setUrl()/destroy() for a literal `bridgeOutage.`, while the design it claimed
+  // to reject put the stamp in a shared helper CALLED from those bodies, so it would
+  // have passed against the very regression it named. #1168's pin counts the call
+  // instead, which a wrapper cannot evade.
 });
 
 // ── #1145: the interval must be the OUTAGE, not one backoff step ─────────────
@@ -937,4 +939,197 @@ test("#1145: a second outage measures itself, not the gap since the first", () =
   tracker.noteHandshake();
   assert.equal(tracker.outageMs(), 1500, "the second outage is 1.5s, not 10 minutes");
   assert.equal(shouldNudgeAfterMidTaskReconnect({ outageMs: tracker.outageMs() }), false);
+});
+
+// ── #1168: a WEDGED orchestrator's death is recorded as a CONCLUSION ──────────
+//
+// The outage clock is started by the socket `close` listener, and a wedged orchestrator
+// never fires one: it holds the connection open and answers nothing. So the death that
+// killed the running turn goes unrecorded, and the clock only starts when that process
+// finally dies — measuring the user's restart instead of the wedge. The turn is never
+// resumed.
+//
+// Two earlier attempts recorded it as a DURATION, from the teardown side and from the
+// handshake redial, and both converted a missed nudge into a false one. What this pins
+// is the third shape: the panel records the CONCLUSION it actually reached ("nothing is
+// behind this socket"), the reader weighs it ahead of the clock, and a turn start still
+// stands it down — so an orchestrator that turns out to be alive is never nudged.
+
+test("#1168: a wedge that no close ever reported still resumes the turn", () => {
+  // The reported sequence, to scale. A turn is in flight; the orchestrator wedges with
+  // its socket OPEN, so nothing closes and nothing opens an outage. The panel spends its
+  // full redial ladder (~60s) establishing that nothing answers, then concludes. The user
+  // restarts the orchestrator out-of-band and it is back in three seconds.
+  const { clock, tracker } = trackerAt();
+  tracker.noteTurnStarted();
+  clock.t += 60_000; // the redial ladder — an open socket, no `models`, no close
+  tracker.noteAgentGone(); // the panel concludes the agent behind it is gone
+  clock.t += 120_000; // the user reads the hint and restarts it out-of-band
+  tracker.noteBridgeClosed(); // the wedged process finally dies as it is replaced
+  clock.t += 3000; // the fresh orchestrator binds the port…
+  tracker.noteHandshake(); // …and handshakes
+
+  // THE DEFECT, asserted rather than described: three minutes with no agent behind the
+  // socket are measured as the three-second RESTART, which the duration guard correctly
+  // reads as a blip. Weighing it alone is what loses the nudge, so this must stay true —
+  // it is the gap, not the thing being fixed.
+  assert.equal(tracker.outageMs(), 3000);
+  assert.equal(
+    shouldNudgeAfterMidTaskReconnect({ outageMs: tracker.outageMs() }),
+    false,
+    "the clock alone cannot see a wedge — this is the gap, and it must stay visible here",
+  );
+  // The fix: the conclusion the panel actually reached is the evidence.
+  assert.equal(tracker.agentGone(), true, "the handshake must not erase the conclusion");
+  assert.equal(
+    shouldNudgeAfterMidTaskReconnect({
+      outageMs: tracker.outageMs(),
+      agentGone: tracker.agentGone(),
+    }),
+    true,
+    "a turn a concluded death interrupted must be resumed",
+  );
+});
+
+test("#1168: the two evidence kinds DISAGREE, so the fix cannot be inert", () => {
+  // #1096's review proved by mutation that token-presence scans stay green under an
+  // inverted guard. This is the behavioural equivalent: for one and the same measured
+  // interval the answer must differ on the conclusion alone. If these ever agree, either
+  // the flag stopped being read or it stopped mattering, and the wedge is unfixed again.
+  const fast = 3000;
+  assert.notEqual(
+    shouldNudgeAfterMidTaskReconnect({ outageMs: fast, agentGone: true }),
+    shouldNudgeAfterMidTaskReconnect({ outageMs: fast, agentGone: false }),
+    "a concluded death must change the answer the clock alone would give",
+  );
+  assert.equal(shouldNudgeAfterMidTaskReconnect({ outageMs: fast, agentGone: true }), true);
+  assert.equal(shouldNudgeAfterMidTaskReconnect({ outageMs: fast, agentGone: false }), false);
+  // …and with NO outage at all, which is the wedge's own reading before any close.
+  assert.equal(shouldNudgeAfterMidTaskReconnect({ outageMs: 0, agentGone: true }), true);
+  assert.equal(shouldNudgeAfterMidTaskReconnect({ outageMs: 0 }), false);
+});
+
+test("#1168: an orchestrator that turns out to be ALIVE is never nudged", () => {
+  // The half that makes this shippable, and the one both previous attempts failed. The
+  // panel can conclude a death and be wrong — a very slow boot answers eventually. What
+  // makes that safe is the same guarantee #1163 rests on: a live turn re-announces, and
+  // that frame stands the conclusion down before the ready ack can act on it.
+  const { clock, tracker } = trackerAt();
+  tracker.noteTurnStarted();
+  clock.t += 60_000;
+  tracker.noteAgentGone(); // the panel gives up…
+  clock.t += 5000;
+  tracker.noteTurnStarted(); // …but the surviving turn re-announces on reconnect
+  assert.equal(tracker.agentGone(), false, "a live turn must retire the conclusion");
+  assert.equal(
+    shouldNudgeAfterMidTaskReconnect({
+      outageMs: tracker.outageMs(),
+      agentGone: tracker.agentGone(),
+    }),
+    false,
+    "an agent that is working must never be told to start over",
+  );
+});
+
+test("#1168: a death concluded before this turn is not this turn's evidence", () => {
+  // The turn-scoping rule #1145/#1163 established for the duration, applied to the flag —
+  // without it a wedge settled two turns ago would nudge every later reconnect. Safe by
+  // construction at the call site too: the panel arms its mid-task marker in the same
+  // frame that starts the turn, so an armed marker implies this event has already run.
+  const { clock, tracker } = trackerAt();
+  tracker.noteAgentGone(); // a wedge, concluded and long since recovered
+  clock.t += 600_000;
+  tracker.noteTurnStarted(); // a brand-new turn the user just typed
+  assert.equal(tracker.agentGone(), false);
+  assert.equal(
+    shouldNudgeAfterMidTaskReconnect({
+      outageMs: tracker.outageMs(),
+      agentGone: tracker.agentGone(),
+    }),
+    false,
+    "a settled wedge must not nudge a turn that started after it",
+  );
+});
+
+test("#1168: nothing but an explicit conclusion sets the flag", () => {
+  // The agent-not-ready-YET case, which attempt 2 stamped and must not: a fresh mount,
+  // a close, a redial's reopen and a late handshake are all ordinary events, and none of
+  // them is a death. A tracker that reported one here would nudge every slow first
+  // connect that happened to follow a turn.
+  const { clock, tracker } = trackerAt();
+  assert.equal(tracker.agentGone(), false, "a fresh tracker has concluded nothing");
+  tracker.noteTurnStarted();
+  tracker.noteBridgeClosed();
+  clock.t += 45_000; // a genuinely slow cold start
+  tracker.noteHandshake();
+  assert.equal(tracker.agentGone(), false, "a slow boot is not a death");
+  // The outage it DID measure is still weighed normally — recording a conclusion must
+  // not disturb the duration path either way.
+  assert.equal(tracker.outageMs(), 45_000);
+});
+
+test("#1168: only the literal boolean opens the gate", () => {
+  // This branch BYPASSES the duration guard, so a caller that guessed the field name
+  // must not be able to nudge with a truthy string. Asserted because `=== true` reads
+  // like an accident next to the `typeof` checks around it, and a "simplification" to
+  // truthiness would silently widen the one path that can skip the whole guard.
+  for (const truthy of ["1", 1, {}, [], "true"]) {
+    assert.equal(
+      shouldNudgeAfterMidTaskReconnect({ outageMs: 0, agentGone: truthy }),
+      false,
+      "a non-boolean must fall through to the clock, not open the gate",
+    );
+  }
+  // And omitting it entirely leaves every pre-#1168 answer exactly as it was.
+  assert.equal(shouldNudgeAfterMidTaskReconnect({ outageMs: 30_000 }), true);
+  assert.equal(shouldNudgeAfterMidTaskReconnect({ outageMs: 5999 }), false);
+});
+
+test("#1168 WIRING: the death is recorded where the panel EARNS the conclusion", () => {
+  // Replaces the NOTE this file carried while the gap was unfixed. The two attempts that
+  // failed differed from this one only in WHERE they stamped, so placement is the fix —
+  // and it is the one thing the behavioural tests above cannot see.
+  const src = readFileSync(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8");
+  const CALL = "bridgeOutage.noteAgentGone();";
+
+  // Exactly one site, for #1096's reason: a loose scan asserts nothing, and the old
+  // negative scan this replaces would have PASSED against the design it named (it
+  // searched the teardown bodies for a literal `bridgeOutage.`, while the design it
+  // rejected put the stamp in a shared helper those bodies call). Counting the call
+  // itself cannot be evaded that way — a wrapper still has to contain this line, and
+  // the body check below then fails.
+  assert.equal(
+    src.split(CALL).length - 1,
+    1,
+    "a death must be concluded in exactly one place — teardowns and redials cannot",
+  );
+
+  const at = src.indexOf("function showExternalHintOnce()");
+  assert.ok(at > 0, "showExternalHintOnce must exist");
+  const rest = src.slice(at);
+  const end = rest.indexOf("\n  function ", 1);
+  const body = rest.slice(0, end > 0 ? end : 2000);
+  assert.ok(body.includes(CALL), "the death is recorded where 'no agent is listening' latches");
+
+  // …and AFTER both reasons the conclusion might not be earned yet: #1136's fallback
+  // dial (a configured URL that outlived its process is not a dead agent) and the latch
+  // itself. Recording above the fallback's early `return` is the same over-claim #1136
+  // moved this latch to avoid, and is how attempt 2 went wrong one layer up.
+  assert.ok(
+    body.indexOf("bridgeFallbackPlan({") < body.indexOf(CALL),
+    "the fallback must be tried before any death is concluded",
+  );
+  assert.ok(
+    body.indexOf("externalHintShown = true;") < body.indexOf(CALL),
+    "the death is concluded exactly when the hint becomes true, not before",
+  );
+
+  // The reader, pinned by exact substring like the three write sites above it: a flag
+  // nothing consults leaves the wedge unfixed while every test here still passes.
+  assert.ok(
+    src.includes(
+      "if (!shouldNudgeAfterMidTaskReconnect({ outageMs: bridgeOutage.outageMs(), agentGone: bridgeOutage.agentGone() })) return;",
+    ),
+    "the ready-ack mid-task branch must weigh the conclusion alongside the measured outage",
+  );
 });

--- a/browser_tests/unit/session-rebind.test.mjs
+++ b/browser_tests/unit/session-rebind.test.mjs
@@ -608,7 +608,7 @@ test("#1138 wiring: the call site NEGATES the predicate and returns", () => {
   const src = readFileSync(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8");
   assert.ok(
     src.includes(
-      "if (!shouldNudgeAfterMidTaskReconnect({ outageMs: bridgeOutage.outageMs()",
+      "if (!shouldNudgeAfterMidTaskReconnect({ outageMs: bridgeOutage.outageMs() })) return;",
     ),
     "the ready-ack mid-task branch must NEGATE the predicate and read the measured outage",
   );
@@ -633,6 +633,7 @@ test("#1138 wiring: the call site NEGATES the predicate and returns", () => {
   // assert nothing.
   for (const [site, snippet] of [
     ["the socket close handler must open the outage", "bridgeOutage.noteBridgeClosed();"],
+    ["a concluded death must open one too (#1168)", "bridgeOutage.noteAgentGone();"],
     ["the models handshake must close it", "bridgeOutage.noteHandshake();"],
     ["a turn start must scope the evidence to that turn", "bridgeOutage.noteTurnStarted();"],
   ]) {
@@ -941,25 +942,27 @@ test("#1145: a second outage measures itself, not the gap since the first", () =
   assert.equal(shouldNudgeAfterMidTaskReconnect({ outageMs: tracker.outageMs() }), false);
 });
 
-// ── #1168: a WEDGED orchestrator's death is recorded as a CONCLUSION ──────────
+// ── #1168: a WEDGED orchestrator's death OPENS an outage of its own ───────────
 //
 // The outage clock is started by the socket `close` listener, and a wedged orchestrator
-// never fires one: it holds the connection open and answers nothing. So the death that
-// killed the running turn goes unrecorded, and the clock only starts when that process
-// finally dies — measuring the user's restart instead of the wedge. The turn is never
-// resumed.
+// never fires one: it holds the connection open and answers nothing. So the outage the
+// death caused is not merely mismeasured, it is never opened at all — and when the wedged
+// process finally dies the clock starts from THAT moment, so a user who restarts it
+// promptly measures the restart. Minutes with no agent behind the socket are weighed as a
+// three-second blip and the turn is never resumed.
 //
-// Two earlier attempts recorded it as a DURATION, from the teardown side and from the
-// handshake redial, and both converted a missed nudge into a false one. What this pins
-// is the third shape: the panel records the CONCLUSION it actually reached ("nothing is
-// behind this socket"), the reader weighs it ahead of the clock, and a turn start still
-// stands it down — so an orchestrator that turns out to be alive is never nudged.
+// The fix opens the outage where the panel CONCLUDES the death. What it deliberately does
+// not do is exempt that death from the threshold — a first draft passed the conclusion to
+// the predicate and let it outrank the clock, and review showed that nudges a live agent
+// whenever the conclusion is wrong (a socket stale under a sleep / NAT idle-kill presents
+// identically). The interval remains the sole gate; #1168 only makes sure it is measured
+// from when the agent stopped answering rather than from when its process finally exited.
 
 test("#1168: a wedge that no close ever reported still resumes the turn", () => {
   // The reported sequence, to scale. A turn is in flight; the orchestrator wedges with
-  // its socket OPEN, so nothing closes and nothing opens an outage. The panel spends its
-  // full redial ladder (~60s) establishing that nothing answers, then concludes. The user
-  // restarts the orchestrator out-of-band and it is back in three seconds.
+  // its socket OPEN, so nothing closes. The panel spends its full redial ladder (~60s)
+  // establishing that nothing answers, then concludes. The user reads the hint, restarts
+  // the agent by hand, and the fresh one is up three seconds after the old port frees.
   const { clock, tracker } = trackerAt();
   tracker.noteTurnStarted();
   clock.t += 60_000; // the redial ladder — an open socket, no `models`, no close
@@ -969,120 +972,107 @@ test("#1168: a wedge that no close ever reported still resumes the turn", () => 
   clock.t += 3000; // the fresh orchestrator binds the port…
   tracker.noteHandshake(); // …and handshakes
 
-  // THE DEFECT, asserted rather than described: three minutes with no agent behind the
-  // socket are measured as the three-second RESTART, which the duration guard correctly
-  // reads as a blip. Weighing it alone is what loses the nudge, so this must stay true —
-  // it is the gap, not the thing being fixed.
+  assert.equal(
+    tracker.outageMs(),
+    123_000,
+    "the outage runs from the death the panel concluded, not from the process exit",
+  );
+  assert.equal(
+    shouldNudgeAfterMidTaskReconnect({ outageMs: tracker.outageMs() }),
+    true,
+    "a turn a wedge interrupted must be resumed",
+  );
+});
+
+test("#1168: the counterfactual — measuring from the process exit loses the nudge", () => {
+  // What main does with the same sequence, asserted rather than described: with nothing
+  // recording the death, the first close is the wedged process finally exiting, and the
+  // interval is the three-second RESTART. Under the threshold, no nudge, turn stranded.
+  // If these two ever agree the fix has become invisible.
+  const { clock, tracker } = trackerAt();
+  tracker.noteTurnStarted();
+  clock.t += 60_000;
+  clock.t += 120_000; // …no noteAgentGone(): the wedge goes unrecorded
+  tracker.noteBridgeClosed();
+  clock.t += 3000;
+  tracker.noteHandshake();
   assert.equal(tracker.outageMs(), 3000);
   assert.equal(
     shouldNudgeAfterMidTaskReconnect({ outageMs: tracker.outageMs() }),
     false,
-    "the clock alone cannot see a wedge — this is the gap, and it must stay visible here",
-  );
-  // The fix: the conclusion the panel actually reached is the evidence.
-  assert.equal(tracker.agentGone(), true, "the handshake must not erase the conclusion");
-  assert.equal(
-    shouldNudgeAfterMidTaskReconnect({
-      outageMs: tracker.outageMs(),
-      agentGone: tracker.agentGone(),
-    }),
-    true,
-    "a turn a concluded death interrupted must be resumed",
+    "this is the bug — three minutes with no agent read as a blip",
   );
 });
 
-test("#1168: the two evidence kinds DISAGREE, so the fix cannot be inert", () => {
-  // #1096's review proved by mutation that token-presence scans stay green under an
-  // inverted guard. This is the behavioural equivalent: for one and the same measured
-  // interval the answer must differ on the conclusion alone. If these ever agree, either
-  // the flag stopped being read or it stopped mattering, and the wedge is unfixed again.
-  const fast = 3000;
-  assert.notEqual(
-    shouldNudgeAfterMidTaskReconnect({ outageMs: fast, agentGone: true }),
-    shouldNudgeAfterMidTaskReconnect({ outageMs: fast, agentGone: false }),
-    "a concluded death must change the answer the clock alone would give",
-  );
-  assert.equal(shouldNudgeAfterMidTaskReconnect({ outageMs: fast, agentGone: true }), true);
-  assert.equal(shouldNudgeAfterMidTaskReconnect({ outageMs: fast, agentGone: false }), false);
-  // …and with NO outage at all, which is the wedge's own reading before any close.
-  assert.equal(shouldNudgeAfterMidTaskReconnect({ outageMs: 0, agentGone: true }), true);
-  assert.equal(shouldNudgeAfterMidTaskReconnect({ outageMs: 0 }), false);
-});
-
-test("#1168: an orchestrator that turns out to be ALIVE is never nudged", () => {
-  // The half that makes this shippable, and the one both previous attempts failed. The
-  // panel can conclude a death and be wrong — a very slow boot answers eventually. What
-  // makes that safe is the same guarantee #1163 rests on: a live turn re-announces, and
-  // that frame stands the conclusion down before the ready ack can act on it.
+test("#1168: a conclusion the panel got WRONG must not nudge a live agent", () => {
+  // The finding that rejected the first draft, kept as a regression test. The panel
+  // cannot tell "the orchestrator died" from "my own socket went stale while it kept
+  // working": a half-open TCP after a laptop sleep, a NAT idle-kill or a VPN flap all
+  // present as an open socket answering nothing, so the give-up ladder concludes a death
+  // that never happened. The orchestrator is alive and mid-turn, and answers again as
+  // soon as the stale socket is torn down.
+  //
+  // Nothing here relies on frame ORDERING. The earlier draft's safety argument did — it
+  // assumed a surviving turn's re-announce beats the `ready` ack — and this file already
+  // records (see the #1163 test above) that the panel guarantees no such thing. The
+  // elapsed interval is what makes this safe, which is why the conclusion opens an outage
+  // instead of bypassing the threshold.
   const { clock, tracker } = trackerAt();
   tracker.noteTurnStarted();
   clock.t += 60_000;
-  tracker.noteAgentGone(); // the panel gives up…
-  clock.t += 5000;
-  tracker.noteTurnStarted(); // …but the surviving turn re-announces on reconnect
-  assert.equal(tracker.agentGone(), false, "a live turn must retire the conclusion");
+  tracker.noteAgentGone(); // concluded — wrongly
+  clock.t += 1000;
+  tracker.noteBridgeClosed(); // the OS finally tears the stale TCP down
+  clock.t += 1500;
+  tracker.noteHandshake(); // the SAME, still-alive orchestrator answers
+  assert.equal(tracker.outageMs(), 2500);
   assert.equal(
-    shouldNudgeAfterMidTaskReconnect({
-      outageMs: tracker.outageMs(),
-      agentGone: tracker.agentGone(),
-    }),
+    shouldNudgeAfterMidTaskReconnect({ outageMs: tracker.outageMs() }),
     false,
-    "an agent that is working must never be told to start over",
+    "an agent that never stopped working must not be told to start over",
   );
 });
 
-test("#1168: a death concluded before this turn is not this turn's evidence", () => {
-  // The turn-scoping rule #1145/#1163 established for the duration, applied to the flag —
-  // without it a wedge settled two turns ago would nudge every later reconnect. Safe by
-  // construction at the call site too: the panel arms its mid-task marker in the same
-  // frame that starts the turn, so an armed marker implies this event has already run.
+test("#1168: a concluded death does not restart a clock already running", () => {
+  // The give-up ladder can be reached with an outage already open (the terminal
+  // `disconnected` caller gets there through its own failed retries). Re-stamping would
+  // discard everything before it — the #1145 backoff-step defect through a new door — so
+  // the first opener wins here exactly as it does for a close.
   const { clock, tracker } = trackerAt();
-  tracker.noteAgentGone(); // a wedge, concluded and long since recovered
+  tracker.noteTurnStarted();
+  tracker.noteBridgeClosed(); // t=0, the drop
+  clock.t += 20_000; // reconnect patience runs out
+  tracker.noteAgentGone(); // the same latch, reached from the disconnected caller
+  clock.t += 2000;
+  tracker.noteHandshake();
+  assert.equal(tracker.outageMs(), 22_000, "the outage keeps its original start");
+  assert.equal(shouldNudgeAfterMidTaskReconnect({ outageMs: tracker.outageMs() }), true);
+});
+
+test("#1168: a turn start still closes an outage a conclusion opened", () => {
+  // Turn-scoping must reach the new opener too, or a wedge concluded before this turn
+  // would be re-read as this turn's evidence — the #1145/#1163 defect one door along.
+  const { clock, tracker } = trackerAt();
+  tracker.noteAgentGone();
   clock.t += 600_000;
   tracker.noteTurnStarted(); // a brand-new turn the user just typed
-  assert.equal(tracker.agentGone(), false);
+  assert.equal(tracker.isDown(), false, "a turn start ends the outage, whoever opened it");
+  assert.equal(tracker.outageMs(), 0);
   assert.equal(
-    shouldNudgeAfterMidTaskReconnect({
-      outageMs: tracker.outageMs(),
-      agentGone: tracker.agentGone(),
-    }),
+    shouldNudgeAfterMidTaskReconnect({ outageMs: tracker.outageMs() }),
     false,
     "a settled wedge must not nudge a turn that started after it",
   );
 });
 
-test("#1168: nothing but an explicit conclusion sets the flag", () => {
-  // The agent-not-ready-YET case, which attempt 2 stamped and must not: a fresh mount,
-  // a close, a redial's reopen and a late handshake are all ordinary events, and none of
-  // them is a death. A tracker that reported one here would nudge every slow first
-  // connect that happened to follow a turn.
-  const { clock, tracker } = trackerAt();
-  assert.equal(tracker.agentGone(), false, "a fresh tracker has concluded nothing");
-  tracker.noteTurnStarted();
-  tracker.noteBridgeClosed();
-  clock.t += 45_000; // a genuinely slow cold start
-  tracker.noteHandshake();
-  assert.equal(tracker.agentGone(), false, "a slow boot is not a death");
-  // The outage it DID measure is still weighed normally — recording a conclusion must
-  // not disturb the duration path either way.
-  assert.equal(tracker.outageMs(), 45_000);
-});
-
-test("#1168: only the literal boolean opens the gate", () => {
-  // This branch BYPASSES the duration guard, so a caller that guessed the field name
-  // must not be able to nudge with a truthy string. Asserted because `=== true` reads
-  // like an accident next to the `typeof` checks around it, and a "simplification" to
-  // truthiness would silently widen the one path that can skip the whole guard.
-  for (const truthy of ["1", 1, {}, [], "true"]) {
-    assert.equal(
-      shouldNudgeAfterMidTaskReconnect({ outageMs: 0, agentGone: truthy }),
-      false,
-      "a non-boolean must fall through to the clock, not open the gate",
-    );
-  }
-  // And omitting it entirely leaves every pre-#1168 answer exactly as it was.
-  assert.equal(shouldNudgeAfterMidTaskReconnect({ outageMs: 30_000 }), true);
-  assert.equal(shouldNudgeAfterMidTaskReconnect({ outageMs: 5999 }), false);
+test("#1168: an unreadable clock cannot manufacture a death", () => {
+  // Same safe direction noteBridgeClosed takes: with no readable clock the outage is not
+  // opened at all, so the nudge is withheld rather than invented.
+  const broken = createBridgeOutageTracker({ now: () => NaN });
+  broken.noteAgentGone();
+  assert.equal(broken.isDown(), false);
+  assert.equal(broken.outageMs(), 0);
+  assert.equal(shouldNudgeAfterMidTaskReconnect({ outageMs: broken.outageMs() }), false);
 });
 
 test("#1168 WIRING: the death is recorded where the panel EARNS the conclusion", () => {
@@ -1124,12 +1114,14 @@ test("#1168 WIRING: the death is recorded where the panel EARNS the conclusion",
     "the death is concluded exactly when the hint becomes true, not before",
   );
 
-  // The reader, pinned by exact substring like the three write sites above it: a flag
-  // nothing consults leaves the wedge unfixed while every test here still passes.
+  // And the conclusion must NOT be handed to the predicate as a second input. The first
+  // draft did exactly that and was rejected: it let a conclusion the panel cannot verify
+  // bypass the threshold, nudging a live agent whenever a stale socket looked like a
+  // death. The elapsed interval stays the sole gate.
   assert.ok(
     src.includes(
-      "if (!shouldNudgeAfterMidTaskReconnect({ outageMs: bridgeOutage.outageMs(), agentGone: bridgeOutage.agentGone() })) return;",
+      "if (!shouldNudgeAfterMidTaskReconnect({ outageMs: bridgeOutage.outageMs() })) return;",
     ),
-    "the ready-ack mid-task branch must weigh the conclusion alongside the measured outage",
+    "the nudge must be decided on the measured outage alone, never on the raw conclusion",
   );
 });

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -28914,14 +28914,14 @@ function buildPanel() {
         // and #1096's review demonstrated by mutation that such a test stays green when
         // the guard is inverted — which is the one regression that matters here.
         //
-        // #1168 — and the measured outage is not the only evidence. A WEDGED
-        // orchestrator holds its socket open and answers nothing, so no close fires and
-        // no outage is opened at all; the clock starts only when the wedged process
-        // finally dies, and a user who restarts it promptly measures that restart rather
-        // than the wedge. The panel's own conclusion that nothing is behind the socket
-        // is the direct form of what the duration is a proxy for, so it is passed
-        // alongside and outranks it.
-        if (!shouldNudgeAfterMidTaskReconnect({ outageMs: bridgeOutage.outageMs(), agentGone: bridgeOutage.agentGone() })) return;
+        // #1168 — unchanged here, deliberately. A wedged orchestrator's death now opens
+        // an outage of its own (bridgeOutage.noteAgentGone, from where the panel
+        // concludes it), so the gap this missed reaches the SAME threshold rather than
+        // being exempted from it. A first draft passed the conclusion in alongside the
+        // duration and let it outrank the guard; review showed that nudges a live agent
+        // whenever the panel's conclusion is wrong — a socket that went stale under a
+        // sleep or a NAT idle-kill is indistinguishable from a death here.
+        if (!shouldNudgeAfterMidTaskReconnect({ outageMs: bridgeOutage.outageMs() })) return;
         appendSystem(tr("panel.reconnected_picking_up_where_we_left_off", "Reconnected — picking up where we left off."));
         showThinking();
         if (client.sendUserMessage(
@@ -30281,11 +30281,20 @@ function buildPanel() {
     // Both callers reach it having established that, not assumed it: the handshake
     // timeout (an OPEN socket that answered nothing for the full redial ladder — the
     // WEDGE this issue is about, where no close ever fires and nothing else records a
-    // death) and the terminal `disconnected` status (reconnect patience exhausted). The
-    // panel never kills anything here, which is the point — this distribution CANNOT
-    // respawn the orchestrator (externalOrchestratorMode is hardcoded true, and the
-    // pack's /connect ignores `force` entirely), so the death has to be concluded from
-    // the panel's own observation or not at all.
+    // death) and the terminal `disconnected` status (reconnect patience exhausted, whose
+    // own retries have already opened an outage, so this is a no-op there). The panel
+    // never kills anything here, which is the point — this distribution CANNOT respawn
+    // the orchestrator (externalOrchestratorMode is hardcoded true, and the pack's
+    // /connect ignores `force` entirely), so the death has to be concluded from the
+    // panel's own observation or not at all.
+    //
+    // This OPENS an outage; it does not assert one was long enough to matter. The
+    // threshold still decides, because a conclusion reached here can be wrong: a socket
+    // that went stale under a laptop sleep, a NAT idle-kill or a VPN flap presents
+    // exactly like a wedge, and the orchestrator behind it may be alive and mid-turn.
+    // When it is, it answers again within moments of this point and the short interval
+    // withholds the nudge; a genuine wedge takes the user reading the hint below and
+    // restarting the agent by hand, which never fits inside that window.
     bridgeOutage.noteAgentGone();
     appendSystem(
       tr(

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -19404,13 +19404,13 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
       // MID_TASK_KEY, and that is not quite true: connectBackend() clears it only when
       // `switching`. (hardRestart() had the same hole and no longer does — #1166.)
       //
-      // A WEDGED orchestrator is not covered here either: it holds its socket OPEN and
-      // answers nothing, so no close ever fires and no outage is recorded for a death
-      // the panel then resolves by force-respawning it. Both gaps are real and are
-      // tracked as their own issue rather than patched from here — two attempts to
-      // record those deaths from the teardown side turned a MISSED nudge into a FALSE
-      // one, because the teardown functions cannot distinguish "the orchestrator died"
-      // from "the user changed the bridge URL" or "the agent has not booted yet".
+      // A WEDGED orchestrator is still not covered here, and by design: it holds its
+      // socket OPEN and answers nothing, so no close ever fires. #1168 records that
+      // death where it is actually CONCLUDED (showExternalHintOnce, past the redial and
+      // fallback ladder) via bridgeOutage.noteAgentGone() — not from here and not from
+      // the teardown side, whose functions cannot distinguish "the orchestrator died"
+      // from "the user changed the bridge URL" or "the agent has not booted yet". Two
+      // attempts to stamp it from a teardown turned a MISSED nudge into a FALSE one.
       bridgeOutage.noteBridgeClosed();
       if (!closed) {
         // FIX 1 — auto-reconnecting: keep the pill STEADY (scheduleReconnect picks
@@ -28913,7 +28913,15 @@ function buildPanel() {
         // A source-scan over this file could only assert the guard's tokens are present,
         // and #1096's review demonstrated by mutation that such a test stays green when
         // the guard is inverted — which is the one regression that matters here.
-        if (!shouldNudgeAfterMidTaskReconnect({ outageMs: bridgeOutage.outageMs() })) return;
+        //
+        // #1168 — and the measured outage is not the only evidence. A WEDGED
+        // orchestrator holds its socket open and answers nothing, so no close fires and
+        // no outage is opened at all; the clock starts only when the wedged process
+        // finally dies, and a user who restarts it promptly measures that restart rather
+        // than the wedge. The panel's own conclusion that nothing is behind the socket
+        // is the direct form of what the duration is a proxy for, so it is passed
+        // alongside and outranks it.
+        if (!shouldNudgeAfterMidTaskReconnect({ outageMs: bridgeOutage.outageMs(), agentGone: bridgeOutage.agentGone() })) return;
         appendSystem(tr("panel.reconnected_picking_up_where_we_left_off", "Reconnected — picking up where we left off."));
         showThinking();
         if (client.sendUserMessage(
@@ -30259,6 +30267,26 @@ function buildPanel() {
       return; // the hint is only true once the fallback has failed too
     }
     externalHintShown = true;
+    // #1168 — and this is where the panel concludes the agent behind the bridge socket
+    // is GONE, so this is where that death is recorded.
+    //
+    // The site is chosen, not convenient. Everything above is the ladder of reasons the
+    // conclusion might NOT be earned yet — the patient cold-start window, the bounded
+    // handshake redial (the agent-not-ready-YET case), and #1136's fallback dial for a
+    // configured URL that outlived its process. Only past all of them is "no agent is
+    // listening" true, and it is the identical claim: #1136 moved this latch here for
+    // exactly the over-claim this would otherwise repeat. Recording the death anywhere
+    // earlier is what sank the two previous attempts.
+    //
+    // Both callers reach it having established that, not assumed it: the handshake
+    // timeout (an OPEN socket that answered nothing for the full redial ladder — the
+    // WEDGE this issue is about, where no close ever fires and nothing else records a
+    // death) and the terminal `disconnected` status (reconnect patience exhausted). The
+    // panel never kills anything here, which is the point — this distribution CANNOT
+    // respawn the orchestrator (externalOrchestratorMode is hardcoded true, and the
+    // pack's /connect ignores `force` entirely), so the death has to be concluded from
+    // the panel's own observation or not at all.
+    bridgeOutage.noteAgentGone();
     appendSystem(
       tr(
         "panel.no_agent_is_listening_on_the_bridge",

--- a/web/js/lib/session-rebind.js
+++ b/web/js/lib/session-rebind.js
@@ -84,25 +84,15 @@ export function shouldRehelloAfterCommand(cmd, reply) {
 // absent, zero, negative or unreadable all mean no outage was measured, and no outage
 // means no nudge.
 //
-// #1168 — `agentGone` is the OTHER kind of evidence, and it outranks the clock.
-//
-// Everything above reasons about a duration because the panel usually cannot observe a
-// death directly, so it infers one from how long the bridge was gone. That inference is
-// exactly backwards in the case this parameter exists for. A WEDGED orchestrator holds
-// its socket OPEN and answers nothing, so no close ever fires and no outage is ever
-// opened; the clock starts only when the wedged process finally dies. A user who
-// restarts it promptly therefore measures the RESTART — a few seconds, under the
-// threshold — and the turn the wedge killed is never resumed, even though the panel had
-// spent a full minute establishing that nothing was behind that socket.
-//
-// So when the caller has CONCLUDED the agent is gone (see `noteAgentGone` on the tracker
-// below), the proxy is not consulted: the thing it was estimating is already known.
-export function shouldNudgeAfterMidTaskReconnect({ outageMs = 0, minOutageMs = 6000, agentGone = false } = {}) {
-  // `=== true`, not truthiness, and deliberately not symmetric with the duration checks
-  // below: this branch BYPASSES the guard, so only the literal boolean the tracker sets
-  // may open it. A stray "1"/1/{} from a caller that guessed the field name falls
-  // through to the clock instead of nudging on the strength of a typo.
-  if (agentGone === true) return true;
+// #1168 deliberately did NOT add a second input here. The wedge it fixes is an outage
+// this predicate never got to see, not a case the threshold judges wrongly, so it is
+// fixed by opening that outage (see `noteAgentGone` on the tracker below) rather than by
+// letting a caller's conclusion outrank the clock. A first draft did the latter and was
+// rejected in review: the panel cannot tell "the orchestrator died" from "my own socket
+// went stale while it kept working" — both are an open socket that answers nothing — and
+// a bypass would have nudged a live agent mid-turn on the second. The elapsed interval
+// is what separates them, so it stays the sole gate.
+export function shouldNudgeAfterMidTaskReconnect({ outageMs = 0, minOutageMs = 6000 } = {}) {
   if (typeof outageMs !== "number" || !Number.isFinite(outageMs)) return false;
   // Not `> 0` by accident: a measured outage is a real elapsed duration, so a
   // non-positive one is the never-dropped sentinel, an ended-and-consumed outage, or a
@@ -133,7 +123,8 @@ export function shouldNudgeAfterMidTaskReconnect({ outageMs = 0, minOutageMs = 6
 //     a re-advertise on a live socket (#310 does one after every free_vram) and records
 //     nothing rather than inheriting the previous outage as if it were its own.
 //   noteAgentGone()     — the panel CONCLUDED the agent behind the bridge socket is gone.
-//     A separate event from a close, and deliberately not spelled as one: see its body.
+//     Opens an outage exactly as a close does, and is a separate event only because the
+//     DECISION differs: a close is observed, this is concluded. See its body.
 //   noteTurnStarted()   — a new agent turn began, so outages that ended before it are no
 //     longer evidence about the turn now running. This is what stops a real but settled
 //     drop from being re-read later as this turn's — the #1138 defect with a stale
@@ -151,11 +142,6 @@ export function createBridgeOutageTracker({ now = () => Date.now() } = {}) {
   let startedAt = null;
   // The outage the current turn has seen, in ms; 0 means "no drop during this turn".
   let outageMs = 0;
-  // #1168 — whether the panel concluded, DURING THIS TURN, that the agent behind the
-  // bridge socket is gone. Scoped exactly like outageMs above and cleared by the same
-  // event, for the same reason: a death concluded before this turn is not evidence
-  // about the turn running now.
-  let agentGone = false;
   const readClock = () => {
     const t = now();
     return typeof t === "number" && Number.isFinite(t) ? t : null;
@@ -169,29 +155,39 @@ export function createBridgeOutageTracker({ now = () => Date.now() } = {}) {
       // a missed nudge leaves an idle agent, an invented one derails a working agent.
       if (t !== null) startedAt = t;
     },
-    // #1168 — the panel concluded the agent behind the bridge socket is GONE.
+    // #1168 — the panel CONCLUDED the agent behind the bridge socket is gone, so the
+    // outage starts HERE.
     //
-    // Deliberately not folded into noteBridgeClosed(): that name means "a socket
-    // closed", and the case this exists for is precisely the one where none does. A
-    // wedged orchestrator holds its connection OPEN and answers nothing, so the close
-    // listener never runs and the death goes unrecorded until the wedged process
-    // eventually dies — by which time the clock measures the user's restart instead of
-    // the outage. Overloading the socket-event name is what let two earlier attempts
-    // read as plausible while being wrong: one stamped the shared teardown helper
-    // (~17 call sites, most of them a LIVE orchestrator being re-pointed), the other
-    // stamped the handshake REDIAL, whose own doc calls it the agent-not-ready-YET
-    // case. Both converted a missed nudge into a false one, which is strictly worse.
+    // A wedged orchestrator holds its connection OPEN and answers nothing, so the close
+    // listener never runs. The outage it caused is therefore not merely mismeasured, it
+    // is never opened at all — and when the wedged process finally dies the clock starts
+    // from that moment, so a user who restarts it promptly measures the RESTART. Minutes
+    // with no agent behind the socket are weighed as a three-second blip and the turn the
+    // wedge killed is never resumed.
     //
-    // It records a CONCLUSION, not an interval, because no honest interval exists here.
-    // The panel cannot see when the agent behind an open socket stopped answering; it
-    // knows only that it has now given up on it, after the full bounded ladder of
-    // cold-start windows and redials that give-up costs. Manufacturing a duration from
-    // that moment would re-lose the nudge on exactly the fast recovery this is for, so
-    // the reader (`shouldNudgeAfterMidTaskReconnect`) weighs the flag AHEAD of the clock
-    // and this leaves `startedAt`/`outageMs` untouched: an outage a real close opened is
-    // still measured normally, and a death is not also charged as one.
+    // Same body as noteBridgeClosed above, and a separate method for the DECISION, not
+    // the effect. That name means "a socket closed" — an observation. This one is a
+    // conclusion the panel reaches after a bounded ladder of cold-start windows and
+    // redials, and it is a conclusion only its caller can be trusted to have earned.
+    // Keeping it separate is what stopped the two rejected attempts from being spelled
+    // as this one: they stamped an outage in the shared teardown helper (~17 call sites,
+    // most of them a LIVE orchestrator being re-pointed) and in the handshake REDIAL,
+    // whose own doc calls it the agent-not-ready-YET case.
+    //
+    // What it deliberately does NOT do is exempt the death from the threshold. The panel
+    // cannot distinguish "the orchestrator died" from "my own socket went stale while it
+    // kept working" — a half-open TCP after a sleep, a NAT idle-kill or a VPN flap looks
+    // identical from here — so a conclusion is evidence that an outage BEGAN, never that
+    // it was long enough to have killed the turn. The elapsed interval is what separates
+    // the two, and it stays the sole gate: a live orchestrator that answers again
+    // moments later measures short and is left alone, while a wedge the user has to
+    // notice and restart by hand cannot be.
     noteAgentGone() {
-      agentGone = true;
+      if (startedAt !== null) return; // already inside an outage — not a new one
+      const t = readClock();
+      // An unreadable clock cannot start an outage; see noteBridgeClosed for why that is
+      // the safe direction.
+      if (t !== null) startedAt = t;
     },
     noteHandshake() {
       if (startedAt === null) return; // ended no outage — records nothing
@@ -232,13 +228,6 @@ export function createBridgeOutageTracker({ now = () => Date.now() } = {}) {
       // satisfied by simply never nudging.
       startedAt = null;
       outageMs = 0;
-      // #1168 — a concluded death is turn-scoped evidence for the same reason a measured
-      // outage is, and this is the event that scopes it. It is also the whole safety
-      // argument for letting the flag outrank the clock: an orchestrator that turns out
-      // to be ALIVE re-announces its running turn, and that frame lands here and stands
-      // the conclusion down before the `ready` ack can act on it. A dead one has no turn
-      // to announce, so nothing arrives, the flag stands, and the nudge fires.
-      agentGone = false;
     },
     /** The outage the current turn has seen, in ms (0 = none).
      *
@@ -264,15 +253,10 @@ export function createBridgeOutageTracker({ now = () => Date.now() } = {}) {
       // reports no outage rather than a negative one.
       return t === null ? outageMs : Math.max(0, t - startedAt);
     },
-    /** #1168 — true when the panel concluded, during THIS turn, that the agent behind
-     *  the bridge socket is gone. Unlike outageMs() this is not re-derived from a clock:
-     *  it is the observation itself, and it survives the handshake that recovers the
-     *  connection because the nudge is decided one frame later, on the `ready` ack. */
-    agentGone: () => agentGone,
-    /** True while the bridge is down — the outage has begun but not yet ended.
+    /** True while the bridge is down — the outage has begun but not yet ended, whether
+     *  a close observed that or #1168's noteAgentGone concluded it.
      *  Read by the tests that pin the open/closed transitions; the panel decides on
-     *  outageMs() and agentGone() (#1168), so this stays a state ACCESSOR and never a
-     *  predicate of its own. */
+     *  outageMs() alone, so this stays a state ACCESSOR and never a second predicate. */
     isDown: () => startedAt !== null,
   };
 }

--- a/web/js/lib/session-rebind.js
+++ b/web/js/lib/session-rebind.js
@@ -271,7 +271,8 @@ export function createBridgeOutageTracker({ now = () => Date.now() } = {}) {
     agentGone: () => agentGone,
     /** True while the bridge is down — the outage has begun but not yet ended.
      *  Read by the tests that pin the open/closed transitions; the panel decides on
-     *  outageMs() alone, so this stays a state ACCESSOR and never a second predicate. */
+     *  outageMs() and agentGone() (#1168), so this stays a state ACCESSOR and never a
+     *  predicate of its own. */
     isDown: () => startedAt !== null,
   };
 }

--- a/web/js/lib/session-rebind.js
+++ b/web/js/lib/session-rebind.js
@@ -83,7 +83,26 @@ export function shouldRehelloAfterCommand(cmd, reply) {
 // `outageMs` is therefore required to be a positive, finite number of milliseconds:
 // absent, zero, negative or unreadable all mean no outage was measured, and no outage
 // means no nudge.
-export function shouldNudgeAfterMidTaskReconnect({ outageMs = 0, minOutageMs = 6000 } = {}) {
+//
+// #1168 — `agentGone` is the OTHER kind of evidence, and it outranks the clock.
+//
+// Everything above reasons about a duration because the panel usually cannot observe a
+// death directly, so it infers one from how long the bridge was gone. That inference is
+// exactly backwards in the case this parameter exists for. A WEDGED orchestrator holds
+// its socket OPEN and answers nothing, so no close ever fires and no outage is ever
+// opened; the clock starts only when the wedged process finally dies. A user who
+// restarts it promptly therefore measures the RESTART — a few seconds, under the
+// threshold — and the turn the wedge killed is never resumed, even though the panel had
+// spent a full minute establishing that nothing was behind that socket.
+//
+// So when the caller has CONCLUDED the agent is gone (see `noteAgentGone` on the tracker
+// below), the proxy is not consulted: the thing it was estimating is already known.
+export function shouldNudgeAfterMidTaskReconnect({ outageMs = 0, minOutageMs = 6000, agentGone = false } = {}) {
+  // `=== true`, not truthiness, and deliberately not symmetric with the duration checks
+  // below: this branch BYPASSES the guard, so only the literal boolean the tracker sets
+  // may open it. A stray "1"/1/{} from a caller that guessed the field name falls
+  // through to the clock instead of nudging on the strength of a typo.
+  if (agentGone === true) return true;
   if (typeof outageMs !== "number" || !Number.isFinite(outageMs)) return false;
   // Not `> 0` by accident: a measured outage is a real elapsed duration, so a
   // non-positive one is the never-dropped sentinel, an ended-and-consumed outage, or a
@@ -113,6 +132,8 @@ export function shouldNudgeAfterMidTaskReconnect({ outageMs = 0, minOutageMs = 6
 //     outage ENDS and its duration is finally known. A handshake with no outage open is
 //     a re-advertise on a live socket (#310 does one after every free_vram) and records
 //     nothing rather than inheriting the previous outage as if it were its own.
+//   noteAgentGone()     — the panel CONCLUDED the agent behind the bridge socket is gone.
+//     A separate event from a close, and deliberately not spelled as one: see its body.
 //   noteTurnStarted()   — a new agent turn began, so outages that ended before it are no
 //     longer evidence about the turn now running. This is what stops a real but settled
 //     drop from being re-read later as this turn's — the #1138 defect with a stale
@@ -130,6 +151,11 @@ export function createBridgeOutageTracker({ now = () => Date.now() } = {}) {
   let startedAt = null;
   // The outage the current turn has seen, in ms; 0 means "no drop during this turn".
   let outageMs = 0;
+  // #1168 — whether the panel concluded, DURING THIS TURN, that the agent behind the
+  // bridge socket is gone. Scoped exactly like outageMs above and cleared by the same
+  // event, for the same reason: a death concluded before this turn is not evidence
+  // about the turn running now.
+  let agentGone = false;
   const readClock = () => {
     const t = now();
     return typeof t === "number" && Number.isFinite(t) ? t : null;
@@ -142,6 +168,30 @@ export function createBridgeOutageTracker({ now = () => Date.now() } = {}) {
       // handshake records no duration, so the nudge is withheld — the safe direction:
       // a missed nudge leaves an idle agent, an invented one derails a working agent.
       if (t !== null) startedAt = t;
+    },
+    // #1168 — the panel concluded the agent behind the bridge socket is GONE.
+    //
+    // Deliberately not folded into noteBridgeClosed(): that name means "a socket
+    // closed", and the case this exists for is precisely the one where none does. A
+    // wedged orchestrator holds its connection OPEN and answers nothing, so the close
+    // listener never runs and the death goes unrecorded until the wedged process
+    // eventually dies — by which time the clock measures the user's restart instead of
+    // the outage. Overloading the socket-event name is what let two earlier attempts
+    // read as plausible while being wrong: one stamped the shared teardown helper
+    // (~17 call sites, most of them a LIVE orchestrator being re-pointed), the other
+    // stamped the handshake REDIAL, whose own doc calls it the agent-not-ready-YET
+    // case. Both converted a missed nudge into a false one, which is strictly worse.
+    //
+    // It records a CONCLUSION, not an interval, because no honest interval exists here.
+    // The panel cannot see when the agent behind an open socket stopped answering; it
+    // knows only that it has now given up on it, after the full bounded ladder of
+    // cold-start windows and redials that give-up costs. Manufacturing a duration from
+    // that moment would re-lose the nudge on exactly the fast recovery this is for, so
+    // the reader (`shouldNudgeAfterMidTaskReconnect`) weighs the flag AHEAD of the clock
+    // and this leaves `startedAt`/`outageMs` untouched: an outage a real close opened is
+    // still measured normally, and a death is not also charged as one.
+    noteAgentGone() {
+      agentGone = true;
     },
     noteHandshake() {
       if (startedAt === null) return; // ended no outage — records nothing
@@ -182,6 +232,13 @@ export function createBridgeOutageTracker({ now = () => Date.now() } = {}) {
       // satisfied by simply never nudging.
       startedAt = null;
       outageMs = 0;
+      // #1168 — a concluded death is turn-scoped evidence for the same reason a measured
+      // outage is, and this is the event that scopes it. It is also the whole safety
+      // argument for letting the flag outrank the clock: an orchestrator that turns out
+      // to be ALIVE re-announces its running turn, and that frame lands here and stands
+      // the conclusion down before the `ready` ack can act on it. A dead one has no turn
+      // to announce, so nothing arrives, the flag stands, and the nudge fires.
+      agentGone = false;
     },
     /** The outage the current turn has seen, in ms (0 = none).
      *
@@ -207,6 +264,11 @@ export function createBridgeOutageTracker({ now = () => Date.now() } = {}) {
       // reports no outage rather than a negative one.
       return t === null ? outageMs : Math.max(0, t - startedAt);
     },
+    /** #1168 — true when the panel concluded, during THIS turn, that the agent behind
+     *  the bridge socket is gone. Unlike outageMs() this is not re-derived from a clock:
+     *  it is the observation itself, and it survives the handshake that recovers the
+     *  connection because the nudge is decided one frame later, on the `ready` ack. */
+    agentGone: () => agentGone,
     /** True while the bridge is down — the outage has begun but not yet ended.
      *  Read by the tests that pin the open/closed transitions; the panel decides on
      *  outageMs() alone, so this stays a state ACCESSOR and never a second predicate. */


### PR DESCRIPTION
Closes #1168.

## The gap, restated in terms of what this build can actually do

The panel decides a turn needs resuming from **how long the bridge was down**, and that
clock is started by the socket `close` listener. A **wedged** orchestrator never fires
one: it holds the connection open and answers nothing. So the outage its death caused is
not merely mismeasured — **it is never opened at all**. The clock starts only when the
wedged process eventually exits, so a user who restarts the agent promptly measures the
**restart**: three seconds, under the 6s threshold, no nudge, turn stranded.

The issue's own triage comment established the two facts that change the shape of the fix,
and I re-verified both:

- `externalOrchestratorMode()` returns a hardcoded `true`, so `onHandshakeTimeout` always
  takes the external branch and `tryAutoReclaim` is unreachable (it re-guards on the same
  predicate at its first line).
- `force` appears **0 times** in `__init__.py` — the pack's `/connect` ignores it entirely.

So the panel **cannot respawn the orchestrator**, and no fix can be built on "record the
death when the panel kills it". The death must be concluded from the panel's own
observation or not at all.

## The fix

`noteAgentGone()` — a new tracker event — **opens an outage exactly as a close does**, at
the one place the panel concludes the agent behind the socket is gone.

That place is `showExternalHintOnce()`'s latch, and it is chosen rather than convenient.
Everything above it is the ladder of reasons the conclusion is *not earned yet*: the
patient cold-start window, the bounded handshake redial (the agent-not-ready-***yet***
case), and #1136's fallback dial for a configured URL that outlived its process. #1136
moved that latch there precisely to stop the panel over-claiming "no agent is listening",
and concluding a death is the identical claim. Stamping earlier is what sank both previous
attempts.

It is a separate method from `noteBridgeClosed()` for the **decision**, not the effect: a
close is *observed*, this is *concluded*, and only the caller can be trusted to have earned
it. Keeping the names apart is what stops this from being spelled the way the rejected
attempts were.

| | stamped at | why it was wrong |
|---|---|---|
| Attempt 1 | shared teardown helper | ~17 call sites (Disconnect, provider switch, soft reload, hard restart, tunnel re-point, autoconnect retarget). Most are a **live** orchestrator being re-pointed. |
| Attempt 2 | `tryHandshakeRedial` | Its own doc calls it the agent-not-ready-***yet*** case. Nothing dropped, nothing was killed. |

## What it deliberately does NOT do — and the review round that established that

My first draft passed the conclusion into `shouldNudgeAfterMidTaskReconnect` as a second
input that **outranked the clock**. The gate returned NO-SHIP, correctly.

The panel cannot distinguish the two states that latch collapses. *"The orchestrator died"*
and *"my own socket went stale while it kept working"* — a half-open TCP after a laptop
sleep, a NAT idle-kill, a VPN flap — both present as an open socket answering nothing, and
both reach the same give-up. With the threshold bypassed, the second sends *"your
connection dropped mid-task … continue exactly what you were doing"* into a turn that never
stopped: the exact harm both earlier attempts were rejected for, and a behaviour change
from `main`.

The draft's safety argument was that a surviving turn's `turn:working` re-announce would
stand the conclusion down first. **This repo already records that no such ordering is
guaranteed** — the #1163 test carries a comment saying it was rewritten specifically to
stop pinning that assumption, and `session-rebind.js` notes ten lines below that `ready`
goes out synchronously while the models frame comes from an async continuation.

The gap this issue reports is an outage the predicate **never got to see**, not one it
judges wrongly. So the reader is unchanged and the interval remains the sole gate:

- a wedge is now measured from where the panel concluded it (**~123s** in the reported
  sequence) instead of from the wedged process's exit (**~3s**);
- a conclusion the panel got **wrong** is measured too — a live orchestrator that answers
  again moments later measures short and is left alone;
- a genuine wedge requires the user to read the hint and restart the agent by hand, which
  never fits inside the 6s window.

A conclusion is evidence that an outage **began**, never that it was long enough to have
killed the turn.

#1166, which the issue named as a prerequisite (a stale mid-task marker on hard-restart
failure branches), is **closed** on main.

## Verification

Mutation, not a green suite. Each of these turns the suite **red**:

| mutation | result |
|---|---|
| delete the write site | ✗ red |
| method kept but emptied (records nothing) | ✗ red |
| drop the first-opener guard (a conclusion re-stamps a running outage) | ✗ red |
| turn start no longer closes an outage a conclusion opened | ✗ red |
| record moved **above** #1136's fallback (attempt-2's over-claim) | ✗ red |

One equivalent mutant survived and is not a gap: removing the `t !== null` clock guard is a
no-op because `readClock()` already normalises a non-finite reading to `null`.

The regression test for the gate's P1 pins the reviewer's exact sequence and **relies on no
frame ordering at all**. The wiring test now also asserts the predicate is called with the
outage *alone*, so the rejected shape cannot return silently. The call-site pin counts
occurrences (`=== 1`) rather than scanning teardown bodies — the previous negative pin
searched `stop()/setUrl()/destroy()` for a literal `bridgeOutage.` and would have **passed**
against the very design it named.

- `npm run test:unit` — **4532 pass, 0 fail**
- `check-panel-scope` — OK (a fresh worktree has no `node_modules`, and this gate silently
  skips without one; I linked one in. It is the only thing that catches a name resolving in
  a sibling function)
- `tsc --noEmit` — clean

## Out of scope, stated plainly

An **already-handshaken** socket that wedges still has no detector — the handshake timeout
only arms on a socket that opened and never handshook. Closing that needs a heartbeat,
which is a new mechanism under the freeze, not this bug.

---

codex was unavailable (account exhausted until 2026-08-19); gated by an independent
adversarial review instead. That review returned NO-SHIP on the first draft; the finding is
addressed above and re-gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
