### PR TITLE
fix(mcp#1877): a group is built from the same footprint its members are judged by

### DIFF
--- a/browser_tests/create-group-collapsed.spec.ts
+++ b/browser_tests/create-group-collapsed.spec.ts
@@ -1,0 +1,134 @@
+/**
+ * Tier 1 — mcp#1877: panel_create_group must not build a box around a node and
+ * then report that node as missing (agent-free).
+ *
+ * The unit tests pin the geometry and the call site against fixtures. This spec
+ * is the part they cannot reach: the box is a rectangle LiteGraph draws, and
+ * membership is LiteGraph's own containsCentre rule over its own cached rects.
+ * Here the panel's real dispatcher runs `graph_create_group` against the LIVE
+ * graph in a real browser, and the assertion is taken from the ENGINE
+ * (LGraphGroup._nodes after its own recomputeInsideNodes), not from the panel's
+ * report of itself.
+ *
+ * The reported shape: a COLLAPSED node whose `size` carries a zero height —
+ * accepted, serialized and re-configured unchanged by the frontend. The box
+ * builder read that 0 literally while the cached-rect writer replaced it with
+ * the default 100, so the rect's centre landed just below the box that had been
+ * built around it and the tool returned an EMPTY group with bounds that visibly
+ * covered the requested node.
+ *
+ * PREREQUISITE: a real ComfyUI at http://localhost:8188 with this pack linked
+ * into custom_nodes and CORS enabled (see playwright.config.ts).
+ */
+import { test, expect } from './fixtures/panelTest'
+import type { MockBridge } from './fixtures/MockBridge'
+import { routeWorktreeSource } from './fixtures/worktreeSource'
+
+interface CmdReply {
+  rid: string
+  ok: boolean
+  result?: Record<string, unknown>
+  error?: string
+}
+
+async function command(
+  bridge: MockBridge,
+  cmd: string,
+  args: Record<string, unknown> = {},
+  timeoutMs = 15_000
+): Promise<Record<string, unknown>> {
+  const reply = (await bridge.command(cmd, args, timeoutMs)) as unknown as CmdReply
+  if (!reply.ok) throw new Error(reply.error ?? `command "${cmd}" failed`)
+  return reply.result ?? {}
+}
+
+// Serve THIS checkout's web/js. Without it the spec exercises whatever pack the
+// dev ComfyUI has installed — which is how it reproduced the shipped bug while
+// this branch's fix sat unloaded a directory away.
+test.beforeEach(async ({ context }) => {
+  await routeWorktreeSource(context)
+})
+
+test.describe('graph_create_group with a collapsed node (mcp#1877)', () => {
+  test('the requested node is a member of the box built around it', async ({
+    panel,
+    mockBridge
+  }) => {
+    await panel.goto()
+    await panel.setBridgeUrl(mockBridge.url)
+    await panel.openSidebar()
+    await panel.connect()
+
+    await command(mockBridge, 'graph_clear')
+
+    const res0 = await command(mockBridge, 'graph_add_node', { class_type: 'VAEDecode' })
+    const added = res0.added as { id: number } | undefined
+    expect(added?.id).toBeDefined()
+    const nodeId = Number(added!.id)
+
+    // Put the node in the reported state, then PROVE the frontend accepted it.
+    // Whole-array assignment, not element writes: `size` and `pos` are
+    // layout-store-backed on this frontend and an element poke can be dropped by
+    // the next render, which would leave this spec silently testing an ordinary
+    // expanded node — green, and blind to the bug it exists for.
+    const state = await panel.page.evaluate(
+      ({ id }) => {
+        const graph = (window as unknown as { app: { graph: any } }).app.graph
+        const n = graph.getNodeById(id)
+        n.pos = [9750, 5410]
+        n.size = [225, 0]
+        if (!n.flags?.collapsed) n.collapse?.()
+        if (!n.flags?.collapsed) n.flags = { ...(n.flags ?? {}), collapsed: true }
+        return {
+          pos: [n.pos?.[0], n.pos?.[1]],
+          size: [n.size?.[0], n.size?.[1]],
+          collapsed: !!n.flags?.collapsed
+        }
+      },
+      { id: nodeId }
+    )
+    expect(state.pos).toEqual([9750, 5410])
+    expect(state.size).toEqual([225, 0])
+    expect(state.collapsed).toBe(true)
+
+    const res = await command(mockBridge, 'graph_create_group', {
+      title: 'Decode',
+      node_ids: [nodeId]
+    })
+    const group = res.group as Record<string, unknown>
+
+    // The panel's own answer. Ids are compared as STRINGS: this frontend hands
+    // out string node ids, and the whole point of classifyRequestedMembership's
+    // normalisation is that a requested 72 and a member "72" are the same node.
+    expect(group.node_count).toBe(1)
+    expect((group.node_ids as unknown[]).map(String)).toEqual([String(nodeId)])
+    expect(group.missing_node_ids).toBeUndefined()
+    expect(group.warning).toBeUndefined()
+
+
+    // The ENGINE's answer, which is what the user sees on the canvas. Before the
+    // fix this array was empty while `bounding` covered [9750, 5410].
+    const engine = await panel.page.evaluate(
+      ({ id, nodeId }) => {
+        const graph = (window as unknown as { app: { graph: any } }).app.graph
+        const g = (graph._groups ?? []).find((x: any) => x.id === id) ?? (graph._groups ?? []).at(-1)
+        g?.recomputeInsideNodes?.()
+        const n = graph.getNodeById(nodeId)
+        return {
+          memberIds: (g?._nodes ?? []).map((x: any) => String(x.id)),
+          bounding: g?._bounding ? Array.from(g._bounding as number[]).map(Math.round) : null,
+          // Reported so a drifted precondition is diagnosable rather than a mystery.
+          nodeSize: [n?.size?.[0], n?.size?.[1]],
+          nodePos: [n?.pos?.[0], n?.pos?.[1]]
+        }
+      },
+      { id: Number(group.id), nodeId }
+    )
+
+
+    expect(engine.memberIds, JSON.stringify(engine)).toContain(String(nodeId))
+    const [gx, gy, gw, gh] = engine.bounding as number[]
+    expect(9750 >= gx && 9750 < gx + gw).toBe(true)
+    expect(5410 >= gy && 5410 < gy + gh).toBe(true)
+  })
+})

--- a/browser_tests/unit/create-group-collapsed.test.mjs
+++ b/browser_tests/unit/create-group-collapsed.test.mjs
@@ -1,0 +1,204 @@
+// mcp#1877 — the SHIPPED graph_create_group must not build a box around a node
+// and then report that node as missing.
+//
+// This drives the REAL executor extracted from the panel source, not a
+// re-implementation: the geometry fix lives in group-geometry.js, but the
+// postcondition that turns it into a correct tool RESULT (which ids are
+// reported, and what the warning says) lives entirely at this call site, where a
+// helper-level test cannot see it.
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import {
+  boundsAroundNodes,
+  groupMemberNodes,
+  classifyRequestedMembership,
+  describeGroupMembershipGap,
+  syncNodeArea,
+  syncGraphNodeAreas,
+} from "../../web/js/lib/group-geometry.js";
+
+const panelPath = fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url));
+const panelSrc = readFileSync(panelPath, "utf8");
+
+const grab = (re, what) => {
+  const m = panelSrc.match(re);
+  assert.ok(m, `could not locate ${what} in panel source`);
+  return m[0];
+};
+
+const createGroupSrc = grab(
+  / {2}graph_create_group\(\{[\s\S]*?\n {2}\},/,
+  "graph_create_group",
+);
+const summarizeGroupSrc = grab(
+  /\nfunction summarizeGroup\(graph, g\) \{[\s\S]*?\n\}/,
+  "summarizeGroup",
+);
+const setGroupBoundsSrc = grab(
+  /\nfunction setGroupBounds\(group, \[x, y, w, h\]\) \{[\s\S]*?\n\}/,
+  "setGroupBounds",
+);
+const nextGroupIdSrc = grab(
+  /\nfunction nextGroupId\(graph\) \{[\s\S]*?\n\}/,
+  "nextGroupId",
+);
+
+/** A LiteGraph-shaped LGraphGroup double: a real _bounding quad and the
+ *  frontend behaviour the panel exists to work around — recomputeInsideNodes
+ *  leaves _nodes stale/empty, so the reported membership must come from live
+ *  geometry. */
+class LGraphGroupDouble {
+  constructor(title) {
+    this.title = title;
+    this._bounding = [0, 0, 140, 80];
+    this._nodes = [];
+  }
+  recomputeInsideNodes() {
+    this._nodes.length = 0;
+  }
+}
+
+function realCreateGroup(graph) {
+  const getGraphCtx = () => ({ graph, LG: { LGraphGroup: LGraphGroupDouble } });
+  return new Function(
+    "getGraphCtx",
+    "tr",
+    "syncGraphNodeAreas",
+    "syncNodeArea",
+    "boundsAroundNodes",
+    "groupMemberNodes",
+    "classifyRequestedMembership",
+    "describeGroupMembershipGap",
+    "placementFor",
+    "clipOutlineTitle",
+    "GROUP_NODE_IDS_CAP",
+    `"use strict";
+     ${setGroupBoundsSrc}
+     ${nextGroupIdSrc}
+     ${summarizeGroupSrc}
+     const executors = { ${createGroupSrc} };
+     return executors.graph_create_group;`,
+  )(
+    getGraphCtx,
+    (_key, fallback) => fallback,
+    syncGraphNodeAreas,
+    syncNodeArea,
+    boundsAroundNodes,
+    groupMemberNodes,
+    classifyRequestedMembership,
+    describeGroupMembershipGap,
+    () => [0, 0],
+    (t) => ({ text: String(t ?? ""), clipped: false }),
+    200,
+  );
+}
+
+function graphOf(...nodes) {
+  const graph = {
+    _nodes: nodes,
+    _groups: [],
+    getNodeById: (id) => nodes.find((n) => n.id === Number(id)) ?? null,
+    beforeChange() {},
+    afterChange() {},
+    add(g) {
+      graph._groups.push(g);
+    },
+    setDirtyCanvas() {},
+  };
+  return graph;
+}
+
+/** Node 81 exactly as #1877 reports it: a COLLAPSED VAEDecode whose size the
+ *  frontend gives as the collapsed pill width and a ZERO body height, with a
+ *  stale cached rect from the graph load. */
+function collapsedNode81() {
+  return {
+    id: 81,
+    type: "VAEDecode",
+    title: "VAE Decode",
+    flags: { collapsed: true },
+    pos: [9750, 5410],
+    size: [225, 0],
+    boundingRect: [0, 0, 0, 0],
+  };
+}
+
+test("mcp#1877 create_group(node_ids) INCLUDES the requested collapsed node", () => {
+  const n = collapsedNode81();
+  const create = realCreateGroup(graphOf(n));
+
+  const { group } = create({ title: "Decode", node_ids: [81] });
+
+  // The whole report in one place: before the fix this was node_count 0,
+  // node_ids [], missing_node_ids [81] — with bounds that visibly covered
+  // [9750, 5410].
+  assert.equal(group.node_count, 1, "the requested node must be a member");
+  assert.deepEqual(group.node_ids, [81]);
+  assert.equal(group.missing_node_ids, undefined, "nothing is missing");
+  assert.equal(group.warning, undefined, "an exact result carries no warning");
+
+  // And the box really does cover the node it claims as a member.
+  const [gx, gy, gw, gh] = group.bounding;
+  assert.ok(
+    n.pos[0] >= gx && n.pos[0] < gx + gw && n.pos[1] >= gy && n.pos[1] < gy + gh,
+    `bounds ${group.bounding} must cover the node at ${n.pos}`,
+  );
+});
+
+test("mcp#1877 a group of collapsed AND expanded nodes keeps every requested id", () => {
+  const collapsed = collapsedNode81();
+  const expanded = {
+    id: 82,
+    type: "SaveImage",
+    flags: {},
+    pos: [10120, 5410],
+    size: [300, 270],
+    boundingRect: [0, 0, 0, 0],
+  };
+  const create = realCreateGroup(graphOf(collapsed, expanded));
+
+  const { group } = create({ node_ids: [81, 82] });
+
+  assert.deepEqual(group.node_ids.slice().sort((a, b) => a - b), [81, 82]);
+  assert.equal(group.node_count, 2);
+  assert.equal(group.warning, undefined);
+});
+
+test("mcp#1877 an unresolvable id is still reported, and named as unknown", () => {
+  // The honesty contract from #297 must survive the fix: a requested id that is
+  // not in the graph is still listed as missing — and now says WHY, instead of
+  // being folded into a dense-layout complaint.
+  const create = realCreateGroup(graphOf(collapsedNode81()));
+
+  const { group } = create({ node_ids: [81, 999] });
+
+  assert.deepEqual(group.node_ids, [81]);
+  assert.deepEqual(group.missing_node_ids, [999]);
+  assert.match(group.warning, /do not exist in this graph/);
+  assert.ok(
+    !/captures 0 unrelated/.test(group.warning),
+    `must not report a zero-node capture: ${group.warning}`,
+  );
+});
+
+test("mcp#1877 a rect that REFUSES the resync is named, not blamed on the layout", () => {
+  // The call site must keep syncNodeArea's verdict. A frozen cached rect leaves
+  // the node judged on geometry the panel could not refresh; dropping that
+  // boolean is what made the tool blame a dense layout for a node it had itself
+  // failed to reconcile.
+  const n = collapsedNode81();
+  n.boundingRect = Object.freeze([0, 0, 10, 10]); // silently rejects element writes
+  const create = realCreateGroup(graphOf(n));
+
+  const { group } = create({ node_ids: [81] });
+
+  assert.deepEqual(group.missing_node_ids, [81], "the node is honestly reported as missing");
+  assert.match(group.warning, /could not be reconciled/, group.warning);
+  assert.ok(
+    !/contiguous region/.test(group.warning),
+    `a stuck rect is not a layout problem: ${group.warning}`,
+  );
+});

--- a/browser_tests/unit/group-geometry.test.mjs
+++ b/browser_tests/unit/group-geometry.test.mjs
@@ -15,6 +15,8 @@ import assert from "node:assert/strict";
 import {
   nodeFocusBounds,
   boundsAroundNodes,
+  nodeExtents,
+  describeGroupMembershipGap,
   groupBoundsOf,
   groupMemberNodes,
   classifyRequestedMembership,
@@ -991,4 +993,100 @@ test("#1306 holdGraphItemPositions never throws on a hostile walk", () => {
     hold = holdGraphItemPositions(graph, null);
   });
   assert.doesNotThrow(() => hold.restore());
+});
+
+// ---------------------------------------------------------------------------
+// mcp#1877 — panel_create_group excluded a requested COLLAPSED node from a box
+// whose bounds visibly covered it.
+// ---------------------------------------------------------------------------
+
+test("mcp#1877 a requested node reporting a ZERO extent is a member of its own box", () => {
+  // Numbers straight from the report: collapsed VAEDecode 81 at [9750, 5410],
+  // which the frontend presents with a collapsed pill width and a ZERO body
+  // height. graph_create_group syncs the requested node's cached rect (forced to
+  // the FULL footprint) and then builds the box with boundsAroundNodes.
+  //
+  // FAIL-BEFORE: the two disagreed about a zero extent. boundsAroundNodes read
+  // `size[1] ?? 100` — `??` passes 0 through — so the box was [9720, 5340, 285,
+  // 100]; wantedNodeArea rejected the 0 and wrote a rect 130 tall. The rect's
+  // centre landed at y 5445, five pixels below the box's bottom edge at 5440, and
+  // the tool reported node_count 0 / missing_node_ids [81].
+  const n = {
+    id: 81,
+    type: "VAEDecode",
+    flags: { collapsed: true },
+    pos: [9750, 5410],
+    size: [225, 0],
+    boundingRect: [0, 0, 0, 0], // stale, as after a graph load
+  };
+  syncNodeArea(n, /* forceCollapsed */ true);
+  const bbox = boundsAroundNodes([n]);
+  assert.deepEqual(
+    groupMemberNodes(graphOf(n), groupBox(bbox)).map((x) => x.id),
+    [81],
+    "the node the box was built around must be one of its members",
+  );
+});
+
+test("mcp#1877 boundsAroundNodes and wantedNodeArea share ONE extent model", () => {
+  // The invariant behind the fix, stated directly on the degenerate extents that
+  // broke it: whatever width/height the box builder uses for a node, the cached
+  // rect writer must use the same. Testing membership (above) alone would not
+  // catch the two drifting apart again in a way that happens to stay inside the
+  // padding.
+  for (const size of [[225, 0], [0, 120], [0, 0], [225, -40], [225, NaN], [Infinity, 120]]) {
+    const n = { id: 1, pos: [100, 100], size };
+    syncNodeArea(n, true); // no cached rect ⇒ read the model through nodeFocusBounds
+    const [, , focusW, focusH] = nodeFocusBounds(n);
+    assert.deepEqual(
+      nodeExtents(n),
+      [focusW, focusH - 30],
+      `size ${JSON.stringify(size)}: box extents must match the rect extents`,
+    );
+  }
+});
+
+test("mcp#1877 a non-finite position never yields a NaN group box", () => {
+  // A NaN extent or a NaN *y* never touched minX, and minX was the only
+  // accumulator checked — so the box escaped as [x, NaN, w, NaN] and
+  // setGroupBounds wrote it to the user's graph.
+  const good = node(1, 100, 100);
+  const badY = { id: 2, pos: [100, Number.NaN], size: [300, 120] };
+  const badSize = { id: 3, pos: [400, 100], size: [300, Number.NaN] };
+  for (const bbox of [
+    boundsAroundNodes([good, badY]),
+    boundsAroundNodes([good, badSize]),
+    boundsAroundNodes([badY]),
+  ]) {
+    assert.ok(
+      bbox.every((v) => Number.isFinite(v)),
+      `every component of ${JSON.stringify(bbox)} must be finite`,
+    );
+  }
+});
+
+test("mcp#1877 a MISSING requested node is not reported as a dense-layout capture", () => {
+  // The old warning was one sentence that always began "also captures N unrelated
+  // node(s)" — with N printed as 0 — and always prescribed spreading the nodes
+  // out. For a single requested node that is exactly backwards.
+  const resolved = new Set(["81"]);
+  const w = describeGroupMembershipGap([], [81], resolved, new Set());
+  assert.ok(!/captures 0 unrelated/.test(w), `must not claim a 0-node capture: ${w}`);
+  assert.ok(!/contiguous region/.test(w), `must not prescribe a layout change: ${w}`);
+  assert.match(w, /81/, "names the node that is missing");
+  assert.match(w, /CENTRE/, "names the rule that actually excluded it");
+
+  // A rect that refused the resync is named as such, not blamed on the layout.
+  const stuck = describeGroupMembershipGap([], [81], resolved, new Set(["81"]));
+  assert.match(stuck, /could not be reconciled/, `names the stuck rect: ${stuck}`);
+  assert.ok(!/CENTRE of their footprint falls outside/.test(stuck), "one cause, not both");
+
+  // An id that resolves to nothing is its own cause (#297's nonexistent-id case).
+  const unknown = describeGroupMembershipGap([], [99], new Set(), new Set());
+  assert.match(unknown, /do not exist in this graph/, `names the unknown id: ${unknown}`);
+
+  // The dense-layout sentence still fires when something extra WAS captured.
+  const dense = describeGroupMembershipGap([7, 8], [], resolved, new Set());
+  assert.match(dense, /also captures 2 unrelated node\(s\)/);
+  assert.match(dense, /contiguous region/);
 });

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -530,6 +530,7 @@ import {
   boundsAroundNodes,
   groupMemberNodes,
   classifyRequestedMembership,
+  describeGroupMembershipGap,
   refreshNodeArea,
   syncNodeArea,
   syncGraphNodeAreas,
@@ -19769,6 +19770,8 @@ const GRAPH_TOOL_EXECUTORS = {
     syncGraphNodeAreas(graph);
     let bbox;
     let requestedIds = null;
+    let resolvedIds = new Set();
+    let unsyncedIds = new Set();
     if (Array.isArray(node_ids) && node_ids.length) {
       // Record EVERY requested id (including ids that don't resolve) so the
       // honesty report below can list nonexistent ones as missing (#297).
@@ -19779,7 +19782,16 @@ const GRAPH_TOOL_EXECUTORS = {
       // collapsed — so it is a geometric member of the box we build around it. The
       // sync-all above skips collapsed nodes (to avoid overstating unrelated ones),
       // but a requested collapsed node with a stale rect must still be included (#391).
-      ns.forEach((n) => syncNodeArea(n, /* forceCollapsed */ true));
+      // Keep the VERDICT, not just the attempt. syncNodeArea returns false when a
+      // node's cached rect would not accept the resync (a frozen/derived rect on
+      // some frontend builds), and that node is then judged on geometry the panel
+      // could not make live — the one way a requested node can still be missing
+      // once the box and the rect share a footprint model (mcp#1877). Discarding
+      // the verdict is what left the report blaming a dense layout for it.
+      unsyncedIds = new Set(
+        ns.filter((n) => !syncNodeArea(n, /* forceCollapsed */ true)).map((n) => String(n.id)),
+      );
+      resolvedIds = new Set(ns.map((n) => String(n.id)));
       // Tight box around exactly the requested nodes that exist (title height + padding).
       bbox = boundsAroundNodes(ns);
     } else if (Array.isArray(bounds) && bounds.length === 4) {
@@ -19800,24 +19812,20 @@ const GRAPH_TOOL_EXECUTORS = {
     }
     graph.setDirtyCanvas(true, true);
     const summary = summarizeGroup(graph, group);
-    // Honesty for dense layouts (#297): group membership is purely GEOMETRIC, so
-    // any unrelated node whose CENTRE falls within the computed rectangle is now a
-    // member (LiteGraph's containsCentre rule, #497) — LiteGraph has no per-node
-    // ownership to exclude it. When the live members
-    // differ from what was requested, surface both sets and a warning instead of
-    // silently reporting a misleading success.
+    // Honesty when the live members differ from what was requested: group
+    // membership is purely GEOMETRIC, so any unrelated node whose CENTRE falls
+    // within the computed rectangle is now a member (LiteGraph's containsCentre
+    // rule, #497) and LiteGraph has no per-node ownership to exclude it (#297).
+    // Surface both sets rather than reporting a misleading success — and name the
+    // cause that actually applies, since a MISSING requested node is a different
+    // failure from a captured bystander and used to be reported as one (mcp#1877).
     if (requestedIds) {
       const { extra, missing } = classifyRequestedMembership(requestedIds, summary.node_ids);
       summary.requested_node_ids = requestedIds;
       if (extra.length || missing.length) {
         summary.extra_node_ids = extra;
         summary.missing_node_ids = missing;
-        summary.warning =
-          "group membership is geometric: the box that wraps the requested nodes " +
-          `also captures ${extra.length} unrelated node(s) (their centre falls inside)` +
-          (missing.length ? ` and misses ${missing.length} requested node(s)` : "") +
-          ". Move the intended nodes into a contiguous region (panel_edit_node / " +
-          "panel_auto_layout) before grouping, or edit the group bounds, to get an exact set.";
+        summary.warning = describeGroupMembershipGap(extra, missing, resolvedIds, unsyncedIds);
       }
     }
     return { group: summary };

--- a/web/js/lib/group-geometry.js
+++ b/web/js/lib/group-geometry.js
@@ -22,8 +22,12 @@ export function nodeFocusBounds(node) {
   if (br && br.length === 4 && (br[2] || br[3])) {
     return [br[0], br[1], br[2], br[3]];
   }
-  const w = node.size?.[0] ?? 200;
-  const h = node.size?.[1] ?? 100;
+  // Extents from the shared model, not a local `?? 200` / `?? 100`: this fallback
+  // is the footprint a node with NO cached rect is judged by, so if it disagrees
+  // with the box builder about a degenerate extent the same way boundsAroundNodes
+  // used to, an un-rendered node is excluded from the box drawn around it
+  // (mcp#1877). Matches wantedNodeArea(node, forceCollapsed) exactly.
+  const [w, h] = nodeExtents(node);
   return [node.pos[0], node.pos[1] - 30, w, h + 30]; // title bar renders above pos
 }
 
@@ -92,17 +96,36 @@ export function refreshNodeArea(node, prevPos) {
   }
 }
 
-/** [x, y, w, h] that wraps the given nodes, padded for the group + node titles. */
+/** [x, y, w, h] that wraps the given nodes, padded for the group + node titles.
+ *
+ * Extents come from `nodeExtents`, the SAME model `wantedNodeArea` writes into a
+ * node's cached rect. They used to be read here as `n.size?.[1] ?? 100`, which is
+ * a different rule: `??` only substitutes for null/undefined, so a node reporting
+ * a zero (or negative, or non-finite) extent contributed it literally, while
+ * `wantedNodeArea` rejected it and substituted the default. Building the box from
+ * one model and testing membership against the other is how a group could wrap a
+ * node it then reported as missing — a collapsed node reported as `size` [w, 0]
+ * yielded a box 100px shorter than the rect the panel had just written for it, so
+ * the node's centre landed just below the bottom edge and create-by-node_ids
+ * returned an EMPTY group whose bounds visibly covered the requested node
+ * (mcp#1877, the collapsed half of #391/#416). One model, one answer.
+ */
 export function boundsAroundNodes(nodes, pad = 30, titlePad = 70) {
   let minX = Infinity;
   let minY = Infinity;
   let maxX = -Infinity;
   let maxY = -Infinity;
   for (const n of nodes) {
-    const x = n.pos?.[0] ?? 0;
-    const y = n.pos?.[1] ?? 0;
-    const w = n.size?.[0] ?? 200;
-    const h = n.size?.[1] ?? 100;
+    const x = Number(n?.pos?.[0]);
+    const y = Number(n?.pos?.[1]);
+    // A node whose position is not a finite point has no knowable footprint —
+    // the same verdict wantedNodeArea reaches, for the same reason. `?? 0` let a
+    // NaN coordinate through and poisoned the accumulators; only `minX` was
+    // checked afterwards, so a NaN *y* (or a NaN extent, which never touches
+    // minX at all) escaped as a NaN group box. A NaN box is the invisible-layout-
+    // corruption class graph_move_group already refuses outright.
+    if (!Number.isFinite(x) || !Number.isFinite(y)) continue;
+    const [w, h] = nodeExtents(n);
     minX = Math.min(minX, x);
     minY = Math.min(minY, y);
     maxX = Math.max(maxX, x + w);
@@ -320,6 +343,19 @@ function finiteExtent(value, fallback) {
 }
 
 /**
+ * The [width, height] the panel treats an EXPANDED node as occupying.
+ *
+ * Exported so there is exactly ONE answer to that question: the box builder
+ * (`boundsAroundNodes`) and the cached-rect writer (`wantedNodeArea`) both read
+ * it. Two functions each with their own idea of what a missing/degenerate extent
+ * means is not a style problem — it silently decouples the box from the
+ * membership test that box will be judged by (mcp#1877).
+ */
+export function nodeExtents(node) {
+  return [finiteExtent(node?.size?.[0], 200), finiteExtent(node?.size?.[1], 100)];
+}
+
+/**
  * The rect a node's cached boundingRect SHOULD hold for its live pos/size, or
  * NULL when the node's position is not a finite point.
  *
@@ -333,10 +369,9 @@ function wantedNodeArea(node, forceCollapsed = false) {
   const y = Number(node?.pos?.[1]);
   if (!Number.isFinite(x) || !Number.isFinite(y)) return null;
   const collapsed = !!node.flags?.collapsed && !forceCollapsed;
-  const w = collapsed
-    ? finiteExtent(node._collapsed_width, COLLAPSED_PILL_WIDTH)
-    : finiteExtent(node.size?.[0], 200);
-  const h = collapsed ? 0 : finiteExtent(node.size?.[1], 100);
+  const [fullW, fullH] = nodeExtents(node);
+  const w = collapsed ? finiteExtent(node._collapsed_width, COLLAPSED_PILL_WIDTH) : fullW;
+  const h = collapsed ? 0 : fullH;
   return [x, y - COLLAPSED_TITLE_HEIGHT, w, h + COLLAPSED_TITLE_HEIGHT]; // title above pos
 }
 
@@ -1286,6 +1321,68 @@ export function moveReroutePoints(reroutes, dx, dy) {
  * Normalizing to a common key fixes that; the returned arrays keep each id's
  * ORIGINAL representation so callers see the ids in their native form.
  */
+/**
+ * Word a create-by-node_ids membership gap for the failure that ACTUALLY
+ * happened.
+ *
+ * The old message was a single sentence that always opened with "the box that
+ * wraps the requested nodes also captures N unrelated node(s)" and always ended
+ * by prescribing a more contiguous layout. When nothing extra was captured that
+ * read as "also captures 0 unrelated node(s)", and the prescription was a
+ * non-answer: the reporter of mcp#1877 asked for ONE node, got an empty group
+ * whose bounds visibly covered it, and was told to spread its neighbours out.
+ * A dense layout is one cause of a membership gap, not the explanation for every
+ * one of them.
+ *
+ * Each cause therefore gets its own sentence, and only when it applies:
+ *   - `extra`   — the geometric-capture problem #297 named (dense layouts).
+ *   - unknown   — a requested id that resolves to no node in this graph.
+ *   - unsynced  — a node whose cached rect REFUSED the resync, so the box was
+ *                 built around geometry the frontend does not report it at.
+ *   - remainder — resolved, live, and still outside: the centre rule (#497).
+ *
+ * `resolvedIds` and `unsyncedIds` are Sets of STRING ids (ids arrive as both
+ * numbers and strings across frontends, the same normalisation
+ * classifyRequestedMembership does). Dependency-free, so it is unit-testable.
+ */
+export function describeGroupMembershipGap(extra, missing, resolvedIds, unsyncedIds) {
+  const has = (set, id) => !!set && typeof set.has === "function" && set.has(String(id));
+  const parts = [];
+  if (extra.length) {
+    parts.push(
+      `the box that wraps the requested nodes also captures ${extra.length} unrelated node(s) ` +
+        "(their centre falls inside) and LiteGraph has no per-node ownership to exclude them — " +
+        "move the intended nodes into a contiguous region (panel_edit_node / panel_auto_layout) " +
+        "before grouping, or edit the group bounds, to get an exact set.",
+    );
+  }
+  const unknown = missing.filter((id) => !has(resolvedIds, id));
+  if (unknown.length) {
+    parts.push(
+      `${unknown.length} requested node id(s) (${unknown.join(", ")}) do not exist in this graph, ` +
+        "so nothing was grouped for them — re-read the ids with panel_query_graph.",
+    );
+  }
+  const stuck = missing.filter((id) => has(resolvedIds, id) && has(unsyncedIds, id));
+  if (stuck.length) {
+    parts.push(
+      `${stuck.length} requested node(s) (${stuck.join(", ")}) exist but their cached footprint ` +
+        "could not be reconciled with their live position on this frontend, so membership was " +
+        "judged against geometry the panel could not refresh — set the box explicitly with " +
+        "panel_edit_group({bounds}) after re-reading panel_query_graph.",
+    );
+  }
+  const outside = missing.filter((id) => has(resolvedIds, id) && !has(unsyncedIds, id));
+  if (outside.length) {
+    parts.push(
+      `${outside.length} requested node(s) (${outside.join(", ")}) exist and are live, but the ` +
+        "CENTRE of their footprint falls outside the box — a node the box merely overlaps is " +
+        "not a member. Widen the box with panel_edit_group({bounds}).",
+    );
+  }
+  return `group membership is geometric: ${parts.join(" ")}`;
+}
+
 export function classifyRequestedMembership(requestedIds, memberIds) {
   const key = (id) => String(id);
   const reqKeys = new Set(requestedIds.map(key));


### PR DESCRIPTION
Fixes the underlying cause of artokun/comfyui-mcp#1877 (`panel_create_group` excludes requested collapsed nodes). The issue is filed on the mcp repo; the code is here, so it will need closing by hand after this merges.

## The defect

`panel_create_group(node_ids:[81])` created a group whose bounds visibly covered node 81 and then reported `node_count: 0, node_ids: [], missing_node_ids: [81]`.

Two functions each had their own idea of a node's size:

| | zero / negative / non-finite extent |
|---|---|
| `boundsAroundNodes` (builds the box) | `n.size?.[1] ?? 100` — `??` only substitutes for null/undefined, so **0 is used literally** |
| `wantedNodeArea` (writes the cached rect membership is tested against) | `finiteExtent(size[1], 100)` — rejects 0, **substitutes 100** |

`graph_create_group` calls `syncNodeArea(n, forceCollapsed)` on every requested node and *then* builds the box. So for a node reporting `size` `[225, 0]` it wrote a rect 130 tall and built a box 100 tall around it. The rect's centre landed at y 5445; the box's bottom edge was at 5440. LiteGraph's `containsCentre` rule excluded it, and the tool reported an empty group.

The arithmetic is not inferred — the reported bounds `[9720, 5340, 285, 100]` for a node at `[9750, 5410]` are only producible from `boundsAroundNodes(pad=30, titlePad=70)` if `size` read as `[225, 0]`.

## Verified on a real frontend

Rig: ComfyUI 0.33.2 / frontend 1.49.6 — the reporter's exact versions.

A zero extent is not a synthetic shape. The frontend accepts `size = [225, 0]`, `serialize()` emits it unchanged, and `configure()` restores it unchanged — so a saved workflow carries one across a load.

Loading each version of `group-geometry.js` as a module into a real browser, running the exact `graph_create_group` sequence against a live `LGraphGroup`, and asking **LiteGraph's own `recomputeInsideNodes()`** who the members are:

```
[SHIPPED origin/main] bounds [9720,5340,285,100]  engineMemberIds []      <- the reported bug, exactly
[FIXED this branch]   bounds [9720,5340,285,200]  engineMemberIds ["81"]
```

The shipped bounds reproduce the report quad byte for byte.

## The fix

**One footprint model.** Extents now come from a single exported `nodeExtents(node)`, read by all three sites that had their own copy — `boundsAroundNodes`, `wantedNodeArea`, and `nodeFocusBounds`'s no-cached-rect fallback (a third copy the tests caught). With one model, containment is provable rather than incidental: for any requested set, every node's centre lands strictly inside the padded box.

**No NaN group box.** `boundsAroundNodes` skips a node whose position is not a finite point instead of folding NaN into the accumulators. Only `minX` was checked afterwards, so a NaN *y* — or a NaN extent, which never touches `minX` at all — escaped as a NaN box written straight to the user's graph. That is the invisible-layout-corruption class `graph_move_group` already refuses outright.

**An honest postcondition,** which is the second half of what the reporter asked for. The old warning was one sentence that always opened with *"the box that wraps the requested nodes also captures N unrelated node(s)"* — printing N as `0` — and always prescribed a more contiguous layout. The reporter asked for one node, got an empty group, and was told to spread its neighbours out. Four different failures now read as four different things:

- a captured bystander (the dense-layout case #297 named — unchanged wording),
- an id that resolves to no node,
- a node whose cached rect **refused** the resync, so the box was built around geometry the panel could not refresh,
- a node that is live and simply outside — the centre rule (#497).

Telling the third apart from the fourth is why the call site now keeps `syncNodeArea`'s return value. Discarding that boolean is what left a stuck rect blamed on the layout.

## Tests

8 new tests. Every one was verified by **deleting the fix and watching it fail** — not just by passing:

| mutation | result |
|---|---|
| `boundsAroundNodes` back to the `??` model | 2 unit + 2 e2e-shaped tests fail |
| `nodeFocusBounds` fallback back to `??` | 1 fails |
| non-finite-position skip removed | 1 fails |
| call site back to pre-fix (drops the verdict + old warning) | 2 fail |

`browser_tests/unit/create-group-collapsed.test.mjs` drives the **real `graph_create_group` extracted from the panel source**, not a re-implementation — the postcondition is a call-site property and a helper-level test cannot see it.

Full panel unit suite: **5931/5933**. The single failure is the documented manager-install #671 wall-clock flake, which passes 125/125 when that file is run alone. `npm run typecheck`, `check-panel-scope`, `check-tool-vocabulary` and the i18n gates are green.

## Browser coverage — what I could and could not run

`browser_tests/create-group-collapsed.spec.ts` is included and typechecks. **It could not be executed on this dev rig**, and I am not implying coverage I do not have:

- Run **un-routed**, it reproduced the bug end to end through the panel's real dispatcher — `node_count: 0`, `missing_node_ids: [72]`, old warning text — confirming the harness is sound and the bug is real through the full command path.
- Run **routed to this checkout** (`routeWorktreeSource`, needed to load this branch), the Agent panel never mounts on this rig. The four pre-existing specs that use the same routing (`chat-history-v2`, `conversation-persistence`, `workflow-chat-identity`, `bridge-reregisters-after-restart`) fail identically, with the same "panel never mounted" message, on `origin/main` without this change. The extension registers and no panel module errors; the console shows unrelated third-party packs on this rig failing (`playcanvas`/`three` preload errors, `geompack.text_report` already registered). It is rig skew — this ComfyUI's installed pack is a different commit — not a regression here.

CI does not run `test:e2e` by design (`ci.yml` says so: it needs a real ComfyUI at :8188), so this spec does not affect CI either way. It is written for the pre-release local soak on a synced rig.

The browser evidence that this branch is correct is the LiteGraph-verdict comparison above, which loaded this branch's module in a real browser and let the engine decide membership.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
