### PR TITLE
fix(1448): panel_get_errors no longer attaches a stale execution error to a reused node id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+### Fixed
+- `panel_get_errors` no longer joins a previous workflow's runtime failure onto a current node that only shares the same id — correlation now requires matching node type as well (#1448)
+
 ## [0.15.12] - 2026-08-19
 
 ### Fixed

--- a/browser_tests/unit/exec-error-bounds.test.mjs
+++ b/browser_tests/unit/exec-error-bounds.test.mjs
@@ -22,6 +22,8 @@ import {
   EXEC_ERR_EXECUTED_CAP,
   EXEC_ERR_OUTPUTS_JSON_CAP,
   boundExecFailurePayload,
+  executionErrorMatchesCurrentGraph,
+  applyRuntimeExecFailure,
 } from "../../web/js/lib/exec-error-bounds.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -220,14 +222,123 @@ test("current_outputs omission note states the cap is fixed and names no phantom
 // EMITS through them. A revert to the verbatim emission — the exact #664
 // defect — must fail the build, not slip through (a fix on one branch was
 // once silently reverted by a later bulk rewrite; token presence ≠ wiring).
+// #1448: the argument is the correlated detail, not the raw lastExecFailure
+// capture — emitting lastExecFailure here re-joins a stale error by id alone.
 test("graph_get_errors emits the bounded payload and the verbatim emission is gone (#664)", () => {
   assert.match(
     PANEL_SOURCE,
-    /last_execution_error:\s*boundExecFailurePayload\(lastExecFailure\)/,
-    "graph_get_errors must emit lastExecFailure through boundExecFailurePayload",
+    /last_execution_error:\s*boundExecFailurePayload\(execFailureDetail\)/,
+    "graph_get_errors must emit the correlated execFailureDetail through boundExecFailurePayload",
   );
   assert.ok(
     !/last_execution_error:\s*lastExecFailure\b/.test(PANEL_SOURCE),
     "the verbatim `last_execution_error: lastExecFailure` emission must not reappear",
+  );
+  assert.ok(
+    !/last_execution_error:\s*boundExecFailurePayload\(lastExecFailure\)/.test(PANEL_SOURCE),
+    "emitting the raw lastExecFailure capture re-opens #1448 (id-only join across workflows)",
+  );
+});
+
+function nodesById(...nodes) {
+  return new Map(nodes.map((n) => [String(n.id), n]));
+}
+
+test("#1448 reporter: RCAITKLoadPipeline failure is not joined onto LoadImage id 2", () => {
+  // Measured: workflow A failed at node id 2 (RCAITKLoadPipeline,
+  // ModuleNotFoundError: No module named 'src.pipelines'). After switching to
+  // workflow B, node id 2 was LoadImage, and panel_get_errors still attached
+  // that exception to it because correlation was id-only.
+  const e = {
+    node_id: 2,
+    node_type: "RCAITKLoadPipeline",
+    exception_type: "ModuleNotFoundError",
+    exception_message: "No module named 'src.pipelines'",
+  };
+  const byId = nodesById({ id: 2, type: "LoadImage" });
+  const applied = applyRuntimeExecFailure(e, byId);
+  assert.equal(applied.detail, null, "last_execution_error must omit the foreign failure");
+  assert.equal(applied.failure, null, "clean must not be dirtied by the foreign failure");
+  assert.equal(applied.reason, null, "LoadImage must not receive an execution reason");
+  assert.equal(boundExecFailurePayload(applied.detail), null);
+  assert.equal(executionErrorMatchesCurrentGraph(e, byId), false);
+});
+
+test("#1448 a matching id AND type still reports the runtime failure", () => {
+  const e = {
+    node_id: 2,
+    node_type: "RCAITKLoadPipeline",
+    exception_type: "ModuleNotFoundError",
+    exception_message: "No module named 'src.pipelines'",
+  };
+  const byId = nodesById({ id: 2, type: "RCAITKLoadPipeline" });
+  const applied = applyRuntimeExecFailure(e, byId);
+  assert.equal(applied.detail, e);
+  assert.equal(applied.failure.node_id, 2);
+  assert.equal(applied.failure.node_type, "RCAITKLoadPipeline");
+  assert.equal(applied.failure.exception_type, "ModuleNotFoundError");
+  assert.equal(applied.failure.message, "No module named 'src.pipelines'");
+  assert.deepEqual(applied.reason, {
+    kind: "execution",
+    exception_type: "ModuleNotFoundError",
+    message: "No module named 'src.pipelines'",
+  });
+  const payload = boundExecFailurePayload(applied.detail);
+  assert.equal(payload.node_id, 2);
+  assert.equal(payload.node_type, "RCAITKLoadPipeline");
+});
+
+test("#1448 a reused id whose current node is absent from the viewed graph is omitted", () => {
+  const e = { node_id: 2, node_type: "RCAITKLoadPipeline", exception_message: "gone" };
+  const applied = applyRuntimeExecFailure(e, nodesById({ id: 9, type: "LoadImage" }));
+  assert.equal(applied.detail, null);
+  assert.equal(applied.reason, null);
+});
+
+test("#1448 missing type information fails OPEN so a genuine failure is not swallowed", () => {
+  const noErrorType = applyRuntimeExecFailure(
+    { node_id: 2, exception_message: "boom" },
+    nodesById({ id: 2, type: "LoadImage" }),
+  );
+  assert.equal(noErrorType.failure.node_id, 2);
+  assert.equal(noErrorType.reason.kind, "execution");
+
+  const noNodeType = applyRuntimeExecFailure(
+    { node_id: 2, node_type: "LoadImage", exception_message: "boom" },
+    nodesById({ id: 2 }),
+  );
+  assert.equal(noNodeType.failure.node_id, 2);
+});
+
+test("#1448 comfyClass is the type that execution_error.node_type names", () => {
+  const e = { node_id: 2, node_type: "LoadImage", exception_message: "bad image" };
+  const applied = applyRuntimeExecFailure(e, nodesById({ id: 2, type: "Load Image", comfyClass: "LoadImage" }));
+  assert.equal(applied.detail, e);
+  const mismatch = applyRuntimeExecFailure(e, nodesById({ id: 2, type: "LoadImage", comfyClass: "RCAITKLoadPipeline" }));
+  assert.equal(mismatch.detail, null);
+});
+
+test("#1448 a node-id-less failure stays graph-level — there is no node to mis-blame", () => {
+  const e = { exception_type: "RuntimeError", exception_message: "prompt failed" };
+  const applied = applyRuntimeExecFailure(e, nodesById({ id: 2, type: "LoadImage" }));
+  assert.equal(applied.detail, e);
+  assert.equal(applied.reason, null);
+  assert.equal(applied.failure.node_id, null);
+});
+
+test("graph_get_errors correlates runtime failures through applyRuntimeExecFailure (#1448)", () => {
+  assert.match(
+    PANEL_SOURCE,
+    /applyRuntimeExecFailure\(e,\s*byId\)/,
+    "graph_get_errors must correlate the captured error against the current graph's node map",
+  );
+  assert.match(
+    PANEL_SOURCE,
+    /const clean =\s*!nodeErrors &&\s*!execFailure &&/,
+    "clean must follow the correlated execFailure, not the raw lastExecFailure capture",
+  );
+  assert.ok(
+    !/const clean =\s*!nodeErrors &&\s*!lastExecFailure &&/.test(PANEL_SOURCE),
+    "clean must not be dirtied by a stale lastExecFailure from another workflow",
   );
 });

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -317,7 +317,7 @@ import {
   GET_ERRORS_STEP_CAP_MS,
   getErrorsStepBudgetMs,
 } from "./lib/get-errors-budget.js";
-import { boundExecFailurePayload } from "./lib/exec-error-bounds.js";
+import { applyRuntimeExecFailure, boundExecFailurePayload } from "./lib/exec-error-bounds.js";
 import {
   drivenWidgetsFor,
   drivenTag,
@@ -16049,28 +16049,25 @@ const GRAPH_TOOL_EXECUTORS = {
     //    below. `exception_type` is carried because "PIL.UnidentifiedImageError"
     //    explains far more than the message; the traceback is dropped HERE to stay
     //    token-bounded (a capped traceback ships in `last_execution_error`, #664).
+    //
+    //    #1448: correlate against the CURRENT graph by node id AND node type.
+    //    ComfyUI reuses ids across workflows, so an id-only join attached
+    //    workflow A's RCAITKLoadPipeline ModuleNotFoundError to workflow B's
+    //    LoadImage at the same id. A stale/foreign error is omitted from
+    //    per-node reasons, `clean`, and last_execution_error together.
     let execFailure = null;
+    let execFailureDetail = null;
     try {
       let e = lastExecFailure;
       if (!e) {
         const store = getPiniaStore("executi" + "on" + "Error");
         e = store?.["lastExecuti" + "on" + "Error"] ?? null;
       }
-      if (e) {
-        const msg = coerceMessageText(e.exception_message ?? e.message ?? "").trim();
-        execFailure = {
-          node_id: e.node_id ?? null,
-          node_type: e.node_type ?? null,
-          ...(e.exception_type ? { exception_type: e.exception_type } : {}),
-          message: msg || null,
-        };
-        if (e.node_id != null) {
-          addReason(e.node_id, {
-            kind: "execution",
-            ...(e.exception_type ? { exception_type: e.exception_type } : {}),
-            message: msg || null,
-          });
-        }
+      const applied = applyRuntimeExecFailure(e, byId);
+      execFailureDetail = applied.detail;
+      execFailure = applied.failure;
+      if (applied.reason && e?.node_id != null) {
+        addReason(e.node_id, applied.reason);
       }
     } catch {
       /* optional */
@@ -16120,7 +16117,7 @@ const GRAPH_TOOL_EXECUTORS = {
     // node fails on it at queue time whichever kind it is.
     const clean =
       !nodeErrors &&
-      !lastExecFailure &&
+      !execFailure &&
       !erroredNodes.length &&
       !missingModels.length &&
       !missingMedia.length &&
@@ -16210,7 +16207,7 @@ const GRAPH_TOOL_EXECUTORS = {
       // --- backwards-compatible payloads (existing consumers read these) ---
       // Bounded at emission (#664): verbatim, this carried tensor-sized
       // current_inputs/current_outputs and huge traceback lines (41k+ tokens).
-      last_execution_error: boundExecFailurePayload(lastExecFailure),
+      last_execution_error: boundExecFailurePayload(execFailureDetail),
       node_errors: nodeErrors,
       ...(clean ? { note: tr("panel.no_errors_recorded_since_the_last_execution", "no errors recorded since the last execution start") } : {}),
     };

--- a/web/js/lib/exec-error-bounds.js
+++ b/web/js/lib/exec-error-bounds.js
@@ -68,6 +68,69 @@ function capSerializedText(text, cap) {
 }
 
 /**
+ * True when a captured execution_error belongs on the currently-viewed graph.
+ *
+ * #1448: ComfyUI reuses node ids across workflows. Matching on id alone joined
+ * workflow A's `RCAITKLoadPipeline` ModuleNotFoundError onto workflow B's
+ * `LoadImage` that happened to also be id `2`. Correlation requires the current
+ * node at that id to still be the same type.
+ *
+ * Fail-open on missing type information so a genuine failure is never swallowed
+ * because a node has no type yet. Fail-closed when the id is present but the
+ * current node is a different type, or the id is absent from this graph. A
+ * node-id-less error is kept as graph-level: there is no node to mis-blame.
+ */
+export function executionErrorMatchesCurrentGraph(error, nodeById) {
+  if (error == null) return false;
+  if (error.node_id == null) return true;
+  if (!nodeById || typeof nodeById.get !== "function") return false;
+  let failedNode;
+  try {
+    failedNode = nodeById.get(String(error.node_id));
+  } catch {
+    return false;
+  }
+  if (!failedNode) return false;
+  const currentNodeType = failedNode.comfyClass ?? failedNode.type ?? null;
+  if (!error.node_type || currentNodeType == null || currentNodeType === "") return true;
+  return String(error.node_type) === String(currentNodeType);
+}
+
+/**
+ * Correlate a captured execution_error onto the current graph. graph_get_errors
+ * uses this for per-node `reasons`, `clean`, and `last_execution_error` so the
+ * three surfaces cannot disagree (#1448).
+ *
+ * Returns `{ detail, failure, reason }`:
+ *   - `detail` — the raw captured error (for last_execution_error), or null
+ *   - `failure` — the slim summary used for `clean` / red-outline classification
+ *   - `reason` — the per-node `{kind:"execution", ...}` payload, or null
+ *
+ * A stale or foreign error returns all-null.
+ */
+export function applyRuntimeExecFailure(error, nodeById) {
+  if (!executionErrorMatchesCurrentGraph(error, nodeById)) {
+    return { detail: null, failure: null, reason: null };
+  }
+  const msg = coerceMessageText(error.exception_message ?? error.message ?? "").trim();
+  const failure = {
+    node_id: error.node_id ?? null,
+    node_type: error.node_type ?? null,
+    ...(error.exception_type ? { exception_type: error.exception_type } : {}),
+    message: msg || null,
+  };
+  const reason =
+    error.node_id != null
+      ? {
+          kind: "execution",
+          ...(error.exception_type ? { exception_type: error.exception_type } : {}),
+          message: msg || null,
+        }
+      : null;
+  return { detail: error, failure, reason };
+}
+
+/**
  * Bounded form of one captured execution_error detail. `null` in → `null` out
  * (no failure stays "no failure"); a non-object detail is coerced into the
  * message rather than dropped, so a failure is never reported as absent.


### PR DESCRIPTION
Fixes #1448

## What the user now observes

After switching workflows, `panel_get_errors` no longer joins the previous workflow's runtime failure onto a current node that only happens to reuse the same id.

The reporter's case: workflow A failed at node id 2 (`RCAITKLoadPipeline`, `ModuleNotFoundError: No module named 'src.pipelines'`). Workflow B's node id 2 is a `LoadImage`. `panel_get_errors` now omits that stale failure from per-node reasons, from `clean`, and from `last_execution_error`. A genuine failure of the same id **and** type still reports.

## Why

ComfyUI reuses node ids across workflows. `graph_get_errors` correlated `lastExecFailure` by id only, so a foreign error was attached to whichever current node occupied that id.

## Fix

Runtime execution errors are correlated against the current graph by node id **and** node type (`applyRuntimeExecFailure`). A stale/foreign error is omitted from all three surfaces together.

## Tests

`node --test browser_tests/unit/exec-error-bounds.test.mjs` — reporter case plus source-guards that `graph_get_errors` actually wires the correlated detail.
