### PR TITLE
fix(1385): the coalescer-join pin is checked at EVERY call site, not once over the body

### DIFF
--- a/browser_tests/unit/single-node-def.test.mjs
+++ b/browser_tests/unit/single-node-def.test.mjs
@@ -466,6 +466,45 @@ test("#1180: the widen's bound fits INSIDE the registration deadline it runs und
   );
 });
 
+/**
+ * #1385 — every argument list `name(` is called with in `src`, one entry per CALL SITE.
+ *
+ * A single regex over a function body cannot do this job: it answers "is this written
+ * SOMEWHERE in here", and a body with two call sites keeps answering yes after one of them
+ * is unwired. Returning the sites separately is what lets each be asserted on its own, and
+ * what makes a THIRD site — the shape of defect that keeps recurring here — visible the day
+ * it is written rather than the day it breaks.
+ *
+ * A balanced-paren scan rather than a regex because the calls span lines and nest parens
+ * (`budget.remaining()`). Quoted text is skipped so a paren inside a string cannot mis-slice
+ * a call; the scan throws rather than guessing if the parens do not balance.
+ */
+function callArgumentLists(src, name) {
+  const opener = `${name}(`;
+  const lists = [];
+  for (let at = src.indexOf(opener); at >= 0; at = src.indexOf(opener, at + 1)) {
+    // `foo.refreshComfyNodeDefs(` / `myRefreshComfyNodeDefs(` are different functions.
+    if (/[A-Za-z0-9_$.]/.test(src[at - 1] ?? "")) continue;
+    let depth = 0;
+    let quote = null;
+    let i = at + opener.length - 1;
+    for (; i < src.length; i++) {
+      const ch = src[i];
+      if (quote) {
+        if (ch === "\\") i++;
+        else if (ch === quote) quote = null;
+        continue;
+      }
+      if (ch === '"' || ch === "'" || ch === "`") quote = ch;
+      else if (ch === "(") depth++;
+      else if (ch === ")" && --depth === 0) break;
+    }
+    assert.ok(depth === 0 && i < src.length, `unbalanced parentheses after ${opener}`);
+    lists.push(src.slice(at + opener.length, i));
+  }
+  return lists;
+}
+
 test("#1192: graph_add_node's serialized bounds FIT the command budget", () => {
   // The predecessor of this test asserted the OPPOSITE — that this path exceeds the budget —
   // and said so in its own failure message: "If that is genuinely fixed, close #1192 and
@@ -582,7 +621,9 @@ test("#1192: graph_add_node's serialized bounds FIT the command budget", () => {
       "the single-class fast path",
     ],
     [/await boundedGetNodeDefs\(budget\.bounded\(NODE_DEFS_FETCH_TIMEOUT_MS\)\)/, "the whole-schema fetch"],
-    [/joinMs: budget\.remaining\(\) - ADD_NODE_POST_REFRESH_RESERVE_MS/, "the coalescer join"],
+    // The fifth wait — the coalescer join — is NOT a row here. #1385: it has two call sites,
+    // so a body-wide match is satisfied by whichever one is left. It is pinned per call site
+    // below instead.
     [/budget\.bounded\(CUSTOM_WIDGET_REGISTRATION_TIMEOUT_MS\)/, "the custom-widget registration wait"],
   ];
   for (const [re, what] of wired) {
@@ -606,6 +647,41 @@ test("#1192: graph_add_node's serialized bounds FIT the command budget", () => {
       `${name} appears ${total} time(s) in graph_add_node but only ${capped} are capped by the command budget`,
     );
   }
+
+  // ── THE FIFTH WAIT: EVERY coalescer call, not "one of them somewhere" ─────────
+  //
+  // #1385 — this used to be one more row in `wired`, a single `assert.match` for
+  // `joinMs: budget.remaining() - ADD_NODE_POST_REFRESH_RESERVE_MS` anywhere in the body.
+  // There are TWO calls carrying it — the resolver's join and #1242's forced drift recovery —
+  // so unwrapping either left the other satisfying the regex and the pin passed over a
+  // half-unwired file. Verified by mutation in BOTH directions on the shipped source: with
+  // one call's `joinMs` deleted this test still passed in ~2s, either way round.
+  //
+  // That is the worst wait in this command to lose quietly. Its absence does not fail a
+  // test, it HANGS — deleting the resolver's `joinMs` left add-node-command-budget.test.mjs
+  // running until an external cap killed it, and `npm run test:unit` passes no
+  // --test-timeout, so node:test buffered the whole file's output and printed nothing at
+  // all. A named assertion here is what turns that into a sentence.
+  //
+  // ENUMERATED, not counted: "there are 2" goes stale the moment a third call site is
+  // written unbounded, which is this same defect in a new place. Every call the body makes
+  // must carry the bound, however many there turn out to be.
+  const coalescerCalls = callArgumentLists(stripped, "refreshComfyNodeDefs");
+  assert.ok(
+    coalescerCalls.length >= 2,
+    `graph_add_node should still make both coalescer calls (the resolver's join and #1242's ` +
+      `forced drift recovery); found ${coalescerCalls.length} — if one was deliberately ` +
+      "removed, say which here rather than lowering the floor",
+  );
+  coalescerCalls.forEach((args, i) => {
+    assert.match(
+      args,
+      /joinMs: budget\.remaining\(\) - ADD_NODE_POST_REFRESH_RESERVE_MS/,
+      `refreshComfyNodeDefs call ${i + 1} of ${coalescerCalls.length} in graph_add_node does ` +
+        "not draw its join bound from the command budget — unbounded, that call waits out a " +
+        `run started under someone else's deadline. Its arguments: ${args.trim()}`,
+    );
+  });
 
   // The reserve is DERIVED from the step it protects, not picked, so the two cannot drift.
   assert.match(


### PR DESCRIPTION
Closes #1385.

## What was wrong

`graph_add_node` has five budgeted waits, each with a source-level pin in
`browser_tests/unit/single-node-def.test.mjs` asserting the call site is wired to the
bounding primitive. The fifth — the coalescer join — was one row in the `wired` list:

```js
[/joinMs: budget\.remaining\(\) - ADD_NODE_POST_REFRESH_RESERVE_MS/, "the coalescer join"],
```

a single `assert.match` over the whole function body. The body makes **two** calls carrying
that bound — the resolver's join (`web/js/comfyui-mcp-panel.js:12261`) and #1242's forced
drift recovery (`:12352`) — so a match anywhere satisfied it and unwrapping either one left
the other holding the pin green over a half-unwired file.

## Mutation evidence (before the change)

Ran against the shipped source on `origin/main` (567e6438), deleting one `joinMs:` line at a
time:

| mutation | `single-node-def.test.mjs` |
|---|---|
| resolver join (`:12261`) unwrapped | **pass**, exit 0, 2s |
| drift recovery (`:12352`) unwrapped | **pass**, exit 0, 2s |

So the row never failed for *either* unwrapping — it was dead weight in both directions, a
bit stronger than the issue's "one is masked by the other". The drift-recovery site happens
to be pinned separately by `add-node-command-budget.test.mjs:602` and
`add-node-schema-drift-recovery.test.mjs:112` (both anchor on `force: true,`); the
**resolver's join had no dedicated source pin anywhere in the suite**.

**And its absence does not fail a test — it hangs.** With the resolver's `joinMs` deleted,
`add-node-command-budget.test.mjs` ran until an external cap killed it (150s+, against a
whole-file baseline of ~1s), and because `npm run test:unit` passes no `--test-timeout`,
node:test buffers the file's output and printed **nothing at all** — not a failure, not a
test name. Re-running that file with `--test-timeout=8000` names the two tests that stall:

```
not ok 1 - #1192: an add refuses IN WORDS when the in-flight refresh would eat the whole budget
not ok 3 - #1192: the abandoned add does NOT start a competing registration run
```

## The change

Test-only. The `wired` row is replaced by a per-call-site check: enumerate every
`refreshComfyNodeDefs(...)` call in the comment-stripped `graph_add_node` body by
balanced-paren scan, and require **each** one to carry the bound.

Enumerated, not counted. The issue called counting the weaker option because "there are 2"
goes stale the day a third call site is written — the same defect in a new place. The new
helper returns one entry per call site, so the assertion scales with however many there are,
and the failure message names *which* call and prints its arguments.

## Mutation evidence (after the change)

| mutation | `single-node-def.test.mjs` | failure message |
|---|---|---|
| resolver join unwrapped | **fail**, exit 1, ~1.2s | `refreshComfyNodeDefs call 1 of 2 … Its arguments: defs, {` |
| drift recovery unwrapped | **fail**, exit 1, ~1.2s | `refreshComfyNodeDefs call 2 of 2 … Its arguments: undefined, {` |
| both unwrapped | **fail**, exit 1 | `call 1 of 2` |
| **third, unbounded call inserted** into `graph_add_node` | **fail**, exit 1 | `call 2 of 3 … Its arguments: undefined, { force: true }` |
| unmutated | **pass**, 13/13 | — |

The third-site row is the one the issue specifically said counting could not see. It was
inserted inside `graph_add_node` (an earlier attempt anchored on a same-shaped call at
`:10622` in a *different* function and correctly did not trip this pin — the scan is scoped
to the body, as intended).

## Verification

- `npm run test:unit` — **5446 pass, 0 fail** (exit 0), full suite in the worktree after `npm ci`.
- `npm run typecheck` — clean.
- `node --check web/js/comfyui-mcp-panel.js` — clean at every mutation step.

## Not done, deliberately

- **No Playwright run.** This diff touches one unit test file; `web/js/` and every shipped
  asset are byte-identical to `origin/main`, so there is nothing the panel renders to verify.
  I am claiming no browser coverage here rather than implying it.
- **`--test-timeout` was not added to `test:unit`.** The silent-hang behaviour above is real
  and worth fixing, but it is a suite-wide change with flake risk on a shared runner and is
  not what #1385 asks for. Flagging it as a separate call.
- The shipped source is untouched — the code was correct as shipped, as the issue states.

## Gate

codex was unavailable (account exhausted until 2026-08-19 20:43; it is 02:00 local); gated by
an independent adversarial review instead, via `.claude/autopilot/claude-gate.mjs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
