### PR TITLE
fix(342): the outline resolves a link's live target slot through the backlink — a stale target_slot renders nothing instead of fabricating connectivity

### DIFF
--- a/browser_tests/outline-orphaned-link-renders-nothing.spec.ts
+++ b/browser_tests/outline-orphaned-link-renders-nothing.spec.ts
@@ -1,0 +1,109 @@
+/**
+ * #342 — the outline must not fabricate connectivity out of a stale `target_slot`.
+ *
+ * A link record's `target_slot` is captured at connect time. When the target node's
+ * inputs are COMPACTED afterwards — a `COMFY_DYNAMICCOMBO_V3` rebuilding its slots on a
+ * selection change, a removed dynamic `ref_video_N` input shifting the tail — the index
+ * survives the transformation that invalidated it. `panel_graph_outline` rendered
+ * `tgt.inputs[l.target_slot].name`, so it reported the link against whatever slot now
+ * OCCUPIES that index. The reporter's outline said
+ * `VAEDecode → easy saveVideo.output_mode.save_metadata` (a BOOLEAN) over a graph whose
+ * IMAGE link no longer existed, while `panel_query_graph` — which reads the live
+ * `inputs[].link` backlink — correctly showed it gone.
+ *
+ * This spec builds that state in a REAL graph in a REAL ComfyUI: connect two nodes, then
+ * remove the target's input slot WITHOUT disconnecting, which is exactly what the
+ * dynamic-combo rebuild leaves behind (link record alive in `graph.links` and in the
+ * origin's `outputs[].links`; no input backlinks it any more). The unit tests pin the
+ * render block; this pins that a live graph, a live outline handler and a live frontend
+ * still agree.
+ *
+ * Measured here against the pre-fix panel: the outline row read `→ <id>.vae`.
+ */
+import { test, expect } from './fixtures/panelTest'
+import { claimFreshCanvas, settleCanvas } from './fixtures/canvasIdentity'
+
+test('an outgoing link whose target slot was removed renders NOTHING in the outline', async ({
+  page,
+  panel,
+  mockBridge,
+}) => {
+  await panel.goto()
+  await panel.setBridgeUrl(mockBridge.url)
+  await panel.openSidebar()
+  await panel.connect()
+  await claimFreshCanvas(page, mockBridge)
+
+  const made = await page.evaluate(() => {
+    const w = window as any
+    const app = w.comfyAPI?.app?.app || w.app
+    const LG = w.LiteGraph || w.comfyAPI?.litegraph?.LiteGraph
+    const graph = app?.canvas?.graph ?? app?.graph
+    const latent = LG.createNode('EmptyLatentImage')
+    const decode = LG.createNode('VAEDecode')
+    graph.add(latent)
+    graph.add(decode)
+    // VAEDecode inputs are [samples (LATENT), vae (VAE)]. Wire the LATENT into slot 0.
+    latent.connect(0, decode, 0)
+    const linkId = decode.inputs?.[0]?.link ?? null
+    const before = {
+      slot0: decode.inputs?.[0]?.name ?? null,
+      linkId,
+      // The origin still lists the link on its output — the outline walks THIS.
+      onOutput: (latent.outputs?.[0]?.links ?? []).includes(linkId),
+    }
+    // The compaction: the slot the link landed on is REMOVED and the tail shifts up,
+    // with no disconnect. `vae` now sits at index 0 — the index the link still records.
+    decode.inputs.splice(0, 1)
+    const after = {
+      slot0: decode.inputs?.[0]?.name ?? null,
+      backlinked: (decode.inputs ?? []).some((i: any) => i?.link === linkId),
+      recordedTargetSlot: graph.links?.[linkId]?.target_slot ?? null,
+      stillOnOutput: (latent.outputs?.[0]?.links ?? []).includes(linkId),
+    }
+    return { decodeId: String(decode.id), latentId: String(latent.id), before, after }
+  })
+
+  // Preconditions — if any of these drift, the spec is no longer reproducing #342 and
+  // must be repaired rather than relaxed.
+  expect(made.before.slot0, 'precondition: the LATENT lands on `samples`').toBe('samples')
+  expect(made.before.linkId, 'precondition: the connect produced a link').not.toBeNull()
+  expect(made.before.onOutput, 'precondition: the origin output lists the link').toBe(true)
+  expect(made.after.slot0, 'precondition: compaction shifted `vae` into the freed index').toBe('vae')
+  expect(made.after.backlinked, 'precondition: no input backlinks the link any more').toBe(false)
+  expect(
+    made.after.recordedTargetSlot,
+    'precondition: the link record still points at the freed index',
+  ).toBe(0)
+  expect(
+    made.after.stillOnOutput,
+    'precondition: the orphaned record survives on the origin output — this is what the outline walks',
+  ).toBe(true)
+
+  await settleCanvas(page)
+
+  const outline = await mockBridge.command('graph_outline', {})
+  expect(outline.ok).toBe(true)
+  const text = String(outline.result?.outline ?? '')
+
+  // The bug, named exactly: the slot that took the freed index must not be reported as
+  // the link's target.
+  expect(text, 'the outline must not attribute the dropped link to `vae`').not.toContain(
+    `${made.decodeId}.vae`,
+  )
+  // …and no row may claim ANY outgoing target for the origin node, because the graph has
+  // none that executes.
+  const originRow = text
+    .split('\n')
+    .findIndex((line) => line.trimStart().startsWith(`${made.latentId}  EmptyLatentImage`))
+  expect(originRow, 'the origin node must still be listed').toBeGreaterThanOrEqual(0)
+  const rowsAfterOrigin = text.split('\n').slice(originRow + 1, originRow + 3)
+  expect(
+    rowsAfterOrigin.filter((line) => line.trimStart().startsWith('→')),
+    'an orphaned link must render no outgoing row at all',
+  ).toEqual([])
+
+  // The target node itself is untouched — the fix removes a false claim, it does not
+  // hide the graph.
+  expect(text, 'the target node is still in the outline').toContain(`${made.decodeId}  VAEDecode`)
+})

--- a/browser_tests/unit/graph-read.test.mjs
+++ b/browser_tests/unit/graph-read.test.mjs
@@ -5,6 +5,9 @@
 //          stored value as if it were the value that executes.
 //   #609 — one oversized widget blob (or several nodes) must not blow the whole
 //          max_chars budget and return shown:0 for a node asked for by id.
+//   #342 — a link's recorded target_slot goes stale when the target's inputs are
+//          compacted; the outline must resolve the LIVE backlink and render
+//          NOTHING for an orphaned link.
 import test from "node:test";
 import assert from "node:assert/strict";
 
@@ -14,6 +17,7 @@ import {
   linkDrivenWidgets,
   drivenWidgetsFor,
   drivenTag,
+  liveLinkTargetInput,
   capWidgetValue,
   capSummaryWidgets,
   clipLine,
@@ -545,4 +549,79 @@ test("#1634 clipCompactValue honours a raised cap for a pinpoint read", () => {
   const pinpoint = clipCompactValue(prompt, WIDGET_VALUE_CAP);
   assert.equal(pinpoint.clipped, false);
   assert.equal(pinpoint.text, prompt);
+});
+
+// ---- #342: live target-slot resolution for the outline ---------------------
+
+// The #342 shape: `easy saveVideo` after `input_mode` (COMFY_DYNAMICCOMBO_V3)
+// collapsed — link 7's recorded target_slot (2, the old `input_mode.images`) is
+// stale, and slot 2 is now occupied by the BOOLEAN `output_mode.save_metadata`.
+// The live truth: NO input backlinks link 7 — the connection is gone.
+function saveVideoAfterComboCollapse() {
+  return {
+    id: 12,
+    type: "easy saveVideo",
+    inputs: [
+      { name: "input_mode", type: "COMBO", link: null },
+      { name: "output_mode.save_metadata", type: "BOOLEAN", link: null },
+      { name: "output_mode", type: "COMBO", link: null },
+      { name: "filename_prefix", type: "STRING", link: null },
+    ],
+  };
+}
+
+test("liveLinkTargetInput returns null for an orphaned link (slot removed) (#342)", () => {
+  // The orphaned record must render NOTHING — the old render showed it against
+  // save_metadata, fabricating a connection the graph no longer has.
+  assert.equal(liveLinkTargetInput(saveVideoAfterComboCollapse(), 7), null);
+});
+
+test("liveLinkTargetInput finds the live slot AFTER compaction shifted it (#342)", () => {
+  // A removed ref_video_0 input compacted the tail: link 9 was recorded against
+  // slot 3 but the input that still backlinks it now sits at index 2.
+  const node = {
+    id: 5,
+    inputs: [
+      { name: "image", type: "IMAGE", link: null },
+      { name: "ref_video_1", type: "VIDEO", link: 9 },
+      { name: "fps", type: "FLOAT", link: null },
+    ],
+  };
+  assert.deepEqual(liveLinkTargetInput(node, 9), { index: 1, name: "ref_video_1" });
+});
+
+test("liveLinkTargetInput resolves the ordinary uncompacted case (#342)", () => {
+  const node = {
+    id: 3,
+    inputs: [
+      { name: "model", type: "MODEL", link: 4 },
+      { name: "clip", type: "CLIP", link: null },
+    ],
+  };
+  assert.deepEqual(liveLinkTargetInput(node, 4), { index: 0, name: "model" });
+});
+
+test("liveLinkTargetInput keeps the index when the live input has no name (#342)", () => {
+  const node = { id: 8, inputs: [{ type: "IMAGE", link: 2 }] };
+  assert.deepEqual(liveLinkTargetInput(node, 2), { index: 0, name: undefined });
+});
+
+test("liveLinkTargetInput matches a string link id against a numeric backlink (#342)", () => {
+  const node = { id: 8, inputs: [{ name: "image", type: "IMAGE", link: 7 }] };
+  assert.deepEqual(liveLinkTargetInput(node, "7"), { index: 0, name: "image" });
+});
+
+test("liveLinkTargetInput never matches an unlinked input — even to link id 0 (#342)", () => {
+  // Number(null) is 0: without the null guard, link id 0 would "resolve" to the
+  // first UNCONNECTED input and fabricate the very connectivity #342 removes.
+  const node = { id: 8, inputs: [{ name: "image", type: "IMAGE", link: null }] };
+  assert.equal(liveLinkTargetInput(node, 0), null);
+});
+
+test("liveLinkTargetInput never throws on malformed nodes (#342)", () => {
+  assert.equal(liveLinkTargetInput(null, 1), null);
+  assert.equal(liveLinkTargetInput({}, 1), null);
+  // Holes in the inputs array are skipped, not crashed on.
+  assert.equal(liveLinkTargetInput({ inputs: [null, undefined] }, 3), null);
+  assert.deepEqual(liveLinkTargetInput({ inputs: [null, { link: 3 }] }, 3), { index: 1, name: undefined });
 });

--- a/browser_tests/unit/outline-coverage.test.mjs
+++ b/browser_tests/unit/outline-coverage.test.mjs
@@ -14,6 +14,7 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
+import { liveLinkTargetInput } from "../../web/js/lib/graph-read.js";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const PANEL_JS = join(HERE, "../../web/js/comfyui-mcp-panel.js");
@@ -244,4 +245,120 @@ test("#809 each rung is measured WITH its footer, and the counters reset inside"
   // The ladder loop must contain no post-hoc append of the note.
   const ladder = body.slice(body.indexOf("// Walk DOWN the ladder"));
   assert.doesNotMatch(ladder, /outline \+= outlineValueClipNote/, "no post-fit append");
+});
+
+// ---- #342: the OUTGOING render must resolve the link's LIVE target slot -----
+//
+// A link record's `target_slot` is captured at connect time and goes STALE when the
+// target node's inputs are compacted afterwards (a COMFY_DYNAMICCOMBO_V3 rebuilding
+// its slots, a removed dynamic `ref_video_N` input shifting the tail). The outline
+// then reported the link against whatever slot now OCCUPIES that index —
+// `VAEDecode → easy saveVideo.output_mode.save_metadata`, a BOOLEAN — while
+// panel_query_graph, which reads the live `inputs[].link` backlink, correctly showed
+// the connection was gone.
+//
+// These tests EXECUTE the render block lifted verbatim out of the handler, because a
+// helper-level test cannot see this call site: with the entire wiring hunk reverted,
+// all eight liveLinkTargetInput unit tests (and the other 5030) still pass. Reading
+// the source would not have caught that; running it does.
+
+/** The outgoing-link render block, taken VERBATIM from the graph_outline handler and
+ *  run against a synthetic graph. Free variables of the block are injected. */
+function renderOutgoing({ node, links, nodes }) {
+  const body = outline();
+  const start = body.indexOf("const outs = [];");
+  const end = body.indexOf("if (outs.length)", start);
+  assert.notEqual(start, -1, "the outgoing-link render block must be locatable");
+  assert.ok(end > start, "the outgoing-link render block must terminate at its emit");
+  assert.equal(body.lastIndexOf("const outs = [];"), start, "one outgoing render block only");
+  const block = body.slice(start, end);
+  // eslint-disable-next-line no-new-func -- running the real source IS the assertion
+  const run = new Function("n", "links", "byId", "liveLinkTargetInput", block + " return outs;");
+  return run(node, links, new Map(nodes.map((x) => [x.id, x])), liveLinkTargetInput);
+}
+
+test("#342 an ORPHANED outgoing link renders NOTHING, not the slot that took its index", () => {
+  // The repro: `easy saveVideo` after `input_mode` (COMFY_DYNAMICCOMBO_V3) collapsed.
+  // Link 7's recorded target_slot 1 was `input_mode.images`; slot 1 now holds the
+  // BOOLEAN `output_mode.save_metadata`, and NO input backlinks link 7 any more.
+  const target = {
+    id: 12,
+    type: "easy saveVideo",
+    inputs: [
+      { name: "input_mode", type: "COMBO", link: null },
+      { name: "output_mode.save_metadata", type: "BOOLEAN", link: null },
+      { name: "output_mode", type: "COMBO", link: null },
+      { name: "filename_prefix", type: "STRING", link: null },
+    ],
+  };
+  const origin = { id: 4, type: "VAEDecode", outputs: [{ name: "IMAGE", links: [7] }] };
+  const outs = renderOutgoing({
+    node: origin,
+    nodes: [origin, target],
+    links: { 7: { id: 7, origin_id: 4, origin_slot: 0, target_id: 12, target_slot: 1 } },
+  });
+  assert.deepEqual(outs, [], "a link no input backlinks must not appear in the outline");
+  // Named explicitly: this exact string is what #342 was filed about.
+  assert.ok(
+    !outs.includes("12.output_mode.save_metadata"),
+    "the outline must never attribute a dropped link to the slot that took its index",
+  );
+});
+
+test("#342 a link whose live slot SHIFTED renders the slot it actually feeds", () => {
+  // A removed dynamic `ref_video_0` compacted the tail: link 9 was recorded against
+  // slot 2, but the input that still backlinks it now sits at index 1. Slot 2 now
+  // holds `fps` — which is what the stale render reported.
+  const target = {
+    id: 5,
+    type: "Bernini r2v",
+    inputs: [
+      { name: "image", type: "IMAGE", link: null },
+      { name: "ref_video_1", type: "VIDEO", link: 9 },
+      { name: "fps", type: "FLOAT", link: null },
+    ],
+  };
+  const origin = { id: 2, type: "LoadVideo", outputs: [{ name: "VIDEO", links: [9] }] };
+  const outs = renderOutgoing({
+    node: origin,
+    nodes: [origin, target],
+    links: { 9: { id: 9, origin_id: 2, origin_slot: 0, target_id: 5, target_slot: 2 } },
+  });
+  assert.deepEqual(outs, ["5.ref_video_1"]);
+  assert.ok(!outs.includes("5.fps"), "the stale index must not name the input it now points at");
+});
+
+test("#342 an ordinary, uncompacted link still renders exactly as before", () => {
+  const target = {
+    id: 3,
+    type: "KSampler",
+    inputs: [
+      { name: "model", type: "MODEL", link: 4 },
+      { name: "positive", type: "CONDITIONING", link: null },
+    ],
+  };
+  const origin = { id: 1, type: "CheckpointLoaderSimple", outputs: [{ name: "MODEL", links: [4] }] };
+  const outs = renderOutgoing({
+    node: origin,
+    nodes: [origin, target],
+    links: { 4: { id: 4, origin_id: 1, origin_slot: 0, target_id: 3, target_slot: 0 } },
+  });
+  assert.deepEqual(outs, ["3.model"]);
+});
+
+test("#342 with no live inputs to verify against, the recorded slot renders as a bare index", () => {
+  // Fail-open is bounded to the case where there is nothing to check: the target is
+  // not in this graph's node set (a dead record naming an id the outline does not
+  // even list, so the reader can SEE it is dangling), or it carries no inputs array.
+  const origin = { id: 6, type: "VAEDecode", outputs: [{ name: "IMAGE", links: [11, 12] }] };
+  const inputless = { id: 8, type: "Note" };
+  const outs = renderOutgoing({
+    node: origin,
+    nodes: [origin, inputless],
+    links: {
+      11: { id: 11, origin_id: 6, origin_slot: 0, target_id: 99, target_slot: 2 },
+      12: { id: 12, origin_id: 6, origin_slot: 0, target_id: 8, target_slot: 0 },
+    },
+  });
+  assert.deepEqual(outs, ["99.2", "8.0"]);
 });

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -10486,6 +10486,9 @@ const GRAPH_TOOL_EXECUTORS = {
             // "looks wired" over a graph whose connection is gone. An ORPHANED
             // link (no input backlinks it) renders NOTHING, matching
             // panel_query_graph's live read.
+            // Fail-open ONLY where there is nothing to check against: the target is
+            // not in this graph's node set (a dangling id the outline does not even
+            // list, so a reader can see it is dead) or it carries no inputs array.
             if (!tgt || !Array.isArray(tgt.inputs)) {
               outs.push(`${l.target_id}.${tgt?.inputs?.[l.target_slot]?.name ?? l.target_slot}`);
               continue;

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -285,6 +285,7 @@ import { boundExecFailurePayload } from "./lib/exec-error-bounds.js";
 import {
   drivenWidgetsFor,
   drivenTag,
+  liveLinkTargetInput,
   capSummaryWidgets,
   clipLine,
   fitDetailLine,
@@ -10477,7 +10478,21 @@ const GRAPH_TOOL_EXECUTORS = {
             const l = links[lid];
             if (!l) continue;
             const tgt = byId.get(l.target_id);
-            outs.push(`${l.target_id}.${tgt?.inputs?.[l.target_slot]?.name ?? l.target_slot}`);
+            // #342: resolve the LIVE target slot through the target's own
+            // inputs[].link backlink. The link record's target_slot goes stale
+            // when the target's inputs are compacted (dynamic-combo rebuild,
+            // removed ref_video_N input), and rendering it then reports the link
+            // against whatever slot now occupies that index — an outline that
+            // "looks wired" over a graph whose connection is gone. An ORPHANED
+            // link (no input backlinks it) renders NOTHING, matching
+            // panel_query_graph's live read.
+            if (!tgt || !Array.isArray(tgt.inputs)) {
+              outs.push(`${l.target_id}.${tgt?.inputs?.[l.target_slot]?.name ?? l.target_slot}`);
+              continue;
+            }
+            const live = liveLinkTargetInput(tgt, lid);
+            if (!live) continue;
+            outs.push(`${l.target_id}.${live.name ?? live.index}`);
           }
         }
         if (outs.length) out.push(`     → ${outs.join(", ")}`);

--- a/web/js/lib/graph-read.js
+++ b/web/js/lib/graph-read.js
@@ -13,6 +13,11 @@
 //          the whole max_chars budget, returning `shown:0` for a node you asked for
 //          by id. capSummaryWidgets() bounds each value; isLineProtected() keeps the
 //          FIRST match and any explicitly-requested id renderable regardless.
+//   #342 — a link record's `target_slot` goes stale when the target node's inputs
+//          are compacted (dynamic-combo rebuild, removed ref_video_N input).
+//          liveLinkTargetInput() resolves the LIVE slot through the target's own
+//          inputs[].link backlink so the outline never renders an orphaned link
+//          against a slot it no longer feeds.
 
 /** Per-widget-value character cap for the `detail` projection (#609). Big enough
  *  to identify a value, small enough that one blob can't starve a whole query. */
@@ -57,6 +62,42 @@ export function linkDrivenWidgets(node) {
     out[inp.name] = { node_id: originId, output_slot: originSlot ?? 0 };
   }
   return out;
+}
+
+/**
+ * #342: the LIVE input slot a link actually lands on, resolved through the target
+ * node's OWN `inputs[].link` backlink — never through the link record's
+ * `target_slot`.
+ *
+ * `target_slot` is captured at connect time and goes STALE when the target's inputs
+ * are compacted afterwards — a dynamic combo (COMFY_DYNAMICCOMBO_V3) rebuilding its
+ * slots on a selection change, or a removed ref_video_N input shifting the tail.
+ * Rendering the stale index reports connectivity against whatever slot now OCCUPIES
+ * it: panel_graph_outline showed `VAEDecode → node.output_mode.save_metadata` (a
+ * BOOLEAN slot) while panel_query_graph, which reads the live backlink, correctly
+ * showed the link was gone. The backlink is also what the prompt serializer walks,
+ * so it is the one source of truth for "is this actually connected".
+ *
+ * Returns `{ index, name }` for the input that backlinks `linkId`, or null when NO
+ * input does — an ORPHANED link record whose slot was removed. The caller must
+ * render NOTHING for an orphaned link: showing it against a slot it no longer feeds
+ * fabricates connectivity that does not execute.
+ *
+ * Call only when `Array.isArray(targetNode.inputs)`; without a live inputs list
+ * there is nothing to verify against and the caller falls back to the recorded
+ * `target_slot` (rendered as a bare index, exactly as before).
+ */
+export function liveLinkTargetInput(targetNode, linkId) {
+  const inputs = targetNode?.inputs ?? [];
+  for (let i = 0; i < inputs.length; i++) {
+    const inp = inputs[i];
+    // `!= null` first: Number(null) is 0, and a real link id of 0 must not match an
+    // input that has NO link.
+    if (inp && inp.link != null && Number(inp.link) === Number(linkId)) {
+      return { index: i, name: inp.name };
+    }
+  }
+  return null;
 }
 
 /** Restrict a full link-driven map to only the names that are actually WIDGETS on


### PR DESCRIPTION
## Mechanism

`panel_graph_outline` rendered each outgoing link's target as `tgt.inputs[l.target_slot]?.name` — the `target_slot` recorded on the link record at connect time. That index is captured before a transformation that invalidates it: when the target node's inputs are **compacted** — a `COMFY_DYNAMICCOMBO_V3` selection rebuilding the node's slots, or the reporter's removed dynamic `ref_video_0` shifting the tail — the recorded index survives while the slot it named does not. The outline then reported the link against whatever slot now *occupies* that index: `VAEDecode → easy saveVideo.output_mode.save_metadata`, a BOOLEAN, over a graph whose IMAGE link no longer executes. `panel_query_graph`, which reads the live `inputs[].link` backlink, correctly showed it gone — so the two readers disagreed and the cheaper one lied.

The original #342 complaint — `graph_set_widget` accepting an out-of-enum combo value — was fixed in 0.11.7 (#233/#240). What the 2026-08-18 reproduction on panel 0.14.43 / frontend 1.49.6 describes is this outline staleness, which that fix never touched.

## Fix

- `liveLinkTargetInput()` in `web/js/lib/graph-read.js` resolves the input a link actually lands on by scanning the **target node's own `inputs[].link` backlinks** — the same live truth the prompt serializer walks — never the recorded `target_slot`. Returns `{ index, name }`, or `null` when nothing backlinks the link (an orphaned record).
- The outline executor uses it: an **orphaned link renders nothing**, matching `panel_query_graph`. A link whose live slot merely *shifted* renders the slot it actually feeds.
- `Number(null) === 0`, so a real link id of `0` is guarded from matching an *unlinked* input.
- The fallback is honest about being fail-**open**, not fail-closed: when the target is not in this graph's node set (or carries no `inputs` array) the recorded slot is still rendered as a bare index, exactly as before. That case is self-disclosing — the id it names appears nowhere else in the outline — and was deliberately left alone rather than broadened.

## What the first pass was missing, and the refutation

The fix landed with eight unit tests, all of them exercising the **helper**. Measured on a clean worktree: reverting the entire wiring hunk in `web/js/comfyui-mcp-panel.js` — the outline back to rendering the recorded `target_slot`, the bug fully restored — left the suite at **5038 tests, 5036 pass, 1 fail (the known #671 wall-clock flake), 1 todo**, with all eight #342 tests green. The fix was unpinned; a later edit could have removed it silently.

Two commits close that:

1. **`browser_tests/unit/outline-coverage.test.mjs`** — four tests that lift the outgoing-link render block *verbatim* out of the `graph_outline` handler and execute it, so the assertion runs the production source rather than a copy. With the wiring reverted they report the exact strings #342 was filed about:

   | case | actual (fix reverted) | expected |
   | --- | --- | --- |
   | orphaned link | `['12.output_mode.save_metadata']` | `[]` |
   | slot shifted by compaction | `['5.fps']` | `['5.ref_video_1']` |

2. **`browser_tests/outline-orphaned-link-renders-nothing.spec.ts`** — the same state built in a **real graph in a real ComfyUI**: connect `EmptyLatentImage.LATENT → VAEDecode.samples`, then remove the target's input slot without disconnecting (what the dynamic-combo rebuild leaves behind — record alive in `graph.links` and on the origin's `outputs[].links`, no input backlinking it). `vae` shifts into the freed index. Pre-fix panel: **FAIL**, `Expected substring: not "2.vae"` — the live handler attributing the dropped link to the slot that took its index. With the fix: **PASS**. Preconditions are asserted before the outline is read, so a future frontend that cleans the record up on splice fails the spec as "no longer reproducing #342" instead of passing vacuously.

## Verification

Run from the worktree against a ComfyUI 0.33.1 / frontend 1.48.7 started on an isolated `--base-directory` with this branch junctioned into `custom_nodes`.

- `npm run test:unit` — **5042 tests, 5040 pass, 1 fail, 1 todo**. The single failure is `#671 verifyInstalled … fast-draining install`, the known wall-clock flake; re-run alone it is **125/125 green**.
- `npm run typecheck` — clean. `npm run check:scope` — every name resolves.
- `npx playwright test --workers=1` — **52 passed / 21 failed** with this branch, against a **19 failed / 54 passed** baseline measured back-to-back on the same rig with only `web/js/` reverted to `origin/main`. The failure set is the same pre-existing `MockBridge.waitForUserMessage timed out` cluster (chat history, conversation persistence, streaming, workflow-chat identity) — none of those specs call `graph_outline`. The two that differ between the runs, `agent-drive.spec.ts:113` ("highlight issued BEFORE the first page lands") and `conversation-persistence.spec.ts:261` ("a stale tab republishes the removed thread"), are both ordering races and both are absent from one run and present in the other; neither touches the changed path.
- The specs that *do* exercise `graph_outline` — `outline-orphaned-link-renders-nothing`, `outline-reports-renamed-labels`, `outline-tags-not-forgeable` — are **8/8 green** with the fix.

## Gate

Not self-gated. `codex exec` is account-exhausted until 2026-08-19 20:43 and the substitute `claude-gate.mjs` is blocked on the weekly account limit, so no gate script was run here — the orchestrator gates and merges this.

This addresses the underlying cause of #342; closing that issue is the orchestrator's call, so this PR does not carry an auto-close reference.
