### PR TITLE
fix(1181): a virtual PrimitiveNode feeding a subgraph input is reported as the non-source it is

### DIFF
--- a/browser_tests/unit/virtual-source-promotion.test.mjs
+++ b/browser_tests/unit/virtual-source-promotion.test.mjs
@@ -1,0 +1,276 @@
+/**
+ * #1181 — a frontend-only virtual PrimitiveNode wired INTO a promoted subgraph
+ * input never reaches the prompt: ComfyUI's graphToPrompt DROPS the virtual node,
+ * so the link carries nothing across the subgraph boundary and the inner node's
+ * STORED widget value is what serializes. The panel read path claimed the exact
+ * opposite ("the value in `widgets` is the stale stored value, NOT what
+ * executes"), and panel_run queued the stale prompt in silence.
+ *
+ * Reported on ComfyUI 0.32.0 / frontend 1.48.7: the flattened CLIPTextEncode
+ * kept the old internal widget text and the virtual PrimitiveNode was absent
+ * from the execution graph; swapping the primitive for a BACKEND
+ * PrimitiveStringMultiline made the source node appear in the prompt and the
+ * rendered subject change as requested.
+ *
+ * The panel does not build this prompt and cannot carry the value itself — what
+ * it can do, and what these pin, is stop asserting the backwards claim and stop
+ * queueing in silence.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import {
+  isNonSerializingValueSource,
+  virtualFedInputs,
+  collectVirtualSourceFeeds,
+  virtualSourceNote,
+  virtualSourceTag,
+} from "../../web/js/lib/virtual-source-promotion.js";
+
+// ---- fixtures ---------------------------------------------------------------
+
+const primitive = (id, value = "a lantern") => ({
+  id,
+  type: "PrimitiveNode",
+  isVirtualNode: true,
+  widgets: [{ name: "value", value }],
+});
+const backendNode = (id, type = "PrimitiveStringMultiline") => ({
+  id,
+  type,
+  constructor: { nodeData: {} },
+});
+
+/** A subgraph container whose input `text` is fed by link 7. */
+const container = (id, inner = [], linkId = 7) => ({
+  id,
+  type: "some-subgraph-uuid",
+  subgraph: { _nodes: inner },
+  widgets: [{ name: "text", value: "OLD stored text" }],
+  inputs: [{ name: "text", type: "STRING", link: linkId, _widget: { name: "text" } }],
+});
+
+/** A graph holding `nodes` plus `links` in the object form the live graph uses. */
+const graphOf = (nodes, links = {}) => ({ _nodes: nodes, links });
+
+const primitiveFeed = () =>
+  graphOf(
+    [primitive(85), container(10)],
+    { 7: { origin_id: 85, origin_slot: 0 } },
+  );
+
+// ---- isNonSerializingValueSource --------------------------------------------
+
+test("#1181 a virtual PrimitiveNode is a non-serializing value source", () => {
+  assert.equal(isNonSerializingValueSource(primitive(85)), true);
+});
+
+test("#1181 a backend node is NOT a non-serializing source — its value DOES cross the boundary", () => {
+  // The reporter verified this direction: a backend PrimitiveStringMultiline
+  // wired the same way appears in the execution graph and drives the value.
+  assert.equal(isNonSerializingValueSource(backendNode(85)), false);
+});
+
+test("#1181 a subgraph container is never a value source, even though it is virtual", () => {
+  assert.equal(
+    isNonSerializingValueSource({ id: 1, isVirtualNode: true, subgraph: { _nodes: [] } }),
+    false,
+  );
+});
+
+test("#1181 a virtual node with a CONNECTED input can relay a real value — not flagged", () => {
+  assert.equal(
+    isNonSerializingValueSource({
+      id: 2,
+      isVirtualNode: true,
+      inputs: [{ name: "in", link: 3 }],
+    }),
+    false,
+  );
+});
+
+test("#1181 a bare virtual node with nothing to forward IS flagged", () => {
+  assert.equal(isNonSerializingValueSource({ id: 2, isVirtualNode: true, inputs: [] }), true);
+});
+
+test("#1181 malformed/missing nodes fail safe: not a source, never a throw", () => {
+  assert.equal(isNonSerializingValueSource(null), false);
+  assert.equal(isNonSerializingValueSource(undefined), false);
+  assert.equal(isNonSerializingValueSource({}), false);
+});
+
+// ---- virtualFedInputs ---------------------------------------------------------
+
+test("#1181 a container input fed by a PrimitiveNode is reported, naming the source", () => {
+  const g = primitiveFeed();
+  const host = g._nodes[1];
+  host.graph = g;
+  const fed = virtualFedInputs(host);
+  assert.deepEqual(fed, { text: { node_id: 85, output_slot: 0, origin_type: "PrimitiveNode" } });
+});
+
+test("#1181 the SAME wiring from a BACKEND source is not virtual-fed (the working case)", () => {
+  const g = graphOf(
+    [backendNode(85), container(10)],
+    { 7: { origin_id: 85, origin_slot: 0 } },
+  );
+  g._nodes[1].graph = g;
+  assert.deepEqual(virtualFedInputs(g._nodes[1]), {});
+});
+
+test("#1181 a non-container node is never virtual-fed, even with a primitive origin", () => {
+  // Top-level PrimitiveNode → ordinary node WORKS (graphToPrompt resolves the
+  // primitive into the consumer's widget); only the subgraph boundary loses it.
+  const leaf = {
+    id: 3,
+    type: "CLIPTextEncode",
+    widgets: [{ name: "text", value: "x" }],
+    inputs: [{ name: "text", type: "STRING", link: 7 }],
+  };
+  const g = graphOf([primitive(85), leaf], { 7: { origin_id: 85, origin_slot: 0 } });
+  leaf.graph = g;
+  assert.deepEqual(virtualFedInputs(leaf), {});
+});
+
+test("#1181 array-form links and getNodeById-only graphs are read too", () => {
+  const host = container(10);
+  const nodes = [primitive(85), host];
+  const g = {
+    _nodes: nodes,
+    links: { 7: [7, 85, 0, 10, 0, "STRING"] },
+    getNodeById: (id) => nodes.find((n) => n.id === id),
+  };
+  host.graph = g;
+  assert.deepEqual(virtualFedInputs(host), {
+    text: { node_id: 85, output_slot: 0, origin_type: "PrimitiveNode" },
+  });
+});
+
+test("#1181 a dangling link id or missing origin node yields no entry, never a throw", () => {
+  const host = container(10, [], 99);
+  const g = graphOf([host], {});
+  host.graph = g;
+  assert.deepEqual(virtualFedInputs(host), {});
+  const host2 = container(11);
+  const g2 = graphOf([host2], { 7: { origin_id: 404, origin_slot: 0 } });
+  host2.graph = g2;
+  assert.deepEqual(virtualFedInputs(host2), {});
+});
+
+test("#1181 an unlinked host input is not virtual-fed", () => {
+  const host = container(10, [], null);
+  const g = graphOf([host], {});
+  host.graph = g;
+  assert.deepEqual(virtualFedInputs(host), {});
+});
+
+// ---- collectVirtualSourceFeeds ------------------------------------------------
+
+test("#1181 the run-time scan finds a primitive feed at the ROOT level", () => {
+  const found = collectVirtualSourceFeeds(primitiveFeed());
+  assert.equal(found.length, 1);
+  assert.equal(found[0].subgraph_node_id, "10");
+  assert.equal(found[0].input_name, "text");
+  assert.equal(found[0].origin_id, "85");
+  assert.equal(found[0].origin_type, "PrimitiveNode");
+});
+
+test("#1181 the scan descends into subgraphs (a feed one level down is still lost)", () => {
+  const inner = [primitive(85), container(10)];
+  const innerGraph = graphOf(inner, { 7: { origin_id: 85, origin_slot: 0 } });
+  const outer = { id: 5, subgraph: innerGraph, inputs: [], widgets: [] };
+  const root = graphOf([outer], {});
+  const found = collectVirtualSourceFeeds(root);
+  assert.equal(found.length, 1);
+  assert.equal(found[0].subgraph_node_id, "10");
+});
+
+test("#1181 a healthy graph reports nothing", () => {
+  const g = graphOf(
+    [backendNode(1, "KSampler"), backendNode(2, "SaveImage")],
+    { 7: { origin_id: 1, origin_slot: 0 } },
+  );
+  assert.deepEqual(collectVirtualSourceFeeds(g), []);
+});
+
+test("#1181 a subgraph cycle terminates instead of hanging", () => {
+  const a = { id: 1, inputs: [], widgets: [] };
+  const b = { id: 2, inputs: [], widgets: [] };
+  a.subgraph = graphOf([b], {});
+  b.subgraph = graphOf([a], {}); // pathological self-reference
+  assert.deepEqual(collectVirtualSourceFeeds(graphOf([a], {})), []);
+});
+
+// ---- virtualSourceNote --------------------------------------------------------
+
+test("#1181 the queue-time note names the source and says the STORED value executes", () => {
+  const note = virtualSourceNote(collectVirtualSourceFeeds(primitiveFeed()));
+  assert.match(note, /PrimitiveNode #85/);
+  assert.match(note, /subgraph #10/);
+  assert.match(note, /"text"/);
+  assert.match(note, /STORED/i, "says the inner stored value is what executes");
+  assert.match(note, /does NOT reach the prompt|dropped from the prompt/i);
+  // The remedy the reporter verified: a BACKEND primitive carries the value.
+  assert.match(note, /backend/i);
+});
+
+test("#1181 no findings, no note", () => {
+  assert.equal(virtualSourceNote([]), "");
+  assert.equal(virtualSourceNote(null), "");
+});
+
+// ---- virtualSourceTag ---------------------------------------------------------
+
+test("#1181 the outline/compact tag says the link value is NOT what executes", () => {
+  const tag = virtualSourceTag({ node_id: 85, output_slot: 0 });
+  assert.match(tag, /#85\.0/);
+  assert.match(tag, /NOT what executes|not serialized|stored value/i);
+  assert.equal(virtualSourceTag(null), "");
+});
+
+// ---- wiring pins --------------------------------------------------------------
+//
+// The detector above is only worth anything where the reporter was misled: the
+// read path (panel_query_graph / panel_graph_outline), the run path
+// (panel_run → graph_run), and the write path (panel_set_widget on the promoted
+// rail). These pin that the consumers actually CONSUME the lib — the pattern
+// slot-labels.test.mjs established for module-local panel functions — so the
+// detector cannot rot back into "perfectly correct and entirely unwired".
+
+const PANEL_JS = fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url));
+const WIDGET_WRITE_JS = fileURLToPath(new URL("../../web/js/lib/widget-write.js", import.meta.url));
+
+test("#1181 the read path splits virtual-fed widgets OUT of driven_by_link and says what executes", () => {
+  const src = readFileSync(PANEL_JS, "utf8");
+  assert.match(src, /from "\.\/lib\/virtual-source-promotion\.js"/, "the panel imports the detector");
+  assert.match(src, /const virtualFed = virtualFedInputs\(node\);/, "summarizeNode computes the virtual-fed set");
+  assert.match(src, /fed_by_virtual_source: fedByVirtual/, "summarizeNode emits the corrected claim");
+  assert.match(src, /source_not_serialized: true/, "inputs[].connected_from is annotated");
+  // The outline and compact rows must not reuse drivenTag's backwards claim for these.
+  assert.match(src, /virtualSourceTag\(vFed\[w\.name\]\)/, "the outline row tags virtual-fed widgets");
+  assert.match(src, /vFed\[k\] \? virtualSourceTag\(vFed\[k\]\)/, "the compact row tags virtual-fed widgets");
+});
+
+test("#1181 graph_run discloses a virtual-fed subgraph input at QUEUE time, scoped runs included", () => {
+  const src = readFileSync(PANEL_JS, "utf8");
+  assert.match(src, /collectVirtualSourceFeeds\(rootGraph\)/, "graph_run scans the root graph");
+  assert.match(src, /accept\.virtual_source_feeds = virtualFeeds;/);
+  assert.match(src, /accept\.virtual_source_note = virtualSourceNote\(virtualFeeds\);/);
+  // Unlike #985's disabled-outputs scan, this one must NOT sit inside the
+  // `if (!partialTargets)` exemption — a dropped source feeds nothing no matter
+  // how the run is scoped. Pin that the scan comes AFTER that block closes.
+  const exempt = src.indexOf("if (!partialTargets) {");
+  const scan = src.indexOf("collectVirtualSourceFeeds(rootGraph)");
+  const blockEnd = src.indexOf("return accept;", exempt);
+  assert.ok(exempt > 0 && scan > blockEnd - 4000 && scan < blockEnd, "scan runs outside the scoped-run exemption");
+});
+
+test("#1181 the promoted-write refusal names the real repairs when the outer feed is virtual", () => {
+  const src = readFileSync(WIDGET_WRITE_JS, "utf8");
+  assert.match(src, /isNonSerializingValueSource\(origin\)/, "the refusal inspects the outer link's origin");
+  assert.match(src, /does NOT cross the subgraph boundary/, "the corrected refusal says what happens");
+  // The generic #366 refusal must still exist for real-source / nested-promotion cases.
+  assert.match(src, /parent rail widget could not be identified/, "the generic refusal is kept");
+});

--- a/browser_tests/unit/widget-write.test.mjs
+++ b/browser_tests/unit/widget-write.test.mjs
@@ -1081,6 +1081,76 @@ test("#366 FAIL CLOSED: an EXTERNALLY-LINKED host input (nested/further promotio
   assert.equal(inner.widgets[0].value, 1280, "inner must not be written on fail-closed");
 });
 
+test("#1181 FAIL CLOSED with the CORRECTED advice: an outer link from a VIRTUAL PrimitiveNode carries nothing — write inner or use a backend node", () => {
+  // The #1181 configuration: the host input's outer link originates at a
+  // frontend-only PrimitiveNode, which the prompt compiler drops. The generic
+  // "edit from the outermost subgraph node" advice is wrong here — this IS the
+  // outermost node and its rail is non-authoritative BECAUSE of that link. The
+  // refusal must name the real repairs instead, and must still refuse (#366).
+  const inner = { id: 54, type: "CLIPTextEncode", widgets: [{ name: "text", type: "STRING", value: "OLD stored text" }] };
+  const subgraph = { _nodes: [inner], getNodeById: (id) => (String(id) === "54" ? inner : null) };
+  const rail = { name: "text", type: "STRING", value: "OLD stored text" };
+  const primitiveSource = { id: 85, type: "PrimitiveNode", isVirtualNode: true, widgets: [{ name: "value", value: "a lantern" }] };
+  const parent = {
+    id: 66,
+    type: "SubgraphNode",
+    subgraph,
+    inputs: [{ name: "text", link: 7, _widget: rail, _subgraphSlot: { name: "text" } }],
+    widgets: [rail],
+  };
+  const rootGraph = {
+    _nodes: [primitiveSource, parent],
+    links: { 7: { origin_id: 85, origin_slot: 0 } },
+    getNodeById: (id) => (String(id) === "85" ? primitiveSource : String(id) === "66" ? parent : null),
+  };
+  parent.graph = rootGraph;
+  const resolveSource = (_n, si) =>
+    si?.name === "text" ? { sourceNodeId: "54", sourceWidgetName: "text" } : null;
+
+  assert.throws(
+    () => applyWidgetWrite(parent, "text", "a lantern", { resolveSource }),
+    (err) =>
+      err instanceof WidgetWriteError &&
+      /does NOT cross the subgraph boundary/.test(err.message) &&
+      /PrimitiveNode #85/.test(err.message) &&
+      /inner node directly/.test(err.message) &&
+      /BACKEND node/.test(err.message),
+  );
+  assert.equal(rail.value, "OLD stored text", "rail untouched on refusal");
+  assert.equal(inner.widgets[0].value, "OLD stored text", "inner untouched on refusal");
+});
+
+test("#1181 the generic advice is KEPT when the outer link's origin is a REAL backend node", () => {
+  // Same linked host input, but the origin is a backend node whose value DOES
+  // cross the boundary — the #366 message ("edit from the outermost subgraph
+  // node") is the true one there and must not be displaced.
+  const inner = { id: 54, type: "CLIPTextEncode", widgets: [{ name: "text", type: "STRING", value: "old" }] };
+  const subgraph = { _nodes: [inner], getNodeById: (id) => (String(id) === "54" ? inner : null) };
+  const rail = { name: "text", type: "STRING", value: "old" };
+  const backendSource = { id: 85, type: "PrimitiveStringMultiline", constructor: { nodeData: {} } };
+  const parent = {
+    id: 66,
+    type: "SubgraphNode",
+    subgraph,
+    inputs: [{ name: "text", link: 7, _widget: rail, _subgraphSlot: { name: "text" } }],
+    widgets: [rail],
+  };
+  parent.graph = {
+    _nodes: [backendSource, parent],
+    links: { 7: { origin_id: 85, origin_slot: 0 } },
+  };
+  const resolveSource = (_n, si) =>
+    si?.name === "text" ? { sourceNodeId: "54", sourceWidgetName: "text" } : null;
+
+  assert.throws(
+    () => applyWidgetWrite(parent, "text", "new", { resolveSource }),
+    (err) =>
+      err instanceof WidgetWriteError &&
+      /parent rail widget could not be identified/.test(err.message) &&
+      !/does NOT cross the subgraph boundary/.test(err.message),
+  );
+});
+
 test("#366 SEVERE FAIL CLOSED: a NAME-ONLY `input.widget` stub + an unrelated same-named decoy is REFUSED (identity auth, never a name match)", () => {
   // The exact severe repro: the host input carries ONLY a `{ name }` stub (no
   // identity-linked projection), and the parent has ONE unrelated widget that

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -187,6 +187,12 @@ import {
   disabledOutputsInPrompt,
   disabledOutputsNote,
 } from "./lib/muted-subgraph-outputs.js";
+import {
+  collectVirtualSourceFeeds,
+  virtualFedInputs,
+  virtualSourceNote,
+  virtualSourceTag,
+} from "./lib/virtual-source-promotion.js";
 import { findStalePlaceholders, stalePlaceholderNote } from "./lib/stale-placeholders.js";
 import {
   findRepeatingControlWidgets,
@@ -9105,6 +9111,12 @@ function summarizeNode(node) {
   for (const w of node.widgets ?? []) {
     if (w && typeof w.name === "string") widgets[w.name] = w.value;
   }
+  // #1181: promoted inputs on a subgraph container whose link origin is a
+  // frontend-only VIRTUAL source (e.g. a canvas PrimitiveNode). graphToPrompt
+  // DROPS that source, so the link carries nothing at run time — the opposite
+  // of what `driven_by_link` asserts. Computed once and consulted by both the
+  // inputs[] annotation and the driven_by_link split below.
+  const virtualFed = virtualFedInputs(node);
   // #636: a user-RENAMED slot/widget keeps its programmatic NAME (what panel_set_widget
   // and panel_connect address) and gains a DISPLAY LABEL. Reporting only the name made
   // renames invisible, so the agent told the user their renames had not stuck when the
@@ -9123,6 +9135,9 @@ function summarizeNode(node) {
       ...(label != null ? { label } : {}),
       type: inp.type,
       connected_from: from,
+      // #1181: the link's origin is a virtual node the prompt compiler drops —
+      // the connection is real on the canvas but carries NOTHING at run time.
+      ...(from && virtualFed[inp.name] ? { source_not_serialized: true } : {}),
     };
   });
   const outputs = (node.outputs ?? []).map((out, i) => {
@@ -9167,7 +9182,17 @@ function summarizeNode(node) {
   // execution — the stored `w.value` is stale (e.g. a KSampler steps/cfg fed from a
   // Primitive/switch rail). Surface which widgets are overridden and by whom so the
   // read flags the stale value rather than reporting it as if it were effective.
-  const drivenByLink = drivenWidgetsFor(node, Object.keys(widgets));
+  const allDriven = drivenWidgetsFor(node, Object.keys(widgets));
+  // #1181: ...UNLESS the link's origin is a frontend-only VIRTUAL source feeding a
+  // promoted subgraph input. graphToPrompt drops that origin, so nothing arrives on
+  // the link and the stored value IS what executes — the #607 claim is exactly
+  // backwards for these. Split them out and report them under their own true claim.
+  const drivenByLink = {};
+  const fedByVirtual = {};
+  for (const [name, src] of Object.entries(allDriven)) {
+    if (virtualFed[name]) fedByVirtual[name] = { ...src, origin_type: virtualFed[name].origin_type };
+    else drivenByLink[name] = src;
+  }
   const summary = {
     id: node.id,
     type: node.type,
@@ -9195,6 +9220,12 @@ function summarizeNode(node) {
     // #607: names here are OVERRIDDEN by a link at run time — the value in `widgets`
     // is the stale stored value, NOT what executes. Each entry names the source.
     ...(Object.keys(drivenByLink).length ? { driven_by_link: drivenByLink } : {}),
+    // #1181: names here LOOK link-driven but the source is a frontend-only VIRTUAL
+    // node (e.g. a canvas PrimitiveNode) that the prompt compiler DROPS — the link
+    // carries NOTHING at run time, so the value in `widgets` IS what executes (the
+    // exact opposite of driven_by_link). To make the canvas value take effect,
+    // replace the source with a backend node or set the inner widget directly.
+    ...(Object.keys(fedByVirtual).length ? { fed_by_virtual_source: fedByVirtual } : {}),
     inputs,
     outputs,
   };
@@ -10334,6 +10365,10 @@ const GRAPH_TOOL_EXECUTORS = {
           );
           // #607: flag widgets overridden by a link so the stored value isn't read as effective.
           const driven = drivenWidgetsFor(n, (n.widgets ?? []).map((w) => w?.name).filter(Boolean));
+          // #1181: a VIRTUAL source (e.g. PrimitiveNode) feeding a promoted subgraph input
+          // is dropped by the prompt compiler — the stored value IS what executes, so these
+          // get their own tag instead of drivenTag's "the stored value is stale".
+          const vFed = virtualFedInputs(n);
           // #636 — the DISPLAY name a user renamed this widget to. graph_query already
           // reports these (`widget_labels`), but the outline did not, and the outline is
           // the reader an agent reaches for first: the reporter was told their renames
@@ -10356,7 +10391,11 @@ const GRAPH_TOOL_EXECUTORS = {
               const withLabel = label ? `${base} [renamed "${tagText_(title_(label))}"]` : base;
               const mode = cagMode.get(w.name);
               const withMode = mode ? `${withLabel} [after_gen=${mode}]` : withLabel;
-              return driven[w.name] ? `${withMode}${drivenTag(driven[w.name])}` : withMode;
+              return vFed[w.name]
+                ? `${withMode}${virtualSourceTag(vFed[w.name])}`
+                : driven[w.name]
+                  ? `${withMode}${drivenTag(driven[w.name])}`
+                  : withMode;
             })
             .join(" ");
         }
@@ -10823,6 +10862,9 @@ const GRAPH_TOOL_EXECUTORS = {
       } else {
         // #607: flag link-driven widgets in the compact line too.
         const driven = drivenWidgetsFor(n, (n.widgets ?? []).map((w) => w?.name).filter(Boolean));
+        // #1181: virtually-fed promoted inputs get the tag that says the stored
+        // value executes — drivenTag would claim the opposite.
+        const vFed = virtualFedInputs(n);
         const w = Object.entries(widgetsOf(n))
           .map(([k, v]) => {
             // ONE cap across the row (see compactValueCap above). A per-widget cap that
@@ -10831,7 +10873,8 @@ const GRAPH_TOOL_EXECUTORS = {
             // raises", while raising `max_chars` demonstrably lifted them (gate).
             const c = clipCompactValue(v, compactValueCap);
             if (c.clipped) rowClips++;
-            return `${k}=${c.text}${driven[k] ? drivenTag(driven[k]) : ""}`;
+            const tag = vFed[k] ? virtualSourceTag(vFed[k]) : driven[k] ? drivenTag(driven[k]) : "";
+            return `${k}=${c.text}${tag}`;
           })
           .join(" ");
         const ins = [...(up.get(String(n.id)) ?? [])].join(",");
@@ -13980,6 +14023,28 @@ const GRAPH_TOOL_EXECUTORS = {
       } catch {
         /* a diagnostic must never take down the run it describes */
       }
+    }
+    // #1181 — a frontend-only VIRTUAL PrimitiveNode wired into a promoted subgraph
+    // input is DROPPED by the prompt compiler: the canvas shows the new value, the
+    // run serializes the inner node's STORED widget value, and the execution
+    // succeeds silently with the old prompt (the reporter's exact harm — canvas and
+    // execution disagreed, reused cached conditioning and all). Measured on ComfyUI
+    // 0.32.0 / frontend 1.48.7.
+    //
+    // Same posture as #985 above: the panel does not build this prompt and cannot
+    // carry the value across the boundary, but it can stop queueing in silence.
+    // Reported at QUEUE time so an agent can interrupt rather than learn it from
+    // the render. Scoped runs are NOT exempt — unlike #985 this is not about
+    // execution roots: a dropped source feeds nothing no matter how the run is
+    // scoped. The note states the read-from-graph caveat itself.
+    try {
+      const virtualFeeds = collectVirtualSourceFeeds(rootGraph);
+      if (virtualFeeds.length) {
+        accept.virtual_source_feeds = virtualFeeds;
+        accept.virtual_source_note = virtualSourceNote(virtualFeeds);
+      }
+    } catch {
+      /* a diagnostic must never take down the run it describes */
     }
     return accept;
   },

--- a/web/js/lib/virtual-source-promotion.js
+++ b/web/js/lib/virtual-source-promotion.js
@@ -1,0 +1,187 @@
+/**
+ * #1181 — a frontend-only VIRTUAL value source (the canvas PrimitiveNode) wired
+ * INTO a promoted subgraph input never reaches the prompt.
+ *
+ * Reported on ComfyUI 0.32.0 / frontend 1.48.7: a PrimitiveNode connected to a
+ * promoted STRING input on a subgraph showed the new value on the canvas, and
+ * panel_query_graph reported the subgraph input as link-driven — but
+ * `app.graphToPrompt` DROPS the virtual node, so the link carries nothing
+ * across the subgraph boundary and the inner node's STORED widget value is what
+ * serialized. The execution succeeded silently with the old prompt and reused
+ * cached conditioning: canvas state and actual execution prompt disagreed. The
+ * reporter verified the counterpart too — a BACKEND PrimitiveStringMultiline
+ * wired the same way appears in the execution graph and drives the value.
+ *
+ * A whole-graph `panel_run` hands prompt construction to ComfyUI's own
+ * `app.queuePrompt`, so the panel does not build this prompt and cannot carry
+ * the value across the boundary itself. What it CAN do is stop being silent —
+ * and stop asserting the opposite of the truth, which is what the read path did
+ * before this issue: `linkDrivenWidgets` flags any link-connected widget as
+ * "OVERRIDDEN by a link at run time — the stored value is stale, NOT what
+ * executes", which is exactly backwards when the link's origin is a virtual
+ * node the prompt compiler drops.
+ *
+ * WHY THE TARGET IS A SUBGRAPH CONTAINER: a top-level PrimitiveNode feeding an
+ * ORDINARY node works — graphToPrompt resolves the primitive's value into the
+ * consumer's widget. The value is lost only at the subgraph boundary, where the
+ * promoted input's inner consumers are rewired to an origin that no longer
+ * exists in the prompt. So `virtualFedInputs` fires on container inputs only.
+ *
+ * Read-only and dependency-free, like graph-read.js / muted-subgraph-outputs.js,
+ * so it can be unit-tested in isolation
+ * (browser_tests/unit/virtual-source-promotion.test.mjs). Nothing here mutates
+ * the graph: pushing the primitive's value into the inner widget during a read
+ * or a run is exactly the silent-mutation class #979/#233 forbid.
+ */
+
+/**
+ * True when `node` is a frontend-only VIRTUAL value source whose output cannot
+ * reach the serialized prompt: ComfyUI's graphToPrompt drops it, so a link from
+ * it carries nothing.
+ *
+ * Two positive shapes, both deliberately narrow:
+ *   1. type "PrimitiveNode" — the reported, verified case. The broader
+ *      FRONTEND_ONLY_NODE_TYPES allowlist is NOT reused wholesale: Note has no
+ *      outputs, a Reroute relays whatever is upstream (fine when the upstream
+ *      is real), and KJNodes' Get/Set bus is resolved BY graphToPrompt — calling
+ *      any of those "carries nothing" would be a false claim.
+ *   2. any OTHER litegraph virtual node (`isVirtualNode === true`) that is not a
+ *      subgraph container and has NO connected input to forward — whatever it
+ *      displays lives only in the frontend. A subgraph container is excluded
+ *      explicitly: it is virtual too, but its outputs are COMPUTED from real
+ *      inner nodes and serialize normally.
+ */
+export function isNonSerializingValueSource(node) {
+  if (!node || typeof node !== "object") return false;
+  if (node.type === "PrimitiveNode") return true;
+  if (node.isVirtualNode === true && !node.subgraph) {
+    return !(node.inputs ?? []).some((i) => i?.link != null);
+  }
+  return false;
+}
+
+/** Resolve a node by id inside `graph`, tolerating both live-graph shapes. */
+function nodeById(graph, id) {
+  if (!graph || id == null) return null;
+  if (typeof graph.getNodeById === "function") return graph.getNodeById(id) ?? null;
+  const nodes = Array.isArray(graph._nodes) ? graph._nodes : Array.isArray(graph.nodes) ? graph.nodes : [];
+  return nodes.find((n) => String(n?.id) === String(id)) ?? null;
+}
+
+/**
+ * Map of input-name → { node_id, output_slot, origin_type } for every input on a
+ * SUBGRAPH CONTAINER whose link origin is a non-serializing virtual source —
+ * i.e. a promoted input that LOOKS fed but receives nothing at queue time.
+ *
+ * Keyed by input name so it composes with `linkDrivenWidgets`/`drivenWidgetsFor`
+ * (same key space). `graph` defaults to `node.graph`; the graph walker passes it
+ * explicitly because a container found mid-walk may not carry a back-pointer.
+ * Never throws: a malformed link or missing origin yields fewer entries.
+ */
+export function virtualFedInputs(node, graph = node?.graph) {
+  const out = {};
+  if (!node?.subgraph) return out;
+  const links = graph?.links ?? {};
+  for (const inp of node.inputs ?? []) {
+    if (!inp || inp.link == null || typeof inp.name !== "string") continue;
+    const l = links[inp.link];
+    if (!l) continue;
+    // Support both object links ({origin_id,origin_slot}) and array links [id,os,...].
+    const originId = l.origin_id ?? l[1];
+    const originSlot = l.origin_slot ?? l[2];
+    if (originId == null) continue;
+    const origin = nodeById(graph, originId);
+    if (!isNonSerializingValueSource(origin)) continue;
+    out[inp.name] = {
+      node_id: originId,
+      output_slot: originSlot ?? 0,
+      origin_type: typeof origin.type === "string" ? origin.type : null,
+    };
+  }
+  return out;
+}
+
+/**
+ * Walk every graph level, depth-first, and return one finding per promoted
+ * subgraph input fed by a non-serializing virtual source. Used by `graph_run`
+ * to say at QUEUE time that a run will ignore the canvas value.
+ *
+ * The cycle guard is PATH-LOCAL (a new Set per branch), matching
+ * collectDisabledAncestorOutputs: one subgraph definition can be instanced more
+ * than once, and a global visited set would consume the shared definition on
+ * the first instance and miss the second. Fully defensive — a diagnostic must
+ * never take down the run it describes.
+ */
+export function collectVirtualSourceFeeds(rootGraph) {
+  const found = [];
+  const walk = (graph, seenOnPath) => {
+    if (!graph || seenOnPath.has(graph)) return;
+    const nextSeen = new Set(seenOnPath);
+    nextSeen.add(graph);
+    const nodes = Array.isArray(graph._nodes) ? graph._nodes : Array.isArray(graph.nodes) ? graph.nodes : [];
+    for (const node of nodes) {
+      if (!node || node.id == null) continue;
+      if (node.subgraph) {
+        const fed = virtualFedInputs(node, graph);
+        for (const [name, src] of Object.entries(fed)) {
+          found.push({
+            subgraph_node_id: String(node.id),
+            subgraph_title: typeof node.title === "string" ? node.title : null,
+            input_name: name,
+            origin_id: String(src.node_id),
+            origin_type: src.origin_type,
+          });
+        }
+        walk(node.subgraph, nextSeen);
+      }
+    }
+  };
+  try {
+    walk(rootGraph, new Set());
+  } catch {
+    /* partial findings beat none; never throw out of a diagnostic */
+  }
+  return found;
+}
+
+/**
+ * The queue-time sentence. States what happens (the source is dropped, the
+ * STORED inner value executes), that the panel is not the one deciding it, the
+ * build it was measured on, and the remedy the reporter verified — a BACKEND
+ * primitive carries the value across the same boundary.
+ */
+export function virtualSourceNote(feeds) {
+  if (!Array.isArray(feeds) || feeds.length === 0) return "";
+  const n = feeds.length;
+  const which = feeds
+    .slice(0, 5)
+    .map(
+      (f) =>
+        `${f.origin_type ?? "virtual node"} #${f.origin_id} → subgraph #${f.subgraph_node_id} input "${f.input_name}"`,
+    )
+    .join("; ");
+  const more = n > 5 ? `; and ${n - 5} more` : "";
+  return (
+    `This workflow feeds ${n} promoted subgraph input${n === 1 ? "" : "s"} from a frontend-only ` +
+      `VIRTUAL node — ${which}${more}. On the build this was measured on (ComfyUI 0.32.0 / ` +
+      `frontend 1.48.7) the prompt compiler DROPS that source: the value on the link does NOT ` +
+      `reach the prompt, and each inner node's STORED widget value is what executes — the run ` +
+      `renders the OLD value while the canvas shows the new one, and nothing in the run says so ` +
+      `(#1181). This is read from the GRAPH, not from the queued prompt — the panel does not build ` +
+      `that prompt and cannot carry the value across the boundary — so on a build that resolves ` +
+      `virtual sources through subgraph inputs this warns about a run that was fine. To make the ` +
+      `canvas value take effect, replace the virtual source with a BACKEND node (e.g. ` +
+      `PrimitiveStringMultiline, verified by the reporter), or set the inner node's widget directly.`
+  );
+}
+
+/**
+ * The outline/compact-row counterpart of `drivenTag` for a widget whose link
+ * origin is a non-serializing virtual source. The plain tag ("link-driven")
+ * means "the stored value is stale, the link overrides it" — true for a real
+ * source, exactly backwards for this one, so it needs its own words.
+ */
+export function virtualSourceTag(src) {
+  if (!src) return "";
+  return ` [⚠ virtual source #${src.node_id}.${src.output_slot} — NOT serialized; the stored value is what executes]`;
+}

--- a/web/js/lib/widget-write.js
+++ b/web/js/lib/widget-write.js
@@ -1,5 +1,6 @@
 import { pressableWidgetHint } from "./pressable-widget.js";
 import { explainNumericNormalization, normalizationNote } from "./widget-normalization.js";
+import { isNonSerializingValueSource } from "./virtual-source-promotion.js";
 
 // #976: captured at module load so invoking a widget's callback cannot read any
 // property off the callback itself (a poisoned `.call` getter or a Proxy trap would
@@ -1037,6 +1038,39 @@ export function resolveWidgetWrite(
             ? [promotedParentWidget]
             : [];
       if (!promotedParentWidget) {
+        // #1181 — when the host input's OUTER link originates at a frontend-only
+        // VIRTUAL source (a canvas PrimitiveNode), the generic advice below is
+        // wrong in both directions: editing "the outermost subgraph node" cannot
+        // help (that IS this node, and its rail is non-authoritative because of
+        // the link), and the link itself carries NOTHING — the prompt compiler
+        // drops the virtual origin, so the inner node's STORED widget value is
+        // what executes. Say so, and point at the two repairs that work. The
+        // refusal itself stands: a write here would still report success over a
+        // rail nothing serializes from (#366's fail-closed posture is untouched).
+        if (promotedHostInput?.link != null) {
+          const links = node.graph?.links ?? {};
+          const l = links[promotedHostInput.link];
+          const originId = l ? (l.origin_id ?? l[1]) : null;
+          const origin =
+            originId != null && node.graph
+              ? (typeof node.graph.getNodeById === "function"
+                  ? node.graph.getNodeById(originId)
+                  : (node.graph._nodes ?? []).find((nd) => String(nd?.id) === String(originId)))
+              : null;
+          if (isNonSerializingValueSource(origin)) {
+            throw new WidgetWriteError(
+              `promoted widget "${widgetName}" on subgraph node ${node.id} is fed by ` +
+                `${origin.type ?? "a frontend-only virtual node"} #${originId}, which the prompt ` +
+                `compiler DROPS — the value on that link does NOT cross the subgraph boundary, so ` +
+                `no write to this rail can take effect and editing the outermost subgraph node ` +
+                `cannot help either. What executes is each INNER node's stored widget value: set ` +
+                `the widget on the inner node directly (enter the subgraph, then panel_set_widget ` +
+                `there), or replace the virtual source with a BACKEND node (e.g. ` +
+                `PrimitiveStringMultiline), whose value does cross (#1181). Refusing to write, ` +
+                `which would report success over a value that cannot serialize.`,
+            );
+          }
+        }
         throw new WidgetWriteError(
           `promoted widget "${widgetName}" on subgraph node ${node.id} resolves to an inner ` +
             `widget, but its AUTHORITATIVE parent rail widget could not be identified (the value ` +


### PR DESCRIPTION
## Root cause

A frontend-only virtual `PrimitiveNode` wired into a promoted subgraph input never reaches the prompt: `panel_run` hands prompt construction to ComfyUI's own `app.queuePrompt`, and `graphToPrompt` **drops** the virtual node, so the link carries nothing across the subgraph boundary and the inner node's **stored** widget value is what serializes. The reporter measured this on ComfyUI 0.32.0 / frontend 1.48.7 — the run succeeded silently with the old prompt and reused cached conditioning, while the canvas showed the new value.

The panel-side defect was that the panel asserted the exact opposite of this truth:

- `linkDrivenWidgets` judged a widget link-driven from `inp.link` + the link's `origin_id` alone and never looked at the origin **node**, so `panel_query_graph` / `panel_graph_outline` reported the subgraph input as "OVERRIDDEN by a link at run time — the stored value is stale, NOT what executes" — backwards for a virtual origin.
- `panel_run` queued in silence: the only preflight flags serialized entries with no `class_type`, and a virtual node that `graphToPrompt` drops leaves no entry at all.
- `panel_set_widget` on the promoted rail refused (correct, #366 fail-closed) but advised "edit from the outermost subgraph node" — impossible in this configuration, since that node's rail is non-authoritative *because* of the virtual feed.

## What this does

The value loss itself is upstream (the panel does not build the prompt and cannot carry the value across the boundary; silently pushing the primitive's value into inner widgets during a read/run is exactly the mutation class #979/#233 forbid). So this stops the lies and names the verified repairs:

- **New read-only detector** `web/js/lib/virtual-source-promotion.js`: `isNonSerializingValueSource` (deliberately narrow — `PrimitiveNode`, or any virtual non-container node with no connected input to forward; backend nodes, bus nodes and reroutes are never misreported), `virtualFedInputs`, `collectVirtualSourceFeeds`, `virtualSourceNote`, `virtualSourceTag`.
- **Read path** (`summarizeNode`, outline, compact rows): virtually-fed promoted inputs are split out of `driven_by_link` into `fed_by_virtual_source` ("the stored value IS what executes"), `inputs[].connected_from` gains `source_not_serialized: true`, and rows get a tag saying the link value is not serialized.
- **Run path** (`graph_run`): scans the live graph at queue time and returns `virtual_source_feeds` + `virtual_source_note` naming each feed and the remedies (replace with a backend node — the reporter verified `PrimitiveStringMultiline` crosses the same boundary — or set the inner widget directly). Scoped runs are **not** exempt — unlike #985 this is not about execution roots.
- **Write path** (`widget-write.js`): the #366 refusal stands, but when the host input's outer link originates at a non-serializing virtual source the message now says why editing the outermost node cannot help and points at the two repairs that work.

## Verification

- `npm ci` — clean
- `npm run test:unit` — 4982 pass / 0 fail (1 pre-existing todo), including the new `browser_tests/unit/virtual-source-promotion.test.mjs` (22 tests: predicate, per-container detection, whole-graph walk, note/tag wording, and source-pins that the panel actually consumes the lib) and 2 new `widget-write.test.mjs` cases (virtual origin → corrected refusal; backend origin → generic #366 advice kept)
- `npm run typecheck` — clean
- Existing #607 link-driven and #1087 set-widget-warning tests untouched and green (`graph-read.test.mjs`, `set-widget-link-driven.test.mjs`)

Not verified: a live-browser end-to-end run on the reporter's build (no rig here). The note wording follows the #985 precedent — it states the measured build and discloses that on a frontend that resolves virtual sources through subgraph boundaries, this warns about a run that was fine.

Follow-up (deliberately out of scope): the #1087 direct-inner-write warning cannot be safely inverted from the inner side — an inner node fed by a promoted rail always sees the virtual boundary IO node as its link origin, so the real-feed and virtual-feed cases are indistinguishable without mapping the boundary slot back to a specific container instance. The corrected refusal above terminates the wrong-advice loop after one step.

Closes #1181