### PR TITLE
fix(1320): surface the Manager update traceback in panel_update_node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project are documented here. This project adheres to
 
 ### Fixed
 - graph mutations no longer stay stuck in `[backend-reconnecting]` after a long Wan render: a busy `/prompt` poll is not a down socket, and binding status now distinguishes a readable canvas from a backend that is actually reconnecting (#1325)
+- panel_update_node surfaces the Manager update traceback instead of hiding it behind a generic "check the server log" error (#1320)
 - dictation listens for the spoken language when the panel UI is the English catalog floor — a German (or other unshipped) speaker no longer gets an English recognizer (#1329)
 - panel_set_widget can author an LTXDirector timeline from the serialized widgets when the live timeline editor is not initialized (#1308)
 - live-sync no longer reports notified unless the active canvas actually holds the saved workflow (#1299)

--- a/browser_tests/unit/manager-dialect.test.mjs
+++ b/browser_tests/unit/manager-dialect.test.mjs
@@ -21,6 +21,7 @@ const {
   legacyUpdateBody,
   assertBatchOk,
   classifyUpdateOutcome,
+  taskFailureReason,
 } = ManagerInstall;
 
 const UNREACHABLE = "ComfyUI-Manager not reachable (is the built-in Manager enabled?)";
@@ -609,6 +610,11 @@ function graphUpdateDeps(overrides) {
       status: QUEUE_STATUS,
     }),
     classifyUpdateOutcome,
+    // #1320 — finalizeUpdate reads the log only on a generic Manager failure.
+    // Dialect tests stub waitForUpdateResult to a success, so these stay quiet.
+    isGenericManagerUpdateError: () => false,
+    readUpdateTraceback: async () => null,
+    taskFailureReason,
     ...overrides,
   };
 }

--- a/browser_tests/unit/manager-update-traceback.test.mjs
+++ b/browser_tests/unit/manager-update-traceback.test.mjs
@@ -1,0 +1,389 @@
+// panel#1320 — panel_update_node hid the Manager update traceback behind
+//
+//   Update of "seedvr2_videoupscaler" FAILED: ... An error occurred while
+//   updating 'seedvr2_videoupscaler'.. The pack was NOT updated — check the
+//   ComfyUI server log for the full traceback.
+//
+// Manager's do_update (glob/manager_server.py) RETURNS that one-liner as the
+// task result and prints the real evidence only to the server log:
+//
+//   * ManagedResult failure logs
+//     ERROR: An error occurred while updating 'X'. (res.result=..., res.action=...)
+//   * Exception path calls traceback.print_exc() and does not even log the
+//     generic sentence.
+//
+// These tests pin the extractor against those two wire shapes, then drive the
+// SHIPPED graph_update_node so a missing bind (the helper existing but never
+// called) fails here instead of in the browser.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import {
+  classifyUpdateOutcome,
+  taskFailureReason,
+  isMethodNotAllowed,
+  isManagerUnreachable,
+  isManagerRouteMissing,
+  dialectRetryTarget,
+  assertBatchOk,
+  legacyUpdateBody,
+} from "../../web/js/lib/manager-install.js";
+import {
+  extractUpdateTraceback,
+  isGenericManagerUpdateError,
+  readUpdateTraceback,
+  UPDATE_TRACEBACK_MAX_LINES,
+  UPDATE_TRACEBACK_LINE_CAP,
+} from "../../web/js/lib/manager-update-traceback.js";
+
+const PACK = "seedvr2_videoupscaler";
+const GENERIC = `An error occurred while updating '${PACK}'.`;
+
+const ESC = String.fromCharCode(27);
+
+// Verbatim shapes from ComfyUI-Manager's do_update. The KeyError is what the
+// exception arm prints when cnr_map does not have the pack (the line after
+// unified_update that reads cnr_map[node_name]); the res.action line is what
+// the ManagedResult arm logs.
+const EXCEPTION_TB = [
+  "Traceback (most recent call last):",
+  `  File "C:\\Users\\Artokun\\ComfyUI\\custom_nodes\\ComfyUI-Manager\\glob\\manager_server.py", line 1234, in do_update`,
+  "    url = core.unified_manager.cnr_map[node_name].get('repository')",
+  "          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^",
+  `KeyError: '${PACK}'`,
+].join("\n");
+
+const DETAILED_ERROR =
+  `ERROR: An error occurred while updating '${PACK}'. (res.result=False, res.action=update-git)`;
+
+const GIT_TB = [
+  "Traceback (most recent call last):",
+  `  File "C:\\Users\\Artokun\\ComfyUI\\custom_nodes\\ComfyUI-Manager\\glob\\manager_core.py", line 2100, in repo_update`,
+  "    remote.fetch()",
+  "git.exc.GitCommandError: Cmd('git') failed due to: exit code(128)",
+  "  cmdline: git fetch",
+  "  stderr: 'error: Your local changes to the following files would be overwritten by merge'",
+].join("\n");
+
+const GENERIC_ITEM = {
+  ui_id: "u-1320",
+  client_id: "comfyui-mcp-panel",
+  kind: "update",
+  result: GENERIC,
+  status: { status_str: "error", completed: true, messages: [GENERIC] },
+  params: { node_name: PACK },
+};
+
+function readPanelSource() {
+  return readFileSync(
+    fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url)),
+    "utf8",
+  );
+}
+
+function pick(src, re, name) {
+  const m = src.match(re);
+  assert.ok(m, `could not locate ${name} in panel source`);
+  return m[0];
+}
+
+// ---------------------------------------------------------------------------
+// Pure extractor
+// ---------------------------------------------------------------------------
+
+test("#1320 the generic Manager sentence is recognised, and only that sentence", () => {
+  assert.equal(isGenericManagerUpdateError(GENERIC), true);
+  assert.equal(
+    isGenericManagerUpdateError("the Manager reported the task as failed (no detail provided)"),
+    true,
+  );
+  assert.equal(
+    isGenericManagerUpdateError("Exception: 'InstallPackParams' object has no attribute 'node_name'"),
+    false,
+  );
+  assert.equal(isGenericManagerUpdateError(null), false);
+  assert.equal(isGenericManagerUpdateError(""), false);
+});
+
+test("#1320 extract: exception-arm traceback (no generic ERROR line in the log)", () => {
+  // The exception arm print_exc()s and returns the generic sentence without
+  // logging it. The traceback naming the pack / do_update is the whole record.
+  const got = extractUpdateTraceback(EXCEPTION_TB, PACK);
+  assert.match(got, /KeyError: 'seedvr2_videoupscaler'/);
+  assert.match(got, /do_update/);
+  assert.doesNotMatch(got, /check the ComfyUI server log/);
+});
+
+test("#1320 extract: ManagedResult arm keeps the res.action line", () => {
+  // No traceback — the one extra fact Manager DID write is res.action.
+  const got = extractUpdateTraceback(DETAILED_ERROR, PACK);
+  assert.match(got, /res\.action=update-git/);
+  assert.match(got, /seedvr2_videoupscaler/);
+});
+
+test("#1320 extract: traceback immediately above the generic ERROR is kept WITH the ERROR", () => {
+  const log = `${GIT_TB}\n${DETAILED_ERROR}`;
+  const got = extractUpdateTraceback(log, PACK);
+  assert.match(got, /GitCommandError/);
+  assert.match(got, /overwritten by merge/);
+  assert.match(got, /res\.action=update-git/);
+});
+
+test("#1320 extract: colour codes do not defeat the match, or leak into the result", () => {
+  const coloured =
+    `${ESC}[31m[ERROR]${ESC}[0m ${DETAILED_ERROR}`;
+  const got = extractUpdateTraceback(coloured, PACK);
+  assert.match(got, /res\.action=update-git/);
+  assert.ok(!got.includes(ESC), "an escape byte must never reach the reader");
+});
+
+test("#1320 extract: another pack's failure is NEVER attributed to this update", () => {
+  const other = [
+    "Traceback (most recent call last):",
+    "  File \"manager_server.py\", line 1, in do_update",
+    "KeyError: 'somebody-else'",
+    "ERROR: An error occurred while updating 'somebody-else'. (res.result=False, res.action=update-git)",
+  ].join("\n");
+  assert.equal(extractUpdateTraceback(other, PACK), null);
+  // A prefix of this pack's name is not this pack.
+  assert.equal(extractUpdateTraceback(EXCEPTION_TB, "seed"), null);
+});
+
+test("#1320 extract: the LAST matching failure wins", () => {
+  const log = [
+    "Traceback (most recent call last):",
+    "  File \"manager_server.py\", line 1, in do_update",
+    "PermissionError: first attempt",
+    `ERROR: An error occurred while updating '${PACK}'. (res.result=False, res.action=update-git)`,
+    "Traceback (most recent call last):",
+    "  File \"manager_server.py\", line 1, in do_update",
+    "OSError: retry",
+    `ERROR: An error occurred while updating '${PACK}'. (res.result=False, res.action=update-cnr)`,
+  ].join("\n");
+  const got = extractUpdateTraceback(log, PACK);
+  assert.match(got, /OSError: retry/);
+  assert.match(got, /res\.action=update-cnr/);
+  assert.doesNotMatch(got, /PermissionError/);
+});
+
+test("#1320 extract: junk / empty / missing pack is not a verdict", () => {
+  assert.equal(extractUpdateTraceback("", PACK), null);
+  assert.equal(extractUpdateTraceback("unrelated info log\n", PACK), null);
+  assert.equal(extractUpdateTraceback(EXCEPTION_TB, ""), null);
+  assert.equal(extractUpdateTraceback(null, PACK), null);
+  assert.equal(extractUpdateTraceback(EXCEPTION_TB, null), null);
+});
+
+test("#1320 extract: a long traceback is capped, and the cap is disclosed", () => {
+  const lines = ["Traceback (most recent call last):"];
+  for (let i = 0; i < UPDATE_TRACEBACK_MAX_LINES + 10; i++) {
+    lines.push(`  File "x.py", line ${i}, in do_update`);
+  }
+  lines.push(`KeyError: '${PACK}'`);
+  const got = extractUpdateTraceback(lines.join("\n"), PACK);
+  assert.match(got, /truncated to last/);
+  assert.match(got, new RegExp(`KeyError: '${PACK}'`));
+  assert.ok(got.split(/\n/).length <= UPDATE_TRACEBACK_MAX_LINES + 2);
+});
+
+test("#1320 extract: a huge traceback LINE is capped", () => {
+  const huge = "x".repeat(UPDATE_TRACEBACK_LINE_CAP + 80);
+  const log = [
+    "Traceback (most recent call last):",
+    `  File "manager_server.py", line 1, in do_update`,
+    `KeyError: '${PACK}' ${huge}`,
+  ].join("\n");
+  const got = extractUpdateTraceback(log, PACK);
+  assert.ok(got.includes("…"));
+  assert.ok(!got.includes(huge));
+});
+
+test("#1320 readUpdateTraceback uses fileURL, not /api, and never throws", async () => {
+  const calls = [];
+  const realFetch = globalThis.fetch;
+  const api = { fileURL: (r) => `/base${r}` };
+  try {
+    globalThis.fetch = async (url) => {
+      calls.push(String(url));
+      return { ok: true, json: async () => ({ entries: [{ m: EXCEPTION_TB }] }) };
+    };
+    const got = await readUpdateTraceback(PACK, api);
+    assert.match(got, /KeyError: 'seedvr2_videoupscaler'/);
+    assert.deepEqual(calls, ["/base/internal/logs/raw"], "fileURL is honoured, /api is not");
+    assert.ok(!calls[0].includes("/api/"), "the /api prefix is what 404s");
+
+    globalThis.fetch = async () => ({ ok: false, status: 404 });
+    assert.equal(await readUpdateTraceback(PACK, api), null);
+    globalThis.fetch = async () => {
+      throw new Error("offline");
+    };
+    assert.equal(await readUpdateTraceback(PACK, api), null);
+  } finally {
+    globalThis.fetch = realFetch;
+  }
+  assert.equal(await readUpdateTraceback(PACK, undefined), null);
+});
+
+// ---------------------------------------------------------------------------
+// classifyUpdateOutcome — the message the tool actually throws
+// ---------------------------------------------------------------------------
+
+test("#1320 classifyUpdateOutcome attaches the traceback and drops the 'check the log' pointer", () => {
+  const outcome = classifyUpdateOutcome({
+    item: GENERIC_ITEM,
+    target: PACK,
+    dialect: "v2",
+    traceback: EXCEPTION_TB,
+  });
+  assert.equal(outcome.state, "failed");
+  assert.match(outcome.message, /FAILED/);
+  assert.match(outcome.message, /KeyError: 'seedvr2_videoupscaler'/);
+  assert.match(outcome.message, /Manager traceback/);
+  assert.doesNotMatch(outcome.message, /check the ComfyUI server log for the full traceback/);
+});
+
+test("#1320 classifyUpdateOutcome without a traceback still points at the log", () => {
+  // Honest miss: we looked, the log did not yield one. The existing #364
+  // wording stays so a specific Manager exception (already in `reason`) is
+  // unchanged when no extra traceback is supplied.
+  const outcome = classifyUpdateOutcome({
+    item: GENERIC_ITEM,
+    target: PACK,
+    dialect: "v2",
+  });
+  assert.equal(outcome.state, "failed");
+  assert.match(outcome.message, /check the ComfyUI server log for the full traceback/);
+  assert.doesNotMatch(outcome.message, /Manager traceback/);
+});
+
+// ---------------------------------------------------------------------------
+// SHIPPED PATH — the real graph_update_node, extracted
+// ---------------------------------------------------------------------------
+
+function buildGraphUpdateNode(deps) {
+  const src = readPanelSource();
+  const methodSrc = pick(
+    src,
+    /async graph_update_node\(\{ id, version, channel, mode \}\) \{[\s\S]*?\n  \},\r?\n/,
+    "graph_update_node",
+  );
+  const factory = new Function(
+    ...Object.keys(deps),
+    `const handlers = { ${methodSrc} };\nreturn handlers.graph_update_node;`,
+  );
+  return factory(...Object.values(deps));
+}
+
+test("#1320 graph_update_node CALLS readUpdateTraceback on a generic Manager failure", () => {
+  // Without this the helper is dead code: a source-only test of the extractor
+  // would pass just as happily with finalizeUpdate never reading the log.
+  const method = pick(
+    readPanelSource(),
+    /async graph_update_node\(\{ id, version, channel, mode \}\) \{[\s\S]*?\n  \},\r?\n/,
+    "graph_update_node",
+  );
+  assert.match(method, /readUpdateTraceback/);
+  assert.match(method, /isGenericManagerUpdateError/);
+  assert.match(method, /traceback/);
+});
+
+test("#1320 shipped graph_update_node surfaces the traceback, not a pointer to the log", async () => {
+  let readFor = null;
+  const update = buildGraphUpdateNode({
+    detectManagerDialect: async () => "v2",
+    crypto: { randomUUID: () => "u-1320" },
+    api: { clientId: "c-1" },
+    legacyUpdateBody,
+    managerCall: async () => {
+      throw new Error("legacy should not run");
+    },
+    managerV2: async () => ({}),
+    isMethodNotAllowed,
+    assertBatchOk,
+    isManagerUnreachable,
+    isManagerRouteMissing,
+    dialectRetryTarget,
+    noteManagerDialectDowngrade: () => {},
+    reProbeManagerDialect: async () => "v2",
+    waitForUpdateResult: async () => ({
+      item: GENERIC_ITEM,
+      status: { total_count: 0, done_count: 1, in_progress_count: 0, is_processing: false },
+    }),
+    classifyUpdateOutcome,
+    taskFailureReason,
+    isGenericManagerUpdateError,
+    readUpdateTraceback: async (packId) => {
+      readFor = packId;
+      return extractUpdateTraceback(`${EXCEPTION_TB}\n${DETAILED_ERROR}`, packId);
+    },
+  });
+
+  await assert.rejects(
+    () => update({ id: PACK, version: "nightly" }),
+    (err) => {
+      assert.match(err.message, /FAILED/);
+      assert.match(err.message, /KeyError: 'seedvr2_videoupscaler'/);
+      assert.match(err.message, /do_update/);
+      assert.match(err.message, /res\.action=update-git/);
+      assert.doesNotMatch(
+        err.message,
+        /check the ComfyUI server log for the full traceback/,
+        "the tool result is the traceback, not a pointer to it",
+      );
+      return true;
+    },
+  );
+  assert.equal(readFor, PACK, "the log read is for the pack we asked to update");
+});
+
+test("#1320 shipped graph_update_node does NOT read the log for a specific Manager exception", async () => {
+  // The #364 AttributeError is already in status.messages. Fetching the log
+  // would only add latency; the reason is already the traceback.
+  let reads = 0;
+  const specific = {
+    ...GENERIC_ITEM,
+    status: {
+      status_str: "error",
+      completed: true,
+      messages: ["Exception: 'InstallPackParams' object has no attribute 'node_name'"],
+    },
+  };
+  const update = buildGraphUpdateNode({
+    detectManagerDialect: async () => "v2",
+    crypto: { randomUUID: () => "u-364" },
+    api: { clientId: "c-1" },
+    legacyUpdateBody,
+    managerCall: async () => {
+      throw new Error("legacy should not run");
+    },
+    managerV2: async () => ({}),
+    isMethodNotAllowed,
+    assertBatchOk,
+    isManagerUnreachable,
+    isManagerRouteMissing,
+    dialectRetryTarget,
+    noteManagerDialectDowngrade: () => {},
+    reProbeManagerDialect: async () => "v2",
+    waitForUpdateResult: async () => ({ item: specific, status: { is_processing: false } }),
+    classifyUpdateOutcome,
+    taskFailureReason,
+    isGenericManagerUpdateError,
+    readUpdateTraceback: async () => {
+      reads += 1;
+      return "SHOULD NOT BE ATTACHED";
+    },
+  });
+
+  await assert.rejects(
+    () => update({ id: "ComfyUI-GGUF" }),
+    (err) => {
+      assert.match(err.message, /no attribute 'node_name'/);
+      assert.doesNotMatch(err.message, /SHOULD NOT BE ATTACHED/);
+      return true;
+    },
+  );
+  assert.equal(reads, 0, "a specific Manager exception does not pay for a log read");
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -224,6 +224,7 @@ import {
   verifyExternalLinks,
 } from "./lib/unpack-link-verify.js";
 import { readSaveFailureCause } from "./lib/userdata-failure-cause.js";
+import { isGenericManagerUpdateError, readUpdateTraceback } from "./lib/manager-update-traceback.js";
 import { describeScreenshotFraming } from "./lib/screenshot-framing.js";
 import { readActiveSidebarTab, shouldDetachPanelRoot, findSidebarTabButton } from "./lib/active-sidebar-tab.js";
 import { buildPanelFailureShell } from "./lib/panel-failure-shell.js";
@@ -19735,7 +19736,16 @@ const GRAPH_TOOL_EXECUTORS = {
         };
       }
       const { item, status } = await waitForUpdateResult(ui_id);
-      const outcome = classifyUpdateOutcome({ item, status, target: id, dialect });
+      // #1320 — Manager's do_update records only "An error occurred while
+      // updating 'X'." and prints the real traceback to the server log. When
+      // the stored reason is that generic sentence, fetch the log and attach
+      // the traceback so the tool result is the evidence, not a pointer to it.
+      let traceback;
+      const failReason = taskFailureReason(item);
+      if (isGenericManagerUpdateError(failReason)) {
+        traceback = await readUpdateTraceback(id, api);
+      }
+      const outcome = classifyUpdateOutcome({ item, status, target: id, dialect, traceback });
       if (outcome.state === "failed") throw new Error(outcome.message);
       if (outcome.state === "updated") {
         return {

--- a/web/js/lib/manager-install.js
+++ b/web/js/lib/manager-install.js
@@ -1407,11 +1407,16 @@ export function taskHistoryBlindNote(dialect) {
  *   3. "unverified"— no terminal task record yet (still running, history not
  *                    served by a legacy Manager, or a shape we don't recognize).
  *                    Honest "queued, could not confirm" — NEVER a failure.
- * @param {{ item?:unknown, status?:unknown, target:string, dialect?:string }} input
+ * @param {{ item?:unknown, status?:unknown, target:string, dialect?:string, traceback?:string }} input
  */
-export function classifyUpdateOutcome({ item, status, target, dialect } = {}) {
+export function classifyUpdateOutcome({ item, status, target, dialect, traceback } = {}) {
   const reason = taskFailureReason(item);
   if (reason) {
+    // #1320 — Manager's do_update stores only "An error occurred while updating
+    // 'X'." and prints the real traceback to the server log. When the caller
+    // managed to read that log, the tool result IS the traceback; do not also
+    // send the reader to the log they can no longer see from here.
+    const tb = typeof traceback === "string" && traceback.trim() ? traceback.trim() : "";
     return {
       state: "failed",
       status,
@@ -1419,8 +1424,10 @@ export function classifyUpdateOutcome({ item, status, target, dialect } = {}) {
         `Update of "${target}" FAILED: the ComfyUI-Manager task terminated with an ` +
         `error` +
         (dialect ? ` (dialect ${dialect})` : "") +
-        `: ${reason}. The pack was NOT updated — check the ComfyUI server log for the ` +
-        `full traceback.`,
+        `: ${reason}. The pack was NOT updated` +
+        (tb
+          ? `. Manager traceback:\n${tb}`
+          : ` — check the ComfyUI server log for the full traceback.`),
     };
   }
   if (taskSucceeded(item)) {

--- a/web/js/lib/manager-update-traceback.js
+++ b/web/js/lib/manager-update-traceback.js
@@ -1,0 +1,195 @@
+import { readComfyLogText } from "./comfy-log.js";
+
+/**
+ * #1320 — `panel_update_node` hid the Manager update traceback behind a
+ * generic sentence.
+ *
+ * ComfyUI-Manager's `do_update` (glob/manager_server.py) has two failure
+ * arms, and BOTH return the same one-liner as the task result:
+ *
+ *     "An error occurred while updating '<pack>'."
+ *
+ * The real evidence is written only to the server log:
+ *
+ *   * ManagedResult failure (`res.result` is false) logs
+ *     `ERROR: An error occurred while updating 'X'. (res.result=..., res.action=...)`
+ *     — the action is the one extra fact the HTTP history never carries.
+ *   * Exception path calls `traceback.print_exc()` and does not even log the
+ *     generic sentence. The traceback is the whole record.
+ *
+ * The task-history helpers in manager-install.js correctly surface whatever
+ * the Manager stored. That store is the generic sentence. This module reads
+ * `/internal/logs/raw` (same transport as #771/#775) and pulls out the
+ * traceback / detailed ERROR line so the tool result is the evidence, not a
+ * pointer to the log.
+ *
+ * Never throws. A miss is `null` / `""`, which the caller reports as "we
+ * could not find a traceback" rather than inventing a cause.
+ */
+
+// Built from the code point, never written as a literal escape. Same reason
+// as pack-import-failures.js / userdata-failure-cause.js: a raw 0x1B in the
+// source is invisible in a diff and one mangling edit away from matching
+// nothing.
+const ANSI = new RegExp(String.fromCharCode(27) + "\\[[0-9;]*m", "g");
+
+const GENERIC_UPDATE = /An error occurred while updating\s+'([^']+)'/i;
+
+/** Caps so a noisy log cannot overflow the tool result. Fixed; no parameter
+ *  raises them. The full traceback remains in the ComfyUI server console. */
+export const UPDATE_TRACEBACK_MAX_LINES = 40;
+export const UPDATE_TRACEBACK_LINE_CAP = 500;
+
+/**
+ * Is this the one-liner Manager stores as the task result — i.e. the case
+ * where the real evidence is only in the server log?
+ */
+export function isGenericManagerUpdateError(reason) {
+  if (typeof reason !== "string" || !reason) return false;
+  if (GENERIC_UPDATE.test(reason)) return true;
+  return /reported the task as failed \(no detail provided\)/i.test(reason);
+}
+
+function stripAnsi(line) {
+  return typeof line === "string" ? line.replace(ANSI, "") : "";
+}
+
+function samePack(captured, packId) {
+  return captured.toLowerCase() === packId.toLowerCase();
+}
+
+function isTracebackStart(line) {
+  return /Traceback \(most recent call last\):/.test(line);
+}
+
+/** A line that continues a Python traceback (indented frames, chained-exception
+ *  markers, or the `SomeError: message` terminator). Deliberately does NOT
+ *  match Manager's `ERROR: An error occurred while updating ...` log line —
+ *  that is a logging level, not a Python exception type (`Error` vs `ERROR`). */
+function isTracebackContinuation(line) {
+  const s = stripAnsi(line);
+  if (!s.trim()) return true;
+  if (/^\s/.test(s)) return true;
+  if (isTracebackStart(s)) return true;
+  if (/During handling of the above exception/.test(s)) return true;
+  if (/The above exception was the direct cause/.test(s)) return true;
+  return /^[A-Za-z_][\w.]*(Error|Exception|Exit|Warning|Interrupt):/.test(s.trim());
+}
+
+function collectTracebackAt(lines, start) {
+  if (start < 0 || start >= lines.length || !isTracebackStart(lines[start])) return null;
+  const out = [lines[start]];
+  for (let i = start + 1; i < lines.length; i++) {
+    if (!isTracebackContinuation(lines[i])) break;
+    out.push(lines[i]);
+  }
+  while (out.length && !out[out.length - 1].trim()) out.pop();
+  return out.length ? out : null;
+}
+
+function boundTraceback(text) {
+  const raw = text.split(/\r?\n/);
+  const sliced = raw.length > UPDATE_TRACEBACK_MAX_LINES ? raw.slice(-UPDATE_TRACEBACK_MAX_LINES) : raw;
+  const lines = sliced.map((l) =>
+    l.length > UPDATE_TRACEBACK_LINE_CAP ? `${l.slice(0, UPDATE_TRACEBACK_LINE_CAP)}…` : l,
+  );
+  let out = lines.join("\n").trim();
+  if (!out) return null;
+  if (raw.length > UPDATE_TRACEBACK_MAX_LINES) {
+    out = `(traceback truncated to last ${UPDATE_TRACEBACK_MAX_LINES} lines)\n${out}`;
+  }
+  return out;
+}
+
+function mentionsPack(block, packId) {
+  // Quoted (`KeyError: 'pack'`) or a path segment — a bare substring would
+  // attribute `seedvr2_videoupscaler`'s crash to a pack named `seed`.
+  const id = packId.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return new RegExp(`(?:['"\`]${id}['"\`]|[\\\\/]${id}(?:[\\\\/.'"\`]|$))`, "i").test(
+    block.join("\n"),
+  );
+}
+
+function mentionsUpdateHandler(block) {
+  return /\bdo_update\b|\bunified_update\b|\brepo_update\b/.test(block.join("\n"));
+}
+
+/**
+ * The last traceback / detailed ERROR line in `logText` that belongs to an
+ * update of `packId`.
+ *
+ * Correlation, in order:
+ *   1. The last `An error occurred while updating '<packId>'` line (Manager's
+ *      own log of this failure). Prefer the traceback immediately above it,
+ *      and always keep that line itself — it carries `res.action`.
+ *   2. Otherwise the last traceback that NAMES this pack (quoted or as a
+ *      path segment). A frame that merely says `do_update` is not enough —
+ *      that would steal a neighbour's crash.
+ *
+ * @param {string} logText raw /internal/logs feed
+ * @param {string} packId the pack we asked Manager to update
+ * @returns {string|null}
+ */
+export function extractUpdateTraceback(logText, packId) {
+  if (typeof logText !== "string" || !logText) return null;
+  if (typeof packId !== "string" || !packId) return null;
+
+  const lines = logText.split(/\r?\n/).map(stripAnsi);
+
+  let anchor = -1;
+  for (let i = 0; i < lines.length; i++) {
+    const m = GENERIC_UPDATE.exec(lines[i]);
+    if (m && samePack(m[1], packId)) anchor = i;
+  }
+
+  if (anchor >= 0) {
+    let tbStart = -1;
+    for (let i = anchor; i >= 0 && i >= anchor - 80; i--) {
+      if (isTracebackStart(lines[i])) {
+        tbStart = i;
+        break;
+      }
+    }
+    const parts = [];
+    if (tbStart >= 0) {
+      const block = collectTracebackAt(lines, tbStart);
+      // Keep a nearby traceback even if the frames do not name the pack
+      // (GitCommandError often does not). A traceback 80 lines back that
+      // names neither the pack nor do_update is somebody else's.
+      if (
+        block &&
+        (mentionsPack(block, packId) || mentionsUpdateHandler(block) || tbStart >= anchor - 15)
+      ) {
+        parts.push(block.join("\n").trimEnd());
+      }
+    }
+    const detail = lines[anchor].trim();
+    if (detail && !parts.some((p) => p.includes(detail))) parts.push(detail);
+    return boundTraceback(parts.join("\n")) ;
+  }
+
+  let last = null;
+  for (let i = 0; i < lines.length; i++) {
+    if (!isTracebackStart(lines[i])) continue;
+    const block = collectTracebackAt(lines, i);
+    // No generic ERROR line for THIS pack: only a traceback that NAMES the
+    // pack is ours. Matching any do_update frame would steal a neighbour's
+    // crash (the exception arm prints the pack in the KeyError / fail text
+    // when it has one).
+    if (block && mentionsPack(block, packId)) last = block;
+  }
+  return last ? boundTraceback(last.join("\n")) : null;
+}
+
+/**
+ * Fetch the log and pull out this pack's update traceback. Never throws.
+ *
+ * @param {string} packId
+ * @param {{ fileURL?: (route: string) => string }} api
+ * @returns {Promise<string|null>}
+ */
+export async function readUpdateTraceback(packId, api) {
+  const text = await readComfyLogText(api);
+  if (!text) return null;
+  return extractUpdateTraceback(text, packId);
+}


### PR DESCRIPTION
## Report

`panel_update_node({id:'seedvr2_videoupscaler', version:'nightly'})` failed and returned only:

```
Update of "seedvr2_videoupscaler" FAILED: the ComfyUI-Manager task terminated with an error (dialect v2): An error occurred while updating 'seedvr2_videoupscaler'.. The pack was NOT updated — check the ComfyUI server log for the full traceback.
```

The tool promised a traceback and did not include it, so the caller had to go to the server log.

## Root cause

#364 already made `panel_update_node` report a Manager task failure instead of a false success. The reason it reports is whatever ComfyUI-Manager stored on the task.

Manager's `do_update` (glob/manager_server.py) has two failure arms, and **both** store the same one-liner as the task result:

- ManagedResult failure (`res.result` is false) logs `ERROR: An error occurred while updating 'X'. (res.result=..., res.action=...)` and returns `"An error occurred while updating 'X'."`
- Exception path calls `traceback.print_exc()` and returns the same one-liner — the traceback never enters the history record.

The panel was faithfully forwarding that store, then pointing at the log.

## Fix

On a generic Manager update failure, `graph_update_node` reads `/internal/logs/raw` (same transport as #771/#775) and attaches the traceback — or the `res.action` ERROR line when there is no traceback — to the thrown error. A specific Manager exception (the #364 `AttributeError`) is left alone; that reason already is the traceback.

Another pack's crash is not attributed to this update. A miss still points at the log.

Fixes #1320

## Test plan

```
node --test browser_tests/unit/manager-update-traceback.test.mjs \
  browser_tests/unit/manager-update-verify.test.mjs \
  browser_tests/unit/manager-dialect.test.mjs
```

61/61 pass, including the shipped `graph_update_node`:

- exception-arm traceback (`KeyError: 'seedvr2_videoupscaler'` / `do_update`) is attached
- ManagedResult `res.action=update-git` line is kept
- the "check the ComfyUI server log for the full traceback" pointer is dropped when the traceback is present
- another pack's `do_update` crash is not attributed to this update
- a specific Manager exception does not pay for a log read
