### PR TITLE
fix(1634): a node read by id returns its full widget value, not a survey clip

### DIFF
--- a/browser_tests/pinpoint-read-returns-full-value.spec.ts
+++ b/browser_tests/pinpoint-read-returns-full-value.spec.ts
@@ -1,0 +1,97 @@
+/**
+ * #1634 — the agent kept handing back a CUT-OFF positive prompt.
+ *
+ * The filed hypothesis was `graph_outline`'s ladder shedding widget values on an
+ * over-budget graph. Measured, that is not it: it reproduces on a graph of a handful of
+ * nodes, where no rung degrades and nothing is near a budget. The cause is that the
+ * compact projection's fixed 60-char value clip — a SURVEY cap, sized so a 200-node
+ * listing of unidentified nodes stays small — was also applied when the caller named the
+ * node explicitly by `ids`. That is the opposite case: the node is already identified, so
+ * the clip only starves the value that was asked for. The shortfall is silent, because a
+ * clipped prompt ends in an ellipsis a real prompt could plausibly contain.
+ *
+ * This drives the REAL executor against a REAL canvas, because the fix's call site
+ * (`clipCompactValue(v, compactValueCap)` in comfyui-mcp-panel.js) is invisible to the
+ * helper-level unit tests in browser_tests/unit/graph-read.test.mjs — those would stay
+ * green with the wiring deleted.
+ */
+import { test, expect } from './fixtures/panelTest'
+import { claimFreshCanvas, settleCanvas } from './fixtures/canvasIdentity'
+
+/** 300 chars — longer than the 60-char survey clip, far under every budget. */
+const PROMPT =
+  'masterpiece, best quality, ultra detailed, a lone astronaut standing on a windswept ' +
+  'red dune at golden hour, visor reflecting twin suns, volumetric god rays, fine sand ' +
+  'particles drifting, cinematic composition, 85mm lens, shallow depth of field, ' +
+  'photorealistic, 8k, sharp focus, dramatic rim lighting'
+
+async function makePromptNode(page: any) {
+  return await page.evaluate((text: string) => {
+    const w = window as any
+    const app = w.comfyAPI?.app?.app || w.app
+    const LG = w.LiteGraph || w.comfyAPI?.litegraph?.LiteGraph
+    const n = LG.createNode('CLIPTextEncode')
+    ;(app?.canvas?.graph ?? app?.graph).add(n)
+    n.title = 'Positive Prompt'
+    const wdg = (n.widgets || []).find((x: any) => x.name === 'text') || (n.widgets || [])[0]
+    if (wdg) wdg.value = text
+    return { id: String(n.id), value: String(wdg?.value ?? '') }
+  }, PROMPT)
+}
+
+test('reading ONE node by id returns its full prompt, without fields:detail', async ({
+  page,
+  panel,
+  mockBridge,
+}) => {
+  await panel.goto()
+  await panel.setBridgeUrl(mockBridge.url)
+  await panel.openSidebar()
+  await panel.connect()
+  await claimFreshCanvas(page, mockBridge)
+
+  const made = await makePromptNode(page)
+  expect(made.value, 'precondition: the widget really holds the whole prompt').toBe(PROMPT)
+  expect(PROMPT.length).toBeGreaterThan(60)
+  await settleCanvas(page)
+
+  // The pinpoint read, exactly as an agent issues it — `ids`, no `fields`.
+  const res = await mockBridge.command('graph_query', { ids: [made.id] })
+  expect(res.ok).toBe(true)
+  const text = String(res.result?.text ?? '')
+
+  // THE BUG: this returned the prompt cut at 60 chars.
+  expect(text, 'the node asked for by id must carry its whole value').toContain(PROMPT)
+  // …and with nothing clipped there is nothing to report.
+  expect(text, 'no clip note when nothing was clipped').not.toContain('widget value(s) clipped')
+  // Still a compact one-line row, not the detail JSON — the shape is unchanged.
+  expect(text, 'compact shape preserved').toMatch(new RegExp(`#${made.id}\\s+CLIPTextEncode`))
+})
+
+test('a SURVEY read still clips at 60 and names the lever that helps', async ({
+  page,
+  panel,
+  mockBridge,
+}) => {
+  await panel.goto()
+  await panel.setBridgeUrl(mockBridge.url)
+  await panel.openSidebar()
+  await panel.connect()
+  await claimFreshCanvas(page, mockBridge)
+
+  await makePromptNode(page)
+  await settleCanvas(page)
+
+  // No `ids` — the caller has NOT identified the node, so the survey cap is correct and
+  // must survive the fix. This is the assertion that stops the pinpoint cap leaking into
+  // the survey path and un-bounding a 200-node listing.
+  const res = await mockBridge.command('graph_query', { types: ['CLIPTextEncode'] })
+  expect(res.ok).toBe(true)
+  const text = String(res.result?.text ?? '')
+
+  expect(text, 'a survey must NOT carry the whole value').not.toContain(PROMPT)
+  expect(text).toContain('clipped to 60 chars by `fields`:"compact"')
+  expect(text, 'and it points at a projection that genuinely carries more').toContain(
+    'read fuller values with `fields`:"detail"',
+  )
+})

--- a/browser_tests/unit/graph-read.test.mjs
+++ b/browser_tests/unit/graph-read.test.mjs
@@ -523,6 +523,13 @@ test("#1634 the clip note names the cap actually in force", () => {
   const byBudget = compactClipNote(1, 976, 2000);
   assert.match(byBudget, /clipped to 976 chars to fit `max_chars`=2000/);
   assert.match(byBudget, /raise `max_chars`/);
+  // #1634 (gate): BELOW the fixed cap, `fields`:"detail" reserves less of the budget for
+  // framing and genuinely carries more — suppressing it there is the #809 wrong-lever bug.
+  assert.match(byBudget, /`fields`:"detail"/);
+  // ...and when the budget degraded the cap back to the survey clip, the survey note is
+  // emitted verbatim: the longer text rides inside max_chars and at the floor it alone
+  // pushed a reply that fitted past the bound.
+  assert.equal(compactClipNote(1, 60, 500), compactClipNote(1));
 
   // At the ceiling, "raise max_chars" would itself be dead.
   assert.match(compactClipNote(1, 1024, 60000), /already at its ceiling of 60000/);

--- a/browser_tests/unit/graph-read.test.mjs
+++ b/browser_tests/unit/graph-read.test.mjs
@@ -499,3 +499,45 @@ test("budget loop stays bounded for a large ids list — only the first overflow
   assert.ok(shown >= 1 && shown < 10, `bounded: rendered ${shown} of 10, not all`);
   assert.equal(truncated, true, "the rest are honestly marked truncated");
 });
+
+// #1634 — a compact row's 60-char clip is a SURVEY cap. On a PINPOINT read (explicit
+// `ids`) it starved the very value the caller asked for: measured on a FOUR-node graph,
+// {ids:["2"]} returned a 300-char prompt cut at 60 in a 301-char reply against a
+// 12000-char budget. These pin the note's half of that fix — it must name the cap that
+// ACTUALLY fired, because at the fixed cap "use fields:detail" is a dead retry.
+test("#1634 the clip note names the cap actually in force", () => {
+  // Survey read: unchanged — 60 chars, and `fields`:"detail" is a live remedy.
+  const survey = compactClipNote(3);
+  assert.match(survey, /clipped to 60 chars by `fields`:"compact"/);
+  assert.match(survey, /read fuller values with `fields`:"detail"/);
+  assert.equal(compactClipNote(3), compactClipNote(3, 60), "60 is the survey default");
+
+  // Pinpoint at the FIXED cap: `fields`:"detail" applies the SAME cap, so pointing
+  // there would be exactly the dead retry #809 exists to remove.
+  const atCap = compactClipNote(1, WIDGET_VALUE_CAP, 60000);
+  assert.match(atCap, new RegExp(`clipped to ${WIDGET_VALUE_CAP} chars`));
+  assert.doesNotMatch(atCap, /read fuller values with `fields`:"detail"/);
+  assert.match(atCap, /no parameter raises/);
+
+  // Pinpoint cut by max_chars instead: name max_chars, which genuinely helps.
+  const byBudget = compactClipNote(1, 976, 2000);
+  assert.match(byBudget, /clipped to 976 chars to fit `max_chars`=2000/);
+  assert.match(byBudget, /raise `max_chars`/);
+
+  // At the ceiling, "raise max_chars" would itself be dead.
+  assert.match(compactClipNote(1, 1024, 60000), /already at its ceiling of 60000/);
+
+  assert.equal(compactClipNote(0, WIDGET_VALUE_CAP, 12000), "", "still silent when nothing clipped");
+});
+
+test("#1634 clipCompactValue honours a raised cap for a pinpoint read", () => {
+  const prompt = "m".repeat(300);
+  // Survey cap starves it...
+  const survey = clipCompactValue(prompt, 60);
+  assert.equal(survey.clipped, true);
+  assert.ok(survey.text.length < 70);
+  // ...the pinpoint cap carries it whole, with no clip to report.
+  const pinpoint = clipCompactValue(prompt, WIDGET_VALUE_CAP);
+  assert.equal(pinpoint.clipped, false);
+  assert.equal(pinpoint.text, prompt);
+});

--- a/browser_tests/unit/graph-read.test.mjs
+++ b/browser_tests/unit/graph-read.test.mjs
@@ -10,6 +10,7 @@ import assert from "node:assert/strict";
 
 import {
   WIDGET_VALUE_CAP,
+  COMPACT_VALUE_CLIP,
   linkDrivenWidgets,
   drivenWidgetsFor,
   drivenTag,
@@ -514,27 +515,24 @@ test("#1634 the clip note names the cap actually in force", () => {
 
   // Pinpoint at the FIXED cap: `fields`:"detail" applies the SAME cap, so pointing
   // there would be exactly the dead retry #809 exists to remove.
-  const atCap = compactClipNote(1, WIDGET_VALUE_CAP, 60000);
+  const atCap = compactClipNote(1, WIDGET_VALUE_CAP);
   assert.match(atCap, new RegExp(`clipped to ${WIDGET_VALUE_CAP} chars`));
   assert.doesNotMatch(atCap, /read fuller values with `fields`:"detail"/);
   assert.match(atCap, /no parameter raises/);
 
-  // Pinpoint cut by max_chars instead: name max_chars, which genuinely helps.
-  const byBudget = compactClipNote(1, 976, 2000);
-  assert.match(byBudget, /clipped to 976 chars to fit `max_chars`=2000/);
-  assert.match(byBudget, /raise `max_chars`/);
-  // #1634 (gate): BELOW the fixed cap, `fields`:"detail" reserves less of the budget for
-  // framing and genuinely carries more — suppressing it there is the #809 wrong-lever bug.
-  assert.match(byBudget, /`fields`:"detail"/);
-  // ...and when the budget degraded the cap back to the survey clip, the survey note is
-  // emitted verbatim: the longer text rides inside max_chars and at the floor it alone
-  // pushed a reply that fitted past the bound.
-  assert.equal(compactClipNote(1, 60, 500), compactClipNote(1));
-
-  // At the ceiling, "raise max_chars" would itself be dead.
-  assert.match(compactClipNote(1, 1024, 60000), /already at its ceiling of 60000/);
-
-  assert.equal(compactClipNote(0, WIDGET_VALUE_CAP, 12000), "", "still silent when nothing clipped");
+  // #1634 (gate): there are exactly TWO honest forms, because the cap is uniform across
+  // the row and is only ever the survey clip or the fixed cap. An intermediate,
+  // budget-derived cap was tried and removed — it named a number that was in force for no
+  // widget, and called a cut "unraisable" that raising `max_chars` demonstrably lifted.
+  // The survey clip is one of them, verbatim.
+  assert.equal(compactClipNote(1, 60), compactClipNote(1), "the survey cap uses the survey note");
+  // Whichever form is emitted, the number it names is a cap that really applies — never a
+  // budget-derived figure that was in force for no widget.
+  for (const cap of [COMPACT_VALUE_CLIP, WIDGET_VALUE_CAP]) {
+    const named = /clipped to (\d+) chars/.exec(compactClipNote(1, cap))?.[1];
+    assert.equal(named, String(cap), `the note must name the cap in force (${cap})`);
+  }
+  assert.equal(compactClipNote(0, WIDGET_VALUE_CAP), "", "still silent when nothing clipped");
 });
 
 test("#1634 clipCompactValue honours a raised cap for a pinpoint read", () => {

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -10295,12 +10295,10 @@ const GRAPH_TOOL_EXECUTORS = {
     // graph, {ids:["2"]} returned the prompt cut at 60 chars in a 301-char reply against a
     // 12000-char budget — so this is not the outline ladder degrading on a big graph.
     //
-    // Mirrors the orchestrator twin in comfyui-mcp src/services/graph-query.ts. The cap is
-    // tightened to `max_chars` (as capSummaryWidgets does for `detail`) and floored at the
-    // survey clip: without that reserve the FIRST row — which #609 protects from the budget
-    // and never drops — breaches the bound outright on a small `max_chars`.
+    // Mirrors the orchestrator twin in comfyui-mcp src/services/graph-query.ts.
+    // Deliberately unchanged: the compact SHAPE, the survey path, `max_chars`, and the
+    // outline ladder.
     //
-    // Deliberately unchanged: the compact SHAPE, the survey path, and `max_chars`.
     // Only a SINGLE id is a pinpoint read. Treating any `ids` list as one cost rows the
     // caller explicitly asked for and main returned in full — 20 ordinary 600-char prompts
     // at the default budget went from 20/20 to 18/20 (gate). One id also means at most one
@@ -10310,7 +10308,12 @@ const GRAPH_TOOL_EXECUTORS = {
     // leaking — a floor of 60 per widget still grows without bound across many widgets, so
     // a 24-widget node breached `max_chars` on default parameters while reporting
     // truncated:false (gate). A fit test cannot leak: if the generous rendering does not
-    // fit we use main's, so this is never worse than main on any shape.
+    // fit we use main's rendering instead.
+    //
+    // This does not make the `max_chars` bound softer than main's — but nor does it fix
+    // the softness that is already there: clipLine bounds the LINE, while the header and
+    // clip note ride outside it, so both main and this overshoot slightly on hostile
+    // shapes. It must not be read as claiming otherwise.
     const compactValueCap = (() => {
       if (!pinpoint) return COMPACT_VALUE_CLIP;
       const only = byId.get(wantIds[0]);

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -10351,10 +10351,21 @@ const GRAPH_TOOL_EXECUTORS = {
       } else {
         // #607: flag link-driven widgets in the compact line too.
         const driven = drivenWidgetsFor(n, (n.widgets ?? []).map((w) => w?.name).filter(Boolean));
+        // Never below the survey clip, so a tight budget degrades to main's behaviour.
+        let rowBudget = pinpoint
+          ? Math.max(COMPACT_VALUE_CLIP, maxChars - 1024)
+          : Number.POSITIVE_INFINITY;
         const w = Object.entries(widgetsOf(n))
           .map(([k, v]) => {
-            const c = clipCompactValue(v, compactValueCap);
+            // #1634 (gate): a PER-VALUE cap does not bound the ROW — N widgets at the cap
+            // sum to N×cap, and the #609-protected first row can never be dropped to
+            // recover, so a multi-widget pinpoint node breached max_chars on DEFAULT
+            // parameters (12169/12000 with six long widgets; 2700/2500 with an ordinary
+            // positive+negative pair). ONE budget spent across the row, not per widget.
+            const cap = Math.min(compactValueCap, Math.max(COMPACT_VALUE_CLIP, rowBudget));
+            const c = clipCompactValue(v, cap);
             if (c.clipped) rowClips++;
+            rowBudget -= c.text.length;
             return `${k}=${c.text}${driven[k] ? drivenTag(driven[k]) : ""}`;
           })
           .join(" ");

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -254,6 +254,9 @@ import {
   compactClipNote,
   LIMIT_CEILING,
   MAX_CHARS_CEILING,
+  // #1634: the pinpoint per-value cap for an explicit-`ids` read is derived from these.
+  WIDGET_VALUE_CAP,
+  COMPACT_VALUE_CLIP,
   OUTLINE_DETAIL_LEVELS,
   clampOutlineMaxChars,
   outlineDegradeBanner,
@@ -10284,6 +10287,24 @@ const GRAPH_TOOL_EXECUTORS = {
 
     // 4) Projection, char-bounded.
     const proj = fields === "ids" || fields === "detail" ? fields : "compact";
+    // #1634: a compact row's 60-char value clip is a SURVEY cap — it keeps a 200-node
+    // listing of nodes you have not identified yet small. When the caller passed explicit
+    // `ids` they have ALREADY identified the nodes, so the read is a PINPOINT one and the
+    // survey cap is starving the value they asked for. A Discord reporter kept getting a
+    // cut-off positive prompt quoted back as the node's content; measured on a FOUR-node
+    // graph, {ids:["2"]} returned the prompt cut at 60 chars in a 301-char reply against a
+    // 12000-char budget — so this is not the outline ladder degrading on a big graph.
+    //
+    // Mirrors the orchestrator twin in comfyui-mcp src/services/graph-query.ts. The cap is
+    // tightened to `max_chars` (as capSummaryWidgets does for `detail`) and floored at the
+    // survey clip: without that reserve the FIRST row — which #609 protects from the budget
+    // and never drops — breaches the bound outright on a small `max_chars`.
+    //
+    // Deliberately unchanged: the compact SHAPE, the survey path, and `max_chars`.
+    const pinpoint = !!wantIds?.length;
+    const compactValueCap = pinpoint
+      ? Math.min(WIDGET_VALUE_CAP, Math.max(COMPACT_VALUE_CLIP, maxChars - 1024))
+      : COMPACT_VALUE_CLIP;
     const clip = (v, n = 60) => {
       const s = String(typeof v === "string" ? v : JSON.stringify(v) ?? "").replace(/\s+/g, " ");
       return s.length > n ? s.slice(0, n - 1) + "…" : s;
@@ -10332,7 +10353,7 @@ const GRAPH_TOOL_EXECUTORS = {
         const driven = drivenWidgetsFor(n, (n.widgets ?? []).map((w) => w?.name).filter(Boolean));
         const w = Object.entries(widgetsOf(n))
           .map(([k, v]) => {
-            const c = clipCompactValue(v);
+            const c = clipCompactValue(v, compactValueCap);
             if (c.clipped) rowClips++;
             return `${k}=${c.text}${driven[k] ? drivenTag(driven[k]) : ""}`;
           })
@@ -10371,7 +10392,7 @@ const GRAPH_TOOL_EXECUTORS = {
           })
         : "";
       const body = proj === "ids" ? lines.join(",") : lines.join("\n");
-      return `${header}\n${body}${tail}${compactClipNote(lineClips.reduce((x, y) => x + y, 0))}`;
+      return `${header}\n${body}${tail}${compactClipNote(lineClips.reduce((x, y) => x + y, 0), compactValueCap, maxChars)}`;
     };
     let text = assemble();
     while (text.length > maxChars && lines.length > 1) {

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -10301,10 +10301,27 @@ const GRAPH_TOOL_EXECUTORS = {
     // and never drops — breaches the bound outright on a small `max_chars`.
     //
     // Deliberately unchanged: the compact SHAPE, the survey path, and `max_chars`.
-    const pinpoint = !!wantIds?.length;
-    const compactValueCap = pinpoint
-      ? Math.min(WIDGET_VALUE_CAP, Math.max(COMPACT_VALUE_CLIP, maxChars - 1024))
-      : COMPACT_VALUE_CLIP;
+    // Only a SINGLE id is a pinpoint read. Treating any `ids` list as one cost rows the
+    // caller explicitly asked for and main returned in full — 20 ordinary 600-char prompts
+    // at the default budget went from 20/20 to 18/20 (gate). One id also means at most one
+    // row, so there is no budget to divide and no row-count to regress.
+    const pinpoint = wantIds?.length === 1;
+    // Raise the cap only when the generous row DEMONSTRABLY fits. Arithmetic reserves kept
+    // leaking — a floor of 60 per widget still grows without bound across many widgets, so
+    // a 24-widget node breached `max_chars` on default parameters while reporting
+    // truncated:false (gate). A fit test cannot leak: if the generous rendering does not
+    // fit we use main's, so this is never worse than main on any shape.
+    const compactValueCap = (() => {
+      if (!pinpoint) return COMPACT_VALUE_CLIP;
+      const only = byId.get(wantIds[0]);
+      if (!only) return COMPACT_VALUE_CLIP;
+      let total = 0;
+      for (const [k, v] of Object.entries(widgetsOf(only)))
+        total += k.length + 2 + clipCompactValue(v, WIDGET_VALUE_CAP).text.length;
+      // The reserve covers what shares the budget with the row: header, the row's own
+      // prefix and ref lists, the truncation tail and the clip note.
+      return total <= maxChars - 1024 ? WIDGET_VALUE_CAP : COMPACT_VALUE_CLIP;
+    })();
     const clip = (v, n = 60) => {
       const s = String(typeof v === "string" ? v : JSON.stringify(v) ?? "").replace(/\s+/g, " ");
       return s.length > n ? s.slice(0, n - 1) + "…" : s;
@@ -10351,21 +10368,14 @@ const GRAPH_TOOL_EXECUTORS = {
       } else {
         // #607: flag link-driven widgets in the compact line too.
         const driven = drivenWidgetsFor(n, (n.widgets ?? []).map((w) => w?.name).filter(Boolean));
-        // Never below the survey clip, so a tight budget degrades to main's behaviour.
-        let rowBudget = pinpoint
-          ? Math.max(COMPACT_VALUE_CLIP, maxChars - 1024)
-          : Number.POSITIVE_INFINITY;
         const w = Object.entries(widgetsOf(n))
           .map(([k, v]) => {
-            // #1634 (gate): a PER-VALUE cap does not bound the ROW — N widgets at the cap
-            // sum to N×cap, and the #609-protected first row can never be dropped to
-            // recover, so a multi-widget pinpoint node breached max_chars on DEFAULT
-            // parameters (12169/12000 with six long widgets; 2700/2500 with an ordinary
-            // positive+negative pair). ONE budget spent across the row, not per widget.
-            const cap = Math.min(compactValueCap, Math.max(COMPACT_VALUE_CLIP, rowBudget));
-            const c = clipCompactValue(v, cap);
+            // ONE cap across the row (see compactValueCap above). A per-widget cap that
+            // varied as a budget drained made the clip note incoherent: values cut at
+            // 2048, 736 and 60 were all reported as "clipped to 2048 … which no parameter
+            // raises", while raising `max_chars` demonstrably lifted them (gate).
+            const c = clipCompactValue(v, compactValueCap);
             if (c.clipped) rowClips++;
-            rowBudget -= c.text.length;
             return `${k}=${c.text}${driven[k] ? drivenTag(driven[k]) : ""}`;
           })
           .join(" ");
@@ -10403,7 +10413,7 @@ const GRAPH_TOOL_EXECUTORS = {
           })
         : "";
       const body = proj === "ids" ? lines.join(",") : lines.join("\n");
-      return `${header}\n${body}${tail}${compactClipNote(lineClips.reduce((x, y) => x + y, 0), compactValueCap, maxChars)}`;
+      return `${header}\n${body}${tail}${compactClipNote(lineClips.reduce((x, y) => x + y, 0), compactValueCap)}`;
     };
     let text = assemble();
     while (text.length > maxChars && lines.length > 1) {

--- a/web/js/lib/graph-read.js
+++ b/web/js/lib/graph-read.js
@@ -262,10 +262,20 @@ export function clipCompactValue(v, n = COMPACT_VALUE_CLIP) {
   return s.length > n ? { text: s.slice(0, n - 1) + "…", clipped: true } : { text: s, clipped: false };
 }
 
-/** #809: the one-line footer for compact rows whose values were clipped. */
-export function compactClipNote(count) {
+/** #809: the one-line footer for compact rows whose values were clipped.
+ *
+ *  #1634: `cap` is the per-value cap ACTUALLY in force. On a PINPOINT read (explicit
+ *  `ids`) it is raised off the survey clip, and then "read fuller values with
+ *  `fields`:"detail"" would be exactly the dead retry #809 exists to remove — detail
+ *  applies the SAME fixed cap. Name the cap that fired, and the lever that would help.
+ *  Mirrors the orchestrator twin in comfyui-mcp src/services/graph-query.ts. */
+export function compactClipNote(count, cap = COMPACT_VALUE_CLIP, maxChars = undefined) {
   if (!count) return "";
-  return `\n(${count} widget value(s) clipped to ${COMPACT_VALUE_CLIP} chars by \`fields\`:"compact" — read fuller values with \`fields\`:"detail", which caps values at ${WIDGET_VALUE_CAP} chars.)`;
+  if (cap <= COMPACT_VALUE_CLIP)
+    return `\n(${count} widget value(s) clipped to ${COMPACT_VALUE_CLIP} chars by \`fields\`:"compact" — read fuller values with \`fields\`:"detail", which caps values at ${WIDGET_VALUE_CAP} chars.)`;
+  return cap < WIDGET_VALUE_CAP
+    ? `\n(${count} widget value(s) clipped to ${cap} chars to fit \`max_chars\`=${maxChars} — ${raiseOrCeiling("max_chars", maxChars, MAX_CHARS_CEILING)} for fuller values, up to a fixed ${WIDGET_VALUE_CAP}-char per-value cap.)`
+    : `\n(${count} widget value(s) clipped to ${WIDGET_VALUE_CAP} chars — the same fixed per-value cap \`fields\`:"detail" applies, which no parameter raises.)`;
 }
 
 // ---------------------------------------------------------------------------

--- a/web/js/lib/graph-read.js
+++ b/web/js/lib/graph-read.js
@@ -271,10 +271,18 @@ export function clipCompactValue(v, n = COMPACT_VALUE_CLIP) {
  *  Mirrors the orchestrator twin in comfyui-mcp src/services/graph-query.ts. */
 export function compactClipNote(count, cap = COMPACT_VALUE_CLIP, maxChars = undefined) {
   if (!count) return "";
+  // When the budget degraded the pinpoint cap back to the survey clip, the cap in force
+  // IS the survey one — emit the survey note verbatim rather than a longer one saying the
+  // same thing. The longer text is not free: it rides inside `max_chars`, and at the 500
+  // floor it alone pushed a reply that fitted past the bound (gate).
   if (cap <= COMPACT_VALUE_CLIP)
     return `\n(${count} widget value(s) clipped to ${COMPACT_VALUE_CLIP} chars by \`fields\`:"compact" — read fuller values with \`fields\`:"detail", which caps values at ${WIDGET_VALUE_CAP} chars.)`;
+  // #1634 (gate): dropping the `fields`:"detail" pointer is only honest AT the fixed cap,
+  // where detail applies the same cap. BELOW it detail is strictly better — capSummaryWidgets
+  // reserves less of the budget for framing — so suppressing the pointer there would hand
+  // back the very clipped prompt this issue is about, minus the lever that works.
   return cap < WIDGET_VALUE_CAP
-    ? `\n(${count} widget value(s) clipped to ${cap} chars to fit \`max_chars\`=${maxChars} — ${raiseOrCeiling("max_chars", maxChars, MAX_CHARS_CEILING)} for fuller values, up to a fixed ${WIDGET_VALUE_CAP}-char per-value cap.)`
+    ? `\n(${count} widget value(s) clipped to ${cap} chars to fit \`max_chars\`=${maxChars} — ${raiseOrCeiling("max_chars", maxChars, MAX_CHARS_CEILING)}, or read this node with \`fields\`:"detail", which reserves less of the budget for framing and so carries more at this size.)`
     : `\n(${count} widget value(s) clipped to ${WIDGET_VALUE_CAP} chars — the same fixed per-value cap \`fields\`:"detail" applies, which no parameter raises.)`;
 }
 

--- a/web/js/lib/graph-read.js
+++ b/web/js/lib/graph-read.js
@@ -269,21 +269,15 @@ export function clipCompactValue(v, n = COMPACT_VALUE_CLIP) {
  *  `fields`:"detail"" would be exactly the dead retry #809 exists to remove — detail
  *  applies the SAME fixed cap. Name the cap that fired, and the lever that would help.
  *  Mirrors the orchestrator twin in comfyui-mcp src/services/graph-query.ts. */
-export function compactClipNote(count, cap = COMPACT_VALUE_CLIP, maxChars = undefined) {
+export function compactClipNote(count, cap = COMPACT_VALUE_CLIP) {
   if (!count) return "";
-  // When the budget degraded the pinpoint cap back to the survey clip, the cap in force
-  // IS the survey one — emit the survey note verbatim rather than a longer one saying the
-  // same thing. The longer text is not free: it rides inside `max_chars`, and at the 500
-  // floor it alone pushed a reply that fitted past the bound (gate).
+  // #1634: the cap is uniform across the row and is only ever the survey clip or the fixed
+  // per-value cap, so the note has exactly two honest forms. An intermediate, budget-derived
+  // cap was tried and removed: it made the note name a number that was in force for no
+  // widget, and called a cut "unraisable" that raising `max_chars` lifted (gate).
   if (cap <= COMPACT_VALUE_CLIP)
     return `\n(${count} widget value(s) clipped to ${COMPACT_VALUE_CLIP} chars by \`fields\`:"compact" — read fuller values with \`fields\`:"detail", which caps values at ${WIDGET_VALUE_CAP} chars.)`;
-  // #1634 (gate): dropping the `fields`:"detail" pointer is only honest AT the fixed cap,
-  // where detail applies the same cap. BELOW it detail is strictly better — capSummaryWidgets
-  // reserves less of the budget for framing — so suppressing the pointer there would hand
-  // back the very clipped prompt this issue is about, minus the lever that works.
-  return cap < WIDGET_VALUE_CAP
-    ? `\n(${count} widget value(s) clipped to ${cap} chars to fit \`max_chars\`=${maxChars} — ${raiseOrCeiling("max_chars", maxChars, MAX_CHARS_CEILING)}, or read this node with \`fields\`:"detail", which reserves less of the budget for framing and so carries more at this size.)`
-    : `\n(${count} widget value(s) clipped to ${WIDGET_VALUE_CAP} chars — the same fixed per-value cap \`fields\`:"detail" applies, which no parameter raises.)`;
+  return `\n(${count} widget value(s) clipped to ${WIDGET_VALUE_CAP} chars — the same fixed per-value cap \`fields\`:"detail" applies, which no parameter raises.)`;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Live-canvas half of **artokun/comfyui-mcp#1634**. Orchestrator twin: **artokun/comfyui-mcp#1637**.

This is the half the reporter actually hits — they read the prompt off the live canvas via `panel_query_graph`, which lands here, not in the orchestrator's saved-workflow engine.

## The filed hypothesis is not what happens

#1634 proposed that `graph_outline` sheds widget values on an over-budget graph, with a falsifiable prediction attached: *"If the prompt is truncated on a small graph, this analysis is wrong and the bug is elsewhere."*

Measured on a four-node graph — no rung degrades, nothing near a budget — a 300-char prompt still came back cut at 60, in a **301-char reply against a 12000-char budget**. So the prediction lands on the "wrong" side, and the truncation is not graph-size dependent. That also explains the reporter's "**always**": a fixed clip fires every time; a ladder rung would not.

## What actually happens

The compact projection clips widget values at a fixed 60 chars. That is a **survey** cap — it keeps a 200-node listing of nodes you have not identified yet small.

It was also applied when the caller named the node **explicitly by `ids`** — the opposite case. There the node is already identified, so the clip only starves the value that was asked for. And the shortfall is **silent**: a clipped prompt ends in an ellipsis a real prompt could plausibly contain, so it gets quoted back as the node's content — which is why it reads as a bug in the prompt node rather than in the retrieval.

## The fix

A **single-id** read renders its widget values at the same per-value cap the `detail` projection uses — but only when the generous row **demonstrably fits** the budget. If it does not fit, we render exactly what main renders.

Two deliberate restrictions, both caught by the review gate on earlier versions:

- **Only one id is a pinpoint.** Treating any `ids` list as one cost rows the caller explicitly asked for (20 ordinary 600-char prompts went 20/20 → 18/20).
- **A fit test, not an arithmetic reserve.** Reserves leaked — a per-widget floor still grows without bound across many widgets, so a 24-widget node breached `max_chars` on *default* parameters while reporting `truncated:false`.

Deliberately **unchanged**: the compact **shape** (still one line per node), the **survey** path, **`max_chars`**, and the **outline ladder** — which #1634 flagged as carrying expensive #809/#1184/#1203 invariants. This does not touch it.

`compactClipNote()` now takes the cap in force and has exactly **two** honest forms, because the cap is uniform across a row and is only ever the survey clip or the fixed per-value cap. An intermediate budget-derived cap was tried and removed: it named a number that was in force for *no* widget, and called a cut "unraisable" that raising `max_chars` demonstrably lifted — the #809 wrong-lever defect verbatim.

## Verification — browser, not just helpers

The call site (`clipCompactValue(v, compactValueCap)`) is **invisible to the helper-level unit tests**: `browser_tests/unit/graph-read.test.mjs` stays green with the wiring deleted. So this adds `browser_tests/pinpoint-read-returns-full-value.spec.ts`, driving the real `graph_query` executor against a real canvas.

**Mutation-tested in the browser:**

| | pinpoint test | survey test |
|---|---|---|
| with the fix | **pass** | pass |
| `web/js` reverted to `origin/main`, spec retained | **FAIL** (60-char clip) | pass |

The wiring is load-bearing, and the survey path is provably untouched.

- `node --test browser_tests/unit/graph-read.test.mjs` — 40 pass (38 pre-existing + 2 new).
- `check-panel-scope`, `check-tool-vocabulary`, `i18n-check` — all OK.
- Full `npx playwright test --workers=1` — results in the comment below.

### A harness note worth recording

The e2e suite serves the panel through ComfyUI's `custom_nodes` junction, which points at the **main checkout**, not at a worktree. My first run therefore tested `main`'s code and the fix looked absent; pointing the junction at the worktree instead left the panel unable to mount. The served checkout was also **7 commits behind `origin/main`**, so dropping newer files into it broke module load outright — which looks exactly like "your change broke the panel". Fast-forwarding it and re-applying the two files was what finally exercised the real path. I left that checkout clean and current.

## Gate

codex was unavailable (account exhausted until 2026-08-19); gated by an independent adversarial review instead (`claude-gate.mjs`), which spawns a fresh reviewer that has never seen my reasoning. Disclosing the substitution is the condition it was accepted under.
