### PR TITLE
fix(584): a backend restart under a live tab re-probes the pack version and self-heals

### DIFF
--- a/browser_tests/unit/bundle-version.test.mjs
+++ b/browser_tests/unit/bundle-version.test.mjs
@@ -204,3 +204,70 @@ test("#584 healer invariants: loop-guard read-back and bounded prime are present
     "the probe settles before the sidebar tab registers (no stale-capability window)",
   );
 });
+
+// The setup()-time heal cannot fire for the scenario this issue keeps
+// recurring with: a pack update + ComfyUI restart UNDER an already-open tab
+// (panel_restart_comfyui, Manager reboot) — no page load happens, the tab
+// keeps re-advertising its old version in every re-hello, and the write fence
+// refuses every mutation while reads keep working. The panel already detects
+// exactly that event (the "reconnected" listener invalidates the Manager
+// dialect cache and node defs for the same reason); the version re-probe must
+// ride the same signal.
+test("#584 reconnect trigger: the reconnected listener re-probes the pack version", () => {
+  const src = readFileSync(
+    join(dirname(fileURLToPath(import.meta.url)), "../../web/js/comfyui-mcp-panel.js"),
+    "utf8",
+  ).replace(/\r\n/g, "\n");
+  // Anchor on the post-reconnect settle watch kick — unique to the listener
+  // that owns the backend-restart invalidations.
+  const kick = src.indexOf("kickPostReconnectSettleWatch(backendReconnectEpoch);");
+  assert.notEqual(kick, -1, "the reconnected listener kicks the settle watch");
+  const heal = src.indexOf("void healStaleBundleIfNeeded();", kick);
+  assert.ok(heal !== -1 && heal - kick < 2000, "the version re-probe rides the same reconnect signal");
+});
+
+// A reconnect-triggered heal navigates without a user at the keyboard, so the
+// healer's reload needs the same guards the commanded frontend reload got in
+// #701 — and one more, because its loop-guard marker is armed BEFORE the
+// navigation: a cancelled unload must not burn the tab's one heal attempt.
+test("#584 healer navigation guards: unsaved-work refusal, socket-down defer, cancelled-unload recovery", () => {
+  const src = readFileSync(
+    join(dirname(fileURLToPath(import.meta.url)), "../../web/js/comfyui-mcp-panel.js"),
+    "utf8",
+  ).replace(/\r\n/g, "\n");
+  const healStart = src.indexOf("async function healStaleBundleIfNeeded()");
+  assert.notEqual(healStart, -1);
+  const body = src.slice(healStart, src.indexOf("\n}\n", healStart));
+
+  // Unsaved work is detected BEFORE the marker is armed — a refused heal
+  // leaves the marker un-armed so a later load/reconnect can still heal.
+  const blockers = body.indexOf("unsavedReloadBlockers(app?.extensionManager?.workflow?.openWorkflows)");
+  assert.notEqual(blockers, -1, "the healer consults the unsaved-work blockers");
+  const arm = body.indexOf("ssSet(BUNDLE_HEAL_KEY, marker);");
+  assert.ok(arm !== -1 && blockers < arm, "blockers are checked before the loop-guard marker is armed");
+
+  // The probe + prime can span a NEW disconnect: a heal that finds the backend
+  // socket down defers its navigation and UN-ARMS the marker, or the next
+  // reconnect would read the attempt as spent and never retry.
+  const prime = body.indexOf("primeModuleCache({");
+  const socketDown = body.indexOf("if (comfyBackendSocketDown)", prime);
+  assert.ok(socketDown > prime, "the socket is re-checked after the prime, before navigating");
+  const deferUnarm = body.indexOf("ssSet(BUNDLE_HEAL_KEY, null);", socketDown);
+  assert.ok(
+    deferUnarm !== -1 && deferUnarm < body.indexOf("window.location.replace", socketDown),
+    "a deferred heal un-arms the marker so the next reconnect retries",
+  );
+
+  // The blocked-navigation notice is armed BEFORE navigating (same order as
+  // the commanded reload path), and its fire-path un-arms the marker —
+  // surviving the deadline proves the unload was cancelled, so the reload
+  // never happened and the heal attempt must not be counted as spent.
+  const notice = body.indexOf("armReloadBlockedNotice({");
+  const navigate = body.indexOf("window.location.replace");
+  assert.ok(notice !== -1 && notice < navigate, "the cancelled-navigation notice is armed before navigating");
+  const noticeBlock = body.slice(notice, navigate);
+  assert.ok(
+    noticeBlock.includes("ssSet(BUNDLE_HEAL_KEY, null);"),
+    "a provably-cancelled navigation returns the heal attempt",
+  );
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -1674,6 +1674,19 @@ function setupListeners() {
       // The watch runs only the same safe heals a graph command runs lazily;
       // it never repaints the canvas from serialized state (#604).
       kickPostReconnectSettleWatch(backendReconnectEpoch);
+      // #584: this reconnect can ALSO be a backend restart that swapped the
+      // pack on disk (a panel update + panel_restart_comfyui / Manager reboot)
+      // under the live tab. The running bundle is then older than the
+      // installed one, advertises its old version in every re-hello, and the
+      // orchestrator's write fence refuses every mutation while reads keep
+      // working — and the setup()-time heal never fires for this tab, because
+      // nothing here reloads the page. Same "the backend restarted, my cached
+      // state is wrong" invalidation as the dialect cache / node defs above:
+      // re-probe the pack version against the backend that is answering NOW
+      // (the version route reads pyproject.toml at request time). The healer
+      // no-ops on "current"/"unknown", so a blip-reconnect costs one bounded
+      // loopback fetch and nothing else.
+      void healStaleBundleIfNeeded();
     });
   } catch {
     // api unavailable — graph_get_errors reports null.
@@ -35030,6 +35043,25 @@ async function healStaleBundleIfNeeded() {
       );
       return;
     }
+    // #584/#701 — the heal's navigation is not user-initiated, so it gets the
+    // same guard the commanded frontend reload got: with unsaved work open,
+    // ComfyUI's beforeunload cancels the navigation AFTER the browser has torn
+    // down this tab's socket, and nobody is at the keyboard to answer the
+    // dialog. Worse HERE than on the commanded path: the loop-guard marker is
+    // armed below, so a cancelled navigation would burn the tab's ONE heal
+    // attempt on a reload that never happened and misreport the reason on the
+    // next load. Detect the blockers up front and leave the marker UN-armed,
+    // so a later load or reconnect can still heal once the work is saved.
+    // (Fail-open on an unreadable workflow list is deliberate — same rule as
+    // reload-blocked.js: an unknown flag is not evidence of unsaved work.)
+    const healBlockers = unsavedReloadBlockers(app?.extensionManager?.workflow?.openWorkflows);
+    if (healBlockers.length) {
+      console.warn(
+        `[comfyui-mcp-panel] this tab is running a STALE panel bundle (running ${PANEL_VERSION}, ` +
+          `installed ${installed}). ${reloadWouldBeBlockedMessage(healBlockers)}`,
+      );
+      return;
+    }
     ssSet(BUNDLE_HEAL_KEY, marker);
     if (ssGet(BUNDLE_HEAL_KEY) !== marker) {
       // codex gate round 3 — the loop guard is itself an operation that can
@@ -35065,9 +35097,39 @@ async function healStaleBundleIfNeeded() {
           `panel still reports ${PANEL_VERSION} afterwards, hard-refresh (Ctrl+Shift+R).`,
       );
     }
+    // #584 — the probe + prime above can span a NEW backend disconnect (a
+    // restart still in progress): reloading into a down server re-fetches
+    // whatever the half-restarted backend serves and strands the tab on the
+    // same stale evidence. The #646 gate refuses graph mutations while the
+    // socket is down, so none can be orphaned in flight here; defer instead,
+    // and UN-ARM the marker — this attempt never navigated, so the reconnect
+    // that follows the backend coming back must be allowed to retry the heal.
+    if (comfyBackendSocketDown) {
+      ssSet(BUNDLE_HEAL_KEY, null);
+      console.warn(
+        `[comfyui-mcp-panel] this tab is running a STALE panel bundle (running ${PANEL_VERSION}, ` +
+          `installed ${installed}) but ComfyUI's backend is still reconnecting — deferring the ` +
+          `self-heal reload to the next reconnect or page load.`,
+      );
+      return;
+    }
     // Arm the sidebar reopen exactly like the frontend soft reload, then swap
     // the page URL so the reload also re-fetches the document itself.
     ssSet(SIDEBAR_REOPEN_KEY, "1");
+    // #584/#701 — the blockers check above is a SNAPSHOT: work can become
+    // unsaved during the prime, so the navigation below can still be cancelled
+    // by a beforeunload dialog after the socket is already torn down. Surviving
+    // the deadline is proof the unload was cancelled (a successful navigation
+    // destroys this document first), so the notice's fire-path also UN-ARMS the
+    // loop-guard marker: the reload never happened, and the next page load or
+    // reconnect must get its heal attempt back. Same arm-before-navigate order
+    // as the commanded reload path.
+    armReloadBlockedNotice({
+      notify: (m) => {
+        ssSet(BUNDLE_HEAL_KEY, null);
+        console.warn(`[comfyui-mcp-panel] ${m}`);
+      },
+    });
     try {
       const u = new URL(window.location.href);
       u.searchParams.set("cmcpReload", String(Date.now()));


### PR DESCRIPTION
## Root cause

The stale-bundle healer (#624) was wired to exactly one trigger — page load — and the scenario this issue keeps recurring with has no page load in it: a pack update staged under an already-open tab, then a ComfyUI restart (`panel_restart_comfyui`, Manager reboot). The orchestrator runs out-of-band, so the bridge socket survives; the tab keeps running the JS it loaded when the page was opened, re-advertises that old `PANEL_VERSION` in its hello on every reconnect, and the write fence refuses every mutation while reads keep working. The panel already detects precisely that event — the `reconnected` listener invalidates the Manager dialect cache (#605) and re-pulls node defs for the same "the backend restarted, my cached state is wrong" reason — but never re-probed the pack version. (Diagnosis: `docs/triage/2026-08-14-open-issues.md`, #584 section.)

This is the half of #584 the panel can still reach. A bundle older than the healer cannot run it (the documented structural floor) — those tabs keep the hard-refresh remedy, and correcting the advice they get is #1229's job, unchanged.

## What changed (`web/js/comfyui-mcp-panel.js`)

1. **The missing trigger.** The `reconnected` listener now calls `healStaleBundleIfNeeded()` alongside the dialect-cache/node-defs invalidations. The version route reads `pyproject.toml` at request time, so post-restart it reports the new version; a probe that fails during the restart window stays "unknown" and does nothing — the fail-open verdict is untouched. A blip-reconnect costs one bounded (2s) loopback fetch and nothing else.

2. **The healer's navigation gets the #701 guards, plus one its one-shot marker makes necessary.** A reconnect-triggered heal navigates with nobody at the keyboard:
   - unsaved work is detected **before** the loop-guard marker is armed — ComfyUI's `beforeunload` cancels the navigation after the socket is torn down, and with the marker armed that would burn the tab's single heal attempt on a reload that never happened (and misreport the reason on the next load). A refused heal leaves the marker un-armed so a later load/reconnect can still heal.
   - the probe + prime (up to ~7s) can span a **new** disconnect: if `comfyBackendSocketDown` is true at navigation time the heal defers and un-arms the marker, so the reconnect that follows retries instead of reading the attempt as spent. The #646 gate refuses graph mutations while the socket is down, so none can be orphaned in flight by the defer-or-navigate decision.
   - the cancelled-navigation notice (`armReloadBlockedNotice`) is armed before navigating — same order as the commanded reload path — and its fire-path un-arms the marker: surviving the deadline proves the unload was cancelled, so the attempt is returned rather than consumed.

The fence is not weakened — mutations stay fail-closed; this only lets a tab that *can* heal itself learn that it needs to.

## Verification

Worktree at `0dbb8e28` (origin/main), one commit on top:

- `npm ci` — clean, 0 vulnerabilities
- `npm run test:unit` — **4935 pass / 0 fail** (4936 total, 1 pre-existing todo). Includes 2 new source-pin tests in `browser_tests/unit/bundle-version.test.mjs`: the re-probe rides the reconnect signal; blockers are checked before the marker is armed, a socket-down defer un-arms it, and the cancelled-unload notice returns the attempt. (One flake observed: `manager-install.test.mjs` #671 failed once under the full suite and passes standalone both with and without this change — timing-sensitive, unrelated.)
- `npm run typecheck` — clean

Not live-verified against a running ComfyUI (no rig on this machine); the trigger and guards are pinned at source level, matching the existing test style for this browser-wired code.

Closes artokun/comfyui-mcp-panel#584