### PR TITLE
fix(1739): a re-pended run completion re-arms the reconcile sweep

### DIFF
--- a/browser_tests/unit/run-completion.test.mjs
+++ b/browser_tests/unit/run-completion.test.mjs
@@ -742,3 +742,77 @@ test("#986 (codex r3): a later `executing` must NOT upgrade a FABRICATED start t
   assert.equal(h.flushes.length, 2, "a real render is delivered even when its duration looks tiny");
   assert.equal(h.flushes[1].looksCached, false, "an INVENTED duration is never called a cache hit");
 });
+
+// ---------------------------------------------------------------------------
+// comfyui-mcp#1739 — a successful panel run whose completion frame FAILED to
+// send (bridge/socket churn around a workflow-tab switch re-hello) is re-pended
+// by markUndelivered. But flush() retires runs OPTIMISTICALLY, so a safety-sweep
+// tick in the async compose+send window sees an empty ledger and self-disarms —
+// leaving the re-pended run in a ledger NOTHING sweeps until a real reconnect
+// edge or the next queue (possibly never). The tracker now notifies the wiring
+// (onRepend) on every re-pend so it can re-arm the sweep.
+// ---------------------------------------------------------------------------
+
+test("#1739: markUndelivered re-pend fires onRepend so recovery can be re-armed", () => {
+  const repends = [];
+  const tracker = createRunCompletionTracker({
+    onFlush: () => {},
+    onRepend: (id) => repends.push(id),
+    // No-op scheduler: markDelivered schedules a fence-prune timer, and a REAL
+    // one would hold the node process open for the whole fence TTL.
+    setTimer: () => 0,
+    clearTimer: () => {},
+  });
+  tracker.markUndelivered("prompt-x");
+  assert.deepEqual(repends, ["prompt-x"], "the re-pend is announced with the run's id");
+  assert.ok(tracker.hasPending(), "the run is genuinely back in the pending ledger");
+});
+
+test("#1739: a null id re-pends nothing and must NOT fire onRepend", () => {
+  const repends = [];
+  const tracker = createRunCompletionTracker({
+    onFlush: () => {},
+    onRepend: (id) => repends.push(id),
+    // No-op scheduler: markDelivered schedules a fence-prune timer, and a REAL
+    // one would hold the node process open for the whole fence TTL.
+    setTimer: () => 0,
+    clearTimer: () => {},
+  });
+  tracker.markUndelivered(null);
+  assert.equal(repends.length, 0);
+  assert.equal(tracker.hasPending(), false);
+});
+
+test("#1739: markDelivered is a confirmation, not a re-pend — it never fires onRepend", () => {
+  const repends = [];
+  const tracker = createRunCompletionTracker({
+    onFlush: () => {},
+    onRepend: (id) => repends.push(id),
+    // No-op scheduler: markDelivered schedules a fence-prune timer, and a REAL
+    // one would hold the node process open for the whole fence TTL.
+    setTimer: () => 0,
+    clearTimer: () => {},
+  });
+  tracker.markDelivered("prompt-x");
+  assert.equal(repends.length, 0);
+});
+
+test("#1739 wiring: the panel re-arms the run-reconcile sweep on every re-pend", () => {
+  // Behavioral tests above inject onRepend by hand; this pins the REAL call
+  // site's wiring by source inspection — the established pattern for the giant
+  // module (cf. the #609 wiring test above).
+  const src = readFileSync(
+    fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url)),
+    "utf8",
+  ).replace(/\r\n/g, "\n");
+  const start = src.indexOf("createRunCompletionTracker({");
+  assert.notEqual(start, -1, "could not locate the createRunCompletionTracker call site");
+  const end = src.indexOf("onFlush:", start);
+  assert.notEqual(end, -1, "could not locate the onFlush option after the call site");
+  const head = src.slice(start, end);
+  assert.match(
+    head,
+    /onRepend:\s*\(\)\s*=>\s*\{[\s\S]*armRunReconcileSweepRef\?\.\(\)/,
+    "a re-pended run must re-arm the safety sweep, or its completion can be lost forever",
+  );
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -32418,6 +32418,21 @@ function buildPanel() {
   // This closure owns ONLY presentation: it receives the full, correctly-scoped
   // batch + duration for a completed prompt and composes the single agent_event.
   const runCompletion = createRunCompletionTracker({
+    // comfyui-mcp#1739 — a run re-pended by markUndelivered (the completion frame's
+    // sendFrame failed: bridge/socket churn, e.g. around a workflow-tab switch
+    // re-hello) re-enters a ledger that may have NO sweeper left: flush() retired
+    // the run OPTIMISTICALLY, and a safety-sweep tick landing in that async
+    // compose+send window saw an empty ledger and self-disarmed. Without a re-arm
+    // here the run sits pending until a real `reconnected` edge or the next queue —
+    // possibly forever — while /history already holds its outputs: exactly the
+    // reported "successful run, no completion event, manual get_history recovery".
+    // Re-arming on every re-pend closes the hole; arm() is single-flight, so a
+    // redundant kick is a no-op.
+    onRepend: () => {
+      try {
+        armRunReconcileSweepRef?.();
+      } catch {}
+    },
     // #986 — a suppressed duplicate is not silently dropped. It is a canvas re-queue
     // whose output was already announced and which plainly did not render (a
     // sub-second "render" of a clip that took minutes the first time), so the agent

--- a/web/js/lib/run-completion.js
+++ b/web/js/lib/run-completion.js
@@ -61,6 +61,9 @@ export const NO_PROMPT_KEY = "__no_prompt__";
  *   with the FULL batch for that prompt_id, the correct start→finish duration,
  *   and the prompt_id (`key`/`promptId`) so the delivery can be attributed.
  * @param {() => number} [opts.now]        Clock (injectable for tests).
+ * @param {(promptId:(string|null)) => void} [opts.onRepend]  Called after
+ *   markUndelivered() re-pends a run, so the wiring can re-arm recovery
+ *   (the safety sweep) for the ledger the run just re-entered (#1739).
  * @param {(fn:Function, ms:number) => any} [opts.setTimer]
  * @param {(t:any) => void} [opts.clearTimer]
  * @param {number} [opts.debounceMs]       Orphan-flush / re-arm interval (default 1500).
@@ -71,6 +74,13 @@ export function createRunCompletionTracker({
   onReconcileError,
   onReconcileInterrupted,
   onReconcileGiveUp,
+  // comfyui-mcp#1739 — called AFTER markUndelivered() has re-pended a run. The
+  // pending ledger is recovery-driven (reconnect edges + the safety sweep, which
+  // SELF-DISARMS the moment it observes an empty ledger), and flush() retires a
+  // run OPTIMISTICALLY before the async compose+send resolves — so a send that
+  // then fails re-pends a run into a ledger nothing is sweeping. This hook is how
+  // the wiring re-arms recovery; without it the re-pend is a silent dead end.
+  onRepend,
   now = () => Date.now(),
   setTimer = (fn, ms) => setTimeout(fn, ms),
   clearTimer = (t) => clearTimeout(t),
@@ -931,6 +941,10 @@ export function createRunCompletionTracker({
       // 120s backstop can't be what decides isSettled() for it (#585).
       clearAwaitingDelivery(k);
       if (!pending.has(k)) pending.set(k, { promptId: k, at: now() }); // normalized string id
+      // comfyui-mcp#1739 — the re-pend is only half the recovery: the ledger the
+      // run just re-entered may have NO sweeper left (the safety sweep disarmed
+      // during the optimistic-retire window), so notify the wiring to re-arm it.
+      if (typeof onRepend === "function") onRepend(promptIdOf(k));
     },
 
     /**


### PR DESCRIPTION
## Root cause

A successful `panel_run` completion can be silently lost (artokun/comfyui-mcp#1739: run succeeded, 8 temp PNGs in `/history`, but no `[panel event] Run finished` reached the agent and recovery required manual `get_history` + `panel_show_media`).

The loss mechanism is in the panel's run-completion recovery chain:

1. `flush()` retires a run from the pending ledger **optimistically**, before the async `composeRunCompletionFrame` + `sendFrame` resolves (`web/js/lib/run-completion.js`).
2. The safety sweep (`web/js/lib/run-reconcile-sweep.js`) **self-disarms** on any tick that observes an empty ledger — and a tick landing inside that async compose+send window sees exactly that.
3. When `sendFrame` then fails (bridge/socket churn — e.g. the `rehello` a workflow-tab switch itself triggers), `markUndelivered()` re-pends the run into a ledger **nothing is sweeping**. Recovery then depends on a real `reconnected` edge or the next queue — which may never come. The run's outputs sit in `/history` while the agent waits forever.

## Fix

- `web/js/lib/run-completion.js`: new optional `onRepend` hook, fired after `markUndelivered()` has genuinely re-pended a run (not on null ids, not on `markDelivered`).
- `web/js/comfyui-mcp-panel.js`: the tracker wiring passes `onRepend: () => armRunReconcileSweepRef?.()`, re-arming the /history reconcile sweep for the ledger the run just re-entered. `arm()` is single-flight, so a redundant kick is a no-op; the sweep still self-disarms once the ledger truly drains.

This covers all four `markUndelivered` call sites (completion send failure, compose throw, reconcile-error send failure, interrupted-notice send failure) through the single re-pend choke point.

## Verification

- `browser_tests/unit/run-completion.test.mjs`: 3 new behavioral tests (`onRepend` fires with the run's id on re-pend; not for null id; not on `markDelivered`) + 1 wiring test pinning the panel call site (source-inspection pattern, cf. the #609 wiring test).
- `node --test browser_tests/unit/run-completion.test.mjs` → 35 pass / 0 fail.
- `npm ci` → clean, 0 vulnerabilities.
- `npm run test:unit` (i18n-check + i18n-render-check + check-tool-vocabulary + check-panel-scope + full unit suite) → exit 0, 5509 tests, 0 fail. (One unrelated timing flake in `manager-install.test.mjs` `#671 fast-draining install` on the first run under load; that file passes 125/125 in isolation and the full gate rerun is green.)
- `npm run typecheck` (`tsc --noEmit`) → exit 0.

## Scope note

The issue's second symptom — the canvas PreviewImage staying empty for a background tab — is ComfyUI-core behavior (core only paints the active graph; the panel never writes canvas previews) and is not addressed here. This PR fixes the agent-facing loss: the completion event is now recovered and delivered.

Closes artokun/comfyui-mcp#1739