### PR TITLE
fix(1215): an untagged canvas is no longer captured into the target tab's state on a switch

### DIFF
--- a/browser_tests/unit/open-rebind-proof.test.mjs
+++ b/browser_tests/unit/open-rebind-proof.test.mjs
@@ -782,11 +782,13 @@ test("#702: the fence note is ONLY on the content-unverified outcome", () => {
 //
 // Nothing was fooled. All four parts of resolveOpenRebindVerdict are taken
 // against the root the loader produced, so each was a true statement about a
-// poisoned SOURCE state. #968 closed the writer this repo owns and recorded
-// that an untagged root is still captured; a state already poisoned still
-// reaches the load, and the load is what makes it durable — it stamps the
-// target's identity onto the foreign graph, so a later save writes it to the
-// target's file.
+// poisoned SOURCE state. #968 closed the writer this repo owns, and #1215 then
+// closed the untagged-root residual it had recorded — the capture now runs on
+// an untagged root only when the pointer never moved. A state poisoned BEFORE
+// that gate still reaches the load, and the load is what makes it durable — it
+// stamps the target's identity onto the foreign graph, so a later save writes
+// it to the target's file — which is why the open reply carries the
+// `unproven_source_state` disclosure for exactly that combination.
 // ---------------------------------------------------------------------------
 
 /** A serialized tab state carrying the panel's durable workflow tag. */
@@ -1106,4 +1108,76 @@ test("#1089 follow-up: the foreign-source finding rides a FAILING open too", () 
     /sourceForeign/,
     "describeOpenRebindOutcome must stay ignorant of the source-state question",
   );
+});
+
+// ---------------------------------------------------------------------------
+// #1215 — the untagged-root capture residual #968 recorded is CLOSED.
+//
+// The reporter's sequence: panel_open_workflow on another tab reported
+// opened/main, active_matches_target:true and the target's uuid — and
+// panel_graph_outline then read an unrelated default canvas with zero shared
+// node ids. The open's own checkState() capture had serialized the
+// still-mounted PREVIOUS tab's untagged canvas into the target's tracker, and
+// the repaint faithfully reproduced it; every proof part passed against the
+// poisoned source. "unknown" from describeLiveCanvasBinding no longer admits
+// the capture when the pointer just moved, and an untagged repaint source on a
+// switched tab is disclosed rather than silently served.
+// ---------------------------------------------------------------------------
+
+test("#1215: the pre-switch active workflow is snapshotted BEFORE the pointer moves", () => {
+  const src = readFileSync(PANEL_JS, "utf8");
+  const snapAt = src.indexOf("const activeBefore = activeWorkflowRef();");
+  const switchAt = src.indexOf("await s.openWorkflow(target);");
+  assert.notEqual(snapAt, -1, "the pre-switch pointer must be snapshotted");
+  assert.notEqual(switchAt, -1);
+  assert.ok(snapAt < switchAt, "…before openWorkflow, which is what changes the answer");
+});
+
+test("#1215: an untagged root admits the capture only in the already-current case", () => {
+  const src = readFileSync(PANEL_JS, "utf8");
+  const gateAt = src.indexOf("const captureBinding = describeLiveCanvasBinding(target);");
+  assert.notEqual(gateAt, -1, "the capture must stay gated on the live-canvas binding");
+  const captureAt = src.indexOf("checkState?.()", gateAt);
+  assert.notEqual(captureAt, -1);
+  const gate = src.slice(gateAt, captureAt);
+  assert.match(gate, /pointerMovedThisOpen = !sameWorkflowObject\(activeBefore, target\)/);
+  // "bound" captures outright — the #604/#708 divergence's node-written values
+  // ride on it — and a proven-foreign root still skips. "unknown" no longer
+  // suffices on its own: the pointer must NOT have moved.
+  assert.match(gate, /captureBinding === "bound"/);
+  assert.match(gate, /captureBinding !== "foreign" && !pointerMovedThisOpen/);
+  assert.doesNotMatch(
+    gate,
+    /if \(captureBinding !== "foreign"\)/,
+    '"not foreign" alone was the #1215 hole — it must not come back',
+  );
+});
+
+test("#1215: an untagged repaint source on a tab switch is DISCLOSED, not silently served", () => {
+  const src = readFileSync(PANEL_JS, "utf8");
+  // The finding needs all three: the pointer moved, the tag-based
+  // classification did not fire, and the source state carries no workflow_uuid.
+  const classifyAt = src.indexOf('}) === "foreign"');
+  assert.notEqual(classifyAt, -1, "the tag-based classification must still be there");
+  const at = src.indexOf("sourceUnproven =", classifyAt);
+  assert.notEqual(at, -1, "the untagged-source finding must be computed alongside it");
+  const stmt = src.slice(at, src.indexOf(";", at));
+  assert.match(stmt, /!sourceForeign/, "the foreign finding keeps its own, stronger disclosure");
+  assert.match(stmt, /pointerMovedThisOpen/);
+  assert.match(stmt, /WORKFLOW_UUID_FIELD/, "the untagged question is about the source state's own stamp");
+  // …and it must reach the reply on its own key, like foreign_source_state.
+  const keyAt = src.indexOf("unproven_source_state:");
+  assert.notEqual(keyAt, -1, "the caller must be told the source carried no resolvable identity");
+  assert.match(src.slice(Math.max(0, keyAt - 200), keyAt), /\.\.\.\(sourceUnproven/);
+  const block = src.slice(keyAt, src.indexOf("\n    };", keyAt));
+  assert.match(block, /VERIFY THE GRAPH BEFORE EDITING/);
+  assert.match(block, /panel_graph_outline/, "it must name the read that lets the caller check");
+  // MAY, not IS — an untagged state is the normal case for a workflow the panel
+  // never stamped, so a definite claim would warn on every such open.
+  assert.match(block, /MAY be, not IS/);
+  assert.match(block, /is TRUE\b/, "the other fields are true, not broken");
+  assert.match(block, /panel_load_workflow/);
+  assert.match(block, /REPLACES the canvas/);
+  assert.match(block, /#874/, "the node-written-values trap must be named");
+  assert.match(block, /a plain save/, "…and the save-over-the-target trap");
 });

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -15168,6 +15168,13 @@ const GRAPH_TOOL_EXECUTORS = {
     // edits (or was edited during `openWorkflow`) already reads clean. That erased signal
     // is what would authorize the destructive re-read to discard the user's work.
     const wasDirty = !!target.isModified;
+    // #1215 — WHO was active before this open moves the pointer, snapshotted now:
+    // `s.openWorkflow(target)` below changes the answer. The #874 canvas capture's
+    // own precondition is "the mounted canvas is the target's", and on an UNTAGGED
+    // root — where describeLiveCanvasBinding can only answer "unknown" — whether
+    // the pointer just moved is the only evidence left bearing on that. Consumed
+    // by the capture gate below.
+    const activeBefore = activeWorkflowRef();
     // Bound to a local whose name does NOT end in "s": the #268 frontend-contract scanner
     // captures members off the workflow-service alias `s` with an unanchored `s\.` pattern,
     // so `canvas.<member>` would be misread as a new workflow-SERVICE dependency. This is a
@@ -15194,6 +15201,15 @@ const GRAPH_TOOL_EXECUTORS = {
     // identity, so the repaint below reproduced a graph that is not this workflow's.
     // Drives the disk re-read that corrects it, and is disclosed either way.
     let sourceForeign = false;
+    // #1215 — set at the capture gate: the active pointer was on a DIFFERENT
+    // workflow when this open began (or unreadable). Drives both the gate itself
+    // and the untagged-source disclosure below.
+    let pointerMovedThisOpen = false;
+    // #1215 — the weaker sibling of sourceForeign: the repaint source carried NO
+    // resolvable workflow identity at all, on an open that switched tabs. The
+    // tag-based classification answers "unknown" for it, which warns nobody —
+    // and that is the configuration the wrong-canvas reports arrived in.
+    let sourceUnproven = false;
     let reloaded = false;
     let reloadError = null;
     let openFailed = null;
@@ -15325,33 +15341,46 @@ const GRAPH_TOOL_EXECUTORS = {
           // concurrency — which is what the reports without a reconnect storm were telling
           // us all along.
           //
-          // The guard is the #708 oracle, already used for exactly this hazard on the SAVE
-          // path: a positive, durable identity conflict refuses the capture. "unknown"
-          // still captures, so older frontends and first observation behave as before —
-          // this only ever REMOVES a capture we can prove is reading someone else's canvas.
-          // When the target IS already the painted tab (the `wasOpen`/already-current case
-          // #874 was written for) the binding is "bound" and the capture runs unchanged.
-          // The question is ONLY "is the mounted canvas this target's graph?", and it must
-          // be answered with POSITIVE proof, because BOTH answers can destroy data:
-          // capturing a foreign canvas writes another workflow's graph into this one
-          // (#968), and skipping a legitimate capture lets the repaint below overwrite live
-          // canvas work with a stale snapshot (#874). There is no safe default, so this
-          // never guesses from "did the pointer move" — that says nothing about who owns
-          // the canvas, and an earlier draft of this fix got both directions wrong with it
-          // (codex).
+          // The guard has two tiers, because "unknown" turned out to be two different
+          // questions (#1215).
           //
-          //   "bound"   — the root graph carries THIS workflow's identity tag. Proof. This
-          //               is the already-current case #874 was written for, and it captures
-          //               exactly as it always did.
+          // Tier one is the #708 oracle, already used for exactly this hazard on the SAVE
+          // path, and its POSITIVE answers decide outright:
+          //
+          //   "bound"   — the root graph carries THIS workflow's identity tag. Proof.
+          //               Capture whether or not the pointer moved: the mounted canvas is
+          //               the target's, so the capture can only preserve its node-written
+          //               values (#874) — including the #604/#708 divergence, where the
+          //               target's canvas was already mounted under another tab's pointer.
           //   "foreign" — the root positively belongs to another workflow. Skip.
-          //   "unknown" — cannot tell. CAPTURES, exactly as it does today.
           //
-          // "unknown" deliberately changes NOTHING, which is the same discipline #708
-          // already applies with this oracle: only a POSITIVE, durable identity conflict
-          // refuses, so older frontends and a first observation behave as they always have.
-          // This fix therefore closes the provable case and introduces no regression
-          // anywhere else — it can only ever REMOVE a capture proven to be reading another
-          // workflow's canvas.
+          // Tier two fires only when the tag is silent ("unknown": an untagged root, an
+          // older frontend, a first observation). There, "did the pointer move during
+          // this open?" DOES bear on the capture's own precondition — "the mounted canvas
+          // is the target's" — because on a switch `openWorkflow` moved the pointer and
+          // repainted NOTHING (that is why this function repaints at all), so the mounted
+          // canvas is the PREVIOUS tab's, and an untagged capture can only serialize that
+          // tab's graph into the target's state. That is the poisoning #968/#1089/#1215
+          // reported: the repaint below then faithfully reproduced it, and every proof
+          // part passed against the poisoned source. When the pointer did NOT move — the
+          // already-current case #874 was written for — the mounted canvas is the
+          // target's own and the capture runs exactly as it always has.
+          //
+          //   "unknown" + pointer moved   — SKIP. The capture's precondition is unmet.
+          //   "unknown" + already current — capture, as before.
+          //
+          // The codex note this replaces said the guard "never guesses from 'did the
+          // pointer move'", and an earlier draft did get both directions wrong with it —
+          // by letting pointer movement decide a REFUSAL, where it proves nothing about
+          // who owns the canvas. That objection stands in that direction, and nothing
+          // here refuses on it. Here the snapshot gates only the capture, a WRITE whose
+          // correctness already depends on the canvas being the target's, and whose
+          // absence is the safe direction on a switch: the cost of a skipped legitimate
+          // capture is confined to the #604/#708 divergence (node-written values that
+          // only ever existed on the mounted canvas are reverted by the repaint below),
+          // while the cost of a wrong one is another tab's whole graph imported into
+          // this workflow's state under this workflow's identity. BOTH answers can still
+          // destroy data, so the tier-one positives keep deciding outright.
           //
           // I tried to do better and the attempt was unsound, so it is recorded here rather
           // than repeated: falling back to node-id OVERLAP against the target's own state
@@ -15362,13 +15391,17 @@ const GRAPH_TOOL_EXECUTORS = {
           // reading (DISJOINT is suspicious) and its own header warns that a refusal built
           // on it would be a wrong-graph refusal of its own (codex).
           //
-          // KNOWN RESIDUAL, stated rather than hidden: an UNTAGGED root graph is still
-          // captured, so the contamination remains reachable on a canvas the panel has
-          // never stamped. Closing that needs ownership evidence that does not exist yet —
-          // not a guess dressed as one — and the reported cases are saved, panel-driven
-          // workflows whose roots carry the tag, which is the case this does close.
+          // WHAT REMAINS OPEN, stated rather than hidden: a target state poisoned BEFORE
+          // this gate existed stays poisoned — it is untagged, so
+          // describeRepaintSourceBinding below can only answer "unknown" for it, which is
+          // why the reply discloses that combination (unproven_source_state) instead of
+          // reporting a bland success.
           const captureBinding = describeLiveCanvasBinding(target);
-          if (captureBinding !== "foreign") {
+          pointerMovedThisOpen = !sameWorkflowObject(activeBefore, target);
+          if (
+            captureBinding === "bound" ||
+            (captureBinding !== "foreign" && !pointerMovedThisOpen)
+          ) {
             try {
               // AWAITED (codex). A frontend whose tracker captures asynchronously would
               // otherwise have `activeState` read before the capture landed — the silent
@@ -15443,6 +15476,19 @@ const GRAPH_TOOL_EXECUTORS = {
                   return Array.isArray(openNow) && openNow.some((w) => sameWorkflowObject(w, owner));
                 },
               }) === "foreign";
+            // #1215 — the UNTAGGED arm the tag-based classification cannot reach.
+            // `describeRepaintSourceBinding` answers "unknown" for a source carrying
+            // no resolvable identity, and "unknown" warns nobody — yet an untagged
+            // source on a tab-switching open is exactly the configuration the
+            // wrong-canvas reports arrived in (a state poisoned before the capture
+            // gate above existed reads identically to the target's own untagged
+            // state; the panel cannot separate them, and says so rather than
+            // guessing). Disclosure only, like its foreign sibling — refusing here
+            // strands the pointer the same way (see the #1089 note above).
+            sourceUnproven =
+              !sourceForeign &&
+              pointerMovedThisOpen &&
+              typeof st?.extra?.[WORKFLOW_META_NAMESPACE]?.[WORKFLOW_UUID_FIELD] !== "string";
             // A graph shape is not ownership proof: two dirty tabs can have the same
             // nodes, and the normal read guard intentionally stays inconclusive for a
             // dirty, un-stamped root. Stamp THIS target's live-object identity into the
@@ -16057,6 +16103,36 @@ const GRAPH_TOOL_EXECUTORS = {
                 "Could not verify whether the on-disk file still matches this tab (disk read unavailable or slower than its deadline). Treat the canvas as possibly stale; call panel_load_workflow to be sure you have the on-disk version.",
             }
           : {}),
+      // #1215 — the weaker sibling of foreign_source_state. The repaint source
+      // carried NO resolvable identity (untagged), and this open switched tabs, so
+      // the panel cannot show the canvas it just painted was built from this
+      // workflow's own state — and before the capture gate above existed, an
+      // untagged capture on a switch serialized the PREVIOUS tab's canvas into
+      // this tab's state, which then repainted faithfully with every proof part
+      // passing. The two read identically now, so this discloses instead of
+      // claiming. Its own key, like the foreign one: a caller can hit it with
+      // neither `stale` nor `canvas_file_divergence` firing.
+      ...(sourceUnproven
+        ? {
+            unproven_source_state:
+              "VERIFY THE GRAPH BEFORE EDITING. This open switched tabs, and the in-memory " +
+              "state the canvas was repainted from carried NO workflow identity the panel " +
+              "could check — untagged states read the same whether they are this workflow's " +
+              "own or a previous tab's graph left behind by an older capture path, and the " +
+              "panel observed no evidence separating the two. Everything else on this reply " +
+              "(path, filename, workflow_uuid, modified) is TRUE of the tab and says nothing " +
+              "about which graph the state held, which is why none of it warned. Read the " +
+              "graph (panel_graph_outline / panel_query_graph) and compare it against what " +
+              "you expect this workflow to contain. MAY be, not IS: an untagged state is the " +
+              "normal case for a workflow the panel has never stamped, so this fires on good " +
+              "opens too, and only your comparison separates them. If it IS the wrong graph, " +
+              "panel_load_workflow with this workflow's path loads the saved copy from disk. " +
+              "Weigh that: it REPLACES the canvas, and the tab's modified flag does not " +
+              "account for values a NODE wrote rather than you (#874) — so preserve anything " +
+              "you need to a NEW path first: a plain save would write the canvas over the " +
+              "workflow you asked for, because the active identity already names that one.",
+          }
+        : {}),
     };
   },
 


### PR DESCRIPTION
## Root cause

`workflow_open`'s repaint poisons the target tab's in-memory state and then faithfully reproduces it. After `s.openWorkflow(target)` moves the active pointer to tab B but before anything repaints, the executor calls `target.changeTracker.checkState()` — ComfyUI's capture, which serializes the STILL-MOUNTED root (tab A's canvas) into the now-active tracker, i.e. into B's `activeState`. The repaint then loads that same state, so all four rebind proof parts are true statements about a poisoned source, and the open returns PROVEN, publishing B's `workflow_uuid` while A's graph sits on the canvas under B's stamp. Every later graph read honestly answers from the wrong graph — the silent wrong-canvas success in #1215's reports (reproduced as late as mcp 0.51.57 / panel 0.14.44, where `panel_graph_outline` returned an unrelated default canvas after a proven open).

The #968 guard already refused the capture on a POSITIVE identity conflict (`describeLiveCanvasBinding` → `foreign`), but recorded its own residual: an UNTAGGED root answers `unknown`, and `unknown` captured. After a restart with `Comfy.Workflow.Persist=false` — exactly the reported configuration — nothing has stamped the roots yet, so every root is untagged and the poisoning path was wide open. #968/#1089/#1111 are the tagged ancestors of this same defect; this closes the untagged residual they left.

## Fix

Panel-side only, in `web/js/comfyui-mcp-panel.js`:

1. **Snapshot the pre-switch active workflow** (`activeBefore = activeWorkflowRef()`) before `openWorkflow` moves the pointer.
2. **Tighten the capture gate.** `bound` still captures outright (that is the #874 already-current case and the #604/#708 divergence, where node-written values only exist on the mounted canvas), `foreign` still skips. `unknown` now captures only when the pointer did NOT move — on a switch, `openWorkflow` moved the pointer and repainted nothing, so the mounted canvas is the previous tab's and an untagged capture can only import the other tab's graph. The codex note that previously blocked this ("never guesses from 'did the pointer move'") is REWRITTEN in place rather than silently inverted: that objection holds for refusals, where pointer movement proves nothing; here the snapshot gates a WRITE whose own precondition is "the mounted canvas is the target's".
3. **Disclose what remains.** A state poisoned before this gate existed is untagged, so `describeRepaintSourceBinding` can only answer `unknown` for it and the existing `foreign_source_state` disclosure never fires. A new, deliberately weaker `unproven_source_state` key is emitted when the open switched tabs and the repaint source carried no resolvable identity — it says VERIFY THE GRAPH BEFORE EDITING, names `panel_graph_outline`/`panel_load_workflow`, and is explicit that an untagged state is the NORMAL case for a workflow the panel never stamped, so it fires on good opens too ("MAY be, not IS").

No refusal is added anywhere: the #1089 analysis stands — refusing after the pointer moved strands the session with every `graph_*` command fenced, including the `panel_load_workflow` the refusal would recommend.

Accepted cost, recorded in the comment: in the #604/#708 divergence (target's canvas mounted while the pointer sat on another tab) a skipped capture forfeits preserving node-written values that only ever existed on that mounted canvas; the repaint reverts them. The alternative is the silent wrong-graph serve this fixes.

## Verification

- `npm ci` — clean, 0 vulnerabilities.
- `npm run test:unit` — **5034 tests, 5033 pass, 0 fail, 1 todo (pre-existing)**.
- `npm run typecheck` (`tsc --noEmit`) — clean.
- New tests in `browser_tests/unit/open-rebind-proof.test.mjs` pin: the pre-switch snapshot precedes `openWorkflow`; the gate requires `bound` or a non-moved pointer (and `if (captureBinding !== "foreign")` alone must not come back); `sourceUnproven` requires pointer-moved + no foreign finding + no `workflow_uuid` on the source; the `unproven_source_state` reply carries the verify/read/recover wording with the MAY-not-IS hedge.

Not verified: a live-browser reproduction of the original sequence (no ComfyUI instance driven here). The fix follows the mechanism the in-repo triage (`docs/triage/2026-08-14-open-issues.md`, #1215 section) established from the captured receipts, and the behavior change is pinned by the unit tests above.

Closes #1215