### PR TITLE
fix(1290): the desktop app disables dictation with the reason, instead of failing on every click

### DIFF
--- a/browser_tests/unit/voice-support.test.mjs
+++ b/browser_tests/unit/voice-support.test.mjs
@@ -1,0 +1,60 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { readFileSync } from 'node:fs'
+
+import { isEmbeddedDesktopShell, voiceInputSupport } from '../../web/js/lib/voice-support.js'
+
+// #1290 — the mic button was gated on the SpeechRecognition API object EXISTING.
+// The ComfyUI desktop app's Electron shell exposes webkitSpeechRecognition but
+// has no speech service behind it, so dictation could never work there and the
+// button still looked ready — every click failed instead of saying so.
+
+class FakeSR {}
+
+test('#1290 a desktop shell is detected from the Electron bridge or the UA token', () => {
+  assert.equal(isEmbeddedDesktopShell({ electronBridge: {} }), true)
+  assert.equal(isEmbeddedDesktopShell({ userAgent: 'Mozilla/5.0 (Windows NT 10.0) Chrome/126.0.0.0 Electron/31.0.0' }), true)
+  assert.equal(isEmbeddedDesktopShell({ electronBridge: {}, userAgent: '' }), true)
+  assert.equal(
+    isEmbeddedDesktopShell({ userAgent: 'Mozilla/5.0 (Windows NT 10.0) AppleWebKit/537.36 Chrome/126.0.0.0 Safari/537.36' }),
+    false,
+  )
+  assert.equal(isEmbeddedDesktopShell({}), false)
+})
+
+test('#1290 no API object at all keeps the plain not-supported reason', () => {
+  const v = voiceInputSupport({ SR: undefined, desktopShell: false })
+  assert.equal(v.supported, false)
+  assert.equal(v.title, 'Voice input is not supported in this browser')
+})
+
+test('#1290 an API object in a desktop shell is UNSUPPORTED — and the title names the remedy', () => {
+  const v = voiceInputSupport({ SR: FakeSR, desktopShell: true })
+  assert.equal(v.supported, false)
+  assert.match(v.title, /desktop app/, 'says WHERE dictation is unavailable')
+  assert.match(v.title, /speech-recognition service/, 'says WHY')
+  assert.match(v.title, /Chrome or Edge/, 'says what to do instead')
+})
+
+test('#1290 an API object in a plain browser is supported, with no title to show', () => {
+  const v = voiceInputSupport({ SR: FakeSR, desktopShell: false })
+  assert.deepEqual(v, { supported: true })
+})
+
+test('#1290 WIRED: the mic button and the click handler both consult the support verdict', () => {
+  const src = readFileSync(new URL('../../web/js/comfyui-mcp-panel.js', import.meta.url), 'utf8')
+  assert.match(src, /import \{ isEmbeddedDesktopShell, voiceInputSupport \} from "\.\/lib\/voice-support\.js";/)
+
+  // The verdict is computed once, from the API object AND the desktop-shell check.
+  assert.match(src, /const voiceSupport = voiceInputSupport\(\{/)
+  assert.match(src, /desktopShell: isEmbeddedDesktopShell\(\{/)
+
+  // The button is disabled with the verdict's OWN title — no inline string that
+  // could drift from the lib's reason.
+  assert.match(src, /micBtn\.disabled = true;\s*\n\s*micBtn\.title = voiceSupport\.title;/)
+
+  // The click path refuses on the verdict too, so a stale listener cannot start
+  // a backend-less session.
+  assert.match(src, /if \(!voiceSupport\.supported\) return;/)
+  assert.ok(!src.includes('if (!SR) return;'), 'the API-exists-only guard is retired')
+})

--- a/locales/en/main.json
+++ b/locales/en/main.json
@@ -876,6 +876,7 @@
       "view_full_size": "View full size",
       "voice_input_error": "Voice input error: {error}",
       "voice_input_failed_this_browser_could_not": "Voice input failed: this browser could not reach its speech-recognition service (\"network\"). Chromium-based browsers other than Google Chrome and Microsoft Edge ship without one, so dictation cannot work here — use Chrome or Edge for voice input.",
+      "voice_input_is_not_available_in_the": "Voice input is not available in the ComfyUI desktop app — its embedded browser has no speech-recognition service. Open ComfyUI in Chrome or Edge to dictate.",
       "voice_input_is_not_supported_in_this": "Voice input is not supported in this browser",
       "voice_input_was_blocked_allow_microphone": "Voice input was blocked (\"{error}\"): allow microphone access for this page and try again.",
       "waiting_for_approval": "Waiting for approval…",

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -67,6 +67,7 @@
 import { resolvePromotedInnerTarget } from "./lib/widget-write.js";
 import { describeVoiceError } from "./lib/voice-error.js";
 import { voiceRecognitionLang } from "./lib/voice-language.js";
+import { isEmbeddedDesktopShell, voiceInputSupport } from "./lib/voice-support.js";
 import { marked } from "./vendor/marked.esm.js";
 import DOMPurify from "./vendor/purify.es.js";
 import qrcodegen from "./vendor/qrcode.esm.js";
@@ -33261,12 +33262,23 @@ function buildPanel() {
   // ---- voice dictation (browser speech recognition; Chrome) ----
   const SR = window.SpeechRecognition ?? window.webkitSpeechRecognition;
   let recognition = null;
-  if (!SR) {
+  // "Supported" means a speech SERVICE exists, not just the API object (#1290): the
+  // ComfyUI desktop app's Electron shell exposes webkitSpeechRecognition but has no
+  // backend behind it, so the button must say dictation is unavailable rather than
+  // fail on every click. Detected the way openExternalUrl already detects Electron.
+  const voiceSupport = voiceInputSupport({
+    SR,
+    desktopShell: isEmbeddedDesktopShell({
+      electronBridge: window.electronAPI ?? window.comfyAPI?.electron,
+      userAgent: navigator.userAgent,
+    }),
+  });
+  if (!voiceSupport.supported) {
     micBtn.disabled = true;
-    micBtn.title = tr("panel.voice_input_is_not_supported_in_this", "Voice input is not supported in this browser");
+    micBtn.title = voiceSupport.title;
   }
   micBtn.addEventListener("click", () => {
-    if (!SR) return;
+    if (!voiceSupport.supported) return;
     if (recognition) {
       recognition.stop();
       return;

--- a/web/js/lib/voice-support.js
+++ b/web/js/lib/voice-support.js
@@ -1,0 +1,57 @@
+// #1290 — in the ComfyUI desktop app the mic button must SAY dictation cannot work.
+//
+// ## The defect
+//
+// The composer gated the mic button on `window.SpeechRecognition ??
+// window.webkitSpeechRecognition` existing. In the desktop app (Electron) the API
+// object EXISTS, so the button looked ready — but Electron ships with no speech
+// service behind it, and every dictation attempt failed at `start()`. "Supported"
+// was being read as "the constructor exists" when the question the user needs
+// answered is "is there a backend that can recognize speech".
+//
+// ## What this module does
+//
+// Two small verdicts, both pure so the panel's DOM wiring stays thin:
+//
+//   * `isEmbeddedDesktopShell` — are we inside Electron. Detected the way the rest
+//     of the panel already detects it (the `electronAPI` / `comfyAPI.electron`
+//     bridge openExternalUrl uses), with the `Electron/` UA token as the belt to
+//     the bridge's suspenders.
+//   * `voiceInputSupport` — can dictation work HERE, and if not, the one sentence
+//     that says why. A desktop shell is unsupported even when the API object
+//     exists, and the sentence names the remedy: open ComfyUI in Chrome or Edge.
+import { tr } from "./i18n.js";
+
+/**
+ * Whether this window is an embedded Electron shell (ComfyUI Desktop). The bridge
+ * object is checked first because it cannot lie about its own presence; the UA
+ * token covers shells where the bridge was never injected.
+ */
+export function isEmbeddedDesktopShell({ electronBridge, userAgent } = {}) {
+  return Boolean(electronBridge) || /Electron\//.test(userAgent || "");
+}
+
+/**
+ * Dictation support as `{ supported, title? }`. `title` is the mic button's
+ * hover text when unsupported — the button is DISABLED, so the title is the only
+ * place the reason can live, and it must say why rather than just "no".
+ */
+export function voiceInputSupport({ SR, desktopShell } = {}) {
+  if (!SR) {
+    return {
+      supported: false,
+      title: tr("panel.voice_input_is_not_supported_in_this", "Voice input is not supported in this browser"),
+    };
+  }
+  if (desktopShell) {
+    return {
+      supported: false,
+      title: tr(
+        "panel.voice_input_is_not_available_in_the",
+        "Voice input is not available in the ComfyUI desktop app — its embedded browser has no " +
+          "speech-recognition service. Open ComfyUI in Chrome or Edge to dictate.",
+      ),
+    };
+  }
+  return { supported: true };
+}


### PR DESCRIPTION
## Root cause

The mic button was gated on the SpeechRecognition API object **existing** (`window.SpeechRecognition ?? window.webkitSpeechRecognition`). The ComfyUI desktop app's Electron shell exposes `webkitSpeechRecognition` but ships **no speech service behind it**, so the button looked ready and every dictation attempt failed at `start()`. "Supported" was read as "the constructor exists" when the question the user needs answered is "is there a backend that can recognize speech" — and in Electron there never is one.

## The fix

New module `web/js/lib/voice-support.js` with two pure verdicts:

- `isEmbeddedDesktopShell({ electronBridge, userAgent })` — detects Electron the way the rest of the panel already detects it (the `electronAPI` / `comfyAPI.electron` bridge that `openExternalUrl` uses), with the `Electron/` UA token as backup for shells where the bridge was never injected.
- `voiceInputSupport({ SR, desktopShell })` — returns `{ supported, title? }`. A desktop shell is unsupported **even when the API object exists**, and the disabled button's hover title says why and names the remedy: *"Voice input is not available in the ComfyUI desktop app — its embedded browser has no speech-recognition service. Open ComfyUI in Chrome or Edge to dictate."*

Both the button setup and the click handler consult the verdict, so a stale listener cannot start a backend-less session. The no-API-at-all case keeps the existing "not supported in this browser" string unchanged. One new English catalog string, generated with `node scripts/i18n-build-en.mjs`.

Independent branch off `origin/main`; touches different lines of the dictation block than #1288 (#1301) and #1289 (#1302), so the three merge cleanly in any order.

## Verified

- `npm ci` — clean
- `npm run typecheck` (tsc --noEmit) — clean
- `npm run test:unit` — 4869 tests, 0 fail (includes `i18n-check`, `i18n-render-check`, `check-tool-vocabulary`, `check-panel-scope` gates)
- New `browser_tests/unit/voice-support.test.mjs` — 5 tests: shell detection via bridge and UA token, no-API keeps the plain reason, desktop+API is unsupported with a title naming the remedy, plain browser is supported, and a WIRED test pinning that the button and click handler both consult the verdict (and the old `if (!SR)` guard is retired).

Note: verified by unit tests and gates; I could not click the button inside a real ComfyUI Desktop install from here, so the Electron detection is pinned to the two signals the codebase already relies on (bridge object + UA token) rather than a live manual test.

Closes #1290