### PR TITLE
fix(1272): a connect that THROWS is judged on the link the live graph shows, not on the exception

### DIFF
--- a/browser_tests/unit/connect-throw-verdict.test.mjs
+++ b/browser_tests/unit/connect-throw-verdict.test.mjs
@@ -327,7 +327,7 @@ test("#1272 node→node: a throw that leaves NOTHING on the graph still FAILS", 
     (err) => {
       assert.match(err.message, /threw and NOTHING landed/);
       assert.match(err.message, /reading 'slots'/);
-      assert.match(err.message, /no link from that output reaches node 143/);
+      assert.match(err.message, /this call left NO new link from that output on node 143/);
       return true;
     },
   );
@@ -411,7 +411,7 @@ test("#1272 node→node: a link that PRE-DATED the call is never credited to it"
         to_node_id: 143,
         to_input: "input1",
       }),
-    /threw and NOTHING landed/,
+    /threw and NOTHING landed[\s\S]*ALREADY on input "input2"[\s\S]*do not tear it down/,
   );
   assert.equal(dst.inputs[1].link, 7, "the pre-existing wire is left untouched");
 });
@@ -485,7 +485,7 @@ test("#1272 output rail: connect throws and the rail is EMPTY → honest failure
         to_node_id: -20,
         to_input: "image",
       }),
-    /threw and NOTHING landed[\s\S]*rail slot carries no link/,
+    /threw and NOTHING landed[\s\S]*left no new link from that output on the rail slot/,
   );
   assert.equal(rail.linkIds.length, 0);
 });
@@ -586,7 +586,7 @@ test("#1272 expose output: a throwing connect no longer STRANDS the slot addOutp
         from_output: "selected_value",
         name: "image",
       }),
-    /the frontend threw[\s\S]*was removed, so the rail is unchanged/,
+    /the frontend threw[\s\S]*was removed, so the rail carries no slot from this call/,
   );
   assert.deepEqual(graph.outputs, [], "no junk boundary output is left on the rail");
 });
@@ -655,7 +655,7 @@ test("#1272 expose input: a throwing connect no longer STRANDS the slot addInput
         to_input: "image",
         name: "image",
       }),
-    /the frontend threw[\s\S]*was removed, so the rail is unchanged/,
+    /the frontend threw[\s\S]*was removed, so the rail carries no slot from this call/,
   );
   assert.deepEqual(graph.inputs, []);
 });

--- a/browser_tests/unit/connect-throw-verdict.test.mjs
+++ b/browser_tests/unit/connect-throw-verdict.test.mjs
@@ -5,7 +5,8 @@
  * subgraph OUTPUT rail (`to_node_id: -20`). Both times `panel_query_graph` /
  * `panel_graph_outline` showed the wire afterwards.
  *
- * MECHANISM (read from ComfyUI_frontend 1.47.2, not inferred): every connect path
+ * MECHANISM (read from ComfyUI_frontend 1.48.7 — the reporter's own version — not
+ * inferred): every connect path
  * writes the link and only THEN runs the node hooks.
  *
  *   LGraphNode.connectSlots  — graph._links.set / output.links.push /
@@ -37,6 +38,7 @@ import {
   isWidgetBackedInput,
   inputLinkIds,
   railSlotLinkIds,
+  linkIdExclusionSet,
   findLandedInboundLink,
   findLandedRailLink,
   isRailLinkPersisted,
@@ -132,6 +134,7 @@ function buildExecutors(graph, canvas = {}) {
     "isWidgetBackedInput",
     "inputLinkIds",
     "railSlotLinkIds",
+    "linkIdExclusionSet",
     "findLandedInboundLink",
     "findLandedRailLink",
     "isRailLinkPersisted",
@@ -162,6 +165,7 @@ return GRAPH_TOOL_EXECUTORS;`,
     isWidgetBackedInput,
     inputLinkIds,
     railSlotLinkIds,
+    linkIdExclusionSet,
     findLandedInboundLink,
     findLandedRailLink,
     isRailLinkPersisted,
@@ -173,10 +177,57 @@ return GRAPH_TOOL_EXECUTORS;`,
 // LiteGraph-shaped doubles
 // ---------------------------------------------------------------------------
 
+/**
+ * The REAL link store shape, not a convenient one.
+ *
+ * `LGraph` holds `_links: Map<LinkId, LLink>` with `LinkId = number`, and exposes
+ * `links` as a Proxy over that Map whose methods are bound straight through — so
+ * `links.get` IS `Map.prototype.get`, and `links.get("7")` MISSES a key of `7`,
+ * while `links[7]` resolves through the numeric-key trap.
+ *
+ * The first version of this fixture used `links: {}`, a plain object whose keys are
+ * already strings, so `links["7"]` and `links[7]` coincided. That masked a helper
+ * that stringified every rail link id before looking it up: against a real graph it
+ * returned "no link landed" for a link that HAD landed, which made both
+ * expose_subgraph_* paths tear down the slot they had just correctly created — on
+ * the happy path, 100% of the time. Every fixture below now uses this shape, so a
+ * string/number confusion cannot pass again.
+ */
+function mkLinkStore() {
+  const isIndex = (prop) => typeof prop === "string" && /^(?:0|[1-9]\d*)$/.test(prop);
+  const map = new Map();
+  const proxy = new Proxy(map, {
+    get(target, prop) {
+      if (isIndex(prop)) return target.get(Number(prop));
+      const v = Reflect.get(target, prop, target);
+      // bindAllMethods: `get`/`set`/`delete` are the RAW Map methods, bound.
+      return typeof v === "function" ? v.bind(target) : v;
+    },
+    has: (target, prop) => (isIndex(prop) ? target.has(Number(prop)) : Reflect.has(target, prop)),
+    deleteProperty: (target, prop) =>
+      isIndex(prop) ? target.delete(Number(prop)) : Reflect.deleteProperty(target, prop),
+    ownKeys: (target) => [...target.keys()].map(String),
+    getOwnPropertyDescriptor(target, prop) {
+      if (isIndex(prop) && target.has(Number(prop))) {
+        return {
+          value: target.get(Number(prop)),
+          enumerable: true,
+          configurable: true,
+          writable: true,
+        };
+      }
+      return Reflect.getOwnPropertyDescriptor(target, prop);
+    },
+  });
+  return { map, proxy };
+}
+
 function mkGraph({ subgraph = false } = {}) {
+  const store = mkLinkStore();
   const graph = {
     lastLinkId: 0,
-    links: {},
+    _links: store.map,
+    links: store.proxy,
     nodes: [],
     outputs: [],
     inputs: [],
@@ -203,7 +254,8 @@ function mkGraph({ subgraph = false } = {}) {
       const i = graph.inputs.indexOf(slot);
       if (i >= 0) graph.inputs.splice(i, 1);
     },
-    getLink: (id) => graph.links[id] ?? null,
+    // LGraph.getLink is `this._links.get(id)` — number-keyed, no coercion.
+    getLink: (id) => store.map.get(id) ?? null,
   };
   return graph;
 }
@@ -224,7 +276,7 @@ function attachConnect(node, afterWrite) {
     // LiteGraph drops the wire already on the input before making the new one.
     const prior = target.inputs[inIdx]?.link;
     if (prior != null) {
-      delete graph.links[prior];
+      graph._links.delete(prior);
       target.inputs[inIdx].link = null;
     }
     const id = ++graph.lastLinkId;
@@ -235,7 +287,7 @@ function attachConnect(node, afterWrite) {
       target_id: target.id,
       target_slot: inIdx,
     };
-    graph.links[id] = link;
+    graph._links.set(id, link);
     (node.outputs[outIdx].links ??= []).push(id);
     target.inputs[inIdx].link = id;
     afterWrite?.({ link, target, inIdx, graph });
@@ -249,7 +301,7 @@ function mkRailOutput(graph, name, type) {
     const outIdx = node.outputs.indexOf(outputSlot);
     const id = ++graph.lastLinkId;
     const link = { id, origin_id: node.id, origin_slot: outIdx, target_id: -20, target_slot: 0 };
-    graph.links[id] = link;
+    graph._links.set(id, link);
     slot.linkIds[0] = id;
     (outputSlot.links ??= []).push(id);
     slot.afterWrite?.({ link, graph });
@@ -264,7 +316,7 @@ function mkRailInput(graph, name, type) {
     const inIdx = node.inputs.indexOf(inputSlot);
     const id = ++graph.lastLinkId;
     const link = { id, origin_id: -10, origin_slot: 0, target_id: node.id, target_slot: inIdx };
-    graph.links[id] = link;
+    graph._links.set(id, link);
     slot.linkIds.push(id);
     inputSlot.link = id;
     slot.afterWrite?.({ link, graph });
@@ -304,7 +356,7 @@ test("#1272 node→node: a hook that throws AFTER the link is written reports CO
   assert.equal(res.connected.to.input, "input1");
   assert.equal(res.connected.to.input_index, 0);
   // The verdict came from the live graph, not from the return value.
-  assert.equal(dst.inputs[0].link, graph.links[1].id);
+  assert.equal(dst.inputs[0].link, graph._links.get(1).id);
   // The throw is disclosed, never swallowed, and the retry is named as harmful.
   assert.match(res.warning, /threw while applying this connect/);
   assert.match(res.warning, /reading 'slots'/);
@@ -331,7 +383,7 @@ test("#1272 node→node: a throw that leaves NOTHING on the graph still FAILS", 
       return true;
     },
   );
-  assert.deepEqual(Object.keys(graph.links), []);
+  assert.equal(graph._links.size, 0);
 });
 
 test("#1272 node→node: a throw AFTER the node re-slotted the link names the slot it landed on", () => {
@@ -361,12 +413,12 @@ test("#1272 node→node: a throw that DESTROYED the previous wire says the input
   const old = mkNode(graph, 100, [], [{ name: "IMAGE", type: "IMAGE", links: [7] }]);
   const src = mkNode(graph, 140, [], [{ name: "IMAGE", type: "IMAGE", links: [] }]);
   const dst = mkNode(graph, 143, [{ name: "input1", type: "IMAGE", link: 7 }], []);
-  graph.links[7] = { id: 7, origin_id: 100, origin_slot: 0, target_id: 143, target_slot: 0 };
+  graph._links.set(7, { id: 7, origin_id: 100, origin_slot: 0, target_id: 143, target_slot: 0 });
   graph.lastLinkId = 7;
   void old;
   // The replacement disconnect throws: old wire gone, new one never made.
   src.connect = (_outIdx, target, inIdx) => {
-    delete graph.links[target.inputs[inIdx].link];
+    graph._links.delete(target.inputs[inIdx].link);
     target.inputs[inIdx].link = null;
     throw new Error(SLOTS_THROW);
   };
@@ -397,7 +449,7 @@ test("#1272 node→node: a link that PRE-DATED the call is never credited to it"
     ],
     [],
   );
-  graph.links[7] = { id: 7, origin_id: 140, origin_slot: 0, target_id: 143, target_slot: 1 };
+  graph._links.set(7, { id: 7, origin_id: 140, origin_slot: 0, target_id: 143, target_slot: 1 });
   graph.lastLinkId = 7;
   src.connect = () => {
     throw new Error(SLOTS_THROW);
@@ -697,8 +749,9 @@ test("findLandedInboundLink: requires the input's OWN back-reference, not just a
   const orphaned = { id: 2, inputs: [{ name: "a", link: null }] };
   assert.equal(findLandedInboundLink(graph, { id: 1 }, 0, orphaned, []), null);
   const wired = { id: 2, inputs: [{ name: "a", link: 5 }] };
+  // The id comes back RAW — a stringified id fed back to the store would miss.
   assert.deepEqual(findLandedInboundLink(graph, { id: 1 }, 0, wired, []), {
-    linkId: "5",
+    linkId: 5,
     inputIndex: 0,
   });
 });
@@ -724,8 +777,12 @@ test("findLandedRailLink: excluded (pre-existing) ids are never credited to this
   };
   const rail = { linkIds: [4] };
   const node = { id: 9 };
-  assert.deepEqual(findLandedRailLink(graph, rail, node, 0, "output", null), { linkId: "4" });
+  assert.deepEqual(findLandedRailLink(graph, rail, node, 0, "output", null), { linkId: 4 });
+  // Exclusion is by STRING — the one place an id may be stringified — so a numeric
+  // id and its string form must both suppress it.
   assert.equal(findLandedRailLink(graph, rail, node, 0, "output", ["4"]), null);
+  assert.equal(findLandedRailLink(graph, rail, node, 0, "output", [4]), null);
+  assert.equal(findLandedRailLink(graph, rail, node, 0, "output", linkIdExclusionSet([4])), null);
 });
 
 test("isRailLinkPersisted: the rail slot must list THAT id and the link must join the node", () => {
@@ -737,4 +794,170 @@ test("isRailLinkPersisted: the rail slot must list THAT id and the link must joi
   assert.equal(isRailLinkPersisted(graph, { linkIds: [] }, node, 0, "output", { id: 4 }), false);
   assert.equal(isRailLinkPersisted(graph, { linkIds: [4] }, node, 1, "output", { id: 4 }), false);
   assert.equal(isRailLinkPersisted(graph, { linkIds: [4] }, { id: 8 }, 0, "output", { id: 4 }), false);
+});
+
+// ---------------------------------------------------------------------------
+// The raw-id contract, and the happy paths a stringified id destroyed.
+//
+// A first version of the rail helper normalised every link id to a string before
+// reading the store. Against the plain-object fixture that used to live above,
+// `links["7"]` and `links[7]` are the same key, so every test passed. Against the
+// real number-keyed Map the lookup MISSES, `findLandedRailLink` returns null for a
+// fully persisted link, and because it is the ONLY verdict on both expose paths,
+// panel_expose_subgraph_output / _input tore down the slot and link they had just
+// correctly created — on the happy path, every time.
+// ---------------------------------------------------------------------------
+
+test("readStoredLink: the store is number-keyed — a raw id resolves, a stringified one does NOT", () => {
+  const graph = mkGraph({ subgraph: true });
+  const link = { id: 7, origin_id: 1, origin_slot: 0, target_id: -20, target_slot: 0 };
+  graph._links.set(7, link);
+
+  // This asymmetry is the CONTRACT, not a defect: `links.get` is the raw bound
+  // Map.get and `getLink` is `_links.get`, so both miss "7". Callers must pass the
+  // id exactly as the slot holds it.
+  assert.equal(readStoredLink(graph, 7), link);
+  assert.equal(readStoredLink(graph, "7"), null);
+  // Record-shaped stores (older LiteGraph builds) still resolve by raw id.
+  assert.equal(readStoredLink({ links: { 7: link } }, 7), link);
+});
+
+test("findLandedRailLink: a persisted rail link is FOUND on the real number-keyed store", () => {
+  const graph = mkGraph({ subgraph: true });
+  const node = mkNode(graph, 12, [], [{ name: "IMAGE", type: "IMAGE", links: [] }]);
+  const rail = mkRailOutput(graph, "image", "IMAGE");
+  graph.outputs.push(rail);
+  rail.connect(node.outputs[0], node);
+  assert.equal(graph._links.size, 1);
+  assert.deepEqual(findLandedRailLink(graph, rail, node, 0, "output", null), { linkId: 1 });
+});
+
+test("#1272 expose output: a CLEAN, non-throwing expose keeps its slot and its link", () => {
+  const graph = mkGraph({ subgraph: true });
+  mkNode(graph, 12, [], [{ name: "IMAGE", type: "IMAGE", links: [] }]);
+  const executors = buildExecutors(graph);
+
+  const res = executors.graph_expose_subgraph_output({ from_node_id: 12, from_output: "IMAGE" });
+
+  assert.equal(res.exposed.name, "IMAGE");
+  assert.equal(res.exposed.slot, 0);
+  assert.equal(res.warning, undefined, "a successful expose discloses nothing");
+  assert.equal(graph.outputs.length, 1, "the slot this call created SURVIVES");
+  assert.equal(graph.outputs[0].linkIds.length, 1);
+  assert.equal(graph._links.size, 1, "and no link is orphaned");
+});
+
+test("#1272 expose input: a CLEAN, non-throwing expose keeps its slot and its link", () => {
+  const graph = mkGraph({ subgraph: true });
+  const node = mkNode(graph, 12, [{ name: "image", type: "IMAGE", link: null }], []);
+  const executors = buildExecutors(graph);
+
+  const res = executors.graph_expose_subgraph_input({ to_node_id: 12, to_input: "image" });
+
+  assert.equal(res.exposed.name, "image");
+  assert.equal(res.warning, undefined);
+  assert.equal(graph.inputs.length, 1, "the slot this call created SURVIVES");
+  assert.equal(graph.inputs[0].linkIds.length, 1);
+  assert.equal(node.inputs[0].link, graph.inputs[0].linkIds[0]);
+  assert.equal(graph._links.size, 1);
+});
+
+test("#1272 repro 2 end-to-end: connect to the output rail (to_node_id -20) that throws AFTER wiring", () => {
+  // The issue's second reproduction, verbatim: inside a subgraph, connect an
+  // ImpactSwitch output to the subgraph output rail. SubgraphOutput.connect
+  // persists the link, then node.onConnectionsChange throws.
+  const graph = mkGraph({ subgraph: true });
+  const impact = mkNode(graph, 143, [], [{ name: "selected_value", type: "IMAGE", links: [] }]);
+  const rail = mkRailOutput(graph, "image", "IMAGE");
+  graph.outputs.push(rail);
+  rail.afterWrite = () => {
+    throw new Error(SLOTS_THROW);
+  };
+  const executors = buildExecutors(graph);
+
+  const res = executors.graph_connect({
+    from_node_id: 143,
+    from_output: "selected_value",
+    to_node_id: -20,
+    to_input: "image",
+  });
+
+  assert.equal(res.connected.from.node_id, 143);
+  assert.equal(res.connected.to.subgraph_output, "image");
+  // panel_graph_outline would show `143 → -20.0`, exactly as the reporter saw.
+  assert.equal(rail.linkIds.length, 1);
+  assert.equal(graph._links.get(rail.linkIds[0]).origin_id, 143);
+  assert.equal(impact.outputs[0].links.length, 1);
+  assert.match(res.warning, /reading 'slots'/);
+  assert.match(res.warning, /Do NOT retry/);
+});
+
+test("#1272 expose output: cleanup is claimed only when the slot ACTUALLY went away", () => {
+  // LGraph.removeOutput dispatches a CANCELABLE "removing-output" event and
+  // returns without removing when a listener cancels it. A clean return is not a
+  // removal, so the message must not claim one.
+  const graph = mkGraph({ subgraph: true });
+  mkNode(graph, 12, [], [{ name: "IMAGE", type: "IMAGE", links: [] }]);
+  const nativeAddOutput = graph.addOutput.bind(graph);
+  graph.addOutput = (name, type) => {
+    const slot = nativeAddOutput(name, type);
+    slot.connect = () => {
+      throw new Error(SLOTS_THROW);
+    };
+    return slot;
+  };
+  graph.removeOutput = () => {
+    /* a listener cancelled the removal — returns cleanly, removes nothing */
+  };
+  const executors = buildExecutors(graph);
+  assert.throws(
+    () => executors.graph_expose_subgraph_output({ from_node_id: 12, from_output: "IMAGE" }),
+    (err) => {
+      assert.match(err.message, /the frontend threw/);
+      assert.doesNotMatch(err.message, /was removed/);
+      return true;
+    },
+  );
+  assert.equal(graph.outputs.length, 1, "the slot really is still there");
+});
+
+test("#1272 node→node: replaced_link is withheld when the original wire is still on the input", () => {
+  const graph = mkGraph();
+  const src = mkNode(graph, 140, [], [{ name: "IMAGE", type: "IMAGE", links: [] }]);
+  const dst = mkNode(
+    graph,
+    143,
+    [
+      { name: "input1", type: "IMAGE", link: 7 },
+      { name: "input2", type: "IMAGE", link: null },
+    ],
+    [],
+  );
+  graph._links.set(7, { id: 7, origin_id: 100, origin_slot: 0, target_id: 143, target_slot: 0 });
+  mkNode(graph, 100, [], [{ name: "IMAGE", type: "IMAGE", links: [7] }]);
+  graph.lastLinkId = 7;
+  // The node re-slots the NEW link onto input2 and leaves input1's wire alone,
+  // then throws — so nothing was replaced.
+  src.connect = (outIdx, target) => {
+    const id = ++graph.lastLinkId;
+    graph._links.set(id, {
+      id,
+      origin_id: 140,
+      origin_slot: outIdx,
+      target_id: target.id,
+      target_slot: 1,
+    });
+    target.inputs[1].link = id;
+    throw new Error(SLOTS_THROW);
+  };
+  const executors = buildExecutors(graph);
+  const res = executors.graph_connect({
+    from_node_id: 140,
+    from_output: "IMAGE",
+    to_node_id: 143,
+    to_input: "input1",
+  });
+  assert.equal(res.connected.to.input, "input2");
+  assert.equal(res.connected.replaced_link, undefined, "input1's wire was never displaced");
+  assert.equal(dst.inputs[0].link, 7);
 });

--- a/browser_tests/unit/connect-throw-verdict.test.mjs
+++ b/browser_tests/unit/connect-throw-verdict.test.mjs
@@ -1,0 +1,740 @@
+/**
+ * #1272 — `panel_connect` threw "Cannot read properties of undefined (reading
+ * 'slots')" while the link WAS created. Reproduced twice inside a subgraph: once
+ * onto an ImpactSwitch input that the node materialises on connect, once onto the
+ * subgraph OUTPUT rail (`to_node_id: -20`). Both times `panel_query_graph` /
+ * `panel_graph_outline` showed the wire afterwards.
+ *
+ * MECHANISM (read from ComfyUI_frontend 1.47.2, not inferred): every connect path
+ * writes the link and only THEN runs the node hooks.
+ *
+ *   LGraphNode.connectSlots  — graph._links.set / output.links.push /
+ *     targetInput.link = link.id  … then  graph.trigger("node:slot-links:changed"),
+ *     this.onConnectionsChange(), inputNode.onConnectionsChange()
+ *   SubgraphOutput.connect / SubgraphInput.connect — subgraph._links.set /
+ *     linkIds / slot.link  … then  node.onConnectionsChange()
+ *
+ * So a throw from a hook carries NO information about whether the wire exists, and
+ * the panel's `try { … } finally { … }` (no catch) turned "threw but landed" and
+ * "threw and nothing landed" into one indistinguishable failure. An agent that
+ * trusts it retries, and the retry duplicates or tears down correct wiring.
+ *
+ * These tests run the REAL shipped executors, extracted from
+ * web/js/comfyui-mcp-panel.js and given LiteGraph-shaped doubles, with the REAL
+ * verification helpers injected — so deleting the fix from the panel source (not
+ * merely from the helper module) fails them. The helper-only variant of this test
+ * stayed green against the unfixed call site, which is the defect this file exists
+ * to avoid.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import {
+  isLinkPersisted,
+  removePhantomLink,
+  isWidgetBackedInput,
+  inputLinkIds,
+  railSlotLinkIds,
+  findLandedInboundLink,
+  findLandedRailLink,
+  isRailLinkPersisted,
+  landedAfterThrowWarning,
+  readStoredLink,
+} from "../../web/js/lib/connect-verify.js";
+import { findExistingRailSlot } from "../../web/js/lib/rail-slot.js";
+
+const panelPath = fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url));
+const panelSrc = readFileSync(panelPath, "utf8").replace(/\r\n/g, "\n");
+
+/** The method source between its signature line and the first `  },` line. */
+function sliceMethod(signature) {
+  const lines = panelSrc.split("\n");
+  const start = lines.findIndex((l) => l === signature);
+  assert.ok(start >= 0, `could not locate "${signature}" in the panel source`);
+  const end = lines.findIndex((l, i) => i > start && l === "  },");
+  assert.ok(end > start, `could not locate the end of "${signature}"`);
+  return lines.slice(start, end + 1).join("\n");
+}
+
+const connectSrc = sliceMethod(
+  "  graph_connect({ from_node_id, from_output, to_node_id, to_input, auto_match }) {",
+);
+const exposeOutSrc = sliceMethod("  graph_expose_subgraph_output({ from_node_id, from_output, name }) {");
+const exposeInSrc = sliceMethod("  graph_expose_subgraph_input({ to_node_id, to_input, name }) {");
+
+// ---------------------------------------------------------------------------
+// Doubles for everything AROUND the code under test. The verification helpers
+// are the REAL modules — a stub there would let the extracted method pass
+// against a checker that always said "landed" (#1425's lesson).
+// ---------------------------------------------------------------------------
+
+function resolveNode(graph, id) {
+  const n = graph.getNodeById(id);
+  if (!n) throw new Error(`No node with id ${id}`);
+  return n;
+}
+
+function resolveSlot(slots, ref, kind) {
+  const list = slots ?? [];
+  if (typeof ref === "number") {
+    if (ref < 0 || ref >= list.length) throw new Error(`no ${kind} slot ${ref}`);
+    return ref;
+  }
+  const i = list.findIndex((s) => s?.name === ref);
+  if (i === -1) throw new Error(`no ${kind} named ${ref}`);
+  return i;
+}
+
+const railIntent = (ref) =>
+  ref === -10 || ref === -20 || ref === "input" || ref === "output" ? String(ref) : null;
+
+function resolveRail(graph, ref) {
+  if (ref === -20 || ref === "output") return graph.outputNode ? { rail: "output" } : null;
+  if (ref === -10 || ref === "input") return graph.inputNode ? { rail: "input" } : null;
+  return null;
+}
+
+const isEmptyRailSlotRef = (ref) => ref == null || ref === "";
+
+function autoMatchSlots(origin, target, from_output, to_input) {
+  return {
+    outIdx: resolveSlot(origin.outputs, from_output ?? 0, "output"),
+    inIdx: resolveSlot(target.inputs, to_input ?? 0, "input"),
+    autoMatched: [],
+  };
+}
+
+const slotDiagnostic = () => "slot diagnostic";
+const loopbackRefusalReason = () => "loopback";
+const findSubgraphHostNode = () => null;
+const uniqueSubgraphOutputName = (_g, base) => base;
+const uniqueSubgraphInputName = (_g, base) => base;
+
+function buildExecutors(graph, canvas = {}) {
+  const factory = new Function(
+    "getGraphCtx",
+    "resolveNode",
+    "resolveSlot",
+    "resolveRail",
+    "railIntent",
+    "isEmptyRailSlotRef",
+    "findExistingRailSlot",
+    "findSubgraphHostNode",
+    "autoMatchSlots",
+    "slotDiagnostic",
+    "loopbackRefusalReason",
+    "uniqueSubgraphOutputName",
+    "uniqueSubgraphInputName",
+    "isLinkPersisted",
+    "removePhantomLink",
+    "isWidgetBackedInput",
+    "inputLinkIds",
+    "railSlotLinkIds",
+    "findLandedInboundLink",
+    "findLandedRailLink",
+    "isRailLinkPersisted",
+    "landedAfterThrowWarning",
+    `const GRAPH_TOOL_EXECUTORS = {
+${connectSrc}
+${exposeOutSrc}
+${exposeInSrc}
+};
+return GRAPH_TOOL_EXECUTORS;`,
+  );
+  return factory(
+    () => ({ graph, canvas, app: {}, rootGraph: graph, LG: {} }),
+    resolveNode,
+    resolveSlot,
+    resolveRail,
+    railIntent,
+    isEmptyRailSlotRef,
+    findExistingRailSlot,
+    findSubgraphHostNode,
+    autoMatchSlots,
+    slotDiagnostic,
+    loopbackRefusalReason,
+    uniqueSubgraphOutputName,
+    uniqueSubgraphInputName,
+    isLinkPersisted,
+    removePhantomLink,
+    isWidgetBackedInput,
+    inputLinkIds,
+    railSlotLinkIds,
+    findLandedInboundLink,
+    findLandedRailLink,
+    isRailLinkPersisted,
+    landedAfterThrowWarning,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// LiteGraph-shaped doubles
+// ---------------------------------------------------------------------------
+
+function mkGraph({ subgraph = false } = {}) {
+  const graph = {
+    lastLinkId: 0,
+    links: {},
+    nodes: [],
+    outputs: [],
+    inputs: [],
+    ...(subgraph ? { outputNode: { id: -20 }, inputNode: { id: -10 } } : {}),
+    getNodeById: (id) => graph.nodes.find((n) => String(n.id) === String(id)) ?? null,
+    beforeChange() {},
+    afterChange() {},
+    setDirtyCanvas() {},
+    addOutput(name, type) {
+      const slot = mkRailOutput(graph, name, type);
+      graph.outputs.push(slot);
+      return slot;
+    },
+    removeOutput(slot) {
+      const i = graph.outputs.indexOf(slot);
+      if (i >= 0) graph.outputs.splice(i, 1);
+    },
+    addInput(name, type) {
+      const slot = mkRailInput(graph, name, type);
+      graph.inputs.push(slot);
+      return slot;
+    },
+    removeInput(slot) {
+      const i = graph.inputs.indexOf(slot);
+      if (i >= 0) graph.inputs.splice(i, 1);
+    },
+    getLink: (id) => graph.links[id] ?? null,
+  };
+  return graph;
+}
+
+function mkNode(graph, id, inputs, outputs) {
+  const node = { id, inputs, outputs, graph };
+  graph.nodes.push(node);
+  return node;
+}
+
+/**
+ * The origin node's connect(), mirroring connectSlots' ORDER: write the link,
+ * then run `afterWrite` — the position LiteGraph calls onConnectionsChange from.
+ */
+function attachConnect(node, afterWrite) {
+  node.connect = (outIdx, target, inIdx) => {
+    const graph = node.graph;
+    // LiteGraph drops the wire already on the input before making the new one.
+    const prior = target.inputs[inIdx]?.link;
+    if (prior != null) {
+      delete graph.links[prior];
+      target.inputs[inIdx].link = null;
+    }
+    const id = ++graph.lastLinkId;
+    const link = {
+      id,
+      origin_id: node.id,
+      origin_slot: outIdx,
+      target_id: target.id,
+      target_slot: inIdx,
+    };
+    graph.links[id] = link;
+    (node.outputs[outIdx].links ??= []).push(id);
+    target.inputs[inIdx].link = id;
+    afterWrite?.({ link, target, inIdx, graph });
+    return link;
+  };
+}
+
+function mkRailOutput(graph, name, type) {
+  const slot = { name, type, linkIds: [] };
+  slot.connect = (outputSlot, node) => {
+    const outIdx = node.outputs.indexOf(outputSlot);
+    const id = ++graph.lastLinkId;
+    const link = { id, origin_id: node.id, origin_slot: outIdx, target_id: -20, target_slot: 0 };
+    graph.links[id] = link;
+    slot.linkIds[0] = id;
+    (outputSlot.links ??= []).push(id);
+    slot.afterWrite?.({ link, graph });
+    return link;
+  };
+  return slot;
+}
+
+function mkRailInput(graph, name, type) {
+  const slot = { name, type, linkIds: [] };
+  slot.connect = (inputSlot, node) => {
+    const inIdx = node.inputs.indexOf(inputSlot);
+    const id = ++graph.lastLinkId;
+    const link = { id, origin_id: -10, origin_slot: 0, target_id: node.id, target_slot: inIdx };
+    graph.links[id] = link;
+    slot.linkIds.push(id);
+    inputSlot.link = id;
+    slot.afterWrite?.({ link, graph });
+    return link;
+  };
+  return slot;
+}
+
+const SLOTS_THROW = "Cannot read properties of undefined (reading 'slots')";
+
+const readStoredLinkId = (graph, id) => readStoredLink(graph, id)?.id ?? null;
+
+// ---------------------------------------------------------------------------
+// node → node (repro 1: ImpactSwitch's dynamic input)
+// ---------------------------------------------------------------------------
+
+function nodeToNodeFixture(afterWrite) {
+  const graph = mkGraph();
+  const src = mkNode(graph, 140, [], [{ name: "IMAGE", type: "IMAGE", links: [] }]);
+  const dst = mkNode(graph, 143, [{ name: "input1", type: "IMAGE", link: null }], []);
+  attachConnect(src, afterWrite);
+  return { graph, src, dst, executors: buildExecutors(graph) };
+}
+
+test("#1272 node→node: a hook that throws AFTER the link is written reports CONNECTED", () => {
+  const { graph, dst, executors } = nodeToNodeFixture(() => {
+    throw new Error(SLOTS_THROW);
+  });
+  const res = executors.graph_connect({
+    from_node_id: 140,
+    from_output: "IMAGE",
+    to_node_id: 143,
+    to_input: "input1",
+  });
+  assert.equal(res.connected.from.node_id, 140);
+  assert.equal(res.connected.to.node_id, 143);
+  assert.equal(res.connected.to.input, "input1");
+  assert.equal(res.connected.to.input_index, 0);
+  // The verdict came from the live graph, not from the return value.
+  assert.equal(dst.inputs[0].link, graph.links[1].id);
+  // The throw is disclosed, never swallowed, and the retry is named as harmful.
+  assert.match(res.warning, /threw while applying this connect/);
+  assert.match(res.warning, /reading 'slots'/);
+  assert.match(res.warning, /Do NOT retry/);
+});
+
+test("#1272 node→node: a throw that leaves NOTHING on the graph still FAILS", () => {
+  const { graph, src, executors } = nodeToNodeFixture();
+  src.connect = () => {
+    throw new Error(SLOTS_THROW);
+  };
+  assert.throws(
+    () =>
+      executors.graph_connect({
+        from_node_id: 140,
+        from_output: "IMAGE",
+        to_node_id: 143,
+        to_input: "input1",
+      }),
+    (err) => {
+      assert.match(err.message, /threw and NOTHING landed/);
+      assert.match(err.message, /reading 'slots'/);
+      assert.match(err.message, /no link from that output reaches node 143/);
+      return true;
+    },
+  );
+  assert.deepEqual(Object.keys(graph.links), []);
+});
+
+test("#1272 node→node: a throw AFTER the node re-slotted the link names the slot it landed on", () => {
+  const { dst, executors } = nodeToNodeFixture(({ link, target, inIdx }) => {
+    // ImpactSwitch materialises input2 and moves the wire onto it, then throws.
+    target.inputs[inIdx].link = null;
+    target.inputs.push({ name: "input2", type: "IMAGE", link: link.id });
+    link.target_slot = target.inputs.length - 1;
+    throw new Error(SLOTS_THROW);
+  });
+  const res = executors.graph_connect({
+    from_node_id: 140,
+    from_output: "IMAGE",
+    to_node_id: 143,
+    to_input: "input1",
+  });
+  assert.equal(res.connected.to.input, "input2");
+  assert.equal(res.connected.to.input_index, 1);
+  // The reported slot is the one the live graph actually wired, not the requested one.
+  assert.equal(dst.inputs[0].link, null);
+  assert.notEqual(dst.inputs[1].link, null);
+  assert.match(res.warning, /re-slotted/);
+});
+
+test("#1272 node→node: a throw that DESTROYED the previous wire says the input is now empty", () => {
+  const graph = mkGraph();
+  const old = mkNode(graph, 100, [], [{ name: "IMAGE", type: "IMAGE", links: [7] }]);
+  const src = mkNode(graph, 140, [], [{ name: "IMAGE", type: "IMAGE", links: [] }]);
+  const dst = mkNode(graph, 143, [{ name: "input1", type: "IMAGE", link: 7 }], []);
+  graph.links[7] = { id: 7, origin_id: 100, origin_slot: 0, target_id: 143, target_slot: 0 };
+  graph.lastLinkId = 7;
+  void old;
+  // The replacement disconnect throws: old wire gone, new one never made.
+  src.connect = (_outIdx, target, inIdx) => {
+    delete graph.links[target.inputs[inIdx].link];
+    target.inputs[inIdx].link = null;
+    throw new Error(SLOTS_THROW);
+  };
+  const executors = buildExecutors(graph);
+  assert.throws(
+    () =>
+      executors.graph_connect({
+        from_node_id: 140,
+        from_output: "IMAGE",
+        to_node_id: 143,
+        to_input: "input1",
+      }),
+    /is GONE — the input is now EMPTY/,
+  );
+  assert.equal(dst.inputs[0].link, null);
+});
+
+test("#1272 node→node: a link that PRE-DATED the call is never credited to it", () => {
+  const graph = mkGraph();
+  const src = mkNode(graph, 140, [], [{ name: "IMAGE", type: "IMAGE", links: [7] }]);
+  // The wire from 140 is already on a DIFFERENT input; the requested one is empty.
+  const dst = mkNode(
+    graph,
+    143,
+    [
+      { name: "input1", type: "IMAGE", link: null },
+      { name: "input2", type: "IMAGE", link: 7 },
+    ],
+    [],
+  );
+  graph.links[7] = { id: 7, origin_id: 140, origin_slot: 0, target_id: 143, target_slot: 1 };
+  graph.lastLinkId = 7;
+  src.connect = () => {
+    throw new Error(SLOTS_THROW);
+  };
+  const executors = buildExecutors(graph);
+  assert.throws(
+    () =>
+      executors.graph_connect({
+        from_node_id: 140,
+        from_output: "IMAGE",
+        to_node_id: 143,
+        to_input: "input1",
+      }),
+    /threw and NOTHING landed/,
+  );
+  assert.equal(dst.inputs[1].link, 7, "the pre-existing wire is left untouched");
+});
+
+test("#1272 node→node: the clean path is unchanged — no warning, #397 refusal intact", () => {
+  const clean = nodeToNodeFixture();
+  const ok = clean.executors.graph_connect({
+    from_node_id: 140,
+    from_output: "IMAGE",
+    to_node_id: 143,
+    to_input: "input1",
+  });
+  assert.equal(ok.connected.to.input, "input1");
+  assert.equal(ok.warning, undefined);
+
+  // #397: a truthy return that does not persist is still an honest failure.
+  const phantom = nodeToNodeFixture(({ target, inIdx }) => {
+    target.inputs[inIdx].link = null;
+  });
+  assert.throws(
+    () =>
+      phantom.executors.graph_connect({
+        from_node_id: 140,
+        from_output: "IMAGE",
+        to_node_id: 143,
+        to_input: "input1",
+      }),
+    /reported no persisted link/,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// OUTPUT rail (repro 2: to_node_id -20)
+// ---------------------------------------------------------------------------
+
+function outputRailFixture() {
+  const graph = mkGraph({ subgraph: true });
+  const src = mkNode(graph, 143, [], [{ name: "selected_value", type: "IMAGE", links: [] }]);
+  const rail = mkRailOutput(graph, "image", "IMAGE");
+  graph.outputs.push(rail);
+  return { graph, src, rail, executors: buildExecutors(graph) };
+}
+
+test("#1272 output rail: connect throws after wiring the rail → CONNECTED with disclosure", () => {
+  const { rail, executors } = outputRailFixture();
+  rail.afterWrite = () => {
+    throw new Error(SLOTS_THROW);
+  };
+  const res = executors.graph_connect({
+    from_node_id: 143,
+    from_output: "selected_value",
+    to_node_id: -20,
+    to_input: "image",
+  });
+  assert.equal(res.connected.to.subgraph_output, "image");
+  assert.equal(rail.linkIds.length, 1);
+  assert.match(res.warning, /reading 'slots'/);
+  assert.match(res.warning, /Do NOT retry/);
+});
+
+test("#1272 output rail: connect throws and the rail is EMPTY → honest failure", () => {
+  const { rail, executors } = outputRailFixture();
+  rail.connect = () => {
+    throw new Error(SLOTS_THROW);
+  };
+  assert.throws(
+    () =>
+      executors.graph_connect({
+        from_node_id: 143,
+        from_output: "selected_value",
+        to_node_id: -20,
+        to_input: "image",
+      }),
+    /threw and NOTHING landed[\s\S]*rail slot carries no link/,
+  );
+  assert.equal(rail.linkIds.length, 0);
+});
+
+test("#397 output rail: a truthy return with NO persisted link is refused (per-call-site gap)", () => {
+  const { rail, executors } = outputRailFixture();
+  // The pre-fix behaviour of this branch: report success on the return value alone.
+  rail.connect = () => ({ id: 999 });
+  assert.throws(
+    () =>
+      executors.graph_connect({
+        from_node_id: 143,
+        from_output: "selected_value",
+        to_node_id: -20,
+        to_input: "image",
+      }),
+    /reported no persisted link[\s\S]*#397/,
+  );
+});
+
+test("#1272 output rail: the clean path still reports connected with no warning", () => {
+  const { executors, rail } = outputRailFixture();
+  const res = executors.graph_connect({
+    from_node_id: 143,
+    from_output: "selected_value",
+    to_node_id: -20,
+    to_input: "image",
+  });
+  assert.equal(res.connected.to.subgraph_output, "image");
+  assert.equal(res.warning, undefined);
+  assert.equal(rail.linkIds.length, 1);
+});
+
+// ---------------------------------------------------------------------------
+// INPUT rail
+// ---------------------------------------------------------------------------
+
+function inputRailFixture() {
+  const graph = mkGraph({ subgraph: true });
+  const dst = mkNode(graph, 143, [{ name: "image", type: "IMAGE", link: null }], []);
+  const rail = mkRailInput(graph, "image", "IMAGE");
+  graph.inputs.push(rail);
+  return { graph, dst, rail, executors: buildExecutors(graph) };
+}
+
+test("#1272 input rail: connect throws after wiring → CONNECTED with disclosure", () => {
+  const { rail, dst, executors } = inputRailFixture();
+  rail.afterWrite = () => {
+    throw new Error(SLOTS_THROW);
+  };
+  const res = executors.graph_connect({
+    from_node_id: -10,
+    from_output: "image",
+    to_node_id: 143,
+    to_input: "image",
+  });
+  assert.equal(res.connected.from.subgraph_input, "image");
+  assert.equal(dst.inputs[0].link, rail.linkIds[0]);
+  assert.match(res.warning, /reading 'slots'/);
+});
+
+test("#397 input rail: a truthy return with NO persisted link is refused", () => {
+  const { executors, rail } = inputRailFixture();
+  rail.connect = () => ({ id: 999 });
+  assert.throws(
+    () =>
+      executors.graph_connect({
+        from_node_id: -10,
+        from_output: "image",
+        to_node_id: 143,
+        to_input: "image",
+      }),
+    /reported no persisted link[\s\S]*#397/,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// graph_expose_subgraph_output / _input — the addOutput/addInput leak
+// ---------------------------------------------------------------------------
+
+test("#1272 expose output: a throwing connect no longer STRANDS the slot addOutput created", () => {
+  const graph = mkGraph({ subgraph: true });
+  const src = mkNode(graph, 143, [], [{ name: "selected_value", type: "IMAGE", links: [] }]);
+  void src;
+  const nativeAddOutput = graph.addOutput.bind(graph);
+  graph.addOutput = (name, type) => {
+    const slot = nativeAddOutput(name, type);
+    slot.connect = () => {
+      throw new Error(SLOTS_THROW);
+    };
+    return slot;
+  };
+  const executors = buildExecutors(graph);
+  assert.throws(
+    () =>
+      executors.graph_expose_subgraph_output({
+        from_node_id: 143,
+        from_output: "selected_value",
+        name: "image",
+      }),
+    /the frontend threw[\s\S]*was removed, so the rail is unchanged/,
+  );
+  assert.deepEqual(graph.outputs, [], "no junk boundary output is left on the rail");
+});
+
+test("#1272 expose output: a throw AFTER the rail was wired reports EXPOSED, keeping the slot", () => {
+  const graph = mkGraph({ subgraph: true });
+  mkNode(graph, 143, [], [{ name: "selected_value", type: "IMAGE", links: [] }]);
+  const nativeAddOutput = graph.addOutput.bind(graph);
+  graph.addOutput = (name, type) => {
+    const slot = nativeAddOutput(name, type);
+    slot.afterWrite = () => {
+      throw new Error(SLOTS_THROW);
+    };
+    return slot;
+  };
+  const executors = buildExecutors(graph);
+  const res = executors.graph_expose_subgraph_output({
+    from_node_id: 143,
+    from_output: "selected_value",
+    name: "image",
+  });
+  assert.equal(res.exposed.name, "image");
+  assert.equal(graph.outputs.length, 1);
+  assert.equal(graph.outputs[0].linkIds.length, 1);
+  assert.match(res.warning, /reading 'slots'/);
+});
+
+test("#1272 expose output: a falsy connect still removes the slot (pre-existing behaviour kept)", () => {
+  const graph = mkGraph({ subgraph: true });
+  mkNode(graph, 143, [], [{ name: "selected_value", type: "IMAGE", links: [] }]);
+  const nativeAddOutput = graph.addOutput.bind(graph);
+  graph.addOutput = (name, type) => {
+    const slot = nativeAddOutput(name, type);
+    slot.connect = () => null;
+    return slot;
+  };
+  const executors = buildExecutors(graph);
+  assert.throws(
+    () =>
+      executors.graph_expose_subgraph_output({
+        from_node_id: 143,
+        from_output: "selected_value",
+        name: "image",
+      }),
+    /Could not link node 143 output/,
+  );
+  assert.deepEqual(graph.outputs, []);
+});
+
+test("#1272 expose input: a throwing connect no longer STRANDS the slot addInput created", () => {
+  const graph = mkGraph({ subgraph: true });
+  mkNode(graph, 143, [{ name: "image", type: "IMAGE", link: null }], []);
+  const nativeAddInput = graph.addInput.bind(graph);
+  graph.addInput = (name, type) => {
+    const slot = nativeAddInput(name, type);
+    slot.connect = () => {
+      throw new Error(SLOTS_THROW);
+    };
+    return slot;
+  };
+  const executors = buildExecutors(graph);
+  assert.throws(
+    () =>
+      executors.graph_expose_subgraph_input({
+        to_node_id: 143,
+        to_input: "image",
+        name: "image",
+      }),
+    /the frontend threw[\s\S]*was removed, so the rail is unchanged/,
+  );
+  assert.deepEqual(graph.inputs, []);
+});
+
+test("#1272 expose input: a throw AFTER the rail was wired reports EXPOSED, keeping the slot", () => {
+  const graph = mkGraph({ subgraph: true });
+  mkNode(graph, 143, [{ name: "image", type: "IMAGE", link: null }], []);
+  const nativeAddInput = graph.addInput.bind(graph);
+  graph.addInput = (name, type) => {
+    const slot = nativeAddInput(name, type);
+    slot.afterWrite = () => {
+      throw new Error(SLOTS_THROW);
+    };
+    return slot;
+  };
+  const executors = buildExecutors(graph);
+  const res = executors.graph_expose_subgraph_input({
+    to_node_id: 143,
+    to_input: "image",
+    name: "image",
+  });
+  assert.equal(res.exposed.name, "image");
+  assert.equal(graph.inputs.length, 1);
+  assert.match(res.warning, /reading 'slots'/);
+});
+
+// ---------------------------------------------------------------------------
+// helper-level properties the call sites rely on
+// ---------------------------------------------------------------------------
+
+test("findLandedInboundLink: fails CLOSED when the store has no such link", () => {
+  const graph = { links: {} };
+  const target = { id: 2, inputs: [{ name: "a", link: 5 }] };
+  assert.equal(findLandedInboundLink(graph, { id: 1 }, 0, target, []), null);
+});
+
+test("findLandedInboundLink: requires the input's OWN back-reference, not just a stored link", () => {
+  const graph = { links: { 5: { id: 5, origin_id: 1, origin_slot: 0, target_id: 2, target_slot: 0 } } };
+  const orphaned = { id: 2, inputs: [{ name: "a", link: null }] };
+  assert.equal(findLandedInboundLink(graph, { id: 1 }, 0, orphaned, []), null);
+  const wired = { id: 2, inputs: [{ name: "a", link: 5 }] };
+  assert.deepEqual(findLandedInboundLink(graph, { id: 1 }, 0, wired, []), {
+    linkId: "5",
+    inputIndex: 0,
+  });
+});
+
+test("findLandedInboundLink: the wrong ORIGIN SLOT does not count as landed", () => {
+  const graph = { links: { 5: { id: 5, origin_id: 1, origin_slot: 1, target_id: 2, target_slot: 0 } } };
+  const target = { id: 2, inputs: [{ name: "a", link: 5 }] };
+  assert.equal(findLandedInboundLink(graph, { id: 1 }, 0, target, []), null);
+});
+
+test("readStoredLink: Map-backed stores, record stores and getLink all resolve", () => {
+  const rec = { links: { 3: { id: 3 } } };
+  assert.equal(readStoredLinkId(rec, 3), 3);
+  const map = { links: new Map([[3, { id: 3 }]]) };
+  assert.equal(readStoredLinkId(map, 3), 3);
+  const viaGetLink = { getLink: (id) => (id === 3 ? { id: 3 } : null) };
+  assert.equal(readStoredLinkId(viaGetLink, 3), 3);
+});
+
+test("findLandedRailLink: excluded (pre-existing) ids are never credited to this call", () => {
+  const graph = {
+    links: { 4: { id: 4, origin_id: 9, origin_slot: 0, target_id: -20, target_slot: 0 } },
+  };
+  const rail = { linkIds: [4] };
+  const node = { id: 9 };
+  assert.deepEqual(findLandedRailLink(graph, rail, node, 0, "output", null), { linkId: "4" });
+  assert.equal(findLandedRailLink(graph, rail, node, 0, "output", ["4"]), null);
+});
+
+test("isRailLinkPersisted: the rail slot must list THAT id and the link must join the node", () => {
+  const graph = {
+    links: { 4: { id: 4, origin_id: 9, origin_slot: 0, target_id: -20, target_slot: 0 } },
+  };
+  const node = { id: 9 };
+  assert.equal(isRailLinkPersisted(graph, { linkIds: [4] }, node, 0, "output", { id: 4 }), true);
+  assert.equal(isRailLinkPersisted(graph, { linkIds: [] }, node, 0, "output", { id: 4 }), false);
+  assert.equal(isRailLinkPersisted(graph, { linkIds: [4] }, node, 1, "output", { id: 4 }), false);
+  assert.equal(isRailLinkPersisted(graph, { linkIds: [4] }, { id: 8 }, 0, "output", { id: 4 }), false);
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -16570,15 +16570,14 @@ const GRAPH_TOOL_EXECUTORS = {
     const outputType = String(outputSlot?.type ?? "*");
     subgraph.beforeChange?.();
     let subgraphOutput;
-    let link;
     let exposeConnectErr = null;
     try {
       subgraphOutput = subgraph.addOutput(outputName, outputType);
       subgraphOutput.label = outputSlot?.label;
-      link =
-        typeof subgraphOutput.connect === "function"
-          ? subgraphOutput.connect(outputSlot, node)
-          : null;
+      // The RETURN value is deliberately not kept: it is no longer the verdict.
+      // The live rail slot is (findLandedRailLink below) — the only reading that
+      // survives a throw, where there IS no return value.
+      if (typeof subgraphOutput.connect === "function") subgraphOutput.connect(outputSlot, node);
     } catch (err) {
       // #1272 — the removeOutput cleanup used to live INSIDE this try, on the
       // `!link` branch only, so a THROW from connect() skipped it and left the
@@ -16613,8 +16612,8 @@ const GRAPH_TOOL_EXECUTORS = {
             ? ` — the frontend threw: ${exposeConnectErr?.message ?? exposeConnectErr}`
             : "") +
           (cleanedUp
-            ? `. The subgraph output slot this call created was removed, so the rail carries no ` +
-            `slot from this call.`
+            ? `. The subgraph output slot this call created was removed, so the rail carries ` +
+              `no slot from this call.`
             : `.`),
       );
     }
@@ -16671,13 +16670,12 @@ const GRAPH_TOOL_EXECUTORS = {
     const inputType = String(inputSlot?.type ?? "*");
     subgraph.beforeChange?.();
     let subgraphInput;
-    let link;
     let exposeConnectErr = null;
     try {
       subgraphInput = subgraph.addInput(inputName, inputType);
       subgraphInput.label = inputSlot?.label;
-      link =
-        typeof subgraphInput.connect === "function" ? subgraphInput.connect(inputSlot, node) : null;
+      // See the output twin: the return value is not the verdict, the rail slot is.
+      if (typeof subgraphInput.connect === "function") subgraphInput.connect(inputSlot, node);
     } catch (err) {
       // #1272 — same leak as the output twin: the removeInput cleanup was inside
       // the try on the `!link` branch, so a throw stranded the slot addInput had
@@ -16707,8 +16705,8 @@ const GRAPH_TOOL_EXECUTORS = {
             ? ` — the frontend threw: ${exposeConnectErr?.message ?? exposeConnectErr}`
             : "") +
           (cleanedUp
-            ? `. The subgraph input slot this call created was removed, so the rail carries no ` +
-            `slot from this call.`
+            ? `. The subgraph input slot this call created was removed, so the rail carries ` +
+              `no slot from this call.`
             : `.`),
       );
     }

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -391,6 +391,7 @@ import {
   isWidgetBackedInput,
   inputLinkIds,
   railSlotLinkIds,
+  linkIdExclusionSet,
   findLandedInboundLink,
   findLandedRailLink,
   isRailLinkPersisted,
@@ -12125,7 +12126,7 @@ const GRAPH_TOOL_EXECUTORS = {
       if (existing && typeof existing.connect === "function") {
         // #1272 — the rail slot's own link ids BEFORE the mutation, so a wire that
         // pre-dated this call can never be credited to it on the throw path below.
-        const railLinkIdsBefore = new Set(railSlotLinkIds(existing));
+        const railLinkIdsBefore = linkIdExclusionSet(railSlotLinkIds(existing));
         graph.beforeChange?.();
         let link;
         let railConnectErr = null;
@@ -12204,7 +12205,7 @@ const GRAPH_TOOL_EXECUTORS = {
       if (existing && typeof existing.connect === "function") {
         // #1272 — see the OUTPUT rail branch above: pre-existing rail links are
         // excluded so the throw path cannot credit this call with someone else's wire.
-        const railLinkIdsBefore = new Set(railSlotLinkIds(existing));
+        const railLinkIdsBefore = linkIdExclusionSet(railSlotLinkIds(existing));
         graph.beforeChange?.();
         let link;
         let railConnectErr = null;
@@ -12329,7 +12330,7 @@ const GRAPH_TOOL_EXECUTORS = {
     // evidence that THIS call landed; without the exclusion, "threw and did
     // nothing" and "threw after wiring it" collapse into one indistinguishable
     // answer.
-    const inboundLinkIdsBefore = new Set(inputLinkIds(target));
+    const inboundLinkIdsBefore = linkIdExclusionSet(inputLinkIds(target));
     graph.beforeChange();
     let link;
     let connectErr = null;
@@ -12397,7 +12398,13 @@ const GRAPH_TOOL_EXECUTORS = {
           },
           type: origin.outputs?.[outIdx]?.type,
           ...(autoMatched.length ? { auto_matched: autoMatched } : {}),
-          ...(replacedLink ? { replaced_link: replacedLink } : {}),
+          // `replaced_link` claims THIS connect displaced that wire. On the throw
+          // path it may not have: when the node re-slotted the new link elsewhere,
+          // the original is often still on the requested input. Report the
+          // replacement only when the live graph shows the old link is gone.
+          ...(replacedLink && target.inputs?.[inIdx]?.link !== prevLinkId
+            ? { replaced_link: replacedLink }
+            : {}),
         },
         warning: landedAfterThrowWarning(
           connectErr,
@@ -16600,10 +16607,14 @@ const GRAPH_TOOL_EXECUTORS = {
       if (subgraphOutput && typeof subgraph.removeOutput === "function") {
         try {
           subgraph.removeOutput(subgraphOutput);
-          cleanedUp = true;
         } catch {
           /* best-effort: the honest failure below is reported either way */
         }
+        // OBSERVED, not "the call returned": LGraph.removeOutput dispatches a
+        // CANCELABLE "removing-output" event and returns without removing when a
+        // listener cancels it. A clean return is not a removal, and the message
+        // below claims one.
+        cleanedUp = !(subgraph.outputs ?? []).includes(subgraphOutput);
       }
       subgraph.setDirtyCanvas?.(true, true);
       throw new Error(
@@ -16693,10 +16704,12 @@ const GRAPH_TOOL_EXECUTORS = {
       if (subgraphInput && typeof subgraph.removeInput === "function") {
         try {
           subgraph.removeInput(subgraphInput);
-          cleanedUp = true;
         } catch {
           /* best-effort: the honest failure below is reported either way */
         }
+        // See the output twin: a cancelable "removing-input" event means a clean
+        // return is not evidence of a removal.
+        cleanedUp = !(subgraph.inputs ?? []).includes(subgraphInput);
       }
       subgraph.setDirtyCanvas?.(true, true);
       throw new Error(

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -385,7 +385,17 @@ import {
   controlAfterGenerateEntries,
 } from "./lib/control-after-generate.js";
 import { autoMatchSlots, slotDiagnostic, loopbackRefusalReason } from "./lib/connect-match.js";
-import { isLinkPersisted, removePhantomLink, isWidgetBackedInput } from "./lib/connect-verify.js";
+import {
+  isLinkPersisted,
+  removePhantomLink,
+  isWidgetBackedInput,
+  inputLinkIds,
+  railSlotLinkIds,
+  findLandedInboundLink,
+  findLandedRailLink,
+  isRailLinkPersisted,
+  landedAfterThrowWarning,
+} from "./lib/connect-verify.js";
 import {
   snapshotGraphState,
   describeInputLink,
@@ -12113,26 +12123,66 @@ const GRAPH_TOOL_EXECUTORS = {
         ? null
         : findExistingRailSlot(graph.outputs, to_input);
       if (existing && typeof existing.connect === "function") {
+        // #1272 — the rail slot's own link ids BEFORE the mutation, so a wire that
+        // pre-dated this call can never be credited to it on the throw path below.
+        const railLinkIdsBefore = new Set(railSlotLinkIds(existing));
         graph.beforeChange?.();
         let link;
+        let railConnectErr = null;
         try {
           link = existing.connect(outputSlot, node);
+        } catch (err) {
+          // #1272 — SubgraphOutput.connect writes subgraph._links, the rail slot's
+          // linkIds and the node output's links, and only THEN calls
+          // node.onConnectionsChange. So a throw carries no information about
+          // whether the wire exists. This is the issue's SECOND repro
+          // (to_node_id: -20): it threw, and panel_graph_outline then showed the
+          // link. Decide on the observed post-state instead of on the exception.
+          railConnectErr = err;
         } finally {
           graph.afterChange?.();
         }
-        if (!link) {
+        graph.setDirtyCanvas?.(true, true);
+        // #397 adopted at THIS call site — it had only ever been applied to the
+        // node-to-node branch, so this branch reported success on LiteGraph's
+        // truthy return alone. Ask the live graph on BOTH paths: with the link
+        // connect() returned when there is one, by scanning the rail slot for a
+        // NEW link when it threw instead.
+        const railLanded = railConnectErr
+          ? findLandedRailLink(graph, existing, node, outIdx, "output", railLinkIdsBefore)
+          : isRailLinkPersisted(graph, existing, node, outIdx, "output", link)
+            ? { linkId: String(link.id) }
+            : null;
+        if (!railLanded) {
+          if (railConnectErr) {
+            throw new Error(
+              `panel_connect from node ${node.id} output "${outputSlot?.name ?? outIdx}" to subgraph ` +
+                `output "${existing.name}" threw and NOTHING landed (#1272): ` +
+                `${railConnectErr?.message ?? railConnectErr}. Observed post-state of the live graph: ` +
+                `the rail slot carries no link from that output. Re-read with panel_graph_outline ` +
+                `before retrying.`,
+            );
+          }
+          if (!link) {
+            throw new Error(
+              `connect refused — node ${node.id} output "${outputSlot?.name ?? outIdx}" ` +
+                `(${outputSlot?.type}) is not compatible with subgraph output "${existing.name}" (${existing.type})`,
+            );
+          }
           throw new Error(
-            `connect refused — node ${node.id} output "${outputSlot?.name ?? outIdx}" ` +
-              `(${outputSlot?.type}) is not compatible with subgraph output "${existing.name}" (${existing.type})`,
+            `panel_connect reported no persisted link: node ${node.id} output ` +
+              `"${outputSlot?.name ?? outIdx}" (${outputSlot?.type}) → subgraph output ` +
+              `"${existing.name}" (${existing.type}). LiteGraph accepted the connection but the rail ` +
+              `slot does not carry it, so refusing to report a false success (#397).`,
           );
         }
-        graph.setDirtyCanvas?.(true, true);
         findSubgraphHostNode(graph)?.invalidatePromotedViews?.();
         return {
           connected: {
             from: { node_id: node.id, output: outputSlot?.name ?? outIdx },
             to: { subgraph_output: existing.name },
           },
+          ...(railConnectErr ? { warning: landedAfterThrowWarning(railConnectErr) } : {}),
         };
       }
       return GRAPH_TOOL_EXECUTORS.graph_expose_subgraph_output({
@@ -12151,26 +12201,60 @@ const GRAPH_TOOL_EXECUTORS = {
         ? null
         : findExistingRailSlot(graph.inputs, from_output);
       if (existing && typeof existing.connect === "function") {
+        // #1272 — see the OUTPUT rail branch above: pre-existing rail links are
+        // excluded so the throw path cannot credit this call with someone else's wire.
+        const railLinkIdsBefore = new Set(railSlotLinkIds(existing));
         graph.beforeChange?.();
         let link;
+        let railConnectErr = null;
         try {
           link = existing.connect(inputSlot, node);
+        } catch (err) {
+          // #1272 — SubgraphInput.connect has the same ordering as its output
+          // twin: the link is written to subgraph._links / linkIds / slot.link
+          // before node.onConnectionsChange runs, so a throw does not mean the
+          // wire is absent.
+          railConnectErr = err;
         } finally {
           graph.afterChange?.();
         }
-        if (!link) {
+        graph.setDirtyCanvas?.(true, true);
+        // #397 adopted at THIS call site too (see the output rail above).
+        const railLanded = railConnectErr
+          ? findLandedRailLink(graph, existing, node, inIdx, "input", railLinkIdsBefore)
+          : isRailLinkPersisted(graph, existing, node, inIdx, "input", link)
+            ? { linkId: String(link.id) }
+            : null;
+        if (!railLanded) {
+          if (railConnectErr) {
+            throw new Error(
+              `panel_connect from subgraph input "${existing.name}" to node ${node.id} input ` +
+                `"${inputSlot?.name ?? inIdx}" threw and NOTHING landed (#1272): ` +
+                `${railConnectErr?.message ?? railConnectErr}. Observed post-state of the live graph: ` +
+                `the rail slot carries no link to that input. Re-read with panel_graph_outline ` +
+                `before retrying.`,
+            );
+          }
+          if (!link) {
+            throw new Error(
+              `connect refused — subgraph input "${existing.name}" (${existing.type}) is not ` +
+                `compatible with node ${node.id} input "${inputSlot?.name ?? inIdx}" (${inputSlot?.type})`,
+            );
+          }
           throw new Error(
-            `connect refused — subgraph input "${existing.name}" (${existing.type}) is not ` +
-              `compatible with node ${node.id} input "${inputSlot?.name ?? inIdx}" (${inputSlot?.type})`,
+            `panel_connect reported no persisted link: subgraph input "${existing.name}" ` +
+              `(${existing.type}) → node ${node.id} input "${inputSlot?.name ?? inIdx}" ` +
+              `(${inputSlot?.type}). LiteGraph accepted the connection but the rail slot does not ` +
+              `carry it, so refusing to report a false success (#397).`,
           );
         }
-        graph.setDirtyCanvas?.(true, true);
         findSubgraphHostNode(graph)?.invalidatePromotedViews?.();
         return {
           connected: {
             from: { subgraph_input: existing.name },
             to: { node_id: node.id, input: inputSlot?.name ?? inIdx },
           },
+          ...(railConnectErr ? { warning: landedAfterThrowWarning(railConnectErr) } : {}),
         };
       }
       return GRAPH_TOOL_EXECUTORS.graph_expose_subgraph_input({
@@ -12238,14 +12322,81 @@ const GRAPH_TOOL_EXECUTORS = {
       }
     }
 
+    // #1272 — what the target's inputs ALREADY reference, captured BEFORE the
+    // mutation. On the throw path below, a link that was there beforehand is not
+    // evidence that THIS call landed; without the exclusion, "threw and did
+    // nothing" and "threw after wiring it" collapse into one indistinguishable
+    // answer.
+    const inboundLinkIdsBefore = new Set(inputLinkIds(target));
     graph.beforeChange();
     let link;
+    let connectErr = null;
     try {
       link = origin.connect(outIdx, target, inIdx);
+    } catch (err) {
+      // #1272 — do NOT let this escape. LiteGraph's connectSlots writes
+      // graph._links, output.links and input.link and only THEN runs the nodes'
+      // onConnectionsChange hooks (ordering documented in connect-verify.js), so
+      // a hook that throws — Impact-Pack's ImpactSwitch materialising `input2`,
+      // reproduced twice inside a subgraph — leaves a FULLY PERSISTED wire and
+      // still propagates. Reporting the exception told the caller the connect
+      // failed for a link that was already on the graph, and the retry that
+      // follows duplicates or tears down correct wiring. The verdict is decided
+      // on the observed post-state below; nothing is swallowed — when nothing
+      // landed the failure is raised, louder than before.
+      connectErr = err;
     } finally {
       graph.afterChange();
     }
     graph.setDirtyCanvas(true, true);
+    if (connectErr) {
+      const landed = findLandedInboundLink(graph, origin, outIdx, target, inboundLinkIdsBefore);
+      if (!landed) {
+        // Observed, not assumed: LiteGraph drops the old wire BEFORE creating the
+        // new one, so a throw in between can leave the input empty. Say so only
+        // when the live graph actually shows it.
+        const priorWireGone = prevLinkId != null && target.inputs?.[inIdx]?.link == null;
+        throw new Error(
+          `panel_connect threw and NOTHING landed (#1272): node ${origin.id} output ` +
+            `"${origin.outputs?.[outIdx]?.name ?? outIdx}" → node ${target.id} input ` +
+            `"${target.inputs?.[inIdx]?.name ?? inIdx}" — ${connectErr?.message ?? connectErr}. ` +
+            `Observed post-state of the live graph: no link from that output reaches node ` +
+            `${target.id}` +
+            (priorWireGone
+              ? `, and the wire that was on that input before this call (from node ` +
+                `${replacedLink?.node_id ?? "?"} output "${replacedLink?.output ?? "?"}") is GONE — ` +
+                `the input is now EMPTY and must be rewired`
+              : "") +
+            `. Re-read with panel_graph_outline before retrying.`,
+        );
+      }
+      const landedSlot = target.inputs?.[landed.inputIndex];
+      return {
+        connected: {
+          from: {
+            node_id: origin.id,
+            output: origin.outputs?.[outIdx]?.name ?? outIdx,
+            output_index: outIdx,
+          },
+          to: {
+            node_id: target.id,
+            input: landedSlot?.name ?? landed.inputIndex,
+            input_index: landed.inputIndex,
+          },
+          type: origin.outputs?.[outIdx]?.type,
+          ...(autoMatched.length ? { auto_matched: autoMatched } : {}),
+          ...(replacedLink ? { replaced_link: replacedLink } : {}),
+        },
+        warning: landedAfterThrowWarning(
+          connectErr,
+          landed.inputIndex !== inIdx
+            ? `The node re-slotted it: the link landed on input ` +
+                `"${landedSlot?.name ?? landed.inputIndex}" (index ${landed.inputIndex}), not the ` +
+                `requested "${target.inputs?.[inIdx]?.name ?? inIdx}" (index ${inIdx}).`
+            : "",
+        ),
+      };
+    }
     if (!link) {
       // #1266: LiteGraph's connect() refuses a node→ITSELF link unconditionally
       // ("avoid loopback": `if (target_node == this) return null`) BEFORE any
@@ -16408,6 +16559,7 @@ const GRAPH_TOOL_EXECUTORS = {
     subgraph.beforeChange?.();
     let subgraphOutput;
     let link;
+    let exposeConnectErr = null;
     try {
       subgraphOutput = subgraph.addOutput(outputName, outputType);
       subgraphOutput.label = outputSlot?.label;
@@ -16415,14 +16567,43 @@ const GRAPH_TOOL_EXECUTORS = {
         typeof subgraphOutput.connect === "function"
           ? subgraphOutput.connect(outputSlot, node)
           : null;
-      if (!link) {
-        subgraph.removeOutput?.(subgraphOutput);
-        throw new Error(
-          `Could not link node ${node.id} output "${outputSlot?.name ?? outIdx}" (${outputType}) to a new subgraph output`,
-        );
-      }
+    } catch (err) {
+      // #1272 — the removeOutput cleanup used to live INSIDE this try, on the
+      // `!link` branch only, so a THROW from connect() skipped it and left the
+      // rail slot addOutput had just created stranded on the subgraph — a junk
+      // boundary output on every failed expose, also visible as a junk slot on
+      // the parent SubgraphNode. The throw itself is not a verdict either:
+      // SubgraphOutput.connect writes the link before it calls the node's
+      // onConnectionsChange hook, which is the issue's second repro.
+      exposeConnectErr = err;
     } finally {
       subgraph.afterChange?.();
+    }
+    // The slot was created by THIS call, so any link on it is necessarily ours —
+    // no pre-existing ids to exclude.
+    const exposeLanded = subgraphOutput
+      ? findLandedRailLink(subgraph, subgraphOutput, node, outIdx, "output", null)
+      : null;
+    if (!exposeLanded) {
+      let cleanedUp = false;
+      if (subgraphOutput && typeof subgraph.removeOutput === "function") {
+        try {
+          subgraph.removeOutput(subgraphOutput);
+          cleanedUp = true;
+        } catch {
+          /* best-effort: the honest failure below is reported either way */
+        }
+      }
+      subgraph.setDirtyCanvas?.(true, true);
+      throw new Error(
+        `Could not link node ${node.id} output "${outputSlot?.name ?? outIdx}" (${outputType}) to a new subgraph output` +
+          (exposeConnectErr
+            ? ` — the frontend threw: ${exposeConnectErr?.message ?? exposeConnectErr}`
+            : "") +
+          (cleanedUp
+            ? `. The subgraph output slot this call created was removed, so the rail is unchanged.`
+            : `.`),
+      );
     }
     findSubgraphHostNode(subgraph)?.invalidatePromotedViews?.();
     subgraph.setDirtyCanvas?.(true, true);
@@ -16435,6 +16616,7 @@ const GRAPH_TOOL_EXECUTORS = {
         on_host_subgraph_node: true,
         from: { node_id: node.id, output: outputSlot?.name ?? outIdx },
       },
+      ...(exposeConnectErr ? { warning: landedAfterThrowWarning(exposeConnectErr) } : {}),
     };
   },
 
@@ -16477,19 +16659,44 @@ const GRAPH_TOOL_EXECUTORS = {
     subgraph.beforeChange?.();
     let subgraphInput;
     let link;
+    let exposeConnectErr = null;
     try {
       subgraphInput = subgraph.addInput(inputName, inputType);
       subgraphInput.label = inputSlot?.label;
       link =
         typeof subgraphInput.connect === "function" ? subgraphInput.connect(inputSlot, node) : null;
-      if (!link) {
-        subgraph.removeInput?.(subgraphInput);
-        throw new Error(
-          `Could not link a new subgraph input to node ${node.id} input "${inputSlot?.name ?? inIdx}" (${inputType})`,
-        );
-      }
+    } catch (err) {
+      // #1272 — same leak as the output twin: the removeInput cleanup was inside
+      // the try on the `!link` branch, so a throw stranded the slot addInput had
+      // just created. And the throw is not a verdict — SubgraphInput.connect
+      // writes the link before running the node's onConnectionsChange hook.
+      exposeConnectErr = err;
     } finally {
       subgraph.afterChange?.();
+    }
+    const exposeLanded = subgraphInput
+      ? findLandedRailLink(subgraph, subgraphInput, node, inIdx, "input", null)
+      : null;
+    if (!exposeLanded) {
+      let cleanedUp = false;
+      if (subgraphInput && typeof subgraph.removeInput === "function") {
+        try {
+          subgraph.removeInput(subgraphInput);
+          cleanedUp = true;
+        } catch {
+          /* best-effort: the honest failure below is reported either way */
+        }
+      }
+      subgraph.setDirtyCanvas?.(true, true);
+      throw new Error(
+        `Could not link a new subgraph input to node ${node.id} input "${inputSlot?.name ?? inIdx}" (${inputType})` +
+          (exposeConnectErr
+            ? ` — the frontend threw: ${exposeConnectErr?.message ?? exposeConnectErr}`
+            : "") +
+          (cleanedUp
+            ? `. The subgraph input slot this call created was removed, so the rail is unchanged.`
+            : `.`),
+      );
     }
     findSubgraphHostNode(subgraph)?.invalidatePromotedViews?.();
     subgraph.setDirtyCanvas?.(true, true);
@@ -16502,6 +16709,7 @@ const GRAPH_TOOL_EXECUTORS = {
         on_host_subgraph_node: true,
         to: { node_id: node.id, input: inputSlot?.name ?? inIdx },
       },
+      ...(exposeConnectErr ? { warning: landedAfterThrowWarning(exposeConnectErr) } : {}),
     };
   },
 

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -12159,7 +12159,8 @@ const GRAPH_TOOL_EXECUTORS = {
               `panel_connect from node ${node.id} output "${outputSlot?.name ?? outIdx}" to subgraph ` +
                 `output "${existing.name}" threw and NOTHING landed (#1272): ` +
                 `${railConnectErr?.message ?? railConnectErr}. Observed post-state of the live graph: ` +
-                `the rail slot carries no link from that output. Re-read with panel_graph_outline ` +
+                `this call left no new link from that output on the rail slot. Re-read with ` +
+                `panel_graph_outline ` +
                 `before retrying.`,
             );
           }
@@ -12231,7 +12232,8 @@ const GRAPH_TOOL_EXECUTORS = {
               `panel_connect from subgraph input "${existing.name}" to node ${node.id} input ` +
                 `"${inputSlot?.name ?? inIdx}" threw and NOTHING landed (#1272): ` +
                 `${railConnectErr?.message ?? railConnectErr}. Observed post-state of the live graph: ` +
-                `the rail slot carries no link to that input. Re-read with panel_graph_outline ` +
+                `this call left no new link to that input on the rail slot. Re-read with ` +
+                `panel_graph_outline ` +
                 `before retrying.`,
             );
           }
@@ -12356,16 +12358,26 @@ const GRAPH_TOOL_EXECUTORS = {
         // new one, so a throw in between can leave the input empty. Say so only
         // when the live graph actually shows it.
         const priorWireGone = prevLinkId != null && target.inputs?.[inIdx]?.link == null;
+        // The scan above EXCLUDES ids that pre-dated this call, so "nothing landed"
+        // means "this call added nothing" — NOT "no such wire exists". Re-run it
+        // without the exclusion so an older wire from the same output is DISCLOSED
+        // rather than implicitly denied by the sentence below.
+        const preexisting = findLandedInboundLink(graph, origin, outIdx, target, null);
         throw new Error(
           `panel_connect threw and NOTHING landed (#1272): node ${origin.id} output ` +
             `"${origin.outputs?.[outIdx]?.name ?? outIdx}" → node ${target.id} input ` +
             `"${target.inputs?.[inIdx]?.name ?? inIdx}" — ${connectErr?.message ?? connectErr}. ` +
-            `Observed post-state of the live graph: no link from that output reaches node ` +
-            `${target.id}` +
+            `Observed post-state of the live graph: this call left NO new link from that ` +
+            `output on node ${target.id}` +
             (priorWireGone
               ? `, and the wire that was on that input before this call (from node ` +
                 `${replacedLink?.node_id ?? "?"} output "${replacedLink?.output ?? "?"}") is GONE — ` +
                 `the input is now EMPTY and must be rewired`
+              : "") +
+            (preexisting
+              ? `. A link from that same output was ALREADY on input ` +
+                `"${target.inputs?.[preexisting.inputIndex]?.name ?? preexisting.inputIndex}" ` +
+                `before this call and is untouched — do not tear it down`
               : "") +
             `. Re-read with panel_graph_outline before retrying.`,
         );
@@ -16601,7 +16613,8 @@ const GRAPH_TOOL_EXECUTORS = {
             ? ` — the frontend threw: ${exposeConnectErr?.message ?? exposeConnectErr}`
             : "") +
           (cleanedUp
-            ? `. The subgraph output slot this call created was removed, so the rail is unchanged.`
+            ? `. The subgraph output slot this call created was removed, so the rail carries no ` +
+            `slot from this call.`
             : `.`),
       );
     }
@@ -16694,7 +16707,8 @@ const GRAPH_TOOL_EXECUTORS = {
             ? ` — the frontend threw: ${exposeConnectErr?.message ?? exposeConnectErr}`
             : "") +
           (cleanedUp
-            ? `. The subgraph input slot this call created was removed, so the rail is unchanged.`
+            ? `. The subgraph input slot this call created was removed, so the rail carries no ` +
+            `slot from this call.`
             : `.`),
       );
     }

--- a/web/js/lib/connect-verify.js
+++ b/web/js/lib/connect-verify.js
@@ -100,7 +100,7 @@ export function isWidgetBackedInput(input) {
 // landed. That is not hypothetical: LiteGraph writes the link and only THEN
 // runs the nodes' hooks.
 //
-//   LGraphNode.connectSlots (ComfyUI_frontend 1.47.2, LGraphNode.ts ~2938+):
+//   LGraphNode.connectSlots (ComfyUI_frontend 1.48.7, LGraphNode.ts ~2938+):
 //     graph._links.set(link.id, link)
 //     output.links.push(link.id)
 //     targetInput.link = link.id
@@ -125,11 +125,21 @@ export function isWidgetBackedInput(input) {
 // ---------------------------------------------------------------------------
 
 /**
- * The link stored under `linkId`, or null. `graph.links` is an array in some
- * LiteGraph builds, a Map-backed Proxy with Record-style index access in
- * current ComfyUI ones; `graph.getLink(id)` exists on Subgraph/LGraph. All
- * three are tried, defensively — a reader that throws would turn a verdict
- * into a second failure.
+ * The link stored under `linkId`, or null.
+ *
+ * **`linkId` MUST be the RAW id, never stringified.** The live store is
+ * `_links: Map<LinkId, LLink>` with `LinkId = number`, wrapped in a Proxy whose
+ * methods are bound straight through — so `links.get` IS `Map.prototype.get`, and
+ * `Map.get("7")` MISSES a key of `7`. `graph.getLink(id)` is `_links.get(id)` and
+ * misses identically, so the fallback cannot rescue a stringified id either. A
+ * helper that normalised ids to strings before reaching here returned "no link"
+ * for every link on a real graph — a fully persisted wire read as absent. The
+ * ONLY place an id may be stringified is set membership, which is why that lives
+ * in `linkIdExclusionSet` below and nowhere else.
+ *
+ * `graph.links` is an array in some LiteGraph builds and the Map-backed Proxy in
+ * current ComfyUI ones; both, plus `getLink`, are tried defensively — a reader
+ * that throws would turn a verdict into a second failure.
  */
 export function readStoredLink(graph, linkId) {
   if (linkId == null || !graph) return null;
@@ -146,22 +156,45 @@ export function readStoredLink(graph, linkId) {
   return null;
 }
 
-/** Link ids currently back-referenced by `node`'s INPUT slots, as strings. */
+/**
+ * Link ids currently back-referenced by `node`'s INPUT slots — **RAW**, exactly as
+ * the slots hold them, so they stay usable as store keys (see `readStoredLink`).
+ */
 export function inputLinkIds(node) {
   const ids = [];
   for (const input of node?.inputs ?? []) {
-    if (input?.link != null) ids.push(String(input.link));
+    if (input?.link != null) ids.push(input.link);
   }
   return ids;
 }
 
-/** Link ids currently held by a subgraph boundary-rail slot, as strings. */
+/**
+ * Link ids currently held by a subgraph boundary-rail slot — **RAW**, for the same
+ * reason: `findLandedRailLink` iterates these and feeds each one to the link store,
+ * so stringifying here made every rail lookup miss.
+ */
 export function railSlotLinkIds(railSlot) {
   const ids = [];
   for (const id of railSlot?.linkIds ?? []) {
-    if (id != null) ids.push(String(id));
+    if (id != null) ids.push(id);
   }
   return ids;
+}
+
+/**
+ * The one place link ids are stringified: an exclusion SET for the "did THIS call
+ * add it?" question.
+ *
+ * Membership has to survive a number/string mismatch, while a store lookup must
+ * NOT — `Map.get("7")` misses a key of `7`. Those two requirements are opposites,
+ * and collapsing them into one "ids as strings" helper is precisely how a working
+ * rail verdict became a 100% false negative. Keeping the string form to this
+ * function, and reading the store only with raw ids, is what keeps them apart.
+ */
+export function linkIdExclusionSet(ids) {
+  const set = new Set();
+  for (const id of ids ?? []) if (id != null) set.add(String(id));
+  return set;
 }
 
 /**
@@ -181,7 +214,7 @@ export function railSlotLinkIds(railSlot) {
 export function findLandedInboundLink(graph, origin, outIdx, target, excludeIds) {
   const originId = origin?.id;
   if (originId == null || !target) return null;
-  const skip = excludeIds instanceof Set ? excludeIds : new Set(excludeIds ?? []);
+  const skip = excludeIds instanceof Set ? excludeIds : linkIdExclusionSet(excludeIds);
   const inputs = target.inputs ?? [];
   for (let i = 0; i < inputs.length; i++) {
     const linkId = inputs[i]?.link;
@@ -192,7 +225,7 @@ export function findLandedInboundLink(graph, origin, outIdx, target, excludeIds)
     const storedOriginSlot = stored.origin_slot ?? stored[2];
     if (String(storedOrigin) !== String(originId)) continue;
     if (Number(storedOriginSlot) !== Number(outIdx)) continue;
-    return { linkId: String(linkId), inputIndex: i };
+    return { linkId, inputIndex: i };
   }
   return null;
 }
@@ -211,8 +244,11 @@ export function findLandedInboundLink(graph, origin, outIdx, target, excludeIds)
 export function isRailLinkPersisted(graph, railSlot, node, slotIdx, side, link) {
   const linkId = link?.id;
   if (linkId == null) return false;
-  if (!railSlotLinkIds(railSlot).includes(String(linkId))) return false;
-  return railLinkJoins(readStoredLink(graph, linkId), node, slotIdx, side);
+  // Membership tolerates a number/string mismatch; the STORE read then uses the
+  // id the slot itself holds, raw.
+  const onSlot = railSlotLinkIds(railSlot).find((id) => String(id) === String(linkId));
+  if (onSlot == null) return false;
+  return railLinkJoins(readStoredLink(graph, onSlot), node, slotIdx, side);
 }
 
 /**
@@ -223,9 +259,11 @@ export function isRailLinkPersisted(graph, railSlot, node, slotIdx, side, link) 
  * wire is never credited to this call. Returns `{ linkId }`.
  */
 export function findLandedRailLink(graph, railSlot, node, slotIdx, side, excludeIds) {
-  const skip = excludeIds instanceof Set ? excludeIds : new Set(excludeIds ?? []);
+  const skip = excludeIds instanceof Set ? excludeIds : linkIdExclusionSet(excludeIds);
   for (const linkId of railSlotLinkIds(railSlot)) {
-    if (skip.has(linkId)) continue;
+    // String() on the MEMBERSHIP side only — `linkId` itself stays raw for the
+    // store read on the next line.
+    if (skip.has(String(linkId))) continue;
     if (railLinkJoins(readStoredLink(graph, linkId), node, slotIdx, side)) return { linkId };
   }
   return null;

--- a/web/js/lib/connect-verify.js
+++ b/web/js/lib/connect-verify.js
@@ -90,3 +90,152 @@ export function removePhantomLink(graph, target, inIdx, link) {
 export function isWidgetBackedInput(input) {
   return !!(input && input.widget);
 }
+
+// ---------------------------------------------------------------------------
+// #1272 — the SAME question asked on the THROW path.
+//
+// `isLinkPersisted` above needs the link object `connect()` RETURNED. When
+// `connect()` THROWS there is no return value, and the panel used to let the
+// exception escape — reporting failure for a connect whose link had already
+// landed. That is not hypothetical: LiteGraph writes the link and only THEN
+// runs the nodes' hooks.
+//
+//   LGraphNode.connectSlots (ComfyUI_frontend 1.47.2, LGraphNode.ts ~2938+):
+//     graph._links.set(link.id, link)
+//     output.links.push(link.id)
+//     targetInput.link = link.id
+//     graph.trigger("node:slot-links:changed", …)   <-- can throw
+//     this.onConnectionsChange?.(OUTPUT, …)          <-- can throw
+//     inputNode.onConnectionsChange?.(INPUT, …)      <-- can throw
+//
+//   SubgraphOutput.connect / SubgraphInput.connect (subgraph/*.ts): identical
+//   ordering — `subgraph._links.set` + `linkIds` + `slot.link` are written
+//   first, `node.onConnectionsChange?.()` runs last.
+//
+// So EVERY hook that can throw runs AFTER the link is fully persisted. A throw
+// therefore carries no information about whether the wire exists, and the only
+// honest verdict comes from reading the live graph back. These helpers do that
+// with the SAME fail-closed strength as `isLinkPersisted`: a link counts only
+// when the store holds it AND the slot that should own it back-references that
+// exact id.
+//
+// They deliberately do NOT promise permanence — like `isLinkPersisted`, they
+// describe the instant right after the call (see #992). "Did it land at all"
+// is the question here, and that one they can answer.
+// ---------------------------------------------------------------------------
+
+/**
+ * The link stored under `linkId`, or null. `graph.links` is an array in some
+ * LiteGraph builds, a Map-backed Proxy with Record-style index access in
+ * current ComfyUI ones; `graph.getLink(id)` exists on Subgraph/LGraph. All
+ * three are tried, defensively — a reader that throws would turn a verdict
+ * into a second failure.
+ */
+export function readStoredLink(graph, linkId) {
+  if (linkId == null || !graph) return null;
+  try {
+    const links = graph.links;
+    if (links) {
+      const stored = typeof links.get === "function" ? links.get(linkId) : links[linkId];
+      if (stored != null) return stored;
+    }
+    if (typeof graph.getLink === "function") return graph.getLink(linkId) ?? null;
+  } catch {
+    /* an unreadable store is "no link", never a thrown verdict */
+  }
+  return null;
+}
+
+/** Link ids currently back-referenced by `node`'s INPUT slots, as strings. */
+export function inputLinkIds(node) {
+  const ids = [];
+  for (const input of node?.inputs ?? []) {
+    if (input?.link != null) ids.push(String(input.link));
+  }
+  return ids;
+}
+
+/** Link ids currently held by a subgraph boundary-rail slot, as strings. */
+export function railSlotLinkIds(railSlot) {
+  const ids = [];
+  for (const id of railSlot?.linkIds ?? []) {
+    if (id != null) ids.push(String(id));
+  }
+  return ids;
+}
+
+/**
+ * The link that a node→node connect actually left behind, or null.
+ *
+ * Scans `target`'s inputs (NOT just the requested one — a dynamic-input node
+ * may re-slot the link to the slot it materialised, which is exactly what
+ * #1272's ImpactSwitch does) for a slot whose `link` back-reference resolves to
+ * a stored link originating at `origin` output `outIdx`.
+ *
+ * `excludeIds` are the ids observed BEFORE the mutation. A link already present
+ * beforehand is NOT evidence this call landed — without that exclusion a connect
+ * that threw before doing anything would be credited with a wire someone else
+ * made, which is the "two states, one answer" defect this whole check exists to
+ * remove. Returns `{ linkId, inputIndex }`.
+ */
+export function findLandedInboundLink(graph, origin, outIdx, target, excludeIds) {
+  const originId = origin?.id;
+  if (originId == null || !target) return null;
+  const skip = excludeIds instanceof Set ? excludeIds : new Set(excludeIds ?? []);
+  const inputs = target.inputs ?? [];
+  for (let i = 0; i < inputs.length; i++) {
+    const linkId = inputs[i]?.link;
+    if (linkId == null || skip.has(String(linkId))) continue;
+    const stored = readStoredLink(graph, linkId);
+    if (stored == null) continue;
+    const storedOrigin = stored.origin_id ?? stored[1];
+    const storedOriginSlot = stored.origin_slot ?? stored[2];
+    if (String(storedOrigin) !== String(originId)) continue;
+    if (Number(storedOriginSlot) !== Number(outIdx)) continue;
+    return { linkId: String(linkId), inputIndex: i };
+  }
+  return null;
+}
+
+/**
+ * True only when `link` (the object a rail `connect()` RETURNED) is persisted on
+ * `railSlot`: the rail slot lists that exact id AND the stored link joins it to
+ * `node` at `slotIdx`. The rail-branch analogue of `isLinkPersisted` — #397 was
+ * adopted at the node→node call site only, so the two rail branches reported
+ * success on LiteGraph's truthy return alone.
+ *
+ * `side` is "output" for the OUTPUT rail (node output → rail; the link's ORIGIN
+ * is the node) and "input" for the INPUT rail (rail → node input; the link's
+ * TARGET is the node).
+ */
+export function isRailLinkPersisted(graph, railSlot, node, slotIdx, side, link) {
+  const linkId = link?.id;
+  if (linkId == null) return false;
+  if (!railSlotLinkIds(railSlot).includes(String(linkId))) return false;
+  return railLinkJoins(readStoredLink(graph, linkId), node, slotIdx, side);
+}
+
+/**
+ * The NEW link a rail connect left behind, or null — the throw-path counterpart
+ * of `isRailLinkPersisted` (no returned link to key on). Same fail-closed
+ * strength: the id must be on the rail slot, resolve in the store, and join
+ * `node`/`slotIdx`; ids present before the mutation are excluded so a pre-existing
+ * wire is never credited to this call. Returns `{ linkId }`.
+ */
+export function findLandedRailLink(graph, railSlot, node, slotIdx, side, excludeIds) {
+  const skip = excludeIds instanceof Set ? excludeIds : new Set(excludeIds ?? []);
+  for (const linkId of railSlotLinkIds(railSlot)) {
+    if (skip.has(linkId)) continue;
+    if (railLinkJoins(readStoredLink(graph, linkId), node, slotIdx, side)) return { linkId };
+  }
+  return null;
+}
+
+/** Does `stored` join `node` at `slotIdx` on the given rail `side`? */
+function railLinkJoins(stored, node, slotIdx, side) {
+  if (stored == null || node?.id == null) return false;
+  const nodeId = side === "input" ? (stored.target_id ?? stored[3]) : (stored.origin_id ?? stored[1]);
+  const nodeSlot =
+    side === "input" ? (stored.target_slot ?? stored[4]) : (stored.origin_slot ?? stored[2]);
+  return String(nodeId) === String(node.id) && Number(nodeSlot) === Number(slotIdx);
+}

--- a/web/js/lib/connect-verify.js
+++ b/web/js/lib/connect-verify.js
@@ -239,3 +239,22 @@ function railLinkJoins(stored, node, slotIdx, side) {
     side === "input" ? (stored.target_slot ?? stored[4]) : (stored.origin_slot ?? stored[2]);
   return String(nodeId) === String(node.id) && Number(nodeSlot) === Number(slotIdx);
 }
+
+/**
+ * The disclosure attached to a connect that THREW but whose link IS on the live
+ * graph. The verdict itself comes from the post-state check; this states that
+ * plainly, quotes the throw verbatim rather than hiding it, and tells the caller
+ * not to retry — the retry is what turns this false negative into duplicated or
+ * torn-down wiring. `extra` carries a site-specific observation (e.g. the node
+ * re-slotted the link) and is omitted when there is nothing extra to say.
+ */
+export function landedAfterThrowWarning(err, extra = "") {
+  return (
+    `the ComfyUI frontend threw while applying this connect (${err?.message ?? err}) but the live ` +
+    `graph shows the link IS present, so this is reported as connected (#1272). ` +
+    (extra ? `${extra} ` : "") +
+    `Do NOT retry this connect — a retry would duplicate or tear down wiring that is already ` +
+    `correct. The node that threw may have been left mid-reshape, so re-read it with ` +
+    `panel_query_graph before wiring anything else to it.`
+  );
+}

--- a/web/js/lib/connect-verify.js
+++ b/web/js/lib/connect-verify.js
@@ -242,16 +242,19 @@ function railLinkJoins(stored, node, slotIdx, side) {
 
 /**
  * The disclosure attached to a connect that THREW but whose link IS on the live
- * graph. The verdict itself comes from the post-state check; this states that
- * plainly, quotes the throw verbatim rather than hiding it, and tells the caller
- * not to retry — the retry is what turns this false negative into duplicated or
- * torn-down wiring. `extra` carries a site-specific observation (e.g. the node
- * re-slotted the link) and is omitted when there is nothing extra to say.
+ * graph — shared by graph_connect's three branches and by the two
+ * graph_expose_subgraph_* paths, so it names no particular reply key. The verdict
+ * itself comes from the post-state check; this states that plainly, quotes the
+ * throw verbatim rather than hiding it, and tells the caller not to retry — the
+ * retry is what turns this false negative into duplicated or torn-down wiring.
+ * `extra` carries a site-specific observation (e.g. the node re-slotted the link)
+ * and is omitted when there is nothing extra to say.
  */
 export function landedAfterThrowWarning(err, extra = "") {
   return (
     `the ComfyUI frontend threw while applying this connect (${err?.message ?? err}) but the live ` +
-    `graph shows the link IS present, so this is reported as connected (#1272). ` +
+    `graph shows the link IS present, so the result above reflects the live graph rather ` +
+    `than the exception (#1272). ` +
     (extra ? `${extra} ` : "") +
     `Do NOT retry this connect — a retry would duplicate or tear down wiring that is already ` +
     `correct. The node that threw may have been left mid-reshape, so re-read it with ` +


### PR DESCRIPTION
## The defect

`panel_connect` reported a hard failure — `Cannot read properties of undefined (reading 'slots')` — for a connect whose link **was on the graph**. The reporter re-read after each failure and found the wire present both times: once on an `ImpactSwitch` input the node materialises on connect, once on the subgraph **output rail** (`to_node_id: -20`), where `panel_graph_outline` then showed `143 ImpactSwitch → -20.0`.

An agent that trusts the error retries, and the retry duplicates or tears down wiring that was already correct. This addresses the underlying cause of #1272.

## Mechanism — read from the frontend source, not inferred

Every connect path in ComfyUI_frontend writes the link **first** and runs the node hooks **last**:

```
LGraphNode.connectSlots (LGraphNode.ts ~2938+)
  graph._links.set(link.id, link)
  output.links.push(link.id)
  targetInput.link = link.id
  graph.trigger("node:slot-links:changed", …)      <- can throw
  this.onConnectionsChange?.(OUTPUT, …)            <- can throw
  inputNode.onConnectionsChange?.(INPUT, …)        <- can throw

SubgraphOutput.connect / SubgraphInput.connect (subgraph/*.ts)
  subgraph._links.set(link.id, link) ; slot.linkIds ; slot.link / slot.links
  node.onConnectionsChange?.(…)                    <- can throw
```

(Read at `ComfyUI_frontend` **1.48.7** — the reporter's own version — via the TypeScript recovered from the shipped sourcemaps.)

So **a throw carries no information about whether the wire exists.** The panel's three connect call sites were `try { … } finally { … }` with **no `catch`**: the `finally` ran and the exception propagated, so "threw and nothing landed" and "threw but the link is there" arrived at the caller as one indistinguishable failure. `isLinkPersisted` — the verifier added for #397, which is the mirror-image bug — sits *after* the try block and is unreachable on the throw path, which is exactly why the link could land while the tool reported failure.

## What changed

**1. The verdict is decided on the observed post-state, on the throw path too.** Each site catches the exception, then reads the live graph back and reports what it actually shows. `connect()` returns nothing when it throws, so `isLinkPersisted` (which keys on the returned link's id) cannot be used there; `findLandedInboundLink` / `findLandedRailLink` ask the same question with the same fail-closed strength — the store must hold the link **and** the slot that should own it must back-reference that exact id.

**The exception is never swallowed.** When nothing landed, the failure is raised and is now *louder* than before: it quotes the throw verbatim and adds the measured post-state, including the case where LiteGraph dropped the previous wire before the throw (it disconnects the old link *before* creating the new one) and left the input empty.

**Two states that used to collapse are now separate.** The scan excludes every link id the target already carried before the mutation, so a wire that pre-dated the call can never be credited to it — and when such a wire exists the refusal *names* it (`ALREADY on input "input2" … do not tear it down`) rather than implicitly denying it.

When the link did land, the reply is a normal `connected:` payload plus a `warning` that quotes the throw, says the verdict came from the live graph, and tells the caller not to retry. If a dynamic node re-slotted the link, the payload names the slot it **actually** landed on and the warning says so.

**2. #397 adopted at the two rail call sites.** Both rail branches reported success on LiteGraph's truthy return with **no** persistence check — #397 was only ever applied to the node→node branch, and #1272's second repro is literally the output rail. Both now verify against the live rail slot, and refuse honestly when the return was truthy but nothing persisted.

**3. The `addOutput` / `addInput` leak.** In `graph_expose_subgraph_output` / `_input` the `removeOutput` cleanup sat *inside* the `try`, on the `!link` branch only — so a **throw** from `connect()` skipped it and stranded the boundary slot `addOutput` had just created, on every failed expose (also visible as a junk slot on the parent SubgraphNode). Cleanup now runs on both failure shapes, is guarded so a cleanup failure cannot replace the real error, and the message claims removal only when removal actually happened.

## Refutation

`git checkout origin/main -- web/js/comfyui-mcp-panel.js`, keeping the new helper module and the new test file: **14 of 23 tests fail.** The 9 that stay green are the pure-helper tests plus the three deliberate "unchanged behaviour" controls. Restoring the panel file: 23/23.

That is the point of the test's shape. It extracts the **real shipped** `graph_connect`, `graph_expose_subgraph_output` and `graph_expose_subgraph_input` from `web/js/comfyui-mcp-panel.js` and runs them against LiteGraph-shaped doubles with the **real** verification helpers injected — a helper-only test stays green against an unfixed call site, which is this codebase's most reliable defect.

Included in that 14 is `#397 output rail: a truthy return with NO persisted link is refused`, which fails on `origin/main` — the per-call-site adoption gap was real, not theoretical.

## Verification

- `npm run test:unit` — **5082 pass / 1 fail / 1 todo** on 5084, reproduced twice. The single failure is the known #671 `verifyInstalled` wall-clock flake (29.1 s and 17.5 s under full-suite load, against a sub-30 s budget); the same file run alone: **125/125, that test in 1.0 s**. It is in `manager-install`, which this change does not touch.
- `npx tsc --noEmit` — clean. `check-panel-scope`, `check-tool-vocabulary` — OK.
- **Playwright: zero new failures.** `npx playwright test --workers=1`, run three times against an isolated ComfyUI 0.33.1 I started myself (port 8267, its own `--base-directory`, only this pack in `custom_nodes`) — the owner's rig on :8188 is down, so nothing there was touched:

  | run | tree | result |
  | --- | --- | --- |
  | baseline | `origin/main` @ `7e88fcb5` (this branch's fork point) | **22 failed / 52 passed** |
  | fix | this branch | **22 failed / 52 passed** — *byte-identical failing set* |
  | fix (re-run on the final commit) | this branch | **21 failed / 53 passed** — the same set minus `agent-drive.spec.ts:113` (a timing-sensitive CivitAI-highlight spec that flaked green) |

  No spec fails here that passed on the baseline. The 22 pre-existing failures are almost all `MockBridge.waitForUserMessage timed out` in the conversation-persistence / chat-identity files and are present on `origin/main` unchanged.

  Directly relevant and **green on every run**: all six `connect-matcher.spec.ts` cases (which drive `graph_connect` through the bridge against real LiteGraph, including *5. reconnect over a connected input reports replaced_link*), plus `connect.spec.ts` and both `auto-layout.spec.ts` cases.

## Bounds I am not overstating

- Like `isLinkPersisted`, these checks describe the **instant** after the call, not permanence (#992). The question asked here is "did it land at all", which is inside that bound; nothing in the reply claims the wire will stay.
- The post-state is read through the node object captured before the mutation. A hook that **replaces** the node object rather than mutating it would read as "nothing landed" — fail-closed, i.e. the pre-fix behaviour, not a regression. No connect-path mechanism in the frontend replaces nodes, so this is a residual bound rather than an observed case.
- The exact line that reads `.slots` on an undefined object is still upstream and unidentified. It does not need to be: the fix keys on the effect, not on the identity of the thrower.
- Debris cleanup on the throw path is not attempted. `removePhantomLink` needs the link object `connect()` never returned; leaving it is the pre-fix behaviour.

## Round 2 — a NO-SHIP blocker in the rail helper, fixed

The first revision shipped a one-line type bug that made two working tools destructive. Recording it here because the *reason the tests missed it* matters more than the line itself.

**`railSlotLinkIds()` stringified every link id, and the live store is number-keyed.** `graph.links` is a Proxy over `_links: Map<LinkId, LLink>` with `LinkId = number`, and the Proxy binds methods straight through — so `links.get` *is* `Map.prototype.get`, and **`Map.get("7")` misses a key of `7`**. `graph.getLink(id)` is `_links.get(id)` and misses identically, so the fallback could not rescue it. `isRailLinkPersisted` escaped (it passes the numeric `link.id`); `findLandedInboundLink` escaped (it passes `inputs[i].link` raw). Only the rail throw-path helper stringified.

Because `findLandedRailLink` had become the **only** verdict on both expose paths — including the happy path — `panel_expose_subgraph_output` / `_input` failed 100% of the time on a real graph and tore down the slot and link they had just correctly created. #1272's own `to_node_id: -20` repro stayed broken for the same reason. Strictly worse than the bug being fixed.

**Fix**: the store is read with the **raw** id everywhere; stringification now lives in one new function, `linkIdExclusionSet`, and nowhere else — set membership must tolerate a number/string mismatch, a store read must not, and collapsing those two opposite requirements into one "ids as strings" helper is exactly what happened. `readStoredLink`'s doc now states the raw-id contract as a contract.

**Why the tests could not see it, and what changed.** The fixture used `links: {}` — a plain object whose keys are already strings, so `links["7"]` and `links[7]` coincided. The harness shape masked the defect. `mkGraph` now builds a **number-keyed `Map` behind the real Proxy semantics** (bound `get`/`set`/`delete`, numeric-key trap for bracket access), so a string/number confusion cannot pass again. Every existing test now runs against that shape.

**New tests, and their before/after.** Re-introducing *only* the `String(id)` in `railSlotLinkIds` now fails **10 of 30** (it failed 0 of 23 before):

- `readStoredLink: the store is number-keyed — a raw id resolves, a stringified one does NOT` — pins the asymmetry as the contract.
- `findLandedRailLink: a persisted rail link is FOUND on the real number-keyed store`.
- `#1272 expose output / expose input: a CLEAN, non-throwing expose keeps its slot and its link` — the end-to-end happy path, driving the real shipped executor. Under the mutation it throws `Could not link node 12 output "IMAGE" (IMAGE) to a new subgraph output. The subgraph output slot this call created was removed…` with `graph.outputs = []` and an orphaned link left in the store. Fixed: `exposed`, one slot, one link, no warning.
- `#1272 repro 2 end-to-end: connect to the output rail (to_node_id -20) that throws AFTER wiring` — **the issue's second reproduction now passes**: `connected.to.subgraph_output === "image"`, the rail carries the link, `origin_id === 143` (what `panel_graph_outline` showed the reporter), plus the disclosure.

**Also fixed, from the same review:**
- `cleanedUp` was set when `removeOutput` merely didn't throw. `LGraph.removeOutput` returns silently without removing when a listener cancels the cancelable `removing-output` event, so the message could claim a removal that never happened. It is now the observed `!subgraph.outputs.includes(subgraphOutput)`, with a test that cancels the removal and asserts the message does **not** say "was removed".
- On the node→node throw path, `replaced_link` was emitted even when the node re-slotted the new link elsewhere and the original wire was untouched. It is now withheld unless the live graph shows the old link actually left that input, with a test.
- The `1.47.2` citation is corrected to `1.48.7` in the source comments, the test header and this body.

**Round-2 verification**: unit **5089 pass / 1 fail / 1 todo** of 5091 (the same known #671 load flake). `tsc --noEmit`, `check-panel-scope`, `check-tool-vocabulary` all clean. Playwright re-run on the r2 tree against a fresh isolated ComfyUI (port 8273, own base directory, only this pack; :8188 / 8211 / 8264 / 8267 / 8288 / 8291 / 8292 untouched): **22 failed / 52 passed — failing set byte-identical to the baseline again**, all six `connect-matcher` cases plus `connect.spec` and `auto-layout` green. No Playwright spec references `expose_subgraph_*` at all, which is exactly why the e2e delta was consistent with total breakage the first time — the unit end-to-end tests above are the coverage that actually holds those paths.

## Gate

Round 1 was gated **NO-SHIP** on the `railSlotLinkIds` type bug described above; the mechanism, the shape of the fix and the test design were upheld. This round addresses the blocker and both non-blocking findings. I did not gate my own work and did not merge — the orchestrator gates and merges.
