### PR TITLE
fix(886): an open refused on a properties difference names the keys that differ

### DIFF
--- a/browser_tests/unit/open-node-difference.test.mjs
+++ b/browser_tests/unit/open-node-difference.test.mjs
@@ -579,3 +579,150 @@ test("a duplicate on EITHER side alone is enough to refuse the comparison", () =
     assert.equal(out.sameNodeSet, false);
   }
 });
+
+// ── #886: a `properties` difference names the KEYS that moved ─────────────
+//
+// The last recurrences of #886 report opens refused on per-node `properties`
+// (and `widgets_values`) differences with the node set intact. `properties` is
+// one field name standing in for a whole bag of keys — a pack-version stamp the
+// frontend rewrote and an extension's stored settings read identically at the
+// field level, and the maintainer's per-key account of the rewrite cannot be
+// written until a report says WHICH keys moved. The verdict is deliberately
+// untouched; these pin that the disclosure now carries the keys.
+
+test("a properties difference names the differing keys inside it", () => {
+  const d = classifyNodeDifference({
+    expectedNodes: [node(1, "KSampler", { properties: { ver: "v0.3.64", cnr_id: "comfy-core" } })],
+    actualNodes: [node(1, "KSampler", { properties: { ver: "0.3.64", cnr_id: "comfy-core" } })],
+  });
+  assert.equal(d.sameNodeSet, true);
+  assert.equal(d.cosmeticOnly, false, "properties is not cosmetic — the verdict is untouched");
+  assert.deepEqual(d.fields, ["properties"]);
+  assert.deepEqual(d.propertyFields, ["ver"], "the KEY that moved is named, not just the field");
+});
+
+test("property keys union across nodes, sorted, and a matched properties bag names none", () => {
+  const d = classifyNodeDifference({
+    expectedNodes: [
+      node(1, "A", { properties: { ver: "v1", models: [{ name: "m", extra: 1 }] } }),
+      node(2, "B", { properties: { ver: "1" } }),
+    ],
+    actualNodes: [
+      node(1, "A", { properties: { ver: "1", models: [{ name: "m" }] } }),
+      node(2, "B", { properties: { ver: "1" } }),
+    ],
+  });
+  assert.deepEqual(d.fields, ["properties"], "node 2's properties matched — only node 1 differs");
+  assert.deepEqual(d.propertyFields, ["models", "ver"]);
+});
+
+test("a key present-as-undefined inside properties reads as ABSENT, same as a field", () => {
+  // JSON.stringify drops undefined values, so no saved file can carry one — a live
+  // in-memory properties bag holds keys no disk state can reproduce (#1001's rule,
+  // one level down).
+  const d = classifyNodeDifference({
+    expectedNodes: [node(1, "A", { properties: { ver: "1" } })],
+    actualNodes: [node(1, "A", { properties: { ver: "1", showAdvanced: undefined } })],
+  });
+  assert.deepEqual(d.fields, []);
+  assert.deepEqual(d.propertyFields, []);
+});
+
+test("an unreadable properties shape names the FIELD but no keys", () => {
+  // Fail closed in the direction that costs: a properties value the classifier
+  // cannot read keys out of must not invent a key list — and must not lose the
+  // field-level difference either.
+  for (const bad of [null, [1, 2], "string"]) {
+    const d = classifyNodeDifference({
+      expectedNodes: [node(1, "A", { properties: { ver: "1" } })],
+      actualNodes: [node(1, "A", { properties: bad })],
+    });
+    assert.deepEqual(d.fields, ["properties"], JSON.stringify(bad));
+    assert.deepEqual(d.propertyFields, [], "no keys are guessed at");
+  }
+});
+
+test("a wholly absent properties bag names no keys — absence is already the field difference", () => {
+  const d = classifyNodeDifference({
+    expectedNodes: [node(1, "A", { properties: { ver: "1" } })],
+    actualNodes: [node(1, "A")],
+  });
+  assert.deepEqual(d.fields, ["properties"]);
+  assert.deepEqual(d.propertyFields, []);
+});
+
+test("the open refusal names the differing property keys, so the report carries them", () => {
+  const msg = describeOpenRebindOutcome(CONTENT_ONLY, {
+    targetLabel: "origami.json",
+    contentComparable: true,
+    contentSurfaces: ["nodes"],
+    contentNodeDifference: {
+      comparable: true,
+      sameNodeSet: true,
+      cosmeticOnly: false,
+      fields: ["order", "properties", "size"],
+      propertyFields: ["ver"],
+    },
+  });
+  assert.match(msg, /no node was lost/i);
+  assert.match(msg, /order, properties, size/, "the fields are still named");
+  assert.match(msg, /within properties, the keys that differ are: ver/, "and now the keys are too");
+  assert.doesNotMatch(msg, /no missing work to redo/i, "the reassurance is NOT widened");
+});
+
+test("the key list is capped, and says how many were trimmed", () => {
+  const propertyFields = Array.from({ length: 14 }, (_, i) => `k${String(i).padStart(2, "0")}`);
+  const msg = describeOpenRebindOutcome(CONTENT_ONLY, {
+    targetLabel: "origami.json",
+    contentComparable: true,
+    contentSurfaces: ["nodes"],
+    contentNodeDifference: {
+      comparable: true,
+      sameNodeSet: true,
+      cosmeticOnly: false,
+      fields: ["properties"],
+      propertyFields,
+    },
+  });
+  assert.match(msg, /k00/, "the first keys are named");
+  assert.match(msg, /and 4 more/, "the trim is disclosed, not silent");
+  assert.doesNotMatch(msg, /k13/, "a hostile properties bag cannot grow the clause without bound");
+});
+
+test("an empty key list adds no empty clause — an unreadable shape reads exactly as before", () => {
+  const msg = describeOpenRebindOutcome(CONTENT_ONLY, {
+    targetLabel: "origami.json",
+    contentComparable: true,
+    contentSurfaces: ["nodes"],
+    contentNodeDifference: {
+      comparable: true,
+      sameNodeSet: true,
+      cosmeticOnly: false,
+      fields: ["properties"],
+      propertyFields: [],
+    },
+  });
+  assert.match(msg, /what differs is per-node \(properties\)\. A widget value/);
+  assert.doesNotMatch(msg, /keys that differ/, "no keys were read, so none are claimed");
+});
+
+test("the key detail rides the real pipeline, not a hand-built shape", () => {
+  // describeGraphStateDifference -> contentNodeDifference -> the clause, with the
+  // classifier producing propertyFields itself.
+  const state = {
+    nodes: [node(1, "KSampler", { properties: { ver: "v0.3.64" }, widgets_values: [1] })],
+  };
+  const diff = describeGraphStateDifference({
+    rootGraph: rootOf([node(1, "KSampler", { properties: { ver: "0.3.64" }, widgets_values: [1] })]),
+    state,
+  });
+  assert.deepEqual(diff.nodeDifference?.propertyFields, ["ver"]);
+  const msg = describeOpenRebindOutcome(CONTENT_ONLY, {
+    targetLabel: "origami.json",
+    contentComparable: diff.comparable,
+    contentSurfaces: diff.surfaces,
+    contentAccountedSurfaces: diff.accountedSurfaces,
+    contentNodeDifference: diff.nodeDifference,
+  });
+  assert.match(msg, /the keys that differ are: ver/);
+});

--- a/browser_tests/unit/open-rebind-proof.test.mjs
+++ b/browser_tests/unit/open-rebind-proof.test.mjs
@@ -401,7 +401,7 @@ test("describeGraphStateDifference: names the surfaces that disagreed, and only 
     surfaces: ["nodes"],
     accountedSurfaces: [],
     // #825 — a DROPPED node: same-set must be false, and never "cosmetic".
-    nodeDifference: { comparable: true, sameNodeSet: false, cosmeticOnly: false, fields: [] },
+    nodeDifference: { comparable: true, sameNodeSet: false, cosmeticOnly: false, fields: [], propertyFields: [] },
   });
 
   const groupsDiffer = structuredClone(state);

--- a/web/js/lib/graph-binding.js
+++ b/web/js/lib/graph-binding.js
@@ -622,17 +622,22 @@ function nodeIdentityKey(node) {
  * `unknown` either way, deliberately. It makes the DISCLOSURE say which of the two
  * it observed, because they send a reader to opposite places.
  *
- * Returns `{ comparable, sameNodeSet, cosmeticOnly, fields }`:
+ * Returns `{ comparable, sameNodeSet, cosmeticOnly, fields, propertyFields }`:
  *  - `sameNodeSet` — every loaded node is present with the same id AND type, and
  *    no extra ones appeared. Nothing was dropped, added or retyped.
  *  - `cosmeticOnly` — sameNodeSet AND every per-node difference is confined to
  *    COSMETIC_NODE_FIELDS. This is the "the frontend re-measured it" case.
  *  - `fields` — the per-node keys that actually differed, so the disclosure can
  *    name them instead of asking the reader to guess.
+ *  - `propertyFields` — when `properties` is one of those fields, the keys INSIDE
+ *    it that differed (#886). One field name covers both a pack-version stamp the
+ *    frontend rewrote and an extension's stored settings; the disclosure needs
+ *    the keys to tell the reader which. Empty when properties matched or its
+ *    shape was unreadable — no keys are named rather than guessed at.
  * Anything unreadable is `comparable:false` and asserts nothing.
  */
 export function classifyNodeDifference({ expectedNodes, actualNodes } = {}) {
-  const NOT_COMPARABLE = { comparable: false, sameNodeSet: false, cosmeticOnly: false, fields: [] };
+  const NOT_COMPARABLE = { comparable: false, sameNodeSet: false, cosmeticOnly: false, fields: [], propertyFields: [] };
   if (!Array.isArray(expectedNodes) || !Array.isArray(actualNodes)) return NOT_COMPARABLE;
   try {
     const byKey = (list) => {
@@ -683,18 +688,39 @@ export function classifyNodeDifference({ expectedNodes, actualNodes } = {}) {
     const has = (node, field) =>
       Object.prototype.hasOwnProperty.call(node, field) && node[field] !== undefined;
     const fields = new Set();
+    // #886 — `properties` is one field name standing in for a whole bag of keys, and
+    // the difference between a benign one (a pack-version stamp the frontend rewrote)
+    // and a real one (an extension's stored settings) is WHICH KEYS moved. The open
+    // refusal names the field; name the keys too, so the reader can judge and the
+    // report carries the measurement a per-key account would need. Same discipline as
+    // the field comparison above: presence before value, `undefined` is absent. Only
+    // when BOTH sides are readable objects — anything else names no keys rather than
+    // guessing, exactly as an unreadable node set asserts nothing.
+    const propertyFields = new Set();
+    const readableProps = (v) => v !== null && typeof v === "object" && !Array.isArray(v);
 
     for (const [key, expectedNode] of expected) {
       const actualNode = actual.get(key);
       const keys = new Set([...Object.keys(expectedNode), ...Object.keys(actualNode)]);
       for (const field of keys) {
-        if (has(expectedNode, field) !== has(actualNode, field)) {
-          fields.add(field);
-          continue;
-        }
+        const present = has(expectedNode, field) === has(actualNode, field);
         const a = JSON.stringify(canonicalizeShapeValue(expectedNode[field]));
         const b = JSON.stringify(canonicalizeShapeValue(actualNode[field]));
-        if (a !== b) fields.add(field);
+        if (present && a === b) continue;
+        fields.add(field);
+        if (field !== "properties") continue;
+        const before = expectedNode.properties;
+        const after = actualNode.properties;
+        if (!readableProps(before) || !readableProps(after)) continue;
+        for (const propKey of new Set([...Object.keys(before), ...Object.keys(after)])) {
+          if (has(before, propKey) !== has(after, propKey)) {
+            propertyFields.add(propKey);
+            continue;
+          }
+          const pa = JSON.stringify(canonicalizeShapeValue(before[propKey]));
+          const pb = JSON.stringify(canonicalizeShapeValue(after[propKey]));
+          if (pa !== pb) propertyFields.add(propKey);
+        }
       }
     }
     const list = [...fields].sort();
@@ -703,6 +729,7 @@ export function classifyNodeDifference({ expectedNodes, actualNodes } = {}) {
       sameNodeSet: true,
       cosmeticOnly: list.length > 0 && list.every((field) => COSMETIC_NODE_FIELDS.has(field)),
       fields: list,
+      propertyFields: [...propertyFields].sort(),
     };
   } catch {
     return NOT_COMPARABLE;
@@ -1644,6 +1671,21 @@ function nodeSurfaceClause(observed = {}) {
     );
   }
   const fields = (diff.fields ?? []).join(", ") || "no readable field";
+  // #886 — when `properties` is among the differing fields, name the KEYS that
+  // differ inside it. "properties" alone sends the reader to re-read the whole
+  // graph for what may be a rewritten pack-version stamp; the keys are the
+  // difference between that and an extension's stored settings, and naming them
+  // is what turns the next report of this shape into the measurement a per-key
+  // account could be written from. Capped, so a hostile properties bag cannot
+  // grow this clause without bound; the cap only trims the LIST, never the
+  // verdict, which this clause does not touch.
+  const propertyKeys = Array.isArray(diff.propertyFields) ? diff.propertyFields : [];
+  const namedKeys = propertyKeys.slice(0, 10).join(", ");
+  const keyDetail =
+    diff.fields?.includes("properties") && namedKeys
+      ? `; within properties, the keys that differ are: ${namedKeys}` +
+        (propertyKeys.length > 10 ? `, and ${propertyKeys.length - 10} more` : "")
+      : "";
   if (diff.cosmeticOnly) {
     // States the NODE observation and stops. The overall "nothing to redo"
     // conclusion is the headline's to draw, and only when `nodes` is the sole
@@ -1661,7 +1703,7 @@ function nodeSurfaceClause(observed = {}) {
   }
   return (
     ` — every node that was loaded IS on the canvas with the same id and type and nothing extra ` +
-    `appeared, so no node was lost; what differs is per-node (${fields}). A widget value is real ` +
+    `appeared, so no node was lost; what differs is per-node (${fields})${keyDetail}. A widget value is real ` +
     `content, so read it (panel_graph_outline) before assuming either way`
   );
 }


### PR DESCRIPTION
Reported in #886 — `panel_open_workflow` keeps reporting UNCONFIRMED on opens whose only differences are per-node `properties` / `widgets_values`, and the thread's blocker for two months has been that nobody can say WHICH keys moved.

## Where the issue stands on current main

Most of #886 is already fixed and released, and this PR does not re-litigate any of it:

- a `definitions` difference that is pure link renumbering is accounted for (#1125, 0.14.20)
- an open where only presentation moved reports applied, with the fields disclosed (#1274, 0.14.44)
- an accounted `definitions` surface no longer blocks the reassurance (#1252/#1291, 0.14.44)

The two most recent recurrences (2026-08-15, panel 0.14.42 and 0.14.43) both predate those releases, but each names a difference set that still refuses on main **deliberately**: per-node `properties` (with `size`/`order`) in one, `size` + `widgets_values` in the other. `properties` and `widgets_values` are outside every allowlist for the reason recorded in `resolveOpenRebindVerdict` — a mid-`configure()` partial load drops exactly those fields, and nothing the panel can see separates that from the frontend normalizing them.

## Root cause of the remaining cost

The refusal names the differing **fields** (`properties, size, order`) but `properties` is one field name standing in for a whole bag of keys. A rewritten pack-version stamp (`ver`) and an extension's stored settings read identically at the field level, so the reader cannot judge the refusal, and the automated reports pasted onto #886 cannot answer the question the thread keeps asking: *which keys inside `properties` does the frontend normalize?* I checked the obvious candidate before writing this — in comfyui_frontend_package 1.48.7 the only generic `properties` transform (zod validation's `ver` leading-`v` strip) is gated behind `Comfy.Validation.Workflows`, which **defaults to false** — so on default installs these differences come from node-pack constructors and `loadedGraphNode` hooks, which cannot be allowlisted blind. The maintainers' measured-key requirement stands, and this change exists to produce exactly that measurement.

## The change — disclosure only, verdict untouched

`classifyNodeDifference` now also returns `propertyFields`: when `properties` is among the differing per-node fields and both sides are readable objects, the keys INSIDE `properties` that differ, computed with the same discipline as the field comparison (presence before value, `undefined` is absent, anything unreadable names no keys). `nodeSurfaceClause` appends them to the refusal:

> what differs is per-node (order, properties, size)**; within properties, the keys that differ are: ver**. A widget value is real content, so read it (panel_graph_outline) before assuming either way

The list is capped at 10 keys with the trim disclosed (", and N more"), so a hostile properties bag cannot grow the clause without bound.

Nothing else moves: `CONTENT_UNVERIFIED` still throws, the fence is still withheld, `widgets_values` stays outside both allowlists, and an unreadable `properties` shape names the field but no keys — fail closed, same as an unreadable node set.

## What this deliberately does NOT do

- It does not admit `properties` or `widgets_values` into `COSMETIC_NODE_FIELDS` or `RECOMPUTED_NODE_FIELDS`. Without a per-key measurement that would be the fabricated all-clear this guard exists to avoid — and my source check above shows the reporters' differences are not the one transform the frontend documents.
- It does not change the reassurance tiers: a non-cosmetic difference still gets "no node was lost" and never "no missing work to redo".

## Verification

- `npm run test:unit` — **4949 tests, 4948 pass, 0 fail, 1 pre-existing todo**; i18n, i18n-render, tool-vocabulary and panel-scope gates all OK.
- `npm run typecheck` — clean.
- 9 new tests in `open-node-difference.test.mjs` (this file's style), including: the key union across nodes, `undefined`-is-absent one level down, unreadable/absent `properties` naming no keys, the refusal sentence carrying the keys, the cap disclosing its trim, and the full pipeline (`describeGraphStateDifference` → `describeOpenRebindOutcome`) rather than a hand-built shape. One existing whole-shape assertion in `open-rebind-proof.test.mjs` gained `propertyFields: []` for the additive field.
- Not done: no live-rig reproduction (no ComfyUI instance was available where this was built) — the change is disclosure-only, so nothing it ships can soften a verdict untested.

Closes #886
