### PR TITLE
fix(1282): panel_set_widget refreshes a node's dynamic input slots after the write

### DIFF
--- a/browser_tests/unit/dynamic-inputs-refresh.test.mjs
+++ b/browser_tests/unit/dynamic-inputs-refresh.test.mjs
@@ -1,0 +1,287 @@
+/**
+ * Unit tests for #1282 — the dynamic-input-slot refresh after a widget write —
+ * run with `node --test`.
+ *
+ * These drive runSetWidget(), the SAME async unit graph_set_widget delegates to,
+ * so the production path is exercised (not a parallel reimplementation).
+ *
+ * The fixtures reproduce KJNodes' `setupDynamicInputs` (web/js/jsnodes.js)
+ * faithfully, because its exact wrapper is the whole bug:
+ *
+ *     countW.callback = function (value, canvas) {
+ *       const r = origCb ? origCb.apply(this, arguments) : undefined;
+ *       if (!canvas) rebuild();   // bare = API reload; skip interactive scrub
+ *       return r;
+ *     };
+ *     node.addWidget("button", "Update inputs", null, rebuild);
+ *
+ * The panel's write path invokes the widget callback WITH the canvas argument
+ * (as an interactive edit does), so the pack deliberately skipped the rebuild —
+ * the write succeeded, `image_3…` never came into existence, and follow-up reads
+ * served the stale slot list.
+ *
+ * Invariants under test:
+ *   1. A count-widget write on such a node now leaves the input slots matching
+ *      the count, and the result discloses the refresh (dynamic_inputs_refreshed
+ *      + the post-refresh slot names).
+ *   2. Shrinking the count removes trailing slots (the pack's own rebuild
+ *      behaviour, driven through its own control).
+ *   3. The refresh is verified by EFFECT: a control that accepts the press and
+ *      changes nothing is never reported as a refresh.
+ *   4. A control that THROWS does not fail the verified write; the failure is
+ *      disclosed (dynamic_inputs_refresh_failed), including the partial-rebuild
+ *      case.
+ *   5. Keying is on the CONTROL (a litegraph button named exactly
+ *      "Update inputs"), never on a value widget that happens to share the name,
+ *      and nodes without the control are untouched.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { runSetWidget } from "../../web/js/lib/set-widget.js";
+import {
+  dynamicInputsRefreshControl,
+  refreshDynamicInputsAfterWrite,
+} from "../../web/js/lib/dynamic-inputs-refresh.js";
+
+// Registry entries with no `nodeData`, so the placeholder cross-check in
+// assertResolvedTargetRegistered is skipped while the type still resolves as
+// registered — the same fixture style the stale-combo tests use.
+const REGISTRY = { ImageBatchMulti: {}, KSampler: {} };
+
+// The fresh /object_info oracle runSetWidget requires (#458): a live backend that
+// defines the fixture types, so the fresh-backend type gate is a no-op here.
+const FRESH = { ImageBatchMulti: {}, KSampler: {} };
+const freshOracle = { getFreshObjectInfo: async () => FRESH };
+
+// A truthy canvas, as production wires (app.canvas) — the argument KJNodes'
+// wrapper takes as the tell to SKIP the rebuild.
+const CANVAS = { isFakeCanvas: true };
+
+/**
+ * A faithful stand-in for a KJNodes ImageBatchMulti after `setupDynamicInputs`:
+ * `count` image_N slots, a count widget whose callback rebuilds ONLY on a bare
+ * (canvas-less) invocation, and the "Update inputs" button holding the rebuild.
+ */
+function makeKjMultiNode(count = 2) {
+  const node = {
+    id: 42,
+    type: "ImageBatchMulti",
+    inputs: [],
+    widgets: [],
+    addInput(name, type) {
+      this.inputs.push({ name, type, link: null });
+    },
+    removeInput(i) {
+      this.inputs.splice(i, 1);
+    },
+  };
+  // Verbatim semantics of KJNodes' setupDynamicInputs rebuild.
+  const rebuild = () => {
+    if (!node.inputs) node.inputs = [];
+    const countW = node.widgets?.find((w) => w.name === "inputcount");
+    if (!countW) return;
+    const target = countW.value;
+    const current = node.inputs.filter((i) => i.name?.startsWith("image_")).length;
+    if (target === current) return;
+    if (target < current) {
+      for (let i = 0; i < current - target; i++) node.removeInput(node.inputs.length - 1);
+    } else {
+      for (let i = current + 1; i <= target; i++) node.addInput(`image_${i}`, "IMAGE");
+    }
+  };
+  // The wrapped count callback: canvas present ⇒ interactive scrub ⇒ skip.
+  const countW = {
+    name: "inputcount",
+    type: "number",
+    value: count,
+    callback(value, canvas) {
+      if (!canvas) rebuild();
+    },
+  };
+  node.widgets.push(countW);
+  node.widgets.push({ name: "Update inputs", type: "button", value: null, callback: rebuild });
+  for (let i = 1; i <= count; i++) node.addInput(`image_${i}`, "IMAGE");
+  return node;
+}
+
+const inputNames = (node) => node.inputs.map((i) => i.name);
+
+test("#1282 repro: inputcount 2→5 refreshes the slots and discloses the new list", async () => {
+  const node = makeKjMultiNode(2);
+  const res = await runSetWidget(node, "inputcount", 5, {
+    registry: REGISTRY,
+    ...freshOracle,
+    canvas: CANVAS,
+  });
+
+  assert.equal(res.set.value, 5, "the write itself still reports the value that landed");
+  assert.equal(res.set.dynamic_inputs_refreshed, true);
+  assert.deepEqual(res.set.dynamic_inputs, ["image_1", "image_2", "image_3", "image_4", "image_5"]);
+  // The GRAPH, not just the report: the follow-up read this issue was about.
+  assert.deepEqual(inputNames(node), ["image_1", "image_2", "image_3", "image_4", "image_5"]);
+});
+
+test("#1282 shrinking the count removes trailing slots through the node's own control", async () => {
+  const node = makeKjMultiNode(4);
+  const res = await runSetWidget(node, "inputcount", 2, {
+    registry: REGISTRY,
+    ...freshOracle,
+    canvas: CANVAS,
+  });
+
+  assert.equal(res.set.dynamic_inputs_refreshed, true);
+  assert.deepEqual(res.set.dynamic_inputs, ["image_1", "image_2"]);
+  assert.deepEqual(inputNames(node), ["image_1", "image_2"]);
+});
+
+test("#1282 WITHOUT the fix the slots stayed stale — the canvas tell is what skipped the rebuild", async () => {
+  // Guards the fixture itself: with canvas passed (what the write path does) the
+  // KJNodes wrapper must NOT rebuild, or every test above is testing nothing.
+  const node = makeKjMultiNode(2);
+  node.widgets[0].callback(5, CANVAS);
+  node.widgets[0].value = 5;
+  assert.deepEqual(inputNames(node), ["image_1", "image_2"], "interactive-style invocation skips the rebuild");
+  // …and a bare invocation (API reload) rebuilds — the pack's other entry point.
+  node.widgets[0].callback(5, undefined);
+  assert.deepEqual(inputNames(node), ["image_1", "image_2", "image_3", "image_4", "image_5"]);
+});
+
+test("no refresh control on the node ⇒ the result is untouched and nothing is pressed", async () => {
+  const widget = { name: "steps", type: "number", value: 20 };
+  const node = { id: 3, type: "KSampler", widgets: [widget], inputs: [] };
+  const res = await runSetWidget(node, "steps", 30, {
+    registry: REGISTRY,
+    ...freshOracle,
+    canvas: CANVAS,
+  });
+  assert.equal(res.set.value, 30);
+  assert.equal("dynamic_inputs_refreshed" in res.set, false);
+  assert.equal("dynamic_inputs" in res.set, false);
+  assert.equal("dynamic_inputs_refresh_failed" in res.set, false);
+});
+
+test("a press that changes NOTHING is not reported as a refresh (effect, not the call)", async () => {
+  // Slots already match the value being written — the pack's rebuild returns early.
+  const node = makeKjMultiNode(2);
+  let presses = 0;
+  const button = node.widgets[1];
+  const orig = button.callback;
+  button.callback = (...args) => {
+    presses += 1;
+    return orig(...args);
+  };
+  const res = await runSetWidget(node, "inputcount", 2, {
+    registry: REGISTRY,
+    ...freshOracle,
+    canvas: CANVAS,
+  });
+  assert.equal(presses, 1, "the control is still pressed — idempotence is the pack's early return");
+  assert.equal("dynamic_inputs_refreshed" in res.set, false, "nothing changed ⇒ nothing claimed");
+});
+
+test("a value widget NAMED like the control is never pressed", async () => {
+  // The pressable-widget.js "Add Noise" lesson: keying on a name is only safe
+  // because the candidate must be a litegraph BUTTON. A combo carrying the same
+  // name holds a value and must keep it.
+  const decoy = { name: "Update inputs", type: "combo", options: { values: ["a", "b"] }, value: "a" };
+  const countW = { name: "inputcount", type: "number", value: 2 };
+  const node = {
+    id: 9,
+    type: "ImageBatchMulti",
+    inputs: [{ name: "image_1" }, { name: "image_2" }],
+    widgets: [countW, decoy],
+  };
+  const res = await runSetWidget(node, "inputcount", 5, {
+    registry: REGISTRY,
+    ...freshOracle,
+    canvas: CANVAS,
+  });
+  assert.equal(res.set.value, 5);
+  assert.equal(decoy.value, "a", "the same-named value widget was not invoked");
+  assert.equal("dynamic_inputs_refreshed" in res.set, false);
+  assert.deepEqual(inputNames(node), ["image_1", "image_2"], "no control ⇒ slots unchanged, as before the fix");
+});
+
+test("a control that THROWS does not fail the verified write; the failure is disclosed", async () => {
+  const node = makeKjMultiNode(2);
+  node.widgets[1].callback = () => {
+    throw new Error("pack code exploded");
+  };
+  const res = await runSetWidget(node, "inputcount", 5, {
+    registry: REGISTRY,
+    ...freshOracle,
+    canvas: CANVAS,
+  });
+  assert.equal(res.set.value, 5, "the write is still reported as the verified success it is");
+  assert.equal(typeof res.set.dynamic_inputs_refresh_failed, "string");
+  assert.match(res.set.dynamic_inputs_refresh_failed, /succeeded and was verified/);
+  assert.match(res.set.dynamic_inputs_refresh_failed, /pack code exploded/);
+  assert.match(res.set.dynamic_inputs_refresh_failed, /may still be stale/);
+  assert.equal("dynamic_inputs_refreshed" in res.set, false);
+  assert.deepEqual(inputNames(node), ["image_1", "image_2"], "the throw left the slots as they were");
+});
+
+test("a control that partially rebuilds and THEN throws discloses the partial state", async () => {
+  const node = makeKjMultiNode(2);
+  node.widgets[1].callback = () => {
+    node.addInput("image_3", "IMAGE");
+    throw new Error("died mid-rebuild");
+  };
+  const res = await runSetWidget(node, "inputcount", 5, {
+    registry: REGISTRY,
+    ...freshOracle,
+    canvas: CANVAS,
+  });
+  assert.equal(res.set.value, 5);
+  assert.match(res.set.dynamic_inputs_refresh_failed, /PARTIALLY rebuilt/);
+  assert.deepEqual(res.set.dynamic_inputs, ["image_1", "image_2", "image_3"], "the observed post-throw list is disclosed");
+});
+
+test("the refresh is bracketed by the command's undo-history hooks", async () => {
+  const node = makeKjMultiNode(2);
+  let before = 0;
+  let after = 0;
+  const res = await runSetWidget(node, "inputcount", 5, {
+    registry: REGISTRY,
+    ...freshOracle,
+    canvas: CANVAS,
+    beforeChange: () => {
+      before += 1;
+    },
+    afterChange: () => {
+      after += 1;
+    },
+  });
+  assert.equal(res.set.dynamic_inputs_refreshed, true);
+  // One pair for the write itself, one pair for the refresh press.
+  assert.equal(before, 2);
+  assert.equal(after, 2);
+  assert.ok(before > 0 && after > 0);
+});
+
+// ── the lib's own contract, driven directly ──────────────────────────────────
+
+test("dynamicInputsRefreshControl finds only a callable button with the exact name", () => {
+  const node = makeKjMultiNode(2);
+  assert.equal(dynamicInputsRefreshControl(node), node.widgets[1]);
+  assert.equal(dynamicInputsRefreshControl({ widgets: [{ name: "Update inputs", type: "combo", callback() {} }] }), null);
+  assert.equal(dynamicInputsRefreshControl({ widgets: [{ name: "Update inputs", type: "button" }] }), null, "no callback ⇒ nothing to press");
+  assert.equal(dynamicInputsRefreshControl({ widgets: [{ name: "update inputs", type: "button", callback() {} }] }), null, "the name match is exact");
+  assert.equal(dynamicInputsRefreshControl({}), null);
+  assert.equal(dynamicInputsRefreshControl(null), null);
+});
+
+test("refreshDynamicInputsAfterWrite returns null when there is no control, and never throws", () => {
+  assert.equal(refreshDynamicInputsAfterWrite({ id: 1 }), null);
+  assert.equal(refreshDynamicInputsAfterWrite(null), null);
+  // A hostile node whose widgets getter throws must not escape either.
+  const hostile = {};
+  Object.defineProperty(hostile, "widgets", {
+    get() {
+      throw new Error("nope");
+    },
+  });
+  const out = refreshDynamicInputsAfterWrite(hostile);
+  assert.ok(out === null || typeof out.failed === "string", "hostile reads degrade to a disclosure, never a throw");
+});

--- a/web/js/lib/dynamic-inputs-refresh.js
+++ b/web/js/lib/dynamic-inputs-refresh.js
@@ -1,0 +1,231 @@
+/**
+ * #1282 — after `panel_set_widget` writes a count widget, a dynamic-input node's
+ * input slots stayed STALE.
+ *
+ * ## The mechanism this works around, read from the pack
+ *
+ * KJNodes' `*Multi` nodes (ImageBatchMulti, ImageAddMulti, CrossFadeImagesMulti,
+ * TransitionImagesMulti, ImageConcatMulti, MaskBatchMulti, ConditioningMultiCombine,
+ * JoinStringMulti) share one helper, `setupDynamicInputs` (ComfyUI-KJNodes
+ * web/js/jsnodes.js), which does two things:
+ *
+ *   1. wraps the count widget's callback as
+ *
+ *          countW.callback = function (value, canvas) {
+ *            const r = origCb ? origCb.apply(this, arguments) : undefined;
+ *            if (!canvas) rebuild();   // bare = API reload; skip interactive scrub
+ *            return r;
+ *          };
+ *
+ *      — the `canvas` argument is the pack's deliberate tell: an INTERACTIVE edit
+ *      carries it, and scrubbing a count must not reflow the node under the user's
+ *      cursor, so the rebuild is skipped. The panel's write path invokes the
+ *      callback exactly the way an interactive edit does (`widget-write.js` passes
+ *      `canvas`), so a panel write took the skip branch and the slots never moved.
+ *      The write reported success — verified, honestly — while `image_3…` did not
+ *      exist, and every follow-up read saw the stale slot list.
+ *
+ *   2. adds a button widget, `node.addWidget("button", "Update inputs", null, rebuild)`,
+ *      so the interactive user can run the deferred rebuild. That button is the
+ *      pack's own refresh control: pressing it is what a user does after scrubbing
+ *      the count, and `rebuild` is idempotent — it adds or removes trailing inputs
+ *      until their count matches the widget, and returns early when they already do.
+ *
+ * ## What this does
+ *
+ * After a write has succeeded and been verified, if the node the write landed on
+ * carries that control, press it — inside the same synchronous stretch as the
+ * write, so no workflow switch or concurrent command can interleave, and inside
+ * the same before/afterChange bracketing every graph mutation here gets, so the
+ * slot changes are part of the command's undo history.
+ *
+ * ## Why it is keyed this way
+ *
+ * NOT keyed on node.type: the pack list above is a version-dependent enumeration,
+ * and a node added to the pack tomorrow would silently keep the stale-slot
+ * behaviour. The key is the CONTROL itself — a litegraph `type === "button"`
+ * widget named exactly "Update inputs" with a callable callback. That name is the
+ * behavioural contract ("rebuild my input slots from the count widget"), and the
+ * press is verified by its effect, so a control that accepts the call and does
+ * nothing is never reported as a refresh (the #757 probe found pack callbacks that
+ * accept a call and do exactly nothing).
+ *
+ * Name-keying is deliberate and safe here, unlike the refusal-hint case
+ * `pressable-widget.js` rejected: a candidate must already be a BUTTON — a value
+ * widget that happens to share the name (the "Add Noise" combo problem) is never
+ * touched — and the press only ever runs on a node whose write already succeeded.
+ * It is also never AUTO-pressed to satisfy a missing widget; that refusal stays
+ * exactly as it was.
+ *
+ * ## What it reports
+ *
+ *   - slots changed → `{ refreshed: true, inputs: [...] }`, the node's input slot
+ *     names AFTER the press, so the caller can proceed without a re-read.
+ *   - the control threw → `{ failed: <sentence> }`. The write already succeeded
+ *     and was verified, so this must not throw — the failure is disclosed on the
+ *     result instead, with the partial-rebuild possibility stated.
+ *   - no such control, or the press changed nothing (slots already matched — the
+ *     idempotent no-op) → `null`, and the result looks exactly as it did before
+ *     this change. "Changed nothing" cannot be distinguished from a broken control
+ *     that silently no-ops, so nothing is claimed either way; the follow-up
+ *     panel_query_graph read shows the truth.
+ *
+ * Never throws: it runs AFTER a verified write, and a failure here must never turn
+ * that write's honest success into an error report.
+ */
+
+// The label `setupDynamicInputs` gives its rebuild button. Treated as the
+// behavioural contract — see the header for why the route keys on it.
+export const UPDATE_INPUTS_BUTTON = "Update inputs";
+
+// Captured at module load, as widget-write.js does for its own callback
+// invocation: a poisoned `.call` getter or Proxy trap on the control must not be
+// able to throw from INSIDE the span the throw is attributed to.
+const reflectApply = Reflect.apply;
+
+/** The node's input slot names, in order. Never throws. */
+function inputNames(node) {
+  try {
+    if (!Array.isArray(node?.inputs)) return [];
+    return node.inputs.map((inp) => {
+      try {
+        return typeof inp?.name === "string" ? inp.name : null;
+      } catch {
+        return null;
+      }
+    });
+  } catch {
+    return [];
+  }
+}
+
+function sameNames(a, b) {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) if (a[i] !== b[i]) return false;
+  return true;
+}
+
+/** A never-throwing rendering of what the control's invocation threw. */
+function coerceThrowMessage(err) {
+  try {
+    const msg = err?.message;
+    if (typeof msg === "string" && msg) return msg;
+    return String(err);
+  } catch {
+    return "the reason could not be rendered";
+  }
+}
+
+/**
+ * The node's dynamic-input refresh control, when it exposes one: a litegraph
+ * button widget named exactly "Update inputs" with a callable callback. Returns
+ * null for every other node — which is almost all of them. Never throws.
+ *
+ * @param {object} node
+ */
+export function dynamicInputsRefreshControl(node) {
+  try {
+    const widgets = node?.widgets;
+    if (!Array.isArray(widgets)) return null;
+    for (const w of widgets) {
+      try {
+        if (w?.type === "button" && w?.name === UPDATE_INPUTS_BUTTON && typeof w?.callback === "function") {
+          return w;
+        }
+      } catch {
+        /* an unreadable widget is not the control */
+      }
+    }
+  } catch {
+    /* an unreadable node has no control this file may invoke */
+  }
+  return null;
+}
+
+/**
+ * Press the node's own dynamic-input refresh control after a successful write.
+ *
+ * Call ONLY from the synchronous write boundary of a write that has already
+ * succeeded and been verified — the press is a graph mutation (inputs are
+ * added/removed), so it must not sit across an await.
+ *
+ * @returns {null | { refreshed: true, inputs: (string|null)[] } | { failed: string }}
+ *   See the module header for the three outcomes.
+ */
+export function refreshDynamicInputsAfterWrite(node, { canvas, beforeChange, afterChange, setDirty } = {}) {
+  try {
+    const button = dynamicInputsRefreshControl(node);
+    if (!button) return null;
+
+    const before = inputNames(node);
+    // Bookkeeping hooks are best-effort, exactly as widget-write.js's own
+    // safeBefore/safeAfter: a throwing history hook must never decide the outcome
+    // it is merely bracketing, and must never replace the disclosure the caller
+    // needs to read.
+    try {
+      beforeChange?.();
+    } catch {
+      /* history hook is best-effort */
+    }
+    let threw = null;
+    try {
+      // Invoked with litegraph's button-click argument shape (widget, canvas,
+      // node, pos, event). The control this route exists for — the pack's
+      // `rebuild` — reads no arguments at all (verified in its source), so the
+      // exact list is convention, not contract. `node.pos` may be a throwing
+      // getter, so the arguments are built INSIDE the try: that throw is then
+      // attributed to the refresh attempt rather than escaping over a verified
+      // write.
+      const args = [button, canvas, node, node?.pos, undefined];
+      reflectApply(button.callback, button, args);
+    } catch (err) {
+      threw = err;
+    } finally {
+      try {
+        afterChange?.();
+      } catch {
+        /* history hook is best-effort */
+      }
+    }
+
+    const after = inputNames(node);
+    const changed = !sameNames(before, after);
+
+    if (threw) {
+      // The write already succeeded; the refresh is the part that failed. The
+      // control may have partially rebuilt the slots before it threw, so say
+      // that rather than calling the slots simply stale.
+      return {
+        failed:
+          `The write itself succeeded and was verified, but invoking the node's own ` +
+          `"${UPDATE_INPUTS_BUTTON}" control threw (${coerceThrowMessage(threw)}), so its dynamic ` +
+          `input slots may still be stale${changed ? " — and may be PARTIALLY rebuilt, because the list changed before it threw" : ""}. ` +
+          `Read the node with panel_query_graph before relying on its inputs.`,
+        ...(changed ? { inputs: after } : {}),
+      };
+    }
+
+    // A press that changed nothing is the idempotent no-op — the slots already
+    // matched the widget. It cannot be told apart from a control that silently
+    // does nothing, so nothing is claimed.
+    if (!changed) return null;
+
+    try {
+      setDirty?.();
+    } catch {
+      /* a repaint hint is cosmetic — never fail a refresh that worked */
+    }
+    return { refreshed: true, inputs: after };
+  } catch (err) {
+    // This runs after a verified write; nothing it does may escape over that
+    // success — but an unexpected failure of the refresh MACHINERY itself (as
+    // opposed to the control, handled above) is still disclosed, because the
+    // slots it leaves behind are the stale ones this file exists to fix.
+    return {
+      failed:
+        `The write itself succeeded and was verified, but refreshing the node's dynamic ` +
+        `input slots afterwards failed (${coerceThrowMessage(err)}), so they may still be ` +
+        `stale. Read the node with panel_query_graph before relying on its inputs.`,
+    };
+  }
+}

--- a/web/js/lib/set-widget.js
+++ b/web/js/lib/set-widget.js
@@ -15,6 +15,9 @@
 //      on a genuinely-resolved direct node (never a placeholder).
 //   3. applyWidgetWrite with the resolved-target registry guard, which runs
 //      BEFORE value coercion and any mutation/callback.
+// Post-write, inside the same synchronous boundary (#1282): refresh the node's
+// dynamic input slots via its own "Update inputs"-style control when it exposes
+// one — disclosed on the success result, never thrown over a verified write.
 
 import {
   applyWidgetWrite,
@@ -35,6 +38,7 @@ import {
 } from "./node-resolve.js";
 import { controlAfterGenerateWarning, controlEntryForWidget } from "./control-after-generate.js";
 import { linkDrivenWidgets, drivenTag } from "./graph-read.js";
+import { refreshDynamicInputsAfterWrite } from "./dynamic-inputs-refresh.js";
 import {
   uploadInputConfig,
   uploadInputAccepts,
@@ -538,7 +542,7 @@ export async function runSetWidget(
     // shared write path is not on offer, and pretending otherwise is what cost a round.
     const prepared = typeof prepareWriteTarget === "function" ? prepareWriteTarget() : null;
     try {
-      return applyWidgetWrite(node, widgetName, value, {
+      const set = applyWidgetWrite(node, widgetName, value, {
         resolveSource,
         canvas,
         beforeChange,
@@ -548,6 +552,44 @@ export async function runSetWidget(
         promotedResolution,
         ...extra,
       });
+      // #1282 — REFRESH DYNAMIC INPUT SLOTS after the write, on the node the write
+      // landed on, inside the SAME synchronous stretch (no await since the fence, so
+      // the press cannot interleave with a workflow switch or another command frame).
+      //
+      // The write already fired the widget's own callback the way an interactive edit
+      // does — with the canvas argument — and KJNodes' *Multi nodes take that exact
+      // argument as the deliberate tell to SKIP their slot rebuild (scrubbing a count
+      // must not reflow the node under the user's cursor; their `setupDynamicInputs`
+      // rebuilds only on a bare, canvas-less invocation). Their deferred rebuild lives
+      // behind the node's own "Update inputs" button, so a verified write to
+      // `inputcount` reported success while image_3… never came into existence and
+      // every follow-up read served the stale slot list. Pressing that control after
+      // the write is the same gesture the interactive user performs, it is idempotent
+      // (a no-op when the slots already match), and it is verified by its EFFECT —
+      // a control that accepts the call and changes nothing is never reported as a
+      // refresh. See lib/dynamic-inputs-refresh.js for the keying and why it is not
+      // a node-type list.
+      //
+      // Runs AFTER applyWidgetWrite's own verification, so the write's verdict never
+      // depends on the refresh; a refresh failure is DISCLOSED on the success result,
+      // never thrown over a verified write. The press runs inside its own
+      // before/afterChange bracket so the slot changes join the command's undo
+      // history.
+      const refresh = refreshDynamicInputsAfterWrite(resolvedTargetNode ?? node, {
+        canvas,
+        beforeChange,
+        afterChange,
+        setDirty,
+      });
+      if (!refresh) return set;
+      if (refresh.failed) {
+        return {
+          ...set,
+          dynamic_inputs_refresh_failed: refresh.failed,
+          ...(refresh.inputs ? { dynamic_inputs: refresh.inputs } : {}),
+        };
+      }
+      return { ...set, dynamic_inputs_refreshed: true, dynamic_inputs: refresh.inputs };
     } catch (err) {
       // The write refused over a target this attempt had just created. Undo it in the same
       // synchronous stretch, so the graph the refusal is reported over is the graph the


### PR DESCRIPTION
## Root cause

`panel_set_widget` on a KJNodes `*Multi` node (e.g. ImageBatchMulti `inputcount` 2→5) reported a verified success while the node's input slots never changed — follow-up reads still saw only `image_1, image_2`.

The write path *does* fire the widget's own callback, with the `canvas` argument, exactly as an interactive edit does. KJNodes' `setupDynamicInputs` ([web/js/jsnodes.js](https://github.com/kijai/ComfyUI-KJNodes/blob/main/web/js/jsnodes.js)) takes that argument as a deliberate tell to **skip** the rebuild — scrubbing a count must not reflow the node under the user's cursor — and rebuilds only on a bare, canvas-less invocation ("API reload") or when the user presses the node's **Update inputs** button. So a programmatic write took the interactive-skip branch and the deferred rebuild behind that button never ran. This was a silent partial effect, not a thrown error: the stored value moved, the graph topology did not.

(Nodes whose callback rebuilds unconditionally — the rgthree-style case — were already fine, because that callback does run during the write.)

## Fix

After a write has **succeeded and been verified**, `runSetWidget`'s synchronous write boundary now presses the node's own refresh control, when it exposes one (`web/js/lib/dynamic-inputs-refresh.js`):

- **Keyed on the control, not the node type** — a litegraph `type === "button"` widget named exactly `Update inputs` with a callable callback. A pack-version enumeration of KJNodes types would silently stale on the next pack release; a value widget sharing the name (the "Add Noise" lesson from `pressable-widget.js`) is never touched. The deliberate refusal to auto-press a control for a *missing* widget is unchanged — this only runs after a write that already succeeded.
- **Same boundary, same undo bracketing** — the press happens inside the same synchronous stretch as the write (no await since the workflow fence) and inside its own before/afterChange pair, so slot changes join the command's undo history.
- **Reported by effect, never by the call** (the #757 probe found pack callbacks that accept a call and do nothing):
  - slots changed → `dynamic_inputs_refreshed: true` + `dynamic_inputs: [...]` (post-refresh slot names);
  - the control **threw** → the write is still reported as the verified success it is, with `dynamic_inputs_refresh_failed` disclosing the reason — including the *partially rebuilt* case, with the observed post-throw list;
  - press changed nothing (slots already matched — the pack's rebuild is idempotent) → nothing is claimed; the result looks exactly as before.

## Verification

Gates run in the worktree (from `origin/main`):

- `npm ci` — clean, 0 vulnerabilities
- `npm run test:unit` (i18n checks + tool-vocabulary + panel-scope gates + full `node --test` suite) — **4892 tests: 4891 pass, 0 fail, 1 todo**
- `npm run typecheck` (`tsc --noEmit`) — clean

New coverage in `browser_tests/unit/dynamic-inputs-refresh.test.mjs` (11 tests), driving `runSetWidget` directly so the test path is the production path: the #1282 repro (2→5 adds `image_3..5` and discloses the new list), shrink (4→2 removes trailing slots), a fixture-guard test proving the KJNodes canvas-tell reproduction is faithful, idempotent no-op not reported as a refresh, same-named value widget never pressed, throwing control disclosed without failing the verified write, partial-rebuild disclosure, undo-hook bracketing, and the lib's own never-throw contract.

Not verified against a live ComfyUI with KJNodes installed — the wrapper semantics are reproduced verbatim from the pack source in the fixtures, and a fixture-guard test pins that the reproduction exhibits the reported skip behaviour.

Closes #1282