### PR TITLE
fix(1270): panel_show_media video preview uses the source duration

### DIFF
--- a/browser_tests/unit/media-duration.test.mjs
+++ b/browser_tests/unit/media-duration.test.mjs
@@ -1,0 +1,232 @@
+/**
+ * #1270 — the video preview must use the SOURCE duration, not a truncated
+ * default. These tests call the shipped helpers; a source pin then proves
+ * the panel actually uses them.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import {
+  SOURCE_END_EPSILON_S,
+  bindSourcePlayback,
+  durationLooksTruncated,
+  seekableEnd,
+  shouldContinuePastReportedEnd,
+  sourceMediaDuration,
+  storyboardSampleTimes,
+} from "../../web/js/lib/media-duration.js";
+
+const PANEL = readFileSync(
+  fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url)),
+  "utf8",
+);
+
+/** Fake media element: duration + an optional seekable range. */
+function media({ duration, seekable, currentTime = 0 } = {}) {
+  const end = seekable;
+  return {
+    duration,
+    currentTime,
+    ended: false,
+    loop: true,
+    seekable:
+      Number.isFinite(end) && end > 0
+        ? {
+            length: 1,
+            end: (i) => {
+              if (i !== 0) throw new Error("out of range");
+              return end;
+            },
+          }
+        : { length: 0, end: () => 0 },
+  };
+}
+
+// ── source duration ────────────────────────────────────────────────────────
+
+test("#1270: a concat whose element reports the FIRST clip still yields the source length", () => {
+  // The report: 19.56s container, Chromium `duration` = 15s (the generated
+  // clip), seekable still covers the title + clip + end card.
+  const el = media({ duration: 15, seekable: 19.56 });
+  assert.equal(sourceMediaDuration(el), 19.56);
+  assert.equal(durationLooksTruncated(el), true);
+});
+
+test("#1270: when duration and seekable agree, that number is the source", () => {
+  const el = media({ duration: 19.56, seekable: 19.56 });
+  assert.equal(sourceMediaDuration(el), 19.56);
+  assert.equal(durationLooksTruncated(el), false);
+});
+
+test("#1270: Infinity / NaN / 0 duration fall through to the seekable range", () => {
+  assert.equal(sourceMediaDuration(media({ duration: Infinity, seekable: 19.56 })), 19.56);
+  assert.equal(sourceMediaDuration(media({ duration: NaN, seekable: 19.56 })), 19.56);
+  assert.equal(sourceMediaDuration(media({ duration: 0, seekable: 19.56 })), 19.56);
+  assert.equal(sourceMediaDuration(media({ duration: -1, seekable: 19.56 })), 19.56);
+});
+
+test("#1270: no usable number is null — never a default duration", () => {
+  assert.equal(sourceMediaDuration(null), null);
+  assert.equal(sourceMediaDuration(undefined), null);
+  assert.equal(sourceMediaDuration(media({ duration: Infinity })), null);
+  assert.equal(sourceMediaDuration(media({ duration: NaN })), null);
+  assert.equal(sourceMediaDuration({}), null);
+});
+
+test("#1270: a seekable.end that throws is not a duration", () => {
+  const el = {
+    duration: 15,
+    seekable: {
+      length: 1,
+      end: () => {
+        throw new Error("detached");
+      },
+    },
+  };
+  assert.equal(seekableEnd(el), null);
+  assert.equal(sourceMediaDuration(el), 15);
+  assert.equal(durationLooksTruncated(el), false);
+});
+
+test("#1270: the longer of the two finite numbers wins", () => {
+  // Duration can also be the LONGER one (a padded container); do not
+  // prefer seekable just because it exists.
+  assert.equal(sourceMediaDuration(media({ duration: 20, seekable: 15 })), 20);
+});
+
+// ── storyboard samples span the source, not a 5–95% default ────────────────
+
+test("#1270: storyboard samples run from 0 to the source end", () => {
+  const times = storyboardSampleTimes(19.56, 5);
+  assert.equal(times.length, 5);
+  assert.equal(times[0], 0);
+  assert.ok(times[times.length - 1] > 19.5, "the last cell is the source tail, not 95%");
+  assert.ok(times[times.length - 1] < 19.56, "seeking to exact duration often fails");
+  // The previous HEAD=0.05 / TAIL=0.95 default put the first cell at 0.978s
+  // and the last at 18.58s — missing the title card and most of the end card.
+  assert.ok(times[0] < 0.05 * 19.56, "must not skip the first 5%");
+  assert.ok(times[times.length - 1] > 0.95 * 19.56, "must not stop at 95%");
+});
+
+test("#1270: a single cell lands at the midpoint of the SOURCE duration", () => {
+  assert.deepEqual(storyboardSampleTimes(19.56, 1), [9.78]);
+  // Not the midpoint of a truncated 15s default.
+  assert.notDeepEqual(storyboardSampleTimes(19.56, 1), [7.5]);
+});
+
+test("#1270: garbage duration / count produce no timestamps", () => {
+  assert.deepEqual(storyboardSampleTimes(0, 5), []);
+  assert.deepEqual(storyboardSampleTimes(NaN, 5), []);
+  assert.deepEqual(storyboardSampleTimes(Infinity, 5), []);
+  assert.deepEqual(storyboardSampleTimes(19.56, 0), []);
+  assert.deepEqual(storyboardSampleTimes(19.56, -1), []);
+  assert.deepEqual(storyboardSampleTimes(19.56, 0.4), []);
+});
+
+// ── playback continues past a truncated `ended` ────────────────────────────
+
+test("#1270: ended at the reported 15s is not the source end", () => {
+  const el = media({ duration: 15, seekable: 19.56, currentTime: 15 });
+  assert.equal(shouldContinuePastReportedEnd(el), true);
+});
+
+test("#1270: ended at the source tail is the real end", () => {
+  const el = media({ duration: 15, seekable: 19.56, currentTime: 19.56 });
+  assert.equal(shouldContinuePastReportedEnd(el), false);
+});
+
+test("#1270: bindSourcePlayback continues past a false ended, then loops at the source end", () => {
+  const listeners = new Map();
+  const plays = [];
+  const el = media({ duration: 15, seekable: 19.56, currentTime: 15 });
+  el.addEventListener = (name, fn) => {
+    if (!listeners.has(name)) listeners.set(name, []);
+    listeners.get(name).push(fn);
+  };
+  el.removeEventListener = (name, fn) => {
+    const list = listeners.get(name) || [];
+    listeners.set(
+      name,
+      list.filter((f) => f !== fn),
+    );
+  };
+  el.play = () => {
+    plays.push(el.currentTime);
+  };
+
+  const stop = bindSourcePlayback(el, { loop: true });
+  assert.equal(el.loop, false, "native loop would restart at the truncated duration");
+
+  for (const fn of listeners.get("ended") || []) fn();
+  assert.ok(el.currentTime > 15, "must nudge into the remaining source, not restart");
+  assert.ok(el.currentTime < 19.56);
+  assert.equal(plays.length, 1);
+
+  // Real source end → restart from 0.
+  el.currentTime = 19.56;
+  for (const fn of listeners.get("ended") || []) fn();
+  assert.equal(el.currentTime, 0);
+  assert.equal(plays.length, 2);
+
+  stop();
+  assert.equal((listeners.get("ended") || []).length, 0, "unsubscribe must detach");
+});
+
+test("#1270: bindSourcePlayback is a no-op on something that cannot listen", () => {
+  assert.equal(typeof bindSourcePlayback(null), "function");
+  bindSourcePlayback(null)();
+  bindSourcePlayback({})();
+});
+
+test("#1270: the epsilon the helpers share is the one they compare against", () => {
+  // A currentTime inside the epsilon of the source is the end, not "more tail".
+  const el = media({
+    duration: 15,
+    seekable: 19.56,
+    currentTime: 19.56 - SOURCE_END_EPSILON_S + 0.001,
+  });
+  assert.equal(shouldContinuePastReportedEnd(el), false);
+});
+
+// ── the panel actually ships these helpers ─────────────────────────────────
+
+test("#1270: the storyboard builder samples the source duration, not video.duration", () => {
+  const start = PANEL.indexOf("async function buildVideoStoryboard(");
+  assert.ok(start > 0, "could not locate buildVideoStoryboard");
+  const body = PANEL.slice(start, start + 4500);
+  assert.match(body, /sourceMediaDuration\(video\)/, "must read the source duration");
+  assert.match(body, /storyboardSampleTimes\(/, "must sample across that duration");
+  assert.doesNotMatch(
+    body,
+    /const duration = Number\(video\.duration\)/,
+    "the truncated element duration is not the source",
+  );
+  assert.doesNotMatch(body, /STORYBOARD\.HEAD/, "the 5% head skip is the truncated default");
+  assert.doesNotMatch(body, /STORYBOARD\.TAIL/, "the 95% tail cut is the truncated default");
+});
+
+test("#1270: the chat player and the lightbox bind source-duration playback", () => {
+  const mountStart = PANEL.indexOf("function mountHolderVideo(holder) {");
+  const mountEnd = PANEL.indexOf("function unmountHolderVideo(holder) {");
+  assert.ok(mountStart > 0 && mountEnd > mountStart, "could not bound mountHolderVideo");
+  const mount = PANEL.slice(mountStart, mountEnd);
+  assert.match(mount, /preload = "auto"/, "metadata-only preload is what reports the first clip");
+  assert.match(mount, /bindSourcePlayback\(v/, "native loop would cut the tail off");
+
+  const unmount = PANEL.slice(mountEnd, PANEL.indexOf("function paintVideo("));
+  assert.match(unmount, /_releasePlayback/, "unmount must drop the source-loop listeners");
+
+  const lbStart = PANEL.indexOf("if (it.type === \"video\") {");
+  assert.ok(lbStart > 0, "could not locate the lightbox video branch");
+  const lb = PANEL.slice(lbStart, lbStart + 800);
+  assert.match(lb, /bindSourcePlayback\(v/, "the lightbox is the same player");
+});
+
+test("#1270: the panel imports the shipped helpers — deleting the import cannot stay green", () => {
+  assert.match(
+    PANEL,
+    /import \{\s*bindSourcePlayback,\s*sourceMediaDuration,\s*storyboardSampleTimes,\s*\} from "\.\/lib\/media-duration\.js";/,
+  );
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -517,6 +517,11 @@ import {
 import { createRunCompletionTracker } from "./lib/run-completion.js";
 import { composeRunCompletionFrame } from "./lib/run-completion-frame.js";
 import { composeShowMediaReply } from "./lib/media-preview.js";
+import {
+  bindSourcePlayback,
+  sourceMediaDuration,
+  storyboardSampleTimes,
+} from "./lib/media-duration.js";
 import { readyAckCanPromoteBackend } from "./lib/pi-readiness.js";
 import { createRunReconcileSweep } from "./lib/run-reconcile-sweep.js";
 import {
@@ -6970,8 +6975,6 @@ const STORYBOARD = {
   GAP: 6, // px gap between cells
   PAD: 8, // px outer padding
   LABEL: true, // draw a small frame-index label in each cell
-  HEAD: 0.05, // skip the first 5% (likely black/fade-in)
-  TAIL: 0.95, // stop at 95% (likely black/fade-out)
   SEEK_TIMEOUT_MS: 4000, // per-frame seek guard
   META_TIMEOUT_MS: 15000, // loadedmetadata guard
 };
@@ -6999,7 +7002,7 @@ function awaitMediaEvent(el, name, timeoutMs) {
 
 /**
  * Build a contact-sheet/storyboard PNG from a same-origin video URL by sampling
- * N frames evenly across HEAD..TAIL of its duration and tiling them into a grid.
+ * N frames evenly across the SOURCE duration and tiling them into a grid.
  * Same-origin /view means the canvas is NOT tainted, so toBlob works. Returns a
  * PNG Blob, or null if the video can't be decoded/sampled. Never throws.
  */
@@ -7051,15 +7054,17 @@ async function buildVideoStoryboard(url) {
 
   try {
     await awaitMediaEvent(video, "loadedmetadata", STORYBOARD.META_TIMEOUT_MS);
-    const duration = Number(video.duration);
+    // #1270 — `video.duration` on a concat / edit-list MP4 is often the FIRST
+    // clip, not the container. The storyboard samples the source duration.
+    const duration = sourceMediaDuration(video);
     const vw = video.videoWidth;
     const vh = video.videoHeight;
-    if (!isFinite(duration) || duration <= 0 || !vw || !vh) {
+    if (!duration || !vw || !vh) {
       // #1493 — say WHICH. A caller that only sees `null` cannot tell a codec
       // the browser will not decode from a frame it could not paint, and the
       // two need different advice.
       return storyboardFailure(
-        !isFinite(duration) || duration <= 0
+        !duration
           ? "the browser reported no usable duration for it (its codec may not be decodable here — VP9/AV1 .webm is the usual case)"
           : "the browser reported zero video dimensions for it (its codec may not be decodable here)",
       );
@@ -7081,14 +7086,13 @@ async function buildVideoStoryboard(url) {
     ctx.fillStyle = "#111114";
     ctx.fillRect(0, 0, canvas.width, canvas.height);
 
-    // Evenly-spaced timestamps across HEAD..TAIL (skip likely-black head/tail).
-    const lo = duration * STORYBOARD.HEAD;
-    const hi = duration * STORYBOARD.TAIL;
-    const span = Math.max(0, hi - lo);
+    // Evenly-spaced timestamps across the SOURCE duration (#1270). The old
+    // 5%–95% default skipped title/end cards on a concat file.
+    const sampleAt = storyboardSampleTimes(duration, n);
 
     let painted = 0;
     for (let i = 0; i < n; i += 1) {
-      const t = n === 1 ? duration / 2 : lo + (span * i) / (n - 1);
+      const t = sampleAt[i];
       try {
         video.currentTime = Math.min(Math.max(0, t), Math.max(0, duration - 0.01));
         await awaitMediaEvent(video, "seeked", STORYBOARD.SEEK_TIMEOUT_MS);
@@ -26892,6 +26896,10 @@ function buildPanel() {
     // Release any decoded <video> before it leaves the DOM (memory + stop audio).
     const releaseVideo = () => {
       try {
+        mediaWrap._releasePlayback?.();
+      } catch { /* best-effort */ }
+      mediaWrap._releasePlayback = null;
+      try {
         const v = mediaWrap.querySelector("video");
         if (v) { v.pause(); v.removeAttribute("src"); v.load(); }
       } catch { /* best-effort */ }
@@ -26913,8 +26921,10 @@ function buildPanel() {
       if (it.type === "video") {
         const v = document.createElement("video");
         v.src = it.url; v.controls = true; v.autoplay = true; v.loop = true;
-        v.playsInline = true; v.className = "cmcp-lightbox-el";
+        v.playsInline = true; v.preload = "auto"; v.className = "cmcp-lightbox-el";
         mediaWrap.appendChild(v);
+        // #1270 — same source-duration loop as the chat player.
+        mediaWrap._releasePlayback = bindSourcePlayback(v, { loop: true });
         v.play?.().catch(() => {}); // opened by a user gesture; ignore if blocked
       } else {
         const img = document.createElement("img");
@@ -27190,13 +27200,18 @@ function buildPanel() {
     v.loop = true;
     v.playsInline = true;
     v.controls = true;
-    v.preload = "metadata";
+    // #1270 — metadata-only preload is what reports the first clip of a concat
+    // MP4 as the whole duration. Load enough of the source that seekable covers it.
+    v.preload = "auto";
     v.src = holder.dataset.src;
     v.style.cssText = "width:100%;display:block;border-radius:6px;";
     v.addEventListener("loadedmetadata", () => {
       // Learn the real aspect ratio so the placeholder (and layout) match exactly.
       if (v.videoWidth && v.videoHeight) holder.style.aspectRatio = `${v.videoWidth} / ${v.videoHeight}`;
     });
+    // Native `loop` restarts at the (possibly truncated) `duration`. Bind
+    // playback to the source length so a title/end card past that number plays.
+    holder._releasePlayback = bindSourcePlayback(v, { loop: true });
     // #909 — SAY SO when the browser cannot decode it. `show_media` reports the DOM
     // dispatch, not the decode, so an MP4 the browser refuses (the report: MPEG-4 Part 2,
     // `mpeg4`/`mp4v`) answered ok:true and rendered a blank card — indistinguishable from
@@ -27230,6 +27245,12 @@ function buildPanel() {
       // not deterministic release, and unmount will skip this element once `_video` is
       // null, so this is the last chance to do it (codex).
       try {
+        holder._releasePlayback?.();
+      } catch {
+        /* best-effort */
+      }
+      holder._releasePlayback = null;
+      try {
         v.removeAttribute("src");
         v.load();
       } catch {
@@ -27249,6 +27270,12 @@ function buildPanel() {
   function unmountHolderVideo(holder) {
     const v = holder._video;
     if (!v) return;
+    try {
+      holder._releasePlayback?.();
+    } catch {
+      /* best-effort */
+    }
+    holder._releasePlayback = null;
     try {
       v.pause();
       v.removeAttribute("src");

--- a/web/js/lib/media-duration.js
+++ b/web/js/lib/media-duration.js
@@ -1,0 +1,171 @@
+// How long a video the panel is about to preview actually is (#1270).
+//
+// THE DEFECT. panel_show_media paints a native <video> and the storyboard
+// samples timestamps off `video.duration`. For a concat / edit-list MP4
+// (title card + generated clip + end card is the report) Chromium often
+// reports the FIRST clip's duration — 15s — while the container and the
+// seekable range still cover the whole source (~19.5s). Native `loop` and
+// `ended` then fire at that truncated number, so the tail never plays and
+// the storyboard never samples it. ffprobe on the same file is fine; the
+// panel was trusting the element's first answer.
+//
+// THE SOURCE DURATION is the longer of a finite `duration` and the last
+// seekable end. A truncated default is not a duration. Sampling and looping
+// both have to use this number, or the preview is a different video from
+// the file the caller handed over.
+//
+// Kept standalone (no DOM construction) so node --test can drive the
+// decisions the player and the storyboard actually ship.
+
+/** Epsilon (seconds) for "are we at the end?" — seeking to exact duration
+ *  often fails, and a 50 fps frame is 0.02s. */
+export const SOURCE_END_EPSILON_S = 0.05;
+
+function finitePositive(n) {
+  const v = Number(n);
+  return Number.isFinite(v) && v > 0 ? v : null;
+}
+
+/** Last seekable end, or null when the element has no usable range. */
+export function seekableEnd(media) {
+  try {
+    const ranges = media?.seekable;
+    if (!ranges || !ranges.length) return null;
+    return finitePositive(ranges.end(ranges.length - 1));
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * The duration the SOURCE can actually play, not the first number the
+ * element reports.
+ *
+ * A concat / edit-list file can report a truncated `duration` (often the
+ * first clip) while remaining seekable past it. Infinity / NaN / 0 are not
+ * durations. When both numbers exist, the longer one is the source.
+ *
+ * @param {{duration?:unknown, seekable?:{length:number, end:(i:number)=>number}}} media
+ * @returns {number|null}
+ */
+export function sourceMediaDuration(media) {
+  if (!media) return null;
+  const reported = finitePositive(media.duration);
+  const seekable = seekableEnd(media);
+  if (reported == null) return seekable;
+  if (seekable == null) return reported;
+  return Math.max(reported, seekable);
+}
+
+/**
+ * True when `duration` is a finite number SHORTER than the source we can
+ * still seek. Callers that loop or sample on `duration` alone will cut the
+ * tail off (#1270).
+ */
+export function durationLooksTruncated(media) {
+  const reported = finitePositive(media?.duration);
+  const source = sourceMediaDuration(media);
+  return reported != null && source != null && source > reported + SOURCE_END_EPSILON_S;
+}
+
+/**
+ * Timestamps for an N-cell storyboard across the FULL source duration.
+ *
+ * The previous default skipped the first 5% and last 5% ("likely black").
+ * That is a truncated default: a 1.5s title card and a 3s end card on a
+ * ~19.5s concat sit in those bands and never appear on the sheet. Samples
+ * run 0 .. duration, with the last cell a hair before the end so a seek
+ * to exact duration does not fail.
+ *
+ * @param {number} duration source duration in seconds
+ * @param {number} n cell count
+ * @returns {number[]}
+ */
+export function storyboardSampleTimes(duration, n) {
+  const d = finitePositive(duration);
+  const count = Number.isFinite(n) ? Math.trunc(n) : 0;
+  if (d == null || count < 1) return [];
+  if (count === 1) return [d / 2];
+  const last = Math.max(0, d - 0.01);
+  const times = [];
+  for (let i = 0; i < count; i += 1) {
+    times.push((last * i) / (count - 1));
+  }
+  return times;
+}
+
+/**
+ * `ended` (or a native loop) fired, but the source still has tail left —
+ * continue from here rather than restarting or stopping.
+ */
+export function shouldContinuePastReportedEnd(media) {
+  const end = sourceMediaDuration(media);
+  const t = Number(media?.currentTime);
+  if (end == null || !Number.isFinite(t)) return false;
+  return t < end - SOURCE_END_EPSILON_S;
+}
+
+/**
+ * Bind a <video> so playback and looping follow the SOURCE duration.
+ *
+ * Native `loop` uses the (possibly truncated) `duration`. When the source
+ * is longer we turn that off and:
+ *   - on `ended` while the tail remains: nudge past the false end and play
+ *   - on a real source end, with loop: restart from 0
+ *
+ * Returns an unsubscribe. No-ops on a media object that cannot listen.
+ *
+ * @param {{loop?:boolean, currentTime?:number, ended?:boolean, play?:()=>unknown, addEventListener?:Function, removeEventListener?:Function, duration?:unknown, seekable?:unknown}} video
+ * @param {{loop?:boolean}} [opts]
+ */
+export function bindSourcePlayback(video, { loop = true } = {}) {
+  if (!video || typeof video.addEventListener !== "function") return () => {};
+
+  const adopt = () => {
+    if (durationLooksTruncated(video)) video.loop = false;
+    else if (loop) video.loop = true;
+  };
+
+  const onEnded = () => {
+    const end = sourceMediaDuration(video);
+    if (end == null) return;
+    if (shouldContinuePastReportedEnd(video)) {
+      // False `ended` at the truncated duration. Nudge into the remaining
+      // source and keep playing so the tail is not dropped.
+      video.currentTime = Math.min(end - 0.01, Number(video.currentTime) + 0.01);
+      try {
+        video.play?.();
+      } catch {
+        /* blocked autoplay is not a duration failure */
+      }
+      return;
+    }
+    if (loop) {
+      video.currentTime = 0;
+      try {
+        video.play?.();
+      } catch {
+        /* same */
+      }
+    }
+  };
+
+  video.addEventListener("loadedmetadata", adopt);
+  video.addEventListener("durationchange", adopt);
+  // Seekable grows as the source buffers; durationchange does not always fire
+  // for that, and the first clip's duration is what loadedmetadata saw.
+  video.addEventListener("progress", adopt);
+  video.addEventListener("ended", onEnded);
+  adopt();
+
+  return () => {
+    try {
+      video.removeEventListener("loadedmetadata", adopt);
+      video.removeEventListener("durationchange", adopt);
+      video.removeEventListener("progress", adopt);
+      video.removeEventListener("ended", onEnded);
+    } catch {
+      /* a detached node may refuse */
+    }
+  };
+}


### PR DESCRIPTION
Fixes #1270

## The mechanism

`panel_show_media` paints a native `<video>` and the storyboard samples timestamps off `video.duration`. For a concat / edit-list MP4 — the report is a 1.5s title card + ~15s generated clip + 3s end card, 19.56s container, 978 frames, `+faststart` — Chromium often reports the **first clip's duration** (15s) while the container and the seekable range still cover the whole source.

Two things then cut the tail off:

1. Native `loop` / `ended` fire at that truncated number, so the chat player (and the lightbox) never play the end card.
2. The storyboard sampled `video.duration` across a 5%–95% window. Even a correct duration skipped the title and most of the end card; a 15s report sampled only the middle clip.

ffprobe and a full ffmpeg decode of the same file are fine. The panel was trusting the element's first answer. `preload="metadata"` made that first answer more likely.

Owner's "preview is just outputs" note is not this path: `show_media` paints the resolved source URL, not the last run output. The 15s the user saw is the element's truncated duration of the file they asked to show.

## The fix

The source duration is the longer of a finite `duration` and the last seekable end. A truncated default is not a duration.

- Storyboard samples that number from 0 to the source end (`storyboardSampleTimes`), not `HEAD=0.05` / `TAIL=0.95`.
- Chat player and lightbox use `preload="auto"` so seekable covers the source, and `bindSourcePlayback` continues past a false `ended` then loops at the real end.

The decisions live in `web/js/lib/media-duration.js` so the tests call the shipped functions, not a replica.

## Tests

`node --test --test-concurrency=4 browser_tests/unit/media-duration.test.mjs browser_tests/unit/media-preview.test.mjs browser_tests/unit/video-decode-error.test.mjs browser_tests/unit/media-collapse.test.mjs` — 144/144.
