### PR TITLE
fix(mcp#1940): serverDeclaresEmptyComboOptions reads the V2 combo shape

### DIFF
--- a/browser_tests/unit/asset-staleness.test.mjs
+++ b/browser_tests/unit/asset-staleness.test.mjs
@@ -1611,3 +1611,39 @@ test("#1172 WIRING: the disclosure survives the `refreshed: true` branch (#981's
   // verdict what #1133 deliberately permits via the write path.
   assert.doesNotMatch(code, /empty_combo_lists[\s\S]{0,200}?refreshed = false/, "disclosure, not failure");
 });
+
+test("mcp#1940 review: emptyComboListsOnGraph discloses V2 empties, and still never discloses an UNREAD list", () => {
+  // The sibling of the write-path bug, found by review of its fix. isEmptyComboSpec tested
+  // Array.isArray(spec[0]), true only for V1, so a graph carrying a V2 empty combo
+  // disclosed nothing at all.
+  const defsByType = {
+    CustomCombo: { input: { required: { choice: ["COMBO", { multiselect: false, options: [] }] } } },
+    LegacyEmpty: { input: { required: { pick: [[], {}] } } },
+    V2Full: { input: { required: { pick: ["COMBO", { options: ["a", "b"] }] } } },
+    V2Remote: { input: { required: { pick: ["COMBO", { remote: { route: "/internal/files/output" } }] } } },
+    V3Dyn: { input: { required: { pick: ["COMFY_DYNAMICCOMBO_V3", { options: [{ key: "png" }] }] } } },
+  };
+  const rootGraph = {
+    _nodes: [
+      { type: "CustomCombo" },
+      { type: "LegacyEmpty" },
+      { type: "V2Full" },
+      { type: "V2Remote" },
+      { type: "V3Dyn" },
+    ],
+  };
+  const found = emptyComboListsOnGraph(rootGraph, defsByType);
+  assert.deepEqual(found, [
+    { type: "CustomCombo", widget: "choice" },
+    { type: "LegacyEmpty", widget: "pick" },
+  ]);
+});
+
+test("mcp#1940 review: a REMOTE V2 is unread even when it also carries an empty options array", () => {
+  // The invariant the whole change rests on: unread must never read as empty. A remote
+  // list arrives from a separate fetch, so options:[] alongside it is "not here yet".
+  assert.equal(authoritativeComboValues(["COMBO", { remote: { route: "/r" }, options: [] }]), null);
+  assert.equal(authoritativeComboValues(["COMBO", { remote: { route: "/r" } }]), null);
+  // Without a remote marker an empty list is still a real, server-published answer.
+  assert.deepEqual(authoritativeComboValues(["COMBO", { options: [] }]), []);
+});

--- a/browser_tests/unit/node-resolve.test.mjs
+++ b/browser_tests/unit/node-resolve.test.mjs
@@ -2728,3 +2728,110 @@ test("#1523 add_node: a throwing isLoadedSubgraphType fails closed rather than a
   assert.doesNotMatch(err.message, /graph unreadable/);
   assert.doesNotMatch(err.message, /comfyui-reactor-node/);
 });
+
+// ── mcp#1940 ─────────────────────────────────────────────────────────────────
+// The V2 combo spec. Everything above declares combos in the V1 shape
+// `[[opt, ...], config]`, where the option array IS `spec[0]`. A live ComfyUI 0.33
+// /object_info publishes 676 inputs in the V2 shape instead —
+// `["COMBO", { options: [...] }]` — with the literal type string "COMBO" at
+// `spec[0]` and the list under the config object. `serverDeclaresEmptyComboOptions`
+// tested `Array.isArray(spec[0])`, so every V2 combo was filed as "not a combo" and
+// the #507 accept could never be reached: measured 0 of 11 server-declared-empty V2
+// inputs recognised, against 30 of 30 V1.
+//
+// The reported node is verbatim from that rig:
+//     "choice": ["COMBO", { "multiselect": false, "options": [] }]
+// which made `CustomCombo.choice` permanently unwritable, blamed on a STALE list that
+// no refresh could ever change.
+function customComboFixture(liveOptions = []) {
+  const reg = loadedRegistry(["CustomCombo"]);
+  const widget = { name: "choice", type: "combo", options: { values: liveOptions }, value: "" };
+  const node = { id: 816, type: "CustomCombo", widgets: [widget], constructor: reg["CustomCombo"] };
+  return { reg, node, widget };
+}
+// /object_info in which CustomCombo's `choice` is declared in the V2 shape.
+function customComboObjectInfo(config) {
+  const info = objectInfo(["CustomCombo"]);
+  info["CustomCombo"] = { input: { required: { choice: ["COMBO", config] } } };
+  return info;
+}
+
+test("mcp#1940 e2e: a V2 combo whose SERVER option list is empty becomes writable", async () => {
+  const { reg, node, widget } = customComboFixture([]);
+  const res = await runSetWidget(node, "choice", "Default", {
+    registry: reg,
+    getRegistry: () => reg,
+    getFreshObjectInfo: async () => customComboObjectInfo({ multiselect: false, options: [] }),
+    wasTypeEverDefined: () => true,
+    refreshCombos: refreshFromServer,
+    ...HOOKS,
+  });
+  assert.equal(res.set.value, "Default");
+  assert.equal(widget.value, "Default", "the write reached the live widget");
+  assert.equal(res.empty_option_list, true, "reported honestly as an unvalidatable empty list");
+});
+
+test("mcp#1940 e2e: a V2 combo with a REAL server list is still validated STRICTLY", async () => {
+  // The fix must not turn "V2" into a blanket accept. A V2 spec that publishes a real
+  // list is refreshed and enforced exactly like V1: a member lands, a non-member is
+  // refused and nothing is written.
+  const config = { multiselect: false, options: ["Quality", "Default", "Turbo"] };
+  const ok = customComboFixture([]);
+  const res = await runSetWidget(ok.node, "choice", "Turbo", {
+    registry: ok.reg,
+    getRegistry: () => ok.reg,
+    getFreshObjectInfo: async () => customComboObjectInfo(config),
+    wasTypeEverDefined: () => true,
+    refreshCombos: refreshFromServer,
+    ...HOOKS,
+  });
+  assert.equal(ok.widget.value, "Turbo");
+  assert.notEqual(res.empty_option_list, true, "a real list is not the empty-list path");
+
+  const bad = customComboFixture([]);
+  await assert.rejects(
+    () =>
+      runSetWidget(bad.node, "choice", "Nonexistent", {
+        registry: bad.reg,
+        getRegistry: () => bad.reg,
+        getFreshObjectInfo: async () => customComboObjectInfo(config),
+        wasTypeEverDefined: () => true,
+        refreshCombos: refreshFromServer,
+        ...HOOKS,
+      }),
+    /not a valid option|refused/i,
+  );
+  assert.equal(bad.widget.value, "", "an off-list value is still refused (#240 intact)");
+});
+
+test("mcp#1940: serverDeclaresEmptyComboOptions reads the V2 shape, and still refuses to guess", () => {
+  const defs = {
+    T: {
+      input: {
+        required: {
+          v2empty: ["COMBO", { multiselect: false, options: [] }],
+          v2full: ["COMBO", { options: ["a", "b"] }],
+          // The list is a SEPARATE fetch that has not landed. Unread is not empty.
+          v2remote: ["COMBO", { remote: { route: "/internal/files/output" } }],
+          // The keys select SUB-INPUTS to materialize; they are not an option list.
+          v3dynamic: ["COMFY_DYNAMICCOMBO_V3", { options: [{ key: "png" }] }],
+          v1empty: [[], {}],
+          v1full: [["a"], {}],
+          notacombo: ["STRING", {}],
+        },
+        optional: { v2optEmpty: ["COMBO", { options: [] }] },
+      },
+    },
+  };
+  assert.equal(serverDeclaresEmptyComboOptions(defs, "T", "v2empty"), true);
+  assert.equal(serverDeclaresEmptyComboOptions(defs, "T", "v2optEmpty"), true, "optional inputs count too");
+  assert.equal(serverDeclaresEmptyComboOptions(defs, "T", "v2full"), false);
+  // Both of these are "could not read the list", which must fail CLOSED — never be
+  // mistaken for the server declaring the list empty.
+  assert.equal(serverDeclaresEmptyComboOptions(defs, "T", "v2remote"), false, "an unlanded remote list is not an empty one");
+  assert.equal(serverDeclaresEmptyComboOptions(defs, "T", "v3dynamic"), false, "dynamic V3 keys are not an option list");
+  // V1 and non-combo behaviour is unchanged.
+  assert.equal(serverDeclaresEmptyComboOptions(defs, "T", "v1empty"), true);
+  assert.equal(serverDeclaresEmptyComboOptions(defs, "T", "v1full"), false);
+  assert.equal(serverDeclaresEmptyComboOptions(defs, "T", "notacombo"), false);
+});

--- a/browser_tests/unit/node-resolve.test.mjs
+++ b/browser_tests/unit/node-resolve.test.mjs
@@ -2835,3 +2835,60 @@ test("mcp#1940: serverDeclaresEmptyComboOptions reads the V2 shape, and still re
   assert.equal(serverDeclaresEmptyComboOptions(defs, "T", "v1full"), false);
   assert.equal(serverDeclaresEmptyComboOptions(defs, "T", "notacombo"), false);
 });
+
+// The REPORTED shape end-to-end: a subgraph instance promoting a V2 empty COMBO.
+// mcp#1940 was filed as a promoted-widget bug — "cannot set ANY promoted COMBO on a
+// subgraph node" — so a fix for the combo SHAPE has to be shown to clear the actual
+// reported scenario, not just a bare node. The promotion resolves to the concrete
+// inner CustomCombo (`followPromotionToConcrete`), which is the type whose def the
+// empty-list gate reads; before the fix that read said "not a combo" and the write
+// was refused with a stale-list message no refresh could clear.
+function promotedCustomComboFixture() {
+  const inner = {
+    id: 795,
+    type: "CustomCombo",
+    // Empty live list — nothing for the parent rail to project either.
+    widgets: [{ name: "choice", type: "combo", options: { values: [] }, value: "" }],
+    constructor: { nodeData: { input: { required: {} } } },
+  };
+  const subgraph = { _nodes: [inner], getNodeById: (id) => (String(id) === "795" ? inner : null) };
+  const railWidget = { name: "mode", type: "combo", options: { values: [] }, value: "" };
+  const parent = {
+    id: 816,
+    // The synthetic subgraph UUID from the report — never in /object_info, and never
+    // looked up: the promotion is traversed to the inner type instead.
+    type: "6c697765-ebd7-4e1e-8af0-d84d620be471",
+    subgraph,
+    inputs: [{ name: "mode", _widget: railWidget, _subgraphSlot: { name: "mode" } }],
+    widgets: [railWidget],
+  };
+  const resolveSource = (_n, si) =>
+    si?.name === "mode" ? { sourceNodeId: "795", sourceWidgetName: "choice" } : null;
+  return { parent, inner, resolveSource };
+}
+
+test("mcp#1940 e2e: a PROMOTED V2 empty combo on a subgraph instance is settable from the parent", async () => {
+  const reg = loadedRegistry(["CustomCombo"]);
+  reg["6c697765-ebd7-4e1e-8af0-d84d620be471"] = reg["SubgraphNode"] ?? function SubgraphNode() {};
+  const { parent, inner, resolveSource } = promotedCustomComboFixture();
+  const fresh = objectInfo(["CustomCombo"]);
+  fresh["CustomCombo"] = { input: { required: { choice: ["COMBO", { multiselect: false, options: [] }] } } };
+  const res = await runSetWidget(parent, "mode", "Default", {
+    registry: reg,
+    getRegistry: () => reg,
+    getFreshObjectInfo: async () => fresh,
+    // The UUID was NEVER a backend type — it is a subgraph. Answering `true` here
+    // would claim its absence from /object_info means an uninstalled pack (#458).
+    wasTypeEverDefined: (t) => t === "CustomCombo",
+    refreshCombos: refreshFromServer,
+    resolveSource,
+    ...HOOKS,
+  });
+  assert.equal(res.set.value, "Default");
+  assert.equal(res.set.promoted_from.inner_node_id, 795, "resolved through the promotion, not the UUID");
+  assert.equal(
+    inner.widgets.find((w) => w.name === "choice").value,
+    "Default",
+    "the value reached the inner widget the rail projects",
+  );
+});

--- a/web/js/lib/asset-staleness.js
+++ b/web/js/lib/asset-staleness.js
@@ -850,13 +850,23 @@ function mergedInputsFor(def, cache, type) {
 /**
  * Is this input spec a combo whose authoritative option list came back EMPTY?
  *
- * A combo's spec is `[[opt, ...], config?]`. An empty first element is the backend saying
- * "this widget has no valid values" — which is a real answer (#507/#1133: a server with zero
- * checkpoints), not a panel failure. It is worth DISCLOSING and never worth refusing over.
+ * An empty published list is the backend saying "this widget has no valid values" — a real
+ * answer (#507/#1133: a server with zero checkpoints), not a panel failure. It is worth
+ * DISCLOSING and never worth refusing over.
+ *
+ * mcp#1940 — read through `authoritativeComboValues`, never off `spec[0]`. This tested
+ * `Array.isArray(spec[0])`, which holds only for the V1 shape `[[opt, ...], config?]`; a V2
+ * `["COMBO", { options: [] }]` leaves the type string "COMBO" at `spec[0]` and was silently
+ * skipped, so a graph carrying one (CustomCombo, HypernetworkLoader, …) disclosed nothing.
+ * That is the same per-call-site adoption gap this reader was introduced to close in the
+ * WRITE path — found here by review of that fix, one module away from it.
+ *
+ * Unread still never counts as empty: a remote V2 whose list has not landed, and a dynamic
+ * V3, both yield null and are not disclosed.
  */
 function isEmptyComboSpec(spec) {
-  const first = Array.isArray(spec) ? spec[0] : undefined;
-  return Array.isArray(first) && first.length === 0;
+  const values = authoritativeComboValues(spec);
+  return Array.isArray(values) && values.length === 0;
 }
 
 /**

--- a/web/js/lib/asset-staleness.js
+++ b/web/js/lib/asset-staleness.js
@@ -12,7 +12,13 @@
  *      the class def wasn't matched at load, even though the live def names them. (#199)
  */
 
-import { parseAnnotatedFilepath } from "./input-asset.js";
+import { authoritativeComboValues, parseAnnotatedFilepath } from "./input-asset.js";
+
+// mcp#1940 — `authoritativeComboValues` moved to the LEAF module input-asset.js so
+// `serverDeclaresEmptyComboOptions` (which lives there) can share the one canonical
+// reader without this file and that one importing each other. Re-exported here because
+// this is where it was published and callers import it from this path.
+export { authoritativeComboValues };
 
 const UNKNOWN_WIDGET_RE = /^UNKNOWN(_\d+)?$/;
 
@@ -776,35 +782,6 @@ export function collectAllGraphs(rootGraph) {
  * map supplies the concrete-def key to look its options up under (#458×#366). Widgets
  * not in the map fall back to their own name.
  */
-/**
- * The authoritative option list a def spec publishes, or NULL when this spec does not
- * carry one. Never guesses: a caller that gets null has learned that it cannot rebuild
- * this widget, which is a different thing from a widget that is not a combo.
- *
- * MEASURED against a live ComfyUI 0.33 /object_info (848 types), because the V1 shape was
- * the only one this file handled and it is now the MINORITY:
- *
- *     [[opt, ...], config?]                    V1, 61 inputs   — the historical shape
- *     ["COMBO", { options: [opt, ...] }]       V2, 467 inputs  — silently skipped before
- *     ["COMBO", { remote: { route } }]         V2 remote, 1    — the list is a separate
- *                                              fetch; the frontend shows "Loading…" until
- *                                              it lands, so there is nothing to copy
- *     ["COMFY_DYNAMICCOMBO_V3", { options: [{ key, inputs }] }]   120 inputs — the keys
- *                                              select SUB-INPUTS to materialize; copying
- *                                              the keys alone would publish a list this
- *                                              file cannot honour
- *
- * The last two return null on purpose. `refreshComboOptionsFromDefs` counts them as
- * SKIPPED rather than treating "I did not rebuild it" as "there was nothing to rebuild".
- */
-export function authoritativeComboValues(spec) {
-  if (!Array.isArray(spec)) return null;
-  // V1 — the first element IS the option array.
-  if (Array.isArray(spec[0])) return spec[0];
-  // V2 — a "COMBO" type string, options under the config object.
-  if (spec[0] === "COMBO" && Array.isArray(spec[1]?.options)) return spec[1].options;
-  return null;
-}
 
 /**
  * Whether this input is a COMBO whose list this file could not derive — a remote V2, a

--- a/web/js/lib/input-asset.js
+++ b/web/js/lib/input-asset.js
@@ -183,6 +183,13 @@ export function authoritativeComboValues(spec) {
   // V1 — the first element IS the option array.
   if (Array.isArray(spec[0])) return spec[0];
   // V2 — a "COMBO" type string, options under the config object.
+  //
+  // A REMOTE list is unread by definition: it arrives from a separate fetch and the
+  // frontend shows "Loading…" until it lands. Measured remote V2 specs carry no `options`
+  // array at all, so this is defense in depth rather than a live shape — but the whole
+  // safety argument for reading V2 is that UNREAD never becomes EMPTY, and a spec carrying
+  // `remote` alongside an empty `options` would be exactly the case that breaks it.
+  if (spec[0] === "COMBO" && spec[1]?.remote) return null;
   if (spec[0] === "COMBO" && Array.isArray(spec[1]?.options)) return spec[1].options;
   return null;
 }

--- a/web/js/lib/input-asset.js
+++ b/web/js/lib/input-asset.js
@@ -155,6 +155,39 @@ export function uploadInputConfig(defsByType, type, widgetName) {
 }
 
 /**
+ * The authoritative option list a def spec publishes, or NULL when this spec does not
+ * carry one. Never guesses: a caller that gets null has learned that it cannot read
+ * this list, which is a different thing from an input that is not a combo.
+ *
+ * MEASURED against a live ComfyUI 0.33 /object_info, because the V1 shape was the only
+ * one originally handled and it is now the MINORITY:
+ *
+ *     [[opt, ...], config?]                    V1 — the historical shape
+ *     ["COMBO", { options: [opt, ...] }]       V2 — the common shape today
+ *     ["COMBO", { remote: { route } }]         V2 remote — the list is a separate fetch;
+ *                                              nothing to read until it lands
+ *     ["COMFY_DYNAMICCOMBO_V3", { options: [{ key, inputs }] }]
+ *                                              the keys select SUB-INPUTS to materialize;
+ *                                              they are not an option list
+ *
+ * The last two return null on purpose — "I could not read it", never "it is empty".
+ * That distinction is load-bearing for `serverDeclaresEmptyComboOptions` below.
+ *
+ * Lives in this LEAF module (no imports) so both consumers can share one reader:
+ * asset-staleness.js re-exports it, and `serverDeclaresEmptyComboOptions` uses it
+ * directly. It previously lived in asset-staleness.js, which this file must not
+ * import from — that is how the two drifted apart (mcp#1940).
+ */
+export function authoritativeComboValues(spec) {
+  if (!Array.isArray(spec)) return null;
+  // V1 — the first element IS the option array.
+  if (Array.isArray(spec[0])) return spec[0];
+  // V2 — a "COMBO" type string, options under the config object.
+  if (spec[0] === "COMBO" && Array.isArray(spec[1]?.options)) return spec[1].options;
+  return null;
+}
+
+/**
  * TRUE only when the freshly-fetched /object_info AUTHORITATIVELY declares `widgetName`
  * on `type` to be a combo whose option list is EMPTY — i.e. the SERVER itself says there
  * is nothing to validate against (StarNodes' `"model": ((), {...})` ⇒ `[[], {...}]`).
@@ -168,8 +201,22 @@ export function uploadInputConfig(defsByType, type, widgetName) {
  * violating #240. Requiring the SERVER to declare the list empty makes that impossible.
  *
  * Fails CLOSED on every uncertainty: no defs, no def for the type, no such input, a
- * non-combo spec (a type string like "INT"/"STRING"), or a NON-EMPTY declared list all
- * return false, so the value simply stays rejected exactly as before.
+ * spec that publishes no readable option list, or a NON-EMPTY declared list all return
+ * false, so the value simply stays rejected exactly as before.
+ *
+ * mcp#1940 — the emptiness test reads the list through `authoritativeComboValues`, NOT
+ * off `spec[0]`. `spec[0]` is the option array only in the V1 shape; the now-common V2
+ * `["COMBO", { options: [] }]` puts it under the config object and leaves the literal
+ * type string "COMBO" at `spec[0]`. Testing `Array.isArray(spec[0])` therefore filed
+ * every V2 combo under "not a combo" and returned false — measured on a live 0.33
+ * /object_info as 0 of 11 server-declared-empty V2 inputs recognised, against 30 of 30
+ * V1. That made #507's last-resort accept UNREACHABLE for them, so `CustomCombo.choice`
+ * (declared `["COMBO", { multiselect: false, options: [] }]`) was permanently unwritable
+ * and the refusal blamed a STALE list that no refresh could ever change.
+ *
+ * The read stays authoritative in the direction that matters. A remote V2 and a dynamic
+ * V3 both yield null, not [], so neither is mistaken for "the server says empty" — an
+ * unread list must keep failing closed, exactly as a NON-EMPTY one does.
  */
 export function serverDeclaresEmptyComboOptions(defsByType, type, widgetName) {
   try {
@@ -179,8 +226,7 @@ export function serverDeclaresEmptyComboOptions(defsByType, type, widgetName) {
     const spec =
       (input.required && input.required[widgetName]) ??
       (input.optional && input.optional[widgetName]);
-    if (!Array.isArray(spec)) return false;
-    const options = spec[0];
+    const options = authoritativeComboValues(spec);
     return Array.isArray(options) && options.length === 0;
   } catch {
     return false;


### PR DESCRIPTION
Panel-side root cause for **artokun/comfyui-mcp#1940** — "panel_set_widget cannot set ANY promoted COMBO on a subgraph node".

Review is **pending**; nothing here has been reviewed yet.

## The report's framing is a red herring

The issue diagnoses this as a promoted-widget problem: the subgraph node's type is a UUID absent from `/object_info`, so the validator resolves an empty option list and fails closed. It asks for the option list to be resolved from the INNER node instead.

That mechanism does not hold up. The panel already walks the promotion chain to the ultimate concrete node and deliberately refuses to authorize a virtual subgraph type (`set-widget.js:333-340`) — "a virtual intermediate subgraph type is never in /object_info and must be traversed, not authorized". And `CustomCombo` is not missing from `/object_info` at all: it is present, along with `UNETLoader` and `CLIPLoader`, in all 4498 types on this rig.

## The actual cause: a combo spec shape the gate cannot see

`serverDeclaresEmptyComboOptions` is the gate on #507's last-resort "an empty option list is not knowable, so take the value as written". It read the option list off `spec[0]` (`input-asset.js:182-184`):

```js
if (!Array.isArray(spec)) return false;
const options = spec[0];
return Array.isArray(options) && options.length === 0;
```

`spec[0]` is the option array only in the **V1** shape `[[opt, ...], config]`. The now-common **V2** shape puts the list under the config object and leaves the literal type string `"COMBO"` at `spec[0]`. The reported node, verbatim from this machine's `/object_info`:

```json
"choice": ["COMBO", { "multiselect": false, "options": [] }]
```

So `Array.isArray(spec[0])` is false and every V2 combo was filed as "not a combo". The gate's own docblock said it fails closed on "a non-combo spec (a type string like `INT`/`STRING`)" — `"COMBO"` **is** a type string, so the bug was written down in the comment without being seen.

With the gate always false, the accept branch at `set-widget.js:967` is structurally unreachable, the ladder falls through, and the user gets the retryable "may simply be stale" wording that no refresh can ever clear. That is the reported string exactly, including the `after refreshing combo options` frame.

**This has nothing to do with subgraphs.** It reproduces on a bare `CustomCombo` node with no subgraph anywhere.

### Measured on a live ComfyUI 0.33 `/object_info`

| | V1 `[[...], {}]` | V2 `["COMBO", {options}]` |
|---|---|---|
| combo inputs | 3335 | 676 |
| server-declared **empty** | 30 | 11 |
| recognised by the gate **before** | 30 / 30 | **0 / 11** |
| recognised **after** | 30 / 30 | 11 / 11 |

The 11: `CustomCombo.choice`, `HypernetworkLoader.hypernetwork_name`, `PhotoMakerLoader.photomaker_model_name`, `AudioEncoderLoader.audio_encoder_name`, `OpticalFlowLoader.model_name`, `LoadMoGeModel.model_name`, `LoadDA3Model.model_name`, `LoadBackgroundRemovalModel.bg_removal_name`, `LoadTrainingDataset.folder_name`, `GeminiInputFiles.file`, `OpenAIInputFiles.file`.

## The fix — adopt the reader that already existed

`authoritativeComboValues` in `asset-staleness.js` already handles V1 and V2, and was measured for precisely this reason ("V1 ... is now the MINORITY", V2 "silently skipped before"). `serverDeclaresEmptyComboOptions` lives in `input-asset.js` and never adopted it — the same per-call-site adoption gap as #1621.

`input-asset.js` is a **leaf** that `asset-staleness.js` imports FROM, so it cannot import back without a cycle. The reader moves to the leaf and `asset-staleness.js` re-exports it: one canonical implementation, every existing importer untouched, no cycle.

**Strictness is unchanged where it matters.** A remote V2 (`{ remote: { route } }`) and a dynamic V3 both still yield `null`, not `[]` — an UNREAD list is never mistaken for a server-declared-empty one and keeps failing closed, exactly as a non-empty list does.

## Evidence

- **Executed, not read.** The real module against the real `/object_info`: V2 goes 0/11 → 11/11, V1 holds 30/30, `UNETLoader.unet_name` (14 real options) and `KSampler.seed` (not a combo) stay `false`.
- **Delete the fix → named tests fail.** Reverting the two-line body: `mcp#1940 e2e: a V2 combo whose SERVER option list is empty becomes writable` and `mcp#1940: serverDeclaresEmptyComboOptions reads the V2 shape...` both fail (119 → 117 pass, 2 fail).
- **The e2e drives the production path**, not the helper — it calls `runSetWidget` (what `graph_set_widget` delegates to) and asserts the value reached the live widget, so a helper-only fix would not satisfy it.
- **Loosening is also caught.** Mutating the reader so a remote V2 returns `[]` instead of `null` fails the refuses-to-guess assertion.
- Full panel unit suite **6089 pass / 0 fail / 1 todo** (6090); `check-panel-scope` OK; `tsc --noEmit` clean.
- Playwright `--workers=1` running; result posted below before merge.

## What I deliberately did NOT do

- **The issue's requested fix** — resolving combo options from the inner node for promoted widgets. The evidence says that path is not what fails, and building it would add a second resolution mechanism next to the one already in `followPromotionToConcrete`.
- **The "Secondary" wording change.** With this fix the reported case no longer reaches that message. The cases still reaching it (remote V2 whose list has not landed, a shape newer than this code) genuinely *can* be resolved by waiting or refreshing, so "may simply be stale" is not wrong for them. Rewording it now would be guessing at a message I can no longer reproduce.
- **The `unet_name` / `clip_name` half of the report.** `UNETLoader.unet_name` is V1 with 14 real options on this rig, so it cannot fail through this path. The report bundles two symptoms under one error string; this PR fixes the `choice` one and I am **not** claiming it fixes the other. That is why it does not auto-close mcp#1940.
- **Anything in the `comfyui-mcp` repo.** grok-swarm holds an active claim on the orchestrator half of #1940; this branch does not touch it.
