### PR TITLE
fix(1748): outline clip footer names note nodes whose text was clipped

### DIFF
--- a/browser_tests/unit/graph-read.test.mjs
+++ b/browser_tests/unit/graph-read.test.mjs
@@ -38,6 +38,8 @@ import {
   clipOutlineTitle,
   OUTLINE_TITLE_CAP,
   MAX_CHARS_CEILING,
+  // #1748
+  NOTE_NODE_TYPES,
 } from "../../web/js/lib/graph-read.js";
 
 // ---- #607: link-driven widget detection -----------------------------------
@@ -427,6 +429,33 @@ test("#809 the outline footer covers title clips as well as value clips", () => 
   const both = outlineValueClipNote(2, 3);
   assert.match(both, /2 widget value\(s\) clipped to 60 chars and 3 title\(s\) clipped to 120 chars/);
   assert.match(both, /`max_chars` does not raise/);
+});
+
+test("#1748 the outline footer names NOTE nodes whose text was clipped", () => {
+  // No note ids → byte-identical to the old footer: an unnoted graph pays nothing and
+  // the clause never fires on title-only clips either.
+  assert.equal(outlineValueClipNote(2, 0), outlineValueClipNote(2, 0, []), "no ids, no clause");
+  const noted = outlineValueClipNote(3, 0, [7, 12]);
+  assert.match(noted, /3 widget value\(s\) clipped to 60 chars/);
+  assert.match(noted, /on-canvas note text \(node id\(s\): 7, 12\)/, "names the note nodes");
+  assert.match(noted, /trigger words and usage instructions/, "says WHY a note clip matters");
+  // The remedy that was already there still applies — detail reads the note up to the
+  // fixed per-widget cap.
+  assert.match(noted, /panel_query_graph \{ids:\[…\], fields:'detail'\}/);
+  // The id list is bounded: a graph dense with notes cannot flood the footer (the
+  // footer is part of the measured rung, but an unbounded list would still be noise).
+  const many = outlineValueClipNote(25, 0, Array.from({ length: 30 }, (_, i) => i + 1));
+  assert.match(many, /\+10 more/, "the id list is capped with an explicit remainder");
+  assert.doesNotMatch(many, /\b21\b/, "ids past the cap are not listed");
+});
+
+test("#1748 NOTE_NODE_TYPES is the positive allowlist of on-canvas prose nodes", () => {
+  assert.ok(NOTE_NODE_TYPES.has("Note"));
+  assert.ok(NOTE_NODE_TYPES.has("MarkdownNote"));
+  // A type that merely CONTAINS "note" is not prose-on-canvas by convention — the
+  // footer naming a non-note would send the agent reading instructions that are not.
+  assert.ok(!NOTE_NODE_TYPES.has("NoteToSelf"));
+  assert.ok(!NOTE_NODE_TYPES.has("Reroute"));
 });
 
 test("#809 shown-of-matched is always stated, so 'how much is left' is never guesswork", () => {

--- a/browser_tests/unit/outline-coverage.test.mjs
+++ b/browser_tests/unit/outline-coverage.test.mjs
@@ -225,9 +225,28 @@ test("#809 the outline's own fixed clips are not left silent", () => {
   assert.match(body, /outlineTitlesClipped\+\+/, "so is the fixed per-title clip");
   assert.match(
     body,
-    /outlineValueClipNote\(outlineClipped, outlineTitlesClipped\)/,
+    /outlineValueClipNote\(outlineClipped, outlineTitlesClipped, outlineClippedNoteIds\)/,
     "and both are reported on the outline itself",
   );
+});
+
+// A bare count of clipped values cannot tell the reader that one of them was on-canvas
+// INSTRUCTIONS (a Note/MarkdownNote holding trigger words) rather than a re-queryable
+// seed — the row's own 60-char clip reads as the whole note. The footer must NAME the
+// note nodes whose text was clipped, and the id list must reset per rung like the
+// counts do, or a lower rung would claim note clips it does not contain.
+test("#1748 clipped NOTE text is named by node id, not folded into the count", () => {
+  const body = outline();
+  assert.match(body, /let outlineClippedNoteIds = \[\];/, "the note-id list exists");
+  assert.match(
+    body,
+    /NOTE_NODE_TYPES\.has\(node\?\.type\) && !outlineClippedNoteIds\.includes\(node\.id\)\s*\)\s*\n?\s*outlineClippedNoteIds\.push\(node\.id\)/,
+    "a clipped value on a Note/MarkdownNote records the node id, deduped",
+  );
+  const assembleStart = body.indexOf("const assemble = (level) => {");
+  assert.notEqual(assembleStart, -1, "assemble() must exist");
+  const assembleBody = body.slice(assembleStart, body.indexOf("// Walk DOWN the ladder"));
+  assert.match(assembleBody, /outlineClippedNoteIds = \[\];/, "the id list resets per rung, inside assemble");
 });
 
 // The footer is PART of the rung. Appending it after the fit test could tip a rung over

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -335,6 +335,8 @@ import {
   // #1634: the pinpoint per-value cap for an explicit-`ids` read is derived from these.
   WIDGET_VALUE_CAP,
   COMPACT_VALUE_CLIP,
+  // #1748: which frontend node types carry on-canvas prose as a widget value.
+  NOTE_NODE_TYPES,
   OUTLINE_DETAIL_LEVELS,
   clampOutlineMaxChars,
   outlineDegradeBanner,
@@ -11216,6 +11218,11 @@ const GRAPH_TOOL_EXECUTORS = {
     // raises these clips, so the footer must not pretend one does.
     let outlineClipped = 0;
     let outlineTitlesClipped = 0;
+    // #1748: WHICH clipped values were on-canvas note text (Note/MarkdownNote). A bare
+    // count cannot tell the reader that one of them was the workflow's INSTRUCTIONS
+    // (trigger words, download paths) rather than a seed it can re-query, so the footer
+    // names the note nodes whose text the 60-char clip hid. Render order, deduped.
+    let outlineClippedNoteIds = [];
     /**
      * clipOutlineTitle, counting — every title in the outline goes through here.
      *
@@ -11285,9 +11292,18 @@ const GRAPH_TOOL_EXECUTORS = {
      * quote/backslash-dense value can render slightly longer than 60; that costs a few
      * characters against max_chars and cannot reintroduce a forgeable tag (codex).
      */
-    const fmtVal = (v) => {
+    const fmtVal = (v, node) => {
       const s = String(typeof v === "string" ? v : JSON.stringify(v) ?? "").replace(/\s+/g, " ");
-      const clipped = s.length <= 60 ? s : (outlineClipped++, s.slice(0, 57) + "…");
+      let clipped = s;
+      if (s.length > 60) {
+        outlineClipped++;
+        // #1748: a clipped NOTE value is lost instructions, not a re-queryable detail —
+        // remember the node so the footer can name it (the row's own 60-char clip reads
+        // as the whole note otherwise).
+        if (NOTE_NODE_TYPES.has(node?.type) && !outlineClippedNoteIds.includes(node.id))
+          outlineClippedNoteIds.push(node.id);
+        clipped = s.slice(0, 57) + "…";
+      }
       if (!/[[\]]/.test(clipped)) return clipped;
       // Escape backslashes first, then quotes, so the escape introduced for a quote is
       // not doubled — and the closing quote cannot be swallowed by a trailing backslash.
@@ -11350,7 +11366,7 @@ const GRAPH_TOOL_EXECUTORS = {
             .map((w) => {
               // At "no_values" the widget NAMES still tell an agent what is configurable;
               // the VALUES are the bulk of the bytes, so they go first.
-              const base = level === "full" ? `${w.name}=${fmtVal(w.value)}` : w.name;
+              const base = level === "full" ? `${w.name}=${fmtVal(w.value, n)}` : w.name;
               // The NAME stays the addressable key and stays first — panel_set_widget
               // takes the name, not the label — with the label annotated beside it in the
               // same bracket idiom as [after_gen=…] and [bypass].
@@ -11463,6 +11479,7 @@ const GRAPH_TOOL_EXECUTORS = {
     const assemble = (level) => {
       outlineClipped = 0;
       outlineTitlesClipped = 0;
+      outlineClippedNoteIds = [];
       const banner = outlineDegradeBanner({
         level,
         nodeCount: nodes.length,
@@ -11489,7 +11506,7 @@ const GRAPH_TOOL_EXECUTORS = {
         (banner ? `${banner}\n\n` : "") +
         head +
         bodyText +
-        outlineValueClipNote(outlineClipped, outlineTitlesClipped)
+        outlineValueClipNote(outlineClipped, outlineTitlesClipped, outlineClippedNoteIds)
       );
     };
 

--- a/web/js/lib/graph-read.js
+++ b/web/js/lib/graph-read.js
@@ -33,6 +33,12 @@ export const MAX_CHARS_FLOOR = 500;
 /** Widget values are clipped to this in the `compact` projection (a FIXED cap). */
 export const COMPACT_VALUE_CLIP = 60;
 
+/** #1748: frontend node types whose widget value IS on-canvas prose — the place
+ *  workflow authors put trigger words, download paths and usage instructions. A
+ *  clipped value on one of these is lost instructions, not a re-queryable detail,
+ *  so the outline footer names them instead of folding them into a bare count. */
+export const NOTE_NODE_TYPES = new Set(["Note", "MarkdownNote"]);
+
 /**
  * #809 (codex gate): "raise `X` up to N" is ITSELF a dead retry when the caller is
  * already at N, and "raise `X`" with no ceiling leaves them guessing how far. Both cost
@@ -436,13 +442,25 @@ export function outlineDegradeBanner({ level, nodeCount, groupCount, maxChars })
  *
  * "Read FULL values" would over-promise: panel_query_graph's detail projection has its
  * own fixed 2048-char per-widget cap (codex gate). Say "fuller, up to N".
- */
-export function outlineValueClipNote(valueCount, titleCount = 0) {
+ *
+ * #1748: `noteIds` are the NOTE-node ids (Note/MarkdownNote) whose widget values were
+ * among the clips. A bare count cannot tell the reader that one of the clipped values
+ * was on-canvas INSTRUCTIONS (trigger words, download paths) rather than a seed it can
+ * re-query — and the node row's own 60-char clip reads as the whole note. Naming the
+ * ids turns "N values clipped" into "instructions existed, and here is where". The id
+ * list is bounded so a graph dense with notes cannot flood the footer. */
+export function outlineValueClipNote(valueCount, titleCount = 0, noteIds = []) {
   if (!valueCount && !titleCount) return "";
   const parts = [];
   if (valueCount) parts.push(`${valueCount} widget value(s) clipped to ${COMPACT_VALUE_CLIP} chars`);
   if (titleCount) parts.push(`${titleCount} title(s) clipped to ${OUTLINE_TITLE_CAP} chars`);
-  return `\n\n(${parts.join(" and ")} — fixed outline caps that \`max_chars\` does not raise. Read fuller values with panel_query_graph {ids:[…], fields:'detail'}, which caps each value at ${WIDGET_VALUE_CAP} chars.)`;
+  let noteClause = "";
+  if (noteIds.length) {
+    const shown = noteIds.slice(0, 20);
+    const more = noteIds.length - shown.length;
+    noteClause = ` The clipped values include on-canvas note text (node id(s): ${shown.join(", ")}${more ? `, +${more} more` : ""}) — notes are where workflow authors put trigger words and usage instructions; read them before prompting.`;
+  }
+  return `\n\n(${parts.join(" and ")} — fixed outline caps that \`max_chars\` does not raise.${noteClause} Read fuller values with panel_query_graph {ids:[…], fields:'detail'}, which caps each value at ${WIDGET_VALUE_CAP} chars.)`;
 }
 
 /** Group/subgraph titles are user-controlled and unbounded. */


### PR DESCRIPTION
## Root cause

`panel_graph_outline` clips every widget value at a fixed 60 chars (`COMPACT_VALUE_CLIP`) even on the `full` rung, and sheds values entirely at the `no_values` rung. The elision was already *announced* (`outlineValueClipNote()` footer, `outlineDegradeBanner()`), but the footer was a bare count — it could not tell an agent that one of the clipped values was on-canvas `Note`/`MarkdownNote` text (LoRA trigger words, download paths, usage instructions) rather than a re-queryable detail like `steps=20`. Worse, the note row's own 60-char clip ends in "…" but reads as plausibly-complete prose, so the agent was left believing it had read the workflow when the instructions were elided. (Per the issue thread, the ladder's rung logic itself is load-bearing and was deliberately not reordered.)

## Fix

- `web/js/lib/graph-read.js`: new `NOTE_NODE_TYPES` allowlist (`Note`, `MarkdownNote`); `outlineValueClipNote(valueCount, titleCount, noteIds)` gains a third param — when any clipped value came from a note node, the footer names the node ids and says why a note clip matters (trigger words / usage instructions), keeping the existing `panel_query_graph {ids:[…], fields:'detail'}` remedy. The id list is capped at 20 with an explicit `+N more`. No note ids → footer is byte-identical to before.
- `web/js/comfyui-mcp-panel.js`: `fmtVal` records the node id when it clips a value on a `NOTE_NODE_TYPES` node (deduped, render order); the list resets per rung inside `assemble()` alongside the existing counters, exactly like `outlineClipped`/`outlineTitlesClipped`, so a lower rung never claims note clips it does not contain.

## Verification

- `npm ci` — clean, 0 vulnerabilities.
- `npm run test:unit` (i18n-check + i18n-render-check + check-tool-vocabulary + check-panel-scope + `node --test browser_tests/unit/*.test.mjs`) — **5654 pass, 0 fail** (1 todo, pre-existing). Includes the tool-vocabulary gate; no new `panel_*` identifiers introduced.
- `npm run typecheck` (`tsc --noEmit`) — clean.
- New tests: behavioral coverage of the note-id clause (named ids, remedy, 20-id bound, no-ids identity) and `NOTE_NODE_TYPES` membership in `browser_tests/unit/graph-read.test.mjs`; structural coverage (id list exists, dedupe site, per-rung reset, footer call signature) in `browser_tests/unit/outline-coverage.test.mjs`.

Closes artokun/comfyui-mcp#1748