### PR TITLE
fix(1295): a dynamically added node survives workflow switch + reconnect

### DIFF
--- a/browser_tests/unit/flush-source-before-switch.test.mjs
+++ b/browser_tests/unit/flush-source-before-switch.test.mjs
@@ -1,0 +1,318 @@
+// #1295 — a dynamically added node must survive workflow switch + reconnect.
+//
+// THE REPORT. After installing Impact Pack and restarting ComfyUI, the live
+// workflow still contained the expected 31 nodes but the dynamically added
+// ImpactWildcardProcessor (id 49) was absent. The panel had also reported a
+// workflow identity/reconnect race after restart. Same family as #1215/#1267:
+// the switch's capture writes the WRONG tab, and the outgoing tab's tracker
+// never received the extra node, so reconnect restores 31.
+//
+// THE CAUSE. ComfyUI snapshots on user input only. `panel_add_node` lands the
+// node on the live canvas, then defers the tracker snapshot until after the
+// reply (#581). `workflow_open` then moves the pointer and repaints TARGET from
+// TARGET's `activeState`. It used to capture into TARGET (the #1215 poison);
+// after that skip, nothing flushed SOURCE while SOURCE was still active.
+// SOURCE's tracker stayed at 31 nodes. Reconnect restores SOURCE from that
+// tracker. Node 49 is gone.
+//
+// THE FIX is the inverse of #1215, not a weakening of it: flush SOURCE's live
+// canvas into SOURCE's tracker BEFORE `openWorkflow` moves the pointer.
+// These tests drive the SHIPPED helper, then pin that `workflow_open` actually
+// calls it on `activeBefore` before the switch. Deleting either fails them.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import { flushSourceCanvasBeforeSwitch } from "../../web/js/lib/flush-source-before-switch.js";
+
+const PANEL_JS = fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url));
+const SRC = readFileSync(PANEL_JS, "utf8").replace(/\r\n/g, "\n");
+
+const ORIGINAL_NODES = Array.from({ length: 31 }, (_, i) => ({
+  id: i + 1,
+  type: i === 0 ? "CheckpointLoaderSimple" : `Node${i + 1}`,
+}));
+const ADDED = { id: 49, type: "ImpactWildcardProcessor" };
+
+const clone = (v) => JSON.parse(JSON.stringify(v));
+
+function makeSource(nodes) {
+  return {
+    path: "workflows/source.json",
+    isModified: false,
+    changeTracker: { activeState: { nodes: clone(nodes), links: [] } },
+  };
+}
+
+function makeTarget() {
+  return {
+    path: "workflows/target.json",
+    isModified: false,
+    changeTracker: { activeState: { nodes: [{ id: 1, type: "Note" }], links: [] } },
+  };
+}
+
+/** Models `captureCanvasIntoTracker`: serialize the LIVE canvas into SOURCE. */
+function capturingFrom(liveCanvas) {
+  const calls = [];
+  const captureCanvasIntoTracker = (wf) => {
+    calls.push(wf);
+    wf.changeTracker.activeState = clone(liveCanvas);
+    wf.isModified = true;
+    return { verdict: "captured" };
+  };
+  return { captureCanvasIntoTracker, calls };
+}
+
+function ids(state) {
+  return (state?.nodes ?? []).map((n) => n.id);
+}
+
+// ---------------------------------------------------------------------------
+// Behaviour of the shipped helper
+// ---------------------------------------------------------------------------
+
+test("#1295: a dynamically added node on the live canvas lands in SOURCE's tracker before the switch", async () => {
+  const source = makeSource(ORIGINAL_NODES);
+  const target = makeTarget();
+  const liveCanvas = { nodes: [...clone(ORIGINAL_NODES), ADDED], links: [] };
+  const { captureCanvasIntoTracker, calls } = capturingFrom(liveCanvas);
+
+  const result = await flushSourceCanvasBeforeSwitch({
+    source,
+    target,
+    sameWorkflowObject: (a, b) => a === b,
+    describeLiveCanvasBinding: () => "unknown",
+    captureCanvasIntoTracker,
+  });
+
+  assert.equal(result.flushed, true);
+  assert.equal(result.verdict, "captured");
+  assert.equal(calls.length, 1, "exactly one capture");
+  assert.equal(calls[0], source, "the capture must write SOURCE, never TARGET");
+  assert.ok(
+    ids(source.changeTracker.activeState).includes(49),
+    "ImpactWildcardProcessor id 49 must be in SOURCE's tracker before the switch",
+  );
+  assert.equal(source.changeTracker.activeState.nodes.length, 32);
+  assert.equal(source.isModified, true, "the extra node is unsaved work, not a clean tab");
+  assert.equal(
+    target.changeTracker.activeState.nodes.length,
+    1,
+    "#1215: TARGET's state must not be rewritten by this flush",
+  );
+});
+
+test("#1295: reconnect restore from the flushed tracker still has the added node", async () => {
+  // The reconnect half: ComfyUI restores open tabs from ChangeTracker state, not
+  // from the live canvas (that object is gone). If the flush did not land, this
+  // restore is 31 nodes and id 49 is unrecoverable.
+  const source = makeSource(ORIGINAL_NODES);
+  const liveCanvas = { nodes: [...clone(ORIGINAL_NODES), ADDED], links: [] };
+  const { captureCanvasIntoTracker } = capturingFrom(liveCanvas);
+
+  await flushSourceCanvasBeforeSwitch({
+    source,
+    target: makeTarget(),
+    sameWorkflowObject: (a, b) => a === b,
+    describeLiveCanvasBinding: () => "bound",
+    captureCanvasIntoTracker,
+  });
+
+  const restoredAfterReconnect = clone(source.changeTracker.activeState);
+  assert.ok(
+    restoredAfterReconnect.nodes.some((n) => n.id === 49 && n.type === "ImpactWildcardProcessor"),
+    "the reconnect restore must still carry ImpactWildcardProcessor id 49",
+  );
+  assert.equal(restoredAfterReconnect.nodes.length, 32);
+});
+
+test("#1295: WITHOUT the flush, reconnect restore loses the added node — that is the bug", () => {
+  const source = makeSource(ORIGINAL_NODES);
+  const liveCanvas = { nodes: [...clone(ORIGINAL_NODES), ADDED], links: [] };
+  // No flush. The switch discards the live canvas; reconnect reads the tracker.
+  assert.equal(liveCanvas.nodes.length, 32, "the canvas DID hold the extra node");
+  const restoredAfterReconnect = clone(source.changeTracker.activeState);
+  assert.equal(restoredAfterReconnect.nodes.length, 31);
+  assert.ok(
+    !restoredAfterReconnect.nodes.some((n) => n.id === 49),
+    "the unflushed tracker is the 31-node report",
+  );
+});
+
+test("#1295: already-current (no pointer move) does not recapture — #874's target capture owns that", async () => {
+  const source = makeSource(ORIGINAL_NODES);
+  let captures = 0;
+  const result = await flushSourceCanvasBeforeSwitch({
+    source,
+    target: source,
+    sameWorkflowObject: (a, b) => a === b,
+    describeLiveCanvasBinding: () => "bound",
+    captureCanvasIntoTracker: () => {
+      captures += 1;
+      return { verdict: "captured" };
+    },
+  });
+  assert.equal(result.flushed, false);
+  assert.equal(result.reason, "already-current");
+  assert.equal(captures, 0);
+});
+
+test("#1295: a FOREIGN canvas is not imported into SOURCE — that is the #1215 poison the other way", async () => {
+  const source = makeSource(ORIGINAL_NODES);
+  let captures = 0;
+  const result = await flushSourceCanvasBeforeSwitch({
+    source,
+    target: makeTarget(),
+    sameWorkflowObject: (a, b) => a === b,
+    describeLiveCanvasBinding: () => "foreign",
+    captureCanvasIntoTracker: () => {
+      captures += 1;
+      return { verdict: "captured" };
+    },
+  });
+  assert.equal(result.flushed, false);
+  assert.equal(result.reason, "foreign");
+  assert.equal(captures, 0);
+  assert.equal(source.changeTracker.activeState.nodes.length, 31, "SOURCE's tracker is untouched");
+});
+
+test("#1295: an untagged ('unknown') source MUST flush — that is the Persist=false restart case", async () => {
+  const source = makeSource(ORIGINAL_NODES);
+  const liveCanvas = { nodes: [...clone(ORIGINAL_NODES), ADDED], links: [] };
+  const { captureCanvasIntoTracker } = capturingFrom(liveCanvas);
+  const result = await flushSourceCanvasBeforeSwitch({
+    source,
+    target: makeTarget(),
+    sameWorkflowObject: (a, b) => a === b,
+    describeLiveCanvasBinding: () => "unknown",
+    captureCanvasIntoTracker,
+  });
+  assert.equal(result.flushed, true);
+  assert.ok(ids(source.changeTracker.activeState).includes(49));
+});
+
+test("#1295: a pending capture is awaited — otherwise the switch races the snapshot", async () => {
+  const source = makeSource(ORIGINAL_NODES);
+  const liveCanvas = { nodes: [...clone(ORIGINAL_NODES), ADDED], links: [] };
+  let resolveSettled;
+  const settled = new Promise((resolve) => {
+    resolveSettled = resolve;
+  });
+  const pending = flushSourceCanvasBeforeSwitch({
+    source,
+    target: makeTarget(),
+    sameWorkflowObject: (a, b) => a === b,
+    describeLiveCanvasBinding: () => "bound",
+    captureCanvasIntoTracker: (wf) => {
+      queueMicrotask(() => {
+        wf.changeTracker.activeState = clone(liveCanvas);
+        resolveSettled("captured");
+      });
+      return { verdict: "pending", settled };
+    },
+  });
+  const result = await pending;
+  assert.equal(result.flushed, true);
+  assert.equal(result.verdict, "captured");
+  assert.ok(ids(source.changeTracker.activeState).includes(49));
+});
+
+test("#1295: a throwing capture never blocks the switch", async () => {
+  const source = makeSource(ORIGINAL_NODES);
+  const result = await flushSourceCanvasBeforeSwitch({
+    source,
+    target: makeTarget(),
+    sameWorkflowObject: (a, b) => a === b,
+    describeLiveCanvasBinding: () => {
+      throw new Error("oracle exploded");
+    },
+    captureCanvasIntoTracker: () => {
+      throw new Error("serialize failed");
+    },
+  });
+  assert.equal(result.flushed, false);
+  assert.equal(result.reason, "failed");
+});
+
+test("#1295: no source (nothing was active) is a no-op, not a throw", async () => {
+  const result = await flushSourceCanvasBeforeSwitch({
+    source: null,
+    target: makeTarget(),
+    sameWorkflowObject: (a, b) => a === b,
+    describeLiveCanvasBinding: () => "bound",
+    captureCanvasIntoTracker: () => {
+      throw new Error("must not capture");
+    },
+  });
+  assert.equal(result.flushed, false);
+  assert.equal(result.reason, "no-source");
+});
+
+test("#1295: sameWorkflowObject, not `===`, decides already-current (proxied workflow objects)", async () => {
+  const source = makeSource(ORIGINAL_NODES);
+  const targetProxy = { ...source };
+  let captures = 0;
+  const result = await flushSourceCanvasBeforeSwitch({
+    source,
+    target: targetProxy,
+    sameWorkflowObject: () => true,
+    describeLiveCanvasBinding: () => "bound",
+    captureCanvasIntoTracker: () => {
+      captures += 1;
+      return { verdict: "captured" };
+    },
+  });
+  assert.equal(result.flushed, false);
+  assert.equal(result.reason, "already-current");
+  assert.equal(captures, 0);
+});
+
+// ---------------------------------------------------------------------------
+// Wiring — deleting the call in workflow_open must fail these
+// ---------------------------------------------------------------------------
+
+test("#1295: workflow_open flushes SOURCE (activeBefore) BEFORE openWorkflow moves the pointer", () => {
+  assert.match(
+    SRC,
+    /import \{\s*flushSourceCanvasBeforeSwitch\s*\} from "\.\/lib\/flush-source-before-switch\.js"/,
+    "the shipped helper must be imported, not inlined",
+  );
+
+  const snapAt = SRC.indexOf("const activeBefore = activeWorkflowRef();");
+  const flushAt = SRC.indexOf("await flushSourceCanvasBeforeSwitch({");
+  const openAt = SRC.indexOf("await s.openWorkflow(target);");
+  assert.notEqual(snapAt, -1, "the pre-switch pointer must still be snapshotted (#1215)");
+  assert.notEqual(flushAt, -1, "the source flush must exist");
+  assert.notEqual(openAt, -1, "openWorkflow is what moves the pointer");
+  assert.ok(snapAt < flushAt, "activeBefore is captured before the flush reads it");
+  assert.ok(flushAt < openAt, "the flush must run while SOURCE is still the active pointer");
+
+  const call = SRC.slice(flushAt, SRC.indexOf("});", flushAt) + 3);
+  assert.match(call, /source:\s*activeBefore/, "the flush target is the outgoing tab");
+  assert.doesNotMatch(
+    call,
+    /source:\s*target/,
+    "flushing TARGET would be the #1215 poison",
+  );
+  assert.match(call, /describeLiveCanvasBinding/, "foreign canvases must still skip");
+  assert.match(call, /captureCanvasIntoTracker/, "the flush uses the proven capture helper");
+  assert.match(call, /sameWorkflowObject/, "already-current is object identity, not path text");
+});
+
+test("#1295: the #1215 TARGET capture gate still skips an untagged switch — this flush does not reopen it", () => {
+  const gateAt = SRC.indexOf("const captureBinding = describeLiveCanvasBinding(target);");
+  assert.notEqual(gateAt, -1, "#1215's target capture gate must remain");
+  const flushAt = SRC.indexOf("await flushSourceCanvasBeforeSwitch({");
+  assert.ok(flushAt < gateAt, "source flush is BEFORE the switch; target capture is AFTER");
+  const gate = SRC.slice(gateAt, SRC.indexOf("await target.changeTracker?.checkState?.()", gateAt));
+  assert.match(gate, /captureBinding === "bound"/);
+  assert.match(gate, /captureBinding !== "foreign" && !pointerMovedThisOpen/);
+  assert.doesNotMatch(
+    gate,
+    /if \(captureBinding !== "foreign"\)/,
+    '"not foreign" alone was the #1215 hole — the source flush must not bring it back',
+  );
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -398,6 +398,7 @@ import {
   verifyDisconnect,
 } from "./lib/disconnect-verify.js";
 import { deferChangeTrackerSnapshot } from "./lib/change-tracker-snapshot.js";
+import { flushSourceCanvasBeforeSwitch } from "./lib/flush-source-before-switch.js";
 import { coerceMessageText, isDroppedAgentReplay, serializeContext } from "./lib/chat-serialize.js";
 import {
   applyCurrentDefWidgetValues,
@@ -15607,6 +15608,22 @@ const GRAPH_TOOL_EXECUTORS = {
       // guard age out mid-flight (see begin/endWorkflowReloadStep).
       beginWorkflowReloadStep(reloadGuardToken);
       try {
+        // #1295 — FLUSH THE SOURCE, not the target, while SOURCE is still active.
+        // Inverse of the #1215 capture gate below. A node added through the bridge
+        // lives on the live canvas and is invisible to the outgoing tab's tracker
+        // (ComfyUI snapshots on user input; the add's own snapshot is deferred after
+        // the reply). Switching then repaints from that stale snapshot and the
+        // added node is gone; a later reconnect restores the same stale state.
+        // captureCanvasIntoTracker no-ops on a non-active tracker, so this has to
+        // happen BEFORE openWorkflow moves the pointer. Best-effort: a failed
+        // flush must not block the switch.
+        await flushSourceCanvasBeforeSwitch({
+          source: activeBefore,
+          target,
+          sameWorkflowObject,
+          describeLiveCanvasBinding,
+          captureCanvasIntoTracker,
+        });
         // #968 — claim this move BEFORE it happens, so the observer attributes it to this
         // command rather than reporting it as a move nobody made. A claim that is never
         // followed by a move is discarded by the next observation.

--- a/web/js/lib/flush-source-before-switch.js
+++ b/web/js/lib/flush-source-before-switch.js
@@ -1,0 +1,94 @@
+/**
+ * #1295 — flush the outgoing tab's live canvas into ITS tracker before a
+ * workflow switch moves the pointer.
+ *
+ * ComfyUI's ChangeTracker snapshots on USER INPUT events only. A node added
+ * through the bridge (`panel_add_node`) lives on the live canvas, but the
+ * outgoing tab's `activeState` is one capture behind — the add's own snapshot
+ * is deferred after the reply (#581) and is lost if a switch/reconnect lands
+ * first. The switch then repaints from that stale snapshot and the added node
+ * is gone; a later reconnect restores the same stale state. Measured shape of
+ * the report: a 31-node workflow, ImpactWildcardProcessor id 49 on the canvas,
+ * 31 nodes after the switch+reconnect, node 49 absent.
+ *
+ * This is the inverse of the #1215 capture gate, not a weakening of it:
+ *
+ *   #1215  — do NOT write SOURCE's still-mounted canvas into TARGET after the
+ *            pointer has moved (that poisons the tab being opened).
+ *   #1295  — DO write SOURCE's canvas into SOURCE, while SOURCE is still the
+ *            active pointer. `captureCanvasIntoTracker` no-ops on a non-active
+ *            tracker, so this has to happen BEFORE `openWorkflow`.
+ *
+ * "foreign" still skips: the mounted canvas is proven to belong to someone
+ * else, and capturing it would be the #708/#1215 poisoning in the other
+ * direction. "unknown" MUST flush — that is the already-current untagged
+ * case, and it is the configuration after a restart with Persist=false
+ * (#1215's reported setup), which is when the extra node is most at risk.
+ *
+ * Best-effort: a failed or pending-then-failed capture never blocks the
+ * switch. Blocking it would strand the session on a tab the caller is
+ * trying to leave. Callers inject the collaborators so the decision is
+ * unit-testable without a DOM.
+ */
+
+/**
+ * @param {{
+ *   source?: object | null,
+ *   target?: object | null,
+ *   sameWorkflowObject?: (a: unknown, b: unknown) => boolean,
+ *   describeLiveCanvasBinding?: (wf: object) => string,
+ *   captureCanvasIntoTracker?: (wf: object) =>
+ *     | { verdict?: string, settled?: Promise<string> }
+ *     | null
+ *     | undefined,
+ * }} [input]
+ * @returns {Promise<{ flushed: boolean, reason: string, verdict?: string }>}
+ */
+export async function flushSourceCanvasBeforeSwitch({
+  source,
+  target,
+  sameWorkflowObject,
+  describeLiveCanvasBinding,
+  captureCanvasIntoTracker,
+} = {}) {
+  try {
+    if (!source || typeof source !== "object") {
+      return { flushed: false, reason: "no-source" };
+    }
+    const same =
+      typeof sameWorkflowObject === "function"
+        ? sameWorkflowObject(source, target)
+        : source === target;
+    if (same) return { flushed: false, reason: "already-current" };
+
+    const binding =
+      typeof describeLiveCanvasBinding === "function"
+        ? describeLiveCanvasBinding(source)
+        : "unknown";
+    if (binding === "foreign") return { flushed: false, reason: "foreign" };
+    if (typeof captureCanvasIntoTracker !== "function") {
+      return { flushed: false, reason: "unavailable" };
+    }
+
+    const captured = captureCanvasIntoTracker(source);
+    if (!captured || typeof captured !== "object") {
+      return { flushed: false, reason: "unavailable" };
+    }
+    let verdict = captured.verdict;
+    if (verdict === "pending") {
+      try {
+        verdict = (await captured.settled) ?? "unverified";
+      } catch {
+        verdict = "failed";
+      }
+    }
+    const finalVerdict = typeof verdict === "string" && verdict ? verdict : "unverified";
+    return {
+      flushed: finalVerdict === "captured",
+      reason: finalVerdict,
+      verdict: finalVerdict,
+    };
+  } catch {
+    return { flushed: false, reason: "failed" };
+  }
+}


### PR DESCRIPTION
## Root cause

`panel_add_node` lands the node on the live canvas, but ComfyUI's ChangeTracker snapshots on USER INPUT events only. The add's own tracker snapshot is deferred until after the rid reply (#581). `workflow_open` then moved the pointer and repainted TARGET from TARGET's `activeState`. After #1215 it correctly refuses to serialize the still-mounted SOURCE canvas into TARGET — but nothing flushed SOURCE into SOURCE while SOURCE was still active. SOURCE's tracker stayed one capture behind. A later reconnect restores open tabs from that tracker, not from the discarded live canvas.

The report: a 31-node workflow, ImpactWildcardProcessor id 49 on the canvas, 31 nodes after the switch+reconnect, node 49 absent. Same family as #1215/#1267 (the switch writes the wrong tab; the outgoing tab never received the extra node).

## Fix

Panel-side only.

1. New helper `flushSourceCanvasBeforeSwitch` (`web/js/lib/flush-source-before-switch.js`). Before `openWorkflow` moves the pointer, capture the live canvas into SOURCE's tracker — while SOURCE is still the active pointer (`captureCanvasIntoTracker` no-ops on a non-active tracker).
2. Skip when the pointer is not moving (already-current; #874's TARGET capture owns that) or when the canvas is proven `foreign` to SOURCE (that would be the #1215 poison in the other direction). `unknown` MUST flush: that is the already-current untagged case, and it is the configuration after a restart with Persist=false (#1215's reported setup).
3. Best-effort: a failed flush never blocks the switch.

This is the inverse of #1215, not a weakening of it. The TARGET capture gate after the switch is unchanged.

## Verification

- `node --test browser_tests/unit/flush-source-before-switch.test.mjs` — **12/12 pass**.
- Related existing tests (`open-rebind-proof`, `new-workflow-persistence`, `change-tracker-snapshot`, `civitai-workflow`) — **98/98 pass**.
- `node scripts/check-panel-scope.mjs` — OK.
- `npx tsc --noEmit` — clean.

The new tests drive the shipped helper (a 31-node tracker + live ImpactWildcardProcessor id 49 lands in SOURCE; reconnect restore from that tracker still has node 49; without the flush the restore is the 31-node report) and pin that `workflow_open` calls it on `activeBefore` before `openWorkflow`. Deleting either fails them. The #1215 TARGET gate is asserted still present and still refusing `"not foreign" alone`.

Not verified: a live-browser reproduction of the original Impact Pack install + restart sequence (no ComfyUI instance driven here).

Fixes #1295
