### PR TITLE
fix(1498): a graph read dates itself against the manual-change block it contradicts

### DIFF
--- a/browser_tests/unit/manual-change-claims.test.mjs
+++ b/browser_tests/unit/manual-change-claims.test.mjs
@@ -50,7 +50,7 @@ function buildDiff() {
   const factory = new Function(
     "slotRenameLines",
     "canonicalNodeId",
-    `${body}\nreturn { diffGraphsForAgent, widgetName, resolvedWidgetName };`,
+    `${body}\nreturn { diffGraphsForAgent, resolvedWidgetName };`,
   );
   return factory(slotRenameLines, canonicalNodeId);
 }

--- a/browser_tests/unit/manual-change-claims.test.mjs
+++ b/browser_tests/unit/manual-change-claims.test.mjs
@@ -174,10 +174,13 @@ test("a REPEATED widget name is refused rather than guessed at", () => {
   // compare against is how a wrong-target claim gets made, so this says nothing.
   const res = reconcileWidgetClaims(
     [{ node_id: 8, widget: "RGTHREE_TOGGLE_AND_NAV", reported: true }],
+    // The FIRST row deliberately DISAGREES with the claim: a guard that merely took
+    // row[0] would report a supersession here, so this kills that mutation instead of
+    // passing by luck.
     () =>
       nodeWith([
-        { name: "RGTHREE_TOGGLE_AND_NAV", value: true },
         { name: "RGTHREE_TOGGLE_AND_NAV", value: false },
+        { name: "RGTHREE_TOGGLE_AND_NAV", value: true },
       ]),
   );
   assert.deepEqual(res.rows, []);

--- a/browser_tests/unit/manual-change-claims.test.mjs
+++ b/browser_tests/unit/manual-change-claims.test.mjs
@@ -1,0 +1,304 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  liveWidgetValue,
+  reconcileWidgetClaims,
+  supersededNote,
+  SUPERSEDED_CAP,
+} from "../../web/js/lib/manual-change-claims.js";
+import { slotRenameLines } from "../../web/js/lib/slot-rename-diff.js";
+import { canonicalNodeId } from "../../web/js/lib/node-id.js";
+
+/**
+ * #1498 — "Manual canvas change event disagrees with live graph widget state".
+ *
+ * The reporter's session was told by the MANUAL CANVAS CHANGES block that a combo
+ * had moved to XFORMERS, then read the same node with panel_graph_outline and
+ * panel_query_graph and got the OLD value from both. It filed that as inconsistent
+ * state across panel surfaces.
+ *
+ * Measured against the shipped frontend (1.49.6): `widgets_values[i]` IS
+ * `widgets[i].value` at the instant of the serialize the block is built from, for
+ * plain nodes and for subgraph nodes alike. So the two surfaces cannot disagree at
+ * one moment — they were two readings taken at DIFFERENT moments, and only the
+ * ordering was missing. These tests pin the disclosure that supplies it.
+ */
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const PANEL_JS = join(HERE, "../../web/js/comfyui-mcp-panel.js");
+
+const panelSource = () => readFileSync(PANEL_JS, "utf8").replace(/\r\n/g, "\n");
+
+function sliceBetween(src, startNeedle, endNeedle) {
+  const start = src.indexOf(startNeedle);
+  assert.notEqual(start, -1, `could not locate ${JSON.stringify(startNeedle)}`);
+  const end = src.indexOf(endNeedle, start + 1);
+  assert.ok(end > start, `could not locate ${JSON.stringify(endNeedle)} after it`);
+  return src.slice(start, end);
+}
+
+/** The panel's REAL diff helpers, lifted out with only their two library imports
+ *  injected — so what is exercised below is the shipped function, not a copy of it
+ *  that could drift. */
+function buildDiff() {
+  const src = panelSource();
+  const body = sliceBetween(src, 'const MODE_NAME = { 0: "active"', "function connectCommand(");
+  const factory = new Function(
+    "slotRenameLines",
+    "canonicalNodeId",
+    `${body}\nreturn { diffGraphsForAgent, widgetName, resolvedWidgetName };`,
+  );
+  return factory(slotRenameLines, canonicalNodeId);
+}
+
+// A REAL KSampler as ComfyUI frontend 1.49.6 serializes it (captured from a live
+// canvas: `control_after_generate` carries options.serialize:false and is STILL
+// written, at its own index, so the array aligns with `node.widgets` one-for-one).
+const KSAMPLER_WIDGETS = [
+  "seed",
+  "control_after_generate",
+  "steps",
+  "cfg",
+  "sampler_name",
+  "scheduler",
+  "denoise",
+];
+const ksamplerValues = () => [0, "randomize", 20, 8, "euler", "simple", 1];
+const serializedGraph = (widgets_values) => ({
+  nodes: [{ id: 8, type: "KSampler", widgets_values }],
+  links: [],
+});
+const liveKSampler = {
+  getNodeById: (id) =>
+    Number(id) === 8 ? { id: 8, widgets: KSAMPLER_WIDGETS.map((name) => ({ name })) } : null,
+};
+
+test("a widget-value line records the claim it just asserted", () => {
+  const { diffGraphsForAgent } = buildDiff();
+  const prev = serializedGraph(ksamplerValues());
+  const next = ksamplerValues();
+  next[4] = "dpmpp_2m";
+  const claims = [];
+  const lines = diffGraphsForAgent(prev, serializedGraph(next), liveKSampler, claims);
+  assert.equal(lines.length, 1);
+  assert.match(lines[0], /sampler_name euler → dpmpp_2m/);
+  assert.deepEqual(claims, [
+    { node_id: 8, node_type: "KSampler", widget: "sampler_name", reported: "dpmpp_2m" },
+  ]);
+});
+
+test("the claim carries the RAW value, not the line's clipped rendering", () => {
+  // Load-bearing: the reconciliation compares against the live widget, and a value
+  // the display truncated at 40 chars would never compare equal to it.
+  const { diffGraphsForAgent } = buildDiff();
+  const long = "a".repeat(120);
+  const prev = serializedGraph(["short"]);
+  const claims = [];
+  const live = { getNodeById: () => ({ id: 8, widgets: [{ name: "text" }] }) };
+  const lines = diffGraphsForAgent(prev, serializedGraph([long]), live, claims);
+  assert.match(lines[0], /…/); // the LINE is clipped
+  assert.equal(claims[0].reported, long); // the CLAIM is not
+});
+
+test("no claim is recorded when the widget's name cannot be resolved", () => {
+  // The reconciliation looks the widget back up BY NAME; `#4` is not a name any
+  // reader would find, so a claim under it could never be checked — and an
+  // unverifiable claim that rides anyway is the fabrication this issue is about.
+  const { diffGraphsForAgent } = buildDiff();
+  const next = ksamplerValues();
+  next[4] = "dpmpp_2m";
+  const claims = [];
+  const lines = diffGraphsForAgent(
+    serializedGraph(ksamplerValues()),
+    serializedGraph(next),
+    { getNodeById: () => null },
+    claims,
+  );
+  assert.match(lines[0], /#4 euler → dpmpp_2m/);
+  assert.deepEqual(claims, []);
+});
+
+test("the diff still works for callers that want only the lines", () => {
+  const { diffGraphsForAgent } = buildDiff();
+  const next = ksamplerValues();
+  next[2] = 30;
+  const lines = diffGraphsForAgent(serializedGraph(ksamplerValues()), serializedGraph(next), liveKSampler);
+  assert.equal(lines.length, 1);
+});
+
+// ---- reconciliation -------------------------------------------------------
+
+const nodeWith = (widgets) => ({ id: 8, widgets });
+
+test("a claim the live graph still agrees with says nothing", () => {
+  const res = reconcileWidgetClaims(
+    [{ node_id: 8, widget: "sampler_name", reported: "dpmpp_2m" }],
+    () => nodeWith([{ name: "sampler_name", value: "dpmpp_2m" }]),
+  );
+  assert.deepEqual(res.rows, []);
+  assert.equal(res.differing, 0);
+});
+
+test("a claim the canvas has moved past is reported with BOTH values", () => {
+  const res = reconcileWidgetClaims(
+    [{ node_id: 8, node_type: "RayInitializerAdvanced", widget: "XFuser_attention", reported: "XFORMERS" }],
+    () => nodeWith([{ name: "XFuser_attention", value: "TORCH_EFFICIENT" }]),
+  );
+  assert.deepEqual(res.rows, [
+    {
+      node_id: 8,
+      node_type: "RayInitializerAdvanced",
+      widget: "XFuser_attention",
+      reported: "XFORMERS",
+      now: "TORCH_EFFICIENT",
+    },
+  ]);
+  assert.equal(res.differing, 1);
+});
+
+test("a node that no longer resolves is NOT reported as a superseded value", () => {
+  const res = reconcileWidgetClaims(
+    [{ node_id: 8, widget: "seed", reported: 5 }],
+    () => null,
+  );
+  assert.deepEqual(res.rows, []);
+  assert.equal(res.checked, 0);
+});
+
+test("a REPEATED widget name is refused rather than guessed at", () => {
+  // rgthree's Fast Groups rows all carry one name (panel#1402). Picking a row to
+  // compare against is how a wrong-target claim gets made, so this says nothing.
+  const res = reconcileWidgetClaims(
+    [{ node_id: 8, widget: "RGTHREE_TOGGLE_AND_NAV", reported: true }],
+    () =>
+      nodeWith([
+        { name: "RGTHREE_TOGGLE_AND_NAV", value: true },
+        { name: "RGTHREE_TOGGLE_AND_NAV", value: false },
+      ]),
+  );
+  assert.deepEqual(res.rows, []);
+});
+
+test("a widget that is gone is refused too", () => {
+  const res = reconcileWidgetClaims(
+    [{ node_id: 8, widget: "lora_3", reported: "x.safetensors" }],
+    () => nodeWith([{ name: "lora_1", value: "y.safetensors" }]),
+  );
+  assert.deepEqual(res.rows, []);
+});
+
+test("a resolver that throws is survived, not propagated", () => {
+  const res = reconcileWidgetClaims(
+    [{ node_id: 8, widget: "seed", reported: 1 }],
+    () => {
+      throw new Error("graph torn down");
+    },
+  );
+  assert.deepEqual(res.rows, []);
+});
+
+test("a string and a number of the same digits are DIFFERENT values", () => {
+  // A combo that stores "1" and an INT that holds 1 are not the same state, and a
+  // loose compare would silently swallow exactly the disagreement being reported.
+  const res = reconcileWidgetClaims(
+    [{ node_id: 8, widget: "steps", reported: "20" }],
+    () => nodeWith([{ name: "steps", value: 20 }]),
+  );
+  assert.equal(res.differing, 1);
+});
+
+test("the rider is capped, and says how many it did not show", () => {
+  const claims = Array.from({ length: SUPERSEDED_CAP + 4 }, (_, i) => ({
+    node_id: i,
+    widget: `w${i}`,
+    reported: "old",
+  }));
+  const res = reconcileWidgetClaims(claims, (id) => nodeWith([{ name: `w${id}`, value: "new" }]));
+  assert.equal(res.rows.length, SUPERSEDED_CAP);
+  assert.equal(res.differing, SUPERSEDED_CAP + 4);
+  assert.match(supersededNote(res), new RegExp(`showing ${SUPERSEDED_CAP} of ${SUPERSEDED_CAP + 4}`));
+});
+
+test("a long value is clipped so the rider cannot dominate the reply", () => {
+  const res = reconcileWidgetClaims(
+    [{ node_id: 8, widget: "text", reported: "a".repeat(500) }],
+    () => nodeWith([{ name: "text", value: "b".repeat(500) }]),
+  );
+  assert.ok(res.rows[0].reported.length <= 60);
+  assert.ok(res.rows[0].now.length <= 60);
+});
+
+test("the note states WHICH reading is newer, not merely that they differ", () => {
+  // The whole finding is the ordering. Two values with no as-of is the contradiction
+  // the reporter filed, restated.
+  const note = supersededNote({
+    rows: [{ node_id: 8, widget: "XFuser_attention", reported: "XFORMERS", now: "TORCH_EFFICIENT" }],
+    differing: 1,
+  });
+  assert.match(note, /MANUAL CANVAS CHANGES/);
+  assert.match(note, /THIS read is newer/);
+  assert.match(note, /Do not re-apply the reported value/);
+});
+
+test("nothing to say produces no note at all", () => {
+  assert.equal(supersededNote({ rows: [], differing: 0 }), "");
+  assert.equal(supersededNote(), "");
+});
+
+test("liveWidgetValue reads by NAME, the same key the graph readers use", () => {
+  assert.deepEqual(liveWidgetValue(nodeWith([{ name: "cfg", value: 8 }]), "cfg"), {
+    resolved: true,
+    value: 8,
+  });
+  assert.deepEqual(liveWidgetValue(nodeWith([]), "cfg"), { resolved: false });
+  assert.deepEqual(liveWidgetValue(null, "cfg"), { resolved: false });
+});
+
+// ---- wiring ---------------------------------------------------------------
+// A helper that nothing calls fixes nothing. These assert on the SOURCE, because
+// the install is a one-line spread that no unit test of the lib can observe.
+
+test("the banner arms the claims it is about to assert, and only for its own block", () => {
+  const banner = sliceBetween(panelSource(), "function manualChangeBanner()", "\n/**");
+  assert.match(banner, /diffGraphsForAgent\(lastAgentGraph, curr, live, claims\)/);
+  assert.match(banner, /manualChangeClaims = claims;/);
+  // Cleared with the baseline, so a previous turn's assertions can never be checked
+  // against this turn's canvas.
+  assert.match(banner, /manualChangeClaims = \[\];/);
+});
+
+test("the banner states its AS-OF and that a later live read wins", () => {
+  const banner = sliceBetween(panelSource(), "function manualChangeBanner()", "\n/**");
+  assert.match(banner, /AS OF THE MOMENT THIS MESSAGE WAS SENT/);
+  assert.match(banner, /that read is NEWER and it wins/);
+  // The old present-tense claim is what made a correct live read look like a broken
+  // surface; it must not come back.
+  assert.doesNotMatch(banner, /Treat the canvas as being in THIS state now/);
+});
+
+test("both graph reads carry the rider", () => {
+  const src = panelSource();
+  const outline = sliceBetween(src, "  graph_outline({ max_chars } = {}) {", "\n  graph_query(");
+  assert.match(outline, /\.\.\.manualChangeSupersededRider\(rootGraph\)/);
+  const query = sliceBetween(src, "  graph_query({ types, title, where", "\n  graph_find_nodes(");
+  assert.match(query, /\.\.\.manualChangeSupersededRider\(rootGraph\)/);
+});
+
+test("a widget the panel itself writes retires its claim", () => {
+  const src = panelSource();
+  const setWidget = sliceBetween(src, "  async graph_set_widget({ node_id, widget", "\n  // artokun/comfyui-mcp#938");
+  const run = setWidget.indexOf("const result = await runSetWidget(");
+  const drop = setWidget.indexOf("dropManualChangeClaim(");
+  assert.ok(run !== -1, "runSetWidget call not found");
+  assert.ok(drop > run, "the claim must be retired AFTER the write that ran");
+});
+
+test("claims do not outlive the turn that made them", () => {
+  const src = panelSource();
+  const done = sliceBetween(src, '} else if (state === "done") {', "onLog(text)");
+  assert.match(done, /manualChangeClaims = \[\];/);
+});

--- a/browser_tests/unit/rgthree-lora-row.test.mjs
+++ b/browser_tests/unit/rgthree-lora-row.test.mjs
@@ -1334,6 +1334,9 @@ const EXECUTOR_DEPS = [
   // The coalescer's live slot. This harness's refreshCombos path is never exercised (the
   // runSetWidget double never calls it), so a fixed null is the truth here.
   "nodeDefRefreshInFlight",
+  // #1498 — the handler retires the turn's manual-change claim for the widget it just
+  // wrote. Panel module state, so the harness supplies a no-op double.
+  "dropManualChangeClaim",
 ];
 
 /**
@@ -1471,6 +1474,7 @@ function executor(node, overrides = {}) {
     // with the shipped numbers, from the shared harness constants.
     ...setWidgetCommandBudgetDeps(),
     nodeDefRefreshInFlight: null,
+    dropManualChangeClaim: () => {},
     ...overrides,
   };
   const factory = new Function(

--- a/browser_tests/unit/set-widget-stale-combo-budget.test.mjs
+++ b/browser_tests/unit/set-widget-stale-combo-budget.test.mjs
@@ -227,6 +227,9 @@ const EXECUTOR_DEPS = [
   // out of the eval harness throws ReferenceError, the catch returns false, fetchApi
   // never runs, and #1418's hung-probe assertion reads as "skipped" instead of bounded.
   "inputAssetViewQuery",
+  // #1498 — the handler retires the turn's manual-change claim for the widget it just
+  // wrote. Panel module state, so the harness supplies a no-op double.
+  "dropManualChangeClaim",
 ];
 
 function deferred() {
@@ -354,6 +357,7 @@ function realGraphSetWidget({
     // refreshCombos reads before it calls the coalescer.
     nodeDefRefreshInFlight: inFlight,
     inputAssetViewQuery,
+    dropManualChangeClaim: () => {},
   };
   const factory = new Function(
     ...EXECUTOR_DEPS,

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -8885,21 +8885,20 @@ const modeName = (m) => MODE_NAME[m] ?? `mode${m ?? 0}`;
 // Serialized link = [id, origin_id, origin_slot, target_id, target_slot, type].
 // Compare by ENDPOINTS (link ids churn on every edit), not by id.
 const linkKey = (l) => `${l[1]}:${l[2]}->${l[3]}:${l[4]}`;
-// The live widget's NAME for a serialized `widgets_values` index, or null when it
-// cannot be resolved. Separate from widgetName() below because the two answers are
-// used differently: the DISPLAY falls back to a positional `#i`, while a #1498
-// claim must not be recorded at all without a name — the reconciliation looks the
-// widget back up BY NAME, exactly as the graph readers key it, and `#3` is not a
-// name any reader would find.
+// The live widget's NAME for a serialized `widgets_values` index, or NULL when it
+// cannot be resolved.
+//
+// #1498 — null rather than the old `#i` fallback, because the two answers are not
+// interchangeable any more. The DISPLAY still falls back to the positional `#i`, at
+// the one line that renders it; a CLAIM must not be recorded without a name at all,
+// since the reconciliation looks the widget back up BY NAME — exactly as the graph
+// readers key it — and `#3` is not a name any reader would find.
 function resolvedWidgetName(liveGraph, nodeId, i) {
   try {
     const w = liveGraph?.getNodeById?.(canonicalNodeId(nodeId))?.widgets?.[i];
     if (w && typeof w.name === "string" && w.name) return w.name;
   } catch {}
   return null;
-}
-function widgetName(liveGraph, nodeId, i) {
-  return resolvedWidgetName(liveGraph, nodeId, i) ?? `#${i}`;
 }
 function shortVal(v) {
   const s = String(typeof v === "string" ? v : (JSON.stringify(v) ?? "")).replace(/\s+/g, " ");

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -412,6 +412,7 @@ import { canonicalNodeId, isQualifiedNodeId } from "./lib/node-id.js";
 import { configureAppMode } from "./lib/configure-app-mode.js";
 import { boundByChars, normalizeViewportMaxChars, viewportTruncation, VIEWPORT_DEFAULT_MAX_CHARS } from "./lib/viewport-char-bound.js";
 import { classifyManualChangeBaseline } from "./lib/manual-change-gate.js";
+import { reconcileWidgetClaims, supersededNote } from "./lib/manual-change-claims.js";
 import {
   CANVAS_TOOL_DISCLOSURE,
   commandProvesExposure,
@@ -8834,6 +8835,14 @@ let lastAgentGraphKey = null;
 // "100+ nodes removed" notice that the very next live graph read contradicted.
 let lastAgentGraphEpoch = -1;
 let sessionEpoch = 0;
+// #1498 — the widget-value triples the LAST emitted MANUAL CANVAS CHANGES block
+// actually asserted, plus the workflow identity they were read under. A graph read
+// later in the same turn re-checks these against the live graph so a canvas that
+// moved on mid-turn is disclosed as a newer observation rather than surfacing as
+// two panel surfaces silently disagreeing. Emptied whenever the baseline is
+// reseeded, at turn end, and per-widget whenever the PANEL itself writes one.
+let manualChangeClaims = [];
+let manualChangeClaimsKey = null;
 
 // #291 — live-canvas tool exposure.
 //
@@ -8876,12 +8885,21 @@ const modeName = (m) => MODE_NAME[m] ?? `mode${m ?? 0}`;
 // Serialized link = [id, origin_id, origin_slot, target_id, target_slot, type].
 // Compare by ENDPOINTS (link ids churn on every edit), not by id.
 const linkKey = (l) => `${l[1]}:${l[2]}->${l[3]}:${l[4]}`;
-function widgetName(liveGraph, nodeId, i) {
+// The live widget's NAME for a serialized `widgets_values` index, or null when it
+// cannot be resolved. Separate from widgetName() below because the two answers are
+// used differently: the DISPLAY falls back to a positional `#i`, while a #1498
+// claim must not be recorded at all without a name — the reconciliation looks the
+// widget back up BY NAME, exactly as the graph readers key it, and `#3` is not a
+// name any reader would find.
+function resolvedWidgetName(liveGraph, nodeId, i) {
   try {
     const w = liveGraph?.getNodeById?.(canonicalNodeId(nodeId))?.widgets?.[i];
-    if (w && w.name) return w.name;
+    if (w && typeof w.name === "string" && w.name) return w.name;
   } catch {}
-  return `#${i}`;
+  return null;
+}
+function widgetName(liveGraph, nodeId, i) {
+  return resolvedWidgetName(liveGraph, nodeId, i) ?? `#${i}`;
 }
 function shortVal(v) {
   const s = String(typeof v === "string" ? v : (JSON.stringify(v) ?? "")).replace(/\s+/g, " ");
@@ -8891,7 +8909,11 @@ function shortVal(v) {
 // Diff two serialized root graphs (prev → curr) into compact, LLM-readable lines.
 // Reports node add/remove, mode (bypass/mute) changes, widget-value changes, title
 // changes, and connection add/remove. Ignores pure moves/resizes/recolors (noise).
-function diffGraphsForAgent(prev, curr, liveGraph) {
+// `claims` (#1498) is an OUT-parameter: every widget-value line this diff asserts
+// also pushes the { node, widget, value } triple it asserted, so a later graph read
+// can re-check just those triples and disclose the ones the canvas has moved past.
+// Optional — callers that only want the text pass nothing.
+function diffGraphsForAgent(prev, curr, liveGraph, claims = null) {
   if (!prev || !curr) return [];
   const lines = [];
   const P = new Map((prev.nodes || []).map((n) => [n.id, n]));
@@ -8917,7 +8939,11 @@ function diffGraphsForAgent(prev, curr, liveGraph) {
         for (let i = 0; i < Math.max(pv.length, cv.length); i++) {
           if (JSON.stringify(pv[i]) === JSON.stringify(cv[i])) continue;
           if ((cv[i] && typeof cv[i] === "object") || (pv[i] && typeof pv[i] === "object")) continue; // skip nested preview blobs
-          lines.push(`• ${label(c)}: ${widgetName(liveGraph, id, i)} ${shortVal(pv[i])} → ${shortVal(cv[i])}`);
+          const wname = resolvedWidgetName(liveGraph, id, i);
+          lines.push(`• ${label(c)}: ${wname ?? `#${i}`} ${shortVal(pv[i])} → ${shortVal(cv[i])}`);
+          // #1498 — record the CLAIM, not the rendered line: the reconciliation needs
+          // the raw value to compare, and `shortVal` has already clipped it.
+          if (wname && claims) claims.push({ node_id: id, node_type: c.type, widget: wname, reported: cv[i] });
         }
       } else {
         lines.push(`• ${label(c)}: widgets changed`);
@@ -9080,6 +9106,11 @@ function manualChangeBanner() {
     lastAgentGraph = curr;
     lastAgentGraphKey = currKey;
     lastAgentGraphEpoch = sessionEpoch;
+    // #1498 — claims belong to the block that made them. Drop them with the baseline
+    // they were taken against, so a read can never reconcile against a stale turn's
+    // assertions; the diff path below re-arms them for the block it is about to emit.
+    manualChangeClaims = [];
+    manualChangeClaimsKey = null;
   };
   const decision = classifyManualChangeBaseline({
     hasBaseline: true,
@@ -9106,9 +9137,15 @@ function manualChangeBanner() {
       `node ids may not apply. Re-read with panel_graph_outline before editing.\n\n`
     );
   }
-  const lines = diffGraphsForAgent(lastAgentGraph, curr, live);
+  const claims = [];
+  const lines = diffGraphsForAgent(lastAgentGraph, curr, live, claims);
   reseed();
   if (!lines.length) return "";
+  // #1498 — arm the reconciliation for THIS block only (reseed above cleared the
+  // previous one). Keyed to the workflow the reading was taken from, so a tab switch
+  // mid-turn cannot make a read compare node ids across two different graphs.
+  manualChangeClaims = claims;
+  manualChangeClaimsKey = currKey;
   const MAX = 40;
   const shown = lines.slice(0, MAX);
   const more = lines.length > MAX ? `\n  …and ${lines.length - MAX} more change(s)` : "";
@@ -9116,8 +9153,67 @@ function manualChangeBanner() {
     `⟳ MANUAL CANVAS CHANGES since your last turn — the user edited the graph directly:\n  ` +
     shown.join("\n  ") +
     more +
-    `\nTreat the canvas as being in THIS state now (it overrides what you remember); ` +
-    `re-read with panel_graph_outline if the changes are substantial.\n\n`
+    // #1498 — STATE THE AS-OF, and the precedence that follows from it. This block is
+    // one reading, taken when the message was sent; the user is sitting in ComfyUI and
+    // can keep editing while the turn runs, and a node's own callback can normalize a
+    // value straight back. Claiming the present tense outright ("the canvas IS in this
+    // state") made a later, CORRECT live read look like a broken panel surface.
+    `\nThis is the canvas AS OF THE MOMENT THIS MESSAGE WAS SENT. It overrides what you ` +
+    `remember — but NOT a live read taken after it: if panel_graph_outline or ` +
+    `panel_query_graph reports a different value, that read is NEWER and it wins. ` +
+    `Re-read with panel_graph_outline if the changes are substantial.\n\n`
+  );
+}
+
+/**
+ * #1498 — the reply rider that dates the two readings against each other.
+ *
+ * Called by the graph READS, which are the surface that observes the disagreement.
+ * Re-checks only the widget triples the current turn's MANUAL CANVAS CHANGES block
+ * asserted, against the live root graph, and returns the ones it no longer holds.
+ * Returns `{}` — no fields at all — when there is nothing to say, so an unaffected
+ * read is byte-identical to before and costs nothing against `max_chars`.
+ *
+ * Refuses to reconcile across a WORKFLOW SWITCH: node ids are per-graph, so
+ * comparing a claim taken on workflow A against workflow B's node of the same id is
+ * exactly the wrong-target claim panel#348/#198 removed from the diff itself. An
+ * unreadable identity on either side is the same refusal — never inferred.
+ */
+function manualChangeSupersededRider(rootGraph) {
+  if (!manualChangeClaims.length || !rootGraph) return {};
+  let key = null;
+  try {
+    key = workflowStableUuid();
+  } catch {
+    key = null;
+  }
+  if (key == null || manualChangeClaimsKey == null || key !== manualChangeClaimsKey) return {};
+  let result;
+  try {
+    result = reconcileWidgetClaims(manualChangeClaims, (nodeId) =>
+      rootGraph.getNodeById?.(canonicalNodeId(nodeId)) ?? null,
+    );
+  } catch {
+    // A read must never fail over its own explanatory rider.
+    return {};
+  }
+  if (!result.rows.length) return {};
+  return {
+    manual_changes_superseded: result.rows,
+    manual_changes_superseded_note: supersededNote(result),
+  };
+}
+
+/** #1498 — the PANEL just wrote this widget, so a later difference on it is the
+ *  model's own edit, not the user's. Drop the claim rather than let the rider
+ *  report the agent's write back to it as the canvas moving on. Matching is by
+ *  node id + widget name, the pair the claim is keyed on; ids are compared as
+ *  strings because a serialized id is a number and a live one is a string. */
+function dropManualChangeClaim(nodeId, widget) {
+  if (!manualChangeClaims.length || nodeId == null || typeof widget !== "string") return;
+  const id = String(nodeId);
+  manualChangeClaims = manualChangeClaims.filter(
+    (c) => !(String(c.node_id) === id && c.widget === widget),
   );
 }
 
@@ -11787,6 +11883,12 @@ const GRAPH_TOOL_EXECUTORS = {
       ...(activeMaybeStale
         ? { active_possibly_stale: true, stale_hint: activeStaleHint() }
         : {}),
+      // #1498 — name any widget this turn's MANUAL CANVAS CHANGES block announced that
+      // the canvas has already moved past. Rides OUTSIDE `outline`, so it cannot be shed
+      // by the detail ladder: the whole point is that this read is the newer reading, and
+      // a degraded rung is exactly when the reader most needs to be told which one dates
+      // from when. Bounded to 8 rows by the lib.
+      ...manualChangeSupersededRider(rootGraph),
     };
   },
 
@@ -11947,6 +12049,11 @@ const GRAPH_TOOL_EXECUTORS = {
       ...groupsCut,
       ...(groups.length ? { groups } : {}),
       ...(inSubgraph ? { rails: describeRails(graph) } : {}),
+      // #1498 — same rider as graph_outline, on `meta` so it reaches BOTH of this
+      // command's return paths (rows and the group_by aggregate). Resolved against the
+      // ROOT graph, never `graph`: the block diffs the root, so a claim must be checked
+      // where it was made even when the caller is reading inside a subgraph.
+      ...manualChangeSupersededRider(rootGraph),
     };
 
     // 3) Aggregate?
@@ -14387,6 +14494,12 @@ const GRAPH_TOOL_EXECUTORS = {
     // The creation and its rollback both live inside this call now, at the synchronous write
     // boundary — see `prepareWriteTarget` above. There is nothing to undo out here.
     const result = await runSetWidget(node, widget, value, setWidgetOpts);
+    // #1498 — the PANEL owns this widget's value from here on, so the turn's
+    // MANUAL CANVAS CHANGES claim about it is spent: leaving it armed would make the
+    // next graph read report the model's OWN write back to it as the user editing
+    // again. Placed after runSetWidget, which throws on every refusal, so only a write
+    // that actually ran retires the claim.
+    dropManualChangeClaim(node?.id ?? node_id, widget);
 
     // #418: LiteGraph's `has_errors` red flag is STICKY — repointing a widget from a
     // missing asset (or an invalid value) to a valid one drops the missing-asset
@@ -33094,6 +33207,11 @@ function buildPanel() {
         liveTurnThreadId = null;
         hideThinking(); // authoritative terminal frame — clears the action label too
         ssSet(MID_TASK_KEY, null); // turn finished cleanly — nothing to resume
+        // #1498 — the turn that owned these claims is over. Retire them BEFORE the
+        // snapshot below (which can throw), so a failed serialize cannot leave a
+        // finished turn's assertions armed for the next one's reads.
+        manualChangeClaims = [];
+        manualChangeClaimsKey = null;
         // Snapshot the graph the agent is leaving behind; the next user turn diffs
         // the live graph against this to surface MANUAL edits made between turns.
         try {

--- a/web/js/lib/manual-change-claims.js
+++ b/web/js/lib/manual-change-claims.js
@@ -1,0 +1,140 @@
+// #1498 — reconcile what the MANUAL CANVAS CHANGES block CLAIMED against the live
+// graph, at the moment a graph read actually runs.
+//
+// ## The defect
+//
+// The turn-start block and a graph read are TWO READINGS TAKEN AT DIFFERENT
+// MOMENTS. The block is built from one `rootGraph.serialize()` when the user's
+// message is sent; `graph_outline` / `graph_query` walk the live nodes later, when
+// the model gets round to calling them. Measured on the shipped frontend
+// (1.49.6), a node's `widgets_values[i]` is exactly `widgets[i].value` at the
+// instant of that serialize — so the two surfaces CANNOT disagree about a widget
+// at the same moment. When they do disagree, the value changed in between: the
+// user is sitting in ComfyUI and can keep editing (or a node's own callback can
+// normalize the value back) while the model works.
+//
+// Nothing said so. The block asserted its state in the present tense and the
+// orchestrator prompt calls it ground truth, so the reporter's session read a
+// widget change the block announced, saw the very next live read report the OLD
+// value, and filed it as two panel surfaces holding inconsistent state. Both
+// readings were correct; only their as-of was missing, and the model had been
+// told the older one wins.
+//
+// ## What this does
+//
+// The banner records the (node, widget, value) triples it ASSERTED. A later read
+// re-checks just those triples against the live graph and, when one no longer
+// holds, says so in-band with both values. The read is the newer observation, so
+// it is the one that stands — the rider exists to make that ordering visible
+// instead of leaving the model to adjudicate a contradiction it cannot date.
+//
+// Deliberately CONSERVATIVE — it must never invent a supersession:
+//   • the node must still resolve, and carry EXACTLY ONE widget of that name.
+//     A missing node or a repeated name (rgthree's `RGTHREE_TOGGLE_AND_NAV`
+//     rows, panel#1402) cannot be compared without picking a row, and picking
+//     one is how a wrong-target claim gets made.
+//   • a widget the PANEL itself wrote this turn is dropped from the claim set by
+//     the caller — the model changed it, so a difference there is its own edit
+//     and reporting it as the user's would be a fabrication.
+//   • the claims carry the workflow identity they were taken under; the caller
+//     refuses to reconcile across a switch.
+//
+// Pure + side-effect-free so the whole decision is unit-testable without a DOM.
+
+/** Rider cap. The block itself already shows at most 40 lines; a read only needs
+ *  enough to establish THAT the canvas moved on and which widgets it moved. */
+export const SUPERSEDED_CAP = 8;
+
+/** Per-value display clip, matching the outline's own 60-char widget clip so a
+ *  long prompt cannot make this rider the biggest thing in the reply. */
+const VALUE_CLIP = 60;
+
+function clipValue(v) {
+  const s = String(typeof v === "string" ? v : (JSON.stringify(v) ?? "")).replace(/\s+/g, " ");
+  return s.length > VALUE_CLIP ? s.slice(0, VALUE_CLIP - 3) + "…" : s;
+}
+
+/** Structural equality over the scalars a widget claim can carry. `JSON.stringify`
+ *  because a claim's value came from a serialized snapshot and the live one comes
+ *  off the widget: `1` and `1` compare equal, `"1"` and `1` do not, which is the
+ *  distinction a combo/int disagreement turns on. */
+function sameValue(a, b) {
+  return JSON.stringify(a ?? null) === JSON.stringify(b ?? null);
+}
+
+/**
+ * The live value of the ONE widget named `name` on `node`, or `{ resolved:false }`
+ * when there is no such widget or more than one carries the name.
+ *
+ * Reads `node.widgets` by NAME — the same key `summarizeNode` and the outline use
+ * — so the comparison is against the value those readers would report, not against
+ * a positional index the readers never consult.
+ */
+export function liveWidgetValue(node, name) {
+  const rows = (node?.widgets ?? []).filter((w) => w && w.name === name);
+  if (rows.length !== 1) return { resolved: false };
+  return { resolved: true, value: rows[0].value };
+}
+
+/**
+ * Which of `claims` the live graph no longer agrees with.
+ *
+ * @param {Array<{node_id: any, node_type?: string, widget: string, reported: any}>} claims
+ * @param {(nodeId: any) => any} resolveNode live node for a claim's id, or null
+ * @param {number} cap  maximum rows returned
+ * @returns {{rows: Array, checked: number, differing: number}}
+ *   `rows` is capped; `differing` is the true count so the note can say when it cut.
+ */
+export function reconcileWidgetClaims(claims, resolveNode, cap = SUPERSEDED_CAP) {
+  const rows = [];
+  let checked = 0;
+  let differing = 0;
+  for (const c of Array.isArray(claims) ? claims : []) {
+    if (!c || typeof c.widget !== "string" || !c.widget) continue;
+    let node = null;
+    try {
+      node = resolveNode(c.node_id);
+    } catch {
+      node = null;
+    }
+    // A node that no longer resolves is not evidence of a superseded VALUE — it was
+    // removed, which the next turn's block reports as a removal in its own right.
+    if (!node) continue;
+    const live = liveWidgetValue(node, c.widget);
+    if (!live.resolved) continue;
+    checked += 1;
+    if (sameValue(live.value, c.reported)) continue;
+    differing += 1;
+    if (rows.length >= cap) continue;
+    rows.push({
+      node_id: c.node_id,
+      ...(c.node_type ? { node_type: c.node_type } : {}),
+      widget: c.widget,
+      reported: clipValue(c.reported),
+      now: clipValue(live.value),
+    });
+  }
+  return { rows, checked, differing };
+}
+
+/**
+ * The in-band sentence that rides with the rows. States the ORDERING, because that
+ * is the whole finding: the block is a turn-START reading and this read is newer,
+ * so the read wins. Without that the two numbers are just a contradiction.
+ */
+export function supersededNote({ rows, differing } = {}) {
+  const shown = Array.isArray(rows) ? rows.length : 0;
+  if (!shown) return "";
+  const cut =
+    typeof differing === "number" && differing > shown
+      ? ` (showing ${shown} of ${differing})`
+      : "";
+  return (
+    `The "MANUAL CANVAS CHANGES" block at the start of this turn reported the value under ` +
+    `\`reported\`; the canvas now holds \`now\`${cut}. That block is a reading taken when the ` +
+    `user's message was sent — THIS read is newer, so \`now\` is what is on the canvas and what ` +
+    `will execute. The user can keep editing while you work, and a node's own callback can ` +
+    `normalize a value back, so a difference here is the canvas moving on, not a failed edit. ` +
+    `Do not re-apply the reported value unless the user asks for it.`
+  );
+}


### PR DESCRIPTION
Fixes #1498

## What was actually wrong

The reporter's session was told by the `⟳ MANUAL CANVAS CHANGES` block that node 8's
`XFuser_attention` had moved `TORCH_EFFICIENT → XFORMERS`, then read the same node with
`panel_graph_outline` and `panel_query_graph` and got `TORCH_EFFICIENT` from both. That was
filed as inconsistent state across panel surfaces.

**It is a reading-time defect, not a state defect.** I checked the two sources against the
shipped frontend on the rig (ComfyUI_frontend 1.49.6, live canvas, not from memory):

- the block is built from one `rootGraph.serialize()` taken when the user's message is sent;
- `LGraphNode.serialize()` writes `widgets_values[n] = widgets[n].value` **at the live index**
  — verified for `KSampler` (`control_after_generate` carries `options.serialize:false` and is
  still written at its own index, so the array does not compact), `LoadImage`, and a
  `SubgraphNode` with a promoted widget plus a non-widget input;
- the readers walk `graph._nodes` and key by widget **name**.

So the two surfaces *cannot* disagree about a widget at the same moment. When they disagree,
the value changed **in between** — the user is sitting in ComfyUI and can keep editing while
the turn runs, and a node's own callback can normalize a value straight back.

Nothing said so. The block asserted the present tense —

> Treat the canvas as being in THIS state now (it overrides what you remember)

— and the orchestrator prompt calls the block ground truth. So a *correct* live read taken
seconds later looked like a broken panel surface, and the model had been told the older
reading wins. Both observations were right; only their as-of was missing.

## The fix

1. **The block states its as-of and the precedence that follows.** It is the canvas as of the
   moment the message was sent; it still overrides what the model *remembers*, but a live read
   taken after it is NEWER and wins.
2. **The block records the `(node, widget, value)` triples it asserted**, and
   `panel_graph_outline` / `panel_query_graph` re-check just those against the live graph. Any
   the canvas has moved past ride back as `manual_changes_superseded` (both values) plus a note
   that says which reading dates from when. The rider is outside `outline`, so the detail
   ladder cannot shed it — a degraded rung is exactly when the reader most needs it.

Conservative by construction, because a fabricated supersession is worse than silence:

- a node that no longer resolves, a **repeated** widget name (rgthree's
  `RGTHREE_TOGGLE_AND_NAV` rows, #1402), or a widget that is gone → refused, not guessed;
- claims carry the workflow identity they were read under and are not reconciled across a
  switch (node ids are per-graph — the wrong-target claim #348/#198 removed from the diff);
- a widget the **panel itself** wrote retires its own claim, so the model is never told its own
  edit was the user changing something;
- claims never outlive the turn that made them (cleared on reseed, at turn end, and before the
  turn-end snapshot that can throw);
- values are compared structurally (`"1"` ≠ `1`) and clipped to 60 chars, rows capped at 8 with
  the true count disclosed;
- when there is nothing to say the replies carry **no new fields at all**.

## Verification

- `browser_tests/unit/manual-change-claims.test.mjs` — 21 tests. The diff helpers are lifted
  out of the shipped panel source and executed (not re-implemented), against a real serialized
  `KSampler` captured from the live canvas.
- **Mutation-tested, 8/8 killed**: dropping the claim record, either rider spread, the
  `set_widget` retire, the turn-end clear, restoring the old present-tense sentence, accepting a
  duplicated widget name, and comparing values loosely each fail a test. The first pass left the
  duplicate-name mutation ALIVE — the fixture's first row happened to carry the claimed value —
  so that test was rewritten against a row that disagrees.
- The one-line installs are asserted at the **source** level (the rider spread in both reads,
  the retire after `runSetWidget`, the turn-end clear), because a helper-level test cannot see
  them.
- Full unit suite: **5902 pass / 0 fail** (5903 collected).
- `node scripts/check-panel-scope.mjs` — OK (compiler-backed; this is the gate that catches a
  live panel `ReferenceError`).
- `node scripts/check-tool-vocabulary.mjs` — OK.
- Two `graph_set_widget` executor harnesses build the shipped handler with `new Function` over
  an explicit dep list, so the new identifier was a harness `ReferenceError`, not a product
  failure. Fixed in the harnesses (a no-op double) — no assertion was loosened.

## Gate

**codex was unavailable (account exhausted until 2026-08-19 20:43), so this was gated by an
independent adversarial review instead** — `.claude/autopilot/claude-gate.mjs`, a fresh
reviewer that never saw the implementation. Verdict: **SHIP (exit 0)**. Disclosing the
substitution is the condition it was accepted under.

It executed the shipped code rather than reading it, and reported: fails-closed on all five
uncertain inputs; the workflow-key gate refuses a mid-turn tab switch; `runSetWidget` is the
only widget-mutation path in the panel, so the retire covers every panel write; the new fields
reach the wire whole (no reply allowlist); and it independently re-derived the
`widgets_values[i] === widgets[i].value` claim from the installed frontend's own
`core-*.js`. It ran 9 mutations of its own and killed 8.

**The one survivor has been fixed since:** deleting `manualChangeSupersededRider`'s
workflow-key gate outright survived, because the function had only source-regex coverage and a
regex cannot watch a guard stop working. `cc8df4aa` lifts the shipped function out and drives
it (the reporter's own case end to end, a workflow switch, a thrown/absent identity, an
agreeing canvas, a throwing graph); that mutation and a second one now go red.

Two later commits landed after the gate took its diff snapshot, both additive or subtractive
only: `49a7a341` deletes the now-unused `widgetName` wrapper (its single caller moved to
`resolvedWidgetName`), and `cc8df4aa` adds the tests above. Full suite and
`check-panel-scope` re-run green on the final head; the lone `#671 verifyInstalled` failure in
one full-suite pass is the known wall-clock flake and passes on its own (125/125).

## Deliberately not done

- **Playwright was not run.** The live ComfyUI install symlinks to the MAIN checkout, so the
  browser suite would exercise `main`, not this branch, and repointing it would collide with
  other agents in that tree. Nothing here renders in the sidebar: the block rides in the
  turn's `context` (never in `user_message.text`, #1310) and the rider is a tool-reply field.
  Coverage is the panel-scope compiler gate plus the unit suite; I am not implying browser
  coverage I do not have.
- No i18n keys added (agent-facing strings are not localized), so `i18n:build` was not needed.
- The orchestrator's own prompt line about the block (`src/orchestrator/index.ts`) is left
  alone — it already tells the model to re-read, and the overreaching present-tense claim was
  the panel's.
