### PR TITLE
fix(1544): name a failed pack as the cause only when Manager's node map proves it owns the type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+### Fixed
+- panel_add_node names a failed custom-node pack as the reason a type is missing only when ComfyUI-Manager's node map says that pack provides it; an unproven failure is reported as a separate issue rather than the cause (#1544)
+
 ## [0.15.30] - 2026-08-20
 
 ### Fixed

--- a/browser_tests/unit/pack-import-failures.test.mjs
+++ b/browser_tests/unit/pack-import-failures.test.mjs
@@ -535,9 +535,9 @@ test("#1544 POSITIVE evidence only — a map that omits the pack never drops it"
 test("#1544 packsProvidingType reads the class list, and claims nothing else", () => {
   assert.deepEqual(
     [...packsProvidingType(NODE_MAP, "PreviewVideo")].sort(),
-    ["llmtoolkit", "vertexaicomfyuinodes"],
+    ["llm-toolkit", "vertex-ai-comfyui-nodes"],
   );
-  assert.deepEqual([...packsProvidingType(NODE_MAP, "LTXVAddGuide")], ["comfyuiltxvideo"]);
+  assert.deepEqual([...packsProvidingType(NODE_MAP, "LTXVAddGuide")], ["comfyui-ltxvideo"]);
   // Nothing to go on ⇒ no owners, which is the branch that handles not knowing.
   assert.equal(packsProvidingType(NODE_MAP, "NoSuchType").size, 0);
   assert.equal(packsProvidingType(null, "PreviewVideo").size, 0);
@@ -670,4 +670,58 @@ test("#1544 nodeMapPackCount counts what is checkable, not what is present", () 
   assert.equal(nodeMapPackCount(null), 0);
   assert.equal(nodeMapPackCount("<html>"), 0);
   assert.equal(nodeMapPackCount([["A"]]), 0, "an array payload carries no class list we can read");
+});
+
+test("#1544 two DIFFERENT packs that normalise alike never prove ownership", () => {
+  // Real collision from the live catalogue: ComfyUI-OmniSVG (A043-studios) and
+  // ComfyUI_OmniSVG (smthemex) are separate projects by separate authors. Under the
+  // #1447 `packKey` normalisation — which strips every non-alphanumeric — they are
+  // one key, and a failed A043 install would have been named as the proven owner of
+  // a class only smthemex provides. That is #1544's own bug restated with MORE
+  // confidence, which is strictly worse than the hedge it replaced.
+  //
+  // Measured on the live 5583-entry map: `packKey` leaves 79 keys claimed by more
+  // than one entry, 72 of which disagree about class names. Keeping separators takes
+  // that to 3, at no cost to the installed-folder hit rate (59/75 either way).
+  const COLLIDING = {
+    "https://github.com/A043-studios/ComfyUI-OmniSVG": [
+      ["OmniSVG Model Loader"],
+      { title_aux: "ComfyUI-OmniSVG" },
+    ],
+    "https://github.com/smthemex/ComfyUI_OmniSVG": [
+      ["SVG Saver"],
+      { title_aux: "ComfyUI_OmniSVG" },
+    ],
+  };
+  // Each is proven owner of its OWN class, and of nothing else.
+  assert.deepEqual([...packsProvidingType(COLLIDING, "OmniSVG Model Loader")], ["comfyui-omnisvg"]);
+  assert.deepEqual([...packsProvidingType(COLLIDING, "SVG Saver")], ["comfyui_omnisvg"]);
+
+  // The hyphen pack failed; the underscore pack owns the requested class. Nothing
+  // may present the hyphen pack as the cause.
+  const note = importFailureNote(["ComfyUI-OmniSVG"], {
+    forType: "SVG Saver",
+    liveDefs: CORE_ONLY_DEFS,
+    nodeMap: COLLIDING,
+  });
+  assert.match(note, /SEPARATE ISSUE/);
+  assert.doesNotMatch(note, /is provided by/);
+});
+
+test("#1544 entries under ONE key must agree before that key owns a type", () => {
+  // The 3 collisions that survive separator-preserving keys. Aliases of a single
+  // pack list the same classes and still promote; two projects filed under one key
+  // that disagree promote nothing.
+  const ALIASES = {
+    "https://github.com/x/Same-Pack": [["ClassA"], {}],
+    "https://github.com/x/Same-Pack.git": [["ClassA"], {}],
+  };
+  assert.deepEqual([...packsProvidingType(ALIASES, "ClassA")], ["same-pack"], "agreeing aliases promote");
+
+  const DISAGREE = {
+    "https://github.com/one/Dup-Pack": [["ClassA"], {}],
+    "https://github.com/two/Dup-Pack": [["ClassB"], {}],
+  };
+  assert.equal(packsProvidingType(DISAGREE, "ClassA").size, 0, "one entry omits it ⇒ not proven");
+  assert.equal(packsProvidingType(DISAGREE, "ClassB").size, 0);
 });

--- a/browser_tests/unit/pack-import-failures.test.mjs
+++ b/browser_tests/unit/pack-import-failures.test.mjs
@@ -725,3 +725,30 @@ test("#1544 entries under ONE key must agree before that key owns a type", () =>
   assert.equal(packsProvidingType(DISAGREE, "ClassA").size, 0, "one entry omits it ⇒ not proven");
   assert.equal(packsProvidingType(DISAGREE, "ClassB").size, 0);
 });
+
+test("#1544 a map HIT promotes through the shipped guard, not just the helper", async () => {
+  // Review gap: the other resolver test asserts SEPARATE ISSUE, which is ALSO the
+  // no-map wording — so discarding the fetched map (`await readNodeMap()` without
+  // assigning it) would still have passed every test here. The cost test proves the
+  // injector is CALLED and the wiring test proves the panel PASSES it; neither
+  // proves the fetched payload reaches importFailureNote. This does: the map owns
+  // the type, so the refusal must carry the causal wording.
+  const { assertAddNodeResolvableRefreshing } = await import(
+    "../../web/js/lib/node-resolve.js"
+  );
+  const err = await assertAddNodeResolvableRefreshing({}, "LTXVAddGuide", {
+    getFreshObjectInfo: async () => CORE_ONLY_DEFS,
+    wasTypeEverDefined: () => false,
+    readImportFailures: async () => ["ComfyUI-LTXVideo"],
+    readNodeMap: async () => NODE_MAP,
+  }).then(
+    () => null,
+    (e) => e,
+  );
+  assert.ok(err, "an absent type must still be refused");
+  assert.match(err.message, /Unknown node type "LTXVAddGuide"/);
+  assert.match(err.message, /BEFORE INSTALLING ANYTHING/);
+  assert.match(err.message, /"LTXVAddGuide" is provided by ComfyUI-LTXVideo/);
+  assert.match(err.message, /Ownership is from ComfyUI-Manager's node map/);
+  assert.doesNotMatch(err.message, /SEPARATE ISSUE/);
+});

--- a/browser_tests/unit/pack-import-failures.test.mjs
+++ b/browser_tests/unit/pack-import-failures.test.mjs
@@ -24,6 +24,7 @@ import {
   readPackImportFailures,
   dropLivePackImportFailures,
   packsProvidingType,
+  nodeMapPackCount,
 } from "../../web/js/lib/pack-import-failures.js";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
@@ -635,4 +636,38 @@ test("#1544 WIRING: the add-node guard is handed the Manager node map", () => {
     /readNodeMap: \(\) => managerGet\("customnode\/getmappings\?mode=cache"\)/,
     "panel_add_node must fetch the ownership map, or #1544 ships as dead code",
   );
+});
+
+test("#1544 a 200 that is not a catalogue is NOT a completed ownership check", () => {
+  // #808's finding, one layer down. Manager answers `{}` when it assembled its list
+  // from none of channel, cache or bundled copy; a captive proxy answers 200 with a
+  // sign-in page. Both are objects. Reporting "the node map does not link it to that
+  // type" about either asserts a check that never ran — the same unearned claim
+  // #1544 exists to stop.
+  const forEmpty = (nodeMap) =>
+    importFailureNote(["coldinfire_fal_privacy"], {
+      forType: "PreviewVideo",
+      liveDefs: CORE_ONLY_DEFS,
+      nodeMap,
+    });
+
+  for (const payload of [{}, { error: "sign in" }, { "some-pack": { title: "no class list" } }]) {
+    const note = forEmpty(payload);
+    assert.match(note, /returned no usable node catalogue, so ownership could not be checked/);
+    assert.doesNotMatch(note, /does not link it to that type/);
+    assert.match(note, /SEPARATE ISSUE/, "still non-causal either way");
+  }
+
+  // A populated catalogue that genuinely lacks the link keeps the stronger wording.
+  assert.match(forEmpty(NODE_MAP), /does not link it to that type/);
+});
+
+test("#1544 nodeMapPackCount counts what is checkable, not what is present", () => {
+  assert.equal(nodeMapPackCount(NODE_MAP), 3);
+  assert.equal(nodeMapPackCount({}), 0);
+  assert.equal(nodeMapPackCount({ error: "sign in" }), 0);
+  assert.equal(nodeMapPackCount({ pack: [["A"], {}], broken: { no: "classes" } }), 1);
+  assert.equal(nodeMapPackCount(null), 0);
+  assert.equal(nodeMapPackCount("<html>"), 0);
+  assert.equal(nodeMapPackCount([["A"]]), 0, "an array payload carries no class list we can read");
 });

--- a/browser_tests/unit/pack-import-failures.test.mjs
+++ b/browser_tests/unit/pack-import-failures.test.mjs
@@ -23,6 +23,7 @@ import {
   importFailureNote,
   readPackImportFailures,
   dropLivePackImportFailures,
+  packsProvidingType,
 } from "../../web/js/lib/pack-import-failures.js";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
@@ -314,8 +315,17 @@ test("#1447 a leftover failure is labelled as not owning the requested type", as
   );
   assert.match(err.message, /ComfyUI-LTXVideo/);
   assert.doesNotMatch(err.message, /comfyui-reactor-node/);
-  assert.match(err.message, /does not prove it provides "VideoToImages"/);
-  assert.match(err.message, /may be unrelated/);
+  // #1544 made this claim stronger and moved it to the FRONT. #1447 shipped it as a
+  // trailing "does not prove it provides X — the failure may be unrelated", and a
+  // reporter read straight past it to the pack name. Same finding, stated where it
+  // is read; the ordering assertion is what stops it drifting back to a footnote.
+  assert.match(err.message, /not the cause of this missing type/);
+  assert.match(err.message, /Nothing ties it to "VideoToImages"/);
+  assert.ok(
+    err.message.indexOf("not the cause of this missing type") <
+      err.message.indexOf("ComfyUI-LTXVideo"),
+    "the qualifier must come before the pack name",
+  );
 });
 
 test("#1447 importFailureNote itself drops a live pack", () => {
@@ -411,4 +421,218 @@ test("#1180: the bound covers the BODY, not just the response head", async () =>
   } finally {
     globalThis.fetch = original;
   }
+});
+
+// --- #1544: a failed pack is the CAUSE only when the node map says it owns the type ---
+//
+// `panel_add_node PreviewVideo` was refused with "coldinfire_fal_privacy FAILED TO
+// IMPORT at startup" attached. Nothing connected them. The note had a trailing
+// hedge, and it did not survive contact with a reader: the sentence that leads
+// with a pack name is the one that gets acted on.
+//
+// The fixture mirrors a real `/customnode/getmappings` payload — BOTH key shapes
+// occur in one response (repo URL and bare registry id), and the three packs below
+// are the three the live 5583-entry map really does list for PreviewVideo.
+const NODE_MAP = {
+  "https://github.com/khanhlvg/vertex-ai-comfyui-nodes": [
+    ["PreviewVideo", "VertexImagen"],
+    { title_aux: "[Unofficial] Vertex AI Custom Nodes for ComfyUI" },
+  ],
+  "llm-toolkit": [["PreviewVideo"], { title_aux: "ComfyUI LLM Toolkit" }],
+  "https://github.com/lightricks/ComfyUI-LTXVideo.git": [
+    ["LTXVAddGuide", "LTXVPreprocess"],
+    { title_aux: "ComfyUI-LTXVideo" },
+  ],
+};
+
+/** A live /object_info with no custom-node pack in common with the failures. */
+const CORE_ONLY_DEFS = { KSampler: { python_module: "nodes" } };
+
+test("#1544 the reported refusal no longer blames an unrelated failed pack", () => {
+  const note = importFailureNote(["coldinfire_fal_privacy"], {
+    forType: "PreviewVideo",
+    liveDefs: CORE_ONLY_DEFS,
+    nodeMap: NODE_MAP,
+  });
+  // The map lists three packs for PreviewVideo and coldinfire_fal_privacy is not
+  // one of them, so nothing may present it as the reason.
+  assert.doesNotMatch(note, /BEFORE INSTALLING ANYTHING/);
+  assert.match(note, /SEPARATE ISSUE, not the cause of this missing type/);
+  assert.match(note, /ComfyUI-Manager's node map does not link it to that type/);
+  assert.match(note, /do not reinstall it expecting "PreviewVideo" to appear/);
+
+  // ORDER is the fix. The pack is still disclosed — a failed import is a real
+  // problem — but the reader meets "not the cause" before they meet the name.
+  // Assert the position, not just the presence: the pre-#1544 note contained the
+  // very same hedge words and still read as an accusation because they came last.
+  assert.match(note, /coldinfire_fal_privacy/);
+  assert.ok(
+    note.indexOf("not the cause of this missing type") < note.indexOf("coldinfire_fal_privacy"),
+    "the disclaimer must precede the pack name, or it is the old bug with more words",
+  );
+});
+
+test("#1544 ownership PROVEN still gets #775's causal note", () => {
+  // The case #775 was filed about: the pack really did fail, and it really is why
+  // the type is missing. That advice must not be watered down by this change.
+  // Doubles as the key-shape test: a `.git`-suffixed repo URL must match the
+  // folder name the IMPORT FAILED log line prints.
+  const note = importFailureNote(["ComfyUI-LTXVideo"], {
+    forType: "LTXVAddGuide",
+    liveDefs: CORE_ONLY_DEFS,
+    nodeMap: NODE_MAP,
+  });
+  assert.match(note, /BEFORE INSTALLING ANYTHING/);
+  assert.match(note, /"LTXVAddGuide" is provided by ComfyUI-LTXVideo/);
+  assert.match(note, /installing it again will not help/);
+  assert.match(note, /Ownership is from ComfyUI-Manager's node map/);
+  assert.doesNotMatch(note, /SEPARATE ISSUE/);
+});
+
+test("#1544 when ownership is proven, ONLY the owner is named", () => {
+  const note = importFailureNote(["coldinfire_fal_privacy", "ComfyUI-LTXVideo"], {
+    forType: "LTXVAddGuide",
+    liveDefs: CORE_ONLY_DEFS,
+    nodeMap: NODE_MAP,
+  });
+  assert.match(note, /provided by ComfyUI-LTXVideo/);
+  // Re-listing the unrelated failure inside the one message that finally has a
+  // definite answer would put the ambiguity straight back.
+  assert.doesNotMatch(note, /coldinfire_fal_privacy/);
+  assert.match(note, /that line/, "one named pack means one log line, not 'those lines'");
+});
+
+test("#1544 no map means ownership was NOT CHECKED, and says so", () => {
+  // Manager disabled, legacy, or unreachable. "We did not check" and "we checked
+  // and found nothing" send the reader to different next steps, so they must not
+  // arrive as the same sentence.
+  const note = importFailureNote(["coldinfire_fal_privacy"], {
+    forType: "PreviewVideo",
+    liveDefs: CORE_ONLY_DEFS,
+  });
+  assert.match(note, /SEPARATE ISSUE, not the cause of this missing type/);
+  assert.match(note, /node map could not be read, so ownership was not checked/);
+  assert.doesNotMatch(note, /does not link it to that type/);
+});
+
+test("#1544 POSITIVE evidence only — a map that omits the pack never drops it", () => {
+  // The tempting next step is "the map knows this pack and its class list omits the
+  // type, so it is not the owner". Measured against a live map, 4 of the 59
+  // installed packs it recognises share NO class with their own /object_info
+  // entries — the catalogue lags a pack's releases. Acting on that would silently
+  // discard real import failures: #775's fault with the sign flipped. The failure
+  // must survive, demoted but disclosed.
+  const note = importFailureNote(["ComfyUI-LTXVideo"], {
+    forType: "PreviewVideo",
+    liveDefs: CORE_ONLY_DEFS,
+    nodeMap: NODE_MAP,
+  });
+  assert.match(note, /ComfyUI-LTXVideo/, "a real failure is never silently dropped");
+  assert.match(note, /SEPARATE ISSUE/);
+});
+
+test("#1544 packsProvidingType reads the class list, and claims nothing else", () => {
+  assert.deepEqual(
+    [...packsProvidingType(NODE_MAP, "PreviewVideo")].sort(),
+    ["llmtoolkit", "vertexaicomfyuinodes"],
+  );
+  assert.deepEqual([...packsProvidingType(NODE_MAP, "LTXVAddGuide")], ["comfyuiltxvideo"]);
+  // Nothing to go on ⇒ no owners, which is the branch that handles not knowing.
+  assert.equal(packsProvidingType(NODE_MAP, "NoSuchType").size, 0);
+  assert.equal(packsProvidingType(null, "PreviewVideo").size, 0);
+  assert.equal(packsProvidingType({}, "PreviewVideo").size, 0);
+  assert.equal(packsProvidingType(NODE_MAP, "").size, 0);
+  // The ARRAY payload shape carries ids and titles, never a class list we have
+  // seen — so it yields no owners rather than a guessed field name.
+  assert.equal(packsProvidingType([{ id: "x", nodenames: ["PreviewVideo"] }], "PreviewVideo").size, 0);
+});
+
+test("#1544 panel_add_node PreviewVideo: the shipped guard, end to end", async () => {
+  const { assertAddNodeResolvableRefreshing } = await import(
+    "../../web/js/lib/node-resolve.js"
+  );
+  const err = await assertAddNodeResolvableRefreshing({}, "PreviewVideo", {
+    getFreshObjectInfo: async () => CORE_ONLY_DEFS,
+    wasTypeEverDefined: () => false,
+    readImportFailures: async () => ["coldinfire_fal_privacy"],
+    readNodeMap: async () => NODE_MAP,
+  }).then(
+    () => null,
+    (e) => e,
+  );
+  assert.ok(err, "an absent type must still be refused");
+  assert.match(err.message, /Unknown node type "PreviewVideo"/);
+  assert.match(err.message, /SEPARATE ISSUE, not the cause of this missing type/);
+  assert.doesNotMatch(err.message, /BEFORE INSTALLING ANYTHING/);
+});
+
+test("#1544 a node-map read that throws leaves the refusal intact", async () => {
+  // Manager unreachable on the refusal path. A diagnostic must never replace the
+  // refusal it exists to explain.
+  const { assertAddNodeResolvableRefreshing } = await import(
+    "../../web/js/lib/node-resolve.js"
+  );
+  const err = await assertAddNodeResolvableRefreshing({}, "PreviewVideo", {
+    getFreshObjectInfo: async () => CORE_ONLY_DEFS,
+    wasTypeEverDefined: () => false,
+    readImportFailures: async () => ["coldinfire_fal_privacy"],
+    readNodeMap: async () => {
+      throw new Error("Manager is not reachable");
+    },
+  }).then(
+    () => null,
+    (e) => e,
+  );
+  assert.match(err.message, /Unknown node type "PreviewVideo"/);
+  assert.match(err.message, /ownership was not checked/);
+});
+
+test("#1544 the ~1.4MB node map is read ONLY when a failure needs adjudicating", async () => {
+  const { assertAddNodeResolvableRefreshing } = await import(
+    "../../web/js/lib/node-resolve.js"
+  );
+  const run = async (type, failures, liveDefs = CORE_ONLY_DEFS) => {
+    let reads = 0;
+    await assertAddNodeResolvableRefreshing({}, type, {
+      getFreshObjectInfo: async () => liveDefs,
+      wasTypeEverDefined: () => false,
+      readImportFailures: async () => failures,
+      readNodeMap: async () => {
+        reads++;
+        return NODE_MAP;
+      },
+    }).catch(() => {});
+    return reads;
+  };
+
+  assert.equal(await run("PreviewVideo", []), 0, "nothing failed: nothing to adjudicate");
+  assert.equal(
+    await run("VideoToImages", ["comfyui-reactor-node"], {
+      ...CORE_ONLY_DEFS,
+      ReActorFaceSwap: { python_module: "custom_nodes.comfyui-reactor-node" },
+    }),
+    0,
+    "#1447 dropped the only failure: the map cannot change the answer",
+  );
+  assert.equal(
+    await run("2fd9c1ea-1f4c-4b1e-9a3e-8f2b7c6d5e40", ["coldinfire_fal_privacy"]),
+    0,
+    "#1523 a subgraph UUID has no pack owner to look up",
+  );
+  assert.equal(await run("PreviewVideo", ["coldinfire_fal_privacy"]), 1, "…and exactly once when it does");
+});
+
+test("#1544 WIRING: the add-node guard is handed the Manager node map", () => {
+  // A one-line injection is invisible to every helper-level test above: the whole
+  // ownership check is inert if the panel never passes `readNodeMap`. Pin the CALL
+  // SITE, in the same options object that wires #775's log reader.
+  const src = readFileSync(PANEL_JS, "utf8");
+  const i = src.indexOf("readImportFailures: () => readPackImportFailures(api),");
+  assert.ok(i > 0, "the #775 add-node wiring must still be there to anchor on");
+  const block = src.slice(i, i + 1200);
+  assert.match(
+    block,
+    /readNodeMap: \(\) => managerGet\("customnode\/getmappings\?mode=cache"\)/,
+    "panel_add_node must fetch the ownership map, or #1544 ships as dead code",
+  );
 });

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -13022,6 +13022,15 @@ const GRAPH_TOOL_EXECUTORS = {
       // add never pays for it. A pack that failed to import looks exactly like a
       // pack that is not installed, and the refusal used to name only the latter.
       readImportFailures: () => readPackImportFailures(api),
+      // #1544 — the ownership oracle. Naming a failed pack as the REASON a type is
+      // missing is a causal claim, and the log alone cannot support it: a reporter
+      // asking for PreviewVideo was told an unrelated coldinfire_fal_privacy had
+      // failed to import. ComfyUI-Manager's node map carries each pack's class
+      // names, so it can tie a failure to THIS class_type — or leave it unproven,
+      // which the refusal then states plainly. Same dialect-routed GET (and #605
+      // self-heal) panel_search_nodes uses; the resolver only calls this when a
+      // surviving import failure actually needs adjudicating.
+      readNodeMap: () => managerGet("customnode/getmappings?mode=cache"),
       // #1523 — subgraph UUIDs are never in /object_info. The live workflow's
       // subgraphs registry is the oracle that distinguishes a loaded SAM3
       // subgraph from a missing backend pack. capturedContext is already in

--- a/web/js/lib/node-resolve.js
+++ b/web/js/lib/node-resolve.js
@@ -28,7 +28,7 @@ export const COMFY_CORE_SENTINEL_TYPES = [
   "SaveImage",
 ];
 
-import { importFailureNote } from "./pack-import-failures.js";
+import { importFailureNote, relevantPackImportFailures } from "./pack-import-failures.js";
 
 /** True when `type` is registered in the live LiteGraph registry object
  *  (LG.registered_node_types). */
@@ -557,7 +557,8 @@ export function assertAddNodeResolvable(registry, class_type) {
 export async function assertAddNodeResolvableRefreshing(getRegistry, class_type, opts = {}) {
   // #775 — `readImportFailures` is injected and awaited ONLY on the refusal path,
   // so a healthy add pays nothing for it.
-  const { getFreshObjectInfo, refresh, wasTypeEverDefined, readImportFailures } = opts;
+  const { getFreshObjectInfo, refresh, wasTypeEverDefined, readImportFailures, readNodeMap } =
+    opts;
   const readRegistry = () =>
     typeof getRegistry === "function" ? getRegistry() : getRegistry;
 
@@ -692,13 +693,29 @@ export async function assertAddNodeResolvableRefreshing(getRegistry, class_type,
       // different type (VideoToImages) is missing.
       // #1523 — UUID types never reach here (handled above). Remaining failures
       // still do not prove ownership of the requested type.
+      // #1544 — naming a failed pack is a CAUSAL claim, and the panel was making it
+      // without evidence: `PreviewVideo` was refused with "coldinfire_fal_privacy
+      // FAILED TO IMPORT" attached. ComfyUI-Manager's node map is the ownership
+      // oracle (`readNodeMap`), and it is read ONLY once there is a surviving
+      // failure to adjudicate — it is a ~1.4 MB payload, and a refusal with no
+      // import failures must not pay for it.
       let failedNote = "";
       if (typeof readImportFailures === "function") {
         try {
-          failedNote = importFailureNote(await readImportFailures(), {
-            forType: class_type,
-            liveDefs: freshDefs,
-          });
+          const failed = await readImportFailures();
+          const noteOpts = { forType: class_type, liveDefs: freshDefs };
+          if (
+            typeof readNodeMap === "function" &&
+            relevantPackImportFailures(failed, noteOpts).length > 0
+          ) {
+            try {
+              noteOpts.nodeMap = await readNodeMap();
+            } catch {
+              // Manager unreachable/disabled: ownership stays unestablished, which
+              // the note reports as exactly that rather than guessing a cause.
+            }
+          }
+          failedNote = importFailureNote(failed, noteOpts);
         } catch {
           // A diagnostic that throws must not replace the refusal it explains.
         }

--- a/web/js/lib/pack-import-failures.js
+++ b/web/js/lib/pack-import-failures.js
@@ -27,6 +27,16 @@ import { readComfyLogText } from "./comfy-log.js";
  * types. Establishing that needs the pack's NODE_CLASS_MAPPINGS, which is not
  * readable from the browser — so the wording stays at "check these first".
  *
+ * #1544 CORRECTS THAT LAST PARAGRAPH. A pack's class list IS readable from the
+ * browser: ComfyUI-Manager's `/customnode/getmappings` is keyed pack →
+ * [[classNames…], meta], and the panel had been fetching that very payload for
+ * panel_search_nodes while throwing the class list away. Because ownership looked
+ * unknowable, every caller settled for a hedge — and a hedge in the last sentence
+ * did not stop `panel_add_node PreviewVideo` from reading as "coldinfire_fal_privacy
+ * is why". So ownership is now CHECKED (`packsProvidingType`): a pack the map ties
+ * to the requested type is named as the cause outright, and one it does not is
+ * presented as a separate problem, up front, in the first clause the reader sees.
+ *
  * #1447 — a pack that currently PROVIDES types cannot be the reason a different
  * type is missing. ReActorFaceSwap had just been added when `panel_add_node`
  * VideoToImages appended "comfyui-reactor-node FAILED TO IMPORT". That sentence
@@ -127,6 +137,86 @@ export function dropLivePackImportFailures(failed, liveDefs) {
   return failed.filter((name) => !live.has(packKey(name)));
 }
 
+/** A subgraph definition id, never a pack-provided class name (#1523). */
+const SUBGRAPH_UUID =
+  /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
+
+/**
+ * The pack folder a ComfyUI-Manager node-map KEY corresponds to.
+ *
+ * Manager keys the map by whatever identifies the pack in its catalogue, and both
+ * shapes occur in one payload (observed on a live 5583-entry map): a repo URL
+ * (`https://github.com/0velia/ComfyUI-Dynamic-Dropdowns`) and a bare registry id
+ * (`llm-toolkit`). Manager clones into a folder named after that last segment, which
+ * is the SAME segment the `(IMPORT FAILED)` log line prints — so the final path
+ * component, `.git` stripped, is what the two sides have in common. Normalised
+ * through `packKey` so case and separators do not decide a match.
+ */
+function packKeyFromNodeMapKey(key) {
+  const s = String(key || "")
+    .trim()
+    .replace(/[?#].*$/, "")
+    .replace(/\/+$/, "");
+  if (!s) return "";
+  const seg = s.split(/[/\\]/).filter(Boolean).pop() || s;
+  return packKey(seg.replace(/\.git$/i, ""));
+}
+
+/**
+ * Pack keys that ComfyUI-Manager's node map says PROVIDE `forType`.
+ *
+ * The map (`/customnode/getmappings`) is keyed pack → [[classNames…], meta]; that
+ * class-name array is the ownership evidence this module previously recorded as
+ * unreadable from a browser. It is readable — the panel already fetches this exact
+ * payload for panel_search_nodes (`parseNodeMappings`), which consumed only the meta
+ * object and discarded the class list.
+ *
+ * POSITIVE EVIDENCE ONLY, deliberately. The converse — "the map knows this pack and
+ * its class list omits the type, therefore it is not the owner" — is NOT sound: on
+ * the machine this was measured on, 4 of the 59 installed packs the map recognises
+ * share no class at all with their own live /object_info entries, because the
+ * catalogue lags a pack's current release. Acting on that would silently discard
+ * real import failures — the #775 fault with its sign flipped. So a match PROMOTES a
+ * failure to "the cause"; a non-match only declines to promote it.
+ *
+ * @param {unknown} nodeMap raw `/customnode/getmappings` payload (or null)
+ * @param {string} forType requested class_type
+ * @returns {Set<string>} normalised pack keys
+ */
+export function packsProvidingType(nodeMap, forType) {
+  const type = String(forType || "").trim();
+  const out = new Set();
+  if (!type || !nodeMap || typeof nodeMap !== "object") return out;
+  // Both wire shapes, exactly as parseNodeMappings handles them: an ARRAY of pack
+  // objects, or the documented MAP of key → [[classNames…], meta].
+  const entries = Array.isArray(nodeMap)
+    ? nodeMap.map((p) => [p?.id ?? p?.reference ?? p?.title, p?.nodenames ?? p?.nodes])
+    : Object.entries(nodeMap).map(([k, v]) => [k, Array.isArray(v) ? v[0] : v?.nodenames]);
+  for (const [key, classes] of entries) {
+    if (!Array.isArray(classes) || !classes.includes(type)) continue;
+    const pk = packKeyFromNodeMapKey(key);
+    if (pk) out.add(pk);
+  }
+  return out;
+}
+
+/**
+ * The failures a note would actually name: log failures minus the ones the live
+ * backend contradicts (#1447), and none at all for a subgraph UUID (#1523).
+ *
+ * Exported so a caller can decide whether fetching the node map is worth it BEFORE
+ * paying for it — that payload is ~1.4 MB, and there is nothing to adjudicate when
+ * this comes back empty.
+ */
+export function relevantPackImportFailures(failed, opts = {}) {
+  const o = opts && typeof opts === "object" ? opts : {};
+  const forType = typeof o.forType === "string" ? o.forType.trim() : "";
+  // #1523 — a UUID class_type is a subgraph definition, not a pack-provided node.
+  // The note would name an unrelated failed pack with no possible ownership link.
+  if (forType && SUBGRAPH_UUID.test(forType)) return [];
+  return dropLivePackImportFailures(failed, o.liveDefs);
+}
+
 /**
  * What to add to a missing-node message once the import failures are known.
  *
@@ -137,39 +227,85 @@ export function dropLivePackImportFailures(failed, liveDefs) {
  * `opts.forType` names the missing class so a leftover failure is labelled
  * unrelated rather than read as its cause. A subgraph UUID forType yields
  * no note at all (#1523) — ownership mapping cannot link a pack to it.
+ * `opts.nodeMap` is ComfyUI-Manager's node map; it is what PROMOTES a failure from
+ * an unrelated diagnostic to the stated cause (#1544).
+ *
+ * #1544 — the note used to open with "BEFORE INSTALLING ANYTHING: ComfyUI reported
+ * that this pack FAILED TO IMPORT" for ANY unknown type, and hedge only in its last
+ * sentence. A reporter asking for `PreviewVideo` was told `coldinfire_fal_privacy`
+ * had failed to import; the two have nothing to do with each other, and a leading
+ * sentence outweighs a trailing qualifier. So the causal framing is now earned
+ * rather than assumed: it appears only for a pack the node map ties to this exact
+ * class_type, and every other failure is presented as what it is — a real problem
+ * worth fixing that does not explain THIS missing type.
  */
 export function importFailureNote(failed, opts = {}) {
-  const forType = opts && typeof opts === "object" && typeof opts.forType === "string"
-    ? opts.forType.trim()
-    : "";
-  // #1523 — a UUID class_type is a subgraph definition, not a pack-provided
-  // node. The note would name an unrelated failed pack with no possible
-  // ownership link.
-  if (
-    forType &&
-    /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/.test(forType)
-  ) {
-    return "";
-  }
-  const relevant = dropLivePackImportFailures(
-    failed,
-    opts && typeof opts === "object" ? opts.liveDefs : undefined,
-  );
+  const o = opts && typeof opts === "object" ? opts : {};
+  const forType = typeof o.forType === "string" ? o.forType.trim() : "";
+  const relevant = relevantPackImportFailures(failed, o);
   if (relevant.length === 0) return "";
+
+  // Plurality follows the packs the sentence actually NAMES, not every failure in
+  // the log — a causal note names only the owner, so "those lines" would point the
+  // reader at log lines the message never mentioned.
+  const howToReadTheLog = (count) =>
+    `Check the server log (get_system_stats action:"logs") for the ImportError above ` +
+    `${count > 1 ? "those lines" : "that line"} — it is usually a version ` +
+    `mismatch between the pack and ComfyUI.`;
+
+  // EARNED CAUSE — the map ties one of these packs to this exact class_type. Only
+  // the owner is named: the other failures are real, but they are not what this add
+  // ran into, and listing them here would re-create the #1544 ambiguity inside the
+  // one message that finally has a definite answer. A workflow LOAD still reports
+  // every failure (the no-forType branch below).
+  const owners = packsProvidingType(o.nodeMap, forType);
+  const owning = owners.size ? relevant.filter((name) => owners.has(packKey(name))) : [];
+  if (owning.length) {
+    const many = owning.length > 1;
+    return (
+      ` BEFORE INSTALLING ANYTHING: "${forType}" is provided by ${owning.join(", ")}, and ` +
+      `ComfyUI reported that ${many ? "those packs" : "it"} FAILED TO IMPORT at startup. ` +
+      `A pack that fails to import registers NONE of its nodes, so its node types are missing ` +
+      `exactly as if it were not installed, and installing it again will not help. ` +
+      howToReadTheLog(owning.length) +
+      ` (Ownership is from ComfyUI-Manager's node map.)`
+    );
+  }
+
   const list = relevant.join(", ");
   const plural = relevant.length > 1;
-  const ownership = forType
-    ? ` This does not prove ${plural ? "they provide" : "it provides"} "${forType}" — ` +
-      `the failure may be unrelated.`
-    : ` This does not prove ${plural ? "they own" : "it owns"} the ` +
-      `missing types; it is the first thing to rule out.`;
+
+  // NO REQUESTED TYPE — the workflow-load path (#775), where the note explains a SET
+  // of missing types rather than one. There is nothing to establish ownership
+  // against, so this keeps its original wording.
+  if (!forType) {
+    return (
+      ` BEFORE INSTALLING ANYTHING: ComfyUI reported that ${plural ? "these packs" : "this pack"} ` +
+      `FAILED TO IMPORT at startup — ${list}. A pack that fails to import registers NONE of its ` +
+      `nodes, so its node types are missing exactly as if it were not installed, and installing it ` +
+      `again will not help. ` +
+      howToReadTheLog(relevant.length) +
+      ` This does not prove ${plural ? "they own" : "it owns"} the ` +
+      `missing types; it is the first thing to rule out.`
+    );
+  }
+
+  // UNEARNED — say so FIRST, so the pack name cannot be read as the answer. Which
+  // check came up short is stated exactly: a map that was read and did not link the
+  // pack is different evidence from a map that could not be read at all, and the
+  // reader's next step differs accordingly.
+  const why =
+    o.nodeMap && typeof o.nodeMap === "object"
+      ? `ComfyUI-Manager's node map does not link ${plural ? "them" : "it"} to that type`
+      : `ComfyUI-Manager's node map could not be read, so ownership was not checked`;
   return (
-    ` BEFORE INSTALLING ANYTHING: ComfyUI reported that ${plural ? "these packs" : "this pack"} ` +
-    `FAILED TO IMPORT at startup — ${list}. A pack that fails to import registers NONE of its ` +
-    `nodes, so its node types are missing exactly as if it were not installed, and installing it ` +
-    `again will not help. Check the server log (get_system_stats action:"logs") for the ` +
-    `ImportError above ${plural ? "those lines" : "that line"} — it is usually a version mismatch ` +
-    `between the pack and ComfyUI.` +
-    ownership
+    ` SEPARATE ISSUE, not the cause of this missing type: ComfyUI reported that ` +
+    `${plural ? "these packs" : "this pack"} FAILED TO IMPORT at startup — ${list}. ` +
+    `Nothing ties ${plural ? "them" : "it"} to "${forType}" — ${why} — so do not reinstall ` +
+    `${plural ? "them" : "it"} expecting "${forType}" to appear. ` +
+    `${plural ? "Those failures are" : "That failure is"} still worth fixing on ${
+      plural ? "their" : "its"
+    } own: a pack that fails to import registers NONE of its nodes. ` +
+    howToReadTheLog(relevant.length)
   );
 }

--- a/web/js/lib/pack-import-failures.js
+++ b/web/js/lib/pack-import-failures.js
@@ -204,6 +204,29 @@ export function packsProvidingType(nodeMap, forType) {
 }
 
 /**
+ * How many packs a node-map payload actually let us CHECK — entries carrying a
+ * class-name array.
+ *
+ * Counted rather than assumed because a 200 is not a catalogue. #808 measured this
+ * on the search path: ComfyUI-Manager answers `{}` when it built its list from none
+ * of channel, cache or bundled copy, and a captive proxy can answer 200 with a
+ * sign-in page. Both survive a `typeof === "object"` test, and treating either as a
+ * consulted map turns "we did not check" into "we checked and found nothing" — the
+ * same class of unearned claim #1544 is about, one layer down.
+ *
+ * @param {unknown} nodeMap raw `/customnode/getmappings` payload
+ * @returns {number}
+ */
+export function nodeMapPackCount(nodeMap) {
+  if (!nodeMap || typeof nodeMap !== "object" || Array.isArray(nodeMap)) return 0;
+  let n = 0;
+  for (const val of Object.values(nodeMap)) {
+    if (Array.isArray(val) && Array.isArray(val[0])) n++;
+  }
+  return n;
+}
+
+/**
  * The failures a note would actually name: log failures minus the ones the live
  * backend contradicts (#1447), and none at all for a subgraph UUID (#1523).
  *
@@ -297,9 +320,18 @@ export function importFailureNote(failed, opts = {}) {
   // check came up short is stated exactly: a map that was read and did not link the
   // pack is different evidence from a map that could not be read at all, and the
   // reader's next step differs accordingly.
-  const why =
-    o.nodeMap && typeof o.nodeMap === "object"
-      ? `ComfyUI-Manager's node map does not link ${plural ? "them" : "it"} to that type`
+  // #808's lesson, applied to ownership: a 200 is not a catalogue. Manager answers
+  // `{}` when it assembled its list from none of its three sources, and a proxy can
+  // answer 200 with something that is not a catalogue at all. Both are objects, so
+  // "did we get a map" cannot be `typeof === object` — that would report "the map
+  // does not link it to that type" about a map that listed nothing, asserting a
+  // check that never ran. Count the packs the payload actually let us check.
+  const checkable = nodeMapPackCount(o.nodeMap);
+  const gotAnObject = !!o.nodeMap && typeof o.nodeMap === "object";
+  const why = checkable
+    ? `ComfyUI-Manager's node map does not link ${plural ? "them" : "it"} to that type`
+    : gotAnObject
+      ? `ComfyUI-Manager returned no usable node catalogue, so ownership could not be checked`
       : `ComfyUI-Manager's node map could not be read, so ownership was not checked`;
   return (
     ` SEPARATE ISSUE, not the cause of this missing type: ComfyUI reported that ` +

--- a/web/js/lib/pack-import-failures.js
+++ b/web/js/lib/pack-import-failures.js
@@ -150,7 +150,8 @@ const SUBGRAPH_UUID =
  * (`llm-toolkit`). Manager clones into a folder named after that last segment, which
  * is the SAME segment the `(IMPORT FAILED)` log line prints — so the final path
  * component, `.git` stripped, is what the two sides have in common. Normalised
- * through `packKey` so case and separators do not decide a match.
+ * through `ownerKey` — case-folded, separators KEPT — see there for why the looser
+ * `packKey` merges packs that are genuinely different projects.
  */
 function packKeyFromNodeMapKey(key) {
   const s = String(key || "")
@@ -159,7 +160,29 @@ function packKeyFromNodeMapKey(key) {
     .replace(/\/+$/, "");
   if (!s) return "";
   const seg = s.split(/[/\\]/).filter(Boolean).pop() || s;
-  return packKey(seg.replace(/\.git$/i, ""));
+  return ownerKey(seg.replace(/\.git$/i, ""));
+}
+
+/**
+ * The identity an OWNERSHIP claim is matched on: case-folded, separators KEPT.
+ *
+ * Deliberately stricter than `packKey`, which strips every non-alphanumeric. That
+ * loose form is right for #1447 — it matches a pack folder against ITSELF across
+ * case and separator drift — but it is wrong here, because it merges packs that are
+ * genuinely different projects. `ComfyUI-OmniSVG` (A043-studios) and
+ * `ComfyUI_OmniSVG` (smthemex) are separate repos by separate authors and collapse
+ * to one key; so do `ComfyUI-QwenVL`, `ComfyUI-Qwen-VL` and `ComfyUI_QwenVL`.
+ * Promoting on that would name the WRONG pack as a proven cause — #1544's own bug,
+ * restated with more confidence.
+ *
+ * Measured on the live 5583-entry map: under `packKey`, 79 normalised keys are
+ * claimed by more than one catalogue entry and 72 of those disagree about class
+ * names. Keeping separators takes that to 3, and costs nothing — the installed
+ * folder hit rate is 59/75 either way, because Manager clones into a folder named
+ * after the repo, separators and all.
+ */
+function ownerKey(name) {
+  return String(name || "").trim().toLowerCase();
 }
 
 /**
@@ -194,11 +217,24 @@ export function packsProvidingType(nodeMap, forType) {
   // "no owner", which is the branch that already handles not knowing. So an array
   // simply yields no owners and the caller says ownership was not established.
   if (Array.isArray(nodeMap)) return out;
+  // UNANIMITY among every catalogue entry sharing an owner key. Keeping separators
+  // leaves 3 keys still claimed by entries that disagree about class names, and a
+  // single one of those is enough to name the wrong pack with confidence. So a key
+  // owns the type only when EVERY entry filed under it provides it: aliases of one
+  // pack agree and still promote; two different projects that collide do not.
+  const byKey = new Map();
   for (const [key, val] of Object.entries(nodeMap)) {
     const classes = Array.isArray(val) ? val[0] : null;
-    if (!Array.isArray(classes) || !classes.includes(type)) continue;
+    if (!Array.isArray(classes)) continue;
     const pk = packKeyFromNodeMapKey(key);
-    if (pk) out.add(pk);
+    if (!pk) continue;
+    const seen = byKey.get(pk) || { entries: 0, providing: 0 };
+    seen.entries += 1;
+    if (classes.includes(type)) seen.providing += 1;
+    byKey.set(pk, seen);
+  }
+  for (const [pk, seen] of byKey) {
+    if (seen.providing > 0 && seen.providing === seen.entries) out.add(pk);
   }
   return out;
 }
@@ -285,7 +321,7 @@ export function importFailureNote(failed, opts = {}) {
   // one message that finally has a definite answer. A workflow LOAD still reports
   // every failure (the no-forType branch below).
   const owners = packsProvidingType(o.nodeMap, forType);
-  const owning = owners.size ? relevant.filter((name) => owners.has(packKey(name))) : [];
+  const owning = owners.size ? relevant.filter((name) => owners.has(ownerKey(name))) : [];
   if (owning.length) {
     const many = owning.length > 1;
     return (

--- a/web/js/lib/pack-import-failures.js
+++ b/web/js/lib/pack-import-failures.js
@@ -187,12 +187,15 @@ export function packsProvidingType(nodeMap, forType) {
   const type = String(forType || "").trim();
   const out = new Set();
   if (!type || !nodeMap || typeof nodeMap !== "object") return out;
-  // Both wire shapes, exactly as parseNodeMappings handles them: an ARRAY of pack
-  // objects, or the documented MAP of key → [[classNames…], meta].
-  const entries = Array.isArray(nodeMap)
-    ? nodeMap.map((p) => [p?.id ?? p?.reference ?? p?.title, p?.nodenames ?? p?.nodes])
-    : Object.entries(nodeMap).map(([k, v]) => [k, Array.isArray(v) ? v[0] : v?.nodenames]);
-  for (const [key, classes] of entries) {
+  // ONLY the documented MAP shape, key → [[classNames…], meta]. `parseNodeMappings`
+  // also accepts an ARRAY of pack objects, but it reads ids and titles from those —
+  // it never reads a class list, and no array payload carrying one was observed
+  // here. Inventing a field name for it would be a guess, and a wrong guess reads as
+  // "no owner", which is the branch that already handles not knowing. So an array
+  // simply yields no owners and the caller says ownership was not established.
+  if (Array.isArray(nodeMap)) return out;
+  for (const [key, val] of Object.entries(nodeMap)) {
+    const classes = Array.isArray(val) ? val[0] : null;
     if (!Array.isArray(classes) || !classes.includes(type)) continue;
     const pk = packKeyFromNodeMapKey(key);
     if (pk) out.add(pk);
@@ -303,9 +306,14 @@ export function importFailureNote(failed, opts = {}) {
     `${plural ? "these packs" : "this pack"} FAILED TO IMPORT at startup — ${list}. ` +
     `Nothing ties ${plural ? "them" : "it"} to "${forType}" — ${why} — so do not reinstall ` +
     `${plural ? "them" : "it"} expecting "${forType}" to appear. ` +
+    // #775's advice is still owed to the reader — a failed import is a real fault
+    // whoever hits this should fix, and re-installing is a dead end for it whether
+    // or not it owns the type they asked for. Demoting the CAUSAL claim must not
+    // quietly drop the remedy that made the note worth writing.
     `${plural ? "Those failures are" : "That failure is"} still worth fixing on ${
       plural ? "their" : "its"
-    } own: a pack that fails to import registers NONE of its nodes. ` +
+    } own: a pack that fails to import registers NONE of its nodes, and installing ` +
+    `${plural ? "them" : "it"} again will not help. ` +
     howToReadTheLog(relevant.length)
   );
 }


### PR DESCRIPTION
Closes #1544.

## The bug, reproduced by execution

`panel_add_node PreviewVideo` was refused with `coldinfire_fal_privacy FAILED TO IMPORT at startup` attached. Running the shipped `importFailureNote` on `origin/main` against a live ComfyUI (4498 types, `PreviewVideo` genuinely absent) reproduces the reported string exactly:

> …Check the exact class_type via create_workflow (action:"node_info") **BEFORE INSTALLING ANYTHING: ComfyUI reported that this pack FAILED TO IMPORT at startup — coldinfire_fal_privacy.** … This does not prove it provides "PreviewVideo" — the failure may be unrelated.

The hedge was already there. It was the **last sentence**, behind a lead that named a pack — so it read as an accusation with a footnote. The reporter acted on the lead, which is what leads are for.

## Why it could not do better before — and why that changed

The module's own docblock recorded the constraint:

> Establishing that needs the pack's NODE_CLASS_MAPPINGS, which is not readable from the browser

**That is no longer true, and it was the reason every caller settled for a hedge.** ComfyUI-Manager's `/customnode/getmappings` is keyed `pack → [[classNames…], meta]`, and the panel *already fetches that exact payload* for `panel_search_nodes` — `parseNodeMappings` reads `val[1]` (the meta) and throws `val[0]` (the class list) away. The ownership evidence was one array index from being in hand.

`packsProvidingType` reads it. Ownership now decides the framing:

| evidence | message |
|---|---|
| catalogue ties a failed pack to this `class_type` | `BEFORE INSTALLING ANYTHING: "X" is provided by <pack>…` — #775's causal advice, unchanged |
| catalogue searched, no link | `SEPARATE ISSUE, not the cause of this missing type: …` |
| no usable catalogue came back (`{}`, a proxy's sign-in page) | same, but *ownership could not be checked* |
| map unreadable (Manager off/legacy/unreachable) | same, but *ownership was not checked* |

Those last three are distinguished deliberately: "we did not check", "nothing came back to check against" and "we checked and found nothing" send a reader to different next steps.

The reported case now reads:

> …**SEPARATE ISSUE, not the cause of this missing type:** ComfyUI reported that this pack FAILED TO IMPORT at startup — coldinfire_fal_privacy. Nothing ties it to "PreviewVideo" — ComfyUI-Manager's node map does not link it to that type — so do not reinstall it expecting "PreviewVideo" to appear. That failure is still worth fixing on its own…

## Two defects this PR found in its own code

Both came out of the risk list I posted for review, not out of the diff. Both are fixed here.

**1. A 200 from Manager is not a catalogue** (`dcb7168d`). The unproven branch chose its wording on `typeof nodeMap === "object"`. But #808 already measured that Manager answers `{}` when it built its list from none of channel, cache or bundled copy, and a captive proxy answers 200 with a sign-in page — both objects. So an empty catalogue printed *"the node map does not link it to that type"*: a check that never ran, reported as one that ran and found nothing. `nodeMapPackCount` now counts entries that actually carry a class list.

**2. Ownership was matched on a key that merges distinct packs** (`8112fdb2`). `packKey` strips every non-alphanumeric, so `ComfyUI-OmniSVG` (A043-studios) and `ComfyUI_OmniSVG` (smthemex) — different repos, different authors — collapsed to one key, as did `ComfyUI-QwenVL` / `ComfyUI-Qwen-VL` / `ComfyUI_QwenVL`.

| owner key | keys claimed by >1 entry | …of those, entries **disagreeing** about class names |
|---|---|---|
| `packKey` (strips separators) | 79 | **72** |
| `ownerKey` (separators kept) | — | **3** |

That would have named the **wrong** pack as a proven cause — this issue's bug with more confidence. Ownership now matches on `ownerKey` (case-folded, separators kept); `dropLivePackImportFailures` keeps `packKey`, where loose matching is correct. **The tightening costs nothing:** installed-folder hit rate is 59/75 under both. For the 3 keys that still collide, a key owns a type only when **every** entry filed under it provides it — aliases agree and still promote; two projects sharing a key promote nothing.

## The claim I am least sure of

**`packsProvidingType` is positive-evidence-only, and that asymmetry is the whole safety argument.** The stronger rule — *"the catalogue knows this pack, its class list omits the type, therefore it is not the owner"* — would let the note actively exonerate a pack and **drop** `coldinfire_fal_privacy` outright rather than demote it.

I measured it before trusting it: of the 59 installed packs the catalogue recognises on this machine, **4 share no class at all** with their own `/object_info` entries, because the catalogue lags a pack's current release. That is ~7% of real import failures silently discarded — #775's fault with the sign flipped. Not implemented; a test pins that it stays unimplemented. **If that reasoning is wrong, this PR under-reports real causes.**

Also heuristic, and worth attacking: the folder↔catalogue-key match (last path segment, `.git` stripped). It ties `(IMPORT FAILED): …/ComfyUI-LTXVideo` to `https://github.com/lightricks/ComfyUI-LTXVideo.git`. A pack cloned into a renamed folder will not match — failing toward "unproven", the safe direction, but a genuinely-owning pack can go un-promoted. **59/75 (79%)** measured hit rate.

Third: only the documented MAP shape is read. `parseNodeMappings` also accepts an ARRAY of pack objects, but never reads a class list from one and I observed no array payload carrying one — so rather than invent a field name, an array yields no owners and the caller says ownership was unestablished.

## Cost

The catalogue is ~1.4 MB. `relevantPackImportFailures` is exported so the resolver fetches it **only when a surviving import failure actually needs adjudicating** — 0 fetches when nothing failed, when #1447's live-drop emptied the list, or for a #1523 subgraph UUID; exactly 1 otherwise. Pinned by test.

## Verified by mutation, not by a green suite

Ten mutations across three rounds; **every one went RED, each caught by its own named test**, with the baseline green before and after each:

| mutation | caught by |
|---|---|
| restore the causal-first framing for an unproven pack | `#1544 the reported refusal no longer blames an unrelated failed pack` |
| `packsProvidingType` always returns no owners | `#1544 ownership PROVEN still gets #775's causal note` |
| **panel stops passing `readNodeMap`** (fix ships inert) | `#1544 WIRING: the add-node guard is handed the Manager node map` |
| fetch the node map unconditionally | `#1544 the ~1.4MB node map is read ONLY when a failure needs adjudicating` |
| claim the map was checked when never read | `#1544 no map means ownership was NOT CHECKED, and says so` |
| disown a failure the map does not list | `#1544 POSITIVE evidence only — a map that omits the pack never drops it` |
| treat any object as a consulted catalogue | `#1544 a 200 that is not a catalogue is NOT a completed ownership check` |
| count entries that carry no class list | `#1544 nodeMapPackCount counts what is checkable, not what is present` |
| match ownership on the loose `packKey` again | `#1544 two DIFFERENT packs that normalise alike never prove ownership` |
| drop unanimity among entries sharing a key | `#1544 entries under ONE key must agree before that key owns a type` |

The wiring mutation matters most: the injection is one line in a 2 MB monolith, invisible to every helper-level test, and without that pin the whole check could ship dead. It was caught by that test **and only** that test.

An ordering assertion ("not the cause" must appear *before* the pack name) is the other deliberate one — the pre-#1544 note contained the same hedge words and still misled, so presence alone is not a regression guard.

## Test results

- **Unit: 6078 pass, 0 fail, 1 todo** (`npm run test:unit`, full suite). 16 new tests; #1447's two superseded wording pins updated to assert the *stronger* front-loaded claim plus ordering.
- `npm run typecheck` clean; `check:scope` OK (every name in the monolith resolves — the gate that catches a bad injection).
- **Real-data end-to-end**, against this machine's live ComfyUI and its 5583-entry Manager catalogue: the reported `PreviewVideo` refusal names no cause, and **400/401 sampled packs are still proven owner of their own class** — the collision tightening did not cost promotion.
- **Browser: 63 passed / 18 failed** (`npx playwright test --workers=1`, against a ComfyUI serving this branch). The 18 are **pre-existing**: the same 7 spec files run against unmodified `origin/main` (`9d332968`) on the same instance give a **byte-identical list of 18 failures**. They are MockBridge conversation/persistence/streaming specs, unrelated to this change; no assertion was loosened. Fixing that rig belongs to its own issue.

## What I deliberately did not do

- **Did not list the packs that *do* provide the type.** The catalogue knows `PreviewVideo` comes from `llm-toolkit`, `comfyui-nodes-erpk` and `vertex-ai-comfyui-nodes`, and naming them would be genuinely useful — but the issue asked for the misattribution to stop, not for install suggestions, and the freeze says bugs only.
- **Did not change the workflow-LOAD path.** With no requested type there is nothing to establish ownership against, so `api-workflow-load.js` keeps #775's exact wording and still reports every failure.
- **Did not drop unproven failures** — see the measurement above.
- **Did not touch `parseNodeMappings`** or `packKey`, though both now share a concern with the new code; changing a live search path or #1447's matcher was more risk than this bug is worth.
- In the proven-ownership branch, only the owner is named; other failures are omitted from *that* message rather than re-listed, which would put the ambiguity straight back.

## Review status

**Review pending — not gated.** `codex-gate.mjs` was deliberately not run (it currently answers from the owner's weakest model, so a SHIP from it would wear an authority it does not have). grok review requested in the comments, with the risky parts named. I have not merged and will not merge on my own verification alone.
