### PR TITLE
fix(1299): live_sync reports notified only when the active canvas applied

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project are documented here. This project adheres to
 ## [Unreleased]
 
 ### Fixed
+- live-sync no longer reports notified unless the active canvas actually holds the saved workflow (#1299)
 - `panel_edit_group({bounds})` writes the group box only — contained nodes stay at their canvas coordinates (#1306)
 - an already-full origin can save workflow drafts again after the chat-history quota fix (#1305)
 - a group that encloses rgthree Label nodes now moves, instead of being refused because those nodes' visual bounds are not the panel's generic footprint — the same nodes already moved fine one-by-one with panel_edit_node (#1300)

--- a/browser_tests/unit/live-sync-ack.test.mjs
+++ b/browser_tests/unit/live-sync-ack.test.mjs
@@ -1,0 +1,339 @@
+// #1299 — live_sync.notified must mean the ACTIVE canvas holds the saved workflow.
+//
+// The reported failure: H3 apply saved the file, returned notified:true with one
+// notified client, and panel_graph_outline still showed the previous clip
+// switches. Delivery of a notification is not application. These tests drive
+// the SHIPPED helpers (web/js/lib/live-sync-ack.js) plus the panel executor
+// wiring, so deleting either — the decision that forbids a false notified, or
+// the executor that actually calls it — fails here.
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+import {
+  LIVE_SYNC_RELOAD_ACTION,
+  LIVE_SYNC_STATUS,
+  decideLiveSyncAck,
+  liveSyncPathsMatch,
+  widgetFingerprint,
+  canvasMatchesSavedWorkflow,
+  composeLiveSyncReply,
+  runWorkflowLiveSync,
+} from "../../web/js/lib/live-sync-ack.js";
+import { activeWorkflowFenceApplies } from "../../web/js/lib/workflow-chat-identity.js";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const PANEL_JS = join(HERE, "../../web/js/comfyui-mcp-panel.js");
+const PANEL_SRC = readFileSync(PANEL_JS, "utf8").replace(/\r\n/g, "\n");
+
+function clipGraph({ clip2 = false, clip3 = false, clip4 = false } = {}) {
+  return {
+    nodes: [
+      { id: 1, type: "CLIPTextEncode", widgets_values: ["a cat"] },
+      {
+        id: 40,
+        type: "Graph",
+        widgets_values: [true, clip2, clip3, clip4, false],
+      },
+    ],
+    definitions: {
+      subgraphs: [
+        {
+          id: "clip-block",
+          nodes: [
+            { id: 2, type: "PrimitiveBoolean", widgets_values: [clip2] },
+            { id: 3, type: "PrimitiveBoolean", widgets_values: [clip3] },
+            { id: 4, type: "PrimitiveBoolean", widgets_values: [clip4] },
+          ],
+        },
+      ],
+    },
+  };
+}
+
+test("#1299 notified is true ONLY when the canvas matches the saved workflow", () => {
+  const applied = decideLiveSyncAck({
+    hasActiveTab: true,
+    canvasMatchesSaved: true,
+  });
+  assert.equal(applied.notified, true);
+  assert.equal(applied.applied, true);
+  assert.equal(applied.status, LIVE_SYNC_STATUS.APPLIED);
+
+  for (const input of [
+    { hasActiveTab: false },
+    { hasActiveTab: true, pathMatches: false },
+    { hasActiveTab: true, isModified: true, canvasMatchesSaved: false },
+    { hasActiveTab: true, canvasMatchesSaved: false, diskReadable: false },
+    { hasActiveTab: true, canvasMatchesSaved: false, expectedShaMatches: false },
+    { hasActiveTab: true, canvasMatchesSaved: false, reloadAttempted: true, reloadCompleted: false },
+    { hasActiveTab: true, canvasMatchesSaved: false, reloadAttempted: true, reloadCompleted: true },
+    { hasActiveTab: true, canvasMatchesSaved: false },
+    {},
+  ]) {
+    const ack = decideLiveSyncAck(input);
+    assert.equal(ack.notified, false, JSON.stringify(input));
+    assert.equal(ack.applied, false, JSON.stringify(input));
+    assert.notEqual(ack.status, LIVE_SYNC_STATUS.APPLIED, JSON.stringify(input));
+  }
+});
+
+test("#1299 a dirty tab whose canvas still shows the old clips is refused, not notified", () => {
+  const ack = decideLiveSyncAck({
+    hasActiveTab: true,
+    isModified: true,
+    canvasMatchesSaved: false,
+  });
+  assert.deepEqual(ack, {
+    notified: false,
+    applied: false,
+    status: LIVE_SYNC_STATUS.REFUSED,
+    reason: "dirty",
+  });
+  const reply = composeLiveSyncReply(ack.status === LIVE_SYNC_STATUS.REFUSED
+    ? { hasActiveTab: true, isModified: true, canvasMatchesSaved: false }
+    : ack);
+  assert.equal(reply.notified, false);
+  assert.equal(reply.reload, LIVE_SYNC_RELOAD_ACTION);
+  assert.match(reply.note, /panel_load_workflow/);
+  assert.match(reply.note, /intentionally not replaced/);
+});
+
+test("#1299 composeLiveSyncReply cannot be talked into notified:true", () => {
+  const reply = composeLiveSyncReply(
+    { hasActiveTab: true, isModified: true, canvasMatchesSaved: false },
+    { notified: true, applied: true, status: "applied" },
+  );
+  assert.equal(reply.notified, false);
+  assert.equal(reply.applied, false);
+  assert.equal(reply.status, LIVE_SYNC_STATUS.REFUSED);
+});
+
+test("liveSyncPathsMatch: omitted path means the active tab; slash/backslash and workflows/ prefix agree", () => {
+  assert.equal(liveSyncPathsMatch("", "workflows/H3.json"), true);
+  assert.equal(liveSyncPathsMatch(null, "workflows/H3.json"), true);
+  assert.equal(liveSyncPathsMatch("workflows/H3.json", "workflows/H3.json"), true);
+  assert.equal(liveSyncPathsMatch("H3.json", "workflows/H3.json"), true);
+  assert.equal(liveSyncPathsMatch("workflows\\H3.json", "workflows/H3.json"), true);
+  assert.equal(liveSyncPathsMatch("workflows/Other.json", "workflows/H3.json"), false);
+});
+
+test("#1299 widget fingerprint sees subgraph clip switches, not presentation", () => {
+  const saved = clipGraph({ clip2: true, clip3: true, clip4: true });
+  const liveStale = clipGraph({ clip2: false, clip3: false, clip4: false });
+  const liveMoved = clipGraph({ clip2: true, clip3: true, clip4: true });
+  liveMoved.nodes[0].pos = [999, 999];
+  liveMoved.nodes[1].size = [40, 40];
+
+  assert.equal(canvasMatchesSavedWorkflow(liveStale, saved), false);
+  assert.equal(canvasMatchesSavedWorkflow(liveMoved, saved), true);
+  assert.equal(widgetFingerprint({ nodes: [] }).comparable, false);
+  assert.equal(canvasMatchesSavedWorkflow({ nodes: [] }, { nodes: [] }), false);
+});
+
+test("#1299 runWorkflowLiveSync: dirty stale canvas never loads and never reports notified", async () => {
+  let loads = 0;
+  const saved = clipGraph({ clip2: true, clip3: true, clip4: true });
+  const live = clipGraph({ clip2: false, clip3: false, clip4: false });
+  const wf = { path: "workflows/H3.json", isModified: true };
+  const reply = await runWorkflowLiveSync(
+    { path: "workflows/H3.json" },
+    {
+      getActiveWorkflow: () => wf,
+      readDisk: async () => JSON.stringify(saved),
+      serializeCanvas: () => live,
+      loadGraph: async () => {
+        loads += 1;
+      },
+    },
+  );
+  assert.equal(loads, 0, "a dirty tab must not be overwritten");
+  assert.equal(reply.notified, false);
+  assert.equal(reply.applied, false);
+  assert.equal(reply.status, LIVE_SYNC_STATUS.REFUSED);
+  assert.equal(reply.reason, "dirty");
+  assert.equal(reply.reload, LIVE_SYNC_RELOAD_ACTION);
+});
+
+test("#1299 runWorkflowLiveSync: a clean tab reloads, and notified is true only after the canvas matches", async () => {
+  const saved = clipGraph({ clip2: true, clip3: true, clip4: true });
+  let live = clipGraph({ clip2: false, clip3: false, clip4: false });
+  const wf = { path: "workflows/H3.json", isModified: false };
+  const reply = await runWorkflowLiveSync(
+    { path: "H3.json" },
+    {
+      getActiveWorkflow: () => wf,
+      readDisk: async () => JSON.stringify(saved),
+      serializeCanvas: () => live,
+      loadGraph: async (graph) => {
+        live = graph;
+      },
+      rebaseline: async (target, text) => {
+        target.originalContent = text;
+      },
+    },
+  );
+  assert.equal(reply.notified, true);
+  assert.equal(reply.applied, true);
+  assert.equal(reply.status, LIVE_SYNC_STATUS.APPLIED);
+  assert.equal(reply.reload, undefined);
+  assert.equal(live.nodes[1].widgets_values[1], true);
+});
+
+test("#1299 runWorkflowLiveSync: a reload that leaves the canvas stale is NOT notified", async () => {
+  const saved = clipGraph({ clip2: true, clip3: true, clip4: true });
+  const live = clipGraph({ clip2: false, clip3: false, clip4: false });
+  const wf = { path: "workflows/H3.json", isModified: false };
+  const reply = await runWorkflowLiveSync(
+    {},
+    {
+      getActiveWorkflow: () => wf,
+      readDisk: async () => JSON.stringify(saved),
+      serializeCanvas: () => live,
+      loadGraph: async () => {
+        /* pretended to load; canvas object is unchanged */
+      },
+    },
+  );
+  assert.equal(reply.notified, false);
+  assert.equal(reply.status, LIVE_SYNC_STATUS.STALE);
+  assert.equal(reply.reason, "canvas_unchanged");
+});
+
+test("#1299 runWorkflowLiveSync: an edit during the disk-read await still refuses", async () => {
+  let loads = 0;
+  const saved = clipGraph({ clip2: true });
+  const live = clipGraph({ clip2: false });
+  const wf = { path: "workflows/H3.json", isModified: false };
+  const reply = await runWorkflowLiveSync(
+    {},
+    {
+      getActiveWorkflow: () => wf,
+      readDisk: async () => {
+        wf.isModified = true;
+        return JSON.stringify(saved);
+      },
+      serializeCanvas: () => live,
+      loadGraph: async () => {
+        loads += 1;
+      },
+    },
+  );
+  assert.equal(loads, 0);
+  assert.equal(reply.notified, false);
+  assert.equal(reply.reason, "dirty");
+});
+
+test("#1299 runWorkflowLiveSync: a tab switch during the disk read does not load into the new canvas", async () => {
+  let loads = 0;
+  const saved = clipGraph({ clip2: true });
+  const live = clipGraph({ clip2: false });
+  const original = { path: "workflows/H3.json", isModified: false };
+  const other = { path: "workflows/Other.json", isModified: false };
+  let current = original;
+  const reply = await runWorkflowLiveSync(
+    { path: "workflows/H3.json" },
+    {
+      getActiveWorkflow: () => current,
+      readDisk: async () => {
+        current = other;
+        return JSON.stringify(saved);
+      },
+      serializeCanvas: () => live,
+      loadGraph: async () => {
+        loads += 1;
+      },
+    },
+  );
+  assert.equal(loads, 0);
+  assert.equal(reply.notified, false);
+  assert.equal(reply.status, LIVE_SYNC_STATUS.NO_ACTIVE);
+});
+
+test("#1299 runWorkflowLiveSync: expected digest mismatch is unverified, not notified", async () => {
+  let loads = 0;
+  const saved = clipGraph({ clip2: true });
+  const live = clipGraph({ clip2: true });
+  const wf = { path: "workflows/H3.json", isModified: false };
+  const reply = await runWorkflowLiveSync(
+    { expected_sha256: "deadbeef" },
+    {
+      getActiveWorkflow: () => wf,
+      readDisk: async () => JSON.stringify(saved),
+      serializeCanvas: () => live,
+      sha256: async () => "cafebabe",
+      loadGraph: async () => {
+        loads += 1;
+      },
+    },
+  );
+  assert.equal(loads, 0);
+  assert.equal(reply.notified, false);
+  assert.equal(reply.status, LIVE_SYNC_STATUS.UNVERIFIED);
+  assert.equal(reply.reason, "sha_mismatch");
+});
+
+test("#1299 live_sync is an active-canvas mutation, so the uuid fence applies", () => {
+  assert.equal(activeWorkflowFenceApplies({ cmd: "workflow_live_sync" }), true);
+  assert.equal(activeWorkflowFenceApplies({ cmd: "live_sync" }), true);
+});
+
+test("#1299 the panel executor is the shipped path: it calls runWorkflowLiveSync", () => {
+  const start = PANEL_SRC.indexOf("async workflow_live_sync(");
+  assert.notEqual(start, -1, "workflow_live_sync executor missing");
+  const alias = PANEL_SRC.indexOf("async live_sync(");
+  assert.notEqual(alias, -1, "live_sync alias missing — the H3 cmd name would 404");
+  const bodyStart = PANEL_SRC.indexOf("{", start);
+  const renameAt = PANEL_SRC.indexOf("\n  async workflow_rename(", start);
+  assert.notEqual(renameAt, -1);
+  const body = PANEL_SRC.slice(bodyStart, renameAt);
+  assert.match(body, /runWorkflowLiveSync\(/);
+  assert.doesNotMatch(body, /notified:\s*true/);
+  assert.match(PANEL_SRC, /api\.addEventListener\(\s*["']live_sync["']/);
+});
+
+test("#1299 extracting the shipped executor: dirty canvas → notified false, no loadGraphData", async () => {
+  const start = PANEL_SRC.indexOf("async workflow_live_sync(");
+  const end = PANEL_SRC.indexOf("\n  async live_sync(", start);
+  assert.notEqual(start, -1);
+  assert.notEqual(end, -1);
+  const source = PANEL_SRC.slice(start, end);
+  let loads = 0;
+  const saved = clipGraph({ clip2: true, clip3: true, clip4: true });
+  const live = clipGraph({ clip2: false, clip3: false, clip4: false });
+  const wf = { path: "workflows/H3.json", isModified: true };
+  const fakeApp = {
+    extensionManager: { workflow: { activeWorkflow: wf } },
+    graph: { serialize: () => live },
+    loadGraphData: async () => {
+      loads += 1;
+    },
+  };
+  const executor = new Function(
+    "runWorkflowLiveSync",
+    "getGraphCtx",
+    "app",
+    "activeWorkflowRef",
+    "workflowDiskContent",
+    "clearSpuriousOpenModified",
+    "sha256Hex",
+    "sendLiveSyncAckOnComfySocket",
+    `const GRAPH_TOOL_EXECUTORS = { ${source} };
+     return GRAPH_TOOL_EXECUTORS.workflow_live_sync;`,
+  )(
+    runWorkflowLiveSync,
+    () => ({ app: fakeApp }),
+    fakeApp,
+    () => wf,
+    async () => JSON.stringify(saved),
+    async () => {},
+    async () => "abc",
+    () => {},
+  );
+  const reply = await executor({ path: "workflows/H3.json" });
+  assert.equal(loads, 0);
+  assert.equal(reply.notified, false);
+  assert.equal(reply.status, LIVE_SYNC_STATUS.REFUSED);
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -501,6 +501,7 @@ import {
   isAbandonedInteractive,
 } from "./lib/interactive-abandon.js";
 import { decideOpenStaleness } from "./lib/workflow-open-staleness.js";
+import { runWorkflowLiveSync } from "./lib/live-sync-ack.js";
 import {
   OPEN_DISK_READ_BUDGET_MS,
   withDeadline,
@@ -1741,6 +1742,15 @@ function setupListeners() {
     } catch (err) {
       console.warn("[comfyui-mcp-panel] Manager task-result capture unavailable:", err);
     }
+    // #1299 — an out-of-band workflow save (H3 apply) announces itself as a
+    // ComfyUI `live_sync` event. Counting that the event was *delivered* is
+    // how notified:true was reported while the canvas stayed stale. The
+    // executor ACKs only after the active canvas actually holds the saved
+    // graph (or it reports refused/stale).
+    api.addEventListener("live_sync", (ev) => {
+      const detail = ev?.detail && typeof ev.detail === "object" ? ev.detail : {};
+      void GRAPH_TOOL_EXECUTORS.workflow_live_sync(detail);
+    });
     api.addEventListener("execution_error", (ev) => {
       lastExecFailure = { ...(ev.detail ?? {}), ts: new Date().toISOString() };
     });
@@ -6004,6 +6014,29 @@ async function workflowDiskBytes(rawPath) {
     return new Uint8Array(await res.arrayBuffer());
   } catch {
     return null; // unknown ⇒ fail safe (gate leaves overwrite:false — never a forced clobber)
+  }
+}
+
+/** #1299 — hex SHA-256 of a string, or null when SubtleCrypto is missing. */
+async function sha256Hex(text) {
+  if (typeof text !== "string") return null;
+  try {
+    const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(text));
+    return Array.from(new Uint8Array(digest), (b) => b.toString(16).padStart(2, "0")).join("");
+  } catch {
+    return null;
+  }
+}
+
+/** #1299 — best-effort ACK on ComfyUI's own socket so a send_sync caller can
+ *  wait for application, not delivery. Never throws. */
+function sendLiveSyncAckOnComfySocket(result) {
+  try {
+    const sock = api?.socket;
+    if (!sock || sock.readyState !== 1) return;
+    sock.send(JSON.stringify({ type: "live_sync_ack", data: result }));
+  } catch {
+    /* the command reply is the authoritative ACK */
   }
 }
 
@@ -16678,6 +16711,45 @@ const GRAPH_TOOL_EXECUTORS = {
     };
   },
 
+  // #1299 — apply an out-of-band saved workflow onto the ACTIVE canvas, and
+  // report notified only when that canvas actually holds the saved widgets.
+  // A dirty tab is refused (unsaved work is not clobbered). `live_sync` is the
+  // same executor under the name the H3 tool already sends.
+  async workflow_live_sync(args = {}) {
+    let host = app;
+    try {
+      host = getGraphCtx().app || app;
+    } catch {
+      host = app;
+    }
+    return runWorkflowLiveSync(args, {
+      getActiveWorkflow: () =>
+        host?.extensionManager?.workflow?.activeWorkflow || activeWorkflowRef(),
+      readDisk: (p) => workflowDiskContent(p),
+      serializeCanvas: () => host?.graph?.serialize?.() ?? null,
+      loadGraph: async (graph, target) => {
+        await host.loadGraphData(graph, true, true, target, { __cmcpKeepInstance: true });
+      },
+      rebaseline: async (target, diskText) => {
+        try {
+          target.originalContent = diskText;
+        } catch {
+          /* getter-only */
+        }
+        try {
+          await clearSpuriousOpenModified(target, { stillOwns: () => true });
+        } catch {
+          /* best-effort — a leftover modified flag is loud, not a false apply */
+        }
+      },
+      sha256: sha256Hex,
+      sendAck: sendLiveSyncAckOnComfySocket,
+    });
+  },
+  async live_sync(args) {
+    return GRAPH_TOOL_EXECUTORS.workflow_live_sync(args);
+  },
+
   async workflow_rename({ name, path }) {
     const s = app?.extensionManager?.workflow;
     if (!s?.renameWorkflow) throw new Error("rename unavailable on this frontend");
@@ -21055,6 +21127,12 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
         if (!SILENT_CMDS.has(msg.cmd)) {
           onCommand?.(msg.cmd, msg, reply);
         }
+        return;
+      }
+      // #1299 — a type-only live-sync frame (no cmd). Same executor as the
+      // command path; notified still means the canvas applied, never delivery.
+      if (msg && msg.type === "live_sync" && typeof msg.cmd !== "string") {
+        await GRAPH_TOOL_EXECUTORS.workflow_live_sync(msg);
         return;
       }
       // Reply to a direct callTool() request (cid-correlated).

--- a/web/js/lib/live-sync-ack.js
+++ b/web/js/lib/live-sync-ack.js
@@ -1,0 +1,315 @@
+// #1299 — live-sync acknowledgement. `notified` means the ACTIVE canvas holds
+// the saved workflow, never that a notification was delivered.
+//
+// An external writer (H3 apply, an out-of-band JSON save) can update the file
+// and count websocket clients as notified while the open tab still shows the
+// previous widgets. Delivery and application are different facts. This module
+// is the only place that may set `notified: true`, and it does so only when
+// the live canvas's widget values match the saved graph.
+//
+// A dirty tab is refused rather than reloaded: clobbering unsaved canvas work
+// is data loss. The reply names `panel_load_workflow` as the explicit reload.
+
+import { normalizedWorkflowPath } from "./workflow-chat-identity.js";
+
+/** Public recovery named in the reply. Not an internal bridge command. */
+export const LIVE_SYNC_RELOAD_ACTION = "panel_load_workflow";
+
+export const LIVE_SYNC_STATUS = Object.freeze({
+  APPLIED: "applied",
+  REFUSED: "refused",
+  STALE: "stale",
+  UNVERIFIED: "unverified",
+  NO_ACTIVE: "no_active",
+});
+
+function fail(status, extra = {}) {
+  return { notified: false, applied: false, status, ...extra };
+}
+
+/**
+ * @param {{
+ *   hasActiveTab?: boolean,
+ *   pathMatches?: boolean,
+ *   isModified?: boolean,
+ *   canvasMatchesSaved?: boolean,
+ *   diskReadable?: boolean,
+ *   expectedShaMatches?: boolean | null,
+ *   reloadAttempted?: boolean,
+ *   reloadCompleted?: boolean,
+ * }} [input]
+ * @returns {{
+ *   notified: boolean,
+ *   applied: boolean,
+ *   status: string,
+ *   reason?: string,
+ * }}
+ *
+ * INVARIANT: `notified === true` iff `status === "applied"` iff the canvas
+ * currently matches the saved workflow. No other branch may set notified.
+ */
+export function decideLiveSyncAck({
+  hasActiveTab = false,
+  pathMatches = true,
+  isModified = false,
+  canvasMatchesSaved = false,
+  diskReadable = true,
+  expectedShaMatches = null,
+  reloadAttempted = false,
+  reloadCompleted = false,
+} = {}) {
+  if (!hasActiveTab || pathMatches === false) {
+    return fail(LIVE_SYNC_STATUS.NO_ACTIVE, { reason: "no_active_tab" });
+  }
+  if (expectedShaMatches === false) {
+    return fail(LIVE_SYNC_STATUS.UNVERIFIED, { reason: "sha_mismatch" });
+  }
+  if (canvasMatchesSaved === true) {
+    return { notified: true, applied: true, status: LIVE_SYNC_STATUS.APPLIED };
+  }
+  if (isModified) {
+    return fail(LIVE_SYNC_STATUS.REFUSED, { reason: "dirty" });
+  }
+  if (!diskReadable) {
+    return fail(LIVE_SYNC_STATUS.UNVERIFIED, { reason: "disk_unreadable" });
+  }
+  if (reloadAttempted && !reloadCompleted) {
+    return fail(LIVE_SYNC_STATUS.STALE, { reason: "reload_failed" });
+  }
+  if (reloadAttempted && reloadCompleted) {
+    return fail(LIVE_SYNC_STATUS.STALE, { reason: "canvas_unchanged" });
+  }
+  return fail(LIVE_SYNC_STATUS.STALE, { reason: "not_applied" });
+}
+
+/** True when `requested` names the active tab, or when no path was given. */
+export function liveSyncPathsMatch(requested, activePath) {
+  if (requested == null || requested === "") return true;
+  const a = normalizedWorkflowPath(requested);
+  const b = normalizedWorkflowPath(activePath);
+  if (!a || !b) return false;
+  if (a === b) return true;
+  const strip = (p) => p.replace(/^(workflows\/)+/, "").replace(/^\.\//, "");
+  return strip(a) === strip(b);
+}
+
+function nodeWidgets(node) {
+  if (!node || typeof node !== "object") return undefined;
+  if (Object.prototype.hasOwnProperty.call(node, "widgets_values") && node.widgets_values !== undefined) {
+    return node.widgets_values;
+  }
+  if (Array.isArray(node.widgets)) return node.widgets.map((w) => w?.value);
+  return undefined;
+}
+
+function walkNodes(nodes, prefix, out) {
+  if (!Array.isArray(nodes)) return;
+  for (const node of nodes) {
+    if (!node || typeof node !== "object") continue;
+    const id = node.id == null ? "" : String(node.id);
+    const key = prefix + id;
+    const widgets = nodeWidgets(node);
+    if (widgets !== undefined) out.push([key, JSON.stringify(widgets)]);
+    if (node.subgraph && typeof node.subgraph === "object") {
+      walkNodes(node.subgraph.nodes, `${key}/`, out);
+    }
+  }
+}
+
+/**
+ * Stable fingerprint of widget values across the root graph, in-node subgraphs,
+ * and `definitions.subgraphs`. Presentation (pos/size/color) is ignored — clip
+ * switches and prompts are the signal #1299 actually observed as stale.
+ *
+ * `comparable:false` when either side has no nodes: empty-vs-empty must not
+ * count as a match (that would bless a blank canvas as "applied").
+ */
+export function widgetFingerprint(graph) {
+  const out = [];
+  if (!graph || typeof graph !== "object") {
+    return { comparable: false, key: "" };
+  }
+  walkNodes(graph.nodes, "", out);
+  const defs = graph.definitions?.subgraphs;
+  if (Array.isArray(defs)) {
+    for (const sg of defs) {
+      if (!sg || typeof sg !== "object") continue;
+      const sid = sg.id == null ? "" : String(sg.id);
+      walkNodes(sg.nodes, `def:${sid}/`, out);
+    }
+  }
+  if (out.length === 0) return { comparable: false, key: "" };
+  out.sort((a, b) => (a[0] < b[0] ? -1 : a[0] > b[0] ? 1 : 0));
+  return { comparable: true, key: JSON.stringify(out) };
+}
+
+/** True only when both graphs are readable AND their widget fingerprints match. */
+export function canvasMatchesSavedWorkflow(liveGraph, savedGraph) {
+  const live = widgetFingerprint(liveGraph);
+  const saved = widgetFingerprint(savedGraph);
+  if (!live.comparable || !saved.comparable) return false;
+  return live.key === saved.key;
+}
+
+function parseGraph(text) {
+  if (text && typeof text === "object") return text;
+  if (typeof text !== "string" || !text) return null;
+  try {
+    const parsed = JSON.parse(text);
+    return parsed && typeof parsed === "object" ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function noteFor(decision) {
+  switch (decision.status) {
+    case LIVE_SYNC_STATUS.APPLIED:
+      return "The active canvas holds the saved workflow.";
+    case LIVE_SYNC_STATUS.REFUSED:
+      return (
+        `The saved file changed but the live tab was intentionally not replaced — ` +
+        `it has unsaved canvas edits, and overwriting them would be data loss. ` +
+        `The active canvas still shows the previous values. To take the on-disk ` +
+        `version (discarding in-canvas work), call ${LIVE_SYNC_RELOAD_ACTION} with ` +
+        `this workflow's path. To keep the canvas, save first (panel_save_workflow).`
+      );
+    case LIVE_SYNC_STATUS.NO_ACTIVE:
+      return (
+        `No open tab matches this workflow, so the canvas was not updated. ` +
+        `Open it with ${LIVE_SYNC_RELOAD_ACTION} if you want the saved file on the canvas.`
+      );
+    case LIVE_SYNC_STATUS.UNVERIFIED:
+      return decision.reason === "sha_mismatch"
+        ? "The on-disk file does not match the expected digest, so nothing was applied to the canvas."
+        : "The on-disk file could not be read, so the canvas was not updated.";
+    default:
+      return (
+        `The saved file is not what the active canvas shows. ` +
+        `Call ${LIVE_SYNC_RELOAD_ACTION} with this workflow's path to load the on-disk version.`
+      );
+  }
+}
+
+/**
+ * Agent-facing reply. `notified` is copied from decideLiveSyncAck and never
+ * invented here. `reload` is only present when the canvas did NOT apply, so a
+ * caller cannot treat a successful apply as a prompt to clobber the tab.
+ */
+export function composeLiveSyncReply(decision, extra = {}) {
+  const ack = decideLiveSyncAck(decision);
+  const reply = {
+    ...extra,
+    notified: ack.notified,
+    applied: ack.applied,
+    status: ack.status,
+    ...(ack.reason ? { reason: ack.reason } : {}),
+    note: noteFor(ack),
+  };
+  // `notified` is decideLiveSyncAck's, even if `extra` tried to set it.
+  reply.notified = ack.notified;
+  reply.applied = ack.applied;
+  if (!ack.notified) reply.reload = LIVE_SYNC_RELOAD_ACTION;
+  else delete reply.reload;
+  return reply;
+}
+
+/**
+ * Orchestrate one live-sync attempt. All I/O is injected so unit tests drive
+ * this function — the same one the panel executor calls.
+ *
+ * `io.loadGraph(savedGraph, workflow)` is only invoked when the tab is clean
+ * AND the canvas does not already match. A dirty tab never reaches it.
+ */
+export async function runWorkflowLiveSync(args = {}, io = {}) {
+  const requestedPath = typeof args.path === "string" ? args.path.trim() : "";
+  const expectedSha =
+    typeof args.expected_sha256 === "string" && args.expected_sha256.trim()
+      ? args.expected_sha256.trim()
+      : typeof args.sha256 === "string" && args.sha256.trim()
+        ? args.sha256.trim()
+        : "";
+
+  const active = io.getActiveWorkflow?.() ?? null;
+  const activePath = typeof active?.path === "string" ? active.path : "";
+  if (!active) {
+    const reply = composeLiveSyncReply({ hasActiveTab: false });
+    io.sendAck?.(reply);
+    return reply;
+  }
+  if (!liveSyncPathsMatch(requestedPath, activePath)) {
+    const reply = composeLiveSyncReply({ hasActiveTab: true, pathMatches: false });
+    io.sendAck?.(reply);
+    return reply;
+  }
+
+  const wasDirty = !!active.isModified;
+  const diskText = await io.readDisk?.(activePath);
+  // Re-check AFTER the await. A user edit during the disk read is still unsaved
+  // work, and reloading over it is the data-loss case this exists to refuse.
+  // A tab switch during the await means serializeCanvas() is now a DIFFERENT
+  // workflow — refuse rather than apply the file to the wrong canvas.
+  const activeNow = io.getActiveWorkflow?.() ?? active;
+  if (activeNow !== active) {
+    const reply = composeLiveSyncReply({ hasActiveTab: true, pathMatches: false });
+    io.sendAck?.(reply);
+    return reply;
+  }
+  const isModified = wasDirty || !!active.isModified;
+  const diskReadable = typeof diskText === "string";
+  const savedGraph = parseGraph(diskText);
+  const liveGraph = io.serializeCanvas?.() ?? null;
+  const matchesBefore = canvasMatchesSavedWorkflow(liveGraph, savedGraph);
+
+  let expectedShaMatches = null;
+  if (expectedSha) {
+    if (!diskReadable) expectedShaMatches = false;
+    else {
+      const hex = await io.sha256?.(diskText);
+      expectedShaMatches =
+        typeof hex === "string" && hex.toLowerCase() === expectedSha.toLowerCase();
+    }
+  }
+
+  const base = {
+    hasActiveTab: true,
+    pathMatches: true,
+    isModified,
+    canvasMatchesSaved: matchesBefore,
+    diskReadable,
+    expectedShaMatches,
+  };
+
+  if (expectedShaMatches === false || matchesBefore || isModified || !diskReadable || !savedGraph) {
+    const reply = composeLiveSyncReply({
+      ...base,
+      canvasMatchesSaved: expectedShaMatches === false ? false : matchesBefore,
+      diskReadable: diskReadable && !!savedGraph,
+    });
+    io.sendAck?.(reply);
+    return reply;
+  }
+
+  let reloadCompleted = false;
+  try {
+    await io.loadGraph?.(savedGraph, active);
+    reloadCompleted = true;
+    await io.rebaseline?.(active, diskText);
+  } catch {
+    reloadCompleted = false;
+  }
+
+  const matchesAfter = canvasMatchesSavedWorkflow(io.serializeCanvas?.() ?? null, savedGraph);
+  const reply = composeLiveSyncReply({
+    hasActiveTab: true,
+    pathMatches: true,
+    isModified: false,
+    canvasMatchesSaved: matchesAfter,
+    diskReadable: true,
+    expectedShaMatches,
+    reloadAttempted: true,
+    reloadCompleted,
+  });
+  io.sendAck?.(reply);
+  return reply;
+}


### PR DESCRIPTION
## Summary

`h3_apply_workflow_update` saved the workflow file and returned `live_sync.notified=true` with one notified client, while `panel_graph_outline` on the same tab still showed the previous clip switches (`enable_clip_2/3/4=false` vs saved `[1,2,3,4]`). Notification *delivery* was being counted as the canvas having applied the saved graph.

## Fix

- `notified: true` is now set in one place (`decideLiveSyncAck`) and only when the live widget fingerprint matches the saved workflow — including subgraph clip switches.
- A dirty tab is **refused**, not reloaded. The reply names `panel_load_workflow` as the explicit reload so unsaved canvas work is not clobbered.
- A clean tab reloads in place (`__cmcpKeepInstance`) and is re-checked; a reload that leaves the canvas stale still reports `notified: false`.
- The panel executor is `workflow_live_sync` with a `live_sync` alias, plus a ComfyUI `live_sync` event listener. The ACK on ComfyUI's socket is `live_sync_ack` with the same payload.

## Tests

Shipped `runWorkflowLiveSync` and the extracted panel executor, driven with the reporter's dirty-stale clip-switch shape.

```
node --test browser_tests/unit/live-sync-ack.test.mjs
```

14/14 pass, including: dirty tab never calls `loadGraphData` and never reports notified; clean reload reports notified only after widgets match; a no-op reload stays `stale` / `canvas_unchanged`.

Fixes #1299
