### PR TITLE
fix(1198): the Settings path must not leave the saved default naming a backend it never reached

### DIFF
--- a/browser_tests/unit/settings-backend-default.test.mjs
+++ b/browser_tests/unit/settings-backend-default.test.mjs
@@ -1,0 +1,546 @@
+// #1198 — the Settings path commits the durable default before #1184's guard can abort.
+//
+// #1184 stopped `connectBackend()` committing anything until the old provider's session was
+// durably invalidated. The Settings dropdown slips past that entirely, because ComfyUI has
+// already written `SETTING_BACKEND` by the time it notifies the panel at all:
+//
+//   combo → ComfyUI writes the SAVED default → onChange → applyBackend → connectBackend →
+//   #1184's guard aborts → the saved default still names a backend never connected to.
+//
+// `STORAGE_KEY_BACKEND` (which #1184 leaves alone on an abort) shadows it on this machine,
+// so the damage only surfaces where there is no runtime pick to shadow it: a fresh profile,
+// another browser, a cleared site. That is what makes it worth a test rather than a look.
+//
+// THE HARD PART IS NOT THE ROLLBACK, IT IS ROLLING BACK WITHOUT THE STORM. Writing this
+// setting is what caused the 9181 "ready"/"waiting" connect storm, so the tests below drive
+// the panel's REAL onChange and REAL applyBackend over a model of the REAL ComfyUI settings
+// store, and count connects. A rollback that re-entered would show up as more than one.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import { BACKEND_SWITCH } from "../../web/js/lib/backend-switch.js";
+import {
+  SETTINGS_BACKEND_ROLLBACK,
+  createSettingsBackendDefault,
+  planSettingsBackendRollback,
+} from "../../web/js/lib/settings-backend-default.js";
+
+const PANEL_LF = readFileSync(
+  fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url)),
+  "utf8",
+).replace(/\r\n/g, "\n");
+
+const SETTING_BACKEND = "comfyui-mcp.defaultBackend";
+
+// ---------------------------------------------------------------------------
+// A model of ComfyUI's settings store, transcribed from the shipped frontend.
+//
+// From `src/platform/settings/settingStore.ts` (ComfyUI_frontend 1.50.3, read out of the
+// sourcemap shipped beside the bundle). All three behaviours below are load-bearing for
+// the fix, so they are modelled rather than assumed:
+//
+//   (A) `onChange(newValue, oldValue)` is dispatched SYNCHRONOUSLY from inside
+//       `setSettingValue`, and it is handed the PREVIOUS value;
+//   (B) `if (newValue === oldValue) return undefined` — an unchanged write is a complete
+//       no-op: no notification, no server call;
+//   (C) `settingValues[key] = newValue` and `await api.storeSetting(...)` both happen
+//       AFTER the notification, so a handler still reads the OLD value while it runs.
+//
+// `deferNotify` models a frontend that delivers the notification later instead. Nothing in
+// the settings API promises (A), and `suppressSettingOnChange` is documented in the panel as
+// best-effort for exactly that reason — so the fix has to hold in both modes, and is tested
+// in both.
+// ---------------------------------------------------------------------------
+function createComfySettingStore({ initial = {}, deferNotify = false } = {}) {
+  const values = { ...initial };
+  const handlers = new Map();
+  const serverWrites = [];
+  const queue = [];
+  return {
+    register: (key, onChange) => handlers.set(key, onChange),
+    get: (key) => values[key],
+    serverWrites,
+    /** ComfyUI's `settingStore.set`, in the order the real one does it. */
+    set(key, value) {
+      const oldValue = values[key];
+      if (value === oldValue) return; // (B)
+      const notify = () => handlers.get(key)?.(value, oldValue); // (A)
+      if (deferNotify) queue.push(notify);
+      else notify();
+      values[key] = value; // (C) — after the notification, not before
+      serverWrites.push({ key, value });
+    },
+    /** Deliver whatever a deferred frontend would have delivered later. */
+    drain() {
+      while (queue.length) queue.shift()();
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// The SHIPPED handler bodies, extracted and run.
+//
+// A module can be perfectly correct and never reached; the panel is 1.7MB of IIFE, so the
+// only way to prove these two are wired is to lift them out of the source and drive them.
+// ---------------------------------------------------------------------------
+function loneMatch(re, what) {
+  const all = [...PANEL_LF.matchAll(re)];
+  assert.equal(all.length, 1, `expected exactly 1 ${what}, got ${all.length}`);
+  return all[0][0];
+}
+
+const onChangeSrc = loneMatch(
+  /\n {6}onChange: \(v, previous\) => \{[\s\S]*?\n {6}\},/g,
+  "SETTING_BACKEND onChange",
+);
+const applyBackendSrc = loneMatch(
+  /\n {2}panelHooks\.applyBackend = async \(id, previous\) => \{[\s\S]*?\n {2}\};/g,
+  "panelHooks.applyBackend",
+);
+
+test("#1198 the extracted bodies really are the shipped ones", () => {
+  assert.match(onChangeSrc, /panelHooks\.applyBackend\?\.\(v, previous\)/, "onChange slice reaches the hook call");
+  assert.match(applyBackendSrc, /await connectBackend\(id\)/, "applyBackend slice reaches the switch");
+  // The onChange slice must be the one attached to SETTING_BACKEND and no other row. Every
+  // other setting in this list takes `(v)`, so the arity is the discriminator — assert the
+  // slice sits inside the SETTING_BACKEND block rather than trusting that.
+  const backendAt = PANEL_LF.indexOf("id: SETTING_BACKEND");
+  const sliceAt = PANEL_LF.indexOf(onChangeSrc);
+  assert.ok(backendAt > 0 && sliceAt > backendAt, "the extracted onChange must belong to SETTING_BACKEND");
+  assert.equal(
+    PANEL_LF.slice(backendAt + "id: SETTING_BACKEND".length, sliceAt).indexOf("id: SETTING_"),
+    -1,
+    "…and no other setting may start between the two",
+  );
+});
+
+/**
+ * Wire the real onChange + real applyBackend + real settings-backend-default module to a
+ * modelled ComfyUI store. Only `connectBackend` is a stub — it is the thing under whose
+ * outcome this whole decision hangs.
+ */
+function buildPanel({
+  storedBackend = "claude",
+  selectedBackend = "claude",
+  outcome = BACKEND_SWITCH.INVALIDATE_FAILED,
+  deferNotify = false,
+  onConnect = null,
+} = {}) {
+  const store = createComfySettingStore({ initial: { [SETTING_BACKEND]: storedBackend }, deferNotify });
+  const transcript = [];
+  const connects = [];
+
+  // The panel's own module-scope helpers, same shape as the real ones.
+  let suppressSettingOnChange = false;
+  const getSetting = (id) => store.get(id);
+  const setSetting = (id, value) => {
+    try {
+      suppressSettingOnChange = true;
+      store.set(id, value);
+    } finally {
+      suppressSettingOnChange = false;
+    }
+  };
+  const settingsBackendDefault = createSettingsBackendDefault({
+    read: () => getSetting(SETTING_BACKEND),
+    write: (value) => setSetting(SETTING_BACKEND, value),
+  });
+
+  const panelHooks = { applyBackend: null };
+  const connectBackend = async (id) => {
+    connects.push(id);
+    // A real switch awaits the invalidate before it can decide, so the window this fix has
+    // to survive is real. `onConnect` is how a test moves the world during that window.
+    await null;
+    if (onConnect) onConnect({ id, store, setSetting });
+    const result = typeof outcome === "function" ? outcome(id) : outcome;
+    return { switched: result === BACKEND_SWITCH.SWITCHED, reason: result };
+  };
+
+  const applyFactory = new Function(
+    "deps",
+    `
+    let { selectedBackend } = deps;
+    const { panelHooks, appendSystem, tr, BACKEND_LABELS, connectBackend, BACKEND_SWITCH, settingsBackendDefault } = deps;
+    ${applyBackendSrc}
+    return panelHooks.applyBackend;
+    `,
+  );
+  panelHooks.applyBackend = applyFactory({
+    selectedBackend,
+    panelHooks,
+    appendSystem: (m) => transcript.push(m),
+    tr: (_key, fallback, params) =>
+      fallback.replace(/\{(\w+)\}/g, (_m, k) => (params && params[k] != null ? params[k] : `{${k}}`)),
+    BACKEND_LABELS: { claude: "Claude", codex: "ChatGPT (Codex)", gemini: "Gemini" },
+    connectBackend,
+    BACKEND_SWITCH,
+    settingsBackendDefault,
+  });
+
+  // The onChange body reads `suppressSettingOnChange` and `settingsArmed` as live module
+  // bindings, so they are `let`s inside the built scope rather than snapshotted parameters.
+  const onChangeFactory = new Function(
+    "deps",
+    `
+    let settingsArmed = deps.settingsArmed;
+    const { panelHooks, settingsBackendDefault } = deps;
+    let suppressSettingOnChange = false;
+    const row = {
+      ${onChangeSrc.trim().replace(/,$/, "")}
+    };
+    return {
+      onChange: row.onChange,
+      setSuppress: (x) => { suppressSettingOnChange = x; },
+      readSuppress: () => suppressSettingOnChange,
+    };
+  `,
+  );
+  const built = onChangeFactory({ settingsArmed: true, panelHooks, settingsBackendDefault });
+
+  // The panel's real `setSetting` raises the suppress flag around ITS writes. The extracted
+  // onChange closes over its own copy, so mirror the flag across for the duration of a write
+  // — otherwise the "identified before suppressed" ordering could never be exercised.
+  store.register(SETTING_BACKEND, (v, previous) => {
+    built.setSuppress(suppressSettingOnChange);
+    try {
+      return built.onChange(v, previous);
+    } finally {
+      built.setSuppress(false);
+    }
+  });
+
+  return {
+    store,
+    transcript,
+    connects,
+    settingsBackendDefault,
+    /** What a user picking a row in the Settings combo does. */
+    pick: (id) => store.set(SETTING_BACKEND, id),
+    savedDefault: () => store.get(SETTING_BACKEND),
+  };
+}
+
+/** Let every promise chain started by a synchronous notification settle. */
+const settle = async () => { for (let i = 0; i < 12; i++) await Promise.resolve(); };
+
+// ---------------------------------------------------------------------------
+// THE DEFECT
+// ---------------------------------------------------------------------------
+
+test("#1198 an ABORTED Settings switch does not leave the saved default naming it", async () => {
+  const p = buildPanel({ storedBackend: "claude", selectedBackend: "claude" });
+  p.pick("codex");
+  await settle();
+
+  assert.deepEqual(p.connects, ["codex"], "the switch is attempted exactly once");
+  assert.equal(
+    p.savedDefault(),
+    "claude",
+    "the saved default must not name a backend the panel never connected to — that is #1198",
+  );
+  // The server write is what outlives the tab and wins on a fresh profile, so assert the
+  // durable half explicitly rather than inferring it from the in-memory value.
+  assert.deepEqual(
+    p.store.serverWrites.map((w) => w.value),
+    ["codex", "claude"],
+    "the restore must be PERSISTED, not just corrected in memory",
+  );
+});
+
+test("#1198 the abort does not claim the default changed", async () => {
+  const p = buildPanel();
+  p.pick("codex");
+  await settle();
+  assert.deepEqual(
+    p.transcript,
+    [],
+    "announcing 'Default backend → X' for a switch that was then rolled back is the false-reassurance shape this repo keeps fixing",
+  );
+});
+
+test("#1198 a SUCCESSFUL Settings switch keeps the new default, and says so", async () => {
+  const p = buildPanel({ outcome: BACKEND_SWITCH.SWITCHED });
+  p.pick("codex");
+  await settle();
+  assert.equal(p.savedDefault(), "codex", "a switch that happened must keep the default it set");
+  assert.deepEqual(p.transcript, ["Default backend → ChatGPT (Codex)."]);
+});
+
+test("#1198 a FIRST CONNECT via Settings keeps the default too", async () => {
+  // CONNECTED, not SWITCHED: nothing was live, so there was no session to invalidate and no
+  // switch to abort. `switched` is false here exactly as it is for an abort, which is why
+  // the rollback keys on `reason` — a boolean would roll this one back and wipe the
+  // default the user just chose.
+  const p = buildPanel({ outcome: BACKEND_SWITCH.CONNECTED });
+  p.pick("codex");
+  await settle();
+  assert.equal(p.savedDefault(), "codex", "a first connect is not an abort");
+  assert.deepEqual(p.transcript, ["Default backend → ChatGPT (Codex)."]);
+});
+
+// ---------------------------------------------------------------------------
+// THE 9181 STORM — the reason the obvious fix was called wrong in the issue
+// ---------------------------------------------------------------------------
+
+test("#1198 the rollback does not re-enter connectBackend — the 9181 storm stays fixed", async () => {
+  const p = buildPanel();
+  p.pick("codex");
+  await settle();
+  assert.deepEqual(
+    p.connects,
+    ["codex"],
+    "the restore write must not come back round through onChange → applyBackend → connectBackend",
+  );
+  assert.equal(p.settingsBackendDefault.outstandingWrite(), null, "and its echo must have been consumed");
+});
+
+test("#1198 …and still does not, when the notification is DEFERRED", async () => {
+  // The scar's premise: ComfyUI fires onChange after `suppressSettingOnChange` has reset. It
+  // does not on 1.50.3 — the dispatch is synchronous — but nothing in the API promises that,
+  // so the marker has to carry the fix on its own with the flag contributing nothing.
+  const p = buildPanel({ deferNotify: true });
+  p.pick("codex");
+  p.store.drain();
+  await settle();
+  p.store.drain();
+  await settle();
+
+  assert.deepEqual(p.connects, ["codex"], "a deferred echo must be IDENTIFIED, not raced");
+  assert.equal(p.savedDefault(), "claude", "and the rollback still lands");
+});
+
+// ---------------------------------------------------------------------------
+// THE RACES
+// ---------------------------------------------------------------------------
+
+test("#1198 a rollback never clobbers a pick the user made while the switch was awaiting", async () => {
+  // The compare-and-swap. The invalidate is awaited, so the user has a real window in which
+  // to change the setting again; putting the old value back at that point would silently
+  // discard a choice they did make — worse than the defect being fixed. Here the second
+  // switch SUCCEEDS, so the setting must be left naming it.
+  const p = buildPanel({
+    outcome: (id) => (id === "codex" ? BACKEND_SWITCH.INVALIDATE_FAILED : BACKEND_SWITCH.SWITCHED),
+    onConnect: ({ id, store }) => {
+      if (id === "codex") store.set(SETTING_BACKEND, "gemini");
+    },
+  });
+  p.pick("codex");
+  await settle();
+  assert.deepEqual(p.connects, ["codex", "gemini"], "the second pick really is attempted");
+  assert.equal(p.savedDefault(), "gemini", "the newer pick, which SUCCEEDED, must survive the stale rollback");
+});
+
+test("#1198 two overlapping aborted switches unwind to the last backend actually reached", async () => {
+  // Not exotic: a wedged history store fails EVERY switch, so a user who tries twice lands
+  // here every time. The second rollback's `previous` is the first switch's un-reached
+  // backend ("codex"), so restoring to it would leave the saved default naming a backend the
+  // panel never connected to — this defect, one step down the chain. It must reach "claude".
+  const p = buildPanel({
+    onConnect: ({ store }) => store.set(SETTING_BACKEND, "gemini"),
+  });
+  p.pick("codex");
+  await settle();
+  assert.deepEqual(p.connects, ["codex", "gemini"]);
+  assert.equal(
+    p.savedDefault(),
+    "claude",
+    "unwinding one step lands on 'codex', which was never reached either",
+  );
+});
+
+test("#1198 the restore target is the SETTING's previous value, not the live backend", async () => {
+  // These legitimately diverge: a chip pick moves the runtime backend WITHOUT touching the
+  // saved default (#1184's FIX 1). Here the saved default is "claude" while the panel is
+  // running on "codex" from a chip. Restoring to the live backend would write a default the
+  // user never chose — a different wrong-default bug wearing the fix's clothes.
+  const p = buildPanel({ storedBackend: "claude", selectedBackend: "codex" });
+  p.pick("gemini");
+  await settle();
+  assert.equal(p.savedDefault(), "claude", "roll back to what the SETTING held, not to selectedBackend");
+});
+
+test("#1198 re-picking the backend the panel is already on stays a no-op", async () => {
+  const p = buildPanel({ storedBackend: "claude", selectedBackend: "codex" });
+  p.pick("codex");
+  await settle();
+  assert.deepEqual(p.connects, [], "applyBackend's idempotence guard still short-circuits");
+  assert.equal(p.savedDefault(), "codex", "and the default the user chose is left alone");
+});
+
+// ---------------------------------------------------------------------------
+// THE PLANNER, branch by branch
+// ---------------------------------------------------------------------------
+
+test("#1198 only the #1184 abort rolls back — every other outcome opts out", () => {
+  for (const outcome of [BACKEND_SWITCH.SWITCHED, BACKEND_SWITCH.CONNECTED, "some_future_reason", undefined]) {
+    assert.deepEqual(
+      planSettingsBackendRollback({ outcome, attempted: "codex", previous: "claude", current: "codex" }),
+      { restore: false, to: null, reason: SETTINGS_BACKEND_ROLLBACK.NOT_ABORTED },
+      `${String(outcome)} must not inherit a rollback by falling through`,
+    );
+  }
+});
+
+test("#1198 the planner refuses without a usable previous value", () => {
+  const base = { outcome: BACKEND_SWITCH.INVALIDATE_FAILED, attempted: "codex", current: "codex" };
+  for (const previous of [undefined, null, "", 7, {}, "codex"]) {
+    assert.equal(
+      planSettingsBackendRollback({ ...base, previous }).reason,
+      SETTINGS_BACKEND_ROLLBACK.NO_PREVIOUS,
+      `previous=${JSON.stringify(previous)} gives nothing to restore to`,
+    );
+  }
+});
+
+test("#1198 the planner refuses when the setting has moved on", () => {
+  assert.deepEqual(
+    planSettingsBackendRollback({
+      outcome: BACKEND_SWITCH.INVALIDATE_FAILED,
+      attempted: "codex",
+      previous: "claude",
+      current: "gemini",
+    }),
+    { restore: false, to: null, reason: SETTINGS_BACKEND_ROLLBACK.SUPERSEDED },
+  );
+});
+
+test("#1198 the planner restores when, and only when, all three hold", () => {
+  assert.deepEqual(
+    planSettingsBackendRollback({
+      outcome: BACKEND_SWITCH.INVALIDATE_FAILED,
+      attempted: "codex",
+      previous: "claude",
+      current: "codex",
+    }),
+    { restore: true, to: "claude", reason: SETTINGS_BACKEND_ROLLBACK.RESTORED },
+  );
+});
+
+// ---------------------------------------------------------------------------
+// THE ECHO MARKER
+// ---------------------------------------------------------------------------
+
+function marker({ current = "codex", write = () => {} } = {}) {
+  return createSettingsBackendDefault({ read: () => current, write });
+}
+
+test("#1198 isSelfWrite is false when the panel has written nothing", () => {
+  assert.equal(marker().isSelfWrite("claude"), false);
+});
+
+test("#1198 the marker is consumed once and does not linger", () => {
+  const d = marker();
+  d.rollback({ outcome: BACKEND_SWITCH.INVALIDATE_FAILED, attempted: "codex", previous: "claude" });
+  assert.equal(d.outstandingWrite(), "claude", "a deferred frontend has not delivered it yet");
+  assert.equal(d.isSelfWrite("claude"), true, "the echo is identified");
+  assert.equal(d.isSelfWrite("claude"), false, "a SECOND claude — a real pick — is not swallowed");
+});
+
+test("#1198 a marker that is never delivered cannot eat a later real pick", () => {
+  // Self-limiting. If our write produced no notification (fact (B): ComfyUI skips the
+  // dispatch entirely when the value is unchanged), the FIRST notification of any kind must
+  // clear the marker, or it sits there waiting to swallow a change the user really made.
+  const d = marker();
+  d.rollback({ outcome: BACKEND_SWITCH.INVALIDATE_FAILED, attempted: "codex", previous: "claude" });
+  assert.equal(d.isSelfWrite("gemini"), false, "a different value is not ours");
+  assert.equal(d.outstandingWrite(), null, "…and it ends the outstanding write");
+  assert.equal(d.isSelfWrite("claude"), false, "so a later genuine pick of claude gets through");
+});
+
+test("#1198 a write that throws leaves no marker behind", () => {
+  const d = marker({
+    write: () => {
+      throw new Error("settings store unavailable");
+    },
+  });
+  assert.throws(() =>
+    d.rollback({ outcome: BACKEND_SWITCH.INVALIDATE_FAILED, attempted: "codex", previous: "claude" }),
+  );
+  assert.equal(d.outstandingWrite(), null, "no notification is coming, so nothing may wait for one");
+});
+
+test("#1198 a refused rollback writes nothing and marks nothing", () => {
+  const writes = [];
+  const d = marker({ current: "gemini", write: (v) => writes.push(v) });
+  const plan = d.rollback({ outcome: BACKEND_SWITCH.INVALIDATE_FAILED, attempted: "codex", previous: "claude" });
+  assert.equal(plan.reason, SETTINGS_BACKEND_ROLLBACK.SUPERSEDED);
+  assert.deepEqual(writes, []);
+  assert.equal(d.outstandingWrite(), null);
+});
+
+// ---------------------------------------------------------------------------
+// WIRING — the module can be right and dead
+// ---------------------------------------------------------------------------
+
+test("#1198 WIRING: the echo is identified BEFORE the suppress flag is consulted", () => {
+  // Order matters and is invisible to an outcome test. ComfyUI dispatches onChange
+  // synchronously from inside setSetting, so the rollback's echo arrives while
+  // `suppressSettingOnChange` is still true. If the flag were checked first it would swallow
+  // the notification and leave the marker outstanding — armed to eat the user's next real
+  // pick of that backend.
+  const code = onChangeSrc
+    .split("\n")
+    .filter((l) => !l.trim().startsWith("//"))
+    .join("\n");
+  const self = code.indexOf("settingsBackendDefault.isSelfWrite(v)");
+  const suppress = code.indexOf("suppressSettingOnChange");
+  assert.ok(self > 0, "the handler must ask whether the notification is the panel's own");
+  assert.ok(suppress > 0, "the best-effort flag is still there for writes that are not ours");
+  assert.ok(self < suppress, "isSelfWrite must be asked FIRST, or the flag swallows the echo");
+});
+
+test("#1198 WIRING: applyBackend forwards the previous value and branches on the reason", () => {
+  const code = applyBackendSrc
+    .split("\n")
+    .filter((l) => !l.trim().startsWith("//"))
+    .join("\n");
+  assert.match(
+    code,
+    /reason === BACKEND_SWITCH\.INVALIDATE_FAILED/,
+    "a boolean `switched` cannot tell an abort from a first connect — it must branch on the reason",
+  );
+  assert.match(
+    code,
+    /settingsBackendDefault\.rollback\(\{ outcome: reason, attempted: id, previous \}\)/,
+    "the rollback must be handed the setting's previous value, not left to guess one",
+  );
+  // The announcement must sit AFTER the outcome is known. Before this fix it was the first
+  // statement in the function, so an aborted switch printed a change to the durable default
+  // that the panel then undid.
+  const announce = code.indexOf("panel.default_backend_switched");
+  const connect = code.indexOf("await connectBackend(id)");
+  assert.ok(announce > 0 && connect > 0, "both must still be present");
+  assert.ok(announce > connect, "the default may only be announced once the switch has actually happened");
+});
+
+test("#1198 WIRING: the Settings path is the ONLY writer of the saved default", () => {
+  // #1184's FIX 1: a chip or model-popover switch is session-only and must leave the saved
+  // default alone. The rollback is a new write to that setting, so pin that it did not
+  // reappear inside connectBackend, where it caused the 9181 storm.
+  const at = PANEL_LF.indexOf("async function connectBackend(id) {");
+  assert.ok(at > 0);
+  const body = PANEL_LF.slice(at, PANEL_LF.indexOf("\n  }", at))
+    .split("\n")
+    .filter((l) => !l.trim().startsWith("//"))
+    .join("\n");
+  assert.doesNotMatch(
+    body,
+    /setSetting\(SETTING_BACKEND/,
+    "writing the saved default from the switch path is the re-entrant write that stormed",
+  );
+});
+
+test("#1198 WIRING: connectBackend returns the whole result, reason included", () => {
+  const at = PANEL_LF.indexOf("async function connectBackend(id) {");
+  const body = PANEL_LF.slice(at, PANEL_LF.indexOf("\n  }", at));
+  assert.match(body, /return await runBackendSwitch\(id, \{/, "the reason must survive the call");
+  assert.doesNotMatch(
+    body,
+    /const \{ switched \} = await runBackendSwitch/,
+    "destructuring only `switched` throws away the one field that separates an abort from a connect",
+  );
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -203,6 +203,10 @@ import { describeNodeDefRefresh } from "./lib/node-def-refresh.js";
 // #1184 — the ORDER a backend switch commits in. A module because the defect is an
 // ordering property, and order cannot be asserted against the 1.7MB panel IIFE.
 import { BACKEND_SWITCH, runBackendSwitch } from "./lib/backend-switch.js";
+// #1198 — the Settings path's half of that guard. ComfyUI has already written the saved
+// default by the time it notifies us, so an aborted switch has to be undone there rather
+// than merely not committed.
+import { createSettingsBackendDefault } from "./lib/settings-backend-default.js";
 import { fetchNodeDefsWithRetry, OBJECT_INFO_RETRY_DELAYS_MS } from "./lib/object-info-retry.js";
 import { createObjectInfoCache, CACHE_OUTCOME } from "./lib/object-info-cache.js";
 import { fetchWholeObjectInfo, objectInfoOracleFailureNote } from "./lib/object-info-oracle.js";
@@ -4144,6 +4148,23 @@ function setSetting(id, value) {
   }
 }
 
+/** #1198 — the panel's owner of SETTING_BACKEND, the SAVED default.
+ *
+ *  ComfyUI persists the combo's new value and only then notifies us, so by the time
+ *  #1184's guard can abort the switch the durable default already names a backend the
+ *  panel may never reach — and unlike `STORAGE_KEY_BACKEND` (which the abort already
+ *  leaves alone) that value is not browser-scoped, so it wins on a fresh profile.
+ *
+ *  Undoing it means writing the setting again, which is the re-entrant write that caused
+ *  the 9181 connect storm. This does it safely: a compare-and-swap, so a stale rollback
+ *  cannot clobber a newer pick, plus a value-marker that IDENTIFIES the resulting echo
+ *  instead of trying to suppress it inside a time window. See lib/settings-backend-default.js
+ *  for what the shipped ComfyUI settings store actually does and why that is enough. */
+const settingsBackendDefault = createSettingsBackendDefault({
+  read: () => getSetting(SETTING_BACKEND),
+  write: (value) => setSetting(SETTING_BACKEND, value),
+});
+
 // Drive the secure token flow from a Settings button. Reuses the SAME masked
 // secure input the agent's panel_request_secret tool already opens — the pasted
 // value rides the existing request_secret bridge command straight into the
@@ -4706,9 +4727,20 @@ function panelSettingsList() {
         ];
       },
       defaultValue: "claude",
-      onChange: (v) => {
+      // #1198 — `previous` is ComfyUI's `oldValue`, the second argument it has always passed
+      // and this handler always dropped. It is the ONLY record of what the saved default held
+      // before this change: the store is overwritten the moment this returns, so by the time
+      // the switch has finished awaiting there is nothing left to read. Without it an aborted
+      // switch has no value to roll back to.
+      onChange: (v, previous) => {
+        // ASKED FIRST, BEFORE the suppress flag, and that order is load-bearing. ComfyUI
+        // dispatches onChange synchronously from inside setSetting, so the panel's own
+        // rollback echoes back while `suppressSettingOnChange` is still true — letting the
+        // flag win here would swallow the notification and leave the rollback's marker
+        // outstanding, armed to eat the user's next real pick of that backend.
+        if (settingsBackendDefault.isSelfWrite(v)) return;
         if (suppressSettingOnChange || !settingsArmed) return;
-        panelHooks.applyBackend?.(v);
+        panelHooks.applyBackend?.(v, previous);
       },
     },
     // mcp#884 — the "Chat conversation scope" combo is retired: the conversation
@@ -30731,7 +30763,17 @@ function buildPanel() {
     //
     // Committing later rather than rolling back: an undo would have to restore six pieces
     // of state, and `armContext` has no disarm affordance at all.
-    const { switched } = await runBackendSwitch(id, {
+    //
+    // #1198 — the RESULT is returned whole, `reason` included, not just `switched`. The
+    // boolean cannot tell the Settings path what it needs to know: it is false both for an
+    // abort (the panel is still on the old backend, so the saved default must be rolled
+    // back) and for an ordinary first connect or re-pick (the panel IS on `id`, so the
+    // saved default is correct and must stand). Only `reason` separates those two.
+    //
+    // Callers must branch on `reason`, never on this object's truthiness — an object is
+    // always truthy, so `if (await connectBackend(x))` would read as "it switched" on the
+    // abort path too. The three call sites that ignore the result are unaffected.
+    return await runBackendSwitch(id, {
       liveBackend: () => connectedBackend,
       pickedBackend: () => selectedBackend,
       // What the INCOMING backend already has, answered by the STORE under that backend's
@@ -30829,7 +30871,6 @@ function buildPanel() {
         );
       },
     });
-    return switched;
   }
 
   // Soft reload: pick up new code WITHOUT restarting ComfyUI, keeping this
@@ -33136,14 +33177,35 @@ function buildPanel() {
   // idempotent (no-ops when the value already matches) so a setSetting→onChange
   // echo can't loop. Cleared in destroy() so a stale closure can't drive a torn-down
   // panel; the most-recently-mounted panel owns the hooks.
-  panelHooks.applyBackend = (id) => {
+  // #1198 — `previous` is what SETTING_BACKEND held before ComfyUI overwrote it, handed to
+  // us by the settings store. This is the path that owns the SAVED default, and the only
+  // one allowed to write it: a chip or model-popover switch is session-only and must leave
+  // it alone (#1184's FIX 1).
+  panelHooks.applyBackend = async (id, previous) => {
     if (!id || id === selectedBackend) return;
-    appendSystem(tr("panel.default_backend_switched", "Default backend → {backend}.", { backend: BACKEND_LABELS[id] || id }));
     // Route through connectBackend, which CENTRALLY seeds prefs from the new
     // backend's group before connecting (same path as the chips / model-popover
     // provider row) — exactly ONE connect, and the single post-handshake catalog
     // push carries the new backend's values. No set_options is sent here.
-    connectBackend(id);
+    const { reason } = await connectBackend(id);
+    // #1198 — the abort. ComfyUI has ALREADY persisted the new value; #1184's guard runs
+    // too late to stop that, so this puts it back. `rollback` is a compare-and-swap and
+    // no-ops unless the setting still holds the backend whose switch failed, so a user who
+    // changed it again while the invalidate was awaiting keeps their newer choice.
+    if (reason === BACKEND_SWITCH.INVALIDATE_FAILED) {
+      settingsBackendDefault.rollback({ outcome: reason, attempted: id, previous });
+      // Deliberately silent: connectBackend's `disclose` has already said the switch did
+      // not happen, and with the default restored that line is now true of the saved
+      // default too. A second line saying so would need a new catalog key, and the English
+      // catalog is frozen (#1135).
+      return;
+    }
+    // ANNOUNCED ONLY ONCE IT IS TRUE. This used to be printed before the switch was even
+    // attempted, so an aborted switch left the transcript asserting a change to the durable
+    // default that the panel then undid — the false-reassurance shape this repo keeps
+    // fixing. It lands just after connectAgent's "connecting" line now, which reads as the
+    // confirmation it actually is.
+    appendSystem(tr("panel.default_backend_switched", "Default backend → {backend}.", { backend: BACKEND_LABELS[id] || id }));
   };
   // mcp#884 — panelHooks.applyChatScope is gone with the retired scope setting:
   // its only caller was the removed combo's onChange, and keeping a live scope

--- a/web/js/lib/settings-backend-default.js
+++ b/web/js/lib/settings-backend-default.js
@@ -1,0 +1,235 @@
+// #1198 — the SETTINGS path commits the durable default before #1184's guard can abort.
+//
+// #1184 made `connectBackend()` commit nothing until the old provider's session had been
+// durably invalidated. It cannot cover the Settings dropdown, because that path commits
+// BEFORE `connectBackend` is ever called — and the commit it makes is the durable one:
+//
+//   Settings combo → ComfyUI writes SETTING_BACKEND → onChange → applyBackend →
+//   connectBackend → [#1184's guard aborts]
+//
+// `SETTING_BACKEND` is the SAVED DEFAULT. It lives in comfy.settings.json, outlives the
+// tab, and — unlike `STORAGE_KEY_BACKEND`, which #1184 already leaves untouched on an
+// abort — it is not browser-scoped, so it wins on a fresh profile (a different browser,
+// a cleared site, an incognito window) where there is no runtime pick to shadow it. The
+// panel was left with a durable default naming a backend it had never connected to.
+//
+// ---------------------------------------------------------------------------
+// WHAT COMFYUI ACTUALLY DOES, read from the shipped frontend rather than assumed
+// ---------------------------------------------------------------------------
+//
+// From `src/platform/settings/settingStore.ts` (ComfyUI_frontend 1.50.3, via the
+// sourcemap next to the bundle), which `app.ui.settings.setSettingValue` delegates to:
+//
+//     function applySettingLocally(key, value) {
+//       const newValue = tryMigrateDeprecatedValue(settingsById.value[key], cloneDeep(value))
+//       const oldValue = get(key)
+//       if (newValue === oldValue) return undefined        // (B)
+//       onChange(settingsById.value[key], newValue, oldValue)   // (A) — SYNCHRONOUS
+//       settingValues.value[key] = typedNewValue
+//       return { previousValue: oldValue, newValue: typedNewValue }
+//     }
+//     async function set(key, value) {
+//       const applied = applySettingLocally(key, value)
+//       if (applied === undefined) return
+//       await api.storeSetting(key, applied.newValue)      // (C) — the SERVER write, LAST
+//     }
+//
+// Three facts fall out, and this module is built on the second and third:
+//
+//   (A) `onChange` is dispatched SYNCHRONOUSLY, from inside `setSettingValue`, and it is
+//       handed the PREVIOUS value as its second argument. The panel's handler ignored that
+//       argument; it is the only thing that knows what to restore to, because by the time
+//       the switch has finished awaiting, the store has already been overwritten.
+//   (B) Writing a value EQUAL to the stored one does nothing at all — no `onChange`, no
+//       server write. So a restore is free when there is nothing to restore.
+//   (C) The durable (server) write happens AFTER the notification. The issue described the
+//       order as "persists, then notifies"; it is the other way round. That does not make
+//       the defect go away — `onChange` cannot veto, its return value is discarded, and
+//       (C) runs unconditionally once the handler returns — but it is why option 1 in the
+//       issue ("validate before ComfyUI persists") is not expressible: there is no
+//       pre-change hook, only a notification that is already too late to refuse.
+//
+// ---------------------------------------------------------------------------
+// WHY THIS IS A COMPARE-AND-SWAP, AND WHY THAT IS NOT THE 9181 STORM
+// ---------------------------------------------------------------------------
+//
+// The panel carries a scar from rolling this setting back before. `connectBackend` used to
+// call `setSetting(SETTING_BACKEND, id)`, which re-entered through `SETTING_BACKEND.onChange`
+// → `applyBackend` → `connectBackend` → `setSetting` → … so each switch overlapped several
+// connects and the bridge's close-old-on-new-hello looped. That is the 9181 "ready"/"waiting"
+// storm, and `suppressSettingOnChange` is documented as BEST-EFFORT precisely because it is a
+// time window: set true, write, set false — which covers the notification only if it is
+// delivered synchronously, and nothing in the API promises that.
+//
+// This module does not re-enter that loop, for two independent reasons:
+//
+//   1. THE DECISION IS A CAS, and JavaScript makes it atomic for free. `rollback` reads the
+//      current value and writes the previous one in ONE synchronous block, so nothing can be
+//      interleaved between the read and the write. If the setting no longer holds the value
+//      whose switch aborted, somebody else has moved it since and this rollback is stale —
+//      it does nothing rather than clobbering a newer pick. That is the entire hazard of a
+//      late rollback, and it is closed by construction rather than by timing.
+//
+//   2. THE ECHO IS IDENTIFIED, NOT SUPPRESSED. `rollback` records the value it is about to
+//      write; `isSelfWrite` consumes that record when the matching notification arrives.
+//      Because the marker is a VALUE rather than a window, it is correct whether the
+//      notification is synchronous (today) or deferred (any future frontend) — which is the
+//      thing `suppressSettingOnChange` cannot promise. The marker is self-limiting: the
+//      FIRST notification of any kind ends it, so a write that is never notified cannot
+//      leave a marker lying in wait to swallow a genuine pick later.
+//
+// The rollback is also the only `SETTING_BACKEND` write on this path, and it only ever
+// writes a value BACKWARDS to one the setting already held. It cannot drive the panel to a
+// backend nobody asked for, which is what the old re-entrant write did.
+
+import { BACKEND_SWITCH } from "./backend-switch.js";
+
+/** Why a rollback did or did not happen. For the caller and for tests. */
+export const SETTINGS_BACKEND_ROLLBACK = Object.freeze({
+  /** The setting was put back to the value it held before the aborted switch. */
+  RESTORED: "restored",
+  /** The switch was not aborted — the panel really is on the new backend. */
+  NOT_ABORTED: "not_aborted",
+  /** The setting has moved on since; a stale rollback must not clobber a newer pick. */
+  SUPERSEDED: "superseded",
+  /** Nothing usable to restore to, so leaving it alone is the lesser wrong. */
+  NO_PREVIOUS: "no_previous",
+});
+
+/**
+ * Decide whether the saved default must be put back, and to what.
+ *
+ * Pure, so the decision can be tested apart from the write. Every branch is a REFUSAL to
+ * write except the last one: a rollback that fires when it should not is worse than the
+ * defect it fixes, because it discards a choice the user did make.
+ *
+ * @param {{
+ *   outcome: string,            // the `reason` from `runBackendSwitch`
+ *   attempted: string,          // the backend the Settings combo asked for
+ *   previous: unknown,          // ComfyUI's `oldValue` — what the setting held before
+ *   current: unknown,           // what the setting holds NOW, read in the same tick
+ * }} q
+ * @returns {{restore: boolean, to: string|null, reason: string}}
+ */
+export function planSettingsBackendRollback({ outcome, attempted, previous, current } = {}) {
+  // OPT IN, never opt out. Only the #1184 abort leaves the panel on a different backend
+  // than the setting names; SWITCHED and CONNECTED both mean the panel really is on
+  // `attempted`, so the saved default is correct and must stand. A future outcome has to
+  // name itself here rather than inherit a rollback by falling through a `!== SWITCHED`.
+  if (outcome !== BACKEND_SWITCH.INVALIDATE_FAILED) {
+    return { restore: false, to: null, reason: SETTINGS_BACKEND_ROLLBACK.NOT_ABORTED };
+  }
+  // ComfyUI 1.50.3 always passes `oldValue` (it defaults through `getDefaultValue`, and this
+  // setting declares `defaultValue: "claude"`), so this guard is for a frontend that does
+  // not. There is deliberately no fallback to `selectedBackend`: the two legitimately
+  // diverge — a chip pick moves the runtime backend WITHOUT touching the saved default
+  // (that is #1184's FIX 1) — so restoring to it would write a default the user never
+  // chose, turning a wrong-default bug into a different wrong-default bug.
+  if (typeof previous !== "string" || !previous || previous === attempted) {
+    return { restore: false, to: null, reason: SETTINGS_BACKEND_ROLLBACK.NO_PREVIOUS };
+  }
+  // THE CAS. Read in the same synchronous block as the write that follows, so "still ours"
+  // cannot go stale between the two.
+  if (current !== attempted) {
+    return { restore: false, to: null, reason: SETTINGS_BACKEND_ROLLBACK.SUPERSEDED };
+  }
+  return { restore: true, to: previous, reason: SETTINGS_BACKEND_ROLLBACK.RESTORED };
+}
+
+/**
+ * The panel's owner of `SETTING_BACKEND`: it performs the rollback and recognises the
+ * notification that rollback causes.
+ *
+ * @param {{read: () => unknown, write: (value: string) => void}} io
+ *   `read`/`write` are the panel's `getSetting`/`setSetting` bound to SETTING_BACKEND.
+ */
+export function createSettingsBackendDefault({ read, write }) {
+  /** The value this module last wrote and has not yet seen come back, or null. */
+  let outstanding = null;
+
+  /** A restore that was SUPERSEDED, kept so the switch that superseded it can finish the job.
+   *
+   *  Two overlapping Settings switches that BOTH abort is not exotic: when the history store
+   *  is wedged every switch aborts, so a user who tries twice hits it every time. The second
+   *  rollback's `previous` is then the FIRST switch's un-reached backend, and restoring to it
+   *  would land the saved default on a backend the panel never connected to — the very
+   *  defect this module exists to stop, one step down the chain.
+   *
+   *  `{displaced, to}` says "the value `displaced` is not a real resting place; anything that
+   *  would restore to it should restore to `to` instead". Because `to` is itself resolved
+   *  through this table before being stored, a chain of any depth collapses to the last value
+   *  the panel actually rested on rather than only unwinding one step. */
+  let superseded = null;
+
+  return {
+    /**
+     * Is this notification the panel's own rollback echoing back?
+     *
+     * MUST be consulted BEFORE `suppressSettingOnChange`, or the two fight: under today's
+     * synchronous dispatch the suppress flag is still true when the echo arrives, so it
+     * would swallow the notification and leave `outstanding` set — armed to eat the user's
+     * next genuine pick of that backend. Asking here first makes the marker correct under
+     * both timings and leaves the suppress flag to the writes that are not ours.
+     */
+    isSelfWrite(value) {
+      if (outstanding === null) return false;
+      const mine = outstanding === value;
+      // SELF-LIMITING. Either way this notification ends the outstanding write. A different
+      // value means ours was superseded before it was ever delivered (or never fired at all,
+      // per fact (B)); keeping the marker past that point is how a stale one would later
+      // swallow a change the user really made.
+      outstanding = null;
+      return mine;
+    },
+
+    /**
+     * Put the saved default back if — and only if — the switch aborted and the setting
+     * still holds the value whose switch aborted.
+     *
+     * @returns {{restore: boolean, to: string|null, reason: string}} what it decided
+     */
+    rollback({ outcome, attempted, previous } = {}) {
+      // Resolve the target through any superseded rollback FIRST. If what we are about to
+      // restore to is itself a backend an earlier aborted switch put there, restoring to it
+      // would just re-commit an un-reached value.
+      const target = superseded && superseded.displaced === previous ? superseded.to : previous;
+      const plan = planSettingsBackendRollback({
+        outcome,
+        attempted,
+        previous: target,
+        // Read HERE, immediately before the write below, with no await between them.
+        current: read(),
+      });
+      if (plan.reason === SETTINGS_BACKEND_ROLLBACK.SUPERSEDED) {
+        // A newer switch is in flight and owns the setting now. Hand it the resting place
+        // this rollback could not reach, so that if it also aborts it unwinds the whole
+        // chain instead of stopping at this switch's un-reached backend.
+        superseded = { displaced: attempted, to: target };
+        return plan;
+      }
+      // Any other outcome settles the question: either the setting is now correct (the
+      // switch really happened) or this rollback is about to make it correct. Either way a
+      // stale chain must not survive to redirect an unrelated rollback later.
+      superseded = null;
+      if (!plan.restore) return plan;
+      // Marked BEFORE the write, because the write dispatches `onChange` synchronously and
+      // the echo therefore arrives during `write(...)`, not after it.
+      outstanding = plan.to;
+      let wrote = false;
+      try {
+        write(plan.to);
+        wrote = true;
+      } finally {
+        // Only on a throw. A write that failed produces no notification, so the marker has
+        // nothing to consume it and must be dropped here. It is NOT cleared on success —
+        // that would be `suppressSettingOnChange`'s time window all over again, and it is
+        // exactly what a deferred notification would fall through.
+        if (!wrote) outstanding = null;
+      }
+      return plan;
+    },
+
+    /** Test seam: the write still awaiting its notification, if any. */
+    outstandingWrite: () => outstanding,
+  };
+}


### PR DESCRIPTION
Fixes #1198.

## What was wrong

ComfyUI writes `SETTING_BACKEND` and only *then* notifies the panel, so #1184's guard runs far
too late to stop it: by the time `connectBackend` can abort, the **saved default** —
`comfy.settings.json`, not browser-scoped, so it wins on a fresh profile where no runtime pick
shadows it — already names a backend the panel may never connect to.

## What ComfyUI actually does

Read out of the shipped frontend (`src/platform/settings/settingStore.ts`, via the sourcemap
beside the bundle) rather than assumed, because all three facts are load-bearing and one of them
contradicts the issue:

* **(A)** `onChange` is dispatched **synchronously** from inside `setSettingValue`, and is handed
  the **previous** value as its second argument — which this handler had always dropped, and
  which is the only record of what to restore to.
* **(B)** Writing an unchanged value is a complete no-op — no notification, no server call.
* **(C)** The server write happens **after** the notification, not before. The issue says
  "persists, then notifies"; it is the other way round. That does not rescue anything —
  `onChange` cannot veto and its return value is discarded — but it is why option 1 (validate
  before ComfyUI persists) is not expressible: there is no pre-change hook, only a notification
  already too late to refuse.

## The fix — the issue's option 2

The reason option 2 was called "the most state to get right" is that writing this setting is what
caused the 9181 "ready"/"waiting" connect storm. Two things keep it out of that loop:

* a **compare-and-swap**, atomic for free because the read and the write sit in one synchronous
  block. A rollback that finds the setting has moved on does nothing rather than clobbering a
  newer pick;
* the echo is **identified, not suppressed**. The module marks the value it is about to write and
  consumes the matching notification. A value marker is correct whether dispatch is synchronous
  (today) or deferred (any future frontend), which is exactly what `suppressSettingOnChange` — a
  time window, documented as best-effort — cannot promise. `isSelfWrite` is therefore asked
  **before** that flag, or the flag swallows the echo and strands the marker.

Two things the tests found that reading did not:

* restoring to `previous` is wrong when two Settings switches overlap and both abort (a wedged
  history store fails every switch, so trying twice hits it every time): the second rollback's
  `previous` is the first switch's un-reached backend, landing the default on this very defect one
  step down. A superseded rollback now hands its resting place to the switch that superseded it,
  so a chain of any depth collapses to the last backend actually reached;
* "Default backend → X" was printed before the switch was even attempted, so an abort left the
  transcript asserting a durable change the panel then undid. It is announced once it is true. No
  new catalog key — the abort already discloses, and English is frozen (#1135).

`connectBackend` returns the whole result now: `switched` is false for **both** an abort and an
ordinary first connect, and only `reason` separates them — rolling back on the boolean would wipe
the default a first-connect user just chose.

Restoring to `selectedBackend` was considered and rejected: a chip pick moves the runtime backend
*without* touching the saved default (#1184's FIX 1), so the two legitimately diverge and that
would write a default the user never chose.

## Verification

**The three ComfyUI facts were re-checked against the frontend installed on this machine**, not
just cited: `onChange(setting, newValue, oldValue)` dispatches `setting.onChange(newValue,
oldValue)` synchronously; `if (newValue === oldValue) return undefined` precedes any notification;
`await api.storeSetting(...)` follows it; and `get()` falls back through `getDefaultValue()`, so
`oldValue` is always a non-empty string for a setting declaring `defaultValue: "claude"` — the
`NO_PREVIOUS` branch really is belt-and-braces for a different frontend, as the comment claims.

**Mutation-tested — the suite is red for each of the five ways this fix could be undone:**

| Mutation | Tests that go red |
| --- | --- |
| drop the `rollback` call in `applyBackend` | 5, incl. the primary defect test |
| branch on `switched` instead of `reason` | first-connect keeps its default; wiring |
| ask `suppressSettingOnChange` before `isSelfWrite` | the 9181 storm test; wiring |
| remove the compare-and-swap | 4, incl. "never clobbers a newer pick" |
| remove the superseded-chain resolution | two overlapping aborted switches |

24 new tests drive the **real** `onChange` and **real** `applyBackend`, extracted from the panel
source, over a model of the real ComfyUI settings store — in both synchronous and deferred
notification modes — and count connects, so a rollback that re-entered would show up as a second
connect.

Full unit suite green (4564 pass / 0 fail) after rebasing onto current `main`, which had itself
landed +172 lines in the panel monolith these tests regex over. CI Lint pack green.
