### PR TITLE
fix(1305): reclaim an already-full origin so ComfyUI can save drafts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project are documented here. This project adheres to
 ## [Unreleased]
 
 ### Fixed
+- an already-full origin can save workflow drafts again after the chat-history quota fix (#1305)
 - a group that encloses rgthree Label nodes now moves, instead of being refused because those nodes' visual bounds are not the panel's generic footprint — the same nodes already moved fine one-by-one with panel_edit_node (#1300)
 - a subgraph preview widget is promoted through the frontend's previewExposure store, and a failed link-only promote no longer hides behind a missing promotion store (#1271)
 

--- a/browser_tests/unit/legacy-shadow-quota.test.mjs
+++ b/browser_tests/unit/legacy-shadow-quota.test.mjs
@@ -6,9 +6,14 @@ import {
   ChatHistoryStore,
   boundShadowBytes,
   mergeHistorySnapshots,
+  measurePanelShadowBytes,
+  probeDraftIndexWrite,
+  writeLocalStorageItem,
   CHAT_HISTORY_SCHEMA,
   CHAT_HISTORY_DB_VERSION,
   CHAT_HISTORY_LEGACY_STORE,
+  CHAT_HISTORY_LOCAL_SNAPSHOT_KEY,
+  COMFY_DRAFT_INDEX_KEY,
 } from "../../web/js/lib/chat-history-store.js";
 
 // #861 — the panel's localStorage shadow kept every `legacyShadow` thread in full,
@@ -1243,4 +1248,171 @@ test("a metadata-only version never displaces the payload-carrier for the same h
     { nodes: [] },
     "…and the payload obviously survives the canonical-last order too",
   );
+});
+
+// ── #1305: an already-full origin still cannot take ComfyUI's draft ─────────
+//
+// #861 bounded the snapshot. #1318 stripped version payloads so the bound can
+// hold. The symptom came back on 0.14.44 anyway, because neither change
+// reclaimed a PREVIOUSLY over-budget origin:
+//
+//   1. Browsers measure remaining quota BEFORE freeing the value being
+//      replaced, so setItem of a smaller snapshot still throws.
+//   2. The two-key shadow (threads + historyMeta) is a second full copy of
+//      the same cache, so even a successful bound left ~3MB of a 5MB origin
+//      in panel keys and Comfy.Workflow.DraftIndex.v2 had nothing left.
+//
+// Do not clear the origin. Only panel keys that IndexedDB already holds may
+// move, and a failed draft probe is a recovery message — not a wipe.
+
+const THREADS_KEY = "comfyui-mcp.panel.threads";
+const META_KEY = "comfyui-mcp.panel.historyMeta";
+const SNAPSHOT_KEY = CHAT_HISTORY_LOCAL_SNAPSHOT_KEY;
+
+function createQuotaStorage(maxBytes) {
+  const map = new Map();
+  const used = () => {
+    let n = 0;
+    for (const value of map.values()) n += String(value).length;
+    return n;
+  };
+  class QuotaExceededError extends Error {
+    constructor() {
+      super("The quota has been exceeded.");
+      this.name = "QuotaExceededError";
+      this.code = 22;
+    }
+  }
+  return {
+    getItem: (key) => (map.has(key) ? map.get(key) : null),
+    setItem: (key, value) => {
+      const next = String(value);
+      // Chrome: remaining is checked BEFORE the old value is freed. A rewrite
+      // of a smaller payload still throws when leftover headroom is smaller
+      // than the new payload — the #1305 failure.
+      if (used() + next.length > maxBytes) throw new QuotaExceededError();
+      map.set(key, next);
+    },
+    removeItem: (key) => { map.delete(key); },
+    _map: map,
+    _used: used,
+  };
+}
+
+const preV1157Thread = (id, ts, size) => ({
+  id,
+  ts,
+  updatedAt: ts,
+  msgs: [{ id: `${id}-m`, role: "user", text: "x".repeat(size) }],
+});
+
+test("writeLocalStorageItem shrinks a key the naive setItem cannot replace", () => {
+  const storage = createQuotaStorage(1000);
+  storage.setItem("k", "a".repeat(800));
+  assert.throws(() => storage.setItem("k", "b".repeat(400)), { name: "QuotaExceededError" });
+  assert.equal(writeLocalStorageItem(storage, "k", "b".repeat(400)), true);
+  assert.equal(storage.getItem("k").length, 400);
+});
+
+test("an over-budget pre-0.11.57 shadow leaves room for Comfy.Workflow.DraftIndex.v2", async () => {
+  // The upgrade state the issue names: a 0.11.56-or-older install wrote every
+  // transcript into `threads` + `historyMeta`, no historySnapshot, no bound.
+  // Origin ~5MB. Panel keys already ~3.6MB. ComfyUI then cannot persist the
+  // draft index, and #861's post-bound setItem cannot replace the huge key.
+  const quota = 5_000_000;
+  const storage = createQuotaStorage(quota);
+  const threads = Array.from({ length: 24 }, (_, i) => preV1157Thread(`old-${i}`, i + 1, 140_000));
+  storage.setItem(THREADS_KEY, JSON.stringify(threads));
+  storage.setItem(META_KEY, JSON.stringify({ updatedAt: 1 }));
+  const foreign = { keep: true, pad: "c".repeat(200) };
+  storage.setItem("Comfy.Workflow.OpenTabs", JSON.stringify(foreign));
+  assert.equal(storage.getItem(SNAPSHOT_KEY), null, "precondition: pre-0.11.57 has no atomic snapshot");
+  assert.ok(storage._used() > 3_000_000, "precondition: the origin is already over the panel budget");
+
+  const indexedDb = createFakeIndexedDb();
+  const failures = [];
+  const store = new ChatHistoryStore({
+    storage,
+    indexedDb,
+    maxShadowBytes: 1_500_000,
+    onPersistenceError: (failure) => failures.push(failure),
+  });
+  const local = store.readLocal();
+  store.persist(local.threads, local.meta);
+  assert.equal(await store.flush(), true, "history must persist");
+  assert.equal(store.lastDraftHeadroomOk, true, "the draft-index probe must succeed after reclaim");
+  assert.ok(
+    store.lastShadowBytes <= 1_500_000,
+    `panel shadow still over budget: ${store.lastShadowBytes}`,
+  );
+  assert.deepEqual(
+    JSON.parse(storage.getItem("Comfy.Workflow.OpenTabs")),
+    foreign,
+    "a non-panel origin key must not be rewritten",
+  );
+
+  const draft = JSON.stringify({
+    version: 2,
+    workflows: { wf: { modified: true, pad: "d".repeat(80_000) } },
+  });
+  storage.setItem(COMFY_DRAFT_INDEX_KEY, draft);
+  assert.equal(storage.getItem(COMFY_DRAFT_INDEX_KEY), draft, "ComfyUI must be able to persist the draft index");
+
+  const reader = new ChatHistoryStore({ storage, indexedDb });
+  const read = await reader.readCanonical();
+  const ids = new Set((read?.threads || []).map((t) => t.id));
+  for (const thread of threads) {
+    assert.ok(ids.has(thread.id), `${thread.id} must still be recoverable from IndexedDB`);
+  }
+  assert.equal(
+    failures.some((f) => f.code === "history-draft-headroom-unavailable"),
+    false,
+    "a successful reclaim must not nag",
+  );
+});
+
+test("without IndexedDB the over-budget shadow is not deleted to make room", async () => {
+  const storage = createQuotaStorage(5_000_000);
+  const threads = Array.from({ length: 10 }, (_, i) => preV1157Thread(`only-${i}`, i + 1, 80_000));
+  storage.setItem(THREADS_KEY, JSON.stringify(threads));
+  storage.setItem(META_KEY, JSON.stringify({}));
+  const store = new ChatHistoryStore({ storage, indexedDb: null, maxShadowBytes: 1_500_000 });
+  store.persist(threads, {});
+  await store.flush();
+  const kept = JSON.parse(storage.getItem(THREADS_KEY) || "[]");
+  assert.equal(kept.length, 10, "an only-copy transcript must stay when nothing is durable");
+});
+
+test("a draft probe that still fails is reported, and foreign keys stay", async () => {
+  // After the panel has done everything it is allowed to, some other occupant
+  // of the origin can still leave no room. The recovery is a message, not a
+  // wipe of site data.
+  const storage = createQuotaStorage(2_000_000);
+  const hog = "z".repeat(1_999_996);
+  storage.setItem("other-extension.blob", hog);
+  const indexedDb = createFakeIndexedDb();
+  const failures = [];
+  const store = new ChatHistoryStore({
+    storage,
+    indexedDb,
+    maxShadowBytes: 50_000,
+    onPersistenceError: (failure) => failures.push(failure),
+  });
+  store.persist([preV1157Thread("T0", 1, 40)], {});
+  assert.equal(await store.flush(), true, "history itself persisted");
+  assert.equal(store.lastDraftHeadroomOk, false);
+  assert.ok(
+    failures.some((f) => f.code === "history-draft-headroom-unavailable"),
+    "the remaining failure must be named",
+  );
+  assert.equal(storage.getItem("other-extension.blob"), hog, "foreign origin data is not cleared");
+  assert.equal(probeDraftIndexWrite(storage), false);
+});
+
+test("measurePanelShadowBytes sums only the keys it is given", () => {
+  const storage = createMemoryStorage();
+  storage.setItem(THREADS_KEY, "aaa");
+  storage.setItem(META_KEY, "bb");
+  storage.setItem("ignore-me", "cccccccc");
+  assert.equal(measurePanelShadowBytes(storage, [THREADS_KEY, META_KEY]), 5);
 });

--- a/locales/en/main.json
+++ b/locales/en/main.json
@@ -407,6 +407,7 @@
       "comfyui_agent_panel_your_agent_session_s": "ComfyUI Agent Panel — your agent session's window into this graph",
       "comfyui_is_back_reconnecting_the_agent": "ComfyUI is back — reconnecting the agent…",
       "comfyui_is_restarting": "ComfyUI is restarting…",
+      "comfyui_still_cannot_save_workflow_drafts": "ComfyUI still cannot save workflow drafts. The panel already moved chat history out of this site's shared browser storage — nothing was deleted. Do not clear this site's data: that would drop your open workflow tabs. Free space from other extensions on this origin, then save or send once to retry.",
       "coming_soon": " — coming soon",
       "command_copied": "Command copied.",
       "command_failed": "{cmd} failed",

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -26535,6 +26535,14 @@ function buildPanel() {
                 "Some legacy chat history has no IndexedDB copy and could not be saved to localStorage. " +
                   "Keep this tab open, free browser storage, then send or edit once to retry.",
               )
+            : failure?.code === "history-draft-headroom-unavailable"
+              ? tr(
+                  "panel.comfyui_still_cannot_save_workflow_drafts",
+                  "ComfyUI still cannot save workflow drafts. The panel already moved chat history out of " +
+                    "this site's shared browser storage — nothing was deleted. Do not clear this site's data: " +
+                    "that would drop your open workflow tabs. Free space from other extensions on this origin, " +
+                    "then save or send once to retry.",
+                )
             : tr(
                 "panel.chat_history_could_not_be_saved_keep",
                 "Chat history could not be saved. Keep this tab open, free browser storage, then send or edit once to retry.",

--- a/web/js/lib/chat-history-store.js
+++ b/web/js/lib/chat-history-store.js
@@ -29,6 +29,8 @@ export const CHAT_HISTORY_LEGACY_STORE = "legacy";
 export const CHAT_HISTORY_LOCAL_SNAPSHOT_KEY = "comfyui-mcp.panel.historySnapshot";
 export const CHAT_HISTORY_MAX_IMPORT_BYTES = 25 * 1024 * 1024;
 export const CHAT_HISTORY_EXPORT_FORMAT = "comfyui-agent-panel-chat-history";
+/** ComfyUI's own draft-index key on the shared origin (#1305). */
+export const COMFY_DRAFT_INDEX_KEY = "Comfy.Workflow.DraftIndex.v2";
 
 const DEFAULT_THREADS_KEY = "comfyui-mcp.panel.threads";
 const DEFAULT_META_KEY = "comfyui-mcp.panel.historyMeta";
@@ -85,6 +87,89 @@ const MAX_TODO_TEXT = 2000;
 
 function utf8ByteLength(value) {
   return new TextEncoder().encode(String(value)).byteLength;
+}
+
+export function isQuotaExceededError(error) {
+  if (!error) return false;
+  return error.name === "QuotaExceededError"
+    || error.name === "NS_ERROR_DOM_QUOTA_REACHED"
+    || error.code === 22
+    || error.code === 1014;
+}
+
+/**
+ * Write one localStorage key, and if the origin is already full, drop THIS key
+ * first so a shrink can land (#1305).
+ *
+ * Browsers measure remaining quota BEFORE freeing the value being replaced.
+ * That is why #861's bounded `setItem` still threw on an already-over-budget
+ * origin: the new payload was smaller, but not smaller than the leftover
+ * headroom, so the huge pre-0.11.57 shadow never moved. Removing the key
+ * first is the only way a guest can give the host its bytes back.
+ *
+ * On a failed retry the previous value is restored when we still have it —
+ * this must not become a delete of someone else's key (the draft-index probe
+ * uses the same helper).
+ */
+export function writeLocalStorageItem(storage, key, value) {
+  writeLocalStorageItem.lastError = null;
+  if (!storage) return false;
+  try {
+    storage.setItem(key, value);
+    return true;
+  } catch (error) {
+    writeLocalStorageItem.lastError = error;
+    if (!isQuotaExceededError(error)) return false;
+    let previous = null;
+    try { previous = storage.getItem(key); } catch { /* ignore */ }
+    try { storage.removeItem(key); } catch { /* ignore */ }
+    try {
+      storage.setItem(key, value);
+      writeLocalStorageItem.lastError = null;
+      return true;
+    } catch (retry) {
+      writeLocalStorageItem.lastError = retry;
+      if (previous != null) {
+        try { storage.setItem(key, previous); } catch { /* best-effort restore */ }
+      }
+      return false;
+    }
+  }
+}
+
+export function measurePanelShadowBytes(storage, keys) {
+  if (!storage) return 0;
+  let total = 0;
+  for (const key of keys) {
+    try {
+      const raw = storage.getItem(key);
+      if (typeof raw === "string") total += raw.length;
+    } catch { /* ignore */ }
+  }
+  return total;
+}
+
+/**
+ * Can ComfyUI still persist `Comfy.Workflow.DraftIndex.v2`? (#1305)
+ *
+ * Writes the EXISTING value back when one is present, so this is not a
+ * rewrite of the user's drafts. A missing key gets a tiny probe that is
+ * removed again. Never clears any other origin key.
+ */
+export function probeDraftIndexWrite(storage) {
+  if (!storage) return false;
+  let previous;
+  try {
+    previous = storage.getItem(COMFY_DRAFT_INDEX_KEY);
+  } catch {
+    return false;
+  }
+  const payload = previous == null ? "{\"v\":2}" : previous;
+  const wrote = writeLocalStorageItem(storage, COMFY_DRAFT_INDEX_KEY, payload);
+  if (previous == null && wrote) {
+    try { storage.removeItem(COMFY_DRAFT_INDEX_KEY); } catch { /* probe only */ }
+  }
+  return wrote;
 }
 
 function finiteTs(value) {
@@ -1950,6 +2035,8 @@ export class ChatHistoryStore {
     this.maxShadowBytes = Number.isFinite(options.maxShadowBytes)
       ? options.maxShadowBytes
       : LOCAL_SHADOW_MAX_BYTES;
+    this.lastDraftHeadroomOk = null;
+    this.lastShadowBytes = 0;
     /**
      * What the legacy store has ACCEPTED, as id -> content fingerprint (#861).
      *
@@ -2280,26 +2367,51 @@ export class ChatHistoryStore {
     // fires onPersistenceError forever against a state that can never fit.
     const legacyComplete = legacyThreads.every((thread) =>
       shadowById.has(thread.id) || this._durableLegacy?.get(thread.id) === legacyFingerprint(thread));
-    try {
-      this.storage?.setItem(this.snapshotKey, bounded.serialized);
-      this.lastShadowWriteOk = true;
-      this.lastShadowError = null;
-    } catch (error) {
+    const shadowKeys = [this.snapshotKey, this.threadsKey, this.metaKey];
+    const dropDuplicateKeys = () => {
+      // The two-key shadow is a cache of the atomic snapshot (and of IndexedDB
+      // once canonicalDurable). Dropping it is not a delete of user data — it
+      // is how an already-full origin gets the headroom ComfyUI needs (#1305).
+      // Never run this without a durable copy: the caller gates on
+      // canonicalDurable.
+      try { this.storage?.removeItem(this.threadsKey); } catch { /* ignore */ }
+      try { this.storage?.removeItem(this.metaKey); } catch { /* ignore */ }
+    };
+    const measure = () => {
+      this.lastShadowBytes = measurePanelShadowBytes(this.storage, shadowKeys);
+      return this.lastShadowBytes;
+    };
+
+    let snapshotOk = writeLocalStorageItem(this.storage, this.snapshotKey, bounded.serialized);
+    if (!snapshotOk && canonicalDurable) {
+      dropDuplicateKeys();
+      snapshotOk = writeLocalStorageItem(this.storage, this.snapshotKey, bounded.serialized);
+    }
+    if (!snapshotOk) {
       this.lastShadowWriteOk = false;
-      this.lastShadowError = error;
-      this.onShadowError?.(error);
+      this.lastShadowError = writeLocalStorageItem.lastError
+        || new Error("localStorage shadow write failed");
+      this.onShadowError?.(this.lastShadowError);
+      measure();
       return { committed: false, complete: false, legacyComplete: false };
     }
-    try {
-      this.storage?.setItem(this.threadsKey, JSON.stringify(keptThreads));
-    } catch {
-      // The atomic shadow is already committed.
+    this.lastShadowWriteOk = true;
+    this.lastShadowError = null;
+
+    const threadsJson = JSON.stringify(keptThreads);
+    const metaJson = JSON.stringify(snapshot.meta ?? {});
+    const totalIfDuplicated = bounded.serialized.length + threadsJson.length + metaJson.length;
+    if (canonicalDurable && totalIfDuplicated > this.maxShadowBytes) {
+      // The byte bound was on the snapshot alone, so writing threads+meta
+      // again doubled the panel's share and left ComfyUI no room. Once
+      // canonical holds the transcripts, the two-key copy is the leftover
+      // occupancy #1305 is about — drop it rather than keep a second 1.5MB.
+      dropDuplicateKeys();
+    } else {
+      writeLocalStorageItem(this.storage, this.threadsKey, threadsJson);
+      writeLocalStorageItem(this.storage, this.metaKey, metaJson);
     }
-    try {
-      this.storage?.setItem(this.metaKey, JSON.stringify(snapshot.meta));
-    } catch {
-      // The atomic shadow is already committed.
-    }
+    measure();
     return { committed: true, complete, legacyComplete };
   }
 
@@ -2463,12 +2575,30 @@ export class ChatHistoryStore {
       })
       .then((merged) => {
         let postMergeShadowWrite = null;
+        let draftHeadroom = null;
         if (merged) {
           this._lastCommitted = merged;
           this._observeSnapshot(merged);
           postMergeShadowWrite = this._writeLocalSnapshot(merged, protectedThreadIds, {
             canonicalDurable: true,
           });
+          // After the shadow has been given a chance to shrink, ask whether
+          // ComfyUI can still write its draft index. A failed probe is not a
+          // failed history persist — do not dirty the write — but it is the
+          // remaining #1305 failure, and it must be named rather than left
+          // as ComfyUI's "Failed to save workflow draft" with no pointer.
+          draftHeadroom = probeDraftIndexWrite(this.storage);
+          this.lastDraftHeadroomOk = draftHeadroom;
+          if (!draftHeadroom) {
+            this.onPersistenceError?.({
+              ok: true,
+              code: "history-draft-headroom-unavailable",
+              retryable: true,
+              shadowCommitted: Boolean(postMergeShadowWrite?.committed),
+              canonicalCommitted: true,
+              panelBytes: this.lastShadowBytes,
+            });
+          }
           try {
             this._broadcastChannel?.postMessage({ type: "history-changed", writerId: this.writerId });
           } catch {


### PR DESCRIPTION
## Root cause

#861 / #1318 bounded the localStorage *snapshot* and stripped durable version payloads, but an already-full origin still could not save workflow drafts:

1. Browsers measure remaining quota **before** freeing the value being replaced. A smaller bounded `setItem` still throws `QuotaExceededError` when leftover headroom is smaller than the new payload, so the huge pre-0.11.57 `threads` key never moved.
2. After the bound, the panel still wrote a second full copy to `comfyui-mcp.panel.threads` + `historyMeta`. Two 1.5MB caches left ComfyUI no room for `Comfy.Workflow.DraftIndex.v2`.

## Fix

Do **not** clear or rewrite the origin. Only panel keys that IndexedDB already holds may move.

- `writeLocalStorageItem` — on quota, drop **this** key first so a shrink can land, then restore the previous value if the retry fails.
- After a canonical commit, if snapshot + threads + meta would exceed the panel budget, drop the two-key duplicate. The atomic snapshot (and IndexedDB) still have the transcripts.
- If the snapshot write itself cannot land on a full origin, drop the duplicate first and retry.
- After reclaim, probe `Comfy.Workflow.DraftIndex.v2` by writing the existing value back (or a tiny probe that is removed). A failed probe is a named recovery message, not a wipe.

## Verification

- `node --test browser_tests/unit/legacy-shadow-quota.test.mjs browser_tests/unit/chat-history-store.test.mjs` — 123 pass, including:
  - upgrade from an over-budget pre-0.11.57 shadow, then `Comfy.Workflow.DraftIndex.v2` can be written
  - Chrome-style quota replace cannot shrink, remove-then-set can
  - without IndexedDB the only-copy shadow is not deleted
  - a still-full origin surfaces `history-draft-headroom-unavailable` and leaves foreign keys untouched
- `node scripts/i18n-check.mjs` — locales OK

Fixes #1305
