### PR TITLE
fix(1496): panel_list_nodes with search filters the installed packs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+### Fixed
+- `panel_list_nodes` with `search` (or `query`) filters the installed-pack list instead of returning every pack (#1496)
+
 ## [0.15.25] - 2026-08-20
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ which receives `panel_*` by a different route.
 | `panel_get_subgraph` | Read inside a subgraph node's inner graph |
 | `panel_get_errors` | Read the last execution error + per-node validation errors |
 | `panel_list_workflows` | List open workflow tabs and which is active |
-| `panel_list_nodes` | List installed custom-node packs |
+| `panel_list_nodes` | List installed custom-node packs (optional `search` or `query` filters by pack name) |
 | `panel_list_mcp` | List connected MCP servers |
 | `panel_get_content_mode` | Read the adult-content (NSFW) consent state |
 

--- a/browser_tests/unit/nodes-list-search.test.mjs
+++ b/browser_tests/unit/nodes-list-search.test.mjs
@@ -1,0 +1,141 @@
+/**
+ * #1496 — `panel_list_nodes` rejected `search` at the MCP schema (`{}` + strict)
+ * with Unrecognized key. The panel half: when `search` (reporter) or `query`
+ * (the panel_search_nodes alias) arrives on `nodes_list`, filter the installed
+ * payload instead of dumping every pack. A miss discloses total so it cannot
+ * be read as "nothing is installed".
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import {
+  filterInstalledPayload,
+  installedListQuery,
+  listedNodesResult,
+} from "../../web/js/lib/manager-install.js";
+
+const PANEL = readFileSync(fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url)), "utf8");
+const README = readFileSync(fileURLToPath(new URL("../../README.md", import.meta.url)), "utf8");
+
+/** The reporter's pack plus a couple of neighbours, in Manager v4's map shape. */
+const INSTALLED_MAP = {
+  "ComfyUI-SeedVR2_VideoUpscaler": {
+    ver: "1.2.0",
+    cnr_id: "seedvr2",
+    aux_id: "numz/ComfyUI-SeedVR2_VideoUpscaler",
+    enabled: true,
+  },
+  "rgthree-comfy": { ver: "1.0.0", cnr_id: "rgthree-comfy", enabled: true },
+  "ComfyUI-Manager": { ver: "3.10", cnr_id: "comfyui-manager", enabled: true },
+};
+
+const INSTALLED_ARRAY = [
+  { title: "ComfyUI-SeedVR2_VideoUpscaler", cnr_id: "seedvr2" },
+  { title: "rgthree-comfy", cnr_id: "rgthree-comfy" },
+  "ComfyUI-Manager",
+];
+
+test("#1496 the reporter's search:SeedVR2 keeps that pack and drops the rest", () => {
+  const res = listedNodesResult(INSTALLED_MAP, { search: "SeedVR2" });
+  assert.equal(res.search, "SeedVR2");
+  assert.equal(res.count, 1);
+  assert.equal(res.total, 3);
+  assert.deepEqual(Object.keys(res.installed), ["ComfyUI-SeedVR2_VideoUpscaler"]);
+  assert.equal(res.installed["ComfyUI-SeedVR2_VideoUpscaler"].cnr_id, "seedvr2");
+  assert.equal(res.note, undefined, "a hit must not carry the miss note");
+});
+
+test("#1496 query is accepted as the panel_search_nodes alias", () => {
+  const res = listedNodesResult(INSTALLED_MAP, { query: "seedvr2" });
+  assert.equal(res.query, "seedvr2");
+  assert.equal(res.search, undefined);
+  assert.equal(res.count, 1);
+  assert.deepEqual(Object.keys(res.installed), ["ComfyUI-SeedVR2_VideoUpscaler"]);
+});
+
+test("#1496 search wins when both keys are non-empty", () => {
+  const res = listedNodesResult(INSTALLED_MAP, { search: "SeedVR2", query: "rgthree" });
+  assert.equal(res.search, "SeedVR2");
+  assert.equal(res.query, undefined);
+  assert.equal(res.count, 1);
+  assert.deepEqual(Object.keys(res.installed), ["ComfyUI-SeedVR2_VideoUpscaler"]);
+});
+
+test("#1496 no filter returns the raw payload unchanged — no count/total/note", () => {
+  const res = listedNodesResult(INSTALLED_MAP, {});
+  assert.equal(res.installed, INSTALLED_MAP);
+  assert.equal(res.search, undefined);
+  assert.equal(res.query, undefined);
+  assert.equal(res.count, undefined);
+  assert.equal(res.total, undefined);
+  assert.equal(res.note, undefined);
+});
+
+test("#1496 whitespace-only search is not a filter", () => {
+  assert.deepEqual(installedListQuery({ search: "   " }), { key: null, value: "" });
+  const res = listedNodesResult(INSTALLED_MAP, { search: "  \n" });
+  assert.equal(res.installed, INSTALLED_MAP);
+  assert.equal(res.count, undefined);
+});
+
+test("#1496 a miss discloses total so it cannot be read as nothing installed", () => {
+  const res = listedNodesResult(INSTALLED_MAP, { search: "definitely-not-here" });
+  assert.equal(res.count, 0);
+  assert.equal(res.total, 3);
+  assert.deepEqual(res.installed, {});
+  assert.match(res.note, /0 of 3 installed packs matched search "definitely-not-here"/);
+  assert.match(res.note, /panel_search_nodes/);
+  assert.match(res.note, /query/);
+});
+
+test("#1496 terms are AND — SeedVR2 rgthree matches neither pack", () => {
+  const res = listedNodesResult(INSTALLED_MAP, { search: "SeedVR2 rgthree" });
+  assert.equal(res.count, 0);
+  assert.equal(res.total, 3);
+});
+
+test("#1496 legacy array shape is filtered the same way", () => {
+  const res = listedNodesResult(INSTALLED_ARRAY, { search: "SeedVR2" });
+  assert.equal(res.count, 1);
+  assert.equal(res.total, 3);
+  assert.equal(res.installed.length, 1);
+  assert.equal(res.installed[0].cnr_id, "seedvr2");
+});
+
+test("#1496 cnr_id / aux_id are in the haystack, not just the module key", () => {
+  const byCnr = listedNodesResult(INSTALLED_MAP, { search: "numz" });
+  assert.deepEqual(Object.keys(byCnr.installed), ["ComfyUI-SeedVR2_VideoUpscaler"]);
+  const byAux = filterInstalledPayload(INSTALLED_MAP, "comfyui-manager");
+  assert.equal(byAux.count, 1);
+  assert.ok(byAux.installed["ComfyUI-Manager"]);
+});
+
+test("#1496 a non-string search is ignored rather than stringified", () => {
+  assert.deepEqual(installedListQuery({ search: true }), { key: null, value: "" });
+  assert.equal(listedNodesResult(INSTALLED_MAP, { search: 1 }).installed, INSTALLED_MAP);
+});
+
+test("#1496 README names the accepted keys", () => {
+  const row = README.split("\n").find((l) => l.includes("`panel_list_nodes`"));
+  assert.ok(row, "the tool table must list panel_list_nodes");
+  assert.match(row, /`search`/);
+  assert.match(row, /`query`/);
+});
+
+test("#1496 nodes_list feeds the command args through listedNodesResult on BOTH list routes", () => {
+  const start = PANEL.indexOf("async nodes_list(");
+  assert.notEqual(start, -1, "nodes_list executor must exist");
+  const end = PANEL.indexOf("async nodes_install(", start);
+  assert.ok(end > start, "nodes_install must follow nodes_list");
+  const body = PANEL.slice(start, end);
+  assert.match(body, /async nodes_list\(args\s*=\s*\{\}\)/);
+  assert.equal(
+    [...body.matchAll(/listedNodesResult\(/g)].length,
+    2,
+    "both the dialect-routed GET and the absolute legacy fallback must filter",
+  );
+  assert.match(body, /listedNodesResult\(await managerGet\(route\), args\)/);
+  assert.match(body, /listedNodesResult\(await managerCall\(route\), args\)/);
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -120,6 +120,7 @@ import {
   taskHistoryBlindNote,
   installGitUrl,
   installedListRoute,
+  listedNodesResult,
   isManagerRouteMissing,
   isManagerUnreachable,
   markManagerUnreachable,
@@ -20942,7 +20943,7 @@ const GRAPH_TOOL_EXECUTORS = {
     return searchNodesVia(managerGet, managerCall, { query, limit, objectInfoGet: fetchObjectInfo });
   },
 
-  async nodes_list() {
+  async nodes_list(args = {}) {
     // #423: route the installed-node list by dialect (managerGet strips /v2 for
     // legacy) with an explicit ?mode=default — matching the live-tested
     // orchestrator. A pip Manager in --enable-manager-legacy-ui mode can answer
@@ -20959,12 +20960,15 @@ const GRAPH_TOOL_EXECUTORS = {
     // the 404/unreachable fallback below never fires and the raw error leaked to
     // the agent. Retry transient transport failures with a short bounded backoff,
     // then reword into an actionable "still reconnecting" status.
+    // #1496 — `search` (reporter) or `query` (panel_search_nodes alias) filters
+    // the installed payload. The MCP schema is still empty `{}` today, so this
+    // is inert until the orchestrator forwards the key.
     return retryDuringReconnect(async () => {
       try {
-        return { installed: await managerGet(route) };
+        return listedNodesResult(await managerGet(route), args);
       } catch (err) {
         if (!isManagerUnreachable(err)) throw err;
-        return { installed: await managerCall(route) };
+        return listedNodesResult(await managerCall(route), args);
       }
     });
   },

--- a/web/js/lib/manager-install.js
+++ b/web/js/lib/manager-install.js
@@ -208,6 +208,75 @@ export function parseInstalled(raw) {
 }
 
 /**
+ * #1496 — which filter a `nodes_list` command asked for.
+ * `search` is the reporter's key (and the compact-mode list_tools filter).
+ * `query` is the alias panel_search_nodes / panel_find_nodes already use.
+ * Prefer `search` when both are non-empty.
+ */
+export function installedListQuery(args = {}) {
+  const search = args?.search;
+  const query = args?.query;
+  if (typeof search === "string" && search.trim()) return { key: "search", value: search };
+  if (typeof query === "string" && query.trim()) return { key: "query", value: query };
+  return { key: null, value: "" };
+}
+
+function installedEntryHay(entry, mapKey) {
+  if (typeof entry === "string") return entry.toLowerCase();
+  if (!entry || typeof entry !== "object") return String(mapKey ?? "").toLowerCase();
+  return [mapKey, entry.title, entry.module, entry.cnr_id, entry.aux_id, entry.ver]
+    .filter((v) => typeof v === "string" && v)
+    .join(" ")
+    .toLowerCase();
+}
+
+/** Filter a raw Manager `/customnode/installed` payload, preserving map vs array shape. */
+export function filterInstalledPayload(raw, query) {
+  const terms = queryTerms(query);
+  if (Array.isArray(raw)) {
+    const total = raw.length;
+    if (!terms.length) return { installed: raw, total, count: total };
+    const installed = raw.filter((entry) => matchesAllTerms(installedEntryHay(entry), terms));
+    return { installed, total, count: installed.length };
+  }
+  if (raw && typeof raw === "object") {
+    const entries = Object.entries(raw);
+    const total = entries.length;
+    if (!terms.length) return { installed: raw, total, count: total };
+    const installed = {};
+    for (const [k, v] of entries) {
+      if (matchesAllTerms(installedEntryHay(v, k), terms)) installed[k] = v;
+    }
+    return { installed, total, count: Object.keys(installed).length };
+  }
+  return { installed: raw, total: 0, count: 0 };
+}
+
+/**
+ * #1496 — `panel_list_nodes` result. No filter → `{installed}` as before.
+ * A `search`/`query` filters the payload and discloses count/total so a miss
+ * cannot be read as "nothing is installed".
+ */
+export function listedNodesResult(raw, args = {}) {
+  const { key, value } = installedListQuery(args);
+  if (!key) return { installed: raw };
+  const filtered = filterInstalledPayload(raw, value);
+  const out = {
+    installed: filtered.installed,
+    [key]: value,
+    count: filtered.count,
+    total: filtered.total,
+  };
+  if (filtered.count === 0) {
+    out.note =
+      `0 of ${filtered.total} installed packs matched ${key} "${value}". ` +
+      `This filters ALREADY-INSTALLED packs, not the installable registry — ` +
+      `use panel_search_nodes with query for packs you can install.`;
+  }
+  return out;
+}
+
+/**
  * Does the installed-nodes list contain the pack we just tried to install?
  * `idOrUrl` is the install target — a registry id (author/pack or CNR id) or a
  * git URL. For a git URL we match on the derived repo name. Compares against


### PR DESCRIPTION
Fixes #1496

## What was actually wrong

`panel_list_nodes({"search":"SeedVR2"})` returned MCP `-32602 Unrecognized key: "search"`.

The **shipped schema is in comfyui-mcp**, not here:

```ts
def("panel_list_nodes", "... Read-only.", {},
    async (_args, ctx) => ctx.call({ cmd: "nodes_list" }, 20000))
```

Empty object, `.strict()`. `panel_search_nodes` already takes `query`. MCP does **not** send `query` (or anything) to `nodes_list` — the handler ignores args. The panel executor was `nodes_list()` with no parameters and returned the entire installed payload.

So the reporter's call never reached the panel. The empty schema also does not tell a caller which filter key, if any, would work — because none would.

## The fix (panel half)

`nodes_list` now accepts `search` (the reporter's key; also compact-mode `list_tools`) or `query` (the `panel_search_nodes` / `panel_find_nodes` alias). Prefer `search` when both are non-empty.

It filters the raw Manager `/customnode/installed` payload (v4 map or legacy array) by those terms, AND-matched across module / title / cnr_id / aux_id / ver, using the same `queryTerms` / `matchesAllTerms` matcher as node search. Shape is preserved.

- No filter → `{installed}` as before (same object identity).
- A hit → `{installed, search|query, count, total}`.
- A miss → the same plus a note that this is a filter of **already-installed** packs (`0 of N`), not a registry search — use `panel_search_nodes` with `query` for installable packs. So a zero cannot be read as "nothing is installed".

Whitespace-only / non-string `search` is not a filter.

## Companion (orchestrator)

This is inert on a current MCP. Until comfyui-mcp adds optional `search` (and `query` as alias) to the `panel_list_nodes` schema **and forwards those keys** on `cmd: "nodes_list"`, the reporter's call still dies at `-32602` before the panel sees it. Same pattern as #1126: the panel half has to land first so an older orchestrator still works, and so the filter is there the moment the key is declared upstream.

## Verification

- `browser_tests/unit/nodes-list-search.test.mjs` — reporter's `search:"SeedVR2"` against a v4 map, `query` alias, search-wins, no-filter identity, whitespace, miss disclosure, AND terms, legacy array, cnr_id/aux_id haystack, non-string ignored, README keys, both `managerGet` / `managerCall` routes wired through `listedNodesResult`.
- `node scripts/check-panel-scope.mjs` — OK.
- `node scripts/check-tool-vocabulary.mjs` — OK.
- Full unit suite: **5963 pass / 1 fail / 1 todo**. The fail is the known wall-clock flake `#671 verifyInstalled (real panel source) still verifies a fast-draining install`; that file is **125/125** on its own.

## Deliberately not done

- Playwright was not run. The live ComfyUI install symlinks to the main checkout, so the browser suite would exercise `main`, not this branch.
- No i18n keys (agent-facing strings are not localized).
- Orchestrator schema is left alone — it lives in artokun/comfyui-mcp.
