### PR TITLE
fix(1267b): a Save-As acknowledges the CAPTURE it observed, not the openWorkflow it called

### DIFF
--- a/browser_tests/unit/save-as-capture-observed.test.mjs
+++ b/browser_tests/unit/save-as-capture-observed.test.mjs
@@ -1,0 +1,335 @@
+// #1267 half (b) — a Save-As must ACKNOWLEDGE THE CAPTURE, not the call.
+//
+// Reported: "the tool reported the new workflow name, the active canvas reverted, and
+// the newly named copy was EMPTY." The mechanism, read off the installed 1.47 frontend
+// bundle rather than inferred:
+//
+//   ComfyWorkflow:  get activeState() { return this.changeTracker?.activeState ?? null }
+//   ComfyWorkflow.save():  this.content = JSON.stringify(this.activeState); …POST…
+//   workflowStore.saveAs(wf, path):  builds the copy UNLOADED (changeTracker = null)
+//   workflowStore.openWorkflow(w):   if (isActive(w)) return w   ← returns without loading
+//
+// So the bytes a Save-As writes are the COPY's activeState at write time, and a copy
+// whose tracker was never built serializes to the JSON literal `null`. `main` guarded
+// this with a CAPABILITY check only ("openWorkflow exists, therefore the copy is
+// loaded") — a dispatch receipt, not an effect. And every downstream guard confirms the
+// bad write: the post-write read-back compares the target against the copy's OWN
+// content, so `"null" === "null"` reads back as "ours" — a false success, not a catch.
+//
+// THE TWO EMPTY CASES MUST STAY DISTINGUISHABLE. A user can legitimately Save-As an
+// empty canvas, and refusing that would be data loss pointed the other way. The signal
+// is CAPTURE COMPLETION, never node count: the frontend's own blankGraph is
+// {last_node_id:0,last_link_id:0,nodes:[],links:[],groups:[],config:{},extra:{},version:0.4}
+// and LGraph.serialize() always returns an object carrying a `nodes` array. `nodes: []`
+// saves; `null` refuses. Both directions are asserted below.
+
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  saveActiveWorkflow,
+  classifyGraphCapture,
+  classifyWorkflowCapture
+} from '../../web/js/lib/workflow-save.js'
+
+// The frontend's own blankGraph (read out of the installed bundle) — what an EMPTY
+// canvas actually serializes to. This is the shape the guard must never refuse.
+const BLANK_GRAPH = {
+  last_node_id: 0,
+  last_link_id: 0,
+  nodes: [],
+  links: [],
+  groups: [],
+  config: {},
+  extra: {},
+  version: 0.4
+}
+
+const GRAPH_WITH_NODES = {
+  ...BLANK_GRAPH,
+  last_node_id: 2,
+  nodes: [{ id: 1, type: 'CheckpointLoaderSimple' }, { id: 2, type: 'SaveImage' }]
+}
+
+/** A workflow-store double that models the REAL 1.47 data flow the bug lives in:
+ *  the copy is created UNLOADED, `activeState` is derived from the change tracker,
+ *  and the persist serializes `activeState` into `content` before writing it.
+ *
+ *  Knobs (each reproduces one real failure mode, none loosen an assertion):
+ *    openLoadsCopy   — false ⇒ openWorkflow returns WITHOUT building a tracker
+ *                      (the store's `if (isActive(w)) return w` early exit).
+ *    dropTrackerAtWrite — true ⇒ the tracker vanishes inside save()'s own await
+ *                      (the microtask gap it opens before reading activeState).
+ *    sourceState     — what the SOURCE tab's graph is (an empty canvas is legal). */
+function makeStore({
+  files = [],
+  active,
+  openLoadsCopy = true,
+  dropTrackerAtWrite = false
+} = {}) {
+  const disk = new Map()
+  for (const f of files) disk.set(f, JSON.stringify({ id: 'source-uuid', ...GRAPH_WITH_NODES }))
+  const lookup = new Map()
+  if (active) lookup.set(active.path, active)
+  const calls = []
+
+  const svc = {
+    activeWorkflow: active,
+    calls,
+    disk,
+    lookup,
+    getWorkflowByPath(path) {
+      return lookup.get(path)
+    },
+    // workflowStore.saveAs: deep-copies the SOURCE's activeState into the copy's
+    // content, mints a fresh id, and inserts an UNLOADED record at the target path.
+    saveAs(wf, path) {
+      calls.push(['saveAs', wf.path, path])
+      const cloned = JSON.parse(JSON.stringify(wf.activeState))
+      cloned.id = 'copy-uuid'
+      const serialized = JSON.stringify(cloned)
+      const copy = {
+        path,
+        filename: path.split('/').pop(),
+        directory: path.split('/').slice(0, -1).join('/') || 'workflows',
+        initialMode: wf.initialMode,
+        size: -1,
+        isPersisted: false,
+        isTemporary: true,
+        changeTracker: null, // UNLOADED — exactly as the real store leaves it
+        content: serialized,
+        originalContent: serialized,
+        get activeState() {
+          return this.changeTracker ? this.changeTracker.activeState : null
+        }
+      }
+      lookup.set(path, copy)
+      return copy
+    },
+    async openWorkflow(copy) {
+      calls.push(['openWorkflow', copy.path])
+      if (openLoadsCopy) {
+        const state = JSON.parse(copy.content)
+        copy.changeTracker = {
+          activeState: state,
+          initialState: state,
+          prepareForSave() {}
+        }
+      }
+      svc.activeWorkflow = copy
+    },
+    // ComfyWorkflow.save(): content := JSON.stringify(activeState), THEN POST.
+    async saveWorkflow(wf) {
+      if (dropTrackerAtWrite) wf.changeTracker = null // save()'s pre-read await gap
+      wf.content = JSON.stringify(wf.activeState)
+      calls.push(['saveWorkflow', wf.path, wf.content])
+      disk.set(wf.path, wf.content)
+    },
+    async closeWorkflow(wf) {
+      calls.push(['closeWorkflow', wf.path])
+      lookup.delete(wf.path)
+    },
+    async renameWorkflow(wf, newPath) {
+      calls.push(['renameWorkflow', wf.path, newPath])
+      const bytes = disk.get(wf.path)
+      disk.delete(wf.path)
+      lookup.delete(wf.path)
+      wf.path = newPath
+      wf.filename = newPath.split('/').pop()
+      disk.set(newPath, bytes)
+      lookup.set(newPath, wf)
+    }
+  }
+  return svc
+}
+
+function makeSource(state) {
+  return {
+    path: 'workflows/Src1267.json',
+    filename: 'Src1267.json',
+    directory: 'workflows',
+    size: 4096,
+    isPersisted: true,
+    isTemporary: false,
+    changeTracker: { activeState: state, prepareForSave() {} },
+    get activeState() {
+      return this.changeTracker ? this.changeTracker.activeState : null
+    }
+  }
+}
+
+const onDisk = (svc) => async (path) => (svc.disk.has(path) ? true : false)
+
+// ---------------------------------------------------------------------------
+// The classifier — the ONE definition both guards ask.
+// ---------------------------------------------------------------------------
+
+test('#1267: capture completion separates "never captured" from "genuinely empty"', () => {
+  // NEVER CAPTURED — no serialization happened. No canvas can produce these.
+  assert.equal(classifyGraphCapture(null), 'uncaptured')
+  assert.equal(classifyGraphCapture('null'), 'uncaptured', 'the bytes an unloaded copy writes')
+  assert.equal(classifyGraphCapture(''), 'uncaptured')
+  assert.equal(classifyGraphCapture('   '), 'uncaptured')
+  assert.equal(classifyGraphCapture(42), 'uncaptured')
+  assert.equal(classifyGraphCapture([]), 'uncaptured')
+  assert.equal(classifyGraphCapture({}), 'uncaptured', 'an object with no nodes array')
+
+  // GENUINELY EMPTY — a COMPLETED serialization of an empty canvas. Must save.
+  assert.equal(classifyGraphCapture(BLANK_GRAPH), 'captured')
+  assert.equal(classifyGraphCapture(JSON.stringify(BLANK_GRAPH)), 'captured')
+  assert.equal(classifyGraphCapture({ nodes: [] }), 'captured')
+  assert.equal(classifyGraphCapture(GRAPH_WITH_NODES), 'captured')
+
+  // UNKNOWN — nothing was observed, so nothing may be refused. On a real
+  // ComfyWorkflow `activeState` is a class getter that yields null (never
+  // undefined) when unloaded, so undefined means "this object does not expose it".
+  assert.equal(classifyGraphCapture(undefined), 'unknown')
+  assert.equal(classifyGraphCapture('{not json'), 'unknown')
+  assert.equal(classifyWorkflowCapture(undefined), 'unknown')
+  assert.equal(classifyWorkflowCapture({}), 'unknown', 'a stub with no activeState field')
+  assert.equal(
+    classifyWorkflowCapture({
+      get activeState() {
+        throw new Error('unreadable')
+      }
+    }),
+    'unknown',
+    'a throwing getter is unknown, never a refusal'
+  )
+  assert.equal(classifyWorkflowCapture({ activeState: null }), 'uncaptured')
+  assert.equal(classifyWorkflowCapture({ activeState: BLANK_GRAPH }), 'captured')
+})
+
+// ---------------------------------------------------------------------------
+// The CALL SITE — drive the real saveActiveWorkflow, not the helper.
+// ---------------------------------------------------------------------------
+
+test('#1267: openWorkflow returning without loading the copy REFUSES — no empty file is written', async () => {
+  const active = makeSource(GRAPH_WITH_NODES)
+  const svc = makeStore({ files: [active.path], active, openLoadsCopy: false })
+
+  await assert.rejects(
+    () => saveActiveWorkflow(svc, 'Copy1267', { existsOnDisk: onDisk(svc) }),
+    /never captured|EMPTY workflow/,
+    'refused rather than acknowledging a save it had not captured'
+  )
+
+  // The whole point: NOTHING was written.
+  assert.ok(!svc.disk.has('workflows/Copy1267.json'), 'no file was created at the target')
+  assert.ok(
+    !svc.calls.some((c) => c[0] === 'saveWorkflow'),
+    'the write was never attempted — this is a PRE-COMMIT refusal'
+  )
+  // …and the source is intact, with the user returned to it.
+  assert.ok(svc.disk.has(active.path), 'the ORIGINAL file is untouched')
+  assert.equal(svc.activeWorkflow, active, 'the previously-active tab was restored')
+  assert.equal(svc.lookup.get('workflows/Copy1267.json'), undefined, 'the orphan copy was purged')
+})
+
+test('#1267 regression witness: main would have written the literal `null` and reported success', async () => {
+  // Same double, with the guard's input removed from the equation: prove the double
+  // really does reproduce the bug, so a green suite is not green by construction.
+  const active = makeSource(GRAPH_WITH_NODES)
+  const svc = makeStore({ files: [active.path], active, openLoadsCopy: false })
+  const copy = svc.saveAs(active, 'workflows/Witness1267.json')
+  await svc.openWorkflow(copy)
+  await svc.saveWorkflow(copy)
+  assert.equal(
+    svc.disk.get('workflows/Witness1267.json'),
+    'null',
+    'an unloaded copy really does serialize to the JSON literal null'
+  )
+})
+
+test('#1267 the OTHER direction: a legitimately EMPTY canvas still saves', async () => {
+  // The guard must not become the same two-states-collapse pointed backwards. An
+  // empty canvas is a COMPLETED capture (the frontend's blankGraph) and is a save
+  // the user is entitled to.
+  const active = makeSource(BLANK_GRAPH)
+  const svc = makeStore({ files: [active.path], active })
+
+  const saved = await saveActiveWorkflow(svc, 'EmptyOnPurpose', { existsOnDisk: onDisk(svc) })
+
+  assert.equal(saved, 'EmptyOnPurpose')
+  assert.ok(svc.disk.has('workflows/EmptyOnPurpose.json'), 'the empty workflow WAS saved')
+  const written = JSON.parse(svc.disk.get('workflows/EmptyOnPurpose.json'))
+  assert.deepEqual(written.nodes, [], 'and it is an honest empty graph, not a refusal')
+  assert.ok(svc.disk.has(active.path), 'the original is still on disk (#226)')
+})
+
+test('#1267: a normal Save-As is unchanged — the copy carries the source graph', async () => {
+  const active = makeSource(GRAPH_WITH_NODES)
+  const svc = makeStore({ files: [active.path], active })
+
+  const saved = await saveActiveWorkflow(svc, 'Copy1267', { existsOnDisk: onDisk(svc) })
+
+  assert.equal(saved, 'Copy1267')
+  const written = JSON.parse(svc.disk.get('workflows/Copy1267.json'))
+  assert.equal(written.nodes.length, 2, 'the real graph landed')
+  assert.ok(svc.disk.has(active.path), 'the original is still on disk (#226)')
+})
+
+test('#1267: a pre-commit refusal is NOT adopted by the post-commit reconciliation', async () => {
+  // The failure handler exists to ADOPT a write that committed before its response
+  // was lost. A refusal raised before any write must not travel that path, or the
+  // refusal turns back into a reported success. Here the read-back oracle is rigged
+  // to claim "ours" for anything — if the refusal were reconciled, this would resolve.
+  const active = makeSource(GRAPH_WITH_NODES)
+  const svc = makeStore({ files: [active.path], active, openLoadsCopy: false })
+  let reconciled = 0
+
+  await assert.rejects(
+    () =>
+      saveActiveWorkflow(svc, 'Copy1267', {
+        existsOnDisk: onDisk(svc),
+        reconcileSavedCopy: async () => {
+          reconciled += 1
+          return 'ours'
+        }
+      }),
+    /never captured|EMPTY workflow/
+  )
+  assert.equal(reconciled, 0, 'the read-back oracle was never consulted for a pre-commit refusal')
+  assert.ok(!svc.disk.has('workflows/Copy1267.json'), 'still nothing on disk')
+})
+
+test('#1267: state lost inside save()’s own await is reported, never acknowledged', async () => {
+  // The residual the pre-write guard cannot reach: ComfyUI's save() awaits a dynamic
+  // import before it reads activeState. Here the tracker dies in that gap, so the
+  // write really does land — and it lands EMPTY. The reply must say so.
+  const active = makeSource(GRAPH_WITH_NODES)
+  const svc = makeStore({ files: [active.path], active, dropTrackerAtWrite: true })
+
+  await assert.rejects(
+    () => saveActiveWorkflow(svc, 'Copy1267', { existsOnDisk: onDisk(svc) }),
+    /contain no graph|EMPTY/,
+    'reported the bytes it observed, not the call it made'
+  )
+  assert.equal(svc.disk.get('workflows/Copy1267.json'), 'null', 'the empty write did happen')
+  assert.ok(svc.disk.has(active.path), 'the original is untouched')
+  assert.equal(svc.activeWorkflow, active, 'the previous tab was restored, not left on the husk')
+})
+
+test('#1267: the copy’s own read-back cannot see an empty write (why the guard is needed)', async () => {
+  // Documents the collapse the fix removes: reconcileSavedCopy compares the target
+  // against the COPY'S OWN content. When the copy wrote "null", the disk holds "null"
+  // and the oracle says "ours" — a false success confirmed by the very check that was
+  // supposed to catch it. With the guard in place the save never reaches that point.
+  const active = makeSource(GRAPH_WITH_NODES)
+  const svc = makeStore({ files: [active.path], active, dropTrackerAtWrite: true })
+  const verdicts = []
+
+  await assert.rejects(
+    () =>
+      saveActiveWorkflow(svc, 'Copy1267', {
+        existsOnDisk: onDisk(svc),
+        reconcileSavedCopy: async (path, copy) => {
+          const v = svc.disk.get(path) === copy.content ? 'ours' : 'foreign'
+          verdicts.push(v)
+          return v
+        }
+      }),
+    /contain no graph|EMPTY/
+  )
+  assert.deepEqual(verdicts, [], 'the bytes guard fires BEFORE the oracle can bless the empty file')
+})

--- a/browser_tests/unit/workflow-save.test.mjs
+++ b/browser_tests/unit/workflow-save.test.mjs
@@ -1736,7 +1736,11 @@ function makeLowLevelStore({ active, saveWorkflowImpl } = {}) {
         get isPersisted() {
           return this.size !== -1
         },
-        content: '{"id":"OUR-ID"}',
+        // A real copy's content is a SERIALIZED GRAPH (store.saveAs deep-copies the
+        // source's activeState and stamps a fresh id), never a bare id. Modelled
+        // faithfully so the #1267 capture check sees what a real save would send;
+        // the id is what these tests' read-back identity assertions turn on.
+        content: '{"id":"OUR-ID","nodes":[],"links":[],"version":0.4}',
         changeTracker: { prepareForSave() {} }
       }
       store.set(path, copy) // raw into the lookup
@@ -1968,6 +1972,12 @@ test('#309 P2: an adopted copy is marked PERSISTED (size != -1) so a later in-pl
 // activeState the live canvas; updateModified sets isModified = !graphEqual(initial,
 // active) (JSON compare here). reset() re-baselines to activeState (the WRONG direction
 // the fix must avoid). undo() restores the previous state and recomputes.
+// A GRAPH-SHAPED state snapshot. The `v` tag is what these tests compare (S0/S1/S2);
+// the surrounding `nodes`/`links` are what a real serialized workflow always carries —
+// modelled so the #1267 capture check sees the shape a real save would send, and so a
+// snapshot in these doubles cannot be mistaken for a graph that was never captured.
+const graphState = (v) => ({ id: 'OUR-ID', nodes: [], links: [], version: 0.4, extra: { v } })
+
 function attachChangeTracker(copy, { committedContent, activeState, undoStack = [] }) {
   copy.content = committedContent
   const eq = (a, b) => JSON.stringify(a) === JSON.stringify(b)
@@ -2014,7 +2024,7 @@ test('#309 P1: adoption keeps the copy DIRTY when the canvas was edited DURING t
   svc.saveAs = (wf, path) => {
     const copy = origSaveAs(wf, path)
     // The write committed S1; the user edited the live canvas to S2 during the await.
-    attachChangeTracker(copy, { committedContent: JSON.stringify({ v: 'S1' }), activeState: { v: 'S2' } })
+    attachChangeTracker(copy, { committedContent: JSON.stringify(graphState('S1')), activeState: graphState('S2') })
     return copy
   }
   const existsOnDisk = async () => false
@@ -2052,10 +2062,10 @@ test('#309 P1: adoption sets isModified on OUR copy directly — a distinct late
   const origSaveAs = svc.saveAs
   svc.saveAs = (wf, path) => {
     const copy = origSaveAs(wf, path)
-    copy.content = JSON.stringify({ v: 'S1' }) // committed S1; A itself is clean (active S1)
+    copy.content = JSON.stringify(graphState('S1')) // committed S1; A itself is clean (active S1)
     copy.changeTracker = {
       initialState: JSON.parse(copy.content),
-      activeState: { v: 'S1' },
+      activeState: graphState('S1'),
       workflow: copy,
       // Faithful 1.47: resolve the workflow BY PATH and write isModified on it.
       updateModified() {
@@ -2094,9 +2104,9 @@ test('#309 P1: adoption with NO in-flight edit is CLEAN, and a later Undo makes 
     const copy = origSaveAs(wf, path)
     // Committed S1; live canvas still S1 (no edit during the await); undo stack has S0.
     attachChangeTracker(copy, {
-      committedContent: JSON.stringify({ v: 'S1' }),
-      activeState: { v: 'S1' },
-      undoStack: [{ v: 'S0' }],
+      committedContent: JSON.stringify(graphState('S1')),
+      activeState: graphState('S1'),
+      undoStack: [graphState('S0')],
     })
     return copy
   }
@@ -2126,13 +2136,13 @@ test('#309 P1: a SUCCESSFUL Save-As with an in-flight edit keeps the copy DIRTY 
     // The write PERSISTS S1; the user edits the live canvas to S2 during the (successful)
     // save await.
     saveWorkflowImpl: async (wf) => {
-      wf.changeTracker.activeState = { v: 'S2' }
+      wf.changeTracker.activeState = graphState('S2')
     },
   })
   const origSaveAs = svc.saveAs
   svc.saveAs = (wf, path) => {
     const copy = origSaveAs(wf, path)
-    attachChangeTracker(copy, { committedContent: JSON.stringify({ v: 'S1' }), activeState: { v: 'S1' } })
+    attachChangeTracker(copy, { committedContent: JSON.stringify(graphState('S1')), activeState: graphState('S1') })
     return copy
   }
   const existsOnDisk = async () => false
@@ -2157,7 +2167,7 @@ test('#309 P1: a SUCCESSFUL Save-As with NO in-flight edit leaves the copy CLEAN
   const origSaveAs = svc.saveAs
   svc.saveAs = (wf, path) => {
     const copy = origSaveAs(wf, path)
-    attachChangeTracker(copy, { committedContent: JSON.stringify({ v: 'S1' }), activeState: { v: 'S1' } })
+    attachChangeTracker(copy, { committedContent: JSON.stringify(graphState('S1')), activeState: graphState('S1') })
     return copy
   }
   const existsOnDisk = async () => false

--- a/web/js/lib/workflow-save.js
+++ b/web/js/lib/workflow-save.js
@@ -1320,14 +1320,27 @@ function resolveSaveAsCopy(svc, { reconcileSavedCopy, producedRecord, canvasBind
         // Until now the ONLY thing standing between this route and a saved-but-empty
         // file was a CAPABILITY check: `openWorkflow` must exist, therefore the copy
         // must be loaded. That is a dispatch receipt, not an effect — `openWorkflow`
-        // returning proves it was called, never that a change tracker was built. The
-        // store's own `openWorkflow` returns EARLY (`if (isActive(w)) return w`) without
-        // loading, and the service's returns early on the same condition; a load that
-        // resolves without populating the tracker leaves `activeState === null`, which
-        // `ComfyWorkflow.save()` serializes to the JSON literal `null` — an empty file,
-        // POSTed and reported as a successful Save-As. Every downstream guard then
-        // CONFIRMS it: the post-write read-back compares the target against the copy's
-        // own content, so `"null"` matches `"null"` and reads back as "ours".
+        // returning proves it was CALLED, never that a change tracker was BUILT.
+        //
+        // What was MEASURED on the installed frontend bundle (not inferred):
+        //   · `workflowStore.saveAs(wf, path)` returns the copy UNLOADED — the class
+        //     field `changeTracker = null` is never set by it;
+        //   · `get activeState() { return this.changeTracker?.activeState ?? null }`;
+        //   · `ComfyWorkflow.save()` begins `this.content = JSON.stringify(this.activeState)`
+        //     and POSTs that — so an unloaded copy writes the JSON literal `null`;
+        //   · BOTH `openWorkflow` variants can return WITHOUT loading — each begins with an
+        //     `isActive` early exit, and neither returns anything the caller could use to
+        //     tell "loaded it" from "decided not to".
+        //
+        // Which of those drops the capture in any given session is NOT something this
+        // guard needs to know, and guessing is how a fix ends up aimed at the wrong
+        // line: it asks the copy what it is ABOUT TO WRITE. That question has one
+        // answer whatever the upstream cause.
+        //
+        // It has to be asked HERE because nothing downstream can: the post-write
+        // read-back compares the target against the copy's OWN content, so a copy that
+        // wrote `"null"` finds `"null"` on disk and reads back as "ours" — the check
+        // meant to catch a bad write CONFIRMS this one.
         //
         // So ask the copy what it is actually going to write, SYNCHRONOUSLY, with no
         // await between the question and the write. `classifyWorkflowCapture` allows a
@@ -1368,7 +1381,11 @@ function resolveSaveAsCopy(svc, { reconcileSavedCopy, producedRecord, canvasBind
         // must not go down the ambiguity path: that path exists to ADOPT a write that
         // committed before its response was lost, and adopting here would convert a
         // refusal into a reported success on a target we never wrote.
-        if (!isConflictError(err) && !isPreCommitRefusal(err) && typeof reconcileSavedCopy === "function") {
+        if (
+          !isConflictError(err) &&
+          !isPreCommitRefusal(err) &&
+          typeof reconcileSavedCopy === "function"
+        ) {
           let state = "unknown";
           try {
             state = await reconcileSavedCopy(finalTargetPath, copy);
@@ -1406,16 +1423,6 @@ function resolveSaveAsCopy(svc, { reconcileSavedCopy, producedRecord, canvasBind
         if (prevActive !== undefined) svc.activeWorkflow = prevActive;
         throw err;
       }
-      // SUCCESS-PATH BOOKKEEPING (#309 P1, mirror of the adoption branch). ComfyUI's own
-      // saveWorkflow(copy) captures copy.content, awaits the write, THEN calls
-      // changeTracker.reset() (re-baselining to the LIVE canvas) and forces
-      // isModified=false. If the user edited the graph DURING the successful save await,
-      // the live canvas advanced past what committed (disk holds S1, canvas is S2), so
-      // upstream marks the copy "clean" at S2 while S2 is UNSAVED — workflow_close then
-      // silently unloads it (data loss). Re-run our committed-vs-live bookkeeping to
-      // OVERRIDE that: baseline to the COMMITTED snapshot (copy.content) and set
-      // isModified DIRECTLY on OUR copy (never path-resolving). Identical to upstream
-      // when no edit occurred; strictly more correct when an in-flight edit happened.
       // #1267 — POST-WRITE: report the BYTES, not the call. `ComfyWorkflow.save()`'s
       // first statement is `this.content = JSON.stringify(this.activeState)`, so after a
       // reported-success persist `copy.content` IS the payload that went to /userdata —
@@ -1443,6 +1450,16 @@ function resolveSaveAsCopy(svc, { reconcileSavedCopy, producedRecord, canvasBind
             `previous tab has been restored. Delete "${finalTargetPath}" and retry (#1267).`,
         );
       }
+      // SUCCESS-PATH BOOKKEEPING (#309 P1, mirror of the adoption branch). ComfyUI's own
+      // saveWorkflow(copy) captures copy.content, awaits the write, THEN calls
+      // changeTracker.reset() (re-baselining to the LIVE canvas) and forces
+      // isModified=false. If the user edited the graph DURING the successful save await,
+      // the live canvas advanced past what committed (disk holds S1, canvas is S2), so
+      // upstream marks the copy "clean" at S2 while S2 is UNSAVED — workflow_close then
+      // silently unloads it (data loss). Re-run our committed-vs-live bookkeeping to
+      // OVERRIDE that: baseline to the COMMITTED snapshot (copy.content) and set
+      // isModified DIRECTLY on OUR copy (never path-resolving). Identical to upstream
+      // when no edit occurred; strictly more correct when an in-flight edit happened.
       markCopyPersisted(copy);
       // P0 — POST-WRITE CLOBBER DETECTION. The server's overwrite:false is NOT
       // exclusive-create (os.path.exists → await body-read → os.replace), so a target

--- a/web/js/lib/workflow-save.js
+++ b/web/js/lib/workflow-save.js
@@ -162,6 +162,102 @@ export function diskExistenceFromStatus(status) {
   return null;
 }
 
+/** #1267 — TRI-STATE: did the graph CAPTURE actually land, for the value a Save-As
+ *  copy is about to write (or has just written)?
+ *
+ *  THE DEFECT THIS SEPARATES. A Save-As copy is persisted by ComfyUI's
+ *  `ComfyWorkflow.save()`, whose FIRST statement is
+ *  `this.content = JSON.stringify(this.activeState)` — so the bytes that land are
+ *  the copy's `activeState` at write time, and NOTHING else. `activeState` is the
+ *  derived getter `this.changeTracker?.activeState ?? null` (measured on the
+ *  installed 1.47 bundle), so a copy whose tracker was never built serializes to
+ *  the JSON literal `null`: a file that is not a workflow, written and reported
+ *  as a successful save. The panel's post-write read-back cannot see it — it
+ *  compares the target against the copy's OWN content, and `"null" === "null"`
+ *  reads back as "ours", i.e. as a confirmed success.
+ *
+ *  THE TWO EMPTY CASES, AND WHY THEY ARE DISTINGUISHABLE. A user may legitimately
+ *  Save-As an EMPTY canvas, and refusing that would be its own data loss. So the
+ *  signal here is CAPTURE COMPLETION, never node count:
+ *    · genuinely empty  ⇒ a COMPLETED serialization. `LGraph.serialize()` always
+ *      returns an OBJECT carrying a `nodes` array, and the frontend's own
+ *      `blankGraph` is `{last_node_id:0,last_link_id:0,nodes:[],links:[],groups:[],
+ *      config:{},extra:{},version:0.4}` (both read out of the installed bundle).
+ *      `nodes: []` is therefore "captured" and MUST save.
+ *    · never captured   ⇒ NO serialization happened: `null` (an absent tracker), or
+ *      a value that is not a serialized graph at all. No canvas — empty or not —
+ *      can produce that.
+ *
+ *  UNKNOWN NEVER REFUSES, and it is a genuinely distinct third state rather than a
+ *  hedge: on a real ComfyWorkflow `activeState` is a CLASS GETTER that yields
+ *  `null` when unloaded, never `undefined`. So `undefined` means the object does
+ *  not expose the field at all (a frontend that does not model it, a stub), which
+ *  is exactly the case in which we have observed nothing and must not veto. Same
+ *  for content that will not parse.
+ *
+ *  Accepts either the state OBJECT (pre-write: what `save()` will serialize) or the
+ *  serialized STRING (post-write: `copy.content`, the exact bytes `save()` POSTed),
+ *  so both guards ask ONE question with one definition. */
+export function classifyGraphCapture(state) {
+  if (state === undefined) return "unknown"; // field not exposed ⇒ nothing observed
+  if (state === null) return "uncaptured"; // absent tracker ⇒ serializes to `null`
+  if (typeof state === "string") {
+    if (state.trim() === "") return "uncaptured"; // empty bytes are not a graph
+    let parsed;
+    try {
+      parsed = JSON.parse(state);
+    } catch {
+      return "unknown"; // unreadable ⇒ we cannot judge it ⇒ never refuse on it
+    }
+    return classifyGraphCapture(parsed === undefined ? null : parsed);
+  }
+  if (typeof state !== "object" || Array.isArray(state)) return "uncaptured";
+  // The one structural test: a serialized graph carries a `nodes` ARRAY. Empty is fine.
+  if (!Array.isArray(state.nodes)) return "uncaptured";
+  return "captured";
+}
+
+/** Read a workflow's `activeState` without letting a hostile/absent getter decide the
+ *  outcome: an unreadable state is "unknown" (never a refusal), same as an absent one. */
+export function classifyWorkflowCapture(wf) {
+  let state;
+  try {
+    state = wf?.activeState;
+  } catch {
+    return "unknown";
+  }
+  return classifyGraphCapture(state);
+}
+
+/** Errors raised by a guard that runs BEFORE any write are marked, so the copy
+ *  adapter's failure handler does not run its AMBIGUOUS-post-commit reconciliation
+ *  (read the target back, and ADOPT it when it holds our content). That
+ *  reconciliation exists for a persist that may have committed before its response
+ *  was lost; a pre-commit refusal provably wrote nothing, and sending it down that
+ *  path could turn a refusal into a reported success. */
+function markPreCommit(err) {
+  try {
+    Object.defineProperty(err, "cmcpPreCommit", {
+      value: true,
+      enumerable: false,
+      configurable: true,
+      writable: true,
+    });
+  } catch {
+    /* frozen error ⇒ unmarked; the handler just takes the normal (removal) path */
+  }
+  return err;
+}
+
+/** True for a refusal raised before any write was attempted. */
+function isPreCommitRefusal(err) {
+  try {
+    return err?.cmcpPreCommit === true;
+  } catch {
+    return false;
+  }
+}
+
 /** Record the authoritative outcome into an optional `details` sink (a plain object
  *  the caller passes to saveActiveWorkflow). No-op when absent, so behaviour and the
  *  return value are unchanged for every existing caller/test. */
@@ -1218,6 +1314,48 @@ function resolveSaveAsCopy(svc, { reconcileSavedCopy, producedRecord, canvasBind
         // copy persists the state `saveAs` took from the source tab; asking the copy's
         // tracker to "prepare" re-reads the shared global canvas, which is precisely the
         // read that put a foreign workflow's graph into a brand-new tab's file.
+        //
+        // #1267 — OBSERVE THE CAPTURE, DO NOT INFER IT FROM THE CALL ABOVE.
+        //
+        // Until now the ONLY thing standing between this route and a saved-but-empty
+        // file was a CAPABILITY check: `openWorkflow` must exist, therefore the copy
+        // must be loaded. That is a dispatch receipt, not an effect — `openWorkflow`
+        // returning proves it was called, never that a change tracker was built. The
+        // store's own `openWorkflow` returns EARLY (`if (isActive(w)) return w`) without
+        // loading, and the service's returns early on the same condition; a load that
+        // resolves without populating the tracker leaves `activeState === null`, which
+        // `ComfyWorkflow.save()` serializes to the JSON literal `null` — an empty file,
+        // POSTed and reported as a successful Save-As. Every downstream guard then
+        // CONFIRMS it: the post-write read-back compares the target against the copy's
+        // own content, so `"null"` matches `"null"` and reads back as "ours".
+        //
+        // So ask the copy what it is actually going to write, SYNCHRONOUSLY, with no
+        // await between the question and the write. `classifyWorkflowCapture` allows a
+        // legitimately EMPTY canvas (a completed serialization with `nodes: []`) and
+        // refuses only a state that never got serialized at all; a frontend that does
+        // not expose `activeState` is "unknown" and is not refused.
+        //
+        // REFUSING HERE COSTS NOTHING AND DESTROYS NOTHING: it runs BEFORE any write,
+        // so no file is created, the source tab and its file are untouched, and the
+        // catch below removes the in-memory copy and restores the previously-active
+        // tab — the user is returned to their real graph and can retry.
+        //
+        // RESIDUAL, stated honestly: ComfyUI's `save()` awaits a dynamic import before
+        // it reads `activeState`, so a tracker torn down inside that microtask gap is
+        // not caught here. That is the same residual this module already documents for
+        // the #708/#878 canvas re-asserts, and the post-write check below — which reads
+        // the BYTES the write used — is what covers it.
+        if (classifyWorkflowCapture(copy) === "uncaptured") {
+          throw markPreCommit(
+            new Error(
+              `refusing to save "${effectiveName}": the copy's graph was never captured, so the ` +
+                `only thing this save could write to "${finalTargetPath}" is an EMPTY workflow. ` +
+                `(An empty CANVAS still captures — this is a copy that holds no serialized graph ` +
+                `at all.) NOTHING was written and the original is untouched; the previous tab has ` +
+                `been restored. Retry the save (#1267).`,
+            ),
+          );
+        }
         await svc.saveWorkflow(copy);
       } catch (err) {
         // P2 — distinguish a CONFIRMED pre-commit failure (409 conflict, or the
@@ -1226,7 +1364,11 @@ function resolveSaveAsCopy(svc, { reconcileSavedCopy, producedRecord, canvasBind
         // response was lost/failed to parse). Blindly removing the copy on ambiguity
         // ORPHANS the on-disk file (a later retry then 409s). So on a NON-conflict
         // failure, RECONCILE by reading the target back:
-        if (!isConflictError(err) && typeof reconcileSavedCopy === "function") {
+        // #1267 — a PRE-COMMIT refusal (raised before `saveWorkflow` was ever called)
+        // must not go down the ambiguity path: that path exists to ADOPT a write that
+        // committed before its response was lost, and adopting here would convert a
+        // refusal into a reported success on a target we never wrote.
+        if (!isConflictError(err) && !isPreCommitRefusal(err) && typeof reconcileSavedCopy === "function") {
           let state = "unknown";
           try {
             state = await reconcileSavedCopy(finalTargetPath, copy);
@@ -1274,6 +1416,33 @@ function resolveSaveAsCopy(svc, { reconcileSavedCopy, producedRecord, canvasBind
       // OVERRIDE that: baseline to the COMMITTED snapshot (copy.content) and set
       // isModified DIRECTLY on OUR copy (never path-resolving). Identical to upstream
       // when no edit occurred; strictly more correct when an in-flight edit happened.
+      // #1267 — POST-WRITE: report the BYTES, not the call. `ComfyWorkflow.save()`'s
+      // first statement is `this.content = JSON.stringify(this.activeState)`, so after a
+      // reported-success persist `copy.content` IS the payload that went to /userdata —
+      // the effect we observed, not the request we made. Classifying it closes the one
+      // residual the pre-write guard cannot: a tracker torn down inside the microtask gap
+      // `save()` opens (it awaits a dynamic import before reading `activeState`).
+      //
+      // This is deliberately NOT a node-count veto. It fires only on bytes that are not a
+      // serialized graph at all (`null`, empty); `{…,"nodes":[],…}` — the frontend's own
+      // blankGraph — classifies as CAPTURED and reports success like any other save.
+      //
+      // The write already happened, so this cannot un-write it and must not pretend to:
+      // it surfaces the truth instead of a false acknowledgement, and hands the user back
+      // their previous tab (their real graph) rather than leaving them bound to a target
+      // we just proved holds no graph. The file is left in place — deleting on this path
+      // is its own hazard, and the source was never touched.
+      const writtenCapture = classifyGraphCapture(copy?.content);
+      if (writtenCapture === "uncaptured") {
+        removeInMemoryWorkflow(svc, copy);
+        if (prevActive !== undefined) svc.activeWorkflow = prevActive;
+        throw new Error(
+          `save-as wrote "${finalTargetPath}" but the bytes it sent contain no graph — the copy's ` +
+            `state was lost between opening it and the write, so the file is EMPTY. Reporting the ` +
+            `failure rather than a phantom success: the original workflow was NOT modified and the ` +
+            `previous tab has been restored. Delete "${finalTargetPath}" and retry (#1267).`,
+        );
+      }
       markCopyPersisted(copy);
       // P0 — POST-WRITE CLOBBER DETECTION. The server's overwrite:false is NOT
       // exclusive-create (os.path.exists → await body-read → os.replace), so a target


### PR DESCRIPTION
Addresses **half (b) only** of panel#1267 — the save-as half. Half (a) (the stale
workflow-instance fence after a render reconnect) is **not touched**: it overlaps
reconnect work owned elsewhere (#654's re-advertise fix landed today, #1014 was parked
as a design record), and nothing here reads or moves the fence.

## The defect: an acknowledgement issued before the effect it claims

The reporter got the new workflow's name back, the canvas reverted, and the copy was
empty. Reproduced live, below.

The Save-As copy route is the low-level trio `saveAs → openWorkflow → saveWorkflow`.
What the bytes on disk actually are, measured against the installed frontend bundle
(`comfyui_frontend_package`, not inferred):

- `workflowStore.saveAs(wf, path)` returns the copy **unloaded** — it never sets
  `changeTracker`.
- `ComfyWorkflow`: `get activeState() { return this.changeTracker?.activeState ?? null }`.
- `ComfyWorkflow.save()` begins `this.content = JSON.stringify(this.activeState)` and
  POSTs that. So a copy whose tracker was never built writes the **JSON literal `null`**.
- Both `openWorkflow` variants can return **without loading** (each opens with an
  `isActive` early exit), and neither returns anything that distinguishes "loaded it"
  from "decided not to".

`main`'s only protection was a **capability** check — `openWorkflow` must exist,
therefore the copy must be loaded. That is a dispatch receipt, not an observation.

Worse, every downstream guard **confirms** the bad write. The post-write read-back
(`reconcileSavedCopy`) compares the target against the copy's **own** content, so a copy
that wrote `"null"` finds `"null"` on disk and reads back as `"ours"` — the check meant to
catch a bad write blesses this one. "We wrote the user's graph" and "we wrote the literal
`null`" were the same observation.

## The fix: ask what is about to be written, then report what was written

One classifier, `classifyGraphCapture`, asked at two points in the copy adapter
(`web/js/lib/workflow-save.js`):

1. **Pre-write**, synchronously between `openWorkflow(copy)` and `saveWorkflow(copy)`,
   with no `await` in between: classify `copy.activeState` — what `save()` is about to
   serialize. `uncaptured` ⇒ refuse. Nothing is written, the source file and tab are
   untouched, the in-memory copy is removed and the previous tab restored.
2. **Post-write**, after a reported-success persist: classify `copy.content` — the exact
   bytes `save()` POSTed, i.e. the effect observed rather than the request made. This
   closes the one residual the pre-write check cannot reach (`save()` awaits a dynamic
   import before reading `activeState`). It surfaces the truth instead of a phantom
   success; it does not delete the file, and the source was never touched.

A pre-commit refusal is marked so the failure handler skips its ambiguous-post-commit
reconciliation — that path exists to **adopt** a write that committed before its response
was lost, and adopting a refusal would turn it straight back into a reported success.

## How "captured too early" is separated from "genuinely empty"

The signal is **capture completion**, never node count — a user is entitled to Save-As an
empty canvas, and refusing that is data loss pointed the other way.

- **Genuinely empty** ⇒ a *completed* serialization. `LGraph.serialize()` always returns an
  object carrying a `nodes` array, and the frontend's own `blankGraph` is
  `{last_node_id:0,last_link_id:0,nodes:[],links:[],groups:[],config:{},extra:{},version:0.4}`
  (both read out of the shipped bundle). `nodes: []` classifies as **captured** and saves.
- **Never captured** ⇒ no serialization happened at all: `null`/absent tracker, or a value
  that is not a serialized graph. No canvas — empty or not — can produce that.
- **Unknown never refuses**, and it is a real third state, not a hedge: on a real
  `ComfyWorkflow`, `activeState` is a class getter that yields `null` when unloaded, never
  `undefined`. `undefined` therefore means the object does not expose the field (an older
  frontend, a stub), which is precisely when nothing has been observed. Unparseable bytes
  are `unknown` too.

## Live verification on a real rig

An isolated ComfyUI (0.33.1, frontend 1.48.7) on its own port and `--base-directory`, with
an **empty** workflow library — every workflow below is a throwaway this run created. The
real `workflowStore` trio, with the panel's real `saveActiveWorkflow` imported into the page
from the URL ComfyUI serves it at. The owner's `:8188` was not touched.

| scenario | `origin/main` | this branch |
| --- | --- | --- |
| A — healthy Save-As of a 1-node graph | saved; disk has 1 node | saved; disk has 1 node (unchanged) |
| B — copy left uncaptured (`openWorkflow` moves the pointer, builds no tracker) | **reported success**, disk = `null`, `NOT-A-GRAPH` | **refused**; target `404` (nothing written); source still on disk; active tab back on the source |
| C — genuinely EMPTY canvas | saved; `nodes: []` | saved; `nodes: []` (unchanged) |

B on `main` is the reported bug, byte for byte: the tool returns the new name, and the file
is the literal `null`.

## Refutation

Four mutations, each reverted after:

| mutation | result |
| --- | --- |
| delete the pre-write capture guard | **2 fail** (the refusal test; the pre-commit/reconcile test) |
| delete the post-write bytes check | **2 fail** (the in-`save()` loss test; the read-back-blesses-it test) |
| drop `!isPreCommitRefusal(err)` from the reconcile branch | **1 fail** (refusal gets adopted as success) |
| swap capture-completion for a **node-count** veto | **9 fail** — including "a legitimately EMPTY canvas still saves" and 7 pre-existing #226/#309 save tests |

The last one is the both-directions proof: the obvious wrong fix (refuse an empty graph)
is caught by the suite, not by review.

Both failing tests under mutation 1 drive the real `saveActiveWorkflow`, so the **call
site** is pinned, not just the helper — deleting the whole wiring hunk goes red.

## Tests

`browser_tests/unit/save-as-capture-observed.test.mjs` (new, 8 tests): the classifier
table in all three states; the call-site refusal with "nothing written / source intact /
previous tab restored"; a **regression witness** that drives the double bare and asserts it
really does produce `"null"` (so a green suite is not green by construction); the empty-canvas
direction; the pre-commit/reconcile separation; the in-`save()` loss; and the read-back
collapse this fix removes.

Two shared doubles in `workflow-save.test.mjs` were made faithful rather than loosened: a
copy's `content` is now a serialized graph (`{"id":…,"nodes":[],"links":[]}`) instead of a
bare `{"id":…}`, and the S0/S1/S2 tracker snapshots are graph-shaped. That is what the real
`store.saveAs` produces; no assertion was weakened.

## Gates

- `npm run test:unit` — **5090 pass / 1 fail**, the fail being the known #671 wall-clock
  flake under load; **125/125 green** when `manager-install.test.mjs` is re-run alone.
- `npm run typecheck` — clean. `node --check` on the changed file — clean.
- Playwright `--workers=1`, fix branch vs an `origin/main` baseline worktree, each against
  its own isolated ComfyUI: **53 passed / 22 failed on BOTH, and the 22 failure names are
  byte-identical — delta zero.** (Those 22 are environmental in this sandbox: chat-history
  / IndexedDB / streaming specs that need an orchestrator. They fail the same way on
  `origin/main`.) `save-persists-node-set-values` and `dirty-guards-see-node-writes` pass
  on both.
- **codex was unavailable (account exhausted until 2026-08-19), and `claude-gate.mjs` is
  blocked on the weekly limit — so this PR carries NO independent gate.** Per instruction I
  did not run a gate script and did not substitute a self-review for one. The orchestrator
  gates and merges.

## What I deliberately did not do

- Did not touch half (a) — no reconnect, routing, or workflow-instance-fence code is in
  this diff.
- Did not add a node-count or "looks empty" veto anywhere; the only refusals are on values
  that are not a serialized graph at all.
- Did not extend the guard to the **in-place** save route. It writes `wf.activeState` for the
  ACTIVE tab, which is loaded by construction, and widening a refusal onto the route that
  overwrites a user's existing file is not something this evidence supports.
- Did not delete the empty file the post-write check detects — deleting on that path is its
  own hazard; the error names the file so the user can.

Reference: this addresses **the underlying cause of #1267 (half b)**. Closing is the
orchestrator's call.
