### PR TITLE
fix(1298): missing-node mutation errors name the current live ids

### DIFF
--- a/browser_tests/unit/node-scope-locator.test.mjs
+++ b/browser_tests/unit/node-scope-locator.test.mjs
@@ -126,6 +126,75 @@ test("no root graph ⇒ the original message, unchanged", () => {
   assert.equal(describeMissingNode(5, null, true), "No node with id 5 in the current graph");
 });
 
+// ── #1298 current ids on a genuine miss ───────────────────────────────────
+//
+// Reporter: panel_remove_node(99) after a prior outline had shown 99, then the
+// user deleted nodes. The miss said only "not in the current graph" and sent
+// them to re-read — a second round-trip whose answer was already on the graph
+// the write had just searched. Naming the live ids lets the next mutation
+// retarget (or skip) without another outline.
+
+test("#1298 genuine miss lists the current live ids so a mutation can retarget", () => {
+  const root = sub([
+    node(1, { type: "CheckpointLoaderSimple" }),
+    node(3, { type: "KSampler" }),
+    node(8, { type: "SaveImage" }),
+  ]);
+  const msg = describeMissingNode(99, root, true);
+  assert.match(msg, /^No node with id 99/);
+  assert.match(msg, /not in any other scope either/);
+  assert.match(msg, /Current ids on the graph you are viewing:/);
+  assert.match(msg, /1 \(CheckpointLoaderSimple\)/);
+  assert.match(msg, /3 \(KSampler\)/);
+  assert.match(msg, /8 \(SaveImage\)/);
+  assert.ok(!/99 \(/.test(msg), "must not invent the missing id as live");
+  assert.match(msg, /Retarget using a current id/);
+});
+
+test("#1298 lists ids from the graph being viewed, not the root", () => {
+  // A subgraph-scoped write that misses must not hand back root ids: those are
+  // not addressable without exiting, and naming them would retarget the next
+  // mutation into the wrong scope.
+  const inner = sub([node(10, { type: "InnerA" }), node(11, { type: "InnerB" })]);
+  const root = sub([node(1, { type: "Root" }), node(9, { title: "S", subgraph: inner })]);
+  const msg = describeMissingNode(99, root, false, inner);
+  assert.match(msg, /10 \(InnerA\)/);
+  assert.match(msg, /11 \(InnerB\)/);
+  assert.ok(!/1 \(Root\)/.test(msg), "root ids would retarget a write into the wrong scope");
+});
+
+test("#1298 current-id list is capped so a large graph does not dump every id", () => {
+  const nodes = Array.from({ length: 60 }, (_, i) => node(i + 1, { type: "N" }));
+  const msg = describeMissingNode(999, sub(nodes), true);
+  assert.match(msg, /Current ids on the graph you are viewing:/);
+  assert.match(msg, /1 \(N\)/);
+  assert.match(msg, /40 \(N\)/);
+  assert.match(msg, /and 20 more/);
+  assert.ok(!/\b41 \(N\)/.test(msg), "the 41st id is past the cap");
+});
+
+test("#1298 empty current graph is said plainly", () => {
+  const msg = describeMissingNode(99, sub([]), true);
+  assert.match(msg, /currently has no nodes/);
+  assert.match(msg, /Re-read with panel_graph_outline/);
+  assert.ok(!/Current ids on the graph you are viewing:/.test(msg));
+});
+
+test("#1298 a current graph with no root still names live ids", () => {
+  // resolveNode can lose the root (getGraphCtx throws) and still holds the
+  // graph it just searched. That graph's ids are the ones a retarget can use.
+  const current = sub([node(4, { type: "CLIPTextEncode" })]);
+  const msg = describeMissingNode(99, null, true, current);
+  assert.match(msg, /^No node with id 99 in the current graph/);
+  assert.match(msg, /4 \(CLIPTextEncode\)/);
+  assert.match(msg, /Retarget using a current id/);
+});
+
+test("#1298 current-id listing never throws", () => {
+  const root = { get _nodes() { throw new Error("boom"); } };
+  assert.doesNotThrow(() => describeMissingNode(1, root, true));
+});
+
 // ── WIRING ────────────────────────────────────────────────────────────────
 test("WIRING: resolveNode builds its error through describeMissingNode", async () => {
   // resolveNode is module-private and shared by 20+ handlers, so the wiring is pinned
@@ -135,11 +204,22 @@ test("WIRING: resolveNode builds its error through describeMissingNode", async (
   assert.match(src, /import \{ describeMissingNode(?:, describeRailNodeTarget)? \} from "\.\/lib\/node-scope-locator\.js";/);
   const fn = src.slice(src.indexOf("function resolveNode(graph, nodeId) {"));
   const body = fn.slice(0, fn.indexOf("function normalizeLegacyNodeId"));
-  assert.ok(body.includes("describeMissingNode(nodeId, rootGraph, viewingRoot)"),
-    "the failure path must go through the locator");
+  assert.ok(body.includes("describeMissingNode(nodeId, rootGraph, viewingRoot, graph)"),
+    "the failure path must go through the locator with the live graph so current ids can be named");
   // The lookup itself must be unchanged — this is diagnostics only, never a wider search.
   assert.ok(body.includes("graph.getNodeById(canonicalNodeId(nodeId))"),
     "resolution must still be scoped to the current graph");
   // And the diagnostic must not be able to break the call.
   assert.ok(body.includes("} catch {"), "reading the root must be guarded");
+  // graph_save_subgraph used to throw the bare prefix and skip the locator, so a
+  // post-edit miss there named no current ids. Pin the one remaining production
+  // site onto resolveNode.
+  assert.ok(
+    /target = resolveNode\(graph, node_id\)/.test(src),
+    "graph_save_subgraph must resolve through the same miss path",
+  );
+  assert.ok(
+    !/throw new Error\(`No node with id \$\{node_id\} in the current graph`\)/.test(src),
+    "no production mutation may still throw the bare missing-id message",
+  );
 });

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -9526,7 +9526,9 @@ function resolveNode(graph, nodeId) {
     } catch {
       rootGraph = null;
     }
-    throw new Error(describeMissingNode(nodeId, rootGraph, viewingRoot));
+    // #1298 — pass the graph this lookup just searched so a genuine miss can
+    // name the current ids the next mutation can actually target.
+    throw new Error(describeMissingNode(nodeId, rootGraph, viewingRoot, graph));
   }
   return node;
 }
@@ -17319,8 +17321,7 @@ const GRAPH_TOOL_EXECUTORS = {
     const store = getSubgraphStore();
     let target = null;
     if (node_id != null) {
-      target = graph.getNodeById(canonicalNodeId(node_id));
-      if (!target) throw new Error(`No node with id ${node_id} in the current graph`);
+      target = resolveNode(graph, node_id);
       if (!target.subgraph) {
         throw new Error(`Node ${node_id} (${target.type}) is not a subgraph node`);
       }

--- a/web/js/lib/node-scope-locator.js
+++ b/web/js/lib/node-scope-locator.js
@@ -20,6 +20,13 @@
  *
  * This module answers the question the failure raises: WHERE is it, then?
  *
+ * #1298 is the sibling when the answer is NOWHERE. A mutation after a graph
+ * change (the user deleted nodes; a load remapped ids) used to stop at "not in
+ * the current graph" and send the caller to re-read. The re-read is a second
+ * round-trip they already had the evidence for: the live graph the write just
+ * searched. The genuine-miss path now names the current ids on the graph the
+ * mutation applied to, so the next call can retarget without another outline.
+ *
  * SEARCH IS BOUNDED AND NON-THROWING. It runs only on the failure path, and any
  * unexpected shape simply ends that branch — a diagnostic that throws would replace a
  * bad error with a worse one.
@@ -41,6 +48,13 @@
 
 /** Depth guard for a pathological/looping graph. Real workflows nest a handful deep. */
 const MAX_DEPTH = 12;
+
+/**
+ * Cap on ids named in a genuine-miss error. The list exists so a mutation can
+ * retarget without another outline call (#1298); it is not a substitute for
+ * outline, so a 200-node dump would hide the diagnosis.
+ */
+const MAX_CURRENT_IDS = 40;
 
 function nodesOf(graph) {
   const raw = graph?._nodes ?? graph?.nodes;
@@ -108,18 +122,66 @@ export function countSubgraphs(rootGraph) {
 }
 
 /**
+ * Current ids on the graph a mutation actually applied to, so a genuine miss
+ * can name what IS addressable (#1298). Best-effort and non-throwing: a
+ * diagnostic that throws replaces a bad error with a worse one.
+ *
+ * The missing id is filtered out even if `_nodes` and `getNodeById` have
+ * drifted — listing it as live would send the caller back at the same miss.
+ */
+function currentIdSuffix(graph, nodeId) {
+  if (!graph) return "";
+  try {
+    const wanted = nodeId == null ? "" : String(nodeId);
+    const parts = [];
+    for (const n of nodesOf(graph)) {
+      if (n?.id == null) continue;
+      if (wanted && String(n.id) === wanted) continue;
+      const type =
+        typeof n.type === "string" && n.type
+          ? n.type
+          : typeof n.comfyClass === "string" && n.comfyClass
+            ? n.comfyClass
+            : "";
+      parts.push(type ? `${n.id} (${type})` : `${n.id}`);
+    }
+    if (!parts.length) {
+      return (
+        "The graph you are viewing currently has no nodes. " +
+        "Re-read with panel_graph_outline before retrying."
+      );
+    }
+    const shown = parts.slice(0, MAX_CURRENT_IDS);
+    const extra =
+      parts.length > MAX_CURRENT_IDS ? `, …and ${parts.length - MAX_CURRENT_IDS} more` : "";
+    return (
+      `Current ids on the graph you are viewing: ${shown.join(", ")}${extra}. ` +
+      `Retarget using a current id; re-read with panel_graph_outline if you need wiring.`
+    );
+  } catch {
+    return "";
+  }
+}
+
+/**
  * The message for a node id that did not resolve in the current graph.
  *
  * Always begins `No node with id <id>` so existing callers/tests that match that
  * prefix are unaffected.
  *
  * @param {number|string} nodeId
- * @param {object|null} rootGraph  null/absent ⇒ the plain message, unchanged
+ * @param {object|null} rootGraph  null/absent ⇒ the plain message, unless
+ *   `currentGraph` can still name live ids
  * @param {boolean} viewingRoot    true when the current graph IS the root
+ * @param {object|null} [currentGraph]  the graph the mutation applied to (the
+ *   one `getNodeById` just searched). When omitted, the root is used only if
+ *   `viewingRoot` is true — a subgraph view must not be told the root's ids.
  */
-export function describeMissingNode(nodeId, rootGraph, viewingRoot) {
+export function describeMissingNode(nodeId, rootGraph, viewingRoot, currentGraph) {
   const base = `No node with id ${nodeId} in the current graph`;
-  if (!rootGraph) return base;
+  const graphForIds = currentGraph ?? (viewingRoot ? rootGraph : null);
+  const ids = currentIdSuffix(graphForIds, nodeId);
+  if (!rootGraph) return ids ? `${base}. ${ids}` : base;
 
   const found = locateNodeAcrossScopes(rootGraph, nodeId);
   if (!found) {
@@ -128,7 +190,7 @@ export function describeMissingNode(nodeId, rootGraph, viewingRoot) {
       `${base} — and it is not in any other scope either ` +
       `(searched the root graph${subs ? ` and ${subs} subgraph(s)` : ""}). ` +
       `The id may be from a different workflow, or the node was removed. ` +
-      `Re-read with panel_graph_outline before retrying.`
+      (ids || `Re-read with panel_graph_outline before retrying.`)
     );
   }
 


### PR DESCRIPTION
## Summary

`panel_remove_node` for node 99 returned `No node with id 99 in the current graph` after a prior `panel_graph_outline` had shown that node, then the user deleted nodes. The miss sent the caller to re-read — a second round-trip whose answer was already on the graph the write had just searched. That failed an otherwise-done repair step.

## Fix

A genuine miss (`describeMissingNode` when the id is in no scope) now names the **current ids on the graph the mutation applied to**, with types, so the next call can retarget without another outline:

```
No node with id 99 in the current graph — and it is not in any other scope either
(searched the root graph). The id may be from a different workflow, or the node
was removed. Current ids on the graph you are viewing: 1 (CheckpointLoaderSimple),
3 (KSampler), 8 (SaveImage). Retarget using a current id; re-read with
panel_graph_outline if you need wiring.
```

- List is taken from the graph `resolveNode` just searched, not the root, so a subgraph-scoped write cannot be retargeted onto root ids.
- Capped at 40 so a large graph does not dump every id.
- Scope-mismatch messages (node is on the root / inside a subgraph) are unchanged — those already name the remedy.
- The one remaining bare throw (`graph_save_subgraph`) now goes through `resolveNode`, so it gets the same diagnosis.

Diagnostics only. Resolution stays scoped to the current graph.

## Tests

```
node --test --test-concurrency=4 browser_tests/unit/node-scope-locator.test.mjs browser_tests/unit/rail-id-diagnosis.test.mjs
```

30/30 pass, including the reporter's 99-after-deletions case, viewing-graph vs root ids, the 40-id cap, empty graph, missing-root-still-lists-live-ids, and the resolveNode / graph_save_subgraph wiring pins.

Fixes #1298
