### PR TITLE
fix(1848): a schema read that timed out is UNKNOWN, not proof that nothing outputs the type

### DIFF
--- a/browser_tests/unit/add-node-socket-proof-scope.test.mjs
+++ b/browser_tests/unit/add-node-socket-proof-scope.test.mjs
@@ -570,7 +570,8 @@ for (const [label, bad] of [
       "a broken whole-schema read is not evidence that nothing produces the type",
     );
     assert.match(err.message, /whether any installed node outputs it is UNKNOWN/);
-    assert.match(err.message, /RETRY this add/, "the remedy follows the real cause");
+    assert.match(err.message, /ALSO worth a RETRY/, "the unresolved producer question is surfaced");
+    assert.match(err.message, /Reload the ComfyUI browser tab/, "and the proven cause keeps its remedy");
     assert.doesNotMatch(
       err.message,
       /SEEDVR2_DIT/,

--- a/browser_tests/unit/add-node-socket-proof-scope.test.mjs
+++ b/browser_tests/unit/add-node-socket-proof-scope.test.mjs
@@ -560,7 +560,17 @@ for (const [label, bad] of [
       (e) => e,
     );
     assert.ok(err, "still fails closed — an unproven sibling type is not waived");
-    assert.match(err.message, /no installed node outputs "SEEDVR2_VAE"/);
+    // #1848 — the widen is what would have answered "does anything output SEEDVR2_VAE?",
+    // and in this fixture it could not. Refusing is right; asserting ABSENCE is not, and
+    // that over-claim is the same one #821 was filed about, left behind on the failure
+    // path after #821 fixed the success path.
+    assert.doesNotMatch(
+      err.message,
+      /no installed node outputs "SEEDVR2_VAE"/,
+      "a broken whole-schema read is not evidence that nothing produces the type",
+    );
+    assert.match(err.message, /whether any installed node outputs it is UNKNOWN/);
+    assert.match(err.message, /RETRY this add/, "the remedy follows the real cause");
     assert.doesNotMatch(
       err.message,
       /SEEDVR2_DIT/,
@@ -612,10 +622,18 @@ test("#821: a failed widen leaves the guard exactly as it fails closed today", a
     },
   });
 
-  await assert.rejects(
-    () => graph_add_node({ class_type: "SeedVR2VideoUpscaler" }),
-    /no installed node outputs "SEEDVR2_DIT"/,
+  // #1848 — the guard's behaviour is unchanged (still refused, nothing added); what the
+  // refusal SAYS is not. getNodeDefs throws here, so the whole-schema proof never
+  // happened, and this is the exact sentence #821 was reported for: SeedVR2VideoUpscaler
+  // told "no installed node outputs SEEDVR2_DIT" while SeedVR2LoadDiTModel — which
+  // outputs precisely that — sat on the canvas.
+  const err = await graph_add_node({ class_type: "SeedVR2VideoUpscaler" }).then(
+    () => null,
+    (e) => e,
   );
+  assert.ok(err, "still fails closed on a fetch that did not happen");
+  assert.doesNotMatch(err.message, /no installed node outputs "SEEDVR2_DIT"/);
+  assert.match(err.message, /UNKNOWN/);
   assert.equal(comfy.graph._nodes.length, 0);
 });
 

--- a/browser_tests/unit/node-widget-materialization.test.mjs
+++ b/browser_tests/unit/node-widget-materialization.test.mjs
@@ -1020,8 +1020,11 @@ test("#695: graph_add_node consumes the report and message, and names the class"
     src,
     // #1180 — monotonicNow, not Date.now. `startedAt` is read from the monotonic clock, so
     // subtracting a wall-clock reading from it reports an elapsed wait of roughly 1.7e12 ms.
-    /unavailableRequiredWidgetMessage\(unavailable, classType, monotonicNow\(\) - startedAt\)/,
-    "the refusal is built from the report, with the elapsed wait — measured on ONE clock",
+    // #1848 — the fourth argument is the fix: without it the refusal cannot tell
+    // "checked, nothing produces it" from "could not check". Deleting it here is
+    // invisible to every message-level test above, so it is pinned at the source.
+    /unavailableRequiredWidgetMessage\(unavailable, classType, monotonicNow\(\) - startedAt, schemaProofComplete\)/,
+    "the refusal is built from the report, with the elapsed wait — measured on ONE clock — and whether the schema proof completed",
   );
   assert.match(
     src,
@@ -1314,4 +1317,72 @@ test("#636: EVERY input carrying the type must be accounted for, not just one", 
   );
   const both = { type: "X", inputs: [{ name: "video" }, { name: "video_b" }], widgets: [] };
   assert.deepEqual(unavailableEntriesLiveNodeCannotExplain(refused, both), []);
+});
+
+// ---------------------------------------------------------------------------
+// #1848 — "no installed node outputs T" is a claim about the WHOLE install, and it
+// is only true if the whole schema was actually read.
+// ---------------------------------------------------------------------------
+
+test("#1848: a widen that could not answer is reported as UNKNOWN, not as absence", () => {
+  const report = [{ type: "SAM3_MODEL_CONFIG", inputs: ["sam3_model_config"], linkProven: false }];
+
+  // The reporter's case: LoadSAM3Model was added seconds earlier and outputs exactly this
+  // type, /object_info proves it — but the bounded whole-schema read did not finish, so
+  // nothing here had grounds to say anything about producers.
+  const unknown = unavailableRequiredWidgetMessage(report, "SAM3Grounding", 5000, false);
+  assert.doesNotMatch(
+    unknown,
+    /no installed node outputs/,
+    "never asserts absence from a state of not-knowing",
+  );
+  assert.match(unknown, /UNKNOWN/);
+  assert.match(unknown, /did not complete in time/);
+  assert.match(unknown, /not evidence that nothing produces it/);
+
+  // And the remedy has to change with the cause: reloading the tab re-registers widgets,
+  // which does nothing for an /object_info read that ran out of time.
+  assert.match(unknown, /RETRY this add/);
+  assert.match(unknown, /Reloading the tab does NOT help/);
+  assert.doesNotMatch(unknown, /Reload the ComfyUI browser tab so node packs/);
+});
+
+test("#1848: a COMPLETE proof still asserts absence, and keeps its own remedy", () => {
+  // The fix must not soften the case that is genuinely proven — a type nothing outputs
+  // still fails closed with the message #695 built.
+  const report = [{ type: "ZIPN_STYLE_GALLERY", inputs: ["gallery"], linkProven: false }];
+  const complete = unavailableRequiredWidgetMessage(report, "ZipnStyler", 5000, true);
+  assert.match(complete, /no installed node outputs "ZIPN_STYLE_GALLERY"/);
+  assert.match(complete, /Reload the ComfyUI browser tab/);
+  assert.doesNotMatch(complete, /UNKNOWN/);
+  assert.doesNotMatch(complete, /RETRY this add/);
+
+  // Default-true: every existing caller that passes three arguments keeps the old text.
+  assert.equal(unavailableRequiredWidgetMessage(report, "ZipnStyler", 5000), complete);
+});
+
+test("#1848: link-proven inputs are unaffected by the schema-proof state", () => {
+  // linkProven is decided by the backend's own declaration, not by the widen, so an
+  // incomplete proof must not change that branch's text.
+  const report = [{ type: "ACME_VALUE", inputs: ["amount"], linkProven: true }];
+  const a = unavailableRequiredWidgetMessage(report, "AcmeNode", 5000, true);
+  const b = unavailableRequiredWidgetMessage(report, "AcmeNode", 5000, false);
+  for (const m of [a, b]) {
+    assert.match(m, /declares "ACME_VALUE" as a link datatype/);
+    assert.doesNotMatch(m, /no installed node outputs/);
+  }
+});
+
+test("#1848 WIRING: the widen's failure sets the flag the message reads", () => {
+  // The flag is only correct if it is set on the SAME branch that discards the widen.
+  // A helper-level test cannot see that; assert on the source.
+  const src = readFileSync(PANEL_JS, "utf8");
+  assert.match(src, /let schemaProofComplete = true;/, "declared before the widen");
+  // The else-branch of the widen acceptance test is the only place it may be cleared:
+  // widenSocketProof answers null for every doubtful payload INCLUDING a timeout.
+  assert.match(
+    src,
+    /if \(widened && typeof widened\.has === "function"\) \{[\s\S]{0,200}?\} else \{[\s\S]{0,400}?schemaProofComplete = false;/,
+    "cleared exactly where the widen is rejected, not somewhere else",
+  );
 });

--- a/browser_tests/unit/node-widget-materialization.test.mjs
+++ b/browser_tests/unit/node-widget-materialization.test.mjs
@@ -1346,9 +1346,18 @@ test("#1848: a widen that could not answer is reported as UNKNOWN, not as absenc
 
   // And the remedy has to change with the cause: reloading the tab re-registers widgets,
   // which does nothing for an /object_info read that ran out of time.
-  assert.match(unknown, /RETRY this add/);
-  assert.match(unknown, /Reloading the tab does NOT help/);
-  assert.doesNotMatch(unknown, /Reload the ComfyUI browser tab so node packs/);
+  // ADDITIVE. Every entry here reached the report because no widget constructor
+  // appeared after the full poll, so the missing widget is PROVEN and its remedy must
+  // survive. The unfinished schema read adds a second possible cause, it does not
+  // retract the first — and since the widen's bound is fixed, telling a user to retry
+  // INSTEAD of reloading would loop forever on a large enough /object_info.
+  assert.match(unknown, /Reload the ComfyUI browser tab/, "the proven cause keeps its remedy");
+  assert.match(unknown, /ALSO worth a RETRY/, "and the unresolved one is added, not substituted");
+  assert.doesNotMatch(
+    unknown,
+    /not a frontend widget|does NOT help/,
+    "never denies the one cause that is actually proven",
+  );
 });
 
 test("#1848: a COMPLETE proof still asserts absence, and keeps its own remedy", () => {
@@ -1359,7 +1368,7 @@ test("#1848: a COMPLETE proof still asserts absence, and keeps its own remedy", 
   assert.match(complete, /no installed node outputs "ZIPN_STYLE_GALLERY"/);
   assert.match(complete, /Reload the ComfyUI browser tab/);
   assert.doesNotMatch(complete, /UNKNOWN/);
-  assert.doesNotMatch(complete, /RETRY this add/);
+  assert.doesNotMatch(complete, /ALSO worth a RETRY/);
 
   // Default-true: every existing caller that passes three arguments keeps the old text.
   assert.equal(unavailableRequiredWidgetMessage(report, "ZipnStyler", 5000), complete);
@@ -1380,7 +1389,7 @@ test("#1848: link-proven inputs are unaffected by the schema-proof state", () =>
     // works for it. linkProven comes from SAFE_SOCKET_TYPES / core 3D types / this
     // class's own outputs, none of which a widen can change.
     assert.match(m, /Reload the ComfyUI browser tab/, "keeps the remedy that fits its cause");
-    assert.doesNotMatch(m, /RETRY this add/);
+    assert.doesNotMatch(m, /ALSO worth a RETRY/);
   }
 });
 
@@ -1396,7 +1405,7 @@ test("#1848: a MIXED report gives both remedies, because it has both causes", ()
     5000,
     false,
   );
-  assert.match(message, /RETRY this add/, "for the input whose producer question went unanswered");
+  assert.match(message, /ALSO worth a RETRY/, "for the input whose producer question went unanswered");
   assert.match(message, /Reload the ComfyUI browser tab/, "for the input waiting on a widget");
 });
 

--- a/browser_tests/unit/node-widget-materialization.test.mjs
+++ b/browser_tests/unit/node-widget-materialization.test.mjs
@@ -1337,7 +1337,11 @@ test("#1848: a widen that could not answer is reported as UNKNOWN, not as absenc
     "never asserts absence from a state of not-knowing",
   );
   assert.match(unknown, /UNKNOWN/);
-  assert.match(unknown, /did not complete in time/);
+  // Deliberately not "in time": schemaProofComplete=false also covers a rejected
+  // getNodeDefs and an empty payload, so claiming a TIMEOUT would over-specify a
+  // cause the flag cannot distinguish.
+  assert.match(unknown, /did not complete/);
+  assert.doesNotMatch(unknown, /did not complete in time/);
   assert.match(unknown, /not evidence that nothing produces it/);
 
   // And the remedy has to change with the cause: reloading the tab re-registers widgets,
@@ -1370,7 +1374,30 @@ test("#1848: link-proven inputs are unaffected by the schema-proof state", () =>
   for (const m of [a, b]) {
     assert.match(m, /declares "ACME_VALUE" as a link datatype/);
     assert.doesNotMatch(m, /no installed node outputs/);
+    // The REMEDY, not just the cause. Checking only the cause line is how the first
+    // version of this fix shipped a report-wide remedy over a per-entry cause: a
+    // link-proven entry got "reloading does NOT help", deleting the only advice that
+    // works for it. linkProven comes from SAFE_SOCKET_TYPES / core 3D types / this
+    // class's own outputs, none of which a widen can change.
+    assert.match(m, /Reload the ComfyUI browser tab/, "keeps the remedy that fits its cause");
+    assert.doesNotMatch(m, /RETRY this add/);
   }
+});
+
+test("#1848: a MIXED report gives both remedies, because it has both causes", () => {
+  // One input waiting on a widget, another on an answer. Emitting only one remedy
+  // strands whichever input it does not address.
+  const message = unavailableRequiredWidgetMessage(
+    [
+      { type: "IMAGE,MASK", inputs: ["canvas"], linkProven: true },
+      { type: "SAM3_MODEL_CONFIG", inputs: ["cfg"], linkProven: false },
+    ],
+    "MixedNode",
+    5000,
+    false,
+  );
+  assert.match(message, /RETRY this add/, "for the input whose producer question went unanswered");
+  assert.match(message, /Reload the ComfyUI browser tab/, "for the input waiting on a widget");
 });
 
 test("#1848 WIRING: the widen's failure sets the flag the message reads", () => {

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -10710,7 +10710,10 @@ async function awaitRequiredCustomWidgetRegistration(
   // spend the full 5 s on every such add and still reach the same answer. A widen that
   // throws or yields nothing leaves the original proof in place and the guard fails closed
   // exactly as it does today — #580's protection does not depend on this succeeding.
-  if (unavailable.length && typeof widenSocketProof === "function") {
+  // #1848 — a widen that was ATTEMPTED and could not answer leaves the guard failing
+  // closed (correct), but it also means nothing here knows whether a producer exists.
+  // Remember that, so the refusal reports "unknown" instead of "nothing outputs it".
+  let schemaProofComplete = true;  if (unavailable.length && typeof widenSocketProof === "function") {
     let widened = null;
     try {
       // #1192 — the widen's bound is derived from THIS wait's effective deadline, which
@@ -10722,6 +10725,10 @@ async function awaitRequiredCustomWidgetRegistration(
     if (widened && typeof widened.has === "function") {
       socketTypes = widened;
       unavailable = check();
+    } else {
+      // null is this helper's answer for every doubtful payload INCLUDING a call that
+      // never returned in budget — which is exactly "I did not find out".
+      schemaProofComplete = false;
     }
   }
   while (monotonicNow() < deadline) {
@@ -10767,7 +10774,7 @@ async function awaitRequiredCustomWidgetRegistration(
   // of defect as #663 and #852: a refusal naming a remedy that cannot work.
   const cutShort = wait < CUSTOM_WIDGET_REGISTRATION_TIMEOUT_MS;
   throw new Error(
-    unavailableRequiredWidgetMessage(unavailable, classType, monotonicNow() - startedAt) +
+    unavailableRequiredWidgetMessage(unavailable, classType, monotonicNow() - startedAt, schemaProofComplete) +
       (cutShort
         ? `\nNOTE: this wait was cut short — it got ${(wait / 1000).toFixed(1)}s of its normal ` +
           `${(CUSTOM_WIDGET_REGISTRATION_TIMEOUT_MS / 1000).toFixed(1)}s because THIS COMMAND had ` +

--- a/web/js/lib/node-widget-materialization.js
+++ b/web/js/lib/node-widget-materialization.js
@@ -298,30 +298,55 @@ export function unavailableRequiredWidgetReport(
 
 /**
  * The refusal text for a report that never cleared. Says which INPUT is unsatisfiable
- * (not just its datatype), which of the two situations it is, and what actually fixes
+ * (not just its datatype), which of the situations it is, and what actually fixes
  * each — the previous single-cause message named a remedy ("retry shortly") that cannot
  * work for a datatype no widget will ever back, and named none for the case that does.
+ *
+ * #1848 — there are THREE situations, not two. "No installed node outputs T" is a claim
+ * about the whole install, and it is only true if the whole schema was actually read. The
+ * socket proof may come from a single-class /object_info (#780's optimisation), in which
+ * case it is widened against the full schema on the refusal path (#821) — and that widen
+ * is BOUNDED (#1180/#1192), so on a heavy install it can return nothing. When it does,
+ * the guard rightly keeps failing closed, but the MESSAGE must not upgrade "I could not
+ * find out" into "nothing produces it". That is the same false-cause defect #695 and #700
+ * were about, and it sends the reader to a remedy (reload the tab) that cannot help: the
+ * missing thing is not a frontend widget, it is the answer to a question never asked.
+ *
+ * `schemaProofComplete` is false only when a widen was attempted and could not answer.
  */
-export function unavailableRequiredWidgetMessage(report, classType, waitedMs) {
+export function unavailableRequiredWidgetMessage(report, classType, waitedMs, schemaProofComplete = true) {
   const target = classType ? `"${classType}"` : "this node";
   const lines = report.map((entry) => {
     const inputs = entry.inputs.map((name) => `"${name}"`).join(", ");
     const cause = entry.linkProven
       ? `the backend declares "${entry.type}" as a link datatype, but this input also declares a ` +
         `widget value (default/min/max/options), so it needs a registered widget and none appeared`
-      : `no installed node outputs "${entry.type}" and no frontend widget is registered for it`;
+      : schemaProofComplete
+        ? `no installed node outputs "${entry.type}" and no frontend widget is registered for it`
+        : `no frontend widget is registered for "${entry.type}", and whether any installed node ` +
+          `outputs it is UNKNOWN — the full /object_info read that would answer it did not ` +
+          `complete in time, so this is not evidence that nothing produces it`;
     return `  - input ${inputs} (declared type "${entry.type}"): ${cause}.`;
   });
   const waited = Number.isFinite(waitedMs) ? `${(waitedMs / 1000).toFixed(1)}s` : "the wait window";
+  const remedy = schemaProofComplete
+    ? "Reload the ComfyUI browser tab so node packs can re-register their frontend widgets, then " +
+      "retry. If it fails again the pack's frontend extension is not loading and retrying alone " +
+      "will not fix it. This is NOT a link datatype being misread: an input the backend proves is " +
+      "a socket (MASK, IMAGE, LATENT, a comma-joined union of them) is added immediately, without " +
+      "any wait."
+    : // The schema read is the thing that ran out of time, so a retry is the remedy that can
+      // actually change the answer — unlike reloading the tab, which re-registers widgets and
+      // does nothing about an /object_info read that did not finish.
+      "RETRY this add: the full /object_info read is what ran out of time, and a retry can " +
+      "complete it. Reloading the tab does NOT help here — the missing thing is the schema " +
+      "answer, not a frontend widget. If it keeps timing out, this install's /object_info is " +
+      "large enough that the read needs a longer budget.";
   return (
     `Cannot add ${target}: ${report.length} required input type${report.length === 1 ? "" : "s"} ` +
     `had no widget after ${waited} waiting for node extensions to register.\n` +
     `${lines.join("\n")}\n` +
-    "Reload the ComfyUI browser tab so node packs can re-register their frontend widgets, then " +
-    "retry. If it fails again the pack's frontend extension is not loading and retrying alone " +
-    "will not fix it. This is NOT a link datatype being misread: an input the backend proves is " +
-    "a socket (MASK, IMAGE, LATENT, a comma-joined union of them) is added immediately, without " +
-    "any wait."
+    remedy
   );
 }
 

--- a/web/js/lib/node-widget-materialization.js
+++ b/web/js/lib/node-widget-materialization.js
@@ -325,23 +325,39 @@ export function unavailableRequiredWidgetMessage(report, classType, waitedMs, sc
         ? `no installed node outputs "${entry.type}" and no frontend widget is registered for it`
         : `no frontend widget is registered for "${entry.type}", and whether any installed node ` +
           `outputs it is UNKNOWN — the full /object_info read that would answer it did not ` +
-          `complete in time, so this is not evidence that nothing produces it`;
+          `complete, so this is not evidence that nothing produces it`;
     return `  - input ${inputs} (declared type "${entry.type}"): ${cause}.`;
   });
   const waited = Number.isFinite(waitedMs) ? `${(waitedMs / 1000).toFixed(1)}s` : "the wait window";
-  const remedy = schemaProofComplete
-    ? "Reload the ComfyUI browser tab so node packs can re-register their frontend widgets, then " +
-      "retry. If it fails again the pack's frontend extension is not loading and retrying alone " +
-      "will not fix it. This is NOT a link datatype being misread: an input the backend proves is " +
-      "a socket (MASK, IMAGE, LATENT, a comma-joined union of them) is added immediately, without " +
-      "any wait."
-    : // The schema read is the thing that ran out of time, so a retry is the remedy that can
-      // actually change the answer — unlike reloading the tab, which re-registers widgets and
-      // does nothing about an /object_info read that did not finish.
-      "RETRY this add: the full /object_info read is what ran out of time, and a retry can " +
-      "complete it. Reloading the tab does NOT help here — the missing thing is the schema " +
-      "answer, not a frontend widget. If it keeps timing out, this install's /object_info is " +
-      "large enough that the read needs a longer budget.";
+  // #1848 (gate) — the CAUSE is per entry, so the REMEDY has to be too. `linkProven` is
+  // decided from SAFE_SOCKET_TYPES / core 3D types / this class's own outputs, none of
+  // which a widen can change, so a report made only of link-proven entries is untouched
+  // by the schema question and must keep the remedy that can actually help it. Switching
+  // the whole message on a report-wide flag deleted that advice — the same
+  // remedy-that-cannot-work defect (#695/#700) this change exists to fix.
+  const schemaUnknown = !schemaProofComplete && report.some((e) => !e.linkProven);
+  const anyLinkProven = report.some((e) => e.linkProven);
+  const reloadRemedy =
+    "Reload the ComfyUI browser tab so node packs can re-register their frontend widgets, then " +
+    "retry. If it fails again the pack's frontend extension is not loading and retrying alone " +
+    "will not fix it. This is NOT a link datatype being misread: an input the backend proves is " +
+    "a socket (MASK, IMAGE, LATENT, a comma-joined union of them) is added immediately, without " +
+    "any wait.";
+  // The schema read is the thing that did not answer, so a retry is the remedy that can
+  // change it — unlike reloading the tab, which re-registers widgets and does nothing
+  // about an /object_info read that never came back.
+  const retryRemedy =
+    "RETRY this add: the full /object_info read that would answer the producer question did " +
+    "not complete, and a retry can complete it. Reloading the tab does NOT help THAT input — " +
+    "the missing thing is the schema answer, not a frontend widget. If it keeps failing, this " +
+    "install's /object_info may be large enough that the read needs a longer budget.";
+  // A MIXED report needs both: one input is waiting on a widget, another on an answer.
+  const remedy = schemaUnknown
+    ? anyLinkProven
+      ? `${retryRemedy}
+${reloadRemedy}`
+      : retryRemedy
+    : reloadRemedy;
   return (
     `Cannot add ${target}: ${report.length} required input type${report.length === 1 ? "" : "s"} ` +
     `had no widget after ${waited} waiting for node extensions to register.\n` +

--- a/web/js/lib/node-widget-materialization.js
+++ b/web/js/lib/node-widget-materialization.js
@@ -336,28 +336,29 @@ export function unavailableRequiredWidgetMessage(report, classType, waitedMs, sc
   // the whole message on a report-wide flag deleted that advice — the same
   // remedy-that-cannot-work defect (#695/#700) this change exists to fix.
   const schemaUnknown = !schemaProofComplete && report.some((e) => !e.linkProven);
-  const anyLinkProven = report.some((e) => e.linkProven);
   const reloadRemedy =
     "Reload the ComfyUI browser tab so node packs can re-register their frontend widgets, then " +
     "retry. If it fails again the pack's frontend extension is not loading and retrying alone " +
     "will not fix it. This is NOT a link datatype being misread: an input the backend proves is " +
     "a socket (MASK, IMAGE, LATENT, a comma-joined union of them) is added immediately, without " +
     "any wait.";
-  // The schema read is the thing that did not answer, so a retry is the remedy that can
-  // change it — unlike reloading the tab, which re-registers widgets and does nothing
-  // about an /object_info read that never came back.
+  // ADDITIVE, never substitutive. Every entry in this report reached it because no widget
+  // constructor existed after the full poll, so "no frontend widget is registered" is the
+  // one thing here that is PROVEN. An unfinished schema read adds a second possible cause
+  // (a sibling may output the type); it does not retract the first. Saying "the missing
+  // thing is the schema answer, not a frontend widget" denied the proven half and removed
+  // its remedy — and because the widen's bound is fixed, an install whose /object_info
+  // exceeds it re-fails identically on every retry, so that advice could never resolve.
   const retryRemedy =
-    "RETRY this add: the full /object_info read that would answer the producer question did " +
-    "not complete, and a retry can complete it. Reloading the tab does NOT help THAT input — " +
-    "the missing thing is the schema answer, not a frontend widget. If it keeps failing, this " +
-    "install's /object_info may be large enough that the read needs a longer budget.";
-  // A MIXED report needs both: one input is waiting on a widget, another on an answer.
-  const remedy = schemaUnknown
-    ? anyLinkProven
-      ? `${retryRemedy}
-${reloadRemedy}`
-      : retryRemedy
-    : reloadRemedy;
+    "ALSO worth a RETRY: whether any installed node outputs the type(s) above is unresolved — " +
+    "the full /object_info read that would settle it did not complete, and a retry can " +
+    "complete that read. If retries keep hitting the same wall, this install's /object_info " +
+    "may be large enough that the read needs a longer budget.";
+  // The reload advice fits EVERY entry (each one is a widget that did not appear), so it
+  // is always emitted. The retry advice is stacked on top only when a producer question
+  // was left unanswered.
+  const remedy = schemaUnknown ? `${reloadRemedy}
+${retryRemedy}` : reloadRemedy;
   return (
     `Cannot add ${target}: ${report.length} required input type${report.length === 1 ? "" : "s"} ` +
     `had no widget after ${waited} waiting for node extensions to register.\n` +


### PR DESCRIPTION
Fixes artokun/comfyui-mcp#1848.

`panel_add_node` refused every node with a required custom-typed input, reporting **"no installed node outputs `SAM3_MODEL_CONFIG`"** while `LoadSAM3Model` — which outputs exactly that — had been added to the same graph seconds earlier and was sitting in `/object_info`.

## The reporter's diagnosis was wrong, and that matters

They concluded the producible-type set comes from a hardcoded core allowlist. It does not: `registeredSocketTypes()` derives it from `/object_info` outputs, and #822 already stopped it being read off a single-class payload. Both of those shipped long before their build.

The real cause is one step further on. The socket proof may come from a **single-class** `/object_info` (#780's optimisation), so on the refusal path it is widened against the whole schema (#821) — and that widen is **bounded** (#1180/#1192). On a heavy install it returns `null`, which the helper uses for *every* doubtful payload **including a call that never answered in budget**.

The guard then keeps failing closed, which is right. The **message** was not:

```js
const cause = entry.linkProven
  ? `the backend declares "${type}" as a link datatype, …`
  : `no installed node outputs "${type}" and no frontend widget is registered for it`;
```

Two states, two branches — and no third for *"I could not find out."* So `linkProven:false` rendered as a claim about the **whole install**, asserted from having failed to read the install. It then sent the reader to reload the tab, which re-registers frontend widgets and does nothing about an `/object_info` read that ran out of time.

The module states the principle it was violating, two functions up:

> "I did not find out" is not "nothing outputs anything", and the difference matters because the caller REPLACES its proof with whatever comes back.

That was applied to **replacing** the proof, and not to **describing** it.

## The change

A third cause. When a widen was attempted and could not answer, the refusal says the producer question is **UNKNOWN** and recommends a **retry** — the thing that can actually complete the read. A complete proof is untouched: it still asserts absence and still recommends reloading the tab.

## Five existing assertions changed — deliberately, and stated plainly

`add-node-socket-proof-scope.test.mjs` pinned `no installed node outputs "SEEDVR2_VAE"` / `"SEEDVR2_DIT"` for a widen that **provably could not answer** (broken `getNodeDefs`, null/empty/non-object payload, a throw).

That is the same over-claim #821 was reported for. #821 fixed the path where the widen *succeeds*; the failure path kept the original sentence — literally the one from that report, where `SeedVR2VideoUpscaler` was told nothing outputs `SEEDVR2_DIT` while `SeedVR2LoadDiTModel` sat on the canvas.

They are **updated, not loosened**. Each still asserts the guard fails closed and nothing is added, still asserts the already-proven type is never named, and now *additionally* asserts the message does not claim absence and does say UNKNOWN.

## Verification

- Full suite **5832 pass / 0 fail** (5833 total). `check-tool-vocabulary`, `check-panel-scope`, `i18n:check`, `i18n-render-check` all OK.
- **Three mutations, all killed**: dropping the 4th argument at the call site (caught by a source-level assertion, since a call-site argument is invisible to message-level tests), never clearing the flag on the widen's reject branch, and collapsing the third cause back into absence.

## Not fixed here, and worth its own issue

The reporter filed `panel_refresh_nodes` returning `combo_refresh_failed` / *"did not answer within this refresh's remaining budget"* as a secondary, smaller issue. It is the **same root cause** — `/object_info` work not completing on an install with 381 models — and this PR only makes the resulting message honest. Whether those budgets should scale with install size is a separate question I have not touched.

Filed on the orchestrator repo, fixed here: the guard and its message are panel-side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
