### PR TITLE
fix(1480): a silent Manager in_progress is named as a stall, not as progress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+### Fixed
+- a Manager install queue that stays `in_progress` with no count change is reported as a silent stall, not as progress: `panel_node_queue_status` still attaches Manager's real counts, names any in-progress pack, and after two minutes of the same fingerprint tells you to verify with `panel_list_nodes` instead of waiting forever (#1480)
+
 ## [0.15.21] - 2026-08-20
 
 ### Fixed

--- a/browser_tests/unit/manager-queue-stall.test.mjs
+++ b/browser_tests/unit/manager-queue-stall.test.mjs
@@ -1,0 +1,272 @@
+// #1480 — `panel_install_node` queued comfyui_controlnet_aux, then
+// `panel_node_queue_status` kept returning Manager's
+// `{total_count:1, done_count:12, in_progress_count:1, is_processing:true}`
+// for over two minutes with no completion, no failure, and no install log.
+// The panel was forwarding that payload as-is (correct) and never timing a
+// silent in_progress (the reporting gap): a poll that repeats the same counts
+// forever reads as "still working".
+//
+// These tests pin: the fingerprint of a processing status, the watch that
+// times an unchanged fingerprint, the stall note that does not claim failure,
+// and that the REAL `nodes_queue_status` — extracted from the panel — names
+// the stall on the reporter's payload while leaving Manager's counts attached.
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import * as ManagerInstall from "../../web/js/lib/manager-install.js";
+const {
+  QUEUE_SILENT_STALL_MS,
+  collectInProgressTasks,
+  collectRecentTaskFailures,
+  createManagerQueueWatch,
+  createManagerTaskResultLog,
+  dialectServesTaskHistory,
+  looksLikeTaskHistory,
+  queueIsProcessing,
+  queueProgressFingerprint,
+  silentQueueStallNote,
+  taskHistoryBlindNote,
+  unlistedGitUrlAdvice,
+} = ManagerInstall;
+
+/** The exact status the reporter polled, including the odd done_count > total. */
+const REPORTER_STATUS = {
+  total_count: 1,
+  done_count: 12,
+  in_progress_count: 1,
+  pending_count: 0,
+  is_processing: true,
+};
+const IDLE = { total_count: 0, done_count: 0, in_progress_count: 0, is_processing: false };
+const TARGET = "comfyui_controlnet_aux";
+const UI_ID = "u-1480";
+
+function readPanelSource() {
+  return readFileSync(
+    fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url)),
+    "utf8",
+  );
+}
+
+function pick(src, re, name) {
+  const m = src.match(re);
+  assert.ok(m, `could not locate ${name} in panel source`);
+  return m[0];
+}
+
+function buildQueueStatus({ dialect, routes, managerTaskResults, managerQueueWatch, now }) {
+  const src = readPanelSource();
+  const get = async (route) => {
+    for (const [prefix, handler] of Object.entries(routes)) {
+      if (route.startsWith(prefix)) {
+        const out = typeof handler === "function" ? handler(route) : handler;
+        if (out instanceof Error) throw out;
+        return out;
+      }
+    }
+    throw new Error(`unstubbed route: ${route}`);
+  };
+  const deps = {
+    detectManagerDialect: async () => dialect,
+    managerGet: get,
+    collectInProgressTasks,
+    collectRecentTaskFailures,
+    dialectServesTaskHistory,
+    looksLikeTaskHistory,
+    taskHistoryBlindNote,
+    unlistedGitUrlAdvice,
+    silentQueueStallNote,
+    managerTaskResults,
+    managerQueueWatch:
+      managerQueueWatch ??
+      createManagerQueueWatch({ now: now ?? (() => Date.now()) }),
+    CAPTURED_FAILURE_TTL_MS: 30 * 60 * 1000,
+    MANAGER_FETCH_TIMEOUT_MS: 15000,
+    AbortSignal,
+  };
+  const factory = new Function(
+    ...Object.keys(deps),
+    `const tools = {
+${pick(src, /  async nodes_queue_status\(\) \{[\s\S]*?\n  \},/, "nodes_queue_status")}
+};
+return () => tools.nodes_queue_status();`,
+  );
+  return factory(...Object.values(deps));
+}
+
+// ---------------------------------------------------------------------------
+// The fingerprint of a processing status
+// ---------------------------------------------------------------------------
+
+test("#1480: the reporter's payload is processing, an idle queue is not", () => {
+  assert.equal(queueIsProcessing(REPORTER_STATUS), true);
+  assert.equal(queueIsProcessing(IDLE), false);
+  assert.equal(queueIsProcessing(null), false);
+  assert.equal(queueIsProcessing({}), false);
+});
+
+test("#1480: unchanged counts share a fingerprint; a moved count does not", () => {
+  const a = queueProgressFingerprint(REPORTER_STATUS);
+  const b = queueProgressFingerprint({ ...REPORTER_STATUS });
+  assert.equal(typeof a, "string");
+  assert.equal(a, b);
+  assert.notEqual(
+    a,
+    queueProgressFingerprint({ ...REPORTER_STATUS, done_count: 13 }),
+    "a done_count bump is progress, not a stall",
+  );
+  assert.equal(queueProgressFingerprint(IDLE), null);
+});
+
+test("#1480: the same in_progress repeating past the stall window is a stall", () => {
+  let now = 1_000_000;
+  const watch = createManagerQueueWatch({ now: () => now, stallMs: QUEUE_SILENT_STALL_MS });
+  const first = watch.observe(REPORTER_STATUS);
+  assert.equal(first.processing, true);
+  assert.equal(first.stalled, false);
+  assert.equal(first.silent_ms, 0);
+
+  now += QUEUE_SILENT_STALL_MS + 5_000;
+  const later = watch.observe(REPORTER_STATUS);
+  assert.equal(later.processing, true);
+  assert.equal(later.stalled, true);
+  assert.equal(later.silent_ms, QUEUE_SILENT_STALL_MS + 5_000);
+  assert.equal(later.fingerprint, first.fingerprint);
+});
+
+test("#1480: a count change resets the silent clock", () => {
+  let now = 1_000_000;
+  const watch = createManagerQueueWatch({ now: () => now, stallMs: QUEUE_SILENT_STALL_MS });
+  watch.observe(REPORTER_STATUS);
+  now += QUEUE_SILENT_STALL_MS - 1_000;
+  watch.observe({ ...REPORTER_STATUS, done_count: 13 });
+  now += 2_000;
+  const after = watch.observe({ ...REPORTER_STATUS, done_count: 13 });
+  assert.equal(after.stalled, false, "progress within the window is not a stall");
+  assert.equal(after.silent_ms, 2_000);
+});
+
+test("#1480: a drained queue clears the watch", () => {
+  let now = 1_000_000;
+  const watch = createManagerQueueWatch({ now: () => now, stallMs: QUEUE_SILENT_STALL_MS });
+  watch.observe(REPORTER_STATUS);
+  now += QUEUE_SILENT_STALL_MS + 1;
+  assert.equal(watch.observe(IDLE).stalled, false);
+  assert.equal(watch.observe(IDLE).processing, false);
+});
+
+test("#1480: the stall note does not claim the install failed", () => {
+  const note = silentQueueStallNote({ silent_ms: QUEUE_SILENT_STALL_MS });
+  assert.match(note, /SAME in_progress/);
+  assert.match(note, /panel_list_nodes/);
+  assert.doesNotMatch(note, /install FAILED/i);
+  assert.doesNotMatch(note, /\bfailed\b/i);
+});
+
+test("#1480: history in_progress items are collected by id, not as failures", () => {
+  const history = {
+    history: {
+      [UI_ID]: {
+        ui_id: UI_ID,
+        kind: "install",
+        params: { id: TARGET },
+        status: { status_str: "in_progress", completed: false, messages: [] },
+      },
+      other: {
+        ui_id: "other",
+        kind: "update",
+        params: { id: "comfyui-mcp-panel" },
+        status: { status_str: "error", completed: true, messages: ["stale"] },
+      },
+    },
+  };
+  assert.deepEqual(collectInProgressTasks(history), [
+    { ui_id: UI_ID, kind: "install", id: TARGET },
+  ]);
+  assert.equal(collectRecentTaskFailures(history).length, 1);
+});
+
+// ---------------------------------------------------------------------------
+// Real-source harness: the poll the reporter made
+// ---------------------------------------------------------------------------
+
+test("#1480: the poll the reporter made now names the silent stall", async () => {
+  let now = 1_000_000;
+  const watch = createManagerQueueWatch({ now: () => now, stallMs: QUEUE_SILENT_STALL_MS });
+  const queueStatus = buildQueueStatus({
+    dialect: "v2",
+    routes: {
+      "manager/queue/status": REPORTER_STATUS,
+      "manager/queue/history": {
+        history: {
+          [UI_ID]: {
+            ui_id: UI_ID,
+            kind: "install",
+            params: { id: TARGET },
+            status: { status_str: "in_progress", completed: false, messages: [] },
+          },
+        },
+      },
+    },
+    managerTaskResults: createManagerTaskResultLog(),
+    managerQueueWatch: watch,
+  });
+
+  const first = await queueStatus();
+  assert.deepEqual(first.status, REPORTER_STATUS, "Manager's counts stay attached");
+  assert.equal(first.queue_liveness.stalled, false);
+  assert.deepEqual(first.in_progress, [{ ui_id: UI_ID, kind: "install", id: TARGET }]);
+  assert.equal(first.failure_reporting, "complete");
+  assert.equal(first.note, undefined, "a fresh in_progress is not a stall yet");
+
+  now += QUEUE_SILENT_STALL_MS + 5_000;
+  const later = await queueStatus();
+  assert.deepEqual(later.status, REPORTER_STATUS, "still Manager's payload, not a rewritten failure");
+  assert.equal(later.queue_liveness.stalled, true);
+  assert.equal(later.queue_liveness.silent_ms, QUEUE_SILENT_STALL_MS + 5_000);
+  assert.match(later.note, /SAME in_progress/);
+  assert.match(later.note, /panel_list_nodes/);
+  assert.doesNotMatch(later.note, /\bfailed\b/i);
+  assert.deepEqual(later.in_progress, [{ ui_id: UI_ID, kind: "install", id: TARGET }]);
+});
+
+test("#1480: a first poll of a busy queue is not a stall", async () => {
+  const queueStatus = buildQueueStatus({
+    dialect: "v2",
+    routes: {
+      "manager/queue/status": REPORTER_STATUS,
+      "manager/queue/history": { history: {} },
+    },
+    managerTaskResults: createManagerTaskResultLog(),
+  });
+  const out = await queueStatus();
+  assert.equal(out.queue_liveness.stalled, false);
+  assert.equal(out.queue_liveness.silent_ms, 0);
+  assert.equal(out.note, undefined);
+});
+
+test("#1480: an idle queue still has no stall fields", async () => {
+  const queueStatus = buildQueueStatus({
+    dialect: "v2",
+    routes: {
+      "manager/queue/status": IDLE,
+      "manager/queue/history": { history: {} },
+    },
+    managerTaskResults: createManagerTaskResultLog(),
+  });
+  const out = await queueStatus();
+  assert.equal(out.queue_liveness, undefined);
+  assert.equal(out.in_progress, undefined);
+  assert.equal(out.note, undefined);
+  assert.equal(out.failure_reporting, "complete");
+});
+
+test("#1480: nodes_queue_status observes the watch on the real path", () => {
+  const src = readPanelSource();
+  const method = pick(src, /  async nodes_queue_status\(\) \{[\s\S]*?\n  \},/, "nodes_queue_status");
+  assert.match(method, /managerQueueWatch\.observe\(status\)/);
+  assert.match(method, /silentQueueStallNote/);
+  assert.match(method, /collectInProgressTasks/);
+});

--- a/browser_tests/unit/manager-task-broadcast.test.mjs
+++ b/browser_tests/unit/manager-task-broadcast.test.mjs
@@ -32,7 +32,9 @@ import { fileURLToPath } from "node:url";
 import * as ManagerInstall from "../../web/js/lib/manager-install.js";
 const {
   classifyInstallOutcome,
+  collectInProgressTasks,
   collectRecentTaskFailures,
+  createManagerQueueWatch,
   createManagerTaskResultLog,
   dialectServesTaskHistory,
   looksLikeTaskHistory,
@@ -40,6 +42,7 @@ const {
   queueDrained,
   queueEventFailureReason,
   queueEventTaskResults,
+  silentQueueStallNote,
   taskFailureReason,
   taskHistoryBlindNote,
   unlistedGitUrlAdvice,
@@ -422,12 +425,15 @@ function buildQueueStatus({ dialect, routes, managerTaskResults }) {
   const deps = {
     detectManagerDialect: async () => dialect,
     managerGet: get,
+    collectInProgressTasks,
     collectRecentTaskFailures,
     dialectServesTaskHistory,
     looksLikeTaskHistory,
     taskHistoryBlindNote,
     unlistedGitUrlAdvice,
+    silentQueueStallNote,
     managerTaskResults,
+    managerQueueWatch: createManagerQueueWatch(),
     CAPTURED_FAILURE_TTL_MS: 30 * 60 * 1000,
     MANAGER_FETCH_TIMEOUT_MS: 15000,
     AbortSignal,

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -109,11 +109,14 @@ import {
   buildInstallRequest,
   classifyInstallOutcome,
   classifyUpdateOutcome,
+  collectInProgressTasks,
   collectRecentTaskFailures,
+  createManagerQueueWatch,
   createManagerTaskResultLog,
   dialectRetryTarget,
   dialectServesTaskHistory,
   looksLikeTaskHistory,
+  silentQueueStallNote,
   taskHistoryBlindNote,
   installGitUrl,
   installedListRoute,
@@ -6900,6 +6903,9 @@ function boundedDelay(ms, deadline) {
  *  the next line, which is what leaves a poll looking at an idle queue holding
  *  nothing. See manager-install.js for the source it was read from. */
 const managerTaskResults = createManagerTaskResultLog();
+
+/** Times a silent Manager in_progress so a poll can name a stall (#1480). */
+const managerQueueWatch = createManagerQueueWatch();
 
 /** How long a captured failure stays reportable on a queue poll. A defeat from
  *  hours ago is not what "is my install done?" is asking, and repeating it reads
@@ -21122,8 +21128,23 @@ const GRAPH_TOOL_EXECUTORS = {
     // byte-identical to a v4 with nothing to report.
     const canReportFailures = dialectServesTaskHistory(dialect) && looksLikeTaskHistory(history);
     const blindNote = canReportFailures ? "" : taskHistoryBlindNote(dialect);
+    // #1480 — Manager's counts are still attached as `status`. A repeating
+    // in_progress is timed here so a silent stall is named instead of looking
+    // like progress; the stall note never rewrites those counts and never
+    // claims the task failed.
+    const liveness = managerQueueWatch.observe(status);
+    const inProgress = liveness.processing ? collectInProgressTasks(history) : [];
+    const stallNote = liveness.stalled ? silentQueueStallNote(liveness) : "";
+    const withLiveness = (out) => {
+      if (inProgress.length) out.in_progress = inProgress;
+      if (liveness.processing) {
+        out.queue_liveness = { stalled: liveness.stalled, silent_ms: liveness.silent_ms };
+      }
+      if (stallNote) out.note = out.note ? `${out.note}\n\n${stallNote}` : stallNote;
+      return out;
+    };
     if (recentFailures.length) {
-      return {
+      return withLiveness({
         status,
         recent_failures: recentFailures,
         failure_reporting: canReportFailures ? "complete" : "partial",
@@ -21139,12 +21160,12 @@ const GRAPH_TOOL_EXECUTORS = {
           // record. Those are real, but the list is not exhaustive — say so,
           // rather than let a partial list be taken for the whole story.
           (blindNote ? `\n\n${blindNote}` : ""),
-      };
+      });
     }
     if (!canReportFailures) {
-      return { status, failure_reporting: "unavailable", note: blindNote };
+      return withLiveness({ status, failure_reporting: "unavailable", note: blindNote });
     }
-    return { status, failure_reporting: "complete" };
+    return withLiveness({ status, failure_reporting: "complete" });
   },
 
   // #851 — every branch below names the TARGET as well as the route, via

--- a/web/js/lib/manager-install.js
+++ b/web/js/lib/manager-install.js
@@ -1130,6 +1130,137 @@ export function collectRecentTaskFailures(resp, { limit = 20 } = {}) {
 }
 
 // ---------------------------------------------------------------------------
+// #1480 — a silent in_progress is not progress
+// ---------------------------------------------------------------------------
+//
+// /v2/manager/queue/status is an aggregate of counts. A wedged Manager worker
+// keeps answering the same `{total_count:1, in_progress_count:1, is_processing:true}`
+// forever, with no per-task terminal record and no install log. The panel was
+// forwarding that payload as-is — which is the right status, and the wrong
+// conclusion: a poll that never times a silent in_progress reads as "still
+// working, wait longer" for as long as the caller is willing to wait.
+//
+// These helpers do not rewrite Manager's counts and do not manufacture a
+// failure. They measure whether the SAME processing fingerprint has been
+// repeating, and after QUEUE_SILENT_STALL_MS they name that as a stall.
+
+/** Status strings that mean the task has not reached a terminal yet. Narrow
+ *  on purpose: only spellings Manager actually writes for a live task. */
+const TASK_IN_PROGRESS_STATUS = new Set(["in_progress", "running", "pending"]);
+
+/** How long the same processing counts may repeat before a poll names a stall.
+ *  Matches the reported wait (over two minutes of unchanged in_progress). A
+ *  slow-but-alive clone can outlive this; the stall note is a visibility
+ *  warning, never a failure verdict. */
+export const QUEUE_SILENT_STALL_MS = 120_000;
+
+/** Is Manager currently claiming the queue is working? True only on an explicit
+ *  processing flag or a positive in-progress/pending count — a malformed or
+ *  idle status is not processing. */
+export function queueIsProcessing(status) {
+  if (!status || typeof status !== "object" || Array.isArray(status)) return false;
+  if (status.is_processing === true) return true;
+  if (typeof status.in_progress_count === "number" && status.in_progress_count > 0) return true;
+  if (typeof status.pending_count === "number" && status.pending_count > 0) return true;
+  return false;
+}
+
+/** A fingerprint of the processing counts so "the same in_progress repeating"
+ *  is distinguishable from a count that actually moved. Idle/malformed → null. */
+export function queueProgressFingerprint(status) {
+  if (!queueIsProcessing(status)) return null;
+  return [
+    status.is_processing === true ? "1" : "0",
+    Number(status.total_count) || 0,
+    Number(status.done_count) || 0,
+    Number(status.in_progress_count) || 0,
+    Number(status.pending_count) || 0,
+  ].join(":");
+}
+
+/**
+ * Collect the still-running tasks from a /v2/manager/queue/history response.
+ * Only explicit in_progress/running/pending status_str values — never inferred
+ * from a missing terminal, so an unrecognized shape cannot become a live task.
+ */
+export function collectInProgressTasks(resp, { limit = 20 } = {}) {
+  const history =
+    resp && typeof resp === "object" && "history" in resp ? resp.history : resp;
+  if (!history || typeof history !== "object") return [];
+  const items = Array.isArray(history) ? history : Object.values(history);
+  const out = [];
+  for (const item of items) {
+    if (!isTaskHistoryItem(item)) continue;
+    const str = taskStatusStr(item);
+    if (!str) continue;
+    const lower = str.toLowerCase();
+    if (!TASK_IN_PROGRESS_STATUS.has(lower)) continue;
+    if (TASK_SUCCESS_STATUS.has(lower) || TASK_FAILURE_STATUS.has(lower)) continue;
+    out.push({
+      ui_id: typeof item.ui_id === "string" ? item.ui_id : undefined,
+      kind: typeof item.kind === "string" ? item.kind : undefined,
+      id: taskParamId(item),
+    });
+  }
+  return out.slice(-limit);
+}
+
+/**
+ * What to tell a poll whose Manager counts have not moved for stallMs.
+ * Says the in_progress is Manager's own repeating status, not panel-invented
+ * progress, and does NOT claim the task failed — absence of a log is not a
+ * terminal record.
+ */
+export function silentQueueStallNote({ silent_ms, silentMs } = {}) {
+  const ms = typeof silent_ms === "number" ? silent_ms : silentMs;
+  const secs = Math.max(0, Math.round((Number(ms) || 0) / 1000));
+  return (
+    `NOTE — the Manager queue has reported the SAME in_progress counts for ${secs}s with no change. ` +
+    `That is Manager's own status, forwarded as-is — it is NOT panel-invented progress, and it is NOT a completion. ` +
+    `A silent in_progress is not proof the install is running. VERIFY with panel_list_nodes; if the pack is still ` +
+    `absent, check the ComfyUI server log for clone/pip activity. Do not restart solely because the queue is still ` +
+    `in_progress — a restart will not finish a wedged clone. If the log is also silent, the Manager worker is stuck.`
+  );
+}
+
+/**
+ * Observes successive /queue/status payloads and times how long the SAME
+ * processing fingerprint has been repeating.
+ *
+ * @param {{stallMs?: number, now?: () => number}} [opts]
+ */
+export function createManagerQueueWatch({ stallMs = QUEUE_SILENT_STALL_MS, now = () => Date.now() } = {}) {
+  let fingerprint = null;
+  let since = 0;
+  return {
+    /**
+     * @param {unknown} status
+     * @returns {{processing: boolean, stalled: boolean, silent_ms: number, fingerprint: string|null}}
+     */
+    observe(status) {
+      const t = now();
+      if (!queueIsProcessing(status)) {
+        fingerprint = null;
+        since = 0;
+        return { processing: false, stalled: false, silent_ms: 0, fingerprint: null };
+      }
+      const fp = queueProgressFingerprint(status);
+      if (fingerprint !== fp) {
+        fingerprint = fp;
+        since = t;
+      }
+      const silentMs = Math.max(0, t - since);
+      return {
+        processing: true,
+        stalled: silentMs >= stallMs,
+        silent_ms: silentMs,
+        fingerprint: fp,
+      };
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
 // comfyui-mcp#1606 — a per-task result on the build that keeps NO task history
 // ---------------------------------------------------------------------------
 //


### PR DESCRIPTION
Fixes #1480

`panel_install_node` queued `comfyui_controlnet_aux`. Polling `panel_node_queue_status` then kept returning Manager's own `{total_count:1, done_count:12, in_progress_count:1, is_processing:true}` for over two minutes, with no completion, no failure, and no install log. The panel was forwarding that payload as-is (correct) and never timing a silent `in_progress` (the reporting gap): the same counts forever read as "still working, wait longer".

This does not patch Manager. A wedged worker is still Manager's stall. The poll now:

- still attaches Manager's real `status` unchanged
- names any in-progress pack from history (`in_progress`)
- times the same processing fingerprint across polls (`queue_liveness`)
- after two minutes of no count change, adds a stall note that is **not** a failure: verify with `panel_list_nodes`, check the ComfyUI log, do not restart solely because the queue is still `in_progress`

A count that actually moves resets the clock. An idle queue is unchanged.

Proof: `browser_tests/unit/manager-queue-stall.test.mjs` drives the extracted `nodes_queue_status` on the reporter's payload. `#1606` queue-poll tests still pass.
