### PR TITLE
fix(1296): a frontend-only add_node refusal names the unloaded pack JS, not a missing install

### DIFF
--- a/browser_tests/unit/node-resolve.test.mjs
+++ b/browser_tests/unit/node-resolve.test.mjs
@@ -978,10 +978,11 @@ test("#496 add_node: a genuinely INVALID target still fails closed (unknown type
   );
   // (d) an allowlisted name that is NOT registered in the live registry at all — the
   //     exemption requires registry membership (which is also what createNode needs).
+  //     Still refused; only the diagnosis changed (#1296 — see the dedicated block below).
   const reg4 = loadedRegistry();
   await assert.rejects(
     () => assertAddNodeResolvableRefreshing(() => reg4, "MarkdownNote", ADD_OPTS(fresh)),
-    /Unknown node type|does not provide/i,
+    /frontend-only node type|does not provide/i,
   );
 });
 
@@ -1018,6 +1019,82 @@ test("#496 add_node: object_info UNAVAILABLE still fails closed, even for a fron
         wasTypeEverDefined: () => false,
       }),
     /cannot verify|object_info is unavailable/i,
+  );
+});
+
+// ---- #1296: an allowlisted FRONTEND-ONLY type that is NOT in the live registry is
+//      still refused (LiteGraph could only mint a placeholder — that part is
+//      correct), but the refusal must stop diagnosing it as "not installed / its
+//      pack failed to import" and pointing at create_workflow (action:"node_info").
+//      A frontend-only class never comes from /object_info, so no fetch can confirm
+//      it, and the reported rig (rgthree-comfy installed, ComfyUI restarted, tab
+//      never reloaded) is exactly "pack JS not loaded in this tab". The refusal now
+//      names that and prescribes the ONE action that changes it: reload the tab. ---
+
+test('#1296 add_node: "Fast Groups Bypasser (rgthree)" with rgthree installed but the tab never reloaded is refused with a RELOAD-THE-TAB diagnosis, not "not installed"', async () => {
+  const fresh = objectInfo(); // healthy backend — never lists a frontend-only type
+  const reg = loadedRegistry(); // this tab predates the rgthree install: not registered
+  await assert.rejects(
+    () => assertAddNodeResolvableRefreshing(() => reg, "Fast Groups Bypasser (rgthree)", ADD_OPTS(fresh)),
+    (err) => {
+      assert.match(err.message, /frontend-only node type/);
+      assert.match(err.message, /RELOAD the ComfyUI tab/);
+      // The old diagnosis — install a pack they already have, then query the live
+      // /object_info for a type that is never in it — must be GONE.
+      assert.doesNotMatch(err.message, /not installed, its pack was removed/);
+      assert.doesNotMatch(err.message, /failed to import/);
+      assert.doesNotMatch(err.message, /create_workflow \(action:"node_info"\)/);
+      return true;
+    },
+  );
+  // …and once the tab IS reloaded (the pack JS registers the class, defless), the
+  // same add succeeds — the refusal above was about this tab, not the type.
+  const regReloaded = loadedRegistry([], ["Fast Groups Bypasser (rgthree)"]);
+  await assert.doesNotReject(() =>
+    assertAddNodeResolvableRefreshing(() => regReloaded, "Fast Groups Bypasser (rgthree)", ADD_OPTS(fresh)),
+  );
+});
+
+test("#1296 add_node: the reload diagnosis is scoped — provenance-bearing husk, ever-seen removal, and non-allowlisted types keep their own refusals", async () => {
+  const fresh = objectInfo();
+  // (a) an allowlisted name whose REGISTERED class carries backend provenance (a
+  //     removed pack's stale class squatting a reserved name) is NOT told to reload —
+  //     it keeps the generic unknown-type refusal.
+  const regHusk = loadedRegistry(["MarkdownNote"]); // registered WITH nodeData
+  await assert.rejects(
+    () => assertAddNodeResolvableRefreshing(() => regHusk, "MarkdownNote", ADD_OPTS(fresh)),
+    (err) => {
+      assert.match(err.message, /Unknown node type "MarkdownNote"/);
+      assert.doesNotMatch(err.message, /RELOAD the ComfyUI tab/);
+      return true;
+    },
+  );
+  // (b) the EVER-SEEN gate still wins over the reload diagnosis: a type the backend
+  //     reported earlier this session and no longer does is a REMOVED pack.
+  const reg = loadedRegistry();
+  await assert.rejects(
+    () =>
+      assertAddNodeResolvableRefreshing(
+        () => reg,
+        "Fast Groups Bypasser (rgthree)",
+        ADD_OPTS(fresh, (t) => t === "Fast Groups Bypasser (rgthree)"),
+      ),
+    (err) => {
+      assert.match(err.message, /defined this node type earlier this session|removed/i);
+      assert.doesNotMatch(err.message, /RELOAD the ComfyUI tab/);
+      return true;
+    },
+  );
+  // (c) a genuinely unknown, non-allowlisted type keeps the generic refusal with the
+  //     node_info pointer — nothing about it suggests a not-yet-loaded pack.
+  await assert.rejects(
+    () => assertAddNodeResolvableRefreshing(() => reg, "TotallyMadeUpNode", ADD_OPTS(fresh)),
+    (err) => {
+      assert.match(err.message, /Unknown node type "TotallyMadeUpNode"/);
+      assert.match(err.message, /create_workflow \(action:"node_info"\)/);
+      assert.doesNotMatch(err.message, /RELOAD the ComfyUI tab/);
+      return true;
+    },
   );
 });
 
@@ -1120,10 +1197,11 @@ test("#496 recurrence: the SetNode/GetNode allowlist entries do NOT weaken the g
     /defined this node type earlier this session|removed/i,
   );
   // (c) An allowlisted name that is NOT registered in the live registry at all stays
-  //     refused (registry membership is also what createNode needs).
+  //     refused (registry membership is also what createNode needs). #1296 changed only
+  //     the DIAGNOSIS: it now names the unloaded pack JS and prescribes a tab reload.
   await assert.rejects(
     () => assertAddNodeResolvableRefreshing(() => loadedRegistry(), "SetNode", ADD_OPTS(fresh)),
-    /Unknown node type|does not provide/i,
+    /frontend-only node type|does not provide/i,
   );
 });
 

--- a/web/js/lib/node-resolve.js
+++ b/web/js/lib/node-resolve.js
@@ -520,6 +520,35 @@ export async function assertAddNodeResolvableRefreshing(getRegistry, class_type,
       ) {
         return;
       }
+      // #1296 — a type ON the frontend-only allowlist that is absent from the LIVE
+      // REGISTRY is refused correctly, but the generic refusal below misdiagnoses WHY:
+      // "not installed, its pack was removed, or its pack failed to import" sends the
+      // user to reinstall a pack they already have (the reported case: rgthree-comfy
+      // installed and verified, ComfyUI restarted — which does NOT reload the open
+      // tab). A pack's frontend JS is fetched once at PAGE LOAD, so a pack installed
+      // after this tab opened registers nothing here, and no /object_info refresh can
+      // fix that — a frontend-only class never comes from the backend. Nothing the
+      // server reports can confirm or deny a frontend-only type, so name the one
+      // action that changes the outcome: RELOAD the ComfyUI tab. Only the never-seen
+      // verdict may say this — a removed/unseeded/pending history keeps its own
+      // honest message above, and an allowlisted name whose REGISTERED class carries
+      // backend provenance (a name-collision husk) stays on the generic refusal.
+      if (
+        verdict === "never-seen" &&
+        FRONTEND_ONLY_NODE_TYPES.has(class_type) &&
+        !isRegisteredNodeType(readRegistry(), class_type)
+      ) {
+        throw new Error(
+          `Cannot add "${class_type}": it is a frontend-only node type — the ComfyUI backend ` +
+            `never provides it, so its absence from /object_info is expected — but it is NOT ` +
+            `registered in this tab's live node registry. A pack's frontend JS is loaded once ` +
+            `at page load, and restarting the ComfyUI server does NOT reload an already-open ` +
+            `tab, so a pack installed after this tab opened registers nothing here. RELOAD the ` +
+            `ComfyUI tab and retry. If it is still refused after a reload, the pack that provides ` +
+            `it is not installed (or its frontend JS failed to load). Refusing to add rather than ` +
+            `let LiteGraph mint an unresolved placeholder node (#458).`,
+        );
+      }
       // Not defined by the current backend (never installed, or its pack was
       // removed). Fail closed even if a stale registry entry survives (#458/P1-C).
       // #741: the pointer must be a tool that searches node CLASSES


### PR DESCRIPTION
## Root cause

`panel_add_node` with `class_type: "Fast Groups Bypasser (rgthree)"` was refused with
`Unknown node type — the ComfyUI backend does not provide it (not installed, its pack was
removed, or its pack failed to import)`, even with rgthree-comfy installed and verified.

Two things were already true on main, and both are correct:

1. The type is on the `FRONTEND_ONLY_NODE_TYPES` allowlist, and the add guard's frontend-only
   exemption (#496) authorizes it — **when the class is registered in this tab's live
   LiteGraph registry**.
2. When it is **not** registered there, the add is still refused — also correct, because
   LiteGraph could only mint an unresolved placeholder for a class it has never seen.

The defect is the refusal's diagnosis. A pack's frontend JS is fetched **once at page load**,
so on a tab opened before rgthree was installed — and restarting the ComfyUI server does NOT
reload an already-open tab, which is exactly what the reporter did — the class never registers,
and nothing the server reports can confirm or deny a frontend-only type (it is absent from
`/object_info` by design). The generic refusal sent the user to reinstall a pack they already
had, and pointed at `create_workflow (action:"node_info")`, which queries the live
`/object_info` and can never list this class. Same family as panel#1284 / the three call sites
in #1353 — which explicitly left this one out ("NOT covered. Same family, different call site:
`assertAddNodeResolvableRefreshing` requires live-registry membership").

## The fix

In `assertAddNodeResolvableRefreshing` (`web/js/lib/node-resolve.js`), on the refusal path,
when the history verdict is **never-seen**, the type is **on the frontend-only allowlist**,
and it is **not registered in the live registry**, the refusal now says what actually happened:
a frontend-only type this tab never loaded the JS for — **RELOAD the ComfyUI tab** and retry;
if it still refuses after a reload, the pack is genuinely not installed (or its JS failed to
load). The add itself is still refused — only the diagnosis changed; no authorization decision
moves.

Scoping, pinned by tests:

- `removed` / `unseeded` / `pending` history verdicts keep their own honest messages.
- An allowlisted name whose **registered** class carries backend provenance (a removed pack's
  stale class squatting a reserved name) keeps the generic unknown-type refusal — no reload advice.
- Non-allowlisted unknowns keep the generic refusal with the `node_info` pointer.
- Once the tab IS reloaded and the class registers (defless), the same add succeeds — the
  refusal was about this tab, not the type.

## Verification

- `npm ci` — clean.
- `npm run typecheck` — clean.
- `npm run test:unit` — 5146 tests, 5144 pass, 1 fail: the known #671 `verifyInstalled`
  wall-clock flake in `manager-install.test.mjs` under load. Re-run alone: 125/125 green.
  Nothing in this change touches it. (Same flake #1353 hit.)
- Static gates run by `test:unit` (i18n-check, i18n-render-check, check-tool-vocabulary,
  check-panel-scope) all pass — also re-run individually: all OK.
- Mutation check: neutralizing the new condition turns the primary #1296 test RED
  (`/frontend-only node type/` no longer matches; the old "not installed …" text returns);
  the rest of the file stays green. Mutation reverted.
- Browser e2e NOT run — requires a live ComfyUI on localhost:8188; no spec in the suite
  exercises this guard, so it would add no coverage for this change.

Closes #1296
