### PR TITLE
fix(1516): a timestamp-less transcript keeps the order it was written in

### DIFF
--- a/browser_tests/legacy-transcript-order.spec.ts
+++ b/browser_tests/legacy-transcript-order.spec.ts
@@ -1,0 +1,112 @@
+/**
+ * #1516 — after a hard refresh that crossed a panel version boundary, the user
+ * reported "refreshing the page seems to have repeated my initial messages to
+ * you". Nothing was re-sent to the agent; the CHAT PANE re-painted the stored
+ * transcript out of order, dropping the earliest prompts below the agent's last
+ * reply.
+ *
+ * A pre-0.11.0 panel (before IndexedDB and the atomic snapshot key existed)
+ * wrote a bare array of threads under `comfyui-mcp.panel.threads`, and its
+ * messages carried no id and no timestamp. The restore path merges its own
+ * mount-time read of that array with the copy ChatHistoryStore.load() resolves
+ * to, and the merge sorted timestamp-less records by their content-hash id.
+ *
+ * Measured against this exact seed before the fix:
+ *
+ *     stored   u1 a1 u2 a2 u3 a3
+ *     painted  a3 u1 u2 a1 a2 u3
+ *
+ * This spec is deliberately agent-free and never sends a message: the defect is
+ * in hydration, and seeding at document start is the only way to reproduce a
+ * bundle-version boundary the harness cannot otherwise cross.
+ */
+import { test, expect } from './fixtures/panelTest'
+import { routeWorktreeSource } from './fixtures/worktreeSource'
+
+test.beforeEach(async ({ context }) => {
+  await routeWorktreeSource(context)
+})
+
+const LEGACY_THREAD_ID = '11111111-2222-3333-4444-555555555555'
+const USER_TEXTS = ['legacy first 1516', 'legacy second 1516', 'legacy third 1516']
+
+test('#1516: a pre-0.11 transcript hydrates in the order it was written', async ({
+  page,
+  panel,
+  context
+}) => {
+  // Seeded at document start, so the panel's synchronous restore reads exactly
+  // what the older bundle left behind — no id, no createdAt, no ts, and a BARE
+  // ARRAY under the pre-v3 key.
+  await context.addInitScript(
+    ({ threadId, texts }) => {
+      const msgs: Array<Record<string, string>> = []
+      texts.forEach((text: string, i: number) => {
+        msgs.push({ role: 'user', text })
+        msgs.push({ role: 'agent', text: `legacy reply ${i}` })
+      })
+      localStorage.removeItem('comfyui-mcp.panel.historySnapshot')
+      localStorage.removeItem('comfyui-mcp.panel.historyMeta')
+      localStorage.setItem(
+        'comfyui-mcp.panel.threads',
+        JSON.stringify([
+          { id: threadId, ts: Date.now() - 60_000, workflowKey: 'panel:global', msgs }
+        ])
+      )
+      sessionStorage.setItem('comfyui-mcp.panel.currentThreadId', threadId)
+    },
+    { threadId: LEGACY_THREAD_ID, texts: USER_TEXTS }
+  )
+
+  await panel.goto()
+  await panel.openSidebar()
+  await expect(panel.userBubble(USER_TEXTS[2])).toBeVisible()
+
+  // Settle the async durable hydration: the synchronous paint-only pass reads the
+  // shadow, and the merge that used to shuffle the transcript runs after
+  // IndexedDB and settings resolve.
+  await expect
+    .poll(async () =>
+      page.evaluate(() =>
+        [...document.querySelectorAll('.cmcp-root .cmcp-bubble')].map((el) =>
+          (el as HTMLElement).innerText.trim().split('\n')[0]
+        )
+      )
+    )
+    .toEqual([
+      'legacy first 1516',
+      'legacy reply 0',
+      'legacy second 1516',
+      'legacy reply 1',
+      'legacy third 1516',
+      'legacy reply 2'
+    ])
+
+  // Each prompt appears ONCE. The reporter read the reshuffle as a repeat, so
+  // assert the count too rather than only the order.
+  for (const text of USER_TEXTS) {
+    await expect(panel.userBubbles.filter({ hasText: text })).toHaveCount(1)
+  }
+
+  // What was painted is what got persisted: a second reload must not shuffle it
+  // back, and the durable record must not keep the scrambled order either.
+  await expect
+    .poll(async () =>
+      page.evaluate(() => {
+        const raw = localStorage.getItem('comfyui-mcp.panel.historySnapshot')
+        if (!raw) return null
+        const thread = JSON.parse(raw).threads.find(
+          (t: { id: string }) => t.id === '11111111-2222-3333-4444-555555555555'
+        )
+        return thread ? thread.msgs.map((m: { text: string }) => m.text) : null
+      })
+    )
+    .toEqual([
+      'legacy first 1516',
+      'legacy reply 0',
+      'legacy second 1516',
+      'legacy reply 1',
+      'legacy third 1516',
+      'legacy reply 2'
+    ])
+})

--- a/browser_tests/unit/legacy-transcript-order.test.mjs
+++ b/browser_tests/unit/legacy-transcript-order.test.mjs
@@ -21,6 +21,8 @@
  */
 import assert from 'node:assert/strict'
 import test from 'node:test'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
 
 import { mergeHistorySnapshots } from '../../web/js/lib/chat-history-store.js'
 
@@ -92,4 +94,41 @@ test('#1516: timestamped messages still interleave by TIME, not by position', ()
 test('#1516: a single snapshot was already in order and stays that way', () => {
   const only = mergeHistorySnapshots({ threads: [legacyThread(CONVERSATION)], meta: {} })
   assert.deepEqual(textsOf(only), CONVERSATION)
+})
+
+/**
+ * The precondition the tiebreak rests on.
+ *
+ * The rank only ever decides an order when the timestamp comparison ties, and it
+ * can only tie when BOTH messages lack a usable time. `normalizeMessage` floors a
+ * time-less message at createdAt:1, so a live transcript stays timestamp-ordered
+ * exactly as long as the panel keeps stamping every message it records. There is
+ * one writer — `record()` is the only place anything reaches `thread.msgs` — so
+ * this is a one-line invariant, and if a later edit drops it the rank silently
+ * starts re-ordering a MODERN conversation instead of repairing a legacy one.
+ *
+ * Scoped to record()'s own body on purpose: a body-wide scan of the 38k-line panel
+ * would be satisfied by any sibling that happens to mention createdAt.
+ */
+test('#1516: record() stamps createdAt on every entry, which is what keeps live transcripts time-ordered', () => {
+  const panelUrl = new URL('../../web/js/comfyui-mcp-panel.js', import.meta.url)
+  const source = readFileSync(fileURLToPath(panelUrl), 'utf8').replace(/\r\n/g, '\n')
+  const start = source.indexOf('\n  function record(entry) {')
+  assert.notEqual(start, -1, 'could not locate record()')
+  const end = source.indexOf('\n  }\n', source.indexOf('thread.msgs.push(entry);', start))
+  assert.ok(end > start, 'could not locate the end of record()')
+  const body = source.slice(start, end)
+  assert.match(
+    body,
+    /if \(!Number\(entry\.createdAt\)\) entry\.createdAt = now;[\s\S]{0,400}?thread\.msgs\.push\(entry\);/,
+    'record() must stamp createdAt BEFORE the entry reaches thread.msgs'
+  )
+})
+
+test('#1516: record() is still the only path into thread.msgs', () => {
+  const panelUrl = new URL('../../web/js/comfyui-mcp-panel.js', import.meta.url)
+  const source = readFileSync(fileURLToPath(panelUrl), 'utf8').replace(/\r\n/g, '\n')
+  // A second writer would be a second place a message can arrive without a time.
+  const pushes = source.match(/\.msgs\.push\(/g) || []
+  assert.equal(pushes.length, 1, 'a new thread.msgs writer must also stamp createdAt (see #1516)')
 })

--- a/browser_tests/unit/legacy-transcript-order.test.mjs
+++ b/browser_tests/unit/legacy-transcript-order.test.mjs
@@ -1,0 +1,95 @@
+/**
+ * #1516 — a hard refresh across the 0.7.x -> 0.15.x panel boundary re-ordered the
+ * user's transcript, so their earliest prompts came back BELOW the agent's last
+ * reply and read as a replay of the conversation.
+ *
+ * A pre-v3 panel (anything before 0.11.0, which is where IndexedDB and the
+ * atomic snapshot key arrived) wrote a BARE ARRAY of threads under
+ * `comfyui-mcp.panel.threads`, and its messages carried no `id`, no `createdAt`
+ * and no `ts`. On the next mount the current panel normalizes those records —
+ * floor `createdAt` at 1, mint `legacy-<content hash>` ids — and then merges its
+ * in-memory copy with the one `ChatHistoryStore.load()` returns.
+ *
+ * That merge sorts. With every message pinned at createdAt:1 the timestamp
+ * comparison is a dead heat for the whole thread, so the tiebreak decided the
+ * order — and the tiebreak was the message id, which for these records is a hash
+ * of the message's own text. The transcript came back in hash order.
+ *
+ * These tests pin the ORDER, not the merge's dedupe (which has its own coverage
+ * in chat-history-store.test.mjs). Delete the rank tiebreak in
+ * mergeThreadMessages and the first two go red.
+ */
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { mergeHistorySnapshots } from '../../web/js/lib/chat-history-store.js'
+
+const THREAD_ID = '11111111-2222-3333-4444-555555555555'
+
+/** A thread exactly as a pre-0.11.0 panel left it: no message ids, no times. */
+function legacyThread(texts, overrides = {}) {
+  return {
+    id: THREAD_ID,
+    ts: 1_700_000_000_000,
+    workflowKey: 'panel:global',
+    msgs: texts.map((text, i) => ({ role: i % 2 === 0 ? 'user' : 'agent', text })),
+    ...overrides
+  }
+}
+
+const CONVERSATION = ['u1', 'a1', 'u2', 'a2', 'u3', 'a3']
+
+const textsOf = (snapshot) => snapshot.threads[0].msgs.map((m) => m.text)
+
+test('#1516: merging two copies of a pre-v3 thread keeps the stored order', () => {
+  // The panel's own restore does exactly this: it merges the snapshot it read
+  // synchronously at mount with the one ChatHistoryStore.load() resolves to.
+  const first = mergeHistorySnapshots({ threads: [legacyThread(CONVERSATION)], meta: {} })
+  const merged = mergeHistorySnapshots(
+    { threads: first.threads, meta: first.meta },
+    { threads: first.threads, meta: first.meta }
+  )
+  assert.deepEqual(
+    textsOf(merged),
+    CONVERSATION,
+    'a timestamp-less transcript must not be re-ordered by the merge'
+  )
+})
+
+test('#1516: the order survives the round trip a reload actually makes', () => {
+  // Merge, persist, read back, merge again — a second reload must not shuffle
+  // what the first one settled on.
+  let snapshot = mergeHistorySnapshots({ threads: [legacyThread(CONVERSATION)], meta: {} })
+  for (let reload = 0; reload < 3; reload += 1) {
+    const roundTripped = JSON.parse(JSON.stringify(snapshot))
+    snapshot = mergeHistorySnapshots(
+      { threads: roundTripped.threads, meta: roundTripped.meta },
+      { threads: snapshot.threads, meta: snapshot.meta }
+    )
+    assert.deepEqual(textsOf(snapshot), CONVERSATION, `reload ${reload + 1} re-ordered the transcript`)
+  }
+})
+
+test('#1516: timestamped messages still interleave by TIME, not by position', () => {
+  // The rank tiebreak must never outrank a real clock — two tabs writing
+  // concurrently still merge causally. `later` is appended to the merge AFTER
+  // `earlier`, so position alone would put it last; its timestamp must win.
+  const withTimes = (msgs) => ({
+    id: THREAD_ID,
+    ts: 1_700_000_000_000,
+    workflowKey: 'panel:global',
+    msgs
+  })
+  const earlier = withTimes([
+    { id: 'm-a', role: 'user', text: 'a', createdAt: 3000 },
+    { id: 'm-c', role: 'user', text: 'c', createdAt: 5000 }
+  ])
+  const later = withTimes([{ id: 'm-b', role: 'agent', text: 'b', createdAt: 4000 }])
+  const merged = mergeHistorySnapshots({ threads: [earlier], meta: {} }, { threads: [later], meta: {} })
+  assert.deepEqual(textsOf(merged), ['a', 'b', 'c'])
+})
+
+test('#1516: a single snapshot was already in order and stays that way', () => {
+  const only = mergeHistorySnapshots({ threads: [legacyThread(CONVERSATION)], meta: {} })
+  assert.deepEqual(textsOf(only), CONVERSATION)
+})

--- a/web/js/lib/chat-history-store.js
+++ b/web/js/lib/chat-history-store.js
@@ -941,8 +941,27 @@ function mergeThreadMessages(older, newer) {
   const oldMessages = Array.isArray(older?.msgs) ? older.msgs : [];
   const newMessages = Array.isArray(newer?.msgs) ? newer.msgs : [];
   const byId = new Map();
+  // The TIEBREAK, and it is the whole of #1516. A pre-v3 transcript carries no
+  // per-message timestamp, so normalizeMessage floors every one of its messages
+  // at createdAt:1 — which makes the timestamp comparison below a dead heat for
+  // the ENTIRE thread. The old tiebreak was the message id, and a pre-v3
+  // message's id is `legacy-<hash of its own content>`: sorting on it dealt the
+  // user's conversation back in content-hash order. Measured on a six-message
+  // legacy thread crossing the 0.7.x -> 0.15.x boundary the reporter hit:
+  //
+  //     stored   u1, a1, u2, a2, u3, a3
+  //     painted  a2, u3, a3, a1, u2, u1
+  //
+  // The user's first two prompts land after the agent's LAST reply, which is
+  // what "refreshing the page repeated my initial messages" looks like from the
+  // chat pane. Position in the source arrays is the order those records were
+  // actually written in, so rank by that instead. Timestamped messages are
+  // untouched: their comparison resolves before this ever runs, so cross-tab
+  // causal interleaving keeps deciding by time.
+  const rank = new Map();
   for (const message of [...oldMessages, ...newMessages]) {
     const previous = byId.get(message.id);
+    if (!rank.has(message.id)) rank.set(message.id, rank.size);
     if (!previous || compareRevisions(message.revision || message, previous.revision || previous) > 0) {
       byId.set(message.id, message);
     }
@@ -950,6 +969,7 @@ function mergeThreadMessages(older, newer) {
   return [...byId.values()].sort(
     (a, b) =>
       finiteTs(a.createdAt || a.ts) - finiteTs(b.createdAt || b.ts) ||
+      (rank.get(a.id) ?? 0) - (rank.get(b.id) ?? 0) ||
       String(a.id).localeCompare(String(b.id)),
   );
 }


### PR DESCRIPTION
Fixes #1516

## What the user saw

After a cache-bypassing reload that crossed a panel bundle boundary (the tab had
been open since before an in-place ComfyUI-Manager update — see #1515), the user
reported: *"refreshing the page seems to have repeated my initial messages to you."*
The agent confirmed nothing was re-sent: no duplicate prompts reached its context.
So the issue filed this as a transcript-**rendering** symptom, and that is exactly
what it is.

## Mechanism

A pre-0.11.0 panel — everything before IndexedDB and the atomic snapshot key
existed, which is the era of a tab that advertises **no** `panel_version` — wrote a
**bare array** of threads under `comfyui-mcp.panel.threads`, and its messages
carried no `id`, no `createdAt` and no `ts`.

On the next mount the current panel normalizes those records: it floors
`createdAt` at `1` (`normalizeMessage`) and mints a synthetic
`legacy-<stableHash(threadId:ordinal:canonicalJson(message))>` id. Restore then
merges its own mount-time read with the copy `ChatHistoryStore.load()` resolves
to (`comfyui-mcp-panel.js`, `historyRestoreReady`):

```js
const merged = mergeHistorySnapshots({ threads, meta: historyMeta }, loaded)
```

`mergeThreadMessages` sorts that union:

```js
finiteTs(a.createdAt || a.ts) - finiteTs(b.createdAt || b.ts) ||
String(a.id).localeCompare(String(b.id))
```

With every message pinned at `createdAt: 1` the timestamp comparison is a dead
heat **for the whole thread**, so the tiebreak decides — and for these records the
tiebreak is a hash of the message's own text. The conversation is dealt back in
content-hash order.

## Evidence — reproduced, not reasoned

Seeded the exact pre-0.11 shape at document start and loaded the real panel in
Chromium (`browser_tests/legacy-transcript-order.spec.ts`). What the sidebar
painted, verbatim from the run, **before** the fix:

```
stored   u1  a1  u2  a2  u3  a3
painted  a3  u1  u2  a1  a2  u3
```

Rendered chat pane before:

```
legacy reply 2 / legacy first 1516 / legacy second 1516 / legacy reply 0 / legacy reply 1 / legacy third 1516
```

after:

```
legacy first 1516 / legacy reply 0 / legacy second 1516 / legacy reply 1 / legacy third 1516 / legacy reply 2
```

The user's first two prompts land **below the agent's last reply**. Scrolled to the
bottom of a fresh reload, that reads as your earlier messages showing up again.

## The fix

One tiebreak in `mergeThreadMessages`: rank by the position the message held in
the source arrays — the order those records were actually written in — before
falling back to the id. Timestamped messages are untouched, because their
comparison resolves first, so cross-tab causal interleaving still decides by time.

## Verification

- `npm run test:unit` — **6004 pass / 0 fail** (4 new).
- `npm run typecheck` — clean.
- Playwright, `--workers=1` — the new spec passes against a real ComfyUI + panel.
- **Mutation-verified in three directions**, not just "the suite is green":
  - delete the rank tiebreak → the two order tests fail, the two control tests stay green, **and the browser spec fails** (`Expected - 2 / Received + 2`);
  - move the rank tiebreak *above* the clock → only `timestamped messages still interleave by TIME` fails, proving that guard is load-bearing and not decorative;
  - restore → all four green again.

## What I deliberately did NOT do

- **The ordinal-shift identity hazard.** The synthetic legacy id embeds the
  message's ordinal, so two copies of one thread that disagree on ordinals mint
  different ids for the same message and the merge **duplicates** it. I reproduced
  that at module level (a 6-message thread merged with its own 4-message tail
  yields 10). It is already fenced in production by
  `mergeUnderCanonicalCheckpoint` — a flagged pre-v3 snapshot is quarantined
  wholesale against a fenced canonical, and replaced as a unit against an
  unfenced one — and I could not construct a production path that reaches the
  unguarded merge with shifted ordinals. Widening the fix to cover it would mean
  changing legacy message identity, which is a much larger change than this
  issue's evidence supports. Flagged here rather than silently dropped.
- **Nothing agent-facing.** No change to `armVisibleTranscriptReplay` /
  `buildReplayTranscript`; the issue's own agent-side evidence says nothing was
  re-sent, and my reading agrees — the panel has no server frame that replays a
  transcript into the chat pane.

## Unrelated observation from the harness (not fixed here)

The FIRST message sent on an unsaved canvas is refused by the #1095 route guard:
grounding auto-saves the workflow, the tab identity flips `tmp:` → `wf:` mid-dispatch,
and `sendUserMessage` returns false. Reproduced with frame logging; the second send
goes through. This currently breaks every e2e spec whose first action is
`sendMessage` (`pending-queue.spec.ts` fails on unmodified `main` on this box for
exactly this reason). Not this PR's scope, and this spec is deliberately agent-free
so it does not depend on it — but it is worth its own issue.

## Review

**Review is PENDING.** Not gated, not reviewed, no verdict claimed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
