### PR TITLE
fix(1266): a same-node connect refusal is reported as LiteGraph's loopback guard, not a false type mismatch

### DIFF
--- a/browser_tests/unit/connect-match.test.mjs
+++ b/browser_tests/unit/connect-match.test.mjs
@@ -12,7 +12,8 @@
  *   #169 — auto-match never silently clobbers an OCCUPIED dynamic wildcard ("*")
  *          input when no free wildcard slot exists yet; an explicit to_input
  *          still replaces deliberately.
- * Plus the invariant that genuinely incompatible types stay refused (#204).
+ * Plus the invariant that genuinely incompatible types stay refused (#204),
+ * and the same-node loopback refusal diagnostic (#1266).
  */
 import test from "node:test";
 import assert from "node:assert/strict";
@@ -24,6 +25,7 @@ import {
   isTypeCompatible,
   isWildcardSlotType,
   slotDiagnostic,
+  loopbackRefusalReason,
 } from "../../web/js/lib/connect-match.js";
 
 // VHS_LoadVideo-shaped origin: IMAGE output at index 0, plus non-IMAGE outputs.
@@ -381,4 +383,72 @@ test("#651: a comma multi-type input is matched by ANY of its declared segments 
   // Exact-tier hit on the multi-type slot means the wildcard is never consulted.
   assert.deepEqual(typeMatchedIndices(target.inputs, "MASK"), [0]);
   assert.deepEqual(typeMatchedIndices(target.inputs, "IMAGE"), [0]);
+});
+
+// ---- #1266: a SAME-NODE (loopback) refusal is not a type mismatch -----------
+//
+// Reported: panel_connect from subgraph node 78 output 1 (CONDITIONING) to the
+// SAME node's unconnected input 3 (positive, CONDITIONING) was refused with
+// "No input on node 78 accepts type CONDITIONING" — while the diagnostic's own
+// slot listing showed [3] positive (CONDITIONING). Routing through a Reroute
+// succeeded, proving the types are compatible. LiteGraph's connect() guards
+// loopback unconditionally (`if (target_node == this) return null`) BEFORE any
+// type check, so the falsy link carries no type verdict; the generic
+// slotDiagnostic tail was reading it as one.
+
+// The reported subgraph node: CONDITIONING output at slot 1, CONDITIONING
+// input "positive" at slot 3.
+function subgraphNode78() {
+  return {
+    id: 78,
+    type: "SubgraphNode",
+    outputs: [
+      { name: "images", type: "IMAGE" },
+      { name: "CONDITIONING", type: "CONDITIONING" },
+    ],
+    inputs: [
+      { name: "model", type: "MODEL", link: 11 },
+      { name: "clip", type: "CLIP", link: 12 },
+      { name: "latent", type: "LATENT", link: null },
+      { name: "positive", type: "CONDITIONING", link: null },
+    ],
+  };
+}
+
+test("#1266: the loopback reason names the slots and states the types ARE compatible", () => {
+  const reason = loopbackRefusalReason(subgraphNode78(), 1, 3);
+  assert.match(reason, /to ITSELF/);
+  assert.match(reason, /loopback guard, not a type mismatch/);
+  assert.match(reason, /output "CONDITIONING" \(CONDITIONING\)/);
+  assert.match(reason, /input "positive" \(CONDITIONING\)/);
+  assert.match(reason, /Reroute/);
+});
+
+test("#1266: with the reason override the diagnostic KEEPS the slot listing but drops the false type tail", () => {
+  const node = subgraphNode78();
+  const msg = slotDiagnostic(node, node, {
+    from_output: 1,
+    to_input: 3,
+    reason: loopbackRefusalReason(node, 1, 3),
+  });
+  // The full slot listing is preserved — it was the reporter's evidence.
+  assert.match(msg, /\[3\] "positive" \(CONDITIONING\)/);
+  // The false "no input accepts type CONDITIONING" claim is gone.
+  assert.doesNotMatch(msg, /No input on node 78 accepts type/);
+  assert.match(msg, /loopback guard, not a type mismatch/);
+});
+
+test("#1266: without the override the same refusal still shows the OLD (false) tail — the override is what fixes it", () => {
+  const node = subgraphNode78();
+  const msg = slotDiagnostic(node, node, { from_output: 1, to_input: 3 });
+  assert.match(msg, /No input on node 78 accepts type CONDITIONING/);
+});
+
+test("#1266: a genuinely incompatible same-node pair is not CALLED compatible — the guard verdict stays honest", () => {
+  const node = subgraphNode78();
+  // output 0 (IMAGE) → input 3 (CONDITIONING): LiteGraph would refuse on the
+  // loopback guard first, so the message must not claim a type verdict either way.
+  const reason = loopbackRefusalReason(node, 0, 3);
+  assert.match(reason, /refuses before any type check runs/);
+  assert.doesNotMatch(reason, /ARE type-compatible/);
 });

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -353,7 +353,7 @@ import {
   controlAfterGenerateModes,
   controlAfterGenerateEntries,
 } from "./lib/control-after-generate.js";
-import { autoMatchSlots, slotDiagnostic } from "./lib/connect-match.js";
+import { autoMatchSlots, slotDiagnostic, loopbackRefusalReason } from "./lib/connect-match.js";
 import { isLinkPersisted, removePhantomLink, isWidgetBackedInput } from "./lib/connect-verify.js";
 import {
   snapshotGraphState,
@@ -11775,7 +11775,19 @@ const GRAPH_TOOL_EXECUTORS = {
     }
     graph.setDirtyCanvas(true, true);
     if (!link) {
-      throw new Error(slotDiagnostic(origin, target, { from_output, to_input }));
+      // #1266: LiteGraph's connect() refuses a node→ITSELF link unconditionally
+      // ("avoid loopback": `if (target_node == this) return null`) BEFORE any
+      // type check — so for a same-node request the computed slotDiagnostic tail
+      // ("No input on node N accepts type X") is a FALSE type mismatch: the
+      // refusal says nothing about the slots' types. Keep the full slot listing
+      // but override the tail with the actual restriction.
+      throw new Error(
+        slotDiagnostic(origin, target, {
+          from_output,
+          to_input,
+          ...(origin === target ? { reason: loopbackRefusalReason(origin, outIdx, inIdx) } : {}),
+        }),
+      );
     }
     // #397 CONNECT HONESTY: origin.connect() can return a truthy link that LiteGraph
     // does NOT persist — a WIDGET-backed target input (rgthree/Impact nodes expose

--- a/web/js/lib/connect-match.js
+++ b/web/js/lib/connect-match.js
@@ -12,6 +12,9 @@
 //   #169 — auto-match must never silently clobber an OCCUPIED dynamic wildcard
 //          ("*") input (rgthree Fast Bypasser / Power Lora) when no free
 //          wildcard slot is available yet.
+//   #1266 — a LiteGraph refusal on a SAME-NODE (loopback) connect is not a
+//          type mismatch: loopbackRefusalReason replaces the computed
+//          "no input accepts type X" tail that falsely blamed the slots' types.
 
 export const SLOT_RANK_EXACT = 2;
 export const SLOT_RANK_WILD = 1;
@@ -181,6 +184,31 @@ export function slotDiagnostic(origin, target, requested = {}) {
     `Node ${origin.id} outputs: ${outs || "none"}\n` +
     `Node ${target.id} inputs:  ${ins || "none"}\n` +
     tail
+  );
+}
+
+/** #1266 — the honest failure tail when LiteGraph refused a connection whose
+ *  ORIGIN and TARGET are the SAME node. LiteGraph's connect() guards loopback
+ *  unconditionally (`if (target_node == this) return null`) BEFORE any type
+ *  check runs, so slotDiagnostic's computed "no input accepts type X" tail is
+ *  a FALSE type mismatch here: the refusal says nothing about the slots'
+ *  types. Names the resolved slot pair, states the verdict the panel's OWN
+ *  predicate gives (without claiming LiteGraph agreed — it never looked), and
+ *  points at the Reroute workaround the reporter verified. Only a reason
+ *  string; the caller passes it as slotDiagnostic's `reason` override so the
+ *  full slot listing is kept. */
+export function loopbackRefusalReason(node, outIdx, inIdx) {
+  const out = node.outputs?.[outIdx];
+  const inp = node.inputs?.[inIdx];
+  const pair =
+    `output "${out?.name ?? outIdx}" (${renderSlotType(out?.type)}) → ` +
+    `input "${inp?.name ?? inIdx}" (${renderSlotType(inp?.type)})`;
+  const verdict = isTypeCompatible(out?.type, inp?.type)
+    ? "the slots ARE type-compatible — this is LiteGraph's loopback guard, not a type mismatch"
+    : "the loopback guard refuses before any type check runs, so this refusal is not a type verdict";
+  return (
+    `LiteGraph refuses a connection from a node to ITSELF (${pair}): ${verdict}. ` +
+    `Route through a Reroute node to wire the node's own output back to its input.`
   );
 }
 


### PR DESCRIPTION
## Root cause

`panel_connect` from subgraph node 78 output 1 (CONDITIONING) to the **same** node's unconnected input 3 (positive, CONDITIONING) failed with `No input on node 78 accepts type CONDITIONING` — while the diagnostic's own slot listing showed `[3] positive (CONDITIONING)`, and the identical connection routed through a Reroute succeeded.

The refusal never came from a type check. LiteGraph's `connect()` guards loopback unconditionally (`if (target_node == this) return null`, [LGraphNode.ts](https://github.com/Comfy-Org/litegraph.js/blob/master/src/LGraphNode.ts)) **before** any type comparison runs, so its falsy return carries no type verdict. But `graph_connect`'s refusal path fed every falsy link to `slotDiagnostic`, whose computed tail unconditionally claims "no input accepts type X" — reading a loopback guard as a type mismatch.

## Fix

Minimal, diagnostic-only; no matching or type-safety behavior changes:

- `web/js/comfyui-mcp-panel.js` (`graph_connect`): when LiteGraph returns no link and origin **is** the target, the diagnostic keeps the full slot listing but overrides the computed tail via `slotDiagnostic`'s existing `reason` mechanism.
- `web/js/lib/connect-match.js`: new exported `loopbackRefusalReason(node, outIdx, inIdx)` builds that tail. It names the resolved slot pair, states the panel's OWN type verdict without claiming LiteGraph agreed (it never looked), and points at the Reroute workaround the reporter verified. For a genuinely incompatible same-node pair it says the loopback guard refuses before any type check runs — it never calls an incompatible pair compatible.
- Genuine type mismatches between different nodes keep the exact diagnostic they had.

This is the issue's own second remedy ("report a cycle restriction rather than a false type mismatch"); the first ("permit … when LiteGraph accepts the cycle") needs no code — whatever LiteGraph accepts already goes through untouched.

## Verification

- `npm ci` — clean.
- `node --test browser_tests/unit/connect-match.test.mjs` — 33/33 pass, including 4 new #1266 tests: the reason names the slots and states the types ARE compatible; the overridden diagnostic keeps the slot listing and drops the false tail; without the override the old false tail still appears (pinning what changed); a genuinely incompatible same-node pair is not called compatible.
- `npm run test:unit` (i18n-check, i18n-render-check, check-tool-vocabulary, check-panel-scope, all unit tests) — 4884 pass, 0 fail, 1 todo.
- `npm run typecheck` (`tsc --noEmit`) — clean.

Closes #1266