### PR TITLE
fix(1665): unpack_subgraph verifies external links survived and refuses loudly when any were dropped

### DIFF
--- a/browser_tests/unit/unpack-link-verify.test.mjs
+++ b/browser_tests/unit/unpack-link-verify.test.mjs
@@ -1,0 +1,245 @@
+/**
+ * comfyui-mcp#1665 — panel_unpack_subgraph silently dropped external links whose
+ * parent-graph targets were widget-converted inputs (`length`) or dynamic/optional
+ * inputs (`values.a`, `ref_audios.ref_audio_0`), leaving them half-broken: target
+ * slot `connected_from: null` while the source output still reported `links: 1`.
+ *
+ * MEASURED on ComfyUI 0.33.0 / frontend 1.49.6 (the reporter's graph): 3 of ~35
+ * external links were not restored by litegraph's unpackSubgraph, every one into a
+ * widget-converted or dynamic target slot, and the tool returned a bare success.
+ * Repairing by hand with panel_connect worked, so the information needed to detect
+ * the loss is available — these tests pin the snapshot/verify logic that detects it.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  snapshotExternalLinks,
+  verifyExternalLinks,
+} from "../../web/js/lib/unpack-link-verify.js";
+
+const mkLink = (id, origin_id, origin_slot, target_id, target_slot) => ({
+  id,
+  origin_id,
+  origin_slot,
+  target_id,
+  target_slot,
+});
+
+const mkGraph = (nodes, links, { asMap = true } = {}) => ({
+  links: asMap
+    ? new Map(links.map((l) => [l.id, l]))
+    : Object.fromEntries(links.map((l) => [l.id, l])),
+  getNodeById(id) {
+    return nodes.find((n) => String(n.id) === String(id)) ?? null;
+  },
+});
+
+const input = (name, link = null) => ({ name, link });
+const output = (name, links = []) => ({ name, links });
+
+/** The reporter's shape: subgraph node 6350 whose output rail feeds node 136's
+ *  widget-converted `length` input. */
+const fixtureBefore = () => {
+  const n131 = { id: 131, outputs: [output("INT", [50])], inputs: [] };
+  const n136 = {
+    id: 136,
+    inputs: [input("prompt", 51), input("width", 52), input("length", 53)],
+    outputs: [],
+  };
+  const subgraphNode = {
+    id: 6350,
+    inputs: [input("int_in", 50)],
+    outputs: [output("int_out", [53])],
+    subgraph: { inputs: [{ name: "int_in", linkIds: [900] }] },
+  };
+  const links = [
+    mkLink(50, 131, 0, 6350, 0), // 131.INT -> subgraph input rail
+    mkLink(51, 6400, 0, 136, 0), // unrelated interior source -> 136.prompt
+    mkLink(52, 6400, 1, 136, 1), // unrelated -> 136.width
+    mkLink(53, 6350, 0, 136, 2), // subgraph output rail -> 136.length
+  ];
+  return { graph: mkGraph([n131, n136, subgraphNode], links), n131, n136, subgraphNode };
+};
+
+test("#1665 snapshot names external endpoints on BOTH sides of the wrapper", () => {
+  const { graph, subgraphNode } = fixtureBefore();
+  const snap = snapshotExternalLinks(graph, subgraphNode);
+  assert.equal(snap.unverifiable.length, 0);
+  assert.equal(snap.links.length, 2);
+  const inbound = snap.links.find((l) => l.kind === "in");
+  assert.deepEqual(inbound.source, { node_id: 131, slot: 0, name: "INT" });
+  assert.equal(inbound.rail, "int_in");
+  assert.equal(inbound.consumers, 1);
+  assert.equal(inbound.baseline, 1);
+  const outbound = snap.links.find((l) => l.kind === "out");
+  assert.deepEqual(outbound.target, { node_id: 136, slot: 2, name: "length" });
+  assert.equal(outbound.rail, "int_out");
+});
+
+test("#1665 a clean unpack verifies every external link as restored", () => {
+  const { graph, n136, subgraphNode } = fixtureBefore();
+  const snap = snapshotExternalLinks(graph, subgraphNode);
+  // Post-unpack: rail 6350 is gone; the inlined interior node 6367 now feeds
+  // 136.length, and 131.INT feeds the inlined consumer 6368.
+  n136.inputs[2].link = 60;
+  graph.links.delete(50);
+  graph.links.delete(53);
+  graph.links.set(60, mkLink(60, 6367, 0, 136, 2));
+  graph.links.set(61, mkLink(61, 131, 0, 6368, 0));
+  const n6367 = { id: 6367, outputs: [output("INT", [60])], inputs: [] };
+  const n6368 = { id: 6368, inputs: [input("a", 61)], outputs: [] };
+  const graph2 = mkGraph([graph.getNodeById(131), n136, n6367, n6368], [...graph.links.values()]);
+  const res = verifyExternalLinks(graph2, snap);
+  assert.equal(res.restored, 2);
+  assert.deepEqual(res.dropped, []);
+});
+
+test("#1665 the reporter's exact failure: widget-converted target comes back link:null with a ghost on the source", () => {
+  const { graph, n136, subgraphNode } = fixtureBefore();
+  const snap = snapshotExternalLinks(graph, subgraphNode);
+  // Post-unpack reality from the issue: 136.length has connected_from null, but a
+  // stale link id still claims the origin — the one-sided ghost. 131 kept its link.
+  n136.inputs[2].link = null;
+  graph.links.delete(50);
+  graph.links.set(53, mkLink(53, 6367, 0, 136, 2)); // ghost: stored, never attached
+  graph.links.set(61, mkLink(61, 131, 0, 6368, 0));
+  const n6367 = { id: 6367, outputs: [output("INT", [53])], inputs: [] };
+  const n6368 = { id: 6368, inputs: [input("a", 61)], outputs: [] };
+  const graph2 = mkGraph([graph.getNodeById(131), n136, n6367, n6368], [...graph.links.values()]);
+  const res = verifyExternalLinks(graph2, snap);
+  assert.equal(res.restored, 1, "the 131.INT side survived");
+  assert.equal(res.dropped.length, 1);
+  assert.match(res.dropped[0], /136\.length/, "the dropped link is named, not indexed");
+  assert.match(res.dropped[0], /subgraph output "int_out"/);
+});
+
+test("#1665 slot INDICES shifting (new dynamic slot) does not defeat the name-based check", () => {
+  const { graph, n136, subgraphNode } = fixtureBefore();
+  const snap = snapshotExternalLinks(graph, subgraphNode);
+  // The measured report: 136 gained a dynamic ref_audio_1 slot, moving `length`.
+  n136.inputs = [
+    input("prompt", 51),
+    input("width", 52),
+    input("ref_audio_1", null), // new dynamic slot — length is now index 3
+    input("length", 60),
+  ];
+  graph.links.delete(50);
+  graph.links.delete(53);
+  graph.links.set(60, mkLink(60, 6367, 0, 136, 3));
+  graph.links.set(61, mkLink(61, 131, 0, 6368, 0));
+  const n6367 = { id: 6367, outputs: [output("INT", [60])], inputs: [] };
+  const n6368 = { id: 6368, inputs: [input("a", 61)], outputs: [] };
+  const graph2 = mkGraph([graph.getNodeById(131), n136, n6367, n6368], [...graph.links.values()]);
+  const res = verifyExternalLinks(graph2, snap);
+  assert.equal(res.restored, 2);
+  assert.deepEqual(res.dropped, []);
+});
+
+test("#1665 a target whose slot NAME vanished fails CLOSED as dropped", () => {
+  const { graph, n136, subgraphNode } = fixtureBefore();
+  const snap = snapshotExternalLinks(graph, subgraphNode);
+  n136.inputs = [input("prompt", 51), input("width", 52)]; // dynamic re-slot ate `length`
+  graph.links.delete(50);
+  graph.links.delete(53);
+  graph.links.set(61, mkLink(61, 131, 0, 6368, 0));
+  const n6368 = { id: 6368, inputs: [input("a", 61)], outputs: [] };
+  const graph2 = mkGraph([graph.getNodeById(131), n136, n6368], [...graph.links.values()]);
+  const res = verifyExternalLinks(graph2, snap);
+  assert.equal(res.restored, 1);
+  assert.equal(res.dropped.length, 1);
+  assert.match(res.dropped[0], /136\.length/);
+});
+
+test("#1665 a stored link that disagrees with the back-reference is NOT restored", () => {
+  const { graph, n136, subgraphNode } = fixtureBefore();
+  const snap = snapshotExternalLinks(graph, subgraphNode);
+  // 136.length references link 60, but the stored link 60 claims a DIFFERENT target
+  // slot — the re-slotted mismatch from the dynamic-input failure mode.
+  n136.inputs[2].link = 60;
+  graph.links.delete(50);
+  graph.links.delete(53);
+  graph.links.set(60, mkLink(60, 6367, 0, 136, 9));
+  graph.links.set(61, mkLink(61, 131, 0, 6368, 0));
+  const n6367 = { id: 6367, outputs: [output("INT", [60])], inputs: [] };
+  const n6368 = { id: 6368, inputs: [input("a", 61)], outputs: [] };
+  const graph2 = mkGraph([graph.getNodeById(131), n136, n6367, n6368], [...graph.links.values()]);
+  const res = verifyExternalLinks(graph2, snap);
+  assert.equal(res.dropped.length, 1);
+  assert.match(res.dropped[0], /136\.length/);
+});
+
+test("#1665 inbound fan-out: every interior consumer must get a live link back", () => {
+  // One rail link feeding TWO interior consumers; the unpack recreated only one.
+  const n131 = { id: 131, outputs: [output("INT", [50])], inputs: [] };
+  const subgraphNode = {
+    id: 6350,
+    inputs: [input("int_in", 50)],
+    outputs: [],
+    subgraph: { inputs: [{ name: "int_in", linkIds: [900, 901] }] },
+  };
+  const graph = mkGraph([n131, subgraphNode], [mkLink(50, 131, 0, 6350, 0)]);
+  const snap = snapshotExternalLinks(graph, subgraphNode);
+  assert.equal(snap.links[0].consumers, 2);
+  assert.equal(snap.links[0].baseline, 1);
+
+  const restoredOne = mkGraph(
+    [n131, { id: 6368, inputs: [input("a", 61)], outputs: [] }],
+    [mkLink(61, 131, 0, 6368, 0)],
+  );
+  const res1 = verifyExternalLinks(restoredOne, snap);
+  assert.equal(res1.dropped.length, 1, "one of two consumers lost its feed");
+  assert.match(res1.dropped[0], /fed 2 interior node\(s\)/);
+
+  const restoredBoth = mkGraph(
+    [
+      n131,
+      { id: 6368, inputs: [input("a", 61)], outputs: [] },
+      { id: 6369, inputs: [input("b", 62)], outputs: [] },
+    ],
+    [mkLink(61, 131, 0, 6368, 0), mkLink(62, 131, 0, 6369, 0)],
+  );
+  const res2 = verifyExternalLinks(restoredBoth, snap);
+  assert.equal(res2.restored, 1);
+  assert.deepEqual(res2.dropped, []);
+});
+
+test("#1665 a pre-existing dangling link is UNVERIFIABLE, not a refusal — the unpack did not cause it", () => {
+  const subgraphNode = {
+    id: 6350,
+    inputs: [input("ghost_in", 999)], // link id 999 is not in the link table
+    outputs: [output("out", [])],
+    subgraph: { inputs: [] },
+  };
+  const graph = mkGraph([subgraphNode], []);
+  const snap = snapshotExternalLinks(graph, subgraphNode);
+  assert.equal(snap.links.length, 0);
+  assert.equal(snap.unverifiable.length, 1);
+  const res = verifyExternalLinks(graph, snap);
+  assert.deepEqual(res.dropped, []);
+  assert.equal(res.unverifiable.length, 1);
+  assert.match(res.unverifiable[0], /ghost_in/);
+});
+
+test("#1665 object-keyed link tables (older LiteGraph) verify the same", () => {
+  const n136 = { id: 136, inputs: [input("length", 53)], outputs: [] };
+  const subgraphNode = {
+    id: 6350,
+    inputs: [],
+    outputs: [output("int_out", [53])],
+    subgraph: { inputs: [] },
+  };
+  const graph = mkGraph([n136, subgraphNode], [mkLink(53, 6350, 0, 136, 0)], { asMap: false });
+  const snap = snapshotExternalLinks(graph, subgraphNode);
+  assert.equal(snap.links.length, 1);
+  // Post-unpack: link re-created from the inlined node, still object-keyed.
+  const graph2 = mkGraph(
+    [n136, { id: 6367, outputs: [output("INT", [60])], inputs: [] }],
+    [mkLink(60, 6367, 0, 136, 0)],
+    { asMap: false },
+  );
+  n136.inputs[0].link = 60;
+  const res = verifyExternalLinks(graph2, snap);
+  assert.equal(res.restored, 1);
+  assert.deepEqual(res.dropped, []);
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -198,6 +198,10 @@ import {
   materializedValuesNote,
   findDivergentPromotedValues,
 } from "./lib/unpack-promoted-values.js";
+import {
+  snapshotExternalLinks,
+  verifyExternalLinks,
+} from "./lib/unpack-link-verify.js";
 import { readSaveFailureCause } from "./lib/userdata-failure-cause.js";
 import { describeScreenshotFraming } from "./lib/screenshot-framing.js";
 import { readActiveSidebarTab, shouldDetachPanelRoot, findSidebarTabButton } from "./lib/active-sidebar-tab.js";
@@ -16045,6 +16049,12 @@ const GRAPH_TOOL_EXECUTORS = {
     }
     // unpackSubgraph wraps its own beforeChange/afterChange for undo, so don't
     // nest another pair here.
+    // comfyui-mcp#1665 — snapshot the subgraph's EXTERNAL links (endpoints resolved
+    // to slot NAMES, since indices shift during the unpack) so the rewire can be
+    // verified afterwards instead of trusted. litegraph's unpackSubgraph silently
+    // drops links whose targets are widget-converted or dynamic inputs and leaves
+    // one-sided ghosts behind; a bare success over that is silent graph corruption.
+    const externalLinks = snapshotExternalLinks(graph, node);
     try {
       graph.unpackSubgraph(node, { skipMissingNodes: true });
     } catch (err) {
@@ -16067,6 +16077,40 @@ const GRAPH_TOOL_EXECUTORS = {
           : `unpack_subgraph failed AFTER partially modifying the graph and the automatic rollback did not complete — undo (Ctrl+Z) to restore: ${reason}`,
       );
     }
+    // comfyui-mcp#1665 — the unpack returned without throwing, but that is NOT proof
+    // the external links survived: the measured failure threw nothing while dropping
+    // 3 of ~35 links into widget-converted / dynamic target slots. Re-resolve every
+    // expected link by NAME against the live link table; if any cannot be proven
+    // present, roll back and refuse with exactly what would have been lost rather
+    // than report a success over a graph that would render wrong.
+    const linkCheck = verifyExternalLinks(graph, externalLinks);
+    if (linkCheck.dropped.length) {
+      let rolledBack = false;
+      if (rollback && typeof app?.loadGraphData === "function") {
+        try {
+          const activeWorkflow = app?.extensionManager?.workflow?.activeWorkflow || null;
+          await app.loadGraphData(...resolveLoadGraphArgs(rollback, activeWorkflow));
+          rolledBack = true;
+        } catch {
+          rolledBack = false;
+        }
+      }
+      const lost = linkCheck.dropped.map((d) => `  - ${d}`).join("\n");
+      throw new Error(
+        `unpack_subgraph refused: the unpack did not restore ${linkCheck.dropped.length} ` +
+          `external link(s):\n${lost}\n` +
+          `These are links litegraph's unpackSubgraph rewires by slot index and silently loses ` +
+          `when the target is a widget-converted or dynamic input (comfyui-mcp#1665). ` +
+          (rolledBack
+            ? `The workflow was reloaded from its pre-unpack snapshot, so the subgraph and all ` +
+              `its links are intact — nothing was lost. Unpack in the ComfyUI canvas and re-add ` +
+              `the named links by hand, or remove the dynamic/widget-converted targets from the ` +
+              `link set and retry.`
+            : `The pre-unpack snapshot could NOT be reloaded, so those links are gone from the ` +
+              `live graph and the source outputs may carry stale link ids — reconnect the named ` +
+              `targets with panel_connect, then save + panel_load_workflow to prune the ghosts.`),
+      );
+    }
     const newNodeIds = (graph._nodes ?? []).filter((n) => !before.has(n.id)).map((n) => n.id);
     graph.setDirtyCanvas?.(true, true);
     canvas?.setDirty?.(true, true);
@@ -16075,6 +16119,14 @@ const GRAPH_TOOL_EXECUTORS = {
         node_id,
         new_node_ids: newNodeIds,
         node_count: newNodeIds.length,
+        // #1665 — disclose the verification so a caller never has to take the rewire
+        // on trust: how many external links were checked and restored, and any whose
+        // pre-unpack state could not even be read (pre-existing corruption the unpack
+        // did not cause, disclosed rather than silently inherited).
+        ...(externalLinks.links.length
+          ? { external_links_verified: linkCheck.restored }
+          : {}),
+        ...(linkCheck.unverifiable.length ? { external_links_unverifiable: linkCheck.unverifiable } : {}),
         // #979 — disclose what was carried inward. An unpack cannot be undone from
         // this result, so a caller checking values afterwards needs to know which
         // ones this moved, and which widgets it could not match.

--- a/web/js/lib/unpack-link-verify.js
+++ b/web/js/lib/unpack-link-verify.js
@@ -1,0 +1,233 @@
+/**
+ * comfyui-mcp#1665 — `panel_unpack_subgraph` silently DROPPED external links whose
+ * parent-graph targets were widget-converted inputs (`length`) or dynamic/optional
+ * inputs (`values.a`, `ref_audios.ref_audio_0`), and left them HALF-BROKEN: the
+ * target slot came back `connected_from: null` while the source output still
+ * reported `links: 1` (a one-sided ghost that even serialized to disk). The tool
+ * returned a plain success payload, so nothing told the caller the graph it just
+ * mutated would render wrong.
+ *
+ * WHY IT HAPPENS: litegraph's `unpackSubgraph` rewires the rails' external links by
+ * slot INDEX. Slot indices shift during the unpack (the measured report: node 136
+ * gained a new dynamic `ref_audio_1` slot), and widget-backed / dynamic inputs are
+ * re-slotted or skipped entirely — the link is never re-created on the target, but
+ * the id lingers on the source output's link list.
+ *
+ * WHAT THIS MODULE DOES: snapshots the subgraph node's EXTERNAL link set BEFORE the
+ * unpack (endpoints resolved to slot NAMES, not indices, because indices shift), and
+ * after the unpack re-resolves every expected link against the LIVE link table. A
+ * link counts as restored only when the stored link AND the target input's
+ * back-reference agree (the ghost above fails exactly that check — same test as
+ * connect-verify's isLinkPersisted). What cannot be proven present is reported as
+ * dropped so the caller can refuse loudly instead of reporting a corrupt success.
+ *
+ * Pure (no DOM / no ComfyUI globals — graph + nodes are passed in) so the SAME check
+ * runs under unit test and in production. Fully defensive; never throws — an
+ * unreadable piece lands in `unverifiable` rather than breaking the unpack report.
+ */
+
+/** All stored link objects on `graph` — `graph.links` is a Map in current LiteGraph
+ *  builds and a plain object/array in older ones; both are read here. */
+function storedLinks(graph) {
+  const links = graph?.links;
+  if (!links) return [];
+  try {
+    if (typeof links.values === "function") return Array.from(links.values());
+    return Object.values(links);
+  } catch {
+    return [];
+  }
+}
+
+/** One stored link by id (Map `.get` or key/index access). */
+function readLink(graph, id) {
+  const links = graph?.links;
+  if (links == null || id == null) return null;
+  try {
+    return typeof links.get === "function" ? (links.get(id) ?? null) : (links[id] ?? null);
+  } catch {
+    return null;
+  }
+}
+
+/** LLink field access — object form (`origin_id`) or array form (`[1]`). */
+const linkId = (l) => l?.id ?? l?.[0];
+const linkOriginId = (l) => l?.origin_id ?? l?.[1];
+const linkOriginSlot = (l) => l?.origin_slot ?? l?.[2];
+const linkTargetId = (l) => l?.target_id ?? l?.[3];
+const linkTargetSlot = (l) => l?.target_slot ?? l?.[4];
+
+function getNode(graph, id) {
+  try {
+    return id != null && typeof graph?.getNodeById === "function" ? graph.getNodeById(id) : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Case-insensitive slot-index lookup by name (mirrors the panel's resolveSlot). */
+function slotIndexByName(slots, name) {
+  if (typeof name !== "string" || !Array.isArray(slots)) return -1;
+  const lower = name.toLowerCase();
+  return slots.findIndex((s) => s?.name?.toLowerCase() === lower);
+}
+
+/**
+ * Count LIVE links out of (`nodeId`, `outIdx`) — live means the stored link exists
+ * AND its target input back-references the same link id. The one-sided ghost of
+ * #1665 (stored + on the origin's list, but the target input is `link: null`) is
+ * NOT live, which is exactly what makes it detectable here.
+ */
+function liveLinkCountFrom(graph, nodeId, outIdx) {
+  let count = 0;
+  for (const stored of storedLinks(graph)) {
+    if (stored == null) continue;
+    if (String(linkOriginId(stored)) !== String(nodeId)) continue;
+    if (Number(linkOriginSlot(stored)) !== Number(outIdx)) continue;
+    const target = getNode(graph, linkTargetId(stored));
+    if (target?.inputs?.[linkTargetSlot(stored)]?.link === linkId(stored)) count += 1;
+  }
+  return count;
+}
+
+/**
+ * Snapshot every external link touching `subgraphNode` (the wrapper in the PARENT
+ * graph), endpoints named by slot NAME so the post-unpack check is immune to the
+ * slot-index shifting that causes #1665.
+ *
+ * Returns `{ links, unverifiable }`:
+ *  - `links` entries are `{ kind: "in", rail, source: {node_id, slot, name}, consumers, baseline }`
+ *    (external SOURCE → subgraph input rail) or `{ kind: "out", rail, target: {node_id, slot, name} }`
+ *    (subgraph output rail → external TARGET).
+ *  - `unverifiable` entries are links whose endpoints could not even be READ — a
+ *    pre-existing dangling/corrupt link the unpack did not cause. They are disclosed
+ *    but must not force a refusal (the loss, if any, predates this call).
+ */
+export function snapshotExternalLinks(graph, subgraphNode) {
+  const links = [];
+  const unverifiable = [];
+  if (!graph || !subgraphNode) return { links, unverifiable };
+  try {
+    const inputs = Array.isArray(subgraphNode.inputs) ? subgraphNode.inputs : [];
+    for (let i = 0; i < inputs.length; i++) {
+      const slot = inputs[i];
+      if (slot?.link == null) continue;
+      const rail = typeof slot?.name === "string" ? slot.name : `slot ${i}`;
+      const stored = readLink(graph, slot.link);
+      const originId = stored ? linkOriginId(stored) : null;
+      const originSlot = stored ? linkOriginSlot(stored) : null;
+      const origin = getNode(graph, originId);
+      if (originId == null || originSlot == null || !origin) {
+        unverifiable.push({ rail, reason: "the link into this rail could not be resolved before the unpack" });
+        continue;
+      }
+      const name = origin.outputs?.[originSlot]?.name ?? null;
+      // One rail link can FAN OUT to several interior consumers; the unpack should
+      // recreate one live link per consumer in place of the single rail link, so the
+      // post-check compares counts, not mere existence.
+      let consumers = 1;
+      const railSlot = subgraphNode.subgraph?.inputs?.[i];
+      if (railSlot && Array.isArray(railSlot.linkIds)) consumers = railSlot.linkIds.length;
+      links.push({
+        kind: "in",
+        rail,
+        source: { node_id: originId, slot: originSlot, name },
+        consumers,
+        baseline: liveLinkCountFrom(graph, originId, originSlot),
+      });
+    }
+    const outputs = Array.isArray(subgraphNode.outputs) ? subgraphNode.outputs : [];
+    for (let i = 0; i < outputs.length; i++) {
+      const slot = outputs[i];
+      const rail = typeof slot?.name === "string" ? slot.name : `slot ${i}`;
+      const linkIds = Array.isArray(slot?.links) ? slot.links : [];
+      for (const id of linkIds) {
+        const stored = readLink(graph, id);
+        const targetId = stored ? linkTargetId(stored) : null;
+        const targetSlot = stored ? linkTargetSlot(stored) : null;
+        const target = getNode(graph, targetId);
+        const name = target?.inputs?.[targetSlot]?.name ?? null;
+        if (targetId == null || targetSlot == null || !target || name == null) {
+          unverifiable.push({
+            rail,
+            reason: "the external target of this rail could not be named before the unpack",
+          });
+          continue;
+        }
+        links.push({ kind: "out", rail, target: { node_id: targetId, slot: targetSlot, name } });
+      }
+    }
+  } catch {
+    // A poisoned accessor on the wrapper must not break the unpack path; whatever was
+    // gathered so far is still checked, and the gap is disclosed.
+    unverifiable.push({ rail: "(unknown)", reason: "reading the subgraph's external links threw" });
+  }
+  return { links, unverifiable };
+}
+
+/** Human-readable one-liner for a dropped expected link (names, not indices). */
+function describeExpected(e) {
+  const srcName = e.source?.name ?? `slot ${e.source?.slot}`;
+  const tgtName = e.target?.name ?? `slot ${e.target?.slot}`;
+  return e.kind === "in"
+    ? `${e.source?.node_id}.${srcName} → subgraph input "${e.rail}" (fed ${e.consumers} interior node(s))`
+    : `subgraph output "${e.rail}" → ${e.target?.node_id}.${tgtName}`;
+}
+
+/**
+ * Re-resolve every expected link from `snapshotExternalLinks` against the LIVE graph
+ * after the unpack. Returns `{ restored, dropped, unverifiable }` — `dropped` holds
+ * a named description per link that cannot be PROVEN present. Fail-closed per link:
+ * a target whose slot name no longer resolves (dynamic re-slotting) counts as
+ * dropped, because reporting it restored would be the silent corruption this exists
+ * to stop.
+ */
+export function verifyExternalLinks(graph, snapshot) {
+  const dropped = [];
+  const unverifiable = [...(snapshot?.unverifiable ?? [])].map(
+    (u) => `rail "${u.rail}": ${u.reason}`,
+  );
+  let restored = 0;
+  for (const e of snapshot?.links ?? []) {
+    let ok = false;
+    try {
+      ok = e.kind === "in" ? inboundRestored(graph, e) : outboundRestored(graph, e);
+    } catch {
+      ok = false;
+    }
+    if (ok) restored += 1;
+    else dropped.push(describeExpected(e));
+  }
+  return { restored, dropped, unverifiable };
+}
+
+/** External SOURCE → rail → interior consumer(s): the unpack should leave
+ *  `baseline - 1 + consumers` live links from the source slot (the rail link itself
+ *  is gone, one new live link per interior consumer). */
+function inboundRestored(graph, e) {
+  const origin = getNode(graph, e.source?.node_id);
+  if (!origin) return false;
+  let outIdx = slotIndexByName(origin.outputs, e.source?.name);
+  if (outIdx === -1) outIdx = e.source?.slot;
+  if (outIdx == null) return false;
+  const expected = Math.max(0, (e.baseline ?? 1) - 1) + (e.consumers ?? 1);
+  return liveLinkCountFrom(graph, e.source.node_id, outIdx) >= expected;
+}
+
+/** Rail → external TARGET: the target node survives the unpack, so the check is
+ *  name-based on its CURRENT inputs (indices may have shifted — that is the bug).
+ *  The input must reference a stored link that agrees it targets this node/slot. */
+function outboundRestored(graph, e) {
+  const target = getNode(graph, e.target?.node_id);
+  if (!target) return false;
+  const inIdx = slotIndexByName(target.inputs, e.target?.name);
+  if (inIdx === -1) return false; // name gone — cannot prove survival, fail closed
+  const id = target.inputs?.[inIdx]?.link;
+  if (id == null) return false;
+  const stored = readLink(graph, id);
+  if (!stored) return false;
+  return (
+    String(linkTargetId(stored)) === String(e.target.node_id) &&
+    Number(linkTargetSlot(stored)) === Number(inIdx)
+  );
+}


### PR DESCRIPTION
## Root cause

`panel_unpack_subgraph` trusted litegraph's `unpackSubgraph` to rewire the rails' external links. It rewires by **slot index**, and indices shift during the unpack (the measured report: node 136 gained a new dynamic `ref_audio_1` slot). Links into **widget-converted inputs** (`length`) and **dynamic/optional inputs** (`values.a`, `ref_audios.ref_audio_0`) are never re-created on the target — the target slot comes back `connected_from: null` while the source output still reports `links: 1` (a one-sided ghost that even serialized to disk). The tool returned a bare success payload over a graph that would render wrong, with no error and no warning.

Measured on the reporter's graph (ComfyUI 0.33.0 / frontend 1.49.6): 3 of ~35 external links dropped, every one into a widget-converted or dynamic target slot; all plain typed inputs survived.

## Fix — verify the rewire, refuse loudly when links were lost (fail CLOSED)

In `graph_unpack_subgraph` (`web/js/comfyui-mcp-panel.js`), around the existing #405 atomicity pattern:

1. **Before** the unpack, `snapshotExternalLinks` records every external link touching the wrapper — external source → input rail (with interior fan-out count) and output rail → external target — with endpoints resolved to slot **names**, not indices.
2. **After** the unpack, `verifyExternalLinks` re-resolves each expected link against the live link table. A link counts as restored only when the stored link **and** the target input's back-reference agree — the #1665 ghost (stored + on the origin's list, target `link: null`) fails exactly that check. Name-based target resolution is immune to the index shifting that causes the bug; a target whose slot name vanished fails closed as dropped.
3. If any link cannot be proven present, the handler **reloads the pre-unpack snapshot and throws**, naming every dropped link (`subgraph output "int_out" → 136.length`, …) — the subgraph is intact and nothing is lost. If the reload itself fails, the error says so and gives the repair path (`panel_connect` + save/load to prune ghosts).
4. On success the payload discloses the verification: `external_links_verified: N`, plus `external_links_unverifiable` for pre-existing dangling links the unpack did not cause (disclosed, never refused on).

The check lives in a new pure module `web/js/lib/unpack-link-verify.js` (no DOM/ComfyUI globals — graph passed in), same pattern as `connect-verify.js` / `subgraph-conversion-integrity.js`, so unit tests drive the identical logic production runs.

## Verification

- `browser_tests/unit/unpack-link-verify.test.mjs` — 9 new tests: the reporter's exact ghost shape, slot-index shift survival, vanished slot name (fail closed), stored/back-reference mismatch, inbound fan-out shortfall, pre-existing dangling link → unverifiable (not refused), object-keyed link tables. All pass.
- `npm ci` — clean, 0 vulnerabilities.
- `npm run test:unit` (i18n + vocabulary + scope checks + 253 unit files) — **4904 pass, 0 fail**.
- `npm run typecheck` (`tsc --noEmit`) — clean.

## Deliberately out of scope (follow-ups from the issue)

- Auto-repairing dropped links by name instead of refusing (the issue notes manual `panel_connect` repair works) — refusal + rollback was chosen as the fail-closed minimum; auto-repair can layer on later.
- `panel_graph_outline`'s off-by-one target-slot naming for widget-converted inputs (issue item 4) — a separate read-side bug.

Closes artokun/comfyui-mcp#1665
