### PR TITLE
fix(1332): panel_get_errors drops missing types the client can now construct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project are documented here. This project adheres to
 ## [Unreleased]
 
 ### Fixed
+- `panel_get_errors` no longer keeps load-time missing-node-type errors after a ComfyUI restart that registered those classes — leftover placeholders are reported as needing a save+reopen, not as still-uninstalled types (#1332)
 - agent-directed instruction blocks (LIVE-CANVAS TOOLS, MANUAL CANVAS CHANGES, query-graph budget accounting) stay in the agent's context and no longer render in the user's chat (#1310)
 - graph mutations no longer stay stuck in `[backend-reconnecting]` after a long Wan render: a busy `/prompt` poll is not a down socket, and binding status now distinguishes a readable canvas from a backend that is actually reconnecting (#1325)
 - panel_update_node surfaces the Manager update traceback instead of hiding it behind a generic "check the server log" error (#1320)

--- a/browser_tests/unit/asset-staleness.test.mjs
+++ b/browser_tests/unit/asset-staleness.test.mjs
@@ -977,8 +977,8 @@ test("#984 source guard: graph_get_errors' own `clean` folds in the live scan", 
   const cleanExpr = /const clean =([\s\S]{0,600}?);/.exec(panelSrc)?.[1] ?? "";
   assert.ok(cleanExpr.length > 0, "the `clean` expression must still exist to be checked");
   assert.match(cleanExpr, /!liveScan\?\.unavailable\?\.length/, "`clean` must account for the live scan (#984)");
-  for (const surface of ["missingModels", "missingMedia", "missingNodeTypes", "missingNodeCount"]) {
-    assert.match(cleanExpr, new RegExp(`!${surface}`), `the #399 surfaces must survive: ${surface}`);
+  for (const surface of ["missingModels", "missingMedia", "missingNodeTypes", "missingNodeCount", "stalePlaceholders"]) {
+    assert.match(cleanExpr, new RegExp(`!${surface}`), `the #399/#1332 surfaces must survive: ${surface}`);
   }
   // The summary now derives every count from the shared helper above, which is tested
   // BEHAVIOURALLY. This only pins that the label is wired to it — codex was right that
@@ -1009,6 +1009,30 @@ test("graphErrorsResultIsClean: FALSE for raw validation / execution errors", ()
   assert.equal(graphErrorsResultIsClean({ node_errors: { 3: { errors: [] } } }), false);
   assert.equal(graphErrorsResultIsClean({ last_execution_error: { node_id: 5 } }), false);
   assert.equal(graphErrorsResultIsClean({ errored_count: 2 }), false);
+});
+
+test("#1332 graphErrorsResultIsClean: FALSE for leftover placeholders after a class registered", () => {
+  // The type is no longer missing, but the already-placed node is still dead.
+  // Labelling that "none" is the #981 lie this issue must not re-open.
+  assert.equal(
+    graphErrorsResultIsClean({
+      stale_placeholders: [{ node_id: "12", type: "easy stylesSelector" }],
+      requires_reload: true,
+    }),
+    false,
+  );
+  assert.equal(graphErrorsResultIsClean({ requires_reload: true }), false);
+});
+
+test("#1332 graphErrorsFindingCounts: stale placeholders count as findings, not as missing types", () => {
+  const counts = graphErrorsFindingCounts({
+    missing_node_types: ["GetImageSize+"],
+    stale_placeholders: [
+      { node_id: "2", type: "easy stylesSelector" },
+      { node_id: "3", type: "easy showAnything" },
+    ],
+  });
+  assert.equal(counts.missingAssets, 3, "the still-missing type AND the two leftovers");
 });
 
 // ---- #407: a subfolder-registered model resolves against the live combo -----

--- a/browser_tests/unit/stale-placeholders.test.mjs
+++ b/browser_tests/unit/stale-placeholders.test.mjs
@@ -26,6 +26,9 @@ import {
   isPlaceholderNode,
   findStalePlaceholders,
   stalePlaceholderNote,
+  withoutClientRegisteredTypes,
+  anyRecordedTypeUnregistered,
+  adjudicateRecordedMissingNodeTypes,
 } from "../../web/js/lib/stale-placeholders.js";
 
 /** A node whose class WAS registered: ComfyUI attaches `nodeData` to the constructor. */
@@ -278,4 +281,139 @@ test("#981 (codex r2) source guard: the disclosure survives the SUCCESS path of 
   // the canvas, not about the refresh having failed.
   assert.ok(!/ok: false/.test(src.slice(src.indexOf("async refresh_nodes()"), src.indexOf("graph_serialize()"))),
     "requires_reload must not be turned into a failure");
+});
+
+// ── #1332 — get_errors must not keep a load-time missing-type list after a restart ──
+
+const ISSUE_RECORDED = ["easy stylesSelector", "easy showAnything", "GetImageSize+"];
+const issueRegistry = (...clientRegistered) => (type) => clientRegistered.includes(type);
+
+test("#1332 the reported case: Easy-Use types drop off missing once the client can construct them", () => {
+  // After restore + restart, panel_add_node of easy stylesSelector succeeded.
+  // GetImageSize+ was a genuinely uninstalled leftover and must stay reported.
+  const nodes = [
+    placeholder(12, "easy stylesSelector"),
+    realNode(40, "easy stylesSelector"),
+    placeholder(13, "easy showAnything"),
+    placeholder(7, "GetImageSize+"),
+  ];
+  const { stillMissing, stalePlaceholders } = adjudicateRecordedMissingNodeTypes(
+    ISSUE_RECORDED,
+    nodes,
+    issueRegistry("easy stylesSelector", "easy showAnything"),
+  );
+  assert.deepEqual(stillMissing, ["GetImageSize+"]);
+  assert.deepEqual(
+    stalePlaceholders.map((s) => `${s.node_id}:${s.type}`),
+    ["12:easy stylesSelector", "13:easy showAnything"],
+    "the leftover placeholders stay a finding; the freshly-added real node does not",
+  );
+});
+
+test("#1332 a now-registered type with no live instance is dropped, not kept as missing", () => {
+  // The load-time store outlived its nodes (or the agent removed the placeholders).
+  // The type is constructable on this page, so it is not missing.
+  const { stillMissing, stalePlaceholders } = adjudicateRecordedMissingNodeTypes(
+    ["easy stylesSelector", "GetImageSize+"],
+    [placeholder(7, "GetImageSize+")],
+    issueRegistry("easy stylesSelector"),
+  );
+  assert.deepEqual(stillMissing, ["GetImageSize+"]);
+  assert.deepEqual(stalePlaceholders, []);
+});
+
+test("#1332 a rebuilt node plus a stale store snapshot is not missing and not a placeholder", () => {
+  const { stillMissing, stalePlaceholders } = adjudicateRecordedMissingNodeTypes(
+    ["easy stylesSelector"],
+    [realNode(40, "easy stylesSelector")],
+    issueRegistry("easy stylesSelector"),
+  );
+  assert.deepEqual(stillMissing, []);
+  assert.deepEqual(stalePlaceholders, []);
+});
+
+test("#1332 a type the client still cannot instantiate stays missing", () => {
+  assert.deepEqual(
+    withoutClientRegisteredTypes(ISSUE_RECORDED, issueRegistry()),
+    ISSUE_RECORDED,
+  );
+  assert.equal(anyRecordedTypeUnregistered(ISSUE_RECORDED, issueRegistry()), true);
+  assert.equal(
+    anyRecordedTypeUnregistered(ISSUE_RECORDED, issueRegistry("easy stylesSelector", "easy showAnything", "GetImageSize+")),
+    false,
+    "no refresh needed once every recorded type is already in the client registry",
+  );
+});
+
+test("#1332 unknown registration status fails closed — the type stays reported", () => {
+  assert.deepEqual(withoutClientRegisteredTypes(["X"], null), ["X"]);
+  assert.deepEqual(withoutClientRegisteredTypes(["X"], undefined), ["X"]);
+  assert.deepEqual(
+    withoutClientRegisteredTypes(["X"], () => {
+      throw new Error("registry boom");
+    }),
+    ["X"],
+  );
+  assert.equal(anyRecordedTypeUnregistered(["X"], null), false, "cannot prove a refresh would help");
+  assert.equal(
+    anyRecordedTypeUnregistered(["X"], () => {
+      throw new Error("boom");
+    }),
+    true,
+    "a throwing lookup is treated as unregistered so a refresh is still attempted",
+  );
+  assert.deepEqual(withoutClientRegisteredTypes(null, () => true), []);
+  assert.deepEqual(withoutClientRegisteredTypes([], () => true), []);
+});
+
+test("#1332 source guard: get_errors adjudicates AFTER the node-def refresh, against the CLIENT registry", () => {
+  const src = readFileSync(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8");
+  const at = src.indexOf("async graph_get_errors() {");
+  assert.ok(at > 0, "graph_get_errors must still be recognisable");
+  const end = src.indexOf("async workflow_save(", at);
+  assert.ok(end > at, "the executor's end must still be recognisable");
+  const body = src.slice(at, end);
+  const refreshAt = body.indexOf("refreshComfyNodeDefs(undefined, { force: true })");
+  const adjudicateAt = body.indexOf("adjudicateRecordedMissingNodeTypes(");
+  const reasonsAt = body.indexOf("collectMissingNodeTypeReasons(nodes, missingNodeTypes)");
+  assert.ok(refreshAt > 0, "get_errors still force-refreshes node defs");
+  assert.ok(adjudicateAt > refreshAt, "adjudication must run AFTER the refresh so LiteGraph is current");
+  assert.ok(reasonsAt > adjudicateAt, "per-node missing_node_type blame uses the FILTERED list");
+  assert.match(
+    body,
+    /isRegisteredNodeType\(LiteGraph\?\.registered_node_types, type\)/,
+    "client registry, not /object_info — backend presence is a different fact",
+  );
+  assert.match(body, /kind: "stale_placeholder"/, "leftover placeholders become a per-node reason");
+  assert.match(body, /stale_placeholders: stalePlaceholders/);
+  assert.match(body, /requires_reload: true/);
+  assert.ok(
+    !/removeMissingNodesByType\s*\(/.test(src),
+    "the load-time store is still not cleared — #981's worse-answer hole",
+  );
+});
+
+test("#1332 source guard: the refresh trigger fires for an unregistered recorded type", () => {
+  const src = readFileSync(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8");
+  const at = src.indexOf("function hasRawMissingAssetCandidates() {");
+  assert.ok(at > 0, "the refresh trigger must still be recognisable");
+  const end = src.indexOf("\nfunction withRefreshTimeout", at);
+  assert.ok(end > at, "the trigger's end must still be recognisable");
+  const body = src.slice(at, end);
+  assert.match(body, /anyRecordedTypeUnregistered\(/);
+  assert.match(
+    body,
+    /isRegisteredNodeType\(LiteGraph\?\.registered_node_types, type\)/,
+    "same client-registry predicate as the adjudication",
+  );
+});
+
+test("#1332 source guard: the turn-start banner uses the same adjudication", () => {
+  const src = readFileSync(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8");
+  const at = src.indexOf("async function validationBanner() {");
+  assert.ok(at > 0, "the banner must still be recognisable");
+  const body = src.slice(at, src.indexOf("async graph_get_errors()", at));
+  assert.ok(body.length > 200, "the banner body must still sit before graph_get_errors");
+  assert.match(body, /adjudicateRecordedMissingNodeTypes\(/);
+  assert.match(body, /still PLACEHOLDERS after their class registered/);
 });

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -206,7 +206,12 @@ import {
   virtualSourceNote,
   virtualSourceTag,
 } from "./lib/virtual-source-promotion.js";
-import { findStalePlaceholders, stalePlaceholderNote } from "./lib/stale-placeholders.js";
+import {
+  findStalePlaceholders,
+  stalePlaceholderNote,
+  anyRecordedTypeUnregistered,
+  adjudicateRecordedMissingNodeTypes,
+} from "./lib/stale-placeholders.js";
 import {
   findRepeatingControlWidgets,
   scopedBatchSeedNote,
@@ -9263,6 +9268,27 @@ function hasRawMissingAssetCandidates() {
   } catch {
     /* optional */
   }
+  // #1332 — the load-time missing-node-type store is the same kind of snapshot as
+  // the model/media stores: after a ComfyUI restart that registered the class, it
+  // still names it. A forced /object_info refresh is how this page learns the new
+  // registry; without it get_errors would adjudicate against the PRE-restart
+  // LiteGraph and keep reporting a type panel_add_node can already construct.
+  // Only when a recorded type is still absent from the CLIENT registry — a
+  // genuine miss, or a restart whose refresh has not landed yet. Types already
+  // in LiteGraph are dropped at report time without another fetch.
+  try {
+    const recorded = collectMissingAssets(false).nodeTypes;
+    if (
+      anyRecordedTypeUnregistered(
+        recorded,
+        (type) => isRegisteredNodeType(LiteGraph?.registered_node_types, type),
+      )
+    ) {
+      return true;
+    }
+  } catch {
+    /* store / registry unreadable → do not spend the 14s refresh on a guess */
+  }
   return false;
 }
 
@@ -9344,7 +9370,32 @@ async function validationBanner() {
   ) {
     return "";
   }
-  missing.any = !!(missing.models.length || missing.media.length || missing.nodeTypes.length || missing.nodeCount);
+  // #1332 — same re-evaluation as graph_get_errors, so the turn-start banner
+  // cannot keep saying "node types not installed" after a restart that registered
+  // them. Placeholders of those types stay a warning (they still fail at queue
+  // time) rather than being dropped as if the canvas were clean.
+  let bannerStalePlaceholders = [];
+  try {
+    const { rootGraph: bannerRoot } = getGraphCtx();
+    const allNodes = collectAllGraphs(bannerRoot).flatMap((g) => g?._nodes ?? []);
+    const adjudicated = adjudicateRecordedMissingNodeTypes(
+      missing.nodeTypes,
+      allNodes,
+      (type) => isRegisteredNodeType(LiteGraph?.registered_node_types, type),
+    );
+    missing.nodeTypes = adjudicated.stillMissing;
+    bannerStalePlaceholders = adjudicated.stalePlaceholders;
+    if (!missing.nodeTypes.length) missing.nodeCount = 0;
+  } catch {
+    bannerStalePlaceholders = [];
+  }
+  missing.any = !!(
+    missing.models.length ||
+    missing.media.length ||
+    missing.nodeTypes.length ||
+    missing.nodeCount ||
+    bannerStalePlaceholders.length
+  );
   // #415: the ⚠️ MISSING ASSETS block reads as authoritative at turn start, but the
   // stores are LOAD-TIME only and the live combo can drift BOTH ways — a since-uploaded
   // asset the banner still calls missing, OR a since-deleted asset a prior-confirmed
@@ -9385,6 +9436,7 @@ async function validationBanner() {
         missing.media.map((x) => `${x.node_id}:${x.file}`),
         missing.nodeTypes,
         missing.nodeCount,
+        bannerStalePlaceholders.map((s) => `${s.node_id}:${s.type}`),
       ],
     });
   } catch {
@@ -9449,6 +9501,14 @@ async function validationBanner() {
       lines.push(`node types not installed: ${missing.nodeTypes.slice(0, 12).map((t) => coerceMessageText(t)).join(", ")}`);
     } else if (missing.nodeCount) {
       lines.push(`${missing.nodeCount} node type(s) not installed on this ComfyUI`);
+    }
+    if (bannerStalePlaceholders.length) {
+      const types = [...new Set(bannerStalePlaceholders.map((s) => coerceMessageText(s.type)).filter(Boolean))];
+      lines.push(
+        `${bannerStalePlaceholders.length} node(s) still PLACEHOLDERS after their class registered ` +
+          `(${types.slice(0, 6).join(", ")}): SAVE then reopen the saved workflow — registering a class ` +
+          `does not rehydrate nodes created while it was unknown (#1332/#981)`,
+      );
     }
     out +=
       `⚠️ MISSING ASSETS — the user's canvas has RED nodes RIGHT NOW because the workflow ` +
@@ -15173,6 +15233,27 @@ const GRAPH_TOOL_EXECUTORS = {
           "DIFFERENT workflows. Retry panel_get_errors — it re-reads the now-active workflow.",
       );
     }
+    // #1332 — the missing-node-type store is a LOAD-TIME snapshot. After a
+    // ComfyUI restart that registered the class (a fresh panel_add_node of that
+    // type succeeds), it still names it. Re-evaluate against this page's client
+    // registry so a now-constructable type is not reported as missing. Leftover
+    // placeholders of those types stay a finding — they are not missing, they
+    // need a save+reopen (#981). The store is not cleared.
+    let stalePlaceholders = [];
+    try {
+      const allNodes = collectAllGraphs(rootGraph).flatMap((g) => g?._nodes ?? []);
+      const adjudicated = adjudicateRecordedMissingNodeTypes(
+        assets.nodeTypes,
+        allNodes,
+        (type) => isRegisteredNodeType(LiteGraph?.registered_node_types, type),
+      );
+      assets.nodeTypes = adjudicated.stillMissing;
+      stalePlaceholders = adjudicated.stalePlaceholders;
+      if (!assets.nodeTypes.length) assets.nodeCount = 0;
+    } catch {
+      /* unreadable registry → keep the load-time list (fail closed) */
+      stalePlaceholders = [];
+    }
     assets.any = !!(assets.models.length || assets.media.length || assets.nodeTypes.length || assets.nodeCount);
     const missingModels = assets.models.map((m) => ({ ...m, kind: "missing_model" }));
     const missingMedia = assets.media.map((m) => ({ ...m, kind: "missing_media" }));
@@ -15210,6 +15291,13 @@ const GRAPH_TOOL_EXECUTORS = {
     //    identical to how a subgraph-hosted missing model behaves here.
     for (const { nodeId, type } of collectMissingNodeTypeReasons(nodes, missingNodeTypes)) {
       addReason(nodeId, { kind: "missing_node_type", type });
+    }
+    // Placeholders of a NOW-registered type on the currently viewed graph. Types
+    // nested in an un-entered subgraph stay on the top-level stale_placeholders
+    // list (same scope split as missing_node_types above).
+    for (const s of stalePlaceholders) {
+      if (s?.node_id == null || !byId.has(String(s.node_id))) continue;
+      addReason(s.node_id, { kind: "stale_placeholder", type: s.type });
     }
 
     // 3) Per-node VALIDATION errors from the last queue attempt. `app.lastNodeErrors`
@@ -15325,6 +15413,7 @@ const GRAPH_TOOL_EXECUTORS = {
       !missingMedia.length &&
       !missingNodeTypes.length &&
       !missingNodeCount &&
+      !stalePlaceholders.length &&
       !liveScan?.unavailable?.length;
     return {
       viewing: describeActiveGraph(graph),
@@ -15389,6 +15478,13 @@ const GRAPH_TOOL_EXECUTORS = {
       ...(missingNodeTypes.length ? { missing_node_types: missingNodeTypes } : {}),
       ...(missingNodeCount && !missingNodeTypes.length
         ? { missing_node_count: missingNodeCount }
+        : {}),
+      ...(stalePlaceholders.length
+        ? {
+            requires_reload: true,
+            stale_placeholders: stalePlaceholders.slice(0, MAX_STATE_NODES),
+            stale_placeholders_note: stalePlaceholderNote(stalePlaceholders),
+          }
         : {}),
       // --- backwards-compatible payloads (existing consumers read these) ---
       // Bounded at emission (#664): verbatim, this carried tensor-sized

--- a/web/js/lib/asset-staleness.js
+++ b/web/js/lib/asset-staleness.js
@@ -511,7 +511,8 @@ export function collectMissingNodeTypeReasons(nodes, missingNodeTypes) {
 /**
  * True when a `graph_get_errors` RESULT payload represents a genuinely CLEAN graph —
  * no per-node validation errors, no execution failure, no errored nodes, AND no
- * missing-asset surface of ANY kind (models / media / node-types / node-count). Every
+ * missing-asset surface of ANY kind (models / media / node-types / node-count /
+ * stale placeholders left after a class registered — #1332). Every
  * consumer that summarizes the result — the command-summary label, banners, etc. —
  * must derive "errors vs none" from THIS, so a missing-asset-ONLY result (e.g. a red or
  * BYPASSED uninstalled node, #399/#356) is never labelled "none" while its own payload
@@ -529,6 +530,8 @@ export function graphErrorsResultIsClean(result) {
     !len(result.missing_media) &&
     !len(result.missing_node_types) &&
     !(Number(result.missing_node_count) > 0) &&
+    !len(result.stale_placeholders) &&
+    !result.requires_reload &&
     // #984 — the #745 LIVE scan was added to the payload after this helper was
     // written and never folded in, so a result carrying `unavailable_widget_values`
     // was still labelled "Checked errors — none". Every entry there is a widget
@@ -617,7 +620,11 @@ export function graphErrorsFindingCounts(result) {
   return {
     erroredNodes: Number(r.errored_count) || 0,
     missingAssets:
-      models.length + media.length + arr(r.missing_node_types).length + (Number(r.missing_node_count) || 0),
+      models.length +
+      media.length +
+      arr(r.missing_node_types).length +
+      (Number(r.missing_node_count) || 0) +
+      arr(r.stale_placeholders).length,
     unavailable,
     unchecked: arr(r.unchecked_nodes).length,
   };

--- a/web/js/lib/stale-placeholders.js
+++ b/web/js/lib/stale-placeholders.js
@@ -25,6 +25,12 @@
  * fails at queue time. The reporter's own second option is the correct one — do not
  * claim a complete refresh when the placeholders did not come back — and this module
  * establishes exactly that condition.
+ *
+ * #1332 is the other half of the same measurement. After a restart that really did
+ * register the class (a fresh `panel_add_node` of that type succeeds), `panel_get_errors`
+ * must not keep listing it under `missing_node_types`. The type is not missing. Leftover
+ * placeholders stay a finding — they move to `stale_placeholders` / `requires_reload` —
+ * so the canvas is never declared clean over a dead node. The store is still not cleared.
  */
 
 /**
@@ -139,7 +145,7 @@ export function stalePlaceholderNote(stale) {
     // than asserted of every node in the list.
     `does not rehydrate nodes that were created while it was unknown. Each of these carries no ` +
     `class definition; on the instance measured for #981 that also meant no widgets and no ` +
-    `title. They will still be reported as missing, and they were never ` +
+    `title. They were never ` +
     `rebuilt against the class, so do not rely on ${stale.length === 1 ? "it" : "them"} ` +
     // "Reload" alone is ambiguous (codex) — a browser refresh restores whatever the
     // frontend last autosaved, which is not reliably the graph on screen. The remedy is
@@ -155,4 +161,75 @@ export function stalePlaceholderNote(stale) {
     `a plain browser refresh restores whatever the frontend last autosaved rather than the ` +
     `graph in front of you.`
   );
+}
+
+/**
+ * #1332 — drop types the live CLIENT registry can instantiate from a load-time
+ * missing-node-type list.
+ *
+ * The store is never re-evaluated after a ComfyUI restart that registered the class
+ * (stale-placeholders.js measured that). A type that is NOW in `LiteGraph.registered_node_types`
+ * is not missing — `panel_add_node` of that class succeeds — so leaving it on
+ * `missing_node_types` is the stale answer. Unknown registration status keeps the type
+ * reported (fail closed). Order-preserving. A missing/non-function lookup is treated as
+ * "cannot prove registered" and returns the input list unchanged.
+ */
+export function withoutClientRegisteredTypes(types, isClientRegistered) {
+  if (!Array.isArray(types) || !types.length) return Array.isArray(types) ? types : [];
+  if (typeof isClientRegistered !== "function") return types;
+  const out = [];
+  for (const t of types) {
+    let registered = false;
+    try {
+      registered = !!isClientRegistered(t);
+    } catch {
+      registered = false;
+    }
+    if (!registered) out.push(t);
+  }
+  return out;
+}
+
+/**
+ * True when at least one recorded missing type is NOT in the client registry — the
+ * condition that makes a forced `/object_info` refresh worth paying for before
+ * `panel_get_errors` adjudicates. All-registered (or an unreadable lookup) is false:
+ * the filter above can drop those types without a fetch, and a 14s refresh on a
+ * permanently-missing type is the same cost the missing-model path already accepts,
+ * but only while something is still actually unregistered.
+ */
+export function anyRecordedTypeUnregistered(types, isClientRegistered) {
+  if (!Array.isArray(types) || !types.length) return false;
+  if (typeof isClientRegistered !== "function") return false;
+  for (const t of types) {
+    try {
+      if (!isClientRegistered(t)) return true;
+    } catch {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * #1332 — one decision for the two answers `panel_get_errors` must not mix:
+ *
+ *   stillMissing       — types the client registry still cannot instantiate
+ *   stalePlaceholders  — already-placed nodes of a NOW-registered type that
+ *                        were never rehydrated (#981)
+ *
+ * The recorded list is the load-time snapshot (after the virtual-node filter).
+ * Placeholders are detected against that full snapshot, not against `stillMissing`,
+ * because a type that just registered is exactly the one whose leftover nodes
+ * need the save+reopen disclosure.
+ */
+export function adjudicateRecordedMissingNodeTypes(recordedTypes, nodes, isClientRegistered) {
+  const recorded = Array.isArray(recordedTypes) ? recordedTypes : [];
+  return {
+    stillMissing: withoutClientRegisteredTypes(recorded, isClientRegistered),
+    stalePlaceholders: findStalePlaceholders(nodes, {
+      recordedMissingTypes: recorded,
+      isClientRegistered,
+    }),
+  };
 }


### PR DESCRIPTION
Fixes #1332.

After restoring Easy-Use and restarting ComfyUI, `panel_add_node` of `easy stylesSelector` succeeded — the class was registered — but `panel_get_errors` still listed `easy stylesSelector` / `easy showAnything` as missing. The load-time `missingNodesError` store is never re-evaluated; registering a class also does not rehydrate nodes placed while it was unknown (#981). Clearing that store would make get_errors report clean over a dead node.

## What changed

`panel_get_errors` (and the turn-start banner, so they cannot disagree) re-evaluate the snapshot against this page's **client** registry after the forced node-def refresh:

- a type now in `LiteGraph.registered_node_types` leaves `missing_node_types`
- leftover placeholders of those types move to `stale_placeholders` / `requires_reload` (save, then reopen that saved workflow)
- a type the client still cannot instantiate stays missing (`GetImageSize+` in the report)
- the store is still not cleared

The refresh trigger now also fires when a recorded type is absent from the client registry, so a post-restart get_errors can pick up newly registered packs without waiting for an add. Types already constructable skip the fetch.

## Tests

The reported mix is pinned as a unit: Easy-Use types drop off missing once the client can construct them; the leftover placeholders stay a finding; the freshly-added real node does not; `GetImageSize+` stays missing. Source guards pin that get_errors adjudicates **after** the node-def refresh, against the client registry, and that the store is still not cleared.

```
node --test browser_tests/unit/stale-placeholders.test.mjs \
            browser_tests/unit/asset-staleness.test.mjs \
            browser_tests/unit/get-errors-budget.test.mjs
```

135/135 pass. Browser e2e not run — no spec in the suite drives `graph_get_errors` through a ComfyUI restart.
