### PR TITLE
fix(1723): a back-to-back graph command flushes the pending tracker snapshot before the fence

### DIFF
--- a/browser_tests/unit/change-tracker-snapshot.test.mjs
+++ b/browser_tests/unit/change-tracker-snapshot.test.mjs
@@ -4,7 +4,10 @@ import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 
-import { deferChangeTrackerSnapshot } from "../../web/js/lib/change-tracker-snapshot.js";
+import {
+  deferChangeTrackerSnapshot,
+  flushPendingChangeTrackerSnapshot,
+} from "../../web/js/lib/change-tracker-snapshot.js";
 
 test("#581 defers the captured tracker snapshot and preserves its receiver", () => {
   let queued = null;
@@ -56,4 +59,100 @@ test("#581 wires the deferred snapshot after delivering a successful command rep
   assert.ok(capture >= 0, "successful executor path captures its tracker");
   assert.ok(deliverAt > capture, "reply delivery follows the successful executor");
   assert.ok(defer > deliverAt, "snapshot is scheduled only after the reply is delivered");
+});
+
+test("#1723 flush runs the pending capture synchronously and cancels its timer", () => {
+  let calls = 0;
+  const tracker = { checkState() { calls += 1; } };
+  let queued = null;
+  let cancelled = null;
+  const schedule = (callback) => {
+    queued = callback;
+    return "timer-1";
+  };
+  const cancel = (timer) => {
+    cancelled = timer;
+  };
+
+  assert.equal(deferChangeTrackerSnapshot(tracker, schedule, cancel), true);
+  // The burst's next command arrives before the timer phase: the capture has not run.
+  assert.equal(calls, 0);
+  assert.equal(flushPendingChangeTrackerSnapshot(tracker), true);
+  assert.equal(calls, 1, "the fence's next observation sees the refreshed state");
+  assert.equal(cancelled, "timer-1", "the deferred timer is cancelled so the capture runs once");
+  // Nothing remains pending; a second flush is a no-op.
+  assert.equal(flushPendingChangeTrackerSnapshot(tracker), false);
+  assert.equal(calls, 1);
+});
+
+test("#1723 flush refuses a tracker that does not own the pending snapshot", () => {
+  let callsA = 0;
+  const trackerA = { checkState() { callsA += 1; } };
+  const trackerB = { checkState() { assert.fail("tracker B must never be captured by A's snapshot"); } };
+  let queued = null;
+  assert.equal(deferChangeTrackerSnapshot(trackerA, (callback) => { queued = callback; }), true);
+
+  // A tab switch in the window: the pending capture belongs to A and stays deferred.
+  assert.equal(flushPendingChangeTrackerSnapshot(trackerB), false);
+  assert.equal(flushPendingChangeTrackerSnapshot(null), false);
+  assert.equal(callsA, 0);
+  // The original timer still fires for A, exactly once.
+  queued();
+  assert.equal(callsA, 1);
+});
+
+test("#1723 a stale timer must not clear a NEWER pending record", () => {
+  const tracker = { checkState() {} };
+  let first = null;
+  let second = null;
+  deferChangeTrackerSnapshot(tracker, (callback) => { first = callback; });
+  deferChangeTrackerSnapshot(tracker, (callback) => { second = callback; });
+  // The first timer fires after the second defer replaced the record: the second
+  // record must survive so a flush can still consume it.
+  first();
+  assert.equal(flushPendingChangeTrackerSnapshot(tracker), true);
+  second(); // idempotent no-op capture; must not throw.
+});
+
+test("#1723 prefers captureCanvasState over the deprecated checkState", () => {
+  let current = 0;
+  let legacy = 0;
+  const tracker = {
+    captureCanvasState() { current += 1; },
+    checkState() { legacy += 1; },
+  };
+  let queued = null;
+  assert.equal(deferChangeTrackerSnapshot(tracker, (callback) => { queued = callback; }), true);
+  assert.equal(flushPendingChangeTrackerSnapshot(tracker), true);
+  assert.equal(current, 1);
+  assert.equal(legacy, 0, "the deprecated name is only a fallback");
+});
+
+test("#1723 defers and flushes on a tracker that only has captureCanvasState", () => {
+  let calls = 0;
+  const tracker = { captureCanvasState() { calls += 1; } };
+  let queued = null;
+  assert.equal(
+    deferChangeTrackerSnapshot(tracker, (callback) => { queued = callback; }),
+    true,
+    "a current-frontend tracker must still queue — checkState-only support leaves the fingerprint stale forever",
+  );
+  queued();
+  assert.equal(calls, 1);
+});
+
+test("#1723 flush swallows a capture failure like the deferred path does", () => {
+  const tracker = { checkState() { throw new Error("workflow disposed"); } };
+  deferChangeTrackerSnapshot(tracker, () => {});
+  assert.doesNotThrow(() => flushPendingChangeTrackerSnapshot(tracker));
+  assert.equal(flushPendingChangeTrackerSnapshot(tracker), false, "a consumed record stays consumed");
+});
+
+test("#1723 wires the flush BEFORE the graph-binding fence in the dispatch path", () => {
+  const here = dirname(fileURLToPath(import.meta.url));
+  const source = readFileSync(join(here, "../../web/js/comfyui-mcp-panel.js"), "utf8").replace(/\r\n/g, "\n");
+  const flush = source.indexOf("flushPendingChangeTrackerSnapshot(");
+  const fence = source.indexOf("assertGraphBoundToActiveWorkflow(graph, rootGraph, graphCommandBindingBar(msg.cmd))");
+  assert.ok(flush >= 0, "the dispatch path flushes a pending tracker snapshot");
+  assert.ok(fence > flush, "the flush lands before the binding fence reads the tracker");
 });

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -435,7 +435,10 @@ import {
   describeInputLink,
   verifyDisconnect,
 } from "./lib/disconnect-verify.js";
-import { deferChangeTrackerSnapshot } from "./lib/change-tracker-snapshot.js";
+import {
+  deferChangeTrackerSnapshot,
+  flushPendingChangeTrackerSnapshot,
+} from "./lib/change-tracker-snapshot.js";
 import { flushSourceCanvasBeforeSwitch } from "./lib/flush-source-before-switch.js";
 import { coerceMessageText, isDroppedAgentReplay, serializeContext, stripAgentDirectedBlocks } from "./lib/chat-serialize.js";
 import {
@@ -21757,6 +21760,14 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
                 });
                 if (reconnectGate) throw reconnectRefusalError(reconnectGate);
               }
+              // comfyui-mcp#1723 — a successful command defers its tracker snapshot
+              // past the reply (#581); a back-to-back command from the same burst
+              // reaches the fence on the stale pre-command fingerprint and refuses
+              // the RIGHT canvas. Flush the capture already committed to (same
+              // tracker only — a different active tracker means the tab moved).
+              flushPendingChangeTrackerSnapshot(
+                app?.extensionManager?.workflow?.activeWorkflow?.changeTracker ?? null,
+              );
               const { graph, rootGraph } = getGraphCtx();
               assertGraphBoundToActiveWorkflow(graph, rootGraph, graphCommandBindingBar(msg.cmd));
             }

--- a/web/js/lib/change-tracker-snapshot.js
+++ b/web/js/lib/change-tracker-snapshot.js
@@ -6,20 +6,70 @@
 // tracker that owned the completed edit, then yield one UI turn before asking it
 // to snapshot. Capturing it matters: looking up activeWorkflow in the callback
 // could snapshot a tab the user selected after the edit instead.
+//
+// comfyui-mcp#1723 — the deferral leaves a WINDOW: until the timer fires, the
+// tracker's captured state still describes the canvas BEFORE the panel's own
+// edit, and the graph-binding fence reads that lag as a shape mismatch — so a
+// back-to-back graph command from the same burst (two calls dispatched in one
+// turn, both handled before the timer phase) refused the RIGHT canvas, and every
+// mutation needed its own re-open first. The pending record below lets the next
+// graph command FLUSH the already-committed capture synchronously before its
+// fence runs: the capture was going to happen either way, so flushing changes
+// only WHEN it lands, never WHETHER.
+
+let pendingSnapshot = null;
+
+function captureNow(changeTracker) {
+  // `checkState` is DEPRECATED upstream — it warns, then delegates to this — so
+  // prefer the current name and keep the old one as the fallback for older
+  // frontends (mirrors captureCanvasIntoTracker's resolution order).
+  const capture = changeTracker?.captureCanvasState ?? changeTracker?.checkState;
+  if (typeof capture !== "function") return false;
+  try {
+    capture.call(changeTracker);
+  } catch {
+    // Older frontends and transient workflow teardown keep undo best-effort.
+  }
+  return true;
+}
 
 /**
  * Queue a best-effort ChangeTracker snapshot without blocking the current command
  * reply. Returns whether a snapshot was queued. `schedule` is injectable for the
  * no-DOM unit test; production uses the browser timer.
  */
-export function deferChangeTrackerSnapshot(changeTracker, schedule = setTimeout) {
-  if (typeof changeTracker?.checkState !== "function") return false;
-  schedule(() => {
-    try {
-      changeTracker.checkState();
-    } catch {
-      // Older frontends and transient workflow teardown keep undo best-effort.
-    }
+export function deferChangeTrackerSnapshot(changeTracker, schedule = setTimeout, cancel = clearTimeout) {
+  if (
+    typeof changeTracker?.captureCanvasState !== "function" &&
+    typeof changeTracker?.checkState !== "function"
+  ) {
+    return false;
+  }
+  const record = { tracker: changeTracker };
+  const timer = schedule(() => {
+    // A flush (or a newer defer) may have consumed the record already; the
+    // capture is diff-based and idempotent, so firing anyway is harmless — only
+    // the pending marker must not be cleared from under a NEWER record.
+    if (pendingSnapshot === record) pendingSnapshot = null;
+    captureNow(changeTracker);
   }, 0);
+  record.cancel = () => cancel(timer);
+  pendingSnapshot = record;
   return true;
+}
+
+/**
+ * #1723 — run the deferred snapshot NOW, before the caller's next observation of
+ * the tracker. Refuses unless the pending record belongs to THIS tracker: a
+ * capture serializes the live canvas, so flushing a tracker that no longer owns
+ * it would stamp one workflow's canvas onto another's state. Returns whether a
+ * pending snapshot was consumed. The timer is cancelled so the capture runs
+ * exactly once.
+ */
+export function flushPendingChangeTrackerSnapshot(changeTracker) {
+  const record = pendingSnapshot;
+  if (!record || !changeTracker || record.tracker !== changeTracker) return false;
+  pendingSnapshot = null;
+  record.cancel();
+  return captureNow(changeTracker);
 }


### PR DESCRIPTION
## Root cause

artokun/comfyui-mcp#1723 — after any successful panel graph mutation, the panel defers its ChangeTracker snapshot past the reply (deliberately, #581: serializing a large graph synchronously delayed the rid reply past the orchestrator timeout). Until that timer fires, the tracker's captured state still describes the canvas **before** the panel's own edit, and the graph-binding fence (`resolveGraphBindingVerdict`) reads the panel's own just-applied mutation as `root-shape-mismatch`. Two consequences:

- **Bursts**: two mutations dispatched in one turn are both handled before the timer phase, so the second refuses the RIGHT canvas (the issue's "one succeeds, one fails" case) — and this survives on current main.
- **Sequential** calls on the reporter's panel 0.14.3 failed for a simpler reason: the post-command snapshot wiring (#594) only shipped in 0.14.10, so the fingerprint never refreshed at all. It also silently never refreshes on any frontend where the deprecated `checkState` has been removed in favour of `captureCanvasState` — the deferred path only knew the old name.

Net effect reported: every graph mutation needed its own `panel_open_workflow` rebind first.

## Fix

- `web/js/lib/change-tracker-snapshot.js` now keeps the pending snapshot in a module record and exports `flushPendingChangeTrackerSnapshot(tracker)`: it runs the already-committed capture synchronously, cancels the timer so the capture runs exactly once, and **refuses unless the pending record belongs to the same tracker** — a capture serializes the live canvas, so flushing a tracker that no longer owns it would stamp one workflow's canvas onto another's state.
- The dispatch path in `web/js/comfyui-mcp-panel.js` flushes the pending snapshot (for the active workflow's tracker) immediately before the graph-binding fence. The capture was going to happen either way; this only makes its ordering deterministic for the next command in a burst.
- The snapshot now prefers `captureCanvasState` over the deprecated `checkState` (same resolution order as `captureCanvasIntoTracker`), so a current-frontend tracker actually refreshes.

No behaviour change outside the window: with no snapshot pending, or a different tracker active (tab moved), everything is exactly as before.

## Verification

- `browser_tests/unit/change-tracker-snapshot.test.mjs`: 7 new tests — flush captures synchronously and cancels the timer; flush refuses a tracker that does not own the pending snapshot (tab-switch safety); a stale timer cannot clear a NEWER pending record; `captureCanvasState` is preferred and suffices alone; capture failures are swallowed like the deferred path; and a source-order wiring test pins that the flush lands before the binding fence in dispatch.
- `npm ci` — clean.
- `npm run test:unit` (i18n-check + i18n-render-check + check-tool-vocabulary + check-panel-scope + full unit suite): **5497 tests, 5496 pass, 0 fail** (1 pre-existing skip/todo).
- `npm run typecheck` (`tsc --noEmit`) — clean.

Not verified against a live ComfyUI browser session — the fix is pinned at unit/wiring level. The one case in the issue this does not claim to explain is `panel_run` failing immediately after `panel_save_workflow` on 0.14.3, which may have involved post-run widget rewrites (control_after_generate) drifting the canvas; several of those dialect false-positives were fixed separately in 0.14.4x–0.15.x (#1467, #1623). The flush also covers the run-after-save ordering hazard where the save's own snapshot was still pending.

Closes artokun/comfyui-mcp#1723