### PR TITLE
fix(1275): panel_refresh_nodes can no longer report success over a pruned live canvas

### DIFF
--- a/browser_tests/unit/asset-staleness.test.mjs
+++ b/browser_tests/unit/asset-staleness.test.mjs
@@ -1321,8 +1321,8 @@ test("#1172 WIRING: the disclosure survives the `refreshed: true` branch (#981's
   assert.match(code, /verdict\.empty_combo_lists = empties;/, "the verdict must carry the field");
   assert.match(
     code,
-    /if \(refreshed\) return \{ ok: true, refreshed: true, \.\.\.stale, \.\.\.emptyCombos \};/,
-    "…and the refreshed:true branch must forward it",
+    /if \(refreshed\) return \{ ok: true, refreshed: true, \.\.\.stale, \.\.\.emptyCombos, \.\.\.restored \};/,
+    "…and the refreshed:true branch must forward it (…and #1275's restored disclosure rides the same branch)",
   );
   // The spread alone is not enough: `emptyCombos` could still be built without the list
   // itself, forwarding only the note. Pin BOTH fields of the mapping.

--- a/browser_tests/unit/refresh-graph-guard.test.mjs
+++ b/browser_tests/unit/refresh-graph-guard.test.mjs
@@ -1,0 +1,477 @@
+// #1275 — panel_refresh_nodes deleted newly added unconnected live-canvas nodes.
+//
+// The reporter added seven nodes with panel_add_node, called panel_refresh_nodes
+// to refresh a LoadImage dropdown, and five of the seven silently vanished —
+// LoadImage #13, two CLIPTextEncode, an ImageDecode, a SaveImage — while the
+// tool answered {ok:true, refreshed:true}. The pruning step runs inside
+// frontend/extension code the panel calls (registerNodesFromDefs /
+// refreshComboInNodes hooks), so the panel cannot prevent it by choosing
+// different calls; what it can do is REFUSE to report a refresh over a graph it
+// watched shrink. These tests pin:
+//
+//   1. the pure inventory/diff/label helpers (lib/graph-node-inventory.js);
+//   2. the verdict wording (lib/node-def-refresh.js) — restored disclosure and
+//      the fail-closed graph_nodes_lost verdict;
+//   3. the SHIPPING registerComfyNodeDefs, extracted from the monolith and
+//      driven with doubles whose register phase prunes the graph, so deleting
+//      the guard wiring in the panel fails these tests;
+//   4. the refresh_nodes executor forwarding restored_nodes / lost_nodes into
+//      the tool reply (the #981/#1172 whitelist hole, this time for #1275).
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+import {
+  liveGraphNodeInventory,
+  vanishedLiveNodes,
+  missingInventoryIds,
+  nodeInventoryLabel,
+} from "../../web/js/lib/graph-node-inventory.js";
+import {
+  NODE_DEF_REFRESH_REASONS,
+  describeNodeDefRefresh,
+  describeRefreshGraphLoss,
+  restoredLiveNodesNote,
+} from "../../web/js/lib/node-def-refresh.js";
+import { fetchNodeDefsWithRetry, OBJECT_INFO_RETRY_DELAYS_MS } from "../../web/js/lib/object-info-retry.js";
+import { withTimeout } from "../../web/js/lib/bounded-step.js";
+import {
+  COMBO_NO_ANSWER,
+  COMBO_OK,
+  NODE_DEFS_FETCH_SHARE,
+  NODE_DEFS_FETCH_TIMEOUT_MS,
+  NODE_DEFS_NO_ANSWER,
+  NODE_DEFS_RUN_BUDGET_MS,
+  monotonicNow,
+  nodeDefsBudgetLeft,
+} from "./_panel-constants.mjs";
+
+const NODE_DEFS_RETRY_DELAYS_MS = OBJECT_INFO_RETRY_DELAYS_MS;
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const SRC = readFileSync(join(HERE, "../../web/js/comfyui-mcp-panel.js"), "utf8").replace(/\r\n/g, "\n");
+
+// ---------------------------------------------------------------------------
+// Fake live graph: just enough LiteGraph for collectAllGraphs + the guard.
+// ---------------------------------------------------------------------------
+
+function fakeNode(id, type, title = null) {
+  return { id, type, title: title ?? type };
+}
+
+function fakeGraph(nodeList) {
+  return {
+    _nodes: [...nodeList],
+    serialize() {
+      return { nodes: this._nodes.map((n) => ({ id: n.id, type: n.type, title: n.title })) };
+    },
+  };
+}
+
+// The issue's reproduction shape: seven newly added nodes, mixed
+// connected/unconnected (link realism is irrelevant to the guard — it watches
+// node PRESENCE), ids 13-19 as reported.
+const SEVEN = [
+  fakeNode(13, "LoadImage"),
+  fakeNode(14, "CLIPTextEncode"),
+  fakeNode(15, "CLIPTextEncode"),
+  fakeNode(16, "LanPaint_ImageEncode"),
+  fakeNode(17, "LanPaint_KSampler"),
+  fakeNode(18, "LanPaint_ImageDecode"),
+  fakeNode(19, "SaveImage"),
+];
+// The five the reporter lost.
+const PRUNED_IDS = new Set([13, 14, 15, 18, 19]);
+
+// ---------------------------------------------------------------------------
+// 1. The pure helpers
+// ---------------------------------------------------------------------------
+
+test("#1275: the inventory walks subgraphs and keeps graph identity", () => {
+  const inner = fakeGraph([fakeNode(1, "LoadImage")]);
+  const root = fakeGraph([fakeNode(2, "CheckpointLoaderSimple"), { ...fakeNode(3, "SubgraphNode"), subgraph: inner }]);
+  const inv = liveGraphNodeInventory(root);
+  assert.equal(inv.length, 3);
+  assert.deepEqual(
+    inv.map((e) => e.id).sort(),
+    [1, 2, 3],
+  );
+  const innerEntry = inv.find((e) => e.id === 1);
+  assert.equal(innerEntry.graph, inner, "the entry remembers WHICH graph held the node");
+});
+
+test("#1275: vanishedLiveNodes names exactly the pruned nodes, connected or not", () => {
+  const graph = fakeGraph(SEVEN);
+  const before = liveGraphNodeInventory(graph);
+  graph._nodes = graph._nodes.filter((n) => !PRUNED_IDS.has(n.id));
+  const vanished = vanishedLiveNodes(before, graph);
+  assert.deepEqual(vanished.map((e) => e.id).sort((a, b) => a - b), [13, 14, 15, 18, 19]);
+  assert.equal(vanishedLiveNodes(before, graph).some((e) => e.id === 16), false, "the survivors stay survivors");
+});
+
+test("#1275: a wholesale graph replacement reads as total loss, not as a clean bill", () => {
+  const before = liveGraphNodeInventory(fakeGraph(SEVEN));
+  const replacement = fakeGraph(SEVEN.slice(0, 2));
+  const vanished = vanishedLiveNodes(before, replacement);
+  assert.equal(vanished.length, 7, "a new graph OBJECT means every old reference is gone");
+  // ...and the id-based post-restore check is what sees through it:
+  assert.deepEqual(missingInventoryIds(before, replacement).map((e) => e.id).sort((a, b) => a - b), [15, 16, 17, 18, 19]);
+});
+
+test("#1275: no loss, no missing root, no false report", () => {
+  const graph = fakeGraph(SEVEN);
+  const before = liveGraphNodeInventory(graph);
+  assert.deepEqual(vanishedLiveNodes(before, graph), []);
+  assert.deepEqual(vanishedLiveNodes(before, null), [], "an unreadable root claims nothing");
+  assert.deepEqual(missingInventoryIds(before, graph), []);
+  assert.deepEqual(vanishedLiveNodes([], graph), []);
+});
+
+test("#1275: labels read like the issue's report", () => {
+  assert.equal(nodeInventoryLabel({ id: 13, type: "LoadImage", title: "LoadImage" }), "LoadImage #13");
+  assert.equal(nodeInventoryLabel({ id: 4, type: "LoadImage", title: "portrait source" }), '"portrait source" (LoadImage #4)');
+  assert.equal(nodeInventoryLabel({ id: 9, type: null, title: null }), "#9");
+});
+
+// ---------------------------------------------------------------------------
+// 2. The verdict wording
+// ---------------------------------------------------------------------------
+
+test("#1275: the fail-closed verdict is not refreshed, names the lost nodes, and says what was tried", () => {
+  const lost = SEVEN.filter((n) => PRUNED_IDS.has(n.id)).map((n) => ({ graph: null, id: n.id, type: n.type, title: n.title }));
+  const v = describeRefreshGraphLoss(lost, { restoreAvailable: false });
+  assert.equal(v.refreshed, false);
+  assert.equal(v.reason, NODE_DEF_REFRESH_REASONS.GRAPH_NODES_LOST);
+  assert.equal(v.lost_nodes.length, 5);
+  assert.match(v.lost_nodes[0], /LoadImage #13/);
+  assert.match(v.remedy, /REMOVED 5 nodes/);
+  assert.match(v.remedy, /LoadImage #13/);
+  assert.match(v.remedy, /no loadGraphData/, "the remedy says why no restore ran");
+  assert.match(v.remedy, /re-add them, or reload your last saved workflow/);
+  assert.match(v.remedy, /Do NOT call panel_refresh_nodes again/);
+  assert.equal(v.detail, undefined, "no restore ran, so no restore detail");
+});
+
+test("#1275: a failed restore is disclosed with its error, not folded into 'still missing'", () => {
+  const lost = [{ graph: null, id: 13, type: "LoadImage", title: "LoadImage" }];
+  const v = describeRefreshGraphLoss(lost, { restoreAvailable: true, restoreThrew: new Error("boom") });
+  assert.match(v.remedy, /the restore itself failed/);
+  assert.match(v.detail, /boom/);
+  const incomplete = describeRefreshGraphLoss(lost, { restoreAvailable: true });
+  assert.match(incomplete.remedy, /still missing/);
+});
+
+test("#1275: the restore disclosure keeps refreshed honest about what was re-verified", () => {
+  const entries = SEVEN.filter((n) => PRUNED_IDS.has(n.id)).map((n) => ({ graph: null, id: n.id, type: n.type, title: n.title }));
+  const note = restoredLiveNodesNote(entries);
+  assert.match(note, /REMOVED 5 nodes/);
+  assert.match(note, /LoadImage #13/);
+  assert.match(note, /re-verified every one is present/);
+  assert.match(note, /only their presence was re-verified/, "presence is the claim, not full fidelity");
+  assert.equal(restoredLiveNodesNote([]), "");
+});
+
+// ---------------------------------------------------------------------------
+// 3. The SHIPPING registerComfyNodeDefs, extracted and driven with doubles.
+//    Same extraction pattern as node-def-refresh.test.mjs, extended with the
+//    #1275 guard collaborators (that harness predates the guard and stays
+//    untouched; this one is where the guard is exercised).
+// ---------------------------------------------------------------------------
+
+/** Balanced-brace extraction of a top-level function by its declaration marker. */
+function extractFunction(marker) {
+  const start = SRC.indexOf(marker);
+  assert.notEqual(start, -1, `${marker} not found`);
+  const open = SRC.indexOf("{", start);
+  let depth = 0;
+  for (let i = open; i < SRC.length; i += 1) {
+    const ch = SRC[i];
+    if (ch === "/" && SRC[i + 1] === "/") {
+      i = SRC.indexOf("\n", i + 2);
+      if (i < 0) break;
+      continue;
+    }
+    if (ch === "/" && SRC[i + 1] === "*") {
+      i = SRC.indexOf("*/", i + 2);
+      if (i < 0) break;
+      i += 1;
+      continue;
+    }
+    if (ch === '"' || ch === "'" || ch === "`") {
+      const quote = ch;
+      for (i += 1; i < SRC.length; i += 1) {
+        if (SRC[i] === "\\") {
+          i += 1;
+          continue;
+        }
+        if (SRC[i] === quote) break;
+      }
+      continue;
+    }
+    if (ch === "{") depth += 1;
+    if (ch === "}" && --depth === 0) return SRC.slice(start, i + 1);
+  }
+  throw new Error(`unterminated function: ${marker}`);
+}
+
+function buildRegisterComfyNodeDefs({ appValue, apiValue }) {
+  const body = extractFunction("async function registerComfyNodeDefs(");
+  const factory = new Function(
+    "app",
+    "api",
+    "recordObjectInfoTypes",
+    "reapplyDefsToLiveNodes",
+    "describeNodeDefRefresh",
+    "fetchNodeDefsWithRetry",
+    "withTimeout",
+    "NODE_DEFS_NO_ANSWER",
+    "COMBO_OK",
+    "COMBO_NO_ANSWER",
+    "NODE_DEFS_FETCH_TIMEOUT_MS",
+    "NODE_DEFS_RUN_BUDGET_MS",
+    "NODE_DEFS_FETCH_SHARE",
+    "nodeDefsBudgetLeft",
+    "monotonicNow",
+    "NODE_DEFS_RETRY_DELAYS_MS",
+    "objectInfoCache",
+    "objectInfoSnapshot",
+    "backendReconnectEpoch",
+    // #1275 — the guard's collaborators, REAL lib functions, so this harness proves
+    // the shipped wiring and not a re-implementation of it.
+    "liveGraphNodeInventory",
+    "vanishedLiveNodes",
+    "missingInventoryIds",
+    "nodeInventoryLabel",
+    "describeRefreshGraphLoss",
+    "restoredLiveNodesNote",
+    `const boundedGetNodeDefs = async (ms = NODE_DEFS_FETCH_TIMEOUT_MS) => {
+       if (typeof api?.getNodeDefs !== "function") return null;
+       const settled = await withTimeout(
+         Promise.resolve().then(() => api.getNodeDefs()).then((value) => ({ value }), (err) => ({ err })),
+         ms,
+         () => NODE_DEFS_NO_ANSWER,
+       );
+       if (settled === NODE_DEFS_NO_ANSWER) return NODE_DEFS_NO_ANSWER;
+       if ("err" in settled) throw settled.err;
+       return settled.value;
+     };
+     let nodeDefsRefreshConfirmed = false;
+     ${body}
+     return { registerComfyNodeDefs };`,
+  );
+  return factory(
+    appValue,
+    apiValue,
+    () => ({}),
+    () => {},
+    describeNodeDefRefresh,
+    (getDefs, opts) => fetchNodeDefsWithRetry(getDefs, { ...opts, sleep: async () => {} }),
+    withTimeout,
+    NODE_DEFS_NO_ANSWER,
+    COMBO_OK,
+    COMBO_NO_ANSWER,
+    NODE_DEFS_FETCH_TIMEOUT_MS,
+    NODE_DEFS_RUN_BUDGET_MS,
+    NODE_DEFS_FETCH_SHARE,
+    nodeDefsBudgetLeft,
+    monotonicNow,
+    NODE_DEFS_RETRY_DELAYS_MS,
+    { invalidate: () => {}, read: async (f) => f() },
+    { clear: () => {}, record: () => true },
+    7,
+    liveGraphNodeInventory,
+    vanishedLiveNodes,
+    missingInventoryIds,
+    nodeInventoryLabel,
+    describeRefreshGraphLoss,
+    restoredLiveNodesNote,
+  );
+}
+
+const DEFS = { LoadImage: { input: { required: {} } } };
+const apiStub = { getNodeDefs: async () => DEFS };
+
+/** An app double whose register phase prunes the five nodes the reporter lost. */
+function pruningApp({ withLoader = true, restoreOmit = new Set() } = {}) {
+  const graph = fakeGraph(SEVEN);
+  const calls = { loadGraphData: [] };
+  const app = {
+    graph,
+    registerNodesFromDefs: async () => {
+      graph._nodes = graph._nodes.filter((n) => !PRUNED_IDS.has(n.id));
+    },
+    refreshComboInNodes: async () => {},
+  };
+  if (withLoader) {
+    app.loadGraphData = async (snapshot) => {
+      calls.loadGraphData.push(snapshot);
+      graph._nodes = snapshot.nodes
+        .filter((d) => !restoreOmit.has(d.id))
+        .map((d) => fakeNode(d.id, d.type, d.title));
+    };
+  }
+  return { app, graph, calls };
+}
+
+test("#1275: a refresh that prunes newly added unconnected nodes restores them and SAYS so", async () => {
+  const { app, calls } = pruningApp();
+  const { registerComfyNodeDefs } = buildRegisterComfyNodeDefs({ appValue: app, apiValue: apiStub });
+  const verdict = await registerComfyNodeDefs(undefined);
+  assert.equal(verdict.refreshed, true, "the refresh itself worked and the canvas is back");
+  assert.equal(calls.loadGraphData.length, 1, "the pre-refresh snapshot was replayed exactly once");
+  assert.equal(
+    calls.loadGraphData[0].nodes.length,
+    7,
+    "the snapshot was taken BEFORE the register phase ran — all seven nodes ride along",
+  );
+  assert.equal(app.graph._nodes.length, 7, "every pruned node is back on the live graph");
+  assert.deepEqual(verdict.restored_nodes.sort(), [
+    "CLIPTextEncode #14",
+    "CLIPTextEncode #15",
+    "LanPaint_ImageDecode #18",
+    "LoadImage #13",
+    "SaveImage #19",
+  ]);
+  assert.match(verdict.restored_nodes_note, /REMOVED 5 nodes/);
+  assert.equal(verdict.lost_nodes, undefined, "a restored loss is not reported as a loss");
+});
+
+test("#1275: no loadGraphData on this frontend → fail CLOSED, the lost nodes named", async () => {
+  const { app, graph } = pruningApp({ withLoader: false });
+  const { registerComfyNodeDefs } = buildRegisterComfyNodeDefs({ appValue: app, apiValue: apiStub });
+  const verdict = await registerComfyNodeDefs(undefined);
+  assert.equal(verdict.refreshed, false, "refreshed over a shrunk canvas is the bug being fixed");
+  assert.equal(verdict.reason, "graph_nodes_lost");
+  assert.equal(verdict.lost_nodes.length, 5);
+  assert.match(verdict.remedy, /LoadImage #13/);
+  assert.match(verdict.remedy, /no loadGraphData/);
+  assert.equal(graph._nodes.length, 2, "nothing was invented back onto the canvas");
+});
+
+test("#1275: a restore that leaves nodes missing fails closed with what is still gone", async () => {
+  const { app, calls } = pruningApp({ restoreOmit: new Set([13, 19]) });
+  const { registerComfyNodeDefs } = buildRegisterComfyNodeDefs({ appValue: app, apiValue: apiStub });
+  const verdict = await registerComfyNodeDefs(undefined);
+  assert.equal(verdict.refreshed, false);
+  assert.equal(verdict.reason, "graph_nodes_lost");
+  assert.deepEqual(verdict.lost_nodes, ["LoadImage #13", "SaveImage #19"], "only the unrecovered nodes are named lost");
+  assert.match(verdict.remedy, /still missing/);
+  assert.equal(calls.loadGraphData.length, 1);
+});
+
+test("#1275: an additive refresh reports nothing about the guard", async () => {
+  const graph = fakeGraph(SEVEN);
+  const app = {
+    graph,
+    registerNodesFromDefs: async () => {},
+    refreshComboInNodes: async () => {},
+    loadGraphData: async () => {
+      throw new Error("must not be called — nothing vanished");
+    },
+  };
+  const { registerComfyNodeDefs } = buildRegisterComfyNodeDefs({ appValue: app, apiValue: apiStub });
+  const verdict = await registerComfyNodeDefs(undefined);
+  assert.deepEqual(verdict, { refreshed: true, reason: "refreshed" });
+});
+
+test("#1275: the graph loss overrides a phase failure already on the verdict", async () => {
+  const { app } = pruningApp({ withLoader: false });
+  app.refreshComboInNodes = async () => {
+    throw new Error("combo exploded");
+  };
+  const { registerComfyNodeDefs } = buildRegisterComfyNodeDefs({ appValue: app, apiValue: apiStub });
+  const verdict = await registerComfyNodeDefs(undefined);
+  assert.equal(verdict.refreshed, false);
+  assert.equal(
+    verdict.reason,
+    "graph_nodes_lost",
+    "the lost nodes are the fact the caller must act on first, ahead of a combo failure",
+  );
+  assert.equal(verdict.lost_nodes.length, 5);
+});
+
+// ---------------------------------------------------------------------------
+// 4. The shipping refresh_nodes executor forwards the guard's fields.
+// ---------------------------------------------------------------------------
+
+function buildRefreshNodes(refreshImpl) {
+  const start = SRC.indexOf("async refresh_nodes()");
+  assert.notEqual(start, -1, "refresh_nodes executor not found in the panel source");
+  const open = SRC.indexOf("{", start);
+  let depth = 0;
+  let end = -1;
+  for (let i = open; i < SRC.length; i += 1) {
+    const ch = SRC[i];
+    if (ch === "/" && SRC[i + 1] === "/") {
+      i = SRC.indexOf("\n", i + 2);
+      if (i < 0) break;
+      continue;
+    }
+    if (ch === "/" && SRC[i + 1] === "*") {
+      i = SRC.indexOf("*/", i + 2);
+      if (i < 0) break;
+      i += 1;
+      continue;
+    }
+    if (ch === '"' || ch === "'" || ch === "`") {
+      const quote = ch;
+      for (i += 1; i < SRC.length; i += 1) {
+        if (SRC[i] === "\\") {
+          i += 1;
+          continue;
+        }
+        if (SRC[i] === quote) break;
+      }
+      continue;
+    }
+    if (ch === "{") depth += 1;
+    if (ch === "}" && --depth === 0) {
+      end = i;
+      break;
+    }
+  }
+  assert.notEqual(end, -1, "could not bound the refresh_nodes executor body");
+  const body = SRC.slice(start, end + 1);
+  const factory = new Function(
+    "refreshComfyNodeDefs",
+    `return (${body.replace(/^async refresh_nodes\(\)/, "async function refresh_nodes()")});`,
+  );
+  return factory(refreshImpl);
+}
+
+test("#1275: restored_nodes survive the executor's success-branch whitelist", async () => {
+  const refresh_nodes = buildRefreshNodes(async () => ({
+    refreshed: true,
+    reason: "refreshed",
+    restored_nodes: ["LoadImage #13"],
+    restored_nodes_note: "The refresh REMOVED 1 node ...",
+  }));
+  const reply = await refresh_nodes();
+  assert.equal(reply.ok, true);
+  assert.equal(reply.refreshed, true);
+  assert.deepEqual(reply.restored_nodes, ["LoadImage #13"]);
+  assert.match(reply.restored_nodes_note, /REMOVED 1 node/);
+});
+
+test("#1275: a fail-closed graph-loss verdict reaches the reply with lost_nodes intact", async () => {
+  const refresh_nodes = buildRefreshNodes(async () => ({
+    refreshed: false,
+    reason: "graph_nodes_lost",
+    lost_nodes: ["LoadImage #13", "SaveImage #19"],
+    remedy: "The refresh REMOVED 2 nodes ...",
+  }));
+  const reply = await refresh_nodes();
+  assert.equal(reply.refreshed, false);
+  assert.equal(reply.reason, "graph_nodes_lost");
+  assert.deepEqual(reply.lost_nodes, ["LoadImage #13", "SaveImage #19"]);
+  assert.match(reply.remedy, /REMOVED 2 nodes/);
+});
+
+test("#1275: a clean verdict still reads clean — no guard fields invented", async () => {
+  const refresh_nodes = buildRefreshNodes(async () => ({ refreshed: true, reason: "refreshed" }));
+  const reply = await refresh_nodes();
+  assert.deepEqual(reply, { ok: true, refreshed: true });
+});

--- a/browser_tests/unit/stale-placeholders.test.mjs
+++ b/browser_tests/unit/stale-placeholders.test.mjs
@@ -259,16 +259,21 @@ test("#981 (codex r2) source guard: the disclosure survives the SUCCESS path of 
   // success path the warning existed and no caller could ever see it. Found by tracing
   // the consumers of the verdict, not by reading the producer.
   const src = readFileSync(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8");
-  // #1172 added a SECOND disclosure that rides the same branch. The hole is the branch's
-  // fixed object literal, so the guard now names every field that must survive it — adding a
-  // third disclosure without extending this line is the same bug again.
+  // #1172 added a SECOND disclosure that rides the same branch, and #1275 a THIRD (the
+  // restored-after-loss disclosure). The hole is the branch's fixed object literal, so the
+  // guard now names every field that must survive it — adding a fourth disclosure without
+  // extending this line is the same bug again.
   assert.match(
     src,
-    /if \(refreshed\) return \{ ok: true, refreshed: true, \.\.\.stale, \.\.\.emptyCombos \};/,
+    /if \(refreshed\) return \{ ok: true, refreshed: true, \.\.\.stale, \.\.\.emptyCombos, \.\.\.restored \};/,
     "forwarded on success",
   );
   assert.match(src, /stale_placeholders_note: verdict\.stale_placeholders_note/, "and the note with it");
   assert.match(src, /empty_combo_lists_note: verdict\.empty_combo_lists_note/, "…and #1172's note too");
+  assert.match(src, /restored_nodes_note: verdict\.restored_nodes_note/, "…and #1275's restore note too");
+  // #1275 — the FAIL side of the same guard: an unrestored loss names its nodes, and a
+  // whitelist that dropped lost_nodes would re-silence exactly what the guard exists to say.
+  assert.match(src, /verdict\?\.lost_nodes\?\.length \? \{ lost_nodes: verdict\.lost_nodes \}/, "lost_nodes forwarded on failure");
   // `ok` must stay true: the refresh did what it claims, and the reload flag is about
   // the canvas, not about the refresh having failed.
   assert.ok(!/ok: false/.test(src.slice(src.indexOf("async refresh_nodes()"), src.indexOf("graph_serialize()"))),

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -206,7 +206,17 @@ import { installSidebarRenderWatchdog } from "./lib/sidebar-render-watchdog.js";
 import { displayLabel, boundaryInputLabel, widgetLabelMap } from "./lib/slot-labels.js";
 import { createObjectInfoHistory, awaitHistoryBaseline } from "./lib/object-info-history.js";
 import { makeRefreshCoalescer } from "./lib/refresh-coalesce.js";
-import { describeNodeDefRefresh } from "./lib/node-def-refresh.js";
+import {
+  describeNodeDefRefresh,
+  describeRefreshGraphLoss,
+  restoredLiveNodesNote,
+} from "./lib/node-def-refresh.js";
+import {
+  liveGraphNodeInventory,
+  vanishedLiveNodes,
+  missingInventoryIds,
+  nodeInventoryLabel,
+} from "./lib/graph-node-inventory.js";
 // #1184 — the ORDER a backend switch commits in. A module because the defect is an
 // ordering property, and order cannot be asserted against the 1.7MB panel IIFE.
 import { BACKEND_SWITCH, runBackendSwitch } from "./lib/backend-switch.js";
@@ -1128,6 +1138,11 @@ async function registerComfyNodeDefs(preloadedDefs) {
   // clean one — misattributing the verdict and, worse, setting the shared
   // confirmed flag after a throw (codex gate r5).
   let didThrow = false;
+  // #1275 — the live-graph guard. Filled with {app, before, snapshot} immediately
+  // before the register phase runs, checked after the verdict is built below.
+  // Declared here because `a` is block-scoped to the try: the guard needs the
+  // app reference to survive into the post-verdict check.
+  let graphGuard = null;
   try {
     const a = typeof app !== "undefined" && app ? app : window.comfyAPI?.app?.app;
     if (!a) return describeNodeDefRefresh({ appAvailable: false, defsObtained: false, defsRegistered: false, comboApiPresent: false, comboRan: false });
@@ -1288,6 +1303,29 @@ async function registerComfyNodeDefs(preloadedDefs) {
         whole: true,
       });
     }
+    // #1275 — snapshot the live graph BEFORE the first mutating phase. Everything
+    // from here to the combo phase calls into frontend and extension code
+    // (registerNodesFromDefs awaits the addCustomNodeDefs/beforeRegisterNodeDef
+    // hooks; refreshComboInNodes runs reloadNodeDefs and the refreshComboInNodes
+    // hook), and on the reporter's install that path silently DELETED newly added
+    // unconnected live-canvas nodes while the verdict said refreshed:true. The
+    // serialize is full-fidelity — nodes, links, ids, positions, modes, widgets,
+    // subgraphs — so the post-verdict guard can put back exactly what was there.
+    // In-memory and cheap against a run that already fetches a 4MB /object_info.
+    // Failures leave graphGuard null and the guard inert: a guard that throws
+    // must never break the refresh it only watches.
+    try {
+      const guardRoot = a.graph ?? a.canvas?.graph;
+      if (guardRoot && typeof guardRoot.serialize === "function") {
+        graphGuard = {
+          app: a,
+          before: liveGraphNodeInventory(guardRoot),
+          snapshot: guardRoot.serialize(),
+        };
+      }
+    } catch {
+      /* the guard is a witness, not a phase — it must never fail the refresh */
+    }
     // Re-register node definitions so newly installed/updated classes and their
     // current widget schemas are known to LiteGraph (#221/#171). defsRegistered
     // is set ONLY when the registration call actually ran — a frontend without
@@ -1419,6 +1457,79 @@ async function registerComfyNodeDefs(preloadedDefs) {
   // `force:true` refresh resolves to the freshness verdict of the fetch IT triggered
   // (codex round-6 P0).
   const verdict = describeNodeDefRefresh({ appAvailable, defsObtained: !!defs, defsRegistered, comboApiPresent, comboRan, phase, didThrow, thrown });
+  // #1275 — VERIFY the refresh was ADDITIVE over the live graph.
+  //
+  // The snapshot above was taken immediately before the register phase, so this
+  // diff measures exactly what the mutating phases did. On the reporter's install
+  // (ComfyUI 0.27.0 / frontend 1.45.20) those phases silently removed five of
+  // seven newly added, still-unconnected nodes and this function returned
+  // refreshed:true over the loss. Which hook pruned them is not established and
+  // runs inside frontend/extension code the panel does not control — so the
+  // panel's obligation is the one it can actually keep: never report a refresh
+  // over a graph it watched shrink.
+  //
+  // The restore goes through the frontend's OWN loader with the full serialized
+  // pre-refresh workflow — the same mechanism restoreSnapshot uses — never a
+  // hand-rolled partial re-add of just the missing nodes, which would have to
+  // re-invent link/id bookkeeping loadGraphData already gets right. A restore
+  // that leaves anything missing, or a frontend without loadGraphData, fails
+  // CLOSED: refreshed:false, the lost nodes named, no success claimed.
+  //
+  // One accepted false positive, stated rather than hidden: a node the USER
+  // deletes by hand inside the refresh window is indistinguishable from one the
+  // refresh pruned, and would be resurrected by the restore. The window is the
+  // register/combo await span, the failure mode is visible and reversible (the
+  // node is back — delete it again), and the bug this guards against is silent
+  // and is not.
+  if (graphGuard) {
+    try {
+      const guardApp = graphGuard.app;
+      const vanished = vanishedLiveNodes(graphGuard.before, guardApp.graph ?? guardApp.canvas?.graph);
+      if (vanished.length) {
+        let stillMissing = null;
+        let restoreThrew = null;
+        if (typeof guardApp.loadGraphData === "function") {
+          try {
+            await guardApp.loadGraphData(
+              graphGuard.snapshot,
+              true,
+              true,
+              // Reached through typeof: the workflow ref is panel bookkeeping, and a
+              // frontend state where it is unavailable must not block the restore.
+              typeof activeWorkflowRef === "function" ? activeWorkflowRef() : undefined,
+              { __cmcpNoFork: true },
+            );
+            // The restore REBUILDS the graph objects, so the graph references on
+            // the pre-restore entries are stale by design; the re-check is by node
+            // id across every graph reachable from the new root.
+            stillMissing = missingInventoryIds(graphGuard.before, guardApp.graph ?? guardApp.canvas?.graph);
+          } catch (e) {
+            restoreThrew = e;
+            stillMissing = vanished;
+          }
+        }
+        if (stillMissing && stillMissing.length === 0) {
+          // Restored and re-verified — disclosed, and refreshed stays true: the
+          // refresh did refresh, and the canvas is back to what it was before.
+          verdict.restored_nodes = vanished.map(nodeInventoryLabel);
+          verdict.restored_nodes_note = restoredLiveNodesNote(vanished);
+        } else {
+          // FAIL CLOSED. The node loss overrides even a real phase failure already
+          // on this verdict: the lost nodes are the fact the caller must act on
+          // first, and "refreshed" over a shrunk canvas is the bug being fixed.
+          Object.assign(
+            verdict,
+            describeRefreshGraphLoss(stillMissing ?? vanished, {
+              restoreAvailable: typeof guardApp.loadGraphData === "function",
+              restoreThrew,
+            }),
+          );
+        }
+      }
+    } catch {
+      /* the guard is a witness, not a phase — it must never fail the refresh */
+    }
+  }
   // #981 — a refresh that registered the definitions has NOT necessarily fixed the
   // canvas. MEASURED: after registering a formerly-missing class, an already-placed
   // node of that class keeps no definition, no widgets and no title — it stays a
@@ -9676,12 +9787,25 @@ const GRAPH_TOOL_EXECUTORS = {
           empty_combo_lists_note: verdict.empty_combo_lists_note,
         }
       : {};
-    if (refreshed) return { ok: true, refreshed: true, ...stale, ...emptyCombos };
+    // #1275 — same forwarding hole as #981/#1172, on the success branch this time
+    // for a RESTORE: the refresh pruned live nodes and the panel put them back.
+    // The caller has to know its canvas was rebuilt from a snapshot, or it will
+    // treat the reply as a no-op while node identities changed under it.
+    const restored = verdict != null && typeof verdict === "object" && verdict.restored_nodes?.length
+      ? {
+          restored_nodes: verdict.restored_nodes,
+          restored_nodes_note: verdict.restored_nodes_note,
+        }
+      : {};
+    if (refreshed) return { ok: true, refreshed: true, ...stale, ...emptyCombos, ...restored };
     return {
       ok: true,
       refreshed: false,
       ...stale,
       reason: verdict?.reason ?? "unknown",
+      // #1275 — the fail-closed graph-loss verdict names what is gone; dropping
+      // the list here would re-silence the exact loss the guard exists to say.
+      ...(verdict?.lost_nodes?.length ? { lost_nodes: verdict.lost_nodes } : {}),
       ...(verdict?.detail ? { detail: verdict.detail } : {}),
       remedy:
         verdict?.remedy ??

--- a/web/js/lib/graph-node-inventory.js
+++ b/web/js/lib/graph-node-inventory.js
@@ -1,0 +1,111 @@
+// #1275 — the live-graph INVENTORY a node-def refresh is checked against.
+//
+// panel_refresh_nodes runs registerNodesFromDefs + reapplyDefsToLiveNodes +
+// app.refreshComboInNodes over the LIVE canvas. On the reporter's install
+// (ComfyUI 0.27.0 / frontend 1.45.20) that path silently DELETED five of seven
+// newly added, still-unconnected nodes — LoadImage #13, two CLIPTextEncode, an
+// ImageDecode and a SaveImage — while the tool answered {ok:true,
+// refreshed:true} over the loss. The pruning step runs inside frontend or
+// extension code the panel calls, not in panel code, so the panel cannot avoid
+// it by picking different calls; what it can do is refuse to let a loss pass
+// silently. This module is the pure half of that guard: what the live graph
+// held before the refresh, what is gone after it, and how a node entry reads
+// in a disclosure.
+//
+// Pure: graphs arrive as arguments; nothing here touches the app or the DOM.
+
+import { collectAllGraphs } from "./asset-staleness.js";
+
+/**
+ * One entry per live node reachable from `rootGraph` (subgraphs included), as
+ * `{ graph, id, type, title }`. The GRAPH REFERENCE is kept on purpose:
+ * `vanishedLiveNodes` keys on it, so a refresh that replaced a graph object
+ * wholesale reads as every node on that graph having vanished — which is
+ * exactly the loss shape this guard exists for. Best-effort: an unreadable
+ * graph yields the entries collected so far, never a throw.
+ */
+export function liveGraphNodeInventory(rootGraph) {
+  const out = [];
+  try {
+    for (const graph of collectAllGraphs(rootGraph)) {
+      for (const node of graph?._nodes ?? []) {
+        if (node == null || node.id == null) continue;
+        out.push({
+          graph,
+          id: node.id,
+          type: node.type ?? node.comfyClass ?? null,
+          title: typeof node.title === "string" ? node.title : null,
+        });
+      }
+    }
+  } catch {
+    /* inventory is best-effort — a guard that throws guards nothing */
+  }
+  return out;
+}
+
+/**
+ * The `before` entries whose node is NO LONGER on the live graph, matched by
+ * (graph reference, node id): an entry whose graph is no longer reachable from
+ * `currentRoot` at all counts as vanished, because whatever replaced that
+ * graph took the node with it. An empty result means the refresh was additive
+ * — nothing the graph held is gone. Returns [] when there is nothing to check
+ * against (`currentRoot` unreadable): the guard then claims nothing, which is
+ * the pre-fix behavior, never a false loss report.
+ */
+export function vanishedLiveNodes(before, currentRoot) {
+  if (!Array.isArray(before) || !before.length || !currentRoot) return [];
+  const after = new Map();
+  try {
+    for (const graph of collectAllGraphs(currentRoot)) {
+      const ids = new Set();
+      for (const node of graph?._nodes ?? []) {
+        if (node?.id != null) ids.add(node.id);
+      }
+      after.set(graph, ids);
+    }
+  } catch {
+    return [];
+  }
+  return before.filter((entry) => entry != null && !after.get(entry.graph)?.has(entry.id));
+}
+
+/**
+ * Id-set membership check for AFTER a full-graph restore: the restore rebuilds
+ * every graph object, so the graph references on the `before` entries are all
+ * stale and `vanishedLiveNodes` would report everything. Used only to verify
+ * that a restore brought the nodes back, not to detect the loss in the first
+ * place. One accepted imprecision, stated rather than hidden: node ids are
+ * unique per graph, not across graphs, so a subgraph-local id that collides
+ * with a surviving id elsewhere can read as restored when it is not. That is
+ * narrower than skipping the verification entirely.
+ */
+export function missingInventoryIds(before, currentRoot) {
+  if (!Array.isArray(before) || !before.length || !currentRoot) return [];
+  const present = new Set();
+  try {
+    for (const graph of collectAllGraphs(currentRoot)) {
+      for (const node of graph?._nodes ?? []) {
+        if (node?.id != null) present.add(node.id);
+      }
+    }
+  } catch {
+    return [];
+  }
+  return before.filter((entry) => entry != null && entry.id != null && !present.has(entry.id));
+}
+
+/**
+ * How one inventory entry reads in a disclosure: `LoadImage #13`, or
+ * `"my loader" (LoadImage #13)` when the user gave the node a real title.
+ * A null type (frontend-only node with neither) degrades to the title or the
+ * bare id rather than printing "null".
+ */
+export function nodeInventoryLabel(entry) {
+  const type = entry?.type ?? null;
+  const title = entry?.title ?? null;
+  const id = entry?.id;
+  if (title && title !== type) return type ? `"${title}" (${type} #${id})` : `"${title}" (#${id})`;
+  if (type) return `${type} #${id}`;
+  return `#${id}`;
+}

--- a/web/js/lib/node-def-refresh.js
+++ b/web/js/lib/node-def-refresh.js
@@ -14,6 +14,8 @@
 //
 // Pure: every input is observed by the caller and passed in.
 
+import { nodeInventoryLabel } from "./graph-node-inventory.js";
+
 /** Stable reason tokens for a node-def refresh that is NOT confirmed fresh. */
 export const NODE_DEF_REFRESH_REASONS = Object.freeze({
   APP_UNAVAILABLE: "app_unavailable",
@@ -23,6 +25,10 @@ export const NODE_DEF_REFRESH_REASONS = Object.freeze({
   REGISTER_API_ABSENT: "register_api_absent",
   COMBO_API_ABSENT: "combo_api_absent",
   COMBO_REFRESH_FAILED: "combo_refresh_failed",
+  // #1275 — the refresh itself deleted live-canvas nodes and they could not all
+  // be restored. A data-loss verdict: it overrides even a real phase failure,
+  // because the lost nodes are the fact the caller must act on first.
+  GRAPH_NODES_LOST: "graph_nodes_lost",
 });
 
 function detailSuffix(thrown) {
@@ -165,4 +171,78 @@ export function describeNodeDefRefresh({
     };
   }
   return { refreshed: true, reason: "refreshed" };
+}
+
+// ---------------------------------------------------------------------------
+// #1275 — the refresh deleted live-canvas nodes. Wording lives here, beside
+// the verdict it overrides, so the disclosure and the failure verdict cannot
+// drift apart. Both helpers take INVENTORY ENTRIES (lib/graph-node-inventory)
+// and both name the nodes: "some nodes disappeared" is the silent-loss bug
+// wearing a disclosure costume.
+// ---------------------------------------------------------------------------
+
+function labelList(entries, cap = 6) {
+  const labels = entries.map(nodeInventoryLabel);
+  const shown = labels.slice(0, cap).join(", ");
+  return labels.length > cap ? `${shown}, and ${labels.length - cap} more` : shown;
+}
+
+/**
+ * Disclosure for a refresh whose graph loss was fully ROLLED BACK: the panel
+ * restored the pre-refresh snapshot through the frontend's own workflow loader
+ * and re-verified every vanished node is present. `refreshed` stays true —
+ * the refresh did refresh, and the canvas is back — but the restore is said
+ * out loud, because an install that pruned the canvas once will do it again.
+ *
+ * Only node PRESENCE is re-verified. The restore replays the full serialized
+ * pre-refresh workflow, so positions, widgets, modes, links and ids are all
+ * rewritten from it — but claiming they were verified would be claiming a
+ * check that did not run, so the note tells the user to look.
+ */
+export function restoredLiveNodesNote(restoredEntries) {
+  const list = Array.isArray(restoredEntries) ? restoredEntries : [];
+  if (!list.length) return "";
+  return (
+    `The refresh REMOVED ${list.length} node${list.length === 1 ? "" : "s"} from the live canvas ` +
+    `while it ran (${labelList(list)}) — a refresh must be additive, and this one was not. ` +
+    "The panel restored the missing nodes from a snapshot taken immediately before the refresh " +
+    "ran, using the frontend's own workflow loader, and re-verified every one is present on the " +
+    "canvas again. Positions, widgets, links and ids were rewritten from that snapshot, but only " +
+    "their presence was re-verified — look at the canvas and save the workflow before relying on " +
+    "it. This install has demonstrated a refresh that prunes the live graph: prefer reloading the " +
+    "tab over panel_refresh_nodes until the pruning cause is identified."
+  );
+}
+
+/**
+ * FAIL-CLOSED verdict for a refresh whose graph loss could NOT be fully
+ * undone. Refreshed is FALSE whatever the refresh's phases accomplished —
+ * a reply that says "refreshed" over a canvas the user just lost work on is
+ * the bug being fixed. `lost_nodes` names what is gone; the remedy says what
+ * was tried (and its outcome, when a restore ran and failed) rather than
+ * guessing at the cause, which is not established.
+ */
+export function describeRefreshGraphLoss(lostEntries, { restoreAvailable = false, restoreThrew = null } = {}) {
+  const lost = Array.isArray(lostEntries) ? lostEntries : [];
+  const n = lost.length;
+  const restoreOutcome = !restoreAvailable
+    ? "This frontend exposes no loadGraphData, so the panel could not restore them. "
+    : restoreThrew
+      ? `The panel tried to restore them from the pre-refresh snapshot and the restore itself failed. `
+      : "The panel tried to restore them from the pre-refresh snapshot, but they are still missing. ";
+  return {
+    refreshed: false,
+    reason: NODE_DEF_REFRESH_REASONS.GRAPH_NODES_LOST,
+    lost_nodes: lost.map(nodeInventoryLabel),
+    ...(restoreThrew
+      ? { detail: `(restore failed: ${String(restoreThrew?.message ?? restoreThrew)})` }
+      : {}),
+    remedy:
+      `The refresh REMOVED ${n} node${n === 1 ? "" : "s"} from the live canvas: ${labelList(lost)}. ` +
+      restoreOutcome +
+      "The removed nodes were unsaved and are gone from the canvas: re-add them, or reload your " +
+      "last saved workflow to recover everything else the canvas held. Do NOT call " +
+      "panel_refresh_nodes again on this install — it pruned the live graph once and a retry has " +
+      "no reason to behave differently.",
+  };
 }


### PR DESCRIPTION
## Root cause

`panel_refresh_nodes` runs `registerComfyNodeDefs`, whose mutating phases call into frontend and extension code the panel does not control: `app.registerNodesFromDefs(defs)` awaits the `addCustomNodeDefs`/`beforeRegisterNodeDef` hooks, and `app.refreshComboInNodes()` runs `reloadNodeDefs` plus the `refreshComboInNodes` extension hook. On the reporter's install (ComfyUI 0.27.0 / frontend 1.45.20) that path silently **deleted five of seven newly added, still-unconnected live-canvas nodes** (LoadImage #13, two CLIPTextEncode, ImageDecode #18, SaveImage #19) — and the tool answered `{ok:true, refreshed:true}` over the loss, so neither the agent nor the user was told the canvas had shrunk 19 → 14.

Which hook prunes them is not established from the panel side; the panel's obligation — the one it can actually keep — is that a refresh it runs never *reports success* over a graph it watched shrink. The fix is in this repo (not comfyui-mcp, which only forwards `{cmd:"refresh_nodes"}` as a read): the destructive path and the verdict both live in the panel.

## The fix

In `registerComfyNodeDefs` (the single choke point every refresh flows through — `refresh_nodes`, reconnect, download-triggered, add_node payload):

1. **Snapshot** the live graph immediately before the register phase — full `rootGraph.serialize()` (nodes, links, ids, positions, modes, widgets, subgraphs) plus a per-graph node inventory (`web/js/lib/graph-node-inventory.js`).
2. **Verify** after the combo phase: diff the live inventory against the snapshot. A graph object replaced wholesale reads as total loss; an unreadable graph claims nothing (pre-fix behavior, never a false report).
3. **Restore** on loss via the frontend's *own* `loadGraphData(snapshot, true, true, activeWorkflowRef(), { __cmcpNoFork: true })` — the same call `restoreSnapshot` already uses — then **re-verify** by node id across the rebuilt graphs.
4. **Report honestly**:
   - Fully restored → `refreshed: true` (it did refresh, and the canvas is back) **plus** `restored_nodes` + `restored_nodes_note` disclosing the removal and restore, and stating that only node *presence* was re-verified.
   - Restore unavailable / threw / incomplete → **fail closed**: `refreshed: false`, `reason: "graph_nodes_lost"`, the still-missing nodes named in `lost_nodes`, a remedy saying what was tried and telling the user to re-add or reload their last save and not to call `panel_refresh_nodes` again on that install. The loss verdict overrides even a real phase failure already on the verdict — the lost nodes are the fact the caller must act on first.

One accepted false positive is stated in the code: a node the user deletes by hand inside the refresh window is indistinguishable from a pruned one and would be resurrected — visible and reversible, where the bug guarded against is silent and is not.

## Verification

- New `browser_tests/unit/refresh-graph-guard.test.mjs` (16 tests): pure inventory/diff/label helpers; verdict wording; the **shipping** `registerComfyNodeDefs` extracted and driven with doubles reproducing the issue's exact shape (7 added nodes, 5 pruned mid-refresh, mixed connected/unconnected) — asserting the snapshot was taken before the mutation, the restore replays it once, every node returns, and the reply says so; plus fail-closed paths (no `loadGraphData`, partial restore) and loss-overrides-phase-failure.
- `#981`/`#1172` source guards in `stale-placeholders.test.mjs` / `asset-staleness.test.mjs` extended to pin the new `...restored` spread and `lost_nodes` forwarding, so a future disclosure cannot fall out of the reply whitelist again.
- Gates (worktree, from `origin/main`): `npm ci` clean; `npm run test:unit` → **4912 tests, 4911 pass, 0 fail**; `npm run typecheck` → clean.

Not verified against a live ComfyUI 1.45.20 tab (no reproduction environment here); the deleting hook itself is third-party and untouched — this change guarantees detection, restore, and honest reporting around it.

Closes #1275