### PR TITLE
fix(1404): refresh_nodes takes a command budget, so a contended refresh replies instead of timing out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+### Fixed
+- `panel_refresh_nodes` no longer times out with no acknowledgement when a node-def refresh is already running: `refresh_nodes` was the one command relayed in the orchestrator's 30 s window that never took a command budget, so a forced call waited unbounded on the in-flight run AND on its own trailing run — past the window, so the reply the panel's bounds exist to produce never left the tab and the user got `did not reply … the ComfyUI tab may be backgrounded or frozen` about a healthy, idle tab. It now bounds that wait at 25 s (the same budget `graph_add_node` and `nodes_install` hold against the same window) and answers `refreshed:false` with `reason:"refresh_still_running"` and a retry that works — the abandoned run is not cancelled, so it is still registering the definitions the call asked for (#1404)
+
 ## [0.15.6] - 2026-08-19
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,13 @@ All notable changes to this project are documented here. This project adheres to
 ## [Unreleased]
 
 ### Fixed
-- `panel_refresh_nodes` no longer times out with no acknowledgement when a node-def refresh is already running: `refresh_nodes` was the one command relayed in the orchestrator's 30 s window that never took a command budget, so a forced call waited unbounded on the in-flight run AND on its own trailing run — past the window, so the reply the panel's bounds exist to produce never left the tab and the user got `did not reply … the ComfyUI tab may be backgrounded or frozen` about a healthy, idle tab. It now bounds that wait at 25 s (the same budget `graph_add_node` and `nodes_install` hold against the same window) and answers `refreshed:false` with `reason:"refresh_still_running"` and a retry that works — the abandoned run is not cancelled, so it is still registering the definitions the call asked for (#1404)
+- `panel_refresh_nodes` no longer times out with no acknowledgement when a node-def refresh is already running: of the six commands relayed in the orchestrator's 30 s window only `graph_add_node` and `nodes_install` held a command budget, and `refresh_nodes` — whose whole body IS a wait on the node-def refresh — did not, so a forced call waited unbounded on the in-flight run AND on its own trailing run — past the window, so the reply the panel's bounds exist to produce never left the tab and the user got `did not reply … the ComfyUI tab may be backgrounded or frozen` about a healthy, idle tab. It now bounds that wait at 25 s (the same budget `graph_add_node` and `nodes_install` hold against the same window) and answers `refreshed:false` with `reason:"refresh_still_running"` and a retry that works — the abandoned run is not cancelled, so it is still registering the definitions the call asked for (#1404)
 
 ## [0.15.6] - 2026-08-19
 
 ### Fixed
 - `panel_query_graph` (fields:'detail') no longer last-wins-collapses widgets that share a name: when a name repeats (rgthree Fast Groups toggle rows), every occurrence is listed so a duplicate or orphaned row is visible (#1402) (#1406)
 - `duplicate_widgets` (the #1402 duplicate-widget report) no longer throws the whole detail read away on a widget named `__proto__`/`constructor`/`toString` — occurrences are accumulated prototype-safely — and is now bounded by the same `max_chars` budget as `widgets` (dropped occurrences are announced with the lever that lifts them, never silently lost), so a many-group Fast Groups Bypasser cannot push the detail line into a whole-row stub. `panel_graph_outline` also labels each same-named row from the widget itself rather than a last-wins name-keyed map, so two different group toggles are no longer both annotated with the last row's label (#1402) (#1405)
-
 
 ## [0.15.5] - 2026-08-19
 

--- a/browser_tests/unit/_panel-constants.mjs
+++ b/browser_tests/unit/_panel-constants.mjs
@@ -15,6 +15,7 @@ import { fileURLToPath } from "node:url";
 
 import { makeCommandBudget } from "../../web/js/lib/command-budget.js";
 import { REFRESH_JOIN_ABANDONED } from "../../web/js/lib/refresh-coalesce.js";
+import { NODE_DEF_REFRESH_REASONS } from "../../web/js/lib/node-def-refresh.js";
 import { clearInheritedExecutionPreview } from "../../web/js/lib/execution-preview-attach.js";
 import { sanitizeNodeAuxId } from "../../web/js/lib/aux-id-sanitize.js";
 
@@ -67,6 +68,25 @@ export const REFRESH_NODES_COMMAND_BUDGET_MS = readPanelNumber(
   /const REFRESH_NODES_COMMAND_BUDGET_MS = (\d+);/,
   "the refresh_nodes command budget",
 );
+
+/**
+ * #1404 — every module binding the `refresh_nodes` executor closes over, BESIDES the
+ * `refreshComfyNodeDefs` each harness supplies its own double for.
+ *
+ * THREE harnesses rebuild that executor in a synthetic scope (node-def-refresh,
+ * refresh-graph-guard, refresh-nodes-command-budget), so a new free identifier in it throws
+ * `ReferenceError` in all three at once — which is exactly how adding the budget was found.
+ * Collected here for the same reason `addNodeCommandBudgetDeps` exists: so the next binding
+ * is added once rather than three times.
+ *
+ * The REAL values — the symbol and the reason vocabulary are imported and the number is read
+ * from the panel source — so no harness can pass against a value the panel no longer holds.
+ */
+export const REFRESH_NODES_EXECUTOR_DEPS = Object.freeze({
+  REFRESH_JOIN_ABANDONED,
+  NODE_DEF_REFRESH_REASONS,
+  REFRESH_NODES_COMMAND_BUDGET_MS,
+});
 
 export const NODE_DEFS_FETCH_TIMEOUT_MS = readPanelNumber(
   /const NODE_DEFS_FETCH_TIMEOUT_MS = (\d+);/,

--- a/browser_tests/unit/_panel-constants.mjs
+++ b/browser_tests/unit/_panel-constants.mjs
@@ -62,6 +62,12 @@ export const ADD_NODE_COMMAND_BUDGET_MS = readPanelNumber(
   "the add_node command budget",
 );
 
+/** #1404 — the whole-command deadline `refresh_nodes` hands the coalescer as `joinMs`. */
+export const REFRESH_NODES_COMMAND_BUDGET_MS = readPanelNumber(
+  /const REFRESH_NODES_COMMAND_BUDGET_MS = (\d+);/,
+  "the refresh_nodes command budget",
+);
+
 export const NODE_DEFS_FETCH_TIMEOUT_MS = readPanelNumber(
   /const NODE_DEFS_FETCH_TIMEOUT_MS = (\d+);/,
   "the single-call fetch bound",

--- a/browser_tests/unit/add-node-schema-drift-recovery.test.mjs
+++ b/browser_tests/unit/add-node-schema-drift-recovery.test.mjs
@@ -73,7 +73,9 @@ test("refresh_nodes really does re-register the class this check reads", () => {
   // chain: refresh_nodes -> refreshComfyNodeDefs(force) -> getNodeDefs +
   // registerNodesFromDefs.
   const fn = PANEL.slice(PANEL.indexOf("async refresh_nodes() {"), PANEL.indexOf("graph_serialize() {"));
-  assert.ok(fn.includes("refreshComfyNodeDefs(undefined, { force: true })"));
+  // #1404 gave the call a `joinMs`, so it no longer fits on one line. Matched as the chain
+  // this test is about — a FORCED call into the coalescer — rather than as a formatting.
+  assert.match(fn, /refreshComfyNodeDefs\(undefined, \{[\s\S]*?force: true,?[\s\S]*?\}\)/);
   const register = PANEL.slice(
     PANEL.indexOf("async function registerComfyNodeDefs"),
     PANEL.indexOf("const refreshComfyNodeDefs = makeRefreshCoalescer"),

--- a/browser_tests/unit/node-def-refresh.test.mjs
+++ b/browser_tests/unit/node-def-refresh.test.mjs
@@ -26,6 +26,7 @@ import {
   NODE_DEFS_FETCH_TIMEOUT_MS,
   NODE_DEFS_NO_ANSWER,
   NODE_DEFS_RUN_BUDGET_MS,
+  REFRESH_NODES_EXECUTOR_DEPS,
   monotonicNow,
   nodeDefsBudgetLeft,
 } from "./_panel-constants.mjs";
@@ -277,11 +278,16 @@ function buildRefreshNodes(refreshImpl) {
   }
   assert.notEqual(end, -1, "could not bound the refresh_nodes executor body");
   const body = SRC.slice(start, end + 1);
+  // #1404 — every OTHER module binding the executor closes over, from the one place that
+  // holds them (REFRESH_NODES_EXECUTOR_DEPS), so a new one is added once for all three
+  // harnesses rather than three times.
+  const extra = Object.entries(REFRESH_NODES_EXECUTOR_DEPS);
   const factory = new Function(
     "refreshComfyNodeDefs",
+    ...extra.map(([name]) => name),
     `return (${body.replace(/^async refresh_nodes\(\)/, "async function refresh_nodes()")});`,
   );
-  return factory(refreshImpl);
+  return factory(refreshImpl, ...extra.map(([, value]) => value));
 }
 
 test("#635: the shipping executor returns reason + remedy when the refresh is not fresh", async () => {

--- a/browser_tests/unit/refresh-graph-guard.test.mjs
+++ b/browser_tests/unit/refresh-graph-guard.test.mjs
@@ -38,6 +38,7 @@ import {
 } from "../../web/js/lib/node-def-refresh.js";
 import { fetchNodeDefsWithRetry, OBJECT_INFO_RETRY_DELAYS_MS } from "../../web/js/lib/object-info-retry.js";
 import { withTimeout } from "../../web/js/lib/bounded-step.js";
+import { REFRESH_NODES_EXECUTOR_DEPS } from "./_panel-constants.mjs";
 import {
   COMBO_NO_ANSWER,
   COMBO_OK,
@@ -442,11 +443,16 @@ function buildRefreshNodes(refreshImpl) {
   }
   assert.notEqual(end, -1, "could not bound the refresh_nodes executor body");
   const body = SRC.slice(start, end + 1);
+  // #1404 — every OTHER module binding the executor closes over, from the one place that
+  // holds them (REFRESH_NODES_EXECUTOR_DEPS), so a new one is added once for all three
+  // harnesses rather than three times.
+  const extra = Object.entries(REFRESH_NODES_EXECUTOR_DEPS);
   const factory = new Function(
     "refreshComfyNodeDefs",
+    ...extra.map(([name]) => name),
     `return (${body.replace(/^async refresh_nodes\(\)/, "async function refresh_nodes()")});`,
   );
-  return factory(refreshImpl);
+  return factory(refreshImpl, ...extra.map(([, value]) => value));
 }
 
 test("#1275: restored_nodes survive the executor's success-branch whitelist", async () => {

--- a/browser_tests/unit/refresh-nodes-command-budget.test.mjs
+++ b/browser_tests/unit/refresh-nodes-command-budget.test.mjs
@@ -21,12 +21,13 @@ import test from "node:test";
 import assert from "node:assert/strict";
 
 import { withTimeout } from "../../web/js/lib/bounded-step.js";
-import { makeRefreshCoalescer, REFRESH_JOIN_ABANDONED } from "../../web/js/lib/refresh-coalesce.js";
+import { makeRefreshCoalescer } from "../../web/js/lib/refresh-coalesce.js";
 import { NODE_DEF_REFRESH_REASONS } from "../../web/js/lib/node-def-refresh.js";
 import {
   PANEL_SRC,
   ADD_NODE_COMMAND_BUDGET_MS,
   REFRESH_NODES_COMMAND_BUDGET_MS,
+  REFRESH_NODES_EXECUTOR_DEPS,
 } from "./_panel-constants.mjs";
 
 const refreshNodesMatch = PANEL_SRC.match(/\n {2}async refresh_nodes\(\) \{[\s\S]*?\n {2}\},/);
@@ -76,8 +77,9 @@ function realRefreshNodes({
 
   const deps = {
     refreshComfyNodeDefs,
-    REFRESH_JOIN_ABANDONED,
-    NODE_DEF_REFRESH_REASONS,
+    // Every other binding from the one place that holds them, so this harness picks up a
+    // new one automatically — then the budget, injected small, LAST so it wins.
+    ...REFRESH_NODES_EXECUTOR_DEPS,
     REFRESH_NODES_COMMAND_BUDGET_MS: budgetMs,
   };
   const names = Object.keys(deps);

--- a/browser_tests/unit/refresh-nodes-command-budget.test.mjs
+++ b/browser_tests/unit/refresh-nodes-command-budget.test.mjs
@@ -1,0 +1,282 @@
+// panel#1404 — `panel_refresh_nodes` timed out with no acknowledgement for 30 s against a
+// ComfyUI that stayed healthy and idle, and the IDENTICAL call succeeded on the retry.
+//
+// The reply was not lost in transit. It was never COMPOSED inside the window: `refresh_nodes`
+// is relayed at comfyui-mcp's `OBJECT_INFO_REFRESH_ACK_TIMEOUT_MS` (30,000 ms) and was the
+// only command relayed there that never took a command budget, so its forced coalescer call
+// waited unbounded on an in-flight run AND on the trailing run queued behind it. Each run is
+// ~14.5 s wall clock on the #610 install (NODE_DEFS_RUN_BUDGET_MS bounds only the WAITING it
+// controls and stops its clock across `registerNodesFromDefs`), and two of them do not fit.
+// The retry succeeds because by then the trailing run has settled and it pays for ONE.
+//
+// THE HARNESS RUNS THE SHIPPED `refresh_nodes` BODY, extracted from the panel source and
+// given injected collaborators, over the REAL coalescer with a REAL in-flight run — the same
+// technique as add-node-command-budget.test.mjs, and for the same reason. A helper-level test
+// cannot reach this defect: `makeRefreshCoalescer` already accepts `joinMs` and already
+// implements it correctly (#1192/#1351), and `refresh_nodes` already handled a non-fresh
+// verdict. The whole bug was that the call site passed no bound. Only an assertion on THAT
+// CALL SITE can see it — which is why every test below drives the extracted executor rather
+// than the coalescer directly, and why deleting `joinMs` from the panel makes them fail.
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { withTimeout } from "../../web/js/lib/bounded-step.js";
+import { makeRefreshCoalescer, REFRESH_JOIN_ABANDONED } from "../../web/js/lib/refresh-coalesce.js";
+import { NODE_DEF_REFRESH_REASONS } from "../../web/js/lib/node-def-refresh.js";
+import {
+  PANEL_SRC,
+  ADD_NODE_COMMAND_BUDGET_MS,
+  REFRESH_NODES_COMMAND_BUDGET_MS,
+} from "./_panel-constants.mjs";
+
+const refreshNodesMatch = PANEL_SRC.match(/\n {2}async refresh_nodes\(\) \{[\s\S]*?\n {2}\},/);
+assert.ok(refreshNodesMatch, "could not locate refresh_nodes in panel source");
+
+/** A tiny deferred so a test can hold the in-flight refresh open until it chooses. */
+function deferred() {
+  let resolve;
+  const promise = new Promise((r) => (resolve = r));
+  return { promise, resolve };
+}
+
+/**
+ * Build the SHIPPED `refresh_nodes` with the REAL coalescer behind it.
+ *
+ * `budgetMs` is injected small so these tests run in milliseconds rather than waiting out the
+ * shipped 25 s. Same code, same arithmetic, shorter deadline — the shipped NUMBER is pinned
+ * separately, against the relay window, at the bottom of this file.
+ *
+ * `holdFirstRun` is a promise the FIRST run waits on before it registers anything. That run
+ * is the one this panel starts for itself — a reconnect, a finished download, or the
+ * missing-asset check that an upload triggers — and it is holding the coalescer's slot when
+ * the tool call arrives. Held open, it is the reported scenario exactly.
+ */
+function realRefreshNodes({
+  holdFirstRun = null,
+  budgetMs = 150,
+  verdicts = [{ refreshed: true, reason: "refreshed" }],
+} = {}) {
+  let inFlight = null;
+  const runs = [];
+  const refreshComfyNodeDefs = makeRefreshCoalescer({
+    getInFlight: () => inFlight,
+    setInFlight: (p) => {
+      inFlight = p;
+    },
+    runRegister: async () => {
+      const index = runs.length;
+      runs.push(index);
+      if (index === 0 && holdFirstRun) await holdFirstRun;
+      return verdicts[Math.min(index, verdicts.length - 1)];
+    },
+    withTimeout,
+  });
+  // A refresh THIS PANEL started — not the tool call — already holding the slot.
+  const inFlightStarted = holdFirstRun ? refreshComfyNodeDefs(undefined, { force: true }) : null;
+
+  const deps = {
+    refreshComfyNodeDefs,
+    REFRESH_JOIN_ABANDONED,
+    NODE_DEF_REFRESH_REASONS,
+    REFRESH_NODES_COMMAND_BUDGET_MS: budgetMs,
+  };
+  const names = Object.keys(deps);
+  const factory = new Function(
+    ...names,
+    `const executors = {${refreshNodesMatch[0]}};
+     return executors.refresh_nodes;`,
+  );
+  return {
+    refresh_nodes: factory(...names.map((n) => deps[n])),
+    refreshComfyNodeDefs,
+    getInFlight: () => inFlight,
+    runs,
+    inFlightStarted,
+  };
+}
+
+/**
+ * Await `run()` but FAIL LOUDLY rather than hang if the budget never reaches the coalescer.
+ *
+ * Without the fix this call resolves only once the held run releases, which is the whole
+ * defect — and a test that simply awaited it would sit there being slow instead of red. The
+ * elapsed time is returned so the caller can assert the bound was the thing that ended it.
+ */
+async function withWatchdog(run, ms, what) {
+  let timer;
+  const startedAt = Date.now();
+  const watchdog = new Promise((_, reject) => {
+    timer = setTimeout(() => reject(new Error(`${what} — waited ${ms}ms`)), ms);
+  });
+  try {
+    const value = await Promise.race([run(), watchdog]);
+    return { value, elapsed: Date.now() - startedAt };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 1. The reported shape: a run already in flight, and the tool call behind it.
+// ---------------------------------------------------------------------------
+
+test("#1404: refresh_nodes REPLIES at its budget instead of waiting two runs out", async () => {
+  const gate = deferred();
+  const built = realRefreshNodes({ holdFirstRun: gate.promise, budgetMs: 150 });
+
+  const { value, elapsed } = await withWatchdog(
+    () => built.refresh_nodes(),
+    1500,
+    "refresh_nodes never replied: the command budget is not reaching the coalescer, so the " +
+      "forced call is waiting for a run someone else started PLUS its own — the composition " +
+      "that does not fit the 30,000 ms relay window",
+  );
+
+  assert.equal(value.ok, true, "nothing failed, so the command still succeeds");
+  assert.equal(value.refreshed, false, "…but it must not claim a refresh it never confirmed");
+  assert.ok(
+    elapsed < 1000,
+    `replied in ${elapsed}ms — the reply must be composed at the bound, not after the run`,
+  );
+
+  gate.resolve();
+  await built.inFlightStarted?.catch(() => {});
+});
+
+test("#1404: the reply NAMES the cause instead of collapsing it into 'unknown'", async () => {
+  const gate = deferred();
+  const built = realRefreshNodes({ holdFirstRun: gate.promise, budgetMs: 150 });
+
+  const { value } = await withWatchdog(() => built.refresh_nodes(), 1500, "refresh_nodes never replied");
+
+  // The STRUCTURED field is the load-bearing part. A caller must never have to parse prose to
+  // decide it may re-issue a command, and "unknown" — what the generic branch produces for a
+  // Symbol — would make a refresh that is still running indistinguishable from a fetch that
+  // threw, which is the one distinction a caller deciding whether to retry actually needs.
+  assert.equal(value.reason, NODE_DEF_REFRESH_REASONS.REFRESH_STILL_RUNNING);
+  assert.notEqual(value.reason, "unknown", "an abandoned wait is not an unknown failure");
+  assert.match(value.remedy, /RETRY/, "…and the remedy is a retry");
+  assert.ok(!/reload/i.test(value.remedy), "…not a tab reload, which throws away canvas state");
+  assert.match(
+    value.detail,
+    /[Nn]othing failed/,
+    "the caller must know nothing was left half-done before it retries",
+  );
+
+  gate.resolve();
+  await built.inFlightStarted?.catch(() => {});
+});
+
+test("#1404: the abandoned run is NOT cancelled, and the retry it asks for succeeds", async () => {
+  // This is why the remedy is honest rather than hopeful, and it is also the reporter's
+  // observation: the identical call succeeded on the second attempt. The coalescer does not
+  // cancel what it stopped waiting for, so the retry pays for ONE run rather than two.
+  const gate = deferred();
+  const built = realRefreshNodes({
+    holdFirstRun: gate.promise,
+    budgetMs: 150,
+    verdicts: [{ refreshed: true, reason: "refreshed" }],
+  });
+
+  const first = await withWatchdog(() => built.refresh_nodes(), 1500, "refresh_nodes never replied");
+  assert.equal(first.value.refreshed, false);
+  assert.notEqual(built.getInFlight(), null, "the run this call abandoned still holds the slot");
+
+  gate.resolve();
+  await built.inFlightStarted?.catch(() => {});
+
+  const second = await withWatchdog(
+    () => built.refresh_nodes(),
+    1500,
+    "the retry the remedy prescribes never replied either",
+  );
+  assert.deepEqual(second.value, { ok: true, refreshed: true });
+});
+
+// ---------------------------------------------------------------------------
+// 2. What the bound must NOT break.
+// ---------------------------------------------------------------------------
+
+test("#1404: an uncontended refresh still reports its real verdict, disclosures included", async () => {
+  // The bound is a deadline for waiting, not a shortcut past the answer. #981/#1172/#1193/#1275
+  // each had to be forwarded through this executor's fixed object literal; a budget that
+  // dropped one of them would re-silence exactly the disclosure it was added for.
+  const built = realRefreshNodes({
+    budgetMs: 5000,
+    verdicts: [
+      {
+        refreshed: true,
+        reason: "refreshed",
+        requires_reload: true,
+        stale_placeholders: ["LoadImage#7"],
+        stale_placeholders_note: "note",
+        empty_combo_lists: ["ckpt_name"],
+        empty_combo_lists_note: "empty note",
+        restored_nodes: ["3"],
+        restored_nodes_note: "restored note",
+        combo_refresh_confirmed: false,
+        combo_refresh_note: "combo note",
+      },
+    ],
+  });
+
+  const { value } = await withWatchdog(() => built.refresh_nodes(), 2000, "refresh_nodes never replied");
+  assert.equal(value.refreshed, true);
+  assert.equal(value.requires_reload, true);
+  assert.deepEqual(value.stale_placeholders, ["LoadImage#7"]);
+  assert.deepEqual(value.empty_combo_lists, ["ckpt_name"]);
+  assert.deepEqual(value.restored_nodes, ["3"]);
+  assert.equal(value.combo_refresh_confirmed, false);
+});
+
+test("#1404: a run that genuinely FAILED still reports its own reason, not the new one", async () => {
+  // The two states must stay distinguishable in BOTH directions. A budget that reported
+  // `refresh_still_running` for a fetch that threw would send the caller to retry forever
+  // against a backend that is down — the mirror image of the bug this fixes.
+  const built = realRefreshNodes({
+    budgetMs: 5000,
+    verdicts: [
+      {
+        refreshed: false,
+        reason: NODE_DEF_REFRESH_REASONS.OBJECT_INFO_FETCH_FAILED,
+        remedy: "check that ComfyUI is running",
+      },
+    ],
+  });
+
+  const { value } = await withWatchdog(() => built.refresh_nodes(), 2000, "refresh_nodes never replied");
+  assert.equal(value.reason, NODE_DEF_REFRESH_REASONS.OBJECT_INFO_FETCH_FAILED);
+  assert.equal(value.remedy, "check that ComfyUI is running");
+});
+
+// ---------------------------------------------------------------------------
+// 3. The shipped number, against the window it exists for.
+// ---------------------------------------------------------------------------
+
+test("#1404: the shipped budget leaves the relay window room to carry the reply", () => {
+  // comfyui-mcp relays `refresh_nodes` at OBJECT_INFO_REFRESH_ACK_TIMEOUT_MS = 30,000 ms. That
+  // constant lives in the OTHER repo, so this asserts the property this repo can keep true:
+  // the budget is the SAME number `graph_add_node` and `nodes_install` already derived against
+  // that window, so the three cannot drift into disagreeing about what "too long" means.
+  assert.equal(
+    REFRESH_NODES_COMMAND_BUDGET_MS,
+    ADD_NODE_COMMAND_BUDGET_MS,
+    "the two commands relayed in the same window must hold the same budget",
+  );
+  assert.ok(
+    REFRESH_NODES_COMMAND_BUDGET_MS > 0 && REFRESH_NODES_COMMAND_BUDGET_MS <= 25000,
+    "a budget at or over the relay window would restore the bug it exists to prevent",
+  );
+});
+
+test("#1404: the shipped call site passes the budget — the helper alone cannot prove this", () => {
+  // `makeRefreshCoalescer` has accepted `joinMs` since #1192 and implements it correctly; the
+  // whole of #1404 was that this one call site never passed it. A behavioural test drives the
+  // extracted body, so it already covers the wiring — this is the same fact asserted where a
+  // reviewer reading the diff will look for it, on the SOURCE.
+  assert.match(
+    refreshNodesMatch[0],
+    /refreshComfyNodeDefs\(undefined, \{\s*force: true,\s*joinMs: REFRESH_NODES_COMMAND_BUDGET_MS,\s*\}\)/,
+    "refresh_nodes must bound its own wait on the coalescer",
+  );
+});

--- a/browser_tests/unit/refresh-nodes-command-budget.test.mjs
+++ b/browser_tests/unit/refresh-nodes-command-budget.test.mjs
@@ -159,6 +159,14 @@ test("#1404: the reply NAMES the cause instead of collapsing it into 'unknown'",
   // decide it may re-issue a command, and "unknown" — what the generic branch produces for a
   // Symbol — would make a refresh that is still running indistinguishable from a fetch that
   // threw, which is the one distinction a caller deciding whether to retry actually needs.
+  // THE LITERAL, not only the map lookup. The panel and this file read the token from the
+  // SAME frozen map, so deleting the entry degrades both to `undefined` together and
+  // `assert.equal(undefined, undefined)` passes — while the shipped reply carries
+  // `reason: undefined`, which `JSON.stringify` DROPS, so the field a caller keys on
+  // vanishes from the wire with all 67 tests in the three refresh harnesses still green.
+  // Measured, not reasoned about: that mutation was run and killed nothing.
+  assert.equal(value.reason, "refresh_still_running", "the WIRE token, spelled out");
+  assert.equal(NODE_DEF_REFRESH_REASONS.REFRESH_STILL_RUNNING, "refresh_still_running");
   assert.equal(value.reason, NODE_DEF_REFRESH_REASONS.REFRESH_STILL_RUNNING);
   assert.notEqual(value.reason, "unknown", "an abandoned wait is not an unknown failure");
   assert.match(value.remedy, /RETRY/, "…and the remedy is a retry");
@@ -227,7 +235,7 @@ test("#1404: an UNCONTENDED run that outlives the budget lands on the same named
     1500,
     "an uncontended slow run never replied",
   );
-  assert.equal(value.reason, NODE_DEF_REFRESH_REASONS.REFRESH_STILL_RUNNING);
+  assert.equal(value.reason, "refresh_still_running");
   assert.equal(built.runs.length, 1, "there was never a second run — nothing else was in flight");
   assert.ok(elapsed < 1000, `replied in ${elapsed}ms — the bound must end this wait too`);
 

--- a/browser_tests/unit/refresh-nodes-command-budget.test.mjs
+++ b/browser_tests/unit/refresh-nodes-command-budget.test.mjs
@@ -54,6 +54,9 @@ function deferred() {
  */
 function realRefreshNodes({
   holdFirstRun = null,
+  // Whether the held run is started BEFORE the tool call (someone else's, holding the slot)
+  // or left for the tool call to start itself (nothing in flight — the uncontended case).
+  startInFlight = true,
   budgetMs = 150,
   verdicts = [{ refreshed: true, reason: "refreshed" }],
 } = {}) {
@@ -73,7 +76,8 @@ function realRefreshNodes({
     withTimeout,
   });
   // A refresh THIS PANEL started — not the tool call — already holding the slot.
-  const inFlightStarted = holdFirstRun ? refreshComfyNodeDefs(undefined, { force: true }) : null;
+  const inFlightStarted =
+    holdFirstRun && startInFlight ? refreshComfyNodeDefs(undefined, { force: true }) : null;
 
   const deps = {
     refreshComfyNodeDefs,
@@ -158,12 +162,24 @@ test("#1404: the reply NAMES the cause instead of collapsing it into 'unknown'",
   assert.equal(value.reason, NODE_DEF_REFRESH_REASONS.REFRESH_STILL_RUNNING);
   assert.notEqual(value.reason, "unknown", "an abandoned wait is not an unknown failure");
   assert.match(value.remedy, /RETRY/, "…and the remedy is a retry");
-  assert.ok(!/reload/i.test(value.remedy), "…not a tab reload, which throws away canvas state");
+  // A tab reload throws away canvas state, so it may only ever be the ESCALATION — named
+  // after the retry, and conditioned on the retry not working. #852/#663: a refusal that
+  // sends the caller to the wrong recovery costs more than the refusal itself.
+  assert.ok(
+    value.remedy.indexOf("RETRY") < value.remedy.search(/reload/i),
+    "reload must come after the retry, never instead of it",
+  );
+  assert.match(value.remedy, /keeps reporting this[\s\S]*reload/i, "…and only if retrying fails");
   assert.match(
     value.detail,
     /[Nn]othing failed/,
     "the caller must know nothing was left half-done before it retries",
   );
+  // BOTH runs. The coalescer returns one symbol whether the budget went on a run someone
+  // else started or on this command's own, so a detail naming only the first would be
+  // flatly wrong on an uncontended big install — the case with no concurrency at all.
+  assert.match(value.detail, /something else started/, "the contended case");
+  assert.match(value.detail, /own registration/, "…and this command's own run");
 
   gate.resolve();
   await built.inFlightStarted?.catch(() => {});
@@ -193,6 +209,29 @@ test("#1404: the abandoned run is NOT cancelled, and the retry it asks for succe
     "the retry the remedy prescribes never replied either",
   );
   assert.deepEqual(second.value, { ok: true, refreshed: true });
+});
+
+test("#1404: an UNCONTENDED run that outlives the budget lands on the same named verdict", async () => {
+  // The other half of the symbol, and the reason the detail names both runs. With nothing in
+  // flight the coalescer takes the last branch — `waitForRun(startRun(…), joinMs)` — so the
+  // budget can run out on a run this command started ITSELF, with no concurrency anywhere.
+  // That is a big install's ordinary case, and a reply that blamed "something else" for it
+  // would be a true-sounding statement about the wrong cause.
+  const gate = deferred();
+  // Held, but NOT pre-started: the slot is empty when the tool call arrives, so the run that
+  // outlives the bound is the one this command started itself.
+  const built = realRefreshNodes({ holdFirstRun: gate.promise, startInFlight: false, budgetMs: 150 });
+
+  const { value, elapsed } = await withWatchdog(
+    () => built.refresh_nodes(),
+    1500,
+    "an uncontended slow run never replied",
+  );
+  assert.equal(value.reason, NODE_DEF_REFRESH_REASONS.REFRESH_STILL_RUNNING);
+  assert.equal(built.runs.length, 1, "there was never a second run — nothing else was in flight");
+  assert.ok(elapsed < 1000, `replied in ${elapsed}ms — the bound must end this wait too`);
+
+  gate.resolve();
 });
 
 // ---------------------------------------------------------------------------

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -10770,16 +10770,24 @@ const GRAPH_TOOL_EXECUTORS = {
         ok: true,
         refreshed: false,
         reason: NODE_DEF_REFRESH_REASONS.REFRESH_STILL_RUNNING,
+        // BOTH RUNS, because the value cannot tell them apart and neither may this sentence.
+        // The coalescer answers with one symbol whether the budget went on a run someone else
+        // started or on the one this command started itself (nothing in flight ⇒ the last
+        // branch of `refresh`), so a message naming only the first would be flatly wrong in
+        // the second case — and it is the case a big install hits without any concurrency at
+        // all. `graph_add_node`'s refusal names both for the same reason.
         detail:
-          `A node-def refresh started by something else — a ComfyUI reconnect, a finished ` +
-          `install or download, or this panel's own missing-asset check after an upload — ` +
-          `was still running, and this command's ` +
-          `${Math.round(REFRESH_NODES_COMMAND_BUDGET_MS / 1000)}s budget ran out waiting ` +
-          `for it. Nothing failed and nothing was changed.`,
+          `A node-def refresh was still running when this command's ` +
+          `${Math.round(REFRESH_NODES_COMMAND_BUDGET_MS / 1000)}s budget ran out waiting for ` +
+          `it — either one something else started (a ComfyUI reconnect, a finished install or ` +
+          `download, this panel's own missing-asset check after an upload) or this command's ` +
+          `own registration. Nothing failed and nothing was changed.`,
         remedy:
-          "That refresh is still running and is fetching exactly the /object_info this call " +
-          "wanted, so RETRY in a few seconds — this normally succeeds on the next attempt " +
-          "because the retry pays for one refresh instead of two.",
+          "That refresh was NOT cancelled — it is still running and still fetching exactly the " +
+          "/object_info this call wanted — so RETRY in a few seconds. A retry that lands after " +
+          "it settles pays for one refresh instead of two, which is normally enough; if it " +
+          "keeps reporting this, the refresh itself is slower than the budget and reloading " +
+          "the ComfyUI tab is the fallback that remains.",
       };
     }
     const refreshed = verdict === true || (verdict != null && typeof verdict === "object" && verdict.refreshed === true);

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -10387,20 +10387,34 @@ const CUSTOM_WIDGET_REGISTRATION_POLL_MS = 25;
 const ADD_NODE_COMMAND_BUDGET_MS = 25000;
 
 /**
- * #1404 — the same budget for `refresh_nodes`, the THIRD command relayed in the 30,000 ms
- * window and the last one that never took one.
+ * #1404 — a command budget for `refresh_nodes`.
+ *
+ * COUNTED, not guessed, because the first draft of this comment guessed and was wrong. SIX
+ * commands are relayed in the orchestrator's 30,000 ms window: `graph_get_object_info`,
+ * `graph_add_node`, `graph_set_widget`, `graph_remove_widget` and `refresh_nodes` through
+ * `OBJECT_INFO_REFRESH_ACK_TIMEOUT_MS`, plus `nodes_install` at a literal 30000. Before this
+ * change only TWO of the six held a command budget — `graph_add_node` (#1192) and
+ * `nodes_install` (#671) — so "the last one that never took one" was false, and the false
+ * version of this sentence concealed a sibling: `graph_set_widget`'s stale-combo recovery
+ * awaits the coalescer with no bound of its own. Filed separately rather than folded in; the
+ * point for a future reader is that this is a RECURRING shape, not a last straggler.
  *
  * REPORTED: after a workflow switch and a successful re-target, `panel_refresh_nodes` got no
  * acknowledgement for 30 s while ComfyUI stayed healthy and idle; the identical call then
  * succeeded on the retry. That is not a lost reply — it is a reply that was never COMPOSED
- * inside the window, and the composition is written down two comments above this one:
- * `makeRefreshCoalescer` guarantees a forced call pays the in-flight run AND its own,
- * serially. Each of those runs is bounded by NODE_DEFS_RUN_BUDGET_MS, which bounds only the
- * WAITING it controls and deliberately stops its clock across `registerNodesFromDefs`
- * (3,972 ms measured) and `reapplyDefsToLiveNodes` — so a run is ~14.5 s wall clock on the
- * #610 install and TWO of them do not fit. `graph_add_node`'s own note says this out loud
- * ("~33 s against the 30 s relay window, with every per-step bound respected"); it fixed the
- * composition for the add and left the tool whose whole body IS that composition unbounded.
+ * inside the window.
+ *
+ * THE COMPOSITION IS ALREADY WRITTEN DOWN, two comments above this one, and that note is the
+ * evidence — not any arithmetic done here. NODE_DEFS_RUN_BUDGET_MS's own docstring says
+ * `makeRefreshCoalescer` "guarantees a forced `panel_refresh_nodes` pays the in-flight run
+ * AND its own, serially, so about 39.6s before a reply is composed. Past the bridge's 20s
+ * READ default and past the 30s command budget both." #1180 shrank the per-run WAITING that
+ * figure was computed from, but it explicitly did NOT bound `registerNodesFromDefs`
+ * (3,972 ms measured) or `reapplyDefsToLiveNodes`, so the composition that note describes
+ * survived it — which is what this issue reports. `graph_add_node`'s note says the same of
+ * its own path ("~33 s against the 30 s relay window, with every per-step bound respected").
+ * #1192/#1351 fixed the composition for the add and left the tool whose whole body IS that
+ * composition unbounded.
  *
  * WHY THE SECOND CALL SUCCEEDS, which is the part that identifies the cause rather than
  * merely fitting it: by then the queued trailing run has settled and the coalescer's slot is

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -245,6 +245,7 @@ import { duplicateWidgetRows } from "./lib/widget-rows.js";
 import { createObjectInfoHistory, awaitHistoryBaseline } from "./lib/object-info-history.js";
 import { makeRefreshCoalescer, REFRESH_JOIN_ABANDONED } from "./lib/refresh-coalesce.js";
 import {
+  NODE_DEF_REFRESH_REASONS,
   describeNodeDefRefresh,
   describeRefreshGraphLoss,
   restoredLiveNodesNote,
@@ -10386,6 +10387,54 @@ const CUSTOM_WIDGET_REGISTRATION_POLL_MS = 25;
 const ADD_NODE_COMMAND_BUDGET_MS = 25000;
 
 /**
+ * #1404 — the same budget for `refresh_nodes`, the THIRD command relayed in the 30,000 ms
+ * window and the last one that never took one.
+ *
+ * REPORTED: after a workflow switch and a successful re-target, `panel_refresh_nodes` got no
+ * acknowledgement for 30 s while ComfyUI stayed healthy and idle; the identical call then
+ * succeeded on the retry. That is not a lost reply — it is a reply that was never COMPOSED
+ * inside the window, and the composition is written down two comments above this one:
+ * `makeRefreshCoalescer` guarantees a forced call pays the in-flight run AND its own,
+ * serially. Each of those runs is bounded by NODE_DEFS_RUN_BUDGET_MS, which bounds only the
+ * WAITING it controls and deliberately stops its clock across `registerNodesFromDefs`
+ * (3,972 ms measured) and `reapplyDefsToLiveNodes` — so a run is ~14.5 s wall clock on the
+ * #610 install and TWO of them do not fit. `graph_add_node`'s own note says this out loud
+ * ("~33 s against the 30 s relay window, with every per-step bound respected"); it fixed the
+ * composition for the add and left the tool whose whole body IS that composition unbounded.
+ *
+ * WHY THE SECOND CALL SUCCEEDS, which is the part that identifies the cause rather than
+ * merely fitting it: by then the queued trailing run has settled and the coalescer's slot is
+ * free, so the retry pays ONE run instead of two. Nothing about the tab, the socket or the
+ * fence differs between the two calls — only the number of runs in front of them.
+ *
+ * WHAT STARTS THE FIRST RUN is not a coincidence of timing either. Two forced,
+ * fire-and-forget refreshes are keyed on `hasRawMissingAssetCandidates()` — the validation
+ * banner's and `graph_get_errors`' — and a just-uploaded input file is exactly what makes
+ * that predicate true. The upload that gives an agent a reason to call this tool is the same
+ * event that makes the panel start its own refresh, so the two race BY CONSTRUCTION.
+ *
+ * 25,000 ms, mirroring ADD_NODE_COMMAND_BUDGET_MS and NODES_INSTALL_COMMAND_BUDGET_MS
+ * against the same 30,000 ms window for the same reason: 5,000 ms of slack for composing the
+ * reply, serialising it, and the websocket hop.
+ *
+ * WHAT IT COSTS, stated rather than left to be discovered. A single UNCONTENDED run that
+ * would have taken between 25 s and 30 s used to reply `refreshed:true` and now reports
+ * `refresh_still_running` instead. That window is 5 s wide, it is past twice the #610
+ * measurement, and the run is not cancelled — it keeps going and keeps the slot, so the
+ * retry the reply asks for joins a registration already in progress. In exchange every
+ * CONTENDED call — the reported bug, which today produces a bare `did not reply … the
+ * ComfyUI tab may be backgrounded or frozen` about a demonstrably healthy tab — gets a
+ * worded verdict that names the cause and a remedy that clears it.
+ *
+ * NOT a `makeCommandBudget`, and that is deliberate rather than an oversight. A command
+ * budget exists so SEVERAL bounded steps compose; `refresh_nodes` has exactly one await and
+ * takes it on its first line, so the coalescer's own `joinMs` deadline — taken at invocation
+ * and spanning the join AND the run that follows it (#1351) — already is that budget. A
+ * second clock here would only be able to disagree with it.
+ */
+const REFRESH_NODES_COMMAND_BUDGET_MS = 25000;
+
+/**
  * #1192 — what an add still has to do AFTER the node-def refresh, held back so the join
  * cannot spend it.
  *
@@ -10694,8 +10743,45 @@ const GRAPH_TOOL_EXECUTORS = {
   // #635: a non-fresh verdict now says WHY (reason) and what to do about it
   // (remedy) — a bare {ok:true, refreshed:false} was indistinguishable from a
   // no-op and left the caller guessing whether the call did anything.
+  // #1404: BOUNDED. This one await is the whole command, and unbounded it is the
+  // composition `graph_add_node`'s budget note describes — a forced call pays an in-flight
+  // run AND its own, serially, which does not fit the 30,000 ms window this command is
+  // relayed in. See REFRESH_NODES_COMMAND_BUDGET_MS.
   async refresh_nodes() {
-    const verdict = await refreshComfyNodeDefs(undefined, { force: true });
+    const verdict = await refreshComfyNodeDefs(undefined, {
+      force: true,
+      joinMs: REFRESH_NODES_COMMAND_BUDGET_MS,
+    });
+    // #1404 — a NAMED verdict, before the generic branch below can call it "unknown".
+    //
+    // NOTHING FAILED and nothing was left half-done: the coalescer does not cancel the run
+    // it stopped waiting for (`waitForRun` in refresh-coalesce.js says so), the run keeps
+    // registering the very definitions this call asked for, and it keeps the slot — so the
+    // retry this reply asks for joins work already in progress rather than starting a
+    // stampede. "unknown" would collapse that into the same answer as a fetch that threw,
+    // which is the one distinction a caller deciding whether to retry actually needs.
+    //
+    // Returned as a STRUCTURED `reason` token, not as wording. A caller must never have to
+    // parse prose to decide it may re-issue a command, and the whole argument for retrying
+    // this one — that `refresh_nodes` re-registers defs and rebuilds combo option lists,
+    // changes no graph and is undo-neutral — rests on the field, not on the sentence.
+    if (verdict === REFRESH_JOIN_ABANDONED) {
+      return {
+        ok: true,
+        refreshed: false,
+        reason: NODE_DEF_REFRESH_REASONS.REFRESH_STILL_RUNNING,
+        detail:
+          `A node-def refresh started by something else — a ComfyUI reconnect, a finished ` +
+          `install or download, or this panel's own missing-asset check after an upload — ` +
+          `was still running, and this command's ` +
+          `${Math.round(REFRESH_NODES_COMMAND_BUDGET_MS / 1000)}s budget ran out waiting ` +
+          `for it. Nothing failed and nothing was changed.`,
+        remedy:
+          "That refresh is still running and is fetching exactly the /object_info this call " +
+          "wanted, so RETRY in a few seconds — this normally succeeds on the next attempt " +
+          "because the retry pays for one refresh instead of two.",
+      };
+    }
     const refreshed = verdict === true || (verdict != null && typeof verdict === "object" && verdict.refreshed === true);
     // #981: the stale-placeholder disclosure has to survive BOTH paths. The producer
     // runs the scan whatever the verdict says — a refresh that failed at the combo phase

--- a/web/js/lib/node-def-refresh.js
+++ b/web/js/lib/node-def-refresh.js
@@ -29,6 +29,15 @@ export const NODE_DEF_REFRESH_REASONS = Object.freeze({
   // be restored. A data-loss verdict: it overrides even a real phase failure,
   // because the lost nodes are the fact the caller must act on first.
   GRAPH_NODES_LOST: "graph_nodes_lost",
+  // #1404 — the ONE token in this map that `describeNodeDefRefresh` never produces,
+  // because it does not describe a run at all: the caller's command budget ran out
+  // WAITING for a refresh (someone else's, then its own), and the run it stopped
+  // waiting for is still going. It lives here anyway, and deliberately: `reason` is a
+  // single vocabulary as far as its reader is concerned, and a value that could only be
+  // found by reading the executor is a value nobody will handle. Distinct from every
+  // token above by the fact that matters to a caller — nothing failed, so a retry is
+  // expected to succeed rather than hoped to.
+  REFRESH_STILL_RUNNING: "refresh_still_running",
 });
 
 function detailSuffix(thrown) {


### PR DESCRIPTION
The underlying cause of #1404 is a reply that was **never composed inside the relay window** — not an acknowledgement lost in transit.

## The mechanism

`panel_refresh_nodes` relays `refresh_nodes` at comfyui-mcp's `OBJECT_INFO_REFRESH_ACK_TIMEOUT_MS` = **30,000 ms** (`src/orchestrator/panel-tools.ts`, the `panel_refresh_nodes` call site) — which is the exact number in the report, good corroboration that it reached dispatch and waited for an ack.

**Six** commands are relayed in that 30 s window — `graph_get_object_info`, `graph_add_node`, `graph_set_widget`, `graph_remove_widget` and `refresh_nodes` through `OBJECT_INFO_REFRESH_ACK_TIMEOUT_MS`, plus `nodes_install` at a literal `30000`. Only **two** of the six held a whole-command budget: `graph_add_node` (#1192) and `nodes_install` (#671). **`refresh_nodes` did not** — and its whole body *is* a wait on the node-def refresh. Its executor was:

```js
const verdict = await refreshComfyNodeDefs(undefined, { force: true });
```

No `joinMs`. `makeRefreshCoalescer`'s forced branch then reads `joinMs === null` and `waitForRun` returns the run unbounded, so the call pays, serially:

1. whatever is left of a run **someone else started**, then
2. the trailing run it queues behind it.

**The evidence that two runs do not fit is a note this repo already wrote, not arithmetic of mine.** `NODE_DEFS_RUN_BUDGET_MS`'s own docstring in `comfyui-mcp-panel.js` says `makeRefreshCoalescer` *"guarantees a forced `panel_refresh_nodes` pays the in-flight run AND its own, serially, so about 39.6s before a reply is composed. Past the bridge's 20s READ default and past the 30s command budget both."* #1180 shrank the per-run WAITING that figure was computed from, but it explicitly did **not** bound `registerNodesFromDefs` (3,972 ms measured) or `reapplyDefsToLiveNodes` — so the composition that note describes survived it, which is exactly what this issue reports. `ADD_NODE_COMMAND_BUDGET_MS`'s note says the same of its own path ("~33 s against the 30 s relay window, with every per-step bound respected"). #1192/#1351 fixed the composition for the add and left the tool whose whole body *is* that composition unbounded.

(An earlier draft argued this as "2 × ~14.5 s ≈ 29 s". That is the weakest form of the argument — 29 s is *inside* 30 s — so it is retired in favour of the pre-existing note above.)

**Why the second call succeeds** — the part that identifies the cause rather than merely fitting it: by then the trailing run has settled and the coalescer's slot is free, so the retry pays for ONE run instead of two. Nothing about the tab, the socket, or the fence differs between the two calls; only the number of runs in front of them does.

**Why *this* sequence** — the reporter's step 3 is an image uploaded through the ComfyUI server API. Two forced, fire-and-forget refreshes are keyed on `hasRawMissingAssetCandidates()` (the validation banner's, and `graph_get_errors`'), and a just-uploaded input file is exactly what makes that predicate true. The upload that gives an agent a reason to call this tool is the same event that makes the panel start its own refresh — the two race by construction, and a workflow switch re-renders the banner that starts it.

## Relationship to mcp#1656 (PR #1775, v0.52.6) and mcp#1778 (PR #1782)

Same window, different failure mode — established rather than assumed:

- Both of those are **pre-dispatch fence refusals**: they end in a rejected promise carrying `workflow instance mismatch: …`, produced by `UiBridge.send` *before* `sock.send()`. A refusal is a reply. The reported failure is `markReplyTimeout(markDispatched(…, true))` from `dispatch()`'s reply timer — a POST-write timeout, reachable only after the frame was written and nothing answered for the full 30,000 ms. The two paths cannot produce each other's error.
- Nothing in #1775 or #1782 touches the coalescer, the node-def refresh, or any budget: they change `carryWorkflowCommandStamp` provenance and the save path's corroboration. This branch touches none of theirs.
- What they genuinely share is the *shape* — "a workflow-target transition, healed by a second call" — and that shape is a coincidence of trigger, not of cause: here the second call heals it because the coalescer's slot is free, not because a stamp became provable.

The reporter is on panel **0.14.24**; main is 0.15.5. I checked whether the gap already covered this: it does not. #1161/#1180 (v0.14.35) bounded the *phases inside a run*, and #1192/#1351 bounded *`graph_add_node`'s* wait on the coalescer — neither reaches this call site, which is unbounded on current `main`.

## Why the recovery is safe

**This PR adds no retry.** The standing rule is never to authorise a re-run on parsed prose, so the fix is to make the panel *answer inside the window* rather than to re-issue anything:

- The panel now bounds its own wait at 25,000 ms and returns `{ok:true, refreshed:false, reason:"refresh_still_running", detail, remedy}`.
- `reason` is a **structured token** in the existing `NODE_DEF_REFRESH_REASONS` vocabulary, not wording — a caller keys on the field, never on the sentence.
- Nothing was applied and nothing is half-done: `refresh-coalesce.js`'s `waitForRun` does not cancel the run, so it keeps registering the definitions the call asked for and keeps the slot. A retry therefore joins work already in progress rather than starting a stampede — which is *why* the remedy says retry, and why the reporter's own retry worked.
- The retry is safe on its own terms too, and by construction rather than by claim: `refresh_nodes` re-registers node defs and rebuilds combo option lists, touches no graph, and is undo-neutral (its tool description already says "Idempotent (safe to call repeatedly)").
- Without the branch, an abandoned wait would fall through to `reason: "unknown"` — collapsing "still running" into the same answer as "the fetch threw". A test pins both directions: a genuinely failed run still reports `object_info_fetch_failed`.

**What it costs, stated rather than left to be discovered:** a single *uncontended* run that would have taken between 25 s and 30 s now reports `refresh_still_running` where it used to report `refreshed:true`. That window is 5 s wide, past twice the #610 measurement, and the run is not cancelled. In exchange every contended call — the reported bug — gets a worded verdict instead of `did not reply … the ComfyUI tab may be backgrounded or frozen` said about a demonstrably healthy tab.

## What I deliberately did NOT do

- **No retry was added anywhere**, orchestrator-side or panel-side. The issue asks for an “idempotent recovery path”; re-issuing a command because the first timed out is only safe when you can prove nothing was applied, and the better fix here is the one that makes the reply arrive.
- **The orchestrator's timeout wording is untouched.** `did not reply … the ComfyUI tab may be backgrounded or frozen` is a false claim about this case, but with the reply now composed inside the window it is no longer reached for this cause, and rewording it touches a message a dozen tests assert on.
- **Adjacent gap, filed rather than folded in — and it IS made worse in one branch.** `panel_add_node`'s automatic `panel_refresh_nodes` recovery (comfyui-mcp `src/orchestrator/panel-tools.ts`) branches only on `refreshed.isError`, and a `{ok:true, refreshed:false}` reply is not an error. So the effect of this change on that path is **net mixed, tilted good** — not "unchanged", which is what an earlier draft claimed:
  - **Better, the common branch:** where the recovery used to burn the full 30 s and then fail, it now gets an answer in ≤ 25 s, and when the contending run settles inside that window the second `add()` simply succeeds.
  - **Worse, one branch:** if the second `add()` still refuses, the orchestrator now tells the agent *"panel_refresh_nodes reported success and the add still refuses… Reload the ComfyUI browser tab"* — a false statement about a refresh that reported it did **not** complete, plus the destructive escalation the panel's own remedy deliberately reserves for last. Previously that path reached the honest `isError` branch after timing out.
  - The one-line fix belongs in the other repo (read the verdict, not the flag) and is filed as a follow-up rather than folded in here.

## Live reproduction

Real Chromium, real ComfyUI **0.33.1** on its own base directory at **:8399** (never :8188/:8211), panel served from this worktree, real coalescer, real executor. `/object_info` inflated from this install's 848 core types to **4,240 types / 7,087,848 bytes** so `registerNodesFromDefs`/`reapplyDefsToLiveNodes` — the two calls a run's budget deliberately does not bound — do the walk the reporter's 4,300-type install does.

| | measured |
|---|---|
| one `refresh_nodes`, uncontended | **727 ms** |
| a second `refresh_nodes` issued while the first is running | **1,261 ms** (1.73×) |

That is the composition, live: the contended call pays both runs. Then, with the budget temporarily set to 400 ms in the same live rig, the contended call returned in 803 ms with `{"ok":true,"refreshed":false,"reason":"refresh_still_running",…}` **and the first run still completed `refreshed:true`** — so the bound fires through the shipped call site in a real browser, `withTimeout` is genuinely wired into the coalescer, and an abandoned wait does not cancel the run. The constant was restored (`git diff` clean) before anything was committed.

**What the live rig could NOT show:** the absolute 30 s overrun. On a blank canvas the two unbounded local calls have almost nothing to walk, so two runs cost ~1.3 s here where they cost ~29 s on the reporter's rig. The wall-clock term comes from a populated canvas on a heavy install, and this repo has that measured in-source (#610: ~14.5 s per forced refresh; #1180: `registerNodesFromDefs` 3,972 ms, `refreshComboInNodes` 4,846 ms at 4,320 types). I did not manufacture a number for it.

## Refutation

Every mutation was confirmed applied with `git diff -U0` before the run.

| mutation | anchor confirmed applied | result |
|---|---|---|
| delete `joinMs: REFRESH_NODES_COMMAND_BUDGET_MS` from the call site | `-      joinMs: REFRESH_NODES_COMMAND_BUDGET_MS` | **5 of 8 fail** — the four behavioural tests hit their watchdog at 1,500 ms instead of replying at the bound, plus the source-level call-site pin |
| `if (verdict === REFRESH_JOIN_ABANDONED)` → `if (false && …)` | `+    if (false && verdict === REFRESH_JOIN_ABANDONED) {` | **2 of 8** — both named-verdict tests fall through to `reason:"unknown"` |
| delete `REFRESH_STILL_RUNNING` from `NODE_DEF_REFRESH_REASONS` | `-  REFRESH_STILL_RUNNING: "refresh_still_running",` | **2 of 8** — and **0 of 67 before this round**; see below |
| `REFRESH_NODES_COMMAND_BUDGET_MS = 25000` → `35000` | `+const REFRESH_NODES_COMMAND_BUDGET_MS = 35000;` | **1 of 8** — the budget no longer leaves the relay window room |
| drop the “or this command's own registration” half of the detail | `+… after an upload). ` | **1 of 8** — see the re-review note below |

An earlier version of this table said 4 and “exactly 1” for the first two rows. It was stale — written before the eighth test existed and not re-measured — and the body asserted the numbers were confirmed. Every row above was re-run against the current file, and the mutation script **refuses on a non-unique anchor** rather than picking: that guard fired on the second row, where `if (verdict === REFRESH_JOIN_ABANDONED) {` matches **two** sites (`refresh_nodes` at :10781 and `graph_add_node`'s #1242 recovery at :12548). Mutating the wrong one would have measured nothing and read as a surviving mutant.

**The token was genuinely unpinned, and the gate caught it.** Deleting `REFRESH_STILL_RUNNING` from the frozen map killed **zero** of the 67 tests across all three refresh harnesses: the panel and the tests read the token from the *same* map, so both degraded to `undefined` together and `assert.equal(undefined, undefined)` passed. The shipped reply would have carried `reason: undefined` — a key `JSON.stringify` **drops outright**, so the field a caller keys on vanishes from the wire with every assertion green. Verified, not reasoned about:

```
reason value : undefined
ON THE WIRE  : {"ok":true,"refreshed":false,"remedy":"retry"}
```

Both call sites now assert the **literal** `"refresh_still_running"` alongside the map lookup, and the map entry itself is asserted to equal that literal. The same mutation now fails 2.

**Found by adversarial re-review of my own diff, not by a test.** The first draft's `detail` said the budget went on “a node-def refresh started by something else.” The coalescer returns the SAME symbol whether the wait was on someone else's run or on the run this command started itself (nothing in flight ⇒ `refresh`'s last branch), so that sentence is flatly wrong on an uncontended big install — the case with no concurrency at all. The value cannot tell them apart, so the message names both, as `addNodeRefreshBusyMessage` does. An eighth test drives that uncontended branch behaviourally (`runs.length === 1`), and the `reload` escalation is pinned to appear only AFTER the retry and only conditioned on it.

The tests drive the **shipped `refresh_nodes` body extracted from the panel source** over the **real** `makeRefreshCoalescer` with a **real** in-flight run (the `add-node-command-budget.test.mjs` technique). A helper-level test is blind here by construction: `makeRefreshCoalescer` has implemented `joinMs` correctly since #1192/#1351 and the executor already handled a non-fresh verdict — the entire defect was the call site passing no bound.

Adding the budget made **three** synthetic-scope harnesses throw `ReferenceError` at once, which is the hazard `_panel-constants.mjs` already documents for `graph_add_node`; the bindings now live in one place (`REFRESH_NODES_EXECUTOR_DEPS`) so the next one is added once rather than three times.

## Test evidence

- `npm run test:unit` (i18n check, i18n-render check, tool-vocabulary gate, panel-scope gate, then `node --test`): **5,591 pass / 0 fail / 1 todo** (rebased onto `origin/main` at 09432738, after 0.15.6 was cut).
- `npx tsc --noEmit`: clean.
- `node scripts/check-panel-scope.mjs`: OK.
- **Playwright, `--workers=1`, against the isolated :8399 ComfyUI: 60 passed / 18 failed (78).** All 18 are chat-transcript specs (`chat-history-v2`, `conversation-persistence`, `workflow-chat-identity`, `streaming-render`, `pending-queue`, `hidden-tab`, `external-orchestrator`), all failing on `MockBridge.waitForUserMessage timed out`. **Control:** the same seven spec files re-run with the worktree detached at `origin/main` (fix absent — `grep -c` = 0) fail **the same 18, by name**. They are this fresh isolated base directory's baseline, not a regression. Nothing in the refresh/add-node/errors path failed in either run.


## Gate round 2 — what changed

Three findings, all upheld and all fixed at head `9e26021e`:

1. **A false claim in shipped source and in the CHANGELOG.** “The THIRD command relayed in the 30,000 ms window and the last one that never took one” — it is six, and two of them held budgets. Both corrected by counting the relay sites rather than guessing, and the source comment now records that the false version *concealed* the sibling below. This is the reassurance-shaped claim this project keeps getting caught by.
2. **The reason token was unpinned** — deleting it killed 0 of 67. Fixed with literal assertions; the same mutation now fails 2.
3. **“Not made worse” was refuted in one branch** of `panel_add_node`'s recovery. Restated as net mixed, tilted good, with both branches named.

Plus the stale mutation table, re-measured against the current 8-test file.

**Not mine, credited to the gate:** `graph_set_widget`'s stale-combo recovery awaits `refreshComfyNodeDefs()` with no `joinMs` and no outer bound (`comfyui-mcp-panel.js:13919`, awaited at `web/js/lib/set-widget.js:820`) inside a command relayed at the same 30,000 ms. Lesser than this one — the plain-join branch returns after ONE run rather than queueing a second — but reached only after the authorization `/object_info` has already spent part of the window. That is the **fourth** instance of this shape (#1192 → #1349 → #1404 → this). Filed separately by the gate; deliberately not folded in here.

## Gate

`codex exec` is exhausted until 2026-08-19 20:43 and `claude-gate.mjs` is blocked on the weekly limit, so **this PR is ungated** and I was instructed not to run a gate script. Not merged, per instruction — gating and merging are the owner's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
