### PR TITLE
fix(1389): a stale ROUTE re-advertises itself, like a stale fence identity already does

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project are documented here. This project adheres to
 
 ### Fixed
 - `workflow_open` no longer reports a false content mismatch on `definitions` when the frontend renumbered subgraph NODE ids during the load: the relabeling is proven (same nodes in the same order, links and promoted widgets patched through one injective map) rather than tolerated, and it still refuses when a root node promotes a widget from a node the relabeling touched (artokun/comfyui-mcp#1706)
+- a panel tab whose bridge ROUTE went stale re-advertises itself instead of waiting for a browser refresh: the 600 ms workflow poll now watches the route the orchestrator keys its tab registry on, not only the workflow-instance fence identity, so a re-hello that did not land after a switch, a first save or a rename is retried (bounded) rather than leaving every graph call addressed at a tab id nothing answers to (#1389)
 
 ## [0.15.4] - 2026-08-19
 

--- a/browser_tests/unit/binding-recovery.test.mjs
+++ b/browser_tests/unit/binding-recovery.test.mjs
@@ -416,7 +416,7 @@ test("#607 the dispatch-time fence also re-advertises before refusing", () => {
  * ADVERTISED (`lastAdvertisedWorkflowUuid`) on its success path only — so the
  * harness hands the test a setter for exactly that, and nothing else.
  */
-function buildRehelloHook({ sendHello, stableUuid }) {
+function buildRehelloHook({ sendHello, stableUuid, routeId = () => "route-A" }) {
   const declStart = SRC.indexOf("const MISMATCH_REHELLO_MAX_PER_IDENTITY");
   assert.notEqual(declStart, -1, "the re-hello budget constants are missing");
   const marker = "workflowInstanceMismatchRehello = () => {";
@@ -442,16 +442,21 @@ function buildRehelloHook({ sendHello, stableUuid }) {
     slice.includes("mismatchRehelloLandedCount += 1;"),
     "the extracted hook is truncated — its landed bookkeeping is missing",
   );
+  // #1389 — the hook now also reads the live ROUTE (its budget is keyed on the identity a
+  // hello ADVERTISES, and a route is half of that). A `new Function` scope missing a
+  // binding the shipping code reads throws ReferenceError, which reads as a broken
+  // harness rather than as the missing dependency it is — so inject it here.
   const factory = new Function(
     "sendHello",
     "workflowStableUuid",
+    "bridgeRouteId",
     `let workflowInstanceMismatchRehello = null;\n${slice};\n` +
       `return {\n` +
       `  hook: workflowInstanceMismatchRehello,\n` +
       `  advertise: (uuid) => { lastAdvertisedWorkflowUuid = uuid; },\n` +
       `};`,
   );
-  return factory(sendHello, stableUuid);
+  return factory(sendHello, stableUuid, routeId);
 }
 
 /** Let every queued microtask (the hook's own promise chain) drain. */
@@ -733,7 +738,12 @@ test("#606 the binding refusal marks the reload remedy as REQUESTED, not confirm
  * delegation between them is the shipping one. Deleting the drift hook, or making it
  * fire unconditionally, fails a test below.
  */
-function buildDriftHook({ sendHello, stableUuid }) {
+function buildDriftHook({
+  sendHello,
+  stableUuid,
+  routeStale = () => false,
+  routeId = () => "route-A",
+}) {
   const declStart = SRC.indexOf("const MISMATCH_REHELLO_MAX_PER_IDENTITY");
   assert.notEqual(declStart, -1, "the re-hello budget constants are missing");
   const marker = "workflowIdentityDriftRehello = () => {";
@@ -757,9 +767,19 @@ function buildDriftHook({ sendHello, stableUuid }) {
     slice.includes("mismatchRehelloLandedCount += 1;"),
     "the extracted region is truncated — the #607 landed bookkeeping is missing",
   );
+  // #1389 — the ROUTE half of the same drift check. Asserted on the SLICE (not only
+  // through behaviour) because a `new Function` scope that is missing a binding the
+  // shipping code reads throws ReferenceError, which would read as a broken harness
+  // rather than as the missing dependency it is.
+  assert.ok(
+    slice.includes("advertisedRouteIsStale()"),
+    "the drift hook must also watch the ROUTE the orchestrator keys its tab registry on",
+  );
   const factory = new Function(
     "sendHello",
     "workflowStableUuid",
+    "advertisedRouteIsStale",
+    "bridgeRouteId",
     `let workflowInstanceMismatchRehello = null;\n` +
       `let workflowIdentityDriftRehello = null;\n${slice};\n` +
       `return {\n` +
@@ -768,7 +788,7 @@ function buildDriftHook({ sendHello, stableUuid }) {
       `  advertise: (uuid) => { lastAdvertisedWorkflowUuid = uuid; },\n` +
       `};`,
   );
-  return factory(sendHello, stableUuid);
+  return factory(sendHello, stableUuid, routeStale, routeId);
 }
 
 test("#1209 a fence that drifted under an unchanged route is re-advertised, unprompted", async () => {
@@ -924,6 +944,172 @@ test("#1209 an attempt the #607 guards refused does not spend the drift bound", 
     await settle();
   }
   assert.equal(dbl.started, 3, "the refused ticks left the rest of the bound intact");
+});
+
+// ---------------------------------------------------------------------------
+// #1389 — the ROUTE half of the same drift check.
+//
+// A hello advertises two identities and they do not move together: the fence uuid is
+// durable per workflow INSTANCE, while the route (`tab_id`) is composed from the tab's
+// lease and the workflow's PATH. A first save or a rename/Save-As re-keys the route and
+// leaves the instance exactly where it was — so the uuid half reports convergence, and
+// replenishes the bound, while the address ui-bridge keys its tab registry on is wrong.
+//
+// The panel can already SEE it (`advertisedRouteIsStale()` drives the outbound refusals),
+// but nothing re-advertised on it: the poll re-hellos on the EDGE of a route change and
+// then reports `wfid === currentWorkflowId` forever after, and a held frame may never
+// cause an advertisement by `holdForRoute`'s own rule. A re-advertise that did not land
+// therefore wedged the tab until a browser refresh — the reported recovery.
+// ---------------------------------------------------------------------------
+
+test("#1389 a ROUTE that drifted under an UNCHANGED fence identity is re-advertised", async () => {
+  // The reported shape: same workflow instance (a first save / a rename), so the uuid
+  // the orchestrator holds is still correct — and the route it holds is not. Before this
+  // fix the drift hook saw "uuid converged" and sent nothing, forever.
+  let routeStale = false;
+  const dbl = helloDouble(() => "uuid-SAME", { lands: () => true });
+  const h = buildDriftHook({
+    sendHello: () => dbl.send(),
+    stableUuid: () => "uuid-SAME",
+    routeStale: () => routeStale,
+  });
+  // A landed hello re-advertises the LIVE route, so the staleness clears with it.
+  dbl.harness = {
+    advertise: (uuid) => {
+      h.advertise(uuid);
+      routeStale = false;
+    },
+  };
+  h.advertise("uuid-SAME");
+
+  h.drift();
+  await settle();
+  assert.equal(dbl.started, 0, "an agreeing panel sends nothing");
+
+  routeStale = true; // the save re-keyed the route; the instance is the same object
+  h.drift();
+  await settle();
+  assert.deepEqual(dbl.calls, ["uuid-SAME"], "the drifted ROUTE is re-advertised unprompted");
+
+  // …and it QUIESCES once the advertisement lands, exactly like the fence half.
+  for (let i = 0; i < 10; i += 1) {
+    h.drift();
+    await settle();
+  }
+  assert.equal(dbl.calls.length, 1, "an advertisement that landed ends the route drift");
+});
+
+test("#1389 a converged fence identity does not replenish the bound while the ROUTE is stale", async () => {
+  // The bound is what stops a 600ms poll becoming a greeting storm, and the uuid half
+  // owns its replenishment. Resetting on "the uuid agrees" while the route does not
+  // would make the bound infinite for exactly the case this fix adds — an unbounded
+  // re-hello loop is a NEW wedge, not a fix.
+  const dbl = helloDouble(() => "uuid-SAME");
+  const h = buildDriftHook({
+    sendHello: () => dbl.send(),
+    stableUuid: () => "uuid-SAME",
+    routeStale: () => true, // an orchestrator that takes the hello and keeps the old route
+  });
+  dbl.harness = { advertise: () => {} };
+  h.advertise("uuid-SAME");
+  for (let i = 0; i < 25; i += 1) {
+    h.drift();
+    await settle();
+  }
+  assert.equal(dbl.calls.length, 3, "a route that never clears stops churning");
+});
+
+test("#1389 a route that converges again replenishes the bound for the next real drift", async () => {
+  // BOTH bounds have to hand themselves back, and only one of them did. The drift
+  // caller's own counter replenishes on convergence, but the #607 per-identity budget
+  // underneath it is keyed on the ADVERTISED identity — and while that key was the fence
+  // uuid alone, a pure route drift never presented a new one. Three route
+  // re-advertisements were then all a workflow instance ever got for the life of the
+  // socket: a first save spends one, a rename another, and the third leaves the panel
+  // permanently unable to re-address itself on a canvas the user never left.
+  let routeStale = true;
+  let liveRoute = "route-B";
+  const dbl = helloDouble(() => "uuid-SAME");
+  const h = buildDriftHook({
+    sendHello: () => dbl.send(),
+    stableUuid: () => "uuid-SAME",
+    routeStale: () => routeStale,
+    routeId: () => liveRoute,
+  });
+  // Phase 1: the hellos land but the route stays stale — three tries, then quiet.
+  dbl.harness = { advertise: () => {} };
+  h.advertise("uuid-SAME");
+  for (let i = 0; i < 12; i += 1) {
+    h.drift();
+    await settle();
+  }
+  assert.equal(dbl.calls.length, 3, "the stuck route exhausted the bound");
+
+  // Phase 2: something else re-registered the tab (a reconnect's open hello). One
+  // observed convergence — both halves agreeing — and the mechanism is live again.
+  routeStale = false;
+  h.drift();
+  await settle();
+  assert.equal(dbl.calls.length, 3, "convergence itself sends nothing");
+
+  // Phase 3: a LATER genuine route move — a rename of the same instance, so the fence
+  // uuid is the one it always was and only the route is new evidence.
+  liveRoute = "route-C";
+  routeStale = true;
+  h.drift();
+  await settle();
+  assert.equal(dbl.calls.length, 4, "the next real route drift is advertised again");
+});
+
+test("#1389 an unreadable fence identity does not credit a convergence the panel never observed", async () => {
+  // `uuidObserved` is why the reset is not simply `!drifted`. An identity that cannot be
+  // read is not evidence that re-advertising works here, and crediting it would hand a
+  // later genuine drift a bound this tick never earned — the same rule #1209 states for
+  // its own early exit, kept now that the exit has become a branch.
+  let readable = false;
+  const dbl = helloDouble(() => "uuid-A");
+  const h = buildDriftHook({
+    sendHello: () => dbl.send(),
+    stableUuid: () => {
+      if (!readable) throw new Error("no workflow service");
+      return "uuid-B";
+    },
+    routeStale: () => true,
+  });
+  dbl.harness = { advertise: () => {} };
+  h.advertise("uuid-A");
+
+  // Spend the bound on a route that never converges…
+  readable = true;
+  for (let i = 0; i < 12; i += 1) {
+    h.drift();
+    await settle();
+  }
+  assert.equal(dbl.calls.length, 3, "the stuck route exhausted the bound");
+
+  // …then go unreadable. That is not convergence, so it must not hand the bound back.
+  readable = false;
+  for (let i = 0; i < 12; i += 1) {
+    h.drift();
+    await settle();
+  }
+  assert.equal(dbl.calls.length, 3, "an unreadable identity replenished nothing");
+});
+
+test("#1389 nothing advertised yet is still not a drift, even with the route half added", async () => {
+  // A fresh or reconnecting socket has no landed mapping, so `advertisedRouteIsStale()`
+  // answers false by construction (`mapped`). Pinned here anyway: the route half must not
+  // reopen the race the uuid half's early exit closed — the open hello carries the truth.
+  const dbl = helloDouble(() => "uuid-LIVE");
+  const h = buildDriftHook({
+    sendHello: () => dbl.send(),
+    stableUuid: () => "uuid-LIVE",
+    routeStale: () => false,
+  });
+  dbl.harness = h;
+  h.drift();
+  await settle();
+  assert.equal(dbl.started, 0, "an unadvertised socket must not re-hello");
 });
 
 test("#1209 the workflow poll calls the drift check when the ROUTE did not change", () => {

--- a/browser_tests/unit/binding-recovery.test.mjs
+++ b/browser_tests/unit/binding-recovery.test.mjs
@@ -1066,34 +1066,50 @@ test("#1389 an unreadable fence identity does not credit a convergence the panel
   // read is not evidence that re-advertising works here, and crediting it would hand a
   // later genuine drift a bound this tick never earned — the same rule #1209 states for
   // its own early exit, kept now that the exit has become a branch.
-  let readable = false;
-  const dbl = helloDouble(() => "uuid-A");
+  let readable = true;
+  let routeStale = true;
+  const dbl = helloDouble(() => "uuid-B");
   const h = buildDriftHook({
     sendHello: () => dbl.send(),
     stableUuid: () => {
       if (!readable) throw new Error("no workflow service");
       return "uuid-B";
     },
-    routeStale: () => true,
+    routeStale: () => routeStale,
+    routeId: () => "route-B",
   });
+  // An orchestrator that takes the hellos and republishes nothing, so the drift never
+  // clears on its own and the bound is the only thing that stops the poll.
   dbl.harness = { advertise: () => {} };
   h.advertise("uuid-A");
 
-  // Spend the bound on a route that never converges…
-  readable = true;
+  // Spend the bound on a drift that never converges…
   for (let i = 0; i < 12; i += 1) {
     h.drift();
     await settle();
   }
-  assert.equal(dbl.calls.length, 3, "the stuck route exhausted the bound");
+  assert.equal(dbl.calls.length, 3, "the stuck drift exhausted the bound");
 
-  // …then go unreadable. That is not convergence, so it must not hand the bound back.
+  // …then reach the no-drift branch with the fence identity UNREADABLE. Nothing
+  // disagrees, but nothing was observed to agree either: an exception is not a
+  // convergence, and crediting it would hand the bound straight back.
   readable = false;
+  routeStale = false;
   for (let i = 0; i < 12; i += 1) {
     h.drift();
     await settle();
   }
-  assert.equal(dbl.calls.length, 3, "an unreadable identity replenished nothing");
+  assert.equal(dbl.calls.length, 3, "an unreadable identity is not convergence");
+
+  // The bound really is still spent — a genuine drift returning finds nothing left,
+  // exactly as it would have without the unreadable ticks in between.
+  readable = true;
+  routeStale = true;
+  for (let i = 0; i < 12; i += 1) {
+    h.drift();
+    await settle();
+  }
+  assert.equal(dbl.calls.length, 3, "an unreadable tick replenished nothing");
 });
 
 test("#1389 nothing advertised yet is still not a drift, even with the route half added", async () => {

--- a/browser_tests/unit/command-liveness.test.mjs
+++ b/browser_tests/unit/command-liveness.test.mjs
@@ -866,7 +866,41 @@ test("#1095 codex P1: BOTH outbound send paths consult the advertised route firs
   // retires a prompt permanently on exactly that answer), and answering `false` would leave
   // the tray showing failed while the queued copy still goes out on the next advertisement.
   assert.equal(holdSites.length, 1, "only the session-ordered control frames may be queued");
-  assert.equal(staleReads.length, 2, "…but BOTH send paths must consult the route first");
+  // …but BOTH send paths must consult the route first.
+  //
+  // #1389 — asserted by WHERE each read is, not by how many there are. A third reader now
+  // exists and it is deliberately not a send path: the workflow poll's drift check
+  // re-advertises on the same staleness these two refuse on, because nothing else did and
+  // a held frame may never cause an advertisement (holdForRoute's own rule). Counting to
+  // two would have made adding that reader look like a regression, and raising the count
+  // to three would have stopped saying anything about where the reads are — which is the
+  // whole claim. So: exactly one read inside each send path, and every other read
+  // accounted for by name.
+  const rangeOfMember = (name) => {
+    const at = src.indexOf(`    ${name}(`);
+    assert.notEqual(at, -1, `could not locate ${name}`);
+    const end = src.indexOf("\n    },", at);
+    assert.notEqual(end, -1, `could not bound ${name}`);
+    return [at, end];
+  };
+  const driftStart = src.indexOf("workflowIdentityDriftRehello = () => {");
+  assert.notEqual(driftStart, -1, "the drift re-advertise hook must exist");
+  const driftEnd = src.indexOf("\n  };", driftStart);
+  assert.notEqual(driftEnd, -1, "could not bound the drift re-advertise hook");
+  const readerRanges = {
+    sendUserMessage: rangeOfMember("sendUserMessage"),
+    sendFrame: rangeOfMember("sendFrame"),
+    workflowIdentityDriftRehello: [driftStart, driftEnd],
+  };
+  const readers = staleReads.map((pos) => {
+    const hit = Object.entries(readerRanges).find(([, [a, b]]) => pos >= a && pos <= b);
+    return hit ? hit[0] : `UNACCOUNTED@${pos}`;
+  });
+  assert.deepEqual(
+    readers.slice().sort(),
+    ["sendFrame", "sendUserMessage", "workflowIdentityDriftRehello"],
+    "both send paths must consult the route, and only the drift re-advertise may also read it",
+  );
   assert.equal(
     (src.match(/^\s*function advertisedRouteIsStale\(\) \{/gm) || []).length,
     1,

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -22357,6 +22357,21 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
    *  identity collect an uncounted hello on top of its own budget. */
   let lastAdvertisedWorkflowUuid = null;
   let mismatchRehelloIdentity = null;
+  /** #1389 — the ROUTE half of the identity this budget is keyed on.
+   *
+   *  The budget exists to stop churn on UNCHANGING evidence, and the evidence a re-hello
+   *  carries is its PAYLOAD — which names a fence uuid AND a route. Keyed on the uuid
+   *  alone it could not tell a fresh route from a repeat of the same one, so the drift
+   *  the route half of #1389 detects had only three re-advertisements available for the
+   *  whole life of a workflow instance: a first save spends one, a rename spends another,
+   *  and the third leaves the mechanism permanently spent on a canvas the user never
+   *  stopped working in. A route that MOVED is new evidence by exactly the argument that
+   *  makes a moved uuid new evidence.
+   *
+   *  `null` when the route cannot be read, which compares equal to the next unreadable
+   *  one — an id we cannot READ is not an id we know to be different, so it neither
+   *  resets the budget nor makes every tick look like a fresh identity. */
+  let mismatchRehelloRoute = null;
   let mismatchRehelloLandedCount = 0;
   let mismatchRehelloInFlight = false;
   let lastFailedMismatchRehelloAt = 0;
@@ -22372,8 +22387,19 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
       liveUuid = null;
     }
     if (!liveUuid) return false;
-    if (liveUuid !== mismatchRehelloIdentity) {
+    // #1389 — read the live ROUTE on the same terms: unreadable is `null`, never a
+    // guess and never a fallback to the path (bridgeRouteId refuses rather than
+    // re-merging two tabs, and this must not undo that).
+    let liveRoute = null;
+    try {
+      const read = bridgeRouteId();
+      liveRoute = typeof read === "string" && read ? read : null;
+    } catch {
+      liveRoute = null;
+    }
+    if (liveUuid !== mismatchRehelloIdentity || liveRoute !== mismatchRehelloRoute) {
       mismatchRehelloIdentity = liveUuid;
+      mismatchRehelloRoute = liveRoute;
       mismatchRehelloLandedCount = 0;
       lastFailedMismatchRehelloAt = 0;
     }
@@ -22441,20 +22467,71 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
   //     and firing another one here would only race it.
   //   - an identity that cannot be READ is not an identity known to differ, and it is
   //     not convergence either, so it neither spends the bound nor replenishes it.
+  //
+  // #1389 — TWO ADVERTISEMENTS CAN GO STALE, AND ONLY ONE OF THEM WAS WATCHED.
+  //
+  // A hello carries two identities, and they answer different questions:
+  //
+  //   * `workflow_uuid` — the per-instance FENCE identity. A stale one gets a command
+  //     refused as a `workflow instance mismatch`, which is what #1209 above is about.
+  //   * `tab_id` (the ROUTE, from bridgeRouteId()) — the key ui-bridge keeps exactly ONE
+  //     connection under. A stale one is not a refusal; it is a WRONG or MISSING address.
+  //     The orchestrator resolves every panel_* call and every push against it, and the
+  //     panel refuses its own outbound traffic on it too: `sendUserMessage` returns false
+  //     while `advertisedRouteIsStale()` holds, and `sendFrame` parks session-ordered
+  //     frames behind a hello that, by `holdForRoute`'s own rule, a held frame may never
+  //     cause. Nothing else re-advertises either — the 600 ms poll re-hellos on the EDGE
+  //     of a route change and then reports `wfid === currentWorkflowId` forever after.
+  //
+  // So a re-advertise that did not land, or that landed carrying the route it had already
+  // composed before the switch, left the panel permanently addressed as somewhere it no
+  // longer is, with the user's only recovery a browser refresh — the reported symptom,
+  // verbatim ("a browser F5/hard refresh was required to reconnect").
+  //
+  // THE TWO IDENTITIES DO NOT MOVE TOGETHER, which is why watching one is not watching
+  // both. The route is composed from the tab's lease and the workflow's PATH; the uuid is
+  // durable per workflow INSTANCE. A first save (`tmp:` → `wf:<path>`) and a
+  // rename/Save-As (`wf:<old>` → `wf:<new>`) both re-key the route while the instance —
+  // and therefore the uuid — is the same object it always was. On those, the uuid half of
+  // this check reports convergence and replenishes the bound while the address the
+  // orchestrator holds is wrong. That is the gap; #1267 reports its save-as face.
+  //
+  // Routed through the SAME bounded send, deliberately. The per-identity budget, the
+  // backoff, the in-flight guard and the #1095 gate's coalescing all apply unchanged — so
+  // a route that is stale only because a re-advertise is legitimately PARKED joins that
+  // parked hello instead of racing it, and a route that never converges goes quiet after
+  // the same three tries rather than becoming a greeting storm.
   const DRIFT_REHELLO_MAX_UNCONVERGED = 3;
   let driftRehelloUnconverged = 0;
   workflowIdentityDriftRehello = () => {
-    if (typeof lastAdvertisedWorkflowUuid !== "string" || !lastAdvertisedWorkflowUuid) return;
-    let liveUuid = null;
-    try {
-      const read = workflowStableUuid();
-      liveUuid = typeof read === "string" && read ? read : null;
-    } catch {
-      liveUuid = null;
+    // #1389 — the ROUTE half. `advertisedRouteIsStale()` already fails open on an
+    // unreadable id and answers false on a socket with no landed mapping, so it is
+    // false in exactly the states the uuid half also refuses to act on.
+    const routeDrifted = advertisedRouteIsStale();
+    // The FENCE half (#1209), unchanged in what it observes. Split into "was it
+    // readable" and "did it differ" because the two now have to be reported separately:
+    // an unreadable or never-advertised uuid is no longer a reason to skip the route.
+    let uuidObserved = false;
+    let uuidDrifted = false;
+    if (typeof lastAdvertisedWorkflowUuid === "string" && lastAdvertisedWorkflowUuid) {
+      let liveUuid = null;
+      try {
+        const read = workflowStableUuid();
+        liveUuid = typeof read === "string" && read ? read : null;
+      } catch {
+        liveUuid = null;
+      }
+      if (liveUuid) {
+        uuidObserved = true;
+        uuidDrifted = liveUuid !== lastAdvertisedWorkflowUuid;
+      }
     }
-    if (!liveUuid) return;
-    if (liveUuid === lastAdvertisedWorkflowUuid) {
-      driftRehelloUnconverged = 0;
+    if (!routeDrifted && !uuidDrifted) {
+      // Convergence replenishes the bound — but only when it was OBSERVED. An identity
+      // that could not be read, or a socket that has advertised nothing yet, is not
+      // evidence that re-advertising works here; crediting it would hand a later genuine
+      // drift a bound this tick never earned.
+      if (uuidObserved) driftRehelloUnconverged = 0;
       return;
     }
     if (driftRehelloUnconverged >= DRIFT_REHELLO_MAX_UNCONVERGED) return;


### PR DESCRIPTION
Closes #1389.

## What the reporter hit

A workflow switch while a render was running, and afterwards every `panel_*` graph call
answered `Connected: none` / "no connected tab". `panel_set_workflow_target({mode:"current"})`
applied the target mode and still could not restore the binding. **The only recovery was a
browser F5.**

## The panel-side defect: only half of what a hello advertises was ever watched

A hello carries two identities and they answer different questions:

* **`workflow_uuid`** — the per-instance FENCE identity. A stale one gets a command refused as
  a `workflow instance mismatch`.
* **`tab_id`** (the ROUTE, from `bridgeRouteId()`) — the key `ui-bridge` keeps exactly ONE
  connection under. A stale one is not a refusal, it is a **wrong or missing address**: the
  orchestrator resolves every `panel_*` call and every push against it.

The panel already *sees* route staleness — `advertisedRouteIsStale()` exists and drives its own
outbound refusals (`sendUserMessage` returns false, `sendFrame` parks session-ordered frames).
But nothing re-advertised on it:

* the 600 ms poll re-hellos on the **EDGE** of a route change and reports
  `wfid === currentWorkflowId` on every tick afterwards;
* `holdForRoute`'s own rule is that a held frame may **never** cause an advertisement;
* the one proactive re-advertise the panel has (#1209) compares `lastAdvertisedWorkflowUuid`
  against `workflowStableUuid()` — the fence uuid, and only that.

So a re-advertise that did not land, or that landed carrying the route it had already composed
before the switch, left the tab permanently addressed as somewhere it no longer is. Nothing in
the panel could notice, and F5 was the only way out — verbatim the reported recovery.

**The two identities do not move together**, which is why watching one is not watching both.
The route is composed from the tab's lease and the workflow's PATH; the uuid is durable per
workflow INSTANCE. A first save (`tmp:` → `wf:<path>`) and a rename/Save-As
(`wf:<old>` → `wf:<new>`) both re-key the route while the instance is the object it always was.
On those the uuid half reports convergence — and *replenishes the bound* — while the address the
orchestrator holds is wrong. #1267 reports the save-as face of the same gap.

## The change

Two lines of behaviour, in the mechanism rather than at a caller:

1. `workflowIdentityDriftRehello` (the poll's proactive re-advertise) now observes the **ROUTE**
   as well as the fence uuid, and routes both through the **same** bounded send — so the
   per-identity budget, the backoff, the in-flight guard and the #1095 gate's coalescing all
   apply unchanged. A route that is stale only because a re-advertise is legitimately *parked*
   joins that parked hello instead of racing it; a route that never converges goes quiet after
   the same three tries rather than becoming a greeting storm.
2. The #607 per-identity budget is keyed on the identity a hello **advertises** — uuid **and**
   route. Keyed on the uuid alone it could not tell a fresh route from a repeat of the same one,
   so a pure route drift had only three re-advertisements for the whole life of a workflow
   instance: a first save spends one, a rename another, and the third leaves the mechanism
   permanently spent on a canvas the user never left.

`uuidObserved` is why the "no drift" branch does not simply reset the bound: an identity that
could not be read is not evidence that re-advertising works here, and crediting it would hand a
later genuine drift a bound that tick never earned.

## Proof

Mutation-verified against the shipping source (the harness extracts the real region from the
monolith and drives it with doubles — it is not a re-implementation):

| mutation | result |
|---|---|
| `advertisedRouteIsStale()` → `false` (route half never observed) | **3 fail** |
| drop the route from the budget key | **1 fail** |
| `if (uuidObserved) driftRehelloUnconverged = 0` → unconditional | **1 fail** |
| remove the drift read (structural guard) | **1 fail** |
| move a send-path guard out (original #1095 claim still bites) | **1 fail** |

Production reachability is pinned, not assumed: `noteWorkflowIdentityDrift()` is asserted to
live inside the poll's `wfid === currentWorkflowId` branch, and the poll is the shipping
`setInterval(…, 600)`.

The existing structural guard in `command-liveness.test.mjs` counted `advertisedRouteIsStale()`
readers and expected exactly two. It is **strengthened, not loosened**: it now asserts each read
by the function it sits in (`sendUserMessage`, `sendFrame`, `workflowIdentityDriftRehello`), so
an unaccounted reader still fails and so does moving a send-path guard out.

`npm run test:unit`: **5470 pass, 0 fail** (5471 tests) on the rebased tree, plus
`check-panel-scope` OK — the gate that catches a name resolving in a sibling scope, which is the
real risk when a closure reads two new bindings.

## What this deliberately does NOT do

* **The `QUEUE BUSY` half of the report is not this repo's.** `graph_outline was NOT sent —
  QUEUE BUSY` is emitted by `comfyui-mcp` (`src/orchestrator/panel-tools.ts`, from its #1639) —
  zero occurrences anywhere in the panel. The reporter's "read-only reads should use a safe
  canvas snapshot during rendering" is a request against that orchestrator behaviour and belongs
  upstream; nothing here changes when a read is refused.
* Once the outer bound is spent by a *route* drift, replenishment requires **both** halves
  converged, so in principle a route problem could withhold the bound the #1209 uuid recovery
  depends on. The reviewer chased this and could not construct a production state that reaches
  three non-converging route drifts on a live socket — a landed hello republishes
  `lastAdvertisedRouteId` from the same `bridgeRouteId()` the staleness check reads, so it
  converges on the first try. Recorded rather than papered over.

## Verification not performed

**The Playwright browser suite was NOT run: no ComfyUI is listening on :8188 and none was
allocated for this run.** The suite compiles and discovers (`npx playwright test --list`, 75
tests / 32 files), which is not the same as running it. This change renders nothing — it alters
when the bridge re-advertises — but that is a claim about the code, not an observation in a
browser, and it is stated as such.

## Gate

**codex was unavailable (account exhausted until 2026-08-19 20:43); gated by an independent
adversarial review instead** — a fresh reviewer that had not seen this reasoning. Verdict:
**SHIP** (exit 0). It ran the mutants itself, drove the extracted hook against the real
`routeIsStale` (settled panel, 500 ticks → 0 hellos; reported drift → recovers in 1 hello), and
checked every prose claim in the source comments against the code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
