### PR TITLE
fix(1721): refuse workflow names with path separators instead of silently nesting

### DIFF
--- a/browser_tests/unit/workflow-save.test.mjs
+++ b/browser_tests/unit/workflow-save.test.mjs
@@ -6,7 +6,9 @@ import {
   saveActiveWorkflow,
   describeSaveOutcome,
   classifyOriginalOnDisk,
-  diskExistenceFromStatus
+  diskExistenceFromStatus,
+  nameContainsPathSeparator,
+  pathSeparatorNameError
 } from '../../web/js/lib/workflow-save.js'
 
 // A minimal ComfyUI workflow-service double that records what was called and
@@ -308,6 +310,92 @@ test('rejects an explicit whitespace-only name and leaves the source untouched (
   assert.deepEqual(svc.calls, [])
   assert.ok(svc.disk.has('workflows/Foo.json'))
   assert.equal(svc.disk.size, 1)
+})
+
+test('rejects an explicit name with a forward slash — never creates a nested directory (comfyui-mcp#1721)', async () => {
+  // The reported repro: "LTX-2.5 Inpaint HDR (EXR/VFX)" silently created a
+  // directory "LTX-2.5 Inpaint HDR (EXR" holding "VFX).json" and reported only
+  // the trailing segment as the saved name.
+  const active = {
+    path: 'workflows/Foo.json',
+    filename: 'Foo.json',
+    directory: 'workflows',
+    isPersisted: true,
+    isTemporary: false
+  }
+  const svc = makeService({ files: [active.path], active })
+
+  await assert.rejects(
+    () => saveActiveWorkflow(svc, 'LTX-2.5 Inpaint HDR (EXR/VFX)', {}),
+    /path separator/
+  )
+
+  // Nothing was written, moved, or nested — the source stands as-is.
+  assert.deepEqual(svc.calls, [])
+  assert.ok(svc.disk.has('workflows/Foo.json'))
+  assert.equal(svc.disk.size, 1)
+})
+
+test('rejects an explicit name with a BACKSLASH — a separator on Windows (comfyui-mcp#1721)', async () => {
+  const active = {
+    path: 'workflows/Foo.json',
+    filename: 'Foo.json',
+    directory: 'workflows',
+    isPersisted: true,
+    isTemporary: false
+  }
+  const svc = makeService({ files: [active.path], active })
+
+  await assert.rejects(() => saveActiveWorkflow(svc, 'A\\B', {}), /path separator/)
+  assert.deepEqual(svc.calls, [])
+  assert.equal(svc.disk.size, 1)
+})
+
+test('a slashed name is refused even on a FIRST save of a never-persisted tab (comfyui-mcp#1721)', async () => {
+  const active = {
+    path: 'workflows/Unsaved Workflow.json',
+    filename: 'Unsaved Workflow.json',
+    directory: 'workflows',
+    isPersisted: false,
+    isTemporary: true
+  }
+  const svc = makeService({ files: [], active })
+
+  await assert.rejects(() => saveActiveWorkflow(svc, 'My Workflow (A/B)', {}), /path separator/)
+  assert.deepEqual(svc.calls, [])
+  assert.equal(svc.disk.size, 0)
+})
+
+test('a workflow legitimately living in a SUBFOLDER still saves in place (comfyui-mcp#1721)', async () => {
+  // The guard rejects separators in the caller-supplied NAME only — a tab whose
+  // own directory is a subfolder must not become unsaveable.
+  const active = {
+    path: 'workflows/sub/Foo.json',
+    filename: 'Foo.json',
+    directory: 'workflows/sub',
+    isPersisted: true,
+    isTemporary: false
+  }
+  const svc = makeService({ files: [active.path], active })
+
+  const saved = await saveActiveWorkflow(svc, undefined, {})
+
+  assert.equal(saved, 'Foo')
+  assert.ok(svc.calls.some((c) => c[0] === 'saveWorkflow'), 'saved in place')
+  assert.deepEqual([...svc.disk], ['workflows/sub/Foo.json'])
+})
+
+test('nameContainsPathSeparator / pathSeparatorNameError (comfyui-mcp#1721)', () => {
+  assert.equal(nameContainsPathSeparator('My Workflow (A/B)'), true)
+  assert.equal(nameContainsPathSeparator('A\\B'), true)
+  assert.equal(nameContainsPathSeparator('My Workflow A-B'), false)
+  assert.equal(nameContainsPathSeparator(''), false)
+  assert.equal(nameContainsPathSeparator(undefined), false)
+
+  const err = pathSeparatorNameError('A/B', 'rename')
+  assert.match(err.message, /refusing to rename/)
+  assert.match(err.message, /"A\/B"/)
+  assert.match(err.message, /Nothing was written/)
 })
 
 test('double-extension Save-As to the base name still COPIES, never renames (#226)', async () => {

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -558,6 +558,8 @@ import {
   classifyOriginalOnDisk,
   diskExistenceFromStatus,
   normalizePath,
+  nameContainsPathSeparator,
+  pathSeparatorNameError,
 } from "./lib/workflow-save.js";
 import { createRunCompletionTracker } from "./lib/run-completion.js";
 import {
@@ -17258,6 +17260,9 @@ const GRAPH_TOOL_EXECUTORS = {
     const target = path ? resolveWorkflowSelectorTarget("workflow_rename", s, path) : s.activeWorkflow;
     if (!target) throw new Error("no target workflow");
     const clean = name.replace(/\.json$/i, "");
+    // comfyui-mcp#1721 — a slashed rename target would nest the file into a new
+    // subdirectory (the target is `${dir}${clean}.json`); refuse, never misfile.
+    if (nameContainsPathSeparator(clean)) throw pathSeparatorNameError(clean, "rename");
     const slash = target.path ? target.path.lastIndexOf("/") : -1;
     const dir = slash >= 0 ? target.path.slice(0, slash + 1) : "workflows/";
     try {

--- a/web/js/lib/workflow-save.js
+++ b/web/js/lib/workflow-save.js
@@ -37,6 +37,29 @@ function workflowExt(wf) {
   return wf?.initialMode === "app" ? APP_JSON_EXT : JSON_EXT;
 }
 
+/** True when a workflow NAME carries a path separator ("/" or "\"). A name is a
+ *  bare filename, not a path: every save/rename target is built by concatenating
+ *  the name onto the workflow's own directory (targetPath / the rename executor),
+ *  so a slashed name silently becomes a NESTED path — "My Workflow (A/B)" creates
+ *  a directory "My Workflow (A" holding "B).json" and reports only the trailing
+ *  segment as the saved name (comfyui-mcp#1721). Callers REFUSE such a name
+ *  rather than misfile the workflow. A name with no separator is untouched, so
+ *  workflows legitimately living in subfolders still save in place. */
+export function nameContainsPathSeparator(name) {
+  return /[\\/]/.test(String(name ?? ""));
+}
+
+/** The refusal both the save and rename paths raise for a slashed name
+ *  (comfyui-mcp#1721) — one wording so the remedy is stated once. */
+export function pathSeparatorNameError(name, verb) {
+  return new Error(
+    `refusing to ${verb}: the name ${JSON.stringify(String(name ?? ""))} contains a path ` +
+      `separator ("/" or "\\"), which would silently create a nested directory under the ` +
+      `workflows folder instead of one file (comfyui-mcp#1721). Pass a bare filename ` +
+      `(e.g. "My Workflow A-B"). Nothing was written.`,
+  );
+}
+
 /** The path ComfyUI would actually persist `base` to for this workflow — its own
  *  directory + the mode-correct extension (mirrors appendWorkflowJsonExt +
  *  workflow.directory). Used to classify a save as in-place vs Save-As by the
@@ -600,6 +623,13 @@ export async function saveActiveWorkflow(
   const explicit = typeof name === "string";
   if (explicit && !baseName(name)) {
     throw new Error("name must not be blank — pass a non-whitespace workflow name");
+  }
+  // comfyui-mcp#1721 — refuse a slashed EXPLICIT name BEFORE any probe or write.
+  // Only the caller-supplied name is checked: the current/auto-minted names are
+  // bare filenames by construction, and a workflow already living in a subfolder
+  // must keep saving in place.
+  if (explicit && nameContainsPathSeparator(name)) {
+    throw pathSeparatorNameError(name, "save");
   }
 
   const wasUnsaved = wf.isTemporary === true || wf.isPersisted === false;


### PR DESCRIPTION
Closes artokun/comfyui-mcp#1721.

The issue lives in the comfyui-mcp tracker, but the root cause is in **this** repo: the name-to-path concatenation happens in the panel extension's save/rename code.

## Root cause

Every save/rename target path is built by concatenating the caller-supplied name verbatim onto the workflow's directory — `targetPath()` in `web/js/lib/workflow-save.js` for `panel_save_workflow`, and `` `${dir}${clean}.json` `` in the `workflow_rename` executor for `panel_rename_workflow`. Neither validated the name, so a forward slash (or backslash) was treated as a path separator: saving `"LTX-2.5 Inpaint HDR (EXR/VFX)"` silently created a directory `LTX-2.5 Inpaint HDR (EXR` under `workflows/` holding `VFX).json`, and the reply's `workflow` field reported only the trailing segment `VFX)`. Once the tab's path context sat inside the stray directory, subsequent renames and Save-As kept writing there — neither tool could return the workflow to the workflows root without shell access.

The recently shipped save-path guard (panel#1315) is unrelated: it fences wrong-canvas overwrites (the stamp-vs-destination contradiction), not name-derived path nesting — confirmed before writing this fix.

## Fix — refuse loudly, fail closed

- `web/js/lib/workflow-save.js`: new exported `nameContainsPathSeparator()` predicate and `pathSeparatorNameError()` refusal builder; `saveActiveWorkflow` rejects an explicit name containing `/` or `\` **before any probe or write**, with a message that names the defect and the remedy ("pass a bare filename"). Only the caller-supplied name is checked — the current/auto-minted names are bare filenames by construction, and a workflow legitimately living in a subfolder still saves in place (covered by a regression test).
- `web/js/comfyui-mcp-panel.js` (`workflow_rename`): the same refusal via the shared helper, before any `renameWorkflow` call.

## Verification

- `npm ci` — clean, 0 vulnerabilities.
- `node --test browser_tests/unit/workflow-save.test.mjs` — 87/87 pass, including 5 new tests: forward-slash refusal (the reported repro shape, nothing written), backslash refusal, slashed name refused even on a first save of a never-persisted tab, a subfolder workflow still saving in place, and the predicate/error-builder unit test.
- Full `npm run test:unit` (i18n-check + i18n-render-check + check-tool-vocabulary + check-panel-scope + all unit tests) — 5398 pass, 0 fail, 1 todo (pre-existing).
- `npm run typecheck` (`tsc --noEmit`) — clean.

## Follow-ups (out of scope)

- Workflows already stranded inside stray directories still need manual relocation (or `panel_load_workflow` from an absolute path); this fix stops new strandings.
- A slash-intolerance hint could also be added to the `panel_save_workflow` / `panel_rename_workflow` tool descriptions on the MCP-server side; left out to keep this fix minimal and in the repo where the root cause lives.
