### PR TITLE
fix(1588): the reassurance's own predicate must read the UNEXPLAINED surfaces too

### DIFF
--- a/web/js/lib/graph-binding.js
+++ b/web/js/lib/graph-binding.js
@@ -1850,9 +1850,18 @@ export function describeOpenRebindOutcome(verdict, observed = {}) {
     // strict proof saw something else — a second serialization of a live canvas can
     // move between the verdict and this message. The sentence stays for that, and it
     // stays TRUE of what it is describing, because it asks the same question.
+    //
+    // #1588 — fed the UNEXPLAINED surfaces, not the raw list, for the same reason
+    // `nodesOnly` above is: an accounted `definitions` difference (pure link
+    // renumbering, verified by the fail-closed predicate that produced
+    // `contentAccountedSurfaces`) is not a second surface anyone should weigh, and
+    // the predicate refuses on ANY second surface. Passing the raw list re-blocked
+    // the reassurance one level below the gate the accounted list was added to fix.
+    // Anything NOT accounted for still arrives here and still refuses — `unexplained`
+    // only ever drops a surface the panel has already fully characterised.
     const valuesMatched = openContentDifferenceIsPresentationOnly({
       comparable: compared,
-      surfaces: observed.contentSurfaces,
+      surfaces: unexplained,
       nodeDifference: observed.contentNodeDifference,
     });
     if (compared && nodesOnly && nodeSetIntact) {


### PR DESCRIPTION
## Red main: a merge interaction between #1252 and #1274

CI run 31965727849: `open-subgraph-definitions-disclosure.test.mjs` → "the reporter's shape: an accounted `definitions` no longer blocks the reassurance" fails on `main`, though each PR passed alone.

## Root cause

Two PRs fixed the same defect at two different depths, and only one of them knew about the other:

- **#1252** taught the reassurance GATE in `describeOpenRebindOutcome` to test `unexplainedContentSurfaces(observed)` — so a `definitions` difference that is pure link renumbering (#886, verified by the fail-closed `definitionsDifferOnlyByLinkRenumber` and carried in `contentAccountedSurfaces`) no longer blocks the reassurance.
- **#1274** (landed first) routed the reassurance SENTENCE through the shared `openContentDifferenceIsPresentationOnly` predicate — which deliberately refuses on ANY second differing surface — and fed it the **raw** `observed.contentSurfaces`.

So for the reporter's exact shape (`contentSurfaces: ["nodes", "definitions"]`, `definitions` accounted for, node set intact, cosmetic-only): the gate passed, then `valuesMatched` came out `false` on the raw two-surface list, and the message fell to the weaker "no node was lost … UNCONFIRMED" branch — never saying "carrying the same widget values and links … no missing work to redo". The #1588 reassurance was re-blocked one level below the gate that was fixed.

## The change

One argument at one call site (`web/js/lib/graph-binding.js`, in `describeOpenRebindOutcome`): `openContentDifferenceIsPresentationOnly` is now fed the same `unexplained` surface list the gate uses instead of `observed.contentSurfaces`.

This is safe in both directions:

- `unexplained` only ever drops a surface that is in `contentAccountedSurfaces`, which is produced by the same fail-closed renumber predicate the content verdict trusts, and is additionally gated to `definitions`-only plus actual membership in the differing list. Anything NOT fully characterised still arrives at the predicate and still refuses.
- The predicate itself is untouched, so #1274's pinned guarantee ("a SECOND differing surface is never presentation-only", including a raw `["nodes", "definitions"]` input) still holds, and the verdict path in `graphRootReproducesStateContent` still reads raw surfaces — this changes the sentence, not the answer.

## Verification

- `node --test browser_tests/unit/open-subgraph-definitions-disclosure.test.mjs` — 13/13 pass (was 12/13), including the fail-closed cases ("a definitions difference that is NOT accounted for still blocks the reassurance", "an accounted surface does not license a genuinely unexplained one")
- `npm run test:unit` — 4726 pass / 0 fail / 1 todo; i18n, tool-vocabulary and panel-scope gates all OK
- `npm run typecheck` — clean