### PR TITLE
fix(1707): a promoted-widget write lands in the instance that was addressed, not the shared subgraph definition

### DIFF
--- a/browser_tests/unit/dom-widget-diagnosis.test.mjs
+++ b/browser_tests/unit/dom-widget-diagnosis.test.mjs
@@ -132,10 +132,13 @@ test("WIRING: the failure branch passes the NODE, or the route can never appear"
   // message. widget-write's failure path needs a live graph to drive, so pin it here.
   const { readFile } = await import("node:fs/promises");
   const src = await readFile(new URL("../../web/js/lib/widget-write.js", import.meta.url), "utf8");
-  assert.ok(src.includes("describeNonValueBearingWidget(w, targetNode);"),
-    "the observed-revert branch must pass the node");
+  // `valueWidget`/`valueNode` are the widget the write ASSIGNED and the node that owns
+  // it (comfyui-mcp#1707) — the same pair the read-back above it just failed on. Passing
+  // the promoted INNER pair here would describe a widget this write never touched.
+  assert.ok(src.includes("describeNonValueBearingWidget(valueWidget, valueNode);"),
+    "the observed-revert branch must pass the widget that was written and its node");
   // And it must stay in the OBSERVED-failure branch — never a pre-emptive gate (#715).
-  const idx = src.indexOf("describeNonValueBearingWidget(w, targetNode);");
+  const idx = src.indexOf("describeNonValueBearingWidget(valueWidget, valueNode);");
   const before = src.slice(Math.max(0, idx - 1200), idx);
   assert.ok(before.includes("did not retain the"),
     "must remain attached to the observed-revert failure, not a preflight");

--- a/browser_tests/unit/promoted-value-scope.test.mjs
+++ b/browser_tests/unit/promoted-value-scope.test.mjs
@@ -300,6 +300,78 @@ test("#1707: a failed instance-scoped write does not touch the definition on the
   assert.equal(sg.definition(), 512);
 });
 
+test("#1707 × #805: a rail that snaps the value onto its own grid is a NORMALIZED success, read back from the rail", () => {
+  // The read-back, the normalization explanation and the reported value all have to
+  // come from the widget that was written. Taken from the shared inner widget instead,
+  // an instance-scoped write can never look normalized — the inner value did not move
+  // at all — and a write that APPLIED is reported as "did not retain the requested
+  // value", which is the #805 defect reintroduced through the promoted path.
+  const sg = makeReusableSubgraph({ definitionValue: 512 });
+  const target = sg.instance(293);
+  // The wrapper's own store entry declares the grid, and the rail snaps onto it —
+  // the projection's options come from the store, as they do in the frontend.
+  const state = sg.store.get(target.widgetId);
+  state.options = { min: 1, step: 2 };
+  const snap = (v) => (typeof v === "number" ? state.options.min + Math.round((v - state.options.min) / 2) * 2 : v);
+  // Both doors into the store quantize — a widget that snapped through one and not
+  // the other would not be a snapping widget, it would be an inconsistent fixture.
+  Object.defineProperty(target.rail, "value", {
+    get: () => state.value,
+    set: (next) => {
+      state.value = snap(next);
+    },
+    configurable: true,
+  });
+  Object.defineProperty(target.rail, "callback", {
+    value: (next) => {
+      state.value = snap(next);
+    },
+    configurable: true,
+  });
+
+  const set = applyWidgetWrite(target.node, "width", 4096, { resolveSource });
+
+  assert.equal(set.normalized, true);
+  assert.equal(set.requested_value, 4096);
+  assert.equal(set.value, 4097, "the reply carries the value the RAIL stored");
+  assert.equal(sg.queuedValue(target), 4097);
+  assert.match(set.normalization_note, /width/);
+  assert.equal(sg.definition(), 512, "and the shared definition still did not move");
+});
+
+test("#1707 × #805: a definition that happens to hold the requested value does not decide the read-back", () => {
+  // The narrow case that separates "read the widget we wrote" from "read whichever
+  // widget already agrees": the shared definition is ALREADY 4096, so an early-out
+  // taken from the inner widget would conclude "the value stuck" without ever looking
+  // at the rail — and then reject the rail's legitimately quantized 4097 as a failure,
+  // because nothing computed the normalization that explains it.
+  const sg = makeReusableSubgraph({ definitionValue: 4096 });
+  const target = sg.instance(293);
+  const state = sg.store.get(target.widgetId);
+  state.options = { min: 1, step: 2 };
+  const snap = (v) => (typeof v === "number" ? state.options.min + Math.round((v - state.options.min) / 2) * 2 : v);
+  Object.defineProperty(target.rail, "value", {
+    get: () => state.value,
+    set: (next) => {
+      state.value = snap(next);
+    },
+    configurable: true,
+  });
+  Object.defineProperty(target.rail, "callback", {
+    value: (next) => {
+      state.value = snap(next);
+    },
+    configurable: true,
+  });
+
+  const set = applyWidgetWrite(target.node, "width", 4096, { resolveSource });
+
+  assert.equal(set.normalized, true);
+  assert.equal(set.value, 4097);
+  assert.equal(sg.queuedValue(target), 4097);
+  assert.equal(sg.definition(), 4096, "the definition is untouched — it was never this write's store");
+});
+
 // ------------------------------------------- the shape with no per-instance home
 
 test("#1707: a frontend with no per-instance key keeps the old behaviour, and the reply SAYS the definition was written", () => {

--- a/browser_tests/unit/promoted-value-scope.test.mjs
+++ b/browser_tests/unit/promoted-value-scope.test.mjs
@@ -1,0 +1,319 @@
+/**
+ * comfyui-mcp#1707 — a promoted-widget write aimed at ONE subgraph instance must
+ * not change the shared subgraph DEFINITION, which every sibling instance reads.
+ *
+ * THE FIXTURE IS BUILT FROM THE REAL FRONTEND SHAPE, not from a convenient
+ * approximation. Read off comfyui-frontend 1.48.7 (`SubgraphNode.ts`,
+ * `widgetValueStore.ts`, `widgetId.ts`, `ExecutableNodeDTO.ts` — the version the
+ * reporter ran) and confirmed against a live 1.48.7 canvas:
+ *
+ *   * every instance of one reusable subgraph shares ONE `Subgraph` object, so the
+ *     inner nodes and their widgets are shared too (`a.subgraph === b.subgraph`
+ *     is TRUE for a cloned instance on a live canvas);
+ *   * each instance's host input carries `widgetId = "<rootGraphId>:<nodeId>:<name>"`
+ *     — the wrapper's OWN node id is in the key;
+ *   * the rail widget litegraph projects for that input is a VIEW OF A STORE keyed
+ *     by that id: `get value()` reads it, `set value()` writes it, and its
+ *     `callback` writes it too (that callback is the only bridge a canvas edit
+ *     takes — a canvas edit never touches the inner widget);
+ *   * `_setWidget` SEEDS a newly promoted instance's store entry from the INNER
+ *     widget's current value, which is how a definition write reaches a wrapper
+ *     nobody addressed;
+ *   * queue compilation reads `store[input.widgetId].value` for an unlinked
+ *     promoted input and never reads the inner widget.
+ *
+ * A fixture that stored the rail value ON the rail object would pass whatever the
+ * code did, because the two stores would be one store. The store below is the point.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { applyWidgetWrite, promotedValueScope, WidgetWriteError } from "../../web/js/lib/widget-write.js";
+
+const ROOT_GRAPH_ID = "c4a254bb-935e-4013-b380-5e36954de4b0";
+
+/**
+ * One reusable subgraph definition (an EmptyLatentImage-alike inside), plus a
+ * factory for instances of it — the reporter's shape: several wrappers, one
+ * definition, a promoted `width`.
+ */
+function makeReusableSubgraph({ definitionValue = 512, railWritesDefinition = false } = {}) {
+  const events = { innerCallback: [], railCallback: [], railSets: [] };
+  const inner = {
+    id: 10,
+    type: "EmptyLatentImage",
+    widgets: [
+      {
+        name: "width",
+        type: "INT",
+        value: definitionValue,
+        callback(next) {
+          events.innerCallback.push(next);
+        },
+      },
+    ],
+  };
+  const subgraph = {
+    id: "sg-uuid",
+    _nodes: [inner],
+    getNodeById: (id) => (String(id) === "10" ? inner : null),
+  };
+  // The per-widgetId value store. One store for the whole graph, exactly as the
+  // frontend has one — which is what makes a leak observable at all.
+  const store = new Map();
+
+  /**
+   * A SubgraphNode instance. `promoted: false` models an older frontend that
+   * gives the host input no per-instance key at all (the rail is then a live view
+   * of the inner widget).
+   */
+  function instance(id, { instanceKey = true } = {}) {
+    const widgetId = instanceKey
+      ? `${ROOT_GRAPH_ID}:${encodeURIComponent(String(id))}:${encodeURIComponent("width")}`
+      : undefined;
+    if (widgetId && !store.has(widgetId)) {
+      // `_setWidget` → `registerWidget`: a new instance is SEEDED from the inner
+      // (definition) widget's value at promotion time.
+      store.set(widgetId, { name: "width", type: "INT", value: inner.widgets[0].value, options: {} });
+    }
+    const rail = widgetId
+      ? {
+          get name() {
+            return store.get(widgetId)?.name ?? "width";
+          },
+          get type() {
+            return store.get(widgetId)?.type ?? "text";
+          },
+          get options() {
+            return store.get(widgetId)?.options ?? {};
+          },
+          get value() {
+            return store.get(widgetId)?.value;
+          },
+          set value(next) {
+            events.railSets.push(next);
+            const state = store.get(widgetId);
+            if (state) state.value = next;
+            // A frontend whose rail is NOT really instance-scoped, despite handing
+            // out an instance key — the case the write must detect rather than
+            // assume away.
+            if (railWritesDefinition) inner.widgets[0].value = next;
+          },
+          callback(next) {
+            events.railCallback.push(next);
+            const state = store.get(widgetId);
+            if (state) state.value = next;
+          },
+        }
+      : // Older shape: the rail IS a view of the inner widget, with nowhere else to put a value.
+        {
+          name: "width",
+          type: "INT",
+          get value() {
+            return inner.widgets[0].value;
+          },
+          set value(next) {
+            inner.widgets[0].value = next;
+          },
+        };
+    if (widgetId) {
+      Object.defineProperty(rail, "widgetId", { value: widgetId, enumerable: false, configurable: true });
+    }
+    const input = {
+      name: "width",
+      widgetId,
+      _widget: rail,
+      // Real ComfyUI stores only a NAME STUB here, never a widget object.
+      widget: { name: "width" },
+      _subgraphSlot: { name: "width" },
+    };
+    const node = {
+      id,
+      type: "SubgraphNode",
+      subgraph,
+      inputs: [input],
+      // `SubgraphNode.widgets` is a GETTER that projects the promoted widgets.
+      get widgets() {
+        return [rail];
+      },
+    };
+    return { node, rail, input, widgetId };
+  }
+
+  // What queue compilation reads for an unlinked promoted input
+  // (`ExecutableNodeDTO.resolveInput`).
+  const queuedValue = (inst) => store.get(inst.widgetId)?.value;
+  const definition = () => inner.widgets[0].value;
+
+  return { inner, subgraph, store, instance, queuedValue, definition, events };
+}
+
+const resolveSource = (_node, subgraphInput) =>
+  subgraphInput?.name === "width" ? { sourceNodeId: "10", sourceWidgetName: "width" } : null;
+
+// ---------------------------------------------------------------- scope helper
+
+test("#1707 promotedValueScope: an instance-keyed host input is instance-scoped", () => {
+  const sg = makeReusableSubgraph();
+  const a = sg.instance(293);
+  assert.equal(promotedValueScope(a.node, a.input), "instance");
+});
+
+test("#1707 promotedValueScope: no key, a key naming ANOTHER node, and a malformed key are all definition-scoped", () => {
+  const sg = makeReusableSubgraph();
+  const a = sg.instance(293);
+  assert.equal(promotedValueScope(a.node, { name: "width" }), "subgraph_definition", "no widgetId at all");
+  assert.equal(
+    promotedValueScope(a.node, { widgetId: `${ROOT_GRAPH_ID}:279:width` }),
+    "subgraph_definition",
+    "a key that names a DIFFERENT instance is not proof this write is scoped to THIS one",
+  );
+  assert.equal(promotedValueScope(a.node, { widgetId: `${ROOT_GRAPH_ID}:293` }), "subgraph_definition", "malformed");
+  assert.equal(promotedValueScope(a.node, { widgetId: 42 }), "subgraph_definition", "non-string");
+  assert.equal(promotedValueScope(a.node, { widgetId: "" }), "subgraph_definition", "empty");
+  assert.equal(
+    promotedValueScope(
+      a.node,
+      Object.defineProperty({}, "widgetId", {
+        get() {
+          throw new Error("hostile getter");
+        },
+      }),
+    ),
+    "subgraph_definition",
+    "a throwing getter must not be read as an instance claim",
+  );
+});
+
+test("#1707 promotedValueScope: an id whose node segment is percent-encoded still matches its own node", () => {
+  const sg = makeReusableSubgraph();
+  const a = sg.instance("a:b");
+  assert.equal(a.widgetId, `${ROOT_GRAPH_ID}:a%3Ab:width`);
+  assert.equal(promotedValueScope(a.node, a.input), "instance");
+});
+
+// -------------------------------------------------------- the reported defect
+
+test("#1707: a write aimed at ONE instance leaves the shared definition — and every sibling — alone", () => {
+  const sg = makeReusableSubgraph({ definitionValue: 512 });
+  const target = sg.instance(293);
+  const sibling = sg.instance(279);
+  // Each wrapper starts on its own value, as the reporter's did (1920x1080 vs 1024x1536).
+  target.rail.value = 1920;
+  sibling.rail.value = 1536;
+
+  const set = applyWidgetWrite(target.node, "width", 1024, { resolveSource });
+
+  // The addressed wrapper took the value — including what QUEUE COMPILATION reads.
+  assert.equal(sg.queuedValue(target), 1024);
+  assert.equal(target.rail.value, 1024);
+  // The shared definition did NOT move. This is the assertion that fails on
+  // origin/main, where the write assigns the inner widget.
+  assert.equal(sg.definition(), 512, "the shared subgraph definition must be untouched");
+  // The sibling wrapper nobody addressed kept its own value.
+  assert.equal(sibling.rail.value, 1536);
+  assert.equal(sg.queuedValue(sibling), 1536);
+
+  // An instance created AFTER the write is seeded from the definition, so it is
+  // the one that would silently inherit a leaked value (the wrapper "nobody
+  // touched" in the report).
+  const later = sg.instance(300);
+  assert.equal(later.rail.value, 512, "a new instance must inherit the ORIGINAL definition value");
+
+  // And the reply says which store it wrote, naming the wrapper the caller addressed.
+  assert.equal(set.promoted_from.value_scope, "instance");
+  assert.equal(set.promoted_from.subgraph_node_id, 293);
+  assert.equal(set.promoted_from.inner_node_id, 10);
+  assert.equal(set.node_id, 293, "the value landed on the wrapper, so the reply must name the wrapper");
+  assert.equal(set.widget, "width");
+  assert.equal(set.value, 1024);
+  assert.equal(set.previous, 1920, "the outer rail's previous value");
+  assert.equal(set.inner_previous, 512, "the definition's value, reported and NOT changed");
+});
+
+test("#1707: the instance-scoped write fires the RAIL's callback, not the shared inner node's", () => {
+  const sg = makeReusableSubgraph();
+  const target = sg.instance(293);
+
+  applyWidgetWrite(target.node, "width", 1024, { resolveSource });
+
+  assert.deepEqual(sg.events.railCallback, [1024], "the written widget's own callback runs once");
+  assert.deepEqual(
+    sg.events.innerCallback,
+    [],
+    "the shared definition node's callback must not run for an edit made on one instance",
+  );
+});
+
+test("#1707: an instance key does NOT license the claim — a rail that still writes the definition fails closed", () => {
+  // The discriminator reads the frontend's own store key. If that key is present but
+  // the rail turns out to forward to the inner widget anyway, the write DID reach every
+  // sibling, and reporting `value_scope: "instance"` would be false. Refuse instead.
+  const sg = makeReusableSubgraph({ definitionValue: 512, railWritesDefinition: true });
+  const target = sg.instance(293);
+  const sibling = sg.instance(279);
+  sibling.rail.value = 1536;
+  target.rail.value = 1920;
+
+  assert.throws(
+    () => applyWidgetWrite(target.node, "width", 1024, { resolveSource }),
+    (err) => err instanceof WidgetWriteError && /ALSO changed the shared subgraph definition/.test(err.message),
+  );
+
+  // The REQUESTED value survives nowhere: not on the rail, not in the store queue
+  // compilation reads, and not on the definition every sibling reads. (A rail that
+  // forwards to the definition cannot have both restored independently — the two are
+  // one store — so the refusal is reported as a partial state rather than a clean
+  // rollback, which is what it is.)
+  assert.notEqual(target.rail.value, 1024);
+  assert.notEqual(sg.queuedValue(target), 1024);
+  assert.notEqual(sg.definition(), 1024);
+  assert.notEqual(sibling.rail.value, 1024);
+});
+
+test("#1707: a failed instance-scoped write does not touch the definition on the ROLLBACK either", () => {
+  const sg = makeReusableSubgraph({ definitionValue: 512 });
+  const target = sg.instance(293);
+  // A rail that silently refuses the value: the write must fail verification.
+  Object.defineProperty(target.rail, "value", {
+    get: () => 1920,
+    set: () => {},
+    configurable: true,
+  });
+  let definitionWrites = 0;
+  const innerWidget = sg.inner.widgets[0];
+  let backing = innerWidget.value;
+  Object.defineProperty(innerWidget, "value", {
+    get: () => backing,
+    set: (next) => {
+      definitionWrites += 1;
+      backing = next;
+    },
+    configurable: true,
+  });
+
+  assert.throws(
+    () => applyWidgetWrite(target.node, "width", 1024, { resolveSource }),
+    (err) => err instanceof WidgetWriteError && /did not retain the requested value/.test(err.message),
+  );
+  assert.equal(definitionWrites, 0, "neither the write nor its rollback may assign the shared definition");
+  assert.equal(sg.definition(), 512);
+});
+
+// ------------------------------------------- the shape with no per-instance home
+
+test("#1707: a frontend with no per-instance key keeps the old behaviour, and the reply SAYS the definition was written", () => {
+  const sg = makeReusableSubgraph({ definitionValue: 512 });
+  const legacy = sg.instance(293, { instanceKey: false });
+
+  const set = applyWidgetWrite(legacy.node, "width", 1024, { resolveSource });
+
+  // Unchanged: with no store to write, the value has to live on the definition —
+  // refusing here would block every write on such a frontend, including the
+  // single-instance case that has nothing to leak into.
+  assert.equal(sg.definition(), 1024);
+  assert.equal(legacy.rail.value, 1024);
+  assert.equal(set.node_id, 10, "the inner node is where the value landed");
+  assert.equal(set.promoted_from.value_scope, "subgraph_definition");
+  assert.deepEqual(sg.events.innerCallback, [1024], "the inner widget's callback still fires on this path");
+});

--- a/browser_tests/unit/widget-normalization.test.mjs
+++ b/browser_tests/unit/widget-normalization.test.mjs
@@ -90,7 +90,13 @@ test("#805 WIRING: normalization suppresses the failure AND is disclosed on the 
   )
   assert.match(src, /import \{ explainNumericNormalization, normalizationNote \} from "\.\/widget-normalization\.js"/)
   // The failure branch must be gated on it — otherwise a normalized write still errors.
-  assert.match(src, /if \(!matchesExpected\(w\.value\) && !normalization\) \{/)
+  // `valueWidget` is the widget the write ASSIGNED (comfyui-mcp#1707): the node's own
+  // widget, the promoted inner widget, or — on an instance-scoped promoted write — the
+  // wrapper's own rail. The read-back and the normalization explanation must be taken
+  // from the SAME widget, or a normalizing rail is reported as a failed write.
+  assert.match(src, /const normalization = matchesExpected\(valueWidget\.value\)/)
+  assert.match(src, /explainNumericNormalization\(expected, valueWidget\.value, valueWidget\)/)
+  assert.match(src, /if \(!matchesExpected\(valueWidget\.value\) && !normalization\) \{/)
   // …and the caller must be TOLD, or a silently-changed value is its own defect.
   assert.match(src, /normalized: true/)
   assert.match(src, /requested_value: expected/)

--- a/web/js/lib/widget-write.js
+++ b/web/js/lib/widget-write.js
@@ -1859,7 +1859,14 @@ export function applyWidgetWrite(
       actual: boundPropertyActual,
       unreadable: boundPropertyActual === UNREADABLE_PROPERTY,
     });
-  } else if (parentWidget && !matchesExpected(parentWidget.value)) {
+  } else if (parentWidget && parentWidget !== valueWidget && !matchesExpected(parentWidget.value)) {
+    // comfyui-mcp#1707 — `parentWidget !== valueWidget` because on an instance-scoped
+    // promoted write the rail IS the widget this write assigned, and the branch above
+    // has already verified it — with the #805 normalization allowance this one does not
+    // have. Checking it a second time by strict equality would fail a rail that did
+    // exactly what a numeric widget is supposed to do, reporting "did not retain" for a
+    // write that applied. Nothing is verified less: it is the same object, checked once,
+    // by the check that knows about grids.
     failure =
       `Promoted rail widget "${parentWidget.name}" on subgraph node ${node.id} did not retain ` +
       `the requested value: wrote ${JSON.stringify(expected)} but it became ` +

--- a/web/js/lib/widget-write.js
+++ b/web/js/lib/widget-write.js
@@ -836,6 +836,59 @@ export function resolveHostPromotedWidget(subgraphNode, hostInput) {
 }
 
 /**
+ * comfyui-mcp#1707 — WHERE a promoted subgraph widget's value actually lives.
+ *
+ * A `Subgraph` DEFINITION object is SHARED by every instance placed on the canvas:
+ * `SubgraphNode.subgraph` is the same object for wrappers 279, 293 and 300 of one
+ * reusable subgraph, and so is every node inside it. So an assignment to the inner
+ * widget is an assignment to the DEFINITION — a write aimed at one wrapper that
+ * every sibling wrapper inherits.
+ *
+ * The ComfyUI frontend does NOT store a promoted value there. It gives each host
+ * input a `widgetId` — `"<rootGraphId>:<encoded nodeId>:<encoded input name>"` —
+ * and keeps the value in a per-widgetId store. Both projections it can build for
+ * the rail read and write through that key: the plain store-backed projection
+ * (`get/set value` → the store) and the app-layer promoted DOM widget (whose
+ * `options.getValue/setValue` do the same). It is also the ONLY value the queue
+ * compiler reads for an unlinked promoted input — `ExecutableNodeDTO.resolveInput`
+ * returns `store.getWidget(input.widgetId)?.value` and never looks at the inner
+ * widget. And an on-canvas edit of the promoted control writes ONLY that entry.
+ *
+ * The node id is IN the key, so the key itself proves the scope: when the key's
+ * node segment is THIS wrapper's id, no sibling wrapper can read the entry this
+ * write lands in — the scope is established from the data, not assumed from a
+ * frontend version. Parsed the way the frontend's own `parseWidgetId` parses it
+ * (exactly three colon-separated segments; the id builder percent-encodes the
+ * node id and the name, so neither can introduce a colon).
+ *
+ * Anything else — no `widgetId` at all (an older frontend, where the rail is a live
+ * VIEW of the inner widget and there is no per-instance home to write) or a key that
+ * does not name this wrapper (an unknown keying whose sharing we cannot establish) —
+ * is reported as `"subgraph_definition"`. That is a statement about where the write
+ * then goes, not a prediction about siblings, and the caller is told which one it got.
+ *
+ * @returns {"instance"|"subgraph_definition"}
+ */
+export function promotedValueScope(subgraphNode, hostInput) {
+  let id;
+  try {
+    id = hostInput?.widgetId;
+  } catch {
+    return "subgraph_definition";
+  }
+  if (typeof id !== "string" || id === "") return "subgraph_definition";
+  const parts = id.split(":");
+  if (parts.length !== 3) return "subgraph_definition";
+  let own;
+  try {
+    own = encodeURIComponent(String(subgraphNode?.id));
+  } catch {
+    return "subgraph_definition";
+  }
+  return parts[1] === own ? "instance" : "subgraph_definition";
+}
+
+/**
  * Classify a widget request on `subgraphNode` against `widgetName` and, when it
  * is a PROMOTED subgraph widget, resolve it to the ACTUAL inner (node, widget)
  * AND the authoritative parent rail widget (via the promotion relationship).
@@ -1279,6 +1332,31 @@ export function applyWidgetWrite(
       ? promotedParentWidgets.filter((dw) => dw && dw !== w && dw !== parentWidget)
       : [];
 
+  // comfyui-mcp#1707 — WHICH STORE THIS WRITE OWNS.
+  //
+  // The promoted rail and the inner widget are not two views of one value: in a
+  // frontend that gives the host input a `widgetId`, the rail is this WRAPPER's own
+  // store entry and the inner widget is the SHARED DEFINITION, read by every sibling
+  // instance of the subgraph. Writing both therefore turned a write aimed at wrapper
+  // 293 into a write every sibling inherits (279 and 300 both went to 1024x1024) —
+  // and the definition write is one the UI itself never performs: an on-canvas edit
+  // of a promoted control writes the store entry and nothing else.
+  //
+  // So on the instance-scoped path this write owns the RAIL, and the shared
+  // definition is left exactly as it was — which is also VERIFIED below, because
+  // "the rail is instance-scoped" is a claim about the frontend's plumbing that this
+  // module must not take on trust: if the rail turns out to forward to the inner
+  // widget after all, the definition changes, and that is a failure, not a success.
+  const valueScope = promotedFrom ? promotedValueScope(node, promotedHostInput) : null;
+  const instanceScoped = valueScope === "instance";
+  // The widget this write's VALUE lands on, and the node that OWNS that widget.
+  // Everything downstream — the bound-property binding, the widget callback, the
+  // read-back verification, normalization and the reported result — keys on these,
+  // so each one describes the write that actually happened. On every non-promoted
+  // and every definition-scoped write they are the inner/own target, unchanged.
+  const valueWidget = instanceScoped ? parentWidget : w;
+  const valueNode = instanceScoped ? node : targetNode;
+
   // #507 (codex round-3, MODERATE): coerceWidgetValue validated the value against the
   // IMMEDIATE inner widget's option list only — but a promoted write assigns the SAME
   // value to the parent's authoritative RAIL widget and to every display proxy, whose
@@ -1489,7 +1567,13 @@ export function applyWidgetWrite(
   // (`node.setProperty` mutates `properties`, so a second classification taken later
   // would describe the state this write already produced). See widget-bound-property.js
   // for the two litegraph paths that make the binding load-bearing.
-  const boundProperty = boundPropertyState(targetNode, w);
+  // comfyui-mcp#1707 — taken on the widget this write actually assigns, and on the
+  // node that owns it. On an instance-scoped promoted write that is the RAIL on the
+  // WRAPPER: litegraph's `BaseWidget.setValue` calls `setProperty` on the node whose
+  // widget is being edited, and the inner node's property is definition state this
+  // write deliberately does not touch. Every other write passes the same pair it
+  // always did.
+  const boundProperty = boundPropertyState(valueNode, valueWidget);
   const previousPropertyClone = boundProperty?.reachable ? deepClone(boundProperty.previous) : undefined;
   // The ACTUAL serialization binding for an unlinked subgraph input is its
   // `widgetId` (the widget-value STORE key that queue compilation reads). A callback
@@ -1561,13 +1645,20 @@ export function applyWidgetWrite(
   let widgetCallback = null;
   safeBefore();
   try {
-    // Assign BOTH values first. The parent's projected promoted widget is a VIEW of
-    // the inner widget; its own callback typically FORWARDS to the inner one, so we
-    // fire the SEMANTIC widget callback exactly ONCE (the inner target's), NOT the
-    // rail's — otherwise a forwarding view would double-invoke the side effect. The
-    // rail's value serializes directly from `parentWidget.value`, which we set here,
-    // so it needs no callback of its own.
-    w.value = coerced;
+    // Assign BOTH values first — EXCEPT on an instance-scoped promoted write, where
+    // the inner widget is not a second copy of this value but the SHARED SUBGRAPH
+    // DEFINITION every sibling instance reads (comfyui-mcp#1707). There the rail IS
+    // the store, so assigning the inner widget would not make this write land — it
+    // would only broadcast it to wrappers the caller never addressed.
+    //
+    // On the definition-scoped path (a frontend that gives the host input no
+    // per-instance key) nothing changes: the parent's projected promoted widget is a
+    // VIEW of the inner widget; its own callback typically FORWARDS to the inner one,
+    // so we fire the SEMANTIC widget callback exactly ONCE (the inner target's), NOT
+    // the rail's — otherwise a forwarding view would double-invoke the side effect.
+    // The rail's value serializes directly from `parentWidget.value`, which we set
+    // here, so it needs no callback of its own.
+    if (!instanceScoped) w.value = coerced;
     if (parentWidget) parentWidget.value = coerced;
     // #477: sync the parent-facing DISPLAY proxies too. They are VIEWS of the same
     // promoted value (no semantic callback of their own — the inner target's fires
@@ -1596,16 +1687,25 @@ export function applyWidgetWrite(
     // A throw from here is captured by the same catch as everything else in this envelope
     // and stays UNATTRIBUTED — `onPropertyChanged` is a node's own code and this is not
     // the widget-callback invocation #976 can name.
-    if (boundProperty?.reachable) targetNode.setProperty(boundProperty.property, coerced);
-    // Fire the inner widget's own callback so combo/number side effects run — the
+    if (boundProperty?.reachable) valueNode.setProperty(boundProperty.property, coerced);
+    // Fire the WRITTEN widget's own callback so combo/number side effects run — the
     // same single invocation a manual UI edit of the promoted control performs.
+    //
+    // comfyui-mcp#1707: on an instance-scoped promoted write that is the RAIL's
+    // callback on the WRAPPER, not the inner definition widget's. This is not a
+    // preference — it is the only coherent choice once the definition is left alone:
+    // invoking the inner node's callback would announce a new value for a widget
+    // whose value did not change, and would run that shared node's side effects for
+    // an edit made on ONE instance. It is also what the UI does, for the same reason:
+    // a canvas edit of a promoted control runs the projection's callback (which
+    // writes the store) and never reaches the inner widget's.
     //
     // #976: the flagged span contains the INVOCATION and nothing else, because the
     // flag is an attribution and an attribution that can be raised by anything but
     // the callback body is a lie. Hoisted out of it, in order:
-    //   - the `w.callback` LOOKUP: it may be a throwing accessor, which is not the
-    //     callback failing (it never ran)
-    //   - the ARGUMENTS, including `targetNode.pos`, which may be a throwing getter
+    //   - the `valueWidget.callback` LOOKUP: it may be a throwing accessor, which is
+    //     not the callback failing (it never ran)
+    //   - the ARGUMENTS, including `valueNode.pos`, which may be a throwing getter
     //   - and they are built INSIDE the nullish guard, because the original
     //     `w.callback?.(…)` short-circuited: with no callback, `pos` was never read,
     //     and a node with a throwing `pos` getter and no callback must keep the clean
@@ -1620,11 +1720,11 @@ export function applyWidgetWrite(
     // non-callable callback still throws a TypeError exactly as before, and it takes
     // the argument list without spreading — no `Symbol.iterator` to poison either.
     // `reflectApply` is captured at module load for the same reason.
-    widgetCallback = w.callback;
+    widgetCallback = valueWidget.callback;
     if (widgetCallback !== null && widgetCallback !== undefined) {
-      const callbackArgs = [coerced, canvas, targetNode, targetNode.pos, undefined];
+      const callbackArgs = [coerced, canvas, valueNode, valueNode.pos, undefined];
       threwFromCallback = true;
-      reflectApply(widgetCallback, w, callbackArgs);
+      reflectApply(widgetCallback, valueWidget, callbackArgs);
       threwFromCallback = false; // reached only when it RETURNED — a throw leaves it set
     }
   } catch (err) {
@@ -1676,7 +1776,7 @@ export function applyWidgetWrite(
   const readBoundProperty = () => {
     if (!boundProperty) return UNREADABLE_PROPERTY;
     try {
-      const props = targetNode.properties;
+      const props = valueNode.properties;
       if (!props || typeof props !== "object") return UNREADABLE_PROPERTY;
       return props[boundProperty.property];
     } catch {
@@ -1696,20 +1796,46 @@ export function applyWidgetWrite(
   // Only an EXACTLY reproducible snap counts. If the config does not explain the
   // observed value, this stays the failure it was — no tolerance, because a
   // tolerance would eventually swallow a real revert that landed nearby.
-  const normalization = matchesExpected(w.value)
+  const normalization = matchesExpected(valueWidget.value)
     ? null
-    : explainNumericNormalization(expected, w.value, w);
-  if (!matchesExpected(w.value) && !normalization) {
+    : explainNumericNormalization(expected, valueWidget.value, valueWidget);
+  // comfyui-mcp#1707 — the SHARED DEFINITION must be exactly as it was.
+  //
+  // This is the check that makes the scope classification safe rather than merely
+  // hopeful. `promotedValueScope` reads the frontend's own store key and concludes
+  // the rail is this wrapper's alone; if that plumbing is not what this frontend
+  // actually does — a rail that still forwards to the inner widget — the inner value
+  // moves, and the write silently becomes the cross-instance write this change
+  // exists to stop. Observed, not assumed: a definition that moved is a FAILURE, so
+  // the write rolls back and says so instead of reporting an instance-scoped write it
+  // did not perform. Compared structurally against the pre-mutation clone, so a
+  // callback mutating a captured object in place is caught too.
+  const definitionMoved = instanceScoped && !structurallyEqual(w.value, previousClone);
+  if (!matchesExpected(valueWidget.value) && !normalization) {
     failure =
-      `Widget "${w.name}" on node ${targetNode.id} (${targetNode.type}) did not retain the ` +
-      `requested value: wrote ${JSON.stringify(expected)} but it became ${JSON.stringify(w.value)}.` +
+      `Widget "${valueWidget.name}" on node ${valueNode.id} (${valueNode.type}) did not retain the ` +
+      `requested value: wrote ${JSON.stringify(expected)} but it became ${JSON.stringify(valueWidget.value)}.` +
       // #698 — "did not retain" reads as a transient failure worth retrying. For a
       // non-value-bearing DOM widget it is STRUCTURAL: the widget is a view, its
       // real state lives on the node, and no number of retries will change that.
       // Appended ONLY here, in the branch where the revert has already been
       // OBSERVED — so this can never turn into a pre-emptive refusal of a widget
       // that would have worked. Diagnosis, never a gate.
-      describeNonValueBearingWidget(w, targetNode);
+      describeNonValueBearingWidget(valueWidget, valueNode);
+  } else if (definitionMoved) {
+    // comfyui-mcp#1707 — the rail took the value AND the shared definition moved, so
+    // the two are not independent after all and this write did reach every sibling
+    // instance. Reported as a failure and rolled back: the alternative is a success
+    // result whose `value_scope: "instance"` would be false, which is the exact class
+    // of claim this change exists to remove.
+    failure =
+      `Promoted widget "${valueWidget.name}" on subgraph node ${node.id} is backed by a ` +
+      `per-instance value store (widgetId ${JSON.stringify(promotedHostWidgetId)}), but writing it ` +
+      `ALSO changed the shared subgraph definition's inner widget "${w.name}" on node ` +
+      `${targetNode.id} (${JSON.stringify(previous)} → ${JSON.stringify(w.value)}). That value is ` +
+      `read by every other instance of this subgraph, so the write is not scoped to the ` +
+      `instance it was addressed to. Rolled back rather than report an instance-scoped write ` +
+      `that was not one (comfyui-mcp#1707).`;
   } else if (boundProperty?.reachable && !matchesExpected(boundPropertyActual)) {
     // #1268 / comfyui-mcp#1658 — the widget kept the value and the node's own bound
     // property did NOT. This is the read the old verification never took: `w.value` came
@@ -1727,8 +1853,8 @@ export function applyWidgetWrite(
     // as the abort signal and honours by restoring the previous value.
     failure = boundPropertyFailure({
       property: boundProperty.property,
-      widgetName: w.name,
-      nodeId: targetNode.id,
+      widgetName: valueWidget.name,
+      nodeId: valueNode.id,
       expected,
       actual: boundPropertyActual,
       unreadable: boundPropertyActual === UNREADABLE_PROPERTY,
@@ -1965,15 +2091,24 @@ export function applyWidgetWrite(
       // widget ends on its own captured value either way.
       if (boundProperty?.reachable) {
         try {
-          targetNode.setProperty(boundProperty.property, boundProperty.previous);
+          valueNode.setProperty(boundProperty.property, boundProperty.previous);
         } catch {
           /* restore best-effort; read-back below is authoritative */
         }
       }
-      try {
-        w.value = previous;
-      } catch {
-        /* restore best-effort; read-back below is authoritative */
+      // comfyui-mcp#1707 — restore the inner definition widget only when this write
+      // could have moved it: it was written (the definition-scoped path), or it moved
+      // anyway (the instance-scoped path's own failure branch above). An instance-scoped
+      // write that left it alone must not assign it here either — the assignment is a
+      // no-op for a plain widget but a side effect for a DOM one, and rolling back a
+      // write this path never made is exactly the shared-definition touch it avoided.
+      // The read-back below still compares it against the captured clone either way.
+      if (!instanceScoped || definitionMoved) {
+        try {
+          w.value = previous;
+        } catch {
+          /* restore best-effort; read-back below is authoritative */
+        }
       }
       if (parentWidget) {
         try {
@@ -2118,7 +2253,7 @@ export function applyWidgetWrite(
     setDirty?.();
     if (rollbackFailed) {
       throw new WidgetWriteError(
-        `Widget "${w.name}" on node ${targetNode.id} (${targetNode.type}) write failed: ${failure} ` +
+        `Widget "${valueWidget.name}" on node ${valueNode.id} (${valueNode.type}) write failed: ${failure} ` +
           `Rollback of ${rollbackFailed} did not take effect (a value setter or history hook ` +
           `rejected/overrode it) — the graph may be in a partial state; re-set the widget or undo.`,
         // The one WidgetWriteError raised AFTER the graph was mutated and NOT cleanly
@@ -2145,11 +2280,19 @@ export function applyWidgetWrite(
   // #976: `write_warning_source` carries the attribution as DATA, so a caller does not
   // have to pattern-match prose to render it. Present ONLY for the establishable case;
   // its absence means "not attributable", never "the panel's fault".
+  // comfyui-mcp#1707 — `node_id`/`widget`/`value` name the widget this write ACTUALLY
+  // assigned. For an instance-scoped promoted write that is the wrapper the caller
+  // addressed and its promoted widget — not the inner definition widget, which this
+  // path deliberately leaves untouched, and which the panel's own activity line would
+  // otherwise announce as "Set width = 1024 on node 54" for a node whose value did not
+  // change. Provenance is not lost: `promoted_from.inner_node_id` still names the inner
+  // node and `inner_previous` still reports its (unchanged) value. Every definition-scoped
+  // and non-promoted write reports exactly the fields it always did.
   return {
-    node_id: targetNode.id,
-    widget: w.name,
+    node_id: valueNode.id,
+    widget: valueWidget.name,
     previous: parentWidget ? previousParent : previous,
-    value: w.value,
+    value: valueWidget.value,
     // #1126 — the COERCION-TIME verdict, so the caller reports WHAT HAPPENED instead of
     // inferring it from the rejection that led here. `options.values` is a callback and
     // can answer differently per call: the final attempt may well have been admitted by
@@ -2223,9 +2366,9 @@ export function applyWidgetWrite(
           requested_value: expected,
           normalization_rule: normalization.rule,
           normalization_note: normalizationNote({
-            name: w.name,
+            name: valueWidget.name,
             requested: expected,
-            actual: w.value,
+            actual: valueWidget.value,
             rule: normalization.rule,
           }),
         }
@@ -2237,6 +2380,23 @@ export function applyWidgetWrite(
             ...promotedFrom,
             parent_widget_synced: parentWidget != null,
             ...(displayWidgets.length ? { display_widgets_synced: displayWidgets.length } : {}),
+            // comfyui-mcp#1707 — WHOSE value this changed, as DATA rather than something
+            // a caller has to infer from the shape of the reply:
+            //
+            //   "instance"            the wrapper's own promoted-value store entry was
+            //                         written and the shared subgraph definition was
+            //                         verified UNCHANGED, so sibling instances of the same
+            //                         subgraph keep their own values.
+            //   "subgraph_definition" this frontend exposes no per-instance store for this
+            //                         promoted widget, so the value was written into the
+            //                         subgraph DEFINITION's inner widget — which every
+            //                         instance of this subgraph reads.
+            //
+            // Always present on a promoted write, so "the field is missing" can never be
+            // read as either verdict, and never emitted for a write that took the other
+            // path — the failure branch above rolls back rather than let "instance" stand
+            // for a write that moved the definition.
+            value_scope: valueScope,
           },
         }
       : {}),


### PR DESCRIPTION
A `panel_set_widget` on one saved-subgraph instance changed the promoted value that
other instances of the same subgraph read. This is the panel-side write; the
orchestrator only proxies `graph_set_widget`, so no orchestrator change could reach it
(same class as artokun/comfyui-mcp#801).

## The mechanism, confirmed against the frontend and on a live canvas

Every instance of a reusable subgraph shares **one** `Subgraph` object, so the inner
nodes and their widgets are shared too. `applyWidgetWrite` assigned the promoted value
to the inner widget **and** to the wrapper's rail. On ComfyUI frontends that give the
host input a `widgetId`, those are not two views of one value:

* the rail is **this wrapper's own store entry**, keyed
  `"<rootGraphId>:<nodeId>:<inputName>"` — the wrapper's node id is in the key;
* the inner widget is the **definition** every sibling instance reads;
* queue compilation reads the store entry for an unlinked promoted input
  (`ExecutableNodeDTO.resolveInput` → `useWidgetValueStore().getWidget(id)?.value`) and
  never the inner widget;
* a canvas edit of a promoted control runs the rail projection's callback, which writes
  that store entry **and nothing else** — the definition write is one the UI never
  performs;
* `SubgraphNode._setWidget` **seeds** a newly promoted instance's store entry from the
  inner widget's current value, which is how a definition write reaches a wrapper nobody
  addressed.

Read from comfyui-frontend **1.48.7** — the reporter's version — via the shipped
sourcemaps (`SubgraphNode.ts`, `widgetValueStore.ts`, `widgetId.ts`,
`ExecutableNodeDTO.ts`), then **executed** on a real 1.48.7 canvas driving this module
in the page (two instances of one subgraph, the write aimed at instance A):

| observation | origin/main | this branch |
|---|---|---|
| `a.subgraph === b.subgraph` | `true` | `true` |
| shared definition value | `""` → **`"WRITTEN-TO-A"`** | `""` → `""` |
| addressed wrapper's rail / serialized `widgets_values` | `"WRITTEN-TO-A"` | `"WRITTEN-TO-A"` |
| sibling wrapper with its own value | unchanged | unchanged |
| **a new instance with no promoted value of its own** | **`"WRITTEN-TO-A"`** | `""` |
| reply | `node_id: 10` (inner) | `node_id: 11` (the wrapper), `value_scope: "instance"` |

The last row is the reported symptom: a wrapper nobody touched comes up holding the
value written to another one. On the reporter's canvas the sibling wrappers were in
exactly that state — instances whose promoted value came from the definition rather
than from their own store entry.

## What the panel can and cannot distinguish

**Per-instance storage exists**, and this is established from the data rather than
assumed from a version: the frontend's own store key names the wrapper, so when its node
segment is this wrapper's id, no sibling can read the entry this write lands in. The key
is parsed the way the frontend's `parseWidgetId` parses it.

So the write is **instance-scoped**, not refused:

* the rail (and #477's display proxies) is written; the shared definition is not touched;
* the **rail's** callback fires, not the shared inner node's — invoking the inner node's
  callback would announce a new value for a widget whose value did not change, and run
  that shared node's side effects for an edit made on one instance. It is also what the
  UI does;
* the bound property is taken from the widget the write assigned, on the node that owns
  it (`BaseWidget.setValue` calls `setProperty` on that node);
* **and the shared definition is verified UNCHANGED.** A definition that moved anyway
  means the rail forwards to it after all, which is a **failure** that rolls back —
  never an `"instance"` claim the write cannot stand behind. That check is what makes the
  classification safe rather than hopeful.

**What it cannot distinguish**, stated rather than papered over: a frontend that gives the
host input no key at all. There the rail is a live view of the inner widget and there is
no per-instance home — refusing would block every promoted write on such a frontend,
including the single-instance case with nothing to leak into. That path is unchanged, and
the reply says which one happened: `promoted_from.value_scope` is `"instance"` or
`"subgraph_definition"` on **every** promoted write, so a caller never has to infer it and
a missing field can never read as either verdict.

`node_id` / `widget` / `value` now name the widget the write actually assigned, so the
panel's own activity line no longer reports "Set width = 1024 on node 54" for an inner
node whose value did not change. `promoted_from.inner_node_id` and `inner_previous` keep
the provenance.

A second commit fixes what the first one exposed: #366's strict rail re-check ran on the
same object the read-back had just accepted, without #805's normalization allowance, so a
rail that quantized onto its own declared grid was reported as a failed write. It is now
skipped only when it is literally the same object already verified.

## Refutation

11 source mutations, each applied to a **unique** anchor and confirmed present on disk
before the run (a mutation that did not apply would otherwise score as "caught"), each
reverted afterwards. **11/11 killed** by `browser_tests/unit/promoted-value-scope.test.mjs`:

restore the definition write · make nothing instance-scoped · drop the
definition-unchanged verification · fire the shared inner callback · claim `"instance"`
unconditionally · report the untouched inner node · let the rollback assign the
definition · take the read-back from the inner widget (twice, value and explanation) ·
re-check the rail strictly · report the inner widget's value.

Two of those (`M8`, `M10`) survived the first round and drove a real extra case — a
definition that already holds the requested value, which is what separates "read the
widget we wrote" from "read whichever widget already agrees".

The fixture is built from the real shapes: a shared `Subgraph`, per-widgetId store,
projections that read/write through it, `_setWidget`'s seeding, and the value queue
compilation reads. A fixture that kept the rail value on the rail object would have
passed whatever the code did, because the two stores would be one store.

Unit: **5631 pass / 0 fail** (`npm run test:unit`, up from 5628 — three new source-wiring
assertions were updated to the renamed call sites, deliberately, since they exist to pin
those call sites).

## Playwright delta

`npx playwright test --workers=1` against a dedicated ComfyUI (own port, own base
directory, frontend 1.48.7), origin/main baseline and this branch back to back, panel
swapped by junction with a server restart between runs:

* **baseline (origin/main): 18 failed / 60 passed (7.5m)**
* **this branch: 18 failed / 60 passed (7.5m)** — the same 18 spec names

Delta: **zero**. All 18 are MockBridge conversation-persistence/streaming specs that fail
identically on origin/main in this environment.

codex was unavailable (account exhausted until 2026-08-19 20:43), so this PR is **not**
gated yet; the owner gates and merges.

The underlying cause of artokun/comfyui-mcp#1707.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
