### PR TITLE
fix(1455): normalize both sides before deciding the canvas is not the save's destination

### DIFF
--- a/browser_tests/unit/workflow-save-budget.test.mjs
+++ b/browser_tests/unit/workflow-save-budget.test.mjs
@@ -326,12 +326,12 @@ test("#1455: a Save-As names the DESTINATION, not the source it was copied from"
     budgetMs: WORKFLOW_SAVE_COMMAND_BUDGET_MS,
     modified: true,
     persisted: false,
-    filename: "Copy.json",
+    filename: "Copy",
     requested: "Copy.json",
-    previousActive: "Original.json",
+    previousActive: "Original",
   });
-  assert.match(text, /for "Copy\.json"/);
-  assert.doesNotMatch(text, /for "Original\.json"/);
+  assert.match(text, /for "Copy(\.json)?"/);
+  assert.doesNotMatch(text, /Original/);
   assert.match(text, /modified:true/);
 });
 
@@ -340,11 +340,11 @@ test("#1455: a known destination with the canvas elsewhere withholds the foreign
     budgetMs: WORKFLOW_SAVE_COMMAND_BUDGET_MS,
     modified: false,
     persisted: true,
-    filename: "Something else.json",
+    filename: "Something else",
     requested: "Copy.json",
-    previousActive: "Original.json",
+    previousActive: "Original",
   });
-  assert.match(text, /for "Copy\.json"/);
+  assert.match(text, /for "Copy(\.json)?"/);
   // Those flags belong to another workflow; reporting them here would be a wrong-target
   // claim of exactly the kind this issue is about.
   assert.doesNotMatch(text, /modified:false/);
@@ -358,14 +358,14 @@ test("#1455: an un-named save whose canvas moved says the target is undeterminab
     budgetMs: WORKFLOW_SAVE_COMMAND_BUDGET_MS,
     modified: false,
     persisted: true,
-    filename: "Real name.json",
+    filename: "Real name",
     previousActive: "Unsaved Workflow (2)",
   });
   assert.match(text, /cannot be determined from here/);
-  assert.match(text, /changed from "Unsaved Workflow \(2\)" to "Real name\.json"/);
+  assert.match(text, /changed from "Unsaved Workflow \(2\)" to "Real name"/);
   // No file is named as the target, because none is known to be.
   assert.doesNotMatch(text, /for "Unsaved Workflow \(2\)"/);
-  assert.doesNotMatch(text, /for "Real name\.json"/);
+  assert.doesNotMatch(text, /for "Real name"/);
 });
 
 test("#1455 WIRING: the requested name reaches the reply as the destination", async () => {
@@ -375,8 +375,8 @@ test("#1455 WIRING: the requested name reaches the reply as the destination", as
   const observeWorkflow = () => {
     call += 1;
     return call === 1
-      ? { modified: true, persisted: true, filename: "Original.json" }
-      : { modified: true, persisted: false, filename: "Copy.json" };
+      ? { modified: true, persisted: true, filename: "Original" }
+      : { modified: true, persisted: false, filename: "Copy" };
   };
   await assert.rejects(
     () =>
@@ -390,8 +390,8 @@ test("#1455 WIRING: the requested name reaches the reply as the destination", as
         observeWorkflow,
       }),
     (err) => {
-      assert.match(err.message, /for "Copy\.json"/, "names the requested destination");
-      assert.doesNotMatch(err.message, /for "Original\.json"/, "never the source");
+      assert.match(err.message, /for "Copy(\.json)?"/, "names the destination, not the source");
+      assert.doesNotMatch(err.message, /for "Original"/, "never the source");
       return true;
     },
   );
@@ -407,4 +407,35 @@ test("#1455 WIRING: BOTH save handlers pass the requested name to the bound save
   const bound = panel.match(/runBoundedWorkflowSave\(/g) ?? [];
   assert.equal(bound.length, 2, "exactly two bounded save call sites (workflow_save, workflow_save_as)");
   assert.equal(passes.length, 2, "both of them pass the destination name");
+});
+
+test("#1455: a requested name and the canvas name are the SAME workflow once normalized", () => {
+  // panel_list_workflows hands back "workflows/Foo.json"; the canvas reports "Foo".
+  // Comparing those raw is a wrong-pair test — it claims the canvas moved off its own
+  // destination and suppresses modified:true, the only one-directional evidence here.
+  for (const requested of ["Foo.json", "workflows/Foo.json", " Foo ", "Foo.app.json"]) {
+    const text = describeWorkflowSaveTimeout({
+      budgetMs: WORKFLOW_SAVE_COMMAND_BUDGET_MS,
+      modified: true,
+      persisted: false,
+      filename: "Foo",
+      requested,
+      previousActive: "Original",
+    });
+    assert.doesNotMatch(text, /not the save's destination/, requested + " is the canvas");
+    assert.match(text, /modified:true/, requested + " keeps the dirty observation");
+    assert.match(text, /has not been acknowledged as landed/);
+  }
+});
+
+test("#1455: with no flags readable the reply does not reason about a flag it never saw", () => {
+  const text = describeWorkflowSaveTimeout({
+    budgetMs: WORKFLOW_SAVE_COMMAND_BUDGET_MS,
+    filename: "Foo",
+    requested: "Foo.json",
+  });
+  assert.match(text, /could not be read/);
+  assert.match(text, /UNDETERMINED/);
+  // The modified:false rationale belongs to a reading that did not happen.
+  assert.doesNotMatch(text, /never dirty/);
 });

--- a/web/js/lib/workflow-save-budget.js
+++ b/web/js/lib/workflow-save-budget.js
@@ -22,6 +22,11 @@
 // constant, because that constant lives in the OTHER repo.
 
 import { makeCommandBudget } from "./command-budget.js";
+// #1455 — the SAME normalizer the save layer decides paths with. Comparing a raw
+// requested name against ComfyUI's derived `filename` is a wrong-pair test: the
+// frontend strips the directory and the .json/.app.json suffix, so "Foo.json" and
+// "Foo" are the same workflow and must not read as a moved canvas.
+import { baseName } from "./workflow-save.js";
 
 /** Whole-command deadline `workflow_save` / `workflow_save_as` take. */
 export const WORKFLOW_SAVE_COMMAND_BUDGET_MS = 13000;
@@ -90,6 +95,14 @@ export function describeWorkflowSaveTimeout({
   const total = Number.isFinite(budgetMs) && budgetMs > 0 ? budgetMs : WORKFLOW_SAVE_COMMAND_BUDGET_MS;
   const seconds = Math.max(1, Math.round(total / 1000));
   const str = (v) => (typeof v === "string" && v ? v : null);
+  // Directory + extension are presentation, not identity: `panel_list_workflows`
+  // reports "workflows/Foo.json" and the canvas reports "Foo" for one workflow.
+  const nameKey = (v) => {
+    const raw = String(v ?? "").trim();
+    if (!raw) return "";
+    const segments = raw.split(/[\\/]/);
+    return baseName(segments[segments.length - 1] ?? raw);
+  };
   const dest = str(requested);
   const active = str(filename);
   const prior = str(previousActive);
@@ -113,7 +126,7 @@ export function describeWorkflowSaveTimeout({
         `and panel_list_workflows reports that same flag. Treat the outcome as UNDETERMINED. `;
 
   // Case 3 — the target is genuinely unknown. Never dressed up as case 2.
-  if (!dest && prior && active && prior !== active) {
+  if (!dest && prior && active && nameKey(prior) !== nameKey(active)) {
     return (
       `workflow_save did not finish within ${seconds}s. ` +
       head +
@@ -123,12 +136,15 @@ export function describeWorkflowSaveTimeout({
     );
   }
 
-  const subject = dest ?? prior ?? active;
+  // When the destination and the canvas are the SAME workflow, prefer the name the
+  // frontend derived: it is the file as it actually exists. `dest` is only needed to
+  // NAME a target the canvas is not showing.
+  const subject = dest && active && nameKey(dest) === nameKey(active) ? active : (dest ?? prior ?? active);
   const who = subject ? `"${subject}"` : "the active workflow";
 
   // Case 1 with a moved canvas: the destination is known, but the flags on screen
   // belong to some other workflow. Report the target; withhold the foreign flags.
-  if (dest && active && active !== dest) {
+  if (dest && active && nameKey(active) !== nameKey(dest)) {
     return (
       `workflow_save did not finish within ${seconds}s for ${who}. ` +
       head +
@@ -138,8 +154,24 @@ export function describeWorkflowSaveTimeout({
     );
   }
 
-  const reads = flags.length ? `The same tab reports ${flags.join(" ")}. ` : "The tab's save flags could not be read. ";
-  return `workflow_save did not finish within ${seconds}s for ${who}. ` + head + reads + verdict + retry;
+  if (!flags.length) {
+    // Nothing was read, so there is no observation to report and nothing to reason
+    // from. Saying "modified:false is also the state of…" here would discuss a flag
+    // this reply never saw.
+    return (
+      `workflow_save did not finish within ${seconds}s for ${who}. ` +
+      head +
+      `The tab's save flags could not be read, so the outcome is UNDETERMINED. ` +
+      retry
+    );
+  }
+  return (
+    `workflow_save did not finish within ${seconds}s for ${who}. ` +
+    head +
+    `The same tab reports ${flags.join(" ")}. ` +
+    verdict +
+    retry
+  );
 }
 
 /**

--- a/web/js/lib/workflow-save.js
+++ b/web/js/lib/workflow-save.js
@@ -24,7 +24,7 @@ const APP_JSON_EXT = ".app.json";
 
 /** Strip a trailing workflow extension (.app.json or .json) and surrounding
  *  whitespace. Mirrors how ComfyUI derives a bare filename from a path. */
-function baseName(name) {
+export function baseName(name) {
   const s = String(name || "").trim();
   const lower = s.toLowerCase();
   if (lower.endsWith(APP_JSON_EXT)) return s.slice(0, -APP_JSON_EXT.length).trim();


### PR DESCRIPTION
Follow-up to #1456, which merged at its **second** commit while the third was still in review. The third is this one, and without it the shipped reply is wrong on the most ordinary Save-As there is.

## What is live on `main` (0.15.15) right now

`web/js/lib/workflow-save-budget.js:131` compares a **raw requested name** against ComfyUI's **derived filename**:

```js
if (dest && active && active !== dest) {
```

The frontend strips the directory and the `.json` / `.app.json` suffix, so `ComfyWorkflow.filename` is `"Foo"` for a workflow stored at `workflows/Foo.json`. A caller who copies a name straight out of `panel_list_workflows` — which reports `workflows/Foo.json` — and calls `workflow_save_as({ name: "Foo.json" })` therefore trips the guard on a save that is proceeding perfectly normally.

Two consequences, both bad:

1. The reply asserts **"The active workflow is "Foo", not the save's destination"** — which is false; it *is* the destination.
2. It then **withholds `modified:true`**, the one piece of one-directional evidence the reply has. So on that path it is strictly *less* informative than the code it replaced, on top of stating something untrue. An agent told the canvas has moved off its destination has a live incentive to `panel_open_workflow` while the write is still in flight.

Same wrong pair for `" Foo "` (the save layer trims) and `"Foo.app.json"`.

## The fix

Both sides go through `baseName()` — the same normalizer the save layer already decides paths with (`workflow-save.js:636`, `:639`, `:1318`). It is now exported rather than re-implemented, so the two cannot drift; the repo's own comment notes this is the one place that compared a name to `wf.filename` without it.

When destination and canvas are the same workflow, the reply prefers the canvas's derived name — that is the file as it exists. The requested name is only needed to *name a target the canvas is not showing*.

Also included: with **no** flags readable at all, the reply no longer reasons about `modified:false`. It never saw that flag, so it reports that nothing could be read, and UNDETERMINED.

## Verification

- Full suite **5757 pass / 0 fail**; `check-tool-vocabulary` OK; `check-panel-scope` OK.
- **Gate: SHIP** (round 3). Independent adversarial reviewer, codex unavailable — disclosed. It ran 12 mutations: each call site losing `targetName` *independently*, `nameKey` losing normalization, the case-3 branch, the no-flags branch, foreign-flag withholding, both verdict reversions, `subject` preferring canvas over destination, and the pre-save observation being skipped — **all killed**.
- Test fixtures now carry the shapes the real frontend produces (bare basename). The previous ones put an extension on both sides, so they agreed with each other and with nothing in production.

## Known, deliberately not fixed here

The gate raised one **P2 non-blocker**: `wf.filename` is already extension-stripped and `nameKey` strips again, so an externally-placed `Foo.json.json` reports `filename "Foo.json"`, normalizes to `"Foo"`, and would match a requested `"Foo"` — suppressing the "canvas is elsewhere" disclosure. The panel cannot create such a file (`baseName` strips the requested extension), the reply still says UNDETERMINED, and it still directs the caller to read the file, so there is no false success claim in any branch. Filed separately rather than widening this PR past the defect it fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
