### PR TITLE
fix(978): a first save publishes the identity it produced even when the swap carry fails safe

### DIFF
--- a/browser_tests/unit/save-as-identity.test.mjs
+++ b/browser_tests/unit/save-as-identity.test.mjs
@@ -33,12 +33,29 @@ test("#941: an already-established canvas is left alone", () => {
 
 test("#941: an in-place save never establishes", () => {
   // It keeps the same object, whose identity is already established; there is nothing to
-  // mint and no caller to strand. Deliberately not widened — measured, an in-place/first
-  // save already reports `workflow_uuid` correctly.
+  // mint and no caller to strand. An unknown save shape stays fail-closed: no save kind,
+  // no mint.
   assert.equal(shouldEstablishIdentityAfterSave({ savedAs: false, alreadyEstablished: false }), false);
   assert.equal(shouldEstablishIdentityAfterSave({ savedAs: false, alreadyEstablished: true }), false);
   assert.equal(shouldEstablishIdentityAfterSave({}), false, "unknown shape must not mint");
   assert.equal(shouldEstablishIdentityAfterSave(), false);
+});
+
+test("#978: a FIRST save with nothing established must establish too", () => {
+  // The recurrence: a first save swaps the active object exactly like a Save-As, and the
+  // #557 carry that usually threads the predecessor's identity across that swap fails
+  // SAFE on any proof gap. Scoped to Save-As, this rule then let the reply report
+  // `workflow_identity_unavailable` while the fence's own minting read refused the next
+  // call with the identity the reply had declined to publish (panel 0.14.41).
+  assert.equal(shouldEstablishIdentityAfterSave({ firstSave: true, alreadyEstablished: false }), true);
+  assert.equal(shouldEstablishIdentityAfterSave({ savedAs: false, firstSave: true, alreadyEstablished: false }), true);
+});
+
+test("#978: a first save the carry already seeded is left alone", () => {
+  // The healthy path: the #557 carry threaded the predecessor's uuid onto the successor,
+  // so the produced record reads as established and nothing is minted over it — the two
+  // paths never compete over the same object.
+  assert.equal(shouldEstablishIdentityAfterSave({ firstSave: true, alreadyEstablished: true }), false);
 });
 
 test("#941: once established, the reply carries what the fence compares against", () => {

--- a/browser_tests/unit/save-reply-identity.test.mjs
+++ b/browser_tests/unit/save-reply-identity.test.mjs
@@ -106,8 +106,9 @@ test("#747 WIRING: BOTH save handlers report the identity, and the FLAG follows 
   // #941 — and BOTH must establish the identity first, or the read above finds nothing for
   // a Save-As's brand-new object and reports `workflow_identity_unavailable` while the
   // fence, whose own read mints, refuses the next call with the identity it just declined
-  // to publish.
+  // to publish. #978 recurrence — the same holds for a FIRST save, whose successor is just
+  // as brand-new when the #557 carry fails safe; the firstSave flag must reach the rule.
   // …from the record the SAVE produced, not a later active-canvas read (#941, codex).
-  assert.match(saveBlock, /saveProducedIdentity\(producedRecord, !!outcome\.saved_as\)/);
-  assert.match(saveAsBlock, /saveProducedIdentity\(producedRecord, true\)/);
+  assert.match(saveBlock, /saveProducedIdentity\(producedRecord, \{ savedAs: !!outcome\.saved_as, firstSave: !!outcome\.first_save \}\)/);
+  assert.match(saveAsBlock, /saveProducedIdentity\(producedRecord, \{ savedAs: true, firstSave: !!outcome\.first_save \}\)/);
 });

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -3623,13 +3623,23 @@ function loadLandedWorkflowUuid(appRef, targetedWorkflow) {
  * active, and it establishes for the object the SAVE ITSELF produced — never for whatever
  * happens to be active afterwards, which a tab switch during the save's awaits could make
  * a different workflow entirely (codex).
+ *
+ * #978 recurrence — `firstSave` extends the same licence to a first save. Its successor
+ * is just as brand-new as a Save-As copy; the #557 carry threads the predecessor's uuid
+ * onto it when every continuity proof passes, but that carry fails SAFE on any proof gap,
+ * and then an un-established successor reached this reply and was reported
+ * `workflow_identity_unavailable` while the fence's own minting read refused the next call
+ * with the very value the reply declined to publish (measured on 0.14.41 / frontend
+ * 1.48.7). A carry-seeded record reads as already established and is untouched, so the
+ * two paths never compete over the same object.
  */
-function saveProducedIdentity(savedRecord, savedAs) {
+function saveProducedIdentity(savedRecord, { savedAs = false, firstSave = false } = {}) {
   try {
     if (!savedRecord || typeof savedRecord !== "object") return null;
     if (
       !shouldEstablishIdentityAfterSave({
         savedAs,
+        firstSave,
         alreadyEstablished: Boolean(establishedWorkflowReplyIdentity(savedRecord)),
       })
     ) {
@@ -14379,7 +14389,13 @@ const GRAPH_TOOL_EXECUTORS = {
     // Fully programmatic — no Save/Rename dialog. Auto-names a never-saved
     // workflow; saves in place otherwise.
     const { name: workflow, producedRecord, ...outcome } = await programmaticSave(name);
-    const replyIdentity = saveProducedIdentity(producedRecord, !!outcome.saved_as);
+    // #978 recurrence — a FIRST save swaps the active object too, and the #557 carry
+    // that usually threads the identity across that swap fails SAFE on any proof gap,
+    // leaving the produced record un-established and the reply reporting
+    // `workflow_identity_unavailable` while the fence's own minting read refused the
+    // next call with that very identity. Establish from the save's own produced record
+    // for a first save exactly as for a Save-As (#941).
+    const replyIdentity = saveProducedIdentity(producedRecord, { savedAs: !!outcome.saved_as, firstSave: !!outcome.first_save });
     // outcome surfaces WHAT happened (saved_as/copied_from/original_preserved or
     // first_save) so a rename-vs-copy is never silent (mcp#579).
     //
@@ -14403,7 +14419,7 @@ const GRAPH_TOOL_EXECUTORS = {
     const { name: workflow, producedRecord, ...outcome } = await programmaticSave(name);
     // #747 — this path ALWAYS changes which workflow is active, so it is the one
     // that strands a caller. Report the new instance identity here.
-    const replyIdentity = saveProducedIdentity(producedRecord, true);
+    const replyIdentity = saveProducedIdentity(producedRecord, { savedAs: true, firstSave: !!outcome.first_save });
     // #978 — the DISCLOSURE follows what the save actually did, not this handler's name
     // (codex). Asked to save an unsaved tab, the adapter classifies it `first_save`: the
     // successor is identity-CONTINUOUS with the temporary predecessor, so the root's

--- a/web/js/lib/save-reply-identity.js
+++ b/web/js/lib/save-reply-identity.js
@@ -117,9 +117,29 @@ export function saveReplyIdentity(identity, { savedAs = false } = {}) {
  * Establishing it as part of the save closes that gap at the only moment the panel knows
  * the new instance and the caller does not. Deliberately NOT widened to every save: an
  * in-place save keeps the same object, whose identity is already established, so there is
- * nothing to mint and no reason to touch it. Only the case that strands a caller.
+ * nothing to mint and no reason to touch it. Only the cases that strand a caller.
+ *
+ * #978 recurrence — a FIRST save is one of those cases too, and scoping this to Save-As
+ * left it standing. A first save (never-persisted tab saved under a name) swaps the active
+ * object exactly like a Save-As: the successor is brand new, and nothing has established
+ * an identity for it either. The #557 carry was supposed to cover that case by threading
+ * the predecessor's uuid onto the successor — and on a healthy run it does. But the carry
+ * is deliberately fail-safe: any proof gap (a tab switch landing in the save's awaits, an
+ * unreadable openWorkflows list, a token mismatch on an unverified frontend) aborts it,
+ * and then the reply found nothing established and reported `workflow_identity_unavailable`
+ * — while the fence, whose own read mints, refused the very next call with the identity
+ * the reply had declined to publish. Measured on panel 0.14.41 / frontend 1.48.7: a first
+ * save of a new tab succeeded with `workflow_identity_unavailable: true` and the session
+ * stayed fenced to the pre-save instance until a manual re-target.
+ *
+ * The #716 objection does not apply here for the same reason it did not apply to Save-As:
+ * this establishes an identity for the record the SAVE ITSELF produced (the token- or
+ * event-proven output of the save transaction), never for whatever canvas happens to be
+ * active — so it is the mutation reporting its own result, not a read deciding what the
+ * canvas is. And it cannot collide with the carry: a record the carry already seeded reads
+ * as `alreadyEstablished` and is left alone.
  */
-export function shouldEstablishIdentityAfterSave({ savedAs = false, alreadyEstablished = false } = {}) {
+export function shouldEstablishIdentityAfterSave({ savedAs = false, firstSave = false, alreadyEstablished = false } = {}) {
   if (alreadyEstablished) return false;
-  return savedAs === true;
+  return savedAs === true || firstSave === true;
 }


### PR DESCRIPTION
## Root cause

The still-open half of #978 is the recurrence reported on panel 0.14.41 / comfyui-mcp 0.51.56 (frontend 1.48.7): a **first save** of a new tab (`panel_new_workflow` → build graph → `panel_save_workflow(name)`) succeeded with `workflow_identity_unavailable: true` and no instance identity, leaving the session fenced to the pre-save instance until a manual `panel_set_workflow_target({mode:"current"})`.

#941 gave a save reply the licence to *establish* the identity of the record the save itself produced — but scoped it to Save-As (`shouldEstablishIdentityAfterSave` required `savedAs === true`), on the assumption that a first save needs no mint because the #557 swap carry always threads the predecessor's uuid onto the successor. That assumption is the gap: the carry is deliberately **fail-safe** and aborts on any proof gap (a tab switch landing in the save's awaits, an unreadable `openWorkflows`, a produced-record token mismatch on an unverified frontend). When it aborts on a first save, the successor is a brand-new object with nothing established — the reply honestly reported "unavailable", while the fence's own minting read refused the very next call with the identity the reply had declined to publish. Same wedge as #941, one route over.

Staleness check: the save-identity path is unchanged since the reporter's 0.14.41 (verified: no commits to `web/js/lib/workflow-save.js` / `save-reply-identity.js` / the `saveProducedIdentity` wiring between v0.14.41 and current main). #1279 (0.14.44) made the fence *refresh* proactive, which heals the session after the fact — but the first-save reply still publishes nothing, which is the symptom the recurrence isolates.

## Fix

A first save swaps the active object exactly like a Save-As, so the same #941 licence now applies: `shouldEstablishIdentityAfterSave` accepts `firstSave`, and `workflow_save` / `workflow_save_as` pass `!!outcome.first_save` through `saveProducedIdentity`. The establish still:

- covers only the record the **save itself produced** (the token/event-proven output of the save transaction) — never whatever canvas happens to be active afterwards, so #716 is untouched;
- never mints over an identity the #557 carry already seeded (`alreadyEstablished` wins, so the healthy path is byte-identical to before);
- stays fail-closed for in-place saves and unknown shapes (no save kind, no mint);
- keeps reporting `workflow_identity_unavailable` honestly when there is no proven produced record at all.

## Verification

- `npm ci` — clean, 0 vulnerabilities
- `npm run test:unit` — 4941 pass / 0 fail / 1 todo, including the two new tests (a first save establishes when unestablished; a carry-seeded first save is left alone) and the updated wiring test pinning the `firstSave` flag through both save handlers
- `npm run typecheck` — clean

Not verified against the reporter's exact frontend (1.48.7): which carry proof gate fired there is not identified, and the fix is scoped to the consequence every one of those gates shares. When the produced record itself went unproven (token mismatch), the reply still reports absence — by design.

Closes #978