### PR TITLE
fix(1351): graph_add_node still replies when its own refresh run would miss the window

### DIFF
--- a/browser_tests/unit/add-node-command-budget.test.mjs
+++ b/browser_tests/unit/add-node-command-budget.test.mjs
@@ -163,6 +163,15 @@ function realGraphAddNode({
   // null for "no refresh is in flight". Held open, it is the reported scenario: a ComfyUI
   // restart, whose reconnect refresh is still running when the add arrives.
   holdInFlight = null,
+  // #1351 — milliseconds the PAYLOAD run (this add's own registration) waits before it
+  // registers. The residual: joinMs used to ignore this wait, so a join that landed still
+  // paid the own run in full. Zero keeps every #1192 test on the same clock it had.
+  ownRunMs = 0,
+  // Defs the payload-less (reconnect) run registers once it lands. Default is a live
+  // fetch, which includes NewNode — the #1192 "lands in time" path. The #1351 residual
+  // is the older reconnect that did NOT see NewNode, so this add's own run is what
+  // registers it.
+  inFlightDefs = undefined,
   budgetMs = 400,
   reserveMs = 120,
   registrationMs = 200,
@@ -195,7 +204,10 @@ function realGraphAddNode({
       runs.push(defs);
       // The reconnect run — the one with no payload — is the one a test can hold open.
       if (defs == null && holdInFlight) await holdInFlight;
-      app.registerNodesFromDefs(defs ?? (await api.getNodeDefs()));
+      // #1351 — this add's own registration, after any join. Distinct from holdInFlight:
+      // that is someone else's run, this is ours.
+      if (defs != null && ownRunMs > 0) await sleep(ownRunMs);
+      app.registerNodesFromDefs(defs ?? inFlightDefs ?? (await api.getNodeDefs()));
       return true;
     },
     withTimeout,
@@ -609,4 +621,80 @@ test("#1192: an abandoned drift recovery is reported as a RETRY, not as 'unknown
     /retry/i,
     "…and its reason must name the remedy that actually works",
   );
+});
+
+// ---------------------------------------------------------------------------
+// 5. #1351: the join SUCCEEDING is not the end of the wait this command owns.
+//
+// `joinMs` bounded the wait on someone else's run. After that join landed, this add's
+// OWN run was awaited unbounded — 8.0× its bound in the gate measurement (2,251 ms
+// against 280 ms), and ~13 s on shipped numbers after a join that ended at 20 s, which
+// is the ~33 s worst case against the 30 s relay window. The failing path is the one
+// where every per-step bound is respected and the command still outlives the window.
+// ---------------------------------------------------------------------------
+
+test("#1351: a join that lands near its bound does not then wait out this add's own run", async () => {
+  // The join SUCCEEDS — the in-flight reconnect finishes inside joinMs. The own run is
+  // then what used to blow the window. Without the bound it would take landing + 2000 ms;
+  // with it the add refuses at what joinMs has left and names the retry.
+  const gate = deferred();
+  const comfy = makeComfy();
+  const built = realGraphAddNode({
+    comfy,
+    holdInFlight: gate.promise,
+    // Older reconnect: settled, but did not register NewNode. This add's own run is
+    // the one that would — and used to be waited out unbounded after the join.
+    inFlightDefs: { ExistingNode: backendObjectInfo().ExistingNode },
+    ownRunMs: 2000,
+    budgetMs: 280,
+    reserveMs: 40,
+  });
+
+  const started = Date.now();
+  const pending = built.graph_add_node({ class_type: "NewNode" });
+  // Land AFTER the add has reached the join, so this is the succeed-then-own-run path
+  // rather than a race against a timer started at harness construction.
+  await sleep(30);
+  gate.resolve();
+  await assert.rejects(
+    () => pending,
+    (err) => {
+      assert.equal(err.message, addNodeRefreshBusyMessage("NewNode"));
+      return true;
+    },
+    "an add whose own run would blow the remaining bound must refuse, in words",
+  );
+  const elapsed = Date.now() - started;
+  assert.ok(
+    elapsed < 1200,
+    `the add took ${elapsed}ms — it must give up at the remaining bound, not wait the own run's 2000ms`,
+  );
+  assert.equal(comfy.graph._nodes.length, 0, "the graph was not touched");
+  await built.inFlightStarted?.catch(() => {});
+});
+
+test("#1351: with NO refresh in flight the add still stops waiting on its own run at the bound", async () => {
+  // The 8.0× measurement: no join to spend, a 280 ms bound, a multi-second own run.
+  const comfy = makeComfy();
+  const built = realGraphAddNode({
+    comfy,
+    ownRunMs: 2000,
+    budgetMs: 280,
+    reserveMs: 0,
+  });
+
+  const started = Date.now();
+  await assert.rejects(
+    () => built.graph_add_node({ class_type: "NewNode" }),
+    (err) => {
+      assert.equal(err.message, addNodeRefreshBusyMessage("NewNode"));
+      return true;
+    },
+  );
+  const elapsed = Date.now() - started;
+  assert.ok(
+    elapsed < 1200,
+    `the add took ${elapsed}ms against a 280ms bound — the own run is unbounded again`,
+  );
+  assert.equal(comfy.graph._nodes.length, 0, "the graph was not touched");
 });

--- a/browser_tests/unit/refresh-coalesce.test.mjs
+++ b/browser_tests/unit/refresh-coalesce.test.mjs
@@ -414,3 +414,108 @@ test("#1192: a bounded FORCED join that lands still forwards the trailing run's 
   await inflight;
   assert.equal(await forced, true, "the trailing run's own verdict, not a stand-in");
 });
+
+// ── #1351: joinMs bounds the invocation, not just the join ───────────────────
+//
+// #1192 capped the wait on a run someone else started. The residual is the run THIS
+// caller starts AFTER that join lands: `joinMs` used to ignore it, so a join that
+// succeeded near its bound still paid a full own run (~13 s of waiting + unbounded
+// local work) and missed the 30 s relay window with every per-step bound green.
+// Measured at 8.0× (2,251 ms against a 280 ms bound) during the #1342/#1349 gate.
+
+test("#1351: a join that lands still bounds the run that follows it", async () => {
+  const joinGate = deferred();
+  const ownGate = deferred();
+  const { coalescer, registered } = makeHarness(async (defs) => {
+    if (defs == null) await joinGate.promise;
+    else await ownGate.promise; // this caller's own run never lands on its own
+  });
+
+  const older = coalescer();
+  const NEW_DEFS = { NewNode: {} };
+  const started = Date.now();
+  const withPayload = coalescer(NEW_DEFS, { joinMs: 80 });
+  // The join SUCCEEDS — the residual is not an abandoned join. The own run is what
+  // used to be waited out unbounded.
+  joinGate.resolve();
+  await older;
+
+  const outcome = await withPayload;
+  assert.equal(outcome, REFRESH_JOIN_ABANDONED, "the caller stopped waiting on its own run");
+  assert.ok(
+    Date.now() - started < 500,
+    "…at what joinMs had left, not when the own run eventually settles",
+  );
+  // The join settled, so starting the run is not a stampede. The payload is in the
+  // slot and will register; only this caller's wait ended.
+  assert.ok(registered.includes(NEW_DEFS), "the own run started after the join settled");
+
+  ownGate.resolve();
+});
+
+test("#1351: with nothing in flight, joinMs still bounds THIS run", async () => {
+  // The 8.0× measurement: no meaningful join, a 280 ms bound, a 2,251 ms own run.
+  const gate = deferred();
+  const { coalescer, registered } = makeHarness(async () => {
+    await gate.promise;
+  });
+
+  const NEW_DEFS = { NewNode: {} };
+  const started = Date.now();
+  const outcome = await coalescer(NEW_DEFS, { joinMs: 40 });
+
+  assert.equal(outcome, REFRESH_JOIN_ABANDONED, "a bound with no join to spend still expires");
+  assert.ok(Date.now() - started < 400, "…at the bound, not when the run eventually settles");
+  assert.ok(registered.includes(NEW_DEFS), "the run was started; only the wait ended");
+
+  gate.resolve();
+});
+
+test("#1351: an own run that lands INSIDE the remaining bound still registers (#289 P2 intact)", async () => {
+  const gate = deferred();
+  const { coalescer, registered } = makeHarness(async (defs) => {
+    if (defs == null) await gate.promise;
+  });
+
+  const older = coalescer();
+  const NEW_DEFS = { NewNode: {} };
+  const withPayload = coalescer(NEW_DEFS, { joinMs: 5000 });
+  gate.resolve();
+  await older;
+  const outcome = await withPayload;
+
+  assert.notEqual(outcome, REFRESH_JOIN_ABANDONED, "a healthy own run is not abandoned");
+  assert.ok(registered.includes(NEW_DEFS), "the fresh payload was registered, bound or no bound");
+});
+
+test("#1351: abandoning the wait on an own run does not cancel it", async () => {
+  // withTimeout does not cancel. The run keeps occupying the slot and registering, so a
+  // retry joins work already in flight rather than starting a competing pass.
+  const ownGate = deferred();
+  const { coalescer, registered, getInFlight } = makeHarness(async (defs) => {
+    if (defs != null) await ownGate.promise;
+  });
+
+  const NEW_DEFS = { NewNode: {} };
+  assert.equal(await coalescer(NEW_DEFS, { joinMs: 40 }), REFRESH_JOIN_ABANDONED);
+  assert.ok(getInFlight(), "the own run is still in the slot after this caller gave up");
+
+  ownGate.resolve();
+  await getInFlight();
+  assert.ok(registered.includes(NEW_DEFS), "…and it still registered the payload");
+});
+
+test("#1351: a forced run with nothing in flight is bounded too", async () => {
+  const gate = deferred();
+  const { coalescer } = makeHarness(async () => {
+    await gate.promise;
+  });
+
+  const started = Date.now();
+  assert.equal(
+    await coalescer(undefined, { force: true, joinMs: 40 }),
+    REFRESH_JOIN_ABANDONED,
+  );
+  assert.ok(Date.now() - started < 400, "force:true is not a way around the bound");
+  gate.resolve();
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -1853,12 +1853,13 @@ const refreshComfyNodeDefs = makeRefreshCoalescer({
     nodeDefRefreshInFlight = p;
   },
   runRegister: registerComfyNodeDefs,
-  // #1192 — the repo's ONE bounding primitive, injected so a caller can bound its own WAIT
-  // on a run someone else started (`opts.joinMs`). Without it the coalescer waits
-  // unbounded, exactly as it always did — the safe direction for a wiring mistake to fail
-  // in, since the alternative would abandon every join on a panel that forgot this line.
-  // Safe is not the same as noticed, though: dropping it silently restores #1192, so the
-  // CALL SITE is pinned by a test, not just the helper's behaviour.
+  // #1192 / #1351 — the repo's ONE bounding primitive, injected so a caller can bound its
+  // own WAIT (`opts.joinMs`) on a run someone else started AND on the run this caller
+  // starts after that join. Without it the coalescer waits unbounded, exactly as it always
+  // did — the safe direction for a wiring mistake to fail in, since the alternative would
+  // abandon every join on a panel that forgot this line. Safe is not the same as noticed,
+  // though: dropping it silently restores #1192, so the CALL SITE is pinned by a test, not
+  // just the helper's behaviour.
   withTimeout,
 });
 
@@ -10348,7 +10349,8 @@ const ADD_NODE_COMMAND_BUDGET_MS = 25000;
 const ADD_NODE_POST_REFRESH_RESERVE_MS = CUSTOM_WIDGET_REGISTRATION_TIMEOUT_MS;
 
 /**
- * #1192 — the refusal for an add whose budget went on a refresh SOMEONE ELSE started.
+ * #1192 / #1351 — the refusal for an add whose budget went on a node-def refresh —
+ * someone else's in-flight run, or this command's own run after that join settled.
  *
  * RECOVERABLE BY CONSTRUCTION, and worded to say so. The in-flight run was not cancelled
  * (nothing here can cancel it) and it is registering the very definitions this add needs, so
@@ -10357,9 +10359,10 @@ const ADD_NODE_POST_REFRESH_RESERVE_MS = CUSTOM_WIDGET_REGISTRATION_TIMEOUT_MS;
  * payload while claiming success, not dropping one while refusing.
  */
 const addNodeRefreshBusyMessage = (classType) =>
-  `Cannot add "${classType}" right now: a node-def refresh started by something else — a ` +
-  "ComfyUI reconnect, a finished install, or another tool call — was still running, and " +
-  `waiting for it would have used up this command's ${Math.round(ADD_NODE_COMMAND_BUDGET_MS / 1000)}s ` +
+  `Cannot add "${classType}" right now: a node-def refresh — a ComfyUI reconnect, a ` +
+  "finished install, another tool call, or this command's own registration — was still " +
+  "running, and waiting for it would have used up this command's " +
+  `${Math.round(ADD_NODE_COMMAND_BUDGET_MS / 1000)}s ` +
   "budget before the node could be registered. NOTHING WAS ADDED and nothing was changed. " +
   "That refresh is still running and is registering exactly the definitions this add needs, " +
   "so RETRY in a few seconds — this normally succeeds on the next attempt. If it keeps " +
@@ -12257,21 +12260,26 @@ const GRAPH_TOOL_EXECUTORS = {
         currentDef = snapshotBackendDef(freshDefs, class_type);
         return freshDefs;
       },
-      // #1192 — THE TERM THAT CANNOT BE SHRUNK FROM HERE, bounded at the only thing this
-      // caller owns: its own WAIT.
+      // #1192 / #1351 — THE TERM THAT CANNOT BE SHRUNK FROM HERE is the in-flight run
+      // someone else started. This caller owns its own WAIT, including the run it starts
+      // after that join settles.
       //
       // `refreshComfyNodeDefs` is the coalescer. With a payload it waits for any in-flight
       // run and then starts its own, so on the scenario this add is most likely to meet —
       // a ComfyUI restart, which is exactly when a reconnect-triggered refresh is already
       // running — it pays a full run (about 9,000 ms of bounded waiting plus unbounded
       // local work) before its OWN registration begins. That first run started under
-      // someone else's deadline and no number passed from here can shorten it.
+      // someone else's deadline and no number passed from here can shorten it. The own
+      // run used to be unbounded from here too: a join landing at 20,000 ms then added
+      // ~13,000 ms of this caller's work, ~33 s against the 30 s relay window, with every
+      // per-step bound respected. `joinMs` is now a deadline for the whole invocation.
       //
       // So the wait is capped, and a cap needs a decision for when it fires. Proceeding
       // would mean adding a node whose class may not be registered — #458's fabricated
       // placeholder. Blocking is the reported bug. It REFUSES, in words, recoverably: see
       // `addNodeRefreshBusyMessage`, and `REFRESH_JOIN_ABANDONED` in refresh-coalesce.js
-      // for why the abandoned caller must not start a competing run instead.
+      // for why an abandoned JOIN must not start a competing run, and why an abandoned
+      // OWN RUN still starts (the slot is free; retry joins a registration already going).
       //
       // The reserve is held back so the join cannot eat the steps that follow it. Without
       // it a join finishing at the wire leaves the widget-registration wait milliseconds,

--- a/web/js/lib/refresh-coalesce.js
+++ b/web/js/lib/refresh-coalesce.js
@@ -22,18 +22,22 @@
 // AFTER the current run settles. Multiple forced calls that arrive during one
 // in-flight run coalesce into a SINGLE trailing run (no /object_info stampede).
 //
-// #1192 — A CALLER MAY BOUND ITS OWN WAIT, and that is the only thing it may bound.
+// #1192 / #1351 — A CALLER MAY BOUND ITS OWN WAIT. That wait is the whole invocation,
+// not just the join.
 //
 // Every branch above begins with `await current` — a wait on a run that ALREADY STARTED,
 // under a deadline someone else took. A caller cannot retroactively shorten that run, and
-// nothing here pretends to: `opts.joinMs` bounds the CALLER'S WAIT and never the run. The
-// run keeps going, registers whatever it fetched, and clears the slot exactly as before.
+// nothing here pretends to: `opts.joinMs` never cancels work already in flight. The run
+// keeps going, registers whatever it fetched, and clears the slot exactly as before.
 //
-// This exists because the wait is a real term in a command's budget. `graph_add_node` meets
-// it on the scenario it is most likely to fail on — a ComfyUI restart, which is precisely
-// when a reconnect-triggered refresh is already in flight — and a full run costs ~9s of
-// bounded waiting plus ~4s of deliberately-unbounded local work. Unbounded, that single
-// term can consume most of the add's window before its own registration has begun.
+// #1192 bounded the JOIN. That was not enough. With a payload the join is followed by
+// THIS caller's own `startRun`, and `joinMs` used to ignore that second wait. Measured:
+// a 280 ms bound, join landing inside it, then the own run adding 2,251 ms (8.0×). With
+// shipped numbers a join can end at 20,000 ms and the own run then adds ~13,000 ms
+// (NODE_DEFS_RUN_BUDGET_MS plus the deliberately-unbounded local work) — ~33 s against
+// the 30 s relay window, with every per-step bound respected. So `joinMs` is a deadline
+// for this invocation: the join, then whatever remains for the run this caller starts.
+// The run is not cancelled (nothing here can cancel it); the caller stops WAITING.
 //
 // WHAT AN ABANDONED JOIN MUST NOT DO is start a run anyway. The whole reason this
 // coordinator exists is that two concurrent `registerNodesFromDefs` passes stampede; a
@@ -42,9 +46,15 @@
 // as a regression of #289 P2 until the caller's half is read with it: `graph_add_node` does
 // not proceed on that value, it REFUSES IN WORDS and says to retry. Dropping a payload
 // while refusing is safe; dropping one while claiming success is the bug #289 was about.
+//
+// An abandoned OWN RUN is the other half. The join already settled, so starting the run
+// is not a stampede — the slot is free and the payload is the one this caller brought.
+// The run is started, occupies the slot, and keeps registering; only this caller's wait
+// ends. Retry then joins a run that is already registering the class it asked for.
 
 /**
- * Returned when the caller stopped WAITING for a refresh someone else started.
+ * Returned when the caller stopped WAITING — either for a refresh someone else started,
+ * or for a run this caller started that did not finish inside what `joinMs` had left.
  *
  * A distinct value rather than `undefined`, because `undefined` is already what a
  * successful plain join resolves to and the two demand opposite handling — one means "the
@@ -85,6 +95,35 @@ async function joinBounded(current, joinMs, withTimeout) {
   );
 }
 
+/**
+ * Wait for a run THIS caller started (or a shared trailing run), for at most `ms`.
+ *
+ * Distinct from `joinBounded`: the run already belongs to this invocation (or to #396's
+ * trailing guarantee), so a timeout does not cancel it and does not prevent it occupying
+ * the slot. The caller stops waiting and says so. `ms <= 0` must not reach `withTimeout`,
+ * which reads a non-positive bound as NO BOUND.
+ *
+ * A rejecting run still rejects: #608 reads the verdict a forced refresh resolves, and a
+ * bound on the wait must not quietly turn that into a success. Only the abandonment is new.
+ */
+async function waitForRun(run, ms, withTimeout) {
+  if (ms === null) return run;
+  // An abandoned wait is not a reason to turn the run's failure into an unhandled rejection.
+  run.catch(() => {});
+  if (!(ms > 0)) return REFRESH_JOIN_ABANDONED;
+  const settled = await withTimeout(
+    Promise.resolve(run).then(
+      (value) => ({ value }),
+      (err) => ({ err }),
+    ),
+    ms,
+    () => null,
+  );
+  if (settled === null) return REFRESH_JOIN_ABANDONED;
+  if ("err" in settled) throw settled.err;
+  return settled.value;
+}
+
 //   getInFlight / setInFlight : accessors for the shared single-flight promise slot
 //                               (module-level in the panel).
 //   runRegister(preloadedDefs) : performs the actual (idempotent) registration; its
@@ -123,6 +162,10 @@ export function makeRefreshCoalescer({ getInFlight, setInFlight, runRegister, wi
       opts && Number.isFinite(opts.joinMs) && typeof withTimeout === "function"
         ? opts.joinMs
         : null;
+    // #1351 — `joinMs` is a deadline for THIS invocation, taken once, so the join and the
+    // run that follows it COMPOSE rather than add. Wall clock, matching `withTimeout`.
+    const startedAt = joinMs === null ? 0 : Date.now();
+    const remaining = () => (joinMs === null ? null : joinMs - (Date.now() - startedAt));
     const current = getInFlight();
     if (current) {
       // No payload, not forced ⇒ joining the settled refresh is enough.
@@ -137,7 +180,10 @@ export function makeRefreshCoalescer({ getInFlight, setInFlight, runRegister, wi
         // run here would put a second `registerNodesFromDefs` alongside one still going,
         // which is the stampede this coordinator exists to prevent. The caller refuses.
         if (!(await joinBounded(current, joinMs, withTimeout))) return REFRESH_JOIN_ABANDONED;
-        return startRun(preloadedDefs);
+        // #1351 — the join settled, so starting our own run is not a stampede. What remains
+        // of `joinMs` bounds the wait on THAT run. Wrapping join+run as one promise and
+        // bounding it once would start the run after an abandoned join — the stampede.
+        return waitForRun(startRun(preloadedDefs), remaining(), withTimeout);
       }
       // Forced, no payload ⇒ guarantee a fresh fetch AFTER the current run
       // settles; coalesce concurrent forced calls into ONE trailing run (#396).
@@ -146,6 +192,8 @@ export function makeRefreshCoalescer({ getInFlight, setInFlight, runRegister, wi
       // nothing else. A second forced caller with a longer budget still gets the same run;
       // one that gives up does not cancel it, and does not stop it from being queued. That
       // asymmetry is deliberate: the run is #396's guarantee to whoever else is waiting.
+      // The queued promise already includes the trailing `startRun`, so this one bound
+      // covers join AND run — the shape #1351 brings to the payload path as well.
       if (!trailing) {
         trailing = (async () => {
           try {
@@ -157,29 +205,13 @@ export function makeRefreshCoalescer({ getInFlight, setInFlight, runRegister, wi
           return startRun(undefined);
         })();
       }
-      const queued = trailing;
-      if (joinMs === null) return queued;
-      // The trailing promise must not go unhandled when this caller stops waiting on it:
-      // #396 guarantees the run to other waiters, and an abandoned wait is not a reason to
-      // turn its failure into an unhandled rejection.
-      queued.catch(() => {});
-      // A budget already spent abandons WITHOUT awaiting — see joinBounded.
-      if (!(joinMs > 0)) return REFRESH_JOIN_ABANDONED;
-      const settled = await withTimeout(
-        queued.then(
-          (value) => ({ value }),
-          (err) => ({ err }),
-        ),
-        joinMs,
-        () => null,
-      );
-      if (settled === null) return REFRESH_JOIN_ABANDONED;
-      // A forced refresh that REJECTS has always rejected for its caller (#608 reads the
-      // verdict it resolves), and a bound on the wait must not quietly turn that into a
-      // success. Only the abandonment is new.
-      if ("err" in settled) throw settled.err;
-      return settled.value;
+      return waitForRun(trailing, joinMs, withTimeout);
     }
-    return startRun(preloadedDefs);
+    // #1351 — nothing in flight, so `joinMs` has no join to bound. It still bounds THIS
+    // run: the 8.0× measurement was a 2,251 ms own run against a 280 ms bound with the
+    // join landing (or never starting) inside it. A bound already spent starts nothing —
+    // the same as an abandoned join, and for the same `withTimeout` trap.
+    if (joinMs !== null && !(joinMs > 0)) return REFRESH_JOIN_ABANDONED;
+    return waitForRun(startRun(preloadedDefs), joinMs, withTimeout);
   };
 }


### PR DESCRIPTION
Fixes #1351.

## What was wrong

`joinMs` bounded only the *join* — how long a caller waits for a refresh already in flight. After that join landed, `graph_add_node`'s own run was awaited unbounded.

Measured during the #1342/#1349 gate: **8.0× the bound** (2,251 ms against a 280 ms bound). With shipped numbers a join can end at 20,000 ms and the own run then adds ~13,000 ms (`NODE_DEFS_RUN_BUDGET_MS` plus the deliberately-unbounded local work), so the worst case is **~33 s against the 30 s relay window**. Every per-step bound is respected; the command still outlives the window. The failing path is the one where the join *succeeds* near its bound.

Raising `OBJECT_INFO_REFRESH_ACK_TIMEOUT_MS` is the non-fix the issue asked not to take.

## Fix

`joinMs` is a deadline for the whole `refresh()` invocation, not just the join.

- An abandoned **join** still starts nothing (the stampede `makeRefreshCoalescer` exists to prevent).
- After a join settles, this caller's own run **is** started — the slot is free, so that is not a stampede — and what remains of `joinMs` bounds the wait on it. The run is not cancelled (`withTimeout` never cancels); only this caller's wait ends. Retry joins a registration already going.
- With nothing in flight, `joinMs` still bounds this run. That is the 8.0× measurement.
- The forced trailing path already bounded join+run as one promise; it now shares `waitForRun`.

The refusal wording covers both someone else's in-flight run and this command's own registration. Retry is still the remedy.

## Tests

Drive the shipped functions, not a model of them:

- `refresh-coalesce.test.mjs` — join lands, own run is slow → `REFRESH_JOIN_ABANDONED` at the remaining bound; no-in-flight run bounded; healthy own run still registers; abandoned wait does not cancel the run.
- `add-node-command-budget.test.mjs` — shipped `graph_add_node` body against the real coalescer: join succeeds on a stale reconnect, own run would take 2 s → worded refusal inside the command budget; same with no in-flight refresh.

## Verification

- `node --test --test-timeout=15000 --test-concurrency=4` on `refresh-coalesce`, `add-node-command-budget`, `single-node-def`, `add-node-schema-auto-refresh`, `add-node-schema-drift-recovery`, `command-budget` — **73 pass, 0 fail**.
- `node --check` on the two edited shipped files.

CI is authority for the full suite.
