### PR TITLE
fix(1463): a subgraph conversion that THROWS says whether the graph changed

### DIFF
--- a/browser_tests/unit/subgraph-conversion-integrity.test.mjs
+++ b/browser_tests/unit/subgraph-conversion-integrity.test.mjs
@@ -41,6 +41,10 @@ import {
   disconnectedBoundaryInputs,
   brokenConversionRefusal,
   brokenConversionWarning,
+  detachedConversionNodes,
+  detachedConversionRefusal,
+  conversionSnapshot,
+  conversionThrowReport,
 } from "../../web/js/lib/subgraph-conversion-integrity.js";
 
 const src = () =>
@@ -434,10 +438,28 @@ test("#1571 the advisory findings reach the reported payload on both paths", () 
 });
 
 test("#1571 the guard is imported, not shadowed by a local stub", () => {
-  assert.match(
-    src(),
-    /import \{\s*danglingInputLinks,\s*disconnectedBoundaryInputs,\s*brokenConversionRefusal,\s*brokenConversionWarning,\s*\} from "\.\/lib\/subgraph-conversion-integrity\.js";/,
+  // Name-by-name rather than as one frozen block: #1463 added four more exports to the
+  // same import, and an exact-block match would have failed on that without any of these
+  // four guards having changed. What must not drift is that each one comes from the lib
+  // and is not re-declared in the monolith.
+  const s = src();
+  const imported = s.match(
+    /import \{([\s\S]*?)\} from "\.\/lib\/subgraph-conversion-integrity\.js";/,
   );
+  assert.ok(imported, "the integrity guards must be imported from the lib");
+  for (const name of [
+    "danglingInputLinks",
+    "disconnectedBoundaryInputs",
+    "brokenConversionRefusal",
+    "brokenConversionWarning",
+  ]) {
+    assert.ok(imported[1].includes(name), `${name} must be imported from the lib`);
+    assert.doesNotMatch(
+      s,
+      new RegExp(`\\r?\\nfunction ${name}\\(`),
+      `${name} must not be shadowed by a local stub`,
+    );
+  }
 });
 
 // ── BEHAVIOUR, through the REAL shipped executor. The wiring tests above prove the calls
@@ -459,6 +481,13 @@ function realExecutor(name, args, convertToSubgraph, wrapper) {
     /function subgraphConversionAdvisories\(\{ disconnected, dangling, warning \}\) \{[\s\S]*?\r?\n\}/,
   );
   assert.ok(landed && serializable && advisories, "the conversion guards must be locatable");
+  // #1463 — the executors reach convertToSubgraph through this runner now. Injected from
+  // the REAL source for the same reason as the guards above: a stub would let a
+  // regression in it pass every test in this file.
+  const runner = s.match(
+    /function convertSelectionToSubgraph\(\{ graph, canvas, nodes, what \}\) \{[\s\S]*?\r?\n\}/,
+  );
+  assert.ok(runner, "could not locate convertSelectionToSubgraph in panel source");
   const graph = {
     _nodes: [wrapper],
     getNodeById: (id) => ({ id: Number(id) }),
@@ -474,6 +503,7 @@ function realExecutor(name, args, convertToSubgraph, wrapper) {
     "syncGraphNodeAreas",
     "groupMemberNodes",
     "clearStaleRedFlagsAfterSubgraphConversion",
+    "convertSelectionToSubgraph",
     "assertSubgraphNodeLanded",
     "assertSubgraphConversionSerializable",
     "subgraphConversionAdvisories",
@@ -484,6 +514,13 @@ function realExecutor(name, args, convertToSubgraph, wrapper) {
     () => {},
     () => [{ id: 192 }, { id: 265 }, { id: 273 }],
     () => {},
+    new Function(
+      "detachedConversionNodes",
+      "detachedConversionRefusal",
+      "conversionSnapshot",
+      "conversionThrowReport",
+      `return ${runner[0]};`,
+    )(detachedConversionNodes, detachedConversionRefusal, conversionSnapshot, conversionThrowReport),
     new Function(`return ${landed[0]};`)(),
     new Function(
       "danglingInputLinks",

--- a/browser_tests/unit/subgraph-conversion-throw-verdict.test.mjs
+++ b/browser_tests/unit/subgraph-conversion-throw-verdict.test.mjs
@@ -40,10 +40,21 @@
 // wrong, which is worse. The confident verdict is now gated on the link table too, and on
 // nothing having replaced `convertToSubgraph` on the graph object.
 //
+// ## The refusal that may NOT be made (gate P1 on the second version)
+//
+// It then swept every neighbour. Direction decides fatality: the input-side reconnect is
+// `outputNode.connectSlots(output, subgraphNode, …)` — `this` is the OUTSIDE producer, so
+// a detached producer throws — while the output-side one is
+// `subgraphNode.connectSlots(output, inputNode, …)`, where `this` is the new wrapper and
+// nothing ever reads the consumer's graph. Refusing on a detached consumer blocked a
+// conversion the frontend completes, in the exact pathological state this feature is for.
+// Only upstream producers, and only selected nodes that actually carry a link, are fatal.
+//
 // ## What is pinned here
 //
 // 1. The pre-flight names the one condition that provably causes this, on the SELECTION
-//    and on its boundary NEIGHBOURS, and refuses before anything is mutated.
+//    and on its upstream PRODUCERS, refuses before anything is mutated — and refuses
+//    neither a downstream consumer nor an unlinked selected node.
 // 2. It refuses ONLY on a nullish back-reference — never on graph identity, which on a
 //    reactive frontend would read a Vue proxy of the live root as a foreign graph and
 //    refuse every conversion (the #558 proxy/raw duality).
@@ -77,7 +88,8 @@ const code = () =>
     .join("\n");
 
 /** The chain measured in the browser: 1→2→3→4, links 10/11/12, live-litegraph `Map`
- *  link table. Selecting [2, 3] makes 1 and 4 the boundary neighbours. */
+ *  link table. Selecting [2, 3] makes node 1 the upstream PRODUCER and node 4 the
+ *  downstream CONSUMER — the two that fail differently. */
 function chain({ linksAs = "map" } = {}) {
   const n1 = { id: 1, inputs: [], outputs: [{ links: [10] }] };
   const n2 = { id: 2, inputs: [{ link: 10 }], outputs: [{ links: [11] }] };
@@ -109,10 +121,10 @@ function chain({ linksAs = "map" } = {}) {
 /* 1. the pre-flight finds the condition that throws                           */
 /* -------------------------------------------------------------------------- */
 
-test("a detached boundary NEIGHBOUR is found — that is the destructive case", () => {
+test("a detached upstream PRODUCER is found — that is the destructive case", () => {
   const { graph, n1, n2, n3 } = chain();
-  n1.graph = null; // node 1 is outside the selection; the reconnect loop touches it
-  assert.deepEqual(detachedConversionNodes(graph, [n2, n3]), [{ id: 1, role: "neighbour" }]);
+  n1.graph = null; // node 1 feeds the selection; the reconnect calls connectSlots ON it
+  assert.deepEqual(detachedConversionNodes(graph, [n2, n3]), [{ id: 1, role: "producer" }]);
 });
 
 test("a detached SELECTED node is found too", () => {
@@ -126,13 +138,13 @@ test("a healthy chain produces no finding", () => {
   assert.deepEqual(detachedConversionNodes(graph, [n2, n3]), []);
 });
 
-test("neighbours are found through a serialized link table as well as a live Map", () => {
+test("producers are found through a serialized link table as well as a live Map", () => {
   for (const linksAs of ["map", "tuples", "object"]) {
     const { graph, n1, n2, n3 } = chain({ linksAs });
     n1.graph = null;
     assert.deepEqual(
       detachedConversionNodes(graph, [n2, n3]),
-      [{ id: 1, role: "neighbour" }],
+      [{ id: 1, role: "producer" }],
       `link table: ${linksAs}`,
     );
   }
@@ -141,6 +153,41 @@ test("neighbours are found through a serialized link table as well as a live Map
 /* -------------------------------------------------------------------------- */
 /* 2. it refuses on nothing else                                               */
 /* -------------------------------------------------------------------------- */
+
+test("a detached DOWNSTREAM consumer is NOT refused — the conversion survives it", () => {
+  // gate r5 P1. Direction decides fatality, and the first version swept both, so a
+  // conversion the frontend completes was hard-refused with a destructive-sounding
+  // reason. Read out of the installed frontend: the output-side reconnect is
+  // `subgraphNode.connectSlots(output, inputNode, …)` — `this` is the freshly added
+  // wrapper, never the consumer — and `disconnectOutput` dereferences only `this.graph`
+  // while writing `target.inputs[slot].link = null`. Nothing reads the consumer's graph.
+  const { graph, n2, n3, n4 } = chain();
+  n4.graph = null; // node 4 consumes the selection's output
+  assert.deepEqual(detachedConversionNodes(graph, [n2, n3]), []);
+});
+
+test("a detached node that is BOTH a consumer and a producer is still refused", () => {
+  // Direction is per-edge, not per-node: if it feeds anything selected, it is fatal.
+  const { graph, n1, n2, n3, n4 } = chain();
+  n1.graph = null;
+  n4.graph = null;
+  assert.deepEqual(detachedConversionNodes(graph, [n2, n3]), [{ id: 1, role: "producer" }]);
+});
+
+test("a detached SELECTED node with no links at all is not refused", () => {
+  // Measured in-browser: two detached, unlinked nodes wrap without error, because a
+  // selected node is only dereferenced through disconnectInput/disconnectOutput and
+  // LGraph.remove reaches those per-link.
+  const loose = { id: 7, inputs: [], outputs: [{ links: [] }], graph: null };
+  const byId = new Map([[7, loose]]);
+  const graph = { getNodeById: (id) => byId.get(id) ?? null, links: new Map(), subgraphs: new Map() };
+  assert.deepEqual(detachedConversionNodes(graph, [loose]), []);
+
+  // …but one carrying a single link is.
+  const wired = { id: 8, inputs: [{ link: 10 }], outputs: [], graph: null };
+  byId.set(8, wired);
+  assert.deepEqual(detachedConversionNodes(graph, [wired]), [{ id: 8, role: "selected" }]);
+});
 
 test("a node whose graph is a DIFFERENT object is never reported", () => {
   // On a reactive frontend `node.graph` and the graph handed to a command can be a Vue
@@ -172,16 +219,16 @@ test("an empty selection produces no finding", () => {
 test("the refusal states the graph was not touched, and names the nodes", () => {
   const msg = detachedConversionRefusal({
     what: "panel_create_subgraph",
-    detached: [{ id: 1, role: "neighbour" }],
+    detached: [{ id: 1, role: "producer" }],
   });
   assert.match(msg, /was NOT run and the graph is unchanged/);
-  assert.match(msg, /node 1 wired to it/);
+  assert.match(msg, /node 1 feeding it/);
   // It must carry the string the reporter would search for.
   assert.match(msg, /Attempted to access LGraph reference that was null or undefined\./);
 });
 
 test("the refusal names the consequence of the ROLE it found, not the other one", () => {
-  // gate r3 P1: one sentence was emitted for both, and it described the neighbour
+  // gate r3 P1: one sentence was emitted for both, and it described the producer
   // outcome. The selected-node path throws at disconnectInput — before the removal
   // loop — so "already removed the nodes you selected" was a state it never reaches.
   const picked = detachedConversionRefusal({
@@ -194,26 +241,26 @@ test("the refusal names the consequence of the ROLE it found, not the other one"
   assert.doesNotMatch(picked, /the nodes you selected are gone/);
   assert.doesNotMatch(picked, /wired to nothing/);
 
-  const neighbour = detachedConversionRefusal({
+  const producer = detachedConversionRefusal({
     what: "panel_subgraph_group",
-    detached: [{ id: 1, role: "neighbour" }],
+    detached: [{ id: 1, role: "producer" }],
   });
-  assert.match(neighbour, /in the reconnect pass/);
-  assert.match(neighbour, /the nodes you selected are gone/);
-  assert.doesNotMatch(neighbour, /throw at disconnectInput/);
+  assert.match(producer, /in the reconnect pass/);
+  assert.match(producer, /the nodes you selected are gone/);
+  assert.doesNotMatch(producer, /throw at disconnectInput/);
 
   // Both roles present: both consequences stated, neither invented.
   const both = detachedConversionRefusal({
     what: "panel_create_subgraph",
-    detached: [{ id: 2, role: "selected" }, { id: 1, role: "neighbour" }],
+    detached: [{ id: 2, role: "selected" }, { id: 1, role: "producer" }],
   });
-  assert.match(both, /node 2 in your selection, and node 1 wired to it/);
+  assert.match(both, /node 2 in your selection, and node 1 feeding it/);
   assert.match(both, /throw at disconnectInput/);
   assert.match(both, /in the reconnect pass/);
 
   // gate r4: "every other panel tool keeps working meanwhile" was not true either — a
   // detached node throws out of the disconnect paths too. Same habit, smaller stakes.
-  for (const msg of [picked, neighbour, both]) {
+  for (const msg of [picked, producer, both]) {
     assert.doesNotMatch(msg, /Every other panel tool keeps working/);
     assert.match(msg, /anything that disconnects or removes it can hit the same throw/);
   }

--- a/browser_tests/unit/subgraph-conversion-throw-verdict.test.mjs
+++ b/browser_tests/unit/subgraph-conversion-throw-verdict.test.mjs
@@ -254,6 +254,14 @@ test("nothing moved → the report says so, and that there is nothing to undo", 
   assert.match(msg, /link table is unchanged at 3 entries/);
   assert.doesNotMatch(msg, /HAS CHANGED/);
   assert.ok(msg.includes(RAW));
+  // `wrapped` is an own-property test, so it cannot see a patch on LGraph.prototype.
+  // The sentence must therefore claim only what was measured — this graph OBJECT.
+  assert.match(msg, /nothing on this graph object overrides/);
+  assert.doesNotMatch(
+    msg,
+    /nothing has replaced convertToSubgraph/,
+    "a prototype-level patch would make that wider claim false",
+  );
 });
 
 test("a WRAPPED convertToSubgraph withdraws the confident verdict — the gate P1", () => {

--- a/browser_tests/unit/subgraph-conversion-throw-verdict.test.mjs
+++ b/browser_tests/unit/subgraph-conversion-throw-verdict.test.mjs
@@ -112,13 +112,13 @@ function chain({ linksAs = "map" } = {}) {
 test("a detached boundary NEIGHBOUR is found — that is the destructive case", () => {
   const { graph, n1, n2, n3 } = chain();
   n1.graph = null; // node 1 is outside the selection; the reconnect loop touches it
-  assert.deepEqual(detachedConversionNodes(graph, [n2, n3]), [1]);
+  assert.deepEqual(detachedConversionNodes(graph, [n2, n3]), [{ id: 1, role: "neighbour" }]);
 });
 
 test("a detached SELECTED node is found too", () => {
   const { graph, n2, n3 } = chain();
   n2.graph = null;
-  assert.deepEqual(detachedConversionNodes(graph, [n2, n3]), [2]);
+  assert.deepEqual(detachedConversionNodes(graph, [n2, n3]), [{ id: 2, role: "selected" }]);
 });
 
 test("a healthy chain produces no finding", () => {
@@ -130,7 +130,11 @@ test("neighbours are found through a serialized link table as well as a live Map
   for (const linksAs of ["map", "tuples", "object"]) {
     const { graph, n1, n2, n3 } = chain({ linksAs });
     n1.graph = null;
-    assert.deepEqual(detachedConversionNodes(graph, [n2, n3]), [1], `link table: ${linksAs}`);
+    assert.deepEqual(
+      detachedConversionNodes(graph, [n2, n3]),
+      [{ id: 1, role: "neighbour" }],
+      `link table: ${linksAs}`,
+    );
   }
 });
 
@@ -166,11 +170,46 @@ test("an empty selection produces no finding", () => {
 });
 
 test("the refusal states the graph was not touched, and names the nodes", () => {
-  const msg = detachedConversionRefusal({ what: "panel_create_subgraph", detached: [1] });
+  const msg = detachedConversionRefusal({
+    what: "panel_create_subgraph",
+    detached: [{ id: 1, role: "neighbour" }],
+  });
   assert.match(msg, /was NOT run and the graph is unchanged/);
-  assert.match(msg, /Node 1 /);
+  assert.match(msg, /node 1 wired to it/);
   // It must carry the string the reporter would search for.
   assert.match(msg, /Attempted to access LGraph reference that was null or undefined\./);
+});
+
+test("the refusal names the consequence of the ROLE it found, not the other one", () => {
+  // gate r3 P1: one sentence was emitted for both, and it described the neighbour
+  // outcome. The selected-node path throws at disconnectInput — before the removal
+  // loop — so "already removed the nodes you selected" was a state it never reaches.
+  const picked = detachedConversionRefusal({
+    what: "panel_create_subgraph",
+    detached: [{ id: 2, role: "selected" }],
+  });
+  assert.match(picked, /node 2 in your selection/);
+  assert.match(picked, /throw at disconnectInput/);
+  assert.match(picked, /registered a subgraph definition/);
+  assert.doesNotMatch(picked, /the nodes you selected are gone/);
+  assert.doesNotMatch(picked, /wired to nothing/);
+
+  const neighbour = detachedConversionRefusal({
+    what: "panel_subgraph_group",
+    detached: [{ id: 1, role: "neighbour" }],
+  });
+  assert.match(neighbour, /in the reconnect pass/);
+  assert.match(neighbour, /the nodes you selected are gone/);
+  assert.doesNotMatch(neighbour, /throw at disconnectInput/);
+
+  // Both roles present: both consequences stated, neither invented.
+  const both = detachedConversionRefusal({
+    what: "panel_create_subgraph",
+    detached: [{ id: 2, role: "selected" }, { id: 1, role: "neighbour" }],
+  });
+  assert.match(both, /node 2 in your selection, and node 1 wired to it/);
+  assert.match(both, /throw at disconnectInput/);
+  assert.match(both, /in the reconnect pass/);
 });
 
 /* -------------------------------------------------------------------------- */
@@ -476,4 +515,185 @@ test("the runner refuses BEFORE the conversion and keeps beforeChange/afterChang
   assert.ok(fn.includes("graph.afterChange?.()"), "afterChange must still be called");
   assert.ok(fn.includes("finally"), "afterChange must stay in a finally");
   assert.ok(fn.includes("{ cause: err }"), "the frontend's own error must be kept as the cause");
+});
+
+/* -------------------------------------------------------------------------- */
+/* 6. the runner EXECUTED, not read                                            */
+/*                                                                             */
+/* gate r3 P1: everything above pinned the helpers, and section 5 pinned the    */
+/* call sites — as REGEXES over source text, which an inert guard satisfies.    */
+/* `if (detached.length)` → `if (detached.length > 2)` passed the whole 5,799-  */
+/* test suite while the exact #1463 state reached convertToSubgraph and         */
+/* destroyed the selection. These drive the shipped runner instead.             */
+/* -------------------------------------------------------------------------- */
+
+/** The shipped `convertSelectionToSubgraph`, extracted from the monolith and wired to
+ *  the REAL lib helpers — the same pattern subgraph-stale-outline.test.mjs uses on the
+ *  two executors. A stub would defeat the point of this section. */
+const runner = (() => {
+  const match = src()
+    .replace(/\r\n/g, "\n")
+    .match(/function convertSelectionToSubgraph\(\{ graph, canvas, nodes, what \}\) \{[\s\S]*?\n\}/);
+  assert.ok(match, "could not locate convertSelectionToSubgraph in panel source");
+  return new Function(
+    "detachedConversionNodes",
+    "detachedConversionRefusal",
+    "conversionSnapshot",
+    "conversionThrowReport",
+    `return ${match[0]};`,
+  )(detachedConversionNodes, detachedConversionRefusal, conversionSnapshot, conversionThrowReport);
+})();
+
+/** A graph/canvas pair that records what the runner did to it.
+ *
+ *  `wrapped` decides WHERE `convertToSubgraph` lives. A stock frontend carries it on
+ *  `LGraph.prototype`, so the default puts it on a prototype — hanging the fake straight
+ *  off the graph object would make every rig look monkey-patched to the snapshot, and
+ *  the confident verdict would be unreachable in these tests for the wrong reason. */
+function rig({ convert, noSelectionApi = false, wrapped = false } = {}) {
+  const { graph: base, n1, n2, n3, n4 } = chain();
+  const calls = [];
+  let graph;
+  const convertToSubgraph = (items) => {
+    calls.push("convertToSubgraph");
+    return convert
+      ? convert(items, graph)
+      : { node: { id: 99 }, subgraph: { name: "New Subgraph" } };
+  };
+  graph = Object.create(wrapped ? {} : { convertToSubgraph });
+  Object.assign(graph, {
+    getNodeById: (id) => base.getNodeById(id),
+    links: base.links,
+    subgraphs: base.subgraphs,
+    beforeChange: () => calls.push("beforeChange"),
+    afterChange: () => calls.push("afterChange"),
+  });
+  if (wrapped) graph.convertToSubgraph = convertToSubgraph;
+  for (const n of [n1, n2, n3, n4]) n.graph = graph;
+  const canvas = { selectedItems: new Set() };
+  if (!noSelectionApi) {
+    canvas.selectItems = (items) => {
+      calls.push("selectItems");
+      canvas.selectedItems = new Set(items);
+    };
+  }
+  return { graph, canvas, calls, n1, n2, n3, n4 };
+}
+
+test("EXECUTED: a detached NEIGHBOUR is refused and the frontend is never called", () => {
+  const { graph, canvas, calls, n1, n2, n3 } = rig();
+  n1.graph = null;
+  assert.throws(
+    () => runner({ graph, canvas, nodes: [n2, n3], what: "panel_create_subgraph" }),
+    /was NOT run and the graph is unchanged/,
+  );
+  assert.ok(!calls.includes("convertToSubgraph"), "the conversion must not have been attempted");
+  assert.ok(!calls.includes("beforeChange"), "and no change window must have been opened");
+});
+
+test("EXECUTED: a detached SELECTED node is refused and the frontend is never called", () => {
+  const { graph, canvas, calls, n2, n3 } = rig();
+  n2.graph = null;
+  assert.throws(
+    () => runner({ graph, canvas, nodes: [n2, n3], what: "panel_subgraph_group" }),
+    /registered a subgraph definition/,
+  );
+  assert.ok(!calls.includes("convertToSubgraph"));
+});
+
+test("EXECUTED: a healthy selection is selected, converted, and returned unchanged", () => {
+  const { graph, canvas, calls, n2, n3 } = rig();
+  const res = runner({ graph, canvas, nodes: [n2, n3], what: "panel_create_subgraph" });
+  assert.equal(res.node.id, 99, "the frontend's own result must come back untouched");
+  assert.deepEqual(calls, ["selectItems", "beforeChange", "convertToSubgraph", "afterChange"]);
+  assert.deepEqual([...canvas.selectedItems], [n2, n3], "the runner must select what it was given");
+});
+
+test("EXECUTED: a frontend with no selection API is refused, not fallen through", () => {
+  const { graph, canvas, calls, n2, n3 } = rig({ noSelectionApi: true });
+  canvas.selectedItems = new Set([graph.getNodeById(1)]); // a stale selection to convert
+  assert.throws(
+    () => runner({ graph, canvas, nodes: [n2, n3], what: "panel_create_subgraph" }),
+    /exposes no selection API/,
+  );
+  assert.ok(!calls.includes("convertToSubgraph"), "the stale selection must not be converted");
+});
+
+test("EXECUTED: a destructive throw is reported as CHANGED, with the cause kept", () => {
+  const original = new Error("Attempted to access LGraph reference that was null or undefined.");
+  const { graph, canvas, calls, n2, n3 } = rig({
+    convert: (_items, g) => {
+      // Reproduce the shipped order: definition registered, selected nodes removed.
+      g.subgraphs.set("new-def", {});
+      const byId = new Map([[1, g.getNodeById(1)], [4, g.getNodeById(4)]]);
+      g.getNodeById = (id) => byId.get(id) ?? null;
+      throw original;
+    },
+  });
+  try {
+    runner({ graph, canvas, nodes: [n2, n3], what: "panel_create_subgraph" });
+    assert.fail("the runner must rethrow");
+  } catch (err) {
+    assert.match(err.message, /HAS CHANGED/);
+    assert.match(err.message, /2 of the 2 node\(s\) you selected \(2, 3\)/);
+    assert.match(err.message, /1 subgraph definition\(s\) were registered/);
+    assert.ok(err.message.includes(original.message), "the frontend's wording must survive");
+    assert.equal(err.cause, original, "the original error must be the cause");
+  }
+  assert.ok(calls.includes("afterChange"), "afterChange must still run on the throw path");
+});
+
+test("EXECUTED: a throw that moved nothing is reported as unchanged", () => {
+  const original = new Error("Attempted to access LGraph reference that was null or undefined.");
+  const { graph, canvas, n2, n3 } = rig({
+    convert: () => {
+      throw original;
+    },
+  });
+  assert.throws(
+    () => runner({ graph, canvas, nodes: [n2, n3], what: "panel_create_subgraph" }),
+    (err) => {
+      assert.match(err.message, /nothing the panel can read moved/);
+      assert.doesNotMatch(err.message, /HAS CHANGED/);
+      return true;
+    },
+  );
+});
+
+test("EXECUTED: the same still graph under a WRAPPED method withdraws the verdict", () => {
+  // Identical to the test above except where convertToSubgraph lives. Nothing the
+  // snapshot reads moved either way; only the wrapper changes what may be claimed.
+  const { graph, canvas, n2, n3 } = rig({
+    wrapped: true,
+    convert: () => {
+      throw new Error("Attempted to access LGraph reference that was null or undefined.");
+    },
+  });
+  assert.throws(
+    () => runner({ graph, canvas, nodes: [n2, n3], what: "panel_create_subgraph" }),
+    (err) => {
+      assert.match(err.message, /could NOT establish whether the graph changed/);
+      assert.doesNotMatch(err.message, /nothing the panel can read moved/);
+      return true;
+    },
+  );
+});
+
+test("EXECUTED: a link table the wrapper grew is reported as CHANGED", () => {
+  // The gate r1 P1 state, driven end to end: nodes and definitions untouched, links not.
+  const { graph, canvas, n2, n3 } = rig({
+    wrapped: true,
+    convert: (_items, g) => {
+      g.links.set(99, { id: 99, origin_id: 1, target_id: 4 });
+      throw new Error("Attempted to access LGraph reference that was null or undefined.");
+    },
+  });
+  assert.throws(
+    () => runner({ graph, canvas, nodes: [n2, n3], what: "panel_create_subgraph" }),
+    (err) => {
+      assert.match(err.message, /HAS CHANGED/);
+      assert.match(err.message, /the link table went from 3 to 4 entries/);
+      return true;
+    },
+  );
 });

--- a/browser_tests/unit/subgraph-conversion-throw-verdict.test.mjs
+++ b/browser_tests/unit/subgraph-conversion-throw-verdict.test.mjs
@@ -18,14 +18,27 @@
 //     node 5 is the new subgraph node; its input link is `null`
 //
 // The selected nodes were REMOVED, a definition was registered, and the wrapper was left
-// wired to nothing — reported to the caller as a bare exception. Clearing the back
-// reference on a SELECTED node instead throws with the canvas untouched, and an extension
-// that wraps `convertToSubgraph` (cg-use-everywhere replaces `app.graph.convertToSubgraph`
-// with a whole-graph pre-pass; its frames are in the reproduction's stack) throws before
-// the frontend's own code runs at all.
+// wired to nothing — reported to the caller as a bare exception.
 //
-// One message, two opposite states of the canvas. The caller's correct next move — retry,
-// or undo and re-read — differs completely between them, and it had no way to tell.
+// Clearing the back-reference on a SELECTED node instead throws at `disconnectInput`,
+// which the shipped `_convertToSubgraphImpl` runs AFTER `createSubgraph`. Measured
+// through `LGraph.prototype.convertToSubgraph`, bypassing the wrapper this install has:
+//
+//     nodes 1,2,3,4 → 1,2,3,4   but   subgraph defs 0 → 1
+//
+// So the two failures are not "destroyed" versus "untouched": one loses nodes, the other
+// quietly registers a definition, and both print the same sentence.
+//
+// ## The claim that may NOT be made (gate P1 on the first version of this)
+//
+// The first version answered "the graph is UNCHANGED … nothing to undo" from node
+// presence and the definition count alone. `convertToSubgraph` is instance-assignable
+// and extensions replace it — cg-use-everywhere sets `app.graph.convertToSubgraph` to a
+// wrapper that rewires links, delegates, and calls its restorer OUTSIDE a `finally`, so
+// a throw from the delegate leaves injected links behind with every node and definition
+// exactly where it was. The old code said nothing; that version said something confidently
+// wrong, which is worse. The confident verdict is now gated on the link table too, and on
+// nothing having replaced `convertToSubgraph` on the graph object.
 //
 // ## What is pinned here
 //
@@ -34,10 +47,12 @@
 // 2. It refuses ONLY on a nullish back-reference — never on graph identity, which on a
 //    reactive frontend would read a Vue proxy of the live root as a foreign graph and
 //    refuse every conversion (the #558 proxy/raw duality).
-// 3. A throw is reported with a measured verdict, and the frontend's message survives
-//    verbatim in all three verdicts so that existing searches for it still hit.
-// 4. Both tool entry points route through it. A helper nobody calls fixes nothing, and
-//    #1463 reported BOTH paths failing identically.
+// 3. A throw is reported with a measured verdict; "unchanged" requires every surface
+//    readable, still, and unwrapped; and the frontend's message survives verbatim in all
+//    three verdicts so that existing searches for it still hit.
+// 4. Both tool entry points route through it, and the runner makes the selection itself
+//    rather than converting whatever happened to be selected. A helper nobody calls fixes
+//    nothing, and #1463 reported BOTH paths failing identically.
 
 import test from "node:test";
 import assert from "node:assert/strict";
@@ -164,12 +179,22 @@ test("the refusal states the graph was not touched, and names the nodes", () => 
 
 const RAW = "Attempted to access LGraph reference that was null or undefined.";
 
+/** A fully readable, unwrapped snapshot — the only shape that may yield "unchanged". */
+const snap = (over = {}) => ({
+  present: [2, 3],
+  readable: true,
+  definitions: 0,
+  links: 3,
+  wrapped: false,
+  ...over,
+});
+
 test("nodes gone → the report says the graph CHANGED and names them", () => {
   const msg = conversionThrowReport({
     what: "panel_create_subgraph",
     message: RAW,
-    before: { present: [2, 3], readable: true, definitions: 0 },
-    after: { present: [], readable: true, definitions: 1 },
+    before: snap(),
+    after: snap({ present: [], definitions: 1 }),
   });
   assert.match(msg, /FAILED PART WAY THROUGH and the graph HAS CHANGED/);
   assert.match(msg, /2 of the 2 node\(s\) you selected \(2, 3\)/);
@@ -182,36 +207,106 @@ test("a definition registered with every node still present also counts as CHANG
   const msg = conversionThrowReport({
     what: "panel_subgraph_group",
     message: RAW,
-    before: { present: [2, 3], readable: true, definitions: 0 },
-    after: { present: [2, 3], readable: true, definitions: 1 },
+    before: snap(),
+    after: snap({ definitions: 1 }),
   });
   assert.match(msg, /HAS CHANGED/);
-  assert.match(msg, /every node you selected is still on the canvas/);
+  assert.match(msg, /1 subgraph definition\(s\) were registered/);
+  assert.doesNotMatch(msg, /already off the canvas/);
 });
 
-test("nothing moved → the report says UNCHANGED and that there is nothing to undo", () => {
+test("LINK-level mutation alone counts as CHANGED — the gate P1", () => {
+  // cg-use-everywhere's wrapper injects links, delegates, and restores OUTSIDE a
+  // `finally`. On a throw the links stay while every node and definition is where it
+  // was, and the first version of this reported "UNCHANGED … nothing to undo".
   const msg = conversionThrowReport({
     what: "panel_create_subgraph",
     message: RAW,
-    before: { present: [2, 3], readable: true, definitions: 0 },
-    after: { present: [2, 3], readable: true, definitions: 0 },
+    before: snap({ links: 3, wrapped: true }),
+    after: snap({ links: 4, wrapped: true }),
   });
-  assert.match(msg, /the graph is UNCHANGED/);
+  assert.match(msg, /HAS CHANGED/);
+  assert.match(msg, /the link table went from 3 to 4 entries/);
+  assert.doesNotMatch(msg, /nothing to undo/);
+  // Nothing was removed, so it must not invent a half-built wrapper on the canvas.
+  assert.doesNotMatch(msg, /wired to nothing/);
+});
+
+test("a link table that SHRANK is a change too", () => {
+  const msg = conversionThrowReport({
+    what: "panel_create_subgraph",
+    message: RAW,
+    before: snap({ links: 4 }),
+    after: snap({ links: 3 }),
+  });
+  assert.match(msg, /HAS CHANGED/);
+});
+
+test("nothing moved → the report says so, and that there is nothing to undo", () => {
+  const msg = conversionThrowReport({
+    what: "panel_create_subgraph",
+    message: RAW,
+    before: snap(),
+    after: snap(),
+  });
+  assert.match(msg, /nothing the panel can read moved/);
   assert.match(msg, /nothing to undo/);
+  assert.match(msg, /link table is unchanged at 3 entries/);
   assert.doesNotMatch(msg, /HAS CHANGED/);
   assert.ok(msg.includes(RAW));
+});
+
+test("a WRAPPED convertToSubgraph withdraws the confident verdict — the gate P1", () => {
+  // Every observed surface is still, but something is in the call path that can move a
+  // surface this cannot see. "Nothing to undo" is then a claim, not a measurement.
+  const msg = conversionThrowReport({
+    what: "panel_create_subgraph",
+    message: RAW,
+    before: snap({ wrapped: true }),
+    after: snap({ wrapped: true }),
+  });
+  assert.match(msg, /could NOT establish whether the graph changed/);
+  assert.match(msg, /replaced convertToSubgraph on this graph/);
+  assert.doesNotMatch(msg, /nothing to undo/);
+  assert.doesNotMatch(msg, /nothing the panel can read moved/);
+  // It still reports what it DID measure.
+  assert.match(msg, /All 2 node\(s\) you selected are still on the canvas/);
+});
+
+test("an uncountable link table withdraws the confident verdict", () => {
+  const msg = conversionThrowReport({
+    what: "panel_create_subgraph",
+    message: RAW,
+    before: snap({ links: null }),
+    after: snap({ links: null }),
+  });
+  assert.match(msg, /could NOT establish/);
+  assert.match(msg, /link table could not be counted/);
+  assert.doesNotMatch(msg, /nothing to undo/);
+});
+
+test("an uncountable definition table withdraws the confident verdict", () => {
+  const msg = conversionThrowReport({
+    what: "panel_create_subgraph",
+    message: RAW,
+    before: snap({ definitions: null }),
+    after: snap({ definitions: null }),
+  });
+  assert.match(msg, /could NOT establish/);
+  assert.match(msg, /subgraph definitions could not be counted/);
 });
 
 test("an unreadable snapshot is reported as UNKNOWN, never as untouched", () => {
   const msg = conversionThrowReport({
     what: "panel_create_subgraph",
     message: RAW,
-    before: { present: [], readable: false, definitions: null },
-    after: { present: [], readable: false, definitions: null },
+    before: { present: [], readable: false, definitions: null, links: null, wrapped: false },
+    after: { present: [], readable: false, definitions: null, links: null, wrapped: false },
   });
   assert.match(msg, /could NOT establish whether the graph changed/);
   assert.match(msg, /unknown rather than untouched/);
-  assert.doesNotMatch(msg, /the graph is UNCHANGED/);
+  assert.match(msg, /does not expose the node lookup/);
+  assert.doesNotMatch(msg, /nothing the panel can read moved/);
   assert.ok(msg.includes(RAW));
 });
 
@@ -220,17 +315,21 @@ test("a definition COUNT that only fell is not reported as a change", () => {
   const msg = conversionThrowReport({
     what: "panel_create_subgraph",
     message: RAW,
-    before: { present: [2], readable: true, definitions: 3 },
-    after: { present: [2], readable: true, definitions: 2 },
+    before: snap({ present: [2], definitions: 3 }),
+    after: snap({ present: [2], definitions: 2 }),
   });
-  assert.match(msg, /the graph is UNCHANGED/);
+  assert.match(msg, /nothing the panel can read moved/);
 });
 
 test("every verdict names the tool and attributes the throw to the frontend", () => {
   const cases = [
-    { before: { present: [2], readable: true, definitions: 0 }, after: { present: [], readable: true, definitions: 1 } },
-    { before: { present: [2], readable: true, definitions: 0 }, after: { present: [2], readable: true, definitions: 0 } },
-    { before: { present: [], readable: false, definitions: null }, after: { present: [], readable: false, definitions: null } },
+    { before: snap(), after: snap({ present: [], definitions: 1 }) },
+    { before: snap(), after: snap() },
+    { before: snap({ wrapped: true }), after: snap({ wrapped: true }) },
+    {
+      before: { present: [], readable: false, definitions: null, links: null, wrapped: false },
+      after: { present: [], readable: false, definitions: null, links: null, wrapped: false },
+    },
   ];
   for (const c of cases) {
     const msg = conversionThrowReport({ what: "panel_subgraph_group", message: RAW, ...c });
@@ -273,10 +372,34 @@ test("a re-issued id does not read as the original node surviving", () => {
 
 test("a frontend with no node lookup reports itself unreadable rather than empty", () => {
   const { n2, n3 } = chain();
-  const snap = conversionSnapshot({}, [n2, n3]);
-  assert.equal(snap.readable, false);
-  assert.deepEqual(snap.present, [2, 3]);
-  assert.equal(snap.definitions, null);
+  const taken = conversionSnapshot({}, [n2, n3]);
+  assert.equal(taken.readable, false);
+  assert.deepEqual(taken.present, [2, 3]);
+  assert.equal(taken.definitions, null);
+  assert.equal(taken.links, null);
+});
+
+test("the link table is counted in every shape, and reported null when it is not there", () => {
+  for (const [linksAs, expected] of [["map", 3], ["tuples", 3], ["object", 3]]) {
+    const { graph, n2, n3 } = chain({ linksAs });
+    assert.equal(conversionSnapshot(graph, [n2, n3]).links, expected, `shape: ${linksAs}`);
+  }
+  assert.equal(conversionSnapshot({ getNodeById: () => null }, []).links, null);
+});
+
+test("a wrapper on convertToSubgraph is detected, and the stock prototype method is not", () => {
+  // Measured on this install: the method exists on LGraph.prototype AND cg-use-everywhere
+  // assigns an own property over it. Only the own property means an extension is in the
+  // call path, so only that may withdraw the confident verdict.
+  const proto = { convertToSubgraph() {} };
+  const stock = Object.create(proto);
+  stock.getNodeById = () => null;
+  assert.equal(conversionSnapshot(stock, []).wrapped, false, "an inherited method is not a wrapper");
+
+  const wrapped = Object.create(proto);
+  wrapped.getNodeById = () => null;
+  wrapped.convertToSubgraph = function () {};
+  assert.equal(conversionSnapshot(wrapped, []).wrapped, true, "an own property is a wrapper");
 });
 
 /* -------------------------------------------------------------------------- */
@@ -295,6 +418,31 @@ test("neither conversion tool calls convertToSubgraph bare any more", () => {
   assert.ok(
     runner.slice(0, runner.indexOf("\nfunction ")).includes("graph.convertToSubgraph(canvas.selectedItems)"),
     "the surviving call site must be the runner's",
+  );
+});
+
+test("the two conversion tools no longer select for themselves — the runner does", () => {
+  // Both had the same hole: with neither selection API present they fell through and
+  // converted `canvas.selectedItems` as they found it, which is a set the caller never
+  // named. Selection belongs to the runner now, where it can refuse instead.
+  const body = code();
+  for (const marker of ['what: "panel_create_subgraph"', 'what: "panel_subgraph_group"']) {
+    const at = body.indexOf(marker);
+    assert.ok(at > 0, `${marker} must be present`);
+    const before = body.slice(Math.max(0, at - 700), at);
+    assert.doesNotMatch(
+      before,
+      /canvas\.select(Items|Nodes)\(ns\)/,
+      `${marker}: the executor must not make the selection itself`,
+    );
+  }
+  const runner = body.slice(body.indexOf("function convertSelectionToSubgraph("));
+  const fn = runner.slice(0, runner.indexOf("\nfunction "));
+  assert.ok(fn.includes("canvas?.selectItems"), "the runner must make the selection");
+  assert.ok(fn.includes("canvas?.selectNodes"), "including the deprecated fallback");
+  assert.ok(
+    fn.indexOf("selection API") < fn.indexOf("graph.convertToSubgraph"),
+    "a frontend with no selection API must be refused before the conversion, not after",
   );
 });
 

--- a/browser_tests/unit/subgraph-conversion-throw-verdict.test.mjs
+++ b/browser_tests/unit/subgraph-conversion-throw-verdict.test.mjs
@@ -1,0 +1,319 @@
+// comfyui-mcp-panel#1463 — `panel_create_subgraph` / `panel_subgraph_group` both failed
+// with nothing but the frontend's own exception text:
+//
+//     Error: Attempted to access LGraph reference that was null or undefined.
+//
+// The reporter concluded "no other side effects", retried three times, then tried the
+// group entry point, then a two-node native-only selection, and got the identical string
+// every time. Six failures, no information.
+//
+// ## What was measured (real browser, the ComfyUI on this machine)
+//
+// Root graph `1→2→3→4` wired in a chain, node 1's `graph` back-reference cleared,
+// converting the middle pair `[2, 3]`:
+//
+//     nodes before: 1,2,3,4        subgraph definitions: 0
+//     → throws "Attempted to access LGraph reference that was null or undefined."
+//     nodes after:  1,4,5          subgraph definitions: 1
+//     node 5 is the new subgraph node; its input link is `null`
+//
+// The selected nodes were REMOVED, a definition was registered, and the wrapper was left
+// wired to nothing — reported to the caller as a bare exception. Clearing the back
+// reference on a SELECTED node instead throws with the canvas untouched, and an extension
+// that wraps `convertToSubgraph` (cg-use-everywhere replaces `app.graph.convertToSubgraph`
+// with a whole-graph pre-pass; its frames are in the reproduction's stack) throws before
+// the frontend's own code runs at all.
+//
+// One message, two opposite states of the canvas. The caller's correct next move — retry,
+// or undo and re-read — differs completely between them, and it had no way to tell.
+//
+// ## What is pinned here
+//
+// 1. The pre-flight names the one condition that provably causes this, on the SELECTION
+//    and on its boundary NEIGHBOURS, and refuses before anything is mutated.
+// 2. It refuses ONLY on a nullish back-reference — never on graph identity, which on a
+//    reactive frontend would read a Vue proxy of the live root as a foreign graph and
+//    refuse every conversion (the #558 proxy/raw duality).
+// 3. A throw is reported with a measured verdict, and the frontend's message survives
+//    verbatim in all three verdicts so that existing searches for it still hit.
+// 4. Both tool entry points route through it. A helper nobody calls fixes nothing, and
+//    #1463 reported BOTH paths failing identically.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+import {
+  detachedConversionNodes,
+  detachedConversionRefusal,
+  conversionSnapshot,
+  conversionThrowReport,
+} from "../../web/js/lib/subgraph-conversion-integrity.js";
+
+const src = () =>
+  readFileSync(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8");
+
+/** Source with comment lines stripped — the guard's own doc comment quotes the code it
+ *  replaced, and matching that would pass on a reverted tree. */
+const code = () =>
+  src()
+    .split(/\r?\n/)
+    .filter((line) => !/^\s*(\*|\/\/)/.test(line))
+    .join("\n");
+
+/** The chain measured in the browser: 1→2→3→4, links 10/11/12, live-litegraph `Map`
+ *  link table. Selecting [2, 3] makes 1 and 4 the boundary neighbours. */
+function chain({ linksAs = "map" } = {}) {
+  const n1 = { id: 1, inputs: [], outputs: [{ links: [10] }] };
+  const n2 = { id: 2, inputs: [{ link: 10 }], outputs: [{ links: [11] }] };
+  const n3 = { id: 3, inputs: [{ link: 11 }], outputs: [{ links: [12] }] };
+  const n4 = { id: 4, inputs: [{ link: 12 }], outputs: [{ links: [] }] };
+  const nodes = [n1, n2, n3, n4];
+  const rawLinks = [
+    { id: 10, origin_id: 1, origin_slot: 0, target_id: 2, target_slot: 0 },
+    { id: 11, origin_id: 2, origin_slot: 0, target_id: 3, target_slot: 0 },
+    { id: 12, origin_id: 3, origin_slot: 0, target_id: 4, target_slot: 0 },
+  ];
+  const links =
+    linksAs === "map"
+      ? new Map(rawLinks.map((l) => [l.id, l]))
+      : linksAs === "tuples"
+        ? rawLinks.map((l) => [l.id, l.origin_id, l.origin_slot, l.target_id, l.target_slot])
+        : Object.fromEntries(rawLinks.map((l) => [l.id, l]));
+  const byId = new Map(nodes.map((n) => [n.id, n]));
+  const graph = {
+    getNodeById: (id) => byId.get(id) ?? null,
+    links,
+    subgraphs: new Map(),
+  };
+  for (const n of nodes) n.graph = graph;
+  return { graph, n1, n2, n3, n4 };
+}
+
+/* -------------------------------------------------------------------------- */
+/* 1. the pre-flight finds the condition that throws                           */
+/* -------------------------------------------------------------------------- */
+
+test("a detached boundary NEIGHBOUR is found — that is the destructive case", () => {
+  const { graph, n1, n2, n3 } = chain();
+  n1.graph = null; // node 1 is outside the selection; the reconnect loop touches it
+  assert.deepEqual(detachedConversionNodes(graph, [n2, n3]), [1]);
+});
+
+test("a detached SELECTED node is found too", () => {
+  const { graph, n2, n3 } = chain();
+  n2.graph = null;
+  assert.deepEqual(detachedConversionNodes(graph, [n2, n3]), [2]);
+});
+
+test("a healthy chain produces no finding", () => {
+  const { graph, n2, n3 } = chain();
+  assert.deepEqual(detachedConversionNodes(graph, [n2, n3]), []);
+});
+
+test("neighbours are found through a serialized link table as well as a live Map", () => {
+  for (const linksAs of ["map", "tuples", "object"]) {
+    const { graph, n1, n2, n3 } = chain({ linksAs });
+    n1.graph = null;
+    assert.deepEqual(detachedConversionNodes(graph, [n2, n3]), [1], `link table: ${linksAs}`);
+  }
+});
+
+/* -------------------------------------------------------------------------- */
+/* 2. it refuses on nothing else                                               */
+/* -------------------------------------------------------------------------- */
+
+test("a node whose graph is a DIFFERENT object is never reported", () => {
+  // On a reactive frontend `node.graph` and the graph handed to a command can be a Vue
+  // proxy and its raw target. Comparing graph identity would refuse every conversion.
+  const { graph, n1, n2, n3 } = chain();
+  n1.graph = { notTheSameObject: true };
+  assert.deepEqual(detachedConversionNodes(graph, [n2, n3]), []);
+});
+
+test("a node the graph does not own is never reported, however detached", () => {
+  const { graph, n2, n3 } = chain();
+  const impostor = { id: 2, graph: null, inputs: [], outputs: [] }; // same id, other object
+  assert.deepEqual(detachedConversionNodes(graph, [impostor, n2, n3]), []);
+});
+
+test("an unreadable graph falls through to the conversion instead of refusing it", () => {
+  const { n2, n3 } = chain();
+  n2.graph = null;
+  assert.deepEqual(detachedConversionNodes({ links: null }, [n2, n3]), []);
+  assert.deepEqual(detachedConversionNodes(null, [n2, n3]), []);
+});
+
+test("an empty selection produces no finding", () => {
+  const { graph } = chain();
+  assert.deepEqual(detachedConversionNodes(graph, []), []);
+  assert.deepEqual(detachedConversionNodes(graph, undefined), []);
+});
+
+test("the refusal states the graph was not touched, and names the nodes", () => {
+  const msg = detachedConversionRefusal({ what: "panel_create_subgraph", detached: [1] });
+  assert.match(msg, /was NOT run and the graph is unchanged/);
+  assert.match(msg, /Node 1 /);
+  // It must carry the string the reporter would search for.
+  assert.match(msg, /Attempted to access LGraph reference that was null or undefined\./);
+});
+
+/* -------------------------------------------------------------------------- */
+/* 3. a throw is reported with a MEASURED verdict                              */
+/* -------------------------------------------------------------------------- */
+
+const RAW = "Attempted to access LGraph reference that was null or undefined.";
+
+test("nodes gone → the report says the graph CHANGED and names them", () => {
+  const msg = conversionThrowReport({
+    what: "panel_create_subgraph",
+    message: RAW,
+    before: { present: [2, 3], readable: true, definitions: 0 },
+    after: { present: [], readable: true, definitions: 1 },
+  });
+  assert.match(msg, /FAILED PART WAY THROUGH and the graph HAS CHANGED/);
+  assert.match(msg, /2 of the 2 node\(s\) you selected \(2, 3\)/);
+  assert.match(msg, /1 subgraph definition\(s\) were registered/);
+  assert.match(msg, /do not retry blindly/);
+  assert.ok(msg.includes(RAW), "the frontend's own message must survive verbatim");
+});
+
+test("a definition registered with every node still present also counts as CHANGED", () => {
+  const msg = conversionThrowReport({
+    what: "panel_subgraph_group",
+    message: RAW,
+    before: { present: [2, 3], readable: true, definitions: 0 },
+    after: { present: [2, 3], readable: true, definitions: 1 },
+  });
+  assert.match(msg, /HAS CHANGED/);
+  assert.match(msg, /every node you selected is still on the canvas/);
+});
+
+test("nothing moved → the report says UNCHANGED and that there is nothing to undo", () => {
+  const msg = conversionThrowReport({
+    what: "panel_create_subgraph",
+    message: RAW,
+    before: { present: [2, 3], readable: true, definitions: 0 },
+    after: { present: [2, 3], readable: true, definitions: 0 },
+  });
+  assert.match(msg, /the graph is UNCHANGED/);
+  assert.match(msg, /nothing to undo/);
+  assert.doesNotMatch(msg, /HAS CHANGED/);
+  assert.ok(msg.includes(RAW));
+});
+
+test("an unreadable snapshot is reported as UNKNOWN, never as untouched", () => {
+  const msg = conversionThrowReport({
+    what: "panel_create_subgraph",
+    message: RAW,
+    before: { present: [], readable: false, definitions: null },
+    after: { present: [], readable: false, definitions: null },
+  });
+  assert.match(msg, /could NOT establish whether the graph changed/);
+  assert.match(msg, /unknown rather than untouched/);
+  assert.doesNotMatch(msg, /the graph is UNCHANGED/);
+  assert.ok(msg.includes(RAW));
+});
+
+test("a definition COUNT that only fell is not reported as a change", () => {
+  // Defensive: a shrinking count is not evidence this conversion created anything.
+  const msg = conversionThrowReport({
+    what: "panel_create_subgraph",
+    message: RAW,
+    before: { present: [2], readable: true, definitions: 3 },
+    after: { present: [2], readable: true, definitions: 2 },
+  });
+  assert.match(msg, /the graph is UNCHANGED/);
+});
+
+test("every verdict names the tool and attributes the throw to the frontend", () => {
+  const cases = [
+    { before: { present: [2], readable: true, definitions: 0 }, after: { present: [], readable: true, definitions: 1 } },
+    { before: { present: [2], readable: true, definitions: 0 }, after: { present: [2], readable: true, definitions: 0 } },
+    { before: { present: [], readable: false, definitions: null }, after: { present: [], readable: false, definitions: null } },
+  ];
+  for (const c of cases) {
+    const msg = conversionThrowReport({ what: "panel_subgraph_group", message: RAW, ...c });
+    assert.match(msg, /panel_subgraph_group/);
+    assert.match(msg, /ComfyUI's (own )?convertToSubgraph/);
+    assert.ok(msg.includes(RAW));
+  }
+});
+
+test("a throw with no message still produces a usable report", () => {
+  const msg = conversionThrowReport({
+    what: "panel_create_subgraph",
+    message: "",
+    before: { present: [2], readable: true, definitions: 0 },
+    after: { present: [2], readable: true, definitions: 0 },
+  });
+  assert.match(msg, /\(no message\)/);
+});
+
+/* -------------------------------------------------------------------------- */
+/* 4. the snapshot compares node IDENTITY                                      */
+/* -------------------------------------------------------------------------- */
+
+test("a re-issued id does not read as the original node surviving", () => {
+  const { graph, n2, n3 } = chain();
+  const before = conversionSnapshot(graph, [n2, n3]);
+  assert.deepEqual(before.present, [2, 3]);
+  assert.equal(before.definitions, 0);
+  assert.equal(before.readable, true);
+
+  // The frontend removed 2 and 3 and handed id 2 to something else.
+  const replacement = { id: 2, inputs: [], outputs: [], graph };
+  const after = conversionSnapshot(
+    { getNodeById: (id) => (id === 2 ? replacement : null), links: null, subgraphs: new Map([["a", {}]]) },
+    [n2, n3],
+  );
+  assert.deepEqual(after.present, []);
+  assert.equal(after.definitions, 1);
+});
+
+test("a frontend with no node lookup reports itself unreadable rather than empty", () => {
+  const { n2, n3 } = chain();
+  const snap = conversionSnapshot({}, [n2, n3]);
+  assert.equal(snap.readable, false);
+  assert.deepEqual(snap.present, [2, 3]);
+  assert.equal(snap.definitions, null);
+});
+
+/* -------------------------------------------------------------------------- */
+/* 5. both tools actually go through it                                        */
+/* -------------------------------------------------------------------------- */
+
+test("neither conversion tool calls convertToSubgraph bare any more", () => {
+  const body = code();
+  const bare = body.match(/graph\.convertToSubgraph\(canvas\.selectedItems\)/g) ?? [];
+  assert.equal(
+    bare.length,
+    1,
+    "exactly one call site may remain — the shared runner inside convertSelectionToSubgraph",
+  );
+  const runner = body.slice(body.indexOf("function convertSelectionToSubgraph("));
+  assert.ok(
+    runner.slice(0, runner.indexOf("\nfunction ")).includes("graph.convertToSubgraph(canvas.selectedItems)"),
+    "the surviving call site must be the runner's",
+  );
+});
+
+test("both entry points route through the runner, naming themselves", () => {
+  const body = code();
+  assert.match(body, /convertSelectionToSubgraph\(\{[\s\S]{0,200}?what: "panel_create_subgraph",/);
+  assert.match(body, /convertSelectionToSubgraph\(\{[\s\S]{0,200}?what: "panel_subgraph_group",/);
+});
+
+test("the runner refuses BEFORE the conversion and keeps beforeChange/afterChange paired", () => {
+  const body = code();
+  const runner = body.slice(body.indexOf("function convertSelectionToSubgraph("));
+  const fn = runner.slice(0, runner.indexOf("\nfunction "));
+  const refuseAt = fn.indexOf("detachedConversionRefusal");
+  const convertAt = fn.indexOf("graph.convertToSubgraph");
+  assert.ok(refuseAt > -1 && convertAt > -1, "both the refusal and the call must be present");
+  assert.ok(refuseAt < convertAt, "the refusal must come before the conversion, or it repairs nothing");
+  assert.ok(fn.includes("graph.beforeChange?.()"), "beforeChange must still be called");
+  assert.ok(fn.includes("graph.afterChange?.()"), "afterChange must still be called");
+  assert.ok(fn.includes("finally"), "afterChange must stay in a finally");
+  assert.ok(fn.includes("{ cause: err }"), "the frontend's own error must be kept as the cause");
+});

--- a/browser_tests/unit/subgraph-conversion-throw-verdict.test.mjs
+++ b/browser_tests/unit/subgraph-conversion-throw-verdict.test.mjs
@@ -440,9 +440,13 @@ test("the two conversion tools no longer select for themselves — the runner do
   const fn = runner.slice(0, runner.indexOf("\nfunction "));
   assert.ok(fn.includes("canvas?.selectItems"), "the runner must make the selection");
   assert.ok(fn.includes("canvas?.selectNodes"), "including the deprecated fallback");
+  // `indexOf` alone has no teeth here: deleting the refusal makes it -1, which is
+  // "before" everything. Require it to be PRESENT first.
+  const refusalAt = fn.indexOf("selection API");
+  assert.ok(refusalAt > -1, "a frontend with neither selection API must be refused, not fallen through");
   assert.ok(
-    fn.indexOf("selection API") < fn.indexOf("graph.convertToSubgraph"),
-    "a frontend with no selection API must be refused before the conversion, not after",
+    refusalAt < fn.indexOf("graph.convertToSubgraph"),
+    "and refused before the conversion, not after it",
   );
 });
 

--- a/browser_tests/unit/subgraph-conversion-throw-verdict.test.mjs
+++ b/browser_tests/unit/subgraph-conversion-throw-verdict.test.mjs
@@ -210,6 +210,13 @@ test("the refusal names the consequence of the ROLE it found, not the other one"
   assert.match(both, /node 2 in your selection, and node 1 wired to it/);
   assert.match(both, /throw at disconnectInput/);
   assert.match(both, /in the reconnect pass/);
+
+  // gate r4: "every other panel tool keeps working meanwhile" was not true either — a
+  // detached node throws out of the disconnect paths too. Same habit, smaller stakes.
+  for (const msg of [picked, neighbour, both]) {
+    assert.doesNotMatch(msg, /Every other panel tool keeps working/);
+    assert.match(msg, /anything that disconnects or removes it can hit the same throw/);
+  }
 });
 
 /* -------------------------------------------------------------------------- */

--- a/browser_tests/unit/subgraph-stale-outline.test.mjs
+++ b/browser_tests/unit/subgraph-stale-outline.test.mjs
@@ -14,6 +14,10 @@ import {
   disconnectedBoundaryInputs,
   brokenConversionRefusal,
   brokenConversionWarning,
+  detachedConversionNodes,
+  detachedConversionRefusal,
+  conversionSnapshot,
+  conversionThrowReport,
 } from "../../web/js/lib/subgraph-conversion-integrity.js";
 
 const panelPath = fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url));
@@ -73,10 +77,27 @@ const advisoriesMatch = panelSrc.match(
 assert.ok(advisoriesMatch, "could not locate subgraphConversionAdvisories in panel source");
 const subgraphConversionAdvisories = new Function(`return ${advisoriesMatch[0]};`)();
 
+// #1463 — both executors now reach convertToSubgraph through a shared runner that
+// refuses a detached selection up front and reports a throw with a measured
+// mutation verdict. Same treatment again: the REAL runner, wired to the REAL lib
+// helpers, so a regression in it fails here instead of hiding behind a stub.
+const runnerMatch = panelSrc.match(
+  /function convertSelectionToSubgraph\(\{ graph, canvas, nodes, what \}\) \{[\s\S]*?\r?\n\}/,
+);
+assert.ok(runnerMatch, "could not locate convertSelectionToSubgraph in panel source");
+const convertSelectionToSubgraph = new Function(
+  "detachedConversionNodes",
+  "detachedConversionRefusal",
+  "conversionSnapshot",
+  "conversionThrowReport",
+  `return ${runnerMatch[0]};`,
+)(detachedConversionNodes, detachedConversionRefusal, conversionSnapshot, conversionThrowReport);
+
 function realCreate(getGraphCtx, clearStaleRedFlagsAfterSubgraphConversion) {
   return new Function(
     "getGraphCtx",
     "clearStaleRedFlagsAfterSubgraphConversion",
+    "convertSelectionToSubgraph",
     "assertSubgraphNodeLanded",
     "assertSubgraphConversionSerializable",
     "subgraphConversionAdvisories",
@@ -84,6 +105,7 @@ function realCreate(getGraphCtx, clearStaleRedFlagsAfterSubgraphConversion) {
   )(
     getGraphCtx,
     clearStaleRedFlagsAfterSubgraphConversion,
+    convertSelectionToSubgraph,
     assertSubgraphNodeLanded,
     assertSubgraphConversionSerializable,
     subgraphConversionAdvisories,
@@ -103,6 +125,7 @@ function realGroup(
     "syncGraphNodeAreas",
     "groupMemberNodes",
     "clearStaleRedFlagsAfterSubgraphConversion",
+    "convertSelectionToSubgraph",
     "assertSubgraphNodeLanded",
     "assertSubgraphConversionSerializable",
     "subgraphConversionAdvisories",
@@ -113,6 +136,7 @@ function realGroup(
     syncGraphNodeAreas,
     groupMemberNodes,
     clearStaleRedFlagsAfterSubgraphConversion,
+    convertSelectionToSubgraph,
     assertSubgraphNodeLanded,
     assertSubgraphConversionSerializable,
     subgraphConversionAdvisories,

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -9280,22 +9280,36 @@ function clearStaleRedFlag(node, { app, graph, rootGraph }) {
 /** Run the frontend's conversion so that a THROW is as informative as a return.
  *
  *  #1463 — both tools called `graph.convertToSubgraph()` bare, so the caller got the
- *  frontend's raw exception and nothing else. That is not enough to act on, because
- *  the SAME exception is reachable from both sides of the mutation: driven in a
- *  browser, a detached boundary neighbour makes it throw in the reconnect loop with
- *  the selected nodes ALREADY REMOVED and a subgraph definition already registered,
- *  while a detached selected node (and any extension pre-pass wrapping the method)
- *  throws with the canvas untouched. #1463's reporter read the bare message as "no
- *  other side effects" and retried three times.
+ *  frontend's raw exception and nothing else. That is not enough to act on, because the
+ *  SAME exception lands at different points of the mutation: driven in a browser, a
+ *  detached boundary neighbour throws in the reconnect loop with the selected nodes
+ *  ALREADY REMOVED, while a detached selected node throws at `disconnectInput` with the
+ *  nodes intact but a subgraph definition already registered. #1463's reporter read the
+ *  bare message as "no other side effects" and retried three times.
  *
- *  So: refuse up front on the one state that provably causes it and would cause the
- *  destructive half, and otherwise measure the graph either side of the call and
- *  report which of the two happened. The frontend's own message is always quoted
- *  verbatim inside the result and kept as `cause`, so nothing greppable is lost.
+ *  So: refuse up front on the state that provably causes it, and otherwise measure the
+ *  graph either side of the call and report what actually moved. The frontend's own
+ *  message is always quoted verbatim inside the result and kept as `cause`, so nothing
+ *  greppable is lost. What the measurement may and may not conclude — and why a wrapper
+ *  on `convertToSubgraph` withdraws the confident answer — is argued in the lib.
+ *
+ *  The SELECTION is made here rather than at the two call sites, because both had the
+ *  same hole: on a frontend with neither selection API they fell through and converted
+ *  whatever happened to be selected, which is a set the caller never named.
+ *  `graph_select_nodes` already refuses that; now so does this.
  *
  *  `beforeChange`/`afterChange` stay paired exactly as before — the report is added
  *  around them, not in place of them. */
 function convertSelectionToSubgraph({ graph, canvas, nodes, what }) {
+  if (typeof canvas?.selectItems === "function") canvas.selectItems(nodes);
+  else if (typeof canvas?.selectNodes === "function") canvas.selectNodes(nodes);
+  else {
+    throw new Error(
+      `${what} was NOT run and the graph is unchanged — this ComfyUI frontend exposes no ` +
+        `selection API (neither canvas.selectItems nor canvas.selectNodes), and converting ` +
+        `whatever happened to be selected instead would wrap a set you never named.`,
+    );
+  }
   const detached = detachedConversionNodes(graph, nodes);
   if (detached.length) throw new Error(detachedConversionRefusal({ what, detached }));
   const before = conversionSnapshot(graph, nodes);
@@ -18140,9 +18154,8 @@ const GRAPH_TOOL_EXECUTORS = {
       .map((id) => graph.getNodeById(Number(id)))
       .filter(Boolean);
     if (!ns.length) throw new Error("provide node_ids to group into a subgraph");
-    if (typeof canvas.selectItems === "function") canvas.selectItems(ns);
-    else if (typeof canvas.selectNodes === "function") canvas.selectNodes(ns);
-    // #1463 — a THROW here is reported with a mutation verdict, not raw.
+    // #1463 — selects, refuses a detached selection, and reports a THROW with a
+    // mutation verdict instead of the frontend's bare exception.
     const res = convertSelectionToSubgraph({
       graph,
       canvas,
@@ -18189,10 +18202,8 @@ const GRAPH_TOOL_EXECUTORS = {
     if (!ns.length) {
       throw new Error(`group "${g.title}" has no nodes inside its box to wrap into a subgraph`);
     }
-    if (typeof canvas.selectItems === "function") canvas.selectItems(ns);
-    else if (typeof canvas.selectNodes === "function") canvas.selectNodes(ns);
-    // #1463 — same throw-side reporting as panel_create_subgraph. Both entry points
-    // failed identically in that report, so neither may keep the bare re-throw.
+    // #1463 — same runner as panel_create_subgraph. Both entry points failed
+    // identically in that report, so neither may keep the bare re-throw.
     const res = convertSelectionToSubgraph({
       graph,
       canvas,

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -382,6 +382,10 @@ import {
   disconnectedBoundaryInputs,
   brokenConversionRefusal,
   brokenConversionWarning,
+  detachedConversionNodes,
+  detachedConversionRefusal,
+  conversionSnapshot,
+  conversionThrowReport,
 } from "./lib/subgraph-conversion-integrity.js";
 import {
   classifyWorkflowRefresh,
@@ -9283,6 +9287,46 @@ function clearStaleRedFlag(node, { app, graph, rootGraph }) {
  *
  *  Presence is checked on the LIVE graph, not just on the returned object: a result
  *  carrying a node that never landed is exactly the case a truthful report must catch. */
+/** Run the frontend's conversion so that a THROW is as informative as a return.
+ *
+ *  #1463 — both tools called `graph.convertToSubgraph()` bare, so the caller got the
+ *  frontend's raw exception and nothing else. That is not enough to act on, because
+ *  the SAME exception is reachable from both sides of the mutation: driven in a
+ *  browser, a detached boundary neighbour makes it throw in the reconnect loop with
+ *  the selected nodes ALREADY REMOVED and a subgraph definition already registered,
+ *  while a detached selected node (and any extension pre-pass wrapping the method)
+ *  throws with the canvas untouched. #1463's reporter read the bare message as "no
+ *  other side effects" and retried three times.
+ *
+ *  So: refuse up front on the one state that provably causes it and would cause the
+ *  destructive half, and otherwise measure the graph either side of the call and
+ *  report which of the two happened. The frontend's own message is always quoted
+ *  verbatim inside the result and kept as `cause`, so nothing greppable is lost.
+ *
+ *  `beforeChange`/`afterChange` stay paired exactly as before — the report is added
+ *  around them, not in place of them. */
+function convertSelectionToSubgraph({ graph, canvas, nodes, what }) {
+  const detached = detachedConversionNodes(graph, nodes);
+  if (detached.length) throw new Error(detachedConversionRefusal({ what, detached }));
+  const before = conversionSnapshot(graph, nodes);
+  graph.beforeChange?.();
+  try {
+    return graph.convertToSubgraph(canvas.selectedItems);
+  } catch (err) {
+    throw new Error(
+      conversionThrowReport({
+        what,
+        message: err?.message ?? String(err),
+        before,
+        after: conversionSnapshot(graph, nodes),
+      }),
+      { cause: err },
+    );
+  } finally {
+    graph.afterChange?.();
+  }
+}
+
 function assertSubgraphNodeLanded(res, graph, what) {
   const node = res?.node;
   const id = node?.id;
@@ -18098,13 +18142,13 @@ const GRAPH_TOOL_EXECUTORS = {
     if (!ns.length) throw new Error("provide node_ids to group into a subgraph");
     if (typeof canvas.selectItems === "function") canvas.selectItems(ns);
     else if (typeof canvas.selectNodes === "function") canvas.selectNodes(ns);
-    graph.beforeChange?.();
-    let res;
-    try {
-      res = graph.convertToSubgraph(canvas.selectedItems);
-    } finally {
-      graph.afterChange?.();
-    }
+    // #1463 — a THROW here is reported with a mutation verdict, not raw.
+    const res = convertSelectionToSubgraph({
+      graph,
+      canvas,
+      nodes: ns,
+      what: "panel_create_subgraph",
+    });
     clearStaleRedFlagsAfterSubgraphConversion(res, { app, graph, rootGraph });
     graph.setDirtyCanvas?.(true, true);
     // `node_id: null` inside a `subgraph:` payload reads as a success with a missing
@@ -18147,13 +18191,14 @@ const GRAPH_TOOL_EXECUTORS = {
     }
     if (typeof canvas.selectItems === "function") canvas.selectItems(ns);
     else if (typeof canvas.selectNodes === "function") canvas.selectNodes(ns);
-    graph.beforeChange?.();
-    let res;
-    try {
-      res = graph.convertToSubgraph(canvas.selectedItems);
-    } finally {
-      graph.afterChange?.();
-    }
+    // #1463 — same throw-side reporting as panel_create_subgraph. Both entry points
+    // failed identically in that report, so neither may keep the bare re-throw.
+    const res = convertSelectionToSubgraph({
+      graph,
+      canvas,
+      nodes: ns,
+      what: "panel_subgraph_group",
+    });
     clearStaleRedFlagsAfterSubgraphConversion(res, { app, graph, rootGraph });
     graph.setDirtyCanvas?.(true, true);
     // Same guard as panel_create_subgraph: a conversion that produced no node must

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -9277,16 +9277,6 @@ function clearStaleRedFlag(node, { app, graph, rootGraph }) {
  * wrapper but does not revalidate their sticky red flags. Re-adjudicate only
  * those direct neighbours; never the wrapper or the nodes moved inside it.
  */
-/** Confirm `convertToSubgraph` actually produced a subgraph NODE on this graph.
- *
- *  Both conversion tools reported `node_id: res?.node?.id ?? null` — so a conversion
- *  that produced nothing returned `{subgraph: {node_id: null, name: null, …}}` with no
- *  error, which reads as "a subgraph was created". The sibling graph_add_subgraph
- *  already guards this ("don't report a fake success if deserialize produced
- *  nothing"); this is the same rule applied to the two paths that were missing it.
- *
- *  Presence is checked on the LIVE graph, not just on the returned object: a result
- *  carrying a node that never landed is exactly the case a truthful report must catch. */
 /** Run the frontend's conversion so that a THROW is as informative as a return.
  *
  *  #1463 — both tools called `graph.convertToSubgraph()` bare, so the caller got the
@@ -9327,6 +9317,16 @@ function convertSelectionToSubgraph({ graph, canvas, nodes, what }) {
   }
 }
 
+/** Confirm `convertToSubgraph` actually produced a subgraph NODE on this graph.
+ *
+ *  Both conversion tools reported `node_id: res?.node?.id ?? null` — so a conversion
+ *  that produced nothing returned `{subgraph: {node_id: null, name: null, …}}` with no
+ *  error, which reads as "a subgraph was created". The sibling graph_add_subgraph
+ *  already guards this ("don't report a fake success if deserialize produced
+ *  nothing"); this is the same rule applied to the two paths that were missing it.
+ *
+ *  Presence is checked on the LIVE graph, not just on the returned object: a result
+ *  carrying a node that never landed is exactly the case a truthful report must catch. */
 function assertSubgraphNodeLanded(res, graph, what) {
   const node = res?.node;
   const id = node?.id;

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -9272,11 +9272,6 @@ function clearStaleRedFlag(node, { app, graph, rootGraph }) {
   return false;
 }
 
-/**
- * `convertToSubgraph()` rewires surviving root-graph neighbours to its new
- * wrapper but does not revalidate their sticky red flags. Re-adjudicate only
- * those direct neighbours; never the wrapper or the nodes moved inside it.
- */
 /** Run the frontend's conversion so that a THROW is as informative as a return.
  *
  *  #1463 — both tools called `graph.convertToSubgraph()` bare, so the caller got the
@@ -9404,6 +9399,11 @@ function subgraphConversionAdvisories({ disconnected, dangling, warning }) {
   };
 }
 
+/**
+ * `convertToSubgraph()` rewires surviving root-graph neighbours to its new
+ * wrapper but does not revalidate their sticky red flags. Re-adjudicate only
+ * those direct neighbours; never the wrapper or the nodes moved inside it.
+ */
 function clearStaleRedFlagsAfterSubgraphConversion(res, { app, graph, rootGraph }) {
   try {
     for (const id of collectLinkedNeighborNodeIds(res?.node, graph?.links)) {

--- a/web/js/lib/subgraph-conversion-integrity.js
+++ b/web/js/lib/subgraph-conversion-integrity.js
@@ -443,39 +443,76 @@ function linkLookup(links) {
 }
 
 const linkOriginId = (link) => link?.origin_id ?? (Array.isArray(link) ? link[1] : undefined);
-const linkTargetId = (link) => link?.target_id ?? (Array.isArray(link) ? link[3] : undefined);
 
-/** Ids of the nodes directly wired to `node` — the boundary neighbours a conversion
- *  has to disconnect and re-attach, and therefore the ones whose detachment is fatal.
+/**
+ * Ids of the nodes FEEDING `node` — its upstream producers.
  *
- *  Takes a prepared `lookup` rather than the link table, so a caller sweeping a whole
- *  selection indexes a serialized (array) table once instead of once per node. */
-function linkedNeighborIds(node, lookup) {
+ * Deliberately not "everything wired to it" (gate r5 P1). Direction decides whether a
+ * detached neighbour is fatal, and only the upstream side is, read out of the installed
+ * frontend's own sourcemapped litegraph:
+ *
+ *   - Upstream: the reconnect is `outputNode.connectSlots(output, subgraphNode, …)`
+ *     (`LGraph.ts`), where `outputNode` is the OUTSIDE producer — and `connectSlots`
+ *     opens with `const { graph } = this; if (!graph) throw new NullGraphError()`
+ *     (`LGraphNode.ts`). A detached producer therefore throws, after the selected nodes
+ *     have already been removed. That is #1463's destructive case, and the one measured
+ *     in the browser.
+ *   - Downstream: the reconnect is `subgraphNode.connectSlots(output, inputNode, …)` —
+ *     `this` is the freshly added wrapper, whose graph is set. Nothing reads the
+ *     consumer's `graph`: `disconnectOutput` dereferences only `this.graph` and writes
+ *     `target.inputs[slot].link = null`, and `connectSlots`' one call into the consumer,
+ *     `inputNode.disconnectInput(...)`, is gated on that same link being non-null, which
+ *     `disconnectOutput` has already cleared. A detached consumer converts fine.
+ *
+ * Sweeping both directions and refusing on either would block a conversion the frontend
+ * completes — a worse outcome than the bug, in the exact pathological state this feature
+ * exists for.
+ *
+ * Takes a prepared `lookup` rather than the link table, so a caller sweeping a whole
+ * selection indexes a serialized (array) table once instead of once per node.
+ */
+function upstreamProducerIds(node, lookup) {
   const ids = new Set();
   for (const input of Array.isArray(node?.inputs) ? node.inputs : []) {
     const id = linkOriginId(lookup(input?.link));
     if (id != null) ids.add(id);
   }
-  for (const output of Array.isArray(node?.outputs) ? node.outputs : []) {
-    for (const linkId of Array.isArray(output?.links) ? output.links : []) {
-      const id = linkTargetId(lookup(linkId));
-      if (id != null) ids.add(id);
-    }
-  }
   return ids;
+}
+
+/** Does the conversion ever ask this node to disconnect anything?
+ *
+ *  A SELECTED node is only dereferenced through `disconnectInput`/`disconnectOutput`,
+ *  and both are reached per-link — `LGraph.remove` calls them only for slots that carry
+ *  one. A detached node with no links at all converts cleanly (measured: two detached,
+ *  unlinked nodes wrap without error), so refusing it would be over-refusal. */
+function carriesAnyLink(node) {
+  for (const input of Array.isArray(node?.inputs) ? node.inputs : []) {
+    if (input?.link != null) return true;
+  }
+  for (const output of Array.isArray(node?.outputs) ? node.outputs : []) {
+    if (Array.isArray(output?.links) && output.links.length) return true;
+  }
+  return false;
 }
 
 /**
  * Nodes involved in this conversion that the graph OWNS but that do not point back at
  * it — the state that provably throws `NullGraphError` out of `convertToSubgraph`.
  *
- * Each entry carries its `role`, because the two roles fail DIFFERENTLY and the refusal
- * has to say which. Read out of the shipped bundle's `LGraph.ts` on this install:
- * `createSubgraph` @1792 → `disconnectInput` @1807 → `for (const node of nodes)
+ * Two roles only, and each carries its own consequence, because they fail DIFFERENTLY
+ * and the refusal has to say which. Read out of the shipped bundle's `LGraph.ts` on this
+ * install: `createSubgraph` @1792 → `disconnectInput` @1807 → `for (const node of nodes)
  * this.remove(node)` @1817 → `this.add(subgraphNode)` @1858. A detached node in the
  * SELECTION throws at 1807 — a definition is already registered, nothing is removed yet.
- * A detached NEIGHBOUR survives that loop and throws in the reconnect that follows 1858,
- * by which point the selected nodes are gone and the wrapper exists unwired.
+ * A detached upstream PRODUCER survives that loop and throws in the reconnect that
+ * follows 1858, by which point the selected nodes are gone and the wrapper exists
+ * unwired.
+ *
+ * A detached downstream CONSUMER is deliberately absent: the conversion never reads its
+ * `graph`, so refusing on it would block a conversion the frontend completes. See
+ * {@link upstreamProducerIds} for that trace, and {@link carriesAnyLink} for the
+ * matching narrowing on the selection side.
  *
  * Ownership is proved by NODE identity (`getNodeById(id)` returns this very object),
  * never by graph identity. `node.graph !== graph` would read a Vue proxy of the live
@@ -498,11 +535,16 @@ export function detachedConversionNodes(graph, nodes) {
     if (!node || seen.has(node)) return;
     seen.add(node);
     if (!owns(node)) return;
-    if (node.graph == null) found.push({ id: node.id, role });
+    if (node.graph != null) return;
+    // A selected node is only dereferenced per-link; an unlinked one converts cleanly.
+    if (role === "selected" && !carriesAnyLink(node)) return;
+    found.push({ id: node.id, role });
   };
+  // Selection first, so a node that is both selected and someone's producer is reported
+  // once, under the role whose consequence lands first.
   for (const node of selection) consider(node, "selected");
   for (const node of selection) {
-    for (const id of linkedNeighborIds(node, lookup)) consider(graph.getNodeById(id), "neighbour");
+    for (const id of upstreamProducerIds(node, lookup)) consider(graph.getNodeById(id), "producer");
   }
   return found;
 }
@@ -520,16 +562,16 @@ export function detachedConversionRefusal({ what, detached }) {
   const idsOf = (role) =>
     bad.filter((entry) => entry?.role === role).map((entry) => entry?.id);
   const picked = idsOf("selected");
-  const neighbours = idsOf("neighbour");
+  const producers = idsOf("producer");
   const listing = [];
   if (picked.length) {
     listing.push(
       `node${picked.length === 1 ? "" : "s"} ${picked.join(", ")} in your selection`,
     );
   }
-  if (neighbours.length) {
+  if (producers.length) {
     listing.push(
-      `node${neighbours.length === 1 ? "" : "s"} ${neighbours.join(", ")} wired to it`,
+      `node${producers.length === 1 ? "" : "s"} ${producers.join(", ")} feeding it`,
     );
   }
   const who = listing.length ? listing.join(", and ") : `node(s) ${bad.map((e) => e?.id).join(", ")}`;
@@ -542,9 +584,9 @@ export function detachedConversionRefusal({ what, detached }) {
         `definition on the workflow and no node to show for it`,
     );
   }
-  if (neighbours.length) {
+  if (producers.length) {
     consequence.push(
-      `a detached node WIRED to the selection makes it throw later still, in the reconnect ` +
+      `a detached node FEEDING the selection makes it throw later still, in the reconnect ` +
         `pass, by which point the nodes you selected are gone and the wrapper it built is ` +
         `sitting there wired to nothing`,
     );

--- a/web/js/lib/subgraph-conversion-integrity.js
+++ b/web/js/lib/subgraph-conversion-integrity.js
@@ -422,9 +422,11 @@ const linkOriginId = (link) => link?.origin_id ?? (Array.isArray(link) ? link[1]
 const linkTargetId = (link) => link?.target_id ?? (Array.isArray(link) ? link[3] : undefined);
 
 /** Ids of the nodes directly wired to `node` — the boundary neighbours a conversion
- *  has to disconnect and re-attach, and therefore the ones whose detachment is fatal. */
-function linkedNeighborIds(node, links) {
-  const lookup = linkLookup(links);
+ *  has to disconnect and re-attach, and therefore the ones whose detachment is fatal.
+ *
+ *  Takes a prepared `lookup` rather than the link table, so a caller sweeping a whole
+ *  selection indexes a serialized (array) table once instead of once per node. */
+function linkedNeighborIds(node, lookup) {
   const ids = new Set();
   for (const input of Array.isArray(node?.inputs) ? node.inputs : []) {
     const id = linkOriginId(lookup(input?.link));
@@ -458,6 +460,7 @@ export function detachedConversionNodes(graph, nodes) {
   if (!selection.length) return [];
   if (typeof graph?.getNodeById !== "function") return [];
   const owns = (node) => node?.id != null && graph.getNodeById(node.id) === node;
+  const lookup = linkLookup(graph?.links);
   const found = [];
   const seen = new Set();
   const consider = (node) => {
@@ -468,7 +471,7 @@ export function detachedConversionNodes(graph, nodes) {
   };
   for (const node of selection) {
     consider(node);
-    for (const id of linkedNeighborIds(node, graph?.links)) consider(graph.getNodeById(id));
+    for (const id of linkedNeighborIds(node, lookup)) consider(graph.getNodeById(id));
   }
   return found;
 }

--- a/web/js/lib/subgraph-conversion-integrity.js
+++ b/web/js/lib/subgraph-conversion-integrity.js
@@ -466,9 +466,16 @@ function linkedNeighborIds(node, lookup) {
 }
 
 /**
- * Ids of nodes involved in this conversion that the graph OWNS but that do not point
- * back at it — the state that provably throws `NullGraphError` out of
- * `convertToSubgraph`, one of them destructively.
+ * Nodes involved in this conversion that the graph OWNS but that do not point back at
+ * it — the state that provably throws `NullGraphError` out of `convertToSubgraph`.
+ *
+ * Each entry carries its `role`, because the two roles fail DIFFERENTLY and the refusal
+ * has to say which. Read out of the shipped bundle's `LGraph.ts` on this install:
+ * `createSubgraph` @1792 → `disconnectInput` @1807 → `for (const node of nodes)
+ * this.remove(node)` @1817 → `this.add(subgraphNode)` @1858. A detached node in the
+ * SELECTION throws at 1807 — a definition is already registered, nothing is removed yet.
+ * A detached NEIGHBOUR survives that loop and throws in the reconnect that follows 1858,
+ * by which point the selected nodes are gone and the wrapper exists unwired.
  *
  * Ownership is proved by NODE identity (`getNodeById(id)` returns this very object),
  * never by graph identity. `node.graph !== graph` would read a Vue proxy of the live
@@ -487,35 +494,72 @@ export function detachedConversionNodes(graph, nodes) {
   const lookup = linkLookup(graph?.links);
   const found = [];
   const seen = new Set();
-  const consider = (node) => {
+  const consider = (node, role) => {
     if (!node || seen.has(node)) return;
     seen.add(node);
     if (!owns(node)) return;
-    if (node.graph == null) found.push(node.id);
+    if (node.graph == null) found.push({ id: node.id, role });
   };
+  for (const node of selection) consider(node, "selected");
   for (const node of selection) {
-    consider(node);
-    for (const id of linkedNeighborIds(node, lookup)) consider(graph.getNodeById(id));
+    for (const id of linkedNeighborIds(node, lookup)) consider(graph.getNodeById(id), "neighbour");
   }
   return found;
 }
 
 /** The pre-flight refusal. Raised BEFORE `convertToSubgraph` is called, so it is the
- *  one report in this file that can promise the canvas is untouched. */
+ *  one report in this file that can promise the canvas is untouched.
+ *
+ *  It names the consequence PER ROLE. A single sentence for both was wrong for one of
+ *  them (gate r3 P1): a detached selected node throws before the removal loop, so
+ *  "after it has already removed the nodes you selected" described a state that path
+ *  never reaches, while the state it DOES leave — a registered subgraph definition —
+ *  went unmentioned. */
 export function detachedConversionRefusal({ what, detached }) {
   const bad = Array.isArray(detached) ? detached : [];
-  const one = bad.length === 1;
+  const idsOf = (role) =>
+    bad.filter((entry) => entry?.role === role).map((entry) => entry?.id);
+  const picked = idsOf("selected");
+  const neighbours = idsOf("neighbour");
+  const listing = [];
+  if (picked.length) {
+    listing.push(
+      `node${picked.length === 1 ? "" : "s"} ${picked.join(", ")} in your selection`,
+    );
+  }
+  if (neighbours.length) {
+    listing.push(
+      `node${neighbours.length === 1 ? "" : "s"} ${neighbours.join(", ")} wired to it`,
+    );
+  }
+  const who = listing.length ? listing.join(", and ") : `node(s) ${bad.map((e) => e?.id).join(", ")}`;
+  // What the frontend would leave behind, stated only for the roles actually present.
+  const consequence = [];
+  if (picked.length) {
+    consequence.push(
+      `a detached node in the SELECTION makes it throw at disconnectInput, which runs after ` +
+        `it has already registered a subgraph definition — so you would be left with a ` +
+        `definition on the workflow and no node to show for it`,
+    );
+  }
+  if (neighbours.length) {
+    consequence.push(
+      `a detached node WIRED to the selection makes it throw later still, in the reconnect ` +
+        `pass, by which point the nodes you selected are gone and the wrapper it built is ` +
+        `sitting there wired to nothing`,
+    );
+  }
   return (
-    `${what} was NOT run and the graph is unchanged. Node${one ? "" : "s"} ${bad.join(", ")} ` +
-    `${one ? "is" : "are"} listed on this graph but ${one ? "does" : "do"} not reference it ` +
-    `back (node.graph is unset), and ComfyUI's convertToSubgraph throws "Attempted to access ` +
-    `LGraph reference that was null or undefined." on exactly that — after it has already ` +
-    `removed the nodes you selected, leaving a half-built subgraph wired to nothing ` +
-    `(comfyui-mcp-panel#1463). Refusing here is what keeps that from happening. This is a ` +
-    `stale canvas, not a bad selection: it follows a ComfyUI restart, or an extension ` +
-    `detaching a node without removing it. Reload the ComfyUI page to rebuild the graph ` +
-    `(save first — panel_save_workflow), then retry. Every other panel tool keeps working ` +
-    `meanwhile; subgraph conversion is the one that touches this back-reference.`
+    `${what} was NOT run and the graph is unchanged. The graph lists ${who}, but ` +
+    `${bad.length === 1 ? "it does" : "they do"} not reference it back (node.graph is ` +
+    `unset), and ComfyUI's convertToSubgraph throws "Attempted to access LGraph reference ` +
+    `that was null or undefined." on exactly that (comfyui-mcp-panel#1463). Where it throws ` +
+    `decides what you are left with: ${consequence.join("; ")}. Refusing here is what keeps ` +
+    `either from happening. This is a stale canvas, not a bad selection: it follows a ` +
+    `ComfyUI restart, or an extension detaching a node without removing it. Reload the ` +
+    `ComfyUI page to rebuild the graph (save first — panel_save_workflow), then retry. ` +
+    `Every other panel tool keeps working meanwhile; subgraph conversion is the one that ` +
+    `touches this back-reference.`
   );
 }
 

--- a/web/js/lib/subgraph-conversion-integrity.js
+++ b/web/js/lib/subgraph-conversion-integrity.js
@@ -380,13 +380,35 @@ export function brokenConversionWarning({ what, subgraphNodeId, dangling, discon
  * thing the caller was told is the bare frontend message. #1463's reporter read that
  * as "no other side effects" and retried three times.
  *
- * The same message is also reachable with NOTHING mutated: the frontend throws out of
- * `disconnectInput`/`disconnectOutput` too, which run before the removal loop, and an
- * extension that wraps `convertToSubgraph` can throw before the frontend's own code
- * runs at all (cg-use-everywhere replaces `app.graph.convertToSubgraph` with a pre-pass
- * that analyses the whole graph first — its frames are in the reproduction's stack).
- * One message, two opposite states, and the caller's correct next move differs
- * completely between them. So measure it instead of guessing.
+ * The same message is also reachable with the graph barely touched — the frontend
+ * throws out of `disconnectInput`/`disconnectOutput` too, which run before the removal
+ * loop — so the caller's correct next move differs completely between two failures that
+ * read identically. Measure it instead of guessing.
+ *
+ * ## What "unchanged" may NOT be claimed from (gate P1)
+ *
+ * The first version of this said "the graph is UNCHANGED … nothing to undo" whenever the
+ * selected nodes were still present and no definition had been registered. That is a
+ * POSITIVE claim from two surfaces, and it is false wherever the mutation happened on a
+ * third:
+ *
+ *   - `LGraph.convertToSubgraph` is a plain instance-assignable method, and extensions
+ *     replace it. cg-use-everywhere sets `app.graph.convertToSubgraph` to a wrapper that
+ *     calls `convert_to_links(...)` — real link mutation — then delegates, then calls
+ *     `mods.restorer()` OUTSIDE a `finally`. Any throw from the delegate leaves the
+ *     injected links behind, with every node and definition exactly where it was.
+ *   - The measured, unwrapped order inside `_convertToSubgraphImpl` is
+ *     `createSubgraph` (definition registered) BEFORE the `disconnectInput` loop. So a
+ *     detached SELECTED node does NOT throw with the canvas untouched: driven in a
+ *     browser through `LGraph.prototype.convertToSubgraph` (bypassing the installed
+ *     wrapper), `nodes 1,2,3,4 → 1,2,3,4` but `subgraph defs 0 → 1`. The definition
+ *     count is what catches that, and this file must keep counting it.
+ *
+ * So the confident verdict is gated on there being nothing unobserved: node presence,
+ * the definition count and the link-table size all readable and all identical, AND no
+ * wrapper installed on the graph (detected as `convertToSubgraph` being an OWN property
+ * of the instance — verified true on this install, where the method also exists on the
+ * prototype). Anything else is reported as UNKNOWN, which is weaker but true.
  *
  * ## Why `node.graph == null` is the one condition worth naming
  *
@@ -394,9 +416,11 @@ export function brokenConversionWarning({ what, subgraphNodeId, dangling, discon
  * while its own `graph` back-reference is unset. On the conversion path that is
  * reachable for a node the graph still lists — `LGraph.remove` sets `node.graph = null`
  * BEFORE it splices the node out of `_nodes`, and `node.graph` is a plain settable
- * property any extension can clear. A SELECTED node in that state throws before
- * anything is mutated; a boundary NEIGHBOUR in that state throws in the reconnect
- * loop, which is the destructive case measured above. Both were reproduced in-browser.
+ * property any extension can clear. A SELECTED node in that state throws at
+ * `disconnectInput`, after a definition has been registered; a boundary NEIGHBOUR in
+ * that state throws in the reconnect loop, after the selected nodes have been removed —
+ * the destructive case measured above. Both were reproduced in-browser, which is why
+ * the pre-flight refuses on either rather than only on the selection.
  * ========================================================================= */
 
 /** Read a link table in any of the shapes {@link readLinkIds} accepts, by id. */
@@ -495,11 +519,31 @@ export function detachedConversionRefusal({ what, detached }) {
   );
 }
 
+/** Number of entries in a link table of any accepted shape, or `null` if it cannot be
+ *  counted. The live graph exposes a Map-like with a numeric `.size` (measured). */
+function linkTableSize(graph) {
+  const links = graph?.links;
+  if (!links) return null;
+  if (typeof links.size === "number") return links.size;
+  if (Array.isArray(links)) return links.length;
+  if (typeof links === "object") return Object.keys(links).length;
+  return null;
+}
+
 /**
  * What of this conversion is still on the graph.
  *
+ * Three surfaces, because two were not enough (see the header): the selected nodes, the
+ * subgraph-definition count, and the size of the link table — that last one being the
+ * only thing that sees a wrapper which rewires links and throws before undoing it.
+ *
  * `present` is compared by node IDENTITY, not by id, so an id the frontend later
  * re-issues cannot read as "the node survived".
+ *
+ * `wrapped` records that something replaced `convertToSubgraph` on this graph OBJECT.
+ * On a stock frontend the method lives on `LGraph.prototype`, so an own property means
+ * an extension is in the call path and can mutate outside everything measured here. It
+ * does not make the report wrong; it makes the confident verdict unavailable.
  */
 export function conversionSnapshot(graph, nodes) {
   const present = [];
@@ -513,6 +557,8 @@ export function conversionSnapshot(graph, nodes) {
     present,
     readable,
     definitions: typeof definitions === "number" ? definitions : null,
+    links: linkTableSize(graph),
+    wrapped: !!graph && Object.prototype.hasOwnProperty.call(graph, "convertToSubgraph"),
   };
 }
 
@@ -523,55 +569,97 @@ export function conversionSnapshot(graph, nodes) {
  * not the frontend's wording, decides whether a retry is safe. The frontend's message
  * is carried through VERBATIM and quoted: it is the only greppable thing #1463's
  * reporter had, and dropping it would break every existing search for it.
+ *
+ * Three verdicts, and the ONLY confident one is the negative. "Changed" needs a single
+ * piece of positive evidence; "unchanged" needs every surface readable, every surface
+ * still, and nothing in the call path that could have moved a surface this cannot see.
+ * Everything else is UNKNOWN — a weaker answer than the old bare exception in tone, but
+ * unlike a false "nothing to undo" it never sends the caller the wrong way.
  */
 export function conversionThrowReport({ what, message, before, after }) {
   const raw = typeof message === "string" && message.trim() ? message.trim() : "(no message)";
   const beforeIds = Array.isArray(before?.present) ? before.present : [];
   const afterIds = Array.isArray(after?.present) ? after.present : [];
   const removed = beforeIds.filter((id) => !afterIds.includes(id));
+  const num = (v) => (typeof v === "number" ? v : null);
   const addedDefs =
-    typeof before?.definitions === "number" && typeof after?.definitions === "number"
+    num(before?.definitions) != null && num(after?.definitions) != null
       ? after.definitions - before.definitions
       : null;
+  const linkDelta =
+    num(before?.links) != null && num(after?.links) != null ? after.links - before.links : null;
   const tail =
     `The throw came from ComfyUI's own convertToSubgraph — the panel calls that method, it ` +
     `does not implement it, and extensions are free to replace it — so the wording quoted ` +
     `above is not necessarily litegraph's.`;
 
-  if (removed.length || (addedDefs != null && addedDefs > 0)) {
-    const lost = removed.length
-      ? `${removed.length} of the ${beforeIds.length} node(s) you selected (${removed.join(", ")}) ` +
-        `${removed.length === 1 ? "is" : "are"} already off the canvas`
-      : `every node you selected is still on the canvas`;
-    const defs =
-      addedDefs != null && addedDefs > 0
-        ? `, and ${addedDefs} subgraph definition(s) were registered`
-        : "";
+  // CHANGED — any one positive observation is enough, and each is stated as measured.
+  const evidence = [];
+  if (removed.length) {
+    evidence.push(
+      `${removed.length} of the ${beforeIds.length} node(s) you selected (${removed.join(", ")}) ` +
+        `${removed.length === 1 ? "is" : "are"} already off the canvas`,
+    );
+  }
+  if (addedDefs != null && addedDefs > 0) {
+    evidence.push(`${addedDefs} subgraph definition(s) were registered`);
+  }
+  if (linkDelta != null && linkDelta !== 0) {
+    evidence.push(`the link table went from ${before.links} to ${after.links} entries`);
+  }
+  if (evidence.length) {
+    const halfBuilt = removed.length
+      ? ` Whatever wrapper the conversion got as far as creating was never finished, so it ` +
+        `can be sitting on the canvas wired to nothing.`
+      : "";
     return (
       `${what} FAILED PART WAY THROUGH and the graph HAS CHANGED — do not retry blindly. ` +
-      `${lost}${defs}. Whatever wrapper the conversion got as far as creating was never ` +
-      `finished, so it can be sitting on the canvas wired to nothing. ComfyUI's ` +
-      `convertToSubgraph threw: "${raw}". Undo the conversion in ComfyUI (Ctrl+Z) or reload ` +
-      `the workflow, then re-read the graph (panel_graph_outline) before doing anything ` +
-      `else — the node ids you passed no longer describe the canvas. ${tail}`
+      `${evidence.join("; ")}.${halfBuilt} ComfyUI's convertToSubgraph threw: "${raw}". Undo ` +
+      `the conversion in ComfyUI (Ctrl+Z) or reload the workflow, then re-read the graph ` +
+      `(panel_graph_outline) before doing anything else — what you passed may no longer ` +
+      `describe the canvas. ${tail}`
     );
   }
 
+  // What could have moved without this being able to see it. A confident "unchanged" is
+  // only available when this list is empty.
+  const blind = [];
   if (!before?.readable || !after?.readable) {
+    blind.push("this frontend does not expose the node lookup the presence check needs");
+  }
+  if (num(before?.definitions) == null || num(after?.definitions) == null) {
+    blind.push("its subgraph definitions could not be counted");
+  }
+  if (linkDelta == null) {
+    blind.push("its link table could not be counted");
+  }
+  if (before?.wrapped || after?.wrapped) {
+    blind.push(
+      "an extension has replaced convertToSubgraph on this graph, and such a wrapper can " +
+        "rewire links before delegating and throw before it undoes them",
+    );
+  }
+  if (blind.length) {
+    const measured =
+      before?.readable && after?.readable
+        ? `All ${beforeIds.length} node(s) you selected are still on the canvas. `
+        : "";
     return (
-      `${what} failed, and the panel could NOT establish whether the graph changed — this ` +
-      `frontend does not expose the node lookup that check needs, so treat the canvas as ` +
-      `unknown rather than untouched. ComfyUI's convertToSubgraph threw: "${raw}". Re-read ` +
-      `the graph (panel_graph_outline) before retrying. ${tail}`
+      `${what} failed, and the panel could NOT establish whether the graph changed — treat ` +
+      `the canvas as unknown rather than untouched. ${measured}What it cannot rule out: ` +
+      `${blind.join("; ")}. ComfyUI's convertToSubgraph threw: "${raw}". Re-read the graph ` +
+      `(panel_graph_outline) before retrying. ${tail}`
     );
   }
 
   return (
-    `${what} failed and the graph is UNCHANGED — all ${beforeIds.length} selected node(s) ` +
-    `are still on the canvas and no subgraph was created, so there is nothing to undo. ` +
-    `ComfyUI's convertToSubgraph threw: "${raw}". A straight retry will hit the same thing; ` +
-    `the selection itself is intact, so this is about the state of the canvas, not the nodes ` +
-    `you named. Reloading the ComfyUI page rebuilds the graph and clears the stale-canvas ` +
-    `form of this (save first — panel_save_workflow). ${tail}`
+    `${what} failed and nothing the panel can read moved: all ${beforeIds.length} selected ` +
+    `node(s) are still on the canvas, no subgraph definition was registered, the link table ` +
+    `is unchanged at ${after.links} entries, and nothing has replaced convertToSubgraph on ` +
+    `this graph. There is nothing to undo. ComfyUI's convertToSubgraph threw: "${raw}". A ` +
+    `straight retry will hit the same thing; the selection itself is intact, so this is about ` +
+    `the state of the canvas, not the nodes you named. Reloading the ComfyUI page rebuilds ` +
+    `the graph and clears the stale-canvas form of this (save first — panel_save_workflow). ` +
+    `${tail}`
   );
 }

--- a/web/js/lib/subgraph-conversion-integrity.js
+++ b/web/js/lib/subgraph-conversion-integrity.js
@@ -355,3 +355,220 @@ export function brokenConversionWarning({ what, subgraphNodeId, dangling, discon
     `${boundaryNote(loose)}${recoveryAdvice()}`
   );
 }
+
+/* ===========================================================================
+ * #1463 — a conversion that THROWS must say whether the graph changed.
+ *
+ * Everything above answers "the conversion RETURNED — is what it produced sound?".
+ * This half answers the question that was never asked: `convertToSubgraph` threw,
+ * so what is on the canvas now?
+ *
+ * ## What was measured
+ *
+ * Driven in a real browser against the ComfyUI on this machine, root graph `1→2→3→4`
+ * wired in a chain, converting the middle pair `[2, 3]` with node 1's `graph`
+ * back-reference cleared:
+ *
+ *     nodes before: 1,2,3,4        subgraph definitions: 0
+ *     → convertToSubgraph throws "Attempted to access LGraph reference that was
+ *       null or undefined."
+ *     nodes after:  1,4,5          subgraph definitions: 1
+ *     node 5 is the new subgraph node; its input link is `null`
+ *
+ * Nodes 2 and 3 are GONE, a subgraph definition is registered, and the wrapper the
+ * conversion got as far as creating was never wired back to node 1 — and the only
+ * thing the caller was told is the bare frontend message. #1463's reporter read that
+ * as "no other side effects" and retried three times.
+ *
+ * The same message is also reachable with NOTHING mutated: the frontend throws out of
+ * `disconnectInput`/`disconnectOutput` too, which run before the removal loop, and an
+ * extension that wraps `convertToSubgraph` can throw before the frontend's own code
+ * runs at all (cg-use-everywhere replaces `app.graph.convertToSubgraph` with a pre-pass
+ * that analyses the whole graph first — its frames are in the reproduction's stack).
+ * One message, two opposite states, and the caller's correct next move differs
+ * completely between them. So measure it instead of guessing.
+ *
+ * ## Why `node.graph == null` is the one condition worth naming
+ *
+ * `NullGraphError` is thrown by litegraph wherever a node is asked to do graph work
+ * while its own `graph` back-reference is unset. On the conversion path that is
+ * reachable for a node the graph still lists — `LGraph.remove` sets `node.graph = null`
+ * BEFORE it splices the node out of `_nodes`, and `node.graph` is a plain settable
+ * property any extension can clear. A SELECTED node in that state throws before
+ * anything is mutated; a boundary NEIGHBOUR in that state throws in the reconnect
+ * loop, which is the destructive case measured above. Both were reproduced in-browser.
+ * ========================================================================= */
+
+/** Read a link table in any of the shapes {@link readLinkIds} accepts, by id. */
+function linkLookup(links) {
+  if (!links) return () => null;
+  if (typeof links.get === "function") return (id) => (id == null ? null : (links.get(id) ?? null));
+  if (Array.isArray(links)) {
+    const byId = new Map();
+    for (const link of links) {
+      if (Array.isArray(link)) {
+        if (link[0] != null) byId.set(String(link[0]), link);
+      } else if (link && typeof link === "object" && link.id != null) {
+        byId.set(String(link.id), link);
+      }
+    }
+    return (id) => (id == null ? null : (byId.get(String(id)) ?? null));
+  }
+  if (typeof links === "object") return (id) => (id == null ? null : (links[id] ?? null));
+  return () => null;
+}
+
+const linkOriginId = (link) => link?.origin_id ?? (Array.isArray(link) ? link[1] : undefined);
+const linkTargetId = (link) => link?.target_id ?? (Array.isArray(link) ? link[3] : undefined);
+
+/** Ids of the nodes directly wired to `node` — the boundary neighbours a conversion
+ *  has to disconnect and re-attach, and therefore the ones whose detachment is fatal. */
+function linkedNeighborIds(node, links) {
+  const lookup = linkLookup(links);
+  const ids = new Set();
+  for (const input of Array.isArray(node?.inputs) ? node.inputs : []) {
+    const id = linkOriginId(lookup(input?.link));
+    if (id != null) ids.add(id);
+  }
+  for (const output of Array.isArray(node?.outputs) ? node.outputs : []) {
+    for (const linkId of Array.isArray(output?.links) ? output.links : []) {
+      const id = linkTargetId(lookup(linkId));
+      if (id != null) ids.add(id);
+    }
+  }
+  return ids;
+}
+
+/**
+ * Ids of nodes involved in this conversion that the graph OWNS but that do not point
+ * back at it — the state that provably throws `NullGraphError` out of
+ * `convertToSubgraph`, one of them destructively.
+ *
+ * Ownership is proved by NODE identity (`getNodeById(id)` returns this very object),
+ * never by graph identity. `node.graph !== graph` would read a Vue proxy of the live
+ * root as a foreign graph and refuse every conversion on a reactive frontend — the
+ * same proxy/raw duality as #558. Only a NULLISH back-reference counts, because only
+ * that is unambiguous: the graph lists the node, the node denies the graph.
+ *
+ * Returns `[]` for anything unreadable — a graph this cannot inspect must fall through
+ * to the conversion, not be refused by it.
+ */
+export function detachedConversionNodes(graph, nodes) {
+  const selection = Array.isArray(nodes) ? nodes : [];
+  if (!selection.length) return [];
+  if (typeof graph?.getNodeById !== "function") return [];
+  const owns = (node) => node?.id != null && graph.getNodeById(node.id) === node;
+  const found = [];
+  const seen = new Set();
+  const consider = (node) => {
+    if (!node || seen.has(node)) return;
+    seen.add(node);
+    if (!owns(node)) return;
+    if (node.graph == null) found.push(node.id);
+  };
+  for (const node of selection) {
+    consider(node);
+    for (const id of linkedNeighborIds(node, graph?.links)) consider(graph.getNodeById(id));
+  }
+  return found;
+}
+
+/** The pre-flight refusal. Raised BEFORE `convertToSubgraph` is called, so it is the
+ *  one report in this file that can promise the canvas is untouched. */
+export function detachedConversionRefusal({ what, detached }) {
+  const bad = Array.isArray(detached) ? detached : [];
+  const one = bad.length === 1;
+  return (
+    `${what} was NOT run and the graph is unchanged. Node${one ? "" : "s"} ${bad.join(", ")} ` +
+    `${one ? "is" : "are"} listed on this graph but ${one ? "does" : "do"} not reference it ` +
+    `back (node.graph is unset), and ComfyUI's convertToSubgraph throws "Attempted to access ` +
+    `LGraph reference that was null or undefined." on exactly that — after it has already ` +
+    `removed the nodes you selected, leaving a half-built subgraph wired to nothing ` +
+    `(comfyui-mcp-panel#1463). Refusing here is what keeps that from happening. This is a ` +
+    `stale canvas, not a bad selection: it follows a ComfyUI restart, or an extension ` +
+    `detaching a node without removing it. Reload the ComfyUI page to rebuild the graph ` +
+    `(save first — panel_save_workflow), then retry. Every other panel tool keeps working ` +
+    `meanwhile; subgraph conversion is the one that touches this back-reference.`
+  );
+}
+
+/**
+ * What of this conversion is still on the graph.
+ *
+ * `present` is compared by node IDENTITY, not by id, so an id the frontend later
+ * re-issues cannot read as "the node survived".
+ */
+export function conversionSnapshot(graph, nodes) {
+  const present = [];
+  const readable = typeof graph?.getNodeById === "function";
+  for (const node of Array.isArray(nodes) ? nodes : []) {
+    if (node?.id == null) continue;
+    if (!readable || graph.getNodeById(node.id) === node) present.push(node.id);
+  }
+  const definitions = graph?.subgraphs?.size;
+  return {
+    present,
+    readable,
+    definitions: typeof definitions === "number" ? definitions : null,
+  };
+}
+
+/**
+ * The report for a conversion that threw.
+ *
+ * It leads with the verdict the caller acts on — did the graph change? — because that,
+ * not the frontend's wording, decides whether a retry is safe. The frontend's message
+ * is carried through VERBATIM and quoted: it is the only greppable thing #1463's
+ * reporter had, and dropping it would break every existing search for it.
+ */
+export function conversionThrowReport({ what, message, before, after }) {
+  const raw = typeof message === "string" && message.trim() ? message.trim() : "(no message)";
+  const beforeIds = Array.isArray(before?.present) ? before.present : [];
+  const afterIds = Array.isArray(after?.present) ? after.present : [];
+  const removed = beforeIds.filter((id) => !afterIds.includes(id));
+  const addedDefs =
+    typeof before?.definitions === "number" && typeof after?.definitions === "number"
+      ? after.definitions - before.definitions
+      : null;
+  const tail =
+    `The throw came from ComfyUI's own convertToSubgraph — the panel calls that method, it ` +
+    `does not implement it, and extensions are free to replace it — so the wording quoted ` +
+    `above is not necessarily litegraph's.`;
+
+  if (removed.length || (addedDefs != null && addedDefs > 0)) {
+    const lost = removed.length
+      ? `${removed.length} of the ${beforeIds.length} node(s) you selected (${removed.join(", ")}) ` +
+        `${removed.length === 1 ? "is" : "are"} already off the canvas`
+      : `every node you selected is still on the canvas`;
+    const defs =
+      addedDefs != null && addedDefs > 0
+        ? `, and ${addedDefs} subgraph definition(s) were registered`
+        : "";
+    return (
+      `${what} FAILED PART WAY THROUGH and the graph HAS CHANGED — do not retry blindly. ` +
+      `${lost}${defs}. Whatever wrapper the conversion got as far as creating was never ` +
+      `finished, so it can be sitting on the canvas wired to nothing. ComfyUI's ` +
+      `convertToSubgraph threw: "${raw}". Undo the conversion in ComfyUI (Ctrl+Z) or reload ` +
+      `the workflow, then re-read the graph (panel_graph_outline) before doing anything ` +
+      `else — the node ids you passed no longer describe the canvas. ${tail}`
+    );
+  }
+
+  if (!before?.readable || !after?.readable) {
+    return (
+      `${what} failed, and the panel could NOT establish whether the graph changed — this ` +
+      `frontend does not expose the node lookup that check needs, so treat the canvas as ` +
+      `unknown rather than untouched. ComfyUI's convertToSubgraph threw: "${raw}". Re-read ` +
+      `the graph (panel_graph_outline) before retrying. ${tail}`
+    );
+  }
+
+  return (
+    `${what} failed and the graph is UNCHANGED — all ${beforeIds.length} selected node(s) ` +
+    `are still on the canvas and no subgraph was created, so there is nothing to undo. ` +
+    `ComfyUI's convertToSubgraph threw: "${raw}". A straight retry will hit the same thing; ` +
+    `the selection itself is intact, so this is about the state of the canvas, not the nodes ` +
+    `you named. Reloading the ComfyUI page rebuilds the graph and clears the stale-canvas ` +
+    `form of this (save first — panel_save_workflow). ${tail}`
+  );
+}

--- a/web/js/lib/subgraph-conversion-integrity.js
+++ b/web/js/lib/subgraph-conversion-integrity.js
@@ -652,11 +652,17 @@ export function conversionThrowReport({ what, message, before, after }) {
     );
   }
 
+  // "nothing overrides it ON THIS GRAPH OBJECT" is exactly what `wrapped` measures, and
+  // is all this may say: a patch applied to `LGraph.prototype` is invisible to an
+  // own-property test, so the wider claim ("nothing has replaced convertToSubgraph")
+  // would be false there — and an unverified sentence in a tool result gets quoted back
+  // as a measurement. It costs nothing to say only the true one.
   return (
     `${what} failed and nothing the panel can read moved: all ${beforeIds.length} selected ` +
     `node(s) are still on the canvas, no subgraph definition was registered, the link table ` +
-    `is unchanged at ${after.links} entries, and nothing has replaced convertToSubgraph on ` +
-    `this graph. There is nothing to undo. ComfyUI's convertToSubgraph threw: "${raw}". A ` +
+    `is unchanged at ${after.links} entries, and nothing on this graph object overrides ` +
+    `ComfyUI's own convertToSubgraph. There is nothing to undo. ComfyUI's convertToSubgraph ` +
+    `threw: "${raw}". A ` +
     `straight retry will hit the same thing; the selection itself is intact, so this is about ` +
     `the state of the canvas, not the nodes you named. Reloading the ComfyUI page rebuilds ` +
     `the graph and clears the stale-canvas form of this (save first — panel_save_workflow). ` +

--- a/web/js/lib/subgraph-conversion-integrity.js
+++ b/web/js/lib/subgraph-conversion-integrity.js
@@ -558,8 +558,11 @@ export function detachedConversionRefusal({ what, detached }) {
     `either from happening. This is a stale canvas, not a bad selection: it follows a ` +
     `ComfyUI restart, or an extension detaching a node without removing it. Reload the ` +
     `ComfyUI page to rebuild the graph (save first — panel_save_workflow), then retry. ` +
-    `Every other panel tool keeps working meanwhile; subgraph conversion is the one that ` +
-    `touches this back-reference.`
+    // NOT "every other panel tool keeps working meanwhile" (gate r4): a detached node
+    // throws out of the disconnect paths too, so that would be another claim wider than
+    // anything measured here — the exact habit this file exists to break.
+    `Tools that never ask this node to do graph work are unaffected, but anything that ` +
+    `disconnects or removes it can hit the same throw.`
   );
 }
 


### PR DESCRIPTION
Fixes #1463

## What #1463 reported

`panel_create_subgraph` and `panel_subgraph_group` both failed with nothing but the
frontend's own exception text:

```
Error: Attempted to access LGraph reference that was null or undefined.
```

Six failures in a row — 8 nodes, retried 3×, then the same 8 via `panel_create_group` +
`panel_subgraph_group`, then a 2-node native-only selection — all with that one string and
no stack. Every other `panel_*` mutation tool worked throughout the same session, before
and after a ComfyUI process restart, and `panel_graph_outline` reported
`canvas_binding: "bound"` / `mutations_ready: true` at the moment of failure.

## What was measured

Driven in a real browser against the ComfyUI on this machine. Root graph `1→2→3→4` wired
in a chain, converting the middle pair `[2, 3]`, with node 1's `graph` back-reference
cleared:

```
nodes before: 1,2,3,4        subgraph definitions: 0
→ convertToSubgraph throws "Attempted to access LGraph reference that was null or undefined."
nodes after:  1,4,5          subgraph definitions: 1
node 5 is the new subgraph node; its input link is null
```

**Nodes 2 and 3 are gone**, a subgraph definition is registered, and the wrapper the
conversion got as far as creating was never wired back to node 1 — and the only thing the
caller was told is the bare frontend message. #1463's reporter read exactly that as "no
other side effects" and retried three times.

Clearing the back-reference on a **selected** node instead throws at `disconnectInput`,
which the shipped `_convertToSubgraphImpl` runs *after* `createSubgraph`. Measured through
`LGraph.prototype.convertToSubgraph`, bypassing the wrapper this install has:

```
nodes 1,2,3,4 → 1,2,3,4   but   subgraph defs 0 → 1
```

So the two failures are not "destroyed" versus "untouched" — one loses nodes, the other
quietly registers a definition, and both print the same sentence.

## The fix

Both tools now reach the frontend through one shared runner
(`convertSelectionToSubgraph`), which does three things the bare call could not:

1. **Refuses up front on the condition that provably causes this — and only where it is
   actually fatal.** A node the graph lists but that does not point back at it
   (`node.graph` unset) is checked on the selection and on its **upstream producers**. The
   refusal happens before `convertToSubgraph` is called, so it can honestly promise the
   canvas is untouched, and it names the nodes, the per-role consequence, and the remedy.

   Direction decides fatality. The input-side reconnect is
   `outputNode.connectSlots(output, subgraphNode, …)` — `this` is the *outside producer*,
   and `connectSlots` opens with `if (!graph) throw new NullGraphError()`. The output-side
   one is `subgraphNode.connectSlots(output, inputNode, …)`, where `this` is the freshly
   added wrapper and nothing ever reads the consumer's `graph`. So a detached **consumer**
   is not refused — it converts fine — and neither is a detached selected node carrying no
   links, which was measured wrapping cleanly.

   Ownership is proved by **node** identity (`getNodeById(id)` returns this very object),
   never by graph identity: `node.graph !== graph` would read a Vue proxy of the live root
   as a foreign graph and refuse every conversion on a reactive frontend (the #558
   proxy/raw duality). Only a *nullish* back-reference counts — the graph lists the node,
   the node denies the graph. An unreadable graph falls through to the conversion rather
   than being refused by it.

2. **Reports a throw with a measured verdict.** Three surfaces are snapshotted either side
   of the call — the selected nodes (by identity), the subgraph-definition count, and the
   size of the link table — plus whether anything has replaced `convertToSubgraph` on the
   graph object. The verdict is then `HAS CHANGED` (naming what moved), `UNCHANGED`, or
   `could NOT establish` — never a claim wider than the measurement. See the gate section
   below for why that last one exists.

3. **Makes the selection itself, and refuses a frontend that cannot select.** Both
   executors previously fell through with no selection made when neither `selectItems` nor
   `selectNodes` exists, converting whatever happened to be selected — a set the caller
   never named. `panel_select_nodes` already refused that; now so does this.

The frontend's own message is quoted **verbatim** in all three verdicts and kept as the
error's `cause`, so nothing greppable is lost. `beforeChange`/`afterChange` stay paired in
a `finally` exactly as before.

This is the mirror of #1571 (`a subgraph conversion that broke the graph stops reporting
success`): a conversion that *changed* the graph must stop reporting as a bare failure.

## Gate

Codex was unavailable (account exhausted until 2026-08-19 20:43); gated by an independent
adversarial review instead (`.claude/autopilot/claude-gate.mjs`), per the standing
authorisation. Six rounds, four of them substantive — every finding below was
independently re-verified before being acted on, not taken on faith.

**Round 1 — NO-SHIP, and it was right.** The first version answered "the graph is
UNCHANGED … nothing to undo" from node presence and the definition count alone.
`convertToSubgraph` is instance-assignable and extensions replace it — cg-use-everywhere
sets `app.graph.convertToSubgraph` to a wrapper that rewires links, delegates, and calls
`mods.restorer()` **outside** a `finally`, so a throw from the delegate leaves injected
links behind with every node and definition exactly where it was. The old code said
nothing; that version said something confidently wrong, which is worse. It also caught two
false comments and the silent selection fall-through. → link-table term, `wrapped` term,
three-way verdict, selection moved into the runner.

**Round 2 — SHIP**, with two non-blocking notes (`wrapped` is an own-property test, so
"nothing has replaced convertToSubgraph" is false for a prototype-level patch; an orphaned
jsdoc). Both applied.

**Round 3 — NO-SHIP, two more real P1s.**

1. `detachedConversionRefusal` emitted **one** sentence for both states it fires on, and
   that sentence described the neighbour outcome. The shipped order is `createSubgraph`
   @1792 → `disconnectInput` @1807 → `remove` @1817 → `add` @1858, so a detached
   *selected* node throws before anything is removed — "after it has already removed the
   nodes you selected" is a state that path never reaches, while the state it *does* leave
   (a registered definition) went unmentioned. Findings now carry their role and the
   message states the consequence per role.
2. **Nothing pinned the guard behaviourally.** `if (detached.length)` →
   `if (detached.length > 2)` passed all 5,799 tests while the exact #1463 state reached
   `convertToSubgraph` and destroyed the selection — the three tests touching the runner
   were regexes over source text, which an inert guard satisfies. Section 6 of the spec now
   extracts the shipped runner and **drives** it.

**Round 4 — SHIP.** All five mutants killed; the reviewer independently confirmed against
the running frontend bundle that `LGraph.add` sets `node.graph` before `_nodes_by_id`, that
`remove` clears it before deleting the lookup (so the refusal cannot false-positive on a
healthy node), and that `Subgraph.inputNode`/`outputNode` are fields never in
`_nodes_by_id` (so the neighbour sweep cannot false-refuse inside a subgraph). One sub-P1
prose note — "every other panel tool keeps working meanwhile" is not strictly true, since a
detached node throws out of the disconnect paths too — applied.

**Round 5 — NO-SHIP, and the sharpest finding of the six.** The `role` split was at the
wrong seam: it swept *every* neighbour, so a detached **downstream consumer** hard-refused
a conversion the frontend completes, with a message asserting a destruction that never
happens on that path — a fix worse than the bug, in exactly the pathological state this
feature targets. I re-read the shipped `LGraphNode.connectSlots` / `disconnectOutput` and
the two reconnect loops before acting, and the claim holds: only `this.graph` is ever
dereferenced, and on the output side `this` is the wrapper. Roles are now
`selected`/`producer`, the sweep walks input-side origins only, and the same narrowing was
applied to the selection side (an unlinked detached selected node is no longer refused —
also measured). Three new mutants pin it: sweeping consumers again (2 fail), refusing an
unlinked selection again (1), and `carriesAnyLink` forced true (1).

**Round 6 — SHIP, no findings.** All eight mutants killed. The reviewer re-derived the
direction split from the frontend source, confirmed `carriesAnyLink` matches
`LGraph.remove`'s per-link guards exactly, and refuted "fix worse than the bug" by
running it: a detached downstream consumer, unlinked detached selected nodes, and a
healthy chain all convert normally through the shipped runner. It also checked robustness
this PR had not: a thrown *string* (litegraph does `throw 'Target Node not found'`)
survives verbatim with `cause` intact, and the real `MapProxyHandler` link proxy reads
correctly through both `.get` and `.size`.

## Proof, in a live browser

Running the shipped runner against the live graph:

| scenario | before this PR | after |
| --- | --- | --- |
| the destructive repro (`1,2,3,4`, node 1 detached) | `1,4,5` — nodes 2 and 3 destroyed, bare exception | **`1,2,3,4` — untouched**, precise refusal |
| healthy conversion (control) | OK | OK — `node 5`, `1,4,5` |
| a wrapper rewires links, then the delegate throws | `UNCHANGED … nothing to undo` (false) | `could NOT establish … an extension has replaced convertToSubgraph on this graph` |
| wrapper present, nothing observable moved | bare exception | `could NOT establish` + what it *did* measure |
| unwrapped graph, nothing moved | bare exception | `nothing the panel can read moved … link table is unchanged at 3 entries … nothing to undo` |
| frontend with no selection API | converts a set the caller never named | `was NOT run and the graph is unchanged` |

## Verified by mutation

`browser_tests/unit/subgraph-conversion-throw-verdict.test.mjs` (29 tests). Each mutation
was applied to the tree and the suite re-run; all restore green:

| mutation | failures |
| --- | --- |
| ownership checked by **graph** identity (the Vue-proxy trap) | 1 |
| report always claims UNCHANGED | 2 |
| frontend message dropped from the report | 4 |
| `panel_create_subgraph` reverted to the bare pre-fix call | 2 |
| `panel_subgraph_group` reverted to the bare pre-fix call | 2 |
| refusal moved to *after* the conversion | 1 |
| `cause` dropped | 1 |
| `afterChange` moved out of `finally` | 3 |
| wrapper term dropped from the snapshot | 1 |
| link term dropped from the snapshot | 1 |
| a wrapper no longer withdraws the confident verdict | 1 |
| a link-table delta no longer counts as CHANGED | 3 |
| link table always reads as uncountable | 1 |
| wrapper detected on the prototype too (over-detection) | 1 |
| no-selection-API refusal removed | 1 |
| selection moved back out of the runner | 1 |
| **the guard made inert** (`if (detached.length > 2)`) | 2 |
| **the guard short-circuited** (`if (false && detached.length)`) | 2 |
| the producer sweep removed | 3 |
| consumers swept as well (the over-refusal) | 2 |
| an unlinked detached selection refused again | 1 |
| `carriesAnyLink` forced true | 1 |
| the definition count dropped from the snapshot | 3 |
| the role dropped from each finding | 2 |

The last four are the round-3 escapes: before section 6 existed, an inert guard passed the
whole suite while the exact #1463 state destroyed the selection. Similarly, the first
version of the ordering assertion used `indexOf(...) < indexOf(...)`, which deleting the
refusal turns into `-1 < n` — green. Both now require the thing to be *present and doing
something*, driven by execution.

Full suite: **5811 pass, 0 fail** (`npm run test:unit`), `tsc --noEmit` clean. The two existing `new Function`
extraction harnesses (`subgraph-stale-outline`, `subgraph-conversion-integrity`) inject the
**real** runner rather than a stub — a stub there would hide a regression in it. The #1571
"imported, not shadowed by a local stub" test was rewritten to check the four guards
name-by-name instead of matching one frozen import block, so adding exports to that lib can
no longer fail it spuriously.

## Browser suite

The panel bundle from this branch was loaded into a real Chromium against the live ComfyUI
(all 564 assets route-swapped, the same technique as the suite's own
`fixtures/worktreeSource.ts`): extension `comfyui-mcp.agent-panel` registers, the Agent
sidebar tab renders, **no page errors**.

`npx playwright test --workers=1` was also run in full: **59 passed, 19 failed**. Those
failures are pre-existing. Re-running the six affected spec files against a clean
`origin/main` worktree gives **4 passed, 16 failed** — the same MockBridge-timeout set, one
*more* failure than this branch. They sit in chat persistence, streaming render and the
mock bridge; this change touches only the two subgraph-conversion executors and a pure lib.

The full suite could not be pointed at this branch: the shared ComfyUI resolves the
`custom_nodes` junction at startup (its checkout is 66 commits behind `origin/main`), and
restarting it would have killed a third-party job that was running. Hence the route-swap
above, and the same-machine baseline comparison rather than a green wall.

The browser evidence above covers everything through gate round 2. The later revisions —
per-role refusal wording, and the executed-runner spec — landed after the shared ComfyUI
went down (not by this run), so they are verified by the executed-runner tests in section 6
of the spec rather than re-driven in a browser. They change message text and test coverage;
the guard's runtime behaviour, that it refuses before `convertToSubgraph` is called, is
unchanged and is the thing those tests execute.

## What this does NOT claim

I could **not** reproduce #1463's original trigger on current `main` — a clean conversion
works for 4520 of 4525 registered node types on this install, and survives chains, groups,
nesting, workflow round-trips and node-definition refreshes. The throw originates inside
ComfyUI's `convertToSubgraph`, which the panel calls but does not implement and which
extensions are free to replace. So this change makes the reporter's failure **diagnosable
and non-destructive**; it does not promise their particular conversion now succeeds. If the
detached-node condition was what they hit, it now refuses cleanly instead of eating the
selection — and either way the next report will carry a verdict instead of one opaque line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
