### PR TITLE
fix(1357): a combo that cannot list the file is no authority on whether it exists

### DIFF
--- a/browser_tests/unit/asset-staleness.test.mjs
+++ b/browser_tests/unit/asset-staleness.test.mjs
@@ -1119,6 +1119,37 @@ test("#984 (codex): `unchecked` is reported but is never a finding", () => {
   assert.equal(counts.erroredNodes, 0);
 });
 
+test("#1357: `unchecked` counts NODES, because that is what the pill says", () => {
+  // Since #1357 one node can contribute several entries — a widget value the
+  // server's combo has no authority over is abstained on per VALUE. The pill reads
+  // "{count} nodes could not be checked", so three nested LoadImage paths on node 4
+  // must not render as "3 nodes".
+  const counts = graphErrorsFindingCounts({
+    unchecked_nodes: [
+      { id: 4, type: "LoadImage", widget: "image", value: "a/1.png", reason: "not checked: x" },
+      { id: 4, type: "LoadImage", widget: "image2", value: "a/2.png", reason: "not checked: x" },
+      { id: 4, type: "LoadImage", widget: "image3", value: "a/3.png", reason: "not checked: x" },
+      { id: 9, type: "SomePackNode", reason: "node type not found in /object_info" },
+    ],
+  });
+  assert.equal(counts.unchecked, 2, "node 4 once, node 9 once");
+  assert.equal(counts.unavailable, 0, "an abstention is still never a finding");
+});
+
+test("#1357: an id-less unchecked entry is counted, never merged away", () => {
+  // Collapsing every `{id: undefined}` into one bucket would UNDER-report, which is
+  // the wrong direction for a count whose whole job is to say "I did not look here".
+  const counts = graphErrorsFindingCounts({
+    unchecked_nodes: [{ reason: "a" }, { reason: "b" }, { id: null, reason: "c" }],
+  });
+  assert.equal(counts.unchecked, 3);
+  // A numeric and a string id for the same node are one node, not two.
+  assert.equal(
+    graphErrorsFindingCounts({ unchecked_nodes: [{ id: 7 }, { id: "7" }] }).unchecked,
+    1,
+  );
+});
+
 test("#984: the overlap join is injective — a concatenation collision cannot swallow a finding", () => {
   // Without a field separator, (node "1", file "23") and (node "12", file "3") produce
   // the same key, and a real live-scan finding is silently deduped away as a phantom

--- a/browser_tests/unit/live-combo-availability.test.mjs
+++ b/browser_tests/unit/live-combo-availability.test.mjs
@@ -217,7 +217,7 @@ test("#745 WIRING: get_errors actually calls the scan, inside its budget", async
   const here = dirname(fileURLToPath(import.meta.url))
   const src = readFileSync(join(here, "../../web/js/comfyui-mcp-panel.js"), "utf8")
 
-  assert.match(src, /import \{ scanComboAvailability, comboAvailabilityNote \} from "\.\/lib\/live-combo-availability\.js"/)
+  assert.match(src, /import \{[\s\S]{0,200}?scanComboAvailability,[\s\S]{0,200}?comboAvailabilityNote,[\s\S]{0,200}?\} from "\.\/lib\/live-combo-availability\.js"/)
   // It must draw from the SHARED budget, not run unbounded.
   assert.match(src, /errorsStepBudget\(GET_ERRORS_STEP_CAP_MS\)[\s\S]{0,400}scanComboAvailability/)
   // …and it must be emitted, with the unchecked list alongside it.

--- a/browser_tests/unit/live-combo-unenumerable-assets.test.mjs
+++ b/browser_tests/unit/live-combo-unenumerable-assets.test.mjs
@@ -1,0 +1,398 @@
+// panel#1357 — the combo list is not an authority over a file it cannot enumerate.
+//
+// Reported: `upload_image` put `AgentLibrary/HaReen/Main-9-1.png` in the input
+// directory, `panel_set_widget` wrote it and answered `server_confirmed: true`
+// (its #387 /view probe), and `panel_get_errors` then listed that exact value as
+// `missing_asset` in the same session. Both files were on disk; switching to
+// root-level filenames made the "error" vanish.
+//
+// Cause: `LoadImage.INPUT_TYPES` builds its list from `os.listdir(input_dir)`
+// filtered by `isfile` — TOP LEVEL only — while `folder_paths.get_annotated_filepath`
+// resolves nested paths fine. So `sub/dir/x.png` can never be a member of that
+// combo, and `options.includes(value)` returning false says nothing whatsoever
+// about whether the file exists. Same for an `[output]`/`[temp]`-annotated value,
+// which resolves against a different root entirely.
+//
+// The #745 live scan now asks the SERVER about exactly those values, using the same
+// probe set_widget used to confirm them — so the two can no longer contradict — and
+// abstains (UNKNOWN) when the server will not answer, rather than inventing a miss.
+
+import assert from "node:assert/strict";
+import test from "node:test";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+import {
+  scanComboAvailability,
+  comboConfigsOf,
+  uncheckedNodesNote,
+} from "../../web/js/lib/live-combo-availability.js";
+import { inputAssetProbeVerdict } from "../../web/js/lib/input-asset.js";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const PANEL_JS = join(HERE, "../../web/js/comfyui-mcp-panel.js");
+
+/** An /object_info/<class> body in the shape verified live in #745. */
+const classBody = (name, required) => ({ [name]: { input: { required } } });
+
+const node = (id, type, widgets) => ({ id, type, widgets });
+
+/** The verified live LoadImage shape: top-level input files, `{image_upload: true}`. */
+const LOAD_IMAGE = classBody("LoadImage", {
+  image: [["root.png", "other.png"], { image_upload: true }],
+  upload: ["IMAGEUPLOAD", {}],
+});
+
+/** A NON-upload file combo. folder_paths lists checkpoints RECURSIVELY, so a
+ *  nested value there really is enumerable and its absence really is an answer. */
+const CKPT = classBody("CheckpointLoaderSimple", {
+  ckpt_name: [["SDXL/base.safetensors"], {}],
+});
+
+const NESTED = "AgentLibrary/HaReen/Main-9-1.png";
+
+test("#1357 a server-CONFIRMED nested upload value is not reported at all", async () => {
+  const probed = [];
+  const r = await scanComboAvailability(
+    [node(4, "LoadImage", [{ name: "image", value: NESTED }])],
+    async () => LOAD_IMAGE,
+    {
+      confirmServerAsset: (value, ref) => {
+        probed.push({ value, ...ref });
+        return true;
+      },
+    },
+  );
+  assert.deepEqual(r.unavailable, []);
+  assert.deepEqual(r.unknown, []);
+  // Probed at the path LoadImage itself would resolve.
+  assert.deepEqual(probed, [
+    { value: NESTED, filename: "Main-9-1.png", subfolder: "AgentLibrary/HaReen", type: "input" },
+  ]);
+});
+
+test("#1357 a nested upload value the server says is ABSENT is still reported", async () => {
+  // The fix must not become a blanket amnesty for anything with a slash in it.
+  const r = await scanComboAvailability(
+    [node(4, "LoadImage", [{ name: "image", value: NESTED }])],
+    async () => LOAD_IMAGE,
+    { confirmServerAsset: () => false },
+  );
+  assert.equal(r.unavailable.length, 1);
+  assert.equal(r.unavailable[0].value, NESTED);
+  assert.equal(r.unavailable[0].kind, "missing_asset");
+  assert.deepEqual(r.unknown, []);
+});
+
+test("#1357 an UNANSWERABLE probe is UNKNOWN — not missing, not clean", async () => {
+  // A flaky /view must not masquerade as a confirmed miss: non-membership in a
+  // list that cannot contain the value is no evidence at all.
+  const unanswerable = [
+    () => null,
+    () => undefined,
+    () => {
+      throw new Error("network down");
+    },
+    async () => {
+      throw new Error("timeout");
+    },
+  ];
+  for (const confirmServerAsset of unanswerable) {
+    const r = await scanComboAvailability(
+      [node(4, "LoadImage", [{ name: "image", value: NESTED }])],
+      async () => LOAD_IMAGE,
+      { confirmServerAsset },
+    );
+    assert.deepEqual(r.unavailable, []);
+    assert.equal(r.unknown.length, 1);
+    assert.equal(r.unknown[0].id, 4);
+    assert.equal(r.unknown[0].widget, "image");
+    assert.equal(r.unknown[0].value, NESTED);
+    assert.match(r.unknown[0].reason, /^not checked:/);
+  }
+});
+
+test("#1357 with NO probe injected the value is unknown, never a finding", async () => {
+  const r = await scanComboAvailability(
+    [node(4, "LoadImage", [{ name: "image", value: NESTED }])],
+    async () => LOAD_IMAGE,
+  );
+  assert.deepEqual(r.unavailable, []);
+  assert.equal(r.unknown.length, 1);
+  assert.match(r.unknown[0].reason, /no server file check was available/);
+});
+
+test("#1357 an [output]-annotated value is unenumerable too, and probes that root", async () => {
+  // folder_paths.annotated_filepath resolves this against the OUTPUT root; the
+  // input combo lists bare input names, so it is never a member (#743's shape,
+  // now reaching the live scan as well).
+  const probed = [];
+  const r = await scanComboAvailability(
+    [node(9, "LoadImage", [{ name: "image", value: "detailed/Anima_00005_.png [output]" }])],
+    async () => LOAD_IMAGE,
+    {
+      confirmServerAsset: (value, ref) => {
+        probed.push(ref);
+        return true;
+      },
+    },
+  );
+  assert.deepEqual(r.unavailable, []);
+  assert.deepEqual(probed, [
+    { filename: "Anima_00005_.png", subfolder: "detailed", type: "output" },
+  ]);
+});
+
+test("#1357 a ROOT-level [temp] value is unenumerable — the annotation alone suffices", async () => {
+  const probed = [];
+  await scanComboAvailability(
+    [node(9, "LoadImage", [{ name: "image", value: "scratch.png [temp]" }])],
+    async () => LOAD_IMAGE,
+    {
+      confirmServerAsset: (value, ref) => {
+        probed.push(ref);
+        return true;
+      },
+    },
+  );
+  assert.deepEqual(probed, [{ filename: "scratch.png", subfolder: "", type: "temp" }]);
+});
+
+test("#1357 a BARE root-level name stays adjudicated by the combo", async () => {
+  // The combo DOES enumerate top-level input files, so absence there is a real
+  // answer and must not be softened into an unknown — nor cost a server probe.
+  let probes = 0;
+  const r = await scanComboAvailability(
+    [node(4, "LoadImage", [{ name: "image", value: "not-uploaded.png" }])],
+    async () => LOAD_IMAGE,
+    {
+      confirmServerAsset: () => {
+        probes += 1;
+        return true;
+      },
+    },
+  );
+  assert.equal(probes, 0);
+  assert.equal(r.unavailable.length, 1);
+  assert.equal(r.unavailable[0].value, "not-uploaded.png");
+});
+
+test("#1357 a NON-upload combo is never softened, however nested the value", async () => {
+  // ckpt_name's listing IS recursive, so `Other/missing.safetensors` really is
+  // absent. Only an upload input's list is structurally incomplete.
+  let probes = 0;
+  const r = await scanComboAvailability(
+    [node(2, "CheckpointLoaderSimple", [{ name: "ckpt_name", value: "Other/missing.safetensors" }])],
+    async () => CKPT,
+    {
+      confirmServerAsset: () => {
+        probes += 1;
+        return true;
+      },
+    },
+  );
+  assert.equal(probes, 0);
+  assert.equal(r.unavailable.length, 1);
+  assert.equal(r.unavailable[0].kind, "missing_asset");
+});
+
+test("#1357 #240 strictness holds: a non-image extension is not cleared by /view", async () => {
+  // `/view?type=input` serves ANY input file. Letting a nested `.txt` through on a
+  // bare existence hit would put a value in a LoadImage image combo that fails at
+  // execution — the same over-acceptance set_widget's uploadInputAccepts refuses.
+  let probes = 0;
+  const r = await scanComboAvailability(
+    [node(4, "LoadImage", [{ name: "image", value: "notes/readme.txt" }])],
+    async () => LOAD_IMAGE,
+    {
+      confirmServerAsset: () => {
+        probes += 1;
+        return true;
+      },
+    },
+  );
+  assert.equal(probes, 0);
+  assert.equal(r.unavailable.length, 1);
+  assert.equal(r.unavailable[0].value, "notes/readme.txt");
+});
+
+test("#1357 a backslash value is split only where the SERVER would split it", async () => {
+  const windows = [];
+  const posix = [];
+  const value = "AgentLibrary\\HaReen\\Main-9-1.png";
+  const rWin = await scanComboAvailability(
+    [node(4, "LoadImage", [{ name: "image", value }])],
+    async () => LOAD_IMAGE,
+    {
+      backslashIsSeparator: true,
+      confirmServerAsset: (v, ref) => {
+        windows.push(ref);
+        return true;
+      },
+    },
+  );
+  assert.deepEqual(rWin.unavailable, []);
+  assert.deepEqual(windows, [
+    { filename: "Main-9-1.png", subfolder: "AgentLibrary/HaReen", type: "input" },
+  ]);
+  // On a POSIX server that backslash is a literal filename character, so the
+  // value is a ROOT-level name the combo really does enumerate. Probing a path
+  // the server would not resolve could clear a genuinely missing file (#513).
+  const rPosix = await scanComboAvailability(
+    [node(4, "LoadImage", [{ name: "image", value }])],
+    async () => LOAD_IMAGE,
+    {
+      backslashIsSeparator: false,
+      confirmServerAsset: (v, ref) => {
+        posix.push(ref);
+        return true;
+      },
+    },
+  );
+  assert.deepEqual(posix, []);
+  assert.equal(rPosix.unavailable.length, 1);
+});
+
+test("#1357 the default is POSIX semantics — never split a backslash on a guess", async () => {
+  const r = await scanComboAvailability(
+    [node(4, "LoadImage", [{ name: "image", value: "dir\\x.png" }])],
+    async () => LOAD_IMAGE,
+    { confirmServerAsset: () => true },
+  );
+  assert.equal(r.unavailable.length, 1);
+});
+
+test("#1357 one probe per distinct FILE, not per node", async () => {
+  const seen = [];
+  const nodes = Array.from({ length: 20 }, (_, i) =>
+    node(i, "LoadImage", [{ name: "image", value: NESTED }]));
+  await scanComboAvailability(nodes, async () => LOAD_IMAGE, {
+    confirmServerAsset: (v, ref) => {
+      seen.push(ref);
+      return true;
+    },
+  });
+  assert.equal(seen.length, 1);
+});
+
+test("#1357 the probe cap is disclosed, never silently truncated", async () => {
+  const nodes = Array.from({ length: 5 }, (_, i) =>
+    node(i, "LoadImage", [{ name: "image", value: `sub${i}/x.png` }]));
+  const r = await scanComboAvailability(nodes, async () => LOAD_IMAGE, {
+    maxAssetProbes: 2,
+    confirmServerAsset: () => true,
+  });
+  assert.deepEqual(r.unavailable, []);
+  assert.equal(r.unknown.length, 3);
+  assert.equal(r.unchecked_asset_probe_limit, 2);
+  assert.match(r.unknown[0].reason, /2-file server-existence probe cap/);
+});
+
+test("#1357 a budget that dies BETWEEN the lookup and the probe abstains, not accuses", async () => {
+  // Scripted so the class lookup lands inside the budget and only the FILE probe
+  // falls outside it — otherwise the assertion passes for the wrong reason (the
+  // class was never fetched, so nothing was judged at all).
+  //   call 1 = deadline base, call 2 = the class-lookup check, call 3 = the probe.
+  const clock = [0, 0, 5000];
+  let i = 0;
+  let probes = 0;
+  const r = await scanComboAvailability(
+    [node(4, "LoadImage", [{ name: "image", value: NESTED }])],
+    async () => LOAD_IMAGE,
+    {
+      budgetMs: 1000,
+      now: () => clock[Math.min(i++, clock.length - 1)],
+      confirmServerAsset: () => {
+        probes += 1;
+        return true;
+      },
+    },
+  );
+  assert.equal(probes, 0, "the probe must not be attempted past the deadline");
+  assert.deepEqual(r.unavailable, [], "an unaffordable check is not a finding");
+  assert.equal(r.unknown.length, 1);
+  assert.match(r.unknown[0].reason, /ran out of its shared server-call budget/);
+  assert.equal(r.unchecked_budget_exhausted, true);
+});
+
+test("#1357 the class-limit flag still reads as the CLASS limit, not the probe one", async () => {
+  // The two caps are different facts; collapsing them would misname what was skipped.
+  const nodes = Array.from({ length: 4 }, (_, i) =>
+    node(i, `Pack${i}`, [{ name: "x", value: "v" }]));
+  const r = await scanComboAvailability(nodes, async (cls) => classBody(cls, { x: [["a"], {}] }), {
+    maxClasses: 2,
+  });
+  assert.equal(r.unchecked_class_limit, 2);
+  assert.equal(r.unchecked_asset_probe_limit, undefined);
+  assert.equal(r.unchecked_budget_exhausted, undefined);
+});
+
+test("#1357 comboConfigsOf carries the upload flag, and separates absent from empty", async () => {
+  assert.equal(comboConfigsOf({}, "Nope"), null);
+  assert.equal(comboConfigsOf(null, "Nope"), null);
+  const cfgs = comboConfigsOf(LOAD_IMAGE, "LoadImage");
+  assert.deepEqual(cfgs.get("image"), { image_upload: true });
+  // A typed input is not a combo, so it has no config entry here.
+  assert.equal(cfgs.has("upload"), false);
+  assert.equal(comboConfigsOf(classBody("T", { x: ["INT", {}] }), "T").size, 0);
+  // A combo declared with no config object still yields a config entry, so a
+  // caller can tell "combo without upload flag" from "not a combo at all".
+  assert.deepEqual(comboConfigsOf(classBody("T", { x: [["a"]] }), "T").get("x"), {});
+});
+
+test("#1357 only a 404 is 'absent'; every other outcome is 'did not answer'", () => {
+  assert.equal(inputAssetProbeVerdict({ ok: true, status: 200 }), true);
+  assert.equal(inputAssetProbeVerdict({ ok: false, status: 206 }), true);
+  assert.equal(inputAssetProbeVerdict({ ok: false, status: 404 }), false);
+  // A traversal refusal, an auth wall, a dead backend and a proxy error page are
+  // NOT the server saying the file is gone. Reading any of them as `false` would
+  // put a present file back under missing_asset — the #1357 regression itself.
+  for (const status of [0, 400, 401, 403, 429, 500, 502, 503]) {
+    assert.equal(inputAssetProbeVerdict({ ok: false, status }), null, `status ${status}`);
+  }
+  assert.equal(inputAssetProbeVerdict(null), null);
+  assert.equal(inputAssetProbeVerdict(undefined), null);
+});
+
+test("#1357 WIRING: get_errors' live scan really is given the server probe", () => {
+  // The lib can be perfect and the bug still ship if get_errors never injects the
+  // probe — the scan's own default is "no probe", which abstains rather than
+  // clears, so a missed wiring would be silent in every lib-level test above.
+  const src = readFileSync(PANEL_JS, "utf8");
+  assert.match(src, /confirmServerAsset: \(_value, ref\) =>\s*\n?\s*probeInputAssetPresence\(ref, errorsStepBudget\(/);
+  assert.match(src, /backslashIsSeparator,\s*\n\s*confirmServerAsset:/);
+  // Split the value the way the SERVER does, not the way the browser would.
+  assert.match(
+    src,
+    /const backslashIsSeparator =\s*\n?\s*statsBudget > 0 \? await inputAssetServerUsesWindowsPaths\(statsBudget\) : false;/,
+  );
+});
+
+test("#1357 WIRING: the probe is tri-state, and the media filter keeps its old floor", () => {
+  const src = readFileSync(PANEL_JS, "utf8");
+  assert.match(src, /return inputAssetProbeVerdict\(res\);/);
+  // The store-driven missing-media filter must still collapse "absent" and
+  // "unknown" into "keep reporting" — it has a prior assertion the scan lacks,
+  // and loosening it here would silently un-ship #513/#743.
+  assert.match(src, /\(await probeInputAssetPresence\(ref, probeBudget\)\) === true/);
+});
+
+test("#1357 WIRING: an abstention is disclosed, never left to read as clean", () => {
+  const src = readFileSync(PANEL_JS, "utf8");
+  assert.match(src, /unchecked_nodes_note: uncheckedNodesNote\(liveScan\.unknown\)/);
+  assert.match(src, /unchecked_asset_probe_limit: liveScan\.unchecked_asset_probe_limit/);
+});
+
+test("#1357 unchecked_nodes is worded as an abstention, not a clearance", async () => {
+  const note = uncheckedNodesNote([
+    { id: 1, type: "SomePackNode", reason: "node type not found in /object_info" },
+    { id: 4, type: "LoadImage", widget: "image", value: NESTED, reason: "not checked: x" },
+  ]);
+  assert.match(note, /NOT CHECKED/);
+  assert.match(note, /1 node\(s\) whose type this scan could not resolve/);
+  assert.match(note, /1 widget value\(s\)/);
+  assert.match(note, /abstentions, not clearances/);
+  assert.equal(uncheckedNodesNote([]), "");
+  assert.equal(uncheckedNodesNote(null), "");
+});

--- a/browser_tests/unit/live-combo-unenumerable-assets.test.mjs
+++ b/browser_tests/unit/live-combo-unenumerable-assets.test.mjs
@@ -390,9 +390,13 @@ test("#1357 unchecked_nodes is worded as an abstention, not a clearance", async 
     { id: 4, type: "LoadImage", widget: "image", value: NESTED, reason: "not checked: x" },
   ]);
   assert.match(note, /NOT CHECKED/);
-  assert.match(note, /1 node\(s\) whose type this scan could not resolve/);
+  assert.match(note, /1 node\(s\) this scan could not judge/);
   assert.match(note, /1 widget value\(s\)/);
   assert.match(note, /abstentions, not clearances/);
+  // The node bucket also holds class-cap and budget skips, whose type resolved
+  // fine. The summary must not name a cause it did not read — the per-entry
+  // `reason` is where the three are told apart.
+  assert.doesNotMatch(note, /could not resolve/);
   assert.equal(uncheckedNodesNote([]), "");
   assert.equal(uncheckedNodesNote(null), "");
 });

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -15346,12 +15346,17 @@ const GRAPH_TOOL_EXECUTORS = {
       // #1357 — the scan's combo lists cannot enumerate an input file below the
       // input root (LoadImage.INPUT_TYPES is `os.listdir` + `isfile`, top level
       // only) nor an `[output]`/`[temp]`-annotated value, so for those it asks
-      // the server directly rather than calling a present file missing. Same
-      // /view probe panel_set_widget already uses to server-confirm the very
-      // same value (#387) — the two must not contradict each other. The path
-      // split follows the SERVER's platform, exactly as the missing-media probe
-      // above does; an unknown platform keeps POSIX semantics so a backslash is
-      // never re-read as a separator the server would not honour (#513). Read
+      // the server directly rather than calling a present file missing. The same
+      // /view EVIDENCE panel_set_widget accepts the very same value on (#387) —
+      // the two must not confirm and deny one value in one session. Not
+      // byte-for-byte the same probe: set_widget's inline one always normalises
+      // backslashes and always asks the `input` root, while this one parses the
+      // annotation for its root and splits on the SERVER's platform, exactly as
+      // the missing-media probe above does. Where they can differ (a `sub\a.png`
+      // on a POSIX server) this one is the STRICTER of the two — it declines to
+      // split, so the value stays reported. An unknown platform keeps POSIX
+      // semantics, so a backslash is never re-read as a separator the server
+      // would not honour (#513). Read
       // BEFORE the scan's own budget is taken, so a slow /system_stats shortens
       // the scan rather than letting it start with a full step it no longer has
       // (it is cached for the session, and the media probe above normally warms

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -195,7 +195,11 @@ import { fetchSingleNodeDef } from "./lib/single-node-def.js";
 import { saveReplyIdentity, shouldEstablishIdentityAfterSave } from "./lib/save-reply-identity.js";
 import { describeOpenActiveBinding } from "./lib/open-active-binding.js";
 import { compareVersions, releasesSince, summarizeReleases, updateAnnouncement } from "./lib/changelog-delta.js";
-import { scanComboAvailability, comboAvailabilityNote } from "./lib/live-combo-availability.js";
+import {
+  scanComboAvailability,
+  comboAvailabilityNote,
+  uncheckedNodesNote,
+} from "./lib/live-combo-availability.js";
 import {
   collectDisabledAncestorOutputs,
   disabledOutputsInPrompt,
@@ -300,6 +304,7 @@ import { runSetWidget } from "./lib/set-widget.js";
 import { declaredInputNames, runRemoveWidget } from "./lib/remove-widget.js";
 import {
   filterServerConfirmedInputSubfolderCandidates,
+  inputAssetProbeVerdict,
   inputPathsUseWindowsSeparators,
 } from "./lib/input-asset.js";
 import {
@@ -9317,25 +9322,46 @@ async function filterServerConfirmedInputSubfolderMedia(
   if (!(probeBudget > 0)) return media;
   return filterServerConfirmedInputSubfolderCandidates(
     media,
-    async (assetValue, ref) => {
-      try {
-        if (typeof api?.fetchApi !== "function") return false;
-        const { subfolder, filename, type } = ref ?? {};
-        if (!filename || !type) return false;
-        const qs = new URLSearchParams({ filename, subfolder, type }).toString();
-        const res = await api.fetchApi(`/view?${qs}`, {
-          method: "GET",
-          cache: "no-store",
-          headers: { Range: "bytes=0-0" },
-          signal: AbortSignal.timeout(probeBudget),
-        });
-        return !!res && (res.ok || res.status === 206);
-      } catch {
-        return false;
-      }
-    },
+    async (assetValue, ref) => (await probeInputAssetPresence(ref, probeBudget)) === true,
     { backslashIsSeparator },
   );
+}
+
+/**
+ * TRI-STATE `/view` existence probe for a parsed `{filename, subfolder, type}` ref:
+ *
+ *   true  — the server served the file: it is there.
+ *   false — the server ANSWERED and said it is not there (404).
+ *   null  — could not be determined (no api client, malformed ref, timeout,
+ *           network failure, or any other status).
+ *
+ * The third state is the whole point (#1357). Callers that only ever over-report
+ * (the missing-media filter above) collapse `false` and `null` into "keep the
+ * candidate", which is safe there because a STORE already asserted the miss. The
+ * live combo scan has no such prior assertion — its only other evidence is a combo
+ * list that structurally cannot contain the value — so treating a flaky fetch as a
+ * confirmed miss would manufacture the exact false positive that issue reports.
+ */
+async function probeInputAssetPresence(ref, timeoutMs) {
+  try {
+    if (typeof api?.fetchApi !== "function") return null;
+    const { subfolder, filename, type } = ref ?? {};
+    if (!filename || !type) return null;
+    if (!(timeoutMs > 0)) return null;
+    const qs = new URLSearchParams({ filename, subfolder: subfolder ?? "", type }).toString();
+    const res = await api.fetchApi(`/view?${qs}`, {
+      method: "GET",
+      cache: "no-store",
+      headers: { Range: "bytes=0-0" },
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+    // ComfyUI's /view 404s a path it resolved but did not find. Every OTHER
+    // status (400 traversal refusal, 403, 5xx, a proxy's error page) means the
+    // question was not answered, NOT that the file is absent.
+    return inputAssetProbeVerdict(res);
+  } catch {
+    return null;
+  }
 }
 
 /** True when EITHER missing-asset store holds a RAW candidate (isMissing !== false),
@@ -15317,12 +15343,33 @@ const GRAPH_TOOL_EXECUTORS = {
     // worse than the omission this closes.
     let liveScan = null;
     try {
+      // #1357 — the scan's combo lists cannot enumerate an input file below the
+      // input root (LoadImage.INPUT_TYPES is `os.listdir` + `isfile`, top level
+      // only) nor an `[output]`/`[temp]`-annotated value, so for those it asks
+      // the server directly rather than calling a present file missing. Same
+      // /view probe panel_set_widget already uses to server-confirm the very
+      // same value (#387) — the two must not contradict each other. The path
+      // split follows the SERVER's platform, exactly as the missing-media probe
+      // above does; an unknown platform keeps POSIX semantics so a backslash is
+      // never re-read as a separator the server would not honour (#513). Read
+      // BEFORE the scan's own budget is taken, so a slow /system_stats shortens
+      // the scan rather than letting it start with a full step it no longer has
+      // (it is cached for the session, and the media probe above normally warms
+      // it, so this is free in the common case).
+      const statsBudget = errorsStepBudget(GET_ERRORS_STEP_CAP_MS);
+      const backslashIsSeparator =
+        statsBudget > 0 ? await inputAssetServerUsesWindowsPaths(statsBudget) : false;
       const scanBudgetMs = errorsStepBudget(GET_ERRORS_STEP_CAP_MS);
       if (scanBudgetMs > 0) {
         liveScan = await scanComboAvailability(
           nodes,
           (cls) => fetchSingleNodeDef(cls, (route) => api?.fetchApi?.(route)),
-          { budgetMs: scanBudgetMs },
+          {
+            budgetMs: scanBudgetMs,
+            backslashIsSeparator,
+            confirmServerAsset: (_value, ref) =>
+              probeInputAssetPresence(ref, errorsStepBudget(GET_ERRORS_STEP_CAP_MS)),
+          },
         );
       }
     } catch {
@@ -15586,9 +15633,17 @@ const GRAPH_TOOL_EXECUTORS = {
             unavailable_widget_values_note: comboAvailabilityNote(liveScan.unavailable),
           }
         : {}),
-      ...(liveScan?.unknown?.length ? { unchecked_nodes: liveScan.unknown } : {}),
+      ...(liveScan?.unknown?.length
+        ? {
+            unchecked_nodes: liveScan.unknown,
+            unchecked_nodes_note: uncheckedNodesNote(liveScan.unknown),
+          }
+        : {}),
       ...(liveScan?.unchecked_budget_exhausted ? { unchecked_budget_exhausted: true } : {}),
       ...(liveScan?.unchecked_class_limit ? { unchecked_class_limit: liveScan.unchecked_class_limit } : {}),
+      ...(liveScan?.unchecked_asset_probe_limit
+        ? { unchecked_asset_probe_limit: liveScan.unchecked_asset_probe_limit }
+        : {}),
       ...(missingModels.length ? { missing_models: missingModels } : {}),
       ...(missingMedia.length ? { missing_media: missingMedia } : {}),
       ...(missingNodeTypes.length ? { missing_node_types: missingNodeTypes } : {}),

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -15345,18 +15345,20 @@ const GRAPH_TOOL_EXECUTORS = {
     try {
       // #1357 — the scan's combo lists cannot enumerate an input file below the
       // input root (LoadImage.INPUT_TYPES is `os.listdir` + `isfile`, top level
-      // only) nor an `[output]`/`[temp]`-annotated value, so for those it asks
-      // the server directly rather than calling a present file missing. The same
-      // /view EVIDENCE panel_set_widget accepts the very same value on (#387) —
-      // the two must not confirm and deny one value in one session. Not
-      // byte-for-byte the same probe: set_widget's inline one always normalises
-      // backslashes and always asks the `input` root, while this one parses the
-      // annotation for its root and splits on the SERVER's platform, exactly as
-      // the missing-media probe above does. Where they can differ (a `sub\a.png`
-      // on a POSIX server) this one is the STRICTER of the two — it declines to
-      // split, so the value stays reported. An unknown platform keeps POSIX
-      // semantics, so a backslash is never re-read as a separator the server
-      // would not honour (#513). Read
+      // only, nodes.py) nor an `[output]`/`[temp]`/`[input]`-annotated value, so
+      // for those it asks the server directly rather than calling a present file
+      // missing. The same /view EVIDENCE panel_set_widget accepts the very same
+      // value on (#387) — the two must not confirm and deny one value in one
+      // session. NOT byte-for-byte the same probe, and it diverges BOTH ways:
+      //   - `sub\a.png` on a POSIX server — set_widget normalises the backslash
+      //     and would clear it; this declines to split, so the value stays
+      //     reported. STRICTER.
+      //   - `x.png [output]` — set_widget always asks the `input` root and would
+      //     404; this parses the annotation and asks `output`, which is the root
+      //     `folder_paths.get_annotated_filepath` actually resolves. LOOSER, and
+      //     correct — that is the #743 false positive.
+      // An unknown platform keeps POSIX semantics, so a backslash is never
+      // re-read as a separator the server would not honour (#513). Read
       // BEFORE the scan's own budget is taken, so a slow /system_stats shortens
       // the scan rather than letting it start with a full step it no longer has
       // (it is cached for the session, and the media probe above normally warms

--- a/web/js/lib/asset-staleness.js
+++ b/web/js/lib/asset-staleness.js
@@ -626,7 +626,15 @@ export function graphErrorsFindingCounts(result) {
       (Number(r.missing_node_count) || 0) +
       arr(r.stale_placeholders).length,
     unavailable,
-    unchecked: arr(r.unchecked_nodes).length,
+    // #1357 — DISTINCT nodes, not entries. This feeds a pill that literally reads
+    // "{count} nodes could not be checked", and since #1357 one node can put
+    // several entries in that list: a widget value the server's combo has no
+    // authority over is reported per VALUE, so three nested LoadImage paths on one
+    // node used to render as "3 nodes". The list itself still carries every entry
+    // with its own reason; only the node COUNT is counted as nodes.
+    unchecked: new Set(
+      arr(r.unchecked_nodes).map((u, i) => (u?.id == null ? `#${i}` : `id:${String(u.id)}`)),
+    ).size,
   };
 }
 

--- a/web/js/lib/input-asset.js
+++ b/web/js/lib/input-asset.js
@@ -47,6 +47,47 @@ const UPLOAD_KIND_EXTENSIONS = {
 };
 
 /**
+ * The TRI-STATE verdict a ComfyUI `/view` existence probe supports (#1357).
+ *
+ *   true  — the server served the file: it is there.
+ *   false — the server ANSWERED and said it is not there (404).
+ *   null  — the question was NOT answered: no response, a traversal refusal (400),
+ *           an auth/proxy status, a 5xx, a timeout.
+ *
+ * The third state is load-bearing. A caller that only ever over-reports (the
+ * missing-media filter, which already has a STORE asserting the miss) may collapse
+ * `false` and `null` into "keep reporting". The live combo scan may NOT: its only
+ * other evidence is an option list that structurally cannot contain the value, so
+ * a flaky fetch read as a confirmed miss manufactures the exact false positive
+ * #1357 reported. `null` on every uncertainty, always.
+ */
+export function inputAssetProbeVerdict(res) {
+  try {
+    if (!res) return null;
+    if (res.ok === true || res.status === 206) return true;
+    return res.status === 404 ? false : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * `config` back, when it is an input spec's config object carrying at least one
+ * UPLOAD flag; otherwise null. Callers that already hold the per-input config
+ * (the live combo scan reads it straight out of `/object_info/<class>`) use this
+ * instead of re-walking a whole defs map, so both paths decide "is this an upload
+ * input" from the ONE flag list above.
+ */
+export function uploadConfigOf(config) {
+  try {
+    if (!config || typeof config !== "object") return null;
+    return UPLOAD_CONFIG_FLAGS.some((f) => config[f]) ? config : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
  * The config object for `widgetName` on the fresh /object_info def for `type`, when
  * that input is an UPLOAD input; otherwise null. ComfyUI encodes an input spec as
  * `[typeOrOptions, config?]`; an upload input carries e.g. `{ image_upload: true }`.
@@ -63,9 +104,7 @@ export function uploadInputConfig(defsByType, type, widgetName) {
       (input.required && input.required[widgetName]) ??
       (input.optional && input.optional[widgetName]);
     if (!Array.isArray(spec)) return null;
-    const config = spec[1];
-    if (!config || typeof config !== "object") return null;
-    return UPLOAD_CONFIG_FLAGS.some((f) => config[f]) ? config : null;
+    return uploadConfigOf(spec[1]);
   } catch {
     return null;
   }

--- a/web/js/lib/live-combo-availability.js
+++ b/web/js/lib/live-combo-availability.js
@@ -35,7 +35,14 @@
  * set a lora basename while the dropdown was empty.
  */
 
+
 import { isFrontendVirtualNode } from "./frontend-virtual-nodes.js";
+import {
+  parseAnnotatedFilepath,
+  splitInputAssetRef,
+  uploadConfigOf,
+  uploadInputAccepts,
+} from "./input-asset.js";
 
 /** Inputs whose combo lists name files on disk, rather than modes like
  *  `sampler_name: [euler, …]`. A value outside ANY combo's options is a genuine
@@ -63,12 +70,31 @@ export function optionsLookLikeFiles(options) {
  *   the class is absent (an `{}` body). null means UNKNOWN, never "no combos".
  */
 export function comboInputsOf(body, className) {
+  return parseClassCombos(body, className)?.options ?? null;
+}
+
+/**
+ * The CONFIG object each combo input carries, from the same body/parse as
+ * `comboInputsOf`. ComfyUI declares a combo as `[[...allowed], {opts}]`; `{opts}`
+ * is where an upload input announces itself (`{image_upload: true}`), and that
+ * flag is the only thing that distinguishes a list the server can fully enumerate
+ * from one it structurally cannot (see `scanComboAvailability`). null on an absent
+ * class, exactly like `comboInputsOf`.
+ *
+ * @returns {Map<string, object>|null} widget name -> config (`{}` when absent)
+ */
+export function comboConfigsOf(body, className) {
+  return parseClassCombos(body, className)?.configs ?? null;
+}
+
+function parseClassCombos(body, className) {
   if (!body || typeof body !== "object") return null;
   const spec = body[className];
   if (!spec || typeof spec !== "object") return null;
   const input = spec.input;
-  if (!input || typeof input !== "object") return new Map();
-  const out = new Map();
+  const options = new Map();
+  const configs = new Map();
+  if (!input || typeof input !== "object") return { options, configs };
   for (const group of ["required", "optional"]) {
     const entries = input[group];
     if (!entries || typeof entries !== "object") continue;
@@ -76,11 +102,12 @@ export function comboInputsOf(body, className) {
       // A combo is declared as `[[...allowed], {opts}]`; a typed input as
       // `["MODEL", {...}]`. Only the first form enumerates values.
       if (Array.isArray(def) && Array.isArray(def[0])) {
-        out.set(name, def[0].filter((v) => typeof v === "string"));
+        options.set(name, def[0].filter((v) => typeof v === "string"));
+        configs.set(name, def[1] && typeof def[1] === "object" ? def[1] : {});
       }
     }
   }
-  return out;
+  return { options, configs };
 }
 
 /**
@@ -129,10 +156,26 @@ export function linkDrivenWidgetNames(node) {
   return names;
 }
 
+/**
+ * #1357 — the wording for a value the combo has no jurisdiction over and the
+ * server could not be asked about. Kept in one place so "I could not check this"
+ * never drifts into reading like "I checked and it is fine".
+ */
+const UNENUMERABLE_PREFIX =
+  "not checked: this value names a file below the input root (or under an " +
+  "[output]/[temp] annotation), which /object_info's combo list cannot enumerate";
+
 export async function scanComboAvailability(
   nodes,
   fetchClassInfo,
-  { maxClasses = 80, budgetMs = 0, now = () => Date.now() } = {},
+  {
+    maxClasses = 80,
+    maxAssetProbes = 48,
+    budgetMs = 0,
+    now = () => Date.now(),
+    confirmServerAsset = null,
+    backslashIsSeparator = false,
+  } = {},
 ) {
   const unavailable = [];
   const unknown = [];
@@ -169,16 +212,83 @@ export async function scanComboAvailability(
     }
     let entry;
     try {
-      const combos = comboInputsOf(await fetchClassInfo(className), className);
+      const body = await fetchClassInfo(className);
+      const combos = comboInputsOf(body, className);
       entry = combos === null
         ? { reason: "node type not found in /object_info" }
-        : { combos };
+        : { combos, configs: comboConfigsOf(body, className) ?? new Map() };
     } catch {
       // A failed lookup is UNKNOWN, never "no combos".
       entry = { reason: "node type could not be looked up (/object_info call failed)" };
     }
     cache.set(className, entry);
     return entry;
+  };
+
+  // #1357 — an UPLOAD combo is the one option list the server cannot fully
+  // enumerate, so non-membership in it is NOT evidence of absence.
+  //
+  // ComfyUI's LoadImage.INPUT_TYPES lists only TOP-LEVEL files of the input dir
+  // (`os.listdir` + `isfile`), yet `folder_paths.get_annotated_filepath` happily
+  // resolves `AgentLibrary/HaReen/Main-9-1.png` — and an `x.png [output]` value
+  // resolves against a DIFFERENT root entirely. Such a value can therefore NEVER
+  // be a member of the combo, no matter how fresh the fetch. Calling it
+  // `missing_asset` is exactly the "could not look it up" / "looked it up and it
+  // is not there" collapse this module exists to prevent: the reporter's file was
+  // on disk, `panel_set_widget` had already server-confirmed it via the SAME
+  // /view probe (#387), and get_errors contradicted it in the next breath.
+  //
+  // So for those values the combo abstains and the SERVER is asked instead:
+  //   present  -> nothing to report
+  //   absent   -> a real answer; report it exactly as before
+  //   no answer (no probe injected, failed, capped, out of budget) -> UNKNOWN
+  //
+  // Everything else keeps the combo as the authority: a BARE root-level name IS
+  // enumerated, a non-upload combo (`ckpt_name`, whose folder_paths listing IS
+  // recursive) IS enumerated, and a value whose extension is not a loadable asset
+  // of this input's upload kind stays rejected on #240 strictness — a mere /view
+  // hit proves a file exists, not that LoadImage can load it.
+  const assetProbes = new Map();
+  let assetProbeCount = 0;
+  let assetProbeLimitHit = false;
+  const adjudicateUnenumerableAsset = async (config, value) => {
+    const cfg = uploadConfigOf(config);
+    if (!cfg) return null;
+    const { name: bare, type: root, annotated } = parseAnnotatedFilepath(value);
+    const { subfolder, filename } = splitInputAssetRef(bare, { backslashIsSeparator });
+    if (!filename) return null;
+    if (!annotated && !subfolder) return null;
+    if (!uploadInputAccepts(cfg, bare)) return null;
+    if (typeof confirmServerAsset !== "function") {
+      return { reason: `${UNENUMERABLE_PREFIX}, and no server file check was available` };
+    }
+    const key = `${root}:${subfolder}/${filename}`;
+    let probe = assetProbes.get(key);
+    if (!probe) {
+      if (assetProbeCount >= maxAssetProbes) {
+        assetProbeLimitHit = true;
+        return { reason: `${UNENUMERABLE_PREFIX}, and this call's ${maxAssetProbes}-file server-existence probe cap was reached` };
+      }
+      if (now() >= deadline) {
+        outOfBudget = true;
+        return { reason: `${UNENUMERABLE_PREFIX}, and get_errors ran out of its shared server-call budget` };
+      }
+      assetProbeCount += 1;
+      // The injected probe is TRI-state on purpose: `false` must mean "the server
+      // answered and the file is not there" and nothing else, or a flaky fetch
+      // would masquerade as a confirmed miss.
+      probe = Promise.resolve()
+        .then(() => confirmServerAsset(value, { filename, subfolder, type: root }))
+        .then(
+          (r) => (r === true ? "present" : r === false ? "absent" : "unknown"),
+          () => "unknown",
+        );
+      assetProbes.set(key, probe);
+    }
+    const verdict = await probe;
+    if (verdict === "present") return { present: true };
+    if (verdict === "absent") return null;
+    return { reason: `${UNENUMERABLE_PREFIX}, and the server file check did not answer` };
   };
 
   for (const node of nodes) {
@@ -227,6 +337,14 @@ export async function scanComboAvailability(
       const value = widget.value;
       if (typeof value !== "string" || value === "") continue;
       if (options.includes(value)) continue;
+      // #1357 — before calling it missing, check whether this combo could have
+      // listed it at all.
+      const asset = await adjudicateUnenumerableAsset(entry.configs?.get(name), value);
+      if (asset?.present) continue;
+      if (asset?.reason) {
+        unknown.push({ id: node.id, type: className, widget: name, value, reason: asset.reason });
+        continue;
+      }
       unavailable.push({
         id: node.id,
         type: className,
@@ -241,11 +359,13 @@ export async function scanComboAvailability(
       });
     }
   }
-  if (!truncated) return { unavailable, unknown };
+  if (!truncated && !outOfBudget && !assetProbeLimitHit) return { unavailable, unknown };
   return {
     unavailable,
     unknown,
-    ...(outOfBudget ? { unchecked_budget_exhausted: true } : { unchecked_class_limit: maxClasses }),
+    ...(outOfBudget ? { unchecked_budget_exhausted: true } : {}),
+    ...(truncated && !outOfBudget ? { unchecked_class_limit: maxClasses } : {}),
+    ...(assetProbeLimitHit ? { unchecked_asset_probe_limit: maxAssetProbes } : {}),
   };
 }
 
@@ -265,7 +385,34 @@ export function comboAvailabilityNote(unavailable) {
     `load-time missing-model scan it DOES see nodes added this session. It covers ` +
     `the graph level currently being viewed; nodes inside a subgraph you are not ` +
     `in are NOT scanned, so an empty list here is not proof about them. A node ` +
-    `whose type could not be resolved is listed under unchecked_nodes rather ` +
-    `than being reported as healthy.`
+    `whose type could not be resolved — or a value this scan has no authority ` +
+    `over — is listed under unchecked_nodes rather than being reported as healthy.`
+  );
+}
+
+/**
+ * Wording for `unchecked_nodes`, emitted whenever the scan abstained. Without it
+ * an abstention sits in the payload next to "no errors recorded" and reads as a
+ * clearance, which is the reading #1357 was harmed by — in the opposite
+ * direction, but from the same collapse of "unknown" into a verdict.
+ */
+export function uncheckedNodesNote(unknown) {
+  if (!Array.isArray(unknown) || unknown.length === 0) return "";
+  const values = unknown.filter((u) => typeof u?.widget === "string").length;
+  const types = unknown.length - values;
+  const parts = [];
+  if (types) parts.push(`${types} node(s) whose type this scan could not resolve`);
+  if (values) {
+    parts.push(
+      `${values} widget value(s) the server's combo list has no authority over ` +
+        `(an input file below the input root, or one carrying an [output]/[temp] ` +
+        `annotation, which /object_info never enumerates)`,
+    );
+  }
+  return (
+    `NOT CHECKED: ${parts.join(" and ")}. These are abstentions, not clearances: ` +
+    `each entry carries the reason it could not be judged. Nothing here is a ` +
+    `report that the value is missing, and nothing here is a report that it is ` +
+    `fine — confirm the file yourself if it matters.`
   );
 }

--- a/web/js/lib/live-combo-availability.js
+++ b/web/js/lib/live-combo-availability.js
@@ -35,7 +35,6 @@
  * set a lora basename while the dropdown was empty.
  */
 
-
 import { isFrontendVirtualNode } from "./frontend-virtual-nodes.js";
 import {
   parseAnnotatedFilepath,
@@ -163,7 +162,7 @@ export function linkDrivenWidgetNames(node) {
  */
 const UNENUMERABLE_PREFIX =
   "not checked: this value names a file below the input root (or under an " +
-  "[output]/[temp] annotation), which /object_info's combo list cannot enumerate";
+  "[output]/[temp]/[input] annotation), which /object_info's combo list cannot enumerate";
 
 export async function scanComboAvailability(
   nodes,
@@ -409,7 +408,7 @@ export function uncheckedNodesNote(unknown) {
   if (values) {
     parts.push(
       `${values} widget value(s) the server's combo list has no authority over ` +
-        `(an input file below the input root, or one carrying an [output]/[temp] ` +
+        `(an input file below the input root, or one carrying an [output]/[temp]/[input] ` +
         `annotation, which /object_info never enumerates)`,
     );
   }

--- a/web/js/lib/live-combo-availability.js
+++ b/web/js/lib/live-combo-availability.js
@@ -401,7 +401,11 @@ export function uncheckedNodesNote(unknown) {
   const values = unknown.filter((u) => typeof u?.widget === "string").length;
   const types = unknown.length - values;
   const parts = [];
-  if (types) parts.push(`${types} node(s) whose type this scan could not resolve`);
+  // "could not resolve the type" would be wrong for two of the three ways a NODE
+  // lands here — the class cap and the budget cutoff both skip a type that
+  // resolves perfectly well. The per-entry `reason` distinguishes them; this
+  // summary must not assert a cause it has not read.
+  if (types) parts.push(`${types} node(s) this scan could not judge`);
   if (values) {
     parts.push(
       `${values} widget value(s) the server's combo list has no authority over ` +


### PR DESCRIPTION
Closes #1357

## The contradiction

`upload_image` put `AgentLibrary/HaReen/Main-9-1.png` in the input directory.
`panel_set_widget` wrote it and answered **`server_confirmed: true`**.
`panel_get_errors`, in the same session, listed that exact value under
`unavailable_widget_values` as **`missing_asset`**. Both files were on disk.
Using root-level filenames made the "error" disappear.

## Cause

`LoadImage.INPUT_TYPES` builds its option list from `os.listdir(input_dir)`
filtered by `isfile` — **top level only** — while
`folder_paths.get_annotated_filepath` resolves nested paths perfectly well. So a
`subfolder/name.png` value can *never* be a member of that combo, no matter how
fresh the `/object_info` fetch, and the #745 live scan's `options.includes(value)`
returning false said **nothing at all** about whether the file existed.

This was already known in two other places in this panel:

- `set-widget.js` — the #387 upload-asset recovery, whose header spells out this
  exact ComfyUI behaviour and probes `/view` to accept the value.
- `input-asset.js` — the #513/#743 `filterServerConfirmedInputSubfolderCandidates`
  used by the *store*-driven missing-media path.

The live scan (`live-combo-availability.js`, landed independently in `def53f0e`)
never got the same treatment. Not a regression of a prior fix — a gap between two
detection halves that were built at different times. The result was the panel
confirming and denying the same value in one session.

## The fix

For a value the combo has **no jurisdiction over** — an upload input (`image_upload`
/ `video_upload` / `audio_upload` / `model_upload`) holding a nested path or an
`[output]`/`[temp]`/`[input]`-annotated value — the scan asks the server through the
same `/view` probe `set_widget` used to confirm it:

| server says | scan says |
|---|---|
| present | nothing reported |
| absent (404) | reported, exactly as before |
| did not answer | **UNKNOWN**, with the reason, under `unchecked_nodes` |

The third row is why the probe is **tri-state**. Only a 404 means "not there". A
400 traversal refusal, a 403, a 5xx or a timeout means the question was not
answered — collapsing those into "absent" would rebuild this bug out of a flaky
fetch. The store-driven missing-media filter keeps its old floor (`=== true`): it
has a prior assertion from the frontend store that the live scan does not.

### What deliberately did NOT change

The issue proposed normalizing separators before the membership comparison. That
would not have fixed it: the qualified path is absent from the option list under
*any* separator. The combo stays the authority everywhere it actually is one:

- a **bare root-level** name IS enumerated → absence is a real answer, and costs no probe
- a **non-upload** combo (`ckpt_name` — `folder_paths` lists checkpoints *recursively*) IS enumerated
- a nested value whose extension is not a loadable asset of this input's upload kind stays rejected on #240 strictness — `/view` serves *any* input file, so a hit proves existence, not loadability
- a backslash is split only where the **server** would split it (#513); the default is POSIX, so an unknown platform never re-reads one as a separator

### Bounds and disclosure

One probe per distinct **file** (not per node), a 48-file cap, and the shared #589
`get_errors` budget — read *before* the scan takes its own step, so a slow
`/system_stats` shortens the scan instead of letting it start with a step it no
longer has. Past either bound the value is UNCHECKED and says so:
`unchecked_asset_probe_limit`, and a new `unchecked_nodes_note` that words an
abstention as an abstention rather than letting it sit beside "no errors recorded"
reading like a clearance.

## Verification

`npm run test:unit` — **5162/5164 pass**, `check-panel-scope` OK (every name in the
monolith resolves). The 2 failures are the documented #671 wall-clock flakes;
`manager-install.test.mjs` run alone is **125/125**.

**Verified by mutation.** Replacing the adjudication call with `const asset = null`
turns **8 of the 21** new tests red, including the reporter's exact value:

```
✖ a server-CONFIRMED nested upload value is not reported at all
✖ an UNANSWERABLE probe is UNKNOWN — not missing, not clean
✖ with NO probe injected the value is unknown, never a finding
✖ an [output]-annotated value is unenumerable too, and probes that root
✖ a ROOT-level [temp] value is unenumerable
✖ a backslash value is split only where the SERVER would split it
✖ one probe per distinct FILE, not per node
✖ the probe cap is disclosed, never silently truncated
```

The 9 that stay green under mutation are the negative controls (bare name,
non-upload combo, `.txt` extension, POSIX backslash default, class-limit naming) —
they pin behaviour this change must *not* alter, so passing both ways is correct.

Three `WIRING:` tests read the real panel source, because the lib's own default is
"no probe" (which abstains rather than clears) — a missed injection would be
invisible to every lib-level test above.

## Gate

**SHIP** — five clean rounds (exit 0 each), the last two against the rebased branch.

> codex was unavailable (account exhausted until 2026-08-19 20:43); gated by an
> independent adversarial review instead, per the owner-authorised substitution.
> Each round spawns a fresh reviewer that never saw this PR's reasoning.

Every round ran the code rather than reading it. Between them they:

- drove `inputAssetProbeVerdict` against ~13 hostile Response shapes — no `status`,
  a `"404"` *string*, an `ok` getter that throws, statuses 0/400/401/403/429/5xx —
  and confirmed `null` on every uncertainty
- traced all four platform × annotation combinations through ComfyUI's own
  `annotated_filepath` → `commonpath` → `basename` and confirmed the probe lands on
  the file `LoadImage` would resolve
- checked `Load3D`: it declares `file_upload`, which is *not* in `UPLOAD_CONFIG_FLAGS`,
  so its recursively-listed combo correctly stays the authority
- re-derived the budget bound instead of taking my word: each probe's grant is
  `min(4000, 18000 − elapsed)`, so overrun is capped at one in-flight probe and total
  elective wait stays under the 20 s bridge read. Measured live: 60 nested values
  against a 150 ms-RTT server → 4055 ms, 26 probed, 34 abstained, flag set
- ran ~13 mutations per round; every load-bearing one went red, including deleting
  the panel's `confirmServerAsset` wiring

Three findings, all fixed here, none behavioural:

| round | finding | commit |
|---|---|---|
| 1 | a comment claimed this was the "same /view probe" as `set_widget` — it shares the *evidence*, not the implementation | `ee34baa1` |
| 2 | `uncheckedNodesNote` summarised every node-level abstention as "type could not be resolved", but that bucket also holds class-cap and budget skips | `16dfc682` |
| 4 | the `unchecked` pill reads "{count} **nodes** could not be checked" while counting *entries* — since this branch, one node can contribute several | `a49109b3` |

That last one is a real user-visible defect this branch would otherwise have
introduced: three nested `LoadImage` paths on one node would have rendered as
"3 nodes". Now counts distinct node ids, with an id-less entry counted rather than
merged, so it can only over-state how much was skipped — never under-state it.
Mutation-verified: reverting it turns both new `asset-staleness` tests red.

## Test results

`npm run test:unit` — **5381/5383**, plus `i18n-check`, `i18n-render-check`,
`check-tool-vocabulary`, `check-panel-scope` ("every name resolves") and
`tsc --noEmit` all clean. The 2 are the documented #671 wall-clock flakes;
`manager-install.test.mjs` alone is **125/125**.

Rebased onto the 17 commits main moved during this work. The one conflict was an
import line against #1284's `isFrontendVirtualNode`; the two changes are orthogonal
(that skips virtual nodes *before* the class lookup, this adjudicates upload values
*after* it) and the full suite is green with both.

## Browser verification — NOT run, and why

The Playwright suite needs a live ComfyUI at `localhost:8188` with this pack
junctioned into `custom_nodes`. Nothing was listening on 8188/8189/8288/8000 during
this run and no isolated ComfyUI was allocated to it, so **the e2e suite did not
run** — I am not claiming coverage I do not have.

Scope note, not an excuse: this change renders nothing. It alters the
`panel_get_errors` reply payload, two pure lib modules, and one count feeding an
existing pill — no new DOM, no CSS, no sidebar element. What a browser run would
genuinely add is integration against a real `/object_info` and `/view`: a reviewer
with a live rig should replay the issue's five steps (upload to a subfolder →
`panel_set_widget` → `panel_get_errors`) as the end-to-end confirmation.
