### PR TITLE
fix(mcp#1827): promoted parent widget values survive inner subgraph edits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project are documented here. This project adheres to
 - `graph_unexpose_subgraph_input` / `graph_unexpose_subgraph_output` remove a subgraph boundary slot by name — the inverse of the expose pair; dropped interior/host wires are counted and reported (artokun/comfyui-mcp#1294)
 
 ### Fixed
+- entering a copied subgraph, editing its inner graph, and exiting no longer clears promoted widget values on the parent instances (artokun/comfyui-mcp#1827)
 - `panel_get_errors` no longer flags a pasted LoadImage file like `pasted/image (992).png` as missing when the file is on disk and `/view` serves it (#1357)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,15 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+### Fixed
+- entering a copied subgraph, editing its inner graph, and exiting no longer clears promoted widget values on the parent instances (artokun/comfyui-mcp#1827)
+
 ## [0.15.14] - 2026-08-19
 
 ### Added
 - `graph_unexpose_subgraph_input` / `graph_unexpose_subgraph_output` remove a subgraph boundary slot by name — the inverse of the expose pair; dropped interior/host wires are counted and reported (artokun/comfyui-mcp#1294)
 
 ### Fixed
-- entering a copied subgraph, editing its inner graph, and exiting no longer clears promoted widget values on the parent instances (artokun/comfyui-mcp#1827)
 - `panel_get_errors` no longer flags a pasted LoadImage file like `pasted/image (992).png` as missing when the file is on disk and `/view` serves it (#1357)
 
 ### Added

--- a/browser_tests/unit/subgraph-instance-widgets.test.mjs
+++ b/browser_tests/unit/subgraph-instance-widgets.test.mjs
@@ -1,0 +1,222 @@
+/**
+ * comfyui-mcp#1827 — after panel_enter_subgraph on a COPIED subgraph, adding and
+ * rewiring inner nodes (without touching the promoted STRING), then
+ * panel_exit_subgraph, both parent instances showed widgets.text="" .
+ *
+ * The frontend reconfigures every instance of the shared definition and reseeds
+ * the per-instance store from the INNER widget (or leaves the rail empty). The
+ * panel snapshots instance-scoped rails before the inner mutation and writes
+ * them back after.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+import {
+  collectSubgraphInstanceNodes,
+  snapshotPromotedInstanceWidgets,
+  restorePromotedInstanceWidgets,
+  withPreservedPromotedInstanceWidgets,
+} from "../../web/js/lib/subgraph-instance-widgets.js";
+
+const ROOT_GRAPH_ID = "c4a254bb-935e-4013-b380-5e36954de4b0";
+const SRC = readFileSync(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8");
+
+/**
+ * Two wrappers, one shared Subgraph — the copied-subgraph shape. Each instance
+ * has its own store-backed promoted STRING; the inner CLIPTextEncode keeps the
+ * template default.
+ */
+function makeCopiedSubgraph({ definitionValue = "TEMPLATE-DEFAULT" } = {}) {
+  const inner = {
+    id: 10,
+    type: "CLIPTextEncode",
+    widgets: [{ name: "text", type: "STRING", value: definitionValue }],
+  };
+  const subgraph = { id: "sg-uuid", _nodes: [inner] };
+  const store = new Map();
+
+  function instance(id, text) {
+    const widgetId = `${ROOT_GRAPH_ID}:${encodeURIComponent(String(id))}:${encodeURIComponent("text")}`;
+    store.set(widgetId, { name: "text", type: "STRING", value: text });
+    const rail = {
+      name: "text",
+      type: "STRING",
+      get widgetId() {
+        return widgetId;
+      },
+      get value() {
+        return store.get(widgetId)?.value;
+      },
+      set value(next) {
+        const state = store.get(widgetId);
+        if (state) state.value = next;
+      },
+      callback(next) {
+        const state = store.get(widgetId);
+        if (state) state.value = next;
+      },
+    };
+    const input = { name: "text", widgetId, _widget: rail };
+    const node = {
+      id,
+      type: subgraph.id,
+      subgraph,
+      inputs: [input],
+      get widgets() {
+        return [rail];
+      },
+    };
+    return { node, rail, widgetId };
+  }
+
+  /** What SubgraphNode.configure + _setWidget does to copied instances. */
+  function wipeInstanceOverrides(to = "") {
+    for (const state of store.values()) state.value = to;
+  }
+
+  return { inner, subgraph, store, instance, wipeInstanceOverrides };
+}
+
+test("#1827 collectSubgraphInstanceNodes finds every copy that shares the definition", () => {
+  const sg = makeCopiedSubgraph();
+  const a = sg.instance(82, "A");
+  const b = sg.instance(116, "B");
+  const other = { id: 3, type: "KSampler", subgraph: { id: "other" } };
+  const root = { _nodes: [a.node, b.node, other] };
+  const found = collectSubgraphInstanceNodes(root, sg.subgraph);
+  assert.deepEqual(
+    found.map((n) => n.id).sort((x, y) => x - y),
+    [82, 116],
+  );
+});
+
+test("#1827 collect matches a copy by type UUID even when the subgraph object was cloned", () => {
+  const sg = makeCopiedSubgraph();
+  const a = sg.instance(82, "A");
+  const cloneDef = { id: "sg-uuid", _nodes: sg.subgraph._nodes };
+  const b = sg.instance(116, "B");
+  b.node.subgraph = cloneDef;
+  const root = { _nodes: [a.node, b.node] };
+  const found = collectSubgraphInstanceNodes(root, sg.subgraph);
+  assert.equal(found.length, 2);
+});
+
+test("#1827: enter → inner mutation → exit keeps each copy's promoted STRING", async () => {
+  const sg = makeCopiedSubgraph();
+  const a = sg.instance(82, "INSTANCE-A-PROMPT");
+  const b = sg.instance(116, "INSTANCE-B-PROMPT");
+  const root = { _nodes: [a.node, b.node] };
+
+  await withPreservedPromotedInstanceWidgets(root, sg.subgraph, () => {
+    // Inner graph mutation: add/rewire nodes. The promoted STRING is not touched.
+    sg.subgraph._nodes.push({ id: 11, type: "Note" });
+    sg.wipeInstanceOverrides("");
+    assert.equal(a.rail.value, "", "the frontend wipe is what the reporter read");
+    assert.equal(b.rail.value, "");
+  });
+
+  assert.equal(a.rail.value, "INSTANCE-A-PROMPT");
+  assert.equal(b.rail.value, "INSTANCE-B-PROMPT");
+  assert.equal(sg.inner.widgets[0].value, "TEMPLATE-DEFAULT", "the shared definition must not move");
+});
+
+test("#1827 restore does not write the shared inner widget", () => {
+  const sg = makeCopiedSubgraph();
+  const a = sg.instance(82, "INSTANCE-A-PROMPT");
+  const root = { _nodes: [a.node] };
+  const snap = snapshotPromotedInstanceWidgets(root, sg.subgraph);
+  sg.wipeInstanceOverrides("");
+  sg.inner.widgets[0].value = "TEMPLATE-DEFAULT";
+  restorePromotedInstanceWidgets(root, snap);
+  assert.equal(sg.inner.widgets[0].value, "TEMPLATE-DEFAULT");
+  assert.equal(a.rail.value, "INSTANCE-A-PROMPT");
+});
+
+test("#1827 a definition-scoped rail (no widgetId) is not written — that store is the inner widget", () => {
+  const inner = { widgets: [{ name: "text", value: "TEMPLATE-DEFAULT" }] };
+  const subgraph = { id: "sg-uuid", _nodes: [inner] };
+  const rail = {
+    name: "text",
+    get value() {
+      return inner.widgets[0].value;
+    },
+    set value(next) {
+      inner.widgets[0].value = next;
+    },
+  };
+  const node = {
+    id: 82,
+    type: "sg-uuid",
+    subgraph,
+    inputs: [{ name: "text" }],
+    widgets: [rail],
+  };
+  const root = { _nodes: [node] };
+  const snap = snapshotPromotedInstanceWidgets(root, subgraph);
+  inner.widgets[0].value = "";
+  const res = restorePromotedInstanceWidgets(root, snap);
+  assert.equal(res.restored, 0);
+  assert.equal(inner.widgets[0].value, "", "must not broadcast the snapshot into the definition");
+});
+
+test("#1827 an unexposed widget is skipped, not invented", () => {
+  const sg = makeCopiedSubgraph();
+  const a = sg.instance(82, "INSTANCE-A-PROMPT");
+  const root = { _nodes: [a.node] };
+  const snap = snapshotPromotedInstanceWidgets(root, sg.subgraph);
+  a.node.inputs = [];
+  Object.defineProperty(a.node, "widgets", { get: () => [] });
+  const res = restorePromotedInstanceWidgets(root, snap);
+  assert.equal(res.restored, 0);
+  assert.equal(res.skipped, 1);
+});
+
+test("#1827 empty string, 0 and false are snapshotted — they are real values", () => {
+  const sg = makeCopiedSubgraph();
+  const a = sg.instance(82, "");
+  const root = { _nodes: [a.node] };
+  const snap = snapshotPromotedInstanceWidgets(root, sg.subgraph);
+  assert.equal(snap.entries[0].value, "");
+  a.rail.value = "CHANGED";
+  restorePromotedInstanceWidgets(root, snap);
+  assert.equal(a.rail.value, "");
+});
+
+test("#1827 withPreserved is a no-op at the root graph", async () => {
+  let ran = 0;
+  const root = { _nodes: [] };
+  const out = await withPreservedPromotedInstanceWidgets(root, root, () => {
+    ran += 1;
+    return "ok";
+  });
+  assert.equal(out, "ok");
+  assert.equal(ran, 1);
+});
+
+test("#1827 restore still runs when the inner mutation throws", async () => {
+  const sg = makeCopiedSubgraph();
+  const a = sg.instance(82, "INSTANCE-A-PROMPT");
+  const root = { _nodes: [a.node] };
+  await assert.rejects(
+    withPreservedPromotedInstanceWidgets(root, sg.subgraph, () => {
+      sg.wipeInstanceOverrides("");
+      throw new Error("connect threw after wiring");
+    }),
+    /connect threw/,
+  );
+  assert.equal(a.rail.value, "INSTANCE-A-PROMPT", "a throw must not keep the wiped rails");
+});
+
+test("#1827 the dispatcher snapshots before a subgraph mutation and restores after", () => {
+  assert.match(
+    SRC,
+    /withPreservedPromotedInstanceWidgets/,
+    "inner mutations must run inside the preserve wrapper, not only have the helper imported",
+  );
+  assert.match(
+    SRC,
+    /visibleMutationTarget\.graph !== visibleMutationTarget\.rootGraph/,
+    "preserve only while INSIDE a subgraph — the reported enter/mutate/exit path",
+  );
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -230,6 +230,7 @@ import {
   materializedValuesNote,
   findDivergentPromotedValues,
 } from "./lib/unpack-promoted-values.js";
+import { withPreservedPromotedInstanceWidgets } from "./lib/subgraph-instance-widgets.js";
 import {
   snapshotExternalLinks,
   verifyExternalLinks,
@@ -22477,7 +22478,7 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
               const { graph, rootGraph, canvas } = getGraphCtx();
               assertGraphBoundToActiveWorkflow(graph, rootGraph, graphCommandBindingBar(msg.cmd));
               if (graphCommandMayMutateWorkflow(msg.cmd)) {
-                visibleMutationTarget = { graph, canvas };
+                visibleMutationTarget = { graph, canvas, rootGraph };
               }
             }
             // PINNED-TARGET GUARD (#349): a `workflow_path` on the command means the
@@ -22550,7 +22551,25 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
                 );
               }
             }
-            result = await executor(msg);
+            // #1827 — copied subgraph instances share one definition. An inner
+            // add/rewire reconfigures every wrapper and reseeds promoted rails
+            // from the INNER widget, which clears instance STRING overrides.
+            // Snapshot the parent rails before the mutation and write them back
+            // after (rail only — never the shared inner widget).
+            const runExecutor = () => executor(msg);
+            if (
+              visibleMutationTarget?.graph &&
+              visibleMutationTarget.rootGraph &&
+              visibleMutationTarget.graph !== visibleMutationTarget.rootGraph
+            ) {
+              result = await withPreservedPromotedInstanceWidgets(
+                visibleMutationTarget.rootGraph,
+                visibleMutationTarget.graph,
+                runExecutor,
+              );
+            } else {
+              result = await runExecutor();
+            }
             // #1443 — the executor mutated LiteGraph (and outline will agree).
             // Tell the ACTIVE canvas, bump the revision Vue nodes paint from,
             // and disclose if that canvas never acknowledged. A miss is not a

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -22556,7 +22556,6 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
             // from the INNER widget, which clears instance STRING overrides.
             // Snapshot the parent rails before the mutation and write them back
             // after (rail only — never the shared inner widget).
-            const runExecutor = () => executor(msg);
             if (
               visibleMutationTarget?.graph &&
               visibleMutationTarget.rootGraph &&
@@ -22565,10 +22564,10 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
               result = await withPreservedPromotedInstanceWidgets(
                 visibleMutationTarget.rootGraph,
                 visibleMutationTarget.graph,
-                runExecutor,
+                () => executor(msg),
               );
             } else {
-              result = await runExecutor();
+              result = await executor(msg);
             }
             // #1443 — the executor mutated LiteGraph (and outline will agree).
             // Tell the ACTIVE canvas, bump the revision Vue nodes paint from,

--- a/web/js/lib/subgraph-instance-widgets.js
+++ b/web/js/lib/subgraph-instance-widgets.js
@@ -1,0 +1,230 @@
+/**
+ * comfyui-mcp#1827 — keep instance-scoped promoted widget values when a subgraph
+ * DEFINITION is updated.
+ *
+ * Copied subgraph nodes share one `Subgraph` object (`clone()` does not deep-clone).
+ * Entering a copy, adding/rewiring inner nodes, then exiting caused ComfyUI to
+ * reconfigure every instance of that definition. `SubgraphNode.configure` recreates
+ * host inputs WITHOUT `widgetId`, so `_applyPromotedWidgetValues` is a no-op, and
+ * `_setWidget` then seeds the per-instance store from the INNER widget (or leaves
+ * the rail as `""`). `panel_query_graph` showed `widgets.text=""` on every copy;
+ * `inner_previous` still held the template default.
+ *
+ * The panel cannot stop the frontend replacing the definition. It can snapshot the
+ * parent rails BEFORE an inner mutation and write them back AFTER, once widgetIds
+ * exist again. Restore writes the RAIL only — never the shared inner widget.
+ */
+
+import { promotedValueScope } from "./widget-write.js";
+
+function cloneValue(value) {
+  if (value == null || typeof value !== "object") return value;
+  try {
+    if (typeof structuredClone === "function") return structuredClone(value);
+  } catch {
+    /* JSON fallback below */
+  }
+  try {
+    return JSON.parse(JSON.stringify(value));
+  } catch {
+    return value;
+  }
+}
+
+function valuesMatch(a, b) {
+  if (Object.is(a, b)) return true;
+  if (a == null || b == null) return false;
+  if (typeof a !== "object" || typeof b !== "object") return false;
+  try {
+    return JSON.stringify(a) === JSON.stringify(b);
+  } catch {
+    return false;
+  }
+}
+
+function subgraphIdentity(subgraph) {
+  if (!subgraph || typeof subgraph !== "object") return null;
+  if (subgraph.id != null) return String(subgraph.id);
+  return null;
+}
+
+/**
+ * Every SubgraphNode that instances `subgraph`. Copied wrappers share the object
+ * AND the type UUID (`SubgraphNode.type === subgraph.id`); match either so a
+ * clone that did not keep object identity still restores.
+ */
+export function collectSubgraphInstanceNodes(rootGraph, subgraph) {
+  const out = [];
+  if (!rootGraph || !subgraph) return out;
+  const wantId = subgraphIdentity(subgraph);
+  const stack = [rootGraph];
+  const seen = new Set();
+  while (stack.length) {
+    const graph = stack.pop();
+    if (!graph || seen.has(graph)) continue;
+    seen.add(graph);
+    for (const node of graph._nodes ?? []) {
+      if (!node) continue;
+      if (node.subgraph) stack.push(node.subgraph);
+      const sameObject = node.subgraph === subgraph;
+      const sameId =
+        wantId != null &&
+        (String(node.subgraph?.id ?? "") === wantId || String(node.type ?? "") === wantId);
+      if (sameObject || sameId) out.push(node);
+    }
+  }
+  return out;
+}
+
+function readRails(node) {
+  let widgets;
+  try {
+    widgets = node?.widgets;
+  } catch {
+    return [];
+  }
+  if (!Array.isArray(widgets)) return [];
+  const out = [];
+  for (const rail of widgets) {
+    if (!rail || typeof rail.name !== "string" || !rail.name) continue;
+    let value;
+    try {
+      value = rail.value;
+    } catch {
+      continue;
+    }
+    let widgetId = null;
+    try {
+      widgetId = typeof rail.widgetId === "string" && rail.widgetId ? rail.widgetId : null;
+    } catch {
+      widgetId = null;
+    }
+    if (!widgetId) {
+      const input = (node.inputs ?? []).find((inp) => inp && inp.name === rail.name);
+      try {
+        widgetId = typeof input?.widgetId === "string" && input.widgetId ? input.widgetId : null;
+      } catch {
+        widgetId = null;
+      }
+    }
+    out.push({ name: rail.name, value, widgetId, rail });
+  }
+  return out;
+}
+
+function findRail(node, widgetName, widgetId) {
+  const rails = readRails(node);
+  if (widgetId) {
+    const byId = rails.find((r) => r.widgetId === widgetId);
+    if (byId) return byId;
+  }
+  return rails.find((r) => r.name === widgetName) ?? null;
+}
+
+function hostInputFor(node, widgetName, widgetId) {
+  const inputs = node?.inputs;
+  if (!Array.isArray(inputs)) return widgetId ? { widgetId } : { name: widgetName };
+  if (widgetId) {
+    const byId = inputs.find((inp) => inp && inp.widgetId === widgetId);
+    if (byId) return byId;
+  }
+  return inputs.find((inp) => inp && inp.name === widgetName) ?? { widgetId, name: widgetName };
+}
+
+/**
+ * @returns {{ subgraph: object, entries: Array<{ nodeId: *, widgetName: string, value: *, widgetId: string | null }> }}
+ */
+export function snapshotPromotedInstanceWidgets(rootGraph, subgraph) {
+  const entries = [];
+  for (const node of collectSubgraphInstanceNodes(rootGraph, subgraph)) {
+    for (const rail of readRails(node)) {
+      entries.push({
+        nodeId: node.id,
+        widgetName: rail.name,
+        value: cloneValue(rail.value),
+        widgetId: rail.widgetId,
+      });
+    }
+  }
+  return { subgraph, entries };
+}
+
+/**
+ * Write snapshotted instance values back onto matching parent rails. Skips a
+ * rail that is definition-scoped (no per-instance `widgetId`) so a restore
+ * cannot broadcast into the shared inner widget. Missing rails (unexposed
+ * since the snapshot) are skipped, not invented.
+ *
+ * @returns {{ restored: number, skipped: number }}
+ */
+export function restorePromotedInstanceWidgets(rootGraph, snapshot) {
+  const result = { restored: 0, skipped: 0 };
+  if (!snapshot || !Array.isArray(snapshot.entries) || snapshot.entries.length === 0) {
+    return result;
+  }
+  const instances = collectSubgraphInstanceNodes(rootGraph, snapshot.subgraph);
+  const byId = new Map();
+  for (const node of instances) {
+    if (node?.id != null) byId.set(String(node.id), node);
+  }
+  for (const entry of snapshot.entries) {
+    const node = byId.get(String(entry.nodeId));
+    if (!node) {
+      result.skipped += 1;
+      continue;
+    }
+    const found = findRail(node, entry.widgetName, entry.widgetId);
+    if (!found) {
+      result.skipped += 1;
+      continue;
+    }
+    const hostInput = hostInputFor(node, entry.widgetName, entry.widgetId ?? found.widgetId);
+    if (promotedValueScope(node, hostInput) !== "instance") {
+      result.skipped += 1;
+      continue;
+    }
+    if (valuesMatch(found.value, entry.value)) {
+      result.skipped += 1;
+      continue;
+    }
+    const next = cloneValue(entry.value);
+    try {
+      found.rail.value = next;
+    } catch {
+      result.skipped += 1;
+      continue;
+    }
+    if (typeof found.rail.callback === "function") {
+      try {
+        found.rail.callback(next);
+      } catch {
+        /* setter is the store; a callback throw must not undo a landed restore */
+      }
+    }
+    result.restored += 1;
+  }
+  return result;
+}
+
+/**
+ * Snapshot instance-scoped promoted rails, run `fn`, then restore. Used around
+ * inner-graph mutations (and exit) so a definition replace cannot keep the
+ * empty rails it just wrote. `fn` may be sync or async.
+ *
+ * A frontend `queueMicrotask` may delete a store entry AFTER the mutation
+ * returns; one microtask flush runs before restore so that delete lands first.
+ */
+export async function withPreservedPromotedInstanceWidgets(rootGraph, subgraph, fn) {
+  if (!rootGraph || !subgraph || rootGraph === subgraph) return fn();
+  const snapshot = snapshotPromotedInstanceWidgets(rootGraph, subgraph);
+  try {
+    return await fn();
+  } finally {
+    try {
+      await Promise.resolve();
+    } catch {
+      /* a hostile thenable must not skip restore */
+    }
+    restorePromotedInstanceWidgets(rootGraph, snapshot);
+  }
+}


### PR DESCRIPTION
Copied subgraph instances share one definition. After `panel_enter_subgraph` on a copy, adding or rewiring inner nodes (without touching the promoted STRING) then `panel_exit_subgraph` left both parent instances with `widgets.text=""`. `panel_set_widget` recovery showed `previous=""` while `inner_previous` still held the template default. Silent — no exception.

ComfyUI reseeds promoted rails from the inner widget when the subgraph definition is updated. Snapshot instance-scoped parent rails before an inner-graph mutation and write them back after (rail only, never the shared inner widget).

Fixes artokun/comfyui-mcp#1827
