### PR TITLE
fix(1300): a group containing rgthree Label nodes moves instead of being refused

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project are documented here. This project adheres to
 ## [Unreleased]
 
 ### Fixed
+- a group that encloses rgthree Label nodes now moves, instead of being refused because those nodes' visual bounds are not the panel's generic footprint — the same nodes already moved fine one-by-one with panel_edit_node (#1300)
 - a subgraph preview widget is promoted through the frontend's previewExposure store, and a failed link-only promote no longer hides behind a missing promotion store (#1271)
 
 ## [0.15.3] - 2026-08-19

--- a/browser_tests/unit/group-geometry.test.mjs
+++ b/browser_tests/unit/group-geometry.test.mjs
@@ -23,6 +23,7 @@ import {
   syncGraphNodeAreas,
   moveGroupMembers,
   nodeAreaIsLive,
+  nodeAreaOriginTracks,
 } from "../../web/js/lib/group-geometry.js";
 
 // Minimal fixtures. No boundingRect => nodeFocusBounds falls back to pos/size
@@ -822,11 +823,15 @@ test("#813 a rect exposed by a COPYING getter is not reported moved (review P2)"
   assert.deepEqual(real, [100, 70, 80, 30], "and the underlying rect really was never updated");
 });
 
-test("#813 an EXPANDED node's authoritative extents are not overwritten (review P2)", () => {
+test("#813/#1300 an EXPANDED node's authoritative extents are not overwritten (review P2)", () => {
   // A custom node whose updateArea() computes visible bounds reaching past `size` — a
   // legitimate engine answer that differs from the panel's generic footprint model. The
   // collapsed repair must not fire here: overwriting the engine's rect and reporting
   // success would make later rect-first membership wrong.
+  //
+  // #813 left this node STUCK rather than overwrite. That is the #1300 false
+  // refusal: the position DID land, the origin DID track, only the extent model
+  // disagreed. The node must MOVE, and the engine's extents must survive.
   const n = {
     id: 31,
     pos: [100, 100],
@@ -840,12 +845,91 @@ test("#813 an EXPANDED node's authoritative extents are not overwritten (review 
 
   const r = moveGroupMembers([n], 10, 10);
 
-  assert.deepEqual(r.stuck, [n], "an expanded node with a non-generic rect is still stuck");
+  assert.deepEqual(r.stuck, [], "an expanded node whose origin tracked is not stuck");
+  assert.deepEqual(r.moved, [n], "…it moved");
+  assert.deepEqual(n.pos, [110, 110]);
   assert.deepEqual(
     [...n.boundingRect],
     [110, 80, 400, 300],
     "and its authoritative extents survive — never replaced by the 200x130 generic model",
   );
+});
+
+test("#1300 a Label (rgthree)-shaped member moves even though its rect is not the generic footprint", () => {
+  // The reporter's nodes 579/594/606: frontend-only Label (rgthree). Their
+  // updateArea() writes font-scaled visual bounds that are much larger than
+  // size, so nodeAreaIsLive is false by construction. pinned is not the
+  // discriminator — 579 was unpinned, 594 and 606 were pinned, all three
+  // refused. panel_edit_node moved each of them.
+  const label = (id, pinned) => ({
+    id,
+    type: "Label (rgthree)",
+    pos: [100, 100],
+    size: [210, 56],
+    flags: { pinned },
+    boundingRect: [100, 70, 420, 180],
+    updateArea() {
+      this.boundingRect = [this.pos[0], this.pos[1] - 30, 420, 180];
+    },
+  });
+  const unpinned = label(579, false);
+  const pinned = label(594, true);
+
+  const r = moveGroupMembers([unpinned, pinned], 50, 25);
+
+  assert.deepEqual(r.stuck, [], "neither pinned nor unpinned Label is stuck");
+  assert.deepEqual(r.moved, [unpinned, pinned]);
+  assert.deepEqual(unpinned.pos, [150, 125]);
+  assert.deepEqual(pinned.pos, [150, 125]);
+  assert.deepEqual([...unpinned.boundingRect], [150, 95, 420, 180], "engine extents survive");
+  assert.deepEqual([...pinned.boundingRect], [150, 95, 420, 180]);
+});
+
+test("#1300 an expanded copying-getter rect is still stuck (#408 preserved)", () => {
+  // Same copying-getter shape as the #813 collapsed test, but expanded: the
+  // origin-tracks check must re-read, not trust a throwaway write, or a Label
+  // whose boundingRect getter returns a copy would report moved and then vanish
+  // from the group on the next rect-first membership read.
+  const real = [100, 70, 420, 180];
+  const n = {
+    id: 606,
+    type: "Label (rgthree)",
+    pos: [100, 100],
+    size: [210, 56],
+    get boundingRect() {
+      return [...real];
+    },
+    updateArea() { /* writes to a copy, dropped */ },
+  };
+
+  const r = moveGroupMembers([n], 50, 25);
+
+  assert.deepEqual(r.moved, [], "a rect whose writes cannot be observed is not 'moved'");
+  assert.deepEqual(r.stuck, [n]);
+  assert.deepEqual(real, [100, 70, 420, 180], "and the underlying rect really was never updated");
+});
+
+test("#1300 an expanded frozen rect is still stuck (#408 preserved)", () => {
+  const n = {
+    id: 607,
+    type: "Label (rgthree)",
+    pos: [100, 100],
+    size: [210, 56],
+    boundingRect: Object.freeze([100, 70, 420, 180]),
+  };
+
+  const r = moveGroupMembers([n], 50, 25);
+
+  assert.deepEqual(r.moved, [], "an uncorrectable rect still refuses");
+  assert.deepEqual(r.stuck, [n]);
+});
+
+test("#1300 nodeAreaOriginTracks: origin shifted by the delta, extents ignored", () => {
+  const n = { boundingRect: [110, 80, 420, 180] };
+  assert.equal(nodeAreaOriginTracks(n, [100, 70], 10, 10), true);
+  assert.equal(nodeAreaOriginTracks(n, [100, 70], 0, 0), false, "wrong delta");
+  assert.equal(nodeAreaOriginTracks({ boundingRect: null }, [100, 70], 10, 10), true, "no cached rect");
+  assert.equal(nodeAreaOriginTracks({ get boundingRect() { throw new TypeError("gone"); } }, [100, 70], 10, 10), false);
 });
 
 test("#813 a node whose flags accessor THROWS is stuck, not repaired", () => {

--- a/browser_tests/unit/move-group.test.mjs
+++ b/browser_tests/unit/move-group.test.mjs
@@ -2210,6 +2210,47 @@ test("moveReroutePoints skips malformed points and never throws", () => {
   assert.doesNotThrow(() => moveReroutePoints(undefined, 1, 1));
 });
 
+test("#1300 the reported move: a group enclosing rgthree Label nodes moves, whole, with no partial", () => {
+  // The reporter's groups 7 and 15: each enclosed one or more Label (rgthree)
+  // nodes whose updateArea() writes font-scaled visual bounds far past `size`.
+  // panel_move_group classified them stuck AFTER writing their positions
+  // ("would not accept a new position (node 594, node 606)") and rolled back;
+  // panel_edit_node moved the same ids. pinned is not the discriminator — 579
+  // was unpinned, 594/606 were pinned.
+  const label = (id, pos, pinned) => ({
+    id,
+    type: "Label (rgthree)",
+    pos: [...pos],
+    size: [210, 56],
+    flags: { pinned },
+    boundingRect: [pos[0], pos[1] - 30, 420, 180],
+    updateArea() {
+      this.boundingRect = [this.pos[0], this.pos[1] - 30, 420, 180];
+    },
+  });
+  const sampler = node(1, [80, 200], [200, 100]);
+  const unpinned = label(579, [100, 100], false);
+  const pinnedA = label(594, [120, 140], true);
+  const pinnedB = label(606, [140, 160], true);
+  const g = group(15, [50, 50, 500, 400], "LTX column");
+  const graph = makeGraph({ nodes: [sampler, unpinned, pinnedA, pinnedB], groups: [g] });
+
+  const res = realMoveGroup(graph)({ group_id: 15, pos: [1500, -40] });
+
+  assert.equal(res.moved.nodes, 4, "sampler + three Labels moved — no refusal, no partial");
+  assert.deepEqual(sampler.pos, [1530, 110]);
+  assert.deepEqual(unpinned.pos, [1550, 10]);
+  assert.deepEqual(pinnedA.pos, [1570, 50]);
+  assert.deepEqual(pinnedB.pos, [1590, 70]);
+  assert.deepEqual(g._bounding, [1500, -40, 500, 400]);
+  assert.deepEqual(
+    res.group.node_ids.sort((a, b) => a - b),
+    [1, 579, 594, 606],
+    "and every enclosed node is still reported as a member at the new box",
+  );
+  assert.deepEqual([...unpinned.boundingRect], [1550, -20, 420, 180], "Label extents stay the engine's, not the generic model");
+});
+
 test("#813 the reported move: a group of COLLAPSED members moves, whole, with no partial", () => {
   // The reporter's group 6 ("Face Detail & Output"): four collapsed size:[225,0] nodes,
   // moved to [1500,-40]. Every one was called "would not accept a new position" — after its

--- a/web/js/lib/group-geometry.js
+++ b/web/js/lib/group-geometry.js
@@ -360,6 +360,50 @@ export function nodeAreaIsLive(node) {
   }
 }
 
+/**
+ * Did this node's cached boundingRect ORIGIN shift by (dx, dy)?
+ *
+ * Distinct from `nodeAreaIsLive`, which asks whether the WHOLE rect matches the
+ * panel's generic `[x, y-30, w, h+30]` model. A custom node (Label (rgthree) and
+ * anything else whose `updateArea()` draws past `size`) has a live, engine-
+ * authoritative rect whose extents will NEVER match that model. Demanding the
+ * generic footprint made `panel_move_group` refuse a group of those nodes after
+ * their positions had already been written, while `panel_edit_node` — which never
+ * asks this question — moved the same nodes fine (#1300).
+ *
+ * Membership is still rect-first: if the origin did not track the move, the next
+ * geometric read would leave the node in the group it has actually left, so this
+ * returns false and the caller treats the node as stuck (#408). Re-reads
+ * `boundingRect` so a copying getter (writes to a throwaway) cannot fake a pass.
+ *
+ * `originBefore` is the `[x, y]` origin SNAPSHOTTED before the position write.
+ * Null/missing means there was no cached rect to compare: a missing rect means
+ * membership reads use live pos/size, and a rect that only appeared after the
+ * write is the engine's answer for the NEW position. Either way the origin cannot
+ * be stale from the old one, so a finite origin (or no rect at all) is enough.
+ */
+export function nodeAreaOriginTracks(node, originBefore, dx, dy) {
+  try {
+    const br = node?.boundingRect;
+    if (!br || br.length !== 4) return true; // nothing cached ⇒ reads use live pos
+    const f32 = isFloat32(br);
+    if (!originBefore || originBefore.length !== 2) {
+      const x = Number(br[0]);
+      const y = Number(br[1]);
+      return Number.isFinite(x) && Number.isFinite(y);
+    }
+    const ox = Number(originBefore[0]);
+    const oy = Number(originBefore[1]);
+    if (!Number.isFinite(ox) || !Number.isFinite(oy)) return false;
+    const wantDx = Number(dx);
+    const wantDy = Number(dy);
+    if (!Number.isFinite(wantDx) || !Number.isFinite(wantDy)) return false;
+    return samePoint(Number(br[0]), ox + wantDx, f32) && samePoint(Number(br[1]), oy + wantDy, f32);
+  } catch {
+    return false; // an unreadable rect cannot be shown to have tracked
+  }
+}
+
 export function syncNodeArea(node, forceCollapsed = false) {
   try {
     // Read the live geometry FIRST, even when there is no cached rect to write.
@@ -511,6 +555,26 @@ export function moveGroupMembers(members, dx, dy) {
       continue;
     }
     attempted.push([n, px, py]);
+    // Snapshot the cached origin BEFORE the write so the #1300 origin-tracks
+    // check can delta-compare afterwards. A throwing accessor is "unreadable",
+    // not "no rect": we cannot prove the origin tracked a value we never captured.
+    let originBefore = null;
+    let originReadable = false;
+    try {
+      const br = n?.boundingRect;
+      if (br && br.length === 4) {
+        const ox = Number(br[0]);
+        const oy = Number(br[1]);
+        if (Number.isFinite(ox) && Number.isFinite(oy)) {
+          originBefore = [ox, oy];
+          originReadable = true;
+        }
+      } else {
+        originReadable = true; // no cached rect ⇒ membership reads use live pos
+      }
+    } catch {
+      originReadable = false;
+    }
     let landedExactly = false;
     try {
       landedExactly = writePoint(n, "pos", px + dx, py + dy);
@@ -553,17 +617,14 @@ export function moveGroupMembers(members, dx, dy) {
       // left. The question changes from "does the rect already agree" to "can the rect be
       // MADE to agree", which is the one the caller actually needs answered.
       //
-      // TWO THINGS THE CORRECTION IS DELIBERATELY NOT (both found in review):
+      // TWO THINGS THE COLLAPSED CORRECTION IS DELIBERATELY NOT (both found in review):
       //
-      // 1. IT IS NOT UNGATED. Only a COLLAPSED node gets it. An expanded node's
-      //    `updateArea()` may authoritatively compute extents that legitimately differ from
-      //    the generic `[x, y-30, size0, size1+30]` model — visible bounds that reach past
-      //    `size`, on a custom node that draws outside its box. Forcing the generic
-      //    footprint there would overwrite the engine's own answer and then report success,
-      //    and rect-first membership would be wrong afterwards. The reported defect is
-      //    specifically the collapsed-PILL disagreement, so that is all this repairs; an
-      //    expanded node with an uncorrectable rect is still stuck, exactly as before.
-      //    A `flags` accessor that THROWS reads as not-collapsed, so it fails closed.
+      // 1. IT IS NOT UNGATED. Only a COLLAPSED node gets the pill-force. An expanded
+      //    node's `updateArea()` may authoritatively compute extents that legitimately
+      //    differ from the generic `[x, y-30, size0, size1+30]` model — visible bounds
+      //    that reach past `size`, on a custom node that draws outside its box. Forcing
+      //    the generic footprint there would overwrite the engine's own answer and then
+      //    report success, and rect-first membership would be wrong afterwards.
       //
       // 2. IT DOES NOT TRUST `syncNodeArea`'s OWN VERDICT ALONE. `boundingRect` can be an
       //    accessor whose getter returns a FRESH array on every read — a shape this file
@@ -573,20 +634,42 @@ export function moveGroupMembers(members, dx, dy) {
       //    node's real rect never changed: the move would report the node moved while the
       //    next membership read still saw the old rect and dropped it from the group. So the
       //    verdict is re-read through `nodeAreaIsLive`, which fetches the property again.
+      //
+      // panel#1300 — AN EXPANDED MEMBER WITH CUSTOM EXTENTS IS NOT STUCK EITHER.
+      //
+      // The #813 review left expanded custom-extent nodes stuck rather than overwrite
+      // their engine rect. That is the #1300 false refusal: `Label (rgthree)` (and any
+      // decorative node that draws past `size`) lands the position write, `updateArea()`
+      // shifts the origin by the same delta, and `nodeAreaIsLive` still fails because
+      // width/height are not the generic model. `panel_edit_node` never asks that
+      // question, so the same node moves fine one-by-one. The remedy is not to force
+      // the generic footprint (that is the overwrite #813 correctly refused) — it is
+      // to accept a rect whose ORIGIN tracked the move, extents and all.
       let isCollapsed = false;
+      let flagsReadable = true;
       try {
         isCollapsed = !!n?.flags?.collapsed;
       } catch {
-        // Unreadable flags ⇒ not eligible for the collapsed repair. Mutation reports
-        // flipping this to `true` as a SURVIVOR, and it is an equivalent mutant rather than
-        // a gap: `syncNodeArea` reads the same `flags` accessor through `wantedNodeArea`,
-        // so it throws, is caught there, and returns false — the node is stuck either way.
-        // Stated here so the next run does not re-chase it; the BEHAVIOUR is pinned by
-        // "a node whose flags accessor THROWS is stuck, not repaired".
+        // Unreadable flags ⇒ not eligible for the collapsed repair AND not eligible
+        // for the #1300 origin-tracks path. We cannot tell a collapsed pill from a
+        // custom-extent Label, so we cannot choose a verdict. Mutation reports
+        // flipping this to `true` as a SURVIVOR, and it is an equivalent mutant rather
+        // than a gap: `syncNodeArea` reads the same `flags` accessor through
+        // `wantedNodeArea`, so it throws, is caught there, and returns false — the
+        // node is stuck either way. Stated here so the next run does not re-chase
+        // it; the BEHAVIOUR is pinned by "a node whose flags accessor THROWS is
+        // stuck, not repaired".
+        flagsReadable = false;
         isCollapsed = false;
       }
-      if (!nodeAreaIsLive(n) && !(isCollapsed && syncNodeArea(n) && nodeAreaIsLive(n))) {
-        landedExactly = false;
+      if (isCollapsed) {
+        if (!nodeAreaIsLive(n) && !(syncNodeArea(n) && nodeAreaIsLive(n))) {
+          landedExactly = false;
+        }
+      } else if (!nodeAreaIsLive(n)) {
+        if (!flagsReadable || !originReadable || !nodeAreaOriginTracks(n, originBefore, dx, dy)) {
+          landedExactly = false;
+        }
       }
     } catch {
       landedExactly = false;


### PR DESCRIPTION
Fixes #1300 (related: #813, #408).

## The report

`panel_move_group` refused any group that enclosed a `Label (rgthree)` node:

```
refusing to move group 15: 2 enclosed item(s) would not accept a new position
(node 594, node 606) — move them out of the group (panel_edit_node) and retry…
NOTHING was moved.
```

`panel_edit_node {node_id: 579, pos: [...]}` moved that exact node and returned a normal before/after. Same for 594 and 606. `pinned` is not the discriminator: 579 was unpinned, 594 and 606 were pinned. The common factor is the frontend-only type `Label (rgthree)`.

## Root cause

This is the expanded-node twin of #813.

`moveGroupMembers` verifies the position write with `writePoint`, then **overrides** the verdict if `nodeAreaIsLive` is false. That check requires the cached `boundingRect` to equal **all four** components of the panel's generic `[x, y-30, size0, size1+30]` model.

`Label (rgthree)` (and any custom node that draws past `size`) has `updateArea()` write font-scaled visual bounds that will never match that model. The position write lands. The rect origin tracks the move. Only the extent model disagrees. `panel_edit_node` never asks this question, so the same node moves fine.

#813's review left this case stuck rather than overwrite the engine's extents with the generic footprint. That conservative choice *is* the #1300 false refusal.

## The fix

After a successful position write, an expanded member whose rect is not the generic footprint is accepted when the cached rect **origin** shifted by the same delta. Extents are left as the engine wrote them — the overwrite #813 correctly refused.

**#408 is not relaxed.** A frozen rect, a copying-getter rect, or a node whose `flags` accessor throws is still stuck. Membership is rect-first: an origin that cannot be shown to have tracked would report the node in a group it has left.

Collapsed members still take the #813 pill-force path. That repair stays ungated — it is not reused for expanded custom-extent nodes.

## Verification

Shipped path: `browser_tests/unit/move-group.test.mjs` extracts the real `graph_move_group` and moves a group enclosing a sampler plus three Label-shaped nodes (pinned and unpinned). No refusal, no partial, membership at the new box includes all four, Label extents stay the engine's.

Also pins: origin-tracks helper; Label-shaped `moveGroupMembers`; copying-getter and frozen expanded rects still stuck; the previous #813 "authoritative extents survive" fixture now expects MOVE rather than stuck.

```
node --test browser_tests/unit/group-geometry.test.mjs browser_tests/unit/move-group.test.mjs
148 pass, 0 fail
```
