### PR TITLE
fix(1269): a second panel bundle in the page stands down instead of fighting for the tab

### DIFF
--- a/browser_tests/unit/duplicate-panel-guard.test.mjs
+++ b/browser_tests/unit/duplicate-panel-guard.test.mjs
@@ -1,0 +1,168 @@
+/**
+ * Unit tests for #1269 — one panel bundle per page.
+ *
+ * Two installs of the pack (a git clone at custom_nodes/comfyui-mcp-panel AND a
+ * Manager install at custom_nodes/comfyui-agent-panel) load two bundles into the
+ * same page; both connect and hello under the same workflow tab ids, and the
+ * stale copy's version-less, fence-less hello can own the connection the
+ * orchestrator routes to — so a CURRENT install sees graph writes refused as
+ * "this tab advertised NO panel version", and a hard refresh cannot help. These
+ * lock the module-scope arbitration (newer copy wins, older stands down loudly)
+ * and the setup()-time backstop for copies too old to carry the guard.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+import {
+  arbitratePanelCopy,
+  countExtensionsNamed,
+  describeDuplicatePanelCopies,
+  describeUnguardedDuplicatePanelCopy,
+  installDirFromBundleUrl,
+  PANEL_EXTENSION_NAME,
+} from "../../web/js/lib/duplicate-panel-guard.js";
+
+test("arbitratePanelCopy: the only copy claims the page and stays active", () => {
+  const registry = {};
+  const a = arbitratePanelCopy({ registry, self: { version: "0.15.1", url: "/extensions/comfyui-mcp-panel/x.js" } });
+  assert.equal(a.outcome, "sole");
+  assert.equal(a.active(), true);
+  assert.equal(a.prior, null);
+});
+
+test("arbitratePanelCopy: a NEWER later copy takes over and stands the older one down", () => {
+  const registry = {};
+  const older = arbitratePanelCopy({ registry, self: { version: "0.11.43", url: "/extensions/comfyui-agent-panel/x.js" } });
+  assert.equal(older.outcome, "sole");
+  const newer = arbitratePanelCopy({ registry, self: { version: "0.15.1", url: "/extensions/comfyui-mcp-panel/x.js" } });
+  assert.equal(newer.outcome, "took-over");
+  assert.equal(newer.active(), true);
+  assert.deepEqual(newer.prior, { version: "0.11.43", url: "/extensions/comfyui-agent-panel/x.js" });
+  // The older copy's flag moved AFTER its own arbitration — the setup()-time
+  // re-check exists for exactly this ordering, and it names WHO took over.
+  assert.equal(older.active(), false);
+  assert.deepEqual(older.supersededBy(), { version: "0.15.1", url: "/extensions/comfyui-mcp-panel/x.js" });
+  // The registry now names the newer copy, so a THIRD copy arbitrates against it.
+  const third = arbitratePanelCopy({ registry, self: { version: "0.14.0", url: "/extensions/third/x.js" } });
+  assert.equal(third.outcome, "stood-down");
+});
+
+test("arbitratePanelCopy: an older or equal later copy stands down; the first claim keeps the page", () => {
+  const registry = {};
+  const first = arbitratePanelCopy({ registry, self: { version: "0.15.1", url: "/extensions/comfyui-agent-panel/x.js" } });
+  const older = arbitratePanelCopy({ registry, self: { version: "0.11.43", url: "/extensions/comfyui-mcp-panel/x.js" } });
+  assert.equal(older.outcome, "stood-down");
+  assert.equal(older.active(), false);
+  assert.equal(first.active(), true);
+  const equal = arbitratePanelCopy({ registry, self: { version: "0.15.1", url: "/extensions/elsewhere/x.js" } });
+  assert.equal(equal.outcome, "stood-down");
+  assert.equal(first.active(), true);
+});
+
+test("arbitratePanelCopy: a malformed prior claim is claimable, not a silencer", () => {
+  const registry = { __comfyuiMcpPanelGuard: { noVersion: true } };
+  const a = arbitratePanelCopy({ registry, self: { version: "0.15.1", url: "/extensions/comfyui-mcp-panel/x.js" } });
+  assert.equal(a.outcome, "sole");
+  assert.equal(a.active(), true);
+});
+
+test("arbitratePanelCopy: a throwing prior standDown does not keep the newer copy off the page", () => {
+  const registry = {
+    __comfyuiMcpPanelGuard: {
+      version: "0.11.43",
+      url: "/extensions/old/x.js",
+      standDown: () => { throw new Error("broken"); },
+    },
+  };
+  const newer = arbitratePanelCopy({ registry, self: { version: "0.15.1", url: "/extensions/comfyui-mcp-panel/x.js" } });
+  assert.equal(newer.outcome, "took-over");
+  assert.equal(newer.active(), true);
+});
+
+test("installDirFromBundleUrl: names the custom_nodes directory the bundle was served from", () => {
+  assert.equal(
+    installDirFromBundleUrl("http://127.0.0.1:8188/extensions/comfyui-agent-panel/comfyui-mcp-panel.js"),
+    "comfyui-agent-panel",
+  );
+  assert.equal(installDirFromBundleUrl("/extensions/comfyui-mcp-panel/comfyui-mcp-panel.js"), "comfyui-mcp-panel");
+  assert.equal(installDirFromBundleUrl("not-a-bundle-url"), null);
+  assert.equal(installDirFromBundleUrl(undefined), null);
+});
+
+test("describeDuplicatePanelCopies: names BOTH install directories and the remedy", () => {
+  const msg = describeDuplicatePanelCopies({
+    outcome: "stood-down",
+    self: { version: "0.11.43", url: "http://x/extensions/comfyui-mcp-panel/comfyui-mcp-panel.js" },
+    prior: { version: "0.15.1", url: "http://x/extensions/comfyui-agent-panel/comfyui-mcp-panel.js" },
+  });
+  assert.match(msg, /comfyui-mcp-panel/);
+  assert.match(msg, /comfyui-agent-panel/);
+  assert.match(msg, /0\.11\.43/);
+  assert.match(msg, /0\.15\.1/);
+  assert.match(msg, /standing down/);
+  assert.match(msg, /Remove one of the two panel installs/);
+  const takeover = describeDuplicatePanelCopies({
+    outcome: "took-over",
+    self: { version: "0.15.1", url: "/extensions/comfyui-mcp-panel/x.js" },
+    prior: { version: "0.11.43", url: "/extensions/comfyui-agent-panel/x.js" },
+  });
+  assert.match(takeover, /newer copy is taking over/);
+});
+
+test("describeUnguardedDuplicatePanelCopy: names the cause without claiming the other copy's version", () => {
+  const msg = describeUnguardedDuplicatePanelCopy({
+    self: { version: "0.15.1", url: "/extensions/comfyui-mcp-panel/x.js" },
+  });
+  assert.match(msg, /another copy of the panel pack is registered/);
+  assert.match(msg, /comfyui-mcp-panel/);
+  assert.match(msg, /0\.15\.1/);
+  assert.match(msg, /remove it, and restart/);
+});
+
+test("countExtensionsNamed: our own registration is one; above one is a duplicate pack", () => {
+  assert.equal(countExtensionsNamed(undefined, PANEL_EXTENSION_NAME), 0);
+  assert.equal(countExtensionsNamed([], PANEL_EXTENSION_NAME), 0);
+  assert.equal(countExtensionsNamed([{ name: PANEL_EXTENSION_NAME }], PANEL_EXTENSION_NAME), 1);
+  assert.equal(
+    countExtensionsNamed(
+      [{ name: PANEL_EXTENSION_NAME }, { name: "other.ext" }, { name: PANEL_EXTENSION_NAME }, null],
+      PANEL_EXTENSION_NAME,
+    ),
+    2,
+  );
+});
+
+// The wiring is browser plumbing (module scope / registration / setup), so its
+// safety INVARIANTS are pinned at source level, in the style of the #584
+// healer pins in bundle-version.test.mjs:
+//   - the arbitration runs at MODULE SCOPE (before any registration polling),
+//     or two copies can both register before either arbitrates;
+//   - registration honors the verdict BEFORE wrapping the app or registering;
+//   - setup() re-checks (a later-evaluated newer copy can stand this one down
+//     after it registered) and runs the guardless-duplicate backstop.
+test("#1269 wiring invariants: module-scope arbitration, guarded registration, setup() re-check", () => {
+  const src = readFileSync(
+    join(dirname(fileURLToPath(import.meta.url)), "../../web/js/comfyui-mcp-panel.js"),
+    "utf8",
+  ).replace(/\r\n/g, "\n");
+  const arbitration = src.indexOf("const panelCopyArbitration = arbitratePanelCopy({");
+  assert.notEqual(arbitration, -1, "the copy arbitration runs at module scope");
+  const registration = src.indexOf("function registerExtensionWhenReady(");
+  assert.ok(arbitration < registration, "the arbitration precedes registration polling");
+  const guard = src.indexOf("if (!panelCopyArbitration.active()) return notePanelCopyStandDown();", registration);
+  assert.ok(guard !== -1 && guard < src.indexOf("installCreateBoundaryFork(app);", registration),
+    "a stood-down copy returns before wrapping the app or registering");
+  const setupAt = src.indexOf("async setup() {");
+  const setupRecheck = src.indexOf("if (panelCopyGuardBlocksSetup(app)) return;", setupAt);
+  assert.ok(setupRecheck !== -1, "setup() re-checks the arbitration — it can move after registration");
+  const helper = src.indexOf("function panelCopyGuardBlocksSetup(");
+  const backstop = src.indexOf("countExtensionsNamed(comfyApp?.extensions, PANEL_EXTENSION_NAME)", helper);
+  assert.ok(backstop !== -1, "the guardless-duplicate backstop lives in the setup() gate");
+  assert.ok(
+    backstop > src.indexOf("if (!panelCopyArbitration.active()) {", helper),
+    "the backstop runs only for the copy that survived arbitration",
+  );
+});

--- a/browser_tests/unit/i18n.test.mjs
+++ b/browser_tests/unit/i18n.test.mjs
@@ -267,7 +267,12 @@ test("the catalog is loaded at startup, before the panel paints", () => {
   const src = readFileSync(join(ROOT, "web/js/comfyui-mcp-panel.js"), "utf8");
   const setupAt = src.indexOf("async setup() {");
   assert.notEqual(setupAt, -1, "registerExtension must still have a setup()");
-  const head = src.slice(setupAt, setupAt + 900);
+  // The window covers everything setup() does BEFORE the catalog load. It grew
+  // 900 → 1200 with #1269, whose duplicate-copy gate is itself mandated-first
+  // (a copy that lost the page arbitration must stop before anything wraps or
+  // connects); the pin's purpose — awaited, and before the first paint — is
+  // unchanged.
+  const head = src.slice(setupAt, setupAt + 1200);
   assert.match(head, /await applyPanelLocale\(\)/, "setup() must await the catalog load");
 
   // AWAITED, not fired-and-forgotten: an unawaited load resolves after the first render and

--- a/scripts/check-tool-vocabulary.mjs
+++ b/scripts/check-tool-vocabulary.mjs
@@ -207,6 +207,12 @@ const NOT_TOOL_NAMES = [
     context: "panel_version: panelVersion",
     why: "same payload property key in the session-rebind frame, not a tool reference",
   },
+  {
+    name: "panel_version",
+    file: "web/js/lib/duplicate-panel-guard.js",
+    context: "no `panel_version` before 0.11.83",
+    why: "the hello payload field, named in the #1269 doc comment — not a tool reference",
+  },
 ];
 
 /**

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -77,6 +77,13 @@ import { armReloadBlockedNotice, unsavedReloadBlockers, reloadWouldBeBlockedMess
 // #1180 — the repo's one bounded-step primitive. A second timeout helper written alongside
 // it is how this repo keeps producing near-duplicate bugs, per that file's own header.
 import { withTimeout } from "./lib/bounded-step.js";
+import {
+  arbitratePanelCopy,
+  countExtensionsNamed,
+  describeDuplicatePanelCopies,
+  describeUnguardedDuplicatePanelCopy,
+  PANEL_EXTENSION_NAME,
+} from "./lib/duplicate-panel-guard.js";
 import { pressableWidgetHint } from "./lib/pressable-widget.js";
 import { looksLikeApiWorkflow, apiLoadShortfall, apiLoadNote } from "./lib/api-workflow-load.js";
 import { installNodeConfigureIsolation, retryNodeRestores } from "./lib/load-restore-isolation.js";
@@ -1716,6 +1723,24 @@ const DOCS_URL = "https://comfyui-mcp.artokun.io/docs";
 // `node scripts/set-version.mjs <v>` (updates this AND pyproject together); CI
 // and the publish gate FAIL if the two ever drift, so this can't go stale.
 const PANEL_VERSION = "0.15.2";
+
+// #1269 — ONE panel bundle per page, arbitrated AT MODULE SCOPE, before either
+// copy's registration polling can run. Two installs of this pack (a git clone at
+// custom_nodes/comfyui-mcp-panel AND a Manager install at custom_nodes/comfyui-agent-panel)
+// load two bundles into the same page; both connect and hello under the same
+// workflow tab ids, and whichever hello lands last owns the one connection the
+// bridge keeps per tab id. A stale copy winning that race is why a CURRENT
+// install sees graph writes refused as "this tab advertised NO panel version" —
+// and why a hard refresh cannot help (the stale copy is served from its own
+// stale directory). The orchestrator cannot tell a stale duplicate's hello from
+// a genuinely old panel's and must fail closed either way, so the arbitration
+// has to happen here: the NEWER bundle runs, the older one stands down loudly.
+// Consulted again inside setup() — a later-evaluated newer copy can stand this
+// one down after it has already registered.
+const panelCopyArbitration = arbitratePanelCopy({
+  registry: globalThis,
+  self: { version: PANEL_VERSION, url: import.meta.url },
+});
 
 // The connected orchestrator's console URL/token (captured off the `backends`
 // bridge message — see onBackends). Drives the "API Keys" credentials frame;
@@ -35333,6 +35358,43 @@ async function healStaleBundleIfNeeded() {
   }
 }
 
+// #1269 — the loud stand-down, shared by the registration gate and the setup()
+// re-check. `prior` names the copy that beat this one at arbitration;
+// `supersededBy()` names the newer copy that stood this one down afterwards.
+function notePanelCopyStandDown() {
+  console.error(
+    describeDuplicatePanelCopies({
+      outcome: panelCopyArbitration.outcome,
+      self: { version: PANEL_VERSION, url: import.meta.url },
+      prior: panelCopyArbitration.prior ?? panelCopyArbitration.supersededBy?.(),
+    }),
+  );
+}
+
+// #1269 — the setup()-time half of the duplicate-copy guard. True means setup
+// must NOT proceed: the arbitration moved after this copy registered (a later-
+// evaluated newer copy stood it down), so say so and stop before anything wraps,
+// probes, or connects. False still carries one duty: NAME a GUARDLESS duplicate —
+// a copy too old to arbitrate never writes the shared claim, but it registers
+// under the same extension name, and setup() runs after every registration.
+function panelCopyGuardBlocksSetup(comfyApp) {
+  if (!panelCopyArbitration.active()) {
+    notePanelCopyStandDown();
+    return true;
+  }
+  if (
+    panelCopyArbitration.outcome === "sole" &&
+    countExtensionsNamed(comfyApp?.extensions, PANEL_EXTENSION_NAME) > 1
+  ) {
+    console.error(
+      describeUnguardedDuplicatePanelCopy({
+        self: { version: PANEL_VERSION, url: import.meta.url },
+      }),
+    );
+  }
+  return false;
+}
+
 function registerExtensionWhenReady(tries = 0) {
   const comfyApp = window.comfyAPI?.app?.app || window.app;
   if (!comfyApp || typeof comfyApp.registerExtension !== "function") {
@@ -35347,6 +35409,10 @@ function registerExtensionWhenReady(tries = 0) {
   }
   app = comfyApp;
   api = window.comfyAPI?.api?.api || window.api || null;
+  // #1269 — a copy that LOST the module-scope arbitration never registers: no
+  // sidebar tab, no bridge socket, no hello. Loud, never silent — a page with
+  // no panel and no explanation is the worst outcome.
+  if (!panelCopyArbitration.active()) return notePanelCopyStandDown();
   // #570 P0 — wrap app.loadGraphData so every workflow CREATION (import/paste/duplicate/
   // new) mints a fresh per-instance uuid, so a copy can't inherit the source's session.
   installCreateBoundaryFork(app);
@@ -35361,6 +35427,10 @@ function registerExtensionWhenReady(tries = 0) {
     // never persist a raw value here. See panelSettingsList() above.
     settings: panelSettingsList(),
     async setup() {
+      // #1269 — the page arbitration can move AFTER registration (a later-
+      // evaluated newer copy stood this one down); honor it, and name a
+      // guardless duplicate, before anything wraps, probes, or connects.
+      if (panelCopyGuardBlocksSetup(app)) return;
       // #1667 P0 — wrap the workflow store's saveWorkflow with the stale-canvas
       // persist guard FIRST, before any of the below can trigger a graph change that
       // the frontend autosave would persist unchecked. setup() runs post-app-init, so

--- a/web/js/lib/duplicate-panel-guard.js
+++ b/web/js/lib/duplicate-panel-guard.js
@@ -1,0 +1,153 @@
+/**
+ * #1269 — ONE panel bundle per page.
+ *
+ * The pack can be installed twice — a git clone at `custom_nodes/comfyui-mcp-panel`
+ * AND a Manager/Registry install at `custom_nodes/comfyui-agent-panel` — and ComfyUI
+ * loads BOTH web bundles into the same page. Each copy opens its own bridge socket
+ * and hellos under the same workflow tab ids, and the bridge keeps exactly one
+ * connection per tab id: whichever hello landed last owns it. A STALE copy's hello
+ * (no `panel_version` before 0.11.83, no workflow-stamp fence flags before 0.11.29,
+ * bare `wf:<path>` tab ids before the per-tab route) then owns the connection the
+ * orchestrator routes "the active workflow" to, while the CURRENT copy's full
+ * advertisement sits on a connection nothing routes to. Every graph write is
+ * refused as "this tab advertised NO panel version" on an install that is current,
+ * and the stated remedy — a hard refresh — cannot help, because the stale copy is
+ * served from its own stale directory and re-registers on every reload.
+ *
+ * The orchestrator cannot fix this from its side: a version-less hello is
+ * indistinguishable from a genuinely old panel, and the write fence must fail
+ * closed either way. What CAN fix it is the bundle itself, at module scope, before
+ * either copy's `setup()` can register or connect: arbitrate so the NEWER bundle
+ * runs and the older one stands down loudly.
+ *
+ * These helpers are PURE / dependency-injected (no DOM, no ComfyUI globals) so the
+ * arbitration is unit-testable without a browser.
+ */
+
+import { compareVersions } from "./changelog-delta.js";
+
+/** The shared page-global both copies of the bundle arbitrate through. */
+export const DUPLICATE_PANEL_GUARD_KEY = "__comfyuiMcpPanelGuard";
+
+/** The extension name every copy of this pack registers under. */
+export const PANEL_EXTENSION_NAME = "comfyui-mcp.agent-panel";
+
+/** The install directory a bundle URL names: `/extensions/<dir>/...`. */
+export function installDirFromBundleUrl(url) {
+  const match = typeof url === "string" && url.match(/\/extensions\/([^/]+)\//);
+  return match ? match[1] : null;
+}
+
+/**
+ * Arbitrate between the copies of this pack loaded in one page. Returns an
+ * `active()` the caller must consult BEFORE registering (and again at `setup()`:
+ * a later-evaluated NEWER copy can stand this one down after it registered).
+ *
+ *  - no prior claim          → claim the page (`"sole"`).
+ *  - prior claim, we are NEWER → stand the prior copy down and take the page
+ *                               (`"took-over"`). A stale copy must never win just
+ *                               because its directory sorts first.
+ *  - prior claim, same/older → stand down (`"stood-down"`); the first claim keeps
+ *                               the page.
+ *
+ * A malformed prior claim (a foreign script that collided with the key) carries
+ * no comparable version and no working standDown — treat it as claimable rather
+ * than letting it silence the panel.
+ */
+export function arbitratePanelCopy({ registry, key = DUPLICATE_PANEL_GUARD_KEY, self } = {}) {
+  let stoodDown = false;
+  // WHO stood this copy down, when the stand-down arrives after this copy's own
+  // arbitration (a later-evaluated newer copy). Recorded so the setup()-time
+  // re-check can name the copy it is yielding to instead of "unknown location".
+  let supersededBy = null;
+  const claim = {
+    version: self?.version,
+    url: self?.url,
+    standDown: (successor) => {
+      stoodDown = true;
+      supersededBy =
+        successor && typeof successor === "object"
+          ? { version: successor.version, url: successor.url }
+          : null;
+    },
+  };
+  const prior = registry?.[key];
+  if (!prior || typeof prior !== "object" || typeof prior.version !== "string") {
+    registry[key] = claim;
+    return { outcome: "sole", active: () => !stoodDown, supersededBy: () => supersededBy, prior: null };
+  }
+  if (compareVersions(self?.version, prior.version) > 0) {
+    try {
+      prior.standDown?.({ version: self?.version, url: self?.url });
+    } catch {
+      /* a throwing standDown must not keep the newer copy off the page */
+    }
+    registry[key] = claim;
+    return {
+      outcome: "took-over",
+      active: () => !stoodDown,
+      supersededBy: () => supersededBy,
+      prior: { version: prior.version, url: prior.url },
+    };
+  }
+  stoodDown = true;
+  return {
+    outcome: "stood-down",
+    active: () => false,
+    supersededBy: () => supersededBy,
+    prior: { version: prior.version, url: prior.url },
+  };
+}
+
+/**
+ * The loud half of the arbitration: name BOTH install directories and the remedy.
+ * Silent stand-down would leave a page with no panel and no explanation; a quiet
+ * console.debug would never be found.
+ */
+export function describeDuplicatePanelCopies({ outcome, self, prior } = {}) {
+  const dirOf = (copy) => installDirFromBundleUrl(copy?.url) ?? copy?.url ?? "unknown location";
+  const mine = `custom_nodes/${dirOf(self)}`;
+  const theirs = `custom_nodes/${dirOf(prior)}`;
+  const remedy =
+    `Remove one of the two panel installs (${mine} and ${theirs}) and restart ComfyUI — ` +
+    `until then the two copies fight over the same browser tab, and graph writes are ` +
+    `refused as if the panel were out of date (#1269).`;
+  if (outcome === "took-over") {
+    return (
+      `[comfyui-mcp-panel] two copies of the panel pack are loaded: ${theirs} ` +
+      `(panel ${prior?.version ?? "unknown"}) and ${mine} (panel ${self?.version ?? "unknown"}). ` +
+      `The newer copy is taking over; the older one is standing down. ${remedy}`
+    );
+  }
+  return (
+    `[comfyui-mcp-panel] two copies of the panel pack are loaded: ${theirs} ` +
+    `(panel ${prior?.version ?? "unknown"}) and ${mine} (panel ${self?.version ?? "unknown"}). ` +
+    `This copy is standing down. ${remedy}`
+  );
+}
+
+/**
+ * Backstop for a copy too OLD to carry this guard: it never writes the shared
+ * claim, so arbitration cannot see it — but it registers under the SAME extension
+ * name, which the frontend's extension list does show. `extensions` is the app's
+ * registered extension objects; OUR own registration is one of them, so a count
+ * above 1 means another copy of this pack is loaded.
+ */
+export function countExtensionsNamed(extensions, name) {
+  if (!Array.isArray(extensions)) return 0;
+  return extensions.filter((ext) => ext && ext.name === name).length;
+}
+
+/** The message for the guardless-duplicate backstop. Stays active on purpose:
+ *  standing down would hand the page to a copy too old to arbitrate; the fight
+ *  is no worse than before this guard existed, and now it is NAMED. */
+export function describeUnguardedDuplicatePanelCopy({ self } = {}) {
+  const mine = `custom_nodes/${installDirFromBundleUrl(self?.url) ?? self?.url ?? "unknown location"}`;
+  return (
+    `[comfyui-mcp-panel] another copy of the panel pack is registered alongside this one ` +
+    `(${mine}, panel ${self?.version ?? "unknown"}) — check custom_nodes for a second panel ` +
+    `install (e.g. both comfyui-mcp-panel and comfyui-agent-panel), remove it, and restart ` +
+    `ComfyUI. Two copies fight over the same browser tab, and graph writes are refused as ` +
+    `if the panel were out of date (#1269).`
+  );
+}


### PR DESCRIPTION
## Root cause

The pack can be installed twice — a git clone at `custom_nodes/comfyui-mcp-panel` AND a Manager/Registry install at `custom_nodes/comfyui-agent-panel` — and ComfyUI loads BOTH web bundles into the same page (measured in the issue's second report: both directories loaded, session panel 0.9.9 vs startup 0.11.43). Each copy opens its own bridge socket and hellos under the same workflow tab ids, and the bridge keeps exactly one connection per tab id: whichever hello lands last owns it.

A stale copy's hello predates the fields the fence reads — no `panel_version` before 0.11.83, no `enforces_workflow_stamp` before 0.11.29, bare `wf:<path>` tab ids before the per-tab route (#640) — so when it owns the routed connection, the orchestrator's write fence (`ui-bridge.ts`, requiresWorkflowStampEnforcement) sees a conn with no version and no fence flags and refuses every graph write as "this tab advertised NO panel version" — even though the SAME page's current bundle advertised its version in full, on a connection the write was not routed to (or that lost the last-hello-wins race). Reads keep working because the fence only gates writes, and the stated remedy — a hard refresh — cannot help, because the stale copy is served from its own stale directory and re-registers on every reload. All of that matches the report: read-only `panel_*` calls succeed, writes refuse, on-disk pack current.

The orchestrator cannot fix this from its side: a version-less hello is indistinguishable from a genuinely old panel, and the write fence must fail closed either way. Only the bundle can keep two copies of itself from running in one page.

## Fix

Panel-side, at module scope, before either copy's registration polling can run: the copies arbitrate through a shared page-global — the NEWER bundle runs, the older one stands down, loudly (console.error naming both install directories, resolved from each bundle's own `import.meta.url`, plus the remedy: remove one install and restart).

- `web/js/lib/duplicate-panel-guard.js` (new, pure/DI like `bundle-version.js`): `arbitratePanelCopy` (sole / took-over / stood-down, with the loser's flag flippable AFTER its own arbitration), `describeDuplicatePanelCopies`, `countExtensionsNamed`, `describeUnguardedDuplicatePanelCopy`.
- `web/js/comfyui-mcp-panel.js`: arbitration at module scope; a copy that lost never registers; `setup()` re-checks (a later-evaluated newer copy can stand this one down after it registered) and NAMEs a GUARDLESS duplicate — a copy too old to carry this guard never writes the shared claim, but it registers under the same extension name (`comfyui-mcp.agent-panel`), which the setup-time extension list shows. The guardless case stays active on purpose (standing down would hand the page to the stale copy) — it is no worse than before, and now the cause is named.

## Tests

- `browser_tests/unit/duplicate-panel-guard.test.mjs` (new, 10 tests): arbitration outcomes (sole / newer-takes-over / older-or-equal-stands-down / malformed prior claim / throwing standDown), URL→install-dir, both messages naming directories + remedy, the extension-name count, and source-level pins for the wiring (module-scope arbitration precedes registration polling; the registration gate precedes `installCreateBoundaryFork`; `setup()` re-checks and runs the backstop).
- `browser_tests/unit/i18n.test.mjs`: the "catalog loads first in setup()" source pin measures a 900-char head window that had ~27 chars of headroom left; the #1269 gate is itself mandated-first (a copy that lost the page arbitration must stop before anything wraps or connects), so the window grew 900 → 1200 with a comment saying why. The pin's purpose — awaited, before the first paint — is unchanged.

## Verification (worktree, from origin/main)

- `npm ci` — clean, 0 vulnerabilities
- `npm run test:unit` (i18n-check, i18n-render-check, check-tool-vocabulary, check-panel-scope, full node --test) — 5001 pass, 0 fail, 1 todo
- `npm run typecheck` — clean

## Honest limits

- A stale copy already shipped without this guard cannot be made to stand down; the guarded copy detects it via the same-name registration and NAMES it, which is the part that was missing (the only symptom today is the fence's misleading refusal).
- For the single-copy case (one install, genuinely stale cached browser bundle), the fence's existing refusal and remedy are correct and unchanged.

Closes #1269