### PR TITLE
fix(1467): a clipboard's file item no longer discards the text pasted with it

### DIFF
--- a/browser_tests/unit/composer-paste.test.mjs
+++ b/browser_tests/unit/composer-paste.test.mjs
@@ -1,0 +1,265 @@
+// #1467 — pasted chat text silently dropped before reaching the agent.
+//
+// Two silent content-loss paths on the composer, tested at two different depths.
+//
+// The paste handler is exercised as SHIPPED: its listener is sliced out of the
+// panel source and evaluated against doubles, so these tests fail if the routing
+// decision is reverted, and they cannot pass against a copy of the handler that
+// no longer exists. The decision itself lives in web/js/lib/composer-paste.js and
+// is tested directly for the cases a DOM cannot reach cheaply.
+//
+// The orphaned-token guard sits inside the 250-line submit handler, which cannot
+// be rebuilt in a synthetic scope; it is pinned at the source level instead —
+// including its ORDER relative to resetAttachments(), because a guard that reads
+// the registry after it is cleared reports every token as orphaned.
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+import {
+  PASTE_TEXT_THRESHOLD,
+  PASTE_TEXT_LINE_THRESHOLD,
+  isLargePaste,
+  planComposerPaste,
+  orphanAttachmentTokens,
+} from "../../web/js/lib/composer-paste.js";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const PANEL_SRC = readFileSync(join(HERE, "../../web/js/comfyui-mcp-panel.js"), "utf8").replace(/\r\n/g, "\n");
+
+// ---------------------------------------------------------------------------
+// The shipped paste listener, rebuilt against doubles.
+// ---------------------------------------------------------------------------
+
+/** Slice the composer's `paste` listener out of the panel source. */
+function shippedPasteListenerSource() {
+  const open = `input.addEventListener("paste", (ev) => {`;
+  const start = PANEL_SRC.indexOf(open);
+  assert.notEqual(start, -1, "the composer's paste listener is no longer findable — update this harness");
+  const close = "\n  });";
+  const end = PANEL_SRC.indexOf(close, start);
+  assert.notEqual(end, -1, "the paste listener's end is no longer findable — update this harness");
+  return PANEL_SRC.slice(start, end + close.length);
+}
+
+/**
+ * Run the SHIPPED listener over one synthetic clipboard and report what it did.
+ * Every collaborator is a double, so the only real logic under test is the
+ * handler's own routing plus the real planComposerPaste it calls.
+ */
+function runShippedPaste({ file = null, text = "" }) {
+  const calls = { handleFile: [], handlePastedText: [], insertAtCaret: [], prevented: 0, stopped: 0 };
+  let listener = null;
+  const input = {
+    addEventListener(type, fn) {
+      if (type === "paste") listener = fn;
+    },
+  };
+  // eslint-disable-next-line no-new-func -- the point is to run the shipped source
+  const register = new Function(
+    "input",
+    "handleFile",
+    "handlePastedText",
+    "insertAtCaret",
+    "planComposerPaste",
+    shippedPasteListenerSource(),
+  );
+  register(
+    input,
+    (f) => calls.handleFile.push(f),
+    (t) => calls.handlePastedText.push(t),
+    (t) => calls.insertAtCaret.push(t),
+    planComposerPaste,
+  );
+  assert.ok(listener, "the sliced source did not register a paste listener");
+  listener({
+    clipboardData: {
+      items: file ? [{ kind: "file", getAsFile: () => file }] : [{ kind: "string" }],
+      getData: (fmt) => (fmt === "text/plain" ? text : ""),
+    },
+    preventDefault() {
+      calls.prevented += 1;
+    },
+    stopPropagation() {
+      calls.stopped += 1;
+    },
+  });
+  return calls;
+}
+
+const BIG = "prompt line that goes on and on. ".repeat(40); // ~1.3 KB, like the report
+
+test("#1467 a clipboard carrying BOTH a file and a large text keeps the text", () => {
+  const file = { name: "image.png", type: "image/png" };
+  const calls = runShippedPaste({ file, text: BIG });
+  // The regression: the file branch called preventDefault() and returned, so the
+  // text was discarded AND the browser's own insertion was suppressed.
+  assert.deepEqual(calls.handlePastedText, [BIG]);
+  assert.deepEqual(calls.handleFile, [file]);
+  assert.equal(calls.prevented, 1);
+  assert.equal(calls.stopped, 1);
+});
+
+test("#1467 a clipboard carrying a file and a SHORT text still places the text", () => {
+  const file = { name: "image.png", type: "image/png" };
+  const calls = runShippedPaste({ file, text: "a red car" });
+  assert.deepEqual(calls.insertAtCaret, ["a red car"], "short text must be inserted by hand — default is suppressed");
+  assert.deepEqual(calls.handleFile, [file]);
+  assert.deepEqual(calls.handlePastedText, []);
+});
+
+test("#1467 a screenshot paste (file, no text) is unchanged", () => {
+  const file = { name: "image.png", type: "image/png" };
+  const calls = runShippedPaste({ file, text: "" });
+  assert.deepEqual(calls.handleFile, [file]);
+  assert.deepEqual(calls.insertAtCaret, []);
+  assert.deepEqual(calls.handlePastedText, []);
+  assert.equal(calls.prevented, 1, "the composer still claims a pasted file");
+  assert.equal(calls.stopped, 1, "#384 — and still keeps it from ComfyUI's canvas paste handler");
+});
+
+test("#1467 a large text paste with no file still collapses to a chip", () => {
+  const calls = runShippedPaste({ text: BIG });
+  assert.deepEqual(calls.handlePastedText, [BIG]);
+  assert.deepEqual(calls.handleFile, []);
+  assert.equal(calls.prevented, 1);
+  assert.equal(calls.stopped, 1, "#384 — a large paste must not reach ComfyUI's canvas paste handler");
+});
+
+test("#1467 a small text paste with no file is left entirely to the browser", () => {
+  const calls = runShippedPaste({ text: "hello" });
+  assert.equal(calls.prevented, 0, "claiming this event would suppress the insertion nothing replaces");
+  assert.equal(calls.stopped, 0);
+  assert.deepEqual(calls.handlePastedText, []);
+  assert.deepEqual(calls.insertAtCaret, []);
+  assert.deepEqual(calls.handleFile, []);
+});
+
+test("#1467 an item that reports kind:file but yields no File falls back to the text route", () => {
+  const calls = runShippedPaste({ file: null, text: BIG });
+  assert.deepEqual(calls.handleFile, []);
+  assert.deepEqual(calls.handlePastedText, [BIG]);
+});
+
+// ---------------------------------------------------------------------------
+// The decision itself.
+// ---------------------------------------------------------------------------
+
+test("#1467 planComposerPaste never answers with a flavour it discards", () => {
+  const flavours = [
+    { hasFile: false, text: "" },
+    { hasFile: false, text: "short" },
+    { hasFile: false, text: BIG },
+    { hasFile: true, text: "" },
+    { hasFile: true, text: "short" },
+    { hasFile: true, text: BIG },
+  ];
+  for (const c of flavours) {
+    const plan = planComposerPaste(c);
+    assert.equal(plan.file, c.hasFile, `the file must survive ${JSON.stringify(c.text.slice(0, 8))}`);
+    if (c.text) {
+      assert.notEqual(plan.text, "none", "text present but the plan places none of it");
+      // "default" means the browser inserts it; every other answer places it here.
+      assert.ok(["attach", "insert", "default"].includes(plan.text));
+    }
+    // The one answer that leaves the event alone must not be paired with a claim.
+    if (plan.text === "default") assert.equal(plan.file, false);
+  }
+});
+
+test("#1467 isLargePaste is long OR tall, and the thresholds are exclusive/inclusive as stated", () => {
+  assert.equal(isLargePaste("x".repeat(PASTE_TEXT_THRESHOLD)), false, "exactly the threshold is not over it");
+  assert.equal(isLargePaste("x".repeat(PASTE_TEXT_THRESHOLD + 1)), true);
+  assert.equal(isLargePaste("a\n".repeat(PASTE_TEXT_LINE_THRESHOLD - 1)), false);
+  assert.equal(isLargePaste("a\n".repeat(PASTE_TEXT_LINE_THRESHOLD)), true, "a tall paste collapses however short");
+  assert.equal(isLargePaste(""), false);
+  assert.equal(isLargePaste(undefined), false);
+});
+
+// ---------------------------------------------------------------------------
+// Orphaned attachment tokens.
+// ---------------------------------------------------------------------------
+
+test("#1467 a token whose attachment is still registered is not orphaned", () => {
+  const atts = [{ id: 1, kind: "text", content: "…" }];
+  assert.deepEqual(orphanAttachmentTokens("[Pasted text #1] can you read this?", atts), []);
+});
+
+test("#1467 a recalled message whose registry was cleared names its dead tokens", () => {
+  // ↑ history recall / ✎ edit / double-Esc rewind hand back the RAW text after
+  // resetAttachments() has emptied the registry.
+  assert.deepEqual(orphanAttachmentTokens("[Pasted text #1] can you read this?", []), ["[Pasted text #1]"]);
+});
+
+test("#1467 an id alone never resolves a token — kind and id must both match", () => {
+  const atts = [{ id: 1, kind: "image", name: "a.png" }];
+  assert.deepEqual(orphanAttachmentTokens("[Image #1] [Pasted text #1]", atts), ["[Pasted text #1]"]);
+});
+
+test("#1467 every attachment kind's token is recognised", () => {
+  const text = "[Image #1] [Pasted text #2] [Video #3] [File #4] [Workflow #5]";
+  assert.deepEqual(orphanAttachmentTokens(text, []), [
+    "[Image #1]",
+    "[Pasted text #2]",
+    "[Video #3]",
+    "[File #4]",
+    "[Workflow #5]",
+  ]);
+  const live = [
+    { id: 1, kind: "image" },
+    { id: 2, kind: "text" },
+    { id: 3, kind: "video" },
+    { id: 4, kind: "textfile" },
+    { id: 5, kind: "workflow" },
+  ];
+  assert.deepEqual(orphanAttachmentTokens(text, live), []);
+  // `file` (an unknown binary uploaded into input/) also carries a [File #N] token.
+  assert.deepEqual(orphanAttachmentTokens("[File #4]", [{ id: 4, kind: "file" }]), []);
+});
+
+test("#1467 a repeated dead token is reported once, and a clean message reports nothing", () => {
+  assert.deepEqual(orphanAttachmentTokens("[Pasted text #1] and again [Pasted text #1]", []), ["[Pasted text #1]"]);
+  assert.deepEqual(orphanAttachmentTokens("just a normal question", []), []);
+});
+
+test("#1467 the token scan does not carry lastIndex between calls", () => {
+  const text = "[Pasted text #1] tail";
+  assert.deepEqual(orphanAttachmentTokens(text, []), ["[Pasted text #1]"]);
+  assert.deepEqual(orphanAttachmentTokens(text, []), ["[Pasted text #1]"], "a shared global regex would return []");
+});
+
+// ---------------------------------------------------------------------------
+// Wiring — the guard exists AND the send path reaches it, in the right order.
+// ---------------------------------------------------------------------------
+
+test("#1467 the panel imports the paste plan and the orphan scan", () => {
+  assert.match(
+    PANEL_SRC,
+    /import \{ planComposerPaste, orphanAttachmentTokens \} from "\.\/lib\/composer-paste\.js";/,
+    "the composer-paste import is gone — the helpers below are then dead code",
+  );
+});
+
+test("#1467 the submit path scans for orphaned tokens BEFORE the registry is cleared", () => {
+  const scan = PANEL_SRC.indexOf("const orphanedTokens = orphanAttachmentTokens(text, attachments);");
+  assert.notEqual(scan, -1, "the submit path no longer scans for orphaned attachment tokens");
+  const reset = PANEL_SRC.indexOf("resetAttachments();", scan);
+  assert.notEqual(reset, -1, "resetAttachments() no longer follows the scan in the submit path");
+  assert.ok(scan < reset, "reading the registry after it is cleared reports EVERY token as orphaned");
+  // And the finding is surfaced rather than counted and dropped.
+  const warn = PANEL_SRC.indexOf("panel.attachment_content_no_longer_loaded");
+  assert.ok(warn > scan, "the orphaned tokens are never told to the user");
+  assert.match(PANEL_SRC.slice(scan, warn + 400), /appendSystem\(/, "the warning is not appended to the chat");
+});
+
+test("#1467 the paste handler no longer returns out of the file branch", () => {
+  const listener = shippedPasteListenerSource();
+  assert.doesNotMatch(
+    listener,
+    /handleFile\(file\);\s*\n\s*return;/,
+    "an early return after handleFile() is exactly the shape that discarded the pasted text",
+  );
+  assert.match(listener, /planComposerPaste\(\{ hasFile: !!file, text \}\)/);
+});

--- a/locales/en/main.json
+++ b/locales/en/main.json
@@ -342,6 +342,7 @@
       "at_menu_subgraph": "subgraph",
       "at_menu_workflow": "workflow — {title}",
       "attach_an_image_video_workflow_json_or": "Attach an image, video, workflow (.json), or text file",
+      "attachment_content_no_longer_loaded": "Sent without the content behind {tokens} — that attachment is no longer loaded, so the agent received the placeholder only. Re-paste or re-attach it to send the content.",
       "auto": "Auto",
       "auto_arranged_columns_one": " ({count} column)",
       "auto_arranged_columns_other": " ({count} columns)",

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -485,6 +485,7 @@ import {
   registryTypePredicate,
   formatUnpasteableCopyWarning,
 } from "./lib/paste-report.js";
+import { planComposerPaste, orphanAttachmentTokens } from "./lib/composer-paste.js";
 import {
   withInMemoryClipboard,
   getInMemoryClipboard,
@@ -36050,7 +36051,10 @@ function buildPanel() {
   //   • workflow → the .json is read and inlined so the agent can load/analyze it
   //   • text     → the file's text is read and inlined (like a big paste)
   // A big text paste also collapses to a [Pasted text #N] chip.
-  const PASTE_TEXT_THRESHOLD = 800; // chars; longer pastes collapse to a chip
+  // The size at which a paste collapses to a chip is planComposerPaste's to know
+  // (web/js/lib/composer-paste.js) — it decides the file and text halves of one
+  // clipboard together, which is what stopped a file item from silently eating the
+  // text pasted with it (#1467).
   const MAX_INLINE_TEXT = 600_000; // chars; cap inlined file text (workflows/docs)
   // Text-ish files we read & inline rather than upload. (.json is handled as a
   // workflow first; if it doesn't parse as one it falls back to a text file.)
@@ -36586,31 +36590,30 @@ function buildPanel() {
     // Any pasted file (a screenshot, or a file copied from the OS) routes through
     // the same dispatcher as the attach button and drag-drop.
     const fileItem = Array.from(dt.items || []).find((it) => it.kind === "file");
-    if (fileItem) {
-      const file = fileItem.getAsFile();
-      if (file) {
-        ev.preventDefault();
-        // Once the composer has claimed a pasted file, stop the event here.
-        // Without stopPropagation it keeps bubbling to `document`, where
-        // ComfyUI core's own global paste-to-canvas listener also inspects the
-        // clipboard and drops a duplicate, unwanted LoadImage node onto the
-        // live graph for every screenshot/image attached to a chat message
-        // (#384).
-        ev.stopPropagation();
-        handleFile(file);
-        return;
-      }
-    }
+    const file = fileItem ? fileItem.getAsFile() : null;
     const text = dt.getData("text/plain");
-    if (text && (text.length > PASTE_TEXT_THRESHOLD || (text.match(/\n/g) || []).length >= 12)) {
-      ev.preventDefault();
-      // Same rationale as the file branch (#384): the composer has claimed this
-      // large paste as an attachment, so keep it from bubbling to ComfyUI's
-      // document-level paste handler (which would try to paste graph JSON /
-      // nodes onto the canvas).
-      ev.stopPropagation();
-      handlePastedText(text);
-    }
+    // #1467 — BOTH halves of the clipboard are decided in one place. The file
+    // branch used to call preventDefault() and RETURN, which threw away any
+    // text/plain that arrived with the file AND suppressed the browser's own
+    // insertion of it. Copying rich content on Windows (Word, Outlook, Excel,
+    // and many web pages) puts a synthesized bitmap on the clipboard next to the
+    // text, so pasting a prompt out of a document attached a picture of it and
+    // dropped every character, with no error and no placeholder.
+    const plan = planComposerPaste({ hasFile: !!file, text });
+    // The only answer that claims nothing: a small paste with no file, which the
+    // browser inserts for us exactly as it always did.
+    if (!plan.file && plan.text === "default") return;
+    ev.preventDefault();
+    // Once the composer has claimed this paste, stop the event here. Without
+    // stopPropagation it keeps bubbling to `document`, where ComfyUI core's own
+    // global paste-to-canvas listener also inspects the clipboard — dropping a
+    // duplicate, unwanted LoadImage node onto the live graph for every
+    // screenshot/image attached to a chat message, and trying to paste graph
+    // JSON / nodes onto the canvas for a large text paste (#384).
+    ev.stopPropagation();
+    if (plan.file) handleFile(file);
+    if (plan.text === "attach") handlePastedText(text);
+    else if (plan.text === "insert") insertAtCaret(text);
   });
 
   // ---- voice dictation (browser speech recognition; Chrome) ----
@@ -37190,7 +37193,24 @@ function buildPanel() {
     const refVideos = attachments.filter((a) => a.kind === "video" && referenced(a));
     const refFiles = attachments.filter((a) => (a.kind === "textfile" || a.kind === "workflow") && referenced(a));
     const refUploads = attachments.filter((a) => a.kind === "file" && referenced(a));
+    // #1467 — a token whose attachment is GONE. The registry is cleared after every
+    // send, but the raw composer text (tokens and all) is kept and handed back by ↑
+    // history recall, the ✎ edit control and the double-Esc rewind. Re-sending one of
+    // those shipped a bare `[Pasted text #1]` to the agent: the pasted content silently
+    // absent, no error, no placeholder — the message merely looked complete. Computed
+    // BEFORE resetAttachments() clears the registry it is measured against.
+    const orphanedTokens = orphanAttachmentTokens(text, attachments);
     resetAttachments();
+    if (orphanedTokens.length) {
+      appendSystem(
+        tr(
+          "panel.attachment_content_no_longer_loaded",
+          "Sent without the content behind {tokens} — that attachment is no longer loaded, " +
+            "so the agent received the placeholder only. Re-paste or re-attach it to send the content.",
+          { tokens: orphanedTokens.join(", ") },
+        ),
+      );
+    }
     const pending = [...refImgs, ...refVideos, ...refFiles, ...refUploads];
     if (pending.length) await Promise.all(pending.map((a) => a.ready));
     // Paint the message's media. For a queued send this runs later, inside

--- a/web/js/lib/composer-paste.js
+++ b/web/js/lib/composer-paste.js
@@ -1,0 +1,129 @@
+/**
+ * Composer paste routing + orphaned attachment tokens (#1467).
+ *
+ * Two silent content-loss defects on the chat input path, both of which end with
+ * the agent receiving a message the user believes carried more than it did, and
+ * NOTHING on screen saying so.
+ *
+ * 1. A clipboard that carries BOTH a file item and text.
+ *    The composer's paste handler took the first `kind:"file"` item, called
+ *    preventDefault() and RETURNED — so `text/plain` from the same clipboard was
+ *    discarded before anything could look at it, and the browser's own default
+ *    insertion was suppressed too. That is not an exotic clipboard: copying rich
+ *    content on Windows (Word, Outlook, Excel, PowerPoint, and many web pages)
+ *    puts a synthesized bitmap on the clipboard ALONGSIDE the text, which Chrome
+ *    surfaces as an `image/png` file item. Pasting a prompt copied out of a
+ *    document therefore attached a picture and dropped every character of the
+ *    text, with no error and no placeholder.
+ *
+ *    {@link planComposerPaste} decides both halves at once, so the file branch
+ *    can no longer consume the event on the text's behalf. It never answers
+ *    "discard": every clipboard flavour the composer claims is either attached
+ *    or inserted.
+ *
+ * 2. An attachment token with no attachment behind it.
+ *    A pasted block collapses to a `[Pasted text #N]` token in the composer and
+ *    is expanded back to the full text at send. The attachment registry is
+ *    CLEARED after every send, but the raw composer text — tokens and all — is
+ *    kept for ↑ history recall, the ✎ edit control and the double-Esc rewind.
+ *    Re-sending a recalled message therefore ships the bare token: the agent
+ *    gets `[Pasted text #1]`, the pasted content is gone, and neither side is
+ *    told. {@link orphanAttachmentTokens} names exactly those tokens so the
+ *    composer can say so out loud instead.
+ *
+ * Pure and dependency-free so both decisions are testable without a DOM.
+ */
+
+/** Chars; a longer paste collapses to a chip instead of filling the composer. */
+export const PASTE_TEXT_THRESHOLD = 800;
+
+/** Newlines; a paste at least this tall collapses to a chip whatever its length. */
+export const PASTE_TEXT_LINE_THRESHOLD = 12;
+
+/**
+ * Is this paste big enough to collapse into a `[Pasted text #N]` chip rather
+ * than land in the composer verbatim? Long OR tall — a 30-line block of short
+ * lines is just as unreadable in a 120px textarea as one long paragraph.
+ */
+export function isLargePaste(text) {
+  if (typeof text !== "string" || !text) return false;
+  if (text.length > PASTE_TEXT_THRESHOLD) return true;
+  return (text.match(/\n/g) || []).length >= PASTE_TEXT_LINE_THRESHOLD;
+}
+
+/**
+ * What the composer should do with one paste.
+ *
+ * @param {{hasFile?: boolean, text?: string}} clipboard
+ *   `hasFile` — the clipboard carries at least one `kind:"file"` item the
+ *   composer can attach; `text` — its `text/plain` flavour (may be empty).
+ * @returns {{file: boolean, text: "attach"|"insert"|"none"|"default"}}
+ *   `file`   — route the file item through the attachment pipeline.
+ *   `text`   — `"attach"`  collapse it to a pasted-text chip;
+ *              `"insert"`  put it in the composer at the caret ourselves;
+ *              `"none"`    there is no text to place;
+ *              `"default"` leave the event alone and let the browser insert it.
+ *
+ * The `"default"` answer is the ONLY one that does not claim the event, and it
+ * is returned only when nothing else about the clipboard is being claimed
+ * either — so a caller that honours this shape can never call preventDefault()
+ * on a flavour it then fails to place. A file and text are both taken when both
+ * are present: which one the user "meant" is not knowable from the clipboard,
+ * and guessing is what lost the text in the first place.
+ */
+export function planComposerPaste({ hasFile = false, text = "" } = {}) {
+  const body = typeof text === "string" ? text : "";
+  const file = !!hasFile;
+  if (isLargePaste(body)) return { file, text: "attach" };
+  if (!file) return { file: false, text: "default" };
+  // The file branch suppresses the browser's own insertion, so any text that
+  // came with it has to be placed by hand or it is gone.
+  return { file: true, text: body ? "insert" : "none" };
+}
+
+/** The inline token each attachment kind inserts into the composer. */
+export const ATTACHMENT_TOKEN_LABELS = Object.freeze({
+  image: "Image",
+  text: "Pasted text",
+  video: "Video",
+  textfile: "File",
+  file: "File",
+  workflow: "Workflow",
+});
+
+/** Every attachment token the composer can insert, as it appears in the text. */
+export const ATTACHMENT_TOKEN_RE = /\[(Pasted text|Image|Video|File|Workflow) #(\d+)\]/g;
+
+/**
+ * The attachment tokens present in `text` that NO live attachment backs.
+ *
+ * Matching is by (label, id) against the registry, not by id alone: ids are
+ * per-message and restart at 1, so `[Image #1]` and `[Pasted text #1]` can both
+ * be live at once and a bare id would call one of them resolved on the other's
+ * evidence.
+ *
+ * @param {string} text  the raw composer text about to be sent
+ * @param {Array<{id?: any, kind?: string}>} attachments  the live registry
+ * @returns {string[]} the orphaned tokens, in the order they appear, deduped
+ */
+export function orphanAttachmentTokens(text, attachments) {
+  if (typeof text !== "string" || !text) return [];
+  const live = new Set();
+  for (const a of attachments ?? []) {
+    const label = ATTACHMENT_TOKEN_LABELS[a?.kind];
+    if (label && a?.id != null) live.add(`${label} #${a.id}`);
+  }
+  const out = [];
+  const seen = new Set();
+  // A fresh regex per call: ATTACHMENT_TOKEN_RE is global, and a shared lastIndex
+  // would make the second call on the same string start half way through it.
+  const re = new RegExp(ATTACHMENT_TOKEN_RE.source, "g");
+  let m;
+  while ((m = re.exec(text)) !== null) {
+    const key = `${m[1]} #${m[2]}`;
+    if (live.has(key) || seen.has(key)) continue;
+    seen.add(key);
+    out.push(m[0]);
+  }
+  return out;
+}


### PR DESCRIPTION
Fixes #1467.

## Root cause

The composer's paste listener inspected the clipboard for a **file item first**, and when it found one it called `preventDefault()` and **returned**. That did two things at once: it discarded any `text/plain` that arrived in the same clipboard, and — because of the `preventDefault()` — it also suppressed the browser's own insertion of that text.

This is not an exotic clipboard. Copying rich content on Windows (Word, Outlook, Excel, and many web pages) puts a **synthesized bitmap alongside the text**. So pasting a prompt out of a document attached a picture of it and dropped every character, with no error and no placeholder.

That accounts for both symptoms in the report from one mechanism: the pasted prompt never arrived, and the user saw an unexpected image attachment in the same session.

## The fix

Both halves of a clipboard are now decided together, in `web/js/lib/composer-paste.js`:

- `planComposerPaste({ hasFile, text })` returns what to do with the file and the text as one answer. The only plan that claims nothing is a small text-only paste, which the browser inserts exactly as before.
- When the composer claims the paste (`preventDefault()` + `stopPropagation()` — still required, so ComfyUI core's document-level handler does not drop a duplicate `LoadImage` node onto the graph, #384), the text half is now handled explicitly: `attach` for a large paste, `insert` via `insertAtCaret` for a small one.
- `orphanAttachmentTokens(text, attachments)` catches the other half of the silent loss: a message referencing an attachment token whose content is no longer loaded now appends an explicit system line instead of sending a message that merely *looks* complete. It is computed **before** `resetAttachments()` clears the registry it is measured against.

## Verification

- `browser_tests/unit/composer-paste.test.mjs` — **17/17**, covering the routing on the shipped listener and the orphan-token guard.
- **Mutation-tested.** Restoring the original bug (`if (plan.file) { handleFile(file); return; }`) turns **2** tests red; dropping the caret insertion — the exact silent-drop path — turns **1** red. Baseline restores to 17/17.
- Full suite **5787 pass / 0 fail**; `check-tool-vocabulary` OK; `check-panel-scope` OK; `i18n:check` locales OK; `i18n-render-check` OK.

## One defect found and fixed during review

The change added a `tr()` site whose key was **not** in the committed catalog, so `regenerating English is a ROUND TRIP` failed: extraction found `panel.attachment_content_no_longer_loaded`, `locales/en/main.json` did not have it. Regenerated with `npm run i18n:build` (one key added, 1108 total).

Worth noting how it surfaced: the targeted `composer-paste` file was green on its own, and clean `main` passes i18n 30/30. Only the **full** suite caught it — a new user-facing string is invisible to the test file that motivated it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
