### PR TITLE
fix(1407): A2UI card buttons send a user message when clicked

### DIFF
--- a/browser_tests/unit/a2ui-card-buttons.test.mjs
+++ b/browser_tests/unit/a2ui-card-buttons.test.mjs
@@ -1,0 +1,217 @@
+// #1407 — A2UI Card buttons must fire a user message on click.
+//
+// Buttons rendered by panel_ui_render looked clickable but produced no
+// user_message. The Button leaf was mounted through the vendored a2ui/lit
+// Shadow DOM (`a2ui-surface`); on ComfyUI frontend 1.49.6 that catalog's
+// action callback never runs, so ctx.choose() / onAction never ran.
+//
+// The shipped path is now a native <button> whose click handler calls
+// buttonReplyText + ctx.choose. This file drives that path through
+// renderA2UICard (the function panel_ui_render actually calls) against a
+// minimal DOM — the same harness as a2ui-card-identity.test.mjs — and
+// pins the structural contract that Button is NOT a Lit leaf.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import { buttonReplyText } from "../../web/js/lib/chat-serialize.js";
+
+// ── minimal DOM ────────────────────────────────────────────────────────────
+class El {
+  constructor(tag) {
+    this.tagName = String(tag).toUpperCase();
+    this.children = [];
+    this.style = { cssText: "" };
+    this.dataset = {};
+    this.hidden = false;
+    this.className = "";
+    this.disabled = false;
+    this.type = "";
+    this._text = "";
+    this._listeners = new Map();
+    this.classList = {
+      add: (...names) => {
+        const set = new Set(String(this.className).split(/\s+/).filter(Boolean));
+        for (const n of names) set.add(n);
+        this.className = [...set].join(" ");
+      },
+      remove() {},
+      toggle() {},
+      contains: (n) => String(this.className).split(/\s+/).includes(n),
+    };
+  }
+  set textContent(v) { this._text = String(v ?? ""); this.children = []; }
+  get textContent() { return this._text; }
+  appendChild(c) { this.children.push(c); return c; }
+  append(...c) { for (const x of c) this.children.push(x); }
+  replaceChildren(...c) { this.children = [...c]; }
+  remove() {}
+  setAttribute(k, v) { this[k] = v; }
+  removeAttribute(k) { delete this[k]; }
+  addEventListener(t, fn) {
+    if (!this._listeners.has(t)) this._listeners.set(t, []);
+    this._listeners.get(t).push(fn);
+  }
+  querySelector(sel) { return this.querySelectorAll(sel)[0] ?? null; }
+  querySelectorAll(sel) {
+    const out = [];
+    const walkEl = (el) => {
+      for (const c of el.children || []) {
+        if (matches(c, sel)) out.push(c);
+        walkEl(c);
+      }
+    };
+    walkEl(this);
+    return out;
+  }
+  click() {
+    if (this.disabled) return;
+    for (const fn of this._listeners.get("click") || []) fn({ type: "click", target: this });
+  }
+  focus() {}
+}
+
+function matches(el, sel) {
+  if (sel.startsWith(".")) return String(el.className).split(/\s+/).includes(sel.slice(1));
+  return el.tagName === String(sel).toUpperCase();
+}
+
+globalThis.HTMLElement = class {};
+globalThis.Document = class {};
+globalThis.Document.prototype.adoptedStyleSheets = [];
+globalThis.CSSStyleSheet = class { replaceSync() {} get cssRules() { return []; } };
+globalThis.customElements = { define() {}, get() { return undefined; } };
+globalThis.document = {
+  adoptedStyleSheets: [],
+  createElement: (t) => new El(t),
+  createElementNS: (_ns, t) => new El(t),
+  createTextNode: (t) => ({ nodeType: 3, textContent: String(t) }),
+  createComment: () => ({ nodeType: 8 }),
+  createDocumentFragment: () => new El("#fragment"),
+  createTreeWalker: () => ({ currentNode: null, nextNode: () => null }),
+};
+globalThis.window = globalThis;
+
+const { renderA2UICard, validateA2UISpec } = await import("../../web/js/cmcp-a2ui.js");
+
+const a2uiSrc = readFileSync(fileURLToPath(new URL("../../web/js/cmcp-a2ui.js", import.meta.url)), "utf8");
+const adapterSrc = readFileSync(fileURLToPath(new URL("../../web/js/cmcp-a2ui-lit-adapter.js", import.meta.url)), "utf8");
+
+function walk(el, out = []) {
+  if (!el) return out;
+  out.push(el);
+  for (const c of el.children || []) walk(c, out);
+  return out;
+}
+
+function cardButtons(root) {
+  return walk(root).filter((el) => el.tagName === "BUTTON" && String(el.className).split(/\s+/).includes("cmcp-a2ui-btn"));
+}
+
+function cardSpec() {
+  const r = validateA2UISpec({
+    root: "card",
+    components: [
+      { id: "card", type: "Card", children: ["yes", "no"] },
+      { id: "yes", type: "Button", label: "Approve", reply: "approved" },
+      { id: "no", type: "Button", label: "Reject", reply: "rejected" },
+    ],
+  });
+  assert.equal(r.ok, true, r.errors?.join("; "));
+  return r.spec;
+}
+
+function submitSpec() {
+  const r = validateA2UISpec({
+    root: "col",
+    components: [
+      { id: "col", type: "Column", children: ["email", "go"] },
+      { id: "email", type: "TextField", name: "email", label: "Email", value: "a@b.com" },
+      { id: "go", type: "Button", label: "Send", reply: "submit", submit: true },
+    ],
+  });
+  assert.equal(r.ok, true, r.errors?.join("; "));
+  return r.spec;
+}
+
+function buttonOf(spec, id) {
+  return spec.components.find((c) => c.id === id);
+}
+
+// ── structure: Button is light-DOM HTML, not a Lit a2ui-surface ───────────
+
+test("#1407 Button is not a Lit leaf — frontend 1.49.6 never fires that action callback", () => {
+  // The 1.49.6 failure was the catalog Shadow DOM path. Pinning the native
+  // <button> + buttonReplyText/ctx.choose wiring means a re-route through
+  // a2ui-surface fails this file before it can ship silent clicks again.
+  assert.match(
+    a2uiSrc,
+    /case "Button": \{\s*\/\/ Native HTML[\s\S]*?document\.createElement\("button"\)/,
+  );
+  assert.match(a2uiSrc, /ctx\.choose\(btn, buttonReplyText\(c, ctx\.fields\)\)/);
+  assert.doesNotMatch(
+    a2uiSrc,
+    /case "Text":\s*case "Button":\s*case "Divider":/,
+    "Button must not share the Lit leaf switch with Text/Divider/Image",
+  );
+  assert.match(a2uiSrc, /case "Text":\s*case "Divider":\s*case "Image":/);
+  assert.doesNotMatch(adapterSrc, /if \(c\.type === "Button"\)/);
+  assert.doesNotMatch(adapterSrc, /component: "Button"/);
+});
+
+test("#1407 Lit still mounts Text, Divider, and Image", () => {
+  assert.match(adapterSrc, /case "Text":/);
+  assert.match(adapterSrc, /case "Divider":/);
+  assert.match(adapterSrc, /case "Image":/);
+});
+
+// ── executable: a click on the shipped card fires onAction ────────────────
+
+test("#1407 clicking a Card Button sends the reply and resolves the card", () => {
+  const spec = cardSpec();
+  const actions = [];
+  const handle = renderA2UICard(spec, { onAction: (t) => actions.push(t) });
+  const buttons = cardButtons(handle.el);
+  assert.equal(buttons.length, 2, "both Card buttons must be native <button>s at render time");
+  assert.equal(walk(handle.el).filter((el) => el.dataset?.a2uiType === "Button").length, 0);
+
+  const approve = buttons.find((b) => b.textContent === buttonOf(spec, "yes").label);
+  assert.ok(approve, "the Approve button must be the native control, not a Lit wrapper");
+  approve.click();
+
+  assert.deepEqual(actions, [buttonReplyText(buttonOf(spec, "yes"))]);
+  assert.equal(handle.isResolved(), true);
+  assert.equal(approve.disabled, true);
+});
+
+test("#1407 a second click after resolve does not fire again", () => {
+  const spec = cardSpec();
+  const actions = [];
+  const handle = renderA2UICard(spec, { onAction: (t) => actions.push(t) });
+  const buttons = cardButtons(handle.el);
+  const approve = buttons.find((b) => b.textContent === buttonOf(spec, "yes").label);
+  const reject = buttons.find((b) => b.textContent === buttonOf(spec, "no").label);
+  approve.click();
+  approve.click();
+  reject.click();
+  assert.deepEqual(actions, [buttonReplyText(buttonOf(spec, "yes"))]);
+  assert.equal(handle.isResolved(), true);
+});
+
+test("#1407 a submit Button click serializes live field values", () => {
+  const spec = submitSpec();
+  const actions = [];
+  const handle = renderA2UICard(spec, { onAction: (t) => actions.push(t) });
+  const inputs = walk(handle.el).filter((el) => el.tagName === "INPUT");
+  assert.equal(inputs.length, 1);
+  const [btn] = cardButtons(handle.el);
+  assert.ok(btn);
+  btn.click();
+  const field = buttonOf(spec, "email");
+  assert.deepEqual(
+    actions,
+    [buttonReplyText(buttonOf(spec, "go"), [{ name: field.name, read: () => inputs[0].value }])],
+  );
+});

--- a/web/js/cmcp-a2ui-lit-adapter.js
+++ b/web/js/cmcp-a2ui-lit-adapter.js
@@ -1,6 +1,7 @@
 // cmcp-a2ui-lit-adapter.js — routes a scoped set of A2UI leaf components
-// (Text, Button, Divider, Image) through the vendored @a2ui/lit
-// basic catalog (web/js/vendor/a2ui-lit.bundle.js), per Task 1's GO decision.
+// (Text, Divider, Image) through the vendored @a2ui/lit basic catalog
+// (web/js/vendor/a2ui-lit.bundle.js), per Task 1's GO decision.
+// Button is a native <button> in cmcp-a2ui.js (#1407).
 //
 // SCOPE (see task-3-report.md "deviations" for the full rationale):
 //   - Row/Column/Card containers stay hand-rolled in cmcp-a2ui.js. The
@@ -19,16 +20,16 @@
 //   - Heading stays hand-rolled (reviewer fix): the catalog maps it to
 //     Text{variant:hN}, which needs a markdown renderer and otherwise
 //     renders literal "#" prefixes. A plain <hN> is strictly better.
-//   - Text, Button, Divider, Image have no children to interleave
-//     and no read-back requirement, so each mounts as its own tiny
+//   - Text, Divider, Image have no children to interleave and no
+//     read-back requirement, so each mounts as its own tiny
 //     single-component a2ui-surface, wrapped in a plain <span> the
 //     hand-rolled container tree slots in like any other child.
+//   - Button is native HTML in cmcp-a2ui.js. The catalog's Shadow DOM
+//     action callback does not fire on ComfyUI frontend 1.49.6 (#1407).
 //
 // The vendor bundle is dynamically imported INSIDE a function, never at
 // module top level, so this file (and cmcp-a2ui.js, which imports it) stays
 // importable under `node --test` with no DOM/browser present.
-
-import { buttonReplyText } from "./lib/chat-serialize.js";
 
 let _bundlePromise = null;
 function loadBundle() {
@@ -39,9 +40,8 @@ function loadBundle() {
 let _surfaceSeq = 0;
 
 /** v0.9 component messages for ONE leaf, id "root" (a2ui-surface always
- *  renders starting from "root"). `disabled` strips a Button's action —
- *  a protocol-level inert with no Shadow DOM reach-in needed. */
-function leafMessages(c, disabled) {
+ *  renders starting from "root"). */
+function leafMessages(c) {
   switch (c.type) {
     case "Text":
       return [{ id: "root", component: "Text", text: c.text }];
@@ -50,19 +50,6 @@ function leafMessages(c, disabled) {
     case "Image":
       // Catalog prop names are `url`/`description`, not `src`/`alt`.
       return [{ id: "root", component: "Image", url: c.src, description: c.caption || "" }];
-    case "Button": {
-      const label = { id: "label", component: "Text", text: c.label };
-      const btn = {
-        id: "root",
-        component: "Button",
-        child: "label",
-        variant: c.style === "primary" ? "primary" : "default",
-      };
-      // A mini-surface hosts exactly one Button, so the action payload's
-      // content is unused (see onFire()) — the event just needs to fire.
-      if (!disabled) btn.action = { event: { name: "reply" } };
-      return [label, btn];
-    }
     default:
       throw new Error("cmcp-a2ui-lit-adapter: unmapped leaf type " + c.type);
   }
@@ -72,15 +59,11 @@ function leafMessages(c, disabled) {
  * Mount ONE leaf component as its own tiny a2ui-surface. Returns a plain
  * <span> wrapper synchronously (empty); it fills in once the vendor bundle
  * resolves (cached after the first call across all leaves/cards).
- *
- * onFire(): called when a Button's action fires. No payload is passed —
- * the caller already knows which spec component `c` this wrapper is for.
  */
-export function mountA2uiLeaf(c, { onFire } = {}) {
+export function mountA2uiLeaf(c) {
   const wrap = document.createElement("span");
   wrap.className = "cmcp-a2ui-lit-leaf";
   wrap.dataset.a2uiType = c.type;
-  wrap._a2uiWantsDisabled = false;
 
   loadBundle().then(({ basicCatalog, MessageProcessor }) => {
     // Stale-mount guard (reviewer fix): a superseded update() paint (or a
@@ -89,56 +72,27 @@ export function mountA2uiLeaf(c, { onFire } = {}) {
     if (!wrap.isConnected) return;
     const surfaceId = `leaf-${++_surfaceSeq}`;
     const surfaceEl = document.createElement("a2ui-surface");
-    const processor = new MessageProcessor([basicCatalog], () => onFire?.());
+    const processor = new MessageProcessor([basicCatalog]);
     processor.onSurfaceCreated((s) => {
       surfaceEl.surface = s;
     });
     processor.processMessages([
       { version: "v0.9", createSurface: { surfaceId, catalogId: basicCatalog.id } },
-      // Mount already-inert if resolve() raced ahead of this promise (e.g.
-      // the card was dismissed before the bundle finished loading).
-      { version: "v0.9", updateComponents: { surfaceId, components: leafMessages(c, wrap._a2uiWantsDisabled) } },
+      { version: "v0.9", updateComponents: { surfaceId, components: leafMessages(c) } },
     ]);
     wrap.appendChild(surfaceEl);
     wrap._a2uiProcessor = processor;
     wrap._a2uiSurfaceId = surfaceId;
   });
 
-  // Card lifecycle hook (called from cmcp-a2ui.js's resolve()): make this
-  // leaf inert. No-op for non-Button leaves (Text/Divider/Image
-  // have no interaction to disable).
-  wrap._a2uiDisable = () => {
-    wrap._a2uiWantsDisabled = true;
-    if (c.type !== "Button" || !wrap._a2uiProcessor) return;
-    wrap._a2uiProcessor.processMessages([
-      { version: "v0.9", updateComponents: { surfaceId: wrap._a2uiSurfaceId, components: leafMessages(c, true) } },
-    ]);
-  };
-
   return wrap;
 }
 
 /**
- * Entry point cmcp-a2ui.js's mountComponents() calls for the four leaf types
- * routed through Lit (Text, Button, Divider, Image). `ctx` is the same lifecycle context renderA2UICard()
- * builds (buttons/inputs/fields/choose/isResolved) — Button wiring mirrors
- * the hand-rolled Button case exactly (reply text, submit serialization via
- * ctx.fields, ctx.choose()) so resolve()/update() behave identically
- * regardless of which path rendered a given card.
+ * Entry point cmcp-a2ui.js's mountComponents() calls for the leaf types
+ * routed through Lit (Text, Divider, Image). Button is a native <button>
+ * in that file so a click reaches ctx.choose() on frontend 1.49.6 (#1407).
  */
-export function mountStandardComponent(c, ctx) {
-  if (c.type === "Button") {
-    const wrap = mountA2uiLeaf(c, {
-      onFire: () => {
-        if (ctx.isResolved()) return;
-        // buttonReplyText coerces an object reply to a string BEFORE the submit
-        // fields template interpolates it, so a malformed spec can't bake
-        // "[object Object]" into the outgoing message (#219).
-        ctx.choose(wrap, buttonReplyText(c, ctx.fields));
-      },
-    });
-    ctx.buttons.push(wrap);
-    return wrap;
-  }
+export function mountStandardComponent(c) {
   return mountA2uiLeaf(c);
 }

--- a/web/js/cmcp-a2ui.js
+++ b/web/js/cmcp-a2ui.js
@@ -6,7 +6,7 @@
 // Component types and attributes come from the enums validated here. See
 // docs/superpowers/specs/2026-07-10-a2ui-chat-design.md.
 
-import { coerceMessageText } from "./lib/chat-serialize.js";
+import { buttonReplyText, coerceMessageText } from "./lib/chat-serialize.js";
 
 export const A2UI_CAPS = Object.freeze({
   maxComponents: 64,
@@ -215,17 +215,19 @@ export function validateA2UISpec(raw) {
 // Part 2: renderer + card lifecycle. document is touched only inside calls.
 //
 // GO branch (Task 1 spike decided GO — see .superpowers/sdd/task-1-report.md):
-// Text/Button/Divider/Image mount through the vendored @a2ui/lit
-// basic catalog via cmcp-a2ui-lit-adapter.js. Row/Column/Card containers,
-// TextField/Select/Checkbox form fields, and Heading stay hand-rolled here —
-// see the scope note at the top of cmcp-a2ui-lit-adapter.js and
-// task-3-report.md for why (container interleaving with comfy:graph/chart;
-// reliable synchronous read-back for submit serialization; Heading would
-// render literal "#" without a markdown renderer). comfy:graph/comfy:chart
-// are always hand-rolled: we draw those SVGs from data, which IS the custom
-// catalog. This static import is DOM-free at module scope (the adapter
-// lazy-imports the vendor bundle inside a function), so this file stays
-// importable under `node --test`.
+// Text/Divider/Image mount through the vendored @a2ui/lit basic catalog via
+// cmcp-a2ui-lit-adapter.js. Button is a native <button> whose click handler
+// calls buttonReplyText + ctx.choose (#1407 — the Lit Shadow DOM action
+// callback does not fire on ComfyUI frontend 1.49.6). Row/Column/Card
+// containers, TextField/Select/Checkbox form fields, and Heading stay
+// hand-rolled here — see the scope note at the top of
+// cmcp-a2ui-lit-adapter.js and task-3-report.md for why (container
+// interleaving with comfy:graph/chart; reliable synchronous read-back for
+// submit serialization; Heading would render literal "#" without a
+// markdown renderer). comfy:graph/comfy:chart are always hand-rolled: we
+// draw those SVGs from data, which IS the custom catalog. This static
+// import is DOM-free at module scope (the adapter lazy-imports the vendor
+// bundle inside a function), so this file stays importable under `node --test`.
 // ---------------------------------------------------------------------------
 
 import { mountStandardComponent } from "./cmcp-a2ui-lit-adapter.js";
@@ -455,10 +457,11 @@ function buildChartSVG(c) {
 
 /**
  * Mount one validated spec into a container element. Internal seam: standard
- * leaf types (Text/Button/Divider/Image) delegate to the Lit adapter;
- * Heading, containers (Row/Column/Card), form fields (TextField/Select/
- * Checkbox), and comfy:* stay hand-rolled here (see cmcp-a2ui-lit-adapter.js's
- * scope note; Heading is hand-rolled so it never shows raw "#" markdown).
+ * leaf types (Text/Divider/Image) delegate to the Lit adapter; Button is a
+ * native <button> (#1407); Heading, containers (Row/Column/Card), form
+ * fields (TextField/Select/Checkbox), and comfy:* stay hand-rolled here
+ * (see cmcp-a2ui-lit-adapter.js's scope note; Heading is hand-rolled so it
+ * never shows raw "#" markdown).
  * Returns nothing; ctx.fields collects { name, read() } for submit serialization.
  */
 function mountComponents(container, spec, ctx) {
@@ -470,10 +473,24 @@ function mountComponents(container, spec, ctx) {
     const c = byId.get(id);
     switch (c.type) {
       case "Text":
-      case "Button":
       case "Divider":
       case "Image":
         return mountStandardComponent(c, ctx);
+      case "Button": {
+        // Native HTML, not the Lit a2ui-surface. Frontend 1.49.6 never
+        // delivers the catalog's Shadow DOM action callback, so a Button
+        // mounted there looks clickable and does nothing (#1407).
+        const btn = document.createElement("button");
+        btn.type = "button";
+        btn.className = "cmcp-a2ui-btn" + (c.style === "primary" ? " primary" : "");
+        btn.textContent = c.label;
+        btn.addEventListener("click", () => {
+          if (ctx.isResolved()) return;
+          ctx.choose(btn, buttonReplyText(c, ctx.fields));
+        });
+        ctx.buttons.push(btn);
+        return btn;
+      }
       case "Heading": {
         // Hand-rolled (reviewer fix): the Lit catalog's Text{variant:hN}
         // renders literal "#" prefixes without a markdown renderer. A plain
@@ -582,7 +599,7 @@ export function renderA2UICard(spec, { onAction, onDismiss, cardId: reuseId } = 
       // a submit-serialized object) can arrive as a non-string here. Normalize
       // at this single chokepoint so an object never reaches resolve()'s
       // choiceText.split() or the outgoing user_message as "[object Object]"
-      // (#219). Both the hand-rolled and Lit Button paths flow through choose().
+      // (#219). The native Button click path flows through choose().
       const reply = coerceMessageText(text);
       handle.resolve(reply, btn);
       onAction?.(reply);
@@ -633,9 +650,9 @@ export function renderA2UICard(spec, { onAction, onDismiss, cardId: reuseId } = 
       el.classList.add("resolved");
       el.querySelector(".cmcp-a2ui-x")?.remove();
       for (const b of ctx.buttons) {
-        b.disabled = true; // harmless on the Lit wrapper <span>; real effect if ever a native <button>
+        b.disabled = true;
         b.classList?.add("cmcp-a2ui-lit-inert");
-        b._a2uiDisable?.(); // Lit path: strip the Button's action at the protocol level
+        b._a2uiDisable?.();
       }
       if (chosenBtn) chosenBtn.classList.add("chosen");
       for (const i of ctx.inputs) i.disabled = true;


### PR DESCRIPTION
Fixes #1407.

## What the reporter hit

Buttons rendered by panel_ui_render appeared correctly but clicks produced no user message. A recording confirmed core controls worked while A2UI buttons stayed inert. The Button path used the vendored a2ui/lit Shadow DOM surface (a2ui-surface) and its action callback does not fire on ComfyUI frontend 1.49.6.

Silent failure: the card stayed unresolved and nothing reached the agent.

## The change

Button leaves are native HTML buttons. The click handler calls the existing buttonReplyText + ctx.choose path, so a click becomes the same visible user message it always should have. Lit remains for Text, Divider, and Image.

## Proof

renderA2UICard is driven against a minimal DOM (the same harness as the card-identity suite):

- a Card with two Buttons renders native `button.cmcp-a2ui-btn` elements immediately (not Lit wrappers)
- clicking Approve fires onAction with buttonReplyText of that component and resolves the card
- a second click after resolve does not fire again
- a submit Button serializes live field values through the same buttonReplyText path
- source contract: Button is not grouped with the Lit leaves; the adapter no longer maps `component: "Button"`

```
node --test --test-concurrency=4 \
  browser_tests/unit/a2ui-card-buttons.test.mjs \
  browser_tests/unit/a2ui-card-identity.test.mjs \
  browser_tests/unit/a2ui-validate.test.mjs \
  browser_tests/unit/a2ui-repaint-live-card.test.mjs \
  browser_tests/unit/chat-serialize.test.mjs
```

69 pass, 0 fail.
