### PR TITLE
fix(mcp#1871): a run-to-node stops being vetoed by a branch it excluded

### DIFF
--- a/browser_tests/unit/partial-run-prune.test.mjs
+++ b/browser_tests/unit/partial-run-prune.test.mjs
@@ -1,0 +1,283 @@
+/**
+ * Unit tests for web/js/lib/partial-run-prune.js — run with `node --test`.
+ *
+ * Guards comfyui-mcp#1871: `panel_run(to_node_id: 43)` was refused because nodes 56/57
+ * on an UNRELATED output branch named a class the server does not have. ComfyUI's
+ * `validate_prompt` checks every posted node's class BEFORE it narrows execution to
+ * `partial_execution_targets`, so a branch the caller excluded could veto a branch they
+ * asked for.
+ *
+ * The two properties these tests pin:
+ *   1. the backward closure is COMPLETE — a run must never lose a node its branch needs
+ *      (the direction that turns a working run into "Required input is missing");
+ *   2. the second post is licensed only by STRUCTURED evidence that the first one queued
+ *      nothing, and only when the node ComfyUI named is one the caller's scope excluded.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  upstreamClosure,
+  rejectionNodeId,
+  rejectionQueuedNothing,
+  prunedScopedPromptBody,
+  prunedRetryForRejection,
+  prunedRetryNote,
+} from "../../web/js/lib/partial-run-prune.js";
+
+// The reporter's shape: one checkpoint feeding TWO independent output branches. 43 is
+// the ByteDance output they asked for; 56/57 are the Topaz nodes that refused it.
+const TWO_BRANCH = {
+  "1": { class_type: "CheckpointLoaderSimple", inputs: { ckpt_name: "sd.safetensors" } },
+  "2": { class_type: "CLIPTextEncode", inputs: { text: "a cat", clip: ["1", 1] } },
+  "3": { class_type: "KSampler", inputs: { model: ["1", 0], positive: ["2", 0], seed: 42 } },
+  "40": { class_type: "VAEDecode", inputs: { samples: ["3", 0], vae: ["1", 2] } },
+  "43": { class_type: "SaveImage", inputs: { images: ["40", 0] } },
+  "56": { class_type: "TopazUpscale", inputs: { image: ["40", 0] } },
+  "57": { class_type: "SaveImage", inputs: { images: ["56", 0] } },
+};
+
+const bodyFor = (prompt, targets, extra = {}) =>
+  JSON.stringify({
+    prompt,
+    client_id: "abc",
+    number: 1073741822,
+    partial_execution_targets: targets,
+    extra_data: { extra_pnginfo: { workflow: { nodes: ["the whole graph"] } } },
+    ...extra,
+  });
+
+const rejection = (nodeId, classType = "TopazUpscale") => ({
+  error: {
+    type: "missing_node_type",
+    message: `Node '${classType}' not found. The custom node may not be installed.`,
+    details: `Node ID '#${nodeId}'`,
+    extra_info: { node_id: String(nodeId), class_type: classType, node_title: classType },
+  },
+  node_errors: {},
+});
+
+// A Response double with the surface the guard uses (mirrors run-scope-guard.test.mjs).
+function jsonResponse(status, obj) {
+  return {
+    status,
+    clone() {
+      return { json: async () => JSON.parse(JSON.stringify(obj)) };
+    },
+    text: async () => JSON.stringify(obj),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// The closure — completeness first
+// ---------------------------------------------------------------------------
+
+test("#1871 upstreamClosure keeps the target and everything upstream, and nothing else", () => {
+  const keep = upstreamClosure(TWO_BRANCH, ["43"]);
+  assert.deepEqual([...keep].sort(), ["1", "2", "3", "40", "43"]);
+  // The other branch is out — that is the whole fix.
+  assert.equal(keep.has("56"), false);
+  assert.equal(keep.has("57"), false);
+});
+
+test("#1871 upstreamClosure keeps a node SHARED by both branches", () => {
+  // 40 feeds 43 AND 56. Targeting 57 must still bring 40, 3, 2, 1 along.
+  const keep = upstreamClosure(TWO_BRANCH, ["57"]);
+  assert.deepEqual([...keep].sort(), ["1", "2", "3", "40", "56", "57"]);
+});
+
+test("#1871 upstreamClosure handles several roots at once", () => {
+  const keep = upstreamClosure(TWO_BRANCH, ["43", "57"]);
+  assert.equal(keep.size, Object.keys(TWO_BRANCH).length);
+});
+
+test("#1871 upstreamClosure accepts subgraph colon-path ids as ordinary keys", () => {
+  const nested = {
+    "10:15:358": { class_type: "VAEDecode", inputs: { samples: ["7", 0] } },
+    "10:15:359": { class_type: "PreviewImage", inputs: { images: ["10:15:358", 0] } },
+    "7": { class_type: "KSampler", inputs: {} },
+    "99": { class_type: "SaveImage", inputs: { images: ["7", 0] } },
+  };
+  const keep = upstreamClosure(nested, ["10:15:359"]);
+  assert.deepEqual([...keep].sort(), ["10:15:358", "10:15:359", "7"]);
+});
+
+test("#1871 upstreamClosure is null when a requested root is not in the prompt — a closure it cannot resolve is never guessed", () => {
+  assert.equal(upstreamClosure(TWO_BRANCH, ["404"]), null);
+  assert.equal(upstreamClosure(TWO_BRANCH, ["43", "404"]), null);
+  assert.equal(upstreamClosure(TWO_BRANCH, []), null);
+  assert.equal(upstreamClosure(null, ["43"]), null);
+  assert.equal(upstreamClosure([], ["43"]), null);
+});
+
+test("#1871 upstreamClosure terminates on a link cycle", () => {
+  const cyclic = {
+    a: { class_type: "A", inputs: { x: ["b", 0] } },
+    b: { class_type: "B", inputs: { x: ["a", 0] } },
+    z: { class_type: "Z", inputs: {} },
+  };
+  const keep = upstreamClosure(cyclic, ["a"]);
+  assert.deepEqual([...keep].sort(), ["a", "b"]);
+});
+
+test("#1871 upstreamClosure errs toward KEEPING: a nested or ambiguous value that names a real node keeps it", () => {
+  const odd = {
+    "1": { class_type: "Loader", inputs: {} },
+    "2": { class_type: "Weird", inputs: { many: [["1", 0], ["3", 0]], opts: { a: ["4", 0] } } },
+    "3": { class_type: "Other", inputs: {} },
+    "4": { class_type: "Another", inputs: {} },
+    "5": { class_type: "Unrelated", inputs: {} },
+  };
+  const keep = upstreamClosure(odd, ["2"]);
+  // A pack that nests links in a list or an object still gets its dependencies. The
+  // failure this rules out is dropping one, which would break a run that used to work.
+  assert.deepEqual([...keep].sort(), ["1", "2", "3", "4"]);
+  assert.equal(keep.has("5"), false);
+});
+
+test("#1871 upstreamClosure ignores a link-shaped value naming a node that is not in the prompt", () => {
+  const g = { "1": { class_type: "A", inputs: { size: [512, 0] } } };
+  assert.deepEqual([...upstreamClosure(g, ["1"])], ["1"]);
+});
+
+// ---------------------------------------------------------------------------
+// Reading the rejection — structured fields only
+// ---------------------------------------------------------------------------
+
+test("#1871 rejectionNodeId reads extra_info.node_id, as a string or a number", () => {
+  assert.equal(rejectionNodeId(rejection(56)), "56");
+  assert.equal(rejectionNodeId({ error: { extra_info: { node_id: 56 } } }), "56");
+});
+
+test("#1871 rejectionNodeId never parses PROSE — a rejection that only says it in the message is not a licence", () => {
+  assert.equal(
+    rejectionNodeId({
+      error: {
+        type: "missing_node_type",
+        message: "Node 'TopazUpscale' not found. The custom node may not be installed.",
+        details: "Node ID '#56'",
+        extra_info: {},
+      },
+    }),
+    null,
+  );
+  // The shapes with no node at all: outputs failed validation, no outputs.
+  assert.equal(rejectionNodeId({ error: { type: "prompt_outputs_failed_validation", extra_info: {} } }), null);
+  assert.equal(rejectionNodeId({ error: { type: "prompt_no_outputs" } }), null);
+  assert.equal(rejectionNodeId({}), null);
+  assert.equal(rejectionNodeId(null), null);
+});
+
+test("#1871 rejectionQueuedNothing: a body carrying a prompt_id is an ACCEPTED prompt and is never re-postable", () => {
+  // The #944 partial-validation reply: node_errors AND an id, for a prompt already running.
+  assert.equal(
+    rejectionQueuedNothing({ prompt_id: "abc", error: { extra_info: { node_id: "56" } }, node_errors: {} }),
+    false,
+  );
+  assert.equal(rejectionQueuedNothing(rejection(56)), true);
+  assert.equal(rejectionQueuedNothing({ node_errors: { 3: {} } }), false); // no top-level error
+  assert.equal(rejectionQueuedNothing({ error: {} }), false); // empty error object
+});
+
+// ---------------------------------------------------------------------------
+// The rewritten body
+// ---------------------------------------------------------------------------
+
+test("#1871 prunedScopedPromptBody removes the other branch and carries every other field through untouched", () => {
+  const out = prunedScopedPromptBody(bodyFor(TWO_BRANCH, ["43"]), ["43"]);
+  assert.ok(out);
+  assert.deepEqual(out.removed.sort(), ["56", "57"]);
+  const parsed = JSON.parse(out.text);
+  assert.deepEqual(Object.keys(parsed.prompt).sort(), ["1", "2", "3", "40", "43"]);
+  // The scope still travels, so the guard's own verification still passes on the retry.
+  assert.deepEqual(parsed.partial_execution_targets, ["43"]);
+  // The queue-position mark identifies this run; losing it would make our own post foreign.
+  assert.equal(parsed.number, 1073741822);
+  assert.equal(parsed.client_id, "abc");
+  // extra_data carries the FULL workflow for extra_pnginfo — a saved image still embeds
+  // the graph the user was looking at, not the pruned prompt.
+  assert.deepEqual(parsed.extra_data.extra_pnginfo.workflow.nodes, ["the whole graph"]);
+  // The kept nodes are byte-identical, links and all.
+  assert.deepEqual(parsed.prompt["3"], TWO_BRANCH["3"]);
+});
+
+test("#1871 prunedScopedPromptBody returns null when there is nothing to prune — no identical second post", () => {
+  assert.equal(prunedScopedPromptBody(bodyFor(TWO_BRANCH, ["43", "57"]), ["43", "57"]), null);
+});
+
+test("#1871 prunedScopedPromptBody returns null for a body it cannot read or a target it cannot resolve", () => {
+  assert.equal(prunedScopedPromptBody("not json", ["43"]), null);
+  assert.equal(prunedScopedPromptBody(JSON.stringify([1, 2]), ["43"]), null);
+  assert.equal(prunedScopedPromptBody(bodyFor(TWO_BRANCH, ["43"]), ["404"]), null);
+  assert.equal(prunedScopedPromptBody(bodyFor(TWO_BRANCH, ["43"]), []), null);
+  assert.equal(prunedScopedPromptBody(JSON.stringify({ prompt: null, partial_execution_targets: ["43"] }), ["43"]), null);
+});
+
+// ---------------------------------------------------------------------------
+// The decision
+// ---------------------------------------------------------------------------
+
+test("#1871 prunedRetryForRejection: the reported case — a 400 naming an out-of-scope node buys one pruned post", async () => {
+  const body = bodyFor(TWO_BRANCH, ["43"]);
+  const out = await prunedRetryForRejection(jsonResponse(400, rejection(56)), body, ["43"]);
+  assert.ok(out);
+  assert.equal(out.namedNode, "56");
+  assert.deepEqual(out.removed.sort(), ["56", "57"]);
+  assert.deepEqual(Object.keys(JSON.parse(out.text).prompt).sort(), ["1", "2", "3", "40", "43"]);
+});
+
+test("#1871 prunedRetryForRejection: a missing node INSIDE the requested branch is NOT retried — pruning cannot fix it and the clear answer is the useful one", async () => {
+  const body = bodyFor(TWO_BRANCH, ["43"]);
+  assert.equal(await prunedRetryForRejection(jsonResponse(400, rejection(40, "VAEDecode")), body, ["43"]), null);
+  // The target itself.
+  assert.equal(await prunedRetryForRejection(jsonResponse(400, rejection(43, "SaveImage")), body, ["43"]), null);
+});
+
+test("#1871 prunedRetryForRejection: nothing is re-posted without structured proof that the first post queued nothing", async () => {
+  const body = bodyFor(TWO_BRANCH, ["43"]);
+  // Accepted (2xx) — the run is already queued.
+  assert.equal(await prunedRetryForRejection(jsonResponse(200, { prompt_id: "p1" }), body, ["43"]), null);
+  // A prompt id ALONGSIDE the error (#944 partial validation): already running.
+  assert.equal(
+    await prunedRetryForRejection(jsonResponse(400, { ...rejection(56), prompt_id: "p1" }), body, ["43"]),
+    null,
+  );
+  // A rejection that names no node in a structured field.
+  assert.equal(
+    await prunedRetryForRejection(
+      jsonResponse(400, { error: { type: "prompt_outputs_failed_validation", details: "Node ID '#56'", extra_info: {} } }),
+      body,
+      ["43"],
+    ),
+    null,
+  );
+  // A node we never sent.
+  assert.equal(await prunedRetryForRejection(jsonResponse(400, rejection(999)), body, ["43"]), null);
+  // Unreadable response / unreadable request.
+  assert.equal(await prunedRetryForRejection(null, body, ["43"]), null);
+  assert.equal(await prunedRetryForRejection({ status: 400 }, body, ["43"]), null);
+  assert.equal(await prunedRetryForRejection(jsonResponse(400, rejection(56)), "not json", ["43"]), null);
+  // An UNSCOPED run (no targets) is never pruned — the caller asked for the whole graph.
+  assert.equal(await prunedRetryForRejection(jsonResponse(400, rejection(56)), body, []), null);
+});
+
+test("#1871 prunedRetryForRejection never throws on a response whose json() rejects", async () => {
+  const hostile = {
+    status: 400,
+    clone: () => ({
+      json: async () => {
+        throw new Error("body already read");
+      },
+    }),
+  };
+  assert.equal(await prunedRetryForRejection(hostile, bodyFor(TWO_BRANCH, ["43"]), ["43"]), null);
+});
+
+test("#1871 the disclosure names the node ComfyUI refused, what was omitted, and what is still broken", () => {
+  const note = prunedRetryNote({ toNodeId: 43, namedNode: "56", removed: ["56", "57"] });
+  assert.match(note, /node 56/);
+  assert.match(note, /56, 57/);
+  assert.match(note, /Nothing was queued by that refusal/);
+  // It must not leave the caller thinking the missing pack is now fine.
+  assert.match(note, /FULL run will still fail/);
+});

--- a/browser_tests/unit/partial-run-prune.test.mjs
+++ b/browser_tests/unit/partial-run-prune.test.mjs
@@ -120,19 +120,51 @@ test("#1871 upstreamClosure terminates on a link cycle", () => {
   assert.deepEqual([...keep].sort(), ["a", "b"]);
 });
 
-test("#1871 upstreamClosure errs toward KEEPING: a nested or ambiguous value that names a real node keeps it", () => {
+test("#1871 upstreamClosure reads a dependency the way ComfyUI does — the input value ITSELF, never something nested inside it", () => {
+  // codex gate r1, P1. A widget value can be an arbitrary object, and scanning into it
+  // pulled unrelated nodes into the closure. That is not a harmless over-keep: the retry
+  // is declined when the node ComfyUI named is inside the closure, so a coordinate pair
+  // in some node's settings would silently reinstate the refusal this module removes.
+  //
+  // Neither ComfyUI consumer looks inside a value: comfy_execution/graph_utils.is_link
+  // tests the value, and execution.validate_inputs reads `val[0]` of the value.
   const odd = {
     "1": { class_type: "Loader", inputs: {} },
-    "2": { class_type: "Weird", inputs: { many: [["1", 0], ["3", 0]], opts: { a: ["4", 0] } } },
+    "2": {
+      class_type: "Weird",
+      inputs: {
+        image: ["1", 0], // a real link — kept
+        config: { coordinates: ["56", 0] }, // widget data — NOT a link
+        many: [["3", 0], ["4", 0]], // a list of pairs is not a link either
+      },
+    },
     "3": { class_type: "Other", inputs: {} },
     "4": { class_type: "Another", inputs: {} },
-    "5": { class_type: "Unrelated", inputs: {} },
+    "56": { class_type: "TopazUpscale", inputs: {} },
   };
-  const keep = upstreamClosure(odd, ["2"]);
-  // A pack that nests links in a list or an object still gets its dependencies. The
-  // failure this rules out is dropping one, which would break a run that used to work.
-  assert.deepEqual([...keep].sort(), ["1", "2", "3", "4"]);
-  assert.equal(keep.has("5"), false);
+  assert.deepEqual([...upstreamClosure(odd, ["2"])].sort(), ["1", "2"]);
+});
+
+test("#1871 upstreamClosure does not treat a longer list as a dependency — validate_inputs never looks one up", () => {
+  // `len(val) != 2` is an error there, not a lookup, so the node is not needed. Keeping
+  // it would be an over-keep, and an over-keep of the refused node suppresses the retry.
+  const g = {
+    "7": { class_type: "Loader", inputs: {} },
+    "8": { class_type: "Consumer", inputs: { x: ["7", 0, 99], y: ["7"] } },
+  };
+  assert.deepEqual([...upstreamClosure(g, ["8"])], ["8"]);
+});
+
+test("#1871 upstreamClosure keeps a node referenced by a top-level pair even when the id is not a STRING — validate_inputs looks it up unguarded", () => {
+  // execution.py validate_inputs does `o_id = val[0]; prompt[o_id]['class_type']` for
+  // ANY length-2 list input. Keeping a superset of what the executor's stricter is_link
+  // walks is the safe side: pruning such a node away would turn the retry into an
+  // exception_during_validation.
+  const g = {
+    "7": { class_type: "Loader", inputs: {} },
+    "8": { class_type: "Consumer", inputs: { x: [7, 0] } },
+  };
+  assert.deepEqual([...upstreamClosure(g, ["8"])].sort(), ["7", "8"]);
 });
 
 test("#1871 upstreamClosure ignores a link-shaped value naming a node that is not in the prompt", () => {
@@ -224,6 +256,26 @@ test("#1871 prunedRetryForRejection: the reported case — a 400 naming an out-o
   assert.equal(out.namedNode, "56");
   assert.deepEqual(out.removed.sort(), ["56", "57"]);
   assert.deepEqual(Object.keys(JSON.parse(out.text).prompt).sort(), ["1", "2", "3", "40", "43"]);
+});
+
+test("#1871 prunedRetryForRejection: a widget value that merely CONTAINS the refused node's id does not suppress the retry", () => {
+  // codex gate r1, P1 — the regression this pins. Node 43's settings hold a coordinate
+  // pair `["56", 0]` nested in an object. Scanning into widget values put 56 in the
+  // closure, so the retry was declined and the reporter's refusal came straight back.
+  const withWidgetData = {
+    ...TWO_BRANCH,
+    "43": { class_type: "SaveImage", inputs: { images: ["40", 0], meta: { crop: ["56", 0] } } },
+  };
+  const keep = upstreamClosure(withWidgetData, ["43"]);
+  assert.equal(keep.has("56"), false, "a nested pair is widget data, not a dependency");
+  return prunedRetryForRejection(
+    jsonResponse(400, rejection(56)),
+    bodyFor(withWidgetData, ["43"]),
+    ["43"],
+  ).then((out) => {
+    assert.ok(out, "the run is still retried");
+    assert.deepEqual(out.removed.sort(), ["56", "57"]);
+  });
 });
 
 test("#1871 prunedRetryForRejection: a missing node INSIDE the requested branch is NOT retried — pruning cannot fix it and the clear answer is the useful one", async () => {

--- a/browser_tests/unit/run-scope-guard.test.mjs
+++ b/browser_tests/unit/run-scope-guard.test.mjs
@@ -3631,4 +3631,12 @@ test("#1871 WIRING: graph_run actually RENDERS the pruned-retry disclosure into 
   assert.match(raw, /accept\.excluded_nodes_note = prunedRetryNote\(/, "and the sentence is built from them");
   assert.match(raw, /toNodeId: to_node_id/, "the note names the node the caller asked for");
   assert.match(raw, /namedNode: pr\.namedNode/, "and the node ComfyUI refused");
+  // codex gate r2, P1 — the note says the pruned prompt is the one ComfyUI ACCEPTED.
+  // A retry that was itself refused must never reach it, and that must be true of
+  // this line rather than of three early returns further up.
+  assert.match(
+    source.slice(start - 200, start + 120),
+    /runScopeResult\.verified > 0/,
+    "the acceptance claim is gated on a post ComfyUI actually accepted",
+  );
 });

--- a/browser_tests/unit/run-scope-guard.test.mjs
+++ b/browser_tests/unit/run-scope-guard.test.mjs
@@ -3433,3 +3433,202 @@ test("#752 a build that reads ONLY partialExecutionTargets is served NATIVELY, n
     stop()
   }
 })
+
+// ---------------------------------------------------------------------------
+// comfyui-mcp#1871 — a run-to-node refused over a node on ANOTHER branch.
+//
+// ComfyUI's validate_prompt checks that every node in the POSTED prompt resolves
+// to an installed class before it narrows execution to partial_execution_targets
+// (0.33.2 execution.py: the two early returns come three lines above the
+// `x in partial_execution_list` test). So the reporter's Topaz nodes 56/57 — not
+// upstream of the node 43 they asked for, and never going to execute — refused the
+// whole run.
+//
+// These drive the REAL orchestration: dispatchScopedRun through a mock frontend and
+// a server double that answers exactly as ComfyUI 0.33.2 does.
+// ---------------------------------------------------------------------------
+
+// One checkpoint, two independent output branches. 43 is the branch asked for.
+const TWO_BRANCH_OUTPUT = {
+  "1": { class_type: "CheckpointLoaderSimple", inputs: { ckpt_name: "sd.safetensors" } },
+  "3": { class_type: "KSampler", inputs: { model: ["1", 0], seed: 42 } },
+  "40": { class_type: "VAEDecode", inputs: { samples: ["3", 0], vae: ["1", 2] } },
+  "43": { class_type: "SaveImage", inputs: { images: ["40", 0] } },
+  "56": { class_type: "TopazUpscale", inputs: { image: ["40", 0] } },
+  "57": { class_type: "SaveImage", inputs: { images: ["56", 0] } },
+};
+
+// ComfyUI's own rejection shape for a class it cannot resolve (execution.py 0.33.2).
+const missingNodeRejection = (nodeId, classType) => ({
+  error: {
+    type: "missing_node_type",
+    message: `Node '${classType}' not found. The custom node may not be installed.`,
+    details: `Node ID '#${nodeId}'`,
+    extra_info: { node_id: String(nodeId), class_type: classType, node_title: classType },
+  },
+  node_errors: {},
+});
+
+test("#1871 integration: ComfyUI refuses over an out-of-scope node ⇒ ONE pruned re-post queues the requested branch", async () => {
+  const stop = keepAlive();
+  try {
+    let n = 0;
+    const server = makeServer(async () => {
+      n++;
+      // First post: the whole prompt, refused over node 56 — exactly the report.
+      if (n === 1) return jsonResponse(400, missingNodeRejection(56, "TopazUpscale"));
+      return jsonResponse(200, { prompt_id: "srv-pruned" });
+    });
+    const apiTarget = { fetchApi: server };
+    const app = makeFrontend({ shape: "shim", apiTarget, output: TWO_BRANCH_OUTPUT });
+    const ids = [];
+    const rejections = [];
+    const result = await dispatchScopedRun({
+      app, apiTarget, execIds: ["43"], batch: 1, toNodeId: 43,
+      onPromptId: (p) => ids.push(p),
+      onRejection: (r) => rejections.push(r),
+    });
+
+    assert.equal(result.outcome, "dispatched");
+    assert.equal(result.verified, 1);
+    assert.deepEqual(ids, ["srv-pruned"]);
+    // The refusal that queued nothing must NOT be reported as this run's outcome —
+    // graph_run turns a captured rejection into a failure, and the run succeeded.
+    assert.deepEqual(rejections, [], "the superseded refusal is not surfaced as the run's verdict");
+
+    assert.equal(server.calls.length, 2, "exactly one extra post — never a loop");
+    const first = JSON.parse(server.calls[0].options.body);
+    const second = JSON.parse(server.calls[1].options.body);
+    assert.deepEqual(Object.keys(first.prompt).sort(), ["1", "3", "40", "43", "56", "57"]);
+    assert.deepEqual(
+      Object.keys(second.prompt).sort(),
+      ["1", "3", "40", "43"],
+      "the second post carries the backward closure of node 43 and nothing else",
+    );
+    assert.deepEqual(second.partial_execution_targets, ["43"], "the scope still travels");
+    assert.equal(second.number, result.queueMark, "the pruned post still carries THIS run's identity");
+
+    // DISCLOSED, not silent: the caller is told their ComfyUI refused the first post.
+    assert.deepEqual(result.prunedRetry.removed.sort(), ["56", "57"]);
+    assert.equal(result.prunedRetry.namedNode, "56");
+  } finally {
+    stop();
+  }
+});
+
+test("#1871 integration: a missing node INSIDE the requested branch is reported, not retried", async () => {
+  const stop = keepAlive();
+  try {
+    const server = makeServer(async () => jsonResponse(400, missingNodeRejection(40, "VAEDecode")));
+    const apiTarget = { fetchApi: server };
+    const app = makeFrontend({ shape: "shim", apiTarget, output: TWO_BRANCH_OUTPUT });
+    const rejections = [];
+    const result = await dispatchScopedRun({
+      app, apiTarget, execIds: ["43"], batch: 1, toNodeId: 43,
+      onRejection: (r) => rejections.push(r),
+    });
+    assert.equal(server.calls.length, 1, "pruning cannot fix it, so nothing is re-posted");
+    assert.equal(result.prunedRetry, null);
+    assert.equal(rejections.length, 1);
+    assert.equal(rejections[0].error.extra_info.node_id, "40", "the caller gets the answer that matters");
+  } finally {
+    stop();
+  }
+});
+
+test("#1871 integration: a run ComfyUI ACCEPTS is untouched — one post, no prune, even with a prunable other branch", async () => {
+  const stop = keepAlive();
+  try {
+    const server = makeServer();
+    const apiTarget = { fetchApi: server };
+    const app = makeFrontend({ shape: "shim", apiTarget, output: TWO_BRANCH_OUTPUT });
+    const result = await dispatchScopedRun({ app, apiTarget, execIds: ["43"], batch: 1, toNodeId: 43 });
+    assert.equal(result.outcome, "dispatched");
+    assert.equal(server.calls.length, 1, "the happy path never pays a second round trip");
+    assert.equal(result.prunedRetry, null);
+    // The prompt ComfyUI received is the one the frontend built — the other branch is
+    // still in it, so its cached outputs are not evicted by this run (execution.py
+    // set_prompt(prompt.keys()) + clean_unused).
+    assert.deepEqual(Object.keys(JSON.parse(server.calls[0].options.body).prompt).sort(), [
+      "1", "3", "40", "43", "56", "57",
+    ]);
+  } finally {
+    stop();
+  }
+});
+
+test("#1871 integration: when the pruned post is ALSO refused, the SECOND rejection is the one reported", async () => {
+  const stop = keepAlive();
+  try {
+    let n = 0;
+    const server = makeServer(async () => {
+      n++;
+      if (n === 1) return jsonResponse(400, missingNodeRejection(56, "TopazUpscale"));
+      return jsonResponse(400, missingNodeRejection(3, "KSampler"));
+    });
+    const apiTarget = { fetchApi: server };
+    const app = makeFrontend({ shape: "shim", apiTarget, output: TWO_BRANCH_OUTPUT });
+    const rejections = [];
+    const result = await dispatchScopedRun({
+      app, apiTarget, execIds: ["43"], batch: 1, toNodeId: 43,
+      onRejection: (r) => rejections.push(r),
+    });
+    assert.equal(server.calls.length, 2);
+    assert.equal(result.verified, 0);
+    assert.equal(rejections.length, 1, "one verdict, not two");
+    assert.equal(
+      rejections[0].error.extra_info.node_id,
+      "3",
+      "the reported blocker is the one inside the requested branch",
+    );
+    assert.equal(result.prunedRetry.namedNode, "56", "the superseded refusal is still disclosed");
+  } finally {
+    stop();
+  }
+});
+
+test("#1871 integration: an UNSCOPED run is never pruned — the caller asked for the whole graph", async () => {
+  const stop = keepAlive();
+  try {
+    let n = 0;
+    const server = makeServer(async () => {
+      n++;
+      return jsonResponse(400, missingNodeRejection(56, "TopazUpscale"));
+    });
+    const apiTarget = { fetchApi: server };
+    const app = makeFrontend({ shape: "shim", apiTarget, output: TWO_BRANCH_OUTPUT });
+    // The unscoped path uses the historical capture wrap, which has no scope and no
+    // prune: a full run that names a missing node is a real failure of what was asked.
+    const rejections = [];
+    apiTarget.fetchApi = createRunFetchInterceptor({
+      origFetchApi: server,
+      onRejection: (r) => rejections.push(r),
+    });
+    await app.queuePrompt(0, 1, undefined);
+    assert.equal(server.calls.length, 1);
+    assert.equal(rejections.length, 1);
+    assert.equal(n, 1);
+  } finally {
+    stop();
+  }
+});
+
+test("#1871 WIRING: graph_run actually RENDERS the pruned-retry disclosure into the run result", () => {
+  // The guard can record the retry perfectly and the caller still never hear about
+  // it — a one-line assignment in the reply builder is exactly the kind of install
+  // a lib-level test cannot see. So this asserts on the call site itself.
+  const here = dirname(fileURLToPath(import.meta.url));
+  const source = readFileSync(join(here, "../../web/js/comfyui-mcp-panel.js"), "utf8");
+  assert.match(
+    source,
+    /import \{ prunedRetryNote \} from "\.\/lib\/partial-run-prune\.js";/,
+    "the panel imports the note builder",
+  );
+  const start = source.indexOf("runScopeResult?.prunedRetry");
+  assert.ok(start > 0, "the reply builder reads the recorded retry");
+  const raw = source.slice(start, source.indexOf("\n    }", start));
+  assert.match(raw, /accept\.excluded_nodes_omitted/, "the omitted node ids reach the result");
+  assert.match(raw, /accept\.excluded_nodes_note = prunedRetryNote\(/, "and the sentence is built from them");
+  assert.match(raw, /toNodeId: to_node_id/, "the note names the node the caller asked for");
+  assert.match(raw, /namedNode: pr\.namedNode/, "and the node ComfyUI refused");
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -16115,7 +16115,15 @@ const GRAPH_TOOL_EXECUTORS = {
     // running. But the caller must not be left believing this ComfyUI is healthy —
     // their next FULL run will still fail on the same node — and an agent that
     // cannot see the extra round trip cannot report it either.
-    if (partialTargets && runScopeResult?.prunedRetry) {
+    //
+    // GATED ON A VERIFIED POST (codex gate r2, P1), not on reaching this line. The
+    // note asserts that the pruned prompt is the one ComfyUI ACCEPTED, and the
+    // control flow above does establish that — a failed retry returns at the
+    // outcome check, a rejected one at summarizePromptRejection. But that is an
+    // invariant held three early-returns away, and one of them returns null for a
+    // 400 whose error and node_errors are both empty. A claim about acceptance
+    // reads the count of posts ComfyUI accepted, so it stays true on its own.
+    if (partialTargets && runScopeResult?.prunedRetry && runScopeResult.verified > 0) {
       const pr = runScopeResult.prunedRetry;
       accept.excluded_nodes_omitted = Array.isArray(pr.removed) ? pr.removed : [];
       accept.excluded_nodes_note = prunedRetryNote({

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -656,6 +656,7 @@ import {
 } from "./lib/graph-binding.js";
 import { summarizePromptRejection, buildQueueAcceptResult } from "./lib/queue-rejection.js";
 import { createRunFetchInterceptor, dispatchScopedRun } from "./lib/run-scope-guard.js";
+import { prunedRetryNote } from "./lib/partial-run-prune.js";
 import { queueMembership, historyEntryFor } from "./lib/history-reconcile.js";
 import {
   normalizeModels,
@@ -16103,6 +16104,25 @@ const GRAPH_TOOL_EXECUTORS = {
     if (partialTargets && runScopeResult?.overrunBlocked > 0) {
       accept.extra_dispatch_blocked = runScopeResult.overrunBlocked;
       accept.extra_dispatch_note = runScopeResult.overrunNote;
+    }
+    // comfyui-mcp#1871 — this run queued only because a SECOND post left out the
+    // nodes the caller's own scope excluded. ComfyUI validates that every node in
+    // the posted prompt resolves to an installed class before it narrows execution
+    // to partial_execution_targets, so one unavailable pack on another branch
+    // refuses a run-to-node that never touches it.
+    //
+    // A DISCLOSURE, not a failure: the branch that was asked for is queued and
+    // running. But the caller must not be left believing this ComfyUI is healthy —
+    // their next FULL run will still fail on the same node — and an agent that
+    // cannot see the extra round trip cannot report it either.
+    if (partialTargets && runScopeResult?.prunedRetry) {
+      const pr = runScopeResult.prunedRetry;
+      accept.excluded_nodes_omitted = Array.isArray(pr.removed) ? pr.removed : [];
+      accept.excluded_nodes_note = prunedRetryNote({
+        toNodeId: to_node_id,
+        namedNode: pr.namedNode,
+        removed: pr.removed,
+      });
     }
     // #985 — a WHOLE-GRAPH run hands prompt construction to ComfyUI, and ComfyUI
     // applies a subgraph wrapper's mute/bypass only at the TOP level: a wrapper

--- a/web/js/lib/partial-run-prune.js
+++ b/web/js/lib/partial-run-prune.js
@@ -87,34 +87,41 @@
 const has = (map, key) => Object.prototype.hasOwnProperty.call(map, key);
 
 /**
- * Every prompt node id referenced as a LINK by one input value.
+ * The prompt node id one input value depends on, or null.
  *
- * ComfyUI's API prompt encodes a link as a two-element array `[node_id, output_index]`,
- * and `execution.validate_inputs` reads `val[0]` as the upstream node id. That is the
- * shape matched here.
+ * The predicate is ComfyUI's, not an approximation of it. Both consumers of a posted
+ * prompt read a dependency from the input value ITSELF — never from anything nested
+ * inside it:
  *
- * The direction of error is deliberate and one-way: this is used to decide what to KEEP,
- * so over-matching keeps a node that did not need to be kept (harmless — the run is
- * unchanged, it just prunes less) while under-matching drops a node the branch needs and
- * turns a working run into "Required input is missing". So a widget value that merely
- * LOOKS like a link (`[3, 0]` on a node whose id is "3") keeps node 3, and container
- * values are scanned recursively in case a pack ever nests links in a list or object —
- * neither can remove a dependency, only add one.
+ *   comfy_execution/graph_utils.py  is_link(obj): a list, length 2, obj[0] a str,
+ *                                   obj[1] an int/float. Used by the executor's
+ *                                   get_input_data and by the cache-key walk.
+ *   execution.py validate_inputs    `if isinstance(val, list)` -> length 2 -> `o_id =
+ *                                   val[0]` -> `prompt[o_id]['class_type']`, an
+ *                                   UNGUARDED lookup that raises when the id is absent.
+ *
+ * The second is the broader of the two and is the one the closure must satisfy: a node
+ * referenced by a top-level two-element list has to survive the prune, or the retry dies
+ * as an exception_during_validation. Hence `String(value[0])` plus a membership test
+ * rather than is_link's stricter typing — that keeps a superset of what the executor
+ * walks, which is the safe side. The length-2 requirement is NOT loosened for the same
+ * reason in reverse: validate_inputs never looks up a longer list, so treating one as a
+ * dependency would be an over-keep (see below).
+ *
+ * NOTHING is scanned recursively (codex gate r1, P1). A widget value can be an arbitrary
+ * object, and `{config:{coordinates:["56", 0]}}` on a node in the branch would have
+ * pulled node 56 into the closure. That is not a harmless over-keep:
+ * `prunedRetryForRejection` declines to retry when the node ComfyUI named is INSIDE the
+ * closure, so an unrelated coordinate pair would silently reinstate the very refusal
+ * this module exists to remove. Neither ComfyUI consumer looks inside a value, so
+ * neither does this.
  */
-function linkedIds(value, promptMap, out, depth = 0) {
-  if (depth > 4 || value == null || typeof value !== "object") return;
-  if (Array.isArray(value)) {
-    if (value.length === 2 && (typeof value[0] === "string" || typeof value[0] === "number")) {
-      const key = String(value[0]);
-      if (has(promptMap, key)) {
-        out.add(key);
-        return; // a matched link is fully consumed; its index is not a container
-      }
-    }
-    for (const v of value) linkedIds(v, promptMap, out, depth + 1);
-    return;
-  }
-  for (const v of Object.values(value)) linkedIds(v, promptMap, out, depth + 1);
+function linkedId(value, promptMap) {
+  if (!Array.isArray(value) || value.length !== 2) return null;
+  const raw = value[0];
+  if (raw == null || typeof raw === "object") return null;
+  const key = String(raw);
+  return has(promptMap, key) ? key : null;
 }
 
 /**
@@ -141,16 +148,17 @@ export function upstreamClosure(promptMap, rootIds) {
     const entry = promptMap[id];
     const inputs = entry && typeof entry === "object" ? entry.inputs : null;
     if (!inputs || typeof inputs !== "object") continue;
-    const found = new Set();
     try {
-      linkedIds(inputs, promptMap, found);
+      for (const value of Object.values(inputs)) {
+        const dep = linkedId(value, promptMap);
+        if (dep != null && !keep.has(dep)) stack.push(dep);
+      }
     } catch {
-      // A hostile/exotic inputs object must not take down the run. An input we could
-      // not read contributes no dependency, and the verification in
-      // prunedScopedPromptBody is what stops a half-read closure from being posted.
+      // A hostile/exotic inputs object (a throwing getter) must not take down the run.
+      // An input that could not be read contributes no dependency, and the verification
+      // in prunedScopedPromptBody is what stops a half-read closure from being posted.
       continue;
     }
-    for (const dep of found) if (!keep.has(dep)) stack.push(dep);
   }
   return keep;
 }

--- a/web/js/lib/partial-run-prune.js
+++ b/web/js/lib/partial-run-prune.js
@@ -1,0 +1,337 @@
+/**
+ * comfyui-mcp#1871 — a run-to-node (`panel_run to_node_id`) refused because of a node
+ * on a DIFFERENT output branch.
+ *
+ * The reporter asked for node 43 (a ByteDance output). ComfyUI answered
+ *
+ *   Node '…' not found. The custom node may not be installed.  (Node ID '#56')
+ *
+ * naming Topaz nodes 56/57, which are not upstream of 43 and would never have executed.
+ * The documented contract of run-to-node is that ONLY the selected output and its
+ * upstream dependencies run — so a branch the caller excluded had a veto over a branch
+ * they asked for, and the whole feature is unusable on any workflow that carries one
+ * unavailable pack anywhere.
+ *
+ * ## Where the veto comes from (read out of ComfyUI 0.33.2, the reporter's version)
+ *
+ * `server.py` passes `partial_execution_targets` to exactly one place:
+ *
+ *     valid = await execution.validate_prompt(prompt_id, prompt, partial_execution_targets)
+ *
+ * and `execution.validate_prompt` opens with a loop over EVERY entry of the posted
+ * prompt:
+ *
+ *     for x in prompt:
+ *         if 'class_type' not in prompt[x]:            -> return (False, missing_node_type…)
+ *         class_ = nodes.NODE_CLASS_MAPPINGS.get(prompt[x]['class_type'], None)
+ *         if class_ is None:                           -> return (False, missing_node_type…)
+ *         if OUTPUT_NODE and (partial_execution_list is None or x in partial_execution_list):
+ *             outputs.add(x)
+ *
+ * The partial list is consulted only on that last line — three lines AFTER the two
+ * early returns. So the scope narrows which outputs become execution roots, and narrows
+ * nothing at all about which nodes must resolve to an installed class. Every other use
+ * of the prompt downstream (`outputs_to_execute`, the executor's own walk) is already
+ * scoped correctly; this one pre-loop is the entire defect.
+ *
+ * That is upstream behaviour and this panel cannot change it. What it CAN do is stop
+ * posting nodes the caller excluded: a prompt pruned to the backward closure of the
+ * requested targets executes EXACTLY the same nodes (the roots are the targets, and the
+ * executor reaches only their dependencies), while the pre-loop no longer sees the other
+ * branch at all.
+ *
+ * ## Why this is a RETRY and not the default
+ *
+ * Pruning every scoped run would be simpler, and it was the first design. It has a real
+ * cost, measured in the same file:
+ *
+ *     for cache in self.caches.all:
+ *         await cache.set_prompt(dynamic_prompt, prompt.keys(), is_changed_cache)
+ *         cache.clean_unused()
+ *
+ * The default (classic `HierarchicalCache`) drops every cached output whose key is not
+ * in the prompt it was just handed. A prompt pruned to one branch therefore EVICTS the
+ * other branch's cached results, so a scoped preview would quietly make the user's next
+ * full run recompute a branch it had already rendered — on the workflows where run-to-node
+ * is most useful, that is minutes of GPU time nobody asked to spend.
+ *
+ * So the prune is spent only where the alternative is a total refusal: the run posts the
+ * prompt the frontend built, exactly as before, and only a rejection that names an
+ * out-of-scope node buys a second, pruned post. A run that ComfyUI accepts is byte-for-byte
+ * unchanged by this module.
+ *
+ * ## What licenses a second post
+ *
+ * Re-posting is only safe if the first post queued NOTHING, and that is established from
+ * structured fields, never from message text (a message is a description, not a receipt):
+ *
+ *   - a non-2xx status, and
+ *   - a body carrying a top-level `error` object, and
+ *   - NO `prompt_id` in that body.
+ *
+ * `server.py` mints a prompt id and calls `prompt_queue.put(...)` only inside the
+ * `if valid[0]:` branch; the rejection branch returns `{"error": …, "node_errors": …}`
+ * with status 400 having queued nothing. A body that carries an id is an accepted prompt
+ * and is never retried here.
+ *
+ * The rejection must ALSO name a node — `error.extra_info.node_id`, the field ComfyUI
+ * populates for exactly the two early returns above — and that node must be OUTSIDE the
+ * closure we compute ourselves from the posted body. Both halves matter: the id is what
+ * makes the decision structured, and the closure check is what makes it relevant. A
+ * missing node INSIDE the requested branch is not fixable by pruning, so it is reported
+ * as-is rather than retried; `prompt_outputs_failed_validation` and `prompt_no_outputs`
+ * carry `extra_info: {}` and so never reach a retry either.
+ */
+
+/** True when `key` is an own key of the prompt map. */
+const has = (map, key) => Object.prototype.hasOwnProperty.call(map, key);
+
+/**
+ * Every prompt node id referenced as a LINK by one input value.
+ *
+ * ComfyUI's API prompt encodes a link as a two-element array `[node_id, output_index]`,
+ * and `execution.validate_inputs` reads `val[0]` as the upstream node id. That is the
+ * shape matched here.
+ *
+ * The direction of error is deliberate and one-way: this is used to decide what to KEEP,
+ * so over-matching keeps a node that did not need to be kept (harmless — the run is
+ * unchanged, it just prunes less) while under-matching drops a node the branch needs and
+ * turns a working run into "Required input is missing". So a widget value that merely
+ * LOOKS like a link (`[3, 0]` on a node whose id is "3") keeps node 3, and container
+ * values are scanned recursively in case a pack ever nests links in a list or object —
+ * neither can remove a dependency, only add one.
+ */
+function linkedIds(value, promptMap, out, depth = 0) {
+  if (depth > 4 || value == null || typeof value !== "object") return;
+  if (Array.isArray(value)) {
+    if (value.length === 2 && (typeof value[0] === "string" || typeof value[0] === "number")) {
+      const key = String(value[0]);
+      if (has(promptMap, key)) {
+        out.add(key);
+        return; // a matched link is fully consumed; its index is not a container
+      }
+    }
+    for (const v of value) linkedIds(v, promptMap, out, depth + 1);
+    return;
+  }
+  for (const v of Object.values(value)) linkedIds(v, promptMap, out, depth + 1);
+}
+
+/**
+ * The BACKWARD CLOSURE of `rootIds` in a posted prompt: the roots plus every node
+ * reachable by walking input links upstream. Returns null when the prompt is not a usable
+ * map or when ANY root is absent from it — an unresolvable root means the closure would be
+ * a guess, and the caller must then leave the body alone.
+ *
+ * Cycle-safe (a visited set) and order-independent. Ids are compared as STRINGS: a
+ * subgraph-nested target is a colon path ("10:15:359"), which is a prompt key like any
+ * other.
+ */
+export function upstreamClosure(promptMap, rootIds) {
+  if (!promptMap || typeof promptMap !== "object" || Array.isArray(promptMap)) return null;
+  const roots = (Array.isArray(rootIds) ? rootIds : []).map(String);
+  if (!roots.length) return null;
+  for (const r of roots) if (!has(promptMap, r)) return null;
+  const keep = new Set();
+  const stack = [...roots];
+  while (stack.length) {
+    const id = stack.pop();
+    if (keep.has(id)) continue;
+    keep.add(id);
+    const entry = promptMap[id];
+    const inputs = entry && typeof entry === "object" ? entry.inputs : null;
+    if (!inputs || typeof inputs !== "object") continue;
+    const found = new Set();
+    try {
+      linkedIds(inputs, promptMap, found);
+    } catch {
+      // A hostile/exotic inputs object must not take down the run. An input we could
+      // not read contributes no dependency, and the verification in
+      // prunedScopedPromptBody is what stops a half-read closure from being posted.
+      continue;
+    }
+    for (const dep of found) if (!keep.has(dep)) stack.push(dep);
+  }
+  return keep;
+}
+
+/**
+ * The node id a /prompt REJECTION names, when it names one in a structured field.
+ *
+ * `error.extra_info.node_id` is populated by ComfyUI for both early returns of
+ * `validate_prompt`'s pre-loop (no class_type; class not in NODE_CLASS_MAPPINGS) — the
+ * only rejections a prune can fix. Read as a string; `details` ("Node ID '#56'") and
+ * `message` are prose and are never parsed.
+ *
+ * Deliberately NOT gated on `error.type`. The id is what makes this decision structured,
+ * and the caller additionally requires that the named node lies outside the requested
+ * branch — a rejection that names a node the caller excluded is one the caller's own
+ * request already answers, whatever the server chose to call it. Every OTHER rejection
+ * shape ComfyUI produces (`prompt_outputs_failed_validation`, `prompt_no_outputs`,
+ * `invalid_prompt_id`) carries `extra_info: {}` and stops here.
+ */
+export function rejectionNodeId(rejectionBody) {
+  const err = rejectionBody?.error;
+  if (!err || typeof err !== "object" || Array.isArray(err)) return null;
+  const extra = err.extra_info;
+  if (!extra || typeof extra !== "object" || Array.isArray(extra)) return null;
+  const id = extra.node_id;
+  if (typeof id === "string" && id.trim() !== "") return id.trim();
+  if (typeof id === "number" && Number.isFinite(id)) return String(id);
+  return null;
+}
+
+/**
+ * True when a parsed /prompt response body proves NOTHING was queued: a top-level
+ * `error` object and no `prompt_id`. Status is checked by the caller.
+ *
+ * The absence of an id is the load-bearing half. ComfyUI's partial-validation path
+ * (#944) returns an id ALONGSIDE `node_errors` for a prompt it accepted and is already
+ * running; re-posting that would double-render it. An id present ⇒ never retried.
+ */
+export function rejectionQueuedNothing(body) {
+  if (!body || typeof body !== "object" || Array.isArray(body)) return false;
+  if (body.prompt_id != null && String(body.prompt_id).trim() !== "") return false;
+  const err = body.error;
+  return !!err && typeof err === "object" && !Array.isArray(err) && Object.keys(err).length > 0;
+}
+
+/**
+ * The same POST /prompt body with every node OUTSIDE the backward closure of
+ * `expectedExecIds` removed, or null when that cannot be done safely.
+ *
+ * Null (leave the body exactly as it was) for: an unreadable body, a prompt that is not a
+ * map, a target that is not a key of the prompt, and — importantly — a closure that
+ * already covers the whole prompt, because then there is nothing to prune and a second
+ * identical post would be pointless traffic.
+ *
+ * Everything except `prompt` is carried over verbatim: `partial_execution_targets` (so
+ * the scope the guard verified still travels), the queue-position `number` that
+ * identifies this run, `client_id`, and `extra_data` — which holds the FULL workflow for
+ * `extra_pnginfo`, so a saved image still embeds the whole graph the user was looking at,
+ * not the pruned one.
+ *
+ * The prune verifies ITSELF before returning, the way repairScopeInBody does: the
+ * rewritten text is re-parsed and the result must carry exactly the closure's node ids and
+ * the unchanged targets. Anything short of that returns null and the caller forwards the
+ * original — a rewrite that cannot be confirmed is not a rewrite.
+ *
+ * @returns {{text:string, removed:string[], kept:number}|null}
+ */
+export function prunedScopedPromptBody(bodyText, expectedExecIds) {
+  const expected = (Array.isArray(expectedExecIds) ? expectedExecIds : []).map(String);
+  if (!expected.length) return null;
+  let body;
+  try {
+    body = JSON.parse(bodyText);
+  } catch {
+    return null;
+  }
+  if (!body || typeof body !== "object" || Array.isArray(body)) return null;
+  const promptMap = body.prompt;
+  const keep = upstreamClosure(promptMap, expected);
+  if (!keep || !keep.size) return null;
+  const allIds = Object.keys(promptMap);
+  const removed = allIds.filter((id) => !keep.has(id));
+  if (!removed.length) return null; // nothing to prune — never re-post an identical body
+  const prunedPrompt = {};
+  for (const id of allIds) if (keep.has(id)) prunedPrompt[id] = promptMap[id];
+  let text;
+  try {
+    text = JSON.stringify({ ...body, prompt: prunedPrompt });
+  } catch {
+    return null;
+  }
+  // Re-read what was produced. The check is on the PARSED result, not on the object we
+  // built: JSON.stringify is where a value can vanish, and this is the last point at
+  // which that can be caught.
+  let check;
+  try {
+    check = JSON.parse(text);
+  } catch {
+    return null;
+  }
+  const outMap = check?.prompt;
+  if (!outMap || typeof outMap !== "object" || Array.isArray(outMap)) return null;
+  const outIds = Object.keys(outMap);
+  if (outIds.length !== keep.size) return null;
+  for (const id of outIds) if (!keep.has(id)) return null;
+  for (const id of expected) if (!has(outMap, id)) return null;
+  const targets = check.partial_execution_targets;
+  if (!Array.isArray(targets) || targets.length !== expected.length) return null;
+  const got = targets.map(String);
+  if (!expected.every((id) => got.includes(id))) return null;
+  return { text, removed, kept: outIds.length };
+}
+
+/**
+ * The whole decision, in one place: given the body we posted, the response ComfyUI
+ * returned, and the scope the caller asked for — is there a pruned body worth posting
+ * once more?
+ *
+ * All four conditions must hold, and each is checked against a structured field:
+ *   1. the response is non-2xx (it is a rejection at all);
+ *   2. its body proves nothing was queued (a top-level `error`, no `prompt_id`);
+ *   3. it names a node in `error.extra_info.node_id`;
+ *   4. that node is OUTSIDE the backward closure of the requested targets — i.e. it is a
+ *      node the caller's own request already excluded from execution.
+ *
+ * Returns null on anything else, including every kind of read failure: this sits on the
+ * path of a run that is already failing, and it must be able to add nothing rather than
+ * add a new failure mode.
+ *
+ * @returns {{text:string, removed:string[], namedNode:string}|null}
+ */
+export async function prunedRetryForRejection(res, bodyText, expectedExecIds) {
+  try {
+    const status = Number(res?.status);
+    if (!Number.isFinite(status) || (status >= 200 && status < 300)) return null;
+    if (typeof res?.clone !== "function") return null;
+    const parsed = await res.clone().json();
+    if (!rejectionQueuedNothing(parsed)) return null;
+    const namedNode = rejectionNodeId(parsed);
+    if (namedNode == null) return null;
+    const expected = (Array.isArray(expectedExecIds) ? expectedExecIds : []).map(String);
+    let requestBody;
+    try {
+      requestBody = JSON.parse(bodyText);
+    } catch {
+      return null;
+    }
+    const keep = upstreamClosure(requestBody?.prompt, expected);
+    if (!keep) return null;
+    // The named node must be one the caller EXCLUDED. A node inside the requested branch
+    // is a real blocker for the run they asked for, and hiding it behind a second post
+    // that fails the same way would replace a clear answer with a slower one.
+    if (keep.has(namedNode)) return null;
+    if (!has(requestBody.prompt, namedNode)) return null; // named a node we never sent
+    const pruned = prunedScopedPromptBody(bodyText, expected);
+    if (!pruned) return null;
+    return { text: pruned.text, removed: pruned.removed, namedNode };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * The disclosure sentence for a run that only queued because unrelated nodes were left
+ * out of the second post. Stated as what was OBSERVED — ComfyUI refused, naming a node
+ * outside the branch; the panel re-posted without the excluded nodes — because the panel
+ * cannot see why that node is unavailable on this server, only that it refused.
+ */
+export function prunedRetryNote({ toNodeId, namedNode, removed }) {
+  const list = (Array.isArray(removed) ? removed : []).map(String);
+  const shown = list.slice(0, 12);
+  const more = list.length > shown.length ? `, and ${list.length - shown.length} more` : "";
+  return (
+    `ComfyUI first REFUSED this run over node ${namedNode}, which is not upstream of ` +
+    `node ${toNodeId} and would not have executed: its prompt validation checks that every ` +
+    `node in the posted prompt resolves to an installed class BEFORE it narrows execution ` +
+    `to the requested branch (comfyui-mcp#1871). Nothing was queued by that refusal. The ` +
+    `panel then re-posted the SAME run with the ${list.length} node(s) outside the requested ` +
+    `branch omitted — ${shown.join(", ")}${more} — and that is the prompt ComfyUI accepted. ` +
+    `The nodes that executed are exactly node ${toNodeId} and its upstream dependencies, ` +
+    `which is what run-to-node asks for; the omitted nodes are untouched on your canvas and ` +
+    `a FULL run will still fail on them until the pack behind node ${namedNode} is installed.`
+  );
+}

--- a/web/js/lib/run-scope-guard.js
+++ b/web/js/lib/run-scope-guard.js
@@ -5,6 +5,13 @@ import { tr } from "./i18n.js";
 // input its handler overwrites) already live in scoped-batch-seed.js; this file
 // imports the verdict rather than restating them.
 import { rgthreeQueueTimeSeedInput } from "./scoped-batch-seed.js";
+// comfyui-mcp#1871 — ComfyUI's prompt validation requires EVERY node in the posted
+// prompt to resolve to an installed class before it narrows execution to
+// partial_execution_targets, so one unavailable pack on an unrelated branch vetoes a
+// run-to-node of a branch that does not touch it. The measured upstream facts, the
+// backward-closure walk, and the structured test that licenses a second post live in
+// partial-run-prune.js; this file imports the verdict.
+import { prunedRetryForRejection } from "./partial-run-prune.js";
 // #1273 — the THIRD volatility signal: cg-use-everywhere materialises its
 // broadcast links into the prompt inside its own queuePrompt patch, so the
 // inputs it will inject are queue-time volatile too. The measured facts about
@@ -1221,7 +1228,7 @@ export function createScopedRunGuard({
 } = {}) {
   const expected = (execIds ?? []).map(String);
   const maxBatch = Math.max(1, Math.floor(Number(batch)) || 1);
-  const state = { observed: 0, repaired: 0, rejected: 0, refused: 0, overrun: 0, overrunError: null, inFlight: 0, indeterminate: 0, closed: false, retired: false, dropped: null, droppedReason: null, failed: null, repairedFromKeys: null };
+  const state = { observed: 0, repaired: 0, rejected: 0, refused: 0, overrun: 0, overrunError: null, inFlight: 0, indeterminate: 0, closed: false, retired: false, dropped: null, droppedReason: null, failed: null, repairedFromKeys: null, prunedRetry: null };
   const waiters = new Set();
   const notify = () => {
     for (const fire of [...waiters]) fire();
@@ -1349,6 +1356,20 @@ export function createScopedRunGuard({
       let res;
       try {
         res = await origFetchApi(route, forwardOptions);
+        // comfyui-mcp#1871 — ComfyUI refuses a prompt whose OTHER branch names a class
+        // this server does not have, before it ever looks at partial_execution_targets.
+        // That refusal queued nothing (structured proof: non-2xx, a top-level `error`,
+        // no prompt_id), and the node it names is one this run's own scope excluded —
+        // so the requested branch gets ONE more post, with the excluded nodes left out.
+        // Null for every other outcome, including an accepted prompt: a run ComfyUI
+        // takes never reaches a second post, and the response below is the first one.
+        const retry = await prunedRetryForRejection(res, forwardOptions?.body, expected);
+        if (retry) {
+          // Record BEFORE the post, so a retry that throws is still disclosed as having
+          // been attempted rather than vanishing into the dispatch-failure message.
+          state.prunedRetry = { namedNode: retry.namedNode, removed: retry.removed };
+          res = await origFetchApi(route, { ...forwardOptions, body: retry.text });
+        }
       } catch (err) {
         // INDETERMINATE, not "never arrived" (codex gate r6). A fetch can throw
         // after ComfyUI already received and queued the prompt — a reset while
@@ -1813,6 +1834,10 @@ export async function dispatchScopedRun({
     }
     // r6: the dispatch itself failed (fetch threw / malformed response) —
     // terminal, truthful, NEVER queued:true.
+    // comfyui-mcp#1871 — every terminal return carries `prunedRetry`: when ComfyUI
+    // refused the first post over a node on ANOTHER branch and the run only queued
+    // because a second post left that branch out, this is the only place the caller
+    // can learn it happened. Null on every run that was accepted first time.
     if (guard.state.failed != null) {
       return {
         outcome: "failed",
@@ -1820,6 +1845,7 @@ export async function dispatchScopedRun({
         verified: guard.state.observed,
         indeterminate: guard.state.indeterminate,
       volatileInputs: volatileList,
+        prunedRetry: guard.state.prunedRetry,
         error: guard.state.failed +
           (!retireGuard
             ? " The scope guard stays installed as a sentinel for the rest of this page session."
@@ -1839,6 +1865,7 @@ export async function dispatchScopedRun({
         repairedFromKeys: guard.state.repairedFromKeys,
         indeterminate: guard.state.indeterminate,
       volatileInputs: volatileList,
+        prunedRetry: guard.state.prunedRetry,
       };
     }
     // The FULL batch verified — genuinely dispatched (r5: never on a partial).
@@ -1865,6 +1892,7 @@ export async function dispatchScopedRun({
         overrunNote: guard.state.overrunError,
         indeterminate: guard.state.indeterminate,
       volatileInputs: volatileList,
+        prunedRetry: guard.state.prunedRetry,
       };
     }
     // r7 CONTENT DRIFT with ZERO verified posts is NOT an argument-shape
@@ -1891,6 +1919,7 @@ export async function dispatchScopedRun({
       verified: guard.state.observed,
       indeterminate: guard.state.indeterminate,
       volatileInputs: volatileList,
+      prunedRetry: guard.state.prunedRetry,
       error: scopePartialBatchError({
         toNodeId,
         verified: guard.state.observed,


### PR DESCRIPTION
Fixes the underlying cause of artokun/comfyui-mcp#1871.

## The report

`panel_run(to_node_id: 43)` was meant to run only the ByteDance output branch. ComfyUI refused the whole run:

```
ComfyUI refused to queue the workflow: Node '...' not found. The custom node may not be installed. (Node ID #56)
```

Nodes 56/57 are Topaz nodes on a **different** output branch. They are not upstream of 43 and would never have executed.

## Why it happens

Read out of ComfyUI 0.33.2 (the reporter's version). `server.py` hands `partial_execution_targets` to exactly one place:

```python
valid = await execution.validate_prompt(prompt_id, prompt, partial_execution_targets)
```

and `execution.validate_prompt` opens with a loop over **every** entry of the posted prompt:

```python
for x in prompt:
    if 'class_type' not in prompt[x]:            # -> return (False, missing_node_type…)
    class_ = nodes.NODE_CLASS_MAPPINGS.get(prompt[x]['class_type'], None)
    if class_ is None:                           # -> return (False, missing_node_type…)
    if OUTPUT_NODE and (partial_execution_list is None or x in partial_execution_list):
        outputs.add(x)
```

The partial list is consulted on that last line — three lines **after** the two early returns. So the scope narrows which outputs become execution roots and narrows nothing about which nodes must resolve to an installed class. One unavailable pack anywhere in a workflow refuses every run-to-node in it, which is exactly the case run-to-node exists for.

That is upstream behaviour and the panel cannot change it. What it can change is which nodes it posts.

## The fix

When ComfyUI refuses a scoped run and the node it **names** lies outside the backward closure of the requested targets, the run gets one more post with the excluded nodes omitted. Same targets, same queue-position mark, same `extra_data` (so a saved image still embeds the full workflow) — only `prompt` is narrowed to the closure. Execution is unchanged by construction: `outputs_to_execute` is the partial targets, and the executor reaches only their dependencies.

**A retry, not the default.** Pruning every scoped run was the first design and it has a real cost, measured in the same file:

```python
for cache in self.caches.all:
    await cache.set_prompt(dynamic_prompt, prompt.keys(), is_changed_cache)
    cache.clean_unused()
```

The default classic cache drops every cached output whose key is not in the prompt it was just handed, so always-pruning would evict the *other* branch's cached results and make the user's next full run recompute a branch it had already rendered. Paying that only where the alternative is a total refusal keeps the accepted path byte-identical to today.

**What licenses a second post** — structured fields only, never message text:

- non-2xx status, **and**
- a top-level `error` object, **and**
- no `prompt_id` (`server.py` mints an id and calls `prompt_queue.put` only inside `if valid[0]:`), **and**
- `error.extra_info.node_id` names a node, **and**
- that node is outside the closure computed from the body we posted.

`details: "Node ID '#56'"` and the message are prose and are never parsed. A missing node **inside** the requested branch is not retried — pruning cannot fix it, and the clear answer is the useful one. `prompt_outputs_failed_validation` and `prompt_no_outputs` carry `extra_info: {}` and never reach a retry. The #944 partial-validation reply (an id *alongside* `node_errors`, for a prompt already running) is excluded by the id check.

**What counts as a dependency** is ComfyUI's own predicate, not an approximation. Both consumers read it from the input value itself: `comfy_execution/graph_utils.is_link` (list, length 2, `obj[0]` a str, `obj[1]` a number) and `execution.validate_inputs` (`isinstance(val, list)` → length 2 → `prompt[val[0]]['class_type']`, an unguarded lookup). The closure matches the broader of the two — a top-level length-2 list whose first element names a node in the prompt — so nothing `validate_inputs` would look up is ever pruned away.

**Disclosed, not silent.** The run result carries `excluded_nodes_omitted` plus a note naming the node ComfyUI refused, what was left out, and the fact that a FULL run will still fail until that pack is installed. A run that succeeds because the panel quietly changed the request is exactly the kind of thing the caller must be told.

## Gate

`node .claude/autopilot/codex-gate.mjs` — **SHIP** (exit 0) on round 3. It found two real defects first, both fixed here:

- **r1 P1** — the closure scanned *recursively* into input values on the theory that over-keeping is harmless. It is not: the retry is declined when the node ComfyUI named is inside the closure, so a coordinate pair like `{config:{coordinates:["56",0]}}` on a node in the branch would have handed the reporter their refusal straight back. Fixed by matching ComfyUI's predicate exactly, with a regression test on that shape.
- **r2 P1** — the disclosure asserts the pruned prompt is the one ComfyUI *accepted*. That was true by control flow, but the invariant lived three early-returns away and one of them returns null for a 400 whose `error` and `node_errors` are both empty. The claim now reads the count of posts ComfyUI accepted.

## Verification

`node --test browser_tests/unit/*.test.mjs` — 5948 pass. The one red is the known `#671 verifyInstalled` wall-clock flake (manager-install.test.mjs:821): it passes 125/125 when that file runs alone, and this branch does not touch it. `tsc --noEmit`, `i18n-check`, `i18n-render-check`, `check-tool-vocabulary`, `check-panel-scope` (with the compiler, via a node_modules junction — a fresh worktree does not inherit one) all clean. `npx playwright test --list` compiles: 78 tests in 33 files.

27 new tests: 21 pure (`browser_tests/unit/partial-run-prune.test.mjs`), 5 integration through the real `dispatchScopedRun` orchestration, 1 wiring test asserting on the panel source that the disclosure reaches the reply and is gated on acceptance.

Five mutations, each watched to fail:

| mutation | result |
| --- | --- |
| delete the retry call in `run-scope-guard.js` | 2 integration tests fail |
| delete the disclosure block in `comfyui-mcp-panel.js` | the wiring test fails |
| stop the closure walking upstream | 12 tests fail |
| drop the length-2 requirement from the link predicate | 1 test fails |
| drop the `verified > 0` acceptance gate | the wiring test fails |

**Not run, and why:** the Playwright e2e suite. ComfyUI serves the panel from `custom_nodes/comfyui-mcp-panel`, a junction to the main checkout — not to this worktree — so a run from here would have exercised the main checkout's working tree and said nothing about this change. This change is not UI-rendering: it alters the JSON `graph_run` returns and the request body a scoped run posts, both of which the unit suite drives through the real orchestration.

**Deliberately not done:** when the pruned post is *also* refused, the second rejection is what the caller is shown (the blocker inside their own branch, which is the actionable one) and the first, superseded refusal appears only in `prunedRetry`. Surfacing it in the rejection prose too would be a second sentence to keep true for no decision it changes.
