### PR TITLE
fix(1413): graph_set_widget stale-combo recovery takes the command budget

### DIFF
--- a/browser_tests/unit/_panel-constants.mjs
+++ b/browser_tests/unit/_panel-constants.mjs
@@ -88,6 +88,18 @@ export const REFRESH_NODES_EXECUTOR_DEPS = Object.freeze({
   REFRESH_NODES_COMMAND_BUDGET_MS,
 });
 
+/** #1413 — the whole-command deadline `graph_set_widget` takes on its first line. */
+export const SET_WIDGET_COMMAND_BUDGET_MS = readPanelNumber(
+  /const SET_WIDGET_COMMAND_BUDGET_MS = (\d+);/,
+  "the set_widget command budget",
+);
+
+/** #1413 — what a widget write still has to do after the stale-combo refresh, held back. */
+export const SET_WIDGET_POST_REFRESH_RESERVE_MS = readPanelNumber(
+  /const SET_WIDGET_POST_REFRESH_RESERVE_MS = (\d+);/,
+  "the set_widget post-refresh reserve",
+);
+
 export const NODE_DEFS_FETCH_TIMEOUT_MS = readPanelNumber(
   /const NODE_DEFS_FETCH_TIMEOUT_MS = (\d+);/,
   "the single-call fetch bound",
@@ -177,5 +189,22 @@ export function addNodeCommandBudgetDeps() {
     // a hand-copied sentence here would just be a third place for it to drift.
     addNodeRefreshBusyMessage: (classType) =>
       `HARNESS STUB refusal for "${classType}" — the shipped wording lives in the panel.`,
+  };
+}
+
+/**
+ * #1413 — every module binding the command budget added to `graph_set_widget`, in ONE
+ * place, for the same reason addNodeCommandBudgetDeps exists: harnesses that rebuild that
+ * executor in a synthetic scope throw ReferenceError on a new free identifier, and each
+ * would otherwise grow its own copy of these. The REAL implementations where they exist
+ * (`makeCommandBudget`, and the numbers read from the panel source), so a harness cannot
+ * pass against a value the panel no longer holds.
+ */
+export function setWidgetCommandBudgetDeps() {
+  return {
+    makeCommandBudget,
+    SET_WIDGET_COMMAND_BUDGET_MS,
+    SET_WIDGET_POST_REFRESH_RESERVE_MS,
+    monotonicNow,
   };
 }

--- a/browser_tests/unit/rgthree-lora-row.test.mjs
+++ b/browser_tests/unit/rgthree-lora-row.test.mjs
@@ -20,6 +20,7 @@ import {
   POWER_LORA_LOADER_TYPE,
 } from "../../web/js/lib/rgthree-lora-row.js";
 import { runSetWidget } from "../../web/js/lib/set-widget.js";
+import { setWidgetCommandBudgetDeps } from "./_panel-constants.mjs";
 
 const SLOT = { on: true, lora: "x.safetensors", strength: 0.5, strengthTwo: null };
 
@@ -1317,6 +1318,12 @@ const EXECUTOR_DEPS = [
   "refreshComfyNodeDefs",
   "clearStaleRedFlag",
   "snapshotAuthorizationNote",
+  // #1413 — the handler's first line is now a command budget. The REAL pieces, collected in
+  // _panel-constants.mjs so no harness keeps its own copy of the numbers.
+  "makeCommandBudget",
+  "SET_WIDGET_COMMAND_BUDGET_MS",
+  "SET_WIDGET_POST_REFRESH_RESERVE_MS",
+  "monotonicNow",
 ];
 
 /**
@@ -1450,6 +1457,9 @@ function executor(node, overrides = {}) {
     clearStaleRedFlag: () => {},
     objectInfoHistory: { wasTypeEverDefined: () => true },
     comfyBackendIsDown: () => false,
+    // #1413 — the handler now takes a command budget on its first line. The real pieces,
+    // with the shipped numbers, from the shared harness constants.
+    ...setWidgetCommandBudgetDeps(),
     ...overrides,
   };
   const factory = new Function(

--- a/browser_tests/unit/set-widget-combo-fallback.test.mjs
+++ b/browser_tests/unit/set-widget-combo-fallback.test.mjs
@@ -27,6 +27,8 @@ import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 
+import { SET_WIDGET_POST_REFRESH_RESERVE_MS } from "./_panel-constants.mjs";
+
 const HERE = dirname(fileURLToPath(import.meta.url));
 const PANEL_JS = join(HERE, "../../web/js/comfyui-mcp-panel.js");
 const panelSrc = readFileSync(PANEL_JS, "utf8");
@@ -37,27 +39,37 @@ const panelSrc = readFileSync(PANEL_JS, "utf8");
 const match = panelSrc.match(/refreshCombos: \(defs, target, concreteType, nameMap\) => \{[\s\S]*?\n {6}\},/);
 assert.ok(match, "could not locate the panel's refreshCombos wiring");
 
-function shippedRefreshCombos({ onFromDefs, onFullRefresh }) {
+function shippedRefreshCombos({
+  onFromDefs,
+  onFullRefresh,
+  // #1413 — the callback now draws its join bound from the command budget the handler
+  // took on its first line. A healthy command's remainder, by default.
+  budget = { remaining: () => 21000 },
+}) {
   const body = match[0].replace(/^refreshCombos: /, "");
   const factory = new Function(
     "refreshComboOptionsFromDefs",
     "refreshComfyNodeDefs",
+    "budget",
+    "SET_WIDGET_POST_REFRESH_RESERVE_MS",
     `return (${body.replace(/,$/, "")});`,
   );
-  return factory(onFromDefs, onFullRefresh);
+  return factory(onFromDefs, onFullRefresh, budget, SET_WIDGET_POST_REFRESH_RESERVE_MS);
 }
 
-function spies() {
-  const calls = { fromDefs: [], full: 0 };
+function spies(overrides = {}) {
+  const calls = { fromDefs: [], full: 0, fullArgs: [] };
   const fn = shippedRefreshCombos({
     onFromDefs: (target, defs, type, nameMap) => {
       calls.fromDefs.push({ target, defs, type, nameMap });
       return 1;
     },
-    onFullRefresh: () => {
+    onFullRefresh: (...args) => {
       calls.full++;
+      calls.fullArgs.push(args);
       return Promise.resolve("full");
     },
+    ...overrides,
   });
   return { fn, calls };
 }
@@ -116,4 +128,32 @@ test("#767 nameMap still reaches the refresh for a RENAMED nested promotion", ()
   const nameMap = { outer_name: "ckpt_name" };
   fn(DEFS, TARGET, "CheckpointLoaderSimple", nameMap);
   assert.equal(calls.fromDefs[0].nameMap, nameMap);
+});
+
+test("#1413 the full-refresh fallback is bounded by the command's remaining budget", () => {
+  // The whole point of the issue: this await used to be a bare `refreshComfyNodeDefs()`,
+  // a plain join of a run someone else started with no bound at all, inside the 30s relay
+  // window. Deleting the joinMs from the panel must fail HERE — a lib-level test cannot
+  // see the wiring, and the other suites re-implement this callback.
+  const budget = { remaining: () => 12345 };
+  const { fn, calls } = spies({ budget });
+  fn(undefined, TARGET, "CheckpointLoaderSimple", null);
+  assert.equal(calls.full, 1, "the fallback still runs");
+  assert.deepEqual(
+    calls.fullArgs[0],
+    [undefined, { joinMs: 12345 - SET_WIDGET_POST_REFRESH_RESERVE_MS }],
+    "joinMs is the command's remainder minus the reserve — not a fresh constant, not absent",
+  );
+});
+
+test("#1413 an exhausted command hands the coalescer a non-positive joinMs, not silence", () => {
+  // The coalescer treats joinMs <= 0 as "abandon WITHOUT awaiting" (withTimeout would read
+  // it as NO BOUND), which is the honest refusal the lib then raises. Wiring that dropped
+  // the joinMs instead would restore the unbounded hang at exactly the worst moment.
+  const budget = { remaining: () => -50 };
+  const { fn, calls } = spies({ budget });
+  fn(undefined, TARGET, "CheckpointLoaderSimple", null);
+  assert.equal(calls.full, 1);
+  const { joinMs } = calls.fullArgs[0][1];
+  assert.ok(Number.isFinite(joinMs) && joinMs <= 0, `joinMs must say "spent", got ${joinMs}`);
 });

--- a/browser_tests/unit/set-widget-stale-combo-budget.test.mjs
+++ b/browser_tests/unit/set-widget-stale-combo-budget.test.mjs
@@ -1,0 +1,398 @@
+/**
+ * #1413 — `graph_set_widget`'s stale-combo recovery awaited `refreshComfyNodeDefs()` with
+ * no `joinMs` and no outer bound, inside the orchestrator's 30,000 ms relay window
+ * (`OBJECT_INFO_REFRESH_ACK_TIMEOUT_MS`, the same constant add_node is relayed at). The
+ * fourth instance of the defect #1192 fixed for `graph_add_node`: reached only after the
+ * authorization /object_info has already spent part of the window, an unbounded join of a
+ * run someone else started could outlive the relay and turn a worded, retryable refusal
+ * into a bare `did not reply to "graph_set_widget" within 30000 ms`.
+ *
+ * TWO layers are tested, because the defect lives in the SEAM between them:
+ *
+ *   1. THE LIB (runSetWidget, driven directly — the same unit the handler delegates to):
+ *      an abandoned refresh (REFRESH_JOIN_ABANDONED back from refreshCombos) must refuse
+ *      IN WORDS — nothing written, retry is the remedy — instead of revalidating against
+ *      the list that was never refreshed and calling the value "not a valid option".
+ *
+ *   2. THE WIRING (the SHIPPED graph_set_widget body, extracted from the panel source and
+ *      run against doubles, the rgthree-lora-row technique): the handler must take a
+ *      command budget on its first line and thread `budget.remaining() - reserve` into
+ *      the coalescer as `joinMs`. The coalescer and the budget are REAL — a stubbed
+ *      refresh would pass against a wiring that bounds nothing, which is exactly the
+ *      failure this file exists to catch.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { runSetWidget } from "../../web/js/lib/set-widget.js";
+import { makeRefreshCoalescer, REFRESH_JOIN_ABANDONED } from "../../web/js/lib/refresh-coalesce.js";
+import { withTimeout } from "../../web/js/lib/bounded-step.js";
+import { createObjectInfoCache, CACHE_OUTCOME } from "../../web/js/lib/object-info-cache.js";
+import { fetchWholeObjectInfo, objectInfoOracleFailureNote } from "../../web/js/lib/object-info-oracle.js";
+import { isRgthreeLoraRowCreation, createRgthreeLoraRow } from "../../web/js/lib/rgthree-lora-row.js";
+import {
+  PANEL_SRC,
+  setWidgetCommandBudgetDeps,
+  SET_WIDGET_COMMAND_BUDGET_MS,
+  SET_WIDGET_POST_REFRESH_RESERVE_MS,
+} from "./_panel-constants.mjs";
+
+// ---------------------------------------------------------------------------
+// 1. The lib: an abandoned refresh is a worded, honest, retryable refusal.
+// ---------------------------------------------------------------------------
+
+// A registry whose entries have no `nodeData` so the placeholder cross-check in
+// assertResolvedTargetRegistered is skipped while the type still resolves as registered.
+const REGISTRY = { LoadImage: {} };
+
+// Fresh /object_info oracle, as every runSetWidget driver must supply (#458). The stale-
+// COMBO recovery is the subject, so the type gate is a no-op here.
+const FRESH = { LoadImage: {} };
+const freshOracle = { getFreshObjectInfo: async () => FRESH };
+
+function makeNode(type, widget) {
+  return { id: 105, type, widgets: [widget] };
+}
+
+test("#1413 an abandoned combo refresh refuses IN WORDS — never 'not a valid option'", async () => {
+  const widget = { name: "image", type: "combo", options: { values: ["old_a.png"] }, value: "old_a.png" };
+  const node = makeNode("LoadImage", widget);
+  let refreshCalls = 0;
+  await assert.rejects(
+    () =>
+      runSetWidget(node, "image", "new.png", {
+        registry: REGISTRY,
+        ...freshOracle,
+        refreshCombos: async () => {
+          refreshCalls += 1;
+          return REFRESH_JOIN_ABANDONED; // the panel's bounded join gave up waiting
+        },
+      }),
+    (err) => {
+      assert.match(err.message, /panel_set_widget refused "image" on node 105/, "the standard refusal frame");
+      assert.match(err.message, /still running/, "the cause: a refresh this command stopped waiting for");
+      assert.match(err.message, /did NOT complete/, "the revalidation never happened, and it says so");
+      assert.match(err.message, /NOTHING WAS WRITTEN/, "the caller must know the graph is untouched");
+      assert.match(err.message, /RETRY/, "…and that retrying is the remedy");
+      assert.match(err.message, /panel_refresh_nodes/, "…with a concrete escalation if retrying keeps failing");
+      assert.ok(
+        !/not a valid option/.test(err.message),
+        "the refresh never re-read the list, so 'invalid value' is a cause this refusal cannot assert",
+      );
+      return true;
+    },
+  );
+  assert.equal(refreshCalls, 1, "the refresh was still attempted exactly once");
+  assert.equal(widget.value, "old_a.png", "nothing was written");
+});
+
+test("#1413 an abandoned refresh outranks the upload-asset probe — no unbounded step after the budget", async () => {
+  // #387's probe is a server round-trip with no budget of its own. Running it AFTER the
+  // command's budget ran out on the refresh would reopen exactly the relay-window overrun
+  // the joinMs bound just closed — so the refusal comes first. On the retry the refresh
+  // has usually landed and a genuine asset then takes the ordinary probe path.
+  const widget = { name: "image", type: "combo", options: { values: ["old_a.png"] }, value: "old_a.png" };
+  const node = makeNode("LoadImage", widget);
+  let probes = 0;
+  await assert.rejects(
+    () =>
+      runSetWidget(node, "image", "sub/new.png", {
+        registry: REGISTRY,
+        ...freshOracle,
+        refreshCombos: async () => REFRESH_JOIN_ABANDONED,
+        confirmServerAsset: async () => {
+          probes += 1;
+          return true;
+        },
+      }),
+    /still running/,
+  );
+  assert.equal(probes, 0, "the probe does not run on a command whose budget is spent");
+  assert.equal(widget.value, "old_a.png");
+});
+
+test("#1413 a refresh that COMPLETES (resolves undefined) still drives the retry, unchanged", async () => {
+  // The healthy path must not be narrowed by the abandonment check: a plain join that
+  // settled resolves undefined (the coalescer's documented success value), and the write
+  // is then revalidated against the refreshed list exactly as before.
+  const widget = { name: "image", type: "combo", options: { values: ["old_a.png"] }, value: "old_a.png" };
+  const node = makeNode("LoadImage", widget);
+  const res = await runSetWidget(node, "image", "new.png", {
+    registry: REGISTRY,
+    ...freshOracle,
+    refreshCombos: async () => {
+      widget.options.values = ["old_a.png", "new.png"];
+      return undefined;
+    },
+  });
+  assert.equal(res.set.value, "new.png");
+  assert.equal(res.refreshed, true);
+});
+
+// ---------------------------------------------------------------------------
+// 2. The wiring: the SHIPPED graph_set_widget, extracted and run.
+// ---------------------------------------------------------------------------
+//
+// The defect is not in any helper — `makeRefreshCoalescer` has accepted `joinMs` since
+// #1192. It is in whether THIS call site threads the budget through, and only driving the
+// shipped body with the real coalescer answers that.
+
+const SET_WIDGET_SRC = (() => {
+  const m = PANEL_SRC.match(/ {2}async graph_set_widget\(\{ node_id, widget, value, workflow_uuid \}\) \{[\s\S]*?\n {2}\},/);
+  assert.ok(m, "could not locate graph_set_widget in the panel source");
+  return m[0];
+})();
+
+/** Every free name the extracted method can reach — the rgthree-lora-row list, kept in step. */
+const EXECUTOR_DEPS = [
+  "getGraphCtx",
+  "resolveNode",
+  "classifyLtxTimelineWrite",
+  "derivedTimelineRefusal",
+  "applyLtxTimelineWrite",
+  "classifyPromptRelayTimelineWrite",
+  "promptRelayDerivedRefusal",
+  "applyPromptRelayTimelineWrite",
+  "classifyRgthreeFastGroupsWrite",
+  "rgthreeFastGroupsRefusal",
+  "classifyIdeogram4PromptBuilderWrite",
+  "ideogram4PromptBuilderRefusal",
+  "awaitObjectInfoHistorySeed",
+  "isRgthreeLoraRowCreation",
+  "createRgthreeLoraRow",
+  "assertActiveWorkflowCommandTarget",
+  "WORKFLOW_UUID_FIELD",
+  "runSetWidget",
+  "objectInfoCache",
+  "CACHE_OUTCOME",
+  "fetchWholeObjectInfo",
+  "api",
+  "backendReconnectEpoch",
+  "objectInfoSnapshot",
+  "recordObjectInfoTypes",
+  "objectInfoOracleFailureNote",
+  "comfyBackendSocketDown",
+  "comfyBackendIsDown",
+  "objectInfoHistory",
+  "sourceForSubgraphInput",
+  "refreshComboOptionsFromDefs",
+  "refreshComfyNodeDefs",
+  "clearStaleRedFlag",
+  "snapshotAuthorizationNote",
+  "makeCommandBudget",
+  "SET_WIDGET_COMMAND_BUDGET_MS",
+  "SET_WIDGET_POST_REFRESH_RESERVE_MS",
+  "monotonicNow",
+];
+
+function deferred() {
+  let resolve;
+  const promise = new Promise((r) => (resolve = r));
+  return { promise, resolve };
+}
+
+/**
+ * Build the SHIPPED `graph_set_widget` with the REAL runSetWidget, the REAL coalescer and
+ * the REAL command budget — only the graph, the network and the clocks' SCALE are doubled.
+ *
+ * `budgetMs`/`reserveMs` are injected small so the tests run in milliseconds rather than
+ * waiting out the shipped 25s; the shipped numbers are pinned separately below.
+ */
+function realGraphSetWidget({
+  node,
+  widget,
+  // A promise a refresh someone else started waits on before registering — the reported
+  // scenario (a reconnect refresh still running when the write arrives). Null: nothing
+  // in flight.
+  holdInFlight = null,
+  // Set on the refresh run to make the retry SUCCEED (the healthy path).
+  onRunRegister = null,
+  budgetMs = 400,
+  reserveMs = 120,
+} = {}) {
+  const graph = {
+    _nodes: [node],
+    beforeChange() {},
+    afterChange() {},
+    setDirtyCanvas() {},
+  };
+  const context = {
+    app: { canvas: null },
+    graph,
+    // "Note" registered with NO nodeData/comfyClass — a genuine frontend-only class, the
+    // two positive signals the #475 exemption requires.
+    LG: { registered_node_types: { LoadImage: {}, Note: {} } },
+    rootGraph: graph,
+  };
+
+  // The authorization oracle answers with a schema that does NOT contain the (frontend-
+  // only, allowlisted) node type — which is precisely the case that sends the panel's
+  // refreshCombos down the full-refresh fallback this issue is about: a payload that
+  // cannot contain the keyed type must not be treated as the authoritative list (#796).
+  const api = {
+    getNodeDefs: async () => ({ LoadImage: { input: { required: { image: [["old_a.png"], {}] } } } }),
+    fetchApi: async () => ({ ok: false, status: 404 }),
+  };
+
+  // The REAL single-flight coordinator over a real slot, with a real in-flight run when
+  // the test holds one open. Stubbing this away would remove the term the issue is about.
+  let inFlight = null;
+  const runs = [];
+  const refreshComfyNodeDefs = makeRefreshCoalescer({
+    getInFlight: () => inFlight,
+    setInFlight: (p) => {
+      inFlight = p;
+    },
+    runRegister: async (defs) => {
+      runs.push(defs);
+      if (defs == null && holdInFlight) await holdInFlight;
+      onRunRegister?.(defs);
+      return true;
+    },
+    withTimeout,
+  });
+  const inFlightStarted = holdInFlight ? refreshComfyNodeDefs(undefined) : null;
+
+  const deps = {
+    getGraphCtx: () => context,
+    resolveNode: () => node,
+    classifyLtxTimelineWrite: () => null,
+    classifyPromptRelayTimelineWrite: () => null,
+    classifyRgthreeFastGroupsWrite: () => null,
+    classifyIdeogram4PromptBuilderWrite: () => null,
+    awaitObjectInfoHistorySeed: async () => {},
+    // The REAL classifier and creator, as rgthree-lora-row.test.mjs requires: a double
+    // would let the executor pass against a route that never fires.
+    isRgthreeLoraRowCreation,
+    createRgthreeLoraRow,
+    assertActiveWorkflowCommandTarget: () => {},
+    WORKFLOW_UUID_FIELD: "workflow_uuid",
+    runSetWidget,
+    objectInfoCache: createObjectInfoCache(),
+    CACHE_OUTCOME,
+    fetchWholeObjectInfo,
+    api,
+    backendReconnectEpoch: 0,
+    objectInfoSnapshot: { record: () => true, authorize: () => ({ defs: null, reason: "none recorded" }) },
+    recordObjectInfoTypes: (defs) => defs,
+    objectInfoOracleFailureNote,
+    comfyBackendSocketDown: false,
+    comfyBackendIsDown: () => false,
+    // "Note" is frontend-only and never seen on a backend — never-seen is the verdict that
+    // lets the #475 allowlist authorize it against a schema that cannot contain it.
+    objectInfoHistory: { wasTypeEverDefined: () => false },
+    sourceForSubgraphInput: () => undefined,
+    refreshComboOptionsFromDefs: () => 0,
+    refreshComfyNodeDefs,
+    clearStaleRedFlag: () => {},
+    snapshotAuthorizationNote: () => "",
+    ...setWidgetCommandBudgetDeps(),
+    SET_WIDGET_COMMAND_BUDGET_MS: budgetMs,
+    SET_WIDGET_POST_REFRESH_RESERVE_MS: reserveMs,
+  };
+  const factory = new Function(
+    ...EXECUTOR_DEPS,
+    `const GRAPH_TOOL_EXECUTORS = { ${SET_WIDGET_SRC} }; return GRAPH_TOOL_EXECUTORS.graph_set_widget;`,
+  );
+  return {
+    graph_set_widget: factory(...EXECUTOR_DEPS.map((n) => deps[n])),
+    runs,
+    inFlightStarted,
+  };
+}
+
+// A "Note" node is on the reserved frontend-only allowlist (#475): registered with no
+// backend provenance, legitimately absent from /object_info, so authorization passes AND
+// the payload cannot refresh its combo — the one route to the full-refresh fallback.
+function noteNode() {
+  const widget = { name: "mode", type: "combo", options: { values: ["a"] }, value: "a" };
+  const node = { id: 7, type: "Note", widgets: [widget] };
+  return { node, widget };
+}
+
+test("#1413 wiring: a held-open in-flight refresh refuses the write at the budget, in words", async () => {
+  const { node, widget } = noteNode();
+  const gate = deferred(); // the reconnect run never lands — the reported scenario
+  const built = realGraphSetWidget({ node, holdInFlight: gate.promise, budgetMs: 400, reserveMs: 120 });
+
+  const started = Date.now();
+  await assert.rejects(
+    () => built.graph_set_widget({ node_id: 7, widget: "mode", value: "b", workflow_uuid: "u" }),
+    (err) => {
+      assert.match(err.message, /panel_set_widget refused "mode" on node 7/, "the standard refusal frame");
+      assert.match(err.message, /still running/, "the true cause, not 'not a valid option'");
+      assert.match(err.message, /NOTHING WAS WRITTEN/);
+      assert.match(err.message, /RETRY/);
+      return true;
+    },
+  );
+  const elapsed = Date.now() - started;
+  assert.ok(
+    elapsed < 4000,
+    `the write took ${elapsed}ms — unbounded, it would never have answered at all while the gate is held`,
+  );
+  assert.equal(widget.value, "a", "nothing was written");
+  assert.deepEqual(built.runs, [undefined], "the abandoned write did NOT start a competing refresh run");
+
+  gate.resolve();
+  await built.inFlightStarted?.catch(() => {});
+});
+
+test("#1413 wiring: an in-flight refresh that LANDS in time lets the retry succeed", async () => {
+  // The bound must not become a way to refuse writes on a machine doing nothing wrong.
+  const { node, widget } = noteNode();
+  const built = realGraphSetWidget({
+    node,
+    holdInFlight: new Promise((r) => setTimeout(r, 20)),
+    onRunRegister: () => {
+      widget.options.values = ["a", "b"]; // the refresh delivers the new option
+    },
+    budgetMs: 4000,
+    reserveMs: 120,
+  });
+
+  const res = await built.graph_set_widget({ node_id: 7, widget: "mode", value: "b", workflow_uuid: "u" });
+  assert.equal(res.set.value, "b", "the write landed on the retry");
+  assert.equal(res.refreshed, true);
+  await built.inFlightStarted;
+});
+
+test("#1413 wiring: with NOTHING in flight the fallback still runs the refresh, bounded", async () => {
+  const { node, widget } = noteNode();
+  const built = realGraphSetWidget({
+    node,
+    onRunRegister: () => {
+      widget.options.values = ["a", "b"];
+    },
+    budgetMs: 4000,
+    reserveMs: 120,
+  });
+  const res = await built.graph_set_widget({ node_id: 7, widget: "mode", value: "b", workflow_uuid: "u" });
+  assert.equal(res.set.value, "b");
+  assert.equal(built.runs.length, 1, "the fallback ran exactly one refresh");
+});
+
+// ---------------------------------------------------------------------------
+// 3. The shipped numbers, pinned against the relay window (the single-node-def
+//    technique): the harnesses above inject small budgets, so only a source-level check
+//    can catch the constants drifting.
+// ---------------------------------------------------------------------------
+
+test("#1413 the shipped budget mirrors add_node's against the same 30s relay window", () => {
+  assert.equal(SET_WIDGET_COMMAND_BUDGET_MS, 25000, "25s budget + 5s slack against the 30s relay");
+  assert.ok(
+    SET_WIDGET_POST_REFRESH_RESERVE_MS > 0 && SET_WIDGET_POST_REFRESH_RESERVE_MS < SET_WIDGET_COMMAND_BUDGET_MS,
+    "a reserve that is nothing protects nothing; one that is everything refuses everything",
+  );
+  const body = SET_WIDGET_SRC;
+  assert.match(
+    body,
+    /const budget = makeCommandBudget\(SET_WIDGET_COMMAND_BUDGET_MS, monotonicNow\);/,
+    "the deadline is taken inside the handler, from the monotonic clock",
+  );
+  assert.match(
+    body,
+    /joinMs: budget\.remaining\(\) - SET_WIDGET_POST_REFRESH_RESERVE_MS/,
+    "the fallback join draws from the command's remaining budget, not a fresh constant",
+  );
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -10396,8 +10396,9 @@ const ADD_NODE_COMMAND_BUDGET_MS = 25000;
  * change only TWO of the six held a command budget — `graph_add_node` (#1192) and
  * `nodes_install` (#671) — so "the last one that never took one" was false, and the false
  * version of this sentence concealed a sibling: `graph_set_widget`'s stale-combo recovery
- * awaits the coalescer with no bound of its own. Filed separately rather than folded in; the
- * point for a future reader is that this is a RECURRING shape, not a last straggler.
+ * awaits the coalescer with no bound of its own (bounded in #1413). Filed separately rather
+ * than folded in; the point for a future reader is that this is a RECURRING shape, not a
+ * last straggler.
  *
  * REPORTED: after a workflow switch and a successful re-target, `panel_refresh_nodes` got no
  * acknowledgement for 30 s while ComfyUI stayed healthy and idle; the identical call then
@@ -10544,6 +10545,44 @@ function widenSocketProofBudget(deadlineMs) {
   // fetch inside a wait that has already run out.
   return Math.max(1, Math.floor(whole / WIDEN_SOCKET_PROOF_DIVISOR));
 }
+
+/**
+ * #1413 — `graph_set_widget`'s whole-command deadline, taken on the handler's first line.
+ *
+ * The fourth instance of the defect #1192 fixed for `graph_add_node` and #1404/#1409 for
+ * `refresh_nodes`: a wait relayed inside the orchestrator's 30,000 ms window
+ * (`OBJECT_INFO_REFRESH_ACK_TIMEOUT_MS` in comfyui-mcp's panel-tools.ts — the same relay
+ * constant add_node is measured against) that never took a command budget. Here it is the
+ * stale-combo recovery's `refreshComfyNodeDefs()` fallback: a plain join of a run someone
+ * else started, under a deadline this command never stated. One run is ~14.5 s of wall
+ * clock (NODE_DEFS_RUN_BUDGET_MS deliberately stops its clock across
+ * registerNodesFromDefs/reapplyDefsToLiveNodes), and the recovery is reached only AFTER
+ * the authorization /object_info has already spent part of the window — so an unbounded
+ * join can outlive the relay even with every other step on the path bounded, and the
+ * reply is then the bare `did not reply to "graph_set_widget" within 30000 ms` that names
+ * nothing, instead of the worded, retryable refusal below.
+ *
+ * 25,000 ms, mirroring ADD_NODE_COMMAND_BUDGET_MS against the same 30,000 ms window for
+ * the same reason: 5,000 ms of slack for composing the reply, serialising it, and the
+ * websocket hop. Mirrored rather than derived for the same reason too — the relay
+ * constant lives in the OTHER repo, and a derived copy here could not be kept true.
+ */
+const SET_WIDGET_COMMAND_BUDGET_MS = 25000;
+
+/**
+ * #1413 — what a widget write still has to do AFTER the stale-combo refresh, held back so
+ * the join cannot spend it.
+ *
+ * The retry write itself is synchronous, but a still-refused value then runs the #387
+ * upload-asset probe (one ranged /view request), and the refusal or result still has to
+ * be composed, serialised and relayed. A join handed the whole remainder can land at the
+ * wire and leave those steps nothing — the same wrong-cause refusal
+ * ADD_NODE_POST_REFRESH_RESERVE_MS exists to prevent on the add path. PICKED, not derived:
+ * none of the steps it protects has a measured bound to derive from, and the cost of a
+ * reserve that is too large is only a slightly earlier "retry" on a path that was already
+ * going to say exactly that.
+ */
+const SET_WIDGET_POST_REFRESH_RESERVE_MS = 4000;
 
 async function awaitRequiredCustomWidgetRegistration(
   nodeData,
@@ -13564,6 +13603,12 @@ const GRAPH_TOOL_EXECUTORS = {
   },
 
   async graph_set_widget({ node_id, widget, value, workflow_uuid }) {
+    // #1413 — ONE deadline for the whole command, taken BEFORE anything awaits, so the
+    // bounded steps inside it compose instead of adding (#1192, #671). The step this
+    // exists for is the stale-combo recovery's refresh join below: reached only after
+    // the authorization /object_info has already spent part of the relay window, and
+    // unbounded until now.
+    const budget = makeCommandBudget(SET_WIDGET_COMMAND_BUDGET_MS, monotonicNow);
     const { app, graph, LG, rootGraph } = getGraphCtx();
     const node = resolveNode(graph, node_id);
     // #982 — PER-REQUEST, not module state (codex). A concurrent refresh or a second
@@ -13935,7 +13980,19 @@ const GRAPH_TOOL_EXECUTORS = {
           refreshComboOptionsFromDefs(target, defs, keyType, nameMap);
           return;
         }
-        return refreshComfyNodeDefs();
+        // #1413 — the ONE await on this recovery path that was never bounded: a plain
+        // join of a node-def refresh someone else started, under a deadline this command
+        // never stated. It now draws what the command has left, minus the reserve the
+        // retry write and the reply still need. The run is NOT cancelled (the coalescer
+        // never cancels work in flight — it keeps the slot and keeps registering, which
+        // is exactly what makes the retry safe). REFRESH_JOIN_ABANDONED comes back as the
+        // return value rather than a throw, because set-widget.js awaits this call inside
+        // a best-effort catch that would swallow one; the lib turns the token into a
+        // worded "nothing was written — retry" refusal instead of revalidating against
+        // the list that was never refreshed and calling the value invalid.
+        return refreshComfyNodeDefs(undefined, {
+          joinMs: budget.remaining() - SET_WIDGET_POST_REFRESH_RESERVE_MS,
+        });
       },
       // #387: last-resort probe for an UPLOAD input value the refreshed /object_info
       // combo still cannot list — a LoadImage image uploaded under a SUBFOLDER (ComfyUI

--- a/web/js/lib/set-widget.js
+++ b/web/js/lib/set-widget.js
@@ -39,6 +39,7 @@ import {
 import { controlAfterGenerateWarning, controlEntryForWidget } from "./control-after-generate.js";
 import { linkDrivenWidgets, drivenTag } from "./graph-read.js";
 import { refreshDynamicInputsAfterWrite } from "./dynamic-inputs-refresh.js";
+import { REFRESH_JOIN_ABANDONED } from "./refresh-coalesce.js";
 import {
   uploadInputConfig,
   uploadInputAccepts,
@@ -73,6 +74,32 @@ function coerceAdvisoryMessage(err) {
   } catch {
     return "the reason could not be rendered";
   }
+}
+
+/**
+ * #1413 — the refusal for a stale-combo recovery whose authoritative refresh was still
+ * running when the command's budget ran out.
+ *
+ * RECOVERABLE BY CONSTRUCTION, and worded to say so — the same shape as #1192's
+ * addNodeRefreshBusyMessage. The in-flight refresh was NOT cancelled (the coalescer never
+ * cancels work someone else started) and it is registering the very list this write needs,
+ * so the retry this text asks for is the normal outcome, not a hope. What it must NOT say
+ * is "not a valid option": the revalidation never completed, so this refusal cannot tell a
+ * genuinely-invalid value from one the refresh would have accepted — and claiming the
+ * former is how a retryable busy reads as a permanent rejection.
+ */
+function staleComboRefreshBusyMessage() {
+  return (
+    "the value is not in this combo's current option list, and the authoritative refresh " +
+    "that would have re-read the list — a node-def refresh started by a ComfyUI reconnect, " +
+    "a finished install, or another tool call — was still running when this command's time " +
+    "budget ran out waiting for it, so the revalidation did NOT complete. This refusal " +
+    "cannot tell a genuinely-invalid value from one the refresh would have accepted. " +
+    "NOTHING WAS WRITTEN and nothing was changed. That refresh is still running and is " +
+    "registering exactly the list this write needs, so RETRY in a few seconds — this " +
+    "normally succeeds on the next attempt. If it keeps happening, call panel_refresh_nodes " +
+    "once and wait for it to report, then retry the write."
+  );
 }
 
 export async function runSetWidget(
@@ -806,6 +833,11 @@ export async function runSetWidget(
     // upload-asset probe for a value the refreshed list still cannot contain.
     let latest = err;
     if (typeof refreshCombos === "function") {
+      // #1413 — the panel bounds this wait by the command's remaining budget, and a bound
+      // that runs out is reported back as a STRUCTURED TOKEN (REFRESH_JOIN_ABANDONED), not
+      // a throw — the catch below is the best-effort channel and would swallow one. The
+      // in-flight refresh is not cancelled by the abandonment; only THIS caller's wait ends.
+      let refreshJoinAbandoned = false;
       try {
         // Reuse the /object_info payload already fetched for type authorization so a
         // combo miss does not round-trip /object_info a SECOND time (#458 P2). Key the
@@ -817,9 +849,24 @@ export async function runSetWidget(
           writeTargetWidgetName && concreteWidgetName
             ? { [writeTargetWidgetName]: concreteWidgetName }
             : undefined;
-        await refreshCombos(freshDefs ?? undefined, resolvedTargetNode, authTarget?.type, comboNameMap);
+        const refreshOutcome = await refreshCombos(freshDefs ?? undefined, resolvedTargetNode, authTarget?.type, comboNameMap);
+        refreshJoinAbandoned = refreshOutcome === REFRESH_JOIN_ABANDONED;
       } catch {
         /* refresh best-effort; fall through to re-raise the original rejection */
+      }
+      // #1413 — the refresh never re-read the list, so the retry CANNOT be trusted: it
+      // would re-fail against the same stale snapshot and the refusal would call the
+      // value "not a valid option" — a false cause for a retryable busy, and the exact
+      // report this issue exists to replace. Refuse IN WORDS instead, before the retry
+      // and before the upload probe: the budget that ran out is the command's, and an
+      // unbounded /view probe after it would reopen the relay-window overrun the bound
+      // just closed. On the retry the refresh has usually landed, so the value then
+      // takes the ordinary path — accepted against the fresh list, or probed, or refused
+      // for a reason that is true. A PARTIAL first write is the one case that outranks
+      // this wording: its own error reports a graph that could not be restored, and that
+      // must propagate undiluted rather than be replaced by "nothing was written".
+      if (refreshJoinAbandoned) {
+        throw refusalFrame(err.partialWrite ? err : new Error(staleComboRefreshBusyMessage()));
       }
       try {
         return withWarning({ set: write(), refreshed: true });


### PR DESCRIPTION
Closes #1413

## Root cause

`graph_set_widget`'s stale-combo recovery awaited `refreshComfyNodeDefs()` with no `joinMs` and no outer bound — the fourth instance of the wait-relayed-inside-the-30s-window defect (#1192 `graph_add_node` → #1349 → #1404 `refresh_nodes` → this). The recovery is reached only *after* the authorization `/object_info` has already spent part of the window, so a plain join of a refresh run someone else started (~14.5 s wall clock; `NODE_DEFS_RUN_BUDGET_MS` deliberately stops its clock across the local registration work) could outlive the relay even with every other step bounded. The reply then never left the tab, and the user got a bare `did not reply to "graph_set_widget" within 30000 ms` instead of a worded, retryable refusal.

## What changed

Same shape as #1192/#1399, reusing the existing primitives — no new mechanism:

- **`web/js/comfyui-mcp-panel.js`** — the handler takes a command budget on its first line (`makeCommandBudget(SET_WIDGET_COMMAND_BUDGET_MS, monotonicNow)`, 25,000 ms mirroring `ADD_NODE_COMMAND_BUDGET_MS` against the same 30 s relay window). The `refreshCombos` fallback now passes `joinMs: budget.remaining() - SET_WIDGET_POST_REFRESH_RESERVE_MS` (4,000 ms held back for the retry write, the #387 probe, and composing the reply — picked, not derived, and the comment says so).
- **`web/js/lib/set-widget.js`** — the recovery reads `REFRESH_JOIN_ABANDONED` back from `refreshCombos` (a structured token rather than a throw, since that await sits inside a best-effort catch) and refuses **in words**: the revalidation did not complete, this refusal cannot tell a genuinely-invalid value from one the refresh would have accepted, NOTHING WAS WRITTEN, RETRY (the in-flight run is never cancelled, so the retry joins work already in progress), escalate to `panel_refresh_nodes` if it persists. It never falls through to "not a valid option", and it refuses *before* the unbounded upload-asset probe so a spent budget is not followed by another unbounded wait. A `partialWrite` first error still propagates verbatim per `refusalFrame`'s contract.

## Tests

- New `browser_tests/unit/set-widget-stale-combo-budget.test.mjs`: lib-level refusal wording/honesty (driving the real `runSetWidget`), plus the **shipped** `graph_set_widget` extracted from the panel source and run against the **real** coalescer with a held-open in-flight run — asserting the command answers at the budget rather than hanging, starts no competing run, and still succeeds when the refresh lands in time. Shipped numbers pinned against the relay window at the source level.
- `set-widget-combo-fallback.test.mjs` (which drives the shipped `refreshCombos` wiring) gained the new free names and pins that the fallback carries `joinMs` from the budget — including the exhausted-budget (`<= 0`) shape the coalescer abandons on without awaiting.
- `_panel-constants.mjs` gained `SET_WIDGET_COMMAND_BUDGET_MS` / `SET_WIDGET_POST_REFRESH_RESERVE_MS` (read from panel source) and `setWidgetCommandBudgetDeps()`; `rgthree-lora-row.test.mjs`'s executor harness now injects them (it runs the shipped handler and would otherwise hit the new free identifiers).

## Audit of the other two relayed commands (requested in the issue)

`graph_get_object_info` and `graph_remove_widget` never await the coalescer — their only wait is a single `/object_info` read through `fetchWholeObjectInfo`, which is already deadline-bounded (`OBJECT_INFO_DEADLINE_MS`). No fifth instance of *this* shape hides there.

## Gates

- `npm ci` ✓
- `npm run test:unit` ✓ (5,593 tests, 0 failures; one `manager-install` assertion flaked on a first full run and passed on the isolated and repeated full runs — untouched by this change)
- `npm run typecheck` ✓
