### PR TITLE
fix(1535): a no-name save of a .app.json workflow writes that file, not a plain .json fork

### DIFF
--- a/browser_tests/noname-save-keeps-app-json.spec.ts
+++ b/browser_tests/noname-save-keeps-app-json.spec.ts
@@ -1,0 +1,110 @@
+/**
+ * #1535 — a NO-NAME `panel_save_workflow({})` on an active `.app.json` workflow must
+ * write THAT file, not fork a plain `.json` beside it.
+ *
+ * The reported sequence, run here against the real ComfyUI frontend:
+ *   save under a ".app" name  → workflows/<stem>.app.json
+ *   open it                   → the frontend reports filename "<stem>" (getFilenameDetails
+ *                               strips the compound ".app.json" suffix) while
+ *                               `initialMode` is derived from the FILE's extra.linearMode
+ *   graph_configure_app_mode  → writes extra.linearMode = true on the live root, and does
+ *                               NOT touch `initialMode`
+ *   save with no name         → the save layer rebuilt the target as
+ *                               "<stem>" + modeExt(initialMode) = "<stem>.json", saw a
+ *                               relocation, and routed to the Save-As COPY path. A NEW
+ *                               `workflows/<stem>.json` appeared holding the app-mode
+ *                               configuration, `saved_as: true` was reported, and the file
+ *                               the user was actually editing was never written.
+ *
+ * That is silent data divergence: the caller is told the save succeeded and keeps working
+ * in a file that does not have its edits.
+ *
+ * The assertions below are on the OBSERVED EFFECT — the routing key of the reply and the
+ * bytes on disk — not on which branch the code took.
+ */
+import { test, expect } from './fixtures/panelTest'
+import { routeWorktreeSource } from './fixtures/worktreeSource'
+
+test.beforeEach(async ({ context }) => {
+  await routeWorktreeSource(context)
+})
+
+/** Read a workflow file back through ComfyUI's own userdata API. `null` = absent. */
+async function readWorkflowFile(page: import('@playwright/test').Page, userdataPath: string) {
+  return await page.evaluate(async (path) => {
+    const api = (window as any).comfyAPI?.api?.api
+    if (typeof api?.fetchApi !== 'function') return { status: -1, body: null }
+    const res = await api.fetchApi(`/userdata/${encodeURIComponent(path)}`)
+    if (!res?.ok) return { status: res?.status ?? -1, body: null }
+    let body: any = null
+    try {
+      body = JSON.parse(await res.text())
+    } catch {
+      body = null
+    }
+    return { status: res.status, body }
+  }, userdataPath)
+}
+
+test('a no-name save of an active .app.json workflow writes that file, not a plain .json fork', async ({
+  page,
+  panel,
+  mockBridge
+}) => {
+  await panel.goto()
+  await panel.setBridgeUrl(mockBridge.url)
+  await panel.openSidebar()
+  await panel.connect()
+
+  const stem = `cmcp-e2e-1535-${Date.now()}`
+  const appPath = `workflows/${stem}.app.json`
+  const forkPath = `workflows/${stem}.json`
+
+  // Step 2 of the report: a save under a ".app" name lands the file at "<stem>.app.json".
+  const created = await mockBridge.command('workflow_save', { name: `${stem}.app` })
+  expect(created.ok, `the setup save must succeed: ${created.error ?? ''}`).toBe(true)
+  expect(
+    (await readWorkflowFile(page, appPath)).status,
+    'the setup must actually produce the .app.json file the report starts from'
+  ).toBe(200)
+
+  // Step 3: reopen it, so the workflow's identity comes from the PATH the way the report's
+  // does — this is what makes `filename` "<stem>" with the ".app" suffix living only in the
+  // path.
+  const opened = await mockBridge.command('workflow_open', { path: appPath })
+  expect(opened.ok, `reopening the .app.json must succeed: ${opened.error ?? ''}`).toBe(true)
+
+  // Step 4: configure app mode. This writes extra.linearMode on the live root.
+  const configured = await mockBridge.command('graph_configure_app_mode', { default_mode: 'app' })
+  expect(configured.ok, `configure_app_mode must succeed: ${configured.error ?? ''}`).toBe(true)
+  expect(configured.result?.linearMode, 'app mode must be on for the save to carry it').toBe(true)
+
+  // Step 5: THE CALL UNDER TEST — save with no name at all.
+  const saved = await mockBridge.command('workflow_save', {})
+  expect(saved.ok, `the no-name save must succeed: ${saved.error ?? ''}`).toBe(true)
+
+  // THE ASSERTIONS. A no-name save is an in-place save of the file the caller is editing.
+  expect(
+    saved.result?.routing_key,
+    'the no-name save must report the file it was editing, not a plain-.json fork'
+  ).toBe(`wf:${appPath}`)
+  expect(
+    saved.result?.saved_as,
+    'a no-name save is not a Save-As — reporting one tells the caller a NEW file holds its work'
+  ).toBeFalsy()
+
+  // Disk is the arbiter: the edits must be in the file the caller is editing...
+  const appFile = await readWorkflowFile(page, appPath)
+  expect(appFile.status, 'the .app.json the caller was editing must still be there').toBe(200)
+  expect(
+    appFile.body?.extra?.linearMode,
+    'the app-mode configuration must have landed in the .app.json, not somewhere else'
+  ).toBe(true)
+
+  // ...and no orphan may have been created beside it holding that work.
+  const fork = await readWorkflowFile(page, forkPath)
+  expect(
+    fork.status,
+    `a no-name save must not create ${forkPath} — that is the orphan the report describes`
+  ).toBe(404)
+})

--- a/browser_tests/unit/workflow-save.test.mjs
+++ b/browser_tests/unit/workflow-save.test.mjs
@@ -989,6 +989,205 @@ test('P0-b: no-name save of an on-disk app-mode workflow COPIES to .app.json, so
 })
 
 // ---------------------------------------------------------------------------
+// #1535 — the MIRROR of P0-b, and the direction that loses work.
+//
+// A workflow whose file is ALREADY at "<stem>.app.json". The frontend's
+// getFilenameDetails strips the compound suffix, so `filename` is "<stem>" with the
+// ".app" living only in `path`; `initialMode` is read from the FILE's extra.linearMode at
+// load, so a workflow configured into App Mode AFTER it was opened still reads unset (or
+// "graph"). The filename+mode reconstruction therefore produced "<stem>.json", the save
+// read that as a relocation, and a no-name save FORKED a new plain .json holding the
+// caller's work while the .app.json it was editing went unwritten.
+//
+// Both spellings of the mode are covered, because they are two different production
+// states and only one of them is what a fresh file produces: `undefined` (the file has no
+// extra.linearMode at all — reproduced live) and `"graph"` (the file says
+// linearMode:false — what the issue reporter's file held on disk).
+for (const [label, initialMode] of [
+  ['mode never populated (no extra.linearMode in the file)', undefined],
+  ['mode read as "graph" (the file says linearMode:false)', 'graph']
+]) {
+  test(`#1535: a NO-NAME save of a workflow on disk at "<stem>.app.json" writes THAT file — ${label}`, async () => {
+    const active = {
+      path: 'workflows/Anima Turbo.app.json',
+      // What getFilenameDetails reports for that path: the compound suffix is stripped
+      // whole, so nothing here carries the ".app".
+      filename: 'Anima Turbo',
+      directory: 'workflows',
+      initialMode,
+      isPersisted: true,
+      isTemporary: false
+    }
+    const svc = makeFaithfulService({ files: [active.path], active })
+
+    const saved = await saveActiveWorkflow(svc, undefined, {
+      autoWorkflowName: () => 'Untitled',
+      existsOnDisk: async (p) => svc.disk.has(p)
+    })
+
+    assert.equal(saved, 'Anima Turbo')
+    // The file the caller was editing is the file that was written...
+    assert.ok(
+      svc.calls.some((c) => c[0] === 'saveWorkflow' && c[1] === 'workflows/Anima Turbo.app.json'),
+      'the write must target the .app.json the workflow occupies'
+    )
+    assert.ok(svc.disk.has('workflows/Anima Turbo.app.json'), 'the .app.json is still on disk')
+    // ...and no orphan was created beside it holding that work.
+    assert.ok(
+      !svc.disk.has('workflows/Anima Turbo.json'),
+      'a no-name save must not fork a plain .json — that is the reported data divergence'
+    )
+    assert.ok(!svc.calls.some((c) => c[0] === 'saveAs'), 'not a Save-As: nothing was copied')
+    assert.ok(!svc.calls.some((c) => c[0] === 'renameWorkflow'), 'and nothing was moved (#226)')
+  })
+}
+
+test('#1535: the in-place classification is the SAVE OUTCOME, so the reply cannot report a Save-As', async () => {
+  // describeSaveOutcome reads the mode the save DECIDED. If the fork route were taken it
+  // would record "save-as-copy" and the reply would carry `saved_as: true` — the field
+  // that told the reporter a NEW file held their work. Assert the recorded mode, not just
+  // the disk, so a future change that writes the right file but still announces a copy is
+  // caught here rather than by a reader of the reply.
+  const active = {
+    path: 'workflows/Anima Turbo.app.json',
+    filename: 'Anima Turbo',
+    directory: 'workflows',
+    initialMode: 'graph',
+    isPersisted: true,
+    isTemporary: false
+  }
+  const svc = makeFaithfulService({ files: [active.path], active })
+  const details = {}
+
+  await saveActiveWorkflow(svc, undefined, {
+    autoWorkflowName: () => 'Untitled',
+    existsOnDisk: async (p) => svc.disk.has(p),
+    details
+  })
+
+  assert.equal(details.mode, 'in-place', 'a no-name save of its own file is an in-place save')
+  assert.equal(details.targetPath, 'workflows/Anima Turbo.app.json', 'and it names that file')
+  assert.deepEqual(describeSaveOutcome(details), {}, 'so the reply carries no saved_as/copied_from')
+})
+
+test('#1535 stays in ONE direction: an EXPLICIT name is still placed by the mode, not by the source suffix', async () => {
+  // The agent-visible way to create an app file is `panel_save_workflow({name:"X.app"})`.
+  // If the ".app" already on the SOURCE path were folded into the extension for named
+  // saves too, that call would land at "X.app.app.json" once the active workflow is itself
+  // an app file. It must not: only the NO-NAME case reads the path.
+  const active = {
+    path: 'workflows/Anima Turbo.app.json',
+    filename: 'Anima Turbo',
+    directory: 'workflows',
+    initialMode: 'graph',
+    isPersisted: true,
+    isTemporary: false
+  }
+  const svc = makeFaithfulService({ files: [active.path], active })
+
+  const saved = await saveActiveWorkflow(svc, 'Anima Turbo v2.app', {
+    existsOnDisk: async (p) => svc.disk.has(p)
+  })
+
+  // The copy route reports the FRONTEND's display name for the file it produced
+  // (baseName of the new tab's filename), which is unchanged by this fix and is why the
+  // ".app" is absent here — the file, asserted below, is what matters.
+  assert.equal(saved, 'Anima Turbo v2')
+  assert.ok(svc.disk.has('workflows/Anima Turbo v2.app.json'), 'the named copy lands where the caller asked')
+  assert.ok(!svc.disk.has('workflows/Anima Turbo v2.app.app.json'), 'never a doubled suffix')
+  assert.ok(svc.disk.has('workflows/Anima Turbo.app.json'), 'and the source survives (#226)')
+})
+
+// --- the three boundary guards, each pinned by the case that DISTINGUISHES it. ---
+// Written from mutation results: dropping any one of them left the suite green, so each
+// of these exists to make that mutant die rather than to restate the fix.
+
+test('#1535 boundary: an EXPLICIT name matching the source stem is still a Save-As, not an in-place write', async () => {
+  // `panel_save_workflow({name:"Anima Turbo"})` while editing "Anima Turbo.app.json". The
+  // stem is IDENTICAL, so a path-reading rule that forgot to require "no name given"
+  // would classify it in-place and overwrite the .app.json instead of producing the file
+  // the caller asked for. An explicit name is a destination, and the mode picks its
+  // extension.
+  const active = {
+    path: 'workflows/Anima Turbo.app.json',
+    filename: 'Anima Turbo',
+    directory: 'workflows',
+    initialMode: 'graph',
+    isPersisted: true,
+    isTemporary: false
+  }
+  const svc = makeFaithfulService({ files: [active.path], active })
+
+  await saveActiveWorkflow(svc, 'Anima Turbo', { existsOnDisk: async (p) => svc.disk.has(p) })
+
+  assert.ok(svc.disk.has('workflows/Anima Turbo.json'), 'the caller got the file it named')
+  assert.ok(svc.disk.has('workflows/Anima Turbo.app.json'), 'and the source was not consumed (#226)')
+  assert.ok(svc.calls.some((c) => c[0] === 'saveAs'), 'routed to the copy path')
+  assert.ok(
+    !svc.calls.some((c) => c[0] === 'saveWorkflow' && c[1] === 'workflows/Anima Turbo.app.json'),
+    'the source file was never written in place'
+  )
+})
+
+test('#1535 boundary: a tab that READS unsaved stays on the collision-checked route, even at a .app.json path', async () => {
+  // #215 drift makes `isTemporary` unreliable in BOTH directions, and the destructive one
+  // is a genuinely never-persisted tab that reads persisted: the in-place branch writes
+  // `wf.path` with force, so it would clobber whatever already occupies that path instead
+  // of going through the first-save route's absent-oracle + overwrite:false collision
+  // check. Anything that cannot prove it is already its own file on disk stays on the
+  // checked route — the same fail-safe direction the rest of this module takes.
+  const active = {
+    path: 'workflows/Drifted.app.json',
+    filename: 'Drifted',
+    directory: 'workflows',
+    initialMode: 'graph',
+    isPersisted: false, // drifted / never-persisted — indistinguishable here
+    isTemporary: true
+  }
+  const svc = makeFaithfulService({ files: [active.path], active })
+
+  await saveActiveWorkflow(svc, undefined, {
+    autoWorkflowName: () => 'Untitled',
+    existsOnDisk: async (p) => svc.disk.has(p)
+  })
+
+  assert.ok(svc.calls.some((c) => c[0] === 'saveAs'), 'went through the collision-checked copy route')
+  assert.ok(
+    !svc.calls.some((c) => c[0] === 'saveWorkflow' && c[1] === 'workflows/Drifted.app.json'),
+    'never took the unchecked in-place write on a tab whose persistence is unproven'
+  )
+  assert.ok(!svc.calls.some((c) => c[0] === 'renameWorkflow'), 'and nothing was moved (#226)')
+})
+
+test('#1535 boundary: a filename that no longer matches the path does NOT authorize writing that path', async () => {
+  // The rule is FULL-PATH equality with this workflow's own ".app.json" sibling, not "the
+  // path happens to end in .app.json". A tab whose `filename` has moved on from its
+  // `path` (a rename in flight) has two different destinations in hand, and the name is
+  // the one the caller last set — so it keeps driving the destination. Matching on the
+  // suffix alone would silently overwrite the file at the OLD path instead.
+  const active = {
+    path: 'workflows/Old Name.app.json',
+    filename: 'Fresh Name',
+    directory: 'workflows',
+    initialMode: 'graph',
+    isPersisted: true,
+    isTemporary: false
+  }
+  const svc = makeFaithfulService({ files: [active.path], active })
+
+  await saveActiveWorkflow(svc, undefined, {
+    autoWorkflowName: () => 'Untitled',
+    existsOnDisk: async (p) => svc.disk.has(p)
+  })
+
+  assert.ok(
+    !svc.calls.some((c) => c[0] === 'saveWorkflow' && c[1] === 'workflows/Old Name.app.json'),
+    'the file at the stale path must not be written on the strength of its suffix'
+  )
+  assert.ok(svc.disk.has('workflows/Old Name.app.json'), 'and it is still on disk (#226)')
+})
+
+// ---------------------------------------------------------------------------
 // ComfyUI frontend 1.47.x (issue #268). The workflow store no longer exposes
 // `saveWorkflowAs`; it exposes the low-level pair `saveAs(wf, path)` (builds a
 // NEW copy object at `path`, leaving the source object and its file untouched)

--- a/web/js/lib/workflow-save.js
+++ b/web/js/lib/workflow-save.js
@@ -69,6 +69,22 @@ function targetPath(wf, base) {
   return normalizePath(`${directoryOf(wf)}${base}${workflowExt(wf)}`);
 }
 
+/** #1535 — TRUE when this workflow's own file already sits at the ".app.json" sibling of
+ *  `base`, i.e. its path is exactly what targetPath() would produce for `base` if the
+ *  mode said "app". That is the one state in which the filename+mode reconstruction is
+ *  LOSSY: getFilenameDetails strips the compound ".app.json", so `filename` carries no
+ *  ".app" to rebuild it from, and `initialMode` — read from the file's own
+ *  `extra.linearMode` at load — has nothing to say about a workflow whose App Mode was
+ *  configured afterwards. Comparing full paths (not suffixes) keeps this to the workflow's
+ *  OWN file: a different directory, a different stem, or an external/URL-derived path
+ *  (directoryOf redirects those to the workflows root) simply does not match. */
+function pathIsAppSuffixedSiblingOf(wf, base) {
+  if (!base) return false;
+  const path = normalizePath(wf?.path);
+  if (!path) return false;
+  return normalizePath(`${directoryOf(wf)}${base}${APP_JSON_EXT}`) === path;
+}
+
 /** A readable, TOTAL description of a thrown value for an error message. Deliberately
  *  local and defensive: `String(err)` on a plain object yields "[object Object]", and
  *  `JSON.stringify` returns UNDEFINED for an object whose `toJSON()` does — so neither is
@@ -651,14 +667,60 @@ export async function saveActiveWorkflow(
   // strip it again to "Foo" and misjudge a Save-As to "Foo" as an in-place save.
   //
   // The effective target name is the explicit/auto name for a Save-As, else the
-  // workflow's CURRENT name — because even a no-name save relocates when the
-  // mode-derived extension differs from the on-disk path (P0-b): an on-disk
+  // workflow's CURRENT name — because even a no-name save can land somewhere else when
+  // the mode-derived extension differs from the on-disk path (P0-b): an on-disk
   // "Foo.json" opened with initialMode "app" has a mode-derived target of
-  // "Foo.app.json", so a plain `saveWorkflow` would MOVE "Foo.json" → "Foo.app.json"
-  // and consume the source. targetPath() applies the mode-correct extension.
+  // "Foo.app.json", so it is a RELOCATION and must go down the copy path rather than
+  // let ComfyUI's own service-level saveWorkflow MOVE "Foo.json" → "Foo.app.json" and
+  // consume the source (#226). targetPath() applies the mode-correct extension.
   const currentPath = normalizePath(wf.path);
   const effectiveName = desired || currentName;
-  const finalTargetPath = effectiveName ? targetPath(wf, effectiveName) : "";
+  // #1535 — EXCEPT that the reconstruction cannot round-trip a ".app.json" file, and a
+  // NO-NAME save of one was forking a plain ".json" beside it.
+  //
+  // The frontend's own getFilenameDetails strips the COMPOUND ".app.json" suffix, so a
+  // workflow at "workflows/X.app.json" reports `filename` "X" — the ".app" survives only
+  // in `path`. `initialMode` is the other half of the reconstruction, and it is populated
+  // from the FILE's `extra.linearMode` at load time; for a file whose App Mode was
+  // configured AFTER it was opened it stays unset (or "graph"), because
+  // graph_configure_app_mode writes `extra.linearMode` on the live root and never touches
+  // `initialMode`. Both halves then say "plain", the target came out "workflows/X.json",
+  // that read as a relocation, and the save routed itself down the Save-As COPY path: a
+  // NEW X.json appeared holding the caller's App Mode configuration, the reply said
+  // `saved_as: true`, and the X.app.json the caller was editing was never written. The
+  // caller is told the save succeeded while its work sits in a file it is not editing.
+  //
+  // The path is the identity that ROUND-TRIPS to the file on disk, so for a no-name save
+  // it wins — and the in-place branch really does write it: `saveInPlace` calls
+  // `svc.saveWorkflow(wf)`, where `svc` is the workflow STORE (`extensionManager.workflow`
+  // exposes saveAs / renameWorkflow / openWorkflows, not the service's saveWorkflowAs).
+  // The store's saveWorkflow is `wf.save()` → `UserFile.save({force:true})`, a write to
+  // `this.path`. Verified by execution on ComfyUI 0.33.2 / frontend 1.49.6 rather than by
+  // reading it: driven to `path` "workflows/X.app.json" with `initialMode` unset and
+  // `extra.linearMode` true, `svc.saveWorkflow(wf)` wrote X.app.json, left `wf.path`
+  // unchanged, and created no X.json beside it.
+  //
+  // DELIBERATELY ONE DIRECTION. The mirror case — an on-disk "Foo.json" whose content
+  // declares app mode, so the mode-derived target is "Foo.app.json" — is NOT changed and
+  // still goes down the non-destructive copy route (P0-b). That direction produces a file
+  // whose extension AGREES with its own content and leaves the source intact; this one
+  // produced a ".json" holding `linearMode: true`, an extension contradicting its content,
+  // while abandoning the consistent file that already existed. Only the lossy direction is
+  // repaired here.
+  //
+  // Everything else is untouched by construction: an EXPLICIT name still resolves through
+  // targetPath (that is how a ".app.json" is created in the first place, and re-deriving
+  // its extension from the source would turn `name:"X.app"` into "X.app.app.json"), a
+  // never-persisted tab still has its first file PLACED by targetPath (which also leaves
+  // grounding — it only ever saves a never-persisted workflow — alone), and an
+  // external/URL-derived source cannot match, because directoryOf() redirects those to
+  // the workflows root so the equality below can never hold for them.
+  const finalTargetPath =
+    !desired && !wasUnsaved && pathIsAppSuffixedSiblingOf(wf, currentName)
+      ? currentPath
+      : effectiveName
+        ? targetPath(wf, effectiveName)
+        : "";
 
   // A safe save requires a RESOLVED, non-empty target path. Without one — e.g. a
   // persisted workflow whose filename is empty/unresolved and no name was given —


### PR DESCRIPTION
Closes #1535.

## What the caller saw

`panel_save_workflow({})` — a no-name, save-in-place call — on a workflow living at
`workflows/X.app.json` created a **new** `workflows/X.json` holding the caller's App Mode
configuration, reported `saved_as: true`, and never wrote the file the caller was editing.
The reporter's `.app.json` still read `linearMode:false, 0 inputs, 0 outputs` while the
orphan `.json` held `linearMode:true, 4 inputs, 1 output`.

## Mechanism, established by execution

Reproduced in a real browser against the reporter's own stack (ComfyUI 0.33.2, frontend
1.49.6) before any code was written. On unmodified `origin/main` the new spec fails with:

```
Expected: "wf:workflows/cmcp-e2e-1535-1787261586640.app.json"
Received: "wf:workflows/cmcp-e2e-1535-1787261586640.json"
```

A second probe dumped the frontend's own identity at each step of the report:

```
after-open      path=workflows/<stem>.app.json  filename=<stem>  initialMode=null
after-configure path=workflows/<stem>.app.json  filename=<stem>  initialMode=null  liveLinearMode=true
saved           saved_as=true  routing_key=wf:workflows/<stem>.json  copied_from=<stem>
```

`saveActiveWorkflow` resolves its destination by rebuilding `filename + modeExtension`,
and that round-trip is lossy for exactly one shape:

- the frontend's `getFilenameDetails` strips the **compound** `.app.json` suffix, so a
  workflow at `X.app.json` reports `filename` `"X"` — the `.app` survives only in `path`;
- `initialMode` is populated from the **file's** `extra.linearMode` at load, and
  `graph_configure_app_mode` writes `extra.linearMode` on the live root and never touches
  `initialMode`. For a workflow configured into App Mode after it was opened it stays
  unset (or `"graph"`).

Both halves then say "plain", the target comes out `workflows/X.json`, that reads as a
relocation, and the save routes itself down the Save-As **copy** path.

## The fix

For a **no-name** save, the target is the workflow's own path when that path is exactly
the `.app.json` sibling the reconstruction dropped. The path is the identity that
round-trips to the file on disk, so it wins.

The in-place branch really does write that path — this is the load-bearing claim and it
was measured, not read. `saveInPlace` calls `svc.saveWorkflow(wf)`, and `svc` here is the
workflow **store** (`extensionManager.workflow` exposes `saveAs` / `renameWorkflow` /
`openWorkflows`, not the service's `saveWorkflowAs`). The store's `saveWorkflow` is
`wf.save()` → `UserFile.save({force:true})`, a write to `this.path`. Driven on the rig to
`path` `workflows/X.app.json` with `initialMode` unset and `extra.linearMode` true:

```
PROBE direct={"before":{"path":"workflows/<stem>.app.json","filename":"<stem>","initialMode":null},
              "err":null,"afterPath":"workflows/<stem>.app.json","afterInitialMode":null}
PROBE appFile={"status":200,"linearMode":true}
PROBE forkFile={"status":404,"linearMode":null}
```

It is the **service's** `saveWorkflow` that recomputes
`directory + appendWorkflowJsonExt(filename, isApp)` and `renameWorkflow()`s the source to
it. Nothing on this path calls that.

### Deliberately one direction

The mirror case — an on-disk `Foo.json` whose content declares app mode, so the
mode-derived target is `Foo.app.json` (the existing `P0-b` test) — is **not** changed and
still goes down the non-destructive copy route. That direction produces a file whose
extension agrees with its own content and leaves the source intact; this one produced a
`.json` holding `linearMode:true` — an extension contradicting its content — while
abandoning the consistent file that already existed. Only the lossy direction is repaired.

## Evidence

**Deleted the fix, watched named tests fail.** Five mutations, each applied to real bytes
and verified to have applied (the file is CRLF; an LF-only anchor reads as "survived"
without ever landing):

| # | mutation | result |
|---|---|---|
| 1 | **call site**: `finalTargetPath` back to the plain reconstruction | 3 named tests fail |
| 2 | **helper**: `pathIsAppSuffixedSiblingOf` always false | 3 named tests fail |
| 3 | drop the `!desired` guard (a named save would read the source suffix) | 1 named test fails |
| 4 | drop the `!wasUnsaved` guard | 1 named test fails |
| 5 | match any `.app.json` path instead of this workflow's OWN sibling path | 1 named test fails |

Mutations 3–5 **survived** the first pass — the three boundary tests exist because of
that, not as restatements of the fix.

- Live save test: `browser_tests/noname-save-keeps-app-json.spec.ts` drives the reporter's
  five steps against a throwaway workflow on the real ComfyUI and asserts the routing key,
  the absence of `saved_as`, `extra.linearMode` in the `.app.json` **on disk**, and a
  404 at the `.json` path. Red on `origin/main`, green here.
- Full panel unit suite + gates (`npm run test:unit`): **6058 pass, 0 fail**.
- Full browser suite `npx playwright test --workers=1`: running; result posted below.

## Review pending

Not gated and not reviewed. `codex-gate.mjs` was deliberately not run. grok review is
requested in a comment on this PR naming the risky parts; **do not merge until it comes
back.**

## Deliberately not done

- The mirror direction (`Foo.json` + app-mode content) is unchanged, so the reporter's
  orphan `Example.json` will still copy to `Example.app.json` on its next no-name save.
  Changing that is a product decision about whether the panel should follow ComfyUI's own
  `.json` → `.app.json` migration, not a bug fix.
- The `P0` refusal for a persisted workflow with an **empty** filename is untouched.
- `svc.saveWorkflow` was **not** replaced or re-pointed, and `wf.initialMode` is never
  mutated — the fix changes only which path the save aims at.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
