### PR TITLE
fix(1331): leftover link-driven widgets are not graph drift after reconnect

### DIFF
--- a/browser_tests/unit/run-scope-guard.test.mjs
+++ b/browser_tests/unit/run-scope-guard.test.mjs
@@ -473,6 +473,205 @@ test("#1273 promptContentHash: an untouched UE graph stamps EQUAL to its dispatc
   );
 });
 
+// ---------------------------------------------------------------------------
+// #1331 — the FOURTH volatility mechanism: after reconnect, leftover values of
+// link-driven converted widgets (MiniMax H3 clip/vae/model/length, …) settle
+// between the pre-dispatch stamp and the POST body. The #1050 single retry
+// still races because serializeValue keeps flipping those leftovers. The
+// value that EXECUTES is the incoming link; the leftover is non-semantic.
+// A PURE SOCKET (connected input, no matching widget / no convert-to-input
+// marker) stays hashed — a KSampler.model rewire is still drift.
+// ---------------------------------------------------------------------------
+
+const minimaxH3Node = (id, { leftover = true } = {}) => ({
+  id,
+  type: "MiniMaxH3ReferenceToVideo",
+  widgets: [
+    { name: "clip", value: leftover ? "clip_l.safetensors" : ["4", 0] },
+    { name: "vae", value: leftover ? "ae.safetensors" : ["5", 0] },
+    { name: "length", value: leftover ? 81 : ["9", 0] },
+    { name: "prompt", value: "a cat" },
+  ],
+  inputs: [
+    { name: "clip", link: 11, widget: { name: "clip" } },
+    { name: "vae", link: 12, widget: { name: "vae" } },
+    { name: "length", link: 13, widget: { name: "length" } },
+    { name: "prompt", link: null },
+  ],
+});
+
+const hooklessControl = (value = "randomize") => ({
+  name: "control_after_generate",
+  value,
+  options: {
+    serialize: false,
+    canvasOnly: true,
+    values: ["fixed", "increment", "decrement", "randomize"],
+  },
+});
+
+test("#1331 collectVolatileInputs: a link-driven converted widget is volatile, its unlinked sibling is not", () => {
+  const graph = {
+    _nodes: [
+      minimaxH3Node(1000),
+      { id: 3, widgets: [{ name: "steps", value: 20 }], inputs: [{ name: "model", link: 1 }] },
+    ],
+  };
+  const pairs = collectVolatileInputs(graph);
+  assert.ok(pairs.has("1000 clip"), "converted clip leftover is the race");
+  assert.ok(pairs.has("1000 vae"), "converted vae leftover is the race");
+  assert.ok(pairs.has("1000 length"), "converted length leftover is the race");
+  assert.ok(!pairs.has("1000 prompt"), "an UNLINKED sibling widget stays drift-covered");
+  assert.ok(!pairs.has("3 model"), "a PURE SOCKET (no matching widget, no convert marker) stays hashed");
+  assert.ok(!pairs.has("3 steps"), "an unlinked widget on another node stays covered");
+});
+
+test("#1331 collectVolatileInputs: a same-name widget + linked input (no input.widget marker) is still the leftover", () => {
+  // Older frontends omit input.widget and just keep the widget next to a
+  // same-named connected input. That is still a converted leftover.
+  const graph = {
+    _nodes: [{
+      id: 110,
+      widgets: [{ name: "clip", value: "clip_l.safetensors" }, { name: "text", value: "hi" }],
+      inputs: [{ name: "clip", link: 7 }, { name: "text", link: null }],
+    }],
+  };
+  const pairs = collectVolatileInputs(graph);
+  assert.ok(pairs.has("110 clip"));
+  assert.ok(!pairs.has("110 text"));
+});
+
+test("#1331 collectVolatileInputs: the convert-to-input marker counts even when the widget was hidden", () => {
+  // After convert, some builds drop the widget from node.widgets but leave
+  // input.widget.name. graphToPrompt can still emit a leftover under that name
+  // while the frontend settles — exclude the name, not the socket's siblings.
+  const graph = {
+    _nodes: [{
+      id: 1100,
+      widgets: [{ name: "prompt", value: "a cat" }],
+      inputs: [
+        { name: "clip", link: 1, widget: { name: "clip" } },
+        { name: "model", link: 2 },
+      ],
+    }],
+  };
+  const pairs = collectVolatileInputs(graph);
+  assert.ok(pairs.has("1100 clip"), "hidden converted widget is still the leftover");
+  assert.ok(!pairs.has("1100 model"), "a pure socket on the same node stays hashed");
+  assert.ok(!pairs.has("1100 prompt"), "an unlinked live widget stays covered");
+});
+
+test("#1331 collectVolatileInputs: the link-driven exclusion reaches nested subgraphs with the colon-path execId", () => {
+  const root = {
+    _nodes: [{ id: 10, widgets: [], subgraph: { _nodes: [minimaxH3Node(15)] } }],
+  };
+  const pairs = collectVolatileInputs(root);
+  assert.ok(pairs.has("10:15 clip"), "nested leftover pairs line up with the flattened prompt keys");
+  assert.ok(!pairs.has("10:15 prompt"));
+});
+
+test("#1331 collectVolatileInputs: an unlinked converted-shaped widget is NOT volatile — a mid-window edit is still drift", () => {
+  const graph = {
+    _nodes: [{
+      id: 1000,
+      widgets: [{ name: "clip", value: "clip_l.safetensors" }],
+      inputs: [{ name: "clip", link: null, widget: { name: "clip" } }],
+    }],
+  };
+  assert.equal(collectVolatileInputs(graph).size, 0, "no live link ⇒ the widget value is still what executes");
+});
+
+test("#1331 promptContentHash: leftover widget values stamp EQUAL to the dispatched link form — and a real edit still refuses", () => {
+  const volatileInputs = collectVolatileInputs({ _nodes: [minimaxH3Node(1000)] });
+  const stamped = {
+    "4": { class_type: "CLIPLoader", inputs: { clip_name: "clip_l.safetensors" } },
+    "1000": {
+      class_type: "MiniMaxH3ReferenceToVideo",
+      inputs: { clip: "clip_l.safetensors", vae: "ae.safetensors", length: 81, prompt: "a cat" },
+    },
+    "223": { class_type: "VHS_VideoCombine", inputs: { images: ["1000", 0] } },
+  };
+  const atHash = promptContentHash(stamped, volatileInputs);
+  const dispatched = (inputs) =>
+    JSON.stringify({
+      prompt: {
+        "4": { class_type: "CLIPLoader", inputs: { clip_name: "clip_l.safetensors" } },
+        "1000": { class_type: "MiniMaxH3ReferenceToVideo", inputs },
+        "223": { class_type: "VHS_VideoCombine", inputs: { images: ["1000", 0] } },
+      },
+    });
+  assert.equal(
+    promptContentHashFromBody(
+      dispatched({ clip: ["4", 0], vae: ["5", 0], length: ["9", 0], prompt: "a cat" }),
+      volatileInputs,
+    ),
+    atHash,
+    "the leftover→link flip is the exclusion's purpose — the scoped run is no longer refused",
+  );
+  assert.notEqual(
+    promptContentHashFromBody(
+      dispatched({ clip: ["4", 0], vae: ["5", 0], length: ["9", 0], prompt: "a dog" }),
+      volatileInputs,
+    ),
+    atHash,
+    "a mid-window edit to any OTHER input of the same node is still drift",
+  );
+  assert.equal(
+    promptContentHashFromBody(
+      dispatched({ clip: ["88", 0], vae: ["5", 0], length: ["9", 0], prompt: "a cat" }),
+      volatileInputs,
+    ),
+    atHash,
+    "a mid-window rewiring OF the excluded leftover itself is the documented residual",
+  );
+});
+
+test("#1331 collectVolatileInputs: hookless control_after_generate (reconnect) excludes the governed seed, not a sibling", () => {
+  // After reconnect the combo is present by OPTION SHAPE before beforeQueued
+  // is re-hung. The #572 hook scan finds nothing; the leftover seed still
+  // randomizes between stamp and dispatch.
+  const control = hooklessControl("randomize");
+  const seed = { name: "noise_seed", value: 111, linkedWidgets: [control] };
+  const graph = { _nodes: [{ id: 16, widgets: [seed, control, { name: "steps", value: 20 }] }] };
+  for (const w of graph._nodes[0].widgets) {
+    assert.equal(typeof w.beforeQueued, "undefined", `${w.name} carries no beforeQueued`);
+  }
+  const pairs = collectVolatileInputs(graph);
+  assert.ok(pairs.has("16 noise_seed"), "the governed seed is volatile without a hook");
+  assert.ok(pairs.has("16 control_after_generate"), "the carrier's own name is excluded too");
+  assert.ok(!pairs.has("16 steps"), "a sibling stays drift-covered");
+});
+
+test("#1331 collectVolatileInputs: a FIXED hookless control excludes nothing", () => {
+  const control = hooklessControl("fixed");
+  const seed = { name: "noise_seed", value: 111, linkedWidgets: [control] };
+  const graph = { _nodes: [{ id: 16, widgets: [seed, control] }] };
+  assert.equal(collectVolatileInputs(graph).size, 0);
+});
+
+test("#1331 promptContentHash: hookless randomize seed churn is not drift — a sibling edit still is", () => {
+  const control = hooklessControl("randomize");
+  const seed = { name: "noise_seed", value: 111, linkedWidgets: [control] };
+  const volatileInputs = collectVolatileInputs({
+    _nodes: [{ id: 16, widgets: [seed, control, { name: "steps", value: 20 }] }],
+  });
+  const atHash = promptContentHash(
+    { "16": { class_type: "RandomNoise", inputs: { noise_seed: 111, steps: 20 } } },
+    volatileInputs,
+  );
+  const body = (inputs) => JSON.stringify({ prompt: { "16": { class_type: "RandomNoise", inputs } } });
+  assert.equal(
+    promptContentHashFromBody(body({ noise_seed: 999983, steps: 20 }), volatileInputs),
+    atHash,
+    "reconnect seed churn without a re-hung hook is the exclusion's purpose",
+  );
+  assert.notEqual(
+    promptContentHashFromBody(body({ noise_seed: 999983, steps: 25 }), volatileInputs),
+    atHash,
+    "a genuine mid-window edit to a non-excluded input of the same node refuses",
+  );
+});
+
 
 test("#572 promptContentHash: the narrowed exclusion tolerates ONLY the hook's own input — a seed edit is the documented residual, an edit to any OTHER input of the same node refuses", () => {
   const control = { name: "control_after_generate", value: "randomize", beforeQueued() {} };
@@ -2291,6 +2490,161 @@ test("#1124 integration: the exclusion is ONE input — an armed rgthree Seed do
       // the refusal names the REAL change instead of the red herring the reporter
       // was handed.
       assert.doesNotMatch(result.error, /47 seed/, `${label}: the substituted seed is no longer blamed`);
+    }
+  } finally {
+    stop();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// #1331 integration — the reporter's sequence, driven through dispatchScopedRun
+// (the SAME orchestration graph_run / panel_run runs).
+//
+// After reconnect a MiniMax H3 node still has leftover clip/vae/length widget
+// values; the live inputs are already linked. The stamp serializes the leftovers;
+// the deferred POST serializes the incoming links (or later leftovers). Before
+// #1331 that pair always mismatched and the #1050 retry failed identically.
+// ---------------------------------------------------------------------------
+
+const MINIMAX_STAMP = {
+  "4": { class_type: "CLIPLoader", inputs: { clip_name: "clip_l.safetensors" } },
+  "5": { class_type: "VAELoader", inputs: { vae_name: "ae.safetensors" } },
+  "1000": {
+    class_type: "MiniMaxH3ReferenceToVideo",
+    inputs: { clip: "clip_l.safetensors", vae: "ae.safetensors", length: 81, prompt: "a cat" },
+  },
+  "223": { class_type: "VHS_VideoCombine", inputs: { images: ["1000", 0] } },
+};
+
+function makeMinimaxReconnectFrontend({ apiTarget, alsoEdit = null } = {}) {
+  const app = {
+    queueItems: [],
+    posted: [],
+    graph: { _nodes: [minimaxH3Node(1000), { id: 223, widgets: [] }] },
+    graphToPrompt: async () => ({ output: structuredClone(MINIMAX_STAMP), workflow: {} }),
+    queuePrompt: async (number, batch, arg) => {
+      const targets = Array.isArray(arg) ? arg : arg?.queueNodeIds;
+      const output = structuredClone(MINIMAX_STAMP);
+      // The reconnect race: dispatch serializes the incoming links, not the leftovers.
+      output["1000"].inputs.clip = ["4", 0];
+      output["1000"].inputs.vae = ["5", 0];
+      output["1000"].inputs.length = ["9", 0];
+      if (alsoEdit) alsoEdit(output);
+      const body = frontendBody({ output, number, targets: targets?.length ? targets : null });
+      app.posted.push(body);
+      await apiTarget.fetchApi(...promptPost(body));
+      return true;
+    },
+  };
+  return app;
+}
+
+test("#1331 integration: leftover link-driven clip/vae/length after reconnect is OUR dispatch — the scoped run reaches ComfyUI instead of racing the stamp", async () => {
+  const stop = keepAlive();
+  try {
+    const server = makeServer();
+    const apiTarget = { fetchApi: server };
+    const app = makeMinimaxReconnectFrontend({ apiTarget });
+    const ids = [];
+    const result = await dispatchScopedRun({
+      app, apiTarget, execIds: ["223"], batch: 1, toNodeId: 223,
+      verifyTimeoutMs: 500,
+      onPromptId: (p) => ids.push(p),
+    });
+    assert.equal(result.outcome, "dispatched", "the #556 graph-stamp refusal is gone");
+    assert.equal(result.verified, 1);
+    assert.deepEqual(ids, ["srv-1"]);
+    assert.equal(server.calls.length, 1, "the scoped prompt actually reached ComfyUI");
+    assert.deepEqual(JSON.parse(server.calls[0].options.body).partial_execution_targets, ["223"]);
+    assert.deepEqual(
+      result.volatileInputs,
+      ["1000 clip", "1000 length", "1000 vae"],
+      "the gap is DISCLOSED, never silent: graph_run turns this into drift_coverage",
+    );
+  } finally {
+    stop();
+  }
+});
+
+test("#1331 integration: the leftover exclusion does NOT let a real edit ride along", async () => {
+  const stop = keepAlive();
+  try {
+    for (const [label, edit] of [
+      ["an unlinked sibling widget", (o) => { o["1000"].inputs.prompt = "a dog"; }],
+      ["a pure-socket rewire elsewhere", (o) => { o["223"].inputs.images = ["5", 0]; }],
+      ["a node added", (o) => { o["77"] = { class_type: "SaveImage", inputs: {} }; }],
+    ]) {
+      const server = makeServer();
+      const apiTarget = { fetchApi: server };
+      const app = makeMinimaxReconnectFrontend({ apiTarget, alsoEdit: edit });
+      const result = await dispatchScopedRun({
+        app, apiTarget, execIds: ["223"], batch: 1, toNodeId: 223, verifyTimeoutMs: 500,
+      });
+      assert.equal(result.outcome, "refused", `${label} is still drift`);
+      assert.match(result.error, /graph CHANGED/i, label);
+      assert.equal(server.calls.length, 0, `${label}: the edited workflow never left the tab`);
+      assert.doesNotMatch(result.error, /1000 clip/, `${label}: the leftover is no longer blamed`);
+    }
+  } finally {
+    stop();
+  }
+});
+
+test("#1331 integration: hookless RandomNoise seed churn after reconnect is OUR dispatch, a sibling edit is not", async () => {
+  const stop = keepAlive();
+  try {
+    const control = hooklessControl("randomize");
+    const seed = { name: "noise_seed", value: 111, linkedWidgets: [control] };
+    const stamp = {
+      "16": { class_type: "RandomNoise", inputs: { noise_seed: 111, steps: 20 } },
+      "223": { class_type: "VHS_VideoCombine", inputs: { images: ["16", 0] } },
+    };
+    {
+      const server = makeServer();
+      const apiTarget = { fetchApi: server };
+      const app = {
+        graph: { _nodes: [{ id: 16, widgets: [seed, control, { name: "steps", value: 20 }] }] },
+        graphToPrompt: async () => ({ output: structuredClone(stamp), workflow: {} }),
+        queuePrompt: async (number, _batch, arg) => {
+          const targets = Array.isArray(arg) ? arg : arg?.queueNodeIds;
+          const output = structuredClone(stamp);
+          output["16"].inputs.noise_seed = 999983;
+          await apiTarget.fetchApi(...promptPost(frontendBody({
+            output, number, targets: targets?.length ? targets : null,
+          })));
+          return true;
+        },
+      };
+      const result = await dispatchScopedRun({
+        app, apiTarget, execIds: ["223"], batch: 1, toNodeId: 223, verifyTimeoutMs: 500,
+      });
+      assert.equal(result.outcome, "dispatched", "hookless seed churn is not a user edit");
+      assert.equal(server.calls.length, 1, "the scoped prompt reached ComfyUI");
+      assert.ok(result.volatileInputs.includes("16 noise_seed"));
+    }
+    {
+      const server = makeServer();
+      const apiTarget = { fetchApi: server };
+      const app = {
+        graph: { _nodes: [{ id: 16, widgets: [seed, control, { name: "steps", value: 20 }] }] },
+        graphToPrompt: async () => ({ output: structuredClone(stamp), workflow: {} }),
+        queuePrompt: async (number, _batch, arg) => {
+          const targets = Array.isArray(arg) ? arg : arg?.queueNodeIds;
+          const output = structuredClone(stamp);
+          output["16"].inputs.noise_seed = 999983;
+          output["16"].inputs.steps = 25;
+          await apiTarget.fetchApi(...promptPost(frontendBody({
+            output, number, targets: targets?.length ? targets : null,
+          })));
+          return true;
+        },
+      };
+      const result = await dispatchScopedRun({
+        app, apiTarget, execIds: ["223"], batch: 1, toNodeId: 223, verifyTimeoutMs: 500,
+      });
+      assert.equal(result.outcome, "refused", "a sibling edit is still drift");
+      assert.match(result.error, /16 steps/);
+      assert.equal(server.calls.length, 0);
     }
   } finally {
     stop();

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -14761,15 +14761,17 @@ const GRAPH_TOOL_EXECUTORS = {
       accept.fixed_seed_nodes = repeatingRgthreeSeeds(rgthreeSeeds);
       accept.fixed_seed_note = fixedSeedNote;
     }
-    // #572/#1124 — TRUTHFUL drift-coverage note for a scoped run: the drift hash
-    // excluded the inputs that mutate at queue time by either known mechanism —
-    // beforeQueued carriers + their linked, serialized targets (e.g. a
-    // control_after_generate seed reroll), and the seed of an ARMED rgthree Seed
-    // node, which carries no hook at all because rgthree substitutes it inside
-    // its own api.queuePrompt patch. A user edit to exactly THOSE inputs during
-    // the queue window is indistinguishable from the queue-time mutation
-    // (accepted residual), so the result names the uncovered inputs instead of
-    // implying full-graph drift proof. Every other input was covered.
+    // #572/#1124/#1331 — TRUTHFUL drift-coverage note for a scoped run: the drift
+    // hash excluded the inputs that mutate at queue time by the known
+    // mechanisms — beforeQueued carriers + their linked, serialized targets
+    // (e.g. a control_after_generate seed reroll), the seed of an ARMED
+    // rgthree Seed node (no hook: rgthree substitutes inside its own
+    // api.queuePrompt patch), leftover values of link-driven converted
+    // widgets (clip/vae/model settling after reconnect), and UE broadcast
+    // targets. A user edit to exactly THOSE inputs during the queue window
+    // is indistinguishable from the queue-time mutation (accepted residual),
+    // so the result names the uncovered inputs instead of implying full-graph
+    // drift proof. Every other input was covered.
     //
     // The note does not say WHICH mechanism excluded which input: the panel
     // knows, but the reader's question is "what was not checked", and a
@@ -14781,8 +14783,9 @@ const GRAPH_TOOL_EXECUTORS = {
         uncovered_inputs: uncovered,
         note:
           "These inputs mutate at queue time — a beforeQueued hook (e.g. a " +
-          "control_after_generate seed reroll), or an extension that rewrites the prompt in " +
-          "its own api.queuePrompt patch (an armed Seed (rgthree) node) — so they were " +
+          "control_after_generate seed reroll), an extension that rewrites the prompt in " +
+          "its own api.queuePrompt patch (an armed Seed (rgthree) node), or a leftover " +
+          "link-driven widget value settling after reconnect (clip/vae/model) — so they were " +
           "excluded from this run's graph-drift check: a user edit to exactly these inputs " +
           "during the queue window is indistinguishable from that mutation and would NOT " +
           "have been caught. Every other input was drift-covered.",

--- a/web/js/lib/run-scope-guard.js
+++ b/web/js/lib/run-scope-guard.js
@@ -11,6 +11,11 @@ import { rgthreeQueueTimeSeedInput } from "./scoped-batch-seed.js";
 // the pack (the extra.ue_links record, the io-node ids, the subgraph routing)
 // live in use-everywhere-links.js; this file imports the verdict.
 import { ueQueueTimeLinkPairs } from "./use-everywhere-links.js";
+// #1331 — after reconnect a converted widget's leftover value (clip/vae/model/…)
+// can still churn while the live input is already linked. control_after_generate
+// can also be present by OPTION SHAPE before its beforeQueued hook is re-hung.
+// Both detectors already live in their own modules; this file imports the verdict.
+import { controlAfterGenerateEntries } from "./control-after-generate.js";
 // #556 — panel_run's to_node_id ("run to node") must NEVER silently fall through
 // to a FULL-graph execution. A scoped run can fail open on two channels:
 //
@@ -82,7 +87,9 @@ import { ueQueueTimeLinkPairs } from "./use-everywhere-links.js";
 //    at queue time (beforeQueued hooks: seed widgets re-rolled by their linked
 //    control_after_generate, and the hook widgets themselves; plus prompts
 //    rewritten by an extension's own api.queuePrompt patch, which carry no hook
-//    at all — rgthree's armed Seed node, #1124), which change
+//    at all — rgthree's armed Seed node, #1124; plus leftover values of
+//    link-driven converted widgets that settle from the widget default to the
+//    incoming link after reconnect — MiniMax H3 clip/vae/model, #1331), which change
 //    between any two serializations of the SAME graph by design (#572: the
 //    exclusion must reach the hook's serialized TARGET, not just the
 //    unserialized control the hook hangs on), and (b) inputs whose value the
@@ -404,13 +411,16 @@ export function promptContentHashFromBody(bodyText, volatileInputs = null) {
 /**
  * The "execId inputName" pairs whose values MUTATE AT QUEUE TIME — after our
  * pre-dispatch stamp and before the POST body is built — collected from the live
- * root graph and every nested subgraph. THREE signals, one per mechanism: a
+ * root graph and every nested subgraph. FOUR signals, one per mechanism: a
  * widget-level `beforeQueued` hook (#572), an extension that patches
  * `api.queuePrompt` and rewrites the outgoing prompt directly (rgthree's armed
  * Seed node, #1124 — invisible to any widget scan, matched by node identity),
- * and an extension that materialises virtual links into the prompt at queue
+ * an extension that materialises virtual links into the prompt at queue
  * time (cg-use-everywhere, #1273 — matched by the pack's own `extra.ue_links`
- * record, see ueQueueTimeLinkPairs).
+ * record, see ueQueueTimeLinkPairs), and a leftover widget value whose
+ * SAME-NAMED input is already link-connected (#1331 — after reconnect the
+ * serialized form flips from the stale widget default to the incoming link,
+ * or the leftover filename itself settles, while the canvas is idle).
  * execId is the flattened prompt id: String(node.id) at root, the
  * colon-joined subgraph-instance path for nested nodes ("10:15:359") — the
  * same path buildNodeExecutionId produces, so pairs line up with the keys of
@@ -447,6 +457,32 @@ export function promptContentHashFromBody(bodyText, volatileInputs = null) {
  * run result's `drift_coverage` note so the caller knows which inputs were not
  * drift-covered for that run.
  */
+/**
+ * Widget names on `node` whose SAME-NAMED input is currently link-connected
+ * (#1331). The leftover widget value is non-semantic: execution reads the
+ * link. A connected input with no matching widget and no convert-to-input
+ * marker is a pure socket and is NOT returned — those stay drift-covered.
+ * Never throws: this runs on the stamp path.
+ */
+function linkDrivenWidgetInputNames(node) {
+  const names = new Set();
+  try {
+    const live = new Set();
+    for (const w of node?.widgets ?? []) {
+      if (w && typeof w.name === "string") live.add(w.name);
+    }
+    for (const input of node?.inputs ?? []) {
+      if (!input || input.link == null) continue;
+      const converted = typeof input.widget?.name === "string" ? input.widget.name : null;
+      if (converted) names.add(converted);
+      else if (typeof input.name === "string" && live.has(input.name)) names.add(input.name);
+    }
+  } catch {
+    /* a malformed node contributes no pairs — fail toward detecting drift */
+  }
+  return names;
+}
+
 export function collectVolatileInputs(rootGraph) {
   const pairs = new Set();
   const seen = new Set();
@@ -497,6 +533,34 @@ export function collectVolatileInputs(rootGraph) {
       // is call another extension's documented queue-time substitution a user edit.
       const rgthreeSeedInput = rgthreeQueueTimeSeedInput(node);
       if (rgthreeSeedInput != null) addPair(execId, rgthreeSeedInput);
+      // #1331 — THE FOURTH VOLATILITY SIGNAL. After a reconnect the frontend
+      // re-materialises converted widgets (clip/vae/model/length/…) while their
+      // SAME-NAMED input is already linked. graphToPrompt then serializes the
+      // leftover widget value on one pass and the incoming link (or a later
+      // leftover) on the next — 100+ `clip`/`vae`/`model` diffs on a large
+      // MiniMax H3 graph, every one of them link-driven, none of them a user
+      // edit. The #1050 single retry still races because serializeValue keeps
+      // settling those leftovers. The value that EXECUTES is the link; the
+      // leftover is non-semantic. Exclude exactly those widget names.
+      //
+      // NARROW BY CONSTRUCTION: a connected input with no matching widget and
+      // no convert-to-input marker (`input.widget`) is a PURE SOCKET and stays
+      // hashed — a rewire of KSampler.model is still drift. A converted widget
+      // (`input.widget.name`, or a live widget whose name matches a linked
+      // input) is the leftover that races.
+      for (const name of linkDrivenWidgetInputNames(node)) addPair(execId, name);
+      // #1331 (b) — after reconnect the stock control_after_generate combo
+      // can be present by OPTION SHAPE before its beforeQueued hook is
+      // re-hung. The hook scan above then finds nothing, and a randomize
+      // RandomNoise seed churns between stamp and dispatch the same way
+      // #572 already excluded when the hook WAS there. The shipped detector
+      // (controlAfterGenerateEntries) is hook-independent; a "fixed" mode
+      // still excludes nothing.
+      for (const entry of controlAfterGenerateEntries(node)) {
+        if (entry.mode === "fixed") continue;
+        addPair(execId, entry.widget);
+        if (entry.control !== entry.widget) addPair(execId, entry.control);
+      }
       if (node.subgraph) walk(node.subgraph, execId);
     }
   };


### PR DESCRIPTION
Fixes #1331

After reconnect, `panel_run({to_node_id})` on a large MiniMax H3 graph refused as a #556 graph-stamp race: 100+ `clip`/`vae`/`model` diffs, canvas idle, nothing queued. The MCP #1050 single retry hit the same leftovers.

Those names are converted widgets whose live input is already linked. `graphToPrompt` serializes the leftover widget value on the pre-dispatch stamp and the incoming link (or a later leftover) on the POST. The value that executes is the link; the leftover is not a user edit.

## What changed

`collectVolatileInputs` grows a fourth volatility signal, same architecture as #572 / #1124 / #1273:

- A widget whose same-named input is link-connected (or that carries the convert-to-input `input.widget` marker) is excluded from both canons.
- After reconnect, `control_after_generate` can be present by option shape before its `beforeQueued` hook is re-hung. The shipped detector now covers that hookless case too; `fixed` still excludes nothing.

A **pure socket** (connected input, no matching widget, no convert marker) stays hashed. A KSampler.model rewire is still drift.

The uncovered names ride out in `volatileInputs` → `drift_coverage`, same residual class as the other signals.

## Verification

`node --test browser_tests/unit/run-scope-guard.test.mjs` — 118 pass / 0 fail (the shipped `dispatchScopedRun` / `panel_run` stamp path):

- leftover clip/vae/length vs dispatched links → `dispatched`, scoped to the requested node
- an unlinked sibling, a pure-socket rewire, or a node add → still `graph_changed`, leftover no longer blamed
- hookless RandomNoise seed churn after reconnect → dispatched; a sibling `steps` edit still refused
