### PR TITLE
fix(1192): the FIFTH wait in graph_add_node draws from the command budget too

### DIFF
--- a/browser_tests/unit/add-node-command-budget.test.mjs
+++ b/browser_tests/unit/add-node-command-budget.test.mjs
@@ -540,3 +540,71 @@ test("#1192: every step stalling at once still replies inside the command budget
   gate.resolve();
   await built.inFlightStarted?.catch(() => {});
 });
+
+// ---------------------------------------------------------------------------
+// 4. THE FIFTH WAIT: #1242's drift recovery is inside this command too.
+//
+// `graph_add_node` has FIVE waits, not four. The fifth is #1242's `force: true` refresh,
+// run when the registered schema has drifted from the backend's. The coalescer's forced
+// branch AWAITS ANY IN-FLIGHT RUN before queueing its own, so unbounded it is the same
+// term this issue is about — reached later, with the window already partly spent.
+//
+// Counting `budget.` call sites in the source cannot see this: the budget was threaded
+// through four awaits and the fifth simply was not one of them. Only a test that DRIVES
+// this path finds it, which is why this one holds a real in-flight run open and asserts
+// the add still answers at all.
+// ---------------------------------------------------------------------------
+
+test("#1192: the #1242 drift-recovery refresh is bounded by the command budget too", async () => {
+  // The class is ALREADY registered, so the resolver returns on its fast path and never
+  // calls refresh — the only refresh this add performs is #1242's. `driftedRequiredInput-
+  // Names` is forced non-empty so that recovery actually runs; that is the path under test.
+  const comfy = makeComfy();
+  comfy.app.registerNodesFromDefs({ ExistingNode: backendObjectInfo().ExistingNode });
+  const gate = deferred(); // a reconnect refresh that never lands
+  const built = realGraphAddNode({
+    comfy,
+    holdInFlight: gate.promise,
+    budgetMs: 400,
+    reserveMs: 120,
+    overrides: { driftedRequiredInputNames: () => ["seed"] },
+  });
+
+  const started = Date.now();
+  // UNBOUNDED, this call parks on the held-open run and the add never answers at all — the
+  // reported failure, reproduced. Bounded, it gives up and refuses in words about the drift.
+  await assert.rejects(
+    () => built.graph_add_node({ class_type: "ExistingNode" }),
+    (err) => {
+      assert.match(err.message, /required input/i, "the refusal is the drift one, worded");
+      return true;
+    },
+  );
+  const elapsed = Date.now() - started;
+  assert.ok(
+    elapsed < 3000,
+    `the drift recovery took ${elapsed}ms — it must give up at the command's bound, not ` +
+      "wait out a run started by something else",
+  );
+  gate.resolve();
+});
+
+test("#1192: an abandoned drift recovery is reported as a RETRY, not as 'unknown'", async () => {
+  // The generic branch turns any non-true verdict into reason "unknown". A Symbol lands
+  // there unless it is handled FIRST, and "unknown" is the shape of answer this repo keeps
+  // getting burned by: it cannot tell a refresh that FAILED from one this command simply
+  // stopped waiting for. Only the second is cleared by retrying.
+  const addBody = addNodeMatch[0];
+  assert.match(
+    addBody,
+    /force: true,\s*\n\s*joinMs: budget\.remaining\(\) - ADD_NODE_POST_REFRESH_RESERVE_MS,/,
+    "the #1242 drift refresh must draw its join bound from the command budget",
+  );
+  const at = addBody.indexOf("if (verdict === REFRESH_JOIN_ABANDONED)");
+  assert.ok(at > 0, "an abandoned drift recovery must be distinguished from a failed one");
+  assert.match(
+    addBody.slice(at, at + 700),
+    /retry/i,
+    "…and its reason must name the remedy that actually works",
+  );
+});

--- a/browser_tests/unit/add-node-schema-auto-refresh.test.mjs
+++ b/browser_tests/unit/add-node-schema-auto-refresh.test.mjs
@@ -279,7 +279,20 @@ test("#1242: the reporter's add succeeds in one call — the panel refreshes fir
   assert.equal(comfy.graph._nodes.length, 1);
   assert.equal(refreshCalls.length, 1, "exactly one refresh — the recovery, not a retry storm");
   assert.equal(refreshCalls[0].defs, undefined, "the refresh is the whole-schema forced one");
-  assert.deepEqual(refreshCalls[0].opts, { force: true });
+  assert.equal(refreshCalls[0].opts.force, true, "the recovery is the forced whole-schema one");
+  // #1192 — and it is BOUNDED now. This recovery awaits any refresh already in flight before
+  // queueing its own; unbounded that wait is the composition defect #1192 is about, arriving
+  // at the one await inside this command that named no bound. Asserting the bound EXISTS is
+  // stronger than the literal `{ force: true }` this replaces, which could not see it.
+  assert.ok(
+    Number.isFinite(refreshCalls[0].opts.joinMs) && refreshCalls[0].opts.joinMs > 0,
+    "the drift recovery's wait must be bounded by what the command has left",
+  );
+  assert.deepEqual(
+    Object.keys(refreshCalls[0].opts).sort(),
+    ["force", "joinMs"],
+    "…and nothing else is passed",
+  );
 });
 
 test("#1242: the recovery is disclosed on the result, not silent", async () => {

--- a/browser_tests/unit/add-node-schema-drift-recovery.test.mjs
+++ b/browser_tests/unit/add-node-schema-drift-recovery.test.mjs
@@ -104,7 +104,18 @@ test("#1242: the add runs the refresh itself, then re-checks, BEFORE the refusal
   const refusalAt = PANEL.indexOf("added or retyped since this page loaded its node schema");
   assert.ok(checkAt > 0 && refusalAt > checkAt, "the drift check must precede the refusal");
   const between = PANEL.slice(checkAt, refusalAt);
-  const refreshAt = between.indexOf("refreshComfyNodeDefs(undefined, { force: true })");
+  // #1192 — the call now spans lines because it carries a bound, so this matches the SHAPE
+  // rather than one spelling of it. STRONGER than the literal it replaces: it pins that the
+  // drift recovery is forced AND that its wait draws from the command budget, which is the
+  // property #1192 needs and the literal could not express.
+  const forced = between.match(
+    /refreshComfyNodeDefs\(undefined, \{\s*force: true,\s*joinMs: budget\.remaining\(\) - ADD_NODE_POST_REFRESH_RESERVE_MS,\s*\}\)/,
+  );
+  assert.ok(
+    forced,
+    "the drift branch must run the forced refresh itself, bounded by the command budget",
+  );
+  const refreshAt = forced.index;
   assert.ok(refreshAt > 0, "the drift branch must run the forced refresh itself");
   const recheckAt = between.indexOf("drifted = driftedRequiredInputNames(currentDef, nodeData)", refreshAt);
   assert.ok(recheckAt > refreshAt, "the drift must be re-checked AFTER the refresh");

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -11966,8 +11966,36 @@ const GRAPH_TOOL_EXECUTORS = {
     let schemaRefreshIncompleteReason = null;
     if (drifted.length) {
       try {
-        const verdict = await refreshComfyNodeDefs(undefined, { force: true });
-        if (!(verdict === true || (verdict != null && typeof verdict === "object" && verdict.refreshed === true))) {
+        // #1192 — THE FIFTH WAIT, and the one the command budget did not reach.
+        //
+        // #1242's recovery is a `force: true` refresh, and the coalescer's forced branch
+        // AWAITS ANY RUN ALREADY IN FLIGHT before it queues its own. Unbounded, that is
+        // exactly the term this issue is about — a wait on a run started under someone
+        // else's deadline — arriving through the one await inside `graph_add_node` that
+        // named no bound. It sits AFTER the resolver, so it is reached with the window
+        // already partly spent, and on the reported scenario (a ComfyUI restart, whose
+        // reconnect refresh is still running) it could park here until the relay gave up
+        // and the user got the bare "did not reply" this whole change exists to replace.
+        //
+        // Same allowance as the resolver's join, and the same reserve held back, so a
+        // drift recovery cannot eat the window the widget-registration wait still needs.
+        const verdict = await refreshComfyNodeDefs(undefined, {
+          force: true,
+          joinMs: budget.remaining() - ADD_NODE_POST_REFRESH_RESERVE_MS,
+        });
+        if (verdict === REFRESH_JOIN_ABANDONED) {
+          // A NAMED reason, not the "unknown" the generic branch below produces for a
+          // Symbol. NOTHING FAILED: the refresh is still running and still registering the
+          // schema this add wants, so the drift re-check may still clear — and if it does
+          // not, the refusal names a cause a retry actually clears. "unknown" would say
+          // the opposite by omission, and cannot tell a refresh that FAILED from one this
+          // command merely stopped waiting for.
+          schemaRefreshIncompleteReason =
+            "a node-def refresh started by something else was still running, and this " +
+            "command's time budget ran out waiting for it — nothing failed, so retry";
+        } else if (
+          !(verdict === true || (verdict != null && typeof verdict === "object" && verdict.refreshed === true))
+        ) {
           schemaRefreshIncompleteReason =
             (verdict != null && typeof verdict === "object" && verdict.reason) || "unknown";
         }


### PR DESCRIPTION
**Stacks on #1342** (`fix/1192-add-node-command-budget`), which is the substance of the #1192
fix and is correct. The base branch here is that PR, so the diff below is only my delta: the
one call site its budget did not reach, plus what I measured reviewing it.

## The defect

#1342 threads the command budget through **four** of `graph_add_node`'s waits — the baseline
seed, the single-type fetch, the whole-schema fetch, and the widget-registration wait — and
bounds the resolver's join on an in-flight refresh.

`graph_add_node` has **five**. The fifth is #1242's schema-drift recovery, at
`web/js/comfyui-mcp-panel.js:11786` on that branch:

```js
const verdict = await refreshComfyNodeDefs(undefined, { force: true });
```

No `joinMs`. The coalescer's FORCED branch awaits any run **already in flight** before it queues
its own (`web/js/lib/refresh-coalesce.js`, the `if (current)` block), so unbounded this is
precisely the term #1192 is about — a wait on a run started under someone else's deadline —
arriving through the one `await` inside this command that named no bound. It sits *after* the
resolver, so it is reached with the window already partly spent, and on the reported scenario
(a ComfyUI restart, whose reconnect refresh is still running) the add parks there until the
30,000 ms relay gives up and the user gets the bare `did not reply to "graph_add_node"` that
this whole change exists to replace.

A source-level count of `budget.` call sites cannot see this: the budget was threaded through
four awaits and the fifth simply was not one of them.

For the record, since "a bigger constant is not a fix" is the obvious worry with any change of
this shape: **#1342 raises no existing timeout.** `git diff origin/main...` over `web/js` adds
exactly two numeric constants — `ADD_NODE_COMMAND_BUDGET_MS = 25000` (a CAP every step draws
from, not an enlargement) and `WIDEN_SOCKET_PROOF_DIVISOR = 2` (naming an existing divisor).
`NODE_DEFS_FETCH_TIMEOUT_MS` (10000), `NODE_DEFS_RUN_BUDGET_MS` (9000),
`OBJECT_INFO_SEED_WAIT_MS` (8000) and `CUSTOM_WIDGET_REGISTRATION_TIMEOUT_MS` (5000) all keep
their values. This delta adds no constant at all.

## The fix

Same allowance as the resolver's join, and the same reserve held back, so a drift recovery
cannot eat the window the widget-registration wait still needs. An abandoned recovery gets its
**own** reason rather than falling into the generic branch: a Symbol is not `typeof "object"`,
so it would have been reported as reason `"unknown"` — i.e. as a refresh that FAILED, which
sends the caller to the wrong recovery. Nothing failed; the refresh is still running and is
still registering the schema the add wants, so the reason says retry.

Healthy adds are unchanged: `joinMs` is only consulted inside the coalescer's `if (current)`
branch, so with no refresh in flight this call takes the path it always did.

The second commit updates #1242's two existing pins, which pinned the OLD literal
(`refreshComfyNodeDefs(undefined, { force: true })` — one as a source substring, one as
`deepEqual(opts, { force: true })`). **Updated, not loosened:** each now pins *more* than it
did — the source pin matches the call's shape *and* requires the budget-derived `joinMs`; the
options pin asserts `force` is set, that `joinMs` is finite and positive, and that nothing else
is passed. Verified in both directions: remove the bound from the panel again and both files go
red.

## Refutation (run, not reasoned)

Removed the `joinMs` again and re-ran: the new test does not merely fail — **it hangs, and
`graph_add_node` never answers at all.** That is the reported failure, reproduced at the call
site the budget missed. With the bound in place the add gives up at **279.8 ms** of a 400 ms
budget with a 120 ms reserve and refuses in words about the drift.

I also ran four mutations against #1342's own work. All killed:

| mutation | result |
|---|---|
| delete the `withTimeout` wiring on the coalescer (a one-line install) | ✖ red — the call site is pinned, not just the helper |
| restore the unbounded resolver join | **hang** — the add never answers |
| drop `budget.bounded(...)` from the widget-registration wait | ✖ red |
| remove `bounded()`'s 1 ms floor (the #1188 "0 means NO BOUND" trap) | **hang** |

## Measured

- The relay window #1342 cites is **correct, and I verified it independently**:
  `OBJECT_INFO_REFRESH_ACK_TIMEOUT_MS = 30_000` at comfyui-mcp
  `src/orchestrator/panel-tools.ts:821`, applied to `graph_add_node` at `:9650`. The issue's
  20,000 ms ui-bridge default is *not* the binding number for this command.
- **`joinMs` bounds the JOIN only, never the run that follows it.** Driven against the real
  coalescer: join bound 280 ms, in-flight run 250 ms (settles inside the bound), the caller's
  own run 2,000 ms → `refresh()` resolved in **2,251 ms — 8.0× its own join bound**.
- The drift recovery's live bound, read off the shipped constants by #1242's own harness:
  **`joinMs: 19999.3`** — i.e. 25,000 − 5,000, as designed.

## What still adds up (stated, not fixed here)

With `ADD_NODE_COMMAND_BUDGET_MS = 25_000` and `ADD_NODE_POST_REFRESH_RESERVE_MS = 5_000`, a
join is allowed to end as late as **20,000 ms** into the command. The caller's own run that
follows draws nothing from the budget: `NODE_DEFS_RUN_BUDGET_MS = 9_000` bounds only the
*waiting* inside a run, and `registerNodesFromDefs` is deliberately unbounded (3,972 ms
measured, per #1342's own comment). So a worst case of roughly **33,000 ms** survives on the
path where the join succeeds near its bound — still past the 30,000 ms window, though far
better than the ~41,000 ms it replaces, and every other path composes.

Closing that last term means bounding a *run* from its caller, which is exactly the subject of
the separate open issue #1193 (`refreshComboInNodes` alone at ~4.8 s of a 9 s run budget). I
deliberately did not touch it, and this PR does not resolve it.

## Verification

**Browser suite — `npx playwright test --workers=1`**, against a real ComfyUI 0.33.1 running on
its own port and base-directory with this branch junctioned into its `custom_nodes`, so the
module the browser loads is the changed one and not the shared checkout's (confirmed by
fetching the served bundle and finding this commit's code in it):

| tree | result |
|---|---|
| this branch (`a11eb0fa`) | **53 passed / 20 failed**, 10.6 min |
| #1342's head (`fc0e4b09`) | 52 passed / 21 failed, 10.1 min |
| `origin/main`, same 21 spec files, its own instance | **21 failed — the same tests, name for name** |

The e2e delta attributable to this change is **zero**: the 20 failures here are a strict subset
of the 21 that `origin/main` fails on this rig, and they sit entirely in the chat /
conversation-persistence / MockBridge specs. Neither spec that exercises `add_node`
(`auto-layout`, `blank-canvas-not-wedged`) is among them.

This issue is about timing, so plainly: the machine was loaded during these runs and the
wall-clock numbers are noisy. It is the branch-vs-`origin/main` comparison, not the absolute
count, that carries the claim.

**CI does not run on this PR, and that is structural, not a failure.**
`.github/workflows/ci.yml` triggers on `pull_request: branches: [main]`, and this PR's base is
#1342's branch. It will fire automatically the moment #1342 merges and GitHub retargets this to
`main`. I ran that job's own steps locally instead:

- `node --check` over `web/js` — **167 files, 0 errors** (the CI step verbatim)
- `npm run typecheck` — clean
- `npm run test:unit` — see below; includes the tool-vocabulary, panel-scope and i18n gates
- Python steps are untouched by this diff (JS and test files only)

`npm run test:unit` — **5,061 tests, 5,059 pass, 1 fail, 1 todo.** The single failure is the
known #671 `verifyInstalled` wall-clock flake in `manager-install.test.mjs` (26.1 s), untouched
by this diff and **125/125 green when that file is run alone**.

Gate: **not run.** `codex exec` is account-exhausted and I was instructed not to run a gate
script — the orchestrator gates and merges.

This addresses the underlying cause of #1192 together with #1342. Neither closing the issue nor
merging is a decision of mine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
