### PR TITLE
fix(1495): the "you are inside a subgraph" remedy is now checked, not assumed

### DIFF
--- a/browser_tests/unit/node-scope-locator.test.mjs
+++ b/browser_tests/unit/node-scope-locator.test.mjs
@@ -114,6 +114,71 @@ test("a root node while viewing a subgraph tells you to EXIT", () => {
   assert.match(msg, /panel_exit_subgraph/);
 });
 
+// ── #1495 the scope claim must be CHECKED, not assumed ────────────────────
+//
+// Reporter: panel_exit_subgraph returned scope=root / settled=true; a later
+// panel_enter_subgraph(5548) failed saying they were inside a subgraph; the
+// panel_exit_subgraph that error prescribed answered "already at root"; the
+// retry then succeeded. Nothing in the panel had two scope stores to
+// desynchronise — resolveScope is the single authority. What was wrong was the
+// MESSAGE: this branch asserted a subgraph scope it never looked at, because its
+// premise ("only reachable while viewing a subgraph") is not an invariant. The
+// root walk reads `_nodes`; the lookup that missed reads `getNodeById`. When
+// those two drift on the ROOT graph, the caller is at root and is sent to leave a
+// subgraph they are not in — the exact round-trip the reporter ran.
+
+test("#1495 a root node that missed while VIEWING root does not claim a subgraph", () => {
+  // The lookup searched the root graph itself (currentGraph === rootGraph) and the
+  // root walk found the id there. Claiming a subgraph scope here is unsupportable.
+  const root = sub([node(5548, { type: "SaveImage" }), node(12, { type: "KSampler" })]);
+  const msg = describeMissingNode(5548, root, true, root);
+  assert.match(msg, /^No node with id 5548/);
+  assert.ok(
+    !/you are currently inside a subgraph/.test(msg),
+    "must not assert a viewing scope it did not check",
+  );
+  assert.ok(
+    !/Call panel_exit_subgraph, then retry/.test(msg),
+    "prescribing the exit is the wasted round-trip the reporter ran",
+  );
+  assert.match(msg, /IS on the root graph/);
+  assert.match(msg, /NOT a subgraph scope problem/);
+  // and it still hands back something the caller can act on
+  assert.match(msg, /12 \(KSampler\)/);
+});
+
+test("#1495 the graph the lookup SEARCHED outranks a separately-read viewingRoot", () => {
+  // resolveNode reads `viewingRoot` from a SECOND getGraphCtx(), taken after the
+  // lookup. `currentGraph` is the graph the lookup actually ran on, so identity
+  // against the root decides — two readings must not be presented as one.
+  const root = sub([node(7, { type: "A" }), node(8, { type: "B" })]);
+  const msg = describeMissingNode(7, root, false, root);
+  assert.ok(!/you are currently inside a subgraph/.test(msg));
+  assert.match(msg, /IS on the root graph/);
+});
+
+test("#1495 a genuine subgraph view still gets the EXIT remedy", () => {
+  // The fix must not disarm the #697 message: when the lookup really did run on a
+  // subgraph, leaving it IS the remedy.
+  const inner = sub([node(10, { type: "InnerA" })]);
+  const root = sub([node(7, { type: "Root" }), node(9, { title: "S", subgraph: inner })]);
+  const msg = describeMissingNode(7, root, false, inner);
+  assert.match(msg, /on the ROOT graph/);
+  assert.match(msg, /you are currently inside a subgraph/);
+  assert.match(msg, /Call panel_exit_subgraph, then retry/);
+});
+
+test("#1495 a root graph holding only the missing node does not also say it is empty", () => {
+  // currentIdSuffix filters the missing id out, so a one-node root degrades to
+  // "has no nodes" — which would contradict "it IS on the root graph" in the same
+  // breath. The retarget list is offered only when it actually names ids.
+  const root = sub([node(7, { type: "SaveImage" })]);
+  const msg = describeMissingNode(7, root, true, root);
+  assert.match(msg, /IS on the root graph/);
+  assert.ok(!/currently has no nodes/.test(msg), "self-contradicting in one message");
+  assert.match(msg, /Re-read with panel_graph_outline/);
+});
+
 test("a genuine miss says how hard it looked, and does not invent a location", () => {
   const root = sub([node(1), node(9, { subgraph: sub([node(2)]) })]);
   const msg = describeMissingNode(999, root, true);

--- a/web/js/lib/node-scope-locator.js
+++ b/web/js/lib/node-scope-locator.js
@@ -56,6 +56,13 @@ const MAX_DEPTH = 12;
  */
 const MAX_CURRENT_IDS = 40;
 
+/**
+ * The opening of the retarget suffix, named once because #1495's message has to ask
+ * whether the suffix actually NAMES ids (it degrades to "…has no nodes" on an empty
+ * graph) before it may offer it as the remedy. A second literal here would drift.
+ */
+const CURRENT_IDS_PREFIX = "Current ids on the graph you are viewing: ";
+
 function nodesOf(graph) {
   const raw = graph?._nodes ?? graph?.nodes;
   return Array.isArray(raw) ? raw : [];
@@ -155,7 +162,7 @@ function currentIdSuffix(graph, nodeId) {
     const extra =
       parts.length > MAX_CURRENT_IDS ? `, …and ${parts.length - MAX_CURRENT_IDS} more` : "";
     return (
-      `Current ids on the graph you are viewing: ${shown.join(", ")}${extra}. ` +
+      `${CURRENT_IDS_PREFIX}${shown.join(", ")}${extra}. ` +
       `Retarget using a current id; re-read with panel_graph_outline if you need wiring.`
     );
   } catch {
@@ -195,7 +202,40 @@ export function describeMissingNode(nodeId, rootGraph, viewingRoot, currentGraph
   }
 
   if (found.scope === "root") {
-    // Only reachable while viewing a subgraph, so the remedy is to leave it.
+    // #1495 — this branch used to assert "you are currently inside a subgraph"
+    // unconditionally, on the premise the old comment here stated: that it was
+    // "only reachable while viewing a subgraph". Nothing enforces that premise.
+    // The branch fires whenever the ROOT walk finds the id, and the ROOT walk reads
+    // the graph's node LIST (`_nodes`) while the lookup that just missed reads the
+    // id INDEX (`getNodeById`) — the same two sources `currentIdSuffix` above
+    // already assumes can drift. When they drift on the root graph, the caller is
+    // AT root and is told to leave a subgraph they are not in. The reporter ran
+    // exactly that: panel_exit_subgraph answered "already at root", and the retry
+    // that followed succeeded. The wasted round-trip IS the defect, and its cause
+    // is a scope claim published without checking the scope.
+    //
+    // So decide it from evidence THIS call holds. `currentGraph` is the graph the
+    // failed lookup actually searched, so `currentGraph === rootGraph` is
+    // same-reading object identity. `viewingRoot` is a separately-timed reading of
+    // the viewing scope (resolveNode takes it AFTER the lookup, from a second
+    // getGraphCtx()), so it is only consulted when no `currentGraph` was passed.
+    const searchedRoot = currentGraph ? currentGraph === rootGraph : Boolean(viewingRoot);
+    if (searchedRoot) {
+      // The retarget list is offered only when it actually names ids: on a graph
+      // whose only node is the missing one it degrades to "has no nodes", which
+      // would contradict the sentence right before it.
+      const retarget = ids.startsWith(CURRENT_IDS_PREFIX)
+        ? ids
+        : "Re-read with panel_graph_outline before retrying.";
+      return (
+        `${base} — but node ${nodeId} IS on the root graph, and the root graph is what ` +
+        `you are VIEWING, so this is NOT a subgraph scope problem: panel_exit_subgraph ` +
+        `would answer "already at root" and change nothing. The root graph's node list ` +
+        `holds ${nodeId} while the id lookup this write uses did not resolve it, so the ` +
+        `id and that graph's index disagree. ` +
+        retarget
+      );
+    }
     return (
       `${base}. Node ${nodeId} is on the ROOT graph, but you are currently inside a ` +
       `subgraph — the write applies to the graph you are VIEWING, not the whole ` +


### PR DESCRIPTION
Fixes #1495

## What the reporter saw

1. `panel_exit_subgraph` → `scope=root`, `settled=true`.
2. A later turn: `panel_enter_subgraph(5548)` refused —
   *"No node with id 5548 in the current graph. Node 5548 is on the ROOT graph, but you are currently inside a subgraph … Call panel_exit_subgraph, then retry."*
3. `panel_exit_subgraph` → `{"viewing":{"scope":"root"},"note":"already at root"}`.
4. Retry `panel_enter_subgraph(5548)` → succeeded.

They read that as two scope stores drifting apart and prescribed synchronising "the graph mutation router's active subgraph scope" with the viewer scope.

## The prescribed fix has nothing to synchronise

There is only one scope store. `resolveScope()` in `web/js/lib/subgraph-scope.js` is the single authority that **both** reads and writes derive their target graph from — that is literally what it was built for (`#220`/`#308`: "ONE authoritative scope resolver … so a read and an edit issued back-to-back can never target two different graphs"). `getGraphCtx()` is its only consumer, and both `graph_enter_subgraph` and `graph_exit_subgraph` go through it. Nothing there desynchronised, and adding a second reconciliation would have papered over the actual defect.

## The defect is the message, not the state

`describeMissingNode()`'s root-scope branch asserted the subgraph scope **unconditionally**, on the premise its own comment stated:

```js
if (found.scope === "root") {
  // Only reachable while viewing a subgraph, so the remedy is to leave it.
```

Nothing enforces that premise. The branch fires whenever the ROOT walk finds the id, and the two sides ask different sources:

- `locateNodeAcrossScopes()` walks the graph's node **LIST** (`_nodes ?? nodes`);
- `resolveNode()`'s lookup that just missed reads the id **INDEX** (`graph.getNodeById(...)`).

Those two drifting is not a hypothetical here — `currentIdSuffix()`, forty lines above in the same file, already filters on exactly that possibility ("even if `_nodes` and `getNodeById` have drifted"). Drift them on the **root** graph and this branch tells a caller who is at root to leave a subgraph they are not in. That is the reporter's trace, step for step: the refusal prescribes `panel_exit_subgraph`, `panel_exit_subgraph` truthfully answers "already at root" (the canvas *was* at root), and the retry succeeds because the target was addressable all along. The "contradiction" is one claim that was never checked, not two states that disagreed.

The caller had already computed the answer: `resolveNode()` passes `viewingRoot` in as the third argument. The branch never read it.

## The change

`describeMissingNode()` now decides the scope from evidence the call actually holds:

```js
const searchedRoot = currentGraph ? currentGraph === rootGraph : Boolean(viewingRoot);
```

`currentGraph` is the graph the failed lookup **actually searched**, so `currentGraph === rootGraph` is same-reading object identity. It outranks `viewingRoot` on purpose: `viewingRoot` is a separately-timed reading, taken from a *second* `getGraphCtx()` **after** the lookup, and presenting two readings as one is the shape of the original bug. `viewingRoot` is still honoured for the older three-argument call shape.

- **Lookup ran on root** → the reply says node N *is* on the root graph you are viewing, says plainly that `panel_exit_subgraph` would only answer "already at root" and change nothing, and hands back the live ids to retarget with. The remedy that wasted a round-trip is no longer prescribed.
- **Lookup ran on a subgraph** → the `#697` exit remedy is preserved verbatim.

One supporting nit: the `"Current ids on the graph you are viewing: "` opening is now a named constant, because the new message has to ask whether that suffix actually *names* ids before offering it — on a root graph whose only node is the missing one it degrades to "has no nodes", which would contradict the sentence right before it.

## What is NOT claimed

This does not claim to eliminate the underlying `_nodes` / `_nodes_by_id` drift that made the lookup miss in the first place — the reporter's retry succeeding says it is transient, and I have no reproduction of its cause. What is fixed is that the panel no longer publishes a scope verdict it did not check, and no longer sends the caller round a loop that provably cannot help. If the drift itself is worth chasing, it deserves its own issue with a reproduction.

## Verification

- `node --test browser_tests/unit/*.test.mjs` → **5872 pass / 0 fail** (1 pre-existing todo).
- **Mutation 1** — delete the `searchedRoot` guard (restore the old unconditional message): **3 of the 4 new tests fail**. The 4th (a genuine subgraph view still gets the EXIT remedy) correctly stays green, since that path is unchanged.
- **Mutation 2** — keep the guard but drop identity precedence (`searchedRoot = Boolean(viewingRoot)`): the "graph the lookup SEARCHED outranks a separately-read viewingRoot" test fails. The precedence line is load-bearing on its own, not carried by the branch.
- `node scripts/check-tool-vocabulary.mjs` → OK (34 literals, 10 distinct, all valid).
- `node scripts/check-panel-scope.mjs` → OK (every name resolves).
- No `tr()` string added, so no i18n key/round-trip work.

**Browser suite:** not run. The change is confined to a pure string-building helper in `web/js/lib/node-scope-locator.js` with no DOM, canvas or render surface — it changes the text of a thrown error, which the unit suite covers directly and the call-site wiring test already pins at source. I am stating that rather than implying coverage I do not have.

---

**Gate disclosure:** codex was unavailable (account exhausted until 2026-08-19 20:43); gated by an independent adversarial review instead, per the authorised substitution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
