### PR TITLE
fix(1444): editing a node keeps compact geometry instead of inflating it

### DIFF
--- a/browser_tests/unit/graph-edit-node.test.mjs
+++ b/browser_tests/unit/graph-edit-node.test.mjs
@@ -5,6 +5,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { canonicalNodeId, isQualifiedNodeId } from "../../web/js/lib/node-id.js";
+import { writePoint, refreshNodeArea } from "../../web/js/lib/group-geometry.js";
 import { fileURLToPath } from "node:url";
 
 const panelPath = fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url));
@@ -36,6 +37,7 @@ function realGraphEditNode(getGraphCtx, resolveNode, refreshNodeArea, unsafeBypa
     // extracted method pass against a canonicalNodeId that always returned NaN.
     "canonicalNodeId",
     "isQualifiedNodeId",
+    "writePoint",
     `const executors = { ${methodMatch[0]} }; return executors.graph_edit_node;`,
   );
   return factory(
@@ -47,6 +49,7 @@ function realGraphEditNode(getGraphCtx, resolveNode, refreshNodeArea, unsafeBypa
     railKindFor,
     canonicalNodeId,
     isQualifiedNodeId,
+    writePoint,
   );
 }
 
@@ -70,9 +73,10 @@ function realLegacyMotion(getGraphCtx, resolveNode, refreshNodeArea, unsafeBypas
     "normalizeLegacyNodeId",
     "canonicalNodeId",
     "isQualifiedNodeId",
+    "writePoint",
     `const GRAPH_TOOL_EXECUTORS = { ${methodMatch[0]} ${legacyMoveMatch[0]} ${legacyResizeMatch[0]} };
      return { move: GRAPH_TOOL_EXECUTORS.graph_move_node, resize: GRAPH_TOOL_EXECUTORS.graph_resize_node };`,
-  )(getGraphCtx, resolveNode, refreshNodeArea, unsafeBypassMappings, resolveRailNode, railKindFor, normalizeLegacyNodeId, canonicalNodeId, isQualifiedNodeId);
+  )(getGraphCtx, resolveNode, refreshNodeArea, unsafeBypassMappings, resolveRailNode, railKindFor, normalizeLegacyNodeId, canonicalNodeId, isQualifiedNodeId, writePoint);
 }
 
 function realLegacyTitle(getGraphCtx, resolveNode, refreshNodeArea, unsafeBypassMappings, resolveRailNode, railKindFor, normalizeLegacyNodeId) {
@@ -86,8 +90,9 @@ function realLegacyTitle(getGraphCtx, resolveNode, refreshNodeArea, unsafeBypass
     "normalizeLegacyNodeId",
     "canonicalNodeId",
     "isQualifiedNodeId",
+    "writePoint",
     `const GRAPH_TOOL_EXECUTORS = { ${methodMatch[0]} ${legacyTitleMatch[0]} }; return GRAPH_TOOL_EXECUTORS.graph_set_title;`,
-  )(getGraphCtx, resolveNode, refreshNodeArea, unsafeBypassMappings, resolveRailNode, railKindFor, normalizeLegacyNodeId, canonicalNodeId, isQualifiedNodeId);
+  )(getGraphCtx, resolveNode, refreshNodeArea, unsafeBypassMappings, resolveRailNode, railKindFor, normalizeLegacyNodeId, canonicalNodeId, isQualifiedNodeId, writePoint);
 }
 
 function realLegacyCollapsed(getGraphCtx, resolveNode, refreshNodeArea, unsafeBypassMappings, resolveRailNode, railKindFor, normalizeLegacyNodeId) {
@@ -101,8 +106,9 @@ function realLegacyCollapsed(getGraphCtx, resolveNode, refreshNodeArea, unsafeBy
     "normalizeLegacyNodeId",
     "canonicalNodeId",
     "isQualifiedNodeId",
+    "writePoint",
     `const GRAPH_TOOL_EXECUTORS = { ${methodMatch[0]} ${legacyCollapsedMatch[0]} }; return GRAPH_TOOL_EXECUTORS.graph_set_node_collapsed;`,
-  )(getGraphCtx, resolveNode, refreshNodeArea, unsafeBypassMappings, resolveRailNode, railKindFor, normalizeLegacyNodeId, canonicalNodeId, isQualifiedNodeId);
+  )(getGraphCtx, resolveNode, refreshNodeArea, unsafeBypassMappings, resolveRailNode, railKindFor, normalizeLegacyNodeId, canonicalNodeId, isQualifiedNodeId, writePoint);
 }
 
 function realLegacyMode(getGraphCtx, resolveNode, unsafeBypassMappings, normalizeLegacyNodeId) {
@@ -564,4 +570,109 @@ test("#538 legacy wrappers normalize canonical numeric node-id strings without w
   assert.throws(() => move({ node_id: "07", pos: [1, 2] }), /node_id must be an integer/);
   assert.throws(() => title({ node_id: "8.0", title: "wrong" }), /node_id must be an integer/);
   assert.equal(titleNode.title, "Legacy title", "invalid legacy forms are rejected before the strict editor mutates");
+});
+
+/** ComfyUI-shaped node: pos and size are views into one [x, y, w, h] Rectangle.
+ *  updateArea writes [x, y, x2, y2] into that same buffer — the #1444 inflation
+ *  (height becomes y+h, then the next stack/move compounds to tens of thousands). */
+function makeRectBackedNode(id, { pos = [100, 200], size = [210, 80] } = {}) {
+  const rect = new Float64Array([pos[0], pos[1], size[0], size[1]]);
+  return {
+    id,
+    title: `Node ${id}`,
+    flags: {},
+    get pos() { return rect.subarray(0, 2); },
+    set pos(v) {
+      if (!v || v.length < 2) return;
+      rect[0] = v[0];
+      rect[1] = v[1];
+    },
+    get size() { return rect.subarray(2, 4); },
+    set size(v) {
+      if (!v || v.length < 2) return;
+      rect[2] = v[0];
+      rect[3] = v[1];
+    },
+    setSize(s) { this.size = s; },
+    boundingRect: rect,
+    updateArea() {
+      const x = this.pos[0];
+      const y = this.pos[1];
+      const w = this.size[0];
+      const h = this.size[1];
+      rect[0] = x;
+      rect[1] = y;
+      rect[2] = x + w;
+      rect[3] = y + h;
+    },
+  };
+}
+
+test("#1444 a move does not inflate size when pos/size share a Rectangle buffer", () => {
+  const node = makeRectBackedNode(1, { pos: [100, 200], size: [210, 80] });
+  const startedWidth = node.size[0];
+  const startedHeight = node.size[1];
+  const events = [];
+  const graph = {
+    beforeChange: () => events.push("before"),
+    afterChange: () => events.push("after"),
+    setDirtyCanvas: () => events.push("dirty"),
+    getNodeById: (id) => (id === 1 ? node : null),
+  };
+  // Real refreshNodeArea so updateArea actually runs after the pos write, like
+  // the shipped GRAPH_TOOL_EXECUTORS path.
+  const edit = realGraphEditNode(
+    () => ({ graph, LG: { LGraphCanvas: { node_colors: {} } } }),
+    (_g, id) => {
+      if (id !== 1) throw new Error(`No node with id ${id}`);
+      return node;
+    },
+    refreshNodeArea,
+    () => [],
+    () => null,
+    () => null,
+  );
+
+  const result = edit({ node_id: 1, pos: [400, 500] });
+  assert.equal(node.pos[0], 400);
+  assert.equal(node.pos[1], 500);
+  assert.equal(node.size[0], startedWidth, "width must stay the pre-move size, not x+w");
+  assert.equal(node.size[1], startedHeight, "height must stay the pre-move size, not y+h");
+  assert.equal(result.edited[0].after.size.length, 2);
+  assert.deepEqual(result.edited[0].after.size, [startedWidth, startedHeight]);
+  assert.deepEqual(result.edited[0].after.pos, [400, 500]);
+});
+
+test("#1444 rejects a tens-of-thousands size without mutating the node", () => {
+  const node = makeNode(1, { pos: [40, 60], size: [210, 80] });
+  const { fn, events } = setup([node]);
+  const beforeSize = [node.size[0], node.size[1]];
+  const beforePos = [node.pos[0], node.pos[1]];
+  // Reporter's LoadImage height. Must refuse before any write.
+  assert.throws(() => fn({ node_id: 1, size: [210, 49135.84375] }), /size/);
+  assert.deepEqual([node.size[0], node.size[1]], beforeSize);
+  assert.deepEqual([node.pos[0], node.pos[1]], beforePos);
+  assert.deepEqual(events, []);
+});
+
+test("#1444 rejects a billion-pixel position without mutating the node", () => {
+  const node = makeNode(1, { pos: [40, 60], size: [210, 80] });
+  const { fn, events } = setup([node]);
+  const beforePos = [node.pos[0], node.pos[1]];
+  assert.throws(() => fn({ node_id: 1, pos: [100, 1e9] }), /pos/);
+  assert.deepEqual([node.pos[0], node.pos[1]], beforePos);
+  assert.deepEqual(events, []);
+});
+
+test("#1444 setSize/onResize inflation is rolled back, not reported as success", () => {
+  const node = makeNode(1, { pos: [40, 60], size: [210, 80] });
+  const beforeSize = [node.size[0], node.size[1]];
+  node.setSize = () => {
+    // Image-preview / computeSize path that writes the reporter's LoadImage height.
+    node.size = [210, 49135.84375];
+  };
+  const { fn, events } = setup([node]);
+  assert.throws(() => fn({ node_id: 1, size: [400, 200] }), /size/);
+  assert.deepEqual([node.size[0], node.size[1]], beforeSize);
+  assert.deepEqual(events.filter((e) => e === "before" || e === "after"), ["before", "after"]);
 });

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -531,6 +531,7 @@ import {
   holdGraphItemPositions,
   describeItems,
   describeThrown,
+  writePoint,
 } from "./lib/group-geometry.js";
 import {
   activeWorkflowPossiblyStale,
@@ -14451,11 +14452,25 @@ const GRAPH_TOOL_EXECUTORS = {
     if (own("preset") && (own("color") || own("bgcolor"))) {
       throw new Error("preset cannot be combined with color or bgcolor");
     }
-    if (own("pos") && (!Array.isArray(args.pos) || args.pos.length !== 2 || !args.pos.every(Number.isFinite))) {
-      throw new Error("pos must be [x, y] finite numbers");
+    // #1444 — read [0],[1] only. ComfyUI backs pos/size with a 4-float Rectangle;
+    // spreading that container reports [x, y, w, h] as "size" (height = y) and a
+    // later setSize of those first two numbers inflates the node to its position.
+    const pair = (p) => {
+      const x = Number(p?.[0]);
+      const y = Number(p?.[1]);
+      return Number.isFinite(x) && Number.isFinite(y) ? [x, y] : null;
+    };
+    // Compact nodes are a few hundred px; image previews stay below 8K. Tens of
+    // thousands are the corrupted-geometry signature from #1444, not a real node.
+    const MAX_NODE_SIZE = 16384;
+    const MAX_NODE_COORD = 1e6;
+    const sizeSane = (s) => s && s[0] > 0 && s[1] > 0 && s[0] <= MAX_NODE_SIZE && s[1] <= MAX_NODE_SIZE;
+    const posSane = (p) => p && Math.abs(p[0]) <= MAX_NODE_COORD && Math.abs(p[1]) <= MAX_NODE_COORD;
+    if (own("pos") && (!Array.isArray(args.pos) || args.pos.length !== 2 || !posSane(pair(args.pos)))) {
+      throw new Error("pos must be [x, y] finite numbers within a reasonable canvas range");
     }
-    if (own("size") && (!Array.isArray(args.size) || args.size.length !== 2 || !args.size.every((n) => Number.isFinite(n) && n > 0))) {
-      throw new Error("size must be two positive numbers");
+    if (own("size") && (!Array.isArray(args.size) || args.size.length !== 2 || !sizeSane(pair(args.size)))) {
+      throw new Error("size must be two positive numbers within a reasonable canvas range");
     }
     if (own("title") && typeof args.title !== "string") throw new Error("title must be a string");
     if (own("shape") && !["default", "box", "round", "card"].includes(args.shape)) {
@@ -14523,8 +14538,8 @@ const GRAPH_TOOL_EXECUTORS = {
     }
     const snapshot = (node) => ({
       node,
-      pos: [...(node.pos ?? [])],
-      size: [...(node.size ?? [])],
+      pos: pair(node.pos) ?? [],
+      size: pair(node.size) ?? [],
       title: node.title,
       hasColor: Object.prototype.hasOwnProperty.call(node, "color"),
       color: node.color,
@@ -14538,24 +14553,34 @@ const GRAPH_TOOL_EXECUTORS = {
       mode: node.mode,
     });
     const before = nodes.map(snapshot);
-    const restore = (s) => {
-      const node = s.node;
-      const currentPos = [...(node.pos ?? [])];
-      node.pos = [...s.pos];
-      // Re-run LiteGraph's geometry path for targets that already accepted the edit:
-      // setSize carries widget/layout side effects which a raw node.size assignment
-      // cannot undo. If an extension rejects restoration too, preserve the captured
-      // geometry directly rather than leaving a partial transaction behind.
+    const writeSize = (node, size) => {
+      if (!size || size.length < 2) return false;
       let restoredSize = false;
       if (typeof node.setSize === "function") {
         try {
-          node.setSize([...s.size]);
-          restoredSize = node.size?.[0] === s.size[0] && node.size?.[1] === s.size[1];
+          node.setSize([size[0], size[1]]);
+          const now = pair(node.size);
+          restoredSize = !!now && now[0] === size[0] && now[1] === size[1];
         } catch {
           // Fall through to the authoritative snapshot assignment below.
         }
       }
-      if (!restoredSize) node.size = [...s.size];
+      if (!restoredSize) {
+        if (!writePoint(node, "size", size[0], size[1])) node.size = [size[0], size[1]];
+      }
+      const now = pair(node.size);
+      return !!now && now[0] === size[0] && now[1] === size[1];
+    };
+    const restore = (s) => {
+      const node = s.node;
+      const currentPos = pair(node.pos) ?? [];
+      if (s.pos.length >= 2) writePoint(node, "pos", s.pos[0], s.pos[1]);
+      else node.pos = [...s.pos];
+      // Re-run LiteGraph's geometry path for targets that already accepted the edit:
+      // setSize carries widget/layout side effects which a raw node.size assignment
+      // cannot undo. If an extension rejects restoration too, preserve the captured
+      // geometry directly rather than leaving a partial transaction behind.
+      writeSize(node, s.size);
       refreshNodeArea(node, currentPos);
       node.title = s.title;
       if (s.hasColor) node.color = s.color;
@@ -14571,8 +14596,8 @@ const GRAPH_TOOL_EXECUTORS = {
     };
     const summarize = (node) => ({
       node_id: node.id,
-      pos: [...(node.pos ?? [])],
-      size: [...(node.size ?? [])],
+      pos: pair(node.pos) ?? [],
+      size: pair(node.size) ?? [],
       title: node.title,
       color: node.color ?? null,
       bgcolor: node.bgcolor ?? null,
@@ -14586,15 +14611,41 @@ const GRAPH_TOOL_EXECUTORS = {
     graph.beforeChange?.();
     try {
       for (const node of nodes) {
+        const snap = before[nodes.indexOf(node)];
         if (own("pos")) {
-          const previous = [...(node.pos ?? [])];
-          node.pos = [Number(args.pos[0]), Number(args.pos[1])];
+          const previous = pair(node.pos) ?? [0, 0];
+          const next = pair(args.pos);
+          writePoint(node, "pos", next[0], next[1]);
           refreshNodeArea(node, previous);
+          // Shared-buffer updateArea + delta-sync can apply the move twice
+          // (pos becomes x+(x-oldX)). Pin the requested point.
+          const landed = pair(node.pos);
+          if (!landed || landed[0] !== next[0] || landed[1] !== next[1]) {
+            writePoint(node, "pos", next[0], next[1]);
+          }
+          if (!posSane(pair(node.pos))) {
+            throw new Error("pos must be [x, y] finite numbers within a reasonable canvas range");
+          }
         }
         if (own("size")) {
-          const size = [Number(args.size[0]), Number(args.size[1])];
+          const size = pair(args.size);
           if (typeof node.setSize === "function") node.setSize(size);
-          else node.size = size;
+          else if (!writePoint(node, "size", size[0], size[1])) node.size = size;
+          // setSize/onResize may clamp to a widget minimum. Refuse only when
+          // that path inflates to a non-node size (the #1444 signature).
+          if (!sizeSane(pair(node.size))) {
+            throw new Error("size must be two positive numbers within a reasonable canvas range");
+          }
+        } else if (snap.size.length >= 2) {
+          // #1444 — a move/title/color must not let updateArea rewrite size from
+          // a shared Rectangle (height becomes y, then tens of thousands).
+          const now = pair(node.size);
+          if (!now || now[0] !== snap.size[0] || now[1] !== snap.size[1]) {
+            writeSize(node, snap.size);
+          }
+          if (!sizeSane(pair(node.size))) {
+            throw new Error("size must be two positive numbers within a reasonable canvas range");
+          }
         }
         if (own("title")) node.title = args.title;
         if (palette) {


### PR DESCRIPTION
Fixes #1444

`panel_edit_node` could report success after writing node `size`/`pos` in the tens of thousands (LoadImage height 49135, CLIPLoader y=132312). ComfyUI backs `pos` and `size` with views into one `[x, y, w, h]` Rectangle. Spreading that container, then letting `updateArea`/`setSize` rewrite it, turned height into `y+h`; the next edit stacked on that and the canvas grew without bound.

This keeps the shipped `graph_edit_node` path:

- Read/write only `[0],[1]` (never spread a 4-float rect into size)
- Write through `writePoint` so layout-store setters and typed-array views both land
- Pin unedited size after a move, so `refreshNodeArea` cannot inflate it
- Reject requested or resulting geometry that is not a compact node

A unit test drives the real editor against a Rectangle-backed node whose `updateArea` writes `[x, y, x2, y2]` into the shared buffer — the reporter's inflation — and against the 49135-pixel LoadImage height.
