### PR TITLE
fix(1358 followup): the load watch reports whether it was ENTERED, not just installed

### DIFF
--- a/browser_tests/unit/open-completed-restore.test.mjs
+++ b/browser_tests/unit/open-completed-restore.test.mjs
@@ -398,12 +398,14 @@ test("panel#1283 an uninstrumentable frontend answers null, never false", () => 
 });
 
 test("panel#1283 the fold is true only when BOTH halves looked and neither saw a throw", () => {
-  assert.equal(loadRestoreCompleted({ nodeIsolation: { failures: [] }, graphWatch: { throws: [] } }), true);
+  // `entered: 1` is part of "looked" — see the F1 section at the foot of this file.
+  const watched = (throws) => ({ throws, entered: 1 });
+  assert.equal(loadRestoreCompleted({ nodeIsolation: { failures: [] }, graphWatch: watched([]) }), true);
   assert.equal(
-    loadRestoreCompleted({ nodeIsolation: { failures: [{ id: 3 }] }, graphWatch: { throws: [] } }),
+    loadRestoreCompleted({ nodeIsolation: { failures: [{ id: 3 }] }, graphWatch: watched([]) }),
     false,
   );
-  assert.equal(loadRestoreCompleted({ nodeIsolation: { failures: [] }, graphWatch: { throws: ["x"] } }), false);
+  assert.equal(loadRestoreCompleted({ nodeIsolation: { failures: [] }, graphWatch: watched(["x"]) }), false);
 });
 
 test("panel#1283 both wraps compose: a node throw is contained, the graph throw is not", () => {
@@ -413,6 +415,10 @@ test("panel#1283 both wraps compose: a node throw is contained, the graph throw 
   };
   const nodeIsolation = installNodeConfigureIsolation(LG);
   const graphWatch = installGraphConfigureWatch(LG);
+  // The graph restore runs — so the watch is ENTERED and this is not the un-watched
+  // case the F1 section below is about.
+  assert.equal(LG.LGraph.prototype.configure({ nodes: [] }), "graph-ok");
+  assert.equal(graphWatch.entered, 1);
   // The node throw is swallowed and RECORDED (#1260's contract, unchanged)…
   assert.equal(LG.LGraphNode.prototype.configure({ id: 7, type: "FaceDetailer" }), undefined);
   assert.equal(nodeIsolation.failures.length, 1);
@@ -671,4 +677,200 @@ test("panel#1283 wiring: a node the retry could not heal is still disclosed on t
   const repaint = src.slice(repaintAt, src.indexOf("} catch (err)", repaintAt));
   assert.match(repaint, /retryNodeRestores\(app\?\.graph, containedNodeFailureList\)/);
   assert.match(repaint, /openRestoreFailures = retry\.failed;/);
+});
+
+// ── F1: INSTALLED IS NOT ENTERED (post-merge review of #1358) ────────────────
+
+/**
+ * #1358's own two-states-one-answer fold, one level down from the one it fixed.
+ *
+ * The fold licensed "the restore ran to completion" off two EMPTY records. Empty
+ * means "nothing threw" — or "the wrapper was installed on a method nothing called".
+ * Wrapping a prototype proves the method EXISTS; it proves nothing about whether
+ * this frontend's restore went THROUGH it.
+ *
+ * No test written against the wrappers can see that, because a test that drives a
+ * wrapper always enters it. This fixture deliberately does not: the root graph
+ * carries its OWN `configure` and never calls `super`, which is a frontend
+ * restructure the panel does not control. The abort then happens where nothing is
+ * watching, both records stay empty, and a genuinely partial load is waved through
+ * as "normalization" — precisely the harm #1358 exists to prevent.
+ */
+function frontendWhoseRootBypassesLGraphPrototype() {
+  class LGraphNode {
+    constructor(id, type) {
+      this.id = id;
+      this.type = type;
+      this.widgets_values = ["construction-default"];
+    }
+    configure(info) {
+      this.widgets_values = info.widgets_values;
+      return "node-ok";
+    }
+  }
+  class LGraph {
+    // The prototype method `installGraphConfigureWatch` wraps. Present and wrappable —
+    // and never reached by the root graph's restore on this frontend.
+    configure() {
+      throw new Error("LGraph.prototype.configure was reached — the fixture is wrong");
+    }
+  }
+  class RootGraph extends LGraph {
+    constructor(nodes) {
+      super();
+      this.nodes = nodes;
+    }
+    // Its OWN restore, with no `super.configure`. The node loop still dispatches
+    // through `LGraphNode.prototype`, so the NODE wrapper is entered — which is why
+    // a node-level counter would not have caught this.
+    configure(state) {
+      for (const info of state.nodes) {
+        // The abort. Node 2 and everything after it keep construction defaults.
+        // `loadGraphData`'s own catch swallows this, exactly as production does.
+        if (info.id === 2) throw new Error("reroute validation blew up mid-restore");
+        this.nodes.find((n) => n.id === info.id)?.configure(info);
+      }
+    }
+    serialize() {
+      return stateOf(
+        this.nodes.map((n) => node(n.id, n.type, { widgets_values: n.widgets_values })),
+      );
+    }
+  }
+  return { LG: { LGraph, LGraphNode }, RootGraph };
+}
+
+/** Run one load on that frontend, exactly as `workflow_open` runs it. */
+function runBypassedLoad() {
+  const { LG, RootGraph } = frontendWhoseRootBypassesLGraphPrototype();
+  const root = new RootGraph([new LG.LGraphNode(1, "KSampler"), new LG.LGraphNode(2, "FaceDetailer")]);
+  const payload = stateOf([
+    node(1, "KSampler", { widgets_values: ["authored-1"] }),
+    node(2, "FaceDetailer", { widgets_values: ["authored-2"] }),
+  ]);
+  const nodeIsolation = installNodeConfigureIsolation(LG);
+  const graphWatch = installGraphConfigureWatch(LG);
+  try {
+    try {
+      root.configure(payload);
+    } catch {
+      // `loadGraphData`'s own catch. The restore aborted; nothing propagates.
+    }
+  } finally {
+    nodeIsolation.restore();
+    graphWatch.restore();
+  }
+  return { root, payload, nodeIsolation, graphWatch };
+}
+
+test("panel#1283 F1: a watch installed on a method the restore never calls is UNKNOWN, not completed", () => {
+  const { root, nodeIsolation, graphWatch } = runBypassedLoad();
+  assert.ok(nodeIsolation && graphWatch, "both wraps INSTALL on this frontend — that is the trap");
+
+  // Everything #1358 looked at reads "clean".
+  assert.deepEqual(nodeIsolation.failures, [], "no node throw was contained…");
+  assert.deepEqual(graphWatch.throws, [], "…and no graph throw was seen");
+  // …because nothing watched. The NODE wrapper was entered — gating on it would not
+  // have caught this — and the graph watch was not.
+  assert.equal(nodeIsolation.entered, 1, "the node wrapper ran for the one node that restored");
+  assert.equal(graphWatch.entered, 0, "the graph watch was installed and NEVER entered");
+  // And the load really was partial: node 2 sits at construction defaults.
+  assert.deepEqual(root.serialize().nodes[1].widgets_values, ["construction-default"]);
+
+  // The fold must therefore say UNKNOWN. #1358 as shipped said `true` here.
+  assert.equal(loadRestoreCompleted({ nodeIsolation, graphWatch }), null);
+});
+
+test("panel#1283 F1: the consuming ground does not fire, and `null` degrades to pre-#1358 behaviour", () => {
+  const { root, payload, nodeIsolation, graphWatch } = runBypassedLoad();
+  const observed = loadRestoreCompleted({ nodeIsolation, graphWatch });
+  assert.equal(observed, null);
+
+  const proof = graphRootReproducesStateContent({ rootGraph: root, state: payload, loadRanToCompletion: observed });
+  assert.equal(proof.proven, false);
+  assert.equal(proof.normalizedOnly, false, "a load nobody watched may not be called normalization");
+  assert.deepEqual(proof.normalizedFields, []);
+
+  // THE REFUTATION, in the same test. The ONLY input that differs is the observation:
+  // with the answer #1358 shipped, the lost widget value is waved through.
+  const asShipped = graphRootReproducesStateContent({ rootGraph: root, state: payload, loadRanToCompletion: true });
+  assert.equal(asShipped.normalizedOnly, true, "…which is exactly what the shipped fold answered");
+  assert.deepEqual(asShipped.normalizedFields, ["widgets_values"]);
+
+  // `null`, not `false`: the consumer's ground is licensed on `=== true`, and #1623's
+  // WEAKER ground is vetoed on `=== false`. So unknown must degrade to the pre-#1358
+  // path — identical to a caller that never asked the question — and not to a new
+  // refusal that #1358 was never entitled to introduce.
+  const neverAsked = graphRootReproducesStateContent({ rootGraph: root, state: payload });
+  assert.equal(proof.presentationOnly, neverAsked.presentationOnly);
+  assert.deepEqual(proof.fields, neverAsked.fields);
+  assert.equal(
+    graphRootReproducesStateContent({ rootGraph: root, state: payload, loadRanToCompletion: false })
+      .presentationOnly,
+    false,
+    "…and `false` still vetoes it, which is the behaviour `null` must NOT borrow",
+  );
+});
+
+test("panel#1283 F1: gating on the NODE count would manufacture a false unknown", () => {
+  // This is why the veto is `graphWatch.entered` alone. An empty workflow restores
+  // through the graph watch and configures NO nodes: `nodeIsolation.entered === 0` is
+  // the correct reading there, and the load demonstrably ran to the end.
+  const LG = fakeLG();
+  const nodeIsolation = installNodeConfigureIsolation(LG);
+  const graphWatch = installGraphConfigureWatch(LG);
+  assert.equal(LG.LGraph.prototype.configure({ nodes: [] }), "graph-ok");
+  nodeIsolation.restore();
+  graphWatch.restore();
+  assert.equal(nodeIsolation.entered, 0, "no node configured — an empty workflow");
+  assert.equal(graphWatch.entered, 1);
+  assert.equal(loadRestoreCompleted({ nodeIsolation, graphWatch }), true, "…and that IS a completed restore");
+});
+
+test("panel#1283 F1: a deactivated wrapper counts nothing — a pass-through is not an observation", () => {
+  const LG = fakeLG();
+  const inner = installGraphConfigureWatch(LG);
+  const outer = installGraphConfigureWatch(LG);
+  // Out of order, so the deactivated inner stays in the chain as a pass-through.
+  inner.restore();
+  assert.equal(LG.LGraph.prototype.configure({ nodes: [] }), "graph-ok");
+  assert.equal(outer.entered, 1, "the active wrapper counted its entry");
+  assert.equal(inner.entered, 0, "the deactivated one is a pass-through and counts nothing");
+  outer.restore();
+});
+
+test("panel#1283 F1: a handle that cannot say whether it ran is UNKNOWN, not a pass", () => {
+  const clean = { failures: [] };
+  for (const graphWatch of [
+    { throws: [] }, // no counter at all — a hand-rolled or stale handle
+    { throws: [], entered: 0 },
+    { throws: [], entered: -1 },
+    { throws: [], entered: "1" },
+    { throws: [], entered: null },
+    { throws: [], entered: true },
+    { throws: [], entered: Number.NaN }, // `< 1` would have let this through
+  ]) {
+    assert.equal(
+      loadRestoreCompleted({ nodeIsolation: clean, graphWatch }),
+      null,
+      `entered=${String(graphWatch.entered)} must not license a completion`,
+    );
+  }
+  assert.equal(loadRestoreCompleted({ nodeIsolation: clean, graphWatch: { throws: [], entered: 1 } }), true);
+  assert.equal(loadRestoreCompleted({ nodeIsolation: clean, graphWatch: { throws: [], entered: 12 } }), true);
+});
+
+test("panel#1283 F1: the real handles expose `entered` as a live count, and a throw still counts", () => {
+  const LG = fakeLG();
+  LG.LGraph.prototype.configure = function () {
+    throw new Error("groups blew up");
+  };
+  const watch = installGraphConfigureWatch(LG);
+  assert.equal(watch.entered, 0, "installed, not yet entered");
+  assert.throws(() => LG.LGraph.prototype.configure({}));
+  // Counted on ENTRY: an aborted restore is the case the watch exists for, and a
+  // counter bumped on the way out would read 0 for exactly it.
+  assert.equal(watch.entered, 1);
+  assert.equal(loadRestoreCompleted({ nodeIsolation: { failures: [] }, graphWatch: watch }), false);
+  watch.restore();
 });

--- a/browser_tests/unit/open-completed-restore.test.mjs
+++ b/browser_tests/unit/open-completed-restore.test.mjs
@@ -27,7 +27,8 @@
  * Adding them one at a time is a treadmill: the next pack invents the next field.
  *
  * THE MECHANISM, AND WHY IT IS ANSWERABLE NOW. `resolveOpenRebindVerdict` names
- * exactly ONE reason a content difference might mean loss:
+ * exactly ONE reason a content difference might mean loss (quoted as that comment read
+ * before this landed — it now points at the discriminator instead):
  *
  *   "`loadGraphData` catches a `configure()` failure and returns. A throw in that
  *    second pass leaves the complete node id/type set, the links, and the panel's
@@ -45,7 +46,7 @@
  * `installNodeConfigureIsolation` records per-node throws (#1260, on `graph_load`),
  * and `installGraphConfigureWatch` (added here) records a throw out of the restore.
  * `workflow_open` now installs both, so `loadRanToCompletion` REFUTES that hypothesis
- * per load, by observation. That is the discriminator the comment says does not exist.
+ * per load, by observation. That is the discriminator the comment said did not exist.
  *
  * WHAT THIS DOES NOT CLAIM, and the tests below hold the line: it never says the
  * differing values are the file's values. It says the restore did not stop early, so

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -16589,8 +16589,8 @@ const GRAPH_TOOL_EXECUTORS = {
             //
             // `resolveOpenRebindVerdict` refuses this open on one named hypothesis: a
             // mid-`configure()` throw leaves the node id/type set, the links and the
-            // marker over nodes that lost their values, "and no discriminator available
-            // to the panel separates them" from a normalization. These two wraps ARE that
+            // marker over nodes that lost their values, which its comment once called
+            // indistinguishable from a normalization. These two wraps ARE the
             // discriminator, and they are the whole of it — measured against the frontend
             // source, `LGraph.prototype.configure` runs its node pass with no try/catch
             // and nothing between it and `loadGraphData`'s own catch adds one, so a throw

--- a/web/js/lib/graph-binding.js
+++ b/web/js/lib/graph-binding.js
@@ -959,8 +959,10 @@ function sizeDifferenceIsHeightOnly(expectedNodes, actualNodes) {
  * `widgets_values`, `properties`, `title`, `flags`, `mode`, `inputs` and `outputs`
  * are every one of them OUTSIDE `COSMETIC_NODE_FIELDS`, and `configure()` writes
  * them in the same pass as the cosmetic five — so a load that died mid-configure
- * answers false on the first node it reached. The discriminator that comment says
- * does not exist is WHICH FIELDS DIFFER, and the panel already computes it.
+ * answers false on the first node it reached. One discriminator that comment once said
+ * did not exist is WHICH FIELDS DIFFER, and the panel already computes it. (The other,
+ * an observation of the load itself, is `openContentDifferenceIsCompletedLoadNormalization`
+ * below.)
  *
  * It is deliberately NOT a widening of `RECOMPUTED_NODE_FIELDS`. That set licenses
  * "the content was reproduced", which is why it demands a characterised rewrite per
@@ -1017,7 +1019,8 @@ export function openContentDifferenceIsPresentationOnly({ comparable, surfaces, 
  * `resolveOpenRebindVerdict` states exactly one mechanism for why a content
  * difference might mean data loss: `loadGraphData` catches a mid-`configure()` throw
  * and returns, leaving the node id/type set and the marker over nodes that lost their
- * values. It then says no discriminator separates that from normalization.
+ * values. Before panel#1283/#1358 it added that no discriminator separates that from
+ * normalization; that sentence is gone from it now and points back here instead.
  *
  * There is one, and the panel already owns half of it. `installNodeConfigureIsolation`
  * (#1260) records every per-node `configure` throw; `installGraphConfigureWatch`
@@ -1790,20 +1793,32 @@ export const OPEN_REBIND_STATUS = Object.freeze({
  * from the bytes handed in. It is therefore genuinely a false negative to deny the
  * OPEN for it, and softening it was tried here.
  *
- * It was reverted, because the two cases cannot currently be told apart. LiteGraph
- * creates every node (with its id and type) and THEN configures each one, and
- * `loadGraphData` catches a `configure()` failure and returns. A throw in that
+ * It was reverted the first time, because the two cases could not then be told apart.
+ * LiteGraph creates every node (with its id and type) and THEN configures each one,
+ * and `loadGraphData` catches a `configure()` failure and returns. A throw in that
  * second pass leaves the complete node id/type set, the links, and the panel's
  * marker — written by `_configureBase` before any node is built — over nodes that
  * silently LOST their widget values and properties. That is byte-for-byte the same
- * observation as "the loader normalized the widget values", and no discriminator
- * available to the panel separates them. Reporting it as a completed open would
- * fabricate a success over data loss, which is worse than the false negative.
+ * observation as "the loader normalized the widget values". Reporting it as a
+ * completed open would fabricate a success over data loss, which is worse than the
+ * false negative.
  *
- * So `unknown` stays `unknown` here — deliberately, and it is the honest answer to a
- * question this code cannot settle. What the status split buys is that the
- * DISCLOSURE can now say the binding IS proven and only the content is unconfirmed,
- * instead of implying the canvas may be the wrong workflow.
+ * THE DISCRIMINATOR NOW EXISTS (panel#1283 / #1358), and it is not a field-name
+ * judgement — it is an observation of THIS load. `installNodeConfigureIsolation` and
+ * `installGraphConfigureWatch` (web/js/lib/load-restore-isolation.js) wrap the only
+ * two places the restore can abort, `loadRestoreCompleted` folds them into
+ * true/false/null, and `openContentDifferenceIsCompletedLoadNormalization` (above)
+ * consumes it. In one line: **a mid-`configure()` abort is a THROW, and a load whose
+ * throws the panel watched for and did not see did not abort.** Only an explicit
+ * `true` licenses anything — `false` (something threw) and `null` (the watch was
+ * absent, or installed on a method this frontend's restore never called) both keep
+ * the old, refusing path.
+ *
+ * `resolveOpenRebindVerdict` itself is unchanged and still says `unknown` on
+ * `contentMatches !== true`: the discriminator is applied UPSTREAM, where the content
+ * proof is computed, so what arrives here is already the answer. What the status split
+ * buys is that the DISCLOSURE can say the binding IS proven and only the content is
+ * unconfirmed, instead of implying the canvas may be the wrong workflow.
  *
  * Every part is compared against `true` explicitly: an unreadable observation
  * arrives as null/undefined and must count as NOT proven, never as proven.

--- a/web/js/lib/load-restore-isolation.js
+++ b/web/js/lib/load-restore-isolation.js
@@ -130,7 +130,8 @@ export function retryNodeRestores(graph, failures) {
  * ## Why this observation has to exist
  *
  * `resolveOpenRebindVerdict` refuses to report an open applied whenever the graph
- * on the canvas is not byte-reproducible from the payload, and states its reason:
+ * on the canvas is not byte-reproducible from the payload. Its reason, as that comment
+ * read BEFORE this observation existed (it now points here instead):
  *
  *   "LiteGraph creates every node (with its id and type) and THEN configures each
  *    one, and `loadGraphData` catches a `configure()` failure and returns. A throw
@@ -155,8 +156,8 @@ export function retryNodeRestores(graph, failures) {
  * reroute validation, groups, execution order, proxy-widget migration).
  *
  * Both are observable. `installNodeConfigureIsolation` above already records the
- * first, for #1260. This records the second. Together they answer the question the
- * comment says cannot be answered: **did any part of this restore abort?**
+ * first, for #1260. This records the second. Together they answer the question that
+ * comment said could not be answered: **did any part of this restore abort?**
  *
  * ## Why the pair is exhaustive and the node wrap alone is not
  *

--- a/web/js/lib/load-restore-isolation.js
+++ b/web/js/lib/load-restore-isolation.js
@@ -42,6 +42,13 @@ function errorText(err) {
  * (or the frontend) may have chained on top, and restoring over that would
  * silently drop THEIR wrapper. A deactivated wrapper left in a chain is a
  * pass-through, so every restore order stays correct.
+ *
+ * The handle also reports `entered`: how many times the wrapper actually RAN
+ * while active. Installed is not entered — a frontend whose nodes do not resolve
+ * `configure` through `LGraphNode.prototype` leaves this at 0 while every field
+ * above still reads like a clean load. It is a DIAGNOSTIC here and nothing gates
+ * on it; `loadRestoreCompleted` explains why the graph-level count is the one
+ * that licenses the verdict and this one must not.
  */
 export function installNodeConfigureIsolation(LG) {
   const proto = LG?.LGraphNode?.prototype;
@@ -49,8 +56,10 @@ export function installNodeConfigureIsolation(LG) {
   const original = proto.configure;
   const failures = [];
   let active = true;
+  let entered = 0;
   const wrapped = function (info) {
     if (!active) return original.call(this, info);
+    entered += 1;
     try {
       return original.call(this, info);
     } catch (err) {
@@ -66,6 +75,9 @@ export function installNodeConfigureIsolation(LG) {
   proto.configure = wrapped;
   return {
     failures,
+    get entered() {
+      return entered;
+    },
     restore() {
       active = false;
       if (proto.configure === wrapped) proto.configure = original;
@@ -175,6 +187,23 @@ export function retryNodeRestores(graph, failures) {
  * configure). The caller must read null as UNKNOWN — never as "nothing threw" —
  * because a frontend this cannot instrument is exactly one whose restore it cannot
  * vouch for.
+ *
+ * ## INSTALLED is not ENTERED — why the handle counts `entered`
+ *
+ * Wrapping a prototype method proves the method exists. It does NOT prove the
+ * restore went THROUGH it. On a frontend where the root graph stops resolving
+ * `configure` via `LGraph.prototype` — an own-property `configure` on the graph
+ * instance, or a subclass whose `configure` does not call `super` — the wrap
+ * installs, is never entered, and `throws` stays empty for the whole load. An
+ * empty `throws` then means either "nothing threw" or "nothing was watched", and
+ * those are the two states this module exists to keep apart. A genuinely partial
+ * load would be waved through as normalization, which is precisely the harm the
+ * observation was added to prevent.
+ *
+ * So `entered` counts every call that reached the ACTIVE wrapper (a deactivated
+ * one is a pass-through and counts nothing — an entry after `restore()` is not
+ * evidence about the load). `entered === 0` means the question was never asked,
+ * and `loadRestoreCompleted` folds it to UNKNOWN.
  */
 export function installGraphConfigureWatch(LG) {
   const proto = LG?.LGraph?.prototype;
@@ -182,8 +211,13 @@ export function installGraphConfigureWatch(LG) {
   const original = proto.configure;
   const throws = [];
   let active = true;
+  let entered = 0;
   const wrapped = function (...args) {
     if (!active) return original.apply(this, args);
+    // BEFORE the try. This counts ENTRY, not success: a call that throws was
+    // still watched, and a counter incremented on the way out would read 0 for
+    // exactly the aborted load this watch exists to see.
+    entered += 1;
     try {
       return original.apply(this, args);
     } catch (err) {
@@ -196,6 +230,9 @@ export function installGraphConfigureWatch(LG) {
   proto.configure = wrapped;
   return {
     throws,
+    get entered() {
+      return entered;
+    },
     restore() {
       active = false;
       // Only when this wrapper is still the installed one — the same rule
@@ -209,19 +246,53 @@ export function installGraphConfigureWatch(LG) {
 /**
  * Fold the two observations into ONE answer with THREE states.
  *
- * `true`  — every wrap was installed AND nothing threw: the restore ran to the end.
+ * `true`  — the graph restore RAN THROUGH the watch and nothing threw: it ran to
+ *           the end.
  * `false` — something threw. The partial-load hypothesis is LIVE for this load.
- * `null`  — at least one wrap could not be installed, so the question was never
- *           asked. Unknown, and the caller must treat it as such: a load that
- *           could not be watched proves nothing about whether it completed.
+ * `null`  — the question was never asked. Either a wrap could not be installed, or
+ *           it was installed on a method the restore never called. Unknown, and the
+ *           caller must treat it as such: a load that could not be watched proves
+ *           nothing about whether it completed.
  *
  * The null case is the point. Collapsing "nothing threw" and "nobody looked" into
  * one boolean is the exact defect this whole family is about, one level down.
+ *
+ * ## Why `graphWatch.entered` gates the verdict
+ *
+ * The first cut of this fold asked only whether both handles EXIST and neither
+ * recorded anything. Existence is an answer about the prototype, not about the
+ * load: install on a method nothing calls and both records stay empty, which is
+ * byte-identical to a clean restore. That is the same two-states-one-answer fold
+ * one level further down, and no test could see it, because a test that drives the
+ * wrappers always enters them.
+ *
+ * An ABSENT or non-numeric count is unknown too, not a pass. A handle that cannot
+ * say whether it ran has not established that it ran.
+ *
+ * ## Why `nodeIsolation.entered` does NOT, and must not
+ *
+ * Two reasons, and they point the same way.
+ *
+ * 1. Zero node configures is a LEGITIMATE completed restore — an empty workflow,
+ *    or one whose nodes all failed to construct. Gating on it would answer UNKNOWN
+ *    for loads that demonstrably ran to the end: a false negative manufactured by
+ *    the guard, which is the fix being worse than the bug.
+ * 2. It is not needed. The node wrapper is a CONTAINMENT, and the graph watch is
+ *    the backstop underneath it: a node whose `configure` never routes through
+ *    `LGraphNode.prototype` still throws INTO `LGraph.prototype.configure`'s node
+ *    loop, which has no try/catch of its own — so the abort escapes into the graph
+ *    watch and is recorded there. An unentered node wrapper loses containment for
+ *    that node; it does not lose the OBSERVATION. An unentered graph watch loses
+ *    the observation outright, which is why only that one may answer null.
  */
 export function loadRestoreCompleted({ nodeIsolation, graphWatch } = {}) {
   if (!nodeIsolation || !graphWatch) return null;
   const nodeFailures = Array.isArray(nodeIsolation.failures) ? nodeIsolation.failures : null;
   const graphThrows = Array.isArray(graphWatch.throws) ? graphWatch.throws : null;
   if (!nodeFailures || !graphThrows) return null;
+  // INSTALLED IS NOT ENTERED. An empty `throws` off a watch the restore never
+  // reached is "nobody looked", and it must not read as "nothing threw".
+  const graphEntered = graphWatch.entered;
+  if (typeof graphEntered !== "number" || graphEntered < 1) return null;
   return nodeFailures.length === 0 && graphThrows.length === 0;
 }

--- a/web/js/lib/load-restore-isolation.js
+++ b/web/js/lib/load-restore-isolation.js
@@ -294,6 +294,8 @@ export function loadRestoreCompleted({ nodeIsolation, graphWatch } = {}) {
   // INSTALLED IS NOT ENTERED. An empty `throws` off a watch the restore never
   // reached is "nobody looked", and it must not read as "nothing threw".
   const graphEntered = graphWatch.entered;
-  if (typeof graphEntered !== "number" || graphEntered < 1) return null;
+  // `>= 1` and not `< 1`: NaN fails every comparison, so a `< 1` test would let it
+  // through as "entered" — the same fold, hiding in an operator.
+  if (typeof graphEntered !== "number" || !(graphEntered >= 1)) return null;
   return nodeFailures.length === 0 && graphThrows.length === 0;
 }


### PR DESCRIPTION
Corrective work on shipped code. An independent **post-merge** review of #1358 (already on `main` as `a6767ba9`) found two defects in it. Both are instances of class 1 of `.claude/autopilot/review-taxonomy.md` — *two distinct states collapse into one indistinguishable answer*.

No closing keywords: the family issues are already closed, and comfyui-mcp#1705 must stay open.

## F1 — #1358 reproduced its own defect, one level down

#1358 made the open's third ground depend on `loadRanToCompletion`, licensed strictly on `=== true`. That observation comes from two installed wrappers — `installNodeConfigureIsolation` and `installGraphConfigureWatch`. **Neither recorded whether its wrapper was ever *entered*.**

So `loadRestoreCompleted` could not tell apart:

- **nothing threw** — the load really did run to completion, and
- **we installed on a method nothing calls** — we observed nothing at all.

Wrapping a prototype method proves the method **exists**. It proves nothing about whether this frontend's restore went **through** it.

### The failing scenario

A frontend where the root graph stops resolving `configure` through `LGraph.prototype` — an own-property `configure` on the graph instance, or a subclass whose `configure` does not call `super`. Then:

- `installGraphConfigureWatch` **installs** (the prototype method is there) and is never **entered**;
- the restore aborts partway; `loadGraphData`'s own catch swallows it;
- `graphWatch.throws` is empty and `nodeIsolation.failures` is empty;
- `loadRestoreCompleted` answered **`true`**;
- `openContentDifferenceIsCompletedLoadNormalization` fires, and a genuinely partial load — nodes sitting at construction defaults with their `widgets_values` gone — is waved through as *normalization*.

That is precisely the harm #1358 exists to prevent, reintroduced by #1358's own observation gap. And no test could see it, because a test that drives the wrappers always enters them.

### The fix

Both handles now expose `entered`, counted **inside** the wrapper and **on entry** — a call that throws was still watched, and a counter bumped on the way out would read 0 for exactly the aborted load the watch exists to see. A deactivated wrapper is a pass-through and counts nothing.

`loadRestoreCompleted` returns **`null`** — not `false` — when `graphWatch.entered` is 0, absent, or not a number. (`!(x >= 1)`, not `x < 1`: `NaN` fails every comparison, so `< 1` would have let it through as "entered" — the same fold hiding in an operator. There is a test.)

`null` is load-bearing, and the consumer contract was verified before relying on it:

| consumer | its test | effect of `null` |
|---|---|---|
| `openContentDifferenceIsCompletedLoadNormalization` | `loadRanToCompletion !== true` → `false` | the third ground refuses |
| `graphRootReproducesStateContent`'s `presentationOnly` veto | `loadRanToCompletion !== false` | **not** vetoed |
| `describeOpenRebindOutcome` | already distinguishes null from false | no completion sentence |

So `null` degrades to **exactly** pre-#1358 behaviour — byte-identical to a caller that never asked the question — rather than to a new refusal #1358 was never entitled to introduce. `false` still vetoes the weaker #1623 ground; `null` must not borrow that, and a test asserts the difference.

### Only `graphWatch.entered` gates the verdict

The reviewer specified `graphWatch.entered` only. Both handles get the counter (the node one as a **diagnostic**), but **only the graph count vetoes**:

1. Zero node configures is a **legitimate** completed restore — an empty workflow. Gating on `nodeIsolation.entered` would answer UNKNOWN for loads that demonstrably ran to the end: a false negative manufactured by the guard, which is class 5. There is a test for that exact case.
2. It is not needed. The node wrapper is a **containment**; the graph watch is the backstop underneath it. A node whose `configure` never routes through `LGraphNode.prototype` still throws into `LGraph.prototype.configure`'s node loop, which has no try/catch of its own — so the abort escapes into the graph watch and **is** recorded. An unentered node wrapper loses containment for that node; it does not lose the **observation**. An unentered graph watch loses the observation outright.

### The test is the point

The new fixture is a frontend whose root graph carries its **own** `configure` and never calls `super`. The node loop still dispatches through `LGraphNode.prototype`, so `nodeIsolation.entered === 1` — **a node-level counter would not have caught this** — while `graphWatch.entered === 0`.

The same test carries its own refutation: with the answer #1358 shipped (`loadRanToCompletion: true`) the lost `widgets_values` is credited as `normalizedOnly` with `normalizedFields: ["widgets_values"]`; with the `null` this PR produces, it is not.

### Refutation

Every mutation was confirmed applied **on disk** before its run (these files are CRLF; `$`-anchored substitutions silently no-op).

| mutation | result |
|---|---|
| delete the whole fix (`git show origin/main:` over the file) | **7 tests fail** |
| delete the `entered` gate in `loadRestoreCompleted` | **KILLED** — 3 tests |
| delete `entered += 1` from the graph wrapper | **KILLED** |
| drop `entered` from the graph handle | **KILLED** |
| count on the way *out* instead of on entry | **KILLED** |
| `< 1` instead of `!(>= 1)` (NaN slips through) | **KILLED** |
| drop `entered` from the *node* handle | **KILLED** — and only the two **diagnostic** assertions, not the fold's verdict, which is the documented design |

### Measured on the rig, not read

The one thing source-reading cannot settle is whether the **real** frontend enters the watch — if it did not, this guard would turn every `workflow_open`'s third ground into UNKNOWN. Probed against a live ComfyUI (frontend `1.48.7`) by wrapping the prototypes in-page and running a real `app.loadGraphData` on a 2-node payload:

```json
{ "rootCtor": "LGraph", "rootResolvesViaLGraphPrototype": true,
  "graphEntered": 1, "nodeEntered": 2 }
```

The watch is entered, so the verdict is unchanged in production. The guard fires only on the frontend shape it was written for.

## F2 — a doc comment on `main` that was false

`resolveOpenRebindVerdict` still told a reader that the softening "was reverted, because the two cases cannot currently be told apart … no discriminator available to the panel separates them", and that "`unknown` stays `unknown` here — deliberately".

#1358 built exactly that discriminator, so the comment contradicted the code beside it. A future agent reading "no discriminator exists" would not go looking for the one that now does — and a false mechanism comment has twice sent work in this repo down the wrong path.

It now points at `loadRestoreCompleted` / `openContentDifferenceIsCompletedLoadNormalization` and states the discriminator in one line: **a mid-`configure()` abort is a THROW, and a load whose throws the panel watched for and did not see did not abort.** It also keeps the honest note that `resolveOpenRebindVerdict` itself is unchanged — the discriminator is applied upstream, where the content proof is computed.

Four other sites quoted that sentence in the **present** tense (`graph-binding.js` ×2, `comfyui-mcp-panel.js`, and the test file's own header). Leaving them would have manufactured the same class-6 defect this half of the PR removes, so they now read as the pre-#1358 wording.

## Verification

- `npm run test:unit` — **5429 pass / 0 fail / 1 todo** (5430 tests) (includes `i18n-check`, `i18n-render-check`, `check-tool-vocabulary`, `check-panel-scope`)
- `browser_tests/unit/open-completed-restore.test.mjs` — **36 pass** (30 before, 6 new)
- Playwright, `--workers=1`, against a dedicated ComfyUI on `:8299` with its own base directory, same specs both sides, only the served panel swapped — **zero regressions.** Baseline (`origin/main` panel): 56 passed / 19 failed / 75, 8.5m. With the fix: 57 passed / 18 failed / 75, 8.3m. Set difference in the regression direction is **empty**; the one moving spec (`agent-drive.spec.ts:113`, CivitAI modal highlight timing) failed on the baseline and passed with the fix — a flake, unrelated to this change. The 18 shared failures are pre-existing on `origin/main` in this environment (bridge / conversation-persistence specs on a fresh instance). `tsc --noEmit` clean.

No behaviour change beyond the verdict: the wrappers still contain / re-throw exactly as before, `restore()` is untouched, and `entered` is additive on both handles.

CHANGELOG deliberately not edited — the release PR (#1381) generates its section from commit subjects, and hand-editing `[Unreleased]` would only conflict with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
