### PR TITLE
fix(1402): harden duplicate_widgets — prototype-safe, budget-bounded, per-row outline labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+### Fixed
+- `duplicate_widgets` (the #1402 duplicate-widget report) no longer throws the whole detail read away on a widget named `__proto__`/`constructor`/`toString` — occurrences are accumulated prototype-safely — and is now bounded by the same `max_chars` budget as `widgets` (dropped occurrences are announced with the lever that lifts them, never silently lost), so a many-group Fast Groups Bypasser cannot push the detail line into a whole-row stub. `panel_graph_outline` also labels each same-named row from the widget itself rather than a last-wins name-keyed map, so two different group toggles are no longer both annotated with the last row's label (#1402)
+
 ## [0.15.5] - 2026-08-19
 
 ### Added

--- a/browser_tests/duplicate-widget-rows-are-visible.spec.ts
+++ b/browser_tests/duplicate-widget-rows-are-visible.spec.ts
@@ -1,0 +1,152 @@
+/**
+ * #1402 — a node whose widgets share ONE name must not read as a node with one row.
+ *
+ * rgthree's Fast Groups Bypasser/Muter names EVERY group-toggle row
+ * `RGTHREE_TOGGLE_AND_NAV`. summarizeNode keys widgets by name, so a node rendering two
+ * toggle rows returned a single, healthy-looking entry:
+ *
+ *     "widgets": {"RGTHREE_TOGGLE_AND_NAV": {"toggled": false}},
+ *     "widget_labels": {"RGTHREE_TOGGLE_AND_NAV": "Enable MODEL REF"}
+ *
+ * On the strength of that read the agent told the user the node's data was correct and
+ * only the canvas draw was stale — the opposite of the truth — and shipped a fix that
+ * could not work. The unit tests pin the derivation; this pins that the payload an agent
+ * actually receives, from a real panel in a real browser, carries the second row. The
+ * report was filed with "parses cleanly, not verified at runtime" — this is that
+ * verification.
+ *
+ * rgthree is not installed in this harness, so the shape is reproduced directly: two
+ * widgets, one name, different labels and values. That is precisely what the bypasser
+ * hands the panel.
+ */
+import { test, expect } from './fixtures/panelTest'
+import { claimFreshCanvas, settleCanvas } from './fixtures/canvasIdentity'
+
+const DUP = 'RGTHREE_TOGGLE_AND_NAV'
+
+/** Add a node carrying two same-named toggle rows, as the bypasser does. */
+async function makeDuplicateRowNode(page: import('@playwright/test').Page) {
+  return await page.evaluate((dupName) => {
+    const w = window as any
+    const app = w.comfyAPI?.app?.app || w.app
+    const LG = w.LiteGraph || w.comfyAPI?.litegraph?.LiteGraph
+    const n = LG.createNode('EmptyLatentImage')
+    ;(app?.canvas?.graph ?? app?.graph).add(n)
+    // Clone a real widget so the row keeps whatever type/options the canvas needs to
+    // draw it, then give both copies the SAME name — the rgthree shape.
+    const proto = (n.widgets || [])[0]
+    const row = (label: string, toggled: boolean) => ({
+      ...proto,
+      name: dupName,
+      label,
+      value: { toggled },
+    })
+    n.widgets.push(row('Enable MODEL FL2', true))
+    n.widgets.push(row('Enable MODEL REF', false))
+    return { id: String(n.id), rows: n.widgets.filter((x: any) => x?.name === dupName).length }
+  }, DUP)
+}
+
+test('the detail read reports BOTH rows that share one widget name', async ({
+  page,
+  panel,
+  mockBridge,
+}) => {
+  await panel.goto()
+  await panel.setBridgeUrl(mockBridge.url)
+  await panel.openSidebar()
+  await panel.connect()
+  await claimFreshCanvas(page, mockBridge)
+
+  const made = await makeDuplicateRowNode(page)
+  expect(made.rows, 'precondition: the node really carries two same-named rows').toBe(2)
+  await settleCanvas(page)
+
+  const res = await mockBridge.command('graph_query', { ids: [made.id], fields: 'detail' })
+  expect(res.ok).toBe(true)
+  const text = String(res.result?.text ?? '')
+  const node = JSON.parse(text.trim().split('\n').find((l) => l.includes(DUP)) ?? '{}')
+
+  // THE BUG: this was the entire report for a two-row node.
+  expect(node.widgets?.[DUP], 'the name-keyed map still holds the last row (back-compat)').toEqual({
+    toggled: false,
+  })
+
+  // The fix: the dropped row is present, with its own label and its own value.
+  const rows = node.duplicate_widgets?.[DUP]
+  expect(rows, 'duplicate_widgets must name the repeated widget').toBeDefined()
+  expect(rows).toHaveLength(2)
+  expect(rows.map((r: any) => r.label)).toEqual(['Enable MODEL FL2', 'Enable MODEL REF'])
+  expect(rows.map((r: any) => r.value?.toggled)).toEqual([true, false])
+  // The precise wrong answer the reporter gave: the read said the node was all-off while
+  // a row sat toggled ON. Both states are now visible in the payload.
+  expect(
+    rows.some((r: any) => r.value?.toggled === true),
+    'a row that is ON must be visible even when the collapsed map says off',
+  ).toBe(true)
+  // Canvas order, so the LAST occurrence is the one `widgets` ended up holding.
+  expect(rows.at(-1).value).toEqual(node.widgets[DUP])
+})
+
+test('a node with unique widget names carries no duplicate report at all', async ({
+  page,
+  panel,
+  mockBridge,
+}) => {
+  // The other half of the fix, and the one that keeps it free: an ordinary node's detail
+  // must be exactly what it was before this field existed. Without this, the key would
+  // land on every read and cost every caller tokens to learn nothing.
+  await panel.goto()
+  await panel.setBridgeUrl(mockBridge.url)
+  await panel.openSidebar()
+  await panel.connect()
+  await claimFreshCanvas(page, mockBridge)
+
+  const made = await page.evaluate(() => {
+    const w = window as any
+    const app = w.comfyAPI?.app?.app || w.app
+    const LG = w.LiteGraph || w.comfyAPI?.litegraph?.LiteGraph
+    const n = LG.createNode('EmptyLatentImage')
+    ;(app?.canvas?.graph ?? app?.graph).add(n)
+    return { id: String(n.id) }
+  })
+  await settleCanvas(page)
+
+  const res = await mockBridge.command('graph_query', { ids: [made.id], fields: 'detail' })
+  expect(res.ok).toBe(true)
+  const text = String(res.result?.text ?? '')
+  expect(text, 'an ordinary node must not mention duplicates').not.toContain('duplicate_widgets')
+})
+
+test('the outline annotates each shared-name row with ITS OWN label', async ({
+  page,
+  panel,
+  mockBridge,
+}) => {
+  // graph_outline renders one token per widget in the array, so it always showed both
+  // rows — but it looked each row's label up BY NAME, which is last-wins. Both rows were
+  // therefore annotated with the last row's label: the outline stated, of two different
+  // group toggles, that they were the same one.
+  await panel.goto()
+  await panel.setBridgeUrl(mockBridge.url)
+  await panel.openSidebar()
+  await panel.connect()
+  await claimFreshCanvas(page, mockBridge)
+
+  const made = await makeDuplicateRowNode(page)
+  expect(made.rows).toBe(2)
+  await settleCanvas(page)
+
+  const outline = await mockBridge.command('graph_outline', {})
+  expect(outline.ok).toBe(true)
+  const text = String(outline.result?.outline ?? '')
+
+  expect(text, 'the first row keeps its own label').toContain('[renamed "Enable MODEL FL2"]')
+  expect(text, 'the second row keeps its own label').toContain('[renamed "Enable MODEL REF"]')
+  // THE BUG: the last row's label was stamped on both, so FL2 never appeared and REF
+  // appeared twice.
+  expect(
+    text.match(/\[renamed "Enable MODEL REF"\]/g)?.length ?? 0,
+    'the last row\'s label must not be stamped onto the first',
+  ).toBe(1)
+})

--- a/browser_tests/unit/duplicate-widget-rows.test.mjs
+++ b/browser_tests/unit/duplicate-widget-rows.test.mjs
@@ -1,0 +1,238 @@
+/**
+ * Unit tests for web/js/lib/widget-rows.js (#1402) — run with `node --test`.
+ *
+ * Reported: a Fast Groups Bypasser (rgthree) matching two groups rendered TWO toggle
+ * rows on the canvas. rgthree names every one of those rows `RGTHREE_TOGGLE_AND_NAV`,
+ * and summarizeNode keys widgets by name, so every `panel_query_graph {fields:'detail'}`
+ * returned a single, healthy-looking entry:
+ *
+ *     "widgets": {"RGTHREE_TOGGLE_AND_NAV": {"toggled": false}},
+ *     "widget_labels": {"RGTHREE_TOGGLE_AND_NAV": "Enable MODEL REF"}
+ *
+ * On the strength of that read the agent told the user the node's data was correct and
+ * only the canvas draw was stale — the opposite of the truth — and shipped a fix that
+ * could not work. The collapsed map carried no hint that a second row existed, so the
+ * wrong state was undetectable short of a screenshot.
+ *
+ * What is pinned here, in both directions:
+ *   - every occurrence of a repeated name is reported, in canvas order, with its OWN
+ *     value and label (the reported bug), and
+ *   - a node whose widget names are unique reports NOTHING extra. That is what keeps
+ *     the common node's payload byte-identical, and it is the half that stops the new
+ *     key from becoming noise on every read.
+ *
+ * The name-keyed `widgets` map is deliberately left alone: it is the identity
+ * panel_set_widget addresses, and re-shaping it would break every caller to fix a case
+ * most nodes never hit.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import { duplicateWidgetRows } from "../../web/js/lib/widget-rows.js";
+
+const PANEL_JS = fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url));
+
+/** The reported node: two rgthree group-toggle rows sharing ONE name. */
+const rgthreeNode = () => ({
+  widgets: [
+    { name: "RGTHREE_TOGGLE_AND_NAV", label: "Enable MODEL FL2", value: { toggled: true } },
+    { name: "RGTHREE_TOGGLE_AND_NAV", label: "Enable MODEL REF", value: { toggled: false } },
+  ],
+});
+
+test("#1402: both rgthree toggle rows are reported, not just the one the map kept", () => {
+  const dup = duplicateWidgetRows(rgthreeNode());
+  assert.deepEqual(dup, {
+    RGTHREE_TOGGLE_AND_NAV: [
+      { index: 0, label: "Enable MODEL FL2", value: { toggled: true } },
+      { index: 1, label: "Enable MODEL REF", value: { toggled: false } },
+    ],
+  });
+  // The precise failure that cost the reporter: the name-keyed read showed toggled:false
+  // for the whole node while a row sat toggled:true. Both states are now visible.
+  const rows = dup.RGTHREE_TOGGLE_AND_NAV;
+  assert.equal(rows.length, 2, "the row COUNT is what the collapsed map could never give");
+  assert.deepEqual(
+    rows.map((r) => r.value.toggled),
+    [true, false],
+  );
+});
+
+test("#1402: unique widget names report NOTHING — the common node is unchanged", () => {
+  // This is what keeps `duplicate_widgets` off an ordinary node's payload entirely.
+  assert.deepEqual(
+    duplicateWidgetRows({
+      widgets: [
+        { name: "seed", value: 1 },
+        { name: "steps", value: 20 },
+        { name: "cfg", value: 8 },
+      ],
+    }),
+    {},
+  );
+  assert.deepEqual(duplicateWidgetRows({ widgets: [] }), {});
+  assert.deepEqual(duplicateWidgetRows({}), {});
+  assert.deepEqual(duplicateWidgetRows(null), {});
+  assert.deepEqual(duplicateWidgetRows(undefined), {});
+});
+
+test("#1402: only the REPEATED names are reported, never the unique ones beside them", () => {
+  const dup = duplicateWidgetRows({
+    widgets: [
+      { name: "seed", value: 1 },
+      { name: "RGTHREE_TOGGLE_AND_NAV", value: { toggled: true } },
+      { name: "steps", value: 20 },
+      { name: "RGTHREE_TOGGLE_AND_NAV", value: { toggled: false } },
+    ],
+  });
+  assert.deepEqual(Object.keys(dup), ["RGTHREE_TOGGLE_AND_NAV"]);
+  // `index` is the position in node.widgets — the order the canvas renders the rows —
+  // so it stays true across the unique widgets interleaved between the duplicates.
+  assert.deepEqual(
+    dup.RGTHREE_TOGGLE_AND_NAV.map((r) => r.index),
+    [1, 3],
+  );
+});
+
+test("#1402: occurrences are in CANVAS order, so the last is the one `widgets` kept", () => {
+  // The contract a caller reasons with: `widgets[name]` holds the final occurrence, and
+  // everything before it is what the map dropped. Order is therefore load-bearing, not
+  // incidental — a set or a sorted map would break it.
+  const dup = duplicateWidgetRows({
+    widgets: [
+      { name: "mode", value: "first" },
+      { name: "mode", value: "second" },
+      { name: "mode", value: "third" },
+    ],
+  });
+  assert.deepEqual(
+    dup.mode.map((r) => r.value),
+    ["first", "second", "third"],
+  );
+  // Mirror the name-keyed build summarizeNode runs and confirm the claim holds.
+  const widgets = {};
+  for (const w of [
+    { name: "mode", value: "first" },
+    { name: "mode", value: "second" },
+    { name: "mode", value: "third" },
+  ]) {
+    widgets[w.name] = w.value;
+  }
+  assert.equal(widgets.mode, dup.mode.at(-1).value);
+});
+
+test("#1402: identical rows are NOT collapsed — two of them IS the reported symptom", () => {
+  // The user's canvas rendered two rows that looked the same. De-duplicating equal
+  // occurrences here would hide exactly the state this exists to surface.
+  const dup = duplicateWidgetRows({
+    widgets: [
+      { name: "RGTHREE_TOGGLE_AND_NAV", label: "Enable MODEL FL2", value: { toggled: true } },
+      { name: "RGTHREE_TOGGLE_AND_NAV", label: "Enable MODEL FL2", value: { toggled: true } },
+    ],
+  });
+  assert.equal(dup.RGTHREE_TOGGLE_AND_NAV.length, 2);
+});
+
+test("#1402: each occurrence carries its OWN label, under #636's rules", () => {
+  const dup = duplicateWidgetRows({
+    widgets: [
+      // No label carried ⇒ no `label` key. Never invented, same as #636.
+      { name: "dup", value: 1 },
+      // A label equal to the name is not a rename and is not emitted.
+      { name: "dup", label: "dup", value: 2 },
+      // Surrounding whitespace is trimmed; a real rename survives.
+      { name: "dup", label: "  Real Rename  ", value: 3 },
+    ],
+  });
+  assert.deepEqual(dup.dup, [
+    { index: 0, value: 1 },
+    { index: 1, value: 2 },
+    { index: 2, label: "Real Rename", value: 3 },
+  ]);
+});
+
+test("#1402: malformed widgets are skipped, matching the name-keyed map's own filter", () => {
+  // The map summarizeNode builds keeps `typeof w.name === "string"` and nothing else, so
+  // this must report duplicates of exactly the names that map can collapse. A nameless
+  // widget can never collide, and counting one would report a duplicate that is not one.
+  const dup = duplicateWidgetRows({
+    widgets: [
+      null,
+      { value: "no name at all" },
+      { name: 42, value: "non-string name" },
+      { name: "dup", value: "a" },
+      undefined,
+      { name: "dup", value: "b" },
+    ],
+  });
+  assert.deepEqual(Object.keys(dup), ["dup"]);
+  // Indices still point into node.widgets, past the malformed entries.
+  assert.deepEqual(
+    dup.dup.map((r) => r.index),
+    [3, 5],
+  );
+});
+
+test("#1402: a widget named `__proto__` is reported, not thrown on", () => {
+  // A widget name is arbitrary third-party data. Bucketing into a plain object reads
+  // `bucket["__proto__"]` back as Object.prototype rather than a missing key, so the
+  // obvious `(out[name] ??= []).push(…)` throws — and a throw here takes the WHOLE
+  // node's detail with it, which is strictly worse than the collapsed read this
+  // replaces. Every one of these must come back as ordinary data.
+  for (const name of ["__proto__", "constructor", "toString", "hasOwnProperty", "valueOf"]) {
+    const node = { widgets: [{ name, value: 1 }, { name, value: 2 }] };
+    let dup;
+    assert.doesNotThrow(() => {
+      dup = duplicateWidgetRows(node);
+    }, `duplicateWidgetRows must not throw on a widget named ${name}`);
+    assert.deepEqual(Object.keys(dup), [name], `${name} must be an OWN key`);
+    assert.deepEqual(dup[name].map((r) => r.value), [1, 2]);
+    // It must survive the trip the payload actually makes, as data and not as a
+    // prototype mutation — the detail line is JSON.stringify'd before it is sent.
+    assert.deepEqual(JSON.parse(JSON.stringify(dup))[name].map((r) => r.value), [1, 2]);
+  }
+  // …and no such name leaks onto the prototype of anything.
+  assert.equal({}.polluted, undefined);
+  assert.deepEqual(duplicateWidgetRows({ widgets: [{ name: "__proto__", value: 1 }] }), {});
+});
+
+test("#1402: summarizeNode ACTUALLY emits this — the helper must not sit unwired", () => {
+  // Without this the helper above could be perfectly correct and reach no caller, which
+  // is indistinguishable from the bug. summarizeNode backs panel_query_graph
+  // (fields:'detail') and panel_get_subgraph — the reads the report was filed against.
+  const src = readFileSync(PANEL_JS, "utf8");
+  assert.match(src, /import \{ duplicateWidgetRows \} from "\.\/lib\/widget-rows\.js"/);
+  assert.match(
+    src,
+    /const duplicateWidgets = duplicateWidgetRows\(node\);/,
+    "summarizeNode computes the duplicate rows",
+  );
+  assert.match(
+    src,
+    /duplicate_widgets: duplicateWidgets/,
+    "summarizeNode emits them on the payload",
+  );
+});
+
+test("#1402: the OUTLINE labels each widget from the widget, not from a last-wins map", () => {
+  // graph_outline renders one token per entry of the widgets ARRAY, so it always showed
+  // both rgthree rows — but it looked their label up in `widgetLabelMap(n)[w.name]`,
+  // which is last-wins. Two different group toggles were therefore both annotated
+  // `[renamed "Enable MODEL REF"]`: the outline stated they were the same toggle.
+  const src = readFileSync(PANEL_JS, "utf8");
+  assert.match(
+    src,
+    /const label = displayLabel\(w\);/,
+    "the outline reads the label off the widget itself",
+  );
+  assert.doesNotMatch(
+    src,
+    /widgetLabelMap\(n\)/,
+    "no per-widget outline lookup may go back through the name-keyed map",
+  );
+  // summarizeNode's own `widget_labels` map is name-keyed BY CONTRACT (#636) and stays —
+  // duplicate_widgets is what carries the labels it cannot hold.
+  assert.match(src, /const widgetLabels = widgetLabelMap\(node\);/);
+});

--- a/browser_tests/unit/graph-read.test.mjs
+++ b/browser_tests/unit/graph-read.test.mjs
@@ -185,6 +185,62 @@ test("capSummaryWidgets tightens the per-value cap to a SMALL total budget (#609
   assert.match(capped.widgets.blob, /over the `max_chars` budget; raise `max_chars` \(up to 60000\)\)$/);
 });
 
+test("#1402: duplicate_widgets is bounded by the SAME budget, not exempt from it", () => {
+  // duplicate_widgets carries a value per OCCURRENCE, and the node it exists for (a Fast
+  // Groups Bypasser over many groups) is exactly the one that repeats a row many times.
+  // Left uncapped it would push the detail past max_chars and fitDetailLine would stub
+  // the WHOLE row — the field would make the read carry LESS than before it existed.
+  const rows = Array.from({ length: 40 }, (_, i) => ({
+    index: i,
+    label: `Enable GROUP ${i}`,
+    value: "z".repeat(500),
+  }));
+  const capped = capSummaryWidgets(
+    { id: 1, widgets: { RGTHREE_TOGGLE_AND_NAV: "z".repeat(500) }, duplicate_widgets: { RGTHREE_TOGGLE_AND_NAV: rows } },
+    WIDGET_VALUE_CAP,
+    3000,
+  );
+  assert.ok(JSON.stringify(capped).length < 3000 * 2, `line bounded, got ${JSON.stringify(capped).length}`);
+  assert.doesNotThrow(() => JSON.parse(JSON.stringify(capped)), "still valid JSON");
+  // Dropped occurrences are ANNOUNCED with the lever that lifts them, never silently
+  // lost — a silent drop here is the collapsed map's failure wearing a different key.
+  assert.match(
+    capped.duplicate_widgets["…"],
+    /more duplicate widget occurrence\(s\) cut by the `max_chars` budget; raise `max_chars` \(up to 60000\)/,
+  );
+  // At least one occurrence always survives, so the field never renders empty.
+  assert.ok(capped.duplicate_widgets.RGTHREE_TOGGLE_AND_NAV.length >= 1);
+  // The input is not mutated (the #609 contract for `widgets` holds here too).
+  assert.equal(rows.length, 40);
+  assert.equal(rows[0].value.length, 500);
+});
+
+test("#1402: a duplicate report that FITS is passed through untouched", () => {
+  // The common affected node — two rgthree toggle rows — is far under budget and must
+  // arrive exactly as summarizeNode built it, markers and clipping nowhere in sight.
+  const duplicate_widgets = {
+    RGTHREE_TOGGLE_AND_NAV: [
+      { index: 0, label: "Enable MODEL FL2", value: { toggled: true } },
+      { index: 1, label: "Enable MODEL REF", value: { toggled: false } },
+    ],
+  };
+  const summary = { id: 1, widgets: { RGTHREE_TOGGLE_AND_NAV: { toggled: false } }, duplicate_widgets };
+  const capped = capSummaryWidgets(summary, WIDGET_VALUE_CAP, 12000);
+  assert.deepEqual(capped.duplicate_widgets, duplicate_widgets);
+  assert.ok(!("…" in capped.duplicate_widgets), "nothing was cut, so nothing is announced");
+  // Nothing changed at all ⇒ the identical object comes back, as with an uncapped node.
+  assert.equal(capped, summary);
+});
+
+test("#1402: a summary with NO duplicates is untouched — the common node is unchanged", () => {
+  const summary = { id: 1, widgets: { seed: 1, steps: 20 } };
+  assert.equal(capSummaryWidgets(summary, WIDGET_VALUE_CAP, 12000), summary);
+  assert.ok(!("duplicate_widgets" in capSummaryWidgets(summary, WIDGET_VALUE_CAP, 12000)));
+  // A widgets-only clip must not invent the key either.
+  const clipped = capSummaryWidgets({ id: 1, widgets: { blob: "x".repeat(5000) } }, WIDGET_VALUE_CAP, 600);
+  assert.ok(!("duplicate_widgets" in clipped));
+});
+
 test("capSummaryWidgets stays bounded on ESCAPE-HEAVY content at a small budget (#609)", () => {
   // Every char JSON-escapes to two; halving the effective cap keeps the escaped line
   // near the budget rather than doubling past it.

--- a/browser_tests/unit/summarize-duplicate-widgets.test.mjs
+++ b/browser_tests/unit/summarize-duplicate-widgets.test.mjs
@@ -22,6 +22,7 @@ import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 
 import { displayLabel, boundaryInputLabel, widgetLabelMap } from "../../web/js/lib/slot-labels.js";
+import { duplicateWidgetRows } from "../../web/js/lib/widget-rows.js";
 import { virtualFedInputs } from "../../web/js/lib/virtual-source-promotion.js";
 import { controlAfterGenerateModes } from "../../web/js/lib/control-after-generate.js";
 import { drivenWidgetsFor } from "../../web/js/lib/graph-read.js";
@@ -52,6 +53,7 @@ const summarizeNode = (() => {
     "boundaryInputLabel",
     "displayLabel",
     "widgetLabelMap",
+    "duplicateWidgetRows",
     "controlAfterGenerateModes",
     "drivenWidgetsFor",
     `${fn}; return summarizeNode;`,
@@ -60,6 +62,7 @@ const summarizeNode = (() => {
     boundaryInputLabel,
     displayLabel,
     widgetLabelMap,
+    duplicateWidgetRows,
     controlAfterGenerateModes,
     drivenWidgetsFor,
   );
@@ -129,4 +132,27 @@ test("#1402 index is the live widgets[] slot, not a filtered-name compact index"
   assert.equal(node.widgets[listed[1].index], b);
   assert.equal("label" in listed[0], false, "no invented label when the widget carries none");
   assert.equal("label" in listed[1], false);
+});
+
+test("#1402 a widget named __proto__ is reported, not thrown on", () => {
+  // A widget name is arbitrary third-party data. Accumulating occurrences into a plain
+  // object reads `bucket["__proto__"]` back as Object.prototype rather than a missing
+  // key, so `(out[name] ??= []).push(…)` THROWS — and a throw here takes the WHOLE
+  // node's detail with it, strictly worse than the collapsed read this field replaced.
+  for (const name of ["__proto__", "constructor", "toString"]) {
+    const node = bypasser([{ name, value: 1 }, { name, value: 2 }]);
+    let summary;
+    assert.doesNotThrow(() => {
+      summary = summarizeNode(node);
+    }, `summarizeNode must not throw on a widget named ${name}`);
+    assert.deepEqual(
+      summary.duplicate_widgets[name].map((r) => r.value),
+      [1, 2],
+      `${name} must come back as ordinary data`,
+    );
+    // It must survive the trip the payload actually makes — the detail line is
+    // JSON.stringify'd before it is sent.
+    assert.deepEqual(JSON.parse(JSON.stringify(summary.duplicate_widgets))[name].map((r) => r.value), [1, 2]);
+  }
+  assert.equal({}.polluted, undefined, "nothing leaked onto Object.prototype");
 });

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -240,6 +240,7 @@ import { readActiveSidebarTab, shouldDetachPanelRoot, findSidebarTabButton } fro
 import { buildPanelFailureShell } from "./lib/panel-failure-shell.js";
 import { installSidebarRenderWatchdog } from "./lib/sidebar-render-watchdog.js";
 import { displayLabel, boundaryInputLabel, widgetLabelMap } from "./lib/slot-labels.js";
+import { duplicateWidgetRows } from "./lib/widget-rows.js";
 import { createObjectInfoHistory, awaitHistoryBaseline } from "./lib/object-info-history.js";
 import { makeRefreshCoalescer, REFRESH_JOIN_ABANDONED } from "./lib/refresh-coalesce.js";
 import {
@@ -9742,13 +9743,8 @@ async function revertGraphSnapshotByMid(mid) {
  *  (positions, colors, internal state) to keep token cost low. */
 function summarizeNode(node) {
   const widgets = {};
-  const namedWidgets = [];
-  const list = node.widgets ?? [];
-  for (let i = 0; i < list.length; i++) {
-    const w = list[i];
-    if (!w || typeof w.name !== "string") continue;
-    widgets[w.name] = w.value;
-    namedWidgets.push({ index: i, w });
+  for (const w of node.widgets ?? []) {
+    if (w && typeof w.name === "string") widgets[w.name] = w.value;
   }
   // #1402: several widgets can legitimately share ONE name — every toggle row of
   // rgthree's Fast Groups Bypasser/Muter is named `RGTHREE_TOGGLE_AND_NAV`. The
@@ -9756,19 +9752,11 @@ function summarizeNode(node) {
   // and the read reports one row's state as if it were the whole node's, hiding
   // duplicated or orphaned rows completely. Surface every occurrence, in canvas
   // order, whenever a name repeats, so a collapsed row is visible instead of
-  // silently dropped.
-  const nameCounts = new Map();
-  for (const { w } of namedWidgets) nameCounts.set(w.name, (nameCounts.get(w.name) ?? 0) + 1);
-  const duplicateWidgets = {};
-  for (const { index, w } of namedWidgets) {
-    if ((nameCounts.get(w.name) ?? 0) < 2) continue;
-    const label = displayLabel(w);
-    (duplicateWidgets[w.name] ??= []).push({
-      index,
-      ...(label != null ? { label } : {}),
-      value: w.value,
-    });
-  }
+  // silently dropped. Accumulated in a Map, not a plain object: a widget name is
+  // arbitrary third-party data, and `(out["__proto__"] ??= []).push(…)` reads
+  // Object.prototype back instead of a missing key and THROWS — taking the whole
+  // node's detail with it, which is strictly worse than the collapsed read.
+  const duplicateWidgets = duplicateWidgetRows(node);
   // #1181: promoted inputs on a subgraph container whose link origin is a
   // frontend-only VIRTUAL source (e.g. a canvas PrimitiveNode). graphToPrompt
   // DROPS that source, so the link carries nothing at run time — the opposite
@@ -11191,7 +11179,13 @@ const GRAPH_TOOL_EXECUTORS = {
           // "had not stuck" while the canvas plainly showed them, and only a screenshot
           // settled it. Renamed widgets ONLY, so an unrenamed graph's outline is
           // byte-identical to before and costs nothing against max_chars.
-          const renamed = widgetLabelMap(n);
+          //
+          // #1402: read the label off the WIDGET, not off a name-keyed map. The outline
+          // renders one token per widget in the array, so it already shows every row of
+          // a repeated name — but looking each row's label up by NAME is last-wins, so
+          // both rgthree `RGTHREE_TOGGLE_AND_NAV` rows were annotated with the LAST row's
+          // label and the outline stated, of two different group toggles, that they were
+          // the same one. Identical for every unique name, which is nearly all of them.
           widgets = (n.widgets ?? [])
             .filter((w) => w && typeof w.name === "string")
             .map((w) => {
@@ -11203,7 +11197,7 @@ const GRAPH_TOOL_EXECUTORS = {
               // same bracket idiom as [after_gen=…] and [bypass].
               // ESCAPED, not merely clipped (codex): `title_` bounds the SIZE, `tagText_`
               // stops a user-controlled label from closing this tag and forging the next.
-              const label = renamed[w.name];
+              const label = displayLabel(w);
               const withLabel = label ? `${base} [renamed "${tagText_(title_(label))}"]` : base;
               const mode = cagMode.get(w.name);
               const withMode = mode ? `${withLabel} [after_gen=${mode}]` : withLabel;

--- a/web/js/lib/graph-read.js
+++ b/web/js/lib/graph-read.js
@@ -170,8 +170,9 @@ function entrySize(key, value) {
   return JSON.stringify(String(key)).length + vLen + 2; // "key": value ,
 }
 
-/** Return a shallow clone of a summarizeNode() result whose `widgets` are bounded
- *  (#609): each value is clipped, AND the total serialized widgets size is kept under
+/** Return a shallow clone of a summarizeNode() result whose `widgets` (and
+ *  `duplicate_widgets`, #1402) are bounded (#609): each value is clipped, AND the
+ *  total serialized widgets size is kept under
  *  `totalCap` by DROPPING overflow widgets (keeping valid JSON) with an elision
  *  marker — so even a node with many oversized widgets can't blow the char budget.
  *  When a budget is set, the per-value cap is tightened to it so even the single
@@ -209,7 +210,56 @@ export function capSummaryWidgets(summary, cap = WIDGET_VALUE_CAP, totalCap = In
     widgets["…"] =
       `${omitted} more widget(s) cut by the \`max_chars\` budget; ` +
       raiseOrCeiling("max_chars", totalCap, MAX_CHARS_CEILING);
-  return changed ? { ...summary, widgets } : summary;
+  // #1402: `duplicate_widgets` carries a VALUE PER OCCURRENCE, so it is unbounded input
+  // on the very line #609 exists to bound — and the node class it exists for (a Fast
+  // Groups Bypasser over many groups) is precisely the one that repeats a row many
+  // times. Left uncapped it could push the detail past `max_chars`, and fitDetailLine
+  // would then degrade the WHOLE row to a stub: the read this field was added to
+  // improve would come back carrying LESS than before it existed. Bound it in the same
+  // clip-then-drop-with-a-marker idiom, against whatever budget the name-keyed map left
+  // — `widgets` is the addressable, back-compatible field and is served first.
+  const dup = summary.duplicate_widgets;
+  let duplicates = dup;
+  if (dup && typeof dup === "object" && Object.keys(dup).length) {
+    const budget = Number.isFinite(totalCap) ? Math.max(0, totalCap - used) : Infinity;
+    // A Map, then Object.fromEntries — a widget name is third-party data, and
+    // `bucket["__proto__"] ??= []` reads Object.prototype instead of a missing key and
+    // then throws on .push. See web/js/lib/widget-rows.js for the same reasoning.
+    const kept = new Map();
+    let dUsed = 0;
+    let dOmitted = 0;
+    let stopped = false;
+    for (const [rawKey, rows] of Object.entries(dup)) {
+      const k = capKey(rawKey);
+      if (k !== rawKey) changed = true;
+      for (const row of Array.isArray(rows) ? rows : []) {
+        if (stopped) { dOmitted++; continue; }
+        const value = capWidgetValue(row?.value, perValueCap, totalCap);
+        if (value !== row?.value) changed = true;
+        const entry = { ...row, value };
+        // Keep at least ONE occurrence, then stop once the total would exceed the
+        // budget — the same floor `widgets` keeps. A field that can silently render
+        // empty is the collapsed map's failure wearing a different key.
+        if (Number.isFinite(budget) && dUsed > 0 && dUsed + entrySize(k, entry) > budget) {
+          stopped = true;
+          dOmitted++;
+          changed = true;
+          continue;
+        }
+        if (!kept.has(k)) kept.set(k, []);
+        kept.get(k).push(entry);
+        dUsed += entrySize(k, entry);
+      }
+    }
+    if (dOmitted > 0)
+      kept.set(
+        "…",
+        `${dOmitted} more duplicate widget occurrence(s) cut by the \`max_chars\` budget; ` +
+          raiseOrCeiling("max_chars", totalCap, MAX_CHARS_CEILING),
+      );
+    duplicates = Object.fromEntries(kept);
+  }
+  return changed ? { ...summary, widgets, ...(dup ? { duplicate_widgets: duplicates } : {}) } : summary;
 }
 
 /** Hard-clip an assembled COMPACT (plain-string) line to `maxChars` (#609). The

--- a/web/js/lib/widget-rows.js
+++ b/web/js/lib/widget-rows.js
@@ -1,0 +1,89 @@
+// WIDGET ROWS THAT SHARE ONE NAME (#1402).
+//
+// Every structured read reports a node's widgets as a name-keyed object:
+//
+//     const widgets = {};
+//     for (const w of node.widgets ?? []) widgets[w.name] = w.value;
+//
+// That shape assumes widget names are UNIQUE. They are not. rgthree's Fast Groups
+// Bypasser/Muter names EVERY group-toggle row `RGTHREE_TOGGLE_AND_NAV`, so a node
+// rendering N toggle rows reports exactly ONE entry — the last one wins and the rest
+// vanish without trace.
+//
+// The damage is not that the read is lossy, it is that the read looks HEALTHY. A
+// reporter added a Fast Groups Bypasser matching two groups, the canvas rendered two
+// rows, and every `panel_query_graph {fields:'detail'}` came back with a single tidy
+// `RGTHREE_TOGGLE_AND_NAV` entry and a single `widget_labels` entry. On the strength of
+// that read they told the user the node's DATA was correct and only the canvas draw was
+// stale — the exact opposite of the truth — and shipped a fix that could not work. The
+// collapsed map gave no hint that more than one widget had contributed to it, so there
+// was no way to detect the real state short of asking for a screenshot.
+//
+// The correction is ADDITIVE and strictly OBSERVED, for the same reason #636's was:
+//   * the name-keyed map stays exactly as it is. It is what panel_set_widget addresses
+//     and what every existing caller parses; re-shaping it to an array would break them
+//     all to fix a case that most nodes never hit.
+//   * a duplicate report is emitted ONLY when a name is genuinely carried by more than
+//     one widget. A node with unique widget names — which is nearly all of them — reads
+//     byte-identical to before, so this costs nothing on the common path.
+//   * nothing is inferred or de-duplicated. Every occurrence is reported, in the array
+//     order the canvas renders, including occurrences whose value and label are equal.
+//     Two identical rows ARE the bug in the reported case; collapsing them here would
+//     reintroduce it one layer up.
+//
+// Extracted so the derivation is unit-tested against the SAME code summarizeNode runs.
+
+import { displayLabel } from "./slot-labels.js";
+
+/**
+ * Map of widget NAME → every widget carrying that name, for names carried by MORE THAN
+ * ONE widget, and only those. Empty object when every name is unique, so a caller can
+ * omit the key entirely rather than emit an empty map on every node.
+ *
+ * Each occurrence reports:
+ *   * `index` — position in `node.widgets`, i.e. the order the canvas renders the rows.
+ *     Positional only: widgets are addressed by NAME, and a repeated name cannot be
+ *     addressed unambiguously at all, which is itself worth knowing.
+ *   * `label` — the display label this occurrence carries, when it carries a distinct
+ *     one (#636 rules, via displayLabel). Omitted when it carries none. The occurrences
+ *     of one name routinely carry DIFFERENT labels — the rgthree toggle rows are named
+ *     alike and labelled per group — and the name-keyed `widget_labels` map can hold
+ *     only one of them.
+ *   * `value` — this occurrence's own value, unwrapped exactly as stored.
+ *
+ * Occurrences are in canvas order, so the LAST entry for a name is the one the
+ * name-keyed `widgets` map ended up holding; the earlier ones are what it dropped.
+ *
+ * The name filter matches the name-keyed map's own (`typeof w.name === "string"`), so
+ * this reports duplicates of exactly the names that map can collapse — no more, no less.
+ *
+ * Accumulated in a Map and materialised with Object.fromEntries, NOT by assigning into
+ * a plain object: a widget name is arbitrary third-party data, and `bucket["__proto__"]`
+ * reads back Object.prototype rather than a missing key, so the obvious
+ * `(out[name] ??= []).push(…)` THROWS on a node with two widgets named `__proto__`,
+ * `constructor` or `toString`. A read that throws is worse than the collapsed read this
+ * replaces — it takes the whole node's detail with it. Object.fromEntries creates a
+ * genuine own property for every key, including those.
+ */
+export function duplicateWidgetRows(node) {
+  const named = [];
+  const widgets = node?.widgets ?? [];
+  for (let i = 0; i < widgets.length; i++) {
+    const w = widgets[i];
+    if (w && typeof w.name === "string") named.push({ index: i, widget: w });
+  }
+  const counts = new Map();
+  for (const { widget } of named) counts.set(widget.name, (counts.get(widget.name) ?? 0) + 1);
+  const out = new Map();
+  for (const { index, widget } of named) {
+    if ((counts.get(widget.name) ?? 0) < 2) continue;
+    const label = displayLabel(widget);
+    if (!out.has(widget.name)) out.set(widget.name, []);
+    out.get(widget.name).push({
+      index,
+      ...(label != null ? { label } : {}),
+      value: widget.value,
+    });
+  }
+  return Object.fromEntries(out);
+}


### PR DESCRIPTION
Follow-up to #1402. #1406 shipped the `duplicate_widgets` field; this PR is reduced to the hardening the merged fix lacked. The name-keyed `widgets` map and the merged payload shape are unchanged — an unaffected node's payload is byte-identical.

## The three gaps this closes

**1. Prototype-safe accumulation.** The merged inline accumulation was `(duplicateWidgets[w.name] ??= []).push(…)` into a plain object. A widget name is arbitrary third-party data: for a name like `__proto__`, `constructor` or `toString`, the `??=` reads `Object.prototype` back instead of a missing key and `.push` **throws** — taking the whole node's detail read with it, strictly worse than the collapsed read the field replaced. Occurrences are now accumulated in a `Map` and materialised with `Object.fromEntries` (new `web/js/lib/widget-rows.js`, so the derivation is unit-tested against the same code `summarizeNode` runs).

**2. `duplicate_widgets` is bounded by the #609 `max_chars` budget.** The field carries a value *per occurrence*, and the node class it exists for (a Fast Groups Bypasser over many groups) is exactly the one that repeats a row many times. Left uncapped it could push the detail line past `max_chars`, and `fitDetailLine` would then stub the WHOLE row — the field would make the read carry less than before it existed. `capSummaryWidgets` now bounds it in the same clip-then-drop-with-a-marker idiom, against whatever budget the name-keyed map left; dropped occurrences are announced with the lever that lifts them, never silently lost.

**3. `graph_outline` labels each same-named row from the widget itself.** The outline renders one token per widget in the array, so it always showed every `RGTHREE_TOGGLE_AND_NAV` row — but it looked each row's label up in the last-wins `widgetLabelMap(n)`, so both rows were annotated with the LAST row's label: the outline stated, of two different group toggles, that they were the same one. It now uses `displayLabel(w)` per row — identical for every unique name, which is nearly all of them.

## Proof

- `npm run test:unit` — 5570 pass, 0 fail (includes new `duplicate-widget-rows.test.mjs`, the budget tests in `graph-read.test.mjs`, and a shipped-`summarizeNode` `__proto__` regression test in `summarize-duplicate-widgets.test.mjs`)
- `npm run typecheck` — clean
- `browser_tests/duplicate-widget-rows-are-visible.spec.ts` pins the end-to-end payload from a real panel: both rows reported, unique-name nodes carry no key, outline annotates each row with its own label
