### PR TITLE
fix(654): a ComfyUI restart the bridge SURVIVES re-advertises the tab route

### DIFF
--- a/browser_tests/bridge-reregisters-after-restart.spec.ts
+++ b/browser_tests/bridge-reregisters-after-restart.spec.ts
@@ -164,8 +164,6 @@ test('a ComfyUI restart under a LIVE bridge re-advertises the tab route', async 
   })
   const socketsAtStart = mockBridge.connectionsOpened
 
-  /** ComfyUI's backend socket goes away for `downMs` and comes back. The BRIDGE
-   *  is deliberately untouched — that is the whole point of this shape. */
   const fireComfyApiEvent = async (name: string) => {
     // The SAME resolution the panel itself uses to find the api singleton
     // (`window.comfyAPI?.api?.api || window.api`). Reaching for `app.api`
@@ -183,6 +181,8 @@ test('a ComfyUI restart under a LIVE bridge re-advertises the tab route', async 
     expect(delivered, `ComfyUI's api singleton must accept the ${name} event`).toBe(true)
   }
 
+  /** ComfyUI's backend socket goes away for `downMs` and comes back. The BRIDGE
+   *  is deliberately untouched — that is the whole point of this shape. */
   const bounceComfyBackend = async (downMs: number) => {
     await fireComfyApiEvent('reconnecting')
     await page.waitForTimeout(downMs)

--- a/browser_tests/bridge-reregisters-after-restart.spec.ts
+++ b/browser_tests/bridge-reregisters-after-restart.spec.ts
@@ -31,6 +31,7 @@
  */
 import { test, expect, deleteSavedWorkflow } from './fixtures/panelTest'
 import { MockBridge } from './fixtures/MockBridge'
+import { routeWorktreeSource } from './fixtures/worktreeSource'
 
 test.setTimeout(180_000)
 
@@ -107,4 +108,127 @@ test('the tab re-registers after the bridge dies and respawns', async ({
   } finally {
     await cleanup()
   }
+})
+
+/**
+ * #654, the shape the spec above cannot reach: THE BRIDGE SURVIVES THE RESTART.
+ *
+ * The spec above reproduces a bridge that dies with ComfyUI and comes back on the
+ * same port. That was the deployment when it was written; it no longer is. The
+ * pack is pure-frontend and can no longer spawn the orchestrator
+ * (`externalOrchestratorMode()` is hardcoded true), so the orchestrator now runs
+ * out-of-band and ALWAYS survives a ComfyUI restart. The bridge socket therefore
+ * never closes, no socket `open` handler fires, and `connectAgent()` early-returns
+ * on an already-OPEN socket — so nothing sent the `hello` that is the only thing
+ * which re-registers this tab's route.
+ *
+ * What that produces is the report verbatim: the restart confirms its down/up
+ * cycle, the orchestrator's post-restart watch waits for a strictly NEWER hello
+ * generation that never arrives, and every graph tool answers `Connected: none`
+ * until the browser tab is reloaded by hand.
+ *
+ * The restart is driven through ComfyUI's OWN api events, which is exactly what
+ * the panel sees during a real one — the frontend socket goes away
+ * (`reconnecting`) and comes back (`reconnected`) while the page stays loaded.
+ * Killing the real ComfyUI would prove the same thing and take the whole suite's
+ * backend with it.
+ *
+ * The CONTROL half is the load-bearing one. ComfyUI fires `reconnected` for
+ * benign blips too — viewing an asset, checking an image, a tab refocus — and a
+ * hello is a full re-greeting that bumps the agent-session epoch and draws a
+ * fresh ready ack. A fix that re-advertised on those would be #1138's
+ * false-nudge-into-a-live-session harm wearing this issue's clothes, so the short
+ * bounce asserts SILENCE before the long one asserts recovery.
+ */
+test('a ComfyUI restart under a LIVE bridge re-advertises the tab route', async ({
+  page,
+  panel,
+  mockBridge
+}) => {
+  // Serve THIS checkout's web/js tree. Not optional and not a nicety: the dev
+  // ComfyUI loads the pack from a git-linked checkout on another branch, and
+  // without this the spec measures that branch. Verified by running it exactly
+  // once without the route — the panel produced no re-advertise at all, which is
+  // this issue reproducing in the browser rather than the test passing.
+  await routeWorktreeSource(page.context())
+
+  await panel.goto()
+  await panel.setBridgeUrl(mockBridge.url)
+  await panel.openSidebar()
+  await panel.connect()
+  await expect(panel.statusPill).toHaveText(/connected/i, { timeout: 20_000 })
+
+  const hellos: Record<string, unknown>[] = []
+  mockBridge.onFrame((f) => {
+    if (f.type === 'hello') hellos.push(f)
+  })
+  const socketsAtStart = mockBridge.connectionsOpened
+
+  /** ComfyUI's backend socket goes away for `downMs` and comes back. The BRIDGE
+   *  is deliberately untouched — that is the whole point of this shape. */
+  const fireComfyApiEvent = async (name: string) => {
+    // The SAME resolution the panel itself uses to find the api singleton
+    // (`window.comfyAPI?.api?.api || window.api`). Reaching for `app.api`
+    // instead finds an object the panel never listened on, and the control half
+    // of this test would then pass for the wrong reason — silence because the
+    // event went nowhere. Assert the dispatch was accepted so that failure mode
+    // is loud rather than green.
+    const delivered = await page.evaluate((event) => {
+      const w = window as any
+      const api = w.comfyAPI?.api?.api || w.api
+      if (!api || typeof api.dispatchEvent !== 'function') return false
+      api.dispatchEvent(new CustomEvent(event))
+      return true
+    }, name)
+    expect(delivered, `ComfyUI's api singleton must accept the ${name} event`).toBe(true)
+  }
+
+  const bounceComfyBackend = async (downMs: number) => {
+    await fireComfyApiEvent('reconnecting')
+    await page.waitForTimeout(downMs)
+    await fireComfyApiEvent('reconnected')
+  }
+
+  // CONTROL: a sub-second blip is not a restart and must produce no greeting.
+  await bounceComfyBackend(600)
+  await page.waitForTimeout(3_000)
+  expect(
+    hellos.length,
+    'a benign WS blip must NOT re-greet the agent — that is the #1138 harm'
+  ).toBe(0)
+
+  // THE INVARIANT: a restart-length outage re-advertises the route, with no page
+  // reload and no reconnect.
+  await bounceComfyBackend(7_000)
+  await expect
+    .poll(() => hellos.length, {
+      timeout: 30_000,
+      message: 'the tab must re-advertise its route after a restart the bridge survived'
+    })
+    .toBeGreaterThan(0)
+
+  expect(
+    mockBridge.connectionsOpened,
+    'and it must do so on the SAME socket — no drop, no redial, no page reload'
+  ).toBe(socketsAtStart)
+
+  const route = String(hellos[hellos.length - 1]?.tab_id ?? '')
+  expect(route, 'the re-advertise must carry a real route, never a bare path').toMatch(
+    /^(wf:[^:]+:|tmp:)/
+  )
+
+  // The hello is only the ANNOUNCEMENT. #654's symptom is that graph tools stay
+  // unusable afterwards, so drive one: that is what "Connected: none" was about.
+  const outline = await mockBridge.command('graph_outline', {})
+  expect(
+    outline.ok,
+    'a graph command must route after the re-advertise — announcing is not being usable'
+  ).toBe(true)
+
+  // ONE-SHOT: `reconnected` repeats, and each repeat is another full re-greeting
+  // if the claim is not stamped. A second event with no new outage adds nothing.
+  const afterRestart = hellos.length
+  await fireComfyApiEvent('reconnected')
+  await page.waitForTimeout(3_000)
+  expect(hellos.length, 'a repeated `reconnected` must not re-greet again').toBe(afterRestart)
 })

--- a/browser_tests/fixtures/MockBridge.ts
+++ b/browser_tests/fixtures/MockBridge.ts
@@ -77,6 +77,7 @@ export class MockBridge {
     greeting: string | null
   }
   private readonly sockets = new Set<WebSocket>()
+  private connectionsAccepted = 0
   private readonly userMessageCbs = new Set<UserMessageCb>()
   private readonly frameCbs = new Set<FrameCb>()
   private readonly userMessages: UserMessage[] = []
@@ -139,7 +140,18 @@ export class MockBridge {
     return addr.port
   }
 
+  /** How many WebSocket connections this bridge has ACCEPTED since `start()`.
+   *
+   *  #654 turns on a distinction the status pill cannot make: a tab that
+   *  RE-ADVERTISED on its live socket vs. one whose socket dropped and dialled
+   *  back. Both end at "connected" with a fresh hello on the wire, and only the
+   *  first is what a ComfyUI restart under a surviving orchestrator produces. */
+  get connectionsOpened(): number {
+    return this.connectionsAccepted
+  }
+
   private handleConnection(sock: WebSocket) {
+    this.connectionsAccepted += 1
     this.sockets.add(sock)
     sock.on('close', () => this.sockets.delete(sock))
     sock.on('message', (data) => {

--- a/browser_tests/unit/session-rebind.test.mjs
+++ b/browser_tests/unit/session-rebind.test.mjs
@@ -10,6 +10,8 @@ import { readFileSync } from "node:fs";
 
 import {
   shouldResumeAfterComfyReconnect,
+  shouldReadvertiseAfterComfyRestart,
+  createComfyBackendOutageTracker,
   shouldRehelloAfterCommand,
   shouldNudgeAfterMidTaskReconnect,
   createBridgeOutageTracker,
@@ -1124,4 +1126,304 @@ test("#1168 WIRING: the death is recorded where the panel EARNS the conclusion",
     ),
     "the nudge must be decided on the measured outage alone, never on the raw conclusion",
   );
+});
+
+// ---- #654 re-advertise the tab after a ComfyUI restart --------------------
+//
+// The report: `panel_restart_comfyui` confirms the server cycle
+// (`saw_down:true`, `confirmed_cycle:true`, `server_ready:true`) and the tab is
+// never usable again — the reply's tab-reconnected and graph-tools-ready flags
+// both stay false, and every graph call answers `Connected: none` until the
+// browser tab is reloaded by hand.
+//
+// The panel re-registers its bridge route ONLY by sending a `hello`, and on this
+// path nothing sent one: the pack is pure-frontend, so the orchestrator survives
+// the restart, the bridge socket never closes, no socket `open` handler runs,
+// and `connectAgent()` early-returns on an already-OPEN socket. The orchestrator
+// waits for a strictly NEWER hello generation that can never arrive.
+
+test("#654: bridge UP + a real restart-length outage → re-advertise the route", () => {
+  assert.equal(
+    shouldReadvertiseAfterComfyRestart({ bridgeConnected: true, outageMs: 26_000 }),
+    true,
+  );
+});
+
+test("#654: bridge DOWN → never, whatever the outage — the socket's own open-hello owns it", () => {
+  // Firing here as well is two greetings and two `ready` acks for one outage,
+  // which is #1138's false-nudge-into-a-live-session harm.
+  assert.equal(
+    shouldReadvertiseAfterComfyRestart({ bridgeConnected: false, outageMs: 26_000 }),
+    false,
+  );
+});
+
+test("#654: a benign WS blip is NOT a restart", () => {
+  // ComfyUI fires `reconnected` for viewing an asset, checking an image, a tab
+  // refocus. The elapsed interval is the only thing that separates those from a
+  // restart, so a short one must not re-greet a working agent.
+  assert.equal(shouldReadvertiseAfterComfyRestart({ bridgeConnected: true, outageMs: 800 }), false);
+  assert.equal(
+    shouldReadvertiseAfterComfyRestart({ bridgeConnected: true, outageMs: 5999 }),
+    false,
+  );
+  assert.equal(shouldReadvertiseAfterComfyRestart({ bridgeConnected: true, outageMs: 6000 }), true);
+});
+
+test("#654: an unmeasured outage is not evidence of a restart", () => {
+  // Absent, zero, negative and unreadable all mean "no outage was measured" —
+  // never "a long one". A missed re-advertise leaves the tab exactly as it is
+  // today; an invented one re-greets a live agent, so this fails closed.
+  for (const outageMs of [undefined, 0, -1, NaN, Infinity, "26000", null]) {
+    assert.equal(
+      shouldReadvertiseAfterComfyRestart({ bridgeConnected: true, outageMs }),
+      false,
+      `outageMs ${String(outageMs)} must not authorise a re-advertise`,
+    );
+  }
+  assert.equal(
+    shouldReadvertiseAfterComfyRestart({
+      bridgeConnected: true,
+      outageMs: 26_000,
+      minOutageMs: NaN,
+    }),
+    false,
+  );
+});
+
+test("#654: a hello that already landed during the outage suppresses the re-advertise", () => {
+  // The bridge dropped and reconnected FIRST: its socket-open hello already
+  // re-registered the tab, so this one would be the redundant second greeting.
+  assert.equal(
+    shouldReadvertiseAfterComfyRestart({
+      bridgeConnected: true,
+      outageMs: 26_000,
+      helloLandedSinceOutage: true,
+    }),
+    false,
+  );
+});
+
+test("#654: one-shot per outage — a repeated `reconnected` does not re-greet", () => {
+  assert.equal(
+    shouldReadvertiseAfterComfyRestart({
+      bridgeConnected: true,
+      outageMs: 26_000,
+      alreadyReadvertised: true,
+    }),
+    false,
+  );
+});
+
+test("#654 INVARIANT: the re-advertise and the #278 resume can never both fire", () => {
+  // The whole reason this is a separate predicate is that #278's
+  // `if (bridgeConnected) return false` must stay exactly as strict. Enumerate
+  // the cross product rather than reasoning about it: a guard that is present,
+  // correct in isolation and comparing the wrong pair is this repo's most
+  // expensive recurring defect.
+  for (const bridgeConnected of [true, false]) {
+    for (const outageMs of [0, 800, 26_000]) {
+      for (const rebootPending of [true, false]) {
+        for (const hasResumableSession of [true, false]) {
+          const resume = shouldResumeAfterComfyReconnect({
+            bridgeConnected,
+            rebootPending,
+            hasResumableSession,
+          });
+          const readvertise = shouldReadvertiseAfterComfyRestart({ bridgeConnected, outageMs });
+          assert.ok(
+            !(resume && readvertise),
+            `both fired for bridgeConnected=${bridgeConnected} outageMs=${outageMs}`,
+          );
+        }
+      }
+    }
+  }
+});
+
+// ---- #654 the backend outage tracker --------------------------------------
+
+test("#654 tracker: the FIRST down signal owns the outage — later ones do not reset it", () => {
+  // The defect this exists to prevent is a SEQUENCE, so drive one. ComfyUI
+  // announces a drop as `reconnecting` AND as a null `status` payload, and a
+  // frontend emits several across a restart. Re-stamping on each measures the
+  // gap between the last two instead of the restart — #1145 exactly.
+  let clock = 1000;
+  const t = createComfyBackendOutageTracker({ now: () => clock });
+  t.noteDown(3);
+  clock = 5000;
+  t.noteDown(3); // a second `reconnecting`
+  clock = 20_000;
+  t.noteDown(3); // a null `status` payload
+  clock = 27_000;
+  t.noteUp();
+  assert.equal(t.outageMs(), 26_000, "the outage is measured from the FIRST signal");
+  assert.equal(t.seq(), 1, "three signals, one outage");
+});
+
+test("#654 tracker: a reconnect that ended no outage records nothing", () => {
+  // It must not inherit the previous outage as if it were its own — the rule the
+  // bridge tracker's `noteHandshake` already follows for a re-advertise on a
+  // live socket.
+  let clock = 1000;
+  const t = createComfyBackendOutageTracker({ now: () => clock });
+  t.noteDown(0);
+  clock = 30_000;
+  t.noteUp();
+  assert.equal(t.outageMs(), 29_000);
+  clock = 40_000;
+  t.noteUp(); // a `reconnected` with no drop before it
+  assert.equal(t.outageMs(), 0, "an unopened outage measures nothing, not the last one");
+});
+
+test("#654 tracker: a near-zero start is a REAL reading, not 'no outage'", () => {
+  // performance.now()'s origin is page load, so a drop moments after load
+  // genuinely stamps ~0. A falsy-0 sentinel would read that as "no outage open",
+  // every later signal would re-stamp it, and the restart would measure one
+  // backoff step (#1138's sentinel-sharing-a-value-with-real-data defect).
+  let clock = 0;
+  const t = createComfyBackendOutageTracker({ now: () => clock });
+  t.noteDown(0);
+  clock = 500;
+  t.noteDown(0); // must NOT re-stamp
+  clock = 26_000;
+  t.noteUp();
+  assert.equal(t.outageMs(), 26_000);
+});
+
+test("#654 tracker: reads LIVE while open, so listener order cannot change the answer", () => {
+  // Two listeners on one `reconnected` event, registered at different times: the
+  // module-scope one closes the outage, the panel's reads it. Both orders must
+  // agree, or the fix works only when the listeners happen to be registered in
+  // one particular sequence.
+  let clock = 1000;
+  const t = createComfyBackendOutageTracker({ now: () => clock });
+  t.noteDown(0);
+  clock = 27_000;
+  const readBeforeClose = t.outageMs();
+  t.noteUp();
+  const readAfterClose = t.outageMs();
+  assert.equal(readBeforeClose, 26_000);
+  assert.equal(readAfterClose, 26_000);
+});
+
+test("#654 tracker: the hello baseline is captured when the outage OPENS", () => {
+  let clock = 1000;
+  const t = createComfyBackendOutageTracker({ now: () => clock });
+  t.noteDown(7);
+  clock = 27_000;
+  t.noteUp();
+  assert.equal(t.helloBaseline(), 7);
+  // A hello that landed during the outage (the bridge dropped and re-helloed
+  // first) is therefore visible to the caller as a count above the baseline.
+  assert.equal(9 > t.helloBaseline(), true);
+  assert.equal(7 > t.helloBaseline(), false);
+});
+
+test("#654 tracker: an unreadable clock opens no outage and authorises nothing", () => {
+  const t = createComfyBackendOutageTracker({ now: () => NaN });
+  t.noteDown(0);
+  t.noteUp();
+  assert.equal(t.outageMs(), 0);
+  assert.equal(t.seq(), 0, "no outage was opened, so no seq was consumed");
+});
+
+test("#654 tracker: a backwards clock cannot produce a negative duration", () => {
+  let clock = 30_000;
+  const t = createComfyBackendOutageTracker({ now: () => clock });
+  t.noteDown(0);
+  clock = 1000;
+  t.noteUp();
+  assert.equal(t.outageMs(), 0);
+});
+
+test("#654 wiring: the panel measures, feeds and consults the outage — every site", () => {
+  // The predicate and the tracker are covered by behaviour above. This covers
+  // what a pure test cannot see: that production actually reaches them. A
+  // tracker nothing feeds answers 0 forever and every test above still passes —
+  // deleting a single write site silently restores "no restart was ever
+  // observed", which IS the bug. Exact substrings on purpose: #1096's review
+  // proved by mutation that loose token scans over this file assert nothing.
+  const src = readFileSync(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8");
+  for (const [site, snippet] of [
+    [
+      "the tracker measures on the MONOTONIC clock (its own default is Date.now())",
+      "const comfyBackendOutage = createComfyBackendOutageTracker({ now: monotonicNow });",
+    ],
+    [
+      "the `reconnecting` listener opens the outage, carrying the landed-hello baseline",
+      "comfyBackendOutage.noteDown(landedHelloCount); // #654 — open the outage clock on the FIRST down signal.",
+    ],
+    [
+      "the null-`status` down signal opens it too — some frontends announce the drop only that way",
+      "        comfyBackendOutage.noteDown(landedHelloCount);",
+    ],
+    [
+      "the `reconnected` listener closes it",
+      "comfyBackendOutage.noteUp(); // #654 — close the outage clock and record its duration.",
+    ],
+    [
+      "a LANDED hello advances the count the baseline is compared against",
+      "          landedHelloCount++;",
+    ],
+    [
+      "the panel consults the predicate on the reconnect path",
+      "      shouldReadvertiseAfterComfyRestart({",
+    ],
+    [
+      "the one-shot claim is stamped from the tracker's own outage identity",
+      "      comfyRestartReadvertisedSeq = comfyBackendOutage.seq();",
+    ],
+  ]) {
+    assert.ok(src.includes(snippet), site);
+  }
+  // …and the branch RE-ADVERTISES. Asserted POSITIONALLY, not by presence: this
+  // file already contains three other `client?.rehello?.()` calls (#607, #310,
+  // #508), so a presence check stays green with THIS one deleted — the exact
+  // mutation this assertion was rewritten to catch, and the "wiring tests must
+  // check PATHS" lesson. It must be `rehello`, never `connectAgent()`, which
+  // early-returns on an already-OPEN socket and so can never produce a hello.
+  const claim = src.indexOf("      comfyRestartReadvertisedSeq = comfyBackendOutage.seq();");
+  assert.notEqual(claim, -1);
+  const branchEnd = src.indexOf("    // After ComfyUI comes back (backend-only reboot", claim);
+  assert.notEqual(branchEnd, -1, "the #654 branch sits above the #278 resume commentary");
+  const branch = src.slice(claim, branchEnd);
+  assert.ok(
+    branch.includes("client?.rehello?.();"),
+    "the #654 branch must re-advertise the route, and it must do so with rehello",
+  );
+  assert.doesNotMatch(
+    branch,
+    /connectAgent\(/,
+    "connectAgent() cannot hello on an open socket — using it here is a no-op that looks like a fix",
+  );
+  // The re-advertise must sit BEFORE the resume gate, because that gate RETURNS
+  // — placed after it, the branch this fix exists for is never reached.
+  const readvertise = src.indexOf("shouldReadvertiseAfterComfyRestart({");
+  const resume = src.indexOf("!shouldResumeAfterComfyReconnect({");
+  assert.ok(readvertise !== -1 && resume !== -1);
+  assert.ok(
+    readvertise < resume,
+    "the re-advertise must run before the resume gate's early return",
+  );
+});
+
+test("#654: #278's guard is NOT relaxed to make room for this", () => {
+  // The recurring way this cluster gets worse is by widening an existing guard
+  // instead of adding a narrower action beside it. `if (bridgeConnected) return
+  // false` is what stops a benign blip bouncing a live agent session.
+  const lib = readFileSync(new URL("../../web/js/lib/session-rebind.js", import.meta.url), "utf8");
+  const resumeStart = lib.indexOf("export function shouldResumeAfterComfyReconnect(");
+  assert.notEqual(resumeStart, -1);
+  // Bounded by the NEXT export, not by the first "\n}" — the signature's own
+  // destructured-parameter brace closes before the body begins, so a slice that
+  // stopped there would read an empty body and assert on nothing.
+  const nextExport = lib.indexOf("\nexport function", resumeStart + 1);
+  assert.notEqual(nextExport, -1);
+  const body = lib.slice(resumeStart, nextExport);
+  assert.ok(body.includes("if (bridgeConnected) return false;"), "#278's guard stands unchanged");
+  // And `shouldRehelloAfterCommand` stays narrow — widening it to cover the
+  // restart was the tempting wrong fix: at `comfy_reboot` reply time ComfyUI is
+  // on its way DOWN, so a hello there reaches nothing.
+  assert.equal(shouldRehelloAfterCommand("comfy_reboot", { ok: true }), false);
 });

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -554,9 +554,11 @@ import {
 } from "./lib/model-catalog.js";
 import {
   shouldResumeAfterComfyReconnect,
+  shouldReadvertiseAfterComfyRestart,
   shouldRehelloAfterCommand,
   shouldNudgeAfterMidTaskReconnect,
   createBridgeOutageTracker,
+  createComfyBackendOutageTracker,
   performSoftReloadRecovery,
   retryDuringReconnect,
   dedupeWorkflowTabRecords,
@@ -703,6 +705,20 @@ let postReconnectWatchToken = 0;
 // signal). A graph mutation dispatched in that gap can be applied and then wiped
 // by the incoming restore — so mutations are refused while this holds.
 let comfyBackendSocketDown = false;
+// #654 — the ComfyUI BACKEND outage clock. The elapsed interval is the only
+// thing that separates a real restart from a benign WS blip (asset view, image
+// check, tab refocus), and `reconnected` fires for both.
+//
+// Constructed on the MONOTONIC clock: the tracker's own default is `Date.now()`
+// so it stays usable standalone, so which clock the PANEL measures with is
+// decided here and nowhere else. A wall clock lets an NTP/DST correction inside
+// a restart invent or erase an outage (the rule reconnect-staleness.js and
+// #1145's bridge tracker already established).
+const comfyBackendOutage = createComfyBackendOutageTracker({ now: monotonicNow });
+// The outage seq the #654 re-advertise has already fired for. One-shot per
+// outage: `reconnected` can repeat, and a hello is a full re-greeting. 0 is a
+// safe start because the tracker's seq only reaches 1 once an outage has opened.
+let comfyRestartReadvertisedSeq = 0;
 // #402 — OPEN RECEIPTS. Every workflow_open / workflow_new that RAN is journaled here
 // with the selector it was asked for, the identity it resolved to, and whether it
 // applied. When a mid-command drop loses the reply, this is the ONLY non-inferential
@@ -1654,6 +1670,7 @@ function setupListeners() {
     api.addEventListener("reconnecting", () => {
       nodeDefsRefreshConfirmed = false;
       comfyBackendSocketDown = true;
+      comfyBackendOutage.noteDown(landedHelloCount); // #654 — open the outage clock on the FIRST down signal.
       objectInfoSnapshot.clear(); // #1223 — see condition 3 in lib/object-info-snapshot.js.
     });
     api.addEventListener("status", (ev) => {
@@ -1661,6 +1678,10 @@ function setupListeners() {
       if (ev?.detail == null) {
         nodeDefsRefreshConfirmed = false;
         comfyBackendSocketDown = true;
+        // #654 — and it is a down signal in its own right: some frontends
+        // announce the drop only this way, so the outage clock must open here
+        // too or the restart measures as no outage at all.
+        comfyBackendOutage.noteDown(landedHelloCount);
         objectInfoSnapshot.clear(); // #1223 — same reasoning as `reconnecting`.
       }
     });
@@ -1669,6 +1690,7 @@ function setupListeners() {
     // stale node registry + combos then (#221/#171/#185/#181).
     api.addEventListener("reconnected", () => {
       comfyBackendSocketDown = false;
+      comfyBackendOutage.noteUp(); // #654 — close the outage clock and record its duration.
       objectInfoSnapshot.clear(); // #1223 — see condition 3 in lib/object-info-snapshot.js.
       // #433: the frontend may now restore a stale/wrong active tab — bump the
       // epoch and arm the monotonic possibly-stale window. Bumping the epoch
@@ -8306,6 +8328,14 @@ let sessionEpoch = 0;
 // received neither. So this bumps on a socket (re)connect AND on every
 // AGENT_SESSION_RESET_FRAMES frame.
 let agentSessionEpoch = 0;
+// #654 — hellos that PROVABLY reached the wire, counted. Deliberately its own
+// counter rather than a read of agentSessionEpoch: that epoch also advances on
+// every AGENT_SESSION_RESET_FRAMES frame, so it cannot tell "the tab announced
+// itself" from "the agent session was reset for some other reason" — two states
+// collapsing into one answer is the defect class this file keeps re-learning.
+// Incremented on the same landed-hello path that advances the epoch, so it is
+// never credited for a hello the panel merely meant to send.
+let landedHelloCount = 0;
 // canvasToolsProvenEpoch is the ONLY evidence the panel has about the agent's
 // toolset, and it is one-directional: a `cmd` frame reaches this panel solely
 // because the model invoked a panel_* tool (panel-tools.ts is the only caller of
@@ -20706,6 +20736,11 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
         // pre-hello agent, which is exactly the generation it was stamped with.
         if (sent) {
           agentSessionEpoch++;
+          // #654 — this tab is now announced. Counted on the SAME landed path and
+          // for the same reason: a hello that never reached the wire registered
+          // nothing, and crediting it would suppress the one re-advertise that
+          // could actually re-register the tab after a restart.
+          landedHelloCount++;
           // Published only now, for the same reason the epoch advances only now:
           // a hello that never reached the wire advertised nothing.
           lastAdvertisedWorkflowUuid = advertisedWorkflowUuid;
@@ -31694,6 +31729,50 @@ function buildPanel() {
     // may have been missed, so reconcile pending runs against /history first,
     // independent of whether we go on to resume the agent below (#370).
     void reconcileRunsAfterReconnect();
+    // #654 — RE-ADVERTISE THE BRIDGE ROUTE when the bridge stayed up.
+    //
+    // The resume below is the bridge-DIED recovery and declines this case on
+    // purpose (#278). But the pack is pure-frontend now — it can no longer spawn
+    // the orchestrator, so `externalOrchestratorMode()` is hardcoded true and the
+    // orchestrator ALWAYS survives a ComfyUI restart. The bridge socket therefore
+    // never closes, no socket `open` handler runs, `connectAgent()` early-returns
+    // on an already-OPEN socket, and nothing sends the `hello` that is the only
+    // thing which re-registers this tab's route. The orchestrator's post-restart
+    // watch waits for a strictly NEWER hello generation that never arrives, so
+    // the restart reply's tab-reconnected and graph-tools-ready flags both stay
+    // false after every successful restart and the only recovery is a manual
+    // browser refresh — this issue, verbatim.
+    //
+    // The repair is the one the panel already ships for a free_vram bounce
+    // (#310): re-advertise. Placed BEFORE the resume gate because that gate
+    // returns, and gated so the two can never both fire — resume requires the
+    // bridge DOWN, this requires it UP. `client.rehello()` (not `connectAgent()`,
+    // which cannot produce a hello on an open socket) routes through the #1095
+    // gate, so the re-advertise waits out in-flight commands instead of stranding
+    // one mid-flight.
+    if (
+      shouldReadvertiseAfterComfyRestart({
+        bridgeConnected: client.isConnected(),
+        outageMs: comfyBackendOutage.outageMs(),
+        // A bridge that dropped and came back during this outage already
+        // re-registered through its own socket-open hello; a second greeting
+        // here is the #1138 double-ready-ack harm.
+        helloLandedSinceOutage: landedHelloCount > comfyBackendOutage.helloBaseline(),
+        alreadyReadvertised: comfyRestartReadvertisedSeq === comfyBackendOutage.seq(),
+      })
+    ) {
+      // Claimed BEFORE the send, so a `reconnected` that repeats cannot fire a
+      // second greeting while the first is still resolving its identity. The
+      // hello is bounded and the socket's own open-hello remains the fallback,
+      // so a claim spent on a send that never lands costs one restart's
+      // re-advertise — where an unclaimed repeat costs a re-greeting per event.
+      comfyRestartReadvertisedSeq = comfyBackendOutage.seq();
+      try {
+        client?.rehello?.();
+      } catch {
+        // the reconnect path retries the hello
+      }
+    }
     // After ComfyUI comes back (backend-only reboot — the page didn't reload),
     // the orchestrator died with it. Respawn + reconnect if the agent was in use.
     // ComfyUI fires "reconnected" for BENIGN WS blips too — viewing assets,

--- a/web/js/lib/session-rebind.js
+++ b/web/js/lib/session-rebind.js
@@ -29,6 +29,163 @@ export function shouldResumeAfterComfyReconnect({
   return Boolean(rebootPending || autoConnect || hasResumableSession);
 }
 
+// #654 — may this ComfyUI `reconnected` re-advertise the tab's bridge route?
+//
+// The gate above is the RESUME decision and its `if (bridgeConnected) return false`
+// is #278's: a benign ComfyUI WS blip must never bounce or respawn a live agent
+// session. That guard is not relaxed here — this is a SECOND, cheaper action on
+// the branch the resume declines, and the two are mutually exclusive by
+// construction (resume needs the bridge DOWN, this needs it UP).
+//
+// Why that branch needed one at all. The pack is pure-frontend and can no longer
+// spawn the orchestrator (`externalOrchestratorMode()` is hardcoded true), so the
+// orchestrator ALWAYS survives a ComfyUI restart now and the bridge socket never
+// closes. The panel re-registers its bridge route only by sending a `hello`, and
+// on this path nothing sends one: `connectAgent()` cannot, because `connect()`
+// early-returns on an already-OPEN socket, and no socket `open` handler fires.
+// The tab therefore sits on a live socket it never re-announced — the
+// orchestrator's post-restart watch waits for a strictly NEWER hello generation
+// that will never arrive, so the restart reply's tab-reconnected and
+// graph-tools-ready flags both stay false after every successful restart, with a
+// manual browser refresh as the only recovery.
+//
+// This is the same non-destructive repair `shouldRehelloAfterCommand` already
+// ships for `free_vram` (#310) — re-advertise the route — but triggered by the
+// `reconnected` event rather than a command reply, because at `comfy_reboot`
+// reply time ComfyUI is on its way DOWN and a hello then is useless.
+//
+// A landed hello is NOT a cheap frame, which is what every input below is for.
+// It bumps the agent-session epoch (discarding #291's canvas-tool proof), draws
+// a fresh `ready` ack (which drives #585's post-restart resume), and runs the
+// orchestrator's panel sync. After a real restart all three are exactly what is
+// wanted — they are what the socket-drop path does — but firing them on every
+// benign blip is the #1138 false-nudge harm. So:
+//
+//   - `bridgeConnected` false → the socket dropped, and its own `open` handler
+//     already sends a hello. A second one here is two greetings and two ready
+//     acks for one outage.
+//   - `helloLandedSinceOutage` → a hello reached the wire since this outage
+//     began (a bridge drop that reconnected FIRST), so the tab is already
+//     re-registered. Measured from hellos that provably landed, never from ones
+//     the panel meant to send.
+//   - `alreadyReadvertised` → one-shot per outage; `reconnected` can repeat.
+//   - `outageMs` → the elapsed interval is the ONLY thing separating a real
+//     restart from a WS blip (asset view, image check, tab refocus). Same
+//     reasoning and same default threshold as `shouldNudgeAfterMidTaskReconnect`
+//     below; deliberately one number, not a second one to keep in sync.
+//
+// A duration, not a timestamp to subtract from `now`, for #1145's reason: the
+// caller measures the interval once and a duration cannot be silently reread as
+// "time since the last drop, whenever that was". Absent, zero, negative or
+// unreadable all mean no outage was measured, and no measured outage means no
+// re-advertise — the safe direction, since a missed re-advertise leaves the tab
+// exactly as wedged as it is today while an invented one re-greets a live agent.
+export function shouldReadvertiseAfterComfyRestart({
+  bridgeConnected = false,
+  outageMs = 0,
+  helloLandedSinceOutage = false,
+  alreadyReadvertised = false,
+  minOutageMs = 6000,
+} = {}) {
+  if (!bridgeConnected) return false;
+  if (helloLandedSinceOutage) return false;
+  if (alreadyReadvertised) return false;
+  if (typeof outageMs !== "number" || !Number.isFinite(outageMs)) return false;
+  if (outageMs <= 0) return false;
+  if (typeof minOutageMs !== "number" || !Number.isFinite(minOutageMs)) return false;
+  return outageMs >= minOutageMs;
+}
+
+// #654 — the accounting that produces the `outageMs` above, for ComfyUI's OWN
+// backend socket (the bridge has its own tracker, `createBridgeOutageTracker`
+// below; the two measure different connections and must not be conflated).
+//
+// It lives here, as a tracker over injected time, for the same reason that one
+// does: the defect it guards against is a SEQUENCE, and only a sequence can
+// demonstrate it. ComfyUI announces a drop as `reconnecting` AND as a null
+// `status` payload, and a frontend can emit several before it comes back — so
+// the FIRST one opens the outage and every one after it belongs to the same
+// outage. A tracker that re-stamped on each would measure the gap between the
+// last two signals instead of the restart, which is #1145 exactly: a 26-second
+// restart read as a three-second blip and the recovery withheld.
+//
+// It also carries the two facts the caller needs to make the decision ONCE per
+// outage rather than once per event:
+//
+//   seq()          — identity of the current outage, advanced when one OPENS, so
+//                    it is stamped strictly before any `reconnected` reader can
+//                    run whatever order the listeners were registered in. 0 means
+//                    no outage has ever opened, which lets a caller's "already
+//                    handled" watermark start at 0 with no second sentinel.
+//   helloBaseline()— the landed-hello count at the moment the outage opened, so
+//                    a bridge that dropped and re-helloed DURING the outage is
+//                    distinguishable from one that stayed up throughout.
+export function createComfyBackendOutageTracker({ now = () => Date.now() } = {}) {
+  // NULL while the backend socket is up, never 0: the panel measures on
+  // `monotonicNow()` (performance.now), whose origin is page load, so an early
+  // enough drop genuinely stamps a near-zero value. A falsy-0 sentinel would read
+  // that as "no outage open" and every later signal would re-stamp it — #1138's
+  // mistake, a sentinel sharing a value with real data.
+  let startedAt = null;
+  let lastOutageMs = 0;
+  let outageSeq = 0;
+  let baseline = 0;
+  const readClock = () => {
+    const t = now();
+    return typeof t === "number" && Number.isFinite(t) ? t : null;
+  };
+  return {
+    /** A backend down signal. `landedHellos` is the caller's count of hellos that
+     *  provably reached the wire, captured as this outage's baseline. */
+    noteDown(landedHellos = 0) {
+      if (startedAt !== null) return; // inside an outage already — not a new one
+      const t = readClock();
+      // An unreadable clock cannot open an outage. Nothing is stamped, so the
+      // reconnect measures no outage and withholds the re-advertise — the safe
+      // direction: a missed one leaves the tab exactly as it is today, an
+      // invented one re-greets a live agent.
+      if (t === null) return;
+      startedAt = t;
+      outageSeq += 1;
+      baseline =
+        typeof landedHellos === "number" && Number.isFinite(landedHellos) ? landedHellos : 0;
+    },
+    /** The backend socket is back. Closes the outage and records its duration. */
+    noteUp() {
+      if (startedAt === null) {
+        // Ended no outage — records nothing rather than inheriting the previous
+        // one as if it were this reconnect's.
+        lastOutageMs = 0;
+        return;
+      }
+      const t = readClock();
+      // An outage whose end could not be timed measured nothing; closing it with
+      // a stale duration would credit this reconnect with the last one's.
+      lastOutageMs = t === null ? 0 : Math.max(0, t - startedAt);
+      startedAt = null;
+    },
+    /** The outage this reconnect ended, in ms (0 = none).
+     *
+     *  Reads LIVE while the outage is still open, so the answer does not depend
+     *  on whether the listener that closes it happened to run first. Two
+     *  listeners on one event, registered at different times: an ordering
+     *  assumption there is what #1327 recurred on. Both orders agree here. */
+    outageMs() {
+      if (startedAt !== null) {
+        const t = readClock();
+        return t === null ? 0 : Math.max(0, t - startedAt);
+      }
+      return lastOutageMs;
+    },
+    seq() {
+      return outageSeq;
+    },
+    helloBaseline() {
+      return baseline;
+    },
+  };
+}
+
 // #310 — free_vram can bounce the ComfyUI connection (models unloaded, the WS
 // blips), which drops the orchestrator's tab mapping the way a restart does.
 // Re-advertise (rehello) this tab after a successful free_vram so the very next


### PR DESCRIPTION
Refs the underlying cause of artokun/comfyui-mcp-panel#654.

## The mechanism

The panel re-registers its bridge route by exactly one act: sending a `hello`.
On the ComfyUI-restart path nothing sends one any more.

The pack is pure-frontend and can no longer spawn the orchestrator, so
`externalOrchestratorMode()` is hardcoded `true` (`comfyui-mcp-panel.js:4574`).
The orchestrator therefore runs out-of-band and **always survives** a ComfyUI
restart. Follow what that leaves:

| step | what happens |
|---|---|
| the bridge socket | never closes — the orchestrator did not die |
| the socket `open` handler | never fires, so its `sendHello()` never runs |
| `onComfyReconnected` | `shouldResumeAfterComfyReconnect` returns `false` on `bridgeConnected` (#278, correctly) and the handler returns having done nothing |
| `connectAgent()` (had it been reached) | `connect()` early-returns on an already-OPEN socket, so it cannot produce a hello either |

The tab sits on a live socket it never re-announced. Orchestrator-side,
`awaitPostRestartReachable` waits for a **strictly newer** hello generation
(`current.generation > before.generation`), which can never arrive — so
`panel_restart_comfyui` reports a confirmed server cycle with the tab-reconnected
and graph-tools-ready flags both false, on **every** restart, and a manual
browser refresh is the only recovery. That is this report verbatim, including
the 2026-08-14 and 2026-08-15 recurrences.

This is the remaining half of Cluster A in `docs/triage/2026-08-14-open-issues.md`
(committed to main in #1234). The other half, #584's version re-probe, landed in
0.15.1 as #1317 and hooks the same `reconnected` signal.

## The fix

The repair this panel already ships for a `free_vram` bounce (#310):
**re-advertise the route**. Triggered by the `reconnected` event rather than a
command reply, because at `comfy_reboot` reply time ComfyUI is on its way down
and a hello then reaches nothing.

**#278's guard is not relaxed.** `if (bridgeConnected) return false` is what
stops a benign WS blip bouncing a live agent session, and it stands untouched
(pinned by a test). This is a second, cheaper action on the branch that guard
declines, and the two are mutually exclusive by construction — resume needs the
bridge DOWN, this needs it UP. A cross-product test asserts they can never both
fire rather than reasoning that they cannot.

A landed hello is not a cheap frame — it bumps the agent-session epoch, draws a
fresh `ready` ack and runs the orchestrator's panel sync — which is why it is
gated on four things rather than fired on every `reconnected`:

- **the bridge stayed UP.** If it dropped, its own socket-open hello already
  registered the tab; a second here is two greetings and two ready acks for one
  outage (#1138's harm).
- **no hello LANDED during the outage** — counted from hellos that provably
  reached the wire, never from ones the panel meant to send. This covers the
  deployment where the bridge *does* drop and re-hellos before `reconnected`
  arrives.
- **one-shot per outage.** `reconnected` repeats.
- **a MEASURED outage** at or past the same 6s threshold
  `shouldNudgeAfterMidTaskReconnect` already uses — deliberately one number, not
  a second to keep in sync. The elapsed interval is the only thing separating a
  restart from a blip (asset view, image check, tab refocus), and absent, zero,
  negative or unreadable all mean "not measured", never "long".

The outage accounting is a tracker over injected time, like #1145's bridge one
and for the same reason: **the defect it prevents is a sequence.** ComfyUI
announces a drop as `reconnecting` *and* as a null `status` payload and emits
several across one restart, so the first opens the outage and later ones must not
move its start — re-stamping reads a 26s restart as a 3s blip and withholds the
recovery. It measures on the monotonic clock, holds `null` (not `0`) as its
no-outage sentinel because `performance.now()` legitimately reads ~0 near page
load, and reads **live** while an outage is open so the answer does not depend on
which of the two `reconnected` listeners happens to run first.

## The refutation

Not asserted — run. **Thirteen mutations, thirteen caught.**

| mutation | caught by |
|---|---|
| delete the re-advertise call (`rehello` → no-op) | e2e + wiring |
| swap it for `connectAgent()` (dead on an open socket) | wiring |
| delete the `reconnecting` down-stamp | wiring |
| delete the null-`status` down-stamp | wiring |
| delete the `reconnected` close | wiring |
| delete `landedHelloCount++` | wiring |
| wall clock instead of monotonic | wiring |
| move the branch after the resume gate's early return | wiring |
| invert the bridge-up guard | behaviour |
| drop the blip threshold | behaviour |
| drop the landed-hello suppression | behaviour |
| drop the one-shot claim | behaviour |
| tracker re-stamps on every down signal (#1145 shape) | tracker sequence |
| falsy-0 sentinel instead of `=== null` (#1138 shape) | tracker sequence |

**One survived at first and is worth naming.** The wiring assertion for the
re-advertise was a presence check on `client?.rehello?.();` — and this file holds
three other `rehello` call sites (#607, #310, #508), so deleting *this* one left
the assertion green. That is "wiring tests must check PATHS" exactly. It is now
positional: the call must appear inside the #654 branch, and `connectAgent(` must
not.

## Browser verification

`npx playwright test --workers=1` from this worktree — **result reported below.**

The new e2e (`bridge-reregisters-after-restart.spec.ts`) drives ComfyUI's own
`reconnecting` → `reconnected` api events under a **live** MockBridge and
requires:

- a fresh hello, on the **same** socket (`connectionsOpened` unchanged — no drop,
  no redial, no page reload), carrying a real route;
- a `graph_outline` routing through afterwards — announcing the registration is
  not the same as being usable, which is what `Connected: none` was about;
- **silence** for a sub-second blip (the control half — a fix that re-greeted on
  those would be #1138 wearing this issue's clothes);
- **silence** for a repeated `reconnected`.

Two harness facts, both found by running it:

1. The api singleton is `window.comfyAPI?.api?.api`, not `app.api`. Dispatching
   on the latter reaches an object the panel never listened on, and the control
   half would then pass for the wrong reason. The helper now asserts the dispatch
   was accepted.
2. This spec did not route the worktree's source, so it was measuring the dev
   ComfyUI's installed checkout. Run once in that state, the new test produced
   **no re-advertise at all** — this issue reproducing in the browser against the
   installed build. `routeWorktreeSource` is now applied in the new test, with
   that finding recorded beside it.

`MockBridge` gains a `connectionsOpened` counter: the status pill cannot tell a
re-advertise on a live socket from a socket that dropped and dialled back, and
only the first is what this scenario produces.

Unit: 5045/5047. The single failure is the known `#671 verifyInstalled` wall-clock
flake under full-suite contention — 125/125 in isolation, and it touches nothing
in this change.

## What I deliberately did not do

- **Did not widen `shouldRehelloAfterCommand`.** Its narrowness is pinned on
  purpose, and a hello at `comfy_reboot` reply time reaches a server on its way
  down.
- **Did not touch #1096** ("bridge survived, tab route unrestored"), whose
  trigger is a plain socket drop rather than a restart, nor mcp#1670/#1671 or
  panel#1262.
- **Did not change the orchestrator side.** `graph_tools_ready` and `ready` still
  fail closed on an unproven reconnect, which is right; this makes the proof
  arrive instead of weakening what counts as proof.
- **Did not verify the #585 resume interaction end-to-end.** The re-advertise's
  `ready` ack reaches `handleRebootResumeAck`, which is the post-restart resume
  the panel's own `comfy_reboot` message promises and which is currently
  unreachable in this deployment — I believe that is a second thing this fixes,
  but I did not drive a real agent turn across a restart to confirm it, so I am
  claiming the route registration only. Reviewers should look hardest there.

---

Codex was unavailable (account exhausted until 2026-08-19), so this was **not**
self-gated; the orchestrator owns gating and merging.
