### PR TITLE
fix(1477): a tab switch no longer leaves graph reads refused on a stale root identity

### DIFF
--- a/browser_tests/unit/stale-root-fence-after-tab-switch.test.mjs
+++ b/browser_tests/unit/stale-root-fence-after-tab-switch.test.mjs
@@ -1,0 +1,369 @@
+/**
+ * #1477 — Workflow tab switch leaves stale root workflow identity fence.
+ *
+ * After the frontend switched to a saved workflow, panel_graph_outline and
+ * panel_get_errors both failed `[root-workflow-uuid-mismatch]`. panel_open_workflow
+ * then ran but returned content mismatch / outcome unknown (the #1111/#1089
+ * wording). panel_list_workflows (fence-exempt) republished the active identity
+ * and the next outline succeeded.
+ *
+ * Two holes on the shipped path:
+ *
+ *   1. Tab-switch rebind (#817) proved content with byte-identity. A workflow
+ *      containing subgraphs regenerates definition link/node ids on the live
+ *      canvas (#886/#1706) while the tracker still holds the saved ids, so a
+ *      canvas that IS the new tab's still refused. The fence now uses the same
+ *      content proof workflow_open already trusts.
+ *
+ *   2. A CONTENT_UNVERIFIED open whose only differing surface is `definitions`
+ *      threw before publishing `workflow_uuid`, leaving the session fenced to
+ *      the prior workflow. Binding is proven; a previous-workflow graph disagrees
+ *      on nodes/links, not on this surface alone. The open now publishes the
+ *      fence and discloses.
+ *
+ * These drive the shipped functions (rootContentProvesActiveWorkflow, the
+ * extracted assertGraphBoundToActiveWorkflow, openContentDifferenceIsDefinitionsOnly)
+ * — not a reimplementation.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+import {
+  activeWorkflowProvenEmpty,
+  contentProofExclusiveAmongOpen,
+  graphBindingRefusalMessage,
+  graphCommandBindingBar,
+  graphRootMatchesState,
+  graphRootProvenEmpty,
+  graphRootReproducesStateContent,
+  graphRootWorkflowUuidMismatches,
+  openContentDifferenceIsDefinitionsOnly,
+  resolveGraphBindingVerdict,
+  resolveGraphRootUuidRebind,
+  rootContentProvesActiveWorkflow,
+  rootContentProvesActiveWorkflowDespiteEdits,
+  sealProvenRootBinding,
+} from "../../web/js/lib/graph-binding.js";
+import { rawWorkflowObject, sameWorkflowObject } from "../../web/js/lib/workflow-chat-identity.js";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const PANEL_JS = join(HERE, "../../web/js/comfyui-mcp-panel.js");
+const PANEL_SRC = readFileSync(PANEL_JS, "utf8").replace(/\r\n/g, "\n");
+
+const ACTIVE = "1477active-0000-4000-8000-00000000000a";
+const PREV = "1477prevtab-0000-4000-8000-00000000000b";
+
+const NODES = [
+  { id: 1, type: "KSampler", pos: [0, 0], size: [200, 100], widgets_values: [1] },
+  { id: 2, type: "VAEDecode", pos: [0, 0], size: [200, 100], widgets_values: [] },
+];
+
+function subgraph(lastLinkId, linkId) {
+  return {
+    id: "sub-1",
+    name: "Upscale",
+    state: { lastNodeId: 623, lastLinkId, lastGroupId: 0, lastRerouteId: 0 },
+    nodes: [
+      { id: 65, type: "LoadImage", outputs: [{ name: "IMAGE", type: "IMAGE", links: [linkId] }] },
+      { id: 623, type: "SaveImage", inputs: [{ name: "images", type: "IMAGE", link: linkId }] },
+    ],
+    links: [[linkId, 65, 0, 623, 0, "IMAGE"]],
+    inputs: [],
+    outputs: [],
+  };
+}
+
+function stateOf(defs, nodes = NODES) {
+  return {
+    nodes: nodes.map((n) => ({ ...n })),
+    links: [],
+    groups: [],
+    config: {},
+    extra: { frontendVersion: "1.49.6" },
+    definitions: { subgraphs: [subgraph(...defs)] },
+  };
+}
+
+const SAVED_DEFS = [2092, 7];
+const LIVE_DEFS = [2106, 21];
+
+function rootOf(tag, liveState) {
+  return {
+    _nodes: liveState.nodes,
+    extra: { frontendVersion: "1.49.6", comfyui_mcp: { workflow_uuid: tag } },
+    serialize() {
+      return {
+        ...liveState,
+        extra: { ...liveState.extra, comfyui_mcp: { workflow_uuid: tag } },
+      };
+    },
+  };
+}
+
+function tabOf(state, { modified = false } = {}) {
+  return {
+    path: "workflows/minimaxH3InfiniteVideoRef2va9Img3_v2Turbo.json",
+    filename: "minimaxH3InfiniteVideoRef2va9Img3_v2Turbo.json",
+    isPersisted: true,
+    isModified: modified,
+    changeTracker: { activeState: state },
+  };
+}
+
+function panelFunctionStart(src, name, from = 0) {
+  const bare = src.indexOf(`function ${name}(`, from);
+  assert.notEqual(bare, -1, `could not locate ${name} in panel source`);
+  const asyncAt = bare - "async ".length;
+  return asyncAt >= 0 && src.startsWith("async ", asyncAt) ? asyncAt : bare;
+}
+
+function panelFunctionSource(src, name, nextName) {
+  const start = panelFunctionStart(src, name);
+  const end = panelFunctionStart(src, nextName, start + 1);
+  assert.ok(end > start, `could not locate ${nextName} after ${name}`);
+  return src.slice(start, end);
+}
+
+/** The shipping fence, extracted — the function panel_graph_outline actually runs. */
+function buildFence({ openWorkflows, rootGraph }) {
+  const fenceSource = panelFunctionSource(PANEL_SRC, "assertGraphBoundToActiveWorkflow", "getPiniaStore");
+  const ownsTagSource = panelFunctionSource(PANEL_SRC, "workflowOwnsRootUuidTag", "assertGraphBoundToActiveWorkflow");
+  const activeWorkflow = openWorkflows[0];
+  const ownsTag = new Function(
+    "workflowStableUuid",
+    "rawWorkflowObject",
+    "sameWorkflowObject",
+    "workflowUuidOwner",
+    "WORKFLOW_META_NAMESPACE",
+    "WORKFLOW_UUID_FIELD",
+    `${ownsTagSource}\nreturn workflowOwnsRootUuidTag;`,
+  )(() => ACTIVE, rawWorkflowObject, sameWorkflowObject, () => null, "comfyui_mcp", "workflow_uuid");
+  return new Function(
+    "activeWorkflowRef",
+    "workflowObjectUuid",
+    "workflowStableUuid",
+    "graphRootWorkflowUuidMismatches",
+    "resolveGraphBindingVerdict",
+    "graphBindingRefusalMessage",
+    "activeWorkflowProvenEmpty",
+    "graphRootProvenEmpty",
+    "workflowOwnsRootUuidTag",
+    "rememberWorkflowUuidOwner",
+    "resolveGraphRootUuidRebind",
+    "postReconnectSettleWindow",
+    "sealProvenRootBinding",
+    "rootContentProvesActiveWorkflow",
+    "rootContentProvesActiveWorkflowDespiteEdits",
+    "contentProofExclusiveAmongOpen",
+    "graphRootMatchesState",
+    "sameWorkflowObject",
+    "app",
+    "WORKFLOW_META_NAMESPACE",
+    "WORKFLOW_UUID_FIELD",
+    `${fenceSource}\nreturn assertGraphBoundToActiveWorkflow;`,
+  )(
+    () => activeWorkflow,
+    (wf) => (wf === activeWorkflow ? ACTIVE : null),
+    () => ACTIVE,
+    graphRootWorkflowUuidMismatches,
+    resolveGraphBindingVerdict,
+    graphBindingRefusalMessage,
+    activeWorkflowProvenEmpty,
+    graphRootProvenEmpty,
+    ownsTag,
+    () => {},
+    resolveGraphRootUuidRebind,
+    () => false,
+    sealProvenRootBinding,
+    rootContentProvesActiveWorkflow,
+    rootContentProvesActiveWorkflowDespiteEdits,
+    contentProofExclusiveAmongOpen,
+    graphRootMatchesState,
+    sameWorkflowObject,
+    { graph: rootGraph, extensionManager: { workflow: { openWorkflows } } },
+    "comfyui_mcp",
+    "workflow_uuid",
+  );
+}
+
+// ── the reported tab-switch case ─────────────────────────────────────────────
+
+test("#1477 a stale tag plus definitions-only live rewrite IS the active workflow", () => {
+  const saved = stateOf(SAVED_DEFS);
+  const live = stateOf(LIVE_DEFS);
+  const root = rootOf(PREV, live);
+  const active = tabOf(saved);
+  assert.equal(
+    graphRootMatchesState({ rootGraph: root, state: saved }),
+    false,
+    "precondition: byte-identity still sees the definitions rewrite — that is why #817 missed this",
+  );
+  assert.equal(
+    graphRootReproducesStateContent({ rootGraph: root, state: saved }).proven,
+    true,
+    "the open's own content proof already accounts for the rewrite",
+  );
+  assert.equal(
+    rootContentProvesActiveWorkflow({ rootGraph: root, activeWorkflow: active, proofExclusive: true }),
+    true,
+    "the tab-switch rebind must ask that same question",
+  );
+  assert.equal(
+    resolveGraphRootUuidRebind({
+      rootGraph: root,
+      activeWorkflowUuid: ACTIVE,
+      contentProvesActiveWorkflow: true,
+    }),
+    "rebind",
+  );
+});
+
+test("#1477 the shipping fence restamps the tag and admits the read", () => {
+  const saved = stateOf(SAVED_DEFS);
+  const live = stateOf(LIVE_DEFS);
+  const root = rootOf(PREV, live);
+  const active = tabOf(saved);
+  const fence = buildFence({ openWorkflows: [active], rootGraph: root });
+  assert.doesNotThrow(
+    () => fence(root, root, graphCommandBindingBar("graph_outline")),
+    "panel_graph_outline must not refuse the canvas the user just switched to",
+  );
+  assert.equal(root.extra.comfyui_mcp.workflow_uuid, ACTIVE, "the previous tab's tag is gone");
+});
+
+test("#1477 panel_get_errors draws the same bar — both reported tools recover", () => {
+  assert.deepEqual(graphCommandBindingBar("graph_get_errors"), graphCommandBindingBar("graph_outline"));
+});
+
+test("#1477 a different ROOT node set is still a foreign canvas — fail closed", () => {
+  const saved = stateOf(SAVED_DEFS);
+  const foreign = stateOf(LIVE_DEFS, [{ id: 9, type: "SaveImage", pos: [0, 0], size: [10, 10], widgets_values: [] }]);
+  const root = rootOf(PREV, foreign);
+  const active = tabOf(saved);
+  assert.equal(
+    rootContentProvesActiveWorkflow({ rootGraph: root, activeWorkflow: active, proofExclusive: true }),
+    false,
+  );
+  const fence = buildFence({ openWorkflows: [active], rootGraph: root });
+  assert.throws(
+    () => fence(root, root, graphCommandBindingBar("graph_outline")),
+    /\[root-workflow-uuid-mismatch\]/,
+  );
+  assert.equal(root.extra.comfyui_mcp.workflow_uuid, PREV, "the tag is untouched");
+});
+
+test("#1477 a ROOT widget-value difference is still a foreign canvas", () => {
+  const saved = stateOf(SAVED_DEFS);
+  const live = stateOf(LIVE_DEFS, [
+    { ...NODES[0], widgets_values: [999] },
+    NODES[1],
+  ]);
+  const root = rootOf(PREV, live);
+  const active = tabOf(saved);
+  assert.equal(
+    rootContentProvesActiveWorkflow({ rootGraph: root, activeWorkflow: active, proofExclusive: true }),
+    false,
+    "a genuine content change must not ride in on the definitions rewrite",
+  );
+});
+
+test("#1477 cosmetic nodes plus accounted definitions still prove the canvas", () => {
+  // The presentation-only ground used to read RAW surfaces, so `nodes`+`definitions`
+  // (the subgraph-workflow shape) failed it even when definitions were accounted
+  // and the node difference was pos/order only.
+  const saved = stateOf(SAVED_DEFS);
+  const live = stateOf(LIVE_DEFS, [
+    { ...NODES[0], pos: [40, 10], order: 2 },
+    { ...NODES[1], pos: [240, 10], order: 1 },
+  ]);
+  const proof = graphRootReproducesStateContent({ rootGraph: rootOf(PREV, live), state: saved });
+  assert.equal(proof.presentationOnly, true);
+  assert.equal(
+    rootContentProvesActiveWorkflow({
+      rootGraph: rootOf(PREV, live),
+      activeWorkflow: tabOf(saved),
+      proofExclusive: true,
+    }),
+    true,
+  );
+});
+
+// ── open must not leave the session fenced to the prior workflow ─────────────
+
+test("#1477 definitions-only is recognised, and a node mismatch is not", () => {
+  assert.equal(
+    openContentDifferenceIsDefinitionsOnly({ comparable: true, surfaces: ["definitions"] }),
+    true,
+  );
+  assert.equal(
+    openContentDifferenceIsDefinitionsOnly({ comparable: true, surfaces: ["nodes", "definitions"] }),
+    false,
+    "a previous-workflow graph disagrees on nodes — that stays fail-closed",
+  );
+  assert.equal(
+    openContentDifferenceIsDefinitionsOnly({ comparable: true, surfaces: ["nodes"] }),
+    false,
+  );
+  assert.equal(openContentDifferenceIsDefinitionsOnly({ comparable: false, surfaces: ["definitions"] }), false);
+  assert.equal(openContentDifferenceIsDefinitionsOnly({ comparable: true, surfaces: [] }), false);
+});
+
+test("#1477 a CONTENT_UNVERIFIED open that is definitions-only publishes the fence", () => {
+  // The throw is what skipped `workflow_uuid`. Binding-proven + definitions-only
+  // must take the disclose-and-publish path instead.
+  const openBody = PANEL_SRC.slice(
+    PANEL_SRC.indexOf("async workflow_open({ path, rid }) {"),
+    PANEL_SRC.indexOf("\n  async workflow_live_sync("),
+  );
+  assert.match(
+    openBody,
+    /openContentDifferenceIsDefinitionsOnly\(\{/,
+    "the open must ask the definitions-only question before throwing",
+  );
+  assert.match(openBody, /openDefinitionsUnverified = true/, "and take the publish path");
+  const skipBlock = openBody.slice(openBody.indexOf("openContentDifferenceIsDefinitionsOnly({"));
+  assert.match(
+    skipBlock,
+    /openDefinitionsUnverified = true[\s\S]*?else \{\s*rebindFailed = new Error\(\s*describeOpenRebindOutcome/,
+    "the skip is decided BEFORE the throw, and every other verdict still throws",
+  );
+  assert.match(openBody, /definitions_unverified: true/, "the reply discloses rather than hiding it");
+  assert.match(openBody, /\.\.\.\(activeWorkflowUuid \? \{ workflow_uuid: activeWorkflowUuid \} : \{\}\)/);
+});
+
+test("#1477 a genuine wrong-graph open still throws — the skip is definitions-only", () => {
+  const openBody = PANEL_SRC.slice(
+    PANEL_SRC.indexOf("async workflow_open({ path, rid }) {"),
+    PANEL_SRC.indexOf("\n  async workflow_live_sync("),
+  );
+  // The throw remains for every other CONTENT_UNVERIFIED / UNPROVEN verdict.
+  assert.match(openBody, /rebindFailed = new Error\(\s*describeOpenRebindOutcome\(verdict,/);
+  assert.match(
+    openBody,
+    /verdict\.status === OPEN_REBIND_STATUS\.CONTENT_UNVERIFIED/,
+    "UNPROVEN (identity not proven) must not take this skip",
+  );
+});
+
+// ── tab switch restamps in the same tick as the session re-hello ─────────────
+
+test("#1477 a genuine tab switch heals the root tag next to the re-hello", () => {
+  const start = PANEL_SRC.indexOf("function onWorkflowMaybeChanged() {");
+  assert.notEqual(start, -1);
+  const body = PANEL_SRC.slice(start, PANEL_SRC.indexOf("\n  function renderHistory()", start));
+  assert.match(body, /client\?\.rehello\?\.\(\)/, "the session fence still republishes");
+  assert.match(
+    body,
+    /if \(!renaming\) tryHealStaleRootWorkflowIdentity\(\)/,
+    "and the root tag is restamped on the same switch, not a later graph command",
+  );
+  const heal = panelFunctionSource(PANEL_SRC, "tryHealStaleRootWorkflowIdentity", "stampGraphRootWorkflowUuid");
+  assert.match(
+    heal,
+    /assertGraphBoundToActiveWorkflow\(graph, rootGraph, graphCommandBindingBar\("graph_outline"\)\)/,
+    "the heal is the shipped fence, not a second spelling of the proof",
+  );
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -640,6 +640,7 @@ import {
   describeGraphStateDifference,
   resolveOpenRebindVerdict,
   describeOpenRebindOutcome,
+  openContentDifferenceIsDefinitionsOnly,
   OPEN_REBIND_STATUS,
   OPEN_PROOF_FIELD,
   sealProvenRootBinding,
@@ -7944,6 +7945,22 @@ function assertGraphBoundToActiveWorkflow(
     graphLoading,
   });
   if (verdict) throw new Error(graphBindingRefusalMessage(verdict));
+}
+
+/**
+ * #1477 — after a workflow tab switch, restamp a proven-stale root tag in the
+ * SAME tick as the session re-hello, so the live canvas identity and the active
+ * workflow fence cannot disagree. Uses the shipped fence (read bar): it already
+ * rebinds on content proof and fails closed on a foreign canvas. A throw here
+ * is swallowed — the next graph command runs the same fence.
+ */
+function tryHealStaleRootWorkflowIdentity() {
+  try {
+    const { graph, rootGraph } = getGraphCtx();
+    assertGraphBoundToActiveWorkflow(graph, rootGraph, graphCommandBindingBar("graph_outline"));
+  } catch {
+    /* best-effort — a canvas that cannot prove ownership stays tagged as it is */
+  }
 }
 
 /**
@@ -16948,6 +16965,10 @@ const GRAPH_TOOL_EXECUTORS = {
     // on an observation of the restore itself, so it names the fields rather than
     // vouching for them.
     let openContentNormalized = null;
+    // #1477 — a definitions-only mismatch on a proven binding. The open still
+    // publishes workflow_uuid (so the session is not left fenced to the prior
+    // workflow) and discloses rather than throwing.
+    let openDefinitionsUnverified = false;
     // #1260's disclosure, on the OPEN path: every node whose saved state could not be
     // applied even after the post-load retry. Non-empty is what makes the refusal
     // actionable — it is the difference between "widget values differ" and "this pack's
@@ -17423,37 +17444,54 @@ const GRAPH_TOOL_EXECUTORS = {
                 const contentDiff = contentMatches
                   ? { comparable: true, surfaces: [], accountedSurfaces: [], nodeDifference: null }
                   : describeGraphStateDifference({ rootGraph, state: repaintState });
-                rebindFailed = new Error(
-                  describeOpenRebindOutcome(verdict, {
-                    targetLabel: target.filename || target.path || "the requested workflow",
-                    activeLabel: activeNow ? activeNow.filename || activeNow.path || "another tab" : "no active tab",
-                    expectedMarker: openProofMarker,
-                    observedMarker: rootGraph?.extra?.[WORKFLOW_META_NAMESPACE]?.[OPEN_PROOF_FIELD] ?? null,
-                    expectedUuid: targetUuid,
-                    observedUuid: rootGraph?.extra?.[WORKFLOW_META_NAMESPACE]?.[WORKFLOW_UUID_FIELD] ?? null,
-                    contentComparable: contentDiff.comparable,
-                    contentSurfaces: contentDiff.surfaces,
-                    // #1588 — which of those the panel has already fully characterised
-                    // (today: a `definitions` difference that is pure RENUMBERING — link ids,
-                    // and comfyui-mcp#1706 subgraph node ids — which a load of a workflow
-                    // containing subgraphs routinely produces).
-                    // Without this the disclosure counts an explained surface as a
-                    // second unexplained one and drops to the maximal-alarm wording.
-                    contentAccountedSurfaces: contentDiff.accountedSurfaces,
-                    // panel#1283 family — whether the restore ABORTED. `false` is the one
-                    // case where a content difference has a known cause other than the
-                    // frontend rewriting its own fields, and it is the case the reader
-                    // most needs named. `null` (the load could not be watched) is passed
-                    // through as null and says nothing, which is the pre-existing state
-                    // of knowledge.
-                    contentLoadRanToCompletion: loadRanToCompletion,
-                    contentRestoreFailures: openRestoreFailures,
-                    // #825 — within the `nodes` surface, whether anything was LOST
-                    // or the frontend merely re-measured the boxes. Same three
-                    // words otherwise, opposite meanings for the reader.
-                    contentNodeDifference: contentDiff.nodeDifference,
-                  }),
-                );
+                // #1477 — binding proven, and the only differing surface is
+                // `definitions`. That is not a previous-workflow graph (#1111/#1089
+                // disagree on nodes/links). Throwing here skipped the workflow_uuid
+                // publish and left the session fenced to the prior workflow, so
+                // panel_graph_outline then failed until panel_list_workflows
+                // republished the identity. Publish the fence; disclose; still fail
+                // closed when any other surface disagrees.
+                if (
+                  verdict.status === OPEN_REBIND_STATUS.CONTENT_UNVERIFIED &&
+                  openContentDifferenceIsDefinitionsOnly({
+                    comparable: contentDiff.comparable,
+                    surfaces: contentDiff.surfaces,
+                  })
+                ) {
+                  openDefinitionsUnverified = true;
+                } else {
+                  rebindFailed = new Error(
+                    describeOpenRebindOutcome(verdict, {
+                      targetLabel: target.filename || target.path || "the requested workflow",
+                      activeLabel: activeNow ? activeNow.filename || activeNow.path || "another tab" : "no active tab",
+                      expectedMarker: openProofMarker,
+                      observedMarker: rootGraph?.extra?.[WORKFLOW_META_NAMESPACE]?.[OPEN_PROOF_FIELD] ?? null,
+                      expectedUuid: targetUuid,
+                      observedUuid: rootGraph?.extra?.[WORKFLOW_META_NAMESPACE]?.[WORKFLOW_UUID_FIELD] ?? null,
+                      contentComparable: contentDiff.comparable,
+                      contentSurfaces: contentDiff.surfaces,
+                      // #1588 — which of those the panel has already fully characterised
+                      // (today: a `definitions` difference that is pure RENUMBERING — link ids,
+                      // and comfyui-mcp#1706 subgraph node ids — which a load of a workflow
+                      // containing subgraphs routinely produces).
+                      // Without this the disclosure counts an explained surface as a
+                      // second unexplained one and drops to the maximal-alarm wording.
+                      contentAccountedSurfaces: contentDiff.accountedSurfaces,
+                      // panel#1283 family — whether the restore ABORTED. `false` is the one
+                      // case where a content difference has a known cause other than the
+                      // frontend rewriting its own fields, and it is the case the reader
+                      // most needs named. `null` (the load could not be watched) is passed
+                      // through as null and says nothing, which is the pre-existing state
+                      // of knowledge.
+                      contentLoadRanToCompletion: loadRanToCompletion,
+                      contentRestoreFailures: openRestoreFailures,
+                      // #825 — within the `nodes` surface, whether anything was LOST
+                      // or the frontend merely re-measured the boxes. Same three
+                      // words otherwise, opposite meanings for the reader.
+                      contentNodeDifference: contentDiff.nodeDifference,
+                    }),
+                  );
+                }
               }
             } finally {
               // Strip the marker so it does not ride the user's next save. In a FINALLY,
@@ -17879,6 +17917,18 @@ const GRAPH_TOOL_EXECUTORS = {
               `widgets are built asynchronously by their own pack. Nothing is missing because of ` +
               `it. That failure came from the node's own frontend code, not from the open; if it ` +
               `recurs, update or report the pack.`,
+          }
+        : {}),
+      ...(openDefinitionsUnverified
+        ? {
+            definitions_unverified: true,
+            definitions_unverified_note:
+              `workflow_open RAN and the canvas IS bound to this workflow — instance, marker and ` +
+              `identity all matched — but its subgraph definitions differ from the state that was ` +
+              `loaded. That is not a previous-workflow graph: a wrong canvas disagrees on nodes or ` +
+              `links, not on this surface alone. The session fence is published so a later graph ` +
+              `read is not refused as the prior workflow. Compare the graph with panel_graph_outline ` +
+              `if a subgraph value matters; a genuine wrong-graph still fails closed (#1477).`,
           }
         : {}),
       ...(openContentNormalized?.length
@@ -31436,6 +31486,11 @@ function buildPanel() {
         } catch {
           /* reconnect path retries the hello */
         }
+        // #1477 — the re-hello publishes the new session fence; this restamps the
+        // root tag when content proves the canvas is the new tab's. Together they
+        // are the atomic identity update a tab switch was leaving split. A rename
+        // is the same instance, so the tag already matches and this is a no-op.
+        if (!renaming) tryHealStaleRootWorkflowIdentity();
         const name = wf?.filename || wfkey || wfid;
         client?.armContext?.(
           renaming

--- a/web/js/lib/graph-binding.js
+++ b/web/js/lib/graph-binding.js
@@ -1009,6 +1009,23 @@ export function openContentDifferenceIsPresentationOnly({ comparable, surfaces, 
 }
 
 /**
+ * #1477 — the live root differs from what was loaded ONLY on `definitions`.
+ *
+ * Binding (instance, marker, identity) is a separate question, already proven by
+ * the time this is asked. A previous-workflow graph (#1111/#1089) disagrees on
+ * `nodes` / `links` / `groups`, not on this surface alone. So a definitions-only
+ * mismatch is a frontend id rewrite (or an unaccounted cousin of one), not a
+ * wrong canvas, and it must not leave the session fenced to the prior workflow.
+ *
+ * It does NOT claim the subgraph internals are the file's. Callers disclose.
+ */
+export function openContentDifferenceIsDefinitionsOnly({ comparable, surfaces } = {}) {
+  if (comparable !== true) return false;
+  const unique = Array.isArray(surfaces) ? [...new Set(surfaces)] : [];
+  return unique.length === 1 && unique[0] === "definitions";
+}
+
+/**
  * Did this open apply COMPLETELY, leaving only per-node fields the frontend rewrote?
  * (panel#1283 / #1285 / #1307 / #1330, comfyui-mcp#1705)
  *
@@ -1111,6 +1128,22 @@ export function graphRootReproducesStateContent({ rootGraph, state, loadRanToCom
     // Never inferred from an absent comparison: `comparable:false` means no
     // comparison happened, which is not evidence either way.
     if (diff?.comparable !== true) return NOT_PROVEN;
+    // panel#1283 family — the surfaces still UNEXPLAINED, which is what #1588's second
+    // round established the reassurance's own predicate must read. `definitions` differs
+    // on every open of a workflow containing subgraphs (#886: link ids are regenerated),
+    // and `describeGraphStateDifference` has already run the SAME fail-closed predicate
+    // the strict proof below trusts to decide whether THIS difference is only that. A
+    // surface that predicate accounted for is not a second unexplained difference, and
+    // comfyui-mcp#1705 is precisely the shape that fails on it: `nodes, definitions`.
+    //
+    // #1477 — computed BEFORE presentationOnly so that ground can read the same list.
+    // Passing the RAW surfaces made a cosmetic-only node rewrite plus an accounted
+    // `definitions` difference fail presentation-only (unique length 2), so a faithful
+    // tab-switch onto a subgraph workflow still refused as root-workflow-uuid-mismatch.
+    const accounted = Array.isArray(diff.accountedSurfaces) ? diff.accountedSurfaces : [];
+    const unexplainedSurfaces = (Array.isArray(diff.surfaces) ? diff.surfaces : []).filter(
+      (s) => !accounted.includes(s),
+    );
     // #1623 — the WEAKER question ("could anything authored have been lost"), asked
     // off THE SAME SNAPSHOT the strict proof below reads. Answering it from a second
     // serialization would reopen exactly the hole the frozen snapshot closes: a
@@ -1142,20 +1175,9 @@ export function graphRootReproducesStateContent({ rootGraph, state, loadRanToCom
       loadRanToCompletion !== false &&
       openContentDifferenceIsPresentationOnly({
         comparable: true,
-        surfaces: diff.surfaces,
+        surfaces: unexplainedSurfaces,
         nodeDifference: diff.nodeDifference,
       });
-    // panel#1283 family — the surfaces still UNEXPLAINED, which is what #1588's second
-    // round established the reassurance's own predicate must read. `definitions` differs
-    // on every open of a workflow containing subgraphs (#886: link ids are regenerated),
-    // and `describeGraphStateDifference` has already run the SAME fail-closed predicate
-    // the strict proof below trusts to decide whether THIS difference is only that. A
-    // surface that predicate accounted for is not a second unexplained difference, and
-    // comfyui-mcp#1705 is precisely the shape that fails on it: `nodes, definitions`.
-    const accounted = Array.isArray(diff.accountedSurfaces) ? diff.accountedSurfaces : [];
-    const unexplainedSurfaces = (Array.isArray(diff.surfaces) ? diff.surfaces : []).filter(
-      (s) => !accounted.includes(s),
-    );
     // The load RAN TO COMPLETION, so the mid-`configure()` partial load the strict
     // refusal rests on did not happen here. Weaker than `presentationOnly` about the
     // fields (it names them rather than vouching for them) and stronger about the LOAD
@@ -1310,6 +1332,11 @@ export function graphRootMismatchesActiveWorkflow({ rootGraph, activeWorkflow } 
   // belongs to a different tab.
   if (activeWorkflow?.isModified === true) return false;
   const activeState = activeWorkflowCurrentState(activeWorkflow);
+  // #1477 — a definitions-only (or presentation-only) rewrite is THIS workflow's
+  // canvas, not a different graph. Byte-shape treats regenerated subgraph ids as
+  // a mismatch, so after the tab-switch rebind restamped the tag the shape guard
+  // still refused panel_graph_outline. Same proof the rebind already asked.
+  if (graphRootAgreesWithActiveState(rootGraph, activeState)) return false;
   const expected = activeState?.nodes;
   const live = rootGraph?._nodes;
   if (!Array.isArray(expected) || !Array.isArray(live)) return false;
@@ -2482,6 +2509,28 @@ export function graphCommandMayMutateWorkflow(command) {
  *     keeps the pre-seal fail-closed behaviour.
  * Returns true only when it actually wrote the stamp.
  */
+
+/**
+ * #1477 — does this root agree with the workflow's current state enough to
+ * prove it is THAT workflow's canvas?
+ *
+ * Byte-identity is too strict after a tab switch: subgraph definition ids are
+ * regenerated on the live canvas while the tracker still holds the saved ids.
+ * This is the same bar `workflow_open` uses to decide the canvas is this
+ * workflow (`proven` or `presentationOnly`), plus definitions-only — a previous
+ * workflow's graph disagrees on root nodes or links, not on this surface alone.
+ */
+function graphRootAgreesWithActiveState(rootGraph, state) {
+  if (state == null) return false;
+  const proof = graphRootReproducesStateContent({ rootGraph, state });
+  if (proof.proven === true || proof.presentationOnly === true) return true;
+  const diff = describeGraphStateDifference({ rootGraph, state });
+  return openContentDifferenceIsDefinitionsOnly({
+    comparable: diff.comparable,
+    surfaces: diff.surfaces,
+  });
+}
+
 /**
  * POSITIVE proof that the live root graph IS the active workflow's own canvas,
  * from its CONTENT alone — independent of whatever identity tag it happens to
@@ -2493,8 +2542,15 @@ export function graphCommandMayMutateWorkflow(command) {
  *   - ROOT scope: a descended subgraph is not the workflow's root canvas;
  *   - CLEAN tab: a dirty tracker's state can lag the real canvas (#545), so it
  *     cannot prove anything about it;
- *   - the root must serialize EQUAL to the workflow's own CURRENT state — not
- *     its load baseline, which legitimately differs from an edited canvas;
+ *   - the root must reproduce the workflow's own CURRENT state — not its load
+ *     baseline, which legitimately differs from an edited canvas. Byte-identity
+ *     (`graphRootMatchesState`) is too strict here: a tab switch onto a workflow
+ *     containing subgraphs regenerates definition link/node ids on the live
+ *     canvas (#886/#1706) while the tracker still holds the saved ids, so the
+ *     canvas IS this workflow's and a stale previous-tab tag still refused every
+ *     graph tool (#1477). `graphRootReproducesStateContent` is the same proof
+ *     `workflow_open` already trusts, and it still fails closed on a foreign
+ *     node set, a rewired link, or a widget-value change;
  *   - EXCLUSIVE: two clean, separately open DUPLICATE tabs can carry
  *     byte-identical state, and equality alone cannot tell the active tab's
  *     canvas from its twin's. The caller establishes this by enumerating the
@@ -2511,7 +2567,7 @@ export function rootContentProvesActiveWorkflow({
     if (proofExclusive !== true) return false;
     if (!rootGraph || !activeWorkflow) return false;
     if (activeWorkflow.isModified === true) return false;
-    return graphRootMatchesState({ rootGraph, state: activeWorkflowCurrentState(activeWorkflow) });
+    return graphRootAgreesWithActiveState(rootGraph, activeWorkflowCurrentState(activeWorkflow));
   } catch {
     return false;
   }
@@ -2542,7 +2598,9 @@ export function contentProofExclusiveAmongOpen({ rootGraph, others } = {}) {
       if (other.isModified === true) return false;
       const state = activeWorkflowCurrentState(other);
       if (state == null) return false; // no readable state — same reason
-      if (graphRootMatchesState({ rootGraph, state })) return false; // a proven twin
+      // Same comparison the proof uses (#1477): a twin that only disagrees by
+      // definition renumbering is still a twin.
+      if (graphRootAgreesWithActiveState(rootGraph, state)) return false;
     }
     return true;
   } catch {
@@ -2599,7 +2657,7 @@ export function rootContentProvesActiveWorkflowDespiteEdits({
     const state = activeWorkflowCurrentState(activeWorkflow);
     if (state == null) return false;
     if (serializedStateProvenEmpty(state)) return false;
-    return graphRootMatchesState({ rootGraph, state });
+    return graphRootAgreesWithActiveState(rootGraph, state);
   } catch {
     return false;
   }


### PR DESCRIPTION
Fixes #1477

After a frontend tab switch onto a saved workflow, `panel_graph_outline` and `panel_get_errors` were refused as `root-workflow-uuid-mismatch`. `panel_open_workflow` then reported a content mismatch / outcome unknown (the #1111/#1089 wording), and only `panel_list_workflows` (fence-exempt) republished the identity so the next outline succeeded.

**Cause.** ComfyUI reuses `app.graph` across tabs. The tab-switch rebind (#817) proved content with byte-identity, so a subgraph workflow whose live canvas had regenerated definition link/node ids (#886/#1706) still looked like a foreign graph and kept the previous tab's root tag. If the agent then followed the open remedy and the only remaining difference was `definitions`, the open threw before publishing `workflow_uuid` and left the session fenced to the prior workflow.

**Fix.**
- The tab-switch content proof is the same one `workflow_open` already trusts (reproduced content, presentation-only, or definitions-only). A foreign node set or a root widget-value change still fails closed.
- A genuine tab switch restamps that proven tag in the same tick as the session re-hello.
- A binding-proven open whose only differing surface is `definitions` publishes the fence and discloses, instead of throwing.

Verified by driving the shipped `assertGraphBoundToActiveWorkflow` (the function `panel_graph_outline` actually runs) plus the open-path skip, in `browser_tests/unit/stale-root-fence-after-tab-switch.test.mjs`.
