### PR TITLE
fix(1308): author an LTXDirector timeline without a live editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project are documented here. This project adheres to
 
 ### Fixed
 - dictation listens for the spoken language when the panel UI is the English catalog floor — a German (or other unshipped) speaker no longer gets an English recognizer (#1329)
+- panel_set_widget can author an LTXDirector timeline from the serialized widgets when the live timeline editor is not initialized (#1308)
 - live-sync no longer reports notified unless the active canvas actually holds the saved workflow (#1299)
 - `panel_edit_group({bounds})` writes the group box only — contained nodes stay at their canvas coordinates (#1306)
 - an already-full origin can save workflow drafts again after the chat-history quota fix (#1305)

--- a/browser_tests/unit/ltx-director.test.mjs
+++ b/browser_tests/unit/ltx-director.test.mjs
@@ -6,6 +6,8 @@
 // reverted if written directly. These tests drive the REAL shipped lib.
 import test from "node:test";
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 import {
   LTX_DIRECTOR_NODE_TYPE,
   LTX_TIMELINE_MASTER_WIDGET,
@@ -14,9 +16,14 @@ import {
   classifyLtxTimelineWrite,
   normalizeLtxTimelineValue,
   currentTimelineSnapshot,
+  parseTimelineSnapshot,
+  deriveLtxTimelineWidgets,
+  readLtxTimelineWindow,
   derivedTimelineRefusal,
   applyLtxTimelineWrite,
   LtxTimelineWriteError,
+  LTX_AUDIO_TOGGLE_WIDGET,
+  LTX_MOTION_TOGGLE_WIDGET,
 } from "../../web/js/lib/ltx-director.js";
 
 /** A fake node whose _timelineEditor records the _applyLoadedTimeline call. */
@@ -39,6 +46,37 @@ function makeLtxNode({
 
 /** The JSON string passed to the node's _applyLoadedTimeline, parsed back. */
 const drivenPayload = (calls) => JSON.parse(calls[0].jsonStr);
+
+/** A headless LTXDirector — widgets exist, live TimelineEditor does not (#1308). */
+function makeHeadlessLtxNode({
+  id = 42,
+  timelineData = "",
+  localPrompts = "",
+  segmentLengths = "",
+  guideStrength = "",
+  useCustomAudio = false,
+  useCustomMotion = true,
+  startFrame = 0,
+  durationFrames = 120,
+  extraWidgets = [],
+} = {}) {
+  const widgets = [
+    { name: "timeline_data", value: timelineData },
+    { name: "local_prompts", value: localPrompts },
+    { name: "segment_lengths", value: segmentLengths },
+    { name: "guide_strength", value: guideStrength },
+    { name: LTX_AUDIO_TOGGLE_WIDGET, value: useCustomAudio },
+    { name: LTX_MOTION_TOGGLE_WIDGET, value: useCustomMotion },
+    { name: "start_frame", value: startFrame },
+    { name: "duration_frames", value: durationFrames },
+    ...extraWidgets,
+  ];
+  return { id, type: LTX_DIRECTOR_NODE_TYPE, widgets, _timelineEditor: null };
+}
+
+function widgetOf(node, name) {
+  return node.widgets.find((w) => w.name === name);
+}
 
 /** A minimally-valid segment — finite numeric start + length are REQUIRED (NaN-timing guard). */
 const seg = (extra = {}) => ({ start: 0, length: 24, ...extra });
@@ -269,11 +307,11 @@ test("currentTimelineSnapshot reads the widget JSON, and null on empty/invalid",
   assert.equal(currentTimelineSnapshot({}), null);
 });
 
-test("applyLtxTimelineWrite fails LOUDLY when the editor / load path is missing", () => {
-  // No editor at all (node UI not initialized).
+test("applyLtxTimelineWrite fails LOUDLY when the editor is missing AND there are no serialized widgets", () => {
+  // No editor and no node.widgets — nothing to write.
   const noEditor = makeLtxNode({ withEditor: false });
   assert.throws(() => applyLtxTimelineWrite(noEditor.node, "{}"), LtxTimelineWriteError);
-  // Editor present but without the _applyLoadedTimeline method (pack version mismatch).
+  // Editor present but without the _applyLoadedTimeline method, and no node widgets.
   const wrongMethod = makeLtxNode({ method: "_somethingElse" });
   assert.throws(() => applyLtxTimelineWrite(wrongMethod.node, "{}"), LtxTimelineWriteError);
 });
@@ -355,4 +393,246 @@ test("derivedTimelineRefusal names the widget, the node, and points at timeline_
   assert.match(msg, /node 99/);
   assert.match(msg, /timeline_data/);
   assert.match(msg, /#314/);
+});
+
+test("parseTimelineSnapshot / currentTimelineSnapshot read the widget JSON, and null on empty/invalid", () => {
+  assert.deepEqual(parseTimelineSnapshot('{"a":1}'), { a: 1 });
+  assert.equal(parseTimelineSnapshot(""), null);
+  assert.equal(parseTimelineSnapshot("not json"), null);
+  assert.deepEqual(currentTimelineSnapshot({ timelineDataWidget: { value: '{"a":1}' } }), { a: 1 });
+});
+
+test("deriveLtxTimelineWidgets mirrors commitChanges: joiners, gap absorb, window fill", () => {
+  // Two 24-frame segments on a 120-frame window: last length absorbs the trailing 72.
+  const d = deriveLtxTimelineWidgets(
+    { segments: [seg({ prompt: "a" }), seg({ start: 24, length: 24, prompt: "b" })] },
+    { startFrames: 0, durationFrames: 120 },
+  );
+  assert.equal(d.local_prompts, "a | b");
+  assert.equal(d.segment_lengths, "24,96", "no space after comma; last segment fills the window");
+  assert.equal(d.guide_strength, "1.00,1.00", "non-text segments emit default 1.00");
+});
+
+test("deriveLtxTimelineWidgets skips text segments for guide_strength and uses explicit strength", () => {
+  const d = deriveLtxTimelineWidgets(
+    {
+      segments: [
+        seg({ prompt: "img", guideStrength: 0.4 }),
+        seg({ start: 24, length: 24, prompt: "txt", type: "text" }),
+      ],
+    },
+    { startFrames: 0, durationFrames: 48 },
+  );
+  assert.equal(d.local_prompts, "img | txt");
+  assert.equal(d.guide_strength, "0.40");
+});
+
+test("deriveLtxTimelineWidgets retake mode emits preserved/retake/preserved regions", () => {
+  const d = deriveLtxTimelineWidgets(
+    {
+      retakeMode: true,
+      global_prompt: "keep",
+      retakeStart: 24,
+      retakeLength: 48,
+      retakePrompt: "new take",
+      retakeStrength: 0.7,
+    },
+    { startFrames: 0, durationFrames: 120 },
+  );
+  assert.equal(d.local_prompts, "keep | new take | keep");
+  assert.equal(d.segment_lengths, "24,48,48");
+  assert.equal(d.guide_strength, "0.00,0.70,0.00");
+});
+
+test("readLtxTimelineWindow reads start_frame / duration_frames with the editor's fallbacks", () => {
+  const node = makeHeadlessLtxNode({ startFrame: 8, durationFrames: 96 });
+  assert.deepEqual(readLtxTimelineWindow(node), { startFrames: 8, durationFrames: 96 });
+  assert.deepEqual(readLtxTimelineWindow({ widgets: [] }), { startFrames: 0, durationFrames: 24 });
+  assert.deepEqual(readLtxTimelineWindow({ widgets: [{ name: "duration_frames", value: 0 }] }), {
+    startFrames: 0,
+    durationFrames: 24,
+  });
+});
+
+test("applyLtxTimelineWrite authors a timeline from serialized widgets when the editor is absent (#1308)", () => {
+  const node = makeHeadlessLtxNode();
+  const value = { global_prompt: "g", segments: [seg({ prompt: "hello", guideStrength: 0.5 })] };
+  const res = applyLtxTimelineWrite(node, value);
+  assert.equal(res.ltx_timeline.driven, true);
+  assert.equal(res.ltx_timeline.fallback, true);
+  assert.equal(res.ltx_timeline.editor_driven, false);
+  assert.equal(res.ltx_timeline.segments, 1);
+  assert.deepEqual(res.ltx_timeline.derived_regenerated, [...LTX_DERIVED_TIMELINE_WIDGETS]);
+  assert.equal(JSON.parse(widgetOf(node, "timeline_data").value).global_prompt, "g");
+  assert.equal(widgetOf(node, "local_prompts").value, "hello");
+  // 24-frame segment on the node's 120-frame window → last (only) segment fills to 120.
+  assert.equal(widgetOf(node, "segment_lengths").value, "120");
+  assert.equal(widgetOf(node, "guide_strength").value, "0.50");
+  assert.equal(res.ltx_timeline.local_prompts, "hello");
+  assert.equal(res.ltx_timeline.segment_lengths, "120");
+  assert.equal(res.ltx_timeline.guide_strength, "0.50");
+});
+
+test("serialized fallback MERGES onto the current timeline_data widget (omitted tracks preserved)", () => {
+  const current = {
+    global_prompt: "old global",
+    segments: [seg({ prompt: "old-seg" })],
+    motionSegments: [seg({ prompt: "keep-motion" })],
+    audioSegments: [seg({ prompt: "keep-audio" })],
+    audioTrackEnabled: true,
+  };
+  const node = makeHeadlessLtxNode({ timelineData: JSON.stringify(current) });
+  const res = applyLtxTimelineWrite(node, { segments: [seg({ prompt: "new-seg" })] });
+  const written = JSON.parse(widgetOf(node, "timeline_data").value);
+  assert.deepEqual(written.segments, [seg({ prompt: "new-seg" })]);
+  assert.deepEqual(written.motionSegments, [seg({ prompt: "keep-motion" })]);
+  assert.deepEqual(written.audioSegments, [seg({ prompt: "keep-audio" })]);
+  assert.equal(written.global_prompt, "old global");
+  assert.equal(res.ltx_timeline.merged_onto_current, true);
+  assert.deepEqual(res.ltx_timeline.preserved_tracks.sort(), ["audioSegments", "motionSegments"]);
+  assert.equal(widgetOf(node, "local_prompts").value, "new-seg");
+});
+
+test("serialized fallback sets use_custom_audio / use_custom_motion from the timeline flags", () => {
+  const node = makeHeadlessLtxNode({ useCustomAudio: false, useCustomMotion: true });
+  const res = applyLtxTimelineWrite(node, {
+    segments: [seg({ prompt: "a" })],
+    audioTrackEnabled: true,
+    motionTrackEnabled: false,
+  });
+  assert.equal(widgetOf(node, LTX_AUDIO_TOGGLE_WIDGET).value, true);
+  assert.equal(widgetOf(node, LTX_MOTION_TOGGLE_WIDGET).value, false);
+  assert.deepEqual(res.ltx_timeline.audio_motion_toggles, {
+    [LTX_AUDIO_TOGGLE_WIDGET]: true,
+    [LTX_MOTION_TOGGLE_WIDGET]: false,
+  });
+});
+
+test("serialized fallback defaults omitted audio/motion flags to ON (pack: `!== false`)", () => {
+  const node = makeHeadlessLtxNode({ useCustomAudio: false, useCustomMotion: false });
+  applyLtxTimelineWrite(node, { segments: [seg({ prompt: "a" })] });
+  assert.equal(widgetOf(node, LTX_AUDIO_TOGGLE_WIDGET).value, true);
+  assert.equal(widgetOf(node, LTX_MOTION_TOGGLE_WIDGET).value, true);
+});
+
+test("an unready editor plus serialized widgets takes the fallback, not a refusal (#1308)", () => {
+  const node = makeHeadlessLtxNode();
+  // Editor object exists but has no load path — the install-without-hard-refresh shape.
+  node._timelineEditor = { timeline: {} };
+  const res = applyLtxTimelineWrite(node, { segments: [seg({ prompt: "via-fallback" })] });
+  assert.equal(res.ltx_timeline.fallback, true);
+  assert.equal(widgetOf(node, "local_prompts").value, "via-fallback");
+});
+
+test("a ready live editor is preferred over the serialized fallback", () => {
+  const { node, calls } = makeLtxNode();
+  node.widgets = [
+    { name: "timeline_data", value: "" },
+    { name: "local_prompts", value: "" },
+    { name: "segment_lengths", value: "" },
+    { name: "guide_strength", value: "" },
+  ];
+  const res = applyLtxTimelineWrite(node, { segments: [seg({ prompt: "via-editor" })] });
+  assert.equal(res.ltx_timeline.editor_driven, true);
+  assert.equal(res.ltx_timeline.fallback, false);
+  assert.equal(calls.length, 1);
+  assert.equal(widgetOf(node, "local_prompts").value, "", "fallback must not also assign widgets");
+});
+
+test("serialized fallback REFUSES when derived widgets are missing (execute would stay on old prompts)", () => {
+  const node = {
+    id: 9,
+    type: LTX_DIRECTOR_NODE_TYPE,
+    widgets: [{ name: "timeline_data", value: "" }],
+  };
+  assert.throws(() => applyLtxTimelineWrite(node, { segments: [seg({ prompt: "x" })] }), /local_prompts/);
+  assert.equal(widgetOf(node, "timeline_data").value, "", "must not write timeline_data alone");
+});
+
+test("serialized fallback REFUSES a wipe-inducing payload BEFORE opening the undo envelope", () => {
+  const node = makeHeadlessLtxNode();
+  const order = [];
+  assert.throws(
+    () =>
+      applyLtxTimelineWrite(node, { segments: [null] }, {
+        beforeChange: () => order.push("before"),
+        afterChange: () => order.push("after"),
+        setDirty: () => order.push("dirty"),
+      }),
+    LtxTimelineWriteError,
+  );
+  assert.deepEqual(order, []);
+  assert.equal(widgetOf(node, "timeline_data").value, "");
+});
+
+test("serialized fallback wraps the write in an undo envelope: before → after → dirty", () => {
+  const node = makeHeadlessLtxNode();
+  const order = [];
+  applyLtxTimelineWrite(node, { segments: [seg({ prompt: "x" })] }, {
+    beforeChange: () => order.push("before"),
+    afterChange: () => order.push("after"),
+    setDirty: () => order.push("dirty"),
+  });
+  assert.deepEqual(order, ["before", "after", "dirty"]);
+});
+
+// The SHIPPED graph_set_widget branch — not a copy of it. A headless LTXDirector
+// (widgets exist, no live editor) must author the timeline through that exact code.
+const PANEL_SRC = readFileSync(
+  fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url)),
+  "utf8",
+).replace(/\r\n/g, "\n");
+
+const LTX_SET_WIDGET_BRANCH = PANEL_SRC.match(
+  /const ltxKind = classifyLtxTimelineWrite\(node, widget\);\n    if \(ltxKind === "derived"\) \{[\s\S]*?setDirty: \(\) => graph\.setDirtyCanvas\(true, true\),\n      \}\);\n    \}/,
+);
+
+test("graph_set_widget still routes LTXDirector timeline_data through applyLtxTimelineWrite", () => {
+  assert.ok(LTX_SET_WIDGET_BRANCH, "LTXDirector branch not found in graph_set_widget");
+  const ltxAt = PANEL_SRC.indexOf("const ltxKind = classifyLtxTimelineWrite");
+  const applyAt = PANEL_SRC.indexOf("return applyLtxTimelineWrite(node, value,");
+  const genericAt = PANEL_SRC.indexOf("await runSetWidget(node, widget, value");
+  assert.ok(ltxAt > 0 && applyAt > 0 && genericAt > 0);
+  assert.ok(ltxAt < applyAt && applyAt < genericAt, "LTX route must stay ahead of the generic write");
+});
+
+test("shipped graph_set_widget authors an LTXDirector timeline without a live editor (#1308)", () => {
+  assert.ok(LTX_SET_WIDGET_BRANCH, "LTXDirector branch not found in graph_set_widget");
+  const node = makeHeadlessLtxNode();
+  const graph = {
+    log: [],
+    beforeChange() {
+      this.log.push("before");
+    },
+    afterChange() {
+      this.log.push("after");
+    },
+    setDirtyCanvas() {
+      this.log.push("dirty");
+    },
+  };
+  const run = new Function(
+    "classifyLtxTimelineWrite",
+    "derivedTimelineRefusal",
+    "applyLtxTimelineWrite",
+    "node",
+    "widget",
+    "value",
+    "graph",
+    `return (function () { ${LTX_SET_WIDGET_BRANCH[0]} })();`,
+  );
+  const res = run(
+    classifyLtxTimelineWrite,
+    derivedTimelineRefusal,
+    applyLtxTimelineWrite,
+    node,
+    LTX_TIMELINE_MASTER_WIDGET,
+    { global_prompt: "g", segments: [seg({ prompt: "shipped" })] },
+    graph,
+  );
+  assert.equal(res.ltx_timeline.fallback, true);
+  assert.equal(res.ltx_timeline.driven, true);
+  assert.equal(widgetOf(node, "local_prompts").value, "shipped");
+  assert.equal(JSON.parse(widgetOf(node, "timeline_data").value).global_prompt, "g");
+  assert.deepEqual(graph.log, ["before", "after", "dirty"]);
 });

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -23580,7 +23580,9 @@ function describeCommand(cmd, msg, reply) {
                   { count: seg },
                 )
               : "") +
-            tr("panel.ltx_timeline_resynced", " — UI re-synced, derived prompt/length widgets regenerated"),
+            (r.ltx_timeline.fallback
+              ? ""
+              : tr("panel.ltx_timeline_resynced", " — UI re-synced, derived prompt/length widgets regenerated")),
         };
       }
       // #366: a promoted-subgraph write is only truly applied when the parent RAIL

--- a/web/js/lib/ltx-director.js
+++ b/web/js/lib/ltx-director.js
@@ -32,6 +32,13 @@
 // independently — a direct write is reverted — so we REFUSE them LOUDLY (mirroring #560's
 // principle of "a loud, safe failure over silent corruption") and redirect the caller to
 // `timeline_data`.
+//
+// #1308. After a pack install + backend restart the node and its widgets exist, but the
+// frontend extension may not have constructed TimelineEditor yet. Requiring the live editor
+// then leaves NO programmatic authoring path, even though a serialized timeline_data + the
+// derived widgets is exactly what a copy/paste of the node already persists. When the editor
+// is unavailable we fall back to writing those widgets ourselves, using the same
+// commitChanges() derivation the editor would have run, so execute() sees the new prompts.
 
 export const LTX_DIRECTOR_NODE_TYPE = "LTXDirector";
 
@@ -45,6 +52,28 @@ export const LTX_DERIVED_TIMELINE_WIDGETS = Object.freeze([
   "segment_lengths",
   "guide_strength",
 ]);
+
+// Optional toggles commitChanges / syncWidgetsAndUI keep in lock-step with the timeline's
+// audioTrackEnabled / motionTrackEnabled flags (default ON when the field is omitted).
+export const LTX_AUDIO_TOGGLE_WIDGET = "use_custom_audio";
+export const LTX_MOTION_TOGGLE_WIDGET = "use_custom_motion";
+
+// Serialised fallback (#1308) needs the master + every derived widget: Python execute()
+// reads local_prompts / segment_lengths / guide_strength, never timeline_data alone.
+const FALLBACK_REQUIRED_WIDGETS = Object.freeze([
+  LTX_TIMELINE_MASTER_WIDGET,
+  ...LTX_DERIVED_TIMELINE_WIDGETS,
+]);
+
+// Separators mirrored from TimelineEditor.commitChanges() — note NO space after the
+// length/strength commas (unlike PromptRelay's ", ").
+const LTX_PROMPT_JOIN = " | ";
+const LTX_LENGTH_JOIN = ",";
+const LTX_STRENGTH_JOIN = ",";
+
+// Match getStartFrames() / getDurationFrames() when the widget is missing or invalid.
+const DEFAULT_START_FRAMES = 0;
+const DEFAULT_DURATION_FRAMES = 24;
 
 /**
  * True for an LTXDirector node (matched on the ComfyUI class, never a value shape).
@@ -203,8 +232,7 @@ export function normalizeLtxTimelineValue(value) {
  * already stripped, so it is safe to JSON round-trip, unlike the live editor.timeline which
  * holds DOM/Image refs). Returns the parsed plain object, or null when it can't be read.
  */
-export function currentTimelineSnapshot(editor) {
-  const raw = editor?.timelineDataWidget?.value;
+export function parseTimelineSnapshot(raw) {
   if (typeof raw !== "string" || raw.trim() === "") return null;
   try {
     const parsed = JSON.parse(raw);
@@ -212,6 +240,143 @@ export function currentTimelineSnapshot(editor) {
   } catch {
     return null;
   }
+}
+
+export function currentTimelineSnapshot(editor) {
+  return parseTimelineSnapshot(editor?.timelineDataWidget?.value);
+}
+
+function findWidget(node, name) {
+  const widgets = Array.isArray(node?.widgets) ? node.widgets : [];
+  return widgets.find((w) => w?.name === name) ?? null;
+}
+
+function nodeTimelineSnapshot(node) {
+  return parseTimelineSnapshot(findWidget(node, LTX_TIMELINE_MASTER_WIDGET)?.value);
+}
+
+function readIntWidget(node, name, { min, fallback }) {
+  const n = Number.parseInt(findWidget(node, name)?.value, 10);
+  return Number.isFinite(n) && n >= min ? n : fallback;
+}
+
+/**
+ * The clip window commitChanges() uses: start_frame + duration_frames widgets, with the
+ * same missing/invalid fallbacks as TimelineEditor.getStartFrames / getDurationFrames.
+ */
+export function readLtxTimelineWindow(node) {
+  return {
+    startFrames: readIntWidget(node, "start_frame", { min: 0, fallback: DEFAULT_START_FRAMES }),
+    durationFrames: readIntWidget(node, "duration_frames", { min: 1, fallback: DEFAULT_DURATION_FRAMES }),
+  };
+}
+
+function isReadyLtxEditor(editor) {
+  return !!(editor && typeof editor._applyLoadedTimeline === "function" && editor.timelineDataWidget);
+}
+
+function mergeOntoCurrent(base, overlay) {
+  const merged = base ? { ...base, ...overlay } : overlay;
+  const preservedTracks = base
+    ? SEGMENT_ARRAY_FIELDS.filter(
+        (f) => !Object.prototype.hasOwnProperty.call(overlay, f) && Array.isArray(base[f]) && base[f].length,
+      )
+    : [];
+  return { merged, preservedTracks, mergedOntoCurrent: base != null };
+}
+
+function strengthString(v) {
+  const n = v !== undefined ? Number(v) : 1.0;
+  return (Number.isFinite(n) ? n : 1.0).toFixed(2);
+}
+
+/**
+ * The node's own derived-widget computation, mirrored from TimelineEditor.commitChanges().
+ * local_prompts joins with " | "; segment_lengths and guide_strength join with "," (no
+ * space). Gaps inside the start/duration window are absorbed into the adjacent segment;
+ * the last kept segment is extended to fill the window. Non-text segments in range emit
+ * a two-decimal guide strength (default 1.00).
+ */
+export function deriveLtxTimelineWidgets(timeline, { startFrames = DEFAULT_START_FRAMES, durationFrames = DEFAULT_DURATION_FRAMES } = {}) {
+  const segs = Array.isArray(timeline?.segments) ? [...timeline.segments] : [];
+  segs.sort((a, b) => a.start - b.start);
+  const endFrames = startFrames + durationFrames;
+
+  if (timeline?.retakeMode) {
+    const retakeStart = Number.isFinite(timeline.retakeStart) ? timeline.retakeStart : 0;
+    const retakeLength = Number.isFinite(timeline.retakeLength) ? timeline.retakeLength : durationFrames;
+    const retakeEnd = retakeStart + retakeLength;
+    const retakePrompt = timeline.retakePrompt || "";
+    const globalPrompt = timeline.global_prompt || "";
+    const retakeStrength = Number.isFinite(Number(timeline.retakeStrength)) ? Number(timeline.retakeStrength) : 1.0;
+    const lengths = [];
+    const prompts = [];
+    const strengths = [];
+
+    const pBeforeLen = Math.min(endFrames, retakeStart) - startFrames;
+    if (pBeforeLen > 0) {
+      lengths.push(pBeforeLen);
+      prompts.push(globalPrompt || "video");
+      strengths.push("0.00");
+    }
+    const rStart = Math.max(startFrames, retakeStart);
+    const rEnd = Math.min(endFrames, retakeEnd);
+    const rLen = rEnd - rStart;
+    if (rLen > 0) {
+      lengths.push(rLen);
+      prompts.push(retakePrompt || "video");
+      strengths.push(retakeStrength.toFixed(2));
+    }
+    const pAfterLen = endFrames - Math.max(startFrames, retakeEnd);
+    if (pAfterLen > 0) {
+      lengths.push(pAfterLen);
+      prompts.push(globalPrompt || "video");
+      strengths.push("0.00");
+    }
+    return {
+      local_prompts: prompts.join(LTX_PROMPT_JOIN),
+      segment_lengths: lengths.join(LTX_LENGTH_JOIN),
+      guide_strength: strengths.join(LTX_STRENGTH_JOIN),
+    };
+  }
+
+  const contiguousLengths = [];
+  const contiguousPrompts = [];
+  let currentCursor = startFrames;
+  let pendingGap = 0;
+  for (const seg of segs) {
+    if (seg.start + seg.length <= startFrames) continue;
+    if (seg.start >= endFrames) break;
+    const effectiveStart = Math.max(seg.start, startFrames);
+    if (effectiveStart > currentCursor) {
+      const gapLength = Math.min(effectiveStart, endFrames) - currentCursor;
+      if (contiguousLengths.length > 0) {
+        contiguousLengths[contiguousLengths.length - 1] += gapLength;
+      } else {
+        pendingGap += gapLength;
+      }
+    }
+    const clippedEnd = Math.min(seg.start + seg.length, endFrames);
+    contiguousLengths.push(clippedEnd - effectiveStart + pendingGap);
+    contiguousPrompts.push(seg.prompt || "");
+    pendingGap = 0;
+    currentCursor = Math.max(currentCursor, seg.start + seg.length);
+  }
+  const clampedCursor = Math.min(currentCursor, endFrames);
+  if (contiguousLengths.length > 0 && clampedCursor < endFrames) {
+    contiguousLengths[contiguousLengths.length - 1] += endFrames - clampedCursor;
+  }
+
+  const guide = segs
+    .filter((s) => s.type !== "text")
+    .filter((s) => s.start + s.length > startFrames && s.start < endFrames)
+    .map((s) => strengthString(s.guideStrength));
+
+  return {
+    local_prompts: contiguousPrompts.join(LTX_PROMPT_JOIN),
+    segment_lengths: contiguousLengths.join(LTX_LENGTH_JOIN),
+    guide_strength: guide.join(LTX_STRENGTH_JOIN),
+  };
 }
 
 /** The refusal message for a DERIVED-widget write — explains why + points at timeline_data. */
@@ -237,9 +402,11 @@ export function derivedTimelineRefusal(widgetName, nodeId) {
  *     pre-change snapshot. afterChange ALWAYS runs (even on throw); beforeChange is only
  *     fired once the value + editor are validated, so a refusal establishes no empty undo step.
  *   - `setDirty` repaints the canvas on success.
- * Returns a result envelope. Throws LtxTimelineWriteError when the value is invalid, or the
- * editor / load method is unavailable (node UI not initialized, or a pack version without the
- * load path) — an HONEST failure rather than a raw write that would be silently reverted.
+ * Returns a result envelope. Throws LtxTimelineWriteError when the value is invalid, or
+ * neither a ready editor NOR the serialized timeline_data + derived widgets exist — an
+ * HONEST failure rather than a raw write that would be silently reverted. When the editor
+ * is missing but the widgets are present (#1308), writes the serialized values and
+ * regenerates the derived widgets so execute() sees the new prompts.
  *
  * MERGE, not replace. The node's _applyLoadedTimeline is a whole-timeline REPLACE that
  * DEFAULTS every omitted field (an absent track loads as [], an absent global_prompt as "").
@@ -249,44 +416,42 @@ export function derivedTimelineRefusal(widgetName, nodeId) {
  * clean current-timeline snapshot, so anything they don't mention is PRESERVED. An explicit
  * empty array (e.g. `motionSegments: []`) still clears that track; only OMISSION preserves.
  */
-export function applyLtxTimelineWrite(node, value, { getEditor, beforeChange, afterChange, setDirty } = {}) {
-  const { timeline } = normalizeLtxTimelineValue(value);
-  const editor = typeof getEditor === "function" ? getEditor(node) : node?._timelineEditor;
-  // Require BOTH the load method AND the timeline_data widget it dereferences
-  // UNCONDITIONALLY (`this.timelineDataWidget.value`, not behind a guard). Without the
-  // widget, _applyLoadedTimeline throws internally and swallows it behind its own alert(),
-  // applying nothing — so a method-presence-only check would report a false "driven"
-  // success and dirty the graph for no effect.
-  if (!editor || typeof editor._applyLoadedTimeline !== "function" || !editor.timelineDataWidget) {
+function applySerializedLtxTimeline(node, merged, { beforeChange, afterChange, setDirty, preservedTracks, mergedOntoCurrent }) {
+  const missing = FALLBACK_REQUIRED_WIDGETS.filter((name) => !findWidget(node, name));
+  if (missing.length) {
     throw new LtxTimelineWriteError(
-      `LTXDirector node ${node?.id} has no live, ready timeline editor to drive (the node UI has not ` +
-        `initialized, its timeline_data widget is missing, or this pack version does not expose the ` +
-        `timeline load path). Open the node on the canvas, or edit the timeline from the node UI; ` +
-        `panel_set_widget cannot re-sync the custom timeline on this version.`,
+      `LTXDirector node ${node?.id} has no live, ready timeline editor, and cannot use the serialized ` +
+        `fallback because the widget(s) ${missing.join(", ")} are missing. The node's Python execute() ` +
+        `reads local_prompts / segment_lengths / guide_strength — writing timeline_data alone would ` +
+        `leave the render on the OLD prompts (#1308). Refresh the ComfyUI tab so the pack frontend ` +
+        `initializes, or open the node on the canvas.`,
     );
   }
-  // Merge the caller's fields (the effective timeline — unwrapped from a { timeline: {…} }
-  // wrapper) onto the node's CLEAN current snapshot so omitted fields are preserved. When no
-  // snapshot is readable there is nothing to preserve, so fall back to a pure replace with the
-  // caller's object. The result is always an UNWRAPPED timeline object, which the node accepts
-  // via `data.timeline || data`.
-  const overlay = effectiveTimeline(timeline);
-  const base = currentTimelineSnapshot(editor);
-  const merged = base ? { ...base, ...overlay } : overlay;
-  const preservedTracks = base
-    ? SEGMENT_ARRAY_FIELDS.filter(
-        (f) => !Object.prototype.hasOwnProperty.call(overlay, f) && Array.isArray(base[f]) && base[f].length,
-      )
-    : [];
 
-  // Bracket the mutation in one undo envelope (afterChange in finally so a thrown load path
-  // never leaves the history open). The node's authored load path re-parses into
-  // this.timeline, syncs the global-prompt DOM + media, REGENERATES
-  // local_prompts/segment_lengths/guide_strength via commitChanges(), and re-renders.
-  // fileHandle=null (not loaded from a picked file).
+  const derived = deriveLtxTimelineWidgets(merged, readLtxTimelineWindow(node));
+  const audioOn = merged.audioTrackEnabled !== false;
+  const motionOn = merged.motionTrackEnabled !== false;
+  const toggles = {};
+  if (findWidget(node, LTX_AUDIO_TOGGLE_WIDGET)) toggles[LTX_AUDIO_TOGGLE_WIDGET] = audioOn;
+  if (findWidget(node, LTX_MOTION_TOGGLE_WIDGET)) toggles[LTX_MOTION_TOGGLE_WIDGET] = motionOn;
+
   beforeChange?.();
   try {
-    editor._applyLoadedTimeline(JSON.stringify(merged), null);
+    findWidget(node, LTX_TIMELINE_MASTER_WIDGET).value = JSON.stringify(merged);
+    for (const name of LTX_DERIVED_TIMELINE_WIDGETS) {
+      findWidget(node, name).value = derived[name];
+    }
+    for (const [name, val] of Object.entries(toggles)) {
+      findWidget(node, name).value = val;
+    }
+    if (Object.prototype.hasOwnProperty.call(merged, "inpaint_audio")) {
+      const w = findWidget(node, "inpaint_audio");
+      if (w) w.value = !!merged.inpaint_audio;
+    }
+    if (Object.prototype.hasOwnProperty.call(merged, "overrideAudio")) {
+      const w = findWidget(node, "override_audio");
+      if (w) w.value = !!merged.overrideAudio;
+    }
   } finally {
     afterChange?.();
   }
@@ -297,10 +462,73 @@ export function applyLtxTimelineWrite(node, value, { getEditor, beforeChange, af
       node_id: node?.id,
       widget: LTX_TIMELINE_MASTER_WIDGET,
       driven: true,
-      merged_onto_current: base != null,
+      fallback: true,
+      editor_driven: false,
+      merged_onto_current: mergedOntoCurrent,
       preserved_tracks: preservedTracks,
       segments,
       derived_regenerated: [...LTX_DERIVED_TIMELINE_WIDGETS],
+      ...derived,
+      ...(Object.keys(toggles).length ? { audio_motion_toggles: toggles } : {}),
     },
   };
+}
+
+export function applyLtxTimelineWrite(node, value, { getEditor, beforeChange, afterChange, setDirty } = {}) {
+  const { timeline } = normalizeLtxTimelineValue(value);
+  const editor = typeof getEditor === "function" ? getEditor(node) : node?._timelineEditor;
+  const overlay = effectiveTimeline(timeline);
+
+  // Prefer the live editor when it is actually ready. The node's _applyLoadedTimeline
+  // re-parses into this.timeline, syncs the DOM, and regenerates the derived widgets.
+  if (isReadyLtxEditor(editor)) {
+    const { merged, preservedTracks, mergedOntoCurrent } = mergeOntoCurrent(
+      currentTimelineSnapshot(editor),
+      overlay,
+    );
+    beforeChange?.();
+    try {
+      editor._applyLoadedTimeline(JSON.stringify(merged), null);
+    } finally {
+      afterChange?.();
+    }
+    setDirty?.();
+    const segments = Array.isArray(merged.segments) ? merged.segments.length : undefined;
+    return {
+      ltx_timeline: {
+        node_id: node?.id,
+        widget: LTX_TIMELINE_MASTER_WIDGET,
+        driven: true,
+        fallback: false,
+        editor_driven: true,
+        merged_onto_current: mergedOntoCurrent,
+        preserved_tracks: preservedTracks,
+        segments,
+        derived_regenerated: [...LTX_DERIVED_TIMELINE_WIDGETS],
+      },
+    };
+  }
+
+  // #1308: no live editor (pack JS not yet initialized, node never rendered). Author the
+  // serialized widgets the node already persists — the copy/paste workaround proves that
+  // shape is accepted. Still refuse when even timeline_data is absent: there is nothing to
+  // write and a "driven" report would be a lie.
+  if (findWidget(node, LTX_TIMELINE_MASTER_WIDGET)) {
+    const { merged, preservedTracks, mergedOntoCurrent } = mergeOntoCurrent(nodeTimelineSnapshot(node), overlay);
+    return applySerializedLtxTimeline(node, merged, {
+      beforeChange,
+      afterChange,
+      setDirty,
+      preservedTracks,
+      mergedOntoCurrent,
+    });
+  }
+
+  throw new LtxTimelineWriteError(
+    `LTXDirector node ${node?.id} has no live, ready timeline editor to drive (the node UI has not ` +
+      `initialized, its timeline_data widget is missing, or this pack version does not expose the ` +
+      `timeline load path) and no serialized timeline_data widget to fall back to. Open the node on ` +
+      `the canvas, or refresh the ComfyUI tab so the pack frontend initializes; panel_set_widget ` +
+      `cannot author the timeline until one of those is available.`,
+  );
 }


### PR DESCRIPTION
Fixes #1308.

## The report

`panel_set_widget` on `LTXDirector.timeline_data` refused after a WhatDreamsCost-ComfyUI install + backend restart without a hard refresh:

```
LTXDirector node has no live, ready timeline editor to drive (the node UI has not initialized,
its timeline_data widget is missing, or this pack version does not expose the timeline load path).
```

Ordinary widgets wrote fine. The node and all widgets existed. Only the custom TimelineEditor had not been constructed. The working workaround was copy/paste of a one-node UI workflow whose `widgets_values` already held `timeline_data` plus the derived widgets — proof that serialized values are accepted.

## Root cause

The `#314` route required a live `TimelineEditor._applyLoadedTimeline` (and its `timelineDataWidget`). That is the right path when the editor exists. When the pack frontend has not initialized, there was no fallback, so programmatic timeline authoring was blocked.

Python `execute()` reads `local_prompts` / `segment_lengths` / `guide_strength`, not `timeline_data` alone. A raw master-widget write would have been the #506 PromptRelay trap.

## The fix

- Live, ready editor → still drive `_applyLoadedTimeline` (unchanged).
- No ready editor, but `timeline_data` + derived widgets exist → write the serialized timeline and regenerate `local_prompts`, `segment_lengths`, `guide_strength`, and the `use_custom_audio` / `use_custom_motion` toggles from the same `commitChanges()` rules the editor uses.
- Still refuse when even those widgets are missing (nothing honest to write).
- Merge-onto-current, wipe guards, and the undo envelope are shared by both paths.

## Verification

`browser_tests/unit/ltx-director.test.mjs` drives the shipped lib and extracts the real `graph_set_widget` LTX branch. Headless node (widgets, no editor) authors the timeline; derived widgets match `commitChanges()`; live editor is still preferred; missing derived widgets refuse; wipe-inducing payloads never open the undo envelope.
