### PR TITLE
fix(1459): key the requested name and the canvas name with the operation each needs

### DIFF
--- a/browser_tests/unit/workflow-save-budget.test.mjs
+++ b/browser_tests/unit/workflow-save-budget.test.mjs
@@ -16,6 +16,8 @@
  */
 import test from "node:test";
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 
 import { withTimeout } from "../../web/js/lib/bounded-step.js";
 import {
@@ -438,4 +440,143 @@ test("#1455: with no flags readable the reply does not reason about a flag it ne
   assert.match(text, /UNDETERMINED/);
   // The modified:false rationale belongs to a reading that did not happen.
   assert.doesNotMatch(text, /never dirty/);
+});
+
+// ---------------------------------------------------------------------------
+// #1459 — the two sides of the comparison are normalized to DIFFERENT degrees.
+//
+// The fixture is the repo's own documented double-extension shape (the same one
+// workflow-save.test.mjs uses for the #226 rename hazard): a file persisted at
+// "workflows/Foo.json.json" reports filename "Foo.json", because ComfyUI's
+// getFilenameDetails has already taken the final ".json" off. Stripping it AGAIN
+// on this side keys it as "Foo" — colliding with a genuinely different workflow.
+// ---------------------------------------------------------------------------
+
+test("#1459: an externally-placed Foo.json.json is NOT the destination of a save to Foo", () => {
+  // The canvas holds "workflows/Foo.json.json" (filename "Foo.json"); the save was
+  // asked for "Foo", which the save layer resolves to "workflows/Foo.json". Two
+  // different files. Double-stripping the canvas name makes them read as one, which
+  // suppresses the disclosure AND prints the source's flags as the target's.
+  const text = describeWorkflowSaveTimeout({
+    budgetMs: WORKFLOW_SAVE_COMMAND_BUDGET_MS,
+    modified: false,
+    persisted: true,
+    filename: "Foo.json",
+    requested: "Foo",
+  });
+  assert.match(text, /not the save's destination/, "the canvas is a different file and must be disclosed as one");
+  assert.match(text, /The active workflow is "Foo\.json"/);
+  assert.match(text, /do not describe "Foo"/);
+  // The foreign flags belong to the source. Printing them here is the wrong-target
+  // claim this whole chain exists to prevent.
+  assert.doesNotMatch(text, /persisted:true/);
+  assert.doesNotMatch(text, /modified:false/);
+});
+
+test("#1459: the reply for a double-extension canvas names the REQUESTED destination", () => {
+  // `subject` picks the frontend name only when the two are the same workflow. With
+  // the double-strip, "Foo.json" wins the subject slot and the reply is headed with
+  // a file the caller never asked to write.
+  const text = describeWorkflowSaveTimeout({
+    budgetMs: WORKFLOW_SAVE_COMMAND_BUDGET_MS,
+    modified: true,
+    persisted: true,
+    filename: "Foo.json",
+    requested: "Foo",
+  });
+  assert.match(text, /for "Foo"\. /, "headed with the destination, not the canvas");
+  assert.doesNotMatch(text, /for "Foo\.json"/);
+});
+
+test("#1459: an un-named save that moved between Foo.json.json and Foo.json is undeterminable", () => {
+  // Both sides are frontend-derived here: the canvas moved from the double-extension
+  // file (filename "Foo.json") to a real "workflows/Foo.json" (filename "Foo"). Those
+  // are two workflows; double-stripping keys them both to "Foo", so the "which file
+  // does the hung write target?" disclosure is skipped and the reply falls through to
+  // the in-place case — reporting flags that describe neither write with confidence.
+  const text = describeWorkflowSaveTimeout({
+    budgetMs: WORKFLOW_SAVE_COMMAND_BUDGET_MS,
+    modified: false,
+    persisted: true,
+    filename: "Foo",
+    previousActive: "Foo.json",
+  });
+  assert.match(text, /cannot be determined from here/);
+  assert.match(text, /changed from "Foo\.json" to "Foo"/);
+});
+
+test("#1459: the #1455 requested-name normalization is unchanged — directory and extension still strip", () => {
+  // The fix must narrow ONLY the frontend side. Every requested spelling that #1455
+  // taught to match a bare canvas name still has to match, or this trades one
+  // wrong-target reply for another.
+  for (const requested of ["Foo", "Foo.json", "workflows/Foo.json", "workflows\\Foo.json", " Foo ", "Foo.app.json"]) {
+    const text = describeWorkflowSaveTimeout({
+      budgetMs: WORKFLOW_SAVE_COMMAND_BUDGET_MS,
+      modified: true,
+      persisted: false,
+      filename: "Foo",
+      requested,
+    });
+    assert.doesNotMatch(text, /not the save's destination/, requested + " is the canvas");
+    assert.match(text, /modified:true/, requested + " keeps the dirty observation");
+  }
+});
+
+test("#1459: a directory on the frontend name is still dropped, without touching the extension", () => {
+  // activeKey drops the directory and nothing else. "workflows/Foo" is the canvas for
+  // a requested "Foo"; "workflows/Foo.json" (a double-extension file) is not.
+  const same = describeWorkflowSaveTimeout({
+    budgetMs: WORKFLOW_SAVE_COMMAND_BUDGET_MS,
+    modified: true,
+    persisted: false,
+    filename: "workflows/Foo",
+    requested: "Foo",
+  });
+  assert.doesNotMatch(same, /not the save's destination/);
+
+  const different = describeWorkflowSaveTimeout({
+    budgetMs: WORKFLOW_SAVE_COMMAND_BUDGET_MS,
+    modified: true,
+    persisted: false,
+    filename: "workflows/Foo.json",
+    requested: "Foo",
+  });
+  assert.match(different, /not the save's destination/);
+});
+
+test("#1459 SOURCE: the frontend-derived name is never run through baseName", () => {
+  // The whole defect is one helper applied to both sides, and a helper-level test cannot
+  // see WHICH helper a call site chose — swapping activeKey back to requestedKey at any
+  // one of the three sites is invisible to every assertion above that does not happen to
+  // exercise that exact branch. Assert on the shipped source instead.
+  const src = readFileSync(
+    fileURLToPath(new URL("../../web/js/lib/workflow-save-budget.js", import.meta.url)),
+    "utf8",
+  );
+  // Comments talk ABOUT baseName() at length; only real code counts.
+  const code = src.replace(/\/\*[\s\S]*?\*\//g, "").replace(/^\s*\/\/.*$/gm, "");
+  const body = code.slice(code.indexOf("export function describeWorkflowSaveTimeout"));
+
+  assert.equal(body.includes("nameKey("), false, "the shared over-stripping helper is gone");
+  assert.equal(
+    (body.match(/requestedKey\((?:active|prior)\)/g) ?? []).length,
+    0,
+    "a frontend-derived name must never take the extension-stripping key",
+  );
+  assert.equal(
+    (body.match(/activeKey\(dest\)/g) ?? []).length,
+    0,
+    "the raw requested name must never take the directory-only key",
+  );
+  // Every comparison the reply branches on is keyed, and keyed with the RIGHT side's key.
+  assert.match(body, /activeKey\(prior\) !== activeKey\(active\)/, "case 3 keys both frontend names");
+  assert.match(body, /requestedKey\(dest\) === activeKey\(active\)/, "the subject picks per-side keys");
+  assert.match(body, /activeKey\(active\) !== requestedKey\(dest\)/, "the disclosure branch keys per side");
+  // And requestedKey is the ONLY thing in this module allowed to strip an extension.
+  assert.match(code, /const requestedKey = \(v\) => baseName\(dropDir\(v\)\)/);
+  assert.equal(
+    (code.match(/baseName\(/g) ?? []).length,
+    1,
+    "exactly one baseName call site — the requested-name key",
+  );
 });

--- a/web/js/lib/workflow-save-budget.js
+++ b/web/js/lib/workflow-save-budget.js
@@ -104,15 +104,15 @@ export function describeWorkflowSaveTimeout({
   // #1459 — but the two sides arrive normalized to DIFFERENT degrees, so one shared
   // helper cannot key both. `requested` is the caller's raw string and may still carry
   // a directory and a ".json"/".app.json" suffix — exactly what the save layer strips
-  // with baseName() before it builds the target path. `filename` has already had ONE
-  // trailing extension removed by the frontend (UserFile → getPathDetails →
-  // getFilenameDetails), so the directory is the only part of it still safe to drop.
-  // Running it through baseName() too strips it a SECOND time — the same double-strip
-  // workflow-save.js:650 documents as unsafe:
-  // a file on disk at "…/Foo.json.json" reports filename "Foo.json", which stripped
-  // again reads "Foo" and matches a requested "Foo". A genuinely different workflow
-  // then passes as the destination, the "not the save's destination" disclosure is
-  // suppressed, and the SOURCE's dirty/persisted flags are printed as the target's.
+  // with baseName() before it builds the target path. `filename` has already been
+  // stripped by the frontend (UserFile → getPathDetails → getFilenameDetails), so the
+  // directory is the only part of it still safe to drop. Running it through baseName()
+  // too strips it a SECOND time — the same double-strip workflow-save.js:650 documents
+  // as unsafe: a file on disk at "…/Foo.json.json" reports filename "Foo.json", which
+  // stripped again reads "Foo" and matches a requested "Foo". A genuinely different
+  // workflow then passes as the destination, the "not the save's destination"
+  // disclosure is suppressed, and the SOURCE's dirty/persisted flags are printed as
+  // the target's.
   const dropDir = (v) => {
     const raw = String(v ?? "").trim();
     if (!raw) return "";
@@ -121,13 +121,18 @@ export function describeWorkflowSaveTimeout({
   };
   /** Key a caller-supplied name: both the directory and the extension are presentation. */
   const requestedKey = (v) => baseName(dropDir(v));
-  // KNOWN AND UNCHANGED: getFilenameDetails removes one extension, not the compound
-  // ".app.json" — an app-mode workflow on disk at "Foo.app.json" reports filename
-  // "Foo.app", which no longer keys equal to a requested "Foo". That mismatch predates
-  // this change and is identical before and after it; activeKey deliberately does not
-  // paper over it, because ".app" is also a legal thing to call a workflow and guessing
-  // wrong here is the very failure mode above. Not normalizing it costs at most an extra
-  // "cannot say which file" disclosure, which is the safe direction to be wrong in.
+  // What getFilenameDetails actually does, read off the shipped frontend (1.49.6) rather
+  // than assumed: ONE special case for the compound ".app.json", then a cut at the LAST
+  // dot. So "Foo.app.json" → "Foo", "Foo.json" → "Foo", "Foo.json.json" → "Foo.json",
+  // and "My.Workflow.json" → "My.Workflow". Every one of those is already as bare as the
+  // frontend can make it, which is why activeKey must not cut again.
+  //
+  // KNOWN AND UNCHANGED: it leaves ONE residual mismatch, in the other (safe) direction.
+  // A workflow literally NAMED "Foo.app" persists at "Foo.app.json" and so reports
+  // filename "Foo", while requestedKey keeps the ".app" baseName does not recognise —
+  // the two do not key equal. That is identical before and after this change, and it
+  // errs toward an extra "cannot say which file" disclosure rather than toward a
+  // wrong-target claim, so it is left alone rather than papered over with another guess.
   /** Key a frontend-derived `filename`: drop the directory and NOTHING else. */
   const activeKey = (v) => dropDir(v);
   const dest = str(requested);

--- a/web/js/lib/workflow-save-budget.js
+++ b/web/js/lib/workflow-save-budget.js
@@ -26,6 +26,9 @@ import { makeCommandBudget } from "./command-budget.js";
 // requested name against ComfyUI's derived `filename` is a wrong-pair test: the
 // frontend strips the directory and the .json/.app.json suffix, so "Foo.json" and
 // "Foo" are the same workflow and must not read as a moved canvas.
+// #1459 — it applies to the REQUESTED name only. The frontend's `filename` has
+// already had its extension removed, and stripping it twice collapses distinct
+// workflows onto one key (see describeWorkflowSaveTimeout).
 import { baseName } from "./workflow-save.js";
 
 /** Whole-command deadline `workflow_save` / `workflow_save_as` take. */
@@ -97,12 +100,28 @@ export function describeWorkflowSaveTimeout({
   const str = (v) => (typeof v === "string" && v ? v : null);
   // Directory + extension are presentation, not identity: `panel_list_workflows`
   // reports "workflows/Foo.json" and the canvas reports "Foo" for one workflow.
-  const nameKey = (v) => {
+  //
+  // #1459 — but the two sides arrive normalized to DIFFERENT degrees, so one shared
+  // helper cannot key both. `requested` is the caller's raw string and may still carry
+  // a directory and a ".json"/".app.json" suffix — exactly what the save layer strips
+  // with baseName() before it builds the target path. `filename` is the frontend's
+  // ALREADY extension-stripped name (UserFile → getPathDetails → getFilenameDetails),
+  // so only the directory is left to drop. Running it through baseName() too strips it
+  // a SECOND time — the same double-strip workflow-save.js:650 documents as unsafe:
+  // a file on disk at "…/Foo.json.json" reports filename "Foo.json", which stripped
+  // again reads "Foo" and matches a requested "Foo". A genuinely different workflow
+  // then passes as the destination, the "not the save's destination" disclosure is
+  // suppressed, and the SOURCE's dirty/persisted flags are printed as the target's.
+  const dropDir = (v) => {
     const raw = String(v ?? "").trim();
     if (!raw) return "";
     const segments = raw.split(/[\\/]/);
-    return baseName(segments[segments.length - 1] ?? raw);
+    return (segments[segments.length - 1] ?? raw).trim();
   };
+  /** Key a caller-supplied name: both the directory and the extension are presentation. */
+  const requestedKey = (v) => baseName(dropDir(v));
+  /** Key a frontend-derived `filename`: its extension is already gone. Drop only the directory. */
+  const activeKey = (v) => dropDir(v);
   const dest = str(requested);
   const active = str(filename);
   const prior = str(previousActive);
@@ -126,7 +145,8 @@ export function describeWorkflowSaveTimeout({
         `and panel_list_workflows reports that same flag. Treat the outcome as UNDETERMINED. `;
 
   // Case 3 — the target is genuinely unknown. Never dressed up as case 2.
-  if (!dest && prior && active && nameKey(prior) !== nameKey(active)) {
+  // BOTH sides here are frontend-derived `filename`s, so both take activeKey.
+  if (!dest && prior && active && activeKey(prior) !== activeKey(active)) {
     return (
       `workflow_save did not finish within ${seconds}s. ` +
       head +
@@ -139,12 +159,12 @@ export function describeWorkflowSaveTimeout({
   // When the destination and the canvas are the SAME workflow, prefer the name the
   // frontend derived: it is the file as it actually exists. `dest` is only needed to
   // NAME a target the canvas is not showing.
-  const subject = dest && active && nameKey(dest) === nameKey(active) ? active : (dest ?? prior ?? active);
+  const subject = dest && active && requestedKey(dest) === activeKey(active) ? active : (dest ?? prior ?? active);
   const who = subject ? `"${subject}"` : "the active workflow";
 
   // Case 1 with a moved canvas: the destination is known, but the flags on screen
   // belong to some other workflow. Report the target; withhold the foreign flags.
-  if (dest && active && nameKey(active) !== nameKey(dest)) {
+  if (dest && active && activeKey(active) !== requestedKey(dest)) {
     return (
       `workflow_save did not finish within ${seconds}s for ${who}. ` +
       head +

--- a/web/js/lib/workflow-save-budget.js
+++ b/web/js/lib/workflow-save-budget.js
@@ -27,8 +27,8 @@ import { makeCommandBudget } from "./command-budget.js";
 // frontend strips the directory and the .json/.app.json suffix, so "Foo.json" and
 // "Foo" are the same workflow and must not read as a moved canvas.
 // #1459 — it applies to the REQUESTED name only. The frontend's `filename` has
-// already had its extension removed, and stripping it twice collapses distinct
-// workflows onto one key (see describeWorkflowSaveTimeout).
+// already had one trailing extension removed, and stripping it again collapses
+// distinct workflows onto one key (see describeWorkflowSaveTimeout).
 import { baseName } from "./workflow-save.js";
 
 /** Whole-command deadline `workflow_save` / `workflow_save_as` take. */
@@ -104,10 +104,11 @@ export function describeWorkflowSaveTimeout({
   // #1459 — but the two sides arrive normalized to DIFFERENT degrees, so one shared
   // helper cannot key both. `requested` is the caller's raw string and may still carry
   // a directory and a ".json"/".app.json" suffix — exactly what the save layer strips
-  // with baseName() before it builds the target path. `filename` is the frontend's
-  // ALREADY extension-stripped name (UserFile → getPathDetails → getFilenameDetails),
-  // so only the directory is left to drop. Running it through baseName() too strips it
-  // a SECOND time — the same double-strip workflow-save.js:650 documents as unsafe:
+  // with baseName() before it builds the target path. `filename` has already had ONE
+  // trailing extension removed by the frontend (UserFile → getPathDetails →
+  // getFilenameDetails), so the directory is the only part of it still safe to drop.
+  // Running it through baseName() too strips it a SECOND time — the same double-strip
+  // workflow-save.js:650 documents as unsafe:
   // a file on disk at "…/Foo.json.json" reports filename "Foo.json", which stripped
   // again reads "Foo" and matches a requested "Foo". A genuinely different workflow
   // then passes as the destination, the "not the save's destination" disclosure is
@@ -120,7 +121,14 @@ export function describeWorkflowSaveTimeout({
   };
   /** Key a caller-supplied name: both the directory and the extension are presentation. */
   const requestedKey = (v) => baseName(dropDir(v));
-  /** Key a frontend-derived `filename`: its extension is already gone. Drop only the directory. */
+  // KNOWN AND UNCHANGED: getFilenameDetails removes one extension, not the compound
+  // ".app.json" — an app-mode workflow on disk at "Foo.app.json" reports filename
+  // "Foo.app", which no longer keys equal to a requested "Foo". That mismatch predates
+  // this change and is identical before and after it; activeKey deliberately does not
+  // paper over it, because ".app" is also a legal thing to call a workflow and guessing
+  // wrong here is the very failure mode above. Not normalizing it costs at most an extra
+  // "cannot say which file" disclosure, which is the safe direction to be wrong in.
+  /** Key a frontend-derived `filename`: drop the directory and NOTHING else. */
   const activeKey = (v) => dropDir(v);
   const dest = str(requested);
   const active = str(filename);


### PR DESCRIPTION
Fixes #1459.

> **Stacked on #1458.** `nameKey()` does not exist on `main` yet — it arrives with #1458, and
> #1459 is the P2 residue that PR's gate raised against it. So the base of this PR is
> `fix/1455-normalize-name-comparison`, and the diff below is only the #1459 change.
> GitHub retargets this to `main` when #1458 merges.

## The defect

`nameKey()` normalizes **both** sides of the "is the canvas the save's destination?" comparison
with one helper: drop the directory, then `baseName()` off a trailing `.json` / `.app.json`.

That is right for `requested`. It arrives raw from the caller (`workflow_save({name})` →
`targetName`), and `baseName()` is exactly what the save layer strips with before it builds the
target path.

It is one strip too many for the other side. `filename` is read off
`app.extensionManager.workflow.activeWorkflow` (`observeActiveWorkflowSaveState`,
comfyui-mcp-panel.js:6122), and the frontend has **already** stripped it
(`UserFile` → `getPathDetails` → `getFilenameDetails`). Running it through `baseName()` strips it
a second time — the same double-strip this repo documents as unsafe at
`web/js/lib/workflow-save.js:650`, an invariant that has been in the tree since #226/#231:

> `ComfyUI strips the final ".json" from the on-disk name, so a file at "…/Foo.json.json" reports filename "Foo.json"; baseName() would strip it again to "Foo" and misjudge a Save-As to "Foo" as an in-place save.`

### `getFilenameDetails`, read rather than assumed

Transcribed from the bundle the live ComfyUI actually serves
(`/assets/formatUtil-BIkJATtP.js`, frontend 1.49.6) — one compound case, then a cut at the
**last** dot:

```js
var n=`app.json`, r=`.json`, i=`.app.json`
function getFilenameDetails(e){
  if(e.toLowerCase().endsWith(i) && e.length>i.length)
    return {filename:e.slice(0,-i.length), suffix:n};
  let t=e.lastIndexOf(`.`);
  return t<=0?{filename:e,suffix:null}:{filename:e.slice(0,t),suffix:e.slice(t+1)}}
```

| on disk | reported `filename` |
|---|---|
| `Foo.json` | `Foo` |
| `Foo.app.json` | `Foo` |
| **`Foo.json.json`** | **`Foo.json`** |
| `My.Workflow.json` | `My.Workflow` |

Every one of those is already as bare as the frontend can make it. That third row is the whole
issue.

## The input that separates them

An externally-placed `workflows/Foo.json.json` reports `filename: "Foo.json"` — the exact shape
the repo's own #226 fixture already models (`browser_tests/unit/workflow-save.test.mjs:401`).
Double-stripped it keys as `"Foo"` and matches a requested `"Foo"`, so:

- a genuinely different workflow reads as the save's destination;
- the *"The active workflow is …, not the save's destination"* disclosure is suppressed;
- and the **source's** `modified`/`persisted` flags are printed as though they described the target.

The same collision hits the un-named path, where **both** sides are frontend-derived: a canvas
that moved from `Foo.json.json` (filename `"Foo.json"`) to a real `Foo.json` (filename `"Foo"`)
keys identically, so "which file does the hung write target?" is never asked and the reply falls
through to the in-place case.

## The fix

Two keys, each applied to the side it belongs to — the direction the issue asks for:

- `requestedKey(v)` — directory **and** extension. For the caller's raw string.
- `activeKey(v)` — directory only. For a frontend-derived `filename`, which the frontend has
  already taken one trailing extension off.

`baseName` now has exactly one call site in the module, inside `requestedKey`.

## Verification

**Unit — `npm run test:unit`: 5763 pass, 0 fail** (i18n, i18n-render, tool-vocabulary and
panel-scope checks included; the run has 1 pre-existing `todo`).

Six new tests, built from the real `X.json.json` shape rather than a synthetic one, since — as the
issue notes — the existing fixtures cannot express the difference.

**Verified by mutation, not by a green suite.** Reverting only the fix
(`activeKey = (v) => baseName(dropDir(v))`, i.e. the old shared helper) turns **5 of the 6** red:

```
✖ #1459: an externally-placed Foo.json.json is NOT the destination of a save to Foo
✖ #1459: the reply for a double-extension canvas names the REQUESTED destination
✖ #1459: an un-named save that moved between Foo.json.json and Foo.json is undeterminable
✖ #1459: a directory on the frontend name is still dropped, without touching the extension
✖ #1459 SOURCE: the frontend-derived name is never run through baseName
✔ #1459: the #1455 requested-name normalization is unchanged   ← regression guard, green by design
```

That last green one is the point of it: the fix must narrow **only** the frontend side, so every
requested spelling #1455 taught to match (`Foo`, `Foo.json`, `workflows/Foo.json`,
`workflows\Foo.json`, `" Foo "`, `Foo.app.json`) still has to match a canvas `"Foo"`.

**A helper-level test cannot see which helper a call site chose** — swapping `activeKey` back to
`requestedKey` at any one of the three comparison sites is invisible to any assertion that does not
happen to exercise that exact branch. `#1459 SOURCE` therefore asserts on the shipped source: that
`nameKey(` is gone, that `requestedKey` never receives `active`/`prior`, that `activeKey` never
receives `dest`, that all three comparisons key per-side, and that `baseName(` appears exactly once
in non-comment code.

## Gate

**codex was unavailable (account exhausted until 2026-08-19 20:43); gated by an independent
adversarial review instead** — `claude-gate.mjs`, a fresh reviewer given only the diff, per the
authorised substitution. Disclosing that substitution is the condition it was accepted under.

Three rounds, all **SHIP (exit 0)**. Full verdicts in a comment below. The gate ran things rather
than reading them: 7/7 mutations killed (including each of the three call sites swapped
individually), an 810-combination behavioural diff of shipped-vs-reverted (9 disk paths × 9
requested names × 10 prior-actives) in which **98 rows change and all 98 involve a `.json.json`
path** — every one moving `IN-PLACE-FLAGS → DISCLOSE-MOVED`/`UNDETERMINABLE`, zero collateral on
any normal-shape path — and a 1728-combination hostile fuzz (null/NaN/arrays/throwing
`toString`/NUL bytes/5000-char names) with no throws.

Rounds 2 and 3 are **comment-only** commits (`f84e4e0`, `412a8b6`); the executable diff has been
byte-identical since `054b184`. Round 2 caught that a comment I added overstated what
`getFilenameDetails` strips — it checked the shipped frontend instead of believing me, and it was
right. `412a8b6` corrects it, and round 3 re-gated that exact tree. Recording it because in this
repo an unverified claim in a comment gets quoted back later as the repo's own measurement.

## Browser suite — not run, and why

Playwright was **not** run for this change, rather than run and reported as coverage it would not be.

- The changed module has exactly one importer (`web/js/comfyui-mcp-panel.js:602`), and
  `describeWorkflowSaveTimeout`'s string reaches only the bridge dispatch at
  comfyui-mcp-panel.js:22337 — an MCP tool reply. `workflow_save`/`workflow_save_as` are **not**
  slash commands (`runLocalCommand` is wired to `graph_canvas`, `graph_run`, `graph_get_errors`
  only), so this text has no DOM path and the sidebar renders nothing from it.
- The message only fires when a `/userdata` write hangs past the 13 s budget, which the Tier-1
  MockBridge suite has no way to provoke.
- No live ComfyUI serves this branch: the suite drives whatever pack is junctioned into
  `localhost:8188`, and a green run there would have exercised code that predates both #1458 and
  this fix. Repointing the shared instance would have disturbed another agent's run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
