### PR TITLE
fix(1447): unknown-type add no longer reports an unrelated ReActor import failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+### Fixed
+- adding an unknown node type no longer reports an unrelated ReActor import failure when that pack currently provides other live types (#1447)
+
 ## [0.15.15] - 2026-08-20
 
 ### Fixed

--- a/browser_tests/unit/pack-import-failures.test.mjs
+++ b/browser_tests/unit/pack-import-failures.test.mjs
@@ -22,6 +22,7 @@ import {
   packsThatFailedToImport,
   importFailureNote,
   readPackImportFailures,
+  dropLivePackImportFailures,
 } from "../../web/js/lib/pack-import-failures.js";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
@@ -216,6 +217,115 @@ test("#775 a reader that THROWS does not replace the refusal", async () => {
 test("#775 WIRING: the panel supplies the reader to the add-node resolver", () => {
   const src = readFileSync(PANEL_JS, "utf8");
   assert.match(src, /readImportFailures: \(\) => readPackImportFailures\(api\)/);
+});
+
+// ---------------------------------------------------------------------------
+// #1447: an import-failure note must not name a pack that is currently live.
+// ---------------------------------------------------------------------------
+
+test("#1447 a pack that currently provides types is dropped from the note", () => {
+  // ReActorFaceSwap in the live /object_info is proof comfyui-reactor-node
+  // registered. Naming it as the reason VideoToImages is missing is the report.
+  const live = {
+    KSampler: { python_module: "nodes" },
+    ReActorFaceSwap: { python_module: "custom_nodes.comfyui-reactor-node" },
+  };
+  assert.deepEqual(
+    dropLivePackImportFailures(["comfyui-reactor-node"], live),
+    [],
+  );
+});
+
+test("#1447 hyphen/underscore/case in the folder still identify the same pack", () => {
+  const live = {
+    ReActorFaceSwap: { python_module: "custom_nodes.comfyui_reactor_node.nodes" },
+  };
+  assert.deepEqual(
+    dropLivePackImportFailures(["ComfyUI-Reactor-Node"], live),
+    [],
+  );
+});
+
+test("#1447 a pack with NO live types is kept — that is still the #775 case", () => {
+  // ComfyUI-LTXVideo failed to import, so none of ITS types are in /object_info.
+  // Core LTX nodes from comfy_extras do not exonerate it.
+  const live = {
+    KSampler: { python_module: "nodes" },
+    LTXVImgToVideo: { python_module: "comfy_extras.nodes_lt" },
+  };
+  assert.deepEqual(
+    dropLivePackImportFailures(["ComfyUI-LTXVideo", "comfyui-reactor-node"], live),
+    ["ComfyUI-LTXVideo", "comfyui-reactor-node"],
+  );
+});
+
+test("#1447 no python_module evidence leaves the list alone", () => {
+  // A stub map without python_module must not silently eat the #775 note.
+  assert.deepEqual(
+    dropLivePackImportFailures(["ComfyUI-LTXVideo"], { KSampler: {} }),
+    ["ComfyUI-LTXVideo"],
+  );
+  assert.deepEqual(dropLivePackImportFailures(["ComfyUI-LTXVideo"], null), [
+    "ComfyUI-LTXVideo",
+  ]);
+});
+
+test("#1447 panel_add_node of VideoToImages does not name a live ReActor pack", async () => {
+  // The shipped add-node guard, on the reporter's sequence: ReActorFaceSwap is
+  // on the backend, VideoToImages is not, the log still has an old reactor
+  // IMPORT FAILED line. The refusal must stay a refusal and must not append
+  // that pack as if it owned the missing type.
+  const { assertAddNodeResolvableRefreshing } = await import(
+    "../../web/js/lib/node-resolve.js"
+  );
+  const err = await assertAddNodeResolvableRefreshing({}, "VideoToImages", {
+    getFreshObjectInfo: async () => ({
+      KSampler: { python_module: "nodes" },
+      ReActorFaceSwap: { python_module: "custom_nodes.comfyui-reactor-node" },
+    }),
+    wasTypeEverDefined: () => false,
+    readImportFailures: async () => ["comfyui-reactor-node"],
+  }).then(
+    () => null,
+    (e) => e,
+  );
+  assert.ok(err, "an absent type must still be refused");
+  assert.match(err.message, /Unknown node type "VideoToImages"/);
+  assert.doesNotMatch(err.message, /comfyui-reactor-node/);
+  assert.doesNotMatch(err.message, /FAILED TO IMPORT/);
+});
+
+test("#1447 a leftover failure is labelled as not owning the requested type", async () => {
+  // A pack that really did fail (no live types) is still worth naming — #775 —
+  // but must not read as the cause of an unrelated class_type.
+  const { assertAddNodeResolvableRefreshing } = await import(
+    "../../web/js/lib/node-resolve.js"
+  );
+  const err = await assertAddNodeResolvableRefreshing({}, "VideoToImages", {
+    getFreshObjectInfo: async () => ({
+      KSampler: { python_module: "nodes" },
+      ReActorFaceSwap: { python_module: "custom_nodes.comfyui-reactor-node" },
+    }),
+    wasTypeEverDefined: () => false,
+    readImportFailures: async () => ["comfyui-reactor-node", "ComfyUI-LTXVideo"],
+  }).then(
+    () => null,
+    (e) => e,
+  );
+  assert.match(err.message, /ComfyUI-LTXVideo/);
+  assert.doesNotMatch(err.message, /comfyui-reactor-node/);
+  assert.match(err.message, /does not prove it provides "VideoToImages"/);
+  assert.match(err.message, /may be unrelated/);
+});
+
+test("#1447 importFailureNote itself drops a live pack", () => {
+  const note = importFailureNote(["comfyui-reactor-node"], {
+    forType: "VideoToImages",
+    liveDefs: {
+      ReActorFaceSwap: { python_module: "custom_nodes.comfyui-reactor-node" },
+    },
+  });
+  assert.equal(note, "");
 });
 
 test("#1180: a hanging log read cannot outlive the refusal it is explaining", async () => {

--- a/web/js/lib/node-resolve.js
+++ b/web/js/lib/node-resolve.js
@@ -561,10 +561,16 @@ export async function assertAddNodeResolvableRefreshing(getRegistry, class_type,
       // are absent from /object_info exactly as if it were gone. Installing it
       // again cannot help. I walked into that dead end myself and filed a wrong
       // diagnosis from it (ComfyUI-LTXVideo, ImportError on a core rename).
+      // #1447 — pass the live map and the requested type so a pack that currently
+      // provides nodes (ReActorFaceSwap just added) is not named as the reason a
+      // different type (VideoToImages) is missing.
       let failedNote = "";
       if (typeof readImportFailures === "function") {
         try {
-          failedNote = importFailureNote(await readImportFailures());
+          failedNote = importFailureNote(await readImportFailures(), {
+            forType: class_type,
+            liveDefs: freshDefs,
+          });
         } catch {
           // A diagnostic that throws must not replace the refusal it explains.
         }

--- a/web/js/lib/pack-import-failures.js
+++ b/web/js/lib/pack-import-failures.js
@@ -26,6 +26,14 @@ import { readComfyLogText } from "./comfy-log.js";
  * This NAMES what failed; it does not claim the failed pack owns the missing
  * types. Establishing that needs the pack's NODE_CLASS_MAPPINGS, which is not
  * readable from the browser — so the wording stays at "check these first".
+ *
+ * #1447 — a pack that currently PROVIDES types cannot be the reason a different
+ * type is missing. ReActorFaceSwap had just been added when `panel_add_node`
+ * VideoToImages appended "comfyui-reactor-node FAILED TO IMPORT". That sentence
+ * is only true of a pack that registered NONE of its nodes; a live
+ * `python_module` on /object_info is the proof it did. Drop those before naming
+ * them. Remaining failures still do not prove ownership of the requested type,
+ * so the note says so in the type's own words.
  */
 
 // Built from the code point, never written as a literal escape. The first
@@ -71,23 +79,80 @@ export async function readPackImportFailures(api) {
   return packsThatFailedToImport(text);
 }
 
+/** Folder-name key: case, hyphens and underscores are the same pack. */
+function packKey(name) {
+  return String(name || "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "");
+}
+
+/**
+ * `python_module` is `custom_nodes.<folder>` or `custom_nodes.<folder>.<sub>`.
+ * The folder is the same path segment the IMPORT FAILED log line names.
+ * Core modules (`nodes`, `comfy_extras.*`) are not packs.
+ */
+function packKeyFromPythonModule(pythonModule) {
+  const s = String(pythonModule || "").trim();
+  const m = /^(?:custom_nodes)[./]([^./\\]+)/i.exec(s);
+  return m ? packKey(m[1]) : "";
+}
+
+/**
+ * Packs whose IMPORT FAILED line is contradicted by the live backend: at least
+ * one current /object_info entry carries their folder as `python_module`.
+ *
+ * A pack that registered types did not "register NONE of its nodes", so naming
+ * it as the reason a *different* type is missing is the #1447 misdiagnosis.
+ * No `python_module` evidence leaves the list unchanged — fail open toward the
+ * #775 note rather than silently drop a real failure.
+ *
+ * @param {string[]} failed pack names from the log
+ * @param {object|null|undefined} liveDefs current /object_info map (or absent)
+ * @returns {string[]}
+ */
+export function dropLivePackImportFailures(failed, liveDefs) {
+  if (!Array.isArray(failed) || failed.length === 0) return [];
+  if (!liveDefs || typeof liveDefs !== "object") return failed.slice();
+  const live = new Set();
+  for (const def of Object.values(liveDefs)) {
+    const key = packKeyFromPythonModule(def && typeof def === "object" ? def.python_module : "");
+    if (key) live.add(key);
+  }
+  if (live.size === 0) return failed.slice();
+  return failed.filter((name) => !live.has(packKey(name)));
+}
+
 /**
  * What to add to a missing-node message once the import failures are known.
  *
  * Empty when nothing failed — then "install the pack" really is the best advice
  * available, and adding a hedge would only dilute it.
+ *
+ * `opts.liveDefs` drops packs that currently provide types (#1447).
+ * `opts.forType` names the missing class so a leftover failure is labelled
+ * unrelated rather than read as its cause.
  */
-export function importFailureNote(failed) {
-  if (!Array.isArray(failed) || failed.length === 0) return "";
-  const list = failed.join(", ");
-  const plural = failed.length > 1;
+export function importFailureNote(failed, opts = {}) {
+  const relevant = dropLivePackImportFailures(
+    failed,
+    opts && typeof opts === "object" ? opts.liveDefs : undefined,
+  );
+  if (relevant.length === 0) return "";
+  const list = relevant.join(", ");
+  const plural = relevant.length > 1;
+  const forType = opts && typeof opts.forType === "string" ? opts.forType.trim() : "";
+  const ownership = forType
+    ? ` This does not prove ${plural ? "they provide" : "it provides"} "${forType}" — ` +
+      `the failure may be unrelated.`
+    : ` This does not prove ${plural ? "they own" : "it owns"} the ` +
+      `missing types; it is the first thing to rule out.`;
   return (
     ` BEFORE INSTALLING ANYTHING: ComfyUI reported that ${plural ? "these packs" : "this pack"} ` +
     `FAILED TO IMPORT at startup — ${list}. A pack that fails to import registers NONE of its ` +
     `nodes, so its node types are missing exactly as if it were not installed, and installing it ` +
     `again will not help. Check the server log (get_system_stats action:"logs") for the ` +
     `ImportError above ${plural ? "those lines" : "that line"} — it is usually a version mismatch ` +
-    `between the pack and ComfyUI. This does not prove ${plural ? "they own" : "it owns"} the ` +
-    `missing types; it is the first thing to rule out.`
+    `between the pack and ComfyUI.` +
+    ownership
   );
 }


### PR DESCRIPTION
Fixes #1447

`panel_add_node` of an unknown class_type such as `VideoToImages` appended every pack the ComfyUI log had marked `IMPORT FAILED`, including `comfyui-reactor-node` after `ReActorFaceSwap` had just been added on the same canvas. The named pack and the missing type are unrelated; a pack that currently provides types did not register none of its nodes.

The add-node refusal now:

- Drops import-failure names whose folder still appears as `python_module` on the live `/object_info` map
- Labels any leftover failure as not proven to provide the requested type
- Still names a pack that failed and registered nothing — the #775 LTXVideo case

A unit test drives `assertAddNodeResolvableRefreshing` (the guard `panel_add_node` uses) with the reporter's sequence: ReActor live, VideoToImages absent, reactor still in the log.
