### PR TITLE
fix(1294): copy/paste keeps groups and branch positions

### DIFF
--- a/browser_tests/unit/copy-paste-layout.test.mjs
+++ b/browser_tests/unit/copy-paste-layout.test.mjs
@@ -1,0 +1,563 @@
+/**
+ * #1294: panel_copy_nodes + panel_paste_nodes lost every group and collapsed
+ * same-type branch rows onto one coordinate.
+ *
+ * Repro shape: five "Power Lora Loader (rgthree)" nodes at y=-20/640/1300/1960/2620
+ * plus a group around each row. LiteGraph only serializes groups that are IN the
+ * selection (a node_ids copy selects nodes only), and clone/configure drops unique
+ * pos on those loaders — paste reported copied:121 / pasted_count:121 / group_count:0
+ * with all five loaders at [2288, 1320].
+ *
+ * Pure helpers are tested directly. The shipped graph_copy_nodes / graph_paste_nodes
+ * bodies are extracted and run against a LiteGraph double that reproduces BOTH
+ * bugs, so deleting the group collect, the clipboard patch, or the post-paste
+ * restore turns these red.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import {
+  CLIPBOARD_KEY,
+  withInMemoryClipboard,
+  getInMemoryClipboard,
+  getEffectiveClipboard,
+  clearInMemoryClipboard,
+} from "../../web/js/lib/clipboard-store.js";
+import {
+  recordCopiedNodes,
+  getVerifiedSnapshot,
+  parseClipboardNodes,
+  diffCopiedVsPasted,
+  formatDroppedWarning,
+  unregisteredCopiedTypes,
+  registryTypePredicate,
+  formatUnpasteableCopyWarning,
+} from "../../web/js/lib/paste-report.js";
+import {
+  finitePoint,
+  isGraphNode,
+  isGraphGroup,
+  partitionSelection,
+  groupsFullyCoveredBy,
+  snapshotNodeLayout,
+  snapshotGroupLayout,
+  collectCopySelection,
+  snapshotCopyLayout,
+  patchClipboardLayout,
+  parseClipboardLayout,
+  recordCopiedLayout,
+  getVerifiedLayout,
+  clearCopiedLayout,
+  pairCopiedToPasted,
+  layoutOrigin,
+  resolvePasteDest,
+  translateBounding,
+  applyPastedLayout,
+} from "../../web/js/lib/copy-paste-layout.js";
+import { groupMemberNodes, groupBoundsOf } from "../../web/js/lib/group-geometry.js";
+
+const LORA = "Power Lora Loader (rgthree)";
+const BRANCH_YS = [-20, 640, 1300, 1960, 2620];
+
+const panelPath = fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url));
+const panelSrc = readFileSync(panelPath, "utf8");
+
+const grab = (re, what) => {
+  const m = panelSrc.match(re);
+  assert.ok(m, `could not locate ${what} in panel source`);
+  return m[0];
+};
+
+const copySrc = grab(/ {2}graph_copy_nodes\(\{ node_ids \} = \{\}\) \{[\s\S]*?\n {2}\},/, "graph_copy_nodes");
+const pasteSrc = grab(/ {2}graph_paste_nodes\(\{ pos, connect_inputs \} = \{\}\) \{[\s\S]*?\n {2}\},/, "graph_paste_nodes");
+const setGroupBoundsSrc = grab(/\nfunction setGroupBounds\(group, \[x, y, w, h\]\) \{[\s\S]*?\n\}/, "setGroupBounds");
+const nextGroupIdSrc = grab(/\nfunction nextGroupId\(graph\) \{[\s\S]*?\n\}/, "nextGroupId");
+
+function summarizeNode(n) {
+  return {
+    id: n.id,
+    type: n.type,
+    pos: n.pos ? [Math.round(n.pos[0]), Math.round(n.pos[1])] : null,
+    ...(n.flags?.collapsed ? { collapsed: true } : {}),
+  };
+}
+
+function summarizeGroup(graph, g) {
+  const b = g._bounding ?? [g.pos?.[0] ?? 0, g.pos?.[1] ?? 0, g.size?.[0] ?? 0, g.size?.[1] ?? 0];
+  return {
+    id: g.id,
+    title: g.title,
+    bounding: b.map((n) => Math.round(n)),
+    node_ids: groupMemberNodes(graph, g).map((n) => n.id),
+  };
+}
+
+function makeStorage() {
+  const map = new Map();
+  return {
+    getItem(k) {
+      return map.has(k) ? map.get(k) : null;
+    },
+    setItem(k, v) {
+      map.set(k, String(v));
+    },
+    removeItem(k) {
+      map.delete(k);
+    },
+  };
+}
+
+function LGraphGroup(title) {
+  this.title = title;
+  this._bounding = [0, 0, 0, 0];
+  this.flags = {};
+}
+
+/** Frontend double that reproduces both #1294 bugs. */
+function makeFrontend({ loseLoraPos = true, pasteGroups = true } = {}) {
+  let nextNodeId = 1;
+  let nextGroupId = 1;
+  const graph = {
+    _nodes: [],
+    _groups: [],
+    beforeChange() {},
+    afterChange() {},
+    setDirtyCanvas() {},
+    getNodeById(id) {
+      return this._nodes.find((n) => n.id === Number(id)) ?? null;
+    },
+    add(item) {
+      if (item && typeof item.type === "string") {
+        if (item.id == null) item.id = nextNodeId++;
+        this._nodes.push(item);
+      } else if (item) {
+        if (item.id == null) item.id = nextGroupId++;
+        this._groups.push(item);
+      }
+    },
+  };
+  const canvas = {
+    graph,
+    selectedItems: new Set(),
+    selectItems(items) {
+      this.selectedItems = new Set(items);
+    },
+    selectNodes(items) {
+      this.selectedItems = new Set(items);
+    },
+    storage: null,
+    copyToClipboard(items) {
+      const nodes = [];
+      const groups = [];
+      for (const it of items ?? this.selectedItems) {
+        if (it && typeof it.type === "string") {
+          // BUG: clone/serialize loses unique pos on Power Lora Loader.
+          const pos = loseLoraPos && it.type === LORA ? [0, 0] : [...it.pos];
+          nodes.push({ id: it.id, type: it.type, pos, flags: { ...(it.flags || {}) } });
+        } else if (it && (it._bounding || it.bounding)) {
+          const b = it._bounding || it.bounding;
+          groups.push({
+            title: it.title,
+            bounding: [...b],
+            color: it.color,
+            flags: { ...(it.flags || {}) },
+          });
+        }
+      }
+      this.storage.setItem(CLIPBOARD_KEY, JSON.stringify({ nodes, groups, links: [] }));
+    },
+    pasteFromClipboard(options = {}) {
+      const raw = this.storage.getItem(CLIPBOARD_KEY);
+      if (!raw) return;
+      const data = JSON.parse(raw);
+      const position = options.position ?? [2288, 1320];
+      let offsetX = Infinity;
+      let offsetY = Infinity;
+      for (const n of data.nodes ?? []) {
+        if (!n.pos) continue;
+        if (n.pos[0] < offsetX) offsetX = n.pos[0];
+        if (n.pos[1] < offsetY) offsetY = n.pos[1];
+      }
+      for (const g of data.groups ?? []) {
+        if (!g.bounding) continue;
+        if (g.bounding[0] < offsetX) offsetX = g.bounding[0];
+        if (g.bounding[1] < offsetY) offsetY = g.bounding[1];
+      }
+      if (!Number.isFinite(offsetX)) {
+        offsetX = 0;
+        offsetY = 0;
+      }
+      const dx = position[0] - offsetX;
+      const dy = position[1] - offsetY;
+      for (const info of data.nodes ?? []) {
+        const node = {
+          id: nextNodeId++,
+          type: info.type,
+          pos: [...(info.pos ?? [0, 0])],
+          size: [200, 80],
+          flags: { ...(info.flags || {}) },
+        };
+        // BUG: configure ignores pos on Power Lora Loader — they keep the
+        // createNode default, then the same translation stacks them.
+        if (loseLoraPos && info.type === LORA) node.pos = [0, 0];
+        node.pos = [node.pos[0] + dx, node.pos[1] + dy];
+        graph._nodes.push(node);
+      }
+      if (pasteGroups) {
+        for (const info of data.groups ?? []) {
+          const g = new LGraphGroup(info.title);
+          g._bounding = [
+            info.bounding[0] + dx,
+            info.bounding[1] + dy,
+            info.bounding[2],
+            info.bounding[3],
+          ];
+          g.color = info.color;
+          g.flags = { ...(info.flags || {}) };
+          g.id = nextGroupId++;
+          graph._groups.push(g);
+        }
+      }
+    },
+  };
+  return { graph, canvas, LG: { LGraphGroup, registered_node_types: { [LORA]: {}, KSampler: {} } } };
+}
+
+function addBranch(graph, index, y) {
+  const lora = {
+    id: index * 2 + 1,
+    type: LORA,
+    pos: [100, y],
+    size: [225, 80],
+    flags: {},
+  };
+  const sampler = {
+    id: index * 2 + 2,
+    type: "KSampler",
+    pos: [400, y],
+    size: [200, 80],
+    flags: {},
+  };
+  const group = new LGraphGroup(`Branch ${index + 1}`);
+  group.id = index + 1;
+  group._bounding = [50, y - 70, 600, 180];
+  graph._nodes.push(lora, sampler);
+  graph._groups.push(group);
+  return { lora, sampler, group };
+}
+
+function makeBranchedGraph() {
+  const { graph, canvas, LG } = makeFrontend();
+  const branches = BRANCH_YS.map((y, i) => addBranch(graph, i, y));
+  return { graph, canvas, LG, branches };
+}
+
+function shippedCopyPaste(srcGraph, srcCanvas, srcLG) {
+  const storage = makeStorage();
+  srcCanvas.storage = storage;
+  const window = { localStorage: storage };
+  const setGroupBounds = new Function(`${setGroupBoundsSrc}; return setGroupBounds;`)();
+  const nextGroupId = new Function(`${nextGroupIdSrc}; return nextGroupId;`)();
+
+  const copy = new Function(
+    "getGraphCtx",
+    "collectCopySelection",
+    "snapshotCopyLayout",
+    "withInMemoryClipboard",
+    "getInMemoryClipboard",
+    "patchClipboardLayout",
+    "CLIPBOARD_KEY",
+    "recordCopiedNodes",
+    "recordCopiedLayout",
+    "registryTypePredicate",
+    "unregisteredCopiedTypes",
+    "formatUnpasteableCopyWarning",
+    "window",
+    `"use strict"; const e = { ${copySrc} }; return e.graph_copy_nodes;`,
+  )(
+    () => ({ graph: srcGraph, canvas: srcCanvas, LG: srcLG }),
+    collectCopySelection,
+    snapshotCopyLayout,
+    withInMemoryClipboard,
+    getInMemoryClipboard,
+    patchClipboardLayout,
+    CLIPBOARD_KEY,
+    recordCopiedNodes,
+    recordCopiedLayout,
+    registryTypePredicate,
+    unregisteredCopiedTypes,
+    formatUnpasteableCopyWarning,
+    window,
+  );
+
+  function makePaster(dstGraph, dstCanvas, dstLG) {
+    dstCanvas.storage = storage;
+    return new Function(
+      "getGraphCtx",
+      "getEffectiveClipboard",
+      "getVerifiedLayout",
+      "parseClipboardLayout",
+      "withInMemoryClipboard",
+      "resolvePasteDest",
+      "applyPastedLayout",
+      "setGroupBounds",
+      "nextGroupId",
+      "summarizeNode",
+      "summarizeGroup",
+      "parseClipboardNodes",
+      "getVerifiedSnapshot",
+      "diffCopiedVsPasted",
+      "formatDroppedWarning",
+      "window",
+      `"use strict"; const e = { ${pasteSrc} }; return e.graph_paste_nodes;`,
+    )(
+      () => ({ graph: dstGraph, canvas: dstCanvas, LG: dstLG }),
+      getEffectiveClipboard,
+      getVerifiedLayout,
+      parseClipboardLayout,
+      withInMemoryClipboard,
+      resolvePasteDest,
+      applyPastedLayout,
+      setGroupBounds,
+      nextGroupId,
+      summarizeNode,
+      summarizeGroup,
+      parseClipboardNodes,
+      getVerifiedSnapshot,
+      diffCopiedVsPasted,
+      formatDroppedWarning,
+      window,
+    );
+  }
+
+  return { copy, makePaster, storage, window };
+}
+
+// ---- pure helpers ----------------------------------------------------------
+
+test("partitionSelection keeps nodes and groups apart", () => {
+  const node = { id: 1, type: LORA, pos: [0, 0] };
+  const group = { title: "G", _bounding: [0, 0, 10, 10] };
+  const { nodes, groups } = partitionSelection([node, group, { id: 2 }]);
+  assert.deepEqual(nodes, [node]);
+  assert.deepEqual(groups, [group]);
+  assert.equal(isGraphNode(node), true);
+  assert.equal(isGraphGroup(group), true);
+  assert.equal(isGraphGroup(node), false);
+});
+
+test("groupsFullyCoveredBy requires every member to be selected", () => {
+  const { graph, branches } = makeBranchedGraph();
+  const allIds = graph._nodes.map((n) => n.id);
+  assert.equal(groupsFullyCoveredBy(graph, allIds).length, 5);
+  const firstBranchOnly = [branches[0].lora.id, branches[0].sampler.id];
+  const covered = groupsFullyCoveredBy(graph, firstBranchOnly);
+  assert.equal(covered.length, 1);
+  assert.equal(covered[0].title, "Branch 1");
+  assert.equal(groupsFullyCoveredBy(graph, [branches[0].lora.id]).length, 0);
+});
+
+test("patchClipboardLayout restores live pos and injects missing groups", () => {
+  const raw = JSON.stringify({
+    nodes: [
+      { id: 1, type: LORA, pos: [0, 0] },
+      { id: 2, type: "KSampler", pos: [400, -20] },
+    ],
+    groups: [],
+    links: [],
+  });
+  const patched = patchClipboardLayout(raw, {
+    nodes: [{ id: 1, type: LORA, pos: [100, -20] }, { id: 2, type: "KSampler", pos: [400, -20] }],
+    groups: [{ title: "Branch 1", bounding: [50, -90, 600, 180] }],
+  });
+  const layout = parseClipboardLayout(patched);
+  assert.deepEqual(layout.nodes[0].pos, [100, -20]);
+  assert.equal(layout.groups.length, 1);
+  assert.equal(layout.groups[0].title, "Branch 1");
+});
+
+test("pairCopiedToPasted matches same-type rows in order and skips drops", () => {
+  const copied = BRANCH_YS.map((y, i) => ({ id: i + 1, type: LORA, pos: [100, y] }));
+  copied.push({ id: 99, type: "AudioCrop", pos: [0, 0] });
+  const pasted = BRANCH_YS.map((y, i) => ({ id: 100 + i, type: LORA, pos: [2288, 1320] }));
+  const pairs = pairCopiedToPasted(copied, pasted);
+  assert.equal(pairs.length, 5);
+  assert.deepEqual(pairs.map((p) => p.copied.pos[1]), BRANCH_YS);
+  assert.deepEqual(pairs.map((p) => p.pasted.id), [100, 101, 102, 103, 104]);
+});
+
+test("applyPastedLayout uncollapses same-type rows with one translation", () => {
+  const copied = BRANCH_YS.map((y, i) => ({ id: i + 1, type: LORA, pos: [100, y] }));
+  const pasted = BRANCH_YS.map((_, i) => ({ id: 100 + i, type: LORA, pos: [2288, 1320] }));
+  const dest = [2288, 1320];
+  const { translation, restored_positions } = applyPastedLayout({
+    pastedNodes: pasted,
+    pastedGroups: [],
+    layout: { nodes: copied, groups: [] },
+    dest,
+  });
+  assert.equal(restored_positions, 5);
+  assert.deepEqual(translation, [2288 - 100, 1320 - BRANCH_YS[0]]);
+  const ys = pasted.map((n) => n.pos[1]);
+  assert.deepEqual(ys, BRANCH_YS.map((y) => y + translation[1]));
+  assert.equal(new Set(ys).size, 5, "every branch row kept a distinct y");
+});
+
+test("applyPastedLayout recreates a group the frontend dropped", () => {
+  const node = { id: 10, type: "KSampler", pos: [400, 100], size: [200, 80] };
+  const created = [];
+  const layout = {
+    nodes: [{ id: 2, type: "KSampler", pos: [400, 0] }],
+    groups: [{ title: "Sampler", bounding: [350, -70, 300, 180] }],
+  };
+  const dest = [400, 100];
+  applyPastedLayout({
+    pastedNodes: [node],
+    pastedGroups: [],
+    layout,
+    dest,
+    hooks: {
+      createGroup(spec) {
+        const g = { title: spec.title, _bounding: [...spec.bounding] };
+        created.push(g);
+        return g;
+      },
+    },
+  });
+  assert.equal(created.length, 1);
+  assert.equal(created[0].title, "Sampler");
+  const origin = layoutOrigin(layout.nodes, layout.groups);
+  assert.deepEqual(created[0]._bounding, translateBounding(layout.groups[0].bounding, [dest[0] - origin[0], dest[1] - origin[1]]));
+});
+
+test("getVerifiedLayout is fingerprint-guarded like the node snapshot", () => {
+  clearCopiedLayout();
+  recordCopiedLayout({ nodes: [{ id: 1, type: LORA, pos: [1, 2] }], groups: [] }, "fp-a");
+  assert.deepEqual(getVerifiedLayout("fp-a").nodes[0].pos, [1, 2]);
+  assert.equal(getVerifiedLayout("fp-b"), null);
+  assert.equal(getVerifiedLayout(null), null);
+  clearCopiedLayout();
+});
+
+test("layoutOrigin is the top-left of nodes and groups", () => {
+  assert.deepEqual(
+    layoutOrigin(
+      [{ pos: [100, 50] }, { pos: [400, -20] }],
+      [{ bounding: [10, 80, 20, 20] }],
+    ),
+    [10, -20],
+  );
+  assert.deepEqual(resolvePasteDest([5, 6], []), [5, 6]);
+  assert.deepEqual(finitePoint(["nope", 1]), null);
+});
+
+test("snapshotNodeLayout records collapsed flags", () => {
+  const snap = snapshotNodeLayout({ id: 1, type: LORA, pos: [8, 9], flags: { collapsed: true } });
+  assert.deepEqual(snap.flags, { collapsed: true });
+  assert.deepEqual(snapshotGroupLayout(null, { title: "G", _bounding: [1, 2, 3, 4], flags: { collapsed: true } }).flags, {
+    collapsed: true,
+  });
+});
+
+// ---- shipped handlers ------------------------------------------------------
+
+test("#1294 shipped copy+paste keeps groups and distinct branch y-positions", () => {
+  clearInMemoryClipboard();
+  clearCopiedLayout();
+  const src = makeBranchedGraph();
+  const { copy, makePaster } = shippedCopyPaste(src.graph, src.canvas, src.LG);
+
+  const nodeIds = src.graph._nodes.map((n) => n.id);
+  const copied = copy({ node_ids: nodeIds });
+  assert.equal(copied.copied, 10, "copied reports NODE count, not nodes+groups");
+  assert.equal(copied.copied_groups, 5, "fully-selected groups are counted");
+
+  const payload = JSON.parse(getInMemoryClipboard());
+  assert.equal(payload.groups.length, 5, "clipboard itself carries the groups");
+  const loraInClip = payload.nodes.filter((n) => n.type === LORA);
+  assert.deepEqual(
+    loraInClip.map((n) => n.pos[1]).sort((a, b) => a - b),
+    [...BRANCH_YS],
+    "clipboard pos is the LIVE y, not the collapsed clone pos",
+  );
+
+  const dst = makeFrontend();
+  const paste = makePaster(dst.graph, dst.canvas, dst.LG);
+  const result = paste({ pos: [2288, 1320], connect_inputs: false });
+
+  assert.equal(result.pasted_count, 10);
+  assert.equal(result.copied_groups, 5);
+  assert.equal(result.pasted_groups, 5, "groups survived paste");
+  assert.equal(dst.graph._groups.length, 5);
+
+  const loraYs = result.pasted.filter((n) => n.type === LORA).map((n) => n.pos[1]);
+  assert.equal(new Set(loraYs).size, 5, "Power Lora rows did not collapse onto one y");
+  const deltas = loraYs.slice(1).map((y, i) => y - loraYs[i]);
+  const expected = BRANCH_YS.slice(1).map((y, i) => y - BRANCH_YS[i]);
+  assert.deepEqual(deltas, expected, "one consistent translation — relative branch spacing held");
+});
+
+test("#1294 still recreates groups when LiteGraph paste drops them", () => {
+  clearInMemoryClipboard();
+  clearCopiedLayout();
+  const src = makeBranchedGraph();
+  const { copy, makePaster } = shippedCopyPaste(src.graph, src.canvas, src.LG);
+  copy({ node_ids: src.graph._nodes.map((n) => n.id) });
+
+  const dst = makeFrontend({ pasteGroups: false });
+  const paste = makePaster(dst.graph, dst.canvas, dst.LG);
+  const result = paste({ pos: [1000, 500], connect_inputs: false });
+  assert.equal(result.pasted_groups, 5);
+  assert.equal(dst.graph._groups.length, 5);
+  assert.ok(dst.graph._groups.every((g) => String(g.title).startsWith("Branch")));
+});
+
+test("#1294 a partial node_ids copy does not invent a half-selected group", () => {
+  clearInMemoryClipboard();
+  clearCopiedLayout();
+  const src = makeBranchedGraph();
+  const { copy } = shippedCopyPaste(src.graph, src.canvas, src.LG);
+  const onlyLoras = src.branches.map((b) => b.lora.id);
+  const copied = copy({ node_ids: onlyLoras });
+  assert.equal(copied.copied, 5);
+  assert.equal(copied.copied_groups, 0, "group whose sampler was not selected is not copied");
+});
+
+test("#1294 native clipboard replacement is not overwritten by the layout snapshot", () => {
+  clearInMemoryClipboard();
+  clearCopiedLayout();
+  const src = makeBranchedGraph();
+  const { copy, storage } = shippedCopyPaste(src.graph, src.canvas, src.LG);
+  copy({ node_ids: src.graph._nodes.map((n) => n.id) });
+  const native = JSON.stringify({ nodes: [{ id: 9, type: "KSampler", pos: [1, 2] }], groups: [], links: [] });
+  storage.setItem(CLIPBOARD_KEY, native);
+  assert.equal(getVerifiedLayout(native), null, "changed clipboard invalidates the layout snapshot");
+  assert.deepEqual(parseClipboardLayout(getEffectiveClipboard(storage)).nodes[0].type, "KSampler");
+});
+
+test("#1294 collapsed flags ride along with the restored positions", () => {
+  clearInMemoryClipboard();
+  clearCopiedLayout();
+  const src = makeBranchedGraph();
+  src.branches[0].lora.flags.collapsed = true;
+  src.branches[2].lora.flags.collapsed = true;
+  const { copy, makePaster } = shippedCopyPaste(src.graph, src.canvas, src.LG);
+  copy({ node_ids: src.graph._nodes.map((n) => n.id) });
+  const dst = makeFrontend();
+  const paste = makePaster(dst.graph, dst.canvas, dst.LG);
+  const result = paste({ pos: [0, 0], connect_inputs: false });
+  const collapsed = result.pasted.filter((n) => n.type === LORA && n.collapsed);
+  assert.equal(collapsed.length, 2);
+  const ys = result.pasted.filter((n) => n.type === LORA).map((n) => n.pos[1]);
+  assert.equal(new Set(ys).size, 5, "collapsed loaders still keep their branch y");
+});
+
+test("shipped copy still fails loud on a missing node_id", () => {
+  clearInMemoryClipboard();
+  clearCopiedLayout();
+  const src = makeBranchedGraph();
+  const { copy } = shippedCopyPaste(src.graph, src.canvas, src.LG);
+  assert.throws(() => copy({ node_ids: [src.graph._nodes[0].id, 99999] }), /not found/);
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -429,7 +429,18 @@ import {
   withInMemoryClipboard,
   getInMemoryClipboard,
   getEffectiveClipboard,
+  CLIPBOARD_KEY,
 } from "./lib/clipboard-store.js";
+import {
+  collectCopySelection,
+  snapshotCopyLayout,
+  patchClipboardLayout,
+  parseClipboardLayout,
+  recordCopiedLayout,
+  getVerifiedLayout,
+  applyPastedLayout,
+  resolvePasteDest,
+} from "./lib/copy-paste-layout.js";
 import { createMediaRecorder } from "./lib/chat-media.js";
 import { createMediaCollapseStore } from "./lib/media-collapse.js";
 import {
@@ -17045,10 +17056,21 @@ const GRAPH_TOOL_EXECUTORS = {
       else if (typeof canvas.selectNodes === "function") canvas.selectNodes(ns);
     }
     const selected = canvas.selectedItems;
-    const count = selected?.size ?? (Array.isArray(selected) ? selected.length : 0);
-    if (!count) {
+    const selectedCount = selected?.size ?? (Array.isArray(selected) ? selected.length : 0);
+    if (!selectedCount) {
       throw new Error("nothing selected to copy — pass node_ids or select nodes first");
     }
+    // #1294: LiteGraph only serializes groups that are IN the selection, and a
+    // node_ids copy selects nodes only — so every group vanished on paste. Also
+    // collect groups whose members are fully selected and pass them with the
+    // nodes, then patch the clipboard with LIVE positions (clone/configure drops
+    // unique pos on some types, collapsing same-type branch rows onto one point).
+    const selection = collectCopySelection(graph, selected);
+    if (!selection.nodes.length) {
+      throw new Error("nothing selected to copy — pass node_ids or select nodes first");
+    }
+    if (typeof canvas.selectItems === "function") canvas.selectItems(selection.items);
+    const layout = snapshotCopyLayout(graph, selection);
     // panel#500: copyToClipboard persists the payload in localStorage, which
     // throws QuotaExceededError ("The quota has been exceeded.") once a large
     // multi-node selection overflows the ~5–10 MB quota — the copy then failed
@@ -17062,7 +17084,14 @@ const GRAPH_TOOL_EXECUTORS = {
     } catch {
       storage = null;
     }
-    withInMemoryClipboard(storage, () => canvas.copyToClipboard(selected));
+    withInMemoryClipboard(storage, () => {
+      canvas.copyToClipboard(selection.items);
+      const raw = storage && typeof storage.getItem === "function" ? storage.getItem(CLIPBOARD_KEY) : getInMemoryClipboard();
+      const patched = patchClipboardLayout(raw, layout);
+      if (patched && patched !== raw && storage && typeof storage.setItem === "function") {
+        storage.setItem(CLIPBOARD_KEY, patched);
+      }
+    });
     // Snapshot the copied node types (plus a fingerprint of the clipboard
     // payload AFTER the copy) so the next graph_paste_nodes can detect any node
     // the target frontend silently drops on paste — and so a later native
@@ -17070,7 +17099,8 @@ const GRAPH_TOOL_EXECUTORS = {
     // fingerprint comes from the in-memory store, so it's stable even when the
     // localStorage mirror was refused for quota.
     const fingerprint = getInMemoryClipboard();
-    recordCopiedNodes(selected, fingerprint);
+    recordCopiedNodes(selection.nodes, fingerprint);
+    recordCopiedLayout(layout, fingerprint);
     // #286: never report a clean copy that can't round-trip. Any copied node
     // whose type is unregistered on THIS frontend (uninstalled custom-node pack)
     // will be silently dropped by a later paste — the destination is the same
@@ -17080,8 +17110,8 @@ const GRAPH_TOOL_EXECUTORS = {
     // missing/empty (frontend not fully loaded) registryTypePredicate returns
     // undefined and we report nothing rather than falsely flagging every node.
     const isRegisteredType = registryTypePredicate(LG?.registered_node_types);
-    const unregistered = unregisteredCopiedTypes(selected, isRegisteredType);
-    const result = { copied: count };
+    const unregistered = unregisteredCopiedTypes(selection.nodes, isRegisteredType);
+    const result = { copied: selection.nodes.length, copied_groups: selection.groups.length };
     if (unregistered.length) {
       result.unregistered_types = unregistered;
       result.warning = formatUnpasteableCopyWarning(unregistered);
@@ -17099,8 +17129,10 @@ const GRAPH_TOOL_EXECUTORS = {
       throw new Error("pasteFromClipboard unavailable on this frontend");
     }
     const before = new Set((graph._nodes ?? []).map((n) => n.id));
+    const beforeGroups = new Set(graph._groups ?? []);
     const options = { connectInputs: connect_inputs ?? false };
-    if (Array.isArray(pos) && pos.length === 2) options.position = [Number(pos[0]), Number(pos[1])];
+    const dest = Array.isArray(pos) && pos.length === 2 ? [Number(pos[0]), Number(pos[1])] : null;
+    if (dest && dest.every(Number.isFinite)) options.position = dest;
     // panel#500: read the clipboard through the in-memory store so a payload
     // that overflowed localStorage on copy is still available to paste (reads
     // of the clipboard key resolve to the in-memory copy, or to localStorage
@@ -17111,16 +17143,52 @@ const GRAPH_TOOL_EXECUTORS = {
     } catch {
       storage = null;
     }
+    // Effective payload BEFORE paste — same bytes paste will consume. Needed so
+    // we can restore positions/groups even when LiteGraph's configure drops pos
+    // or skips groups that were not in the native selection (#1294).
+    const rawClipboard = getEffectiveClipboard(storage);
+    const layout = getVerifiedLayout(rawClipboard) ?? parseClipboardLayout(rawClipboard);
     graph.beforeChange?.();
     try {
       withInMemoryClipboard(storage, () => canvas.pasteFromClipboard(options));
+      const pastedNodes = (graph._nodes ?? []).filter((n) => !before.has(n.id));
+      const pastedGroups = (graph._groups ?? []).filter((g) => !beforeGroups.has(g));
+      const pasteDest = dest && dest.every(Number.isFinite) ? dest : resolvePasteDest(null, pastedNodes);
+      applyPastedLayout({
+        pastedNodes,
+        pastedGroups,
+        layout,
+        dest: pasteDest,
+        hooks: {
+          createGroup: (spec) => {
+            const GroupCls = LG?.LGraphGroup;
+            if (typeof GroupCls !== "function") return null;
+            const group = new GroupCls(typeof spec.title === "string" && spec.title ? spec.title : "Group");
+            if (spec.color != null) group.color = String(spec.color);
+            if (Number.isFinite(spec.font_size)) group.font_size = Number(spec.font_size);
+            if (spec.flags) group.flags = { ...(group.flags || {}), ...spec.flags };
+            setGroupBounds(group, spec.bounding);
+            graph.add(group);
+            if (group.id == null) group.id = nextGroupId(graph);
+            group.recomputeInsideNodes?.();
+            return group;
+          },
+          placeGroup: (group, bounding) => {
+            setGroupBounds(group, bounding);
+            group.recomputeInsideNodes?.();
+          },
+        },
+      });
     } finally {
       graph.afterChange?.();
     }
     graph.setDirtyCanvas?.(true, true);
+    // Summarize AFTER the layout restore so returned positions are the ones that
+    // actually landed, not the collapsed same-type coordinate LiteGraph left.
     const pasted = (graph._nodes ?? [])
       .filter((n) => !before.has(n.id))
       .map((n) => summarizeNode(n));
+    const groupsNow = (graph._groups ?? []).filter((g) => !beforeGroups.has(g));
     // Surface any node the frontend silently DROPPED on paste (an unregistered
     // node type such as AudioCrop/AudioSeparation) instead of quietly reducing
     // the count (#261). Diff the clipboard snapshot from the matching
@@ -17133,7 +17201,6 @@ const GRAPH_TOOL_EXECUTORS = {
     // Ctrl+C that replaced the clipboard can never resurrect a stale snapshot.
     // Effective payload = in-memory copy (authoritative after a quota overflow)
     // or localStorage when a native Ctrl+C replaced it since the tool copy.
-    const rawClipboard = getEffectiveClipboard(storage);
     let expected = parseClipboardNodes(rawClipboard);
     if (!expected.length) expected = getVerifiedSnapshot(rawClipboard);
     // A type is a genuine drop only if it isn't a registered node class on this
@@ -17146,7 +17213,16 @@ const GRAPH_TOOL_EXECUTORS = {
       pasted,
       isRegisteredType,
     );
-    const result = { pasted_count: pasted.length, pasted_node_ids: pasted.map((n) => n.id), pasted };
+    const result = {
+      pasted_count: pasted.length,
+      pasted_node_ids: pasted.map((n) => n.id),
+      pasted,
+      copied_groups: layout.groups.length,
+      pasted_groups: groupsNow.length,
+    };
+    if (groupsNow.length) {
+      result.groups = groupsNow.map((g) => summarizeGroup(graph, g));
+    }
     if (dropped_count > 0) {
       result.dropped_count = dropped_count;
       result.dropped_nodes = dropped;

--- a/web/js/lib/copy-paste-layout.js
+++ b/web/js/lib/copy-paste-layout.js
@@ -1,0 +1,488 @@
+/**
+ * Copy/paste layout preservation (#1294).
+ *
+ * LiteGraph's clipboard only serializes groups that are IN the selection, and
+ * `panel_copy_nodes(node_ids)` selects nodes only — so every group vanishes on
+ * paste. Separately, some node types (rgthree Power Lora Loader and friends)
+ * lose their unique `pos` across clone/configure, so same-type branch rows
+ * collapse onto one paste coordinate.
+ *
+ * These helpers (1) collect groups whose members are fully selected, (2) patch
+ * the clipboard payload with live positions + those groups, and (3) after paste
+ * apply ONE translation to every landed node and recreate any group the
+ * frontend dropped. Dependency-light (group-geometry only) so the algorithms
+ * are unit-testable with plain object fixtures.
+ */
+
+import {
+  groupBoundsOf,
+  groupMemberNodes,
+  writePoint,
+  refreshNodeArea,
+} from "./group-geometry.js";
+
+/** A finite [x, y], or null. */
+export function finitePoint(v) {
+  const x = Number(v?.[0]);
+  const y = Number(v?.[1]);
+  return Number.isFinite(x) && Number.isFinite(y) ? [x, y] : null;
+}
+
+/** A finite [x, y, w, h], or null. */
+export function finiteBounding(v) {
+  const x = Number(v?.[0]);
+  const y = Number(v?.[1]);
+  const w = Number(v?.[2]);
+  const h = Number(v?.[3]);
+  return [x, y, w, h].every(Number.isFinite) ? [x, y, w, h] : null;
+}
+
+/** LiteGraph node vs group/reroute: nodes carry a string `type` and an id. */
+export function isGraphNode(item) {
+  return !!(item && item.id != null && typeof item.type === "string");
+}
+
+/** Group-shaped canvas item (has a box, is not a typed node). */
+export function isGraphGroup(item) {
+  if (!item || isGraphNode(item)) return false;
+  if (item._bounding && item._bounding.length >= 4) return true;
+  if (Array.isArray(item.bounding) && item.bounding.length >= 4) return true;
+  return !!(item.pos && item.size && item.title != null);
+}
+
+/** Split a selection into nodes and groups. */
+export function partitionSelection(items) {
+  const nodes = [];
+  const groups = [];
+  for (const it of items ?? []) {
+    if (isGraphNode(it)) nodes.push(it);
+    else if (isGraphGroup(it)) groups.push(it);
+  }
+  return { nodes, groups };
+}
+
+/**
+ * Groups whose EVERY geometric member is in `selectedIds` (and that have at
+ * least one member). A group with a node outside the selection is skipped —
+ * pasting it would enclose nodes that were not copied.
+ */
+export function groupsFullyCoveredBy(graph, selectedIds, memberOf = groupMemberNodes) {
+  const ids = selectedIds instanceof Set ? selectedIds : new Set(selectedIds);
+  const out = [];
+  for (const g of graph?._groups ?? []) {
+    let members;
+    try {
+      members = memberOf(graph, g) ?? [];
+    } catch {
+      continue;
+    }
+    if (!members.length) continue;
+    if (members.every((n) => ids.has(n.id))) out.push(g);
+  }
+  return out;
+}
+
+/** Live node positions/flags — never trust clone()/serialize() for these. */
+export function snapshotNodeLayout(node) {
+  const pos = finitePoint(node?.pos);
+  let collapsed = false;
+  try {
+    collapsed = !!node?.flags?.collapsed;
+  } catch {
+    collapsed = false;
+  }
+  return {
+    id: node?.id,
+    type: typeof node?.type === "string" ? node.type : null,
+    pos,
+    ...(collapsed ? { flags: { collapsed: true } } : {}),
+  };
+}
+
+/** Live group box + identity fields for clipboard inject / recreate. */
+export function snapshotGroupLayout(graph, g, boundsOf = groupBoundsOf) {
+  let bounding = null;
+  try {
+    bounding = finiteBounding(boundsOf(g)) ?? finiteBounding(g?._bounding) ??
+      finiteBounding(g?.bounding) ??
+      finiteBounding([g?.pos?.[0], g?.pos?.[1], g?.size?.[0], g?.size?.[1]]);
+  } catch {
+    bounding = null;
+  }
+  let collapsed = false;
+  try {
+    collapsed = !!g?.flags?.collapsed;
+  } catch {
+    collapsed = false;
+  }
+  return {
+    id: g?.id,
+    title: g?.title ?? "Group",
+    color: g?.color,
+    font_size: g?.font_size,
+    bounding,
+    ...(collapsed ? { flags: { collapsed: true } } : {}),
+  };
+}
+
+/** Title + size: translation-invariant identity for matching copied vs pasted groups. */
+export function groupLayoutKey(g) {
+  const title = String(g?.title ?? "");
+  const b = finiteBounding(g?.bounding) ?? finiteBounding(g?._bounding);
+  const w = Math.round(Number(b?.[2]) || 0);
+  const h = Math.round(Number(b?.[3]) || 0);
+  return `${title}\0${w}x${h}`;
+}
+
+function clipboardGroupPayload(g) {
+  const bounding = finiteBounding(g.bounding);
+  if (!bounding) return null;
+  return {
+    title: g.title ?? "Group",
+    bounding,
+    ...(g.color != null ? { color: g.color } : {}),
+    ...(Number.isFinite(g.font_size) ? { font_size: g.font_size } : {}),
+    ...(g.flags ? { flags: { ...g.flags } } : {}),
+    id: -1,
+  };
+}
+
+/**
+ * Nodes + fully-covered groups that a copy should serialize. Always unions
+ * groups already in the selection with groups whose members are fully selected.
+ */
+export function collectCopySelection(graph, selectedItems) {
+  const { nodes, groups: selectedGroups } = partitionSelection(selectedItems);
+  const selectedIds = new Set(nodes.map((n) => n.id));
+  const covered = groupsFullyCoveredBy(graph, selectedIds);
+  const seen = new Set(selectedGroups);
+  const groups = [...selectedGroups];
+  for (const g of covered) {
+    if (seen.has(g)) continue;
+    seen.add(g);
+    groups.push(g);
+  }
+  return { nodes, groups, items: [...nodes, ...groups] };
+}
+
+export function snapshotCopyLayout(graph, selection) {
+  return {
+    nodes: (selection?.nodes ?? []).map(snapshotNodeLayout),
+    groups: (selection?.groups ?? []).map((g) => snapshotGroupLayout(graph, g)),
+  };
+}
+
+// Live layout recorded at copy time, paired with the same fingerprint
+// paste-report uses. Trusted only while the clipboard still holds our payload —
+// a native Ctrl+C in between replaces the bytes and invalidates this snapshot.
+let _layoutSnapshot = { nodes: [], groups: [] };
+let _layoutFingerprint = null;
+
+/** Record the live layout just copied. `fingerprint` is the raw clipboard. */
+export function recordCopiedLayout(layout, fingerprint = null) {
+  _layoutSnapshot = {
+    nodes: [...(layout?.nodes ?? [])],
+    groups: [...(layout?.groups ?? [])],
+  };
+  _layoutFingerprint = fingerprint;
+  return _layoutSnapshot;
+}
+
+/** Test hook / explicit clear. */
+export function clearCopiedLayout() {
+  _layoutSnapshot = { nodes: [], groups: [] };
+  _layoutFingerprint = null;
+}
+
+/**
+ * The copy-time layout, but ONLY if `currentFingerprint` proves the clipboard
+ * hasn't changed since it was recorded. Otherwise null (caller parses the
+ * clipboard itself — native Ctrl+C must win).
+ */
+export function getVerifiedLayout(currentFingerprint) {
+  if (
+    _layoutFingerprint != null &&
+    currentFingerprint != null &&
+    currentFingerprint === _layoutFingerprint
+  ) {
+    return _layoutSnapshot;
+  }
+  return null;
+}
+
+function parseClipboardObject(raw) {
+  let data = raw;
+  if (typeof raw === "string") {
+    try {
+      data = JSON.parse(raw);
+    } catch {
+      return null;
+    }
+  }
+  if (!data || typeof data !== "object") return null;
+  return data;
+}
+
+/**
+ * Rewrite a LiteGraph clipboard payload so every node carries its LIVE pos
+ * (and collapsed flag) and fully-covered groups are present. Returns the
+ * patched JSON string, or the original when the payload is unreadable.
+ */
+export function patchClipboardLayout(raw, layout) {
+  const data = parseClipboardObject(raw);
+  if (!data) return raw;
+  const payload = Array.isArray(data)
+    ? { nodes: data, links: [], groups: [] }
+    : { ...data };
+  payload.nodes = Array.isArray(payload.nodes) ? payload.nodes.map((n) => ({ ...n })) : [];
+  payload.groups = Array.isArray(payload.groups) ? payload.groups.map((g) => ({ ...g })) : [];
+  if (payload.links == null) payload.links = [];
+
+  const byId = new Map();
+  for (const n of layout?.nodes ?? []) {
+    if (n?.id != null) byId.set(n.id, n);
+  }
+  for (const n of payload.nodes) {
+    const live = byId.get(n.id);
+    if (!live) continue;
+    if (live.pos) n.pos = [live.pos[0], live.pos[1]];
+    if (live.flags?.collapsed) {
+      n.flags = { ...(n.flags || {}), collapsed: true };
+    }
+  }
+
+  const existing = new Set(payload.groups.map(groupLayoutKey));
+  for (const g of layout?.groups ?? []) {
+    const key = groupLayoutKey(g);
+    if (existing.has(key)) continue;
+    const row = clipboardGroupPayload(g);
+    if (!row) continue;
+    payload.groups.push(row);
+    existing.add(key);
+  }
+  return JSON.stringify(payload);
+}
+
+/** Nodes (with pos) + groups from a clipboard payload. */
+export function parseClipboardLayout(raw) {
+  const data = parseClipboardObject(raw);
+  if (!data) return { nodes: [], groups: [] };
+  const nodeList = Array.isArray(data) ? data : Array.isArray(data.nodes) ? data.nodes : [];
+  const groupList = Array.isArray(data) ? [] : Array.isArray(data.groups) ? data.groups : [];
+  const nodes = [];
+  for (const n of nodeList) {
+    if (!n || n.id == null || typeof n.type !== "string") continue;
+    nodes.push({
+      id: n.id,
+      type: n.type,
+      pos: finitePoint(n.pos),
+      ...(n.flags?.collapsed ? { flags: { collapsed: true } } : {}),
+    });
+  }
+  const groups = [];
+  for (const g of groupList) {
+    const bounding = finiteBounding(g?.bounding) ?? finiteBounding(g?._bounding);
+    if (!bounding) continue;
+    groups.push({
+      id: g.id,
+      title: g.title ?? "Group",
+      color: g.color,
+      font_size: g.font_size,
+      bounding,
+      ...(g.flags?.collapsed ? { flags: { collapsed: true } } : {}),
+    });
+  }
+  return { nodes, groups };
+}
+
+/**
+ * Pair clipboard nodes (in order, by type) with freshly pasted nodes.
+ * Drops (unregistered types that never landed) are skipped on the clipboard side.
+ */
+export function pairCopiedToPasted(copied, pasted) {
+  const unused = new Map();
+  for (const n of pasted ?? []) {
+    const t = n?.type;
+    if (typeof t !== "string") continue;
+    if (!unused.has(t)) unused.set(t, []);
+    unused.get(t).push(n);
+  }
+  const pairs = [];
+  for (const c of copied ?? []) {
+    if (typeof c?.type !== "string") continue;
+    const q = unused.get(c.type);
+    if (!q || !q.length) continue;
+    pairs.push({ copied: c, pasted: q.shift() });
+  }
+  return pairs;
+}
+
+/** Top-left of the copied layout (nodes + group boxes). */
+export function layoutOrigin(nodes, groups) {
+  let x = Infinity;
+  let y = Infinity;
+  for (const n of nodes ?? []) {
+    const p = finitePoint(n?.pos);
+    if (!p) continue;
+    if (p[0] < x) x = p[0];
+    if (p[1] < y) y = p[1];
+  }
+  for (const g of groups ?? []) {
+    const b = finiteBounding(g?.bounding);
+    if (!b) continue;
+    if (b[0] < x) x = b[0];
+    if (b[1] < y) y = b[1];
+  }
+  return Number.isFinite(x) ? [x, y] : [0, 0];
+}
+
+/** Caller `pos`, else the top-left of whatever actually landed. */
+export function resolvePasteDest(explicitPos, pastedNodes) {
+  if (Array.isArray(explicitPos) && explicitPos.length === 2) {
+    const p = finitePoint(explicitPos);
+    if (p) return p;
+  }
+  let x = Infinity;
+  let y = Infinity;
+  for (const n of pastedNodes ?? []) {
+    const p = finitePoint(n?.pos);
+    if (!p) continue;
+    if (p[0] < x) x = p[0];
+    if (p[1] < y) y = p[1];
+  }
+  return Number.isFinite(x) ? [x, y] : null;
+}
+
+export function translateBounding(bounding, translation) {
+  const b = finiteBounding(bounding);
+  if (!b) return null;
+  const dx = Number(translation?.[0]) || 0;
+  const dy = Number(translation?.[1]) || 0;
+  return [b[0] + dx, b[1] + dy, b[2], b[3]];
+}
+
+function findMatchingGroup(pastedGroups, copied, used) {
+  const key = groupLayoutKey(copied);
+  for (const g of pastedGroups ?? []) {
+    if (used.has(g)) continue;
+    const live = {
+      title: g.title,
+      bounding: finiteBounding(g._bounding) ?? finiteBounding(g.bounding) ??
+        finiteBounding([g.pos?.[0], g.pos?.[1], g.size?.[0], g.size?.[1]]),
+    };
+    if (groupLayoutKey(live) === key) return g;
+  }
+  return null;
+}
+
+function defaultWriteNodePos(node, x, y, prev) {
+  const ok = writePoint(node, "pos", x, y);
+  refreshNodeArea(node, prev);
+  return ok;
+}
+
+function defaultPlaceGroup(group, bounding) {
+  const b = finiteBounding(bounding);
+  if (!b) return false;
+  const box = group._bounding;
+  if (box && box.length >= 4) {
+    try {
+      box[0] = b[0];
+      box[1] = b[1];
+      box[2] = b[2];
+      box[3] = b[3];
+      return true;
+    } catch {
+      /* fall through */
+    }
+  }
+  try {
+    group.pos = [b[0], b[1]];
+    group.size = [b[2], b[3]];
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * After LiteGraph paste: restore each landed node to `copied.pos + translation`
+ * and recreate any fully-copied group the frontend dropped. `translation` is
+ * dest − origin so every node/group moves by the SAME delta — same-type rows
+ * cannot collapse onto one coordinate.
+ *
+ * `hooks.createGroup(spec)` should add a group to the graph and return it.
+ */
+export function applyPastedLayout({
+  pastedNodes,
+  pastedGroups,
+  layout,
+  dest,
+  hooks = {},
+} = {}) {
+  const copiedNodes = layout?.nodes ?? [];
+  const copiedGroups = layout?.groups ?? [];
+  const pairs = pairCopiedToPasted(copiedNodes, pastedNodes);
+  const origin = layoutOrigin(copiedNodes, copiedGroups);
+  const target = dest ?? resolvePasteDest(null, pastedNodes);
+  const translation = target ? [target[0] - origin[0], target[1] - origin[1]] : [0, 0];
+  const writeNode = hooks.writeNodePos ?? defaultWriteNodePos;
+  const placeGroup = hooks.placeGroup ?? defaultPlaceGroup;
+
+  let restored = 0;
+  for (const { copied, pasted } of pairs) {
+    if (!copied.pos || !pasted) continue;
+    const nx = copied.pos[0] + translation[0];
+    const ny = copied.pos[1] + translation[1];
+    let prev = [Number.NaN, Number.NaN];
+    try {
+      prev = [Number(pasted.pos?.[0]), Number(pasted.pos?.[1])];
+    } catch {
+      /* unreadable — write still attempted */
+    }
+    if (writeNode(pasted, nx, ny, prev)) restored += 1;
+    if (copied.flags?.collapsed) {
+      try {
+        pasted.flags = { ...(pasted.flags || {}), collapsed: true };
+      } catch {
+        /* ignore */
+      }
+    }
+  }
+
+  const used = new Set();
+  const created = [];
+  for (const cg of copiedGroups) {
+    const want = translateBounding(cg.bounding, translation);
+    if (!want) continue;
+    const match = findMatchingGroup(pastedGroups, cg, used);
+    if (match) {
+      used.add(match);
+      placeGroup(match, want);
+      if (cg.flags?.collapsed) {
+        try {
+          match.flags = { ...(match.flags || {}), collapsed: true };
+        } catch {
+          /* ignore */
+        }
+      }
+    } else if (typeof hooks.createGroup === "function") {
+      const g = hooks.createGroup({
+        title: cg.title,
+        bounding: want,
+        color: cg.color,
+        font_size: cg.font_size,
+        flags: cg.flags,
+      });
+      if (g) created.push(g);
+    }
+  }
+
+  return {
+    translation,
+    restored_positions: restored,
+    created_groups: created.length,
+    pasted_group_count: (pastedGroups?.length ?? 0) + created.length,
+    created,
+  };
+}


### PR DESCRIPTION
## Summary

`panel_copy_nodes` + `panel_paste_nodes` copied every selected node into a new workflow but dropped every group and stacked same-type branch rows on one coordinate. Repro from #1294: 121 nodes / 11 groups became 121 nodes / 0 groups, and five `Power Lora Loader (rgthree)` nodes at y=-20/640/1300/1960/2620 all landed at `[2288,1320]`.

LiteGraph only serializes groups that are **in the selection**, and a `node_ids` copy selected nodes only. Separately, clone/configure drops unique `pos` on some types, so paste applied one translation to a shared default.

## Fix

- Collect groups whose members are fully selected and pass them with the nodes to `copyToClipboard`.
- Patch the clipboard with live node positions and those groups; record a fingerprint-guarded layout snapshot (native Ctrl+C still wins).
- After paste, apply **one** dest−origin translation to every landed node and recreate any group the frontend dropped.
- Results report `copied_groups` / `pasted_groups` so structural loss is detectable.

## Tests

Shipped `graph_copy_nodes` / `graph_paste_nodes` extracted and run against a LiteGraph double that reproduces both bugs (groups omitted from a node-only selection; Power Lora configure ignores `pos`).

```
node --test --test-concurrency=4 browser_tests/unit/copy-paste-layout.test.mjs
```

15/15 pass, including the 5-branch y-spacing case and group recreate when LiteGraph paste drops groups.

Fixes #1294
