### PR TITLE
release: v0.15.0 — opening the panel can start the orchestrator for you

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+## [0.15.0] - 2026-08-17
+
+### Added
+- opening the panel can now START the local MCP orchestrator for you, with a chooser for the LLM provider. The companion launcher binds loopback-only behind a 32-byte token; the pack proxies it so the token never reaches the browser, and the proxy refuses a declared Origin that is not the Host the browser addressed — a plain cross-tab form post can no longer start the process on your behalf (#1243)
+- `panel_set_widget` can CREATE an rgthree `lora_N` slot: writing `lora_1` on a fresh node mints the row instead of being refused for a widget only the node's DOM-only "Add Lora" button could bring into existence. Keyed on node type, the `lora_<n>` name shape and a lora-slot-shaped value, so an ordinary typo cannot reach it (#757)
+
+### Fixed
+- a voice-dictation error now names the cause and the way out, not just the Web Speech code (#1288)
+- dictation listens in the panel's language, not the browser's (#1289)
+- the desktop app disables dictation with the reason, instead of failing on every click (#1290)
+- a search limit above the cap is disclosed as limit_cap, not silently honored (#1287)
+
+
 ## [0.14.44] - 2026-08-16
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-agent-panel"
 description = "Autonomous AI agent in the ComfyUI sidebar - local-first, bring any LLM. Run it on your Claude or ChatGPT subscription (no API keys, no extra LLM costs), on a Kimi K3 / GLM / OpenRouter key, or fully offline on free local models via Ollama, LM Studio, or llama.cpp. The agent drives your live canvas at full parity: add, wire, move and tweak nodes with Ctrl+Z undo, load whole workflows and installer packs in one shot, generate images, video and audio, browse CivitAI, and run your workflow - asking before it spends paid API credits. The sidebar UI for comfyui-mcp, the local-first, agent-native control plane for ComfyUI. The panel speaks 12 languages, matching your ComfyUI language automatically: English, 한국어, 日本語, 中文 (简体), 中文 (繁體), Русский, Français, Español, Português (BR), Türkçe, العربية, فارسی."
-version = "0.14.44"
+version = "0.15.0"
 license = { file = "LICENSE" }
 requires-python = ">=3.9"
 # UI-only pack: no Python deps. The frontend floor guarantees

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -1579,7 +1579,7 @@ const DOCS_URL = "https://comfyui-mcp.artokun.io/docs";
 // Panel version — surfaced in the "Need help?" diagnostics blob. Bump via
 // `node scripts/set-version.mjs <v>` (updates this AND pyproject together); CI
 // and the publish gate FAIL if the two ever drift, so this can't go stale.
-const PANEL_VERSION = "0.14.44";
+const PANEL_VERSION = "0.15.0";
 
 // The connected orchestrator's console URL/token (captured off the `backends`
 // bridge message — see onBackends). Drives the "API Keys" credentials frame;


### PR DESCRIPTION
Release cut carrying two features and four fixes since v0.14.44. **Minor bump to 0.15.0** for the two `feat` commits. Merging auto-publishes to the Comfy Registry via `publish_action.yml`; no tag on merge (the v0.14.44 tag was pushed separately).

**#1243 — panel-open MCP autostart + provider chooser.** Opening the panel can now start the local MCP orchestrator, with a chooser for the LLM provider. The companion launcher binds loopback-only behind a 32-byte token with constant-time compare and one fixed command; the pack proxies it so the token never reaches the browser. A pre-merge review caught the confused-deputy hole this creates — any open tab could plain-form-post to the proxy and have the bearer token attached on its behalf — so the proxy now refuses a declared Origin (or Referer) whose authority is not the Host the browser addressed, copies the launcher reply through an allowlist instead of popping `token` off a denylist, and no longer reflects aiohttp's error text (loopback host + ephemeral port) into the page.

**#1241 — `panel_set_widget` can create an rgthree `lora_N` slot (#757).** Rows used to exist only after the node's DOM-only "Add Lora" button was clicked, so every write to `lora_1` on a fresh node was refused for a widget no tool could bring into existence. Minting is keyed on three independent facts — node type, the `lora_<n>` name shape, and a lora-slot-shaped value — so an ordinary typo cannot reach it; the pack method is feature-detected and its effect verified, and a row minted under the wrong name is removed again with the refusal naming the real next row.

**Dictation fixes (#1301, #1302, #1303)** — a voice-dictation error names the cause and the way out instead of just the Web Speech code (#1288); dictation listens in the panel's language, not the browser's (#1289); the desktop app disables dictation WITH the reason instead of failing on every click (#1290).

**#1304** — a search limit above the cap is disclosed as `limit_cap`, not silently honored (#1287).

Specs/triage (#815 changelog-in-panel spec, #998, #1212, #1234 issue triage) carry no changelog bullets — the repo's changelog convention drops `spec`/`chore`/`test` types.

Suite green at 4880 passed / 0 failed (1 todo); `tsc --noEmit` clean; CI version gate verified locally — pyproject and `PANEL_VERSION` both at 0.15.0. `web/changelog.json` intentionally untouched (known pre-existing drift, handled separately).
