### PR TITLE
fix(1260): one node's configure throw no longer aborts the rest of a graph load

### DIFF
--- a/browser_tests/unit/load-restore-isolation.test.mjs
+++ b/browser_tests/unit/load-restore-isolation.test.mjs
@@ -1,0 +1,181 @@
+/**
+ * Unit tests for web/js/lib/load-restore-isolation.js — run with `node --test`.
+ *
+ * Models the REAL bug from #1260: a workflow reload through LiteGraph's
+ * restore (create every node, then `node.configure(info)` in `nodes` order,
+ * then links/groups) aborted at the FIRST node whose configure threw — an
+ * Impact-Pack FaceDetailer whose widgets are built asynchronously — leaving
+ * every later node at construction defaults and links/groups never applied,
+ * while the load reported a clean success.
+ *
+ * These drive the SAME wrapper graph_load installs around app.loadGraphData
+ * (installNodeConfigureIsolation) and the SAME post-load retry
+ * (retryNodeRestores), against a fake LiteGraph/LGraphNode pair that
+ * reproduces the prototype-dispatched configure loop.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  installNodeConfigureIsolation,
+  retryNodeRestores,
+} from "../../web/js/lib/load-restore-isolation.js";
+
+/** A minimal LiteGraph/LGraphNode pair: configure dispatches through the
+ *  prototype, exactly as litegraph's restore loop calls it. */
+function makeLiteGraph() {
+  class LGraphNode {
+    constructor(id) {
+      this.id = id;
+      this.configured = [];
+    }
+    configure(info) {
+      this.configured.push(info);
+      return "configured";
+    }
+  }
+  return { LGraphNode };
+}
+
+test("#1260: a throw from one node's configure is contained — later nodes restore, the throw is recorded", () => {
+  const LG = makeLiteGraph();
+  const base = LG.LGraphNode.prototype.configure;
+  LG.LGraphNode.prototype.configure = function (info) {
+    if (info.id === 15) throw new TypeError("widgets not built yet");
+    return base.call(this, info);
+  };
+
+  const isolation = installNodeConfigureIsolation(LG);
+  assert.ok(isolation, "isolation installs on a prototype-dispatched configure");
+  const nodes = [new LG.LGraphNode(15), new LG.LGraphNode(16), new LG.LGraphNode(17)];
+  const infos = [
+    { id: 15, type: "FaceDetailer" },
+    { id: 16, type: "SaveImage" },
+    { id: 17, type: "MarkdownNote" },
+  ];
+  try {
+    // litegraph's restore loop, in `nodes` order — the loop that used to abort.
+    for (let i = 0; i < nodes.length; i++) nodes[i].configure(infos[i]);
+  } finally {
+    isolation.restore();
+  }
+
+  assert.equal(isolation.failures.length, 1, "exactly the throwing node was recorded");
+  const f = isolation.failures[0];
+  assert.equal(f.id, 15);
+  assert.equal(f.type, "FaceDetailer");
+  assert.equal(f.error, "widgets not built yet");
+  assert.deepEqual(f.info, { id: 15, type: "FaceDetailer" }, "the serialized data rides along for the retry");
+  assert.deepEqual(nodes[1].configured, [infos[1]], "the node AFTER the throw restored normally");
+  assert.deepEqual(nodes[2].configured, [infos[2]], "every later node restored normally");
+});
+
+test("the wrapper preserves a non-throwing configure's return value and `this`", () => {
+  const LG = makeLiteGraph();
+  const isolation = installNodeConfigureIsolation(LG);
+  try {
+    const node = new LG.LGraphNode(3);
+    const ret = node.configure({ id: 3, type: "KSampler" });
+    assert.equal(ret, "configured");
+    assert.deepEqual(node.configured, [{ id: 3, type: "KSampler" }]);
+  } finally {
+    isolation.restore();
+  }
+  assert.equal(isolation.failures.length, 0);
+});
+
+test("restore() puts the original back, and a later throw propagates again", () => {
+  const LG = makeLiteGraph();
+  const original = LG.LGraphNode.prototype.configure;
+  const isolation = installNodeConfigureIsolation(LG);
+  assert.notEqual(LG.LGraphNode.prototype.configure, original, "wrapper is installed");
+  isolation.restore();
+  assert.equal(LG.LGraphNode.prototype.configure, original, "original is restored");
+
+  const second = installNodeConfigureIsolation(LG);
+  second.restore();
+  LG.LGraphNode.prototype.configure = function () {
+    throw new Error("post-restore boom");
+  };
+  assert.throws(
+    () => LG.LGraphNode.prototype.configure.call(new LG.LGraphNode(1), { id: 1 }),
+    /post-restore boom/,
+    "with no active wrapper, a configure throw propagates exactly as unwrapped",
+  );
+});
+
+test("install returns null when there is nothing to wrap (fail-open, pre-fix behaviour)", () => {
+  assert.equal(installNodeConfigureIsolation(null), null);
+  assert.equal(installNodeConfigureIsolation({}), null);
+  assert.equal(installNodeConfigureIsolation({ LGraphNode: {} }), null);
+});
+
+test("chained isolations: restoring the INNER one first does not drop the outer's containment", () => {
+  const LG = makeLiteGraph();
+  const base = LG.LGraphNode.prototype.configure;
+  LG.LGraphNode.prototype.configure = function (info) {
+    if (info.id === 7) throw new Error("chain boom");
+    return base.call(this, info);
+  };
+  const inner = installNodeConfigureIsolation(LG);
+  const outer = installNodeConfigureIsolation(LG);
+  const outerWrapper = LG.LGraphNode.prototype.configure;
+  const node = new LG.LGraphNode(7);
+
+  node.configure({ id: 7, type: "X" });
+  assert.equal(inner.failures.length, 1, "the INNERMOST wrapper swallows and records the throw first");
+  assert.equal(outer.failures.length, 0, "the outer wrapper never saw it — the inner swallowed first");
+
+  inner.restore(); // out of order: the OUTER wrapper is still installed
+  assert.equal(
+    LG.LGraphNode.prototype.configure,
+    outerWrapper,
+    "the inner restore must not clobber the outer wrapper",
+  );
+  node.configure({ id: 7, type: "X" });
+  assert.equal(outer.failures.length, 1, "with the inner deactivated, the outer now contains the throw");
+  assert.equal(inner.failures.length, 1, "the deactivated inner records nothing further");
+
+  outer.restore();
+  assert.throws(
+    () => node.configure({ id: 7, type: "X" }),
+    /chain boom/,
+    "once every wrapper is restored or deactivated, throws propagate again",
+  );
+  assert.equal(node.configure({ id: 8, type: "Y" }), "configured", "non-throwing nodes are unaffected");
+});
+
+test("#1260 retry: a node whose widgets exist by retry time restores; a still-throwing node is disclosed with the NEW error", () => {
+  const LG = makeLiteGraph();
+  const healed = new LG.LGraphNode(15);
+  healed.type = "FaceDetailer";
+  const stubborn = new LG.LGraphNode(21);
+  stubborn.type = "MarkdownNote";
+  stubborn.configure = () => {
+    throw new Error("still broken");
+  };
+  const graph = {
+    getNodeById(id) {
+      if (id === 15) return healed;
+      if (id === 21) return stubborn;
+      return null;
+    },
+  };
+  const failures = [
+    { id: 15, type: "FaceDetailer", error: "widgets not built yet", info: { id: 15, widgets_values: [768] } },
+    { id: 21, type: "MarkdownNote", error: "first boom", info: { id: 21, widgets_values: ["hi"] } },
+    { id: 99, type: "Ghost", error: "creation failed too", info: { id: 99 } },
+  ];
+  const { restored, failed } = retryNodeRestores(graph, failures);
+  assert.deepEqual(restored, [{ id: 15, type: "FaceDetailer" }]);
+  assert.deepEqual(healed.configured, [{ id: 15, widgets_values: [768] }], "the serialized data was re-applied");
+  assert.equal(failed.length, 2);
+  assert.equal(failed[0].error, "still broken", "the retry's error replaces the stale load-time error");
+  assert.equal(failed[0].retry, undefined, "a node that IS on the graph gets no retry marker");
+  assert.equal(failed[1].retry, "node-not-on-graph", "a node that never landed is told apart from a re-throw");
+});
+
+test("retry tolerates a missing graph and empty failures (nothing to heal, nothing to disclose)", () => {
+  assert.deepEqual(retryNodeRestores(null, []), { restored: [], failed: [] });
+  assert.deepEqual(retryNodeRestores(undefined, undefined), { restored: [], failed: [] });
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -79,6 +79,7 @@ import { armReloadBlockedNotice, unsavedReloadBlockers, reloadWouldBeBlockedMess
 import { withTimeout } from "./lib/bounded-step.js";
 import { pressableWidgetHint } from "./lib/pressable-widget.js";
 import { looksLikeApiWorkflow, apiLoadShortfall, apiLoadNote } from "./lib/api-workflow-load.js";
+import { installNodeConfigureIsolation, retryNodeRestores } from "./lib/load-restore-isolation.js";
 import { readPackImportFailures } from "./lib/pack-import-failures.js";
 import { pairDurabilityView } from "./lib/pair-durability-view.js";
 import {
@@ -11740,7 +11741,7 @@ const GRAPH_TOOL_EXECUTORS = {
   // current graph), so a ready pack/template graph lands without recreating it
   // node-by-node. Mirrors restoreSnapshot's app.loadGraphData(...) path.
   async graph_load({ graph: incoming } = {}) {
-    const { app, graph, rootGraph } = getGraphCtx();
+    const { app, graph, rootGraph, LG } = getGraphCtx();
     // This executor is also called directly by the CivitAI workflow picker,
     // bypassing bridge dispatch. Refuse before snapshot/load so that path cannot
     // report a successful load into a stale prior tab (#349).
@@ -11886,11 +11887,29 @@ const GRAPH_TOOL_EXECUTORS = {
     // form then, so options lands in its proper 5th slot; a blank-canvas load (single arg) is
     // a genuine creation and takes the normal fresh-mint path.
     const loadArgs = resolveLoadGraphArgs(clone, activeWorkflow);
-    if (activeWorkflow && typeof activeWorkflow === "object") {
-      await app.loadGraphData(...loadArgs, { __cmcpKeepInstance: true });
-    } else {
-      await app.loadGraphData(...loadArgs);
+    // #1260 — contain a per-node configure throw to the node that threw. One
+    // node whose widgets are not all built yet (Impact-Pack's FaceDetailer,
+    // whose extension adds widgets asynchronously) otherwise aborts the
+    // frontend's whole restore sequence: every LATER node stays at
+    // construction defaults and links/groups are never applied, while the load
+    // reports a clean success. With the throw contained, the sequence
+    // completes and only the throwing node needs the post-load retry below.
+    const isolation = installNodeConfigureIsolation(LG);
+    try {
+      if (activeWorkflow && typeof activeWorkflow === "object") {
+        await app.loadGraphData(...loadArgs, { __cmcpKeepInstance: true });
+      } else {
+        await app.loadGraphData(...loadArgs);
+      }
+    } finally {
+      isolation?.restore();
     }
+    // Retry each contained node ONCE, now that the load has settled and its
+    // asynchronously-built widgets usually exist. A node that still throws is
+    // DISCLOSED below — never folded into a clean `loaded: true`.
+    const { restored: retriedNodes, failed: unrestoredNodes } = isolation?.failures?.length
+      ? retryNodeRestores(app?.graph, isolation.failures)
+      : { restored: [], failed: [] };
     // comfyui-mcp#1478 (defect 1) — REPORT THE IDENTITY THIS LOAD LANDED ON.
     //
     // `activeWorkflow` was captured before the load and passed to loadGraphData as the
@@ -11909,6 +11928,28 @@ const GRAPH_TOOL_EXECUTORS = {
       node_count: clone.nodes.length,
       ...(auxSanitized ? { aux_id_sanitized: auxSanitized } : {}),
       ...(loadedWorkflowUuid ? { workflow_uuid: loadedWorkflowUuid } : {}),
+      ...(retriedNodes.length ? { nodes_restored_on_retry: retriedNodes } : {}),
+      // #1260 — name every node whose saved state could NOT be applied, with
+      // the error its own configure raised. The rest of the graph — links,
+      // groups, and every other node — restored normally; only these are at
+      // construction defaults.
+      ...(unrestoredNodes.length
+        ? {
+            node_restore_failures: unrestoredNodes.map(({ id, type, error, retry }) => ({
+              id,
+              type,
+              error,
+              ...(retry ? { retry } : {}),
+            })),
+            warning:
+              `${unrestoredNodes.length} node(s) threw while their saved state was being applied ` +
+              `and are at CONSTRUCTION DEFAULTS (widgets, position): ` +
+              unrestoredNodes.map((f) => `${f.type ?? "node"} (id ${f.id})`).join(", ") +
+              `. Links, groups, and every other node restored normally. The throw came from each ` +
+              `node's own frontend code — fix or update that pack, then load again, or reconfigure ` +
+              `these nodes with panel_set_widget before queueing.`,
+          }
+        : {}),
     };
   },
 

--- a/web/js/lib/load-restore-isolation.js
+++ b/web/js/lib/load-restore-isolation.js
@@ -1,0 +1,113 @@
+// #1260 — one node's restore must not abort the rest of the load.
+//
+// LiteGraph restores a serialized graph in passes: every node is CREATED
+// first, then each node is configured in `nodes` order through the PROTOTYPE's
+// `LGraphNode.prototype.configure`, and only afterwards are links and groups
+// applied. A node whose configure THROWS — the reported case is Impact-Pack's
+// FaceDetailer, whose widgets are built asynchronously by its JS extension, so
+// the widget list is incomplete when the serialized values are applied —
+// aborts that whole sequence: every later node stays at construction defaults
+// (pos [10,10], default widgets), and links and groups are never applied. The
+// load then reports a clean success over a graph that cannot queue.
+//
+// The throw belongs to ONE node, so it is contained to that node: while a
+// panel-initiated load runs, `configure` is wrapped so a throw is RECORDED and
+// the sequence continues — links, groups, and every other node restore
+// normally. The caller retries the recorded nodes once after the load (the
+// asynchronously-built widgets usually exist by then) and discloses any that
+// still fail, instead of reporting a clean success.
+
+function errorText(err) {
+  if (err instanceof Error && err.message) return err.message;
+  try {
+    return String(err);
+  } catch {
+    return "an unprintable error";
+  }
+}
+
+/**
+ * Contain per-node `configure` throws for the duration of one load.
+ *
+ * Returns null when isolation is impossible (no LiteGraph / LGraphNode /
+ * prototype configure) — the caller then loads exactly as before, with no
+ * containment and nothing recorded, which is the pre-fix behaviour and never
+ * worse than it.
+ *
+ * Otherwise returns `{ failures, restore }`. `failures` accumulates one entry
+ * per throwing configure: `{ id, type, error, info }`, where `info` is the
+ * serialized node data the retry pass needs and must NOT be serialized into a
+ * tool result. `restore()` deactivates the wrapper and puts the original back
+ * — but only when this wrapper is still the installed one: a second isolation
+ * (or the frontend) may have chained on top, and restoring over that would
+ * silently drop THEIR wrapper. A deactivated wrapper left in a chain is a
+ * pass-through, so every restore order stays correct.
+ */
+export function installNodeConfigureIsolation(LG) {
+  const proto = LG?.LGraphNode?.prototype;
+  if (!proto || typeof proto.configure !== "function") return null;
+  const original = proto.configure;
+  const failures = [];
+  let active = true;
+  const wrapped = function (info) {
+    if (!active) return original.call(this, info);
+    try {
+      return original.call(this, info);
+    } catch (err) {
+      failures.push({
+        id: info?.id ?? this?.id ?? null,
+        type: info?.type ?? this?.type ?? null,
+        error: errorText(err),
+        info: info ?? null,
+      });
+      return undefined;
+    }
+  };
+  proto.configure = wrapped;
+  return {
+    failures,
+    restore() {
+      active = false;
+      if (proto.configure === wrapped) proto.configure = original;
+    },
+  };
+}
+
+/**
+ * One best-effort re-application of each node whose configure threw during the
+ * load, AFTER the load has settled — a node whose widgets are built
+ * asynchronously (the FaceDetailer shape) commonly configures cleanly by then.
+ * Each retry is isolated too: a node that throws again is disclosed with the
+ * NEW error, never retried further by this pass.
+ *
+ * A recorded failure whose node never landed on the graph (creation failed
+ * too, not just configure) cannot be retried; it is disclosed with
+ * `retry: "node-not-on-graph"` so the caller does not confuse "restore threw
+ * again" with "there is nothing to restore onto".
+ */
+export function retryNodeRestores(graph, failures) {
+  const restored = [];
+  const failed = [];
+  for (const failure of failures ?? []) {
+    const node =
+      failure?.id != null && typeof graph?.getNodeById === "function"
+        ? graph.getNodeById(failure.id)
+        : null;
+    if (!node || !failure.info || typeof node.configure !== "function") {
+      failed.push({
+        id: failure?.id ?? null,
+        type: failure?.type ?? null,
+        error: failure?.error ?? "unknown",
+        retry: "node-not-on-graph",
+      });
+      continue;
+    }
+    try {
+      node.configure(failure.info);
+      restored.push({ id: failure.id, type: failure.type });
+    } catch (err) {
+      failed.push({ id: failure.id, type: failure.type, error: errorText(err) });
+    }
+  }
+  return { restored, failed };
+}


### PR DESCRIPTION
## Root cause

LiteGraph restores a serialized graph in passes: it **creates** every node first, then calls `node.configure(info)` per node in `nodes` order (prototype-dispatched through `LGraphNode.prototype.configure`), and only afterwards applies **links and groups**. A node whose `configure` throws — the reported case is Impact-Pack's `FaceDetailer`, whose JS extension builds widgets asynchronously, so the widget list is incomplete when the serialized `widgets_values` are applied — aborted that whole sequence. Every node at/after it stayed at construction defaults (`pos [10,10]`, default widgets), links and groups were never applied, and `graph_load` still returned `{loaded: true, node_count: 21}`. The reloaded workflow then failed to queue (`Required input is missing: images`), and `panel_open_workflow`'s documented recovery — `panel_load_workflow` — produced the same degraded graph.

## Staleness note (the issue's other defect)

Defect (1) of #1260 — `panel_set_widget` throwing `Cannot delete property 'value'` on BOOLEAN widgets — is **already fixed on main**: the write path (`applyWidgetWrite` in `web/js/lib/widget-write.js`) assigns `w.value = coerced` directly, fires the widget's own callback once via `Reflect.apply`, and catches/attributes/discloses any throw. No `delete` exists anywhere in the write path. This PR fixes only defect (2).

## Fix

- New `web/js/lib/load-restore-isolation.js`:
  - `installNodeConfigureIsolation(LG)` wraps `LGraphNode.prototype.configure` for the duration of one panel-initiated load. A per-node throw is **recorded and contained**, so the restore sequence completes — links, groups, and every later node restore normally. Returns `null` (fail-open, pre-fix behaviour) when there is no prototype `configure` to wrap. `restore()` only unwraps when its own wrapper is still installed, so chained/concurrent installs survive any restore order.
  - `retryNodeRestores(graph, failures)` retries each recorded node **once** after the load has settled — the asynchronously-built widgets usually exist by then, which heals the FaceDetailer shape outright. A node that never landed is told apart from a re-throw (`retry: "node-not-on-graph"`).
- `graph_load` (`web/js/comfyui-mcp-panel.js`) installs the isolation around the `loadGraphData` await, runs the retry pass, and discloses:
  - `nodes_restored_on_retry` — nodes the retry healed,
  - `node_restore_failures` + a `warning` naming each node (id, type, its configure's error) that is still at construction defaults — never folded into a clean `loaded: true`.

## Verification

- New `browser_tests/unit/load-restore-isolation.test.mjs` (7 tests, all pass): containment of a mid-sequence throw with later nodes restoring, return-value/`this` passthrough, restore semantics, fail-open install, chained-isolation restore order, retry heal / re-throw / missing-node disclosure.
- Gates (worktree, Node on Windows): `npm ci` OK · `npm run typecheck` OK · `npm run check:scope` OK · `npm run i18n:check` OK · `npm run test:unit` **4999 tests / 4998 pass / 0 fail / 1 todo**.

Not verified live against a real ComfyUI + Impact-Pack install — the fix is exercised at the unit level against a prototype-dispatched configure loop modelling litegraph's restore.

Closes #1260
