### PR TITLE
fix(608): the node-def refresh asks the raw /object_info route when the frontend client does not answer

### DIFF
--- a/browser_tests/unit/_panel-constants.mjs
+++ b/browser_tests/unit/_panel-constants.mjs
@@ -121,6 +121,16 @@ export const NODE_DEFS_FETCH_SHARE = (() => {
 })();
 
 /**
+ * #608 — the client route's share of the FETCH phase, read as the panel states it. A
+ * hardcoded 0.5 here would keep agreeing with itself after the panel moved the reserve,
+ * which is the trap this whole file exists for.
+ */
+export const NODE_DEFS_CLIENT_ROUTE_SHARE = readPanelNumber(
+  /const NODE_DEFS_CLIENT_ROUTE_SHARE = ([\d.]+);/,
+  "the client route's share of the fetch phase",
+);
+
+/**
  * The panel's sentinel for "this call did not answer", mirrored so a rebuilt executor
  * compares against the same value its injected `boundedGetNodeDefs` resolves.
  */

--- a/browser_tests/unit/_panel-constants.mjs
+++ b/browser_tests/unit/_panel-constants.mjs
@@ -121,16 +121,6 @@ export const NODE_DEFS_FETCH_SHARE = (() => {
 })();
 
 /**
- * #608 — the client route's share of the FETCH phase, read as the panel states it. A
- * hardcoded 0.5 here would keep agreeing with itself after the panel moved the reserve,
- * which is the trap this whole file exists for.
- */
-export const NODE_DEFS_CLIENT_ROUTE_SHARE = readPanelNumber(
-  /const NODE_DEFS_CLIENT_ROUTE_SHARE = ([\d.]+);/,
-  "the client route's share of the fetch phase",
-);
-
-/**
  * The panel's sentinel for "this call did not answer", mirrored so a rebuilt executor
  * compares against the same value its injected `boundedGetNodeDefs` resolves.
  */

--- a/browser_tests/unit/node-def-refresh.test.mjs
+++ b/browser_tests/unit/node-def-refresh.test.mjs
@@ -1504,6 +1504,18 @@ test("#608: the client route is capped at a SHARE of the fetch phase, so the fal
     armed[0].ms > clientShare * 0.8,
     `…nor be starved to a floor (saw ${armed[0].ms}ms of ${clientShare}ms)`,
   );
+  // THE RESERVE ITSELF, in absolute milliseconds, because the two assertions above are
+  // written against the share READ FROM THE PANEL and therefore move with it: restoring
+  // NODE_DEFS_CLIENT_ROUTE_SHARE to 1 kept both of them green while leaving the fallback a
+  // one-millisecond budget — the floor `nodeDefsBudgetLeft` returns for an exhausted one,
+  // which in this harness a synchronous double still beats and a real 5MB GET never would.
+  // 1,000ms is twice the ~450ms this repo has measured the raw route at, and the oracle
+  // halves whatever it is given between the response and the body.
+  const reserveMs = wholeFetchPhase - armed[0].ms;
+  assert.ok(
+    reserveMs >= 1000,
+    `the second route must be left a usable reserve, saw ${reserveMs}ms of ${wholeFetchPhase}ms`,
+  );
   timers.fireAll();
   await orFail(running, "the run never finished");
 });

--- a/browser_tests/unit/node-def-refresh.test.mjs
+++ b/browser_tests/unit/node-def-refresh.test.mjs
@@ -23,7 +23,6 @@ import { fetchWholeObjectInfo } from "../../web/js/lib/object-info-oracle.js";
 import {
   COMBO_NO_ANSWER,
   COMBO_OK,
-  NODE_DEFS_CLIENT_ROUTE_SHARE,
   NODE_DEFS_FETCH_SHARE,
   NODE_DEFS_FETCH_TIMEOUT_MS,
   NODE_DEFS_NO_ANSWER,
@@ -413,6 +412,8 @@ function buildRegisterComfyNodeDefs({
   now,
   recordObjectInfoTypes = () => ({}),
   reapplyDefsToLiveNodes = () => {},
+  // #608 — defaults to the REAL oracle. Overridden only to OBSERVE what it is handed.
+  fetchWholeObjectInfo: fetchWholeObjectInfoImpl = fetchWholeObjectInfo,
 }) {
   const body = extractFunction("async function registerComfyNodeDefs(");
   const factory = new Function(
@@ -433,10 +434,10 @@ function buildRegisterComfyNodeDefs({
     "NODE_DEFS_FETCH_TIMEOUT_MS",
     "NODE_DEFS_RUN_BUDGET_MS",
     "NODE_DEFS_FETCH_SHARE",
-    // #608 — the second transport and the reserve that reaches it. The REAL oracle, not a
-    // double: a stub would let this harness agree with itself about the one thing the
-    // fallback has to get right, which is asking a DIFFERENT route the same question.
-    "NODE_DEFS_CLIENT_ROUTE_SHARE",
+    // #608 — the second transport. The REAL oracle by default, not a double: a stub would
+    // let this harness agree with itself about the one thing the fallback has to get right,
+    // which is asking a DIFFERENT route the same question. A test that needs to OBSERVE the
+    // budget it is handed wraps it rather than replacing it.
     "fetchWholeObjectInfo",
     "nodeDefsBudgetLeft",
     "monotonicNow",
@@ -485,8 +486,7 @@ function buildRegisterComfyNodeDefs({
     NODE_DEFS_FETCH_TIMEOUT_MS,
     NODE_DEFS_RUN_BUDGET_MS,
     NODE_DEFS_FETCH_SHARE,
-    NODE_DEFS_CLIENT_ROUTE_SHARE,
-    fetchWholeObjectInfo,
+    fetchWholeObjectInfoImpl,
       // #1193 — ONE clock for the deadline and the arithmetic that reads it. The shared
     // helper reads the REAL monotonicNow; a fake-clock deadline measured against it is a
     // different bound than the one the panel arms (its own nodeDefsBudgetLeft shares the
@@ -1504,45 +1504,86 @@ test("#608: an EMPTY client answer is an ANSWER — the raw route is NOT consult
   assert.equal(fetchApiCalls, 0, "an empty schema is the client's answer, not an absence to route around");
 });
 
-test("#608: the client route is capped at a SHARE of the fetch phase, so the fallback is reachable", async () => {
-  // The reserve is the whole reason the second route gets asked at all: `withTimeout` does
-  // not cancel, so a client route granted the entire fetch phase leaves nothing behind it
-  // and the phase can only report how the first transport failed. Pinned on the ARMED
-  // bound, because a share that quietly returns to 1 passes every other test in this file.
+test("#608: a SLOW BACKEND still refreshes — the client route keeps its whole share", async () => {
+  // THE REGRESSION THIS FIX SHIPPED ONCE, and the reason the reserve is no longer taken
+  // out of the client route. Capping the client at half the fetch phase and calling the
+  // rest the second route's reserve couples two cases with opposite remedies: when the
+  // SLOW PARTY IS THE BACKEND, the raw route inherits the same latency and cannot rescue
+  // anything with the time the first route was just denied. Measured on the extracted run
+  // with the real oracle, an /object_info answering in 3,200 / 3,500 / 5,500 ms went from
+  // refreshed:true on the parent to object_info_fetch_failed — a new hard-failure band, and
+  // nodeDefsRefreshConfirmed false behind it.
+  //
+  // A FAKE CLOCK, so the grant is an exact number rather than a band: the harness drives
+  // the panel's own nodeDefsBudgetLeft off the same injected clock.
+  let clock = 0;
   const timers = virtualTimers();
+  let resolveClient = null;
+  let fetchApiCalls = 0;
   const { registerComfyNodeDefs } = buildRegisterComfyNodeDefs({
     appValue: FULL_APP,
-    apiValue: { getNodeDefs: () => new Promise(() => {}), fetchApi: async () => okResponse({ A: {} }) },
+    apiValue: {
+      getNodeDefs: () => new Promise((res) => { resolveClient = res; }),
+      fetchApi: async () => {
+        fetchApiCalls += 1;
+        return okResponse({ Raw: {} });
+      },
+    },
     timers,
+    now: () => clock,
   });
   const running = registerComfyNodeDefs(undefined);
   await drainMicrotasks(300);
   const armed = timers.armed();
-  assert.equal(armed.length, 1, "exactly the client route's attempt");
-  const wholeFetchPhase = NODE_DEFS_RUN_BUDGET_MS * NODE_DEFS_FETCH_SHARE;
-  const clientShare = wholeFetchPhase * NODE_DEFS_CLIENT_ROUTE_SHARE;
-  assert.ok(
-    armed[0].ms <= Math.ceil(clientShare),
-    `the client route must not be granted more than its share (${clientShare}ms), saw ${armed[0].ms}ms`,
+  assert.equal(armed.length, 1, "the client route's attempt must be bounded");
+  assert.equal(
+    armed[0].ms,
+    Math.floor(NODE_DEFS_RUN_BUDGET_MS * NODE_DEFS_FETCH_SHARE),
+    `the client route must keep the WHOLE fetch share, saw ${armed[0].ms}ms`,
   );
-  assert.ok(
-    armed[0].ms > clientShare * 0.8,
-    `…nor be starved to a floor (saw ${armed[0].ms}ms of ${clientShare}ms)`,
-  );
-  // THE RESERVE ITSELF, in absolute milliseconds, because the two assertions above are
-  // written against the share READ FROM THE PANEL and therefore move with it: restoring
-  // NODE_DEFS_CLIENT_ROUTE_SHARE to 1 kept both of them green while leaving the fallback a
-  // one-millisecond budget — the floor `nodeDefsBudgetLeft` returns for an exhausted one,
-  // which in this harness a synchronous double still beats and a real 5MB GET never would.
-  // 1,000ms is twice the ~450ms this repo has measured the raw route at, and the oracle
-  // halves whatever it is given between the response and the body.
-  const reserveMs = wholeFetchPhase - armed[0].ms;
-  assert.ok(
-    reserveMs >= 1000,
-    `the second route must be left a usable reserve, saw ${reserveMs}ms of ${wholeFetchPhase}ms`,
-  );
+  // It answers LATE but inside its grant. Every service time in the band the first attempt
+  // broke — 3,200ms, 3,500ms, 5,500ms of a 6,000ms bound — is this state.
+  clock = 5500;
+  resolveClient({ SomeNode: {} });
+  const verdict = await orFail(running, "a slow but healthy backend never finished");
+  assert.equal(verdict.refreshed, true, "a slow backend that ANSWERS must still refresh");
+  assert.equal(fetchApiCalls, 0, "the second route is for a route that FAILED, never for a slow one");
+});
+
+test("#608: the second route is handed what is LEFT OF THE RUN, not the share the first one spent", async () => {
+  // The fetch phase's own share has by definition been spent by the route that just failed,
+  // so sizing the fallback from it hands it the 1ms floor `nodeDefsBudgetLeft` returns for
+  // an exhausted budget — a bound only a synchronous double beats, never a real /object_info.
+  // The oracle then halves whatever it is given between the response and the body, and this
+  // repo measures the raw route at ~450ms, so anything under ~1s cannot answer.
+  let clock = 0;
+  const timers = virtualTimers();
+  let handedDeadlineMs = null;
+  const { registerComfyNodeDefs } = buildRegisterComfyNodeDefs({
+    appValue: FULL_APP,
+    apiValue: {
+      getNodeDefs: () => new Promise(() => {}), // never settles: the reported case
+      fetchApi: async () => okResponse({ Raw: {} }),
+    },
+    timers,
+    now: () => clock,
+    // WRAPS the real oracle rather than replacing it, so what is asserted is the budget the
+    // shipped call site computes, with the shipped oracle still doing the work.
+    fetchWholeObjectInfo: (opts) => {
+      handedDeadlineMs = opts.deadlineMs;
+      return fetchWholeObjectInfo(opts);
+    },
+  });
+  const running = registerComfyNodeDefs(undefined);
+  await drainMicrotasks(300);
+  clock = Math.floor(NODE_DEFS_RUN_BUDGET_MS * NODE_DEFS_FETCH_SHARE); // the stall burns its whole grant
   timers.fireAll();
-  await orFail(running, "the run never finished");
+  const verdict = await orFail(running, "the fallback never ran");
+  assert.equal(verdict.refreshed, true, "the raw route answered — the refresh succeeded");
+  assert.ok(
+    handedDeadlineMs >= 1000,
+    `the second route needs a usable budget, got ${handedDeadlineMs}ms`,
+  );
 });
 
 test("#608: when BOTH routes fail the refusal names both, and the detail is unchanged", async () => {
@@ -1623,8 +1664,17 @@ test("#608: the fallback is wired to the WHOLE-schema oracle, after the client r
   );
   assert.match(
     body,
-    /deadlineMs: nodeDefsBudgetLeft\(fetchPhaseDeadline\),/,
-    "the fallback draws on what is LEFT of the fetch phase, never a fresh constant",
+    /deadlineMs: nodeDefsBudgetLeft\(runDeadline\),/,
+    "the fallback draws on what is left of the RUN, never a fresh constant",
+  );
+  // …and specifically NOT the fetch phase's own share, which the route that just failed has
+  // by definition spent. That sizing is what shipped the (3,000ms, 6,000ms) hard-failure
+  // band, and it reads as obviously correct at the call site — so it is pinned as an
+  // ABSENCE too, which is the only way a wrong-but-plausible argument gets caught.
+  assert.doesNotMatch(
+    body,
+    /deadlineMs: nodeDefsBudgetLeft\(runDeadline, NODE_DEFS_FETCH_SHARE\)/,
+    "the second route must not be sized from the share the first route already spent",
   );
   // The rethrow must come AFTER the fallback, or the second route is unreachable for the
   // case that reported this — a client route that throws.

--- a/browser_tests/unit/node-def-refresh.test.mjs
+++ b/browser_tests/unit/node-def-refresh.test.mjs
@@ -1459,6 +1459,31 @@ test("#608: a client route that RESOLVES NOTHING falls through to the raw route"
   assert.equal(verdict.refreshed, true, "a client route that returned nothing left the question open");
 });
 
+test("#608: a client answer that is not a SCHEMA leaves the question open", async () => {
+  // The clauses beside `!defs`. `fetchNodeDefsWithRetry` hands back whatever unusable value
+  // it exhausted on, so an array or a primitive arrives here truthy — and `defsObtained` is
+  // `!!defs`, so the run would go on to register it and report refreshed:true over a payload
+  // that defines nothing. Only the REGISTERED payload can tell the two apart, which is why
+  // this asserts on that rather than on the verdict.
+  let fetched = null;
+  const { registerComfyNodeDefs } = buildRegisterComfyNodeDefs({
+    appValue: {
+      graph: null,
+      registerNodesFromDefs: async (defs) => {
+        fetched = defs;
+      },
+      refreshComboInNodes: async () => {},
+    },
+    apiValue: {
+      getNodeDefs: async () => ["not", "a", "schema"],
+      fetchApi: async () => okResponse({ SomeNode: {} }),
+    },
+  });
+  const verdict = await registerComfyNodeDefs(undefined);
+  assert.equal(verdict.refreshed, true);
+  assert.deepEqual(fetched, { SomeNode: {} }, "the array is not a schema — the raw route answered instead");
+});
+
 test("#608: an EMPTY client answer is an ANSWER — the raw route is NOT consulted", async () => {
   // The oracle's rule, mirrored deliberately: a client expressing deny-all as {} has
   // ANSWERED, and overruling it with a broader schema is the one direction this fallback

--- a/browser_tests/unit/node-def-refresh.test.mjs
+++ b/browser_tests/unit/node-def-refresh.test.mjs
@@ -16,12 +16,14 @@ import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 import { fetchNodeDefsWithRetry, OBJECT_INFO_RETRY_DELAYS_MS } from "../../web/js/lib/object-info-retry.js";
 import { withTimeout } from "../../web/js/lib/bounded-step.js";
+import { fetchWholeObjectInfo } from "../../web/js/lib/object-info-oracle.js";
 
 // #1180 — READ from the panel, never restated. Shared with the other harnesses that
 // rebuild shipped functions, so one copy of a constant cannot drift from another.
 import {
   COMBO_NO_ANSWER,
   COMBO_OK,
+  NODE_DEFS_CLIENT_ROUTE_SHARE,
   NODE_DEFS_FETCH_SHARE,
   NODE_DEFS_FETCH_TIMEOUT_MS,
   NODE_DEFS_NO_ANSWER,
@@ -431,6 +433,11 @@ function buildRegisterComfyNodeDefs({
     "NODE_DEFS_FETCH_TIMEOUT_MS",
     "NODE_DEFS_RUN_BUDGET_MS",
     "NODE_DEFS_FETCH_SHARE",
+    // #608 — the second transport and the reserve that reaches it. The REAL oracle, not a
+    // double: a stub would let this harness agree with itself about the one thing the
+    // fallback has to get right, which is asking a DIFFERENT route the same question.
+    "NODE_DEFS_CLIENT_ROUTE_SHARE",
+    "fetchWholeObjectInfo",
     "nodeDefsBudgetLeft",
     "monotonicNow",
     "NODE_DEFS_RETRY_DELAYS_MS",
@@ -478,6 +485,8 @@ function buildRegisterComfyNodeDefs({
     NODE_DEFS_FETCH_TIMEOUT_MS,
     NODE_DEFS_RUN_BUDGET_MS,
     NODE_DEFS_FETCH_SHARE,
+    NODE_DEFS_CLIENT_ROUTE_SHARE,
+    fetchWholeObjectInfo,
       // #1193 — ONE clock for the deadline and the arithmetic that reads it. The shared
     // helper reads the REAL monotonicNow; a fake-clock deadline measured against it is a
     // different bound than the one the panel arms (its own nodeDefsBudgetLeft shares the
@@ -1360,4 +1369,229 @@ test("#1180: a combo refresh that rejects with a FALSY value is still a failure"
     "registration succeeded here — blaming it is the defect this phase guard exists to prevent",
   );
   assert.equal(getConfirmed(), false, "an unrefreshed combo list must not be trusted");
+});
+
+// ---------------------------------------------------------------------------
+// #608 — the fetch phase's SECOND transport
+//
+// Reported on comfyui-mcp 0.52.26 / ComfyUI 0.33.0 / frontend 1.49.6: after installing
+// custom nodes and restarting, panel_refresh_nodes returned object_info_fetch_failed —
+// "api.getNodeDefs() did not answer within this refresh's remaining budget" — repeatedly,
+// while the same /object_info was being served to a different transport at that moment.
+// `lib/object-info-oracle.js` has asked a second route since #982 and `graph_get_object_info`
+// uses it; this refresh had one route and no way to ask again.
+//
+// Driven through the EXTRACTED shipping function with the REAL oracle, so deleting the
+// fallback from the panel fails these rather than a re-implementation of it.
+// ---------------------------------------------------------------------------
+
+/** A Response-like double for `api.fetchApi("/object_info")`, built from a real shape. */
+const okResponse = (defs) => ({ ok: true, status: 200, json: async () => defs });
+
+test("#608: a client route that NEVER ANSWERS falls through to the raw route", async () => {
+  // The reported failure exactly: getNodeDefs does not throw, it simply never settles.
+  // Before the fallback this ended the command with object_info_fetch_failed.
+  const timers = virtualTimers();
+  let fetched = null;
+  const { registerComfyNodeDefs, getConfirmed } = buildRegisterComfyNodeDefs({
+    appValue: {
+      graph: null,
+      registerNodesFromDefs: async (defs) => {
+        fetched = defs;
+      },
+      refreshComboInNodes: async () => {},
+    },
+    apiValue: {
+      getNodeDefs: () => new Promise(() => {}),
+      fetchApi: async (route) => {
+        assert.equal(route, "/object_info", "the WHOLE schema, never the per-class route");
+        return okResponse({ FreshlyInstalledNode: {} });
+      },
+    },
+    timers,
+  });
+  const running = registerComfyNodeDefs(undefined);
+  await drainMicrotasks(300);
+  assert.equal(timers.armed().length, 1, "the client route's attempt must be bounded");
+  timers.fireAll();
+  const verdict = await orFail(running, "the fetch phase never reached its second route");
+
+  assert.equal(verdict.refreshed, true, "the raw route answered — the refresh succeeded");
+  assert.deepEqual(fetched, { FreshlyInstalledNode: {} }, "…and the FALLBACK payload is what got registered");
+  assert.equal(getConfirmed(), true);
+});
+
+test("#608: a client route that THREW falls through to the raw route", async () => {
+  // #982's own shape: the frontend client fails where the HTTP route does not.
+  let fetched = null;
+  const { registerComfyNodeDefs } = buildRegisterComfyNodeDefs({
+    appValue: {
+      graph: null,
+      registerNodesFromDefs: async (defs) => {
+        fetched = defs;
+      },
+      refreshComboInNodes: async () => {},
+    },
+    apiValue: {
+      getNodeDefs: async () => {
+        throw new TypeError("Failed to fetch");
+      },
+      fetchApi: async () => okResponse({ SomeNode: {} }),
+    },
+  });
+  const verdict = await registerComfyNodeDefs(undefined);
+  assert.equal(verdict.refreshed, true);
+  assert.deepEqual(fetched, { SomeNode: {} });
+});
+
+test("#608: a client route that RESOLVES NOTHING falls through to the raw route", async () => {
+  // `fetchNodeDefsWithRetry` hands back the unusable value rather than throwing when it
+  // exhausts on one, so this arrives at the fallback WITHOUT a caught error — a separate
+  // path from the two above, and the one that used to produce object_info_unavailable.
+  const { registerComfyNodeDefs } = buildRegisterComfyNodeDefs({
+    appValue: FULL_APP,
+    apiValue: {
+      getNodeDefs: async () => null,
+      fetchApi: async () => okResponse({ SomeNode: {} }),
+    },
+  });
+  const verdict = await registerComfyNodeDefs(undefined);
+  assert.equal(verdict.refreshed, true, "a client route that returned nothing left the question open");
+});
+
+test("#608: an EMPTY client answer is an ANSWER — the raw route is NOT consulted", async () => {
+  // The oracle's rule, mirrored deliberately: a client expressing deny-all as {} has
+  // ANSWERED, and overruling it with a broader schema is the one direction this fallback
+  // must never move — the payload also feeds the #458 ever-seen trust root and the #1223
+  // whole-schema snapshot. Only a route that threw or returned NOTHING may be asked again.
+  let fetchApiCalls = 0;
+  const { registerComfyNodeDefs } = buildRegisterComfyNodeDefs({
+    appValue: FULL_APP,
+    apiValue: {
+      getNodeDefs: async () => ({}),
+      fetchApi: async () => {
+        fetchApiCalls += 1;
+        return okResponse({ SomeNode: {} });
+      },
+    },
+  });
+  await registerComfyNodeDefs(undefined);
+  assert.equal(fetchApiCalls, 0, "an empty schema is the client's answer, not an absence to route around");
+});
+
+test("#608: the client route is capped at a SHARE of the fetch phase, so the fallback is reachable", async () => {
+  // The reserve is the whole reason the second route gets asked at all: `withTimeout` does
+  // not cancel, so a client route granted the entire fetch phase leaves nothing behind it
+  // and the phase can only report how the first transport failed. Pinned on the ARMED
+  // bound, because a share that quietly returns to 1 passes every other test in this file.
+  const timers = virtualTimers();
+  const { registerComfyNodeDefs } = buildRegisterComfyNodeDefs({
+    appValue: FULL_APP,
+    apiValue: { getNodeDefs: () => new Promise(() => {}), fetchApi: async () => okResponse({ A: {} }) },
+    timers,
+  });
+  const running = registerComfyNodeDefs(undefined);
+  await drainMicrotasks(300);
+  const armed = timers.armed();
+  assert.equal(armed.length, 1, "exactly the client route's attempt");
+  const wholeFetchPhase = NODE_DEFS_RUN_BUDGET_MS * NODE_DEFS_FETCH_SHARE;
+  const clientShare = wholeFetchPhase * NODE_DEFS_CLIENT_ROUTE_SHARE;
+  assert.ok(
+    armed[0].ms <= Math.ceil(clientShare),
+    `the client route must not be granted more than its share (${clientShare}ms), saw ${armed[0].ms}ms`,
+  );
+  assert.ok(
+    armed[0].ms > clientShare * 0.8,
+    `…nor be starved to a floor (saw ${armed[0].ms}ms of ${clientShare}ms)`,
+  );
+  timers.fireAll();
+  await orFail(running, "the run never finished");
+});
+
+test("#608: when BOTH routes fail the refusal names both, and the detail is unchanged", async () => {
+  // The message half. "check that the ComfyUI server process is still running" stood on the
+  // evidence of ONE route, and the reported install had a healthy server answering another
+  // transport at that same moment. The rethrow is deliberately the client route's own
+  // error, so the detail and the phase attribution are exactly what they were before.
+  const { registerComfyNodeDefs } = buildRegisterComfyNodeDefs({
+    appValue: FULL_APP,
+    apiValue: {
+      getNodeDefs: async () => {
+        throw new TypeError("Failed to fetch");
+      },
+      fetchApi: async () => ({ ok: false, status: 500, json: async () => ({}) }),
+    },
+  });
+  const verdict = await registerComfyNodeDefs(undefined);
+  assert.equal(verdict.reason, "object_info_fetch_failed");
+  assert.match(verdict.detail, /Failed to fetch/, "the client route's own error still words the detail");
+  assert.match(verdict.remedy, /Tried 2 routes/, "both transports are named");
+  assert.match(verdict.remedy, /api\.getNodeDefs\(\) failed: Failed to fetch/);
+  assert.match(verdict.remedy, /GET \/object_info was not OK \(status 500\)/);
+});
+
+test("#608: with no route returning anything, the unavailable verdict names them too", async () => {
+  const { registerComfyNodeDefs } = buildRegisterComfyNodeDefs({
+    appValue: FULL_APP,
+    apiValue: {
+      getNodeDefs: async () => null,
+      fetchApi: async () => ({ ok: false, status: 404, json: async () => ({}) }),
+    },
+  });
+  const verdict = await registerComfyNodeDefs(undefined);
+  assert.equal(verdict.reason, "object_info_unavailable");
+  assert.match(verdict.remedy, /Tried 2 routes/);
+  assert.match(verdict.remedy, /returned no usable schema/, "the client route's outcome, not a fabricated throw");
+  assert.match(verdict.remedy, /status 404/);
+});
+
+test("#608: the verdict prints nothing extra when no routes were recorded", () => {
+  // A caller that does not pass `fetchRouteFailures` must read exactly as it did before,
+  // or every unrelated refusal gains a hollow clause.
+  const before = describeNodeDefRefresh({
+    appAvailable: true,
+    defsObtained: false,
+    comboApiPresent: true,
+    comboRan: false,
+    phase: "fetch",
+    didThrow: true,
+    thrown: new Error("boom"),
+  });
+  assert.doesNotMatch(before.remedy, /Tried /);
+  const after = describeNodeDefRefresh({
+    appAvailable: true,
+    defsObtained: false,
+    comboApiPresent: true,
+    comboRan: false,
+    phase: "fetch",
+    didThrow: true,
+    thrown: new Error("boom"),
+    fetchRouteFailures: ["route one did nothing", "route two did nothing"],
+  });
+  assert.match(after.remedy, /Tried 2 routes: route one did nothing; route two did nothing\./);
+});
+
+test("#608: the fallback is wired to the WHOLE-schema oracle, after the client route", async () => {
+  // Source-level, because two properties here are invisible to behaviour: that the second
+  // route is the shared oracle rather than a hand-rolled fetch (a second timeout helper is
+  // how this repo keeps producing near-duplicate bugs), and that the client route is not
+  // handed to it a second time — which would spend the reserve on the transport that just
+  // failed.
+  const body = extractFunction("async function registerComfyNodeDefs(");
+  assert.match(body, /await fetchWholeObjectInfo\(\{/, "the shared oracle, not a second fetch helper");
+  assert.match(
+    body,
+    /getNodeDefs: null,/,
+    "the client route is NOT re-asked — the retry loop above already is that route",
+  );
+  assert.match(
+    body,
+    /deadlineMs: nodeDefsBudgetLeft\(fetchPhaseDeadline\),/,
+    "the fallback draws on what is LEFT of the fetch phase, never a fresh constant",
+  );
+  // The rethrow must come AFTER the fallback, or the second route is unreachable for the
+  // case that reported this — a client route that throws.
+  const fallbackAt = body.indexOf("await fetchWholeObjectInfo({");
+  const rethrowAt = body.indexOf("if (clientRouteThrew) throw clientRouteError;");
+  assert.ok(fallbackAt > -1 && rethrowAt > fallbackAt, "the client route's error is rethrown only after the retry");
 });

--- a/browser_tests/unit/refresh-graph-guard.test.mjs
+++ b/browser_tests/unit/refresh-graph-guard.test.mjs
@@ -43,7 +43,6 @@ import { REFRESH_NODES_EXECUTOR_DEPS } from "./_panel-constants.mjs";
 import {
   COMBO_NO_ANSWER,
   COMBO_OK,
-  NODE_DEFS_CLIENT_ROUTE_SHARE,
   NODE_DEFS_FETCH_SHARE,
   NODE_DEFS_FETCH_TIMEOUT_MS,
   NODE_DEFS_NO_ANSWER,
@@ -239,9 +238,8 @@ function buildRegisterComfyNodeDefs({ appValue, apiValue }) {
     "NODE_DEFS_FETCH_TIMEOUT_MS",
     "NODE_DEFS_RUN_BUDGET_MS",
     "NODE_DEFS_FETCH_SHARE",
-    // #608 — the second transport the fetch phase falls through to, and the reserve that
-    // reaches it. Real, for the reason node-def-refresh.test.mjs states at its own copy.
-    "NODE_DEFS_CLIENT_ROUTE_SHARE",
+    // #608 — the second transport the fetch phase falls through to. The REAL oracle, for
+    // the reason node-def-refresh.test.mjs states at its own copy.
     "fetchWholeObjectInfo",
     "nodeDefsBudgetLeft",
     "monotonicNow",
@@ -290,7 +288,6 @@ function buildRegisterComfyNodeDefs({ appValue, apiValue }) {
     NODE_DEFS_FETCH_TIMEOUT_MS,
     NODE_DEFS_RUN_BUDGET_MS,
     NODE_DEFS_FETCH_SHARE,
-    NODE_DEFS_CLIENT_ROUTE_SHARE,
     fetchWholeObjectInfo,
       nodeDefsBudgetLeft,
     monotonicNow,

--- a/browser_tests/unit/refresh-graph-guard.test.mjs
+++ b/browser_tests/unit/refresh-graph-guard.test.mjs
@@ -38,10 +38,12 @@ import {
 } from "../../web/js/lib/node-def-refresh.js";
 import { fetchNodeDefsWithRetry, OBJECT_INFO_RETRY_DELAYS_MS } from "../../web/js/lib/object-info-retry.js";
 import { withTimeout } from "../../web/js/lib/bounded-step.js";
+import { fetchWholeObjectInfo } from "../../web/js/lib/object-info-oracle.js";
 import { REFRESH_NODES_EXECUTOR_DEPS } from "./_panel-constants.mjs";
 import {
   COMBO_NO_ANSWER,
   COMBO_OK,
+  NODE_DEFS_CLIENT_ROUTE_SHARE,
   NODE_DEFS_FETCH_SHARE,
   NODE_DEFS_FETCH_TIMEOUT_MS,
   NODE_DEFS_NO_ANSWER,
@@ -237,6 +239,10 @@ function buildRegisterComfyNodeDefs({ appValue, apiValue }) {
     "NODE_DEFS_FETCH_TIMEOUT_MS",
     "NODE_DEFS_RUN_BUDGET_MS",
     "NODE_DEFS_FETCH_SHARE",
+    // #608 — the second transport the fetch phase falls through to, and the reserve that
+    // reaches it. Real, for the reason node-def-refresh.test.mjs states at its own copy.
+    "NODE_DEFS_CLIENT_ROUTE_SHARE",
+    "fetchWholeObjectInfo",
     "nodeDefsBudgetLeft",
     "monotonicNow",
     "NODE_DEFS_RETRY_DELAYS_MS",
@@ -284,6 +290,8 @@ function buildRegisterComfyNodeDefs({ appValue, apiValue }) {
     NODE_DEFS_FETCH_TIMEOUT_MS,
     NODE_DEFS_RUN_BUDGET_MS,
     NODE_DEFS_FETCH_SHARE,
+    NODE_DEFS_CLIENT_ROUTE_SHARE,
+    fetchWholeObjectInfo,
       nodeDefsBudgetLeft,
     monotonicNow,
     NODE_DEFS_RETRY_DELAYS_MS,

--- a/browser_tests/unit/single-node-def.test.mjs
+++ b/browser_tests/unit/single-node-def.test.mjs
@@ -318,25 +318,21 @@ test("#1180: a whole refresh RUN, not each phase, is what fits the budget", () =
     giveBack < src.indexOf('phase = "combo";', localStart),
     "…and be handed back BEFORE the combo phase reads what is left",
   );
-  // #608 split the fetch phase between TWO transports, so the one property this used to
-  // pin is now pinned in three: the phase draws its budget from the RUN deadline, the
-  // client route gets a SHARE of that phase (the rest is the reserve the raw /object_info
-  // route is asked with), and the bound actually armed is what is left of the client
-  // route's own deadline. A constant substituted at any of the three fails here.
+  // #608 added a SECOND transport to this phase and deliberately left this bound ALONE.
+  // The client route still gets the whole fetch share, so no install that refreshed before
+  // can stop refreshing; the fallback draws on what is left of the RUN instead. Taking the
+  // reserve out of THIS grant was tried and shipped a (3,000ms, 6,000ms) hard-failure band
+  // for a merely slow BACKEND, where the second route inherits the same latency and so
+  // cannot rescue anything with the time the first route was just denied.
   assert.match(
     src,
-    /const fetchPhaseBudgetMs = nodeDefsBudgetLeft\(runDeadline, NODE_DEFS_FETCH_SHARE\);/,
-    "the fetch phase must draw its budget from the run deadline",
+    /boundedGetNodeDefs\(nodeDefsBudgetLeft\(runDeadline, NODE_DEFS_FETCH_SHARE\)\)/,
+    "the fetch phase must draw its bound from the run deadline",
   );
   assert.match(
     src,
-    /fetchPhaseStartedAt \+ Math\.max\(1, Math\.floor\(fetchPhaseBudgetMs \* NODE_DEFS_CLIENT_ROUTE_SHARE\)\)/,
-    "the client route takes a share of the phase, so the second transport keeps a reserve",
-  );
-  assert.match(
-    src,
-    /boundedGetNodeDefs\(nodeDefsBudgetLeft\(clientRouteDeadline\)\)/,
-    "…and the bound actually armed is what is left of the client route's deadline",
+    /deadlineMs: nodeDefsBudgetLeft\(runDeadline\),/,
+    "the second route draws on the RUN remainder, not on the share the first route spent",
   );
   // #1193 read the bound into a variable so the refusal can name it. The property this
   // pins is unchanged and now pinned in two halves: the bound is COMPUTED from what the

--- a/browser_tests/unit/single-node-def.test.mjs
+++ b/browser_tests/unit/single-node-def.test.mjs
@@ -318,10 +318,25 @@ test("#1180: a whole refresh RUN, not each phase, is what fits the budget", () =
     giveBack < src.indexOf('phase = "combo";', localStart),
     "…and be handed back BEFORE the combo phase reads what is left",
   );
+  // #608 split the fetch phase between TWO transports, so the one property this used to
+  // pin is now pinned in three: the phase draws its budget from the RUN deadline, the
+  // client route gets a SHARE of that phase (the rest is the reserve the raw /object_info
+  // route is asked with), and the bound actually armed is what is left of the client
+  // route's own deadline. A constant substituted at any of the three fails here.
   assert.match(
     src,
-    /boundedGetNodeDefs\(nodeDefsBudgetLeft\(runDeadline, NODE_DEFS_FETCH_SHARE\)\)/,
-    "the fetch phase must draw its bound from the run deadline",
+    /const fetchPhaseBudgetMs = nodeDefsBudgetLeft\(runDeadline, NODE_DEFS_FETCH_SHARE\);/,
+    "the fetch phase must draw its budget from the run deadline",
+  );
+  assert.match(
+    src,
+    /fetchPhaseStartedAt \+ Math\.max\(1, Math\.floor\(fetchPhaseBudgetMs \* NODE_DEFS_CLIENT_ROUTE_SHARE\)\)/,
+    "the client route takes a share of the phase, so the second transport keeps a reserve",
+  );
+  assert.match(
+    src,
+    /boundedGetNodeDefs\(nodeDefsBudgetLeft\(clientRouteDeadline\)\)/,
+    "…and the bound actually armed is what is left of the client route's deadline",
   );
   // #1193 read the bound into a variable so the refusal can name it. The property this
   // pins is unchanged and now pinned in two halves: the bound is COMPUTED from what the

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -1082,6 +1082,38 @@ const NODE_DEFS_RUN_BUDGET_MS = 9000;
  * A share, not a second constant, so the two cannot be changed into disagreement.
  */
 const NODE_DEFS_FETCH_SHARE = 2 / 3;
+/**
+ * #608 — the share of the FETCH phase the FRONTEND CLIENT route may consume, so the second
+ * transport underneath it is always left something to ask with.
+ *
+ * REPORTED on comfyui-mcp 0.52.26 / ComfyUI 0.33.0 / frontend 1.49.6, after installing
+ * custom nodes and restarting: `panel_refresh_nodes` returned `refreshed:false` /
+ * `object_info_fetch_failed` with "api.getNodeDefs() did not answer within this refresh's
+ * remaining budget", REPEATEDLY, while the same /object_info document was being served fine
+ * to a different transport at the same moment. That rules out a slow BACKEND — a document
+ * the server cannot produce in time is slow for every reader — and leaves the client route
+ * specifically, which is the exact failure `lib/object-info-oracle.js` was written for in
+ * #982 and bounded for in #1161.
+ *
+ * The asymmetry this closes: `graph_get_object_info` asks that oracle and therefore has a
+ * second route, and this refresh — the tool whose whole job is to make a freshly installed
+ * pack selectable — had only one. So the panel refused a question it could already answer.
+ *
+ * WHY NOT SIMPLY A BIGGER BUDGET. That was the other candidate and the evidence excludes
+ * it. A bound can only choose HOW to fail against a route that never settles (#1178,
+ * three attempts), the run budget is sized against the composition two serialized runs make
+ * inside the bridge's read default (NODE_DEFS_RUN_BUDGET_MS), and the reporter's own
+ * corroboration is a route that answered PROMPTLY while this one did not answer at all.
+ * Raising the number spends longer on the transport that is not working.
+ *
+ * A HALF, mirroring the oracle's own CLIENT_ROUTE_SHARE rather than inventing a second
+ * answer to the same question. What it costs is stated there and is the same here: an
+ * install whose client route is merely SLOW — between half the fetch phase and all of it —
+ * is now overridden by the raw route instead of waited on. That route measures ~450ms
+ * against this rig's 5.4MB document, so the run still succeeds; what changes is which
+ * transport served it.
+ */
+const NODE_DEFS_CLIENT_ROUTE_SHARE = 0.5;
 //
 // #954's SCHEDULE, UNFORKED. An earlier pass here cut it to a single 200ms delay, reasoning
 // that a bound which does not cancel lets three abandoned attempts download the whole
@@ -1346,6 +1378,11 @@ async function registerComfyNodeDefs(preloadedDefs) {
   // can never be filed under post-restart provenance.
   const runStartedAtEpoch = backendReconnectEpoch;
   let thrown = null;
+  // #608 — what EACH transport did in the fetch phase, in order, when none of them produced
+  // a payload. The verdict appends it, so a refusal names the routes that were actually
+  // tried instead of leaving "check that the ComfyUI server process is still running" to
+  // stand on the evidence of one route out of two (#982's own defect, and #954's).
+  let fetchRouteFailures = null;
   // Tracked separately from the caught VALUE: a library can throw a FALSY value
   // (throw null / 0 / "") and `if (thrown)` would then read a failed run as a
   // clean one — misattributing the verdict and, worse, setting the shared
@@ -1427,36 +1464,144 @@ async function registerComfyNodeDefs(preloadedDefs) {
       // is deliberately a REAL one when there was one — so the value cannot be asked which
       // kind of failure it represents without undoing that.
       let lastAttemptTimedOut = false;
-      defs = await fetchNodeDefsWithRetry(
-        async () => {
-          // Unreachable as written — `shouldRetry` ends the loop on the first timeout, so
-          // this can never be observed true on entry. Kept because it is the invariant that
-          // makes the flag safe, not a consequence of it: a future `shouldRetry` that
-          // permits one retry after a stall would, without this line, mark every later
-          // attempt as timed out and stop the loop for a reason that had already passed.
-          lastAttemptTimedOut = false;
-          let result;
-          try {
-            result = await boundedGetNodeDefs(nodeDefsBudgetLeft(runDeadline, NODE_DEFS_FETCH_SHARE));
-          } catch (err) {
-            sawRealError = true;
-            lastRealError = err;
-            throw err;
+      // #608 — THE FETCH PHASE IS TWO ROUTES, so its budget is divided BEFORE either runs.
+      //
+      // Divided rather than shared, for the reason the oracle's own accounting states: the
+      // client route does not cancel when it is abandoned, so a route granted the whole
+      // phase leaves the second one nothing and the phase can only report how the first
+      // failed. The client route's grant comes off THIS deadline rather than the run's, so
+      // the reserve cannot be spent by a retry schedule either.
+      const fetchPhaseBudgetMs = nodeDefsBudgetLeft(runDeadline, NODE_DEFS_FETCH_SHARE);
+      const fetchPhaseStartedAt = monotonicNow();
+      const fetchPhaseDeadline = fetchPhaseStartedAt + fetchPhaseBudgetMs;
+      const clientRouteDeadline =
+        fetchPhaseStartedAt + Math.max(1, Math.floor(fetchPhaseBudgetMs * NODE_DEFS_CLIENT_ROUTE_SHARE));
+      // The client route's failure is HELD, not propagated, so the second route is reached
+      // at all — and rethrown UNCHANGED if that one fails too, so the verdict's `detail`
+      // and the attribution above it are exactly what they were before this fallback
+      // existed. A stall must not become a vaguer failure on the way to a second attempt.
+      let clientRouteThrew = false;
+      let clientRouteError = null;
+      try {
+        defs = await fetchNodeDefsWithRetry(
+          async () => {
+            // Unreachable as written — `shouldRetry` ends the loop on the first timeout, so
+            // this can never be observed true on entry. Kept because it is the invariant that
+            // makes the flag safe, not a consequence of it: a future `shouldRetry` that
+            // permits one retry after a stall would, without this line, mark every later
+            // attempt as timed out and stop the loop for a reason that had already passed.
+            lastAttemptTimedOut = false;
+            let result;
+            try {
+              result = await boundedGetNodeDefs(nodeDefsBudgetLeft(clientRouteDeadline));
+            } catch (err) {
+              sawRealError = true;
+              lastRealError = err;
+              throw err;
+            }
+            if (result === NODE_DEFS_NO_ANSWER) {
+              lastAttemptTimedOut = true;
+              if (sawRealError) throw lastRealError;
+              throw new Error("api.getNodeDefs() did not answer within this refresh's remaining budget");
+            }
+            return result;
+          },
+          {
+            delays: NODE_DEFS_RETRY_DELAYS_MS,
+            // An abandoned attempt is still downloading the whole document. Retrying it races
+            // the retry against its own predecessor; an instantly-refused one costs nothing.
+            shouldRetry: () => !lastAttemptTimedOut,
+          },
+        );
+      } catch (err) {
+        clientRouteThrew = true;
+        clientRouteError = err;
+        defs = null;
+      }
+      // #608 — THE SECOND TRANSPORT, on the terms #982 set and #1161 bounded.
+      //
+      // Same question, different route: the WHOLE document, never the per-class
+      // `/object_info/<Type>` one — the oracle's header says why that is not
+      // interchangeable, and this path feeds `objectInfoSnapshot.record(..., whole: true)`,
+      // which is exactly the reader a single-class payload would poison.
+      //
+      // AN EMPTY `{}` IS AN ANSWER, NOT AN ABSENCE, and this mirrors the oracle rather than
+      // `objectInfoLooksTransient`, which the two modules genuinely disagree about. A client
+      // expressing deny-all as an empty map has ANSWERED, and consulting the raw route would
+      // overrule it with a broader schema — the one direction a fallback must never move,
+      // because this payload also feeds the #458 ever-seen trust root. So only a route that
+      // THREW or returned NOTHING (null/undefined/a non-object) leaves the question open,
+      // and only that is asked again here. An empty map keeps the behaviour it has always
+      // had on this path.
+      //
+      // `Object.keys` is deliberately not consulted: it invokes a Proxy's ownKeys trap and
+      // can throw, and this classification sits outside the oracle's guards.
+      //
+      // A FRONTEND WITH NO `getNodeDefs` AT ALL still reports object_info_unavailable and is
+      // NOT rescued here — the outer guard is unchanged. That is a real gap and it is left
+      // open deliberately: nothing has reported it, the reported install has the client
+      // route and it is the one that fails, and widening the entry condition would change
+      // what a build without the API is told on evidence nobody has.
+      if (clientRouteThrew || !defs || typeof defs !== "object" || Array.isArray(defs)) {
+        const {
+          defs: fallbackDefs,
+          failures: fallbackFailures,
+          outcomes: fallbackOutcomes,
+        } = await fetchWholeObjectInfo({
+          // ALREADY ASKED. The loop above IS the client route — with this path's own retry
+          // schedule, its bound and its error attribution — so handing it to the oracle
+          // again would spend the reserve on the transport that just failed.
+          getNodeDefs: null,
+          // `api.fetchApi` defaults to `cache: "no-cache"` (read from the shipped client,
+          // comfyui-frontend-package 1.48.7 on this rig), where `getNodeDefs` overrides it
+          // to `no-store`. Both revalidate with the server, so this cannot answer a REFRESH
+          // out of the HTTP cache with the pre-install schema — which would be worse than
+          // failing, since it would report refreshed:true over the definitions the caller
+          // just installed a pack to replace.
+          fetchApi: typeof api?.fetchApi === "function" ? (route) => api.fetchApi(route) : null,
+          deadlineMs: nodeDefsBudgetLeft(fetchPhaseDeadline),
+        });
+        if (fallbackDefs) {
+          // The question is answered. The run continues exactly as it would have on a
+          // client-route success — recorded, snapshotted, registered, reapplied — because
+          // the fallback changes the transport and never the question.
+          defs = fallbackDefs;
+          clientRouteThrew = false;
+          clientRouteError = null;
+        } else {
+          // Neither route produced a payload. Record what each one did so the verdict can
+          // say it: the client route's sentence is built HERE because the oracle was handed
+          // no client transport and would otherwise report one it never had, and the http
+          // entries are selected by their TAG, never by matching their prose (#1223).
+          let clientSentence = "api.getNodeDefs() returned no usable schema";
+          if (clientRouteThrew) {
+            // Reading `.message` — and `String()` — off a thrown value can itself throw
+            // (a getter-backed subclass, a hostile toString), and this is a diagnostic
+            // path in a function whose callers await it without a catch of their own.
+            let raw = "";
+            try {
+              raw =
+                clientRouteError instanceof Error
+                  ? clientRouteError.message
+                  : clientRouteError == null
+                    ? ""
+                    : String(clientRouteError);
+            } catch {
+              raw = "(an unprintable value)";
+            }
+            clientSentence = raw ? `api.getNodeDefs() failed: ${raw}` : "api.getNodeDefs() failed";
           }
-          if (result === NODE_DEFS_NO_ANSWER) {
-            lastAttemptTimedOut = true;
-            if (sawRealError) throw lastRealError;
-            throw new Error("api.getNodeDefs() did not answer within this refresh's remaining budget");
-          }
-          return result;
-        },
-        {
-          delays: NODE_DEFS_RETRY_DELAYS_MS,
-          // An abandoned attempt is still downloading the whole document. Retrying it races
-          // the retry against its own predecessor; an instantly-refused one costs nothing.
-          shouldRetry: () => !lastAttemptTimedOut,
-        },
-      );
+          fetchRouteFailures = [
+            clientSentence,
+            ...(Array.isArray(fallbackFailures) ? fallbackFailures : []).filter(
+              (_, i) => fallbackOutcomes?.[i]?.route === "http",
+            ),
+          ];
+        }
+      }
+      // Rethrown here rather than at the catch, so the phase attribution, the verdict's
+      // reason and its detail are untouched for the case where both routes failed.
+      if (clientRouteThrew) throw clientRouteError;
     }
     // Record observed backend history (#458 trust root) — covers reconnect, the forced
     // refresh_nodes path, add_node payloads, and download-triggered refreshes.
@@ -1749,6 +1894,9 @@ async function registerComfyNodeDefs(preloadedDefs) {
     phase,
     didThrow,
     thrown,
+    // #608 — what every transport in the fetch phase did, so a refusal about /object_info
+    // names the routes it actually tried.
+    fetchRouteFailures,
   });
   // #1275 — VERIFY the refresh was ADDITIVE over the live graph.
   //

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -1082,38 +1082,6 @@ const NODE_DEFS_RUN_BUDGET_MS = 9000;
  * A share, not a second constant, so the two cannot be changed into disagreement.
  */
 const NODE_DEFS_FETCH_SHARE = 2 / 3;
-/**
- * #608 — the share of the FETCH phase the FRONTEND CLIENT route may consume, so the second
- * transport underneath it is always left something to ask with.
- *
- * REPORTED on comfyui-mcp 0.52.26 / ComfyUI 0.33.0 / frontend 1.49.6, after installing
- * custom nodes and restarting: `panel_refresh_nodes` returned `refreshed:false` /
- * `object_info_fetch_failed` with "api.getNodeDefs() did not answer within this refresh's
- * remaining budget", REPEATEDLY, while the same /object_info document was being served fine
- * to a different transport at the same moment. That rules out a slow BACKEND — a document
- * the server cannot produce in time is slow for every reader — and leaves the client route
- * specifically, which is the exact failure `lib/object-info-oracle.js` was written for in
- * #982 and bounded for in #1161.
- *
- * The asymmetry this closes: `graph_get_object_info` asks that oracle and therefore has a
- * second route, and this refresh — the tool whose whole job is to make a freshly installed
- * pack selectable — had only one. So the panel refused a question it could already answer.
- *
- * WHY NOT SIMPLY A BIGGER BUDGET. That was the other candidate and the evidence excludes
- * it. A bound can only choose HOW to fail against a route that never settles (#1178,
- * three attempts), the run budget is sized against the composition two serialized runs make
- * inside the bridge's read default (NODE_DEFS_RUN_BUDGET_MS), and the reporter's own
- * corroboration is a route that answered PROMPTLY while this one did not answer at all.
- * Raising the number spends longer on the transport that is not working.
- *
- * A HALF, mirroring the oracle's own CLIENT_ROUTE_SHARE rather than inventing a second
- * answer to the same question. What it costs is stated there and is the same here: an
- * install whose client route is merely SLOW — between half the fetch phase and all of it —
- * is now overridden by the raw route instead of waited on. That route measures ~450ms
- * against this rig's 5.4MB document, so the run still succeeds; what changes is which
- * transport served it.
- */
-const NODE_DEFS_CLIENT_ROUTE_SHARE = 0.5;
 //
 // #954's SCHEDULE, UNFORKED. An earlier pass here cut it to a single 200ms delay, reasoning
 // that a bound which does not cancel lets three abandoned attempts download the whole
@@ -1464,18 +1432,44 @@ async function registerComfyNodeDefs(preloadedDefs) {
       // is deliberately a REAL one when there was one — so the value cannot be asked which
       // kind of failure it represents without undoing that.
       let lastAttemptTimedOut = false;
-      // #608 — THE FETCH PHASE IS TWO ROUTES, so its budget is divided BEFORE either runs.
+      // #608 — THE SECOND ROUTE TAKES NOTHING FROM THE FIRST, and this is the whole design
+      // decision, recorded because the obvious alternative was tried and shipped a worse bug
+      // than the one being fixed.
       //
-      // Divided rather than shared, for the reason the oracle's own accounting states: the
-      // client route does not cancel when it is abandoned, so a route granted the whole
-      // phase leaves the second one nothing and the phase can only report how the first
-      // failed. The client route's grant comes off THIS deadline rather than the run's, so
-      // the reserve cannot be spent by a retry schedule either.
-      const fetchPhaseBudgetMs = nodeDefsBudgetLeft(runDeadline, NODE_DEFS_FETCH_SHARE);
-      const fetchPhaseStartedAt = monotonicNow();
-      const fetchPhaseDeadline = fetchPhaseStartedAt + fetchPhaseBudgetMs;
-      const clientRouteDeadline =
-        fetchPhaseStartedAt + Math.max(1, Math.floor(fetchPhaseBudgetMs * NODE_DEFS_CLIENT_ROUTE_SHARE));
+      // The first attempt capped the client route at HALF the fetch phase and called the
+      // other half the second route's reserve. That couples two cases which have opposite
+      // remedies. When the SLOW PARTY IS THE BACKEND both transports are slow — the raw
+      // route inherits the same latency — so halving the client route's grant and handing
+      // the remainder to a route that needs just as long rescues nothing and loses what the
+      // first route would have got. Measured against the extracted run with the real oracle,
+      // an /object_info answering in 3,200ms / 3,500ms / 5,500ms went from refreshed:true on
+      // the parent to object_info_fetch_failed on that attempt — a new hard-failure band
+      // across (3,000ms, 6,000ms), with nodeDefsRefreshConfirmed false behind it, which is
+      // what the note at the combo phase says reopens #610's false "model still missing".
+      // 3-6s is not exotic: this repo has measured a 5.4MB /object_info at 7.5s over a
+      // tunnel, and a post-install restart on a remote is exactly when it is slowest.
+      //
+      // So the client route's grant is UNCHANGED from before this issue — it still gets the
+      // whole fetch share, so no install that refreshed before can stop refreshing — and the
+      // second route draws on what is left of the RUN deadline instead. That budget is only
+      // ever spent in the case the client route has ALREADY definitively failed, which is
+      // the case that used to end the command outright, so nothing that worked can lose by
+      // it. The run's total WAITING is still bounded by the one deadline, so #1180's
+      // composition (two serialized runs inside the bridge's read default) is untouched.
+      //
+      // WHAT IT COSTS, stated rather than left to be found: when the fallback is consulted
+      // it spends time the combo phase would otherwise have had. That is the right trade
+      // and not a close one — a missing payload is a hard refreshed:false, while an
+      // abandoned combo call is a DISCLOSURE (#1193: the reapply sweep has already rebuilt
+      // every live combo from this run's payload, so the verdict is refreshed:true with
+      // combo_refresh_confirmed:false). A degraded confirmation beats no refresh at all.
+      //
+      // NOT RACED. Issuing both routes together would avoid the wait entirely, and it is
+      // declined on this path's own evidence: an abandoned request is NOT cancelled, so a
+      // race puts two whole-document downloads (5.4MB measured) on the same link and makes
+      // the slow case slower — the exact contention the retry schedule's shouldRetry was
+      // added to stop. Sequential-after-a-definite-failure spends nothing on the healthy
+      // path, which is every path that works today.
       // The client route's failure is HELD, not propagated, so the second route is reached
       // at all — and rethrown UNCHANGED if that one fails too, so the verdict's `detail`
       // and the attribution above it are exactly what they were before this fallback
@@ -1493,7 +1487,7 @@ async function registerComfyNodeDefs(preloadedDefs) {
             lastAttemptTimedOut = false;
             let result;
             try {
-              result = await boundedGetNodeDefs(nodeDefsBudgetLeft(clientRouteDeadline));
+              result = await boundedGetNodeDefs(nodeDefsBudgetLeft(runDeadline, NODE_DEFS_FETCH_SHARE));
             } catch (err) {
               sawRealError = true;
               lastRealError = err;
@@ -1559,7 +1553,11 @@ async function registerComfyNodeDefs(preloadedDefs) {
           // failing, since it would report refreshed:true over the definitions the caller
           // just installed a pack to replace.
           fetchApi: typeof api?.fetchApi === "function" ? (route) => api.fetchApi(route) : null,
-          deadlineMs: nodeDefsBudgetLeft(fetchPhaseDeadline),
+          // WHAT IS LEFT OF THE RUN, not of the fetch phase. The fetch phase's own share
+          // has by definition been spent by the route that just failed, so sizing this from
+          // it hands the second transport the 1ms floor — a bound that only a synchronous
+          // double beats and no real /object_info ever does.
+          deadlineMs: nodeDefsBudgetLeft(runDeadline),
         });
         if (fallbackDefs) {
           // The question is answered. The run continues exactly as it would have on a

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -1522,8 +1522,8 @@ async function registerComfyNodeDefs(preloadedDefs) {
       //
       // Same question, different route: the WHOLE document, never the per-class
       // `/object_info/<Type>` one — the oracle's header says why that is not
-      // interchangeable, and this path feeds `objectInfoSnapshot.record(..., whole: true)`,
-      // which is exactly the reader a single-class payload would poison.
+      // interchangeable, and this path files what it fetched in the whole-schema snapshot
+      // (#1223), which is exactly the reader a single-class payload would poison.
       //
       // AN EMPTY `{}` IS AN ANSWER, NOT AN ABSENCE, and this mirrors the oracle rather than
       // `objectInfoLooksTransient`, which the two modules genuinely disagree about. A client

--- a/web/js/lib/node-def-refresh.js
+++ b/web/js/lib/node-def-refresh.js
@@ -15,6 +15,11 @@
 // Pure: every input is observed by the caller and passed in.
 
 import { nodeInventoryLabel } from "./graph-node-inventory.js";
+// #608 — the ONE renderer for "what each route did", shared with the two other refusals
+// that already print it (`graph_get_object_info` and the set_widget fence). It caps the
+// entry count and sanitizes each sentence, which matters here because a caller can hand
+// this text a backend or extension produced.
+import { objectInfoOracleFailureNote } from "./object-info-oracle.js";
 
 /** Stable reason tokens for a node-def refresh that is NOT confirmed fresh. */
 export const NODE_DEF_REFRESH_REASONS = Object.freeze({
@@ -70,6 +75,13 @@ function detailSuffix(thrown) {
  *   didThrow?: boolean,        // a throw happened at all — tracked independently of
  *                              // the caught VALUE, which can be falsy (throw null)
  *   thrown?: any,              // the error a phase threw, if any
+ *   fetchRouteFailures?: string[]|null, // #608 — what EACH transport the fetch phase has
+ *                              // tried actually did, in order, when none of them produced
+ *                              // a payload. The fetch-phase remedies name them: before
+ *                              // this, "check that the ComfyUI server process is still
+ *                              // running" was printed on the evidence of one route, and
+ *                              // the reported install had a healthy server answering a
+ *                              // different transport at that same moment.
  * }} o
  * @returns {{ refreshed: boolean, reason: string, remedy?: string, detail?: string }}
  */
@@ -84,9 +96,13 @@ export function describeNodeDefRefresh({
   phase = "done",
   didThrow,
   thrown = null,
+  fetchRouteFailures = null,
 } = {}) {
   // Backstop for a caller that predates didThrow: a truthy caught value implies it.
   const failed = didThrow === true || !!thrown;
+  // #608 — "" when the caller recorded nothing, so a caller that does not pass this reads
+  // exactly as it did before rather than gaining an empty clause.
+  const routesNote = objectInfoOracleFailureNote(fetchRouteFailures);
   // The registration clause the combo-failure remedies are allowed to make:
   // "WERE re-registered" only when the registration call observably ran.
   const registrationClause = defsRegistered
@@ -127,9 +143,13 @@ export function describeNodeDefRefresh({
             "so the refresh is NOT confirmed. Reload the ComfyUI tab, then retry.";
     const remedy =
       reason === NODE_DEF_REFRESH_REASONS.OBJECT_INFO_FETCH_FAILED
-        ? "The /object_info fetch failed, so nothing was refreshed. The backend may still be " +
-          "restarting — retry once it answers, and if it never does, check that the ComfyUI " +
-          "server process is still running."
+        ? "The /object_info fetch failed on every transport this panel has, so nothing was " +
+          "refreshed. The backend may still be restarting — retry once it answers, and if it " +
+          "never does, check that the ComfyUI server process is still running." +
+          // #608 — the routes, appended rather than folded into the sentence above: which
+          // ones were tried is EVIDENCE, and it is what separates "one client call did not
+          // answer" (where the server is usually fine, and was) from "nothing answers".
+          routesNote
         : reason === NODE_DEF_REFRESH_REASONS.COMBO_REFRESH_FAILED
           ? `${registrationClause}, but refreshing the ` +
             "combo lists failed, so dropdown options may still be stale. Retry; if it keeps " +
@@ -144,9 +164,13 @@ export function describeNodeDefRefresh({
       reason: NODE_DEF_REFRESH_REASONS.OBJECT_INFO_UNAVAILABLE,
       remedy:
         "The panel could not obtain /object_info from the ComfyUI backend (this frontend exposes " +
-        "no getNodeDefs, or it returned nothing), so node definitions and combo lists were NOT " +
-        "refreshed. If the backend is mid-restart, retry once it is up; otherwise reload the " +
-        "ComfyUI tab.",
+        "no getNodeDefs, or no route returned anything usable), so node definitions and combo " +
+        "lists were NOT refreshed. If the backend is mid-restart, retry once it is up; " +
+        "otherwise reload the ComfyUI tab." +
+        // #608 — the same evidence, on the branch a route reached by RESOLVING nothing lands
+        // in. This one never carried a detail at all, so the routes are the only thing that
+        // can tell a caller which transport it was.
+        routesNote,
     };
   }
   if (!defsRegistered) {


### PR DESCRIPTION
Fixes the recurrence on artokun/comfyui-mcp#608.

## What was reported

On comfyui-mcp 0.52.26 / ComfyUI 0.33.0 / frontend 1.49.6, after installing custom nodes and restarting, `panel_refresh_nodes` returned **repeatedly**:

```
refreshed:false  reason:object_info_fetch_failed
detail: api.getNodeDefs() did not answer within this refresh's remaining budget
```

…while the server was healthy and `create_workflow(action:"node_info", refresh:true)` — a **different transport** — returned the requested classes at the same moment.

(The ORIGINAL Aug-1 report asked for a `panel_refresh_nodes` tool because none existed. That shipped long ago and is not re-implemented here. This is the recurrence comment only.)

## The defect

`lib/object-info-oracle.js` exists precisely because a frontend client route can fail, or never settle, while the raw HTTP route answers — #982, bounded in #1161. Its own header states the case: a client route that "does not answer IN TIME" is treated as one that answered nothing, and "now has the raw route consulted over it."

- `graph_get_object_info` consults that oracle: `fetchWholeObjectInfo({ getNodeDefs, fetchApi })`.
- `registerComfyNodeDefs` — the fetch phase behind `refresh_nodes`, reconnect refreshes and install/download refreshes — had **one** transport and no way to ask again. A client route that stalls ends the command.

So the tool whose whole job is making a freshly installed pack selectable refused a question the panel could already answer by another route it has wired.

## The change

`web/js/comfyui-mcp-panel.js` — when the client route has **definitively failed**, the same whole-schema oracle is asked over the raw HTTP route, with what is left of the **run** deadline.

**The second route takes nothing from the first.** The client route's grant is byte-for-byte what it was before this issue — `boundedGetNodeDefs(nodeDefsBudgetLeft(runDeadline, NODE_DEFS_FETCH_SHARE))`, the whole fetch share — and the retry loop around it is unchanged but for indentation. So no install that refreshed before can stop refreshing. See the gate section: taking the reserve out of that grant is exactly the mistake this PR shipped in round 1 and had caught.

The oracle is asked with `getNodeDefs: null`. The retry loop above **is** the client route — with this path's own #954 schedule, its bound and its error attribution — so re-asking it would spend the budget on the transport that just failed.

**An empty `{}` from the client is an ANSWER and is not routed around.** This mirrors the oracle rather than `objectInfoLooksTransient`, which the two modules genuinely disagree about. The payload here also feeds the #458 ever-seen trust root and the #1223 whole-schema snapshot, so overruling a deliberate deny-all with a broader schema is the one direction a fallback must never move. Only a route that threw, or returned null/undefined/a non-object, leaves the question open.

**No stale-cache hazard.** `api.fetchApi` defaults to `cache: "no-cache"` (read from the shipped client, comfyui-frontend-package 1.48.7 on this rig: `fetchWithUnifiedRemint(this.apiURL(e), {cache:"no-cache", ...t, headers:n}, !1)`), where `getNodeDefs` overrides it to `no-store`. Both revalidate with the server, so this cannot answer a *refresh* out of the HTTP cache with the pre-install schema — which would be worse than failing.

**What it costs.** When the fallback is consulted it spends time the combo phase would otherwise have had. That is the right trade and not a close one: a missing payload is a hard `refreshed:false`, while an abandoned combo call is a *disclosure* — #1193's reapply sweep has already rebuilt every live combo from this run's payload, so the verdict is `refreshed:true` with `combo_refresh_confirmed:false`. And it is only ever spent in the case that used to end the command outright. The run's total waiting is still bounded by the one deadline, so #1180's composition (two serialized runs inside the bridge's read default) is untouched.

**Not raced.** Issuing both routes together would avoid the wait entirely, and is declined on this path's own evidence: an abandoned request is not cancelled, so a race puts two whole-document downloads (5.4 MB measured) on the same link and makes the slow case slower — the exact contention `shouldRetry` was added to stop. Sequential-after-a-definite-failure spends nothing on the healthy path, which is every path that works today.

`web/js/lib/node-def-refresh.js` — the message half. When both routes fail the client route's error is rethrown **unchanged**, so the verdict's reason, detail and phase attribution are exactly what they were. What is added is a record of what each route did, appended to the two fetch-phase remedies through the shared `objectInfoOracleFailureNote`. Before this, *"check that the ComfyUI server process is still running"* stood on the evidence of one route out of two — and the reported install had a healthy server.

## Ruled out, explicitly

- **A bigger budget.** A bound can only choose *how* to fail against a route that never settles (#1178 spent three attempts establishing that), the run budget is sized against the composition two serialized runs make inside the bridge's read default, and the reporter's own corroboration is a transport that answered promptly while this one did not answer at all.
- **A cold `/object_info` being legitimately slower than any bound.** Excluded by the same evidence: a document the server cannot produce in time is slow for *every* reader, and another reader had it. The failure was also repeated, where a cold-start cost is paid once.
- **Message honesty alone.** The message *was* partly at fault and that half is fixed here. It is not sufficient on its own: a working route existed and the tool did not ask it.

## Deliberately not done

A frontend with no `api.getNodeDefs` **at all** still reports `object_info_unavailable` — the outer guard is unchanged. Nothing has reported that, the reported install has the client route and it is the one that fails, and widening the entry condition would change what such a build is told on evidence nobody has.

## Gate — round 1 was NO-SHIP, and it was right

codex was unavailable (account exhausted until 2026-08-19); gated by an independent adversarial review instead, per the standing substitution. Disclosing that is the condition the substitution was accepted under.

Round 1 introduced `NODE_DEFS_CLIENT_ROUTE_SHARE = 0.5`, halving the client route's grant (6000 → 3000 ms) and calling the remainder the second route's reserve. The gate executed the shipping `registerComfyNodeDefs` against the real oracle and showed that **couples two cases with opposite remedies**: when the slow party is the **backend**, the raw route inherits the same latency and cannot rescue anything with the time the client route was just denied.

| `/object_info` service time | parent `8db21c88` | round 1 |
|---|---|---|
| 2000 ms | `refreshed:true` | `refreshed:true` |
| **3200 ms** | **`refreshed:true`** | **`object_info_fetch_failed`** |
| **3500 ms** | **`refreshed:true`** | **`object_info_fetch_failed`** |
| **5500 ms** | **`refreshed:true`** | **`object_info_fetch_failed`** |
| 6500 ms | `object_info_fetch_failed` | `object_info_fetch_failed` |

A new hard-failure band across (3000 ms, 6000 ms), with `nodeDefsRefreshConfirmed` false behind it — the trust root the combo phase's own note says reopens #610's false *"model still missing"* — and the new *"failed on every transport this panel has"* telling the user the server may be down about a server that is up and answering. #982's defect arriving through the fix for it. 3–6 s is not exotic: this repo has measured a 5.4 MB `/object_info` at **7.5 s over a tunnel**, and a post-install restart on a remote is exactly when it is slowest.

My round-1 accepted-cost note held only while the slowness was *client-transport-specific*, and I did not test the case where it is not. The reserve now comes from the run remainder, not from the client route.

## Verification

- `node --test browser_tests/unit/*.test.mjs` — 5892 pass, 0 fail. `check-tool-vocabulary` OK, `check-panel-scope` OK. CI green.
- **The assertion the gate said was missing now exists**, and it is the one that would have caught round 1: a slow-but-healthy backend that *answers* still refreshes, and the raw route is never consulted (`fetchApiCalls === 0`). Driven on a fake clock so the client route's grant is an exact number — every service time in the broken band, 3200/3500/5500 ms of a 6000 ms bound, is that state.
- **Mutation-tested after committing, both rounds.** Round 2, every one killed:

  | mutation | result |
  |---|---|
  | re-introduce the round-1 split (`FETCH_SHARE * 0.5`) | the slow-backend test + #1180 fail |
  | size the fallback from the spent fetch share | the wiring absence-pin + #1180 fail |
  | give the fallback the 1 ms floor (round 1's real shape) | *"the second route needs a usable budget, got 1ms"* |
  | disable the fallback (`if (false)`) | 7 tests fail |
  | always fall back (`if (true)`) | the empty-`{}` fail-closed test fails |
  | narrow the guard to `!defs` alone | the non-schema test fails |
  | drop `fetchRouteFailures` / either `routesNote` | 1–2 tests fail |

  In round 1 the share mutation **survived its first test**: the assertion was computed from the constant *read from the panel source*, so the expectation moved with the mutation, and the fallback was left the 1 ms floor `nodeDefsBudgetLeft` returns for an exhausted budget — which a synchronous test double still beats and a real 5 MB GET never would. It is pinned in absolute milliseconds now.
- Two pre-existing source-shape assertions moved with this change and were updated rather than loosened.
  - #1180's fetch-phase bound: restored to exactly the parent's regex, plus a new pin that the fallback draws on `nodeDefsBudgetLeft(runDeadline)` and an `assert.doesNotMatch` that it is **not** sized from the fetch share. The absence is pinned because that sizing reads as obviously correct at the call site.
  - #1223's census counts `objectInfoSnapshot.record(` occurrences, and a **comment** I wrote quoting that call read as a seventh call site. The fix was to **reword the comment, not to bump the count** — the count is the check, and that test's own note records that its earlier `whole: true` version had already been fooled by a comment once.
- `manager-install`'s `#671 verifyInstalled` failed once in a full parallel run and passes alone — the known wall-clock flake under load.

**Not run: the Playwright browser suite.** This change is inside the `/object_info` fetch path and renders nothing, and the branch is not the copy any live ComfyUI on this box serves, so an e2e run would not have exercised it. The shipped `registerComfyNodeDefs` is extracted from the panel source and driven end-to-end against the REAL oracle in `node-def-refresh.test.mjs`, which is the coverage this has.
