### PR TITLE
fix(1351): bound a refresh RUN from its caller, not just the join

### DIFF
--- a/browser_tests/unit/_panel-constants.mjs
+++ b/browser_tests/unit/_panel-constants.mjs
@@ -14,7 +14,7 @@ import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 
 import { makeCommandBudget } from "../../web/js/lib/command-budget.js";
-import { REFRESH_JOIN_ABANDONED } from "../../web/js/lib/refresh-coalesce.js";
+import { REFRESH_JOIN_ABANDONED, REFRESH_RUN_ABANDONED } from "../../web/js/lib/refresh-coalesce.js";
 import { clearInheritedExecutionPreview } from "../../web/js/lib/execution-preview-attach.js";
 
 export const PANEL_SRC = readFileSync(
@@ -139,12 +139,19 @@ export function addNodeCommandBudgetDeps() {
     ADD_NODE_POST_REFRESH_RESERVE_MS: CUSTOM_WIDGET_REGISTRATION_TIMEOUT_MS,
     OBJECT_INFO_SEED_WAIT_MS,
     REFRESH_JOIN_ABANDONED,
+    // #1351 — the second sentinel, returned when the caller stopped waiting for its OWN
+    // run. Reached only when a harness's refresh stub resolves it; the real coalescer's
+    // behaviour is exercised in refresh-coalesce.test.mjs.
+    REFRESH_RUN_ABANDONED,
     widenSocketProofBudget,
     // A STUB, and labelled as one. These three harnesses are about #821/#1223/#620, none of
     // which reaches this branch. The shipped wording is pinned in single-node-def.test.mjs
     // and the behaviour that produces it is exercised in add-node-command-budget.test.mjs;
     // a hand-copied sentence here would just be a third place for it to drift.
     addNodeRefreshBusyMessage: (classType) =>
+      `HARNESS STUB refusal for "${classType}" — the shipped wording lives in the panel.`,
+    // #1351 — the own-run refusal, a stub for the same reason as the busy message above.
+    addNodeRefreshSlowMessage: (classType) =>
       `HARNESS STUB refusal for "${classType}" — the shipped wording lives in the panel.`,
   };
 }

--- a/browser_tests/unit/add-node-command-budget.test.mjs
+++ b/browser_tests/unit/add-node-command-budget.test.mjs
@@ -22,7 +22,7 @@ import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 
 import { withTimeout } from "../../web/js/lib/bounded-step.js";
-import { makeRefreshCoalescer, REFRESH_JOIN_ABANDONED } from "../../web/js/lib/refresh-coalesce.js";
+import { makeRefreshCoalescer, REFRESH_JOIN_ABANDONED, REFRESH_RUN_ABANDONED } from "../../web/js/lib/refresh-coalesce.js";
 import { makeCommandBudget } from "../../web/js/lib/command-budget.js";
 import {
   applyCurrentDefWidgetValues,
@@ -78,6 +78,16 @@ const addNodeRefreshBusyMessage = new Function(
   "ADD_NODE_COMMAND_BUDGET_MS",
   `${busyMatch[0]}
    return addNodeRefreshBusyMessage;`,
+)(25000);
+
+// #1351 — the own-run refusal, built from source for the same reason: the harness must not
+// be able to pass against a paraphrase of the wording the panel actually ships.
+const slowMatch = panelSrc.match(/const addNodeRefreshSlowMessage = [\s\S]*?;\r?\n/);
+assert.ok(slowMatch, "could not locate addNodeRefreshSlowMessage in panel source");
+const addNodeRefreshSlowMessage = new Function(
+  "ADD_NODE_COMMAND_BUDGET_MS",
+  `${slowMatch[0]}
+   return addNodeRefreshSlowMessage;`,
 )(25000);
 
 /** A tiny deferred so a test can hold the in-flight refresh open until it chooses. */
@@ -163,6 +173,13 @@ function realGraphAddNode({
   // null for "no refresh is in flight". Held open, it is the reported scenario: a ComfyUI
   // restart, whose reconnect refresh is still running when the add arrives.
   holdInFlight = null,
+  // #1351 — what the HELD (payload-less) run registers when it lands, or null for the live
+  // backend schema. A refresh whose fetch PREDATES the install registers a stale schema —
+  // which is exactly why the add still needs its own payload run after joining it (#289).
+  inFlightSchema = null,
+  // #1351 — how long the add's OWN run (the payload one, after the join) takes. The
+  // deliberately-unbounded local work, registerNodesFromDefs, modelled as a delay.
+  ownRunMs = 0,
   budgetMs = 400,
   reserveMs = 120,
   registrationMs = 200,
@@ -195,10 +212,16 @@ function realGraphAddNode({
       runs.push(defs);
       // The reconnect run — the one with no payload — is the one a test can hold open.
       if (defs == null && holdInFlight) await holdInFlight;
-      app.registerNodesFromDefs(defs ?? (await api.getNodeDefs()));
+      // #1351 — the caller's OWN (payload) run can be made slow: the unbounded local work
+      // that sat outside the join's bound.
+      if (defs != null && ownRunMs) await sleep(ownRunMs);
+      app.registerNodesFromDefs(defs ?? inFlightSchema ?? (await api.getNodeDefs()));
       return true;
     },
     withTimeout,
+    // #1351 — the same clock the panel wires, so the harness measures runMs exactly as the
+    // shipped coalescer does.
+    now: monotonicNow,
   });
   // A refresh someone else started — a websocket reconnect, a finished install — already
   // holding the slot when the add arrives.
@@ -237,7 +260,9 @@ function realGraphAddNode({
     withTimeout,
     makeCommandBudget,
     REFRESH_JOIN_ABANDONED,
+    REFRESH_RUN_ABANDONED,
     addNodeRefreshBusyMessage,
+    addNodeRefreshSlowMessage,
     clearInheritedExecutionPreview,
     OBJECT_INFO_SEED_WAIT_MS: 8000,
     ADD_NODE_COMMAND_BUDGET_MS: budgetMs,
@@ -341,6 +366,61 @@ test("#1192: the abandoned add does NOT start a competing registration run", asy
 
   gate.resolve();
   await built.inFlightStarted?.catch(() => {});
+});
+
+// ---------------------------------------------------------------------------
+// 1b. #1351 — the join was bounded; the caller's OWN run was not.
+// ---------------------------------------------------------------------------
+
+test("#1351: a join that lands leaves the add's OWN run only what is left — and the refusal says so", async () => {
+  // The residual this issue is about, driven end to end: the in-flight run settles JUST
+  // inside the join's bound (the budget is respected at the join), and then the caller's
+  // own run — the deliberately-unbounded registerNodesFromDefs local work — outlives what
+  // little of runMs remains. Before this fix the add waited that run out: join (~260ms
+  // here) PLUS the full own run (~200ms), a sum no bound on this path reached.
+  const comfy = makeComfy();
+  const built = realGraphAddNode({
+    comfy,
+    // budget 400ms, reserve 120ms ⇒ joinMs = runMs ≈ 280ms. The join lands at 260ms,
+    // leaving the add's own run ~20ms against a 200ms registration. The in-flight run
+    // registers a STALE schema (its fetch predates the install), so the add still needs
+    // its own payload run after the join — the #289 shape.
+    holdInFlight: sleep(260),
+    inFlightSchema: { ExistingNode: backendObjectInfo().ExistingNode },
+    ownRunMs: 200,
+    budgetMs: 400,
+    reserveMs: 120,
+  });
+
+  const started = Date.now();
+  await assert.rejects(
+    () => built.graph_add_node({ class_type: "NewNode" }),
+    (err) => {
+      // The SHIPPED own-run wording, not the busy one and not the resolver's "reload the
+      // tab": the cause is different (nothing ELSE was running), and the payload was not
+      // dropped.
+      assert.equal(err.message, addNodeRefreshSlowMessage("NewNode"));
+      return true;
+    },
+    "an add whose own run outlived the budget must refuse, in words",
+  );
+  const elapsed = Date.now() - started;
+  assert.ok(
+    elapsed < 400,
+    `refused in ${elapsed}ms — inside the command budget, not after join + the whole own run`,
+  );
+  assert.equal(comfy.graph._nodes.length, 0, "the graph was not touched");
+
+  // The OWN RUN WAS NOT DROPPED, unlike the abandoned join's payload: it started when the
+  // join settled (the slot was free — no stampede), and it is registering the very class
+  // the add asked for, which is what makes the refusal's "retry" the normal outcome.
+  assert.equal(built.runs.length, 2, "the add's own run started");
+  await built.inFlightStarted?.catch(() => {});
+  await sleep(300); // let the abandoned run finish
+  assert.ok(
+    comfy.LG.registered_node_types.NewNode,
+    "the abandoned run still registered the class — the retry succeeds",
+  );
 });
 
 // ---------------------------------------------------------------------------

--- a/browser_tests/unit/add-node-schema-auto-refresh.test.mjs
+++ b/browser_tests/unit/add-node-schema-auto-refresh.test.mjs
@@ -288,9 +288,15 @@ test("#1242: the reporter's add succeeds in one call — the panel refreshes fir
     Number.isFinite(refreshCalls[0].opts.joinMs) && refreshCalls[0].opts.joinMs > 0,
     "the drift recovery's wait must be bounded by what the command has left",
   );
+  // #1351 — and the run the recovery STARTS (the coalescer's leading edge, where joinMs
+  // has nothing to bound) is bounded by the same remaining budget.
+  assert.ok(
+    Number.isFinite(refreshCalls[0].opts.runMs) && refreshCalls[0].opts.runMs > 0,
+    "the drift recovery's OWN run must be bounded too — the term #1351 is about",
+  );
   assert.deepEqual(
     Object.keys(refreshCalls[0].opts).sort(),
-    ["force", "joinMs"],
+    ["force", "joinMs", "runMs"],
     "…and nothing else is passed",
   );
 });

--- a/browser_tests/unit/add-node-schema-drift-recovery.test.mjs
+++ b/browser_tests/unit/add-node-schema-drift-recovery.test.mjs
@@ -108,8 +108,10 @@ test("#1242: the add runs the refresh itself, then re-checks, BEFORE the refusal
   // rather than one spelling of it. STRONGER than the literal it replaces: it pins that the
   // drift recovery is forced AND that its wait draws from the command budget, which is the
   // property #1192 needs and the literal could not express.
+  // #1351 — and its OWN run is bounded too (`runMs`), the term joinMs never reached; the
+  // shape now spans both options.
   const forced = between.match(
-    /refreshComfyNodeDefs\(undefined, \{\s*force: true,\s*joinMs: budget\.remaining\(\) - ADD_NODE_POST_REFRESH_RESERVE_MS,\s*\}\)/,
+    /refreshComfyNodeDefs\(undefined, \{\s*force: true,\s*joinMs: budget\.remaining\(\) - ADD_NODE_POST_REFRESH_RESERVE_MS,\s*runMs: budget\.remaining\(\) - ADD_NODE_POST_REFRESH_RESERVE_MS,\s*\}\)/,
   );
   assert.ok(
     forced,

--- a/browser_tests/unit/refresh-coalesce.test.mjs
+++ b/browser_tests/unit/refresh-coalesce.test.mjs
@@ -4,7 +4,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { makeRefreshCoalescer, REFRESH_JOIN_ABANDONED } from "../../web/js/lib/refresh-coalesce.js";
+import { makeRefreshCoalescer, REFRESH_JOIN_ABANDONED, REFRESH_RUN_ABANDONED } from "../../web/js/lib/refresh-coalesce.js";
 // #1192 — the REAL bounding primitive, so `opts.joinMs` is exercised rather than stubbed.
 import { withTimeout } from "../../web/js/lib/bounded-step.js";
 
@@ -413,4 +413,197 @@ test("#1192: a bounded FORCED join that lands still forwards the trailing run's 
   gate.resolve();
   await inflight;
   assert.equal(await forced, true, "the trailing run's own verdict, not a stand-in");
+});
+
+// ── #1351: the caller's OWN run is a wait too, and runMs bounds it ──────────
+//
+// #1192 bounded the JOIN — the wait on a run someone else started. A join that SUCCEEDS is
+// where the unbounded term began: the caller's own run then costs the run budget's bounded
+// waiting PLUS the deliberately-unbounded registerNodesFromDefs local work, and the two
+// summed past the 30,000 ms relay window. `opts.runMs` bounds the wait on the caller's own
+// run, measured from the CALL so the join's cost is subtracted from it rather than added.
+
+test("#1351: an own run that outlives runMs is ABANDONED — but the run is NOT dropped", async () => {
+  // The shape the issue measured: the join succeeded, the caller's own run is the slow one.
+  // The caller must stop waiting AND the payload must still be registered — the slot is
+  // free once the join settles, so starting the run stampedes nothing, and the caller's
+  // retry is meant to find the class registered.
+  const { coalescer, registered, getInFlight } = makeHarness(
+    () => new Promise((r) => setTimeout(r, 200)), // the caller's own run is slow
+  );
+  const NEW_DEFS = { NewNode: {} };
+  const started = Date.now();
+
+  const outcome = await coalescer(NEW_DEFS, { runMs: 25 });
+
+  assert.equal(outcome, REFRESH_RUN_ABANDONED, "the caller stopped waiting and said so");
+  assert.ok(Date.now() - started < 1000, "…at the bound, not when the run eventually finishes");
+  assert.ok(getInFlight(), "the run is STILL IN THE SLOT — the payload was not dropped");
+
+  // The run completes in the background and registers the payload for the retry.
+  await new Promise((r) => setTimeout(r, 300));
+  assert.deepEqual(registered, [NEW_DEFS], "the abandoned run still registered the payload");
+  assert.equal(getInFlight(), null, "…and cleared the slot when it settled");
+});
+
+test("#1351: an own run that lands INSIDE runMs resolves to the run's own value", async () => {
+  // The bound must not become a way to lose verdicts on a healthy machine: a run that
+  // finishes in time resolves exactly as the unbounded path does.
+  const { coalescer } = makeHarnessReturning(() => true);
+  const NEW_DEFS = { NewNode: {} };
+  assert.equal(await coalescer(NEW_DEFS, { runMs: 5000 }), true, "the run's verdict, not a stand-in");
+});
+
+test("#1351: the JOIN's cost is SUBTRACTED from runMs — the two cannot sum to twice it", async () => {
+  // The composition the issue is about: joinMs and runMs handed the same remaining budget
+  // must not add up. Here the join takes ~60ms of a 100ms runMs, so the caller's own run
+  // gets only what is left (~40ms) and is abandoned — a runMs measured from the run's
+  // start would have let it wait the full 100ms on top.
+  const gate = deferred();
+  const { coalescer, registered } = makeHarness(async (defs) => {
+    if (defs == null) {
+      // The in-flight run someone else started: settles after ~60ms.
+      await new Promise((r) => setTimeout(r, 60));
+      return;
+    }
+    await gate.promise; // the caller's own run never lands within the test
+  });
+
+  const older = coalescer(); // in flight for ~60ms
+  const NEW_DEFS = { NewNode: {} };
+  const started = Date.now();
+  const outcome = await coalescer(NEW_DEFS, { joinMs: 5000, runMs: 100 });
+
+  assert.equal(outcome, REFRESH_RUN_ABANDONED, "the leftover after the join was not enough for the run");
+  const waited = Date.now() - started;
+  assert.ok(waited < 150, `total wait (${waited}ms) tracked runMs from the CALL, not joinMs + runMs`);
+  assert.ok(waited >= 55, "…and the join really did consume most of it first");
+
+  gate.resolve();
+  await older;
+  await new Promise((r) => setTimeout(r, 20));
+  assert.ok(registered.includes(NEW_DEFS), "the payload still registered once the run settled");
+});
+
+test("#1351: a runMs of 0 or less starts the run but does not WAIT for it", async () => {
+  // graph_add_node computes runMs by subtraction and can legitimately reach a negative.
+  // `withTimeout` reads a non-positive ms as NO BOUND, so a spent budget expressed
+  // literally would restore the unbounded wait at exactly the moment it ran out — the
+  // #1188 trap, arriving through the run this time. The run still STARTS: the slot is
+  // free and the payload must not be dropped; only the wait is abandoned.
+  const { coalescer, registered } = makeHarness(() => new Promise((r) => setTimeout(r, 50)));
+
+  for (const runMs of [0, -1, -20000]) {
+    assert.equal(
+      await coalescer({ [`N${runMs}`]: {} }, { runMs }),
+      REFRESH_RUN_ABANDONED,
+      `runMs=${runMs} must abandon the wait at once, not wait forever`,
+    );
+    // Let this run settle before the next call, so each iteration meets the LEADING edge
+    // rather than joining the previous still-running one.
+    await new Promise((r) => setTimeout(r, 80));
+  }
+  assert.equal(registered.length, 3, "…and every one of those runs still started");
+});
+
+test("#1351: an own run that REJECTS inside runMs still rejects for its caller", async () => {
+  // A bound on the WAIT must not quietly turn a failed run into a success — only the
+  // abandonment is new. The run's rejection has always propagated (`return startRun(...)`
+  // did), and it still does.
+  const { coalescer } = makeHarness(async () => {
+    throw new Error("registerNodesFromDefs blew up");
+  });
+  await assert.rejects(coalescer({ A: {} }, { runMs: 5000 }), /blew up/);
+});
+
+test("#1351: an abandoned own run that LATER rejects does not go unhandled", async () => {
+  // The caller has stopped listening by the time this run fails. Without the coalescer's
+  // own catch that failure would be an unhandled rejection — which the node test runner
+  // turns into a failure of THIS test, so a green run here is the assertion.
+  let fail;
+  const { coalescer } = makeHarness(
+    () =>
+      new Promise((_, reject) => {
+        fail = reject;
+      }),
+  );
+  assert.equal(await coalescer({ A: {} }, { runMs: 25 }), REFRESH_RUN_ABANDONED);
+  fail(new Error("the abandoned run failed after the caller left"));
+  await new Promise((r) => setTimeout(r, 50));
+});
+
+test("#1351: a run that outlives runMs while a JOIN was abandoned never starts (stampede rule intact)", async () => {
+  // runMs also caps the JOIN (it bounds the call's TOTAL waiting). When the join is what
+  // runs out, the answer is still REFRESH_JOIN_ABANDONED and still NO run is started —
+  // the in-flight run holds the slot, and starting a second registerNodesFromDefs next to
+  // it is the stampede this coordinator exists to prevent.
+  const gate = deferred();
+  const { coalescer, registered } = makeHarness(async (defs) => {
+    if (defs == null) await gate.promise;
+  });
+
+  const older = coalescer(); // holds the slot, gated open
+  const outcome = await coalescer({ NewNode: {} }, { runMs: 25 }); // no joinMs — runMs alone caps the join
+
+  assert.equal(outcome, REFRESH_JOIN_ABANDONED, "a total bound spent on the join is a join abandonment");
+  assert.deepEqual(registered, [undefined], "no competing run was started");
+
+  gate.resolve();
+  await older;
+});
+
+test("#1351: a coalescer with NO withTimeout wired ignores runMs, exactly as it does joinMs", async () => {
+  // The safe direction for a wiring mistake to fail in: an unwired panel keeps today's
+  // unbounded wait rather than abandoning every run at once.
+  const gate = deferred();
+  const { coalescer, registered } = makeHarness(
+    async () => {
+      await gate.promise;
+    },
+    { wireTimeout: false },
+  );
+
+  const pending = coalescer({ A: {} }, { runMs: 10 });
+  await new Promise((r) => setTimeout(r, 60));
+  assert.ok(registered.length === 1, "the run started…");
+
+  gate.resolve();
+  assert.notEqual(await pending, REFRESH_RUN_ABANDONED, "…and the wait was unbounded, as before");
+});
+
+test("#1351: a non-finite runMs is treated as NO bound, never as an armed one", async () => {
+  // Same guard as joinMs: a caller computing runMs from an unset budget can produce
+  // Infinity or NaN, and both must not silently arm (or silently fire) the bound.
+  const gate = deferred();
+  const { coalescer } = makeHarness(async () => {
+    await gate.promise;
+  });
+
+  const pending = [
+    coalescer({ A: {} }, { runMs: Number.POSITIVE_INFINITY }),
+    coalescer({ B: {} }, { runMs: Number.NaN }),
+  ];
+  await new Promise((r) => setTimeout(r, 40));
+
+  gate.resolve();
+  for (const p of pending) assert.notEqual(await p, REFRESH_RUN_ABANDONED);
+});
+
+test("#1351: a bounded FORCED caller on the LEADING edge stops waiting for its own run too", async () => {
+  // The #1242 drift recovery calls force:true with NO refresh necessarily in flight, so it
+  // lands here — the leading edge — where joinMs has nothing to bound. runMs is the bound
+  // that reaches it, and the forced run still happens for everyone else.
+  const gate = deferred();
+  const { coalescer, registered } = makeHarness(async () => {
+    await gate.promise;
+  });
+
+  const started = Date.now();
+  const outcome = await coalescer(undefined, { force: true, runMs: 25 });
+  assert.equal(outcome, REFRESH_RUN_ABANDONED, "the forced caller's wait on its own run is bounded");
+  assert.ok(Date.now() - started < 1000, "…at the bound");
+  assert.equal(registered.length, 1, "the forced run still started — only the wait ended");
+
+  gate.resolve();
+  await new Promise((r) => setTimeout(r, 20));
 });

--- a/browser_tests/unit/single-node-def.test.mjs
+++ b/browser_tests/unit/single-node-def.test.mjs
@@ -583,11 +583,23 @@ test("#1192: graph_add_node's serialized bounds FIT the command budget", () => {
     ],
     [/await boundedGetNodeDefs\(budget\.bounded\(NODE_DEFS_FETCH_TIMEOUT_MS\)\)/, "the whole-schema fetch"],
     [/joinMs: budget\.remaining\(\) - ADD_NODE_POST_REFRESH_RESERVE_MS/, "the coalescer join"],
+    // #1351 — …and the caller's OWN run, the term the join bound never reached. Both
+    // refresh call sites (the resolver's and the #1242 drift recovery's) must carry it:
+    // runMs is measured from the call inside the coalescer, so handing it the same
+    // remaining budget as joinMs bounds the TOTAL wait rather than doubling it.
+    [/runMs: budget\.remaining\(\) - ADD_NODE_POST_REFRESH_RESERVE_MS/, "the coalescer's own-run wait"],
     [/budget\.bounded\(CUSTOM_WIDGET_REGISTRATION_TIMEOUT_MS\)/, "the custom-widget registration wait"],
   ];
   for (const [re, what] of wired) {
     assert.match(body, re, `${what} must draw its bound from the command budget`);
   }
+  // Both refresh call sites, not one: a site pinned by a single match would silently
+  // satisfy the assertion above while the other waited unbounded.
+  assert.equal(
+    (body.match(/runMs: budget\.remaining\(\) - ADD_NODE_POST_REFRESH_RESERVE_MS/g) ?? []).length,
+    2,
+    "runMs must be wired at BOTH refresh call sites (the resolver's and the drift recovery's)",
+  );
 
   // …and NO step may still name one of those constants raw. This is what catches a bound
   // added to this path LATER: the failure mode is not that an existing site regresses, it is
@@ -621,6 +633,9 @@ test("#1192: graph_add_node's serialized bounds FIT the command budget", () => {
   assert.ok(wiredAt > 0, "the panel's coalescer construction must be findable");
   const coalescer = src.slice(wiredAt, src.indexOf("});", wiredAt));
   assert.match(coalescer, /\n\s*withTimeout,/, "the panel's coalescer must be wired with the bounding primitive");
+  // #1351 — and with the monotonic clock runMs is measured on. Same failure shape as the
+  // withTimeout wiring: an omission here degrades the bound silently, so it is pinned.
+  assert.match(coalescer, /\n\s*now: monotonicNow,/, "the panel's coalescer must be wired with the monotonic clock");
 });
 
 test("#1192: an add that gave up waiting for someone else's refresh says so, and says retry", () => {
@@ -664,6 +679,56 @@ test("#1192: an add that gave up waiting for someone else's refresh says so, and
   assert.ok(msg, "the busy refusal's wording must be findable");
   assert.match(msg, /NOTHING WAS ADDED/, "the refusal must say the graph was not touched");
   assert.match(msg, /RETRY/, "…and that a retry is the remedy, because the in-flight run is registering these defs");
+  assert.ok(
+    !/reload/i.test(msg),
+    "…and must NOT send the user to reload the tab, which throws away canvas state for a refresh that is working",
+  );
+});
+
+test("#1351: an add that gave up waiting for its OWN refresh run says so, and says retry", () => {
+  // The mirror of the #1192 pins above, for the bound that issue never reached: a bounded
+  // join that SUCCEEDS is followed by the caller's own run, whose deliberately-unbounded
+  // local work summed with the join past the relay window. The abandoned own run is the
+  // friendlier case — the payload was NOT dropped, it is registering in the coalescer's
+  // slot — so it gets its own flag and its own wording, and both are pinned here.
+  const src = readFileSync(PANEL_JS, "utf8");
+  const at = src.indexOf("  async graph_add_node({ class_type, pos, title }) {");
+  const body = src.slice(at, src.indexOf("\n  async graph_", at + 10));
+
+  assert.match(
+    body,
+    /if \(outcome === REFRESH_RUN_ABANDONED\) refreshRunAbandoned = true;/,
+    "the abandoned own run must be recorded as a flag, not inferred from an error string",
+  );
+  assert.match(
+    body,
+    /if \(refreshRunAbandoned && !isRegisteredNodeType\(LG\?\.registered_node_types \?\? \{\}, class_type\)\)/,
+    "…and re-worded only when the class is ALSO still unregistered — the add's own run may have landed",
+  );
+  assert.ok(
+    !/refreshRunAbandoned[\s\S]{0,300}?err\?*\.message/.test(body),
+    "the budget refusal must never be decided by reading the resolver's message",
+  );
+  // The #1242 drift recovery meets the sentinel on the coalescer's LEADING edge (no run in
+  // flight), where joinMs has nothing to bound — it must name that outcome too, not fall
+  // through to the generic branch's "unknown".
+  assert.match(
+    body,
+    /verdict === REFRESH_RUN_ABANDONED/,
+    "the drift-recovery refresh must name an abandoned own run, not report it as 'unknown'",
+  );
+
+  // The wording itself: same rules as the busy message — nothing was added, retry is the
+  // remedy, and never "reload the tab". Anchored with `\r?\n` for the CRLF reason above.
+  const msg = (src.match(/const addNodeRefreshSlowMessage =[\s\S]*?;\r?\n/) || [])[0];
+  assert.ok(msg, "the own-run refusal's wording must be findable");
+  assert.match(msg, /NOTHING WAS ADDED/, "the refusal must say the graph was not touched");
+  assert.match(msg, /RETRY/, "…and that a retry is the remedy, because the run is registering these defs");
+  assert.match(
+    msg,
+    /still running/,
+    "…and must say the refresh is STILL RUNNING — the payload was not dropped, unlike the join case",
+  );
   assert.ok(
     !/reload/i.test(msg),
     "…and must NOT send the user to reload the tab, which throws away canvas state for a refresh that is working",

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -241,7 +241,7 @@ import { buildPanelFailureShell } from "./lib/panel-failure-shell.js";
 import { installSidebarRenderWatchdog } from "./lib/sidebar-render-watchdog.js";
 import { displayLabel, boundaryInputLabel, widgetLabelMap } from "./lib/slot-labels.js";
 import { createObjectInfoHistory, awaitHistoryBaseline } from "./lib/object-info-history.js";
-import { makeRefreshCoalescer, REFRESH_JOIN_ABANDONED } from "./lib/refresh-coalesce.js";
+import { makeRefreshCoalescer, REFRESH_JOIN_ABANDONED, REFRESH_RUN_ABANDONED } from "./lib/refresh-coalesce.js";
 import {
   describeNodeDefRefresh,
   describeRefreshGraphLoss,
@@ -1859,6 +1859,10 @@ const refreshComfyNodeDefs = makeRefreshCoalescer({
   // Safe is not the same as noticed, though: dropping it silently restores #1192, so the
   // CALL SITE is pinned by a test, not just the helper's behaviour.
   withTimeout,
+  // #1351 — the monotonic clock `opts.runMs` is measured on (the join's cost is subtracted
+  // from the run's allowance, so the two cannot sum to twice the caller's budget). Same
+  // wiring rule as withTimeout: omitting it degrades silently, so the test pins this too.
+  now: monotonicNow,
 });
 
 // #396: download ids already counted as done, so each COMPLETED model download
@@ -10365,6 +10369,25 @@ const addNodeRefreshBusyMessage = (classType) =>
   "happening, call panel_refresh_nodes once and wait for it to report, then retry the add.";
 
 /**
+ * #1351 — the refusal for an add whose budget went on the refresh THIS add started.
+ *
+ * Different cause from `addNodeRefreshBusyMessage`, and the wording must say so: nothing
+ * ELSE was running — this command's own run outlived what was left of its budget (the
+ * join ahead of it had already spent most of the window). The payload was NOT dropped:
+ * the run is in the coalescer's slot registering it now, so the retry is again the normal
+ * outcome rather than a hope. No "reload the tab" here either, for the same reason #1192
+ * gives: the refresh did not fail, and a reload throws away canvas state for nothing.
+ */
+const addNodeRefreshSlowMessage = (classType) =>
+  `Cannot add "${classType}" right now: this command started a node-def refresh to register ` +
+  "the class, and that refresh did not finish within what was left of this command's " +
+  `${Math.round(ADD_NODE_COMMAND_BUDGET_MS / 1000)}s budget. NOTHING WAS ADDED and nothing was ` +
+  "changed. The refresh is still running in the background and is registering exactly the " +
+  "definitions this add needs, so RETRY in a few seconds — this normally succeeds on the " +
+  "next attempt. If it keeps happening, call panel_refresh_nodes once and wait for it to " +
+  "report, then retry the add.";
+
+/**
  * #1180 — the widen runs INSIDE the registration wait above, so its bound has to fit
  * there. The generic 10s node-defs bound is TWICE this function's whole 5s deadline: a
  * timed-out widen would consume the entire wait and leave the poll loop nothing, so the
@@ -12191,6 +12214,12 @@ const GRAPH_TOOL_EXECUTORS = {
     // reason never reaches the resolver's own wording, and matching on that wording to
     // recover it would be exactly the prose-parsing this repo refuses to authorize on.
     let refreshJoinAbandoned = false;
+    // #1351 — the run THIS add started is a wait too, and the one `refreshJoinAbandoned`
+    // never saw: a bounded join that SUCCEEDS is followed by the caller's own run, whose
+    // deliberately-unbounded local work (registerNodesFromDefs) sat outside every bound on
+    // this path. Set when this add stopped waiting for its own run; the run is still in
+    // the coalescer's slot registering this add's payload, which the retry then finds.
+    let refreshRunAbandoned = false;
     // A thunk rather than a bare `await`, so the call below can sit inside a try/catch
     // without re-indenting seventy lines of load-bearing comments in this file.
     const resolveAddNode = () =>
@@ -12276,11 +12305,20 @@ const GRAPH_TOOL_EXECUTORS = {
       // it a join finishing at the wire leaves the widget-registration wait milliseconds,
       // and the add then refuses by naming a widget that was never given time to appear —
       // a true statement about the wrong cause.
+      //
+      // #1351 — and the run that FOLLOWS a successful join is bounded by the same
+      // allowance, not by a second one. `runMs` is measured from this call's start inside
+      // the coalescer, so a join that lands at its bound leaves the run nothing and the
+      // two cannot sum to twice what is left. An abandoned OWN run is the friendlier case:
+      // the payload was not dropped — it is registering in the background right now — so
+      // the refusal below (`addNodeRefreshSlowMessage`) can say the retry finds it done.
       refresh: (defs) =>
         refreshComfyNodeDefs(defs, {
           joinMs: budget.remaining() - ADD_NODE_POST_REFRESH_RESERVE_MS,
+          runMs: budget.remaining() - ADD_NODE_POST_REFRESH_RESERVE_MS,
         }).then((outcome) => {
           if (outcome === REFRESH_JOIN_ABANDONED) refreshJoinAbandoned = true;
+          if (outcome === REFRESH_RUN_ABANDONED) refreshRunAbandoned = true;
           return outcome;
         }),
       // #458 OBSERVED-BACKEND-HISTORY trust root, identical to graph_set_widget's.
@@ -12306,6 +12344,13 @@ const GRAPH_TOOL_EXECUTORS = {
       // the resolver returned successfully and this branch is not reached at all.
       if (refreshJoinAbandoned && !isRegisteredNodeType(LG?.registered_node_types ?? {}, class_type)) {
         throw new Error(addNodeRefreshBusyMessage(class_type));
+      }
+      // #1351 — the same recovery for the run THIS add started. Kept a separate flag and a
+      // separate message because the cause is different: nothing else was running — this
+      // add's own refresh outlived the budget — and the payload is registering now, not
+      // dropped. Same registry re-check: the run may have landed while we gave up.
+      if (refreshRunAbandoned && !isRegisteredNodeType(LG?.registered_node_types ?? {}, class_type)) {
+        throw new Error(addNodeRefreshSlowMessage(class_type));
       }
       throw err;
     }
@@ -12367,9 +12412,15 @@ const GRAPH_TOOL_EXECUTORS = {
         //
         // Same allowance as the resolver's join, and the same reserve held back, so a
         // drift recovery cannot eat the window the widget-registration wait still needs.
+        //
+        // #1351 — `runMs` covers the case the join never sees: NO run in flight, so the
+        // forced call is the coalescer's LEADING edge and starts its own run at once. That
+        // run's deliberately-unbounded local work sat outside the command budget exactly
+        // as it did on the resolver's path above.
         const verdict = await refreshComfyNodeDefs(undefined, {
           force: true,
           joinMs: budget.remaining() - ADD_NODE_POST_REFRESH_RESERVE_MS,
+          runMs: budget.remaining() - ADD_NODE_POST_REFRESH_RESERVE_MS,
         });
         if (verdict === REFRESH_JOIN_ABANDONED) {
           // A NAMED reason, not the "unknown" the generic branch below produces for a
@@ -12381,6 +12432,13 @@ const GRAPH_TOOL_EXECUTORS = {
           schemaRefreshIncompleteReason =
             "a node-def refresh started by something else was still running, and this " +
             "command's time budget ran out waiting for it — nothing failed, so retry";
+        } else if (verdict === REFRESH_RUN_ABANDONED) {
+          // #1351 — the leading-edge case: this command's OWN forced run is the one still
+          // running. Same rule as the join case — name it, say nothing failed, say retry.
+          schemaRefreshIncompleteReason =
+            "the node-def refresh this command started did not finish within this " +
+            "command's time budget — it is still running and still registering the " +
+            "schema this add wants, so retry";
         } else if (
           !(verdict === true || (verdict != null && typeof verdict === "object" && verdict.refreshed === true))
         ) {

--- a/web/js/lib/refresh-coalesce.js
+++ b/web/js/lib/refresh-coalesce.js
@@ -42,6 +42,31 @@
 // as a regression of #289 P2 until the caller's half is read with it: `graph_add_node` does
 // not proceed on that value, it REFUSES IN WORDS and says to retry. Dropping a payload
 // while refusing is safe; dropping one while claiming success is the bug #289 was about.
+//
+// #1351 — AND THE CALLER'S OWN RUN IS A WAIT TOO, which `joinMs` never reached.
+//
+// A bounded join that SUCCEEDS is where the unbounded term begins: the caller's own run
+// then costs the run budget's 9,000 ms of bounded waiting PLUS the deliberately-unbounded
+// local work (`registerNodesFromDefs`, 3,972 ms measured on this rig and worse on bigger
+// installs). Measured against the add path: a join ending at its 20,000 ms bound followed
+// by a ~13,000 ms own run is ~33,000 ms against the 30,000 ms relay window — the budget
+// respected at every step, the command still outliving the window. `joinMs` cannot help:
+// it bounds a wait on a run someone else started, and this run is the caller's own.
+//
+// So `opts.runMs` bounds the caller's wait on the run IT started — and it is measured from
+// the CALL, not from the run's start, because the two waits are the same term in the
+// caller's budget: the join's cost is subtracted, so `joinMs` and `runMs` handed the same
+// remaining budget cannot sum to twice it. A `runMs` also caps the join itself, making it
+// a true bound on this call's TOTAL waiting rather than a second, additive allowance.
+//
+// WHAT AN ABANDONED OWN-RUN MUST NOT DO is drop the payload — the mirror of the join rule.
+// The join already SETTLED, so the slot is free and starting the run stampedes nothing; the
+// run continues in the slot, registers the payload, and the caller's retry finds the class
+// registered. Only the WAIT ends, with `REFRESH_RUN_ABANDONED` — a second sentinel, because
+// the two demand different wording: a join-abandoned add dropped its payload (someone
+// else's refresh is still running), a run-abandoned one did not (its OWN refresh is still
+// running). The run's outcome still reaches whoever waits on the slot next; this caller
+// alone stops listening, and its refusal says to retry.
 
 /**
  * Returned when the caller stopped WAITING for a refresh someone else started.
@@ -51,6 +76,24 @@
  * defs you wanted are registered", the other means "nobody registered anything for you".
  */
 export const REFRESH_JOIN_ABANDONED = Symbol("refresh-join-abandoned");
+
+/**
+ * Returned when the caller stopped WAITING for the run IT started (#1351).
+ *
+ * A distinct value from `REFRESH_JOIN_ABANDONED`, because the two are opposite facts about
+ * the payload: a join-abandoned call DROPPED it (the slot was still occupied, so starting a
+ * run would stampede), while a run-abandoned call's run is IN THE SLOT and registering it
+ * right now. Both refusals say "retry", but only the second can say the registration this
+ * caller needed is already under way.
+ */
+export const REFRESH_RUN_ABANDONED = Symbol("refresh-run-abandoned");
+
+/** The platform's monotonic clock, used when no readable one is injected. */
+function defaultNow() {
+  return typeof performance !== "undefined" && typeof performance.now === "function"
+    ? performance.now()
+    : Date.now();
+}
 
 /**
  * Wait for `current` to SETTLE (either way), for at most `joinMs`.
@@ -93,10 +136,27 @@ async function joinBounded(current, joinMs, withTimeout) {
 //   withTimeout                : the repo's ONE bounding primitive (bounded-step.js),
 //                                injected rather than imported so this module stays a
 //                                pure coordinator and a test can drive the clock. Omit it
-//                                and `opts.joinMs` has nothing to bound with — so an
-//                                unwired coalescer waits unbounded, exactly as it always
-//                                did, rather than silently abandoning every join.
-export function makeRefreshCoalescer({ getInFlight, setInFlight, runRegister, withTimeout }) {
+//                                and `opts.joinMs`/`opts.runMs` have nothing to bound
+//                                with — so an unwired coalescer waits unbounded, exactly
+//                                as it always did, rather than silently abandoning every
+//                                join.
+//   now                        : monotonic clock, injected for the same reason (the panel
+//                                passes its own `monotonicNow`). Read only when a caller
+//                                passed `opts.runMs`: subtracting the join's cost from the
+//                                run's allowance is what keeps the two from adding up.
+export function makeRefreshCoalescer({ getInFlight, setInFlight, runRegister, withTimeout, now }) {
+  // A `now` that is not callable, throws, or answers garbage is one that was not supplied:
+  // the platform clock is used, which is the same answer as the default and always safe —
+  // the same guard command-budget.js gives its own injected clock, for the same reason.
+  const clock = typeof now === "function" ? now : defaultNow;
+  const readNow = () => {
+    try {
+      const t = clock();
+      return Number.isFinite(t) ? t : defaultNow();
+    } catch {
+      return defaultNow();
+    }
+  };
   // The single queued trailing (forced, no-payload) run, or null when none is
   // pending. Coalesces any number of forced calls arriving during one in-flight run.
   let trailing = null;
@@ -123,11 +183,57 @@ export function makeRefreshCoalescer({ getInFlight, setInFlight, runRegister, wi
       opts && Number.isFinite(opts.joinMs) && typeof withTimeout === "function"
         ? opts.joinMs
         : null;
+    // #1351 — the same bound for the wait on the caller's OWN run, gated the same way and
+    // rejected for the same non-finite values. Measured from THIS CALL's start, so the
+    // join's cost is already spent from it: a caller that hands both options the same
+    // remaining budget has bounded its total wait by that budget, not by twice it.
+    const runMs =
+      opts && Number.isFinite(opts.runMs) && typeof withTimeout === "function"
+        ? opts.runMs
+        : null;
+    const callStartedAt = runMs === null ? 0 : readNow();
+    // What is left of runMs for the wait about to start. MAY BE NON-POSITIVE — the readers
+    // below treat that as "abandon without awaiting", never as "no bound", because
+    // `withTimeout` reads ms <= 0 as NO BOUND and a spent budget expressed literally would
+    // restore the unbounded wait at exactly the moment it ran out (#1188's trap).
+    const runLeft = () => (runMs === null ? null : runMs - (readNow() - callStartedAt));
+    // The join draws from runMs too when one was set: runMs is a bound on this call's
+    // TOTAL waiting, and the join is the first wait this call performs.
+    const joinBound =
+      joinMs === null ? runMs : runMs === null ? joinMs : Math.min(joinMs, runMs);
+    // Await the caller's OWN run, bounded when runMs was given. The run is started FIRST
+    // and always — the slot is free by the time this is reached, the payload must not be
+    // dropped (#289 P2), and a leading-edge forced run is a guarantee made to every
+    // waiter, not just this caller. Only the WAIT is bounded: on abandon the run keeps
+    // going in the slot, and REFRESH_RUN_ABANDONED tells the caller so.
+    const awaitOwnRun = (p) => {
+      if (runMs === null) return p;
+      // The run's promise must not go unhandled when this caller stops waiting on it: an
+      // abandoned wait is not a reason to turn the run's later failure into an unhandled
+      // rejection (the forced branch gives `queued` the same guard, for the same reason).
+      p.catch(() => {});
+      const left = runLeft();
+      if (!(left > 0)) return REFRESH_RUN_ABANDONED;
+      return withTimeout(
+        p.then(
+          (value) => ({ value }),
+          (err) => ({ err }),
+        ),
+        left,
+        () => null,
+      ).then((settled) => {
+        if (settled === null) return REFRESH_RUN_ABANDONED;
+        // A run that REJECTS has always rejected for its caller, and a bound on the wait
+        // must not quietly turn that into a success — only the abandonment is new.
+        if ("err" in settled) throw settled.err;
+        return settled.value;
+      });
+    };
     const current = getInFlight();
     if (current) {
       // No payload, not forced ⇒ joining the settled refresh is enough.
       if (preloadedDefs == null && !force) {
-        if (!(await joinBounded(current, joinMs, withTimeout))) return REFRESH_JOIN_ABANDONED;
+        if (!(await joinBounded(current, joinBound, withTimeout))) return REFRESH_JOIN_ABANDONED;
         return;
       }
       // Payload present ⇒ wait for the in-flight run, then register the NEWER
@@ -136,8 +242,10 @@ export function makeRefreshCoalescer({ getInFlight, setInFlight, runRegister, wi
         // #1192 — and if the wait is abandoned, the payload IS dropped. Starting our own
         // run here would put a second `registerNodesFromDefs` alongside one still going,
         // which is the stampede this coordinator exists to prevent. The caller refuses.
-        if (!(await joinBounded(current, joinMs, withTimeout))) return REFRESH_JOIN_ABANDONED;
-        return startRun(preloadedDefs);
+        if (!(await joinBounded(current, joinBound, withTimeout))) return REFRESH_JOIN_ABANDONED;
+        // #1351 — the join settled, so the slot is free: the run starts (the payload is
+        // never dropped), but the caller's WAIT on it is bounded by what runMs has left.
+        return awaitOwnRun(startRun(preloadedDefs));
       }
       // Forced, no payload ⇒ guarantee a fresh fetch AFTER the current run
       // settles; coalesce concurrent forced calls into ONE trailing run (#396).
@@ -158,19 +266,19 @@ export function makeRefreshCoalescer({ getInFlight, setInFlight, runRegister, wi
         })();
       }
       const queued = trailing;
-      if (joinMs === null) return queued;
+      if (joinBound === null) return queued;
       // The trailing promise must not go unhandled when this caller stops waiting on it:
       // #396 guarantees the run to other waiters, and an abandoned wait is not a reason to
       // turn its failure into an unhandled rejection.
       queued.catch(() => {});
       // A budget already spent abandons WITHOUT awaiting — see joinBounded.
-      if (!(joinMs > 0)) return REFRESH_JOIN_ABANDONED;
+      if (!(joinBound > 0)) return REFRESH_JOIN_ABANDONED;
       const settled = await withTimeout(
         queued.then(
           (value) => ({ value }),
           (err) => ({ err }),
         ),
-        joinMs,
+        joinBound,
         () => null,
       );
       if (settled === null) return REFRESH_JOIN_ABANDONED;
@@ -180,6 +288,9 @@ export function makeRefreshCoalescer({ getInFlight, setInFlight, runRegister, wi
       if ("err" in settled) throw settled.err;
       return settled.value;
     }
-    return startRun(preloadedDefs);
+    // #1351 — the LEADING edge is a wait on the caller's own run too, and the one the
+    // #1242 drift recovery meets when no refresh happens to be in flight: bounded by runMs
+    // exactly as the post-join run is, with the run always started.
+    return awaitOwnRun(startRun(preloadedDefs));
   };
 }


### PR DESCRIPTION
## Root cause

`joinMs` (#1192/#1342) bounds only the **join** — the wait on a refresh run someone else started. A join that *succeeds* near its bound is followed by the caller's **own** run, whose deliberately-unbounded local work (`registerNodesFromDefs`, ~4s measured and worse on larger installs) sat outside every bound on the add path. Measured composition from the issue: a join ending at its 20,000 ms bound plus a ~13,000 ms own run sums to ~33,000 ms against the 30,000 ms relay window (`OBJECT_INFO_REFRESH_ACK_TIMEOUT_MS`) — the budget respected at every step, the command still outliving the window. Both `return startRun(preloadedDefs)` sites in `web/js/lib/refresh-coalesce.js` awaited the caller's own run unboundedly.

## Fix

New `opts.runMs` on the coalescer, bounding the caller's wait on the run **it** started:

- Measured **from the call**, not from the run's start: the join's cost is subtracted from it (and it also caps the join), so `joinMs` and `runMs` handed the same remaining budget bound the *total* wait instead of doubling it.
- The run is **never dropped**: on abandonment the slot is free (the join settled, or this is the leading edge), so the run starts anyway, registers the payload in the background, and the caller's retry finds the class registered. Only the *wait* ends, with a new `REFRESH_RUN_ABANDONED` sentinel — distinct from `REFRESH_JOIN_ABANDONED`, because the payload was not dropped and the wording must say so.
- An abandoned own run attaches a catch guard so its later failure cannot become an unhandled rejection; a run that rejects *inside* the bound still rejects for its caller.
- Unwired `withTimeout`/`now` or non-finite/`<= 0` `runMs` degrade exactly as `joinMs` does (unbounded-as-before / abandon-immediately), never silently restoring an unbounded wait.

Wired in `web/js/comfyui-mcp-panel.js`: the coalescer gets `now: monotonicNow`; both `graph_add_node` refresh sites (the resolver's payload refresh and the #1242 drift recovery's forced call, which meets the unbounded **leading edge**) pass `runMs: budget.remaining() - ADD_NODE_POST_REFRESH_RESERVE_MS`; a run-abandoned add refuses with a new `addNodeRefreshSlowMessage` (nothing added, refresh still running, retry — never "reload the tab"), re-worded only when the class is *still* unregistered.

Deliberately **not** done, per the issue: raising `OBJECT_INFO_REFRESH_ACK_TIMEOUT_MS`, which would make a pathologically slow run indistinguishable from a healthy one.

## Verification

- `npm ci` — clean
- `npm run test:unit` — **5506/5506 pass** (was 5506 total before; +10 new #1351 coalescer tests, +1 end-to-end harness test driving the shipped `graph_add_node` through the real coalescer: join lands at ~260ms of a ~280ms bound, own run outlives the rest, add refuses in words *inside* the budget, payload still registers in the background)
- `npm run typecheck` — clean
- `npm run check:scope` — OK
- Wiring pins extended in `single-node-def.test.mjs` (runMs at *both* call sites, `now: monotonicNow`, flag/message shape); harnesses rebuilding the executor (`_panel-constants.mjs`, `add-node-command-budget.test.mjs`) given the new bindings.

Follow-up worth a separate look: `refresh_nodes` itself (`GRAPH_TOOL_EXECUTORS.refresh_nodes`) still awaits its forced run unbounded against the same 30s ack timeout — wiring `runMs` there needs a decision about what verdict the tool reports on abandonment.

Closes #1351