### PR TITLE
fix(1370): a missing-node COUNT is filtered with the names it was counting, and an unnamed miss is still reported

### DIFF
--- a/browser_tests/unit/frontend-virtual-nodes.test.mjs
+++ b/browser_tests/unit/frontend-virtual-nodes.test.mjs
@@ -313,3 +313,215 @@ test("#1648 CALL SITE 3 WIRING: the registry is diagnosis only — the refusal i
   assert.match(block, /if \(badIds\.length\) \{/);
   assert.equal((block.match(/registered_node_types/g) ?? []).length, 1);
 });
+
+// ── #1370: the COUNT is filtered with the names, and only by a REAL removal ──────
+//
+// The filter above only ever touched the type LIST. The collector also returns
+// `nodeCount` (ComfyUI's own `missingNodeCount`) and computes `any` from it, so
+// `{ nodeTypes: [], nodeCount: 2, any: true }` was reachable — and both surfaces that
+// read the bare count then raised an alarm with the names stripped out: graph_get_errors'
+// `missing_node_count: 2` and the banner's "2 node type(s) not installed on this ComfyUI".
+//
+// Driven against the SHIPPED collector, extracted from the panel source and executed —
+// a re-implementation here would pass while production kept the old tuple.
+//
+// The pair that must stay distinguishable is A vs D: "every recorded name was proven
+// frontend-virtual" and "the record named nothing at all" were byte-identical on the
+// collector's output, and only the first is safe to suppress. D is the state the
+// pre-existing `missingNodeCount && !missingNodeTypes.length` consumer branch reports,
+// so it is kept, not deleted.
+
+function extractPanelFn(sig) {
+  const start = PANEL.indexOf(sig);
+  assert.notEqual(start, -1, `${sig} not found in the panel source`);
+  const open = PANEL.indexOf(") {", start) + 1;
+  let depth = 0;
+  for (let i = open; i < PANEL.length; i += 1) {
+    const ch = PANEL[i];
+    if (ch === "/" && PANEL[i + 1] === "/") {
+      i = PANEL.indexOf("\n", i + 2);
+      if (i < 0) break;
+      continue;
+    }
+    if (ch === "/" && PANEL[i + 1] === "*") {
+      i = PANEL.indexOf("*/", i + 2);
+      if (i < 0) break;
+      i += 1;
+      continue;
+    }
+    if (ch === '"' || ch === "'" || ch === "`") {
+      const quote = ch;
+      for (i += 1; i < PANEL.length; i += 1) {
+        if (PANEL[i] === "\\") {
+          i += 1;
+          continue;
+        }
+        if (PANEL[i] === quote) break;
+      }
+      continue;
+    }
+    if (ch === "{") depth += 1;
+    if (ch === "}" && --depth === 0) return PANEL.slice(start, i + 1);
+  }
+  throw new Error(`unterminated: ${sig}`);
+}
+
+const COLLECTOR_BODY = extractPanelFn("function collectMissingAssets(trustComboOverride) {");
+
+/**
+ * Run the shipping collector against a real `missingNodesError` store shape.
+ * `record` is the store's own load-time list; `nodes` is the live graph.
+ */
+function runCollector({ record, count, nodes = [], readableGraph = true }) {
+  const stores = {
+    missingModel: { missingModelCandidates: [] },
+    missingMedia: { missingMediaCandidates: [] },
+    missingNodesError: {
+      hasMissingNodes: true,
+      missingNodeCount: count,
+      missingNodesError: record,
+    },
+  };
+  const factory = new Function(
+    "getPiniaStore",
+    "isStaleAssetCandidate",
+    "resolveMissingModelDirectory",
+    "withoutFrontendVirtualTypes",
+    "collectAllGraphs",
+    "getGraphCtx",
+    `return (${COLLECTOR_BODY});`,
+  );
+  const collect = factory(
+    (name) => stores[name],
+    () => false,
+    (d) => d,
+    withoutFrontendVirtualTypes,
+    (g) => (g ? [g] : []),
+    () => {
+      if (!readableGraph) throw new Error("no graph");
+      return { rootGraph: { _nodes: nodes } };
+    },
+  );
+  const r = collect();
+  return { nodeTypes: r.nodeTypes, nodeCount: r.nodeCount, any: r.any };
+}
+
+test("#1370 A: every recorded type proven frontend-virtual — the count goes with the names", () => {
+  assert.deepEqual(
+    runCollector({
+      record: [{ type: "SetNode" }, { type: "GetNode" }],
+      count: 2,
+      nodes: [virtualNode(1, "SetNode"), virtualNode(2, "GetNode")],
+    }),
+    { nodeTypes: [], nodeCount: 0, any: false },
+  );
+});
+
+test("#1370 D: a record that named NOTHING keeps its count — unknown stays representable", () => {
+  // The panel could not read the record's shape (a Map, an unexpected object) while the
+  // store still says two nodes are missing. Collapsing this into A would report a broken
+  // canvas as clean — the count is the only evidence left.
+  assert.deepEqual(runCollector({ record: [], count: 2, nodes: [virtualNode(1, "SetNode")] }), {
+    nodeTypes: [],
+    nodeCount: 2,
+    any: true,
+  });
+  assert.deepEqual(runCollector({ record: new Map([["SetNode", {}]]), count: 2, nodes: [] }), {
+    nodeTypes: [],
+    nodeCount: 2,
+    any: true,
+  });
+});
+
+test("#1370 F: an entry the parser could not name keeps the count alive", () => {
+  // One record names a virtual type, the other names nothing at all. Nothing was proven
+  // about the second, so suppressing the whole count on the first would hide it.
+  assert.deepEqual(
+    runCollector({
+      record: [{ type: "SetNode" }, { unreadable: 1 }],
+      count: 2,
+      nodes: [virtualNode(1, "SetNode")],
+    }),
+    { nodeTypes: [], nodeCount: 2, any: true },
+  );
+});
+
+test("#1370 the fail-closed directions are untouched: a real miss keeps count AND names", () => {
+  // B — same types, but the pack's JS never loaded in this tab, so they are placeholders.
+  assert.deepEqual(
+    runCollector({
+      record: [{ type: "SetNode" }, { type: "GetNode" }],
+      count: 2,
+      nodes: [placeholderNode(1, "SetNode"), placeholderNode(2, "GetNode")],
+    }),
+    { nodeTypes: ["SetNode", "GetNode"], nodeCount: 2, any: true },
+  );
+  // C — one of each: the survivor keeps the alarm named, so the count is never surfaced.
+  assert.deepEqual(
+    runCollector({
+      record: [{ type: "SetNode" }, { type: "GetNode" }],
+      count: 2,
+      nodes: [virtualNode(1, "SetNode"), placeholderNode(2, "GetNode")],
+    }),
+    { nodeTypes: ["GetNode"], nodeCount: 2, any: true },
+  );
+  // E — an unreadable graph proves nothing virtual, so nothing is suppressed either.
+  assert.deepEqual(
+    runCollector({
+      record: [{ type: "SetNode" }, { type: "GetNode" }],
+      count: 2,
+      nodes: [virtualNode(1, "SetNode"), virtualNode(2, "GetNode")],
+      readableGraph: false,
+    }),
+    { nodeTypes: ["SetNode", "GetNode"], nodeCount: 2, any: true },
+  );
+});
+
+test("#1370 CONSUMER WIRING: both count-readers zero only on an ACTUAL removal", () => {
+  // #1332 zeroes the count when the adjudication drops every type the client can now
+  // construct. Ungated, that same line ALSO fires when the recorded list was empty from
+  // the start (case D), turning "N missing, names unknown" into a clean payload.
+  assert.equal(
+    (PANEL.match(/if \(recordedTypes\.length && !assets\.nodeTypes\.length\) assets\.nodeCount = 0;/g) ?? []).length,
+    1,
+    "graph_get_errors must gate the #1332 zeroing on a real removal",
+  );
+  assert.equal(
+    (PANEL.match(/if \(recordedTypes\.length && !missing\.nodeTypes\.length\) missing\.nodeCount = 0;/g) ?? []).length,
+    1,
+    "the turn-start banner must gate it the same way",
+  );
+  assert.doesNotMatch(PANEL, /if \(!assets\.nodeTypes\.length\) assets\.nodeCount = 0;/);
+  assert.doesNotMatch(PANEL, /if \(!missing\.nodeTypes\.length\) missing\.nodeCount = 0;/);
+  // `recordedTypes` must be what the adjudication was GIVEN. A post-assignment re-read
+  // is always the narrowed list, so the gate would never fire and #1332 would regress.
+  for (const holder of ["assets", "missing"]) {
+    const at = PANEL.indexOf(`const recordedTypes = ${holder}.nodeTypes;`);
+    assert.ok(at > 0, `${holder}: the pre-adjudication capture must exist`);
+    const after = PANEL.slice(at, at + 400);
+    assert.match(
+      after,
+      /adjudicateRecordedMissingNodeTypes\(\r?\n\s+recordedTypes,/,
+      `${holder}: the captured list must be the one adjudicated`,
+    );
+    assert.ok(
+      after.indexOf(`${holder}.nodeTypes = adjudicated.stillMissing;`) >
+        after.indexOf("adjudicateRecordedMissingNodeTypes("),
+      `${holder}: the capture must precede the narrowing assignment`,
+    );
+  }
+});
+
+test("#1370 the bare-count branch is KEPT — it is how an unnamed miss reaches an agent", () => {
+  // Deleting the trigger would have been the other half of the same bug: with the count
+  // now honest, a surviving count means "missing, names unreadable", which must still be
+  // reported. Both consumers keep their branch.
+  assert.ok(
+    PANEL.includes("...(missingNodeCount && !missingNodeTypes.length"),
+    "graph_get_errors must still emit missing_node_count for an unnamed miss",
+  );
+  assert.ok(
+    PANEL.includes("} else if (missing.nodeCount) {"),
+    "the turn-start banner must still report an unnamed miss",
+  );
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -9100,6 +9100,12 @@ function collectMissingAssets(trustComboOverride) {
           ? (Object.values(raw).find(Array.isArray) ?? Object.keys(raw))
           : [];
       nodeTypes = [...new Set(pool.map(asType).filter(Boolean))];
+      // Captured BEFORE the frontend-virtual filter below (#1370): what the load-time
+      // record actually NAMED, and how many of its entries the parser could not name at
+      // all. The suppression after the filter needs both to tell "every name was proven
+      // virtual" apart from "there were never any names".
+      const recordedTypeCount = nodeTypes.length;
+      const unnamedRecordCount = pool.filter((m) => !asType(m)).length;
       // comfyui-mcp#1657 / panel#1284 — a FRONTEND VIRTUAL node is not a missing one.
       //
       // `missingNodesError` is a LOAD-TIME snapshot the frontend never re-evaluates
@@ -9135,6 +9141,30 @@ function collectMissingAssets(trustComboOverride) {
       } catch {
         /* no readable graph → nothing is proven virtual → every type stays reported */
       }
+      // panel#1370 — the COUNT must not outlive the names it was counting.
+      //
+      // The filter above only ever touched the type LIST, so
+      // `{ hasMissingNodes: true, missingNodeCount: 2, nodeTypes: [] }` was reachable and
+      // was measured on a canvas whose two recorded types were both frontend-virtual.
+      // Both surfaces that read the bare count then raised an alarm with the names
+      // stripped out — graph_get_errors' `missing_node_count: 2` and the turn-start
+      // banner's "2 node type(s) not installed on this ComfyUI" — which is NARROWER than
+      // the pre-filter message that at least named them.
+      //
+      // Suppressed HERE, in the shared collector, for the same reason the list is: this
+      // is the one collector graph_get_errors, the turn-start banner and the
+      // stale-red-flag adjudication read, and this family recurred three times precisely
+      // because each call site decided separately.
+      //
+      // TWO conditions, because a bare count is not noise in general. A count with no
+      // names is exactly how "the store says N nodes are missing and the panel could not
+      // read the record's shape" reaches an agent — the state the pre-existing
+      // `missingNodeCount && !missingNodeTypes.length` consumer branch was written to
+      // report, and the only signal left in it. So the count is dropped only when the
+      // record DID name types (the count has a known referent) and every named record was
+      // proven virtual. An entry the parser could not name keeps the count alive, because
+      // nothing about it was proven.
+      if (recordedTypeCount && !nodeTypes.length && !unnamedRecordCount) nodeCount = 0;
     }
   } catch {
     /* optional */
@@ -9519,14 +9549,17 @@ async function validationBanner() {
   try {
     const { rootGraph: bannerRoot } = getGraphCtx();
     const allNodes = collectAllGraphs(bannerRoot).flatMap((g) => g?._nodes ?? []);
+    const recordedTypes = missing.nodeTypes;
     const adjudicated = adjudicateRecordedMissingNodeTypes(
-      missing.nodeTypes,
+      recordedTypes,
       allNodes,
       (type) => isRegisteredNodeType(LiteGraph?.registered_node_types, type),
     );
     missing.nodeTypes = adjudicated.stillMissing;
     bannerStalePlaceholders = adjudicated.stalePlaceholders;
-    if (!missing.nodeTypes.length) missing.nodeCount = 0;
+    // Same gate as graph_get_errors (panel#1370): an empty recorded list was never
+    // narrowed by the adjudication, so its count is an unnamed miss, not a cleared one.
+    if (recordedTypes.length && !missing.nodeTypes.length) missing.nodeCount = 0;
   } catch {
     bannerStalePlaceholders = [];
   }
@@ -15432,14 +15465,21 @@ const GRAPH_TOOL_EXECUTORS = {
     let stalePlaceholders = [];
     try {
       const allNodes = collectAllGraphs(rootGraph).flatMap((g) => g?._nodes ?? []);
+      const recordedTypes = assets.nodeTypes;
       const adjudicated = adjudicateRecordedMissingNodeTypes(
-        assets.nodeTypes,
+        recordedTypes,
         allNodes,
         (type) => isRegisteredNodeType(LiteGraph?.registered_node_types, type),
       );
       assets.nodeTypes = adjudicated.stillMissing;
       stalePlaceholders = adjudicated.stalePlaceholders;
-      if (!assets.nodeTypes.length) assets.nodeCount = 0;
+      // #1332 drops the count when the adjudication removes every type the client can
+      // now construct, so it cannot keep alarming for names that are no longer reported.
+      // panel#1370 — gate that on the adjudication having ACTUALLY removed something. An
+      // empty recorded list means the store named nothing to begin with, and the count is
+      // then the only evidence that anything is missing; zeroing it there turns "N
+      // missing, names unknown" into "no errors recorded since the last execution start".
+      if (recordedTypes.length && !assets.nodeTypes.length) assets.nodeCount = 0;
     } catch {
       /* unreadable registry → keep the load-time list (fail closed) */
       stalePlaceholders = [];


### PR DESCRIPTION
## Summary

`collectMissingAssets` filters `nodeTypes` through the frontend-virtual check added by #1353
but leaves `nodeCount` (ComfyUI's own `missingNodeCount`) alone and computes `any` from it.
Driving the **shipped collector** (extracted from the panel source and executed, not
re-implemented) against a real `missingNodesError` store shape, on `origin/main`:

| store record | live graph | before |
|---|---|---|
| **A** `[{type:"SetNode"},{type:"GetNode"}]`, count 2 | both instances `isVirtualNode: true` | `{nodeTypes: [], nodeCount: 2, any: true}` |
| **D** record names nothing, count 2 | — | `{nodeTypes: [], nodeCount: 2, any: true}` |

A and D are **byte-identical on the collector's output** and mean opposite things. A is
"nothing is missing, the names were correctly suppressed"; D is "two nodes are missing and
the panel could not read the record's shape". Both surfaces that read the bare count then
raised an alarm with the names stripped: `graph_get_errors` → `missing_node_count: 2` with
no names, and the turn-start banner → "2 node type(s) not installed on this ComfyUI" —
narrower than the pre-#1353 message, which at least named them.

## What I decided about the pre-existing `missingNodeCount && !missingNodeTypes.length` branch

The issue offered deleting its trigger. **I kept it, deliberately** — that branch is the
only way case D reaches an agent, and D is a real state (the panel's parser handles a list
or an object; a shape it cannot read leaves the count as the sole evidence). Deleting the
trigger would collapse "N missing, names unknown" into "no errors recorded", which is the
same class of defect as the one being fixed, pointing the other way.

So the count is suppressed **where the reason is known** — in the collector, beside the
filter that stripped the names, under two conditions:

```js
if (recordedTypeCount && !nodeTypes.length && !unnamedRecordCount) nodeCount = 0;
```

- `recordedTypeCount` — the record DID name types, so the count has a known referent (A, not D).
- `!unnamedRecordCount` — every record entry produced a name. An entry the parser could not
  name is an unaccounted-for miss and keeps the count alive; nothing about it was proven.

Filtered in the collector rather than at each consumer for the same reason the type list is:
it is the one collector `graph_get_errors`, the turn-start banner and the stale-red-flag
adjudication share, and this family recurred three times because each call site decided
separately.

## A second, live defect this uncovered in #1380

#1380 (merged ~54 min after #1370 was filed) added `if (!nodeTypes.length) nodeCount = 0` at
**both** consumers, as part of the #1332 stale-placeholder adjudication. That masks case A on
the happy path — and breaks case D: with the recorded list empty from the start, the
adjudication removes nothing, the line fires anyway, and `graph_get_errors` emits
`note: "no errors recorded since the last execution start"` for a canvas whose store says two
nodes are missing. Both consumers now gate that zeroing on the adjudication having **actually
removed something**:

```js
if (recordedTypes.length && !assets.nodeTypes.length) assets.nodeCount = 0;
```

`recordedTypes` is captured **before** the narrowing assignment — a post-assignment re-read is
always the narrowed list, so the gate would never fire and #1332 would regress. That ordering
is pinned.

## Measured effect (same probe, after)

| case | before | after |
|---|---|---|
| A both types proven frontend-virtual | `[], 2, any:true` | `[], 0, any:false` |
| B both real placeholders | `["SetNode","GetNode"], 2` | unchanged |
| C one virtual, one real | `["GetNode"], 2` | unchanged |
| D record names nothing | `[], 2, any:true` | unchanged (**kept**) |
| E unreadable graph (nothing proven virtual) | `["SetNode","GetNode"], 2` | unchanged |
| F one entry unnameable + one virtual | `[], 2, any:true` | unchanged (**kept**) |

## Test plan

- [x] `node --test browser_tests/unit/frontend-virtual-nodes.test.mjs` — 26 pass (20 pre-existing + 6 new). The behavioural tests execute the **shipped** `collectMissingAssets` extracted from `web/js/comfyui-mcp-panel.js`; a re-implementation would have passed while production kept the old tuple.
- [x] `npm run test:unit` — 5434 tests, 1 fail: the known #671 `verifyInstalled` wall-clock flake, which is 125/125 when its file runs alone.
- [x] `node scripts/check-panel-scope.mjs` — OK.
- [x] **Verified by deleting the fix** (committed first, then mutated, each mutation confirmed applied via a non-empty `git diff` before its verdict was believed — these files are CRLF):

| mutation | result |
|---|---|
| delete the collector's `nodeCount = 0` line | **RED** — case A |
| revert `graph_get_errors` to the ungated #1332 form | **RED** — CONSUMER WIRING |
| revert the banner to the ungated form | **RED** — CONSUMER WIRING |
| make the collector zero unconditionally (over-strip) | **RED** — cases D and F |
| delete the pre-adjudication `recordedTypes` capture | **RED** — CONSUMER WIRING |

The over-strip mutation is the one that matters most here: it is the version of this fix that
deletes the branch, and two tests refuse it.

### Browser verification

`npx playwright test --workers=1` against a ComfyUI standing on its own port and base
directory, serving this exact checkout (verified by fetching the module over HTTP before the
run — not just reading the file on disk):

| build | result |
|---|---|
| `origin/main` @ `f6136f6d` | 18 failed, 57 passed |
| this branch on `f6136f6d` | 18 failed, 57 passed — **identical failing set** |

**Delta: zero.** The 18 are a pre-existing red set in this environment (MockBridge
conversation-persistence / chat-history / streaming specs), none of them touching missing
assets or the error surfaces. An earlier baseline run at `e27a78a5` showed 19 — the extra one
was `agent-drive.spec.ts:113`, which passed in all three later runs; a flake, not a delta.
Main has since moved to `7976ee72`; this branch is rebased onto it, and the unit suite and the
scope gate were re-run there, but the browser runs were against `f6136f6d`.

## Gate

Not self-gated. codex is exhausted until 2026-08-19 20:43 and `claude-gate.mjs` is blocked on
the weekly limit, so **this PR has had no independent adversarial gate** — the owner gates and
merges it.

The underlying cause of #1370 is addressed here.
