### PR TITLE
fix(1329): dictation listens for the spoken language, not the English UI floor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project are documented here. This project adheres to
 ## [Unreleased]
 
 ### Fixed
+- dictation listens for the spoken language when the panel UI is the English catalog floor — a German (or other unshipped) speaker no longer gets an English recognizer (#1329)
 - live-sync no longer reports notified unless the active canvas actually holds the saved workflow (#1299)
 - `panel_edit_group({bounds})` writes the group box only — contained nodes stay at their canvas coordinates (#1306)
 - an already-full origin can save workflow drafts again after the chat-history quota fix (#1305)

--- a/browser_tests/unit/voice-language.test.mjs
+++ b/browser_tests/unit/voice-language.test.mjs
@@ -2,11 +2,15 @@ import assert from 'node:assert/strict'
 import test from 'node:test'
 import { readFileSync } from 'node:fs'
 
+import { pickLocale } from '../../web/js/lib/i18n.js'
 import { voiceRecognitionLang } from '../../web/js/lib/voice-language.js'
 
 // #1289 — dictation set recognition.lang from navigator.language alone, so a user
 // who picked a panel (or ComfyUI) language different from their browser's dictated
 // into a recognizer listening for the WRONG language.
+//
+// #1329 — after #1289, currentLocale() (the shipped "en" UI-catalog floor) overrode
+// a German speaker's de-DE. Dictation does not need a translation catalog.
 
 test('#1289 the panel locale wins over the browser language', () => {
   assert.equal(voiceRecognitionLang({ panelLocale: 'fr', browserLang: 'en-US' }), 'fr')
@@ -24,6 +28,35 @@ test('#1289 lang is never empty — en-US is the floor', () => {
   assert.equal(voiceRecognitionLang({}), 'en-US')
   assert.equal(voiceRecognitionLang({ panelLocale: '', browserLang: '' }), 'en-US')
   assert.equal(voiceRecognitionLang(), 'en-US')
+})
+
+test('#1329 the en panel floor does not override a non-English spoken language', () => {
+  // German (and any other language the panel does not ship) flattens to "en" via
+  // pickLocale. Dictation still has to listen for the spoken language.
+  assert.equal(voiceRecognitionLang({ panelLocale: 'en', browserLang: 'de-DE' }), 'de-DE')
+  assert.equal(voiceRecognitionLang({ panelLocale: 'en', browserLang: 'it-IT' }), 'it-IT')
+  assert.equal(voiceRecognitionLang({ panelLocale: 'en', browserLang: 'nl-NL' }), 'nl-NL')
+  assert.equal(voiceRecognitionLang({ panelLocale: 'en', browserLang: 'pl-PL' }), 'pl-PL')
+  assert.equal(voiceRecognitionLang({ panelLocale: 'en', browserLang: 'sv-SE' }), 'sv-SE')
+})
+
+test('#1329 an English browser keeps the en panel locale (or en-US when both are empty)', () => {
+  assert.equal(voiceRecognitionLang({ panelLocale: 'en', browserLang: 'en-US' }), 'en')
+  assert.equal(voiceRecognitionLang({ panelLocale: 'en', browserLang: 'en-GB' }), 'en')
+  assert.equal(voiceRecognitionLang({ panelLocale: 'en', browserLang: 'en' }), 'en')
+})
+
+test('#1329 shipped path: pickLocale floors de-DE to en, then dictation still listens for de-DE', () => {
+  // This is the exact shipped composer path: currentLocale() is pickLocale's result,
+  // handed to voiceRecognitionLang with navigator.language. Detect + no Comfy.Locale
+  // + a German browser is the reporter's setup.
+  const panelLocale = pickLocale({ ourSetting: '', comfyLocale: '', navigatorLangs: ['de-DE'] })
+  assert.equal(panelLocale, 'en', 'German is not a shipped UI locale — pickLocale floors to en')
+  assert.equal(
+    voiceRecognitionLang({ panelLocale, browserLang: 'de-DE' }),
+    'de-DE',
+    'dictation still uses the spoken language, not the UI-catalog floor',
+  )
 })
 
 test('#1289 WIRED: the composer hands the recognizer the PANEL locale, not raw navigator.language', () => {

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -34722,9 +34722,8 @@ function buildPanel() {
       return;
     }
     recognition = new SR();
-    // Dictate in the language the PANEL is speaking (#1289): currentLocale() already
-    // encodes the explicit panel setting → ComfyUI locale → navigator precedence, so
-    // the browser's own language is only a fallback for an unresolved panel.
+    // #1289 / #1329: voiceRecognitionLang prefers a real panel locale, but will not
+    // let the shipped-UI "en" floor override a non-English spoken language.
     recognition.lang = voiceRecognitionLang({ panelLocale: currentLocale(), browserLang: navigator.language });
     recognition.continuous = true;
     recognition.interimResults = false;

--- a/web/js/lib/voice-language.js
+++ b/web/js/lib/voice-language.js
@@ -1,26 +1,42 @@
-// #1289 — dictate in the language the panel is speaking, not whatever the browser says.
+// #1289 / #1329 — dictate in the language the user is speaking.
 //
-// ## The defect
+// ## The defects
 //
-// The composer set `recognition.lang = navigator.language || "en-US"`. A user who set the
-// panel (or ComfyUI itself) to French while their browser reports en-US dictated French
-// into an English recognizer and got garbage back. The panel had ALREADY resolved which
-// language it is speaking — pickLocale's explicit-setting → ComfyUI-locale → navigator
-// order — and dictation ignored all of it.
+// #1289: the composer set `recognition.lang = navigator.language || "en-US"`. A user
+// who set the panel (or ComfyUI itself) to French while their browser reports en-US
+// dictated French into an English recognizer and got garbage back.
+//
+// #1329: after #1289, dictation used the panel's *resolved* locale. The panel only
+// ships [en, zh, zh-TW, ru, ja, ko, fr, es, pt-BR, tr, ar, fa]. pickLocale flattens
+// a de-DE (or it, nl, pl, sv, …) browser to the "en" floor because there is no
+// German catalog. Dictation does not need a translation catalog — a German speaker
+// then gets an English recognizer with no setting that can fix it.
 //
 // ## What this module does
 //
-// One precedence, stated once: the panel's own resolved locale wins; the browser's
-// language is the fallback for a panel that has not resolved one yet; "en-US" is the
-// floor so `lang` is never an empty string (an empty BCP-47 tag is a silent
-// implementation-defined default, which is how this bug looked from the inside).
+// One precedence, stated once:
+//   1. A resolved panel locale that is NOT the "en" fallback floor wins (keeps
+//      #1289: a French panel + English browser still dictates French).
+//   2. When the panel is the "en" floor (or unresolved) and the browser reports a
+//      non-English language, trust the browser — that is the spoken language.
+//   3. Otherwise panel locale, then browser language, then "en-US" so `lang` is
+//      never an empty string.
 // The panel's codes ("pt-BR", "zh-TW", bare "zh") are all valid BCP-47 tags, so no
 // remapping happens here — the locale is passed through, not reinterpreted.
 
 /**
- * The BCP-47 tag to hand SpeechRecognition: the panel's resolved locale first, the
- * browser's language second, "en-US" last.
+ * The BCP-47 tag to hand SpeechRecognition.
+ *
+ * A non-English panel locale wins. The "en" panel floor does not override a
+ * non-English browser language (#1329). "en-US" is last so lang is never empty.
  */
 export function voiceRecognitionLang({ panelLocale, browserLang } = {}) {
+  // Dictation needs the user's SPOKEN language, which is not limited to the locales the
+  // panel ships translations for. When the panel resolved to "en" merely as the fallback
+  // floor (the user's language, e.g. German, is not a shipped panel locale) while the
+  // browser reports a non-English language, trust the browser for dictation -- a German
+  // speaker dictating into an English recognizer gets garbage back.
+  if (panelLocale && panelLocale !== "en") return panelLocale;
+  if (browserLang && !/^en(-|$)/i.test(browserLang)) return browserLang;
   return panelLocale || browserLang || "en-US";
 }


### PR DESCRIPTION
## Summary

Voice dictation used the panel's *resolved* UI locale. The panel only ships catalogs for `[en, zh, zh-TW, ru, ja, ko, fr, es, pt-BR, tr, ar, fa]`, so `pickLocale` flattens `de-DE` (and every other unshipped language) to the `"en"` floor. Dictation does not need a translation catalog — a German speaker then got an English recognizer with no setting that could fix it.

`voiceRecognitionLang` now:

1. Still lets a real non-English panel locale win (`fr` panel + `en-US` browser dictates French — keeps #1289).
2. Does **not** let the shipped `"en"` floor override a non-English browser language (`en` panel + `de-DE` browser dictates German).
3. Falls back to `en-US` only when both sides are empty.

The shipped composer path is unchanged: `voiceRecognitionLang({ panelLocale: currentLocale(), browserLang: navigator.language })`. The floor exception lives in the helper.

Fixes #1329

## Test plan

- [x] `node --test browser_tests/unit/voice-language.test.mjs` — 7 pass, including:
  - shipped path: `pickLocale({ ourSetting: '', comfyLocale: '', navigatorLangs: ['de-DE'] })` floors to `en`, then dictation still listens for `de-DE`
  - other unshipped languages (`it-IT`, `nl-NL`, `pl-PL`, `sv-SE`) also beat the `en` floor
  - `#1289` still holds: `fr` + `en-US` → `fr`; `pt-BR` + `de-DE` → `pt-BR`
  - English-on-English stays `en`; empty stays `en-US`
  - composer still wires `currentLocale()` + `navigator.language` through the helper
- [x] `node --test browser_tests/unit/changelog-integrity.test.mjs` — 4 pass
