### PR TITLE
fix(1872): the refusal claims nothing about a final size it never read

### DIFF
--- a/browser_tests/unit/graph-edit-node.test.mjs
+++ b/browser_tests/unit/graph-edit-node.test.mjs
@@ -769,13 +769,19 @@ test("#1872 refuses when an untouched size drifted and will not go back", () => 
       assert.doesNotMatch(error.message, /600/, "600 is this guard's failed write, not the drift");
       assert.doesNotMatch(
         error.message,
-        /rolled back/,
-        "size is exactly what would not go back — do not promise a rollback of it",
+        /rolled back|left where|unchanged/,
+        "size is exactly what would not go back — claim nothing about where it ended",
       );
+      // The refusal must not name a final size at all. restore() writes size a
+      // SECOND time and re-runs updateArea, so neither this guard's failed write
+      // (600) nor anything else is a state the throwing line ever observed.
+      assert.doesNotMatch(error.message, /600|800/, "no final-state number this line never read");
       return true;
     },
   );
   assert.equal(node.title, "Node 7");
   assert.equal(node.pos[0], 100, "every field the guard CAN restore is restored");
   assert.equal(node.pos[1], 200);
+  // Measured, not assumed: this is why the message may not describe the size.
+  assert.equal(node.size[1], 800, "restore() moves size again after the refusal");
 });

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -15067,12 +15067,17 @@ const GRAPH_TOOL_EXECUTORS = {
               // Name the drift that was OBSERVED — the reading taken BEFORE the restore
               // attempt. Re-reading node.size here would report whatever the failed
               // writeSize left behind (a widget-minimum clamp), which is our own number
-              // rather than the drift the caller needs to see. And do not promise a
-              // rollback: the size is precisely what would not go back. Every other
-              // captured field is restored below, and the edit is refused.
+              // rather than the drift the caller needs to see.
+              //
+              // State NOTHING about where the size ends up. It is not the captured value
+              // (that is what just failed to go back), and it is not the value this write
+              // left either: the catch below runs restore(), which writes size AGAIN and
+              // then re-runs refreshNodeArea/updateArea — measured, that carries the
+              // fixture from 580 to 600 to 800. Any final-state claim here is a number
+              // this line never observed, so send the caller to re-read instead.
               const drifted = now ? `[${now[0]}, ${now[1]}]` : "an unreadable value";
               throw new Error(
-                `node ${node.id} size drifted to ${drifted} during this edit and could not be restored to its previous [${snap.size[0]}, ${snap.size[1]}] — the edit was refused and its size left where the restore attempt landed`,
+                `node ${node.id} size drifted to ${drifted} during this edit and could not be restored to its previous [${snap.size[0]}, ${snap.size[1]}] — the edit was refused; re-read this node's geometry before relying on it`,
               );
             }
           }


### PR DESCRIPTION
Follow-up to #1509 (the underlying cause of artokun/comfyui-mcp#1872 is already fixed there).
This corrects one false clause that #1509 shipped in its own new error message.

## The false clause

#1509 added a refusal for the case where an *untouched* size drifted and could not be put
back. Its last clause read:

> — the edit was refused **and its size left where the restore attempt landed**

That is not true. The `catch` immediately below runs `restore()`, which writes size a
**second** time and then re-runs `refreshNodeArea` → `updateArea`. Measured on the guard's
own fixture, the height moves:

| stage | height |
|---|---|
| entry | 80 |
| `updateArea` drift, the value the message names | 580 |
| this guard's failed `writeSize` | 600 |
| **after `restore()` — where it actually ends** | **800** |

No line on that path ever reads 800, so the message was describing a state it had not
observed. That is the same defect the commit one earlier in #1509 fixed a clause sooner —
I moved the unmeasured claim rather than removing it.

## The change

Say only what was measured: name the drift that was read, and the captured value that would
not go back. Then send the caller to re-read the geometry instead of asserting a final state:

```
node 7 size drifted to [225, 580] during this edit and could not be restored to its
previous [225, 80] — the edit was refused; re-read this node's geometry before relying on it
```

No behaviour change — same throw, same conditions, same rollback path. Message and comment
only.

## Verification

- Probed the shipped executor extracted from `web/js/comfyui-mcp-panel.js` directly: the
  height after the throw is **800**, printed, not assumed.
- `browser_tests/unit/graph-edit-node.test.mjs` now asserts the message contains neither
  `600` nor `800` (no final-state number the throwing line never read) and matches neither
  `rolled back|left where|unchanged`; and asserts `node.size[1] === 800` — the measurement
  that makes any final-state claim wrong.
- **Mutation check:** reverted `web/js/comfyui-mcp-panel.js` to #1509's version with the
  tests in place → `pass 24 / fail 1`, the refusal test. Restored → 25/25.
- Full panel unit suite: `5925 tests, 1 fail` — the known manager-install #671 wall-clock
  flake, unrelated file.
- `i18n-check`, `i18n-render-check`, `check-tool-vocabulary`, `check-panel-scope`: all OK.
- Playwright e2e not run: no spec touches `graph_edit_node`, and this is an error-string
  change with no rendered surface. Saying so rather than implying coverage.

## Gate

codex was unavailable (account exhausted until 2026-08-19); gated by an independent
adversarial review instead (`.claude/autopilot/claude-gate.mjs`), per the standing
substitution. This finding came out of that gate's round 2 on #1509, graded P2 and
explicitly not a merge block — hence a follow-up rather than a revert.
