### PR TITLE
feat(1122): replace a published subgraph blueprint with overwrite:true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+### Added
+- `graph_save_subgraph` can replace a user-published blueprint in place with `overwrite:true` — no Save dialog, bundled/global blueprints stay protected (#1122)
+
 ## [0.15.9] - 2026-08-19
 
 ### Fixed

--- a/browser_tests/unit/blueprint-collision.test.mjs
+++ b/browser_tests/unit/blueprint-collision.test.mjs
@@ -194,10 +194,12 @@ const refusalSite = src.slice(
 test("#636: a GLOBAL collision is not told to delete it", () => {
   // subgraphStore.deleteBlueprint refuses a bundled blueprint outright, so "delete it and
   // retry" is unfollowable — and on a stock install most blueprints are global, making it
-  // the likeliest collision.
+  // the likeliest collision. The wording lives in subgraphCollisionRefusalMessage so it
+  // is tested as a string; pin that this site still classifies globality and refuses
+  // through that helper (overwrite:true cannot free a bundled name — #1122).
   assert.ok(refusalSite.length > 0, "the refusal must classify the collision");
-  assert.match(refusalSite, /ships WITH ComfyUI/, "it must say why the name cannot be freed");
-  assert.match(refusalSite, /Save under a different one/, "and give the one remedy that works");
+  assert.match(refusalSite, /subgraphCollisionRefusalMessage/, "the refusal must use the shared wording");
+  assert.match(refusalSite, /subgraphSaveCollisionAction/, "and classify before throwing");
 });
 
 test("#636: UNKNOWN is not treated as global", () => {

--- a/browser_tests/unit/subgraph-blueprint-overwrite.test.mjs
+++ b/browser_tests/unit/subgraph-blueprint-overwrite.test.mjs
@@ -1,0 +1,232 @@
+// #1122 — graph_save_subgraph must be able to REPLACE a user-published blueprint
+// without a human Save dialog, and must never infer that from a name collision.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import {
+  collisionSharesPublishKey,
+  replacedBlueprintIdentity,
+  subgraphCollisionRefusalMessage,
+  subgraphSaveCollisionAction,
+  withBlueprintOverwriteConfirm,
+} from "../../web/js/lib/subgraph-blueprint-overwrite.js";
+
+test("#1122: a collision without overwrite:true still refuses", () => {
+  assert.equal(
+    subgraphSaveCollisionAction({ hasCollision: true, overwrite: false, isGlobal: false }),
+    "refuse-collision",
+  );
+  assert.equal(
+    subgraphSaveCollisionAction({ hasCollision: true, isGlobal: false }),
+    "refuse-collision",
+    "omitted overwrite must not be treated as consent",
+  );
+});
+
+test("#1122: overwrite is NEVER inferred from a truthy non-true value", () => {
+  for (const overwrite of [1, "true", "yes", {}, []]) {
+    assert.equal(
+      subgraphSaveCollisionAction({ hasCollision: true, overwrite, isGlobal: false }),
+      "refuse-collision",
+      JSON.stringify(overwrite),
+    );
+  }
+});
+
+test("#1122: overwrite:true on a user blueprint is the replace path", () => {
+  assert.equal(
+    subgraphSaveCollisionAction({
+      hasCollision: true,
+      overwrite: true,
+      isGlobal: false,
+    }),
+    "overwrite",
+  );
+});
+
+test("#1122: a GLOBAL blueprint stays non-overwritable even with overwrite:true", () => {
+  assert.equal(
+    subgraphSaveCollisionAction({
+      hasCollision: true,
+      overwrite: true,
+      isGlobal: true,
+    }),
+    "refuse-global",
+  );
+});
+
+test("#1122: unknown globality is not treated as global", () => {
+  // Same rule as the #636 listing: only a positive true narrows the remedy.
+  for (const isGlobal of [false, null, undefined]) {
+    assert.equal(
+      subgraphSaveCollisionAction({
+        hasCollision: true,
+        overwrite: true,
+        isGlobal,
+      }),
+      "overwrite",
+      String(isGlobal),
+    );
+  }
+});
+
+test("#1122: no collision is a normal publish, even with overwrite:true", () => {
+  assert.equal(
+    subgraphSaveCollisionAction({ hasCollision: false, overwrite: true }),
+    "publish",
+  );
+});
+
+test("#1122: an ambiguous library name refuses rather than guessing which to replace", () => {
+  assert.equal(
+    subgraphSaveCollisionAction({
+      hasCollision: true,
+      overwrite: true,
+      isGlobal: false,
+      matchCount: 2,
+    }),
+    "refuse-ambiguous",
+  );
+});
+
+test("#1122: a display_name-only hit is not an in-place replace", () => {
+  assert.equal(
+    subgraphSaveCollisionAction({
+      hasCollision: true,
+      overwrite: true,
+      isGlobal: false,
+      sameCacheKey: false,
+    }),
+    "refuse-keyed-differently",
+  );
+});
+
+test("#1122: collisionSharesPublishKey matches type / bare name, not display_name alone", () => {
+  const names = {
+    fullType: "SubgraphBlueprint.Mine",
+    finalName: "Mine",
+  };
+  assert.equal(collisionSharesPublishKey({ name: "SubgraphBlueprint.Mine" }, names), true);
+  assert.equal(collisionSharesPublishKey({ name: "Mine" }, names), true);
+  assert.equal(
+    collisionSharesPublishKey(
+      { name: "SubgraphBlueprint.deadbeef", display_name: "Mine" },
+      names,
+    ),
+    false,
+    "a hash-keyed entry would CREATE a second file if published under Mine",
+  );
+  assert.equal(collisionSharesPublishKey(null, names), false);
+});
+
+test("#1122: the reply identity names what was replaced", () => {
+  assert.deepEqual(
+    replacedBlueprintIdentity({
+      name: "SubgraphBlueprint.Save_Video",
+      display_name: "Save Video",
+    }),
+    {
+      name: "Save_Video",
+      type: "SubgraphBlueprint.Save_Video",
+      display_name: "Save Video",
+    },
+  );
+});
+
+test("#1122: the collision refusal names overwrite:true as the programmatic option", () => {
+  const msg = subgraphCollisionRefusalMessage({
+    action: "refuse-collision",
+    finalName: "Mine",
+    collisionType: "SubgraphBlueprint.Mine",
+  });
+  assert.match(msg, /overwrite:true/);
+  assert.match(msg, /already exists \(type "SubgraphBlueprint.Mine"\)/);
+  assert.match(msg, /different name/);
+});
+
+test("#1122: a GLOBAL refusal still says the name cannot be freed", () => {
+  const msg = subgraphCollisionRefusalMessage({
+    action: "refuse-global",
+    finalName: "Text to Image",
+    collisionType: "SubgraphBlueprint.04849b7409f059f520924d",
+  });
+  assert.match(msg, /ships WITH ComfyUI/);
+  assert.match(msg, /Save under a different one/);
+  assert.doesNotMatch(msg, /overwrite:true/, "a bundled blueprint cannot be freed by the flag");
+});
+
+test("#1122: auto-confirm answers overwriteBlueprint and no other type", async () => {
+  const calls = [];
+  const store = {
+    showDialog(options) {
+      calls.push(options);
+      return { shown: true };
+    },
+  };
+  let confirmed = false;
+  await withBlueprintOverwriteConfirm(store, async () => {
+    store.showDialog({
+      key: "global-prompt",
+      props: { type: "overwriteBlueprint", onConfirm: () => { confirmed = true; } },
+    });
+    const other = store.showDialog({ props: { type: "delete", onConfirm: () => {} } });
+    assert.equal(other.shown, true, "non-overwrite dialogs must still go through");
+  });
+  assert.equal(confirmed, true);
+  assert.equal(calls.length, 1, "overwriteBlueprint must not reach the real showDialog");
+  assert.equal(calls[0].props.type, "delete");
+});
+
+test("#1122: auto-confirm restores showDialog even when the publish throws", async () => {
+  const orig = function origShowDialog() { return "orig"; };
+  const store = { showDialog: orig };
+  await assert.rejects(
+    () => withBlueprintOverwriteConfirm(store, async () => {
+      store.showDialog({ props: { type: "overwriteBlueprint", onConfirm: () => {} } });
+      throw new Error("publish failed");
+    }),
+    /publish failed/,
+  );
+  assert.equal(store.showDialog, orig);
+});
+
+test("#1122: auto-confirm refuses rather than hang when there is no dialog store", async () => {
+  await assert.rejects(
+    () => withBlueprintOverwriteConfirm(null, async () => {}),
+    /no dialog store/,
+  );
+});
+
+test("#1122: auto-confirm refuses if ComfyUI never asked to overwrite", async () => {
+  const orig = function origShowDialog() { return "orig"; };
+  const store = { showDialog: orig };
+  await assert.rejects(
+    () => withBlueprintOverwriteConfirm(store, async () => "published"),
+    /did not ask to overwrite/,
+  );
+  assert.equal(store.showDialog, orig, "must restore even on the unanswered path");
+});
+
+// ── wiring: the panel actually uses this path ───────────────────────────────
+
+const src = readFileSync(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8");
+const saveSite = src.slice(
+  src.indexOf("async graph_save_subgraph("),
+  src.indexOf("graph_list_subgraphs({ filter, limit } = {})"),
+);
+
+test("#1122: graph_save_subgraph accepts overwrite", () => {
+  assert.match(saveSite, /async graph_save_subgraph\(\{ node_id, name, overwrite \} = \{\}\)/);
+});
+
+test("#1122: overwrite goes through the auto-confirm helper, not a human dialog", () => {
+  assert.match(saveSite, /withBlueprintOverwriteConfirm/);
+  assert.match(saveSite, /getPiniaStore\("dialog"\)/);
+  assert.match(saveSite, /replaced:/);
+});
+
+test("#1122: the no-flag refusal still ends at publishSubgraph so #636 slices stay valid", () => {
+  // blueprint-collision.test.mjs slices up to this exact call. Keep it as the
+  // non-overwrite publish so those tests continue to pin the preflight.
+  assert.match(saveSite, /await store\.publishSubgraph\(finalName\);/);
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -347,6 +347,13 @@ import { describeRenameFailure } from "./lib/workflow-rename-error.js";
 import { isSameInstanceRename } from "./lib/workflow-route-change.js";
 import { boundSubgraphList } from "./lib/subgraph-list-bound.js";
 import {
+  collisionSharesPublishKey,
+  replacedBlueprintIdentity,
+  subgraphCollisionRefusalMessage,
+  subgraphSaveCollisionAction,
+  withBlueprintOverwriteConfirm,
+} from "./lib/subgraph-blueprint-overwrite.js";
+import {
   threadMatchesCurrentWorkflow,
   currentWorkflowIdentityKeys,
   migratableRouteIds,
@@ -18552,7 +18559,10 @@ const GRAPH_TOOL_EXECUTORS = {
   // Publish a subgraph node to the library. node_id selects the subgraph node
   // first (else the current single selection must be a subgraph node). name is the
   // blueprint name (defaults to the node's title). No dialog when name is given.
-  async graph_save_subgraph({ node_id, name } = {}) {
+  // overwrite:true replaces an existing USER blueprint of that name in place
+  // (#1122); bundled/global blueprints stay non-overwritable, and a collision
+  // without the flag still refuses rather than popping ComfyUI's confirm dialog.
+  async graph_save_subgraph({ node_id, name, overwrite } = {}) {
     const { graph, canvas } = getGraphCtx();
     if (!canvas) throw new Error("canvas unavailable");
     const store = getSubgraphStore();
@@ -18606,15 +18616,18 @@ const GRAPH_TOOL_EXECUTORS = {
       d?.name === fullType || bareName(d) === finalName || displayName(d) === finalName;
     // publishSubgraph() pops a confirmOverwrite() dialog on a name COLLISION — which
     // would hang this programmatic call waiting for UI. Preflight and refuse with a
-    // clear error instead. The remedy must be actionable from where the caller IS:
-    // there is no programmatic delete, so name both real options explicitly rather than
-    // leaving "overwrite isn't supported" as a dead end (#636).
+    // clear error instead, unless the caller opted in with overwrite:true (#1122).
+    // Overwrite is never inferred from the collision; bundled/global blueprints stay
+    // non-overwritable. The no-flag remedy must still be actionable from where the
+    // caller IS: name the flag, a different name, or (for a user blueprint) delete
+    // rather than leaving "overwrite isn't supported" as a dead end (#636).
     // ONE snapshot backs BOTH the collision preflight and the before/after comparison, so
     // the entry this call ultimately attributes to itself is one this call PROVED was
     // absent beforehand — not one that merely happens to match the name now.
     const before = blueprintList();
     const beforeKeys = new Set(before.map((d) => d?.name));
-    const collision = before.find(matchesRequested);
+    const matches = before.filter(matchesRequested);
+    const collision = matches[0];
     if (collision) {
       // #636 — DON'T SEND THEM AFTER A BLUEPRINT COMFYUI WON'T DELETE. The remedy below
       // used to say "delete it from the library and retry" unconditionally, and
@@ -18640,15 +18653,40 @@ const GRAPH_TOOL_EXECUTORS = {
       } catch {
         collisionIsGlobal = false;
       }
+      const action = subgraphSaveCollisionAction({
+        hasCollision: true,
+        overwrite,
+        isGlobal: collisionIsGlobal,
+        matchCount: matches.length,
+        sameCacheKey: collisionSharesPublishKey(collision, { fullType, finalName, prefix }),
+      });
+      if (action === "overwrite") {
+        // Answer ComfyUI's confirmOverwrite() ourselves so the official publish
+        // path runs without a human dialog. A matching library entry afterwards
+        // is the observed replace — the key does not change on an in-place save,
+        // so the new-entry check used for first publish cannot prove this one.
+        const replaced = replacedBlueprintIdentity(collision, { prefix });
+        await withBlueprintOverwriteConfirm(getPiniaStore("dialog"), () =>
+          store.publishSubgraph(finalName),
+        );
+        const updated = blueprintList().find(matchesRequested);
+        if (!updated) {
+          throw new Error(
+            `panel_save_subgraph overwrite did not leave a blueprint named "${finalName}" in the ` +
+              `library. Nothing is being reported as saved. Check panel_list_subgraphs, then retry.`,
+          );
+        }
+        return {
+          saved: { name: finalName, from_node_id: target.id, type: updated?.name ?? fullType },
+          replaced: replaced,
+        };
+      }
       throw new Error(
-        `a subgraph blueprint named "${finalName}" already exists (type "${collision.name}") and this ` +
-          `tool will not replace it — replacing one programmatically would need ComfyUI's overwrite ` +
-          `dialog, which cannot be answered from here. ` +
-          (collisionIsGlobal
-            ? `That one ships WITH ComfyUI, and ComfyUI refuses to delete a bundled blueprint — so ` +
-              `there is no way to free the name. Save under a different one.`
-            : `Either save under a different name, or delete "${finalName}" from the subgraph library ` +
-              `in the ComfyUI UI first and then retry this call.`),
+        subgraphCollisionRefusalMessage({
+          action,
+          finalName,
+          collisionType: collision.name,
+        }),
       );
     }
     await store.publishSubgraph(finalName);

--- a/web/js/lib/subgraph-blueprint-overwrite.js
+++ b/web/js/lib/subgraph-blueprint-overwrite.js
@@ -1,0 +1,187 @@
+/**
+ * #1122 — programmatic overwrite of a user-published subgraph blueprint.
+ *
+ * `graph_save_subgraph` already preflights a name collision so ComfyUI's
+ * `publishSubgraph()` cannot pop `confirmOverwrite()` and hang a programmatic
+ * call. That left no way to UPDATE a published blueprint: there is no delete
+ * tool, and overwrite was refused. This module is the opt-in path:
+ *
+ *   - overwrite is NEVER inferred from a collision; the caller must pass
+ *     `overwrite === true`
+ *   - a bundled/global blueprint stays non-overwritable
+ *   - ComfyUI's overwrite dialog is answered programmatically (type
+ *     `overwriteBlueprint` only) so a human Save dialog never appears
+ */
+
+/** @typedef {"publish" | "overwrite" | "refuse-global" | "refuse-collision" | "refuse-ambiguous" | "refuse-keyed-differently"} SubgraphSaveCollisionAction */
+
+/**
+ * Decide what a colliding `graph_save_subgraph` call may do.
+ *
+ * @param {{
+ *   hasCollision?: boolean,
+ *   overwrite?: unknown,
+ *   isGlobal?: boolean | null,
+ *   matchCount?: number,
+ *   sameCacheKey?: boolean,
+ * }} [opts]
+ * @returns {SubgraphSaveCollisionAction}
+ */
+export function subgraphSaveCollisionAction({
+  hasCollision = false,
+  overwrite,
+  isGlobal = false,
+  matchCount = 1,
+  sameCacheKey = true,
+} = {}) {
+  if (!hasCollision) return "publish";
+  // Only a POSITIVE true is global: unknown/unreadable stays overwritable-if-opted-in
+  // rather than withholding a user-blueprint option that may well work (#636).
+  if (isGlobal === true) return "refuse-global";
+  if (overwrite !== true) return "refuse-collision";
+  if (matchCount > 1) return "refuse-ambiguous";
+  // A display_name hit whose stored type is a different key (hash-named) would make
+  // publishSubgraph CREATE a second file instead of replacing the existing one.
+  if (sameCacheKey !== true) return "refuse-keyed-differently";
+  return "overwrite";
+}
+
+/**
+ * True when the colliding library entry is keyed the way `publishSubgraph(name)`
+ * looks it up — full type or prefix-stripped name — not merely by display_name.
+ *
+ * @param {object | null | undefined} collision
+ * @param {{ fullType: string, finalName: string, prefix?: string }} names
+ */
+export function collisionSharesPublishKey(collision, { fullType, finalName, prefix = "SubgraphBlueprint." }) {
+  if (!collision) return false;
+  const type = typeof collision.name === "string" ? collision.name : "";
+  const bare = type.startsWith(prefix) ? type.slice(prefix.length) : type;
+  return type === fullType || bare === finalName;
+}
+
+/**
+ * Identity of the library entry an overwrite is about to replace.
+ *
+ * @param {object | null | undefined} collision
+ * @param {{ prefix?: string }} [opts]
+ */
+export function replacedBlueprintIdentity(collision, { prefix = "SubgraphBlueprint." } = {}) {
+  const type = typeof collision?.name === "string" ? collision.name : null;
+  const t = type ?? "";
+  const name = t.startsWith(prefix) ? t.slice(prefix.length) : t;
+  return {
+    name: name || null,
+    type,
+    display_name: typeof collision?.display_name === "string" ? collision.display_name : null,
+  };
+}
+
+/**
+ * Agent-facing refusal. Global wording keeps the #636 phrases the unit tests pin.
+ *
+ * @param {{
+ *   action: SubgraphSaveCollisionAction,
+ *   finalName: string,
+ *   collisionType?: string | null,
+ * }} opts
+ */
+export function subgraphCollisionRefusalMessage({ action, finalName, collisionType }) {
+  const typeBit =
+    typeof collisionType === "string" && collisionType
+      ? ` (type "${collisionType}")`
+      : "";
+  if (action === "refuse-global") {
+    return (
+      `a subgraph blueprint named "${finalName}" already exists${typeBit} and this ` +
+      `tool will not replace it — replacing one programmatically would need ComfyUI's overwrite ` +
+      `dialog, which cannot be answered from here. ` +
+      `That one ships WITH ComfyUI, and ComfyUI refuses to delete a bundled blueprint — so ` +
+      `there is no way to free the name. Save under a different one.`
+    );
+  }
+  if (action === "refuse-ambiguous") {
+    return (
+      `a subgraph blueprint named "${finalName}" already exists${typeBit} and matches more ` +
+      `than one library entry, so replacing one would be a guess. Pass the unique \`type\` ` +
+      `from panel_list_subgraphs, or save under a different name.`
+    );
+  }
+  if (action === "refuse-keyed-differently") {
+    return (
+      `a subgraph blueprint named "${finalName}" already exists${typeBit}, but ComfyUI ` +
+      `stores it under that type rather than the requested name, so publishing again would ` +
+      `create a second blueprint instead of replacing it. Save under a different name, or ` +
+      `pass a name that matches the stored type.`
+    );
+  }
+  return (
+    `a subgraph blueprint named "${finalName}" already exists${typeBit} and this ` +
+    `tool will not replace it — replacing one programmatically would need ComfyUI's overwrite ` +
+    `dialog, which cannot be answered from here. ` +
+    `Either save under a different name, pass overwrite:true to replace this user blueprint ` +
+    `in place, or delete "${finalName}" from the subgraph library in the ComfyUI UI first ` +
+    `and then retry this call.`
+  );
+}
+
+/**
+ * Run `publishSubgraph` while auto-confirming ComfyUI's overwriteBlueprint dialog
+ * so a human never has to. Any other dialog type still goes through.
+ *
+ * @template T
+ * @param {{ showDialog?: Function } | null | undefined} dialogStore  Pinia id "dialog"
+ * @param {() => (T | Promise<T>)} run
+ * @returns {Promise<T>}
+ */
+export async function withBlueprintOverwriteConfirm(dialogStore, run) {
+  if (!dialogStore || typeof dialogStore.showDialog !== "function") {
+    throw new Error(
+      "cannot overwrite a subgraph blueprint programmatically: this ComfyUI frontend has no " +
+        "dialog store to auto-confirm, and publishSubgraph would hang on the overwrite dialog. " +
+        "Save under a different name instead.",
+    );
+  }
+  const orig = dialogStore.showDialog;
+  let answered = false;
+  function patched(options) {
+    if (options?.props?.type === "overwriteBlueprint") {
+      answered = true;
+      const onConfirm = options.props.onConfirm;
+      if (typeof onConfirm === "function") onConfirm(true);
+      return { key: options?.key ?? "overwriteBlueprint", visible: false };
+    }
+    return orig.call(dialogStore, options);
+  }
+  try {
+    dialogStore.showDialog = patched;
+  } catch {
+    throw new Error(
+      "cannot overwrite a subgraph blueprint programmatically: the dialog store's showDialog " +
+        "could not be intercepted. Save under a different name instead.",
+    );
+  }
+  if (dialogStore.showDialog !== patched) {
+    throw new Error(
+      "cannot overwrite a subgraph blueprint programmatically: the dialog store's showDialog " +
+        "could not be intercepted. Save under a different name instead.",
+    );
+  }
+  try {
+    const result = await run();
+    if (!answered) {
+      throw new Error(
+        "overwrite:true was set, but ComfyUI did not ask to overwrite this blueprint, so " +
+          "nothing is being reported as replaced. The name may not be the library key. Check " +
+          "panel_list_subgraphs and pass the stored type, or save under a different name.",
+      );
+    }
+    return result;
+  } finally {
+    try {
+      dialogStore.showDialog = orig;
+    } catch {
+      // best-effort restore; a later call must not keep auto-confirming
+    }
+  }
+}


### PR DESCRIPTION
Enhancement — do not merge until another agent reviews.

Fixes #1122.

`graph_save_subgraph` can now replace a user-published subgraph blueprint in place when the caller passes `overwrite: true`. ComfyUI's `confirmOverwrite()` dialog is answered programmatically (type `overwriteBlueprint` only), so a human Save dialog never appears.

Without the flag a name collision still refuses — overwrite is never inferred. Bundled/global blueprints stay non-overwritable. The reply includes `replaced` (name/type/display_name) for the library entry that was updated.

A hash-keyed / display_name-only collision is refused rather than publishing a second file under the requested name.
