### PR TITLE
fix(1501): the locator says "I could not look" instead of "it is not there"

### DIFF
--- a/browser_tests/unit/node-scope-locator.test.mjs
+++ b/browser_tests/unit/node-scope-locator.test.mjs
@@ -4,6 +4,7 @@ import {
   locateNodeAcrossScopes,
   countSubgraphs,
   describeMissingNode,
+  isUnsearchable,
 } from "../../web/js/lib/node-scope-locator.js";
 
 /**
@@ -82,9 +83,14 @@ test("a DEEP acyclic chain is bounded — `seen` never fires when every level is
 test("malformed graphs never throw — a diagnostic must not fail", () => {
   for (const bad of [null, undefined, 42, "x", {}, { _nodes: "nope" }]) {
     assert.doesNotThrow(() => locateNodeAcrossScopes(bad, 1));
+    // These are searchABLE — there is simply nothing in them. A completed search
+    // that found nothing is `null`, and stays `null`.
     assert.equal(locateNodeAcrossScopes(bad, 1), null);
   }
-  assert.equal(locateNodeAcrossScopes(sub([node(1)]), "not-a-number"), null);
+  // …whereas an id the walk cannot key on was never searched at all (#1501).
+  assert.deepEqual(locateNodeAcrossScopes(sub([node(1)]), "not-a-number"), {
+    unsearchable: "id-shape",
+  });
 });
 
 // ── the message ───────────────────────────────────────────────────────────
@@ -258,6 +264,121 @@ test("#1298 a current graph with no root still names live ids", () => {
 test("#1298 current-id listing never throws", () => {
   const root = { get _nodes() { throw new Error("boom"); } };
   assert.doesNotThrow(() => describeMissingNode(1, root, true));
+});
+
+// ── #1501 "could not look" is not "it is not there" ───────────────────────
+//
+// The same shape as #1495 twice more: a diagnostic that cannot find a node reported
+// "it does not exist" when what happened was "I could not look". `null` was doing
+// three jobs — searched-and-absent, the walk threw, and the id was not a shape the
+// walk could key on — and the caller could only spell the first of them.
+
+test("#1501 a walk that THREW is not reported as a completed search", () => {
+  // The issue's own scenario: the walk touches arbitrary third-party node objects,
+  // so `n.subgraph` can throw. Before, that came back as `null` — identical to a
+  // finished search that found nothing.
+  const hostile = { id: 9, get subgraph() { throw new Error("third-party getter"); } };
+  const root = sub([node(1), hostile]);
+  const result = locateNodeAcrossScopes(root, 999);
+  assert.ok(isUnsearchable(result), "a thrown walk must not masquerade as a miss");
+  assert.equal(result.unsearchable, "walk-threw");
+  assert.notEqual(result, null);
+});
+
+test("#1501 a thrown walk still never throws out of the diagnostic", () => {
+  const root = { get _nodes() { throw new Error("boom"); } };
+  assert.doesNotThrow(() => locateNodeAcrossScopes(root, 1));
+  assert.doesNotThrow(() => describeMissingNode(1, root, true, root));
+});
+
+test("#1501 a thrown walk says UNKNOWN instead of claiming the node is gone", () => {
+  const hostile = { id: 9, type: "Hostile", get subgraph() { throw new Error("nope"); } };
+  const root = sub([node(1, { type: "CheckpointLoaderSimple" }), hostile]);
+  const msg = describeMissingNode(999, root, true, root);
+  assert.match(msg, /^No node with id 999/);
+  // The three lies, gone.
+  assert.ok(!/may be from a different workflow/.test(msg), "it never searched for that");
+  assert.ok(!/the node was removed/.test(msg), "absence was never established");
+  assert.ok(!/not in any other scope either/.test(msg), "other scopes went unsearched");
+  // …replaced by what actually happened.
+  assert.match(msg, /could NOT be completed/);
+  assert.match(msg, /UNKNOWN/);
+  // and it still hands back something the caller can act on
+  assert.match(msg, /1 \(CheckpointLoaderSimple\)/);
+});
+
+test("#1501 an id shape the walk cannot key on is not searched, and says so", () => {
+  const root = sub([node(1, { type: "KSampler" })]);
+  const msg = describeMissingNode("not-a-number", root, true, root);
+  assert.match(msg, /^No node with id not-a-number/);
+  assert.ok(!/may be from a different workflow/.test(msg));
+  assert.ok(!/not in any other scope either/.test(msg));
+  assert.match(msg, /no wider search was possible/);
+  assert.match(msg, /subgraph-qualified/);
+  assert.match(msg, /UNKNOWN/);
+});
+
+test("#1501 a genuine miss is still a genuine miss — the fix does not blanket everything", () => {
+  // Load-bearing: if "unknown" swallowed the real absence case too, #1298's retarget
+  // path would be lost and the message would stop being actionable.
+  const root = sub([node(1), node(9, { subgraph: sub([node(2)]) })]);
+  const msg = describeMissingNode(999, root, true);
+  assert.equal(isUnsearchable(locateNodeAcrossScopes(root, 999)), false);
+  assert.equal(locateNodeAcrossScopes(root, 999), null);
+  assert.match(msg, /not in any other scope either/);
+  assert.match(msg, /may be from a different workflow/);
+  assert.ok(!/UNKNOWN/.test(msg));
+});
+
+// ── #1501 a QUALIFIED id is a real id (artokun/comfyui-mcp#1425) ──────────
+//
+// `Number("120:104")` is NaN, so the locator returned before searching anything and
+// the caller announced a workflow-identity problem for an id shape the read tools
+// deliberately hand out after a subgraph is unpacked.
+
+test("#1501 a qualified id on the root graph is FOUND, not blamed on another workflow", () => {
+  const root = sub([node("120:104", { type: "KSampler" }), node("120:113", { type: "VAEDecode" })]);
+  const hit = locateNodeAcrossScopes(root, "120:104");
+  assert.equal(hit.scope, "root");
+  assert.deepEqual(hit.hostPath, []);
+  const msg = describeMissingNode("120:104", root, true, root);
+  assert.ok(!/may be from a different workflow/.test(msg), "it came from this graph");
+  assert.ok(!/not in any other scope either/.test(msg));
+  assert.match(msg, /IS on the root graph/);
+});
+
+test("#1501 a qualified id inside a subgraph gets the route, like any other id", () => {
+  const inner = sub([node("263:78", { type: "CLIPTextEncode" })]);
+  const root = sub([node(1), node(9, { title: "Refiner", subgraph: inner })]);
+  const hit = locateNodeAcrossScopes(root, "263:78");
+  assert.equal(hit.scope, "subgraph");
+  assert.deepEqual(hit.hostPath, [{ id: 9, title: "Refiner" }]);
+  const msg = describeMissingNode("263:78", root, true, root);
+  assert.match(msg, /lives INSIDE a subgraph/);
+  assert.match(msg, /panel_enter_subgraph\(9\)/);
+});
+
+test("#1501 a qualified id that really is absent still reports a completed search", () => {
+  const root = sub([node("120:104")]);
+  assert.equal(locateNodeAcrossScopes(root, "999:1"), null);
+  assert.match(describeMissingNode("999:1", root, true), /not in any other scope either/);
+});
+
+test("#1501 a qualified id is never PARSED into the different node its prefix names", () => {
+  // `parseInt("120:104")` is 120 — a real, different node. Matching it would turn a
+  // loud miss into a confident pointer at the wrong node.
+  const root = sub([node(120, { type: "Host" }), node(104, { type: "Other" })]);
+  assert.equal(locateNodeAcrossScopes(root, "120:104"), null);
+  // and the reverse: a plain id must not be answered by a qualified node
+  assert.equal(locateNodeAcrossScopes(sub([node("120:104")]), 120), null);
+});
+
+test("#1501 plain and numeric-string ids are matched exactly as before", () => {
+  // Live ComfyUI ids are strings, so the numeric comparison is the load-bearing one.
+  const root = sub([node("5548", { type: "SaveImage" })]);
+  assert.equal(locateNodeAcrossScopes(root, 5548).scope, "root");
+  assert.equal(locateNodeAcrossScopes(root, "5548").scope, "root");
+  assert.equal(locateNodeAcrossScopes(sub([node(7)]), 7).scope, "root");
 });
 
 // ── WIRING ────────────────────────────────────────────────────────────────

--- a/web/js/lib/node-scope-locator.js
+++ b/web/js/lib/node-scope-locator.js
@@ -31,6 +31,26 @@
  * unexpected shape simply ends that branch — a diagnostic that throws would replace a
  * bad error with a worse one.
  *
+ * NOT-FOUND AND COULD-NOT-LOOK ARE DIFFERENT ANSWERS (#1501). Failing closed is right;
+ * reporting the failure as a finding is not. `null` used to mean all three of "searched
+ * every scope and it is absent", "the walk threw part-way", and "that id is not a shape
+ * I can look up" — and the only one of the three the caller could spell was the first:
+ * "The id may be from a different workflow, or the node was removed." So a malformed
+ * graph or a throwing getter on a third-party node was published to the agent as a
+ * positive statement about the node's ABSENCE. The walk reads arbitrary third-party node
+ * objects (`n.subgraph`, `n.title`, `n.type`), so this is reachable rather than
+ * theoretical. `null` now means only "searched and absent"; "could not look" comes back
+ * as `{ unsearchable }` and the message says so instead of guessing.
+ *
+ * A QUALIFIED ID IS A REAL ID (#1501, artokun/comfyui-mcp#1425). The walk matched on
+ * `Number(id)`, so `120:104` — the form the READ tools deliberately hand out once a
+ * subgraph has been unpacked — came out NaN and the locator returned before searching
+ * anything. The node existed, was addressable, and the diagnostic said it was from a
+ * different workflow: worse than silence, because it points the reader at a
+ * workflow-identity problem that does not exist. Ids are now compared the way
+ * `canonicalNodeId` resolves them — a qualified id by its string key, everything else
+ * numerically, exactly as before.
+ *
  * `MAX_DEPTH` IS THE SAFETY PROPERTY; `seen` IS AN OPTIMIZATION. Worth stating because
  * the reverse is the natural assumption. `MAX_DEPTH` bounds the one case nothing else
  * does — an unbounded ACYCLIC chain, where every level is a distinct object and `seen`
@@ -45,6 +65,8 @@
  * the only one, because picking one and calling it "the" location would be a guess
  * with a plausible-looking shape.
  */
+
+import { isQualifiedNodeId } from "./node-id.js";
 
 /** Depth guard for a pathological/looping graph. Real workflows nest a handful deep. */
 const MAX_DEPTH = 12;
@@ -69,24 +91,54 @@ function nodesOf(graph) {
 }
 
 /**
+ * Why a search produced no location. Both mean "I could not look", never "it is
+ * not there" — see the `{ unsearchable }` note in the module header.
+ *
+ * `"walk-threw"`  the graph walk raised part-way through; scopes remain unsearched.
+ * `"id-shape"`    the id is neither an integer nor a subgraph-qualified id, so there
+ *                 was no key to look for and nothing was searched at all.
+ */
+const UNSEARCHABLE_REASONS = ["walk-threw", "id-shape"];
+
+/** True for the "could not look" result, so a caller can never mistake it for a miss. */
+export function isUnsearchable(result) {
+  return Boolean(result) && UNSEARCHABLE_REASONS.includes(result.unsearchable);
+}
+
+/**
  * Find a node by its LOCAL id anywhere in the workflow, reporting the route to it.
  *
+ * THREE ANSWERS, NOT TWO (#1501). `null` means the search RAN and the id is absent —
+ * only a caller holding that value may say the node is not here. A `{ unsearchable }`
+ * result means the search could not run or could not finish, and the caller must say
+ * that instead of guessing at absence.
+ *
  * @param {object} rootGraph the workflow's root graph
- * @param {number|string} nodeId the local id being looked up
- * @returns {null | {scope: "root"|"subgraph", hostPath: Array<{id: any, title: string}>}}
+ * @param {number|string} nodeId the local id being looked up — an integer, a numeric
+ *   string, or a subgraph-qualified id such as `"120:104"` (comfyui-mcp#1425)
+ * @returns {null | {unsearchable: string} | {scope: "root"|"subgraph", hostPath: Array<{id: any, title: string}>}}
  *   `hostPath` is the chain of subgraph HOST nodes to enter, outermost first; empty
  *   for a node on the root graph.
  */
 export function locateNodeAcrossScopes(rootGraph, nodeId) {
-  const target = Number(nodeId);
-  if (!Number.isFinite(target)) return null;
+  // A qualified id is a LiteGraph object key, matched as the string it is; anything
+  // else keeps the numeric comparison unchanged, so a plain id behaves exactly as
+  // before (including the numeric-string surface: `Number("5548") === 5548`, and live
+  // ComfyUI ids really are strings). Parsing a qualified id is the one thing that must
+  // not happen — `parseInt("263:78")` is 263, a different real node.
+  const qualified = isQualifiedNodeId(nodeId);
+  const target = qualified ? nodeId : Number(nodeId);
+  if (!qualified && !Number.isFinite(target)) return { unsearchable: "id-shape" };
+  const matches = qualified
+    ? (n) => n?.id != null && String(n.id) === target
+    : (n) => Number(n?.id) === target;
   const seen = new Set();
 
   const walk = (graph, hostPath, depth) => {
     if (!graph || depth > MAX_DEPTH || seen.has(graph)) return null;
     seen.add(graph);
     for (const n of nodesOf(graph)) {
-      if (Number(n?.id) === target) {
+      if (matches(n)) {
         return { scope: hostPath.length ? "subgraph" : "root", hostPath };
       }
     }
@@ -103,7 +155,8 @@ export function locateNodeAcrossScopes(rootGraph, nodeId) {
   try {
     return walk(rootGraph, [], 0);
   } catch {
-    return null; // a diagnostic must never throw
+    // Still non-throwing — but no longer indistinguishable from a completed search.
+    return { unsearchable: "walk-threw" };
   }
 }
 
@@ -191,6 +244,25 @@ export function describeMissingNode(nodeId, rootGraph, viewingRoot, currentGraph
   if (!rootGraph) return ids ? `${base}. ${ids}` : base;
 
   const found = locateNodeAcrossScopes(rootGraph, nodeId);
+
+  // #1501 — "I could not look" must never be published as "it is not there". Both of
+  // these used to fall into the genuine-miss branch below and assert absence.
+  if (isUnsearchable(found)) {
+    const why =
+      found.unsearchable === "id-shape"
+        ? `no wider search was possible: ${JSON.stringify(String(nodeId))} is not an id ` +
+          `shape this panel can look up (expected an integer, or a subgraph-qualified ` +
+          `id such as 120:104 — the form the read tools emit once a subgraph is unpacked)`
+        : `the wider search could NOT be completed: reading this workflow's graph threw ` +
+          `part-way through, so some scopes were never searched`;
+    return (
+      `${base} — and ${why}. Whether node ${nodeId} exists in another scope is ` +
+      `UNKNOWN: this is NOT a statement that it was removed or that the id belongs to ` +
+      `a different workflow. ` +
+      (ids || `Re-read with panel_graph_outline before retrying.`)
+    );
+  }
+
   if (!found) {
     const subs = countSubgraphs(rootGraph);
     return (


### PR DESCRIPTION
Closes #1501

Two pre-existing defects in `web/js/lib/node-scope-locator.js`, both the same shape #1495 fixed a third instance of: **a diagnostic that cannot find a node reports "it does not exist" when what actually happened is "I could not look."**

`null` was doing three different jobs — searched-every-scope-and-absent, the walk threw part-way, and the id was not a shape the walk could key on — and the only one of the three the consumer at `:193` could spell was the first:

> The id may be from a different workflow, or the node was removed.

## 1. A walk that THREW was reported as "not found anywhere"

`locateNodeAcrossScopes` ended in `catch { return null }`. Not throwing is right; returning the **same value as a completed search that found nothing** is not. The walk reads arbitrary third-party node objects (`n?.subgraph`, `n.title`, `n.type`), so a malformed graph or a throwing getter is reachable rather than theoretical — and it was published to the agent as a positive statement about the node's *absence*.

## 2. A qualified id could never be found

The walk opened with `Number(nodeId)`, so a **qualified id** (`120:104` — the form the read tools deliberately emit once a subgraph is unpacked, comfyui-mcp#1425) came out `NaN` and the locator returned before searching anything. The node existed, was addressable, and the diagnostic pointed the reader at a workflow-identity problem that does not exist.

This is reachable in production precisely where it hurts: a qualified root-level node written to while viewing a subgraph misses `getNodeById`, and used to be blamed on another workflow instead of being told to `panel_exit_subgraph`.

## The fix

- `null` now means **only** "searched and absent" — so #1298's retarget list and #1495's checked scope claim are untouched.
- "Could not look" returns `{ unsearchable: "walk-threw" | "id-shape" }`, and the message says `UNKNOWN` explicitly, stating that this is *not* a claim of removal or of a foreign workflow.
- Ids are compared the way `canonicalNodeId` already resolves them: a qualified id by its string key, everything else numerically, exactly as before. A qualified id is **never parsed** — `parseInt("120:104")` is `120`, a different real node, which would turn a loud miss into a confident pointer at the wrong one.

Still non-throwing, still bounded, still failing closed.

## Verification

Unit suite green (`node --test browser_tests/unit/*.test.mjs`), typecheck clean. 35/35 in `node-scope-locator.test.mjs`, 10 of them new.

**Mutation-verified — each half of the fix was deleted and the right tests went red:**

| mutation | result |
|---|---|
| thrown-walk answer reverted to `return null` | 2 red (`a walk that THREW…`, `a thrown walk says UNKNOWN…`) |
| qualified-id handling reverted to `Number()`/`null` | 4 red (both qualified-id tests, the id-shape test, the malformed-graph test) |
| `isUnsearchable` branch deleted from `describeMissingNode` | 4 red — including the pre-existing `#1298 current-id listing never throws`, so the new branch is load-bearing for the non-throwing guarantee too |
| restored | 35/35 green |

Guarded against over-correction: `#1501 a genuine miss is still a genuine miss` pins that a real absence still gets `not in any other scope either` / `may be from a different workflow` and **not** `UNKNOWN` — the "unknown" answer must not swallow the actionable case.

`manager-install.test.mjs #671` failed once in the full-suite run and passes 125/125 in isolation — the known wall-clock flake, unrelated to this diff.

## Gate

`codex-gate.mjs` → **SHIP** (exit 0). Codex quota has recovered (the exhaustion window ended 2026-08-19 20:43), so this is the real gate, not the substitute.

## What I did not do

**No Playwright run.** This touches one `web/js/lib` diagnostic module with no DOM or rendering surface — nothing the panel *renders* changes, only the text of an error a bridge command throws. The identical footprint shipped in #1499 (same file, same consumer, same message) with unit tests only. No ComfyUI was allocated for this run, and the only listening instance (`:8188`) is shared — its `custom_nodes` junction points at another checkout, so an e2e run from here would have exercised someone else's code and returned a misleading green, and repointing it would have disrupted another agent. Stating this rather than implying coverage I do not have.

**`MAX_DEPTH` truncation left alone.** A walk that stops at the depth ceiling is arguably a third instance of the same "could not look" shape, but real workflows nest a handful deep, an existing test deliberately pins `null` there as a bounded-search invariant, and #1501 names exactly two defects. Flagging rather than widening the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
