### PR TITLE
fix(1418): the stale-combo refusal names both abandoned states, and the #387 /view probe is bounded

### DIFF
--- a/browser_tests/unit/_panel-constants.mjs
+++ b/browser_tests/unit/_panel-constants.mjs
@@ -18,6 +18,8 @@ import { REFRESH_JOIN_ABANDONED } from "../../web/js/lib/refresh-coalesce.js";
 import { NODE_DEF_REFRESH_REASONS } from "../../web/js/lib/node-def-refresh.js";
 import { clearInheritedExecutionPreview } from "../../web/js/lib/execution-preview-attach.js";
 import { sanitizeNodeAuxId } from "../../web/js/lib/aux-id-sanitize.js";
+import { withTimeout } from "../../web/js/lib/bounded-step.js";
+import { OBJECT_INFO_DEADLINE_MS } from "../../web/js/lib/object-info-oracle.js";
 
 export const PANEL_SRC = readFileSync(
   fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url)),
@@ -154,6 +156,15 @@ export const OBJECT_INFO_SEED_WAIT_MS = readPanelNumber(
   "the baseline seed wait",
 );
 
+/** #1418 — the cap on the #387 upload-asset /view probe, drawn from the post-refresh reserve. */
+export const SET_WIDGET_ASSET_PROBE_MS = readPanelNumber(
+  /const SET_WIDGET_ASSET_PROBE_MS = (\d+);/,
+  "the set_widget upload-asset probe bound",
+);
+
+/** #1418 — re-exported so a harness reads the oracle's OWN number, never a copy of it. */
+export { OBJECT_INFO_DEADLINE_MS };
+
 /**
  * #1192 — every module binding the command budget added to `graph_add_node`, in ONE place.
  *
@@ -206,5 +217,13 @@ export function setWidgetCommandBudgetDeps() {
     SET_WIDGET_COMMAND_BUDGET_MS,
     SET_WIDGET_POST_REFRESH_RESERVE_MS,
     monotonicNow,
+    // #1418 — the three bindings the two capped waits and the bounded #387 probe added.
+    // REAL, not stubbed: `withTimeout` is the repo's one bounding primitive and a double
+    // would let a harness pass against a probe that bounds nothing, and both numbers are
+    // read from the panel source for the reason at the top of this file.
+    withTimeout,
+    OBJECT_INFO_DEADLINE_MS,
+    SET_WIDGET_ASSET_PROBE_MS,
+    OBJECT_INFO_SEED_WAIT_MS,
   };
 }

--- a/browser_tests/unit/_panel-constants.mjs
+++ b/browser_tests/unit/_panel-constants.mjs
@@ -19,6 +19,7 @@ import { NODE_DEF_REFRESH_REASONS } from "../../web/js/lib/node-def-refresh.js";
 import { clearInheritedExecutionPreview } from "../../web/js/lib/execution-preview-attach.js";
 import { sanitizeNodeAuxId } from "../../web/js/lib/aux-id-sanitize.js";
 import { withTimeout } from "../../web/js/lib/bounded-step.js";
+import { inputAssetProbeVerdict } from "../../web/js/lib/input-asset.js";
 import { OBJECT_INFO_DEADLINE_MS } from "../../web/js/lib/object-info-oracle.js";
 
 export const PANEL_SRC = readFileSync(
@@ -225,5 +226,9 @@ export function setWidgetCommandBudgetDeps() {
     OBJECT_INFO_DEADLINE_MS,
     SET_WIDGET_ASSET_PROBE_MS,
     OBJECT_INFO_SEED_WAIT_MS,
+    // #1418 — the #387 probe now returns #1357's TRI-STATE verdict rather than a
+    // boolean, so an unanswered probe stays distinguishable from a real 404. REAL: a
+    // stub would classify every response as whatever the stub decided.
+    inputAssetProbeVerdict,
   };
 }

--- a/browser_tests/unit/object-info-snapshot.test.mjs
+++ b/browser_tests/unit/object-info-snapshot.test.mjs
@@ -30,7 +30,9 @@ import {
   TRANSPORT_OUTCOME,
   fetchWholeObjectInfo,
   objectInfoOracleFailureNote,
+  OBJECT_INFO_DEADLINE_MS,
 } from "../../web/js/lib/object-info-oracle.js";
+import { makeCommandBudget } from "../../web/js/lib/command-budget.js";
 import { createObjectInfoCache, CACHE_OUTCOME } from "../../web/js/lib/object-info-cache.js";
 
 const SCHEMA = { KSampler: { input: {} }, H3Keyframes: { input: {} } };
@@ -508,6 +510,15 @@ function buildShippedOracle({ api, socketDown = false, epoch = 5, snapshot, epoc
     "epochDuringFetch",
     "comfyBackendSocketDown",
     "objectInfoOracleFailureNote",
+    // #1418 — the shipped body now caps the oracle deadline with the command budget
+    // (`deadlineMs: budget.bounded(OBJECT_INFO_DEADLINE_MS)`), so both names have to
+    // exist in this scope or the extracted body throws ReferenceError before it runs.
+    // REAL, not doubled: a stub `budget` would let this harness pass against a call
+    // site whose bound had been deleted. The bound itself is proven in
+    // set-widget-budget-composition.test.mjs — the wrapper below overrides deadlineMs
+    // to 20 so these #1223 cases run fast, which is why they cannot prove it here.
+    "budget",
+    "OBJECT_INFO_DEADLINE_MS",
     // `backendReconnectEpoch` MUST be a live mutable binding in the same scope as the
     // extracted body, because the panel's is module state the body re-reads. An earlier
     // version passed it as a frozen value, which made `observedAtEpoch` and the record-time
@@ -552,6 +563,8 @@ function buildShippedOracle({ api, socketDown = false, epoch = 5, snapshot, epoc
     epochDuringFetch,
     socketDown,
     objectInfoOracleFailureNote,
+    makeCommandBudget(25000, () => performance.now()),
+    OBJECT_INFO_DEADLINE_MS,
   );
 }
 

--- a/browser_tests/unit/rgthree-lora-row.test.mjs
+++ b/browser_tests/unit/rgthree-lora-row.test.mjs
@@ -1331,6 +1331,7 @@ const EXECUTOR_DEPS = [
   "OBJECT_INFO_DEADLINE_MS",
   "SET_WIDGET_ASSET_PROBE_MS",
   "withTimeout",
+  "inputAssetProbeVerdict",
 ];
 
 /**

--- a/browser_tests/unit/rgthree-lora-row.test.mjs
+++ b/browser_tests/unit/rgthree-lora-row.test.mjs
@@ -1324,6 +1324,13 @@ const EXECUTOR_DEPS = [
   "SET_WIDGET_COMMAND_BUDGET_MS",
   "SET_WIDGET_POST_REFRESH_RESERVE_MS",
   "monotonicNow",
+  // #1418 — the capped seed wait, the capped authorization deadline and the bounded
+  // #387 /view probe. Supplied by setWidgetCommandBudgetDeps(); named here because a
+  // free identifier the rebuilt body reaches is a ReferenceError, not a failed assert.
+  "OBJECT_INFO_SEED_WAIT_MS",
+  "OBJECT_INFO_DEADLINE_MS",
+  "SET_WIDGET_ASSET_PROBE_MS",
+  "withTimeout",
 ];
 
 /**

--- a/browser_tests/unit/set-widget-budget-composition.test.mjs
+++ b/browser_tests/unit/set-widget-budget-composition.test.mjs
@@ -178,6 +178,7 @@ const EXECUTOR_DEPS = [
   "OBJECT_INFO_DEADLINE_MS",
   "SET_WIDGET_ASSET_PROBE_MS",
   "withTimeout",
+  "inputAssetProbeVerdict",
 ];
 
 const never = () => new Promise(() => {});
@@ -395,6 +396,58 @@ test("#1418 the #387 /view probe IS reached after a refresh that completes, and 
   assert.match(built.seen.viewRoutes[0], /subfolder=sub/, "…with the nested path #387 is about");
   assert.ok(elapsed < 2500, `the command answered in ${elapsed}ms; unbounded the probe never settles`);
   assert.equal(widget.value, "top.png", "a probe that could not answer admits nothing — #240 strictness holds");
+});
+
+test("#1418 a probe that could not ANSWER is not reported as a confirmed miss", async () => {
+  // The trap this bound would otherwise set. #1357 established the tri-state for the live
+  // combo scan: `false` is the server saying the file is not there, `null` is nobody having
+  // answered. Bounding the probe created a NEW way to produce `null`, and the old boolean
+  // collapsed it into `false` — so a command whose budget ran out would tell the caller
+  // their perfectly-real nested upload is invalid, on the strength of a request that never
+  // came back. That is the same wrong-cause shape this issue is about.
+  const { node, widget } = loadImageNode();
+  const built = realGraphSetWidget({
+    node,
+    getNodeDefs: async () => UPLOAD_DEFS,
+    viewFetch: never, // reached, bounded, never answers
+    budgetMs: 4000,
+    probeMs: 200,
+  });
+  const outcome = await withinWatchdog(2500, "the refusal", () =>
+    built.graph_set_widget({ node_id: 12, widget: "image", value: "sub/new.png", workflow_uuid: "u" }),
+  );
+  assert.ok(outcome instanceof Error);
+  assert.equal(built.seen.viewRoutes.length, 1, "the probe was reached");
+  assert.match(outcome.message, /probe did NOT answer/, "the refusal says the question went unanswered");
+  assert.match(
+    outcome.message,
+    /does NOT\s+establish that the file is missing/,
+    "…and explicitly declines to assert the cause it could not observe",
+  );
+  assert.match(outcome.message, /RETRY/, "…and says the one thing that can change the answer");
+  assert.equal(widget.value, "top.png", "still nothing written — #240 strictness is untouched");
+});
+
+test("#1418 a server that ANSWERS 404 is still a confirmed miss, with no unanswered note", async () => {
+  // The other half: `false` must keep meaning what it meant. A refusal that hedged on a
+  // real 404 would be its own kind of dishonesty, and would train callers to retry forever.
+  const { node } = loadImageNode();
+  const built = realGraphSetWidget({
+    node,
+    getNodeDefs: async () => UPLOAD_DEFS,
+    viewFetch: async () => ({ ok: false, status: 404 }),
+    budgetMs: 4000,
+    probeMs: 300,
+  });
+  const outcome = await withinWatchdog(2500, "the refusal", () =>
+    built.graph_set_widget({ node_id: 12, widget: "image", value: "sub/new.png", workflow_uuid: "u" }),
+  );
+  assert.ok(outcome instanceof Error);
+  assert.equal(built.seen.viewRoutes.length, 1, "the probe was reached and answered");
+  assert.ok(
+    !/probe did NOT answer/.test(outcome.message),
+    "the server answered, so the refusal must NOT hedge — 404 is a real observation",
+  );
 });
 
 test("#1418 a /view that ANSWERS still accepts the nested asset — the bound refuses nothing else", async () => {

--- a/browser_tests/unit/set-widget-budget-composition.test.mjs
+++ b/browser_tests/unit/set-widget-budget-composition.test.mjs
@@ -1,0 +1,523 @@
+/**
+ * #1418 — three things #1416 left behind, and the audit #1413 asked for.
+ *
+ *   1. THE REFUSAL ASSERTED A REFRESH THAT WAS NOT RUNNING. `REFRESH_JOIN_ABANDONED` comes
+ *      back from `refresh-coalesce.js` in TWO states — a join this caller gave up on, and
+ *      a non-positive `joinMs` against an EMPTY slot, which starts nothing — and the
+ *      shipped text ("That refresh is still running and is registering exactly the list
+ *      this write needs") was true in only one. The second arm was reachable with NO
+ *      concurrency at all, because the two waits ahead of the recovery still held flat
+ *      constants that composed past the command budget: 8,000 ms seed + 20,000 ms oracle =
+ *      28,000 ms against a 25,000 ms budget, so `joinMs` came out at -7,000.
+ *
+ *   2. THE #387 `/view` PROBE WAS STILL UNBOUNDED. #1416's abandoned-refresh refusal fires
+ *      before it, which covers the abandoned arm only — when the refresh COMPLETES and the
+ *      retry write still misses (the subfolder-nested LoadImage image the probe exists
+ *      for), the ladder reaches it, and it was the last network step of a command relayed
+ *      at 30,000 ms with no bound of any kind.
+ *
+ *   3. THE AUDIT #1413 ASKED FOR, as a test rather than a sentence: `graph_get_object_info`
+ *      and `graph_remove_widget` are the other two relayed commands, and both are clean
+ *      today — one await each, landing on `fetchWholeObjectInfo`, which bounds itself.
+ *      That is a claim with a shelf life, so it goes red the day either grows a second
+ *      wait or reaches the coalescer, whether or not anyone rereads the note.
+ *
+ * WHAT THESE TESTS DRIVE. The bounds are one-line wiring changes, and a helper-level test
+ * cannot see them — `withTimeout`, `makeCommandBudget` and `fetchWholeObjectInfo` all
+ * accepted these arguments before this change and would pass against a call site that
+ * never passes one. So the SHIPPED `graph_set_widget` body is extracted from the panel
+ * source and run, with the REAL oracle, the REAL budget and the REAL bounding primitive;
+ * only the graph, the network and the SCALE of the constants are doubled.
+ *
+ * AND THE SOURCE PINS ARE SCOPED TO THAT BODY, never to the file. A pin written as
+ * `assert.match(PANEL_SRC, /awaitObjectInfoHistorySeed\(budget\.bounded\(/)` stays GREEN
+ * with `graph_set_widget`'s bound deleted, because `graph_add_node`'s sibling call site
+ * satisfies it — measured, on the branch this issue came from.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { runSetWidget } from "../../web/js/lib/set-widget.js";
+import { makeRefreshCoalescer, REFRESH_JOIN_ABANDONED } from "../../web/js/lib/refresh-coalesce.js";
+import { withTimeout } from "../../web/js/lib/bounded-step.js";
+import { makeCommandBudget } from "../../web/js/lib/command-budget.js";
+import { createObjectInfoCache, CACHE_OUTCOME } from "../../web/js/lib/object-info-cache.js";
+import { fetchWholeObjectInfo, objectInfoOracleFailureNote } from "../../web/js/lib/object-info-oracle.js";
+import { isRgthreeLoraRowCreation, createRgthreeLoraRow } from "../../web/js/lib/rgthree-lora-row.js";
+import {
+  PANEL_SRC,
+  setWidgetCommandBudgetDeps,
+  SET_WIDGET_COMMAND_BUDGET_MS,
+  SET_WIDGET_POST_REFRESH_RESERVE_MS,
+  SET_WIDGET_ASSET_PROBE_MS,
+  OBJECT_INFO_SEED_WAIT_MS,
+  OBJECT_INFO_DEADLINE_MS,
+} from "./_panel-constants.mjs";
+
+// ---------------------------------------------------------------------------
+// 0. The arm the shipped refusal denied existed.
+// ---------------------------------------------------------------------------
+
+test("#1418 the exhausted arm returns REFRESH_JOIN_ABANDONED having started NOTHING", async () => {
+  // Driven over the REAL coalescer at the REAL shipped numbers, on a virtual clock so the
+  // 25s budget costs no wall time. This is the measurement the issue reports, reproduced:
+  // an empty slot plus a non-positive joinMs is the token with no concurrency anywhere.
+  let t = 0;
+  const budget = makeCommandBudget(SET_WIDGET_COMMAND_BUDGET_MS, () => t);
+  t += OBJECT_INFO_SEED_WAIT_MS; // the seed wait, at its own flat constant
+  t += OBJECT_INFO_DEADLINE_MS; // the authorization /object_info, at its own flat constant
+  const joinMs = budget.remaining() - SET_WIDGET_POST_REFRESH_RESERVE_MS;
+  assert.ok(joinMs <= 0, `uncapped, the two waits ahead of the recovery leave joinMs=${joinMs}`);
+
+  let inFlight = null;
+  const runs = [];
+  const refresh = makeRefreshCoalescer({
+    getInFlight: () => inFlight,
+    setInFlight: (p) => (inFlight = p),
+    runRegister: async (defs) => {
+      runs.push(defs);
+      return true;
+    },
+    withTimeout,
+  });
+  const outcome = await refresh(undefined, { joinMs });
+  assert.equal(outcome, REFRESH_JOIN_ABANDONED, "the token comes back");
+  assert.equal(runs.length, 0, "…having started no run at all");
+  assert.equal(inFlight, null, "…and leaving the slot empty, so nothing is registering anything");
+});
+
+test("#1418 the refusal names BOTH abandoned states and rests the retry on the fresh budget", async () => {
+  const widget = { name: "image", type: "combo", options: { values: ["old_a.png"] }, value: "old_a.png" };
+  const node = { id: 105, type: "LoadImage", widgets: [widget] };
+  await assert.rejects(
+    () =>
+      runSetWidget(node, "image", "new.png", {
+        registry: { LoadImage: {} },
+        getFreshObjectInfo: async () => ({ LoadImage: {} }),
+        refreshCombos: async () => REFRESH_JOIN_ABANDONED,
+      }),
+    (err) => {
+      const m = err.message;
+      // STATE A — a run someone else started, still going.
+      assert.match(m, /still running when the budget ran out waiting for it/, "state A is named");
+      assert.match(m, /was NOT\s+cancelled/, "…and that it survives, which is what makes the retry useful");
+      // STATE B — the budget was gone before the recovery; nothing was started.
+      assert.match(
+        m,
+        /no refresh was\s+started for this write at all/,
+        "state B is named — the arm the shipped text asserted could not happen",
+      );
+      // The retry advice must be true on BOTH arms.
+      assert.match(m, /re-enters this recovery with a FRESH\s+budget/, "the fact that holds either way");
+      assert.ok(
+        !/normally succeeds on the next attempt/.test(m),
+        "a promise that is false on state B: the retry meets the same slow /object_info",
+      );
+      assert.match(m, /a bare retry can meet the same wall/, "…said plainly instead");
+      assert.match(m, /panel_refresh_nodes/, "…with the escalation that does resolve state B");
+      // #1413's invariants, unchanged.
+      assert.match(m, /NOTHING WAS WRITTEN/);
+      assert.ok(!/not a valid option/.test(m), "the revalidation never ran, so that cause cannot be asserted");
+      return true;
+    },
+  );
+  assert.equal(widget.value, "old_a.png", "nothing was written");
+});
+
+// ---------------------------------------------------------------------------
+// 1. The wiring: the SHIPPED graph_set_widget, extracted and run.
+// ---------------------------------------------------------------------------
+
+const SET_WIDGET_SRC = (() => {
+  const m = PANEL_SRC.match(/ {2}async graph_set_widget\(\{ node_id, widget, value, workflow_uuid \}\) \{[\s\S]*?\n {2}\},/);
+  assert.ok(m, "could not locate graph_set_widget in the panel source");
+  return m[0];
+})();
+
+/** Every free name the extracted method can reach — kept in step with its siblings. */
+const EXECUTOR_DEPS = [
+  "getGraphCtx",
+  "resolveNode",
+  "classifyLtxTimelineWrite",
+  "derivedTimelineRefusal",
+  "applyLtxTimelineWrite",
+  "classifyPromptRelayTimelineWrite",
+  "promptRelayDerivedRefusal",
+  "applyPromptRelayTimelineWrite",
+  "classifyRgthreeFastGroupsWrite",
+  "rgthreeFastGroupsRefusal",
+  "classifyIdeogram4PromptBuilderWrite",
+  "ideogram4PromptBuilderRefusal",
+  "awaitObjectInfoHistorySeed",
+  "isRgthreeLoraRowCreation",
+  "createRgthreeLoraRow",
+  "assertActiveWorkflowCommandTarget",
+  "WORKFLOW_UUID_FIELD",
+  "runSetWidget",
+  "objectInfoCache",
+  "CACHE_OUTCOME",
+  "fetchWholeObjectInfo",
+  "api",
+  "backendReconnectEpoch",
+  "objectInfoSnapshot",
+  "recordObjectInfoTypes",
+  "objectInfoOracleFailureNote",
+  "comfyBackendSocketDown",
+  "comfyBackendIsDown",
+  "objectInfoHistory",
+  "sourceForSubgraphInput",
+  "refreshComboOptionsFromDefs",
+  "refreshComfyNodeDefs",
+  "clearStaleRedFlag",
+  "snapshotAuthorizationNote",
+  "makeCommandBudget",
+  "SET_WIDGET_COMMAND_BUDGET_MS",
+  "SET_WIDGET_POST_REFRESH_RESERVE_MS",
+  "monotonicNow",
+  "OBJECT_INFO_SEED_WAIT_MS",
+  "OBJECT_INFO_DEADLINE_MS",
+  "SET_WIDGET_ASSET_PROBE_MS",
+  "withTimeout",
+];
+
+const never = () => new Promise(() => {});
+
+/**
+ * Await `run()`, but FAIL rather than hang if a deleted bound makes it never settle.
+ *
+ * Every test below removes a bound to prove it matters, and an unbounded wait does not
+ * report a failure — it stops the run and leaves the suite looking merely slow. A watchdog
+ * turns "this bound is gone" into a red assertion with the elapsed time in it, which is
+ * what a reviewer reverting the fix actually needs to see.
+ */
+async function withinWatchdog(ms, what, run) {
+  const settled = await Promise.race([
+    Promise.resolve(run()).then(
+      (value) => ({ value }),
+      (err) => ({ err }),
+    ),
+    new Promise((r) => setTimeout(() => r(null), ms)),
+  ]);
+  assert.ok(settled !== null, `${what} did not settle within ${ms}ms — the bound it depends on is gone`);
+  if ("err" in settled) return settled.err;
+  return settled.value;
+}
+
+/**
+ * Build the SHIPPED `graph_set_widget` with the REAL runSetWidget, the REAL oracle, the
+ * REAL bounding primitive and the REAL command budget. The constants are injected SMALL
+ * so a bound that is missing costs seconds rather than half a minute; the shipped numbers
+ * are pinned separately at the bottom of this file.
+ */
+function realGraphSetWidget({
+  node,
+  // The `/object_info` the authorization oracle answers with. `never()` models a route
+  // that does not settle — the case the deadline exists for.
+  getNodeDefs,
+  // What `/view?type=input` does when the #387 probe reaches it.
+  viewFetch = async () => ({ ok: true, status: 206 }),
+  // How long the baseline seed takes to land. `never()` models one that does not.
+  seedWait = async () => {},
+  budgetMs = 400,
+  reserveMs = 120,
+  seedMs = 5000,
+  oracleMs = 5000,
+  probeMs = 5000,
+} = {}) {
+  const graph = {
+    _nodes: [node],
+    beforeChange() {},
+    afterChange() {},
+    setDirtyCanvas() {},
+  };
+  const context = {
+    app: { canvas: null },
+    graph,
+    LG: { registered_node_types: { LoadImage: {} } },
+    rootGraph: graph,
+  };
+
+  const seen = { seedMs: null, deadlineMs: null, viewRoutes: [] };
+  const api = {
+    getNodeDefs,
+    fetchApi: async (route) => {
+      if (String(route).startsWith("/view?")) {
+        seen.viewRoutes.push(route);
+        return viewFetch();
+      }
+      return { ok: false, status: 404 };
+    },
+  };
+
+  let inFlight = null;
+  const refreshComfyNodeDefs = makeRefreshCoalescer({
+    getInFlight: () => inFlight,
+    setInFlight: (p) => (inFlight = p),
+    runRegister: async () => true,
+    withTimeout,
+  });
+
+  const deps = {
+    getGraphCtx: () => context,
+    resolveNode: () => node,
+    classifyLtxTimelineWrite: () => null,
+    classifyPromptRelayTimelineWrite: () => null,
+    classifyRgthreeFastGroupsWrite: () => null,
+    classifyIdeogram4PromptBuilderWrite: () => null,
+    // Records the bound it is HANDED and honours it, exactly as `awaitHistoryBaseline`
+    // does: a seed that has not landed inside `waitMs` stops being waited for.
+    awaitObjectInfoHistorySeed: async (ms) => {
+      seen.seedMs = ms;
+      await withTimeout(seedWait(), ms, () => null);
+    },
+    isRgthreeLoraRowCreation,
+    createRgthreeLoraRow,
+    assertActiveWorkflowCommandTarget: () => {},
+    WORKFLOW_UUID_FIELD: "workflow_uuid",
+    runSetWidget,
+    objectInfoCache: createObjectInfoCache(),
+    CACHE_OUTCOME,
+    // The REAL oracle, wrapped only to record the deadline the call site chose. A double
+    // here would let this pass against a handler that passes no deadline at all.
+    fetchWholeObjectInfo: (opts) => {
+      seen.deadlineMs = opts?.deadlineMs;
+      return fetchWholeObjectInfo(opts);
+    },
+    api,
+    backendReconnectEpoch: 0,
+    objectInfoSnapshot: { record: () => true, authorize: () => ({ defs: null, reason: "none recorded" }) },
+    recordObjectInfoTypes: (defs) => defs,
+    objectInfoOracleFailureNote,
+    comfyBackendSocketDown: false,
+    comfyBackendIsDown: () => false,
+    objectInfoHistory: { wasTypeEverDefined: () => true },
+    sourceForSubgraphInput: () => undefined,
+    refreshComboOptionsFromDefs: () => 0,
+    refreshComfyNodeDefs,
+    clearStaleRedFlag: () => {},
+    snapshotAuthorizationNote: () => "",
+    ...setWidgetCommandBudgetDeps(),
+    SET_WIDGET_COMMAND_BUDGET_MS: budgetMs,
+    SET_WIDGET_POST_REFRESH_RESERVE_MS: reserveMs,
+    OBJECT_INFO_SEED_WAIT_MS: seedMs,
+    OBJECT_INFO_DEADLINE_MS: oracleMs,
+    SET_WIDGET_ASSET_PROBE_MS: probeMs,
+  };
+  const factory = new Function(
+    ...EXECUTOR_DEPS,
+    `const GRAPH_TOOL_EXECUTORS = { ${SET_WIDGET_SRC} }; return GRAPH_TOOL_EXECUTORS.graph_set_widget;`,
+  );
+  return { graph_set_widget: factory(...EXECUTOR_DEPS.map((n) => deps[n])), seen };
+}
+
+/** A LoadImage whose `image` input is an UPLOAD combo — the shape the #387 probe gates on. */
+function loadImageNode() {
+  const widget = { name: "image", type: "combo", options: { values: ["top.png"] }, value: "top.png" };
+  return { node: { id: 12, type: "LoadImage", widgets: [widget] }, widget };
+}
+const UPLOAD_DEFS = {
+  LoadImage: { input: { required: { image: [["top.png"], { image_upload: true }] } } },
+};
+
+test("#1418 the seed wait is capped by the command, not by its own flat constant", async () => {
+  // A baseline seed that never lands. Uncapped it holds the command for the WHOLE seed
+  // constant (5,000 ms here, 8,000 ms shipped) before anything else on the path has run.
+  const { node } = loadImageNode();
+  const built = realGraphSetWidget({
+    node,
+    getNodeDefs: async () => UPLOAD_DEFS,
+    seedWait: never,
+    budgetMs: 300,
+    seedMs: 5000,
+  });
+  const startedAt = Date.now();
+  // The value IS in the list, so the write succeeds — this test is about the WAIT, not the
+  // ladder, and a passing write proves the cap did not break the ordinary path either.
+  const res = await withinWatchdog(2000, "the write", () =>
+    built.graph_set_widget({ node_id: 12, widget: "image", value: "top.png", workflow_uuid: "u" }),
+  );
+  assert.equal(res?.set?.value, "top.png", "the ordinary path still writes");
+  const elapsed = Date.now() - startedAt;
+  assert.ok(
+    built.seen.seedMs <= 300,
+    `the seed was handed ${built.seen.seedMs}ms — uncapped it takes the flat 5000ms constant`,
+  );
+  assert.ok(elapsed < 2000, `the command answered in ${elapsed}ms; uncapped it waits out the full 5000ms seed`);
+});
+
+test("#1418 the authorization /object_info deadline is capped by what the command has left", async () => {
+  // Both transports silent, so the REAL oracle runs its deadline out. Uncapped it takes
+  // OBJECT_INFO_DEADLINE_MS whole, on top of whatever the seed already spent.
+  const { node, widget } = loadImageNode();
+  const built = realGraphSetWidget({
+    node,
+    getNodeDefs: never,
+    budgetMs: 400,
+    oracleMs: 5000,
+  });
+  const startedAt = Date.now();
+  // A silent oracle refuses on the #458 unavailable-schema path — the point here is WHEN
+  // it refuses, not which refusal it is.
+  const outcome = await withinWatchdog(2500, "the refusal", () =>
+    built.graph_set_widget({ node_id: 12, widget: "image", value: "sub/new.png", workflow_uuid: "u" }),
+  );
+  assert.ok(outcome instanceof Error, "the write is refused, not silently accepted");
+  const elapsed = Date.now() - startedAt;
+  assert.ok(
+    built.seen.deadlineMs > 0 && built.seen.deadlineMs <= 400,
+    `the oracle was handed ${built.seen.deadlineMs}ms — uncapped it takes its own 5000ms constant`,
+  );
+  assert.ok(elapsed < 2500, `the command answered in ${elapsed}ms; uncapped the oracle alone spends 5000ms`);
+  assert.equal(widget.value, "top.png", "nothing was written");
+});
+
+test("#1418 the #387 /view probe IS reached after a refresh that completes, and is bounded", async () => {
+  // The exact case #1416's refusal does not cover: the refresh completes (the payload
+  // contains LoadImage, so refreshCombos takes the in-place branch and resolves), the
+  // retry write still misses, and the ladder runs the upload-asset probe. `/view` never
+  // answers. Unbounded, this is the last network step of a 30,000 ms-relayed command
+  // parking forever.
+  const { node, widget } = loadImageNode();
+  const built = realGraphSetWidget({
+    node,
+    getNodeDefs: async () => UPLOAD_DEFS,
+    viewFetch: never,
+    budgetMs: 4000,
+    probeMs: 300,
+  });
+  const startedAt = Date.now();
+  const outcome = await withinWatchdog(2500, "the refusal", () =>
+    built.graph_set_widget({ node_id: 12, widget: "image", value: "sub/new.png", workflow_uuid: "u" }),
+  );
+  assert.ok(outcome instanceof Error, "the write is refused, not silently accepted");
+  const elapsed = Date.now() - startedAt;
+  assert.equal(built.seen.viewRoutes.length, 1, "the probe WAS reached — this path is not covered by the refusal");
+  assert.match(built.seen.viewRoutes[0], /subfolder=sub/, "…with the nested path #387 is about");
+  assert.ok(elapsed < 2500, `the command answered in ${elapsed}ms; unbounded the probe never settles`);
+  assert.equal(widget.value, "top.png", "a probe that could not answer admits nothing — #240 strictness holds");
+});
+
+test("#1418 a /view that ANSWERS still accepts the nested asset — the bound refuses nothing else", async () => {
+  // The bound must not become a way to reject #387's whole point. A probe that answers
+  // inside it accepts exactly as before.
+  const { node, widget } = loadImageNode();
+  const built = realGraphSetWidget({
+    node,
+    getNodeDefs: async () => UPLOAD_DEFS,
+    viewFetch: async () => ({ ok: true, status: 206 }),
+    budgetMs: 4000,
+    probeMs: 300,
+  });
+  const res = await built.graph_set_widget({
+    node_id: 12,
+    widget: "image",
+    value: "sub/new.png",
+    workflow_uuid: "u",
+  });
+  assert.equal(res.set.value, "sub/new.png", "the server-confirmed nested asset is written");
+  assert.equal(res.server_confirmed, true);
+  assert.equal(widget.value, "sub/new.png");
+});
+
+// ---------------------------------------------------------------------------
+// 2. The source pins — SCOPED TO graph_set_widget's OWN BODY.
+// ---------------------------------------------------------------------------
+
+test("#1418 the pins are scoped to the method body, not to the file", () => {
+  // The guard on the guard. `graph_add_node` has held `budget.bounded(OBJECT_INFO_SEED_WAIT_MS)`
+  // since #1192, so a file-wide pin is satisfied by ITS call site and stays green with
+  // graph_set_widget's deleted. Assert the extraction really is one method.
+  assert.ok(!/async graph_add_node\(/.test(SET_WIDGET_SRC), "the extraction must not run past into a sibling");
+  assert.ok(SET_WIDGET_SRC.length < PANEL_SRC.length / 4, "…and must be one method, not most of the panel");
+  assert.ok(
+    /budget\.bounded\(OBJECT_INFO_SEED_WAIT_MS\)/.test(PANEL_SRC.replace(SET_WIDGET_SRC, "")),
+    "the sibling call site that makes a file-wide pin worthless is still there — this is why scoping matters",
+  );
+});
+
+test("#1418 graph_set_widget's own body caps every wait ahead of the recovery", () => {
+  assert.match(
+    SET_WIDGET_SRC,
+    /await awaitObjectInfoHistorySeed\(budget\.bounded\(OBJECT_INFO_SEED_WAIT_MS\)\)/,
+    "the seed wait draws from the command budget",
+  );
+  assert.match(
+    SET_WIDGET_SRC,
+    /deadlineMs: budget\.bounded\(OBJECT_INFO_DEADLINE_MS\)/,
+    "the authorization /object_info draws from the command budget",
+  );
+  assert.match(
+    SET_WIDGET_SRC,
+    /budget\.bounded\(SET_WIDGET_ASSET_PROBE_MS\)/,
+    "the #387 upload-asset probe draws from the command budget",
+  );
+  assert.ok(
+    !/await api\.fetchApi\(`\/view\?/.test(SET_WIDGET_SRC),
+    "…and is not awaited bare — a bound beside an unbounded await is not a bound",
+  );
+});
+
+test("#1418 the shipped numbers still compose inside the relay window", () => {
+  // The harnesses above inject small constants, so only a source-level check catches these
+  // drifting. The property: everything the command can spend BEFORE the recovery now fits
+  // inside the budget, where uncapped it was 28,000ms against 25,000ms.
+  assert.equal(OBJECT_INFO_SEED_WAIT_MS + OBJECT_INFO_DEADLINE_MS, 28000, "the uncapped sum this issue measured");
+  assert.ok(
+    OBJECT_INFO_SEED_WAIT_MS + OBJECT_INFO_DEADLINE_MS > SET_WIDGET_COMMAND_BUDGET_MS,
+    "…which is why capping them is not cosmetic: their own constants overrun the budget",
+  );
+  assert.ok(
+    SET_WIDGET_ASSET_PROBE_MS > 0 && SET_WIDGET_ASSET_PROBE_MS < SET_WIDGET_POST_REFRESH_RESERVE_MS,
+    "the probe is sized inside the reserve, so composing and relaying the reply still has room",
+  );
+});
+
+// ---------------------------------------------------------------------------
+// 3. The audit #1413 asked for, as a test.
+// ---------------------------------------------------------------------------
+//
+// "Worth auditing the remaining two relayed commands (graph_get_object_info,
+// graph_remove_widget) in the same pass, so the fifth instance does not get filed next
+// week." Both are clean: one await each, landing on fetchWholeObjectInfo, which bounds
+// itself at OBJECT_INFO_DEADLINE_MS — under the 30,000 ms window with nothing to compose
+// against. Neither needs a command budget. Written as a test because a sentence saying so
+// stops being true silently.
+
+/** Slice one executor method out of the panel source by its exact signature line. */
+function executorBody(signature) {
+  const i = PANEL_SRC.indexOf(signature);
+  assert.ok(i >= 0, `${signature} is no longer findable in the panel source — update this harness`);
+  const j = PANEL_SRC.indexOf("\n  },", i);
+  assert.ok(j > i, `could not find the end of ${signature}`);
+  return PANEL_SRC.slice(i, j + 5);
+}
+
+const CLEAN_RELAYED_COMMANDS = [
+  ["graph_get_object_info", "  async graph_get_object_info({ if_none_match } = {}) {"],
+  ["graph_remove_widget", "  async graph_remove_widget({ node_id, widget, workflow_uuid }) {"],
+];
+
+for (const [name, signature] of CLEAN_RELAYED_COMMANDS) {
+  test(`#1418 audit: ${name} still holds ONE await and never reaches the coalescer`, () => {
+    const body = executorBody(signature);
+    const awaits = body.match(/\bawait\b/g) ?? [];
+    assert.equal(
+      awaits.length,
+      1,
+      `${name} now holds ${awaits.length} awaits. A SECOND one is what makes bounds compose — ` +
+        `if the new wait is unbounded, or bounded by its own flat constant, this command is the ` +
+        `fifth instance of #1192/#1404/#1413/#1418 and needs a command budget of its own.`,
+    );
+    assert.ok(
+      !/refreshComfyNodeDefs/.test(body),
+      `${name} now reaches the node-def coalescer, whose join is unbounded without a joinMs — ` +
+        `the exact step every one of those four issues was filed about.`,
+    );
+    assert.match(
+      body,
+      /fetchWholeObjectInfo\(/,
+      `${name}'s one await is supposed to land on the self-bounding oracle; if it no longer ` +
+        `does, the bound this audit rests on is gone.`,
+    );
+  });
+}

--- a/browser_tests/unit/set-widget-stale-combo-budget.test.mjs
+++ b/browser_tests/unit/set-widget-stale-combo-budget.test.mjs
@@ -183,6 +183,13 @@ const EXECUTOR_DEPS = [
   "SET_WIDGET_COMMAND_BUDGET_MS",
   "SET_WIDGET_POST_REFRESH_RESERVE_MS",
   "monotonicNow",
+  // #1418 — the capped seed wait, the capped authorization deadline and the bounded
+  // #387 /view probe. Supplied by setWidgetCommandBudgetDeps(); named here because a
+  // free identifier the rebuilt body reaches is a ReferenceError, not a failed assert.
+  "OBJECT_INFO_SEED_WAIT_MS",
+  "OBJECT_INFO_DEADLINE_MS",
+  "SET_WIDGET_ASSET_PROBE_MS",
+  "withTimeout",
 ];
 
 function deferred() {

--- a/browser_tests/unit/set-widget-stale-combo-budget.test.mjs
+++ b/browser_tests/unit/set-widget-stale-combo-budget.test.mjs
@@ -190,6 +190,7 @@ const EXECUTOR_DEPS = [
   "OBJECT_INFO_DEADLINE_MS",
   "SET_WIDGET_ASSET_PROBE_MS",
   "withTimeout",
+  "inputAssetProbeVerdict",
 ];
 
 function deferred() {

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -14081,8 +14081,8 @@ const GRAPH_TOOL_EXECUTORS = {
           if (!filename) return false;
           const qs = new URLSearchParams({ filename, subfolder, type: "input" }).toString();
           // withTimeout never rejects and never cancels the request — the fetch keeps
-          // going, this stops waiting on it. A timeout resolves the same NO-ANSWER
-          // sentinel a thrown fetch is caught into below, so both take one branch.
+          // going, this stops waiting on it. A timeout resolves `null`, which
+          // `inputAssetProbeVerdict` already classifies as THE QUESTION WAS NOT ANSWERED.
           const res = await withTimeout(
             api.fetchApi(`/view?${qs}`, {
               method: "GET",
@@ -14092,9 +14092,15 @@ const GRAPH_TOOL_EXECUTORS = {
             budget.bounded(SET_WIDGET_ASSET_PROBE_MS),
             () => null,
           );
-          return !!res && (res.ok || res.status === 206);
+          // #1418 — the TRI-STATE verdict (#1357), not `!!res && …`. Bounding this probe
+          // created a second way for it to come back without an answer, and the old
+          // boolean collapsed that into "the server says the file is not there" — which
+          // set-widget.js would then report as a confirmed miss. `null` keeps "nobody
+          // answered" distinct from a real 404 all the way into the refusal. It still
+          // does not ACCEPT anything, so #240 strictness is unchanged.
+          return inputAssetProbeVerdict(res);
         } catch {
-          return false;
+          return null;
         }
       },
     };

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -271,7 +271,11 @@ import { BACKEND_SWITCH, runBackendSwitch } from "./lib/backend-switch.js";
 import { createSettingsBackendDefault } from "./lib/settings-backend-default.js";
 import { fetchNodeDefsWithRetry, OBJECT_INFO_RETRY_DELAYS_MS } from "./lib/object-info-retry.js";
 import { createObjectInfoCache, CACHE_OUTCOME } from "./lib/object-info-cache.js";
-import { fetchWholeObjectInfo, objectInfoOracleFailureNote } from "./lib/object-info-oracle.js";
+import {
+  fetchWholeObjectInfo,
+  objectInfoOracleFailureNote,
+  OBJECT_INFO_DEADLINE_MS,
+} from "./lib/object-info-oracle.js";
 import { createObjectInfoSnapshot, snapshotAuthorizationNote } from "./lib/object-info-snapshot.js";
 import { isRgthreeLoraRowCreation, createRgthreeLoraRow } from "./lib/rgthree-lora-row.js";
 import { objectInfoFingerprint, objectInfoUnchanged } from "./lib/object-info-fingerprint.js";
@@ -10584,6 +10588,25 @@ const SET_WIDGET_COMMAND_BUDGET_MS = 25000;
  */
 const SET_WIDGET_POST_REFRESH_RESERVE_MS = 4000;
 
+/**
+ * #1418 — the bound on the #387 upload-asset `/view` probe, drawn from the reserve above.
+ *
+ * The reserve exists to leave the retry write, this probe and the reply something to spend;
+ * it does not by itself STOP the probe spending all of it and more, because the probe held
+ * no bound of its own. One ranged GET (`Range: bytes=0-0`) is a header exchange, so this is
+ * generous by any measure of the request — it is sized against the RESERVE, deliberately
+ * smaller than it, so composing and relaying the reply still has room after a probe that
+ * used its whole allowance.
+ *
+ * PICKED, not derived, like the reserve: there is no measured figure for a one-byte ranged
+ * GET in this repo, and inventing one in a comment is how #1413's "reassurance-shaped
+ * claim" trap gets sprung again. What IS load-bearing and is stated rather than assumed:
+ * this is a CAP, not a grant — `budget.bounded()` hands over the smaller of this and what
+ * the command has left, so a probe reached with a nearly-spent budget waits the remainder
+ * and not this number.
+ */
+const SET_WIDGET_ASSET_PROBE_MS = 3000;
+
 async function awaitRequiredCustomWidgetRegistration(
   nodeData,
   comfyApp,
@@ -12455,10 +12478,25 @@ const GRAPH_TOOL_EXECUTORS = {
         // than parking.
         // #1223 — read the epoch HERE, immediately before the whole request is issued.
         addNodeObservedAtEpoch = backendReconnectEpoch;
-        // #1192 — the same request `graph_set_widget`'s oracle allows 10,000 ms, allowed
-        // 10,000 ms here too, and BOTH now capped by their caller's remaining budget. The
-        // two paths agreeing about how long one /object_info may take is what stops a
-        // "set_widget works but add_node fails" asymmetry appearing on a slow install.
+        // #1192 — this request gets NODE_DEFS_FETCH_TIMEOUT_MS (10,000 ms), capped by what
+        // the command has left.
+        //
+        // #1418 — AND THE TWO PATHS DO NOT AGREE ABOUT THAT NUMBER. An earlier revision of
+        // this comment said "the same request `graph_set_widget`'s oracle allows 10,000 ms"
+        // and that the agreement "stops a 'set_widget works but add_node fails' asymmetry";
+        // both halves were false when written. `graph_set_widget` reads /object_info
+        // through `fetchWholeObjectInfo`, whose OBJECT_INFO_DEADLINE_MS is 20,000 ms — so
+        // the asymmetry that sentence claimed to have closed was the live behaviour, in the
+        // direction it ruled out, and nothing capped that 20,000 ms until #1418 either.
+        //
+        // The two numbers are LEFT DIFFERENT, because they bound different things and each
+        // is argued where it lives: this one bounds `api.getNodeDefs()`, one call; the
+        // oracle's bounds TWO transports plus the fallback's body, split 10s/5s/5s, and
+        // object-info-oracle.js sets out that arithmetic at length. Equalising them to make
+        // a sentence true would be the tail wagging the dog. What both paths now genuinely
+        // share is the property that matters: each takes the SMALLER of its own constant
+        // and its caller's remaining command budget, so neither can outlive the 30,000 ms
+        // relay window however it is reached.
         const whole = await boundedGetNodeDefs(budget.bounded(NODE_DEFS_FETCH_TIMEOUT_MS));
         freshDefs = recordObjectInfoTypes(whole === NODE_DEFS_NO_ANSWER ? null : whole);
         freshDefsAreSingleClass = false;
@@ -13711,7 +13749,15 @@ const GRAPH_TOOL_EXECUTORS = {
     // fails CLOSED for this call only, with a TEMPORARY "retry in a moment" refusal. The
     // seed keeps running, so a late response still establishes the baseline and the next
     // call authorizes normally — ordinary latency must never burn the session.
-    await awaitObjectInfoHistorySeed();
+    //
+    // #1418 — …and CAPPED BY THE COMMAND, the way `graph_add_node` has capped its own copy
+    // since #1192. This is the FIRST of the waits on this path and it held a flat 8,000 ms,
+    // so #1413's budget bounded the LAST step while the two ahead of it could still spend
+    // 28,000 ms between them (8,000 seed + 20,000 `OBJECT_INFO_DEADLINE_MS`) against a
+    // 25,000 ms budget inside a 30,000 ms relay window — measured, and the joinMs the
+    // recovery then computed was -7,000. Capping both brings the worst case before the
+    // recovery to the budget itself, which is what makes the reply land inside the window.
+    await awaitObjectInfoHistorySeed(budget.bounded(OBJECT_INFO_SEED_WAIT_MS));
     // #757 — MINT an rgthree Power Lora Loader row when the write targets one that does not
     // exist yet. Those rows are created only by the node's own "➕ Add Lora" button, a
     // DOM-only control an agent cannot click, so every write to `lora_1` on a fresh node was
@@ -13815,6 +13861,16 @@ const GRAPH_TOOL_EXECUTORS = {
             return fetchWholeObjectInfo({
               getNodeDefs: typeof api?.getNodeDefs === "function" ? () => api.getNodeDefs() : null,
               fetchApi: typeof api?.fetchApi === "function" ? (route) => api.fetchApi(route) : null,
+              // #1418 — the oracle's own 20,000 ms deadline is sized for the operation it
+              // bounds (see OBJECT_INFO_DEADLINE_MS: half to the client route, then a
+              // quarter each to the fallback's response and body). It is NOT sized for the
+              // command it runs inside, and it never was: alone it already exceeds the
+              // 25,000 ms budget once the 8,000 ms seed wait ahead of it is counted. It
+              // keeps its own number and takes the smaller of that and what the command has
+              // left. The oracle normalises non-finite budgets itself and obeys a small
+              // one — `bounded()` never yields a non-positive value, so this can shorten
+              // the deadline but can never remove it.
+              deadlineMs: budget.bounded(OBJECT_INFO_DEADLINE_MS),
             });
           },
           { stamp: () => backendReconnectEpoch },
@@ -14000,6 +14056,22 @@ const GRAPH_TOOL_EXECUTORS = {
       // resolves the nested path). Confirm the file EXISTS in the server's input
       // directory via /view?type=input; a 2xx means it is a valid, loadable asset and
       // set-widget.js accepts it. Range-limited so we do not download the whole file.
+      //
+      // #1418 — BOUNDED BY THE COMMAND, and it is the last thing on this path that was not.
+      // #1416's PR body claimed the abandoned-refresh refusal fired "before the unbounded
+      // upload-asset probe so a spent budget is not followed by another unbounded wait",
+      // and that is true only of the ABANDONED arm. When the refresh COMPLETES and the
+      // retry write still misses — the #387 case this probe exists for, a subfolder-nested
+      // LoadImage image — the ladder reaches it anyway; measured by driving the shipped
+      // runSetWidget with a refreshCombos that resolves normally and a value the refreshed
+      // list still lacks. A `/view` on a half-open connection then parked the last network
+      // step of a command relayed at 30,000 ms with no bound at all.
+      //
+      // A BOUND HERE CANNOT ADMIT A VALUE IT SHOULD REFUSE, which is why it is safe against
+      // #240 strictness: the probe already answers `false` for every error, so the only
+      // thing a timeout can change is `true` → `false`. It refuses a genuine nested asset
+      // on a stalled connection — where the alternative was the whole command missing the
+      // relay window and refusing it with a message that names nothing.
       confirmServerAsset: async (assetValue) => {
         try {
           const v = String(assetValue ?? "").replace(/\\/g, "/");
@@ -14008,11 +14080,18 @@ const GRAPH_TOOL_EXECUTORS = {
           const filename = i >= 0 ? v.slice(i + 1) : v;
           if (!filename) return false;
           const qs = new URLSearchParams({ filename, subfolder, type: "input" }).toString();
-          const res = await api.fetchApi(`/view?${qs}`, {
-            method: "GET",
-            cache: "no-store",
-            headers: { Range: "bytes=0-0" },
-          });
+          // withTimeout never rejects and never cancels the request — the fetch keeps
+          // going, this stops waiting on it. A timeout resolves the same NO-ANSWER
+          // sentinel a thrown fetch is caught into below, so both take one branch.
+          const res = await withTimeout(
+            api.fetchApi(`/view?${qs}`, {
+              method: "GET",
+              cache: "no-store",
+              headers: { Range: "bytes=0-0" },
+            }),
+            budget.bounded(SET_WIDGET_ASSET_PROBE_MS),
+            () => null,
+          );
           return !!res && (res.ok || res.status === 206);
         } catch {
           return false;

--- a/web/js/lib/set-widget.js
+++ b/web/js/lib/set-widget.js
@@ -77,28 +77,56 @@ function coerceAdvisoryMessage(err) {
 }
 
 /**
- * #1413 — the refusal for a stale-combo recovery whose authoritative refresh was still
- * running when the command's budget ran out.
+ * #1413 — the refusal for a stale-combo recovery whose authoritative refresh did not
+ * complete inside the command's budget.
  *
  * RECOVERABLE BY CONSTRUCTION, and worded to say so — the same shape as #1192's
- * addNodeRefreshBusyMessage. The in-flight refresh was NOT cancelled (the coalescer never
- * cancels work someone else started) and it is registering the very list this write needs,
- * so the retry this text asks for is the normal outcome, not a hope. What it must NOT say
- * is "not a valid option": the revalidation never completed, so this refusal cannot tell a
- * genuinely-invalid value from one the refresh would have accepted — and claiming the
- * former is how a retryable busy reads as a permanent rejection.
+ * addNodeRefreshBusyMessage. What it must NOT say is "not a valid option": the revalidation
+ * never completed, so this refusal cannot tell a genuinely-invalid value from one the
+ * refresh would have accepted — and claiming the former is how a retryable busy reads as a
+ * permanent rejection.
+ *
+ * #1418 — IT MUST NAME BOTH STATES, because `REFRESH_JOIN_ABANDONED` comes back in two and
+ * the first draft of this text asserted only one ("That refresh is still running and is
+ * registering exactly the list this write needs"). `refresh-coalesce.js` returns the token
+ * from an EMPTY slot with a non-positive `joinMs` too:
+ *
+ *     if (joinMs !== null && !(joinMs > 0)) return REFRESH_JOIN_ABANDONED;
+ *
+ * — measured reachable with NO concurrency at all, by driving the shipped `refreshCombos`
+ * over the real coalescer: 0 runs started, slot empty afterwards, token returned. On that
+ * arm every clause about a run that "is still running" was flatly false, and the retry
+ * advice ("this normally succeeds on the next attempt") rested on it.
+ *
+ * THIS IS THE SHAPE #1409 ALREADY CORRECTED ONCE, in `refresh_nodes`' own refusal — a
+ * detail naming only the first of two runs was wrong on an uncontended big install. Same
+ * remedy: name both states, and rest the retry advice on what is true in EITHER. The one
+ * fact that holds on both arms is that this command's budget is what ran out, and a retry
+ * re-enters the recovery with a fresh one — so that, not a promise about somebody else's
+ * run, is what the caller is told to act on. Which state produced the token is deliberately
+ * NOT reconstructed here: the coalescer returns one value for both, and a caller that
+ * guessed from `budget.exhausted()` would be asserting a cause it never established, which
+ * is the defect class this whole thread is about.
+ *
+ * The escalation is not decoration either. On the second arm a bare retry can meet the same
+ * slow `/object_info` and land in the same place, so the text says so and names the call
+ * (`panel_refresh_nodes`) that resolves it instead of implying the next attempt must work.
  */
 function staleComboRefreshBusyMessage() {
   return (
     "the value is not in this combo's current option list, and the authoritative refresh " +
-    "that would have re-read the list — a node-def refresh started by a ComfyUI reconnect, " +
-    "a finished install, or another tool call — was still running when this command's time " +
-    "budget ran out waiting for it, so the revalidation did NOT complete. This refusal " +
-    "cannot tell a genuinely-invalid value from one the refresh would have accepted. " +
-    "NOTHING WAS WRITTEN and nothing was changed. That refresh is still running and is " +
-    "registering exactly the list this write needs, so RETRY in a few seconds — this " +
-    "normally succeeds on the next attempt. If it keeps happening, call panel_refresh_nodes " +
-    "once and wait for it to report, then retry the write."
+    "that would have re-read the list did NOT complete inside this command's time budget, " +
+    "so the revalidation never happened. This refusal cannot tell a genuinely-invalid " +
+    "value from one the refresh would have accepted. NOTHING WAS WRITTEN and nothing was " +
+    "changed. TWO situations produce this and the remedy is the same for both: either a " +
+    "node-def refresh started by a ComfyUI reconnect, a finished install, or another tool " +
+    "call was still running when the budget ran out waiting for it — that run was NOT " +
+    "cancelled and is still registering the list this write needs — or the budget was " +
+    "already spent by the steps ahead of this recovery, in which case no refresh was " +
+    "started for this write at all. RETRY: the retry re-enters this recovery with a FRESH " +
+    "budget, and joins the running refresh if there is one. If a slow /object_info is what " +
+    "spent the budget, a bare retry can meet the same wall — so if it keeps happening, " +
+    "call panel_refresh_nodes once and wait for it to report, then retry the write."
   );
 }
 

--- a/web/js/lib/set-widget.js
+++ b/web/js/lib/set-widget.js
@@ -805,6 +805,11 @@ export async function runSetWidget(
     }
   };
 
+  // #1418 — set when the #387 probe was REACHED but did not answer (see the tri-state note
+  // below). Read only by the final refusal, which must not assert a confirmed miss on the
+  // strength of a question the server never answered.
+  let assetProbeUnanswered = false;
+
   // #387 UPLOAD-ASSET fallback: a value rejected by the combo list even AFTER the
   // authoritative /object_info refresh may still be a VALID, loadable input asset the
   // server has on disk but /object_info never enumerates — specifically a LoadImage
@@ -831,13 +836,33 @@ export async function runSetWidget(
       (w) => w?.name === (writeTargetWidgetName ?? widgetName),
     );
     if (!uploadWidget) return false;
-    let exists = false;
+    // #1418 — TRI-STATE, not a boolean, for the reason #1357 already established for the
+    // live combo scan: `false` means the server ANSWERED and said the file is not there,
+    // `null` means the question was NOT answered — no response, a 5xx, a proxy status, or
+    // (new here) the probe's own bound firing because the command's budget ran out. The
+    // two demand different REFUSALS. Collapsing them, as this did while the probe was
+    // unbounded and could only ever answer, now makes an unasked question read as a
+    // confirmed miss — and the refusal below would then tell the caller their value is
+    // invalid on the strength of a request that never came back. That is the same
+    // wrong-cause shape this whole issue is about, so bounding the probe without
+    // splitting these would have traded one instance of it for another.
+    //
+    // A THROW is `null` too: a probe that blew up did not answer the question either.
+    // Neither `false` nor `null` ACCEPTS, so #240 strictness is untouched — the only
+    // thing that changes is what the caller is told.
+    let verdict = null;
     try {
-      exists = await confirmServerAsset(value);
+      const answered = await confirmServerAsset(value);
+      // Tolerates a caller still returning a plain boolean: `true`/`false` keep their
+      // meanings, so a driver that has not been updated behaves exactly as before.
+      verdict = answered === true ? true : answered === false ? false : null;
     } catch {
-      exists = false;
+      verdict = null;
     }
-    if (!exists) return false;
+    if (verdict !== true) {
+      assetProbeUnanswered = verdict === null;
+      return false;
+    }
     // confirmServerAsset may have yielded while the user changed canvases; do
     // not add an option to the captured widget after that switch (#718).
     assertTargetStillCurrentNow();
@@ -1248,9 +1273,27 @@ export async function runSetWidget(
     // contain the value, or a list that could not be read at all. Nothing is appended
     // here suggesting a retry, because at this point there is no argument the caller can
     // add that changes the answer — the decision is the panel's observation, not theirs.
+    //
+    // #1418 — WITH ONE EXCEPTION, and the sentence above is exactly why it has to be named.
+    // When the #387 upload-asset probe was reached and did NOT answer (a 5xx, a proxy
+    // status, a throw, or its bound firing on a spent command budget), the panel did not
+    // observe anything about this value's existence on the server. The rejection carried
+    // in `latest` is still true about the COMBO LIST, so it stays — but "the list does not
+    // list it" is not the whole answer for an upload input, and a caller told only that
+    // will conclude the file is absent when nobody ever managed to ask. A retry DOES change
+    // this one, so unlike every other path out of here, it says so.
+    const probeNote = assetProbeUnanswered
+      ? ` NOTE: this value looks like an uploadable asset for this input, so the panel also ` +
+        `probed the server for a file /object_info cannot list (a subfolder-nested upload, #387) ` +
+        `— and that probe did NOT answer: it timed out, failed, or the command's time budget ` +
+        `ran out before it could. So this refusal rests on the combo list ALONE and does NOT ` +
+        `establish that the file is missing from the server. If you believe the file is there, ` +
+        `RETRY — the retry probes again with a fresh budget.`
+      : "";
     throw new Error(
       `panel_set_widget refused "${widgetName}" on node ${node?.id} (${node?.type})` +
-        `${typeof refreshCombos === "function" ? " after refreshing combo options" : ""}: ${latest.message}`,
+        `${typeof refreshCombos === "function" ? " after refreshing combo options" : ""}: ${latest.message}` +
+        probeNote,
     );
   }
 }


### PR DESCRIPTION
Fixes the three things #1416 left behind, plus the audit #1413 asked for.

> **Replaces #1419, which merged at the wrong commit.** #1419 was squash-merged ~4 minutes
> after it opened, at `6f13af0a` — the **empty `wip(1418): claim` commit** pushed to open the
> draft. That squash (`0b9dc9f6`) is now the top of `main` and changes no files, so the
> comment closing #1418 as "fixed" described code that was never merged. #1418 has been
> reopened and the record corrected there. This PR carries the actual implementation,
> rebased onto the current `main`.

---

## 1. The refusal asserted a refresh that was not running

`REFRESH_JOIN_ABANDONED` comes back from `refresh-coalesce.js` in **two** states, and
#1413's text was true in only one:

> "…That refresh **is still running** and is registering exactly the list this write needs,
> so RETRY in a few seconds — this **normally succeeds on the next attempt**."

The second arm returns the token from an **empty slot** without starting anything:

```js
if (joinMs !== null && !(joinMs > 0)) return REFRESH_JOIN_ABANDONED;
```

…and it is reachable **with no concurrency at all**, because the two waits ahead of the
recovery still held their own flat constants and composed past the budget. Measured by
driving the shipped `refreshCombos` over the **real** coalescer at the **shipped** numbers
(`browser_tests/unit/set-widget-budget-composition.test.mjs`, first test):

```
budget total / spent-before-recovery : 25000 / 28000 (seed 8000 + oracle 20000)
joinMs handed to the coalescer       : -7000
runs the coalescer STARTED           : 0
slot occupied afterwards             : false
outcome is REFRESH_JOIN_ABANDONED    : true
```

**Both halves of the issue's suggested fix are applied, because neither alone is enough:**

- The refusal now names **both** states and rests its retry advice on the one fact true in
  either — *the retry re-enters this recovery with a fresh budget* — following #1409's
  precedent for `refresh_nodes`. It also drops "this normally succeeds on the next attempt",
  which is false on the second arm, and says plainly that a bare retry can meet the same
  slow `/object_info` and that `panel_refresh_nodes` is what resolves that.
- `awaitObjectInfoHistorySeed()` and the authorization `/object_info` are capped with
  `budget.bounded(…)`, the way `graph_add_node` has capped its copies since #1192.

**One correction to the issue's framing:** capping does **not** make the exhausted arm
unreachable without concurrency, so it is not an alternative to the wording fix. `bounded()`
holds total spend to the budget, but the seed and oracle can still consume all 25,000 ms
between them, leaving `joinMs = remaining() − 4000 ≈ −4000` — non-positive, empty slot, same
arm. What the caps actually buy is the property #1413's budget was for: the worst case
*before* the recovery drops from 28,000 ms to the budget itself, so the reply lands inside
the 30,000 ms relay window. The wording fix is the load-bearing one.

## 2. The #387 `/view` probe is bounded

#1416's refusal fires before the probe on the **abandoned** arm only. When the refresh
**completes** and the retry write still misses — the subfolder-nested `LoadImage` image the
probe exists for — the ladder reaches it anyway, and it was the last network step of a
command relayed at 30,000 ms with no bound of any kind. It now draws
`budget.bounded(SET_WIDGET_ASSET_PROBE_MS)` (3,000 ms, sized inside the 4,000 ms
`SET_WIDGET_POST_REFRESH_RESERVE_MS` so composing the reply still has room).

Cannot regress #240: the probe already answers `false` for every error, so a bound can only
turn `true` into `false` — refuse a value, never admit one. A test pins that a `/view` which
*answers* still accepts the nested asset.

## 3. `graph_add_node`'s fetch note stated a number that was never true

The comment claimed the two paths agree at 10,000 ms and that this "stops a *set_widget
works but add_node fails* asymmetry". `graph_set_widget`'s oracle goes through
`fetchWholeObjectInfo`, whose `OBJECT_INFO_DEADLINE_MS` is **20,000 ms**. Corrected rather
than papered over, and the numbers are deliberately left **different** — they bound
different operations, each argued where it lives — with the property they now genuinely
share stated instead: each takes the smaller of its own constant and its caller's remaining
budget.

## 4. The audit #1413 asked for, as a test

`graph_get_object_info` and `graph_remove_widget` are clean: one `await` each, landing on
`fetchWholeObjectInfo`, which bounds itself. Neither needs a command budget. That is a claim
with a shelf life, so it is a test — it goes red the day either grows a second wait or
reaches `refreshComfyNodeDefs`, whether or not anyone rereads the note.

---

## Verification

**Mutation-verified — every fix, deleted, turns its own test red:**

| mutation | red |
|---|---|
| seed cap deleted | `the seed wait is capped by the command…` + the method-body pin |
| oracle `deadlineMs` deleted | `the authorization /object_info deadline is capped…` + the pin |
| probe `withTimeout` deleted | `the #387 /view probe IS reached… and is bounded` + the pin |
| refusal reverted to #1416's wording | `the refusal names BOTH abandoned states…` |
| `graph_remove_widget` given a 2nd await on the coalescer | the audit test |

**The pins are scoped to `graph_set_widget`'s own body, and there is a test that they are.**
A file-wide `assert.match(PANEL_SRC, /awaitObjectInfoHistorySeed\(budget\.bounded\(/)` stays
**green** with this method's bound deleted, because `graph_add_node`'s sibling call site
satisfies it. Mutation M1 confirms the body-scoped pin does go red.

**Three extraction harnesses needed the new module bindings in the same commit** — a new
free name in a rebuilt executor is a `ReferenceError`, not a failed assert. `object-info-snapshot.test.mjs`
rebuilds only the `readObjectInfo` block and gets a **real** `makeCommandBudget`; a stub
there would let it pass against a call site whose bound had been deleted.

- `npm run test:unit` — **5618 pass, 0 fail** (i18n, tool-vocabulary and `check-panel-scope` gates included)
- `npm run typecheck` — clean
- `check-panel-scope` — OK; this is the gate that catches a name resolving in a sibling function, and it needed `npm ci` in the worktree to run at all

**Browser suite NOT run, and this is not implied coverage.** No ComfyUI is listening on any
port on this machine and this run was told not to start one, so `npx playwright test` cannot
execute. The change renders nothing in the sidebar — it alters a tool-result refusal string
and network wait bounds inside graph command handlers — and no e2e spec exercises the
stale-combo recovery (the sole `panel_set_widget` mention in `browser_tests/*.spec.ts` is a
comment in an outline-label spec). `npx playwright test --list` compiles and discovers all
78 tests from this worktree.

**Gate:** codex was unavailable (account exhausted until 2026-08-19 20:43, measured
previously on both the wrapper and direct `codex exec`, so not re-probed); gated by an
independent adversarial review instead, per the authorised substitution. Verdict below.


---

## Addendum — a defect this change would have introduced, caught and fixed

Bounding the #387 probe creates a **second way for it to come back without an answer**, and
the old `!!res && (res.ok || res.status === 206)` collapsed that into the same `false` a real
404 produces. The ladder's final refusal then tells the caller their value *is not a valid
option* — a cause established by a request that never came back. Measured at the boundary:

```
SET_WIDGET_ASSET_PROBE_MS = 3000
fresh budget          remaining=25000ms bound=3000ms -> confirmServerAsset=true
3s left               remaining=3000ms  bound=3000ms -> confirmServerAsset=true
10ms left             remaining=10ms    bound=10ms   -> confirmServerAsset=true
EXHAUSTED (== budget) remaining=0ms     bound=1ms    -> confirmServerAsset=false   <-- healthy 5ms /view
2s OVER budget        remaining=-2000ms bound=1ms    -> confirmServerAsset=false
```

That is the same wrong-cause shape this issue exists to fix, so bounding the probe without
splitting these would have traded one instance of it for another.

**#1357 already built the vocabulary, and the panel already imports it.**
`inputAssetProbeVerdict` is a tri-state where `null` means *the question was not answered* —
and #1357's own note says collapsing `null` into `false` "manufactures the exact false
positive #1357 reported". The probe now returns that verdict, `set-widget.js` keeps "nobody
answered" distinct from "the server said no", and **only** the unanswered case adds a note
saying the refusal rests on the combo list alone and that a retry probes again with a fresh
budget. A real 404 is still reported as a confirmed miss with no hedging — there is a test
for each direction. Neither `false` nor `null` accepts, so #240 strictness is unchanged.

Three further mutations pin it (panel collapsing the tri-state; `set-widget` not recording
the unanswered case; the refusal dropping the note) — each turns the new test red.

Wiring this also required `inputAssetProbeVerdict` in the rebuilt-executor dep lists: my own
test caught the `ReferenceError`, because the swallowing `catch` turned it into a silent
"unanswered" rather than a crash.

**How it was found:** the first gate run was killed by a session restart, but it left its
scratch probes in the worktree. Running the boundary probe it had written is what produced
the table above — so the credit for this one belongs to the gate, even though that run never
returned a verdict.

Totals after this addendum: **8 mutations**, each turning its own test red;
`npm run test:unit` **5620 pass / 0 fail**.

Closes #1418


