### PR TITLE
fix(1443): graph edits appear on the canvas, not only in the outline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+### Fixed
+- graph mutations notify the visible canvas (and bump the frontend layout revision) so a successful edit/remove actually appears, not only in panel_graph_outline (#1443)
+
 ## [0.15.11] - 2026-08-19
 
 ### Added

--- a/browser_tests/unit/visible-canvas-ack.test.mjs
+++ b/browser_tests/unit/visible-canvas-ack.test.mjs
@@ -1,0 +1,388 @@
+/**
+ * #1443 — graph mutations must notify the ACTIVE canvas, not only the graph
+ * object `panel_graph_outline` reads.
+ *
+ * The reported failure: panel_edit_node / panel_edit_group / panel_remove_group
+ * returned success, outline showed the new 10-node group-free graph, and the
+ * user's visible canvas did not change. `graph.setDirtyCanvas` walks
+ * `list_of_graphcanvas`; after a Vue remount that list can omit the canvas the
+ * user is looking at. Vue nodes also paint from a layout store keyed on
+ * graph._version, which a raw setDirtyCanvas never bumps.
+ *
+ * These tests drive the SHIPPED helper (web/js/lib/visible-canvas-ack.js) and
+ * the panel dispatch wiring that calls it after a mutating graph command, plus
+ * the real graph_edit_node / graph_remove_group executors so a helper-only
+ * green cannot hide a dispatch that never invokes it.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+import {
+  VISIBLE_CANVAS_ACK_NOTE,
+  ackVisibleCanvasMutation,
+  findLayoutStore,
+  readCanvasRevision,
+  recommitNodeLayouts,
+  syncLayoutStoreFromGraph,
+  visibleCanvasWasNotified,
+  withVisibleCanvasAck,
+} from "../../web/js/lib/visible-canvas-ack.js";
+import { canonicalNodeId, isQualifiedNodeId } from "../../web/js/lib/node-id.js";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const PANEL_JS = join(HERE, "../../web/js/comfyui-mcp-panel.js");
+const PANEL_SRC = readFileSync(PANEL_JS, "utf8").replace(/\r\n/g, "\n");
+
+function panelFunctionStart(src, name, from = 0) {
+  const bare = src.indexOf(`function ${name}(`, from);
+  assert.notEqual(bare, -1, `could not locate ${name} in panel source`);
+  const asyncAt = bare - "async ".length;
+  return asyncAt >= 0 && src.startsWith("async ", asyncAt) ? asyncAt : bare;
+}
+
+test("#1443 graph.setDirtyCanvas alone is NOT a visible-canvas ack when the active canvas was not dirtied", () => {
+  const canvas = { dirty_canvas: false, dirty_bgcanvas: false };
+  const graph = {
+    _version: 3,
+    setDirtyCanvas() {
+      /* list_of_graphcanvas empty — the reported no-op */
+    },
+  };
+  const before = readCanvasRevision({ graph, canvas });
+  graph.setDirtyCanvas(true, true);
+  const after = readCanvasRevision({ graph, canvas });
+  assert.equal(
+    visibleCanvasWasNotified({ canvas, before, after, dirtyInvoked: false }),
+    false,
+    "a graph-list dirty that never reaches the active canvas is not an ack",
+  );
+});
+
+test("#1443 ackVisibleCanvasMutation dirties the ACTIVE canvas even when graph.setDirtyCanvas is a no-op", () => {
+  const canvas = {
+    dirty_canvas: false,
+    dirty_bgcanvas: false,
+    setDirty(fg, bg) {
+      if (fg) this.dirty_canvas = true;
+      if (bg) this.dirty_bgcanvas = true;
+    },
+  };
+  const graph = {
+    _version: 7,
+    incrementVersion() {
+      this._version += 1;
+    },
+    setDirtyCanvas() {
+      /* no-op: the canvas is not in list_of_graphcanvas */
+    },
+  };
+  const beforeVersion = graph._version;
+  const ack = ackVisibleCanvasMutation({ graph, canvas });
+  assert.equal(ack.notified, true);
+  assert.equal(canvas.dirty_canvas, true);
+  assert.equal(canvas.dirty_bgcanvas, true);
+  assert.notEqual(graph._version, beforeVersion, "Vue paints from graph._version — it must advance");
+});
+
+test("#1443 a layout store is refreshed from the live LiteGraph nodes", () => {
+  const captured = [];
+  let layoutVersion = 1;
+  const layoutStore = {
+    get layoutVersion() {
+      return layoutVersion;
+    },
+    initializeFromLiteGraph(nodes) {
+      captured.push(nodes);
+      layoutVersion += 1;
+    },
+  };
+  const graph = {
+    _nodes: [
+      { id: 4, pos: [10, 20], size: [100, 50] },
+      { id: 8, pos: [30, 40], size: [80, 60] },
+    ],
+    setDirtyCanvas() {},
+  };
+  const ack = ackVisibleCanvasMutation({ graph, canvas: { setDirty() {} }, layoutStore });
+  assert.equal(ack.notified, true);
+  assert.equal(captured.length, 1, "the live graph must be the refresh source");
+  assert.deepEqual(
+    captured[0].map((n) => n.id),
+    graph._nodes.map((n) => n.id),
+    "every live node is pushed — not a hardcoded fixture list",
+  );
+  assert.notEqual(ack.after.layoutVersion, ack.before.layoutVersion);
+});
+
+test("#1443 findLayoutStore prefers an attached store with initializeFromLiteGraph", () => {
+  const store = { initializeFromLiteGraph() {} };
+  assert.equal(findLayoutStore({ graph: { layoutStore: store } }), store);
+  assert.equal(findLayoutStore({ canvas: { layoutStore: store } }), store);
+  assert.equal(findLayoutStore({ graph: {}, canvas: {} }), null);
+  const pinia = new Map([["other", {}], ["layout", store]]);
+  assert.equal(findLayoutStore({ piniaStores: pinia }), store);
+});
+
+test("#1443 Vue-nodes recommit runs pos/size setters so the layout store is told", () => {
+  const layout = [];
+  const proto = {
+    get pos() {
+      return this._pos;
+    },
+    set pos(v) {
+      this._pos[0] = Number(v[0]);
+      this._pos[1] = Number(v[1]);
+      layout.push([Number(v[0]), Number(v[1])]);
+    },
+    get size() {
+      return this._size;
+    },
+    set size(v) {
+      this._size[0] = Number(v[0]);
+      this._size[1] = Number(v[1]);
+    },
+  };
+  const node = Object.assign(Object.create(proto), {
+    id: 1,
+    _pos: [5, 6],
+    _size: [40, 50],
+  });
+  const graph = { _nodes: [node] };
+  const n = recommitNodeLayouts(graph);
+  assert.equal(n, 1);
+  assert.deepEqual(layout, [[5, 6]], "the pos SETTER must run — in-place writes skip the layout store");
+});
+
+test("#1443 ack with vueNodes re-commits live node geometry", () => {
+  let setterRuns = 0;
+  const node = {
+    id: 2,
+    _pos: [1, 2],
+    get pos() {
+      return this._pos;
+    },
+    set pos(v) {
+      this._pos[0] = Number(v[0]);
+      this._pos[1] = Number(v[1]);
+      setterRuns += 1;
+    },
+    size: [10, 10],
+  };
+  const graph = {
+    _nodes: [node],
+    _version: 0,
+    incrementVersion() {
+      this._version += 1;
+    },
+    setDirtyCanvas() {},
+  };
+  ackVisibleCanvasMutation({ graph, vueNodes: true });
+  assert.equal(setterRuns, 1);
+});
+
+test("#1443 withVisibleCanvasAck discloses a miss and leaves a notified result alone", () => {
+  const ok = { edited: [{ node_id: 1 }] };
+  assert.equal(withVisibleCanvasAck(ok, { notified: true }), ok);
+  const missed = withVisibleCanvasAck(ok, { notified: false });
+  assert.equal(missed.canvas_ack, false);
+  assert.equal(missed.canvas_ack_note, VISIBLE_CANVAS_ACK_NOTE);
+  assert.deepEqual(missed.edited, ok.edited);
+});
+
+test("#1443 syncLayoutStoreFromGraph feeds the store the graph's own nodes", () => {
+  const graph = {
+    _nodes: [
+      { id: 11, pos: [0, 1], size: [2, 3] },
+      { id: 12, pos: [4, 5], size: [6, 7] },
+    ],
+  };
+  let received;
+  const store = {
+    initializeFromLiteGraph(nodes) {
+      received = nodes;
+    },
+  };
+  assert.equal(syncLayoutStoreFromGraph(store, graph), true);
+  assert.equal(received.length, graph._nodes.length);
+  assert.equal(received[0].id, graph._nodes[0].id);
+  assert.deepEqual(received[0].pos, [graph._nodes[0].pos[0], graph._nodes[0].pos[1]]);
+});
+
+test("#1443 dispatch acks the visible canvas AFTER a mutating graph executor succeeds", () => {
+  const idx = PANEL_SRC.indexOf("result = await executor(msg);");
+  assert.notEqual(idx, -1, "the dispatch executor call must still exist");
+  const window = PANEL_SRC.slice(idx, idx + 1800);
+  assert.match(
+    window,
+    /ackVisibleCanvasMutation\(/,
+    "the ack must run on the same path as the mutation, not a later idle task",
+  );
+  assert.match(window, /withVisibleCanvasAck\(/);
+  assert.match(window, /graphCommandMayMutateWorkflow\(msg\.cmd\)/);
+  const snapshot = window.indexOf("changeTrackerToSnapshot");
+  const ackAt = window.indexOf("ackVisibleCanvasMutation(");
+  assert.ok(ackAt > -1 && snapshot > -1, "both the tracker snapshot and the canvas ack must be present");
+});
+
+test("#1443 reads are not canvas-acked", () => {
+  // A read that dirtied the canvas would look like a mutation to the user.
+  const fence = PANEL_SRC.slice(
+    PANEL_SRC.indexOf("if (msg.cmd.startsWith(\"graph_\")"),
+    PANEL_SRC.indexOf("result = await executor(msg);"),
+  );
+  assert.match(fence, /visibleMutationTarget/);
+  assert.match(fence, /graphCommandMayMutateWorkflow\(msg\.cmd\)/);
+});
+
+test("#1443 the helper is imported by the panel", () => {
+  assert.match(PANEL_SRC, /from "\.\/lib\/visible-canvas-ack\.js"/);
+  assert.match(PANEL_SRC, /ackVisibleCanvasMutation/);
+  assert.match(PANEL_SRC, /withVisibleCanvasAck/);
+});
+
+function realGraphEditNode(getGraphCtx) {
+  const methodMatch = PANEL_SRC.match(/graph_edit_node\(args = \{\}\) \{[\s\S]*?\n  \},/);
+  assert.ok(methodMatch, "could not locate graph_edit_node in panel source");
+  const factory = new Function(
+    "getGraphCtx",
+    "resolveNode",
+    "refreshNodeArea",
+    "unsafeBypassMappings",
+    "resolveRailNode",
+    "railKindFor",
+    "canonicalNodeId",
+    "isQualifiedNodeId",
+    `const executors = { ${methodMatch[0]} }; return executors.graph_edit_node;`,
+  );
+  const graph = getGraphCtx().graph;
+  return factory(
+    getGraphCtx,
+    (_graph, id) => {
+      const node = graph._nodes.find((n) => n.id === id);
+      if (!node) throw new Error(`No node with id ${id}`);
+      return node;
+    },
+    () => {},
+    () => [],
+    () => null,
+    () => null,
+    canonicalNodeId,
+    isQualifiedNodeId,
+  );
+}
+
+test("#1443 graph_edit_node then ack: outline-visible mutation becomes canvas-visible", () => {
+  const node = {
+    id: 7,
+    pos: [0, 0],
+    size: [140, 60],
+    title: "LoadImage",
+    flags: {},
+    setSize(next) {
+      this.size = [...next];
+    },
+  };
+  const canvas = {
+    dirty_canvas: false,
+    setDirty(fg) {
+      if (fg) this.dirty_canvas = true;
+    },
+  };
+  const graph = {
+    _nodes: [node],
+    _version: 0,
+    incrementVersion() {
+      this._version += 1;
+    },
+    beforeChange() {},
+    afterChange() {},
+    setDirtyCanvas() {
+      /* no-op — the #1443 shape */
+    },
+    getNodeById(id) {
+      return id === node.id ? node : null;
+    },
+  };
+  const fn = realGraphEditNode(() => ({ graph, canvas, LG: { LGraphCanvas: { node_colors: {} } } }));
+  const result = fn({ node_id: 7, pos: [100, 200] });
+  assert.deepEqual(node.pos, [100, 200], "the graph object outline reads DID change");
+  assert.equal(canvas.dirty_canvas, false, "the executor's graph.setDirtyCanvas did not reach the canvas");
+  const ack = ackVisibleCanvasMutation({ graph, canvas });
+  const disclosed = withVisibleCanvasAck(result, ack);
+  assert.equal(ack.notified, true);
+  assert.equal(canvas.dirty_canvas, true, "the active canvas must be dirtied");
+  assert.equal(disclosed, result, "a notified canvas keeps the happy-path reply");
+});
+
+function realRemoveGroup(graph) {
+  const start = PANEL_SRC.indexOf("graph_remove_group({ group_id }) {");
+  assert.ok(start > -1, "graph_remove_group must exist");
+  const end = PANEL_SRC.indexOf("graph_set_node_mode(", start);
+  const body = PANEL_SRC.slice(start, end);
+  const resolveStart = panelFunctionStart(PANEL_SRC, "resolveGroup");
+  const resolveEnd = PANEL_SRC.indexOf("\nfunction nextGroupId", resolveStart);
+  const stillStart = panelFunctionStart(PANEL_SRC, "groupStillPresent");
+  const stillEnd = PANEL_SRC.indexOf("\nfunction describePreflightUndo", stillStart);
+  const summaryStart = panelFunctionStart(PANEL_SRC, "summarizeGroup");
+  const summaryEnd = PANEL_SRC.indexOf("\nfunction ", summaryStart + "function summarizeGroup".length);
+  return new Function(
+    "getGraphCtx",
+    "syncGraphNodeAreas",
+    "summarizeGroup",
+    "resolveGroup",
+    "groupStillPresent",
+    `"use strict";
+     const GRAPH_TOOL_EXECUTORS = { ${body} };
+     return GRAPH_TOOL_EXECUTORS.graph_remove_group;`,
+  )(
+    () => ({ graph }),
+    () => {},
+    (g, group) => ({ id: group.id, title: group.title }),
+    (g, id) => {
+      const found = (g._groups || []).find((x) => x.id === id);
+      if (!found) throw new Error(`No group with id ${id}`);
+      return found;
+    },
+    (g, group) => (g._groups || []).includes(group),
+  );
+}
+
+test("#1443 graph_remove_group then ack: a group gone from the graph is painted off the canvas", () => {
+  const group = { id: 1, title: "Box" };
+  const canvas = {
+    dirty_canvas: false,
+    setDirty(fg) {
+      if (fg) this.dirty_canvas = true;
+    },
+  };
+  const graph = {
+    _nodes: [{ id: 1, pos: [0, 0], size: [10, 10] }],
+    _groups: [group],
+    _version: 4,
+    incrementVersion() {
+      this._version += 1;
+    },
+    beforeChange() {},
+    afterChange() {},
+    setDirtyCanvas() {
+      /* no-op */
+    },
+    removeGroup(g) {
+      const i = this._groups.indexOf(g);
+      if (i >= 0) this._groups.splice(i, 1);
+    },
+  };
+  const fn = realRemoveGroup(graph);
+  const result = fn({ group_id: 1 });
+  assert.equal(graph._groups.length, 0, "outline would already report group-free");
+  assert.equal(canvas.dirty_canvas, false, "the executor did not dirty the active canvas");
+  const beforeVersion = graph._version;
+  const ack = ackVisibleCanvasMutation({ graph, canvas });
+  assert.equal(ack.notified, true);
+  assert.equal(canvas.dirty_canvas, true);
+  assert.notEqual(graph._version, beforeVersion);
+  assert.equal(result.removed.id, 1);
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -470,6 +470,7 @@ import {
   snapshotBackendDef,
 } from "./lib/add-node-widget-guard.js";
 import { sameGraphMutationContext } from "./lib/graph-mutation-context.js";
+import { ackVisibleCanvasMutation, withVisibleCanvasAck } from "./lib/visible-canvas-ack.js";
 import { isImeComposing } from "./lib/ime.js";
 import { installGraphToPromptNullSafety } from "./lib/widget-null-safety.js";
 import {
@@ -22010,6 +22011,10 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
         // has been handed to the socket below, so a large nested subgraph cannot
         // turn an already-applied graph_connect into a false timeout.
         let changeTrackerToSnapshot = null;
+        // #1443 — capture the graph/canvas the fence proved, so a successful
+        // mutation can dirty THAT canvas after the executor (graph.setDirtyCanvas
+        // only walks list_of_graphcanvas, which can omit the visible one).
+        let visibleMutationTarget = null;
         try {
           let result;
           if (msg.cmd === "ask_user") {
@@ -22276,8 +22281,11 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
               flushPendingChangeTrackerSnapshot(
                 app?.extensionManager?.workflow?.activeWorkflow?.changeTracker ?? null,
               );
-              const { graph, rootGraph } = getGraphCtx();
+              const { graph, rootGraph, canvas } = getGraphCtx();
               assertGraphBoundToActiveWorkflow(graph, rootGraph, graphCommandBindingBar(msg.cmd));
+              if (graphCommandMayMutateWorkflow(msg.cmd)) {
+                visibleMutationTarget = { graph, canvas };
+              }
             }
             // PINNED-TARGET GUARD (#349): a `workflow_path` on the command means the
             // agent's session is pinned to a SPECIFIC workflow. But every executor
@@ -22350,6 +22358,22 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
               }
             }
             result = await executor(msg);
+            // #1443 — the executor mutated LiteGraph (and outline will agree).
+            // Tell the ACTIVE canvas, bump the revision Vue nodes paint from,
+            // and disclose if that canvas never acknowledged. A miss is not a
+            // refusal: the graph already changed, and a false "nothing applied"
+            // invites a destructive retry.
+            if (visibleMutationTarget && graphCommandMayMutateWorkflow(msg.cmd)) {
+              const ack = ackVisibleCanvasMutation({
+                graph: visibleMutationTarget.graph,
+                canvas: visibleMutationTarget.canvas ?? app?.canvas,
+                vueNodes: vueNodesActive(
+                  (id) => getSetting(id),
+                  window.LiteGraph ?? globalThis.LiteGraph,
+                ),
+              });
+              result = withVisibleCanvasAck(result, ack);
+            }
             // ComfyUI's ChangeTracker snapshots on USER input events only —
             // graph.beforeChange/afterChange is not wired into it, so bridge-driven
             // mutations were invisible to undo (Ctrl+Z did nothing). An explicit

--- a/web/js/lib/visible-canvas-ack.js
+++ b/web/js/lib/visible-canvas-ack.js
@@ -1,0 +1,238 @@
+/**
+ * #1443 — a LiteGraph mutation is not a visible-canvas mutation.
+ *
+ * `graph.setDirtyCanvas` only walks `graph.list_of_graphcanvas`. After a Vue
+ * remount or canvas swap that list can omit the canvas the user is looking at,
+ * so `panel_edit_node` / `panel_edit_group` / `panel_remove_group` report
+ * success and `panel_graph_outline` (which reads the graph object) agrees,
+ * while the pixels do not move. ComfyUI frontend 1.49's Vue node renderer also
+ * draws node bodies from a layout store keyed on `graph._version` /
+ * `layoutVersion`, which a raw `setDirtyCanvas` never bumps.
+ *
+ * Notify the ACTIVE canvas (the one getGraphCtx named), bump the revision Vue
+ * watches, and re-sync a layout store when one is reachable. The mutation
+ * already happened; this is the receipt that the visible canvas was told.
+ */
+
+/** Named in the reply when the graph changed but the visible canvas did not ack. */
+export const VISIBLE_CANVAS_ACK_NOTE =
+  "The graph was mutated, but the visible canvas did not acknowledge the edit — " +
+  "panel_graph_outline already reflects the new graph, the pixels may not have moved. " +
+  "Reload the ComfyUI tab if the canvas still shows the previous layout.";
+
+/**
+ * Locate the frontend layout store, if this build exposes one. The Vue node
+ * renderer keeps positions there; `initializeFromLiteGraph` is the public
+ * refresh. Never required — older frontends have no store.
+ *
+ * @param {{ graph?: any, canvas?: any, piniaStores?: Iterable<any> | Map<any, any> }} [input]
+ */
+export function findLayoutStore({ graph, canvas, piniaStores } = {}) {
+  const candidates = [
+    graph?.layoutStore,
+    canvas?.layoutStore,
+    canvas?.graph?.layoutStore,
+    graph?.primaryCanvas?.layoutStore,
+  ];
+  // Pinia `_s` is a Map (id → store). Arrays also have `.values()`. Prefer
+  // that so a Map is not iterated as [key, value] pairs.
+  if (piniaStores && typeof piniaStores.values === "function") {
+    for (const store of piniaStores.values()) candidates.push(store);
+  } else if (piniaStores && typeof piniaStores[Symbol.iterator] === "function") {
+    for (const store of piniaStores) candidates.push(store);
+  }
+  for (const candidate of candidates) {
+    if (candidate && typeof candidate.initializeFromLiteGraph === "function") return candidate;
+  }
+  return null;
+}
+
+/**
+ * @param {{ graph?: any, canvas?: any, layoutStore?: any }} [input]
+ * @returns {{ version: number | null, layoutVersion: number | null, geometryVersion: number | null }}
+ */
+export function readCanvasRevision({ graph, canvas, layoutStore } = {}) {
+  const version = numberOrNull(graph?._version ?? graph?.revision);
+  const store = layoutStore ?? findLayoutStore({ graph, canvas });
+  return {
+    version,
+    layoutVersion: numberOrNull(store?.layoutVersion),
+    geometryVersion: numberOrNull(store?.nodeGeometryVersion),
+  };
+}
+
+function numberOrNull(value) {
+  const n = Number(value);
+  return Number.isFinite(n) ? n : null;
+}
+
+/**
+ * Push live LiteGraph geometry into a layout store. Returns whether the store
+ * accepted a refresh, not whether pixels moved.
+ *
+ * @param {any} store
+ * @param {any} graph
+ */
+export function syncLayoutStoreFromGraph(store, graph) {
+  if (!store || typeof store.initializeFromLiteGraph !== "function") return false;
+  const nodes = Array.isArray(graph?._nodes) ? graph._nodes : [];
+  const payload = [];
+  for (const node of nodes) {
+    if (!node || node.id == null) continue;
+    payload.push({
+      id: node.id,
+      pos: [Number(node.pos?.[0]) || 0, Number(node.pos?.[1]) || 0],
+      size: [Number(node.size?.[0]) || 0, Number(node.size?.[1]) || 0],
+    });
+  }
+  try {
+    store.initializeFromLiteGraph(payload);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Re-assign each node's pos/size so a Vue layout-store setter runs. Direct
+ * in-place writes (`node.pos[0] = x`) skip LGraphNode.pos's setter, which is
+ * what commits the move to the frontend layout store. Assignment is the
+ * public API; a throw on one node must not abort the rest.
+ *
+ * @param {any} graph
+ * @returns {number} nodes whose geometry was re-committed
+ */
+export function recommitNodeLayouts(graph) {
+  const nodes = graph?._nodes;
+  if (!Array.isArray(nodes)) return 0;
+  let committed = 0;
+  for (const node of nodes) {
+    if (!node) continue;
+    try {
+      const pos = node.pos;
+      if (pos && pos.length >= 2) node.pos = [Number(pos[0]), Number(pos[1])];
+      const size = node.size;
+      if (size && size.length >= 2) {
+        if (typeof node.setSize === "function") node.setSize([Number(size[0]), Number(size[1])]);
+        else node.size = [Number(size[0]), Number(size[1])];
+      }
+      committed += 1;
+    } catch {
+      /* one hostile node must not abort the rest */
+    }
+  }
+  return committed;
+}
+
+/**
+ * Did the visible canvas (or the revision Vue paints from) move?
+ *
+ * Dirty flags are the LiteGraph receipt. A version/layoutVersion bump is the
+ * Vue-nodes receipt. Invoking `canvas.setDirty` is itself a receipt when the
+ * canvas has no dirty_* flags to read.
+ */
+export function visibleCanvasWasNotified({
+  canvas,
+  before,
+  after,
+  dirtyInvoked = false,
+} = {}) {
+  if (canvas?.dirty_canvas === true || canvas?.dirty_bgcanvas === true) return true;
+  if (dirtyInvoked) return true;
+  if (after?.version != null && before?.version != null && after.version !== before.version) {
+    return true;
+  }
+  if (
+    after?.layoutVersion != null &&
+    before?.layoutVersion != null &&
+    after.layoutVersion !== before.layoutVersion
+  ) {
+    return true;
+  }
+  if (
+    after?.geometryVersion != null &&
+    before?.geometryVersion != null &&
+    after.geometryVersion !== before.geometryVersion
+  ) {
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Tell the visible canvas about an already-applied graph mutation.
+ *
+ * @param {{
+ *   graph?: any,
+ *   canvas?: any,
+ *   layoutStore?: any,
+ *   piniaStores?: Iterable<any> | Map<any, any>,
+ *   vueNodes?: boolean,
+ * }} [input]
+ * @returns {{ notified: boolean, before: object, after: object }}
+ */
+export function ackVisibleCanvasMutation({
+  graph,
+  canvas,
+  layoutStore,
+  piniaStores,
+  vueNodes = false,
+} = {}) {
+  const store = layoutStore ?? findLayoutStore({ graph, canvas, piniaStores });
+  const before = readCanvasRevision({ graph, canvas, layoutStore: store });
+
+  try {
+    graph?.setDirtyCanvas?.(true, true);
+  } catch {
+    /* graph-list dirty is best-effort; the active canvas is the one that matters */
+  }
+
+  let dirtyInvoked = false;
+  try {
+    if (typeof canvas?.setDirty === "function") {
+      canvas.setDirty(true, true);
+      dirtyInvoked = true;
+    }
+  } catch {
+    /* a throwing canvas must not hide the version bump below */
+  }
+
+  try {
+    graph?.incrementVersion?.();
+  } catch {
+    /* older frontends have no incrementVersion */
+  }
+  try {
+    graph?.change?.();
+  } catch {
+    /* on_change listeners are best-effort */
+  }
+
+  const vue = vueNodes === true;
+  if (store) syncLayoutStoreFromGraph(store, graph);
+  if (vue) recommitNodeLayouts(graph);
+
+  const after = readCanvasRevision({ graph, canvas, layoutStore: store });
+  return {
+    notified: visibleCanvasWasNotified({ canvas, before, after, dirtyInvoked }),
+    before,
+    after,
+  };
+}
+
+/**
+ * Merge the ack into a mutation result. Happy-path shape is unchanged when the
+ * canvas acknowledged. A miss is DISCLOSED rather than turned into a refusal:
+ * the graph already changed, and a false "nothing was applied" invites a
+ * destructive retry.
+ *
+ * @param {any} result
+ * @param {{ notified?: boolean } | null | undefined} ack
+ */
+export function withVisibleCanvasAck(result, ack) {
+  if (!ack || ack.notified !== false) return result;
+  if (!result || typeof result !== "object" || Array.isArray(result)) {
+    return { result, canvas_ack: false, canvas_ack_note: VISIBLE_CANVAS_ACK_NOTE };
+  }
+  return { ...result, canvas_ack: false, canvas_ack_note: VISIBLE_CANVAS_ACK_NOTE };
+}


### PR DESCRIPTION
Fixes #1443

`panel_edit_node`, `panel_edit_group`, and `panel_remove_group` wrote the LiteGraph graph and reported success — `panel_graph_outline` then showed the new node set — while the visible ComfyUI canvas did not move. `graph.setDirtyCanvas` only walks `list_of_graphcanvas`; after a Vue remount or canvas swap that list can omit the canvas the user is looking at. Frontend 1.49 Vue nodes also paint from a layout store keyed on `graph._version` / `layoutVersion`, which a raw dirty flag never bumps.

After a successful mutating graph command, the dispatch now acks the **active** canvas (`canvas.setDirty`), bumps `graph.incrementVersion`, re-syncs a reachable layout store, and re-commits node pos/size through the Vue layout-store setters. A miss is disclosed (`canvas_ack: false`) rather than turned into a refusal — the graph already changed, and a false "nothing applied" invites a destructive retry.

Worktree: `C:/Users/Artokun/code/comfyui-mcp-panel/.worktrees/wt-1443`
