### PR TITLE
fix(1283): a load the panel WATCHED run to completion is not a content mismatch

### DIFF
--- a/browser_tests/open-unverified-names-recovery.spec.ts
+++ b/browser_tests/open-unverified-names-recovery.spec.ts
@@ -88,8 +88,12 @@ test('a content-unverified open names the fence recovery, and it works', async (
   await page.evaluate(() => (window as any).__cmcpRestoreConfigure?.())
   const text = JSON.stringify(reopened)
   // Precondition: this must be the outcome the issue is about, not some other failure.
+  // panel#1283 — an ABORTED restore gets its own headline (the "and" form), because both
+  // of the older ones were written for a load that completed and are false here: one says
+  // there is no missing work to redo, the other that the panel cannot tell normalization
+  // from a partial load. This is the more specific sentence of the two, not a looser match.
   expect(text, 'the reply must be the post-repaint content verdict').toContain(
-    'workflow_open RAN, the canvas IS bound to'
+    'workflow_open RAN and the canvas IS bound to'
   )
   expect(reopened.ok, 'content-unverified is ok:false by design').toBe(false)
 

--- a/browser_tests/open-unverified-names-recovery.spec.ts
+++ b/browser_tests/open-unverified-names-recovery.spec.ts
@@ -36,7 +36,14 @@ test('a content-unverified open names the fence recovery, and it works', async (
     const w = window as any
     const app = w.comfyAPI?.app?.app || w.app
     const LG = w.LiteGraph || w.comfyAPI?.litegraph?.LiteGraph
-    ;(app?.canvas?.graph ?? app?.graph).add(LG.createNode('EmptyLatentImage'))
+    const node = LG.createNode('EmptyLatentImage')
+    ;(app?.canvas?.graph ?? app?.graph).add(node)
+    // A NON-DEFAULT value, so the aborted restore below has something to fail to apply.
+    // With the node left at its construction defaults the payload and the post-load canvas
+    // are byte-identical even when configure throws, and the open is PROVEN — correctly,
+    // because nothing was lost. The content verdict this spec guards needs a real loss.
+    const widget = (node.widgets || []).find((x: any) => x.name === 'width')
+    if (widget) widget.value = 1337
   })
   await settleCanvas(page)
 
@@ -45,14 +52,51 @@ test('a content-unverified open names the fence recovery, and it works', async (
     listed.result?.active?.routing_key || listed.result?.active?.key || listed.result?.active?.path
   expect(target, 'an active workflow must be resolvable').toBeTruthy()
 
-  // Reopening the ALREADY-ACTIVE workflow is the CONTENT_UNVERIFIED path.
+  // panel#1283 — ARRANGE THE REAL CONTENT_UNVERIFIED CASE, rather than relying on a
+  // benign repaint difference.
+  //
+  // This spec used to reach CONTENT_UNVERIFIED by simply reopening the already-active
+  // tab: the repaint was not byte-identical and the panel had no way to say why. It has
+  // one now — it watches the restore — so a benign normalization is reported APPLIED with
+  // the fence published, which is the whole of panel#1283/#1285/#1307/#1330 and
+  // comfyui-mcp#1705.
+  //
+  // The verdict this spec guards is unchanged, and it is the case #702 was always about:
+  // a load that ABORTS part-way. `LGraph.configure` runs its node pass with no try/catch,
+  // so one node's `configure` throwing is exactly that shape — the panel records it,
+  // refuses the content, and must still name the fence-exempt recovery. Making a node
+  // throw is therefore a STRONGER arrangement than the old one, not a weaker one: it is
+  // the failure the disclosure exists for.
+  await page.evaluate(() => {
+    const w = window as any
+    const LG = w.LiteGraph || w.comfyAPI?.litegraph?.LiteGraph
+    const proto = LG?.LGraphNode?.prototype
+    const original = proto.configure
+    w.__cmcpRestoreConfigure = () => {
+      proto.configure = original
+      delete w.__cmcpRestoreConfigure
+    }
+    proto.configure = function (info: any) {
+      if (info?.type === 'EmptyLatentImage') throw new Error('pack widgets not built yet')
+      return original.call(this, info)
+    }
+  })
+
+  // Reopening the ALREADY-ACTIVE workflow, with one node's restore throwing, is the
+  // CONTENT_UNVERIFIED path.
   const reopened = await mockBridge.command('workflow_open', { path: target })
+  await page.evaluate(() => (window as any).__cmcpRestoreConfigure?.())
   const text = JSON.stringify(reopened)
   // Precondition: this must be the outcome the issue is about, not some other failure.
   expect(text, 'the reply must be the post-repaint content verdict').toContain(
     'workflow_open RAN, the canvas IS bound to'
   )
   expect(reopened.ok, 'content-unverified is ok:false by design').toBe(false)
+
+  // panel#1283 — and it must name WHAT aborted, so the reader is not left to guess
+  // between a normalization and a node that never got its values.
+  expect(text, 'an aborted restore must be named as such').toContain('DID NOT RUN TO COMPLETION')
+  expect(text, 'and the node that threw must be named').toContain('EmptyLatentImage')
 
   // It must SAY the fence was not refreshed, and name the call that refreshes it.
   // Without this the reply recommends the graph read that is about to be refused.

--- a/browser_tests/reopen-preserves-node-set-values.spec.ts
+++ b/browser_tests/reopen-preserves-node-set-values.spec.ts
@@ -121,8 +121,21 @@ test('reopening the active workflow keeps a value the tracker never saw', async 
   // final assertion below passes vacuously, because the widget write was never
   // touched by anything.
   const ran = JSON.stringify(reopened)
-  expect(ran, 'the reply must be the post-repaint verdict, not an earlier failure').toContain(
-    'workflow_open RAN, the canvas IS bound to'
+  // panel#1283 — TWO replies now prove the repaint ran, and the assertion must accept
+  // both without accepting anything else.
+  //
+  // The sentence above is emitted only by the CONTENT_UNVERIFIED branch. Since the panel
+  // started WATCHING the restore, a benign repaint difference on a load that ran to
+  // completion is reported APPLIED instead — and that reply is a STRONGER post-repaint
+  // signal, not a weaker one: the success path is reached only once this attempt's
+  // one-time marker was found on the live root, which can only be there because THIS
+  // load configured it. An error raised before the repaint has neither, so the vacuous
+  // pass this assertion was written against (codex) is still excluded.
+  const provenPostRepaint =
+    ran.includes('workflow_open RAN, the canvas IS bound to') ||
+    (reopened.ok === true && typeof reopened.result?.workflow_uuid === 'string')
+  expect(provenPostRepaint, 'the reply must be the post-repaint verdict, not an earlier failure').toBe(
+    true
   )
 
   // Two independent signals, because either alone can be satisfied for the wrong

--- a/browser_tests/unit/open-completed-restore.test.mjs
+++ b/browser_tests/unit/open-completed-restore.test.mjs
@@ -166,6 +166,31 @@ test("panel#1283 a changed node SET refuses however complete the restore was", (
   }
 });
 
+test("panel#1283 the SET check is not redundant with the field list — this predicate is exported", () => {
+  // MEASURED by mutation: deleting the `sameNodeSet`/`comparable` line above killed no
+  // test, because `classifyNodeDifference` only computes `fields` once the sets match, so
+  // everything IT produces arrives with an empty list and the field check catches it.
+  // This function is EXPORTED, though, so it must refuse an INCONSISTENT shape rather
+  // than let a set difference through on a field list somebody else built — the same
+  // lesson #1623's own predicate had to learn.
+  for (const diff of [
+    { comparable: true, sameNodeSet: false, cosmeticOnly: false, fields: ["widgets_values"] },
+    { comparable: false, sameNodeSet: true, cosmeticOnly: false, fields: ["widgets_values"] },
+    { comparable: false, sameNodeSet: false, cosmeticOnly: false, fields: ["size", "outputs"] },
+  ]) {
+    assert.equal(
+      openContentDifferenceIsCompletedLoadNormalization({
+        comparable: true,
+        surfaces: ["nodes"],
+        nodeDifference: diff,
+        loadRanToCompletion: true,
+      }),
+      false,
+      `${JSON.stringify(diff)} is inconsistent and must refuse`,
+    );
+  }
+});
+
 test("panel#1283 any surface but `nodes` refuses — a completed node pass explains nothing else", () => {
   for (const surfaces of [
     ["links"],

--- a/browser_tests/unit/open-completed-restore.test.mjs
+++ b/browser_tests/unit/open-completed-restore.test.mjs
@@ -588,6 +588,46 @@ test("panel#1283 a cosmetic difference keeps #1623's stronger disclosure, not th
   assert.deepEqual(proof.fields, ["order", "pos"]);
 });
 
+test("panel#1283 a RECORDED THROW vetoes #1623's cosmetic ground too — the hole the wrap opens", () => {
+  // Before this change `workflow_open` did not contain a per-node configure throw, so a
+  // throwing node aborted the restore and links/groups never landed — refused on the
+  // surface list. Containing it means the rest of the graph restores and the throwing node
+  // sits at CONSTRUCTION DEFAULTS, `pos: [10, 10]` among them — and `pos` is cosmetic. A
+  // node whose saved state differed from its defaults only in position would otherwise be
+  // waved through as "nothing authored was lost" with the user's layout for it gone.
+  const state = stateOf([node(1, "KSampler", { pos: [900, 640] })]);
+  const live = stateOf([{ ...node(1, "KSampler"), pos: [10, 10] }]);
+  const asked = { rootGraph: rootOf(live), state };
+  assert.equal(
+    graphRootReproducesStateContent({ ...asked, loadRanToCompletion: true }).presentationOnly,
+    true,
+    "a completed restore keeps #1623's answer",
+  );
+  assert.equal(
+    graphRootReproducesStateContent({ ...asked, loadRanToCompletion: false }).presentationOnly,
+    false,
+    "a recorded throw must veto it",
+  );
+  // …and a caller that never asked the question is unaffected — every caller but the open.
+  assert.equal(graphRootReproducesStateContent(asked).presentationOnly, true);
+  // `proven` is deliberately NOT vetoed: byte equality means nothing was lost, whatever threw.
+  const exact = graphRootReproducesStateContent({
+    rootGraph: rootOf(state),
+    state,
+    loadRanToCompletion: false,
+  });
+  assert.equal(exact.proven, true);
+  assert.equal(exact.exact, true);
+});
+
+test("panel#1283 wiring: a node the retry HEALED is disclosed on the success reply", () => {
+  const src = readFileSync(PANEL_JS, "utf8");
+  assert.match(src, /nodes_restored_on_retry: openRestoreRetried,/);
+  assert.match(src, /nodes_restored_on_retry_note:/);
+  const assignments = [...src.matchAll(/(?<!let )openRestoreRetried = ([^;\n]+);/g)].map((m) => m[1]);
+  assert.deepEqual(assignments, ["retry.restored"]);
+});
+
 test("panel#1283 wiring: a node the retry could not heal is still disclosed on the open path", () => {
   const src = readFileSync(PANEL_JS, "utf8");
   const openAt = src.indexOf("async workflow_open({");

--- a/browser_tests/unit/open-completed-restore.test.mjs
+++ b/browser_tests/unit/open-completed-restore.test.mjs
@@ -1,0 +1,553 @@
+/**
+ * panel#1283 / #1285 / #1307 / #1330 and comfyui-mcp#1705 — `panel_open_workflow`
+ * reported an ERROR / `applied: unknown` on opens that had in fact applied cleanly.
+ *
+ * WHAT THE FIVE REPORTERS GOT. Every one of them: the canvas bound to the requested
+ * workflow, every node present with the same id and type, nothing extra, a
+ * `panel_graph_outline` afterwards showing the intended graph — and `isError: true`,
+ * no `workflow_uuid`, and a multi-step recovery through `panel_list_workflows`.
+ * The per-node fields that differed were, verbatim from the reports:
+ *
+ *   #1283  order, size, widgets_values          #1330  outputs, size
+ *   #1285  order, size, widgets_values          #1705  inputs, outputs, properties,
+ *   #1307  size, widgets_values                        widgets_values, widgets_values_named
+ *
+ * WHY THE TWO EXISTING GROUNDS CANNOT REACH THEM. Both are FIELD-LEVEL, and both are
+ * right to be:
+ *
+ *   RECOMPUTED_NODE_FIELDS  {size (height-only), inputs}  "is a difference in this
+ *                                                          NAME a rewrite the panel
+ *                                                          has MEASURED?"
+ *   COSMETIC_NODE_FIELDS    {size, pos, order,            "could a difference in this
+ *                            color, bgcolor}               NAME mean lost authoring?"
+ *
+ * `widgets_values` is deliberately outside both — it is the field a genuine partial
+ * load drops, which is what #1111/#1089 are about. `outputs`, `properties` and
+ * `widgets_values_named` are outside both because nobody has characterised them.
+ * Adding them one at a time is a treadmill: the next pack invents the next field.
+ *
+ * THE MECHANISM, AND WHY IT IS ANSWERABLE NOW. `resolveOpenRebindVerdict` names
+ * exactly ONE reason a content difference might mean loss:
+ *
+ *   "`loadGraphData` catches a `configure()` failure and returns. A throw in that
+ *    second pass leaves the complete node id/type set, the links, and the panel's
+ *    marker over nodes that silently LOST their widget values and properties. That
+ *    is byte-for-byte the same observation as 'the loader normalized the widget
+ *    values', and no discriminator available to the panel separates them."
+ *
+ * MEASURED against the frontend source (`LGraph.prototype.configure`, the build
+ * #1260 was measured on): the node pass is a bare loop, `node?.configure(nodeData)`,
+ * with no try/catch of its own and none between it and `loadGraphData`'s. So a THROW
+ * is the only way that partial load can present — out of a node's configure, or out
+ * of the graph restore itself.
+ *
+ * Both are observable, and the panel already owned half of it:
+ * `installNodeConfigureIsolation` records per-node throws (#1260, on `graph_load`),
+ * and `installGraphConfigureWatch` (added here) records a throw out of the restore.
+ * `workflow_open` now installs both, so `loadRanToCompletion` REFUTES that hypothesis
+ * per load, by observation. That is the discriminator the comment says does not exist.
+ *
+ * WHAT THIS DOES NOT CLAIM, and the tests below hold the line: it never says the
+ * differing values are the file's values. It says the restore did not stop early, so
+ * nothing was dropped by a load that aborted — and it NAMES the fields on the reply
+ * (`content_normalized`) rather than vouching for them.
+ *
+ * WHAT STILL REFUSES: a changed node set, any surface but `nodes` (an unaccounted
+ * `definitions` block included — comfyui-mcp#1706 is a DIFFERENT mechanism and is
+ * deliberately left failing here), a recorded throw, and a frontend that could not be
+ * instrumented at all.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import {
+  openContentDifferenceIsCompletedLoadNormalization,
+  graphRootReproducesStateContent,
+  describeOpenRebindOutcome,
+  resolveOpenRebindVerdict,
+  OPEN_REBIND_STATUS,
+} from "../../web/js/lib/graph-binding.js";
+import {
+  installGraphConfigureWatch,
+  installNodeConfigureIsolation,
+  loadRestoreCompleted,
+} from "../../web/js/lib/load-restore-isolation.js";
+
+const PANEL_JS = fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url));
+
+const node = (id, type, extra = {}) => ({
+  id,
+  type,
+  pos: [0, 0],
+  size: [200, 100],
+  order: 0,
+  widgets_values: ["a"],
+  ...extra,
+});
+const rootOf = (state) => ({ serialize: () => JSON.parse(JSON.stringify(state)) });
+const stateOf = (nodes, extra = {}) => ({ nodes, links: [], groups: [], config: {}, extra: {}, ...extra });
+const differing = (fields) => ({ comparable: true, sameNodeSet: true, cosmeticOnly: false, fields });
+
+// ── the predicate ────────────────────────────────────────────────────────────
+
+test("panel#1283 a watched, completed restore whose only surface is `nodes` is normalization", () => {
+  for (const fields of [
+    ["order", "size", "widgets_values"], // #1283, #1285
+    ["size", "widgets_values"], // #1307
+    ["outputs", "size"], // #1330
+    ["inputs", "outputs", "properties", "widgets_values", "widgets_values_named"], // #1705
+  ]) {
+    assert.equal(
+      openContentDifferenceIsCompletedLoadNormalization({
+        comparable: true,
+        surfaces: ["nodes"],
+        nodeDifference: differing(fields),
+        loadRanToCompletion: true,
+      }),
+      true,
+      `${fields.join(", ")} — every reported field set must pass`,
+    );
+  }
+});
+
+test("panel#1283 a load that was NOT watched is UNKNOWN, and unknown is not a yes", () => {
+  // `null` is what `loadRestoreCompleted` answers when either wrap could not be
+  // installed. Reading it as truthy would license the open on a frontend whose restore
+  // the panel cannot see at all — the exact two-states-one-answer fold this predicate
+  // exists to undo.
+  for (const observation of [null, undefined, false, "true", 1, {}]) {
+    assert.equal(
+      openContentDifferenceIsCompletedLoadNormalization({
+        comparable: true,
+        surfaces: ["nodes"],
+        nodeDifference: differing(["widgets_values"]),
+        loadRanToCompletion: observation,
+      }),
+      false,
+      `${JSON.stringify(observation)} must not license the open`,
+    );
+  }
+});
+
+test("panel#1283 a recorded throw still refuses — that IS the partial load", () => {
+  assert.equal(
+    openContentDifferenceIsCompletedLoadNormalization({
+      comparable: true,
+      surfaces: ["nodes"],
+      nodeDifference: differing(["widgets_values"]),
+      loadRanToCompletion: false,
+    }),
+    false,
+  );
+});
+
+test("panel#1283 a changed node SET refuses however complete the restore was", () => {
+  // A node that vanished, appeared or was retyped is the shape real loss takes, and a
+  // restore that ran to the end does not produce it. `sameNodeSet:false` arrives with an
+  // EMPTY field list, so both checks below matter.
+  for (const diff of [
+    { comparable: true, sameNodeSet: false, cosmeticOnly: false, fields: [] },
+    { comparable: false, sameNodeSet: false, cosmeticOnly: false, fields: [] },
+    { comparable: true, sameNodeSet: true, cosmeticOnly: false, fields: [] },
+    null,
+  ]) {
+    assert.equal(
+      openContentDifferenceIsCompletedLoadNormalization({
+        comparable: true,
+        surfaces: ["nodes"],
+        nodeDifference: diff,
+        loadRanToCompletion: true,
+      }),
+      false,
+      `${JSON.stringify(diff)} must refuse`,
+    );
+  }
+});
+
+test("panel#1283 any surface but `nodes` refuses — a completed node pass explains nothing else", () => {
+  for (const surfaces of [
+    ["links"],
+    ["groups"],
+    ["nodes", "links"],
+    ["nodes", "definitions"], // an UNACCOUNTED definitions block: comfyui-mcp#1706's shape
+    ["definitions"],
+    ["reroutes"],
+    ["extra"],
+    [],
+  ]) {
+    assert.equal(
+      openContentDifferenceIsCompletedLoadNormalization({
+        comparable: true,
+        surfaces,
+        nodeDifference: differing(["widgets_values"]),
+        loadRanToCompletion: true,
+      }),
+      false,
+      `${surfaces.join("+") || "(empty)"} must refuse`,
+    );
+  }
+});
+
+test("panel#1283 a comparison that never happened proves nothing", () => {
+  assert.equal(
+    openContentDifferenceIsCompletedLoadNormalization({
+      comparable: false,
+      surfaces: ["nodes"],
+      nodeDifference: differing(["widgets_values"]),
+      loadRanToCompletion: true,
+    }),
+    false,
+  );
+  assert.equal(openContentDifferenceIsCompletedLoadNormalization(), false);
+});
+
+// ── the content proof ────────────────────────────────────────────────────────
+
+test("panel#1307 the reporter's own case: size + widgets_values, restore watched and complete", () => {
+  const state = stateOf([node(1, "KSampler"), node(2, "CLIPTextEncode")]);
+  const live = stateOf([
+    { ...node(1, "KSampler"), size: [200, 130], widgets_values: ["a", "fixed"] },
+    node(2, "CLIPTextEncode"),
+  ]);
+  const proof = graphRootReproducesStateContent({
+    rootGraph: rootOf(live),
+    state,
+    loadRanToCompletion: true,
+  });
+  // NOT `proven`: nothing here characterised the widget rewrite, and this ground does
+  // not pretend it did.
+  assert.equal(proof.proven, false);
+  assert.equal(proof.presentationOnly, false, "widgets_values is not cosmetic and must not become so");
+  assert.equal(proof.normalizedOnly, true);
+  assert.deepEqual(proof.normalizedFields, ["size", "widgets_values"]);
+});
+
+test("panel#1330 outputs + size — the field `inputs` got characterised for and `outputs` never did", () => {
+  const state = stateOf([node(1, "KSampler", { outputs: [{ name: "LATENT", type: "LATENT", links: [4] }] })]);
+  const live = stateOf([
+    {
+      ...node(1, "KSampler"),
+      size: [220, 100],
+      outputs: [{ name: "LATENT", type: "LATENT", links: [4], slot_index: 0 }],
+    },
+  ]);
+  const proof = graphRootReproducesStateContent({
+    rootGraph: rootOf(live),
+    state,
+    loadRanToCompletion: true,
+  });
+  assert.equal(proof.normalizedOnly, true);
+  assert.deepEqual(proof.normalizedFields, ["outputs", "size"]);
+});
+
+test("comfyui-mcp#1705 `nodes` PLUS a definitions block that is only link renumbering", () => {
+  // The reporter's surfaces were `nodes, definitions`. #886 measured that loading any
+  // workflow containing subgraphs regenerates link ids inside `definitions.subgraphs`,
+  // and `describeGraphStateDifference` already runs the fail-closed predicate that says
+  // so. A surface already accounted for must not count as a second unexplained one —
+  // #1588's own rule, applied to this ground too.
+  const sub = (lastLinkId, links) => ({
+    subgraphs: [
+      {
+        id: "sg-1",
+        name: "detailer",
+        nodes: [{ id: 9, type: "VAEDecode", inputs: [], outputs: [] }],
+        links,
+        state: { lastLinkId, lastNodeId: 9 },
+      },
+    ],
+  });
+  const state = stateOf([node(1, "KSampler")], { definitions: sub(2092, [[2092, 9, 0, 9, 0, "IMAGE"]]) });
+  const live = stateOf([{ ...node(1, "KSampler"), widgets_values: ["a", "fixed"], properties: { ver: "2" } }], {
+    definitions: sub(2106, [[2106, 9, 0, 9, 0, "IMAGE"]]),
+  });
+  const proof = graphRootReproducesStateContent({
+    rootGraph: rootOf(live),
+    state,
+    loadRanToCompletion: true,
+  });
+  assert.equal(proof.normalizedOnly, true, "an accounted definitions surface is not a second difference");
+  assert.deepEqual(proof.normalizedFields, ["properties", "widgets_values"]);
+});
+
+test("comfyui-mcp#1706 a definitions difference that is NOT renumbering still refuses", () => {
+  // The reported case is two workflows sharing subgraph definition UUIDs, where the
+  // frontend's root-graph configure DEDUPLICATES subgraph node ids against ids already
+  // reserved by the definitions store. That is a different rewrite from #886's link
+  // renumbering, it has no characterisation here, and this ground must not smuggle it
+  // through: `definitions` is not `nodes`.
+  const defs = (nodeId) => ({
+    subgraphs: [{ id: "sg-1", name: "d", nodes: [{ id: nodeId, type: "VAEDecode" }], links: [], state: {} }],
+  });
+  const state = stateOf([node(1, "KSampler")], { definitions: defs(9) });
+  const live = stateOf([node(1, "KSampler")], { definitions: defs(41) });
+  const proof = graphRootReproducesStateContent({
+    rootGraph: rootOf(live),
+    state,
+    loadRanToCompletion: true,
+  });
+  assert.equal(proof.proven, false);
+  assert.equal(proof.normalizedOnly, false);
+});
+
+test("panel#1283 a LOST node is refused even with the restore watched and complete", () => {
+  const state = stateOf([node(1, "KSampler"), node(2, "CLIPTextEncode")]);
+  const live = stateOf([node(1, "KSampler")]);
+  const proof = graphRootReproducesStateContent({
+    rootGraph: rootOf(live),
+    state,
+    loadRanToCompletion: true,
+  });
+  assert.equal(proof.proven, false);
+  assert.equal(proof.normalizedOnly, false);
+});
+
+test("panel#1283 a lost LINK is refused — the node pass says nothing about links", () => {
+  const state = stateOf([node(1, "KSampler")], { links: [[1, 1, 0, 2, 0, "LATENT"]] });
+  const live = stateOf([{ ...node(1, "KSampler"), widgets_values: ["b"] }], { links: [] });
+  const proof = graphRootReproducesStateContent({
+    rootGraph: rootOf(live),
+    state,
+    loadRanToCompletion: true,
+  });
+  assert.equal(proof.normalizedOnly, false);
+});
+
+test("panel#1283 without the observation the old refusal is unchanged", () => {
+  // The whole reported family, on a caller that does not pass `loadRanToCompletion`:
+  // byte-for-byte the pre-fix answer. Nothing widened by default.
+  const state = stateOf([node(1, "KSampler")]);
+  const live = stateOf([{ ...node(1, "KSampler"), widgets_values: ["CHANGED"] }]);
+  const proof = graphRootReproducesStateContent({ rootGraph: rootOf(live), state });
+  assert.equal(proof.proven, false);
+  assert.equal(proof.presentationOnly, false);
+  assert.equal(proof.normalizedOnly, false);
+  assert.deepEqual(proof.normalizedFields, []);
+});
+
+// ── the observation itself ───────────────────────────────────────────────────
+
+const fakeLG = () => ({
+  LGraph: { prototype: { configure() { return "graph-ok"; } } },
+  LGraphNode: { prototype: { configure() { return "node-ok"; } } },
+});
+
+test("panel#1283 the graph watch OBSERVES and re-throws — it never changes control flow", () => {
+  const LG = fakeLG();
+  const boom = new Error("groups blew up");
+  LG.LGraph.prototype.configure = function () {
+    throw boom;
+  };
+  const watch = installGraphConfigureWatch(LG);
+  assert.throws(() => LG.LGraph.prototype.configure({}), /groups blew up/, "the throw must still reach the caller");
+  assert.deepEqual(watch.throws, ["groups blew up"]);
+  watch.restore();
+  assert.throws(() => LG.LGraph.prototype.configure({}), /groups blew up/);
+  assert.equal(watch.throws.length, 1, "a restored watch records nothing further");
+});
+
+test("panel#1283 the graph watch passes a normal call straight through", () => {
+  const LG = fakeLG();
+  const watch = installGraphConfigureWatch(LG);
+  assert.equal(LG.LGraph.prototype.configure({ nodes: [] }), "graph-ok");
+  assert.deepEqual(watch.throws, []);
+  watch.restore();
+  assert.equal(typeof LG.LGraph.prototype.configure, "function");
+});
+
+test("panel#1283 an uninstrumentable frontend answers null, never false", () => {
+  for (const LG of [null, undefined, {}, { LGraph: {} }, { LGraph: { prototype: {} } }]) {
+    assert.equal(installGraphConfigureWatch(LG), null, `${JSON.stringify(LG)}`);
+  }
+  // …and the fold reports UNKNOWN when either half is missing. "Nobody looked" must not
+  // read as "nothing threw".
+  assert.equal(loadRestoreCompleted({ nodeIsolation: null, graphWatch: { throws: [] } }), null);
+  assert.equal(loadRestoreCompleted({ nodeIsolation: { failures: [] }, graphWatch: null }), null);
+  assert.equal(loadRestoreCompleted({}), null);
+  assert.equal(loadRestoreCompleted(), null);
+  // A malformed record is unknown too, not a clean bill.
+  assert.equal(loadRestoreCompleted({ nodeIsolation: { failures: "none" }, graphWatch: { throws: [] } }), null);
+});
+
+test("panel#1283 the fold is true only when BOTH halves looked and neither saw a throw", () => {
+  assert.equal(loadRestoreCompleted({ nodeIsolation: { failures: [] }, graphWatch: { throws: [] } }), true);
+  assert.equal(
+    loadRestoreCompleted({ nodeIsolation: { failures: [{ id: 3 }] }, graphWatch: { throws: [] } }),
+    false,
+  );
+  assert.equal(loadRestoreCompleted({ nodeIsolation: { failures: [] }, graphWatch: { throws: ["x"] } }), false);
+});
+
+test("panel#1283 both wraps compose: a node throw is contained, the graph throw is not", () => {
+  const LG = fakeLG();
+  LG.LGraphNode.prototype.configure = function () {
+    throw new Error("FaceDetailer widgets not built");
+  };
+  const nodeIsolation = installNodeConfigureIsolation(LG);
+  const graphWatch = installGraphConfigureWatch(LG);
+  // The node throw is swallowed and RECORDED (#1260's contract, unchanged)…
+  assert.equal(LG.LGraphNode.prototype.configure({ id: 7, type: "FaceDetailer" }), undefined);
+  assert.equal(nodeIsolation.failures.length, 1);
+  // …so it never reaches the graph watch, which stays clean and independent.
+  assert.deepEqual(graphWatch.throws, []);
+  assert.equal(loadRestoreCompleted({ nodeIsolation, graphWatch }), false);
+  graphWatch.restore();
+  nodeIsolation.restore();
+});
+
+// ── the disclosure ───────────────────────────────────────────────────────────
+
+test("panel#1283 a refusal on an ABORTED restore names what aborted it", () => {
+  const msg = describeOpenRebindOutcome(
+    resolveOpenRebindVerdict({
+      instanceStillTarget: true,
+      markerMatches: true,
+      identityMatches: true,
+      contentMatches: false,
+    }),
+    {
+      targetLabel: "detailer.json",
+      contentComparable: true,
+      contentSurfaces: ["nodes"],
+      contentNodeDifference: differing(["widgets_values"]),
+      contentLoadRanToCompletion: false,
+      contentRestoreFailures: [{ id: 7, type: "FaceDetailer", error: "widgets not built" }],
+    },
+  );
+  assert.match(msg, /DID NOT RUN TO COMPLETION/);
+  assert.match(msg, /FaceDetailer \(id 7\): widgets not built/);
+  assert.match(msg, /part of what was loaded never landed/);
+});
+
+test("panel#1283 a restore that aborted but left nothing unrestored may NOT claim values are missing", () => {
+  const msg = describeOpenRebindOutcome(
+    resolveOpenRebindVerdict({
+      instanceStillTarget: true,
+      markerMatches: true,
+      identityMatches: true,
+      contentMatches: false,
+    }),
+    {
+      targetLabel: "detailer.json",
+      contentComparable: true,
+      contentSurfaces: ["nodes"],
+      contentNodeDifference: differing(["widgets_values"]),
+      contentLoadRanToCompletion: false,
+      contentRestoreFailures: [],
+    },
+  );
+  assert.match(msg, /DID NOT RUN TO COMPLETION/i);
+  assert.doesNotMatch(msg, /part of what was loaded never landed/, "nothing observed supports that claim");
+  assert.match(msg, /No node is still reported\s+unrestored/);
+});
+
+test("panel#1283 an UNWATCHED load gets no sentence about completion at all", () => {
+  // `null` is the pre-existing state of knowledge. Narrating it in either direction
+  // would state a reading nobody took.
+  for (const observation of [null, undefined]) {
+    const msg = describeOpenRebindOutcome(
+      resolveOpenRebindVerdict({
+        instanceStillTarget: true,
+        markerMatches: true,
+        identityMatches: true,
+        contentMatches: false,
+      }),
+      {
+        targetLabel: "detailer.json",
+        contentComparable: true,
+        contentSurfaces: ["nodes"],
+        contentNodeDifference: differing(["widgets_values"]),
+        contentLoadRanToCompletion: observation,
+      },
+    );
+    assert.equal(
+      resolveOpenRebindVerdict({
+        instanceStillTarget: true,
+        markerMatches: true,
+        identityMatches: true,
+        contentMatches: false,
+      }).status,
+      OPEN_REBIND_STATUS.CONTENT_UNVERIFIED,
+    );
+    assert.doesNotMatch(msg, /RUN TO COMPLETION/i, `${observation} must produce no completion claim`);
+  }
+});
+
+// ── wiring: production must actually reach all of this ───────────────────────
+
+test("panel#1283 wiring: workflow_open installs BOTH wraps around its own load", () => {
+  const src = readFileSync(PANEL_JS, "utf8");
+  const openAt = src.indexOf("async workflow_open({");
+  assert.notEqual(openAt, -1);
+  const repaintAt = src.indexOf("const targetUuid = workflowStableUuid", openAt);
+  const repaint = src.slice(repaintAt, src.indexOf("} catch (err)", repaintAt));
+  // The wraps must be installed BEFORE the load — a wrapper installed afterwards
+  // observes nothing, and the whole ground rests on this ordering.
+  const nodeWrapAt = repaint.indexOf("installNodeConfigureIsolation(LGForOpen)");
+  const graphWrapAt = repaint.indexOf("installGraphConfigureWatch(LGForOpen)");
+  const loadAt = repaint.indexOf("await app.loadGraphData(repaintState, true, true, target);");
+  assert.notEqual(nodeWrapAt, -1, "the node-configure isolation must be installed on the open path");
+  assert.notEqual(graphWrapAt, -1, "the graph-configure watch must be installed on the open path");
+  assert.notEqual(loadAt, -1);
+  assert.ok(nodeWrapAt < loadAt, "a wrap installed after the load observes nothing");
+  assert.ok(graphWrapAt < loadAt, "a wrap installed after the load observes nothing");
+  // …and removed again, in a finally, before anything reads the graph. A wrapper left
+  // live would keep swallowing throws from unrelated later edits.
+  assert.match(
+    repaint,
+    /} finally \{[\s\S]{0,400}?nodeIsolation\?\.restore\(\);[\s\S]{0,80}?graphWatch\?\.restore\(\);/,
+  );
+});
+
+test("panel#1283 wiring: the observation is FOLDED and reaches the proof and the message", () => {
+  const src = readFileSync(PANEL_JS, "utf8");
+  const openAt = src.indexOf("async workflow_open({");
+  const repaintAt = src.indexOf("const targetUuid = workflowStableUuid", openAt);
+  const repaint = src.slice(repaintAt, src.indexOf("} catch (err)", repaintAt));
+  assert.match(
+    repaint,
+    /const loadRanToCompletion = loadRestoreCompleted\(\{ nodeIsolation, graphWatch \}\);/,
+    "the two observations must be folded by the helper that keeps `unknown` representable",
+  );
+  // It must reach the PROOF — this is the one line whose deletion silently restores the
+  // whole reported bug while every predicate test above stays green.
+  assert.match(
+    repaint,
+    /graphRootReproducesStateContent\(\{[\s\S]{0,600}?loadRanToCompletion,[\s\S]{0,80}?\}\);/,
+    "the proof must be asked with the observation",
+  );
+  // …and the MESSAGE, so an aborted restore is named rather than left to guesswork.
+  assert.match(repaint, /contentLoadRanToCompletion: loadRanToCompletion,/);
+  assert.match(repaint, /contentRestoreFailures: openRestoreFailures,/);
+});
+
+test("panel#1283 wiring: the third ground gets its OWN reply key and its own note", () => {
+  const src = readFileSync(PANEL_JS, "utf8");
+  // Borrowing `geometry_rewritten_note` would assert a characterised height-only
+  // rewrite, and borrowing `presentation_rewritten_note` would assert that every
+  // content-bearing field matched. Neither is established here.
+  assert.match(src, /content_normalized: openContentNormalized,/);
+  assert.match(src, /content_normalized_note:/);
+  const noteAt = src.indexOf("content_normalized_note:");
+  const note = src.slice(noteAt, src.indexOf("}", src.indexOf("`,", noteAt)));
+  assert.doesNotMatch(note, /width unchanged/i, "no height-only claim was established here");
+  assert.doesNotMatch(note, /no missing work to redo/i, "nothing here vouches for the values");
+  assert.match(note, /read it with panel_graph_outline/, "a widget value is content — say how to check it");
+  // Assigned from the ground that earned it, and from nothing else.
+  const assignments = [...src.matchAll(/(?<!let )openContentNormalized = ([^;\n]+);/g)].map((m) => m[1]);
+  assert.deepEqual(assignments, ["contentProof.normalizedFields"]);
+  const guardAt = src.indexOf("if (contentProof.normalizedOnly) {");
+  assert.notEqual(guardAt, -1);
+  assert.ok(guardAt < src.indexOf("openContentNormalized = contentProof.normalizedFields;"));
+});
+
+test("panel#1283 wiring: a node the retry could not heal is still disclosed on the open path", () => {
+  const src = readFileSync(PANEL_JS, "utf8");
+  const openAt = src.indexOf("async workflow_open({");
+  const repaintAt = src.indexOf("const targetUuid = workflowStableUuid", openAt);
+  const repaint = src.slice(repaintAt, src.indexOf("} catch (err)", repaintAt));
+  assert.match(repaint, /retryNodeRestores\(app\?\.graph, containedNodeFailureList\)/);
+  assert.match(repaint, /openRestoreFailures = retry\.failed;/);
+});

--- a/browser_tests/unit/open-completed-restore.test.mjs
+++ b/browser_tests/unit/open-completed-restore.test.mjs
@@ -444,6 +444,41 @@ test("panel#1283 a refusal on an ABORTED restore names what aborted it", () => {
   assert.match(msg, /DID NOT RUN TO COMPLETION/);
   assert.match(msg, /FaceDetailer \(id 7\): widgets not built/);
   assert.match(msg, /part of what was loaded never landed/);
+  // …and the HEADLINE must not contradict it. Both pre-existing headlines were written
+  // for a load that completed: one says there is no missing work to redo, the other says
+  // the panel cannot tell normalization from a partial load. The panel CAN tell here, and
+  // the answer is the partial load.
+  assert.doesNotMatch(msg, /no missing work to redo/i);
+  assert.doesNotMatch(msg, /cannot tell from here whether/i);
+  assert.doesNotMatch(msg, /cannot tell whether the ComfyUI frontend merely normalized/i);
+  assert.match(msg, /RESTORE ITSELF DID NOT FINISH/);
+  assert.match(msg, /Do NOT save from here/);
+  assert.match(msg, /carries NO fence refresh/, "the recovery #702 added must still ride along");
+});
+
+test("panel#1283 an aborted restore whose difference is only COSMETIC still refuses, and says so", () => {
+  // The dangerous combination: `pos` moved (cosmetic) AND a node threw. #1623's reassurance
+  // would have fired — "you are on the right workflow and there is no missing work to redo" —
+  // over a node sitting at construction defaults. The proof vetoes the ground; this asserts
+  // the SENTENCE is vetoed too, on the same observation.
+  const msg = describeOpenRebindOutcome(
+    resolveOpenRebindVerdict({
+      instanceStillTarget: true,
+      markerMatches: true,
+      identityMatches: true,
+      contentMatches: false,
+    }),
+    {
+      targetLabel: "detailer.json",
+      contentComparable: true,
+      contentSurfaces: ["nodes"],
+      contentNodeDifference: { comparable: true, sameNodeSet: true, cosmeticOnly: true, fields: ["pos"] },
+      contentLoadRanToCompletion: false,
+      contentRestoreFailures: [{ id: 7, type: "FaceDetailer", error: "widgets not built" }],
+    },
+  );
+  assert.doesNotMatch(msg, /no missing work to redo/i);
+  assert.match(msg, /RESTORE ITSELF DID NOT FINISH/);
 });
 
 test("panel#1283 a restore that aborted but left nothing unrestored may NOT claim values are missing", () => {

--- a/browser_tests/unit/open-completed-restore.test.mjs
+++ b/browser_tests/unit/open-completed-restore.test.mjs
@@ -563,9 +563,29 @@ test("panel#1283 wiring: the third ground gets its OWN reply key and its own not
   // Assigned from the ground that earned it, and from nothing else.
   const assignments = [...src.matchAll(/(?<!let )openContentNormalized = ([^;\n]+);/g)].map((m) => m[1]);
   assert.deepEqual(assignments, ["contentProof.normalizedFields"]);
-  const guardAt = src.indexOf("if (contentProof.normalizedOnly) {");
+  // Gated on the ground that earned it, AND on the stronger one not having earned it
+  // first: a cosmetic difference on a completed restore satisfies both, and two keys for
+  // one observation would make the reply say two different-sized things about the same
+  // fields.
+  const guardAt = src.indexOf("if (contentProof.normalizedOnly && !contentProof.presentationOnly) {");
   assert.notEqual(guardAt, -1);
   assert.ok(guardAt < src.indexOf("openContentNormalized = contentProof.normalizedFields;"));
+});
+
+test("panel#1283 a cosmetic difference keeps #1623's stronger disclosure, not this weaker one", () => {
+  // `pos`/`order` on a watched, completed restore: BOTH grounds are true. The reply must
+  // carry `presentation_rewritten` (every content-bearing field matched) and NOT also
+  // `content_normalized` (the panel observed the difference and not its cause).
+  const state = stateOf([node(1, "KSampler")]);
+  const live = stateOf([{ ...node(1, "KSampler"), pos: [40, 40], order: 3 }]);
+  const proof = graphRootReproducesStateContent({
+    rootGraph: rootOf(live),
+    state,
+    loadRanToCompletion: true,
+  });
+  assert.equal(proof.presentationOnly, true, "#1623's ground still fires");
+  assert.equal(proof.normalizedOnly, true, "and so does this one — which is why the call site picks");
+  assert.deepEqual(proof.fields, ["order", "pos"]);
 });
 
 test("panel#1283 wiring: a node the retry could not heal is still disclosed on the open path", () => {

--- a/browser_tests/unit/open-content-proof.test.mjs
+++ b/browser_tests/unit/open-content-proof.test.mjs
@@ -99,6 +99,11 @@ test("#1001 a byte-identical repaint is still reported as exact", () => {
     // #1623 — a graph that matched has no difference to classify, so the weaker
     // "nothing authored was lost" ground is not what carried it.
     presentationOnly: false,
+    // panel#1283 family — nor the THIRD ground. A byte-identical repaint needs no
+    // observation about whether the restore completed, and claiming one it did not
+    // consult would misattribute the proof.
+    normalizedOnly: false,
+    normalizedFields: [],
   });
 });
 
@@ -234,6 +239,11 @@ test("#1001 an unreadable root proves nothing — absence of comparison is not e
       // could read supports "nothing authored was lost" exactly as little as it
       // supports "the content was reproduced".
       presentationOnly: false,
+      // panel#1283 family — and not the third one. `loadRanToCompletion` was not even
+      // passed here, so the only honest answer is false; a ground that could pass on an
+      // unreadable root would prove an open off a comparison that never happened.
+      normalizedOnly: false,
+      normalizedFields: [],
     });
   }
   assert.equal(graphRootReproducesStateContent({ rootGraph: rootOf(state), state: null }).proven, false);
@@ -242,7 +252,10 @@ test("#1001 an unreadable root proves nothing — absence of comparison is not e
 
 test("#1001 source guard: the open publishes the fence and DISCLOSES rewritten geometry", () => {
   const src = readFileSync(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8");
-  assert.match(src, /const contentProof = graphRootReproducesStateContent\(\{ rootGraph, state: repaintState \}\)/);
+  // The call site now spans several lines (it passes `loadRanToCompletion` too), so the
+  // pin is on the CALL and its two payload arguments rather than on one formatted line —
+  // still a call-site assertion, and still fails if the open stops asking for the proof.
+  assert.match(src, /const contentProof = graphRootReproducesStateContent\(\{[\s\S]{0,600}?state: repaintState,/);
   assert.match(src, /openGeometryRewritten = contentProof\.fields/, "a non-exact proof is recorded");
   assert.match(src, /geometry_rewritten: openGeometryRewritten/, "and reaches the reply");
   assert.match(src, /geometry_rewritten_note:/, "with prose, since a bare field list is not a disclosure");

--- a/browser_tests/unit/open-outcome.test.mjs
+++ b/browser_tests/unit/open-outcome.test.mjs
@@ -505,14 +505,31 @@ test("#721 P1: dirty rebind success requires the target UUID, never only a read-
   // and demanding byte-identity made every such open report CONTENT_UNVERIFIED (which
   // throws, which withholds the fence). The predicate still refuses anything but a
   // nodes-only, same-set, geometry-only difference.
-  assert.match(repaint, /graphRootReproducesStateContent\(\{ rootGraph, state: repaintState \}\)/);
+  // panel#1283 family — the call now also hands over `loadRanToCompletion`, the
+  // observation of whether this restore aborted, so the pin spans the call rather than
+  // one formatted line. Both payload arguments are still named: dropping either one
+  // fails here.
+  assert.match(repaint, /graphRootReproducesStateContent\(\{[\s\S]{0,600}?state: repaintState,/);
+  assert.match(
+    repaint,
+    /graphRootReproducesStateContent\(\{[\s\S]{0,600}?loadRanToCompletion,/,
+    "the completed-restore observation must actually reach the proof",
+  );
   // #1623 — TWO grounds now, and BOTH must be named here. `proven` is the strict
   // "the content was reproduced"; `presentationOnly` is the weaker "nothing authored
   // was lost", which is the question the caller acts on and the one the panel's own
   // disclosure already answered on the same observation. Pinning the expression
   // rather than either half is deliberate: dropping `presentationOnly` restores the
   // reported false error, and dropping `proven` silently narrows the #1001 fix.
-  assert.match(repaint, /const contentMatches = contentProof\.proven \|\| contentProof\.presentationOnly;/);
+  // panel#1283 family — a THIRD ground, `normalizedOnly`, licensed by an observation
+  // that the restore ran to completion rather than by a judgement about a field name.
+  // All three are pinned: dropping `presentationOnly` restores #1623's false error,
+  // dropping `proven` silently narrows the #1001 fix, and dropping `normalizedOnly`
+  // restores the false error this family reported.
+  assert.match(
+    repaint,
+    /const contentMatches =\s*contentProof\.proven \|\| contentProof\.presentationOnly \|\| contentProof\.normalizedOnly;/,
+  );
   // The two disclosures stay SEPARATE. Folding the weaker case into
   // `openGeometryRewritten` would attach a note asserting a characterised
   // height-only rewrite to a difference where no such thing was established.

--- a/browser_tests/unit/open-presentation-only.test.mjs
+++ b/browser_tests/unit/open-presentation-only.test.mjs
@@ -305,9 +305,11 @@ test("#1623 the reassurance sentence itself is unchanged for what still fails", 
 
 test("#1623 wiring: the open's pass/fail reads BOTH grounds, and the disclosures stay separate", () => {
   const src = readFileSync(PANEL_JS, "utf8");
-  // Deleting `|| contentProof.presentationOnly` restores the reported false error and
-  // this assertion is what notices. Deleting the whole line breaks the handler.
-  assert.match(src, /const contentMatches = contentProof\.proven \|\| contentProof\.presentationOnly;/);
+  // panel#1283 family added a THIRD ground to the same expression, so the pin is on the
+  // two disjuncts #1623 is about rather than on the whole line — deleting
+  // `|| contentProof.presentationOnly` still restores the reported false error, and this
+  // assertion is still what notices. Deleting the whole line breaks the handler.
+  assert.match(src, /const contentMatches =\s*contentProof\.proven \|\| contentProof\.presentationOnly/);
   // Two keys, two notes. The weaker ground must not borrow `geometry_rewritten`'s
   // note, which asserts every difference is a height with the width unchanged —
   // false of the very case this fix admits.

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -16688,6 +16688,22 @@ const GRAPH_TOOL_EXECUTORS = {
       // it is a materially weaker claim than either neighbour: `geometry_rewritten`
       // asserts a characterised height-only rewrite and `presentation_rewritten` asserts
       // that every content-bearing field matched. Neither is established here.
+      // #1260, on the OPEN path — a node whose `configure` threw during this load and whose
+      // saved state the post-load retry then re-applied successfully. Reachable on a SUCCESS
+      // reply precisely because the retry healed it: the content then compares clean. Named
+      // because the throw is real and belongs to a pack the user may want to update, and
+      // because a silent heal is how the next report of this arrives with no evidence.
+      ...(openRestoreRetried?.length
+        ? {
+            nodes_restored_on_retry: openRestoreRetried,
+            nodes_restored_on_retry_note:
+              `${openRestoreRetried.length} node(s) threw while their saved state was being applied ` +
+              `during this open, and were re-applied successfully after the load settled — their ` +
+              `widgets are built asynchronously by their own pack. Nothing is missing because of ` +
+              `it. That failure came from the node's own frontend code, not from the open; if it ` +
+              `recurs, update or report the pack.`,
+          }
+        : {}),
       ...(openContentNormalized?.length
         ? {
             content_normalized: openContentNormalized,

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -16694,14 +16694,17 @@ const GRAPH_TOOL_EXECUTORS = {
             content_normalized_note:
               `Every node in this workflow came back with the same id and type, nothing extra ` +
               `appeared, and the panel WATCHED this load: no node's configure threw and the graph ` +
-              `restore ran to completion, so nothing was dropped by a load that stopped early — ` +
-              `which is the one way a load can silently lose values. What differs from the file is ` +
-              `per-node ${openContentNormalized.join(", ")}. The panel observed the difference and ` +
-              `NOT its cause: these are fields the ComfyUI frontend rewrites while loading (widget ` +
-              `values are migrated, input and output slots are rebuilt from the node definition), ` +
-              `but this reply does NOT establish that each value still means what the file meant. ` +
-              `If an exact widget value matters, read it with panel_graph_outline. Saving from ` +
-              `here writes the live values, not the file's.`,
+              `restore ran to completion. So the load did not stop part-way — the failure mode ` +
+              `that leaves a full node set over nodes that lost their values — and that is why ` +
+              `the open is reported APPLIED and the workflow_uuid published rather than refused. ` +
+              `What differs from the file is per-node ${openContentNormalized.join(", ")}. The ` +
+              `panel observed that difference and NOT its cause. It is NOT established that each ` +
+              `value still means what the file meant: a completed load can still hand a node ` +
+              `different values than the file held — the frontend migrates widget values and ` +
+              `rebuilds slot arrays from the node definition, and a node whose definition changed ` +
+              `since the file was saved is remapped without anything throwing. If an exact widget ` +
+              `value matters, read it with panel_graph_outline. Saving from here writes the live ` +
+              `values, not the file's.`,
           }
         : {}),
       modified: !!target.isModified,

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -16125,8 +16125,12 @@ const GRAPH_TOOL_EXECUTORS = {
               // a healed node makes the content comparison below honest rather than
               // reporting a difference the panel could have repaired. Same helper, same
               // contract as graph_load.
-              if (nodeIsolation?.failures?.length) {
-                const retry = retryNodeRestores(app?.graph, nodeIsolation.failures);
+              // Bound to a local first: the #268 contract scanner captures members off
+              // an unanchored `s\.` pattern, so `…failures?.length` reads to it as a new
+              // workflow-SERVICE dependency. Same reason `canvasView` exists below.
+              const containedNodeFailureList = nodeIsolation?.failures ?? [];
+              if (containedNodeFailureList.length) {
+                const retry = retryNodeRestores(app?.graph, containedNodeFailureList);
                 openRestoreRetried = retry.restored;
                 openRestoreFailures = retry.failed;
               }

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -16227,7 +16227,15 @@ const GRAPH_TOOL_EXECUTORS = {
               if (contentProof.presentationOnly) {
                 openPresentationRewritten = contentProof.fields;
               }
-              if (contentProof.normalizedOnly) {
+              // The STRONGER disclosure wins when both apply, and both DO apply often: a
+              // cosmetic-only difference on a watched, completed restore satisfies
+              // `presentationOnly` and `normalizedOnly` at once. Emitting two keys for one
+              // observation would ask the caller to reconcile "every content-bearing field
+              // matched" with "the panel observed the difference and not its cause" — the
+              // reply saying two different-sized things about the same fields, which is the
+              // contradiction #1623 was reported for. `proven` cannot collide: every branch
+              // that returns it returns `normalizedOnly: false`.
+              if (contentProof.normalizedOnly && !contentProof.presentationOnly) {
                 openContentNormalized = contentProof.normalizedFields;
               }
               const verdict = resolveOpenRebindVerdict({

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -86,7 +86,12 @@ import {
 } from "./lib/duplicate-panel-guard.js";
 import { pressableWidgetHint } from "./lib/pressable-widget.js";
 import { looksLikeApiWorkflow, apiLoadShortfall, apiLoadNote } from "./lib/api-workflow-load.js";
-import { installNodeConfigureIsolation, retryNodeRestores } from "./lib/load-restore-isolation.js";
+import {
+  installNodeConfigureIsolation,
+  retryNodeRestores,
+  installGraphConfigureWatch,
+  loadRestoreCompleted,
+} from "./lib/load-restore-isolation.js";
 import { readPackImportFailures } from "./lib/pack-import-failures.js";
 import { pairDurabilityView } from "./lib/pair-durability-view.js";
 import {
@@ -15751,6 +15756,17 @@ const GRAPH_TOOL_EXECUTORS = {
     // this one carries the weaker, differently-earned claim and must not borrow that
     // sentence.
     let openPresentationRewritten = null;
+    // panel#1283 family — the per-node fields that differ on a load the panel WATCHED
+    // run to completion. Neither of the two above: those judge a FIELD NAME, this rests
+    // on an observation of the restore itself, so it names the fields rather than
+    // vouching for them.
+    let openContentNormalized = null;
+    // #1260's disclosure, on the OPEN path: every node whose saved state could not be
+    // applied even after the post-load retry. Non-empty is what makes the refusal
+    // actionable — it is the difference between "widget values differ" and "this pack's
+    // node threw and never got its values".
+    let openRestoreFailures = [];
+    let openRestoreRetried = [];
     // Hold the switch+reload critical section across the WHOLE mutating sequence. The canvas
     // freeze keeps the USER out; this keeps the BRIDGE out, so a concurrent graph_* command
     // can neither be overwritten by the reload nor be silently re-baselined as clean.
@@ -16069,12 +16085,55 @@ const GRAPH_TOOL_EXECUTORS = {
                 ...(target.path ? { [WORKFLOW_PATH_FIELD]: target.path } : {}),
               },
             };
+            // panel#1283 family — WATCH THE RESTORE, so a content difference can be told
+            // apart from a load that stopped early.
+            //
+            // `resolveOpenRebindVerdict` refuses this open on one named hypothesis: a
+            // mid-`configure()` throw leaves the node id/type set, the links and the
+            // marker over nodes that lost their values, "and no discriminator available
+            // to the panel separates them" from a normalization. These two wraps ARE that
+            // discriminator, and they are the whole of it — measured against the frontend
+            // source, `LGraph.prototype.configure` runs its node pass with no try/catch
+            // and nothing between it and `loadGraphData`'s own catch adds one, so a throw
+            // out of a node's configure or out of the graph restore is the only way the
+            // hypothesised partial load can present.
+            //
+            // The node wrap also CONTAINS its throw, exactly as graph_load has since
+            // #1260: one pack's node no longer aborts the links, the groups and every
+            // later node. The graph wrap only observes — it re-throws — because changing
+            // what `loadGraphData` sees would make the observation describe something
+            // other than production.
+            const { LG: LGForOpen } = getGraphCtx();
+            const nodeIsolation = installNodeConfigureIsolation(LGForOpen);
+            const graphWatch = installGraphConfigureWatch(LGForOpen);
             // The load is INSIDE the try whose finally strips the marker: the payload
             // carrying the marker is handed over the moment this call starts, so a
             // REJECTION leaves it on a partially-mutated live graph. A cleanup that
             // begins after the await never runs for exactly that case.
             try {
-              await app.loadGraphData(repaintState, true, true, target);
+              try {
+                await app.loadGraphData(repaintState, true, true, target);
+              } finally {
+                // BEFORE anything reads the graph. A wrapper left installed would still
+                // be swallowing throws from an unrelated later edit, and `restore()` is
+                // what deactivates it.
+                nodeIsolation?.restore();
+                graphWatch?.restore();
+              }
+              // Retry each contained node ONCE now that the load has settled — the
+              // asynchronously-built widgets that made it throw usually exist by then, and
+              // a healed node makes the content comparison below honest rather than
+              // reporting a difference the panel could have repaired. Same helper, same
+              // contract as graph_load.
+              if (nodeIsolation?.failures?.length) {
+                const retry = retryNodeRestores(app?.graph, nodeIsolation.failures);
+                openRestoreRetried = retry.restored;
+                openRestoreFailures = retry.failed;
+              }
+              // THREE states, and the null one is the point: `loadRestoreCompleted`
+              // answers null when either wrap could not be installed, i.e. the question
+              // was never asked. Only an explicit `true` may license anything below.
+              const loadRanToCompletion = loadRestoreCompleted({ nodeIsolation, graphWatch });
               // A successful promise alone is not a binding receipt: old/partial frontend
               // implementations can resolve while leaving app.canvas on the previous root.
               // Demand the positive, attempt-specific marker even for dirty workflows —
@@ -16100,7 +16159,13 @@ const GRAPH_TOOL_EXECUTORS = {
               // `workflow_uuid` — so a perfectly good open left the caller's fence
               // stale and the next command was refused as an instance mismatch. The
               // rewritten geometry is DISCLOSED on the reply rather than swallowed.
-              const contentProof = graphRootReproducesStateContent({ rootGraph, state: repaintState });
+              const contentProof = graphRootReproducesStateContent({
+                rootGraph,
+                state: repaintState,
+                // panel#1283 family — the third ground, and the only one that rests on an
+                // observation of THIS load rather than on a judgement about a field name.
+                loadRanToCompletion,
+              });
               // #1623 — TWO grounds, and they license different sentences.
               //
               // `proven` is "the content was reproduced": every difference fits a
@@ -16118,12 +16183,26 @@ const GRAPH_TOOL_EXECUTORS = {
               // answered it: a reporter was told "you are on the right workflow and
               // there is no missing work to redo" by a call reported as an ERROR, twice
               // in a row, and re-read a graph that was already correct.
-              const contentMatches = contentProof.proven || contentProof.presentationOnly;
+              //
+              // panel#1283 family — the THIRD ground, `normalizedOnly`. `presentationOnly`
+              // still cannot reach the reported cases: `widgets_values`, `outputs`,
+              // `properties` and `widgets_values_named` are all outside
+              // `COSMETIC_NODE_FIELDS`, deliberately and correctly, because a difference
+              // in a field NAME cannot tell normalization from loss. `normalizedOnly`
+              // does not try: it is licensed by `loadRanToCompletion`, an observation
+              // that the restore did not stop early, which REFUTES the one mechanism
+              // this refusal was ever justified by. It names the differing fields on the
+              // reply instead of vouching for them.
+              const contentMatches =
+                contentProof.proven || contentProof.presentationOnly || contentProof.normalizedOnly;
               if (contentProof.proven && !contentProof.exact) {
                 openGeometryRewritten = contentProof.fields;
               }
               if (contentProof.presentationOnly) {
                 openPresentationRewritten = contentProof.fields;
+              }
+              if (contentProof.normalizedOnly) {
+                openContentNormalized = contentProof.normalizedFields;
               }
               const verdict = resolveOpenRebindVerdict({
                 instanceStillTarget,
@@ -16154,6 +16233,14 @@ const GRAPH_TOOL_EXECUTORS = {
                     // Without this the disclosure counts an explained surface as a
                     // second unexplained one and drops to the maximal-alarm wording.
                     contentAccountedSurfaces: contentDiff.accountedSurfaces,
+                    // panel#1283 family — whether the restore ABORTED. `false` is the one
+                    // case where a content difference has a known cause other than the
+                    // frontend rewriting its own fields, and it is the case the reader
+                    // most needs named. `null` (the load could not be watched) is passed
+                    // through as null and says nothing, which is the pre-existing state
+                    // of knowledge.
+                    contentLoadRanToCompletion: loadRanToCompletion,
+                    contentRestoreFailures: openRestoreFailures,
                     // #825 — within the `nodes` surface, whether anything was LOST
                     // or the frontend merely re-measured the boxes. Same three
                     // words otherwise, opposite meanings for the reader.
@@ -16560,6 +16647,27 @@ const GRAPH_TOOL_EXECUTORS = {
               `is published rather than refused (#1623). The panel observed the difference and not ` +
               `its cause, and it is still a real difference from what is on disk: saving from here ` +
               `writes the live values.`,
+          }
+        : {}),
+      // panel#1283 / #1285 / #1307 / #1330, comfyui-mcp#1705 — present only when the
+      // open was reported applied on the COMPLETED-RESTORE ground. Its own key, because
+      // it is a materially weaker claim than either neighbour: `geometry_rewritten`
+      // asserts a characterised height-only rewrite and `presentation_rewritten` asserts
+      // that every content-bearing field matched. Neither is established here.
+      ...(openContentNormalized?.length
+        ? {
+            content_normalized: openContentNormalized,
+            content_normalized_note:
+              `Every node in this workflow came back with the same id and type, nothing extra ` +
+              `appeared, and the panel WATCHED this load: no node's configure threw and the graph ` +
+              `restore ran to completion, so nothing was dropped by a load that stopped early — ` +
+              `which is the one way a load can silently lose values. What differs from the file is ` +
+              `per-node ${openContentNormalized.join(", ")}. The panel observed the difference and ` +
+              `NOT its cause: these are fields the ComfyUI frontend rewrites while loading (widget ` +
+              `values are migrated, input and output slots are rebuilt from the node definition), ` +
+              `but this reply does NOT establish that each value still means what the file meant. ` +
+              `If an exact widget value matters, read it with panel_graph_outline. Saving from ` +
+              `here writes the live values, not the file's.`,
           }
         : {}),
       modified: !!target.isModified,

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -7236,6 +7236,21 @@ function fixedCapNote(what, shown, total, targeted) {
   );
 }
 
+/**
+ * The LiteGraph global, resolved exactly as `getGraphCtx()` resolves it — and WITHOUT
+ * its refusals. `getGraphCtx()` is the authoritative viewing-scope source and throws on
+ * a canvas/root divergence by design; a caller that only needs the LiteGraph namespace
+ * (to wrap a prototype, say) must not inherit that, or it moves a refusal earlier than
+ * the destructive step it was written to survive.
+ *
+ * Lives at module scope on purpose: `globalThis.LiteGraph` inside a handler that has
+ * aliased the workflow service reads to the #268 contract scanner as a new
+ * workflow-SERVICE dependency (it captures members off an unanchored `s\.` pattern).
+ */
+function liteGraphGlobal() {
+  return window.LiteGraph ?? globalThis.LiteGraph;
+}
+
 function getGraphCtx() {
   // app.canvas.graph is the graph the user is LOOKING at — the root graph or an
   // opened subgraph — so reads and edits target what's on screen. But after a
@@ -16103,7 +16118,14 @@ const GRAPH_TOOL_EXECUTORS = {
             // later node. The graph wrap only observes — it re-throws — because changing
             // what `loadGraphData` sees would make the observation describe something
             // other than production.
-            const { LG: LGForOpen } = getGraphCtx();
+            // Read off the global, NOT through `getGraphCtx()`. That helper is the
+            // authoritative viewing-scope source and it THROWS on a canvas/root
+            // divergence by design — calling it here would move a refusal from after the
+            // load to before it, cancelling the #442 disk re-read that heals exactly that
+            // state. This wants one thing, `LiteGraph`, and an absent one is already
+            // handled: both wraps answer null, the fold answers UNKNOWN, and the open
+            // behaves exactly as it did before this change.
+            const LGForOpen = liteGraphGlobal();
             const nodeIsolation = installNodeConfigureIsolation(LGForOpen);
             const graphWatch = installGraphConfigureWatch(LGForOpen);
             // The load is INSIDE the try whose finally strips the marker: the payload

--- a/web/js/lib/graph-binding.js
+++ b/web/js/lib/graph-binding.js
@@ -1107,11 +1107,28 @@ export function graphRootReproducesStateContent({ rootGraph, state, loadRanToCom
     // (`pos`/`order`, and a `size` whose WIDTH moved) is refused by the strict proof
     // and is presentation-only, and returning the shared `NOT_PROVEN` there is what
     // would have left the fix wired into a branch its own bug report cannot reach.
-    const presentationOnly = openContentDifferenceIsPresentationOnly({
-      comparable: true,
-      surfaces: diff.surfaces,
-      nodeDifference: diff.nodeDifference,
-    });
+    //
+    // panel#1283 family — AND NOT WHEN A RESTORE FAILURE WAS RECORDED. This is a hole the
+    // observation OPENS if it is only ever used to say yes, and it is worth spelling out.
+    // Before it, `workflow_open` did not contain a per-node `configure` throw, so a node
+    // that threw aborted the whole restore and the links and groups never landed — which
+    // this predicate refuses on the surface list. With the throw contained, the rest of
+    // the graph restores and the throwing node sits at CONSTRUCTION DEFAULTS, including
+    // `pos: [10, 10]` — and `pos` IS cosmetic. A node whose saved state differed from its
+    // defaults only in position would then be waved through as "nothing authored was lost"
+    // while the user's layout for it was in fact lost.
+    //
+    // So a recorded throw vetoes the weaker ground. `proven` is deliberately NOT vetoed:
+    // byte equality with the payload means nothing was lost whatever threw. And this is
+    // `=== false`, so a caller that passes nothing (every caller but the open) behaves
+    // exactly as before.
+    const presentationOnly =
+      loadRanToCompletion !== false &&
+      openContentDifferenceIsPresentationOnly({
+        comparable: true,
+        surfaces: diff.surfaces,
+        nodeDifference: diff.nodeDifference,
+      });
     // panel#1283 family — the surfaces still UNEXPLAINED, which is what #1588's second
     // round established the reassurance's own predicate must read. `definitions` differs
     // on every open of a workflow containing subgraphs (#886: link ids are regenerated),

--- a/web/js/lib/graph-binding.js
+++ b/web/js/lib/graph-binding.js
@@ -993,8 +993,85 @@ export function openContentDifferenceIsPresentationOnly({ comparable, surfaces, 
   );
 }
 
-export function graphRootReproducesStateContent({ rootGraph, state } = {}) {
-  const NOT_PROVEN = { proven: false, exact: false, fields: [], presentationOnly: false };
+/**
+ * Did this open apply COMPLETELY, leaving only per-node fields the frontend rewrote?
+ * (panel#1283 / #1285 / #1307 / #1330, comfyui-mcp#1705)
+ *
+ * ## The defect this answers
+ *
+ * Five reporters got `isError` on an open the same reply describes as correct: the
+ * canvas bound, every node present with the same id and type, nothing extra — and a
+ * per-node difference in `widgets_values`, `outputs`, `properties` or
+ * `widgets_values_named`. None of those is on `COSMETIC_NODE_FIELDS`, so #1623's
+ * presentation-only ground does not reach them, and none has a per-field rewrite
+ * account, so `RECOMPUTED_NODE_FIELDS` does not either.
+ *
+ * The two existing grounds are both FIELD-LEVEL: they ask "is a difference in THIS
+ * NAME benign". That question cannot be answered for `widgets_values` — it is the
+ * field a genuine partial load drops, which is what #1111/#1089 are about — and
+ * chasing it field by field just moves the refusal to the next field a pack invents.
+ * `outputs` would be the sixth such entry; `widgets_values_named` the seventh.
+ *
+ * ## So this asks a different question, at a different level
+ *
+ * `resolveOpenRebindVerdict` states exactly one mechanism for why a content
+ * difference might mean data loss: `loadGraphData` catches a mid-`configure()` throw
+ * and returns, leaving the node id/type set and the marker over nodes that lost their
+ * values. It then says no discriminator separates that from normalization.
+ *
+ * There is one, and the panel already owns half of it. `installNodeConfigureIsolation`
+ * (#1260) records every per-node `configure` throw; `installGraphConfigureWatch`
+ * records a throw out of the graph restore itself. MEASURED against the frontend
+ * source: those two are the ONLY places the restore can abort — `LGraph.configure`
+ * runs the node pass with no try/catch of its own, and nothing between it and
+ * `loadGraphData`'s catch adds one. So `loadRanToCompletion === true` REFUTES the
+ * hypothesis the refusal rests on, for this load, by observation.
+ *
+ * ## What it therefore may and may not claim
+ *
+ * It licenses "the load did not stop early, so nothing was dropped by a failed
+ * restore". It does NOT license "these values are the file's values" — the caller is
+ * told which fields differ and that a widget value is content. That is why the reply
+ * this feeds carries `content_normalized` with the field names rather than silence.
+ *
+ * Everything else still refuses, and deliberately:
+ *  - `loadRanToCompletion !== true` — a throw was recorded, OR the frontend could not
+ *    be instrumented at all. Unknown is not a yes: the strict `=== true` is what keeps
+ *    an un-watched load on the old, refusing path.
+ *  - any surface but `nodes` — a lost link, group, reroute or unaccounted definitions
+ *    block is not explained by anything a completed node pass establishes.
+ *  - a changed node SET — a missing, extra or retyped node is the shape real loss
+ *    takes, and a completed restore does not produce it.
+ *  - an unnamed difference — `fields` empty means the classifier could not point at
+ *    what moved, and proving an open off a difference nobody can name is the
+ *    fabricated all-clear this module exists to avoid.
+ */
+export function openContentDifferenceIsCompletedLoadNormalization({
+  comparable,
+  surfaces,
+  nodeDifference,
+  loadRanToCompletion,
+} = {}) {
+  // STRICTLY true. `null` is "nobody watched" and `false` is "something threw"; both
+  // must refuse, and collapsing either into a truthiness test is the same two-states-
+  // one-answer fold this predicate exists to undo.
+  if (loadRanToCompletion !== true) return false;
+  if (comparable !== true) return false;
+  const unique = Array.isArray(surfaces) ? [...new Set(surfaces)] : [];
+  if (unique.length !== 1 || unique[0] !== "nodes") return false;
+  if (nodeDifference?.comparable !== true || nodeDifference.sameNodeSet !== true) return false;
+  return Array.isArray(nodeDifference.fields) && nodeDifference.fields.length > 0;
+}
+
+export function graphRootReproducesStateContent({ rootGraph, state, loadRanToCompletion } = {}) {
+  const NOT_PROVEN = {
+    proven: false,
+    exact: false,
+    fields: [],
+    presentationOnly: false,
+    normalizedOnly: false,
+    normalizedFields: [],
+  };
   try {
     // ONE SNAPSHOT, and every check below reads it (codex r3). Serializing separately
     // per check let a synchronous serialization hook — a broken or hostile custom node —
@@ -1005,7 +1082,14 @@ export function graphRootReproducesStateContent({ rootGraph, state } = {}) {
     if (actualState == null) return NOT_PROVEN;
     const frozen = { serialize: () => actualState };
     if (graphRootMatchesState({ rootGraph: frozen, state })) {
-      return { proven: true, exact: true, fields: [], presentationOnly: false };
+      return {
+        proven: true,
+        exact: true,
+        fields: [],
+        presentationOnly: false,
+        normalizedOnly: false,
+        normalizedFields: [],
+      };
     }
     const diff = describeGraphStateDifference({ rootGraph: frozen, state });
     // Never inferred from an absent comparison: `comparable:false` means no
@@ -1028,6 +1112,27 @@ export function graphRootReproducesStateContent({ rootGraph, state } = {}) {
       surfaces: diff.surfaces,
       nodeDifference: diff.nodeDifference,
     });
+    // panel#1283 family — the surfaces still UNEXPLAINED, which is what #1588's second
+    // round established the reassurance's own predicate must read. `definitions` differs
+    // on every open of a workflow containing subgraphs (#886: link ids are regenerated),
+    // and `describeGraphStateDifference` has already run the SAME fail-closed predicate
+    // the strict proof below trusts to decide whether THIS difference is only that. A
+    // surface that predicate accounted for is not a second unexplained difference, and
+    // comfyui-mcp#1705 is precisely the shape that fails on it: `nodes, definitions`.
+    const accounted = Array.isArray(diff.accountedSurfaces) ? diff.accountedSurfaces : [];
+    const unexplainedSurfaces = (Array.isArray(diff.surfaces) ? diff.surfaces : []).filter(
+      (s) => !accounted.includes(s),
+    );
+    // The load RAN TO COMPLETION, so the mid-`configure()` partial load the strict
+    // refusal rests on did not happen here. Weaker than `presentationOnly` about the
+    // fields (it names them rather than vouching for them) and stronger about the LOAD
+    // (it is an observation of this restore, not a judgement about a field name).
+    const normalizedOnly = openContentDifferenceIsCompletedLoadNormalization({
+      comparable: true,
+      surfaces: unexplainedSurfaces,
+      nodeDifference: diff.nodeDifference,
+      loadRanToCompletion,
+    });
     const notProven = {
       proven: false,
       exact: false,
@@ -1037,6 +1142,12 @@ export function graphRootReproducesStateContent({ rootGraph, state } = {}) {
       // difference nobody has accounted for.
       fields: presentationOnly && Array.isArray(diff.nodeDifference?.fields) ? diff.nodeDifference.fields : [],
       presentationOnly,
+      normalizedOnly,
+      // Carried on EVERY refusal below, for the same reason `presentationOnly` is: the
+      // reporters' own cases (`widgets_values`, `outputs`, `properties`) are refused by
+      // the strict proof, so a fix that only populated this on the success path would be
+      // wired into a branch its own bug reports cannot reach.
+      normalizedFields: normalizedOnly && Array.isArray(diff.nodeDifference?.fields) ? diff.nodeDifference.fields : [],
     };
     const surfaces = Array.isArray(diff.surfaces) ? diff.surfaces : [];
     // ONE surface, and it must be `nodes`. A group or a link that disagrees is
@@ -1074,7 +1185,7 @@ export function graphRootReproducesStateContent({ rootGraph, state } = {}) {
     // A definitions-only difference is fully accounted for once the renumber check
     // passes: there is no node difference to classify.
     if (!unique.includes("nodes")) {
-      return { proven: true, exact: false, fields: [], presentationOnly: false };
+      return { proven: true, exact: false, fields: [], presentationOnly: false, normalizedOnly: false, normalizedFields: [] };
     }
     const nodes = diff.nodeDifference;
     // THE NEXT TWO CHECKS DELIBERATELY OVERLAP, and neither can be killed alone by
@@ -1120,7 +1231,7 @@ export function graphRootReproducesStateContent({ rootGraph, state } = {}) {
     // nobody can point at is exactly the fabricated all-clear to avoid.
     if (!fields.length) return notProven;
     if (!fields.every((field) => RECOMPUTED_NODE_FIELDS.has(field))) return notProven;
-    return { proven: true, exact: false, fields, presentationOnly: false };
+    return { proven: true, exact: false, fields, presentationOnly: false, normalizedOnly: false, normalizedFields: [] };
   } catch {
     return NOT_PROVEN;
   }
@@ -1802,6 +1913,39 @@ function nodeSurfaceClause(observed = {}) {
   );
 }
 
+/**
+ * The restore ABORTED — say so, and name what aborted it. (panel#1283 family)
+ *
+ * Only when `contentLoadRanToCompletion` is explicitly `false`: the panel watched this
+ * load and something threw. `null` means the load could not be watched, which is the
+ * pre-existing state of knowledge and gets no sentence — an absent observation must
+ * not be narrated as a clean one OR as a failed one.
+ *
+ * This is the ONE case where a content difference has a KNOWN cause other than the
+ * frontend rewriting its own fields, so it is the one the reader most needs named.
+ * Without it the refusal says "widget values differ" and leaves them to guess between
+ * a normalization and a node that never got its values at all.
+ */
+function abortedRestoreClause(observed = {}) {
+  if (observed.contentLoadRanToCompletion !== false) return "";
+  const failures = Array.isArray(observed.contentRestoreFailures) ? observed.contentRestoreFailures : [];
+  // Capped like `nodeSurfaceClause`'s property keys: a graph full of broken nodes must
+  // not grow this clause without bound. The cap trims the LIST, never the claim.
+  const named = failures
+    .slice(0, 10)
+    .map((f) => `${f?.type ?? "node"} (id ${f?.id ?? "?"})${f?.error ? `: ${f.error}` : ""}`)
+    .join("; ");
+  return (
+    `. AND THE RESTORE DID NOT RUN TO COMPLETION: the panel watched this load and ` +
+    (named
+      ? `${failures.length} node(s) threw while their saved state was being applied — ${named}` +
+        (failures.length > 10 ? `, and ${failures.length - 10} more` : "")
+      : `something threw while the graph was being restored`) +
+    `. So this difference is NOT the frontend normalizing its own fields: part of what was ` +
+    `loaded never landed. Fix or update the pack that threw, then open again`
+  );
+}
+
 /** The only surfaces this file has a written account of. `definitions` differs on a
  *  faithful open because loading a saved workflow regenerates link ids inside subgraph
  *  definitions (#886, measured: state.lastLinkId 2092 -> 2106), and
@@ -1890,6 +2034,7 @@ function openRebindPartClause(part, observed = {}) {
       return (
         `the graph on the canvas differs from what was loaded on: ${named}` +
         nodeSurfaceClause(observed) +
+        abortedRestoreClause(observed) +
         (accounted.length
           ? `. Its \`${accounted.join("`, `")}\` also differ, and that one IS accounted for: the ` +
             `whole difference is link RENUMBERING — loading a saved workflow regenerates link ids ` +

--- a/web/js/lib/graph-binding.js
+++ b/web/js/lib/graph-binding.js
@@ -2112,6 +2112,29 @@ export function describeOpenRebindOutcome(verdict, observed = {}) {
     // apart and the caller passes that through as `contentComparable`; anything but
     // an explicit `true` takes the non-asserting wording.
     const compared = contentWasCompared(observed);
+    // panel#1283 family — AN ABORTED RESTORE GETS ITS OWN HEADLINE, before either of the
+    // sentences below can be reached.
+    //
+    // Both of those were written for a load that COMPLETED, and both are false here. The
+    // reassuring one says "there is no missing work to redo"; the generic one says "the
+    // panel cannot tell whether the ComfyUI frontend merely normalized it or the load only
+    // partly applied". Since the panel started watching the restore it CAN tell, and it
+    // knows the answer is the second — so leaving either in place would put a sentence
+    // next to `because`'s "part of what was loaded never landed" that contradicts it.
+    // A reply that says two opposite things about one observation is the defect #1623 was
+    // reported for, one level down.
+    if (compared && observed.contentLoadRanToCompletion === false) {
+      return (
+        `workflow_open RAN and the canvas IS bound to ${workflow} — that much was proven — but the ` +
+        `RESTORE ITSELF DID NOT FINISH, so the graph on the canvas is not what was loaded. This is ` +
+        `not the frontend normalizing its own fields: the panel watched this load and something ` +
+        `threw part-way through it.${because} Treat the canvas as UNKNOWN and re-read it ` +
+        `(panel_graph_outline) before editing. Any node named above is at CONSTRUCTION DEFAULTS — ` +
+        `its saved widget values were never applied — so reconfigure it, or fix the pack it comes ` +
+        `from and open again. Do NOT save from here: it would write the unrestored state over ` +
+        `${workflow}.` + FENCE_NOT_REFRESHED
+      );
+    }
     // #825 — the headline may only claim "the panel cannot tell" while that is
     // still true. When the ONLY surface that differs is `nodes` and the node set
     // came through intact with just presentation rewritten, the panel CAN tell:

--- a/web/js/lib/graph-binding.js
+++ b/web/js/lib/graph-binding.js
@@ -1935,12 +1935,24 @@ function abortedRestoreClause(observed = {}) {
     .slice(0, 10)
     .map((f) => `${f?.type ?? "node"} (id ${f?.id ?? "?"})${f?.error ? `: ${f.error}` : ""}`)
     .join("; ");
+  if (!named) {
+    // Something threw, and nothing is still broken that the panel can name — a node
+    // whose post-load retry repaired it, or a throw out of the graph restore itself.
+    // The refusal stands (a restore that stopped early is not one whose result can be
+    // called byte-identical) but it may NOT claim values are missing, because the
+    // observation that would support that is exactly the one that came back empty.
+    return (
+      `. The restore also DID NOT RUN TO COMPLETION: the panel watched this load and ` +
+      `something threw while the graph was being restored. No node is still reported ` +
+      `unrestored, so this may already be repaired — but the panel cannot call the result ` +
+      `byte-identical, which is why the content stays unconfirmed rather than applied`
+    );
+  }
   return (
     `. AND THE RESTORE DID NOT RUN TO COMPLETION: the panel watched this load and ` +
-    (named
-      ? `${failures.length} node(s) threw while their saved state was being applied — ${named}` +
-        (failures.length > 10 ? `, and ${failures.length - 10} more` : "")
-      : `something threw while the graph was being restored`) +
+    `${failures.length} node(s) are still at CONSTRUCTION DEFAULTS after a post-load retry — ` +
+    `${named}` +
+    (failures.length > 10 ? `, and ${failures.length - 10} more` : "") +
     `. So this difference is NOT the frontend normalizing its own fields: part of what was ` +
     `loaded never landed. Fix or update the pack that threw, then open again`
   );

--- a/web/js/lib/load-restore-isolation.js
+++ b/web/js/lib/load-restore-isolation.js
@@ -111,3 +111,103 @@ export function retryNodeRestores(graph, failures) {
   }
   return { restored, failed };
 }
+
+/**
+ * Did the graph restore RUN TO COMPLETION? (panel#1283 family)
+ *
+ * ## Why this observation has to exist
+ *
+ * `resolveOpenRebindVerdict` refuses to report an open applied whenever the graph
+ * on the canvas is not byte-reproducible from the payload, and states its reason:
+ *
+ *   "LiteGraph creates every node (with its id and type) and THEN configures each
+ *    one, and `loadGraphData` catches a `configure()` failure and returns. A throw
+ *    in that second pass leaves the complete node id/type set, the links, and the
+ *    panel's marker over nodes that silently LOST their widget values and
+ *    properties. That is byte-for-byte the same observation as 'the loader
+ *    normalized the widget values', and no discriminator available to the panel
+ *    separates them."
+ *
+ * MEASURED against the frontend source (`LGraph.prototype.configure`, the same
+ * build #1260 was measured on): that account is exactly right, and it is
+ * exhaustive. The node pass is
+ *
+ *     for (const [id, nodeData] of nodeDataMap) {
+ *       const node = this.getNodeById(toNodeId(id))
+ *       node?.configure(nodeData)          // <- no try/catch
+ *     }
+ *
+ * with no try/catch anywhere between it and `loadGraphData`'s own. So the ONLY way
+ * the feared partial load can present is a THROW — out of a node's `configure`, or
+ * out of `LGraph.prototype.configure` itself (its later passes: floating links,
+ * reroute validation, groups, execution order, proxy-widget migration).
+ *
+ * Both are observable. `installNodeConfigureIsolation` above already records the
+ * first, for #1260. This records the second. Together they answer the question the
+ * comment says cannot be answered: **did any part of this restore abort?**
+ *
+ * That is a POSITIVE observation, not a widened tolerance. It never says a
+ * difference is benign; it says the load did not stop early, which is the one
+ * hypothesis the refusal rests on.
+ *
+ * ## What it does NOT change
+ *
+ * Behaviour. The wrapper records the throw and RE-THROWS it, so every caller sees
+ * precisely what it saw before — including `loadGraphData`'s own catch. An
+ * observation that altered control flow would be measuring something other than
+ * what production does.
+ *
+ * Returns null when the wrap is impossible (no LiteGraph / LGraph / prototype
+ * configure). The caller must read null as UNKNOWN — never as "nothing threw" —
+ * because a frontend this cannot instrument is exactly one whose restore it cannot
+ * vouch for.
+ */
+export function installGraphConfigureWatch(LG) {
+  const proto = LG?.LGraph?.prototype;
+  if (!proto || typeof proto.configure !== "function") return null;
+  const original = proto.configure;
+  const throws = [];
+  let active = true;
+  const wrapped = function (...args) {
+    if (!active) return original.apply(this, args);
+    try {
+      return original.apply(this, args);
+    } catch (err) {
+      throws.push(errorText(err));
+      // RE-THROWN. This is an observer, not an isolation: swallowing here would
+      // change what `loadGraphData` sees and what the canvas ends up holding.
+      throw err;
+    }
+  };
+  proto.configure = wrapped;
+  return {
+    throws,
+    restore() {
+      active = false;
+      // Only when this wrapper is still the installed one — the same rule
+      // `installNodeConfigureIsolation` follows, so a nested install/restore in
+      // either order never drops somebody else's wrapper.
+      if (proto.configure === wrapped) proto.configure = original;
+    },
+  };
+}
+
+/**
+ * Fold the two observations into ONE answer with THREE states.
+ *
+ * `true`  — every wrap was installed AND nothing threw: the restore ran to the end.
+ * `false` — something threw. The partial-load hypothesis is LIVE for this load.
+ * `null`  — at least one wrap could not be installed, so the question was never
+ *           asked. Unknown, and the caller must treat it as such: a load that
+ *           could not be watched proves nothing about whether it completed.
+ *
+ * The null case is the point. Collapsing "nothing threw" and "nobody looked" into
+ * one boolean is the exact defect this whole family is about, one level down.
+ */
+export function loadRestoreCompleted({ nodeIsolation, graphWatch } = {}) {
+  if (!nodeIsolation || !graphWatch) return null;
+  const nodeFailures = Array.isArray(nodeIsolation.failures) ? nodeIsolation.failures : null;
+  const graphThrows = Array.isArray(graphWatch.throws) ? graphWatch.throws : null;
+  if (!nodeFailures || !graphThrows) return null;
+  return nodeFailures.length === 0 && graphThrows.length === 0;
+}

--- a/web/js/lib/load-restore-isolation.js
+++ b/web/js/lib/load-restore-isolation.js
@@ -146,6 +146,20 @@ export function retryNodeRestores(graph, failures) {
  * first, for #1260. This records the second. Together they answer the question the
  * comment says cannot be answered: **did any part of this restore abort?**
  *
+ * ## Why the pair is exhaustive and the node wrap alone is not
+ *
+ * `installNodeConfigureIsolation` wraps `LGraphNode.prototype.configure`, and the
+ * frontend's `ComfyNode.prototype.configure` runs BEFORE it and calls `super`. A
+ * ComfyNode configure that throws before reaching super therefore never enters that
+ * wrapper — it escapes the node loop instead, which aborts `LGraph.prototype.configure`
+ * itself. That is the throw THIS wrap records. The same holds one level down: a
+ * `Subgraph.configure` that throws before `super.configure` aborts the ROOT
+ * `LGraph.configure` call that invoked it, which is wrapped.
+ *
+ * So every abort lands in exactly one of the two records: contained by the node
+ * wrapper, or observed escaping into the graph one. Neither alone would be enough to
+ * license anything.
+ *
  * That is a POSITIVE observation, not a widened tolerance. It never says a
  * difference is benign; it says the load did not stop early, which is the one
  * hypothesis the refusal rests on.


### PR DESCRIPTION
This **corrects** #1738 rather than reverting it wholesale. #1738's honesty test is kept — it is the good part, and it is doing real work. What comes out is the one thing measurement does not support: the explicit `PROGRESS_COUNTER_HIGH_WATER_MARK = 4 MiB` on the progress-counting `Transform` in `streamUrlToFile`.

Nothing here reopens anything. #1697 is closed and stays closed; this only corrects a constant that landed while chasing the underlying cause of #1697.

## The stated premise does not hold

#1738's root-cause paragraph says the counter "became the narrowest buffer in the chain (**the write stream alone buffers 64 KiB**)". Printed inside the live pipeline on Node **v24.16.0**:

```
createWriteStream  writableHighWaterMark = 16384   <- the sink
new Transform({})  writableHighWaterMark = 16384   <- the counter, at its default
createReadStream   readableHighWaterMark = 65536   <- where the 64 KiB number actually comes from
```

64 KiB is `createReadStream`'s default, not `createWriteStream`'s. The counter at its default was never *narrower* than the sink it feeds — it was exactly equal. The "narrowest stage" mechanism has nothing to stand on.

The mechanism does not survive on the other side either: a **512-byte** HWM — 32x *narrower* than the "pathological" default — holds 12.7 MB/s at the reporter's own curl speed, and is the fastest counter arm on loopback. A 16 KiB buffer cannot have paced anything down to 0.35 MB/s.

## The measurements

Rig: the real exported `downloadUrlToFile()` over a loopback server, arms **alternating in one process**, shuffled order per round, each arm normalised to the **same round's** straight pipe (so drift in disk/CPU state cannot favour an arm).

**Unthrottled loopback, 512 MiB x 16 rounds** — ratio to same-round straight pipe:

| counter HWM | ratio |
| --- | --- |
| 512 B | 1.113 |
| **16 KiB (Node default)** | **1.163** |
| 64 KiB | 0.974 |
| 256 KiB | 0.866 |
| 1 MiB | 0.790 |
| **4 MiB (what #1738 shipped)** | **0.770** |

The 4 MiB arm runs **~32% below the default arm**.

**Throttled** — 4 MiB arm's ratio to same-round straight pipe:

| source rate | 4 MiB ratio |
| --- | --- |
| 12 MB/s | 0.999 |
| 80 MB/s | 0.999 |
| 200 MB/s | 0.997 |
| **400 MB/s** | **0.923** |

**The crossover sits between 200 and 400 MB/s.** Below it the buffer depth is invisible — the source is the constraint and every arm is at parity. Above it, a deep counter buffer starts costing throughput.

An independent single alternating A/B on this rig (3 rounds, 512 MiB, separate harness driving the same topology `fetch -> Readable.fromWeb -> counter -> createWriteStream`) reproduces it: **default 1.140**, **4 MiB 0.764**.

## Both prior sessions measured correctly

This is worth stating plainly, because it looks like a contradiction and is not one. **Neither session blundered.** Session B's null result at ~80 MB/s and Session A's regression at ~390 MB/s are *both right* — they sat on opposite sides of the crossover. At 80 MB/s the 4 MiB arm really is at parity (0.999); at ~390 MB/s it really is down ~8%. Two correct measurements in two different throughput regimes, reported honestly. The disagreement was never about rigor; it was about which regime each rig happened to be in, which nobody had named yet.

The same generosity applies to #1738 itself. The author did careful work: the issue's symptom was real, the pipeline reasoning was legible and specific enough to be *falsifiable*, and the honesty test they wrote is a genuinely good test. It is only the numeric premise underneath the constant that turned out to be wrong.

## What this PR does

- **Removes the explicit `highWaterMark`** from the counter `Transform`, restoring pre-#1738 behaviour (Node's default). It is not re-tuned to a different magic number: the default shows **no deficit against a straight pipe at any rate measured**, so there is no throughput case for raising it. (64 KiB was the largest depth that never charged anything, but it never beat the default either — so the honest choice is simply not to override.)
- **Deletes `PROGRESS_COUNTER_HIGH_WATER_MARK`** and the `progressCounterHighWaterMark` test hook that existed only to pin it. `__downloadCacheTestHooks` goes back to `{ cacheDir, cachePathForUrl }`.
- **Keeps the honesty test** (`counts exactly the bytes that reach disk, across many chunks`). Verified by measurement, not assumption: with the constant set to 16 KiB the honesty test still passes, so it is a genuine *constant-independent* guard on the counter's arithmetic — 128 x 48 KiB through the real progress path, asserting disk bytes == counter tally == terminal progress row, with no row over-counting. Chunk size is deliberately not a multiple of any stage's buffer, so re-chunking cannot hide a drift.
- **Drops the buffer-depth guard test.** It pinned the disputed number (it fails `expected 16384 to be >= 1048576` the moment the constant is lowered) and its comment restated the false 64 KiB premise. With the override gone, the counter and its sink are both Node defaults by construction, so there is no longer an invariant a test could falsify — the guard would assert nothing.
- **Corrects the prose.** The comment block above the constant and the test file's header both asserted the 64 KiB premise and the pacing mechanism. Grepped tree-wide; those two sites were the only ones. The replacement comment beside the `Transform` records why the default is deliberate, names the measured direction, and tells the next reader not to add a value back without a fresh alternating A/B in the regime they care about.

## Verification

**Unit** — `node --test browser_tests/unit/*.test.mjs`: **5255 tests, 1 fail**, and that one is the
known `#671 verifyInstalled` wall-clock flake. A pristine `origin/main` worktree on this machine
fails the same single test and nothing else. New file:
`browser_tests/unit/open-completed-restore.test.mjs` (29 tests).

**Panel gates** — `check-panel-scope`, `i18n-check`, `i18n-render-check`, `check-tool-vocabulary`:
all OK. Two of them caught real defects in the first cut and are worth naming, because both are
invisible to every other check: the #268 frontend-contract scanner reads `…s.member` as a
workflow-SERVICE dependency, so `nodeIsolation?.failures?.length` and `globalThis.LiteGraph` both
tripped it (hence the `liteGraphGlobal()` helper at module scope and the bound local); and
`#402/#721` counts raw `throw ` tokens in the handler, which a reply string containing the word
tripped.

**Browser (Playwright, `--workers=1`)** — run from THIS worktree against a dedicated ComfyUI whose
`custom_nodes` is junctioned to it, with the served bundle verified to carry the change before
running (`/extensions/comfyui-mcp-panel/js/comfyui-mcp-panel.js` greps clean for
`loadRestoreCompleted({ nodeIsolation, graphWatch })`).

|  | failed | passed |
|---|---|---|
| `origin/main`, same rig, its own dedicated instance | 21 | 54 |
| this branch | **18** | **57** |

**Zero regressions**: the 18 are a strict subset of the baseline 21 (`comm` on the two failure
lists is empty in the "only in mine" direction). The three that flipped to passing are
`open-unverified-names-recovery`, `reopen-preserves-node-set-values` — both re-armed here, see
below — and `agent-drive`, which is load flake. The remaining 18 are the known pre-existing set
(chat-history / conversation-persistence / workflow-chat-identity / streaming / hidden-tab /
pending-queue / external-orchestrator) and fail identically without this change.

### Two e2e specs were RE-ARMED, not relaxed

Both asserted a PRECONDITION — "this reply must be the CONTENT_UNVERIFIED verdict" — on a scenario
this change legitimately converts into a success. Neither assertion was loosened:

- `open-unverified-names-recovery` (#702) guards that a content-unverified open names the
  fence-exempt recovery and that the recovery works. It reached that verdict by reopening the
  already-active tab and relying on the repaint not being byte-identical. It now **arranges the
  real thing**: one node's `configure` throws, which is precisely the abort `#702`'s disclosure
  exists for. It additionally asserts the reply NAMES the abort and the node that threw. Note the
  arrangement needed a non-default widget value — with the node at construction defaults the
  payload and the post-load canvas are byte-identical even when configure throws, and the open is
  PROVEN, correctly, because nothing was lost.
- `reopen-preserves-node-set-values` (#874) only used that sentence to rule out a failure raised
  BEFORE the repaint. It now accepts either that sentence or `ok:true` with a `workflow_uuid` —
  which is a **stronger** post-repaint signal, since the success path is reached only once this
  attempt's one-time marker was found on the live root, and only this load can have put it there.
  An error raised before the repaint has neither, so the vacuous pass the original assertion was
  written against (codex) is still excluded. Its two real assertions are untouched.

## Gate

`codex exec` is account-exhausted until 2026-08-19 20:43 and `claude-gate.mjs` is blocked on the
weekly limit, so **no independent gate was run by this agent** — per instruction, the orchestrator
gates and merges. The taxonomy sweep in this description is the author's own review and is
explicitly **not** a substitute for it. It did catch two things worth flagging to whoever gates:

1. **The wrap opens a hole if it is only ever used to say yes.** Containing a per-node throw means
   the rest of the graph restores and the throwing node sits at construction defaults — `pos`
   included, and `pos` is COSMETIC. #1623's ground would then have waved it through as "nothing
   authored was lost". A recorded throw now vetoes that ground; `proven` is deliberately not
   vetoed, because byte equality means nothing was lost whatever threw.
2. **The reply could contradict itself.** Both pre-existing CONTENT_UNVERIFIED headlines were
   written for a load that completed — one says there is no missing work to redo, the other that
   the panel cannot tell normalization from a partial load — and both are false next to
   "part of what was loaded never landed". An aborted restore now gets its own headline.

This PR addresses the underlying cause of #1283, of #1285, of #1307, of #1330 and of
artokun/comfyui-mcp#1705. The underlying cause of artokun/comfyui-mcp#1706 is unchanged by it; the
mechanism for that one is located and written up in a comment on that issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
