### PR TITLE
fix(1422): lightbox stage and collapsed cards honor the same honest failure state

### DIFF
--- a/browser_tests/unit/image-load-failure.test.mjs
+++ b/browser_tests/unit/image-load-failure.test.mjs
@@ -15,13 +15,18 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 
 const src = readFileSync(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8");
+const FAILURE_DEF = "function paintImageFailure(img, url, { offerOpen = true } = {}) {";
 const paint = src.slice(
   src.indexOf("function paintImage(url, name) {"),
-  src.indexOf("function paintImageFailure(img, url) {"),
+  src.indexOf(FAILURE_DEF),
 );
 const failure = src.slice(
-  src.indexOf("function paintImageFailure(img, url) {"),
+  src.indexOf(FAILURE_DEF),
   src.indexOf("function videoObserver() {"),
+);
+const lightbox = src.slice(
+  src.indexOf("function openMediaLightbox(items, startIndex) {"),
+  src.indexOf("function openLightboxFromCard(card) {"),
 );
 
 test("#1417: the image card observes a load failure at all", () => {
@@ -65,4 +70,47 @@ test("#1417: error followed by a 0-size load must not paint twice", () => {
   // Both events can fire for one failure; the guard keeps the card to one message.
   assert.match(failure, /if \(img\._cmcpFailed\) return;/, "the double-fire guard must exist");
   assert.match(failure, /img\._cmcpFailed = true;/, "the failure must be recorded");
+});
+
+// #1422 — two gaps of the same class survived #1417: the lightbox stage was still a
+// silent blank (a failed card stays in collectChatGallery, so prev/next lands on it),
+// and a failed card ignored the collapse toggle (the stylesheet hid `> img`, not the
+// box that replaced it). Both measured in Chromium against merged main.
+
+test("#1422: the lightbox stage observes a load failure", () => {
+  assert.ok(lightbox.length > 0, "openMediaLightbox must exist");
+  assert.match(lightbox, /addEventListener\("error"/, "an undecodable stage must be observed");
+  assert.match(lightbox, /naturalWidth === 0/, "the zero-size decode route applies here too");
+});
+
+test("#1422: the stage reuses the card's failure paint", () => {
+  assert.match(lightbox, /paintImageFailure\(img, it\.url/, "one painter, one wording");
+  assert.match(lightbox, /offerOpen: false/, "the bar already has Open original — no duplicate");
+  assert.match(failure, /offerOpen = true/, "the card keeps its own Open-original button");
+});
+
+test("#1422: a verdict for an item the stage moved on from must not paint", () => {
+  // render() clears the stage with innerHTML="" and detaching an <img> does not fire
+  // error, so no video-style teardown guard is needed — but an async error CAN land
+  // after prev/next moved to another item, and that verdict belongs to a stage that
+  // no longer shows it.
+  assert.match(lightbox, /img\.parentNode !== mediaWrap/, "the stale-stage guard must exist");
+});
+
+test("#1422: the stage listeners attach before src, as the card's do", () => {
+  const errAt = lightbox.indexOf('addEventListener("error"');
+  const srcAt = lightbox.indexOf("img.src = it.url;");
+  assert.ok(errAt > -1 && srcAt > -1, "both statements must exist");
+  assert.ok(errAt < srcAt, "setting src first would race a cache-instant failure");
+});
+
+test("#1422: a collapsed card hides the failure box too", () => {
+  // The box sits in the <img>'s slot as a direct child of the card; the collapse rule
+  // that hid `> img` and `> .cmcp-video-holder` must name it or the one failed card in
+  // the log shows the stub AND the failure box at once.
+  assert.match(
+    src,
+    /\.cmcp-imgcard\.cmcp-media-collapsed > \.cmcp-imgcard-failed \{ display: none; \}/,
+    "the failure box must obey the collapse toggle",
+  );
 });

--- a/browser_tests/unit/media-collapse.test.mjs
+++ b/browser_tests/unit/media-collapse.test.mjs
@@ -339,10 +339,15 @@ test("collapse state is applied at paint time so a replayed card comes back hidd
 });
 
 test("collapsed cards hide the media element itself, and hide the ⛶ with it", () => {
-  assert.match(PANEL, /\.cmcp-imgcard\.cmcp-media-collapsed > img[\s\S]{0,120}display: none/);
+  // The rule gained a third selector in #1422: `.cmcp-imgcard-failed` (the #1417
+  // failure box) sits in the <img>'s slot, so a failed card must obey the toggle too.
+  // `{ display: none; }` now closes the GROUPED rule, so each selector is pinned
+  // individually rather than as `selector { display: none; }` pairs.
+  assert.match(PANEL, /\.cmcp-imgcard\.cmcp-media-collapsed > img[\s\S]{0,200}display: none/);
+  assert.match(PANEL, /\.cmcp-imgcard\.cmcp-media-collapsed > \.cmcp-video-holder,/);
   assert.match(
     PANEL,
-    /\.cmcp-imgcard\.cmcp-media-collapsed > \.cmcp-video-holder \{ display: none; \}/,
+    /\.cmcp-imgcard\.cmcp-media-collapsed > \.cmcp-imgcard-failed \{ display: none; \}/,
   );
   assert.match(
     PANEL,

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -23588,8 +23588,11 @@ const PANEL_CSS = `
    leaving a decoding, looping element behind an invisible box. The stub is the
    only thing left, so its own toggle can NOT be hover-revealed: a control the
    user cannot find is a card they cannot get back. */
+/* #1422 — the #1417 failure box sits in the <img>'s slot; without it in this rule it
+   is the one surface that ignores the toggle, showing stub AND failure box at once. */
 .cmcp-imgcard.cmcp-media-collapsed > img,
-.cmcp-imgcard.cmcp-media-collapsed > .cmcp-video-holder { display: none; }
+.cmcp-imgcard.cmcp-media-collapsed > .cmcp-video-holder,
+.cmcp-imgcard.cmcp-media-collapsed > .cmcp-imgcard-failed { display: none; }
 .cmcp-imgcard.cmcp-media-collapsed .cmcp-media-expand { display: none; }
 .cmcp-imgcard.cmcp-media-collapsed .cmcp-media-collapse { opacity: 1; }
 .cmcp-media-stub {
@@ -28680,7 +28683,23 @@ function buildPanel() {
         v.play?.().catch(() => {}); // opened by a user gesture; ignore if blocked
       } else {
         const img = document.createElement("img");
-        img.src = it.url; img.alt = it.caption || "media"; img.className = "cmcp-lightbox-el";
+        img.alt = it.caption || "media"; img.className = "cmcp-lightbox-el";
+        // #1422 — the stage must SAY SO too. Stepping onto an item the browser cannot
+        // load (a failed card stays in collectChatGallery, so prev/next reaches it)
+        // used to blank the stage with nothing on screen and nothing in the log — the
+        // #1417 failure, one click in. An <img> needs no teardown guard, unlike
+        // mountHolderVideo (#909): render() clears the stage with innerHTML="" and
+        // detaching an <img> does not fire error — only a src change does. The one
+        // guard that IS needed: render() may have moved on before an async error
+        // lands, and a verdict for an item no longer on stage must not paint.
+        // offerOpen:false — the bar already has Open original aimed at this item.
+        const onStageFail = () => {
+          if (img.parentNode !== mediaWrap) return; // render() moved on
+          paintImageFailure(img, it.url, { offerOpen: false });
+        };
+        img.addEventListener("error", onStageFail);
+        img.addEventListener("load", () => { if (img.naturalWidth === 0) onStageFail(); });
+        img.src = it.url;
         mediaWrap.appendChild(img);
       }
       caption.textContent = it.caption || "";
@@ -28927,7 +28946,11 @@ function buildPanel() {
   // also knows how to open a data: URL. `replaceWith` removes the dead <img> and with
   // it the card's click-to-lightbox target, which would only open the same undecodable
   // source one size larger.
-  function paintImageFailure(img, url) {
+  //
+  // #1422 — the same paint serves the lightbox stage, with `offerOpen: false`: the bar
+  // already carries an Open-original button aimed at the current item, so a second one
+  // inside the stage would be a duplicate.
+  function paintImageFailure(img, url, { offerOpen = true } = {}) {
     if (img._cmcpFailed) return; // error followed by a 0-size load must not paint twice
     img._cmcpFailed = true;
     const box = document.createElement("div");
@@ -28938,13 +28961,16 @@ function buildPanel() {
       "color:var(--p-text-muted-color,#a1a1aa);font-size:calc(var(--cmcp-fs, 0.8125rem) * 0.9231);";
     const label = document.createElement("div");
     label.textContent = tr("panel.this_image_could_not_be_loaded", "This image could not be loaded.");
-    const open = document.createElement("button");
-    open.type = "button";
-    open.className = "cmcp-lightbox-open";
-    open.textContent = tr("panel.open_original", "Open original");
-    open.title = tr("panel.open_in_a_new_browser_tab", "Open in a new browser tab");
-    open.addEventListener("click", (e) => { e.stopPropagation(); openMediaUrl(url); });
-    box.append(label, open);
+    box.appendChild(label);
+    if (offerOpen) {
+      const open = document.createElement("button");
+      open.type = "button";
+      open.className = "cmcp-lightbox-open";
+      open.textContent = tr("panel.open_original", "Open original");
+      open.title = tr("panel.open_in_a_new_browser_tab", "Open in a new browser tab");
+      open.addEventListener("click", (e) => { e.stopPropagation(); openMediaUrl(url); });
+      box.appendChild(open);
+    }
     img.replaceWith(box);
   }
 


### PR DESCRIPTION
Closes #1422

Follow-up to #1420 (fix for #1417), which left two gaps of the same silent-failure class — both measured in Chromium against merged `main` by the reporter.

## 1. The lightbox stage is no longer a silent blank

`openMediaLightbox`'s `render()` created its `<img>` with no error handling. A failed card stays in `collectChatGallery` (`card._cmcpMedia` is untouched), so **prev/next from a healthy card lands on the failed item** — and the stage showed nothing.

`render()`'s image branch now attaches `error` and `load` (`naturalWidth === 0`) listeners **before** `src` — the same two failure routes `paintImage` wires — and routes both to the #1420 `paintImageFailure` painter. Per the reporter's note, an `<img>` here needs no #909-style teardown guard (`render()` clears the stage with `innerHTML = ""`; detaching an `<img>` never fires `error`), but one guard IS needed: an async error can land after prev/next moved to another item, so the verdict paints only if the element is still the stage's child (`img.parentNode !== mediaWrap → return`).

`paintImageFailure` gains an `offerOpen` option (default `true` — card behavior unchanged); the stage passes `false` because the lightbox bar already carries **Open original** aimed at the current item, and the bar's caption still names the file.

## 2. A failed image card obeys the collapse toggle again

`img.replaceWith(box)` put `.cmcp-imgcard-failed` in the `<img>`'s slot, but the collapse rule only hid `> img` and `> .cmcp-video-holder` — so a collapsed failed card showed the stub AND the failure box at once. The grouped rule now names the third selector:

```css
.cmcp-imgcard.cmcp-media-collapsed > img,
.cmcp-imgcard.cmcp-media-collapsed > .cmcp-video-holder,
.cmcp-imgcard.cmcp-media-collapsed > .cmcp-imgcard-failed { display: none; }
```

`media-collapse.test.mjs`'s pin of that rule is updated to match the new shape: `{ display: none; }` now closes a grouped three-selector rule, so each selector is pinned individually. (The old `> .cmcp-video-holder { display: none; }` exact-match pin could not survive adding a selector to the group by construction.)

## i18n

No new strings: the notice reuses `panel.this_image_could_not_be_loaded` (shipped for all 12 locales in #1420); the stage adds no button of its own. `npm run i18n:build` produces a byte-identical `locales/en/main.json` (verified; line-ending noise reverted).

## Verification

- `npm ci` — clean (0 vulnerabilities).
- `npm run test:unit` — **5613 tests, 5612 pass, 0 fail, 1 todo** (~40s), first run. Includes the previously-flaky `manager-install.test.mjs`, green this time.
- `npm run typecheck` (`tsc --noEmit`) — clean.
- `node --check web/js/comfyui-mcp-panel.js` — clean.
- New pins in `browser_tests/unit/image-load-failure.test.mjs` (5 added, 12 total in file): stage observes `error`, zero-size route applies, painter reuse with `offerOpen: false`, the stale-stage guard, listeners-before-src ordering, and the collapse CSS naming `.cmcp-imgcard-failed`.

## Follow-up (not in this PR)

The issue ships a ready e2e spec (`fixtures/panelTest` + `mockBridge` can drive `show_media` against a real ComfyUI, unlike the #909 video holder). That is worth landing as real behavioral coverage for #1417+#1422 together; this PR deliberately stays with source pins matching the #1420 style.