### PR TITLE
fix(1246): the never-drains verify test asserts the deadline the code computed, not the wall clock

### DIFF
--- a/browser_tests/unit/manager-install.test.mjs
+++ b/browser_tests/unit/manager-install.test.mjs
@@ -682,7 +682,13 @@ test("waitForQueueDrain (real panel source) returns a drained status without Ref
 // injected budget keeps the test fast WITHOUT touching the timing assertions:
 // verifyInstalled closes over INSTALL_VERIFY_BUDGET_MS, so the factory passes a
 // small stand-in — the drain-loop arithmetic under test is the panel's own.
-function loadVerifyInstalled({ budgetMs, get }) {
+//
+// `fakeTime` ({ now, boundedDelay, abortSignal }) swaps the clock the composed
+// sources read for an injected one (#1246): Date, AbortSignal and boundedDelay
+// arrive as factory parameters, so a test can advance time instead of enduring
+// it and assert on the deadline arithmetic rather than on the wall clock.
+// Without it the real globals are bound and nothing changes.
+function loadVerifyInstalled({ budgetMs, get, fakeTime }) {
   const src = readFileSync(
     fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url)),
     "utf8",
@@ -693,6 +699,7 @@ function loadVerifyInstalled({ budgetMs, get }) {
   assert.ok(delayMatch && waitMatch && verifyMatch,
     "could not locate boundedDelay / waitForQueueDrain / verifyInstalled in panel source");
   const managerGet = async () => { throw new Error("managerGet must not be called (get is always passed)"); };
+  const realBoundedDelay = new Function(`${delayMatch[0]}\nreturn boundedDelay;`)();
   const factory = new Function(
     "queueDrained",
     "classifyInstallOutcome",
@@ -702,7 +709,9 @@ function loadVerifyInstalled({ budgetMs, get }) {
     "MANAGER_FETCH_TIMEOUT_MS",
     "INSTALL_VERIFY_BUDGET_MS",
     "AbortSignal",
-    `${delayMatch[0]}\n${waitMatch[0]}\n${verifyMatch[0]}\nreturn verifyInstalled;`,
+    "Date",
+    "boundedDelay",
+    `${waitMatch[0]}\n${verifyMatch[0]}\nreturn verifyInstalled;`,
   );
   return factory(
     queueDrained,
@@ -712,7 +721,9 @@ function loadVerifyInstalled({ budgetMs, get }) {
     async () => { throw new Error("managerCall must not be called on the v2 dialect"); },
     15000,
     budgetMs,
-    AbortSignal,
+    fakeTime?.abortSignal ?? AbortSignal,
+    fakeTime ? { now: fakeTime.now } : Date,
+    fakeTime?.boundedDelay ?? realBoundedDelay,
   );
 }
 
@@ -721,8 +732,10 @@ test("#671 verifyInstalled (real panel source) answers 'unverified' inside the r
   // scenario: the canvas is responsive, the install is genuinely still running.
   // The installed-list read HANGS (signal-aware): the ONE shared deadline must
   // cap it at whatever budget the drain wait left, not at a fresh 15s.
+  let statusPolls = 0;
   const get = (route, opts) => {
     if (route === "manager/queue/status") {
+      statusPolls += 1;
       return Promise.resolve({ is_processing: true, done_count: 0, total_count: 1 });
     }
     if (route === "customnode/installed") {
@@ -730,17 +743,74 @@ test("#671 verifyInstalled (real panel source) answers 'unverified' inside the r
     }
     return Promise.reject(new Error(`unexpected route ${route}`));
   };
-  const verifyInstalled = loadVerifyInstalled({ budgetMs: 2500, get });
-  const started = Date.now();
-  const outcome = await verifyInstalled("ComfyUI-MelBandRoFormer", "v2", { budgetMs: 2500 });
-  const elapsed = Date.now() - started;
 
-  // The reply must leave the tab WELL inside the orchestrator's 30s window.
-  // Expected ~budget + the ≤1s capped list read. A missing drain budget waits
-  // 120s; a list read on its own fresh 15s timeout (no shared deadline) waits
-  // ~17.5s — both mutants blow this bound. (10s, not tighter: loaded machines
-  // overrun timers — the suite has seen a 5s budget take 10.4s.)
-  assert.ok(elapsed < 10000, `verification outlived its budget (${elapsed} ms)`);
+  // #1246 — this test used to bound the run on the WALL clock (elapsed < 10s
+  // around a 2.5s injected budget). That measured the machine, not the code:
+  // alone it passed in ~3.5s, but inside the loaded full suite the same run
+  // took 18-40s and failed — on branches whose entire diff was markdown. It
+  // now runs on an injected clock, in the style of the drain-wait test above:
+  // boundedDelay's OWN arithmetic advances the fake clock instead of sleeping,
+  // and the fake AbortSignal aborts on the microtask queue — what
+  // classifyInstallOutcome reads is the abort VERDICT, not how long the hang
+  // was endured. What is asserted is the deadline the code computed: the polls
+  // that fit the budget, the delays it was paced with, and the signal cap the
+  // hanging read was handed — the properties the wall-clock bound was a lossy
+  // (and under load, false) proxy for.
+  let now = 0;
+  const delays = [];
+  const timeouts = [];
+  const fakeTime = {
+    now: () => now,
+    // The real boundedDelay's own budget arithmetic (the request capped by
+    // what the deadline leaves), applied to the fake clock rather than slept.
+    boundedDelay: (ms, deadline) => {
+      const wait = Math.max(0, Math.min(ms, deadline - now));
+      delays.push({ ms, wait, remaining: deadline - now });
+      now += wait;
+      return Promise.resolve();
+    },
+    // An abort that fires as soon as it is observed: the hang rejects, the
+    // read classifies as listError — the same verdict the real 1s-capped abort
+    // produces, without the wait. The requested ms is recorded so the shared
+    // deadline's cap on the read is asserted directly.
+    abortSignal: {
+      timeout: (ms) => {
+        timeouts.push(ms);
+        return {
+          addEventListener: (type, cb) => {
+            if (type === "abort") queueMicrotask(cb);
+          },
+        };
+      },
+    },
+  };
+  const verifyInstalled = loadVerifyInstalled({ budgetMs: 2500, get, fakeTime });
+  const outcome = await verifyInstalled("ComfyUI-MelBandRoFormer", "v2", { budgetMs: 2500 });
+
+  // The deadline arithmetic under test: a 2500ms budget is a 1000ms warm-up,
+  // one poll, one 1500ms interval — the loop stops AT the deadline, never past
+  // it. A missing drain budget (the #671 mutant) falls back to the 120s
+  // default: the poll count and the consumed budget both blow up, and this
+  // fails in milliseconds instead of after a 120s stall.
+  assert.equal(statusPolls, 1, "exactly one poll fits a 2500ms budget after the warm-up");
+  assert.deepEqual(
+    delays.map((d) => [d.ms, d.wait]),
+    [[1000, 1000], [1500, 1500]],
+    "one warm-up before the first poll, then the default interval between polls",
+  );
+  assert.ok(
+    delays.every((d) => d.wait <= d.remaining),
+    "every delay is capped by the budget that remains, so it cannot overrun the deadline",
+  );
+  assert.equal(now, 2500, "the drain wait consumed exactly the injected budget and stopped at the deadline");
+  // The hanging list read inherited what the drain wait LEFT of the shared
+  // deadline — nothing — so its signal was the 1000ms floor, not a fresh 15s
+  // (the second #671 mutant: a list read on its own MANAGER_FETCH_TIMEOUT_MS).
+  assert.deepEqual(
+    timeouts,
+    [1500, 1000],
+    "the poll was capped by the remaining budget, the list read by the floor past the shared deadline",
+  );
   // Assert the REASON, not just the state: not-drained is an honest
   // "still in progress", never a fabricated success or failure.
   assert.equal(outcome.state, "unverified");


### PR DESCRIPTION
## Root cause

`browser_tests/unit/manager-install.test.mjs` — *#671 verifyInstalled … when the queue never drains* — bounded the run on the **wall clock** (`elapsed < 10000` around a 2.5 s injected budget). That measured the machine, not the code: run alone it passed in ~3.5 s, but inside the loaded full suite the same run took 18–40 s and failed — on branches whose entire diff was markdown. Six agents on unrelated PRs each had to prove the red was not theirs.

## Fix

Test-only. The test now runs on an **injected clock**, in the style of the neighboring drain-wait test in the same file:

- `loadVerifyInstalled` gains an optional `fakeTime` (`{ now, boundedDelay, abortSignal }`). `Date`, `AbortSignal` and `boundedDelay` were already (or are now) factory parameters of the composed real panel source, so the test advances time instead of enduring it. Without `fakeTime` the real globals are bound and nothing changes — the fast-draining positive control still runs the real clock path untouched.
- The fake `boundedDelay` applies the real one's own budget arithmetic (`min` of the request and what the deadline leaves) to the fake clock rather than sleeping; the fake `AbortSignal.timeout` records the requested ms and aborts on the microtask queue — what `classifyInstallOutcome` reads is the abort *verdict*, not how long the hang was endured.
- The wall-clock assertion is replaced by assertions on the properties it was a lossy proxy for: the poll count that fits the budget (1), the warm-up + interval delays the loop was paced with, each delay capped by the remaining budget, the loop stopping exactly at its deadline (`now === 2500`), and the signal caps handed to the poll and the hanging list read (`[1500, 1000]` — the read gets the 1 s floor past the shared deadline, not a fresh 15 s).

The outcome assertions (`unverified` / `still in progress` / `panel_node_queue_status`) are unchanged.

## Verification

- Targeted file: `node --test browser_tests/unit/manager-install.test.mjs` — **125/125 pass**; the rewritten test runs in **4.7 ms** (was ~3.5 s alone, 18–40 s flaky under suite load).
- Mutant check: temporarily reverting the panel's shared-deadline cap on the list read (fresh `MANAGER_FETCH_TIMEOUT_MS`) fails the new assertion in 4.7 ms with `[1500, 15000] ≠ [1500, 1000]` — the same regression the old 10 s bound was there to catch, now caught deterministically. A missing drain budget (the 120 s default) blows up the poll-count and consumed-budget assertions the same way. Panel source restored; `git diff` confirms test file only.
- `npm run test:unit` (full suite incl. i18n/vocabulary/scope guards): **4881 tests, 4880 pass, 0 fail, 1 todo** (pre-existing).
- `npm run typecheck`: clean.

Closes #1246