### PR TITLE
chore(security): track dependency advisories, weekly and grouped

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,76 @@
+# Dependency and CVE tracking for the sidebar pack.
+#
+# This repo already runs bandit and a YARA-parity pass — in CI and again at
+# publish — but those scan OUR OWN shipped files for malicious patterns. They
+# cannot see a published advisory against a package we already depend on, which
+# is a different question and the one nothing here was asking.
+#
+# It matters for a pack distributed through the Comfy Registry: what ships is a
+# zip of this repo, installed into people's ComfyUI, and the registry's scanner
+# looks for the same inward-facing patterns ours does.
+#
+# WEEKLY AND GROUPED so each PR is actually read rather than rubber-stamped;
+# majors ungrouped so they arrive alone. Bumps are reviewed by a human — the
+# autopilot skips bot-authored PRs by decision.
+version: 2
+updates:
+  # Dev tooling: Playwright, TypeScript, ws, zod. Not shipped to users, but it is
+  # what runs the browser tests that gate this pack.
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: "chore(deps)"
+      prefix-development: "chore(deps-dev)"
+    labels:
+      - "dependencies"
+    groups:
+      npm-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
+  # The one dependency that reaches users: pyproject declares the frontend
+  # package floor the sidebar tab registration relies on.
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: "chore(deps)"
+    labels:
+      - "dependencies"
+    groups:
+      pip-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
+  # Publishing to the registry happens from a workflow; a compromised action
+  # there is a compromised pack.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: "chore(actions)"
+    labels:
+      - "dependencies"
+    groups:
+      actions-all:
+        patterns:
+          - "*"


### PR DESCRIPTION
Companion to artokun/comfyui-mcp#1833. This repo already runs bandit and a YARA-parity pass — in CI *and* again at publish — but those scan **our own shipped files** for malicious patterns. They cannot see a published advisory against a package we already depend on. Different question, and nothing here was asking it.

## Three ecosystems, because all three reach users or gate what does

| ecosystem | what it covers |
|---|---|
| npm | Playwright, TypeScript, ws, zod — not shipped, but it runs the browser tests that gate this pack |
| pip | `pyproject.toml`'s `comfyui-frontend-package` floor — the one dependency that does reach users |
| github-actions | publishing to the Comfy Registry happens from a workflow; a compromised action there is a compromised pack |

**Weekly, grouped, limit 3**, majors ungrouped so they arrive alone and get read alone.

## Notes for this repo specifically

- The pack ships as a zip of this repo into people's ComfyUI installs, and the registry's own scanner looks for the same inward-facing patterns ours does — so "our code is clean" and "our dependencies are clean" are genuinely separate claims, and only the first one was being checked.
- Dependency bumps are a human's call: the autopilot now skips bot-authored PRs outright, after finding that its issue-number extraction could resolve a bump's changelog reference (`#1524`) to a real issue number.
- Bumping `comfyui-frontend-package` deserves care rather than a rubber stamp — it is the floor that guarantees `app.extensionManager.registerSidebarTab` exists, so a major there is a compatibility decision, not a routine update. Grouping deliberately excludes majors for exactly this reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)