### PR TITLE
fix(1519): a programmatic widget write announces itself to the node, not just to the widget

### DIFF
--- a/browser_tests/unit/node-widget-changed.test.mjs
+++ b/browser_tests/unit/node-widget-changed.test.mjs
@@ -534,6 +534,35 @@ test("#1519: a widget with NO options does not break the wrapper's optional read
   assert.deepEqual(seen, [{ min: undefined, widgetName: "text" }]);
 });
 
+test("#1519: a node whose `inputs` is a THROWING accessor still gets its hook fired", () => {
+  // The slot snapshot is instrumentation, not a precondition. A node that defines its
+  // slots as accessors is exactly the kind of node this route exists for, and letting
+  // the BEFORE snapshot abort the route would leave behind the stale slots it fixes —
+  // dressed up as a machinery failure.
+  let fired = 0;
+  const node = {
+    id: 32,
+    type: "N",
+    widgets: [{ name: "w", type: "number", value: 1 }],
+    outputs: [],
+    onWidgetChanged() {
+      fired++;
+    },
+  };
+  Object.defineProperty(node, "inputs", {
+    get() {
+      throw new Error("slots are computed");
+    },
+  });
+
+  const set = applyWidgetWrite(node, "w", 5, HOOKS);
+
+  assert.equal(fired, 1, "the hook must fire even when the slots cannot be read");
+  assert.equal(set.value, 5);
+  assert.equal(set.widget_changed_hook_failed, undefined);
+  assert.equal(set.widget_changed_slots, undefined, "an unreadable snapshot claims nothing either way");
+});
+
 // ---- the helper's own contract ---------------------------------------------
 
 test("#1519: fireNodeWidgetChanged never throws, whatever it is handed", () => {

--- a/browser_tests/unit/node-widget-changed.test.mjs
+++ b/browser_tests/unit/node-widget-changed.test.mjs
@@ -468,6 +468,72 @@ test("#1519: an INSTANCE-SCOPED promoted write announces on the WRAPPER, whose r
   assert.equal(widget, railWidget);
 });
 
+// ---- the hook EVERY node on a real page carries -----------------------------
+
+/**
+ * On a real page this hook is not exotic — the FRONTEND installs one on every node.
+ * `installNodeHooksRecursive` (comfyui-frontend-package 1.48.7, GraphView-*.js) runs
+ * over every node in the graph on attach and again from `onNodeAdded`, wrapping
+ * `onWidgetChanged` to clear widget-related validation errors:
+ *
+ *     e.onWidgetChanged = Mc(e.onWidgetChanged, function (t, n, r, i) {
+ *       if (!Z.rootGraph) return
+ *       let a = is(Z.rootGraph, e); if (!a) return
+ *       let o = { min: i.options?.min, max: i.options?.max }
+ *       let s = wa(Z.rootGraph, e, i)
+ *       s?.sourceExecutionId && ia().clearWidgetRelatedErrors(s.sourceExecutionId, …, n, o)
+ *       ia().clearWidgetRelatedErrors(a, t, i.name, n, o)
+ *     })
+ *
+ * So this change fires on ordinary writes to ordinary nodes, and the argument shape is
+ * load-bearing rather than cosmetic: the wrapper dereferences the FOURTH argument
+ * (`i.options`, `i.name`). Handing it `undefined` there would make every panel write on
+ * a real page throw and newly report `widget_changed_hook_failed`.
+ */
+test("#1519: the frontend's OWN installed hook receives what it dereferences — an ordinary write stays clean", () => {
+  const cleared = [];
+  const node = {
+    id: 30,
+    type: "KSampler",
+    widgets: [{ name: "steps", type: "INT", value: 20, options: { min: 1, max: 100 } }],
+    // The wrapper's body, transcribed from the bundle above.
+    onWidgetChanged(name, value, prevValue, widget) {
+      const bounds = { min: widget.options?.min, max: widget.options?.max };
+      cleared.push({ executionId: `node:${this.id}`, name, widgetName: widget.name, value, bounds });
+    },
+  };
+
+  const set = applyWidgetWrite(node, "steps", 30, HOOKS);
+
+  assert.equal(set.value, 30);
+  assert.equal(
+    set.widget_changed_hook_failed,
+    undefined,
+    "an ordinary write on an ordinary node must not newly carry a hook failure",
+  );
+  assert.equal(set.widget_changed_slots, undefined, "clearing an error moves no slots");
+  assert.deepEqual(cleared, [
+    { executionId: "node:30", name: "steps", widgetName: "steps", value: 30, bounds: { min: 1, max: 100 } },
+  ]);
+});
+
+test("#1519: a widget with NO options does not break the wrapper's optional reads", () => {
+  const seen = [];
+  const node = {
+    id: 31,
+    type: "N",
+    widgets: [{ name: "text", type: "customtext", value: "a" }],
+    onWidgetChanged(name, value, prevValue, widget) {
+      seen.push({ min: widget.options?.min, widgetName: widget.name });
+    },
+  };
+
+  const set = applyWidgetWrite(node, "text", "b", HOOKS);
+
+  assert.equal(set.widget_changed_hook_failed, undefined);
+  assert.deepEqual(seen, [{ min: undefined, widgetName: "text" }]);
+});
+
 // ---- the helper's own contract ---------------------------------------------
 
 test("#1519: fireNodeWidgetChanged never throws, whatever it is handed", () => {

--- a/browser_tests/unit/node-widget-changed.test.mjs
+++ b/browser_tests/unit/node-widget-changed.test.mjs
@@ -1,0 +1,482 @@
+/**
+ * #1519 — `panel_set_widget` never fired the NODE-level litegraph hook
+ * `node.onWidgetChanged(name, value, prevValue, widget)`, so a pack that rebuilds its
+ * slot topology from that hook kept the new widget value and its OLD slots, silently.
+ *
+ * These drive `applyWidgetWrite()` — the same function `graph_set_widget` delegates to
+ * — rather than the helper in isolation, because the whole defect was a MISSING CALL
+ * SITE: a helper-level test of `fireNodeWidgetChanged` passes just as happily with the
+ * write path never calling it, which is exactly the state main was in.
+ *
+ * Run with `node --test`.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { applyWidgetWrite, WidgetWriteError } from "../../web/js/lib/widget-write.js";
+import { fireNodeWidgetChanged, nodeWidgetChangedHook } from "../../web/js/lib/node-widget-changed.js";
+
+const HOOKS = {};
+
+/**
+ * The reported node, reduced to its mechanism: `comfyui-subworkflow`'s SWF_Subworkflow
+ * patches `onWidgetChanged` in `beforeRegisterNodeDef` and builds its `swf_in_*` /
+ * `out_*` slots from the selected child workflow. `panel_add_node` creates it with an
+ * empty `workflow` widget (so its `onAdded` fetches nothing), and the panel write then
+ * set the value while the slots stayed generic.
+ *
+ * The rebuild here is synchronous so the test can observe it; the real pack's is a
+ * `fetch`, which is why the result field is emitted only on an observed change.
+ */
+function makeSubworkflowNode({ onChange } = {}) {
+  const calls = [];
+  const node = {
+    id: 7,
+    type: "SWF_Subworkflow",
+    widgets: [
+      { name: "workflow", type: "combo", options: { values: ["", "child.json"] }, value: "" },
+      { name: "reload_each_execution", type: "toggle", value: false },
+    ],
+    inputs: [{ name: "workflow" }, { name: "reload_each_execution" }],
+    outputs: Array.from({ length: 8 }, (_, i) => ({ name: `out_${i}`, type: "*" })),
+    // Installed on the instance here; on the real pack it is on the node TYPE's
+    // prototype. Either way the lookup this file performs is `node.onWidgetChanged`.
+    onWidgetChanged(name, value, prevValue, widget) {
+      calls.push({ name, value, prevValue, widget, this: this });
+      if (onChange) return onChange.call(this, name, value, prevValue, widget);
+      if (name !== "workflow" || !value) return;
+      // What the pack does once `/subworkflow/info` answers: the boundary nodes of the
+      // selected child become real slots.
+      this.inputs = [
+        { name: "workflow" },
+        { name: "reload_each_execution" },
+        { name: "swf_in_0" },
+        { name: "swf_in_1" },
+      ];
+      this.outputs = [{ name: "out_0", type: "IMAGE" }];
+    },
+  };
+  return { node, calls };
+}
+
+// ---- the defect ------------------------------------------------------------
+
+test("#1519: a programmatic write FIRES the node's onWidgetChanged, so dynamic slots materialise", () => {
+  const { node, calls } = makeSubworkflowNode();
+
+  const set = applyWidgetWrite(node, "workflow", "child.json", HOOKS);
+
+  assert.equal(set.value, "child.json");
+  assert.equal(calls.length, 1, "the node-level hook must fire exactly once");
+  // The slots the report says never appeared. Without the hook these stay
+  // ["workflow", "reload_each_execution"] and every panel_connect to swf_in_0 fails.
+  assert.deepEqual(
+    node.inputs.map((i) => i.name),
+    ["workflow", "reload_each_execution", "swf_in_0", "swf_in_1"],
+  );
+  assert.deepEqual(
+    node.outputs.map((o) => o.name),
+    ["out_0"],
+  );
+});
+
+test("#1519: the hook gets litegraph's argument shape — (name, value, prevValue, widget) on the node", () => {
+  const { node, calls } = makeSubworkflowNode();
+  const widget = node.widgets[0];
+
+  applyWidgetWrite(node, "workflow", "child.json", HOOKS);
+
+  const call = calls[0];
+  assert.equal(call.name, "workflow");
+  assert.equal(call.value, "child.json");
+  assert.equal(call.prevValue, "", "the PRIOR value, as BaseWidget.setValue passes it");
+  assert.equal(call.widget, widget, "the widget object itself, not its name");
+  assert.equal(call.this, node, "invoked with the NODE as the receiver");
+});
+
+test("#1519: the widget's own callback runs BEFORE the node hook, as the frontend orders them", () => {
+  const order = [];
+  const node = {
+    id: 3,
+    type: "N",
+    widgets: [
+      {
+        name: "w",
+        type: "number",
+        value: 1,
+        callback() {
+          order.push("callback");
+        },
+      },
+    ],
+    onWidgetChanged() {
+      order.push("onWidgetChanged");
+    },
+  };
+
+  applyWidgetWrite(node, "w", 5, HOOKS);
+
+  assert.deepEqual(order, ["callback", "onWidgetChanged"]);
+});
+
+// ---- the ordering constraint the report asked for --------------------------
+
+test("#1519: a write that FAILS verification and rolls back does NOT fire the hook", () => {
+  const calls = [];
+  const node = {
+    id: 4,
+    type: "N",
+    widgets: [
+      {
+        name: "c",
+        options: { values: ["a", "b"] },
+        value: "a",
+        callback() {
+          this.value = "b"; // silent drift → verification fails → rollback + throw
+        },
+      },
+    ],
+    onWidgetChanged(...args) {
+      calls.push(args);
+    },
+  };
+
+  assert.throws(
+    () => applyWidgetWrite(node, "c", "a", HOOKS),
+    (err) => err instanceof WidgetWriteError && /did not retain the requested value/.test(err.message),
+  );
+  assert.equal(
+    calls.length,
+    0,
+    "a pack rebuilt against a value that was rolled back is worse than the stale slots this fixes",
+  );
+});
+
+// ---- containment: the hook never decides the write's verdict ---------------
+
+test("#1519: a THROWING hook does not fail the write — the value is in effect and the throw is disclosed", () => {
+  const node = {
+    id: 5,
+    type: "N",
+    widgets: [{ name: "w", type: "number", value: 1 }],
+    onWidgetChanged() {
+      throw new Error("pack blew up");
+    },
+  };
+
+  const set = applyWidgetWrite(node, "w", 5, HOOKS);
+
+  assert.equal(set.value, 5);
+  assert.equal(node.widgets[0].value, 5, "the write is NOT rolled back over a hook failure");
+  assert.match(set.widget_changed_hook_failed, /succeeded and was verified/);
+  assert.match(set.widget_changed_hook_failed, /pack blew up/);
+  assert.match(set.widget_changed_hook_failed, /may be stale/);
+});
+
+test("#1519: a NON-CALLABLE onWidgetChanged is invoked and disclosed, not silently skipped", () => {
+  const node = {
+    id: 6,
+    type: "N",
+    widgets: [{ name: "w", type: "number", value: 1 }],
+    // The frontend's `node.onWidgetChanged?.(…)` would throw here too. Skipping it
+    // silently would restore exactly the silent staleness this fixes.
+    onWidgetChanged: { call() {} },
+  };
+
+  const set = applyWidgetWrite(node, "w", 5, HOOKS);
+
+  assert.equal(set.value, 5);
+  assert.match(set.widget_changed_hook_failed, /is of type "object", not a function/);
+  assert.doesNotMatch(
+    set.widget_changed_hook_failed,
+    /a object/,
+    "typeof yields 'object'; 'a object' reads as a panel bug",
+  );
+});
+
+test("#1519: an onWidgetChanged that is a THROWING ACCESSOR yields no hook and no escape", () => {
+  const node = {
+    id: 8,
+    type: "N",
+    widgets: [{ name: "w", type: "number", value: 1 }],
+  };
+  Object.defineProperty(node, "onWidgetChanged", {
+    get() {
+      throw new Error("poisoned accessor");
+    },
+  });
+
+  const set = applyWidgetWrite(node, "w", 5, HOOKS);
+  assert.equal(set.value, 5);
+  assert.equal(nodeWidgetChangedHook(node), null);
+});
+
+test("#1519: a hook that PARTIALLY rebuilt before throwing says so, and reports what it left", () => {
+  const node = {
+    id: 9,
+    type: "N",
+    widgets: [{ name: "w", type: "number", value: 1 }],
+    inputs: [{ name: "a" }],
+    outputs: [],
+    onWidgetChanged() {
+      this.inputs = [{ name: "a" }, { name: "b" }];
+      throw new Error("halfway");
+    },
+  };
+
+  const set = applyWidgetWrite(node, "w", 5, HOOKS);
+
+  assert.match(set.widget_changed_hook_failed, /PARTIALLY rebuilt/);
+  assert.deepEqual(set.widget_changed_slots, { inputs: ["a", "b"], outputs: [] });
+});
+
+// ---- what the result reports -----------------------------------------------
+
+test("#1519: rebuilt slots are reported as DATA so the caller can wire without a re-read", () => {
+  const { node } = makeSubworkflowNode();
+
+  const set = applyWidgetWrite(node, "workflow", "child.json", HOOKS);
+
+  assert.deepEqual(set.widget_changed_slots, {
+    inputs: ["workflow", "reload_each_execution", "swf_in_0", "swf_in_1"],
+    outputs: ["out_0"],
+  });
+  assert.equal(set.widget_changed_hook_failed, undefined);
+});
+
+test("#1519: a hook that changed no slots claims NOTHING — an async rebuild is 'not yet', not 'nothing'", () => {
+  let fired = 0;
+  const node = {
+    id: 10,
+    type: "N",
+    widgets: [{ name: "w", type: "number", value: 1 }],
+    inputs: [{ name: "a" }],
+    outputs: [{ name: "b" }],
+    onWidgetChanged() {
+      fired++; // a real pack would kick off a fetch here and return
+    },
+  };
+
+  const set = applyWidgetWrite(node, "w", 5, HOOKS);
+
+  assert.equal(fired, 1, "the hook still fires — that is the fix");
+  assert.equal(set.widget_changed_slots, undefined);
+  assert.equal(set.widget_changed_hook_failed, undefined);
+});
+
+test("#1519: a node with NO hook replies exactly as it did before — no new fields", () => {
+  const node = { id: 11, type: "N", widgets: [{ name: "w", type: "number", value: 1 }] };
+
+  const set = applyWidgetWrite(node, "w", 5, HOOKS);
+
+  assert.equal("widget_changed_slots" in set, false);
+  assert.equal("widget_changed_hook_failed" in set, false);
+  assert.equal(set.value, 5);
+  assert.equal(set.previous, 1);
+});
+
+// ---- what the hook is told, vs what the reply reports ----------------------
+
+test("#1519: the hook is handed the VERIFIED value, not the requested one, when a widget normalizes", () => {
+  // #805 — a widget declaring min 1 / step 2 snaps 4096 onto its own grid to 4097.
+  // Handing a pack a value the widget does not hold is how a rebuild lands on state
+  // nothing agrees with, so the hook must see 4097 — the same value the reply reports.
+  const seen = [];
+  const node = {
+    id: 12,
+    type: "N",
+    widgets: [
+      {
+        name: "w",
+        type: "number",
+        value: 1,
+        options: { min: 1, step: 2 },
+        callback() {
+          this.value = 4097; // the widget doing exactly what a numeric widget does
+        },
+      },
+    ],
+    onWidgetChanged(name, value) {
+      seen.push(value);
+    },
+  };
+
+  const set = applyWidgetWrite(node, "w", 4096, HOOKS);
+
+  assert.equal(set.normalized, true, "the fixture must actually normalize, or this proves nothing");
+  assert.equal(set.requested_value, 4096);
+  assert.equal(set.value, 4097);
+  assert.deepEqual(seen, [4097], "never the requested 4096, which the widget does not hold");
+});
+
+test("#1519: a hook that mutates the widget afterwards cannot rewrite the VERIFIED reply", () => {
+  const node = {
+    id: 13,
+    type: "N",
+    widgets: [{ name: "w", type: "number", value: 1 }],
+    onWidgetChanged(name, value, prevValue, widget) {
+      // A rebuild that re-touches the widget IN PLACE, after the verification that
+      // decided this write is done. The reply must state what the verification
+      // established — a post-hook read would report a value nothing checked.
+      widget.value = 999;
+      widget.name = "renamed_by_pack";
+    },
+  };
+
+  const set = applyWidgetWrite(node, "w", 5, HOOKS);
+
+  assert.equal(node.widgets[0].value, 999, "the hook really did move it");
+  assert.equal(set.value, 5, "the reply states the VERIFIED value, not the post-hook read");
+  assert.equal(set.widget, "w");
+});
+
+// ---- history bracketing ----------------------------------------------------
+
+test("#1519: the hook runs inside its OWN before/afterChange bracket, after the write's", () => {
+  const events = [];
+  const node = {
+    id: 14,
+    type: "N",
+    widgets: [{ name: "w", type: "number", value: 1 }],
+    onWidgetChanged() {
+      events.push("hook");
+    },
+  };
+
+  applyWidgetWrite(node, "w", 5, {
+    beforeChange: () => events.push("before"),
+    afterChange: () => events.push("after"),
+  });
+
+  assert.deepEqual(
+    events,
+    ["before", "after", "before", "hook", "after"],
+    "the write's envelope closes (and verifies) first; the slot changes then join the undo history",
+  );
+});
+
+test("#1519: a THROWING history hook does not decide the outcome it merely brackets", () => {
+  let fired = 0;
+  const node = {
+    id: 15,
+    type: "N",
+    widgets: [{ name: "w", type: "number", value: 1 }],
+    onWidgetChanged() {
+      fired++;
+    },
+  };
+
+  const set = applyWidgetWrite(node, "w", 5, {
+    beforeChange: () => {
+      throw new Error("history hook down");
+    },
+    afterChange: () => {
+      throw new Error("history hook down");
+    },
+  });
+
+  assert.equal(fired, 1);
+  assert.equal(set.value, 5);
+  assert.equal(set.widget_changed_hook_failed, undefined);
+});
+
+// ---- promoted writes: exactly once, on the widget whose callback fired -----
+
+/**
+ * The promoted fixture widget-write.test.mjs uses, with a node-level hook on BOTH
+ * ends. The promotion is RENAMED (outer `sched_alias` → inner `scheduler`), the
+ * parent's authoritative rail is identity-linked from the host input, and there is a
+ * decoy parent widget named after the inner source.
+ *
+ * `instance: true` gives the host input a per-instance `widgetId` keyed to this
+ * wrapper, which is what `promotedValueScope` reads to classify the write.
+ */
+function makePromotedFixture({ instance = false } = {}) {
+  const innerCalls = [];
+  const outerCalls = [];
+  const inner = {
+    id: 54,
+    type: "KSampler",
+    widgets: [
+      { name: "seed", type: "INT", value: 959948902156062 },
+      { name: "scheduler", type: "combo", options: { values: ["simple", "karras"] }, value: "simple" },
+    ],
+    onWidgetChanged(...args) {
+      innerCalls.push(args);
+    },
+  };
+  const subgraph = { _nodes: [inner], getNodeById: (id) => (String(id) === "54" ? inner : null) };
+  const railWidget = { name: "sched_alias", type: "combo", options: { values: ["simple", "karras"] }, value: "simple" };
+  const parent = {
+    id: 66,
+    type: "SubgraphNode",
+    subgraph,
+    inputs: [
+      {
+        name: "sched_alias",
+        _widget: railWidget,
+        widget: { name: "sched_alias" },
+        _subgraphSlot: { name: "sched_alias" },
+        ...(instance ? { widgetId: "x:66:sched_alias" } : {}),
+      },
+    ],
+    widgets: [
+      { name: "scheduler", type: "combo", options: { values: ["simple"] }, value: 999 },
+      railWidget,
+    ],
+    onWidgetChanged(...args) {
+      outerCalls.push(args);
+    },
+  };
+  const resolveSource = (_node, subgraphInput) =>
+    subgraphInput?.name === "sched_alias" ? { sourceNodeId: "54", sourceWidgetName: "scheduler" } : null;
+  return { parent, inner, railWidget, resolveSource, innerCalls, outerCalls };
+}
+
+test("#1519: a DEFINITION-SCOPED promoted write announces on the INNER node, exactly once", () => {
+  const { parent, inner, resolveSource, innerCalls, outerCalls } = makePromotedFixture();
+
+  const set = applyWidgetWrite(parent, "sched_alias", "karras", { resolveSource });
+
+  assert.equal(set.value, "karras");
+  // Exactly one announcement, on the same node/widget pair whose callback this write
+  // fires. Announcing the other end too would report a change for a widget that did
+  // not move — widget-write.js's own reasoning for firing ONE semantic callback.
+  assert.equal(outerCalls.length, 0, "the rail's own value change is a projection, not a second edit");
+  assert.deepEqual(innerCalls.length, 1);
+  const [name, value, prev, widget] = innerCalls[0];
+  assert.equal(name, "scheduler", "the INNER widget's name — the one that was written");
+  assert.equal(value, "karras");
+  assert.equal(prev, "simple", "that widget's OWN prior value");
+  assert.equal(widget, inner.widgets.find((w) => w.name === "scheduler"));
+});
+
+test("#1519: an INSTANCE-SCOPED promoted write announces on the WRAPPER, whose rail it wrote", () => {
+  const { parent, resolveSource, railWidget, innerCalls, outerCalls } = makePromotedFixture({ instance: true });
+
+  const set = applyWidgetWrite(parent, "sched_alias", "karras", { resolveSource });
+
+  assert.equal(set.promoted_from.value_scope, "instance");
+  // The shared subgraph DEFINITION is deliberately left alone on this path, so the
+  // inner node has nothing to announce and must not be told otherwise.
+  assert.equal(innerCalls.length, 0);
+  assert.equal(outerCalls.length, 1);
+  const [name, value, prev, widget] = outerCalls[0];
+  assert.equal(name, "sched_alias");
+  assert.equal(value, "karras");
+  assert.equal(prev, "simple");
+  assert.equal(widget, railWidget);
+});
+
+// ---- the helper's own contract ---------------------------------------------
+
+test("#1519: fireNodeWidgetChanged never throws, whatever it is handed", () => {
+  assert.equal(fireNodeWidgetChanged(null, null, {}), null);
+  assert.equal(fireNodeWidgetChanged(undefined, undefined), null);
+  assert.equal(fireNodeWidgetChanged({}, {}, { name: "w" }), null);
+
+  const revoked = Proxy.revocable({}, {});
+  revoked.revoke();
+  const out = fireNodeWidgetChanged({ onWidgetChanged: revoked.proxy }, {}, { name: "w" });
+  assert.match(out.failed, /attempting to invoke/);
+});

--- a/web/js/lib/node-widget-changed.js
+++ b/web/js/lib/node-widget-changed.js
@@ -1,0 +1,256 @@
+/**
+ * #1519 — `panel_set_widget` fired the widget's OWN callback and stopped there, so
+ * the NODE-level litegraph hook `node.onWidgetChanged(name, value, prevValue, widget)`
+ * never ran for a programmatic write.
+ *
+ * ## The mechanism, read from the frontend rather than assumed
+ *
+ * Both of the frontend's interactive write paths fire it, and they fire it in the
+ * SAME position relative to the widget callback that `widget-write.js` already
+ * reproduces for everything else. From comfyui-frontend-package 1.48.7, `BaseWidget.setValue`:
+ *
+ *     this.value = a
+ *     this.options?.property && … && node.setProperty(this.options.property, a)
+ *     this.callback?.(this.value, canvas, node, pos, e)
+ *     node.onWidgetChanged?.(this.name ?? "", a, i, this)      // <- i is the PRIOR value
+ *     node.graph && node.graph.incrementVersion()
+ *
+ * and the canvas mouse path (`processNodeWidgets`):
+ *
+ *     if (prev != w.value) { node.onWidgetChanged?.(w.name, w.value, prev, w); … }
+ *
+ * `widget-write.js` already performs the assignment, the `setProperty` copy-back
+ * (#1268) and the callback invocation in exactly that order — the node hook was the
+ * one step missing, and `onWidgetChanged` appeared NOWHERE in the panel's web/js.
+ *
+ * ## Why the omission is expensive rather than cosmetic
+ *
+ * A pack whose slot TOPOLOGY is driven by a widget hooks `onWidgetChanged`, not the
+ * widget's callback — `beforeRegisterNodeDef` patches the node type's prototype, which
+ * is the only hook that survives the widget being rebuilt. `comfyui-subworkflow`'s
+ * `SWF_Subworkflow` is the reported case: it fetches `/subworkflow/info` for the
+ * selected child workflow from `onWidgetChanged` (plus `onConfigure` and `onAdded`)
+ * and builds its `swf_in_*` / `out_*` slots from the answer. `panel_add_node` creates
+ * it with an empty `workflow` widget, so `onAdded` fetched nothing; `panel_set_widget`
+ * then set the value and fired no node hook, so the fetch never happened and the node
+ * kept the generic `out_0..out_7` shape. The write reported success — honestly, the
+ * VALUE was verified present — and every later `panel_connect` to a real slot failed
+ * because the slot did not exist. Nothing anywhere raised an error, so the natural
+ * read was "this pack is incompatible with the panel".
+ *
+ * This is not specific to that pack. Any node type whose slots are rebuilt from
+ * `onWidgetChanged` was affected identically.
+ *
+ * ## What this does, and the two things it deliberately does not do
+ *
+ * Fires the hook ONCE, on the node/widget pair whose callback the write just fired —
+ * for a promoted write that is the same single semantic widget `widget-write.js`
+ * already chose (see its callback note: the inner target on the definition-scoped
+ * path, the rail on the instance-scoped one). Firing a second hook for the other end
+ * of a promotion would announce a change for a widget whose value did not move.
+ *
+ * It does NOT run on a rolled-back write. The call site sits after the verification
+ * verdict and after every failure path has thrown, so a write that did not stick can
+ * never leave a pack rebuilt against a value that was restored — the failure mode the
+ * report explicitly asked to avoid.
+ *
+ * It does NOT decide the write's verdict. The write already succeeded and was
+ * verified; a hook that throws is DISCLOSED on the success result, never thrown over
+ * it. Same containment `widget-write.js` gives the widget callback, and the same
+ * containment `dynamic-inputs-refresh.js` (#1282) gives the pack's own refresh
+ * button — which is the closest precedent for this whole route.
+ *
+ * ## What it reports
+ *
+ *   - the node's input/output slot names CHANGED → `{ changed: { inputs, outputs } }`,
+ *     so the caller can wire the node without a re-read.
+ *   - the hook threw (or could not be invoked at all) → `{ failed: <sentence> }`.
+ *   - no hook, or the hook ran and the slots did not move → `null`, and the result
+ *     looks exactly as it did before this change.
+ *
+ * "The slots did not move" is NOT reported as anything. A pack that rebuilds them
+ * from a `fetch` (which `SWF_Subworkflow` does) resolves after this returns, so a
+ * synchronous snapshot showing no change means "not yet", not "nothing happened" —
+ * exactly as it means for an interactive edit. Claiming either way would be a lie
+ * about a state this cannot observe.
+ *
+ * Never throws.
+ */
+
+// Captured at module load, as widget-write.js and dynamic-inputs-refresh.js do for
+// their own invocations: a poisoned `.call` getter or a Proxy `get` trap on the hook
+// must not be able to throw from INSIDE the span the throw is attributed to, and
+// `Reflect.apply` checks callability first — so a non-callable hook still throws a
+// TypeError exactly as the frontend's `?.()` form does, and is disclosed as one.
+const reflectApply = Reflect.apply;
+
+/** One slot list's names, in order. Never throws. */
+function slotNames(list) {
+  try {
+    if (!Array.isArray(list)) return [];
+    return list.map((slot) => {
+      try {
+        return typeof slot?.name === "string" ? slot.name : null;
+      } catch {
+        return null;
+      }
+    });
+  } catch {
+    return [];
+  }
+}
+
+/** The node's input AND output slot names. Never throws. */
+function slotSnapshot(node) {
+  return { inputs: slotNames(node?.inputs), outputs: slotNames(node?.outputs) };
+}
+
+function sameNames(a, b) {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) if (a[i] !== b[i]) return false;
+  return true;
+}
+
+function sameSlots(a, b) {
+  return sameNames(a.inputs, b.inputs) && sameNames(a.outputs, b.outputs);
+}
+
+/** A never-throwing rendering of what the hook's invocation threw. */
+function coerceThrowMessage(err) {
+  try {
+    const msg = err?.message;
+    if (typeof msg === "string" && msg) return msg;
+    return String(err);
+  } catch {
+    return "the reason could not be rendered";
+  }
+}
+
+/**
+ * The node-level widget-change hook, when the node has one.
+ *
+ * Read TOTALLY and read ONCE: `onWidgetChanged` may be an accessor (a pack patching
+ * a prototype is the normal way this hook is installed, and a throwing getter is a
+ * legal shape), and a read that throws must yield "no hook" rather than escape over
+ * a verified write. A non-nullish, non-callable value is returned as a CANDIDATE, not
+ * rejected — the frontend's `node.onWidgetChanged?.(…)` would invoke it and throw, and
+ * silently skipping it here would restore exactly the silent staleness this fixes.
+ *
+ * @returns {{ hook: unknown } | null}
+ */
+export function nodeWidgetChangedHook(node) {
+  try {
+    const hook = node?.onWidgetChanged;
+    if (hook === null || hook === undefined) return null;
+    return { hook };
+  } catch {
+    // The read itself threw. There is no hook this file may invoke, and nothing is
+    // claimed about whether one exists.
+    return null;
+  }
+}
+
+/**
+ * Fire `node.onWidgetChanged(name, value, previous, widget)` after a verified write.
+ *
+ * Call ONLY from the synchronous write boundary of a write that has already succeeded
+ * and been verified — the hook is a graph mutation (a pack rebuilds slots from it), so
+ * it must not sit across an await, and it must never run for a write that rolled back.
+ *
+ * @param {object} node    the node that OWNS the written widget (`valueNode`)
+ * @param {object} widget  the widget that was written (`valueWidget`)
+ * @param {{ name: string, value: unknown, previous: unknown,
+ *          beforeChange?: Function, afterChange?: Function, setDirty?: Function }} opts
+ *   `value` is the VERIFIED value read back off the widget, and `previous` is that same
+ *   widget's own prior value — never the other end of a promotion's.
+ * @returns {null | { changed: { inputs: (string|null)[], outputs: (string|null)[] } } | { failed: string }}
+ */
+export function fireNodeWidgetChanged(
+  node,
+  widget,
+  { name, value, previous, beforeChange, afterChange, setDirty } = {},
+) {
+  try {
+    const found = nodeWidgetChangedHook(node);
+    if (!found) return null;
+
+    const before = slotSnapshot(node);
+    // Bookkeeping hooks are best-effort, exactly as widget-write.js's own
+    // safeBefore/safeAfter: a throwing history hook must never decide the outcome it
+    // is merely bracketing. Bracketed so slot changes join the command's undo history.
+    try {
+      beforeChange?.();
+    } catch {
+      /* history hook is best-effort */
+    }
+    let threw = null;
+    let didThrow = false;
+    try {
+      // The frontend's argument shape, verbatim: (name, newValue, prevValue, widget),
+      // with the NODE as the receiver. `Reflect.apply` rather than `hook.call(…)` —
+      // `.call` is a property read ON the hook, so a poisoned getter could throw
+      // without the hook running, and a non-callable `{ call() {} }` would be invoked
+      // through its own `.call` and reported clean.
+      reflectApply(found.hook, node, [name, value, previous, widget]);
+    } catch (err) {
+      didThrow = true;
+      threw = err;
+    } finally {
+      try {
+        afterChange?.();
+      } catch {
+        /* history hook is best-effort */
+      }
+    }
+
+    const after = slotSnapshot(node);
+    const changed = !sameSlots(before, after);
+
+    if (didThrow) {
+      // The write already succeeded and was verified; the hook is the part that
+      // failed. It may have rebuilt some slots before it threw, so say that rather
+      // than calling them simply stale.
+      //
+      // "attempting to invoke", uniformly — a class constructor, a revoked Proxy and
+      // a throwing `apply` trap all satisfy the invocation and throw before any body
+      // runs, so any wording that says the hook RAN is false for them, and this cannot
+      // tell them apart from a body that threw.
+      const notCallable = typeof found.hook !== "function";
+      return {
+        failed:
+          `The write itself succeeded and was verified, but attempting to invoke this node's ` +
+          `own onWidgetChanged hook threw (${coerceThrowMessage(threw)})` +
+          (notCallable
+            ? // No indefinite article: `typeof` yields "object", and "a object" reads
+              // as a panel bug — which is the impression this whole route exists to stop.
+              `. The node's onWidgetChanged is of type "${typeof found.hook}", not a function, so ` +
+              `it could not be invoked at all and none of its side effects ran`
+            : "") +
+          `, so slots or other node state it rebuilds from "${name}" may be stale` +
+          (changed ? " — and may be PARTIALLY rebuilt, because the slot list changed before it threw" : "") +
+          `. Read the node with panel_query_graph before relying on its slots.`,
+        ...(changed ? { changed: after } : {}),
+      };
+    }
+
+    if (!changed) return null;
+
+    try {
+      setDirty?.();
+    } catch {
+      /* a repaint hint is cosmetic — never fail a hook invocation that worked */
+    }
+    return { changed: after };
+  } catch (err) {
+    // Runs after a verified write; nothing here may escape over that success. An
+    // unexpected failure of the MACHINERY (as opposed to the hook, handled above) is
+    // still disclosed, because the state it leaves behind is the stale one this file
+    // exists to fix.
+    return {
+      failed:
+        `The write itself succeeded and was verified, but firing this node's onWidgetChanged ` +
+        `hook afterwards failed (${coerceThrowMessage(err)}), so slots or other node state it ` +
+        `rebuilds may be stale. Read the node with panel_query_graph before relying on its slots.`,
+    };
+  }
+}

--- a/web/js/lib/node-widget-changed.js
+++ b/web/js/lib/node-widget-changed.js
@@ -100,9 +100,30 @@ function slotNames(list) {
   }
 }
 
-/** The node's input AND output slot names. Never throws. */
+/**
+ * The node's input AND output slot names. Never throws.
+ *
+ * The `inputs`/`outputs` READS are inside the try, not just the list walk: a pack that
+ * rebuilds slots is exactly the kind of node that defines them as accessors, and a throw
+ * from the BEFORE snapshot would abort this route before the hook ever fired — reporting
+ * a machinery failure while leaving behind the stale slots this file exists to fix. A
+ * snapshot that could not be taken yields empty lists, which compare equal to the other
+ * side's and so claim nothing either way.
+ */
 function slotSnapshot(node) {
-  return { inputs: slotNames(node?.inputs), outputs: slotNames(node?.outputs) };
+  let inputs = [];
+  let outputs = [];
+  try {
+    inputs = slotNames(node?.inputs);
+  } catch {
+    inputs = [];
+  }
+  try {
+    outputs = slotNames(node?.outputs);
+  } catch {
+    outputs = [];
+  }
+  return { inputs, outputs };
 }
 
 function sameNames(a, b) {

--- a/web/js/lib/widget-write.js
+++ b/web/js/lib/widget-write.js
@@ -1,3 +1,4 @@
+import { fireNodeWidgetChanged } from "./node-widget-changed.js";
 import { pressableWidgetHint } from "./pressable-widget.js";
 import { explainNumericNormalization, normalizationNote } from "./widget-normalization.js";
 import { isNonSerializingValueSource } from "./virtual-source-promotion.js";
@@ -2312,6 +2313,55 @@ export function applyWidgetWrite(
 
   setDirty?.();
 
+  // #1519 — FIRE THE NODE-LEVEL HOOK, here and nowhere else.
+  //
+  // `node.onWidgetChanged(name, value, prevValue, widget)` is the litegraph hook a pack
+  // patches onto a node TYPE (in `beforeRegisterNodeDef`) to rebuild slot topology from
+  // a widget. It is not the widget's own callback and a pack cannot use the callback
+  // instead — the callback lives on a widget the rebuild replaces. The frontend fires
+  // both, in this order, on every interactive edit; this file fired only the callback,
+  // so a programmatic write left such a node holding the NEW widget value and its OLD
+  // slots, silently. See lib/node-widget-changed.js for the frontend call sites this
+  // reproduces and the reported `SWF_Subworkflow` case.
+  //
+  // PLACED AFTER THE VERIFICATION VERDICT, which is the whole of the ordering question
+  // the report raised. Every failure path above has already rolled back and THROWN by
+  // the time control reaches here, so the hook cannot run for a write that did not
+  // stick — a pack rebuilt against a value that was subsequently restored is the one
+  // outcome worse than the stale slots this fixes. Nothing in the rollback machinery is
+  // touched; this is reachable only from the success path.
+  //
+  // FIRED ONCE, on the node/widget pair whose callback this write fired — `valueNode`
+  // and `valueWidget`, which on an instance-scoped promoted write are the wrapper and
+  // its rail, and otherwise the concrete target. Announcing the change a second time
+  // for the other end of a promotion would report a change for a widget whose value
+  // did not move, which is the same reasoning the callback note above records.
+  //
+  // ARGUMENTS: the VERIFIED value read back off the widget, not `coerced`. Where a
+  // widget's own grid normalized the write (#805) the two differ, and handing a pack a
+  // value the widget does not hold is how a rebuild lands on state nothing agrees with.
+  // For every write that did not normalize they are identical. `previousForHook` is
+  // that same widget's own prior value, never the other end of the promotion's.
+  //
+  // Unlike the frontend's `BaseWidget.setValue`, this is NOT gated on the value having
+  // changed. The gate does not exist for the callback invocation above either, and
+  // adding one only here would make re-issuing the same `panel_set_widget` — the
+  // obvious way a caller recovers from exactly this bug — a silent no-op.
+  //
+  // It NEVER decides this write's verdict: a throwing hook is disclosed on the success
+  // result, the same containment the widget callback and #1282's refresh press get.
+  const verifiedValue = valueWidget.value;
+  const verifiedName = valueWidget.name;
+  const previousForHook = instanceScoped ? previousParent : previous;
+  const widgetChanged = fireNodeWidgetChanged(valueNode, valueWidget, {
+    name: verifiedName,
+    value: verifiedValue,
+    previous: previousForHook,
+    beforeChange,
+    afterChange,
+    setDirty,
+  });
+
   // On success, a promoted write has ALWAYS synced the authoritative parent rail
   // widget (verified AFTER afterChange, or it would have rolled back + thrown).
   // parent_widget_synced is reported for observability / defense-in-depth in the
@@ -2330,11 +2380,16 @@ export function applyWidgetWrite(
   // change. Provenance is not lost: `promoted_from.inner_node_id` still names the inner
   // node and `inner_previous` still reports its (unchanged) value. Every definition-scoped
   // and non-promoted write reports exactly the fields it always did.
+  // #1519 — `widget`/`value` are the captures taken BEFORE the node hook fired, not a
+  // fresh read. They are what the verification above ESTABLISHED, and a hook that
+  // rebuilds a node can replace the widget object or move its value; reporting a
+  // post-hook read would put a value in the reply that nothing verified. With no hook
+  // (every stock node) the captures are the same reads this returned before.
   return {
     node_id: valueNode.id,
-    widget: valueWidget.name,
+    widget: verifiedName,
     previous: parentWidget ? previousParent : previous,
-    value: valueWidget.value,
+    value: verifiedValue,
     // #1126 — the COERCION-TIME verdict, so the caller reports WHAT HAPPENED instead of
     // inferring it from the rejection that led here. `options.values` is a callback and
     // can answer differently per call: the final attempt may well have been admitted by
@@ -2390,6 +2445,24 @@ export function applyWidgetWrite(
     // caller reaching that acceptance from EITHER ladder branch sees one field with one
     // name, rather than the #507 branch alone naming it at the runSetWidget level.
     ...(coerceOutcome.emptyAcceptanceUsed ? { empty_option_list: true } : {}),
+    // #1519 — what the node's own onWidgetChanged hook did, as DATA. Both fields are
+    // emitted ONLY on an OBSERVATION, so every node without the hook — which is every
+    // stock ComfyUI node — replies byte-identically to before:
+    //
+    //   widget_changed_slots        the hook rebuilt the node's slots synchronously;
+    //                               these are the input/output names AFTER it, so the
+    //                               caller can wire the node without a re-read.
+    //   widget_changed_hook_failed  attempting to invoke the hook threw. The WRITE is
+    //                               unaffected — it is verified and was not rolled back
+    //                               — but the state the hook rebuilds may be stale or
+    //                               partially rebuilt, and that is stated rather than
+    //                               left for a later `panel_connect` to discover.
+    //
+    // A hook that ran and changed no slots reports NOTHING, because a pack that rebuilds
+    // from a `fetch` (the reported `SWF_Subworkflow` does) resolves after this returns:
+    // a synchronous snapshot showing no change means "not yet", not "nothing happened".
+    ...(widgetChanged?.changed ? { widget_changed_slots: widgetChanged.changed } : {}),
+    ...(widgetChanged?.failed ? { widget_changed_hook_failed: widgetChanged.failed } : {}),
     ...(writeWarning
       ? {
           write_warning: writeWarning,
@@ -2408,9 +2481,11 @@ export function applyWidgetWrite(
           requested_value: expected,
           normalization_rule: normalization.rule,
           normalization_note: normalizationNote({
-            name: valueWidget.name,
+            // #1519 — the same pre-hook captures the verdict was computed from, so the
+            // note cannot describe a value the normalization check never saw.
+            name: verifiedName,
             requested: expected,
-            actual: valueWidget.value,
+            actual: verifiedValue,
             rule: normalization.rule,
           }),
         }


### PR DESCRIPTION
Fixes #1519.

## What was wrong

`panel_set_widget` assigned the value, drove the bound property (#1268) and fired the
widget's own `callback` — and stopped there. The NODE-level litegraph hook
`node.onWidgetChanged(name, value, prevValue, widget)` never ran. `onWidgetChanged`
appeared **nowhere** in `web/js/**` before this PR:

```
$ git grep -n onWidgetChanged origin/main -- .
(no output)
```

That hook is how a pack rebuilds slot **topology** from a widget, and it cannot use the
widget callback instead: `beforeRegisterNodeDef` patches the node *type's* prototype,
which is the only hook that survives the widget being rebuilt.

The reported case is `comfyui-subworkflow`'s `SWF_Subworkflow`: it fetches
`/subworkflow/info` from `onWidgetChanged` and builds its `swf_in_*` / `out_*` slots from
the answer. `panel_add_node` creates it with an empty `workflow` widget, so its `onAdded`
fetched nothing; `panel_set_widget` then set the value and fired no node hook, so the
fetch never happened. The write reported success — honestly; the VALUE was verified
present — and every later `panel_connect` failed because the slot did not exist. Nothing
raised an error anywhere, which is what made it expensive: the natural read was "this
pack is incompatible with the panel", and the discovered workaround was a save + reload
mid-build (only `onConfigure` fires on load).

## The mechanism, read from the frontend rather than assumed

comfyui-frontend-package **1.48.7**, `BaseWidget.setValue` (deminified):

```js
this.value = a
this.options?.property && … && node.setProperty(this.options.property, a)
this.callback?.(this.value, canvas, node, pos, e)
node.onWidgetChanged?.(this.name ?? "", a, prev, this)   // <- the missing step
node.graph && node.graph.incrementVersion()
```

and the canvas mouse path, `processNodeWidgets`:

```js
if (prev != w.value) { node.onWidgetChanged?.(w.name, w.value, prev, w); … }
```

`widget-write.js` already performed the assignment, the `setProperty` copy-back and the
callback **in exactly that order**. The node hook was the one step missing.

### This is not a rare path — every node on a real page carries the hook

`installNodeHooksRecursive` (same bundle, `GraphView-*.js`) wraps `onWidgetChanged` on
**every node in the graph** on attach, and again from `onNodeAdded`:

```js
e.onWidgetChanged = Mc(e.onWidgetChanged, function (t, n, r, i) {
  if (!Z.rootGraph) return
  let a = is(Z.rootGraph, e); if (!a) return
  let o = { min: i.options?.min, max: i.options?.max }
  …
  ia().clearWidgetRelatedErrors(a, t, i.name, n, o)
})
```

Two consequences a reviewer should weigh, both deliberate:

1. A panel write now clears widget-related validation errors the way an interactive edit
   does. That is consistent with what the handler already wants — `graph_set_widget`
   clears the sticky `has_errors` red flag after a write (#418) — but it is a real
   behaviour change on ordinary nodes, not just on packs with dynamic slots.
2. The wrapper dereferences the **fourth** argument (`i.options`, `i.name`), so the
   argument shape is load-bearing: handing it `undefined` would make every panel write on
   a real page throw and newly report `widget_changed_hook_failed`. Two tests transcribe
   that wrapper's body and pin the clean outcome.

## Where it fires — the whole of the ordering question the report raised

After the verification verdict, at the success path, where **every failure path has
already rolled back and thrown**. So the hook cannot run for a write that did not stick:
a pack rebuilt against a value that was subsequently restored is worse than the stale
slots this fixes. **None of the rollback machinery is touched** — the new call is
reachable only from the committed path.

Three further decisions, each stated in the source:

- **Fired once**, on the node/widget pair whose callback the write fired — the inner
  target on a definition-scoped promoted write, the rail on an instance-scoped one.
  Announcing the other end would report a change for a widget whose value did not move,
  which is `widget-write.js`'s own reasoning for firing one semantic callback.
- **Handed the VERIFIED value** read back off the widget, not `coerced`. Where a widget's
  own grid normalized the write (#805) the two differ, and handing a pack a value the
  widget does not hold is how a rebuild lands on state nothing agrees with. The reply
  reports that same capture, taken *before* the hook ran, so a hook that re-touches the
  widget cannot put a value in the reply that nothing verified.
- **Not gated on the value having changed**, unlike the frontend's `setValue`. That gate
  does not exist for the callback invocation either, and adding one only here would make
  re-issuing the same `panel_set_widget` — the obvious way a caller recovers from exactly
  this bug — a silent no-op.

It never decides the write's verdict: a throwing hook is disclosed on the success result,
never thrown over it. Same containment the widget callback gets, same shape #1282's
refresh press uses.

**Undo cost, stated rather than waved at.** The hook runs in its own
`beforeChange`/`afterChange` bracket so slot rebuilds join the command's undo history —
and since every node on a real page has a hook, that bracket now opens on every write.
It does not add an undo entry for a hook that changes nothing: litegraph's
`captureCanvasState()` compares the serialized graph against `activeState` and pushes only
on a diff. What it does cost is one extra graph serialize + compare per `panel_set_widget`.

## What the reply reports

Both fields are emitted only on an **observation**, so every node without the hook replies
byte-identically to before:

- `widget_changed_slots` — the hook rebuilt the node's slots synchronously; the input/
  output names after it, so the caller can wire without a re-read.
- `widget_changed_hook_failed` — attempting to invoke the hook threw. The write is
  unaffected and was not rolled back; the state the hook rebuilds may be stale or
  partially rebuilt, and that is stated rather than left for a later `panel_connect` to
  discover.

A hook that ran and changed no slots reports **nothing**: a pack that rebuilds from a
`fetch` (which `SWF_Subworkflow` does) resolves after this returns, so a synchronous
snapshot showing no change means "not yet", not "nothing happened".

## Evidence — verified by mutation, not by a green suite

20 tests in `browser_tests/unit/node-widget-changed.test.mjs`, driving `applyWidgetWrite()`
(the function `graph_set_widget` delegates to) rather than the helper in isolation — the
defect was a *missing call site*, and a helper-level test passes just as happily with the
write path never calling it, which is the state `main` was in.

| mutation | result |
|---|---|
| call site disabled (`null && fireNodeWidgetChanged(…)`) | **16 of 20 red** (the 4 that stay green are the negative controls: no-hook, throwing accessor, helper-in-isolation, verified-reply capture) |
| hook moved ABOVE the rollback branch | **"a write that FAILS verification and rolls back does NOT fire the hook" red** |
| `coerced` passed instead of the verified read | **the #805 normalization test red** |
| reply re-reads the widget AFTER the hook | **"cannot rewrite the VERIFIED reply" red** |

The last one is worth a note: my first draft of that test replaced `node.widgets` inside
the hook and did **not** catch the mutation — the captured widget object was untouched, so
a re-read still returned the verified value. It was rewritten to mutate the widget in
place, and then it caught it.

Suites, on this branch rebased onto `a6a920f5`:

- `npm run test:unit` — **5982/5984**. The one failure is the known #671 manager-install
  wall-clock flake; re-run alone, `manager-install.test.mjs` is **125/125**.
- widget-write-adjacent suites together (`widget-write`, `set-widget-*`,
  `dynamic-inputs-refresh`, `promoted-value-scope`, `widget-bound-property`,
  `rgthree-lora-row`, plus the new file) — **413/413**.
- `npm run typecheck` clean; `check-panel-scope` and `check-tool-vocabulary` OK.

## Playwright: NOT run against this branch, and why

I could not give this a browser gate, and I would rather say so than imply coverage I do
not have.

The only ComfyUI running here is the shared instance on 8188. Its
`custom_nodes/comfyui-mcp-panel` junction points at the main checkout, which sits on an
unrelated branch — so a Playwright run from this worktree would have exercised that
branch's code, not this one. I repointed the junction at this worktree and **measured that
it changed nothing**: `js/lib/node-widget-changed.js` still 404'd and the served
`widget-write.js` still had zero occurrences of the new import, because aiohttp resolved
the static route at ComfyUI startup. The only way through is to restart the shared
instance, and with other sessions active on this machine (23 chrome processes at the time)
that would have killed someone else's in-flight run. The junction was restored to the main
checkout and re-verified serving.

What that leaves unverified in a real browser: that an ordinary `panel_set_widget` against
the frontend's own installed wrapper stays clean end to end. The two transcribed-wrapper
tests are the closest stand-in and they pass, but they are a transcription, not the real
frontend. The specs that would exercise this for real are
`reopen-preserves-node-set-values`, `save-persists-node-set-values`,
`dirty-guards-see-node-writes` and `duplicate-widget-rows-are-visible` — worth a run by
anyone who has a restartable instance.

## What I deliberately did NOT do

- **No `graph.incrementVersion()`.** The frontend bumps it next to this hook; the panel
  uses its own `setDirty` / history bracketing, and adding a second dirty mechanism is a
  separate change with its own undo consequences.
- **No summary-line change.** `widget_changed_hook_failed` sits on the result the model
  reads, exactly where #1282 put `dynamic_inputs_refresh_failed`; the human activity line
  is untouched.
- **No await.** The hook fires synchronously at the write boundary. A pack whose rebuild
  is a `fetch` materializes its slots shortly after — the same way it does for an
  interactive edit — so the reporter's `panel_connect` step works on the next round trip,
  not within the same reply.
- **Nothing about #1254** (the add-node-after-open wedge the report mentions as the other
  half of its workaround). Separate issue, untouched.

**Review is pending** — requested from grok in a comment below. This is not gated and not
reviewed yet; no verdict is claimed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
