### PR TITLE
fix(1455): the save timeout reports what it observed, never that the write landed

### DIFF
--- a/browser_tests/unit/workflow-save-budget.test.mjs
+++ b/browser_tests/unit/workflow-save-budget.test.mjs
@@ -284,7 +284,9 @@ test("#1434: BOTH save handlers wrap programmaticSave in the bound — the helpe
 });
 
 // ---------------------------------------------------------------------------
-// #1455 — the reply reports OBSERVATIONS, never an inference the flags cannot support.
+// #1455 — the reply reports OBSERVATIONS, and is explicit about WHICH workflow
+// they belong to. The save's destination is the requested name, never a guess
+// made from whichever workflow happens to be active.
 // ---------------------------------------------------------------------------
 
 test("#1455: modified:false is reported, never resolved into 'the write landed'", () => {
@@ -294,63 +296,93 @@ test("#1455: modified:false is reported, never resolved into 'the write landed'"
     persisted: true,
     filename: "Clean.json",
   });
-  // The flag is still surfaced — the caller should see what was read.
   assert.match(text, /modified:false/);
   assert.match(text, /persisted:true/);
-  // But it is never turned into a verdict. isModified === false is equally the state
-  // of a workflow that was never dirty, and the frontend's save() forces past the
-  // isPersisted && !isModified early return, so a clean workflow reaches a hanging PUT
-  // with the flag already false.
+  // isModified === false is equally the state of a workflow that was never dirty, and
+  // save() forces past the isPersisted && !isModified early return, so a clean workflow
+  // reaches a hanging PUT with the flag already false.
   assert.doesNotMatch(text, /the write landed/);
   assert.match(text, /UNDETERMINED/);
-  // The old remedy read the SAME flag, so it cannot settle the question.
   assert.doesNotMatch(text, /Check panel_list_workflows before retrying/);
 });
 
-test("#1455: modified:true still carries its one-directional meaning", () => {
+test("#1455: modified:true keeps its one-directional meaning", () => {
   const text = describeWorkflowSaveTimeout({
     budgetMs: WORKFLOW_SAVE_COMMAND_BUDGET_MS,
     modified: true,
     persisted: true,
     filename: "Dirty.json",
   });
-  // true IS evidence: the canvas has not been marked clean, so nothing was acknowledged.
   assert.match(text, /has not been acknowledged as landed/);
   assert.doesNotMatch(text, /UNDETERMINED/);
 });
 
-test("#1455: a Save-As swap does not attribute the hung write to the previous file", () => {
+test("#1455: a Save-As names the DESTINATION, not the source it was copied from", () => {
+  // workflow-save.js:1353 calls openWorkflow(copy) BEFORE saveWorkflow(copy), so by the
+  // time the budget fires the canvas already shows the copy. The source is the one file
+  // this route provably never writes — naming it would send the caller to read the wrong
+  // file and conclude the save was fine.
+  const text = describeWorkflowSaveTimeout({
+    budgetMs: WORKFLOW_SAVE_COMMAND_BUDGET_MS,
+    modified: true,
+    persisted: false,
+    filename: "Copy.json",
+    requested: "Copy.json",
+    previousActive: "Original.json",
+  });
+  assert.match(text, /for "Copy\.json"/);
+  assert.doesNotMatch(text, /for "Original\.json"/);
+  assert.match(text, /modified:true/);
+});
+
+test("#1455: a known destination with the canvas elsewhere withholds the foreign flags", () => {
   const text = describeWorkflowSaveTimeout({
     budgetMs: WORKFLOW_SAVE_COMMAND_BUDGET_MS,
     modified: false,
-    persisted: false,
-    filename: "NewName.json",
-    subject: "Old.json",
-    subjectChanged: true,
+    persisted: true,
+    filename: "Something else.json",
+    requested: "Copy.json",
+    previousActive: "Original.json",
   });
-  // The subject is the save's TARGET, not whatever is active when the budget fires.
-  assert.match(text, /for "Old\.json"/);
-  assert.match(text, /active workflow changed to "NewName\.json"/);
-  // Flags belonging to a different workflow must not be reported as the target's.
+  assert.match(text, /for "Copy\.json"/);
+  // Those flags belong to another workflow; reporting them here would be a wrong-target
+  // claim of exactly the kind this issue is about.
   assert.doesNotMatch(text, /modified:false/);
-  assert.match(text, /cannot say whether its write completed/);
+  assert.match(text, /do not describe "Copy\.json"/);
 });
 
-test("#1455 WIRING: the target is captured BEFORE the save, not at timeout-fire time", async () => {
-  // The /userdata HEAD probe can hang before any swap, so an observer read at fire time
-  // can name a workflow that was never the target. Deleting the pre-capture makes this
-  // report "After.json" — the wrong file.
+test("#1455: an un-named save whose canvas moved says the target is undeterminable", () => {
+  // First-save auto-naming. "I cannot tell which file" must not collapse into the
+  // in-place case, which is the same failure the modified:false half of this issue is.
+  const text = describeWorkflowSaveTimeout({
+    budgetMs: WORKFLOW_SAVE_COMMAND_BUDGET_MS,
+    modified: false,
+    persisted: true,
+    filename: "Real name.json",
+    previousActive: "Unsaved Workflow (2)",
+  });
+  assert.match(text, /cannot be determined from here/);
+  assert.match(text, /changed from "Unsaved Workflow \(2\)" to "Real name\.json"/);
+  // No file is named as the target, because none is known to be.
+  assert.doesNotMatch(text, /for "Unsaved Workflow \(2\)"/);
+  assert.doesNotMatch(text, /for "Real name\.json"/);
+});
+
+test("#1455 WIRING: the requested name reaches the reply as the destination", async () => {
+  // Deleting `targetName` at either call site drops the only authoritative signal and
+  // sends the reply back to guessing from the active workflow.
   let call = 0;
   const observeWorkflow = () => {
     call += 1;
     return call === 1
-      ? { modified: true, persisted: true, filename: "Before.json" }
-      : { modified: false, persisted: false, filename: "After.json" };
+      ? { modified: true, persisted: true, filename: "Original.json" }
+      : { modified: true, persisted: false, filename: "Copy.json" };
   };
   await assert.rejects(
     () =>
       runBoundedWorkflowSave(() => new Promise(() => {}), {
         budgetMs: 40,
+        targetName: "Copy.json",
         withTimeout: async (p, ms, onTimeout) => {
           const t = new Promise((r) => setTimeout(() => r(onTimeout()), ms));
           return Promise.race([p, t]);
@@ -358,10 +390,21 @@ test("#1455 WIRING: the target is captured BEFORE the save, not at timeout-fire 
         observeWorkflow,
       }),
     (err) => {
-      assert.match(err.message, /for "Before\.json"/, "names the save's target");
-      assert.match(err.message, /changed to "After\.json"/, "discloses the swap");
+      assert.match(err.message, /for "Copy\.json"/, "names the requested destination");
+      assert.doesNotMatch(err.message, /for "Original\.json"/, "never the source");
       return true;
     },
   );
-  assert.ok(call >= 2, "observed both before the save and at the budget");
+  assert.ok(call >= 2, "observed before the save and at the budget");
+});
+
+test("#1455 WIRING: BOTH save handlers pass the requested name to the bound save", () => {
+  // A one-line option at a call site is invisible to a helper-level test: deleting
+  // `targetName: name` leaves every assertion above green while the shipped reply
+  // goes back to guessing the destination from whatever is active. Assert on the SOURCE.
+  const panel = PANEL_SRC;
+  const passes = panel.match(/targetName: name,/g) ?? [];
+  const bound = panel.match(/runBoundedWorkflowSave\(/g) ?? [];
+  assert.equal(bound.length, 2, "exactly two bounded save call sites (workflow_save, workflow_save_as)");
+  assert.equal(passes.length, 2, "both of them pass the destination name");
 });

--- a/browser_tests/unit/workflow-save-budget.test.mjs
+++ b/browser_tests/unit/workflow-save-budget.test.mjs
@@ -155,8 +155,9 @@ test("#1434: the refusal NAMES a live tab and the dirty observation, never 'froz
   assert.match(text, /still live/);
   assert.match(text, /modified:true/);
   assert.match(text, /persisted:true/);
-  assert.match(text, /panel_list_workflows/);
   assert.match(text, /not a backgrounded or frozen tab/);
+  // #1455 — the reply must never resolve landed-ness from the dirty flag.
+  assert.doesNotMatch(text, /if modified is false the write landed/);
   // Same observation the reporter could read after the timeout.
   assert.deepEqual(
     workflowSaveTimeoutObservation({
@@ -280,4 +281,87 @@ test("#1434: BOTH save handlers wrap programmaticSave in the bound — the helpe
     /function observeActiveWorkflowSaveState\(\)/,
     "the timeout path must observe the live dirty flags, not invent them",
   );
+});
+
+// ---------------------------------------------------------------------------
+// #1455 — the reply reports OBSERVATIONS, never an inference the flags cannot support.
+// ---------------------------------------------------------------------------
+
+test("#1455: modified:false is reported, never resolved into 'the write landed'", () => {
+  const text = describeWorkflowSaveTimeout({
+    budgetMs: WORKFLOW_SAVE_COMMAND_BUDGET_MS,
+    modified: false,
+    persisted: true,
+    filename: "Clean.json",
+  });
+  // The flag is still surfaced — the caller should see what was read.
+  assert.match(text, /modified:false/);
+  assert.match(text, /persisted:true/);
+  // But it is never turned into a verdict. isModified === false is equally the state
+  // of a workflow that was never dirty, and the frontend's save() forces past the
+  // isPersisted && !isModified early return, so a clean workflow reaches a hanging PUT
+  // with the flag already false.
+  assert.doesNotMatch(text, /the write landed/);
+  assert.match(text, /UNDETERMINED/);
+  // The old remedy read the SAME flag, so it cannot settle the question.
+  assert.doesNotMatch(text, /Check panel_list_workflows before retrying/);
+});
+
+test("#1455: modified:true still carries its one-directional meaning", () => {
+  const text = describeWorkflowSaveTimeout({
+    budgetMs: WORKFLOW_SAVE_COMMAND_BUDGET_MS,
+    modified: true,
+    persisted: true,
+    filename: "Dirty.json",
+  });
+  // true IS evidence: the canvas has not been marked clean, so nothing was acknowledged.
+  assert.match(text, /has not been acknowledged as landed/);
+  assert.doesNotMatch(text, /UNDETERMINED/);
+});
+
+test("#1455: a Save-As swap does not attribute the hung write to the previous file", () => {
+  const text = describeWorkflowSaveTimeout({
+    budgetMs: WORKFLOW_SAVE_COMMAND_BUDGET_MS,
+    modified: false,
+    persisted: false,
+    filename: "NewName.json",
+    subject: "Old.json",
+    subjectChanged: true,
+  });
+  // The subject is the save's TARGET, not whatever is active when the budget fires.
+  assert.match(text, /for "Old\.json"/);
+  assert.match(text, /active workflow changed to "NewName\.json"/);
+  // Flags belonging to a different workflow must not be reported as the target's.
+  assert.doesNotMatch(text, /modified:false/);
+  assert.match(text, /cannot say whether its write completed/);
+});
+
+test("#1455 WIRING: the target is captured BEFORE the save, not at timeout-fire time", async () => {
+  // The /userdata HEAD probe can hang before any swap, so an observer read at fire time
+  // can name a workflow that was never the target. Deleting the pre-capture makes this
+  // report "After.json" — the wrong file.
+  let call = 0;
+  const observeWorkflow = () => {
+    call += 1;
+    return call === 1
+      ? { modified: true, persisted: true, filename: "Before.json" }
+      : { modified: false, persisted: false, filename: "After.json" };
+  };
+  await assert.rejects(
+    () =>
+      runBoundedWorkflowSave(() => new Promise(() => {}), {
+        budgetMs: 40,
+        withTimeout: async (p, ms, onTimeout) => {
+          const t = new Promise((r) => setTimeout(() => r(onTimeout()), ms));
+          return Promise.race([p, t]);
+        },
+        observeWorkflow,
+      }),
+    (err) => {
+      assert.match(err.message, /for "Before\.json"/, "names the save's target");
+      assert.match(err.message, /changed to "After\.json"/, "discloses the swap");
+      return true;
+    },
+  );
+  assert.ok(call >= 2, "observed both before the save and at the budget");
 });

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -16228,6 +16228,8 @@ const GRAPH_TOOL_EXECUTORS = {
         withTimeout,
         now: monotonicNow,
         observeWorkflow: observeActiveWorkflowSaveState,
+        // #1455 — the destination, not whatever the canvas shows when the budget fires.
+        targetName: name,
       },
     );
     // #978 recurrence — a FIRST save swaps the active object too, and the #557 carry
@@ -16266,6 +16268,8 @@ const GRAPH_TOOL_EXECUTORS = {
         withTimeout,
         now: monotonicNow,
         observeWorkflow: observeActiveWorkflowSaveState,
+        // #1455 — the destination, not whatever the canvas shows when the budget fires.
+        targetName: name,
       },
     );
     // #747 — this path ALWAYS changes which workflow is active, so it is the one

--- a/web/js/lib/workflow-save-budget.js
+++ b/web/js/lib/workflow-save-budget.js
@@ -56,52 +56,53 @@ export function workflowSaveTimeoutObservation(wf) {
 
 /**
  * The refusal a timed-out save throws. States that the tab is still live and what
- * the flags SAY — never what they imply about whether the write landed.
+ * the flags SAY — never what they imply about whether the write completed.
  *
- * #1455: `isModified === false` is also the state of a workflow that was never
- * dirty, so it cannot distinguish "the write landed" from "there was nothing to
- * write". The frontend's save() forces through the `isPersisted && !isModified`
+ * #1455, part 1: `isModified === false` is also the state of a workflow that was
+ * never dirty, so it cannot distinguish "the write landed" from "there was nothing
+ * to write". The frontend's save() forces through the `isPersisted && !isModified`
  * early return, so a persisted-and-clean workflow reaches a hanging PUT with the
  * flag already false. `panel_list_workflows` reports that same flag, so it cannot
  * settle it either. The honest terminal state is "could not determine".
  *
- * `subject` is the workflow the save TARGETED, captured before the save ran; the
- * /userdata HEAD probe can hang before any Save-As swap, so the workflow that is
- * active when the budget fires is not necessarily the one being saved.
+ * #1455, part 2 — WHICH workflow the reply is about. Three cases, kept apart:
+ *
+ *   · `requested` given (workflow_save_as, and any named save) — that IS the
+ *     destination, whatever the canvas is showing. The relocating routes call
+ *     `openWorkflow(copy)` BEFORE `saveWorkflow(copy)` (workflow-save.js:1353), so
+ *     the workflow active when the budget fires is normally the destination and the
+ *     workflow active *before* the save is the SOURCE — which this route never
+ *     writes. Naming either by position is a guess; the requested name is not.
+ *   · no `requested`, and the active workflow did not move — an in-place save; the
+ *     flags describe it.
+ *   · no `requested`, and the active workflow moved — first-save auto-naming. Which
+ *     file the hung write targets cannot be determined from here, and saying so is
+ *     the answer. It is NOT the same as "unchanged", and must not collapse into it.
  */
 export function describeWorkflowSaveTimeout({
   budgetMs = WORKFLOW_SAVE_COMMAND_BUDGET_MS,
   modified,
   persisted,
   filename,
-  subject,
-  subjectChanged = false,
+  requested,
+  previousActive,
 } = {}) {
   const total = Number.isFinite(budgetMs) && budgetMs > 0 ? budgetMs : WORKFLOW_SAVE_COMMAND_BUDGET_MS;
   const seconds = Math.max(1, Math.round(total / 1000));
-  // A direct caller may pass only `filename` (the pre-#1455 shape); fall back to it so
-  // the reply still names the workflow rather than degrading to "the active workflow".
-  const subjectName = typeof subject === "string" && subject ? subject : filename;
-  const target = typeof subjectName === "string" && subjectName ? `"${subjectName}"` : "the active workflow";
-  const nowActive = typeof filename === "string" && filename ? `"${filename}"` : "a different workflow";
+  const str = (v) => (typeof v === "string" && v ? v : null);
+  const dest = str(requested);
+  const active = str(filename);
+  const prior = str(previousActive);
 
-  // The active workflow moved during the budget, so the flags below describe some
-  // OTHER workflow. Reporting them against the target would be a wrong-target claim.
-  if (subjectChanged) {
-    return (
-      `workflow_save did not finish within ${seconds}s for ${target}. ` +
-      `The tab is still live — other commands from it still answer, so this is not a backgrounded or frozen tab. ` +
-      `The save may still complete in the background. The active workflow changed to ${nowActive} while the save was in flight, ` +
-      `so no dirty/persisted flag currently describes ${target} and this reply cannot say whether its write completed. ` +
-      `Confirm by reading the saved file itself before retrying — a re-issue may write twice.`
-    );
-  }
+  const head =
+    `The tab is still live — other commands from it still answer, so this is not a backgrounded or frozen tab. ` +
+    `The save may still complete in the background. `;
+  const retry = `Confirm by reading the saved file itself before retrying — a re-issue may write twice.`;
 
   const flags = [
     modified === true ? "modified:true" : modified === false ? "modified:false" : null,
     persisted === true ? "persisted:true" : persisted === false ? "persisted:false" : null,
   ].filter(Boolean);
-  const reads = flags.length ? `The same tab reports ${flags.join(" ")}. ` : "The tab's save flags could not be read. ";
 
   // modified:true is one-directional evidence: the canvas is still dirty, so nothing
   // has been acknowledged. modified:false proves nothing in either direction.
@@ -111,14 +112,34 @@ export function describeWorkflowSaveTimeout({
       : `These flags cannot show whether the write completed: modified:false is also the state of a workflow that was never dirty, ` +
         `and panel_list_workflows reports that same flag. Treat the outcome as UNDETERMINED. `;
 
-  return (
-    `workflow_save did not finish within ${seconds}s for ${target}. ` +
-    `The tab is still live — other commands from it still answer, so this is not a backgrounded or frozen tab. ` +
-    `The save may still complete in the background. ` +
-    reads +
-    verdict +
-    `Confirm by reading the saved file itself before retrying — a re-issue may write twice.`
-  );
+  // Case 3 — the target is genuinely unknown. Never dressed up as case 2.
+  if (!dest && prior && active && prior !== active) {
+    return (
+      `workflow_save did not finish within ${seconds}s. ` +
+      head +
+      `The active workflow changed from "${prior}" to "${active}" while the save was in flight, and no destination name was requested, ` +
+      `so which file the hung write targets cannot be determined from here. ` +
+      retry
+    );
+  }
+
+  const subject = dest ?? prior ?? active;
+  const who = subject ? `"${subject}"` : "the active workflow";
+
+  // Case 1 with a moved canvas: the destination is known, but the flags on screen
+  // belong to some other workflow. Report the target; withhold the foreign flags.
+  if (dest && active && active !== dest) {
+    return (
+      `workflow_save did not finish within ${seconds}s for ${who}. ` +
+      head +
+      `The active workflow is "${active}", not the save's destination, so its dirty/persisted flags do not describe ${who} ` +
+      `and this reply cannot say whether that write completed. ` +
+      retry
+    );
+  }
+
+  const reads = flags.length ? `The same tab reports ${flags.join(" ")}. ` : "The tab's save flags could not be read. ";
+  return `workflow_save did not finish within ${seconds}s for ${who}. ` + head + reads + verdict + retry;
 }
 
 /**
@@ -134,7 +155,7 @@ export function describeWorkflowSaveTimeout({
  */
 export async function runBoundedWorkflowSave(
   saveFn,
-  { budgetMs = WORKFLOW_SAVE_COMMAND_BUDGET_MS, now, withTimeout, observeWorkflow } = {},
+  { budgetMs = WORKFLOW_SAVE_COMMAND_BUDGET_MS, now, withTimeout, observeWorkflow, targetName } = {},
 ) {
   if (typeof saveFn !== "function") {
     throw new Error("runBoundedWorkflowSave requires a save function");
@@ -145,14 +166,15 @@ export async function runBoundedWorkflowSave(
     );
   }
   const budget = makeCommandBudget(budgetMs, now);
-  // #1455 — capture the save's TARGET before it runs. The /userdata HEAD probe can
-  // hang before any Save-As swap, so the workflow active when the budget fires is not
-  // necessarily the one being saved; naming that one blames the wrong file.
-  let target = {};
+  // #1455 — record which workflow was active BEFORE the save. This is NOT the target:
+  // the relocating routes activate the copy before the write they hang on, so it is the
+  // SOURCE. It is kept only to detect that the canvas moved, which is what makes an
+  // un-named save's destination undeterminable.
+  let priorActive = {};
   try {
-    target = typeof observeWorkflow === "function" ? observeWorkflow() || {} : {};
+    priorActive = typeof observeWorkflow === "function" ? observeWorkflow() || {} : {};
   } catch {
-    target = {};
+    priorActive = {};
   }
   const settled = await withTimeout(
     Promise.resolve()
@@ -171,23 +193,16 @@ export async function runBoundedWorkflowSave(
     } catch {
       observed = {};
     }
-    // Same workflow => its flags describe the target. Different (or unreadable)
-    // => they describe something else, and the reply must not attribute them.
-    const subject = typeof target.filename === "string" && target.filename ? target.filename : observed.filename;
-    const subjectChanged =
-      typeof subject === "string" &&
-      subject !== "" &&
-      typeof observed.filename === "string" &&
-      observed.filename !== "" &&
-      observed.filename !== subject;
     throw new Error(
       describeWorkflowSaveTimeout({
         budgetMs: budget.totalMs,
         modified: observed.modified,
         persisted: observed.persisted,
         filename: observed.filename,
-        subject,
-        subjectChanged,
+        // The requested name is the destination on every named route; the pre-save
+        // active workflow is only evidence that the canvas moved.
+        requested: targetName,
+        previousActive: priorActive.filename,
       }),
     );
   }

--- a/web/js/lib/workflow-save-budget.js
+++ b/web/js/lib/workflow-save-budget.js
@@ -55,34 +55,69 @@ export function workflowSaveTimeoutObservation(wf) {
 }
 
 /**
- * The refusal a timed-out save throws. States that the tab is still live, what
- * the dirty flag currently says, and that the write may still land — never
- * "backgrounded or frozen", which is the orchestrator's guess this report
- * disproved.
+ * The refusal a timed-out save throws. States that the tab is still live and what
+ * the flags SAY — never what they imply about whether the write landed.
+ *
+ * #1455: `isModified === false` is also the state of a workflow that was never
+ * dirty, so it cannot distinguish "the write landed" from "there was nothing to
+ * write". The frontend's save() forces through the `isPersisted && !isModified`
+ * early return, so a persisted-and-clean workflow reaches a hanging PUT with the
+ * flag already false. `panel_list_workflows` reports that same flag, so it cannot
+ * settle it either. The honest terminal state is "could not determine".
+ *
+ * `subject` is the workflow the save TARGETED, captured before the save ran; the
+ * /userdata HEAD probe can hang before any Save-As swap, so the workflow that is
+ * active when the budget fires is not necessarily the one being saved.
  */
 export function describeWorkflowSaveTimeout({
   budgetMs = WORKFLOW_SAVE_COMMAND_BUDGET_MS,
   modified,
   persisted,
   filename,
+  subject,
+  subjectChanged = false,
 } = {}) {
   const total = Number.isFinite(budgetMs) && budgetMs > 0 ? budgetMs : WORKFLOW_SAVE_COMMAND_BUDGET_MS;
   const seconds = Math.max(1, Math.round(total / 1000));
-  const who = typeof filename === "string" && filename ? `"${filename}"` : "the active workflow";
-  const dirty =
+  // A direct caller may pass only `filename` (the pre-#1455 shape); fall back to it so
+  // the reply still names the workflow rather than degrading to "the active workflow".
+  const subjectName = typeof subject === "string" && subject ? subject : filename;
+  const target = typeof subjectName === "string" && subjectName ? `"${subjectName}"` : "the active workflow";
+  const nowActive = typeof filename === "string" && filename ? `"${filename}"` : "a different workflow";
+
+  // The active workflow moved during the budget, so the flags below describe some
+  // OTHER workflow. Reporting them against the target would be a wrong-target claim.
+  if (subjectChanged) {
+    return (
+      `workflow_save did not finish within ${seconds}s for ${target}. ` +
+      `The tab is still live — other commands from it still answer, so this is not a backgrounded or frozen tab. ` +
+      `The save may still complete in the background. The active workflow changed to ${nowActive} while the save was in flight, ` +
+      `so no dirty/persisted flag currently describes ${target} and this reply cannot say whether its write completed. ` +
+      `Confirm by reading the saved file itself before retrying — a re-issue may write twice.`
+    );
+  }
+
+  const flags = [
+    modified === true ? "modified:true" : modified === false ? "modified:false" : null,
+    persisted === true ? "persisted:true" : persisted === false ? "persisted:false" : null,
+  ].filter(Boolean);
+  const reads = flags.length ? `The same tab reports ${flags.join(" ")}. ` : "The tab's save flags could not be read. ";
+
+  // modified:true is one-directional evidence: the canvas is still dirty, so nothing
+  // has been acknowledged. modified:false proves nothing in either direction.
+  const verdict =
     modified === true
-      ? "still reports modified:true — the canvas has not been marked clean, so the write has not been acknowledged as landed"
-      : modified === false
-        ? "now reports modified:false — the write may have landed after this deadline; confirm with panel_list_workflows"
-        : "its modified flag could not be read";
-  const persist =
-    persisted === true ? " persisted:true." : persisted === false ? " persisted:false." : "";
+      ? `modified:true means the canvas has not been marked clean, so the write has not been acknowledged as landed. `
+      : `These flags cannot show whether the write completed: modified:false is also the state of a workflow that was never dirty, ` +
+        `and panel_list_workflows reports that same flag. Treat the outcome as UNDETERMINED. `;
+
   return (
-    `workflow_save did not finish within ${seconds}s for ${who}. ` +
+    `workflow_save did not finish within ${seconds}s for ${target}. ` +
     `The tab is still live — other commands from it still answer, so this is not a backgrounded or frozen tab. ` +
-    `The save may still complete in the background. The same tab ${dirty}.${persist} ` +
-    `Check panel_list_workflows before retrying: if modified is false the write landed; ` +
-    `if it stays true the save is still in flight or failed. Do not re-issue until you have seen that observation.`
+    `The save may still complete in the background. ` +
+    reads +
+    verdict +
+    `Confirm by reading the saved file itself before retrying — a re-issue may write twice.`
   );
 }
 
@@ -110,6 +145,15 @@ export async function runBoundedWorkflowSave(
     );
   }
   const budget = makeCommandBudget(budgetMs, now);
+  // #1455 — capture the save's TARGET before it runs. The /userdata HEAD probe can
+  // hang before any Save-As swap, so the workflow active when the budget fires is not
+  // necessarily the one being saved; naming that one blames the wrong file.
+  let target = {};
+  try {
+    target = typeof observeWorkflow === "function" ? observeWorkflow() || {} : {};
+  } catch {
+    target = {};
+  }
   const settled = await withTimeout(
     Promise.resolve()
       .then(() => saveFn())
@@ -127,12 +171,23 @@ export async function runBoundedWorkflowSave(
     } catch {
       observed = {};
     }
+    // Same workflow => its flags describe the target. Different (or unreadable)
+    // => they describe something else, and the reply must not attribute them.
+    const subject = typeof target.filename === "string" && target.filename ? target.filename : observed.filename;
+    const subjectChanged =
+      typeof subject === "string" &&
+      subject !== "" &&
+      typeof observed.filename === "string" &&
+      observed.filename !== "" &&
+      observed.filename !== subject;
     throw new Error(
       describeWorkflowSaveTimeout({
         budgetMs: budget.totalMs,
         modified: observed.modified,
         persisted: observed.persisted,
         filename: observed.filename,
+        subject,
+        subjectChanged,
       }),
     );
   }


### PR DESCRIPTION
Fixes #1455.

`panel_save_workflow`'s timeout reply told the caller **"if modified is false the write landed"**. It cannot know that. `isModified === false` is equally the state of a workflow that was never dirty, so the flag cannot separate the two cases — and this is reachable, not theoretical:

- `saveInPlace` (`web/js/lib/workflow-save.js:1768`) always calls `svc.saveWorkflow(wf)`;
- the shipped frontend's `ComfyWorkflow.save()` calls `super.save({ force: true })`, bypassing the `isPersisted && !isModified` early return.

So a persisted, clean workflow reaches a hanging `/userdata` PUT with the flag **already false**, and it stays false whether the PUT lands or 500s. The remedy the message recommended reads that same flag — `panel_list_workflows` reports `modified: !!w.isModified` (`comfyui-mcp-panel.js:16327`) — so it could not settle the question either. On the Save-As leg the reply contradicted itself in one paragraph: `persisted:false` (proof the write did **not** land) beside "if modified is false the write landed".

**Second defect, same reply.** `observeActiveWorkflowSaveState()` sampled `activeWorkflow` at *timeout-fire time*, not the workflow the save targeted. The `/userdata` HEAD probe can hang **before** `saveAs`/`openWorkflow` (`workflow-save.js:514`, `:762`), so a `{name:"NewName"}` save from `Old.json` attributed the hung write to `Old.json` — a file that was never the target, whose flags say nothing about `NewName.json`.

## What changed

- The reply reports the flags as **observations** and stops. `modified:true` keeps its one-directional meaning (the canvas was never marked clean, so nothing was acknowledged); `modified:false` is reported as **UNDETERMINED**.
- The save's **target is captured before the save runs**. If the active workflow moves during the budget, the reply names the target, discloses the swap, and withholds flags that describe a different workflow rather than misattributing them.
- Retry guidance now points at reading the saved file itself, since no dirty flag can answer it.

## Verification

- `browser_tests/unit/workflow-save-budget.test.mjs` — **14/14**, four of them new.
- **Mutation-tested, both directions.** Reverting the pre-capture to `subject = observed.filename` turns the wiring test red; restoring the old "if modified is false the write landed" string turns the `modified:false` test red. Each mutation kills exactly one test, and the baseline restores to 14/14 — so the tests pin the fix rather than merely covering the file.
- Full unit suite: **5752 pass / 0 fail** (5753 total).
- `check-tool-vocabulary` OK; `check-panel-scope` OK — every name in the panel bundle resolves.

## Note on one changed assertion

The existing `#1434` test asserted the reply matches `/panel_list_workflows/`. That pinned the *recommendation this issue is about*, so it is replaced rather than removed — the test now asserts the message does **not** claim `if modified is false the write landed`. That is a strictly stronger assertion, not a loosened one.

## Provenance

Both defects were raised as a gate **NO-SHIP** on #1439. That PR merged about a minute later and shipped in **v0.15.14**, so the findings are live on `main` — this is the follow-through, not a re-litigation of #1439, whose bounding mechanism was sound and is untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
