### PR TITLE
fix(1501): a locator that could not look no longer says the node is from another workflow

### DIFF
--- a/browser_tests/unit/node-scope-locator.test.mjs
+++ b/browser_tests/unit/node-scope-locator.test.mjs
@@ -84,7 +84,7 @@ test("malformed graphs never throw — a diagnostic must not fail", () => {
     assert.doesNotThrow(() => locateNodeAcrossScopes(bad, 1));
     assert.equal(locateNodeAcrossScopes(bad, 1), null);
   }
-  assert.equal(locateNodeAcrossScopes(sub([node(1)]), "not-a-number"), null);
+  assert.equal(locateNodeAcrossScopes(sub([node(1)]), "not-a-number").undetermined, "unparseable");
 });
 
 // ── the message ───────────────────────────────────────────────────────────
@@ -258,6 +258,88 @@ test("#1298 a current graph with no root still names live ids", () => {
 test("#1298 current-id listing never throws", () => {
   const root = { get _nodes() { throw new Error("boom"); } };
   assert.doesNotThrow(() => describeMissingNode(1, root, true));
+});
+
+// ── #1501 null must not mean "could not look" ─────────────────────────────
+//
+// Reporter (filed from the #1495 review): locateNodeAcrossScopes returned
+// null for three different jobs — searched-and-absent, the walk threw, and
+// the id was not a finite number — and describeMissingNode could only spell
+// one of them: "The id may be from a different workflow, or the node was
+// removed." A throw mid-walk, or a subgraph-qualified id (`263:78`) the
+// rest of the system produces on purpose, was therefore reported as a
+// positive statement about the node's absence. Same shape as #1495: a
+// diagnostic that could not look claimed a fact it did not have.
+
+test("#1501 a walk that threw is inconclusive, not a miss", () => {
+  // Flat scan of this graph succeeds; descending into node 2 throws. The
+  // search did not finish, so "not in any other scope" is unsupportable.
+  const root = sub([
+    node(1, { type: "KSampler" }),
+    { id: 2, type: "S", get subgraph() { throw new Error("boom"); } },
+  ]);
+  const hit = locateNodeAcrossScopes(root, 99);
+  assert.equal(hit.undetermined, "threw");
+  assert.ok(!hit.scope, "must not look like a location");
+
+  const msg = describeMissingNode(99, root, true, root);
+  assert.match(msg, /^No node with id 99/);
+  assert.match(msg, /this is not a finding that the node is absent/);
+  assert.match(msg, /threw before it finished/);
+  assert.ok(!/not in any other scope either/.test(msg), "the walk did not finish");
+  assert.ok(!/may be from a different workflow/.test(msg), "must not invent a workflow-identity problem");
+  assert.ok(!/the node was removed/.test(msg), "must not invent a removal");
+  // live ids on the graph that DID scan are still the retarget the caller can use
+  assert.match(msg, /1 \(KSampler\)/);
+});
+
+test("#1501 a qualified id is found by the same identity the writes use", () => {
+  // Unpacking leaves genuine root nodes whose id is `263:78`. Number("263:78")
+  // is NaN, and Number.parseInt is 263 — a different, real node. The locator
+  // used to return null before searching and the miss message called it foreign.
+  const root = sub([
+    node("263:78", { type: "CLIPTextEncode" }),
+    node(263, { type: "KSampler" }),
+  ]);
+  const hit = locateNodeAcrossScopes(root, "263:78");
+  assert.equal(hit.scope, "root");
+  assert.deepEqual(hit.hostPath, []);
+  // The parseInt trap: a graph that only has 263 must NOT report `263:78` as found.
+  assert.equal(locateNodeAcrossScopes(sub([node(263)]), "263:78"), null);
+});
+
+test("#1501 a qualified id on the root while viewing a subgraph says EXIT, not 'different workflow'", () => {
+  const inner = sub([node(10, { type: "InnerA" })]);
+  const root = sub([
+    node("263:78", { type: "SaveImage" }),
+    node(9, { title: "S", subgraph: inner }),
+  ]);
+  const msg = describeMissingNode("263:78", root, false, inner);
+  assert.match(msg, /on the ROOT graph/);
+  assert.match(msg, /panel_exit_subgraph/);
+  assert.ok(!/may be from a different workflow/.test(msg));
+  assert.ok(!/not a local integer or a subgraph-qualified id/.test(msg), "it is a qualified id; we searched");
+});
+
+test("#1501 an unparseable id is inconclusive, not a miss", () => {
+  const root = sub([node(1, { type: "KSampler" })]);
+  const hit = locateNodeAcrossScopes(root, "not-a-number");
+  assert.equal(hit.undetermined, "unparseable");
+
+  const msg = describeMissingNode("not-a-number", root, true, root);
+  assert.match(msg, /^No node with id not-a-number/);
+  assert.match(msg, /this is not a finding that the node is absent/);
+  assert.match(msg, /not a local integer or a subgraph-qualified id/);
+  assert.ok(!/not in any other scope either/.test(msg), "nothing was searched");
+  assert.ok(!/may be from a different workflow/.test(msg));
+});
+
+test("#1501 a genuine miss of a qualified id may still say the id is gone", () => {
+  // Once we actually searched, the old sentence is allowed: the node is not here.
+  const root = sub([node(1, { type: "KSampler" })]);
+  const msg = describeMissingNode("120:104", root, true, root);
+  assert.match(msg, /not in any other scope either/);
+  assert.match(msg, /may be from a different workflow/);
 });
 
 // ── WIRING ────────────────────────────────────────────────────────────────

--- a/web/js/lib/node-scope-locator.js
+++ b/web/js/lib/node-scope-locator.js
@@ -46,6 +46,8 @@
  * with a plausible-looking shape.
  */
 
+import { canonicalNodeId } from "./node-id.js";
+
 /** Depth guard for a pathological/looping graph. Real workflows nest a handful deep. */
 const MAX_DEPTH = 12;
 
@@ -69,24 +71,33 @@ function nodesOf(graph) {
 }
 
 /**
- * Find a node by its LOCAL id anywhere in the workflow, reporting the route to it.
+ * Find a node by its local integer or subgraph-qualified id anywhere in the
+ * workflow, reporting the route to it.
  *
  * @param {object} rootGraph the workflow's root graph
- * @param {number|string} nodeId the local id being looked up
- * @returns {null | {scope: "root"|"subgraph", hostPath: Array<{id: any, title: string}>}}
+ * @param {number|string} nodeId the id being looked up
+ * @returns {null | {scope: "root"|"subgraph", hostPath: Array<{id: any, title: string}>} | {undetermined: "threw"|"unparseable"}}
  *   `hostPath` is the chain of subgraph HOST nodes to enter, outermost first; empty
  *   for a node on the root graph.
+ *   `null` is a completed search that found nothing. `undetermined` is the
+ *   distinct "could not look" answer (#1501): the walk threw, or the id is not
+ *   a searchable local/qualified form. Callers must not treat it as a miss.
  */
 export function locateNodeAcrossScopes(rootGraph, nodeId) {
-  const target = Number(nodeId);
-  if (!Number.isFinite(target)) return null;
+  // #1425 / #1501 — a qualified id (`120:104`) is not a finite number. Number()
+  // here used to return null before searching, and the consumer spelled that as
+  // "may be from a different workflow". Use the same identity the writes use.
+  const target = canonicalNodeId(nodeId);
+  if (typeof target === "number" && !Number.isFinite(target)) {
+    return { undetermined: "unparseable" };
+  }
   const seen = new Set();
 
   const walk = (graph, hostPath, depth) => {
     if (!graph || depth > MAX_DEPTH || seen.has(graph)) return null;
     seen.add(graph);
     for (const n of nodesOf(graph)) {
-      if (Number(n?.id) === target) {
+      if (n?.id != null && canonicalNodeId(n.id) === target) {
         return { scope: hostPath.length ? "subgraph" : "root", hostPath };
       }
     }
@@ -103,7 +114,9 @@ export function locateNodeAcrossScopes(rootGraph, nodeId) {
   try {
     return walk(rootGraph, [], 0);
   } catch {
-    return null; // a diagnostic must never throw
+    // a diagnostic must never throw — but null is "searched and absent", and
+    // the consumer used to publish that as a fact about the node (#1501)
+    return { undetermined: "threw" };
   }
 }
 
@@ -191,6 +204,19 @@ export function describeMissingNode(nodeId, rootGraph, viewingRoot, currentGraph
   if (!rootGraph) return ids ? `${base}. ${ids}` : base;
 
   const found = locateNodeAcrossScopes(rootGraph, nodeId);
+  // #1501 — `null` used to mean three things (absent, threw, unparseable) and
+  // this branch could only spell one of them. An inconclusive walk must not
+  // claim the node is missing from the workflow.
+  if (found?.undetermined) {
+    const detail =
+      found.undetermined === "unparseable"
+        ? `${nodeId} is not a local integer or a subgraph-qualified id (e.g. 120:104), so the other scopes were not searched`
+        : `a walk of the other scopes threw before it finished, so their contents were not determined`;
+    return (
+      `${base} — this is not a finding that the node is absent from the rest of the workflow: ${detail}. ` +
+      (ids || `Re-read with panel_graph_outline before retrying.`)
+    );
+  }
   if (!found) {
     const subs = countSubgraphs(rootGraph);
     return (


### PR DESCRIPTION
Fixes #1501

## What the reporter saw

Two pre-existing defects in `describeMissingNode()`, both surfaced while fixing #1495, both the same shape as that bug: a diagnostic that cannot find a node reports "it does not exist" when what actually happened is "I could not look."

`locateNodeAcrossScopes()` returned `null` for three different jobs — searched-and-absent, the walk threw, and the id was not a finite number — and the consumer could only spell one of them:

> The id may be from a different workflow, or the node was removed.

So a malformed graph, a throwing getter on a third-party node, or a subgraph-qualified id (`263:78`) the rest of the system produces on purpose, was reported as a positive statement about the node's absence.

## The change

`null` is now only a completed search that found nothing. The other two jobs get a distinct `{ undetermined }` answer, and the message says so instead of inventing a workflow-identity problem.

1. **A walk that threw** — still fails closed (a diagnostic must never throw), but returns `{ undetermined: "threw" }`. The miss message now says the walk of other scopes threw before it finished, so their contents were not determined. It no longer claims "not in any other scope" or "may be from a different workflow."

2. **A qualified id** — `Number("263:78")` is NaN, so the walk used to return `null` *before searching anything*. The locator now uses `canonicalNodeId()` — the same identity the writes already use (#1425) — so a qualified id is found when it is on the graph (and the `#697`/`#1495` remedies fire), and a genuine miss of one may still say the id is gone because the search actually finished. `Number.parseInt("263:78", 10)` is still rejected: that is node 263, a different real node.

3. **Genuinely unparseable input** (`"not-a-number"`) — `{ undetermined: "unparseable" }`. The other scopes were not searched, and the message says that rather than claiming a foreign workflow.

The historic prefix `No node with id <id> in the current graph` is unchanged.

## What is NOT claimed

This does not make a throwing graph searchable, and it does not change `resolveNode`'s lookup (still current-graph `getNodeById` only). It only stops the diagnostic from publishing an absence it did not establish.

## Verification

- `node --test browser_tests/unit/node-scope-locator.test.mjs` → **pass**.
- `node --test browser_tests/unit/*.test.mjs` → **5956 pass / 1 fail / 1 pre-existing todo**. The failure is `manager-install.test.mjs` `#671 verifyInstalled (real panel source) still verifies a fast-draining install` (`unverified` vs `installed`) — unrelated timing, not this locator.
- **Mutation 1** — restore `catch { return null }`: the "walk that threw is inconclusive" test fails.
- **Mutation 2** — keep `Number(nodeId)` and treat non-finite as unparseable: the qualified-id-found tests fail (the id is never searched).
- **Mutation 3** — `Number.parseInt` instead of `canonicalNodeId`: the trap test fails (`263:78` lands on node 263).
- `node scripts/check-tool-vocabulary.mjs` → OK.
- `node scripts/check-panel-scope.mjs` → OK.
- No `tr()` string added, so no i18n key/round-trip work.

**Browser suite:** not run. The change is confined to a pure string-building helper in `web/js/lib/node-scope-locator.js` with no DOM, canvas or render surface — it changes the text of a thrown error, which the unit suite covers directly and the call-site wiring test already pins at source.
