### PR TITLE
fix(874): saved subgraph host widgets survive panel_load_workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project are documented here. This project adheres to
 ## [Unreleased]
 
 ### Fixed
+- loading a saved workflow no longer resets a subgraph host's prompt, dimensions, length, and selectors to definition defaults (#874)
 - panel_add_node names a failed custom-node pack as the reason a type is missing only when ComfyUI-Manager's node map says that pack provides it; an unproven failure is reported as a separate issue rather than the cause (#1544)
 
 ## [0.15.30] - 2026-08-20

--- a/browser_tests/unit/load-workflow-subgraph-widgets.test.mjs
+++ b/browser_tests/unit/load-workflow-subgraph-widgets.test.mjs
@@ -1,0 +1,261 @@
+/**
+ * #874 remaining load path — `panel_load_workflow` (`graph_load`) of a saved
+ * subgraph host.
+ *
+ * The on-disk JSON keeps the edited `widgets_values` / `widgets_values_named`.
+ * ComfyUI's SubgraphNode.configure then reseeds the live host from INNER
+ * definition widgets, so node 116 shows pack defaults for prompt / dimensions
+ * / length / selectors while seed/fps can remain. The load still reports
+ * `loaded:true`.
+ *
+ * This drives the SHIPPED `graph_load` body, with `loadGraphData` modelled as
+ * that configure (live rails = definition defaults). After graph_load returns,
+ * the live host must show the FILE's values — not a reimplementation of the
+ * apply helper, and not a hardcoded expected list.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import { applySavedSubgraphHostWidgets } from "../../web/js/lib/subgraph-instance-widgets.js";
+import { sanitizeNodesAuxId } from "../../web/js/lib/aux-id-sanitize.js";
+import { resolveLoadGraphArgs } from "../../web/js/lib/session-rebind.js";
+import {
+  installNodeConfigureIsolation,
+  retryNodeRestores,
+} from "../../web/js/lib/load-restore-isolation.js";
+
+const panelPath = fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url));
+const PANEL = readFileSync(panelPath, "utf8").replace(/\r\n/g, "\n");
+
+const start = PANEL.indexOf("  async graph_load({ graph: incoming } = {}) {");
+const end = PANEL.indexOf("\n\n  graph_connect(", start);
+assert.notEqual(start, -1, "graph_load executor must still be recognisable");
+assert.ok(end > start, "the executor that follows graph_load must still be recognisable");
+const graphLoadSource = PANEL.slice(start, end);
+
+const SG_ID = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+const ROOT_GRAPH_ID = "c4a254bb-935e-4013-b380-5e36954de4b0";
+
+/** The reporter's shape: a single-host Image-to-Video subgraph with edited host widgets. */
+function savedWorkflow() {
+  return {
+    nodes: [
+      {
+        id: 116,
+        type: SG_ID,
+        widgets_values: [
+          "a vaporwave alley at dusk",
+          1280,
+          704,
+          81,
+          "wan_high.safetensors",
+          42,
+          16,
+        ],
+        widgets_values_named: {
+          prompt: "a vaporwave alley at dusk",
+          width: 1280,
+          height: 704,
+          length: 81,
+          unet_name: "wan_high.safetensors",
+          seed: 42,
+          fps: 16,
+        },
+      },
+    ],
+    definitions: {
+      subgraphs: [
+        {
+          id: SG_ID,
+          name: "Image to Video (Wan 2.2)",
+          nodes: [
+            {
+              id: 10,
+              type: "CLIPTextEncode",
+              widgets_values: ["DEFINITION-DEFAULT-PROMPT"],
+            },
+          ],
+        },
+      ],
+    },
+  };
+}
+
+const DEFINITION_DEFAULTS = {
+  prompt: "DEFINITION-DEFAULT-PROMPT",
+  width: 832,
+  height: 480,
+  length: 49,
+  unet_name: "wan_default.safetensors",
+  seed: 0,
+  fps: 16,
+};
+
+/**
+ * What SubgraphNode.configure does: rails exist, widgetIds exist, values are
+ * the INNER definition defaults — not the host's saved widgets_values_named.
+ */
+function configureHostFromDefinition(saved) {
+  const def = saved.definitions.subgraphs[0];
+  const named = saved.nodes[0].widgets_values_named;
+  const inner = {
+    id: def.nodes[0].id,
+    type: def.nodes[0].type,
+    widgets: [{ name: "prompt", value: def.nodes[0].widgets_values[0] }],
+  };
+  const subgraph = { id: SG_ID, _nodes: [inner] };
+  const store = new Map();
+  const rails = [];
+  const inputs = [];
+  for (const name of Object.keys(named)) {
+    const widgetId = `${ROOT_GRAPH_ID}:${encodeURIComponent("116")}:${encodeURIComponent(name)}`;
+    store.set(widgetId, { name, value: DEFINITION_DEFAULTS[name] });
+    const rail = {
+      name,
+      get widgetId() {
+        return widgetId;
+      },
+      get value() {
+        return store.get(widgetId)?.value;
+      },
+      set value(next) {
+        const state = store.get(widgetId);
+        if (state) state.value = next;
+      },
+      callback(next) {
+        const state = store.get(widgetId);
+        if (state) state.value = next;
+      },
+    };
+    rails.push(rail);
+    inputs.push({ name, widgetId, _widget: rail });
+  }
+  const host = {
+    id: 116,
+    type: SG_ID,
+    subgraph,
+    inputs,
+    get widgets() {
+      return rails;
+    },
+  };
+  return { host, inner, graph: { _nodes: [host] }, rail: (n) => rails.find((r) => r.name === n) };
+}
+
+function extractGraphLoad(getGraphCtx) {
+  return new Function(
+    "getGraphCtx",
+    "assertGraphBoundToActiveWorkflow",
+    "MUTATION_BINDING_BAR",
+    "coerceMessageText",
+    "looksLikeApiWorkflow",
+    "sanitizeNodesAuxId",
+    "captureGraphSnapshot",
+    "resolveLoadGraphArgs",
+    "installNodeConfigureIsolation",
+    "retryNodeRestores",
+    "loadLandedWorkflowUuid",
+    "applySavedSubgraphHostWidgets",
+    `const GRAPH_TOOL_EXECUTORS = {${graphLoadSource}\n}; return GRAPH_TOOL_EXECUTORS.graph_load;`,
+  )(
+    getGraphCtx,
+    () => {},
+    {},
+    (v) => String(v ?? ""),
+    () => false,
+    sanitizeNodesAuxId,
+    () => {},
+    resolveLoadGraphArgs,
+    installNodeConfigureIsolation,
+    retryNodeRestores,
+    () => null,
+    applySavedSubgraphHostWidgets,
+  );
+}
+
+test("#874 panel_load_workflow leaves the saved subgraph host widgets on the live host", async () => {
+  const file = savedWorkflow();
+  const live = configureHostFromDefinition(file);
+  const app = {
+    loadGraphData: async (payload) => {
+      // The frontend load "succeeds" and leaves definition defaults on the host.
+      assert.equal(payload.nodes[0].id, file.nodes[0].id);
+      Object.assign(live.graph, { extra: payload.extra });
+    },
+    graph: live.graph,
+    extensionManager: { workflow: { activeWorkflow: { path: "wan.json" } } },
+  };
+  const graphLoad = extractGraphLoad(() => ({
+    app,
+    graph: live.graph,
+    rootGraph: live.graph,
+    LG: null,
+  }));
+
+  assert.equal(live.rail("prompt").value, DEFINITION_DEFAULTS.prompt, "the bug: configure left the definition default");
+  const reply = await graphLoad({ graph: file });
+  assert.equal(reply.loaded, true);
+
+  const saved = file.nodes[0].widgets_values_named;
+  for (const [name, want] of Object.entries(saved)) {
+    assert.equal(live.rail(name).value, want, `${name} must be the value the FILE carried`);
+  }
+  assert.equal(live.inner.widgets[0].value, file.definitions.subgraphs[0].nodes[0].widgets_values[0]);
+});
+
+test("#874 removing the post-load apply leaves the host at definition defaults", async () => {
+  const file = savedWorkflow();
+  const live = configureHostFromDefinition(file);
+  const app = {
+    loadGraphData: async () => {},
+    graph: live.graph,
+    extensionManager: { workflow: { activeWorkflow: { path: "wan.json" } } },
+  };
+  const graphLoad = extractGraphLoad(() => ({
+    app,
+    graph: live.graph,
+    rootGraph: live.graph,
+    LG: null,
+  }));
+  // Inject a no-op so this is the SAME executor with the apply stripped — the
+  // semantic assertion the original #874 e2e required: the live host must carry
+  // the file's prompt, not merely that a helper was named.
+  const stripped = new Function(
+    "getGraphCtx",
+    "assertGraphBoundToActiveWorkflow",
+    "MUTATION_BINDING_BAR",
+    "coerceMessageText",
+    "looksLikeApiWorkflow",
+    "sanitizeNodesAuxId",
+    "captureGraphSnapshot",
+    "resolveLoadGraphArgs",
+    "installNodeConfigureIsolation",
+    "retryNodeRestores",
+    "loadLandedWorkflowUuid",
+    "applySavedSubgraphHostWidgets",
+    `const GRAPH_TOOL_EXECUTORS = {${graphLoadSource}\n}; return GRAPH_TOOL_EXECUTORS.graph_load;`,
+  )(
+    () => ({ app, graph: live.graph, rootGraph: live.graph, LG: null }),
+    () => {},
+    {},
+    (v) => String(v ?? ""),
+    () => false,
+    sanitizeNodesAuxId,
+    () => {},
+    resolveLoadGraphArgs,
+    installNodeConfigureIsolation,
+    retryNodeRestores,
+    () => null,
+    () => ({ restored: 0, skipped: 0 }),
+  );
+  await stripped({ graph: file });
+  assert.equal(
+    live.rail("prompt").value,
+    DEFINITION_DEFAULTS.prompt,
+    "without the apply, the host stays at the definition default the reporter saw",
+  );
+  await graphLoad({ graph: file });
+  assert.equal(live.rail("prompt").value, file.nodes[0].widgets_values_named.prompt);
+});

--- a/browser_tests/unit/subgraph-instance-widgets.test.mjs
+++ b/browser_tests/unit/subgraph-instance-widgets.test.mjs
@@ -17,6 +17,7 @@ import {
   snapshotPromotedInstanceWidgets,
   restorePromotedInstanceWidgets,
   withPreservedPromotedInstanceWidgets,
+  applySavedSubgraphHostWidgets,
 } from "../../web/js/lib/subgraph-instance-widgets.js";
 
 const ROOT_GRAPH_ID = "c4a254bb-935e-4013-b380-5e36954de4b0";
@@ -218,5 +219,143 @@ test("#1827 the dispatcher snapshots before a subgraph mutation and restores aft
     SRC,
     /visibleMutationTarget\.graph !== visibleMutationTarget\.rootGraph/,
     "preserve only while INSIDE a subgraph — the reported enter/mutate/exit path",
+  );
+});
+
+/**
+ * #874 load path — a saved subgraph host whose JSON still has the edited
+ * widgets_values_named, after ComfyUI configure reseeds the rails from the
+ * inner definition.
+ */
+const WAN_SG_ID = "11111111-2222-3333-4444-555555555555";
+
+function makeLoadedHost({ savedNamed, definitionDefaults, positional }) {
+  const inner = {
+    id: 10,
+    type: "CLIPTextEncode",
+    widgets: Object.entries(definitionDefaults).map(([name, value]) => ({ name, value })),
+  };
+  const subgraph = { id: WAN_SG_ID, _nodes: [inner] };
+  const store = new Map();
+  const rails = [];
+  const inputs = [];
+  for (const [name, defValue] of Object.entries(definitionDefaults)) {
+    const widgetId = `${ROOT_GRAPH_ID}:${encodeURIComponent("116")}:${encodeURIComponent(name)}`;
+    store.set(widgetId, { name, value: defValue });
+    const rail = {
+      name,
+      get widgetId() {
+        return widgetId;
+      },
+      get value() {
+        return store.get(widgetId)?.value;
+      },
+      set value(next) {
+        const state = store.get(widgetId);
+        if (state) state.value = next;
+      },
+      callback(next) {
+        const state = store.get(widgetId);
+        if (state) state.value = next;
+      },
+    };
+    rails.push(rail);
+    inputs.push({ name, widgetId, _widget: rail });
+  }
+  const live = {
+    id: 116,
+    type: WAN_SG_ID,
+    subgraph,
+    inputs,
+    get widgets() {
+      return rails;
+    },
+  };
+  const saved = {
+    id: 116,
+    type: WAN_SG_ID,
+    ...(positional ? { widgets_values: positional } : {}),
+    ...(savedNamed ? { widgets_values_named: savedNamed } : {}),
+  };
+  return {
+    live,
+    inner,
+    liveRoot: { _nodes: [live] },
+    savedGraph: {
+      nodes: [saved],
+      definitions: { subgraphs: [{ id: WAN_SG_ID, nodes: [inner] }] },
+    },
+    rail: (name) => rails.find((r) => r.name === name),
+  };
+}
+
+test("#874 a saved subgraph host keeps its named widgets, not definition defaults", () => {
+  const savedNamed = {
+    prompt: "a vaporwave alley at dusk",
+    width: 1280,
+    height: 704,
+    length: 81,
+    unet_name: "wan_high.safetensors",
+    seed: 42,
+    fps: 16,
+  };
+  const definitionDefaults = {
+    prompt: "DEFINITION-DEFAULT-PROMPT",
+    width: 832,
+    height: 480,
+    length: 49,
+    unet_name: "wan_default.safetensors",
+    seed: 0,
+    fps: 16,
+  };
+  const fx = makeLoadedHost({ savedNamed, definitionDefaults });
+  assert.equal(fx.rail("prompt").value, definitionDefaults.prompt, "configure left the definition default");
+  applySavedSubgraphHostWidgets(fx.liveRoot, fx.savedGraph);
+  for (const [name, want] of Object.entries(savedNamed)) {
+    assert.equal(fx.rail(name).value, want, `${name} must be the FILE's value`);
+  }
+  assert.equal(fx.inner.widgets[0].value, "DEFINITION-DEFAULT-PROMPT", "the shared definition must not move");
+});
+
+test("#874 positional widgets_values apply when the file has no named map", () => {
+  const definitionDefaults = { prompt: "DEFAULT", width: 832, length: 49 };
+  const positional = ["SAVED-PROMPT", 1280, 81];
+  const fx = makeLoadedHost({ definitionDefaults, positional });
+  applySavedSubgraphHostWidgets(fx.liveRoot, fx.savedGraph);
+  assert.equal(fx.rail("prompt").value, positional[0]);
+  assert.equal(fx.rail("width").value, positional[1]);
+  assert.equal(fx.rail("length").value, positional[2]);
+});
+
+test("#874 named values win when the file carries both maps", () => {
+  const savedNamed = { prompt: "NAMED-PROMPT", width: 1280 };
+  const positional = ["POSITIONAL-PROMPT", 640];
+  const definitionDefaults = { prompt: "DEFAULT", width: 832 };
+  const fx = makeLoadedHost({ savedNamed, definitionDefaults, positional });
+  applySavedSubgraphHostWidgets(fx.liveRoot, fx.savedGraph);
+  assert.equal(fx.rail("prompt").value, savedNamed.prompt);
+  assert.equal(fx.rail("width").value, savedNamed.width);
+});
+
+test("#874 a missing host or empty saved graph is a no-op, not a throw", () => {
+  const fx = makeLoadedHost({
+    savedNamed: { prompt: "SAVED" },
+    definitionDefaults: { prompt: "DEFAULT" },
+  });
+  assert.deepEqual(applySavedSubgraphHostWidgets(null, fx.savedGraph), { restored: 0, skipped: 0 });
+  assert.deepEqual(applySavedSubgraphHostWidgets(fx.liveRoot, null), { restored: 0, skipped: 0 });
+  assert.equal(fx.rail("prompt").value, "DEFAULT");
+});
+
+test("#874 graph_load and the disk-reload open path both re-apply saved host widgets", () => {
+  assert.match(
+    SRC,
+    /applySavedSubgraphHostWidgets\(app\?\.graph, clone\)/,
+    "graph_load — panel_load_workflow — must re-apply the FILE after loadGraphData",
+  );
+  assert.match(
+    SRC,
+    /applySavedSubgraphHostWidgets\(app\?\.graph, diskGraph\)/,
+    "workflow_open's on-disk reload must re-apply the FILE after loadGraphData",
   );
 });

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -234,7 +234,10 @@ import {
   materializedValuesNote,
   findDivergentPromotedValues,
 } from "./lib/unpack-promoted-values.js";
-import { withPreservedPromotedInstanceWidgets } from "./lib/subgraph-instance-widgets.js";
+import {
+  withPreservedPromotedInstanceWidgets,
+  applySavedSubgraphHostWidgets,
+} from "./lib/subgraph-instance-widgets.js";
 import {
   snapshotExternalLinks,
   verifyExternalLinks,
@@ -13677,6 +13680,16 @@ const GRAPH_TOOL_EXECUTORS = {
     const { restored: retriedNodes, failed: unrestoredNodes } = isolation?.failures?.length
       ? retryNodeRestores(app?.graph, isolation.failures)
       : { restored: [], failed: [] };
+    // #874 remaining load path — SubgraphNode.configure seeds host rails from
+    // INNER definition widgets, so a saved subgraph host lands at defaults
+    // (prompt, dimensions, length, selectors) while the file still holds the
+    // edited values. Rails exist after this load; write the FILE's host values
+    // back. Best-effort: a hostile rail must not fail a load that already landed.
+    try {
+      applySavedSubgraphHostWidgets(app?.graph, clone);
+    } catch {
+      /* live graph stays as loadGraphData left it */
+    }
     // comfyui-mcp#1478 (defect 1) — REPORT THE IDENTITY THIS LOAD LANDED ON.
     //
     // `activeWorkflow` was captured before the load and passed to loadGraphData as the
@@ -18147,6 +18160,11 @@ const GRAPH_TOOL_EXECUTORS = {
           beginWorkflowReloadStep(reloadGuardToken);
           try {
             await app.loadGraphData(diskGraph, true, true, target, { __cmcpKeepInstance: true });
+            try {
+              applySavedSubgraphHostWidgets(app?.graph, diskGraph);
+            } catch {
+              /* live graph stays as the file load left it */
+            }
           } finally {
             endWorkflowReloadStep(reloadGuardToken);
           }
@@ -18196,6 +18214,21 @@ const GRAPH_TOOL_EXECUTORS = {
       // holder reopens the canvas.
       releaseWorkflowReloadGuard(reloadGuardToken);
       releaseCanvasInteractionLock(priorInteraction, canvasView);
+    }
+    // #874 — a FIRST-TIME open loads through ComfyUI's openWorkflow, which runs
+    // the same SubgraphNode.configure that drops host widgets_values. Apply the
+    // FILE's host values AFTER content proof so a widget rewrite cannot fail the
+    // open, and only when this tab was not already open (an already-open tab
+    // may hold unsaved edits the file does not). Skip if the disk re-read
+    // already applied the on-disk graph.
+    if (!openFailed && !rebindFailed && !wasOpen && !reloaded) {
+      try {
+        const raw = target.originalContent ?? target.content;
+        const saved = typeof raw === "string" ? JSON.parse(raw) : raw;
+        applySavedSubgraphHostWidgets(app?.graph, saved);
+      } catch {
+        /* unreadable file content — live graph stays as the frontend left it */
+      }
     }
     if (openFailed) throw failOpen(openFailed);
     if (rebindFailed) {
@@ -18518,6 +18551,11 @@ const GRAPH_TOOL_EXECUTORS = {
       serializeCanvas: () => host?.graph?.serialize?.() ?? null,
       loadGraph: async (graph, target) => {
         await host.loadGraphData(graph, true, true, target, { __cmcpKeepInstance: true });
+        try {
+          applySavedSubgraphHostWidgets(host?.graph, graph);
+        } catch {
+          /* live graph stays as the file load left it */
+        }
       },
       rebaseline: async (target, diskText) => {
         try {

--- a/web/js/lib/subgraph-instance-widgets.js
+++ b/web/js/lib/subgraph-instance-widgets.js
@@ -207,6 +207,111 @@ export function restorePromotedInstanceWidgets(rootGraph, snapshot) {
 }
 
 /**
+ * Named `widgets_values_named` map from a serialized node, or null when the
+ * file did not carry one. Positional `widgets_values` is the fallback — it is
+ * what older saves (and a frontend with named restore off) have — zipped with
+ * the LIVE rail names after configure has built them.
+ */
+function savedHostWidgetMap(savedNode, liveNode) {
+  const named = savedNode?.widgets_values_named;
+  if (named && typeof named === "object" && !Array.isArray(named)) {
+    const out = {};
+    for (const [key, value] of Object.entries(named)) {
+      if (typeof key === "string" && key) out[key] = value;
+    }
+    if (Object.keys(out).length) return out;
+  }
+  const positional = savedNode?.widgets_values;
+  if (!Array.isArray(positional)) return {};
+  const names = [];
+  try {
+    for (const rail of liveNode?.widgets ?? []) {
+      if (rail && typeof rail.name === "string" && rail.name) names.push(rail.name);
+    }
+  } catch {
+    return {};
+  }
+  const out = {};
+  for (let i = 0; i < names.length && i < positional.length; i++) {
+    out[names[i]] = positional[i];
+  }
+  return out;
+}
+
+function savedDefinitionsById(savedGraph) {
+  const byId = new Map();
+  for (const def of savedGraph?.definitions?.subgraphs ?? []) {
+    if (def?.id != null) byId.set(String(def.id), def);
+  }
+  return byId;
+}
+
+/**
+ * #874 remaining load path — `panel_load_workflow` / `graph_load` of a saved
+ * subgraph host.
+ *
+ * ComfyUI's `SubgraphNode.configure` (frontend 1.49.6 and current master)
+ * recreates host inputs from the definition, then `_setWidget` seeds the
+ * per-instance store from the INNER widget. `_applyPromotedWidgetValues` is a
+ * no-op while those inputs still have no `widgetId`. The file's
+ * `widgets_values` / `widgets_values_named` survive on disk and the load
+ * reports `loaded:true`, but the live host shows definition defaults for
+ * prompt, dimensions, length, and selectors. Seed/fps can remain because they
+ * are not rebuilt the same way.
+ *
+ * After `loadGraphData` the rails exist and have widgetIds. Re-apply the FILE's
+ * host values onto those instance rails — never the shared inner widget.
+ *
+ * @returns {{ restored: number, skipped: number }}
+ */
+export function applySavedSubgraphHostWidgets(liveRoot, savedGraph) {
+  const result = { restored: 0, skipped: 0 };
+  if (!liveRoot || !savedGraph || typeof savedGraph !== "object") return result;
+  const defs = savedDefinitionsById(savedGraph);
+
+  const applyInGraph = (liveGraph, savedNodes) => {
+    if (!liveGraph || !Array.isArray(savedNodes)) return;
+    const savedById = new Map();
+    for (const node of savedNodes) {
+      if (node?.id != null) savedById.set(String(node.id), node);
+    }
+    let liveNodes;
+    try {
+      liveNodes = liveGraph._nodes;
+    } catch {
+      return;
+    }
+    if (!Array.isArray(liveNodes)) return;
+    for (const live of liveNodes) {
+      if (!live?.subgraph) continue;
+      const saved = savedById.get(String(live.id));
+      if (saved) {
+        const values = savedHostWidgetMap(saved, live);
+        const entries = Object.entries(values).map(([widgetName, value]) => ({
+          nodeId: live.id,
+          widgetName,
+          value: cloneValue(value),
+          widgetId: null,
+        }));
+        if (entries.length) {
+          const one = restorePromotedInstanceWidgets(
+            { _nodes: [live] },
+            { subgraph: live.subgraph, entries },
+          );
+          result.restored += one.restored;
+          result.skipped += one.skipped;
+        }
+      }
+      const def = defs.get(String(live.subgraph.id ?? live.type ?? ""));
+      if (def) applyInGraph(live.subgraph, def.nodes);
+    }
+  };
+
+  applyInGraph(liveRoot, savedGraph.nodes);
+  return result;
+}
+
+/**
  * Snapshot instance-scoped promoted rails, run `fn`, then restore. Used around
  * inner-graph mutations (and exit) so a definition replace cannot keep the
  * empty rails it just wrote. `fn` may be sync or async.


### PR DESCRIPTION
Fixes #874

## What the user now observes

After `panel_load_workflow` of a saved subgraph host (the reporter's single-host Image to Video (Wan 2.2), and the same shape), the live host shows the **file's** prompt, dimensions, length, and model/LoRA selectors — not the subgraph definition defaults. `panel_open_workflow` of a not-yet-open saved file, and an on-disk reload, do the same.

The 0.11.60 `checkState()` reopen fix (#875) stays closed. This is the remaining **load** path the 23:10Z report named.

## Cause

ComfyUI's `SubgraphNode.configure` (frontend 1.49.6 / current master) recreates host inputs from the definition, then `_setWidget` seeds the per-instance store from the **inner** widget. `_applyPromotedWidgetValues` is a no-op while those inputs still have no `widgetId`. The JSON on disk is fine; the load reports `loaded:true`; the live host is at pack defaults. Seed/fps can remain because they are not rebuilt the same way.

#1454 / mcp#1827 (0.15.15) keeps parent widgets across **inner** subgraph edits. It does not re-apply file values after `loadGraphData`.

## Fix

After `loadGraphData` lands, re-apply the file's `widgets_values_named` (else positional `widgets_values`) onto instance-scoped host rails. Shared inner widgets are not written.

## Tests

`browser_tests/unit/load-workflow-subgraph-widgets.test.mjs` drives the shipped `graph_load` body: `loadGraphData` is modelled as that configure (rails = definition defaults). After `graph_load` returns, live rails equal the **file's** named map. Stripping the apply leaves the definition default.
