### PR TITLE
fix(1504): a minted prompt_id decides the verdict, not the node_errors beside it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project are documented here. This project adheres to
 ## [Unreleased]
 
 ### Fixed
+- a run ComfyUI accepted while dropping some outputs is reported as queued, with the dropped outputs named, instead of as a refusal (#1504)
 - `panel_list_nodes` with `search` (or `query`) filters the installed-pack list instead of returning every pack (#1496)
 
 ## [0.15.25] - 2026-08-20

--- a/browser_tests/unit/queue-rejection.test.mjs
+++ b/browser_tests/unit/queue-rejection.test.mjs
@@ -252,3 +252,184 @@ test("WIRING: graph_run passes the run-to-node target into the summary", async (
   assert.ok(src.includes("runToNode: runToNodeInfo,"),
     "summarizePromptRejection must receive the run-to-node target");
 });
+
+// ── #1504: a MINTED prompt_id outranks node_errors ─────────────────────────
+//
+// panel_run answered
+//
+//   ComfyUI refused to queue the workflow
+//   - VAEDecode (node 36): Required input is missing (samples)   … ×6
+//
+// and the ComfyUI queue showed `running: 1`, prompt b01ba287-…, `pending: 0` at the
+// same instant. Every following graph read/edit was then rejected with QUEUE BUSY —
+// by the very render the caller had just been told did not exist.
+//
+// Both statements came from ONE reply. ComfyUI validates each output independently
+// (execution.validate_prompt); when some fail but at least one survives it logs
+// "Output will be ignored", returns valid[0]=True, and server.py takes the
+// `if valid[0]:` branch — prompt_queue.put(...), then
+//
+//     web.json_response({"prompt_id": …, "number": …, "node_errors": valid[3]})
+//
+// at status **200**. The reported workflow had several output branches with some
+// disabled through node modes, so its bypassed VAEDecode branches are exactly the
+// ones ComfyUI dropped.
+//
+// The panel could not tell the two apart because the frontend funnels both channels
+// into one place: app.queuePrompt calls recordNodeErrors(res.node_errors) on the
+// RESOLVED (200) response too, so app.lastNodeErrors is populated for a prompt that
+// is on the GPU. The verdict now takes the minted prompt_id — a receipt ComfyUI
+// issues only after queueing — over that ambiguous channel.
+
+// The six bypassed VAEDecode branches from the report, in ComfyUI node_errors shape.
+const DROPPED_VAE_DECODES = Object.fromEntries(
+  [36, 41, 57, 60, 63, 66].map((id) => [
+    String(id),
+    {
+      class_type: "VAEDecode",
+      dependent_outputs: [],
+      errors: [
+        { type: "required_input_missing", message: "Required input is missing", details: "samples" },
+      ],
+    },
+  ]),
+);
+const RUNNING_PROMPT_ID = "b01ba287-500f-418d-b2e1-353c891065f1";
+
+test("#1504: node_errors beside a MINTED prompt_id is an accepted partial run, NOT a refusal", () => {
+  const verdict = summarizePromptRejection({
+    rejection: null, // 200 — nothing was captured on the non-200 rejection channel
+    lastNodeErrors: DROPPED_VAE_DECODES, // …but the frontend stored the 200 node_errors here
+    acceptedPromptIds: [RUNNING_PROMPT_ID],
+  });
+  assert.equal(
+    verdict,
+    null,
+    "ComfyUI minted a prompt id, so this prompt IS queued — the node_errors name dropped outputs",
+  );
+});
+
+test("#1504: the accept result reports the dropped outputs alongside the prompt_id", () => {
+  // This is the mcp#944 shape — `queued:true` + prompt_id + node_errors, with NO
+  // top-level error — which the orchestrator renders as its "[PARTIAL] ComfyUI
+  // ACCEPTED this prompt and is running it, but it dropped N output(s)" disclosure.
+  // That disclosure has existed since mcp v0.50.2 and was unreachable from here,
+  // because the panel sent node_errors with no prompt_id beside them.
+  const r = buildQueueAcceptResult({
+    batchCount: 1,
+    promptIds: [RUNNING_PROMPT_ID],
+    droppedOutputs: DROPPED_VAE_DECODES,
+  });
+  assert.equal(r.queued, true);
+  assert.equal(r.prompt_id, RUNNING_PROMPT_ID);
+  assert.deepEqual(r.node_errors, DROPPED_VAE_DECODES);
+  assert.equal(r.error, undefined, "no top-level error: the prompt was accepted");
+});
+
+test("#1504: a clean accept says nothing about dropped outputs", () => {
+  // The disclosure is loud, so it must never fire on a run that dropped nothing.
+  for (const dropped of [null, undefined, {}, [], "nope", 0]) {
+    const r = buildQueueAcceptResult({ batchCount: 1, promptIds: ["p1"], droppedOutputs: dropped });
+    assert.equal(
+      r.node_errors,
+      undefined,
+      `no node_errors for droppedOutputs=${JSON.stringify(dropped)}`,
+    );
+  }
+});
+
+test("#1504 does NOT regress #358: a top-level rejection is still a refusal", () => {
+  // The #358 shape is a 400, which mints nothing — acceptedPromptIds is empty and
+  // the verdict is untouched.
+  const verdict = summarizePromptRejection({
+    rejection: { error: MISSING_NODE_TYPE, node_errors: {} },
+    lastNodeErrors: {},
+    acceptedPromptIds: [],
+  });
+  assert.ok(verdict);
+  assert.equal(verdict.queued, false);
+  assert.equal(verdict.error_type, "missing_node_type");
+  assert.equal(verdict.prompt_id, undefined);
+});
+
+test("#1504: node_errors with NO minted prompt_id is still a refusal (unchanged)", () => {
+  // A genuine 400 validation refusal: every output failed, nothing was queued.
+  const verdict = summarizePromptRejection({
+    rejection: { error: null, node_errors: DROPPED_VAE_DECODES },
+    lastNodeErrors: {},
+  });
+  assert.ok(verdict, "with no receipt of acceptance the per-node errors still mean refused");
+  assert.equal(verdict.queued, false);
+  assert.deepEqual(verdict.node_errors, DROPPED_VAE_DECODES);
+});
+
+test("#1504: a top-level error PLUS a minted id stays a refusal, but carries the id", () => {
+  // A batch whose first prompt was accepted and whose second was refused. The two
+  // claims contradict each other, so the verdict does not silently pick the happy
+  // one — it reports the refusal AND the id, which the orchestrator turns into its
+  // "[UNCERTAIN] … a render may already be in flight, do NOT re-run" answer. Losing
+  // the id here is what sends a caller to re-queue work that is already rendering.
+  const verdict = summarizePromptRejection({
+    rejection: { error: MISSING_NODE_TYPE, node_errors: {} },
+    lastNodeErrors: {},
+    acceptedPromptIds: ["p1", "p2"],
+  });
+  assert.ok(verdict);
+  assert.equal(verdict.queued, false);
+  assert.equal(verdict.prompt_id, "p1");
+  assert.deepEqual(verdict.prompt_ids, ["p1", "p2"]);
+});
+
+test("#1504: accepted ids are normalized like every other id boundary (#370)", () => {
+  // 0 is a real prompt id, and 0 / "0" are the same run.
+  assert.equal(
+    summarizePromptRejection({ lastNodeErrors: DROPPED_VAE_DECODES, acceptedPromptIds: [0] }),
+    null,
+    "the falsy-but-valid id 0 is still a receipt of acceptance",
+  );
+  const v = summarizePromptRejection({
+    rejection: { error: MISSING_NODE_TYPE },
+    acceptedPromptIds: [0, "0", null, "  ", undefined, 7],
+  });
+  assert.deepEqual(v.prompt_ids, ["0", "7"], "deduped after string normalization; blanks dropped");
+});
+
+test("#1504: an absent acceptedPromptIds argument leaves every caller verdict unchanged", () => {
+  // Callers that never pass the new argument (and any odd value) must behave
+  // exactly as before — the receipt only ever ADDS acceptance evidence.
+  for (const ids of [undefined, null, [], "p1", 5, {}]) {
+    const v = summarizePromptRejection({
+      rejection: null,
+      lastNodeErrors: { 7: { errors: [{ message: "required input missing" }] } },
+      acceptedPromptIds: ids,
+    });
+    assert.ok(v, `acceptedPromptIds=${JSON.stringify(ids)} must not be read as an acceptance`);
+    assert.equal(v.queued, false);
+  }
+});
+
+test("WIRING #1504: graph_run captures the 200 node_errors and hands the ids to the verdict", async () => {
+  // The tests above prove the verdict is right; none prove graph_run REACHES it.
+  // graph_run lives on a module-private handler map in the monolith and needs a
+  // live app, so pin the three lines the fix depends on. Without any one of them
+  // every test above stays green while panel_run still reports the refusal.
+  const { readFile } = await import("node:fs/promises");
+  const src = await readFile(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8");
+  // …captured from the 200 body on BOTH dispatch paths (unscoped + run-to-node),
+  assert.equal(
+    src.split("onAcceptedNodeErrors: captureAcceptedNodeErrors,").length - 1,
+    2,
+    "both the unscoped interceptor and the scoped dispatch must capture accepted node_errors",
+  );
+  // …the minted ids reach the verdict (without this the refusal returns),
+  assert.ok(
+    src.includes("acceptedPromptIds: queuedPromptIds,"),
+    "summarizePromptRejection must receive the prompt_ids ComfyUI minted",
+  );
+  // …and the dropped outputs reach the accept result (without this the caller is
+  // never told which outputs will produce no file).
+  assert.ok(
+    src.includes("droppedOutputs: acceptedNodeErrors,"),
+    "buildQueueAcceptResult must receive the dropped outputs",
+  );
+});

--- a/browser_tests/unit/run-scope-guard.test.mjs
+++ b/browser_tests/unit/run-scope-guard.test.mjs
@@ -3640,3 +3640,100 @@ test("#1871 WIRING: graph_run actually RENDERS the pruned-retry disclosure into 
     "the acceptance claim is gated on a post ComfyUI actually accepted",
   );
 });
+
+// ---------------------------------------------------------------------------
+// #1504 — node_errors on an ACCEPTED (200) reply
+// ---------------------------------------------------------------------------
+//
+// ComfyUI validates each output independently. When some fail but at least one
+// survives, server.py queues the prompt and answers **200** with `prompt_id` AND
+// the `node_errors` for the outputs it dropped. Those errors are not a refusal,
+// and the capture layer is the only place that can still tell the difference:
+// the frontend records a 200 reply node_errors onto app.lastNodeErrors exactly
+// like a rejection, so by the time graph_run reads that field the distinction is
+// gone. These pin that the 200 body is read for BOTH facts, on BOTH dispatch
+// paths, and that a rejection is still never manufactured from a 200.
+
+const PARTIAL_NODE_ERRORS = {
+  36: {
+    class_type: "VAEDecode",
+    dependent_outputs: [],
+    errors: [{ type: "required_input_missing", message: "Required input is missing", details: "samples" }],
+  },
+};
+
+test("#1504 unscoped interceptor: a 200 with node_errors yields prompt_id + ACCEPTED drops, never a rejection", async () => {
+  const spy = makeServer(async () =>
+    jsonResponse(200, { prompt_id: "p-partial", number: 1, node_errors: PARTIAL_NODE_ERRORS }),
+  );
+  let rejection = null;
+  const ids = [];
+  const dropped = [];
+  const intercepted = createRunFetchInterceptor({
+    origFetchApi: spy,
+    onRejection: (r) => (rejection = r),
+    onPromptId: (p) => ids.push(p),
+    onAcceptedNodeErrors: (ne) => dropped.push(ne),
+  });
+  await intercepted(...promptPost({ prompt: {} }));
+  assert.equal(rejection, null, "a 200 is an acceptance — the rejection channel must stay empty");
+  assert.deepEqual(ids, ["p-partial"], "the minted id is the receipt that this prompt IS queued");
+  assert.deepEqual(dropped, [PARTIAL_NODE_ERRORS], "the dropped outputs come from the 200 body");
+});
+
+test("#1504 unscoped interceptor: a clean 200 reports NO drops", async () => {
+  // Empty / absent / non-object node_errors must never fire the partial disclosure.
+  for (const node_errors of [undefined, null, {}, [], "no"]) {
+    const dropped = [];
+    const intercepted = createRunFetchInterceptor({
+      origFetchApi: makeServer(async () => jsonResponse(200, { prompt_id: "p1", node_errors })),
+      onAcceptedNodeErrors: (ne) => dropped.push(ne),
+    });
+    await intercepted(...promptPost({ prompt: {} }));
+    assert.deepEqual(dropped, [], `node_errors=${JSON.stringify(node_errors)} is not a drop`);
+  }
+});
+
+test("#1504 interceptor: a 400 rejection body is NOT reported as accepted drops", async () => {
+  // The #358 channel is unchanged: a refusal mints nothing, so nothing may reach
+  // the accepted-drops channel or the caller would be told a refused prompt is running.
+  const dropped = [];
+  let rejection = null;
+  const intercepted = createRunFetchInterceptor({
+    origFetchApi: makeServer(async () => jsonResponse(400, { error: null, node_errors: PARTIAL_NODE_ERRORS })),
+    onRejection: (r) => (rejection = r),
+    onAcceptedNodeErrors: (ne) => dropped.push(ne),
+  });
+  await intercepted(...promptPost({ prompt: {} }));
+  assert.deepEqual(dropped, [], "a non-200 never produces accepted drops");
+  assert.deepEqual(rejection.node_errors, PARTIAL_NODE_ERRORS, "it stays a rejection");
+});
+
+test("#1504 integration: a SCOPED run reports the outputs ComfyUI dropped from the prompt it queued", async () => {
+  const stop = keepAlive();
+  try {
+    const apiTarget = {
+      fetchApi: makeServer(async () =>
+        jsonResponse(200, { prompt_id: "p-scoped", number: 1, node_errors: PARTIAL_NODE_ERRORS }),
+      ),
+    };
+    const app = makeFrontend({ shape: "shim", apiTarget });
+    const ids = [];
+    const dropped = [];
+    const result = await dispatchScopedRun({
+      app,
+      apiTarget,
+      execIds: ["14"],
+      batch: 1,
+      toNodeId: 14,
+      onPromptId: (p) => ids.push(p),
+      onAcceptedNodeErrors: (ne) => dropped.push(ne),
+    });
+    assert.equal(result.outcome, "dispatched", "a partial-validation 200 is still a real dispatch");
+    assert.equal(result.verified, 1, "it counts as VERIFIED: ComfyUI accepted and is running it");
+    assert.deepEqual(ids, ["p-scoped"]);
+    assert.deepEqual(dropped, [PARTIAL_NODE_ERRORS]);
+  } finally {
+    stop();
+  }
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -15795,6 +15795,19 @@ const GRAPH_TOOL_EXECUTORS = {
       // are the same run) so #370 reconcile stays string-vs-string.
       if (!queuedPromptIds.includes(pid)) queuedPromptIds.push(pid);
     };
+    // #1504 — node_errors that arrived on an ACCEPTED (200) reply: the outputs
+    // ComfyUI dropped from a prompt it queued anyway ("Output will be ignored").
+    // Read from the response body, NOT from app.lastNodeErrors, because the
+    // frontend stores both channels in the same place: it calls
+    // recordNodeErrors(res.node_errors) on the resolved 200 too, so
+    // lastNodeErrors cannot distinguish a refusal from an accepted partial run —
+    // which is precisely how a running render came back as "refused to queue".
+    // Merged across a batch (first entry per node id wins) because each of the N
+    // prompts gets its own reply and any of them may drop outputs.
+    let acceptedNodeErrors = null;
+    const captureAcceptedNodeErrors = (ne) => {
+      acceptedNodeErrors = { ...(ne ?? {}), ...(acceptedNodeErrors ?? {}) };
+    };
     // #445: guard the VHS null-widget serialization crash. ComfyUI core / node
     // extensions (notably VHS_VideoCombine) serialize EVERY node's widgets when
     // building the prompt — even unused branches, even under "run to node" — and
@@ -15854,6 +15867,7 @@ const GRAPH_TOOL_EXECUTORS = {
           origFetchApi,
           onRejection: captureRejection,
           onPromptId: capturePromptId,
+          onAcceptedNodeErrors: captureAcceptedNodeErrors,
           // #985 — keep each prompt AS SUBMITTED AND ACCEPTED. Re-deriving one
           // afterwards with a second app.graphToPrompt() would describe a different
           // compilation than the one ComfyUI accepted, and that call is not read-only.
@@ -15879,6 +15893,7 @@ const GRAPH_TOOL_EXECUTORS = {
         toNodeId: to_node_id,
         onRejection: captureRejection,
         onPromptId: capturePromptId,
+        onAcceptedNodeErrors: captureAcceptedNodeErrors,
       });
     }
     // Register EVERY accepted prompt_id for reconnect reconciliation (#370) —
@@ -15982,6 +15997,10 @@ const GRAPH_TOOL_EXECUTORS = {
       rejection: promptRejection,
       lastNodeErrors: app.lastNodeErrors,
       runToNode: runToNodeInfo,
+      // #1504 — the prompt_id(s) ComfyUI MINTED for this run. A minted id is a
+      // receipt of acceptance, so per-node errors that arrive beside one are
+      // dropped outputs, not a refusal of the whole prompt.
+      acceptedPromptIds: queuedPromptIds,
     });
     if (rejection) return rejection;
     // Surface the queued prompt_id(s) so the agent can correlate/track the run —
@@ -15991,6 +16010,8 @@ const GRAPH_TOOL_EXECUTORS = {
       batchCount: batch,
       promptIds: queuedPromptIds,
       ranToNode: partialTargets ? Number(to_node_id) : null,
+      // #1504 — outputs ComfyUI dropped from the prompt it queued.
+      droppedOutputs: acceptedNodeErrors,
     });
     // #988 — attach the PRE-dispatch finding.
     const repeatingNote = scopedBatchSeedNote(repeatingControls, batch);

--- a/web/js/lib/queue-rejection.js
+++ b/web/js/lib/queue-rejection.js
@@ -31,13 +31,19 @@
  *   for a run-to-node partial run, naming the target the panel ALREADY verified
  *   advertises `output_node:true`. Used to explain a `prompt_no_outputs` refusal
  *   (#699) instead of passing the bare backend string through.
- * @returns {null | {queued:false, error?:string, error_type?:string, node_errors?:object}}
+ * @param {(string|number)[]} [args.acceptedPromptIds]  Every prompt_id ComfyUI MINTED
+ *   during this run, read out of a 200 POST /prompt body (#1504). A minted id is a
+ *   receipt of acceptance, not a flag the panel set, so it decides the verdict over
+ *   any per-node errors that accompany it.
+ * @returns {null | {queued:false, error?:string, error_type?:string, node_errors?:object,
+ *   prompt_id?:string, prompt_ids?:string[]}}
  *   `null` ⇒ accepted (report queued). Otherwise the failure to return verbatim.
  */
 export function summarizePromptRejection({
   rejection = null,
   lastNodeErrors = null,
   runToNode = null,
+  acceptedPromptIds = [],
 } = {}) {
   const topError = rejection && typeof rejection === "object" ? rejection.error ?? null : null;
   // Prefer the node_errors carried on the rejection body itself; fall back to
@@ -49,7 +55,36 @@ export function summarizePromptRejection({
   // No top-level error AND no per-node errors ⇒ the prompt was accepted.
   if (!hasTopError(topError) && !nodeErrors) return null;
 
+  // #1504 — A MINTED PROMPT ID OUTRANKS node_errors.
+  //
+  // ComfyUI validates each output independently. When some fail but at least one
+  // survives, `validate_prompt` returns True, server.py queues the prompt, and the
+  // reply is a **200** carrying `prompt_id` AND the `node_errors` for the outputs it
+  // dropped. The frontend records those on `app.lastNodeErrors` just the same, so the
+  // per-node channel alone cannot tell "refused" from "accepted, minus two branches".
+  //
+  // Reported as a refusal it produced the exact mismatch of #1504: six bypassed
+  // VAEDecode branches were surfaced as "ComfyUI refused to queue the workflow" while
+  // the render was on the GPU, and every subsequent graph call came back QUEUE BUSY —
+  // the caller was told nothing had been queued by the very run that was blocking it.
+  //
+  // The asymmetry that makes this safe is the same one mcp#944 relies on: `queued` is a
+  // flag the panel sets, but a prompt_id is an identifier ComfyUI MINTED, and server.py
+  // mints one only inside the `if valid[0]:` branch, after `prompt_queue.put(...)`. So
+  // an id present ⇒ work was accepted. #358 does not regress: a pure top-level rejection
+  // is a 400 that mints nothing, leaving this list empty.
+  //
+  // A top-level error still wins, because the two claims then contradict each other and
+  // this module must not pick a side — it reports BOTH (the ids ride along on the result)
+  // and lets the orchestrator send the caller to the queue to settle it.
+  const acceptedIds = normalizeAcceptedIds(acceptedPromptIds);
+  if (acceptedIds.length && !hasTopError(topError)) return null;
+
   const result = { queued: false };
+  if (acceptedIds.length) {
+    result.prompt_id = acceptedIds[0];
+    if (acceptedIds.length > 1) result.prompt_ids = [...acceptedIds];
+  }
   if (hasTopError(topError)) {
     result.error = formatTopError(topError);
     const type = typeof topError === "object" && topError ? topError.type : null;
@@ -125,6 +160,17 @@ function hasTopError(err) {
   return Boolean(err);
 }
 
+/** Accepted prompt ids as a deduped, order-preserving list of non-blank strings. */
+function normalizeAcceptedIds(ids) {
+  const out = [];
+  for (const raw of Array.isArray(ids) ? ids : []) {
+    if (raw == null) continue; // but 0 is a real id — only null/undefined are dropped
+    const id = String(raw).trim();
+    if (id !== "" && !out.includes(id)) out.push(id);
+  }
+  return out;
+}
+
 function normalizeNodeErrors(ne) {
   if (ne && typeof ne === "object" && !Array.isArray(ne) && Object.keys(ne).length) return ne;
   return null;
@@ -137,12 +183,26 @@ function normalizeNodeErrors(ne) {
  * both depend on this. `prompt_id` is the first accepted id; `prompt_ids` is only
  * added for a batch that queued more than one.
  *
+ * #1504 — an accepted run may have DROPPED some outputs. ComfyUI reports those on the
+ * 200 body's `node_errors`, and they are reported here verbatim, on an otherwise normal
+ * accept. This is deliberately loud rather than silent: the failure it replaces claimed
+ * the whole run was refused, and staying quiet would be the opposite error — the caller
+ * would wait for a file that will never be written. The orchestrator renders it as the
+ * mcp#944 "[PARTIAL] … the remaining outputs ARE executing" disclosure, which until now
+ * was unreachable from the panel because the panel never sent a prompt_id alongside them.
+ *
  * @param {object} args
  * @param {number} args.batchCount
  * @param {(string|null)[]} [args.promptIds]  Accepted prompt_ids, in queue order.
  * @param {number|null} [args.ranToNode]      Present for a run-to-node partial run.
+ * @param {object|null} [args.droppedOutputs] `node_errors` from the ACCEPTED 200 reply.
  */
-export function buildQueueAcceptResult({ batchCount, promptIds = [], ranToNode = null } = {}) {
+export function buildQueueAcceptResult({
+  batchCount,
+  promptIds = [],
+  ranToNode = null,
+  droppedOutputs = null,
+} = {}) {
   // NORMALIZE to strings at this ingestion boundary (drop null/undefined) so the
   // reported prompt_id(s), and everything that later reconciles against them, are
   // string-vs-string — a numeric /prompt id can't slip through as a number (#370).
@@ -152,12 +212,14 @@ export function buildQueueAcceptResult({ batchCount, promptIds = [], ranToNode =
       (Array.isArray(promptIds) ? promptIds : []).filter((x) => x != null).map((x) => String(x)),
     ),
   ];
+  const dropped = normalizeNodeErrors(droppedOutputs);
   return {
     queued: true,
     batch_count: batchCount,
     ...(ids.length ? { prompt_id: ids[0] } : {}),
     ...(ids.length > 1 ? { prompt_ids: [...ids] } : {}),
     ...(ranToNode != null ? { ran_to_node: ranToNode } : {}),
+    ...(dropped ? { node_errors: dropped } : {}),
   };
 }
 

--- a/web/js/lib/run-scope-guard.js
+++ b/web/js/lib/run-scope-guard.js
@@ -1119,10 +1119,31 @@ export function scopeDispatchError({ toNodeId, detail, verified, batch }) {
   );
 }
 
-// Capture the #358 top-level rejection / #370 prompt_id out of a /prompt
-// response that is ATTRIBUTED to this run. prompt_id is normalized to a string
-// at capture (0 and "0" are the same run).
-async function captureRunResponse(res, { onRejection, onPromptId }) {
+/**
+ * #1504 — node_errors on an ACCEPTED (200) reply are dropped outputs, not a refusal.
+ *
+ * ComfyUI's `validate_prompt` validates each output independently and keeps the ones
+ * that pass (`good_outputs`). When at least one survives, server.py takes the
+ * `if valid[0]:` branch — it mints a prompt id, calls `prompt_queue.put(...)`, and
+ * answers
+ *
+ *     web.json_response({"prompt_id": …, "number": …, "node_errors": valid[3]})
+ *
+ * with status **200**. So an accepted, already-executing prompt can carry a populated
+ * `node_errors` map naming the outputs it dropped ("Output will be ignored").
+ *
+ * That map is ALSO what the frontend stores: `app.queuePrompt` calls
+ * `recordNodeErrors(res.node_errors)` on the resolved (200) response, so
+ * `app.lastNodeErrors` is populated for a run that is on the GPU right now. Reading
+ * only that channel is what made graph_run answer "ComfyUI refused to queue the
+ * workflow" for six VAEDecode nodes whose branches were bypassed — while the render
+ * they belonged to was running, and every following graph read came back QUEUE BUSY.
+ *
+ * The 200 body is the authoritative, non-stale source for both halves: it says a
+ * prompt id was minted AND which outputs were dropped, in one structured receipt.
+ * `lastNodeErrors` cannot distinguish those two cases at all.
+ */
+async function captureRunResponse(res, { onRejection, onPromptId, onAcceptedNodeErrors }) {
   try {
     const body = await res.clone().json();
     if (res.status !== 200) {
@@ -1131,9 +1152,18 @@ async function captureRunResponse(res, { onRejection, onPromptId }) {
       }
     } else if (body && body.prompt_id != null) {
       onPromptId?.(String(body.prompt_id));
+      reportAcceptedNodeErrors(body, onAcceptedNodeErrors);
     }
   } catch {
     // non-JSON body / clone unsupported — the caller falls back to lastNodeErrors.
+  }
+}
+
+/** Forward a 200 reply's non-empty `node_errors` (the #1504 partial-validation drops). */
+function reportAcceptedNodeErrors(body, onAcceptedNodeErrors) {
+  const ne = body?.node_errors;
+  if (ne && typeof ne === "object" && !Array.isArray(ne) && Object.keys(ne).length) {
+    onAcceptedNodeErrors?.(ne);
   }
 }
 
@@ -1143,13 +1173,14 @@ async function captureRunResponse(res, { onRejection, onPromptId }) {
 // captured through the established #358 channel); "malformed" for anything
 // else (2xx without a prompt_id, non-200 without a rejection body, unparseable
 // body, missing response). Only "accepted" may ever count as verified.
-async function classifyRunResponse(res, { onRejection, onPromptId }) {
+async function classifyRunResponse(res, { onRejection, onPromptId, onAcceptedNodeErrors }) {
   if (!res) return "malformed";
   try {
     const body = await res.clone().json();
     if (res.status === 200) {
       if (body && body.prompt_id != null) {
         onPromptId?.(String(body.prompt_id));
+        reportAcceptedNodeErrors(body, onAcceptedNodeErrors); // #1504
         return "accepted";
       }
       return "malformed";
@@ -1172,11 +1203,16 @@ async function classifyRunResponse(res, { onRejection, onPromptId }) {
  * that error exists; and EVERY accepted prompt_id is captured for the recovery
  * ledger. Installed only for the duration of the queuePrompt call.
  */
-export function createRunFetchInterceptor({ origFetchApi, onRejection = null, onPromptId = null } = {}) {
+export function createRunFetchInterceptor({
+  origFetchApi,
+  onRejection = null,
+  onPromptId = null,
+  onAcceptedNodeErrors = null,
+} = {}) {
   return async function runFetchInterceptor(route, options) {
     const res = await origFetchApi(route, options);
     if (isPromptPost(route, options) && res) {
-      await captureRunResponse(res, { onRejection, onPromptId });
+      await captureRunResponse(res, { onRejection, onPromptId, onAcceptedNodeErrors });
     }
     return res;
   };
@@ -1224,6 +1260,7 @@ export function createScopedRunGuard({
   repairScope = false,
   onRejection = null,
   onPromptId = null,
+  onAcceptedNodeErrors = null,
   onScopeDropped = null,
 } = {}) {
   const expected = (execIds ?? []).map(String);
@@ -1391,7 +1428,11 @@ export function createScopedRunGuard({
         notify();
         throw err; // the frontend sees exactly the failure it would have seen
       }
-      const verdict = await classifyRunResponse(res, { onRejection, onPromptId });
+      const verdict = await classifyRunResponse(res, {
+        onRejection,
+        onPromptId,
+        onAcceptedNodeErrors,
+      });
       // The request DID leave, so the reservation is now settled into a
       // definite outcome. A malformed response keeps the slot consumed on
       // purpose: the post reached ComfyUI and MAY have queued, and re-forwarding
@@ -1586,6 +1627,7 @@ export async function dispatchScopedRun({
   queueMark = null,
   onRejection = null,
   onPromptId = null,
+  onAcceptedNodeErrors = null,
 } = {}) {
   const mark = queueMark ?? newScopedQueueMark();
   // CHAIN COMPOSITION (codex gate r8). Both the entry-time capture below and
@@ -1709,6 +1751,7 @@ export async function dispatchScopedRun({
       repairScope: repair,
       onRejection,
       onPromptId,
+      onAcceptedNodeErrors,
     });
     apiTarget.fetchApi = guard;
     try {


### PR DESCRIPTION
## What was wrong

`panel_run` answered

```
ComfyUI refused to queue the workflow
- VAEDecode (node 36): Required input is missing (samples)   … ×6
```

while the ComfyUI queue showed `running: 1` for prompt `b01ba287-…` with `pending: 0`.
Every graph read and edit that followed came back `QUEUE BUSY` — blocked by the very
render the caller had just been told did not exist.

## Root cause

Both statements came out of **one** reply.

`execution.validate_prompt` validates each output independently, collects `good_outputs`,
logs `"Output will be ignored"` for the rest, and returns `True` whenever at least one
output survives. `server.py` then takes the `if valid[0]:` branch — `prompt_queue.put(...)`,
then

```python
response = {"prompt_id": prompt_id, "number": number, "node_errors": valid[3]}
return web.json_response(response)     # status 200
```

The reported workflow had several output branches with some disabled through node modes,
so its bypassed `VAEDecode` branches were exactly the outputs ComfyUI dropped from a prompt
it had queued and started.

The panel could not tell the two cases apart, because the frontend funnels both channels
into one field — `app.queuePrompt` calls `recordNodeErrors(res.node_errors)` on the
**resolved (200)** response too, so `app.lastNodeErrors` is populated for a prompt that is
on the GPU right now. Reading only that field, `summarizePromptRejection` returned
`{queued:false, node_errors}` and dropped the prompt id on the floor.

**That last part is why the existing repair never fired.** The orchestrator has handled this
exact shape since mcp v0.50.2 (mcp#944): `prompt_id` + `node_errors` with no top-level
`error` is treated as an accepted partial run and rendered as a loud
`[PARTIAL] ComfyUI ACCEPTED this prompt and is running it, but it dropped N output(s)` note.
It keys on the prompt id — which the panel never sent alongside the errors, so the whole
mechanism was unreachable from here and the reply fell through to the plain refusal.

## The fix

Read the 200 body, which carries both facts as one structured receipt:

- **capture** — a 200 reply's non-empty `node_errors` is forwarded as ACCEPTED drops, on
  both dispatch paths (the unscoped interceptor and the scoped run-to-node guard). This has
  to come from the body, not `lastNodeErrors`, which cannot distinguish a refusal from an
  accepted partial run at all.
- **verdict** — `summarizePromptRejection` takes the prompt ids ComfyUI **minted**. `queued`
  is a flag the panel sets; a prompt id is an identifier ComfyUI issues only after
  `prompt_queue.put(...)`. An id present means work was accepted, so the per-node errors
  beside it name dropped outputs, not a refusal.
- **disclosure** — the accept result reports those dropped outputs verbatim, so the caller
  is told which outputs will produce no file. Silence would be the opposite error: it would
  leave them waiting on a render that was never going to write them.

### What does not regress

- **#358** (a top-level rejection swallowed by `app.queuePrompt`) is a 400, which mints
  nothing — the id list is empty and the verdict is untouched.
- A top-level error arriving **with** a minted id stays a refusal — the two claims
  contradict each other and this is not the place to pick a side — but the result now
  carries the id, which the orchestrator turns into its
  `[UNCERTAIN] … a render may already be in flight, do NOT re-run` answer instead of a flat
  "refused" that invites a duplicate render.

## Verification

**Verified by mutation, not by a green suite.** Eight mutations, each applied to the
working tree and reverted from an in-memory backup (never `git checkout`):

| mutation | result |
| --- | --- |
| verdict rule: a minted id no longer outranks `node_errors` | KILLED |
| accept result: dropped outputs no longer reported | KILLED |
| capture: unscoped 200 `node_errors` never forwarded | KILLED |
| capture: scoped 200 `node_errors` never forwarded | KILLED |
| wiring: verdict no longer receives the minted ids | KILLED |
| wiring: accept no longer receives the dropped outputs | KILLED |
| wiring: unscoped path no longer captures accepted `node_errors` | KILLED |
| wiring: scoped path no longer captures accepted `node_errors` | KILLED |

Because a one-line wiring change is invisible to a helper-level test, the call site is
pinned too: the WIRING test asserts `onAcceptedNodeErrors: captureAcceptedNodeErrors`
appears on **both** dispatch paths and that `acceptedPromptIds` / `droppedOutputs` reach
the verdict and the accept result. Removing any one of them turns it red while every
helper-level test stays green.

Upstream behaviour was read out of the installed ComfyUI (`execution.py`, `server.py`) and
the installed frontend bundle (`comfyui_frontend_package` 1.49.6, `recordNodeErrors` on the
resolved response), not assumed.

`npm run test:unit`: 5966 tests, 5965 pass. The single failure is the known
`manager-install` wall-clock flake (#671) — it passes 125/125 when that file is run alone,
and this change touches nothing it exercises. `check-panel-scope` reports OK (every name in
the monolith resolves).

Closes #1504
