### PR TITLE
fix(1310): keep agent-directed instruction blocks out of the user chat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project are documented here. This project adheres to
 ## [Unreleased]
 
 ### Fixed
+- agent-directed instruction blocks (LIVE-CANVAS TOOLS, MANUAL CANVAS CHANGES, query-graph budget accounting) stay in the agent's context and no longer render in the user's chat (#1310)
 - graph mutations no longer stay stuck in `[backend-reconnecting]` after a long Wan render: a busy `/prompt` poll is not a down socket, and binding status now distinguishes a readable canvas from a backend that is actually reconnecting (#1325)
 - panel_update_node surfaces the Manager update traceback instead of hiding it behind a generic "check the server log" error (#1320)
 - dictation listens for the spoken language when the panel UI is the English catalog floor — a German (or other unshipped) speaker no longer gets an English recognizer (#1329)

--- a/browser_tests/streaming-render.spec.ts
+++ b/browser_tests/streaming-render.spec.ts
@@ -21,9 +21,15 @@ test('renders a streamed agent reply into the last agent bubble', async ({
   const received = mockBridge.waitForUserMessage()
   await panel.sendMessage('say hello')
   const msg = await received
-  expect(msg.text).toContain('say hello')
+  expect(msg.text).toBe('say hello')
+  // #1310 — the LIVE-CANVAS block is for the agent. It may ride in context on
+  // an unestablished session, but it must not be the user-visible text.
+  expect(msg.text).not.toContain('LIVE-CANVAS')
+  await expect(panel.userBubbles.last()).toContainText('say hello')
+  await expect(panel.userBubbles.last()).not.toContainText('LIVE-CANVAS')
 
   mockBridge.replyStreamed('hello world')
 
   await expect(panel.agentBubbles.last()).toContainText('hello world')
+  await expect(panel.agentBubbles.last()).not.toContainText('LIVE-CANVAS')
 })

--- a/browser_tests/unit/canvas-tool-disclosure.test.mjs
+++ b/browser_tests/unit/canvas-tool-disclosure.test.mjs
@@ -384,10 +384,43 @@ test("wiring: the disclosure rides on the WIRE frame, not on the composer", () =
   );
   assert.match(
     body,
-    /CANVAS_TOOL_DISCLOSURE \+ text/,
-    "the disclosure must be PREPENDED — appended after the message it reads as commentary",
+    /CANVAS_TOOL_DISCLOSURE\.trimEnd\(\)/,
+    "the disclosure must still ride the frame — in context, not glued onto the user's text",
   );
-  assert.match(body, /text: outText/, "the frame must carry the disclosed text, not the original");
+  assert.match(
+    body,
+    /context: outContext/,
+    "#1310 — agent-directed prose goes in context so the orchestrator prepends it for the model",
+  );
+  assert.match(body, /^\s*text,$/m, "user_message.text stays the original — the visible transcript field");
+  assert.doesNotMatch(
+    body,
+    /CANVAS_TOOL_DISCLOSURE \+ text/,
+    "prepending the disclosure to text is how it rendered in the user's chat (#1310)",
+  );
+});
+
+test("wiring: the shipped chat painters strip agent-directed blocks (#1310)", () => {
+  // The leak is a RENDER one: history replay, an echo, a quoted say, and the
+  // activity-card default all paint whatever string they are handed. The
+  // stripper is the last line of defence — if a painter skips it, the block
+  // is back in the user's chat even when the wire field is clean.
+  const source = panelSource();
+  assert.match(
+    source,
+    /function renderUserText\(container, text, atts\) \{\s*const raw = stripAgentDirectedBlocks\(coerceMessageText\(text\)\);/,
+    "user bubbles must strip before they paint",
+  );
+  assert.match(
+    source,
+    /const safeText = stripAgentDirectedBlocks\(coerceMessageText\(text\)\);/,
+    "agent bubbles must strip before they paint",
+  );
+  assert.match(
+    source,
+    /text = stripAgentDirectedBlocks\(coerceMessageText\(text\)\);\s*detail = detail == null \? detail : stripAgentDirectedBlocks\(coerceMessageText\(detail\)\);/,
+    "activity cards must strip both slots — graph_query used to dump budget_overrun here",
+  );
 });
 
 test("wiring: the composer no longer assembles the disclosure itself", () => {

--- a/browser_tests/unit/chat-serialize.test.mjs
+++ b/browser_tests/unit/chat-serialize.test.mjs
@@ -6,7 +6,10 @@ import {
   buttonReplyText,
   isDroppedAgentReplay,
   serializeContext,
+  stripAgentDirectedBlocks,
 } from "../../web/js/lib/chat-serialize.js";
+
+import { CANVAS_TOOL_DISCLOSURE } from "../../web/js/lib/canvas-tool-disclosure.js";
 
 test("strings pass through unchanged", () => {
   assert.equal(coerceMessageText("hello"), "hello");
@@ -230,4 +233,65 @@ test("an unknown-shape object context degrades to JSON, never [object Object] (#
   assert.notEqual(out, "[object Object]");
   assert.ok(!out.includes("[object Object]"), `got: ${out}`);
   assert.equal(out, '{"foo":1,"bar":2}');
+});
+
+// --- #1310: agent-directed instruction blocks never render in the transcript --
+// The shipped painters (renderUserText / paintAgent / paintCard) run this
+// stripper on every bubble. These cases are the ones the issue named.
+
+test("#1310 LIVE-CANVAS TOOLS is stripped off a user turn, leaving the typed text", () => {
+  const typed = "make the sampler 20 steps";
+  const out = stripAgentDirectedBlocks(CANVAS_TOOL_DISCLOSURE + typed);
+  assert.equal(out, typed);
+  assert.doesNotMatch(out, /LIVE-CANVAS TOOLS/);
+  assert.doesNotMatch(out, /COMFYUI_MCP_TOOL_MODE/);
+});
+
+test("#1310 a user who types LIVE-CANVAS TOOLS mid-sentence is left alone", () => {
+  const typed = "what is this LIVE-CANVAS TOOLS warning?";
+  assert.equal(stripAgentDirectedBlocks(typed), typed);
+});
+
+test("#1310 MANUAL CANVAS CHANGES and ACTIVE WORKFLOW CHANGED strip as prefixes", () => {
+  assert.equal(
+    stripAgentDirectedBlocks(
+      "⟳ MANUAL CANVAS CHANGES since your last turn — the user edited the graph directly:\n  node 3 widget\nTreat the canvas as being in THIS state now.\n\nkeep going",
+    ),
+    "keep going",
+  );
+  assert.equal(
+    stripAgentDirectedBlocks(
+      "⟳ ACTIVE WORKFLOW CHANGED since your last turn. Re-read with panel_graph_outline.\n\nok",
+    ),
+    "ok",
+  );
+});
+
+test("#1310 stacked agent-directed prefixes all come off", () => {
+  const stacked =
+    CANVAS_TOOL_DISCLOSURE +
+    "⟳ MANUAL CANVAS CHANGES since your last turn — the user edited the graph directly:\n  x\nTreat the canvas as being in THIS state now.\n\n" +
+    "hello";
+  assert.equal(stripAgentDirectedBlocks(stacked), "hello");
+});
+
+test("#1310 hidden orchestrator notes and validation banners strip", () => {
+  assert.equal(
+    stripAgentDirectedBlocks(
+      "[The user cannot see this message — it is orchestrator status for you alone.]\n• lock error\n\nplease retry",
+    ),
+    "please retry",
+  );
+  assert.equal(
+    stripAgentDirectedBlocks(
+      "⚠️ GRAPH VALIDATION ERRORS — ComfyUI rejected the current graph at queue time;\n  node 1\nAddress these before running.\n\nfix it",
+    ),
+    "fix it",
+  );
+});
+
+test("#1310 empty / already-clean text is a no-op", () => {
+  assert.equal(stripAgentDirectedBlocks(""), "");
+  assert.equal(stripAgentDirectedBlocks("just a normal message"), "just a normal message");
+  assert.equal(stripAgentDirectedBlocks(null), "");
 });

--- a/browser_tests/unit/command-liveness.test.mjs
+++ b/browser_tests/unit/command-liveness.test.mjs
@@ -824,9 +824,9 @@ test("#1095 codex P1: the canvas-tool disclosure is decided when the frame LEAVE
   assert.ok(closureAt !== -1 && planAt !== -1, "both the closure and the plan must exist");
   assert.ok(planAt > closureAt, "the disclosure must be planned INSIDE the deferred send");
   // …and everything derived from it must live there too, or the recompute is decorative.
-  const outTextAt = body.indexOf("const outText =");
+  const outContextAt = body.indexOf("const outContext =");
   const disclosedAt = body.indexOf("const disclosed =");
-  assert.ok(disclosedAt > closureAt && outTextAt > closureAt, "the decision and the text ride with it");
+  assert.ok(disclosedAt > closureAt && outContextAt > closureAt, "the decision and the context ride with it");
   // The one-shot context is the opposite case and must stay OUTSIDE: pendingContext is
   // consumed when the user presses send, and re-reading it at drain time would either lose
   // it or attach it to the wrong message.

--- a/browser_tests/unit/describe-command-i18n.test.mjs
+++ b/browser_tests/unit/describe-command-i18n.test.mjs
@@ -57,6 +57,10 @@ test("English is unchanged by being keyed — same words, both plural forms", ()
   assert.equal(say("graph_clear", { cleared: 1 }), "Cleared canvas — removed 1 node (one Ctrl+Z restores all)");
   assert.equal(say("graph_clear", { cleared: 3 }), "Cleared canvas — removed 3 nodes (one Ctrl+Z restores all)");
   assert.equal(say("graph_find_nodes", { count: 5, total: 20, truncated: true }), "Found 5+ of 20 nodes");
+  // #1310 — outline/query used to fall through to JSON.stringify(result), which
+  // painted budget_overrun / groups_omitted in the activity card.
+  assert.equal(say("graph_outline", { node_count: 12, degraded_reason: "raise max_chars" }), "Read graph — 12 nodes");
+  assert.equal(say("graph_query", { total: 20, shown: 8, truncated: true, budget_overrun: "huge" }), "Found 8+ of 20 nodes");
   // Two independent counts in one sentence — nodes and columns pluralise separately.
   assert.equal(say("graph_auto_layout", { node_count: 1, columns: 1 }), "Auto-arranged 1 node (1 column)");
   assert.equal(say("graph_auto_layout", { node_count: 9, columns: 1 }), "Auto-arranged 9 nodes (1 column)");
@@ -197,6 +201,25 @@ test("user data in a summary is never mistaken for a placeholder", () => {
     say("graph_set_widget", { set: { widget: "text", value: "a {node_id} b", node_id: 12, previous: null } }),
     'Set text = "a {node_id} b" on node 12',
   );
+});
+
+test("#1310 graph_query / the default do not dump the raw tool payload", () => {
+  __setCatalogForTest("en", {});
+  const query = describeCommand(
+    "graph_query",
+    {},
+    { ok: true, result: { total: 4, shown: 4, budget_overrun: "max_chars", groups_omitted: 3 } },
+  );
+  assert.equal(query.detail, undefined);
+  assert.doesNotMatch(String(query.text), /budget_overrun|groups_omitted|max_chars/);
+
+  const fallback = describeCommand(
+    "some_new_cmd",
+    {},
+    { ok: true, result: { budget_overrun: "secret", groups_omitted: 3 } },
+  );
+  assert.equal(fallback.detail, undefined);
+  assert.equal(fallback.text, "some_new_cmd");
 });
 
 test("#1126: the summary discloses an unvalidated write, scoped to the widget it is about", () => {

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -420,7 +420,7 @@ import {
 } from "./lib/disconnect-verify.js";
 import { deferChangeTrackerSnapshot } from "./lib/change-tracker-snapshot.js";
 import { flushSourceCanvasBeforeSwitch } from "./lib/flush-source-before-switch.js";
-import { coerceMessageText, isDroppedAgentReplay, serializeContext } from "./lib/chat-serialize.js";
+import { coerceMessageText, isDroppedAgentReplay, serializeContext, stripAgentDirectedBlocks } from "./lib/chat-serialize.js";
 import {
   applyCurrentDefWidgetValues,
   driftedRequiredInputNames,
@@ -22307,13 +22307,21 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
         disclosedEpoch: canvasToolDisclosedEpoch,
       });
       const disclosed = disclosure.disclose && typeof text === "string";
-      const outText = disclosed ? CANVAS_TOOL_DISCLOSURE + text : text;
+      // #1310 — the disclosure is agent-directed. It rides in `context` so the
+      // orchestrator still prepends it for the model, but user_message.text stays
+      // what the user (or resume nudge) wrote. Prepending it to `text` made the
+      // block appear in the visible transcript whenever that field was rendered
+      // (history replay, an echo, a quoted say) and users read it as a warning
+      // their install was broken.
+      const outContext = disclosed
+        ? [CANVAS_TOOL_DISCLOSURE.trimEnd(), mergedContext].filter(Boolean).join("\n\n")
+        : mergedContext;
       try {
         sock.send(
           JSON.stringify({
             type: "user_message",
-            text: outText,
-            ...(mergedContext ? { context: mergedContext } : {}),
+            text,
+            ...(outContext ? { context: outContext } : {}),
             ...(images?.length ? { images: normalizeImageList(images) } : {}),
             // Client message id — the orchestrator echoes it in the "working"
             // ack so the panel can mark this exact bubble delivered ("Seen").
@@ -24001,6 +24009,28 @@ function describeCommand(cmd, msg, reply) {
             // Raw validation output — the machine's words, deliberately untranslated.
             detail: r.error ?? (r.node_errors ? JSON.stringify(r.node_errors).slice(0, 300) : undefined),
           };
+    case "graph_outline":
+      // #1310 — a user-facing count only. The outline's budget_overrun / degraded
+      // prose is for the agent and must not land in the activity card.
+      return {
+        icon: "pi-sitemap",
+        text: tr(
+          "panel.read_graph_nodes",
+          { one: "Read graph — {count} node", other: "Read graph — {count} nodes" },
+          { count: r.node_count },
+        ),
+      };
+    case "graph_query":
+      // Same rule: shown/total is what the user can read; groups_omitted and
+      // max_chars accounting stay in the tool result the agent already has.
+      return {
+        icon: "pi-search",
+        text: tr(
+          "panel.found_nodes",
+          { one: "Found {found} of {count} node", other: "Found {found} of {count} nodes" },
+          { count: r.total, found: `${r.shown ?? r.matched ?? r.count ?? 0}${r.truncated ? "+" : ""}` },
+        ),
+      };
     case "graph_find_nodes":
       // The TOTAL drives the plural; the match count carries its own "+" truncation marker,
       // so it is interpolated as text rather than as a second count.
@@ -24079,9 +24109,10 @@ function describeCommand(cmd, msg, reply) {
     case "workflow_save_as":
       return { icon: "pi-save", text: tr("panel.workflow_saved_as", "Saved as “{workflow}”", { workflow: r.workflow }) };
     default:
-      // `cmd` is the raw tool name (an identifier) and the detail is the raw reply payload —
-      // neither is prose, so neither is translated.
-      return { icon: "pi-bolt", text: cmd, detail: JSON.stringify(r).slice(0, 300) };
+      // `cmd` is the raw tool name (an identifier). #1310 — do NOT dump the raw
+      // reply payload: that is how graph_query's budget_overrun / groups_omitted
+      // accounting (and every other agent-only field) rendered in the transcript.
+      return { icon: "pi-bolt", text: cmd };
   }
 }
 
@@ -27615,6 +27646,16 @@ function buildPanel() {
     if (entry?.role !== "user" && turnOutputFenced()) {
       return entry;
     }
+    // #1310 — persist what the user can see. Mutate in place: callers keep this
+    // object. Agent-directed prefixes that leaked into a record (an older build
+    // prepended them to user_message.text; a card used to dump the raw tool
+    // payload) must not come back on replay.
+    if (entry && (entry.role === "user" || entry.role === "agent") && typeof entry.text === "string") {
+      entry.text = stripAgentDirectedBlocks(entry.text);
+    } else if (entry && entry.role === "card") {
+      if (typeof entry.text === "string") entry.text = stripAgentDirectedBlocks(entry.text);
+      if (typeof entry.detail === "string") entry.detail = stripAgentDirectedBlocks(entry.detail);
+    }
     const followsPanel = historyScopeFollowsPanel();
     // Panel-owned continuity uses a global active-thread pointer, but the thread
     // keeps the stable workflow UUID as provenance for archive grouping. Panel
@@ -27777,7 +27818,7 @@ function buildPanel() {
   // Surrounding text renders verbatim too. Tokens with no matching attachment
   // content fall back to their literal text. Never throws into the render.
   function renderUserText(container, text, atts) {
-    const raw = coerceMessageText(text);
+    const raw = stripAgentDirectedBlocks(coerceMessageText(text));
     try {
       const byId = new Map();
       if (Array.isArray(atts)) {
@@ -27882,7 +27923,7 @@ function buildPanel() {
     // isDroppedAgentReplay) — a genuinely-empty STRING record is valid stored
     // input and must still render its empty bubble (#241).
     if (isDroppedAgentReplay(text)) return;
-    const safeText = coerceMessageText(text);
+    const safeText = stripAgentDirectedBlocks(coerceMessageText(text));
     clearEmpty();
     const b = document.createElement("div");
     b.className = "cmcp-bubble agent";
@@ -27894,8 +27935,8 @@ function buildPanel() {
   function paintCard({ icon, text, detail, error }) {
     // Coerce both slots: a structured error/detail (e.g. reply.error object) must
     // never reach textContent as "[object Object]" — live OR on card replay (#276).
-    text = coerceMessageText(text);
-    detail = detail == null ? detail : coerceMessageText(detail);
+    text = stripAgentDirectedBlocks(coerceMessageText(text));
+    detail = detail == null ? detail : stripAgentDirectedBlocks(coerceMessageText(detail));
     clearEmpty();
     const card = document.createElement("div");
     card.className = "cmcp-card" + (error ? " error" : "");
@@ -29493,8 +29534,8 @@ function buildPanel() {
   function commitStream(id, text) {
     const s = streamBubbles.get(id);
     if (!s) return false;
-    s.commitText = text;
-    s.replyTarget = text; // authoritative — guarantees the typewriter reaches the end
+    s.commitText = stripAgentDirectedBlocks(text);
+    s.replyTarget = s.commitText; // authoritative — guarantees the typewriter reaches the end
     // CRITICAL: the typewriter (pumpStreams) runs on requestAnimationFrame, which
     // the browser PAUSES in a hidden/background tab. If the user switched away
     // during the turn (common on long pipeline runs), the reply would never paint
@@ -35824,25 +35865,26 @@ function buildPanel() {
     } catch {
       // graph unavailable — send without subgraph context
     }
-    const context = {
-      workflow: getWorkflowTitle(),
-      ...(viewing.scope === "subgraph" ? { subgraph: viewing.title } : {}),
-    };
-    // Surface any MANUAL canvas edits the user made since the agent's last turn,
-    // prepended to the agent-facing text only (the visible `text` is untouched).
-    // Orchestrator status the user must not see (failed panel auto-sync, lock
-    // recovery, …). Delivered the same way as the banners below — prepended to the
-    // agent-facing text only, so the visible bubble stays what the user typed.
+    // Agent-directed banners ride in `context`, never in user_message.text (#1310).
+    // The visible bubble is the typed `text`; the orchestrator prepends string
+    // context above it for the model. Putting these in `text` is how LIVE-CANVAS
+    // TOOLS / MANUAL CANVAS CHANGES rendered in the user's chat.
     const hiddenNotes = takeHiddenAgentNotes();
-    if (hiddenNotes) sendText = hiddenNotes + sendText;
     const changeBanner = manualChangeBanner();
-    if (changeBanner) sendText = changeBanner + sendText;
     // Surface ComfyUI's own pre-run validation errors (missing models,
     // value_not_in_list, broken links) the instant they appear — the same data the
     // user sees in the frontend's error panel — so the agent isn't blind to a broken
     // graph until it independently re-runs. Conditional + deduped (event-driven).
     const valBanner = await validationBanner();
-    if (valBanner) sendText = valBanner + sendText;
+    const context = [
+      hiddenNotes,
+      changeBanner,
+      valBanner,
+      serializeContext({
+        workflow: getWorkflowTitle(),
+        ...(viewing.scope === "subgraph" ? { subgraph: viewing.title } : {}),
+      }),
+    ].filter(Boolean).join("\n\n") || undefined;
     // The target conversation is decided at DISPATCH, not at type time (gate
     // P0-5): if the shared selection moved while we awaited above, relocate the
     // optimistically recorded prompt into the conversation the backend will

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -27646,16 +27646,6 @@ function buildPanel() {
     if (entry?.role !== "user" && turnOutputFenced()) {
       return entry;
     }
-    // #1310 — persist what the user can see. Mutate in place: callers keep this
-    // object. Agent-directed prefixes that leaked into a record (an older build
-    // prepended them to user_message.text; a card used to dump the raw tool
-    // payload) must not come back on replay.
-    if (entry && (entry.role === "user" || entry.role === "agent") && typeof entry.text === "string") {
-      entry.text = stripAgentDirectedBlocks(entry.text);
-    } else if (entry && entry.role === "card") {
-      if (typeof entry.text === "string") entry.text = stripAgentDirectedBlocks(entry.text);
-      if (typeof entry.detail === "string") entry.detail = stripAgentDirectedBlocks(entry.detail);
-    }
     const followsPanel = historyScopeFollowsPanel();
     // Panel-owned continuity uses a global active-thread pointer, but the thread
     // keeps the stable workflow UUID as provenance for archive grouping. Panel

--- a/web/js/lib/chat-serialize.js
+++ b/web/js/lib/chat-serialize.js
@@ -120,3 +120,44 @@ export function buttonReplyText(component, fields = []) {
   }
   return base;
 }
+
+/**
+ * Agent-directed instruction blocks that must never appear in the user-visible
+ * transcript (#1310). They are written for the model — the LIVE-CANVAS tool
+ * check, manual-edit banners, hidden orchestrator notes, validation injection —
+ * and users read the shouty grammar as a warning their install is broken.
+ *
+ * Each pattern matches ONE block at the start of the string. The stripper
+ * applies them in a loop so stacked prefixes (disclosure + manual changes)
+ * all come off. Anchored at ^ so a user who types the same words is left
+ * alone.
+ */
+const AGENT_DIRECTED_PREFIXES = [
+  /^(?:⚙\s*)?LIVE-CANVAS TOOLS[\s\S]*?(?:\n\n|$)/i,
+  /^⟳\s*MANUAL CANVAS CHANGES[\s\S]*?(?:\n\n|$)/,
+  /^⟳\s*ACTIVE WORKFLOW CHANGED[\s\S]*?(?:\n\n|$)/,
+  /^\[The user cannot see this message[\s\S]*?(?:\n\n|$)/,
+  /^⚠️\s*GRAPH VALIDATION ERRORS[\s\S]*?(?:\n\n|$)/,
+  /^⚠️\s*MISSING ASSETS[\s\S]*?(?:\n\n|$)/,
+  /^⚠️\s*LAST RUN FAILED[\s\S]*?(?:\n\n|$)/,
+];
+
+/** Remove agent-only prefixes from text that is about to be shown to the user. */
+export function stripAgentDirectedBlocks(text) {
+  let out = coerceMessageText(text);
+  if (!out) return out;
+  let prev;
+  do {
+    prev = out;
+    let next = out.replace(/^\s+/, "");
+    for (const re of AGENT_DIRECTED_PREFIXES) {
+      const stripped = next.replace(re, "");
+      if (stripped !== next) {
+        next = stripped;
+        break;
+      }
+    }
+    out = next;
+  } while (out !== prev);
+  return out.replace(/^\s+/, "");
+}


### PR DESCRIPTION
## Root cause

The `⚙ LIVE-CANVAS TOOLS — CHECK YOUR TOOLSET…` block is written entirely for the agent (#291). It was prepended onto `user_message.text` at the wire choke point. That field is what the transcript renders — live, on history replay, and whenever a say/echo quoted it — so users read the shouty caps and remedy list as a warning that **their** install was broken.

The same leak class:

- `⟳ MANUAL CANVAS CHANGES` / validation banners were prepended onto the same `text` field.
- `graph_query` (and any undescribed command) fell through `describeCommand`'s default and dumped `JSON.stringify(result).slice(0, 300)` onto the activity card, which is how `budget_overrun` / `groups_omitted` accounting reached the user.

## Fix

Agent-directed prose goes to the agent's **context** only. The visible transcript never sees it.

- `CANVAS_TOOL_DISCLOSURE` rides in `user_message.context` (the orchestrator still prepends it for the model). `user_message.text` stays what the user typed or the resume nudge wrote.
- Manual-change / validation / hidden-note banners join that same context string instead of `sendText`.
- `stripAgentDirectedBlocks` is the last line of defence on the shipped painters (`renderUserText`, `paintAgent`, `paintCard`, stream commit) and on `record()`, so an older persisted prefix cannot come back on replay. A user who *types* those words mid-sentence is left alone.
- `graph_query` / `graph_outline` get a short count card. The default no longer dumps the raw tool payload.

## Verification

- `node --test browser_tests/unit/chat-serialize.test.mjs browser_tests/unit/canvas-tool-disclosure.test.mjs browser_tests/unit/describe-command-i18n.test.mjs browser_tests/unit/command-liveness.test.mjs` — 130 pass, including:
  - the real `CANVAS_TOOL_DISCLOSURE` string strips off a user turn
  - stacked prefixes all come off
  - a mid-sentence "LIVE-CANVAS TOOLS" is left alone
  - wiring: painters call the stripper; the wire frame puts the disclosure in `context`, not `text`
  - `graph_query` / the default do not dump `budget_overrun`
- `node scripts/i18n-check.mjs` — locales OK
- `node scripts/check-panel-scope.mjs` — OK
- Browser e2e not run here — needs a live ComfyUI on localhost:8188. The streaming-render spec now asserts the user bubble and the wire `text` do not contain `LIVE-CANVAS`.

Fixes #1310
