### PR TITLE
fix(1706 followup): the promoted-widget guard reads every dialect of an id that MOVED, not one spelling

### DIFF
--- a/browser_tests/unit/definitions-renumber.test.mjs
+++ b/browser_tests/unit/definitions-renumber.test.mjs
@@ -835,3 +835,29 @@ test("#1706 a NON-numeric promoted id that names nothing remapped still does not
     );
   }
 });
+
+test("#1706 P0: a promoted widget id in HEX or EXPONENT form still refuses", () => {
+  // The two numeric readings are NOT redundant, and mutation is what showed it: with
+  // only the decimal dialects above, deleting the `Number()` clause killed no test,
+  // because a leading-integer parse already caught `"78.0"`, `" 78"`, `"078"`, `"78abc"`.
+  // These two are the inputs where the readings DISAGREE — `Number("0x4E")` is 78 while
+  // a leading-integer parse is 0, and `Number("7.8e1")` is 78 while the parse is 7 — so
+  // each clause is the only thing standing in front of one of them.
+  const c = captured();
+  const movedFrom = c.payloadDefinitions.subgraphs[0].nodes[0].id;
+  const hex = `0x${movedFrom.toString(16)}`;
+  const exponent = `${movedFrom / 10}e1`;
+  assert.equal(Number(hex), movedFrom, "the hex form must really name the moved node");
+  assert.equal(Number(exponent), movedFrom, "the exponent form must really name the moved node");
+  assert.notEqual(Number(/^\s*[+-]?\d+/.exec(hex)[0]), movedFrom, "and the leading-integer parse must NOT");
+  assert.notEqual(Number(/^\s*[+-]?\d+/.exec(exponent)[0]), movedFrom, "likewise");
+  for (const dialect of [hex, exponent]) {
+    assert.equal(
+      definitionsDifferOnlyByRenumber(c.payloadDefinitions, c.liveDefinitions, {
+        rootNodes: [{ id: 400, type: "sub-1", properties: { proxyWidgets: [[dialect, "seed"]] } }],
+      }),
+      false,
+      `proxyWidgets id ${JSON.stringify(dialect)} names a relabeled node and must refuse`,
+    );
+  }
+});

--- a/browser_tests/unit/definitions-renumber.test.mjs
+++ b/browser_tests/unit/definitions-renumber.test.mjs
@@ -786,3 +786,52 @@ test("#1706 P0: an id whose only change is its TYPE is not a relabeling", () => 
   okLive.subgraphs[1].state = { lastLinkId: 11, lastNodeId: 40 };
   assert.equal(definitionsDifferOnlyByRenumber(payload, okLive, { rootNodes: [] }), true);
 });
+
+test("#1706 P0: a promoted widget id in a NON-CANONICAL dialect still refuses", () => {
+  // Gate finding, and the same class as a string/number key mismatch that made two
+  // tools fail 100% of the time on a real graph tonight. `remappedFrom` is keyed by
+  // `String(payloadId)`, so `"78.0"` / `" 78"` / `"+78"` are all "not in the set" to a
+  // text comparison while naming node 78 to anything that reads the id numerically.
+  // Measured end-to-end by the gate: `definitions` came back ACCOUNTED and the weaker
+  // completed-load ground flipped to normalizedOnly with
+  // `normalizedFields ["properties","widgets_values"]` — reassuring wording over a
+  // genuinely lost promoted widget. The verdict still refused, so no fence was
+  // published, but the sentence was wrong and this closes it.
+  const c = captured();
+  const movedFrom = c.payloadDefinitions.subgraphs[0].nodes[0].id;
+  assert.equal(typeof movedFrom, "number", "the fixture's ids are numeric, as the frontend writes them");
+  for (const dialect of [
+    `${movedFrom}.0`,
+    ` ${movedFrom}`,
+    `+${movedFrom}`,
+    `${movedFrom} `,
+    `0${movedFrom}`,
+    `${movedFrom}.00`,
+    `${movedFrom}abc`, // Number() says NaN; a leading-integer parse says it names the moved node
+    movedFrom, // the number itself, not a string — the schema says string, reality may not
+  ]) {
+    assert.equal(
+      definitionsDifferOnlyByRenumber(c.payloadDefinitions, c.liveDefinitions, {
+        rootNodes: [{ id: 400, type: "sub-1", properties: { proxyWidgets: [[dialect, "seed"]] } }],
+      }),
+      false,
+      `proxyWidgets id ${JSON.stringify(dialect)} names a relabeled node and must refuse`,
+    );
+  }
+});
+
+test("#1706 a NON-numeric promoted id that names nothing remapped still does not block", () => {
+  // The direction that costs something: the guard must not become "refuse whenever any
+  // root node promotes anything". A promoted widget naming a node the relabeling never
+  // touched is not evidence of loss, and the account stays available.
+  const c = captured();
+  for (const id of ["not-a-node", "999999", " 999999", "999999.0"]) {
+    assert.equal(
+      definitionsDifferOnlyByRenumber(c.payloadDefinitions, c.liveDefinitions, {
+        rootNodes: [{ id: 400, type: "sub-1", properties: { proxyWidgets: [[id, "seed"]] } }],
+      }),
+      true,
+      `proxyWidgets id ${JSON.stringify(id)} names nothing that moved`,
+    );
+  }
+});

--- a/web/js/lib/definitions-renumber.js
+++ b/web/js/lib/definitions-renumber.js
@@ -451,10 +451,23 @@ function definitionDiffersOnlyByRenumber(a, b, map, relabeled) {
  * reference is not something this surface may vouch for.
  *
  * An unreadable `proxyWidgets` entry counts as referencing — "cannot tell" is not "no".
+ * So does an id in a non-canonical numeric dialect: see the comparison below.
+ * Keying on ONE spelling of an id is the defect class this repo keeps catching — a
+ * String-keyed set does not see `"78.0"` as the node the frontend patches as 78.
  */
 function rootNodesReferenceRemappedId(rootNodes, remappedFrom) {
   if (!Array.isArray(rootNodes)) return true;
   if (remappedFrom.size === 0) return false;
+  // The same payload id, in every dialect this guard is willing to be sure about.
+  // Comparing ONE spelling is what makes a key-matching guard miss (gate finding):
+  // `78` and `"78.0"` are the same node to anything that reads the id numerically and
+  // two different strings to anything that reads it textually, so a promoted widget
+  // written `"78.0"` slipped past a String-keyed set while the load still broke it.
+  const numericForms = new Set();
+  for (const key of remappedFrom) {
+    const n = Number(key);
+    if (Number.isFinite(n)) numericForms.add(String(n));
+  }
   for (const node of rootNodes) {
     const promoted = node?.properties?.proxyWidgets;
     if (promoted == null) continue;
@@ -468,6 +481,21 @@ function rootNodesReferenceRemappedId(rootNodes, remappedFrom) {
         return true;
       }
       if (remappedFrom.has(key)) return true;
+      const asNumber = Number(key);
+      if (Number.isFinite(asNumber) && numericForms.has(String(asNumber))) return true;
+      // ...and one more reading, because `Number()` is not the only way an id gets
+      // interpreted numerically. `Number("78abc")` is NaN while a leading-integer parse
+      // is 78, so a text comparison AND a `Number()` comparison would both miss an entry
+      // that some reader resolves to a node the relabeling moved.
+      //
+      // Deliberately NOT "refuse every non-canonical id": that was tried and it refuses
+      // `"999999.0"`, which names nothing that moved. An over-broad guard is a
+      // regression wearing a fix's clothes — this asks only whether the entry can be
+      // read as one of the ids that ACTUALLY moved.
+      const leading = /^\s*[+-]?\d+/.exec(key);
+      if (!leading) continue;
+      const asLeadingInt = Number(leading[0]);
+      if (Number.isFinite(asLeadingInt) && numericForms.has(String(asLeadingInt))) return true;
     }
   }
   return false;

--- a/web/js/lib/node-inputs-rebuild.js
+++ b/web/js/lib/node-inputs-rebuild.js
@@ -33,7 +33,7 @@
  * — a slot that disappeared, one that appeared from nowhere, a changed `link`,
  * any other key that moved — returns false, and the caller reads false as NOT
  * PROVEN rather than as "changed". Same contract as
- * `definitionsDifferOnlyByLinkRenumber` (#886), which is the precedent this
+ * `definitionsDifferOnlyByRenumber` (#886, comfyui-mcp#1706), which is the precedent this
  * follows: characterise a specific frontend rewrite, admit exactly that, refuse
  * everything else.
  *


### PR DESCRIPTION
Follow-up to #1388, which merged while I was applying the gate's findings. Two of the three items landed after the merge, so they need their own PR. Item 2 (the CHANGELOG under `## [Unreleased]`, not `## [0.15.4]`) DID make it into #1388 and is already correct on `main` — nothing here touches it.

## 1. The promoted-widget guard keyed on ONE spelling of an id

Gate finding, and the same class as a string/number key mismatch that made two tools fail 100% of the time on a real graph the same night.

`rootNodesReferenceRemappedId` refuses the relabeling account when a root node's `properties.proxyWidgets` names a definition node the relabeling moved. It built that decision from a `Set` keyed by `String(payloadId)` and asked it one question: `remappedFrom.has(String(entry[0]))`.

A promoted-widget id in a non-canonical numeric dialect — `"78.0"`, `" 78"`, `"+78"`, `"078"` — is a *different string* and the *same node*. Measured end-to-end by the gate: that entry made `definitions` come back ACCOUNTED, which took it out of the UNEXPLAINED set the weaker completed-load ground reads, and `normalizedOnly` flipped to **true** with `normalizedFields ["properties","widgets_values"]` — reassuring wording over a genuinely lost promoted widget.

Bounded, and worth stating so the severity is not overread: the VERDICT still refused (`proven:false`), so no fence was published; and the frontend writes these entries as `String(id)` under a `z.tuple([z.string(), z.string()])` schema, so reaching it needs a hand-edited workflow. It is the sentence that was wrong, not the fence.

**The fix asks the question in every reading that can name a node that ACTUALLY MOVED**, and in no more than that:

1. the raw string, as before;
2. `Number(key)` against the numeric normalisation of the remapped ids — this is the only clause that catches `"0x4E"` and `"7.8e1"`;
3. a leading-integer parse — the only clause that catches `"78abc"`, where `Number()` is `NaN`.

**A blanket "refuse every non-canonical id" was written first and then removed.** It refuses `"999999.0"`, which names nothing that moved — an over-broad guard is a regression wearing a fix's clothes, and there is a test pinning that direction (`#1706 a NON-numeric promoted id that names nothing remapped still does not block`).

## 2. Stale prose

`web/js/lib/node-inputs-rebuild.js:36` still cited `definitionsDifferOnlyByLinkRenumber` as the precedent it follows. #1388 renamed that export to `definitionsDifferOnlyByRenumber` because the old name asserted "link" and there are now two measured rewrites. Grepped tree-wide; that was the only remaining site.

## Refutation

Baseline for the three affected files: **107/107**. Twelve mutations, each confirmed applied by `git diff --numstat` before its run. Restored afterwards: **107/107**.

| mutation | verdict |
| --- | --- |
| M1 content-proof call site drops `rootNodes` | killed (2) |
| M2 disclosure call site drops `rootNodes` | killed (1) |
| M3 the node-id account is reverted | killed (8) |
| M4 the proxyWidgets cross-surface guard never fires | killed (5) |
| M5 the allocation counter need not advance | killed (1) |
| M6 link endpoints not compared through the map | killed (7) |
| M7 the map need not be injective | killed (1) |
| M8 a node may be retyped at its position | **SURVIVED** (unchanged, documented at the line) |
| M9 the wider allowances granted without a relabeling | killed (6) |
| M10 an id that only changed TYPE reads as a non-move | killed (1) |
| **M11 the guard reads ONE spelling of the id again** | **killed (1)** |
| **M12 the leading-integer reading is dropped** | **killed (1)** |

M11 SURVIVED on the first attempt, and that was a real finding about the test rather than the code: every decimal dialect I had written (`"78.0"`, `" 78"`, `"+78"`, `"078"`, `"78abc"`) is already caught by the leading-integer clause, so deleting the `Number()` clause killed nothing. The added test isolates the two inputs where the readings DISAGREE — `Number("0x4E") === 78` while the leading-integer parse is `0`, and `Number("7.8e1") === 78` while the parse is `7` — so each clause is now the only thing standing in front of one of them. It asserts that disagreement explicitly, so a future edit cannot quietly make the case vacuous.

**End-to-end on the real captured pair is unchanged** (`describeGraphStateDifference` + `graphRootReproducesStateContent` + `resolveOpenRebindVerdict`, driven with the actual payload and the actual `app.graph.serialize()` output): `surfaces ["definitions"]`, `accountedSurfaces ["definitions"]`, `proven: true`, verdict **proven**. The fix still ships what #1388 shipped.

## Verification

**Unit** — `node --test browser_tests/unit/*.test.mjs`: **5492 pass, 0 fail** (the known `#671 verifyInstalled` wall-clock flake did not fire).

**Panel gates** — `i18n-check`, `i18n-render-check`, `check-tool-vocabulary`, `check-panel-scope`, `tsc --noEmit`: all OK.

**Browser (Playwright)** — NOT re-run for this follow-up. #1388's delta was measured (`origin/main` 18 failed / 57 passed, branch 18 / 57, identical failure lists, each side on its own dedicated ComfyUI). This change touches one predicate's key comparison and one comment, adds no panel-visible behaviour, and its whole effect is to REFUSE in cases that previously slipped through — so I am stating the absence rather than implying coverage I do not have.

## Gate

`codex exec` is account-exhausted until 2026-08-19 20:43 and `claude-gate.mjs` is blocked on the weekly limit, so **no independent gate was run by this agent** — the orchestrator gates and merges.

This addresses two findings against the change that fixed the underlying cause of artokun/comfyui-mcp#1706.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
