### PR TITLE
fix(1263): a grounding auto-persist keeps the workflow's identity across its object swap

### DIFF
--- a/browser_tests/unit/graph-binding.test.mjs
+++ b/browser_tests/unit/graph-binding.test.mjs
@@ -1915,43 +1915,54 @@ test("#557 r3/r4 wiring: programmaticSave threads the pre-save identity across a
     /preSwapUuid = expectWf \? workflowObjectUuid\(expectWf\) \|\| workflowStableUuid\(expectWf\) : null/,
     "the pre-save identity must be captured from the pre-save object BEFORE the save",
   );
+  // #1263 — the carry is shared with grounding's per-turn auto-persist, which swaps
+  // the active object the same way: programmaticSave must delegate with the save's
+  // own evidence, and the shared carry must keep the whole proof bar.
   assert.match(
     body,
-    /preWfStillOpen =\s*!Array\.isArray\(openList\) \|\| openList\.some\(\(w\) => sameWorkflowObject\(w, expectWf\)\)/,
+    /carryIdentityAcrossSaveSwap\(\{\s*svc,\s*preWf: expectWf,\s*preSwapUuid,\s*savedAs: outcome\.saved_as,\s*savedRecord: details\?\.savedRecord \?\? null,?\s*\}\)/,
+    "the carry must be delegated with the save API's own PRODUCED record — never path occupancy (r10 P0)",
+  );
+  const carryStart = src.indexOf("function carryIdentityAcrossSaveSwap(");
+  assert.notEqual(carryStart, -1, "carryIdentityAcrossSaveSwap must exist");
+  const carry = src.slice(carryStart, src.indexOf("\n}\n", carryStart));
+  assert.match(
+    carry,
+    /preWfStillOpen =\s*!Array\.isArray\(openList\) \|\| openList\.some\(\(w\) => sameWorkflowObject\(w, preWf\)\)/,
     "a predecessor still present in the open tabs (a mid-save switch) must be detected",
   );
   assert.match(
-    body,
-    /postWfIsSaveProducedRecord = Boolean\(details\?\.savedRecord\) && sameWorkflowObject\(details\.savedRecord, postSwapWf\)/,
+    carry,
+    /postWfIsSaveProducedRecord = Boolean\(savedRecord\) && sameWorkflowObject\(savedRecord, postSwapWf\)/,
     "continuity must be threaded from the save API's own PRODUCED record — never path occupancy (r10 P0)",
   );
   assert.doesNotMatch(
-    body,
+    carry,
     /successorCarriesPreUuid|postWfIsSaveTargetRecord|targetRecord/,
     "static evidence (tracker state, path occupancy) is NOT continuity (r8/r10 P0) — it must not appear in the carry",
   );
   assert.match(
-    body,
-    /shouldCarryIdentityAcrossSaveSwap\(\{\s*preWf: expectWf,\s*postWf: postSwapWf,\s*savedAs: outcome\.saved_as,\s*preWfStillOpen,\s*postWfHasConflictingEstablishedIdentity,\s*postWfIsSaveProducedRecord,\s*\}\)/,
+    carry,
+    /shouldCarryIdentityAcrossSaveSwap\(\{\s*preWf,\s*postWf: postSwapWf,\s*savedAs,\s*preWfStillOpen,\s*postWfHasConflictingEstablishedIdentity,\s*postWfIsSaveProducedRecord,?\s*\}\)/,
     "the carry must pass ALL continuity evidence to the pure rule (never a Save-As copy, never a mid-save switch, never over an established conflict, never on static evidence)",
   );
   assert.doesNotMatch(
-    body,
+    carry,
     /successorInPreSlot|preSwapSlotIndex/,
     "tab-slot occupancy is NOT continuity evidence (r5 P0) — it must not appear in the carry",
   );
   assert.match(
-    body,
+    carry,
     /postWfHasConflictingEstablishedIdentity = Boolean\(\s*postSwapWf && workflowObjectUuid\(postSwapWf\) && workflowObjectUuid\(postSwapWf\) !== preSwapUuid,?\s*\)/,
     "an established conflicting WeakMap identity on the successor must veto the carry (r7 P0)",
   );
   assert.match(
-    body,
+    carry,
     /setWorkflowObjectUuid\(postSwapWf, preSwapUuid\)/,
     "the successor object cache must be seeded with the pre-save uuid",
   );
   assert.match(
-    body,
+    carry,
     /rememberWorkflowUuidOwner\(preSwapUuid, postSwapWf\)/,
     "the successor must be registered as the pre-save uuid's owner",
   );
@@ -1962,9 +1973,11 @@ test("#557 r3/r4 wiring: programmaticSave threads the pre-save identity across a
 // reconnect during the save). onSave performs the mid-save mutation of svc.
 function buildProgrammaticSaveHarness({ onSave } = {}) {
   const src = readFileSync(PANEL_JS, "utf8").replace(/\r\n/g, "\n");
-  const start = src.indexOf("async function programmaticSave(");
+  // #1263 — the slice starts at the shared carry: programmaticSave delegates to it,
+  // so both functions must be in the evaluated source.
+  const start = src.indexOf("function carryIdentityAcrossSaveSwap(");
   const end = src.indexOf("async function reconcileSavedWorkflowCopy(", start);
-  assert.notEqual(start, -1, "programmaticSave must exist");
+  assert.notEqual(start, -1, "carryIdentityAcrossSaveSwap must exist");
   assert.notEqual(end, -1, "programmaticSave boundary must exist");
   const saveSource = src.slice(start, end);
   const ownsTagSource = panelFunctionSource(src, "workflowOwnsRootUuidTag", "assertGraphBoundToActiveWorkflow");

--- a/browser_tests/unit/workflow-grounding.test.mjs
+++ b/browser_tests/unit/workflow-grounding.test.mjs
@@ -160,3 +160,86 @@ test('groundActiveWorkflow does not double-save a turn that arrives during the c
   await Promise.all([p1, p2])
   assert.equal(copySaves, 1) // the pre-commit copy was NOT grounded a second time
 })
+
+// #1263 — grounding is a FIRST SAVE, and a first save SWAPS the active ComfyWorkflow
+// object. The identity carry must be handed the PRE-SAVE workflow and the save's own
+// PROVEN produced record, inside the grounding transaction — without it the
+// successor's next identity read re-mints the workflow uuid mid-session and the
+// orchestrator's instance fence refuses the next graph mutation.
+function groundingTrioSvc(A, disk) {
+  let active = A
+  return {
+    svc: {
+      get activeWorkflow() { return active },
+      set activeWorkflow(v) { active = v },
+      getWorkflowByPath: (p) => (disk.has(p) && p !== A.path ? { path: p, isPersisted: true } : (active && active.path === p ? active : null)),
+      saveAs: (wf, path) => ({ path, filename: path.split('/').pop(), directory: 'workflows', initialMode: 'default', isPersisted: false, isTemporary: true, changeTracker: { prepareForSave() {} } }),
+      openWorkflow: async (copy) => { active = copy },
+      saveWorkflow: async (copy) => { disk.add(copy.path); copy.isPersisted = true; copy.isTemporary = false }
+    },
+    getActive: () => active
+  }
+}
+
+test('groundActiveWorkflow invokes carryIdentity with the pre-save workflow and the produced record (#1263)', async () => {
+  const A = { isPersisted: false, isTemporary: true, path: 'workflows/Unsaved Workflow.json', filename: 'Unsaved Workflow', directory: 'workflows', initialMode: 'default' }
+  const disk = new Set([A.path])
+  const { svc, getActive } = groundingTrioSvc(A, disk)
+  const carries = []
+  const saved = await groundActiveWorkflow(svc, {
+    existsOnDisk: async () => false,
+    autoWorkflowName: () => 'Untitled X',
+    reconcileSavedCopy: async () => 'unknown',
+    carryIdentity: (args) => carries.push(args)
+  })
+  assert.equal(saved, 'Untitled X')
+  assert.equal(carries.length, 1)
+  assert.equal(carries[0].svc, svc)
+  assert.equal(carries[0].preWf, A)                 // the pre-save (consumed) tab
+  assert.equal(carries[0].savedRecord, getActive()) // the produced, now-active successor
+  assert.notEqual(carries[0].savedRecord, A)
+})
+
+test('groundActiveWorkflow does NOT invoke carryIdentity when nothing was grounded (#1263)', async () => {
+  const svc = { activeWorkflow: { isPersisted: true, isTemporary: false, path: 'workflows/MyFlow.json' } }
+  const carries = []
+  const result = await groundActiveWorkflow(svc, { existsOnDisk: async () => false, carryIdentity: (a) => carries.push(a) })
+  assert.equal(result, null)
+  assert.equal(carries.length, 0)
+})
+
+test('groundActiveWorkflow threads a NULL savedRecord when the produced record is unproven (#1263 fail-safe)', async () => {
+  const A = { isPersisted: false, isTemporary: true, path: 'workflows/Unsaved Workflow.json', filename: 'Unsaved Workflow', directory: 'workflows', initialMode: 'default' }
+  const disk = new Set([A.path])
+  const { svc } = groundingTrioSvc(A, disk)
+  // A tab switch lands during the awaited persist: the post-trio active tab is NOT
+  // the copy the trio wrote, so the adapter threads NO produced record — the carry
+  // must see that as null and fail safe, never seed a foreign tab.
+  const foreign = { path: 'workflows/Foreign.json', filename: 'Foreign', isPersisted: true, isTemporary: false }
+  const origSaveWorkflow = svc.saveWorkflow
+  svc.saveWorkflow = async (copy) => { await origSaveWorkflow(copy); svc.activeWorkflow = foreign }
+  const carries = []
+  const saved = await groundActiveWorkflow(svc, {
+    existsOnDisk: async () => false,
+    autoWorkflowName: () => 'Untitled X',
+    reconcileSavedCopy: async () => 'unknown',
+    carryIdentity: (args) => carries.push(args)
+  })
+  assert.ok(saved, "the save still happened and is reported")
+  assert.equal(carries.length, 1)
+  assert.equal(carries[0].preWf, A)
+  assert.equal(carries[0].savedRecord, null)
+})
+
+test('groundActiveWorkflow still reports the save when carryIdentity throws (#1263)', async () => {
+  const A = { isPersisted: false, isTemporary: true, path: 'workflows/Unsaved Workflow.json', filename: 'Unsaved Workflow', directory: 'workflows', initialMode: 'default' }
+  const disk = new Set([A.path])
+  const { svc } = groundingTrioSvc(A, disk)
+  const saved = await groundActiveWorkflow(svc, {
+    existsOnDisk: async () => false,
+    autoWorkflowName: () => 'Untitled X',
+    reconcileSavedCopy: async () => 'unknown',
+    carryIdentity: () => { throw new Error('boom') }
+  })
+  assert.equal(saved, 'Untitled X') // identity bookkeeping never un-reports a save
+})

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -5566,6 +5566,51 @@ function autoWorkflowName() {
   return `Untitled ${d.getFullYear()}-${p(d.getMonth() + 1)}-${p(d.getDate())} ${p(d.getHours())}-${p(d.getMinutes())}-${p(d.getSeconds())}`;
 }
 
+/** #557 — thread a save's pre-swap identity onto the successor the save itself
+ *  PRODUCED, with continuity verified HERE, at the seed point (postWf is read
+ *  from the service after the awaited save): the predecessor must be GONE from
+ *  the open tabs — a user/reconnect tab switch during the await keeps it open
+ *  and must abort the carry entirely — and the post-save ACTIVE object must be
+ *  the record the save API itself produced (details.savedRecord, threaded by the
+ *  save lib). STATIC evidence is never accepted: tab-slot occupancy can seat a
+ *  foreign tab in the predecessor's old slot (r5), a lagging tracker state
+ *  carrying the pre-save uuid can be residue (r8), and path occupancy is
+ *  satisfied by any close→reopen of the same file — which is a NEW identity,
+ *  not a successor (r10). A successor the event thread can't prove fails SAFE
+ *  (no carry); the lazy backstop / proven repaint heals the genuine case
+ *  afterward. Shared by programmaticSave (panel save tools) and grounding's
+ *  carryIdentity (the per-turn auto-persist, #1263) — both are first-save object
+ *  swaps with the same proof bar. */
+function carryIdentityAcrossSaveSwap({ svc, preWf, preSwapUuid, savedAs = false, savedRecord = null } = {}) {
+  if (!preSwapUuid) return;
+  const postSwapWf = svc?.activeWorkflow;
+  const openList = svc?.openWorkflows;
+  const preWfStillOpen =
+    !Array.isArray(openList) || openList.some((w) => sameWorkflowObject(w, preWf));
+  // r7 P0 — even with continuity proven, never overwrite an established,
+  // DIFFERENT identity on the successor: that is a conflicting tab, not A's
+  // continuation, and seeding it would poison the owner map.
+  const postWfHasConflictingEstablishedIdentity = Boolean(
+    postSwapWf && workflowObjectUuid(postSwapWf) && workflowObjectUuid(postSwapWf) !== preSwapUuid
+  );
+  // r10 P0 — the save API's own produced record is the ONLY succession proof:
+  // a close→reopen of the same path is not what the save produced.
+  const postWfIsSaveProducedRecord = Boolean(savedRecord) && sameWorkflowObject(savedRecord, postSwapWf);
+  if (
+    shouldCarryIdentityAcrossSaveSwap({
+      preWf,
+      postWf: postSwapWf,
+      savedAs,
+      preWfStillOpen,
+      postWfHasConflictingEstablishedIdentity,
+      postWfIsSaveProducedRecord,
+    })
+  ) {
+    if (!workflowObjectUuid(postSwapWf)) setWorkflowObjectUuid(postSwapWf, preSwapUuid);
+    rememberWorkflowUuidOwner(preSwapUuid, postSwapWf);
+  }
+}
+
 /** Programmatically save the active workflow — NO Save/Rename dialog.
  *
  *  Delegates to the shared, unit-tested `saveActiveWorkflow` (web/js/lib/
@@ -5636,46 +5681,16 @@ async function programmaticSave(name) {
   });
   const outcome = describeSaveOutcome(details);
   // #557 r3/r4/r5/r7/r8/r10 — thread the identity across the swap ONLY with
-  // CONTINUITY PROVEN FROM THE SAVE'S OWN REPLACEMENT EVENT, verified at the
-  // seed point (postWf is read from the service HERE, after the awaited save):
-  // the predecessor must be GONE from the open tabs — a user/reconnect tab
-  // switch during the await keeps it open and must abort the carry entirely —
-  // and the post-save ACTIVE object must be the record the save API itself
-  // PRODUCED (details.savedRecord, threaded by the save lib). STATIC evidence
-  // is never accepted: tab-slot occupancy can seat a foreign tab in the
-  // predecessor's old slot (r5), a lagging tracker state carrying the pre-save
-  // uuid can be residue (r8), and path occupancy is satisfied by any
-  // close→reopen of the same file — which is a NEW identity, not a successor
-  // (r10). A successor the event thread can't prove fails SAFE (no carry); the
-  // lazy backstop / proven repaint heals the genuine case afterward.
-  const postSwapWf = svc?.activeWorkflow;
-  if (preSwapUuid) {
-    const openList = svc?.openWorkflows;
-    const preWfStillOpen =
-      !Array.isArray(openList) || openList.some((w) => sameWorkflowObject(w, expectWf));
-    // r7 P0 — even with continuity proven, never overwrite an established,
-    // DIFFERENT identity on the successor: that is a conflicting tab, not A's
-    // continuation, and seeding it would poison the owner map.
-    const postWfHasConflictingEstablishedIdentity = Boolean(
-      postSwapWf && workflowObjectUuid(postSwapWf) && workflowObjectUuid(postSwapWf) !== preSwapUuid
-    );
-    // r10 P0 — the save API's own produced record is the ONLY succession proof:
-    // a close→reopen of the same path is not what the save produced.
-    const postWfIsSaveProducedRecord = Boolean(details?.savedRecord) && sameWorkflowObject(details.savedRecord, postSwapWf);
-    if (
-      shouldCarryIdentityAcrossSaveSwap({
-        preWf: expectWf,
-        postWf: postSwapWf,
-        savedAs: outcome.saved_as,
-        preWfStillOpen,
-        postWfHasConflictingEstablishedIdentity,
-        postWfIsSaveProducedRecord,
-      })
-    ) {
-      if (!workflowObjectUuid(postSwapWf)) setWorkflowObjectUuid(postSwapWf, preSwapUuid);
-      rememberWorkflowUuidOwner(preSwapUuid, postSwapWf);
-    }
-  }
+  // CONTINUITY PROVEN FROM THE SAVE'S OWN REPLACEMENT EVENT. The carry and its
+  // whole proof bar live in carryIdentityAcrossSaveSwap, shared with grounding's
+  // per-turn auto-persist (#1263), which swaps the active object the same way.
+  carryIdentityAcrossSaveSwap({
+    svc,
+    preWf: expectWf,
+    preSwapUuid,
+    savedAs: outcome.saved_as,
+    savedRecord: details?.savedRecord ?? null,
+  });
   // INDEPENDENT post-save verification (a second backstop, at the tool layer) for a
   // Save-As COPY: attest whether the REAL source file is still on disk. This reports
   // PATH PRESENCE (`original_on_disk`), not content identity — an honest, disk-checked
@@ -5942,6 +5957,22 @@ async function groundUnsavedWorkflow() {
       // routes on is enough — threads carry it as `workflowRouteKey`, which is what the
       // filter matches — and if none exists yet there is nothing to bridge anyway.
       identityProbe: (wf) => ({ routeId: (wf ? _tempWorkflowInstanceIds.get(wf) : null) ?? null }),
+      // #1263 — grounding is a FIRST SAVE, and a first save swaps the active
+      // ComfyWorkflow object. Without this carry the successor's next identity
+      // read re-minted the workflow uuid mid-session (no object cache on the new
+      // object, and the just-created file's embedded uuid fails the #557
+      // succession-proof for an unsaved tab whose embed omitted workflow_path),
+      // so the orchestrator's instance fence refused the next graph mutation
+      // until a re-hello landed. Thread the pre-save identity across the swap
+      // exactly as programmaticSave does for the panel's own save tools: the
+      // same predicate, the same fail-safe-on-any-proof-gap behaviour. Ownership
+      // here is known by CAUSATION (the panel called this save and awaited it —
+      // see the #847 note in workflow-chat-identity.js), which is what makes
+      // seeding safe rather than inferred.
+      carryIdentity: ({ svc: groundSvc, preWf, savedRecord }) => {
+        const preSwapUuid = preWf ? workflowObjectUuid(preWf) || workflowStableUuid(preWf) : null;
+        carryIdentityAcrossSaveSwap({ svc: groundSvc, preWf, preSwapUuid, savedAs: false, savedRecord });
+      },
       onGrounded: ({ savedName, identity }) => {
         // One implementation, shared with the tests (codex) — see groundedWorkflowPath.
         const path = groundedWorkflowPath(savedName);

--- a/web/js/lib/workflow-save.js
+++ b/web/js/lib/workflow-save.js
@@ -271,10 +271,20 @@ const _groundingChain = new Map(); // svc -> tail Promise<void>
 /** One grounding attempt: probe the ACTIVE workflow's on-disk state, then save the
  *  EXACT SAME workflow it probed (`expect: wf` → saveActiveWorkflow refuses if the
  *  active workflow changed during the async probe, so we never authorize on tab A
- *  and write to tab B). Best-effort: any refusal/hiccup ⇒ null (leave ungrounded). */
+ *  and write to tab B). Best-effort: any refusal/hiccup ⇒ null (leave ungrounded).
+ *
+ *  `carryIdentity` is an OPTIONAL callback fired synchronously after a successful
+ *  grounding save, inside this serialized transaction, with the pre-save workflow
+ *  and the save's own PROVEN produced record (`details.savedRecord`). Grounding a
+ *  never-persisted tab is a first save, and a first save SWAPS the active
+ *  ComfyWorkflow object — without threading the pre-save identity onto the
+ *  produced successor, the successor's next identity read re-mints the workflow
+ *  uuid mid-session and the orchestrator's instance fence refuses the next graph
+ *  mutation (panel#1263). The callback owns the whole proof decision (it must
+ *  fail safe on any gap); this module only guarantees the timing and the inputs. */
 async function groundOnce(
   svc,
-  { existsOnDisk, autoWorkflowName, reconcileSavedCopy, canvasBinding, identityProbe, onGrounded } = {},
+  { existsOnDisk, autoWorkflowName, reconcileSavedCopy, canvasBinding, identityProbe, onGrounded, carryIdentity } = {},
 ) {
   try {
     const wf = svc?.activeWorkflow;
@@ -294,13 +304,30 @@ async function groundOnce(
       preIdentity = null; // bookkeeping must never stop a save that protects user work
     }
     if (!(await groundingIsSafe(wf, existsOnDisk))) return null;
+    // #1263 — thread the save's outcome sink so the identity carry below can work
+    // from the save's own PROVEN produced record, never a post-await active-tab read.
+    const details = {};
     const savedName = await saveActiveWorkflow(svc, undefined, {
       autoWorkflowName,
       existsOnDisk,
       reconcileSavedCopy,
       canvasBinding,
       expect: wf,
+      details,
     });
+    // The carry runs BEFORE onGrounded and inside the same serialized operation as
+    // the save: the successor it seeds is the live active object RIGHT NOW, and any
+    // later identity read (the 600ms poll, command dispatch) must already see the
+    // carried uuid rather than minting a fresh one. Best-effort like the rest of
+    // grounding bookkeeping — a carry failure must never un-report a save that
+    // already protected the user's work; the drift re-hello heals a missed carry.
+    if (savedName && typeof carryIdentity === "function") {
+      try {
+        carryIdentity({ svc, preWf: wf, savedRecord: details?.savedRecord ?? null });
+      } catch {
+        /* identity bookkeeping must never fail a save that protected user work */
+      }
+    }
     // The name the save ITSELF produced — never re-read from `svc.activeWorkflow`, which by
     // now may be a different tab entirely.
     if (savedName && preIdentity && typeof onGrounded === "function") {


### PR DESCRIPTION
Closes #1263

## Root cause

A new tab from `panel_new_workflow` is grounded on the next agent turn: the panel auto-saves the never-persisted tab under an `Untitled <timestamp>` name (#330 grounding — the "auto-persist" in the report). A first save **swaps the active ComfyWorkflow object**, but the #557 identity carry lived only in `programmaticSave` (the panel's own save tools). Grounding (`groundOnce` in `web/js/lib/workflow-save.js`) never ran it, so the successor object found:

- no object-cache uuid (brand-new object),
- an embedded uuid in the just-written file that **fails the #557 succession proof** — an unsaved tab's embed carries `workflow_uuid` but no `workflow_path`, and `hasEmbeddedUuidSuccessionEvidence` deliberately fails toward forking in exactly that case,

so the next identity read **re-minted the workflow uuid mid-session** (`c3755c1e…` → `42dcaa96…` in the report) and the orchestrator's instance fence refused the next graph mutation with `workflow instance mismatch`.

## Staleness check (why this is not already fixed)

- **#1279** (drift re-hello before the next call) and the tmp:→wf: route-change re-hello only *narrow* the window — a mutation landing before the next 600ms poll is still refused, which is the reported failure.
- **#1323** publishes a first save's produced identity **in the save reply** — but grounding has no reply; nothing published its re-minted identity.
- No commit on current `main` touches `workflow-chat-identity.js`/`workflow-save.js` since the report; the re-mint path is unchanged.

## Fix

- `web/js/lib/workflow-save.js` — `groundOnce` now threads the save's `details` sink and fires an optional `carryIdentity({ svc, preWf, savedRecord })` callback synchronously after a successful grounding save, inside the same serialized transaction, with the save's own PROVEN produced record (`details.savedRecord`). Best-effort: a callback throw never un-reports a save that protected user work.
- `web/js/comfyui-mcp-panel.js` — the #557 carry block is extracted **unchanged** from `programmaticSave` into `carryIdentityAcrossSaveSwap` (same `shouldCarryIdentityAcrossSaveSwap` predicate, same proof bar: predecessor gone from open tabs, no conflicting established identity, produced record is the active object), and `programmaticSave` now delegates to it. `groundUnsavedWorkflow` passes a `carryIdentity` that runs the same carry for the grounding swap — grounding ownership is known by causation (the panel called the save and awaited it), which is what makes seeding safe rather than inferred.

Any proof gap fails safe to the pre-fix behaviour (re-mint + drift re-hello) — never a wrong-canvas seeding.

## Tests

- `browser_tests/unit/workflow-grounding.test.mjs` (+4): the carry receives the pre-save workflow and the produced, now-active successor; no carry when nothing was grounded; `savedRecord` is **null** when the produced record is unproven (mid-save tab switch — fail-safe); a throwing carry never un-reports the save.
- `browser_tests/unit/graph-binding.test.mjs`: the #557 source-pinning test now asserts `programmaticSave` delegates to the shared carry and pins the carry's proof bar at its new home; the eval harness slice includes both functions.

## Verification (worktree at origin/main)

- `npm ci` — clean
- `npm run test:unit` — 4996 tests, 4995 pass, 0 fail, 1 todo (exit 0)
- `npm run typecheck` — clean (exit 0)