### PR TITLE
fix(1271): promote preview widgets through previewExposure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+### Fixed
+- a subgraph preview widget is promoted through the frontend's previewExposure store, and a failed link-only promote no longer hides behind a missing promotion store (#1271)
+
 ## [0.15.3] - 2026-08-19
 
 ### Fixed

--- a/browser_tests/unit/promote-widget-preview-store.test.mjs
+++ b/browser_tests/unit/promote-widget-preview-store.test.mjs
@@ -1,0 +1,335 @@
+// #1271 — panel_promote_widget on frontend 1.48.7: the 'promotion' Pinia store
+// is gone, preview widgets ($$canvas-image-preview) live in `previewExposure`,
+// and a failed link-only promote must not hide behind "no 'promotion' store".
+//
+// graph_promote_widget lives inline in GRAPH_TOOL_EXECUTORS (browser/ComfyUI
+// globals), so this extracts the REAL helper block + the shipped method and
+// evaluates them via `new Function`. The tests drive that function, not a copy.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+const panelPath = fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url));
+const panelSrc = readFileSync(panelPath, "utf8");
+
+function panelFunctionStart(src, name, from = 0) {
+  const bare = src.indexOf(`function ${name}(`, from);
+  assert.notEqual(bare, -1, `could not locate ${name} in panel source`);
+  return bare;
+}
+
+const helpersSrc = panelSrc.slice(
+  panelFunctionStart(panelSrc, "getPiniaStore"),
+  panelFunctionStart(panelSrc, "describeActiveGraph"),
+);
+const methodMatch = panelSrc.match(/graph_promote_widget\(\{ node_id, widget, demote \}\) \{[\s\S]*?\n  \},/);
+assert.ok(methodMatch, "could not locate graph_promote_widget in panel source");
+
+function realPromoteWidget(document, getGraphCtx, resolveNode, pressableWidgetHint = () => "") {
+  return new Function(
+    "document",
+    "getGraphCtx",
+    "resolveNode",
+    "pressableWidgetHint",
+    `${helpersSrc}
+     const executors = { ${methodMatch[0]} };
+     return executors.graph_promote_widget;`,
+  )(document, getGraphCtx, resolveNode, pressableWidgetHint);
+}
+
+/** Pinia as getPiniaStore finds it: #vue-app → __vue_app__ → $pinia._s.get(id). */
+function mockDocument(stores) {
+  const map = new Map(Object.entries(stores));
+  return {
+    getElementById(id) {
+      if (id !== "vue-app") return null;
+      return {
+        __vue_app__: {
+          config: { globalProperties: { $pinia: { _s: { get: (k) => map.get(k) ?? null } } } },
+        },
+      };
+    },
+    querySelector() {
+      return null;
+    },
+  };
+}
+
+/** Minimal previewExposure store — same (rootGraphId, hostLocator) key and
+ *  addExposure/getExposures/removeExposure shape as ComfyUI_frontend 1.48. */
+function makePreviewStore() {
+  const byHost = new Map();
+  const calls = { add: [], remove: [] };
+  const keyOf = (rootGraphId, hostId) => `${rootGraphId}|${hostId}`;
+  return {
+    calls,
+    getExposures(rootGraphId, hostId) {
+      return byHost.get(keyOf(rootGraphId, hostId)) ?? [];
+    },
+    addExposure(rootGraphId, hostId, source) {
+      calls.add.push({ rootGraphId, hostId, source });
+      const key = keyOf(rootGraphId, hostId);
+      const entry = {
+        name: source.sourcePreviewName,
+        sourceNodeId: String(source.sourceNodeId),
+        sourcePreviewName: source.sourcePreviewName,
+      };
+      byHost.set(key, [...(byHost.get(key) ?? []), entry]);
+      return entry;
+    },
+    removeExposure(rootGraphId, hostId, name) {
+      calls.remove.push({ rootGraphId, hostId, name });
+      const key = keyOf(rootGraphId, hostId);
+      byHost.set(
+        key,
+        (byHost.get(key) ?? []).filter((e) => e.name !== name),
+      );
+    },
+  };
+}
+
+function makeLegacyPromotionStore() {
+  const calls = [];
+  return {
+    calls,
+    promote(...args) {
+      calls.push(["promote", ...args]);
+    },
+    demote(...args) {
+      calls.push(["demote", ...args]);
+    },
+  };
+}
+
+function makeHarness({
+  stores = {},
+  innerWidgets = [{ name: "steps", type: "number" }],
+  slotFor = (widget) =>
+    String(widget?.name ?? "").startsWith("$$")
+      ? null
+      : { name: widget.name, type: widget.type ?? "*", label: widget.label, widget: { name: widget.name } },
+  linkConnects = true,
+  atRoot = false,
+} = {}) {
+  const parentInputs = [];
+  const subgraph = {
+    inputs: [],
+    addInput(name, type) {
+      const input = {
+        name,
+        type,
+        label: undefined,
+        connect(_slot, _node) {
+          return linkConnects ? { id: 1 } : null;
+        },
+      };
+      this.inputs.push(input);
+      parentInputs.push({ name, type, _subgraphSlot: input });
+      return input;
+    },
+    removeInput(input) {
+      this.inputs = this.inputs.filter((entry) => entry !== input);
+      const idx = parentInputs.findIndex((entry) => entry._subgraphSlot === input);
+      if (idx >= 0) parentInputs.splice(idx, 1);
+    },
+  };
+  const parent = {
+    id: 10,
+    subgraph,
+    inputs: parentInputs,
+    rootGraph: { id: "root-uuid" },
+    computeSize() {},
+    setDirtyCanvas() {},
+    invalidatePromotedViews() {},
+  };
+  const inner = {
+    id: 3,
+    type: "KSampler",
+    widgets: innerWidgets,
+    getSlotFromWidget(widget) {
+      return slotFor(widget);
+    },
+  };
+  const events = [];
+  const subgraphGraph = {
+    beforeChange() {
+      events.push("before");
+    },
+    afterChange() {
+      events.push("after");
+    },
+  };
+  const rootGraph = { id: "root-uuid", _nodes: [parent] };
+  const canvas = { setDirty() {} };
+  const getGraphCtx = () =>
+    atRoot
+      ? { graph: rootGraph, canvas, rootGraph }
+      : { graph: subgraphGraph, canvas, rootGraph };
+  // The parent lookup is `n.subgraph === graph`. Inside a subgraph the active
+  // graph IS the Subgraph object, not a wrapper — so parent.subgraph must be
+  // the same reference getGraphCtx returns as `graph`.
+  if (!atRoot) parent.subgraph = subgraphGraph;
+  Object.assign(subgraphGraph, {
+    addInput: subgraph.addInput.bind(subgraph),
+    removeInput: subgraph.removeInput.bind(subgraph),
+    inputs: subgraph.inputs,
+  });
+  // promoteWidgetByLink reads subgraphNode.subgraph.addInput — keep that
+  // pointing at the same Subgraph methods after we retarget parent.subgraph.
+  parent.subgraph.addInput = subgraph.addInput.bind(subgraph);
+  parent.subgraph.removeInput = subgraph.removeInput.bind(subgraph);
+  if (!parent.subgraph.inputs) parent.subgraph.inputs = subgraph.inputs;
+
+  const fn = realPromoteWidget(
+    mockDocument(stores),
+    getGraphCtx,
+    (_g, id) => {
+      if (Number(id) === Number(inner.id)) return inner;
+      throw new Error(`No node with id ${id} in the current graph`);
+    },
+  );
+  return { fn, events, parent, inner, subgraph, stores };
+}
+
+const PREVIEW = "$$canvas-image-preview";
+
+test("#1271 a $$ preview widget is promoted through previewExposure, not the gone promotion store", () => {
+  const preview = makePreviewStore();
+  const { fn, events } = makeHarness({
+    stores: { previewExposure: preview },
+    innerWidgets: [{ name: PREVIEW, type: "IMAGE_PREVIEW", serialize: false }],
+  });
+
+  const result = fn({ node_id: 3, widget: PREVIEW });
+
+  assert.equal(result.strategy, "preview-exposure");
+  assert.equal(result.promoted, PREVIEW);
+  assert.deepEqual(result.on_subgraph_nodes, [10]);
+  assert.equal(preview.calls.add.length, 1, "addExposure must run");
+  assert.deepEqual(preview.calls.add[0], {
+    rootGraphId: "root-uuid",
+    hostId: "10",
+    source: { sourceNodeId: "3", sourcePreviewName: PREVIEW },
+  });
+  assert.equal(preview.calls.remove.length, 0);
+  assert.deepEqual(events, ["before", "after"], "must open and close the undo envelope");
+});
+
+test("#1271 demote of a preview exposure calls removeExposure by the store's name", () => {
+  const preview = makePreviewStore();
+  preview.addExposure("root-uuid", "10", { sourceNodeId: "3", sourcePreviewName: PREVIEW });
+  preview.calls.add.length = 0;
+  const { fn } = makeHarness({
+    stores: { previewExposure: preview },
+    innerWidgets: [{ name: PREVIEW, type: "IMAGE_PREVIEW", serialize: false }],
+  });
+
+  const result = fn({ node_id: 3, widget: PREVIEW, demote: true });
+
+  assert.equal(result.strategy, "preview-exposure");
+  assert.equal(result.demoted, PREVIEW);
+  assert.equal(preview.calls.add.length, 0);
+  assert.deepEqual(preview.calls.remove, [{ rootGraphId: "root-uuid", hostId: "10", name: PREVIEW }]);
+});
+
+test("#1271 a second promote of the same preview is idempotent", () => {
+  const preview = makePreviewStore();
+  const { fn } = makeHarness({
+    stores: { previewExposure: preview },
+    innerWidgets: [{ name: PREVIEW, type: "IMAGE_PREVIEW", serialize: false }],
+  });
+
+  fn({ node_id: 3, widget: PREVIEW });
+  const again = fn({ node_id: 3, widget: PREVIEW });
+
+  assert.equal(again.strategy, "preview-exposure");
+  assert.equal(preview.calls.add.length, 1, "must not add a duplicate exposure");
+});
+
+test("#1271 a value widget with a slot still promotes link-only (no store required)", () => {
+  const { fn, parent } = makeHarness({
+    innerWidgets: [{ name: "steps", type: "number" }],
+  });
+
+  const result = fn({ node_id: 3, widget: "steps" });
+
+  assert.equal(result.strategy, "link-only");
+  assert.equal(result.promoted, "steps");
+  assert.equal(parent.inputs.length, 1, "a subgraph input must have been added");
+  assert.equal(parent.inputs[0]._subgraphSlot?.name, "steps");
+});
+
+test("#1271 a failed link-only promote no longer hides behind 'no promotion store'", () => {
+  // The reported bug: a widget with no connectable slot fails the primary path,
+  // then the 1.48 frontend has no 'promotion' store, and the user only saw that
+  // second error. Both must be in the thrown message.
+  const { fn } = makeHarness({
+    innerWidgets: [{ name: "cfg", type: "number" }],
+    slotFor: () => null,
+  });
+
+  assert.throws(
+    () => fn({ node_id: 3, widget: "cfg" }),
+    (err) => {
+      assert.match(err.message, /not backed by a connectable input slot/);
+      assert.match(err.message, /no 'promotion' store/);
+      return true;
+    },
+  );
+});
+
+test("#1271 a preview widget without previewExposure still reports the real link-path error", () => {
+  // 1.48.7 always has previewExposure. This is the "store gone AND preview
+  // detector missed" path: do not regress to masking the slot error.
+  const { fn } = makeHarness({
+    innerWidgets: [{ name: PREVIEW, type: "IMAGE_PREVIEW", serialize: false }],
+    slotFor: () => null,
+  });
+
+  assert.throws(
+    () => fn({ node_id: 3, widget: PREVIEW }),
+    (err) => {
+      assert.match(err.message, /not backed by a connectable input slot/);
+      assert.match(err.message, /no 'promotion' store/);
+      return true;
+    },
+  );
+});
+
+test("#1271 a failed link-only promote still uses the legacy store when it exists", () => {
+  const legacy = makeLegacyPromotionStore();
+  const { fn } = makeHarness({
+    stores: { promotion: legacy },
+    innerWidgets: [{ name: "cfg", type: "number" }],
+    slotFor: () => null,
+  });
+
+  const result = fn({ node_id: 3, widget: "cfg" });
+
+  assert.equal(result.strategy, "legacy-store");
+  assert.equal(legacy.calls.length, 1);
+  assert.equal(legacy.calls[0][0], "promote");
+  assert.equal(legacy.calls[0][1], "root-uuid");
+  assert.equal(legacy.calls[0][2], 10);
+  assert.deepEqual(legacy.calls[0][3], { sourceNodeId: "3", sourceWidgetName: "cfg" });
+});
+
+test("#1271 a type-preview widget (no $$ prefix) still uses previewExposure", () => {
+  const preview = makePreviewStore();
+  const { fn } = makeHarness({
+    stores: { previewExposure: preview },
+    innerWidgets: [{ name: "ui", type: "video", serialize: false }],
+  });
+
+  const result = fn({ node_id: 3, widget: "ui" });
+
+  assert.equal(result.strategy, "preview-exposure");
+  assert.equal(preview.calls.add[0].source.sourcePreviewName, "ui");
+});
+
+test("#1271 refuse at the root — promotion is an inner-widget operation", () => {
+  const { fn } = makeHarness({ atRoot: true });
+  assert.throws(() => fn({ node_id: 3, widget: "steps" }), /Enter the subgraph first/);
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -7667,13 +7667,63 @@ function getPiniaStore(id) {
 
 /** Reach ComfyUI's subgraph widget-promotion store (id "promotion"; methods
  *  promote/demote/isPromoted) — the state that exposes an inner subgraph widget
- *  on the parent SubgraphNode. */
+ *  on the parent SubgraphNode. Frontend >= 1.48 removed this store: value
+ *  widgets promote via linked subgraph inputs, and preview widgets use
+ *  `previewExposure` instead. */
 function getPromotionStore() {
   const store = getPiniaStore("promotion");
   if (!store || typeof store.promote !== "function") {
     throw new Error("widget-promotion unavailable on this ComfyUI frontend (no 'promotion' store)");
   }
   return store;
+}
+
+/** Reach ComfyUI's PREVIEW-widget exposure store (id "previewExposure"; methods
+ *  getExposures/addExposure/removeExposure) — the state behind the canvas action
+ *  "Promote Widget: $$canvas-image-preview". Preview widgets are NOT backed by a
+ *  connectable input slot, so the link-only path (subgraph.addInput + connect)
+ *  cannot promote them, and the legacy "promotion" store no longer exists on
+ *  frontend >= 1.48. Returns null when the store is absent. */
+function getPreviewExposureStore() {
+  const store = getPiniaStore("previewExposure");
+  return store && typeof store.addExposure === "function" ? store : null;
+}
+
+/** Display-only preview widgets: `$$`-prefixed names ($$canvas-image-preview)
+ *  or a non-serializing widget whose type is a preview media type. Matches
+ *  ComfyUI_frontend `isPreviewPseudoWidget` so the panel routes the same
+ *  widgets the canvas context menu does. */
+const PREVIEW_WIDGET_TYPES = new Set(["preview", "video", "audioUI"]);
+function isPreviewWidget(widget) {
+  if (!widget) return false;
+  if (typeof widget.name === "string" && widget.name.startsWith("$$")) return true;
+  if (widget.serialize !== false && widget.options?.serialize !== false) return false;
+  return typeof widget.type === "string" && PREVIEW_WIDGET_TYPES.has(widget.type);
+}
+
+/** Promote/demote a PREVIEW widget on the parent SubgraphNode via the
+ *  previewExposure store. Store shape is (rootGraphId, hostNodeLocator, …)
+ *  — the same key the canvas menu uses. */
+function promotePreviewExposure(store, parents, rootGraph, source, demote) {
+  for (const p of parents) {
+    const rootGraphId = p.rootGraph?.id ?? rootGraph?.id;
+    const hostId = String(p.id);
+    const existing = store.getExposures?.(rootGraphId, hostId) ?? [];
+    const match = existing.filter(
+      (ex) =>
+        String(ex?.sourceNodeId) === source.sourceNodeId &&
+        ex?.sourcePreviewName === source.sourceWidgetName,
+    );
+    if (demote) {
+      for (const ex of match) store.removeExposure?.(rootGraphId, hostId, ex.name);
+    } else if (!match.length) {
+      store.addExposure(rootGraphId, hostId, {
+        sourceNodeId: source.sourceNodeId,
+        sourcePreviewName: source.sourceWidgetName,
+      });
+    }
+  }
+  return true;
 }
 
 /** Reach ComfyUI's subgraph-blueprint store (id "subgraph"). Exposes
@@ -18554,19 +18604,39 @@ const GRAPH_TOOL_EXECUTORS = {
     let strategy = "link-only";
     graph.beforeChange?.();
     try {
-      try {
-        let changed = false;
-        for (const p of parents) {
-          const result = demote ? demoteWidgetByLink(p, source) : promoteWidgetByLink(p, node, w);
-          changed = changed || result.changed;
-        }
-        if (demote && !changed) throw new Error("link-only promoted input not found");
-      } catch (linkErr) {
-        const store = getPromotionStore();
-        strategy = "legacy-store";
-        for (const p of parents) {
-          const rootGraphId = p.rootGraph?.id ?? rootGraph?.id;
-          store[action](rootGraphId, p.id, source);
+      // Preview widgets ($$canvas-image-preview) have no connectable input slot,
+      // so the link-only path cannot promote them. Frontend >= 1.48 exposes
+      // them through the `previewExposure` store (the canvas context-menu
+      // action), and the legacy "promotion" store it used to fall back to no
+      // longer exists there. Route the same widgets the canvas menu does,
+      // first, when that store is present.
+      const previewStore = isPreviewWidget(w) ? getPreviewExposureStore() : null;
+      if (previewStore) {
+        strategy = "preview-exposure";
+        promotePreviewExposure(previewStore, parents, rootGraph, source, demote);
+      } else {
+        try {
+          let changed = false;
+          for (const p of parents) {
+            const result = demote ? demoteWidgetByLink(p, source) : promoteWidgetByLink(p, node, w);
+            changed = changed || result.changed;
+          }
+          if (demote && !changed) throw new Error("link-only promoted input not found");
+        } catch (linkErr) {
+          // Don't mask why the primary path failed — that message is the useful
+          // one. The legacy store is gone on frontend >= 1.48; if it is also
+          // missing here, surface BOTH errors rather than only "no promotion store".
+          strategy = "legacy-store";
+          let store;
+          try {
+            store = getPromotionStore();
+          } catch (storeErr) {
+            throw new Error(`${linkErr?.message ?? linkErr} (and ${storeErr.message})`);
+          }
+          for (const p of parents) {
+            const rootGraphId = p.rootGraph?.id ?? rootGraph?.id;
+            store[action](rootGraphId, p.id, source);
+          }
         }
       }
       refreshPromotedParents(parents, canvas);


### PR DESCRIPTION
## Root cause

On ComfyUI frontend 1.48.7, `panel_promote_widget` of a subgraph preview (`$$canvas-image-preview` on an inner KSampler) failed with:

```
Error: widget-promotion unavailable on this ComfyUI frontend (no 'promotion' store)
```

Two defects:

1. **The `promotion` Pinia store is gone.** ADR 0009 / frontend 1.48 moved value-widget promotion onto linked subgraph inputs and preview surfacing onto a new `previewExposure` store (`addExposure` / `getExposures` / `removeExposure`). The panel still fell back to `getPiniaStore("promotion")`.
2. **That error was the wrong one.** A preview widget has no connectable input slot, so the primary link-only path already failed with `Widget "…" is not backed by a connectable input slot`. `catch (linkErr)` swallowed that and the user only saw the stale-store message.

The canvas context menu's "Promote Widget: $$canvas-image-preview" still worked, because it never used the removed store.

## Fix

- Route preview widgets (`$$`-prefixed, or a non-serializing `preview`/`video`/`audioUI` type — same predicate as the frontend's `isPreviewPseudoWidget`) through `previewExposure` when that store is present. Same `(rootGraphId, hostLocator)` key and `{ sourceNodeId, sourcePreviewName }` payload the canvas menu uses.
- When the link-only path fails **and** the legacy store is also absent, throw **both** errors so the slot failure is no longer hidden.
- Value widgets still promote link-only; the legacy store remains a last-resort fallback on older frontends.

## Verification

- `node --test browser_tests/unit/promote-widget-preview-store.test.mjs` — 9/9 pass. Extracts the shipped `graph_promote_widget` + helpers from `comfyui-mcp-panel.js` and drives them against Pinia-shaped doubles (previewExposure, gone-store, legacy store, link-only).
- `node scripts/check-panel-scope.mjs` — OK
- Related: `pressable-widget`, `changelog-integrity`, `frontend-contract` — 22/22 pass

Fixes #1271
