### PR TITLE
fix(1411): sanitize invalid properties.aux_id on node add/paste so one node can no longer poison every save/load

### DIFF
--- a/browser_tests/unit/_panel-constants.mjs
+++ b/browser_tests/unit/_panel-constants.mjs
@@ -16,6 +16,7 @@ import { fileURLToPath } from "node:url";
 import { makeCommandBudget } from "../../web/js/lib/command-budget.js";
 import { REFRESH_JOIN_ABANDONED } from "../../web/js/lib/refresh-coalesce.js";
 import { clearInheritedExecutionPreview } from "../../web/js/lib/execution-preview-attach.js";
+import { sanitizeNodeAuxId } from "../../web/js/lib/aux-id-sanitize.js";
 
 export const PANEL_SRC = readFileSync(
   fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url)),
@@ -133,6 +134,10 @@ export function addNodeCommandBudgetDeps() {
     // #1286 — graph_add_node now names this after graph.add. The shipped
     // implementation is a no-op when the new id has no leftover store entries.
     clearInheritedExecutionPreview,
+    // #1411 — graph_add_node now sanitizes the fresh node's aux_id after
+    // graph.add. The REAL helper: a valid hint passes through untouched, an
+    // invalid one is dropped, and either way the add proceeds.
+    sanitizeNodeAuxId,
     makeCommandBudget,
     ADD_NODE_COMMAND_BUDGET_MS,
     // Derived exactly as the panel derives it.

--- a/browser_tests/unit/add-node-command-budget.test.mjs
+++ b/browser_tests/unit/add-node-command-budget.test.mjs
@@ -49,6 +49,7 @@ import {
   widenSocketProofBudget,
 } from "./_panel-constants.mjs";
 import { clearInheritedExecutionPreview } from "../../web/js/lib/execution-preview-attach.js";
+import { sanitizeNodeAuxId } from "../../web/js/lib/aux-id-sanitize.js";
 
 const panelPath = fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url));
 const panelSrc = readFileSync(panelPath, "utf8");
@@ -251,6 +252,7 @@ function realGraphAddNode({
     REFRESH_JOIN_ABANDONED,
     addNodeRefreshBusyMessage,
     clearInheritedExecutionPreview,
+    sanitizeNodeAuxId,
     OBJECT_INFO_SEED_WAIT_MS: 8000,
     ADD_NODE_COMMAND_BUDGET_MS: budgetMs,
     ADD_NODE_POST_REFRESH_RESERVE_MS: reserveMs,

--- a/browser_tests/unit/aux-id-sanitize.test.mjs
+++ b/browser_tests/unit/aux-id-sanitize.test.mjs
@@ -1,0 +1,105 @@
+// panel#1411 — a node added via `panel_add_node` could carry
+// `properties.aux_id = "work"`: the frontend/Manager (3.x legacy) metadata chain
+// stamps a malformed install-hint on nodes created via LG.createNode. ComfyUI's
+// workflow zod schema requires aux_id to be `github-user/repo-name` (or absent),
+// so from that add on, EVERY save/load of the workflow failed validation —
+// one added node poisoned the whole workflow file.
+//
+// The load path already sanitized invalid aux_id values; the add and paste paths
+// did not. All three now share the helpers in web/js/lib/aux-id-sanitize.js.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+import { AUX_ID_RE, sanitizeNodeAuxId, sanitizeNodesAuxId } from "../../web/js/lib/aux-id-sanitize.js";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const PANEL = readFileSync(join(HERE, "../../web/js/comfyui-mcp-panel.js"), "utf8");
+
+// ── the helper's behaviour ──────────────────────────────────────────────────
+
+test("#1411 the observed garbage value 'work' is dropped", () => {
+  const node = { properties: { aux_id: "work", "Node name for S&R": "X" } };
+  assert.equal(sanitizeNodeAuxId(node), true, "an invalid hint must be reported as removed");
+  assert.deepEqual(node.properties, { "Node name for S&R": "X" }, "only aux_id is removed");
+});
+
+test("#1411 a valid 'github-user/repo-name' hint is KEPT", () => {
+  const node = { properties: { aux_id: "NikoDemon80/ComfyUI-H3-Motion-Context" } };
+  assert.equal(sanitizeNodeAuxId(node), false);
+  assert.equal(node.properties.aux_id, "NikoDemon80/ComfyUI-H3-Motion-Context");
+});
+
+test("#1411 absent aux_id is untouched, and non-string values are dropped", () => {
+  assert.equal(sanitizeNodeAuxId({ properties: {} }), false);
+  assert.equal(sanitizeNodeAuxId({}), false);
+  assert.equal(sanitizeNodeAuxId(null), false);
+  for (const bad of ["GetNode", "SetNode", "a/b/c", "/repo", "user/", "has space/x", 42]) {
+    const node = { properties: { aux_id: bad } };
+    assert.equal(sanitizeNodeAuxId(node), true, `${JSON.stringify(bad)} must be dropped`);
+    assert.ok(!("aux_id" in node.properties));
+  }
+});
+
+test("#1411 sanitizeNodesAuxId counts drops across a node list", () => {
+  const nodes = [
+    { properties: { aux_id: "work" } },
+    { properties: { aux_id: "user/repo" } },
+    { properties: {} },
+    { properties: { aux_id: "GetNode" } },
+  ];
+  assert.equal(sanitizeNodesAuxId(nodes), 2);
+  assert.equal(nodes[1].properties.aux_id, "user/repo");
+  assert.equal(sanitizeNodesAuxId(null), 0);
+  assert.equal(sanitizeNodesAuxId([]), 0);
+});
+
+test("#1411 the regex matches the zod rule: 'github-user/repo-name' only", () => {
+  assert.ok(AUX_ID_RE.test("comfyanonymous/ComfyUI"));
+  assert.ok(!AUX_ID_RE.test("work"));
+  assert.ok(!AUX_ID_RE.test("no/slash allowed/extra"));
+});
+
+// ── every node-creating path uses it ────────────────────────────────────────
+
+test("#1411 graph_add_node sanitizes the freshly created node after graph.add", () => {
+  const addAt = PANEL.indexOf("async graph_add_node(");
+  const removeAt = PANEL.indexOf("graph_remove_node(", addAt);
+  assert.ok(addAt > 0 && removeAt > addAt, "graph_add_node must exist");
+  const body = PANEL.slice(addAt, removeAt);
+  const graphAddAt = body.indexOf("graph.add(node)");
+  const sanitizeAt = body.indexOf("sanitizeNodeAuxId(node)");
+  assert.ok(graphAddAt > 0, "the node must be added to the graph");
+  assert.ok(sanitizeAt > graphAddAt, "the aux_id sanitize must run AFTER graph.add(node)");
+  assert.ok(
+    body.includes("aux_id_sanitized"),
+    "the add result must disclose when a hint was dropped",
+  );
+});
+
+test("#1411 graph_paste_nodes sanitizes pasted nodes and discloses the count", () => {
+  const pasteAt = PANEL.indexOf("graph_paste_nodes(");
+  assert.ok(pasteAt > 0, "graph_paste_nodes must exist");
+  const body = PANEL.slice(pasteAt, PANEL.indexOf("\n  },", pasteAt));
+  const pasteCallAt = body.indexOf("pasteFromClipboard(options)");
+  const sanitizeAt = body.indexOf("sanitizeNodesAuxId(pastedNodes)");
+  assert.ok(pasteCallAt > 0 && sanitizeAt > pasteCallAt, "sanitize must run after the paste lands");
+  assert.ok(body.includes("aux_id_sanitized"), "the paste result must disclose the drop count");
+});
+
+test("#1411 graph_load_workflow uses the SHARED sanitizer (no private regex copy)", () => {
+  const loadAt = PANEL.indexOf("async graph_load(");
+  assert.ok(loadAt > 0, "graph_load must exist");
+  const body = PANEL.slice(loadAt, PANEL.indexOf("captureGraphSnapshot(null, \"before graph_load\")", loadAt));
+  assert.ok(body.includes("sanitizeNodesAuxId(nodes)"), "the load path must use the shared helper");
+  assert.ok(
+    !body.includes("const AUX_ID_RE"),
+    "the load path must not keep a private copy of the regex",
+  );
+  // Both paths must come from the one lib module.
+  const importLine = 'from "./lib/aux-id-sanitize.js"';
+  assert.ok(PANEL.includes(importLine), "the panel must import the shared helper");
+});

--- a/browser_tests/unit/copy-paste-layout.test.mjs
+++ b/browser_tests/unit/copy-paste-layout.test.mjs
@@ -35,6 +35,7 @@ import {
   registryTypePredicate,
   formatUnpasteableCopyWarning,
 } from "../../web/js/lib/paste-report.js";
+import { sanitizeNodesAuxId } from "../../web/js/lib/aux-id-sanitize.js";
 import {
   finitePoint,
   isGraphNode,
@@ -310,6 +311,7 @@ function shippedCopyPaste(srcGraph, srcCanvas, srcLG) {
       "getVerifiedSnapshot",
       "diffCopiedVsPasted",
       "formatDroppedWarning",
+      "sanitizeNodesAuxId",
       "window",
       `"use strict"; const e = { ${pasteSrc} }; return e.graph_paste_nodes;`,
     )(
@@ -328,6 +330,7 @@ function shippedCopyPaste(srcGraph, srcCanvas, srcLG) {
       getVerifiedSnapshot,
       diffCopiedVsPasted,
       formatDroppedWarning,
+      sanitizeNodesAuxId,
       window,
     );
   }

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -86,6 +86,7 @@ import {
 } from "./lib/duplicate-panel-guard.js";
 import { pressableWidgetHint } from "./lib/pressable-widget.js";
 import { looksLikeApiWorkflow, apiLoadShortfall, apiLoadNote } from "./lib/api-workflow-load.js";
+import { sanitizeNodeAuxId, sanitizeNodesAuxId } from "./lib/aux-id-sanitize.js";
 import {
   installNodeConfigureIsolation,
   retryNodeRestores,
@@ -12590,6 +12591,14 @@ const GRAPH_TOOL_EXECUTORS = {
     } finally {
       graph.afterChange();
     }
+    // #1411 — sanitize the freshly created node's aux_id install-hint, mirroring
+    // the load-path sanitizer in graph_load. The frontend/Manager
+    // metadata chain can stamp a MALFORMED aux_id (observed: "work") on nodes
+    // created via LG.createNode, and ComfyUI's workflow zod schema then rejects
+    // EVERY subsequent save/load of the workflow ("Invalid format. Must be
+    // 'github-user/repo-name'"). A valid hint is kept; an invalid one is dropped
+    // rather than guessed at, so one added node can never poison the file.
+    const auxIdSanitized = sanitizeNodeAuxId(node);
     // #1286 — a newly assigned id may still hold the previous occupant's
     // execution images. Wipe that leftover so this node cannot inherit a preview.
     clearInheritedExecutionPreview(node, {
@@ -12598,6 +12607,9 @@ const GRAPH_TOOL_EXECUTORS = {
     });
     graph.setDirtyCanvas(true, true);
     const added = summarizeNode(node);
+    // #1411 — disclose the dropped install-hint, like every other correction on
+    // this path: the node was created with an aux_id its own zod schema rejects.
+    if (auxIdSanitized) added.aux_id_sanitized = true;
     const rejectedCorrections = correctionOut.rejected ?? [];
     if (valueCorrections.length) {
       added.schema_value_corrections = valueCorrections;
@@ -12847,16 +12859,9 @@ const GRAPH_TOOL_EXECUTORS = {
     // 'github-user/repo-name' (or absent) — packs/exports sometimes carry a bare
     // node name (e.g. "GetNode"/"SetNode"); drop those invalid install-hints rather
     // than let the whole load fail validation.
-    const AUX_ID_RE = /^[^/\s]+\/[^/\s]+$/;
     let auxSanitized = 0;
     const sanitizeNodes = (nodes) => {
-      for (const n of nodes || []) {
-        const aux = n?.properties?.aux_id;
-        if (aux != null && !(typeof aux === "string" && AUX_ID_RE.test(aux))) {
-          delete n.properties.aux_id;
-          auxSanitized++;
-        }
-      }
+      auxSanitized += sanitizeNodesAuxId(nodes);
     };
     sanitizeNodes(clone.nodes);
     // Recurse into subgraph DEFINITIONS — their inner nodes (e.g. KJNodes
@@ -18233,10 +18238,18 @@ const GRAPH_TOOL_EXECUTORS = {
     // or skips groups that were not in the native selection (#1294).
     const rawClipboard = getEffectiveClipboard(storage);
     const layout = getVerifiedLayout(rawClipboard) ?? parseClipboardLayout(rawClipboard);
+    let auxIdSanitizedCount = 0;
     graph.beforeChange?.();
     try {
       withInMemoryClipboard(storage, () => canvas.pasteFromClipboard(options));
       const pastedNodes = (graph._nodes ?? []).filter((n) => !before.has(n.id));
+      // #1411 — LiteGraph's paste configures properties VERBATIM from the
+      // clipboard payload, so a copied node (e.g. one cut from an older,
+      // unsanitized workflow, or a native Ctrl+C of an externally-authored
+      // graph) can land an aux_id the zod schema rejects and poison every later
+      // save/load. Same rule as the load/add paths: valid hint kept, invalid
+      // dropped.
+      auxIdSanitizedCount = sanitizeNodesAuxId(pastedNodes);
       const pastedGroups = (graph._groups ?? []).filter((g) => !beforeGroups.has(g));
       const pasteDest = dest && dest.every(Number.isFinite) ? dest : resolvePasteDest(null, pastedNodes);
       applyPastedLayout({
@@ -18304,6 +18317,7 @@ const GRAPH_TOOL_EXECUTORS = {
       pasted,
       copied_groups: layout.groups.length,
       pasted_groups: groupsNow.length,
+      ...(auxIdSanitizedCount ? { aux_id_sanitized: auxIdSanitizedCount } : {}),
     };
     if (groupsNow.length) {
       result.groups = groupsNow.map((g) => summarizeGroup(graph, g));

--- a/web/js/lib/aux-id-sanitize.js
+++ b/web/js/lib/aux-id-sanitize.js
@@ -1,0 +1,36 @@
+// panel#1411 — `properties.aux_id` is the frontend/Manager install-hint stamped on a
+// node ("github-user/repo-name"). The Manager 3.x legacy metadata chain can stamp a
+// MALFORMED value (observed: "work") on nodes created via LG.createNode, and ComfyUI's
+// workflow zod schema then rejects EVERY subsequent save/load of the workflow with
+// "Invalid format. Must be 'github-user/repo-name'". One bad node poisons the whole
+// workflow file.
+//
+// The sanitizer treats only `github-user/repo-name` (or absence) as valid — the same
+// rule the zod schema enforces — and DELETES an invalid hint rather than guessing a
+// replacement: a wrong repo attribution is worse than none. A valid hint is kept.
+
+/** The zod schema's accepted shape: `github-user/repo-name`, no whitespace. */
+export const AUX_ID_RE = /^[^/\s]+\/[^/\s]+$/;
+
+/**
+ * Drop `node.properties.aux_id` when it is present but not a valid
+ * `github-user/repo-name` hint. Returns true when a value was removed.
+ * No-op (returns false) for missing/valid hints or nodes without properties.
+ */
+export function sanitizeNodeAuxId(node) {
+  const aux = node?.properties?.aux_id;
+  if (aux != null && !(typeof aux === "string" && AUX_ID_RE.test(aux))) {
+    delete node.properties.aux_id;
+    return true;
+  }
+  return false;
+}
+
+/** Sanitize every node in a list; returns how many hints were dropped. */
+export function sanitizeNodesAuxId(nodes) {
+  let dropped = 0;
+  for (const n of nodes || []) {
+    if (sanitizeNodeAuxId(n)) dropped++;
+  }
+  return dropped;
+}


### PR DESCRIPTION
## Root cause

Nodes added via `panel_add_node` go through `graph_add_node` → `LG.createNode`. The frontend/Manager (3.x legacy) metadata chain can stamp a **malformed** `properties.aux_id` (observed: `"work"`) on the freshly created node. ComfyUI's workflow zod schema requires `aux_id` to be `github-user/repo-name` (or absent), so from that add on, **every save/load of the workflow failed validation**:

```
Invalid workflow against zod schema: Validation error: Invalid format.
Must be 'github-user/repo-name' at "definitions.subgraphs[0].nodes[64].properties.aux_id" …
```

The panel already sanitized invalid `aux_id` hints on the **load** path (`graph_load`), but the **add** path had no equivalent guard — so one panel-added node poisoned an otherwise valid workflow file. The **paste** path had the same hole: LiteGraph's `pasteFromClipboard` configures `properties` verbatim from the clipboard payload.

## Fix

All three node-arrival paths now share one helper, new `web/js/lib/aux-id-sanitize.js`:

- `AUX_ID_RE = /^[^/\s]+\/[^/\s]+$/` — the zod shape, `github-user/repo-name`;
- `sanitizeNodeAuxId(node)` / `sanitizeNodesAuxId(nodes)` — a **valid** hint is kept; an **invalid** one is **deleted** rather than guessed at (a wrong repo attribution is worse than none).

Wired in:

- `graph_add_node` — sanitizes the fresh node right after `graph.add(node)`; discloses the drop via `added.aux_id_sanitized = true`;
- `graph_paste_nodes` — sanitizes pasted nodes; discloses `aux_id_sanitized` count in the result;
- `graph_load` — its inline sanitizer now calls the shared helper (behavior unchanged, `aux_id_sanitized` count still reported).

## Verification

- New `browser_tests/unit/aux-id-sanitize.test.mjs` (8 tests): pins that `"work"`, bare node names, `a/b/c`, whitespace and non-string values are dropped; valid `github-user/repo-name` hints are kept; and that `graph_add_node` / `graph_paste_nodes` / `graph_load` all route through the shared helper (source-structure pins, matching this repo's harness style).
- The eval harnesses that rebuild the shipped executors (`_panel-constants.mjs`, `add-node-command-budget.test.mjs`, `copy-paste-layout.test.mjs`) now inject the real helper.
- Gates in the worktree: `npm ci` clean (0 vulnerabilities); `npm run typecheck` (`tsc --noEmit`) passes; `npm run test:unit` — **5578 pass, 0 fail**.

## Follow-up (not in this PR)

The issue notes an alternative: fill in the *correct* `aux_id` from pack metadata (what the frontend does for user-dragged nodes) instead of deleting. Deletion is the safe minimal fix; attribution recovery can build on this helper later.

Closes #1411