### PR TITLE
fix(1187): a structural hand edit inside the tracker's capture lag no longer refuses the workflow's own canvas

### DIFF
--- a/browser_tests/unit/graph-binding.test.mjs
+++ b/browser_tests/unit/graph-binding.test.mjs
@@ -24,6 +24,7 @@ import {
   graphRootMidPopulation,
   graphRootMismatchesActiveWorkflow,
   graphRootContentDriftOnBoundCanvas,
+  graphRootStructureExtendsActiveWorkflow,
   graphRootProvenEmpty,
   graphRootWorkflowUuidMismatches,
   graphRootWorkflowUuidMatches,
@@ -850,6 +851,171 @@ test("#696: a CONFLICTING identity tag still refuses ahead of any content reason
     "the relaxation demands a MATCH, and a foreign tag is the #349 wrong-canvas case",
   );
   assert.equal(driftVerdict(fixture, { rootUuidMismatch: true })?.reason, "root-workflow-uuid-mismatch");
+});
+
+// ── #1187 — A STRUCTURAL HAND EDIT INSIDE THE TRACKER'S CAPTURE LAG ───────────
+//
+// ChangeTracker captures on USER INPUT events, so a node added or a wire dropped
+// by hand leaves `activeState` one capture behind the live canvas while
+// `isModified` has NOT flipped. In that window the equality relaxation above is
+// unreachable — the edit differs structurally by definition — and before this fix
+// every graph read and mutation refused the workflow's OWN canvas until the
+// tracker happened to capture. The rescue is containment, not equality: the live
+// root must still hold every node and link the workflow's own state carries, so
+// the admitted canvas can never be missing anything the workflow owns.
+test("#1187: a node ADDED by hand before the tracker captures is the right canvas, not a refusal", () => {
+  const fixture = driftFixture({
+    drift: (nodes) => {
+      nodes.push({ id: 4, type: "PreviewImage" }); // the hand edit: 3 -> 4 nodes
+    },
+  });
+  assert.equal(
+    graphRootMismatchesActiveWorkflow({ rootGraph: fixture.rootGraph, activeWorkflow: fixture.activeWorkflow }),
+    true,
+    "the content comparator still sees the lag — that difference is real",
+  );
+  assert.equal(
+    graphRootStructureExtendsActiveWorkflow(fixture),
+    true,
+    "…but the live root still CONTAINS every node and link the workflow's own state carries",
+  );
+  assert.equal(
+    driftVerdict(fixture),
+    null,
+    "the reported case (saved 98, live 99, matching tag) must not refuse the read",
+  );
+});
+
+test("#1187: an added node WIRED into the graph is permitted — the state's links all survive", () => {
+  const fixture = driftFixture({
+    drift: (nodes, state) => {
+      nodes.push({ id: 4, type: "PreviewImage" });
+      state.links.push([2, 3, 2, 4, 0, "IMAGE"]); // the wire to the new node
+    },
+  });
+  assert.equal(graphRootStructureExtendsActiveWorkflow(fixture), true);
+  assert.equal(driftVerdict(fixture), null);
+});
+
+test("#1187: a wire added between two EXISTING nodes is permitted — links are containment, not equality", () => {
+  const fixture = driftFixture({
+    drift: (nodes, state) => {
+      state.links.push([2, 1, 0, 3, 3, "CLIP"]); // no new node, one new link
+    },
+  });
+  assert.equal(graphRootStructureExtendsActiveWorkflow(fixture), true);
+  assert.equal(driftVerdict(fixture), null);
+});
+
+test("#1187: a hand REMOVAL still refuses in the lag window — containment must never under-report", () => {
+  // The deliberate bound: live ⊆ state would admit a canvas MISSING content the
+  // workflow owns (the count-short read is the #618 lesson), so removals and
+  // link deletions keep refusing until the tracker captures and the refusal
+  // self-clears.
+  const nodeRemoved = driftFixture({
+    drift: (nodes, state) => {
+      state.nodes = nodes.slice(1);
+    },
+  });
+  assert.equal(graphRootStructureExtendsActiveWorkflow(nodeRemoved), false);
+  assert.equal(driftVerdict(nodeRemoved)?.reason, "root-shape-mismatch");
+
+  const linkRemoved = driftFixture({
+    drift: (nodes, state) => {
+      state.links = [];
+    },
+  });
+  assert.equal(graphRootStructureExtendsActiveWorkflow(linkRemoved), false);
+  assert.equal(driftVerdict(linkRemoved)?.reason, "root-shape-mismatch");
+});
+
+test("#1187: a difference in any OTHER structural surface is not the hand edit and still refuses", () => {
+  // Adding a node does not rewrite groups, reroutes, subgraphs, definitions or
+  // content-bearing extra — those surfaces stay EQUAL under the rescue, so the
+  // #696 structural refusals are untouched.
+  const cases = {
+    "a group changed": (nodes, state) => {
+      nodes.push({ id: 4, type: "PreviewImage" });
+      state.groups = [{ title: "OTHER", bounding: [0, 0, 10, 10] }];
+    },
+    "a reroute appeared": (nodes, state) => {
+      nodes.push({ id: 4, type: "PreviewImage" });
+      state.reroutes = [{ id: "r1", pos: [1, 2] }];
+    },
+    "a top-level subgraph appeared": (nodes, state) => {
+      nodes.push({ id: 4, type: "PreviewImage" });
+      state.subgraphs = [{ id: "s1", nodes: [{ id: 7, type: "SaveImage" }] }];
+    },
+  };
+  for (const [label, drift] of Object.entries(cases)) {
+    const fixture = driftFixture({ drift });
+    assert.equal(graphRootStructureExtendsActiveWorkflow(fixture), false, label);
+    assert.ok(driftVerdict(fixture), `${label} must still be refused`);
+  }
+});
+
+test("#1187: the rescue still demands POSITIVE identity — an untagged or foreign-tagged root refuses", () => {
+  // Same conjunct discipline as the equality relaxation: containment is never
+  // trusted without the workflow's own stamp, because two canvases can both
+  // contain a shared structure.
+  const additive = (nodes) => {
+    nodes.push({ id: 4, type: "PreviewImage" });
+  };
+  const untagged = driftFixture({ rootUuid: null, drift: additive });
+  assert.equal(graphRootStructureExtendsActiveWorkflow(untagged), true, "the content proof itself runs");
+  assert.equal(driftVerdict(untagged)?.reason, "root-shape-mismatch", "…but without identity it proves nothing");
+
+  const foreign = driftFixture({ rootUuid: "bbbbbbbb-2222-4222-8222-bbbbbbbbbbbb", drift: additive });
+  assert.equal(driftVerdict(foreign)?.reason, "root-shape-mismatch");
+});
+
+test("#1187: a count-SHORT canvas is not containment — the mid-restore window stays refused", () => {
+  // The other direction of the bound: a restoring root holding a PREFIX of the
+  // workflow's nodes contains none of what the state carries beyond it, so this
+  // rescue cannot mask #618's mid-population signature.
+  const fixture = driftFixture({
+    drift: (nodes, state) => {
+      state.nodes = nodes.slice(0, 1);
+    },
+  });
+  fixture.rootGraph._nodes = [{ id: 1, type: "CheckpointLoaderSimple" }];
+  assert.equal(graphRootStructureExtendsActiveWorkflow(fixture), false);
+  assert.equal(driftVerdict(fixture, { postReconnectWindow: true })?.reason, "root-mid-population");
+});
+
+test("#1187: an unreadable comparison fails closed, never relaxes", () => {
+  const fixture = driftFixture({
+    drift: (nodes) => {
+      nodes.push({ id: 4, type: "PreviewImage" });
+    },
+  });
+  fixture.rootGraph = {
+    ...fixture.rootGraph,
+    serialize: () => {
+      throw new Error("serializer unavailable");
+    },
+  };
+  assert.equal(graphRootStructureExtendsActiveWorkflow(fixture), false);
+  assert.ok(driftVerdict(fixture), "an uncompleted comparison is not containment");
+  assert.equal(graphRootStructureExtendsActiveWorkflow(), false, "no arguments ⇒ no relaxation");
+  assert.equal(graphRootStructureExtendsActiveWorkflow({}), false);
+});
+
+test("#1187: the first node on a blank, tagged workflow is permitted — blank state is trivially contained", () => {
+  // The edge where the workflow's own state is EMPTY: every blank canvas
+  // satisfies containment, so identity alone separates this from any other
+  // blank-rooted tab — and #570 mints that identity at creation, including
+  // new-blank. With the tag matching, the user's first node must not refuse.
+  const fixture = driftFixture({
+    drift: (nodes, state) => {
+      state.nodes = [{ id: 1, type: "CheckpointLoaderSimple", widgets_values: ["anime.safetensors"] }];
+      state.links = [];
+      state.groups = [];
+    },
+  });
+  fixture.activeWorkflow = wf({ isModified: false, changeTracker: { activeState: { nodes: [] } } });
+  assert.equal(graphRootStructureExtendsActiveWorkflow(fixture), true);
+  assert.equal(driftVerdict(fixture), null);
 });
 
 test("#618: a mid-restore canvas is count-short, so the relaxation cannot mask it", () => {

--- a/docs/design/graph-binding-tag-vs-tracker.md
+++ b/docs/design/graph-binding-tag-vs-tracker.md
@@ -1,6 +1,7 @@
 # `root-shape-mismatch`: why the root tag cannot be trusted, and why settling the tracker cannot verify
 
-**Status:** NEGATIVE RESULT — no fix shipped · **Issue:** artokun/comfyui-mcp-panel#1187 ·
+**Status:** RESOLVED — third attempt shipped (additive structural containment + the identity
+conjunct, `graphRootStructureExtendsActiveWorkflow`) · **Issue:** artokun/comfyui-mcp-panel#1187 ·
 **Investigated on:** `fix/1187-root-tag-outranks-tracker` (PR #1212) · **Last re-verified:** 2026-08-14
 
 This records two fixes that were **built, reviewed and rejected**. It exists so the third
@@ -147,6 +148,48 @@ A narrower option that leg 3 above does **not** rule out: keep the structure con
 attack the *staleness of the comparison input* instead — but note that attempt 2 is the
 obvious form of that idea and it fails, so any variant has to show how it avoids flipping
 `isModified` before the comparison is re-read.
+
+## What shipped (the third attempt)
+
+`graphRootStructureExtendsActiveWorkflow`, consulted as a second disjunct beside
+`structureMatches` — still only ever as a **conjunct of the identity tag**:
+
+```js
+const rootShapeMismatch =
+  contentDiffers &&
+  !((structureMatches || structureExtends) &&
+    graphRootWorkflowUuidMatches({ rootGraph, activeWorkflowUuid }));
+```
+
+The content proof is **containment, not equality**: every node and link the workflow's own
+current state carries must be present on the live root, and every other structural surface
+must be equal — while the live root may carry *more*. A hand edit inside the capture lag is
+exactly "the workflow's structure plus the edit", which equality can never see and
+containment can. Neither rejected mechanism is used: the tag is never trusted alone (the
+containment proof is demanded alongside it, and no foreign canvas satisfies it), and the
+tracker is never settled (nothing captures, `isModified` is never flipped by the check).
+
+The bounds, stated plainly:
+
+- **Additions only.** A hand *removal* in the lag window still refuses and self-clears on
+  the next capture, because the mirror relation (live ⊆ state) would admit a canvas
+  **missing** content the workflow owns — the under-reporting direction (#618's lesson).
+  An admitted canvas always holds everything the workflow owns.
+- **Leg 3's bound widens from "still structurally A" to "structurally A plus additions"**:
+  a sealed closed-duplicate's stranded canvas that then gains nodes keeps its reads. That
+  widening is not avoidable by any fix — *"the user added a node to A"* and *"the sealed
+  duplicate gained the same node"* are observationally identical to every signal the panel
+  has — and it is the same ambiguity the equality relaxation's own comment already accepts
+  knowingly for content drift, bounded in the direction that matters: nothing A owns can
+  be absent from an admitted canvas.
+- The #1014 dependency this document predicted does **not** block this fix: #1187's
+  reporter has a published UUID to anchor the identity conjunct. #1014 remains the
+  no-anchor case and is untouched by it.
+
+Verified by mutation, not only by the suite: deleting the disjunct, forcing containment
+true, dropping the link-containment clause, and dropping the surface-equality clause each
+turn targeted tests red (the pre-existing #696 structural-refusal test catches the last
+two as well).
 
 ## What the verification did and did not prove
 

--- a/web/js/lib/graph-binding.js
+++ b/web/js/lib/graph-binding.js
@@ -1340,6 +1340,100 @@ export function graphRootStructureMatchesActiveWorkflow({ rootGraph, activeWorkf
 }
 
 /**
+ * #1187 — does the live root still CONTAIN the active workflow's whole structure?
+ * Every node the workflow's own current state carries is present with the same id
+ * and type, every one of its links survives, and each remaining structural surface
+ * (floating links, reroutes, groups, config, top-level subgraphs, definitions,
+ * content-bearing extra) is EQUAL. The live root may carry MORE — extra nodes and
+ * extra links — and that is the whole point:
+ *
+ * ChangeTracker captures on user-input events, so a structural HAND EDIT (a node
+ * added, a wire dropped) leaves `activeState` one capture behind the canvas while
+ * `isModified` has not flipped. In that window `graphRootStructureMatchesActive-
+ * Workflow` is false BY DEFINITION — the edit differs structurally — so the
+ * equality relaxation above can never rescue the read, and every graph tool
+ * refuses the workflow's own canvas until the tracker happens to capture. That
+ * window is exactly "the live root is the workflow's structure PLUS the edit",
+ * which this predicate proves from content alone.
+ *
+ * Why the addition-only direction, and why each clause is load-bearing:
+ *
+ *   CONTAINMENT, not intersection. An admitted canvas holds EVERY node and link
+ *   the workflow owns, unaltered — a read served from it can never under-report
+ *   the workflow (the count-short read is the #618 lesson, and a canvas missing
+ *   the workflow's content is what the whole guard exists to refuse). The mirror
+ *   relation — live ⊆ state, a hand REMOVAL still in the lag window — would admit
+ *   exactly that under-reporting canvas, so removals keep refusing here and
+ *   self-clear when the tracker captures. Deliberate, and disclosed in the PR.
+ *
+ *   Non-node/link surfaces stay EQUAL. Adding a node or a wire does not rewrite
+ *   groups, reroutes, subgraphs, definitions or extra, so a canvas that differs
+ *   there is not "A plus an edit" and stays refused, exactly as under the
+ *   equality relaxation.
+ *
+ *   Fail closed on an unreadable side, like every predicate in this module: a
+ *   comparison that could not run is not containment.
+ *
+ * IDENTITY IS STILL A SEPARATE CONJUNCT — this predicate is consulted only
+ * alongside `graphRootWorkflowUuidMatches`, so the stale-tag legs recorded in
+ * docs/design/graph-binding-tag-vs-tracker.md are answered the same way the
+ * equality relaxation answers them: the tag is never trusted alone, and the
+ * content proof demanded here is one no foreign canvas satisfies (a different
+ * workflow does not contain this one's node ids and links). The known residual
+ * is the seal's closed-duplicate gap, widened from "still structurally A" to
+ * "structurally A plus additions": a stranded duplicate canvas that already
+ * carries A's tag and then gains nodes keeps its reads. That is the same
+ * ambiguity `graphRootContentDriftOnBoundCanvas`'s comment accepts knowingly —
+ * the two canvases are observationally identical to every signal the panel has,
+ * and #1187 cannot be fixed without admitting the edit — while the bound still
+ * holds in the direction that matters: nothing A owns can be absent.
+ */
+export function graphRootStructureExtendsActiveWorkflow({ rootGraph, activeWorkflow } = {}) {
+  try {
+    const expected = buildGraphStructureShape(activeWorkflowCurrentState(activeWorkflow));
+    if (expected == null) return false;
+    let actual = null;
+    try {
+      actual = buildGraphStructureShape(rootGraph?.serialize?.());
+    } catch {
+      return false;
+    }
+    if (actual == null) return false;
+    // Nodes: containment by identity (id + type), the same identity
+    // buildGraphStructureShape establishes — type-qualified, so numeric 1 and
+    // string "1" still cannot collide.
+    const actualNodes = new Set(actual.nodes.map((node) => JSON.stringify([node.id, node.type])));
+    for (const node of expected.nodes) {
+      if (!actualNodes.has(JSON.stringify([node.id, node.type]))) return false;
+    }
+    // Links: every link the workflow's state carries must survive on the live
+    // root; the live root may carry extra ones (a wire to the node just added).
+    // A links surface that is present but not an array is malformed — fail closed.
+    const linkSet = (surface) => {
+      if (!surface.present) return new Set();
+      if (!Array.isArray(surface.value)) return null;
+      return new Set(surface.value.map((link) => JSON.stringify(canonicalizeShapeValue(link))));
+    };
+    const expectedLinks = linkSet(expected.links);
+    const actualLinks = linkSet(actual.links);
+    if (expectedLinks == null || actualLinks == null) return false;
+    for (const link of expectedLinks) {
+      if (!actualLinks.has(link)) return false;
+    }
+    // Everything else that identifies a workflow must be EQUAL — an added node
+    // does not touch these surfaces, so a difference here is not the hand edit
+    // this relaxation exists for.
+    const restOf = (shape) => {
+      const { nodes, links, ...rest } = shape;
+      return JSON.stringify(canonicalizeShapeValue(rest));
+    };
+    return restOf(actual) === restOf(expected);
+  } catch {
+    return false;
+  }
+}
+
+/**
  * True only when a root graph carries a durable workflow UUID that conflicts
  * with the active workflow object's already-established UUID. Missing identity
  * on either side is inconclusive: older frontends and first observation must
@@ -2413,22 +2507,28 @@ export function resolveGraphBindingVerdict({
   // "a different graph" from "this graph, drifted, with no identity stamp", and
   // the old message resolved that ambiguity by asserting the worse one.
   //
-  // #1187 — BEFORE YOU RELAX THE `structureMatches` CONJUNCT BELOW, read
-  // docs/design/graph-binding-tag-vs-tracker.md. A structural hand edit makes
-  // `structureMatches` false by definition, so a matching tag cannot rescue the read,
-  // and that refusal is a real reported bug. Two fixes for it were built, reviewed and
-  // REJECTED P0 — dropping the conjunct (a stale tag then permits writes to a canvas
-  // this workflow does not own, see the seal's closed-duplicate gap above), and
-  // settling the tracker first (the capture flips `isModified`, which SUPPRESSES
-  // `graphRootMismatchesActiveWorkflow`'s comparison rather than satisfying it — that
-  // function returns false outright on a dirty tab). Both passed the full unit
-  // suite; one was mutation-verified. The suite does not cover either hazard.
+  // #1187 — the `structureMatches` conjunct alone cannot rescue a structural HAND
+  // EDIT: adding a node or a wire makes the structural comparison false by
+  // definition, so on a clean tab inside ChangeTracker's capture lag the
+  // workflow's own identity stamp never rescued the read and every graph tool
+  // refused the right canvas (docs/design/graph-binding-tag-vs-tracker.md records
+  // the two rejected fixes — dropping the conjunct, settling the tracker — and why
+  // both fail open). What rescues it instead is a CONTENT proof with the same
+  // conjunct discipline: the live root must still CONTAIN the workflow's whole
+  // structure (`graphRootStructureExtendsActiveWorkflow`), so nothing the workflow
+  // owns can be absent from a canvas this admits, and the identity tag is never
+  // trusted without it.
   const contentDiffers = graphRootMismatchesActiveWorkflow({ rootGraph, activeWorkflow });
   const structureMatches =
     contentDiffers && graphRootStructureMatchesActiveWorkflow({ rootGraph, activeWorkflow });
+  const structureExtends =
+    contentDiffers &&
+    structureMatches !== true &&
+    graphRootStructureExtendsActiveWorkflow({ rootGraph, activeWorkflow });
   const rootShapeMismatch =
     contentDiffers &&
-    !(structureMatches && graphRootWorkflowUuidMatches({ rootGraph, activeWorkflowUuid }));
+    !((structureMatches || structureExtends) &&
+      graphRootWorkflowUuidMatches({ rootGraph, activeWorkflowUuid }));
   const currentStateTrustworthy = activeWorkflow?.isModified !== true;
   const baselineReadDesync =
     currentStateTrustworthy &&


### PR DESCRIPTION
Closes #1187. Implements the third attempt the merged diagnostic spec (`docs/design/graph-binding-tag-vs-tracker.md`, PR #1212) pointed at, using neither of the two rejected mechanisms.

## Root cause

`resolveGraphBindingVerdict` consulted the positive root tag only as a conjunct of `structureMatches`, and a structural hand edit (a node added, a wire dropped) makes `structureMatches` false **by definition**. ComfyUI's ChangeTracker captures on user-input events (verified against frontend 1.48.6 `changeTracker.ts`: keydown/keyup, mouseup, `processMouseUp`, context-menu close — never synchronously on graph mutation), so there is a window where `activeState` reports the old graph, the live root reports the new one, and `isModified` has not flipped — the dirty-tab escape hatch does not fire either. In that window every graph read and mutation refused the workflow's own canvas (`root-shape-mismatch`), self-clearing on the next capture, which is why it presented as intermittent.

## The fix — containment, not equality, still conjuncted with identity

New pure predicate `graphRootStructureExtendsActiveWorkflow` in `web/js/lib/graph-binding.js`, added as a second disjunct beside `structureMatches`:

```js
const rootShapeMismatch =
  contentDiffers &&
  !((structureMatches || structureExtends) &&
    graphRootWorkflowUuidMatches({ rootGraph, activeWorkflowUuid }));
```

The content proof is **containment**: every node the workflow's own current state carries is present on the live root with the same id and type, every one of its links survives, and each remaining structural surface (floating links, reroutes, groups, config, top-level subgraphs, definitions, content-bearing extra) is **equal** — while the live root may carry *more*. A hand edit inside the capture lag is exactly "the workflow's structure plus the edit", which equality can never see and containment can.

How it answers the spec's rejection legs:

- **Attempt 1's P0 (trusting the tag) is not repeated.** The tag is never consulted alone; the containment proof is content evidence no foreign canvas satisfies (a different workflow does not contain this one's node ids and links). On the #565/#817 builds where a stale tag can sit on canvas B, B does not contain A's structure, so the rescue does not fire — it does not rely on the tag being fresh.
- **Attempt 2's P0 (settling the tracker) is not repeated.** Nothing captures; `isModified` is never flipped by the check, so the comparison is not suppressed, no undo entry is pushed, and no redo queue is cleared by a read.
- **Leg 3 (the seal's closed-duplicate gap)** is answered by the direction of the bound. An admitted canvas must hold *everything the workflow owns*, so a read served through it can never under-report the workflow (the count-short read is #618's lesson). The gap's bound widens from "still structurally A" to "structurally A plus additions" — a sealed stranded duplicate that then gains nodes keeps its reads. That widening is unavoidable for *any* fix: "the user added a node to A" and "the sealed duplicate gained the same node" are observationally identical to every signal the panel has. It is the same ambiguity the #696 relaxation's own comment already accepts knowingly for content drift.

## Deliberate bounds (disclosed, not hidden)

- **Additions only.** A hand *removal* inside the lag window still refuses and self-clears on the next capture: the mirror relation (live ⊆ state) would admit a canvas missing content the workflow owns — the under-reporting direction this module exists to prevent.
- **Non-node/link surfaces stay equal.** A canvas that differs in groups, reroutes, subgraphs, definitions or extra is not "A plus an edit" and stays refused — the #696 structural refusals are untouched (its test suite entry proves it).
- **Fail closed.** An unreadable serializer or tracker state on either side is not containment.
- The #1014 dependency the spec predicted does not block this fix: #1187's reporter has a published UUID anchoring the identity conjunct. #1014 (the no-anchor case) is untouched.

## Verification

- `npm ci` — clean, 0 vulnerabilities.
- `node --test browser_tests/unit/graph-binding.test.mjs` — 143/143 pass, including 9 new `#1187` tests (add, wired add, link-only add, removal-refuses, other-surfaces-refuse, untagged/foreign-tag-refuses, count-short-refuses, unreadable-fails-closed, blank-workflow-first-node).
- `npm run test:unit` (full suite incl. i18n/vocabulary/scope checks) — 4967 pass, 0 fail, 1 todo.
- `npm run typecheck` (`tsc --noEmit`) — clean.
- **Mutation-verified** (the spec's own warning that a green suite is not proof): (1) deleting the `structureExtends` disjunct → the 4 additive tests go red; (2) forcing containment always-true → 4 refusal tests red; (3) dropping the link-containment clause → 2 red; (4) dropping the surface-equality clause → 2 red. File restored after each.
- Design doc updated: status, the shipped mechanism, and its bounds recorded in `docs/design/graph-binding-tag-vs-tracker.md`.