### PR TITLE
fix(1287): a search limit above the cap is disclosed as limit_cap, not silently honored

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ which receives `panel_*` by a different route.
 
 | Tool | Effect |
 |---|---|
-| `panel_search_nodes` | Search installable node packs (the Manager's own source) |
+| `panel_search_nodes` | Search installable node packs (the Manager's own source; `limit` defaults to 15, max 40) |
 | `panel_install_node` | Queue a pack install (registry id or git URL) |
 | `panel_node_queue_status` | Check the Manager's install / update queue |
 | `panel_restart_comfyui` | Restart ComfyUI to load new nodes — panel auto-reconnects and the agent resumes |

--- a/browser_tests/unit/manager-install.test.mjs
+++ b/browser_tests/unit/manager-install.test.mjs
@@ -30,6 +30,7 @@ const {
   searchNodesVia,
   parseObjectInfoSearch,
   objectInfoSearchFallback,
+  SEARCH_LIMIT_CAP,
 } = ManagerInstall;
 
 test("looksLikeGitUrl recognizes every git protocol, plus author/repo shorthand (#301)", () => {
@@ -1451,6 +1452,62 @@ test("parseNodeMappings handles array + map shapes and caps the limit", () => {
   const many = Array.from({ length: 60 }, (_, i) => ({ id: `p/${i}`, title: `t${i}` }));
   assert.equal(parseNodeMappings(many, "", 999).results.length, 40);
   assert.equal(parseNodeMappings(many, "").results.length, 15);
+});
+
+test("#1287 a limit above the cap is DISCLOSED as limit_cap, not silently honored", () => {
+  // The tool's published description documented no maximum while the schema rejected
+  // limit>40 (MCP -32602) and the panel silently returned fewer rows than asked. The
+  // cap stays — but whenever it bites, the result must NAME it, so a truncated list
+  // can no longer read as the whole answer.
+  const many = Array.from({ length: 60 }, (_, i) => ({ id: `p/${i}`, title: `t${i}` }));
+
+  const clamped = parseNodeMappings(many, "", SEARCH_LIMIT_CAP + 10);
+  assert.equal(clamped.results.length, SEARCH_LIMIT_CAP);
+  assert.equal(clamped.limit_cap, SEARCH_LIMIT_CAP, "a clamped request must say what bound was applied");
+
+  // At or under the cap — and the default path — there is nothing to disclose, and
+  // the payload must not grow a field that claims a clamp that never happened.
+  for (const lim of [SEARCH_LIMIT_CAP, 5, undefined]) {
+    const r = parseNodeMappings(many, "", lim);
+    assert.equal("limit_cap" in r, false, `limit ${String(lim)} was not clamped and must not say it was`);
+  }
+
+  // The /object_info fallback search enforces the same bound and discloses it the
+  // same way.
+  const bigInfo = Object.fromEntries(
+    Array.from({ length: 60 }, (_, i) => [`Node${i}`, { display_name: `Node ${i}` }]),
+  );
+  const infoClamped = parseObjectInfoSearch(bigInfo, "", SEARCH_LIMIT_CAP + 10);
+  assert.equal(infoClamped.results.length, SEARCH_LIMIT_CAP);
+  assert.equal(infoClamped.limit_cap, SEARCH_LIMIT_CAP);
+  assert.equal("limit_cap" in parseObjectInfoSearch(bigInfo, "", SEARCH_LIMIT_CAP), false);
+});
+
+test("#1287 the object_info FALLBACK wrapper keeps the limit_cap disclosure", async () => {
+  // objectInfoSearchFallback re-wraps the parsed result; the disclosure must survive
+  // the re-wrap or the unreachable-Manager path silently loses it.
+  const UNREACHABLE_ERR = new Error("Manager customnode/getmappings: not reachable");
+  const bigInfo = Object.fromEntries(
+    Array.from({ length: 60 }, (_, i) => [`Node${i}`, { display_name: `Node ${i}` }]),
+  );
+  const res = await objectInfoSearchFallback(async () => bigInfo, "", SEARCH_LIMIT_CAP + 10, UNREACHABLE_ERR);
+  assert.equal(res.supported, true);
+  assert.equal(res.results.length, SEARCH_LIMIT_CAP);
+  assert.equal(res.limit_cap, SEARCH_LIMIT_CAP, "the fallback path must disclose the same clamp");
+});
+
+test("#1287 the README documents the same bound the search enforces", () => {
+  // The README tool table is the published description this repo owns — it carried no
+  // maximum while the search enforced one, the disagreement the issue reports. Pin
+  // the row to the enforced cap so the two cannot drift apart again.
+  const readme = readFileSync(fileURLToPath(new URL("../../README.md", import.meta.url)), "utf8");
+  const row = readme.split("\n").find((l) => l.includes("`panel_search_nodes`"));
+  assert.ok(row, "the tool table must list panel_search_nodes");
+  assert.match(
+    row,
+    new RegExp(`max ${SEARCH_LIMIT_CAP}\\b`),
+    "the documented limit bound must match the enforced SEARCH_LIMIT_CAP",
+  );
 });
 
 test("#394 parseNodeMappings MAP-shape id is INSTALLABLE (repo URL), never the display title", () => {

--- a/web/js/lib/manager-install.js
+++ b/web/js/lib/manager-install.js
@@ -574,10 +574,22 @@ export function matchesAllTerms(hay, terms) {
 }
 
 /**
+ * #1287 — the most `limit` panel_search_nodes will return. The orchestrator's input
+ * schema rejects anything above this (MCP -32602, `maximum: 40`) and the panel applies
+ * the same bound when it slices results. A request ABOVE the cap is not an error — the
+ * search itself is valid — but silently returning fewer rows than asked is how a caller
+ * ends up reasoning over a truncated list as if it were the whole answer, so the result
+ * DISCLOSES the clamp as `limit_cap` whenever it bit.
+ */
+export const SEARCH_LIMIT_CAP = 40;
+
+/**
  * Normalize a ComfyUI-Manager `/customnode/getmappings` payload into the
  * nodes_search result shape `{ count, results:[{id,title,description}] }`,
- * filtered by `query` and capped at `limit` (default 15, max 40). Pure so the
- * parse/filter is unit-testable away from the browser Manager client. Handles
+ * filtered by `query` and capped at `limit` (default 15, max SEARCH_LIMIT_CAP —
+ * a request above the cap is disclosed as `limit_cap`, never silently honored,
+ * #1287). Pure so the parse/filter is unit-testable away from the browser
+ * Manager client. Handles
  * both wire shapes: an ARRAY of pack objects, or the documented MAP keyed by
  * repo/url → [ [classNames…], { title, description, … } ]. Issues #251/#255.
  *
@@ -614,13 +626,18 @@ export function parseNodeMappings(data, query, limit) {
       push(meta?.id ?? meta?.reference ?? key, meta?.title, meta?.description);
     }
   }
-  const max = Math.min(Number(limit) || 15, 40);
+  const requested = Number(limit) || 15;
+  const max = Math.min(requested, SEARCH_LIMIT_CAP);
   // #808 — `catalogue_size` is how many packs the payload CONTAINED, before the query
   // filter. Without it, "the catalogue is empty" and "the catalogue is fine, your query
   // matched nothing" both arrive as `count: 0` — and the reader takes the first for the
   // second, concludes the pack does not exist, and goes on trying variations of a search
   // that cannot succeed. That conflation is the whole of #808.
-  return { count: out.length, results: out.slice(0, max), catalogue_size: catalogueSize(data) };
+  const result = { count: out.length, results: out.slice(0, max), catalogue_size: catalogueSize(data) };
+  // #1287 — the caller asked for more than the cap; say so, or the short list reads
+  // as the whole answer.
+  if (requested > SEARCH_LIMIT_CAP) result.limit_cap = SEARCH_LIMIT_CAP;
+  return result;
 }
 
 /**
@@ -646,7 +663,9 @@ export function catalogueSize(data) {
  * name → { display_name, category, description, ... } and is ALWAYS present on any
  * running ComfyUI, so an agent can still discover the nodes it can use RIGHT NOW.
  * Filters by `query` across class name / display_name / category / description and
- * caps at `limit` (default 15, max 40). Pure so it is unit-testable off-browser.
+ * caps at `limit` (default 15, max SEARCH_LIMIT_CAP — a request above the cap is
+ * disclosed as `limit_cap`, never silently honored, #1287). Pure so it is
+ * unit-testable off-browser.
  * `id` is the node class name (usable directly as a node type); these are already
  * installed, so no registry install id is needed.
  */
@@ -664,8 +683,12 @@ export function parseObjectInfoSearch(objectInfo, query, limit) {
       }
     }
   }
-  const max = Math.min(Number(limit) || 15, 40);
-  return { count: out.length, results: out.slice(0, max) };
+  const requested = Number(limit) || 15;
+  const max = Math.min(requested, SEARCH_LIMIT_CAP);
+  const result = { count: out.length, results: out.slice(0, max) };
+  // #1287 — same disclosure as the registry search: a clamped limit is named, not silent.
+  if (requested > SEARCH_LIMIT_CAP) result.limit_cap = SEARCH_LIMIT_CAP;
+  return result;
 }
 
 /**
@@ -686,7 +709,7 @@ export async function objectInfoSearchFallback(objectInfoGet, query, limit, err)
   }
   const parsed = parseObjectInfoSearch(info, query, limit);
   if (!parsed.count) return managerUnavailableResult(query, err);
-  return {
+  const result = {
     supported: true,
     managerReachable: false,
     source: "object_info",
@@ -701,6 +724,9 @@ export async function objectInfoSearchFallback(objectInfoGet, query, limit, err)
       "already available to use directly (add with panel_add_node). Searching/installing " +
       "NEW packs from the registry needs the built-in Manager (v4+) enabled.",
   };
+  // #1287 — the clamp disclosure must survive the fallback re-wrap too.
+  if (parsed.limit_cap) result.limit_cap = parsed.limit_cap;
+  return result;
 }
 
 /**


### PR DESCRIPTION
## Root cause

`panel_search_nodes`'s published tool description documented **no** maximum for `limit`, but the 40-item bound was enforced twice over:

- the orchestrator's input schema rejects `limit > 40` up front (`MCP error -32602 … maximum: 40 … path: ["limit"]`) — the rejection the reporter hit with `limit: 50`;
- the panel itself silently clamped to 40 when slicing results (`Math.min(Number(limit) || 15, 40)` in `web/js/lib/manager-install.js`), so any request above the cap that did reach the panel got a truncated list with no sign anything was cut.

The schema/description half of the contract lives in comfyui-mcp (`src/orchestrator/panel-tools.ts`, `limit: z.number().int().min(1).max(40)` with no `.describe` of the bound) — see follow-up below. This PR aligns every surface **this** repo owns.

## The fix

The cap stays at 40 (the issue offers both remedies — "document it or raise it" — and raising only the panel's clamp would change nothing while the schema still rejects `limit > 40` upstream). What changes:

- `web/js/lib/manager-install.js` — the clamp is now a named, exported `SEARCH_LIMIT_CAP = 40`, and whenever a requested `limit` exceeds it the result carries `limit_cap: 40`: in `parseNodeMappings` (registry search), `parseObjectInfoSearch` (installed-node fallback search), and through `objectInfoSearchFallback`'s re-wrap. A request above the cap is not an error — the search itself is valid — but silently returning fewer rows than asked is how a caller reasons over a truncated list as if it were the whole answer. This mirrors the existing `catalogue_size` disclosure precedent.
- `README.md` — the tool table (the published description this repo owns) now documents `limit` (default 15, max 40).

## Tests

`browser_tests/unit/manager-install.test.mjs`:

- `#1287 a limit above the cap is DISCLOSED as limit_cap, not silently honored` — clamped requests name the bound in both parse functions; requests at/under the cap and the default path grow no `limit_cap` field.
- `#1287 the object_info FALLBACK wrapper keeps the limit_cap disclosure` — the disclosure survives the fallback re-wrap.
- `#1287 the README documents the same bound the search enforces` — pins the README row to `SEARCH_LIMIT_CAP` so the documented and enforced bounds cannot drift apart again (same style as the README-claims test in `canvas-tool-disclosure.test.mjs`).

## Verified

- `npm ci` — clean.
- `npm run test:unit` — i18n-check, i18n-render-check, check-tool-vocabulary and check-panel-scope all OK; then 4867 tests: **4866 pass, 1 todo, 0 fail** (includes 125 in `manager-install.test.mjs`).
- `node scripts/check-tool-vocabulary.mjs` — OK (37 core / 92 panel tools).
- `npm run typecheck` (`tsc --noEmit`) — clean.

## Follow-up (not in this PR)

The MCP-facing tool description and input schema for `panel_search_nodes` live in **comfyui-mcp** (`src/orchestrator/panel-tools.ts`): the description still states no maximum while the schema enforces `max(40)`. Documenting the bound there (a `.describe` on `limit`, which also feeds `docs:gen`) is the remaining half of the issue's "align the published schema/description with the actual maximum" remedy and needs a companion PR in that repo.

Closes #1287