### PR TITLE
fix(1357): a pasted LoadImage file with spaces is no longer flagged missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+### Fixed
+- `panel_get_errors` no longer flags a pasted LoadImage file like `pasted/image (992).png` as missing when the file is on disk and `/view` serves it (#1357)
+
 ## [0.15.13] - 2026-08-19
 
 ### Fixed

--- a/browser_tests/unit/input-asset.test.mjs
+++ b/browser_tests/unit/input-asset.test.mjs
@@ -13,6 +13,8 @@ import {
   filterServerConfirmedInputSubfolderCandidates,
   inputPathsUseWindowsSeparators,
   addComboOption,
+  inputAssetViewQuery,
+  probeInputAssetPresence,
 } from "../../web/js/lib/input-asset.js";
 
 const DEFS = {
@@ -417,4 +419,38 @@ test("addComboOption refuses to clobber a dynamic FUNCTION option source", () =>
   const w = { options: { values: fn } };
   assert.equal(addComboOption(w, "x.png"), false);
   assert.equal(w.options.values, fn, "function source left untouched");
+});
+
+function filenameParamOf(qs) {
+  const part = String(qs).split("&").find((p) => p.startsWith("filename="));
+  return part ? part.slice("filename=".length) : "";
+}
+
+test("#1357 a pasted filename with spaces decodes back to the file on disk", () => {
+  // The 17:40Z value. URLSearchParams would emit `image+%28992%29.png`;
+  // decodeURIComponent of that is `image+(992).png`, which is not on disk.
+  const ref = { filename: "image (992).png", subfolder: "pasted", type: "input" };
+  const qs = inputAssetViewQuery(ref);
+  assert.equal(decodeURIComponent(filenameParamOf(qs)), "image (992).png");
+  assert.notEqual(qs, new URLSearchParams(ref).toString());
+});
+
+test("#1357 the /view probe asks for the spaced pasted file, not a plus-encoded lookalike", async () => {
+  let route = "";
+  const verdict = await probeInputAssetPresence(
+    { filename: "image (992).png", subfolder: "pasted", type: "input" },
+    50,
+    async (r) => {
+      route = r;
+      return { ok: false, status: 206 };
+    },
+  );
+  assert.equal(verdict, true);
+  assert.match(route, /^\/view\?/);
+  assert.equal(decodeURIComponent(filenameParamOf(route.split("?")[1])), "image (992).png");
+});
+
+test("#1357 a plus in the real filename stays a plus, not a space", () => {
+  const qs = inputAssetViewQuery({ filename: "a+b.png", subfolder: "", type: "input" });
+  assert.equal(decodeURIComponent(filenameParamOf(qs)), "a+b.png");
 });

--- a/browser_tests/unit/live-combo-unenumerable-assets.test.mjs
+++ b/browser_tests/unit/live-combo-unenumerable-assets.test.mjs
@@ -32,6 +32,7 @@ import { inputAssetProbeVerdict } from "../../web/js/lib/input-asset.js";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const PANEL_JS = join(HERE, "../../web/js/comfyui-mcp-panel.js");
+const INPUT_ASSET_JS = join(HERE, "../../web/js/lib/input-asset.js");
 
 /** An /object_info/<class> body in the shape verified live in #745. */
 const classBody = (name, required) => ({ [name]: { input: { required } } });
@@ -51,6 +52,8 @@ const CKPT = classBody("CheckpointLoaderSimple", {
 });
 
 const NESTED = "AgentLibrary/HaReen/Main-9-1.png";
+/** The 17:40Z reproduction: ComfyUI paste names duplicates `image (N).png`. */
+const PASTED = "pasted/image (992).png";
 
 test("#1357 a server-CONFIRMED nested upload value is not reported at all", async () => {
   const probed = [];
@@ -69,6 +72,25 @@ test("#1357 a server-CONFIRMED nested upload value is not reported at all", asyn
   // Probed at the path LoadImage itself would resolve.
   assert.deepEqual(probed, [
     { value: NESTED, filename: "Main-9-1.png", subfolder: "AgentLibrary/HaReen", type: "input" },
+  ]);
+});
+
+test("#1357 a pasted LoadImage value with spaces is not reported when the server has it", async () => {
+  const probed = [];
+  const r = await scanComboAvailability(
+    [node(46, "LoadImage", [{ name: "image", value: PASTED }])],
+    async () => LOAD_IMAGE,
+    {
+      confirmServerAsset: (value, ref) => {
+        probed.push({ value, ...ref });
+        return true;
+      },
+    },
+  );
+  assert.deepEqual(r.unavailable, []);
+  assert.deepEqual(r.unknown, []);
+  assert.deepEqual(probed, [
+    { value: PASTED, filename: "image (992).png", subfolder: "pasted", type: "input" },
   ]);
 });
 
@@ -371,11 +393,26 @@ test("#1357 WIRING: get_errors' live scan really is given the server probe", () 
 
 test("#1357 WIRING: the probe is tri-state, and the media filter keeps its old floor", () => {
   const src = readFileSync(PANEL_JS, "utf8");
-  assert.match(src, /return inputAssetProbeVerdict\(res\);/);
+  const lib = readFileSync(INPUT_ASSET_JS, "utf8");
+  assert.match(lib, /return inputAssetProbeVerdict\(res\);/);
   // The store-driven missing-media filter must still collapse "absent" and
   // "unknown" into "keep reporting" — it has a prior assertion the scan lacks,
   // and loosening it here would silently un-ship #513/#743.
   assert.match(src, /\(await probeInputAssetPresence\(ref, probeBudget\)\) === true/);
+});
+
+test("#1357 WIRING: both /view probes percent-encode the filename, not form-encode it", () => {
+  // URLSearchParams encodes a space as `+`. The #1368 probe used that, so
+  // `image (992).png` was asked as `image+(992).png` and 404ed as missing
+  // while `/view` with encodeURIComponent (ComfyUI's own getResourceURL)
+  // returned 200/206. get_errors goes through the lib probe; set_widget
+  // builds the same query string.
+  const src = readFileSync(PANEL_JS, "utf8");
+  const lib = readFileSync(INPUT_ASSET_JS, "utf8");
+  assert.match(lib, /filename=\$\{encodeURIComponent\(String\(filename\)\)\}/);
+  assert.match(src, /probeAssetOnServer\(/);
+  assert.match(src, /inputAssetViewQuery\(\{ filename, subfolder, type: "input" \}\)/);
+  assert.doesNotMatch(src, /URLSearchParams\(\{ filename/);
 });
 
 test("#1357 WIRING: an abstention is disclosed, never left to read as clean", () => {

--- a/browser_tests/unit/set-widget-stale-combo-budget.test.mjs
+++ b/browser_tests/unit/set-widget-stale-combo-budget.test.mjs
@@ -30,6 +30,7 @@ import { withTimeout } from "../../web/js/lib/bounded-step.js";
 import { createObjectInfoCache, CACHE_OUTCOME } from "../../web/js/lib/object-info-cache.js";
 import { fetchWholeObjectInfo, objectInfoOracleFailureNote } from "../../web/js/lib/object-info-oracle.js";
 import { isRgthreeLoraRowCreation, createRgthreeLoraRow } from "../../web/js/lib/rgthree-lora-row.js";
+import { inputAssetViewQuery } from "../../web/js/lib/input-asset.js";
 import {
   PANEL_SRC,
   setWidgetCommandBudgetDeps,
@@ -222,6 +223,10 @@ const EXECUTOR_DEPS = [
   // coalescer, so the value captured at build time is exactly what that read must see:
   // the in-flight run a test started before dispatching the command.
   "nodeDefRefreshInFlight",
+  // #1357 — confirmServerAsset builds the /view query with this free name. Leaving it
+  // out of the eval harness throws ReferenceError, the catch returns false, fetchApi
+  // never runs, and #1418's hung-probe assertion reads as "skipped" instead of bounded.
+  "inputAssetViewQuery",
 ];
 
 function deferred() {
@@ -348,6 +353,7 @@ function realGraphSetWidget({
     // Captured AFTER the held-open run above has taken the slot — the value the shipped
     // refreshCombos reads before it calls the coalescer.
     nodeDefRefreshInFlight: inFlight,
+    inputAssetViewQuery,
   };
   const factory = new Function(
     ...EXECUTOR_DEPS,

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -308,8 +308,9 @@ import { runSetWidget, COMBO_REFRESH_NEVER_RAN } from "./lib/set-widget.js";
 import { declaredInputNames, runRemoveWidget } from "./lib/remove-widget.js";
 import {
   filterServerConfirmedInputSubfolderCandidates,
-  inputAssetProbeVerdict,
+  inputAssetViewQuery,
   inputPathsUseWindowsSeparators,
+  probeInputAssetPresence as probeAssetOnServer,
 } from "./lib/input-asset.js";
 import {
   GET_ERRORS_TOTAL_BUDGET_MS,
@@ -9429,25 +9430,14 @@ async function filterServerConfirmedInputSubfolderMedia(
  * confirmed miss would manufacture the exact false positive that issue reports.
  */
 async function probeInputAssetPresence(ref, timeoutMs) {
-  try {
-    if (typeof api?.fetchApi !== "function") return null;
-    const { subfolder, filename, type } = ref ?? {};
-    if (!filename || !type) return null;
-    if (!(timeoutMs > 0)) return null;
-    const qs = new URLSearchParams({ filename, subfolder: subfolder ?? "", type }).toString();
-    const res = await api.fetchApi(`/view?${qs}`, {
-      method: "GET",
-      cache: "no-store",
-      headers: { Range: "bytes=0-0" },
-      signal: AbortSignal.timeout(timeoutMs),
-    });
-    // ComfyUI's /view 404s a path it resolved but did not find. Every OTHER
-    // status (400 traversal refusal, 403, 5xx, a proxy's error page) means the
-    // question was not answered, NOT that the file is absent.
-    return inputAssetProbeVerdict(res);
-  } catch {
-    return null;
-  }
+  // ComfyUI's /view 404s a path it resolved but did not find. Every OTHER
+  // status (400 traversal refusal, 403, 5xx, a proxy's error page) means the
+  // question was not answered, NOT that the file is absent.
+  return probeAssetOnServer(
+    ref,
+    timeoutMs,
+    typeof api?.fetchApi === "function" ? (route, init) => api.fetchApi(route, init) : null,
+  );
 }
 
 /** True when EITHER missing-asset store holds a RAW candidate (isMissing !== false),
@@ -14226,7 +14216,7 @@ const GRAPH_TOOL_EXECUTORS = {
           const subfolder = i >= 0 ? v.slice(0, i) : "";
           const filename = i >= 0 ? v.slice(i + 1) : v;
           if (!filename) return false;
-          const qs = new URLSearchParams({ filename, subfolder, type: "input" }).toString();
+          const qs = inputAssetViewQuery({ filename, subfolder, type: "input" });
           // #1418 — the LAST network step in a command relayed at 30,000 ms, and until now
           // the only unbounded one: reached after a SUCCESSFUL refresh (the abandoned-join
           // refusal fires before it), so #1413's joinMs never covered it. It draws what the

--- a/web/js/lib/input-asset.js
+++ b/web/js/lib/input-asset.js
@@ -72,6 +72,50 @@ export function inputAssetProbeVerdict(res) {
 }
 
 /**
+ * Query string for a ComfyUI `/view` existence probe.
+ *
+ * Do not build this with `URLSearchParams`. That encodes a space as `+`
+ * (application/x-www-form-urlencoded), and aiohttp/yarl on some ComfyUI
+ * versions treat `+` as a literal plus, so `image (992).png` is asked as
+ * `image+(992).png` and 404s. That is the #1357 regression after #1368 —
+ * the original test value had no spaces, so the probe looked fine. Percent-
+ * encoding matches ComfyUI's own `getResourceURL` (`filename=` +
+ * encodeURIComponent): decodeURIComponent of the filename param is the file
+ * on disk.
+ */
+export function inputAssetViewQuery({ filename, subfolder = "", type = "input" } = {}) {
+  if (!filename || !type) return "";
+  return (
+    `filename=${encodeURIComponent(String(filename))}` +
+    `&subfolder=${encodeURIComponent(String(subfolder ?? ""))}` +
+    `&type=${encodeURIComponent(String(type))}`
+  );
+}
+
+/**
+ * TRI-STATE `/view` existence probe. `fetchApi` is injected so this module
+ * stays free of the ComfyUI API client. See `inputAssetProbeVerdict`.
+ */
+export async function probeInputAssetPresence(ref, timeoutMs, fetchApi) {
+  try {
+    if (typeof fetchApi !== "function") return null;
+    const { filename, type } = ref ?? {};
+    if (!filename || !type) return null;
+    if (!(timeoutMs > 0)) return null;
+    const qs = inputAssetViewQuery(ref);
+    const res = await fetchApi(`/view?${qs}`, {
+      method: "GET",
+      cache: "no-store",
+      headers: { Range: "bytes=0-0" },
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+    return inputAssetProbeVerdict(res);
+  } catch {
+    return null;
+  }
+}
+
+/**
  * `config` back, when it is an input spec's config object carrying at least one
  * UPLOAD flag; otherwise null. Callers that already hold the per-input config
  * (the live combo scan reads it straight out of `/object_info/<class>`) use this


### PR DESCRIPTION
Fixes #1357

`panel_get_errors` again reported `pasted/image (992).png` on a LoadImage node as `unavailable_widget_values.kind: "missing_asset"` after #1368, even though the nested input exists, `/view` returns 200 and 206 with the range probe, and the exact value executed. No `unchecked_nodes` entry — an asserted miss, not a disclosed abstention.

#1368 already asked the server about upload values the combo cannot enumerate. The probe built that `/view` query with `URLSearchParams`, which encodes a space as `+`. On some ComfyUI/aiohttp stacks that plus is a literal plus, so `image (992).png` was asked as `image+(992).png` and 404ed. The original #1368 value (`AgentLibrary/HaReen/Main-9-1.png`) had no spaces, so the probe looked fine.

The probe now percent-encodes like ComfyUI's own `getResourceURL`. `decodeURIComponent` of the filename param is the file on disk. A real 404 is still reported.

Worktree: `C:/Users/Artokun/code/comfyui-mcp-panel/.worktrees/wt-1357`
