### PR TITLE
fix(mcp#1871): the panel's own pre-flight stops vetoing a branch the run excluded

### DIFF
--- a/browser_tests/unit/frontend-virtual-nodes.test.mjs
+++ b/browser_tests/unit/frontend-virtual-nodes.test.mjs
@@ -293,7 +293,7 @@ test("#1648 CALL SITE 3: the bounded list still says how many were withheld", ()
 });
 
 test("#1648 CALL SITE 3 WIRING: graph_run hands the refusal this page's registry", () => {
-  const at = PANEL.indexOf("const badIds = unrunnableNodeIds(built);");
+  const at = PANEL.indexOf("const badIds = unrunnableNodeIdsInScope(built, partialTargets);");
   assert.ok(at > 0, "the pre-flight must still be recognisable");
   const end = PANEL.indexOf("} catch (err) {", at);
   assert.ok(end > at, "the pre-flight's try block must still be recognisable");
@@ -305,10 +305,10 @@ test("#1648 CALL SITE 3 WIRING: graph_run hands the refusal this page's registry
 });
 
 test("#1648 CALL SITE 3 WIRING: the registry is diagnosis only — the refusal is still the prompt", () => {
-  const at = PANEL.indexOf("const badIds = unrunnableNodeIds(built);");
+  const at = PANEL.indexOf("const badIds = unrunnableNodeIdsInScope(built, partialTargets);");
   const end = PANEL.indexOf("} catch (err) {", at);
   const block = PANEL.slice(at, end);
-  // The go/no-go remains `unrunnableNodeIds(built)`; the registry appears only inside the
+  // The go/no-go remains `unrunnableNodeIdsInScope(built, partialTargets)`; the registry appears only inside the
   // message construction. A guard keyed on the registry would refuse runs that succeed.
   assert.match(block, /if \(badIds\.length\) \{/);
   assert.equal((block.match(/registered_node_types/g) ?? []).length, 1);

--- a/browser_tests/unit/graph-to-prompt-failure.test.mjs
+++ b/browser_tests/unit/graph-to-prompt-failure.test.mjs
@@ -103,7 +103,7 @@ test("#1582 the run path guards graphToPrompt BEFORE reading offenders", async (
   assert.ok(endOfTry > at, "the pre-flight try block must still be recognisable");
   const block = src.slice(at, endOfTry);
   const guard = block.indexOf("graphToPromptUnusable(built)");
-  const offenders = block.indexOf("unrunnableNodeIds(built)");
+  const offenders = block.indexOf("unrunnableNodeIdsInScope(built, partialTargets)");
   assert.ok(guard > -1, "the unusable-result guard must exist");
   assert.ok(offenders > -1, "the offender check must still exist");
   // ORDER is the fix. Asking for offenders first answers `[]` for an absent result and
@@ -127,7 +127,7 @@ test("#1582 the refusal keeps the prefix its own catch requires", async () => {
 //    the same real-source extraction pattern manager-dialect.test.mjs uses.
 
 /** Pull the pre-flight try/catch out of the monolith and run it with injected deps. */
-async function buildPreflight({ graphToPrompt, nodes = [], viewedNodes, registry = {} }) {
+async function buildPreflight({ graphToPrompt, nodes = [], viewedNodes, registry = {}, partialTargets }) {
   const { readFileSync } = await import("node:fs");
   const src = readFileSync(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf-8");
   const marker = src.indexOf("      // Inspect the SERIALIZED prompt");
@@ -141,7 +141,12 @@ async function buildPreflight({ graphToPrompt, nodes = [], viewedNodes, registry
     "app",
     "graph",
     "LG",
-    "unrunnableNodeIds",
+    "unrunnableNodeIdsInScope",
+    // comfyui-mcp#1871 - the block now reads the resolved run-to-node scope. It is a
+    // `let` in graph_run, so leaving it out of the factory would make the extracted body
+    // throw a ReferenceError that the pre-flight catch swallows - and the test would then
+    // see "no refusal" from a pre-flight that never ran at all.
+    "partialTargets",
     "describeUnrunnable",
     "missingNodeRunRefusal",
     "graphToPromptUnusable",
@@ -167,7 +172,8 @@ async function buildPreflight({ graphToPrompt, nodes = [], viewedNodes, registry
     { graphToPrompt },
     { _nodes: viewedNodes ?? nodes },
     { registered_node_types: registry },
-    mod.unrunnableNodeIds,
+    mod.unrunnableNodeIdsInScope,
+    partialTargets,
     mod.describeUnrunnable,
     mod.missingNodeRunRefusal,
     mod.graphToPromptUnusable,
@@ -233,6 +239,83 @@ test("#1582 BEHAVIOUR: the #1460 unrunnable-node refusal still fires", async () 
   assert.match(msg, /^NOT queued:/);
   assert.match(msg, /cannot be executed by the server/);
   assert.match(msg, /GoneNode/);
+});
+
+// ── comfyui-mcp#1871. #1511 took ComfyUI's veto of an excluded branch away: when the
+//    SERVER refuses over a node outside the requested closure, the run is re-posted
+//    without that branch. But the server only gets to refuse if we post, and this
+//    pre-flight refuses first. For the case where a pack is missing ENTIRELY there is no
+//    frontend registration, so no class_type, so this check fires and ComfyUI is never
+//    asked — the retry cannot save a run that never left the browser.
+//
+//    Driven through the SAME extracted pre-flight source: this is a claim about what
+//    production refuses, not about what a helper returns.
+
+// Two independent output branches, the reporter's shape: 43 is the branch asked for,
+// 56/57 are the branch whose pack is not installed at all (hence no class_type).
+const twoBranchPrompt = () => ({
+  output: {
+    "43": { class_type: "PreviewImage", inputs: { images: ["44", 0] } },
+    "44": { class_type: "EmptyImage", inputs: { width: 64, height: 64 } },
+    "56": { inputs: { image: ["57", 0] } },
+    "57": { inputs: {} },
+  },
+  workflow: {},
+});
+const twoBranchNodes = [
+  { id: 43, type: "PreviewImage" },
+  { id: 56, type: "TopazVideoAI" },
+];
+
+test("#1871 BEHAVIOUR: a scoped run is NOT refused for an unrunnable node outside its branch", async () => {
+  const msg = await runPreflight({
+    graphToPrompt: async () => twoBranchPrompt(),
+    nodes: twoBranchNodes,
+    registry: { PreviewImage: {} },
+    partialTargets: ["43"],
+  });
+  assert.equal(msg, "__NO_REFUSAL__", "node 56 is not upstream of 43; the run reaches ComfyUI");
+});
+
+test("#1871 BEHAVIOUR: a scoped run IS still refused for an unrunnable node INSIDE its branch", async () => {
+  // The narrowing must not become a blanket exemption for scoped runs: node 56 is now a
+  // dependency of the requested target, so the run genuinely cannot succeed and #1511's
+  // retry could not rescue it either (it declines when the named node is in the closure).
+  const prompt = twoBranchPrompt();
+  prompt.output["43"].inputs.images = ["56", 0];
+  const msg = await runPreflight({
+    graphToPrompt: async () => prompt,
+    nodes: twoBranchNodes,
+    registry: { PreviewImage: {} },
+    partialTargets: ["43"],
+  });
+  assert.match(msg, /^NOT queued:/);
+  assert.match(msg, /TopazVideoAI/);
+});
+
+test("#1871 BEHAVIOUR: a FULL run over the same graph still refuses — the narrowing is scoped-only", async () => {
+  const msg = await runPreflight({
+    graphToPrompt: async () => twoBranchPrompt(),
+    nodes: twoBranchNodes,
+    registry: { PreviewImage: {} },
+    partialTargets: undefined, // no to_node_id ⇒ every node is submitted
+  });
+  assert.match(msg, /^NOT queued:/);
+  assert.match(msg, /TopazVideoAI/);
+});
+
+test("#1871 BEHAVIOUR: an unresolvable scope refuses exactly as an unscoped run does", async () => {
+  // A target that is not a key of this prompt means the closure is a guess. Guessing
+  // toward "let it through" would ship a run that cannot succeed; the safe direction is
+  // the behaviour that already exists.
+  const msg = await runPreflight({
+    graphToPrompt: async () => twoBranchPrompt(),
+    nodes: twoBranchNodes,
+    registry: { PreviewImage: {} },
+    partialTargets: ["not-a-node-in-this-prompt"],
+  });
+  assert.match(msg, /^NOT queued:/);
+  assert.match(msg, /TopazVideoAI/);
 });
 
 // ── ROOT SCOPE (review, P1). graphToPrompt serializes the WHOLE workflow, so naming

--- a/browser_tests/unit/missing-node-preflight.test.mjs
+++ b/browser_tests/unit/missing-node-preflight.test.mjs
@@ -17,6 +17,7 @@ import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 import {
   unrunnableNodeIds,
+  unrunnableNodeIdsInScope,
   describeUnrunnable,
   missingNodeRunRefusal,
 } from "../../web/js/lib/missing-node-preflight.js";
@@ -119,7 +120,7 @@ test("#1460 a long list is bounded but says how many were withheld", () => {
 
 test("#1460 WIRING: the preflight reads the SERIALIZED prompt, not the canvas", () => {
   const src = readFileSync(join(ROOT, "web/js/comfyui-mcp-panel.js"), "utf8");
-  assert.match(src, /import \{[\s\S]*?unrunnableNodeIds,[\s\S]*?\} from "\.\/lib\/missing-node-preflight\.js";/);
+  assert.match(src, /import \{[\s\S]*?unrunnableNodeIdsInScope,[\s\S]*?\} from "\.\/lib\/missing-node-preflight\.js";/);
   const at = src.indexOf("const built = await app.graphToPrompt();");
   assert.ok(at > 0, "the preflight must serialize the prompt itself");
   // Bounded by the pre-flight's OWN catch rather than a byte count. A fixed 600 excluded
@@ -129,10 +130,84 @@ test("#1460 WIRING: the preflight reads the SERIALIZED prompt, not the canvas", 
   const endOfTry = src.indexOf("} catch (err) {", at);
   assert.ok(endOfTry > at, "the pre-flight's try block must still be recognisable");
   const block = src.slice(at, endOfTry);
-  assert.match(block, /unrunnableNodeIds\(built\)/);
+  // comfyui-mcp#1871 - and the SCOPE must be handed to it. `unrunnableNodeIdsInScope(built)`
+  // with the second argument dropped compiles, reads correctly, and silently restores the
+  // unscoped refusal for every run-to-node; only naming `partialTargets` here can see that.
+  assert.match(block, /unrunnableNodeIdsInScope\(built, partialTargets\)/);
   // The refuted approach must be gone entirely.
   assert.equal((src.match(/findUnregisteredTypes/g) ?? []).length, 0);
   assert.equal((src.match(/object_info\/\$\{encodeURIComponent\(cls\)\}/g) ?? []).length, 0);
+});
+
+// ── comfyui-mcp#1871: the refusal is narrowed to the requested branch, and to nothing
+//    else. Each case below is a direction the narrowing could go wrong in.
+
+const TWO_BRANCH = {
+  output: {
+    "43": { class_type: "PreviewImage", inputs: { images: ["44", 0] } },
+    "44": { class_type: "EmptyImage", inputs: {} },
+    "56": { inputs: { image: ["57", 0] } }, // pack absent ⇒ no class_type
+    "57": { inputs: {} },
+  },
+};
+
+test("#1871 a scoped run is refused only for unrunnable nodes inside its closure", () => {
+  assert.deepEqual(unrunnableNodeIdsInScope(TWO_BRANCH, ["43"]), []);
+  // …and the SAME prompt, targeted at the broken branch, still names both.
+  assert.deepEqual(unrunnableNodeIdsInScope(TWO_BRANCH, ["56"]), ["56", "57"]);
+});
+
+test("#1871 the narrowing never applies to a full run", () => {
+  for (const targets of [undefined, null, [], "43", 43]) {
+    assert.deepEqual(
+      unrunnableNodeIdsInScope(TWO_BRANCH, targets),
+      ["56", "57"],
+      `targets=${JSON.stringify(targets)} is not a scope`,
+    );
+  }
+});
+
+test("#1871 the narrowing never applies on a guess", () => {
+  // A root that is not a key of this prompt makes the closure unknowable; the honest
+  // answer is the one that already exists, not "probably fine".
+  assert.deepEqual(unrunnableNodeIdsInScope(TWO_BRANCH, ["nope"]), ["56", "57"]);
+  assert.deepEqual(unrunnableNodeIdsInScope(TWO_BRANCH, ["43", "nope"]), ["56", "57"]);
+  assert.deepEqual(unrunnableNodeIdsInScope({ output: null }, ["43"]), []);
+});
+
+test("#1871 the result is always a SUBSET of the unscoped answer", () => {
+  // The narrowing may only ever remove. A version that recomputed the list, or that
+  // reported closure members rather than filtering, could add an id that is perfectly
+  // runnable — and refuse a run for a node that has nothing wrong with it.
+  const all = unrunnableNodeIds(TWO_BRANCH);
+  for (const targets of [["43"], ["56"], ["44"], ["43", "56"], ["nope"], []]) {
+    for (const id of unrunnableNodeIdsInScope(TWO_BRANCH, targets)) {
+      assert.ok(all.includes(id), `${id} was invented for targets ${JSON.stringify(targets)}`);
+    }
+  }
+});
+
+test("#1871 a healthy graph is never refused, scoped or not", () => {
+  const clean = { output: { "1": { class_type: "PreviewImage", inputs: { images: ["2", 0] } }, "2": { class_type: "EmptyImage", inputs: {} } } };
+  assert.deepEqual(unrunnableNodeIdsInScope(clean, ["1"]), []);
+  assert.deepEqual(unrunnableNodeIdsInScope(clean, undefined), []);
+});
+
+test("#1871 WIRING: the run-to-node target is RESOLVED before the pre-flight reads it", () => {
+  // `partialTargets` is a `let` in graph_run. If the resolve block ever moves back below
+  // the pre-flight, the call site hits the temporal dead zone — and the pre-flight's own
+  // catch swallows everything that is not /^NOT queued:/, so a ReferenceError there does
+  // not surface as an error at all: it silently disables the whole missing-node
+  // pre-flight. Ordering is the only thing that stops that.
+  const src = readFileSync(join(ROOT, "web/js/comfyui-mcp-panel.js"), "utf8");
+  const runAt = src.indexOf("async graph_run({ batch_count, to_node_id }) {");
+  assert.ok(runAt > 0, "graph_run must still be recognisable");
+  const declared = src.indexOf("let partialTargets;", runAt);
+  const assigned = src.indexOf("partialTargets = [res.execId];", runAt);
+  const read = src.indexOf("unrunnableNodeIdsInScope(built, partialTargets)", runAt);
+  assert.ok(declared > runAt, "partialTargets must be declared inside graph_run");
+  assert.ok(assigned > declared, "the resolved target must be assigned to it");
+  assert.ok(read > assigned, "the pre-flight must read it AFTER it is resolved, never before");
 });
 
 test("#1460 WIRING: it runs BEFORE the prompt is queued", () => {

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -374,7 +374,7 @@ import { managerFetchFailureMessage } from "./lib/manager-fetch-failure.js";
 import { withoutFrontendVirtualTypes } from "./lib/frontend-virtual-nodes.js";
 import { collectFrontendVirtualTypes } from "./lib/virtual-registry.js";
 import {
-  unrunnableNodeIds,
+  unrunnableNodeIdsInScope,
   describeUnrunnable,
   missingNodeRunRefusal,
   graphToPromptUnusable,
@@ -15576,6 +15576,69 @@ const GRAPH_TOOL_EXECUTORS = {
     if (typeof app.queuePrompt !== "function") {
       throw new Error("app.queuePrompt is unavailable on this frontend");
     }
+    // "Run to node" = ComfyUI partial execution. The server keeps an OUTPUT node
+    // (SaveImage/PreviewImage/SaveVideo/…) as an execution root only when its id
+    // is in partial_execution_targets, then walks back through that node's
+    // dependencies — so only that branch renders. A non-output node can't be a
+    // root (the prompt would have "no outputs"). An output node nested in a
+    // subgraph is targeted by a PATH-style NodeExecutionId — the colon-joined
+    // chain of subgraph-instance ids from root down to the node ("10:15:359"),
+    // exactly what ComfyUI's own flattened prompt uses (#411). We resolve the id
+    // in the CURRENT viewing scope first (the reporter added the output node
+    // INSIDE the subgraph they were viewing), then root, then any nested subgraph.
+    // Stays undefined for a normal full run (byte-identical to the prior behaviour;
+    // a root-level target yields String(id), the same value as before).
+    //
+    // RESOLVED BEFORE THE PRE-FLIGHT (comfyui-mcp#1871). The pre-flight below refuses a
+    // run for nodes the server cannot execute, and a scoped run must only be refused for
+    // nodes that are IN its scope — which cannot be known before the target is resolved.
+    // Resolution is read-only, so moving it ahead changes nothing it does; it only changes
+    // which refusal answers first, and "node N was not found" is the better answer to a
+    // request naming node N than a report about some other node's pack.
+    let partialTargets;
+    // #699 — carried out of the resolve block so the queue-rejection summary can
+    // explain a `prompt_no_outputs` refusal of a target the panel already verified
+    // advertises output_node:true. Null for a full run.
+    let runToNodeInfo = null;
+    if (to_node_id != null) {
+      // Resolve the run-to-node target in the CURRENT viewing scope first (the reporter
+      // added / is targeting the output node INSIDE the subgraph they are viewing —
+      // active first-level #438/#439, nested #411). resolveRunToNodeTarget encapsulates
+      // the SAME find→output-eligibility→colon-path resolution the tests drive.
+      const viewing = graph !== rootGraph ? graph : null;
+      const res = resolveRunToNodeTarget(rootGraph, viewing, to_node_id);
+      if (!res.ok) {
+        if (res.code === "not_found") {
+          return {
+            queued: false,
+            error:
+              `node ${to_node_id} was not found on the root graph or in any subgraph — ` +
+              `run-to-node targets an output node in the current workflow (check the id in panel_query_graph)`,
+          };
+        }
+        // isOutputNode mirrors ComfyUI's util: node.constructor.nodeData.output_node.
+        if (res.code === "not_output") {
+          return {
+            queued: false,
+            error:
+              `node ${to_node_id} (${res.node.type}) is not an output node — "run to node" can ` +
+              `only target an output node such as SaveImage, PreviewImage, or SaveVideo. Pick the ` +
+              `output node at the end of the branch you want to render (is_output:true in panel_query_graph).`,
+          };
+        }
+        // "unreachable": the owning subgraph isn't reachable from the live root (stale view).
+        return {
+          queued: false,
+          error:
+            `node ${to_node_id} is inside a subgraph that isn't reachable from the current ` +
+            `workflow root (stale view) — re-open the workflow and try again`,
+        };
+      }
+      // Colon path for a nested node ("10:15:359") / first-level ("76:34"), or
+      // String(id) at root.
+      partialTargets = [res.execId];
+      runToNodeInfo = { nodeId: to_node_id, nodeType: res.node?.type };
+    }
     // comfyui-mcp#1460 — PRE-FLIGHT the node types. An unregistered type still draws
     // on the canvas and is still included by ComfyUI's own graphToPrompt, with
     // `class_type: undefined` — so the server answers "has no class_type" for ONE
@@ -15626,7 +15689,13 @@ const GRAPH_TOOL_EXECUTORS = {
           ),
         );
       }
-      const badIds = unrunnableNodeIds(built);
+      // comfyui-mcp#1871 — SCOPED to the requested branch. The refusal's own premise ("a
+      // run carrying an unregistered type cannot succeed") holds for a full run and stopped
+      // holding for a run-to-node once #1511 let ComfyUI's refusal of an excluded branch be
+      // retried without it: such a run CAN succeed, and this check was the only thing left
+      // preventing it. Full runs and every case the closure cannot be computed for get the
+      // unscoped answer, so nothing that refuses today stops refusing.
+      const badIds = unrunnableNodeIdsInScope(built, partialTargets);
       if (badIds.length) {
         const liveNodes = Array.isArray(graph?._nodes) ? graph._nodes : [];
         // comfyui-mcp#1648 — hand the refusal THIS PAGE's litegraph registry so it can
@@ -15665,63 +15734,6 @@ const GRAPH_TOOL_EXECUTORS = {
     const batch = Number.isFinite(requestedBatch)
       ? Math.min(Math.max(requestedBatch, 1), MAX_BATCH)
       : 1;
-
-    // "Run to node" = ComfyUI partial execution. The server keeps an OUTPUT node
-    // (SaveImage/PreviewImage/SaveVideo/…) as an execution root only when its id
-    // is in partial_execution_targets, then walks back through that node's
-    // dependencies — so only that branch renders. A non-output node can't be a
-    // root (the prompt would have "no outputs"). An output node nested in a
-    // subgraph is targeted by a PATH-style NodeExecutionId — the colon-joined
-    // chain of subgraph-instance ids from root down to the node ("10:15:359"),
-    // exactly what ComfyUI's own flattened prompt uses (#411). We resolve the id
-    // in the CURRENT viewing scope first (the reporter added the output node
-    // INSIDE the subgraph they were viewing), then root, then any nested subgraph.
-    // Stays undefined for a normal full run (byte-identical to the prior behaviour;
-    // a root-level target yields String(id), the same value as before).
-    let partialTargets;
-    // #699 — carried out of the resolve block so the queue-rejection summary can
-    // explain a `prompt_no_outputs` refusal of a target the panel already verified
-    // advertises output_node:true. Null for a full run.
-    let runToNodeInfo = null;
-    if (to_node_id != null) {
-      // Resolve the run-to-node target in the CURRENT viewing scope first (the reporter
-      // added / is targeting the output node INSIDE the subgraph they are viewing —
-      // active first-level #438/#439, nested #411). resolveRunToNodeTarget encapsulates
-      // the SAME find→output-eligibility→colon-path resolution the tests drive.
-      const viewing = graph !== rootGraph ? graph : null;
-      const res = resolveRunToNodeTarget(rootGraph, viewing, to_node_id);
-      if (!res.ok) {
-        if (res.code === "not_found") {
-          return {
-            queued: false,
-            error:
-              `node ${to_node_id} was not found on the root graph or in any subgraph — ` +
-              `run-to-node targets an output node in the current workflow (check the id in panel_query_graph)`,
-          };
-        }
-        // isOutputNode mirrors ComfyUI's util: node.constructor.nodeData.output_node.
-        if (res.code === "not_output") {
-          return {
-            queued: false,
-            error:
-              `node ${to_node_id} (${res.node.type}) is not an output node — "run to node" can ` +
-              `only target an output node such as SaveImage, PreviewImage, or SaveVideo. Pick the ` +
-              `output node at the end of the branch you want to render (is_output:true in panel_query_graph).`,
-          };
-        }
-        // "unreachable": the owning subgraph isn't reachable from the live root (stale view).
-        return {
-          queued: false,
-          error:
-            `node ${to_node_id} is inside a subgraph that isn't reachable from the current ` +
-            `workflow root (stale view) — re-open the workflow and try again`,
-        };
-      }
-      // Colon path for a nested node ("10:15:359") / first-level ("76:34"), or
-      // String(id) at root.
-      partialTargets = [res.execId];
-      runToNodeInfo = { nodeId: to_node_id, nodeType: res.node?.type };
-    }
 
     // app.queuePrompt(number, batchCount, queueNodeIds | QueuePromptOptions) —
     // the 3rd arg becomes the request's partial_execution_targets, but its SHAPE

--- a/web/js/lib/missing-node-preflight.js
+++ b/web/js/lib/missing-node-preflight.js
@@ -32,6 +32,13 @@
  * are the bytes that would have been sent.
  */
 
+// comfyui-mcp#1871 — a scoped run must only be refused for nodes that are IN its scope.
+// The backward-closure walk that decides what "in its scope" means already lives in
+// partial-run-prune.js, where #1511 put it; this file imports the verdict rather than
+// restating it. Two answers to one question is two chances to disagree, and the two
+// places that ask it here are the two ends of the same refusal.
+import { upstreamClosure } from "./partial-run-prune.js";
+
 /** A serialized entry the server cannot execute: no usable `class_type`. */
 function unrunnable(entry) {
   const ct = entry?.class_type;
@@ -54,6 +61,45 @@ export function unrunnableNodeIds(prompt) {
     if (entry && typeof entry === "object" && unrunnable(entry)) ids.push(String(id));
   }
   return ids;
+}
+
+/**
+ * The unrunnable ids a run should actually be REFUSED for (comfyui-mcp#1871).
+ *
+ * #1511 removed ComfyUI's veto of a branch a run-to-node excluded: when the server
+ * refuses over a node outside the requested closure, the run gets one more post with
+ * that branch left out. But the server only gets to refuse if we post at all, and this
+ * pre-flight refuses FIRST — unscoped. So the retry never fires for the case where the
+ * pack is missing ENTIRELY rather than backend-only: no frontend registration means no
+ * `class_type` in the serialized prompt, which is this check's whole trigger. Measured
+ * on main after #1511: `panel_run(to_node_id: 43)` with an unregistered pack on nodes
+ * 56/57 is still refused here, naming 56 and 57, and ComfyUI is never asked.
+ *
+ * The refusal rests on one claim: "a run carrying an unregistered type cannot succeed,
+ * so this blocks no working run." That is true of a full run. It stopped being true of a
+ * run-to-node the moment the excluded branch could be dropped from a retry — the run CAN
+ * succeed, and refusing here is the only thing preventing it.
+ *
+ * So the scope narrows the refusal and nothing else. What it does NOT do:
+ *   - it never adds an id (the result is always a subset of `badIds`);
+ *   - it never narrows a full run — with no targets, today's answer is returned;
+ *   - it never narrows on a guess — when the closure cannot be computed (roots that are
+ *     not keys of this prompt, an unreadable prompt), today's answer is returned.
+ * Every uncertain case therefore refuses exactly as it does now.
+ *
+ * @param {unknown} prompt          graphToPrompt() result, or its `output` map
+ * @param {string[]|null|undefined} targetIds  partial-execution roots, null for a full run
+ * @returns {string[]} ids to refuse for
+ */
+export function unrunnableNodeIdsInScope(prompt, targetIds) {
+  const badIds = unrunnableNodeIds(prompt);
+  if (!badIds.length) return badIds;
+  const roots = Array.isArray(targetIds) ? targetIds.map(String) : [];
+  if (!roots.length) return badIds; // full run — every unrunnable node is submitted
+  const map = prompt?.output && typeof prompt.output === "object" ? prompt.output : prompt;
+  const closure = upstreamClosure(map, roots);
+  if (!closure) return badIds; // cannot tell what is unrelated ⇒ refuse as before
+  return badIds.filter((id) => closure.has(id));
 }
 
 /**


### PR DESCRIPTION
Closes the remaining half of the underlying cause of **artokun/comfyui-mcp#1871** — "panel_run to_node_id validates unrelated missing-node branches". (Cross-repo, so it will not auto-close; closing that issue by hand on merge.)

> **This PR was rewritten.** It originally carried a different fix for #1871 — trimming every scoped run's POST body to the target's backward closure — which was gated SHIP and then **superseded by #1511**, merged while it was in review. #1511's design is better: it prunes only *after* ComfyUI has actually refused, so it costs nothing on the runs that were never broken. That work is dropped, and what remains is the part #1511 does not reach. The earlier review, including a P2 it found, is preserved in the comments below.

## What #1511 left behind

#1511 removed **ComfyUI's** veto: when the server refuses a run-to-node over a node outside the requested closure, the run gets one more post with that branch left out.

But the server only gets to refuse if we post — and the #1460 missing-node pre-flight refuses **first**, unscoped. So the retry never fires for the case where the pack is missing *entirely* rather than backend-only: no frontend registration means no `class_type` in the serialized prompt, which is precisely this check's trigger. That is also the likelier shape of "a pack you do not have"; the reporter's own case was the narrower one where the frontend JS had loaded and only the server class was absent.

Measured on `main` at `dd7f37ac`, driving the **real extracted pre-flight block** out of `comfyui-mcp-panel.js`:

```
tree is UNSCOPED
  run-to-node 43: REFUSED — NOT queued: 2 nodes in this workflow cannot be executed
                  by the server — TopazVideoAI (node 56), node 57.
```

Node 43's branch is `EmptyImage → PreviewImage`; 56/57 are a separate branch. ComfyUI is never asked, so nothing #1511 added can help. After this change:

```
tree is SCOPED
  run-to-node 43: no refusal (proceeds to ComfyUI)
  full run:       REFUSED — NOT queued: 2 nodes ... TopazVideoAI (node 56), node 57.
```

## The change

The refusal rests on one claim, stated in its own comment: *"a run carrying an unregistered type cannot succeed, so this blocks no working run."* That is true of a full run. It stopped being true of a run-to-node the moment #1511 let the excluded branch be dropped from a retry — such a run **can** succeed, and this check was the only thing left preventing it.

So the scope narrows the refusal and nothing else:

- the result is always a **subset** of the unscoped answer — pinned by a test that checks every returned id against it across six different target sets, because a version that reported closure members instead of filtering would refuse a run for a node that has nothing wrong with it;
- a full run — no targets, `null`, an empty list, a bare string — gets today's answer;
- an **unresolvable** scope (a root that is not a key of this prompt) gets today's answer, because a closure that cannot be computed is a guess and the safe direction is the behaviour that already exists.

`upstreamClosure` is **imported from `partial-run-prune.js`**, not reimplemented. Both places are answering "is this node part of the requested run?", and #1511's version is the more careful one — it deliberately keeps a superset of what the executor walks, matching `validate_inputs`' broader len-2 handling rather than `is_link`'s stricter typing. Two answers to one question is two chances to disagree, and here they are the two ends of the same refusal.

Resolving the run-to-node target moved above the pre-flight so the scope exists when it is read. Resolution is read-only; it only changes which refusal answers first, and *"node N was not found"* is the better reply to a request naming node N than a report about some other node's pack.

## Evidence

- **The ordering is pinned by its own test**, and it needs to be. With the resolve block below the pre-flight, `partialTargets` sits in its temporal dead zone; the `ReferenceError` is swallowed by the pre-flight's own `catch` (it re-throws only `/^NOT queued:/`), and the entire missing-node check silently stops running. A failure with no symptom at all.
- **Mutation-tested, 5 of 5 killed**: the helper ignoring its scope; narrowing a full run; treating an unresolvable closure as "nothing is in scope"; returning the closure instead of the filtered subset; and the call site dropping its second argument. Each fails at least one test that names what it broke.
- The probe above initially reported a false "no refusal" because it did not inject `partialTargets` into the extracted block — the swallowed-ReferenceError trap, hit live. Both the probe and the `#1582` harness now inject it, which is what makes the "no refusal" result mean anything.
- **The load-bearing claim was tested, not assumed.** Removing our refusal is only an improvement if ComfyUI's own refusal is then rescued by #1511's retry. Against the live server and the real merged helper, for the bare-node shape this change newly lets through:

  ```
  1. ComfyUI's answer to the unpruned body: HTTP 400
     {"error": {"type": "missing_node_type",
                "message": "Node 'ID #56' has no class_type. ...",
                "extra_info": {"node_id": "56", "class_type": null, "node_title": null}}}
  2. rejectionNodeId -> "56"   rejectionQueuedNothing -> true
     is that node outside the requested closure? -> true
  3. prunedRetryForRejection -> RETRY PRODUCED  (namedNode=56, removed=["56","57"])
     retry prompt keys: ["43","44"]
  4. the retry POST: HTTP 200  {"prompt_id": "a10e6c67-...", "node_errors": {}}
  ```

  So the rejection names the node in a **structured** field for the no-`class_type` branch too (not only the unresolved-class one), and the run genuinely completes.
- `npm run test:unit`: **5962 pass / 0 fail** (5953 on `origin/main` before this), including the i18n, tool-vocabulary and panel-scope gates. `npx tsc --noEmit` clean.

## Review status — **PENDING**

**This change has not been reviewed yet.** Review has been requested from grok in a comment below, with the load-bearing parts named. It is not gated, and no verdict is claimed for it. Not to be merged while that review is outstanding, and not on the author's own verification alone.

For the record: the *superseded* diff (the unconditional prune, now dropped) did get an independent adversarial pass, whose verdict and P2 are preserved in the comments above — the P2 about ComfyUI cache eviction is why #1511's conditional design is the right one, and is worth keeping in view if anyone reaches for an unconditional prune again.

## Browser suite

Not re-run against this reduced diff. On the previous one it was `21 failed / 57 passed` against `22 failed / 56 passed` for clean `origin/main` on the same rig — **zero failures unique to the branch**. The suite is broadly red here because ComfyUI's `custom_nodes` junction points at the shared checkout, which sits on another branch, so any spec serving panel source from a worktree gets a split module graph and the panel never mounts. e2e is deliberately not in CI for this repo (`ci.yml`: *"playwright.config.ts requires a real ComfyUI at :8188 with models loaded, so it belongs to the pre-release local soak"*). Nothing here is panel-*rendered*; the change removes a refusal.

## What I deliberately did not do

- **Did not keep the unconditional prune.** It was gated SHIP, but #1511 does the same job without evicting ComfyUI's caches on runs that were never broken. Shipping mine on top would have replaced a cheaper design with a costlier one.
- **Did not add a second closure implementation.** The one #1511 merged is reused as-is.
- **Did not touch the orchestrator.** `panel_run` forwards `{cmd:"graph_run", to_node_id}` and never holds a prompt.
- **Did not repoint the rig's `custom_nodes` junction** to get a greener e2e run. It is shared, and other work is live on that checkout.
