### PR TITLE
fix(1434): panel_save_workflow replies when the save hangs instead of claiming the tab is frozen

### DIFF
--- a/browser_tests/unit/workflow-save-budget.test.mjs
+++ b/browser_tests/unit/workflow-save-budget.test.mjs
@@ -1,0 +1,283 @@
+/**
+ * panel#1434 — `panel_save_workflow` timed out with no acknowledgement for 15 s
+ * against a tab that kept answering `panel_graph_outline` and `panel_list_workflows`,
+ * and still reported persisted:true / modified:true.
+ *
+ * The reply was not lost in transit. It was never COMPOSED inside the window:
+ * `workflow_save` is relayed at 15,000 ms and awaited `programmaticSave` with no
+ * bound, so a /userdata HEAD, GET or PUT that accepts and never answers parks the
+ * rid until the orchestrator gives up and guesses the tab is backgrounded or frozen.
+ *
+ * THE HARNESS RUNS THE SHIPPED `workflow_save` BODY, extracted from the panel source
+ * and given injected collaborators, over the REAL `runBoundedWorkflowSave` with a
+ * REAL hanging save — the same technique as refresh-nodes-command-budget.test.mjs.
+ * A helper-level test cannot reach this defect: `runBoundedWorkflowSave` already
+ * implements the bound, and the whole bug was that the call site never used it.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { withTimeout } from "../../web/js/lib/bounded-step.js";
+import {
+  WORKFLOW_SAVE_COMMAND_BUDGET_MS,
+  WORKFLOW_SAVE_TIMEOUT,
+  describeWorkflowSaveTimeout,
+  runBoundedWorkflowSave,
+  workflowSaveTimeoutObservation,
+} from "../../web/js/lib/workflow-save-budget.js";
+import { PANEL_SRC } from "./_panel-constants.mjs";
+
+const workflowSaveMatch = PANEL_SRC.match(/\n {2}async workflow_save\(\{ name \} = \{\}\) \{[\s\S]*?\n {2}\},/);
+assert.ok(workflowSaveMatch, "could not locate workflow_save in panel source");
+
+const workflowSaveAsMatch = PANEL_SRC.match(/\n {2}async workflow_save_as\(\{ name \}\) \{[\s\S]*?\n {2}\},/);
+assert.ok(workflowSaveAsMatch, "could not locate workflow_save_as in panel source");
+
+// The orchestrator side of this invariant: ctx.call(..., 15000) in
+// comfyui-mcp's panel-tools.ts panel_save_workflow. Duplicated as a literal
+// on purpose — if EITHER side moves, this test forces the relationship to be
+// re-examined.
+const ORCHESTRATOR_SAVE_TIMEOUT_MS = 15000;
+
+function deferred() {
+  let resolve;
+  const promise = new Promise((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
+
+async function withWatchdog(run, ms, what) {
+  let timer;
+  const startedAt = Date.now();
+  const watchdog = new Promise((_, reject) => {
+    timer = setTimeout(() => reject(new Error(`${what} — waited ${ms}ms`)), ms);
+  });
+  try {
+    const value = await Promise.race([Promise.resolve().then(run), watchdog]);
+    return { value, elapsed: Date.now() - startedAt };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function shippedWorkflowSave({ programmaticSave, budgetMs = 40, observeWorkflow } = {}) {
+  const deps = {
+    runBoundedWorkflowSave,
+    programmaticSave,
+    WORKFLOW_SAVE_COMMAND_BUDGET_MS: budgetMs,
+    withTimeout,
+    monotonicNow: () => Date.now(),
+    observeActiveWorkflowSaveState: observeWorkflow,
+    saveProducedIdentity: () => ({ uuid: "u", routingKey: "wf:x" }),
+    saveReplyIdentity: () => ({ workflow_uuid: "u" }),
+    liveWorkflowListActive: () => ({ activeIdentity: { uuid: "u" } }),
+  };
+  const names = Object.keys(deps);
+  const factory = new Function(
+    ...names,
+    `const executors = {${workflowSaveMatch[0]}};
+     return executors.workflow_save;`,
+  );
+  return factory(...names.map((n) => deps[n]));
+}
+
+function shippedWorkflowSaveAs({ programmaticSave, budgetMs = 40, observeWorkflow } = {}) {
+  const deps = {
+    runBoundedWorkflowSave,
+    programmaticSave,
+    WORKFLOW_SAVE_COMMAND_BUDGET_MS: budgetMs,
+    withTimeout,
+    monotonicNow: () => Date.now(),
+    observeActiveWorkflowSaveState: observeWorkflow,
+    saveProducedIdentity: () => ({ uuid: "u", routingKey: "wf:x" }),
+    saveReplyIdentity: () => ({ workflow_uuid: "u" }),
+  };
+  const names = Object.keys(deps);
+  const factory = new Function(
+    ...names,
+    `const executors = {${workflowSaveAsMatch[0]}};
+     return executors.workflow_save_as;`,
+  );
+  return factory(...names.map((n) => deps[n]));
+}
+
+// ---------------------------------------------------------------------------
+// 1. The reported shape: in-place save of a persisted, still-dirty workflow,
+//    whose userdata write never settles.
+// ---------------------------------------------------------------------------
+
+test("#1434: workflow_save REPLIES at its budget instead of hanging on userdata", async () => {
+  const gate = deferred();
+  const observed = {
+    modified: true,
+    persisted: true,
+    filename: "video_minimax_h3_r2v_ai_test.json",
+  };
+  const workflow_save = shippedWorkflowSave({
+    programmaticSave: () => gate.promise,
+    budgetMs: 40,
+    observeWorkflow: () => observed,
+  });
+
+  const { elapsed } = await withWatchdog(
+    async () => {
+      await assert.rejects(
+        () => workflow_save({}),
+        (err) => {
+          assert.equal(
+            err.message,
+            describeWorkflowSaveTimeout({ budgetMs: 40, ...observed }),
+            "the timeout text is the helper's, not a restated sentence",
+          );
+          return true;
+        },
+      );
+    },
+    1500,
+    "workflow_save never replied: the command budget is not wrapping programmaticSave, so " +
+      "a hung userdata write silences the tab for the whole 15 s relay window",
+  );
+
+  assert.ok(elapsed < 1000, `replied in ${elapsed}ms — the reply must be composed at the bound`);
+  gate.resolve({ name: "should-not-land" });
+});
+
+test("#1434: the refusal NAMES a live tab and the dirty observation, never 'frozen'", async () => {
+  const observed = {
+    modified: true,
+    persisted: true,
+    filename: "video_minimax_h3_r2v_ai_test.json",
+  };
+  const text = describeWorkflowSaveTimeout({ budgetMs: WORKFLOW_SAVE_COMMAND_BUDGET_MS, ...observed });
+  assert.match(text, /workflow_save did not finish/);
+  assert.match(text, /video_minimax_h3_r2v_ai_test\.json/);
+  assert.match(text, /still live/);
+  assert.match(text, /modified:true/);
+  assert.match(text, /persisted:true/);
+  assert.match(text, /panel_list_workflows/);
+  assert.match(text, /not a backgrounded or frozen tab/);
+  // Same observation the reporter could read after the timeout.
+  assert.deepEqual(
+    workflowSaveTimeoutObservation({
+      isModified: true,
+      isPersisted: true,
+      filename: "video_minimax_h3_r2v_ai_test.json",
+    }),
+    observed,
+  );
+});
+
+test("#1434: a real save exception is the reply, never rewritten as a hang", async () => {
+  const boom = new Error("Error storing user data file 'workflows/Foo.json': 400");
+  await assert.rejects(
+    () =>
+      runBoundedWorkflowSave(() => Promise.reject(boom), {
+        budgetMs: 500,
+        withTimeout,
+        observeWorkflow: () => ({ modified: true }),
+      }),
+    (err) => {
+      assert.equal(err, boom, "the thrown Error object is the one the save raised");
+      return true;
+    },
+  );
+});
+
+test("#1434: a save that settles in time is returned unchanged", async () => {
+  const result = { name: "Foo.json", producedRecord: null };
+  const got = await runBoundedWorkflowSave(() => Promise.resolve(result), {
+    budgetMs: 500,
+    withTimeout,
+    observeWorkflow: () => ({ modified: false }),
+  });
+  assert.equal(got, result);
+});
+
+test("#1434: a completing in-place save still reports saved:true through the shipped handler", async () => {
+  const workflow_save = shippedWorkflowSave({
+    programmaticSave: async () => ({ name: "Foo.json", producedRecord: { path: "workflows/Foo.json" } }),
+    budgetMs: 500,
+    observeWorkflow: () => ({ modified: false }),
+  });
+  const reply = await workflow_save({});
+  assert.equal(reply.saved, true);
+  assert.equal(reply.workflow, "Foo.json");
+});
+
+test("#1434: workflow_save_as takes the same bound", async () => {
+  const gate = deferred();
+  const workflow_save_as = shippedWorkflowSaveAs({
+    programmaticSave: () => gate.promise,
+    budgetMs: 40,
+    observeWorkflow: () => ({ modified: true, persisted: true, filename: "copy.json" }),
+  });
+
+  await withWatchdog(
+    async () => {
+      await assert.rejects(
+        () => workflow_save_as({ name: "copy" }),
+        (err) => {
+          assert.match(err.message, /workflow_save did not finish/);
+          assert.match(err.message, /copy\.json/);
+          return true;
+        },
+      );
+    },
+    1500,
+    "workflow_save_as never replied",
+  );
+  gate.resolve({ name: "should-not-land" });
+});
+
+test("#1434: refusing without withTimeout is fail-closed, never unbounded", async () => {
+  await assert.rejects(
+    () => runBoundedWorkflowSave(() => new Promise(() => {}), { budgetMs: 500 }),
+    /requires withTimeout/,
+  );
+});
+
+test("#1434: the sentinel is a frozen object, so identity survives a map lookup", () => {
+  assert.equal(Object.isFrozen(WORKFLOW_SAVE_TIMEOUT), true);
+  assert.equal(WORKFLOW_SAVE_TIMEOUT.timeout, true);
+});
+
+// ---------------------------------------------------------------------------
+// 2. The shipped number, against the window it exists for.
+// ---------------------------------------------------------------------------
+
+test("#1434: the shipped budget leaves the 15 s relay window room to carry the reply", () => {
+  assert.ok(
+    WORKFLOW_SAVE_COMMAND_BUDGET_MS < ORCHESTRATOR_SAVE_TIMEOUT_MS,
+    `budget ${WORKFLOW_SAVE_COMMAND_BUDGET_MS} must leave reply margin under the bridge's ${ORCHESTRATOR_SAVE_TIMEOUT_MS} ms`,
+  );
+  assert.ok(WORKFLOW_SAVE_COMMAND_BUDGET_MS > 0);
+});
+
+test("#1434: BOTH save handlers wrap programmaticSave in the bound — the helper alone cannot prove this", () => {
+  assert.match(
+    workflowSaveMatch[0],
+    /runBoundedWorkflowSave\(\s*\(\) => programmaticSave\(name\),/,
+    "workflow_save must bound programmaticSave",
+  );
+  assert.match(
+    workflowSaveMatch[0],
+    /budgetMs: WORKFLOW_SAVE_COMMAND_BUDGET_MS/,
+    "workflow_save must pass the shipped budget, not a restated number",
+  );
+  assert.match(
+    workflowSaveAsMatch[0],
+    /runBoundedWorkflowSave\(\s*\(\) => programmaticSave\(name\),/,
+    "workflow_save_as must bound programmaticSave",
+  );
+  assert.match(
+    workflowSaveAsMatch[0],
+    /budgetMs: WORKFLOW_SAVE_COMMAND_BUDGET_MS/,
+    "workflow_save_as must pass the shipped budget, not a restated number",
+  );
+  assert.match(
+    PANEL_SRC,
+    /function observeActiveWorkflowSaveState\(\)/,
+    "the timeout path must observe the live dirty flags, not invent them",
+  );
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -593,6 +593,11 @@ import {
   nameContainsPathSeparator,
   pathSeparatorNameError,
 } from "./lib/workflow-save.js";
+import {
+  WORKFLOW_SAVE_COMMAND_BUDGET_MS,
+  runBoundedWorkflowSave,
+  workflowSaveTimeoutObservation,
+} from "./lib/workflow-save-budget.js";
 import { createRunCompletionTracker } from "./lib/run-completion.js";
 import {
   clearInheritedExecutionPreview,
@@ -6109,6 +6114,11 @@ async function programmaticSave(name) {
   // the Save-As copy the adapter PROVED active; `savedRecord` covers the first-save path.
   // Either way it is the save transaction's own output, never a later active-canvas read.
   return { name: saved || getWorkflowTitle(), producedRecord: details?.activatedRecord || details?.savedRecord || null, ...outcome };
+}
+
+/** #1434 — dirty/persisted snapshot for a save that did not settle in time. */
+function observeActiveWorkflowSaveState() {
+  return workflowSaveTimeoutObservation(app?.extensionManager?.workflow?.activeWorkflow);
 }
 
 /** Authoritative read-back oracle for saveActiveWorkflow's post-write guards.
@@ -16216,7 +16226,19 @@ const GRAPH_TOOL_EXECUTORS = {
   async workflow_save({ name } = {}) {
     // Fully programmatic — no Save/Rename dialog. Auto-names a never-saved
     // workflow; saves in place otherwise.
-    const { name: workflow, producedRecord, ...outcome } = await programmaticSave(name);
+    // #1434 — userdata HEAD/GET/PUT on this path can hang while the tab stays
+    // live (other RPCs still answer). Bound the save so the reply leaves the
+    // tab inside the orchestrator's 15 s window instead of a bare
+    // `did not reply to "workflow_save"` that claims the tab is frozen.
+    const { name: workflow, producedRecord, ...outcome } = await runBoundedWorkflowSave(
+      () => programmaticSave(name),
+      {
+        budgetMs: WORKFLOW_SAVE_COMMAND_BUDGET_MS,
+        withTimeout,
+        now: monotonicNow,
+        observeWorkflow: observeActiveWorkflowSaveState,
+      },
+    );
     // #978 recurrence — a FIRST save swaps the active object too, and the #557 carry
     // that usually threads the identity across that swap fails SAFE on any proof gap,
     // leaving the produced record un-established and the reply reporting
@@ -16244,7 +16266,17 @@ const GRAPH_TOOL_EXECUTORS = {
 
   async workflow_save_as({ name }) {
     if (!name || typeof name !== "string") throw new Error("name (string) is required");
-    const { name: workflow, producedRecord, ...outcome } = await programmaticSave(name);
+    // #1434 — same bound as workflow_save: both go through programmaticSave, both
+    // are relayed at 15 s, and a hung copy trio is the same silence.
+    const { name: workflow, producedRecord, ...outcome } = await runBoundedWorkflowSave(
+      () => programmaticSave(name),
+      {
+        budgetMs: WORKFLOW_SAVE_COMMAND_BUDGET_MS,
+        withTimeout,
+        now: monotonicNow,
+        observeWorkflow: observeActiveWorkflowSaveState,
+      },
+    );
     // #747 — this path ALWAYS changes which workflow is active, so it is the one
     // that strands a caller. Report the new instance identity here.
     const replyIdentity = saveProducedIdentity(producedRecord, { savedAs: true, firstSave: !!outcome.first_save });

--- a/web/js/lib/workflow-save-budget.js
+++ b/web/js/lib/workflow-save-budget.js
@@ -1,0 +1,146 @@
+// #1434 — ONE deadline for panel_save_workflow, so a hung userdata write cannot
+// silence the tab.
+//
+// Field report: panel_save_workflow delivered workflow_save to the pinned tab and
+// got no acknowledgement for 15,000 ms (the orchestrator's ctx.call budget in
+// comfyui-mcp panel-tools.ts). panel_graph_outline and panel_list_workflows from
+// the SAME tab answered immediately afterward, and list_workflows still showed
+// persisted:true / modified:true. The tab was not backgrounded or frozen — the
+// save path's /userdata HEAD, GET and PUT are unbounded, and a server that
+// accepts those and never answers parks the reply for the whole browser timeout.
+// The retry_of token then waited on that same in-flight promise and timed out
+// identically.
+//
+// The dispatch already replies on throw. What it cannot do is reply while the
+// save promise is still pending. This module bounds that wait: the save is not
+// cancelled (withTimeout never cancels), the ledger settles with a worded
+// refusal that reports the live dirty/modified observation, and a later retry
+// is not left hanging on the original.
+//
+// 13,000 ms, against the 15,000 ms relay window, for the same 2 s reply slack
+// get_errors uses against its 20 s read timeout. Not derived from the relay
+// constant, because that constant lives in the OTHER repo.
+
+import { makeCommandBudget } from "./command-budget.js";
+
+/** Whole-command deadline `workflow_save` / `workflow_save_as` take. */
+export const WORKFLOW_SAVE_COMMAND_BUDGET_MS = 13000;
+
+/** Sentinel withTimeout yields when the save has not settled. Frozen so identity holds. */
+export const WORKFLOW_SAVE_TIMEOUT = Object.freeze({ timeout: true });
+
+/**
+ * Snapshot the dirty/persisted flags a timeout reply can still observe.
+ * Getters that throw are omitted rather than failing the timeout path itself.
+ */
+export function workflowSaveTimeoutObservation(wf) {
+  if (!wf || typeof wf !== "object") return {};
+  const observed = {};
+  try {
+    if (wf.isModified === true || wf.isModified === false) observed.modified = wf.isModified;
+  } catch {
+    /* omit */
+  }
+  try {
+    if (wf.isPersisted === true || wf.isPersisted === false) observed.persisted = wf.isPersisted;
+  } catch {
+    /* omit */
+  }
+  try {
+    if (typeof wf.filename === "string" && wf.filename) observed.filename = wf.filename;
+  } catch {
+    /* omit */
+  }
+  return observed;
+}
+
+/**
+ * The refusal a timed-out save throws. States that the tab is still live, what
+ * the dirty flag currently says, and that the write may still land — never
+ * "backgrounded or frozen", which is the orchestrator's guess this report
+ * disproved.
+ */
+export function describeWorkflowSaveTimeout({
+  budgetMs = WORKFLOW_SAVE_COMMAND_BUDGET_MS,
+  modified,
+  persisted,
+  filename,
+} = {}) {
+  const total = Number.isFinite(budgetMs) && budgetMs > 0 ? budgetMs : WORKFLOW_SAVE_COMMAND_BUDGET_MS;
+  const seconds = Math.max(1, Math.round(total / 1000));
+  const who = typeof filename === "string" && filename ? `"${filename}"` : "the active workflow";
+  const dirty =
+    modified === true
+      ? "still reports modified:true — the canvas has not been marked clean, so the write has not been acknowledged as landed"
+      : modified === false
+        ? "now reports modified:false — the write may have landed after this deadline; confirm with panel_list_workflows"
+        : "its modified flag could not be read";
+  const persist =
+    persisted === true ? " persisted:true." : persisted === false ? " persisted:false." : "";
+  return (
+    `workflow_save did not finish within ${seconds}s for ${who}. ` +
+    `The tab is still live — other commands from it still answer, so this is not a backgrounded or frozen tab. ` +
+    `The save may still complete in the background. The same tab ${dirty}.${persist} ` +
+    `Check panel_list_workflows before retrying: if modified is false the write landed; ` +
+    `if it stays true the save is still in flight or failed. Do not re-issue until you have seen that observation.`
+  );
+}
+
+/**
+ * Run `saveFn` under the command budget. Always settles.
+ *
+ *   - save fulfills → its result
+ *   - save rejects  → that error (the actual save exception, never rewritten as a timeout)
+ *   - save hangs    → describeWorkflowSaveTimeout using observeWorkflow() at fire time
+ *
+ * `withTimeout` maps a rejection onto its fallback, so the save is converted to a
+ * `{ok, result|error}` envelope BEFORE it is bounded — otherwise a real save failure
+ * would be reported as a hang.
+ */
+export async function runBoundedWorkflowSave(
+  saveFn,
+  { budgetMs = WORKFLOW_SAVE_COMMAND_BUDGET_MS, now, withTimeout, observeWorkflow } = {},
+) {
+  if (typeof saveFn !== "function") {
+    throw new Error("runBoundedWorkflowSave requires a save function");
+  }
+  if (typeof withTimeout !== "function") {
+    throw new Error(
+      "runBoundedWorkflowSave requires withTimeout — refusing to run an unbounded save (issue #1434)",
+    );
+  }
+  const budget = makeCommandBudget(budgetMs, now);
+  const settled = await withTimeout(
+    Promise.resolve()
+      .then(() => saveFn())
+      .then(
+        (result) => ({ ok: true, result }),
+        (error) => ({ ok: false, error }),
+      ),
+    budget.bounded(),
+    () => WORKFLOW_SAVE_TIMEOUT,
+  );
+  if (settled === WORKFLOW_SAVE_TIMEOUT || settled == null) {
+    let observed = {};
+    try {
+      observed = typeof observeWorkflow === "function" ? observeWorkflow() || {} : {};
+    } catch {
+      observed = {};
+    }
+    throw new Error(
+      describeWorkflowSaveTimeout({
+        budgetMs: budget.totalMs,
+        modified: observed.modified,
+        persisted: observed.persisted,
+        filename: observed.filename,
+      }),
+    );
+  }
+  if (settled.ok !== true) {
+    if (settled.error instanceof Error) throw settled.error;
+    throw new Error(
+      settled.error == null ? "workflow_save failed" : String(settled.error),
+    );
+  }
+  return settled.result;
+}

--- a/web/js/lib/workflow-save-budget.js
+++ b/web/js/lib/workflow-save-budget.js
@@ -4,7 +4,7 @@
 // Field report: panel_save_workflow delivered workflow_save to the pinned tab and
 // got no acknowledgement for 15,000 ms (the orchestrator's ctx.call budget in
 // comfyui-mcp panel-tools.ts). panel_graph_outline and panel_list_workflows from
-// the SAME tab answered immediately afterward, and list_workflows still showed
+// the SAME tab answered immediately afterward, and panel_list_workflows still showed
 // persisted:true / modified:true. The tab was not backgrounded or frozen — the
 // save path's /userdata HEAD, GET and PUT are unbounded, and a server that
 // accepts those and never answers parks the reply for the whole browser timeout.


### PR DESCRIPTION
## Root cause

`panel_save_workflow` relays `workflow_save` at 15,000 ms. The handler awaited `programmaticSave` with no bound, so a `/userdata` HEAD, GET, or PUT that accepts and never answers parked the rid until the orchestrator gave up with `did not reply to "workflow_save" … the ComfyUI tab may be backgrounded or frozen`.

The reporter's tab was not frozen: `panel_graph_outline` and `panel_list_workflows` from the same tab answered immediately afterward, and list still showed `persisted:true` / `modified:true`. The retry_of token then waited on that same in-flight promise and timed out identically.

## Fix

- `web/js/lib/workflow-save-budget.js`: a 13 s command budget (2 s reply slack under the 15 s relay window). `runBoundedWorkflowSave` always settles: a hung save throws a worded refusal that reports the live dirty/persisted observation and explicitly says the tab is not frozen; a real save exception is rethrown as-is, never rewritten as a hang. The save is not cancelled (`withTimeout` never cancels).
- `web/js/comfyui-mcp-panel.js`: both `workflow_save` and `workflow_save_as` wrap `programmaticSave` in that bound and snapshot `isModified` / `isPersisted` at fire time.

## Verification

- `node --test browser_tests/unit/workflow-save-budget.test.mjs` — 10 pass. Drives the shipped `workflow_save` / `workflow_save_as` bodies extracted from the panel over the real bound, with a hanging `programmaticSave` (the reported shape: persisted, still-dirty, userdata never settles). Also: real save exceptions propagate, a completing save still reports `saved:true`, budget stays under 15 s, both handlers wire the bound.
- `node --test browser_tests/unit/workflow-save.test.mjs browser_tests/unit/new-workflow-persistence.test.mjs browser_tests/unit/save-reply-identity.test.mjs browser_tests/unit/save-as-identity.test.mjs browser_tests/unit/command-budget.test.mjs` — pass.
- `node scripts/check-panel-scope.mjs` — OK.

Fixes #1434
