### PR TITLE
fix(1872): a title-only edit is judged against the node's own snapshot, not a size range

### DIFF
--- a/browser_tests/unit/graph-edit-node.test.mjs
+++ b/browser_tests/unit/graph-edit-node.test.mjs
@@ -762,8 +762,20 @@ test("#1872 refuses when an untouched size drifted and will not go back", () => 
         /two positive numbers/,
         "the caller supplied no size — do not blame their arguments",
       );
+      // updateArea drifted the height to pos.y + h = 580; the failed restore then
+      // left the setter's own 600px minimum behind. Report what was OBSERVED, not
+      // the number our own failed write produced.
+      assert.match(error.message, /\[225, 580\]/, "the message must name the observed drift");
+      assert.doesNotMatch(error.message, /600/, "600 is this guard's failed write, not the drift");
+      assert.doesNotMatch(
+        error.message,
+        /rolled back/,
+        "size is exactly what would not go back — do not promise a rollback of it",
+      );
       return true;
     },
   );
-  assert.deepEqual(node.title, "Node 7");
+  assert.equal(node.title, "Node 7");
+  assert.equal(node.pos[0], 100, "every field the guard CAN restore is restored");
+  assert.equal(node.pos[1], 200);
 });

--- a/browser_tests/unit/graph-edit-node.test.mjs
+++ b/browser_tests/unit/graph-edit-node.test.mjs
@@ -676,3 +676,94 @@ test("#1444 setSize/onResize inflation is rolled back, not reported as success",
   assert.deepEqual([node.size[0], node.size[1]], beforeSize);
   assert.deepEqual(events.filter((e) => e === "before" || e === "after"), ["before", "after"]);
 });
+
+/** A node whose stored body height is ZERO — the shape #1872 reported (a collapsed
+ *  CreateVideo serialized as size [225, 0]). Zero height is the node's OWN stored
+ *  geometry, not something a presentation edit asked for. */
+test("#1872 a title-only edit lands on a node whose stored height is zero", () => {
+  const node = makeNode(35, { pos: [1520, 380], size: [225, 0] });
+  node.flags.collapsed = true;
+  // Real LiteGraph clamping: setSize would raise the height. A title edit must
+  // never reach it, so leave it as the trap it is.
+  node.setSize = () => { throw new Error("setSize must not run for a title-only edit"); };
+  const { fn } = setup([node]);
+
+  const result = fn({ node_id: 35, title: "SCENE 1 - Create Video" });
+
+  assert.equal(node.title, "SCENE 1 - Create Video");
+  assert.deepEqual([node.size[0], node.size[1]], [225, 0], "an untouched size must not be normalized");
+  assert.equal(result.edited[0].after.title, "SCENE 1 - Create Video");
+  assert.deepEqual(result.edited[0].after.size, [225, 0]);
+});
+
+test("#1872 a move on a zero-height node restores the shared Rectangle instead of refusing", () => {
+  const node = makeRectBackedNode(35, { pos: [1520, 380], size: [225, 0] });
+  node.flags.collapsed = true;
+  const graph = {
+    beforeChange: () => {},
+    afterChange: () => {},
+    setDirtyCanvas: () => {},
+    getNodeById: (id) => (id === 35 ? node : null),
+  };
+  const edit = realGraphEditNode(
+    () => ({ graph, LG: { LGraphCanvas: { node_colors: {} } } }),
+    (_g, id) => { if (id !== 35) throw new Error(`No node with id ${id}`); return node; },
+    refreshNodeArea,
+    () => [],
+    () => null,
+    () => null,
+  );
+
+  const result = edit({ node_id: 35, pos: [400, 500], title: "SCENE 1 - Create Video" });
+
+  assert.deepEqual([node.pos[0], node.pos[1]], [400, 500]);
+  assert.deepEqual([node.size[0], node.size[1]], [225, 0], "updateArea inflation must be put back, not accepted");
+  assert.equal(node.title, "SCENE 1 - Create Video");
+  assert.deepEqual(result.edited[0].after.size, [225, 0]);
+});
+
+/** The postcondition this branch actually owes the caller: an untouched size ends
+ *  where it started. Judged against the SNAPSHOT — an absolute range let a drifted
+ *  size through whenever the drifted number happened to look like a node size. */
+test("#1872 refuses when an untouched size drifted and will not go back", () => {
+  let height = 80;
+  const node = {
+    id: 7,
+    pos: [100, 200],
+    title: "Node 7",
+    flags: {},
+    get size() { return [225, height]; },
+    // A widget minimum well above the captured height: restoration cannot land.
+    set size(v) { height = Math.max(600, v[1]); },
+    setSize(s) { this.size = s; },
+    updateArea() { height = this.pos[1] + height; },
+  };
+  const graph = {
+    beforeChange: () => {},
+    afterChange: () => {},
+    setDirtyCanvas: () => {},
+    getNodeById: (id) => (id === 7 ? node : null),
+  };
+  const edit = realGraphEditNode(
+    () => ({ graph, LG: { LGraphCanvas: { node_colors: {} } } }),
+    (_g, id) => { if (id !== 7) throw new Error(`No node with id ${id}`); return node; },
+    refreshNodeArea,
+    () => [],
+    () => null,
+    () => null,
+  );
+
+  assert.throws(
+    () => edit({ node_id: 7, pos: [400, 500] }),
+    (error) => {
+      assert.match(error.message, /could not be restored/);
+      assert.doesNotMatch(
+        error.message,
+        /two positive numbers/,
+        "the caller supplied no size — do not blame their arguments",
+      );
+      return true;
+    },
+  );
+  assert.deepEqual(node.title, "Node 7");
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -15064,8 +15064,15 @@ const GRAPH_TOOL_EXECUTORS = {
           const now = pair(node.size);
           if (!now || now[0] !== snap.size[0] || now[1] !== snap.size[1]) {
             if (!writeSize(node, snap.size)) {
+              // Name the drift that was OBSERVED — the reading taken BEFORE the restore
+              // attempt. Re-reading node.size here would report whatever the failed
+              // writeSize left behind (a widget-minimum clamp), which is our own number
+              // rather than the drift the caller needs to see. And do not promise a
+              // rollback: the size is precisely what would not go back. Every other
+              // captured field is restored below, and the edit is refused.
+              const drifted = now ? `[${now[0]}, ${now[1]}]` : "an unreadable value";
               throw new Error(
-                `node ${node.id} size drifted to [${pair(node.size) ?? []}] during this edit and could not be restored to its previous [${snap.size[0]}, ${snap.size[1]}] — the edit was rolled back`,
+                `node ${node.id} size drifted to ${drifted} during this edit and could not be restored to its previous [${snap.size[0]}, ${snap.size[1]}] — the edit was refused and its size left where the restore attempt landed`,
               );
             }
           }

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -15054,12 +15054,20 @@ const GRAPH_TOOL_EXECUTORS = {
         } else if (snap.size.length >= 2) {
           // #1444 — a move/title/color must not let updateArea rewrite size from
           // a shared Rectangle (height becomes y, then tens of thousands).
+          // #1872 — the caller supplied no size, so the ONLY thing this branch
+          // owes them is that the node's own geometry ends where it started.
+          // Judge that against the SNAPSHOT, never against an absolute sanity
+          // range: a node can legitimately carry a zero body height in its
+          // stored size (the reporter's collapsed CreateVideo serialized
+          // [225, 0]), and sizeSane rejected it, so a title-only edit was
+          // refused over a size the caller never touched.
           const now = pair(node.size);
           if (!now || now[0] !== snap.size[0] || now[1] !== snap.size[1]) {
-            writeSize(node, snap.size);
-          }
-          if (!sizeSane(pair(node.size))) {
-            throw new Error("size must be two positive numbers within a reasonable canvas range");
+            if (!writeSize(node, snap.size)) {
+              throw new Error(
+                `node ${node.id} size drifted to [${pair(node.size) ?? []}] during this edit and could not be restored to its previous [${snap.size[0]}, ${snap.size[1]}] — the edit was rolled back`,
+              );
+            }
           }
         }
         if (own("title")) node.title = args.title;


### PR DESCRIPTION
Fixes the underlying cause of artokun/comfyui-mcp#1872.

## What the reporter hit

`panel_edit_node({ node_id: 35, title: "…" })` on a collapsed `CreateVideo` whose stored
size was `[225, 0]` came back with:

```
Error: size must be two positive numbers within a reasonable canvas range
```

— an argument-validation message for an argument the call never sent. Passing an explicit
`size: [225, 60]` alongside the title worked, which is what pointed at the size path.

## Mechanism (reproduced, not inferred)

Not the arg schema, and not "collapsed". The MCP boundary only validates `size` when it is
supplied (`panel-tools.ts` `validatePanelEditNodeArgs` / `nodeSize()`), and a collapsed node
with a normal height edits fine. The discriminator is a **zero stored height**, and the
refusal is in `graph_edit_node`'s **no-size** branch — the one added for #1444:

```js
} else if (snap.size.length >= 2) {
  const now = pair(node.size);
  if (!now || now[0] !== snap.size[0] || now[1] !== snap.size[1]) writeSize(node, snap.size);
  if (!sizeSane(pair(node.size))) throw new Error("size must be two positive numbers …");
}
```

That branch exists so a move/title/color cannot let `updateArea` rewrite `size` out of a
shared Rectangle, and it does the right thing up to the last line: it restores the captured
size when it drifts. Its **postcondition**, though, is `sizeSane` — an absolute range check
on geometry the caller never touched. Wrong pair, and it fails in both directions:

1. a node whose *own* stored height is `0` never satisfies `s[1] > 0`, so **every**
   title/color/mode/pin edit on it is refused outright — the reported bug;
2. a drift the restore only half-undid **passes** the range whenever the drifted number
   still looks like a node size (`pos.y + h` is under 16384 for any ordinary canvas), so
   the branch silently accepted an inflated node it was written to catch.

Reproduced against the shipped executor extracted from `web/js/comfyui-mcp-panel.js` (the
same extraction the unit suite uses), with a rect-backed node carrying `size [225, 0]`:
the title-only edit threw the reporter's exact string and left `node.title` unchanged,
while the same node at height 80 accepted it.

## The change

Judge the branch by the property it actually owes the caller: **an untouched size ends where
it started.** Refuse only when the size drifted *and* `writeSize` could not put the captured
value back — and say that, instead of blaming arguments the caller did not supply. A
supplied `size` is still range-validated exactly as before, and nothing is normalized: the
node comes out of a title edit still at `[225, 0]`.

One consequence, deliberate: a node whose size was ALREADY corrupt before the call no
longer blocks a title edit. That corruption predates the call, the tool reports it
truthfully in `edited[].after.size` rather than swallowing it, and #1444's actual
complaint — that `panel_edit_node` INFLATED sizes — is fully covered by restoring the
captured value. Policing pre-existing geometry is not a title edit's job.

## Verification

- New tests in `browser_tests/unit/graph-edit-node.test.mjs`, all against the real extracted
  method:
  - title-only edit lands on a zero-height node and leaves `size` at `[225, 0]`
    (`setSize` is a throwing trap in that fixture — a title edit must never reach it);
  - pos+title on a rect-backed zero-height node restores the shared Rectangle instead of
    refusing (this is #1444's own scenario, now passing at height 0);
  - an untouched size that drifted and will **not** go back is refused, and the message is
    asserted *not* to say "two positive numbers".
- **Mutation check:** reverted `web/js/comfyui-mcp-panel.js` to `origin/main` with the tests
  in place → `pass 22 / fail 3`, exactly the three new tests. Restored → 25/25.
- Full panel unit suite: `5925 tests, 1 fail` — the known manager-install #671 wall-clock
  flake; re-run alone: `125/125`, green.
- `i18n-check`, `i18n-render-check`, `check-tool-vocabulary`, `check-panel-scope`: all OK.
  No `tr()` string added, so no new i18n key.
- Playwright e2e not run: this is a bridge-executor postcondition with no rendered surface
  of its own, so the browser suite would not observe the change. Flagging that explicitly
  rather than implying coverage I do not have.

## Gate

codex was unavailable (account exhausted until 2026-08-19); gated by an independent
adversarial review instead (`.claude/autopilot/claude-gate.mjs`), per the standing
substitution.
