### PR TITLE
fix(1286): keep execution image previews on the node that emitted them

### DIFF
--- a/browser_tests/unit/_panel-constants.mjs
+++ b/browser_tests/unit/_panel-constants.mjs
@@ -15,6 +15,7 @@ import { fileURLToPath } from "node:url";
 
 import { makeCommandBudget } from "../../web/js/lib/command-budget.js";
 import { REFRESH_JOIN_ABANDONED } from "../../web/js/lib/refresh-coalesce.js";
+import { clearInheritedExecutionPreview } from "../../web/js/lib/execution-preview-attach.js";
 
 export const PANEL_SRC = readFileSync(
   fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url)),
@@ -134,6 +135,9 @@ export const OBJECT_INFO_SEED_WAIT_MS = readPanelNumber(
  */
 export function addNodeCommandBudgetDeps() {
   return {
+    // #1286 — graph_add_node now names this after graph.add. The shipped
+    // implementation is a no-op when the new id has no leftover store entries.
+    clearInheritedExecutionPreview,
     makeCommandBudget,
     ADD_NODE_COMMAND_BUDGET_MS,
     // Derived exactly as the panel derives it.

--- a/browser_tests/unit/add-node-command-budget.test.mjs
+++ b/browser_tests/unit/add-node-command-budget.test.mjs
@@ -48,6 +48,7 @@ import {
   monotonicNow,
   widenSocketProofBudget,
 } from "./_panel-constants.mjs";
+import { clearInheritedExecutionPreview } from "../../web/js/lib/execution-preview-attach.js";
 
 const panelPath = fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url));
 const panelSrc = readFileSync(panelPath, "utf8");
@@ -237,6 +238,7 @@ function realGraphAddNode({
     makeCommandBudget,
     REFRESH_JOIN_ABANDONED,
     addNodeRefreshBusyMessage,
+    clearInheritedExecutionPreview,
     OBJECT_INFO_SEED_WAIT_MS: 8000,
     ADD_NODE_COMMAND_BUDGET_MS: budgetMs,
     ADD_NODE_POST_REFRESH_RESERVE_MS: reserveMs,

--- a/browser_tests/unit/execution-preview-attach.test.mjs
+++ b/browser_tests/unit/execution-preview-attach.test.mjs
@@ -1,0 +1,212 @@
+// #1286 — after a live-canvas add + run, ComfyUI plants $$canvas-image-preview
+// on a ConditioningConcat (or any non-image node) whose id received the
+// executed / b_preview store entry. These tests drive the SHIPPED helpers in
+// web/js/lib/execution-preview-attach.js and pin the panel call sites so the
+// wiring cannot be dropped.
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+import {
+  CANVAS_IMAGE_PREVIEW_WIDGET,
+  nodeAcceptsExecutionImagePreview,
+  clearStoredExecutionOutputs,
+  stripNodeExecutionPreview,
+  clearInheritedExecutionPreview,
+  stripMisattachedExecutionPreviews,
+} from "../../web/js/lib/execution-preview-attach.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const PANEL = join(__dirname, "..", "..", "web", "js", "comfyui-mcp-panel.js");
+const panelSrc = readFileSync(PANEL, "utf8");
+
+function previewWidget() {
+  return { name: CANVAS_IMAGE_PREVIEW_WIDGET, value: "", onRemove() { this.removed = true; } };
+}
+
+function concatNode(id = 73) {
+  return {
+    id,
+    type: "ConditioningConcat",
+    size: [153, 266],
+    widgets: [previewWidget()],
+    imgs: [{ src: "/view?filename=ComfyUI_00001_.png" }],
+    images: [{ filename: "ComfyUI_00001_.png", type: "output" }],
+    outputs: [{ name: "CONDITIONING", type: "CONDITIONING" }],
+    computeSize() { return [153, 46]; },
+    setSize(size) { this.size = size; },
+  };
+}
+
+function saveImageNode(id = 9) {
+  return {
+    id,
+    type: "SaveImage",
+    constructor: { nodeData: { output_node: true } },
+    widgets: [previewWidget()],
+    imgs: [{ src: "/view?filename=ComfyUI_00001_.png" }],
+    images: [{ filename: "ComfyUI_00001_.png", type: "output" }],
+    outputs: [],
+  };
+}
+
+test("#1286: ConditioningConcat does not accept an execution image preview", () => {
+  assert.equal(
+    nodeAcceptsExecutionImagePreview({
+      type: "ConditioningConcat",
+      outputs: [{ type: "CONDITIONING" }],
+      widgets: [],
+    }),
+    false,
+  );
+});
+
+test("#1286: SaveImage / PreviewImage / KSampler / LoadImage do accept previews", () => {
+  assert.equal(nodeAcceptsExecutionImagePreview({ type: "SaveImage", constructor: { nodeData: { output_node: true } } }), true);
+  assert.equal(nodeAcceptsExecutionImagePreview({ type: "PreviewImage" }), true);
+  assert.equal(nodeAcceptsExecutionImagePreview({ type: "KSampler", outputs: [{ type: "LATENT" }] }), true);
+  assert.equal(
+    nodeAcceptsExecutionImagePreview({
+      type: "LoadImage",
+      widgets: [{ name: "image", value: "x.png" }],
+    }),
+    true,
+  );
+});
+
+test("#1286: stripMisattachedExecutionPreviews removes the preview from ConditioningConcat and keeps SaveImage", () => {
+  const concat = concatNode(73);
+  const save = saveImageNode(9);
+  const nodeOutputs = {
+    "9": { images: [{ filename: "ComfyUI_00001_.png", type: "output" }] },
+    "73": { images: [{ filename: "ComfyUI_00001_.png", type: "output" }] },
+  };
+  const nodePreviewImages = { "73": ["blob:stolen"] };
+
+  const result = stripMisattachedExecutionPreviews({
+    graph: { _nodes: [save, concat] },
+    nodeOutputs,
+    nodePreviewImages,
+    preferNodeId: 9,
+  });
+
+  assert.equal(result.stripped, 1);
+  assert.equal(concat.imgs, undefined);
+  assert.equal(concat.images, undefined);
+  assert.equal(concat.widgets.some((w) => w.name === CANVAS_IMAGE_PREVIEW_WIDGET), false);
+  assert.deepEqual(concat.size, [153, 46]);
+  assert.equal(nodeOutputs["73"], undefined);
+  assert.equal(nodePreviewImages["73"], undefined);
+  assert.ok(nodeOutputs["9"]?.images?.length);
+  assert.equal(save.imgs.length, 1);
+  assert.equal(save.widgets.some((w) => w.name === CANVAS_IMAGE_PREVIEW_WIDGET), true);
+});
+
+test("#1286: stolen outputs with no SaveImage store entry are re-homed onto the emitting node", () => {
+  const concat = concatNode(73);
+  const save = saveImageNode(9);
+  save.imgs = undefined;
+  save.images = undefined;
+  const nodeOutputs = {
+    "73": { images: [{ filename: "final.png", type: "output" }] },
+  };
+
+  const result = stripMisattachedExecutionPreviews({
+    graph: { _nodes: [save, concat] },
+    nodeOutputs,
+    nodePreviewImages: {},
+    preferNodeId: "9",
+  });
+
+  assert.equal(result.rehomed, true);
+  assert.equal(nodeOutputs["9"]?.images?.[0]?.filename, "final.png");
+  assert.equal(nodeOutputs["73"], undefined);
+  assert.equal(concat.imgs, undefined);
+});
+
+test("#1286: a KSampler live preview is not stripped", () => {
+  const sampler = {
+    id: 3,
+    type: "KSampler",
+    outputs: [{ type: "LATENT" }],
+    widgets: [previewWidget()],
+    imgs: [{ src: "blob:latent" }],
+  };
+  const nodeOutputs = { "3": { images: [{ filename: "preview.png", type: "temp" }] } };
+  const result = stripMisattachedExecutionPreviews({
+    graph: { _nodes: [sampler] },
+    nodeOutputs,
+    preferNodeId: 3,
+  });
+  assert.equal(result.stripped, 0);
+  assert.equal(sampler.imgs.length, 1);
+  assert.ok(nodeOutputs["3"]);
+});
+
+test("#1286: clearInheritedExecutionPreview drops leftover store entries on a newly added id", () => {
+  const node = {
+    id: 73,
+    type: "ConditioningConcat",
+    widgets: [previewWidget()],
+    imgs: undefined,
+  };
+  const nodeOutputs = { "73": { images: [{ filename: "old-save.png", type: "output" }] } };
+  const changed = clearInheritedExecutionPreview(node, { nodeOutputs, nodePreviewImages: {} });
+  assert.equal(changed, true);
+  assert.equal(nodeOutputs["73"], undefined);
+  assert.equal(node.widgets.some((w) => w.name === CANVAS_IMAGE_PREVIEW_WIDGET), false);
+});
+
+test("#1286: clearInheritedExecutionPreview does not wipe a LoadImage's hydrating imgs", () => {
+  const node = {
+    id: 12,
+    type: "LoadImage",
+    widgets: [{ name: "image", value: "in.png" }],
+    imgs: [{ src: "/view?filename=in.png" }],
+  };
+  const changed = clearInheritedExecutionPreview(node, { nodeOutputs: {}, nodePreviewImages: {} });
+  assert.equal(changed, false);
+  assert.equal(node.imgs.length, 1);
+});
+
+test("#1286: clearStoredExecutionOutputs accepts number or string ids", () => {
+  const nodeOutputs = { 9: { images: [1] }, "73": { images: [2] } };
+  assert.equal(clearStoredExecutionOutputs({ nodeOutputs }, "9"), true);
+  assert.equal(nodeOutputs[9], undefined);
+  assert.equal(clearStoredExecutionOutputs({ nodeOutputs }, 73), true);
+  assert.equal(nodeOutputs["73"], undefined);
+});
+
+test("#1286: stripNodeExecutionPreview invokes the pseudo-widget onRemove", () => {
+  const node = concatNode(73);
+  const widget = node.widgets[0];
+  stripNodeExecutionPreview(node, { nodeOutputs: { "73": { images: [1] } }, nodePreviewImages: {} });
+  assert.equal(widget.removed, true);
+  assert.equal(node.widgets.length, 0);
+});
+
+test("#1286: the panel imports and calls the shipped sanitizer on the add / remove / run paths", () => {
+  assert.match(panelSrc, /from "\.\/lib\/execution-preview-attach\.js"/);
+  assert.match(panelSrc, /clearInheritedExecutionPreview/);
+  assert.match(panelSrc, /clearStoredExecutionOutputs/);
+  assert.match(panelSrc, /stripMisattachedExecutionPreviews/);
+
+  const addFn = panelSrc.match(/\n {2}async graph_add_node\(\{ class_type, pos, title \}\) \{[\s\S]*?\n {2}\},/);
+  assert.ok(addFn, "graph_add_node body not found");
+  assert.match(addFn[0], /clearInheritedExecutionPreview\(/);
+
+  const removeFn = panelSrc.match(/\n {2}graph_remove_node\(\{ node_id \}\) \{[\s\S]*?\n {2}\},/);
+  assert.ok(removeFn, "graph_remove_node body not found");
+  assert.match(removeFn[0], /clearStoredExecutionOutputs\(/);
+
+  assert.match(panelSrc, /function onExecuted\(/);
+  const onExecuted = panelSrc.match(/function onExecuted\(ev\) \{[\s\S]*?\n {2}function onExecError/);
+  assert.ok(onExecuted, "onExecuted body not found");
+  assert.match(onExecuted[0], /stripMisattachedExecutionPreviews\(/);
+
+  const onSuccess = panelSrc.match(/function onExecutionSuccess\(ev\) \{[\s\S]*?\n {2}function onExecutionStart/);
+  assert.ok(onSuccess, "onExecutionSuccess body not found");
+  assert.match(onSuccess[0], /stripMisattachedExecutionPreviews\(/);
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -531,6 +531,11 @@ import {
   normalizePath,
 } from "./lib/workflow-save.js";
 import { createRunCompletionTracker } from "./lib/run-completion.js";
+import {
+  clearInheritedExecutionPreview,
+  clearStoredExecutionOutputs,
+  stripMisattachedExecutionPreviews,
+} from "./lib/execution-preview-attach.js";
 import { composeRunCompletionFrame } from "./lib/run-completion-frame.js";
 import { composeShowMediaReply } from "./lib/media-preview.js";
 import {
@@ -12058,6 +12063,12 @@ const GRAPH_TOOL_EXECUTORS = {
     } finally {
       graph.afterChange();
     }
+    // #1286 — a newly assigned id may still hold the previous occupant's
+    // execution images. Wipe that leftover so this node cannot inherit a preview.
+    clearInheritedExecutionPreview(node, {
+      nodeOutputs: comfyApp?.nodeOutputs,
+      nodePreviewImages: comfyApp?.nodePreviewImages,
+    });
     graph.setDirtyCanvas(true, true);
     const added = summarizeNode(node);
     const rejectedCorrections = correctionOut.rejected ?? [];
@@ -12146,9 +12157,15 @@ const GRAPH_TOOL_EXECUTORS = {
         `Node ${removedId} could not be removed (it may be protected / ignore_remove).`,
       );
     }
+    // #1286 — drop stored execution images for this id so a later add that
+    // reuses it cannot inherit the removed node's preview.
+    clearStoredExecutionOutputs(
+      { nodeOutputs: app?.nodeOutputs, nodePreviewImages: app?.nodePreviewImages },
+      removedId,
+    );
     graph.setDirtyCanvas(true, true);
     return {
-      removed: summary,
+      removed: summary;
       ...(cleaned && (cleaned.inputs.length || cleaned.outputs.length)
         ? { cleaned_boundary_slots: cleaned }
         : {}),
@@ -32162,6 +32179,18 @@ function buildPanel() {
     if (inlineImages.length || videos.length) {
       runCompletion.onExecuted(d.prompt_id, { images: inlineImages, videos });
     }
+    // #1286 — ComfyUI keys preview images by node id and will plant
+    // $$canvas-image-preview on whatever node now holds that id (a freshly
+    // added ConditioningConcat after a live-canvas edit). Keep the preview
+    // on the emitting image/output node.
+    if (media.length) {
+      stripMisattachedExecutionPreviews({
+        graph: app?.graph,
+        nodeOutputs: app?.nodeOutputs,
+        nodePreviewImages: app?.nodePreviewImages,
+        preferNodeId: nodeId,
+      });
+    }
   }
   function onExecError(ev) {
     const d = ev?.detail ?? {};
@@ -32221,6 +32250,13 @@ function buildPanel() {
   // start→finish duration, and reliably wakes the agent on the real result.
   function onExecutionSuccess(ev) {
     runCompletion.onExecutionSuccess(ev?.detail?.prompt_id);
+    // #1286 — backstop for b_preview frames that never emit `executed` images
+    // (KSampler latent previews routed to a non-image node after an add).
+    stripMisattachedExecutionPreviews({
+      graph: app?.graph,
+      nodeOutputs: app?.nodeOutputs,
+      nodePreviewImages: app?.nodePreviewImages,
+    });
   }
   // Primary render-duration start signal: ComfyUI emits `execution_start` with the
   // prompt_id the instant a run begins — anchor the duration timer there and flush

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -12165,7 +12165,7 @@ const GRAPH_TOOL_EXECUTORS = {
     );
     graph.setDirtyCanvas(true, true);
     return {
-      removed: summary;
+      removed: summary,
       ...(cleaned && (cleaned.inputs.length || cleaned.outputs.length)
         ? { cleaned_boundary_slots: cleaned }
         : {}),

--- a/web/js/lib/execution-preview-attach.js
+++ b/web/js/lib/execution-preview-attach.js
@@ -1,0 +1,236 @@
+/**
+ * #1286 — execution image previews must stay on the node that emitted them.
+ *
+ * ComfyUI's frontend keys `app.nodeOutputs` / `app.nodePreviewImages` by
+ * `String(node.id)` and `onDrawBackground` then plants `$$canvas-image-preview`
+ * on ANY node whose key has images. After a live-canvas add/remove, that key
+ * can be a newly created ConditioningConcat (or any non-image node): the
+ * executed / b_preview frame was stored under the last-assigned id, or a
+ * reused id still held the previous run's images. The node grows from ~46px
+ * to ~266px and query_graph reports the pseudo-widget.
+ *
+ * The panel cannot stop ComfyUI writing the store. It CAN (a) wipe inherited
+ * store entries when a node is created or removed, and (b) after a run, strip
+ * preview state from every node that cannot emit an image.
+ */
+
+export const CANVAS_IMAGE_PREVIEW_WIDGET = "$$canvas-image-preview";
+
+/** Hosts ComfyUI itself treats as canvas-image-preview nodes. */
+const PREVIEW_HOST_TYPES = new Set([
+  "KSampler",
+  "KSamplerAdvanced",
+  "PreviewImage",
+  "SaveImage",
+  "GLSLShader",
+]);
+
+const IMAGE_OUTPUT_TYPES = new Set(["IMAGE", "MASK", "LATENT"]);
+const IMAGE_WIDGET_NAMES = /^(image|images|mask|video)$/i;
+
+function outputStoreKeys(nodeId) {
+  if (nodeId == null) return [];
+  const keys = [String(nodeId)];
+  if (typeof nodeId === "number") {
+    keys.push(nodeId);
+  } else {
+    const n = Number(nodeId);
+    if (Number.isFinite(n) && String(n) === String(nodeId)) keys.push(n);
+  }
+  return keys;
+}
+
+function storeHasImages(bag, nodeId) {
+  if (!bag) return false;
+  for (const key of outputStoreKeys(nodeId)) {
+    const entry = bag[key];
+    if (Array.isArray(entry) && entry.length) return true;
+    if (entry?.images?.length) return true;
+  }
+  return false;
+}
+
+/**
+ * True when this node is a legitimate host for an execution image preview.
+ * ConditioningConcat (CONDITIONING only, no image widget) is not.
+ */
+export function nodeAcceptsExecutionImagePreview(node) {
+  if (!node || typeof node !== "object") return false;
+  if (PREVIEW_HOST_TYPES.has(String(node.type || ""))) return true;
+  if (node.constructor?.nodeData?.output_node) return true;
+  if (node.previewMediaType === "image" || node.previewMediaType === "video") return true;
+  if (Array.isArray(node.outputs)) {
+    for (const out of node.outputs) {
+      if (IMAGE_OUTPUT_TYPES.has(String(out?.type || ""))) return true;
+    }
+  }
+  if (Array.isArray(node.widgets)) {
+    for (const w of node.widgets) {
+      const name = w?.name;
+      if (typeof name !== "string" || name === CANVAS_IMAGE_PREVIEW_WIDGET) continue;
+      if (IMAGE_WIDGET_NAMES.test(name)) return true;
+    }
+  }
+  return false;
+}
+
+/** Drop `app.nodeOutputs` / `app.nodePreviewImages` entries for one id. */
+export function clearStoredExecutionOutputs(stores, nodeId) {
+  if (!stores || nodeId == null) return false;
+  let cleared = false;
+  for (const key of outputStoreKeys(nodeId)) {
+    for (const bag of [stores.nodeOutputs, stores.nodePreviewImages]) {
+      if (bag && Object.prototype.hasOwnProperty.call(bag, key)) {
+        delete bag[key];
+        cleared = true;
+      }
+    }
+  }
+  return cleared;
+}
+
+function removePreviewWidget(node) {
+  const widgets = node?.widgets;
+  if (!Array.isArray(widgets)) return false;
+  let removed = false;
+  for (let i = widgets.length - 1; i >= 0; i--) {
+    if (widgets[i]?.name !== CANVAS_IMAGE_PREVIEW_WIDGET) continue;
+    try {
+      widgets[i].onRemove?.();
+    } catch {
+      /* widget already detached */
+    }
+    widgets.splice(i, 1);
+    removed = true;
+  }
+  return removed;
+}
+
+function restoreCompactSize(node) {
+  if (typeof node.computeSize !== "function") return;
+  try {
+    const size = node.computeSize();
+    if (typeof node.setSize === "function") node.setSize(size);
+    else if (Array.isArray(node.size) && Array.isArray(size) && size.length >= 2) {
+      node.size[0] = size[0];
+      node.size[1] = size[1];
+    }
+  } catch {
+    /* size restore is best-effort */
+  }
+}
+
+/**
+ * Strip execution preview state from one node (imgs, images, the pseudo-widget,
+ * and any store entries keyed by its id). Used for misattached hosts after a run.
+ */
+export function stripNodeExecutionPreview(node, stores) {
+  if (!node) return false;
+  let changed = false;
+  if (node.imgs != null) {
+    node.imgs = undefined;
+    changed = true;
+  }
+  if (node.images != null) {
+    node.images = undefined;
+    changed = true;
+  }
+  if (node.preview != null) {
+    node.preview = undefined;
+    changed = true;
+  }
+  if (removePreviewWidget(node)) changed = true;
+  if (stores && node.id != null && clearStoredExecutionOutputs(stores, node.id)) {
+    changed = true;
+  }
+  if (changed) restoreCompactSize(node);
+  return changed;
+}
+
+/**
+ * A newly created node must not inherit leftover store entries at its id
+ * (the id may have belonged to a removed SaveImage/PreviewImage). Does NOT
+ * clear `node.imgs` — LoadImage may already be hydrating from its filename.
+ */
+export function clearInheritedExecutionPreview(node, stores) {
+  if (!node) return false;
+  let changed = false;
+  if (stores && node.id != null && clearStoredExecutionOutputs(stores, node.id)) {
+    changed = true;
+  }
+  if (removePreviewWidget(node)) {
+    restoreCompactSize(node);
+    changed = true;
+  }
+  return changed;
+}
+
+function moveStoredOutputs(stores, fromId, toId) {
+  if (!stores || fromId == null || toId == null) return false;
+  const toKey = String(toId);
+  let moved = false;
+  for (const fromKey of outputStoreKeys(fromId)) {
+    if (stores.nodeOutputs && stores.nodeOutputs[fromKey]?.images?.length && !storeHasImages(stores.nodeOutputs, toId)) {
+      stores.nodeOutputs[toKey] = stores.nodeOutputs[fromKey];
+      moved = true;
+    }
+    if (
+      stores.nodePreviewImages &&
+      Array.isArray(stores.nodePreviewImages[fromKey]) &&
+      stores.nodePreviewImages[fromKey].length &&
+      !storeHasImages(stores.nodePreviewImages, toId)
+    ) {
+      stores.nodePreviewImages[toKey] = stores.nodePreviewImages[fromKey];
+      moved = true;
+    }
+  }
+  return moved;
+}
+
+/**
+ * After a run: re-home stolen image outputs onto `preferNodeId` when that node
+ * is a real host, then strip preview state from every non-host.
+ *
+ * @returns {{ stripped: number, rehomed: boolean }}
+ */
+export function stripMisattachedExecutionPreviews({
+  graph,
+  nodeOutputs,
+  nodePreviewImages,
+  preferNodeId,
+} = {}) {
+  const nodes = graph?._nodes ?? graph?.nodes ?? [];
+  const stores = { nodeOutputs, nodePreviewImages };
+  let rehomed = false;
+
+  if (preferNodeId != null) {
+    const prefer = nodes.find((n) => n && String(n.id) === String(preferNodeId));
+    if (prefer && nodeAcceptsExecutionImagePreview(prefer)) {
+      const preferHas =
+        storeHasImages(nodeOutputs, preferNodeId) || storeHasImages(nodePreviewImages, preferNodeId);
+      if (!preferHas) {
+        for (const node of nodes) {
+          if (!node || String(node.id) === String(preferNodeId)) continue;
+          if (nodeAcceptsExecutionImagePreview(node)) continue;
+          if (moveStoredOutputs(stores, node.id, preferNodeId)) rehomed = true;
+        }
+      }
+    }
+  }
+
+  let stripped = 0;
+  for (const node of nodes) {
+    if (!node || nodeAcceptsExecutionImagePreview(node)) continue;
+    const hasPreview =
+      node.imgs != null ||
+      node.images != null ||
+      node.preview != null ||
+      (Array.isArray(node.widgets) &&
+        node.widgets.some((w) => w?.name === CANVAS_IMAGE_PREVIEW_WIDGET)) ||
+      storeHasImages(nodeOutputs, node.id) ||
+      storeHasImages(nodePreviewImages, node.id);
+    if (!hasPreview) continue;
+    if (stripNodeExecutionPreview(node, stores)) stripped += 1;
+  }
+  return { stripped, rehomed };
+}


### PR DESCRIPTION
## Summary

After a live-canvas `panel_add_node` + remove + run, ComfyUI keys `app.nodeOutputs` / `app.nodePreviewImages` by `String(node.id)` and `onDrawBackground` plants `$$canvas-image-preview` on **whatever node now holds that id**. A newly created ConditioningConcat (no IMAGE output) was growing from `[153,46]` to `[153,266]` and showing SaveImage's result.

The panel cannot stop ComfyUI writing the store. It now:

- wipes leftover store entries when a node is **added** (id reuse) or **removed**
- after `executed` / `execution_success`, **re-homes** stolen image outputs onto the emitting host and **strips** the pseudo-widget / `node.imgs` from every node that cannot emit an image (ConditioningConcat yes; SaveImage / PreviewImage / KSampler / LoadImage no)

## Test plan

- [x] `node --test browser_tests/unit/execution-preview-attach.test.mjs` — drives the shipped sanitizer (reporter's Concat vs SaveImage shape, re-home, KSampler kept, LoadImage imgs not wiped) and pins the add / remove / run call sites
- [x] add-node harnesses still pass (they inject the new free name)

Fixes #1286
