### PR TITLE
fix(1209): refresh a drifted graph fence before the next call, not after it refuses

### DIFF
--- a/browser_tests/unit/binding-recovery.test.mjs
+++ b/browser_tests/unit/binding-recovery.test.mjs
@@ -705,3 +705,241 @@ test("#606 the binding refusal marks the reload remedy as REQUESTED, not confirm
     );
   }
 });
+
+// ---------------------------------------------------------------------------
+// #1209 — the fence is refreshed BEFORE the refusal, not only after it
+//
+// #607 made the recovery reachable. It is edge-triggered on an actual refusal, so
+// the first graph call after the panel's live identity moved still fails and the
+// reporter still spends a panel_set_workflow_target({mode:"current"}) round-trip on
+// a stale fence the panel could already see.
+//
+// It moves without a tab switch. The switch-path re-hello is gated on
+// workflowTabId() changing, and that id is the saved HANDLE (`wf:<path>`): a workflow
+// replaced IN PLACE under the same tab keeps it while workflowStableUuid() — the
+// per-instance fence identity — is re-minted. Two reporters hit exactly that, one
+// after a tab switch and one on the FIRST call of a brand-new session.
+// ---------------------------------------------------------------------------
+
+/**
+ * Extract the budget block, the #607 hook AND the #1209 drift hook together, so the
+ * delegation between them is the shipping one. Deleting the drift hook, or making it
+ * fire unconditionally, fails a test below.
+ */
+function buildDriftHook({ sendHello, stableUuid }) {
+  const declStart = SRC.indexOf("const MISMATCH_REHELLO_MAX_PER_IDENTITY");
+  assert.notEqual(declStart, -1, "the re-hello budget constants are missing");
+  const marker = "workflowIdentityDriftRehello = () => {";
+  const bodyStart = SRC.indexOf(marker);
+  assert.notEqual(bodyStart, -1, "the bridge client must register the drift re-hello hook");
+  // Same brace arithmetic as buildRehelloHook: the marker ENDS with the body's own
+  // "{", and the slice must end at that index plus the body length (using bodyStart
+  // silently lops the tail off and every assertion below becomes meaningless).
+  const bodyOpen = bodyStart + marker.length - 1;
+  const body = balancedFrom(SRC, marker, bodyOpen);
+  const slice = SRC.slice(declStart, bodyOpen + body.length);
+  assert.ok(
+    slice.includes("workflowInstanceMismatchRehello() === true"),
+    "the drift hook must reuse the bounded #607 send, and charge only a DISPATCHED one",
+  );
+  assert.ok(
+    slice.includes("driftRehelloUnconverged = 0;"),
+    "the extracted region is truncated — the drift bound's replenishment is missing",
+  );
+  assert.ok(
+    slice.includes("mismatchRehelloLandedCount += 1;"),
+    "the extracted region is truncated — the #607 landed bookkeeping is missing",
+  );
+  const factory = new Function(
+    "sendHello",
+    "workflowStableUuid",
+    `let workflowInstanceMismatchRehello = null;\n` +
+      `let workflowIdentityDriftRehello = null;\n${slice};\n` +
+      `return {\n` +
+      `  drift: workflowIdentityDriftRehello,\n` +
+      `  mismatch: workflowInstanceMismatchRehello,\n` +
+      `  advertise: (uuid) => { lastAdvertisedWorkflowUuid = uuid; },\n` +
+      `};`,
+  );
+  return factory(sendHello, stableUuid);
+}
+
+test("#1209 a fence that drifted under an unchanged route is re-advertised, unprompted", async () => {
+  // The reported shape: the orchestrator was told A at connect, the canvas is now B,
+  // and NOTHING has been refused yet. Before this fix the panel sat on that until a
+  // command failed; the reporter's next read-only panel_graph_outline was that command.
+  let live = "uuid-A";
+  const dbl = helloDouble(() => live);
+  const h = buildDriftHook({ sendHello: () => dbl.send(), stableUuid: () => live });
+  dbl.harness = h;
+  h.advertise("uuid-A");
+
+  h.drift();
+  await settle();
+  assert.equal(dbl.calls.length, 0, "a fence that still names the live canvas sends nothing");
+
+  live = "uuid-B"; // in-place replace: same wf:<path> route, fresh instance uuid
+  h.drift();
+  await settle();
+  assert.deepEqual(dbl.calls, ["uuid-B"], "the drifted fence is re-advertised without a refusal");
+
+  // …and it QUIESCES: once the advertisement lands, the panel and the orchestrator
+  // agree again, so the 600ms poll must stop sending. A re-hello per tick would be a
+  // greeting storm — the exact failure the tmp:-id churn produced.
+  for (let i = 0; i < 10; i += 1) {
+    h.drift();
+    await settle();
+  }
+  assert.equal(dbl.calls.length, 1, "an advertisement that landed ends the drift");
+});
+
+test("#1209 an idle panel spends none of the bound a later real drift needs", async () => {
+  // Equality is the common case — it runs on every poll tick. A hook that spent the
+  // bound on the no-drift path would leave a genuine later drift with nothing to
+  // spend, which is the wedge, not the fix.
+  let live = "uuid-A";
+  const dbl = helloDouble(() => live);
+  const h = buildDriftHook({ sendHello: () => dbl.send(), stableUuid: () => live });
+  dbl.harness = h;
+  h.advertise("uuid-A");
+  for (let i = 0; i < 50; i += 1) {
+    h.drift();
+    await settle();
+  }
+  assert.equal(dbl.started, 0, "an idle panel sends nothing");
+
+  // …and the drift it had been idling through is still advertised when it arrives.
+  live = "uuid-B";
+  h.drift();
+  await settle();
+  assert.deepEqual(dbl.calls, ["uuid-B"], "the budget was not spent while nothing had drifted");
+});
+
+test("#1209 nothing advertised yet is not a drift — the open hello carries the truth", async () => {
+  // A fresh or reconnecting socket has told the orchestrator nothing, so there is no
+  // stale cache to correct and firing here would only race the hello that is coming.
+  const dbl = helloDouble(() => "uuid-LIVE");
+  const h = buildDriftHook({ sendHello: () => dbl.send(), stableUuid: () => "uuid-LIVE" });
+  dbl.harness = h;
+  h.drift();
+  await settle();
+  assert.equal(dbl.started, 0, "an unadvertised socket must not re-hello");
+});
+
+test("#1209 an identity that cannot be READ is not an identity known to differ", async () => {
+  const dbl = helloDouble(() => "uuid-A");
+  const h = buildDriftHook({
+    sendHello: () => dbl.send(),
+    stableUuid: () => {
+      throw new Error("no workflow service");
+    },
+  });
+  dbl.harness = h;
+  h.advertise("uuid-A");
+  h.drift();
+  await settle();
+  assert.equal(dbl.started, 0, "an unreadable identity re-hellos nothing");
+});
+
+test("#1209 a drift that cannot be advertised is BOUNDED, like the refusal path", async () => {
+  // An orchestrator that takes the hello and keeps its old stamp (the harness never
+  // republishes) must not turn a 600ms poll into an unbounded re-hello loop — a churn
+  // is a new wedge, not a fix.
+  const dbl = helloDouble(() => "uuid-B");
+  const h = buildDriftHook({ sendHello: () => dbl.send(), stableUuid: () => "uuid-B" });
+  dbl.harness = { advertise: () => {} };
+  h.advertise("uuid-A");
+  for (let i = 0; i < 25; i += 1) {
+    h.drift();
+    await settle();
+  }
+  assert.equal(dbl.calls.length, 3, "a drift that never clears stops churning");
+});
+
+test("#1209 convergence is what replenishes the bound — a switch after a stuck one still lands", async () => {
+  // The bound above must not be a one-way ratchet for the LIFE of the socket. Once an
+  // advertisement demonstrably reached the orchestrator (what it was told names the
+  // live canvas), re-advertising is proven to work here and the next genuine drift —
+  // hours and many workflow switches later — gets the full bound again.
+  let live = "uuid-B";
+  const dbl = helloDouble(() => live);
+  const h = buildDriftHook({ sendHello: () => dbl.send(), stableUuid: () => live });
+  // Phase 1: an orchestrator that takes the hellos and keeps its old stamp. Three
+  // tries, then quiet.
+  dbl.harness = { advertise: () => {} };
+  h.advertise("uuid-A");
+  for (let i = 0; i < 12; i += 1) {
+    h.drift();
+    await settle();
+  }
+  assert.equal(dbl.calls.length, 3, "the stuck identity exhausted the bound");
+
+  // Phase 2: the panel and the orchestrator agree again (a reconnect's open hello, or
+  // the switch-path re-hello, landed). One converged observation, and the mechanism is
+  // live again.
+  dbl.harness = h;
+  h.advertise("uuid-B");
+  h.drift();
+  await settle();
+  assert.equal(dbl.calls.length, 3, "convergence itself sends nothing");
+  live = "uuid-C";
+  h.drift();
+  await settle();
+  assert.deepEqual(dbl.calls.slice(3), ["uuid-C"], "the next real drift is advertised again");
+});
+
+test("#1209 an attempt the #607 guards refused does not spend the drift bound", async () => {
+  // The bound counts re-hellos that were DISPATCHED. #607 refuses one while another is
+  // in flight, and charging the bound for those would burn it on sends that never
+  // happened — the same "recorded before it happened" defect the #607 budget itself
+  // exists to avoid, seen from the caller's side.
+  let release;
+  const gate = new Promise((r) => {
+    release = r;
+  });
+  const dbl = helloDouble(() => "uuid-B", { defer: gate });
+  const h = buildDriftHook({ sendHello: () => dbl.send(), stableUuid: () => "uuid-B" });
+  dbl.harness = { advertise: () => {} };
+  h.advertise("uuid-A");
+
+  for (let i = 0; i < 8; i += 1) {
+    h.drift();
+    await settle();
+  }
+  assert.equal(dbl.started, 1, "the in-flight guard held the burst to one send");
+
+  release();
+  await settle();
+  await settle();
+  // Two dispatches remain, not zero: the seven refused ticks cost nothing.
+  for (let i = 0; i < 8; i += 1) {
+    h.drift();
+    await settle();
+  }
+  assert.equal(dbl.started, 3, "the refused ticks left the rest of the bound intact");
+});
+
+test("#1209 the workflow poll calls the drift check when the ROUTE did not change", () => {
+  // The whole fix is one call on the poll's early-return path, and a hook nobody
+  // invokes is invisible to every test above. This asserts the wiring itself: restore
+  // the bare `return` and this fails.
+  const marker = "if (wfid === currentWorkflowId) {";
+  assert.ok(SRC.includes(marker), "the no-route-change branch must still exist");
+  const branch = balancedFrom(SRC, marker, SRC.indexOf(marker) + marker.length - 1);
+  assert.match(
+    branch,
+    /noteWorkflowIdentityDrift\(\);/,
+    "an unchanged route must still re-check the workflow INSTANCE identity",
+  );
+});
+
+test("#1209 a throwing drift hook never breaks the workflow poll", () => {
+  const src = balancedFrom(SRC, "function noteWorkflowIdentityDrift()");
+  const fn = new Function(
+    "workflowIdentityDriftRehello",
+    `${src}\nreturn noteWorkflowIdentityDrift;`,
+  )(() => {
+    throw new Error("hook exploded");
+  });
+  assert.doesNotThrow(() => fn(), "the poll must survive a hook that throws");
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -3088,6 +3088,38 @@ function noteWorkflowInstanceMismatch() {
     // best-effort — the refusal stands regardless
   }
 }
+// #1209 — the SAME re-advertisement, fired BEFORE the refusal instead of after it.
+//
+// #607 made the recovery reachable; it did not make it unnecessary. The re-hello is
+// edge-triggered on an actual refusal, so the FIRST graph call after the panel's live
+// identity moved still fails, and the reporter has to spend a
+// panel_set_workflow_target({mode:"current"}) round-trip on a fence the panel could
+// already see was stale.
+//
+// It moves without a tab switch, which is why the switch-path re-hello does not cover
+// it: the re-hello in the workflow poll is gated on workflowTabId() changing, and that
+// id is the saved HANDLE (`wf:<path>`) — it is UNCHANGED when a workflow is replaced
+// in place under the same tab (a load into the open canvas, a reopen of the same path,
+// ComfyUI restoring the tab at startup). workflowStableUuid() is per-INSTANCE and the
+// loadGraphData wrapper re-mints it on exactly those in-place replacements, so the
+// fence identity changes while the route the poll watches does not. Two reporters hit
+// that: one after a tab switch, one on the FIRST call of a brand-new session with no
+// switch and no mutation before it.
+//
+// The predicate is the panel's own record of what it TOLD the orchestrator
+// (`lastAdvertisedWorkflowUuid`, published only by a hello that reached the wire)
+// against what is live now. Those differing IS the stale fence, observed from the only
+// side that holds both halves. Nothing here weakens the fence: mutations stay
+// fail-closed against whatever stamp is current, and this only replaces a stamp the
+// panel can prove is out of date with the one it would have refused in favour of.
+let workflowIdentityDriftRehello = null;
+function noteWorkflowIdentityDrift() {
+  try {
+    workflowIdentityDriftRehello?.();
+  } catch {
+    // best-effort — a hook throw must never break the workflow poll
+  }
+}
 /** #750 — the ONE spelling of the fence refusal, reporting WHAT WAS COMPARED
  *  rather than inferring why the two differed.
  *
@@ -19604,19 +19636,19 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
     } catch {
       liveUuid = null;
     }
-    if (!liveUuid) return;
+    if (!liveUuid) return false;
     if (liveUuid !== mismatchRehelloIdentity) {
       mismatchRehelloIdentity = liveUuid;
       mismatchRehelloLandedCount = 0;
       lastFailedMismatchRehelloAt = 0;
     }
-    if (mismatchRehelloLandedCount >= MISMATCH_REHELLO_MAX_PER_IDENTITY) return;
-    if (mismatchRehelloInFlight) return;
+    if (mismatchRehelloLandedCount >= MISMATCH_REHELLO_MAX_PER_IDENTITY) return false;
+    if (mismatchRehelloInFlight) return false;
     if (
       lastFailedMismatchRehelloAt &&
       Date.now() - lastFailedMismatchRehelloAt < MISMATCH_REHELLO_BACKOFF_MS
     )
-      return;
+      return false;
     mismatchRehelloInFlight = true;
     void Promise.resolve()
       .then(() => sendHello())
@@ -19638,6 +19670,60 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
           lastFailedMismatchRehelloAt = Date.now();
         }
       });
+    // Whether a send was DISPATCHED — not whether it landed, which the bookkeeping
+    // above already tracks. #1209's proactive caller charges its own bound on this,
+    // and charging it for an attempt every guard above refused would spend the
+    // re-advertisements a real drift still needs (the "recorded before it happened"
+    // defect, from the other side).
+    return true;
+  };
+
+  // #1209 — proactive half of the same mechanism: re-advertise when the panel can
+  // already SEE that what the orchestrator was last told no longer names the live
+  // canvas, rather than waiting for a command to be refused for saying so.
+  //
+  // Delegates the send to the hook above rather than repeating it, so the per-identity
+  // budget, the backoff and the in-flight guard all apply unchanged.
+  //
+  // IT NEEDS A BOUND OF ITS OWN, and this is the whole reason the proactive path is
+  // not simply the #607 hook wired to the poll. #607 is EDGE-triggered on a refusal,
+  // which only happens when a command is dispatched; this runs on the 600ms workflow
+  // poll, so an identity that never settles would re-hello forever — a greeting storm,
+  // exactly what the churning tmp: id produced before it was keyed on the workflow
+  // OBJECT. #607's own budget cannot hold that: it is keyed on the LIVE identity and
+  // resets the moment that identity changes, which under churn is every tick.
+  //
+  // So: count consecutive attempts that did NOT converge, and let only convergence
+  // replenish them. Convergence — what the orchestrator was last told naming the live
+  // canvas — is the one observation that proves re-advertising works here, and it is
+  // the common case on a settled panel. An identity that never converges is one this
+  // mechanism cannot fix, and it goes quiet after three tries; the #607 refusal path
+  // is untouched and still recovers on demand, which is today's behaviour.
+  //
+  // The two early exits are refusals to act on an unknown, not optimisations:
+  //   - nothing advertised yet (a fresh or reconnecting socket) means there is no
+  //     stale cache to correct — the hello that is about to fire carries the truth,
+  //     and firing another one here would only race it.
+  //   - an identity that cannot be READ is not an identity known to differ, and it is
+  //     not convergence either, so it neither spends the bound nor replenishes it.
+  const DRIFT_REHELLO_MAX_UNCONVERGED = 3;
+  let driftRehelloUnconverged = 0;
+  workflowIdentityDriftRehello = () => {
+    if (typeof lastAdvertisedWorkflowUuid !== "string" || !lastAdvertisedWorkflowUuid) return;
+    let liveUuid = null;
+    try {
+      const read = workflowStableUuid();
+      liveUuid = typeof read === "string" && read ? read : null;
+    } catch {
+      liveUuid = null;
+    }
+    if (!liveUuid) return;
+    if (liveUuid === lastAdvertisedWorkflowUuid) {
+      driftRehelloUnconverged = 0;
+      return;
+    }
+    if (driftRehelloUnconverged >= DRIFT_REHELLO_MAX_UNCONVERGED) return;
+    if (workflowInstanceMismatchRehello() === true) driftRehelloUnconverged += 1;
   };
 
   // When the workflow title changes (rename / open a different file / progress
@@ -27003,7 +27089,21 @@ function buildPanel() {
     const wf = activeWorkflowRef();
     const wfid = workflowTabId();
     const wfkey = wf ? (wf.key || wf.id || "unsaved") : null;
-    if (wfid === currentWorkflowId) return; // case 1: no change
+    if (wfid === currentWorkflowId) {
+      // #1209 — the ROUTE is unchanged; the workflow INSTANCE identity under it may
+      // not be. `wfid` is the saved handle (`wf:<path>`), so a workflow replaced in
+      // place — loaded into the open canvas, reopened at the same path, restored at
+      // startup — lands here with a freshly minted fence uuid and, before this call,
+      // no re-advertisement at all. The orchestrator kept stamping graph commands
+      // with the identity it was told at connect, and the next one was refused as a
+      // `workflow instance mismatch`.
+      //
+      // The check itself is a string compare against what the last LANDED hello
+      // carried, so the settled case (the overwhelming majority of the 600ms ticks
+      // that reach this line) costs one comparison and sends nothing.
+      noteWorkflowIdentityDrift();
+      return; // case 1: no change
+    }
 
     const initial = currentWorkflowId == null;
     const followsPanel = historyScopeFollowsPanel();


### PR DESCRIPTION
Fixes #1209

## What was wrong

The orchestrator stamps every `panel_*` graph command with the workflow instance uuid the panel last advertised in a hello, and the panel refuses a command whose stamp no longer names the live canvas (`workflow instance mismatch`).

**#607 made the recovery reachable, not unnecessary.** Its re-hello is EDGE-triggered on an actual refusal, so the first graph call after the panel's identity moved still fails — and both reporters spent a `panel_set_workflow_target({mode:"current"})` round-trip on a fence the panel could already see was stale.

## Why the existing switch-path re-hello does not cover it

`onWorkflowMaybeChanged` re-hellos only when `workflowTabId()` changes. That id is the saved **handle** (`wf:<path>`), and it is UNCHANGED when a workflow is replaced *in place* under the same tab — loaded into the open canvas, reopened at the same path, restored by ComfyUI at startup. `workflowStableUuid()` is per-**instance**, and the `loadGraphData` wrapper re-mints it on exactly those replacements. So the fence identity moves while the route the poll watches does not, and nothing re-advertises.

That is precisely the second report in the thread: the **first** `panel_graph_outline` of a brand-new session, refused (`58ec734e…` vs live `ed48682a…`) with no tab switch and no prior mutation.

## The change

`web/js/comfyui-mcp-panel.js` — three edits:

1. `noteWorkflowIdentityDrift()` + hook, alongside the existing `noteWorkflowInstanceMismatch()`.
2. The hook itself, registered in the bridge client: compares the live `workflowStableUuid()` against `lastAdvertisedWorkflowUuid` — the panel's own record of what actually reached the orchestrator, published only by a hello that made it to the wire. Those differing IS the stale fence, observed from the only side that holds both halves. The send is the bounded #607 re-hello, unchanged.
3. The 600 ms workflow poll calls it on the path where the route did **not** change.

**The fence is not weakened.** Mutations stay fail-closed against whatever stamp is current; this only replaces a stamp the panel can *prove* is out of date. The issue asked for read-only auto-retry as an alternative — this is strictly narrower: nothing is retried, one advertisement is corrected.

### The proactive path needs a bound of its own

This is not just the #607 hook wired to the poll, and finding that out is what the first round of tests caught. #607's budget is keyed on the LIVE identity and resets whenever it changes; under a churning identity that is every tick, so a level-triggered caller re-hellos forever — a greeting storm, the same failure the churning `tmp:` id produced before it was keyed on the workflow object. The drift path therefore counts consecutive attempts that did not **converge**, lets only convergence replenish them, and charges only a re-hello that was actually **dispatched** (`workflowInstanceMismatchRehello()` now returns whether it sent). An identity that never settles goes quiet after three tries, leaving today's #607 recovery untouched.

## Evidence

`browser_tests/unit/binding-recovery.test.mjs` — 9 new tests in the #607 cluster, extracting the shipping hook verbatim.

**Verified by mutation** — each of these turns the suite red, and reverting turns it green:

| mutation | result |
|---|---|
| remove the poll call site | ✖ 1 fail (the wiring test) |
| no-op the drift hook | ✖ 5 fail |
| remove the drift bound | ✖ 3 fail |
| charge the bound for undispatched attempts | ✖ 7 fail |

- `npm run test:unit` — **4535 tests, 0 fail**.
- The 12 pre-existing #606/#607 tests in the same file still pass — `workflowInstanceMismatchRehello`'s behaviour is unchanged, only its return value is new.

## Not done

- **No browser/e2e run — it could not be run.** The suite does not start ComfyUI (`playwright.config.ts`: *"PREREQUISITES (this suite does NOT start ComfyUI for you)"*), nothing was listening on `localhost:8188`, and no ComfyUI was allocated to this run. Even with one up, the browser loads the pack junctioned into `custom_nodes` — the main checkout, not this worktree — so the run would not have exercised this change; and the tier-1 MockBridge fixtures model no in-place workflow replacement with a real hello round-trip. Stating this rather than implying coverage I do not have.
- What *does* cover the browser-side risk: CI's JS-syntax lint, and `check-panel-scope` — the gate that catches a new module-level binding resolving in a sibling scope, which is a `ReferenceError` the moment the line runs. It needed `npm install` in the worktree to run at all (a fresh worktree inherits no `node_modules`, and it prints CANNOT RUN rather than a false OK); it reports OK. This change renders nothing — it sends one hello frame.
- The `Date.now()` calls in the #607 backoff are pre-existing and untouched; the drift path uses no clock.

---

**Gate disclosure: NOT GATED. This PR is held.**

The codex gate was re-run on head `c043916` on 2026-08-15 and returned **exit 2 (INDETERMINATE)** — the codex account is over its usage limit and does not reset until **2026-08-19 8:43 PM**. An indeterminate gate is not a pass, and no substitute is one either: the `claude-gate.mjs` run recorded here is an independent adversarial review, not the gate this repo merges on. Do not merge until the codex gate has actually returned exit 0.

Everything else is finished — see the verification comment below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

