### PR TITLE
fix(1264): a starved post-open frame wait no longer latches the workflow-switch fence

### DIFF
--- a/browser_tests/unit/open-frame-bound.test.mjs
+++ b/browser_tests/unit/open-frame-bound.test.mjs
@@ -1,0 +1,75 @@
+// comfyui-mcp-panel#1264 — a timed-out workflow_open left the switch fence stuck.
+//
+// workflow_open's re-baseline step (clearSpuriousOpenModified) awaits ONE
+// animation frame while holding a reload step of the switch/reload section.
+// rAF does not fire in a hidden or occluded tab, and a step in flight is
+// deliberately immune to the section's 30s age-out (that immunity exists so a
+// genuine load cannot lose the fence mid-write) — so on a backgrounded tab the
+// frame wait never settled, the fence latched forever, every graph/workflow
+// command was refused, and neither the open's reply nor its open receipt could
+// be delivered until a manual page reload. The reporters' only workaround was
+// F5.
+//
+// The fix bounds the frame wait with the repo's one bounded-step primitive: a
+// starved frame degrades to a timer fallback (the tab keeps a cosmetic
+// modified flag — the LOUD direction) instead of wedging the bridge. These
+// tests pin both halves:
+//
+//   1. the primitive's guarantee the fix relies on — a never-settling step
+//      resolves through its fallback instead of pending forever;
+//   2. the SHIPPING nextFrame in the bundle routing its rAF wait through that
+//      primitive with a positive bound that stays well under the bridge's
+//      15s reply window, so the open's reply/receipt can still land.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+import { withTimeout } from "../../web/js/lib/bounded-step.js";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const source = readFileSync(join(here, "../../web/js/comfyui-mcp-panel.js"), "utf8").replace(/\r\n/g, "\n");
+
+test("#1264 a step that never settles resolves through its fallback instead of wedging", async () => {
+  const outcome = await withTimeout(new Promise(() => {}), 25, () => "fallback");
+  assert.equal(outcome, "fallback", "a starved frame must degrade, never pend forever");
+});
+
+test("#1264 a late-settling step is dropped once the bound has fired", async () => {
+  let late = null;
+  const slow = new Promise((resolve) => setTimeout(() => {
+    late = "late";
+    resolve("late");
+  }, 50));
+  const outcome = await withTimeout(slow, 10, () => "fallback");
+  assert.equal(outcome, "fallback");
+  await slow;
+  assert.equal(late, "late", "the bounded work is not cancelled — only the WAIT is bounded");
+});
+
+test("#1264 the shipping nextFrame bounds its rAF wait with the shared primitive", () => {
+  const decl = source.indexOf("function nextFrame()");
+  assert.ok(decl > 0, "nextFrame exists in the bundle");
+  const body = source.slice(decl, decl + 1200);
+  assert.match(
+    body,
+    /withTimeout\(/,
+    "the frame wait must route through the bounded-step primitive — " +
+      "an unbounded rAF await never settles in a hidden tab and latches the switch fence",
+  );
+  const budget = source.match(/NEXT_FRAME_FALLBACK_MS\s*=\s*(\d+)/);
+  assert.ok(budget, "the fallback budget is a named, reviewable constant");
+  const ms = Number(budget[1]);
+  assert.ok(ms > 0, "the bound must be positive — a non-positive one disables it");
+  assert.ok(
+    ms < 15000,
+    `the bound (${ms}ms) must stay well under the bridge's 15s reply window so the open's ` +
+      "reply and open receipt can still be delivered when the frame is starved",
+  );
+  assert.ok(
+    source.indexOf("NEXT_FRAME_FALLBACK_MS") < decl,
+    "the budget constant is declared before its use",
+  );
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -6026,13 +6026,31 @@ async function groundUnsavedWorkflow() {
   }
 }
 
-/** Resolve on the next animation frame (or a short timer when rAF is absent) so
- *  a just-loaded graph can finish rendering / capturing state before we read it. */
+/** Resolve on the next animation frame so a just-loaded graph can finish
+ *  rendering / capturing state before we read it.
+ *
+ *  comfyui-mcp-panel#1264 — the frame wait must be BOUNDED. rAF does not fire in
+ *  a hidden or occluded tab (and can be starved on a busy one), so an unbounded
+ *  await here never settles in exactly the state a backgrounded ComfyUI tab is
+ *  in. This runs inside workflow_open's switch/reload section holding a reload
+ *  STEP (beginWorkflowReloadStep), and a step in flight is deliberately immune
+ *  to the section's 30s age-out — that immunity exists so a genuine load cannot
+ *  lose the fence mid-write, but a render frame is not a load: starving it
+ *  latched the fence forever, refused every graph/workflow command, and left
+ *  the open's reply (and its open receipt) undeliverable until a manual page
+ *  reload. Falling back to a timer after NEXT_FRAME_FALLBACK_MS degrades the
+ *  wait to "the capture may not have landed yet", which is the LOUD direction —
+ *  the tab keeps a cosmetic modified flag rather than wedging the bridge. */
+const NEXT_FRAME_FALLBACK_MS = 2000;
 function nextFrame() {
-  return new Promise((resolve) => {
-    if (typeof requestAnimationFrame === "function") requestAnimationFrame(() => resolve());
-    else setTimeout(resolve, 16);
-  });
+  return withTimeout(
+    new Promise((resolve) => {
+      if (typeof requestAnimationFrame === "function") requestAnimationFrame(() => resolve());
+      else setTimeout(resolve, 16);
+    }),
+    NEXT_FRAME_FALLBACK_MS,
+    () => undefined,
+  );
 }
 
 /** Opening a workflow must NOT leave it flagged modified. ComfyUI re-serializes


### PR DESCRIPTION
## Root cause

`workflow_open`'s re-baseline step (`clearSpuriousOpenModified`) awaits ONE animation frame via `nextFrame()` while holding a reload step of the switch/reload critical section (`beginWorkflowReloadStep`). `requestAnimationFrame` does not fire in a hidden or occluded tab, and a step in flight is deliberately immune to the section's 30s age-out (`activeWorkflowReloadGuard` never expires while `pending > 0`) — that immunity exists so a genuine load cannot lose the fence mid-write. But a render frame is not a load: on a backgrounded ComfyUI tab the unbounded rAF await never settled, `pending` stayed > 0 forever, and the fence latched — every graph/workflow command was refused ("still switching/reloading") and the open's reply/receipt was undeliverable until a manual F5, exactly the #1264 reports (fence held 2m+; `panel_open_workflow` timing out at 15s with outcome undetermined).

## Fix

Bound the frame wait with the repo's one shared bounded-step primitive, `withTimeout` from `web/js/lib/bounded-step.js` (already imported and used by six other paths in this bundle). After `NEXT_FRAME_FALLBACK_MS = 2000` — well under the bridge's 15s reply window — a starved frame degrades to "the capture may not have landed yet": the tab keeps a cosmetic modified flag (the LOUD direction) instead of wedging the bridge. `withTimeout` never rejects and never cancels the bounded work, so a late-firing frame still runs the re-baseline when it can.

This is the only awaited rAF in the open path — the remaining `requestAnimationFrame` uses are UI render loops that hold no fence.

## Tests

`browser_tests/unit/open-frame-bound.test.mjs` pins both halves:

1. the primitive's guarantee the fix relies on — a never-settling step resolves through its fallback instead of pending forever (and a late-settling step is dropped once the bound has fired);
2. the SHIPPING `nextFrame` in the bundle routes its rAF wait through `withTimeout` with a named, positive bound that stays under the bridge's 15s reply window.

## Verification (worktree, origin/main @ 25cef01e)

- `npm ci` — clean, 0 vulnerabilities
- `node --test browser_tests/unit/open-frame-bound.test.mjs` — 3/3 pass
- `npm run test:unit` — 5034 tests, 5033 pass, 0 fail, 1 todo (i18n checks + tool-vocabulary + panel-scope gates all included and green)
- `npm run typecheck` — clean

Closes #1264