### PR TITLE
fix(1289): dictation listens in the panel's language, not the browser's

### DIFF
--- a/browser_tests/unit/voice-language.test.mjs
+++ b/browser_tests/unit/voice-language.test.mjs
@@ -1,0 +1,42 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { readFileSync } from 'node:fs'
+
+import { voiceRecognitionLang } from '../../web/js/lib/voice-language.js'
+
+// #1289 — dictation set recognition.lang from navigator.language alone, so a user
+// who picked a panel (or ComfyUI) language different from their browser's dictated
+// into a recognizer listening for the WRONG language.
+
+test('#1289 the panel locale wins over the browser language', () => {
+  assert.equal(voiceRecognitionLang({ panelLocale: 'fr', browserLang: 'en-US' }), 'fr')
+  assert.equal(voiceRecognitionLang({ panelLocale: 'pt-BR', browserLang: 'de-DE' }), 'pt-BR')
+  // Regional panel codes are valid BCP-47 tags and pass through untouched.
+  assert.equal(voiceRecognitionLang({ panelLocale: 'zh-TW', browserLang: 'en-US' }), 'zh-TW')
+})
+
+test('#1289 an unresolved panel locale defers to the browser', () => {
+  assert.equal(voiceRecognitionLang({ panelLocale: '', browserLang: 'ja-JP' }), 'ja-JP')
+  assert.equal(voiceRecognitionLang({ browserLang: 'ko-KR' }), 'ko-KR')
+})
+
+test('#1289 lang is never empty — en-US is the floor', () => {
+  assert.equal(voiceRecognitionLang({}), 'en-US')
+  assert.equal(voiceRecognitionLang({ panelLocale: '', browserLang: '' }), 'en-US')
+  assert.equal(voiceRecognitionLang(), 'en-US')
+})
+
+test('#1289 WIRED: the composer hands the recognizer the PANEL locale, not raw navigator.language', () => {
+  // The helper nothing calls is inert, and the old line is the bug itself — pin both.
+  const src = readFileSync(new URL('../../web/js/comfyui-mcp-panel.js', import.meta.url), 'utf8')
+  assert.match(src, /import \{ voiceRecognitionLang \} from "\.\/lib\/voice-language\.js";/)
+
+  const assign = src.indexOf('recognition.lang =')
+  assert.ok(assign > 0, 'recognition.lang is set')
+  const line = src.slice(assign, src.indexOf('\n', assign))
+  assert.match(line, /voiceRecognitionLang\(\{ panelLocale: currentLocale\(\), browserLang: navigator\.language \}\)/)
+  assert.ok(
+    !src.includes('recognition.lang = navigator.language'),
+    'the raw navigator.language assignment is retired',
+  )
+})

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -66,6 +66,7 @@
 // so that path threw ReferenceError rather than refusing cleanly (#1136 sweep).
 import { resolvePromotedInnerTarget } from "./lib/widget-write.js";
 import { describeVoiceError } from "./lib/voice-error.js";
+import { voiceRecognitionLang } from "./lib/voice-language.js";
 import { marked } from "./vendor/marked.esm.js";
 import DOMPurify from "./vendor/purify.es.js";
 import qrcodegen from "./vendor/qrcode.esm.js";
@@ -33271,7 +33272,10 @@ function buildPanel() {
       return;
     }
     recognition = new SR();
-    recognition.lang = navigator.language || "en-US";
+    // Dictate in the language the PANEL is speaking (#1289): currentLocale() already
+    // encodes the explicit panel setting → ComfyUI locale → navigator precedence, so
+    // the browser's own language is only a fallback for an unresolved panel.
+    recognition.lang = voiceRecognitionLang({ panelLocale: currentLocale(), browserLang: navigator.language });
     recognition.continuous = true;
     recognition.interimResults = false;
     recognition.addEventListener("result", (ev) => {

--- a/web/js/lib/voice-language.js
+++ b/web/js/lib/voice-language.js
@@ -1,0 +1,26 @@
+// #1289 — dictate in the language the panel is speaking, not whatever the browser says.
+//
+// ## The defect
+//
+// The composer set `recognition.lang = navigator.language || "en-US"`. A user who set the
+// panel (or ComfyUI itself) to French while their browser reports en-US dictated French
+// into an English recognizer and got garbage back. The panel had ALREADY resolved which
+// language it is speaking — pickLocale's explicit-setting → ComfyUI-locale → navigator
+// order — and dictation ignored all of it.
+//
+// ## What this module does
+//
+// One precedence, stated once: the panel's own resolved locale wins; the browser's
+// language is the fallback for a panel that has not resolved one yet; "en-US" is the
+// floor so `lang` is never an empty string (an empty BCP-47 tag is a silent
+// implementation-defined default, which is how this bug looked from the inside).
+// The panel's codes ("pt-BR", "zh-TW", bare "zh") are all valid BCP-47 tags, so no
+// remapping happens here — the locale is passed through, not reinterpreted.
+
+/**
+ * The BCP-47 tag to hand SpeechRecognition: the panel's resolved locale first, the
+ * browser's language second, "en-US" last.
+ */
+export function voiceRecognitionLang({ panelLocale, browserLang } = {}) {
+  return panelLocale || browserLang || "en-US";
+}


### PR DESCRIPTION
## Root cause

The composer set `recognition.lang = navigator.language || "en-US"`. The panel had **already resolved** which language it is speaking — `pickLocale`'s explicit panel setting → ComfyUI `Comfy.Locale` → navigator order — and dictation ignored all of it. A user who set the panel to French while their browser reported en-US dictated French into an English recognizer and got garbage back.

## The fix

New module `web/js/lib/voice-language.js` exporting `voiceRecognitionLang({ panelLocale, browserLang })`:

- the panel's resolved locale (`currentLocale()`) wins — it already encodes the explicit-setting → ComfyUI-locale → navigator precedence;
- the browser language is the fallback for a panel that has not resolved one;
- `en-US` is the floor, so `lang` is never an empty BCP-47 tag (an empty tag is a silent implementation-defined default — which is how this bug looked from the inside).

Panel locale codes (`pt-BR`, `zh-TW`, bare `zh`) are all valid BCP-47 tags, so they pass through unremapped.

No new UI strings, so no catalog changes. Independent branch off `origin/main`; touches different lines of the dictation block than #1288's PR (#1301), so the two merge cleanly either order.

## Verified

- `npm ci` — clean
- `npm run typecheck` (tsc --noEmit) — clean
- `npm run test:unit` — 4868 tests, 0 fail (includes `i18n-check`, `i18n-render-check`, `check-tool-vocabulary`, `check-panel-scope` gates)
- New `browser_tests/unit/voice-language.test.mjs` — 4 tests: panel locale beats browser language (incl. regional codes passed through untouched), unresolved panel defers to browser, empty never reaches the recognizer, and a WIRED test pinning the composer assignment plus the retirement of the raw `navigator.language` line.

Closes #1289