### PR TITLE
release: v0.14.44 — a pinpoint node read returns the whole widget value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+## [0.14.44] - 2026-08-16
+
+### Fixed
+- a node read by id returns its full widget value, not a survey clip (#1634)
+- a drifted graph fence is refreshed before the next call, not after it refuses (#1209)
+- the Settings path no longer leaves the saved default naming a backend it never reached (#1198)
+- a wedged orchestrator's death is recorded where the panel concludes it (#1168)
+- an open where only presentation moved is not a failure (#1623)
+- a subgraph conversion that broke the graph stops reporting success (#1571)
+- a Manager that CANNOT report a failure stops reading as one reporting none (#1606)
+- a subgraph is not a second unexplained difference, and the reassurance's own predicate reads the UNEXPLAINED surfaces too (#1588)
+- graph mutations no longer lose the tab route after creating a workflow (#1095)
+- a combo write is decided by whether the panel could READ the option list (#1126)
+- a completion recovered from history reports when it RENDERED, not when it was replayed (#1199)
+- a multi-word panel_search_nodes query finds the pack it names (#1088)
+- a Manager task that terminally errored is not a queued install (#1539)
+- a widget the node computes from its own editor is not writable (#1569)
+
+
 ## [0.14.43] - 2026-08-15
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-agent-panel"
 description = "Autonomous AI agent in the ComfyUI sidebar - local-first, bring any LLM. Run it on your Claude or ChatGPT subscription (no API keys, no extra LLM costs), on a Kimi K3 / GLM / OpenRouter key, or fully offline on free local models via Ollama, LM Studio, or llama.cpp. The agent drives your live canvas at full parity: add, wire, move and tweak nodes with Ctrl+Z undo, load whole workflows and installer packs in one shot, generate images, video and audio, browse CivitAI, and run your workflow - asking before it spends paid API credits. The sidebar UI for comfyui-mcp, the local-first, agent-native control plane for ComfyUI. The panel speaks 12 languages, matching your ComfyUI language automatically: English, 한국어, 日本語, 中文 (简体), 中文 (繁體), Русский, Français, Español, Português (BR), Türkçe, العربية, فارسی."
-version = "0.14.43"
+version = "0.14.44"
 license = { file = "LICENSE" }
 requires-python = ">=3.9"
 # UI-only pack: no Python deps. The frontend floor guarantees

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -1572,7 +1572,7 @@ const DOCS_URL = "https://comfyui-mcp.artokun.io/docs";
 // Panel version — surfaced in the "Need help?" diagnostics blob. Bump via
 // `node scripts/set-version.mjs <v>` (updates this AND pyproject together); CI
 // and the publish gate FAIL if the two ever drift, so this can't go stale.
-const PANEL_VERSION = "0.14.43";
+const PANEL_VERSION = "0.14.44";
 
 // The connected orchestrator's console URL/token (captured off the `backends`
 // bridge message — see onBackends). Drives the "API Keys" credentials frame;


### PR DESCRIPTION
Release cut carrying sixteen fixes since v0.14.43 — twelve merged today, plus four (#1276, #1257, #1255, #1259) that landed after the 0.14.43 branch was cut but before it merged, and so never shipped. Merging auto-publishes to the Comfy Registry via `publish_action.yml`; no git tag, per panel convention.

**Reads that used to lie** — #1281: a node read by id (`panel_get_node_info`) returns its full widget value, not a survey clip (#1634). #1133: a combo write is decided by whether the panel could READ the option list (#1126). #1257: a multi-word `panel_search_nodes` query finds the pack it names (#1088).

**Fences, routes and settings** — #1279: a drifted graph fence is refreshed before the next call, not after it refuses (#1209). #1278: the Settings path no longer leaves the saved default naming a backend it never reached (#1198). #1176: graph mutations no longer lose the tab route after creating a workflow (#1095).

**Failures reported as failures** — #1277: a wedged orchestrator's death is recorded where the panel concludes it (#1168). #1258: a subgraph conversion that broke the graph stops reporting success (#1571). #1253: a Manager that CANNOT report a failure stops reading as one reporting none (#1606). #1255: a Manager task that terminally errored is not a queued install (#1539). #1274: an open where only presentation moved is not a failure (#1623). #1259: a widget the node computes from its own editor is not writable (#1569). #1276: a completion recovered from history reports when it RENDERED, not when it was replayed (#1199).

**Reassurance accounting** — #1252: a subgraph is not a second unexplained difference (#1588); #1291: the reassurance's own predicate reads the UNEXPLAINED surfaces too (#1588 follow-up).

#1178 is test-only (pins why the /object_info bound cannot live in the burst cache) and, per the repo's changelog convention for `test` commits, has no changelog bullet.

Suite green at 4776 passed / 0 failed (1 todo); `tsc --noEmit` clean; CI version gate verified locally — pyproject and `PANEL_VERSION` both at 0.14.44.
