### PR TITLE
fix(1402): duplicate same-named widgets are all listed, not last-wins collapsed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project are documented here. This project adheres to
 - `/record-skill` snapshots the open graph as a reusable skill file (`skills/<name>/SKILL.md`) so the agent can rebuild it (#350)
 
 ### Fixed
+- `panel_query_graph` (fields:'detail') no longer last-wins-collapses widgets that share a name: when a name repeats (rgthree Fast Groups toggle rows), every occurrence is listed so a duplicate or orphaned row is visible (#1402)
 - `workflow_open` no longer reports a false content mismatch on `definitions` when the frontend renumbered subgraph NODE ids during the load: the relabeling is proven (same nodes in the same order, links and promoted widgets patched through one injective map) rather than tolerated, and it still refuses when a root node promotes a widget from a node the relabeling touched (artokun/comfyui-mcp#1706)
 - a panel tab whose bridge ROUTE went stale re-advertises itself instead of waiting for a browser refresh: the 600 ms workflow poll now watches the route the orchestrator keys its tab registry on, not only the workflow-instance fence identity, so a re-hello that did not land after a switch, a first save or a rename is retried (bounded) rather than leaving every graph call addressed at a tab id nothing answers to (#1389)
 

--- a/browser_tests/unit/summarize-duplicate-widgets.test.mjs
+++ b/browser_tests/unit/summarize-duplicate-widgets.test.mjs
@@ -1,0 +1,132 @@
+/**
+ * #1402 — summarizeNode last-wins-collapses widgets that share a name.
+ *
+ * Reported: rgthree's Fast Groups Bypasser names every toggle row
+ * `RGTHREE_TOGGLE_AND_NAV`. A node rendering two rows both labelled
+ * "Enable MODEL FL2" and both on was read by panel_query_graph
+ * {fields:'detail'} as a single healthy-looking
+ * `widgets: { RGTHREE_TOGGLE_AND_NAV: { toggled: false } }` — the last
+ * row only. The duplicate was invisible, so the agent told the user the
+ * node's data was correct when it was not.
+ *
+ * The name-keyed `widgets` map stays last-wins for addressing/back-compat.
+ * When a name actually repeats, `duplicate_widgets` lists every occurrence
+ * in canvas order. An unaffected node's payload omits the key entirely.
+ *
+ * Drives the shipped summarizeNode extracted from the panel, with the same
+ * helpers it closes over in production — not a reimplementation.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import { displayLabel, boundaryInputLabel, widgetLabelMap } from "../../web/js/lib/slot-labels.js";
+import { virtualFedInputs } from "../../web/js/lib/virtual-source-promotion.js";
+import { controlAfterGenerateModes } from "../../web/js/lib/control-after-generate.js";
+import { drivenWidgetsFor } from "../../web/js/lib/graph-read.js";
+
+const PANEL_JS = fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url));
+const TOGGLE = "RGTHREE_TOGGLE_AND_NAV";
+const BYPASSER = "Fast Groups Bypasser (rgthree)";
+
+/** Brace-balanced extract so a later nested block cannot truncate the function. */
+function namedFunctionSource(src, name) {
+  const start = src.indexOf(`function ${name}(`);
+  if (start === -1) return null;
+  const open = src.indexOf(") {", start) + 2;
+  let depth = 0;
+  for (let i = open; i < src.length; i += 1) {
+    if (src[i] === "{") depth += 1;
+    if (src[i] === "}" && --depth === 0) return src.slice(start, i + 1);
+  }
+  return null;
+}
+
+const summarizeNode = (() => {
+  const src = readFileSync(PANEL_JS, "utf8");
+  const fn = namedFunctionSource(src, "summarizeNode");
+  assert.ok(fn, "summarizeNode not found in panel source");
+  return new Function(
+    "virtualFedInputs",
+    "boundaryInputLabel",
+    "displayLabel",
+    "widgetLabelMap",
+    "controlAfterGenerateModes",
+    "drivenWidgetsFor",
+    `${fn}; return summarizeNode;`,
+  )(
+    virtualFedInputs,
+    boundaryInputLabel,
+    displayLabel,
+    widgetLabelMap,
+    controlAfterGenerateModes,
+    drivenWidgetsFor,
+  );
+})();
+
+/** The reporter's Fast Groups node: two toggle rows sharing one name. */
+function bypasser(widgets) {
+  return {
+    id: 47,
+    type: BYPASSER,
+    title: BYPASSER,
+    widgets,
+    inputs: [],
+    outputs: [],
+  };
+}
+
+test("#1402 both Fast Groups toggle rows are visible, not last-wins collapsed", () => {
+  const fl2 = { name: TOGGLE, label: "Enable MODEL FL2", value: { toggled: true } };
+  const ref = { name: TOGGLE, label: "Enable MODEL REF", value: { toggled: false } };
+  const node = bypasser([
+    { name: "matchTitle", value: "^MODEL (FL2|REF)$" },
+    fl2,
+    ref,
+  ]);
+
+  const summary = summarizeNode(node);
+
+  // Addressing map stays last-wins so existing callers still key by name.
+  assert.equal(summary.widgets[TOGGLE], ref.value);
+
+  const listed = summary.duplicate_widgets?.[TOGGLE];
+  assert.ok(Array.isArray(listed), "a repeating name is signalled, not silently dropped");
+  assert.equal(listed.length, 2, "every same-named row is listed");
+  assert.equal(listed[0].value, fl2.value, "the first row's value is the widget's own value");
+  assert.equal(listed[1].value, ref.value, "the last row's value is still listed, not only in the map");
+  assert.equal(listed[0].label, fl2.label);
+  assert.equal(listed[1].label, ref.label);
+  // Canvas-order indices into node.widgets, so a reader can tell the rows apart.
+  assert.equal(listed[0].index, 1);
+  assert.equal(listed[1].index, 2);
+});
+
+test("#1402 a name that does not repeat omits duplicate_widgets entirely", () => {
+  const node = bypasser([
+    { name: "matchTitle", value: "^MODEL" },
+    { name: "matchColors", value: "" },
+  ]);
+  const summary = summarizeNode(node);
+  assert.equal("duplicate_widgets" in summary, false);
+  assert.equal(summary.widgets.matchTitle, node.widgets[0].value);
+  assert.equal(summary.widgets.matchColors, node.widgets[1].value);
+});
+
+test("#1402 index is the live widgets[] slot, not a filtered-name compact index", () => {
+  const a = { name: TOGGLE, value: { toggled: true } };
+  const b = { name: TOGGLE, value: { toggled: false } };
+  const node = bypasser([
+    { name: "matchTitle", value: "^MODEL" },
+    { value: "unnamed preview" },
+    a,
+    b,
+  ]);
+  const listed = summarizeNode(node).duplicate_widgets[TOGGLE];
+  assert.equal(listed.length, 2);
+  assert.equal(node.widgets[listed[0].index], a);
+  assert.equal(node.widgets[listed[1].index], b);
+  assert.equal("label" in listed[0], false, "no invented label when the widget carries none");
+  assert.equal("label" in listed[1], false);
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -9742,8 +9742,32 @@ async function revertGraphSnapshotByMid(mid) {
  *  (positions, colors, internal state) to keep token cost low. */
 function summarizeNode(node) {
   const widgets = {};
-  for (const w of node.widgets ?? []) {
-    if (w && typeof w.name === "string") widgets[w.name] = w.value;
+  const namedWidgets = [];
+  const list = node.widgets ?? [];
+  for (let i = 0; i < list.length; i++) {
+    const w = list[i];
+    if (!w || typeof w.name !== "string") continue;
+    widgets[w.name] = w.value;
+    namedWidgets.push({ index: i, w });
+  }
+  // #1402: several widgets can legitimately share ONE name — every toggle row of
+  // rgthree's Fast Groups Bypasser/Muter is named `RGTHREE_TOGGLE_AND_NAV`. The
+  // name-keyed map above is LAST-WINS, so those rows collapse into a single entry
+  // and the read reports one row's state as if it were the whole node's, hiding
+  // duplicated or orphaned rows completely. Surface every occurrence, in canvas
+  // order, whenever a name repeats, so a collapsed row is visible instead of
+  // silently dropped.
+  const nameCounts = new Map();
+  for (const { w } of namedWidgets) nameCounts.set(w.name, (nameCounts.get(w.name) ?? 0) + 1);
+  const duplicateWidgets = {};
+  for (const { index, w } of namedWidgets) {
+    if ((nameCounts.get(w.name) ?? 0) < 2) continue;
+    const label = displayLabel(w);
+    (duplicateWidgets[w.name] ??= []).push({
+      index,
+      ...(label != null ? { label } : {}),
+      value: w.value,
+    });
   }
   // #1181: promoted inputs on a subgraph container whose link origin is a
   // frontend-only VIRTUAL source (e.g. a canvas PrimitiveNode). graphToPrompt
@@ -9851,6 +9875,9 @@ function summarizeNode(node) {
     // widgets only. Address widgets by the KEY (the name); `widget_labels` exists so a
     // rename is visible instead of looking like it did not stick.
     ...(Object.keys(widgetLabels).length ? { widget_labels: widgetLabels } : {}),
+    // #1402: names carried by MORE THAN ONE widget, with each occurrence's value/label.
+    // The name-keyed `widgets` map can only hold the last of them; this is every row.
+    ...(Object.keys(duplicateWidgets).length ? { duplicate_widgets: duplicateWidgets } : {}),
     // #607: names here are OVERRIDDEN by a link at run time — the value in `widgets`
     // is the stale stored value, NOT what executes. Each entry names the source.
     ...(Object.keys(drivenByLink).length ? { driven_by_link: drivenByLink } : {}),


### PR DESCRIPTION
Fixes #1402.

## What the reporter hit

`summarizeNode()` (the `panel_query_graph {fields:'detail'}` payload) built
`widgets` as a name-keyed object. Widget names are not unique: rgthree's Fast
Groups Bypasser/Muter names every toggle row `RGTHREE_TOGGLE_AND_NAV`. A node
rendering two rows both labelled `Enable MODEL FL2` and both on was read as a
single healthy-looking entry — last-wins, the other row silently dropped.

That read is what made the bug costly: the agent told the user the node's data
was correct and only the canvas draw was stale, which was the opposite of
what was true.

## The change

The name-keyed `widgets` map is unchanged (addressing / back-compat). When a
name actually repeats, `duplicate_widgets` lists every occurrence in canvas
order (`index`, `label` when distinct, `value`). An unaffected node's payload
omits the key entirely.

## Proof

The shipped `summarizeNode` is extracted from the panel and driven with the
same helpers it closes over in production:

- two Fast Groups toggle rows: both values and labels visible; `widgets` still last-wins
- unique names: `duplicate_widgets` is absent
- `index` is the live `node.widgets[]` slot (not a filtered-name compact index)

```
node --test --test-concurrency=4 \
  browser_tests/unit/summarize-duplicate-widgets.test.mjs \
  browser_tests/unit/slot-labels.test.mjs \
  browser_tests/unit/rgthree-fast-groups.test.mjs \
  browser_tests/unit/graph-read.test.mjs \
  browser_tests/unit/changelog-integrity.test.mjs
```

69 pass, 0 fail.

`panel_graph_outline` compact still uses the same name-keyed shape; that
blind spot is called out on the issue as a follow-up and is not this PR.
