### PR TITLE
fix(1711): a nested composite field inside a JSON widget validates against its own value's shape

### DIFF
--- a/browser_tests/unit/widget-write.test.mjs
+++ b/browser_tests/unit/widget-write.test.mjs
@@ -517,6 +517,99 @@ test("#179 REGRESSION: a valid full-object write still merges + preserves unspec
   assert.equal(set.value.strengthTwo, null); // preserved
 });
 
+// ---- comfyui-mcp#1711: nested composites inside a JSON widget (Pixaroma) ----
+
+test("comfyui-mcp#1711: a read-modify-write pass-through of a widget holding a nested ARRAY-OF-ARRAYS is accepted", () => {
+  // PixaromaSizes' sizes_ui: scalars plus `sizes`, an Array<Array<number>>. The agent
+  // reads the value verbatim, changes only scalar leaves, and sends the whole JSON back;
+  // the untouched `sizes` field must not be refused as "not a recognized type".
+  const node = {
+    id: 223,
+    type: "PixaromaSizes",
+    widgets: [
+      {
+        name: "sizes_ui",
+        value: { selected: 2, w: 480, h: 864, sizes: [[608, 352], [736, 416], [864, 480]] },
+      },
+    ],
+  };
+  const set = applyWidgetWrite(
+    node,
+    "sizes_ui",
+    '{"selected":8,"w":768,"h":1344,"sizes":[[608,352],[736,416],[864,480]]}',
+    HOOKS,
+  );
+  assert.equal(set.value.selected, 8);
+  assert.equal(set.value.w, 768);
+  assert.deepEqual(set.value.sizes, [[608, 352], [736, 416], [864, 480]]);
+});
+
+test("comfyui-mcp#1711: a CHANGED but same-shaped nested array is accepted", () => {
+  const node = {
+    id: 224,
+    type: "PixaromaSizes",
+    widgets: [
+      { name: "sizes_ui", value: { selected: 2, sizes: [[608, 352], [736, 416]] } },
+    ],
+  };
+  // Add one pair and edit another — the shape (array of [number, number]) is unchanged.
+  const set = applyWidgetWrite(
+    node,
+    "sizes_ui",
+    '{"sizes":[[608,352],[864,480],[1920,1088]]}',
+    HOOKS,
+  );
+  assert.deepEqual(set.value.sizes, [[608, 352], [864, 480], [1920, 1088]]);
+  assert.equal(set.value.selected, 2); // unspecified field preserved
+});
+
+test("comfyui-mcp#1711: a same-shaped nested array is accepted via DOTTED sub-field addressing too", () => {
+  const node = {
+    id: 225,
+    type: "PixaromaSizes",
+    widgets: [
+      { name: "sizes_ui", value: { selected: 2, sizes: [[608, 352]] } },
+    ],
+  };
+  const set = applyWidgetWrite(node, "sizes_ui.sizes", [[1024, 576], [1280, 720]], HOOKS);
+  assert.deepEqual(set.value.sizes, [[1024, 576], [1280, 720]]);
+  assert.equal(set.value.selected, 2);
+});
+
+test("comfyui-mcp#1711: a shape-DIVERGENT value for a nested composite field still FAILS CLOSED", () => {
+  const node = {
+    id: 226,
+    type: "PixaromaSizes",
+    widgets: [
+      { name: "sizes_ui", value: { selected: 2, sizes: [[608, 352], [736, 416]] } },
+    ],
+  };
+  // A string where the array-of-arrays sits, and an array with a wrong leaf type, are
+  // both provable mistypes — refused, and the widget is left untouched.
+  assert.throws(
+    () => applyWidgetWrite(node, "sizes_ui", '{"sizes":"608x352"}', HOOKS),
+    (err) => err instanceof WidgetWriteError && /cannot validate the value/.test(err.message),
+  );
+  assert.throws(
+    () => applyWidgetWrite(node, "sizes_ui", '{"sizes":[["608","352"]]}', HOOKS),
+    (err) => err instanceof WidgetWriteError && /cannot validate the value/.test(err.message),
+  );
+  assert.deepEqual(node.widgets[0].value.sizes, [[608, 352], [736, 416]]);
+});
+
+test("comfyui-mcp#1711: an EMPTY existing array stays fail-closed (no element type to infer)", () => {
+  const node = {
+    id: 227,
+    type: "PixaromaSizes",
+    widgets: [{ name: "sizes_ui", value: { selected: 2, sizes: [] } }],
+  };
+  assert.throws(
+    () => applyWidgetWrite(node, "sizes_ui", '{"sizes":[[608,352]]}', HOOKS),
+    (err) => err instanceof WidgetWriteError && /cannot validate the value/.test(err.message),
+  );
+  assert.deepEqual(node.widgets[0].value.sizes, []);
+});
+
 test("#560 SAFETY: dotted addressing on a SUBGRAPH parent is refused (never a rail-only write)", () => {
   // A subgraph-shaped node whose "lora_1" is NOT resolvable as a promotion alias here:
   // the dotted form must fail closed rather than write the parent rail directly (#366).

--- a/web/js/lib/widget-write.js
+++ b/web/js/lib/widget-write.js
@@ -369,13 +369,42 @@ function coerceByType(type, value, where) {
   return value;
 }
 
+// True when `value` has the SAME recursive type shape as `existing` — every leaf the
+// same primitive type, arrays element-compatible, plain objects carrying no key the
+// existing object lacks. Used to validate an unknown composite's OBJECT/ARRAY field
+// against its own current value (comfyui-mcp#1711): UI-heavy node packs (e.g.
+// ComfyUI-Pixaroma) store state as JSON blobs with nested composites like
+// `sizes: [[608,352],...]`, whose element types are perfectly inferable from the
+// existing value — so a same-shaped write (including the byte-identical pass-through
+// a read-modify-write agent sends back) is provably not a mistype and must be accepted,
+// while a shape-DIVERGENT value (string where an array sits, a foreign key) still fails
+// closed. An EMPTY existing array/object carries no element type to infer, so only an
+// equally-empty value matches it.
+function matchesExistingShape(existing, value) {
+  if (Array.isArray(existing)) {
+    if (!Array.isArray(value)) return false;
+    if (existing.length === 0) return value.length === 0;
+    return value.every((v) => existing.some((e) => matchesExistingShape(e, v)));
+  }
+  if (existing !== null && typeof existing === "object") {
+    if (value === null || typeof value !== "object" || Array.isArray(value)) return false;
+    return Object.keys(value).every(
+      (k) =>
+        Object.prototype.hasOwnProperty.call(existing, k) &&
+        matchesExistingShape(existing[k], value[k]),
+    );
+  }
+  return typeof value === typeof existing && (existing !== null || value === null);
+}
+
 /**
  * Validate + coerce a composite field value. The expected type comes FIRST from the
  * declared schema (so a null current field still enforces the right type, #560 P0), and
  * `null` is accepted only for a nullable field (#560 P2). For an UNKNOWN composite with
- * no schema, fall back to the existing NON-null value's type; a null/undefined current
- * value with no schema is genuinely untyped, so only a primitive is accepted verbatim.
- * Throws WidgetWriteError on a mismatch.
+ * no schema, fall back to the existing NON-null value's type — a scalar field coerces
+ * strictly, and an object/array field is accepted when the value matches the existing
+ * value's recursive shape (comfyui-mcp#1711). A null/undefined current value with no
+ * schema is genuinely untyped and refused. Throws WidgetWriteError on a mismatch.
  */
 function coerceCompositeFieldValue(widgetName, base, field, value) {
   const where = `sub-field "${widgetName}.${field}"`;
@@ -392,10 +421,16 @@ function coerceCompositeFieldValue(widgetName, base, field, value) {
   if (typeof existing === "boolean") return coerceByType("boolean", value, where);
   if (typeof existing === "number") return coerceByType("number", value, where);
   if (typeof existing === "string") return coerceByType("string", value, where);
-  // No schema AND an untyped current value (null/undefined/object): the field's type is
-  // genuinely unknowable, so we REFUSE rather than write a possibly-wrong-typed value —
-  // #560's principle is a loud, safe failure over silent corruption. (A KNOWN composite,
-  // e.g. rgthree, is handled by the schema above and its nullable fields still clear.)
+  // comfyui-mcp#1711: the existing value is an object/array, so the field is a NESTED
+  // composite — not untyped. Validate the value against the existing value's recursive
+  // shape; a same-shaped value (typically the read-modify-write pass-through of the
+  // field's own current content) is safe to write verbatim.
+  if (existing != null && matchesExistingShape(existing, value)) return value;
+  // No schema AND an untyped current value (null/undefined) OR a shape-DIVERGENT value
+  // for a nested composite: the write cannot be proven correctly-typed, so we REFUSE
+  // rather than write a possibly-wrong-typed value — #560's principle is a loud, safe
+  // failure over silent corruption. (A KNOWN composite, e.g. rgthree, is handled by the
+  // schema above and its nullable fields still clear.)
   throw new WidgetWriteError(
     `${where}: cannot validate the value — this composite is not a recognized type and the ` +
       `field's current value is ${existing === undefined ? "undefined" : JSON.stringify(existing)}, ` +


### PR DESCRIPTION
## Root cause

`panel_set_widget` refused composite JSON widgets that contain a **nested composite sub-field** (e.g. ComfyUI-Pixaroma's `sizes_ui.sizes`, an `Array<Array<number>>`). In `web/js/lib/widget-write.js`, `coerceCompositeFieldValue` inferred an expected type only for scalar existing values (boolean/number/string); any object/array existing value fell through to the "not a recognized type" refusal. That refusal fired even on a **byte-identical read-modify-write pass-through** — the agent reads `sizes_ui` via `panel_query_graph`, changes only scalar leaves, sends the whole JSON back, and the untouched `sizes` field was rejected by the very validator that had just reported it as the current value.

## Fix

Unknown-composite sub-fields whose current value is an object/array now validate against the existing value's **recursive type shape** (new `matchesExistingShape` helper): same leaf primitive types, arrays element-compatible, plain objects carrying no foreign key. A same-shaped value — including the pass-through case and legit edits like adding a size pair — is accepted; a shape-divergent value (a string where an array sits, wrong leaf types) still fails closed with the same loud refusal. A null/undefined current value remains genuinely untyped and is still refused, as is a non-empty write into an empty existing array (no element type to infer).

## Verification

- `node --test browser_tests/unit/widget-write.test.mjs` — 172/172 pass, including 5 new tests: pass-through accepted, changed same-shaped array accepted (full-object and dotted sub-field paths), shape-divergent values refused with the widget untouched, empty-array field stays fail-closed.
- `npm ci` — clean, 0 vulnerabilities.
- `npm run test:unit` (i18n-check + i18n-render-check + check-tool-vocabulary + check-panel-scope + full unit suite) — 5389 tests, 0 fail.
- `npm run typecheck` (`tsc --noEmit`) — clean.

Closes artokun/comfyui-mcp#1711