### PR TITLE
fix(1233): a proven read keeps its stale-tag bypass through the executor's own fence re-assert

### DIFF
--- a/browser_tests/unit/read-only-graph-commands.test.mjs
+++ b/browser_tests/unit/read-only-graph-commands.test.mjs
@@ -107,9 +107,10 @@ test("the two other unlisted reads are deliberately still refused", () => {
 // reporter's refusal came from, and it is a whole-file search, so it is exact.
 //
 // NOT TESTED, verified by reading: `graph_get_errors`'s executor writes nothing —
-// it calls `assertGraphBoundToActiveWorkflow(graph, rootGraph)` with no options
-// (so it already took the read-shaped defaults; only the DISPATCH bar was wrong)
-// and otherwise only reads `graph._nodes` and builds a report.
+// it re-asserts the fence on this command's own read bar plus the baseline guard
+// (`graphCommandBindingBar("graph_get_errors")` with `includeBaselineReadGuard`,
+// since #1233 — bare defaults had silently dropped the #995 stale-tag bypass) and
+// otherwise only reads `graph._nodes` and builds a report.
 //
 // A source-scanning version of that check was written and REMOVED. Bounding a
 // method body by counting braces needs real tokenization: masking comments first

--- a/browser_tests/unit/stale-tag-read-executor.test.mjs
+++ b/browser_tests/unit/stale-tag-read-executor.test.mjs
@@ -1,0 +1,260 @@
+/**
+ * #1233 — after a tab switch onto an UNSAVED (never-saved, modified) workflow tab,
+ * panel_graph_outline was refused `[root-workflow-uuid-mismatch]` even though the
+ * #995 dispatch-fence bypass had already PROVEN the canvas: content-equal to the
+ * active tab's own tracker state, exclusive among open tabs, nothing written.
+ *
+ * The fence runs TWICE for those reads. Bridge dispatch asserts with
+ * `graphCommandBindingBar(msg.cmd)` — the read bar, which carries the #995
+ * stale-tag bypass — and the graph_outline / graph_get_errors executors then
+ * RE-assert for the #389 baseline guard. The executors passed NO options, and the
+ * bypass defaults OFF, so the re-assert recomputed the same mismatch and refused
+ * the canvas the dispatch fence had just admitted. Every other read executor
+ * relies on the dispatch fence alone, which is why the surviving symptom named
+ * graph_outline. Re-opening the workflow re-stamps the root tag, which is why
+ * panel_open_workflow "fixed" it.
+ *
+ * Proven here against the SHIPPING fence, extracted from the monolith and driven
+ * with doubles (the graph-binding.test.mjs idiom): the dispatch bar passes the
+ * reported state, bare executor defaults refuse it, and the read bar the
+ * executors now re-assert with passes it — while a foreign canvas, a twin, and
+ * every mutation still refuse.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+import {
+  activeWorkflowProvenEmpty,
+  contentProofExclusiveAmongOpen,
+  graphBindingRefusalMessage,
+  graphCommandBindingBar,
+  graphRootMatchesState,
+  graphRootProvenEmpty,
+  graphRootWorkflowUuidMismatches,
+  resolveGraphBindingVerdict,
+  resolveGraphRootUuidRebind,
+  rootContentProvesActiveWorkflow,
+  rootContentProvesActiveWorkflowDespiteEdits,
+  sealProvenRootBinding,
+} from "../../web/js/lib/graph-binding.js";
+import {
+  rawWorkflowObject,
+  sameWorkflowObject,
+} from "../../web/js/lib/workflow-chat-identity.js";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const PANEL_JS = join(HERE, "../../web/js/comfyui-mcp-panel.js");
+
+/** Index of `function <name>(`, INCLUDING a preceding `async ` when present —
+ *  without it an extracted async function loses its keyword and its `await`
+ *  becomes a syntax error inside `new Function`. (Same helper as
+ *  graph-binding.test.mjs.) */
+function panelFunctionStart(src, name, from = 0) {
+  const bare = src.indexOf(`function ${name}(`, from);
+  assert.notEqual(bare, -1, `could not locate ${name} in panel source`);
+  const asyncAt = bare - "async ".length;
+  return asyncAt >= 0 && src.startsWith("async ", asyncAt) ? asyncAt : bare;
+}
+
+function panelFunctionSource(src, name, nextName) {
+  const start = panelFunctionStart(src, name);
+  const end = panelFunctionStart(src, nextName, start + 1);
+  assert.ok(end > start, `could not locate ${nextName} after ${name}`);
+  return src.slice(start, end);
+}
+
+const ACTIVE_UUID = "1233active-0000-4000-8000-00000000000a";
+const PREV_UUID = "1233prevtab-0000-4000-8000-00000000000b";
+
+const state = (n, tweak = {}) => ({
+  nodes: Array.from({ length: n }, (_, i) => ({ id: i + 1, type: "KSampler", pos: [0, 0], size: [200, 100] })),
+  links: [],
+  groups: [],
+  config: {},
+  extra: {},
+  ...tweak,
+});
+
+/** A live root holding the ACTIVE tab's graph, still wearing the PREVIOUS tab's
+ *  identity tag — ComfyUI reuses one app.graph across tabs and clear/configure
+ *  does not reset graph.extra (the #817 mechanism). */
+const rootOf = (s, tag = PREV_UUID) => ({
+  _nodes: s.nodes,
+  extra: { comfyui_mcp: { workflow_uuid: tag } },
+  serialize: () => ({ ...s, extra: { ...(s.extra ?? {}), comfyui_mcp: { workflow_uuid: tag } } }),
+});
+
+/** The #1233 active tab: never saved, carrying unsaved edits. */
+const unsavedTab = (s, { modified = true } = {}) => ({
+  isPersisted: false,
+  isModified: modified,
+  changeTracker: { activeState: s },
+});
+
+/**
+ * The shipping fence, extracted and wired exactly as graph-binding.test.mjs wires
+ * it: the real lib predicates, the real `workflowOwnsRootUuidTag` (with an empty
+ * owner registry — NOBODY claims the previous tab's tag, the reported state), and
+ * an identity resolver that answers the active tab's own uuid. `openWorkflows`
+ * parameterizes the exclusivity enumeration.
+ */
+function buildFence({ openWorkflows }) {
+  const src = readFileSync(PANEL_JS, "utf8").replace(/\r\n/g, "\n");
+  const fenceSource = panelFunctionSource(src, "assertGraphBoundToActiveWorkflow", "getPiniaStore");
+  const ownsTagSource = panelFunctionSource(src, "workflowOwnsRootUuidTag", "assertGraphBoundToActiveWorkflow");
+  const activeWorkflow = openWorkflows[0];
+  const ownsTag = new Function(
+    "workflowStableUuid",
+    "rawWorkflowObject",
+    "sameWorkflowObject",
+    "workflowUuidOwner",
+    "WORKFLOW_META_NAMESPACE",
+    "WORKFLOW_UUID_FIELD",
+    `${ownsTagSource}\nreturn workflowOwnsRootUuidTag;`,
+  )(
+    () => ACTIVE_UUID,
+    rawWorkflowObject,
+    sameWorkflowObject,
+    () => null, // no registered owner for the previous tab's tag
+    "comfyui_mcp",
+    "workflow_uuid",
+  );
+  return new Function(
+    "activeWorkflowRef",
+    "workflowObjectUuid",
+    "workflowStableUuid",
+    "graphRootWorkflowUuidMismatches",
+    "resolveGraphBindingVerdict",
+    "graphBindingRefusalMessage",
+    "activeWorkflowProvenEmpty",
+    "graphRootProvenEmpty",
+    "workflowOwnsRootUuidTag",
+    "rememberWorkflowUuidOwner",
+    "resolveGraphRootUuidRebind",
+    "postReconnectSettleWindow",
+    "sealProvenRootBinding",
+    "rootContentProvesActiveWorkflow",
+    "rootContentProvesActiveWorkflowDespiteEdits",
+    "contentProofExclusiveAmongOpen",
+    "graphRootMatchesState",
+    "sameWorkflowObject",
+    "app",
+    "WORKFLOW_META_NAMESPACE",
+    "WORKFLOW_UUID_FIELD",
+    `${fenceSource}\nreturn assertGraphBoundToActiveWorkflow;`,
+  )(
+    () => activeWorkflow,
+    (wf) => (wf === activeWorkflow ? ACTIVE_UUID : null),
+    () => ACTIVE_UUID,
+    graphRootWorkflowUuidMismatches,
+    resolveGraphBindingVerdict,
+    graphBindingRefusalMessage,
+    activeWorkflowProvenEmpty,
+    graphRootProvenEmpty,
+    ownsTag,
+    () => {},
+    resolveGraphRootUuidRebind,
+    () => false, // outside any post-reconnect settle window
+    sealProvenRootBinding,
+    rootContentProvesActiveWorkflow,
+    rootContentProvesActiveWorkflowDespiteEdits,
+    contentProofExclusiveAmongOpen,
+    graphRootMatchesState,
+    sameWorkflowObject,
+    { graph: null, extensionManager: { workflow: { openWorkflows } } },
+    "comfyui_mcp",
+    "workflow_uuid",
+  );
+}
+
+/** What the graph_outline / graph_get_errors executors must re-assert with after
+ *  the fix: this command's OWN read bar (the #995 bypass included) plus the
+ *  executor-only #389 baseline guard. */
+const READ_EXECUTOR_BAR = (cmd) => ({ ...graphCommandBindingBar(cmd), includeBaselineReadGuard: true });
+
+// ── the reported case, driven through the shipping fence ─────────────────────
+
+test("#1233 the dispatch fence ADMITS the reported read — the #995 bypass proves the canvas", () => {
+  const s = state(3);
+  const fence = buildFence({ openWorkflows: [unsavedTab(s)] });
+  const root = rootOf(s);
+  assert.doesNotThrow(() => fence(root, root, graphCommandBindingBar("graph_outline")));
+});
+
+test("#1233 bare executor defaults REVOKE that admission — the residual this fix removes", () => {
+  // What the executors passed before the fix: no options. The bypass defaults
+  // OFF, the re-assert recomputes the same mismatch, and the canvas the dispatch
+  // fence had just proven is refused as root-workflow-uuid-mismatch. This is the
+  // exact error text of the report, and it is why panel_open_workflow (which
+  // re-stamps the root) was the only way out.
+  const s = state(3);
+  const fence = buildFence({ openWorkflows: [unsavedTab(s)] });
+  const root = rootOf(s);
+  assert.throws(() => fence(root, root), /\[root-workflow-uuid-mismatch\]/);
+});
+
+test("#1233 the executor's re-assert on the command's OWN read bar passes the same canvas", () => {
+  const s = state(3);
+  const fence = buildFence({ openWorkflows: [unsavedTab(s)] });
+  const root = rootOf(s);
+  assert.doesNotThrow(() => fence(root, root, READ_EXECUTOR_BAR("graph_outline")), "graph_outline");
+  assert.doesNotThrow(() => fence(root, root, READ_EXECUTOR_BAR("graph_get_errors")), "graph_get_errors");
+  assert.equal(
+    root.extra.comfyui_mcp.workflow_uuid,
+    PREV_UUID,
+    "and nothing was written — the bypass clears the flag for the call, the tag is left alone",
+  );
+});
+
+// ── what must still refuse through that same bar ─────────────────────────────
+
+test("#1233 a FOREIGN canvas still refuses — the bypass needs content equality", () => {
+  const fence = buildFence({ openWorkflows: [unsavedTab(state(3))] });
+  const foreign = rootOf(state(5));
+  assert.throws(
+    () => fence(foreign, foreign, READ_EXECUTOR_BAR("graph_outline")),
+    /\[root-workflow-uuid-mismatch\]/,
+  );
+});
+
+test("#1233 a dirty TWIN still refuses — exclusivity is not skippable once edits are allowed (#995)", () => {
+  const s = state(3);
+  const active = unsavedTab(s);
+  const dirtyTwin = unsavedTab(s, { modified: true });
+  const fence = buildFence({ openWorkflows: [active, dirtyTwin] });
+  const root = rootOf(s);
+  assert.throws(() => fence(root, root, READ_EXECUTOR_BAR("graph_outline")), /\[root-workflow-uuid-mismatch\]/);
+});
+
+test("#1233 a MUTATION still refuses the same canvas — the bypass is read-only by classification", () => {
+  const s = state(3);
+  const fence = buildFence({ openWorkflows: [unsavedTab(s)] });
+  const root = rootOf(s);
+  assert.throws(() => fence(root, root, graphCommandBindingBar("graph_add_node")));
+});
+
+// ── the shipping executors really re-assert with their own read bar ──────────
+
+test("#1233 source guard: both re-asserting read executors pass their OWN classified bar", () => {
+  const src = readFileSync(PANEL_JS, "utf8").replace(/\r\n/g, "\n");
+  for (const cmd of ["graph_outline", "graph_get_errors"]) {
+    const methodStart = src.indexOf(`${cmd}(`);
+    assert.notEqual(methodStart, -1, `${cmd} executor not found`);
+    const fenceCall = src.indexOf("assertGraphBoundToActiveWorkflow(graph, rootGraph", methodStart);
+    assert.notEqual(fenceCall, -1, `${cmd} executor no longer re-asserts the fence`);
+    const callSlice = src.slice(fenceCall, fenceCall + 300);
+    assert.match(
+      callSlice,
+      new RegExp(`graphCommandBindingBar\\("${cmd}"\\)`),
+      `${cmd} must re-assert with its OWN classified bar — bare defaults silently drop the #995 stale-tag bypass`,
+    );
+    assert.match(
+      callSlice,
+      /includeBaselineReadGuard: true/,
+      `${cmd} must keep the executor-only #389 baseline read guard on`,
+    );
+  }
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -10277,7 +10277,17 @@ const GRAPH_TOOL_EXECUTORS = {
     const { graph, rootGraph } = getGraphCtx();
     // panel#389: refuse a false-clean empty read when the live graph is desynced
     // from the active workflow (empty canvas graph while the workflow reports nodes).
-    assertGraphBoundToActiveWorkflow(graph, rootGraph);
+    // panel#1233: re-assert on this command's OWN read bar, not bare defaults. The
+    // defaults drop the #995 stale-tag bypass the dispatch fence admitted this read
+    // through, so a canvas that bypass had just PROVEN (content-equal to the active
+    // tab, exclusive, nothing written) was refused again HERE — the
+    // root-workflow-uuid-mismatch a tab switch onto an unsaved/modified tab kept
+    // surfacing. The bypass stays opt-in via the one classification site; the
+    // executor-only baseline guard (#389) is kept on.
+    assertGraphBoundToActiveWorkflow(graph, rootGraph, {
+      ...graphCommandBindingBar("graph_outline"),
+      includeBaselineReadGuard: true,
+    });
     // #429: geometric group membership is tested boundingRect-first, so resync every
     // node's cached rect to its live pos/size BEFORE computing membership — a node
     // moved by a path the panel didn't own (paste/load/manual drag) otherwise reports
@@ -14278,7 +14288,13 @@ const GRAPH_TOOL_EXECUTORS = {
     // from the active workflow (empty canvas graph while the workflow reports nodes)
     // — otherwise get_errors reports "no errors" for a workflow whose red nodes the
     // agent then wrongly tells the user to ignore.
-    assertGraphBoundToActiveWorkflow(graph, rootGraph);
+    // panel#1233: same re-assert fix as graph_outline — this read's OWN bar carries
+    // the #995 stale-tag bypass the dispatch fence granted; bare defaults revoked it
+    // and re-refused a proven canvas on a tab switch onto an unsaved/modified tab.
+    assertGraphBoundToActiveWorkflow(graph, rootGraph, {
+      ...graphCommandBindingBar("graph_get_errors"),
+      includeBaselineReadGuard: true,
+    });
     const nodes = graph._nodes ?? [];
     const byId = new Map(nodes.map((n) => [String(n.id), n]));
     const reasons = new Map();


### PR DESCRIPTION
## Root cause

The binding fence runs **twice** for `graph_outline` and `graph_get_errors`:

1. Bridge dispatch asserts with `graphCommandBindingBar(msg.cmd)` — the read bar, which carries the **#995 stale-tag bypass** (a read on a canvas proven content-equal to the active tab, exclusive among open tabs, proceeds without touching the tag).
2. The executor then **re-asserts** for the #389 baseline read guard — but passed **no options**, and the bypass defaults OFF.

So the re-assert recomputed the same `root-workflow-uuid-mismatch` and refused the canvas the dispatch fence had just proven. That is the reported recurrence: a tab switch onto an **unsaved/modified** tab leaves the previous tab's identity tag on the reused `app.graph` (the #817 mechanism — clear/configure does not reset `graph.extra`); the #995 bypass admitted the read at dispatch; the executor's bare re-assert revoked it. Every other read executor relies on the dispatch fence alone, which is why the surviving symptom named `panel_graph_outline`, and why `panel_open_workflow` (which re-stamps the root) was the only recovery.

This is the residual the 2026-08-14 triage doc predicted for #1233: not the #817 clean-tab rebind, not the #995 dispatch bypass, not the #1209/#1279 orchestrator fence refresh — all shipped — but the gap between them.

## Fix

Both re-asserts now pass the command's **own classified read bar** plus the executor-only `includeBaselineReadGuard: true`:

- `web/js/comfyui-mcp-panel.js` — `graph_outline` and `graph_get_errors` executors call the fence with `{ ...graphCommandBindingBar(<cmd>), includeBaselineReadGuard: true }`.
- The bypass stays opt-in via the one classification site (`graphCommandBindingBar`); nothing new can acquire it by omission.

## What still refuses (pinned by tests)

- a foreign canvas (content differs from the active tab's own state)
- a dirty or identical **twin** tab (exclusivity unprovable)
- every **mutation** on the same evidence (the bypass is read-only by classification)

## Verification

- New `browser_tests/unit/stale-tag-read-executor.test.mjs` drives the **shipping fence** (extracted from the monolith, the graph-binding.test.mjs idiom) through the reported state: dispatch bar admits it, bare executor defaults refuse it with the report's exact error, the fixed executor bar passes it and writes nothing — and the refuse-cases above still refuse. 7/7 pass.
- `npm run test:unit`: 5036 pass / 1 fail — the failure is `#671 verifyInstalled ... fast-draining install` in manager-install.test.mjs, a timing-sensitive flake that **also fails on pristine origin/main** (verified by stashing this change: 5029 pass / same 1 fail) and passes in isolation (125/125).
- `npm run typecheck` (`tsc --noEmit`): clean.

Not verified: a live ComfyUI rig (none available in this environment) — the fix is proven at the extracted-shipping-code level only.

Closes #1233