### PR TITLE
fix(1374): sweep a stolen preview by which node emitted, not by what its type could show

### DIFF
--- a/browser_tests/unit/execution-preview-attach.test.mjs
+++ b/browser_tests/unit/execution-preview-attach.test.mjs
@@ -16,6 +16,9 @@ import {
   stripNodeExecutionPreview,
   clearInheritedExecutionPreview,
   stripMisattachedExecutionPreviews,
+  recordExecutionPreviewOwner,
+  holdsStolenExecutionPreview,
+  executionPreviewOwnerLedger,
 } from "../../web/js/lib/execution-preview-attach.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -209,4 +212,259 @@ test("#1286: the panel imports and calls the shipped sanitizer on the add / remo
   const onSuccess = panelSrc.match(/function onExecutionSuccess\(ev\) \{[\s\S]*?\n {2}function onExecutionStart/);
   assert.ok(onSuccess, "onExecutionSuccess body not found");
   assert.match(onSuccess[0], /stripMisattachedExecutionPreviews\(/);
+});
+
+// ---------------------------------------------------------------------------
+// #1374 — the sweep gated on node TYPE, so an image-capable victim of id reuse
+// (VAEDecode / ImageScale / EmptyLatentImage) kept the previous occupant's
+// preview. Ownership is now proven per id, per emitting node object.
+// ---------------------------------------------------------------------------
+
+/** The store entry ComfyUI writes for an emitting node, as ONE object identity. */
+function outputEntry(filename = "ComfyUI_00001_.png") {
+  return { images: [{ filename, type: "output", subfolder: "" }] };
+}
+
+function imageCapableNode(type, id) {
+  const outputs =
+    type === "EmptyLatentImage" ? [{ name: "LATENT", type: "LATENT" }] : [{ name: "IMAGE", type: "IMAGE" }];
+  return {
+    id,
+    type,
+    size: [210, 266],
+    widgets: [previewWidget()],
+    imgs: [{ src: "/view?filename=ComfyUI_00001_.png" }],
+    images: [{ filename: "ComfyUI_00001_.png", type: "output" }],
+    outputs,
+    computeSize() { return [210, 46]; },
+    setSize(size) { this.size = size; },
+  };
+}
+
+/**
+ * Run 1: `save` emits at `id` and the store entry is recorded as its own.
+ * Returns the ledger and the exact entry object the store holds.
+ */
+function runOneEmission(id, owners) {
+  const save = saveImageNode(id);
+  const entry = outputEntry();
+  const nodeOutputs = { [String(id)]: entry };
+  const graph = { _nodes: [save] };
+  stripMisattachedExecutionPreviews({
+    graph,
+    nodeOutputs,
+    nodePreviewImages: {},
+    preferNodeId: id,
+    owners,
+  });
+  return { save, entry, nodeOutputs };
+}
+
+for (const victimType of ["VAEDecode", "ImageScale", "EmptyLatentImage"]) {
+  test(`#1374: ${victimType} inheriting a reused id does NOT keep the emitter's preview`, () => {
+    const owners = new Map();
+    const { entry, nodeOutputs } = runOneEmission(9, owners);
+
+    // ComfyUI's own paste / undo / load reuses id 9 for a DIFFERENT node. The panel
+    // never sees that edit, so the store entry SaveImage emitted is still sitting there.
+    const victim = imageCapableNode(victimType, 9);
+    const graph = { _nodes: [victim] };
+    const { stripped } = stripMisattachedExecutionPreviews({
+      graph,
+      nodeOutputs,
+      nodePreviewImages: {},
+      owners,
+    });
+
+    assert.equal(stripped, 1, `${victimType} kept a preview it never emitted`);
+    assert.equal(victim.imgs, undefined);
+    assert.equal(victim.widgets.some((w) => w.name === CANVAS_IMAGE_PREVIEW_WIDGET), false);
+    assert.equal(nodeOutputs["9"], undefined);
+    assert.deepEqual(victim.size, [210, 46]);
+    assert.equal(entry.images.length, 1, "the emitter's own entry object is not mutated");
+  });
+}
+
+test("#1374: the emitting node keeps its own preview across later sweeps", () => {
+  const owners = new Map();
+  const { save, nodeOutputs } = runOneEmission(9, owners);
+  const graph = { _nodes: [save] };
+
+  // execution_success backstop, then a later run's sweep — the owner never loses it.
+  stripMisattachedExecutionPreviews({ graph, nodeOutputs, nodePreviewImages: {}, owners });
+  stripMisattachedExecutionPreviews({ graph, nodeOutputs, nodePreviewImages: {}, owners });
+
+  assert.ok(save.imgs?.length, "the node that emitted was stripped");
+  assert.ok(nodeOutputs["9"]?.images?.length);
+});
+
+test("#1374: a same-type recreate/undo at the same id keeps the preview ComfyUI re-plants", () => {
+  const owners = new Map();
+  const { nodeOutputs } = runOneEmission(9, owners);
+
+  // "Fix node (recreate)" and ChangeTracker undo both hand back a NEW object at the
+  // same id, and ComfyUI deliberately re-plants the preview from the surviving store
+  // entry. Stripping there would delete a preview the frontend means to show.
+  const recreated = saveImageNode(9);
+  const graph = { _nodes: [recreated] };
+  const { stripped } = stripMisattachedExecutionPreviews({
+    graph,
+    nodeOutputs,
+    nodePreviewImages: {},
+    owners,
+  });
+
+  assert.equal(stripped, 0);
+  assert.ok(recreated.imgs?.length);
+  assert.ok(nodeOutputs["9"]?.images?.length);
+});
+
+test("#1374: a REPLACED store entry is not judged — restored /history outputs survive", () => {
+  const owners = new Map();
+  const { nodeOutputs } = runOneEmission(9, owners);
+
+  // ComfyUI's queue "Load" does loadGraphData() (which clean()s the stores) and then
+  // repopulates app.nodeOutputs from the job payload: brand-new node objects AND
+  // brand-new entry objects. Nothing here is evidence of a steal.
+  nodeOutputs["9"] = outputEntry("restored_00007_.png");
+  const restored = imageCapableNode("VAEDecode", 9);
+  const graph = { _nodes: [restored] };
+  const { stripped } = stripMisattachedExecutionPreviews({
+    graph,
+    nodeOutputs,
+    nodePreviewImages: {},
+    owners,
+  });
+
+  assert.equal(stripped, 0);
+  assert.ok(restored.imgs?.length);
+  assert.ok(nodeOutputs["9"]?.images?.length);
+});
+
+test("#1374: with no emission on record an image-capable node is left alone", () => {
+  const owners = new Map();
+  const decode = imageCapableNode("VAEDecode", 9);
+  const nodeOutputs = { "9": outputEntry() };
+  const { stripped } = stripMisattachedExecutionPreviews({
+    graph: { _nodes: [decode] },
+    nodeOutputs,
+    nodePreviewImages: {},
+    owners,
+  });
+  assert.equal(stripped, 0);
+  assert.ok(decode.imgs?.length);
+});
+
+test("#1374: a stolen b_preview frame is swept too, not just executed outputs", () => {
+  const owners = new Map();
+  const ksampler = {
+    id: 4,
+    type: "KSampler",
+    outputs: [{ name: "LATENT", type: "LATENT" }],
+    widgets: [],
+    computeSize() { return [270, 262]; },
+    setSize(size) { this.size = size; },
+  };
+  const frame = ["data:image/png;base64,AAAA"];
+  const nodePreviewImages = { "4": frame };
+  stripMisattachedExecutionPreviews({
+    graph: { _nodes: [ksampler] },
+    nodeOutputs: {},
+    nodePreviewImages,
+    preferNodeId: 4,
+    owners,
+  });
+
+  const victim = imageCapableNode("ImageScale", 4);
+  victim.imgs = undefined;
+  victim.images = undefined;
+  const { stripped } = stripMisattachedExecutionPreviews({
+    graph: { _nodes: [victim] },
+    nodeOutputs: {},
+    nodePreviewImages,
+    owners,
+  });
+  assert.equal(stripped, 1);
+  assert.equal(nodePreviewImages["4"], undefined);
+});
+
+test("#1374: the ledger stays graph-sized — records for vanished ids are pruned", () => {
+  const owners = new Map();
+  const { nodeOutputs } = runOneEmission(9, owners);
+  assert.equal(owners.size, 1);
+
+  // The node was removed and the panel's remove hook wiped its store entry: the
+  // record now describes nothing, so it must not accumulate run after run.
+  delete nodeOutputs["9"];
+  stripMisattachedExecutionPreviews({
+    graph: { _nodes: [] },
+    nodeOutputs,
+    nodePreviewImages: {},
+    owners,
+  });
+  assert.equal(owners.size, 0);
+});
+
+test("#1374: holdsStolenExecutionPreview only fires on positive evidence", () => {
+  const owners = new Map();
+  const save = saveImageNode(9);
+  const entry = outputEntry();
+  const stores = { nodeOutputs: { "9": entry }, nodePreviewImages: {} };
+  recordExecutionPreviewOwner(owners, save, stores);
+
+  assert.equal(holdsStolenExecutionPreview(owners, save, stores), false, "the owner itself");
+  assert.equal(
+    holdsStolenExecutionPreview(owners, imageCapableNode("VAEDecode", 9), stores),
+    true,
+    "a different node of a different type on the same entry",
+  );
+  assert.equal(
+    holdsStolenExecutionPreview(owners, imageCapableNode("VAEDecode", 11), stores),
+    false,
+    "a different id",
+  );
+  assert.equal(holdsStolenExecutionPreview(null, save, stores), false);
+});
+
+test("#1374: the PANEL's own call shape (no ledger argument) reaches the fix", () => {
+  // The production call sites pass {graph, nodeOutputs, nodePreviewImages, preferNodeId}
+  // and nothing else, so the module-level ledger is the one that must carry ownership
+  // from one run to the next. Drive exactly that shape.
+  executionPreviewOwnerLedger().clear();
+
+  const save = saveImageNode(9);
+  const entry = outputEntry();
+  const nodeOutputs = { "9": entry };
+  // onExecuted: `executed` named node 9.
+  stripMisattachedExecutionPreviews({
+    graph: { _nodes: [save] },
+    nodeOutputs,
+    nodePreviewImages: {},
+    preferNodeId: 9,
+  });
+  // onExecutionSuccess backstop.
+  stripMisattachedExecutionPreviews({
+    graph: { _nodes: [save] },
+    nodeOutputs,
+    nodePreviewImages: {},
+  });
+
+  const victim = imageCapableNode("VAEDecode", 9);
+  const { stripped } = stripMisattachedExecutionPreviews({
+    graph: { _nodes: [victim] },
+    nodeOutputs,
+    nodePreviewImages: {},
+  });
+
+  assert.equal(stripped, 1);
+  assert.equal(nodeOutputs["9"], undefined);
+  executionPreviewOwnerLedger().clear();
+});
+
+test("#1374: onExecuted still hands the sweep the id that emitted", () => {
+  // Without preferNodeId there is no per-run proof of emission and the ledger can
+  // never be seeded, so the type gate would be the only gate again.
+  const onExecuted = panelSrc.match(/function onExecuted\(ev\) \{[\s\S]*?\n {2}function onExecError/);
+  assert.ok(onExecuted, "onExecuted body not found");
+  assert.match(onExecuted[0], /stripMisattachedExecutionPreviews\(\{[\s\S]*?preferNodeId: nodeId/);
 });

--- a/browser_tests/unit/execution-preview-attach.test.mjs
+++ b/browser_tests/unit/execution-preview-attach.test.mjs
@@ -473,6 +473,51 @@ test("#1374: a LoadImage on a reused id keeps the thumbnail it hydrated itself",
   assert.deepEqual(loader.size, [315, 314], "the node must not collapse");
 });
 
+test("#1374: proving a NON-host's entry stolen still strips it in full (#1286 stays fixed)", () => {
+  const owners = new Map();
+  const { nodeOutputs } = runOneEmission(73, owners);
+
+  // ComfyUI's own paste/undo hands id 73 to a ConditioningConcat — #1286's victim, and
+  // a type that can never host a preview. A preview-only run then plants imgs and the
+  // pseudo-widget on it from a b_preview frame, so nothing it shows was aliased from
+  // the inherited entry: the narrow eviction alone would leave the whole symptom on
+  // screen while still reporting a strip.
+  const concat = concatNode(73);
+  const live = ["data:image/png;base64,AAAA"];
+  const nodePreviewImages = { "73": live };
+  const widget = concat.widgets[0];
+
+  const { stripped } = stripMisattachedExecutionPreviews({
+    graph: { _nodes: [concat] },
+    nodeOutputs,
+    nodePreviewImages,
+    owners,
+  });
+
+  assert.equal(stripped, 1);
+  assert.equal(concat.imgs, undefined, "the concat must not keep the preview");
+  assert.equal(concat.images, undefined);
+  assert.equal(concat.widgets.length, 0, "the pseudo-widget must go");
+  assert.equal(widget.removed, true);
+  assert.deepEqual(concat.size, [153, 46], "the node must collapse back");
+  assert.equal(nodeOutputs["73"], undefined);
+  assert.equal(nodePreviewImages["73"], undefined, "a non-host keeps no frame at all");
+});
+
+test("#1374: a non-host is counted once, not twice, when both paths fire", () => {
+  const owners = new Map();
+  const { entry, nodeOutputs } = runOneEmission(73, owners);
+  const concat = concatNode(73);
+  concat.images = entry.images; // rendered from the stolen entry AND a non-host
+  const { stripped } = stripMisattachedExecutionPreviews({
+    graph: { _nodes: [concat] },
+    nodeOutputs,
+    nodePreviewImages: {},
+    owners,
+  });
+  assert.equal(stripped, 1);
+});
+
 test("#1374: eviction does not take a live b_preview frame with it", () => {
   const owners = new Map();
   const { entry, nodeOutputs } = runOneEmission(9, owners);

--- a/browser_tests/unit/execution-preview-attach.test.mjs
+++ b/browser_tests/unit/execution-preview-attach.test.mjs
@@ -473,11 +473,34 @@ test("#1374: a LoadImage on a reused id keeps the thumbnail it hydrated itself",
   assert.deepEqual(loader.size, [315, 314], "the node must not collapse");
 });
 
+test("#1374: eviction does not take a live b_preview frame with it", () => {
+  const owners = new Map();
+  const { entry, nodeOutputs } = runOneEmission(9, owners);
+
+  // The proof is an entry in nodeOutputs. A node that inherits the id may still be
+  // RUNNING and painting its own latent frames into nodePreviewImages — those are not
+  // this entry's to evict, and deleting them would drop a frame mid-run.
+  const victim = imageCapableNode("VAEDecode", 9, entry);
+  const live = ["data:image/png;base64,AAAA"];
+  const nodePreviewImages = { "9": live };
+  const { stripped } = stripMisattachedExecutionPreviews({
+    graph: { _nodes: [victim] },
+    nodeOutputs,
+    nodePreviewImages,
+    owners,
+  });
+
+  assert.equal(stripped, 1);
+  assert.equal(nodeOutputs["9"], undefined, "the inherited entry goes");
+  assert.equal(nodePreviewImages["9"], live, "the live latent frame stays");
+});
+
 test("#1374: an entry written after the executed sweep is still attributed", () => {
-  // ComfyUI registers its own `executed` listener during app.setup(), before extension
-  // setup, so the panel's sweep can run with the store not yet written. The record is
-  // seeded there and caught up by the execution_success sweep — without that refresh
-  // the emitter's real entry is never attributed and the id can be stolen silently.
+  // The panel's sweep can reach the store before ComfyUI's own `executed` handling has
+  // written it — listener order is not something this module gets to assume. The record
+  // is seeded on the executed sweep and caught up by the execution_success one; without
+  // that refresh the emitter's real entry is never attributed and the id can be stolen
+  // silently.
   const owners = new Map();
   const save = saveImageNode(9);
   const nodeOutputs = {};

--- a/browser_tests/unit/execution-preview-attach.test.mjs
+++ b/browser_tests/unit/execution-preview-attach.test.mjs
@@ -225,7 +225,13 @@ function outputEntry(filename = "ComfyUI_00001_.png") {
   return { images: [{ filename, type: "output", subfolder: "" }] };
 }
 
-function imageCapableNode(type, id) {
+/**
+ * A node showing a preview the frontend planted from `entry`. `unsafeUpdatePreviews`
+ * does `this.images = output.images` BY REFERENCE and renders `imgs` from it, so the
+ * fixture shares the array rather than copying it — that identity is what tells a
+ * stolen render apart from a node's own image state.
+ */
+function imageCapableNode(type, id, entry) {
   const outputs =
     type === "EmptyLatentImage" ? [{ name: "LATENT", type: "LATENT" }] : [{ name: "IMAGE", type: "IMAGE" }];
   return {
@@ -233,10 +239,24 @@ function imageCapableNode(type, id) {
     type,
     size: [210, 266],
     widgets: [previewWidget()],
-    imgs: [{ src: "/view?filename=ComfyUI_00001_.png" }],
-    images: [{ filename: "ComfyUI_00001_.png", type: "output" }],
+    imgs: entry ? entry.images.map((m) => ({ src: `/view?filename=${m.filename}` })) : undefined,
+    images: entry ? entry.images : undefined,
     outputs,
     computeSize() { return [210, 46]; },
+    setSize(size) { this.size = size; },
+  };
+}
+
+/** LoadImage hydrates `imgs` from its OWN filename widget — never from the store. */
+function loadImageNode(id) {
+  return {
+    id,
+    type: "LoadImage",
+    size: [315, 314],
+    widgets: [{ name: "image", value: "portrait.png" }, previewWidget()],
+    imgs: [{ src: "/view?filename=portrait.png&type=input" }],
+    outputs: [{ name: "IMAGE", type: "IMAGE" }],
+    computeSize() { return [315, 58]; },
     setSize(size) { this.size = size; },
   };
 }
@@ -267,7 +287,7 @@ for (const victimType of ["VAEDecode", "ImageScale", "EmptyLatentImage"]) {
 
     // ComfyUI's own paste / undo / load reuses id 9 for a DIFFERENT node. The panel
     // never sees that edit, so the store entry SaveImage emitted is still sitting there.
-    const victim = imageCapableNode(victimType, 9);
+    const victim = imageCapableNode(victimType, 9, entry);
     const graph = { _nodes: [victim] };
     const { stripped } = stripMisattachedExecutionPreviews({
       graph,
@@ -282,6 +302,7 @@ for (const victimType of ["VAEDecode", "ImageScale", "EmptyLatentImage"]) {
     assert.equal(nodeOutputs["9"], undefined);
     assert.deepEqual(victim.size, [210, 46]);
     assert.equal(entry.images.length, 1, "the emitter's own entry object is not mutated");
+    assert.equal(victim.images, undefined);
   });
 }
 
@@ -327,7 +348,7 @@ test("#1374: a REPLACED store entry is not judged — restored /history outputs 
   // repopulates app.nodeOutputs from the job payload: brand-new node objects AND
   // brand-new entry objects. Nothing here is evidence of a steal.
   nodeOutputs["9"] = outputEntry("restored_00007_.png");
-  const restored = imageCapableNode("VAEDecode", 9);
+  const restored = imageCapableNode("VAEDecode", 9, nodeOutputs["9"]);
   const graph = { _nodes: [restored] };
   const { stripped } = stripMisattachedExecutionPreviews({
     graph,
@@ -343,8 +364,9 @@ test("#1374: a REPLACED store entry is not judged — restored /history outputs 
 
 test("#1374: with no emission on record an image-capable node is left alone", () => {
   const owners = new Map();
-  const decode = imageCapableNode("VAEDecode", 9);
-  const nodeOutputs = { "9": outputEntry() };
+  const entry = outputEntry();
+  const decode = imageCapableNode("VAEDecode", 9, entry);
+  const nodeOutputs = { "9": entry };
   const { stripped } = stripMisattachedExecutionPreviews({
     graph: { _nodes: [decode] },
     nodeOutputs,
@@ -353,39 +375,6 @@ test("#1374: with no emission on record an image-capable node is left alone", ()
   });
   assert.equal(stripped, 0);
   assert.ok(decode.imgs?.length);
-});
-
-test("#1374: a stolen b_preview frame is swept too, not just executed outputs", () => {
-  const owners = new Map();
-  const ksampler = {
-    id: 4,
-    type: "KSampler",
-    outputs: [{ name: "LATENT", type: "LATENT" }],
-    widgets: [],
-    computeSize() { return [270, 262]; },
-    setSize(size) { this.size = size; },
-  };
-  const frame = ["data:image/png;base64,AAAA"];
-  const nodePreviewImages = { "4": frame };
-  stripMisattachedExecutionPreviews({
-    graph: { _nodes: [ksampler] },
-    nodeOutputs: {},
-    nodePreviewImages,
-    preferNodeId: 4,
-    owners,
-  });
-
-  const victim = imageCapableNode("ImageScale", 4);
-  victim.imgs = undefined;
-  victim.images = undefined;
-  const { stripped } = stripMisattachedExecutionPreviews({
-    graph: { _nodes: [victim] },
-    nodeOutputs: {},
-    nodePreviewImages,
-    owners,
-  });
-  assert.equal(stripped, 1);
-  assert.equal(nodePreviewImages["4"], undefined);
 });
 
 test("#1374: the ledger stays graph-sized — records for vanished ids are pruned", () => {
@@ -414,12 +403,12 @@ test("#1374: holdsStolenExecutionPreview only fires on positive evidence", () =>
 
   assert.equal(holdsStolenExecutionPreview(owners, save, stores), false, "the owner itself");
   assert.equal(
-    holdsStolenExecutionPreview(owners, imageCapableNode("VAEDecode", 9), stores),
+    holdsStolenExecutionPreview(owners, imageCapableNode("VAEDecode", 9, entry), stores),
     true,
     "a different node of a different type on the same entry",
   );
   assert.equal(
-    holdsStolenExecutionPreview(owners, imageCapableNode("VAEDecode", 11), stores),
+    holdsStolenExecutionPreview(owners, imageCapableNode("VAEDecode", 11, entry), stores),
     false,
     "a different id",
   );
@@ -449,7 +438,7 @@ test("#1374: the PANEL's own call shape (no ledger argument) reaches the fix", (
     nodePreviewImages: {},
   });
 
-  const victim = imageCapableNode("VAEDecode", 9);
+  const victim = imageCapableNode("VAEDecode", 9, entry);
   const { stripped } = stripMisattachedExecutionPreviews({
     graph: { _nodes: [victim] },
     nodeOutputs,
@@ -459,6 +448,65 @@ test("#1374: the PANEL's own call shape (no ledger argument) reaches the fix", (
   assert.equal(stripped, 1);
   assert.equal(nodeOutputs["9"], undefined);
   executionPreviewOwnerLedger().clear();
+});
+
+test("#1374: a LoadImage on a reused id keeps the thumbnail it hydrated itself", () => {
+  const owners = new Map();
+  const { nodeOutputs } = runOneEmission(9, owners);
+
+  // LoadImage is image-capable (test above), so the ledger CAN reach it — and its
+  // imgs/pseudo-widget are its own file thumbnail, not the entry it inherited.
+  // stripNodeExecutionPreview would delete both and collapse the node to 58px.
+  const loader = loadImageNode(9);
+  const ownImgs = loader.imgs;
+  const { stripped } = stripMisattachedExecutionPreviews({
+    graph: { _nodes: [loader] },
+    nodeOutputs,
+    nodePreviewImages: {},
+    owners,
+  });
+
+  assert.equal(stripped, 1, "the leftover store entry must still go");
+  assert.equal(nodeOutputs["9"], undefined, "the inherited entry is dropped");
+  assert.equal(loader.imgs, ownImgs, "the LoadImage thumbnail is not its inheritance");
+  assert.equal(loader.widgets.some((w) => w.name === CANVAS_IMAGE_PREVIEW_WIDGET), true);
+  assert.deepEqual(loader.size, [315, 314], "the node must not collapse");
+});
+
+test("#1374: an entry written after the executed sweep is still attributed", () => {
+  // ComfyUI registers its own `executed` listener during app.setup(), before extension
+  // setup, so the panel's sweep can run with the store not yet written. The record is
+  // seeded there and caught up by the execution_success sweep — without that refresh
+  // the emitter's real entry is never attributed and the id can be stolen silently.
+  const owners = new Map();
+  const save = saveImageNode(9);
+  const nodeOutputs = {};
+  stripMisattachedExecutionPreviews({
+    graph: { _nodes: [save] },
+    nodeOutputs,
+    nodePreviewImages: {},
+    preferNodeId: 9,
+    owners,
+  });
+
+  const entry = outputEntry();
+  nodeOutputs["9"] = entry; // ComfyUI writes it a tick later
+  stripMisattachedExecutionPreviews({
+    graph: { _nodes: [save] },
+    nodeOutputs,
+    nodePreviewImages: {},
+    owners,
+  });
+
+  const victim = imageCapableNode("VAEDecode", 9, entry);
+  const { stripped } = stripMisattachedExecutionPreviews({
+    graph: { _nodes: [victim] },
+    nodeOutputs,
+    nodePreviewImages: {},
+    owners,
+  });
+  assert.equal(stripped, 1);
+  assert.equal(nodeOutputs["9"], undefined);
 });
 
 test("#1374: onExecuted still hands the sweep the id that emitted", () => {

--- a/web/js/lib/execution-preview-attach.js
+++ b/web/js/lib/execution-preview-attach.js
@@ -22,8 +22,22 @@
  * positive evidence -- the very same entry object, under a different node object of
  * a different type. Anything weaker (a replaced entry from a new run or a restored
  * history payload, a same-type recreate/undo whose preview ComfyUI means to restore)
- * falls back to the type gate, so the ledger can only ever strip MORE precisely,
- * never more eagerly.
+ * is not judged at all and falls back to the type gate.
+ *
+ * That WIDENS who the sweep looks at (image-capable hosts are no longer exempt), so
+ * it deliberately NARROWS what it does to them. An image-capable host owns image
+ * state of its own -- LoadImage hydrates `node.imgs` from its filename widget and
+ * carries the same `$$canvas-image-preview` widget -- and none of that belongs to the
+ * inherited entry. Only state ComfyUI derived FROM the stolen entry is evicted, which
+ * is decidable: `unsafeUpdatePreviews` assigns `this.images = output.images` by
+ * reference, so `node.images === record.output.images` is exactly "what is on screen
+ * is the stolen entry". When that does not hold, only the leftover store entry goes.
+ *
+ * Known gap, deliberately not closed here: ownership is seeded from `executed`, so a
+ * node whose only output is `b_preview` latent frames (a KSampler mid-run) never
+ * enters the ledger and is still judged by type alone. Seeding that would mean
+ * attributing on `executing` -- ownership from "started" rather than "emitted" -- which
+ * is a different rule than this issue asks for.
  */
 
 export const CANVAS_IMAGE_PREVIEW_WIDGET = "$$canvas-image-preview";
@@ -95,15 +109,14 @@ export function recordExecutionPreviewOwner(owners, node, stores) {
     node,
     type: String(node.type || ""),
     output: storeEntry(stores?.nodeOutputs, node.id),
-    preview: storeEntry(stores?.nodePreviewImages, node.id),
   });
   return true;
 }
 
 /**
- * True only when the store entry at this node's id is the SAME object we watched a
- * different node -- of a different type -- receive. That is a stolen preview: the id
- * was reused (ComfyUI's own paste/undo/load, paths the panel does not hook) while the
+ * The ownership record proving this node's id holds an entry a DIFFERENT node -- of a
+ * different type -- was credited with, or null. That is a stolen preview: the id was
+ * reused (ComfyUI's own paste/undo/load, paths the panel does not hook) while the
  * emitter's entry stayed behind.
  *
  * Deliberately silent when the evidence is weaker:
@@ -112,16 +125,52 @@ export function recordExecutionPreviewOwner(owners, node, stores) {
  *   - the new occupant has the SAME type     -> a recreate/undo whose preview ComfyUI
  *                                               means to re-plant from the store
  */
-export function holdsStolenExecutionPreview(owners, node, stores) {
-  if (!owners || !node || node.id == null) return false;
+function stolenExecutionPreviewRecord(owners, node, stores) {
+  if (!owners || !node || node.id == null) return null;
   const record = owners.get(String(node.id));
-  if (!record || record.node === node) return false;
-  if (record.type === String(node.type || "")) return false;
-  const output = storeEntry(stores?.nodeOutputs, node.id);
-  if (output !== undefined && output === record.output) return true;
-  const preview = storeEntry(stores?.nodePreviewImages, node.id);
-  if (preview !== undefined && preview === record.preview) return true;
-  return false;
+  if (!record || record.node === node) return null;
+  if (record.type === String(node.type || "")) return null;
+  if (record.output === undefined) return null;
+  return storeEntry(stores?.nodeOutputs, node.id) === record.output ? record : null;
+}
+
+/** Boolean form of {@link stolenExecutionPreviewRecord}. */
+export function holdsStolenExecutionPreview(owners, node, stores) {
+  return stolenExecutionPreviewRecord(owners, node, stores) != null;
+}
+
+/**
+ * Evict a preview this node inherited with a reused id -- WITHOUT touching image state
+ * that is its own. `stripNodeExecutionPreview` is wrong here: it wipes `node.imgs`
+ * unconditionally, which for a LoadImage sitting on a reused id would delete the
+ * thumbnail it hydrated from its own filename widget and collapse the node. That is the
+ * same invariant `clearInheritedExecutionPreview` already protects.
+ *
+ * `node.images` is assigned `output.images` BY REFERENCE by `unsafeUpdatePreviews`, and
+ * `node.imgs` is rendered from it, so array identity decides whether what is on screen
+ * came from the stolen entry. If it did not, the entry is merely leftover in the store
+ * and dropping it is the whole job.
+ */
+function evictInheritedExecutionPreview(node, stores, record) {
+  const rendered =
+    Array.isArray(record?.output?.images) && node.images === record.output.images;
+  let changed = false;
+  if (rendered) {
+    if (node.imgs != null) {
+      node.imgs = undefined;
+      changed = true;
+    }
+    node.images = undefined;
+    if (node.preview != null) {
+      node.preview = undefined;
+      changed = true;
+    }
+    if (removePreviewWidget(node)) changed = true;
+    changed = true;
+    restoreCompactSize(node);
+  }
+  if (clearStoredExecutionOutputs(stores, node.id)) changed = true;
+  return changed;
 }
 
 /**
@@ -135,7 +184,6 @@ function refreshExecutionPreviewOwners(owners, nodesById, stores) {
   for (const [key, record] of owners) {
     if (nodesById.get(key) !== record.node) continue;
     record.output = storeEntry(stores.nodeOutputs, key);
-    record.preview = storeEntry(stores.nodePreviewImages, key);
   }
 }
 
@@ -144,7 +192,6 @@ function pruneExecutionPreviewOwners(owners, nodesById, stores) {
   for (const key of [...owners.keys()]) {
     if (nodesById.has(key)) continue;
     if (storeEntry(stores.nodeOutputs, key) !== undefined) continue;
-    if (storeEntry(stores.nodePreviewImages, key) !== undefined) continue;
     owners.delete(key);
   }
 }
@@ -341,9 +388,16 @@ export function stripMisattachedExecutionPreviews({
   for (const node of nodes) {
     if (!node) continue;
     // A type that COULD show an image is exempt only while nothing proves the image
-    // it is showing belongs to someone else (#1374).
-    const stolen = owners ? holdsStolenExecutionPreview(owners, node, stores) : false;
-    if (!stolen && nodeAcceptsExecutionImagePreview(node)) continue;
+    // it is showing belongs to someone else (#1374) -- and when something does, only
+    // the inherited state goes, never the node's own.
+    const stolen = owners ? stolenExecutionPreviewRecord(owners, node, stores) : null;
+    if (stolen) {
+      if (evictInheritedExecutionPreview(node, stores, stolen)) stripped += 1;
+      // The entry is gone; the record can no longer describe anything.
+      owners.delete(String(node.id));
+      continue;
+    }
+    if (nodeAcceptsExecutionImagePreview(node)) continue;
     const hasPreview =
       node.imgs != null ||
       node.images != null ||
@@ -354,8 +408,6 @@ export function stripMisattachedExecutionPreviews({
       storeHasImages(nodePreviewImages, node.id);
     if (!hasPreview) continue;
     if (stripNodeExecutionPreview(node, stores)) stripped += 1;
-    // The entry is gone; the record can no longer describe anything.
-    if (stolen) owners.delete(String(node.id));
   }
   if (owners) pruneExecutionPreviewOwners(owners, nodesById, stores);
   return { stripped, rehomed };

--- a/web/js/lib/execution-preview-attach.js
+++ b/web/js/lib/execution-preview-attach.js
@@ -33,11 +33,18 @@
  * reference, so `node.images === record.output.images` is exactly "what is on screen
  * is the stolen entry". When that does not hold, only the leftover store entry goes.
  *
- * Known gap, deliberately not closed here: ownership is seeded from `executed`, so a
- * node whose only output is `b_preview` latent frames (a KSampler mid-run) never
- * enters the ledger and is still judged by type alone. Seeding that would mean
- * attributing on `executing` -- ownership from "started" rather than "emitted" -- which
- * is a different rule than this issue asks for.
+ * Known gaps, deliberately not closed here. Both leave an image-capable victim to the
+ * pre-existing type gate, which is where it already was, so neither is a regression:
+ *
+ *   - Ownership is seeded from `executed`, so a node whose only output is `b_preview`
+ *     latent frames (a KSampler mid-run) never enters the ledger and is judged by type
+ *     alone. Seeding it would mean attributing on `executing` -- ownership from
+ *     "started" rather than "emitted" -- a different rule than this issue asks for.
+ *   - A gifs/videos-only emitter (VHS_VideoCombine) has no `output.images` for the
+ *     frontend to alias, so there is no identity to test and `rendered` is false: the
+ *     inherited entry is dropped but a stale animation on an image-capable victim is
+ *     not. Deciding that one needs content matching, which is weaker evidence than
+ *     anything else here rests on.
  */
 
 export const CANVAS_IMAGE_PREVIEW_WIDGET = "$$canvas-image-preview";
@@ -396,26 +403,30 @@ export function stripMisattachedExecutionPreviews({
   for (const node of nodes) {
     if (!node) continue;
     // A type that COULD show an image is exempt only while nothing proves the image
-    // it is showing belongs to someone else (#1374) -- and when something does, only
-    // the inherited state goes, never the node's own.
+    // it is showing belongs to someone else (#1374). Eviction is what that proof buys,
+    // and it is deliberately NARROWER than the type gate's strip -- so it must not
+    // replace it. A node that can never host a preview still falls through and gets
+    // stripped in full; otherwise proving a ConditioningConcat's entry stolen would
+    // leave it holding the very preview #1286 exists to remove.
     const stolen = owners ? stolenExecutionPreviewRecord(owners, node, stores) : null;
+    let changed = false;
     if (stolen) {
-      if (evictInheritedExecutionPreview(node, stores, stolen)) stripped += 1;
+      changed = evictInheritedExecutionPreview(node, stores, stolen);
       // The entry is gone; the record can no longer describe anything.
       owners.delete(String(node.id));
-      continue;
     }
-    if (nodeAcceptsExecutionImagePreview(node)) continue;
-    const hasPreview =
-      node.imgs != null ||
-      node.images != null ||
-      node.preview != null ||
-      (Array.isArray(node.widgets) &&
-        node.widgets.some((w) => w?.name === CANVAS_IMAGE_PREVIEW_WIDGET)) ||
-      storeHasImages(nodeOutputs, node.id) ||
-      storeHasImages(nodePreviewImages, node.id);
-    if (!hasPreview) continue;
-    if (stripNodeExecutionPreview(node, stores)) stripped += 1;
+    if (!nodeAcceptsExecutionImagePreview(node)) {
+      const hasPreview =
+        node.imgs != null ||
+        node.images != null ||
+        node.preview != null ||
+        (Array.isArray(node.widgets) &&
+          node.widgets.some((w) => w?.name === CANVAS_IMAGE_PREVIEW_WIDGET)) ||
+        storeHasImages(nodeOutputs, node.id) ||
+        storeHasImages(nodePreviewImages, node.id);
+      if (hasPreview && stripNodeExecutionPreview(node, stores)) changed = true;
+    }
+    if (changed) stripped += 1;
   }
   if (owners) pruneExecutionPreviewOwners(owners, nodesById, stores);
   return { stripped, rehomed };

--- a/web/js/lib/execution-preview-attach.js
+++ b/web/js/lib/execution-preview-attach.js
@@ -12,6 +12,18 @@
  * The panel cannot stop ComfyUI writing the store. It CAN (a) wipe inherited
  * store entries when a node is created or removed, and (b) after a run, strip
  * preview state from every node that cannot emit an image.
+ *
+ * #1374 — (b) alone gates on what a node TYPE could ever show, so an
+ * image-capable victim (VAEDecode, ImageScale, EmptyLatentImage) that inherits a
+ * reused id keeps the previous occupant's preview. Types cannot answer "did THIS
+ * node emit?", so the sweep also keeps a small ownership ledger: every `executed`
+ * frame names an id, and we remember which node OBJECT held that id plus the exact
+ * store entry it received. A later occupant of the same id is judged stolen only on
+ * positive evidence -- the very same entry object, under a different node object of
+ * a different type. Anything weaker (a replaced entry from a new run or a restored
+ * history payload, a same-type recreate/undo whose preview ComfyUI means to restore)
+ * falls back to the type gate, so the ledger can only ever strip MORE precisely,
+ * never more eagerly.
  */
 
 export const CANVAS_IMAGE_PREVIEW_WIDGET = "$$canvas-image-preview";
@@ -48,6 +60,93 @@ function storeHasImages(bag, nodeId) {
     if (entry?.images?.length) return true;
   }
   return false;
+}
+
+/** The raw store value at `nodeId`, whatever its shape (identity matters, not content). */
+function storeEntry(bag, nodeId) {
+  if (!bag || nodeId == null) return undefined;
+  for (const key of outputStoreKeys(nodeId)) {
+    if (bag[key] !== undefined) return bag[key];
+  }
+  return undefined;
+}
+
+/**
+ * #1374 — id -> the node object that was proven to own the store entry at that id,
+ * with the exact entry objects it received. Keyed by id because that is the only
+ * thing ComfyUI keys previews by; identity-checked because an id is reusable and a
+ * type is not proof of anything.
+ */
+const executionPreviewOwners = new Map();
+
+/** Test seam: the process-wide ledger the panel's call sites use. */
+export function executionPreviewOwnerLedger() {
+  return executionPreviewOwners;
+}
+
+/**
+ * Record that `node` owns whatever the stores currently hold at its id. Called for
+ * the id an `executed` frame named -- the one piece of per-run evidence ComfyUI
+ * gives us about which node actually emitted.
+ */
+export function recordExecutionPreviewOwner(owners, node, stores) {
+  if (!owners || !node || node.id == null) return false;
+  owners.set(String(node.id), {
+    node,
+    type: String(node.type || ""),
+    output: storeEntry(stores?.nodeOutputs, node.id),
+    preview: storeEntry(stores?.nodePreviewImages, node.id),
+  });
+  return true;
+}
+
+/**
+ * True only when the store entry at this node's id is the SAME object we watched a
+ * different node -- of a different type -- receive. That is a stolen preview: the id
+ * was reused (ComfyUI's own paste/undo/load, paths the panel does not hook) while the
+ * emitter's entry stayed behind.
+ *
+ * Deliberately silent when the evidence is weaker:
+ *   - no record for this id                  -> nothing was ever proven to emit here
+ *   - the entry was replaced                 -> a new run, or restored /history outputs
+ *   - the new occupant has the SAME type     -> a recreate/undo whose preview ComfyUI
+ *                                               means to re-plant from the store
+ */
+export function holdsStolenExecutionPreview(owners, node, stores) {
+  if (!owners || !node || node.id == null) return false;
+  const record = owners.get(String(node.id));
+  if (!record || record.node === node) return false;
+  if (record.type === String(node.type || "")) return false;
+  const output = storeEntry(stores?.nodeOutputs, node.id);
+  if (output !== undefined && output === record.output) return true;
+  const preview = storeEntry(stores?.nodePreviewImages, node.id);
+  if (preview !== undefined && preview === record.preview) return true;
+  return false;
+}
+
+/**
+ * Re-snapshot the entries of ids whose owner is still in place. The panel's sweep can
+ * run before ComfyUI's own `executed` listener has written the store, so the snapshot
+ * taken at record time may be a frame behind; refreshing on the later
+ * `execution_success` sweep catches it up. Safe by construction -- an id whose owner
+ * object is unchanged holds that owner's own output.
+ */
+function refreshExecutionPreviewOwners(owners, nodesById, stores) {
+  for (const [key, record] of owners) {
+    if (nodesById.get(key) !== record.node) continue;
+    record.output = storeEntry(stores.nodeOutputs, key);
+    record.preview = storeEntry(stores.nodePreviewImages, key);
+  }
+}
+
+/** Forget ids that no longer name a node or a store entry, so the ledger stays graph-sized. */
+function pruneExecutionPreviewOwners(owners, nodesById, stores) {
+  for (const key of [...owners.keys()]) {
+    if (nodesById.has(key)) continue;
+    if (storeEntry(stores.nodeOutputs, key) !== undefined) continue;
+    if (storeEntry(stores.nodePreviewImages, key) !== undefined) continue;
+    owners.delete(key);
+  }
 }
 
 /**
@@ -189,7 +288,12 @@ function moveStoredOutputs(stores, fromId, toId) {
 
 /**
  * After a run: re-home stolen image outputs onto `preferNodeId` when that node
- * is a real host, then strip preview state from every non-host.
+ * is a real host, then strip preview state from every non-host -- plus (#1374)
+ * every node provably holding an entry a DIFFERENT node emitted, which is the
+ * only way an image-capable victim of id reuse gets swept at all.
+ *
+ * `preferNodeId` is the id an `executed` frame named, so it doubles as this run's
+ * proof of emission and is what feeds the ownership ledger.
  *
  * @returns {{ stripped: number, rehomed: boolean }}
  */
@@ -198,10 +302,25 @@ export function stripMisattachedExecutionPreviews({
   nodeOutputs,
   nodePreviewImages,
   preferNodeId,
+  owners = executionPreviewOwners,
 } = {}) {
   const nodes = graph?._nodes ?? graph?.nodes ?? [];
   const stores = { nodeOutputs, nodePreviewImages };
   let rehomed = false;
+
+  const nodesById = new Map();
+  for (const node of nodes) {
+    if (node && node.id != null) nodesById.set(String(node.id), node);
+  }
+  if (owners) {
+    refreshExecutionPreviewOwners(owners, nodesById, stores);
+    if (preferNodeId != null) {
+      const emitter = nodesById.get(String(preferNodeId));
+      // Record BEFORE the strip loop: the node that just emitted owns this id now,
+      // whatever it inherited a moment ago.
+      if (emitter) recordExecutionPreviewOwner(owners, emitter, stores);
+    }
+  }
 
   if (preferNodeId != null) {
     const prefer = nodes.find((n) => n && String(n.id) === String(preferNodeId));
@@ -220,7 +339,11 @@ export function stripMisattachedExecutionPreviews({
 
   let stripped = 0;
   for (const node of nodes) {
-    if (!node || nodeAcceptsExecutionImagePreview(node)) continue;
+    if (!node) continue;
+    // A type that COULD show an image is exempt only while nothing proves the image
+    // it is showing belongs to someone else (#1374).
+    const stolen = owners ? holdsStolenExecutionPreview(owners, node, stores) : false;
+    if (!stolen && nodeAcceptsExecutionImagePreview(node)) continue;
     const hasPreview =
       node.imgs != null ||
       node.images != null ||
@@ -231,6 +354,9 @@ export function stripMisattachedExecutionPreviews({
       storeHasImages(nodePreviewImages, node.id);
     if (!hasPreview) continue;
     if (stripNodeExecutionPreview(node, stores)) stripped += 1;
+    // The entry is gone; the record can no longer describe anything.
+    if (stolen) owners.delete(String(node.id));
   }
+  if (owners) pruneExecutionPreviewOwners(owners, nodesById, stores);
   return { stripped, rehomed };
 }

--- a/web/js/lib/execution-preview-attach.js
+++ b/web/js/lib/execution-preview-attach.js
@@ -150,6 +150,11 @@ export function holdsStolenExecutionPreview(owners, node, stores) {
  * `node.imgs` is rendered from it, so array identity decides whether what is on screen
  * came from the stolen entry. If it did not, the entry is merely leftover in the store
  * and dropping it is the whole job.
+ *
+ * Scoped to `nodeOutputs` on purpose. The evidence is an entry in THAT store, and says
+ * nothing about `nodePreviewImages` — a node sitting on a reused id may still be running
+ * and painting its own live `b_preview` latent frames, which are not this entry's to
+ * evict. `node.preview` is left for the same reason; the next latent frame repaints it.
  */
 function evictInheritedExecutionPreview(node, stores, record) {
   const rendered =
@@ -161,15 +166,18 @@ function evictInheritedExecutionPreview(node, stores, record) {
       changed = true;
     }
     node.images = undefined;
-    if (node.preview != null) {
-      node.preview = undefined;
-      changed = true;
-    }
     if (removePreviewWidget(node)) changed = true;
     changed = true;
     restoreCompactSize(node);
   }
-  if (clearStoredExecutionOutputs(stores, node.id)) changed = true;
+  const outputs = stores?.nodeOutputs;
+  if (outputs) {
+    for (const key of outputStoreKeys(node.id)) {
+      if (!Object.prototype.hasOwnProperty.call(outputs, key)) continue;
+      delete outputs[key];
+      changed = true;
+    }
+  }
   return changed;
 }
 


### PR DESCRIPTION
## Summary

`stripMisattachedExecutionPreviews` (shipped by #1361 for #1286) decided who may keep an
execution preview by asking **"could this node type ever show an image?"**. ComfyUI attaches
previews purely by node **id** — `unsafeUpdatePreviews` → `getNodeOutputs(this)` →
`$.nodeOutputs[locatorId(this)]` → `this.imgs?.length && showCanvasImagePreview(this)`; no slot,
no prompt-output matching. So an id reused by an *image-capable* node inherits the previous
occupant's images and the type gate waves it through. Holding #1286's scenario fixed and varying
only the victim's type, `ConditioningConcat` / `ConditioningCombine` / `CheckpointLoaderSimple`
were cleaned but `VAEDecode` / `ImageScale` / `EmptyLatentImage` kept the stolen preview.

A type can never answer "did *this node* emit?", so the sweep now also carries a small ownership
ledger. Every `executed` frame names an id (`preferNodeId`, already passed by `onExecuted`); we
remember which node **object** held that id and the exact `nodeOutputs` entry it received. A later
occupant of that id is judged stolen only on positive evidence, and is otherwise left to the
existing type gate:

| evidence | verdict |
|---|---|
| same entry object, different node object, **different type** | stolen → evicted |
| no emission ever recorded for that id | unknown → type gate (unchanged) |
| entry object was **replaced** (new run, or `app.nodeOutputs` repopulated from `/history`) | unknown → type gate |
| different node object but **same type** (`Fix node (recreate)`, ChangeTracker undo) | not stolen — ComfyUI means to re-plant that preview from the surviving entry |

Because this **widens** who the sweep looks at, it deliberately **narrows** what it does to them.
An image-capable host owns image state of its own — a `LoadImage` hydrates `node.imgs` from its
filename widget and carries the same `$$canvas-image-preview` widget — and none of that belongs to
the inherited entry. `unsafeUpdatePreviews` assigns `this.images = output.images` *by reference*,
so `node.images === record.output.images` decides precisely whether what is on screen came from
the stolen entry. When it did, the derived state goes; when it did not, only the leftover store
entry is dropped and the node keeps its own thumbnail and its own size.

Scope is unchanged from the issue's assessment: #1361's `clear*` calls already close id reuse for
all types on the `panel_add_node` / `panel_remove_node` paths, so this only bites on paths the
panel does not hook (ComfyUI's own paste/undo, or a load that resets `last_node_id`). Derived by
construction; not observed in the wild.

**Known gap, deliberately not closed here** (named in the module header): ownership is seeded from
`executed`, and `onExecuted` returns early unless a frame carried media — so a node whose only
output is `b_preview` latent frames (a KSampler mid-run) never enters the ledger and is still
judged by type alone. Seeding it would mean attributing ownership on `executing` — "started"
rather than "emitted" — which is a different rule than this issue asks for.

**No panel source change**: `onExecuted` / `onExecutionSuccess` already call the sweep with exactly
the shape the ledger needs, so the whole fix lands behind the existing call sites.

## Test plan

- [x] `node --test browser_tests/unit/execution-preview-attach.test.mjs` — 26 pass (10 pre-existing #1286 + 16 new)
- [x] `npm run test:unit` on the rebased tree — **5529 pass / 0 fail**
- [x] `npm run typecheck` — clean
- [x] A test drives the **production call shape** (no `owners` argument, so the module-level ledger
  is the one under test) rather than only the injectable seam.
- [x] **Verified by mutation** — 10 mutants, fix committed first, worktree restored after each; **no survivors**:
  | mutant | caught by |
  |---|---|
  | type gate is the only gate again | the 3 victim-type tests + panel-call-shape |
  | stolen host gets the full `stripNodeExecutionPreview` | `a LoadImage on a reused id keeps the thumbnail it hydrated itself` |
  | eviction ignores whether the render came from the stolen entry | same |
  | no refresh of a still-owned id | `an entry written after the executed sweep is still attributed` |
  | same-type guard removed | `a same-type recreate/undo ... keeps the preview ComfyUI re-plants` |
  | entry-identity evidence removed | `a REPLACED store entry is not judged` |
  | owner never recorded | the victim-type tests |
  | eviction scoped back to both stores | `eviction does not take a live b_preview frame with it` |
  | eviction skips the type gate again | `proving a NON-host's entry stolen still strips it in full (#1286 stays fixed)` |
  | prune disabled | `the ledger stays graph-sized` |

### Browser verification — partial, and stated plainly

**No e2e spec in this repo touches `nodeOutputs` / `nodePreviewImages` / `imgs` at all**, so the
Playwright suite cannot validate this fix either way. The most it can show is that the panel still
loads and behaves as it does on `main`.

It was run for real against the ComfyUI allocated to this issue (`ap-1374`, port 9574), with that
instance's `custom_nodes` checkout repointed at this branch and confirmed to be **serving the
patched module** before each run — so these exercised the branch, not `main`. A baseline run of the
same suite against `origin/main` on the same instance is included for attribution, because the
suite is heavily red on this machine regardless of the diff:

| tree | failed | passed |
|---|---|---|
| `origin/main` (baseline) | 35 | 40 |
| this branch | 18 | 57 |

All 18 failures on the branch were a strict subset of the baseline's 35 — none unique to this
change, all chat/conversation/MockBridge specs.

Caveat I am not going to paper over: those numbers were measured on the **round-2** commit. A
re-run against the final commit cascaded to 9 passed, and the cause was environmental, not the
diff — the ComfyUI instance went down mid-run (`curl` to 9574 returns nothing), and the slot is
shared: another session had repointed it to its own commit by the time the run ended. I did not
re-measure after that. Given no spec exercises this code path, the behavioural evidence for the
fix is the unit + mutation work above, not the browser suite.

## Gate

codex was unavailable (account exhausted until 2026-08-19 20:43); gated by an independent
adversarial review instead (`claude-gate.mjs`, a fresh reviewer that never saw the authoring
reasoning).

Round 1 returned **NO-SHIP** with two P1s, both real and both reproduced by the reviewer:

1. the `stolen` branch routed image-capable hosts into `stripNodeExecutionPreview`, destroying a
   `LoadImage`'s own thumbnail and collapsing the node — fixed by the narrowed eviction above, and
   pinned by two of the mutants;
2. the `record.preview` half was unreachable in production, and the test certifying it hand-passed
   a `preferNodeId` the panel never supplies — the half and the test are gone, and the gap is
   documented instead of silently half-covered.

The reviewer also caught that the victim fixtures *copied* the entry's `images` array where the
frontend shares it by reference; corrected, which is what made the `LoadImage` class visible at all.

Round 2 returned **SHIP**, and flagged one P2 which is also fixed: eviction called
`clearStoredExecutionOutputs`, which drops the `nodePreviewImages` entry too. The evidence is an
entry in `nodeOutputs` and says nothing about live `b_preview` frames — a node on a reused id may
still be running and painting its own latent previews, and taking those with it drops a frame
mid-run (and `delete`d blob URLs without releasing them). Eviction is now scoped to `nodeOutputs`,
pinned by a test asserting the live frame survives.

Round 3 returned **NO-SHIP** on a P1 that was **a regression introduced by the round-2 fix** —
narrowing eviction for image-capable hosts was right, but the stolen branch also `continue`d past
the type gate, and eviction is not a superset of `stripNodeExecutionPreview`. A `ConditioningConcat`
on a reused id whose visible preview came from a `b_preview` frame kept `imgs`, the pseudo-widget,
its 266px size and its `nodePreviewImages` frame — #1286's exact symptom — while the sweep still
reported `stripped: 1`, self-healing only on the next queued prompt. Eviction no longer replaces
the type gate: a node that can never host a preview falls through and is stripped in full, counted
once. Every #1374 victim was image-capable, which is why no test drove a non-host through the new
branch; two now do.

That round also surfaced a second gap, now named in the header rather than half-covered: a
gifs/videos-only emitter (`VHS_VideoCombine`) has no `output.images` for the frontend to alias, so
there is no identity to test and a stale animation on an image-capable victim survives. Not a
regression — that victim was fully exempt before.

Two sub-P1 notes recorded rather than fixed, both pre-existing or vanishingly narrow:
`preferNodeId` is `d.node ?? d.display_node` while ComfyUI writes under `display_node || node`, so
a backend-expanded frame never seeds the ledger (identical to pre-diff behaviour — the type gate
still applies); and entry identity survives an in-place mutation of the entry, so a false positive
needs id reuse *and* expansion *and* `setOutputsByLocatorId({merge:true})` at once, with the
surviving entry still containing the stolen image.

Round 4 returned **SHIP** with no findings: 26/26 suite, an independent 11-mutant kill run on the
new logic (8 killed, 3 equivalent), and hostile scenarios against the ledger. The one state that
would destroy a real emitter's preview — two graph nodes sharing an id, where the last-wins
`nodesById` credits the wrong owner — is unreachable, because `LGraph.add` renumbers on id
collision. The reviewer also checked the load-bearing premise (`this.images = output.images` by
reference) verbatim against the frontend source at `litegraphService.ts:791`.

Fixes #1374
