### PR TITLE
fix(1268): a widget write is verified against the node property litegraph binds it to, and says UNKNOWN when it cannot be

### DIFF
--- a/browser_tests/unit/widget-bound-property.test.mjs
+++ b/browser_tests/unit/widget-bound-property.test.mjs
@@ -1,0 +1,239 @@
+/**
+ * panel#1268 / comfyui-mcp#1658 — a widget litegraph binds to one of its node's own
+ * properties (`options.property`). Run with `node --test`.
+ *
+ * Both reports are the same shape: `panel_set_widget` returned success, and the OLD
+ * value was back by the next read and in the render. The cause `applyWidgetWrite` had
+ * was structural — it assigned `w.value` and then read `w.value` back, which is true
+ * whether or not the write reached anything the node reads.
+ *
+ * The fixtures below are litegraph's own two code paths, transcribed from
+ * ComfyUI frontend 1.48.7 (`src/lib/litegraph/src/LGraphNode.ts#setProperty` and
+ * `src/lib/litegraph/src/widgets/BaseWidget.ts#setValue`) rather than invented, so a
+ * test passing here is a statement about the real binding and not about a mock.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { applyWidgetWrite } from "../../web/js/lib/widget-write.js";
+import { boundPropertyName, boundPropertyState } from "../../web/js/lib/widget-bound-property.js";
+
+const HOOKS = {};
+
+/**
+ * `LGraphNode.setProperty`, transcribed:
+ *
+ *     this.properties[name] = value
+ *     if (this.onPropertyChanged?.(name, value, prev_value) === false)
+ *       this.properties[name] = prev_value
+ *     for (const w of this.widgets) if (w.options.property == name) { w.value = value; break }
+ */
+function setProperty(name, value) {
+  this.properties ||= {};
+  if (value === this.properties[name]) return;
+  const prev = this.properties[name];
+  this.properties[name] = value;
+  if (this.onPropertyChanged?.(name, value, prev) === false) this.properties[name] = prev;
+  // NOTE the value pushed into the bound widget: litegraph writes the REQUESTED value,
+  // not `this.properties[name]`. So a node whose `onPropertyChanged` refuses the change
+  // ends up with the widget showing the new value and the property holding the old one —
+  // the divergence this fix exists to catch, produced by litegraph itself.
+  for (const w of this.widgets ?? []) {
+    if (w?.options?.property === name) {
+      w.value = value;
+      break;
+    }
+  }
+}
+
+/**
+ * The reverse leg every one of these nodes runs sooner or later: litegraph copies the
+ * PROPERTY into the bound widget. Any `setProperty` on the node does it; so does the
+ * node's own redraw/refresh code in the packs both issues name. This is the step that
+ * turned a reported success into the old value on the next read.
+ */
+function resyncWidgetsFromProperties(node) {
+  for (const w of node.widgets ?? []) {
+    const p = w?.options?.property;
+    if (typeof p === "string" && node.properties?.[p] !== undefined) w.value = node.properties[p];
+  }
+}
+
+/** A node with one bound widget, wired the way litegraph wires one. */
+function boundNode({ property = "mode", value = "depth", propertyValue = "depth", onPropertyChanged } = {}) {
+  const node = {
+    id: 41,
+    type: "AIO_Preprocessor",
+    properties: { [property]: propertyValue },
+    widgets: [{ name: "preprocessor", type: "combo", value, options: { property, values: ["depth", "pose"] } }],
+    setProperty,
+  };
+  if (onPropertyChanged) node.onPropertyChanged = onPropertyChanged;
+  return node;
+}
+
+// ---- the classifier ---------------------------------------------------------
+
+test("boundPropertyName reads options.property and nothing else", () => {
+  assert.equal(boundPropertyName({ options: { property: "mode" } }), "mode");
+  assert.equal(boundPropertyName({ options: { property: "" } }), null);
+  assert.equal(boundPropertyName({ options: { property: 7 } }), null);
+  assert.equal(boundPropertyName({ options: {} }), null);
+  assert.equal(boundPropertyName({}), null);
+  assert.equal(boundPropertyName(null), null);
+  // A throwing `options` accessor is reported as NO binding, so the write path is
+  // left exactly as it was rather than aimed at a target that could not be read.
+  assert.equal(
+    boundPropertyName({
+      get options() {
+        throw new Error("hostile");
+      },
+    }),
+    null,
+  );
+});
+
+test("a property the node does NOT carry is not a second store", () => {
+  // litegraph's own condition: BaseWidget.setValue syncs only when
+  // `node.properties[p] !== undefined`. With the property absent, an on-canvas edit
+  // writes nothing either, so there is nothing to keep in step.
+  const node = { id: 1, properties: {}, widgets: [], setProperty };
+  assert.equal(boundPropertyState(node, { options: { property: "mode" } }), null);
+  assert.equal(boundPropertyState({ id: 1 }, { options: { property: "mode" } }), null);
+});
+
+test("a bound property with no setProperty is UNKNOWN, not absent", () => {
+  const state = boundPropertyState({ id: 1, properties: { mode: "depth" } }, { options: { property: "mode" } });
+  assert.equal(state.property, "mode");
+  assert.equal(state.reachable, false);
+  assert.match(state.reason, /setProperty/);
+});
+
+// ---- the write path: the CALL SITE -----------------------------------------
+
+test("#1268: the write drives the bound property, not just the widget", () => {
+  const node = boundNode();
+  const set = applyWidgetWrite(node, "preprocessor", "pose", HOOKS);
+
+  // The effect, not the request: the store the NODE reads changed.
+  assert.equal(node.properties.mode, "pose");
+  assert.equal(node.widgets[0].value, "pose");
+  assert.deepEqual(set.bound_property, { name: "mode", previous: "depth" });
+  assert.equal(set.bound_property_unverified, undefined);
+});
+
+test("#1268: the value SURVIVES the node copying its property back into the widget", () => {
+  // This is the reported symptom reproduced end to end. Before the fix the widget held
+  // "pose" and `properties.mode` still held "depth", so this resync — which litegraph
+  // performs on any later setProperty, and which these packs' own redraw code performs —
+  // put "depth" straight back while the tool had already reported success.
+  const node = boundNode();
+  applyWidgetWrite(node, "preprocessor", "pose", HOOKS);
+
+  resyncWidgetsFromProperties(node);
+
+  assert.equal(node.widgets[0].value, "pose");
+});
+
+test("#1268: a node that REFUSES the property fails the write and rolls both stores back", () => {
+  const node = boundNode({ onPropertyChanged: () => false });
+
+  assert.throws(
+    () => applyWidgetWrite(node, "preprocessor", "pose", HOOKS),
+    (err) => {
+      assert.match(err.message, /bound to that node's own property "mode"/);
+      assert.match(err.message, /wrote "pose" but it is "depth"/);
+      return true;
+    },
+  );
+  // Rolled back: neither store is left holding a value the caller was told failed.
+  assert.equal(node.properties.mode, "depth");
+  assert.equal(node.widgets[0].value, "depth");
+});
+
+test("#1658: a bound property that cannot be driven is reported UNKNOWN on a SUCCESS", () => {
+  // The node declares the property, so `w.value` is provably not the only store — but
+  // it exposes no setProperty, so neither driving it nor reading the effect back is
+  // possible from here. Success with the claim narrowed, never a refusal: refusing
+  // would block writes that are very likely fine.
+  const node = {
+    id: 2768,
+    type: "AnimaRegionalCanvasInline",
+    properties: { animaPrompts: "old" },
+    widgets: [{ name: "red_prompt", type: "customtext", value: "old", options: { property: "animaPrompts" } }],
+  };
+
+  const set = applyWidgetWrite(node, "red_prompt", "a red car", HOOKS);
+
+  assert.equal(set.value, "a red car");
+  assert.equal(set.bound_property, undefined);
+  assert.equal(set.bound_property_unverified.name, "animaPrompts");
+  assert.match(set.bound_property_unverified.reason, /setProperty/);
+  assert.match(set.bound_property_note, /CANNOT establish/);
+  assert.match(set.bound_property_note, /panel_set_property/);
+});
+
+// ---- the opposite harm: ordinary writes must be untouched -------------------
+
+test("a widget with no options.property is written and reported exactly as before", () => {
+  const node = {
+    id: 7,
+    type: "KSampler",
+    properties: { "Node name for S&R": "KSampler" },
+    widgets: [{ name: "steps", type: "INT", value: 20 }],
+    setProperty,
+  };
+
+  const set = applyWidgetWrite(node, "steps", 30, HOOKS);
+
+  assert.equal(set.value, 30);
+  assert.equal(node.widgets[0].value, 30);
+  assert.equal(set.bound_property, undefined);
+  assert.equal(set.bound_property_unverified, undefined);
+  assert.equal(set.bound_property_note, undefined);
+  // The node's unrelated properties are not touched by a widget write.
+  assert.deepEqual(node.properties, { "Node name for S&R": "KSampler" });
+});
+
+test("a bound NUMERIC widget the node normalizes still succeeds", () => {
+  // #805: litegraph's own order is `value = v` → `setProperty(p, v)` → `callback`, so a
+  // callback that snaps the widget leaves the property holding the REQUESTED value on
+  // an on-canvas edit too. Failing that divergence would refuse a write the UI performs.
+  const node = {
+    id: 9,
+    type: "Snapper",
+    properties: { size: 512 },
+    widgets: [
+      {
+        name: "size",
+        type: "INT",
+        value: 512,
+        options: { property: "size", min: 1, step: 2 },
+        callback() {
+          node.widgets[0].value = 4097;
+        },
+      },
+    ],
+    setProperty,
+  };
+
+  const set = applyWidgetWrite(node, "size", 4096, HOOKS);
+
+  assert.equal(set.normalized, true);
+  assert.equal(set.value, 4097);
+  assert.equal(node.properties.size, 4096);
+  assert.deepEqual(set.bound_property, { name: "size", previous: 512 });
+});
+
+test("an unrelated failure still rolls the bound property back", () => {
+  // The widget's own callback reverts the value, so the write fails on the #240 check.
+  // The property must not be left carrying the new value after that rollback.
+  const node = boundNode();
+  node.widgets[0].callback = () => {
+    node.widgets[0].value = "depth";
+  };
+
+  assert.throws(() => applyWidgetWrite(node, "preprocessor", "pose", HOOKS), /did not retain/);
+  assert.equal(node.properties.mode, "depth");
+  assert.equal(node.widgets[0].value, "depth");
+});

--- a/browser_tests/unit/widget-bound-property.test.mjs
+++ b/browser_tests/unit/widget-bound-property.test.mjs
@@ -225,6 +225,41 @@ test("a bound NUMERIC widget the node normalizes still succeeds", () => {
   assert.deepEqual(set.bound_property, { name: "size", previous: 512 });
 });
 
+test("a bound widget whose `value` is an ACCESSOR still verifies", () => {
+  // ComfyUI's DOM widgets define `value` as an accessor —
+  // `set value(v) { options.setValue?.(v); callback?.(this.value) }` — so `setProperty`'s
+  // copy-back runs that setter a second time. The write must still verify, and the
+  // widget's own callback must not be able to turn the extra invocation into a failure.
+  // Counted, because the count is the thing that changes for a BOUND widget, and it is
+  // the same count `BaseWidget.setValue` produces for an on-canvas edit of one.
+  let store = "old";
+  let callbacks = 0;
+  const widget = {
+    name: "prompt",
+    type: "customtext",
+    options: { property: "prompt", getValue: () => store, setValue: (v) => (store = v) },
+    callback() {
+      callbacks += 1;
+    },
+    get value() {
+      return this.options.getValue();
+    },
+    set value(v) {
+      this.options.setValue(v);
+      this.callback?.(this.value);
+    },
+  };
+  const node = { id: 3, type: "DomBacked", properties: { prompt: "old" }, widgets: [widget], setProperty };
+
+  const set = applyWidgetWrite(node, "prompt", "new", HOOKS);
+
+  assert.equal(set.value, "new");
+  assert.equal(store, "new");
+  assert.equal(node.properties.prompt, "new");
+  assert.deepEqual(set.bound_property, { name: "prompt", previous: "old" });
+  assert.equal(callbacks, 3);
+});
+
 test("an unrelated failure still rolls the bound property back", () => {
   // The widget's own callback reverts the value, so the write fails on the #240 check.
   // The property must not be left carrying the new value after that rollback.

--- a/web/js/lib/widget-bound-property.js
+++ b/web/js/lib/widget-bound-property.js
@@ -138,11 +138,15 @@ export function boundPropertyState(node, widget) {
  * `onPropertyChanged` returning false is the documented way, but a property accessor
  * or a later hook can produce the same observation.
  */
-export function boundPropertyFailure({ property, widgetName, nodeId, expected, actual }) {
+export function boundPropertyFailure({ property, widgetName, nodeId, expected, actual, unreadable }) {
+  // An unreadable property is reported as unreadable, never rendered as a value. A
+  // throwing accessor and a property genuinely holding `undefined` are different facts,
+  // and JSON.stringify collapses both to the same text.
+  const observed = unreadable ? "unreadable (reading it threw)" : `${JSON.stringify(actual)}`;
   return (
     `Widget "${widgetName}" on node ${nodeId} is bound to that node's own property ` +
     `"${property}" (\`options.property\`), and the property did not take the requested ` +
-    `value: wrote ${JSON.stringify(expected)} but it is ${JSON.stringify(actual)}. ` +
+    `value: wrote ${JSON.stringify(expected)} but it is ${observed}. ` +
     `LiteGraph copies that property back into the widget on the next \`setProperty\`, so ` +
     `reporting success here would report a value the node is about to replace with the ` +
     `old one. Rolled back.`

--- a/web/js/lib/widget-bound-property.js
+++ b/web/js/lib/widget-bound-property.js
@@ -1,0 +1,167 @@
+// A widget that LiteGraph binds to one of its node's own properties (#1268, comfyui-mcp#1658).
+//
+// THE DEFECT THIS EXISTS FOR. `applyWidgetWrite` decided every write by assigning
+// `w.value` and then reading `w.value` back. For a widget whose real state lives
+// somewhere else, that read is a TAUTOLOGY: it confirms the assignment, never the
+// effect. Two reports of the same shape — a clean success followed by the OLD value
+// on the next read, and by a render built from the old value.
+//
+// LiteGraph gives one such "somewhere else" a FIRST-PARTY, DECLARED name, and this
+// module is scoped to exactly that one. A widget may carry `options.property`, the
+// name of an entry in its own node's `properties` map. The two stores are kept in
+// step by litegraph itself, in BOTH directions:
+//
+//   `BaseWidget.setValue` (widgets/BaseWidget.ts — the INTERACTIVE edit path):
+//
+//       this.value = v
+//       if (this.options?.property && node.properties[this.options.property] !== undefined) {
+//         node.setProperty(this.options.property, v)
+//       }
+//       this.callback?.(this.value, canvas, node, pos, e)
+//
+//   `LGraphNode.setProperty` (LGraphNode.ts — the reverse leg):
+//
+//       this.properties[name] = value
+//       if (this.onPropertyChanged?.(name, value, prev_value) === false)
+//         this.properties[name] = prev_value
+//       for (const w of this.widgets) if (w.options.property == name) { w.value = value; break }
+//
+// Read together those two say the thing that matters here. A bare `w.value = x`
+// assignment — which is what a programmatic write does — updates ONE of the two
+// stores. `node.properties[p]` keeps the old value, and the NEXT `setProperty` on
+// that node pushes the old value straight back into `w.value`. The write reads back
+// clean at write time and is gone by the next read: the reported symptom exactly.
+//
+// WHY THIS IS NOT THE GUESS #698 REFUSED. `describeNonValueBearingWidget` deliberately
+// lists a node's property NAMES and refuses to say which one backs a given widget,
+// because pairing them by name similarity would eventually point a write at unrelated
+// node state. Nothing is paired here: `options.property` IS the name, declared by the
+// node's own author, and it is the same field litegraph reads. Where a widget declares
+// no `options.property`, this module returns null and the write path is untouched.
+//
+// SCOPE, and what is deliberately left alone:
+//   * The WRITTEN widget on the node the write landed on. A promoted subgraph rail is
+//     a projection built by the subgraph machinery rather than an `addWidget(…, "prop")`
+//     binding, and #366/#477 already verify it against its own store.
+//   * `node.properties[p] === undefined` is NOT bound. That is litegraph's OWN condition
+//     in `BaseWidget.setValue`: with the property absent, an interactive edit syncs
+//     nothing either, so there is no second store and nothing to report.
+//   * Nothing here invokes a serializer, an options provider, or any other pack callback
+//     to find out what is true. `setProperty` is called on the WRITE path only, which is
+//     the same call an interactive edit makes.
+
+/**
+ * The property name this widget is bound to, or null.
+ *
+ * Read defensively: `options` may be absent on a hand-built widget, and a pack may
+ * install a throwing accessor. An unreadable binding is reported as NO binding, which
+ * leaves the write path exactly as it was rather than inventing a target for it.
+ *
+ * @param {unknown} widget
+ * @returns {string|null}
+ */
+export function boundPropertyName(widget) {
+  try {
+    const opts = widget && typeof widget === "object" ? widget.options : null;
+    if (!opts || typeof opts !== "object") return null;
+    const name = opts.property;
+    return typeof name === "string" && name.length > 0 ? name : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Classify the binding between `widget` and `node`, WITHOUT touching either store.
+ *
+ * Returns null when there is no second store to keep in step — no declared property,
+ * or the node does not carry that property (litegraph's own condition). Otherwise:
+ *
+ *   { property, reachable: true,  previous }   sync it, then verify it stuck
+ *   { property, reachable: false, reason }     the store exists and cannot be reached
+ *                                              from here — report UNKNOWN, never refuse
+ *
+ * The unreachable case is the point. The node declares the property, so the value the
+ * node reads is NOT the one we can see through `w.value`; but with no `setProperty` we
+ * can neither drive it nor read the effect back. Saying "success" there is the same
+ * false claim this module exists to remove, and refusing would block a write that may
+ * well be fine. Unknown is the only honest third answer.
+ *
+ * @param {unknown} node
+ * @param {unknown} widget
+ * @returns {{property: string, reachable: boolean, previous?: unknown, reason?: string}|null}
+ */
+export function boundPropertyState(node, widget) {
+  const property = boundPropertyName(widget);
+  if (!property) return null;
+  let props;
+  try {
+    props = node && typeof node === "object" ? node.properties : undefined;
+  } catch {
+    return { property, reachable: false, reason: "reading the node's `properties` threw" };
+  }
+  if (!props || typeof props !== "object" || Array.isArray(props)) return null;
+  let previous;
+  try {
+    previous = props[property];
+  } catch {
+    return { property, reachable: false, reason: "reading the bound property threw" };
+  }
+  // litegraph's own guard: an ABSENT property is not a second store, and an
+  // interactive edit does not create one either.
+  if (previous === undefined) return null;
+  let hasSetter = false;
+  try {
+    hasSetter = typeof node.setProperty === "function";
+  } catch {
+    hasSetter = false;
+  }
+  if (!hasSetter) {
+    return {
+      property,
+      reachable: false,
+      reason: "the node exposes no `setProperty`, so the bound property cannot be driven the way an on-canvas edit drives it",
+    };
+  }
+  return { property, reachable: true, previous };
+}
+
+/**
+ * The failure text for a bound property that did NOT take the written value.
+ *
+ * Mirrors the #366 rail wording, because it is the same class of fact: a second store
+ * that the node reads is holding a DIFFERENT value from the one just written, so a
+ * success here would be a success for a value the node is about to overwrite.
+ *
+ * States only what was observed — the two values, and that litegraph pushes the
+ * property back into the widget. It does NOT claim to know WHY the node refused it;
+ * `onPropertyChanged` returning false is the documented way, but a property accessor
+ * or a later hook can produce the same observation.
+ */
+export function boundPropertyFailure({ property, widgetName, nodeId, expected, actual }) {
+  return (
+    `Widget "${widgetName}" on node ${nodeId} is bound to that node's own property ` +
+    `"${property}" (\`options.property\`), and the property did not take the requested ` +
+    `value: wrote ${JSON.stringify(expected)} but it is ${JSON.stringify(actual)}. ` +
+    `LiteGraph copies that property back into the widget on the next \`setProperty\`, so ` +
+    `reporting success here would report a value the node is about to replace with the ` +
+    `old one. Rolled back.`
+  );
+}
+
+/**
+ * The UNKNOWN note for a bound property that could not be reached.
+ *
+ * Carried on an otherwise-successful result, next to a structured field, so a caller
+ * can tell "verified" from "assigned, effect not established" without reading prose.
+ */
+export function boundPropertyUnverifiedNote({ property, widgetName, nodeId, reason }) {
+  return (
+    `The write to "${widgetName}" on node ${nodeId} was applied and read back, but this ` +
+    `widget is bound to the node's own property "${property}" (\`options.property\`) and ` +
+    `${reason}. The panel therefore CANNOT establish whether the value the node reads has ` +
+    `changed — the widget's stored value is what was verified, not the bound property. ` +
+    `Read the property with panel_query_graph, and set it with panel_set_property if it ` +
+    `still holds the old value.`
+  );
+}

--- a/web/js/lib/widget-write.js
+++ b/web/js/lib/widget-write.js
@@ -1,6 +1,11 @@
 import { pressableWidgetHint } from "./pressable-widget.js";
 import { explainNumericNormalization, normalizationNote } from "./widget-normalization.js";
 import { isNonSerializingValueSource } from "./virtual-source-promotion.js";
+import {
+  boundPropertyFailure,
+  boundPropertyState,
+  boundPropertyUnverifiedNote,
+} from "./widget-bound-property.js";
 
 // #976: captured at module load so invoking a widget's callback cannot read any
 // property off the callback itself (a poisoned `.call` getter or a Proxy trap would
@@ -1441,6 +1446,16 @@ export function applyWidgetWrite(
   // caught structurally, mirroring the rail's rollback rigor.
   const previousDisplays = displayWidgets.map((dw) => dw.value);
   const previousDisplayClones = displayWidgets.map((dw) => deepClone(dw.value));
+  // #1268 / comfyui-mcp#1658 — the SECOND STORE this write has to keep in step, when
+  // litegraph declares one. `w.value` read back after `w.value = coerced` cannot tell a
+  // write that took effect from a write that landed on a view of state held elsewhere;
+  // a widget carrying `options.property` names that elsewhere itself. Classified BEFORE
+  // the envelope so the write, the verification and the rollback all act on ONE reading
+  // (`node.setProperty` mutates `properties`, so a second classification taken later
+  // would describe the state this write already produced). See widget-bound-property.js
+  // for the two litegraph paths that make the binding load-bearing.
+  const boundProperty = boundPropertyState(targetNode, w);
+  const previousPropertyClone = boundProperty?.reachable ? deepClone(boundProperty.previous) : undefined;
   // The ACTUAL serialization binding for an unlinked subgraph input is its
   // `widgetId` (the widget-value STORE key that queue compilation reads). A callback
   // could keep the SAME host input and projection objects but re-point `widgetId` to
@@ -1523,6 +1538,20 @@ export function applyWidgetWrite(
     // promoted value (no semantic callback of their own — the inner target's fires
     // once below), so we assign their value directly, same as the rail.
     for (const dw of displayWidgets) dw.value = coerced;
+    // #1268 / comfyui-mcp#1658 — drive the BOUND PROPERTY, in litegraph's own position:
+    // `BaseWidget.setValue` assigns the widget, then calls `node.setProperty(...)`, then
+    // fires the callback. Placed here so a programmatic write leaves the node in the SAME
+    // state an on-canvas edit leaves it in — rather than in the half-updated state that
+    // reads back clean and is overwritten by the node's next `setProperty`.
+    //
+    // Inside the SAME undo envelope as the value assignments, so this cannot land while
+    // the widget write rolls back. `setProperty` copies the value into the bound widget as
+    // its last step; `w.value` is already `coerced`, so that copy is a no-op assignment.
+    //
+    // A throw from here is captured by the same catch as everything else in this envelope
+    // and stays UNATTRIBUTED — `onPropertyChanged` is a node's own code and this is not
+    // the widget-callback invocation #976 can name.
+    if (boundProperty?.reachable) targetNode.setProperty(boundProperty.property, coerced);
     // Fire the inner widget's own callback so combo/number side effects run — the
     // same single invocation a manual UI edit of the promoted control performs.
     //
@@ -1592,6 +1621,25 @@ export function applyWidgetWrite(
   let driftFailure = false;
   let writeWarning = null;
   let threwFrame = null;
+  // #1268 — read the bound property TOTALLY. It is ordinary node state on every real
+  // node, but `properties` can be swapped for a Proxy or the key defined as a throwing
+  // accessor by a callback that ran inside the envelope above, and a verification that
+  // throws would escape past the rollback with the write left applied. A read that could
+  // not be taken yields a sentinel that matches nothing, so the write fails CLOSED and
+  // rolls back rather than being reported as verified.
+  const UNREADABLE_PROPERTY = Symbol("bound property unreadable");
+  const readBoundProperty = () => {
+    try {
+      const props = targetNode.properties;
+      if (!props || typeof props !== "object") return UNREADABLE_PROPERTY;
+      return props[boundProperty.property];
+    } catch {
+      return UNREADABLE_PROPERTY;
+    }
+  };
+  // Read ONCE, after the envelope closed. Two reads of a stateful accessor can disagree,
+  // and the verdict and the message it prints must be the same observation.
+  const boundPropertyActual = boundProperty?.reachable ? readBoundProperty() : undefined;
   // #805 — a value the widget's OWN declared grid explains is NORMALIZATION, not a
   // failed write. `matchesExpected` is a strict equality, so a numeric widget doing
   // exactly its job (min 1 / step 2 snaps 4096 -> 4097) was reported as "did not
@@ -1616,6 +1664,29 @@ export function applyWidgetWrite(
       // OBSERVED — so this can never turn into a pre-emptive refusal of a widget
       // that would have worked. Diagnosis, never a gate.
       describeNonValueBearingWidget(w, targetNode);
+  } else if (boundProperty?.reachable && !matchesExpected(boundPropertyActual)) {
+    // #1268 / comfyui-mcp#1658 — the widget kept the value and the node's own bound
+    // property did NOT. This is the read the old verification never took: `w.value` came
+    // back equal to what was assigned to it two statements earlier, which is true whether
+    // or not the write reached anything the node reads.
+    //
+    // Compared against `expected` — the value that was WRITTEN to the property — and not
+    // against `w.value`. That distinction is what keeps a legitimate write passing: when a
+    // widget callback normalizes `w.value` (a numeric grid snapping 4096 to 4097, #805),
+    // the property still holds 4096 and the two stores diverge, but an ON-CANVAS edit
+    // leaves them diverged in exactly the same way — litegraph's `BaseWidget.setValue`
+    // calls `setProperty` BEFORE the callback runs. Failing there would refuse a write the
+    // UI itself performs. What this branch catches is the property not holding what was
+    // written to it at all: `onPropertyChanged` returning false, which litegraph documents
+    // as the abort signal and honours by restoring the previous value.
+    failure = boundPropertyFailure({
+      property: boundProperty.property,
+      widgetName: w.name,
+      nodeId: targetNode.id,
+      expected,
+      actual: boundPropertyActual,
+      unreadable: boundPropertyActual === UNREADABLE_PROPERTY,
+    });
   } else if (parentWidget && !matchesExpected(parentWidget.value)) {
     failure =
       `Promoted rail widget "${parentWidget.name}" on subgraph node ${node.id} did not retain ` +
@@ -1841,6 +1912,18 @@ export function applyWidgetWrite(
           /* restore best-effort; read-back below is authoritative */
         }
       }
+      // #1268 — restore the BOUND PROPERTY before the widget values, through the same
+      // `setProperty` litegraph uses, so the node's own `onPropertyChanged` sees the
+      // rollback the way it sees any other property change. Its last step copies the
+      // restored value into the bound widget, and `w.value = previous` follows, so the
+      // widget ends on its own captured value either way.
+      if (boundProperty?.reachable) {
+        try {
+          targetNode.setProperty(boundProperty.property, boundProperty.previous);
+        } catch {
+          /* restore best-effort; read-back below is authoritative */
+        }
+      }
       try {
         w.value = previous;
       } catch {
@@ -1871,6 +1954,19 @@ export function applyWidgetWrite(
     // object IN PLACE (which an identity compare would miss), are ALL detected.
     let rollbackFailed = null;
     if (!structurallyEqual(w.value, previousClone)) rollbackFailed = `inner "${w.name}"`;
+    // #1268 — the bound property must be back to its captured value too. A node whose
+    // `onPropertyChanged` refuses the write ALSO refuses the restore, which leaves the
+    // node holding a value neither the caller nor the previous state asked for; that is
+    // an honest partial state and is reported as one rather than hidden behind a clean
+    // rollback. Compared structurally against the pre-mutation clone, exactly as the
+    // widget values are, so a hook mutating a restored object in place is caught.
+    if (boundProperty?.reachable) {
+      const restored = readBoundProperty();
+      if (restored === UNREADABLE_PROPERTY || !structurallyEqual(restored, previousPropertyClone)) {
+        const label = `bound property "${boundProperty.property}"`;
+        rollbackFailed = rollbackFailed ? `${rollbackFailed} and ${label}` : label;
+      }
+    }
     if (parentWidget && !structurallyEqual(parentWidget.value, previousParentClone)) {
       rollbackFailed = rollbackFailed
         ? `${rollbackFailed} and rail "${parentWidget.name}"`
@@ -2026,6 +2122,37 @@ export function applyWidgetWrite(
           // a check that did not happen. The cross-check above is what establishes it, and
           // only a match on the serializing rail counts — never a #477 display proxy.
           ...(railValidated ? { promoted_rail_validated: true } : {}),
+        }
+      : {}),
+    // #1268 / comfyui-mcp#1658 — WHAT THE VERIFICATION ACTUALLY ESTABLISHED for a widget
+    // litegraph binds to one of its node's own properties. Two mutually exclusive shapes,
+    // and the second is the whole point of this pair of issues:
+    //
+    //   bound_property             the property was driven with `setProperty` and READ BACK
+    //                              holding the written value. The effect is established, not
+    //                              just the assignment.
+    //   bound_property_unverified  the node declares the property but exposes no way to
+    //                              drive or read it from here. The widget's stored value was
+    //                              verified and the value the NODE reads was not — reported
+    //                              as UNKNOWN on a successful write, because "success" for a
+    //                              value that may be about to be replaced is the false claim
+    //                              both reporters received, and a refusal would block writes
+    //                              that are very likely fine.
+    //
+    // Neither field appears for a widget with no `options.property`, which is every stock
+    // ComfyUI widget built from /object_info — those replies are byte-identical to before.
+    ...(boundProperty?.reachable
+      ? { bound_property: { name: boundProperty.property, previous: boundProperty.previous } }
+      : {}),
+    ...(boundProperty && !boundProperty.reachable
+      ? {
+          bound_property_unverified: { name: boundProperty.property, reason: boundProperty.reason },
+          bound_property_note: boundPropertyUnverifiedNote({
+            property: boundProperty.property,
+            widgetName: w.name,
+            nodeId: targetNode.id,
+            reason: boundProperty.reason,
+          }),
         }
       : {}),
     // #507/#1126 — the empty-list acceptance is what admitted the value. Reported here so a

--- a/web/js/lib/widget-write.js
+++ b/web/js/lib/widget-write.js
@@ -1545,8 +1545,18 @@ export function applyWidgetWrite(
     // reads back clean and is overwritten by the node's next `setProperty`.
     //
     // Inside the SAME undo envelope as the value assignments, so this cannot land while
-    // the widget write rolls back. `setProperty` copies the value into the bound widget as
-    // its last step; `w.value` is already `coerced`, so that copy is a no-op assignment.
+    // the widget write rolls back.
+    //
+    // WHAT THE COPY-BACK COSTS, stated rather than waved at. `setProperty`'s last step
+    // assigns the value into the bound widget. On a plain data-property widget that is a
+    // no-op — `w.value` already holds `coerced`. On a widget whose `value` is an ACCESSOR
+    // (ComfyUI's DOM widgets are: `set value(v) { options.setValue?.(v); callback?.(…) }`)
+    // it runs that setter a second time, so a bound DOM widget's callback fires once more
+    // than it would for an unbound one. That is not a regression introduced here: it is
+    // exactly what `BaseWidget.setValue` does on an on-canvas edit of the same widget —
+    // assign, `setProperty`, then the callback. Matching the interactive path is the whole
+    // point, and the alternative (assigning `properties` and invoking `onPropertyChanged`
+    // by hand) would skip a `setProperty` a pack has overridden.
     //
     // A throw from here is captured by the same catch as everything else in this envelope
     // and stays UNATTRIBUTED — `onPropertyChanged` is a node's own code and this is not
@@ -1629,6 +1639,7 @@ export function applyWidgetWrite(
   // rolls back rather than being reported as verified.
   const UNREADABLE_PROPERTY = Symbol("bound property unreadable");
   const readBoundProperty = () => {
+    if (!boundProperty) return UNREADABLE_PROPERTY;
     try {
       const props = targetNode.properties;
       if (!props || typeof props !== "object") return UNREADABLE_PROPERTY;


### PR DESCRIPTION
## The shared mechanism

`applyWidgetWrite` decided every `panel_set_widget` by assigning `w.value = coerced` and then
reading `w.value` back (`web/js/lib/widget-write.js:1605` on the base commit — the audit's line
number is exact). That comparison is a **tautology**: it confirms the assignment, never the
effect. It cannot distinguish a write that reached what the node reads from a write that landed
on a view of state held somewhere else, and both reporters got a clean success followed by the
old value on the next read.

The verification chain in `applyWidgetWrite` is the **only** place a `panel_set_widget` verdict
is computed — I checked. The four sibling guards (#983 rgthree Fast Groups, #314 LTXDirector,
#506 PromptRelay, comfyui-mcp#1569 Ideogram4) are *pre-write* refusals keyed on node type, not
verifications. The audit's other clause holds too: `onWidgetChanged` has zero hits repo-wide.

## What this changes

LiteGraph gives one of those "somewhere else" stores a **declared, first-party name**, and this
PR is scoped to exactly that one. A widget may carry `options.property`, naming an entry in its
own node's `properties` map, and litegraph keeps the two in step in both directions — quoted
from the installed ComfyUI frontend 1.48.7, not inferred:

```js
// lib/litegraph/src/widgets/BaseWidget.ts — the INTERACTIVE edit path
this.value = v
if (this.options?.property && node.properties[this.options.property] !== undefined) {
  node.setProperty(this.options.property, v)
}
this.callback?.(this.value, canvas, node, pos, e)

// lib/litegraph/src/LGraphNode.ts#setProperty — the reverse leg
this.properties[name] = value
if (this.onPropertyChanged?.(name, value, prev_value) === false) this.properties[name] = prev_value
for (const w of this.widgets) if (w.options.property == name) { w.value = value; break }
```

A bare `w.value = x` — which is what a programmatic write did — updated **one** of the two
stores. `node.properties[p]` kept the old value, and the node's next `setProperty` pushed the
old value straight back into `w.value`. Clean at write time, gone by the next read.

`applyWidgetWrite` now, for a widget that declares `options.property` on a node that carries it:

* **drives** the property with `node.setProperty(...)`, in litegraph's own position (after the
  value assignments, before the widget callback), inside the same undo envelope;
* **verifies the effect** by reading `node.properties[p]` back after `afterChange` — the read
  the old verification never took. A property that did not take the written value fails the
  write and rolls **both** stores back, mirroring the #366 rail check;
* **rolls the property back** through `setProperty` on any failure, and reports an honest
  partial state if the restore did not land;
* reports `bound_property: {name, previous}` on success — the observable that proves the effect
  rather than the request.

Because `setProperty` now runs inside the envelope, the property also enters the undo delta; it
never did before.

The copy-back cost is stated in the code rather than waved at: on an accessor-backed widget
(ComfyUI's DOM widgets are — `set value(v) { options.setValue?.(v); callback?.(…) }`)
`setProperty`'s last step runs the setter a second time. That is not introduced here; it is
exactly what `BaseWidget.setValue` does on an on-canvas edit of the same widget.

## How UNKNOWN is represented

When the node **declares** the property but exposes no `setProperty`, `w.value` is provably not
the only store, and the panel can neither drive the other one nor read the effect back. That is
neither success nor failure, so the result carries `bound_property_unverified: {name, reason}`
plus `bound_property_note` on an **otherwise successful** write: the widget's stored value was
verified, the value the node reads was not, and the note routes the caller to
`panel_query_graph` / `panel_set_property`. A refusal there would block writes that are very
likely fine; a plain success is the false claim these two issues are about.

A property the node does **not** carry is deliberately not classified at all — that is
litegraph's own condition (`node.properties[p] !== undefined`), and with the property absent an
on-canvas edit syncs nothing either.

## The opposite harm

Every stock ComfyUI widget is built from `/object_info` and carries no `options.property`, so
its reply is byte-identical to before and no new code runs. Two tests pin that: a plain
`KSampler.steps` write (no new fields, `node.properties` untouched), and a **bound numeric
widget whose callback normalizes** the value (#805) — litegraph calls `setProperty` *before* the
callback, so an on-canvas edit leaves the same divergence, and failing it would refuse a write
the UI itself performs. It still reports `normalized: true`, not a failure.

This also deliberately does **not** pair a widget to a property by name similarity. #698 refused
that for good reason; nothing is paired here — the node's own author declared the name.

## Refutation

Four candidate general fixes were tried against the frontend's own source and **rejected**.
Recording them so the next pass does not re-tread them.

1. **Verify by calling `serializeValue()`.** It is what the queue reads
   (`src/utils/executionUtil.ts`:
   `widget.serializeValue ? await widget.serializeValue(node, i) : widget.value`), but calling it
   *does work*: core `uploadAudio.ts` **stops an in-progress recording** inside its serializer and
   `webcamCapture.ts` **captures and uploads a frame**. Both are `async`, so two samples are never
   comparable either. Same conclusion comfyui-mcp#1569 reached.
2. **Treat "the widget defines `serializeValue`" as unverified.** Measured against 1.48.7: core
   `Comfy.DynamicPrompts` installs one on **every** widget flagged `dynamicPrompts` (all multiline
   text), `saveImageExtraOutput.ts` on `SaveImage.filename_prefix`, and `ComponentWidgetImpl` on
   every Vue-node widget — and all three **read `widget.value`**. Presence is therefore not
   evidence of divergence, and the signal would fire on the most common writes in the product.
3. **Subscribe to `onWidgetChanged`.** A trap, and its zero hits should stay zero. It is fired
   from exactly one place — `BaseWidget.setValue(value, {e, node, canvas})`, the interactive path.
   A plain `w.value = x` does not fire it, and neither does a pack's own revert, so the listener
   would be silent for precisely the case it was installed for. It is also a single slot on the
   node, so installing one would clobber a pack's.
4. **Re-read after a settle window.** A bounded window cannot distinguish "did not revert" from
   "has not reverted yet", and #1658's revert is on the node's own APPLY. Not shipped: its value
   is speculative and its verdict would be a fresh instance of the same defect.

## Mutation runs (the fix deleted, the tests watched)

| deleted | result |
| --- | --- |
| the `setProperty` call in the write envelope | 3 fail |
| the verification `else if` branch | 1 fail |
| the rollback restore | 1 fail |
| the result fields | 3 fail |
| the `boundPropertyState` classification | 5 fail |

All five hunks are pinned at the **call site** (`applyWidgetWrite`), not only in the helper.

The `setProperty` fixture in the test file is transcribed from litegraph's source. The first
draft of it had `w.value = this.properties[name]`; the real one has `w.value = value`, and
correcting that is what exposed the reachable case — a node whose `onPropertyChanged` returns
`false` ends up with the widget showing the new value and the property holding the old one.

## Per-issue verdict

* **panel#1268** — the shared cause is confirmed and one of its three named stores is closed.
  The reported node is `AIO_Preprocessor` from `comfyui_controlnet_aux`, which ships **no web JS
  at all** (checked against the installed pack), so its `preprocessor` combo is frontend-built
  and carries no `options.property`: this change does not fire for it. What the reporter observed
  — the value gone by the next read — is the tautology this PR names, but I could not establish
  the specific revert path on their build (Linux / ROCm / frontend 1.45.20) and will not publish
  a mechanism I did not measure. **Not closed by this.**
* **comfyui-mcp#1658** — `AnimaRegionalCanvasInline` is not installed on this machine, so the
  pack's own source could not be read, and I will not guess at it. The reporter names
  `node.properties.animaPrompts` as authoritative; if that node binds its textareas with
  `options.property` this change fixes it outright, and if it keeps a name-keyed map instead it
  does not. **Not closed by this.**

Neither issue should be closed on this PR. It closes a real, reachable member of the family — a
widget whose declared property store the write path never touched — and removes the tautology
for that case; the two reported instances need their packs in hand.

The underlying cause of #1268 and the underlying cause of comfyui-mcp#1658 are the same
verification tautology, which is why they were worked as one family.

## Out of scope, noticed in passing

`web/js/lib/unpack-promoted-values.js:267` (#979, the subgraph-unpack path) carries the same
`w.value`-only read-back. Different tool, different issue — left alone.

## Verification

* `npm run test:unit` — **5155 tests, 5153 pass, 1 fail, 1 todo**, gates included
  (i18n-check, i18n-render-check, check-tool-vocabulary, check-panel-scope all OK). The one
  failure is `#671 verifyInstalled … fast-draining install`, the documented wall-clock flake:
  **125/125 in isolation**, and this box was running two Playwright suites at the time.
* Playwright `--workers=1` against a **private** ComfyUI (its own base directory, port 8288, all
  custom nodes disabled except this pack). The owner's :8188 rig was not touched and no borrowed
  instance was used. **Delta: zero.** Base `6f7c9603` and this branch, run against two identical private
  instances: **20 failed / 55 passed on both**, in 10.2 m and 10.0 m. The failure SETS differ
  by one test each way (`agent-drive.spec.ts:113` failed on base only,
  `workflow-chat-identity.spec.ts:333` on this branch only), and per-FILE triage settles both
  as load flakes: `workflow-chat-identity.spec.ts` alone fails the SAME 4 of 6 on base and on
  this branch. The 19 common failures are environmental — this rig's ComfyUI is CPU-only with
  every other custom node disabled, and they are chat-persistence / IndexedDB / streaming
  specs that touch no widget-write code. No assertion was loosened.
* **This PR is ungated.** `codex exec` is exhausted until 2026-08-19 20:43 and `claude-gate.mjs`
  is blocked on the weekly limit, so no independent adversarial review was run — stated plainly
  rather than implied. Gating is the orchestrator's call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
