### PR TITLE
fix(1273): a cg-use-everywhere graph's broadcast targets are queue-time volatile, so run-to-node's graph stamp matches on an untouched canvas

### DIFF
--- a/browser_tests/unit/run-scope-guard.test.mjs
+++ b/browser_tests/unit/run-scope-guard.test.mjs
@@ -417,6 +417,63 @@ test("#1124 promptContentHash: rgthree's substitution is not drift, but an edit 
   );
 });
 
+// ---------------------------------------------------------------------------
+// #1273 — the THIRD volatility mechanism: cg-use-everywhere converts its
+// broadcasts to REAL links inside its own queuePrompt patch, so the stamp's
+// graphToPrompt and the dispatch's serialization of an UNTOUCHED graph differ
+// on exactly the pack's extra.ue_links record. The pair computation itself
+// (including the subgraph routing behind the field report's "103:48 anything"
+// tokens) is pinned in use-everywhere-links.test.mjs; these tests pin the
+// integration: collectVolatileInputs carries the pairs, and the two-channel
+// hash comparison of an untouched UE graph now MATCHES.
+// ---------------------------------------------------------------------------
+
+const ueGraph = () => ({
+  _nodes: [
+    { id: 4, inputs: [], outputs: [{ name: "CLIP", links: [] }] },
+    { id: 22, inputs: [{ name: "clip", link: null }, { name: "text", link: null }] },
+  ],
+  extra: {
+    ue_links: [{ downstream: 22, downstream_slot: 0, upstream: 4, upstream_slot: 0, controller: 48, type: "CLIP" }],
+  },
+});
+
+test("#1273 collectVolatileInputs: a UE broadcast target is volatile, its sibling input is not", () => {
+  const pairs = collectVolatileInputs(ueGraph());
+  assert.ok(pairs.has("22 clip"), "the input the injection will materialise");
+  assert.ok(!pairs.has("22 text"), "everything else keeps full drift coverage");
+  assert.equal(collectVolatileInputs({ _nodes: [], extra: {} }).size, 0,
+    "a graph without a ue_links record is untouched");
+});
+
+test("#1273 promptContentHash: an untouched UE graph stamps EQUAL to its dispatched body — and a real edit still refuses", () => {
+  // The pre-dispatch serialization has NO UE link; the post body carries the
+  // injected one. Before #1273 this pair of hashes always mismatched and every
+  // run-to-node on a UE graph was refused as "the graph CHANGED".
+  const volatileInputs = collectVolatileInputs(ueGraph());
+  const stamped = { "22": { class_type: "CLIPTextEncode", inputs: { text: "a cat" } }, "4": { class_type: "CheckpointLoaderSimple", inputs: {} } };
+  const atHash = promptContentHash(stamped, volatileInputs);
+  const dispatched = (inputs) =>
+    JSON.stringify({ prompt: { "22": { class_type: "CLIPTextEncode", inputs }, "4": { class_type: "CheckpointLoaderSimple", inputs: {} } } });
+  assert.equal(
+    promptContentHashFromBody(dispatched({ clip: ["4", 0], text: "a cat" }), volatileInputs),
+    atHash,
+    "UE's queue-time injection is the exclusion's purpose — the scoped run is no longer refused",
+  );
+  assert.notEqual(
+    promptContentHashFromBody(dispatched({ clip: ["4", 0], text: "a dog" }), volatileInputs),
+    atHash,
+    "a mid-window edit to any OTHER input of the same node is still drift",
+  );
+  assert.equal(
+    promptContentHashFromBody(dispatched({ clip: ["5", 0], text: "a cat" }), volatileInputs),
+    atHash,
+    "a mid-window rewiring OF the excluded input itself is indistinguishable from the " +
+      "injection and is TOLERATED — the documented residual, disclosed via volatileInputs",
+  );
+});
+
+
 test("#572 promptContentHash: the narrowed exclusion tolerates ONLY the hook's own input — a seed edit is the documented residual, an edit to any OTHER input of the same node refuses", () => {
   const control = { name: "control_after_generate", value: "randomize", beforeQueued() {} };
   const seed = { name: "seed", value: 111, linkedWidgets: [control] };

--- a/browser_tests/unit/use-everywhere-links.test.mjs
+++ b/browser_tests/unit/use-everywhere-links.test.mjs
@@ -1,0 +1,167 @@
+/**
+ * #1273 — cg-use-everywhere materialises its broadcast links into the prompt
+ * inside its own queuePrompt patch, so every input its `extra.ue_links` record
+ * names is queue-time volatile (see the module header of
+ * web/js/lib/use-everywhere-links.js for the measured mechanism). These tests
+ * pin the pair computation, including the subgraph routing that produced the
+ * field report's `103:48 anything`-style diff tokens.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { ueQueueTimeLinkPairs } from "../../web/js/lib/use-everywhere-links.js";
+
+const link = (id, origin_id, origin_slot, target_id, target_slot) => ({
+  id,
+  origin_id,
+  origin_slot,
+  target_id,
+  target_slot,
+});
+
+test("#1273 a plain broadcast names the downstream input at the root prefix", () => {
+  const root = {
+    _nodes: [
+      { id: 4, inputs: [], outputs: [{ name: "MODEL", links: [] }] },
+      { id: 22, inputs: [{ name: "clip", link: null }, { name: "steps", link: null }] },
+    ],
+    extra: {
+      ue_links: [{ downstream: 22, downstream_slot: 0, upstream: 4, upstream_slot: 0, controller: 48, type: "CLIP" }],
+    },
+  };
+  assert.deepEqual([...ueQueueTimeLinkPairs(root)].sort(), ["22 clip"],
+    "exactly the injected input is volatile — the sibling input stays drift-covered");
+});
+
+test("#1273 no UE record (or a malformed one) yields no pairs and never throws", () => {
+  assert.equal(ueQueueTimeLinkPairs(null).size, 0);
+  assert.equal(ueQueueTimeLinkPairs({}).size, 0);
+  assert.equal(ueQueueTimeLinkPairs({ _nodes: [], extra: {} }).size, 0);
+  assert.equal(ueQueueTimeLinkPairs({ _nodes: [], extra: { ue_links: "not-an-array" } }).size, 0);
+  assert.equal(ueQueueTimeLinkPairs({ _nodes: [], extra: { ue_links: [null, 42] } }).size, 0);
+});
+
+test("#1273 a STALE record (deleted node or slot) contributes nothing — fail toward detecting drift", () => {
+  const root = {
+    _nodes: [{ id: 22, inputs: [{ name: "clip", link: null }] }],
+    extra: {
+      ue_links: [
+        { downstream: 99, downstream_slot: 0, upstream: 4, upstream_slot: 0, controller: 48, type: "CLIP" },
+        { downstream: 22, downstream_slot: 7, upstream: 4, upstream_slot: 0, controller: 48, type: "CLIP" },
+      ],
+    },
+  };
+  assert.equal(ueQueueTimeLinkPairs(root).size, 0,
+    "the injection cannot happen for these either, so nothing needs excluding");
+});
+
+test("#1273 a broadcast into a SUBGRAPH INSTANCE's input panel routes to every inner consumer of the slot", () => {
+  // The field report's shape: subgraph 103 holds UE senders 48/49/50 fed from
+  // the subgraph input panel; the root record targets instance 103's slot, and
+  // the flattened diff showed `103:48 anything`-style tokens.
+  const subgraph = {
+    _nodes: [
+      { id: 48, inputs: [{ name: "anything", link: 101 }] },
+      { id: 22, inputs: [{ name: "clip", link: null }] },
+    ],
+    links: { 101: link(101, -10, 0, 48, 0) },
+    inputNode: { slots: [{ linkIds: [101] }] },
+    extra: {
+      ue_links: [{ downstream: 22, downstream_slot: 0, upstream: 48, upstream_slot: 0, controller: 48, type: "CLIP" }],
+    },
+  };
+  const root = {
+    _nodes: [
+      { id: 103, inputs: [{ name: "clip", link: null }], subgraph },
+      { id: 106, inputs: [{ name: "clip", link: null }] },
+    ],
+    links: {},
+    extra: {
+      ue_links: [
+        { downstream: 103, downstream_slot: 0, upstream: 5, upstream_slot: 0, controller: 9, type: "CLIP" },
+        { downstream: 106, downstream_slot: 0, upstream: 5, upstream_slot: 1, controller: 9, type: "CLIP" },
+      ],
+    },
+  };
+  const pairs = ueQueueTimeLinkPairs(root);
+  assert.ok(pairs.has("103 clip"), "the instance's own slot pair (harmless — instances flatten away)");
+  assert.ok(pairs.has("103:48 anything"), "the inner consumer of the fed panel slot — the field report's token");
+  assert.ok(pairs.has("103:22 clip"), "the subgraph's own broadcast record applies at the instance prefix");
+  assert.ok(pairs.has("106 clip"), "a root broadcast target at the root prefix");
+  assert.equal(pairs.size, 4, "nothing beyond the routable injections");
+});
+
+test("#1273 a broadcast into the subgraph OUTPUT panel (-20) routes to the outer consumers of the instance's output slot", () => {
+  const subgraph = {
+    _nodes: [{ id: 7, inputs: [], outputs: [{ name: "IMAGE", links: [] }] }],
+    links: {},
+    inputNode: { slots: [] },
+    extra: {
+      ue_links: [{ downstream: -20, downstream_slot: 0, upstream: 7, upstream_slot: 0, controller: 8, type: "IMAGE" }],
+    },
+  };
+  const root = {
+    _nodes: [
+      { id: 10, inputs: [], outputs: [{ name: "IMAGE", links: [55] }], subgraph },
+      { id: 30, inputs: [{ name: "images", link: 55 }, { name: "filename_prefix", link: null }] },
+    ],
+    links: { 55: link(55, 10, 0, 30, 0) },
+    extra: {},
+  };
+  const pairs = ueQueueTimeLinkPairs(root);
+  assert.deepEqual([...pairs], ["30 images"],
+    "the injected inner link resolves on the outer consumer once queued");
+});
+
+test("#1273 the -20 record at the ROOT (no instance) routes nowhere", () => {
+  const root = {
+    _nodes: [{ id: 7, inputs: [] }],
+    extra: { ue_links: [{ downstream: -20, downstream_slot: 0, upstream: 7, upstream_slot: 0, controller: 8, type: "IMAGE" }] },
+  };
+  assert.equal(ueQueueTimeLinkPairs(root).size, 0);
+});
+
+test("#1273 a SHARED subgraph definition is walked once per instance prefix", () => {
+  const subgraph = {
+    _nodes: [{ id: 22, inputs: [{ name: "clip", link: null }] }],
+    links: {},
+    inputNode: { slots: [] },
+    extra: {
+      ue_links: [{ downstream: 22, downstream_slot: 0, upstream: 48, upstream_slot: 0, controller: 48, type: "CLIP" }],
+    },
+  };
+  const root = {
+    _nodes: [
+      { id: 10, inputs: [], subgraph },
+      { id: 11, inputs: [], subgraph },
+    ],
+    extra: {},
+  };
+  const pairs = ueQueueTimeLinkPairs(root);
+  assert.ok(pairs.has("10:22 clip") && pairs.has("11:22 clip"),
+    "both instances' flattened prompt keys are covered");
+});
+
+test("#1273 panel-slot routing recurses through a nested subgraph instance", () => {
+  const inner = {
+    _nodes: [{ id: 5, inputs: [{ name: "model", link: 201 }] }],
+    links: { 201: link(201, -10, 0, 5, 0) },
+    inputNode: { slots: [{ linkIds: [201] }] },
+    extra: {},
+  };
+  const middle = {
+    _nodes: [{ id: 6, inputs: [{ name: "model", link: 101 }], subgraph: inner }],
+    links: { 101: link(101, -10, 0, 6, 0) },
+    inputNode: { slots: [{ linkIds: [101] }] },
+    extra: {},
+  };
+  const root = {
+    _nodes: [{ id: 10, inputs: [{ name: "model", link: null }], subgraph: middle }],
+    extra: {
+      ue_links: [{ downstream: 10, downstream_slot: 0, upstream: 1, upstream_slot: 0, controller: 2, type: "MODEL" }],
+    },
+  };
+  const pairs = ueQueueTimeLinkPairs(root);
+  assert.ok(pairs.has("10:6 model"), "the middle instance's own slot");
+  assert.ok(pairs.has("10:6:5 model"), "the innermost consumer at the full colon path");
+});

--- a/web/js/lib/run-scope-guard.js
+++ b/web/js/lib/run-scope-guard.js
@@ -5,6 +5,12 @@ import { tr } from "./i18n.js";
 // input its handler overwrites) already live in scoped-batch-seed.js; this file
 // imports the verdict rather than restating them.
 import { rgthreeQueueTimeSeedInput } from "./scoped-batch-seed.js";
+// #1273 — the THIRD volatility signal: cg-use-everywhere materialises its
+// broadcast links into the prompt inside its own queuePrompt patch, so the
+// inputs it will inject are queue-time volatile too. The measured facts about
+// the pack (the extra.ue_links record, the io-node ids, the subgraph routing)
+// live in use-everywhere-links.js; this file imports the verdict.
+import { ueQueueTimeLinkPairs } from "./use-everywhere-links.js";
 // #556 — panel_run's to_node_id ("run to node") must NEVER silently fall through
 // to a FULL-graph execution. A scoped run can fail open on two channels:
 //
@@ -398,11 +404,13 @@ export function promptContentHashFromBody(bodyText, volatileInputs = null) {
 /**
  * The "execId inputName" pairs whose values MUTATE AT QUEUE TIME — after our
  * pre-dispatch stamp and before the POST body is built — collected from the live
- * root graph and every nested subgraph. TWO signals, because there are two
- * mechanisms (#1124): a widget-level `beforeQueued` hook, and an extension that
- * patches `api.queuePrompt` and rewrites the outgoing prompt directly. The
- * second is invisible to any widget scan, so it is matched by node identity
- * instead (rgthree's armed Seed node — see rgthreeQueueTimeSeedInput).
+ * root graph and every nested subgraph. THREE signals, one per mechanism: a
+ * widget-level `beforeQueued` hook (#572), an extension that patches
+ * `api.queuePrompt` and rewrites the outgoing prompt directly (rgthree's armed
+ * Seed node, #1124 — invisible to any widget scan, matched by node identity),
+ * and an extension that materialises virtual links into the prompt at queue
+ * time (cg-use-everywhere, #1273 — matched by the pack's own `extra.ue_links`
+ * record, see ueQueueTimeLinkPairs).
  * execId is the flattened prompt id: String(node.id) at root, the
  * colon-joined subgraph-instance path for nested nodes ("10:15:359") — the
  * same path buildNodeExecutionId produces, so pairs line up with the keys of
@@ -493,6 +501,21 @@ export function collectVolatileInputs(rootGraph) {
     }
   };
   walk(rootGraph, "");
+  // #1273 — THE THIRD VOLATILITY SIGNAL. cg-use-everywhere's queuePrompt patch
+  // converts its broadcasts to REAL links before the post body is serialized
+  // and restores them after, so the stamp's graphToPrompt and the dispatch's
+  // serialization of an UNTOUCHED graph differ on exactly the pack's own
+  // `extra.ue_links` record. Every scoped run on a UE graph was refused as
+  // "the graph CHANGED", naming the broadcast targets (model/clip/vae/…), with
+  // the retry failing identically — the injection is deterministic, not a
+  // race. The pairs are exactly the inputs the injection can materialise
+  // (subgraph routing included — see use-everywhere-links.js); everything else
+  // keeps full drift coverage, and the set rides along in `volatileInputs`
+  // like the hook and rgthree pairs. This is its own walk, not a fold into
+  // the loop above: the output-panel routing needs the INSTANCE node a bare
+  // graph walk doesn't carry, and a shared subgraph definition must be walked
+  // once per instance prefix.
+  for (const pair of ueQueueTimeLinkPairs(rootGraph)) pairs.add(pair);
   return pairs;
 }
 

--- a/web/js/lib/use-everywhere-links.js
+++ b/web/js/lib/use-everywhere-links.js
@@ -1,0 +1,183 @@
+/**
+ * #1273 — cg-use-everywhere (UE) materialises its broadcast links into the
+ * prompt AT QUEUE TIME, so the run-to-node graph stamp (#556) could never
+ * match on a UE graph: the pre-dispatch serialization (the panel's direct
+ * `app.graphToPrompt()` call) has NO UE links, the POST body has them all,
+ * and every scoped run was refused as "the graph CHANGED" — on an untouched
+ * canvas, with the retry failing identically.
+ *
+ * THE MECHANISM (read from the pack's own source, chrisgoringe/cg-use-everywhere
+ * @ main, js/use_everywhere.js + js/use_everywhere_graph_analysis.js +
+ * js/use_everywhere_apply.js; the field report on #1273 is the live
+ * observation — every differing entry was a UE broadcast target):
+ *
+ *  - UE patches `app.graphToPrompt` AND `app.queuePrompt`. Its graphToPrompt
+ *    wrapper calls the ORIGINAL unchanged UNLESS `shared.in_queuePrompt` is
+ *    set (its queuePrompt patch sets it) or the user enabled
+ *    "Use Everywhere.Options.always_modify_graph". So the panel's stamp call
+ *    gets the unmodified graph while the dispatch serializes the modified one
+ *    — the mismatch is deterministic, not a race.
+ *  - Inside queuePrompt, `GraphAnalyser.call_function_with_modified_graph`
+ *    adds a REAL link for every broadcast (`convert_to_links`), serializes,
+ *    then restores the canvas. The added links are exactly the pack's own
+ *    analysis record, which it maintains on every graph (root and each
+ *    subgraph) as `graph.extra.ue_links`: entries of
+ *    `{ downstream, downstream_slot, upstream, upstream_slot, controller, type }`
+ *    where downstream/slot name an UNCONNECTED input on a live non-UE node —
+ *    including a SUBGRAPH INSTANCE's input-panel slot, and including the
+ *    subgraph OUTPUT panel (the io node's id is -20; the input io node is -10,
+ *    per the pack's own constants).
+ *
+ * WHAT THIS MODULE DOES: turn that record into the "execId inputName" pairs
+ * the content hash must treat as queue-time volatile — the THIRD volatility
+ * signal in collectVolatileInputs, beside beforeQueued hooks (#572) and
+ * rgthree's prompt rewrite (#1124). Because the injection IS the record (an
+ * unchanged graph injects exactly these links), excluding exactly these pairs
+ * from BOTH canons makes the stamp stable on UE graphs without weakening
+ * drift detection anywhere else: a mid-window edit to any other input still
+ * mismatches, and an edit that rewires the graph changes what the post body
+ * carries OUTSIDE this set (or inside it, the same tolerated-residual class
+ * as rgthree's — disclosed via `volatileInputs` → the run result's
+ * drift_coverage note, never silent).
+ *
+ * ROUTING, because a flattened API prompt has no io nodes:
+ *
+ *  - downstream = an ordinary node: the pair is that node's input name at
+ *    downstream_slot, at the graph's own execId prefix ("103:22 clip").
+ *  - downstream = a SUBGRAPH INSTANCE's input-panel slot: the injected outer
+ *    link makes every INNER consumer of that panel slot resolvable, so the
+ *    pairs are the inner consumers' inputs ("103:48 anything" — a UE sender
+ *    fed from the panel — is how this shows up), recursing when a consumer
+ *    is itself a subgraph instance.
+ *  - downstream = -20 (this graph is a subgraph and the broadcast targets
+ *    its OUTPUT panel): the injected inner link resolves on the OUTER
+ *    consumers of the instance's matching output slot, so the pairs live in
+ *    the PARENT graph at the parent's prefix.
+ *
+ * Anything that cannot be mapped from the live graph (a stale record naming a
+ * deleted node/slot, a dead link, an io pass-through) contributes NO pair —
+ * fail toward detecting drift, exactly like a hook node that can't be
+ * resolved: the worst case is the pre-#1273 refusal on that graph, never a
+ * blind pass. Never throws: this runs on the stamp path, where a throw would
+ * fail every scoped run closed.
+ */
+
+/** The io-node ids cg-use-everywhere's own source compares against. */
+const UE_SUBGRAPH_INPUT_ID = -10;
+const UE_SUBGRAPH_OUTPUT_ID = -20;
+
+/**
+ * Subgraph nesting is shallow by construction, but this walk does NOT dedup by
+ * graph object — a shared subgraph DEFINITION must be walked once per INSTANCE
+ * (the pairs carry the instance's execId prefix, and the -20 routing depends
+ * on the specific instance node) — so a depth bound is the cycle guard.
+ */
+const MAX_UE_WALK_DEPTH = 16;
+
+const entryId = (prefix, id) => (prefix ? `${prefix}:${id}` : String(id));
+
+/**
+ * The "execId inputName" pairs cg-use-everywhere's queue-time link
+ * materialisation can add to the serialized prompt of `rootGraph`, per its
+ * own `extra.ue_links` record on each graph (see the module header).
+ *
+ * @param {object|null} rootGraph  The live root graph (app.graph).
+ * @returns {Set<string>}          Pairs in collectVolatileInputs' format.
+ */
+export function ueQueueTimeLinkPairs(rootGraph) {
+  const pairs = new Set();
+  const addPair = (execId, name) => {
+    if (name != null) pairs.add(`${execId} ${String(name)}`);
+  };
+  const nodeById = (graph, id) => {
+    for (const n of graph?._nodes ?? []) {
+      if (n != null && String(n.id) === String(id)) return n;
+    }
+    return null;
+  };
+  // Live litegraph exposes graph.links as an id-keyed object (the shape the
+  // pack itself indexes); tolerate a Map-shaped build rather than misreading it.
+  const linkById = (graph, lid) => {
+    const links = graph?.links;
+    if (!links) return null;
+    if (typeof links.get === "function") return links.get(lid) ?? null;
+    return links[lid] ?? null;
+  };
+  const linkIdsOf = (slot) => {
+    const ids = slot?.linkIds;
+    if (!ids) return [];
+    return Array.isArray(ids) ? ids : [...ids];
+  };
+
+  // Every inner consumer of a subgraph INPUT panel slot: these inputs gain a
+  // resolvable link once an outer link (real or UE-injected) feeds the slot.
+  const addInputPanelConsumers = (subgraph, slotIndex, prefix, depth) => {
+    if (!subgraph || depth <= 0) return;
+    for (const lid of linkIdsOf(subgraph.inputNode?.slots?.[slotIndex])) {
+      const link = linkById(subgraph, lid);
+      if (!link) continue;
+      // An io pass-through (target -20) routes outward again — not mappable
+      // from here without the parent chain, so it stays drift-covered.
+      const target = nodeById(subgraph, link.target_id);
+      if (!target) continue;
+      const execId = entryId(prefix, target.id);
+      addPair(execId, target.inputs?.[link.target_slot]?.name);
+      if (target.subgraph) addInputPanelConsumers(target.subgraph, link.target_slot, execId, depth - 1);
+    }
+  };
+
+  const walk = (graph, prefix, parent, depth) => {
+    if (!graph || depth <= 0) return;
+    try {
+      const ueLinks = graph.extra?.ue_links;
+      if (Array.isArray(ueLinks)) {
+        for (const entry of ueLinks) {
+          if (!entry) continue;
+          const slot = entry.downstream_slot;
+          if (String(entry.downstream) === String(UE_SUBGRAPH_OUTPUT_ID)) {
+            // A broadcast into THIS subgraph's output panel resolves on the
+            // outer consumers of the instance's matching output slot. The
+            // root graph has no instance — nothing routes outward from it.
+            if (!parent) continue;
+            const out = parent.instanceNode?.outputs?.[slot];
+            for (const lid of Array.isArray(out?.links) ? out.links : []) {
+              const link = linkById(parent.graph, lid);
+              if (!link) continue;
+              const target = nodeById(parent.graph, link.target_id);
+              if (!target) continue;
+              const execId = entryId(parent.prefix, target.id);
+              addPair(execId, target.inputs?.[link.target_slot]?.name);
+              if (target.subgraph) addInputPanelConsumers(target.subgraph, link.target_slot, execId, depth - 1);
+            }
+            continue;
+          }
+          // (Input io node -10 is never a downstream: the pack only analyses
+          // UNCONNECTED inputs of live non-UE nodes, plus the output panel.)
+          if (String(entry.downstream) === String(UE_SUBGRAPH_INPUT_ID)) continue;
+          const downstream = nodeById(graph, entry.downstream);
+          // A stale record names a node that no longer exists — but then the
+          // injection can't happen either, so nothing needs excluding.
+          if (!downstream) continue;
+          const execId = entryId(prefix, downstream.id);
+          addPair(execId, downstream.inputs?.[slot]?.name);
+          if (downstream.subgraph) {
+            // A broadcast into a subgraph INSTANCE's input-panel slot routes
+            // to every inner consumer of that slot once injected.
+            addInputPanelConsumers(downstream.subgraph, slot, execId, depth - 1);
+          }
+        }
+      }
+    } catch {
+      // A malformed record must not take down the stamp path: whatever could
+      // not be read simply stays drift-covered (the pre-#1273 behaviour).
+    }
+    for (const node of graph._nodes ?? []) {
+      if (node?.subgraph && node.id != null) {
+        walk(node.subgraph, entryId(prefix, node.id), { graph, instanceNode: node, prefix }, depth - 1);
+      }
+    }
+  };
+
+  walk(rootGraph, "", null, MAX_UE_WALK_DEPTH);
+  return pairs;
+}


### PR DESCRIPTION
## Root cause

cg-use-everywhere patches BOTH `app.graphToPrompt` and `app.queuePrompt`. Its graphToPrompt wrapper returns the **unmodified** serialization unless it is called from inside its queuePrompt patch (`shared.in_queuePrompt`) — and inside queuePrompt, `GraphAnalyser.call_function_with_modified_graph` temporarily converts every broadcast into a REAL link, serializes, then restores the canvas (pack source: `js/use_everywhere.js`, `js/use_everywhere_graph_analysis.js`, `js/use_everywhere_apply.js`).

The run-to-node guard (#556) stamps the prompt via a direct `app.graphToPrompt()` call — the **unmodified** serialization — and compares it against the POST /prompt body, which carries **all of UE's injected links**. On any graph using Anything Everywhere the two serializations of an untouched canvas can never match, so every scoped run was refused as "the graph CHANGED", and the retry (#1050) failed identically because the injection is deterministic, not a race. The field report's diff tokens (`103:22 clip`, `103:48 anything`, `106 clip`, …) are exactly the pack's broadcast targets.

## Fix

The inputs UE will inject are queue-time **volatile** — the third volatility signal in `collectVolatileInputs`, beside `beforeQueued` hooks (#572) and rgthree's prompt rewrite (#1124). UE's own analysis record, `graph.extra.ue_links` (maintained on the root graph and every subgraph), names precisely what its queue-time patch will materialise, so the stamp and the body can exclude exactly those `execId inputName` pairs on both channels.

New module `web/js/lib/use-everywhere-links.js` (`ueQueueTimeLinkPairs`) maps the record to pairs, including the routing the flattened API prompt requires:

- downstream = ordinary node → that node's input name at the graph's prefix (`103:22 clip`);
- downstream = a **subgraph instance's input-panel slot** → every inner consumer of that panel slot, recursing through nested instances (`103:48 anything` — the field report's sender tokens);
- downstream = `-20` (the subgraph **output** panel) → the outer consumers of the instance's matching output slot, at the parent's prefix;
- stale/unmappable entries (deleted node or slot, dead link, io pass-through) contribute nothing — fail toward detecting drift, i.e. the worst case is the pre-fix refusal on that graph, never a blind pass.

The pairs ride along in `volatileInputs` like the hook/rgthree pairs, so the run result's `drift_coverage` note discloses which inputs were not drift-covered. A shared subgraph definition is walked once per instance prefix (the pairs carry the instance's execId path).

**Accepted residual (same class as #1124, disclosed):** a mid-window edit to one of the excluded inputs themselves (e.g. the user rewires a link onto a UE-target input while the post is pending) is indistinguishable from the injection and is tolerated. An edit to any other input, on any node, still refuses as drift.

## Verification

- New `browser_tests/unit/use-everywhere-links.test.mjs` (8 tests): plain broadcast, malformed/stale records (no throw, no pairs), subgraph-instance input-panel routing (the field report's exact shape), output-panel (-20) routing, root-level -20, shared-definition double instantiation, nested-instance recursion.
- `run-scope-guard.test.mjs`: `collectVolatileInputs` carries the UE pairs while sibling inputs stay covered; end-to-end hash — an untouched UE graph's stamp now EQUALS its dispatched body, a mid-window edit to any other input still refuses, and the tolerated residual is pinned explicitly.
- Gates (worktree, from `origin/main` @ 092d15b8): `npm ci` ✔ (0 vulnerabilities); `npm run test:unit` ✔ exit 0 — 5002 tests, 5001 pass, 0 fail, 1 todo; `npm run typecheck` ✔ exit 0.

Not verified against a live ComfyUI with cg-use-everywhere installed — the pair computation is pinned against the pack's documented record shape and the field report's diff tokens, not a captured live queue.

Closes #1273