### PR TITLE
fix(1014): an open reply reports one identity observation, not two

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+### Fixed
+- `panel_open_workflow` reports the fence uuid from the same active-workflow observation as the binding fields beside it, instead of a second live read that could disagree (#1014)
+
 ## [0.15.8] - 2026-08-19
 
 ### Fixed

--- a/browser_tests/unit/open-outcome.test.mjs
+++ b/browser_tests/unit/open-outcome.test.mjs
@@ -983,6 +983,16 @@ test("#716 wiring: post-open and active workflow responses carry the live instan
     "the binding report must use the shared snapshot, not read the active workflow again",
   );
   assert.match(open, /activeWorkflowUuid \? \{ workflow_uuid: activeWorkflowUuid \} : \{\}/);
+  // #1014 — the callee must CONSUME that snapshot. The call-site match above is
+  // not enough: a helper that re-reads the live binding discards the argument
+  // and the suite still goes green. Code-only so a comment cannot fake it.
+  const helperCode = stripComments(namedFunctionSource(src, "activeWorkflowUuidForOpenReply") || "");
+  assert.match(helperCode, /\bactiveSnapshot\b/, "the helper must read the snapshot it is passed");
+  assert.doesNotMatch(
+    helperCode,
+    /activeWorkflowRef\s*\(/,
+    "the helper must not take a second live read of the active workflow",
+  );
 });
 
 test("#716 P1: service rebind during workflow_open omits the former target UUID", () => {
@@ -1017,7 +1027,11 @@ test("#716 P1: service rebind during workflow_open omits the former target UUID"
     savedWorkflowHandle,
   );
 
-  assert.equal(replyUuid(openedTarget), "11111111-1111-4111-8111-111111111111", "the normal completed open reports its actual active tab");
+  assert.equal(
+    replyUuid(openedTarget, openedTarget),
+    "11111111-1111-4111-8111-111111111111",
+    "the normal completed open reports its actual active tab",
+  );
   // workflow_open has retained its old local `s`, but a reconnect/rebind has
   // replaced the service before the final reply. The old service could still
   // report A; the actual binding now says B. Returning target.uuid here would
@@ -1025,8 +1039,73 @@ test("#716 P1: service rebind during workflow_open omits the former target UUID"
   const staleService = currentService;
   currentService = { activeWorkflow: otherActive };
   assert.equal(staleService.activeWorkflow, openedTarget, "the pre-await service still looks like the opened target");
-  assert.equal(replyUuid(openedTarget), null, "the re-bound live service omits the stale reply UUID and leaves the MCP fence unchanged");
-  assert.equal(replyUuid(otherActive), "22222222-2222-4222-8222-222222222222", "the same helper still reports the actual active tab");
+  assert.equal(
+    replyUuid(openedTarget, otherActive),
+    null,
+    "the re-bound live service omits the stale reply UUID and leaves the MCP fence unchanged",
+  );
+  assert.equal(
+    replyUuid(otherActive, otherActive),
+    "22222222-2222-4222-8222-222222222222",
+    "the same helper still reports the actual active tab",
+  );
+});
+
+test("#1014: open-reply uuid is decided against the shared snapshot, not a second live read", () => {
+  // The park on #1014 measured that `activeWorkflowUuidForOpenReply` declared
+  // `activeSnapshot` and then re-read the live binding. The call-site wiring
+  // test could only see that the snapshot was PASSED; it could not see that
+  // the callee discarded it. A live re-read after any await would pair a uuid
+  // decided against one observation with binding fields decided against another.
+  const src = readFileSync(PANEL_JS, "utf8");
+  const pathSource = namedFunctionSource(src, "savedWorkflowPath");
+  const canonicalUuidSource = namedFunctionSource(src, "isCanonicalWorkflowInstanceUuid");
+  const identitySource = namedFunctionSource(src, "establishedWorkflowReplyIdentity");
+  const helperSource = namedFunctionSource(src, "activeWorkflowUuidForOpenReply");
+  assert.ok(pathSource && canonicalUuidSource && identitySource && helperSource, "the reply identity check must live in the shipped panel source");
+
+  const openedTarget = { isPersisted: true, isTemporary: false, path: "workflows/a.json" };
+  const otherActive = { isPersisted: true, isTemporary: false, path: "workflows/b.json" };
+  const workflowUuids = new WeakMap([
+    [openedTarget, "11111111-1111-4111-8111-111111111111"],
+    [otherActive, "22222222-2222-4222-8222-222222222222"],
+  ]);
+  let liveReads = 0;
+  let currentService = { activeWorkflow: otherActive };
+  const replyUuid = new Function(
+    "activeWorkflowRef",
+    "workflowObjectUuid",
+    "savedWorkflowHandle",
+    `${pathSource}; ${canonicalUuidSource}; ${identitySource}; ${helperSource}; return activeWorkflowUuidForOpenReply;`,
+  )(
+    () => {
+      liveReads += 1;
+      return currentService.activeWorkflow;
+    },
+    (wf) => workflowUuids.get(wf),
+    savedWorkflowHandle,
+  );
+
+  // Snapshot says A (the opened target). A live re-read would see B and omit.
+  // Using the snapshot keeps the uuid aligned with the binding fields the
+  // caller derived from the same observation.
+  assert.equal(
+    replyUuid(openedTarget, openedTarget),
+    "11111111-1111-4111-8111-111111111111",
+    "a matching snapshot publishes even when a later live read would see a different tab",
+  );
+  // Snapshot says B, target is A. A live re-read of A would publish A's uuid
+  // and contradict the binding report that observed B.
+  currentService = { activeWorkflow: openedTarget };
+  assert.equal(
+    replyUuid(openedTarget, otherActive),
+    null,
+    "a mismatched snapshot omits even when a later live read would see the target",
+  );
+  // No snapshot at all — fail closed. The discarded-argument helper used to
+  // succeed here by re-reading.
+  assert.equal(replyUuid(openedTarget), null, "a missing snapshot omits rather than guessing from a second live read");
+  assert.equal(liveReads, 0, "the helper must not consult the live binding at all");
 });
 
 test("#716 P1: service rebind during workflow_list reports only the current active UUID", () => {
@@ -1093,7 +1172,7 @@ test("#716 P1: a malformed truthy active binding cannot mint reply identity", ()
   // Execute the actual shipped reply helper against a truthy but malformed
   // binding. It must be an observation only: no tmp routing id and no UUID can
   // be initialized while deciding whether to publish the response field.
-  assert.equal(replyUuid(malformedActive), null);
+  assert.equal(replyUuid(malformedActive, malformedActive), null);
   assert.equal(workflowUuids.has(malformedActive), false, "must not mint an ephemeral workflow UUID");
 });
 
@@ -1146,7 +1225,7 @@ test("#760: an unsaved canvas with an ESTABLISHED uuid can refresh the fence", (
   );
 
   // The FENCE uuid is published — the canonical live-object value, not the handle.
-  assert.equal(replyUuid(temporaryActive), "33333333-3333-4333-8333-333333333333");
+  assert.equal(replyUuid(temporaryActive, temporaryActive), "33333333-3333-4333-8333-333333333333");
 });
 
 test("#760: an unsaved canvas with NO established uuid still publishes nothing (#716 holds)", () => {
@@ -1176,7 +1255,7 @@ test("#760: an unsaved canvas with NO established uuid still publishes nothing (
     },
   );
 
-  assert.equal(replyUuid(unestablished), null);
+  assert.equal(replyUuid(unestablished, unestablished), null);
   // …and it bailed BEFORE reaching the handle, so nothing was minted on the way.
   assert.equal(tabIdCalls, 0, "an unestablished object must not even ask for a routing handle");
 });
@@ -1202,7 +1281,7 @@ test("#760: a non-canonical uuid on an unsaved canvas is still refused", () => {
     (wf) => `tmp:${String(!!wf)}`,
   );
 
-  assert.equal(replyUuid(temporaryActive), null);
+  assert.equal(replyUuid(temporaryActive, temporaryActive), null);
 });
 
 test("#716 P1: existing mapped UUIDs still omit when noncanonical", () => {
@@ -1236,6 +1315,6 @@ test("#716 P1: existing mapped UUIDs still omit when noncanonical", () => {
 
   for (const workflow of [invalidVersion, invalidVariant, uppercase]) {
     active = workflow;
-    assert.equal(replyUuid(workflow), null, `mapped ${workflow.path} must not publish a noncanonical UUID`);
+    assert.equal(replyUuid(workflow, workflow), null, `mapped ${workflow.path} must not publish a noncanonical UUID`);
   }
 });

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -4041,10 +4041,14 @@ function establishedWorkflowReplyIdentity(wf) {
 function activeWorkflowUuidForOpenReply(target, activeSnapshot) {
   // Do not accept a workflow-service reference captured before workflow_open's
   // awaits: a reconnect can replace/rebind that service while the old instance
-  // still reports `target` as active. Read the panel's CURRENT binding at reply
-  // emission, then require object and routing identity to agree.
-  const active = activeWorkflowRef();
-  if (!target || active !== target) return null;
+  // still reports `target` as active. The caller takes ONE observation of the
+  // live active workflow at reply emission and this helper MUST use that same
+  // object. Re-reading the live binding here would pair a uuid decided against a
+  // later observation with binding fields decided against the snapshot — the
+  // internally contradictory diagnostics #887/#716 exist to prevent. Omit rather
+  // than guess when the snapshot is missing (#1014).
+  const active = activeSnapshot;
+  if (!target || !active || active !== target) return null;
   const activeIdentity = establishedWorkflowReplyIdentity(active);
   const targetIdentity = establishedWorkflowReplyIdentity(target);
   if (!activeIdentity || !targetIdentity || activeIdentity.routingKey !== targetIdentity.routingKey) return null;


### PR DESCRIPTION
## What the user now observes

`panel_open_workflow`'s reply reports the fence uuid from the **same** active-workflow observation as the binding fields beside it. A second live read can no longer disagree with `active_matches_target` / `active_routing_key`.

## Why this is the slice, and what it is not

#1014's **user-visible mutation wedge** (reconnect replaces the ComfyWorkflow object → every mutating command refused for `no trusted identity`) is already closed on current main (0.15.8+): hello advertises `workflowStableUuid()`, a reconnect successor inherits via `shouldForkEmbeddedUuidForLiveOwner`, and the 600ms poll re-hellos on identity drift (#1209/#1279). Re-checked against origin/main; that still holds.

The **title's design ask** — a per-load sanitizer marker that would make adoption of a persisted tag sound — remains unbuilt. The 2026-08-11 hole has not moved: mark every load and delete-A / save-B-at-A's-path still adopts A; mark only minting loads and a reconnect restore is unmarked. Building that is still a design pass, not this PR.

What *was* shippable is the leftover the 2026-08-19 park handed off: `activeWorkflowUuidForOpenReply(target, activeSnapshot)` declared `activeSnapshot` and never read it. The `#716 wiring` test could only see that the call site passed the snapshot. Inserting any await between the snapshot and the helper would silently pair a uuid decided against one observation with binding fields decided against a later one — the exact class of contradictory diagnostics #887/#716 exist to prevent. Today that is rare (no await, and a throw-then-succeed on the two reads is the only currently-reachable mismatch), but the invariant was asserted, not enforced.

## Change

- `activeWorkflowUuidForOpenReply` consumes `activeSnapshot` and omits rather than guessing when it is missing.
- Tests pin the callee, not just the call site: a matching snapshot publishes even if a later live read would see a different tab; a mismatched or missing snapshot omits even if a later live read would see the target.

Does **not** close #1014. The design record stays open.

Refs #1014
