### PR TITLE
fix(608): a later phase must not speak for a run that obtained no /object_info

### DIFF
--- a/browser_tests/unit/node-def-refresh.test.mjs
+++ b/browser_tests/unit/node-def-refresh.test.mjs
@@ -1682,3 +1682,112 @@ test("#608: the fallback is wired to the WHOLE-schema oracle, after the client r
   const rethrowAt = body.indexOf("if (clientRouteThrew) throw clientRouteError;");
   assert.ok(fallbackAt > -1 && rethrowAt > fallbackAt, "the client route's error is rethrown only after the retry");
 });
+
+// ---------------------------------------------------------------------------
+// #608 — a run that obtained NO payload must say so, whatever a later phase did
+// ---------------------------------------------------------------------------
+
+test("#608: a fallback that ALSO fails leaves the no-payload verdict intact", async () => {
+  // THE SECOND REGRESSION THE GATE CAUGHT, and the one that reached main. With getNodeDefs
+  // resolving null (#1223's NOTHING_RETURNED) and the raw route not answering either,
+  // there is no error to rethrow — so the run falls through to the combo phase with
+  // `defs === null` and a budget the second route has spent. The combo call is abandoned,
+  // which sets `thrown`, and the verdict ladder answered `combo_refresh_failed` with a
+  // remedy false in BOTH halves: definitions "were fetched" when none were, and the
+  // frontend "exposes no registerNodesFromDefs" when it does — registration was skipped
+  // only because there was nothing to register. The parent reported the truthful
+  // `object_info_unavailable`, so the fallback turned a correct answer into a wrong one.
+  const timers = virtualTimers();
+  const { registerComfyNodeDefs } = buildRegisterComfyNodeDefs({
+    appValue: {
+      graph: null,
+      registerNodesFromDefs: async () => {},   // PRESENT — the false half of the old remedy
+      refreshComboInNodes: () => new Promise(() => {}), // outlives its starved budget
+    },
+    apiValue: {
+      getNodeDefs: async () => null,
+      fetchApi: () => new Promise(() => {}),   // /object_info never answers
+    },
+    timers,
+    // The oracle gets the SAME virtual timers, so its own bounds are fired here instead of
+    // waited out on a real clock. Still the real oracle — only its clock is injected, which
+    // is the seam it documents for exactly this.
+    fetchWholeObjectInfo: (opts) => fetchWholeObjectInfo({ ...opts, timers }),
+  });
+  const running = registerComfyNodeDefs(undefined);
+  await drainMicrotasks(300);
+  // Drain and fire until the run settles: the oracle arms its own bounds on these timers
+  // too, and the combo phase arms one after them.
+  for (let i = 0; i < 8; i += 1) {
+    timers.fireAll();
+    await drainMicrotasks(200);
+  }
+  const verdict = await orFail(running, "the run never settled");
+
+  assert.equal(verdict.refreshed, false);
+  assert.equal(
+    verdict.reason,
+    "object_info_unavailable",
+    "no route produced a payload — that is the fact to act on, not what the combo phase did",
+  );
+  assert.doesNotMatch(
+    verdict.remedy,
+    /exposes no registerNodesFromDefs/,
+    "this frontend HAS registerNodesFromDefs — it was skipped for want of a payload",
+  );
+  assert.doesNotMatch(verdict.remedy, /were fetched/, "nothing was fetched");
+  assert.match(verdict.remedy, /Tried 2 routes/, "…and the routes that were tried survive");
+});
+
+test("#608: a payload that DID arrive still lets the combo phase word its own failure", async () => {
+  // The other side of the same guard: keyed on `defsObtained`, so a run that obtained a
+  // payload and then failed at the combo phase is untouched. Without this the fix would
+  // swallow every combo failure into the no-payload token.
+  const { registerComfyNodeDefs } = buildRegisterComfyNodeDefs({
+    appValue: {
+      graph: null,
+      registerNodesFromDefs: async () => {},
+      refreshComboInNodes: async () => {
+        throw new Error("reloadNodeDefs blew up");
+      },
+    },
+    apiValue: { getNodeDefs: async () => ({ SomeNode: {} }) },
+  });
+  const verdict = await registerComfyNodeDefs(undefined);
+  assert.equal(verdict.reason, "combo_refresh_failed");
+  assert.match(verdict.remedy, /WERE re-registered/, "registration really did run here");
+});
+
+test("#608: the no-payload guard is keyed on defsObtained, not on the phase name", () => {
+  // Unit-level, over the pure verdict, because the executed test above can only reach the
+  // combo phase. The rule is about the PAYLOAD: any phase after the fetch that failed on a
+  // run with nothing to work on reports the missing payload.
+  for (const phase of ["record", "register", "reapply", "combo"]) {
+    const v = describeNodeDefRefresh({
+      appAvailable: true,
+      defsObtained: false,
+      defsRegistered: false,
+      comboApiPresent: true,
+      comboRan: false,
+      phase,
+      didThrow: true,
+      thrown: new Error("boom"),
+      fetchRouteFailures: ["client said nothing", "raw route said nothing"],
+    });
+    assert.equal(v.reason, "object_info_unavailable", `phase ${phase} must not outrank a missing payload`);
+    assert.match(v.remedy, /Tried 2 routes/, `phase ${phase} must keep the routes evidence`);
+  }
+  // The FETCH phase keeps its own, more specific token: that failure IS the missing
+  // payload, and its detail carries what the transport said.
+  const fetchFailed = describeNodeDefRefresh({
+    appAvailable: true,
+    defsObtained: false,
+    comboApiPresent: true,
+    comboRan: false,
+    phase: "fetch",
+    didThrow: true,
+    thrown: new Error("Failed to fetch"),
+  });
+  assert.equal(fetchFailed.reason, "object_info_fetch_failed");
+  assert.match(fetchFailed.detail, /Failed to fetch/);
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -1458,12 +1458,28 @@ async function registerComfyNodeDefs(preloadedDefs) {
       // it. The run's total WAITING is still bounded by the one deadline, so #1180's
       // composition (two serialized runs inside the bridge's read default) is untouched.
       //
-      // WHAT IT COSTS, stated rather than left to be found: when the fallback is consulted
-      // it spends time the combo phase would otherwise have had. That is the right trade
-      // and not a close one — a missing payload is a hard refreshed:false, while an
-      // abandoned combo call is a DISCLOSURE (#1193: the reapply sweep has already rebuilt
-      // every live combo from this run's payload, so the verdict is refreshed:true with
-      // combo_refresh_confirmed:false). A degraded confirmation beats no refresh at all.
+      // WHAT IT COSTS, BY CASE — written as an exhaustive split because the first version
+      // of this note stated the benign outcome as though it were general, and it was not.
+      // It said "an abandoned combo call is a DISCLOSURE (#1193)", which requires
+      // comboRebuildCovered(), which requires the reapply sweep, which requires `defs`. So
+      // it was true in the state where the fallback ANSWERS and false in the one state
+      // where the fallback costs the combo phase something and returns nothing. The two
+      // states are enumerated here instead:
+      //
+      //   THE FALLBACK ANSWERS — `defs` exists, the reapply sweep has rebuilt every live
+      //     combo from it, and an abandoned frontend combo call is genuinely a disclosure:
+      //     refreshed:true with combo_refresh_confirmed:false (#1193). A degraded
+      //     confirmation beats no refresh.
+      //   THE FALLBACK ALSO FAILS — `defs` is still null, so nothing was going to be
+      //     registered or reapplied whatever the combo phase did. The run reports the
+      //     MISSING PAYLOAD, and describeNodeDefRefresh keys that on `defsObtained` so a
+      //     starved combo phase cannot speak for it. Without that guard this path answered
+      //     combo_refresh_failed with a remedy false in both halves — see the note there.
+      //
+      // What the caller loses in the second case is TIME: the run can spend its whole
+      // budget before reporting where it once gave up sooner. It is bounded by the same run
+      // deadline, it lands well inside the command budget, and the reply is the same
+      // verdict the parent gave with the routes that were tried now named.
       //
       // NOT RACED. Issuing both routes together would avoid the wait entirely, and it is
       // declined on this path's own evidence: an abandoned request is NOT cancelled, so a
@@ -1547,8 +1563,13 @@ async function registerComfyNodeDefs(preloadedDefs) {
           // schedule, its bound and its error attribution — so handing it to the oracle
           // again would spend the reserve on the transport that just failed.
           getNodeDefs: null,
-          // `api.fetchApi` defaults to `cache: "no-cache"` (read from the shipped client,
-          // comfyui-frontend-package 1.48.7 on this rig), where `getNodeDefs` overrides it
+          // `api.fetchApi` defaults to `cache: "no-cache"` — read from the shipped client on
+          // this rig, comfyui_frontend_package 1.48.7, at
+          // static/assets/api--JY_wdaT.js: `fetchWithUnifiedRemint(this.apiURL(e),
+          // {cache:"no-cache", ...t, headers:n}, !1)`. The filename is content-hashed and
+          // the package is not vendored in this repo, so a reader on another machine will
+          // have a different asset name or no copy at all; the claim is from that build and
+          // is worth re-reading rather than inheriting. There `getNodeDefs` overrides it
           // to `no-store`. Both revalidate with the server, so this cannot answer a REFRESH
           // out of the HTTP cache with the pre-install schema — which would be worse than
           // failing, since it would report refreshed:true over the definitions the caller

--- a/web/js/lib/node-def-refresh.js
+++ b/web/js/lib/node-def-refresh.js
@@ -120,9 +120,42 @@ export function describeNodeDefRefresh({
         "refreshed. Reload the ComfyUI tab, then retry.",
     };
   }
+  // #608 — the answer for a run that obtained NO /object_info at all, in one place. Two
+  // branches return it: the ordinary no-payload path below, and a LATER phase that failed
+  // on a run which never had a payload to fail over.
+  const noPayloadRemedy =
+    "The panel could not obtain /object_info from the ComfyUI backend (this frontend exposes " +
+    "no getNodeDefs, or no route returned anything usable), so node definitions and combo " +
+    "lists were NOT refreshed. If the backend is mid-restart, retry once it is up; " +
+    "otherwise reload the ComfyUI tab." +
+    // The routes are the only thing that can tell a caller WHICH transport it was: this
+    // path carries no detail of its own.
+    routesNote;
   if (failed) {
-    const reason =
-      phase === "fetch"
+    // #608 — A LATER PHASE CANNOT SPEAK FOR A RUN THAT NEVER OBTAINED A PAYLOAD, and this
+    // is keyed on `defsObtained` — an input this function is HANDED, not on an assumption
+    // about what else was true.
+    //
+    // Reported by the gate on the fix that made it reachable: with `getNodeDefs` resolving
+    // null (#1223's NOTHING_RETURNED) and the raw route not answering either, the run does
+    // not rethrow — there is no error to rethrow — so it falls through to the combo phase
+    // with `defs === null` and a budget the second route has spent. The combo call is then
+    // abandoned, which sets `thrown`, and this ladder answered `combo_refresh_failed`
+    // with a remedy that was false in BOTH halves: it said definitions "were fetched" when
+    // none were, and that the frontend "exposes no registerNodesFromDefs" when it does —
+    // registration was skipped only because there was nothing to register.
+    //
+    // The combo phase's outcome is not the fact the caller has to act on here, and
+    // `registrationClause` cannot be true on either side of its own ternary when no payload
+    // exists. So the missing payload names the verdict, exactly as it does when nothing
+    // threw at all — the reply for this state is now the same either way.
+    //
+    // PHASE "fetch" IS EXCLUDED and keeps its own token: that failure IS the missing
+    // payload, it is more specific, and its `detail` carries what the transport said.
+    const noPayload = !defsObtained && phase !== "fetch";
+    const reason = noPayload
+      ? NODE_DEF_REFRESH_REASONS.OBJECT_INFO_UNAVAILABLE
+      : phase === "fetch"
         ? NODE_DEF_REFRESH_REASONS.OBJECT_INFO_FETCH_FAILED
         : phase === "combo"
           ? NODE_DEF_REFRESH_REASONS.COMBO_REFRESH_FAILED
@@ -141,8 +174,9 @@ export function describeNodeDefRefresh({
             "persists, reload the ComfyUI tab."
           : "A fresh /object_info was obtained but re-registering the node definitions failed, " +
             "so the refresh is NOT confirmed. Reload the ComfyUI tab, then retry.";
-    const remedy =
-      reason === NODE_DEF_REFRESH_REASONS.OBJECT_INFO_FETCH_FAILED
+    const remedy = noPayload
+      ? noPayloadRemedy
+      : reason === NODE_DEF_REFRESH_REASONS.OBJECT_INFO_FETCH_FAILED
         ? "The /object_info fetch failed on every transport this panel has, so nothing was " +
           "refreshed. The backend may still be restarting — retry once it answers, and if it " +
           "never does, check that the ComfyUI server process is still running." +
@@ -162,15 +196,7 @@ export function describeNodeDefRefresh({
     return {
       refreshed: false,
       reason: NODE_DEF_REFRESH_REASONS.OBJECT_INFO_UNAVAILABLE,
-      remedy:
-        "The panel could not obtain /object_info from the ComfyUI backend (this frontend exposes " +
-        "no getNodeDefs, or no route returned anything usable), so node definitions and combo " +
-        "lists were NOT refreshed. If the backend is mid-restart, retry once it is up; " +
-        "otherwise reload the ComfyUI tab." +
-        // #608 — the same evidence, on the branch a route reached by RESOLVING nothing lands
-        // in. This one never carried a detail at all, so the routes are the only thing that
-        // can tell a caller which transport it was.
-        routesNote,
+      remedy: noPayloadRemedy,
     };
   }
   if (!defsRegistered) {


### PR DESCRIPTION
Fix-forward for a P1 that shipped in #1502 (released as **v0.15.24**). Follow-up on artokun/comfyui-mcp#608.

## Why this exists

#1502 was **merged and released while its independent gate verdict was NO-SHIP**, and the PR was still a draft. The finding does not go away because the branch landed, so this fixes it forward rather than re-litigating the merge.

## The defect, as shipped

`getNodeDefs` resolves **null** (#1223's documented `NOTHING_RETURNED`) and the raw `/object_info` route does not answer either.

There is no error to rethrow — `clientRouteThrew` is false — so the run falls through to `record` / `register` / `reapply` / `combo` with `defs === null`, and the second route has by then spent the budget. `comboWaitMs` collapses toward the 1 ms floor, the combo call is abandoned, that sets `thrown`, and the verdict ladder answers on the **phase** rather than on the missing payload:

| | parent | #1502 (shipped) |
|---|---|---|
| elapsed | 4863 ms | 9008 ms |
| reason | `object_info_unavailable` | `combo_refresh_failed` |
| remedy | truthful | **false in both halves** |
| routes note | n/a | **dropped** |

The remedy claimed definitions *"were fetched"* — none were — and that the frontend *"exposes no `registerNodesFromDefs`"* — it does; registration was skipped only because there was nothing to register. `combo_refresh_failed` is also the token the panel's own budget note records as a previously-shipped bug on a healthy machine. And the `Tried 2 routes:` evidence, which is the entire point of #1502, was dropped on the one path where a user most needs it.

So the second route turned a **correct** answer into a wrong one.

## The fix

One guard in `describeNodeDefRefresh`, keyed on `defsObtained`:

```js
const noPayload = !defsObtained && phase !== "fetch";
```

A later phase cannot speak for a run that never obtained a payload. Phase `fetch` is excluded and keeps `object_info_fetch_failed`: that failure **is** the missing payload, it is more specific, and its `detail` carries what the transport said. The no-payload remedy is lifted to one `const` so this branch and the ordinary no-payload branch below it return the same sentence and cannot drift.

`registrationClause` cannot be true on either side of its own ternary when no payload exists, which is why the old remedy was false whichever way it branched.

## What I got wrong twice, and what is different here

Both earlier cost arguments on this issue were *true everywhere except where the cost actually landed*:

- **Round 1** — "an install whose client route is merely SLOW is overridden by the raw route" held only when the slowness was **client-transport-specific**. When the backend is the slow party, the raw route inherits the same latency. That shipped a hard-failure band across (3000 ms, 6000 ms).
- **Round 2** — "an abandoned combo call is a DISCLOSURE (#1193)" held only when `defs` **exists**, because the disclosure needs `comboRebuildCovered` → `reapplyDefsToLiveNodes` → `defs`. In the one state where the fallback costs the combo phase anything *and* returns nothing, the disclosure is unavailable by construction.

This claim is a different shape: it is keyed on an input the function is **handed** (`defsObtained`), not on an assumption about what else was true, so there is no state it is conditional on. The panel's cost note is rewritten as an **exhaustive two-case split** rather than a general claim — fallback answers / fallback also fails — and the second case now states what it really costs: **time**, bounded by the same run deadline, well inside the command budget, for the same verdict the parent gave plus the routes that were tried.

## Verification

- `node --test browser_tests/unit/*.test.mjs` — 5921 pass, 0 fail. `check-tool-vocabulary` OK, `check-panel-scope` OK.
- The gate's exact input is now an **executed** test through the extracted shipping `registerComfyNodeDefs` with the real oracle: `getNodeDefs → null`, `fetchApi` never answers, `refreshComboInNodes` outlives its starved budget, `registerNodesFromDefs` **present**. It asserts the reason is `object_info_unavailable`, that the remedy contains neither *"were fetched"* nor *"exposes no registerNodesFromDefs"*, and that `Tried 2 routes` survives.
  - The oracle is handed the **same virtual timers** so its own bounds are fired rather than waited out — still the real oracle, only its clock injected, which is the seam it documents.
- Mutation-tested after committing:

  | mutation | result |
  |---|---|
  | remove the guard (`noPayload = false`, i.e. the shipped behaviour) | the executed test + the unit test fail |
  | drop the fetch exclusion (`!defsObtained` alone) | **6+ pre-existing tests** fail — #635, #954, #1180 ×2, #716 — so the exclusion is load-bearing and was already pinned |
  | narrow to the one phase the executed test reaches (`phase === "combo"`) | the per-phase unit test fails |

- The `cache: "no-cache"` claim the reviewer could not verify is now **sourced in the comment**: `comfyui_frontend_package` 1.48.7, `static/assets/api--JY_wdaT.js`, `fetchWithUnifiedRemint(this.apiURL(e), {cache:"no-cache", ...t, headers:n}, !1)`. The filename is content-hashed and the package is not vendored in this repo, so a reader on another machine will have a different asset name or no copy — the comment now says that rather than leaving the claim to be inherited.

**Not run: the Playwright browser suite.** This is a verdict-wording change on the `/object_info` fetch path and renders nothing; the branch is not the copy any live ComfyUI on this box serves. The shipped run is extracted and driven end-to-end instead.

## Gate

codex was unavailable (account exhausted until 2026-08-19); gated by an independent adversarial review instead, per the standing substitution. Disclosing that is the condition the substitution was accepted under. This is round 3 on this issue — the last substantive round before a gate starts finding defects it introduced itself.
