### PR TITLE
fix(mcp#1130): a FLOAT widget's quantization is explained by the grid the frontend actually ran

### DIFF
--- a/browser_tests/unit/widget-normalization.test.mjs
+++ b/browser_tests/unit/widget-normalization.test.mjs
@@ -148,12 +148,21 @@ test("#1130 the float grid is `round`, and NEITHER reading of `step` is it", () 
 });
 
 test("#1130 the float grid is anchored at ZERO, not at min", () => {
-  // NormalizeImages.std: min 0.001, round 0.1. Measured: 0.3381 stores 0.3.
-  // Anchored at min the same arithmetic yields 0.301 — so the anchor is not a
-  // detail, it decides the value.
-  const w = widget({ min: 0.001, max: 1, step: 5, step2: 0.5, round: 0.1, precision: 1 });
-  assert.ok(explainNumericNormalization(0.3381, 0.3, w), "zero-anchored 0.3 is what the widget stored");
-  assert.equal(explainNumericNormalization(0.3381, 0.301, w), null, "the min-anchored answer never happened");
+  // The anchor is usually invisible — `toFixed(precision)` re-rounds onto the
+  // zero grid and hides it — so these are the requests where it is NOT, found by
+  // sweeping the two models against each other and then MEASURED on the rig.
+  // Each pair is (what the widget stored, what a min-anchored model predicts).
+  const std = widget({ min: 0.001, max: 1, step: 5, step2: 0.5, round: 0.1, precision: 1 });
+  assert.ok(explainNumericNormalization(0.0500223, 0.1, std), "measured: 0.0500223 stores 0.1");
+  assert.equal(explainNumericNormalization(0.0500223, 0.001, std), null, "min-anchored says 0.001 — it never happened");
+
+  const duration = widget({ min: 0.01, max: 2048, step: 5, step2: 0.5, round: 0.1, precision: 1 });
+  assert.ok(explainNumericNormalization(0.05137, 0.1, duration), "measured: 0.05137 stores 0.1");
+  assert.equal(explainNumericNormalization(0.05137, 0.01, duration), null, "min-anchored says 0.01");
+
+  const alpha = widget({ min: -10000, max: 10000, step: 1, step2: 0.1, round: 0.01, precision: 1 });
+  assert.ok(explainNumericNormalization(-9999.554863, -9999.6, alpha), "measured: -9999.554863 stores -9999.6");
+  assert.equal(explainNumericNormalization(-9999.554863, -9999.5, alpha), null, "min-anchored says -9999.5");
 });
 
 test("#1130 `toFixed(precision)` is arithmetic, not presentation", () => {

--- a/browser_tests/unit/widget-normalization.test.mjs
+++ b/browser_tests/unit/widget-normalization.test.mjs
@@ -102,3 +102,195 @@ test("#805 WIRING: normalization suppresses the failure AND is disclosed on the 
   assert.match(src, /requested_value: expected/)
   assert.match(src, /normalization_note: normalizationNote\(/)
 })
+
+// ---------------------------------------------------------------------------
+// comfyui-mcp#1130 (recurrence, 2026-08-21) — the same failure on a FLOAT grid.
+//
+//   panel_set_widget AdjustContrast.factor = 1.12 → widget stored 1.1
+//   → "did not retain the requested value"
+//
+// Every widget config and every stored value below was MEASURED on the live rig
+// (ComfyUI 0.33.2 / frontend 1.49.6) by creating the real node, assigning the
+// request and invoking the widget's own callback — the same two steps
+// applyWidgetWrite performs. None of them is derived from the code under test.
+//
+// The frontend's number widget has TWO callbacks and they share no term:
+//
+//   onValueChange (INT)     t = options.step2 || 1
+//                           t === 1 ? Math.round(e)
+//                                   : Math.round((e - min % t) / t) * t + min % t
+//   onFloatValueChange      t = options.round
+//                           r = Math.round(e / t) * t
+//                           clamp(Number(r.toFixed(precision)), min, max)
+//
+// The first fix modelled only the integer one, min-anchored, from `step`.
+// ---------------------------------------------------------------------------
+
+// AdjustContrast declares `{ default: 1, min: 0, max: 2 }` and NO step at all,
+// so the frontend fills in the rest.
+const ADJUST_CONTRAST_FACTOR = { min: 0, max: 2, step: 5, step2: 0.5, round: 0.1, precision: 1 };
+
+test("#1130 the reporter's exact case: 1.12 -> 1.1 is the widget's own grid, not a failed write", () => {
+  const w = widget(ADJUST_CONTRAST_FACTOR);
+  const r = explainNumericNormalization(1.12, 1.1, w);
+  assert.ok(r, "AdjustContrast.factor 1.12 -> 1.1 must be recognised as normalization");
+  assert.match(r.rule, /round 0\.1/);
+});
+
+test("#1130 the float grid is `round`, and NEITHER reading of `step` is it", () => {
+  // This is the whole miss. `step` is 5 and the 10x reading of it is 0.5; the
+  // grid that produced 1.1 is `round` = 0.1. Pin it by asserting the values the
+  // OLD model would have produced are still refused — 1.12 on a step-5 grid
+  // gives 0, on a 0.5 grid gives 1.0.
+  const w = widget(ADJUST_CONTRAST_FACTOR);
+  assert.equal(explainNumericNormalization(1.12, 0, w), null, "step 5 is not the grid");
+  assert.equal(explainNumericNormalization(1.12, 1, w), null, "step 0.5 is not the grid either");
+});
+
+test("#1130 the float grid is anchored at ZERO, not at min", () => {
+  // NormalizeImages.std: min 0.001, round 0.1. Measured: 0.3381 stores 0.3.
+  // Anchored at min the same arithmetic yields 0.301 — so the anchor is not a
+  // detail, it decides the value.
+  const w = widget({ min: 0.001, max: 1, step: 5, step2: 0.5, round: 0.1, precision: 1 });
+  assert.ok(explainNumericNormalization(0.3381, 0.3, w), "zero-anchored 0.3 is what the widget stored");
+  assert.equal(explainNumericNormalization(0.3381, 0.301, w), null, "the min-anchored answer never happened");
+});
+
+test("#1130 `toFixed(precision)` is arithmetic, not presentation", () => {
+  // KSampler.cfg declares step 0.1 → round 0.01, precision 1. Measured: 7.777
+  // stores 7.8, NOT the 7.78 the grid alone gives. A model without the toFixed
+  // term cannot produce this number at all.
+  const w = widget({ min: 0, max: 100, step: 1, step2: 0.1, round: 0.01, precision: 1 });
+  assert.ok(explainNumericNormalization(7.777, 7.8, w), "7.777 -> 7.8 (round 0.01 then 1 dp)");
+  assert.equal(explainNumericNormalization(7.777, 7.78, w), null, "the un-fixed grid value never happened");
+  assert.ok(explainNumericNormalization(8.06, 8.1, w), "8.06 -> 8.1, measured");
+});
+
+test("#1130 the fix is exactness, NOT a tolerance — the raw product is refused", () => {
+  // `Math.round(0.3381 / 0.1) * 0.1` leaves 0.30000000000000004; the frontend's
+  // toFixed makes it the exact double 0.3. Those two differ by 5.5e-17 and only
+  // ONE of them is what the widget stored. If this assertion ever fails, an
+  // epsilon has crept in — and an epsilon here accepts writes that never landed.
+  const w = widget({ min: 0.001, max: 1, step: 5, step2: 0.5, round: 0.1, precision: 1 });
+  assert.notEqual(0.30000000000000004, 0.3);
+  assert.equal(explainNumericNormalization(0.3381, 0.30000000000000004, w), null);
+  assert.ok(explainNumericNormalization(0.3381, 0.3, w));
+});
+
+test("#1130 negative values quantize on the same zero-anchored grid", () => {
+  // StereoImageNode.stereo_balance, measured: -0.91629 stores -0.92.
+  const w = widget({ min: -0.95, max: 0.95, step: 0.5, step2: 0.05, round: 0.01, precision: 2 });
+  assert.ok(explainNumericNormalization(-0.91629, -0.92, w));
+  // LoraLoader.strength_model, measured: 0.755 stores 0.76.
+  const lora = widget({ min: -100, max: 100, step: 0.1, step2: 0.01, round: 0.01, precision: 2 });
+  assert.ok(explainNumericNormalization(0.755, 0.76, lora));
+});
+
+test("#1130 the INT callback's min-OFFSET anchor is still explained on a modern build", () => {
+  // #805's own numbers, in the shape a current frontend actually presents them:
+  // a declared `step: 64, min: 1` arrives as step 640 / step2 64, and the
+  // callback anchors at `min % step2` = 1. 2048 -> 2049 and 4096 -> 4097.
+  const w = widget({ min: 1, max: 1000000000, step: 640, step2: 64, precision: 0 });
+  const a = explainNumericNormalization(2048, 2049, w);
+  assert.ok(a, "2048 -> 2049 (= 1 + 32*64)");
+  assert.match(a.rule, /step 64/);
+  assert.ok(explainNumericNormalization(4096, 4097, w), "4096 -> 4097");
+  // EmptyLatentImage.width, measured: min 16, step2 8 — 1281 stores 1280.
+  assert.ok(
+    explainNumericNormalization(1281, 1280, widget({ min: 16, max: 16384, step: 80, step2: 8, precision: 0 })),
+  );
+  // KSampler.steps, measured: step2 1 — 20.4 stores 20.
+  assert.ok(explainNumericNormalization(20.4, 20, widget({ min: 1, max: 10000, step: 10, step2: 1, precision: 0 })));
+});
+
+test("#1130 REVERSE: a genuine revert is still a failed write", () => {
+  const w = widget(ADJUST_CONTRAST_FACTOR);
+  assert.equal(explainNumericNormalization(1.12, 1, w), null, "reverted to its default 1.0");
+  assert.equal(explainNumericNormalization(1.12, 0, w), null, "reverted to min");
+  assert.equal(explainNumericNormalization(1.12, 1.2, w), null, "one grid step off");
+  assert.equal(explainNumericNormalization(1.12, 1.14, w), null, "a value the grid cannot produce");
+  assert.equal(
+    explainNumericNormalization(1.12, 1.1000000001, w),
+    null,
+    "a near-miss the widget never stored is not 'close enough'",
+  );
+});
+
+test("#1130 REVERSE: only the callback the config selects may explain the value", () => {
+  // Measured on the rig: ThinkingLLM_QwenVL_Advanced.temperature (min 0.1,
+  // round 0.1, step2 0.5, default 0.6) stores 0.4 for a request of 0.4371.
+  // A widget that instead REVERTED to its 0.6 default must stay a failure — and
+  // it did not, before this change: 0.6 is exactly what the unrelated `step2`
+  // 0.5 grid produces from 0.4371, so an explainer that tries every reading at
+  // once reports a write that never landed as normalized. Offering one reading
+  // per config is what makes the optimistic direction safe.
+  const w = widget({ min: 0.1, max: 1, step: 5, step2: 0.5, round: 0.1, precision: 1 });
+  assert.ok(explainNumericNormalization(0.4371, 0.4, w), "the round-0.1 grid is what ran");
+  assert.equal(explainNumericNormalization(0.4371, 0.6, w), null, "a revert to the default is NOT normalization");
+  // Same shape, another measured case from that sweep: PrimitiveFloat.value.
+  const primitiveFloat = widget({ step: 1, step2: 1, round: 0.1, precision: 1 });
+  assert.ok(explainNumericNormalization(0.3371, 0.3, primitiveFloat));
+  assert.equal(explainNumericNormalization(0.3371, 0, primitiveFloat), null, "a revert to 0 is NOT normalization");
+});
+
+// ---- WIRING: the real applyWidgetWrite path, driven by the frontend's own
+// callback rather than a stand-in for it. ------------------------------------
+
+// Transcribed from the running build (frontend 1.49.6), `NumberWidget`'s
+// onFloatValueChange. Kept verbatim so the test cannot drift into agreeing with
+// the module by construction.
+function onFloatValueChange(v) {
+  const t = this.options.round;
+  if (t) {
+    const n = this.options.precision ?? Math.max(0, -Math.floor(Math.log10(t)));
+    const r = Math.round(v / t) * t;
+    this.value = Math.min(
+      Math.max(Number(r.toFixed(n)), this.options.min ?? -Infinity),
+      this.options.max ?? Infinity,
+    );
+  } else {
+    this.value = v;
+  }
+}
+
+test("#1130 WIRING: a float-quantized write comes back as a SUCCESS through applyWidgetWrite", async () => {
+  const { applyWidgetWrite } = await import("../../web/js/lib/widget-write.js");
+  const factor = {
+    name: "factor",
+    type: "number",
+    value: 1,
+    options: { ...ADJUST_CONTRAST_FACTOR },
+    callback: onFloatValueChange,
+  };
+  const node = { id: 7, type: "AdjustContrast", widgets: [factor] };
+  const set = applyWidgetWrite(node, "factor", 1.12, {});
+  assert.equal(factor.value, 1.1, "the canvas holds the quantized value");
+  assert.equal(set.value, 1.1);
+  assert.equal(set.normalized, true, "reported as normalization, not as a failed write");
+  assert.equal(set.requested_value, 1.12);
+  assert.match(set.normalization_rule, /round 0\.1/);
+  assert.match(set.normalization_note, /The write APPLIED/);
+  assert.doesNotMatch(set.normalization_note, /did not retain/);
+});
+
+test("#1130 WIRING: a write the widget REFUSED still fails and still rolls back", async () => {
+  const { applyWidgetWrite, WidgetWriteError } = await import("../../web/js/lib/widget-write.js");
+  const factor = {
+    name: "factor",
+    type: "number",
+    value: 1,
+    options: { ...ADJUST_CONTRAST_FACTOR },
+    // The honest-failure case: a node that snaps the value back to its default.
+    // 1.0 is ALSO what this widget's unrelated step2 grid produces from 1.12, so
+    // this is the exact write an over-broad explainer would call a success.
+    callback() {
+      this.value = 1;
+    },
+  };
+  const node = { id: 7, type: "AdjustContrast", widgets: [factor] };
+  assert.throws(
+    () => applyWidgetWrite(node, "factor", 1.12, {}),
+    (err) => err instanceof WidgetWriteError && /did not retain the requested value/.test(err.message),
+  );
+  assert.equal(factor.value, 1, "rolled back to the prior value");
+});

--- a/browser_tests/unit/widget-normalization.test.mjs
+++ b/browser_tests/unit/widget-normalization.test.mjs
@@ -303,3 +303,21 @@ test("#1130 WIRING: a write the widget REFUSED still fails and still rolls back"
   );
   assert.equal(factor.value, 1, "rolled back to the prior value");
 });
+
+test("#1130 the INT callback does NOT clamp on the panel's write path", () => {
+  // applyWidgetWrite assigns `widget.value` and invokes the callback directly,
+  // so `NumberWidget.setValue`'s clamp never runs. Measured on the rig:
+  // EmptyLatentImage.width (min 16, max 16384, step2 8) stores 20000 for 20001
+  // and -32 for -33 — NOT 16384 and 16. A model that clamps here reports both
+  // of those applied writes as refused.
+  const w = widget({ min: 16, max: 16384, step: 80, step2: 8, precision: 0 });
+  assert.ok(explainNumericNormalization(20001, 20000, w), "above max: snapped, not clamped");
+  assert.ok(explainNumericNormalization(-33, -32, w), "below min: snapped, not clamped");
+  // KSampler.steps (step2 1, max 10000), measured: 20001.4 stores 20001.
+  assert.ok(explainNumericNormalization(20001.4, 20001, widget({ min: 1, max: 10000, step: 10, step2: 1, precision: 0 })));
+  // The FLOAT callback is the one that DOES clamp, and it still must.
+  // AdjustContrast.factor, measured: 7.77 stores 2 and -3.33 stores 0.
+  const f = widget(ADJUST_CONTRAST_FACTOR);
+  assert.ok(explainNumericNormalization(7.77, 2, f), "float clamps to max");
+  assert.ok(explainNumericNormalization(-3.33, 0, f), "float clamps to min");
+});

--- a/browser_tests/unit/widget-normalization.test.mjs
+++ b/browser_tests/unit/widget-normalization.test.mjs
@@ -321,3 +321,24 @@ test("#1130 the INT callback does NOT clamp on the panel's write path", () => {
   assert.ok(explainNumericNormalization(7.77, 2, f), "float clamps to max");
   assert.ok(explainNumericNormalization(-3.33, 0, f), "float clamps to min");
 });
+
+test("#1130 a FLOAT widget with rounding DISABLED is not mistaken for an integer", () => {
+  // grok's residual on PR #1550. With `Comfy.DisableFloatRounding` the frontend
+  // leaves `round` unset; `onFloatValueChange` then stores the value UNCHANGED,
+  // so the explainer is only ever reached when something else moved it — a
+  // genuine drift. The config that remains is shape-identical to an integer's,
+  // and the int grid would happily "explain" that drift.
+  //
+  // AdjustContrast.factor's measured options, minus `round`.
+  const w = widget({ min: 0, max: 2, step: 5, step2: 0.5, precision: 1 });
+  assert.equal(explainNumericNormalization(1.12, 1, w), null, "1.0 is the step2 0.5 grid — but that grid never ran");
+  assert.equal(explainNumericNormalization(1.12, 1.5, w), null);
+  assert.equal(explainNumericNormalization(1.12, 0, w), null, "and it must not fall through to the `step` readings either");
+  // Clamping still applies — it is the one thing that happens regardless.
+  assert.ok(explainNumericNormalization(7.77, 2, w), "above max still clamps");
+  assert.ok(explainNumericNormalization(-3.33, 0, w), "below min still clamps");
+  // A real INT widget (precision 0) is untouched by the guard.
+  assert.ok(explainNumericNormalization(1281, 1280, widget({ min: 16, max: 16384, step: 80, step2: 8, precision: 0 })));
+  // …and so is a widget with no precision at all (older builds, injected steps).
+  assert.ok(explainNumericNormalization(1281, 1280, widget({ min: 16, max: 16384, step2: 8 })));
+});

--- a/web/js/lib/widget-normalization.js
+++ b/web/js/lib/widget-normalization.js
@@ -216,6 +216,18 @@ export function explainNumericNormalization(expected, actual, widget) {
       why: `round ${round}${Number.isInteger(digits) ? ` at ${digits} dp` : ""}`,
       grid: round,
     });
+  } else if (step2 !== null && precision > 0) {
+    // A widget carrying `step2` and a NON-ZERO precision but no `round` is a
+    // FLOAT whose rounding is switched off (`Comfy.DisableFloatRounding`), not an
+    // integer. `onFloatValueChange` then stores the value UNCHANGED — so no grid
+    // explains a change here, and only the clamp reading below may speak.
+    //
+    // Deliberately NO fall-through to the `step` readings: an else-if chain hands
+    // a blocked tier to the NEXT tier, and that is worse than the int reading it
+    // replaced. Simulated over the corpus with `round` stripped, counting genuine
+    // drifts wrongly explained: origin/main 58, int reading 40, falling through to
+    // `step` 58, this branch **1**. Measuring the obvious guard is the only reason
+    // this is not the obvious guard.
   } else if (step2 !== null) {
     // The frontend's INT path — `onValueChange`.
     const offset = step2 === 1 ? 0 : (min ?? 0) % step2;

--- a/web/js/lib/widget-normalization.js
+++ b/web/js/lib/widget-normalization.js
@@ -17,20 +17,65 @@
  * WHAT COUNTS AS NORMALIZATION. Only a value the widget's OWN declared config
  * explains exactly. We do not accept "close enough": a tolerance would eventually
  * swallow a real revert that happened to land nearby. The observed value must be
- * reproducible by snapping the request onto the widget's grid —
+ * reproducible by re-running the frontend's own quantization on the request, and
+ * if no declared reading reproduces it, this stays the failure it was.
  *
- *     snap(v) = clamp(min + round((v - min) / step) * step, min, max)
+ * ---------------------------------------------------------------------------
+ * comfyui-mcp#1130 (recurrence, 2026-08-21) — the SAME failure on a FLOAT grid:
  *
- * — and if no declared grid reproduces it, this stays the failure it was.
+ *     panel_set_widget AdjustContrast.factor = 1.12 → widget stored 1.1
+ *     → "did not retain the requested value"
  *
- * Reported for the issue's own numbers: a widget declaring `min: 1, step: 2`
- * snaps 4096 to 4097 and 8192 to 8193, both exactly as reported.
+ * The first fix modelled quantization as ONE formula — `min + round((v - min) /
+ * step) * step`, clamped — because that is what the integer case looks like. It
+ * is not what the frontend does, and it is not even one formula. Read off the
+ * running build (ComfyUI 0.33.2 / frontend 1.49.6) the number widget has TWO
+ * callbacks, and the float one shares no term with the integer one:
  *
- * The `step / 10` candidate is deliberate, not a fudge: ComfyUI's INT/FLOAT
- * widgets have historically carried a drag-step that is ten times the value step,
- * so a widget can declare `step: 10` and quantize by 1. Trying both DECLARED
- * readings is still explaining the value from the config; inventing a third
- * arbitrary grid would not be.
+ *     // INT — onValueChange
+ *     const t = options.step2 || 1;
+ *     if (t === 1) value = Math.round(e);
+ *     else { const n = (options.min ?? 0) % t; value = Math.round((e - n) / t) * t + n; }
+ *
+ *     // FLOAT — onFloatValueChange
+ *     const t = options.round;
+ *     if (t) {
+ *       const n = options.precision ?? Math.max(0, -Math.floor(Math.log10(t)));
+ *       const r = Math.round(e / t) * t;
+ *       value = clamp(Number(r.toFixed(n)), options.min ?? -Inf, options.max ?? Inf);
+ *     } else value = e;
+ *
+ * Three differences, each on its own enough to make the old model miss:
+ *
+ *  - **The float grid is `options.round`, not `options.step`.** `AdjustContrast.factor`
+ *    declares no step at all, so the frontend fills in `step: 5, step2: 0.5,
+ *    round: 0.1, precision: 1`. The grid that quantized 1.12 to 1.1 is `round`
+ *    — a value neither `step` (5) nor the 10x reading of it (0.5) produces.
+ *  - **The float grid is anchored at ZERO, not at `min`.** `NormalizeImages.std`
+ *    (min 0.001, round 0.1) stores 0.3 for a request of 0.3381; anchored at min
+ *    the same arithmetic yields 0.301.
+ *  - **`toFixed(precision)` is part of the arithmetic, not presentation.** It is
+ *    what makes the stored value the exact double `1.1` rather than the
+ *    `1.1000000000000000888` that `Math.round(1.12 / 0.1) * 0.1` leaves behind.
+ *
+ * That last one is why this file replicates the callbacks verbatim instead of
+ * reaching for an epsilon. The comparison stays a strict `===`; the fix is to
+ * compute the SAME number the frontend computes, `toFixed` included, so exactness
+ * is achievable rather than approximate. A tolerance wide enough to accept
+ * 1.12 → 1.1 would also accept a widget that quietly kept 1.14, and "the write
+ * was refused" is the one verdict this module must never get wrong in the
+ * optimistic direction.
+ *
+ * Measured on the live rig before and after: of 74 real widget writes that the
+ * frontend quantized (80 numeric widgets sampled across the installed packs),
+ * the single-formula model explained 52 and reported 22 as failed writes. The
+ * replicated callbacks explain all 74.
+ *
+ * The pre-`step2` readings below are KEPT, not replaced. Older frontends put only
+ * `step` on the widget, and packs inject a bare `{ step: 8 }` of their own
+ * (AnimateDiff's dimension step, #1533) with no `round`/`step2` beside it. Those
+ * are still declared config, and dropping them would re-break the case this file
+ * was written for.
  */
 
 const isFiniteNumber = (v) => typeof v === "number" && Number.isFinite(v);
@@ -40,20 +85,80 @@ function numericConfig(widget) {
   const o = widget?.options ?? widget?.config ?? null;
   if (!o || typeof o !== "object") return null;
   const num = (v) => (isFiniteNumber(v) ? v : null);
-  return { min: num(o.min), max: num(o.max), step: num(o.step) };
+  return {
+    min: num(o.min),
+    max: num(o.max),
+    step: num(o.step),
+    // The frontend's own split: `step` is the DRAG step (10x), `step2` the value
+    // step the INT callback actually quantizes by.
+    step2: num(o.step2),
+    // The FLOAT callback's grid. Nothing else in this config is it.
+    round: num(o.round),
+    precision: Number.isInteger(o.precision) ? o.precision : null,
+  };
 }
 
-function snap(value, { min, max, step }) {
+function clampTo(value, min, max) {
+  let out = value;
+  if (isFiniteNumber(min)) out = Math.max(min, out);
+  if (isFiniteNumber(max)) out = Math.min(max, out);
+  return out;
+}
+
+/**
+ * `onFloatValueChange`, verbatim — including the `toFixed(precision)` that makes
+ * the stored number an exact decimal rather than the raw product.
+ *
+ * Returns null when this build's config cannot drive it, so the candidate is
+ * SKIPPED rather than contributing a value the frontend would never produce.
+ */
+function snapFloat(value, { round, precision, min, max }) {
+  if (!isFiniteNumber(round) || round <= 0) return null;
+  const digits = precision ?? Math.max(0, -Math.floor(Math.log10(round)));
+  // `toFixed` throws outside 0..100. A config that would throw is a config the
+  // frontend never quantized with, so explain nothing rather than guess.
+  if (!Number.isInteger(digits) || digits < 0 || digits > 100) return null;
+  const raw = Math.round(value / round) * round;
+  if (!Number.isFinite(raw)) return null;
+  const fixed = Number(raw.toFixed(digits));
+  if (!Number.isFinite(fixed)) return null;
+  return clampTo(fixed, min, max);
+}
+
+/**
+ * `onValueChange` (the INT callback), verbatim, plus the min/max clamp
+ * `NumberWidget.setValue` applies around it.
+ *
+ * Note the anchor: `min % step`, not `min`. Both generate the same lattice, but
+ * this is the arithmetic the frontend runs, and matching it exactly is the whole
+ * contract of this module.
+ */
+function snapInt(value, { step2, min, max }) {
+  if (!isFiniteNumber(step2) || step2 <= 0) return null;
+  let out;
+  if (step2 === 1) {
+    out = Math.round(value);
+  } else {
+    const offset = (min ?? 0) % step2;
+    out = Math.round((value - offset) / step2) * step2 + offset;
+  }
+  if (!Number.isFinite(out)) return null;
+  return clampTo(out, min, max);
+}
+
+/**
+ * The pre-`step2` reading: a min-anchored grid taken from `step` alone. Kept for
+ * older frontends and for pack-injected steps (#1533) that carry no `round`.
+ */
+function snapLegacy(value, { min, max, step }) {
   const base = min ?? 0;
   let out = value;
   if (isFiniteNumber(step) && step > 0) {
     out = base + Math.round((value - base) / step) * step;
   }
-  if (isFiniteNumber(min)) out = Math.max(min, out);
-  if (isFiniteNumber(max)) out = Math.min(max, out);
   // Snapping can push a value back outside the grid after clamping; the widget
   // clamps last, so mirror that order rather than re-snapping.
-  return out;
+  return clampTo(out, min, max);
 }
 
 /**
@@ -67,31 +172,68 @@ export function explainNumericNormalization(expected, actual, widget) {
   if (expected === actual) return null; // nothing to explain
   const cfg = numericConfig(widget);
   if (!cfg) return null;
-  const { min, max, step } = cfg;
-  if (min === null && max === null && step === null) return null;
+  const { min, max, step, step2, round, precision } = cfg;
+  if (min === null && max === null && step === null && step2 === null && round === null) return null;
 
+  const bounds = [min !== null ? `min ${min}` : null, max !== null ? `max ${max}` : null].filter(
+    Boolean,
+  );
+  const describe = (why, grid) => ({
+    rule: [why, ...bounds].join(", "),
+    min,
+    max,
+    step: grid,
+  });
+
+  // EXACTLY ONE grid reading is admissible, chosen the way the frontend chooses
+  // its callback — `round` present means `onFloatValueChange` ran, and nothing
+  // else can have. Offering every reading at once is how a tolerance gets in by
+  // the back door: measured over 428 adversarial non-normalizations on the live
+  // corpus, an any-candidate-may-match explainer accepted 8 outright REVERTS,
+  // because a float widget's unrelated drag step happens to reproduce the value
+  // the widget fell back to. Tiering drops that to 0 while still explaining all
+  // 74 real quantizations. Every one of those 8 is a write the caller would have
+  // been told applied when it had not — the one direction this module must never
+  // get wrong.
   const candidates = [];
-  if (isFiniteNumber(step) && step > 0) {
-    candidates.push({ ...cfg, step, why: `step ${step}` });
-    // The historical drag-step-is-10x reading of the SAME declared value.
-    candidates.push({ ...cfg, step: step / 10, why: `step ${step / 10} (declared step ${step})` });
+  if (round !== null) {
+    // The frontend's FLOAT path — `onFloatValueChange`.
+    const digits = precision ?? Math.max(0, -Math.floor(Math.log10(round)));
+    candidates.push({
+      value: () => snapFloat(expected, cfg),
+      why: `round ${round}${Number.isInteger(digits) ? ` at ${digits} dp` : ""}`,
+      grid: round,
+    });
+  } else if (step2 !== null) {
+    // The frontend's INT path — `onValueChange`.
+    const offset = step2 === 1 ? 0 : (min ?? 0) % step2;
+    candidates.push({
+      value: () => snapInt(expected, cfg),
+      why: step2 === 1 ? "whole numbers (step 1)" : `step ${step2} offset ${offset}`,
+      grid: step2,
+    });
+  } else if (step !== null && step > 0) {
+    // Pre-`step2` builds and pack-injected steps (#1533): the declared `step`, and
+    // the historical drag-step-is-10x reading of that SAME declared value.
+    candidates.push({ value: () => snapLegacy(expected, cfg), why: `step ${step}`, grid: step });
+    candidates.push({
+      value: () => snapLegacy(expected, { ...cfg, step: step / 10 }),
+      why: `step ${step / 10} (declared step ${step})`,
+      grid: step / 10,
+    });
   }
   // Pure clamping, with no grid at all.
-  candidates.push({ ...cfg, step: null, why: "clamp" });
+  candidates.push({
+    value: () => snapLegacy(expected, { ...cfg, step: null }),
+    why: "clamp",
+    grid: null,
+  });
 
   for (const c of candidates) {
-    if (snap(expected, c) === actual) {
-      const bounds = [
-        c.min !== null ? `min ${c.min}` : null,
-        c.max !== null ? `max ${c.max}` : null,
-      ].filter(Boolean);
-      return {
-        rule: [c.why, ...bounds].join(", "),
-        min: c.min,
-        max: c.max,
-        step: c.step,
-      };
-    }
+    const produced = c.value();
+    // Strict equality, deliberately. See the header: the fix for the float case
+    // was to compute the frontend's number exactly, never to widen the compare.
+    if (produced !== null && produced === actual) return describe(c.why, c.grid);
   }
   return null;
 }

--- a/web/js/lib/widget-normalization.js
+++ b/web/js/lib/widget-normalization.js
@@ -51,9 +51,12 @@
  *    declares no step at all, so the frontend fills in `step: 5, step2: 0.5,
  *    round: 0.1, precision: 1`. The grid that quantized 1.12 to 1.1 is `round`
  *    — a value neither `step` (5) nor the 10x reading of it (0.5) produces.
- *  - **The float grid is anchored at ZERO, not at `min`.** `NormalizeImages.std`
- *    (min 0.001, round 0.1) stores 0.3 for a request of 0.3381; anchored at min
- *    the same arithmetic yields 0.301.
+ *  - **The float grid is anchored at ZERO, not at `min`.** Usually invisible —
+ *    `toFixed` re-rounds onto the zero grid and hides the shift — but not always:
+ *    `NormalizeImages.std` (min 0.001, round 0.1) stores 0.1 for a request of
+ *    0.0500223, where anchoring at min yields 0.001. Measured, not reasoned: the
+ *    two models were swept against each other for a disagreement and the
+ *    disagreement was then run on the rig.
  *  - **`toFixed(precision)` is part of the arithmetic, not presentation.** It is
  *    what makes the stored value the exact double `1.1` rather than the
  *    `1.1000000000000000888` that `Math.round(1.12 / 0.1) * 0.1` leaves behind.

--- a/web/js/lib/widget-normalization.js
+++ b/web/js/lib/widget-normalization.js
@@ -129,14 +129,24 @@ function snapFloat(value, { round, precision, min, max }) {
 }
 
 /**
- * `onValueChange` (the INT callback), verbatim, plus the min/max clamp
- * `NumberWidget.setValue` applies around it.
+ * `onValueChange` (the INT callback), verbatim.
  *
  * Note the anchor: `min % step`, not `min`. Both generate the same lattice, but
  * this is the arithmetic the frontend runs, and matching it exactly is the whole
  * contract of this module.
+ *
+ * And note what is NOT here: a clamp. The float callback clamps its own result;
+ * this one does not, and the clamp that would otherwise cover it lives in
+ * `NumberWidget.setValue`, which `applyWidgetWrite` does not go through — it
+ * assigns `widget.value` and invokes the callback directly. Measured on the rig
+ * rather than argued: `EmptyLatentImage.width` (min 16, max 16384, step2 8)
+ * stores **20000** for a request of 20001 and **-32** for -33. Clamping here
+ * would predict 16384 and 16, miss both, and report two applied writes as
+ * refused — the very failure this module exists to prevent, and one the
+ * min-anchored model had too. The standalone `clamp` reading below still covers
+ * the paths that DO clamp.
  */
-function snapInt(value, { step2, min, max }) {
+function snapIntNoClamp(value, { step2, min }) {
   if (!isFiniteNumber(step2) || step2 <= 0) return null;
   let out;
   if (step2 === 1) {
@@ -145,8 +155,7 @@ function snapInt(value, { step2, min, max }) {
     const offset = (min ?? 0) % step2;
     out = Math.round((value - offset) / step2) * step2 + offset;
   }
-  if (!Number.isFinite(out)) return null;
-  return clampTo(out, min, max);
+  return Number.isFinite(out) ? out : null;
 }
 
 /**
@@ -211,7 +220,7 @@ export function explainNumericNormalization(expected, actual, widget) {
     // The frontend's INT path — `onValueChange`.
     const offset = step2 === 1 ? 0 : (min ?? 0) % step2;
     candidates.push({
-      value: () => snapInt(expected, cfg),
+      value: () => snapIntNoClamp(expected, cfg),
       why: step2 === 1 ? "whole numbers (step 1)" : `step ${step2} offset ${offset}`,
       grid: step2,
     });


### PR DESCRIPTION
Fixes the recurrence reported on **artokun/comfyui-mcp#1130** (2026-08-21T01:39Z, panel 0.15.22):

> `panel_set_widget` requested `AdjustContrast.factor=1.12`; the widget correctly quantized to `1.1` (0.1 step), but the call returned `did not retain the requested value`.

**Review is PENDING.** Nothing below has been reviewed by anyone but me.

---

## It is neither a regression of #805 nor a float-comparison hazard

The obvious hypothesis was that `1.1` is not exactly representable and a strict `===` against a recomputed expected value was losing to the last bit. **That is not what happens**, and it matters, because the fix that hypothesis suggests (an epsilon) is the one fix that would be dangerous here.

Established by execution, not by reading. On the live rig (ComfyUI 0.33.2 / frontend 1.49.6) I created the real `AdjustContrast` node in a real Chromium, read the widget's own options and invoked its own callback — the same two steps `applyWidgetWrite` performs:

```
AdjustContrast.factor  declared: { default: 1, min: 0, max: 2 }   ← no step at all
             observed options: { min: 0, max: 2, step: 5, step2: 0.5, round: 0.1, precision: 1 }
             1.12  →  1.1        (exact double 1.1, callback `onFloatValueChange`)
```

Feeding that observed shape to `explainNumericNormalization` on `origin/main` returns `null` — so the write is reported as refused. The three candidate grids it tries are `step` 5 (gives 0), `step/10` 0.5 (gives 1.0) and clamp (gives 1.12). **None of them is 0.1.** The comparison never gets close enough for representation to be the issue.

The reason is that #806 modelled quantization as ONE formula, min-anchored, read from `options.step`. The frontend's number widget has **two** callbacks and the float one shares no term with the integer one. Both transcribed verbatim from the running build:

```js
// INT — onValueChange
const t = options.step2 || 1
if (t === 1) value = Math.round(e)
else { const n = (options.min ?? 0) % t; value = Math.round((e - n) / t) * t + n }

// FLOAT — onFloatValueChange
const t = options.round
if (t) {
  const n = options.precision ?? Math.max(0, -Math.floor(Math.log10(t)))
  const r = Math.round(e / t) * t
  value = clamp(Number(r.toFixed(n)), options.min ?? -Inf, options.max ?? Inf)
} else value = e
```

Three independent misses, each sufficient on its own:

| | old model | what the frontend does |
|---|---|---|
| grid | `options.step` (and `step/10`) | `options.round` |
| anchor | `min` | zero |
| final term | none | `Number(r.toFixed(precision))` |

`#805` kept working only by luck of the INT path: for an integer widget the frontend sets `step = 10 × step2`, so `step/10` recovers the real grid, and `min`-anchoring generates the same lattice as `min % step2`-anchoring. The float path decouples them — `AdjustContrast.factor` declares no step, so the frontend supplies `step2: 0.5` **and** `round: 0.1`, and only `round` is the grid.

## The fix

Replicate both callbacks verbatim, and keep the comparison a strict `===`.

The point is worth stating plainly because it is the load-bearing design decision: **`toFixed(precision)` is arithmetic, not presentation.** It is what makes the stored value the exact double `1.1` instead of the `1.1000000000000000888` the multiply leaves behind. Computing the same number the frontend computes makes exactness *reachable*, so no tolerance is needed — and none is introduced. `KSampler.cfg` (round `0.01`, precision `1`) stores **7.8** for a request of 7.777, not the 7.78 the grid alone gives; a model without the `toFixed` term cannot produce that number at all.

Second change, in the *tightening* direction: **exactly one reading is admissible per config**, chosen the way the frontend chooses its callback (`round` present ⇒ the float callback ran; else `step2` ⇒ the int callback; else the pre-`step2` readings). Offering every reading at once is a tolerance by the back door — see the reverse-direction numbers below.

The pre-`step2` `step` / `step/10` readings are **kept**, not replaced: older frontends put only `step` on the widget, and packs inject a bare `{ step: 8 }` with no `round` beside it (#1533).

## Evidence — measured, both directions

Sampled 80 numeric widgets across the installed packs, spanning negative mins, fractional mins, declared and undeclared steps. For each I created the real node in Chromium, wrote an off-grid value and recorded what the widget stored — 74 of the 80 quantized. From those same observations I built 428 adversarial **non**-normalizations: reverts to the previous value, one-grid-step misses, epsilon near-misses, off-grid values, zero.

| | real quantizations reported as FAILED WRITE | reverts/near-misses reported as SUCCESS |
|---|---|---|
| `origin/main` | **22 / 74** | **8 / 428** |
| this branch | **0 / 74** | **0 / 428** |

Both directions moved the right way. The 8 false successes on `origin/main` are a **pre-existing defect in the dangerous direction** that this change also closes: on a float widget the unrelated `step2` grid frequently reproduces the value a *reverted* widget fell back to, so a write that never landed was reported as normalized. Concretely, `ThinkingLLM_QwenVL_Advanced.temperature` (min 0.1, round 0.1, step2 0.5, default 0.6): a request of 0.4371 stores 0.4, but a revert to the 0.6 default is exactly what the 0.5 grid produces — `origin/main` calls that a successful normalized write. Both directions are pinned by tests.

Re-ran the whole corpus **through the real browser ES-module loader** (worktree file routed into a Chromium page, `await import(...)`): module loads, 74/74 explained, 0/428 wrongly accepted.

## Mutation evidence

Every mutation was applied to the committed fix, the named tests were run, and the tree restored.

| mutation | tests that fail |
|---|---|
| restore `origin/main`'s `widget-normalization.js` entirely | **10 of 10** `#1130` tests |
| stop reading `options.round` in `numericConfig` | 10 |
| drop the `toFixed(precision)` term | 4, incl. `` `toFixed(precision)` is arithmetic, not presentation`` and `the fix is exactness, NOT a tolerance` |
| anchor the float grid at `min` instead of zero | 1 — `the float grid is anchored at ZERO, not at min` |
| make the readings non-exclusive again (try every candidate) | 4, incl. **both** REVERSE tests and `WIRING: a write the widget REFUSED still fails and still rolls back` |
| **CALL SITE** — `widget-write.js` no longer consults the explainer | 3: `#1130 WIRING: … comes back as a SUCCESS`, `#805 WIRING`, `#1533: a format-injected step still snaps` |
| put the min/max clamp back into the INT reading | 1 — `the INT callback does NOT clamp on the panel's write path` |
| remove the rounding-disabled guard | 1 — `a FLOAT widget with rounding DISABLED is not mistaken for an integer` |
| keep that guard but let it FALL THROUGH to the `step` readings | 1 — same test |

### Two things adversarial re-review of my own diff turned up

**A second false-failure class, in the INT path — same bug, different callback (third commit).** I wrote `snapInt` to clamp, with a comment claiming `NumberWidget.setValue` applies the clamp around the callback. It does not, because `applyWidgetWrite` never calls `setValue` — it assigns `widget.value` and invokes the callback directly, and `onValueChange` has no clamp of its own. Measured rather than argued: `EmptyLatentImage.width` (min 16, max 16384, step2 8) stores **20000** for a request of 20001 and **-32** for -33. A model that clamps predicts 16384 and 16, matches neither, and reports two applied writes as refused. `onFloatValueChange` DOES clamp and `snapFloat` still does. This one was present in `origin/main`'s model too, so it is a third false-failure the branch closes — it just does not appear in the 74-case table because that corpus only used in-range requests.

**The clamp reading, probed on its own.** The weakest part of the 428-case reverse measurement is that it SKIPS any pretend-value outside `[min, max]`, on the grounds that clamping legitimately explains those. So I probed that skipped region separately: 622 out-of-range requests paired with in-range pretend-stored values (previous value, zero, midpoint, 0.371 of range) — **0 wrongly accepted**.

One of these is worth flagging against myself. The **anchor mutation initially SURVIVED all 19 tests**: with `precision = -log10(round)`, `toFixed` re-rounds a min-anchored value straight back onto the zero grid, so my first version of that assertion tested nothing. I swept the two models against each other for a request where they genuinely disagree, then ran those requests on the rig — the frontend produced the zero-anchored value all three times (`NormalizeImages.std` 0.0500223 → **0.1**, where min-anchored predicts 0.001). The test now uses those measured pairs and the mutant dies. Second commit on this branch.

## Testing

- `npm run test:unit` — **6099 pass, 0 fail** (i18n + tool-vocabulary + panel-scope gates included; `node_modules` junctioned into the worktree so `check-panel-scope` actually runs rather than printing CANNOT RUN).
- 21 tests in `widget-normalization.test.mjs`, 12 of them new. Every widget config and every stored value in them was **measured on the rig**, not derived from the code under test. The two WIRING tests drive the real `applyWidgetWrite` with the frontend's `onFloatValueChange` transcribed verbatim — one asserting the quantized write comes back as `normalized: true`, the other asserting a widget that REFUSED the write still throws `did not retain the requested value` and still rolls back.
- Playwright e2e (`--workers=1`) — result appended in a comment below; the harness routes this worktree's `web/js` into the browser, so the suite does exercise this commit.

## Review round 2 — grok's residual, measured and fixed (fourth commit)

grok approved head `100f39b3` and left one residual: with `Comfy.DisableFloatRounding` the frontend leaves `round` unset, `onFloatValueChange` stores the value unchanged, and what remains on the widget is **shape-identical to an integer config** — so the int reading would happily explain a genuine drift. It called that non-blocking. I simulated it over the corpus (strip `round`, count genuine drifts wrongly explained as normalized) and it is not small:

| | drifts wrongly explained, of 375 |
|---|---|
| `origin/main` | 58 |
| the int reading (head `da0ef584`) | 40 |
| **the obvious guard — block the int reading** | **58, i.e. WORSE** |
| block it *without fall-through* (shipped) | **1** |

The counterintuitive row is the finding: an `else if` chain hands a blocked tier to the **next** tier, and the `step` readings it falls into are broader than the int reading they replaced. The guard only helps if it terminates. Both mutations above — deleting the guard, and keeping it but allowing fall-through — kill the test.

Cost in the measured world: none. 74/74 real quantizations still explained, 0/428 adversarial non-normalizations accepted.

**Honesty about that configuration:** I could not reproduce it on the rig. Patching the in-page setting getter did not change widget construction (`round` stayed 0.1), so the config shape is taken from grok's report, and the numbers above are a simulation of it over real observed configs — not observations of it.

## What I deliberately did not do

- **No epsilon, no tolerance, anywhere.** See the "exactness" test: `0.30000000000000004` and `0.3` differ by 5.5e-17, and only one of them is what the widget stored — the near-miss is refused.
- **Did not touch the `clamp` candidate or the `step`/`step/10` readings' behaviour** beyond making them mutually exclusive with the newer ones. #805's and #1533's tests all still pass unchanged.
- **Did not change `widget-write.js`.** The call site already passed the right widget; the defect was entirely inside the explainer. The call-site mutation above exists to prove the wiring is load-bearing, not because it changed.
- **Did not attempt to make the panel snap the value itself before writing.** The issue's original text floated "write the nearest legal value"; the widget's own callback is the only authority on its grid, and pre-snapping would put a second, drifting copy of that arithmetic in front of it.
- **Did not touch the orchestrator repo.** The `did not retain the requested value` string is produced only in `web/js/lib/widget-write.js`; comfyui-mcp#1130 will need closing by hand, since a cross-repo reference does not auto-close.

Closes-by-hand: artokun/comfyui-mcp#1130

🤖 Generated with [Claude Code](https://claude.com/claude-code)
