### PR TITLE
fix(1328): auto-layout apply stays inside the viewed subgraph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project are documented here. This project adheres to
 ## [Unreleased]
 
 ### Fixed
+- `panel_auto_layout` apply inside a subgraph no longer escapes to and rearranges the root graph (#1328)
 - `panel_get_errors` no longer keeps load-time missing-node-type errors after a ComfyUI restart that registered those classes — leftover placeholders are reported as needing a save+reopen, not as still-uninstalled types (#1332)
 - agent-directed instruction blocks (LIVE-CANVAS TOOLS, MANUAL CANVAS CHANGES, query-graph budget accounting) stay in the agent's context and no longer render in the user's chat (#1310)
 - graph mutations no longer stay stuck in `[backend-reconnecting]` after a long Wan render: a busy `/prompt` poll is not a down socket, and binding status now distinguishes a readable canvas from a backend that is actually reconnecting (#1325)

--- a/browser_tests/unit/auto-layout-scope.test.mjs
+++ b/browser_tests/unit/auto-layout-scope.test.mjs
@@ -1,0 +1,268 @@
+// #1328 — auto-layout apply must not silently fall through to the root graph
+// when the user was viewing a subgraph. These drive the SAME helpers the
+// shipped graph_auto_layout bind uses.
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+import {
+  SUBGRAPH_INPUT_RAIL_ID,
+  SUBGRAPH_OUTPUT_RAIL_ID,
+} from "../../web/js/lib/subgraph-scope.js";
+import {
+  interiorNodeCount,
+  layoutScopeFingerprint,
+  viewingOf,
+  rememberAutoLayoutScope,
+  clearAutoLayoutScope,
+  peekAutoLayoutScope,
+  resolveSubgraphForLayout,
+  resolveAutoLayoutTarget,
+  bindAutoLayoutGraph,
+} from "../../web/js/lib/auto-layout-scope.js";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const PANEL_JS = join(HERE, "../../web/js/comfyui-mcp-panel.js");
+
+function node(id, extra = {}) {
+  return { id, pos: extra.pos ?? [id * 10, 0], size: [200, 100], ...extra };
+}
+
+function makeSubgraph({ name = "inner", nodes = [node(1), node(2), node(3)] } = {}) {
+  const sub = {
+    name,
+    _nodes: nodes,
+    inputNode: { id: SUBGRAPH_INPUT_RAIL_ID },
+    outputNode: { id: SUBGRAPH_OUTPUT_RAIL_ID },
+    beforeChange() {},
+    afterChange() {},
+    setDirtyCanvas() {},
+  };
+  return sub;
+}
+
+function makeRoot(sub, { ownerId = 121, extraRoot = [node(64), node(65)] } = {}) {
+  const owner = { id: ownerId, title: "Pack", subgraph: sub };
+  const root = { _nodes: [...extraRoot, owner] };
+  return { root, owner };
+}
+
+test.beforeEach(() => {
+  clearAutoLayoutScope();
+});
+
+test("interiorNodeCount skips the subgraph rails", () => {
+  const sub = makeSubgraph({
+    nodes: [
+      node(1),
+      node(2),
+      { id: SUBGRAPH_INPUT_RAIL_ID },
+      { id: SUBGRAPH_OUTPUT_RAIL_ID },
+    ],
+  });
+  assert.equal(interiorNodeCount(sub), 2);
+});
+
+test("layoutScopeFingerprint names a live subgraph by its owner node", () => {
+  const sub = makeSubgraph();
+  const { root } = makeRoot(sub);
+  const fp = layoutScopeFingerprint(sub, root);
+  assert.equal(fp.scope, "subgraph");
+  assert.equal(fp.owner_node_id, 121);
+  assert.equal(fp.node_count, 3);
+  assert.equal(fp.graph, sub);
+  assert.deepEqual(viewingOf(fp), {
+    scope: "subgraph",
+    owner_node_id: 121,
+    title: "Pack",
+  });
+});
+
+test("layoutScopeFingerprint reports root when the canvas graph IS the root", () => {
+  const { root } = makeRoot(makeSubgraph());
+  const fp = layoutScopeFingerprint(root, root);
+  assert.equal(fp.scope, "root");
+  assert.equal(fp.owner_node_id, null);
+  assert.deepEqual(viewingOf(fp), { scope: "root" });
+});
+
+test("dry_run on a subgraph remembers it; apply after an escape retargets there", () => {
+  const sub = makeSubgraph();
+  const { root } = makeRoot(sub);
+  const dry = resolveAutoLayoutTarget({
+    liveGraph: sub,
+    liveRoot: root,
+    captured: null,
+    apply: false,
+  });
+  assert.equal(dry.graph, sub);
+  assert.equal(dry.viewing.scope, "subgraph");
+  assert.equal(dry.captured.owner_node_id, 121);
+
+  const applied = resolveAutoLayoutTarget({
+    liveGraph: root,
+    liveRoot: root,
+    captured: dry.captured,
+    apply: true,
+  });
+  assert.equal(applied.error, undefined);
+  assert.equal(applied.graph, sub, "apply must write the subgraph, not the escaped root");
+  assert.equal(applied.retargeted, true);
+  assert.equal(applied.viewing.owner_node_id, 121);
+});
+
+test("apply fail-closes when the escaped subgraph's interior count no longer matches", () => {
+  const sub = makeSubgraph();
+  const { root } = makeRoot(sub);
+  const captured = layoutScopeFingerprint(sub, root);
+  sub._nodes.push(node(99));
+  const applied = resolveAutoLayoutTarget({
+    liveGraph: root,
+    liveRoot: root,
+    captured,
+    apply: true,
+  });
+  assert.match(applied.error, /panel_auto_layout apply refused/);
+  assert.match(applied.error, /Nothing was moved/);
+  assert.match(applied.error, /panel_enter_subgraph/);
+  assert.equal(applied.graph, undefined);
+});
+
+test("apply fail-closes when the remembered subgraph is unreachable from the live root", () => {
+  const sub = makeSubgraph();
+  const captured = layoutScopeFingerprint(sub, makeRoot(sub).root);
+  const otherRoot = { _nodes: [node(64), node(65)] };
+  const applied = resolveAutoLayoutTarget({
+    liveGraph: otherRoot,
+    liveRoot: otherRoot,
+    captured,
+    apply: true,
+  });
+  assert.match(applied.error, /no longer reachable/);
+  assert.match(applied.error, /Nothing was moved/);
+});
+
+test("apply on a live subgraph with no captured identity uses that subgraph", () => {
+  const sub = makeSubgraph();
+  const { root } = makeRoot(sub);
+  const applied = resolveAutoLayoutTarget({
+    liveGraph: sub,
+    liveRoot: root,
+    captured: null,
+    apply: true,
+  });
+  assert.equal(applied.graph, sub);
+  assert.equal(applied.retargeted, false);
+});
+
+test("apply on root with no captured subgraph still layouts the root", () => {
+  const { root } = makeRoot(makeSubgraph());
+  const applied = resolveAutoLayoutTarget({
+    liveGraph: root,
+    liveRoot: root,
+    captured: null,
+    apply: true,
+  });
+  assert.equal(applied.graph, root);
+  assert.equal(applied.retargeted, false);
+  assert.deepEqual(applied.viewing, { scope: "root" });
+});
+
+test("apply fail-closes when the live subgraph owner is a different instance", () => {
+  const subA = makeSubgraph({ name: "A" });
+  const subB = makeSubgraph({ name: "B" });
+  const { root } = makeRoot(subA, { ownerId: 121 });
+  root._nodes.push({ id: 200, title: "Other", subgraph: subB });
+  const captured = layoutScopeFingerprint(subA, root);
+  const applied = resolveAutoLayoutTarget({
+    liveGraph: subB,
+    liveRoot: root,
+    captured,
+    apply: true,
+  });
+  assert.match(applied.error, /owner node 121/);
+  assert.match(applied.error, /owner node 200/);
+});
+
+test("bindAutoLayoutGraph walks the canvas back onto a retargeted subgraph", () => {
+  const sub = makeSubgraph();
+  const { root } = makeRoot(sub);
+  let current = sub;
+  const canvas = {
+    get graph() {
+      return current;
+    },
+    setGraph(g) {
+      current = g;
+    },
+    setDirty() {},
+  };
+  bindAutoLayoutGraph({ graph: sub, rootGraph: root, canvas }, { apply: false });
+  assert.equal(peekAutoLayoutScope()?.owner_node_id, 121);
+
+  const bound = bindAutoLayoutGraph({ graph: root, rootGraph: root, canvas }, { apply: true });
+  assert.equal(bound.graph, sub);
+  assert.equal(bound.retargeted, true);
+  assert.equal(current, sub, "canvas must follow the retarget so move_rail stays in-scope");
+});
+
+test("a root-scoped dry_run drops the remembered subgraph so a later root apply is allowed", () => {
+  const sub = makeSubgraph();
+  const { root } = makeRoot(sub);
+  rememberAutoLayoutScope(layoutScopeFingerprint(sub, root));
+  bindAutoLayoutGraph({ graph: root, rootGraph: root, canvas: {} }, { apply: false });
+  assert.equal(peekAutoLayoutScope(), null);
+  const bound = bindAutoLayoutGraph({ graph: root, rootGraph: root, canvas: {} }, { apply: true });
+  assert.equal(bound.graph, root);
+});
+
+test("resolveSubgraphForLayout finds the subgraph by owner id when the graph ref is stale", () => {
+  const sub = makeSubgraph();
+  const { root } = makeRoot(sub);
+  const captured = {
+    scope: "subgraph",
+    owner_node_id: 121,
+    node_count: 3,
+    graph: { name: "ghost" },
+  };
+  assert.equal(resolveSubgraphForLayout(root, captured), sub);
+});
+
+test("#1328 the shipping auto-layout executor binds scope BEFORE it writes", () => {
+  const src = readFileSync(PANEL_JS, "utf8");
+  const start = src.indexOf("graph_auto_layout({");
+  assert.notEqual(start, -1, "graph_auto_layout must exist");
+  const bodyStart = src.indexOf("{", start);
+  const next = src.indexOf("\n  graph_canvas(", start);
+  const body = src.slice(bodyStart, next);
+  const bindAt = body.indexOf("bindAutoLayoutGraph(ctx, { apply: !dry_run })");
+  const writeAt = body.indexOf("graph.beforeChange()");
+  assert.notEqual(bindAt, -1, "apply must go through bindAutoLayoutGraph");
+  assert.notEqual(writeAt, -1, "apply still wraps writes in one undo step");
+  assert.ok(bindAt < writeAt, "the scope bind must happen before any position write");
+});
+
+test("#1328 getGraphCtx remembers a live subgraph and exit drops it at root", () => {
+  const src = readFileSync(PANEL_JS, "utf8");
+  assert.match(
+    src,
+    /rememberAutoLayoutScope\(layoutScopeFingerprint\(graph, app\.graph\)\)/,
+    "getGraphCtx must capture subgraph identity after enter_subgraph",
+  );
+  const exit = src.slice(src.indexOf("async graph_exit_subgraph()"));
+  const clearAt = exit.indexOf("clearAutoLayoutScope()");
+  const parentAt = exit.indexOf("parentGraph === rootGraph");
+  assert.notEqual(clearAt, -1, "exit must drop the captured identity");
+  assert.ok(parentAt >= 0 && parentAt < clearAt, "only a return to ROOT clears it");
+});
+
+test("#1328 dry_run does not schedule the structural auto-fit", () => {
+  const src = readFileSync(PANEL_JS, "utf8");
+  assert.match(
+    src,
+    /AUTOFIT_CMDS\.has\(cmd\) && msg\?\.dry_run !== true/,
+    "a preview must not fire the post-command fit that can displace the canvas",
+  );
+});

--- a/browser_tests/unit/auto-layout-subgraph.test.mjs
+++ b/browser_tests/unit/auto-layout-subgraph.test.mjs
@@ -1,0 +1,212 @@
+// #1328 — the SHIPPED graph_auto_layout must not mutate the root graph when the
+// canvas escapes a subgraph between dry_run and apply. These extract the real
+// executor from the panel source and drive it against LiteGraph-shaped doubles.
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import { computeLayout } from "../../web/js/lib/layout-engine.js";
+import {
+  boundsAroundNodes,
+  groupMemberNodes,
+  refreshNodeArea,
+  syncGraphNodeAreas,
+} from "../../web/js/lib/group-geometry.js";
+import {
+  SUBGRAPH_INPUT_RAIL_ID,
+  SUBGRAPH_OUTPUT_RAIL_ID,
+} from "../../web/js/lib/subgraph-scope.js";
+import {
+  bindAutoLayoutGraph,
+  clearAutoLayoutScope,
+} from "../../web/js/lib/auto-layout-scope.js";
+
+const panelPath = fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url));
+const panelSrc = readFileSync(panelPath, "utf8");
+
+const grab = (re, what) => {
+  const m = panelSrc.match(re);
+  assert.ok(m, `could not locate ${what} in panel source`);
+  return m[0];
+};
+
+const autoLayoutSrc = grab(
+  / {2}graph_auto_layout\(\{[\s\S]*?\n {2}\},/,
+  "graph_auto_layout",
+);
+const setGroupBoundsSrc = grab(
+  /\nfunction setGroupBounds\(group, \[x, y, w, h\]\) \{[\s\S]*?\n\}/,
+  "setGroupBounds",
+);
+
+function posOf(n) {
+  return [n.pos[0], n.pos[1]];
+}
+
+function node(id, pos = [id * 40, id * 15]) {
+  return {
+    id,
+    type: "CLIPTextEncode",
+    pos: [...pos],
+    size: [200, 80],
+    flags: {},
+  };
+}
+
+function attachGraphApi(graph) {
+  graph.getNodeById = (id) => (graph._nodes ?? []).find((n) => n.id === Number(id)) ?? null;
+  graph.links = graph.links ?? {};
+  graph._groups = graph._groups ?? [];
+  graph.beforeChange = graph.beforeChange ?? (() => {});
+  graph.afterChange = graph.afterChange ?? (() => {});
+  graph.setDirtyCanvas = graph.setDirtyCanvas ?? (() => {});
+  return graph;
+}
+
+function fixture() {
+  const inner = [node(1, [10, 10]), node(2, [20, 80]), node(3, [30, 160])];
+  const sub = attachGraphApi({
+    name: "inner",
+    _nodes: inner,
+    inputNode: { id: SUBGRAPH_INPUT_RAIL_ID, pos: [0, 0] },
+    outputNode: { id: SUBGRAPH_OUTPUT_RAIL_ID, pos: [400, 0] },
+  });
+  const rootNodes = [node(64, [100, 100]), node(65, [400, 100]), node(66, [700, 100])];
+  const owner = { id: 121, type: "SubgraphNode", title: "Pack", pos: [1000, 100], size: [200, 120], flags: {}, subgraph: sub };
+  const root = attachGraphApi({ _nodes: [...rootNodes, owner] });
+  let canvasGraph = sub;
+  const canvas = {
+    get graph() {
+      return canvasGraph;
+    },
+    setGraph(g) {
+      canvasGraph = g;
+    },
+    setDirty() {},
+  };
+  return { inner, sub, root, owner, rootNodes, canvas };
+}
+
+function resolveNode(graph, id) {
+  const n = graph.getNodeById(id);
+  if (!n) throw new Error(`No node with id ${id} in the current graph`);
+  return n;
+}
+
+function realAutoLayout(getGraphCtx) {
+  return new Function(
+    "getGraphCtx",
+    "bindAutoLayoutGraph",
+    "syncGraphNodeAreas",
+    "SUBGRAPH_INPUT_RAIL_ID",
+    "SUBGRAPH_OUTPUT_RAIL_ID",
+    "resolveNode",
+    "groupMemberNodes",
+    "computeLayout",
+    "boundsAroundNodes",
+    "refreshNodeArea",
+    `"use strict";
+     ${setGroupBoundsSrc}
+     const executors = { ${autoLayoutSrc} };
+     return executors.graph_auto_layout;`,
+  )(
+    getGraphCtx,
+    bindAutoLayoutGraph,
+    syncGraphNodeAreas,
+    SUBGRAPH_INPUT_RAIL_ID,
+    SUBGRAPH_OUTPUT_RAIL_ID,
+    resolveNode,
+    groupMemberNodes,
+    computeLayout,
+    boundsAroundNodes,
+    refreshNodeArea,
+  );
+}
+
+test.beforeEach(() => {
+  clearAutoLayoutScope();
+});
+
+test("#1328 dry_run and apply both target the subgraph; an escaped canvas does not move root nodes", () => {
+  const { inner, sub, root, owner, rootNodes, canvas } = fixture();
+  const rootBefore = new Map(root._nodes.map((n) => [n.id, posOf(n)]));
+  const innerBefore = new Map(inner.map((n) => [n.id, posOf(n)]));
+
+  let viewing = sub;
+  const layout = realAutoLayout(() => ({
+    graph: viewing,
+    rootGraph: root,
+    canvas,
+  }));
+
+  const dry = layout({ mode: "flow_horizontal", groups: "ignore", dry_run: true });
+  assert.equal(dry.applied, false);
+  assert.equal(dry.viewing.scope, "subgraph");
+  assert.equal(dry.viewing.owner_node_id, 121);
+  assert.equal(dry.moved.length, 3);
+  assert.deepEqual(
+    dry.moved.map((m) => m.node_id).sort((a, b) => a - b),
+    [1, 2, 3],
+  );
+  for (const n of inner) assert.deepEqual(posOf(n), innerBefore.get(n.id), "dry_run must not move inner nodes");
+  for (const n of root._nodes) assert.deepEqual(posOf(n), rootBefore.get(n.id), "dry_run must not move root nodes");
+
+  // The reported bug: the canvas has escaped to root by the time apply runs.
+  viewing = root;
+  const applied = layout({ mode: "flow_horizontal", groups: "ignore", dry_run: false });
+  assert.equal(applied.applied, true);
+  assert.equal(applied.viewing.scope, "subgraph");
+  assert.equal(applied.viewing.owner_node_id, 121);
+  assert.deepEqual(
+    applied.moved.map((m) => m.node_id).sort((a, b) => a - b),
+    [1, 2, 3],
+    "apply must return inner ids, not the root set that includes owner 121",
+  );
+  for (const n of rootNodes) {
+    assert.deepEqual(posOf(n), rootBefore.get(n.id), `root node ${n.id} must stay put`);
+  }
+  assert.deepEqual(posOf(owner), rootBefore.get(owner.id), "the subgraph owner node on root must stay put");
+  const innerMoved = inner.some((n) => JSON.stringify(posOf(n)) !== JSON.stringify(innerBefore.get(n.id)));
+  assert.equal(innerMoved, true, "inner nodes must actually be rearranged");
+  assert.equal(canvas.graph, sub, "apply must walk the canvas back into the subgraph");
+});
+
+test("#1328 apply without a prior subgraph capture still layouts a live subgraph", () => {
+  const { inner, sub, root, canvas } = fixture();
+  const layout = realAutoLayout(() => ({ graph: sub, rootGraph: root, canvas }));
+  const applied = layout({ mode: "flow_horizontal", groups: "ignore" });
+  assert.equal(applied.applied, true);
+  assert.equal(applied.viewing.scope, "subgraph");
+  assert.equal(applied.moved.length, inner.length);
+});
+
+test("#1328 a root-only apply with no captured subgraph still rearranges the root", () => {
+  const { root, canvas } = fixture();
+  const before = new Map(root._nodes.map((n) => [n.id, posOf(n)]));
+  const layout = realAutoLayout(() => ({ graph: root, rootGraph: root, canvas }));
+  const applied = layout({ mode: "flow_horizontal", groups: "ignore" });
+  assert.equal(applied.applied, true);
+  assert.deepEqual(applied.viewing, { scope: "root" });
+  assert.ok(applied.moved.some((m) => m.node_id === 121), "root layout includes the subgraph owner node");
+  const moved = root._nodes.some((n) => JSON.stringify(posOf(n)) !== JSON.stringify(before.get(n.id)));
+  assert.equal(moved, true);
+});
+
+test("#1328 apply refuses rather than writing root when the subgraph node count drifted", () => {
+  const { inner, sub, root, rootNodes, canvas } = fixture();
+  const originals = inner.slice();
+  const rootBefore = new Map(root._nodes.map((n) => [n.id, posOf(n)]));
+  const innerBefore = new Map(originals.map((n) => [n.id, posOf(n)]));
+  let viewing = sub;
+  const layout = realAutoLayout(() => ({ graph: viewing, rootGraph: root, canvas }));
+  layout({ mode: "flow_horizontal", groups: "ignore", dry_run: true });
+  sub._nodes.push(node(99, [50, 50]));
+  viewing = root;
+  assert.throws(
+    () => layout({ mode: "flow_horizontal", groups: "ignore" }),
+    /Nothing was moved/,
+  );
+  for (const n of rootNodes) assert.deepEqual(posOf(n), rootBefore.get(n.id));
+  for (const n of originals) assert.deepEqual(posOf(n), innerBefore.get(n.id));
+});

--- a/browser_tests/unit/canvas-graph-divergence.test.mjs
+++ b/browser_tests/unit/canvas-graph-divergence.test.mjs
@@ -53,6 +53,10 @@ import {
   SUBGRAPH_OUTPUT_RAIL_ID,
 } from "../../web/js/lib/subgraph-scope.js";
 import {
+  rememberAutoLayoutScope,
+  layoutScopeFingerprint,
+} from "../../web/js/lib/auto-layout-scope.js";
+import {
   graphBindingRefusalMessage,
   graphCommandBindingBar,
   graphCommandMayMutateWorkflow,
@@ -103,8 +107,10 @@ function buildGetGraphCtx(app) {
     "app",
     "window",
     "resolveScope",
+    "rememberAutoLayoutScope",
+    "layoutScopeFingerprint",
     `${source}\nreturn getGraphCtx;`,
-  )(app, { LiteGraph: {} }, resolveScope);
+  )(app, { LiteGraph: {} }, resolveScope, rememberAutoLayoutScope, layoutScopeFingerprint);
 }
 
 function nodes(n, offset = 0) {

--- a/browser_tests/unit/canvas-navigation.test.mjs
+++ b/browser_tests/unit/canvas-navigation.test.mjs
@@ -440,6 +440,9 @@ function buildExitSubgraph(doubles) {
     "describeActiveGraph",
     "assertGraphBoundToActiveWorkflow",
     "coerceMessageText",
+    "clearAutoLayoutScope",
+    "rememberAutoLayoutScope",
+    "layoutScopeFingerprint",
     `return (${body});`,
   );
   return factory(
@@ -449,6 +452,9 @@ function buildExitSubgraph(doubles) {
     doubles.describeActiveGraph,
     doubles.assertGraphBoundToActiveWorkflow,
     doubles.coerceMessageText ?? ((v) => String(v)),
+    doubles.clearAutoLayoutScope ?? (() => {}),
+    doubles.rememberAutoLayoutScope ?? (() => {}),
+    doubles.layoutScopeFingerprint ?? (() => ({ scope: "root" })),
   );
 }
 

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -289,6 +289,12 @@ import {
   resolveRunToNodeTarget,
   unsafeBypassMappings,
 } from "./lib/subgraph-scope.js";
+import {
+  bindAutoLayoutGraph,
+  rememberAutoLayoutScope,
+  clearAutoLayoutScope,
+  layoutScopeFingerprint,
+} from "./lib/auto-layout-scope.js";
 import { runSetWidget } from "./lib/set-widget.js";
 import { declaredInputNames, runRemoveWidget } from "./lib/remove-widget.js";
 import {
@@ -7443,6 +7449,12 @@ function getGraphCtx() {
   if (!graph) {
     throw new Error("ComfyUI graph is not available (app.graph / LiteGraph missing)");
   }
+  // #1328 — remember a live subgraph identity here so an auto-layout APPLY that
+  // later sees a canvas escaped to root can still resolve the graph enter_subgraph
+  // put the user in. Root observations do NOT clear this: escape looks like root.
+  if (scope.scope === "subgraph") {
+    rememberAutoLayoutScope(layoutScopeFingerprint(graph, app.graph));
+  }
   return { app, graph, rootGraph: app.graph, canvas: app.canvas, LG };
 }
 
@@ -14119,7 +14131,10 @@ const GRAPH_TOOL_EXECUTORS = {
     groups = "preserve",
     dry_run = false,
   } = {}) {
-    const { graph } = getGraphCtx();
+    const ctx = getGraphCtx();
+    // #1328 — resolve against the captured viewing-scope identity, not a canvas
+    // that the mutation dispatch/preflight may have walked back to root.
+    const { graph, viewing } = bindAutoLayoutGraph(ctx, { apply: !dry_run });
     // #429: resync live rects before deriving group membership for clustering, so a
     // non-panel move can't cluster the wrong nodes (or drop members) during layout.
     syncGraphNodeAreas(graph);
@@ -14266,6 +14281,7 @@ const GRAPH_TOOL_EXECUTORS = {
         node_count: moved.length,
         columns: layout.columns,
         moved,
+        viewing,
         ...(groupResults.length ? { groups: groupResults } : {}),
         ...(layout.skipped.length ? { skipped: layout.skipped } : {}),
       };
@@ -14301,6 +14317,7 @@ const GRAPH_TOOL_EXECUTORS = {
       node_count: moved.length,
       columns: layout.columns,
       moved,
+      viewing,
       ...(groupResults.length ? { groups: groupResults } : {}),
       ...(layout.skipped.length ? { skipped: layout.skipped } : {}),
     };
@@ -19330,6 +19347,11 @@ const GRAPH_TOOL_EXECUTORS = {
           `subgraph, retry, or leave it on the ComfyUI canvas (its breadcrumb, or double-click out).`,
       );
     }
+    // #1328 — an explicit exit is the one root observation that MAY drop the
+    // captured subgraph identity. Escape (canvas jumped to root without this
+    // call) must keep it so auto-layout apply can still find the subgraph.
+    if (parentGraph === rootGraph) clearAutoLayoutScope();
+    else rememberAutoLayoutScope(layoutScopeFingerprint(parentGraph, rootGraph));
     let viewing = null;
     try {
       viewing = describeActiveGraph(getGraphCtx().graph);
@@ -31489,7 +31511,7 @@ function buildPanel() {
       // debounced fit so the view still settles.
       if (reply.ok) {
         const followed = focusFollowOnCommand(cmd, msg, reply);
-        if (!followed && AUTOFIT_CMDS.has(cmd)) scheduleAutoFit();
+        if (!followed && AUTOFIT_CMDS.has(cmd) && msg?.dry_run !== true) scheduleAutoFit();
       }
       // The agent restarted ComfyUI — arm the auto-resume so we reconnect and
       // nudge it to continue once ComfyUI is back (install→restart→continue).

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -7452,8 +7452,15 @@ function getGraphCtx() {
   // #1328 — remember a live subgraph identity here so an auto-layout APPLY that
   // later sees a canvas escaped to root can still resolve the graph enter_subgraph
   // put the user in. Root observations do NOT clear this: escape looks like root.
+  // Capture is a SIDE-EFFECT of a proven subgraph scope: a helper miss must not
+  // refuse the graph the user is looking at. bindAutoLayoutGraph still sees the
+  // live subgraph on apply if remember does not land.
   if (scope.scope === "subgraph") {
-    rememberAutoLayoutScope(layoutScopeFingerprint(graph, app.graph));
+    try {
+      rememberAutoLayoutScope(layoutScopeFingerprint(graph, app.graph));
+    } catch {
+      // Viewing scope is already proven; do not turn a capture miss into a refusal.
+    }
   }
   return { app, graph, rootGraph: app.graph, canvas: app.canvas, LG };
 }

--- a/web/js/lib/auto-layout-scope.js
+++ b/web/js/lib/auto-layout-scope.js
@@ -1,0 +1,190 @@
+// #1328 — auto-layout apply must target the graph the user was viewing, not
+// whatever canvas.graph happens to point at after the mutation dispatch /
+// preflight. dry_run already reads the live subgraph; apply used to re-resolve
+// from a canvas that had escaped to root and then rearrange the root.
+//
+// The remembered identity is captured when the canvas is OBSERVED inside a
+// subgraph (enter / a subgraph-scoped dry_run / getGraphCtx) and is only
+// discarded on an explicit return to root (exit, or a root-scoped dry_run).
+// An apply whose live canvas is root then re-resolves that identity from the
+// live root and writes THERE — or refuses, if the owner / interior node count
+// no longer match. It never silently falls through to the root graph.
+
+import {
+  SUBGRAPH_INPUT_RAIL_ID,
+  SUBGRAPH_OUTPUT_RAIL_ID,
+  findSubgraphOwner,
+  findNodeInScopes,
+  isSubgraphInRoot,
+} from "./subgraph-scope.js";
+
+let remembered = null;
+
+/** Interior nodes only — rails are not laid out and must not inflate the count. */
+export function interiorNodeCount(graph) {
+  return (graph?._nodes ?? []).filter(
+    (n) => n && n.id !== SUBGRAPH_INPUT_RAIL_ID && n.id !== SUBGRAPH_OUTPUT_RAIL_ID,
+  ).length;
+}
+
+export function layoutScopeFingerprint(graph, rootGraph) {
+  const node_count = interiorNodeCount(graph);
+  if (!rootGraph || !graph || graph === rootGraph) {
+    return { scope: "root", owner_node_id: null, node_count, title: null, graph };
+  }
+  const owner = findSubgraphOwner(rootGraph, graph);
+  if (owner) {
+    return {
+      scope: "subgraph",
+      owner_node_id: owner.id ?? null,
+      node_count,
+      title: owner.title ?? graph?.name ?? "subgraph",
+      graph,
+    };
+  }
+  if (isSubgraphInRoot(rootGraph, graph)) {
+    return {
+      scope: "subgraph",
+      owner_node_id: null,
+      node_count,
+      title: graph?.name ?? "subgraph",
+      graph,
+    };
+  }
+  return { scope: "root", owner_node_id: null, node_count, title: null, graph };
+}
+
+export function viewingOf(fp) {
+  if (!fp || fp.scope !== "subgraph") return { scope: "root" };
+  return {
+    scope: "subgraph",
+    owner_node_id: fp.owner_node_id ?? null,
+    title: fp.title ?? "subgraph",
+  };
+}
+
+export function rememberAutoLayoutScope(fp) {
+  if (fp && fp.scope === "subgraph") remembered = fp;
+  return remembered;
+}
+
+export function clearAutoLayoutScope() {
+  remembered = null;
+}
+
+export function peekAutoLayoutScope() {
+  return remembered;
+}
+
+/** Find the subgraph object a captured fingerprint names on the LIVE root. */
+export function resolveSubgraphForLayout(rootGraph, captured) {
+  if (!captured || captured.scope !== "subgraph" || !rootGraph) return null;
+  if (captured.graph && findSubgraphOwner(rootGraph, captured.graph)) return captured.graph;
+  if (captured.graph && isSubgraphInRoot(rootGraph, captured.graph)) return captured.graph;
+  if (captured.owner_node_id == null) return null;
+  const hit = findNodeInScopes(rootGraph, captured.owner_node_id, rootGraph);
+  return hit?.node?.subgraph ?? null;
+}
+
+function ownerMismatch(captured, live) {
+  return (
+    captured?.owner_node_id != null &&
+    live?.owner_node_id != null &&
+    captured.owner_node_id !== live.owner_node_id
+  );
+}
+
+function mismatchError(captured, live) {
+  const intended =
+    captured?.scope === "subgraph"
+      ? `subgraph owner node ${captured.owner_node_id ?? "unknown"} (${captured.node_count} inner node(s))`
+      : `the root graph (${captured?.node_count ?? "unknown"} node(s))`;
+  const found =
+    live?.scope === "subgraph"
+      ? `subgraph owner node ${live.owner_node_id ?? "unknown"} (${live.node_count} inner node(s))`
+      : `the root graph (${live?.node_count ?? "unknown"} node(s))`;
+  return (
+    `panel_auto_layout apply refused: the intended layout target was ${intended}, but the ` +
+    `graph selected at apply time is ${found}. Nothing was moved. Re-enter the subgraph ` +
+    `(panel_enter_subgraph) if that is still where you mean to work, then retry.`
+  );
+}
+
+function escapedUnreachableError(captured) {
+  return (
+    `panel_auto_layout apply refused: the canvas is at the root graph, but the last viewing ` +
+    `scope was subgraph owner node ${captured.owner_node_id ?? "unknown"} ` +
+    `(${captured.node_count} inner node(s)), which is no longer reachable from the live root. ` +
+    `Nothing was moved. Re-enter the subgraph (panel_enter_subgraph) and retry.`
+  );
+}
+
+/**
+ * Pick the graph auto-layout may read or write.
+ *
+ * dry_run (`apply: false`) uses the live canvas and, when that canvas is a
+ * subgraph, remembers its identity.
+ *
+ * apply uses the live subgraph when the canvas is still inside one (failing
+ * closed on an owner change). If the canvas has escaped to root, it re-resolves
+ * the remembered subgraph from the live root and returns that graph — or
+ * refuses when the owner / interior node count no longer match. It never
+ * returns the root graph while a subgraph identity is still outstanding.
+ */
+export function resolveAutoLayoutTarget({ liveGraph, liveRoot, captured, apply } = {}) {
+  const live = layoutScopeFingerprint(liveGraph, liveRoot);
+  if (!apply) {
+    return {
+      graph: liveGraph,
+      viewing: viewingOf(live),
+      captured: live.scope === "subgraph" ? live : null,
+      retargeted: false,
+    };
+  }
+  if (live.scope === "subgraph") {
+    if (captured?.scope === "subgraph" && ownerMismatch(captured, live)) {
+      return { error: mismatchError(captured, live) };
+    }
+    return { graph: liveGraph, viewing: viewingOf(live), captured: live, retargeted: false };
+  }
+  if (captured?.scope === "subgraph") {
+    const sub = resolveSubgraphForLayout(liveRoot, captured);
+    if (!sub) return { error: escapedUnreachableError(captured) };
+    const now = layoutScopeFingerprint(sub, liveRoot);
+    if (now.node_count !== captured.node_count || ownerMismatch(captured, now)) {
+      return { error: mismatchError(captured, now) };
+    }
+    return { graph: sub, viewing: viewingOf(now), captured: now, retargeted: true };
+  }
+  return { graph: liveGraph, viewing: viewingOf(live), captured: null, retargeted: false };
+}
+
+/**
+ * The production bind: remember a live subgraph, resolve the apply target,
+ * and walk the canvas back onto a retargeted subgraph so follow-up tools
+ * (move_rail) stay in the same scope.
+ */
+export function bindAutoLayoutGraph(ctx, { apply } = {}) {
+  const liveGraph = ctx?.graph ?? null;
+  const liveRoot = ctx?.rootGraph ?? liveGraph;
+  const liveFp = layoutScopeFingerprint(liveGraph, liveRoot);
+  if (liveFp.scope === "subgraph") rememberAutoLayoutScope(liveFp);
+  const target = resolveAutoLayoutTarget({
+    liveGraph,
+    liveRoot,
+    captured: peekAutoLayoutScope(),
+    apply: !!apply,
+  });
+  if (target.error) throw new Error(target.error);
+  if (target.retargeted && typeof ctx?.canvas?.setGraph === "function") {
+    try {
+      ctx.canvas.setGraph(target.graph);
+      ctx.canvas.setDirty?.(true, true);
+    } catch {
+      // The write still goes to the subgraph object; only the view failed to follow.
+    }
+  }
+  if (target.captured?.scope === "subgraph") rememberAutoLayoutScope(target.captured);
+  else if (!apply && liveFp.scope === "root") clearAutoLayoutScope();
+  return target;
+}


### PR DESCRIPTION
## Summary

`panel_auto_layout` dry_run inside a subgraph correctly targeted the inner nodes, but the immediately following apply arranged the **root** graph and left the canvas at root (`panel_move_rail` then refused). The mutation path re-resolved from mutable canvas scope after dispatch/preflight; the dry-run/read path did not.

Apply now carries the viewing-scope identity captured after `panel_enter_subgraph` (and after a subgraph-scoped dry_run). If the canvas has escaped to root, it re-resolves that subgraph from the live root and writes **there**, walking the view back in. If the owner or interior node count no longer match, it fails closed — nothing is moved.

Fixes #1328

## Test plan

- [x] Pure `auto-layout-scope` helpers:
  - dry_run on subgraph + apply after canvas escape retargets the subgraph
  - owner / node-count mismatch refuses with nothing moved
  - unreachable remembered subgraph refuses
  - live subgraph with no capture still layouts that subgraph
  - root-only apply with no capture still layouts the root
  - root-scoped dry_run drops the capture so a later root apply is allowed
  - bind walks `canvas.setGraph` back onto the retargeted subgraph
- [x] Extracted shipped `graph_auto_layout` against LiteGraph-shaped doubles:
  - dry_run and apply both return the inner ids; root positions stay put
  - apply without a prior capture still layouts a live subgraph
  - a root-only apply still rearranges the root (includes the subgraph owner node)
  - drifted inner node count refuses rather than writing root
- [x] Source pins: bind before `beforeChange`; `getGraphCtx` remembers a live subgraph; exit-to-root clears; dry_run does not schedule auto-fit
- [x] Existing canvas-navigation / reconnect-staleness / layout-engine suites still pass
