### PR TITLE
fix(1667): a stale-canvas tab can no longer persist its foreign graph over another workflow's file

### DIFF
--- a/browser_tests/unit/save-path-guard.test.mjs
+++ b/browser_tests/unit/save-path-guard.test.mjs
@@ -1,0 +1,255 @@
+/**
+ * #1667 — P0 DATA LOSS: a stale-canvas tab persisted the WRONG graph over a live file.
+ *
+ * The incident: a tab whose canvas held workflow A's graph was persisted by the
+ * FRONTEND's own save path (autosave / reconnect-restore — no panel command, so the
+ * #708 wrong-canvas fence never saw it) over "CUMSLUT2 - Office Slap.json", destroying
+ * its 31-node graph. The recovered file's own `extra.comfyui_mcp` stamp named a THIRD
+ * workflow's path — the stamp and the destination disagreed, and nothing checked.
+ *
+ * These tests pin the two halves of the fix:
+ *
+ *   1. `decideWorkflowSaveVerdict` refuses EXACTLY the evidenced shape — the state
+ *      about to be written is stamped with a different, still-existing workflow's
+ *      path and the destination is an on-disk file — and allows everything that is
+ *      not provable foreign (no stamp, matching stamp, rename residue, unsaved
+ *      destination). A guard that refuses on a guess is a wrong-graph refusal of its
+ *      own, so the allow-cases are pinned as hard as the refusal.
+ *
+ *   2. The REAL `installSavePathGuard`, extracted from the panel source and driven
+ *      over a fake workflow store, proving the wrapper throws BEFORE the original
+ *      save is called — nothing is written — and that a healthy save passes through.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+import {
+  decideWorkflowSaveVerdict,
+  workflowSaveRefusalError,
+  SAVE_PATH_GUARD_REASON,
+} from "../../web/js/lib/save-path-guard.js";
+import { sameWorkflowObject } from "../../web/js/lib/workflow-chat-identity.js";
+
+// ---------------------------------------------------------------------------
+// 1. The pure verdict.
+// ---------------------------------------------------------------------------
+
+test("#1667 THE REPORTED CASE: a canvas stamped with a THIRD workflow's path is refused over the live file", () => {
+  // The destroyed file's stamp named "CUMSLUT - pussy lips (Copy).json" while the
+  // write targeted "CUMSLUT2 - Office Slap.json" — and the stamped path was a real,
+  // still-existing workflow. This exact crossing is what must never write again.
+  const verdict = decideWorkflowSaveVerdict({
+    destinationPath: "workflows/CUMSLUT2 - Office Slap.json",
+    destinationPersisted: true,
+    stampedPath: "workflows/CUMSLUT - pussy lips (Copy).json",
+    stampedPathOwnedByOther: true,
+  });
+  assert.equal(verdict.allow, false);
+  assert.equal(verdict.reason, SAVE_PATH_GUARD_REASON.STAMPED_PATH_FOREIGN);
+});
+
+test("#1667 a healthy save — stamp matches the destination — is allowed", () => {
+  const verdict = decideWorkflowSaveVerdict({
+    destinationPath: "workflows/a.json",
+    destinationPersisted: true,
+    stampedPath: "workflows/a.json",
+    stampedPathOwnedByOther: false,
+  });
+  assert.deepEqual(verdict, { allow: true });
+});
+
+test("#1667 no stamp at all is ALLOWED — absence proves nothing in either direction", () => {
+  // Blocking every unstamped save would break ordinary ComfyUI use for exactly the
+  // users the stamping fork failed to install for. The guard refuses only on
+  // POSITIVE contradiction.
+  for (const stampedPath of [null, undefined, ""]) {
+    assert.deepEqual(
+      decideWorkflowSaveVerdict({
+        destinationPath: "workflows/a.json",
+        destinationPersisted: true,
+        stampedPath,
+        stampedPathOwnedByOther: false,
+      }),
+      { allow: true },
+    );
+  }
+});
+
+test("#1667 RENAME RESIDUE is allowed — the stamped path no longer names a live record", () => {
+  // After a rename the file moved: the in-memory stamp still names the old path, and
+  // the canvas genuinely belongs to the destination. Refusing here would wedge every
+  // renamed tab — a wrong-graph refusal of the guard's own.
+  const verdict = decideWorkflowSaveVerdict({
+    destinationPath: "workflows/renamed.json",
+    destinationPersisted: true,
+    stampedPath: "workflows/old-name.json",
+    stampedPathOwnedByOther: false, // old path is gone from the store
+  });
+  assert.deepEqual(verdict, { allow: true });
+});
+
+test("#1667 an UNSAVED destination is allowed — no existing file is overwritten (Save-As copy stays saveable)", () => {
+  // A Save-As copy inherits the source's stamp; its target is a temporary record, so
+  // the first write creates a file rather than destroying one.
+  const verdict = decideWorkflowSaveVerdict({
+    destinationPath: "workflows/copy.json",
+    destinationPersisted: false,
+    stampedPath: "workflows/source.json",
+    stampedPathOwnedByOther: true,
+  });
+  assert.deepEqual(verdict, { allow: true });
+});
+
+test("#1667 path comparison is normalized — case and separator drift must not false-refuse", () => {
+  const verdict = decideWorkflowSaveVerdict({
+    destinationPath: "workflows/Sub\\Foo.JSON",
+    destinationPersisted: true,
+    stampedPath: "workflows/sub/foo.json",
+    stampedPathOwnedByOther: false,
+  });
+  assert.deepEqual(verdict, { allow: true });
+});
+
+test("#1667 the refusal names both paths, states NOTHING was written, and names the recovery", () => {
+  const err = workflowSaveRefusalError({
+    allow: false,
+    reason: SAVE_PATH_GUARD_REASON.STAMPED_PATH_FOREIGN,
+    destinationPath: "workflows/CUMSLUT2 - Office Slap.json",
+    stampedPath: "workflows/CUMSLUT - pussy lips (Copy).json",
+  });
+  assert.match(err.message, /CUMSLUT2 - Office Slap\.json/);
+  assert.match(err.message, /CUMSLUT - pussy lips \(Copy\)\.json/);
+  assert.match(err.message, /NOTHING was written/);
+  assert.match(err.message, /panel_open_workflow/);
+  // Honesty pin: the message must present the two readings, not assert one cause.
+  assert.match(err.message, /stale/);
+  assert.match(err.message, /deliberately/);
+});
+
+test("#1667 a verdict with missing paths still produces a coherent refusal", () => {
+  const err = workflowSaveRefusalError({ allow: false });
+  assert.match(err.message, /REFUSED to save/);
+  assert.match(err.message, /NOTHING was written/);
+});
+
+// ---------------------------------------------------------------------------
+// 2. The real installer, driven over a fake workflow store.
+//
+// SCOPE, stated honestly: this exercises the wrapper's LOGIC against a plain-object
+// store. It models neither pinia reactivity nor the real ChangeTracker — a wiring
+// mistake that keeps the wrapper off the real store (e.g. the store not existing at
+// setup() time) is not caught here, only in a live browser.
+// ---------------------------------------------------------------------------
+
+const PANEL_SRC = () =>
+  readFileSync(
+    join(dirname(fileURLToPath(import.meta.url)), "../../web/js/comfyui-mcp-panel.js"),
+    "utf8",
+  ).replace(/\r\n/g, "\n");
+
+/** The REAL installSavePathGuard, sliced from the panel bundle with its module-scope
+ *  state, collaborators injected. */
+function buildInstaller() {
+  const src = PANEL_SRC();
+  const start = src.indexOf("let _savePathGuardInstalled = false;");
+  assert.notEqual(start, -1, "save-path guard state must exist in the panel source");
+  const end = src.indexOf("\nfunction workflowUuidOwner(id) {", start);
+  assert.ok(end > start, "could not bound installSavePathGuard");
+  const source = src.slice(start, end);
+
+  const warnings = [];
+  const build = new Function(
+    "WORKFLOW_META_NAMESPACE",
+    "WORKFLOW_PATH_FIELD",
+    "sameWorkflowObject",
+    "decideWorkflowSaveVerdict",
+    "workflowSaveRefusalError",
+    "console",
+    `${source}\nreturn { installSavePathGuard };`,
+  );
+  return {
+    warnings,
+    buildInstaller: () =>
+      build(
+        "comfyui_mcp",
+        "workflow_path",
+        sameWorkflowObject,
+        decideWorkflowSaveVerdict,
+        workflowSaveRefusalError,
+        { warn: (...args) => warnings.push(args.join(" ")) },
+      ).installSavePathGuard,
+  };
+}
+
+function fakeStore({ stampedPath } = {}) {
+  const wfB = { path: "workflows/B.json", isTemporary: false };
+  const wfA = {
+    path: "workflows/A.json",
+    isTemporary: false,
+    changeTracker: {
+      activeState: {
+        nodes: [{ id: 1 }],
+        extra: stampedPath ? { comfyui_mcp: { workflow_path: stampedPath } } : {},
+      },
+    },
+  };
+  const store = {
+    saved: [],
+    getWorkflowByPath(p) {
+      if (p === "workflows/A.json") return wfA;
+      if (p === "workflows/B.json") return wfB;
+      return null;
+    },
+    async saveWorkflow(wf) {
+      this.saved.push(wf.path);
+    },
+  };
+  return { store, wfA, appRef: { extensionManager: { workflow: store } } };
+}
+
+test("#1667 WRAPPER: a crossed save is refused and the original save is NEVER called", async () => {
+  const { buildInstaller: build } = buildInstaller();
+  const install = build();
+  const { store, wfA, appRef } = fakeStore({ stampedPath: "workflows/B.json" });
+  install(appRef);
+  await assert.rejects(() => store.saveWorkflow(wfA), /REFUSED to save/);
+  assert.deepEqual(store.saved, [], "nothing may be written when the guard refuses");
+});
+
+test("#1667 WRAPPER: a healthy save passes through to the original unchanged", async () => {
+  const { buildInstaller: build } = buildInstaller();
+  const install = build();
+  const { store, wfA, appRef } = fakeStore({ stampedPath: "workflows/A.json" });
+  install(appRef);
+  await store.saveWorkflow(wfA);
+  assert.deepEqual(store.saved, ["workflows/A.json"]);
+});
+
+test("#1667 WRAPPER: an unstamped canvas saves — the guard does not block what it cannot prove", async () => {
+  const { buildInstaller: build } = buildInstaller();
+  const install = build();
+  const { store, wfA, appRef } = fakeStore({ stampedPath: null });
+  install(appRef);
+  await store.saveWorkflow(wfA);
+  assert.deepEqual(store.saved, ["workflows/A.json"]);
+});
+
+test("#1667 WRAPPER: rename residue (stamped path gone from the store) saves", async () => {
+  const { buildInstaller: build } = buildInstaller();
+  const install = build();
+  const { store, wfA, appRef } = fakeStore({ stampedPath: "workflows/old-name.json" });
+  install(appRef);
+  await store.saveWorkflow(wfA);
+  assert.deepEqual(store.saved, ["workflows/A.json"]);
+});
+
+test("#1667 WRAPPER: a missing store is DISCLOSED, not silent — saves proceed unguarded with a warning", async () => {
+  const { buildInstaller: build, warnings } = buildInstaller();
+  const install = build();
+  install({ extensionManager: {} });
+  assert.equal(warnings.length, 1);
+  assert.match(warnings[0], /save-path guard NOT installed/);
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -155,6 +155,7 @@ import {
   pruneGroundingIdentities,
   groundedWorkflowPath,
 } from "./lib/workflow-chat-identity.js";
+import { decideWorkflowSaveVerdict, workflowSaveRefusalError } from "./lib/save-path-guard.js";
 import { validateA2UISpec, renderA2UICard, renderA2UIInert, renderA2UIFailCard, A2UI_CSS } from "./cmcp-a2ui.js";
 import { openSidePanel } from "./cmcp-sidepanel-ui.js";
 import {
@@ -2884,6 +2885,101 @@ function installCreateBoundaryFork(appRef) {
     try {
       console.warn(
         "[comfyui-mcp] creation-boundary fork failed to install; unsaved-workflow resume disabled (fail-closed)",
+        err,
+      );
+    } catch {}
+  }
+}
+
+// #1667 P0 — SAVE-PATH GUARD. The creation-boundary fork above guards who ENTERS a
+// canvas; this guards who LEAVES it for disk. ComfyUI persists a tab's canvas through
+// `workflowStore.saveWorkflow` (autosave "after delay", Ctrl+S, the reconnect/session
+// restore flows all funnel there) and serializes `changeTracker.activeState` verbatim
+// to the tab's path WITHOUT checking the content belongs to that path. When a stale
+// canvas — another workflow's graph — is mounted under a tab (the crossed-identity
+// failure of #1639), that persist overwrites the tab's file with the foreign graph and
+// the original is destroyed (#1667: a user's saved workflow .json was replaced by a
+// different workflow's 15-node graph, unrecoverably, with no panel command involved).
+//
+// The guard refuses exactly ONE shape, the one the destroyed file itself evidenced:
+// the state about to be written is stamped `extra.comfyui_mcp.workflow_path` naming a
+// DIFFERENT workflow that still exists, while the destination is an existing on-disk
+// file. Everything else — no stamp, matching stamp, rename residue (stamped path gone),
+// a never-persisted destination (Save-As copy) — is allowed; see save-path-guard.js for
+// why each of those is not provable foreign. A refusal throws BEFORE the write, so the
+// disk is never touched, and the message names both readings and the re-bind recovery.
+//
+// Installed on the workflow STORE, not per ComfyWorkflow object: the store's
+// `saveWorkflow` is the single funnel the service, the autosave watcher, and the keymap
+// all call, and the store hands out Vue proxies of records created long after this
+// installs. The panel's own panel_save_workflow path passes through the same wrapper —
+// it reaches it already fenced by the #708 wrong-canvas guard, so a healthy panel save
+// satisfies the stamp check; a crossed one is refused here too, which is the point.
+let _savePathGuardInstalled = false;
+const _savePathGuardRefusalsLogged = new Set();
+function installSavePathGuard(appRef) {
+  try {
+    if (_savePathGuardInstalled) return;
+    const svc = appRef?.extensionManager?.workflow;
+    if (!svc || typeof svc.saveWorkflow !== "function") {
+      // The store is not there to wrap — saves proceed UNGUARDED. Say so, once, the
+      // same way the fork's install failure is surfaced: a silent absence here is the
+      // exact condition that let #1667 through.
+      console.warn(
+        "[comfyui-mcp] save-path guard NOT installed: workflow store saveWorkflow is unavailable " +
+          "on this frontend — frontend-initiated saves are not checked against the canvas identity stamp.",
+      );
+      return;
+    }
+    const orig = svc.saveWorkflow.bind(svc);
+    svc.saveWorkflow = async function (wf, ...rest) {
+      let verdict = { allow: true };
+      try {
+        // Verify the EXACT state the write serializes (ComfyWorkflow.save() stringifies
+        // `activeState`), not the live root — the two can differ, and the file gets
+        // this one. `getWorkflowByPath` answers existence from the store's own records;
+        // a lookup failure degrades to "not persisted"/"not owned" — ALLOW, never a
+        // guessed refusal.
+        const state = wf?.changeTracker?.activeState ?? wf?.activeState ?? null;
+        const stampedPath =
+          state?.extra?.[WORKFLOW_META_NAMESPACE]?.[WORKFLOW_PATH_FIELD] ?? null;
+        const destRecord =
+          typeof svc.getWorkflowByPath === "function" && wf?.path ? svc.getWorkflowByPath(wf.path) : null;
+        const stampedRecord =
+          stampedPath && typeof svc.getWorkflowByPath === "function"
+            ? svc.getWorkflowByPath(stampedPath)
+            : null;
+        verdict = decideWorkflowSaveVerdict({
+          destinationPath: wf?.path ?? null,
+          destinationPersisted: Boolean(destRecord) && destRecord?.isTemporary !== true,
+          stampedPath: typeof stampedPath === "string" && stampedPath ? stampedPath : null,
+          stampedPathOwnedByOther: Boolean(stampedRecord) && !sameWorkflowObject(stampedRecord, wf),
+        });
+      } catch {
+        verdict = { allow: true }; // a guard that cannot read its evidence must never invent a refusal
+      }
+      if (!verdict.allow) {
+        const refusal = workflowSaveRefusalError(verdict);
+        // The autosave watcher logs a one-line "Auto save failed" for a thrown save;
+        // make the refusal itself unmistakable in the console — but once per crossing,
+        // not once per autosave retry.
+        const key = `${verdict.destinationPath}<-${verdict.stampedPath}`;
+        if (!_savePathGuardRefusalsLogged.has(key)) {
+          _savePathGuardRefusalsLogged.add(key);
+          try {
+            console.warn(`[comfyui-mcp] ${refusal.message}`);
+          } catch {}
+        }
+        throw refusal;
+      }
+      return orig(wf, ...rest);
+    };
+    _savePathGuardInstalled = true;
+  } catch (err) {
+    _savePathGuardInstalled = false;
+    try {
+      console.warn(
+        "[comfyui-mcp] save-path guard failed to install; frontend-initiated saves are NOT stamp-checked",
         err,
       );
     } catch {}
@@ -34836,6 +34932,13 @@ function registerExtensionWhenReady(tries = 0) {
     // never persist a raw value here. See panelSettingsList() above.
     settings: panelSettingsList(),
     async setup() {
+      // #1667 P0 — wrap the workflow store's saveWorkflow with the stale-canvas
+      // persist guard FIRST, before any of the below can trigger a graph change that
+      // the frontend autosave would persist unchecked. setup() runs post-app-init, so
+      // the pinia workflow store (app.extensionManager.workflow) exists here; if it
+      // does not, the installer says so loudly and saves proceed unguarded — disclosed,
+      // never silent.
+      installSavePathGuard(app);
       // FIRST: resolve the language and pull the catalog, before anything paints. Every
       // failure path inside resolves to an English panel rather than throwing, so this
       // cannot block startup — but it must be AWAITED, because a catalog that arrives

--- a/web/js/lib/save-path-guard.js
+++ b/web/js/lib/save-path-guard.js
@@ -1,0 +1,108 @@
+// #1667 P0 — DATA LOSS: a stale-canvas tab persisted the WRONG graph over a live file.
+//
+// The reported loss: a tab whose canvas held workflow A's graph (mounted there by the
+// crossed-identity failure tracked as #1639) was persisted by the FRONTEND's own save
+// path — autosave / Ctrl+S / the reconnect-restore flow — over an unrelated workflow's
+// .json on disk. No panel command was involved, so the panel's own save fence (#708
+// wrong-canvas guard, which gates panel_save_workflow) never saw the write. The file's
+// original 31-node graph was destroyed.
+//
+// The evidence the file itself kept: the recovered graph's `extra.comfyui_mcp` block
+// carried a `workflow_path` naming a THIRD workflow — the stamp and the destination
+// disagreed, and nothing checked that before writing.
+//
+// So the save funnel is now guarded: before a workflow is persisted IN PLACE over an
+// existing file, the identity stamp embedded in the very state about to be serialized
+// (`changeTracker.activeState.extra.comfyui_mcp.workflow_path`) is compared against the
+// destination path. A stamp that positively names a DIFFERENT, still-existing workflow
+// is proof the content is foreign to the file it is about to overwrite, and the write
+// is REFUSED — fail closed, nothing on disk is touched.
+//
+// WHAT THIS DOES NOT DECIDE (deliberately — a guard that refuses on a guess is a
+// wrong-graph refusal of its own):
+//
+//   * No stamp, or no path field in it → allowed. The stamp is written by the panel's
+//     own load/open wrappers; a canvas that never carried one proves nothing in either
+//     direction, and blocking every unstamped save would break ordinary ComfyUI use
+//     for exactly the users the fork failed to install for.
+//   * Stamped path equals the destination → allowed (that is the common, healthy case).
+//   * Stamped path differs but no longer names a live workflow record → allowed. That
+//     is what RENAME residue looks like: the file moved, the in-memory stamp still
+//     names the old path, and the canvas genuinely belongs to the destination.
+//   * The destination is a never-persisted (temporary) record → allowed. No existing
+//     file is overwritten, so there is nothing to destroy; this is also what keeps a
+//     legitimate Save-As copy — which inherits the source's stamp — saveable.
+//
+// The one deliberate false positive: a file the USER duplicated on disk and opened
+// under the copy's name carries the source's stamp, so its first in-place save is
+// refused. That refusal is recoverable (the message names the re-bind that heals it);
+// the overwrite it exists to prevent is not.
+//
+// Dependency-light: path normalization is imported; the store reads stay in the caller.
+// Unit-testable with plain fixtures.
+
+import { normalizedWorkflowPath } from "./workflow-chat-identity.js";
+
+export const SAVE_PATH_GUARD_REASON = Object.freeze({
+  STAMPED_PATH_FOREIGN: "stamped_path_foreign",
+});
+
+/**
+ * Decide whether an in-place workflow save may proceed.
+ *
+ * @param {object} input
+ * @param {string|null|undefined} input.destinationPath path the save will write to
+ *   (the workflow record's own `path`).
+ * @param {boolean} [input.destinationPersisted] true when the destination is an
+ *   existing, non-temporary record — i.e. the write OVERWRITES an on-disk file.
+ *   Absent/false → nothing to destroy → allow.
+ * @param {string|null|undefined} input.stampedPath the `workflow_path` stamped in the
+ *   state about to be serialized, or null when absent/unreadable.
+ * @param {boolean} [input.stampedPathOwnedByOther] true when the workflow store still
+ *   has a record at `stampedPath` that is NOT the workflow being saved.
+ * @returns {{allow: true} | {allow: false, reason: string, destinationPath: string, stampedPath: string}}
+ */
+export function decideWorkflowSaveVerdict({
+  destinationPath,
+  destinationPersisted = false,
+  stampedPath = null,
+  stampedPathOwnedByOther = false,
+} = {}) {
+  if (!destinationPersisted) return { allow: true };
+  const dest = normalizedWorkflowPath(destinationPath);
+  const stamped = normalizedWorkflowPath(stampedPath);
+  if (!dest || !stamped || dest === stamped) return { allow: true };
+  if (!stampedPathOwnedByOther) return { allow: true };
+  return {
+    allow: false,
+    reason: SAVE_PATH_GUARD_REASON.STAMPED_PATH_FOREIGN,
+    destinationPath,
+    stampedPath,
+  };
+}
+
+/**
+ * The refusal a blocked save throws. States what was compared, what was NOT written,
+ * both readings of the evidence (stale canvas vs deliberate copy), and the recovery.
+ * Deliberately does not claim which reading is true — the panel cannot tell them apart;
+ * it can only refuse to guess with the user's file.
+ */
+export function workflowSaveRefusalError(verdict) {
+  const dest = typeof verdict?.destinationPath === "string" && verdict.destinationPath
+    ? verdict.destinationPath
+    : "this workflow's file";
+  const stamped = typeof verdict?.stampedPath === "string" && verdict.stampedPath
+    ? verdict.stampedPath
+    : "a different workflow";
+  return new Error(
+    `REFUSED to save: the canvas about to overwrite "${dest}" is stamped as belonging to ` +
+      `"${stamped}" (extra.comfyui_mcp.workflow_path), which is a different workflow that ` +
+      `still exists. Writing it would replace that file's content with a graph that does not ` +
+      `belong to it — this is the #1667 stale-canvas data-loss guard, and NOTHING was written. ` +
+      `Either this tab's canvas is stale (mounted from another workflow — reload the file from ` +
+      `disk before losing it), or you deliberately built this content under a copied identity. ` +
+      `If the canvas really is what you want in "${dest}", re-bind the tab first — open the ` +
+      `workflow via panel_open_workflow so its identity is re-verified against the file — then ` +
+      `save again.`,
+  );
+}


### PR DESCRIPTION
Closes artokun/comfyui-mcp#1667 (escalation of artokun/comfyui-mcp#1639).

The issue lives in the `comfyui-mcp` tracker, but the root cause is in **this** repo: the persist that destroyed the file came from the ComfyUI **frontend's own save funnel**, which only the panel extension can intercept.

## Root cause

ComfyUI persists a tab's canvas through `workflowStore.saveWorkflow` → `ComfyWorkflow.save()`, which serializes `changeTracker.activeState` verbatim to the tab's path. Every frontend-initiated save funnels there: the autosave watcher (`useWorkflowAutoSave`, on any `graphChanged` when the tab is `modified` + persisted), Ctrl+S, and the reconnect/session-restore flows. **Nothing on that path checks that the canvas content belongs to the destination path.** When a stale canvas — another workflow's graph mounted under the wrong tab via the #1639 crossed identity — sat on a persisted, `modified:true` tab, the next frontend persist wrote the foreign graph over the live file. In the reported incident a user's 31-node `CUMSLUT2 - Office Slap.json` was overwritten with a different workflow's 15-node graph, with no panel command involved — so the panel's own save fence (the #708 wrong-canvas guard on `panel_save_workflow`) never saw the write. The recovered file's own `extra.comfyui_mcp` stamp proved the crossing: its `workflow_path` named a *third* workflow.

## Fix — fail closed on positive contradiction

`web/js/lib/save-path-guard.js` (new, pure/testable) + wiring in `web/js/comfyui-mcp-panel.js`:

- At extension `setup()`, the panel wraps the workflow **store's** `saveWorkflow` — the single funnel for autosave, keymap saves, and service saves, and the same path the panel's own (already #708-fenced) `panel_save_workflow` uses.
- Before the write, the guard reads the **exact state about to be serialized** (`changeTracker.activeState.extra.comfyui_mcp.workflow_path`) and refuses only the evidenced shape: the stamp positively names a **different, still-existing** workflow while the destination is an **existing on-disk file**. The refusal throws before `saveWorkflow` runs — nothing touches disk — and the message names both paths, states that nothing was written, gives both readings (stale canvas vs deliberate copy; the panel cannot tell them apart and does not pretend to), and names the re-bind recovery (`panel_open_workflow` re-verifies identity against the file, after which a conscious save passes).
- Everything not **provably** foreign still saves, because a guard that refuses on a guess is a wrong-graph refusal of its own:
  - no stamp / no path field → allow (the stamping fork not having run proves nothing; blocking all unstamped saves would break ordinary ComfyUI use);
  - stamp == destination → allow (the healthy common case);
  - stamp differs but names no live record → allow (that is **rename residue** — the file moved, the stamp is stale, the canvas is genuinely the destination's);
  - destination never persisted → allow (no file is overwritten; this keeps a legitimate **Save-As copy**, which inherits the source's stamp, saveable).
- Guard-read failures degrade to allow, never an invented refusal. If the store is unavailable at setup, the guard's absence is disclosed loudly (`console.warn`), matching the creation-boundary fork's fail-disclosed pattern.

**Known, deliberate false positive:** a file the user duplicated on disk and opened under the copy's name carries the source's stamp, so its first in-place save is refused once, with the recovery in the message. Recoverable; the overwrite this prevents was not.

## Verification

- `npm ci` — clean.
- `npm run test:unit` — **4908 pass / 0 fail** (includes 13 new tests in `browser_tests/unit/save-path-guard.test.mjs`; also runs i18n + tool-vocabulary + panel-scope checks).
- `npm run typecheck` — clean.
- New tests pin both halves: the pure verdict (the reported crossing refuses; healthy/no-stamp/rename-residue/unsaved-destination all allow; case+separator normalization doesn't false-refuse; the message is honest about not knowing which reading is true) and the **real installer extracted from the panel bundle** driven over a fake store — a crossed save rejects and the original save is never called; a missing store warns instead of failing silently.

## Scope boundaries / follow-ups (from the issue's list)

- The issue's item 1 (write-block tabs whose post-load content verification failed) needs a per-tab verification-failure record that doesn't exist yet; this PR closes the write hole directly. The read-side hardening is tracked in artokun/comfyui-mcp#1639.
- Item 3 (`.bak` before overwrite) is a ComfyUI-server-side mechanism; the panel cannot make the server write one. Refusing the wrong overwrite is the fail-closed substitute here.
- Direct `ComfyWorkflow.save()` callers that bypass `workflowStore.saveWorkflow` (builder/layer-editor flows) are not wrapped; the mainstream vectors (autosave, Ctrl+S, restore) all go through the store.
- The PNG-embedded-workflow recovery snippet from the issue is worth adding to the docs; not done here.