### PR TITLE
fix(1325): do not keep mutations stuck in backend-reconnecting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project are documented here. This project adheres to
 ## [Unreleased]
 
 ### Fixed
+- graph mutations no longer stay stuck in `[backend-reconnecting]` after a long Wan render: a busy `/prompt` poll is not a down socket, and binding status now distinguishes a readable canvas from a backend that is actually reconnecting (#1325)
 - dictation listens for the spoken language when the panel UI is the English catalog floor — a German (or other unshipped) speaker no longer gets an English recognizer (#1329)
 - panel_set_widget can author an LTXDirector timeline from the serialized widgets when the live timeline editor is not initialized (#1308)
 - live-sync no longer reports notified unless the active canvas actually holds the saved workflow (#1299)

--- a/browser_tests/unit/bundle-version.test.mjs
+++ b/browser_tests/unit/bundle-version.test.mjs
@@ -250,7 +250,7 @@ test("#584 healer navigation guards: unsaved-work refusal, socket-down defer, ca
   // socket down defers its navigation and UN-ARMS the marker, or the next
   // reconnect would read the attempt as spent and never retry.
   const prime = body.indexOf("primeModuleCache({");
-  const socketDown = body.indexOf("if (comfyBackendSocketDown)", prime);
+  const socketDown = body.indexOf("if (comfyBackendIsDown())", prime);
   assert.ok(socketDown > prime, "the socket is re-checked after the prime, before navigating");
   const deferUnarm = body.indexOf("ssSet(BUNDLE_HEAL_KEY, null);", socketDown);
   assert.ok(

--- a/browser_tests/unit/object-info-snapshot.test.mjs
+++ b/browser_tests/unit/object-info-snapshot.test.mjs
@@ -517,6 +517,7 @@ function buildShippedOracle({ api, socketDown = false, epoch = 5, snapshot, epoc
      let oracleFailures = [];
      let snapshotIneligibility = "";
      let setWidgetSchemaFromSnapshot = null;
+     const comfyBackendIsDown = () => comfyBackendSocketDown;
      const historyRecorded = [];
      const recordObjectInfoTypes = (defs) => { historyRecorded.push(defs); return defs; };
      // Declared HERE so it closes over the mutable epoch above and can move it the moment

--- a/browser_tests/unit/reconnect-recovery.test.mjs
+++ b/browser_tests/unit/reconnect-recovery.test.mjs
@@ -25,6 +25,10 @@ import {
   graphMutationReconnectGate,
   reconnectRefusalError,
   readReconnectRefusal,
+  backendSocketIsDown,
+  classifyBackendStatusEvent,
+  describeGraphMutationReadiness,
+  WS_OPEN,
 } from "../../web/js/lib/reconnect-recovery.js";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
@@ -154,6 +158,85 @@ test("#663: a restore that NEVER settles is bounded — the watch exhausts and p
 // ---------------------------------------------------------------------------
 // graphMutationReconnectGate
 // ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// #1325 — sticky down-flag vs live socket
+// ---------------------------------------------------------------------------
+
+test("#1325: a flagged-down socket that is still OPEN is not down", () => {
+  // ComfyUI's `_pollQueue` dispatches status(null) on a failed /prompt while a
+  // long Wan render blocks the backend. The websocket never left OPEN.
+  assert.equal(backendSocketIsDown({ flaggedDown: true, socketReadyState: WS_OPEN }), false);
+});
+
+test("#1325: a flagged-down socket that is not OPEN is down", () => {
+  assert.equal(backendSocketIsDown({ flaggedDown: true, socketReadyState: 0 }), true, "CONNECTING");
+  assert.equal(backendSocketIsDown({ flaggedDown: true, socketReadyState: 2 }), true, "CLOSING");
+  assert.equal(backendSocketIsDown({ flaggedDown: true, socketReadyState: 3 }), true, "CLOSED");
+  assert.equal(backendSocketIsDown({ flaggedDown: true }), true, "unknown readyState fails closed");
+});
+
+test("#1325: an unflagged socket is never down, even if readyState is missing", () => {
+  assert.equal(backendSocketIsDown({ flaggedDown: false, socketReadyState: 3 }), false);
+  assert.equal(backendSocketIsDown({}), false);
+});
+
+test("#1325: a real status payload is the backend talking", () => {
+  assert.equal(
+    classifyBackendStatusEvent({ detail: { exec_info: { queue_remaining: 0 } }, socketReadyState: 3 }),
+    "alive",
+  );
+});
+
+test("#1325: a null status while the socket is OPEN is a busy poll, not a drop", () => {
+  assert.equal(classifyBackendStatusEvent({ detail: null, socketReadyState: WS_OPEN }), "ignore");
+  assert.equal(classifyBackendStatusEvent({ detail: undefined, socketReadyState: WS_OPEN }), "ignore");
+});
+
+test("#1325: a null status while the socket is not OPEN is a lost connection", () => {
+  assert.equal(classifyBackendStatusEvent({ detail: null, socketReadyState: 3 }), "lost");
+  assert.equal(classifyBackendStatusEvent({ detail: null }), "lost", "unknown readyState fails closed");
+});
+
+test("#1325: binding status distinguishes canvas identity from backend readiness", () => {
+  const down = describeGraphMutationReadiness({
+    flaggedDown: true,
+    socketReadyState: 3,
+    canvasBinding: "bound",
+  });
+  assert.equal(down.graph_binding, "reconnecting");
+  assert.equal(down.canvas_binding, "bound", "the canvas is still this workflow's");
+  assert.equal(down.backend_socket, "reconnecting");
+  assert.equal(down.mutations_ready, false);
+  assert.match(down.backend_socket_note, /reload the ComfyUI page or restart ComfyUI/);
+
+  const up = describeGraphMutationReadiness({
+    flaggedDown: true,
+    socketReadyState: WS_OPEN,
+    canvasBinding: "bound",
+  });
+  assert.equal(up.graph_binding, "bound");
+  assert.equal(up.backend_socket, "up");
+  assert.equal(up.mutations_ready, true);
+  assert.equal(up.backend_socket_note, undefined);
+});
+
+test("#1325: a live execution after a Wan render must not stay gated", () => {
+  // The shipped path: flag armed by a busy-poll null status, socket still OPEN.
+  assert.equal(
+    graphMutationReconnectGate({
+      cmd: "graph_set_widget",
+      backendDown: backendSocketIsDown({ flaggedDown: true, socketReadyState: WS_OPEN }),
+    }),
+    null,
+    "OPEN socket + sticky flag must not refuse the mutation",
+  );
+  const stillDown = graphMutationReconnectGate({
+    cmd: "graph_set_widget",
+    backendDown: backendSocketIsDown({ flaggedDown: true, socketReadyState: 3 }),
+  });
+  assert.equal(stillDown?.code, "backend-reconnecting");
+});
 
 test("#646: no instability signal → no gate", () => {
   assert.equal(
@@ -575,7 +658,7 @@ test("#646 wiring: the dispatch fence gates MUTATING graph commands through the 
   assert.match(fence, /graphCommandMayMutateWorkflow\(msg\.cmd\)/, "reads are NOT gated — mutations are");
   assert.match(
     fence,
-    /graphMutationReconnectGate\(\{[\s\S]*?backendDown: comfyBackendSocketDown,[\s\S]*?bindingSettleWindow: postReconnectBindingSettleWindow\(\)/,
+    /graphMutationReconnectGate\(\{[\s\S]*?backendDown: comfyBackendIsDown\(\),[\s\S]*?bindingSettleWindow: postReconnectBindingSettleWindow\(\)/,
     "the gate reads both live signals",
   );
   assert.ok(
@@ -611,7 +694,7 @@ test("#646 wiring: the async write boundary re-checks the gate (a dispatch can s
   const body = SRC.slice(start, start + 1400);
   assert.match(
     body,
-    /graphMutationReconnectGate\(\{[\s\S]*?backendDown: comfyBackendSocketDown,[\s\S]*?bindingSettleWindow: postReconnectBindingSettleWindow\(\)/,
+    /graphMutationReconnectGate\(\{[\s\S]*?backendDown: comfyBackendIsDown\(\),[\s\S]*?bindingSettleWindow: postReconnectBindingSettleWindow\(\)/,
     "the pre-write revalidation consults the same live signals",
   );
   assert.ok(
@@ -621,5 +704,43 @@ test("#646 wiring: the async write boundary re-checks the gate (a dispatch can s
   assert.ok(
     body.indexOf("graphMutationReconnectGate({") < body.indexOf("assertGraphBoundToActiveWorkflow("),
     "the gate fires BEFORE the write-boundary binding assert",
+  );
+});
+
+test("#1325 wiring: a null status only arms the flag when the live socket is not OPEN", () => {
+  const start = SRC.indexOf('api.addEventListener("status"');
+  assert.notEqual(start, -1);
+  const block = SRC.slice(start, start + 1600);
+  assert.match(block, /classifyBackendStatusEvent\(\{/, "the status handler classifies before arming");
+  assert.match(block, /statusKind === "alive"/, "a real queue payload clears a stale flag");
+  assert.match(block, /statusKind === "lost"/, "only a lost-connection null arms the gate");
+  assert.match(block, /noteComfyBackendAlive\(\)/, "alive status un-sticks the mutation guard");
+});
+
+test("#1325 wiring: a live execution frame un-sticks the mutation guard", () => {
+  for (const ev of ["execution_start", "execution_success", "executed", "progress"]) {
+    const start = SRC.indexOf(`api.addEventListener("${ev}"`);
+    assert.notEqual(start, -1, `${ev} listener is still wired`);
+    const block = SRC.slice(start, start + 280);
+    assert.match(block, /noteComfyBackendAlive\(\)/, `${ev} is proof the backend is talking`);
+  }
+});
+
+test("#1325 wiring: binding-status replies publish backend readiness, not just canvas identity", () => {
+  assert.match(SRC, /function backendSocketReplyFields\(/);
+  assert.match(
+    SRC,
+    /outline,[\s\S]{0,400}?\.\.\.backendSocketReplyFields\(activeWorkflowRef\(\)\)/,
+    "graph_outline discloses backend readiness beside the readable canvas",
+  );
+  assert.match(
+    SRC,
+    /\.\.\.backendSocketReplyFields\(active\),/,
+    "workflow_list discloses it on the bound-tab reply",
+  );
+  assert.match(
+    SRC,
+    /\.\.\.backendSocketReplyFields\(target\),/,
+    "workflow_open (set_workflow_target current) discloses it",
   );
 });

--- a/browser_tests/unit/rgthree-lora-row.test.mjs
+++ b/browser_tests/unit/rgthree-lora-row.test.mjs
@@ -1310,6 +1310,7 @@ const EXECUTOR_DEPS = [
   "recordObjectInfoTypes",
   "objectInfoOracleFailureNote",
   "comfyBackendSocketDown",
+  "comfyBackendIsDown",
   "objectInfoHistory",
   "sourceForSubgraphInput",
   "refreshComboOptionsFromDefs",
@@ -1448,6 +1449,7 @@ function executor(node, overrides = {}) {
     runSetWidget: overrides.runSetWidget ?? stubRunSetWidget(),
     clearStaleRedFlag: () => {},
     objectInfoHistory: { wasTypeEverDefined: () => true },
+    comfyBackendIsDown: () => false,
     ...overrides,
   };
   const factory = new Function(

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -266,6 +266,9 @@ import {
   graphMutationReconnectGate,
   reconnectRefusalError,
   readReconnectRefusal,
+  backendSocketIsDown,
+  classifyBackendStatusEvent,
+  describeGraphMutationReadiness,
 } from "./lib/reconnect-recovery.js";
 import { reconcileCompletedDownloads } from "./lib/download-refresh.js";
 import { todoItemGlyph } from "./lib/plan-glyph.js";
@@ -753,7 +756,36 @@ let postReconnectWatchToken = 0;
 // "reconnected" events (a null "status" payload is the same lost-connection
 // signal). A graph mutation dispatched in that gap can be applied and then wiped
 // by the incoming restore — so mutations are refused while this holds.
+//
+// #1325: the flag is a SIGNAL, not the live fact. ComfyUI also dispatches
+// `status` with a null payload from `_pollQueue` when `GET /prompt` fails, and
+// a long GPU-bound render (Wan) makes that poll fail without the websocket
+// ever leaving OPEN. `comfyBackendIsDown()` is the predicate the gate and
+// binding replies consult: flagged-down + OPEN socket is a stale/busy-poll
+// signal, not a restore-is-incoming window.
 let comfyBackendSocketDown = false;
+function comfyBackendSocketReadyState() {
+  const state = api?.socket?.readyState;
+  return typeof state === "number" ? state : undefined;
+}
+function comfyBackendIsDown() {
+  return backendSocketIsDown({
+    flaggedDown: comfyBackendSocketDown,
+    socketReadyState: comfyBackendSocketReadyState(),
+  });
+}
+function noteComfyBackendAlive() {
+  if (!comfyBackendSocketDown) return;
+  comfyBackendSocketDown = false;
+  comfyBackendOutage.noteUp();
+}
+function backendSocketReplyFields(wf) {
+  return describeGraphMutationReadiness({
+    flaggedDown: comfyBackendSocketDown,
+    socketReadyState: comfyBackendSocketReadyState(),
+    canvasBinding: wf ? describeLiveCanvasBinding(wf) : undefined,
+  });
+}
 // #654 — the ComfyUI BACKEND outage clock. The elapsed interval is the only
 // thing that separates a real restart from a benign WS blip (asset view, image
 // check, tab refocus), and `reconnected` fires for both.
@@ -1772,6 +1804,17 @@ function setupListeners() {
     });
     api.addEventListener("execution_start", () => {
       lastExecFailure = null;
+      // #1325 — a live execution frame is proof the backend socket is delivering.
+      noteComfyBackendAlive();
+    });
+    api.addEventListener("execution_success", () => {
+      noteComfyBackendAlive();
+    });
+    api.addEventListener("executed", () => {
+      noteComfyBackendAlive();
+    });
+    api.addEventListener("progress", () => {
+      noteComfyBackendAlive();
     });
     // While the backend socket is down, distrust the combos (they may be about
     // to change) so a stale combo can't suppress a genuine miss (finding #4).
@@ -1786,7 +1829,20 @@ function setupListeners() {
     });
     api.addEventListener("status", (ev) => {
       // A null status payload is ComfyUI's "backend connection lost" signal.
-      if (ev?.detail == null) {
+      // #1325 — except when the live socket is still OPEN: `_pollQueue` dispatches
+      // the same null on a failed /prompt while a long render is blocking the
+      // backend, which is a busy server, not a drop. A real queue payload is
+      // the backend talking, so it also CLEARS a stale flag (`reconnected` can
+      // miss if the socket never left OPEN).
+      const statusKind = classifyBackendStatusEvent({
+        detail: ev?.detail,
+        socketReadyState: comfyBackendSocketReadyState(),
+      });
+      if (statusKind === "alive") {
+        noteComfyBackendAlive();
+        return;
+      }
+      if (ev?.detail == null && statusKind === "lost") {
         nodeDefsRefreshConfirmed = false;
         comfyBackendSocketDown = true;
         // #654 — and it is a down signal in its own right: some frontends
@@ -10290,7 +10346,7 @@ function revalidateGraphMutationContext(captured) {
   // Nothing has been written to the graph yet, so the claim is true here.
   const reconnectGate = graphMutationReconnectGate({
     cmd: "graph_add_node",
-    backendDown: comfyBackendSocketDown,
+    backendDown: comfyBackendIsDown(),
     bindingSettleWindow: postReconnectBindingSettleWindow(),
   });
   if (reconnectGate) throw reconnectRefusalError(reconnectGate);
@@ -11041,6 +11097,11 @@ const GRAPH_TOOL_EXECUTORS = {
       group_count: groups.length,
       viewing: describeActiveGraph(graph),
       outline,
+      // #1325 — canvas readability is not backend readiness. A Wan render can
+      // leave the sticky down-flag armed while this read still works from the
+      // local graph; publish the live socket so the caller does not treat
+      // "outline succeeded" as "mutations will too".
+      ...backendSocketReplyFields(activeWorkflowRef()),
       // #809: the budget, the rung, and WHY — a caller that reads fields rather than
       // prose must still learn that detail was traded away and which lever restores it.
       max_chars: maxChars,
@@ -13351,7 +13412,7 @@ const GRAPH_TOOL_EXECUTORS = {
         // looking in the wrong place (#982).
         const fallback = objectInfoSnapshot.authorize({
           epoch: backendReconnectEpoch,
-          socketDown: comfyBackendSocketDown,
+          socketDown: comfyBackendIsDown(),
           outcomes: outcome?.outcomes,
         });
         if (fallback.defs) {
@@ -15505,6 +15566,10 @@ const GRAPH_TOOL_EXECUTORS = {
       ...(activeMaybeStale
         ? { active_possibly_stale: true, stale_hint: activeStaleHint() }
         : {}),
+      // #1325 — canvas binding ("bound") is not backend readiness. A sticky
+      // reconnect flag after a long render used to leave mutations refused
+      // while this list still reported a healthy bound tab.
+      ...backendSocketReplyFields(active),
     };
   },
 
@@ -16843,6 +16908,10 @@ const GRAPH_TOOL_EXECUTORS = {
       opened: { path: target.path, filename: target.filename },
       routing_key: targetRoutingKeyAtReply,
       ...openActiveBinding,
+      // #1325 — `panel_set_workflow_target({mode:"current"})` lands here and
+      // used to report bound/already_current while mutations stayed refused.
+      // Canvas identity and backend socket are different facts.
+      ...backendSocketReplyFields(target),
       ...(activeWorkflowUuid ? { workflow_uuid: activeWorkflowUuid } : {}),
       // #1001 — present only when the repaint was NOT byte-identical: the node set and
       // every value came through, and the frontend rewrote its own geometry. Disclosed
@@ -21370,7 +21439,7 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
               if (graphCommandMayMutateWorkflow(msg.cmd)) {
                 const reconnectGate = graphMutationReconnectGate({
                   cmd: msg.cmd,
-                  backendDown: comfyBackendSocketDown,
+                  backendDown: comfyBackendIsDown(),
                   bindingSettleWindow: postReconnectBindingSettleWindow(),
                 });
                 if (reconnectGate) throw reconnectRefusalError(reconnectGate);
@@ -36643,7 +36712,7 @@ async function healStaleBundleIfNeeded() {
     // socket is down, so none can be orphaned in flight here; defer instead,
     // and UN-ARM the marker — this attempt never navigated, so the reconnect
     // that follows the backend coming back must be allowed to retry the heal.
-    if (comfyBackendSocketDown) {
+    if (comfyBackendIsDown()) {
       ssSet(BUNDLE_HEAL_KEY, null);
       console.warn(
         `[comfyui-mcp-panel] this tab is running a STALE panel bundle (running ${PANEL_VERSION}, ` +

--- a/web/js/lib/reconnect-recovery.js
+++ b/web/js/lib/reconnect-recovery.js
@@ -139,6 +139,90 @@ function brandGateRefusal(refusal) {
   return refusal;
 }
 
+/** ComfyUI's WebSocket OPEN readyState. Inlined so Node tests need no DOM WebSocket. */
+export const WS_OPEN = 1;
+
+/**
+ * #1325 — is the backend socket actually down RIGHT NOW?
+ *
+ * The sticky `comfyBackendSocketDown` flag is necessary: ComfyUI announces a drop
+ * as events, and a mutation in that gap is the #646 applied-then-wiped hazard.
+ * It is not sufficient. ComfyUI also dispatches `status` with a null payload from
+ * `_pollQueue` whenever `GET /prompt` fails, and that poller — once started —
+ * runs for the life of the tab. A long GPU-bound render (Wan 2.2 dual-pass)
+ * blocks the backend event loop, the poll fails, the flag arms, and `reconnected`
+ * never fires again because the websocket never left OPEN. Graph reads keep
+ * working (they read the local canvas); mutations stay refused forever.
+ *
+ * The live readyState is the fact a restore-is-incoming decision can rest on:
+ * OPEN means no canvas rebuild is in flight. Flagged-down + OPEN is a stale or
+ * busy-poll signal, not a down socket.
+ *
+ * An omitted/unknown readyState + flaggedDown still refuses — fail closed when
+ * we cannot see the socket, which is the #646 direction.
+ */
+export function backendSocketIsDown({ flaggedDown = false, socketReadyState } = {}) {
+  if (flaggedDown !== true) return false;
+  if (socketReadyState === WS_OPEN) return false;
+  return true;
+}
+
+/**
+ * #1325 — classify a ComfyUI `status` event for the mutation-guard flag.
+ *
+ *   - "alive"  — a real queue/status payload; the backend is talking
+ *   - "lost"   — null payload AND the socket is not OPEN (the close-handler signal)
+ *   - "ignore" — null payload while the socket is still OPEN (busy `/prompt` poll)
+ */
+export function classifyBackendStatusEvent({ detail, socketReadyState } = {}) {
+  if (detail != null && typeof detail === "object") return "alive";
+  if (detail == null) {
+    return socketReadyState === WS_OPEN ? "ignore" : "lost";
+  }
+  return "ignore";
+}
+
+const BACKEND_SOCKET_DOWN_NOTE =
+  "ComfyUI's backend connection is down (a restart or reconnect is in progress). " +
+  "The canvas is still readable from local state, but graph mutations are refused " +
+  "until the backend reconnects. Wait a few seconds and retry; if it never comes " +
+  "back, reload the ComfyUI page or restart ComfyUI.";
+
+/**
+ * #1325 — binding-status view of the backend socket.
+ *
+ * Canvas binding ("bound") is a different question (who owns this graph). A
+ * reply that reports only `bound`/`already_current` while mutations are gated
+ * is the #1325 misread: the agent retries the wrong recovery. When the socket
+ * is down, `graph_binding` is "reconnecting" and `canvas_binding` still names
+ * the canvas identity so the two facts stay distinguishable.
+ */
+export function describeGraphMutationReadiness({
+  flaggedDown = false,
+  socketReadyState,
+  canvasBinding,
+} = {}) {
+  const down = backendSocketIsDown({ flaggedDown, socketReadyState });
+  const canvas =
+    canvasBinding === "bound" || canvasBinding === "foreign" || canvasBinding === "unknown"
+      ? canvasBinding
+      : null;
+  if (down) {
+    return {
+      backend_socket: "reconnecting",
+      mutations_ready: false,
+      graph_binding: "reconnecting",
+      ...(canvas ? { canvas_binding: canvas } : {}),
+      backend_socket_note: BACKEND_SOCKET_DOWN_NOTE,
+    };
+  }
+  return {
+    backend_socket: "up",
+    mutations_ready: true,
+    ...(canvas ? { canvas_binding: canvas, graph_binding: canvas } : {}),
+  };
+}
+
 export function graphMutationReconnectGate({ cmd, backendDown = false, bindingSettleWindow = false } = {}) {
   const name = typeof cmd === "string" && cmd ? `"${cmd}"` : "this graph command";
   /** Every refusal from this gate shares these — see the docblock. */


### PR DESCRIPTION
## Summary

After a long Wan render, graph **reads** still worked from the open canvas but every **mutation** stayed refused with `[backend-reconnecting]`. `panel_set_workflow_target({mode:"current"})` still reported a healthy bound tab, so the agent retried the wrong recovery.

ComfyUI dispatches `status` with a null payload from two places: the websocket `close` handler (a real drop) and `_pollQueue` whenever `GET /prompt` fails. A GPU-bound Wan pass blocks the backend event loop, the poll fails, the sticky `comfyBackendSocketDown` flag arms, and `reconnected` never fires again because the websocket never left OPEN.

The mutation gate now consults the **live** socket readyState: flagged-down + OPEN is a busy poll, not a restore-is-incoming window. A real queue/status payload or a live execution frame (`execution_start` / `success` / `executed` / `progress`) also clears a stale flag. Binding-status replies (`workflow_list`, `workflow_open`, `graph_outline`) publish `backend_socket` / `mutations_ready` / `graph_binding` so a readable bound canvas is no longer reported as ready to mutate when the backend is actually down.

Fixes #1325

## Test plan

- [x] `backendSocketIsDown`: flagged + OPEN is not down; flagged + CLOSED/unknown fails closed
- [x] `classifyBackendStatusEvent`: real payload is alive; null + OPEN is a busy poll; null + not OPEN is lost
- [x] `describeGraphMutationReadiness`: down reports `graph_binding: reconnecting` while `canvas_binding` stays `bound`
- [x] shipped gate path: sticky flag + OPEN socket does not refuse `graph_set_widget`
- [x] wiring scans: status classifies before arming; execution frames call `noteComfyBackendAlive`; list/open/outline publish backend readiness; both gate sites use `comfyBackendIsDown()`
- [x] existing `#646` / `#663` / `#1529` reconnect-recovery suite, `#1223` object-info snapshot, `#654` session-rebind, `#584` bundle-heal, `#757` set-widget extract (276 tests)
