### PR TITLE
fix(1242): panel_add_node refreshes a drifted node schema itself, then re-checks

### DIFF
--- a/browser_tests/unit/add-node-schema-auto-refresh.test.mjs
+++ b/browser_tests/unit/add-node-schema-auto-refresh.test.mjs
@@ -1,0 +1,376 @@
+// panel#1242 — `panel_add_node` refused to add LoadImage because the registered
+// frontend node schema was stale:
+//
+//   "LoadImage" required input "image" was added or retyped since this page
+//   loaded its node schema
+//
+// — and the retried identical add, after a manual `panel_refresh_nodes`,
+// succeeded. The panel was refusing a condition it could clear itself, in the
+// same call, at the cost of one forced refresh the caller was going to pay
+// anyway. The reporter's follow-up made the cost concrete: the tool replied
+// with a successful added-node payload while the sidebar reported the refusal,
+// an inconsistent outcome born of the add depending on a recovery only the
+// caller could perform.
+//
+// THE FIX: the drift branch of `graph_add_node` now RUNS the panel_refresh_nodes
+// recovery itself — `refreshComfyNodeDefs(undefined, { force: true })`, the same
+// forced re-register — then re-reads the registry nodeData and re-checks the
+// drift. A drift the refresh clears is added from the CURRENT definition, with
+// the recovery disclosed on the result; only a drift that SURVIVES a real
+// re-registration is refused, and that refusal says the recovery already ran
+// (and why it did not complete, when the refresh said so).
+//
+// The re-check reads the REGISTRY, not the refresh's verdict: a refresh that
+// only claims to have run must not be able to wave a stale schema through.
+//
+// THE HARNESS: these tests run the SHIPPED `graph_add_node` body, extracted from
+// the panel source and given injected collaborators — the same technique as
+// add-node-socket-proof-scope.test.mjs, whose harness this one mirrors.
+import test from "node:test";
+import assert from "node:assert/strict";
+import { withTimeout } from "../../web/js/lib/bounded-step.js";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import {
+  applyCurrentDefWidgetValues,
+  driftedRequiredInputNames,
+  missingRequiredWidgetMaterializations,
+  registeredSocketTypes,
+  unavailableRequiredWidgetMessage,
+  unavailableRequiredWidgetReport,
+} from "../../web/js/lib/node-widget-materialization.js";
+import {
+  assertAddNodeResolvableRefreshing,
+  isRegisteredNodeType,
+} from "../../web/js/lib/node-resolve.js";
+import { fetchSingleNodeDef } from "../../web/js/lib/single-node-def.js";
+import {
+  describeUnmaterializedRequiredWidgets,
+  snapshotBackendDef,
+} from "../../web/js/lib/add-node-widget-guard.js";
+
+const panelPath = fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url));
+const panelSrc = readFileSync(panelPath, "utf8");
+
+const addNodeMatch = panelSrc.match(
+  /\n {2}async graph_add_node\(\{ class_type, pos, title \}\) \{[\s\S]*?\n {2}\},/,
+);
+assert.ok(addNodeMatch, "could not locate graph_add_node in panel source");
+
+const awaitWidgetsMatch = panelSrc.match(
+  /\nasync function awaitRequiredCustomWidgetRegistration\([\s\S]*?\n\}/,
+);
+assert.ok(awaitWidgetsMatch, "could not locate awaitRequiredCustomWidgetRegistration");
+
+const placementMatch = panelSrc.match(/\nfunction placementFor\(graph, pos\) \{[\s\S]*?\n\}/);
+assert.ok(placementMatch, "could not locate placementFor");
+
+const boundedMatch = panelSrc.match(/\nasync function boundedGetNodeDefs\([\s\S]*?\n\}/);
+assert.ok(boundedMatch, "could not locate boundedGetNodeDefs in panel source");
+
+import {
+  NODE_DEFS_FETCH_TIMEOUT_MS,
+  NODE_DEFS_NO_ANSWER,
+  WIDEN_SOCKET_PROOF_TIMEOUT_MS,
+  monotonicNow,
+} from "./_panel-constants.mjs";
+
+// ---------------------------------------------------------------------------
+// The reporter's condition: the backend's CURRENT LoadImage declares a required
+// `image` combo; the registry this page loaded still holds the OLD shape.
+// ---------------------------------------------------------------------------
+
+/** The live backend /object_info. A fresh object each call, exactly like a fetch. */
+function backendObjectInfo() {
+  return {
+    LoadImage: {
+      name: "LoadImage",
+      input: { required: { image: [["a.png", "b.png"], {}] } },
+      output: ["IMAGE", "MASK"],
+    },
+  };
+}
+
+/** The page-load registry entry, from BEFORE the pack added `image`. */
+function staleLoadImageNodeData() {
+  return {
+    name: "LoadImage",
+    input: { required: {} },
+    output: ["IMAGE", "MASK"],
+  };
+}
+
+function makeComfy({ stale = true } = {}) {
+  const widgets = {
+    COMBO(node, name, spec) {
+      return { widget: node.addWidget("combo", name, spec[0][0], null, { values: spec[0] }) };
+    },
+  };
+
+  const registry = {};
+  let nextId = 1;
+
+  const LG = {
+    registered_node_types: registry,
+    createNode(type) {
+      const cls = registry[type];
+      if (!cls) return null;
+      const node = {
+        id: nextId++,
+        type,
+        constructor: cls,
+        pos: [0, 0],
+        size: [210, 100],
+        widgets: [],
+        inputs: [],
+        outputs: [],
+        addWidget(kind, name, value, callback, options) {
+          const widget = { type: kind, name, value, callback, options: options ?? {} };
+          node.widgets.push(widget);
+          return widget;
+        },
+      };
+      for (const [name, spec] of Object.entries(cls.nodeData?.input?.required ?? {})) {
+        const declared = Array.isArray(spec) ? spec[0] : null;
+        if (Array.isArray(declared)) widgets.COMBO(node, name, spec);
+        else if (typeof widgets[declared] === "function") widgets[declared](node, name, spec);
+        else node.inputs.push({ name, type: declared });
+      }
+      return node;
+    },
+  };
+
+  const app = {
+    widgets,
+    async registerNodesFromDefs(defs) {
+      for (const [type, nodeData] of Object.entries(defs ?? {})) {
+        const cls = function ComfyNode() {};
+        cls.nodeData = nodeData;
+        cls.comfyClass = type;
+        registry[type] = cls;
+      }
+    },
+  };
+
+  // The class IS registered — that is what arms the per-class fast path and what
+  // makes this a DRIFT case rather than a freshly-installed-class case. Whether
+  // the entry is the stale page-load one or already current is the scenario knob.
+  void app.registerNodesFromDefs({
+    LoadImage: stale ? staleLoadImageNodeData() : backendObjectInfo().LoadImage,
+  });
+
+  const graph = {
+    _nodes: [],
+    add(node) {
+      graph._nodes.push(node);
+    },
+    beforeChange() {},
+    afterChange() {},
+    setDirtyCanvas() {},
+  };
+
+  return { app, LG, graph, registry };
+}
+
+/** Build the SHIPPED graph_add_node with its collaborators injected. */
+function realGraphAddNode(comfy, overrides = {}) {
+  const { app, LG, graph } = comfy;
+  const context = { app, LG, graph, rootGraph: graph, workflow: { uuid: "wf" } };
+  const refreshCalls = [];
+
+  const api = {
+    async getNodeDefs() {
+      return backendObjectInfo();
+    },
+    // ComfyUI's per-class route, faithful to its real shape: absence is `{}` with HTTP 200.
+    async fetchApi(route) {
+      const cls = decodeURIComponent(String(route).replace("/object_info/", ""));
+      const all = backendObjectInfo();
+      const body = Object.prototype.hasOwnProperty.call(all, cls) ? { [cls]: all[cls] } : {};
+      return { status: 200, json: async () => body };
+    },
+  };
+
+  const deps = {
+    captureGraphMutationContext: () => context,
+    revalidateGraphMutationContext: () => context,
+    awaitObjectInfoHistorySeed: async () => {},
+    recordObjectInfoTypes: (defs) => defs,
+    objectInfoHistory: { wasTypeEverDefined: () => false },
+    objectInfoSnapshot: { record: () => true, clear: () => {} },
+    backendReconnectEpoch: 0,
+    api,
+    // The default is the refresh the reporter ran by hand: forced, whole-schema,
+    // and it re-registers the CURRENT defs — the recovery that clears the drift.
+    // Tests that need it to fail or to lie pass their own through overrides.
+    refreshComfyNodeDefs: async (defs, opts) => {
+      refreshCalls.push({ defs, opts });
+      await app.registerNodesFromDefs(defs ?? backendObjectInfo());
+      return { refreshed: true };
+    },
+    summarizeNode: (node) => ({
+      id: node.id,
+      type: node.type,
+      widgets: node.widgets.map((w) => w.name),
+      inputs: node.inputs.map((i) => i.name),
+    }),
+    assertAddNodeResolvableRefreshing,
+    driftedRequiredInputNames,
+    registeredSocketTypes,
+    missingRequiredWidgetMaterializations,
+    applyCurrentDefWidgetValues,
+    unavailableRequiredWidgetReport,
+    unavailableRequiredWidgetMessage,
+    snapshotBackendDef,
+    isRegisteredNodeType,
+    fetchSingleNodeDef,
+    describeUnmaterializedRequiredWidgets,
+    NODE_DEFS_NO_ANSWER,
+    WIDEN_SOCKET_PROOF_TIMEOUT_MS,
+    monotonicNow,
+    NODE_DEFS_FETCH_TIMEOUT_MS,
+    withTimeout,
+    ...overrides,
+  };
+
+  if (!("boundedGetNodeDefs" in deps)) {
+    const build = new Function(
+      "api",
+      "withTimeout",
+      "NODE_DEFS_NO_ANSWER",
+      "NODE_DEFS_FETCH_TIMEOUT_MS",
+      `${boundedMatch[0]}
+       return boundedGetNodeDefs;`,
+    );
+    deps.boundedGetNodeDefs = (timeoutMs) =>
+      build(deps.api, withTimeout, NODE_DEFS_NO_ANSWER, NODE_DEFS_FETCH_TIMEOUT_MS)(timeoutMs);
+  }
+
+  const names = Object.keys(deps);
+  const factory = new Function(
+    ...names,
+    `${awaitWidgetsMatch[0]}
+     ${placementMatch[0]}
+     const CUSTOM_WIDGET_REGISTRATION_TIMEOUT_MS = 200;
+     const CUSTOM_WIDGET_REGISTRATION_POLL_MS = 5;
+     const executors = {${addNodeMatch[0]}};
+     return executors.graph_add_node;`,
+  );
+  return { graph_add_node: factory(...names.map((n) => deps[n])), refreshCalls };
+}
+
+// ---------------------------------------------------------------------------
+// 1. The reported flow, now in ONE call: drift detected → refresh → add.
+// ---------------------------------------------------------------------------
+
+test("#1242: the reporter's add succeeds in one call — the panel refreshes first", async () => {
+  const comfy = makeComfy({ stale: true });
+  const { graph_add_node, refreshCalls } = realGraphAddNode(comfy);
+
+  const res = await graph_add_node({ class_type: "LoadImage" });
+
+  assert.equal(res.added.type, "LoadImage");
+  assert.deepEqual(res.added.widgets, ["image"], "the node is built from the CURRENT definition");
+  assert.equal(comfy.graph._nodes.length, 1);
+  assert.equal(refreshCalls.length, 1, "exactly one refresh — the recovery, not a retry storm");
+  assert.equal(refreshCalls[0].defs, undefined, "the refresh is the whole-schema forced one");
+  assert.deepEqual(refreshCalls[0].opts, { force: true });
+});
+
+test("#1242: the recovery is disclosed on the result, not silent", async () => {
+  const comfy = makeComfy({ stale: true });
+  const { graph_add_node } = realGraphAddNode(comfy);
+
+  const res = await graph_add_node({ class_type: "LoadImage" });
+
+  assert.equal(res.added.schema_refreshed, true, "the caller must be told the schema moved");
+  assert.match(res.added.warning, /schema .* was stale/i);
+  assert.match(res.added.warning, /panel_refresh_nodes/);
+  // The limit the refusal has always stated applies here too: existing nodes
+  // were not retrofitted.
+  assert.match(res.added.warning, /ALREADY on the canvas/);
+});
+
+// ---------------------------------------------------------------------------
+// 2. The refusal survives — for the drift a real refresh could not clear.
+// ---------------------------------------------------------------------------
+
+test("#1242: a drift that survives the refresh is still refused, with the reason named", async () => {
+  const comfy = makeComfy({ stale: true });
+  // The refresh ran but reported it did not complete, and the registry still
+  // holds the old shape — the #852 refusal is the right answer HERE, not before.
+  let refreshRan = 0;
+  const { graph_add_node } = realGraphAddNode(comfy, {
+    refreshComfyNodeDefs: async () => {
+      refreshRan += 1;
+      return { refreshed: false, reason: "defs_fetch_failed" };
+    },
+  });
+
+  await assert.rejects(
+    () => graph_add_node({ class_type: "LoadImage" }),
+    (err) => {
+      assert.match(err.message, /added or retyped since this page loaded its node schema/);
+      assert.match(err.message, /panel_refresh_nodes recovery itself/);
+      assert.match(err.message, /did not complete \(reason: defs_fetch_failed\)/);
+      assert.match(err.message, /Reloading the ComfyUI tab/);
+      return true;
+    },
+  );
+  assert.equal(refreshRan, 1, "the recovery was attempted before refusing");
+  assert.equal(comfy.graph._nodes.length, 0, "a refused add creates nothing");
+});
+
+test("#1242: a refresh that THROWS is a not-completed refresh, not a crashed add", async () => {
+  const comfy = makeComfy({ stale: true });
+  const { graph_add_node } = realGraphAddNode(comfy, {
+    refreshComfyNodeDefs: async () => {
+      throw new Error("backend gone");
+    },
+  });
+
+  await assert.rejects(
+    () => graph_add_node({ class_type: "LoadImage" }),
+    (err) => {
+      assert.match(err.message, /did not complete \(reason: backend gone\)/);
+      return true;
+    },
+  );
+  assert.equal(comfy.graph._nodes.length, 0);
+});
+
+test("#1242: a refresh that cleared nothing REGISTRY-side cannot wave the drift through", async () => {
+  // The re-check reads the registry the refresh rewrote — not the verdict. A
+  // refresh that claims success but leaves the old nodeData in place must still
+  // be refused; trusting the verdict would be the silent-corruption path.
+  const comfy = makeComfy({ stale: true });
+  const { graph_add_node } = realGraphAddNode(comfy, {
+    refreshComfyNodeDefs: async () => ({ refreshed: true }), // claims it ran; registers nothing
+  });
+
+  await assert.rejects(
+    () => graph_add_node({ class_type: "LoadImage" }),
+    (err) => {
+      assert.match(err.message, /added or retyped since this page loaded its node schema/);
+      assert.match(err.message, /survived it/);
+      return true;
+    },
+  );
+  assert.equal(comfy.graph._nodes.length, 0);
+});
+
+// ---------------------------------------------------------------------------
+// 3. A healthy add pays nothing: the refresh is drift-triggered, not routine.
+// ---------------------------------------------------------------------------
+
+test("#1242: an add with no drift never calls the refresh", async () => {
+  const comfy = makeComfy({ stale: false });
+  const { graph_add_node, refreshCalls } = realGraphAddNode(comfy);
+
+  const res = await graph_add_node({ class_type: "LoadImage" });
+
+  assert.equal(res.added.type, "LoadImage");
+  assert.equal(refreshCalls.length, 0, "a healthy add must not pay for a whole-schema refresh");
+  assert.equal(res.added.schema_refreshed, undefined, "nothing to disclose when nothing happened");
+});

--- a/browser_tests/unit/add-node-schema-drift-recovery.test.mjs
+++ b/browser_tests/unit/add-node-schema-drift-recovery.test.mjs
@@ -14,6 +14,13 @@ import { readFileSync } from "node:fs";
 // their canvas state for something the panel can fix without it is the same
 // class of defect as #663: a refusal that sends the caller to the wrong recovery
 // costs more than the refusal.
+//
+// #1242 — and sending the caller to run that recovery BY HAND was the same
+// defect one level down: the retried identical add succeeded, so the panel was
+// refusing a condition it could clear itself. The add now runs the forced
+// refresh once, re-checks the drift against the registry the refresh rewrote,
+// and only refuses when the drift survives — which is when this message, and
+// its reload fallback, are still the truth.
 
 const PANEL = readFileSync(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8");
 
@@ -79,12 +86,39 @@ test("the drift check reads the registry nodeData the refresh updates", () => {
   // The two halves have to be about the same thing, or the named recovery is a
   // coincidence rather than a fix.
   const site = PANEL.slice(
-    PANEL.indexOf("const drifted = driftedRequiredInputNames"),
+    PANEL.indexOf("let drifted = driftedRequiredInputNames"),
     PANEL.indexOf("added or retyped since this page loaded its node schema"),
   );
   assert.ok(site.includes("driftedRequiredInputNames(currentDef, nodeData)"));
   assert.ok(
-    PANEL.includes("const nodeData = LG?.registered_node_types?.[class_type]?.nodeData;"),
+    PANEL.includes("let nodeData = LG?.registered_node_types?.[class_type]?.nodeData;"),
     "nodeData must come from the LiteGraph registry that registerNodesFromDefs writes",
   );
+});
+
+test("#1242: the add runs the refresh itself, then re-checks, BEFORE the refusal", () => {
+  // The whole point of the fix: the refusal is what remains AFTER the panel has
+  // already run the panel_refresh_nodes recovery once. Order is the claim, so
+  // pin it — refresh, re-read nodeData, re-check drift, and only then the throw.
+  const checkAt = PANEL.indexOf("let drifted = driftedRequiredInputNames");
+  const refusalAt = PANEL.indexOf("added or retyped since this page loaded its node schema");
+  assert.ok(checkAt > 0 && refusalAt > checkAt, "the drift check must precede the refusal");
+  const between = PANEL.slice(checkAt, refusalAt);
+  const refreshAt = between.indexOf("refreshComfyNodeDefs(undefined, { force: true })");
+  assert.ok(refreshAt > 0, "the drift branch must run the forced refresh itself");
+  const recheckAt = between.indexOf("drifted = driftedRequiredInputNames(currentDef, nodeData)", refreshAt);
+  assert.ok(recheckAt > refreshAt, "the drift must be re-checked AFTER the refresh");
+  assert.ok(
+    between.indexOf("nodeData = LG?.registered_node_types?.[class_type]?.nodeData;") > refreshAt,
+    "nodeData must be re-read from the registry the refresh rewrote",
+  );
+});
+
+test("#1242: a drift the refresh clears is NOT refused", () => {
+  // The refusal is gated on the POST-refresh drift, not the pre-refresh one — a
+  // refusal that fired on the stale reading would make the auto-refresh
+  // pointless.
+  const refusalAt = PANEL.indexOf("added or retyped since this page loaded its node schema");
+  const gate = PANEL.slice(PANEL.lastIndexOf("if (drifted.length) {", refusalAt), refusalAt);
+  assert.ok(gate.startsWith("if (drifted.length) {"), "the refusal must be gated on the re-checked drift");
 });

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -11486,30 +11486,55 @@ const GRAPH_TOOL_EXECUTORS = {
         whole: true,
       });
     }
-    const nodeData = LG?.registered_node_types?.[class_type]?.nodeData;
+    let nodeData = LG?.registered_node_types?.[class_type]?.nodeData;
     // A pack upgraded mid-session can add required inputs to an ALREADY
     // registered class; the resolver only refreshes absent classes, so
     // createNode would build the OLD shape — a new link input would not even
-    // get a slot and the node could never validate. Refuse before creating
-    // anything, with the remedy that actually updates the schema.
+    // get a slot and the node could never validate.
     //
-    // #852 — and that remedy is panel_refresh_nodes, not a tab reload. This text
-    // named the reload alone, so a user whose loader options had merely drifted
-    // (a model file moved between folders) was told to throw away their canvas
-    // state for a condition the panel can clear in place: refresh_nodes re-fetches
-    // /object_info and calls registerNodesFromDefs, which is precisely what updates
-    // the nodeData this check reads. Same class of defect as #663 — a refusal that
-    // sends the caller to the wrong recovery costs more than the refusal itself.
-    const drifted = driftedRequiredInputNames(currentDef, nodeData);
+    // #852 — the remedy that updates this schema is refresh_nodes, not a tab
+    // reload: it re-fetches /object_info and calls registerNodesFromDefs, which
+    // is precisely what updates the nodeData this check reads.
+    //
+    // #1242 — so RUN that recovery here, once, before refusing anything. The
+    // refusal used to send the caller away to call panel_refresh_nodes and retry
+    // by hand, and the retried identical add then succeeded — the panel was
+    // refusing a condition it could clear itself, in the same call, at the cost
+    // of one forced refresh the caller was going to pay anyway. The re-check
+    // below reads the registry the refresh rewrote — NOT the refresh's own
+    // verdict — so a refresh that only claims to have run cannot wave a stale
+    // schema through, and only a drift that survives a real re-registration is
+    // refused. nodeData is re-read too: the guards downstream must see the SAME
+    // schema the node is about to be built from.
+    let drifted = driftedRequiredInputNames(currentDef, nodeData);
+    let schemaAutoRefreshed = false;
+    let schemaRefreshIncompleteReason = null;
+    if (drifted.length) {
+      try {
+        const verdict = await refreshComfyNodeDefs(undefined, { force: true });
+        if (!(verdict === true || (verdict != null && typeof verdict === "object" && verdict.refreshed === true))) {
+          schemaRefreshIncompleteReason =
+            (verdict != null && typeof verdict === "object" && verdict.reason) || "unknown";
+        }
+      } catch (e) {
+        schemaRefreshIncompleteReason = e?.message ?? String(e);
+      }
+      nodeData = LG?.registered_node_types?.[class_type]?.nodeData;
+      drifted = driftedRequiredInputNames(currentDef, nodeData);
+      schemaAutoRefreshed = drifted.length === 0;
+    }
     if (drifted.length) {
       throw new Error(
         `"${class_type}" required input${drifted.length === 1 ? "" : "s"} ` +
           `${drifted.map((name) => `"${name}"`).join(", ")} ${drifted.length === 1 ? "was" : "were"} ` +
           "added or retyped since this page loaded its node schema, so creating it now would " +
-          "build the OLD shape. Call panel_refresh_nodes and retry — it re-fetches /object_info " +
-          "and re-registers the class in place, which is exactly what this refusal is waiting " +
-          "for, and it costs you no canvas state. Reloading the ComfyUI tab also works and is " +
-          "the fallback if the refresh reports it did not complete. NOTE: the refresh updates " +
+          "build the OLD shape. This add already ran the panel_refresh_nodes recovery itself — " +
+          "re-fetching /object_info and re-registering the class in place — and the drift " +
+          (schemaRefreshIncompleteReason != null
+            ? `persisted because the refresh reported it did not complete (reason: ${schemaRefreshIncompleteReason}). ` +
+              "Retrying the add runs the refresh again; if it keeps reporting incomplete, "
+            : "survived it, so the registered schema and the live backend genuinely disagree. ") +
+          "Reloading the ComfyUI tab is the fallback that remains. NOTE: the refresh updates " +
           "the CLASS, so the node you add next is correct; nodes ALREADY on the canvas keep the " +
           "shape they were created with.",
       );
@@ -11649,6 +11674,19 @@ const GRAPH_TOOL_EXECUTORS = {
         `That is a defect in the node pack, not in your graph. The kept value is a real ` +
         `member of the list; applying the declared default would have made the node ` +
         `unqueueable.`;
+    }
+    if (schemaAutoRefreshed) {
+      // #1242 — disclose the recovery the add performed on its own. The caller asked
+      // for one node; it got that node PLUS a whole-schema re-registration, and a
+      // silent schema change under their feet is exactly the stale-positive class of
+      // bug this path exists to refuse.
+      added.schema_refreshed = true;
+      added.warning =
+        `${added.warning ? `${added.warning} ` : ""}` +
+        `The registered node schema for "${class_type}" was stale (its pack changed since this ` +
+        "tab loaded), so the panel refreshed it in place — the panel_refresh_nodes recovery — " +
+        "before creating this node, and the node was built from the CURRENT definition. Nodes " +
+        "ALREADY on the canvas keep the shape they were created with.";
     }
     return { added };
   },


### PR DESCRIPTION
## Root cause

`graph_add_node`'s schema-drift guard (web/js/comfyui-mcp-panel.js) compared the backend's CURRENT definition against the page-load LiteGraph registry and, on finding a drifted required input, threw a refusal telling the caller to run `panel_refresh_nodes` and retry by hand. The issue's own reproduction showed the retried identical add then succeeded — the panel was refusing a condition it could clear itself, in the same call. The follow-up report showed the cost: the tool replied with a successful added-node payload while the sidebar reported the stale-schema refusal, an inconsistent outcome born of the add depending on a recovery only the caller could perform.

Checked against current main first: #1313 (dynamic-slot refresh after `panel_set_widget`) and #1218 (combo rebuild in the reapply sweep) shipped but touch different paths; the drift branch still refused immediately, so the issue was live, not stale.

## Fix

In the drift branch of `graph_add_node`:

1. Run the `panel_refresh_nodes` recovery itself, once: `refreshComfyNodeDefs(undefined, { force: true })` — the same forced whole-schema re-register. A throw or a not-completed verdict is captured as the reason, never propagated as a crashed add.
2. Re-read the registry `nodeData` and re-check the drift. The re-check reads the REGISTRY the refresh rewrote, not the refresh's verdict, so a refresh that only claims to have run cannot wave a stale schema through (fail-closed).
3. Cleared → proceed; the node is built from the CURRENT definition, and the recovery is disclosed on the result (`schema_refreshed: true` + a warning that also restates the standing limit: nodes ALREADY on the canvas keep their shape).
4. Still drifted → the #852 refusal fires, updated to say the recovery already ran (and why it did not complete, when the refresh said so), with the tab reload as the remaining fallback.

A healthy add is untouched: the refresh is drift-triggered, so the common path pays nothing.

## Tests

- New `browser_tests/unit/add-node-schema-auto-refresh.test.mjs` runs the SHIPPED `graph_add_node` body (same extraction harness as `add-node-socket-proof-scope.test.mjs`): the reporter's LoadImage flow succeeds in one call with exactly one forced refresh and the disclosure on the result; a drift surviving the refresh is still refused with the not-completed reason named; a throwing refresh is a not-completed refresh, not a crash; a success-claiming refresh that changed nothing registry-side is still refused; a no-drift add never calls the refresh.
- Updated `add-node-schema-drift-recovery.test.mjs`: the refusal-message pins are kept (recovery named first, reload as fallback, the ALREADY-on-canvas limit) and new pins assert the order — refresh, re-read, re-check, THEN refuse.

## Verification (worktree on origin/main 092d15b8)

- `npm ci` — clean, 0 vulnerabilities
- `npm run test:unit` — 5000 tests, 4999 pass, 0 fail, 1 todo
- `npm run typecheck` — `tsc --noEmit` clean

Closes #1242