### PR TITLE
fix(1418): stale-combo refusal tells the truth about the refresh, and the /view probe is bounded

### DIFF
--- a/browser_tests/unit/_panel-constants.mjs
+++ b/browser_tests/unit/_panel-constants.mjs
@@ -18,6 +18,9 @@ import { REFRESH_JOIN_ABANDONED } from "../../web/js/lib/refresh-coalesce.js";
 import { NODE_DEF_REFRESH_REASONS } from "../../web/js/lib/node-def-refresh.js";
 import { clearInheritedExecutionPreview } from "../../web/js/lib/execution-preview-attach.js";
 import { sanitizeNodeAuxId } from "../../web/js/lib/aux-id-sanitize.js";
+import { withTimeout } from "../../web/js/lib/bounded-step.js";
+import { OBJECT_INFO_DEADLINE_MS } from "../../web/js/lib/object-info-oracle.js";
+import { COMBO_REFRESH_NEVER_RAN } from "../../web/js/lib/set-widget.js";
 
 export const PANEL_SRC = readFileSync(
   fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url)),
@@ -197,8 +200,16 @@ export function addNodeCommandBudgetDeps() {
  * place, for the same reason addNodeCommandBudgetDeps exists: harnesses that rebuild that
  * executor in a synthetic scope throw ReferenceError on a new free identifier, and each
  * would otherwise grow its own copy of these. The REAL implementations where they exist
- * (`makeCommandBudget`, and the numbers read from the panel source), so a harness cannot
- * pass against a value the panel no longer holds.
+ * (`makeCommandBudget`, `withTimeout`, the symbols, and the numbers read from the panel
+ * source or imported from the lib that owns them), so a harness cannot pass against a
+ * value the panel no longer holds.
+ *
+ * #1418 widened the budget's reach inside the handler: the seed wait and the oracle read
+ * are now capped with `budget.bounded(...)`, the upload probe is wrapped in `withTimeout`,
+ * and the recovery's refusal distinguishes "still running" from "never ran" on a second
+ * token. `nodeDefRefreshInFlight` is deliberately NOT here: it is the coalescer's live
+ * slot, a piece of mutable module state each harness must wire to its own slot double —
+ * a shared snapshot of it would be stale by construction.
  */
 export function setWidgetCommandBudgetDeps() {
   return {
@@ -206,5 +217,10 @@ export function setWidgetCommandBudgetDeps() {
     SET_WIDGET_COMMAND_BUDGET_MS,
     SET_WIDGET_POST_REFRESH_RESERVE_MS,
     monotonicNow,
+    withTimeout,
+    OBJECT_INFO_SEED_WAIT_MS,
+    OBJECT_INFO_DEADLINE_MS,
+    REFRESH_JOIN_ABANDONED,
+    COMBO_REFRESH_NEVER_RAN,
   };
 }

--- a/browser_tests/unit/object-info-snapshot.test.mjs
+++ b/browser_tests/unit/object-info-snapshot.test.mjs
@@ -30,8 +30,10 @@ import {
   TRANSPORT_OUTCOME,
   fetchWholeObjectInfo,
   objectInfoOracleFailureNote,
+  OBJECT_INFO_DEADLINE_MS,
 } from "../../web/js/lib/object-info-oracle.js";
 import { createObjectInfoCache, CACHE_OUTCOME } from "../../web/js/lib/object-info-cache.js";
+import { makeCommandBudget } from "../../web/js/lib/command-budget.js";
 
 const SCHEMA = { KSampler: { input: {} }, H3Keyframes: { input: {} } };
 const silence = [
@@ -508,6 +510,8 @@ function buildShippedOracle({ api, socketDown = false, epoch = 5, snapshot, epoc
     "epochDuringFetch",
     "comfyBackendSocketDown",
     "objectInfoOracleFailureNote",
+    "OBJECT_INFO_DEADLINE_MS",
+    "makeCommandBudget",
     // `backendReconnectEpoch` MUST be a live mutable binding in the same scope as the
     // extracted body, because the panel's is module state the body re-reads. An earlier
     // version passed it as a frozen value, which made `observedAtEpoch` and the record-time
@@ -520,6 +524,11 @@ function buildShippedOracle({ api, socketDown = false, epoch = 5, snapshot, epoc
      const comfyBackendIsDown = () => comfyBackendSocketDown;
      const historyRecorded = [];
      const recordObjectInfoTypes = (defs) => { historyRecorded.push(defs); return defs; };
+     // #1418 — the shipped body now draws the oracle's deadline from the command budget.
+     // The REAL budget, freshly minted per build, so the arithmetic is production's; the
+     // harness wrapper below still overrides the deadline to its own 20ms, so no test here
+     // waits on it either way.
+     const budget = makeCommandBudget(25000);
      // Declared HERE so it closes over the mutable epoch above and can move it the moment
      // the read is issued — the panel's real hazard is a reconnect landing mid-fetch.
      const fetchWholeObjectInfo = (opts) => {
@@ -552,6 +561,8 @@ function buildShippedOracle({ api, socketDown = false, epoch = 5, snapshot, epoc
     epochDuringFetch,
     socketDown,
     objectInfoOracleFailureNote,
+    OBJECT_INFO_DEADLINE_MS,
+    makeCommandBudget,
   );
 }
 

--- a/browser_tests/unit/relay-window-command-audit.test.mjs
+++ b/browser_tests/unit/relay-window-command-audit.test.mjs
@@ -1,0 +1,57 @@
+/**
+ * #1418 §4 — the audit #1413 asked for, as a test rather than a sentence.
+ *
+ * Five commands are relayed in the orchestrator's 30,000 ms window
+ * (OBJECT_INFO_REFRESH_ACK_TIMEOUT_MS). Three of them hold a command budget now
+ * (graph_add_node #1192, graph_set_widget #1413/#1418, refresh_nodes #1404; nodes_install
+ * has its own at a literal 30000). The remaining two — graph_get_object_info and
+ * graph_remove_widget — were audited clean: each holds exactly ONE await, that await lands
+ * on fetchWholeObjectInfo (which bounds itself at OBJECT_INFO_DEADLINE_MS, under the
+ * window, with nothing to compose against), and neither reaches the refresh coalescer.
+ *
+ * "Audited clean" has a shelf life: the day either command grows a second wait or starts
+ * joining node-def refresh runs, it becomes the fifth instance of the 30s-window defect.
+ * So the audit is asserted here, against the shipped bodies, scoped per method — and it
+ * goes red on exactly that change.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { PANEL_SRC } from "./_panel-constants.mjs";
+
+/** One executor's body, delimited by the next sibling — never a slice into a neighbour. */
+function executorBody(name) {
+  const m = PANEL_SRC.match(new RegExp(`\\n {2}async ${name}\\([\\s\\S]*?\\n {2}\\},`));
+  assert.ok(m, `could not locate ${name} in the panel source`);
+  return m[0];
+}
+
+for (const name of ["graph_get_object_info", "graph_remove_widget"]) {
+  test(`#1418 audit: ${name} has ONE await, on the bounded oracle, and never joins a refresh`, () => {
+    const body = executorBody(name);
+
+    const awaits = body.match(/\bawait\b/g) ?? [];
+    assert.equal(
+      awaits.length,
+      1,
+      `${name} grew a second wait — each wait in a 30s-relayed command must compose ` +
+        "against the others, which is exactly what a command budget is for (#1192 family)",
+    );
+
+    // The one wait is the whole-schema oracle, which carries its own deadline
+    // (OBJECT_INFO_DEADLINE_MS) — there is nothing else on the path to compose against,
+    // so a command budget would buy nothing here.
+    assert.match(
+      body,
+      /fetchWholeObjectInfo\(/,
+      `${name}'s one await must land on the self-bounded oracle`,
+    );
+
+    // The defect this family keeps reproducing: a wait on the node-def refresh coalescer
+    // relayed inside the window with no bound of its own.
+    assert.ok(
+      !body.includes("refreshComfyNodeDefs"),
+      `${name} must never join a node-def refresh run — that wait needs a command budget`,
+    );
+  });
+}

--- a/browser_tests/unit/rgthree-lora-row.test.mjs
+++ b/browser_tests/unit/rgthree-lora-row.test.mjs
@@ -1324,6 +1324,16 @@ const EXECUTOR_DEPS = [
   "SET_WIDGET_COMMAND_BUDGET_MS",
   "SET_WIDGET_POST_REFRESH_RESERVE_MS",
   "monotonicNow",
+  // #1418 — the budget now reaches the seed wait, the oracle read and the upload probe,
+  // and the recovery distinguishes "still running" from "never ran" on a second token.
+  "withTimeout",
+  "OBJECT_INFO_SEED_WAIT_MS",
+  "OBJECT_INFO_DEADLINE_MS",
+  "REFRESH_JOIN_ABANDONED",
+  "COMBO_REFRESH_NEVER_RAN",
+  // The coalescer's live slot. This harness's refreshCombos path is never exercised (the
+  // runSetWidget double never calls it), so a fixed null is the truth here.
+  "nodeDefRefreshInFlight",
 ];
 
 /**
@@ -1460,6 +1470,7 @@ function executor(node, overrides = {}) {
     // #1413 — the handler now takes a command budget on its first line. The real pieces,
     // with the shipped numbers, from the shared harness constants.
     ...setWidgetCommandBudgetDeps(),
+    nodeDefRefreshInFlight: null,
     ...overrides,
   };
   const factory = new Function(

--- a/browser_tests/unit/set-widget-combo-fallback.test.mjs
+++ b/browser_tests/unit/set-widget-combo-fallback.test.mjs
@@ -28,6 +28,8 @@ import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 
 import { SET_WIDGET_POST_REFRESH_RESERVE_MS } from "./_panel-constants.mjs";
+import { REFRESH_JOIN_ABANDONED } from "../../web/js/lib/refresh-coalesce.js";
+import { COMBO_REFRESH_NEVER_RAN } from "../../web/js/lib/set-widget.js";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const PANEL_JS = join(HERE, "../../web/js/comfyui-mcp-panel.js");
@@ -36,7 +38,7 @@ const panelSrc = readFileSync(PANEL_JS, "utf8");
 // Drive the SHIPPED callback, not a transcription of it. The other set-widget
 // suites re-implement `refreshCombos` in the test file, so none of them would
 // notice this wiring changing.
-const match = panelSrc.match(/refreshCombos: \(defs, target, concreteType, nameMap\) => \{[\s\S]*?\n {6}\},/);
+const match = panelSrc.match(/refreshCombos: async \(defs, target, concreteType, nameMap\) => \{[\s\S]*?\n {6}\},/);
 assert.ok(match, "could not locate the panel's refreshCombos wiring");
 
 function shippedRefreshCombos({
@@ -45,6 +47,9 @@ function shippedRefreshCombos({
   // #1413 — the callback now draws its join bound from the command budget the handler
   // took on its first line. A healthy command's remainder, by default.
   budget = { remaining: () => 21000 },
+  // #1418 — the coalescer's live slot, read to tell "a run is still going" apart from
+  // "nothing was started". Empty by default.
+  nodeDefRefreshInFlight = null,
 }) {
   const body = match[0].replace(/^refreshCombos: /, "");
   const factory = new Function(
@@ -52,9 +57,20 @@ function shippedRefreshCombos({
     "refreshComfyNodeDefs",
     "budget",
     "SET_WIDGET_POST_REFRESH_RESERVE_MS",
+    "nodeDefRefreshInFlight",
+    "REFRESH_JOIN_ABANDONED",
+    "COMBO_REFRESH_NEVER_RAN",
     `return (${body.replace(/,$/, "")});`,
   );
-  return factory(onFromDefs, onFullRefresh, budget, SET_WIDGET_POST_REFRESH_RESERVE_MS);
+  return factory(
+    onFromDefs,
+    onFullRefresh,
+    budget,
+    SET_WIDGET_POST_REFRESH_RESERVE_MS,
+    nodeDefRefreshInFlight,
+    REFRESH_JOIN_ABANDONED,
+    COMBO_REFRESH_NEVER_RAN,
+  );
 }
 
 function spies(overrides = {}) {
@@ -156,4 +172,37 @@ test("#1413 an exhausted command hands the coalescer a non-positive joinMs, not 
   assert.equal(calls.full, 1);
   const { joinMs } = calls.fullArgs[0][1];
   assert.ok(Number.isFinite(joinMs) && joinMs <= 0, `joinMs must say "spent", got ${joinMs}`);
+});
+
+test("#1418 an abandonment with NOTHING running is a distinct token, not REFRESH_JOIN_ABANDONED", async () => {
+  // The whole point of the issue: with the budget spent and the slot empty the coalescer
+  // starts NOTHING, so "a refresh is still running — retry joins it" would be a claim about
+  // a run that does not exist. The wrapper translates that arm to COMBO_REFRESH_NEVER_RAN.
+  const { fn } = spies({
+    budget: { remaining: () => -50 }, // joinMs <= 0
+    nodeDefRefreshInFlight: null, // …and the slot is empty
+    onFullRefresh: async () => REFRESH_JOIN_ABANDONED,
+  });
+  const outcome = await fn(undefined, TARGET, "CheckpointLoaderSimple", null);
+  assert.equal(outcome, COMBO_REFRESH_NEVER_RAN, "the refusal must be worded for 'never ran'");
+});
+
+test("#1418 an abandonment with a run in flight (or budget for an own run) stays REFRESH_JOIN_ABANDONED", async () => {
+  // The state the original wording IS true of: a run occupies the slot and is still
+  // registering. Both facts are read BEFORE the coalescer call, so the translation can
+  // never disagree with the coalescer's own decision.
+  for (const [label, extra] of [
+    ["slot occupied, budget spent", { budget: { remaining: () => -50 }, nodeDefRefreshInFlight: Promise.resolve() }],
+    ["slot empty, budget left", { budget: { remaining: () => 5000 }, nodeDefRefreshInFlight: null }],
+  ]) {
+    const { fn } = spies({ ...extra, onFullRefresh: async () => REFRESH_JOIN_ABANDONED });
+    const outcome = await fn(undefined, TARGET, "CheckpointLoaderSimple", null);
+    assert.equal(outcome, REFRESH_JOIN_ABANDONED, `${label}: a refresh is verifiably running`);
+  }
+});
+
+test("#1418 a COMPLETED refresh is returned untouched by the translation", async () => {
+  const { fn } = spies({ budget: { remaining: () => -50 }, nodeDefRefreshInFlight: null });
+  const outcome = await fn(undefined, TARGET, "CheckpointLoaderSimple", null);
+  assert.equal(outcome, "full", "only the abandoned state is reworded");
 });

--- a/browser_tests/unit/set-widget-stale-combo-budget.test.mjs
+++ b/browser_tests/unit/set-widget-stale-combo-budget.test.mjs
@@ -24,7 +24,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { runSetWidget } from "../../web/js/lib/set-widget.js";
+import { runSetWidget, COMBO_REFRESH_NEVER_RAN } from "../../web/js/lib/set-widget.js";
 import { makeRefreshCoalescer, REFRESH_JOIN_ABANDONED } from "../../web/js/lib/refresh-coalesce.js";
 import { withTimeout } from "../../web/js/lib/bounded-step.js";
 import { createObjectInfoCache, CACHE_OUTCOME } from "../../web/js/lib/object-info-cache.js";
@@ -129,6 +129,34 @@ test("#1413 a refresh that COMPLETES (resolves undefined) still drives the retry
   assert.equal(res.refreshed, true);
 });
 
+test("#1418 a never-started recovery says NOTHING IS RUNNING — never 'still running'", async () => {
+  // The budget-spent arm: the coalescer answered without starting anything, so the refusal
+  // must rest the retry on what is true in THAT state — a fresh budget on the retry — not
+  // on joining a run that does not exist.
+  const widget = { name: "image", type: "combo", options: { values: ["old_a.png"] }, value: "old_a.png" };
+  const node = makeNode("LoadImage", widget);
+  await assert.rejects(
+    () =>
+      runSetWidget(node, "image", "new.png", {
+        registry: REGISTRY,
+        ...freshOracle,
+        refreshCombos: async () => COMBO_REFRESH_NEVER_RAN,
+      }),
+    (err) => {
+      assert.match(err.message, /panel_set_widget refused "image" on node 105/, "the standard refusal frame");
+      assert.match(err.message, /never started/, "the true state: the recovery never ran");
+      assert.match(err.message, /No node-def refresh is running/, "…and no run is claimed");
+      assert.match(err.message, /NOTHING WAS WRITTEN/);
+      assert.match(err.message, /RETRY/, "the remedy that is true in this state too");
+      assert.match(err.message, /panel_refresh_nodes/, "…with the same escalation");
+      assert.ok(!/still running/.test(err.message), "must not assert a refresh that does not exist");
+      assert.ok(!/not a valid option/.test(err.message), "nor call the value invalid");
+      return true;
+    },
+  );
+  assert.equal(widget.value, "old_a.png", "nothing was written");
+});
+
 // ---------------------------------------------------------------------------
 // 2. The wiring: the SHIPPED graph_set_widget, extracted and run.
 // ---------------------------------------------------------------------------
@@ -183,6 +211,17 @@ const EXECUTOR_DEPS = [
   "SET_WIDGET_COMMAND_BUDGET_MS",
   "SET_WIDGET_POST_REFRESH_RESERVE_MS",
   "monotonicNow",
+  // #1418 — the budget now reaches the seed wait, the oracle read and the upload probe,
+  // and the recovery distinguishes "still running" from "never ran" on a second token.
+  "withTimeout",
+  "OBJECT_INFO_SEED_WAIT_MS",
+  "OBJECT_INFO_DEADLINE_MS",
+  "REFRESH_JOIN_ABANDONED",
+  "COMBO_REFRESH_NEVER_RAN",
+  // The coalescer's live slot. The shipped refreshCombos reads it BEFORE calling the
+  // coalescer, so the value captured at build time is exactly what that read must see:
+  // the in-flight run a test started before dispatching the command.
+  "nodeDefRefreshInFlight",
 ];
 
 function deferred() {
@@ -190,6 +229,8 @@ function deferred() {
   const promise = new Promise((r) => (resolve = r));
   return { promise, resolve };
 }
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
 /**
  * Build the SHIPPED `graph_set_widget` with the REAL runSetWidget, the REAL coalescer and
@@ -209,6 +250,15 @@ function realGraphSetWidget({
   onRunRegister = null,
   budgetMs = 400,
   reserveMs = 120,
+  // #1418 — the two waits AHEAD of the recovery, made slow so the budget is genuinely
+  // spent when the recovery is reached (the issue's no-concurrency arm).
+  seedDelayMs = 0,
+  oracleDelayMs = 0,
+  // What the authorization oracle answers. Default lacks "Note"; the probe test needs a
+  // LoadImage def whose image input is upload-capable.
+  oracleDefs = null,
+  // /view probe behaviour: default answers 404 (the asset is not there).
+  fetchApiImpl = null,
 } = {}) {
   const graph = {
     _nodes: [node],
@@ -230,8 +280,11 @@ function realGraphSetWidget({
   // refreshCombos down the full-refresh fallback this issue is about: a payload that
   // cannot contain the keyed type must not be treated as the authoritative list (#796).
   const api = {
-    getNodeDefs: async () => ({ LoadImage: { input: { required: { image: [["old_a.png"], {}] } } } }),
-    fetchApi: async () => ({ ok: false, status: 404 }),
+    getNodeDefs: async () => {
+      if (oracleDelayMs) await sleep(oracleDelayMs);
+      return oracleDefs ?? { LoadImage: { input: { required: { image: [["old_a.png"], {}] } } } };
+    },
+    fetchApi: fetchApiImpl ?? (async () => ({ ok: false, status: 404 })),
   };
 
   // The REAL single-flight coordinator over a real slot, with a real in-flight run when
@@ -260,7 +313,10 @@ function realGraphSetWidget({
     classifyPromptRelayTimelineWrite: () => null,
     classifyRgthreeFastGroupsWrite: () => null,
     classifyIdeogram4PromptBuilderWrite: () => null,
-    awaitObjectInfoHistorySeed: async () => {},
+    // #1418 — honors the cap it is handed, the way the shipped one does: it waits at most
+    // waitMs, and a slow seed simply spends it.
+    awaitObjectInfoHistorySeed: (waitMs) =>
+      seedDelayMs ? sleep(Math.min(typeof waitMs === "number" ? waitMs : 8000, seedDelayMs)) : Promise.resolve(),
     // The REAL classifier and creator, as rgthree-lora-row.test.mjs requires: a double
     // would let the executor pass against a route that never fires.
     isRgthreeLoraRowCreation,
@@ -289,6 +345,9 @@ function realGraphSetWidget({
     ...setWidgetCommandBudgetDeps(),
     SET_WIDGET_COMMAND_BUDGET_MS: budgetMs,
     SET_WIDGET_POST_REFRESH_RESERVE_MS: reserveMs,
+    // Captured AFTER the held-open run above has taken the slot — the value the shipped
+    // refreshCombos reads before it calls the coalescer.
+    nodeDefRefreshInFlight: inFlight,
   };
   const factory = new Function(
     ...EXECUTOR_DEPS,
@@ -372,6 +431,83 @@ test("#1413 wiring: with NOTHING in flight the fallback still runs the refresh, 
   assert.equal(built.runs.length, 1, "the fallback ran exactly one refresh");
 });
 
+test("#1418 wiring: a budget spent by the seed+oracle says NOTHING IS RUNNING, with no concurrency", async () => {
+  // The issue's measured arm: no other command, no reconnect, no install — the seed wait
+  // and the authorization read alone spend the budget, the coalescer starts NOTHING, and
+  // the refusal must say so. Driven through the shipped handler so the caps on those two
+  // waits are what keep the answer inside the window at all.
+  const { node, widget } = noteNode();
+  const built = realGraphSetWidget({
+    node,
+    budgetMs: 400,
+    reserveMs: 220,
+    seedDelayMs: 120, // waits its capped allowance…
+    oracleDelayMs: 80, // …and the oracle answers, slowly, inside its own capped share
+  });
+
+  const started = Date.now();
+  await assert.rejects(
+    () => built.graph_set_widget({ node_id: 7, widget: "mode", value: "b", workflow_uuid: "u" }),
+    (err) => {
+      assert.match(err.message, /never started/, "the recovery never ran and says so");
+      assert.match(err.message, /No node-def refresh is running/, "no phantom refresh is claimed");
+      assert.match(err.message, /NOTHING WAS WRITTEN/);
+      assert.match(err.message, /RETRY/);
+      assert.ok(!/still running/.test(err.message), "the other state's wording must not appear");
+      return true;
+    },
+  );
+  const elapsed = Date.now() - started;
+  assert.ok(
+    elapsed < 3000,
+    `the write took ${elapsed}ms — before the caps, the flat seed+oracle waits alone summed past the budget`,
+  );
+  assert.equal(widget.value, "a", "nothing was written");
+  assert.deepEqual(built.runs, [], "no refresh run was ever started");
+});
+
+test("#1418 wiring: a hung /view probe gives up at the budget instead of outliving the relay", async () => {
+  // The probe is reached after a SUCCESSFUL (in-place) refresh, so #1413's joinMs never
+  // covered it: the payload contains LoadImage, the refresh re-lists only the top-level
+  // file, the retry misses the nested value, and the #387 probe hangs on a dead backend.
+  const widget = { name: "image", type: "combo", options: { values: ["example.png"] }, value: "example.png" };
+  const node = { id: 191, type: "LoadImage", widgets: [widget] };
+  let probed = false;
+  const built = realGraphSetWidget({
+    node,
+    budgetMs: 300,
+    reserveMs: 120,
+    oracleDefs: { LoadImage: { input: { required: { image: [["example.png"], { image_upload: true }] } } } },
+    fetchApiImpl: (route) => {
+      if (String(route).startsWith("/view")) {
+        probed = true;
+        return new Promise(() => {}); // half-open: never answers, never fails
+      }
+      return Promise.resolve({ ok: false, status: 404 });
+    },
+  });
+
+  const started = Date.now();
+  await assert.rejects(
+    () =>
+      built.graph_set_widget({
+        node_id: 191,
+        widget: "image",
+        value: "xyr_canvas/boswellia_source.png",
+        workflow_uuid: "u",
+      }),
+    /not a valid option/,
+    "a probe that cannot answer in time is the 'not confirmed' the probe already answers on any doubt",
+  );
+  const elapsed = Date.now() - started;
+  assert.ok(
+    elapsed < 3000,
+    `the probe took ${elapsed}ms of a 300ms command — unbounded, the refusal never leaves the tab`,
+  );
+  assert.ok(probed, "the probe did run — it is bounded, not skipped");
+  assert.equal(widget.value, "example.png", "nothing was written");
+});
+
 // ---------------------------------------------------------------------------
 // 3. The shipped numbers, pinned against the relay window (the single-node-def
 //    technique): the harnesses above inject small budgets, so only a source-level check
@@ -392,7 +528,33 @@ test("#1413 the shipped budget mirrors add_node's against the same 30s relay win
   );
   assert.match(
     body,
-    /joinMs: budget\.remaining\(\) - SET_WIDGET_POST_REFRESH_RESERVE_MS/,
+    /joinMs = budget\.remaining\(\) - SET_WIDGET_POST_REFRESH_RESERVE_MS/,
     "the fallback join draws from the command's remaining budget, not a fresh constant",
+  );
+});
+
+// ---------------------------------------------------------------------------
+// 4. #1418: the waits AHEAD of the recovery draw from the budget too, and the probe
+//    after it is bounded. SCOPED to this command's body — graph_add_node holds the
+//    sibling call sites, so an unscoped pin stays green with these deleted (the trap
+//    the issue itself names).
+// ---------------------------------------------------------------------------
+
+test("#1418 the seed wait and the oracle read are capped by the command budget", () => {
+  const body = SET_WIDGET_SRC;
+  assert.match(
+    body,
+    /awaitObjectInfoHistorySeed\(budget\.bounded\(OBJECT_INFO_SEED_WAIT_MS\)\)/,
+    "the flat 8000ms seed wait is capped by what the command has left",
+  );
+  assert.match(
+    body,
+    /deadlineMs: budget\.bounded\(OBJECT_INFO_DEADLINE_MS\)/,
+    "the flat 20000ms oracle deadline is capped by what the command has left",
+  );
+  assert.match(
+    body,
+    /budget\.bounded\(\)/,
+    "the upload probe draws the remainder (no constant of its own to drift)",
   );
 });

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -271,7 +271,7 @@ import { BACKEND_SWITCH, runBackendSwitch } from "./lib/backend-switch.js";
 import { createSettingsBackendDefault } from "./lib/settings-backend-default.js";
 import { fetchNodeDefsWithRetry, OBJECT_INFO_RETRY_DELAYS_MS } from "./lib/object-info-retry.js";
 import { createObjectInfoCache, CACHE_OUTCOME } from "./lib/object-info-cache.js";
-import { fetchWholeObjectInfo, objectInfoOracleFailureNote } from "./lib/object-info-oracle.js";
+import { fetchWholeObjectInfo, objectInfoOracleFailureNote, OBJECT_INFO_DEADLINE_MS } from "./lib/object-info-oracle.js";
 import { createObjectInfoSnapshot, snapshotAuthorizationNote } from "./lib/object-info-snapshot.js";
 import { isRgthreeLoraRowCreation, createRgthreeLoraRow } from "./lib/rgthree-lora-row.js";
 import { objectInfoFingerprint, objectInfoUnchanged } from "./lib/object-info-fingerprint.js";
@@ -304,7 +304,7 @@ import {
   clearAutoLayoutScope,
   layoutScopeFingerprint,
 } from "./lib/auto-layout-scope.js";
-import { runSetWidget } from "./lib/set-widget.js";
+import { runSetWidget, COMBO_REFRESH_NEVER_RAN } from "./lib/set-widget.js";
 import { declaredInputNames, runRemoveWidget } from "./lib/remove-widget.js";
 import {
   filterServerConfirmedInputSubfolderCandidates,
@@ -12455,10 +12455,14 @@ const GRAPH_TOOL_EXECUTORS = {
         // than parking.
         // #1223 — read the epoch HERE, immediately before the whole request is issued.
         addNodeObservedAtEpoch = backendReconnectEpoch;
-        // #1192 — the same request `graph_set_widget`'s oracle allows 10,000 ms, allowed
-        // 10,000 ms here too, and BOTH now capped by their caller's remaining budget. The
-        // two paths agreeing about how long one /object_info may take is what stops a
-        // "set_widget works but add_node fails" asymmetry appearing on a slow install.
+        // #1192 — allowed 10,000 ms here, capped by the caller's remaining budget.
+        // #1418 — what this comment used to claim about the OTHER path was never true: it
+        // said `graph_set_widget`'s oracle "allows 10,000 ms" and that both were capped, but
+        // that oracle is fetchWholeObjectInfo at OBJECT_INFO_DEADLINE_MS (20,000 ms), and
+        // nothing capped it until #1418 gave it the same budget.bounded(...) treatment. The
+        // two paths genuinely agree now. The earlier sentence is left corrected rather than
+        // deleted because it did real harm twice: a reassurance-shaped claim concealed the
+        // very next occurrence of the defect it described (#1413's note, then this one).
         const whole = await boundedGetNodeDefs(budget.bounded(NODE_DEFS_FETCH_TIMEOUT_MS));
         freshDefs = recordObjectInfoTypes(whole === NODE_DEFS_NO_ANSWER ? null : whole);
         freshDefsAreSingleClass = false;
@@ -13711,7 +13715,12 @@ const GRAPH_TOOL_EXECUTORS = {
     // fails CLOSED for this call only, with a TEMPORARY "retry in a moment" refusal. The
     // seed keeps running, so a late response still establishes the baseline and the next
     // call authorizes normally — ordinary latency must never burn the session.
-    await awaitObjectInfoHistorySeed();
+    // #1418 — capped by what the COMMAND has left, exactly as graph_add_node caps its copy:
+    // the flat 8,000 ms here plus the oracle's flat 20,000 ms used to compose past the
+    // 25,000 ms budget before the stale-combo recovery was even reached, which is how the
+    // recovery's join could be handed a negative allowance with nothing in flight (#1413's
+    // bound then correctly started nothing — and the refusal correctly says so).
+    await awaitObjectInfoHistorySeed(budget.bounded(OBJECT_INFO_SEED_WAIT_MS));
     // #757 — MINT an rgthree Power Lora Loader row when the write targets one that does not
     // exist yet. Those rows are created only by the node's own "➕ Add Lora" button, a
     // DOM-only control an agent cannot click, so every write to `lora_1` on a fresh node was
@@ -13812,9 +13821,19 @@ const GRAPH_TOOL_EXECUTORS = {
             // The OUTCOME rides through the cache, not just the schema (codex): a second
             // concurrent write JOINS this in-flight read and never runs its own loader, so
             // returning bare defs would leave that caller's refusal naming no routes at all.
+            //
+            // #1418 — the deadline is what the COMMAND has left, computed INSIDE the loader
+            // so it is read when the request is actually issued (a joined read runs no
+            // loader and spends nothing), not when the options object was built. Uncapped,
+            // this flat 20,000 ms plus the 8,000 ms seed wait above composed past the
+            // 25,000 ms budget before the stale-combo recovery was reached — the exact
+            // composition #1413's refusal then had to report. On a timeout the oracle
+            // answers "nothing usable" as it already does for every other doubt, and the
+            // write fails closed on the same path, inside the window.
             return fetchWholeObjectInfo({
               getNodeDefs: typeof api?.getNodeDefs === "function" ? () => api.getNodeDefs() : null,
               fetchApi: typeof api?.fetchApi === "function" ? (route) => api.fetchApi(route) : null,
+              deadlineMs: budget.bounded(OBJECT_INFO_DEADLINE_MS),
             });
           },
           { stamp: () => backendReconnectEpoch },
@@ -13958,7 +13977,7 @@ const GRAPH_TOOL_EXECUTORS = {
       // genuinely-invalid value simply stays rejected on the retry). Only a MISSING
       // payload falls back to the full frontend refresh (refreshComfyNodeDefs →
       // refreshComboInNodes), which re-fetches /object_info.
-      refreshCombos: (defs, target, concreteType, nameMap) => {
+      refreshCombos: async (defs, target, concreteType, nameMap) => {
         // A payload that does not CONTAIN the type we are keying on cannot refresh
         // anything: refreshComboOptionsFromDefs looks up `defsByType[type]` and
         // returns 0 on a miss, silently. The caller then treats the retry as
@@ -13990,9 +14009,21 @@ const GRAPH_TOOL_EXECUTORS = {
         // a best-effort catch that would swallow one; the lib turns the token into a
         // worded "nothing was written — retry" refusal instead of revalidating against
         // the list that was never refreshed and calling the value invalid.
-        return refreshComfyNodeDefs(undefined, {
-          joinMs: budget.remaining() - SET_WIDGET_POST_REFRESH_RESERVE_MS,
-        });
+        const joinMs = budget.remaining() - SET_WIDGET_POST_REFRESH_RESERVE_MS;
+        // #1418 — REFRESH_JOIN_ABANDONED answers two different states and the refusal must
+        // not confuse them. With nothing in flight and nothing left, the coalescer starts
+        // NOTHING (its bottom branch returns before startRun) — and "a refresh is still
+        // running, retry joins it" would then be a claim about a run that does not exist.
+        // The distinction is read HERE, from the same two facts the coalescer's own
+        // decision is made from — the slot and the bound — captured BEFORE the call so the
+        // two can never disagree (reading the slot after the await would race the run's
+        // own cleanup). joinMs > 0 always leaves a run owned: no in-flight ⇒ the coalescer
+        // starts this caller's own, which keeps the slot past the abandoned wait.
+        const refreshCanBeRunning = joinMs > 0 || nodeDefRefreshInFlight != null;
+        const outcome = await refreshComfyNodeDefs(undefined, { joinMs });
+        return outcome === REFRESH_JOIN_ABANDONED && !refreshCanBeRunning
+          ? COMBO_REFRESH_NEVER_RAN
+          : outcome;
       },
       // #387: last-resort probe for an UPLOAD input value the refreshed /object_info
       // combo still cannot list — a LoadImage image uploaded under a SUBFOLDER (ComfyUI
@@ -14008,11 +14039,22 @@ const GRAPH_TOOL_EXECUTORS = {
           const filename = i >= 0 ? v.slice(i + 1) : v;
           if (!filename) return false;
           const qs = new URLSearchParams({ filename, subfolder, type: "input" }).toString();
-          const res = await api.fetchApi(`/view?${qs}`, {
-            method: "GET",
-            cache: "no-store",
-            headers: { Range: "bytes=0-0" },
-          });
+          // #1418 — the LAST network step in a command relayed at 30,000 ms, and until now
+          // the only unbounded one: reached after a SUCCESSFUL refresh (the abandoned-join
+          // refusal fires before it), so #1413's joinMs never covered it. It draws what the
+          // command has left. A timeout answers FALSE — the same answer the probe already
+          // gives for every error and every doubt below — so the bound can only ever refuse
+          // a value, never admit one: #240 strictness is untouched. The retry then re-runs
+          // the probe with a fresh budget.
+          const res = await withTimeout(
+            api.fetchApi(`/view?${qs}`, {
+              method: "GET",
+              cache: "no-store",
+              headers: { Range: "bytes=0-0" },
+            }),
+            budget.bounded(),
+            () => null,
+          );
           return !!res && (res.ok || res.status === 206);
         } catch {
           return false;

--- a/web/js/lib/set-widget.js
+++ b/web/js/lib/set-widget.js
@@ -77,28 +77,57 @@ function coerceAdvisoryMessage(err) {
 }
 
 /**
- * #1413 — the refusal for a stale-combo recovery whose authoritative refresh was still
- * running when the command's budget ran out.
+ * #1418 — what the panel's refreshCombos returns instead of REFRESH_JOIN_ABANDONED when the
+ * abandoned wait STARTED NOTHING: the command's budget was already spent before the recovery
+ * could begin (the seed wait and the authorization /object_info are drawn against it too),
+ * so no node-def refresh is running and none is coming. REFRESH_JOIN_ABANDONED alone cannot
+ * say this — the coalescer returns it both for "stopped waiting on a run that is still
+ * going" and for "joinMs was already non-positive with an empty slot", and the refusal below
+ * must not claim a refresh is running in the second case. The coalescer is deliberately NOT
+ * changed to return this itself: graph_add_node reads REFRESH_JOIN_ABANDONED and its wording
+ * is out of scope here, so the distinction is made by THIS command's wrapper, from the same
+ * two facts the coalescer's decision is made from (the slot, and the bound), read BEFORE the
+ * call so the two can never disagree.
+ */
+export const COMBO_REFRESH_NEVER_RAN = Symbol("combo-refresh-never-ran");
+
+/**
+ * #1413/#1418 — the refusal for a stale-combo recovery that never revalidated the value.
  *
  * RECOVERABLE BY CONSTRUCTION, and worded to say so — the same shape as #1192's
- * addNodeRefreshBusyMessage. The in-flight refresh was NOT cancelled (the coalescer never
- * cancels work someone else started) and it is registering the very list this write needs,
- * so the retry this text asks for is the normal outcome, not a hope. What it must NOT say
- * is "not a valid option": the revalidation never completed, so this refusal cannot tell a
- * genuinely-invalid value from one the refresh would have accepted — and claiming the
- * former is how a retryable busy reads as a permanent rejection.
+ * addNodeRefreshBusyMessage. What it must NOT say is "not a valid option": the revalidation
+ * never completed, so this refusal cannot tell a genuinely-invalid value from one a refresh
+ * would have accepted — and claiming the former is how a retryable busy reads as a permanent
+ * rejection.
+ *
+ * `refreshStillRunning` is the panel's VERIFIED statement about the coalescer's slot, not a
+ * guess (#1418): TRUE means a run is occupying it and still registering the very list this
+ * write needs, so the retry joins work in progress. FALSE means the budget was spent before
+ * the recovery could start and NO refresh is running — the retry rests on what is true in
+ * that state: it re-enters the recovery with a fresh budget. Naming only the first state is
+ * the false claim #1409 had to correct in refresh_nodes' own verdict ("a detail naming only
+ * the first is flatly wrong on an uncontended big install").
  */
-function staleComboRefreshBusyMessage() {
+function staleComboRefreshRefusalMessage(refreshStillRunning) {
+  const state = refreshStillRunning
+    ? "the authoritative refresh that would have re-read the list — a node-def refresh " +
+      "started by a ComfyUI reconnect, a finished install, or another tool call — was still " +
+      "running when this command's time budget ran out waiting for it, so the revalidation " +
+      "did NOT complete. That refresh is still running and is registering exactly the list " +
+      "this write needs, so RETRY in a few seconds — this normally succeeds on the next " +
+      "attempt, joining the work already in progress."
+    : "the authoritative refresh that would have re-read the list never started: this " +
+      "command's time budget was already spent (on the startup schema seed and the " +
+      "authorization /object_info read) before the recovery could run. No node-def refresh " +
+      "is running and none is coming. RETRY re-enters the recovery with a fresh budget and " +
+      "normally succeeds once those reads answer faster — if this recurs, the schema read " +
+      "itself is the slow part.";
   return (
-    "the value is not in this combo's current option list, and the authoritative refresh " +
-    "that would have re-read the list — a node-def refresh started by a ComfyUI reconnect, " +
-    "a finished install, or another tool call — was still running when this command's time " +
-    "budget ran out waiting for it, so the revalidation did NOT complete. This refusal " +
-    "cannot tell a genuinely-invalid value from one the refresh would have accepted. " +
-    "NOTHING WAS WRITTEN and nothing was changed. That refresh is still running and is " +
-    "registering exactly the list this write needs, so RETRY in a few seconds — this " +
-    "normally succeeds on the next attempt. If it keeps happening, call panel_refresh_nodes " +
-    "once and wait for it to report, then retry the write."
+    "the value is not in this combo's current option list, and " +
+    state +
+    " This refusal cannot tell a genuinely-invalid value from one the refresh would have " +
+    "accepted. NOTHING WAS WRITTEN and nothing was changed. If it keeps happening, call " +
+    "panel_refresh_nodes once and wait for it to report, then retry the write."
   );
 }
 
@@ -837,7 +866,11 @@ export async function runSetWidget(
       // that runs out is reported back as a STRUCTURED TOKEN (REFRESH_JOIN_ABANDONED), not
       // a throw — the catch below is the best-effort channel and would swallow one. The
       // in-flight refresh is not cancelled by the abandonment; only THIS caller's wait ends.
-      let refreshJoinAbandoned = false;
+      // #1418 — COMBO_REFRESH_NEVER_RAN is the same abandonment with one fact flipped: the
+      // budget was spent before the recovery could begin, so NO refresh is running. The
+      // refusal below words the two states differently because the retry advice that is
+      // true for one ("join the work in progress") is false for the other.
+      let refreshAbandoned = null;
       try {
         // Reuse the /object_info payload already fetched for type authorization so a
         // combo miss does not round-trip /object_info a SECOND time (#458 P2). Key the
@@ -850,7 +883,9 @@ export async function runSetWidget(
             ? { [writeTargetWidgetName]: concreteWidgetName }
             : undefined;
         const refreshOutcome = await refreshCombos(freshDefs ?? undefined, resolvedTargetNode, authTarget?.type, comboNameMap);
-        refreshJoinAbandoned = refreshOutcome === REFRESH_JOIN_ABANDONED;
+        if (refreshOutcome === REFRESH_JOIN_ABANDONED || refreshOutcome === COMBO_REFRESH_NEVER_RAN) {
+          refreshAbandoned = refreshOutcome;
+        }
       } catch {
         /* refresh best-effort; fall through to re-raise the original rejection */
       }
@@ -865,8 +900,12 @@ export async function runSetWidget(
       // for a reason that is true. A PARTIAL first write is the one case that outranks
       // this wording: its own error reports a graph that could not be restored, and that
       // must propagate undiluted rather than be replaced by "nothing was written".
-      if (refreshJoinAbandoned) {
-        throw refusalFrame(err.partialWrite ? err : new Error(staleComboRefreshBusyMessage()));
+      if (refreshAbandoned) {
+        throw refusalFrame(
+          err.partialWrite
+            ? err
+            : new Error(staleComboRefreshRefusalMessage(refreshAbandoned === REFRESH_JOIN_ABANDONED)),
+        );
       }
       try {
         return withWarning({ set: write(), refreshed: true });


### PR DESCRIPTION
Closes #1418

Follow-up to #1416 (which fixed #1413). The command budget landed; this closes what the same pass left behind, in the issue's own numbering.

## 1. The refusal no longer asserts a refresh that is not running

`REFRESH_JOIN_ABANDONED` comes back in two states — "stopped waiting on a run that is still going" and "the budget was already spent with an empty slot, so the coalescer started NOTHING" — and #1416's refusal wording was true only of the first. The second arm was reachable with no concurrency at all: the seed wait (flat 8,000 ms) and the authorization oracle (flat 20,000 ms) composed past the 25,000 ms budget before the recovery was reached.

Both halves of the issue's suggested fix, since they are not exclusive:

- **The waits ahead of the recovery now draw from the budget.** `awaitObjectInfoHistorySeed(budget.bounded(OBJECT_INFO_SEED_WAIT_MS))` (exactly as `graph_add_node` caps its copy) and the oracle's `fetchWholeObjectInfo` gets `deadlineMs: budget.bounded(OBJECT_INFO_DEADLINE_MS)`, computed inside the loader so a joined read spends nothing. A timed-out oracle fails closed on the path it already had — inside the window now.
- **The refusal is worded per state, from verified facts.** The panel's `refreshCombos` wrapper reads the same two facts the coalescer's own decision is made from — the slot and the bound — *before* the call (so the two can never disagree and the read cannot race the run's cleanup). `joinMs <= 0` with an empty slot means the coalescer started nothing, and the wrapper translates that arm to a new `COMBO_REFRESH_NEVER_RAN` token; every other abandonment stays `REFRESH_JOIN_ABANDONED`. `set-widget.js` words the two apart: "still running, retry joins the work in progress" only when a run verifiably exists, and "never started, no refresh is running, retry re-enters with a fresh budget" when none does. The coalescer itself is deliberately untouched — `graph_add_node` reads `REFRESH_JOIN_ABANDONED` and is out of scope.

## 2. The #387 `/view` probe is bounded

It was the last network step in a 30 s-relayed command with no bound at all, reached after a *successful* refresh (the abandoned-join refusal fires before it, which is why #1413's `joinMs` never covered it). The fetch is now wrapped in `withTimeout(..., budget.bounded(), () => null)`: a timeout answers `false`, the same answer the probe already gives for every error and every doubt — so the bound can only ever refuse a value, never admit one, and #240 strictness is untouched.

## 3. The stale `graph_add_node` comment is corrected

It claimed `graph_set_widget`'s oracle "allows 10,000 ms" and that both paths were capped — never true (the oracle is `OBJECT_INFO_DEADLINE_MS`, 20,000 ms, uncapped until now). Corrected, with the note kept rather than deleted because reassurance-shaped claims have now concealed the next occurrence twice.

## 4. The #1413 audit, as a test

New `browser_tests/unit/relay-window-command-audit.test.mjs`: `graph_get_object_info` and `graph_remove_widget` each assert — scoped to the executor's own body — exactly one `await`, landing on the self-bounded `fetchWholeObjectInfo`, and no reach for `refreshComfyNodeDefs`. It goes red the day either grows a second wait, whether or not anyone rereads the note.

## Tests

- `set-widget-stale-combo-budget.test.mjs`: new lib-level test for the never-ran wording; new wiring tests driving the **shipped** `graph_set_widget` over the real coalescer/budget — the no-concurrency budget-spent arm (refusal says "never started / no refresh is running", zero runs started, inside the window) and a hung `/view` probe giving up at the budget. Source pins for the seed/oracle/probe caps are **scoped to the `graph_set_widget` body**, per the issue's own warning that an unscoped pin stays green on `graph_add_node`'s sibling call site.
- `set-widget-combo-fallback.test.mjs`: the shipped-`refreshCombos` harness gained the new free names and three tests pinning the token translation (never-ran, still-running, completed-untouched).
- Harnesses that rebuild the shipped handler/oracle (`rgthree-lora-row`, `object-info-snapshot`) gained the new free names; `setWidgetCommandBudgetDeps()` in `_panel-constants.mjs` now carries them, documented.

## Gates

- `npm ci` ✓
- `npm run test:unit` ✓
- `npm run typecheck` ✓
