### PR TITLE
fix(1261): a rename is announced as a rename, not a workflow switch

### DIFF
--- a/browser_tests/unit/workflow-route-change.test.mjs
+++ b/browser_tests/unit/workflow-route-change.test.mjs
@@ -1,0 +1,85 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { isSameInstanceRename } from "../../web/js/lib/workflow-route-change.js";
+
+/**
+ * #1261 — a rename must not read as a workflow SWITCH.
+ *
+ * Renaming the active saved workflow moves its route id wf:<old> → wf:<new> on the
+ * SAME live workflow object. The panel's poll used to announce every route-id change
+ * as "the user switched the open workflow", so a rename read as a switch to a
+ * different workflow identity and sent the agent re-reading the canvas it was still
+ * bound to. The discriminator is the object, never the path text.
+ */
+
+test("the reporter's case: same live object, wf:→wf: id change — a rename, not a switch", () => {
+  assert.equal(
+    isSameInstanceRename({
+      sameWorkflowObject: true,
+      previousRouteId: "wf:Untitled 2026-08-15 14-11-07",
+      newRouteId: "wf:Krea2",
+    }),
+    true,
+  );
+});
+
+test("a genuine tab switch arrives on a DIFFERENT object — never a rename", () => {
+  // Two tabs can legitimately show the same file, so the path text cannot decide
+  // this. Only the object comparison can, and here it says: different workflow.
+  assert.equal(
+    isSameInstanceRename({
+      sameWorkflowObject: false,
+      previousRouteId: "wf:old",
+      newRouteId: "wf:new",
+    }),
+    false,
+  );
+});
+
+test("an unproven object comparison fails closed — not a rename", () => {
+  assert.equal(
+    isSameInstanceRename({
+      sameWorkflowObject: undefined,
+      previousRouteId: "wf:old",
+      newRouteId: "wf:new",
+    }),
+    false,
+  );
+  assert.equal(
+    isSameInstanceRename({ previousRouteId: "wf:old", newRouteId: "wf:new" }),
+    false,
+  );
+});
+
+test("a first save (tmp:→wf:) is NOT a rename — the adopt case owns that shape", () => {
+  assert.equal(
+    isSameInstanceRename({
+      sameWorkflowObject: true,
+      previousRouteId: "tmp:6f2c1d4e-9b7a-4c1e-8d3f-2a5b7c9d1e2f",
+      newRouteId: "wf:Krea2",
+    }),
+    false,
+  );
+});
+
+test("an UNSAVED canvas never renames (tmp:→tmp:)", () => {
+  assert.equal(
+    isSameInstanceRename({
+      sameWorkflowObject: true,
+      previousRouteId: "tmp:aaaa",
+      newRouteId: "tmp:bbbb",
+    }),
+    false,
+  );
+});
+
+test("non-string route ids fail closed", () => {
+  for (const [previousRouteId, newRouteId] of [
+    [null, "wf:new"],
+    ["wf:old", null],
+    [undefined, undefined],
+    [42, "wf:new"],
+  ]) {
+    assert.equal(isSameInstanceRename({ sameWorkflowObject: true, previousRouteId, newRouteId }), false);
+  }
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -307,6 +307,7 @@ import {
 } from "./lib/graph-read.js";
 import { slotRenameLines } from "./lib/slot-rename-diff.js";
 import { describeRenameFailure } from "./lib/workflow-rename-error.js";
+import { isSameInstanceRename } from "./lib/workflow-route-change.js";
 import { boundSubgraphList } from "./lib/subgraph-list-bound.js";
 import {
   threadMatchesCurrentWorkflow,
@@ -28670,6 +28671,21 @@ function buildPanel() {
         setActiveThread(currentHistoryScopeKey(), thread.id);
         persistThreads();
       }
+      // #1261 — a RENAME is not a switch. ComfyUI renames a saved workflow by
+      // mutating the SAME object's path in place (the instance identity survives;
+      // only the derived route id moves wf:<old> → wf:<new>), so "same live object,
+      // wf:→wf: id change" can only be a rename — a genuine switch always arrives on
+      // a DIFFERENT object. Announcing it with the switch wording below claimed a
+      // different workflow identity and told the agent to re-read the canvas it is
+      // still bound to (the reported "rename reads as a switch with conflicting
+      // identity"). The discriminator is the object, never the path text — see
+      // lib/workflow-route-change.js.
+      const renaming = isSameInstanceRename({
+        sameWorkflowObject: sameWorkflowObject(wf, currentWorkflowRef),
+        previousRouteId: currentWorkflowId,
+        newRouteId: wfid,
+      });
+      const previousName = renaming ? String(currentWorkflowId).replace(/^wf:/, "").split("/").pop() : null;
       currentWorkflowId = wfid;
       currentWorkflowKey = wfkey;
       currentWorkflowRef = wf;
@@ -28681,9 +28697,13 @@ function buildPanel() {
         }
         const name = wf?.filename || wfkey || wfid;
         client?.armContext?.(
-          `[panel] The user switched the open workflow on the canvas — it is now "${name}". ` +
-            `Your panel_* graph tools operate on THIS graph now; re-read it (panel_graph_outline) before ` +
-            `assuming or editing anything, since earlier turns may refer to a different workflow.`,
+          renaming
+            ? `[panel] The open workflow was RENAMED (a rename or save-as of the SAME instance): ` +
+              `"${previousName}" is now "${name}". Same canvas, same conversation, same node ` +
+              `ids — only its file path changed. Earlier turns still refer to THIS workflow.`
+            : `[panel] The user switched the open workflow on the canvas — it is now "${name}". ` +
+              `Your panel_* graph tools operate on THIS graph now; re-read it (panel_graph_outline) before ` +
+              `assuming or editing anything, since earlier turns may refer to a different workflow.`,
         );
         // The armContext line just above is AGENT-facing and stays English; this one is
         // the transcript note the human reads, so only this one is translated.
@@ -28722,12 +28742,15 @@ function buildPanel() {
     // .key getter change), so "same object, wf:→wf: id change" can only be a rename —
     // a genuine switch always arrives on a different object. Without this branch the
     // thread stays keyed to the OLD path and the renamed workflow opens a blank chat.
+    // #1261 — the discriminator now lives in lib/workflow-route-change.js, shared
+    // with the panel-owned-session branch above.
     const renaming =
       wf &&
-      wf === currentWorkflowRef &&
-      currentWorkflowId &&
-      currentWorkflowId.startsWith("wf:") &&
-      wfid.startsWith("wf:");
+      isSameInstanceRename({
+        sameWorkflowObject: wf === currentWorkflowRef,
+        previousRouteId: currentWorkflowId,
+        newRouteId: wfid,
+      });
     if (renaming) {
       const t = threadForWorkflow(historyKey);
       if (t) persistThreads(); // alias + embedded UUID keep the history identity stable

--- a/web/js/lib/workflow-route-change.js
+++ b/web/js/lib/workflow-route-change.js
@@ -1,0 +1,26 @@
+/**
+ * #1261 — a rename must not read as a workflow SWITCH.
+ *
+ * ComfyUI renames (or Save-As-es) a saved workflow by mutating the SAME workflow
+ * object's path in place: the instance identity survives, and only the derived
+ * route id moves `wf:<old path>` -> `wf:<new path>`. A genuine tab switch always
+ * arrives on a DIFFERENT object. So "same live object, wf: -> wf: id change" can
+ * only be a rename, and callers may keep every instance-anchored continuity claim
+ * (the canvas, the conversation, the agent's remembered node ids) while updating
+ * the route.
+ *
+ * The discriminator is the object, never the path text: two tabs can legitimately
+ * show the same file, and a path comparison cannot tell "this tab's file moved"
+ * from "the user switched to another tab on a different file".
+ *
+ * Pure + side-effect-free so the decision is unit-testable in isolation; callers
+ * supply the object comparison and both route ids.
+ *
+ * @param {{sameWorkflowObject?: boolean, previousRouteId?: unknown, newRouteId?: unknown}} input
+ * @returns {boolean}
+ */
+export function isSameInstanceRename({ sameWorkflowObject, previousRouteId, newRouteId } = {}) {
+  if (sameWorkflowObject !== true) return false;
+  if (typeof previousRouteId !== "string" || !previousRouteId.startsWith("wf:")) return false;
+  return typeof newRouteId === "string" && newRouteId.startsWith("wf:");
+}


### PR DESCRIPTION
## Root cause

Renaming (or save-as-ing) the active saved workflow makes ComfyUI mutate the SAME workflow object's path in place: the instance identity survives, and only the derived route id moves `wf:<old>` → `wf:<new>`. The panel-owned-session branch of `onWorkflowMaybeChanged` (`web/js/comfyui-mcp-panel.js`) announced **every** route-id change with the switch wording — `The user switched the open workflow on the canvas … re-read it (panel_graph_outline) before assuming or editing anything, since earlier turns may refer to a different workflow.` So a rename read as a switch to a *different* workflow identity, contradicting the instance binding (the workflow uuid follows the object across a rename, so `panel_set_workflow_target(mode:"current")` correctly reported `already_current` on the same instance) and making a safe edit look like it targeted the wrong workflow.

The per-workflow-history branch already discriminated this shape (case 2b); the panel-owned branch did not.

## Fix

- New pure discriminator `isSameInstanceRename` in `web/js/lib/workflow-route-change.js`: **same live object + `wf:`→`wf:` route change can only be a rename** — a genuine switch always arrives on a different object. The discriminator is the object (via the proxy-safe `sameWorkflowObject`), never the path text, and it fails closed on anything unproven.
- The panel-owned branch now announces a rename as a rename: `The open workflow was RENAMED … "old" is now "new". Same canvas, same conversation, same node ids — only its file path changed.` The re-hello still happens (the route id genuinely moved); only the claim changes.
- The existing case-2b rename check now uses the same helper, so both branches share one discriminator.

## Verification

- `npm ci` — clean, 0 vulnerabilities.
- `npm run test:unit` (i18n-check + i18n-render-check + check-tool-vocabulary + check-panel-scope + node --test) — **5036 pass, 0 fail**, including 6 new tests in `browser_tests/unit/workflow-route-change.test.mjs` covering: the reporter's rename case, a genuine switch on a different object, unproven comparisons failing closed, first-save (`tmp:`→`wf:`) not being a rename, unsaved `tmp:`→`tmp:`, and non-string ids.
- `npm run typecheck` — clean.

Closes #1261