### PR TITLE
fix(861): the shadow sheds version payloads canonical holds, so the byte bound holds

### DIFF
--- a/browser_tests/unit/legacy-shadow-quota.test.mjs
+++ b/browser_tests/unit/legacy-shadow-quota.test.mjs
@@ -5,6 +5,7 @@ import { readFileSync } from "node:fs";
 import {
   ChatHistoryStore,
   boundShadowBytes,
+  mergeHistorySnapshots,
   CHAT_HISTORY_SCHEMA,
   CHAT_HISTORY_DB_VERSION,
   CHAT_HISTORY_LEGACY_STORE,
@@ -1098,4 +1099,148 @@ test("the fence exists BEFORE the record stops existing", async () => {
   assert.ok(intentAt > 0, "the intent must be recorded up front");
   assert.ok(deleteAt > 0, "…and the record deleted after");
   assert.ok(intentAt < deleteAt, "the fence must exist before the record does not");
+});
+
+// ── the recurrence: version payloads ride INSIDE the protected thread ──────
+//
+// #861 shipped the byte bound, and the symptom came back anyway: a long chat on a
+// frequently edited graph captures a workflow version (up to 300KB of serialized
+// graph) on every user turn, twenty per thread, INSIDE the thread record. The live
+// thread is protected from eviction, so whole-thread eviction could never reclaim
+// those bytes — the shadow grew past the budget again, and ComfyUI's saveDraft()
+// failed again on the shared origin. The fix keeps the version LIST in the shadow
+// but strips the restorable payload once canonical is PROVEN to hold it — the same
+// receipt discipline as the legacy eviction, one level down.
+
+const ordinaryThreadWithVersions = (id, ts, versionCount, payloadSize) => ({
+  id,
+  schemaVersion: CHAT_HISTORY_SCHEMA,
+  ts,
+  updatedAt: ts,
+  msgs: [{ id: `${id}-m`, role: "user", text: "hi" }],
+  workflowVersions: Object.fromEntries(
+    Array.from({ length: versionCount }, (_, i) => [
+      `hash-${id}-${i}`,
+      {
+        hash: `hash-${id}-${i}`,
+        capturedAt: ts + i,
+        nodeCount: i + 1,
+        snapshot: { pad: "g".repeat(payloadSize) },
+      },
+    ]),
+  ),
+});
+
+test("version payloads leave the shadow once canonical holds them — the list stays", async () => {
+  const indexedDb = createFakeIndexedDb();
+  const storage = createMemoryStorage();
+  // Budget below the payload total: without the strip the thread could only be
+  // evicted whole or written oversized — the two failures this test must NOT see.
+  const store = new ChatHistoryStore({ storage, indexedDb, maxShadowBytes: 3000 });
+  const thread = ordinaryThreadWithVersions("T0", 1, 6, 800);
+  store.persist([thread], {});
+  await store._writePromise;
+
+  // Second persist: the canonical receipts now exist, so the shadow may shed payloads.
+  store.persist([thread], {});
+  await store._writePromise;
+
+  const written = JSON.parse(storage.getItem("comfyui-mcp.panel.historySnapshot"));
+  assert.ok(
+    JSON.stringify(written).length <= 3000,
+    "the shadow must respect the byte budget even with the live thread protected",
+  );
+  const shadowThread = (written.threads || []).find((t) => t.id === "T0");
+  assert.ok(shadowThread, "the thread itself must stay in the shadow");
+  const versions = Object.values(shadowThread.workflowVersions || {});
+  assert.equal(versions.length, 6, "the version LIST survives the strip");
+  for (const version of versions) {
+    assert.equal(version.snapshot, undefined, "a canonical-durable payload leaves the shadow");
+    assert.ok(version.hash && Number.isFinite(version.capturedAt), "the metadata stays");
+  }
+});
+
+test("version payloads STAY in the shadow while canonical has not accepted them", async () => {
+  // IndexedDB unavailable (private mode, blocked, quota): the shadow is the only
+  // copy of those graphs, and stripping them would be the data-loss path this whole
+  // change is built to avoid. Fail closed means the budget loses, not the data.
+  const storage = createMemoryStorage();
+  const store = new ChatHistoryStore({ storage, indexedDb: null, maxShadowBytes: 500 });
+  store.persist([ordinaryThreadWithVersions("T0", 1, 4, 800)], {});
+  await store._writePromise;
+  const written = JSON.parse(storage.getItem("comfyui-mcp.panel.historySnapshot"));
+  const versions = Object.values(written.threads[0].workflowVersions || {});
+  assert.equal(versions.length, 4);
+  for (const version of versions) {
+    assert.ok(version.snapshot, "no receipt, no strip — the only copy keeps its payload");
+  }
+});
+
+test("a stripped shadow cannot launder the payload out of canonical on reload", async () => {
+  // The strip makes the shadow metadata-only for durable versions, and the shadow
+  // merges AFTER canonical on every load. If the merge let a bare-metadata record
+  // displace the payload-carrier for the same hash, one reload would demote the
+  // in-memory copy, and the next persist would write that demotion INTO canonical —
+  // the durable graph gone, silently, exactly the failure a receipt exists to prevent.
+  const indexedDb = createFakeIndexedDb();
+  const storage = createMemoryStorage();
+  const writer = new ChatHistoryStore({ storage, indexedDb });
+  const thread = ordinaryThreadWithVersions("T0", 1, 3, 200);
+  writer.persist([thread], {});
+  await writer._writePromise;
+  writer.persist([thread], {});
+  await writer._writePromise;
+  const written = JSON.parse(storage.getItem("comfyui-mcp.panel.historySnapshot"));
+  assert.ok(
+    Object.values(written.threads[0].workflowVersions).every((v) => v.snapshot === undefined),
+    "precondition: the shadow really is stripped",
+  );
+
+  const reader = new ChatHistoryStore({ storage, indexedDb });
+  const read = await reader.readCanonical();
+  const restored = (read?.threads || []).find((t) => t.id === "T0");
+  assert.ok(restored, "the thread must reload");
+  for (const [hash, version] of Object.entries(thread.workflowVersions)) {
+    assert.deepEqual(
+      restored.workflowVersions?.[hash]?.snapshot,
+      version.snapshot,
+      `canonical's payload for ${hash} must survive the merge with the stripped shadow`,
+    );
+  }
+});
+
+test("a metadata-only version never displaces the payload-carrier for the same hash", () => {
+  // The merge guard on its own, both argument orders: the hash is content-addressed,
+  // so a record without the graph must never win over the record that has it.
+  const withPayload = {
+    threads: [{
+      id: "T",
+      schemaVersion: CHAT_HISTORY_SCHEMA,
+      ts: 1,
+      updatedAt: 1,
+      msgs: [],
+      workflowVersions: { h: { hash: "h", capturedAt: 10, nodeCount: 3, snapshot: { nodes: [] } } },
+    }],
+    meta: {},
+  };
+  const strippedThread = {
+    id: "T",
+    schemaVersion: CHAT_HISTORY_SCHEMA,
+    ts: 2,
+    updatedAt: 2,
+    msgs: [],
+    workflowVersions: { h: { hash: "h", capturedAt: 10, nodeCount: 3 } },
+  };
+  const shadowLast = mergeHistorySnapshots(withPayload, { threads: [strippedThread], meta: {} });
+  assert.deepEqual(
+    shadowLast.threads[0].workflowVersions.h.snapshot,
+    { nodes: [] },
+    "a stripped shadow merged after canonical must not drop the payload",
+  );
+  const shadowFirst = mergeHistorySnapshots({ threads: [strippedThread], meta: {} }, withPayload);
+  assert.deepEqual(
+    shadowFirst.threads[0].workflowVersions.h.snapshot,
+    { nodes: [] },
+    "…and the payload obviously survives the canonical-last order too",
+  );
 });

--- a/web/js/lib/chat-history-store.js
+++ b/web/js/lib/chat-history-store.js
@@ -167,7 +167,16 @@ function mergeWorkflowVersions(...maps) {
   for (const map of maps) {
     for (const [hash, version] of Object.entries(normalizeWorkflowVersions(map))) {
       const previous = combined[hash];
-      if (!previous || version.capturedAt >= previous.capturedAt) combined[hash] = version;
+      // A version carrying its restorable graph outranks bare metadata for the same
+      // capture (#861). The local shadow strips payloads from what canonical already
+      // holds, and the shadow merges AFTER canonical — without this guard the
+      // stripped copy would launder the durable payload away on the next load. The
+      // hash is content-addressed, so same hash is the same graph: keeping the
+      // payload-carrier loses nothing.
+      const dropsPayload = previous?.snapshot !== undefined && version.snapshot === undefined;
+      if (!previous || (version.capturedAt >= previous.capturedAt && !dropsPayload)) {
+        combined[hash] = version;
+      }
     }
   }
   return normalizeWorkflowVersions(combined);
@@ -1434,6 +1443,63 @@ export function boundShadowBytes(localSnapshot, { maxBytes, evictableIds, protec
 }
 
 /**
+ * Hashes of the workflow versions whose restorable graph payload a snapshot is PROVEN
+ * to hold, per thread id (#861 recurrence).
+ *
+ * A thread carries up to 20 versions x 300KB of serialized graph INSIDE its own
+ * record, and the live thread is protected from eviction — so while those payloads
+ * sit in the localStorage shadow, the byte bound above cannot hold. That is exactly
+ * the reported case: a long chat on a frequently edited graph re-wedged the shared
+ * origin quota even with the cap in place, and ComfyUI's saveDraft() failed again.
+ *
+ * The hash is content-addressed, so a hash present in the canonical record — WITH
+ * its snapshot — is the whole proof that the shadow's copy of that payload is a
+ * cache. This is the receipt that licenses stripping it there.
+ */
+function versionPayloadReceipts(snapshot) {
+  const receipts = new Map();
+  for (const thread of Array.isArray(snapshot?.threads) ? snapshot.threads : []) {
+    if (typeof thread?.id !== "string" || !thread.id) continue;
+    for (const [hash, version] of Object.entries(thread.workflowVersions || {})) {
+      if (version && typeof version === "object" && version.snapshot !== undefined) {
+        let held = receipts.get(thread.id);
+        if (!held) receipts.set(thread.id, (held = new Set()));
+        held.add(hash);
+      }
+    }
+  }
+  return receipts;
+}
+
+/**
+ * The shadow copy of a thread with its canonical-durable version payloads reduced to
+ * metadata (#861 recurrence). The version LIST survives — hash, capturedAt, node
+ * count, title — so startup paint and the history UI are unchanged; only the
+ * restorable graph leaves, and only for versions the receipt proves canonical holds.
+ * The in-memory thread is never touched: any later canonical write re-supplies every
+ * payload from it, so a stripped shadow cannot become the only copy. Versions with
+ * no receipt keep their payload — fail closed, exactly like an un-receipted legacy
+ * thread keeping its place in the shadow.
+ */
+function stripDurableVersionPayloads(thread, receipts) {
+  const held = receipts.get(thread?.id);
+  const versions = thread?.workflowVersions;
+  if (!held || !versions || typeof versions !== "object") return thread;
+  let changed = false;
+  const kept = Object.create(null);
+  for (const [hash, version] of Object.entries(versions)) {
+    if (held.has(hash) && version && typeof version === "object" && version.snapshot !== undefined) {
+      const { snapshot: _dropped, ...metadata } = version;
+      kept[hash] = metadata;
+      changed = true;
+    } else {
+      kept[hash] = version;
+    }
+  }
+  return changed ? { ...thread, workflowVersions: kept } : thread;
+}
+
+/**
  * Read every quarantined pre-v3 transcript out of the legacy store (#861).
  *
  * Returns `null` — NOT `[]` — when the store cannot be reached. The difference is
@@ -2164,7 +2230,18 @@ export class ChatHistoryStore {
       ...thread,
       msgs: thread.msgs.slice(-LOCAL_SHADOW_MESSAGES),
     }));
-    const shadow = [...boundedOrdinary, ...legacyThreads]
+    // #861 recurrence — shed workflow-version PAYLOADS the canonical record is proven
+    // to hold before the byte bound is measured. Without this the bound cannot hold:
+    // the versions ride inside the live thread, and the live thread is protected from
+    // eviction. When this write follows the canonical merge, the snapshot itself is
+    // the receipt; otherwise the last committed canonical state is. No receipt — the
+    // first persist of a session, or any install where IndexedDB is unavailable — and
+    // every payload stays, because then the shadow is still their only copy.
+    const payloadReceipts = versionPayloadReceipts(canonicalDurable ? snapshot : this._lastCommitted);
+    const shadow = [
+      ...boundedOrdinary.map((thread) => stripDurableVersionPayloads(thread, payloadReceipts)),
+      ...legacyThreads,
+    ]
       .sort((a, b) => finiteTs(a.updatedAt || a.ts) - finiteTs(b.updatedAt || b.ts));
     // #861 — the byte bound. Everything here is a CACHE of something durable except
     // legacy threads, which are durable only once the legacy store has accepted


### PR DESCRIPTION
## Root cause

#861 shipped the shadow byte bound in #865, and the same downstream symptom — ComfyUI's `Failed to save workflow draft` on the shared `http://localhost:8188` origin — was reported again on 0.14.44. The cap was real, but it could not hold against the reported case:

- Every user turn captures a **workflow version** — the full serialized graph, up to 300KB — into `thread.workflowVersions`, kept 20 per thread (`comfyui-mcp-panel.js` `workflowVersionSnapshot()`). That is up to ~6MB riding **inside one thread record**.
- `_writeLocalSnapshot` slices `msgs` for the shadow but carries `workflowVersions` in full, and `boundShadowBytes` can only drop **whole threads**.
- The live thread is `protectedIds` — never evictable. So a long chat on a frequently edited graph grows the shadow past `LOCAL_SHADOW_MAX_BYTES` with no eviction able to reclaim it, and the origin quota wedges ComfyUI's drafts again. Exactly the recurrence: "live graph edits during a long sidebar chat".

## Fix

Same receipt discipline as #865's legacy eviction, one level down:

- **`versionPayloadReceipts` / `stripDurableVersionPayloads`** — the shadow keeps the version *list* (hash, capturedAt, nodeCount, title — startup paint and the history UI are unchanged) but strips the restorable graph payload once canonical is **proven** to hold it. The receipt is the canonical record itself: the post-merge snapshot when this write follows the canonical merge, `_lastCommitted` otherwise. The hash is content-addressed, so a hash canonical holds — with its snapshot — is the whole proof the shadow copy is a cache.
- **Fail closed, unchanged.** No receipt — the first persist of a session, or any install where IndexedDB is unavailable — and every payload stays: the budget loses, not the data. The in-memory thread is never touched, so any later canonical write re-supplies every payload; a stripped shadow can never become the only copy.
- **Merge guard in `mergeWorkflowVersions`** — the shadow merges *after* canonical on every load, so without this a stripped, metadata-only record would displace the payload-carrier for the same hash on reload, and the next persist would write that demotion *into* canonical. A version carrying its graph now always outranks bare metadata for the same capture.

## Verification

- `npm ci` — clean, 0 vulnerabilities.
- `npm run test:unit` — **4937 pass, 0 fail** (4938 total, 1 todo), including 4 new tests in `browser_tests/unit/legacy-shadow-quota.test.mjs`:
  - payloads leave the shadow once canonical holds them, the list stays, and the budget holds with the live thread protected;
  - payloads **stay** while canonical has not accepted them (IndexedDB unavailable — fail closed);
  - a stripped shadow cannot launder the payload out of canonical on reload (end-to-end through the fake IndexedDB);
  - the merge guard itself, both argument orders.
- Mutation check: with the source change stashed, the new strip and merge-guard tests fail; the fail-closed test passes, pinning that behavior as unchanged.
- `npm run typecheck` (`tsc --noEmit`) — clean.

Closes artokun/comfyui-mcp-panel#861