### PR TITLE
fix(1536): a long timestamp-less transcript keeps the order it was written in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+### Fixed
+- a timestamp-less transcript longer than the local shadow keeps the order it was written in (#1536)
+
 ## [0.15.28] - 2026-08-20
 
 ### Fixed

--- a/browser_tests/unit/legacy-transcript-order.test.mjs
+++ b/browser_tests/unit/legacy-transcript-order.test.mjs
@@ -154,3 +154,80 @@ test('#1516: importing an exported pre-v3 transcript keeps its order', () => {
   assert.ok(thread, 'the archived thread should import')
   assert.deepEqual(thread.msgs.map((m) => m.text), CONVERSATION)
 })
+
+/**
+ * #1536 — #1530 ranked by first-seen position in `[...oldMessages, ...newMessages]`,
+ * which is only order-preserving when `older` is a prefix of `newer`. Production
+ * is the other shape: `_writeLocalSnapshot` stores `thread.msgs.slice(-200)` while
+ * IndexedDB holds the whole thread, and the panel restore then merges those two
+ * via `mergeHistorySnapshots({ threads: inMemoryTail }, loadedFull)`.
+ *
+ * `older`/`newer` is chosen by `updatedAt`, not argument position, so swapping
+ * the concatenation is the exact mirror failure. These tests pin the three
+ * shapes the merge must survive, driving `mergeHistorySnapshots` the way the
+ * restore path does. Messages already have ids (post-migration) and createdAt
+ * still floored at 1 — that is the record the truncated shadow actually holds.
+ */
+function migratedThread(texts, updatedAt) {
+  return {
+    id: THREAD_ID,
+    ts: 1_700_000_000_000,
+    updatedAt,
+    workflowKey: 'panel:global',
+    schemaVersion: 3,
+    msgs: texts.map((text) => ({
+      id: `id:${text}`,
+      role: CONVERSATION.indexOf(text) % 2 === 0 ? 'user' : 'agent',
+      text,
+      createdAt: 1
+    }))
+  }
+}
+
+function mergeByRecency(olderTexts, newerTexts) {
+  const older = migratedThread(olderTexts, 1_000)
+  const newer = migratedThread(newerTexts, 2_000)
+  // Production may pass the snapshots in either order; updatedAt decides.
+  const forward = mergeHistorySnapshots({ threads: [older], meta: {} }, { threads: [newer], meta: {} })
+  const reverse = mergeHistorySnapshots({ threads: [newer], meta: {} }, { threads: [older], meta: {} })
+  assert.deepEqual(textsOf(forward), textsOf(reverse), 'updatedAt, not argument order, must decide older/newer')
+  return forward
+}
+
+test('#1536: older = prefix of newer keeps the stored order (#1530 still holds)', () => {
+  const merged = mergeByRecency(CONVERSATION.slice(0, 3), CONVERSATION)
+  assert.deepEqual(textsOf(merged), CONVERSATION)
+})
+
+test('#1536: older = tail of newer keeps the stored order (local shadow of a long thread)', () => {
+  // Measured against #1530: ["a2","u3","a3","u1","a1","u2"] — the tail ranked
+  // ahead of the head. This is the panel restore: in-memory shadow is the tail,
+  // load() returns the full IndexedDB copy as newer.
+  const merged = mergeByRecency(CONVERSATION.slice(-3), CONVERSATION)
+  assert.deepEqual(textsOf(merged), CONVERSATION)
+})
+
+test('#1536: a newer tail (the load() merge) also keeps the stored order', () => {
+  // The obvious one-token repair — concatenate newer first — fixes the tail-as-older
+  // case and then fails this mirror. load() merges IndexedDB (full) with the local
+  // shadow (tail); when the shadow is rewritten last it can be the newer snapshot.
+  const merged = mergeByRecency(CONVERSATION, CONVERSATION.slice(-3))
+  assert.deepEqual(textsOf(merged), CONVERSATION)
+})
+
+test('#1536: interleaved overlap keeps each sequence\'s relative order', () => {
+  // Measured against #1530: ["u1","u2","u3","a1","a2"] want u1,a1,u2,a2,u3.
+  const interleaved = ['u1', 'a1', 'u2', 'a2', 'u3']
+  const usersOnly = ['u1', 'u2', 'u3']
+  assert.deepEqual(textsOf(mergeByRecency(usersOnly, interleaved)), interleaved)
+  assert.deepEqual(textsOf(mergeByRecency(interleaved, usersOnly)), interleaved)
+})
+
+test('#1536: the panel restore (same updatedAt, tail then full) keeps the stored order', () => {
+  // Same updatedAt: `next.updatedAt >= prev.updatedAt` makes the SECOND snapshot
+  // newer. That is the panel's `mergeHistorySnapshots({ threads: tail }, loaded)`.
+  const tail = migratedThread(CONVERSATION.slice(-3), 1_700_000_000_000)
+  const full = migratedThread(CONVERSATION, 1_700_000_000_000)
+  const merged = mergeHistorySnapshots({ threads: [tail], meta: {} }, { threads: [full], meta: {} })
+  assert.deepEqual(textsOf(merged), CONVERSATION)
+})

--- a/web/js/lib/chat-history-store.js
+++ b/web/js/lib/chat-history-store.js
@@ -938,17 +938,82 @@ export function retainBoundedThreads(threads, limit, protectedThreadIds = []) {
 }
 
 /**
- * Where each message already sat, by id — the order those records were actually
- * written in. Built from the source lists in the order they are handed over, so
- * the first list defines the baseline and later ones extend it.
+ * First-seen id order of one source list. Used as input to the two-sequence
+ * merge below; a single-list caller (importPayload) is an identity.
+ */
+function messageIdsInOrder(list) {
+  const ids = [];
+  const seen = new Set();
+  for (const message of Array.isArray(list) ? list : []) {
+    if (!message || seen.has(message.id)) continue;
+    seen.add(message.id);
+    ids.push(message.id);
+  }
+  return ids;
+}
+
+/**
+ * Order-preserving merge of two id sequences.
+ *
+ * Shared ids are alignment points. An id unique to one sequence splices in
+ * after its nearest common predecessor rather than after every id from the
+ * other list. When the sequences disagree on the order of a shared pair, the
+ * second sequence wins — at the mergeThreadMessages call that is `newer`.
+ *
+ * Concatenating the lists and ranking first-seen (#1530) only preserves order
+ * when the first list is a prefix of the second. Production is often the other
+ * way around: `_writeLocalSnapshot` stores `thread.msgs.slice(-LOCAL_SHADOW_MESSAGES)`,
+ * so the local shadow is a TAIL, and the panel restore then merges that tail
+ * with the IndexedDB copy. `older`/`newer` is chosen by `updatedAt`, not by
+ * argument position, so swapping the concatenation is the exact mirror failure.
+ * Walk both instead (#1536).
+ */
+function mergeSequenceIds(left, right) {
+  if (!left.length) return right.slice();
+  if (!right.length) return left.slice();
+  const inLeft = new Set(left);
+  const inRight = new Set(right);
+  const emitted = new Set();
+  const merged = [];
+  const emit = (id) => {
+    if (emitted.has(id)) return;
+    emitted.add(id);
+    merged.push(id);
+  };
+  let i = 0;
+  let j = 0;
+  while (i < left.length || j < right.length) {
+    while (i < left.length && (emitted.has(left[i]) || !inRight.has(left[i]))) {
+      emit(left[i++]);
+    }
+    while (j < right.length && (emitted.has(right[j]) || !inLeft.has(right[j]))) {
+      emit(right[j++]);
+    }
+    if (i < left.length && j < right.length) {
+      if (left[i] === right[j]) {
+        emit(left[i]);
+        i += 1;
+        j += 1;
+      } else {
+        emit(right[j++]);
+      }
+      continue;
+    }
+    while (i < left.length) emit(left[i++]);
+    while (j < right.length) emit(right[j++]);
+  }
+  return merged;
+}
+
+/**
+ * Where each message sits after an order-preserving merge of the source lists.
+ * Folded left-to-right so a single list (the import path) keeps its own order.
  */
 function messagePositions(...lists) {
+  let merged = [];
+  for (const list of lists) merged = mergeSequenceIds(merged, messageIdsInOrder(list));
   const rank = new Map();
-  for (const list of lists) {
-    for (const message of Array.isArray(list) ? list : []) {
-      if (message && !rank.has(message.id)) rank.set(message.id, rank.size);
-    }
-  }
+  for (const id of merged) rank.set(id, rank.size);
   return rank;
 }
 
@@ -976,6 +1041,11 @@ function messagePositions(...lists) {
  * import each carried their own copy of the same two-term rule, so fixing only
  * the one this issue arrived through would have left an import able to write the
  * scrambled order straight back into a thread the merge had just repaired.
+ *
+ * The rank itself is an order-preserving two-sequence merge (#1536), not a
+ * first-seen walk of `[...oldMessages, ...newMessages]`. That concatenation
+ * only preserves order when `older` is a prefix of `newer`; the local shadow
+ * is a tail.
  */
 function compareMessageOrder(rank) {
   return (left, right) =>


### PR DESCRIPTION
Fixes #1536

## What the user sees

#1530 (`1465054b`) stopped a timestamp-less transcript re-ordering on reload — but only when the older snapshot is a **prefix** of the newer one. For any pre-v3 thread longer than 200 messages the localStorage shadow is a **tail**, so a hard refresh still paints earlier user prompts below later agent replies. Count never grows; from the bottom of the pane it still reads as a replay.

## Why #1530 did not cover it

`_writeLocalSnapshot` stores `thread.msgs.slice(-LOCAL_SHADOW_MESSAGES)` (`LOCAL_SHADOW_MESSAGES = 200`) while IndexedDB holds up to 5000. Restore merges those two via `mergeThreadMessages(older, newer)`, and `older`/`newer` is chosen by `updatedAt`, not argument position.

#1530 ranked by first-seen position in `[...oldMessages, ...newMessages]`. That is order-preserving only for a prefix. Measured against that ranking:

```
B  tail + full     ->  a2 u3 a3 u1 a1 u2     want u1 a1 u2 a2 u3 a3
D  interleaved     ->  u1 u2 u3 a1 a2        want u1 a1 u2 a2 u3
```

Swapping to `[...newMessages, ...oldMessages]` fixes B and then fails the mirror (full older, tail newer) — the exact failure the issue warned about.

## The fix

An order-preserving two-sequence merge of the two source lists. Shared ids are alignment points; an id unique to one list splices in after its nearest common predecessor. When the sequences disagree on a shared pair, `newer` wins. Timestamped messages are untouched: the clock still resolves first.

Driven through `mergeHistorySnapshots` (the restore path that calls `mergeThreadMessages`) for:

1. older = prefix of newer (#1530 must stay correct)
2. older = tail of newer (#1536 case B — the production shadow)
3. interleaved overlap (case D)

Plus the concatenation-swap mirror (newer = tail) and the panel restore's same-`updatedAt` shape (`mergeHistorySnapshots({ threads: tail }, loadedFull)`).

## Verification

- `node --test --test-concurrency=4 browser_tests/unit/legacy-transcript-order.test.mjs` — 12 pass (5 new)
- `node --test --test-concurrency=4 browser_tests/unit/chat-history-store.test.mjs browser_tests/unit/legacy-shadow-quota.test.mjs` — 123 pass
