### PR TITLE
fix(1272): a caller-supplied exclusion Set is normalised, not trusted

### DIFF
--- a/browser_tests/unit/connect-throw-verdict.test.mjs
+++ b/browser_tests/unit/connect-throw-verdict.test.mjs
@@ -785,6 +785,49 @@ test("findLandedRailLink: excluded (pre-existing) ids are never credited to this
   assert.equal(findLandedRailLink(graph, rail, node, 0, "output", linkIdExclusionSet([4])), null);
 });
 
+// ---------------------------------------------------------------------------
+// A caller-supplied Set must be NORMALISED, not trusted.
+//
+// Both finders used to short-circuit on `excludeIds instanceof Set` and use the
+// caller's Set verbatim. Membership is asked as `skip.has(String(linkId))`, so a
+// Set of RAW NUMBERS — the shape any caller gets from `new Set(railSlot.linkIds)`
+// or `new Set(inputLinkIds(node))`, since both id readers deliberately return raw
+// ids — matched NOTHING: the exclusion evaporated and a link that existed BEFORE
+// the mutation was credited to the current call. That is the same string/number
+// key mismatch this file already recovered from once, arriving from the other
+// side; `linkIdExclusionSet` is now the unconditional gate on both paths.
+// ---------------------------------------------------------------------------
+
+test("both finders normalise a caller-supplied Set — a RAW-number Set still excludes", () => {
+  const rail = { linkIds: [4] };
+  const node = { id: 9 };
+  const railGraph = {
+    links: { 4: { id: 4, origin_id: 9, origin_slot: 0, target_id: -20, target_slot: 0 } },
+  };
+  // Pre-condition: link 4 IS on the rail and IS found when nothing is excluded.
+  assert.deepEqual(findLandedRailLink(railGraph, rail, node, 0, "output", null), { linkId: 4 });
+  // Excluding it as a raw-number Set must suppress it exactly as an array does.
+  assert.equal(findLandedRailLink(railGraph, rail, node, 0, "output", new Set([4])), null);
+  assert.equal(findLandedRailLink(railGraph, rail, node, 0, "output", new Set(["4"])), null);
+
+  // The inbound finder leaks identically without normalisation.
+  const inboundGraph = {
+    links: { 5: { id: 5, origin_id: 1, origin_slot: 0, target_id: 2, target_slot: 0 } },
+  };
+  const target = { id: 2, inputs: [{ name: "a", link: 5 }] };
+  const origin = { id: 1 };
+  assert.deepEqual(findLandedInboundLink(inboundGraph, origin, 0, target, null), {
+    linkId: 5,
+    inputIndex: 0,
+  });
+  assert.equal(findLandedInboundLink(inboundGraph, origin, 0, target, new Set([5])), null);
+  assert.equal(findLandedInboundLink(inboundGraph, origin, 0, target, new Set(["5"])), null);
+
+  // And the normaliser itself accepts a Set, so there is nothing left for a call
+  // site to have to special-case.
+  assert.deepEqual([...linkIdExclusionSet(new Set([4, 5]))], ["4", "5"]);
+});
+
 test("isRailLinkPersisted: the rail slot must list THAT id and the link must join the node", () => {
   const graph = {
     links: { 4: { id: 4, origin_id: 9, origin_slot: 0, target_id: -20, target_slot: 0 } },

--- a/web/js/lib/connect-verify.js
+++ b/web/js/lib/connect-verify.js
@@ -190,6 +190,13 @@ export function railSlotLinkIds(railSlot) {
  * and collapsing them into one "ids as strings" helper is precisely how a working
  * rail verdict became a 100% false negative. Keeping the string form to this
  * function, and reading the store only with raw ids, is what keeps them apart.
+ *
+ * Takes ANY iterable of ids — an array, or a Set a caller already built. Callers
+ * must NOT skip this on the grounds that they already hold a Set: a Set of RAW
+ * numbers passed straight through is a set whose `has(String(id))` never matches,
+ * so every exclusion silently evaporates and a PRE-EXISTING link gets credited to
+ * the current call. Normalising unconditionally is idempotent (a Set of strings
+ * re-normalises to itself) and costs one pass over a handful of ids.
  */
 export function linkIdExclusionSet(ids) {
   const set = new Set();
@@ -214,7 +221,7 @@ export function linkIdExclusionSet(ids) {
 export function findLandedInboundLink(graph, origin, outIdx, target, excludeIds) {
   const originId = origin?.id;
   if (originId == null || !target) return null;
-  const skip = excludeIds instanceof Set ? excludeIds : linkIdExclusionSet(excludeIds);
+  const skip = linkIdExclusionSet(excludeIds);
   const inputs = target.inputs ?? [];
   for (let i = 0; i < inputs.length; i++) {
     const linkId = inputs[i]?.link;
@@ -259,7 +266,7 @@ export function isRailLinkPersisted(graph, railSlot, node, slotIdx, side, link) 
  * wire is never credited to this call. Returns `{ linkId }`.
  */
 export function findLandedRailLink(graph, railSlot, node, slotIdx, side, excludeIds) {
-  const skip = excludeIds instanceof Set ? excludeIds : linkIdExclusionSet(excludeIds);
+  const skip = linkIdExclusionSet(excludeIds);
   for (const linkId of railSlotLinkIds(railSlot)) {
     // String() on the MEMBERSHIP side only — `linkId` itself stays raw for the
     // store read on the next line.


### PR DESCRIPTION
Closes a **latent** exclusion-normalisation leak in `web/js/lib/connect-verify.js`, found by an independent post-merge review of PR #1352 (merged as `2b665f44`). Nothing is broken in shipped behaviour today — no live call site passes a `Set` — but the defect is one edit away from re-causing the class of P0 that file just recovered from, and the suite could not see it.

## The leak

`linkIdExclusionSet` exists because the two halves of the "did THIS call add the link?" question need **opposite** id forms:

- membership must survive a number/string mismatch → ids are stringified;
- the store read must **not** be stringified → `Map.get("7")` misses a key of `7`.

Both finders then short-circuited that helper:

```js
const skip = excludeIds instanceof Set ? excludeIds : linkIdExclusionSet(excludeIds);
```

Membership is asked as `skip.has(String(linkId))`, so a caller's `Set` of **raw numbers** matches nothing. That is not an exotic shape — it is precisely what you get from `new Set(railSlot.linkIds)` or `new Set(inputLinkIds(node))`, because both id readers deliberately return **raw** ids (they have to; they feed the store). The exclusion evaporates silently and a link that existed **before** the mutation is credited to the current call — the "two states, one answer" defect the post-state check exists to remove.

## Reproduction (on `origin/main`, before the change)

The reviewer cited the rail finder; the inbound finder leaks identically:

```
findLandedRailLink(g,  {linkIds:[4]}, {id:9}, 0, "output", new Set([4]))
  -> { linkId: 4 }                    // must be null
findLandedInboundLink(g2, {id:1}, 0, target, new Set([5]))
  -> { linkId: 5, inputIndex: 0 }     // must be null
```

Both credit a **pre-existing** link to the call. Array and string-`Set` forms already behaved correctly, which is exactly why the fixtures never caught it.

## The fix

```js
const skip = linkIdExclusionSet(excludeIds);
```

on both paths. **`linkIdExclusionSet` needed no extension**: it iterates `ids ?? []`, so a `Set` was already an accepted input, and re-normalising a `Set` of strings is idempotent. The `instanceof Set` branch was a pure optimisation that bought nothing and cost the invariant. Its doc block now states that it takes any iterable and *why* a call site must not skip it, so the next reader does not reinstate the branch.

After: both calls above return `null`; array / string-`Set` / `null` forms are unchanged.

## The pin

The reviewer's key observation was that swapping the panel call sites to `new Set(...)` still passed **30/30** — the suite was blind. This PR adds a test that passes `new Set([4])` and `new Set([5])` to both finders and asserts the pre-existing link is **not** credited, with a no-exclusion pre-condition assertion so the test cannot pass by finding nothing at all.

Verified by reverting **only** the two-line fix (test kept):

```
ℹ tests 31   ℹ pass 30   ℹ fail 1
AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:
  actual: { linkId: 4 },
  expected: null,
```

— the reviewer's reproduction verbatim. With the fix restored: 31/31.

## Verification

- `browser_tests/unit/connect-throw-verdict.test.mjs`: **31/31** (was 30/30).
- `npm run test:unit`: **5384 pass / 0 fail / 1 todo** — includes `i18n-check`, `i18n-render-check`, `check-tool-vocabulary` (OK, 34 literals across 176 shipped JS), `check-panel-scope` (OK — every name resolves).
- `tsc --noEmit`: clean.
- Rebased onto `df7821e6` and re-run; `929a4b0d..origin/main` touches neither file.
- **No Playwright coverage exists for these paths** — no spec references `expose_subgraph_*`. That is precisely why these unit end-to-end tests are the coverage that holds them, and why an unpinned helper here is worth a PR of its own.

Scope is two lines of logic plus the comment that explains them, and one test. No behaviour change for any current caller.

Not marked as closing any issue — #1272 is already closed and stays closed; this is follow-up hardening of the code that shipped under it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
