### PR TITLE
feat: graph_get_virtual_types — serve the frontend's proven virtual-node registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project are documented here. This project adheres to
 ## [Unreleased]
 
 ### Added
+- `graph_get_virtual_types` bridge command reports the node types this page's LiteGraph registry proves frontend-virtual (`isVirtualNode === true` on a probe instance of the registered class — KJNodes' Get/Set bus, rgthree's Label / Fast Groups toggles, and any pack that sets the same flag), so the orchestrator's headless `check_runtime` can consult the authority instead of a name list (comfyui-mcp#1400)
 - `graph_configure_app_mode` sets ComfyUI App Mode inputs, outputs, and default mode on the live canvas without clobbering `extra.comfyui_mcp` (#1429)
 - `graph_save_subgraph` can replace a user-published blueprint in place with `overwrite:true` — no Save dialog, bundled/global blueprints stay protected (#1122)
 - `panel_remove_node` accepts `node_ids` and removes every listed node in one undo step — one Ctrl+Z restores them all, and a single reply names what left and what did not (#841)

--- a/browser_tests/unit/virtual-registry.test.mjs
+++ b/browser_tests/unit/virtual-registry.test.mjs
@@ -1,0 +1,176 @@
+// comfyui-mcp#1400 — the frontend's virtual-node registry, served headlessly.
+//
+// `check_runtime` (the paid-API classifier in comfyui-mcp) is headless: it has a
+// graph and /object_info and no node instances, so a third-party VIRTUAL node
+// (rgthree's Label / Fast Groups toggles, KJNodes' Get/Set bus) read as
+// "unknown" and collapsed the whole verdict. This module is the authority it
+// could not consult: the types THIS page's LiteGraph registry proves virtual, by
+// constructing one probe instance of each registered class and reading the same
+// `isVirtualNode === true` flag ComfyUI's own serializer reads (see
+// lib/frontend-virtual-nodes.js for the derivation).
+//
+// EVERY positive test below is paired with its fail-closed twin: a class that
+// does not set the flag, sets it non-exactly, carries backend provenance, or
+// throws on construction must yield NOTHING — the headless classifier keeps its
+// cautious "unknown" for those, which is the direction that costs a question,
+// never a wrong "free".
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+import { collectFrontendVirtualTypes } from "../../web/js/lib/virtual-registry.js";
+import { commandIsCanvasIndependent } from "../../web/js/lib/workflow-chat-identity.js";
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "../..");
+const PANEL = readFileSync(join(ROOT, "web/js/comfyui-mcp-panel.js"), "utf8");
+
+// ── the classes under probe ──────────────────────────────────────────────────
+
+/** A KJNodes-style virtual class: the flag is set unconditionally in the ctor. */
+class KjStyleBusNode {
+  constructor() {
+    this.properties = {};
+    this.isVirtualNode = true;
+  }
+}
+
+/** An rgthree-style virtual class: its base ctor THROWS on the default title, so
+ *  a probe that passes no title never sees the flag. */
+class RgthreeStyleVirtualNode {
+  constructor(title = "__NEED_CLASS_TITLE__") {
+    if (title === "__NEED_CLASS_TITLE__") throw new Error("needs overrides");
+    this.title = title;
+    this.isVirtualNode = true;
+  }
+}
+
+/** A frontend-registered class that is NOT virtual (a canvas tool, a widget). */
+class FrontendToolNode {
+  constructor() {
+    this.isVirtualNode = false;
+  }
+}
+
+/** The flag, but not EXACTLY true — a placeholder cannot forge proof. */
+class LooseFlagNode {
+  constructor() {
+    this.isVirtualNode = "true";
+  }
+}
+
+/** A backend-derived class (registerNodesFromDefs stamps static .nodeData) —
+ *  even a hypothetical one whose instances carry the flag is /object_info's
+ *  question and must never be probed into this list. */
+class BackendDefNode {
+  constructor() {
+    this.isVirtualNode = true; // unreachable: the probe must never construct this
+  }
+  static probeConstructed = false;
+}
+BackendDefNode.nodeData = { name: "BackendDefNode" };
+
+/** A class that cannot be bare-constructed (needs graph context). */
+class NeedsContextNode {
+  constructor() {
+    throw new Error("needs the live graph");
+  }
+}
+
+test("#1400 a constructor-flagged class is reported virtual", () => {
+  const registry = { GetNode: KjStyleBusNode, "Label (rgthree)": RgthreeStyleVirtualNode };
+  assert.deepEqual(collectFrontendVirtualTypes(registry), ["GetNode", "Label (rgthree)"]);
+});
+
+test("#1400 the probe passes a title — an rgthree-style sentinel-throwing ctor is covered", () => {
+  // Constructed bare, this class throws before setting the flag; the collector's
+  // whole point for rgthree is that it probes with an argument.
+  assert.throws(() => new RgthreeStyleVirtualNode());
+  assert.deepEqual(collectFrontendVirtualTypes({ "Label (rgthree)": RgthreeStyleVirtualNode }), [
+    "Label (rgthree)",
+  ]);
+});
+
+test("#1400 a registered class WITHOUT the exact flag is not reported", () => {
+  const registry = { ToolNode: FrontendToolNode, Loose: LooseFlagNode };
+  assert.deepEqual(collectFrontendVirtualTypes(registry), []);
+});
+
+test("#1400 a class with backend provenance is never even constructed", () => {
+  BackendDefNode.probeConstructed = false;
+  class Probed extends BackendDefNode {
+    constructor() {
+      BackendDefNode.probeConstructed = true;
+      super();
+    }
+  }
+  Probed.nodeData = BackendDefNode.nodeData;
+  assert.deepEqual(collectFrontendVirtualTypes({ BackendDefNode: Probed }), []);
+  assert.equal(BackendDefNode.probeConstructed, false);
+});
+
+test("#1400 a class with a static comfyClass marker is likewise skipped", () => {
+  class ComfyClassMarked extends KjStyleBusNode {}
+  ComfyClassMarked.comfyClass = "GetNode";
+  assert.deepEqual(collectFrontendVirtualTypes({ GetNode: ComfyClassMarked }), []);
+});
+
+test("#1400 a throwing constructor proves nothing and is skipped", () => {
+  const registry = { Fragile: NeedsContextNode, GetNode: KjStyleBusNode };
+  assert.deepEqual(collectFrontendVirtualTypes(registry), ["GetNode"]);
+});
+
+test("#1400 non-function entries and throwing getters exempt nothing", () => {
+  const registry = Object.create(null);
+  registry.NotAClass = { isVirtualNode: true };
+  Object.defineProperty(registry, "ThrowsOnRead", {
+    enumerable: true,
+    get() {
+      throw new Error("hostile getter");
+    },
+  });
+  registry.GetNode = KjStyleBusNode;
+  assert.deepEqual(collectFrontendVirtualTypes(registry), ["GetNode"]);
+});
+
+test("#1400 an unreadable registry yields an empty list, never a partial one", () => {
+  for (const bad of [null, undefined, 42, "registry", []]) {
+    assert.deepEqual(collectFrontendVirtualTypes(bad), [], JSON.stringify(bad));
+  }
+});
+
+test("#1400 the placeholder rig (panel#1284): a type with NO registered class lists nothing", () => {
+  // The tab never loaded the pack's JS, so litegraph minted defless placeholders
+  // on the canvas and the registry holds no class at all. There is nothing to
+  // probe — and crucially nothing is CLAIMED. This is the case a name allowlist
+  // gets wrong.
+  assert.deepEqual(collectFrontendVirtualTypes({ KSampler: FrontendToolNode }), []);
+});
+
+// ── the wiring: the answer must actually leave this page ─────────────────────
+
+test("#1400 graph_get_virtual_types is a registered bridge command", () => {
+  // Source-level, like the other executor wiring assertions in this suite: the
+  // handler must sit in GRAPH_TOOL_EXECUTORS or the dispatch answers "Unknown
+  // command".
+  assert.match(PANEL, /graph_get_virtual_types\(\)\s*\{/);
+  assert.match(PANEL, /virtual_types/);
+});
+
+test("#1400 the command reads the registry, not the canvas", () => {
+  // The handler body must take LiteGraph's registered_node_types — a canvas read
+  // would make it answer for the ACTIVE workflow, which the canvas-independence
+  // registration below then mis-describes.
+  const start = PANEL.indexOf("graph_get_virtual_types() {");
+  const handler = PANEL.slice(start, PANEL.indexOf("\n  },", start) + 1);
+  assert.match(handler, /registered_node_types/);
+  assert.doesNotMatch(handler, /getGraphCtx/);
+});
+
+test("#1400 the command is canvas-independent, or the hello-time pull is fenced", () => {
+  // The orchestrator pulls this on hello, before any workflow stamp exists to
+  // agree with; a canvas-targeted command is refused in exactly that position.
+  assert.equal(commandIsCanvasIndependent("graph_get_virtual_types"), true);
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -364,6 +364,7 @@ import { findExistingRailSlot } from "./lib/rail-slot.js";
 import { VENDORED_VOCABULARY_HASH } from "./lib/vocabulary-hash.js";
 import { managerFetchFailureMessage } from "./lib/manager-fetch-failure.js";
 import { withoutFrontendVirtualTypes } from "./lib/frontend-virtual-nodes.js";
+import { collectFrontendVirtualTypes } from "./lib/virtual-registry.js";
 import {
   unrunnableNodeIds,
   describeUnrunnable,
@@ -11032,6 +11033,42 @@ const GRAPH_TOOL_EXECUTORS = {
       node_type_count: Object.keys(defs).length,
       object_info: defs,
     };
+  },
+
+  // comfyui-mcp#1400 — the node types THIS page proves frontend-virtual
+  // (`isVirtualNode === true` on a probe instance of the registered class):
+  // KJNodes' Get/Set bus, rgthree's Label / Fast Groups toggles, litegraph's own
+  // natives, and any pack nobody has heard of that sets the same flag. The
+  // orchestrator asks on hello and publishes the answer to its spawned tool
+  // servers, whose headless `check_runtime` classifier cannot see this registry —
+  // without it every third-party virtual type lands in `unknownNodes` and
+  // collapses the paid-API verdict to "unknown" for a node that can never
+  // execute, let alone bill.
+  //
+  // Reads the GLOBAL LiteGraph registry, not any canvas: registered in
+  // CANVAS_INDEPENDENT_COMMANDS so the workflow fence does not refuse it (a
+  // hello-time pull carries no workflow stamp). Idempotent and free of graph
+  // state, so it is safe to re-ask on every reconnect.
+  //
+  // FAIL CLOSED by construction (see lib/virtual-registry.js): a class with
+  // backend provenance, a throwing constructor, or an absent flag is simply not
+  // listed, and a type that is not listed keeps the classifier's cautious
+  // "unknown". An unreadable registry answers ok:false rather than a partial
+  // list dressed up as complete.
+  graph_get_virtual_types() {
+    const LG = window.LiteGraph ?? globalThis.LiteGraph;
+    const registry = LG?.registered_node_types;
+    if (!registry || typeof registry !== "object") {
+      return {
+        ok: false,
+        reason: "registry_unavailable",
+        detail:
+          "This page's LiteGraph node registry is not readable, so no frontend " +
+          "virtual types can be proven. Nothing is reported rather than a partial list.",
+      };
+    }
+    const virtual_types = collectFrontendVirtualTypes(registry);
+    return { ok: true, virtual_types, virtual_type_count: virtual_types.length };
   },
 
   graph_get_state() {

--- a/web/js/lib/virtual-registry.js
+++ b/web/js/lib/virtual-registry.js
@@ -1,0 +1,108 @@
+// comfyui-mcp#1400 — the frontend's VIRTUAL-node registry, as a bridge answer.
+//
+// `check_runtime` (the headless paid-API classifier in comfyui-mcp) works from a
+// workflow's class_types and the server's /object_info. A type absent from
+// /object_info is reported "unknown" — cautious, and right for a type that COULD
+// be a paid node the server does not expose. But that caution collapses the
+// whole verdict for types that can never execute at all: frontend-only VIRTUAL
+// nodes (KJNodes' Get/Set bus, rgthree's Label / Fast Groups toggles, litegraph's
+// own Note/Reroute/…). #1372/#1564 exempted the names it knew; the owner declined
+// a list of third-party names — a list goes stale and then reads as authoritative.
+//
+// The authority is this page's LiteGraph registry. The signal, proven against the
+// shipped frontend 1.48.7 bundle and each pack's own source (see
+// lib/frontend-virtual-nodes.js for the full derivation), is
+// `instance.isVirtualNode === true` — the exact flag ComfyUI's serializer reads
+// to decide what never reaches the backend. frontend-virtual-nodes.js reads it
+// off LIVE node instances; this module answers for a REGISTERED TYPE that has no
+// live instance, which is check_runtime's case (it classifies a graph that is
+// usually not on the canvas yet).
+//
+// HOW: construct one probe instance of the registered class and read the flag.
+// Every pack that sets it does so unconditionally in its constructor (KJNodes
+// `this.isVirtualNode = true`, rgthree's RgthreeBaseVirtualNode, the frontend's
+// own natives), so one instance speaks for the type. The probe is never added to
+// a graph and is discarded immediately.
+//
+// FAIL-CLOSED, in every direction that matters:
+//
+//   - Classes with BACKEND PROVENANCE (a static .nodeData/.comfyClass, stamped by
+//     the frontend's registerNodesFromDefs — shared predicate with the #458 write
+//     guards, so the two cannot drift) are never probed and never reported. Those
+//     are the server's types (or a removed pack's stale husk); absence from
+//     /object_info there must stay "unknown". This also keeps the frontend's
+//     SUBGRAPH container classes out — they carry a synthesized def by design,
+//     their constructors need graph arguments a probe cannot supply, and
+//     check_runtime already recognizes subgraph instances structurally.
+//   - A constructor that THROWS (some classes need construction context a bare
+//     probe does not provide) proves nothing: the type is simply not reported,
+//     and stays "unknown" to the classifier. Cautious, never wrong.
+//   - A defless PLACEHOLDER is not a registered class at all, so it can never be
+//     probed into a false positive — the #1284 rig (GetNode/SetNode as dead
+//     placeholders in a tab that never loaded KJNodes' JS) reports NO virtual
+//     types for them, exactly as the live-instance predicate does.
+//   - The flag is re-read with `=== true` off the probe, not trusted from the
+//     class: a truthy-but-not-true value is not proof (same bar as
+//     isFrontendVirtualNode).
+//
+// What this deliberately does NOT do: maintain any list of names. A pack nobody
+// has heard of is covered on the same terms, because a virtual node whose class
+// does not set the flag is serialized into the prompt and rejected by the server
+// — a pack cannot both omit the flag and work.
+
+import { hasBackendProvenance } from "./node-resolve.js";
+
+/**
+ * The registered node types this page PROVES frontend-virtual, sorted.
+ *
+ * `registry` is LiteGraph.registered_node_types (type name → node class).
+ * Anything unreadable — no registry, a non-function entry, a throwing
+ * constructor, an unreadable flag — exempts nothing: the type is left out, and
+ * the headless classifier keeps its cautious "unknown" for it.
+ */
+export function collectFrontendVirtualTypes(registry) {
+  const out = new Set();
+  if (!registry || typeof registry !== "object") return [];
+  let names;
+  try {
+    names = Object.keys(registry);
+  } catch {
+    return [];
+  }
+  for (const type of names) {
+    let ctor;
+    try {
+      ctor = registry[type];
+    } catch {
+      continue; // a throwing getter exempts nothing
+    }
+    if (typeof ctor !== "function") continue;
+    // The server's own classes are never probed: a backend-derived (or stale
+    // backend husk) class is /object_info's question, not this registry's.
+    let backend = true;
+    try {
+      backend = hasBackendProvenance(ctor);
+    } catch {
+      continue; // a verdict we cannot read is not "frontend-only"
+    }
+    if (backend) continue;
+    let probe;
+    try {
+      // The title argument is the TYPE, not the display title: rgthree's base
+      // constructor throws on its unset "__NEED_CLASS_TITLE__" default, so a
+      // no-arg probe would refuse every rgthree class for a cosmetic reason.
+      // The probe is discarded; its title is never shown anywhere.
+      probe = new ctor(type);
+    } catch {
+      continue; // a class that cannot be bare-constructed proves nothing
+    }
+    let virtual = false;
+    try {
+      virtual = !!probe && probe.isVirtualNode === true;
+    } catch {
+      virtual = false;
+    }
+    if (virtual) out.add(type);
+  }
+  return [...out].sort();
+}

--- a/web/js/lib/workflow-chat-identity.js
+++ b/web/js/lib/workflow-chat-identity.js
@@ -385,13 +385,17 @@ export function selectorTargetsNonActiveWorkflow({ resolved, active } = {}) {
  *  active one (workflow_list, by contrast, reports the ACTIVE workflow — a
  *  stale-stamped call must not answer for the wrong tab, so it stays fenced).
  *  graph_update_node is a Manager PACK update misnamed with a graph_ prefix; it
- *  touches no graph. */
+ *  touches no graph. graph_get_virtual_types (comfyui-mcp#1400) reads the GLOBAL
+ *  LiteGraph class registry, never a canvas, and its reply describes no workflow —
+ *  and it is pulled by the orchestrator at hello, where no workflow stamp exists
+ *  to agree with. */
 const CANVAS_INDEPENDENT_COMMANDS = new Set([
   'nodes_search',
   'nodes_list',
   'nodes_install',
   'nodes_queue_status',
   'graph_update_node',
+  'graph_get_virtual_types',
   'comfy_reboot',
   'free_vram',
 ]);


### PR DESCRIPTION
## What

Part of **artokun/comfyui-mcp#1400** (the parked half — deliberately does NOT close it; the classifier side is the companion PR in comfyui-mcp).

`check_runtime` is headless: it classifies a workflow's node types against /object_info, and a type absent there is reported `unknown` — cautious, and right for a type that could be a paid node the server does not expose. But that caution collapses the whole verdict for **frontend-only VIRTUAL nodes** (rgthree's `Label` / `Fast Groups Bypasser` / `Fast Groups Muter`, KJNodes' Get/Set bus), which never execute anywhere, let alone bill. The parked issue identified the principled signal — `isVirtualNode === true`, the exact flag ComfyUI's own serializer reads to keep a node out of the prompt — and parked the bridge that would carry it. This PR is the panel half of that bridge.

## How

New bridge command **`graph_get_virtual_types`**: reports the registered node types this page *proves* frontend-virtual. `web/js/lib/virtual-registry.js`'s `collectFrontendVirtualTypes`:

- enumerates `LiteGraph.registered_node_types`;
- **never probes a class with backend provenance** (static `.nodeData`/`.comfyClass` — the shared `hasBackendProvenance` predicate the #458 write guards already use, so the two cannot drift). Those are /object_info's question, and the skip keeps subgraph container classes (which carry a synthesized def by design) out;
- **probe-constructs** each remaining class — `new cls(type)`; the title argument matters because rgthree's base constructor throws on its unset `__NEED_CLASS_TITLE__` default — and keeps the type iff the instance carries `isVirtualNode === true` (exactly, not truthy);
- anything unreadable, unregistered, or throwing lists **nothing** — fail closed, and the headless classifier keeps its cautious `unknown`.

The #1284 rig is the proof this is not a name allowlist: on a tab that never loaded KJNodes' JS, GetNode/SetNode were dead *placeholders* — no registered class, nothing to probe, nothing reported.

The command reads the GLOBAL registry, never a canvas, so it joins `CANVAS_INDEPENDENT_COMMANDS` — the orchestrator pulls it at hello, where no workflow stamp exists to fence on.

## Verification

- `npm run test:unit` — all green except the known #671 `verifyInstalled` wall-clock flake under load; `manager-install.test.mjs` re-run alone: 125/125 green.
- `npm run typecheck` — clean. i18n / tool-vocabulary / panel-scope gates — all OK (new command is a bridge command, not a `panel_*` tool, so no vocabulary entry).
- New suite `browser_tests/unit/virtual-registry.test.mjs`: 12 tests — every positive paired with its fail-closed twin (no flag / non-exact flag / backend provenance / throwing ctor / hostile getter / missing registry), plus source-level wiring assertions (executor registration, canvas-independence).
- **Mutation-checked**: probing without a title arg → RED (2 tests); loosening `=== true` to truthy → RED (1 test); dropping the provenance skip → RED (2 tests).
- Browser e2e NOT run (needs a live ComfyUI on localhost:8188).

## Notes for the companion PR (comfyui-mcp)

- Reply shape: `{ ok: true, virtual_types: string[], virtual_type_count: number }`, or `{ ok: false, reason: "registry_unavailable", detail }`.
- The comfyui-mcp side tables `BRIDGE_CMD_MIN_PANEL_VERSION.graph_get_virtual_types = "0.15.10"`, assuming this ships in the next panel release; if it ships later, that entry needs raising before the companion merges.
