### PR TITLE
fix(mcp#1339 r2): the fixed-seed ARRAY and its SENTENCE come from one predicate

### DIFF
--- a/browser_tests/unit/scoped-batch-seed.test.mjs
+++ b/browser_tests/unit/scoped-batch-seed.test.mjs
@@ -21,6 +21,7 @@ import {
   scopedBatchSeedNote,
   findRgthreeSeedNodes,
   rgthreeFixedSeedNote,
+  repeatingRgthreeSeeds,
   rgthreeQueueTimeSeedInput,
 } from "../../web/js/lib/scoped-batch-seed.js";
 
@@ -434,4 +435,88 @@ test("#1124 — foreign seed nodes and malformed nodes exclude NOTHING (fail tow
   // A throwing accessor must not escape onto the dispatch path.
   const hostile = { type: "Seed (rgthree)", get widgets() { throw new Error("boom"); } };
   assert.equal(rgthreeQueueTimeSeedInput(hostile), null);
+});
+
+/**
+ * #1339 round 2 — THE ARRAY AND THE SENTENCE DISAGREED.
+ *
+ * The shipped fix computed the prose with `varies === false` and the structured
+ * `fixed_seed_nodes` field with `armed === false`. Those agree for a concrete seed and
+ * DISAGREE for the armed-but-degenerate node the note itself calls the confusing case —
+ * so a run against one returned a sentence naming node 649 beside `fixed_seed_nodes: []`.
+ * A program reads the array; only a human reads the sentence.
+ */
+test("#1339 r2 — an ARMED, degenerate node is in the ARRAY, not only in the prose", () => {
+  const degenerate = { ...rgthreeSeed(649, -1), properties: { randomMin: 5, randomMax: 5 } };
+  const found = findRgthreeSeedNodes([degenerate]);
+  // Precondition: this is the shape the two predicates disagreed on.
+  assert.equal(found[0].armed, true);
+  assert.equal(found[0].varies, false);
+
+  const note = rgthreeFixedSeedNote(found, 10);
+  assert.notEqual(note, "", "the prose names it");
+  // THE REGRESSION. Pre-fix this was `[]` — `seeds.filter(s => s.armed === false)`.
+  const repeating = repeatingRgthreeSeeds(found);
+  assert.equal(repeating.length, 1, "the array must name it too");
+  assert.equal(repeating[0].node_id, "649");
+  // …and the entry still carries WHICH of the two ways it repeats, so collapsing the
+  // predicate did not collapse the distinction a reader needs.
+  assert.equal(repeating[0].armed, true);
+  assert.match(repeating[0].degenerate_range, /randomMin=5, randomMax=5/);
+});
+
+test("#1339 r2 — INVARIANT: every node the note names is in the array, and vice versa", () => {
+  // The contract, stated as one property rather than a list of cases: the field is only
+  // attached when the note is non-empty, so an empty array beside a note is a guaranteed
+  // contradiction — never a "no findings" answer.
+  const cases = [
+    ["fixed", [rgthreeSeed(649, 12345)]],
+    ["armed+degenerate", [{ ...rgthreeSeed(649, -1), properties: { randomMin: 5, randomMax: 5 } }]],
+    ["armed+degenerate by step", [{
+      ...rgthreeSeed(650, -1),
+      properties: { randomMin: 0, randomMax: 5 },
+      widgets: [{ name: "seed", value: -1, options: { step: 100 } }],
+    }]],
+    ["armed+healthy", [rgthreeSeed(649, -1)]],
+    ["mixed", [rgthreeSeed(700, -1), rgthreeSeed(701, 999), { ...rgthreeSeed(702, -2), properties: { randomMin: 7, randomMax: 7 } }]],
+    ["none", [ksampler(53, "randomize")]],
+  ];
+  for (const [label, nodes] of cases) {
+    const found = findRgthreeSeedNodes(nodes);
+    const note = rgthreeFixedSeedNote(found, 10);
+    const repeating = repeatingRgthreeSeeds(found);
+    assert.equal(Boolean(note), repeating.length > 0, `${label}: note and array must agree on WHETHER`);
+    // …and on WHICH. Every id the sentence mentions is in the array.
+    for (const s of found) {
+      const named = note.includes(`node ${s.node_id}`);
+      assert.equal(named, repeating.some((r) => r.node_id === s.node_id), `${label}: node ${s.node_id}`);
+    }
+  }
+  // The armed+healthy case must be silent on BOTH channels, or the fix traded a missing
+  // warning for a false one.
+  const healthy = findRgthreeSeedNodes([rgthreeSeed(649, -1)]);
+  assert.equal(rgthreeFixedSeedNote(healthy, 10), "");
+  assert.deepEqual(repeatingRgthreeSeeds(healthy), []);
+});
+
+test("#1339 r2 — repeatingRgthreeSeeds is total: malformed input yields [], never a throw", () => {
+  for (const bad of [null, undefined, "nodes", 7, {}]) assert.deepEqual(repeatingRgthreeSeeds(bad), []);
+  assert.deepEqual(repeatingRgthreeSeeds([null, undefined, {}]), [], "no `varies` ⇒ not a finding");
+});
+
+test("#1339 r2 source guard: the CALL SITE uses the shared predicate, not its own filter", () => {
+  // A helper-level test cannot see this: the assignment lives in the monolith, and the
+  // ONLY thing that made the two disagree was the call site rolling its own filter. So
+  // assert on the source, and on EVERY assignment rather than the first — a second path
+  // attaching the field is exactly how this comes back.
+  const src = readFileSync(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8");
+  const sites = [...src.matchAll(/fixed_seed_nodes\s*=\s*([^\n;]+)/g)].map((m) => m[1].trim());
+  assert.ok(sites.length > 0, "the field is no longer assigned anywhere — has it been renamed?");
+  for (const rhs of sites) {
+    assert.match(rhs, /^repeatingRgthreeSeeds\(/, `fixed_seed_nodes must come from the shared predicate, got: ${rhs}`);
+    assert.doesNotMatch(rhs, /\barmed\b/, `the armed-only filter is the #1339 r2 regression: ${rhs}`);
+  }
+  // It has to be imported to be callable — a bare reference would be a ReferenceError
+  // that only a live panel would surface.
+  assert.match(src, /import \{[^}]*\brepeatingRgthreeSeeds\b[^}]*\} from "\.\/lib\/scoped-batch-seed\.js"/s);
 });

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -207,6 +207,7 @@ import {
   scopedBatchSeedNote,
   findRgthreeSeedNodes,
   rgthreeFixedSeedNote,
+  repeatingRgthreeSeeds,
 } from "./lib/scoped-batch-seed.js";
 import {
   materializePromotedValues,
@@ -14013,9 +14014,14 @@ const GRAPH_TOOL_EXECUTORS = {
     }
     // #1339 — the same class of surprise from a node the scan above cannot see, because
     // rgthree deletes the `control_after_generate` widget it matches on.
+    //
+    // The ARRAY and the SENTENCE come from ONE predicate (repeatingRgthreeSeeds). They
+    // used to be two — `armed === false` here against `varies === false` in the note —
+    // which disagreed on the armed-but-degenerate node the note calls the confusing case,
+    // shipping `fixed_seed_nodes: []` beside a sentence naming that very node.
     const fixedSeedNote = rgthreeFixedSeedNote(rgthreeSeeds, batch);
     if (fixedSeedNote) {
-      accept.fixed_seed_nodes = rgthreeSeeds.filter((s) => s && s.armed === false);
+      accept.fixed_seed_nodes = repeatingRgthreeSeeds(rgthreeSeeds);
       accept.fixed_seed_note = fixedSeedNote;
     }
     // #572/#1124 — TRUTHFUL drift-coverage note for a scoped run: the drift hash

--- a/web/js/lib/scoped-batch-seed.js
+++ b/web/js/lib/scoped-batch-seed.js
@@ -425,6 +425,44 @@ export function rgthreeQueueTimeSeedInput(node) {
 }
 
 /**
+ * The scanned nodes that WILL submit the same seed for every item of a batch.
+ *
+ * THE PROSE AND THE STRUCTURED FIELD MUST BE ONE PREDICATE, and they were two.
+ * `rgthreeFixedSeedNote` selected on `varies === false`, while the caller that
+ * attaches `fixed_seed_nodes` to the run result selected on `armed === false` —
+ * and those disagree on exactly the case the #1339 warning exists for. An ARMED
+ * node whose randomMin/randomMax (or step) admit a single value is `armed: true,
+ * varies: false`, so it was NAMED in the sentence and MISSING from the array.
+ * Because the caller only attaches the field when the note is non-empty, that is
+ * not a hypothetical: a run against an armed-but-degenerate node returned
+ * `fixed_seed_note` saying "ALL 10 ITEMS OF THIS BATCH WILL USE THE SAME SEED
+ * from node 649" next to `fixed_seed_nodes: []`.
+ *
+ * A caller branching on the ARRAY — which is the one a program should read, and the
+ * one #1339's own diagnostic loop asks a reporter to check — therefore concluded
+ * nothing was wrong, in the single case the shipped fix describes as the confusing
+ * one ("you did press the button and it still repeats"). Reading the sentence
+ * instead is not a fix: prose is evidence for a human, never a field to branch on.
+ *
+ * `varies === false` is the correct predicate, so it lives here once and both
+ * consumers call it. `armed` stays ON each entry (with `degenerate_range` beside it)
+ * so a reader can still tell the two ways a seed repeats apart — what is removed is
+ * the ability for the two answers to disagree.
+ *
+ * NOT SHARED WITH `rgthreeQueueTimeSeedInput` (#1124), deliberately: that one gates
+ * on `armed` because a degenerate-range node still SUBSTITUTES and so is still
+ * volatile for the drift hash. Same nodes, opposite question — see its own note.
+ */
+export function repeatingRgthreeSeeds(seeds) {
+  if (!Array.isArray(seeds)) return [];
+  // `varies === false` covers BOTH ways an rgthree seed repeats: a concrete number in the
+  // widget, and an armed node whose random range admits one value. Keying on `armed`
+  // alone missed the second (codex P2) — and an armed-but-degenerate node is the more
+  // confusing of the two, because the user did press the button.
+  return seeds.filter((s) => s && s.varies === false);
+}
+
+/**
  * The disclosure for a batch whose rgthree seed is FIXED.
  *
  * Silent when the node is armed, because then it genuinely varies per item and there is
@@ -437,11 +475,7 @@ export function rgthreeQueueTimeSeedInput(node) {
  */
 export function rgthreeFixedSeedNote(seeds, batchCount) {
   if (!Array.isArray(seeds) || !(Number(batchCount) > 1)) return "";
-  // `varies === false` covers BOTH ways an rgthree seed repeats: a concrete number in the
-  // widget, and an armed node whose random range admits one value. Keying on `armed`
-  // alone missed the second (codex P2) — and an armed-but-degenerate node is the more
-  // confusing of the two, because the user did press the button.
-  const repeating = seeds.filter((s) => s && s.varies === false);
+  const repeating = repeatingRgthreeSeeds(seeds);
   if (!repeating.length) return "";
   const which = repeating
     .slice(0, 5)


### PR DESCRIPTION
## What this is

Recovery of abandoned uncommitted work, plus the finding that it is **not** the issue it was filed under.

I was dispatched to drive panel issue 1339 (`panel_set_widget` transiently rejects a matching
re-derived workflow identity after a download event) and handed an abandoned worktree —
branch `fix/1339-fixed-seed-nodes-contradiction`, three modified files, never committed,
0 commits ahead of its base.

**The inherited diff addresses a different bug than the panel issue it was branched for.**
The `1339` in that branch name is `artokun/comfyui-mcp#1339` — the *MCP* repo's rgthree-seed
issue, fixed here in PR #1082 and referenced throughout `web/js/lib/scoped-batch-seed.js`.
The panel repo's own issue 1339 is unrelated. Two repos, one issue number.

This PR ships the inherited work on its own merits. The panel-issue-1339 finding is in a
comment on that issue.

## The mechanism this fixes

A batch run against an rgthree Seed node computed two answers about the same question from
two different predicates:

- the prose warning (`rgthreeFixedSeedNote`) selected on `varies === false`
- the structured `fixed_seed_nodes` field, assigned at the call site in
  `comfyui-mcp-panel.js`, selected on `armed === false`

Those agree for a concrete seed value and **disagree for an armed node whose
`randomMin`/`randomMax` (or `step`) admit exactly one value** — `armed: true, varies: false`.
That is the case the note's own text calls the confusing one, because the user *did* press
the button and the seed still repeats.

Because the field is only attached when the note is non-empty, the disagreement is not
hypothetical: a run against such a node returned

```
fixed_seed_note: "ALL 10 ITEMS OF THIS BATCH WILL USE THE SAME SEED from node 649"
fixed_seed_nodes: []
```

A program branches on the array. Only a human reads the sentence. So the one case the
warning exists for is the one case a caller reading the structured field concluded was clean.

## The fix

`varies === false` is the correct predicate, so it now lives once in
`repeatingRgthreeSeeds()` in `web/js/lib/scoped-batch-seed.js`, and both consumers call it.
`armed` stays on each returned entry alongside `degenerate_range`, so a reader can still tell
the two ways a seed repeats apart — what is removed is the ability for the two answers to
disagree.

Deliberately **not** shared with `rgthreeQueueTimeSeedInput` (mcp#1124): that one gates on
`armed` because a degenerate-range node still *substitutes* at queue time and so is still
volatile for the drift hash. Same nodes, opposite question.

## What I did with the inherited work, and why

**Adopted unchanged.** Judged on its merits:

- It applies cleanly to current `main` (v0.15.3), 40+ commits past the base it was written on,
  and the defect it names is still live there — the call site on `main` still reads
  `rgthreeSeeds.filter((s) => s && s.armed === false)`.
- Run as it stood in the abandoned worktree, its test file passed **33/33**. It was a
  completed fix with its test, not a test-shaped statement of a bug with nothing behind it.
- It carries a source guard asserting on **every** `fixed_seed_nodes` assignment in the
  monolith, not just the first, and on the import — the two things a helper-level test is
  blind to for a one-line call-site change.

The three-file diff was copied out to a patch before anything was touched; nothing in the
abandoned worktree was checked out, stashed, or reverted, and no work was done inside it.

## Refutation

Green before and after proves nothing, so I deleted the fix twice and watched it fail:

| mutation | result |
|---|---|
| call site reverted to `rgthreeSeeds.filter((s) => s && s.armed === false)` | **1 failed** — `#1339 r2 source guard: the CALL SITE uses the shared predicate, not its own filter` |
| `repeatingRgthreeSeeds` predicate reverted to `armed === false` | **2 failed** — `an ARMED node with a degenerate random range still repeats`, and `an ARMED, degenerate node is in the ARRAY, not only in the prose` |
| restored | 33/33 pass |

Both halves are pinned, and the call-site half is pinned by something that can actually see it.

## Verification

- `npm run test:unit` — **5033/5035 pass, 1 fail**. The single failure is
  `manager-install.test.mjs:836` (`expected 'installed', actual 'unverified'`), the known
  wall-clock flake that fires under machine load; eleven agents are running on this box.
  Re-run alone: **125/125 pass**. It does not touch this change's files.
- Panel scope gate (`check-panel-scope.mjs`), i18n check, i18n render check and the tool
  vocabulary gate all pass.
- Playwright browser suite, `--workers=1`, from this worktree — result appended below.

## Gating

Not gated by me. `codex exec` is account-exhausted until 2026-08-19 20:43 and the substitute
`claude-gate.mjs` is blocked on the weekly account limit, so **no gate has been run on this
PR** — I am not substituting my own review for one. The orchestrator gates and merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
