### PR TITLE
fix(1549): Prompt Builder prompt_text writes keep builder_state in the same step

### DIFF
--- a/browser_tests/unit/minimax-h3-prompt-builder.test.mjs
+++ b/browser_tests/unit/minimax-h3-prompt-builder.test.mjs
@@ -1,0 +1,262 @@
+/**
+ * #1549 — MiniMaxH3PromptBuilder's editor Save writes prompt_text and builder_state
+ * together. Two panel_set_widget calls can split across a render fence. These tests
+ * drive the shipped lib (the same function graph_set_widget returns) so a prompt_text
+ * write cannot leave builder_state on the previous editor JSON.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+import {
+  MINIMAX_H3_PROMPT_BUILDER_TYPE,
+  MINIMAX_H3_PROMPT_TEXT_WIDGET,
+  MINIMAX_H3_BUILDER_STATE_WIDGET,
+  MiniMaxH3PromptBuilderWriteError,
+  isMiniMaxH3PromptBuilderNode,
+  classifyMiniMaxH3PromptBuilderWrite,
+  defaultMiniMaxH3BuilderState,
+  normaliseMiniMaxH3BuilderState,
+  generateMiniMaxH3Prompt,
+  parseMiniMaxH3BuilderState,
+  parseMiniMaxH3GeneratedPrompt,
+  applyMiniMaxH3PromptBuilderWrite,
+} from "../../web/js/lib/minimax-h3-prompt-builder.js";
+
+const TYPE = MINIMAX_H3_PROMPT_BUILDER_TYPE;
+
+function t2vaState(over = {}) {
+  return normaliseMiniMaxH3BuilderState({
+    version: 1,
+    mode: "T2VA",
+    imd: "a lantern swings over wet cobblestones",
+    soundscape: "rain on stone, distant wheels",
+    music: "low strings",
+    ...over,
+  });
+}
+
+function makeNode({
+  id = 12,
+  type = TYPE,
+  prompt = "",
+  state = defaultMiniMaxH3BuilderState(),
+  omit = [],
+} = {}) {
+  const promptWidget = { name: MINIMAX_H3_PROMPT_TEXT_WIDGET, value: prompt };
+  const stateWidget = {
+    name: MINIMAX_H3_BUILDER_STATE_WIDGET,
+    value: typeof state === "string" ? state : JSON.stringify(state),
+  };
+  const widgets = [];
+  if (!omit.includes(MINIMAX_H3_PROMPT_TEXT_WIDGET)) widgets.push(promptWidget);
+  if (!omit.includes(MINIMAX_H3_BUILDER_STATE_WIDGET)) widgets.push(stateWidget);
+  widgets.push({ name: "Edit prompt…", value: null });
+  const node = { id, type, widgets, _mmh3Draft: { dirty: true } };
+  return { node, promptWidget, stateWidget };
+}
+
+function landedPrompt(node) {
+  return node.widgets.find((w) => w.name === MINIMAX_H3_PROMPT_TEXT_WIDGET).value;
+}
+
+function landedState(node) {
+  return parseMiniMaxH3BuilderState(
+    node.widgets.find((w) => w.name === MINIMAX_H3_BUILDER_STATE_WIDGET).value,
+  );
+}
+
+test("#1549: classify matches the two Save widgets on MiniMaxH3PromptBuilder only", () => {
+  const { node } = makeNode();
+  assert.equal(isMiniMaxH3PromptBuilderNode(node), true);
+  assert.equal(isMiniMaxH3PromptBuilderNode({ comfyClass: TYPE, type: "virtual" }), true);
+  assert.equal(classifyMiniMaxH3PromptBuilderWrite(node, MINIMAX_H3_BUILDER_STATE_WIDGET), "master");
+  assert.equal(classifyMiniMaxH3PromptBuilderWrite(node, MINIMAX_H3_PROMPT_TEXT_WIDGET), "output");
+  assert.equal(classifyMiniMaxH3PromptBuilderWrite(node, "prompt_text.0"), "output");
+  assert.equal(classifyMiniMaxH3PromptBuilderWrite(node, "Edit prompt…"), null);
+  assert.equal(classifyMiniMaxH3PromptBuilderWrite({ id: 1, type: "KSampler", widgets: node.widgets }, MINIMAX_H3_PROMPT_TEXT_WIDGET), null);
+});
+
+test("#1549: generate() of a T2VA state round-trips through the labeled parser", () => {
+  const state = t2vaState();
+  const prompt = generateMiniMaxH3Prompt(state);
+  const parsed = parseMiniMaxH3GeneratedPrompt(prompt, defaultMiniMaxH3BuilderState());
+  assert.ok(parsed, "labeled T2VA prompt must parse");
+  assert.equal(generateMiniMaxH3Prompt(parsed), prompt);
+  assert.equal(parsed.imd, state.imd);
+  assert.equal(parsed.soundscape, state.soundscape);
+  assert.equal(parsed.music, state.music);
+});
+
+test("#1549: writing builder_state also writes generate(state) onto prompt_text", () => {
+  const oldState = t2vaState({ imd: "old scene" });
+  const newState = t2vaState({ imd: "new scene", soundscape: "wind", music: "piano" });
+  const { node, promptWidget, stateWidget } = makeNode({
+    prompt: generateMiniMaxH3Prompt(oldState),
+    state: oldState,
+  });
+  const order = [];
+  const hooks = {
+    beforeChange: () => order.push("before"),
+    afterChange: () => order.push("after"),
+    setDirty: () => order.push("dirty"),
+  };
+  const origPromptSet = Object.getOwnPropertyDescriptor(promptWidget, "value");
+  const origStateSet = Object.getOwnPropertyDescriptor(stateWidget, "value");
+  let promptVal = promptWidget.value;
+  let stateVal = stateWidget.value;
+  Object.defineProperty(promptWidget, "value", {
+    get: () => promptVal,
+    set(v) {
+      order.push("prompt");
+      promptVal = v;
+    },
+    configurable: true,
+  });
+  Object.defineProperty(stateWidget, "value", {
+    get: () => stateVal,
+    set(v) {
+      order.push("state");
+      stateVal = v;
+    },
+    configurable: true,
+  });
+
+  const result = applyMiniMaxH3PromptBuilderWrite(
+    node,
+    MINIMAX_H3_BUILDER_STATE_WIDGET,
+    JSON.stringify(newState),
+    hooks,
+  );
+
+  assert.equal(result instanceof Promise, false, "the pair is assigned synchronously — no await between widgets");
+  assert.deepEqual(order, ["before", "prompt", "state", "after", "dirty"]);
+  assert.equal(promptVal, generateMiniMaxH3Prompt(newState));
+  assert.equal(generateMiniMaxH3Prompt(parseMiniMaxH3BuilderState(stateVal)), promptVal);
+  assert.equal(node._mmh3Draft, null);
+  assert.deepEqual(result.minimax_h3_prompt_builder.synced, [
+    MINIMAX_H3_PROMPT_TEXT_WIDGET,
+    MINIMAX_H3_BUILDER_STATE_WIDGET,
+  ]);
+  Object.defineProperty(promptWidget, "value", origPromptSet);
+  Object.defineProperty(stateWidget, "value", origStateSet);
+});
+
+test("#1549 reporter: prompt_text write leaves builder_state consistent, not the old editor JSON", () => {
+  const oldState = t2vaState({ imd: "old scene", soundscape: "rain", music: "piano" });
+  const newState = t2vaState({ imd: "new scene", soundscape: "wind", music: "strings" });
+  const oldPrompt = generateMiniMaxH3Prompt(oldState);
+  const newPrompt = generateMiniMaxH3Prompt(newState);
+  assert.notEqual(oldPrompt, newPrompt);
+
+  const { node } = makeNode({ prompt: oldPrompt, state: oldState });
+  applyMiniMaxH3PromptBuilderWrite(node, MINIMAX_H3_PROMPT_TEXT_WIDGET, newPrompt);
+
+  assert.equal(landedPrompt(node), newPrompt);
+  const landed = landedState(node);
+  assert.notEqual(landed.imd, oldState.imd, "editor state is not left on the previous scene");
+  assert.equal(generateMiniMaxH3Prompt(landed), newPrompt);
+});
+
+test("#1549: prompt_text + companion builder_state writes both values in one envelope", () => {
+  const oldState = t2vaState({ imd: "old" });
+  const newState = t2vaState({ imd: "companion scene", soundscape: "hail", music: "N/A" });
+  const newPrompt = generateMiniMaxH3Prompt(newState);
+  const { node } = makeNode({ prompt: generateMiniMaxH3Prompt(oldState), state: oldState });
+
+  applyMiniMaxH3PromptBuilderWrite(node, MINIMAX_H3_PROMPT_TEXT_WIDGET, newPrompt, {
+    builder_state: JSON.stringify(newState),
+  });
+
+  assert.equal(landedPrompt(node), newPrompt);
+  const landed = landedState(node);
+  assert.equal(landed.imd, newState.imd);
+  assert.equal(landed.soundscape, newState.soundscape);
+  assert.equal(JSON.stringify(landedState(node).off), JSON.stringify(normaliseMiniMaxH3BuilderState(newState).off));
+});
+
+test("#1549: a throwing second assignment restores the first — nothing stays half-written", () => {
+  const oldState = t2vaState({ imd: "old" });
+  const oldPrompt = generateMiniMaxH3Prompt(oldState);
+  const { node, promptWidget, stateWidget } = makeNode({ prompt: oldPrompt, state: oldState });
+  let currentState = stateWidget.value;
+  Object.defineProperty(stateWidget, "value", {
+    get: () => currentState,
+    set(v) {
+      if (v !== currentState) throw new Error("poisoned builder_state setter");
+      currentState = v;
+    },
+    configurable: true,
+  });
+  const prevPrompt = promptWidget.value;
+  assert.throws(
+    () =>
+      applyMiniMaxH3PromptBuilderWrite(
+        node,
+        MINIMAX_H3_BUILDER_STATE_WIDGET,
+        JSON.stringify(t2vaState({ imd: "new" })),
+      ),
+    /poisoned builder_state setter/,
+  );
+  assert.equal(promptWidget.value, prevPrompt);
+});
+
+test("#1549: invalid builder_state JSON is refused before any undo step", () => {
+  const oldState = t2vaState();
+  const { node, promptWidget, stateWidget } = makeNode({
+    prompt: generateMiniMaxH3Prompt(oldState),
+    state: oldState,
+  });
+  let before = 0;
+  assert.throws(
+    () =>
+      applyMiniMaxH3PromptBuilderWrite(node, MINIMAX_H3_BUILDER_STATE_WIDGET, "not-json", {
+        beforeChange: () => {
+          before += 1;
+        },
+      }),
+    MiniMaxH3PromptBuilderWriteError,
+  );
+  assert.equal(before, 0);
+  assert.equal(promptWidget.value, generateMiniMaxH3Prompt(oldState));
+  assert.equal(stateWidget.value, JSON.stringify(oldState));
+});
+
+test("#1549: a missing companion widget refuses and does not write the other", () => {
+  const oldPrompt = "keep me";
+  const { node, promptWidget } = makeNode({ prompt: oldPrompt, omit: [MINIMAX_H3_BUILDER_STATE_WIDGET] });
+  assert.throws(
+    () => applyMiniMaxH3PromptBuilderWrite(node, MINIMAX_H3_PROMPT_TEXT_WIDGET, "new prompt"),
+    /missing the widget/,
+  );
+  assert.equal(promptWidget.value, oldPrompt);
+});
+
+test("#1549: unstructured prompt_text still updates builder_state in the same envelope", () => {
+  const oldState = t2vaState({ imd: "old scene" });
+  const { node } = makeNode({ prompt: generateMiniMaxH3Prompt(oldState), state: oldState });
+  const free = "a red fox walks through snow at dusk";
+  applyMiniMaxH3PromptBuilderWrite(node, MINIMAX_H3_PROMPT_TEXT_WIDGET, free);
+  assert.equal(landedPrompt(node), free);
+  assert.equal(landedState(node).imd, free);
+  assert.notEqual(landedState(node).imd, oldState.imd);
+});
+
+test("#1549: the route is WIRED into graph_set_widget, ahead of the generic write path", () => {
+  const src = readFileSync(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8");
+  assert.match(
+    src,
+    /import \{\s*classifyMiniMaxH3PromptBuilderWrite,\s*applyMiniMaxH3PromptBuilderWrite,\s*\} from "\.\/lib\/minimax-h3-prompt-builder\.js";/,
+  );
+  const handler = src.slice(src.indexOf("async graph_set_widget("));
+  assert.ok(handler.startsWith("async graph_set_widget("), "graph_set_widget handler not found");
+  const routeAt = handler.indexOf("classifyMiniMaxH3PromptBuilderWrite(node, widget)");
+  const writeAt = handler.indexOf("await runSetWidget(");
+  assert.ok(routeAt > 0, "the MiniMax route is not called from graph_set_widget");
+  assert.ok(writeAt > 0, "runSetWidget call site not found in graph_set_widget");
+  assert.ok(routeAt < writeAt, "the pair write must run BEFORE runSetWidget");
+  assert.match(
+    handler.slice(routeAt, writeAt),
+    /return applyMiniMaxH3PromptBuilderWrite\(node, widget, value/,
+  );
+});

--- a/browser_tests/unit/rgthree-lora-row.test.mjs
+++ b/browser_tests/unit/rgthree-lora-row.test.mjs
@@ -1277,7 +1277,7 @@ test("#757 the created row is disclosed on its own field, not in `warning`", () 
 // implementation is verified, never a copy of it.
 
 const SET_WIDGET_SRC = (() => {
-  const m = PANEL_SRC.match(/ {2}async graph_set_widget\(\{ node_id, widget, value, workflow_uuid \}\) \{[\s\S]*?\n {2}\},/);
+  const m = PANEL_SRC.match(/ {2}async graph_set_widget\(\{ node_id, widget, value, workflow_uuid, builder_state \}\) \{[\s\S]*?\n {2}\},/);
   assert.ok(m, "could not locate graph_set_widget in the panel source");
   return m[0];
 })();
@@ -1296,6 +1296,8 @@ const EXECUTOR_DEPS = [
   "rgthreeFastGroupsRefusal",
   "classifyIdeogram4PromptBuilderWrite",
   "ideogram4PromptBuilderRefusal",
+  "classifyMiniMaxH3PromptBuilderWrite",
+  "applyMiniMaxH3PromptBuilderWrite",
   "awaitObjectInfoHistorySeed",
   "isRgthreeLoraRowCreation",
   "createRgthreeLoraRow",
@@ -1459,6 +1461,7 @@ function executor(node, overrides = {}) {
     // stand-in is never an Ideogram4PromptBuilderKJ, so it classifies nothing — same as the
     // other pack classifiers above.
     classifyIdeogram4PromptBuilderWrite: () => null,
+    classifyMiniMaxH3PromptBuilderWrite: () => null,
     awaitObjectInfoHistorySeed: async () => {},
     // The REAL classifier and creator: a double here would let the executor pass against a
     // route that never fires, which is precisely the defect under test.

--- a/browser_tests/unit/set-widget-stale-combo-budget.test.mjs
+++ b/browser_tests/unit/set-widget-stale-combo-budget.test.mjs
@@ -167,7 +167,7 @@ test("#1418 a never-started recovery says NOTHING IS RUNNING — never 'still ru
 // shipped body with the real coalescer answers that.
 
 const SET_WIDGET_SRC = (() => {
-  const m = PANEL_SRC.match(/ {2}async graph_set_widget\(\{ node_id, widget, value, workflow_uuid \}\) \{[\s\S]*?\n {2}\},/);
+  const m = PANEL_SRC.match(/ {2}async graph_set_widget\(\{ node_id, widget, value, workflow_uuid, builder_state \}\) \{[\s\S]*?\n {2}\},/);
   assert.ok(m, "could not locate graph_set_widget in the panel source");
   return m[0];
 })();
@@ -186,6 +186,8 @@ const EXECUTOR_DEPS = [
   "rgthreeFastGroupsRefusal",
   "classifyIdeogram4PromptBuilderWrite",
   "ideogram4PromptBuilderRefusal",
+  "classifyMiniMaxH3PromptBuilderWrite",
+  "applyMiniMaxH3PromptBuilderWrite",
   "awaitObjectInfoHistorySeed",
   "isRgthreeLoraRowCreation",
   "createRgthreeLoraRow",
@@ -321,6 +323,7 @@ function realGraphSetWidget({
     classifyPromptRelayTimelineWrite: () => null,
     classifyRgthreeFastGroupsWrite: () => null,
     classifyIdeogram4PromptBuilderWrite: () => null,
+    classifyMiniMaxH3PromptBuilderWrite: () => null,
     // #1418 — honors the cap it is handed, the way the shipped one does: it waits at most
     // waitMs, and a slow seed simply spends it.
     awaitObjectInfoHistorySeed: (waitMs) =>

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -444,6 +444,10 @@ import {
   ideogram4PromptBuilderRefusal,
 } from "./lib/ideogram4-prompt-builder.js";
 import {
+  classifyMiniMaxH3PromptBuilderWrite,
+  applyMiniMaxH3PromptBuilderWrite,
+} from "./lib/minimax-h3-prompt-builder.js";
+import {
   controlAfterGenerateModes,
   controlAfterGenerateEntries,
 } from "./lib/control-after-generate.js";
@@ -14232,7 +14236,7 @@ const GRAPH_TOOL_EXECUTORS = {
     };
   },
 
-  async graph_set_widget({ node_id, widget, value, workflow_uuid }) {
+  async graph_set_widget({ node_id, widget, value, workflow_uuid, builder_state }) {
     // #1413 — ONE deadline for the whole command, taken BEFORE anything awaits, so the
     // bounded steps inside it compose instead of adding (#1192, #671). The step this
     // exists for is the stale-combo recovery's refresh join below: reached only after
@@ -14332,6 +14336,19 @@ const GRAPH_TOOL_EXECUTORS = {
     // which has no serializer of its own, is deliberately still writable.
     if (classifyIdeogram4PromptBuilderWrite(node, widget) === "derived") {
       throw new Error(ideogram4PromptBuilderRefusal(widget, node.id));
+    }
+    // #1549: MiniMaxH3PromptBuilder's editor Save writes prompt_text and builder_state
+    // together. Two panel_set_widget calls have no transaction boundary, so a render
+    // that starts in the gap fences the second write and leaves the queued prompt and
+    // the saved editor disagreeing. This route assigns both widgets in one undo
+    // envelope, matching the pack's Save, with no await between them.
+    if (classifyMiniMaxH3PromptBuilderWrite(node, widget)) {
+      return applyMiniMaxH3PromptBuilderWrite(node, widget, value, {
+        builder_state,
+        beforeChange: () => graph.beforeChange(),
+        afterChange: () => graph.afterChange(),
+        setDirty: () => graph.setDirtyCanvas(true, true),
+      });
     }
     // #458: WAIT for the startup baseline history seed to land before authorizing, so a
     // write can never decide "never seen" against an un-seeded history — a pack present

--- a/web/js/lib/minimax-h3-prompt-builder.js
+++ b/web/js/lib/minimax-h3-prompt-builder.js
@@ -1,0 +1,590 @@
+// #1549 — MiniMaxH3PromptBuilder's editor Save writes `prompt_text` and `builder_state`
+// together. panel_set_widget is one widget per call, and the orchestrator fences a
+// targeted graph mutation while a ComfyUI prompt is running, so the pair can split:
+// prompt_text lands, a render starts, builder_state is refused unsent. The queued
+// prompt and the saved editor then disagree; the next editor Save overwrites the
+// queued prompt from the stale state.
+//
+// Facts from the pack's own source (ComfyUI-Fantastic-MiniMaxH3-PromptBuilder
+// `web/promptbuilder.js` save() / generate() / defaultState()), not inferred from
+// the report:
+//
+//   save() {
+//     const pw = this.node.widgets?.find((w) => w.name === "prompt_text");
+//     const sw = this.node.widgets?.find((w) => w.name === "builder_state");
+//     if (pw) pw.value = generate(this.state);
+//     if (sw) sw.value = JSON.stringify(this.state);
+//   }
+//
+// execute() reads prompt_text for the STRING output and builder_state only for
+// `_mode_of` (media gating). Mode and prompt cannot disagree after Save because
+// they are assigned in the same turn. This route does the same assignment, in
+// one undo envelope, with no await between the two widgets — so a render that
+// starts after the call cannot split them.
+//
+// `builder_state` is the master (the editor's JSON). Writing it regenerates
+// prompt_text via the pack's generate(). Writing prompt_text with a companion
+// `builder_state` argument writes both as given. Writing prompt_text alone still
+// writes BOTH widgets: the requested string (what execute() queues) and a
+// builder_state aligned so generate(state) matches when the prompt is in the
+// pack's labeled format, otherwise the primary editor field holds the new text.
+//
+// Keyed strictly to node type MiniMaxH3PromptBuilder and those two widget names.
+// Dependency-free. Unit-testable with plain fixtures.
+
+export const MINIMAX_H3_PROMPT_BUILDER_TYPE = "MiniMaxH3PromptBuilder";
+export const MINIMAX_H3_PROMPT_TEXT_WIDGET = "prompt_text";
+export const MINIMAX_H3_BUILDER_STATE_WIDGET = "builder_state";
+
+export const MINIMAX_H3_PROMPT_BUILDER_MODES = Object.freeze([
+  "T2VA",
+  "I2VA",
+  "FL2VA",
+  "L2VA",
+  "REF",
+]);
+
+const TASK_TYPES = Object.freeze([
+  "keyframe completion",
+  "reference generation",
+  "video editing",
+  "video continuation",
+  "audio reuse",
+  "audio reference",
+]);
+
+const IMD_PREFIX = "integrated_multimodal_description: ";
+const SOUNDSCAPE_PREFIX = "overall_soundscape: ";
+const MUSIC_PREFIX = "non_diegetic_music: ";
+
+export class MiniMaxH3PromptBuilderWriteError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "MiniMaxH3PromptBuilderWriteError";
+  }
+}
+
+function baseWidgetName(widgetName) {
+  if (typeof widgetName !== "string") return "";
+  const dot = widgetName.indexOf(".");
+  return dot === -1 ? widgetName : widgetName.slice(0, dot);
+}
+
+function findWidget(node, name) {
+  const widgets = node && Array.isArray(node.widgets) ? node.widgets : [];
+  return widgets.find((w) => w && w.name === name) ?? null;
+}
+
+export function isMiniMaxH3PromptBuilderNode(node) {
+  if (!node || typeof node !== "object") return false;
+  return node.type === MINIMAX_H3_PROMPT_BUILDER_TYPE || node.comfyClass === MINIMAX_H3_PROMPT_BUILDER_TYPE;
+}
+
+/**
+ * `"master"` for builder_state, `"output"` for prompt_text, else null.
+ * Either kind is routed through applyMiniMaxH3PromptBuilderWrite so both
+ * widgets land in the same undo envelope.
+ */
+export function classifyMiniMaxH3PromptBuilderWrite(node, widgetName) {
+  if (!isMiniMaxH3PromptBuilderNode(node)) return null;
+  const name = baseWidgetName(widgetName);
+  if (name === MINIMAX_H3_BUILDER_STATE_WIDGET) return "master";
+  if (name === MINIMAX_H3_PROMPT_TEXT_WIDGET) return "output";
+  return null;
+}
+
+export function defaultMiniMaxH3BuilderState() {
+  return {
+    version: 1,
+    mode: "T2VA",
+    off: {},
+    duration: 5,
+    p2Shot: 1,
+    lastShot: 1,
+    imd: "",
+    soundscape: "",
+    music: "N/A",
+    ref: {
+      subjectDefs: [],
+      summaryTypes: ["reference generation"],
+      summaryText: "",
+      retention: [],
+      styleLine: "",
+      detail: "",
+      soundscape: "",
+      music: "N/A",
+    },
+  };
+}
+
+/** Merge a stored state over the pack's defaults. Same shape as the editor's normaliseState. */
+export function normaliseMiniMaxH3BuilderState(s) {
+  if (!s || typeof s !== "object" || Array.isArray(s) || !s.version) {
+    return defaultMiniMaxH3BuilderState();
+  }
+  const d = defaultMiniMaxH3BuilderState();
+  const mode = MINIMAX_H3_PROMPT_BUILDER_MODES.includes(s.mode) ? s.mode : d.mode;
+  return { ...d, ...s, mode, ref: { ...d.ref, ...(s.ref || {}) } };
+}
+
+function sectionOn(state, name) {
+  return !(state.off && state.off[name]);
+}
+
+function snapLength(seconds) {
+  let L = Math.max(5, Math.round((Number(seconds) || 0) * 24));
+  L += (5 - (L % 17) + 17) % 17;
+  return L;
+}
+
+function snappedSeconds(seconds) {
+  return snapLength(seconds) / 24;
+}
+
+function fmtSS(seconds) {
+  return (Math.round(seconds * 100) / 100).toFixed(2);
+}
+
+function genBase(state) {
+  const S = fmtSS(snappedSeconds(state.duration));
+  let head = "";
+  if (state.mode === "I2VA") {
+    head =
+      "For the target video, at 0.00 seconds into the target video, " +
+      "<Picture 1> (from [Shot 1]) is fully referenced.";
+  } else if (state.mode === "FL2VA") {
+    head =
+      "How the reference pictures align with the target video — " +
+      "Picture 1 (from Shot 1) aligns with the 0.00-second mark of the target video; " +
+      `Picture 2 (from Shot ${state.p2Shot || 1}) aligns with the ${S}-second mark of the target video.`;
+  } else if (state.mode === "L2VA") {
+    head =
+      "How the reference pictures align with the target video — " +
+      `<Picture 1> (from [Shot ${state.lastShot || 1}]) aligns with the ${S}-second mark of the target video.`;
+  }
+  const parts = [`${IMD_PREFIX}${String(state.imd ?? "").trim()}`];
+  if (sectionOn(state, "overall_soundscape")) {
+    parts.push(`${SOUNDSCAPE_PREFIX}${String(state.soundscape ?? "").trim()}`);
+  }
+  if (sectionOn(state, "non_diegetic_music")) {
+    parts.push(`${MUSIC_PREFIX}${String(state.music ?? "").trim() || "N/A"}`);
+  }
+  const body = parts.join("\n\n");
+  return head ? head + "\n\n" + body : body;
+}
+
+function genRef(state) {
+  const r = state.ref || defaultMiniMaxH3BuilderState().ref;
+  const defs = (r.subjectDefs || [])
+    .filter((d) => !d.off)
+    .map((d) => String(d.text ?? "").trim())
+    .filter(Boolean)
+    .join("\n");
+  const types = TASK_TYPES.filter((t) => (r.summaryTypes || []).includes(t)).join(" + ");
+  const summary = `[${types || "reference generation"}] ${String(r.summaryText ?? "").trim()}`;
+  const retention = (r.retention || [])
+    .filter((row) => row.label && !row.off)
+    .map((row) => {
+      const ctx = row.context?.trim() ? ` (${row.context.trim()})` : "";
+      return `${row.label}${ctx}: ${row.marker} - ${String(row.note ?? "").trim()}`;
+    })
+    .join("\n");
+  const detail = [String(r.styleLine ?? "").trim(), String(r.detail ?? "").trim()].filter(Boolean).join("\n");
+  const on = (name) => sectionOn(state, name);
+  const blocks = [];
+  if (on("subject_definitions")) blocks.push(`subject_definitions:\n${defs}`);
+  blocks.push(`summary:\n${summary}`);
+  if (on("retention_analysis")) blocks.push(`retention_analysis:\n${retention}`);
+  blocks.push(`detailed_description:\n${detail}`);
+  if (on("overall_soundscape")) blocks.push(`overall_soundscape:\n${String(r.soundscape ?? "").trim()}`);
+  if (on("non_diegetic_music")) blocks.push(`non_diegetic_music:\n${String(r.music ?? "").trim() || "N/A"}`);
+  return blocks.join("\n\n");
+}
+
+/** The pack's generate(): the STRING execute() queues from editor state. */
+export function generateMiniMaxH3Prompt(state) {
+  const s = normaliseMiniMaxH3BuilderState(state);
+  return s.mode === "REF" ? genRef(s) : genBase(s);
+}
+
+function looksLikeBuilderState(value) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  if (typeof value.version !== "number") return false;
+  return MINIMAX_H3_PROMPT_BUILDER_MODES.includes(value.mode);
+}
+
+function parseJsonObject(raw, label) {
+  if (raw && typeof raw === "object" && !Array.isArray(raw)) return raw;
+  if (typeof raw !== "string") {
+    throw new MiniMaxH3PromptBuilderWriteError(
+      `MiniMaxH3PromptBuilder ${label} must be a JSON object or JSON string (#1549).`,
+    );
+  }
+  const trimmed = raw.trim();
+  if (!trimmed || trimmed === "{}") return {};
+  let parsed;
+  try {
+    parsed = JSON.parse(trimmed);
+  } catch {
+    throw new MiniMaxH3PromptBuilderWriteError(
+      `MiniMaxH3PromptBuilder ${label} is not valid JSON (#1549). The editor Save writes ` +
+        `prompt_text and builder_state together; re-issue builder_state as the editor's JSON ` +
+        `object (stringified) so both widgets can land in one call.`,
+    );
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new MiniMaxH3PromptBuilderWriteError(
+      `MiniMaxH3PromptBuilder ${label} must decode to a JSON object (#1549).`,
+    );
+  }
+  return parsed;
+}
+
+export function parseMiniMaxH3BuilderState(value) {
+  return normaliseMiniMaxH3BuilderState(parseJsonObject(value, "builder_state"));
+}
+
+function compiledPromptFromState(state) {
+  if (typeof state.prompt_text === "string") return state.prompt_text;
+  if (typeof state.compiled === "string") return state.compiled;
+  return generateMiniMaxH3Prompt(state);
+}
+
+function splitLabeledBlocks(text) {
+  return String(text ?? "")
+    .split(/\n\n+/)
+    .map((b) => b.trim())
+    .filter(Boolean);
+}
+
+function takePrefix(block, prefix) {
+  return block.startsWith(prefix) ? block.slice(prefix.length) : null;
+}
+
+/**
+ * Inverse of generate() for the pack's labeled format. Returns null when the
+ * text is not that format, so an unstructured prompt is aligned as a primary
+ * field rather than guessed into the wrong sections.
+ */
+export function parseMiniMaxH3GeneratedPrompt(text, current) {
+  const src = String(text ?? "").trim();
+  if (!src) return null;
+  const base = normaliseMiniMaxH3BuilderState(current);
+  if (
+    /(?:^|\n)(?:subject_definitions|summary|retention_analysis|detailed_description):/.test(src)
+  ) {
+    return parseRefGeneratedPrompt(src, base);
+  }
+  if (
+    src.startsWith("For the target video, at 0.00 seconds") ||
+    src.startsWith("How the reference pictures align with the target video") ||
+    src.includes(IMD_PREFIX.trim())
+  ) {
+    return parseBaseGeneratedPrompt(src, base);
+  }
+  return null;
+}
+
+function parseBaseGeneratedPrompt(src, current) {
+  let rest = src;
+  let mode = current.mode === "REF" ? "T2VA" : current.mode;
+  let duration = current.duration;
+  let p2Shot = current.p2Shot;
+  let lastShot = current.lastShot;
+  if (rest.startsWith("For the target video, at 0.00 seconds")) {
+    mode = "I2VA";
+    const split = rest.indexOf("\n\n");
+    rest = split >= 0 ? rest.slice(split + 2) : "";
+  } else if (rest.startsWith("How the reference pictures align with the target video — Picture 1")) {
+    mode = "FL2VA";
+    const shot = rest.match(/Picture 2 \(from Shot (\d+)\)/);
+    const dur = rest.match(/aligns with the ([0-9.]+)-second mark of the target video\./);
+    if (shot) p2Shot = Number(shot[1]) || p2Shot;
+    if (dur) duration = Number(dur[1]) || duration;
+    const split = rest.indexOf("\n\n");
+    rest = split >= 0 ? rest.slice(split + 2) : "";
+  } else if (rest.startsWith("How the reference pictures align with the target video — <Picture 1>")) {
+    mode = "L2VA";
+    const shot = rest.match(/from \[Shot (\d+)\]/);
+    const dur = rest.match(/aligns with the ([0-9.]+)-second mark of the target video\./);
+    if (shot) lastShot = Number(shot[1]) || lastShot;
+    if (dur) duration = Number(dur[1]) || duration;
+    const split = rest.indexOf("\n\n");
+    rest = split >= 0 ? rest.slice(split + 2) : "";
+  }
+  const blocks = splitLabeledBlocks(rest);
+  const imdBlock = blocks.find((b) => b.startsWith(IMD_PREFIX));
+  if (!imdBlock) return null;
+  const off = { ...(current.off || {}) };
+  const soundscapeBlock = blocks.find((b) => b.startsWith(SOUNDSCAPE_PREFIX));
+  const musicBlock = blocks.find((b) => b.startsWith(MUSIC_PREFIX));
+  off.overall_soundscape = !soundscapeBlock;
+  off.non_diegetic_music = !musicBlock;
+  return {
+    ...current,
+    mode,
+    duration,
+    p2Shot,
+    lastShot,
+    imd: takePrefix(imdBlock, IMD_PREFIX) ?? "",
+    soundscape: soundscapeBlock ? takePrefix(soundscapeBlock, SOUNDSCAPE_PREFIX) ?? "" : current.soundscape,
+    music: musicBlock ? takePrefix(musicBlock, MUSIC_PREFIX) ?? "N/A" : current.music,
+    off,
+  };
+}
+
+function parseRefGeneratedPrompt(src, current) {
+  const blocks = splitLabeledBlocks(src);
+  const byLabel = {};
+  for (const block of blocks) {
+    const nl = block.indexOf(":\n");
+    const colon = block.indexOf(":");
+    if (nl >= 0) byLabel[block.slice(0, nl)] = block.slice(nl + 2);
+    else if (colon >= 0) byLabel[block.slice(0, colon)] = block.slice(colon + 1).trim();
+  }
+  if (!Object.prototype.hasOwnProperty.call(byLabel, "summary") &&
+      !Object.prototype.hasOwnProperty.call(byLabel, "detailed_description")) {
+    return null;
+  }
+  const off = { ...(current.off || {}) };
+  off.subject_definitions = !Object.prototype.hasOwnProperty.call(byLabel, "subject_definitions");
+  off.retention_analysis = !Object.prototype.hasOwnProperty.call(byLabel, "retention_analysis");
+  off.overall_soundscape = !Object.prototype.hasOwnProperty.call(byLabel, "overall_soundscape");
+  off.non_diegetic_music = !Object.prototype.hasOwnProperty.call(byLabel, "non_diegetic_music");
+  const summaryRaw = byLabel.summary || "";
+  const summaryMatch = summaryRaw.match(/^\[([^\]]*)\]\s*(.*)$/s);
+  const typeStr = summaryMatch ? summaryMatch[1] : "";
+  const summaryText = summaryMatch ? summaryMatch[2] : summaryRaw;
+  const summaryTypes = typeStr
+    .split(/\s*\+\s*/)
+    .map((t) => t.trim())
+    .filter((t) => TASK_TYPES.includes(t));
+  const defLines = (byLabel.subject_definitions || "")
+    .split("\n")
+    .map((text) => text.trim())
+    .filter(Boolean)
+    .map((text) => ({ text }));
+  const retention = (byLabel.retention_analysis || "")
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => {
+      const m = line.match(/^(<[^>]+>|[^:(]+)(?:\s*\(([^)]*)\))?:\s*(\S+)\s*-\s*(.*)$/);
+      if (!m) return { label: line, context: "", marker: "", note: "" };
+      return { label: m[1].trim(), context: m[2] || "", marker: m[3], note: m[4] };
+    });
+  const detailRaw = byLabel.detailed_description || "";
+  const detailNl = detailRaw.indexOf("\n");
+  const styleLine = detailNl >= 0 ? detailRaw.slice(0, detailNl) : "";
+  const detail = detailNl >= 0 ? detailRaw.slice(detailNl + 1) : detailRaw;
+  return {
+    ...current,
+    mode: "REF",
+    off,
+    ref: {
+      ...current.ref,
+      subjectDefs: defLines.length ? defLines : current.ref.subjectDefs,
+      summaryTypes: summaryTypes.length ? summaryTypes : current.ref.summaryTypes,
+      summaryText: String(summaryText ?? "").trim(),
+      retention: retention.length ? retention : current.ref.retention,
+      styleLine,
+      detail,
+      soundscape: byLabel.overall_soundscape ?? current.ref.soundscape,
+      music: byLabel.non_diegetic_music || current.ref.music,
+    },
+  };
+}
+
+function alignStateToPrompt(current, prompt) {
+  const parsed = parseMiniMaxH3GeneratedPrompt(prompt, current);
+  if (parsed && generateMiniMaxH3Prompt(parsed) === prompt) return { state: parsed, how: "parsed" };
+  if (parsed) return { state: parsed, how: "parsed_approx" };
+  const mode = current.mode === "REF" ? current.mode : current.mode || "T2VA";
+  if (mode === "REF") {
+    return {
+      state: {
+        ...current,
+        mode: "REF",
+        off: {
+          ...(current.off || {}),
+          overall_soundscape: true,
+          non_diegetic_music: true,
+          subject_definitions: true,
+          retention_analysis: true,
+        },
+        ref: { ...current.ref, summaryText: "", styleLine: "", detail: prompt },
+      },
+      how: "primary_text",
+    };
+  }
+  return {
+    state: {
+      ...current,
+      mode,
+      imd: prompt,
+      off: { ...(current.off || {}), overall_soundscape: true, non_diegetic_music: true },
+    },
+    how: "primary_text",
+  };
+}
+
+function readCurrentState(node) {
+  const w = findWidget(node, MINIMAX_H3_BUILDER_STATE_WIDGET);
+  try {
+    return parseMiniMaxH3BuilderState(w?.value ?? "{}");
+  } catch {
+    return defaultMiniMaxH3BuilderState();
+  }
+}
+
+function resolvePair(node, widgetName, value, companionState) {
+  const name = baseWidgetName(widgetName);
+  const current = readCurrentState(node);
+
+  if (name === MINIMAX_H3_BUILDER_STATE_WIDGET) {
+    const state = parseMiniMaxH3BuilderState(value);
+    return {
+      state,
+      prompt: compiledPromptFromState(state),
+      source: "builder_state",
+      aligned: "generated",
+    };
+  }
+
+  if (companionState !== undefined && companionState !== null && companionState !== "") {
+    const state = parseMiniMaxH3BuilderState(companionState);
+    const prompt = value == null ? compiledPromptFromState(state) : String(value);
+    return {
+      state,
+      prompt,
+      source: "pair",
+      aligned: generateMiniMaxH3Prompt(state) === prompt ? "pair_matches" : "pair_explicit",
+    };
+  }
+
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (trimmed.startsWith("{")) {
+      try {
+        const parsed = JSON.parse(trimmed);
+        if (looksLikeBuilderState(parsed)) {
+          const state = normaliseMiniMaxH3BuilderState(parsed);
+          return {
+            state,
+            prompt: compiledPromptFromState(state),
+            source: "prompt_text_as_state",
+            aligned: "generated",
+          };
+        }
+        if (parsed && typeof parsed === "object" && !Array.isArray(parsed) && parsed.builder_state != null) {
+          const state = parseMiniMaxH3BuilderState(parsed.builder_state);
+          const prompt =
+            typeof parsed.prompt_text === "string" ? parsed.prompt_text : compiledPromptFromState(state);
+          return { state, prompt, source: "envelope", aligned: "pair_explicit" };
+        }
+      } catch {
+        // Plain prompt that happens to start with `{` — treat as output text.
+      }
+    }
+  }
+
+  const prompt = value == null ? "" : String(value);
+  if (generateMiniMaxH3Prompt(current) === prompt) {
+    return { state: current, prompt, source: "prompt_text", aligned: "already" };
+  }
+  const aligned = alignStateToPrompt(current, prompt);
+  return { state: aligned.state, prompt, source: "prompt_text", aligned: aligned.how };
+}
+
+function missingWidgetsMessage(nodeId, missing) {
+  return (
+    `MiniMaxH3PromptBuilder node ${nodeId} is missing the widget(s) ${missing.join(", ")}, so ` +
+    `prompt_text and builder_state cannot be written together (#1549). The pack's editor Save ` +
+    `assigns both in one step; writing one alone is what leaves the queued prompt and the ` +
+    `editor out of sync. Check that ComfyUI-Fantastic-MiniMaxH3-PromptBuilder is installed ` +
+    `and this node is up to date.`
+  );
+}
+
+/**
+ * Write prompt_text and builder_state in one undo envelope, matching the pack's Save.
+ *
+ * `companionState` is the optional `builder_state` argument on graph_set_widget,
+ * used when the caller's widget is prompt_text so both values arrive in ONE
+ * command (the race the reporter hit is strictly between two commands).
+ */
+export function applyMiniMaxH3PromptBuilderWrite(
+  node,
+  widgetName,
+  value,
+  { builder_state: companionState, beforeChange, afterChange, setDirty } = {},
+) {
+  const promptWidget = findWidget(node, MINIMAX_H3_PROMPT_TEXT_WIDGET);
+  const stateWidget = findWidget(node, MINIMAX_H3_BUILDER_STATE_WIDGET);
+  const missing = [];
+  if (!promptWidget) missing.push(MINIMAX_H3_PROMPT_TEXT_WIDGET);
+  if (!stateWidget) missing.push(MINIMAX_H3_BUILDER_STATE_WIDGET);
+  if (missing.length) {
+    throw new MiniMaxH3PromptBuilderWriteError(missingWidgetsMessage(node?.id, missing));
+  }
+
+  const pair = resolvePair(node, widgetName, value, companionState);
+  const serializedState = JSON.stringify(pair.state);
+  const prevPrompt = promptWidget.value;
+  const prevState = stateWidget.value;
+
+  beforeChange?.();
+  try {
+    promptWidget.value = pair.prompt;
+    stateWidget.value = serializedState;
+    if (node && typeof node === "object") node._mmh3Draft = null;
+  } catch (err) {
+    try {
+      promptWidget.value = prevPrompt;
+    } catch {
+      /* restore is best-effort so the original write error stays the refusal */
+    }
+    try {
+      stateWidget.value = prevState;
+    } catch {
+      /* restore is best-effort so the original write error stays the refusal */
+    }
+    throw err;
+  } finally {
+    afterChange?.();
+  }
+  setDirty?.();
+
+  return {
+    set: {
+      widget: baseWidgetName(widgetName) || MINIMAX_H3_PROMPT_TEXT_WIDGET,
+      value: pair.source === "builder_state" || pair.source === "prompt_text_as_state"
+        ? serializedState
+        : pair.prompt,
+      previous: pair.source === "builder_state" || pair.source === "prompt_text_as_state"
+        ? prevState
+        : prevPrompt,
+      node_id: node.id,
+    },
+    companion: {
+      widget:
+        pair.source === "builder_state" || pair.source === "prompt_text_as_state"
+          ? MINIMAX_H3_PROMPT_TEXT_WIDGET
+          : MINIMAX_H3_BUILDER_STATE_WIDGET,
+      value:
+        pair.source === "builder_state" || pair.source === "prompt_text_as_state"
+          ? pair.prompt
+          : serializedState,
+      previous:
+        pair.source === "builder_state" || pair.source === "prompt_text_as_state"
+          ? prevPrompt
+          : prevState,
+    },
+    minimax_h3_prompt_builder: {
+      node_id: node.id,
+      synced: [MINIMAX_H3_PROMPT_TEXT_WIDGET, MINIMAX_H3_BUILDER_STATE_WIDGET],
+      source: pair.source,
+      aligned: pair.aligned,
+    },
+  };
+}


### PR DESCRIPTION
Fixes #1549

A MiniMaxH3PromptBuilder `prompt_text` write could succeed while the follow-up `builder_state` write was refused QUEUE BUSY, because those are two `panel_set_widget` calls and the orchestrator fences a targeted mutation once a ComfyUI prompt is running. The pack's own editor Save assigns both widgets in one turn; the split left the queued prompt and the saved editor disagreeing, and the next editor Save could overwrite the new prompt from the stale state.

`graph_set_widget` now writes both widgets in one undo envelope, with no await between them — the same pairing as LTXDirector / PromptRelay master writes:

- `builder_state` regenerates `prompt_text` via the pack's `generate()`
- `prompt_text` with a companion `builder_state` argument writes both as given
- `prompt_text` alone still updates `builder_state` so a render that starts afterwards cannot leave the editor on the previous JSON

The QUEUE BUSY fence itself is unchanged (refusing unsent remains the recoverable outcome). This does not add a generic multi-widget transaction.
