### PR TITLE
test(1498): execute the manual-change rider, so its workflow-key gate can be watched to fail

### DIFF
--- a/browser_tests/unit/manual-change-claims.test.mjs
+++ b/browser_tests/unit/manual-change-claims.test.mjs
@@ -283,6 +283,92 @@ test("the banner states its AS-OF and that a later live read wins", () => {
   assert.doesNotMatch(banner, /Treat the canvas as being in THIS state now/);
 });
 
+/** The panel's REAL manualChangeSupersededRider, with the module state it reads
+ *  injected as parameters (it only ever reads them). Executed rather than
+ *  regex-matched: the gate on this change killed 8 of 9 mutations off the source
+ *  tests, and the survivor was deleting this function's workflow-key gate — a guard
+ *  no regex assertion can watch fail. */
+function buildRider({ claims, claimsKey, uuid }) {
+  const body = sliceBetween(
+    panelSource(),
+    "function manualChangeSupersededRider(rootGraph) {",
+    "/** #1498 — the PANEL just wrote",
+  );
+  const factory = new Function(
+    "manualChangeClaims",
+    "manualChangeClaimsKey",
+    "workflowStableUuid",
+    "reconcileWidgetClaims",
+    "supersededNote",
+    "canonicalNodeId",
+    `${body}
+return manualChangeSupersededRider;`,
+  );
+  return factory(
+    claims,
+    claimsKey,
+    uuid,
+    reconcileWidgetClaims,
+    supersededNote,
+    canonicalNodeId,
+  );
+}
+
+const graphWith = (widgets) => ({ getNodeById: (id) => (Number(id) === 8 ? { id: 8, widgets } : null) });
+const XFUSER_CLAIM = [
+  { node_id: 8, node_type: "RayInitializerAdvanced", widget: "XFuser_attention", reported: "XFORMERS" },
+];
+
+test("the rider reports the reporter's own case end to end", () => {
+  const rider = buildRider({ claims: XFUSER_CLAIM, claimsKey: "wf-A", uuid: () => "wf-A" });
+  const out = rider(graphWith([{ name: "XFuser_attention", value: "TORCH_EFFICIENT" }]));
+  assert.equal(out.manual_changes_superseded.length, 1);
+  assert.equal(out.manual_changes_superseded[0].now, "TORCH_EFFICIENT");
+  assert.match(out.manual_changes_superseded_note, /THIS read is newer/);
+});
+
+test("the rider REFUSES across a workflow switch", () => {
+  // The claims are root-graph node ids. Checking them against a different workflow's
+  // node of the same id is the wrong-target claim #348/#198 removed from the diff.
+  const rider = buildRider({ claims: XFUSER_CLAIM, claimsKey: "wf-A", uuid: () => "wf-B" });
+  assert.deepEqual(rider(graphWith([{ name: "XFuser_attention", value: "TORCH_EFFICIENT" }])), {});
+});
+
+test("an unreadable identity on either side is a refusal, never an inference", () => {
+  const thrown = buildRider({
+    claims: XFUSER_CLAIM,
+    claimsKey: "wf-A",
+    uuid: () => {
+      throw new Error("no active workflow");
+    },
+  });
+  assert.deepEqual(thrown(graphWith([{ name: "XFuser_attention", value: "TORCH_EFFICIENT" }])), {});
+  const unkeyed = buildRider({ claims: XFUSER_CLAIM, claimsKey: null, uuid: () => "wf-A" });
+  assert.deepEqual(unkeyed(graphWith([{ name: "XFuser_attention", value: "TORCH_EFFICIENT" }])), {});
+});
+
+test("an agreeing canvas, no claims, or no graph adds NO fields at all", () => {
+  const agreeing = buildRider({ claims: XFUSER_CLAIM, claimsKey: "wf-A", uuid: () => "wf-A" });
+  assert.deepEqual(agreeing(graphWith([{ name: "XFuser_attention", value: "XFORMERS" }])), {});
+  assert.deepEqual(
+    buildRider({ claims: [], claimsKey: "wf-A", uuid: () => "wf-A" })(graphWith([])),
+    {},
+  );
+  assert.deepEqual(agreeing(null), {});
+});
+
+test("a graph that throws on lookup does not fail the read", () => {
+  const rider = buildRider({ claims: XFUSER_CLAIM, claimsKey: "wf-A", uuid: () => "wf-A" });
+  assert.deepEqual(
+    rider({
+      getNodeById: () => {
+        throw new Error("graph torn down");
+      },
+    }),
+    {},
+  );
+});
+
 test("both graph reads carry the rider", () => {
   const src = panelSource();
   const outline = sliceBetween(src, "  graph_outline({ max_chars } = {}) {", "\n  graph_query(");


### PR DESCRIPTION
Follow-up to #1503 (the underlying cause of panel issue 1498 was addressed there; this adds
the coverage its gate asked for). Tests only — no product code changes.

## Why

The adversarial gate on #1503 ran nine mutations and killed eight. The one that **survived**
was deleting `manualChangeSupersededRider`'s workflow-key gate outright:

> `manualChangeSupersededRider` has no execution test, only source-regex tests. The guard is
> present and I confirmed it works by running it, so this is a coverage gap, not a defect.

That is exactly the failure mode this repo keeps re-learning: a regex assertion can see that a
call site exists, but it cannot watch a guard stop working. The commit was written and pushed
during the same session; the PR was squash-merged one commit earlier, so it never landed.

## What this adds

`buildRider(...)` lifts the shipped `manualChangeSupersededRider` out of the panel source with
the module state it reads injected as parameters (it only ever reads them), and drives it:

- the reporter's own case end to end — a `RayInitializerAdvanced` whose `XFuser_attention` the
  block reported as `XFORMERS` while the live canvas holds `TORCH_EFFICIENT` — asserting both
  the row and the ordering sentence;
- a mid-turn **workflow switch** (`wf-A` claims, `wf-B` read) → refused;
- an identity that **throws**, and one that is absent → refused, never inferred;
- an agreeing canvas, no claims, and a null graph → **no fields at all**;
- a `getNodeById` that throws → the read still succeeds.

## Verification

- `browser_tests/unit/manual-change-claims.test.mjs` — 26 tests, all pass on current main.
- The gate's surviving mutation now goes **red**: deleting the workflow-key gate fails
  "the rider REFUSES across a workflow switch". A second mutation (treating a thrown identity
  as a match) is killed too.
- Re-verified against `origin/main` at 26ce0f91, after #1502 landed.

## Gate

codex was unavailable (account exhausted until 2026-08-19 20:43); gated by an independent
adversarial review instead — `.claude/autopilot/claude-gate.mjs`, a fresh reviewer that never
saw the implementation. Verdict: **SHIP (exit 0)**. Disclosing the substitution is the condition it was accepted under.

It reproduced the point of the change by execution: with the rider's workflow-key gate deleted
from the panel, the **parent PR's** tests still pass 21/21 while these new tests fail — and the
mutant demonstrably emits a cross-workflow `manual_changes_superseded` row. Four non-equivalent
mutants (delete the gate, invert the comparison, drop the mismatch half, drop the empty-rows
guard) are killed *exclusively* by these tests; it differential-executed the five survivors over
36 key/claimsKey combinations plus throw and null-graph cases and found all five genuinely
equivalent. Full unit suite on its side: 5918 pass, 0 fail, 1 todo.
