### PR TITLE
fix(976): a widget callback's throw now names the file it surfaced from, origin scrubbed

### DIFF
--- a/browser_tests/unit/widget-write.test.mjs
+++ b/browser_tests/unit/widget-write.test.mjs
@@ -2483,6 +2483,229 @@ test("#639: a throwing callback on a verified write is DISCLOSED (write_warning)
   assert.match(set.write_warning, /invokes callbacks programmatically/, "names the one thing that could make it our doing");
 });
 
+// ---- #976 frame: until now the throw left NO evidence of where it surfaced. The
+//      Error was caught inside the lib, only its message was rendered, and nothing
+//      reached the console — so the maintainer twice had to ask the reporter for a
+//      stack the panel itself had destroyed, and the recurrence on 0.13.7 arrived
+//      with no more information than the first report. `write_warning_frame` carries
+//      the innermost non-panel frame as scrubbed DATA, on EITHER attribution branch
+//      (a stack frame is an observation, not an attribution claim). -----
+
+test("#976 frame: the envelope names the FILE the throw surfaced from, with the origin scrubbed", () => {
+  // A browser-shaped stack, as V8 renders it in ComfyUI — the reporter's own
+  // host:port included, which is exactly what must NOT survive into a public issue.
+  const packErr = new TypeError("Cannot read properties of undefined (reading 'options')");
+  packErr.stack =
+    "TypeError: Cannot read properties of undefined (reading 'options')\n" +
+    "    at Object.callback (http://127.0.0.1:8188/extensions/WhatDreamsCost-ComfyUI/js/minimax_h3_director.js:42:17)\n" +
+    "    at applyWidgetWrite (http://127.0.0.1:8188/extensions/comfyui-mcp-panel/js/lib/widget-write.js:1470:11)";
+  const node = {
+    id: 2693,
+    type: "MiniMaxH3Director",
+    widgets: [
+      {
+        name: "duration",
+        type: "INT",
+        value: 5,
+        callback() {
+          throw packErr;
+        },
+      },
+    ],
+  };
+  const set = applyWidgetWrite(node, "duration", 10, HOOKS);
+  assert.equal(set.write_warning_source, "widget_callback", "attribution unchanged");
+  assert.equal(
+    set.write_warning_frame,
+    "at Object.callback (/extensions/WhatDreamsCost-ComfyUI/js/minimax_h3_director.js:42:17)",
+    "the innermost frame, path kept, origin stripped",
+  );
+  assert.doesNotMatch(set.write_warning_frame, /127\.0\.0\.1|8188/, "nothing identifying the reporter's machine");
+});
+
+test("#976 frame: a REAL engine stack yields the callback's own frame — the mechanism is not fixture-shaped", () => {
+  // No crafted `stack` string: whatever V8 actually produces for a callback defined
+  // in THIS file must name THIS file (the pack stand-in), never the write path's.
+  const node = {
+    id: 1,
+    type: "N",
+    widgets: [
+      {
+        name: "n",
+        type: "INT",
+        value: 1,
+        callback() {
+          throw new TypeError("boom-976-real-stack");
+        },
+      },
+    ],
+  };
+  const set = applyWidgetWrite(node, "n", 5, HOOKS);
+  assert.equal(set.write_warning_source, "widget_callback");
+  assert.ok(
+    typeof set.write_warning_frame === "string" && set.write_warning_frame.includes("widget-write.test.mjs"),
+    `the innermost frame is the callback's own file, got: ${set.write_warning_frame}`,
+  );
+});
+
+test("#976 frame: frames inside the write path itself are stepped past", () => {
+  // A throw whose stack STARTS in the panel (a non-callable callback throws at the
+  // Reflect.apply site, inside widget-write.js) must not report the panel's own
+  // frame — that would name widget-write.js for every throw and say nothing.
+  const err = new TypeError("widgetCallback is not a function");
+  err.stack =
+    "TypeError: widgetCallback is not a function\n" +
+    "    at applyWidgetWrite (http://host:8188/extensions/comfyui-mcp-panel/js/lib/widget-write.js:1470:11)\n" +
+    "    at runSetWidget (http://host:8188/extensions/comfyui-mcp-panel/js/lib/set-widget.js:545:20)\n" +
+    "    at execute (http://host:8188/assets/index-BbD9p18C.js:90001:5)";
+  const node = {
+    id: 2,
+    type: "N",
+    widgets: [
+      {
+        name: "n",
+        type: "INT",
+        value: 1,
+        callback() {
+          throw err;
+        },
+      },
+    ],
+  };
+  const set = applyWidgetWrite(node, "n", 5, HOOKS);
+  assert.equal(
+    set.write_warning_frame,
+    "at execute (/assets/index-BbD9p18C.js:90001:5)",
+    "both lib frames skipped; the first non-write-path frame reported",
+  );
+});
+
+test("#976 frame: the UNATTRIBUTED branch carries the frame too — an observation, not an attribution", () => {
+  // A throwing `node.pos` getter is NOT the callback failing (the boundary tests
+  // above pin that no source is claimed) — but the frame still says where the throw
+  // surfaced, because that fact claims nothing about which construct failed.
+  const posErr = new Error("pos boom");
+  posErr.stack =
+    "Error: pos boom\n" +
+    "    at LGraphNode.get pos (http://192.168.1.20:8188/assets/index-BbD9p18C.js:82519:11)\n" +
+    "    at applyWidgetWrite (http://192.168.1.20:8188/extensions/comfyui-mcp-panel/js/lib/widget-write.js:1468:40)";
+  const node = {
+    id: 1,
+    type: "N",
+    get pos() {
+      throw posErr;
+    },
+    widgets: [
+      {
+        name: "n",
+        type: "INT",
+        value: 1,
+        callback() {},
+      },
+    ],
+  };
+  const set = applyWidgetWrite(node, "n", 5, HOOKS);
+  assert.equal(set.write_warning_source, undefined, "still no attribution — the callback never ran");
+  assert.equal(
+    set.write_warning_frame,
+    "at LGraphNode.get pos (/assets/index-BbD9p18C.js:82519:11)",
+    "the observation is emitted anyway",
+  );
+});
+
+test("#976 frame: a throwing `stack` accessor yields no frame — and breaks nothing", () => {
+  // Same totality contract as describeThrown: the reporting path that exists to
+  // report a throw must not itself throw, whatever the thrown value does.
+  const weird = {
+    get message() {
+      return "odd boom";
+    },
+    get stack() {
+      throw new Error("stack boom");
+    },
+  };
+  const node = {
+    id: 1,
+    type: "N",
+    widgets: [
+      {
+        name: "n",
+        type: "INT",
+        value: 1,
+        callback() {
+          throw weird;
+        },
+      },
+    ],
+  };
+  const set = applyWidgetWrite(node, "n", 5, HOOKS);
+  assert.match(set.write_warning, /odd boom/, "the message still renders");
+  assert.equal(set.write_warning_frame, undefined, "no frame — and the report itself survived");
+});
+
+test("#976 frame: a non-Error throw has no stack — the warning stands, no frame claimed", () => {
+  const node = {
+    id: 1,
+    type: "N",
+    widgets: [
+      {
+        name: "n",
+        type: "INT",
+        value: 1,
+        callback() {
+          throw "string boom"; // eslint-disable-line no-throw-literal — the point
+        },
+      },
+    ],
+  };
+  const set = applyWidgetWrite(node, "n", 5, HOOKS);
+  assert.match(set.write_warning, /string boom/);
+  assert.equal(set.write_warning_frame, undefined, "its absence means 'no readable stack', never 'no throw'");
+});
+
+test("#976 frame: SpiderMonkey's fn@url shape is accepted and scrubbed the same way", () => {
+  const err = new TypeError("ff boom");
+  err.stack = "callback@http://127.0.0.1:8188/extensions/pack/file.js:7:13";
+  const node = {
+    id: 1,
+    type: "N",
+    widgets: [
+      {
+        name: "n",
+        type: "INT",
+        value: 1,
+        callback() {
+          throw err;
+        },
+      },
+    ],
+  };
+  const set = applyWidgetWrite(node, "n", 5, HOOKS);
+  assert.equal(set.write_warning_frame, "callback@/extensions/pack/file.js:7:13");
+});
+
+test("#976 frame: a minified single-line frame is capped, not emitted whole", () => {
+  const err = new Error("minified boom");
+  err.stack = `Error: minified boom\n    at ${"x".repeat(400)} (http://h:8188/extensions/p/b.js:1:1)`;
+  const node = {
+    id: 1,
+    type: "N",
+    widgets: [
+      {
+        name: "n",
+        type: "INT",
+        value: 1,
+        callback() {
+          throw err;
+        },
+      },
+    ],
+  };
+  const set = applyWidgetWrite(node, "n", 5, HOOKS);
+  assert.equal(set.write_warning_frame.length, 240, "capped");
+  assert.ok(set.write_warning_frame.endsWith("..."), "the truncation is visible");
+});
+
 // ---- #976 boundary: attribution is claimed ONLY for the invocation itself. The
 //      lookup of `w.callback` and the evaluation of the callback's arguments happen
 //      OUTSIDE the attributed span, because a throwing accessor and a throwing

--- a/web/js/lib/widget-write.js
+++ b/web/js/lib/widget-write.js
@@ -37,6 +37,55 @@ function describeThrown(err) {
   }
 }
 
+/**
+ * #976: the first stack frame OUTSIDE this write path, as scrubbed data.
+ *
+ * `describeThrown` renders the message and nothing else, and the Error is caught
+ * inside this lib so it never reaches the console — so a callback's throw used to
+ * leave NO evidence of WHERE it threw, and the maintainer was reduced to asking
+ * reporters for a stack the panel itself made unobtainable. This emits the single
+ * most useful fact: the innermost frame that is not this module or its set-widget
+ * driver, which names the FILE the throw surfaced from.
+ *
+ * A frame is an OBSERVATION, not an attribution — unlike `write_warning_source` it
+ * claims nothing about which construct failed, so it is emitted for the
+ * unattributed branch too.
+ *
+ * Totality, same contract as describeThrown: `err.stack` may be a throwing accessor
+ * (a hostile Proxy), a non-Error throw has no stack at all, and a frame line may be
+ * any shape — so every read is guarded and any surprise yields null, never a throw
+ * from the path that exists to report one.
+ *
+ * Scrubbing, because this text is pasted into public issues: the frame's ORIGIN
+ * (scheme://host:port, which identifies the reporter's machine) is stripped, keeping
+ * only the URL path — `/extensions/<pack>/<file>.js:LINE:COL` is what a maintainer
+ * needs. Length is capped so a minified single-line bundle cannot make the envelope
+ * unwieldy.
+ */
+function describeThrownFrame(err) {
+  try {
+    const stack = err?.stack;
+    if (typeof stack !== "string" || !stack) return null;
+    for (const line of stack.split("\n")) {
+      const trimmed = line.trim();
+      // V8 ("at fn (url:line:col)") and SpiderMonkey ("fn@url:line:col") both carry
+      // the URL; the message header and anything else is skipped.
+      if (!trimmed.startsWith("at ") && !trimmed.includes("@")) continue;
+      // Frames from the write path itself say where the PANEL was, not where the
+      // throw surfaced — step past them to the first frame that is not ours.
+      if (trimmed.includes("widget-write.js") || trimmed.includes("set-widget.js")) continue;
+      // Strip the origin, keep the path. If the URL shape is not recognized the
+      // frame is still usable — the path is what carries the information.
+      let frame = trimmed.replace(/[a-zA-Z][a-zA-Z0-9+.-]*:\/\/[^/\s)]+(?=\/)/g, "");
+      if (frame.length > 240) frame = frame.slice(0, 237) + "...";
+      return frame;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
 // Widget-value validation + promoted-subgraph-widget target resolution for
 // graph_set_widget. Extracted so the write targets the RIGHT widget with the
 // RIGHT value and can be unit-tested by driving the SAME code path the handler
@@ -1493,9 +1542,12 @@ export function applyWidgetWrite(
   //
   // #639: a THROWN callback is deliberately NOT a verdict in this chain. The value
   // assignments above run BEFORE the callback fires, so when the callback throws the
-  // write may ALREADY be in effect (MiniMaxH3Director's `duration`: the extension's
-  // own callback throws on `options` of undefined on ANY programmatic invocation,
-  // which made the widget permanently unwritable when any throw forced a refusal).
+  // write may ALREADY be in effect — #976's MiniMaxH3Director `duration` write was
+  // verified present by read-back while its callback's throw was still reported.
+  // (An earlier draft of this note claimed that callback throws on ANY programmatic
+  // invocation; that was never measured — the only repro was a synthetic probe on a
+  // stock node — and the installed pack version has no `duration` widget at all, so
+  // the claim is withdrawn. `write_warning_frame` now carries the evidence instead.)
   // Rolling a VERIFIED write back and refusing would report failure for work that
   // succeeded and invite a destructive retry — so the structural checks below
   // decide. A throw on a verified write is DISCLOSED on the success result
@@ -1505,6 +1557,7 @@ export function applyWidgetWrite(
   let originalErr = null;
   let driftFailure = false;
   let writeWarning = null;
+  let threwFrame = null;
   // #805 — a value the widget's OWN declared grid explains is NORMALIZATION, not a
   // failed write. `matchesExpected` is a strict equality, so a numeric widget doing
   // exactly its job (min 1 / step 2 snaps 4096 -> 4097) was reported as "did not
@@ -1639,6 +1692,13 @@ export function applyWidgetWrite(
   // An attribution that overshoots just relocates the wrong blame.
   if (didThrow) {
     const threwDetail = describeThrown(threw);
+    // #976: WHERE the throw surfaced, as scrubbed data — emitted for BOTH the
+    // attributed and the unattributed branch, because a stack frame is an
+    // observation (unlike `write_warning_source`, it claims nothing about which
+    // construct failed). Without it the Error is swallowed inside this lib and the
+    // one fact that could route the report — the file the throw came from — is
+    // destroyed.
+    threwFrame = describeThrownFrame(threw);
     // "ATTEMPT to invoke", uniformly (codex round 3). A class constructor and a
     // revoked Proxy both satisfy `typeof === "function"` and then throw before any
     // body runs, so any wording that says the callback RAN is false for them — and
@@ -1942,6 +2002,10 @@ export function applyWidgetWrite(
       ? {
           write_warning: writeWarning,
           ...(threwFromCallback ? { write_warning_source: "widget_callback" } : {}),
+          // #976: the innermost non-panel stack frame, scrubbed of origin — present
+          // whenever the throw cooperated, on either attribution branch. Its absence
+          // means "no readable stack", never "no throw".
+          ...(threwFrame ? { write_warning_frame: threwFrame } : {}),
         }
       : {}),
     // #805 — the write applied and the node quantized it. Report BOTH values so the


### PR DESCRIPTION
## Root cause

The original defect — a successful write reading as a panel failure — was fixed in 0.11.88 (#987/#989): the write is applied, verified by read-back, deliberately not rolled back, and the exception is attributed as data (`write_warning_source: "widget_callback"`). The 0.13.7 recurrence comment on #976 confirms all of that works.

What remains broken is **observability**: the thrown Error is caught inside `widget-write.js`, only its message is rendered (`describeThrown`), and nothing reaches the console or the result envelope. The panel destroys the one piece of evidence that would route the report — which file the throw surfaced from — which is why the maintainer twice asked the reporter for a stack the panel itself makes unobtainable, and why the recurrence arrived with no more information than the first report. (Diagnosis: the merged triage report `docs/triage/2026-08-14-open-issues.md`, #976 section.)

## Fix

- New `describeThrownFrame(err)` next to `describeThrown` in `web/js/lib/widget-write.js`, under the same totality contract: a throwing `stack` accessor, a non-Error throw, any frame shape all yield `null` — the path that exists to report a throw never throws. It returns the innermost frame that is **not** the write path's own (`widget-write.js`/`set-widget.js` are stepped past), with the **origin stripped** — `http://host:8188/extensions/<pack>/file.js:42:17` → `/extensions/<pack>/file.js:42:17`, because this text gets pasted into public issues — and the length capped at 240 for minified single-line bundles.
- Emitted as `write_warning_frame` in the success envelope alongside `write_warning_source`, on **either** attribution branch: a stack frame is an observation, not an attribution claim, so the unattributed branch (throwing `callback` accessor, throwing `node.pos` getter, reentrant setter) carries it too. Its absence means "no readable stack", never "no throw".
- The `write_warning` prose, the attribution boundary, and the no-rollback decision are untouched (the existing pinned tests at `widget-write.test.mjs` say so).
- Also withdraws the never-measured #639-era comment claiming MiniMaxH3Director's callback throws on `options` of undefined on ANY programmatic invocation — the only repro was a synthetic probe on a stock node, and the installed pack version has no `duration` widget at all. The frame field is what replaces that guess with evidence.

Deliberately not done: rendering the frame into the chat summary (i18n-checked surface; the envelope data is the deliverable), and the triage's optional `onWriteException` console hook (additive, can follow).

## Verification

- 8 new tests in `browser_tests/unit/widget-write.test.mjs`, driving `applyWidgetWrite` (the production path): origin-scrubbed frame on the attributed branch; a **real** V8 stack (not a crafted string) names the callback's own file; lib frames stepped past; unattributed branch carries the frame with no source claimed; throwing `stack` accessor and non-Error throw yield no frame and break nothing; SpiderMonkey `fn@url` shape; 240-char cap.
- **Mutation-verified**: with `web/js/lib/widget-write.js` stashed to origin/main, the 6 frame-asserting tests fail; the 2 no-frame tests pass against both (negative fences, same convention as the existing #976 boundary block).
- Gates in the worktree: `npm ci` (0 vulnerabilities) → `npm run test:unit` (**4947 pass / 0 fail / 1 todo**) → `npm run typecheck` (clean).

Follow-up once this ships: re-ask the #976 reporter for the `write_warning_frame` value from a live run — if it lands inside the WhatDreamsCost/DaSiWa pack, the residual is upstream to the pack; if it lands in the ComfyUI frontend, it joins the #757 family (callbacks written for a click, invoked programmatically).

Closes #976