### PR TITLE
fix(1306): panel_edit_group bounds writes the box only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project are documented here. This project adheres to
 ## [Unreleased]
 
 ### Fixed
+- `panel_edit_group({bounds})` writes the group box only — contained nodes stay at their canvas coordinates (#1306)
 - an already-full origin can save workflow drafts again after the chat-history quota fix (#1305)
 - a group that encloses rgthree Label nodes now moves, instead of being refused because those nodes' visual bounds are not the panel's generic footprint — the same nodes already moved fine one-by-one with panel_edit_node (#1300)
 - a subgraph preview widget is promoted through the frontend's previewExposure store, and a failed link-only promote no longer hides behind a missing promotion store (#1271)

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ which receives `panel_*` by a different route.
 | Tool | Effect |
 |---|---|
 | `panel_move_rail` | Move a subgraph's input / output rail so boundary wires stay short |
-| `panel_create_group` / `panel_move_group` / `panel_edit_group` / `panel_remove_group` | Create, move, retitle/recolor, or delete a labeled group box |
+| `panel_create_group` / `panel_move_group` / `panel_edit_group` / `panel_remove_group` | Create, move, retitle/recolor/resize the box, or delete a labeled group box. `panel_edit_group({bounds})` writes the rectangle only — contained nodes stay put (`panel_move_group` translates them) |
 | `panel_screenshot` | Render the canvas to a PNG so the agent can verify its own layout |
 
 **Workflow tabs**

--- a/browser_tests/unit/edit-group-bounds.test.mjs
+++ b/browser_tests/unit/edit-group-bounds.test.mjs
@@ -1,0 +1,273 @@
+// #1306: `panel_edit_group({bounds})` writes the group BOX only. Contained
+// nodes, nested group boxes and reroutes stay at their canvas coordinates.
+// Some frontends couple a pos / _bounding write to LGraphGroup.move(), which
+// translates the cached `_children` set — the handler must pin those items
+// and put them back after the box write.
+//
+// These tests extract the SHIPPED graph_edit_group (plus resolveGroup /
+// setGroupBounds / summarizeGroup) out of the panel source and run it against
+// LiteGraph-shaped doubles, so they verify the real implementation rather than
+// a copy of it.
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import {
+  groupMemberNodes,
+  syncGraphNodeAreas,
+  holdGraphItemPositions,
+} from "../../web/js/lib/group-geometry.js";
+import { clipOutlineTitle } from "../../web/js/lib/graph-read.js";
+
+const panelPath = fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url));
+const panelSrc = readFileSync(panelPath, "utf8");
+
+const grab = (re, what) => {
+  const m = panelSrc.match(re);
+  assert.ok(m, `could not locate ${what} in panel source`);
+  return m[0];
+};
+
+const resolveGroupSrc = grab(/\nfunction resolveGroup\(graph, groupId\) \{[\s\S]*?\n\}/, "resolveGroup");
+const setGroupBoundsSrc = grab(/\nfunction setGroupBounds\(group, \[x, y, w, h\]\) \{[\s\S]*?\n\}/, "setGroupBounds");
+const summarizeGroupSrc = grab(/\nfunction summarizeGroup\(graph, g\) \{[\s\S]*?\n\}/, "summarizeGroup");
+const editGroupSrc = grab(/ {2}graph_edit_group\(\{ group_id, title, color, font_size, bounds \}\) \{[\s\S]*?\n {2}\},/, "graph_edit_group");
+const GROUP_NODE_IDS_CAP = Number(
+  grab(/\nconst GROUP_NODE_IDS_CAP = (\d+);/, "GROUP_NODE_IDS_CAP").match(/(\d+)/)[1],
+);
+
+/** The real shipped handler, wired to the real shipped geometry lib.
+ *
+ *  `"use strict"` is required: the panel is an ES module, so a write to a frozen
+ *  array or a setter-less accessor THROWS. A sloppy `new Function` body would
+ *  silently drop those writes and let every "frontend couples pos to move"
+ *  test pass against the wrong language. */
+function realEditGroup(graph) {
+  const getGraphCtx = () => ({ graph });
+  return new Function(
+    "getGraphCtx",
+    "syncGraphNodeAreas",
+    "groupMemberNodes",
+    "holdGraphItemPositions",
+    "clipOutlineTitle",
+    "GROUP_NODE_IDS_CAP",
+    `"use strict";
+     ${resolveGroupSrc}
+     ${setGroupBoundsSrc}
+     ${summarizeGroupSrc}
+     const executors = { ${editGroupSrc} };
+     return executors.graph_edit_group;`,
+  )(
+    getGraphCtx,
+    syncGraphNodeAreas,
+    groupMemberNodes,
+    holdGraphItemPositions,
+    clipOutlineTitle,
+    GROUP_NODE_IDS_CAP,
+  );
+}
+
+function node(id, pos, size = [100, 100], rect = null) {
+  return {
+    id,
+    pos: [...pos],
+    size: [...size],
+    boundingRect: rect ? [...rect] : [pos[0], pos[1] - 30, size[0], size[1] + 30],
+  };
+}
+
+function group(id, bounding, title = `G${id}`) {
+  return { id, title, _bounding: [...bounding], recomputeInsideNodes() {} };
+}
+
+function makeGraph({ nodes = [], groups = [], reroutes = null } = {}) {
+  return {
+    _nodes: nodes,
+    _groups: groups,
+    ...(reroutes ? { reroutes } : {}),
+    beforeChange() { this.beforeCount = (this.beforeCount ?? 0) + 1; },
+    afterChange() { this.afterCount = (this.afterCount ?? 0) + 1; },
+    setDirtyCanvas() { this.dirty = true; },
+  };
+}
+
+/** A group whose `pos` setter is LGraphGroup.move() — the #1306 frontend.
+ *  No `_bounding`, so setGroupBounds falls through to pos/size. The setter
+ *  translates every cached child by the origin delta. */
+function groupThatMovesChildrenOnPos(id, bounding, children) {
+  const box = [...bounding];
+  return {
+    id,
+    title: `G${id}`,
+    _children: new Set(children),
+    _nodes: children,
+    get pos() { return [box[0], box[1]]; },
+    set pos(v) {
+      const dx = Number(v[0]) - box[0];
+      const dy = Number(v[1]) - box[1];
+      box[0] = Number(v[0]);
+      box[1] = Number(v[1]);
+      for (const n of this._children) {
+        n.pos[0] += dx;
+        n.pos[1] += dy;
+        if (n.boundingRect) {
+          n.boundingRect[0] += dx;
+          n.boundingRect[1] += dy;
+        }
+      }
+    },
+    get size() { return [box[2], box[3]]; },
+    set size(v) {
+      box[2] = Number(v[0]);
+      box[3] = Number(v[1]);
+    },
+    recomputeInsideNodes() {},
+  };
+}
+
+/** A group whose `_bounding` write (setGroupBounds' preferred path) translates
+ *  cached children — a Proxy over the live quad, the other #1306 frontend. */
+function groupThatMovesChildrenOnBounding(id, bounding, children) {
+  const raw = [...bounding];
+  const g = {
+    id,
+    title: `G${id}`,
+    _children: new Set(children),
+    _nodes: children,
+    recomputeInsideNodes() {},
+  };
+  g._bounding = new Proxy(raw, {
+    get: (target, prop) => Reflect.get(target, prop, target),
+    set(target, prop, value) {
+      if (prop === "0" || prop === "1") {
+        const idx = Number(prop);
+        const delta = Number(value) - target[idx];
+        target[idx] = Number(value);
+        if (delta) {
+          for (const n of g._children) {
+            n.pos[idx] += delta;
+            if (n.boundingRect) n.boundingRect[idx] += delta;
+          }
+        }
+        return true;
+      }
+      target[prop] = value;
+      return true;
+    },
+  });
+  return g;
+}
+
+// ---------------------------------------------------------------------------
+
+test("#1306: editing bounds does not translate contained nodes (plain _bounding)", () => {
+  const a = node(7, [1360, 0]);
+  const b = node(8, [1360, 200]);
+  const away = node(9, [9000, 9000]);
+  const g = group(1, [1300, -40, 400, 400]);
+  const graph = makeGraph({ nodes: [a, b, away], groups: [g] });
+
+  const out = realEditGroup(graph)({ group_id: 1, bounds: [1400, 50, 800, 600] });
+
+  assert.deepEqual(a.pos, [1360, 0], "member node must stay at its canvas coordinate");
+  assert.deepEqual(b.pos, [1360, 200], "the other member must stay put too");
+  assert.deepEqual(away.pos, [9000, 9000], "a node outside the box is not a member and must not move");
+  assert.deepEqual(out.group.bounding, [1400, 50, 800, 600], "the box itself moved");
+  assert.equal(graph.beforeCount, 1);
+  assert.equal(graph.afterCount, 1);
+});
+
+test("#1306: a pos-setter that is LGraphGroup.move() still leaves nodes put", () => {
+  const a = node(7, [1360, 0]);
+  const b = node(8, [5800, 0]);
+  const g = groupThatMovesChildrenOnPos(1, [1300, -40, 500, 200], [a, b]);
+  const graph = makeGraph({ nodes: [a, b], groups: [g] });
+
+  const out = realEditGroup(graph)({ group_id: 1, bounds: [1490, 3, 800, 400] });
+
+  assert.deepEqual(a.pos, [1360, 0], "the move-on-pos frontend must not drag node 7");
+  assert.deepEqual(b.pos, [5800, 0], "the move-on-pos frontend must not drag node 8");
+  assert.deepEqual(out.group.bounding, [1490, 3, 800, 400]);
+});
+
+test("#1306: a _bounding write that translates children still leaves nodes put", () => {
+  const a = node(33, [3050, 450]);
+  const g = groupThatMovesChildrenOnBounding(1, [3000, 400, 400, 300], [a]);
+  const graph = makeGraph({ nodes: [a], groups: [g] });
+
+  const out = realEditGroup(graph)({ group_id: 1, bounds: [3941, 12, 500, 300] });
+
+  assert.deepEqual(a.pos, [3050, 450], "the _bounding-proxy frontend must not drag the decode node");
+  assert.deepEqual(out.group.bounding, [3941, 12, 500, 300]);
+});
+
+test("#1306: shrinking the box leaves nodes put and drops them from membership", () => {
+  const a = node(7, [50, 50]);
+  const b = node(8, [250, 50]);
+  const g = group(1, [0, 0, 400, 200]);
+  const graph = makeGraph({ nodes: [a, b], groups: [g] });
+
+  const out = realEditGroup(graph)({ group_id: 1, bounds: [0, 0, 120, 200] });
+
+  assert.deepEqual(a.pos, [50, 50]);
+  assert.deepEqual(b.pos, [250, 50], "the node that fell outside must not have been translated");
+  assert.deepEqual(out.group.node_ids, [7], "membership follows the NEW box from live geometry");
+  assert.equal(out.group.node_count, 1);
+});
+
+test("#1306: nested group boxes and reroutes stay put when the outer box is resized", () => {
+  const inner = group(2, [50, 50, 100, 100], "Inner");
+  const outer = group(1, [0, 0, 400, 400], "Outer");
+  const a = node(7, [70, 90], [60, 40]);
+  const elbow = { id: 11, pos: [100, 100] };
+  const graph = makeGraph({
+    nodes: [a],
+    groups: [outer, inner],
+    reroutes: new Map([[11, elbow]]),
+  });
+
+  realEditGroup(graph)({ group_id: 1, bounds: [200, 200, 500, 500] });
+
+  assert.deepEqual(a.pos, [70, 90], "the inner node stayed");
+  assert.deepEqual(inner._bounding, [50, 50, 100, 100], "the nested group box stayed");
+  assert.deepEqual([elbow.pos[0], elbow.pos[1]], [100, 100], "the enclosed reroute stayed");
+});
+
+test("#1306: a stale _children cache that still lists a departed node does not drag it", () => {
+  const inside = node(7, [50, 50]);
+  const departed = node(8, [5000, 5000]);
+  const g = groupThatMovesChildrenOnBounding(1, [0, 0, 200, 200], [inside, departed]);
+  const graph = makeGraph({ nodes: [inside, departed], groups: [g] });
+
+  realEditGroup(graph)({ group_id: 1, bounds: [100, 100, 200, 200] });
+
+  assert.deepEqual(inside.pos, [50, 50]);
+  assert.deepEqual(departed.pos, [5000, 5000], "a stale cached child that left the box must not ride along");
+});
+
+test("#1306: title-only edits do not touch node positions or the box", () => {
+  const a = node(7, [50, 50]);
+  const g = group(1, [0, 0, 200, 200], "Old");
+  const graph = makeGraph({ nodes: [a], groups: [g] });
+
+  const out = realEditGroup(graph)({ group_id: 1, title: "New" });
+
+  assert.equal(out.group.title, "New");
+  assert.deepEqual(out.group.bounding, [0, 0, 200, 200]);
+  assert.deepEqual(a.pos, [50, 50]);
+});
+
+test("#1306: non-finite bounds are refused and nothing is written", () => {
+  const a = node(7, [50, 50]);
+  const g = group(1, [0, 0, 200, 200]);
+  const graph = makeGraph({ nodes: [a], groups: [g] });
+  const edit = realEditGroup(graph);
+
+  for (const bad of [[Number.NaN, 0, 10, 10], [0, undefined, 10, 10], [10, 10], "0,0,10,10", [0, 0, 10]]) {
+    assert.throws(() => edit({ group_id: 1, bounds: bad }), /bounds must be \[x, y, w, h\] finite numbers/);
+  }
+  assert.deepEqual(a.pos, [50, 50]);
+  assert.deepEqual(g._bounding, [0, 0, 200, 200]);
+  assert.equal(graph.beforeCount, undefined, "a refused bounds write must not open an undo transaction");
+});

--- a/browser_tests/unit/group-geometry.test.mjs
+++ b/browser_tests/unit/group-geometry.test.mjs
@@ -22,6 +22,7 @@ import {
   syncNodeArea,
   syncGraphNodeAreas,
   moveGroupMembers,
+  holdGraphItemPositions,
   nodeAreaIsLive,
   nodeAreaOriginTracks,
 } from "../../web/js/lib/group-geometry.js";
@@ -953,4 +954,41 @@ test("#813 a node whose flags accessor THROWS is stuck, not repaired", () => {
   }, "a hostile accessor must never escape the mover");
   assert.deepEqual(r.moved, [], "an unreadable node is not reported moved");
   assert.deepEqual(r.stuck, [n]);
+});
+
+// ---- holdGraphItemPositions: pin the graph while a box-only write runs (#1306) ----
+
+test("#1306 holdGraphItemPositions puts nodes, nested boxes and reroutes back", () => {
+  const a = node(1, 100, 100);
+  const inner = groupBox([50, 50, 80, 80]);
+  const outer = groupBox([0, 0, 400, 400]);
+  const elbow = { id: 11, pos: [120, 120] };
+  const graph = {
+    _nodes: [a],
+    _groups: [outer, inner],
+    reroutes: [elbow],
+  };
+  const hold = holdGraphItemPositions(graph, outer);
+  a.pos = [999, 999];
+  inner._bounding = [1, 2, 3, 4];
+  elbow.pos = [0, 0];
+  outer._bounding = [200, 200, 500, 500];
+  hold.restore();
+  assert.deepEqual(a.pos, [100, 100], "the node is back");
+  assert.deepEqual(inner._bounding, [50, 50, 80, 80], "the nested box is back");
+  assert.deepEqual(elbow.pos, [120, 120], "the reroute is back");
+  assert.deepEqual(outer._bounding, [200, 200, 500, 500], "the excepted group is left at its new box");
+});
+
+test("#1306 holdGraphItemPositions never throws on a hostile walk", () => {
+  const graph = {
+    get _nodes() { throw new TypeError("revoked"); },
+    get _groups() { throw new TypeError("revoked"); },
+    get reroutes() { throw new TypeError("revoked"); },
+  };
+  let hold;
+  assert.doesNotThrow(() => {
+    hold = holdGraphItemPositions(graph, null);
+  });
+  assert.doesNotThrow(() => hold.restore());
 });

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -472,6 +472,7 @@ import {
   moveReroutePoints,
   rerouteWriteIsSound,
   groupBoxIsAt,
+  holdGraphItemPositions,
   describeItems,
   describeThrown,
 } from "./lib/group-geometry.js";
@@ -18116,6 +18117,10 @@ const GRAPH_TOOL_EXECUTORS = {
   },
 
   // Edit a group's title / color / font_size / bounds — only the fields passed.
+  // bounds writes the BOX only. Contained nodes, nested groups and reroutes stay
+  // at their canvas coordinates (use panel_move_group to translate them). Some
+  // frontends couple a pos / _bounding write to LGraphGroup.move(), which would
+  // otherwise drag the cached children along with the box (#1306).
   graph_edit_group({ group_id, title, color, font_size, bounds }) {
     const { graph } = getGraphCtx();
     const g = resolveGroup(graph, group_id);
@@ -18123,12 +18128,32 @@ const GRAPH_TOOL_EXECUTORS = {
     // returned node_ids reflect the CURRENT layout, not a stale cached rect (the
     // exact "edit_group still reported the old members" symptom in the report).
     syncGraphNodeAreas(graph);
+    let wantBounds = null;
+    if (bounds != null) {
+      const badBounds = new Error(
+        "bounds must be [x, y, w, h] finite numbers — this edits the group box only; contained nodes stay put (use panel_move_group to translate them)",
+      );
+      if (!Array.isArray(bounds) || bounds.length !== 4) throw badBounds;
+      try {
+        wantBounds = [Number(bounds[0]), Number(bounds[1]), Number(bounds[2]), Number(bounds[3])];
+      } catch {
+        throw badBounds;
+      }
+      if (wantBounds.some((n) => !Number.isFinite(n))) throw badBounds;
+    }
+    // Pin every item on the graph BEFORE the box write. Snapshotting only current
+    // geometric members would miss a stale `_children` cache that move() still
+    // translates.
+    const hold = wantBounds ? holdGraphItemPositions(graph, g) : null;
     graph.beforeChange();
     try {
       if (typeof title === "string") g.title = title;
       if (color != null) g.color = String(color);
       if (Number.isFinite(font_size)) g.font_size = Number(font_size);
-      if (Array.isArray(bounds) && bounds.length === 4) setGroupBounds(g, bounds.map(Number));
+      if (wantBounds) {
+        setGroupBounds(g, wantBounds);
+        hold.restore();
+      }
       g.recomputeInsideNodes?.();
     } finally {
       graph.afterChange();

--- a/web/js/lib/group-geometry.js
+++ b/web/js/lib/group-geometry.js
@@ -1160,6 +1160,87 @@ export function placeReroute(r, x, y) {
 }
 
 /**
+ * Snapshot every node position, every other group box, and every reroute on
+ * the graph, then put them back. A box-only bounds write must not be a group
+ * drag (#1306): some frontends couple `pos` / `_bounding` writes to
+ * LGraphGroup.move(), which translates the cached `_children` set.
+ *
+ * The snapshot is the WHOLE graph, not just current geometric members. A stale
+ * `_children` cache can still include nodes that have left the box, and those
+ * would ride along if we only pinned the live members.
+ *
+ * NEVER THROWS. Restore is best-effort per item — one unrestorable node must
+ * not stop the rest, and must not replace the caller's stated outcome with a
+ * raw TypeError.
+ */
+export function holdGraphItemPositions(graph, exceptGroup) {
+  const nodeSnap = [];
+  try {
+    for (const n of graph?._nodes ?? []) {
+      try {
+        const x = Number(n?.pos?.[0]);
+        const y = Number(n?.pos?.[1]);
+        if (Number.isFinite(x) && Number.isFinite(y)) nodeSnap.push([n, x, y]);
+      } catch {
+        /* unreadable node — skip */
+      }
+    }
+  } catch {
+    /* walk failed — restore what we captured */
+  }
+
+  const groupSnap = [];
+  try {
+    for (const other of graph?._groups ?? []) {
+      if (!other || other === exceptGroup) continue;
+      try {
+        const b = groupBoundsOf(other);
+        if (b) groupSnap.push([other, b]);
+      } catch {
+        /* unreadable box — skip */
+      }
+    }
+  } catch {
+    /* walk failed */
+  }
+
+  const rerouteSnap = [];
+  try {
+    for (const r of allReroutes(graph)) {
+      try {
+        const x = Number(r?.pos?.[0]);
+        const y = Number(r?.pos?.[1]);
+        if (Number.isFinite(x) && Number.isFinite(y)) rerouteSnap.push([r, x, y]);
+      } catch {
+        /* unreadable reroute — skip */
+      }
+    }
+  } catch {
+    /* walk failed */
+  }
+
+  return {
+    restore() {
+      restoreNodePositions(nodeSnap);
+      for (const [g, quad] of groupSnap) {
+        try {
+          restoreGroupBox(g, quad);
+        } catch {
+          /* never raise from a restore */
+        }
+      }
+      for (const [r, x, y] of rerouteSnap) {
+        try {
+          placeReroute(r, x, y);
+        } catch {
+          /* never raise from a restore */
+        }
+      }
+    },
+  };
+}
+
+/**
  * Translate reroute points by (dx, dy), reporting which ones actually moved.
  * Without this a moved group leaves its wire elbows behind and the links visibly
  * snake back to where the group used to be.


### PR DESCRIPTION
## Summary

`panel_edit_group({bounds})` must edit the group **rectangle**, not drag the contents. A layout pass that placed nodes and then resized the boxes was translating every member by the box-origin delta (`[1360,0]` became `[1490,3]`, etc.) while the call returned success.

Some frontends couple a `pos` / `_bounding` write to `LGraphGroup.move()`, which translates the cached `_children` set. The handler now snapshots every node, nested group box, and reroute on the graph **before** the box write and restores them after. A stale `_children` cache cannot leak a translation of a node that already left the box.

Use `panel_move_group` when the contents should move with the box.

Fixes #1306

## Test plan

- [x] Extracted shipped `graph_edit_group` against LiteGraph-shaped doubles:
  - plain `_bounding` write leaves members put
  - a `pos` setter that is `LGraphGroup.move()` still leaves members put
  - a `_bounding` Proxy that translates children still leaves members put
  - shrinking the box updates membership from live geometry without moving nodes
  - nested group boxes and reroutes stay put
  - a stale `_children` entry that left the box is not dragged
  - title-only edits do not touch geometry
  - non-finite bounds are refused with no undo transaction
- [x] `holdGraphItemPositions` helper: restore + never-throws on a hostile walk
- [x] Existing `group-geometry` / `move-group` suites still pass