### PR TITLE
feat(428): converting a video-gen workflow to an app exposes LTX/Wan/Bernini/Hunyuan params and video I/O

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project are documented here. This project adheres to
 ## [Unreleased]
 
 ### Added
+- converting a video-gen workflow to an app exposes LTX 2.3/Director, Wan, Bernini, Hunyuan and Easy-Use Media generation parameters, treats LoadVideo/VHS/easy loadVideo as video inputs, and collects SaveVideo/VHS_VideoCombine/easy saveVideo as video outputs (including ComfyUI history `videos[]`) instead of classifying them as stills (#428)
 - `/record-skill` snapshots the open graph as a reusable skill file (`skills/<name>/SKILL.md`) so the agent can rebuild it (#350)
 
 ### Fixed

--- a/browser_tests/unit/apps.test.mjs
+++ b/browser_tests/unit/apps.test.mjs
@@ -4,7 +4,14 @@
 // AppsClient HTTP surface (mocked fetch).
 import { test } from "node:test";
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 import { AppBuilder, AppsClient } from "../../web/js/cmcp-apps.js";
+
+const APPS_UI = readFileSync(
+  fileURLToPath(new URL("../../web/js/cmcp-apps-ui.js", import.meta.url)),
+  "utf8",
+);
 
 // ── APP-mode config import ──────────────────────────────────────────────────
 
@@ -78,6 +85,72 @@ test("heuristicAppMode: object-valued widget entries (link markers) are skipped"
   assert.ok(cfg.inputs.every((i) => i.positional));
 });
 
+// ── #428 video-gen family convert ───────────────────────────────────────────
+
+test("heuristicAppMode: an LTX graph exposes Director/ImgToVideo params and a video output", () => {
+  const cfg = AppBuilder.heuristicAppMode([
+    { id: 6, type: "CLIPTextEncode", widgets_values: ["a cat walks through a forest"] },
+    { id: 12, type: "EmptyLTXVLatentVideo", widgets_values: [768, 512, 97, 1] },
+    { id: 14, type: "LTXVImgToVideo", widgets_values: [768, 512, 97, 1, 0.6] },
+    { id: 20, type: "LTXDirector", widgets_values: ['{"segments":[]}'] },
+    { id: 21, type: "LTXVConditioning", widgets_values: [25] },
+    { id: 30, type: "SaveVideo", widgets_values: ["ltx"] },
+  ]);
+  assert.ok(cfg.inputs.some((i) => i.nodeId === 14), "LTXVImgToVideo must be an app input");
+  assert.ok(cfg.inputs.some((i) => i.nodeId === 20), "LTXDirector must be an app input");
+  assert.ok(cfg.inputs.some((i) => i.nodeId === 21), "LTXVConditioning must be an app input");
+  const save = cfg.outputs.find((o) => o.nodeId === 30);
+  assert.equal(save?.kind, "video");
+  assert.deepEqual(AppBuilder.videoFamiliesOnGraph([
+    { type: "LTXDirector" },
+    { type: "EmptyLTXVLatentVideo" },
+  ]), ["ltx"]);
+});
+
+test("heuristicAppMode: a Wan graph exposes sampler/FLF params and VHS_VideoCombine as video", () => {
+  const cfg = AppBuilder.heuristicAppMode([
+    { id: 1, type: "WanVideoTextEncode", widgets_values: ["walks", "static"] },
+    { id: 2, type: "WanVideoSampler", widgets_values: [4, 1, 5] },
+    { id: 3, type: "WanFirstLastFrameToVideo", widgets_values: [480, 720, 81] },
+    { id: 9, type: "VHS_VideoCombine", widgets_values: [16, "wan"] },
+  ]);
+  assert.ok(cfg.inputs.some((i) => i.nodeId === 1));
+  assert.ok(cfg.inputs.some((i) => i.nodeId === 2));
+  assert.ok(cfg.inputs.some((i) => i.nodeId === 3));
+  const out = cfg.outputs.find((o) => o.nodeId === 9);
+  assert.equal(out?.kind, "video");
+  assert.ok(AppBuilder.videoFamiliesOnGraph([{ type: "WanVideoSampler" }]).includes("wan"));
+});
+
+test("heuristicAppMode: Bernini r2v, Hunyuan, and Easy-Use Media become video-gen app endpoints", () => {
+  const cfg = AppBuilder.heuristicAppMode([
+    { id: 5, type: "Bernini r2v", widgets_values: [24, 1.0] },
+    { id: 7, type: "HunyuanImageToVideo", widgets_values: [848, 480, 129] },
+    { id: 8, type: "easy loadVideo", widgets_values: ["clip.mp4"] },
+    { id: 12, type: "easy saveVideo", widgets_values: ["easy"] },
+  ]);
+  assert.ok(cfg.inputs.some((i) => i.nodeId === 5), "Bernini r2v must be an app input");
+  assert.ok(cfg.inputs.some((i) => i.nodeId === 7), "HunyuanImageToVideo must be an app input");
+  assert.ok(cfg.inputs.some((i) => i.nodeId === 8 && i.kind === "video"), "easy loadVideo is a video input");
+  const save = cfg.outputs.find((o) => o.nodeId === 12);
+  assert.equal(save?.kind, "video");
+  const families = AppBuilder.videoFamiliesOnGraph([
+    { type: "Bernini r2v" },
+    { type: "HunyuanImageToVideo" },
+    { type: "easy saveVideo" },
+  ]);
+  assert.deepEqual(families, ["bernini", "hunyuan", "easyuse"]);
+});
+
+test("heuristicAppMode: a still-image graph still reports SaveImage as images", () => {
+  const cfg = AppBuilder.heuristicAppMode([
+    { id: 6, type: "CLIPTextEncode", widgets_values: ["a cat"] },
+    { id: 9, type: "SaveImage", widgets_values: ["ComfyUI"] },
+  ]);
+  assert.equal(cfg.outputs.find((o) => o.nodeId === 9)?.kind, "images");
+  assert.deepEqual(AppBuilder.videoFamiliesOnGraph([{ type: "SaveImage" }]), []);
+});
+
 // ── widget classification ───────────────────────────────────────────────────
 
 test("classifyWidget", () => {
@@ -98,6 +171,34 @@ test("classifyWidget", () => {
   // loader still wins over a seed-ish name; positional (nameless) never seeds.
   assert.equal(AppBuilder.classifyWidget("VAELoader", "vae_name", "v.pt"), "model");
   assert.equal(AppBuilder.classifyWidget("KSampler", "", 42), "number");
+  // #428: video file loaders are video, not model/text. Model loaders in the
+  // Wan wrapper still classify as model (the *Loader rule).
+  assert.equal(AppBuilder.classifyWidget("LoadVideo", "video", "clip.mp4"), "video");
+  assert.equal(AppBuilder.classifyWidget("VHS_LoadVideo", "video", "a.webm"), "video");
+  assert.equal(AppBuilder.classifyWidget("easy loadVideo", "video", "x.mp4"), "video");
+  assert.equal(AppBuilder.classifyWidget("WanVideoModelLoader", "model", "wan.safetensors"), "model");
+});
+
+test("live convert and run UI drive AppBuilder video-gen helpers, not a copy", () => {
+  assert.match(APPS_UI, /AppBuilder\.isInputHint\(/);
+  assert.match(APPS_UI, /AppBuilder\.outputKind\(/);
+  assert.match(APPS_UI, /AppBuilder\.collectRunMedia\(/);
+  assert.match(APPS_UI, /AppBuilder\.isRunVideoRef\(/);
+  assert.match(APPS_UI, /video\/\*/);
+  assert.equal(APPS_UI.includes("INPUT_HINT_TYPES.has"), false);
+});
+
+test("collectRunMedia reads ComfyUI videos[] and isRunVideoRef honours format", () => {
+  const media = AppBuilder.collectRunMedia({
+    images: [{ filename: "still.png" }],
+    gifs: [{ filename: "loop.gif", format: "image/gif" }],
+    videos: [{ filename: "clip.mp4", format: "video/h264-mp4" }, { filename: "clip.mp4", format: "video/h264-mp4" }],
+  });
+  assert.equal(media.length, 3);
+  assert.equal(AppBuilder.isRunVideoRef(media.find((r) => r.filename === "clip.mp4")), true);
+  assert.equal(AppBuilder.isRunVideoRef(media.find((r) => r.filename === "loop.gif")), false);
+  assert.equal(AppBuilder.isRunVideoRef(media.find((r) => r.filename === "still.png")), false);
+  assert.deepEqual(AppBuilder.collectRunMedia(null), []);
 });
 
 // ── dependency scan ─────────────────────────────────────────────────────────

--- a/web/js/cmcp-apps-ui.js
+++ b/web/js/cmcp-apps-ui.js
@@ -408,22 +408,19 @@ async function draftFromCanvas(getApp) {
   for (const node of liveNodes) {
     const id = Number(node.id);
     if (!Number.isFinite(id)) continue;
-    const isOutput =
-      node.constructor?.nodeData?.output_node === true ||
-      /^(SaveImage|PreviewImage|SaveVideo|SaveAudio|PreviewAudio|ShowText|PreviewAsText)/.test(
-        String(node.type || ""),
-      );
-    if (isOutput) {
+    const nodeType = String(node.type || "");
+    const outputKind = AppBuilder.outputKind(nodeType, node.constructor?.nodeData?.output_node === true);
+    if (outputKind) {
       outputs.push({
         nodeId: id,
-        kind: /^Show|^PreviewAs/.test(String(node.type || "")) ? "text" : "images",
+        kind: outputKind,
         label: `${node.title || node.type} #${id}`,
         checked: true,
       });
       continue;
     }
     const nodeHasImported = [...importedKeys].some((k) => Number(k.split(".")[0]) === id);
-    if (!AppBuilder.INPUT_HINT_TYPES.has(String(node.type || "")) && !nodeHasImported) continue;
+    if (!AppBuilder.isInputHint(nodeType) && !nodeHasImported) continue;
     // Only a CONNECTED widget-input makes a widget link-driven. Modern
     // frontends materialize an input socket (link: null) for EVERY widget —
     // treating mere presence as link-driven excluded every candidate on
@@ -439,7 +436,6 @@ async function draftFromCanvas(getApp) {
       const key = `${id}.${w.name}`;
       if (seen.has(key)) continue;
       seen.add(key);
-      const nodeType = String(node.type || "");
       const kind = AppBuilder.classifyWidget(nodeType, w.name, w.value, w.type);
       const opts = w.options || {};
       const num = (x) => (typeof x === "number" && Number.isFinite(x) ? x : undefined);
@@ -1376,10 +1372,10 @@ export function createAppsContent(ctx, shell, opts = {}) {
       const field = el("div", "cmcp-apps-field");
       field.append(el("label", "", input.label || key));
       let getter;
-      if (input.kind === "image") {
+      if (input.kind === "image" || input.kind === "video") {
         const fileInput = document.createElement("input");
         fileInput.type = "file";
-        fileInput.accept = "image/*";
+        fileInput.accept = input.kind === "video" ? "video/*" : "image/*";
         field.append(fileInput);
         // Return the raw File — the RUN path decides where the bytes go
         // (local /upload/image, or the bridge's upload_media → the pod).
@@ -1793,10 +1789,10 @@ export function createAppsContent(ctx, shell, opts = {}) {
       const wanted = new Set((app.appMode?.outputs || []).map((o) => String(o.nodeId)));
       for (const [nodeId, out] of Object.entries(st.outputs || {})) {
         if (wanted.size && !wanted.has(String(nodeId))) continue;
-        const media = [...(out.images || []), ...(out.gifs || [])];
+        const media = AppBuilder.collectRunMedia(out);
         for (const ref of media) {
           const url = viewUrl(ref);
-          const isVideo = /webm|mp4|mov|gif/i.test(ref.filename || "");
+          const isVideo = AppBuilder.isRunVideoRef(ref);
           const m = document.createElement(isVideo ? "video" : "img");
           m.src = url;
           if (isVideo) {

--- a/web/js/cmcp-apps.js
+++ b/web/js/cmcp-apps.js
@@ -8,6 +8,15 @@
 // calls: the graph-touching bits live in cmcp-apps-ui.js, which passes plain
 // JSON (serialize() / graphToPrompt() output) into AppBuilder.
 
+import {
+  isVideoLoaderType,
+  isVideoGenInputHint,
+  appOutputKind,
+  collectAppRunMedia,
+  isAppRunVideoRef,
+  videoFamiliesOnGraph,
+} from "./lib/video-gen-families.js";
+
 const API_BASE = "/comfyui_mcp_panel/apps";
 
 /** Default registry base URL (the production Worker once deployed; override
@@ -261,6 +270,7 @@ export class AppBuilder {
     "KSampler",
     "KSamplerAdvanced",
     "SamplerCustom",
+    "SamplerCustomAdvanced",
     "EmptyImage",
     "EmptyLatentImage",
     "EmptySD3LatentImage",
@@ -269,15 +279,40 @@ export class AppBuilder {
     "EmptyMochiLatentVideo",
   ]);
 
+  /** Hint-type OR a video-gen family parameter/loader (#428). */
+  static isInputHint(nodeType) {
+    const t = String(nodeType || "");
+    return AppBuilder.INPUT_HINT_TYPES.has(t) || isVideoGenInputHint(t);
+  }
+
+  /** "video" | "text" | "images" | null. Shared by heuristic + live convert. */
+  static outputKind(nodeType, outputNode = false) {
+    return appOutputKind(nodeType, outputNode);
+  }
+
+  static collectRunMedia(out) {
+    return collectAppRunMedia(out);
+  }
+
+  static isRunVideoRef(ref) {
+    return isAppRunVideoRef(ref);
+  }
+
+  static videoFamiliesOnGraph(nodes) {
+    return videoFamiliesOnGraph(nodes);
+  }
+
   /** Widget value → app input kind. `nodeType` refines (LoadImage → image
    *  upload; *Loader → model picker); `widgetType` is the live litegraph widget
    *  type when available (lets us spot a `color` widget, which is otherwise an
-   *  ordinary string). seed/noise_seed get the dedicated seed control. */
+   *  ordinary string). seed/noise_seed get the dedicated seed control. Video
+   *  file loaders win over the generic *Loader → model rule (#428). */
   static classifyWidget(nodeType, widgetName, value, widgetType) {
     const t = String(nodeType || "");
     const name = String(widgetName || "");
     const wt = String(widgetType || "").toLowerCase();
     if (/loadimage/i.test(t)) return "image";
+    if (isVideoLoaderType(t)) return "video";
     if (/loader/i.test(t) || /_name$/i.test(name)) return "model";
     if (wt === "color" || (/color/i.test(name) && typeof value === "string" && /^#?[0-9a-fA-F]{6}$/.test(value))) {
       return "color";
@@ -302,16 +337,12 @@ export class AppBuilder {
       const id = Number(node.id);
       if (!Number.isFinite(id)) continue;
       const type = String(node.type || "");
-      const isOutput =
-        node.constructor?.nodeData?.output_node === true ||
-        /^(SaveImage|PreviewImage|SaveVideo|SaveAudio|PreviewAudio|ShowText|PreviewAsText)/.test(
-          type,
-        );
-      if (isOutput) {
-        outputs.push({ nodeId: id, kind: /^Show|^PreviewAs/.test(type) ? "text" : "images" });
+      const kind = AppBuilder.outputKind(type, node.constructor?.nodeData?.output_node === true);
+      if (kind) {
+        outputs.push({ nodeId: id, kind });
         continue;
       }
-      if (!AppBuilder.INPUT_HINT_TYPES.has(type)) continue;
+      if (!AppBuilder.isInputHint(type)) continue;
       const values = Array.isArray(node.widgets_values) ? node.widgets_values : [];
       // widgets_values aligns positionally with the node's widget list; with
       // only serialized JSON we lack widget NAMES — the UI layer enriches from

--- a/web/js/lib/video-gen-families.js
+++ b/web/js/lib/video-gen-families.js
@@ -1,0 +1,149 @@
+// Video-gen backend families the Apps converter (and the panel agent driving
+// that surface) can treat as first-class (#428).
+//
+// THE GAP. AppBuilder's heuristic only knew image-shaped hints (LoadImage,
+// EmptyLatentImage, SaveImage) plus two empty-video latents. Converting an
+// LTX 2.3 / Wan / Bernini / Hunyuan / Easy-Use Media graph therefore:
+//   * skipped LTXDirector / LTXVImgToVideo / WanVideoSampler / Bernini r2v as
+//     inputs — the generation parameters the agent is supposed to drive,
+//   * classified LoadVideo / VHS_LoadVideo as ordinary text (or missed them),
+//   * treated SaveVideo as kind "images",
+//   * never offered VHS_VideoCombine / easy saveVideo as outputs at all,
+//   * dropped ComfyUI history's `videos[]` bag when rendering a run.
+//
+// This lib is the catalog + the predicates AppBuilder and the Apps UI share.
+// Match on the ComfyUI class name (node.type / class_type). Prefix tests are
+// keyed to the families named in #428, not a grab-bag of every video-adjacent
+// node (WanVideoBlockSwap / LTXVTiledVAEDecode stay internal).
+
+/** Generation families named in #428. VHS is I/O, not a generator. */
+export const VIDEO_GEN_FAMILIES = Object.freeze(["ltx", "wan", "bernini", "hunyuan", "easyuse"]);
+
+// Nodes whose widgets are the generation parameters a video-gen app should
+// expose (length, strength, fps, prompt, seed, timeline). Exact class names
+// from the packs/skills already in comfyui-mcp and from ComfyUI core.
+const VIDEO_GEN_PARAM_TYPES = new Set([
+  "EmptyLTXVLatentVideo",
+  "EmptyHunyuanLatentVideo",
+  "EmptyMochiLatentVideo",
+  "LTXVImgToVideo",
+  "LTXVConditioning",
+  "LTXVScheduler",
+  "LTXDirector",
+  "WanFirstLastFrameToVideo",
+  "WanImageToVideo",
+  "WanVideoSampler",
+  "WanVideoTextEncode",
+  "WanVideoImageToVideoEncode",
+  "WanVideoAnimateEmbeds",
+  "HunyuanImageToVideo",
+  "SamplerCustomAdvanced",
+]);
+
+/**
+ * Which #428 generation family a node type belongs to, or null. VHS load/combine
+ * and generic SaveVideo are I/O, not a family.
+ */
+export function classifyVideoGenFamily(nodeType) {
+  const t = String(nodeType || "");
+  if (!t) return null;
+  if (/Bernini/i.test(t)) return "bernini";
+  if (/^(LTXDirector|LTXV|LTXAV|EmptyLTXV)/i.test(t)) return "ltx";
+  if (/^(WanVideo|WanFirstLastFrame|WanImageToVideo)/i.test(t)) return "wan";
+  if (/^(EmptyHunyuanLatentVideo|HunyuanImageToVideo|HunyuanVideo)/i.test(t)) return "hunyuan";
+  if (/^easy\s+/i.test(t) && /video/i.test(t)) return "easyuse";
+  return null;
+}
+
+/** User-upload video file loaders (clip in, not a model loader). */
+export function isVideoLoaderType(nodeType) {
+  const t = String(nodeType || "");
+  if (/^(LoadVideo|VHS_LoadVideo)/i.test(t)) return true;
+  if (/^easy\s+loadVideo/i.test(t)) return true;
+  return false;
+}
+
+/**
+ * Nodes that WRITE a video file the Apps runner should collect. CreateVideo is
+ * a mid-graph VIDEO producer (feeds SaveVideo) — not an output unless the
+ * node's own output_node flag says so (handled by the caller).
+ */
+export function isVideoOutputType(nodeType) {
+  const t = String(nodeType || "");
+  if (/^(SaveVideo|PreviewVideo)$/i.test(t)) return true;
+  if (/^VHS_VideoCombine/i.test(t)) return true;
+  if (/^easy\s+saveVideo/i.test(t)) return true;
+  return false;
+}
+
+/** Generation-parameter (or video-loader) node whose widgets belong on an app form. */
+export function isVideoGenInputHint(nodeType) {
+  const t = String(nodeType || "");
+  if (!t) return false;
+  if (VIDEO_GEN_PARAM_TYPES.has(t)) return true;
+  if (isVideoLoaderType(t)) return true;
+  if (/Bernini/i.test(t)) return true;
+  return false;
+}
+
+/**
+ * App output kind for a node type. `outputNode` is the live
+ * `constructor.nodeData.output_node` flag — when true the node is an output
+ * even if its class is not in the Save/Preview regex.
+ *
+ *   "video" | "text" | "images" | null (not an output)
+ *
+ * SaveAudio stays "images" here on purpose: that is what the previous regex
+ * produced, and audio-app I/O is a different slice.
+ */
+export function appOutputKind(nodeType, outputNode = false) {
+  const t = String(nodeType || "");
+  if (isVideoOutputType(t)) return "video";
+  const named = /^(SaveImage|PreviewImage|SaveVideo|SaveAudio|PreviewAudio|ShowText|PreviewAsText)/.test(
+    t,
+  );
+  if (!named && outputNode !== true) return null;
+  return /^Show|^PreviewAs/.test(t) ? "text" : "images";
+}
+
+/** Deduped image/gif/video refs from one node's ComfyUI /history outputs bag. */
+export function collectAppRunMedia(out) {
+  if (!out || typeof out !== "object") return [];
+  const refs = [];
+  const seen = new Set();
+  for (const bag of [out.images, out.gifs, out.videos]) {
+    if (!Array.isArray(bag)) continue;
+    for (const ref of bag) {
+      if (!ref || typeof ref !== "object") continue;
+      const filename = String(ref.filename || ref.name || "");
+      if (!filename) continue;
+      const key = `${ref.subfolder || ""}/${filename}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      refs.push(ref);
+    }
+  }
+  return refs;
+}
+
+/**
+ * Image-vs-video for a history descriptor. Same rule as the panel's
+ * isVideoOutput: honour `format` first (video/* vs image/*, so animated gif
+ * stays an <img>), else the filename extension.
+ */
+export function isAppRunVideoRef(ref) {
+  const fmt = String(ref?.format || "").toLowerCase();
+  if (fmt.startsWith("video/")) return true;
+  if (fmt.startsWith("image/")) return false;
+  return /\.(mp4|webm|mov|mkv|m4v|avi)$/i.test(String(ref?.filename || ref?.name || ""));
+}
+
+/** Distinct #428 families present on a serialized or live node list. */
+export function videoFamiliesOnGraph(nodes) {
+  const found = new Set();
+  for (const node of Array.isArray(nodes) ? nodes : []) {
+    const family = classifyVideoGenFamily(node?.type || node?.class_type || node?.comfyClass);
+    if (family) found.add(family);
+  }
+  return VIDEO_GEN_FAMILIES.filter((f) => found.has(f));
+}


### PR DESCRIPTION
Refs #428.

Smallest missing slice of the video-gen app request: the Apps converter/runner now treats the named video-gen families as first-class instead of image-shaped.

## What the user now observes

Convert an LTX 2.3 / LTXDirector, Wan, Bernini, Hunyuan, or Easy-Use Media workflow to an app and:

- generation-parameter nodes (LTXDirector, LTXVImgToVideo, WanVideoSampler, Bernini r2v, HunyuanImageToVideo, …) show up as app inputs
- `LoadVideo` / `VHS_LoadVideo` / `easy loadVideo` are a **video** file field, not text/model
- `SaveVideo` / `VHS_VideoCombine` / `easy saveVideo` are **video** outputs
- a finished run collects ComfyUI history `videos[]` (not just `images`/`gifs`) and renders them as `<video>`

## What this is not

The full dedicated video-gen product (Seedance-style agent surface, new packs for Bernini/Hunyuan, a new panel agent) is still out of scope. Main already has LTXDirector `panel_set_widget` driving (`web/js/lib/ltx-director.js`), LTX/Wan packs + skills in comfyui-mcp, and the training wizard's LTX 2.3 / Wan 2.2 rows. PR #679 was an empty placeholder and is closed.

This PR is the panel hook that did not exist: Apps conversion had no video family catalog, classified `SaveVideo` as images, and dropped `videos[]`.

## Tests

`node --test --test-concurrency=4 browser_tests/unit/apps.test.mjs` — drives `AppBuilder.heuristicAppMode` / `classifyWidget` / `collectRunMedia` on LTX, Wan, Bernini, Hunyuan, and Easy-Use graphs, and pins the live convert/run UI to those shipped helpers.
