### PR TITLE
fix(1192): graph_add_node gets ONE budget, so its bounds stop adding up

### DIFF
--- a/browser_tests/unit/_panel-constants.mjs
+++ b/browser_tests/unit/_panel-constants.mjs
@@ -13,6 +13,9 @@
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 
+import { makeCommandBudget } from "../../web/js/lib/command-budget.js";
+import { REFRESH_JOIN_ABANDONED } from "../../web/js/lib/refresh-coalesce.js";
+
 export const PANEL_SRC = readFileSync(
   fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url)),
   "utf8",
@@ -35,13 +38,26 @@ export const CUSTOM_WIDGET_REGISTRATION_TIMEOUT_MS = readPanelNumber(
   "the registration deadline",
 );
 
+/**
+ * #1192 — the divisor is a NAMED constant now, because the widen's bound is no longer a
+ * fixed number: it is that fraction of whatever deadline the registration wait actually
+ * received, which under a command budget can be far less than the 5000ms standalone one.
+ * Still read from source rather than restated, for the reason above.
+ */
+export const WIDEN_SOCKET_PROOF_DIVISOR = readPanelNumber(
+  /const WIDEN_SOCKET_PROOF_DIVISOR = (\d+);/,
+  "the widen divisor",
+);
+
 /** Derived exactly as the panel derives it, divisor included, so the two cannot drift. */
 export const WIDEN_SOCKET_PROOF_TIMEOUT_MS = Math.floor(
-  CUSTOM_WIDGET_REGISTRATION_TIMEOUT_MS /
-    readPanelNumber(
-      /WIDEN_SOCKET_PROOF_TIMEOUT_MS = Math\.floor\(CUSTOM_WIDGET_REGISTRATION_TIMEOUT_MS \/ (\d+)\)/,
-      "the widen divisor",
-    ),
+  CUSTOM_WIDGET_REGISTRATION_TIMEOUT_MS / WIDEN_SOCKET_PROOF_DIVISOR,
+);
+
+/** #1192 — the whole-command deadline `graph_add_node` takes on its first line. */
+export const ADD_NODE_COMMAND_BUDGET_MS = readPanelNumber(
+  /const ADD_NODE_COMMAND_BUDGET_MS = (\d+);/,
+  "the add_node command budget",
 );
 
 export const NODE_DEFS_FETCH_TIMEOUT_MS = readPanelNumber(
@@ -82,4 +98,54 @@ export const monotonicNow = () => performance.now();
 /** What is left of a run's budget, derived the way the panel derives it. */
 export function nodeDefsBudgetLeft(deadline, share = 1) {
   return Math.max(1, Math.floor((deadline - monotonicNow()) * share));
+}
+
+/**
+ * #1192 — the widen's share of whatever deadline the registration wait actually got,
+ * derived the way the panel derives it. Rebuilt harnesses name this in their scope because
+ * `awaitRequiredCustomWidgetRegistration` calls it.
+ */
+export function widenSocketProofBudget(deadlineMs) {
+  const whole =
+    Number.isFinite(deadlineMs) && deadlineMs > 0
+      ? deadlineMs
+      : CUSTOM_WIDGET_REGISTRATION_TIMEOUT_MS;
+  return Math.max(1, Math.floor(whole / WIDEN_SOCKET_PROOF_DIVISOR));
+}
+
+/** How long a graph tool waits for the startup baseline seed. */
+export const OBJECT_INFO_SEED_WAIT_MS = readPanelNumber(
+  /const OBJECT_INFO_SEED_WAIT_MS = (\d+);/,
+  "the baseline seed wait",
+);
+
+/**
+ * #1192 — every module binding the command budget added to `graph_add_node`, in ONE place.
+ *
+ * Three harnesses rebuild that executor in a synthetic scope, so a new free identifier in
+ * it throws `ReferenceError` in all three at once — which the resolver then catches and
+ * reports as "object_info is unavailable", i.e. a wrong-cause failure in every one of them.
+ * Collected here so the next binding is added once rather than three times, and so no
+ * harness can quietly acquire a stale copy of one.
+ *
+ * The REAL implementations wherever they exist: `makeCommandBudget` and
+ * `REFRESH_JOIN_ABANDONED` are imported, and the numbers are read from the panel source, so
+ * a harness cannot pass against a value the panel no longer holds.
+ */
+export function addNodeCommandBudgetDeps() {
+  return {
+    makeCommandBudget,
+    ADD_NODE_COMMAND_BUDGET_MS,
+    // Derived exactly as the panel derives it.
+    ADD_NODE_POST_REFRESH_RESERVE_MS: CUSTOM_WIDGET_REGISTRATION_TIMEOUT_MS,
+    OBJECT_INFO_SEED_WAIT_MS,
+    REFRESH_JOIN_ABANDONED,
+    widenSocketProofBudget,
+    // A STUB, and labelled as one. These three harnesses are about #821/#1223/#620, none of
+    // which reaches this branch. The shipped wording is pinned in single-node-def.test.mjs
+    // and the behaviour that produces it is exercised in add-node-command-budget.test.mjs;
+    // a hand-copied sentence here would just be a third place for it to drift.
+    addNodeRefreshBusyMessage: (classType) =>
+      `HARNESS STUB refusal for "${classType}" — the shipped wording lives in the panel.`,
+  };
 }

--- a/browser_tests/unit/add-node-command-budget.test.mjs
+++ b/browser_tests/unit/add-node-command-budget.test.mjs
@@ -1,0 +1,528 @@
+// panel#1192 — `graph_add_node`'s bounds are each defensible alone and do not compose.
+//
+// Serialized on one add they sum past the 30,000 ms window `panel_add_node` relays this
+// command in, so the worst case was a bare `Panel tab … did not reply to "graph_add_node"
+// within 30000 ms` — a message that names nothing and offers no remedy — instead of the
+// worded, retryable refusal each of those bounds exists to produce.
+//
+// The term that dominates is the one a caller cannot shrink: `refresh(freshDefs)` goes
+// through `makeRefreshCoalescer`, which waits for any in-flight run before starting its own.
+// On the scenario this add is most likely to meet — a ComfyUI restart, which is exactly when
+// a reconnect-triggered refresh is already running — that wait is on a run that ALREADY
+// STARTED under someone else's deadline.
+//
+// THE HARNESS runs the SHIPPED `graph_add_node` body, extracted from the panel source and
+// given injected collaborators, and wires the REAL coalescer to a REAL in-flight run — the
+// same technique as add-node-socket-proof-scope.test.mjs. A helper-level test cannot reach
+// this defect: `makeCommandBudget` and `makeRefreshCoalescer` are individually correct, and
+// the bug lives entirely in whether the call site threads one into the other.
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import { withTimeout } from "../../web/js/lib/bounded-step.js";
+import { makeRefreshCoalescer, REFRESH_JOIN_ABANDONED } from "../../web/js/lib/refresh-coalesce.js";
+import { makeCommandBudget } from "../../web/js/lib/command-budget.js";
+import {
+  applyCurrentDefWidgetValues,
+  driftedRequiredInputNames,
+  missingRequiredWidgetMaterializations,
+  registeredSocketTypes,
+  unavailableRequiredWidgetMessage,
+  unavailableRequiredWidgetReport,
+} from "../../web/js/lib/node-widget-materialization.js";
+import {
+  assertAddNodeResolvableRefreshing,
+  isRegisteredNodeType,
+} from "../../web/js/lib/node-resolve.js";
+import { fetchSingleNodeDef } from "../../web/js/lib/single-node-def.js";
+import {
+  describeUnmaterializedRequiredWidgets,
+  snapshotBackendDef,
+} from "../../web/js/lib/add-node-widget-guard.js";
+import {
+  NODE_DEFS_FETCH_TIMEOUT_MS,
+  NODE_DEFS_NO_ANSWER,
+  WIDEN_SOCKET_PROOF_TIMEOUT_MS,
+  monotonicNow,
+  widenSocketProofBudget,
+} from "./_panel-constants.mjs";
+
+const panelPath = fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url));
+const panelSrc = readFileSync(panelPath, "utf8");
+
+const addNodeMatch = panelSrc.match(
+  /\n {2}async graph_add_node\(\{ class_type, pos, title \}\) \{[\s\S]*?\n {2}\},/,
+);
+assert.ok(addNodeMatch, "could not locate graph_add_node in panel source");
+
+const awaitWidgetsMatch = panelSrc.match(
+  /\nasync function awaitRequiredCustomWidgetRegistration\([\s\S]*?\n\}/,
+);
+assert.ok(awaitWidgetsMatch, "could not locate awaitRequiredCustomWidgetRegistration");
+
+const placementMatch = panelSrc.match(/\nfunction placementFor\(graph, pos\) \{[\s\S]*?\n\}/);
+assert.ok(placementMatch, "could not locate placementFor");
+
+const boundedMatch = panelSrc.match(/\nasync function boundedGetNodeDefs\([\s\S]*?\n\}/);
+assert.ok(boundedMatch, "could not locate boundedGetNodeDefs in panel source");
+
+// The SHIPPED refusal, built from source rather than restated. A hand-copied sentence here
+// would let the real one drift into naming a remedy that cannot work while this file stayed
+// green — which is the failure mode the message itself exists to prevent.
+const busyMatch = panelSrc.match(/const addNodeRefreshBusyMessage = [\s\S]*?;\r?\n/);
+assert.ok(busyMatch, "could not locate addNodeRefreshBusyMessage in panel source");
+const addNodeRefreshBusyMessage = new Function(
+  "ADD_NODE_COMMAND_BUDGET_MS",
+  `${busyMatch[0]}
+   return addNodeRefreshBusyMessage;`,
+)(25000);
+
+/** A tiny deferred so a test can hold the in-flight refresh open until it chooses. */
+function deferred() {
+  let resolve;
+  const promise = new Promise((r) => (resolve = r));
+  return { promise, resolve };
+}
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+/** The backend's schema. `NewNode` is the freshly installed class the add is asking for. */
+function backendObjectInfo() {
+  return {
+    ExistingNode: {
+      name: "ExistingNode",
+      input: { required: { seed: ["INT", { default: 0, min: 0, max: 10 }] } },
+      output: ["IMAGE"],
+    },
+    NewNode: {
+      name: "NewNode",
+      input: { required: { count: ["INT", { default: 1, min: 0, max: 8 }] } },
+      output: ["IMAGE"],
+    },
+  };
+}
+
+function makeComfy() {
+  const widgets = {
+    INT(node, name, spec) {
+      const w = { name, type: "number", value: spec?.[1]?.default ?? 0, options: spec?.[1] ?? {} };
+      node.widgets.push(w);
+      return { widget: w };
+    },
+  };
+  const graph = {
+    _nodes: [],
+    add(n) {
+      n.id = this._nodes.length + 1;
+      this._nodes.push(n);
+    },
+    beforeChange() {},
+    afterChange() {},
+    setDirtyCanvas() {},
+  };
+  const LG = {
+    registered_node_types: {},
+    createNode(type) {
+      const nodeData = LG.registered_node_types[type]?.nodeData;
+      if (!nodeData) return null;
+      const node = { type, title: type, pos: [0, 0], size: [200, 100], widgets: [], inputs: [] };
+      for (const [name, spec] of Object.entries(nodeData.input?.required ?? {})) {
+        const ctor = widgets[String(spec?.[0])];
+        if (ctor) ctor(node, name, spec);
+        else node.inputs.push({ name, type: spec?.[0] });
+      }
+      return node;
+    },
+  };
+  const app = {
+    graph,
+    widgets,
+    registerNodesFromDefs(defs) {
+      for (const [type, nodeData] of Object.entries(defs ?? {})) {
+        LG.registered_node_types[type] = { nodeData, comfyClass: type };
+      }
+    },
+  };
+  return { app, LG, graph, widgets };
+}
+
+/**
+ * Build the SHIPPED `graph_add_node` with the REAL coalescer behind it.
+ *
+ * `budgetMs`/`reserveMs` are injected small so these tests run in milliseconds rather than
+ * waiting out the shipped 25s. Same code, same arithmetic, shorter deadline — the shipped
+ * NUMBERS are pinned separately, against the relay window, in single-node-def.test.mjs.
+ */
+function realGraphAddNode({
+  comfy,
+  getNodeDefs,
+  // A promise the PAYLOAD-LESS (reconnect) run waits on before it registers anything, or
+  // null for "no refresh is in flight". Held open, it is the reported scenario: a ComfyUI
+  // restart, whose reconnect refresh is still running when the add arrives.
+  holdInFlight = null,
+  budgetMs = 400,
+  reserveMs = 120,
+  registrationMs = 200,
+  overrides = {},
+} = {}) {
+  const c = comfy ?? makeComfy();
+  const { app, LG, graph } = c;
+  const context = { app, LG, graph, rootGraph: graph, workflow: { uuid: "wf" } };
+
+  const api = {
+    getNodeDefs: getNodeDefs ?? (async () => backendObjectInfo()),
+    async fetchApi(route) {
+      const cls = decodeURIComponent(String(route).replace("/object_info/", ""));
+      const all = backendObjectInfo();
+      const body = Object.prototype.hasOwnProperty.call(all, cls) ? { [cls]: all[cls] } : {};
+      return { status: 200, json: async () => body };
+    },
+  };
+
+  // The REAL single-flight coordinator, over a real slot, with a real in-flight run when the
+  // test supplies one. Stubbing this away would remove the term the whole issue is about.
+  let inFlight = null;
+  const runs = [];
+  const refreshComfyNodeDefs = makeRefreshCoalescer({
+    getInFlight: () => inFlight,
+    setInFlight: (p) => {
+      inFlight = p;
+    },
+    runRegister: async (defs) => {
+      runs.push(defs);
+      // The reconnect run — the one with no payload — is the one a test can hold open.
+      if (defs == null && holdInFlight) await holdInFlight;
+      app.registerNodesFromDefs(defs ?? (await api.getNodeDefs()));
+      return true;
+    },
+    withTimeout,
+  });
+  // A refresh someone else started — a websocket reconnect, a finished install — already
+  // holding the slot when the add arrives.
+  const inFlightStarted = holdInFlight ? refreshComfyNodeDefs(undefined) : null;
+
+  const deps = {
+    captureGraphMutationContext: () => context,
+    revalidateGraphMutationContext: () => context,
+    getGraphCtx: () => context,
+    app,
+    awaitObjectInfoHistorySeed: async () => {},
+    recordObjectInfoTypes: (defs) => defs,
+    objectInfoHistory: { wasTypeEverDefined: () => false },
+    objectInfoSnapshot: { record: () => true, clear: () => {} },
+    backendReconnectEpoch: 0,
+    readPackImportFailures: async () => [],
+    api,
+    refreshComfyNodeDefs,
+    summarizeNode: (node) => ({ id: node.id, type: node.type }),
+    assertAddNodeResolvableRefreshing,
+    driftedRequiredInputNames,
+    registeredSocketTypes,
+    missingRequiredWidgetMaterializations,
+    applyCurrentDefWidgetValues,
+    unavailableRequiredWidgetReport,
+    unavailableRequiredWidgetMessage,
+    snapshotBackendDef,
+    isRegisteredNodeType,
+    fetchSingleNodeDef,
+    describeUnmaterializedRequiredWidgets,
+    NODE_DEFS_NO_ANSWER,
+    WIDEN_SOCKET_PROOF_TIMEOUT_MS,
+    widenSocketProofBudget,
+    monotonicNow,
+    NODE_DEFS_FETCH_TIMEOUT_MS,
+    withTimeout,
+    makeCommandBudget,
+    REFRESH_JOIN_ABANDONED,
+    addNodeRefreshBusyMessage,
+    OBJECT_INFO_SEED_WAIT_MS: 8000,
+    ADD_NODE_COMMAND_BUDGET_MS: budgetMs,
+    ADD_NODE_POST_REFRESH_RESERVE_MS: reserveMs,
+    ...overrides,
+  };
+
+  if (!("boundedGetNodeDefs" in deps)) {
+    const build = new Function(
+      "api",
+      "withTimeout",
+      "NODE_DEFS_NO_ANSWER",
+      "NODE_DEFS_FETCH_TIMEOUT_MS",
+      `${boundedMatch[0]}
+       return boundedGetNodeDefs;`,
+    );
+    deps.boundedGetNodeDefs = (timeoutMs) =>
+      build(deps.api, withTimeout, NODE_DEFS_NO_ANSWER, NODE_DEFS_FETCH_TIMEOUT_MS)(timeoutMs);
+  }
+
+  const names = Object.keys(deps);
+  const factory = new Function(
+    ...names,
+    `${awaitWidgetsMatch[0]}
+     ${placementMatch[0]}
+     const CUSTOM_WIDGET_REGISTRATION_TIMEOUT_MS = ${registrationMs};
+     const CUSTOM_WIDGET_REGISTRATION_POLL_MS = 5;
+     const executors = {${addNodeMatch[0]}};
+     return executors.graph_add_node;`,
+  );
+  return {
+    graph_add_node: factory(...names.map((n) => deps[n])),
+    comfy: c,
+    runs,
+    inFlightStarted,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// 1. The reported composition: the join alone would exhaust the command.
+// ---------------------------------------------------------------------------
+
+test("#1192: an add refuses IN WORDS when the in-flight refresh would eat the whole budget", async () => {
+  // Held open, so the add's `refresh(freshDefs)` genuinely waits on a run it did not start
+  // and cannot shorten — the term the whole issue is about, exercised through the real
+  // coalescer rather than modelled.
+  const gate = deferred();
+  const comfy = makeComfy();
+  const built = realGraphAddNode({
+    comfy,
+    holdInFlight: gate.promise,
+    budgetMs: 400,
+    reserveMs: 120,
+  });
+
+  const started = Date.now();
+  await assert.rejects(
+    () => built.graph_add_node({ class_type: "NewNode" }),
+    (err) => {
+      // The SHIPPED wording, not a paraphrase.
+      assert.equal(err.message, addNodeRefreshBusyMessage("NewNode"));
+      return true;
+    },
+    "an add whose budget went on someone else's refresh must refuse, in words",
+  );
+  const elapsed = Date.now() - started;
+  assert.ok(elapsed < 4000, `refused in ${elapsed}ms — it must give up at the bound, not wait the run out`);
+
+  // NOTHING was added. The alternative to refusing is adding a node whose class may not be
+  // registered, which is #458's fabricated placeholder.
+  assert.equal(comfy.graph._nodes.length, 0, "the graph was not touched");
+
+  gate.resolve();
+  await built.inFlightStarted?.catch(() => {});
+});
+
+test("#1192: the refusal names a remedy that WORKS — retry, not a tab reload", async () => {
+  // #663/#852: a refusal that sends the caller to the wrong recovery costs more than the
+  // refusal itself. The resolver's own message here is "the node-def refresh failed — reload
+  // the ComfyUI tab", which is wrong twice over: the refresh did not fail, and reloading
+  // throws away the user's canvas state for a condition that clears on its own.
+  const msg = addNodeRefreshBusyMessage("NewNode");
+  assert.match(msg, /NOTHING WAS ADDED/, "the caller must know the graph is untouched before it retries");
+  assert.match(msg, /RETRY/, "…and that a retry is the remedy");
+  assert.ok(!/reload/i.test(msg), "…and must not be told to reload the tab");
+  assert.match(msg, /panel_refresh_nodes/, "…with a concrete escalation if retrying keeps failing");
+});
+
+test("#1192: the abandoned add does NOT start a competing registration run", async () => {
+  // Two concurrent registerNodesFromDefs passes are the stampede makeRefreshCoalescer exists
+  // to prevent. A caller that has just given up waiting for one is the last thing that
+  // should launch a second — so the fresh payload is DROPPED, which is safe only because the
+  // caller refuses rather than claiming success. (#289 P2 forbids dropping a payload while
+  // reporting success, not dropping one while refusing.)
+  const gate = deferred();
+  const comfy = makeComfy();
+  const built = realGraphAddNode({ comfy, holdInFlight: gate.promise, budgetMs: 400, reserveMs: 120 });
+
+  await built.graph_add_node({ class_type: "NewNode" }).catch(() => {});
+  assert.deepEqual(built.runs, [undefined], "only the in-flight reconnect run ever started");
+
+  gate.resolve();
+  await built.inFlightStarted?.catch(() => {});
+});
+
+// ---------------------------------------------------------------------------
+// 2. The healthy paths, which the bound must not narrow.
+// ---------------------------------------------------------------------------
+
+test("#1192: an in-flight refresh that lands in time still lets the add through", async () => {
+  // The bound must not become a way to refuse adds on a machine doing nothing wrong. This is
+  // what the reported scenario actually hits most of the time.
+  const comfy = makeComfy();
+  const landing = sleep(20); // the reconnect run finishes well inside the add's join budget
+  const built = realGraphAddNode({ comfy, holdInFlight: landing, budgetMs: 4000, reserveMs: 120 });
+
+  const { added } = await built.graph_add_node({ class_type: "NewNode" });
+  assert.equal(added.type, "NewNode", "the add succeeded");
+  assert.equal(comfy.graph._nodes.length, 1);
+  await built.inFlightStarted;
+});
+
+test("#1192: with NO refresh in flight the add pays nothing for the join at all", async () => {
+  const comfy = makeComfy();
+  const built = realGraphAddNode({ comfy, budgetMs: 4000 });
+  const started = Date.now();
+  const { added } = await built.graph_add_node({ class_type: "NewNode" });
+  assert.equal(added.type, "NewNode");
+  assert.ok(Date.now() - started < 500, "a healthy add is not slowed by a bound it never reaches");
+});
+
+test("#1192: an ALREADY-registered class takes the fast path and never reaches the refresh", async () => {
+  // #780's saving, preserved: the budget must not have made the cheap path pay for the
+  // expensive one's protection.
+  const comfy = makeComfy();
+  comfy.app.registerNodesFromDefs({ ExistingNode: backendObjectInfo().ExistingNode });
+  let wholeReads = 0;
+  const built = realGraphAddNode({
+    comfy,
+    budgetMs: 4000,
+    getNodeDefs: async () => {
+      wholeReads += 1;
+      return backendObjectInfo();
+    },
+  });
+  const { added } = await built.graph_add_node({ class_type: "ExistingNode" });
+  assert.equal(added.type, "ExistingNode");
+  assert.equal(wholeReads, 0, "the whole schema was never re-downloaded");
+  assert.deepEqual(built.runs, [], "…and no refresh run was needed");
+});
+
+// ---------------------------------------------------------------------------
+// 3. The budget reaches the LAST step too, and says so when it does.
+// ---------------------------------------------------------------------------
+
+test("#1192: a /object_info read that eats the budget leaves the add a bound, not a hang", async () => {
+  // The whole-schema fetch draws `budget.bounded(NODE_DEFS_FETCH_TIMEOUT_MS)`. With the
+  // command nearly spent that is a small number, and the add fails closed on the path an
+  // unreadable schema already takes — rather than parking on a 10s bound the command cannot
+  // afford.
+  const comfy = makeComfy();
+  const built = realGraphAddNode({
+    comfy,
+    budgetMs: 200,
+    getNodeDefs: () => new Promise(() => {}), // half-open: never answers, never fails
+  });
+  const started = Date.now();
+  await assert.rejects(
+    () => built.graph_add_node({ class_type: "NewNode" }),
+    /object_info is unavailable|cannot verify node type/,
+    "a schema that never answers must produce the unreadable-schema refusal",
+  );
+  assert.ok(Date.now() - started < 3000, "…at the command's bound, not at the standalone 10s one");
+});
+
+test("#1192: a registration wait cut short by the budget SAYS it was, and says retry first", async () => {
+  // The message this wait throws tells the user to reload the tab and that "retrying alone
+  // will not fix it" — right for an extension that failed to load, and exactly wrong for a
+  // wait that was cut short by a command already running late, where a retry gets the full
+  // window. Without the note, the budget would manufacture a confident wrong diagnosis.
+  const comfy = makeComfy();
+  // A required input whose declared type has no registered widget and no installed producer:
+  // the guard waits for a constructor that will never appear.
+  const schema = {
+    NewNode: {
+      name: "NewNode",
+      input: { required: { thing: ["MYSTERY_T", { default: 1 }] } },
+      output: ["IMAGE"],
+    },
+  };
+  const built = realGraphAddNode({
+    comfy,
+    budgetMs: 260,
+    reserveMs: 0,
+    registrationMs: 200,
+    getNodeDefs: async () => {
+      await sleep(180); // most of the command spent before the wait even begins
+      return schema;
+    },
+  });
+
+  await assert.rejects(
+    () => built.graph_add_node({ class_type: "NewNode" }),
+    (err) => {
+      assert.match(err.message, /had no widget after/, "…still the #695 report, with its causes");
+      assert.match(err.message, /this wait was cut short/, "the truncation must be disclosed");
+      assert.match(err.message, /RETRY FIRST/, "…and the retry must outrank the reload advice");
+      return true;
+    },
+  );
+});
+
+test("#1192: a registration wait that got its FULL window says nothing about a budget", async () => {
+  // The note must not appear on a wait that was not truncated — a disclosure that fires
+  // every time is one nobody reads, and it would send a genuine extension failure chasing a
+  // budget that was never the cause.
+  const comfy = makeComfy();
+  const schema = {
+    NewNode: {
+      name: "NewNode",
+      input: { required: { thing: ["MYSTERY_T", { default: 1 }] } },
+      output: ["IMAGE"],
+    },
+  };
+  const built = realGraphAddNode({
+    comfy,
+    budgetMs: 8000,
+    registrationMs: 120,
+    getNodeDefs: async () => schema,
+  });
+
+  await assert.rejects(
+    () => built.graph_add_node({ class_type: "NewNode" }),
+    (err) => {
+      assert.match(err.message, /had no widget after/);
+      assert.ok(!/cut short/.test(err.message), "an untruncated wait must not claim a budget cut it");
+      return true;
+    },
+  );
+});
+
+// ---------------------------------------------------------------------------
+// 4. The whole point: the command lands inside its window.
+// ---------------------------------------------------------------------------
+
+test("#1192: every step stalling at once still replies inside the command budget", async () => {
+  // The composition, end to end. Before this fix each of these stalls took its own full
+  // bound and they ADDED — ~41s against a 30s relay window — so the reply never left the
+  // tab. Now they draw on one deadline, so the command reports SOMETHING in time, which is
+  // the property the relay actually needs.
+  const comfy = makeComfy();
+  const gate = deferred(); // the reconnect run never lands
+  const BUDGET_MS = 500;
+  const built = realGraphAddNode({
+    comfy,
+    holdInFlight: gate.promise,
+    budgetMs: BUDGET_MS,
+    reserveMs: 100,
+    registrationMs: 200,
+    getNodeDefs: async () => {
+      await sleep(150);
+      return backendObjectInfo();
+    },
+    overrides: {
+      // A baseline seed that never settles on its own: bounded at the command's remainder,
+      // so it costs what the command can afford and no more.
+      awaitObjectInfoHistorySeed: (waitMs) =>
+        new Promise((resolve) => setTimeout(resolve, Math.max(1, Math.min(waitMs ?? 8000, 8000)))),
+    },
+  });
+
+  const started = Date.now();
+  const outcome = await built.graph_add_node({ class_type: "NewNode" }).then(
+    (v) => ({ ok: v }),
+    (err) => ({ err }),
+  );
+  const elapsed = Date.now() - started;
+
+  assert.ok(outcome.err, "with every step stalled the add must refuse rather than succeed");
+  // Generous against the budget, because the unbounded local work this deliberately cannot
+  // interrupt is real and the CI box is shared. The number that matters is that it is a
+  // small multiple of the budget rather than the ~41s sum of the individual bounds.
+  assert.ok(
+    elapsed < BUDGET_MS * 6,
+    `the add took ${elapsed}ms against a ${BUDGET_MS}ms budget — the bounds are adding again`,
+  );
+
+  gate.resolve();
+  await built.inFlightStarted?.catch(() => {});
+});

--- a/browser_tests/unit/add-node-command-budget.test.mjs
+++ b/browser_tests/unit/add-node-command-budget.test.mjs
@@ -430,13 +430,18 @@ test("#1192: a registration wait cut short by the budget SAYS it was, and says r
     comfy,
     budgetMs: 260,
     reserveMs: 0,
-    registrationMs: 200,
+    // 400, not 200: the wait must end at the BUDGET's remainder (~60ms after the fetch), so
+    // the standalone timeout has to sit far enough past it that a wait which ignores the
+    // budget and takes its full window is unambiguously late — 180ms of fetch plus 400ms of
+    // wait is more than double the whole command.
+    registrationMs: 400,
     getNodeDefs: async () => {
       await sleep(180); // most of the command spent before the wait even begins
       return schema;
     },
   });
 
+  const started = Date.now();
   await assert.rejects(
     () => built.graph_add_node({ class_type: "NewNode" }),
     (err) => {
@@ -445,6 +450,15 @@ test("#1192: a registration wait cut short by the budget SAYS it was, and says r
       assert.match(err.message, /RETRY FIRST/, "…and the retry must outrank the reload advice");
       return true;
     },
+  );
+  // The MESSAGE assertions above pass even when the wait ignores the budget it was handed —
+  // `cutShort` is computed from the same `wait` the mutation bypasses — so the truncation
+  // itself is asserted on the clock: the refusal must land near the budget's remainder, not
+  // after the wait's full standalone window. A wait that took its own 400ms after a 180ms
+  // fetch has spent more than two command budgets.
+  assert.ok(
+    Date.now() - started < 400,
+    "the wait must end at the budget's remainder, not run out its full standalone window",
   );
 });
 

--- a/browser_tests/unit/add-node-schema-auto-refresh.test.mjs
+++ b/browser_tests/unit/add-node-schema-auto-refresh.test.mjs
@@ -73,6 +73,7 @@ import {
   NODE_DEFS_FETCH_TIMEOUT_MS,
   NODE_DEFS_NO_ANSWER,
   WIDEN_SOCKET_PROOF_TIMEOUT_MS,
+  addNodeCommandBudgetDeps,
   monotonicNow,
 } from "./_panel-constants.mjs";
 
@@ -231,6 +232,9 @@ function realGraphAddNode(comfy, overrides = {}) {
     monotonicNow,
     NODE_DEFS_FETCH_TIMEOUT_MS,
     withTimeout,
+    // #1192 — the command budget's module bindings, shared across the three harnesses that
+    // rebuild this executor so a new binding is added in ONE place.
+    ...addNodeCommandBudgetDeps(),
     ...overrides,
   };
 

--- a/browser_tests/unit/add-node-socket-proof-scope.test.mjs
+++ b/browser_tests/unit/add-node-socket-proof-scope.test.mjs
@@ -197,6 +197,10 @@ import {
   PANEL_SRC as widenSrcForConsts,
   WIDEN_SOCKET_PROOF_TIMEOUT_MS,
   monotonicNow,
+  // #1192 — the command-budget bindings graph_add_node now names. Collected in one place
+  // because three harnesses rebuild that executor and would otherwise each need their own
+  // copy, which is how a harness acquires a stale one.
+  addNodeCommandBudgetDeps,
 } from "./_panel-constants.mjs";
 
 /** Build the SHIPPED graph_add_node with its collaborators injected. */
@@ -266,6 +270,9 @@ function realGraphAddNode(comfy, overrides = {}) {
     monotonicNow,
     NODE_DEFS_FETCH_TIMEOUT_MS,
     withTimeout,
+    // #1192 — same rule, one issue later: the command budget and the constants its steps
+    // draw from are module scope in the real file, so this scope has to name them all.
+    ...addNodeCommandBudgetDeps(),
     ...overrides,
   };
 

--- a/browser_tests/unit/add-node-upload-widget.test.mjs
+++ b/browser_tests/unit/add-node-upload-widget.test.mjs
@@ -73,6 +73,10 @@ import {
   PANEL_SRC as widenSrcForConsts,
   WIDEN_SOCKET_PROOF_TIMEOUT_MS,
   monotonicNow,
+  // #1192 — the command-budget bindings graph_add_node now names. Collected in one place
+  // because three harnesses rebuild that executor and would otherwise each need their own
+  // copy, which is how a harness acquires a stale one.
+  addNodeCommandBudgetDeps,
 } from "./_panel-constants.mjs";
 
 const panelPath = fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url));
@@ -256,6 +260,9 @@ function realGraphAddNode(comfy, overrides = {}) {
     monotonicNow,
     NODE_DEFS_FETCH_TIMEOUT_MS,
     withTimeout,
+    // #1192 — same rule, one issue later: the command budget and the constants its steps
+    // draw from are module scope in the real file, so this scope has to name them all.
+    ...addNodeCommandBudgetDeps(),
     ...overrides,
   };
   // Resolved from `deps` at CALL time: tests pass their own `api` through overrides, and a

--- a/browser_tests/unit/command-budget.test.mjs
+++ b/browser_tests/unit/command-budget.test.mjs
@@ -1,0 +1,138 @@
+// Unit tests for web/js/lib/command-budget.js — ONE deadline for a whole panel command.
+//
+// #1192. The property under test is not "it subtracts correctly": it is that every way this
+// can be WRONG fails toward a bound rather than away from one. `withTimeout` reads a
+// non-positive `ms` as NO BOUND, so a budget that reports 0, a negative, NaN or Infinity to
+// a caller silently removes the bound at exactly the moment the command is already too slow
+// — the hang arriving through the mechanism meant to prevent it. That trap is recorded in
+// #1188 and in #1180's `nodeDefsBudgetLeft`; this file is where it is checked for the third
+// occurrence of the same primitive.
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { makeCommandBudget } from "../../web/js/lib/command-budget.js";
+import { withTimeout } from "../../web/js/lib/bounded-step.js";
+
+/** A clock the test drives, so nothing here depends on wall-clock timing. */
+function fakeClock(start = 1000) {
+  let t = start;
+  const now = () => t;
+  now.advance = (ms) => {
+    t += ms;
+  };
+  return now;
+}
+
+test("remaining() counts down from the total on the supplied clock", () => {
+  const now = fakeClock();
+  const budget = makeCommandBudget(25000, now);
+  assert.equal(budget.totalMs, 25000);
+  assert.equal(budget.remaining(), 25000);
+  assert.equal(budget.spent(), 0);
+
+  now.advance(4000);
+  assert.equal(budget.remaining(), 21000);
+  assert.equal(budget.spent(), 4000);
+  assert.equal(budget.exhausted(), false);
+});
+
+test("bounded() hands out the SMALLER of what a step wants and what is left", () => {
+  const now = fakeClock();
+  const budget = makeCommandBudget(25000, now);
+
+  // Plenty left ⇒ the step keeps its own bound. This is the healthy case, and it must not
+  // be narrowed: shrinking a bound that had room is how a budget buys itself with false
+  // refusals on a machine that was doing nothing wrong.
+  assert.equal(budget.bounded(10000), 10000);
+
+  now.advance(19000); // 6000 left
+  assert.equal(budget.bounded(10000), 6000, "the command's remainder wins once it is the smaller");
+  assert.equal(budget.bounded(1000), 1000, "…and a modest step is still not narrowed for no reason");
+});
+
+test("an EXHAUSTED budget yields 1ms — never a non-positive ms, which arms no bound at all", () => {
+  const now = fakeClock();
+  const budget = makeCommandBudget(25000, now);
+  now.advance(25000);
+  assert.equal(budget.exhausted(), true);
+  assert.equal(budget.remaining(), 0);
+  assert.equal(budget.bounded(10000), 1, "a spent budget times out immediately and truthfully");
+
+  now.advance(60000); // deep into overrun
+  assert.ok(budget.remaining() < 0, "remaining() reports the overrun honestly…");
+  assert.equal(budget.bounded(10000), 1, "…but bounded() never passes a non-positive ms on");
+});
+
+test("the 1ms floor is not cosmetic: it is what keeps withTimeout ARMED", async () => {
+  // The floor exists for exactly one consumer. Checked against the real primitive rather
+  // than asserted as a number, because the number only matters through this behaviour.
+  const now = fakeClock();
+  const budget = makeCommandBudget(1000, now);
+  now.advance(5000); // long spent
+
+  const never = new Promise(() => {});
+  assert.equal(
+    await withTimeout(never, budget.bounded(10000), () => "degraded"),
+    "degraded",
+    "an exhausted budget must still produce a BOUND, not remove one",
+  );
+});
+
+test("a step that names no bound of its own gets the remainder, never Infinity or NaN", () => {
+  const now = fakeClock();
+  const budget = makeCommandBudget(25000, now);
+  now.advance(5000); // 20000 left
+
+  for (const noBound of [undefined, null, 0, -1, Number.NaN, Number.POSITIVE_INFINITY, "10000"]) {
+    const ms = budget.bounded(noBound);
+    assert.ok(
+      Number.isFinite(ms) && ms > 0,
+      `bounded(${String(noBound)}) produced ${ms}, which withTimeout would read as NO bound`,
+    );
+    assert.equal(ms, 20000, `bounded(${String(noBound)}) must fall back to the remainder`);
+  }
+});
+
+test("a total that was never really set is ZERO, not infinity", () => {
+  // Failing to infinity would silently restore the unbounded path — the reported bug —
+  // whereas failing to zero refuses immediately and truthfully, which a caller can word.
+  for (const bad of [undefined, null, 0, -5, Number.NaN, Number.POSITIVE_INFINITY, "25000"]) {
+    const budget = makeCommandBudget(bad, fakeClock());
+    assert.equal(budget.totalMs, 0, `a total of ${String(bad)} must not become an allowance`);
+    assert.equal(budget.exhausted(), true);
+    assert.equal(budget.bounded(10000), 1, "…and still hands out an armed bound, not a removed one");
+  }
+});
+
+test("an unusable clock degrades to the platform one instead of throwing", async () => {
+  // `graph_add_node` takes this budget on its FIRST line. A guard that threw here would
+  // refuse every add on a page whose `performance` object is unusual — a guard causing the
+  // outage it reports, which this repo has shipped before.
+  const throwing = () => {
+    throw new Error("no clock here");
+  };
+  for (const bad of [undefined, null, 42, throwing, () => Number.NaN]) {
+    const budget = makeCommandBudget(50, bad);
+    assert.ok(Number.isFinite(budget.remaining()), `clock ${String(bad)} must still yield a finite remainder`);
+    assert.ok(budget.bounded(10) > 0);
+  }
+  // …and the platform fallback is a REAL clock, so the budget still expires.
+  const budget = makeCommandBudget(20, undefined);
+  await new Promise((r) => setTimeout(r, 60));
+  assert.equal(budget.exhausted(), true, "the fallback clock must actually advance");
+});
+
+test("the clock does NOT stop: local work spends a command budget", () => {
+  // The opposite of NODE_DEFS_RUN_BUDGET_MS, deliberately. A run budget is an allowance for
+  // WAITING and pushes its deadline out across unbounded local work so that work escapes it.
+  // The orchestrator measures wall clock from dispatch to reply, so a COMMAND budget must
+  // CHARGE that work — otherwise it reports time the command does not have, and the reply
+  // misses the relay window while the budget still claims to be healthy.
+  const now = fakeClock();
+  const budget = makeCommandBudget(25000, now);
+  now.advance(4000); // registerNodesFromDefs, measured at 3972ms on this rig
+  assert.equal(budget.remaining(), 21000, "unbounded local work still spends the command's window");
+  assert.equal(budget.bounded(5000), 5000);
+  now.advance(20000);
+  assert.equal(budget.bounded(5000), 1000, "…so the steps after it get correspondingly less");
+});

--- a/browser_tests/unit/refresh-coalesce.test.mjs
+++ b/browser_tests/unit/refresh-coalesce.test.mjs
@@ -4,7 +4,9 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { makeRefreshCoalescer } from "../../web/js/lib/refresh-coalesce.js";
+import { makeRefreshCoalescer, REFRESH_JOIN_ABANDONED } from "../../web/js/lib/refresh-coalesce.js";
+// #1192 — the REAL bounding primitive, so `opts.joinMs` is exercised rather than stubbed.
+import { withTimeout } from "../../web/js/lib/bounded-step.js";
 
 // A tiny deferred so a test can hold a refresh "in flight" until it chooses.
 function deferred() {
@@ -15,7 +17,7 @@ function deferred() {
 
 // Build a coalescer over a module-like single slot, recording every payload that
 // runRegister actually registered.
-function makeHarness(runImpl) {
+function makeHarness(runImpl, { wireTimeout = true } = {}) {
   let inFlight = null;
   const registered = [];
   const coalescer = makeRefreshCoalescer({
@@ -27,6 +29,9 @@ function makeHarness(runImpl) {
       registered.push(defs);
       if (runImpl) await runImpl(defs);
     },
+    // #1192 — wired by default, because the panel wires it. `wireTimeout: false` is how the
+    // "an unwired coalescer waits unbounded" test drives the omission deliberately.
+    ...(wireTimeout ? { withTimeout } : {}),
   });
   return { coalescer, registered, getInFlight: () => inFlight };
 }
@@ -193,6 +198,219 @@ function makeHarnessReturning(verdictImpl) {
       const v = verdictImpl(defs);
       return v && typeof v.then === "function" ? await v : v;
     },
+    withTimeout,
   });
   return { coalescer };
 }
+
+// ── #1192: a caller may bound its own WAIT, and only that ────────────────────
+//
+// Every branch above begins with `await current` — a wait on a run that ALREADY STARTED
+// under someone else's deadline. `graph_add_node` meets that wait on the scenario it is
+// most likely to fail on (a ComfyUI restart, when a reconnect refresh is already running),
+// and a full run costs ~9s of bounded waiting plus ~4s of deliberately-unbounded local
+// work. Unbounded, that single term consumes most of the add's 25s command budget before
+// its own registration has begun, and the reply misses the 30s relay window entirely — so
+// the user gets `did not reply to "graph_add_node"`, which names nothing, instead of the
+// worded refusal every bound on that path exists to produce.
+
+test("#1192: a payload join that outlives joinMs is ABANDONED, not waited out", async () => {
+  const gate = deferred();
+  const { coalescer, registered } = makeHarness(async (defs) => {
+    if (defs == null) await gate.promise; // the in-flight reconnect refresh never lands
+  });
+
+  const older = coalescer(); // holds the slot, gated open
+  const NEW_DEFS = { NewNode: {} };
+  const started = Date.now();
+  const outcome = await coalescer(NEW_DEFS, { joinMs: 25 });
+
+  assert.equal(outcome, REFRESH_JOIN_ABANDONED, "the caller stopped waiting and said so");
+  assert.ok(Date.now() - started < 1000, "…at the bound, not when the in-flight run eventually settles");
+  // The load-bearing half: it must NOT have started a competing run. Two concurrent
+  // registerNodesFromDefs passes are the stampede this coordinator exists to prevent, and a
+  // caller that has just given up waiting for one is the last thing that should launch a
+  // second.
+  assert.deepEqual(registered, [undefined], "no second run was started alongside the one still going");
+
+  gate.resolve();
+  await older;
+});
+
+test("#1192: a join that lands INSIDE joinMs still registers the fresh payload (#289 P2 intact)", async () => {
+  // The bound must not become a way to drop payloads on a healthy machine. This is the case
+  // the reported scenario actually hits most of the time — the in-flight run finishes, and
+  // the add's own registration goes ahead exactly as before the bound existed.
+  const gate = deferred();
+  const { coalescer, registered } = makeHarness(async (defs) => {
+    if (defs == null) await gate.promise;
+  });
+
+  const older = coalescer();
+  const NEW_DEFS = { NewNode: {} };
+  const withPayload = coalescer(NEW_DEFS, { joinMs: 5000 });
+  gate.resolve();
+  await older;
+  await withPayload;
+
+  assert.ok(registered.includes(NEW_DEFS), "the fresh payload was registered, bound or no bound");
+});
+
+test("#1192: an in-flight run that REJECTS is a SETTLED join, not an abandoned one", async () => {
+  // `withTimeout` degrades a rejection through onTimeout exactly as it does a timeout, so
+  // bounding `current` directly would report a run that FAILED as one that never answered —
+  // and this coordinator has always treated a failed in-flight run as settled, with the
+  // caller then running its own. Reifying before bounding is what keeps that true.
+  const gate = deferred();
+  let first = true;
+  const { coalescer, registered } = makeHarness(async () => {
+    if (first) {
+      first = false;
+      await gate.promise;
+      throw new Error("older refresh failed");
+    }
+  });
+
+  const older = coalescer();
+  const NEW_DEFS = { NewNode: {} };
+  const withPayload = coalescer(NEW_DEFS, { joinMs: 5000 });
+  gate.resolve();
+  await older.catch(() => {});
+  const outcome = await withPayload;
+
+  assert.notEqual(outcome, REFRESH_JOIN_ABANDONED, "a rejection is an ANSWER, not a stall");
+  assert.ok(registered.includes(NEW_DEFS), "…so the payload still ran, as it always has");
+});
+
+test("#1192: a joinMs of 0 or less abandons IMMEDIATELY — it never means 'no bound'", async () => {
+  // `withTimeout` reads a non-positive ms as NO BOUND. A budget expressed literally at the
+  // moment it ran out would therefore restore the unbounded wait — the hang arriving through
+  // the mechanism meant to prevent it. #1188 recorded this trap; it is checked here because
+  // graph_add_node computes joinMs by SUBTRACTION and can legitimately reach a negative.
+  const gate = deferred();
+  const { coalescer, registered } = makeHarness(async (defs) => {
+    if (defs == null) await gate.promise; // never settles
+  });
+
+  const older = coalescer();
+  for (const joinMs of [0, -1, -7500]) {
+    assert.equal(
+      await coalescer({ NewNode: {} }, { joinMs }),
+      REFRESH_JOIN_ABANDONED,
+      `joinMs=${joinMs} must abandon at once, not wait forever`,
+    );
+  }
+  assert.deepEqual(registered, [undefined], "…and must not start a run either");
+
+  gate.resolve();
+  await older;
+});
+
+test("#1192: a coalescer with NO withTimeout wired waits unbounded, exactly as it always did", async () => {
+  // The safe direction for a wiring mistake to fail in: a panel that forgot to inject the
+  // primitive keeps today's behaviour instead of abandoning every join at once, which would
+  // break every add. Safe is not the same as noticed — the panel's CALL SITE is pinned
+  // separately in single-node-def.test.mjs, because this degradation is silent.
+  const gate = deferred();
+  const { coalescer, registered } = makeHarness(
+    async (defs) => {
+      if (defs == null) await gate.promise;
+    },
+    { wireTimeout: false },
+  );
+
+  const older = coalescer();
+  const NEW_DEFS = { NewNode: {} };
+  const withPayload = coalescer(NEW_DEFS, { joinMs: 10 });
+
+  // Give the bound every chance to fire if it were armed.
+  await new Promise((r) => setTimeout(r, 60));
+  assert.deepEqual(registered, [undefined], "still waiting on the in-flight run — no bound was applied");
+
+  gate.resolve();
+  await older;
+  assert.notEqual(await withPayload, REFRESH_JOIN_ABANDONED, "an unwired join is a plain, unbounded join");
+  assert.ok(registered.includes(NEW_DEFS));
+});
+
+test("#1192: a non-finite joinMs is treated as NO bound, never as an armed one", async () => {
+  // A caller computing joinMs from an unset budget can produce Infinity or NaN, and both
+  // reach `withTimeout` as "no bound" anyway. Rejecting them at the door keeps that
+  // accidental behaviour from being load-bearing.
+  const gate = deferred();
+  const { coalescer, registered } = makeHarness(async (defs) => {
+    if (defs == null) await gate.promise;
+  });
+
+  const older = coalescer();
+  const pending = [
+    coalescer({ A: {} }, { joinMs: Number.POSITIVE_INFINITY }),
+    coalescer({ B: {} }, { joinMs: Number.NaN }),
+  ];
+  await new Promise((r) => setTimeout(r, 40));
+  assert.deepEqual(registered, [undefined], "both are still waiting on the in-flight run");
+
+  gate.resolve();
+  await older;
+  for (const p of pending) assert.notEqual(await p, REFRESH_JOIN_ABANDONED);
+});
+
+test("#1192: a plain (payload-less) join can be bounded too, and reports it", async () => {
+  const gate = deferred();
+  const { coalescer, registered } = makeHarness(async () => {
+    await gate.promise;
+  });
+
+  const older = coalescer();
+  assert.equal(await coalescer(undefined, { joinMs: 25 }), REFRESH_JOIN_ABANDONED);
+  assert.equal(registered.length, 1, "a bounded plain join still starts nothing of its own");
+
+  gate.resolve();
+  await older;
+});
+
+test("#1192: a bounded FORCED caller stops waiting but does not cancel #396's trailing run", async () => {
+  // The trailing run is a guarantee made to every forced caller, not to this one. A caller
+  // that gives up must not take it away from the others — so the run stays queued and still
+  // executes, and only this caller's wait ends.
+  const gate = deferred();
+  const registered = [];
+  let inFlight = null;
+  const coalescer = makeRefreshCoalescer({
+    getInFlight: () => inFlight,
+    setInFlight: (p) => {
+      inFlight = p;
+    },
+    runRegister: async (defs) => {
+      registered.push(defs);
+      if (registered.length === 1) await gate.promise; // hold ONLY the first run
+    },
+    withTimeout,
+  });
+
+  const held = coalescer(); // in flight, gated
+  const patient = coalescer(undefined, { force: true }); // no bound
+  assert.equal(await coalescer(undefined, { force: true, joinMs: 25 }), REFRESH_JOIN_ABANDONED);
+
+  gate.resolve();
+  await Promise.all([held, patient]);
+  assert.equal(registered.length, 2, "the trailing run still ran for the caller that kept waiting");
+});
+
+test("#1192: a bounded FORCED join that lands still forwards the trailing run's verdict (#608)", async () => {
+  // #608 reads the freshness verdict off a forced refresh. Bounding the WAIT must not turn a
+  // real verdict into a fabricated one — only an abandonment is new.
+  const gate = deferred();
+  let verdict = false;
+  const { coalescer } = makeHarnessReturning(async (defs) => {
+    if (defs == null) await gate.promise;
+    return verdict;
+  });
+
+  const inflight = coalescer();
+  const forced = coalescer(undefined, { force: true, joinMs: 5000 });
+  verdict = true;
+  gate.resolve();
+  await inflight;
+  assert.equal(await forced, true, "the trailing run's own verdict, not a stand-in");
+});

--- a/browser_tests/unit/single-node-def.test.mjs
+++ b/browser_tests/unit/single-node-def.test.mjs
@@ -151,10 +151,13 @@ test("#767 WIRING: the fast path is gated on the type ALREADY being registered",
   // …with the CONSTANT, not a literal. withTimeout treats a non-positive ms as NO bound, so
   // passing 0 here silently restores the hang while every other assertion still holds —
   // verified: that mutation survived until this line existed.
+  // #1192 — …and that constant is now CAPPED by the command's remaining budget, because it
+  // is not the only bound on this path. A timed-out fast path falls through to the
+  // whole-schema fetch, so the two are additive.
   assert.match(
     body,
-    /fetchSingleNodeDef\(class_type[\s\S]{0,120}?NODE_DEFS_FETCH_TIMEOUT_MS/,
-    "the fast path must be bounded by the named constant, not an inline number",
+    /fetchSingleNodeDef\(class_type[\s\S]{0,400}?budget\.bounded\(NODE_DEFS_FETCH_TIMEOUT_MS\)/,
+    "the fast path must be bounded by the named constant, capped by the command budget",
   );
   assert.ok(guard > 0, "the registered-type gate must be present");
   assert.ok(call > guard, "…and the single-class fetch must sit INSIDE it");
@@ -163,7 +166,14 @@ test("#767 WIRING: the fast path is gated on the type ALREADY being registered",
   // bounded call rather than a bare `await api.getNodeDefs()`. What this pins is that the
   // WHOLE-schema fallback still exists behind the gate, which is the safety property; the
   // literal it used to match was incidental to that.
-  assert.match(body, /await boundedGetNodeDefs\(\)/, "the whole-schema fallback must still be there");
+  // #1192 — the fallback now takes the SAME 10s bound `graph_set_widget`'s oracle gives the
+  // identical request, capped by what the command has left. It used to take the default,
+  // which read as agreement with set_widget only by coincidence.
+  assert.match(
+    body,
+    /await boundedGetNodeDefs\(budget\.bounded\(NODE_DEFS_FETCH_TIMEOUT_MS\)\)/,
+    "the whole-schema fallback must still be there, bounded by the command budget",
+  );
   assert.match(
     body,
     /NODE_DEFS_NO_ANSWER \? null :/,
@@ -394,39 +404,70 @@ test("#1180: the widen's bound fits INSIDE the registration deadline it runs und
   // DERIVED from that deadline, not picked, so the two cannot drift apart.
   assert.match(
     src,
-    /const WIDEN_SOCKET_PROOF_TIMEOUT_MS = Math\.floor\(CUSTOM_WIDGET_REGISTRATION_TIMEOUT_MS \/ \d+\)/,
+    /const WIDEN_SOCKET_PROOF_TIMEOUT_MS = Math\.floor\(\s*CUSTOM_WIDGET_REGISTRATION_TIMEOUT_MS \/ WIDEN_SOCKET_PROOF_DIVISOR,?\s*\)/,
     "the widen's bound must be derived from the registration deadline",
   );
   // READ the divisor from source. Computing it here makes the test agree with itself
   // rather than with the panel: changing the shipped `/ 2` to `/ 1` — which makes the
   // widen exactly as long as the wait it runs inside — survived until this did.
-  const divisor = Number(
-    (src.match(/WIDEN_SOCKET_PROOF_TIMEOUT_MS = Math\.floor\(CUSTOM_WIDGET_REGISTRATION_TIMEOUT_MS \/ (\d+)\)/) || [])[1],
-  );
+  const divisor = Number((src.match(/const WIDEN_SOCKET_PROOF_DIVISOR = (\d+);/) || [])[1]);
   assert.ok(divisor >= 2, `the widen must get a FRACTION of its caller's deadline, saw /${divisor}`);
   const widen = Math.floor(registration / divisor);
   assert.ok(widen > 0 && widen < registration, `the widen bound must fit inside ${registration}ms, got ${widen}`);
 
+  // #1192 — the SAME fraction, of whatever deadline the wait actually got.
+  //
+  // The pin moved from a constant to a derivation because the constant stopped being the
+  // truth. Under a command budget the registration wait can be a few hundred ms, and a
+  // widen still taking a fixed 2500ms of it is this issue's own defect one level down: a
+  // bound sized against a number its caller no longer has. `widenSocketProofBudget` keeps
+  // the ratio; the ratio is what the paragraph above is actually about.
+  const share = src.slice(
+    src.indexOf("function widenSocketProofBudget("),
+    src.indexOf("\n}", src.indexOf("function widenSocketProofBudget(")),
+  );
+  assert.ok(share.length > 0, "the widen's share of its caller's deadline must be findable");
+  assert.match(
+    share,
+    /whole \/ WIDEN_SOCKET_PROOF_DIVISOR/,
+    "the widen must take the same FRACTION of the deadline it actually runs under",
+  );
+  assert.match(
+    share,
+    /Math\.max\(1,/,
+    "a spent budget must yield 1ms, never a non-positive ms that arms no bound at all",
+  );
+  assert.match(
+    share,
+    /CUSTOM_WIDGET_REGISTRATION_TIMEOUT_MS/,
+    "…and a caller that names no deadline must fall back to #580's own",
+  );
+
   // …and the widen must actually use it rather than the generic node-defs bound.
   assert.match(
     src,
-    /boundedGetNodeDefs\(WIDEN_SOCKET_PROOF_TIMEOUT_MS\)/,
-    "the widen must use its own bound, not the 10s single-call one",
+    /widened = await widenSocketProof\(widenSocketProofBudget\(wait\)\)/,
+    "the registration wait must hand the widen its share of the deadline it actually got",
+  );
+  assert.match(
+    src,
+    /boundedGetNodeDefs\(\s*widenMs > 0 \? widenMs : WIDEN_SOCKET_PROOF_TIMEOUT_MS,?\s*\)/,
+    "the widen must use the bound it was handed, not the 10s single-call one",
   );
 });
 
-test("#1180: graph_add_node's bounds are SEQUENTIAL, and their sum is tracked (#1192)", () => {
-  // This test used to assert `single + single + widen < 30000` and pass, which was wrong in
-  // both directions. It omitted the two terms that dominate — the refresh run, paid TWICE
-  // because makeRefreshCoalescer waits for the in-flight run before starting its own, and
-  // the custom-widget registration wait — so it certified an arithmetic the path does not
-  // perform. A budget test that models the wrong composition is worse than none: it reads
-  // as coverage.
+test("#1192: graph_add_node's serialized bounds FIT the command budget", () => {
+  // The predecessor of this test asserted the OPPOSITE — that this path exceeds the budget —
+  // and said so in its own failure message: "If that is genuinely fixed, close #1192 and
+  // replace this with the assertion that it FITS." This is that replacement.
   //
-  // The real worst case EXCEEDS the command budget, and that is filed as #1192 rather than
-  // fixed here. It is not a regression — before this issue these steps were unbounded, so
-  // the same path could hang forever. The purpose of this test is now to stop the sum
-  // GROWING while #1192 is open.
+  // WHAT CHANGED IS NOT THE ARITHMETIC, and that distinction is the whole fix. The
+  // individual bounds are UNCHANGED and their naive sum is still past the relay window. A
+  // fix that made them add up by shrinking each one would have bought the budget with false
+  // refusals on healthy installs — the direction this repo has regressed in before, and the
+  // direction the notes at every one of these constants warn about. What changed is that
+  // they no longer ADD: each is capped by ONE deadline taken at the top of the command, so
+  // the path costs that deadline rather than the sum.
   const src = readFileSync(PANEL_JS, "utf8");
   const num = (re, what) => {
     const m = src.match(re);
@@ -437,51 +478,184 @@ test("#1180: graph_add_node's bounds are SEQUENTIAL, and their sum is tracked (#
   const run = num(/const NODE_DEFS_RUN_BUDGET_MS = (\d+);/, "the refresh run budget");
   const floor = num(/const NODE_DEFS_COMBO_FLOOR_MS = (\d+);/, "the combo phase floor");
   const registration = num(/const CUSTOM_WIDGET_REGISTRATION_TIMEOUT_MS = (\d+);/, "the registration deadline");
+  const seed = num(/const OBJECT_INFO_SEED_WAIT_MS = (\d+);/, "the baseline seed wait");
+  const budget = num(/const ADD_NODE_COMMAND_BUDGET_MS = (\d+);/, "the command budget");
 
-  // Two paths, and the branch that skips the fast path is the expensive one.
+  // The relay window this must fit inside. 30000 is what comfyui-mcp's `panel_add_node`
+  // passes as an explicit reply timeout (`OBJECT_INFO_REFRESH_ACK_TIMEOUT_MS`), NOT the
+  // 20000 ui-bridge read default — which applies to neither this command nor refresh_nodes
+  // nor graph_set_widget, all three of which are relayed at 30000. It is NOT read from this
+  // repo, and saying so is more honest than a local mirror: the panel once carried a
+  // BRIDGE_READ_DEFAULT_MS copy that nothing consumed, so the assertion compared the panel
+  // against the panel and could never have caught the drift it appeared to guard.
+  const RELAY_WINDOW_MS = 30000;
+  assert.ok(budget > 0, "the command budget must be a positive number of milliseconds");
+  assert.ok(
+    budget < RELAY_WINDOW_MS,
+    `the command budget (${budget}ms) must fit inside the ${RELAY_WINDOW_MS}ms relay window`,
+  );
+  // …with real slack, not by a millisecond: the reply still has to be composed, serialized
+  // and pushed through the websocket after the last step returns.
+  assert.ok(
+    RELAY_WINDOW_MS - budget >= 5000,
+    `only ${RELAY_WINDOW_MS - budget}ms of slack between the command budget and the relay window`,
+  );
+
+  // The naive sum, still computed, because it is what the cap exists to defeat.
   //
-  // ALREADY REGISTERED: the fast path runs and, on a hang, times out and falls through to
-  // the whole-schema fetch — they compose rather than exclude each other, because a
-  // timeout is doubt and doubt takes the full fetch. No refresh: the type is registered.
-  const registeredPath = single + single + registration;
+  // ALREADY REGISTERED: the seed wait, then the fast path, which on a hang times out and
+  // falls through to the whole-schema fetch — they compose rather than exclude each other,
+  // because a timeout is doubt and doubt takes the full fetch. No refresh: the type is
+  // registered.
+  const registeredPath = seed + single + single + registration;
   // A run's worst-case WAITING is its budget plus the combo floor: #1193 lets a run
   // exceed NODE_DEFS_RUN_BUDGET_MS by up to the floor when a slow-but-successful fetch
   // spent the combo's remainder. That is the accepted cost of the floor, and it is
-  // counted here so this sum stays honest rather than reassuring.
+  // counted here so this sum stays honest rather than reassuring — the command budget caps
+  // what the add PAYS, not what a run inside it may cost.
   const runWait = run + floor;
   // NOT REGISTERED: no fast path (it is gated on already-registered), then the whole-schema
   // fetch, then the resolver hands the payload to refreshComfyNodeDefs — which waits for
-  // any in-flight run and then performs its own, so the run budget is paid twice.
-  const unregisteredPath = single + runWait + runWait + registration;
-  const worstCase = Math.max(registeredPath, unregisteredPath);
-
-  // The widen is INSIDE the registration wait, not added to it — that is what its divisor
-  // is for — so it must not appear as a separate term.
-  const widen = Math.floor(
-    registration /
-      num(
-        /WIDEN_SOCKET_PROOF_TIMEOUT_MS = Math\.floor\(CUSTOM_WIDGET_REGISTRATION_TIMEOUT_MS \/ (\d+)\)/,
-        "the widen divisor",
-      ),
-  );
-  assert.ok(widen < registration, "the widen is spent inside the registration wait, not alongside it");
-
-  // The known ceiling while #1192 is open. Not a target — a ratchet. Raised from
-  // 33000 to 45000 by #1193's combo floor: two serialized runs can now cost
-  // 2 x (budget + floor) in the case the floor exists for, and the issue records that
-  // trade explicitly.
-  const TRACKED_CEILING_MS = 45000;
+  // any in-flight run and then performs its own, so the run wait is paid twice.
+  const unregisteredPath = seed + single + runWait + runWait + registration;
+  const naiveSum = Math.max(registeredPath, unregisteredPath);
+  // The tracked-ceiling ratchet this replaces was scoped "while #1192 is open" and said to
+  // swap in the FITS assertion once the fix landed. This is that assertion: the naive sum
+  // must STILL exceed the budget (the bounds were capped, not shrunk — a sum under the
+  // budget would mean the cap is decorative and the shrink bought it with false refusals),
+  // and the assertions below pin that the cap is wired at every step.
   assert.ok(
-    worstCase <= TRACKED_CEILING_MS,
-    `one add's serialized bounds now sum to ${worstCase}ms, above the ${TRACKED_CEILING_MS}ms tracked while #1192 is open — ` +
-      "raising a bound on this path makes an already-over-budget command worse",
+    naiveSum > budget,
+    `the per-step bounds sum to ${naiveSum}ms, which no longer exceeds the ${budget}ms budget — ` +
+      "if that is because the bounds were SHRUNK rather than capped, the cap has become " +
+      "decorative and the shrink bought the budget with false refusals on healthy installs. " +
+      "Re-read the notes at each constant before changing this.",
   );
-  // …and the fact that it is over budget is stated, so nobody reads the pass above as fine.
-  const COMMAND_BUDGET_MS = 30000;
+
+  // No SINGLE step may be given more than the whole command. A step that could is one that
+  // reaches the relay window on its own, which is the condition this issue is about.
+  for (const [what, ms] of [
+    ["the baseline seed wait", seed],
+    ["the single-call fetch bound", single],
+    ["the refresh run budget", run],
+    // #1193 — a run may exceed its own budget by up to the combo floor, so the worst-case
+    // wait a step can cost is the pair, and the pair is what must fit under the command.
+    ["a refresh run's worst-case wait (budget + combo floor)", runWait],
+    ["the registration deadline", registration],
+  ]) {
+    assert.ok(ms <= budget, `${what} (${ms}ms) is larger than the whole command budget (${budget}ms)`);
+  }
+
+  // ── The cap is WIRED, at every step, read from the shipped source ─────────────
+  //
+  // These are the assertions that fail when the fix is removed. Everything above passes
+  // whether or not a single call site consults the budget.
+  const at = src.indexOf("  async graph_add_node({ class_type, pos, title }) {");
+  assert.ok(at > 0, "graph_add_node must be findable in the panel source");
+  const body = src.slice(at, src.indexOf("\n  async graph_", at + 10));
+
+  // Taken ONCE, before the first step, on the monotonic clock — like every other elapsed
+  // measurement in this panel. On the wall clock an NTP correction mid-command either
+  // refuses an add that did nothing wrong or extends it past the window it exists to fit.
+  assert.match(
+    body,
+    /const budget = makeCommandBudget\(ADD_NODE_COMMAND_BUDGET_MS, monotonicNow\);/,
+    "the command must take ONE deadline, before any step, on the monotonic clock",
+  );
+
+  // Every step draws from it. Named individually rather than counted, so adding a step
+  // cannot silently satisfy a total.
+  const wired = [
+    [/await awaitObjectInfoHistorySeed\(budget\.bounded\(OBJECT_INFO_SEED_WAIT_MS\)\)/, "the baseline seed wait"],
+    [
+      /fetchSingleNodeDef\(class_type[\s\S]{0,400}?budget\.bounded\(NODE_DEFS_FETCH_TIMEOUT_MS\)/,
+      "the single-class fast path",
+    ],
+    [/await boundedGetNodeDefs\(budget\.bounded\(NODE_DEFS_FETCH_TIMEOUT_MS\)\)/, "the whole-schema fetch"],
+    [/joinMs: budget\.remaining\(\) - ADD_NODE_POST_REFRESH_RESERVE_MS/, "the coalescer join"],
+    [/budget\.bounded\(CUSTOM_WIDGET_REGISTRATION_TIMEOUT_MS\)/, "the custom-widget registration wait"],
+  ];
+  for (const [re, what] of wired) {
+    assert.match(body, re, `${what} must draw its bound from the command budget`);
+  }
+
+  // …and NO step may still name one of those constants raw. This is what catches a bound
+  // added to this path LATER: the failure mode is not that an existing site regresses, it is
+  // that the sixth site nobody thought about is written the way the first five used to be.
+  const stripped = body.replace(/\/\*[\s\S]*?\*\//g, "").replace(/^\s*\/\/.*$/gm, "");
+  for (const name of [
+    "OBJECT_INFO_SEED_WAIT_MS",
+    "NODE_DEFS_FETCH_TIMEOUT_MS",
+    "CUSTOM_WIDGET_REGISTRATION_TIMEOUT_MS",
+  ]) {
+    const total = (stripped.match(new RegExp(name, "g")) ?? []).length;
+    const capped = (stripped.match(new RegExp(`budget\\.bounded\\(${name}\\)`, "g")) ?? []).length;
+    assert.equal(
+      total,
+      capped,
+      `${name} appears ${total} time(s) in graph_add_node but only ${capped} are capped by the command budget`,
+    );
+  }
+
+  // The reserve is DERIVED from the step it protects, not picked, so the two cannot drift.
+  assert.match(
+    src,
+    /const ADD_NODE_POST_REFRESH_RESERVE_MS = CUSTOM_WIDGET_REGISTRATION_TIMEOUT_MS;/,
+    "the post-refresh reserve must be derived from the wait it holds time back for",
+  );
+
+  // The coalescer's join can only be bounded if the panel WIRED the bounding primitive into
+  // it. A one-line wiring omission is invisible to the coalescer's own unit tests — those
+  // inject their own — and silently restores the unbounded wait this issue is about.
+  const wiredAt = src.indexOf("const refreshComfyNodeDefs = makeRefreshCoalescer({");
+  assert.ok(wiredAt > 0, "the panel's coalescer construction must be findable");
+  const coalescer = src.slice(wiredAt, src.indexOf("});", wiredAt));
+  assert.match(coalescer, /\n\s*withTimeout,/, "the panel's coalescer must be wired with the bounding primitive");
+});
+
+test("#1192: an add that gave up waiting for someone else's refresh says so, and says retry", () => {
+  // The resolver SWALLOWS a refresh throw by design — its post-refresh registry re-check is
+  // what decides go/no-go — so the reason an add ran out of budget cannot reach the user
+  // through the resolver's own wording, which says "the node-def refresh failed — reload the
+  // ComfyUI tab and retry". That advice is wrong here in the expensive direction: the
+  // refresh did NOT fail, it is still running and about to register the very class being
+  // asked for. Same class of defect as #663 and #852 — a refusal naming a remedy that cannot
+  // work costs more than the refusal itself.
+  const src = readFileSync(PANEL_JS, "utf8");
+  const at = src.indexOf("  async graph_add_node({ class_type, pos, title }) {");
+  const body = src.slice(at, src.indexOf("\n  async graph_", at + 10));
+
+  // Recovered through a FLAG and the live registry — two structured conditions — never by
+  // matching the resolver's prose. Reading a decision off an error message is how this repo
+  // authorizes things it should not.
+  assert.match(
+    body,
+    /if \(outcome === REFRESH_JOIN_ABANDONED\) refreshJoinAbandoned = true;/,
+    "the abandoned join must be recorded as a flag, not inferred from an error string",
+  );
+  assert.match(
+    body,
+    /if \(refreshJoinAbandoned && !isRegisteredNodeType\(LG\?\.registered_node_types \?\? \{\}, class_type\)\)/,
+    "…and re-worded only when the class is ALSO still unregistered — the in-flight run may have landed",
+  );
   assert.ok(
-    worstCase > COMMAND_BUDGET_MS,
-    `#1192 says this path exceeds the ${COMMAND_BUDGET_MS}ms command budget; it now sums to ` +
-      `${worstCase}ms. If that is genuinely fixed, close #1192 and replace this with the ` +
-      "assertion that it FITS.",
+    !/refreshJoinAbandoned[\s\S]{0,300}?err\?*\.message/.test(body),
+    "the budget refusal must never be decided by reading the resolver's message",
+  );
+
+  // The wording itself must state that nothing was added, and that a retry is the remedy.
+  //
+  // Anchored with `\r?\n`, not `\n`. The working tree is CRLF, so a bare `;\n` matches
+  // NOWHERE, `indexOf` returns -1, and `slice(at, -1)` silently hands back most of the file
+  // — which then contains "reload" for a hundred unrelated reasons and the assertion below
+  // fails on correct code. The mirror-image version of that mistake (an anchor that misses
+  // and reads as a caught mutation) is recorded in #1188.
+  const msg = (src.match(/const addNodeRefreshBusyMessage =[\s\S]*?;\r?\n/) || [])[0];
+  assert.ok(msg, "the busy refusal's wording must be findable");
+  assert.match(msg, /NOTHING WAS ADDED/, "the refusal must say the graph was not touched");
+  assert.match(msg, /RETRY/, "…and that a retry is the remedy, because the in-flight run is registering these defs");
+  assert.ok(
+    !/reload/i.test(msg),
+    "…and must NOT send the user to reload the tab, which throws away canvas state for a refresh that is working",
   );
 });

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -225,7 +225,7 @@ import { buildPanelFailureShell } from "./lib/panel-failure-shell.js";
 import { installSidebarRenderWatchdog } from "./lib/sidebar-render-watchdog.js";
 import { displayLabel, boundaryInputLabel, widgetLabelMap } from "./lib/slot-labels.js";
 import { createObjectInfoHistory, awaitHistoryBaseline } from "./lib/object-info-history.js";
-import { makeRefreshCoalescer } from "./lib/refresh-coalesce.js";
+import { makeRefreshCoalescer, REFRESH_JOIN_ABANDONED } from "./lib/refresh-coalesce.js";
 import {
   describeNodeDefRefresh,
   describeRefreshGraphLoss,
@@ -237,6 +237,11 @@ import {
   missingInventoryIds,
   nodeInventoryLabel,
 } from "./lib/graph-node-inventory.js";
+// #1192 — ONE deadline for a whole COMMAND, which every bounded step inside it draws from.
+// A module because the defect is a COMPOSITION property: each of graph_add_node's bounds
+// was individually correct and their sum was not, and a sum cannot be asserted against the
+// 1.7MB panel IIFE.
+import { makeCommandBudget } from "./lib/command-budget.js";
 // #1184 — the ORDER a backend switch commits in. A module because the defect is an
 // ordering property, and order cannot be asserted against the 1.7MB panel IIFE.
 import { BACKEND_SWITCH, runBackendSwitch } from "./lib/backend-switch.js";
@@ -1157,8 +1162,14 @@ const OBJECT_INFO_SEED_WAIT_MS = 8000;
 // must not start a replacement seed. If the baseline has not landed the history reports
 // PENDING and the guards refuse this ONE call with "retry in a moment"; the seed keeps
 // running and a late response still seeds, so the next call succeeds with no tab reload.
-const awaitObjectInfoHistorySeed = () =>
-  awaitHistoryBaseline(objectInfoHistory, objectInfoHistorySeed, OBJECT_INFO_SEED_WAIT_MS);
+//
+// #1192 — the wait is CAPPED by the caller when the caller has a command budget. 8000ms is
+// a patience limit sized on its own; on the add path it is the FIRST of five serialized
+// bounds, and a command that spends a third of its window before it has even asked what the
+// backend provides has already lost. A caller passing less gets less; passing nothing keeps
+// the standalone limit exactly as it was.
+const awaitObjectInfoHistorySeed = (waitMs = OBJECT_INFO_SEED_WAIT_MS) =>
+  awaitHistoryBaseline(objectInfoHistory, objectInfoHistorySeed, waitMs);
 
 async function registerComfyNodeDefs(preloadedDefs) {
   // Trust the live combos for suppressing missing-asset candidates ONLY once the
@@ -1674,6 +1685,13 @@ const refreshComfyNodeDefs = makeRefreshCoalescer({
     nodeDefRefreshInFlight = p;
   },
   runRegister: registerComfyNodeDefs,
+  // #1192 — the repo's ONE bounding primitive, injected so a caller can bound its own WAIT
+  // on a run someone else started (`opts.joinMs`). Without it the coalescer waits
+  // unbounded, exactly as it always did — the safe direction for a wiring mistake to fail
+  // in, since the alternative would abandon every join on a panel that forgot this line.
+  // Safe is not the same as noticed, though: dropping it silently restores #1192, so the
+  // CALL SITE is pinned by a test, not just the helper's behaviour.
+  withTimeout,
 });
 
 // #396: download ids already counted as done, so each COMPLETED model download
@@ -9840,6 +9858,81 @@ const CUSTOM_WIDGET_REGISTRATION_TIMEOUT_MS = 5000;
 const CUSTOM_WIDGET_REGISTRATION_POLL_MS = 25;
 
 /**
+ * #1192 — ONE budget for the WHOLE `graph_add_node` command.
+ *
+ * PER-STEP BOUNDS DO NOT COMPOSE. #1180 learned that for the phases of one refresh RUN and
+ * fixed it there; this is the same defect one level up, and #1180's own PR filed it rather
+ * than pretending otherwise. Serialized on a single add, the steps cost:
+ *
+ *     awaitObjectInfoHistorySeed                              8,000 ms
+ *     the /object_info read (fast path, then the whole-schema
+ *       fallback a timed-out fast path falls through to)     10,000 ms + 10,000 ms
+ *     refresh(freshDefs) → the coalescer's join on a run
+ *       someone else started                                  9,000 ms + unbounded local
+ *     …then that call's OWN run                               9,000 ms + unbounded local
+ *     awaitRequiredCustomWidgetRegistration                    5,000 ms
+ *
+ * The two /object_info terms are alternatives to the refresh terms — a type already
+ * registered takes the fast path and never refreshes — so the worst SINGLE path is about
+ * 41,000 ms, not the sum of all of them. #1192's table says 33,000 ms because it omits the
+ * seed wait; either figure is past the relay window, which is the point.
+ *
+ * MEASURED, not assumed: `panel_add_node` relays `graph_add_node` with an explicit
+ * 30,000 ms reply timeout (comfyui-mcp `panel-tools.ts`, `OBJECT_INFO_REFRESH_ACK_TIMEOUT_MS`
+ * at the `panel_add_node` call site) — NOT the 20,000 ms ui-bridge read default, which
+ * applies to neither this command nor `refresh_nodes` nor `graph_set_widget`, all three of
+ * which are relayed at 30,000 ms. Past that window the reply the bounds exist to produce
+ * never leaves the tab and the user gets `did not reply to "graph_add_node" within 30000 ms`,
+ * which names nothing and is not actionable.
+ *
+ * 25,000 ms, mirroring NODES_INSTALL_COMMAND_BUDGET_MS against the same 30,000 ms window
+ * for the same reason: 5,000 ms of slack for composing the reply, serialising it, and the
+ * websocket hop. Not derived from the relay constant, because that constant lives in the
+ * OTHER repo and a mirrored copy here would be a number this repo could not keep true.
+ *
+ * WHAT IT DOES NOT DO, stated so this is not read as a wall-clock guarantee. Two calls on
+ * this path are deliberately unbounded — `registerNodesFromDefs` (3,972 ms measured) and
+ * `reapplyDefsToLiveNodes` — and no budget can interrupt them. What the budget does is
+ * CHARGE them: the clock keeps running across them, so every later step gets less and the
+ * command still lands inside the window. See lib/command-budget.js for why that is the
+ * opposite of NODE_DEFS_RUN_BUDGET_MS's deliberate clock-stop.
+ */
+const ADD_NODE_COMMAND_BUDGET_MS = 25000;
+
+/**
+ * #1192 — what an add still has to do AFTER the node-def refresh, held back so the join
+ * cannot spend it.
+ *
+ * The coalescer's `await current` is the term that cannot be shrunk from here: it is a wait
+ * on a run that ALREADY STARTED under its own deadline. Given the whole remainder it can
+ * legitimately consume ~13,000 ms (a run's 9,000 ms of bounded waiting plus its unbounded
+ * local work) and then leave the widget-registration wait a few milliseconds — at which
+ * point the add refuses for the wrong reason, naming a widget that was never given time to
+ * appear instead of the refresh that ate the command.
+ *
+ * DERIVED from the step it protects, not picked, so the two cannot drift apart.
+ */
+const ADD_NODE_POST_REFRESH_RESERVE_MS = CUSTOM_WIDGET_REGISTRATION_TIMEOUT_MS;
+
+/**
+ * #1192 — the refusal for an add whose budget went on a refresh SOMEONE ELSE started.
+ *
+ * RECOVERABLE BY CONSTRUCTION, and worded to say so. The in-flight run was not cancelled
+ * (nothing here can cancel it) and it is registering the very definitions this add needs, so
+ * the retry this text asks for is not a hope — it is the normal outcome once that run lands.
+ * That is what makes dropping the fresh payload acceptable: #289 P2 forbids dropping a
+ * payload while claiming success, not dropping one while refusing.
+ */
+const addNodeRefreshBusyMessage = (classType) =>
+  `Cannot add "${classType}" right now: a node-def refresh started by something else — a ` +
+  "ComfyUI reconnect, a finished install, or another tool call — was still running, and " +
+  `waiting for it would have used up this command's ${Math.round(ADD_NODE_COMMAND_BUDGET_MS / 1000)}s ` +
+  "budget before the node could be registered. NOTHING WAS ADDED and nothing was changed. " +
+  "That refresh is still running and is registering exactly the definitions this add needs, " +
+  "so RETRY in a few seconds — this normally succeeds on the next attempt. If it keeps " +
+  "happening, call panel_refresh_nodes once and wait for it to report, then retry the add.";
+
+/**
  * #1180 — the widen runs INSIDE the registration wait above, so its bound has to fit
  * there. The generic 10s node-defs bound is TWICE this function's whole 5s deadline: a
  * timed-out widen would consume the entire wait and leave the poll loop nothing, so the
@@ -9877,8 +9970,29 @@ const CUSTOM_WIDGET_REGISTRATION_POLL_MS = 25;
  * issue — the refusal is worded and clears on a retry, where the hang it replaced was
  * neither. What it is NOT is headroom, and the number to revisit when the add path's total
  * has room is this one.
+ *
+ * #1192 — the divisor is now NAMED and the widen's bound is computed from the deadline this
+ * wait is ACTUALLY running under, not from the standalone constant. Under a command budget
+ * the effective deadline can be a fraction of the 5000ms below, and a widen still taking
+ * 2500ms of a 400ms wait is this issue's own defect reproduced one level down: a bound
+ * sized against a number its caller no longer has.
  */
-const WIDEN_SOCKET_PROOF_TIMEOUT_MS = Math.floor(CUSTOM_WIDGET_REGISTRATION_TIMEOUT_MS / 2);
+const WIDEN_SOCKET_PROOF_DIVISOR = 2;
+const WIDEN_SOCKET_PROOF_TIMEOUT_MS = Math.floor(
+  CUSTOM_WIDGET_REGISTRATION_TIMEOUT_MS / WIDEN_SOCKET_PROOF_DIVISOR,
+);
+
+/** The widen's share of whatever deadline the registration wait actually got (#1192). */
+function widenSocketProofBudget(deadlineMs) {
+  const whole =
+    Number.isFinite(deadlineMs) && deadlineMs > 0
+      ? deadlineMs
+      : CUSTOM_WIDGET_REGISTRATION_TIMEOUT_MS;
+  // A 1ms floor, never 0: `withTimeout` reads a non-positive ms as NO BOUND, so a
+  // fully-spent budget expressed literally would hand the widen an unbounded whole-schema
+  // fetch inside a wait that has already run out.
+  return Math.max(1, Math.floor(whole / WIDEN_SOCKET_PROOF_DIVISOR));
+}
 
 async function awaitRequiredCustomWidgetRegistration(
   nodeData,
@@ -9888,6 +10002,7 @@ async function awaitRequiredCustomWidgetRegistration(
   classType,
   widenSocketProof,
   liveNodeOfClass,
+  budgetMs,
 ) {
   // MONOTONIC, like every other elapsed-time measurement in this panel. On the wall clock
   // an NTP correction, a DST change or a VM resume between these two reads either ends the
@@ -9895,7 +10010,17 @@ async function awaitRequiredCustomWidgetRegistration(
   // extends it far past the command budget. This deadline gates #580's protection, so it
   // is the wrong one to measure on a clock that can move.
   const startedAt = monotonicNow();
-  const deadline = startedAt + CUSTOM_WIDGET_REGISTRATION_TIMEOUT_MS;
+  // #1192 — the SMALLER of #580's own deadline and what the command has left. This wait is
+  // the LAST of graph_add_node's serialized bounds, so it is the one that reaches the relay
+  // window already late; taking its full 5000ms there converts a worded refusal into a bare
+  // `did not reply`. A caller with no budget passes nothing and keeps #580's deadline
+  // exactly. Never non-positive: a zero deadline would make `monotonicNow() < deadline`
+  // false on entry and report widgets unmaterialized without ever having polled.
+  const wait =
+    Number.isFinite(budgetMs) && budgetMs > 0
+      ? Math.max(1, Math.min(CUSTOM_WIDGET_REGISTRATION_TIMEOUT_MS, budgetMs))
+      : CUSTOM_WIDGET_REGISTRATION_TIMEOUT_MS;
+  const deadline = startedAt + wait;
   let socketTypes = knownSocketTypes;
   const check = () =>
     unavailableRequiredWidgetReport(nodeData, comfyApp?.widgets, socketTypes, currentDef);
@@ -9910,7 +10035,9 @@ async function awaitRequiredCustomWidgetRegistration(
   if (unavailable.length && typeof widenSocketProof === "function") {
     let widened = null;
     try {
-      widened = await widenSocketProof();
+      // #1192 — the widen's bound is derived from THIS wait's effective deadline, which
+      // under a command budget is not the standalone constant.
+      widened = await widenSocketProof(widenSocketProofBudget(wait));
     } catch {
       widened = null;
     }
@@ -9953,8 +10080,24 @@ async function awaitRequiredCustomWidgetRegistration(
   // waived by the check rather than waited out — and whatever is left after the wait gets
   // a message that says which input is stuck and which of the two causes it is, instead of
   // asserting the single cause that sent #695's reporter to the wrong place.
+  //
+  // #1192 — and when the COMMAND BUDGET is what ended the wait, say so, because the message
+  // below otherwise sends the caller to the wrong recovery. It says to reload the tab and
+  // that "retrying alone will not fix it" — advice that is right for an extension which
+  // failed to load and exactly wrong for a wait that was cut short by a command already
+  // running late, where a retry gets the full window and very likely succeeds. Same class
+  // of defect as #663 and #852: a refusal naming a remedy that cannot work.
+  const cutShort = wait < CUSTOM_WIDGET_REGISTRATION_TIMEOUT_MS;
   throw new Error(
-    unavailableRequiredWidgetMessage(unavailable, classType, monotonicNow() - startedAt),
+    unavailableRequiredWidgetMessage(unavailable, classType, monotonicNow() - startedAt) +
+      (cutShort
+        ? `\nNOTE: this wait was cut short — it got ${(wait / 1000).toFixed(1)}s of its normal ` +
+          `${(CUSTOM_WIDGET_REGISTRATION_TIMEOUT_MS / 1000).toFixed(1)}s because THIS COMMAND had ` +
+          "already spent most of its time budget on earlier steps (a node-def refresh, or an " +
+          "/object_info fetch, that was slow or still running). So the widget may simply not have " +
+          "been given long enough to appear. RETRY FIRST — a retry starts with a full budget — and " +
+          "only treat the advice above as the diagnosis if it fails again with the full wait."
+        : ""),
   );
 }
 
@@ -11530,6 +11673,13 @@ const GRAPH_TOOL_EXECUTORS = {
     if (!class_type || typeof class_type !== "string") {
       throw new Error("class_type (string) is required");
     }
+    // #1192 — ONE deadline for the whole command, taken before the first step. Every
+    // bounded wait below asks it for a bound instead of naming its own constant, so the
+    // command's cost is this budget rather than the sum of five numbers that each looked
+    // reasonable alone. A step squeezed by it fails fast and truthfully, and the refusals
+    // below say WHICH step ran out — the property the whole issue is about, since the
+    // alternative was a bare "tab did not reply" that names nothing.
+    const budget = makeCommandBudget(ADD_NODE_COMMAND_BUDGET_MS, monotonicNow);
     // Resolve BEFORE creating so an unresolved type can never be added as a
     // fabricated placeholder (#458). The go/no-go is decided against the CURRENT
     // backend /object_info (fetched fresh) — NOT the LiteGraph registry, which
@@ -11546,7 +11696,9 @@ const GRAPH_TOOL_EXECUTORS = {
     // write/add decide "never seen". If it has not landed the history reports PENDING and
     // this ONE call is refused with a retry-in-a-moment message — a late response still
     // seeds, so the next call succeeds without a reload.
-    await awaitObjectInfoHistorySeed();
+    // #1192 — capped by the command budget. Standalone this waits 8000ms, which is a third
+    // of the whole command spent before the backend has even been asked what it provides.
+    await awaitObjectInfoHistorySeed(budget.bounded(OBJECT_INFO_SEED_WAIT_MS));
     // Captured from the SAME fresh /object_info the resolvability assert just
     // fetched. The widget guards below scan THIS def — the backend's current
     // truth — not the possibly-stale registered nodeData: frontend-injected
@@ -11579,7 +11731,17 @@ const GRAPH_TOOL_EXECUTORS = {
     // and the snapshot (already cleared by the reconnect) would stay empty, refusing the very
     // next render-time widget edit. The epoch has to be read where the request goes out.
     let addNodeObservedAtEpoch = null;
-    await assertAddNodeResolvableRefreshing(() => LG?.registered_node_types ?? {}, class_type, {
+    // #1192 — set when this add stopped WAITING for a node-def refresh someone else had
+    // already started, because waiting longer would have spent the command's whole budget.
+    // A FLAG, not a parsed message: `assertAddNodeResolvableRefreshing` swallows a refresh
+    // throw by design (its post-refresh registry re-check is what decides go/no-go), so the
+    // reason never reaches the resolver's own wording, and matching on that wording to
+    // recover it would be exactly the prose-parsing this repo refuses to authorize on.
+    let refreshJoinAbandoned = false;
+    // A thunk rather than a bare `await`, so the call below can sit inside a try/catch
+    // without re-indenting seventy lines of load-bearing comments in this file.
+    const resolveAddNode = () =>
+      assertAddNodeResolvableRefreshing(() => LG?.registered_node_types ?? {}, class_type, {
       getFreshObjectInfo: async () => {
         // #767 — ask about ONE type instead of re-downloading the whole schema.
         // Measured on a 63-pack install: /object_info is 5,413,770 bytes / 167 ms,
@@ -11607,9 +11769,13 @@ const GRAPH_TOOL_EXECUTORS = {
           // response and its body, so the whole call is wrapped rather than the request
           // alone. A timeout resolves null, which is the same answer it already gives for
           // every other doubt and which sends the add to the full fetch — no new branch.
+          // #1192 — …and capped by what the COMMAND has left, because it is not the only
+          // bound on this path. On a timeout it falls through to the whole-schema fetch,
+          // so the two are additive: 10s + 10s of a 30s window on the branch that has not
+          // even reached the refresh yet.
           const one = await withTimeout(
             fetchSingleNodeDef(class_type, (route) => api?.fetchApi?.(route)),
-            NODE_DEFS_FETCH_TIMEOUT_MS,
+            budget.bounded(NODE_DEFS_FETCH_TIMEOUT_MS),
             () => null,
           );
           if (one) {
@@ -11627,20 +11793,69 @@ const GRAPH_TOOL_EXECUTORS = {
         // than parking.
         // #1223 — read the epoch HERE, immediately before the whole request is issued.
         addNodeObservedAtEpoch = backendReconnectEpoch;
-        const whole = await boundedGetNodeDefs();
+        // #1192 — the same request `graph_set_widget`'s oracle allows 10,000 ms, allowed
+        // 10,000 ms here too, and BOTH now capped by their caller's remaining budget. The
+        // two paths agreeing about how long one /object_info may take is what stops a
+        // "set_widget works but add_node fails" asymmetry appearing on a slow install.
+        const whole = await boundedGetNodeDefs(budget.bounded(NODE_DEFS_FETCH_TIMEOUT_MS));
         freshDefs = recordObjectInfoTypes(whole === NODE_DEFS_NO_ANSWER ? null : whole);
         freshDefsAreSingleClass = false;
         currentDef = snapshotBackendDef(freshDefs, class_type);
         return freshDefs;
       },
-      refresh: (defs) => refreshComfyNodeDefs(defs),
+      // #1192 — THE TERM THAT CANNOT BE SHRUNK FROM HERE, bounded at the only thing this
+      // caller owns: its own WAIT.
+      //
+      // `refreshComfyNodeDefs` is the coalescer. With a payload it waits for any in-flight
+      // run and then starts its own, so on the scenario this add is most likely to meet —
+      // a ComfyUI restart, which is exactly when a reconnect-triggered refresh is already
+      // running — it pays a full run (about 9,000 ms of bounded waiting plus unbounded
+      // local work) before its OWN registration begins. That first run started under
+      // someone else's deadline and no number passed from here can shorten it.
+      //
+      // So the wait is capped, and a cap needs a decision for when it fires. Proceeding
+      // would mean adding a node whose class may not be registered — #458's fabricated
+      // placeholder. Blocking is the reported bug. It REFUSES, in words, recoverably: see
+      // `addNodeRefreshBusyMessage`, and `REFRESH_JOIN_ABANDONED` in refresh-coalesce.js
+      // for why the abandoned caller must not start a competing run instead.
+      //
+      // The reserve is held back so the join cannot eat the steps that follow it. Without
+      // it a join finishing at the wire leaves the widget-registration wait milliseconds,
+      // and the add then refuses by naming a widget that was never given time to appear —
+      // a true statement about the wrong cause.
+      refresh: (defs) =>
+        refreshComfyNodeDefs(defs, {
+          joinMs: budget.remaining() - ADD_NODE_POST_REFRESH_RESERVE_MS,
+        }).then((outcome) => {
+          if (outcome === REFRESH_JOIN_ABANDONED) refreshJoinAbandoned = true;
+          return outcome;
+        }),
       // #458 OBSERVED-BACKEND-HISTORY trust root, identical to graph_set_widget's.
       wasTypeEverDefined: (t) => objectInfoHistory.wasTypeEverDefined(t),
       // #775 — consulted ONLY when the type is about to be refused, so a healthy
       // add never pays for it. A pack that failed to import looks exactly like a
       // pack that is not installed, and the refusal used to name only the latter.
       readImportFailures: () => readPackImportFailures(api),
-    });
+      });
+    try {
+      await resolveAddNode();
+    } catch (err) {
+      // #1192 — a resolver failure caused by THIS command running out of budget on someone
+      // else's refresh must name that, not the resolver's generic "the node-def refresh
+      // failed — reload the ComfyUI tab". That advice is wrong here in the expensive
+      // direction: the refresh did not fail, it is still running and about to register the
+      // very class being asked for, so a retry works and a tab reload throws away the
+      // user's canvas state for nothing.
+      //
+      // Two STRUCTURED conditions, never the error's text. The flag says this add stopped
+      // waiting; the live registry says the class still is not there. Both are needed —
+      // the in-flight run may well have registered it while we gave up, and in that case
+      // the resolver returned successfully and this branch is not reached at all.
+      if (refreshJoinAbandoned && !isRegisteredNodeType(LG?.registered_node_types ?? {}, class_type)) {
+        throw new Error(addNodeRefreshBusyMessage(class_type));
+      }
+      throw err;
+    }
     // #1223 — file the WHOLE map this resolver fetched, when it fetched one.
     //
     // AFTER the resolver, not inside it: when a type needs registering the resolver calls
@@ -11726,7 +11941,7 @@ const GRAPH_TOOL_EXECUTORS = {
     // refuse: same idiom as #775's readImportFailures, so a healthy add still pays nothing
     // and #780's 1,667x saving is kept for every add that does not need it.
     const widenSocketProof = freshDefsAreSingleClass
-      ? async () => {
+      ? async (widenMs) => {
           // #1180 — BOUNDED, and the timeout lands on the SAFE side by construction. This
           // helper already answers null for every doubtful payload, and the caller keeps
           // the proof it holds when it gets null; a call that never answers is the most
@@ -11737,7 +11952,13 @@ const GRAPH_TOOL_EXECUTORS = {
           // below rejects it exactly as it rejects every other non-object payload, and
           // returns null — which is what "keep the proof already in hand" means. Mapping
           // it first was a second spelling of the same decision.
-          const whole = await boundedGetNodeDefs(WIDEN_SOCKET_PROOF_TIMEOUT_MS);
+          // #1192 — the bound comes from the wait this runs INSIDE, which under a command
+          // budget is not the standalone 5000ms constant. `widenSocketProofBudget` supplies
+          // the same fraction of whatever that wait actually got, and falls back to
+          // WIDEN_SOCKET_PROOF_TIMEOUT_MS when a caller passes nothing.
+          const whole = await boundedGetNodeDefs(
+            widenMs > 0 ? widenMs : WIDEN_SOCKET_PROOF_TIMEOUT_MS,
+          );
           // "I did not find out" is not "nothing outputs anything", and the difference
           // matters because the caller REPLACES its proof with whatever comes back.
           // registeredSocketTypes maps a null/empty payload to an EMPTY set, which is
@@ -11775,6 +11996,12 @@ const GRAPH_TOOL_EXECUTORS = {
           return null;
         }
       },
+      // #1192 — the LAST of this command's serialized bounds, and therefore the one most
+      // likely to be running with the window already nearly gone. It takes the smaller of
+      // #580's 5000ms and what the command has left, and says in its refusal when the
+      // budget is what ended it — otherwise the message tells the user to reload the tab
+      // for a widget that was simply never given time to appear.
+      budget.bounded(CUSTOM_WIDGET_REGISTRATION_TIMEOUT_MS),
     );
     const node = LG.createNode(class_type);
     if (!node) {

--- a/web/js/lib/command-budget.js
+++ b/web/js/lib/command-budget.js
@@ -1,0 +1,112 @@
+// ONE deadline for a whole panel COMMAND, so the bounded steps inside it COMPOSE.
+//
+// #1192 — `graph_add_node`'s bounds were each defensible alone and did not add up. Run in
+// sequence on one add they summed to ~33s of bounded waiting (the issue's table omits the
+// 8s baseline-seed wait, so the real figure is ~41s) against a 30,000 ms relay window, and
+// the worst case was therefore a bare `did not reply to "graph_add_node" within 30000 ms`
+// — a message that names nothing — instead of the worded, retryable refusals each of those
+// bounds exists to produce.
+//
+// #671 already solved this shape once for `nodes_install`: one deadline taken at the top of
+// the command, every phase drawing from what is left. This is that idea extracted so the
+// next command does not have to reinvent it a third time.
+//
+// NOT A SECOND `withTimeout`. `bounded-step.js`'s header warns that a duplicate timeout
+// helper is how this repo keeps producing near-duplicate bugs, and that warning is right —
+// so this deliberately does not time anything. It computes ALLOWANCES; `withTimeout` still
+// APPLIES every one of them. The two compose: `withTimeout(p, budget.bounded(OWN_MS), …)`.
+//
+// NOR A SECOND `nodeDefsBudgetLeft`. That one is a RUN budget — an allowance for the
+// WAITING inside a single `registerComfyNodeDefs` pass, and its deadline is deliberately
+// pushed out across `registerNodesFromDefs`/`reapplyDefsToLiveNodes` so unbounded local
+// work escapes it rather than spends it. A COMMAND budget must do the opposite:
+//
+//   THE CLOCK NEVER STOPS. The orchestrator measures wall clock from dispatch to reply, so
+//   local work spends the command's window whether or not this panel can interrupt it.
+//   Pausing here would produce a budget that reports time it does not have.
+//
+// What follows from that, said plainly rather than left to be discovered: a command budget
+// can only guarantee that the WAITING this panel controls stops. It cannot stop
+// `registerNodesFromDefs` (3972 ms measured on this rig). What it does instead is charge
+// that work to the command, so every step AFTER it gets correspondingly less and the reply
+// still leaves the tab inside the window — which is the property the relay actually needs.
+
+/** The platform's monotonic clock, used when a caller supplies no readable one. */
+function defaultNow() {
+  return typeof performance !== "undefined" && typeof performance.now === "function"
+    ? performance.now()
+    : Date.now();
+}
+
+/**
+ * Take a deadline `totalMs` from now, and hand out what is left of it.
+ *
+ * @param {number} totalMs the whole command's allowance
+ * @param {() => number} [now] monotonic clock; the panel passes its own `monotonicNow`
+ *
+ * MONOTONIC, like every other elapsed-time measurement in this panel. On the wall clock an
+ * NTP correction or a VM resume mid-command either exhausts the budget instantly — refusing
+ * an add that had done nothing wrong — or extends it far past the relay window, which is
+ * the failure the budget exists to prevent.
+ *
+ * A `now` that is not callable, or that throws when read, is treated as one that was not
+ * supplied: the platform clock is used. A guard that THROWS here would be a guard causing
+ * the outage it reports — `graph_add_node` takes this budget on its first line, so a throw
+ * would refuse every add on a page whose `performance` object is unusual.
+ */
+export function makeCommandBudget(totalMs, now) {
+  let clock;
+  try {
+    clock = typeof now === "function" ? now : defaultNow;
+  } catch {
+    clock = defaultNow;
+  }
+  const read = () => {
+    let t;
+    try {
+      t = clock();
+    } catch {
+      t = defaultNow();
+    }
+    return Number.isFinite(t) ? t : defaultNow();
+  };
+  // A non-finite or non-positive total is a budget that was never really set. Treat it as
+  // zero rather than as infinity: a command with no allowance refuses immediately and
+  // truthfully, where an infinite one silently restores the unbounded path.
+  const total = Number.isFinite(totalMs) && totalMs > 0 ? totalMs : 0;
+  const startedAt = read();
+  const deadline = startedAt + total;
+
+  const remaining = () => deadline - read();
+
+  return {
+    /** The allowance this budget was created with. */
+    totalMs: total,
+    /** How long the command has been running, on the monotonic clock. */
+    spent: () => read() - startedAt,
+    /** What is left. MAY BE NEGATIVE — callers that need to know it ran out ask for that. */
+    remaining,
+    /** Has the command's window closed? */
+    exhausted: () => remaining() <= 0,
+    /**
+     * The bound for a step that would like `ms`, capped by what the command has left.
+     *
+     * NEVER RETURNS A NON-POSITIVE NUMBER, and that is the load-bearing part.
+     * `withTimeout` treats `ms <= 0` as NO BOUND, so an exhausted budget expressed
+     * literally would REMOVE the bound at exactly the moment the command is already too
+     * slow — the hang arriving through the mechanism meant to prevent it. #1188 recorded
+     * that trap; #1180's `nodeDefsBudgetLeft` has the same 1 ms floor for the same reason.
+     * A spent budget yields 1 ms, which times out immediately and truthfully, and the
+     * caller then asks `exhausted()` to word the refusal correctly.
+     *
+     * A `ms` that is not a positive finite number means the caller states no bound of its
+     * own, so it gets the whole remainder. Never `Infinity`, never NaN — both of those
+     * reach `withTimeout` as "no bound".
+     */
+    bounded: (ms) => {
+      const left = remaining();
+      const want = Number.isFinite(ms) && ms > 0 ? ms : left;
+      return Math.max(1, Math.floor(Math.min(want, left)));
+    },
+  };
+}

--- a/web/js/lib/refresh-coalesce.js
+++ b/web/js/lib/refresh-coalesce.js
@@ -22,12 +22,81 @@
 // AFTER the current run settles. Multiple forced calls that arrive during one
 // in-flight run coalesce into a SINGLE trailing run (no /object_info stampede).
 //
+// #1192 — A CALLER MAY BOUND ITS OWN WAIT, and that is the only thing it may bound.
+//
+// Every branch above begins with `await current` — a wait on a run that ALREADY STARTED,
+// under a deadline someone else took. A caller cannot retroactively shorten that run, and
+// nothing here pretends to: `opts.joinMs` bounds the CALLER'S WAIT and never the run. The
+// run keeps going, registers whatever it fetched, and clears the slot exactly as before.
+//
+// This exists because the wait is a real term in a command's budget. `graph_add_node` meets
+// it on the scenario it is most likely to fail on — a ComfyUI restart, which is precisely
+// when a reconnect-triggered refresh is already in flight — and a full run costs ~9s of
+// bounded waiting plus ~4s of deliberately-unbounded local work. Unbounded, that single
+// term can consume most of the add's window before its own registration has begun.
+//
+// WHAT AN ABANDONED JOIN MUST NOT DO is start a run anyway. The whole reason this
+// coordinator exists is that two concurrent `registerNodesFromDefs` passes stampede; a
+// caller that has just given up waiting for one is the last thing that should launch a
+// second. So the payload is DROPPED and `REFRESH_JOIN_ABANDONED` is returned — which reads
+// as a regression of #289 P2 until the caller's half is read with it: `graph_add_node` does
+// not proceed on that value, it REFUSES IN WORDS and says to retry. Dropping a payload
+// while refusing is safe; dropping one while claiming success is the bug #289 was about.
+
+/**
+ * Returned when the caller stopped WAITING for a refresh someone else started.
+ *
+ * A distinct value rather than `undefined`, because `undefined` is already what a
+ * successful plain join resolves to and the two demand opposite handling — one means "the
+ * defs you wanted are registered", the other means "nobody registered anything for you".
+ */
+export const REFRESH_JOIN_ABANDONED = Symbol("refresh-join-abandoned");
+
+/**
+ * Wait for `current` to SETTLE (either way), for at most `joinMs`.
+ *
+ * Resolves true when it settled, false when the wait was abandoned. Reified before
+ * bounding for the reason `boundedGetNodeDefs` reifies: `withTimeout` degrades a rejection
+ * through `onTimeout()` exactly as it does a timeout, so bounding `current` directly would
+ * report an in-flight run that FAILED as one that never answered — and this coordinator has
+ * always treated a failed in-flight run as a settled one (the caller then runs its own).
+ *
+ * `joinMs <= 0` abandons WITHOUT awaiting. It must never reach `withTimeout`, which reads a
+ * non-positive `ms` as NO BOUND — a budget expressed at exactly the moment it ran out would
+ * otherwise restore the unbounded wait.
+ */
+async function joinBounded(current, joinMs, withTimeout) {
+  if (joinMs === null) {
+    try {
+      await current;
+    } catch {
+      /* a failed in-flight run is a settled one */
+    }
+    return true;
+  }
+  if (!(joinMs > 0)) return false;
+  return withTimeout(
+    Promise.resolve(current).then(
+      () => true,
+      () => true,
+    ),
+    joinMs,
+    () => false,
+  );
+}
+
 //   getInFlight / setInFlight : accessors for the shared single-flight promise slot
 //                               (module-level in the panel).
 //   runRegister(preloadedDefs) : performs the actual (idempotent) registration; its
 //                                own cleanup must NOT clear the slot — the coalescer
 //                                owns the slot lifecycle.
-export function makeRefreshCoalescer({ getInFlight, setInFlight, runRegister }) {
+//   withTimeout                : the repo's ONE bounding primitive (bounded-step.js),
+//                                injected rather than imported so this module stays a
+//                                pure coordinator and a test can drive the clock. Omit it
+//                                and `opts.joinMs` has nothing to bound with — so an
+//                                unwired coalescer waits unbounded, exactly as it always
+//                                did, rather than silently abandoning every join.
+export function makeRefreshCoalescer({ getInFlight, setInFlight, runRegister, withTimeout }) {
   // The single queued trailing (forced, no-payload) run, or null when none is
   // pending. Coalesces any number of forced calls arriving during one in-flight run.
   let trailing = null;
@@ -46,29 +115,37 @@ export function makeRefreshCoalescer({ getInFlight, setInFlight, runRegister }) 
   };
   return async function refresh(preloadedDefs, opts) {
     const force = !!(opts && opts.force);
+    // #1192 — a bound only when the caller asked for one AND a primitive was wired. Both
+    // halves matter: `Number.isFinite` rejects the `Infinity`/`NaN` a caller can compute
+    // from an unset budget, and an unwired `withTimeout` must leave today's unbounded wait
+    // rather than abandon every join at once.
+    const joinMs =
+      opts && Number.isFinite(opts.joinMs) && typeof withTimeout === "function"
+        ? opts.joinMs
+        : null;
     const current = getInFlight();
     if (current) {
       // No payload, not forced ⇒ joining the settled refresh is enough.
       if (preloadedDefs == null && !force) {
-        try {
-          await current;
-        } catch {
-          /* the in-flight refresh failed — a plain join still just returns */
-        }
+        if (!(await joinBounded(current, joinMs, withTimeout))) return REFRESH_JOIN_ABANDONED;
         return;
       }
       // Payload present ⇒ wait for the in-flight run, then register the NEWER
       // payload so a freshly-installed node's defs are not dropped (#289 P2).
       if (preloadedDefs != null) {
-        try {
-          await current;
-        } catch {
-          /* fall through and run our own */
-        }
+        // #1192 — and if the wait is abandoned, the payload IS dropped. Starting our own
+        // run here would put a second `registerNodesFromDefs` alongside one still going,
+        // which is the stampede this coordinator exists to prevent. The caller refuses.
+        if (!(await joinBounded(current, joinMs, withTimeout))) return REFRESH_JOIN_ABANDONED;
         return startRun(preloadedDefs);
       }
       // Forced, no payload ⇒ guarantee a fresh fetch AFTER the current run
       // settles; coalesce concurrent forced calls into ONE trailing run (#396).
+      //
+      // #1192 — the trailing run is SHARED, so `joinMs` bounds this caller's wait on it and
+      // nothing else. A second forced caller with a longer budget still gets the same run;
+      // one that gives up does not cancel it, and does not stop it from being queued. That
+      // asymmetry is deliberate: the run is #396's guarantee to whoever else is waiting.
       if (!trailing) {
         trailing = (async () => {
           try {
@@ -80,7 +157,28 @@ export function makeRefreshCoalescer({ getInFlight, setInFlight, runRegister }) 
           return startRun(undefined);
         })();
       }
-      return trailing;
+      const queued = trailing;
+      if (joinMs === null) return queued;
+      // The trailing promise must not go unhandled when this caller stops waiting on it:
+      // #396 guarantees the run to other waiters, and an abandoned wait is not a reason to
+      // turn its failure into an unhandled rejection.
+      queued.catch(() => {});
+      // A budget already spent abandons WITHOUT awaiting — see joinBounded.
+      if (!(joinMs > 0)) return REFRESH_JOIN_ABANDONED;
+      const settled = await withTimeout(
+        queued.then(
+          (value) => ({ value }),
+          (err) => ({ err }),
+        ),
+        joinMs,
+        () => null,
+      );
+      if (settled === null) return REFRESH_JOIN_ABANDONED;
+      // A forced refresh that REJECTS has always rejected for its caller (#608 reads the
+      // verdict it resolves), and a bound on the wait must not quietly turn that into a
+      // success. Only the abandonment is new.
+      if ("err" in settled) throw settled.err;
+      return settled.value;
     }
     return startRun(preloadedDefs);
   };


### PR DESCRIPTION
## Root cause

`graph_add_node`'s bounds were each defensible alone and did not compose. Serialised on one add — the scenario the panel is most likely to meet on a ComfyUI restart, when a reconnect-triggered refresh is already in flight — they summed to ~41,000 ms of bounded waiting (seed wait 8,000 + fast/whole-schema fetch 10,000 + coalescer join ~9,000 + unbounded local + own run ~9,000 + widget registration 5,000) against the 30,000 ms window `panel_add_node` relays this command in. Past that window the reply the bounds exist to produce never leaves the tab, and the user gets a bare `did not reply to "graph_add_node" within 30000 ms`, which names nothing and is not actionable.

## Fix

One deadline for the whole command, so the bounds stop ADDING:

- **`web/js/lib/command-budget.js` (new)** — `makeCommandBudget(totalMs, now)`: one monotonic deadline taken at the top of the command; every step draws its bound from what is left. It computes ALLOWANCES only — `withTimeout` still applies every one, so no second timeout primitive. Never returns a non-positive bound (`withTimeout` reads `ms <= 0` as NO BOUND — the #1188 trap).
- **`web/js/lib/refresh-coalesce.js`** — `opts.joinMs` bounds the caller's WAIT on a run someone else started, never the run (a caller cannot retroactively shorten work already begun). An abandoned join drops the payload and returns `REFRESH_JOIN_ABANDONED` rather than starting a competing run — two concurrent `registerNodesFromDefs` passes are the stampede the coalescer exists to prevent. Dropping a payload while *refusing* is safe; #289 P2 forbids dropping one while claiming success.
- **`web/js/comfyui-mcp-panel.js`** — `graph_add_node` takes one 25,000 ms budget (mirroring `NODES_INSTALL_COMMAND_BUDGET_MS` against the same 30 s relay window: 5 s of reply/serialise/websocket slack). The seed wait, the single-type fast-path fetch, and the whole-schema fetch each take `budget.bounded(theirOwnConstant)`; the whole-schema fetch is allowed the same 10,000 ms `graph_set_widget`'s oracle allows, settling the two paths' disagreement the issue flagged. The widget-registration wait takes the *smaller* of its own 5,000 ms and what the command has left, and the socket-proof widen is derived from the wait's *effective* deadline. An abandoned join refuses in words — "a node-def refresh started by something else was still running… NOTHING WAS ADDED… RETRY in a few seconds" — recovered through a structured flag plus the live registry, never by parsing the resolver's error text. A registration wait cut short by the budget discloses that in its refusal instead of sending the caller to a tab reload.

## Verification

- `npm ci` — clean, 0 vulnerabilities
- `npm run test:unit` — **5059 tests, 5058 pass, 0 fail, 1 todo** (includes i18n, tool-vocabulary, and panel-scope gates). One earlier full-suite run flaked in `manager-install.test.mjs` #671 `verifyInstalled` (real-clock timing, untouched by this change — history of wall-clock fixes in that file, e.g. 72bbe2b5); passes in isolation and on rerun.
- `npm run typecheck` — clean
- New/extended tests: `add-node-command-budget.test.mjs` (drives the shipped `graph_add_node` body extracted from the panel source against the real coalescer), `command-budget.test.mjs`, `refresh-coalesce.test.mjs`, `single-node-def.test.mjs` (source-level pins, incl. the `withTimeout` wiring of the panel's coalescer).
- Mutation harness (15 targeted mutations of the fix): each caught by the suite — several as hangs reported red, per the harness's own hang≠pass rule.

the underlying cause of #1192

