### PR TITLE
fix(1657,1648,1284): a frontend VIRTUAL node is not a missing one — the derivable signal, at three call sites

### DIFF
--- a/browser_tests/unit/frontend-virtual-nodes.test.mjs
+++ b/browser_tests/unit/frontend-virtual-nodes.test.mjs
@@ -254,9 +254,24 @@ test("#1648 CALL SITE 3: a REGISTERED type is not sent to reload the tab", () =>
   // page, so "reload" would send the user round the same loop from the other side.
   const msg = missingNodeRunRefusal([{ id: "7", type: "SomeDisplayNode", registered: true }]);
   assert.match(msg, /DOES have a node class registered for SomeDisplayNode/);
-  assert.match(msg, /reloading will not change it/);
+  assert.match(msg, /reloading\s+will not change those/);
   assert.doesNotMatch(msg, /RELOAD the ComfyUI tab/);
   assert.doesNotMatch(msg, /install the pack that provides these types/);
+  // Nothing was left unnamed, so no leftover clause.
+  assert.doesNotMatch(msg, /could not be named from the/);
+});
+
+test("#1648 CALL SITE 3: an offender the canvas could not name is never swept into the claim", () => {
+  // `registered: null` is a node whose type the graph could not read. The "registered here"
+  // sentence must stay scoped to what was actually looked at — otherwise it asserts
+  // "nothing is missing" off a node nobody examined.
+  const msg = missingNodeRunRefusal([
+    { id: "7", type: "SomeDisplayNode", registered: true },
+    { id: "8", type: null, registered: null },
+  ]);
+  assert.match(msg, /DOES have a node class registered for SomeDisplayNode/);
+  assert.doesNotMatch(msg, /nothing is missing here/);
+  assert.match(msg, /The other 1 node could not be named from the canvas, so nothing is established about it/);
 });
 
 test("#1648 CALL SITE 3: one unregistered offender in a mixed set still gets the reload remedy", () => {

--- a/browser_tests/unit/frontend-virtual-nodes.test.mjs
+++ b/browser_tests/unit/frontend-virtual-nodes.test.mjs
@@ -1,0 +1,300 @@
+// comfyui-mcp#1657 / #1648 / panel#1284 — "absent from /object_info" is not "missing".
+//
+// Three surfaces collapsed two states into one answer:
+//   A. a node the FRONTEND registers as virtual, which never reaches the backend and is
+//      absent from /object_info BY DESIGN; and
+//   B. a node whose class this page never registered, so litegraph left a placeholder.
+//
+// The discriminator is `node.isVirtualNode === true` — the flag ComfyUI's own serializer
+// reads to skip a node (frontend 1.48.7: `if (e.isVirtualNode || …) continue`), set in
+// their own source by KJNodes' SetNode/GetNode and by rgthree's RgthreeBaseVirtualNode
+// (Label, Fast Groups Bypasser/Muter, Fast Bypasser/Muter, Node Collector, Reroute).
+//
+// EVERY behavioural test below is paired with its case-B twin, because that is the pair a
+// name allowlist gets wrong: panel#1284 and comfyui-mcp#1648 come from the same rig, where
+// GetNode/SetNode were REAL placeholders (the tab had never loaded KJNodes' JS) and an
+// allowlist naming "GetNode"/"SetNode" would have declared a broken run fine.
+//
+// Each of the three call sites is asserted separately. A helper-only suite here is blind
+// by construction — it would leave two of the three unwired and stay green.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+import {
+  isFrontendVirtualNode,
+  frontendVirtualTypesAmong,
+  withoutFrontendVirtualTypes,
+} from "../../web/js/lib/frontend-virtual-nodes.js";
+import { scanComboAvailability } from "../../web/js/lib/live-combo-availability.js";
+import {
+  describeUnrunnable,
+  missingNodeRunRefusal,
+} from "../../web/js/lib/missing-node-preflight.js";
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "../..");
+const PANEL = readFileSync(join(ROOT, "web/js/comfyui-mcp-panel.js"), "utf8");
+
+/** A live KJNodes/rgthree-style virtual node: its class set the flag. */
+const virtualNode = (id, type) => ({ id, type, isVirtualNode: true, widgets: [{ name: "Constant", value: "MODEL" }] });
+/** The SAME type as a defless placeholder — the pack's JS never loaded in this tab. */
+const placeholderNode = (id, type) => ({ id, type, widgets: [{ name: "Constant", value: "MODEL" }] });
+
+// ── the predicate ───────────────────────────────────────────────────────────────
+
+test("#1657 only an explicit isVirtualNode===true is proof; everything else stays reported", () => {
+  assert.equal(isFrontendVirtualNode({ isVirtualNode: true }), true);
+  // The whole point is that a placeholder cannot forge this by accident. Truthy-but-not-true
+  // shapes are the ones a loose check would swallow.
+  for (const bad of [
+    {},
+    { isVirtualNode: false },
+    { isVirtualNode: undefined },
+    { isVirtualNode: "true" },
+    { isVirtualNode: 1 },
+    null,
+    undefined,
+    "GetNode",
+    42,
+  ]) {
+    assert.equal(isFrontendVirtualNode(bad), false, JSON.stringify(bad));
+  }
+});
+
+test("#1657 a type is virtual only when EVERY live instance says so", () => {
+  const nodes = [
+    virtualNode(1, "GetNode"),
+    virtualNode(2, "GetNode"),
+    virtualNode(3, "Label (rgthree)"),
+    { id: 4, type: "KSampler" },
+  ];
+  assert.deepEqual([...frontendVirtualTypesAmong(nodes)].sort(), ["GetNode", "Label (rgthree)"]);
+  // One placeholder of the same type refutes the whole type: that type has a real problem.
+  assert.deepEqual(
+    [...frontendVirtualTypesAmong([...nodes, placeholderNode(5, "GetNode")])],
+    ["Label (rgthree)"],
+  );
+});
+
+test("#1657 a type with no live instance is never cleared, and junk exempts nothing", () => {
+  // The load-time store outlives its nodes; an entry with nothing on canvas stays reported.
+  assert.deepEqual(withoutFrontendVirtualTypes(["GetNode"], []), ["GetNode"]);
+  for (const junk of [null, undefined, "nodes", 7, [null, undefined, {}]]) {
+    assert.deepEqual(withoutFrontendVirtualTypes(["GetNode", "Foo"], junk), ["GetNode", "Foo"]);
+  }
+  assert.deepEqual(withoutFrontendVirtualTypes(null, []), []);
+});
+
+test("#1657 the reported list is filtered in order, and genuine misses survive", () => {
+  const nodes = [
+    virtualNode(1, "GetNode"),
+    virtualNode(2, "SetNode"),
+    virtualNode(3, "MarkdownNote"),
+    virtualNode(4, "Label (rgthree)"),
+    placeholderNode(5, "ImpactWildcardEncode"),
+  ];
+  assert.deepEqual(
+    withoutFrontendVirtualTypes(
+      ["GetNode", "SetNode", "MarkdownNote", "Label (rgthree)", "ImpactWildcardEncode"],
+      nodes,
+    ),
+    ["ImpactWildcardEncode"],
+  );
+});
+
+// ── CALL SITE 1: panel_get_errors' live combo scan (#1657, panel#1284) ───────────
+
+const noClass = async () => ({}); // /object_info/<class> answers {} with HTTP 200 for an absent class
+
+test("#1657 CALL SITE 1: a virtual node is not reported as unchecked, and is never looked up", async () => {
+  const asked = [];
+  const fetchClassInfo = async (cls) => {
+    asked.push(cls);
+    return cls === "KSampler" ? { KSampler: { input: { required: {} } } } : {};
+  };
+  const r = await scanComboAvailability(
+    [
+      virtualNode(1, "GetNode"),
+      virtualNode(2, "SetNode"),
+      virtualNode(3, "MarkdownNote"),
+      virtualNode(4, "Label (rgthree)"),
+      { id: 5, type: "KSampler", widgets: [{ name: "sampler_name", value: "euler" }] },
+    ],
+    fetchClassInfo,
+  );
+  assert.deepEqual(r.unknown, []);
+  assert.deepEqual(r.unavailable, []);
+  // Skipped BEFORE the lookup: no wasted round trip, no slot in the class cap.
+  assert.deepEqual(asked, ["KSampler"]);
+});
+
+test("#1657 CALL SITE 1: the SAME types as placeholders are still reported unchecked", async () => {
+  // panel#1284's rig: the tab never loaded KJNodes' JS. A name allowlist clears these.
+  const r = await scanComboAvailability(
+    [placeholderNode(1, "GetNode"), placeholderNode(2, "SetNode")],
+    noClass,
+  );
+  assert.deepEqual(
+    r.unknown.map((u) => `${u.type}:${u.reason}`),
+    ["GetNode:node type not found in /object_info", "SetNode:node type not found in /object_info"],
+  );
+});
+
+test("#1657 CALL SITE 1: a genuinely uninstalled pack is untouched", async () => {
+  const r = await scanComboAvailability([placeholderNode(9, "ImpactWildcardEncode")], noClass);
+  assert.equal(r.unknown.length, 1);
+  assert.equal(r.unknown[0].type, "ImpactWildcardEncode");
+});
+
+test("#1657 CALL SITE 1: the skip does not hide a REAL unavailable widget value", async () => {
+  // Widening the exemption must not suppress the finding this scan exists for.
+  const r = await scanComboAvailability(
+    [{ id: 1, type: "LoraLoader", widgets: [{ name: "lora_name", value: "gone.safetensors" }] }],
+    async () => ({ LoraLoader: { input: { required: { lora_name: [["kept.safetensors"], {}] } } } }),
+  );
+  assert.equal(r.unavailable.length, 1);
+  assert.equal(r.unavailable[0].value, "gone.safetensors");
+});
+
+test("#1657 CALL SITE 1 WIRING: the scan itself consults the predicate", () => {
+  const src = readFileSync(join(ROOT, "web/js/lib/live-combo-availability.js"), "utf8");
+  assert.match(src, /import \{ isFrontendVirtualNode \} from "\.\/frontend-virtual-nodes\.js";/);
+  const at = src.indexOf("export async function scanComboAvailability");
+  assert.ok(at > 0, "the scan must still be recognisable");
+  const body = src.slice(at);
+  const skip = body.indexOf("if (isFrontendVirtualNode(node)) continue;");
+  const lookup = body.indexOf("const entry = await comboMapFor(className);");
+  assert.ok(skip > 0, "the scan must skip frontend virtual nodes");
+  assert.ok(lookup > skip, "the skip must run BEFORE the per-class lookup spends a fetch");
+});
+
+// ── CALL SITE 2: collectMissingAssets, the shared missing-node-types collector ───
+
+test("#1657 CALL SITE 2 WIRING: the shared collector filters its node-type list", () => {
+  assert.match(PANEL, /import \{ withoutFrontendVirtualTypes \} from "\.\/lib\/frontend-virtual-nodes\.js";/);
+  const at = PANEL.indexOf("function collectMissingAssets(trustComboOverride) {");
+  assert.ok(at > 0, "the shared collector must still be recognisable");
+  // Bounded by the collector's own return, so this stays scoped to that function.
+  const end = PANEL.indexOf("return { models, media, nodeTypes, nodeCount", at);
+  assert.ok(end > at, "the collector's return must still be recognisable");
+  const body = PANEL.slice(at, end);
+  assert.match(body, /nodeTypes = withoutFrontendVirtualTypes\(/);
+  // Filtered against the WHOLE workflow, not just the graph the user happens to be inside:
+  // a virtual node in an un-entered subgraph must not be re-reported by scope alone.
+  assert.match(body, /collectAllGraphs\(getGraphCtx\(\)\.rootGraph\)\.flatMap\(\(g\) => g\?\._nodes \?\? \[\]\)/);
+});
+
+test("#1657 CALL SITE 2 WIRING: every consumer of the collector inherits the filter", () => {
+  // graph_get_errors, the turn-start validation banner and the stale-red-flag adjudication
+  // all read this ONE collector. Filtering anywhere else would have fixed one of them —
+  // which is exactly how this family reached three call sites.
+  assert.ok(
+    (PANEL.match(/collectMissingAssets\(/g) ?? []).length >= 4,
+    "the collector must remain the single source these surfaces share",
+  );
+  assert.equal((PANEL.match(/nodeTypes = withoutFrontendVirtualTypes\(/g) ?? []).length, 1);
+});
+
+// ── CALL SITE 3: panel_run's pre-flight refusal (#1648) ──────────────────────────
+
+test("#1648 CALL SITE 3: an unobserved registry claims nothing — the message is unchanged", () => {
+  // Pinned verbatim: a future edit must not drift the no-evidence branch into a claim.
+  assert.deepEqual(describeUnrunnable(["7"], [{ id: 7, type: "Foo" }]), [{ id: "7", type: "Foo" }]);
+  assert.equal(
+    missingNodeRunRefusal([{ id: "7", type: "Foo" }]),
+    "NOT queued: 1 node in this workflow cannot be executed by the server — Foo (node 7). " +
+      "Their node types are not registered on this ComfyUI, so the prompt was built with no " +
+      "class_type for them and would have failed validation after being queued " +
+      "(comfyui-mcp#1460). Nothing was sent and the queue is untouched. This usually means a " +
+      "custom-node pack is missing or failed to load: install the pack that provides these " +
+      "types (list_packs / install_custom_node), restart ComfyUI so the frontend registers " +
+      "them, then run again. If you expected these nodes to be optional, delete or bypass " +
+      "them first — a bypassed node is dropped during serialization and will not trip this " +
+      "check.",
+  );
+  // An empty registry is a page that registered NOTHING — still no observation.
+  assert.deepEqual(describeUnrunnable(["7"], [{ id: 7, type: "Foo" }], {}), [{ id: "7", type: "Foo" }]);
+});
+
+test("#1648 CALL SITE 3: the page's registry is read, and an unnamed node stays unknown", () => {
+  const registry = { KSampler: {}, LoadImage: {} };
+  assert.deepEqual(describeUnrunnable(["7"], [{ id: 7, type: "SetNode" }], registry), [
+    { id: "7", type: "SetNode", registered: false },
+  ]);
+  assert.deepEqual(describeUnrunnable(["8"], [{ id: 8, type: "KSampler" }], registry), [
+    { id: "8", type: "KSampler", registered: true },
+  ]);
+  // A node the graph could not name tells us nothing about registration.
+  assert.deepEqual(describeUnrunnable(["9"], [], registry), [{ id: "9", type: null, registered: null }]);
+});
+
+test("#1648 CALL SITE 3: an unregistered type prescribes a TAB RELOAD, not another restart", () => {
+  // The reporter had installed the pack and restarted ComfyUI, and was told to install the
+  // pack and restart ComfyUI. The remedy they were missing is the one the old text lacked.
+  const msg = missingNodeRunRefusal([
+    { id: "7", type: "SetNode", registered: false },
+    { id: "8", type: "GetNode", registered: false },
+  ]);
+  assert.match(msg, /^NOT queued: 2 nodes/);
+  assert.match(msg, /This page has no node class registered for SetNode, GetNode/);
+  assert.match(msg, /RELOAD the ComfyUI tab/);
+  assert.match(msg, /restarting the server does NOT add its node classes to a tab\s+that was already open/);
+  assert.match(msg, /already installed the\s+pack and restarted ComfyUI, do that first/);
+  assert.match(msg, /FRONTEND-ONLY node type/);
+  assert.match(msg, /bypass/); // the escape hatch survives every branch
+  // It must still be unmistakable that nothing reached the queue.
+  assert.match(msg, /Nothing was sent and the queue is\s+untouched/);
+});
+
+test("#1648 CALL SITE 3: a REGISTERED type is not sent to reload the tab", () => {
+  // Fixing the wrong remedy must not install a new wrong one. Nothing is missing from this
+  // page, so "reload" would send the user round the same loop from the other side.
+  const msg = missingNodeRunRefusal([{ id: "7", type: "SomeDisplayNode", registered: true }]);
+  assert.match(msg, /DOES have a node class registered for SomeDisplayNode/);
+  assert.match(msg, /reloading will not change it/);
+  assert.doesNotMatch(msg, /RELOAD the ComfyUI tab/);
+  assert.doesNotMatch(msg, /install the pack that provides these types/);
+});
+
+test("#1648 CALL SITE 3: one unregistered offender in a mixed set still gets the reload remedy", () => {
+  const msg = missingNodeRunRefusal([
+    { id: "7", type: "SomeDisplayNode", registered: true },
+    { id: "8", type: "SetNode", registered: false },
+  ]);
+  assert.match(msg, /RELOAD the ComfyUI tab/);
+  // Only the type the claim is true of is named in it.
+  assert.match(msg, /no node class registered for SetNode\b/);
+  assert.doesNotMatch(msg, /no node class registered for SomeDisplayNode/);
+});
+
+test("#1648 CALL SITE 3: the bounded list still says how many were withheld", () => {
+  const many = Array.from({ length: 30 }, (_, i) => ({ id: String(i), type: `T${i}`, registered: false }));
+  const msg = missingNodeRunRefusal(many);
+  assert.match(msg, /30 nodes/);
+  assert.match(msg, /and 18 more/);
+});
+
+test("#1648 CALL SITE 3 WIRING: graph_run hands the refusal this page's registry", () => {
+  const at = PANEL.indexOf("const badIds = unrunnableNodeIds(built);");
+  assert.ok(at > 0, "the pre-flight must still be recognisable");
+  const end = PANEL.indexOf("} catch (err) {", at);
+  assert.ok(end > at, "the pre-flight's try block must still be recognisable");
+  const block = PANEL.slice(at, end);
+  assert.match(block, /describeUnrunnable\(\s*badIds,\s*liveNodes,\s*\(window\.LiteGraph \?\? globalThis\.LiteGraph\)\?\.registered_node_types,?\s*\)/);
+  // NOT `?? {}` — an absent LiteGraph must stay UNKNOWN rather than assert "not registered"
+  // for every type, which would prescribe a tab reload off no evidence at all.
+  assert.doesNotMatch(block, /registered_node_types \?\? \{\}/);
+});
+
+test("#1648 CALL SITE 3 WIRING: the registry is diagnosis only — the refusal is still the prompt", () => {
+  const at = PANEL.indexOf("const badIds = unrunnableNodeIds(built);");
+  const end = PANEL.indexOf("} catch (err) {", at);
+  const block = PANEL.slice(at, end);
+  // The go/no-go remains `unrunnableNodeIds(built)`; the registry appears only inside the
+  // message construction. A guard keyed on the registry would refuse runs that succeed.
+  assert.match(block, /if \(badIds\.length\) \{/);
+  assert.equal((block.match(/registered_node_types/g) ?? []).length, 1);
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -326,6 +326,7 @@ import { describeMissingNode, describeRailNodeTarget } from "./lib/node-scope-lo
 import { findExistingRailSlot } from "./lib/rail-slot.js";
 import { VENDORED_VOCABULARY_HASH } from "./lib/vocabulary-hash.js";
 import { managerFetchFailureMessage } from "./lib/manager-fetch-failure.js";
+import { withoutFrontendVirtualTypes } from "./lib/frontend-virtual-nodes.js";
 import {
   unrunnableNodeIds,
   describeUnrunnable,
@@ -8787,6 +8788,34 @@ function collectMissingAssets(trustComboOverride) {
           ? (Object.values(raw).find(Array.isArray) ?? Object.keys(raw))
           : [];
       nodeTypes = [...new Set(pool.map(asType).filter(Boolean))];
+      // comfyui-mcp#1657 / panel#1284 — a FRONTEND VIRTUAL node is not a missing one.
+      //
+      // `missingNodesError` is a LOAD-TIME snapshot the frontend never re-evaluates
+      // (stale-placeholders.js measured exactly that), so it keeps naming a type after the
+      // page learned to resolve it. On a canvas whose packs ARE loaded that surfaced
+      // GetNode/SetNode/MarkdownNote/Label (rgthree) as missing on a workflow whose most
+      // recent run had succeeded.
+      //
+      // The live graph is the only thing that can say which of the two happened, and it
+      // says it POSITIVELY: a type is dropped only when every instance of it on the canvas
+      // declares `isVirtualNode === true`, the flag ComfyUI's own serializer reads to skip
+      // a node. A pack that is NOT loaded leaves defless placeholders that carry no such
+      // flag, so panel#1284's own GetNode/SetNode — same rig as comfyui-mcp#1648, where the
+      // tab had never loaded KJNodes' JS — stay reported, and the run that would have
+      // failed is still refused. A name allowlist gets that case backwards.
+      //
+      // Filtered HERE, in the shared collector, so graph_get_errors, the turn-start
+      // validation banner and the stale-red-flag adjudication cannot disagree about it —
+      // this family recurred three times precisely because each call site decided
+      // separately.
+      try {
+        nodeTypes = withoutFrontendVirtualTypes(
+          nodeTypes,
+          collectAllGraphs(getGraphCtx().rootGraph).flatMap((g) => g?._nodes ?? []),
+        );
+      } catch {
+        /* no readable graph → nothing is proven virtual → every type stays reported */
+      }
     }
   } catch {
     /* optional */
@@ -14025,7 +14054,27 @@ const GRAPH_TOOL_EXECUTORS = {
       const badIds = unrunnableNodeIds(built);
       if (badIds.length) {
         const liveNodes = Array.isArray(graph?._nodes) ? graph._nodes : [];
-        throw new Error(missingNodeRunRefusal(describeUnrunnable(badIds, liveNodes)));
+        // comfyui-mcp#1648 — hand the refusal THIS PAGE's litegraph registry so it can
+        // tell "the pack is not installed" apart from "the pack is installed and this TAB
+        // never loaded its frontend JS". The reporter had already done everything the old
+        // message asked for; only the registry distinguishes their case, and for a
+        // frontend-only type (Get/Set bus, rgthree toggles) nothing else can — those never
+        // appear in /object_info at all. DIAGNOSIS ONLY: the refusal is still decided by
+        // the serialized prompt above, unchanged.
+        //
+        // Read the same way the #1582 branch does — `LG` is a local in other functions and
+        // is NOT in scope here; the panel-scope gate caught that as a live ReferenceError.
+        // Passed possibly-undefined ON PURPOSE: an unreadable registry must stay UNKNOWN
+        // and reproduce the previous message, never assert "not registered".
+        throw new Error(
+          missingNodeRunRefusal(
+            describeUnrunnable(
+              badIds,
+              liveNodes,
+              (window.LiteGraph ?? globalThis.LiteGraph)?.registered_node_types,
+            ),
+          ),
+        );
       }
     } catch (err) {
       // Only OUR refusal propagates. Anything else (a broken fetch, a frontend

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -8808,11 +8808,18 @@ function collectMissingAssets(trustComboOverride) {
       // validation banner and the stale-red-flag adjudication cannot disagree about it —
       // this family recurred three times precisely because each call site decided
       // separately.
+      //
+      // Guarded on a non-empty list so the graph walk is not paid for at all in the
+      // common case. `clearStaleRedFlag` calls this collector once per linked neighbour
+      // after a subgraph conversion, and that is the one caller where a per-call walk
+      // would compound.
       try {
-        nodeTypes = withoutFrontendVirtualTypes(
-          nodeTypes,
-          collectAllGraphs(getGraphCtx().rootGraph).flatMap((g) => g?._nodes ?? []),
-        );
+        if (nodeTypes.length) {
+          nodeTypes = withoutFrontendVirtualTypes(
+            nodeTypes,
+            collectAllGraphs(getGraphCtx().rootGraph).flatMap((g) => g?._nodes ?? []),
+          );
+        }
       } catch {
         /* no readable graph → nothing is proven virtual → every type stays reported */
       }

--- a/web/js/lib/frontend-virtual-nodes.js
+++ b/web/js/lib/frontend-virtual-nodes.js
@@ -64,6 +64,12 @@
  * (absent flag, unreadable node, no live instance at all) keeps the node reported,
  * which is the direction that costs noise rather than a missed diagnosis.
  *
+ * The one input that would defeat this is a placeholder that somehow arrives WITH the
+ * flag, which would need a workflow file to carry it. It cannot: enumerated across the
+ * shipped 1.48.7 bundle there are 11 occurrences of `isVirtualNode`, and every one is a
+ * class declaration or a read — the graph serializer does not emit it, so no saved
+ * workflow can put it on a node whose class was never registered.
+ *
  * ## Why the write guards' extra clause is not required here
  *
  * `node-resolve.js` additionally demands no backend provenance on the class, because it

--- a/web/js/lib/frontend-virtual-nodes.js
+++ b/web/js/lib/frontend-virtual-nodes.js
@@ -1,0 +1,141 @@
+/**
+ * comfyui-mcp#1657 / panel#1284 — "absent from /object_info" is not "missing".
+ *
+ * Three surfaces answered the question "is this node type real?" with a single
+ * observation — the server's /object_info does not list it — and that observation
+ * cannot tell apart:
+ *
+ *   A. a node the FRONTEND registers as VIRTUAL, which never reaches the backend and
+ *      is absent from /object_info BY DESIGN (KJNodes' Get/Set bus, rgthree's Label
+ *      and Fast Groups toggles, litegraph's own Note/Reroute/PrimitiveNode); and
+ *   B. a node whose pack is not installed, or whose frontend JS this tab never
+ *      loaded, so litegraph minted a defless PLACEHOLDER for it.
+ *
+ * Both are absent from /object_info. Only B is a fault. Collapsing them reports a
+ * working 422-node canvas as a wall of missing node types (#1657), which is the
+ * report the user then acts on.
+ *
+ * ## Why not a list of type names
+ *
+ * Because a list gets case B wrong, and case B is real: panel#1284 and comfyui-mcp#1648
+ * come from the SAME rig (darwin, ComfyUI 0.33.1, frontend 1.48.7, panel 0.14.41), where
+ * `GetNode`/`SetNode` were reported by ComfyUI's OWN missing-nodes store because that
+ * tab's frontend had never loaded KJNodes' JS. On that rig those nodes really were dead,
+ * and a name allowlist containing "GetNode"/"SetNode" would have declared them fine and
+ * sent a broken run to the queue. A list is also stale the moment a pack ships a new
+ * virtual node — which is how this recurred three times.
+ *
+ * ## The derivable signal
+ *
+ * `node.isVirtualNode === true`, read off the live node INSTANCE. This is not a
+ * heuristic and not this repo's invention — it is the exact flag ComfyUI's own
+ * serializer uses to decide what never reaches the backend. Verified in the shipped
+ * frontend 1.48.7 bundle:
+ *
+ *     for (let e of i.values()) {
+ *       if (e.isVirtualNode || e.mode === NEVER || e.mode === BYPASS) continue;
+ *       ...
+ *       a[String(e.id)] = { inputs: t, class_type: e.comfyClass, ... }
+ *     }
+ *
+ * and its `ExecutableNodeDTO` proxies it straight through
+ * (`get isVirtualNode() { return this.node.isVirtualNode }`). So this flag is the ONLY
+ * thing standing between a virtual node and a `class_type: undefined` prompt entry —
+ * exactly the property these surfaces need, asserted by the authority that acts on it.
+ *
+ * Verified against the three packs on this machine's install, which set it in their own
+ * source rather than having it inferred for them:
+ *   - comfyui-kjnodes/web/js/setgetnodes.js  — `this.isVirtualNode = true` on SetNode
+ *     and GetNode ("purely frontend and does not impact the resulting prompt").
+ *   - rgthree-comfy/web/comfyui/base_node.js — `RgthreeBaseVirtualNode` sets it, and
+ *     Label, Fast Groups Bypasser/Muter, Fast Bypasser/Muter, Node Collector and
+ *     Reroute (rgthree) all extend it.
+ *   - the ComfyUI frontend itself — Note, MarkdownNote, PrimitiveNode, Reroute.
+ *
+ * A pack nobody has heard of yet is covered on the same terms, because a virtual node
+ * that does NOT set this flag is serialized into the prompt and fails at the server —
+ * so a pack cannot both omit the flag and work.
+ *
+ * ## What this deliberately does NOT claim
+ *
+ * A defless PLACEHOLDER never carries this flag: litegraph mints it for a type no class
+ * was registered for, so nothing set it. That is what keeps case B reported. The
+ * predicate is a POSITIVE proof of virtuality and nothing else — every other shape
+ * (absent flag, unreadable node, no live instance at all) keeps the node reported,
+ * which is the direction that costs noise rather than a missed diagnosis.
+ *
+ * ## Why the write guards' extra clause is not required here
+ *
+ * `node-resolve.js` additionally demands no backend provenance on the class, because it
+ * authorizes WRITES and a fabricated success there is the #458 hole. These call sites
+ * only decide what to REPORT, and the extra clause would be actively wrong for them: the
+ * frontend STAMPS a synthesized def on every subgraph container's class
+ * (registerSubgraphNodeDef), so requiring provenance-cleanliness would put subgraph
+ * containers — also `isVirtualNode`, also absent from /object_info by design — back on
+ * the missing list this exists to clean up.
+ */
+
+/**
+ * POSITIVE proof that this live node instance is a frontend virtual node: it is never
+ * serialized into a prompt, so its absence from /object_info is expected, not a fault.
+ *
+ * Defensive: anything unreadable answers false, i.e. stays reported.
+ */
+export function isFrontendVirtualNode(node) {
+  try {
+    return !!node && typeof node === "object" && node.isVirtualNode === true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * The node types among `nodes` whose EVERY live instance is a frontend virtual node.
+ *
+ * "Every", not "any": one registered class decides a type's virtuality, so the two agree
+ * in practice — but if a type ever presents both a virtual instance and a placeholder in
+ * the same tab, that type has a real problem and must keep being reported. Requiring
+ * unanimity makes the ambiguous case fail toward reporting.
+ *
+ * A type with NO live instance yields nothing, so a load-time store entry that outlived
+ * its nodes is never cleared by this.
+ */
+export function frontendVirtualTypesAmong(nodes) {
+  const virtual = new Set();
+  const refuted = new Set();
+  try {
+    for (const node of Array.isArray(nodes) ? nodes : []) {
+      let type = null;
+      try {
+        type = typeof node?.type === "string" && node.type ? node.type : null;
+      } catch {
+        type = null;
+      }
+      if (!type) continue;
+      if (isFrontendVirtualNode(node)) virtual.add(type);
+      else refuted.add(type);
+    }
+  } catch {
+    /* a malformed graph exempts nothing — every type stays reported */
+  }
+  for (const t of refuted) virtual.delete(t);
+  return virtual;
+}
+
+/**
+ * Drop the frontend-virtual types from a list of allegedly-missing node types.
+ *
+ * `types` is ComfyUI's own load-time `missingNodesError` record, which the frontend
+ * never re-evaluates (see stale-placeholders.js) — so it keeps naming a type long after
+ * the pack that provides it started working, and it names virtual types whose pack is
+ * working perfectly. `nodes` is the live graph (every scope), the only thing that can
+ * say which of those two happened.
+ *
+ * Order-preserving, and a no-op on any input it cannot read.
+ */
+export function withoutFrontendVirtualTypes(types, nodes) {
+  if (!Array.isArray(types) || !types.length) return Array.isArray(types) ? types : [];
+  const virtual = frontendVirtualTypesAmong(nodes);
+  if (!virtual.size) return types;
+  return types.filter((t) => !virtual.has(t));
+}

--- a/web/js/lib/live-combo-availability.js
+++ b/web/js/lib/live-combo-availability.js
@@ -35,6 +35,8 @@
  * set a lora basename while the dropdown was empty.
  */
 
+import { isFrontendVirtualNode } from "./frontend-virtual-nodes.js";
+
 /** Inputs whose combo lists name files on disk, rather than modes like
  *  `sampler_name: [euler, …]`. A value outside ANY combo's options is a genuine
  *  problem, but only these are missing ASSETS, and calling a bad scheduler a
@@ -182,6 +184,24 @@ export async function scanComboAvailability(
   for (const node of nodes) {
     const className = typeof node?.type === "string" ? node.type : null;
     if (!className || !Array.isArray(node.widgets)) continue;
+    // comfyui-mcp#1657 / panel#1284 — a FRONTEND VIRTUAL node is skipped BEFORE the
+    // lookup, not reported as unchecked after it.
+    //
+    // These have no /object_info entry by design and never reach the server, so there is
+    // no combo for the server to judge their widget values against. Sending them through
+    // the scan produced `{reason: "node type not found in /object_info"}` on a working
+    // canvas — a sentence that reads as an accusation about a missing pack, on nodes whose
+    // pack is installed and functioning. On the reported 422-node workflow that filled the
+    // error surface (GetNode, SetNode, MarkdownNote, Label (rgthree), Fast Bypasser).
+    //
+    // "Skipped" here means NOTHING IS CLAIMED, which is honest rather than lenient: there
+    // was never a judgement available to withhold. It costs no coverage — a virtual node's
+    // widget value is not a server-side asset — and it saves a wasted round trip plus a
+    // slot in the class cap, so a large canvas spends its budget on nodes that can fail.
+    //
+    // A node whose pack is NOT loaded is a defless placeholder, carries no `isVirtualNode`,
+    // and is still scanned and still reported (see frontend-virtual-nodes.js).
+    if (isFrontendVirtualNode(node)) continue;
     const entry = await comboMapFor(className);
     if (!entry.combos) {
       // Unjudgeable. Report the node once, with the REASON it was skipped — a

--- a/web/js/lib/missing-node-preflight.js
+++ b/web/js/lib/missing-node-preflight.js
@@ -285,22 +285,30 @@ export function missingNodeRunRefusal(offenders) {
     );
   }
 
-  // Every offender's type IS registered here, so nothing is missing from this page and a
-  // reload changes nothing. Only what the serializer observed is asserted: it takes an
-  // entry's class_type from the node's own `comfyClass`, and it omits a node entirely when
-  // that node reports `isVirtualNode` — so an entry that arrived with neither came from a
+  // Every type this page WAS ASKED ABOUT is registered here, so a reload changes nothing
+  // for those. Only what the serializer observed is asserted: it takes an entry's
+  // class_type from the node's own `comfyClass`, and it omits a node entirely when that
+  // node reports `isVirtualNode` — so an entry that arrived with neither came from a
   // registered class that has no backend node behind it and does not declare itself
   // virtual. Nothing is claimed about which pack is at fault or how to repair it.
+  //
+  // SCOPED to the offenders the graph could name. A node the canvas could not name has an
+  // unknown type, so nothing was established about it and the sentence must not sweep it
+  // in — that would be a claim of "nothing is missing" built on a node never looked at.
+  const unnamed = all.length - observed.length;
   return (
     head +
-    `This page DOES have a node class registered for ${typeList(observed)} — so nothing is ` +
-    `missing here and reloading will not change it — but the serializer still emitted no ` +
-    `class_type for them, ` +
+    `This page DOES have a node class registered for ${typeList(observed)}, so reloading ` +
+    `will not change those — but the serializer still emitted no class_type for them, ` +
     tail +
     `An entry's class_type comes from the node's own comfyClass, and a node that reports ` +
     `isVirtualNode is left out of the prompt entirely; these did neither, so the registered ` +
     `class has no backend node behind it and does not declare itself virtual. That is a ` +
     `problem in the pack's own frontend node rather than anything this ComfyUI is missing. ` +
+    (unnamed
+      ? `The other ${unnamed} node${unnamed === 1 ? "" : "s"} could not be named from the ` +
+        `canvas, so nothing is established about ${unnamed === 1 ? "it" : "them"}. `
+      : "") +
     BYPASS_NOTE
   );
 }

--- a/web/js/lib/missing-node-preflight.js
+++ b/web/js/lib/missing-node-preflight.js
@@ -153,17 +153,56 @@ export function unserializableGraphRefusal(types) {
  * The serialized entry has lost the type — that is precisely why it is unrunnable — so
  * the canvas is consulted for LABELS ONLY, never to decide whether to refuse. A node
  * the graph cannot name still counts; it is reported by id.
+ *
+ * comfyui-mcp#1648 — `registry` (this page's `LiteGraph.registered_node_types`) is
+ * consulted for the DIAGNOSIS only, never for the refusal. The refusal is still decided
+ * entirely by the serialized prompt, exactly as before; this only lets the message tell
+ * apart two states it used to collapse (see `missingNodeRunRefusal`).
+ *
+ * Each entry gains `registered: true | false` when a registry was supplied, and the key
+ * is OMITTED entirely when it was not — a caller that cannot read the registry says
+ * nothing about registration rather than claiming `false` for everything. A registry
+ * object with no own keys is treated the same way: a page that registered NOTHING has
+ * not observed anything about this type either.
  */
-export function describeUnrunnable(ids, liveNodes) {
+export function describeUnrunnable(ids, liveNodes, registry) {
   const byId = new Map();
   for (const n of Array.isArray(liveNodes) ? liveNodes : []) {
     if (n && n.id != null) byId.set(String(n.id), n);
   }
+  let reg = null;
+  try {
+    if (registry && typeof registry === "object" && Object.keys(registry).length > 0) {
+      reg = registry;
+    }
+  } catch {
+    reg = null; // an unreadable registry is "unknown", never "not registered"
+  }
   return ids.map((id) => {
     const n = byId.get(id);
     const type = typeof n?.type === "string" && n.type ? n.type : null;
-    return { id, type };
+    if (!reg) return { id, type };
+    return {
+      id,
+      type,
+      // A node the graph could not even name tells us nothing about registration.
+      registered: type == null ? null : Object.prototype.hasOwnProperty.call(reg, type),
+    };
   });
+}
+
+/** The escape hatch, kept identical in every branch: a caller with deliberately-optional
+ *  nodes must never be stuck, and a bypassed node is dropped during serialization. */
+const BYPASS_NOTE =
+  `If you expected these nodes to be optional, delete or bypass them first — a bypassed ` +
+  `node is dropped during serialization and will not trip this check.`;
+
+/** Up to six distinct type names from a set of offenders, for a sentence. */
+function typeList(offenders) {
+  const types = [...new Set(offenders.map((o) => o?.type).filter((t) => typeof t === "string" && t))];
+  if (!types.length) return "them";
+  const shown = types.slice(0, 6).join(", ");
+  return types.length > 6 ? `${shown}, and ${types.length - 6} more` : shown;
 }
 
 /**
@@ -171,23 +210,97 @@ export function describeUnrunnable(ids, liveNodes) {
  *
  * Prefixed `NOT queued:` so the caller can tell a refusal from an incidental error in
  * the same block, and so it is unmistakable that nothing was sent.
+ *
+ * ## comfyui-mcp#1648 — the refusal was right and the remedy was wrong
+ *
+ * The reporter installed KJNodes, restarted ComfyUI, and was told by this message to
+ * install the pack and restart ComfyUI. They had. The refusal itself was correct — their
+ * companion report (panel#1284, same rig) shows ComfyUI's OWN missing-nodes store naming
+ * `GetNode`/`SetNode`, so those nodes really were placeholders and the run really would
+ * have failed validation. What was wrong is that this text named ONE cause for a state
+ * that has two, and named the one they had already ruled out:
+ *
+ *   1. the pack is not installed; or
+ *   2. the pack IS installed and the SERVER is fine, but THIS BROWSER TAB never loaded
+ *      the pack's frontend JS — those scripts are fetched when the ComfyUI page loads, so
+ *      a server restart does not put new node classes into an already-open tab.
+ *
+ * Case 2 is the whole story for a FRONTEND-ONLY node type (the Get/Set bus, rgthree's
+ * canvas-only toggles): it never appears in /object_info at all, so no amount of asking
+ * the server distinguishes "not installed" from "installed, tab is stale". The one thing
+ * that does distinguish them is THIS PAGE's own litegraph registry, which is what
+ * `describeUnrunnable` now reads. When it has no class for the type, "reload the tab"
+ * is a remedy the old text never offered.
+ *
+ * With no registry reading available the message is byte-identical to before — an
+ * unobserved registry must not become a claim about one.
  */
 export function missingNodeRunRefusal(offenders) {
-  const list = (Array.isArray(offenders) ? offenders : []).map((o) =>
-    o?.type ? `${o.type} (node ${o.id})` : `node ${o.id}`,
-  );
+  const all = Array.isArray(offenders) ? offenders : [];
+  const list = all.map((o) => (o?.type ? `${o.type} (node ${o.id})` : `node ${o.id}`));
   const shown = list.slice(0, 12);
   const more = list.length > shown.length ? `, and ${list.length - shown.length} more` : "";
   const plural = list.length === 1 ? "" : "s";
-  return (
+  const head =
     `NOT queued: ${list.length} node${plural} in this workflow cannot be executed by the ` +
-    `server — ${shown.join(", ")}${more}. Their node types are not registered on this ` +
-    `ComfyUI, so the prompt was built with no class_type for them and would have failed ` +
+    `server — ${shown.join(", ")}${more}. `;
+  const tail =
+    `so the prompt was built with no class_type for them and would have failed ` +
     `validation after being queued (comfyui-mcp#1460). Nothing was sent and the queue is ` +
-    `untouched. This usually means a custom-node pack is missing or failed to load: ` +
-    `install the pack that provides these types (list_packs / install_custom_node), ` +
-    `restart ComfyUI so the frontend registers them, then run again. If you expected ` +
-    `these nodes to be optional, delete or bypass them first — a bypassed node is ` +
-    `dropped during serialization and will not trip this check.`
+    `untouched. `;
+
+  const observed = all.filter((o) => typeof o?.registered === "boolean");
+  const unregistered = observed.filter((o) => o.registered === false);
+
+  // Nothing was observed about this page's registry — say exactly what was said before.
+  if (!observed.length) {
+    return (
+      head +
+      `Their node types are not registered on this ComfyUI, ` +
+      tail +
+      `This usually means a custom-node pack is missing or failed to load: ` +
+      `install the pack that provides these types (list_packs / install_custom_node), ` +
+      `restart ComfyUI so the frontend registers them, then run again. ` +
+      BYPASS_NOTE
+    );
+  }
+
+  if (unregistered.length) {
+    return (
+      head +
+      `This page has no node class registered for ${typeList(unregistered)}, ` +
+      tail +
+      `TWO different things produce that, and they need different fixes. ` +
+      `(1) The pack is not installed — install it (list_packs / install_custom_node) and ` +
+      `restart ComfyUI. ` +
+      `(2) The pack IS installed and the server is fine, but THIS BROWSER TAB never loaded ` +
+      `its frontend JS: a pack's scripts are fetched when the ComfyUI page loads, so ` +
+      `installing a pack and restarting the server does NOT add its node classes to a tab ` +
+      `that was already open — RELOAD the ComfyUI tab. If you have already installed the ` +
+      `pack and restarted ComfyUI, do that first. ` +
+      `Case (2) is the only possibility for a FRONTEND-ONLY node type (KJNodes' Get/Set ` +
+      `bus, rgthree's Label and Fast Groups toggles): those never appear in /object_info ` +
+      `at all, so nothing the server reports can confirm or deny them. ` +
+      BYPASS_NOTE
+    );
+  }
+
+  // Every offender's type IS registered here, so nothing is missing from this page and a
+  // reload changes nothing. Only what the serializer observed is asserted: it takes an
+  // entry's class_type from the node's own `comfyClass`, and it omits a node entirely when
+  // that node reports `isVirtualNode` — so an entry that arrived with neither came from a
+  // registered class that has no backend node behind it and does not declare itself
+  // virtual. Nothing is claimed about which pack is at fault or how to repair it.
+  return (
+    head +
+    `This page DOES have a node class registered for ${typeList(observed)} — so nothing is ` +
+    `missing here and reloading will not change it — but the serializer still emitted no ` +
+    `class_type for them, ` +
+    tail +
+    `An entry's class_type comes from the node's own comfyClass, and a node that reports ` +
+    `isVirtualNode is left out of the prompt entirely; these did neither, so the registered ` +
+    `class has no backend node behind it and does not declare itself virtual. That is a ` +
+    `problem in the pack's own frontend node rather than anything this ComfyUI is missing. ` +
+    BYPASS_NOTE
   );
 }


### PR DESCRIPTION
A backlog audit grouped `artokun/comfyui-mcp#1400`, `artokun/comfyui-mcp#1648` and
`artokun/comfyui-mcp#1657` as one family across three call sites. Two of the three are
panel-side and are fixed here; the third stays where its owner parked it. The audit's
prescription — "make the call sites consult `FRONTEND_ONLY_NODE_TYPES`" — is refuted
below, with the case that refutes it.

## The shared mechanism

Three surfaces answer "is this node type real?" from ONE observation — the server's
`/object_info` does not list it — and that observation cannot tell apart:

* **A.** a node the FRONTEND registers as VIRTUAL, absent from `/object_info` **by
  design** (KJNodes' Get/Set bus, rgthree's Label and Fast Groups toggles, litegraph's
  own Note / MarkdownNote / Reroute / PrimitiveNode); and
* **B.** a node whose class this page never registered, so litegraph left a defless
  PLACEHOLDER.

Both are absent from `/object_info`. Only **B** is a fault. Collapsed, they report a
working 422-node canvas as a wall of missing node types.

## The derivable signal — not a list of names

`node.isVirtualNode === true`, read off the live node instance. Not a heuristic and not
this repo's invention: it is the exact flag ComfyUI's own serializer reads to decide what
never reaches the backend. From the shipped frontend 1.48.7 bundle:

```js
for (let e of i.values()) {
  if (e.isVirtualNode || e.mode === NEVER || e.mode === BYPASS) continue;
  ...
  a[String(e.id)] = { inputs: t, class_type: e.comfyClass, _meta: { title: e.title } }
}
```

and its `ExecutableNodeDTO` proxies it straight through
(`get isVirtualNode() { return this.node.isVirtualNode }`). So this flag is the only thing
standing between a virtual node and a `class_type: undefined` prompt entry — exactly the
property these surfaces need, asserted by the authority that acts on it.

Confirmed in each pack's own source on this machine's install, rather than inferred:

| source | sets it |
|---|---|
| `comfyui-kjnodes/web/js/setgetnodes.js` | `this.isVirtualNode = true` on `SetNode` and `GetNode` — their own comment: "purely frontend and does not impact the resulting prompt" |
| `rgthree-comfy/web/comfyui/base_node.js` | `RgthreeBaseVirtualNode`, extended by Label, Fast Groups Bypasser/Muter, Fast Bypasser/Muter, Node Collector, Reroute (rgthree) |
| the ComfyUI frontend itself | Note, MarkdownNote, PrimitiveNode, Reroute, `SubgraphNode` |

A pack nobody has heard of yet is covered on the same terms: a virtual node that does not
set this flag is serialized into the prompt and rejected by the server, so a pack cannot
both omit the flag and work.

## Refutation of the audit's prescription

**`FRONTEND_ONLY_NODE_TYPES` is two different sets in two repos, and the audit read the
wrong one.** The panel's (`web/js/lib/node-resolve.js`) has listed Label, Fast Groups
Bypasser/Muter, Fast Bypasser/Muter, Node Collector, Reroute (rgthree), SetNode and
GetNode since #475/#496. Only the orchestrator's
(`comfyui-mcp/src/services/workflow-converter.ts`) is limited to
Reroute/Note/MarkdownNote/PrimitiveNode + the Get/Set bus. So "rgthree Label and Fast
Groups are absent" holds for `check_runtime` only.

**And adopting that list at these call sites would have shipped a bug.** `panel#1284` and
`artokun/comfyui-mcp#1648` come from the SAME rig — darwin, ComfyUI 0.33.1, frontend
1.48.7, comfyui-mcp 0.51.56, panel 0.14.41 — and on it ComfyUI's OWN missing-nodes store
named `GetNode`/`SetNode`, because that tab had never loaded KJNodes' JS. Those nodes
really were dead placeholders. A name allowlist containing "GetNode"/"SetNode" would have
declared them fine and sent a run to the queue that could not execute.

The same predicate gives the RIGHT answer on both rigs, which is the whole argument for
it: on `#1657`'s rig the packs are loaded, the instances report `isVirtualNode`, and they
are dropped; on `#1284`'s rig they are placeholders, report nothing, and stay reported.

The audit's second clause — "`panel_run` and `panel_get_errors` never consult it" — is
literally true and, for `panel_run`, deliberately so: that pre-flight reads the SERIALIZED
prompt precisely so it does not need a name list (#1460). It is not changed here.

## Per-call-site changes

**1. `panel_get_errors`' live combo scan** (`live-combo-availability.js`) — the source of
the verbatim `"node type not found in /object_info"` reason both reporters quote. A
virtual node has no backend definition and therefore no combo the server could judge, so
it is now skipped BEFORE the per-class lookup. Nothing is claimed about it, which is
honest rather than lenient — there was never a judgement available to withhold — and it
saves a wasted round trip plus a slot in the 80-class cap.

**2. `collectMissingAssets`** (`comfyui-mcp-panel.js`) — the shared collector behind
`missing_node_types`. ComfyUI's `missingNodesError` store is a LOAD-TIME snapshot the
frontend never re-evaluates (`stale-placeholders.js` measured exactly that), so it keeps
naming a type after the page learned to resolve it. A type is dropped only when EVERY live
instance of it declares `isVirtualNode`. Filtered in the collector rather than in
`graph_get_errors`, so the tool, the turn-start validation banner and the stale-red-flag
adjudication cannot disagree — this family reached three call sites because each site
decided separately.

**3. `panel_run`'s pre-flight refusal** (`missing-node-preflight.js`) — **the refusal was
right and the remedy was wrong.** `#1648`'s reporter installed KJNodes, restarted ComfyUI,
and was told by this message to install the pack and restart ComfyUI. The message named
ONE cause for a state that has two, and named the one they had already ruled out. It now
reads this page's litegraph registry (DIAGNOSIS ONLY — the go/no-go is still
`unrunnableNodeIds(built)`, unchanged) and distinguishes:

* type not registered here → names both causes and prescribes **RELOAD the ComfyUI tab**,
  because a pack's frontend JS is fetched at page load and a server restart does not add
  its classes to an already-open tab. For a frontend-only type this is the only
  possibility, since nothing the server reports can confirm or deny it.
* type registered here → says so, and explicitly does NOT send the user to reload.
* registry unreadable → the message is **byte-identical to before**, pinned verbatim in a
  test. An unobserved registry must not become a claim about one.

## What stays refused / reported

* `panel_run` refuses exactly the same runs as before — only the text changed. Pinned by a
  wiring test asserting the gate is still the serialized prompt and that
  `registered_node_types` appears exactly once, inside the message construction.
* A type with ANY live placeholder instance → still reported (the unanimity rule).
* A type with NO live instance → still reported; a stale store entry is never cleared this
  way.
* A genuinely uninstalled pack → placeholders, no flag, still reported, run still refused.
* The combo scan's real `unavailable` findings are untouched (pinned).
* `check_runtime` in the orchestrator is not touched at all.

## Refutation (mutation runs)

Each fix was DELETED and the suite re-run. The first attempt reported all-green because
the perl patterns silently failed to match CRLF files — the harness now proves each
mutation landed (byte delta + a post-condition grep) before believing a verdict.

| mutation | result |
|---|---|
| delete the skip in `scanComboAvailability` | RED — killed by the CALL SITE 1 behaviour test **and** its wiring test |
| delete the filter in `collectMissingAssets` | RED — killed by both CALL SITE 2 wiring tests |
| stop passing the registry from `graph_run` | RED — killed by both CALL SITE 3 wiring tests |
| loosen `isVirtualNode === true` to a truthy check | RED |
| drop the unanimity rule | RED |
| make an unreadable registry assert "not registered" (`?? {}`) | RED |

20 new tests, split per call site — a helper-only suite here would have left two of three
unwired and stayed green.

## Verification

* `npm run test:unit` — 5084 tests, 5082 pass, 1 fail: the known `#671`
  `verifyInstalled` wall-clock flake under load. Re-run alone: `manager-install.test.mjs`
  125/125 green. Nothing in this change touches it.
* `npm run typecheck` clean; `npm run test:e2e:list` compiles and discovers 74 specs.
* **Browser e2e NOT run.** It requires a real ComfyUI on `localhost:8188`; that rig is the
  owner's Desktop and is down, and I was instructed not to touch it or borrow another
  instance. No spec in the 32-file suite exercises `graph_get_errors` or `graph_run`'s
  pre-flight, so the gate would have added no coverage for this change — but I did not run
  it and am not implying coverage I do not have.
* Not gated: `codex exec` is exhausted until 2026-08-19 and `claude-gate.mjs` is blocked on
  the weekly limit. The orchestrator gates and merges.

## Issue verdicts

* **`artokun/comfyui-mcp#1657`** — the underlying cause is addressed here: sites 1 and 2.
* **`artokun/comfyui-mcp#1648`** — the underlying cause is addressed here: site 3. Note
  the correction to the report — the refusal was correct on that rig; the misdiagnosis was
  the remedy.
* **`artokun/comfyui-mcp#1400`** — NOT addressed here and deliberately so. Its remaining
  half is `check_runtime`, which is headless and has no node instances to read, and the
  panel command that would carry this signal to it is parked under the freeze by the
  owner's own comment of 2026-08-14. Parking confirmed on the issue, with the signal now
  identified and proven so the parked work has a known shape.
* **`panel#1284`** — the underlying cause is addressed here, and its own `unchecked_nodes`
  complaint goes away. Its `missing_node_types: ["GetNode","SetNode"]` does NOT, and must
  not: on that rig those were placeholders. That issue's thread is where that correction
  belongs.
* **`panel#1296`** (`panel_add_node` rejects Fast Groups Bypasser) — NOT covered. Same
  family, different call site: `assertAddNodeResolvableRefreshing` requires live-registry
  membership, and on a tab that never loaded rgthree's JS there is none. Its refusal text
  has the same defect site 3 fixes here — it sends the user to install a pack they have.
* **`panel#1300`** (`panel_move_group` refuses groups containing Label) — NOT covered.
  Different mechanism: its pre-flight verifies a child WRITE landed by reading position
  back, which is a different collapsed pair and not a node-type question.

