### PR TITLE
fix(1193): a slow-but-healthy fetch no longer starves the combo refresh of its budget

### DIFF
--- a/browser_tests/unit/_panel-constants.mjs
+++ b/browser_tests/unit/_panel-constants.mjs
@@ -61,6 +61,11 @@ export const NODE_DEFS_FETCH_SHARE = (() => {
   return Number(m[1]) / Number(m[2]);
 })();
 
+export const NODE_DEFS_COMBO_FLOOR_MS = readPanelNumber(
+  /const NODE_DEFS_COMBO_FLOOR_MS = (\d+);/,
+  "the combo phase's guaranteed floor",
+);
+
 /**
  * The panel's sentinel for "this call did not answer", mirrored so a rebuilt executor
  * compares against the same value its injected `boundedGetNodeDefs` resolves.

--- a/browser_tests/unit/node-def-refresh.test.mjs
+++ b/browser_tests/unit/node-def-refresh.test.mjs
@@ -22,6 +22,7 @@ import { withTimeout } from "../../web/js/lib/bounded-step.js";
 import {
   COMBO_NO_ANSWER,
   COMBO_OK,
+  NODE_DEFS_COMBO_FLOOR_MS,
   NODE_DEFS_FETCH_SHARE,
   NODE_DEFS_FETCH_TIMEOUT_MS,
   NODE_DEFS_NO_ANSWER,
@@ -389,6 +390,7 @@ function buildRegisterComfyNodeDefs({
   appValue,
   apiValue,
   timers,
+  now,
   recordObjectInfoTypes = () => ({}),
   reapplyDefsToLiveNodes = () => {},
 }) {
@@ -410,6 +412,7 @@ function buildRegisterComfyNodeDefs({
     "NODE_DEFS_FETCH_TIMEOUT_MS",
     "NODE_DEFS_RUN_BUDGET_MS",
     "NODE_DEFS_FETCH_SHARE",
+    "NODE_DEFS_COMBO_FLOOR_MS",
     "nodeDefsBudgetLeft",
     "monotonicNow",
     "NODE_DEFS_RETRY_DELAYS_MS",
@@ -456,8 +459,13 @@ function buildRegisterComfyNodeDefs({
     NODE_DEFS_FETCH_TIMEOUT_MS,
     NODE_DEFS_RUN_BUDGET_MS,
     NODE_DEFS_FETCH_SHARE,
-    nodeDefsBudgetLeft,
-    monotonicNow,
+    NODE_DEFS_COMBO_FLOOR_MS,
+    // #1193 — ONE clock for the deadline and the arithmetic that reads it. The shared
+    // helper reads the REAL monotonicNow; a fake-clock deadline measured against it is a
+    // different bound than the one the panel arms (its own nodeDefsBudgetLeft shares the
+    // panel's clock). Without the override the shared helper is passed through unchanged.
+    now ? (deadline, share = 1) => Math.max(1, Math.floor((deadline - now()) * share)) : nodeDefsBudgetLeft,
+    now ?? monotonicNow,
     NODE_DEFS_RETRY_DELAYS_MS,
     // #716 — the shipping function drops the widget-write burst cache after a successful
     // fetch. A spy, so the harness can prove that happens rather than merely tolerate it.
@@ -872,6 +880,15 @@ function virtualTimers() {
         t.fn();
       }
     },
+    // Advance the clock to `limitMs`: fire every armed timer whose delay is within it,
+    // so a test can let a 4846ms step COMPLETE without firing a 6000ms bound.
+    fireUpTo(limitMs) {
+      for (const [id, t] of [...pending]) {
+        if (t.ms > limitMs) continue;
+        pending.delete(id);
+        t.fn();
+      }
+    },
   };
 }
 
@@ -915,7 +932,11 @@ test("#1180 the combo phase arms a bound, using the panel's constant", async () 
   // phase ran first and its cost comes out of the same total. So the assertion is a band,
   // and both edges matter — 0 or less arms nothing at all (withTimeout's non-positive
   // contract, which silently restores the hang), and anything above the run budget means
-  // the phase is spending time the run has not got.
+  // the phase is spending time the run has not got. #1193's FLOOR sits under that
+  // remainder but does not bind here: this fetch answered instantly, so the remainder is
+  // the whole budget, which is larger than the floor. The floor cases — armed exactly
+  // when the remainder runs out, still bounding, and not shrinking a healthy remainder —
+  // are the #1193 tests below.
   assert.ok(
     armed[0].ms > 0 && armed[0].ms <= NODE_DEFS_RUN_BUDGET_MS,
     `the combo bound must be the run's REMAINING budget, saw ${armed[0].ms}ms against a ${NODE_DEFS_RUN_BUDGET_MS}ms run`,
@@ -949,6 +970,110 @@ test("#1180 a combo refresh that never answers is NOT reported as a refresh", as
     false,
     "a combo refresh that never answered must not license trusting the combo lists to suppress missing assets",
   );
+});
+
+test("#1193: a slow-but-healthy fetch leaves the combo phase its FLOOR, and the healthy combo completes", async () => {
+  // The issue's failing row, run against the SHIPPED executor with a clock the test
+  // controls: the fetch takes 5500ms of its 6000ms share and SUCCEEDS, leaving a pure
+  // remainder of 3500ms for a combo phase whose measured cost is 4846ms — abandoned
+  // before the floor, reporting combo_refresh_failed over a refresh that would have
+  // completed (and leaving the next panel_set_widget refusing the value the refresh
+  // was for).
+  //
+  // Both waits are VIRTUAL: the deadline arithmetic runs on the injected clock, the
+  // combo's own 4846ms on the injected timers. fireUpTo(4846) lets the combo finish
+  // only when the armed bound is LARGER than that — pre-floor it was 3500ms and fired
+  // first, so this test fails on the pre-fix code for the right reason.
+  let now = 0;
+  const timers = virtualTimers();
+  const { registerComfyNodeDefs, getConfirmed } = buildRegisterComfyNodeDefs({
+    appValue: {
+      graph: null,
+      registerNodesFromDefs: async () => {},
+      refreshComboInNodes: () => new Promise((resolve) => { timers.setTimer(resolve, 4846); }),
+    },
+    apiValue: {
+      getNodeDefs: async () => {
+        now += 5500;
+        return { SomeNode: {} };
+      },
+    },
+    timers,
+    now: () => now,
+  });
+  const running = registerComfyNodeDefs(undefined);
+  await drainMicrotasks();
+  timers.fireUpTo(4846);
+  const verdict = await orFail(running, "the combo phase never settled");
+
+  assert.deepEqual(verdict, { refreshed: true, reason: "refreshed" });
+  assert.equal(getConfirmed(), true, "the combo ACTUALLY completed inside its floor, so the trust gate may open");
+});
+
+test("#1193: the floor is ARMED exactly when the remainder runs out — and it still BOUNDS", async () => {
+  // The other half of the floor: it must not become "no bound". Same starved remainder
+  // as above, but the combo never answers — the bound that fires must be the floor
+  // itself, and the run must still give up and say so.
+  let now = 0;
+  const timers = virtualTimers();
+  const { registerComfyNodeDefs, getConfirmed } = buildRegisterComfyNodeDefs({
+    appValue: {
+      graph: null,
+      registerNodesFromDefs: async () => {},
+      refreshComboInNodes: () => new Promise(() => {}), // never settles
+    },
+    apiValue: {
+      getNodeDefs: async () => {
+        now += 5500;
+        return { SomeNode: {} };
+      },
+    },
+    timers,
+    now: () => now,
+  });
+  const running = registerComfyNodeDefs(undefined);
+  await drainMicrotasks();
+  const armed = timers.armed();
+  assert.equal(armed.length, 1, "the fetch's bound is cleared by its answer; only the combo's remains");
+  assert.equal(
+    armed[0].ms,
+    NODE_DEFS_COMBO_FLOOR_MS,
+    `the fetch spent 5500ms of a ${NODE_DEFS_RUN_BUDGET_MS}ms run; the combo phase gets the floor, not the 3500ms remainder`,
+  );
+  timers.fireAll();
+  const verdict = await orFail(running, "the floor removed the bound entirely — registerComfyNodeDefs is still awaiting refreshComboInNodes");
+
+  assert.equal(verdict.refreshed, false);
+  assert.equal(verdict.reason, "combo_refresh_failed");
+  assert.equal(getConfirmed(), false, "a combo that never answered must not be trusted, floor or not");
+});
+
+test("#1193: the floor is a FLOOR, not a new allowance — a fast fetch leaves the whole remainder in charge", async () => {
+  // If the remainder ever SHRANK to the floor the fix would have traded one starvation
+  // for another: a healthy run's combo phase gets the whole remaining budget here and
+  // must keep it.
+  const timers = virtualTimers();
+  const { registerComfyNodeDefs } = buildRegisterComfyNodeDefs({
+    appValue: {
+      graph: null,
+      registerNodesFromDefs: async () => {},
+      refreshComboInNodes: () => new Promise(() => {}), // never settles
+    },
+    apiValue: { getNodeDefs: async () => ({ SomeNode: {} }) },
+    timers,
+    now: () => 0, // no time passes: the remainder is the whole budget
+  });
+  const running = registerComfyNodeDefs(undefined);
+  await drainMicrotasks();
+  const armed = timers.armed();
+  assert.equal(armed.length, 1);
+  assert.equal(
+    armed[0].ms,
+    NODE_DEFS_RUN_BUDGET_MS,
+    "the remainder exceeds the floor, so the bound must stay the remainder",
+  );
+  timers.fireAll();
+  await orFail(running, "the combo phase never gave up");
 });
 
 test("#1180: a REAL error survives a later stall — the synthesized timeout must not speak for it", async () => {

--- a/browser_tests/unit/refresh-graph-guard.test.mjs
+++ b/browser_tests/unit/refresh-graph-guard.test.mjs
@@ -41,6 +41,7 @@ import { withTimeout } from "../../web/js/lib/bounded-step.js";
 import {
   COMBO_NO_ANSWER,
   COMBO_OK,
+  NODE_DEFS_COMBO_FLOOR_MS,
   NODE_DEFS_FETCH_SHARE,
   NODE_DEFS_FETCH_TIMEOUT_MS,
   NODE_DEFS_NO_ANSWER,
@@ -233,6 +234,7 @@ function buildRegisterComfyNodeDefs({ appValue, apiValue }) {
     "NODE_DEFS_FETCH_TIMEOUT_MS",
     "NODE_DEFS_RUN_BUDGET_MS",
     "NODE_DEFS_FETCH_SHARE",
+    "NODE_DEFS_COMBO_FLOOR_MS",
     "nodeDefsBudgetLeft",
     "monotonicNow",
     "NODE_DEFS_RETRY_DELAYS_MS",
@@ -276,6 +278,7 @@ function buildRegisterComfyNodeDefs({ appValue, apiValue }) {
     NODE_DEFS_FETCH_TIMEOUT_MS,
     NODE_DEFS_RUN_BUDGET_MS,
     NODE_DEFS_FETCH_SHARE,
+    NODE_DEFS_COMBO_FLOOR_MS,
     nodeDefsBudgetLeft,
     monotonicNow,
     NODE_DEFS_RETRY_DELAYS_MS,

--- a/browser_tests/unit/single-node-def.test.mjs
+++ b/browser_tests/unit/single-node-def.test.mjs
@@ -315,8 +315,8 @@ test("#1180: a whole refresh RUN, not each phase, is what fits the budget", () =
   );
   assert.match(
     src,
-    /nodeDefsBudgetLeft\(runDeadline\),\s*\(\) => COMBO_NO_ANSWER/,
-    "the combo phase must draw from what the fetch phase left, not from a constant",
+    /Math\.max\(nodeDefsBudgetLeft\(runDeadline\), NODE_DEFS_COMBO_FLOOR_MS\),\s*\(\) => COMBO_NO_ANSWER/,
+    "the combo phase must draw from what the fetch phase left — with #1193's floor under it — not from a private allowance",
   );
   // A monotonic clock, like every other elapsed measurement in this panel: a wall-clock
   // jump mid-run must not hand a phase a negative or enormous remainder.
@@ -348,6 +348,21 @@ test("#1180: a whole refresh RUN, not each phase, is what fits the budget", () =
   assert.ok(
     comboLeft >= 1000,
     `the combo phase is left ${Math.round(comboLeft)}ms of a ${run}ms run — too little to answer in`,
+  );
+
+  // #1193 — the FLOOR under that remainder. A fetch may spend its whole share and still
+  // succeed, leaving `comboLeft` for a phase measured at 4846ms; a pure remainder
+  // abandoned that healthy call. The floor must RAISE the worst-case remainder or it is
+  // decorative, and it must not exceed the run budget or it is a second budget, not a
+  // floor.
+  const floor = num(/const NODE_DEFS_COMBO_FLOOR_MS = (\d+);/, "the combo phase floor");
+  assert.ok(
+    floor > comboLeft,
+    `the floor (${floor}ms) must beat the remainder a full-share fetch leaves (${Math.round(comboLeft)}ms) — closing that gap is the #1193 fix`,
+  );
+  assert.ok(
+    floor <= run,
+    `the floor (${floor}ms) is a floor under one phase of a ${run}ms run, not a budget of its own`,
   );
 
   // #954's SCHEDULE, SHARED not forked — read from the retry module, never restated.
@@ -420,6 +435,7 @@ test("#1180: graph_add_node's bounds are SEQUENTIAL, and their sum is tracked (#
   };
   const single = num(/const NODE_DEFS_FETCH_TIMEOUT_MS = (\d+);/, "the single-call fetch bound");
   const run = num(/const NODE_DEFS_RUN_BUDGET_MS = (\d+);/, "the refresh run budget");
+  const floor = num(/const NODE_DEFS_COMBO_FLOOR_MS = (\d+);/, "the combo phase floor");
   const registration = num(/const CUSTOM_WIDGET_REGISTRATION_TIMEOUT_MS = (\d+);/, "the registration deadline");
 
   // Two paths, and the branch that skips the fast path is the expensive one.
@@ -428,10 +444,15 @@ test("#1180: graph_add_node's bounds are SEQUENTIAL, and their sum is tracked (#
   // the whole-schema fetch — they compose rather than exclude each other, because a
   // timeout is doubt and doubt takes the full fetch. No refresh: the type is registered.
   const registeredPath = single + single + registration;
+  // A run's worst-case WAITING is its budget plus the combo floor: #1193 lets a run
+  // exceed NODE_DEFS_RUN_BUDGET_MS by up to the floor when a slow-but-successful fetch
+  // spent the combo's remainder. That is the accepted cost of the floor, and it is
+  // counted here so this sum stays honest rather than reassuring.
+  const runWait = run + floor;
   // NOT REGISTERED: no fast path (it is gated on already-registered), then the whole-schema
   // fetch, then the resolver hands the payload to refreshComfyNodeDefs — which waits for
   // any in-flight run and then performs its own, so the run budget is paid twice.
-  const unregisteredPath = single + run + run + registration;
+  const unregisteredPath = single + runWait + runWait + registration;
   const worstCase = Math.max(registeredPath, unregisteredPath);
 
   // The widen is INSIDE the registration wait, not added to it — that is what its divisor
@@ -445,11 +466,14 @@ test("#1180: graph_add_node's bounds are SEQUENTIAL, and their sum is tracked (#
   );
   assert.ok(widen < registration, "the widen is spent inside the registration wait, not alongside it");
 
-  // The known ceiling while #1192 is open. Not a target — a ratchet.
-  const TRACKED_CEILING_MS = 33000;
+  // The known ceiling while #1192 is open. Not a target — a ratchet. Raised from
+  // 33000 to 45000 by #1193's combo floor: two serialized runs can now cost
+  // 2 x (budget + floor) in the case the floor exists for, and the issue records that
+  // trade explicitly.
+  const TRACKED_CEILING_MS = 45000;
   assert.ok(
     worstCase <= TRACKED_CEILING_MS,
-    `one add's serialized bounds now sum to ${worstCase}ms, above the ${TRACKED_CEILING_MS}ms recorded in #1192 — ` +
+    `one add's serialized bounds now sum to ${worstCase}ms, above the ${TRACKED_CEILING_MS}ms tracked while #1192 is open — ` +
       "raising a bound on this path makes an already-over-budget command worse",
   );
   // …and the fact that it is over budget is stated, so nobody reads the pass above as fine.

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -861,7 +861,10 @@ const NODE_DEFS_FETCH_TIMEOUT_MS = 10000;
  * A run therefore carries a DEADLINE, and each bounded phase gets what is left of it
  * rather than a private allowance. Two serialized runs then cost 2 x this, and that is the
  * number sized against the read default — 18,000ms against 20,000ms — because that product
- * is what the user actually waits through.
+ * is what the user actually waits through. ONE exception, added for #1193: the combo phase
+ * has a FLOOR under its remainder (NODE_DEFS_COMBO_FLOOR_MS), so a run whose fetch spent
+ * the combo's share can exceed this budget by up to that floor. The floor pays out only
+ * when the fetch was slow but healthy — the case a pure remainder got wrong.
  *
  * WHAT THE DEADLINE DOES NOT COVER, said plainly so this is not read as a total. Two calls
  * run INSIDE the window without drawing from it: `registerNodesFromDefs` and
@@ -897,10 +900,18 @@ const NODE_DEFS_FETCH_TIMEOUT_MS = 10000;
  * COMPLETELY HEALTHY machine, reporting `combo_refresh_failed` on every refresh. That was
  * measured, not reasoned about — the unit suite passed either way.
  *
- * Second, the margin that remains is thinner than this number suggests. The fetch may use
- * its full 6000 ms share and still succeed, which would leave the combo phase 3000 ms
- * against a measured 4846 ms need. That case is #1193; it needs the combo phase to have a
- * floor rather than only a remainder, and that is a design change rather than a constant.
+ * Second, the margin that remains is thinner than this number suggests — and that case,
+ * #1193, is now handled rather than merely recorded. The fetch may use its full 6000 ms
+ * share and still succeed, which leaves a pure remainder of 3000 ms against the measured
+ * 4846 ms need and abandoned a HEALTHY combo phase: `combo_refresh_failed` on a refresh
+ * that would have completed, `nodeDefsRefreshConfirmed` stuck false (which is what reopens
+ * #610's false "model still missing"), and the loader combo the refresh was FOR still
+ * refusing the new value on the next panel_set_widget. The combo phase therefore has a
+ * FLOOR — see NODE_DEFS_COMBO_FLOOR_MS — and a run may exceed this budget by up to that
+ * floor. The alternative #1193 weighed, not waiting for the combo phase at all, was
+ * rejected: it fixes only the verdict's wording while leaving every symptom in place for
+ * the seconds the refresh actually takes — the combos are still stale when the reply
+ * lands, and the write that prompted the refresh is still refused.
  */
 const NODE_DEFS_RUN_BUDGET_MS = 9000;
 /**
@@ -911,6 +922,28 @@ const NODE_DEFS_RUN_BUDGET_MS = 9000;
  * A share, not a second constant, so the two cannot be changed into disagreement.
  */
 const NODE_DEFS_FETCH_SHARE = 2 / 3;
+
+/**
+ * #1193 — a FLOOR under the combo phase's allowance, not a share of the run.
+ *
+ * The combo phase draws what the fetch left of the run deadline, and the fetch may spend
+ * its whole share and still succeed — leaving 3000 ms for a phase measured at 4846 ms
+ * (the table above). A pure remainder abandons a HEALTHY `refreshComboInNodes()` in
+ * exactly the conditions this budget was written for — a congested or remote backend —
+ * reporting `combo_refresh_failed` over a refresh that would have completed, while the
+ * abandoned call keeps running and mutates the graph AFTER the verdict declared it stale.
+ *
+ * SIZED FROM THE MEASUREMENT, not picked: 4846 ms on a 4320-type install, so 6000 ms is
+ * the measured cost plus a quarter.
+ *
+ * THE COST, stated rather than left to be discovered in review: a run can now exceed
+ * NODE_DEFS_RUN_BUDGET_MS by up to this floor. One run's worst-case bounded waiting was
+ * 9000 ms and becomes 15,000 ms; two serialized runs — a forced refresh behind an
+ * in-flight one — were 18,000 ms against the bridge's 20s read default and become
+ * 30,000 ms, over it, in exactly the case the floor exists for. #1192 already tracks that
+ * path's arithmetic; its ratchet test in browser_tests carries the new number.
+ */
+const NODE_DEFS_COMBO_FLOOR_MS = 6000;
 //
 // #954's SCHEDULE, UNFORKED. An earlier pass here cut it to a single 200ms delay, reasoning
 // that a bound which does not cancel lets three abandoned attempts download the whole
@@ -1419,7 +1452,13 @@ async function registerComfyNodeDefs(preloadedDefs) {
         Promise.resolve()
           .then(() => a.refreshComboInNodes())
           .then(() => COMBO_OK, (err) => ({ err })),
-        nodeDefsBudgetLeft(runDeadline),
+        // #1193 — the fetch's remainder, with a FLOOR under it. A fetch that spent its
+        // whole share and still succeeded leaves 3000ms for a phase measured at 4846ms,
+        // and a pure remainder abandoned that HEALTHY call: combo_refresh_failed over a
+        // refresh that would have completed, with the abandoned call mutating the graph
+        // anyway after the verdict declared it stale. The run may exceed its budget by
+        // up to the floor; that trade is recorded at NODE_DEFS_COMBO_FLOOR_MS.
+        Math.max(nodeDefsBudgetLeft(runDeadline), NODE_DEFS_COMBO_FLOOR_MS),
         () => COMBO_NO_ANSWER,
       );
       comboRan = comboSettled === COMBO_OK;
@@ -1436,7 +1475,7 @@ async function registerComfyNodeDefs(preloadedDefs) {
         // catch. The `?? ` that used to guard this assignment could never fire.
         thrown =
           comboSettled === COMBO_NO_ANSWER
-            ? new Error("refreshComboInNodes() did not answer within this refresh's remaining budget")
+            ? new Error("refreshComboInNodes() did not answer within this refresh's remaining budget or its floor")
             : comboSettled.err;
         // WARN HERE, because reifying the outcome took this failure off the throwing path
         // and the catch below is the only place that logged one. The browser console was
@@ -1595,8 +1634,9 @@ async function registerComfyNodeDefs(preloadedDefs) {
     // path. Disclosure, not failure.
     //
     // Read from `defs`, which is already in hand, and NOT by re-reading widgets after
-    // `app.refreshComboInNodes()` resolves: #1193 wants to stop waiting on that call, and a
-    // disclosure that depended on it would report nothing if it were ever abandoned.
+    // `app.refreshComboInNodes()` resolves: the combo phase is bounded and can still be
+    // abandoned past its floor (#1193), and a disclosure that depended on it would report
+    // nothing in that case.
     const empties = emptyComboListsOnGraph(getGraphCtx().rootGraph, defs);
     if (empties.length) {
       verdict.empty_combo_lists = empties;


### PR DESCRIPTION
Closes #1193

## Root cause

`registerComfyNodeDefs` runs under one 9000ms deadline (`NODE_DEFS_RUN_BUDGET_MS`, #1180). The fetch phase may consume its full 2/3 share (6000ms) and still succeed — leaving the combo phase a 3000ms remainder against a measured 4846ms cost (`refreshComboInNodes` re-fetches `/object_info` and rewrites every combo widget in the graph). In exactly the congested/remote-backend case the budget was written for, a **healthy** combo refresh was abandoned: `panel_refresh_nodes` reported `combo_refresh_failed` over a refresh that would have completed, `nodeDefsRefreshConfirmed` stayed false (reopening #610's false "model still missing"), and the loader combo stayed stale so the next `panel_set_widget` rejected the newly installed value — the reported repro.

## Fix

The issue's option (1): a **floor** under the combo phase's remainder — `NODE_DEFS_COMBO_FLOOR_MS = 6000` (the measured 4846ms plus a quarter), applied as `Math.max(nodeDefsBudgetLeft(runDeadline), NODE_DEFS_COMBO_FLOOR_MS)` at the combo bound. A fast fetch is untouched (its remainder exceeds the floor); a slow-but-successful fetch no longer starves the combo phase.

Option (3) — stop waiting for the combo refresh — was rejected and the reason is recorded at the constant: it fixes only the verdict's wording while leaving every symptom in place (combos still stale when the reply lands, the follow-up widget write still refused).

**Stated cost:** a run can now exceed its budget by up to the floor — worst-case bounded waiting 15,000ms per run, 30,000ms for two serialized runs against the 20s bridge read default, only in the case the floor exists for. The #1192 ratchet test carries the new number (33000 → 45000), so the sum is tracked rather than silently grown.

## What changed

- `web/js/comfyui-mcp-panel.js` — the floor constant (with the measurement and the cost stated), the combo bound, the timeout message ("…remaining budget or its floor"), and the budget comments updated to match.
- `browser_tests/unit/node-def-refresh.test.mjs` — three new tests driving the **shipped** executor on an injected clock and virtual timers: the issue's failing row now completes `refreshed: true`; the floor arms at exactly 6000ms when the remainder runs out and still bounds a never-answering combo; a fast fetch keeps the whole remainder (the floor never shrinks it). The harness's `nodeDefsBudgetLeft` now shares the injected clock when one is given — it previously read the real clock, which mismeasured a fake-clock deadline.
- `browser_tests/unit/_panel-constants.mjs`, `refresh-graph-guard.test.mjs` — the new constant read from source / threaded into the rebuilt executor.
- `browser_tests/unit/single-node-def.test.mjs` — the combo-call structural pin updated to the floor shape; floor arithmetic pinned (must beat the worst-case remainder, must not exceed the run budget); the #1192 ratchet counts the floor.

## Verification

- `npm ci` — clean.
- `npm run typecheck` — exit 0.
- `npm run test:unit` (i18n-check + i18n-render-check + check-tool-vocabulary + check-panel-scope + `node --test browser_tests/unit/*.test.mjs`) — **exit 0, 5033 pass / 0 fail.**
- Mutation check: with the `Math.max(…, NODE_DEFS_COMBO_FLOOR_MS)` reverted to a bare remainder (constant kept), the two key #1193 tests fail and pass again with the fix — they detect the pre-fix behavior, not just the text.
- Note: `#671 verifyInstalled … fast-draining install` (a real-wall-clock, 3s-budget test) flaked twice on this loaded machine during full-suite runs — including once on **clean origin/main with these changes stashed** — and passes in isolation both ways. Pre-existing environmental flake, unrelated to this change.
