### PR TITLE
fix(1523): panel_add_node accepts a loaded subgraph UUID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project are documented here. This project adheres to
 ## [Unreleased]
 
 ### Fixed
+- `panel_add_node` of a subgraph UUID already loaded in the live workflow no longer rejects it as an unknown backend node or names an unrelated failed pack (#1523)
 - a run ComfyUI accepted while dropping some outputs is reported as queued, with the dropped outputs named, instead of as a refusal (#1504)
 - `panel_list_nodes` with `search` (or `query`) filters the installed-pack list instead of returning every pack (#1496)
 

--- a/browser_tests/unit/add-node-loaded-subgraph.test.mjs
+++ b/browser_tests/unit/add-node-loaded-subgraph.test.mjs
@@ -1,0 +1,272 @@
+// panel#1523 — `panel_add_node` of a subgraph UUID already loaded in the live
+// workflow rejected it as an unknown backend node and appended an unrelated
+// `comfyui-reactor-node FAILED TO IMPORT`.
+//
+// Subgraph types are never in /object_info (registerSubgraphNodeDef synthesizes
+// the class from the workflow's definitions). The add-node guard's backend
+// oracle therefore cannot authorize them, and the missing-type diagnostic
+// named whichever pack happened to fail import.
+//
+// THE HARNESS runs the SHIPPED `graph_add_node` body, extracted from the panel
+// source — the same technique as add-node-schema-auto-refresh.test.mjs. A
+// helper-only test could not have caught a wiring miss of `getRootGraph`.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { withTimeout } from "../../web/js/lib/bounded-step.js";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import {
+  applyCurrentDefWidgetValues,
+  driftedRequiredInputNames,
+  missingRequiredWidgetMaterializations,
+  registeredSocketTypes,
+  unavailableRequiredWidgetMessage,
+  unavailableRequiredWidgetReport,
+} from "../../web/js/lib/node-widget-materialization.js";
+import {
+  assertAddNodeResolvableRefreshing,
+  isRegisteredNodeType,
+  subgraphUuidAddRefusal,
+} from "../../web/js/lib/node-resolve.js";
+import { fetchSingleNodeDef } from "../../web/js/lib/single-node-def.js";
+import {
+  describeUnmaterializedRequiredWidgets,
+  snapshotBackendDef,
+} from "../../web/js/lib/add-node-widget-guard.js";
+
+const panelPath = fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url));
+const panelSrc = readFileSync(panelPath, "utf8");
+
+const addNodeMatch = panelSrc.match(
+  /\n {2}async graph_add_node\(\{ class_type, pos, title \}\) \{[\s\S]*?\n {2}\},/,
+);
+assert.ok(addNodeMatch, "could not locate graph_add_node in panel source");
+
+const awaitWidgetsMatch = panelSrc.match(
+  /\nasync function awaitRequiredCustomWidgetRegistration\([\s\S]*?\n\}/,
+);
+assert.ok(awaitWidgetsMatch, "could not locate awaitRequiredCustomWidgetRegistration");
+
+const placementMatch = panelSrc.match(/\nfunction placementFor\(graph, pos\) \{[\s\S]*?\n\}/);
+assert.ok(placementMatch, "could not locate placementFor");
+
+const boundedMatch = panelSrc.match(/\nasync function boundedGetNodeDefs\([\s\S]*?\n\}/);
+assert.ok(boundedMatch, "could not locate boundedGetNodeDefs in panel source");
+
+import {
+  NODE_DEFS_FETCH_TIMEOUT_MS,
+  NODE_DEFS_NO_ANSWER,
+  WIDEN_SOCKET_PROOF_TIMEOUT_MS,
+  addNodeCommandBudgetDeps,
+  monotonicNow,
+} from "./_panel-constants.mjs";
+
+/** The reporter's official core Image Segmentation (SAM3) subgraph type. */
+const SAM3_UUID = "6e7ab3ea-96aa-470f-9b94-3d9d0e01f481";
+
+function backendObjectInfo() {
+  return {
+    KSampler: {
+      name: "KSampler",
+      input: { required: { seed: ["INT", { default: 0 }] } },
+      output: ["LATENT"],
+    },
+  };
+}
+
+function uuidSubgraphCtor(uuid) {
+  const ctor = function ComfySubgraphNode() {};
+  ctor.nodeData = { input: { required: {} }, name: uuid };
+  ctor.comfyClass = uuid;
+  return ctor;
+}
+
+function makeComfy({ loadSubgraph = true, registerSubgraph = true } = {}) {
+  const widgets = {};
+  const registry = {};
+  let nextId = 1;
+
+  const ctor = uuidSubgraphCtor(SAM3_UUID);
+  if (registerSubgraph) registry[SAM3_UUID] = ctor;
+
+  const LG = {
+    registered_node_types: registry,
+    createNode(type) {
+      const cls = registry[type];
+      if (!cls) return null;
+      const node = {
+        id: nextId++,
+        type,
+        constructor: cls,
+        pos: [0, 0],
+        size: [210, 100],
+        widgets: [],
+        inputs: [],
+        outputs: [],
+        addWidget(kind, name, value, callback, options) {
+          const widget = { type: kind, name, value, callback, options: options ?? {} };
+          node.widgets.push(widget);
+          return widget;
+        },
+      };
+      for (const [name, spec] of Object.entries(cls.nodeData?.input?.required ?? {})) {
+        node.inputs.push({ name, type: Array.isArray(spec) ? spec[0] : spec });
+      }
+      return node;
+    },
+  };
+
+  const app = {
+    widgets,
+    async registerNodesFromDefs(defs) {
+      for (const [type, nodeData] of Object.entries(defs ?? {})) {
+        const cls = function ComfyNode() {};
+        cls.nodeData = nodeData;
+        cls.comfyClass = type;
+        registry[type] = cls;
+      }
+    },
+  };
+
+  const existing = {
+    id: 1,
+    type: SAM3_UUID,
+    constructor: ctor,
+    subgraph: { id: SAM3_UUID, _nodes: [] },
+  };
+  const graph = {
+    _nodes: loadSubgraph ? [existing] : [],
+    subgraphs: loadSubgraph ? new Map([[SAM3_UUID, existing.subgraph]]) : new Map(),
+    add(node) {
+      graph._nodes.push(node);
+    },
+    beforeChange() {},
+    afterChange() {},
+    setDirtyCanvas() {},
+  };
+
+  return { app, LG, graph, registry };
+}
+
+function realGraphAddNode(comfy, overrides = {}) {
+  const { app, LG, graph } = comfy;
+  const context = { app, LG, graph, rootGraph: graph, workflow: { uuid: "wf" } };
+
+  const api = {
+    async getNodeDefs() {
+      return backendObjectInfo();
+    },
+    async fetchApi(route) {
+      const cls = decodeURIComponent(String(route).replace("/object_info/", ""));
+      const all = backendObjectInfo();
+      const body = Object.prototype.hasOwnProperty.call(all, cls) ? { [cls]: all[cls] } : {};
+      return { status: 200, json: async () => body };
+    },
+  };
+
+  const deps = {
+    captureGraphMutationContext: () => context,
+    revalidateGraphMutationContext: () => context,
+    getGraphCtx: () => context,
+    awaitObjectInfoHistorySeed: async () => {},
+    recordObjectInfoTypes: (defs) => defs,
+    objectInfoHistory: { wasTypeEverDefined: () => false },
+    objectInfoSnapshot: { record: () => true, clear: () => {} },
+    backendReconnectEpoch: 0,
+    readPackImportFailures: async () => ["comfyui-reactor-node"],
+    api,
+    refreshComfyNodeDefs: async () => ({ refreshed: true }),
+    summarizeNode: (node) => ({ id: node.id, type: node.type }),
+    assertAddNodeResolvableRefreshing,
+    driftedRequiredInputNames,
+    registeredSocketTypes,
+    missingRequiredWidgetMaterializations,
+    applyCurrentDefWidgetValues,
+    unavailableRequiredWidgetReport,
+    unavailableRequiredWidgetMessage,
+    snapshotBackendDef,
+    isRegisteredNodeType,
+    fetchSingleNodeDef,
+    describeUnmaterializedRequiredWidgets,
+    NODE_DEFS_NO_ANSWER,
+    WIDEN_SOCKET_PROOF_TIMEOUT_MS,
+    monotonicNow,
+    NODE_DEFS_FETCH_TIMEOUT_MS,
+    withTimeout,
+    ...addNodeCommandBudgetDeps(),
+    ...overrides,
+  };
+
+  if (!("boundedGetNodeDefs" in deps)) {
+    const build = new Function(
+      "api",
+      "withTimeout",
+      "NODE_DEFS_NO_ANSWER",
+      "NODE_DEFS_FETCH_TIMEOUT_MS",
+      `${boundedMatch[0]}
+       return boundedGetNodeDefs;`,
+    );
+    deps.boundedGetNodeDefs = (timeoutMs) =>
+      build(deps.api, withTimeout, NODE_DEFS_NO_ANSWER, NODE_DEFS_FETCH_TIMEOUT_MS)(timeoutMs);
+  }
+
+  const names = Object.keys(deps);
+  const factory = new Function(
+    ...names,
+    `${awaitWidgetsMatch[0]}
+     ${placementMatch[0]}
+     const CUSTOM_WIDGET_REGISTRATION_TIMEOUT_MS = 200;
+     const CUSTOM_WIDGET_REGISTRATION_POLL_MS = 5;
+     const executors = {${addNodeMatch[0]}};
+     return executors.graph_add_node;`,
+  );
+  return { graph_add_node: factory(...names.map((n) => deps[n])), graph };
+}
+
+test("#1523 shipped graph_add_node: a loaded SAM3 subgraph UUID is added, not refused as a missing pack", async () => {
+  const comfy = makeComfy({ loadSubgraph: true, registerSubgraph: true });
+  const { graph_add_node, graph } = realGraphAddNode(comfy);
+  const before = graph._nodes.length;
+
+  const res = await graph_add_node({ class_type: SAM3_UUID });
+
+  assert.equal(res.added.type, SAM3_UUID);
+  assert.equal(graph._nodes.length, before + 1, "a new instance lands on the live graph");
+  assert.equal(graph._nodes[graph._nodes.length - 1].type, SAM3_UUID);
+});
+
+test("#1523 shipped graph_add_node: an unloaded subgraph UUID is refused without naming ReActor", async () => {
+  const comfy = makeComfy({ loadSubgraph: false, registerSubgraph: false });
+  const { graph_add_node } = realGraphAddNode(comfy);
+
+  const err = await graph_add_node({ class_type: SAM3_UUID }).then(
+    () => null,
+    (e) => e,
+  );
+  assert.ok(err, "an unloaded UUID must still be refused");
+  assert.equal(
+    err.message,
+    subgraphUuidAddRefusal(SAM3_UUID, { loaded: false, registered: false }),
+  );
+  assert.doesNotMatch(err.message, /comfyui-reactor-node/);
+  assert.doesNotMatch(err.message, /FAILED TO IMPORT/);
+  assert.doesNotMatch(err.message, /Unknown node type/);
+});
+
+test("#1523 shipped graph_add_node: loaded but unregistered UUID is refused with copy-instance advice", async () => {
+  const comfy = makeComfy({ loadSubgraph: true, registerSubgraph: false });
+  const { graph_add_node } = realGraphAddNode(comfy);
+
+  const err = await graph_add_node({ class_type: SAM3_UUID }).then(
+    () => null,
+    (e) => e,
+  );
+  assert.ok(err, "createNode would mint a placeholder — must refuse");
+  assert.equal(
+    err.message,
+    subgraphUuidAddRefusal(SAM3_UUID, { loaded: true, registered: false }),
+  );
+  assert.doesNotMatch(err.message, /comfyui-reactor-node/);
+});

--- a/browser_tests/unit/node-resolve.test.mjs
+++ b/browser_tests/unit/node-resolve.test.mjs
@@ -31,6 +31,9 @@ import {
   HISTORY_UNSEEDED,
   HISTORY_PENDING,
   backendHistoryVerdict,
+  isSubgraphUuidType,
+  subgraphTypeIsLoaded,
+  subgraphUuidAddRefusal,
 } from "../../web/js/lib/node-resolve.js";
 import { createObjectInfoHistory } from "../../web/js/lib/object-info-history.js";
 // The PRODUCTION graph_set_widget handler body — the executor and these tests
@@ -2545,4 +2548,183 @@ test("#1126: the unreadable fallback REFUSES a nested promotion rather than writ
   assert.equal(concreteWidget.value, "", "the concrete widget is untouched");
   assert.equal(midWidget.value, "", "the intermediate projection is untouched");
   assert.equal(outerWidget.value, "", "the outer rail is untouched");
+});
+
+// ---- #1523: panel_add_node of a loaded subgraph UUID is not an unknown backend
+//      node, and must never name an unrelated failed pack. ----------------------
+
+const SAM3_UUID = "6e7ab3ea-96aa-470f-9b94-3d9d0e01f481";
+
+function uuidSubgraphCtor(uuid) {
+  const ctor = function ComfySubgraphNode() {};
+  ctor.nodeData = { input: { required: {} }, name: uuid };
+  ctor.comfyClass = uuid;
+  return ctor;
+}
+
+function addOptsForSubgraph(reg, { rootGraph, readImportFailures } = {}) {
+  return {
+    getFreshObjectInfo: async () => objectInfo(),
+    refresh: async () => {},
+    wasTypeEverDefined: () => false,
+    getRootGraph: () => rootGraph,
+    readImportFailures:
+      readImportFailures ?? (async () => ["comfyui-reactor-node"]),
+  };
+}
+
+test("#1523 isSubgraphUuidType: RFC-4122 only", () => {
+  assert.equal(isSubgraphUuidType(SAM3_UUID), true);
+  assert.equal(isSubgraphUuidType("KSampler"), false);
+  assert.equal(isSubgraphUuidType("SubgraphBlueprint.Image Segmentation (SAM3)"), false);
+  assert.equal(isSubgraphUuidType(""), false);
+  assert.equal(isSubgraphUuidType(null), false);
+});
+
+test("#1523 subgraphTypeIsLoaded: registry Map, nested instance, fail-closed", () => {
+  const sub = { id: SAM3_UUID, _nodes: [] };
+  const root = { subgraphs: new Map([[SAM3_UUID, sub]]), _nodes: [] };
+  assert.equal(subgraphTypeIsLoaded(root, SAM3_UUID), true);
+
+  const nested = {
+    _nodes: [{ type: SAM3_UUID, subgraph: { id: SAM3_UUID, _nodes: [] } }],
+  };
+  assert.equal(subgraphTypeIsLoaded(nested, SAM3_UUID), true);
+
+  assert.equal(subgraphTypeIsLoaded({ _nodes: [] }, SAM3_UUID), false);
+  assert.equal(subgraphTypeIsLoaded(null, SAM3_UUID), false);
+  assert.equal(subgraphTypeIsLoaded(root, "KSampler"), false);
+});
+
+test("#1523 add_node: loaded + registered SAM3 UUID is ADDABLE on a healthy backend that never lists it", async () => {
+  const reg = loadedRegistry();
+  reg[SAM3_UUID] = uuidSubgraphCtor(SAM3_UUID);
+  const rootGraph = {
+    subgraphs: new Map([[SAM3_UUID, { id: SAM3_UUID, _nodes: [] }]]),
+    _nodes: [{ id: 1, type: SAM3_UUID }],
+  };
+  await assert.doesNotReject(() =>
+    assertAddNodeResolvableRefreshing(() => reg, SAM3_UUID, addOptsForSubgraph(reg, { rootGraph })),
+  );
+});
+
+test("#1523 add_node: the same UUID without a live definition is refused as a subgraph, not a missing pack", async () => {
+  const reg = loadedRegistry();
+  const err = await assertAddNodeResolvableRefreshing(
+    () => reg,
+    SAM3_UUID,
+    addOptsForSubgraph(reg, { rootGraph: { _nodes: [] } }),
+  ).then(
+    () => null,
+    (e) => e,
+  );
+  assert.ok(err, "an unloaded subgraph UUID must still be refused");
+  assert.equal(
+    err.message,
+    subgraphUuidAddRefusal(SAM3_UUID, { loaded: false, registered: false }),
+  );
+  assert.doesNotMatch(err.message, /comfyui-reactor-node/);
+  assert.doesNotMatch(err.message, /FAILED TO IMPORT/);
+  assert.doesNotMatch(err.message, /Unknown node type/);
+  assert.doesNotMatch(err.message, /not installed, its pack was removed/);
+});
+
+test("#1523 add_node: loaded but UNREGISTERED UUID is refused with copy-instance advice, never a pack note", async () => {
+  const reg = loadedRegistry(); // SAM3 class not registered — createNode would mint a placeholder
+  const rootGraph = {
+    subgraphs: new Map([[SAM3_UUID, { id: SAM3_UUID, _nodes: [] }]]),
+    _nodes: [{ id: 1, type: SAM3_UUID }],
+  };
+  const err = await assertAddNodeResolvableRefreshing(
+    () => reg,
+    SAM3_UUID,
+    addOptsForSubgraph(reg, { rootGraph }),
+  ).then(
+    () => null,
+    (e) => e,
+  );
+  assert.ok(err, "an unregistered class must still be refused");
+  assert.equal(
+    err.message,
+    subgraphUuidAddRefusal(SAM3_UUID, { loaded: true, registered: false }),
+  );
+  assert.doesNotMatch(err.message, /comfyui-reactor-node/);
+  assert.doesNotMatch(err.message, /FAILED TO IMPORT/);
+});
+
+test("#1523 add_node: the exemption requires the ever-seen oracle, like the frontend-only one", async () => {
+  const reg = loadedRegistry();
+  reg[SAM3_UUID] = uuidSubgraphCtor(SAM3_UUID);
+  const rootGraph = {
+    subgraphs: new Map([[SAM3_UUID, { id: SAM3_UUID, _nodes: [] }]]),
+    _nodes: [],
+  };
+  await assert.rejects(
+    () =>
+      assertAddNodeResolvableRefreshing(() => reg, SAM3_UUID, {
+        getFreshObjectInfo: async () => objectInfo(),
+        getRootGraph: () => rootGraph,
+        // wasTypeEverDefined deliberately omitted
+      }),
+    (err) => {
+      assert.equal(
+        err.message,
+        subgraphUuidAddRefusal(SAM3_UUID, { loaded: true, registered: true }),
+      );
+      return true;
+    },
+  );
+});
+
+test("#1523 add_node: an EVER-SEEN (removed) UUID still fails closed — the trust root is not bypassed", async () => {
+  const reg = loadedRegistry();
+  reg[SAM3_UUID] = uuidSubgraphCtor(SAM3_UUID);
+  const rootGraph = {
+    subgraphs: new Map([[SAM3_UUID, { id: SAM3_UUID, _nodes: [] }]]),
+    _nodes: [],
+  };
+  await assert.rejects(
+    () =>
+      assertAddNodeResolvableRefreshing(() => reg, SAM3_UUID, {
+        getFreshObjectInfo: async () => objectInfo(),
+        wasTypeEverDefined: (t) => t === SAM3_UUID,
+        getRootGraph: () => rootGraph,
+      }),
+    /defined this node type earlier this session|removed/i,
+  );
+});
+
+test("#1523 add_node: isLoadedSubgraphType override is the positive proof, even without a graph", async () => {
+  const reg = loadedRegistry();
+  reg[SAM3_UUID] = uuidSubgraphCtor(SAM3_UUID);
+  await assert.doesNotReject(() =>
+    assertAddNodeResolvableRefreshing(() => reg, SAM3_UUID, {
+      getFreshObjectInfo: async () => objectInfo(),
+      wasTypeEverDefined: () => false,
+      isLoadedSubgraphType: (t) => t === SAM3_UUID,
+      readImportFailures: async () => ["comfyui-reactor-node"],
+    }),
+  );
+});
+
+test("#1523 add_node: a throwing isLoadedSubgraphType fails closed rather than authorizing", async () => {
+  const reg = loadedRegistry();
+  reg[SAM3_UUID] = uuidSubgraphCtor(SAM3_UUID);
+  const err = await assertAddNodeResolvableRefreshing(() => reg, SAM3_UUID, {
+    getFreshObjectInfo: async () => objectInfo(),
+    wasTypeEverDefined: () => false,
+    isLoadedSubgraphType: () => {
+      throw new Error("graph unreadable");
+    },
+    readImportFailures: async () => ["comfyui-reactor-node"],
+  }).then(
+    () => null,
+    (e) => e,
+  );
+  assert.equal(
+    err.message,
+    subgraphUuidAddRefusal(SAM3_UUID, { loaded: false, registered: true }),
+  );
+  assert.doesNotMatch(err.message, /graph unreadable/);
+  assert.doesNotMatch(err.message, /comfyui-reactor-node/);
 });

--- a/browser_tests/unit/pack-import-failures.test.mjs
+++ b/browser_tests/unit/pack-import-failures.test.mjs
@@ -328,6 +328,41 @@ test("#1447 importFailureNote itself drops a live pack", () => {
   assert.equal(note, "");
 });
 
+test("#1523 a subgraph UUID never gets a pack-import note — no pack can own it", () => {
+  // The reporter's type. ReActor failed to import on that canvas; naming it as
+  // the reason a loaded SAM3 subgraph could not be added is the whole issue.
+  const note = importFailureNote(["comfyui-reactor-node"], {
+    forType: "6e7ab3ea-96aa-470f-9b94-3d9d0e01f481",
+  });
+  assert.equal(note, "");
+});
+
+test("#1523 panel_add_node of a subgraph UUID does not name an unrelated failed pack", async () => {
+  const { assertAddNodeResolvableRefreshing, subgraphUuidAddRefusal } = await import(
+    "../../web/js/lib/node-resolve.js"
+  );
+  const uuid = "6e7ab3ea-96aa-470f-9b94-3d9d0e01f481";
+  const err = await assertAddNodeResolvableRefreshing({}, uuid, {
+    getFreshObjectInfo: async () => ({
+      KSampler: { python_module: "nodes" },
+    }),
+    wasTypeEverDefined: () => false,
+    readImportFailures: async () => ["comfyui-reactor-node"],
+  }).then(
+    () => null,
+    (e) => e,
+  );
+  assert.ok(err, "an unloaded subgraph UUID must still be refused");
+  assert.equal(err.message, subgraphUuidAddRefusal(uuid, { loaded: false, registered: false }));
+  assert.doesNotMatch(err.message, /comfyui-reactor-node/);
+  assert.doesNotMatch(err.message, /FAILED TO IMPORT/);
+});
+
+test("#1523 WIRING: the panel supplies the live root graph to the add-node resolver", () => {
+  const src = readFileSync(PANEL_JS, "utf8");
+  assert.match(src, /getRootGraph: \(\) => capturedContext\?\.rootGraph \?\? capturedContext\?\.graph/);
+});
+
 test("#1180: a hanging log read cannot outlive the refusal it is explaining", async () => {
   // readComfyLogText runs while EXPLAINING a refusal, against the same server whose
   // half-open connection is the reason the refusal is being written. Its catch handles a

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -13022,6 +13022,11 @@ const GRAPH_TOOL_EXECUTORS = {
       // add never pays for it. A pack that failed to import looks exactly like a
       // pack that is not installed, and the refusal used to name only the latter.
       readImportFailures: () => readPackImportFailures(api),
+      // #1523 — subgraph UUIDs are never in /object_info. The live workflow's
+      // subgraphs registry is the oracle that distinguishes a loaded SAM3
+      // subgraph from a missing backend pack. capturedContext is already in
+      // hand; no extra graph probe.
+      getRootGraph: () => capturedContext?.rootGraph ?? capturedContext?.graph,
       });
     try {
       await resolveAddNode();

--- a/web/js/lib/node-resolve.js
+++ b/web/js/lib/node-resolve.js
@@ -37,6 +37,103 @@ export function isRegisteredNodeType(registry, type) {
   return Object.prototype.hasOwnProperty.call(registry, type);
 }
 
+// RFC-4122 UUID — ComfyUI mints these as subgraph *type* ids. Backend class_types
+// are human-readable names; a well-formed UUID is therefore not a missing pack.
+export const SUBGRAPH_UUID_RE =
+  /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
+
+export function isSubgraphUuidType(type) {
+  return typeof type === "string" && SUBGRAPH_UUID_RE.test(type);
+}
+
+function subgraphRegistryHas(reg, type) {
+  if (!reg || type == null) return false;
+  try {
+    if (typeof reg.has === "function" && reg.has(type)) return true;
+    if (typeof reg.get === "function" && reg.get(type)) return true;
+    if (
+      typeof reg === "object" &&
+      !Array.isArray(reg) &&
+      Object.prototype.hasOwnProperty.call(reg, type)
+    ) {
+      return true;
+    }
+  } catch {
+    return false;
+  }
+  return false;
+}
+
+/**
+ * Positive proof the live workflow already holds this subgraph definition.
+ *
+ * Prefers the root graph's `subgraphs` registry (uuid → Subgraph Map on real
+ * LiteGraph builds), then walks nested instances. Fail closed on anything
+ * unreadable — a guess here would authorize LiteGraph to mint a placeholder.
+ */
+export function subgraphTypeIsLoaded(rootGraph, type) {
+  if (!isSubgraphUuidType(type) || !rootGraph || typeof rootGraph !== "object") return false;
+  try {
+    if (subgraphRegistryHas(rootGraph.subgraphs, type)) return true;
+    const seen = new WeakSet();
+    const walk = (graph) => {
+      if (!graph || typeof graph !== "object" || seen.has(graph)) return false;
+      seen.add(graph);
+      if (graph.id != null && String(graph.id) === type) return true;
+      if (subgraphRegistryHas(graph.subgraphs, type)) return true;
+      for (const node of graph._nodes ?? graph.nodes ?? []) {
+        if (!node || typeof node !== "object") continue;
+        if (typeof node.type === "string" && node.type === type) return true;
+        const sub = node.subgraph;
+        if (sub && (String(sub.id) === type || walk(sub))) return true;
+      }
+      return false;
+    };
+    return walk(rootGraph);
+  } catch {
+    return false;
+  }
+}
+
+function subgraphDefinitionLoaded(class_type, opts) {
+  if (!opts || typeof opts !== "object") return false;
+  if (typeof opts.isLoadedSubgraphType === "function") {
+    try {
+      return opts.isLoadedSubgraphType(class_type) === true;
+    } catch {
+      return false;
+    }
+  }
+  let root = null;
+  try {
+    root = typeof opts.getRootGraph === "function" ? opts.getRootGraph() : opts.getRootGraph;
+  } catch {
+    root = null;
+  }
+  return subgraphTypeIsLoaded(root, class_type);
+}
+
+/**
+ * The refusal `assertAddNodeResolvableRefreshing` throws for a UUID class_type
+ * that is not both loaded in the live workflow and registered in LiteGraph.
+ * Exported so tests drive this wording rather than restating it.
+ */
+export function subgraphUuidAddRefusal(class_type, { loaded = false, registered = false } = {}) {
+  const what =
+    loaded && !registered
+      ? `This workflow already has that subgraph definition loaded, but this tab has not ` +
+        `registered the class LiteGraph needs to construct a new instance — copy an existing ` +
+        `instance on the canvas rather than adding by type.`
+      : `Subgraph definitions live in the workflow (or the subgraph library), never in ` +
+        `/object_info. Copy an existing instance if one is on the canvas, or list library ` +
+        `blueprints with panel_list_subgraphs and add with panel_add_subgraph.`;
+  return (
+    `Cannot add "${class_type}": it is a subgraph type, not a ComfyUI backend node — ` +
+    `the backend never lists subgraph UUIDs in /object_info. ${what} ` +
+    `Refusing to add rather than let LiteGraph mint an unresolved placeholder node (#1523).`
+  );
+}
+
 /** True once ComfyUI's backend node definitions have been registered (i.e.
  *  /object_info loaded). False means the backend is unreachable / defs unloaded,
  *  so no Comfy class_type can be resolved and writes must fail rather than
@@ -448,6 +545,14 @@ export function assertAddNodeResolvable(registry, class_type) {
  *                        graph_set_widget. REQUIRED for the frontend-only exemption:
  *                        omit it and NOTHING absent from fresh /object_info is ever
  *                        exempted (fail closed, pre-#496 behaviour).
+ *   getRootGraph       : optional () => the live root graph. #1523 uses it (via
+ *                        subgraphTypeIsLoaded) to recognize a UUID subgraph already
+ *                        loaded in this workflow — those types are never in
+ *                        /object_info, so the backend oracle alone cannot authorize
+ *                        them. Omit it (and isLoadedSubgraphType) and a UUID is
+ *                        still diagnosed as a subgraph rather than a missing pack,
+ *                        but is not addable.
+ *   isLoadedSubgraphType : optional (type) => boolean override for that lookup.
  */
 export async function assertAddNodeResolvableRefreshing(getRegistry, class_type, opts = {}) {
   // #775 — `readImportFailures` is injected and awaited ONLY on the refusal path,
@@ -549,6 +654,27 @@ export async function assertAddNodeResolvableRefreshing(getRegistry, class_type,
             `let LiteGraph mint an unresolved placeholder node (#458).`,
         );
       }
+      // #1523 — a subgraph UUID is never in /object_info (registerSubgraphNodeDef
+      // synthesizes the class locally from the workflow's definitions). Treating
+      // that absence as "unknown backend node" then appending whichever pack
+      // failed to import (ReActor, on the reporter's canvas) is the misdiagnosis:
+      // no custom-node pack owns a UUID type. Loaded + registered ⇒ addable;
+      // anything else gets subgraph-specific copy/library advice, never a pack
+      // import note. The ever-seen gate above still refuses a type the backend
+      // actually reported earlier this session.
+      if (isSubgraphUuidType(class_type)) {
+        const loaded = subgraphDefinitionLoaded(class_type, opts);
+        const registered = isRegisteredNodeType(readRegistry(), class_type);
+        if (
+          typeof wasTypeEverDefined === "function" &&
+          verdict === "never-seen" &&
+          loaded &&
+          registered
+        ) {
+          return;
+        }
+        throw new Error(subgraphUuidAddRefusal(class_type, { loaded, registered }));
+      }
       // Not defined by the current backend (never installed, or its pack was
       // removed). Fail closed even if a stale registry entry survives (#458/P1-C).
       // #741: the pointer must be a tool that searches node CLASSES
@@ -564,6 +690,8 @@ export async function assertAddNodeResolvableRefreshing(getRegistry, class_type,
       // #1447 — pass the live map and the requested type so a pack that currently
       // provides nodes (ReActorFaceSwap just added) is not named as the reason a
       // different type (VideoToImages) is missing.
+      // #1523 — UUID types never reach here (handled above). Remaining failures
+      // still do not prove ownership of the requested type.
       let failedNote = "";
       if (typeof readImportFailures === "function") {
         try {

--- a/web/js/lib/pack-import-failures.js
+++ b/web/js/lib/pack-import-failures.js
@@ -34,6 +34,11 @@ import { readComfyLogText } from "./comfy-log.js";
  * `python_module` on /object_info is the proof it did. Drop those before naming
  * them. Remaining failures still do not prove ownership of the requested type,
  * so the note says so in the type's own words.
+ *
+ * #1523 — a subgraph UUID is never provided by a custom-node pack. Naming
+ * whatever pack happened to fail import (ReActor, on a canvas whose missing
+ * type was Image Segmentation (SAM3)) is the same misdiagnosis. No ownership
+ * mapping can link a pack to a UUID type, so the note stays off.
  */
 
 // Built from the code point, never written as a literal escape. The first
@@ -130,9 +135,22 @@ export function dropLivePackImportFailures(failed, liveDefs) {
  *
  * `opts.liveDefs` drops packs that currently provide types (#1447).
  * `opts.forType` names the missing class so a leftover failure is labelled
- * unrelated rather than read as its cause.
+ * unrelated rather than read as its cause. A subgraph UUID forType yields
+ * no note at all (#1523) — ownership mapping cannot link a pack to it.
  */
 export function importFailureNote(failed, opts = {}) {
+  const forType = opts && typeof opts === "object" && typeof opts.forType === "string"
+    ? opts.forType.trim()
+    : "";
+  // #1523 — a UUID class_type is a subgraph definition, not a pack-provided
+  // node. The note would name an unrelated failed pack with no possible
+  // ownership link.
+  if (
+    forType &&
+    /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/.test(forType)
+  ) {
+    return "";
+  }
   const relevant = dropLivePackImportFailures(
     failed,
     opts && typeof opts === "object" ? opts.liveDefs : undefined,
@@ -140,7 +158,6 @@ export function importFailureNote(failed, opts = {}) {
   if (relevant.length === 0) return "";
   const list = relevant.join(", ");
   const plural = relevant.length > 1;
-  const forType = opts && typeof opts.forType === "string" ? opts.forType.trim() : "";
   const ownership = forType
     ? ` This does not prove ${plural ? "they provide" : "it provides"} "${forType}" — ` +
       `the failure may be unrelated.`


### PR DESCRIPTION
Fixes #1523

`panel_add_node` of a subgraph UUID already loaded in the live workflow (the official core Image Segmentation (SAM3) type `6e7ab3ea-96aa-470f-9b94-3d9d0e01f481`) rejected it as an unknown backend node and appended an unrelated `comfyui-reactor-node FAILED TO IMPORT`.

Subgraph types are never in `/object_info` — `registerSubgraphNodeDef` synthesizes the class from the workflow's definitions — so the backend oracle cannot authorize them. The missing-type diagnostic then named whichever pack happened to fail import. No pack owns a UUID type.

## What the user now observes

- `panel_add_node` of a subgraph UUID **already loaded and registered** in this workflow adds another instance.
- An unloaded (or unregistered) subgraph UUID is refused as a **subgraph**, with copy-instance / `panel_add_subgraph` advice — not as a missing backend pack.
- That refusal never names an unrelated failed pack. Ownership mapping cannot link a pack to a UUID type.

The ever-seen gate still refuses a type the backend actually reported earlier this session.

Related: #512, #1447.
