### PR TITLE
fix(1560): a type-scoped /object_info answers the fence when the whole map never lands

### DIFF
--- a/browser_tests/unit/object-info-snapshot.test.mjs
+++ b/browser_tests/unit/object-info-snapshot.test.mjs
@@ -512,6 +512,11 @@ function buildShippedOracle({ api, socketDown = false, epoch = 5, snapshot, epoc
     "objectInfoOracleFailureNote",
     "OBJECT_INFO_DEADLINE_MS",
     "makeCommandBudget",
+    // #1560 — the shipped body decides the type-scoped route's silence licence beside the
+    // snapshot's own verdict, so this sandbox has to supply the same predicate. A name the
+    // body closes over and the harness does not provide is a harness that models a panel
+    // which does not exist.
+    "noBackendAnswerEstablished",
     // `backendReconnectEpoch` MUST be a live mutable binding in the same scope as the
     // extracted body, because the panel's is module state the body re-reads. An earlier
     // version passed it as a frozen value, which made `observedAtEpoch` and the record-time
@@ -520,6 +525,7 @@ function buildShippedOracle({ api, socketDown = false, epoch = 5, snapshot, epoc
     `let backendReconnectEpoch = initialEpoch;
      let oracleFailures = [];
      let snapshotIneligibility = "";
+     let scopedReadLicensed = false;
      let setWidgetSchemaFromSnapshot = null;
      const comfyBackendIsDown = () => comfyBackendSocketDown;
      const historyRecorded = [];
@@ -548,6 +554,7 @@ function buildShippedOracle({ api, socketDown = false, epoch = 5, snapshot, epoc
        readNote: () => setWidgetSchemaFromSnapshot,
        readIneligibility: () => snapshotIneligibility,
        readFailures: () => oracleFailures,
+       readScopedLicence: () => scopedReadLicensed,
        readHistory: () => historyRecorded,
      };`,
   );
@@ -563,6 +570,7 @@ function buildShippedOracle({ api, socketDown = false, epoch = 5, snapshot, epoc
     objectInfoOracleFailureNote,
     OBJECT_INFO_DEADLINE_MS,
     makeCommandBudget,
+    noBackendAnswerEstablished,
   );
 }
 
@@ -991,4 +999,51 @@ test("#1223 no comment cites a symbol that does not exist", () => {
   for (const [name, src] of [["panel", PANEL_SRC], ["snapshot module", snapshotSrc]]) {
     assert.ok(!/recordsWholeSchemaOnly/.test(src), `${name} still cites a phantom symbol`);
   }
+});
+
+// ───────────── #1560: the SHIPPED body's licence for the type-scoped last resort ──────────
+
+test("#1560 SHIPPED: hung probes LICENSE the type-scoped read; the snapshot and the licence agree", async () => {
+  // Both whole-map routes went silent — the #1560 install. That is the one condition under
+  // which a per-class read may be asked at all, and it is the SAME evidence #1223's snapshot
+  // is licensed on, read once, in the same statement.
+  const snapshot = createObjectInfoSnapshot();
+  const o = buildShippedOracle({ api: hungApi, snapshot, epoch: 5 });
+  assert.equal(await o.getFreshObjectInfo(), null, "nothing usable came back");
+  assert.equal(o.readScopedLicence(), true, "silence licenses the type-scoped route");
+});
+
+test("#1560 SHIPPED: a client ANSWERING deny-all `{}` licenses NOTHING — it is never overruled", async () => {
+  // An empty schema is a client expressing deny-all. Consulting a broader per-class read
+  // there is the one direction object-info-oracle.js's note forbids, and the licence is what
+  // stops it. If this ever reads true, the fence can be widened past a deliberate refusal.
+  const snapshot = createObjectInfoSnapshot();
+  const o = buildShippedOracle({ api: { getNodeDefs: async () => ({}) }, snapshot, epoch: 5 });
+  assert.equal(await o.getFreshObjectInfo(), null, "an empty schema authorizes nothing, as before");
+  assert.equal(o.readScopedLicence(), false, "and it may not be re-asked by another route");
+});
+
+test("#1560 SHIPPED: a route that THREW licenses nothing either — something answered", async () => {
+  const snapshot = createObjectInfoSnapshot();
+  const o = buildShippedOracle({
+    api: {
+      getNodeDefs: async () => {
+        throw new Error("connection refused");
+      },
+      fetchApi: async () => {
+        throw new Error("connection refused");
+      },
+    },
+    snapshot,
+    epoch: 5,
+  });
+  assert.equal(await o.getFreshObjectInfo(), null);
+  assert.equal(o.readScopedLicence(), false, "a refused connection is a process that is GONE, not one that is busy");
+});
+
+test("#1560 SHIPPED: a LIVE answer leaves the licence false — there is nothing to license", async () => {
+  const snapshot = createObjectInfoSnapshot();
+  const o = buildShippedOracle({ api: { getNodeDefs: async () => SCHEMA }, snapshot, epoch: 5 });
+  assert.equal(await o.getFreshObjectInfo(), SCHEMA);
+  assert.equal(o.readScopedLicence(), false);
 });

--- a/browser_tests/unit/set-widget-scoped-object-info.test.mjs
+++ b/browser_tests/unit/set-widget-scoped-object-info.test.mjs
@@ -601,3 +601,67 @@ test("#1560: the COVERED list in the refusal is sanitized too, not just the aske
     "the covered list must be flattened before it reaches the message",
   );
 });
+
+test("#1560: THREE levels of nesting (A→B→C→KSampler) names and fetches EVERY intermediate", async () => {
+  // The two-level fixture above cannot see an under-cover that collects only the FIRST
+  // intermediate: with one level there is only one. `assertMutatedNodeAuthorized` runs per
+  // intermediate, so a type set that stopped early would ask the scoped map about a type it
+  // was never given — a refusal on a legitimate write, and invisible until someone nests
+  // three deep. ComfyUI supports arbitrary nesting.
+  const reg = loadedRegistry(["KSampler"]);
+  const concrete = regNode(100, "KSampler", [{ name: "steps", type: "INT", value: 20 }]);
+  const c = {
+    id: 90,
+    type: "SubgraphC",
+    widgets: [{ name: "steps", type: "INT", value: 20 }],
+    subgraph: { _nodes: [concrete], getNodeById: (id) => (String(id) === "100" ? concrete : null) },
+    inputs: [{ name: "steps", _subgraphSlot: { name: "steps" } }],
+  };
+  const b = {
+    id: 80,
+    type: "SubgraphB",
+    widgets: [{ name: "steps", type: "INT", value: 20 }],
+    subgraph: { _nodes: [c], getNodeById: (id) => (String(id) === "90" ? c : null) },
+    inputs: [{ name: "steps", _subgraphSlot: { name: "steps" } }],
+  };
+  const aRail = { name: "steps", type: "INT", value: 20 };
+  const a = {
+    id: 70,
+    type: "SubgraphA",
+    widgets: [{ name: "decoy", type: "INT", value: 999 }, aRail],
+    subgraph: { _nodes: [b], getNodeById: (id) => (String(id) === "80" ? b : null) },
+    inputs: [{ name: "steps", _widget: aRail, widget: { name: "steps" }, _subgraphSlot: { name: "steps" } }],
+  };
+  for (const t of ["SubgraphA", "SubgraphB", "SubgraphC"]) reg[t] = function Virtual() {};
+  const resolveSource = (n, si) => {
+    if (n === a && si?.name === "steps") return { sourceNodeId: "80", sourceWidgetName: "steps" };
+    if (n === b && si?.name === "steps") return { sourceNodeId: "90", sourceWidgetName: "steps" };
+    if (n === c && si?.name === "steps") return { sourceNodeId: "100", sourceWidgetName: "steps" };
+    return null;
+  };
+
+  const resolution = resolvePromotedInnerTarget(a, "steps", resolveSource);
+  assert.deepEqual(
+    scopedAuthorizationTypes(a, resolution, true, resolveSource).sort(),
+    ["KSampler", "SubgraphA", "SubgraphB", "SubgraphC"],
+    "BOTH intermediates are named, not just the first",
+  );
+
+  const backend = largeInstall({ defined: ["KSampler"] });
+  const { set } = await runSetWidget(a, "steps", 30, {
+    registry: reg,
+    getRegistry: () => reg,
+    getFreshObjectInfo: async () => null,
+    fetchScopedObjectInfo: panelStyleScopedRoute(backend.fetchApi, SILENT_OUTCOMES),
+    wasTypeEverDefined: () => false,
+    resolveSource,
+    ...HOOKS,
+  });
+  assert.equal(set.value, 30);
+  assert.equal(b.widgets[0].value, 30, "the promoted write lands on the immediate inner node");
+  assert.deepEqual(
+    backend.perClassCalls().sort(),
+    ["/object_info/KSampler", "/object_info/SubgraphA", "/object_info/SubgraphB", "/object_info/SubgraphC"],
+    "and every one of the four was actually asked about",
+  );
+});

--- a/browser_tests/unit/set-widget-scoped-object-info.test.mjs
+++ b/browser_tests/unit/set-widget-scoped-object-info.test.mjs
@@ -451,7 +451,17 @@ test("#1560: scopedAuthorizationTypes names EVERY type the fence asks about, fro
 test("#1560: the panel WIRES the scoped route, gated on the silence licence and on the command budget", () => {
   const src = readFileSync(PANEL_JS, "utf8");
   assert.match(src, /fetchScopedObjectInfo:\s*async \(types\) => \{/, "the capability reaches runSetWidget");
-  assert.match(src, /if \(!noBackendAnswerEstablished\(oracleOutcomes\)\)/, "a route that ANSWERED is never overruled");
+  // The licence is DECIDED beside the snapshot's own verdict, on the SAME `outcome.outcomes`,
+  // in the same statement — and merely READ at the gate. A second reading of a fact
+  // established at a moment is how the two could disagree, and this handler enters
+  // `readObjectInfo` more than once (the #1126 live re-ask).
+  assert.match(
+    src,
+    /outcomes: outcome\?\.outcomes,\s*\}\);[\s\S]{0,400}?scopedReadLicensed = noBackendAnswerEstablished\(outcome\?\.outcomes\);/,
+    "decided in the same breath as objectInfoSnapshot.authorize, from the same evidence",
+  );
+  assert.match(src, /if \(!scopedReadLicensed\) \{/, "a route that ANSWERED is never overruled");
+  assert.match(src, /let scopedReadLicensed = false;/, "and it licenses nothing until a read establishes it");
   assert.match(src, /fetchTypeScopedObjectInfo\(types, \{/, "the panel calls the type-scoped reader");
   assert.match(src, /deadlineMs: budget\.bounded\(SCOPED_OBJECT_INFO_DEADLINE_MS\)/, "bounded by what the command has left");
   assert.match(src, /setWidgetSchemaProvenance = \(\) => "scoped"/, "the reply is told which route answered");

--- a/browser_tests/unit/set-widget-scoped-object-info.test.mjs
+++ b/browser_tests/unit/set-widget-scoped-object-info.test.mjs
@@ -1,0 +1,473 @@
+/**
+ * #1560 — the TYPE-SCOPED `/object_info` last resort. Run with `node --test`.
+ *
+ * The report: on ~1023 models and hundreds of custom packs both whole-schema probes time
+ * out while ComfyUI is idle and healthy, `/object_info/SmartResolution` answers 200 in
+ * ~2.7KB, and #1223's snapshot is never populated because no WHOLE map ever lands. So every
+ * `panel_set_widget` refuses FOR THE LIFE OF THE TAB — a permanent refusal on a healthy
+ * backend, not the transient busy-backend timeout the budget was designed for.
+ *
+ * These drive the REAL production handler body (`runSetWidget`) with the capability wired
+ * exactly as `web/js/comfyui-mcp-panel.js` wires it, and they pin BOTH directions:
+ *
+ *   A. The large-install write now SUCCEEDS — direct and PROMOTED (two types), fetching only
+ *      the types the write resolves to, and never populating the #1223 snapshot.
+ *   B. An unverifiable write STILL REFUSES — a removed type, an indefinite per-class answer,
+ *      one indefinite answer inside a promoted set, a whole-map route that ANSWERED rather
+ *      than going silent, and a promotion relinked across the scoped fetch.
+ *
+ * The load-bearing property is the one `object-info-oracle.js` forbade the naive fix for: a
+ * type the scoped map was NOT asked to cover must THROW, never read as absent (#716/#821).
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import { runSetWidget, scopedAuthorizationTypes } from "../../web/js/lib/set-widget.js";
+import {
+  fetchTypeScopedObjectInfo,
+  MAX_SCOPED_TYPES,
+  SCOPED_OBJECT_INFO_DEADLINE_MS,
+} from "../../web/js/lib/scoped-object-info.js";
+import { resolvePromotedInnerTarget } from "../../web/js/lib/widget-write.js";
+import { noBackendAnswerEstablished } from "../../web/js/lib/object-info-snapshot.js";
+import { createObjectInfoSnapshot } from "../../web/js/lib/object-info-snapshot.js";
+import { TRANSPORT_OUTCOME } from "../../web/js/lib/object-info-oracle.js";
+
+const PANEL_JS = fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url));
+const SET_WIDGET_JS = fileURLToPath(new URL("../../web/js/lib/set-widget.js", import.meta.url));
+const HOOKS = { beforeChange() {}, afterChange() {}, setDirty() {} };
+
+/** A registry entry that looks like a genuinely-resolved class (registerNodesFromDefs). */
+function regEntry() {
+  const ctor = function NodeCtor() {};
+  ctor.nodeData = { input: { required: {} } };
+  return ctor;
+}
+function loadedRegistry(types) {
+  const reg = {};
+  for (const t of types) reg[t] = regEntry();
+  return reg;
+}
+function regNode(id, type, widgets, extra = {}) {
+  return { id, type, widgets, constructor: { nodeData: { input: { required: {} } } }, ...extra };
+}
+
+/**
+ * A backend whose WHOLE `/object_info` never lands but which answers per class — the #1560
+ * install. `defined` is what the backend actually provides; anything else answers `{}`/200,
+ * which is how ComfyUI reports "no such class" on this route (#767).
+ */
+function largeInstall({ defined = [], perClass } = {}) {
+  const calls = [];
+  const fetchApi = async (route) => {
+    calls.push(route);
+    if (route === "/object_info") return new Promise(() => {}); // never settles
+    const m = /^\/object_info\/(.+)$/.exec(route);
+    if (!m) return { ok: false, status: 404, json: async () => ({}) };
+    const type = decodeURIComponent(m[1]);
+    if (typeof perClass === "function") {
+      const override = await perClass(type);
+      if (override !== undefined) return override;
+    }
+    return {
+      ok: true,
+      status: 200,
+      json: async () => (defined.includes(type) ? { [type]: { input: { required: {} } } } : {}),
+    };
+  };
+  return { fetchApi, calls, perClassCalls: () => calls.filter((c) => c !== "/object_info") };
+}
+
+/**
+ * The panel's own wiring for the scoped route, reproduced verbatim in shape: the SILENCE
+ * LICENCE first, then the bounded type-scoped read, then the "scoped" provenance stamp.
+ */
+function panelStyleScopedRoute(fetchApi, outcomes, onScoped) {
+  return async (types) => {
+    if (!noBackendAnswerEstablished(outcomes)) {
+      return { defs: null, covered: [], reason: "a whole-schema route ANSWERED rather than going silent" };
+    }
+    const scoped = await fetchTypeScopedObjectInfo(types, { fetchApi, deadlineMs: SCOPED_OBJECT_INFO_DEADLINE_MS });
+    if (scoped.defs && typeof onScoped === "function") onScoped(scoped);
+    return scoped;
+  };
+}
+
+/** Both whole-map routes went SILENT — the outcome list the oracle records for #1560. */
+const SILENT_OUTCOMES = [
+  { route: "client", kind: TRANSPORT_OUTCOME.NO_ANSWER },
+  { route: "http", kind: TRANSPORT_OUTCOME.NO_ANSWER },
+];
+/** A client that ANSWERED deny-all — the one outcome a broader read must never overrule. */
+const ANSWERED_OUTCOMES = [{ route: "client", kind: TRANSPORT_OUTCOME.ANSWERED_UNUSABLE }];
+
+/** The nested A→B→KSampler promotion shape the #458 suite uses. */
+function nestedFixture(reg, concreteType) {
+  const concrete = regNode(90, concreteType, [{ name: "steps", type: "INT", value: 20 }]);
+  const b = {
+    id: 80,
+    type: "SubgraphB",
+    widgets: [{ name: "steps", type: "INT", value: 20 }],
+    subgraph: { _nodes: [concrete], getNodeById: (id) => (String(id) === "90" ? concrete : null) },
+    inputs: [{ name: "steps", _subgraphSlot: { name: "steps" } }],
+  };
+  const aRail = { name: "steps", type: "INT", value: 20 };
+  const a = {
+    id: 70,
+    type: "SubgraphA",
+    widgets: [{ name: "steps_decoy", type: "INT", value: 999 }, aRail],
+    subgraph: { _nodes: [b], getNodeById: (id) => (String(id) === "80" ? b : null) },
+    inputs: [{ name: "steps", _widget: aRail, widget: { name: "steps" }, _subgraphSlot: { name: "steps" } }],
+  };
+  reg.SubgraphA = function SubgraphA() {};
+  reg.SubgraphB = function SubgraphB() {};
+  const resolveSource = (subgraphNode, si) => {
+    if (subgraphNode === a && si?.name === "steps") return { sourceNodeId: "80", sourceWidgetName: "steps" };
+    if (subgraphNode === b && si?.name === "steps") return { sourceNodeId: "90", sourceWidgetName: "steps" };
+    return null;
+  };
+  return { a, b, concrete, resolveSource };
+}
+
+// ───────────────────────────── DIRECTION A: the large-install write now succeeds ──────────
+
+test("#1560 A: whole /object_info never lands, per-class answers ⇒ a DIRECT write is authorized", async () => {
+  const reg = loadedRegistry(["SmartResolution"]);
+  const node = regNode(1976, "SmartResolution", [{ name: "value", type: "INT", value: 512 }]);
+  const backend = largeInstall({ defined: ["SmartResolution"] });
+  const { set } = await runSetWidget(node, "value", 768, {
+    registry: reg,
+    getRegistry: () => reg,
+    // The whole-map oracle produced NOTHING and #1223's snapshot could not stand in — the
+    // exact state the report describes, and today's permanent refusal.
+    getFreshObjectInfo: async () => null,
+    fetchScopedObjectInfo: panelStyleScopedRoute(backend.fetchApi, SILENT_OUTCOMES),
+    wasTypeEverDefined: () => false,
+    ...HOOKS,
+  });
+  assert.equal(set.value, 768, "the write the reporter could never land now lands");
+  assert.equal(node.widgets[0].value, 768);
+  assert.deepEqual(
+    backend.perClassCalls(),
+    ["/object_info/SmartResolution"],
+    "exactly the ONE type this write resolves to is asked about — not the whole install",
+  );
+});
+
+test("#1560 A: a PROMOTED nested write asks about ALL THREE types (#716/#821's 'two types') and succeeds", async () => {
+  const reg = loadedRegistry(["KSampler"]);
+  const { a, b, resolveSource } = nestedFixture(reg, "KSampler");
+  const backend = largeInstall({ defined: ["KSampler"] }); // SubgraphA/B are virtual: `{}`/200
+  const { set } = await runSetWidget(a, "steps", 30, {
+    registry: reg,
+    getRegistry: () => reg,
+    getFreshObjectInfo: async () => null,
+    fetchScopedObjectInfo: panelStyleScopedRoute(backend.fetchApi, SILENT_OUTCOMES),
+    wasTypeEverDefined: () => false,
+    resolveSource,
+    ...HOOKS,
+  });
+  assert.equal(set.value, 30);
+  assert.equal(b.widgets.find((w) => w.name === "steps").value, 30, "the inner promoted widget is written");
+  assert.deepEqual(
+    backend.perClassCalls().sort(),
+    ["/object_info/KSampler", "/object_info/SubgraphA", "/object_info/SubgraphB"].sort(),
+    "the OUTER node, the INTERMEDIATE and the CONCRETE target are each asked about — a " +
+      "single-class payload would have answered one and read the others as absent",
+  );
+});
+
+test("#1560 A: the scoped payload is NEVER recorded into the #1223 snapshot", async () => {
+  // object-info-snapshot.js requires an explicit `whole: true` claim precisely so a
+  // per-class payload cannot make every OTHER type read as a removed pack. This route must
+  // never make that claim, so the snapshot stays empty and later calls keep re-asking.
+  const snapshot = createObjectInfoSnapshot();
+  const reg = loadedRegistry(["SmartResolution"]);
+  const node = regNode(1976, "SmartResolution", [{ name: "value", type: "INT", value: 512 }]);
+  const backend = largeInstall({ defined: ["SmartResolution"] });
+  await runSetWidget(node, "value", 768, {
+    registry: reg,
+    getRegistry: () => reg,
+    getFreshObjectInfo: async () => null,
+    fetchScopedObjectInfo: panelStyleScopedRoute(backend.fetchApi, SILENT_OUTCOMES),
+    wasTypeEverDefined: () => false,
+    ...HOOKS,
+  });
+  const authorized = snapshot.authorize({ epoch: 0, socketDown: false, outcomes: SILENT_OUTCOMES });
+  assert.equal(authorized.defs, null, "no whole map was observed, so the snapshot must still authorize nothing");
+});
+
+// ───────────────────────────── DIRECTION B: an unverifiable write still refuses ────────────
+
+test("#1560 B: a REMOVED type answers `{}`/200 per class ⇒ still FAILS CLOSED (#458 unchanged)", async () => {
+  const reg = loadedRegistry(["GoneNode"]); // the stale registry positive #458 is about
+  const node = regNode(3, "GoneNode", [{ name: "steps", type: "INT", value: 20 }]);
+  const backend = largeInstall({ defined: [] }); // the backend no longer provides it
+  await assert.rejects(
+    () =>
+      runSetWidget(node, "steps", 30, {
+        registry: reg,
+        getRegistry: () => reg,
+        getFreshObjectInfo: async () => null,
+        fetchScopedObjectInfo: panelStyleScopedRoute(backend.fetchApi, SILENT_OUTCOMES),
+        wasTypeEverDefined: () => false,
+        ...HOOKS,
+      }),
+    (err) => err instanceof Error && /backend does not provide node type "GoneNode"/.test(err.message),
+  );
+  assert.equal(node.widgets[0].value, 20, "no mutation");
+});
+
+test("#1560 B: an EVER-SEEN type now absent per class is still diagnosed as a REMOVED pack", async () => {
+  const reg = loadedRegistry(["GoneNode"]);
+  const node = regNode(3, "GoneNode", [{ name: "steps", type: "INT", value: 20 }]);
+  const backend = largeInstall({ defined: [] });
+  await assert.rejects(
+    () =>
+      runSetWidget(node, "steps", 30, {
+        registry: reg,
+        getRegistry: () => reg,
+        getFreshObjectInfo: async () => null,
+        fetchScopedObjectInfo: panelStyleScopedRoute(backend.fetchApi, SILENT_OUTCOMES),
+        wasTypeEverDefined: (t) => t === "GoneNode", // the backend reported it earlier
+        ...HOOKS,
+      }),
+    (err) => err instanceof Error && /its backend was\s+removed \(pack uninstalled\/disabled\)/.test(err.message),
+  );
+  assert.equal(node.widgets[0].value, 20, "no mutation");
+});
+
+test("#1560 B: the per-class route ALSO going silent refuses exactly as today, and SAYS a third route was tried", async () => {
+  const reg = loadedRegistry(["SmartResolution"]);
+  const node = regNode(1976, "SmartResolution", [{ name: "value", type: "INT", value: 512 }]);
+  const backend = largeInstall({ perClass: () => new Promise(() => {}) }); // never settles
+  await assert.rejects(
+    () =>
+      runSetWidget(node, "value", 768, {
+        registry: reg,
+        getRegistry: () => reg,
+        getFreshObjectInfo: async () => null,
+        describeObjectInfoFailure: () => " Tried 2 routes: a; b.",
+        fetchScopedObjectInfo: async (types) =>
+          fetchTypeScopedObjectInfo(types, { fetchApi: backend.fetchApi, deadlineMs: 20 }),
+        wasTypeEverDefined: () => false,
+        ...HOOKS,
+      }),
+    (err) =>
+      err instanceof Error &&
+      /no usable \/object_info schema was obtained/.test(err.message) &&
+      /A type-scoped \/object_info read was tried too — .*did not all answer within/.test(err.message),
+  );
+  assert.equal(node.widgets[0].value, 512, "no mutation");
+});
+
+test("#1560 B: a NON-200 per-class reply establishes nothing and refuses (a proxy page is not an absence)", async () => {
+  const reg = loadedRegistry(["SmartResolution"]);
+  const node = regNode(1976, "SmartResolution", [{ name: "value", type: "INT", value: 512 }]);
+  const backend = largeInstall({ perClass: async () => ({ ok: false, status: 502, json: async () => ({}) }) });
+  await assert.rejects(
+    () =>
+      runSetWidget(node, "value", 768, {
+        registry: reg,
+        getRegistry: () => reg,
+        getFreshObjectInfo: async () => null,
+        fetchScopedObjectInfo: panelStyleScopedRoute(backend.fetchApi, SILENT_OUTCOMES),
+        wasTypeEverDefined: () => false,
+        ...HOOKS,
+      }),
+    (err) => err instanceof Error && /no usable \/object_info schema was obtained/.test(err.message),
+  );
+  assert.equal(node.widgets[0].value, 512, "no mutation");
+});
+
+test("#1560 B: ALL-OR-NOTHING — one indefinite answer inside a PROMOTED set refuses the whole write", async () => {
+  // The concrete target answers perfectly; the INTERMEDIATE container does not. A map that
+  // authorized the part it could answer is exactly what #716/#821 were.
+  const reg = loadedRegistry(["KSampler"]);
+  const { a, b, resolveSource } = nestedFixture(reg, "KSampler");
+  const backend = largeInstall({
+    defined: ["KSampler"],
+    perClass: async (type) => (type === "SubgraphB" ? { ok: false, status: 500, json: async () => ({}) } : undefined),
+  });
+  await assert.rejects(
+    () =>
+      runSetWidget(a, "steps", 30, {
+        registry: reg,
+        getRegistry: () => reg,
+        getFreshObjectInfo: async () => null,
+        fetchScopedObjectInfo: panelStyleScopedRoute(backend.fetchApi, SILENT_OUTCOMES),
+        wasTypeEverDefined: () => false,
+        resolveSource,
+        ...HOOKS,
+      }),
+    (err) => err instanceof Error && /no usable \/object_info schema was obtained/.test(err.message),
+  );
+  assert.equal(b.widgets.find((w) => w.name === "steps").value, 20, "no mutation anywhere in the chain");
+});
+
+test("#1560 B: a whole-map route that ANSWERED is never overruled — the scoped route is not even asked", async () => {
+  // A frontend client expressing deny-all as `{}` is an ANSWER. Consulting a broader
+  // per-class read there is the one direction object-info-oracle.js's note forbids.
+  const reg = loadedRegistry(["SmartResolution"]);
+  const node = regNode(1976, "SmartResolution", [{ name: "value", type: "INT", value: 512 }]);
+  const backend = largeInstall({ defined: ["SmartResolution"] });
+  await assert.rejects(
+    () =>
+      runSetWidget(node, "value", 768, {
+        registry: reg,
+        getRegistry: () => reg,
+        getFreshObjectInfo: async () => null,
+        fetchScopedObjectInfo: panelStyleScopedRoute(backend.fetchApi, ANSWERED_OUTCOMES),
+        wasTypeEverDefined: () => false,
+        ...HOOKS,
+      }),
+    (err) => err instanceof Error && /no usable \/object_info schema was obtained/.test(err.message),
+  );
+  assert.deepEqual(backend.perClassCalls(), [], "not one per-class request was issued");
+  assert.equal(node.widgets[0].value, 512, "no mutation");
+});
+
+test("#1560 B: a promotion RELINKED across the scoped fetch resolves outside the covered set ⇒ refuses", async () => {
+  // The scoped read adds an await between the resolution and the write. A deeper relink in
+  // that window makes the write land on a type the map was never asked to cover — and the
+  // map throws for it rather than reading it as absent, which is the whole guarantee.
+  const reg = loadedRegistry(["KSampler"]);
+  const { a, b, concrete, resolveSource } = nestedFixture(reg, "KSampler");
+  const swapped = regNode(91, "OtherSampler", [{ name: "steps", type: "INT", value: 20 }]);
+  reg.OtherSampler = regEntry();
+  b.subgraph.getNodeById = (id) => (String(id) === "90" ? concrete : String(id) === "91" ? swapped : null);
+  const backend = largeInstall({ defined: ["KSampler", "OtherSampler"] });
+  let relinked = false;
+  const movingResolveSource = (subgraphNode, si) => {
+    if (subgraphNode === b && si?.name === "steps") {
+      return relinked ? { sourceNodeId: "91", sourceWidgetName: "steps" } : { sourceNodeId: "90", sourceWidgetName: "steps" };
+    }
+    return resolveSource(subgraphNode, si);
+  };
+  await assert.rejects(
+    () =>
+      runSetWidget(a, "steps", 30, {
+        registry: reg,
+        getRegistry: () => reg,
+        getFreshObjectInfo: async () => null,
+        fetchScopedObjectInfo: async (types) => {
+          const scoped = await fetchTypeScopedObjectInfo(types, { fetchApi: backend.fetchApi });
+          relinked = true; // the user re-wired the promotion while the request was in flight
+          return scoped;
+        },
+        wasTypeEverDefined: () => false,
+        resolveSource: movingResolveSource,
+        ...HOOKS,
+      }),
+    (err) =>
+      err instanceof Error &&
+      /Refusing to read an unfetched type as ABSENT \(#716\/#821\)/.test(err.message) &&
+      /"OtherSampler"/.test(err.message),
+  );
+  assert.equal(swapped.widgets[0].value, 20, "the swapped-in node was never written");
+  assert.equal(concrete.widgets[0].value, 20, "and neither was the original");
+});
+
+// ───────────────────────── the scoped map itself: it refuses the OTHER question ────────────
+
+test("#1560: a type OUTSIDE the covered set THROWS rather than reading as absent (#716/#821)", async () => {
+  const backend = largeInstall({ defined: ["KSampler"] });
+  const { defs, covered } = await fetchTypeScopedObjectInfo(["KSampler"], { fetchApi: backend.fetchApi });
+  assert.deepEqual(covered, ["KSampler"]);
+  assert.equal(Object.prototype.hasOwnProperty.call(defs, "KSampler"), true, "the asked type answers");
+  assert.throws(
+    () => Object.prototype.hasOwnProperty.call(defs, "VAELoader"),
+    /Refusing to read an unfetched type as ABSENT/,
+    "the UNASKED type must not read as `false` — that is exactly the #716/#821 defect",
+  );
+  assert.throws(() => defs.VAELoader, /Refusing to read an unfetched type as ABSENT/);
+  assert.throws(() => "VAELoader" in defs, /Refusing to read an unfetched type as ABSENT/);
+  // Symbol brands (CACHE_OUTCOME and friends) are never class types and must pass through.
+  assert.equal(defs[Symbol.for("comfyui-mcp.objectInfoOutcome")], undefined);
+  assert.deepEqual(Object.keys(defs), ["KSampler"], "enumeration stays honest and small");
+});
+
+test("#1560: a type that is COVERED but absent reads as a plain absence, not a throw", async () => {
+  const backend = largeInstall({ defined: [] });
+  const { defs } = await fetchTypeScopedObjectInfo(["SubgraphA"], { fetchApi: backend.fetchApi });
+  assert.equal(Object.prototype.hasOwnProperty.call(defs, "SubgraphA"), false, "asked, and definitively absent");
+  assert.deepEqual(Object.keys(defs), []);
+});
+
+test("#1560: fetchTypeScopedObjectInfo fails closed on every indefinite answer", async () => {
+  const cases = [
+    ["non-200", async () => ({ ok: false, status: 404, json: async () => ({}) })],
+    ["unparseable body", async () => ({ ok: true, status: 200, json: async () => { throw new Error("not json"); } })],
+    ["array body", async () => ({ ok: true, status: 200, json: async () => [] })],
+    ["non-object def value", async () => ({ ok: true, status: 200, json: async () => ({ KSampler: "yes" }) })],
+    ["a throwing fetchApi", async () => { throw new Error("boom"); }],
+    ["an unreadable response", async () => ({ get ok() { throw new Error("hostile"); } })],
+  ];
+  for (const [label, perClass] of cases) {
+    const backend = largeInstall({ perClass });
+    const res = await fetchTypeScopedObjectInfo(["KSampler"], { fetchApi: backend.fetchApi });
+    assert.equal(res.defs, null, `${label} must not produce a usable map`);
+    assert.ok(res.reason, `${label} must say why`);
+  }
+});
+
+test("#1560: fetchTypeScopedObjectInfo refuses an empty set, an unwired fetchApi and a runaway chain", async () => {
+  const backend = largeInstall({ defined: ["KSampler"] });
+  assert.equal((await fetchTypeScopedObjectInfo([], { fetchApi: backend.fetchApi })).defs, null);
+  assert.equal((await fetchTypeScopedObjectInfo(["KSampler"], {})).defs, null);
+  const many = Array.from({ length: MAX_SCOPED_TYPES + 1 }, (_, i) => `Type${i}`);
+  const capped = await fetchTypeScopedObjectInfo(many, { fetchApi: backend.fetchApi });
+  assert.equal(capped.defs, null, "a pathological promotion chain is not turned into a request storm");
+  assert.deepEqual(backend.perClassCalls(), [], "and nothing was issued");
+});
+
+// ───────────────────────────────── the CALL SITE, not just the helper ─────────────────────
+
+test("#1560: scopedAuthorizationTypes names EVERY type the fence asks about, from the graph alone", () => {
+  const reg = loadedRegistry(["KSampler"]);
+  const { a, resolveSource } = nestedFixture(reg, "KSampler");
+  const resolution = resolvePromotedInnerTarget(a, "steps", resolveSource);
+  const types = scopedAuthorizationTypes(a, resolution, true, resolveSource);
+  assert.deepEqual(
+    [...types].sort(),
+    ["KSampler", "SubgraphA", "SubgraphB"],
+    "the outer node, the intermediate and the concrete target — computed with NO schema",
+  );
+  // A DIRECT write asks about exactly one type.
+  assert.deepEqual(scopedAuthorizationTypes(regNode(1, "KSampler", []), null, false, undefined), ["KSampler"]);
+  // A resolver that throws must yield NOTHING rather than a partial list, so the scoped read
+  // is simply not attempted and the write refuses on the unchanged path.
+  assert.deepEqual(
+    scopedAuthorizationTypes(a, resolution, true, () => {
+      throw new Error("malformed promotion");
+    }),
+    [],
+  );
+});
+
+test("#1560: the panel WIRES the scoped route, gated on the silence licence and on the command budget", () => {
+  const src = readFileSync(PANEL_JS, "utf8");
+  assert.match(src, /fetchScopedObjectInfo:\s*async \(types\) => \{/, "the capability reaches runSetWidget");
+  assert.match(src, /if \(!noBackendAnswerEstablished\(oracleOutcomes\)\)/, "a route that ANSWERED is never overruled");
+  assert.match(src, /fetchTypeScopedObjectInfo\(types, \{/, "the panel calls the type-scoped reader");
+  assert.match(src, /deadlineMs: budget\.bounded\(SCOPED_OBJECT_INFO_DEADLINE_MS\)/, "bounded by what the command has left");
+  assert.match(src, /setWidgetSchemaProvenance = \(\) => "scoped"/, "the reply is told which route answered");
+  // The scoped payload must never be filed as a whole observation, in either store.
+  const wiring = src.slice(src.indexOf("fetchScopedObjectInfo: async (types)"), src.indexOf("fetchScopedObjectInfo: async (types)") + 1800);
+  assert.equal(/objectInfoSnapshot\.record/.test(wiring), false, "never recorded into the #1223 snapshot");
+  assert.equal(/recordObjectInfoTypes/.test(wiring), false, "never filed into the ever-seen history");
+});
+
+test("#1560: the shared handler asks the scoped route only AFTER the whole map produced nothing", () => {
+  const src = readFileSync(SET_WIDGET_JS, "utf8");
+  assert.match(src, /if \(!freshDefs && !promotedButUnresolvable && typeof fetchScopedObjectInfo === "function"\)/);
+  // Placement is the whole fix: the fetch must sit BELOW the promotion resolution, or the
+  // type set is not known and the payload answers the wrong question (#716/#821).
+  const resolvedAt = src.indexOf("const promotedButUnresolvable =");
+  const scopedAt = src.indexOf("typeof fetchScopedObjectInfo === \"function\"");
+  const authAt = src.indexOf("assertTypeAgainstFreshBackend(freshDefs");
+  assert.ok(resolvedAt > 0 && scopedAt > resolvedAt, "the scoped read is issued after the promotion is resolved");
+  assert.ok(authAt > scopedAt, "and before the type authorization that consumes it");
+});

--- a/browser_tests/unit/set-widget-scoped-object-info.test.mjs
+++ b/browser_tests/unit/set-widget-scoped-object-info.test.mjs
@@ -535,9 +535,15 @@ test("#1560: a hostile class name is FLATTENED before it reaches a refusal a cal
     (err) =>
       err instanceof Error &&
       !err.message.includes(String.fromCharCode(10)) &&
-      /Refusing to read an unfetched type as ABSENT/.test(err.message),
-    "a newline in a node type must not forge structure in the message",
+      /Refusing to read an unfetched type as ABSENT/.test(err.message) &&
+      // FLATTENED, NOT MANGLED. Asserting only that the newline is gone cannot see a
+      // sanitizer that eats ordinary characters — a lost backslash turned this into
+      // `/s+/` and it deleted every letter S from every node type, with this test green.
+      err.message.includes('"Gone Refusing to write: nothing was wrong"'),
+    "a newline in a node type must not forge structure in the message, and nothing else may change",
   );
+  // The ordinary case: a normal type name survives the sanitizer EXACTLY.
+  assert.throws(() => defs.SmartResolution, /node type "SmartResolution" against the ComfyUI backend/);
 });
 
 test("#1560 B: a WORKFLOW SWITCH during the scoped read still refuses before any mutation (#718)", async () => {
@@ -578,4 +584,20 @@ test("#1560: a deeper relink to a node of the SAME type is NOT caught by the sco
   const src = readFileSync(SET_WIDGET_JS, "utf8");
   assert.match(src, /A relink to a node of the SAME type is NOT\s*\/\/\s*caught/);
   assert.match(src, /stale-target hazard,\s*\/\/\s*never a fail-open of the #458 fence/);
+});
+
+test("#1560: the COVERED list in the refusal is sanitized too, not just the asked-for name", async () => {
+  // Both halves of that sentence are node types off the graph. Sanitizing one and
+  // interpolating the other raw is the same defect, half-fixed.
+  const forgedType = `Sneaky${String.fromCharCode(10)}Refusing to write: nothing was wrong`;
+  const backend = largeInstall({ defined: [forgedType] });
+  const { defs } = await fetchTypeScopedObjectInfo([forgedType], { fetchApi: backend.fetchApi });
+  assert.throws(
+    () => defs.SomethingElse,
+    (err) =>
+      err instanceof Error &&
+      !err.message.includes(String.fromCharCode(10)) &&
+      err.message.includes("Sneaky Refusing to write"),
+    "the covered list must be flattened before it reaches the message",
+  );
 });

--- a/browser_tests/unit/set-widget-scoped-object-info.test.mjs
+++ b/browser_tests/unit/set-widget-scoped-object-info.test.mjs
@@ -423,6 +423,15 @@ test("#1560: fetchTypeScopedObjectInfo refuses an empty set, an unwired fetchApi
   const capped = await fetchTypeScopedObjectInfo(many, { fetchApi: backend.fetchApi });
   assert.equal(capped.defs, null, "a pathological promotion chain is not turned into a request storm");
   assert.deepEqual(backend.perClassCalls(), [], "and nothing was issued");
+  // THE VALUE, not just the existence of a cap. `MAX_SCOPED_TYPES + 1` above is
+  // self-referential — it passes for any number the constant happens to hold, so a change to
+  // 1 (refusing every promoted write) or to 500 (a request storm against a backend that is
+  // already struggling) would sail through it. Pin the number and both sides of the boundary.
+  assert.equal(MAX_SCOPED_TYPES, 8, "the cap is a deliberate number, not whatever it drifted to");
+  const atCap = Array.from({ length: MAX_SCOPED_TYPES }, (_, i) => `Type${i}`);
+  const allowed = await fetchTypeScopedObjectInfo(atCap, { fetchApi: backend.fetchApi });
+  assert.ok(allowed.defs, "exactly MAX_SCOPED_TYPES is still ANSWERED — the cap is off-by-one-safe");
+  assert.equal(backend.perClassCalls().length, MAX_SCOPED_TYPES, "one request per type, no more");
 });
 
 // ───────────────────────────────── the CALL SITE, not just the helper ─────────────────────

--- a/browser_tests/unit/set-widget-scoped-object-info.test.mjs
+++ b/browser_tests/unit/set-widget-scoped-object-info.test.mjs
@@ -539,3 +539,43 @@ test("#1560: a hostile class name is FLATTENED before it reaches a refusal a cal
     "a newline in a node type must not forge structure in the message",
   );
 });
+
+test("#1560 B: a WORKFLOW SWITCH during the scoped read still refuses before any mutation (#718)", async () => {
+  // The scoped read adds an await between the promotion resolution and the write. The
+  // workflow fence is what covers that window — it is re-checked synchronously inside
+  // `write`, with no await after it — and the scope trap does NOT cover this shape.
+  const reg = loadedRegistry(["SmartResolution"]);
+  const node = regNode(1976, "SmartResolution", [{ name: "value", type: "INT", value: 512 }]);
+  const backend = largeInstall({ defined: ["SmartResolution"] });
+  let switched = false;
+  await assert.rejects(
+    () =>
+      runSetWidget(node, "value", 768, {
+        registry: reg,
+        getRegistry: () => reg,
+        getFreshObjectInfo: async () => null,
+        fetchScopedObjectInfo: async (types) => {
+          const scoped = await fetchTypeScopedObjectInfo(types, { fetchApi: backend.fetchApi });
+          switched = true; // the user changed the active canvas while this request was in flight
+          return scoped;
+        },
+        assertTargetStillCurrent: () => {
+          if (switched) throw new Error("workflow instance mismatch");
+        },
+        wasTypeEverDefined: () => false,
+        ...HOOKS,
+      }),
+    /workflow instance mismatch/,
+  );
+  assert.equal(node.widgets[0].value, 512, "the stale command must not mutate the new workflow");
+});
+
+test("#1560: a deeper relink to a node of the SAME type is NOT caught by the scope trap — and says so", () => {
+  // The header states this explicitly rather than implying the trap covers every shape: a
+  // relink that lands on a node whose type IS covered asks a question the map can answer, so
+  // nothing throws. That is correct — the authorization is still true of the node driven —
+  // but a comment claiming otherwise is how a false guarantee outlives its author.
+  const src = readFileSync(SET_WIDGET_JS, "utf8");
+  assert.match(src, /A relink to a node of the SAME type is NOT\s*\/\/\s*caught/);
+  assert.match(src, /stale-target hazard,\s*\/\/\s*never a fail-open of the #458 fence/);
+});

--- a/browser_tests/unit/set-widget-scoped-object-info.test.mjs
+++ b/browser_tests/unit/set-widget-scoped-object-info.test.mjs
@@ -485,7 +485,11 @@ test("#1560: the shared handler asks the scoped route only AFTER the whole map p
 
 // ─────────────── the scoped map must not become a hazard of its own (self-review) ─────────
 
-test("#1560: a NON-POSITIVE budget attempts NOTHING — it must never become NO bound", async () => {
+// AN EXPLICIT TIMEOUT, because the failure mode this pins is a HANG. Delete the guard and
+// `withTimeout` treats the 0 as NO bound, so the hanging fetch below never settles and
+// `node --test` waits forever — a mutation that hangs the runner is indistinguishable from
+// one that survived. With a bound it fails, loudly and by name.
+test("#1560: a NON-POSITIVE budget attempts NOTHING — it must never become NO bound", { timeout: 15000 }, async () => {
   // `withTimeout` treats `ms <= 0` as no bound at all, so passing an exhausted budget
   // through would remove the bound at exactly the moment the command has already run out —
   // #1161 arriving through the mechanism meant to prevent it.

--- a/browser_tests/unit/set-widget-scoped-object-info.test.mjs
+++ b/browser_tests/unit/set-widget-scoped-object-info.test.mjs
@@ -32,6 +32,7 @@ import {
   SCOPED_OBJECT_INFO_DEADLINE_MS,
 } from "../../web/js/lib/scoped-object-info.js";
 import { resolvePromotedInnerTarget } from "../../web/js/lib/widget-write.js";
+import { refreshComboOptionsFromDefs } from "../../web/js/lib/asset-staleness.js";
 import { noBackendAnswerEstablished } from "../../web/js/lib/object-info-snapshot.js";
 import { createObjectInfoSnapshot } from "../../web/js/lib/object-info-snapshot.js";
 import { TRANSPORT_OUTCOME } from "../../web/js/lib/object-info-oracle.js";
@@ -664,4 +665,148 @@ test("#1560: THREE levels of nesting (A→B→C→KSampler) names and fetches EV
     ["/object_info/KSampler", "/object_info/SubgraphA", "/object_info/SubgraphB", "/object_info/SubgraphC"],
     "and every one of the four was actually asked about",
   );
+});
+
+// ── The blind-write ladder: the scoped map must not be mistaken for "nothing established" ──
+//
+// Found by an adversarial gate, not by the author, and it is the shape this repo has shipped
+// before: #1223's own snapshot branch was dead code until a test drove the REAL detached map
+// through it. Here the branch keyed on `provenance === "scoped"` could never fire, because
+// the ladder re-asks for a live map and the re-ask re-enters the panel's shared
+// `readObjectInfo`, which re-stamps the provenance on every exit path it has. So the stamp
+// said "none" while the map in hand was the scoped one, and what fired instead told the
+// caller the provenance could not be established AT ALL and to reconnect — false twice over.
+
+/** A combo whose own `options.values` callback THROWS: the valid set is unreadable client-side. */
+const OPTIONS_THROW = () => {
+  throw new Error("the node's own populate() failed");
+};
+
+/**
+ * The panel's provenance stamp, reproduced with the property that made the branch dead: the
+ * shared `readObjectInfo` re-stamps on EVERY exit path, so a FAILED live re-ask overwrites
+ * whatever the scoped read stamped. A test that stubbed a constant `"scoped"` here would
+ * pass against the broken code and prove nothing.
+ */
+function panelStyleStamp() {
+  let stamp = () => "none";
+  return {
+    schemaProvenance: () => stamp(),
+    onScoped: () => {
+      stamp = () => "scoped";
+    },
+    // The panel's own failed-read exit: `setWidgetSchemaProvenance = () => "none"`.
+    refetchObjectInfoLive: async () => {
+      stamp = () => "none";
+      return null;
+    },
+  };
+}
+
+function scopedLadderFixture(serverOptions) {
+  const reg = loadedRegistry(["StarOllamaPromptHelper"]);
+  const widget = { name: "model", type: "combo", options: { values: OPTIONS_THROW }, value: "" };
+  const node = regNode(9, "StarOllamaPromptHelper", [widget]);
+  const backend = largeInstall({
+    defined: ["StarOllamaPromptHelper"],
+    perClass: async (type) =>
+      type === "StarOllamaPromptHelper"
+        ? {
+            ok: true,
+            status: 200,
+            json: async () => ({ StarOllamaPromptHelper: { input: { required: { model: [serverOptions, {}] } } } }),
+          }
+        : undefined,
+  });
+  const stamp = panelStyleStamp();
+  return {
+    widget,
+    run: () =>
+      runSetWidget(node, "model", "qwen3-vl:8b", {
+        registry: reg,
+        getRegistry: () => reg,
+        getFreshObjectInfo: async () => null,
+        fetchScopedObjectInfo: panelStyleScopedRoute(backend.fetchApi, SILENT_OUTCOMES, stamp.onScoped),
+        refetchObjectInfoLive: stamp.refetchObjectInfoLive,
+        schemaProvenance: stamp.schemaProvenance,
+        refreshCombos: (fresh, targetNode, defTypeKey, nameMap) =>
+          refreshComboOptionsFromDefs(targetNode, fresh, defTypeKey, nameMap),
+        wasTypeEverDefined: () => true,
+        ...HOOKS,
+      }),
+  };
+}
+
+test("#1560: an unreadable combo on a scoped map refuses by NAMING the scoped read — server publishes a list", async () => {
+  // The server's list is NON-empty, so the empty-list shape test is false and the ladder used
+  // to fall through to the generic end-of-ladder refusal — which reports only that the combo
+  // could not be read, sending the caller to look at their value while the actual cause is a
+  // backend whose whole /object_info never lands.
+  const { widget, run } = scopedLadderFixture(["qwen3-vl:8b", "llama3"]);
+  await assert.rejects(run(), (err) => {
+    assert.match(err.message, /TYPE-SCOPED read \(#1560\)/, "the refusal must name the route that DID answer");
+    assert.doesNotMatch(err.message, /provenance could not be established at all/);
+    return true;
+  });
+  assert.equal(widget.value, "", "fails closed — a partial view of the schema licenses nothing");
+});
+
+test("#1560: …and when the scoped map declares the list EMPTY, it still does not say 'reconnect'", async () => {
+  // The direction that actually shipped a FALSE cause. An empty list makes the shape test
+  // true, so the pre-fix code refused with "the schema provenance could not be established at
+  // all … Reconnect to ComfyUI and retry" — while a type-scoped read had answered, live,
+  // moments earlier, and on this install reconnecting cannot help at all.
+  const { widget, run } = scopedLadderFixture([]);
+  await assert.rejects(run(), (err) => {
+    assert.match(err.message, /TYPE-SCOPED read \(#1560\)/);
+    assert.doesNotMatch(
+      err.message,
+      /provenance could not be established at all/,
+      "a type-scoped read ANSWERED — claiming nothing was established is the #982 misattribution",
+    );
+    assert.match(err.message, /reconnecting need not help/, "and the remedy must be the one that can work");
+    return true;
+  });
+  assert.equal(widget.value, "", "fails closed");
+});
+
+test("#1560: a LIVE re-ask that SUCCEEDS is used — the brand follows the payload, not a flag", async () => {
+  // The other direction of the same fix. A stamp captured when the scoped map was adopted
+  // would still read "scoped" after the re-ask replaced it with a whole live map; the brand
+  // is a property of the payload, so it answers for the NEW one with nothing to reset.
+  const reg = loadedRegistry(["StarOllamaPromptHelper"]);
+  const widget = { name: "model", type: "combo", options: { values: OPTIONS_THROW }, value: "" };
+  const node = regNode(9, "StarOllamaPromptHelper", [widget]);
+  const backend = largeInstall({
+    defined: ["StarOllamaPromptHelper"],
+    perClass: async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({ StarOllamaPromptHelper: { input: { required: { model: [[], {}] } } } }),
+    }),
+  });
+  let stamp = () => "none";
+  const res = await runSetWidget(node, "model", "qwen3-vl:8b", {
+    registry: reg,
+    getRegistry: () => reg,
+    getFreshObjectInfo: async () => null,
+    fetchScopedObjectInfo: panelStyleScopedRoute(backend.fetchApi, SILENT_OUTCOMES, () => {
+      stamp = () => "scoped";
+    }),
+    // The whole map lands on the re-ask — a WHOLE payload, so it carries no scoped brand.
+    refetchObjectInfoLive: async () => {
+      stamp = () => "live";
+      return { StarOllamaPromptHelper: { input: { required: { model: [[], {}] } } } };
+    },
+    schemaProvenance: () => stamp(),
+    refreshCombos: (fresh, targetNode, defTypeKey, nameMap) =>
+      refreshComboOptionsFromDefs(targetNode, fresh, defTypeKey, nameMap),
+    wasTypeEverDefined: () => true,
+    ...HOOKS,
+  });
+  assert.equal(res.set.value, "qwen3-vl:8b", "a LIVE whole map declaring the list empty licenses the write");
+  // Which acceptance admitted it is decided at COERCION time: this callback throws on every
+  // read, so the disclosure is the UNREADABLE one. What matters here is that the write landed
+  // at all — the live re-ask licensed it, and the scoped refusal did not pre-empt that.
+  assert.equal(res.option_list_unreadable, true, "the caller is still told nothing validated the value");
 });

--- a/browser_tests/unit/set-widget-scoped-object-info.test.mjs
+++ b/browser_tests/unit/set-widget-scoped-object-info.test.mjs
@@ -28,6 +28,7 @@ import { runSetWidget, scopedAuthorizationTypes } from "../../web/js/lib/set-wid
 import {
   fetchTypeScopedObjectInfo,
   MAX_SCOPED_TYPES,
+  SCOPED_OBJECT_INFO,
   SCOPED_OBJECT_INFO_DEADLINE_MS,
 } from "../../web/js/lib/scoped-object-info.js";
 import { resolvePromotedInnerTarget } from "../../web/js/lib/widget-write.js";
@@ -470,4 +471,57 @@ test("#1560: the shared handler asks the scoped route only AFTER the whole map p
   const authAt = src.indexOf("assertTypeAgainstFreshBackend(freshDefs");
   assert.ok(resolvedAt > 0 && scopedAt > resolvedAt, "the scoped read is issued after the promotion is resolved");
   assert.ok(authAt > scopedAt, "and before the type authorization that consumes it");
+});
+
+// ─────────────── the scoped map must not become a hazard of its own (self-review) ─────────
+
+test("#1560: a NON-POSITIVE budget attempts NOTHING — it must never become NO bound", async () => {
+  // `withTimeout` treats `ms <= 0` as no bound at all, so passing an exhausted budget
+  // through would remove the bound at exactly the moment the command has already run out —
+  // #1161 arriving through the mechanism meant to prevent it.
+  let issued = 0;
+  const hangingFetch = async () => {
+    issued += 1;
+    return new Promise(() => {});
+  };
+  for (const deadlineMs of [0, -5]) {
+    const res = await fetchTypeScopedObjectInfo(["KSampler"], { fetchApi: hangingFetch, deadlineMs });
+    assert.equal(res.defs, null, `deadlineMs ${deadlineMs} must authorize nothing`);
+    assert.match(res.reason, /no time was left/);
+  }
+  assert.equal(issued, 0, "and not one request may be issued on a spent budget");
+});
+
+test("#1560: a budget a timer cannot express takes the SHIPPED default, never a 24.8-day grant", async () => {
+  const backend = largeInstall({ defined: ["KSampler"] });
+  for (const deadlineMs of [NaN, Infinity, 5e9, "soon", undefined]) {
+    const res = await fetchTypeScopedObjectInfo(["KSampler"], { fetchApi: backend.fetchApi, deadlineMs });
+    assert.ok(res.defs, `deadlineMs ${String(deadlineMs)} must fall back to ${SCOPED_OBJECT_INFO_DEADLINE_MS}ms and answer`);
+  }
+});
+
+test("#1560: the scoped map is a well-behaved object — branding, freezing and enumeration do not throw", async () => {
+  // A Proxy that answers `has` for a property its NON-EXTENSIBLE target does not own is an
+  // invariant violation and throws TypeError, out of a module whose job is to answer.
+  const backend = largeInstall({ defined: ["KSampler"] });
+  const { defs } = await fetchTypeScopedObjectInfo(["KSampler"], { fetchApi: backend.fetchApi });
+  assert.equal(SCOPED_OBJECT_INFO in defs, true, "the brand is readable");
+  assert.equal(defs[SCOPED_OBJECT_INFO], true);
+  assert.doesNotThrow(() => Object.freeze(defs), "object-info-cache.js freezes its payload; this must survive the same");
+  assert.deepEqual(Object.keys(defs), ["KSampler"]);
+  assert.equal(defs[Symbol.iterator], undefined, "an unrelated symbol is not a class type and passes through");
+});
+
+test("#1560: a hostile class name is FLATTENED before it reaches a refusal a caller reads", async () => {
+  const backend = largeInstall({ defined: ["KSampler"] });
+  const { defs } = await fetchTypeScopedObjectInfo(["KSampler"], { fetchApi: backend.fetchApi });
+  const forged = `Gone${String.fromCharCode(10)}Refusing to write: nothing was wrong`;
+  assert.throws(
+    () => defs[forged],
+    (err) =>
+      err instanceof Error &&
+      !err.message.includes(String.fromCharCode(10)) &&
+      /Refusing to read an unfetched type as ABSENT/.test(err.message),
+    "a newline in a node type must not forge structure in the message",
+  );
 });

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -14610,9 +14610,9 @@ const GRAPH_TOOL_EXECUTORS = {
             defs: null,
             covered: [],
             reason:
-              "the whole-schema routes did not go SILENT, and a type-scoped read may only " +
-              "stand in for routes that were contacted and returned nothing — never overrule " +
-              "what they did establish",
+              "no whole-schema route was both CONTACTED and SILENT, and a type-scoped read " +
+              "may only stand in for one that was — it must never overrule what a route did " +
+              "establish, and it is not a substitute for a route nobody ran",
           };
         }
         const scoped = await fetchTypeScopedObjectInfo(types, {

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -14610,8 +14610,20 @@ const GRAPH_TOOL_EXECUTORS = {
           fetchApi: typeof api?.fetchApi === "function" ? (route) => api.fetchApi(route) : null,
           deadlineMs: budget.bounded(SCOPED_OBJECT_INFO_DEADLINE_MS),
         });
-        // Held for the reply and for the #1126 blind-write ladder, which must NOT treat this
-        // as the server's whole word: it is the server answering now about a handful of types.
+        // Stamped for the #1126 blind-write ladder, which must NOT treat this as the server's
+        // whole word: it is the server answering now about a handful of types.
+        //
+        // NOT "held for the reply" — an earlier version of this comment said so and it was
+        // never true. Only the #1223 snapshot path sets `setWidgetSchemaFromSnapshot`, which
+        // is what puts `schema_source` on the result; a scoped-authorized write reports plain
+        // success, deliberately (the authorization really was the server answering live, so
+        // the argument that justifies disclosing a PAST word does not carry over, and a new
+        // reply field is its own reviewable change under the freeze).
+        //
+        // And this stamp alone cannot carry the fact to the ladder: the ladder re-asks for a
+        // live map, which re-enters this same handler and re-stamps on every exit path it
+        // has. `set-widget.js` therefore reads the BRAND on the payload rather than trusting
+        // this variable to survive; see `provenanceOf` there.
         if (scoped.defs) setWidgetSchemaProvenance = () => "scoped";
         return scoped;
       },

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -281,7 +281,12 @@ import { createSettingsBackendDefault } from "./lib/settings-backend-default.js"
 import { fetchNodeDefsWithRetry, OBJECT_INFO_RETRY_DELAYS_MS } from "./lib/object-info-retry.js";
 import { createObjectInfoCache, CACHE_OUTCOME } from "./lib/object-info-cache.js";
 import { fetchWholeObjectInfo, objectInfoOracleFailureNote, OBJECT_INFO_DEADLINE_MS } from "./lib/object-info-oracle.js";
-import { createObjectInfoSnapshot, snapshotAuthorizationNote } from "./lib/object-info-snapshot.js";
+import {
+  createObjectInfoSnapshot,
+  snapshotAuthorizationNote,
+  noBackendAnswerEstablished,
+} from "./lib/object-info-snapshot.js";
+import { fetchTypeScopedObjectInfo, SCOPED_OBJECT_INFO_DEADLINE_MS } from "./lib/scoped-object-info.js";
 import { isRgthreeLoraRowCreation, createRgthreeLoraRow } from "./lib/rgthree-lora-row.js";
 import { objectInfoFingerprint, objectInfoUnchanged } from "./lib/object-info-fingerprint.js";
 import { confirmCanvasNavigation } from "./lib/canvas-navigation.js";
@@ -14250,6 +14255,13 @@ const GRAPH_TOOL_EXECUTORS = {
     // its refusal, so the message would name routes another call tried. Declared in the
     // handler's own scope, so each invocation reports what IT observed.
     let oracleFailures = [];
+    // #1560 — the MACHINE-READABLE half of the same observation (#1223's tags), kept because
+    // the type-scoped last resort below may only be consulted when the whole-map routes went
+    // SILENT. A route that ANSWERED — threw, a non-gateway status, a client expressing
+    // deny-all as `{}` — must never be overruled by a broader per-class read, which is the
+    // one direction object-info-oracle.js's own note forbids. Per-request for exactly the
+    // reason `oracleFailures` is.
+    let oracleOutcomes = [];
     // #1223 — null while the authorization came from a LIVE probe; the oracle's failure
     // note once it came from the last-observed snapshot instead. Per-request for the same
     // reason `oracleFailures` is: a concurrent write must not make THIS reply claim a
@@ -14483,6 +14495,7 @@ const GRAPH_TOOL_EXECUTORS = {
         );
         const defs = outcome && typeof outcome === "object" && outcome[CACHE_OUTCOME] === true ? outcome.defs : outcome;
         oracleFailures = defs ? [] : (outcome?.failures ?? []);
+        oracleOutcomes = defs ? [] : (outcome?.outcomes ?? []);
         if (defs) {
           // #1126 — ONE fact, from the one component that can establish it. The cache says
           // whether the answer it just handed back is the server speaking NOW ("live") or a
@@ -14549,6 +14562,51 @@ const GRAPH_TOOL_EXECUTORS = {
       // that was perfectly valid.
       refetchObjectInfoLive: async () =>
         setWidgetOpts.readObjectInfo((loader, opts) => objectInfoCache.readFresh(loader, opts)),
+      // #1560 — the THIRD route, and the only one that is TYPE-SCOPED.
+      //
+      // On a ~1023-model install neither whole-schema route ever lands inside its share of
+      // the budget while ComfyUI is idle and healthy, so #1223's snapshot is never populated
+      // and EVERY set_widget refuses for the life of the tab. `/object_info/<Type>` answers
+      // that same install in ~2.7KB. This asks it about exactly the types runSetWidget has
+      // already resolved this write to — see scoped-object-info.js for why a map that
+      // THROWS outside that set is not the per-class payload #716/#821 were about.
+      //
+      // TWO GATES, both here rather than in the lib, because only this file holds the facts.
+      //
+      //   1. THE SILENCE LICENCE. Consulted only when no whole-map route ANSWERED. The SAME
+      //      `noBackendAnswerEstablished` test #1223's snapshot licenses on, for the same
+      //      reason: a client that returned an empty schema has expressed deny-all, and a
+      //      broader per-class read must never overrule it. A timeout, a client that returned
+      //      NOTHING, or a proxy's 504 leave the question unanswered — those, and only those,
+      //      may be asked again by another route.
+      //   2. WHAT THE COMMAND HAS LEFT. The whole-map attempt has already spent most of the
+      //      budget by the time this runs (measured on the reported shape: 15,015 ms of a 20s
+      //      oracle deadline), so this takes `budget.bounded` like every other step and
+      //      cannot push the reply past the bridge's own timeout.
+      //
+      // NEVER recorded into the #1223 snapshot — object-info-snapshot.js requires an explicit
+      // `whole: true` claim precisely so a per-class payload cannot make every OTHER type read
+      // as a removed pack — and never fed to recordObjectInfoTypes, whose ever-seen history is
+      // the fence's own trust root.
+      fetchScopedObjectInfo: async (types) => {
+        if (!noBackendAnswerEstablished(oracleOutcomes)) {
+          return {
+            defs: null,
+            covered: [],
+            reason:
+              "a whole-schema route ANSWERED rather than going silent, so a type-scoped read " +
+              "is not licensed to overrule it",
+          };
+        }
+        const scoped = await fetchTypeScopedObjectInfo(types, {
+          fetchApi: typeof api?.fetchApi === "function" ? (route) => api.fetchApi(route) : null,
+          deadlineMs: budget.bounded(SCOPED_OBJECT_INFO_DEADLINE_MS),
+        });
+        // Held for the reply and for the #1126 blind-write ladder, which must NOT treat this
+        // as the server's whole word: it is the server answering now about a handful of types.
+        if (scoped.defs) setWidgetSchemaProvenance = () => "scoped";
+        return scoped;
+      },
       // What the last oracle attempt observed, so a refusal can say which routes were
       // tried and what each one did instead of asserting an unreachable backend — then,
       // separately, why the last-observed schema could not stand in for them either.

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -14255,13 +14255,19 @@ const GRAPH_TOOL_EXECUTORS = {
     // its refusal, so the message would name routes another call tried. Declared in the
     // handler's own scope, so each invocation reports what IT observed.
     let oracleFailures = [];
-    // #1560 — the MACHINE-READABLE half of the same observation (#1223's tags), kept because
-    // the type-scoped last resort below may only be consulted when the whole-map routes went
-    // SILENT. A route that ANSWERED — threw, a non-gateway status, a client expressing
-    // deny-all as `{}` — must never be overruled by a broader per-class read, which is the
-    // one direction object-info-oracle.js's own note forbids. Per-request for exactly the
-    // reason `oracleFailures` is.
-    let oracleOutcomes = [];
+    // #1560 — may the TYPE-SCOPED last resort be consulted at all?
+    //
+    // Only when no whole-map route ANSWERED. A route that threw, returned a non-gateway
+    // status, or expressed deny-all as `{}` must never be overruled by a broader per-class
+    // read — the one direction object-info-oracle.js's own note forbids.
+    //
+    // CAPTURED WHERE THE SNAPSHOT MAKES THE SAME JUDGEMENT, from the SAME `outcome.outcomes`
+    // in the same statement — never re-read from a variable later. Storing the tag list and
+    // testing it at call time is a second reading of a fact that was established at a
+    // MOMENT, and this handler enters `readObjectInfo` more than once (the #1126 live
+    // re-ask). One verdict, decided beside the snapshot's, cannot disagree with it.
+    // Per-request for exactly the reason `oracleFailures` is.
+    let scopedReadLicensed = false;
     // #1223 — null while the authorization came from a LIVE probe; the oracle's failure
     // note once it came from the last-observed snapshot instead. Per-request for the same
     // reason `oracleFailures` is: a concurrent write must not make THIS reply claim a
@@ -14495,7 +14501,6 @@ const GRAPH_TOOL_EXECUTORS = {
         );
         const defs = outcome && typeof outcome === "object" && outcome[CACHE_OUTCOME] === true ? outcome.defs : outcome;
         oracleFailures = defs ? [] : (outcome?.failures ?? []);
-        oracleOutcomes = defs ? [] : (outcome?.outcomes ?? []);
         if (defs) {
           // #1126 — ONE fact, from the one component that can establish it. The cache says
           // whether the answer it just handed back is the server speaking NOW ("live") or a
@@ -14532,6 +14537,8 @@ const GRAPH_TOOL_EXECUTORS = {
           socketDown: comfyBackendIsDown(),
           outcomes: outcome?.outcomes,
         });
+        // #1560 — the SAME evidence, read ONCE, in the same statement as the snapshot's.
+        scopedReadLicensed = noBackendAnswerEstablished(outcome?.outcomes);
         if (fallback.defs) {
           // Held for the reply. The write is about to be reported as SUCCEEDED and VERIFIED,
           // and it was verified against a schema nobody could re-fetch — an agent that is
@@ -14573,12 +14580,13 @@ const GRAPH_TOOL_EXECUTORS = {
       //
       // TWO GATES, both here rather than in the lib, because only this file holds the facts.
       //
-      //   1. THE SILENCE LICENCE. Consulted only when no whole-map route ANSWERED. The SAME
-      //      `noBackendAnswerEstablished` test #1223's snapshot licenses on, for the same
-      //      reason: a client that returned an empty schema has expressed deny-all, and a
-      //      broader per-class read must never overrule it. A timeout, a client that returned
-      //      NOTHING, or a proxy's 504 leave the question unanswered — those, and only those,
-      //      may be asked again by another route.
+      //   1. THE SILENCE LICENCE, decided beside the snapshot's own verdict on the SAME
+      //      `outcome.outcomes` and merely READ here. A client that returned an empty schema
+      //      has expressed deny-all, and a broader per-class read must never overrule it. A
+      //      timeout, a client that returned NOTHING, or a proxy's 504 leave the question
+      //      unanswered — those, and only those, may be asked again by another route. It is
+      //      false until a read establishes it, so an unwired or never-run oracle licenses
+      //      nothing.
       //   2. WHAT THE COMMAND HAS LEFT. The whole-map attempt has already spent most of the
       //      budget by the time this runs (measured on the reported shape: 15,015 ms of a 20s
       //      oracle deadline), so this takes `budget.bounded` like every other step and
@@ -14589,7 +14597,7 @@ const GRAPH_TOOL_EXECUTORS = {
       // as a removed pack — and never fed to recordObjectInfoTypes, whose ever-seen history is
       // the fence's own trust root.
       fetchScopedObjectInfo: async (types) => {
-        if (!noBackendAnswerEstablished(oracleOutcomes)) {
+        if (!scopedReadLicensed) {
           return {
             defs: null,
             covered: [],

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -14598,12 +14598,21 @@ const GRAPH_TOOL_EXECUTORS = {
       // the fence's own trust root.
       fetchScopedObjectInfo: async (types) => {
         if (!scopedReadLicensed) {
+          // STATE WHAT WAS OBSERVED, not one cause of it. `noBackendAnswerEstablished` is
+          // false for FOUR different things — a route ANSWERED something unusable, a route
+          // THREW, the outcome list was empty, or every route was NOT_ATTEMPTED — and naming
+          // only the first asserts an event that did not happen in the other three. A refusal
+          // that reports a cause it did not establish is #982's own defect, and the reporter
+          // of #1560 went looking at a backend that was answering fine because of exactly
+          // that. (#1223 makes a similar over-specific claim one sentence earlier in the same
+          // refusal; that one is pre-existing and is not touched here.)
           return {
             defs: null,
             covered: [],
             reason:
-              "a whole-schema route ANSWERED rather than going silent, so a type-scoped read " +
-              "is not licensed to overrule it",
+              "the whole-schema routes did not go SILENT, and a type-scoped read may only " +
+              "stand in for routes that were contacted and returned nothing — never overrule " +
+              "what they did establish",
           };
         }
         const scoped = await fetchTypeScopedObjectInfo(types, {

--- a/web/js/lib/object-info-cache.js
+++ b/web/js/lib/object-info-cache.js
@@ -12,7 +12,16 @@
  * A single-class payload would answer the first question and read the second as absent,
  * refusing a legitimate write. That is #821 exactly: the reply is not wrong, the question
  * asked of it was. So this keeps the whole payload and shortens only how often it is
- * re-fetched.
+ * re-fetched — and it still does; nothing in this file caches anything but a whole map.
+ *
+ * #1560 QUALIFIES THE "BEFORE RESOLVING" HALF of that reason without changing what this file
+ * does. On an install whose whole map never lands inside any budget, the fence now has a
+ * LAST-RESORT type-scoped read (`scoped-object-info.js`) issued BELOW the promotion
+ * resolution, so it can name the outer node, every intermediate AND the concrete target
+ * rather than one of them, and the map it hands back THROWS for anything else instead of
+ * reading it as absent. That read deliberately does NOT come through this cache: a partial
+ * map stored here would be handed to the next caller as if it were whole, which is #821 with
+ * a longer fuse.
  *
  * WHAT THIS DOES NOT WEAKEN. Every caller still receives the SAME whole-schema map, so no
  * question changes scope. What changes is age: a write may be authorized against a map

--- a/web/js/lib/object-info-oracle.js
+++ b/web/js/lib/object-info-oracle.js
@@ -19,7 +19,44 @@
  * `add_node` uses is NOT interchangeable here: `set_widget` authorizes two types for a
  * promoted write and fetches BEFORE resolving which target it writes to, so a
  * single-class payload answers one question and reads the other as absent (#716/#821).
- * The fallback changes the TRANSPORT, never the question.
+ * The fallback changes the TRANSPORT, never the question. Both routes THIS module offers
+ * are still whole-schema, and nothing below has been relaxed.
+ *
+ * #1560 RE-EXAMINED THAT PARAGRAPH AND FOUND HALF OF IT LOAD-BEARING AND HALF OF IT AN
+ * ARTEFACT OF WHERE THE FETCH SITS. Recorded here because this comment is what a later
+ * reader will trust, and it foreclosed the fix for a real P2 for as long as it stood alone.
+ *
+ * The report: on ~1023 models and hundreds of packs BOTH routes above time out — the client
+ * on its 10s share, the raw GET on its 5s share — while ComfyUI is idle, `/system_stats`
+ * answers 200 and `/object_info/SmartResolution` answers 200 in ~2.7KB. No whole map ever
+ * lands, so #1223's snapshot is never populated, so EVERY `set_widget` refuses for the life
+ * of the tab. Reproduced by execution against this module, the real burst cache, the real
+ * snapshot and the real `runSetWidget`: zero per-class requests ever issued, the widget never
+ * written, the identical refusal 15,015 ms later on the second call.
+ *
+ * WHAT IS TRUE: a BARE single-class payload cannot serve this fence. "Two types" is real, and
+ * a map that answers one of them and reads the other as absent is #821 exactly.
+ *
+ * WHAT WAS AN ARTEFACT: "fetches BEFORE resolving which target it writes to" describes THIS
+ * fetch, and this fetch is the one that does not need to know. MEASURED — driving
+ * `resolvePromotedInnerTarget` → `followPromotionToConcrete` → `collectPromotionIntermediates`
+ * with NO schema at all on a nested A→B→KSampler write yields the COMPLETE type set
+ * (SubgraphA, SubgraphB, KSampler) from the graph, with nothing fetched. So a type-scoped
+ * read issued BELOW the resolution can name every type the fence will ask about.
+ *
+ * `scoped-object-info.js` is that read, and it is NOT this module's third transport: it is a
+ * LAST RESORT the fence itself reaches for, only after this oracle has returned nothing AND
+ * the #1223 snapshot has refused, and only when no route here ANSWERED — a client expressing
+ * deny-all as `{}` is still never overruled. The map it returns THROWS for any type it was
+ * not asked to cover, so "reads the other as absent" is impossible by construction rather
+ * than by this paragraph being obeyed.
+ *
+ * WHAT REMAINS A TRADE, stated rather than glossed. That map is genuinely PARTIAL: it can
+ * authorize a node type and it cannot answer anything that ranges over the install
+ * (`registeredSocketTypes` is #821's own example), which is why it never reaches the #1223
+ * snapshot, never reaches the ever-seen history, and does not license the #1126 blind write.
+ * `panel_refresh_nodes` is unhelped for the same reason and still refuses on such a backend.
+ * The honest fix for all of that is still a whole `/object_info` that lands.
  *
  * FAIL-CLOSED IS UNCHANGED. Only a usable, non-empty payload authorizes anything; every
  * failure path returns `defs: null`, which the fence already refuses on.

--- a/web/js/lib/scoped-object-info.js
+++ b/web/js/lib/scoped-object-info.js
@@ -47,8 +47,16 @@
  * them. Every one of those types is fetched, and the returned map REFUSES to answer for any
  * type outside that set: an out-of-scope read THROWS rather than reading as absent. So the
  * #716/#821 failure mode is removed BY CONSTRUCTION rather than by remembering not to trip
- * it — and the same trap doubles as the guard for the await this adds, since a promotion
- * that is relinked mid-fetch resolves to a type the map was never asked to cover.
+ * it.
+ *
+ * WHAT THAT TRAP DOES **NOT** COVER, corrected here because the first version of this note
+ * claimed it covered the whole of the await `set-widget.js` adds, and it does not. A
+ * promotion relinked mid-fetch that resolves deeper to a concrete node of a DIFFERENT type
+ * asks about a type this map was never given, so it throws and the write refuses. A relink
+ * to a node of the SAME type asks a question this map CAN answer, and nothing throws — which
+ * is correct, since the authorization is still true of the node actually driven. The full
+ * accounting of that window, including what genuinely does get older and why it is a
+ * stale-TARGET hazard rather than a fail-open of the #458 fence, is at the call site.
  *
  * FAIL-CLOSED IS UNCHANGED, IN BOTH DIRECTIONS.
  *

--- a/web/js/lib/scoped-object-info.js
+++ b/web/js/lib/scoped-object-info.js
@@ -86,6 +86,35 @@
  * against `GET /object_info/KSampler` 3,246 bytes / 1.2 ms on a 63-pack install; the #1560
  * reporter measured `/object_info/SmartResolution` at ~2.7 KB / 200 on an install where the
  * whole dump misses a 5,000 ms share. A promoted write asks for at most a handful of these.
+ *
+ * AND RE-MEASURED HERE, ON THE REPORTER'S VERSION FAMILY, because everything above rests on
+ * a route contract #767 established on ComfyUI 0.30.2 and this ships against 0.33.x. A
+ * comment that asserts a premise nobody re-checked is how a dormant fix reads as correct, so
+ * a live ComfyUI **0.33.2** was stood up and asked directly:
+ *
+ *     GET /object_info/KSampler                 200   2,994 bytes   0.21 s   {"KSampler": {…}}
+ *     GET /object_info/DefinitelyNotARealClass  200       2 bytes   0.21 s   {}
+ *     GET /object_info                          200   1,540,926 bytes        853 types
+ *
+ * Three things that matter, and the second is the one this module's safety actually rests on:
+ *
+ *   1. ABSENCE IS STILL `{}`/200, not a 404, on 0.33.x — the contract `readOneType` treats as
+ *      a definitive absence, now confirmed on the version the reporter runs rather than
+ *      inherited from a measurement three minor versions old.
+ *   2. THE PER-CLASS DEF IS BYTE-IDENTICAL to the whole map's entry for the same class:
+ *      `JSON.stringify(perClass.KSampler) === JSON.stringify(whole.KSampler)` is `true`. So
+ *      for the types it covers this is not a narrower or differently-shaped payload that
+ *      merely happens to answer membership — it is the same object the whole map would have
+ *      handed over, which is what makes the per-type readers downstream (`uploadInputConfig`,
+ *      `refreshCombos`, `serverDeclaresEmptyComboOptions`) correct on it and not merely safe.
+ *   3. That whole map is 1.5 MB with ZERO custom packs installed. The reporter has hundreds.
+ *
+ * WHAT THIS STILL DOES NOT ESTABLISH, stated rather than glossed: a PROXY answering 200 with
+ * a non-schema JSON object would read as a definitive absence and refuse a type the backend
+ * does define. That direction is fail-closed — a refusal, never a wrongful write — and a
+ * proxy answering 200 with HTML fails the parse and disqualifies the whole scoped map
+ * instead. Anyone who finds a shape that fails the OTHER way should treat this paragraph as
+ * the thing that was wrong.
  */
 
 import { withTimeout } from "./bounded-step.js";

--- a/web/js/lib/scoped-object-info.js
+++ b/web/js/lib/scoped-object-info.js
@@ -1,0 +1,331 @@
+/**
+ * #1560 — on a LARGE install the whole `/object_info` NEVER lands, so `set_widget` refuses
+ * FOR THE LIFE OF THE TAB.
+ *
+ * Reported on ~1023 models and hundreds of custom packs (ComfyUI 0.33.0 / frontend 1.49.6):
+ * both whole-schema probes time out — `api.getNodeDefs()` on its 10s share and
+ * `GET /object_info` on its 5s share of the 20s budget — while ComfyUI is idle and healthy,
+ * `/system_stats` answers 200, and `GET /object_info/SmartResolution` answers 200 in ~2.7KB.
+ * Because no WHOLE map ever lands, #1223's snapshot is never populated either, so every
+ * `panel_set_widget` refuses permanently. `panel_disconnect` on the same nodes succeeds,
+ * because it does not go through this fence.
+ *
+ * REPRODUCED BY EXECUTION before anything was written, against the real oracle + real burst
+ * cache + real #1223 snapshot + the real `runSetWidget` body: two hung whole-map routes,
+ * ZERO per-class requests ever issued, the widget never written, and the identical refusal
+ * on the second call 15,015 ms later. That is a PERMANENT refusal on a healthy backend, not
+ * the transient busy-backend timeout the budget was designed for.
+ *
+ * WHY THE OBVIOUS FIX IS FORBIDDEN, and what this does instead.
+ *
+ * `object-info-oracle.js` records that the per-class `/object_info/<Type>` route `add_node`
+ * uses is NOT interchangeable with the whole map here: "`set_widget` authorizes TWO types
+ * for a promoted write and fetches BEFORE resolving which target it writes to, so a
+ * single-class payload answers one question and READS THE OTHER AS ABSENT (#716/#821)."
+ * That is exactly right about a bare single-class payload, and it is the reason this module
+ * is not one.
+ *
+ * MEASURED, not assumed: the ordering the oracle blames is reversible. Driving the REAL
+ * resolution helpers with NO schema at all (`resolvePromotedInnerTarget` →
+ * `followPromotionToConcrete` → `collectPromotionIntermediates`) on the nested A→B→KSampler
+ * shape the #458 suite uses yields the COMPLETE set of types the fence will ask about —
+ * `SubgraphA`, `SubgraphB`, `KSampler` — from the GRAPH, with no `/object_info` consulted.
+ * Moving the whole-map fetch below that resolution also passes the entire unit suite
+ * unchanged (6115 pass / 0 fail, identical to baseline).
+ *
+ * BUT THE REORDER IS NOT WHAT SHIPPED, and that is a finding rather than a preference. The
+ * fetch that must know the target is the FALLBACK, not the first one — and the fallback
+ * already sits after the resolution. Moving the primary fetch would make the resolution
+ * older by up to a whole 20s budget on EVERY call, including the healthy ones, to buy
+ * something only the failing path needs. So `set-widget.js` keeps its fetch exactly where it
+ * was and asks THIS module only after the whole-map oracle and the #1223 snapshot have both
+ * produced nothing.
+ *
+ * WHAT MAKES THIS ANSWER THE RIGHT QUESTION. The caller hands in the EXACT, complete set of
+ * class types the fence is about to ask about — for a promoted write that is the outer
+ * SubgraphNode, every intermediate container, AND the ultimate concrete node, not one of
+ * them. Every one of those types is fetched, and the returned map REFUSES to answer for any
+ * type outside that set: an out-of-scope read THROWS rather than reading as absent. So the
+ * #716/#821 failure mode is removed BY CONSTRUCTION rather than by remembering not to trip
+ * it — and the same trap doubles as the guard for the await this adds, since a promotion
+ * that is relinked mid-fetch resolves to a type the map was never asked to cover.
+ *
+ * FAIL-CLOSED IS UNCHANGED, IN BOTH DIRECTIONS.
+ *
+ *   - ALL-OR-NOTHING. Every requested type must come back DEFINITIVE — HTTP 200 with a
+ *     parseable object body, which on this route is either the class (present) or `{}`
+ *     (absent; `single-node-def.js` verified that ComfyUI answers absence as `{}`/200, not
+ *     404). One indefinite answer and the whole scoped map is null and the caller refuses
+ *     exactly as it does today. A partial map must never authorize a partial question.
+ *   - ABSENCE STILL REFUSES. A type the backend no longer defines comes back `{}`, reads as
+ *     definitively absent, and `assertTypeAgainstFreshBackend`'s unchanged #458 ever-seen
+ *     gate refuses it as a removed pack. This route only ever adds a way to ASK; it decides
+ *     nothing.
+ *   - THE SILENCE LICENCE IS THE CALLER'S TO GRANT. This must not be consulted when a
+ *     whole-map route ANSWERED something unusable — a frontend client expressing deny-all as
+ *     `{}` is an ANSWER, and overruling it with a broader per-class read is the one direction
+ *     the oracle's own note forbids. `set-widget.js` never sees the transport outcomes, so
+ *     the panel wires this behind the SAME `noBackendAnswerEstablished` test #1223's snapshot
+ *     uses, and hands over a null map otherwise.
+ *
+ * WHAT THIS DELIBERATELY DOES NOT DO. It does not populate the #1223 snapshot — that file
+ * requires an explicit `whole: true` claim precisely so a per-class payload can never make
+ * every OTHER type read as removed — and it does not help `panel_refresh_nodes`, which
+ * re-registers the whole schema and is an install-wide question no per-class route can
+ * answer. Both stay refused on a backend whose whole map never lands, and that is correct.
+ *
+ * COST, MEASURED BY THE REPO ALREADY. #767: `GET /object_info` 5,413,770 bytes / 167 ms
+ * against `GET /object_info/KSampler` 3,246 bytes / 1.2 ms on a 63-pack install; the #1560
+ * reporter measured `/object_info/SmartResolution` at ~2.7 KB / 200 on an install where the
+ * whole dump misses a 5,000 ms share. A promoted write asks for at most a handful of these.
+ */
+
+import { withTimeout } from "./bounded-step.js";
+
+/**
+ * The whole scoped set shares ONE deadline, and the requests run concurrently, so this is
+ * the wall clock for all of them rather than a per-type bound that multiplies.
+ *
+ * 5,000 ms is ~4,000x the 1.2 ms this route was measured at (#767) and ~1,800x the
+ * reporter's 2.7 KB response. It is deliberately generous: this is only ever reached AFTER a
+ * whole-map budget has already been spent, so the useful thing left is to ASK, and the
+ * remaining room under the bridge's 30 s command timeout is what actually binds. The caller
+ * passes what the COMMAND has left (`budget.bounded`), so this is a ceiling, not a promise.
+ */
+export const SCOPED_OBJECT_INFO_DEADLINE_MS = 5000;
+
+/**
+ * How many distinct class types one write may ask about.
+ *
+ * A promoted write asks about the outer node, its intermediates and the concrete target. A
+ * pathological or hostile promotion chain could otherwise turn one refusal into an unbounded
+ * fan-out of requests against a backend that is already struggling — which is the condition
+ * this whole path exists for. Above the cap the scoped map is simply not built and the
+ * caller refuses as it does today.
+ */
+export const MAX_SCOPED_TYPES = 8;
+
+/** Marks a map as type-scoped, for anything that needs to know what it is holding. */
+export const SCOPED_OBJECT_INFO = Symbol.for("comfyui-mcp.scopedObjectInfo");
+
+/**
+ * Read one class's def from a `/object_info/<Type>` reply, DISTINGUISHING the three answers
+ * that matter: it is defined, it is definitively NOT defined, or nothing definitive came
+ * back.
+ *
+ * `single-node-def.js` collapses the middle case into null — correct for its caller, which
+ * only wants a confirmation and falls through to the full fetch on every doubt. Here the
+ * difference is load-bearing: an absent type must reach the #458 ever-seen gate as an
+ * ABSENCE, while an unreadable reply must disqualify the whole scoped map.
+ */
+async function readOneType(type, fetchApi) {
+  let res;
+  try {
+    res = await fetchApi(`/object_info/${encodeURIComponent(type)}`);
+  } catch (err) {
+    return { definitive: false, why: describe(`GET /object_info/${type} threw`, err) };
+  }
+  // Reading `ok`/`status` is itself an operation that can throw — an extension may
+  // monkey-patch `fetchApi` and hand back a proxied or getter-backed response. The oracle
+  // learned this the hard way (#1161); the same guard applies here.
+  let ok = false;
+  let status = "unknown";
+  try {
+    ok = !!res && res.ok === true;
+    status = String(res?.status ?? "unknown");
+  } catch (err) {
+    return { definitive: false, why: describe(`GET /object_info/${type} returned an unreadable response`, err) };
+  }
+  if (!ok) {
+    // A non-2xx establishes nothing about the TYPE. An older ComfyUI without this route
+    // answers 404 and a proxy sign-in page answers 200 with HTML — neither is evidence the
+    // backend lacks the class (`single-node-def.js` says the same about its own fast path).
+    return { definitive: false, why: `GET /object_info/${type} was not OK (status ${status})` };
+  }
+  let body;
+  try {
+    body = await res.json();
+  } catch (err) {
+    return { definitive: false, why: describe(`GET /object_info/${type} body did not parse`, err) };
+  }
+  if (!body || typeof body !== "object" || Array.isArray(body)) {
+    return { definitive: false, why: `GET /object_info/${type} returned a non-object body` };
+  }
+  let def;
+  try {
+    def = Object.prototype.hasOwnProperty.call(body, type) ? body[type] : undefined;
+  } catch (err) {
+    return { definitive: false, why: describe(`GET /object_info/${type} body could not be inspected`, err) };
+  }
+  if (def === undefined) {
+    // ComfyUI answers "no such class" as `{}` with HTTP 200 (verified in #767 against a type
+    // the install did not have). THIS is the definitive absence the ever-seen gate needs.
+    return { definitive: true, present: false };
+  }
+  if (!def || typeof def !== "object" || Array.isArray(def)) {
+    // The key is there but the value is not a def. Nothing definitive was established about
+    // the class, and a shape the readers below cannot use must not read as "defined".
+    return { definitive: false, why: `GET /object_info/${type} returned a non-def value for the class` };
+  }
+  return { definitive: true, present: true, def };
+}
+
+/** Control characters, so a newline in an untrusted message cannot forge structure in a reply. */
+// eslint-disable-next-line no-control-regex
+const CONTROL_CHARS = /[\u0000-\u001f\u007f-\u009f]+/g;
+
+/** Bounded, flattened description of an untrusted throw, for a message a caller reads. */
+function describe(label, err) {
+  let raw = "";
+  try {
+    raw = err instanceof Error ? err.message : err == null ? "" : err;
+  } catch {
+    raw = "(an unprintable value)";
+  }
+  let text = "";
+  try {
+    text = String(raw ?? "");
+  } catch {
+    return `${label}: (an unprintable value)`;
+  }
+  const flat = text.replace(CONTROL_CHARS, " ").replace(/\s+/g, " ").trim();
+  const capped = flat.length > 160 ? `${flat.slice(0, 160)}… (truncated)` : flat;
+  return capped ? `${label}: ${capped}` : label;
+}
+
+/**
+ * Wrap the fetched defs so a question this map was never asked to answer THROWS instead of
+ * reading as an absence.
+ *
+ * This is the whole #716/#821 defence. `freshBackendDefinesType` is
+ * `hasOwnProperty(defs, type)`, which cannot tell "the backend does not define it" from "we
+ * never asked" — on a whole map those coincide, on a scoped one they emphatically do not.
+ * So the map itself refuses the second question rather than trusting every present and
+ * future reader to avoid asking it.
+ *
+ * SYMBOLS PASS THROUGH. Callers brand and test payloads with symbol keys
+ * (`CACHE_OUTCOME`), and those are never class types.
+ */
+function scopedView(present, covered) {
+  const target = Object.create(null);
+  for (const [type, def] of present) target[type] = def;
+  // FROZEN, and the traps below deliberately do NOT override mutation. object-info-cache.js
+  // freezes the whole-map payload for the same reason — the level the fence reads is
+  // `hasOwnProperty(defs, type)`, and a consumer that added a key would authorize a type
+  // nobody installed. Freezing the TARGET rather than trapping writes also keeps
+  // `Object.freeze(defs)` working on the proxy, which a hand-written `defineProperty: false`
+  // turns into a TypeError from a module whose job is to answer, not to explode.
+  Object.freeze(target);
+  const inScope = (prop) => typeof prop === "symbol" || covered.has(prop);
+  const refuse = (prop) => {
+    throw new Error(
+      `Cannot verify node type "${String(prop)}" against the ComfyUI backend: the whole ` +
+        `/object_info never answered, so only the types this write resolves to were fetched ` +
+        `per class (${[...covered].join(", ")}) — and "${String(prop)}" is not one of them. ` +
+        `Refusing to read an unfetched type as ABSENT (#716/#821). Reconnect ComfyUI, or wait ` +
+        `for /object_info to answer again, and retry.`,
+    );
+  };
+  return new Proxy(target, {
+    get(t, prop, recv) {
+      if (prop === SCOPED_OBJECT_INFO) return true;
+      if (!inScope(prop)) refuse(prop);
+      return Reflect.get(t, prop, recv);
+    },
+    has(t, prop) {
+      if (prop === SCOPED_OBJECT_INFO) return true;
+      if (!inScope(prop)) refuse(prop);
+      return Reflect.has(t, prop);
+    },
+    getOwnPropertyDescriptor(t, prop) {
+      if (!inScope(prop)) refuse(prop);
+      return Reflect.getOwnPropertyDescriptor(t, prop);
+    },
+    // Only the types actually PRESENT are enumerated, so anything that ranges over the map
+    // (`Object.keys(defs).length`, a serializer) sees a small, honest object rather than a
+    // throw. It still cannot see the install, which is why the scope trap above exists.
+    ownKeys(t) {
+      return Reflect.ownKeys(t);
+    },
+  });
+}
+
+/**
+ * Ask the backend about EXACTLY the class types this write will be authorized against.
+ *
+ * @param {string[]} types  the complete set the fence will ask about — for a promoted write
+ *   the outer SubgraphNode, every intermediate, AND the concrete target. A set that is
+ *   missing one of them does not produce a wrong answer; it produces a refusal, because the
+ *   returned map throws on the type it was not asked to cover.
+ * @param {object} opts
+ * @param {(route: string) => Promise<any>} opts.fetchApi
+ * @param {number} [opts.deadlineMs]  wall clock for the whole set (requests run concurrently)
+ * @param {object} [opts.timers]      test seam, same shape `bounded-step.js` takes
+ * @returns {Promise<{defs: object|null, covered: string[], reason: string}>}
+ *   `defs` is non-null ONLY when EVERY requested type was answered definitively.
+ */
+export async function fetchTypeScopedObjectInfo(
+  types,
+  { fetchApi, deadlineMs = SCOPED_OBJECT_INFO_DEADLINE_MS, timers } = {},
+) {
+  const wanted = [];
+  const seen = new Set();
+  for (const t of Array.isArray(types) ? types : []) {
+    if (typeof t !== "string" || t === "" || seen.has(t)) continue;
+    seen.add(t);
+    wanted.push(t);
+  }
+  if (wanted.length === 0) {
+    return { defs: null, covered: [], reason: "no node type could be resolved to ask the backend about" };
+  }
+  if (wanted.length > MAX_SCOPED_TYPES) {
+    return {
+      defs: null,
+      covered: [],
+      reason:
+        `this write resolves through ${wanted.length} node types, more than the ` +
+        `${MAX_SCOPED_TYPES} a type-scoped /object_info read will issue`,
+    };
+  }
+  if (typeof fetchApi !== "function") {
+    return { defs: null, covered: [], reason: "no fetchApi is wired for the type-scoped route" };
+  }
+
+  const TIMED_OUT = Symbol("scoped-object-info-timeout");
+  const settled = await withTimeout(
+    Promise.all(wanted.map((t) => readOneType(t, fetchApi))).then(
+      (value) => ({ value }),
+      (err) => ({ err }),
+    ),
+    // A non-finite or non-positive budget is not a bound a caller can have meant; take the
+    // shipped default rather than running unbounded, which is the #1161 signature.
+    Number.isFinite(deadlineMs) && deadlineMs > 0 && deadlineMs <= 2 ** 31 - 1
+      ? deadlineMs
+      : SCOPED_OBJECT_INFO_DEADLINE_MS,
+    () => TIMED_OUT,
+    timers ?? undefined,
+  );
+  if (settled === TIMED_OUT) {
+    return {
+      defs: null,
+      covered: [],
+      reason: `the type-scoped /object_info reads (${wanted.join(", ")}) did not all answer within ${deadlineMs}ms`,
+    };
+  }
+  if (settled?.err) {
+    return { defs: null, covered: [], reason: describe("the type-scoped /object_info reads failed", settled.err) };
+  }
+  const results = settled.value;
+  const present = [];
+  for (let i = 0; i < wanted.length; i += 1) {
+    const r = results[i];
+    if (!r?.definitive) {
+      // ALL OR NOTHING. One type this write needs is unestablished, so the map cannot
+      // authorize the write — and a map that answers some of the question is precisely what
+      // #716/#821 were.
+      return { defs: null, covered: [], reason: r?.why || `GET /object_info/${wanted[i]} established nothing` };
+    }
+    if (r.present) present.push([wanted[i], r.def]);
+  }
+  return { defs: scopedView(present, new Set(wanted)), covered: wanted, reason: "" };
+}

--- a/web/js/lib/scoped-object-info.js
+++ b/web/js/lib/scoped-object-info.js
@@ -412,3 +412,32 @@ export async function fetchTypeScopedObjectInfo(
   }
   return { defs: scopedView(present, new Set(wanted)), covered: wanted, reason: "" };
 }
+
+/**
+ * Is THIS the map `fetchTypeScopedObjectInfo` handed back?
+ *
+ * Asked of the payload itself rather than of a stored stamp, and that is the whole point.
+ * `set-widget.js` re-reads its schema provenance AFTER a live re-ask, and the panel's shared
+ * `readObjectInfo` re-stamps that provenance on every one of its exit paths — so a "the
+ * schema is type-scoped" fact recorded at the moment the map was adopted is overwritten
+ * before the ladder reads it, and the branch keyed on it becomes dead code that never fires
+ * while a message asserting a DIFFERENT, false cause fires in its place. That is not
+ * hypothetical: it is exactly how #1223's own snapshot branch came to be dead
+ * (`node-resolve.test.mjs` records it), and it happened again here one field over.
+ *
+ * A brand carried by the object cannot drift, because it is a property of the very payload
+ * being ruled on: if the re-ask replaces that payload with a whole map, this answers false
+ * for the new one without anybody having to remember to clear a flag.
+ *
+ * A foreign object that THROWS on a symbol read is not this module's map, so false is the
+ * right answer for it — and a throw out of a provenance question would replace a refusal
+ * with a crash.
+ */
+export function isTypeScopedObjectInfo(defs) {
+  if (!defs || typeof defs !== "object") return false;
+  try {
+    return defs[SCOPED_OBJECT_INFO] === true;
+  } catch {
+    return false;
+  }
+}

--- a/web/js/lib/scoped-object-info.js
+++ b/web/js/lib/scoped-object-info.js
@@ -186,7 +186,11 @@ function sanitizeName(value) {
   } catch {
     return "(an unprintable value)";
   }
-  const flat = text.replace(CONTROL_CHARS, " ").replace(/s+/g, " ").trim();
+  // `/\s+/`, NOT `/s+/`. A backslash lost in transit made this delete every LETTER S from
+  // every node type in a refusal — "SmartResolution" reading back as "SmartRe olution" — and
+  // the test that was supposed to cover it only asserted that a NEWLINE was gone, so it
+  // passed. The assertions below now pin the name itself, not just the absence of a newline.
+  const flat = text.replace(CONTROL_CHARS, " ").replace(/\s+/g, " ").trim();
   if (!flat) return "(an unnamed type)";
   return flat.length > 120 ? `${flat.slice(0, 120)}… (truncated)` : flat;
 }
@@ -234,9 +238,12 @@ function scopedView(present, covered) {
   // freezes the whole-map payload for the same reason — the level the fence reads is
   // `hasOwnProperty(defs, type)`, and a consumer that added a key would authorize a type
   // nobody installed. Freezing the TARGET rather than trapping writes also keeps
-  // `Object.freeze(defs)` working on the proxy, which a hand-written `defineProperty: false`
-  // turns into a TypeError from a module whose job is to answer, not to explode.
+  // `Object.freeze(defs)` working on the proxy; a hand-written `defineProperty: false` makes
+  // that a TypeError instead.
   Object.freeze(target);
+  // Built ONCE, and sanitized: every one of these names came off the graph too, and a
+  // newline inside one would forge structure in the refusal just as the asked-for name would.
+  const coveredNames = [...covered].map((t) => sanitizeName(t)).join(", ");
   const inScope = (prop) => typeof prop === "symbol" || covered.has(prop);
   const refuse = (prop) => {
     // The name came off the GRAPH and rides into a message someone reads, so it is flattened
@@ -245,7 +252,7 @@ function scopedView(present, covered) {
     throw new Error(
       `Cannot verify node type "${name}" against the ComfyUI backend: the whole ` +
         `/object_info never answered, so only the types this write resolves to were fetched ` +
-        `per class (${[...covered].join(", ")}) — and "${name}" is not one of them. ` +
+        `per class (${coveredNames}) — and "${name}" is not one of them. ` +
         `Refusing to read an unfetched type as ABSENT (#716/#821). Reconnect ComfyUI, or wait ` +
         `for /object_info to answer again, and retry.`,
     );

--- a/web/js/lib/scoped-object-info.js
+++ b/web/js/lib/scoped-object-info.js
@@ -174,6 +174,23 @@ async function readOneType(type, fetchApi) {
 // eslint-disable-next-line no-control-regex
 const CONTROL_CHARS = /[\u0000-\u001f\u007f-\u009f]+/g;
 
+/**
+ * Flatten and cap a class NAME that came off the graph before it rides into a message a
+ * caller reads. Separate from `describe` because that one prefixes a label, and a refusal
+ * reading `node type ": Foo"` is a defect of its own.
+ */
+function sanitizeName(value) {
+  let text = "";
+  try {
+    text = String(value ?? "");
+  } catch {
+    return "(an unprintable value)";
+  }
+  const flat = text.replace(CONTROL_CHARS, " ").replace(/s+/g, " ").trim();
+  if (!flat) return "(an unnamed type)";
+  return flat.length > 120 ? `${flat.slice(0, 120)}… (truncated)` : flat;
+}
+
 /** Bounded, flattened description of an untrusted throw, for a message a caller reads. */
 function describe(label, err) {
   let raw = "";
@@ -209,6 +226,10 @@ function describe(label, err) {
 function scopedView(present, covered) {
   const target = Object.create(null);
   for (const [type, def] of present) target[type] = def;
+  // BRANDED ON THE TARGET, not answered by a trap. A `has`/`get` trap that reports a
+  // property the NON-EXTENSIBLE target below does not own violates a Proxy invariant and
+  // throws TypeError — from a module whose job is to answer a question, not to explode.
+  target[SCOPED_OBJECT_INFO] = true;
   // FROZEN, and the traps below deliberately do NOT override mutation. object-info-cache.js
   // freezes the whole-map payload for the same reason — the level the fence reads is
   // `hasOwnProperty(defs, type)`, and a consumer that added a key would authorize a type
@@ -218,22 +239,23 @@ function scopedView(present, covered) {
   Object.freeze(target);
   const inScope = (prop) => typeof prop === "symbol" || covered.has(prop);
   const refuse = (prop) => {
+    // The name came off the GRAPH and rides into a message someone reads, so it is flattened
+    // and capped exactly like every other untrusted string in this family.
+    const name = sanitizeName(prop);
     throw new Error(
-      `Cannot verify node type "${String(prop)}" against the ComfyUI backend: the whole ` +
+      `Cannot verify node type "${name}" against the ComfyUI backend: the whole ` +
         `/object_info never answered, so only the types this write resolves to were fetched ` +
-        `per class (${[...covered].join(", ")}) — and "${String(prop)}" is not one of them. ` +
+        `per class (${[...covered].join(", ")}) — and "${name}" is not one of them. ` +
         `Refusing to read an unfetched type as ABSENT (#716/#821). Reconnect ComfyUI, or wait ` +
         `for /object_info to answer again, and retry.`,
     );
   };
   return new Proxy(target, {
     get(t, prop, recv) {
-      if (prop === SCOPED_OBJECT_INFO) return true;
       if (!inScope(prop)) refuse(prop);
       return Reflect.get(t, prop, recv);
     },
     has(t, prop) {
-      if (prop === SCOPED_OBJECT_INFO) return true;
       if (!inScope(prop)) refuse(prop);
       return Reflect.has(t, prop);
     },
@@ -291,17 +313,34 @@ export async function fetchTypeScopedObjectInfo(
     return { defs: null, covered: [], reason: "no fetchApi is wired for the type-scoped route" };
   }
 
+  // ONE effective bound, decided here and reported here.
+  //
+  // A NON-NUMBER, a NaN/Infinity, or a value `setTimeout` cannot express takes the shipped
+  // default — none of those is a budget a caller can have meant, and clamping an over-range
+  // one to 2^31-1 turns nonsense into a ~24.8-day grant (object-info-oracle.js measured that
+  // trap). A non-positive NUMBER is a REAL choice and is obeyed by attempting nothing:
+  // `withTimeout` treats `ms <= 0` as NO BOUND, so passing it through would remove the bound
+  // at exactly the moment the command has already run out, which is #1161 arriving through
+  // the mechanism meant to prevent it. (`budget.bounded` floors at 1 ms for this reason, so
+  // the panel never reaches this arm — a direct caller can.)
+  const requested = typeof deadlineMs === "number" ? deadlineMs : NaN;
+  const effectiveMs =
+    Number.isFinite(requested) && requested <= 2 ** 31 - 1 ? requested : SCOPED_OBJECT_INFO_DEADLINE_MS;
+  if (!(effectiveMs > 0)) {
+    return {
+      defs: null,
+      covered: [],
+      reason: `no time was left to ask about ${wanted.join(", ")} per class`,
+    };
+  }
+
   const TIMED_OUT = Symbol("scoped-object-info-timeout");
   const settled = await withTimeout(
     Promise.all(wanted.map((t) => readOneType(t, fetchApi))).then(
       (value) => ({ value }),
       (err) => ({ err }),
     ),
-    // A non-finite or non-positive budget is not a bound a caller can have meant; take the
-    // shipped default rather than running unbounded, which is the #1161 signature.
-    Number.isFinite(deadlineMs) && deadlineMs > 0 && deadlineMs <= 2 ** 31 - 1
-      ? deadlineMs
-      : SCOPED_OBJECT_INFO_DEADLINE_MS,
+    effectiveMs,
     () => TIMED_OUT,
     timers ?? undefined,
   );
@@ -309,7 +348,7 @@ export async function fetchTypeScopedObjectInfo(
     return {
       defs: null,
       covered: [],
-      reason: `the type-scoped /object_info reads (${wanted.join(", ")}) did not all answer within ${deadlineMs}ms`,
+      reason: `the type-scoped /object_info reads (${wanted.join(", ")}) did not all answer within ${effectiveMs}ms`,
     };
   }
   if (settled?.err) {

--- a/web/js/lib/set-widget.js
+++ b/web/js/lib/set-widget.js
@@ -37,6 +37,7 @@ import {
   freshBackendDefinesType,
 } from "./node-resolve.js";
 import { controlAfterGenerateWarning, controlEntryForWidget } from "./control-after-generate.js";
+import { isTypeScopedObjectInfo } from "./scoped-object-info.js";
 import { linkDrivenWidgets, drivenTag } from "./graph-read.js";
 import { refreshDynamicInputsAfterWrite } from "./dynamic-inputs-refresh.js";
 import { REFRESH_JOIN_ABANDONED } from "./refresh-coalesce.js";
@@ -303,6 +304,30 @@ export async function runSetWidget(
       return "unknown";
     }
   };
+  /**
+   * The provenance of THE MAP THIS DECISION IS ABOUT — asked of the PAYLOAD first, and only
+   * then of the stamp.
+   *
+   * `readSchemaProvenance` deliberately holds the QUESTION rather than an answer, because a
+   * verdict computed before an await can be superseded during it (#1126). That is right for
+   * the whole-map routes and WRONG for #1560's type-scoped one, because the ladder below
+   * re-asks the panel for a live map: the re-ask re-enters the panel's shared
+   * `readObjectInfo`, which re-stamps the provenance on EVERY exit path it has. So a FAILED
+   * re-ask — the normal case on an install whose whole map never lands — overwrites "scoped"
+   * with "none" while `authDefs` is still the scoped map. The branch keyed on "scoped" then
+   * never fires, and what fires instead tells the caller the provenance could not be
+   * established AT ALL and to reconnect: false twice over, since a type-scoped read did
+   * answer, live, moments earlier, and reconnecting cannot help a backend whose whole map
+   * never arrives. That is the misattribution class #982/#1223 exist to stop, committed by
+   * the change written to extend them.
+   *
+   * #1223's OWN snapshot branch was dead code for the same reason once — `node-resolve.js`'s
+   * suite records it — so this is that defect one field over, and the reason the answer is
+   * not simply a second stamp captured earlier: a brand belongs to the very object being
+   * ruled on, so when the re-ask DOES replace `authDefs` with a whole live map this answers
+   * for the NEW payload with no flag anyone has to remember to clear.
+   */
+  const provenanceOf = (defs) => (isTypeScopedObjectInfo(defs) ? "scoped" : readSchemaProvenance());
   const liveRegistry = () => (typeof getRegistry === "function" ? getRegistry() : registry);
 
   // (0) FRESH-BACKEND TYPE AUTHORIZATION (#458 set_widget gap, found in review of
@@ -1215,7 +1240,7 @@ export async function runSetWidget(
       // upload probe were awaited, and both of those can supersede it — a refresh, an install,
       // a download completing, a reconnect. A verdict is a statement about a moment, so it is
       // asked at the moment it is used, on the near side of every await that could expire it.
-      let provenance = readSchemaProvenance();
+      let provenance = provenanceOf(freshDefs ?? undefined);
       let authDefs = freshDefs ?? undefined;
       // What the STALE evidence claimed, captured before it is replaced — the difference
       // between "the server publishes a list, as it always did" and "the stale schema said
@@ -1233,7 +1258,36 @@ export async function runSetWidget(
         } catch {
           /* the re-ask failed; provenance stays non-live and the refusals below fire */
         }
-        provenance = readSchemaProvenance();
+        provenance = provenanceOf(authDefs);
+      }
+      // #1560 — a TYPE-SCOPED map is the server answering NOW, but only about the handful of
+      // types this write resolves to. It can authorize the node type; it even holds this
+      // input's own option list. It still may not license the blind write: the whole-schema
+      // probes went silent, so nothing establishes that the panel is looking at the CURRENT
+      // install rather than at one class of it, and widening a last-resort unvalidated write
+      // on a partial view of the schema is the one thing this route was built not to do.
+      //
+      // DECIDED HERE, ABOVE the empty-list shape test, and that placement is the fix rather
+      // than a tidy-up. Below it this branch is unreachable in BOTH directions: when the
+      // scoped map declares the list EMPTY the shape test fires first and refuses with a
+      // message about a provenance that "could not be established at all" — false, a
+      // type-scoped read answered — and when it declares a NON-empty list the ladder falls
+      // through to the generic end-of-ladder refusal, which sends the caller to look at their
+      // value while the actual cause is a backend whose whole map never lands. Verified by
+      // execution, not by reading: with this branch deleted the whole suite stayed green,
+      // which is what dead code looks like from inside a passing test run.
+      if (provenance === "scoped") {
+        throw new Error(
+          `panel_set_widget refused "${widgetName}" on node ${node?.id} (${node?.type}): ` +
+            `${latest.message} The panel could have written it unvalidated if a WHOLE ` +
+            `/object_info declared this input's option list empty — but both whole-schema ` +
+            `probes went silent, so the only schema available is a TYPE-SCOPED read (#1560) ` +
+            `covering just the node types this write resolves to. That is enough to authorize ` +
+            `the node type and not enough to license an unvalidated write, whether or not it ` +
+            `shows this input's list as empty. This is NOT a stale or unreadable schema and ` +
+            `reconnecting need not help: wait for /object_info to answer as a whole again, ` +
+            `then retry.`,
+        );
       }
       if (serverDeclaresEmptyComboOptions(authDefs, authTarget?.type, comboDefInput)) {
         // Fails closed: no live declaration, no blind write. The user is told WHICH fact is
@@ -1359,24 +1413,6 @@ export async function runSetWidget(
       // message would tell the caller only that their combo could not be read, sending them to
       // look at their value while the actual cause is a silent backend — the exact
       // misattribution this whole change exists to stop.
-      // #1560 — a TYPE-SCOPED map is the server answering now, but only about the handful of
-      // types this write resolves to. It can authorize the node type; it holds this input's
-      // option list too, and yet it still may not license the blind write: the whole-map probes
-      // went silent, so nothing establishes that the panel is looking at the CURRENT install
-      // rather than at one class of it. Widening a last-resort unvalidated write on a partial
-      // view of the schema is the one thing this route was built not to do, so it refuses —
-      // exactly as it does today, but saying which route did answer and which did not.
-      if (provenance === "scoped") {
-        throw new Error(
-          `panel_set_widget refused "${widgetName}" on node ${node?.id} (${node?.type}): ` +
-            `${latest.message} The panel could have written it unvalidated if /object_info ` +
-            `declared this input's option list empty — but both whole-schema probes went ` +
-            `silent, and the only schema available is a TYPE-SCOPED read (#1560) covering just ` +
-            `the node types this write resolves to. That is enough to authorize the node type ` +
-            `and not enough to license an unvalidated write. Wait for /object_info to answer ` +
-            `again (or reconnect to ComfyUI) and retry.`,
-        );
-      }
       if (provenance === "snapshot") {
         throw new Error(
           `panel_set_widget refused "${widgetName}" on node ${node?.id} (${node?.type}): ` +

--- a/web/js/lib/set-widget.js
+++ b/web/js/lib/set-widget.js
@@ -131,6 +131,51 @@ function staleComboRefreshRefusalMessage(refreshStillRunning) {
   );
 }
 
+/**
+ * #1560 — the COMPLETE set of class types this write is about to be authorized against,
+ * derived from the GRAPH with no schema and no I/O.
+ *
+ * This is what makes a type-scoped `/object_info` read answer the RIGHT question. The three
+ * guards below ask about exactly these:
+ *
+ *   - `assertTypeAgainstFreshBackend` on the ULTIMATE CONCRETE target's type;
+ *   - `assertMutatedNodeAuthorized` on the OUTER subgraph node's type;
+ *   - `assertMutatedNodeAuthorized` on EVERY intermediate container's type;
+ *   - and the #612 not-promoted diagnosis, on the outer node's type again.
+ *
+ * MEASURED, not reasoned: driving the real helpers on the nested A→B→KSampler shape the #458
+ * suite uses returns SubgraphA / SubgraphB / KSampler with nothing fetched. That is the
+ * "TWO types for a promoted write" the oracle's header warns about, named up front instead of
+ * discovered after the fetch.
+ *
+ * A SUPERSET IS SAFE; A SUBSET IS A REFUSAL, NEVER A WRONG ANSWER. An extra type costs one
+ * ~3KB request. A missing one is a type the returned map was not asked to cover, and reading
+ * it throws rather than reporting it absent — which is the #716/#821 failure this exists to
+ * make impossible.
+ */
+export function scopedAuthorizationTypes(node, promotedResolution, isResolvedPromotion, resolveSource) {
+  const types = [];
+  const push = (t) => {
+    if (typeof t === "string" && t !== "" && !types.includes(t)) types.push(t);
+  };
+  push(node?.type);
+  if (isResolvedPromotion) {
+    // Both helpers walk injected, caller-supplied link data and can throw on a malformed or
+    // cyclic promotion. An incomplete list must never be returned as though it were the whole
+    // set, so a throw yields NOTHING and the scoped read is simply not attempted — the write
+    // then refuses on the unchanged path below.
+    try {
+      push(followPromotionToConcrete(promotedResolution.target, resolveSource)?.node?.type);
+      for (const intermediate of collectPromotionIntermediates(promotedResolution.target, resolveSource)) {
+        push(intermediate?.type);
+      }
+    } catch {
+      return [];
+    }
+  }
+  return types;
+}
+
 export async function runSetWidget(
   node,
   widgetName,
@@ -175,6 +220,10 @@ export async function runSetWidget(
     //                  silent. NOTE it is a detached map of TYPE NAMES ONLY — see the
     //                  fallback below for why that makes it unable to answer this question
     //                  at all, rather than merely answering it staleley
+    //   "scoped"       #1560's TYPE-SCOPED read stood in while both whole-map probes were
+    //                  silent. It is the server answering NOW, but only about the handful of
+    //                  types this write resolves to — so it can authorize a type and it
+    //                  cannot answer anything that ranges over the install
     //   "none"         nothing was established
     //
     // The first four are ONE answer from object-info-cache.js, which owns the generation
@@ -206,6 +255,24 @@ export async function runSetWidget(
     // OUTCOME the ladder needs — a fresh answer — and leaves the cache to decide how to get
     // one without disturbing anybody else.
     refetchObjectInfoLive,
+    // #1560 — the LAST-RESORT, TYPE-SCOPED route: `(types) => { defs, covered, reason }`,
+    // asking the backend about EXACTLY the class types this write is about to be authorized
+    // against, one `/object_info/<Type>` request each.
+    //
+    // Consulted ONLY when the whole-map oracle AND #1223's snapshot have both produced
+    // nothing — on a ~1023-model install the whole dump never lands inside any budget, so
+    // the snapshot is never populated and every write refuses for the LIFE OF THE TAB.
+    //
+    // It is wired here rather than inside `getFreshObjectInfo` for a reason the oracle's own
+    // header names: a per-class payload "answers one question and reads the other as absent
+    // (#716/#821)", and the set of questions is only known once the promotion has been
+    // resolved — which happens BELOW the fetch. By the time this is called the outer node,
+    // every intermediate and the ultimate concrete target are all known, so the map can be
+    // asked to cover all of them and to THROW for anything else (see scoped-object-info.js).
+    //
+    // The panel gates it on the SAME `noBackendAnswerEstablished` licence #1223's snapshot
+    // uses, so a client that ANSWERED deny-all is never overruled by a broader per-class read.
+    fetchScopedObjectInfo,
     // #757 — SYNCHRONOUS target preparation. Some write targets do not exist until
     // something creates them (an rgthree Power Lora Loader `lora_N` row is minted only by
     // the node's own method), and the creation is a graph MUTATION. Injected here, rather
@@ -228,6 +295,7 @@ export async function runSetWidget(
         p === "reconnected" ||
         p === "retired" ||
         p === "snapshot" ||
+        p === "scoped" ||
         p === "none"
         ? p
         : "unknown";
@@ -310,6 +378,64 @@ export async function runSetWidget(
   // into applyWidgetWrite so the write never re-resolves.
   const resolvedTargetNode = isResolvedPromotion ? promotedResolution.target.node : node;
   const promotedButUnresolvable = !!(promotedResolution && promotedResolution.promoted && !promotedResolution.target);
+
+  // #1560 — LAST RESORT: ask the backend about EXACTLY the types this write needs.
+  //
+  // Reached only when the whole-map oracle returned nothing AND #1223's snapshot could not
+  // stand in — on the reported install that is EVERY call, forever, because the whole dump
+  // never lands and so the snapshot is never populated. Reproduced by execution before this
+  // was written: two hung whole-map routes, zero per-class requests ever issued, the widget
+  // never written, the identical refusal 15,015 ms later on the second call.
+  //
+  // PLACED HERE, BELOW THE RESOLUTION, WHICH IS THE WHOLE POINT. The oracle's header rejects
+  // the per-class route for this fence because "set_widget authorizes two types for a
+  // promoted write and fetches BEFORE resolving which target it writes to, so a single-class
+  // payload answers one question and reads the other as absent (#716/#821)". By this line the
+  // promotion HAS been resolved — purely, with no schema and no I/O (measured: the real
+  // resolution helpers produce SubgraphA / SubgraphB / KSampler for a nested A→B→KSampler
+  // write with nothing fetched at all) — so the request can name all of them and the map it
+  // returns THROWS for any type outside that set instead of reading it as absent.
+  //
+  // The primary fetch above deliberately did NOT move. Resolving before it was tried and
+  // passes the whole unit suite, but it would make the resolution older by up to a full
+  // budget on every healthy call to buy something only this path needs.
+  //
+  // THE AWAIT THIS ADDS IS GUARDED BY THE SAME TRAP. It sits between the resolution and the
+  // write, so a promotion relinked mid-fetch could resolve deeper to a different concrete
+  // node — and that node's type is one the scoped map was never asked to cover, so it throws
+  // and the write refuses. The workflow fence (`assertTargetStillCurrent`, re-checked
+  // synchronously inside `write`) already covers a workflow switch across the same window.
+  //
+  // Skipped entirely for a promoted-but-unresolvable write: nothing consults freshDefs on
+  // that path, so a request would only add latency to a refusal that is already decided.
+  let scopedIneligibility = "";
+  if (!freshDefs && !promotedButUnresolvable && typeof fetchScopedObjectInfo === "function") {
+    let scoped = null;
+    try {
+      scoped = await fetchScopedObjectInfo(
+        scopedAuthorizationTypes(node, promotedResolution, isResolvedPromotion, resolveSource),
+      );
+    } catch {
+      // A last-resort route must never replace the refusal it was trying to avoid.
+      scoped = null;
+    }
+    if (scoped && scoped.defs) freshDefs = scoped.defs;
+    else if (scoped && typeof scoped.reason === "string" && scoped.reason) scopedIneligibility = scoped.reason;
+  }
+  // The refusal has to be able to say a THIRD route was tried and what it did. Kept OUT of
+  // the transport list `objectInfoOracleFailureNote` renders — that array is what the two
+  // whole-map routes reported, and splicing a non-route entry into it makes a two-transport
+  // failure claim three routes tried, which is #982's own defect.
+  const describeObjectInfoFailureWithScope = () => {
+    let base = "";
+    try {
+      base = typeof describeObjectInfoFailure === "function" ? describeObjectInfoFailure() || "" : "";
+    } catch {
+      base = ""; // a diagnostic must never replace the refusal it is describing
+    }
+    if (!scopedIneligibility) return base;
+    return `${base} A type-scoped /object_info read was tried too — ${scopedIneligibility}.`;
+  };
   // The node whose TYPE to fresh-authorize. For a promoted write, follow the promotion
   // chain through any NESTED SubgraphNodes to the ULTIMATE CONCRETE backend node and
   // authorize THAT type (a virtual intermediate subgraph type is never in /object_info
@@ -433,7 +559,7 @@ export async function runSetWidget(
       // but absent from the current /object_info is a REMOVED backend node — refuse
       // (the non-forgeable trust root; client shape/name/markers cannot prove this).
       wasTypeEverDefined,
-      describeObjectInfoFailure,
+      describeObjectInfoFailure: describeObjectInfoFailureWithScope,
     });
   }
 
@@ -1216,6 +1342,24 @@ export async function runSetWidget(
       // message would tell the caller only that their combo could not be read, sending them to
       // look at their value while the actual cause is a silent backend — the exact
       // misattribution this whole change exists to stop.
+      // #1560 — a TYPE-SCOPED map is the server answering now, but only about the handful of
+      // types this write resolves to. It can authorize the node type; it holds this input's
+      // option list too, and yet it still may not license the blind write: the whole-map probes
+      // went silent, so nothing establishes that the panel is looking at the CURRENT install
+      // rather than at one class of it. Widening a last-resort unvalidated write on a partial
+      // view of the schema is the one thing this route was built not to do, so it refuses —
+      // exactly as it does today, but saying which route did answer and which did not.
+      if (provenance === "scoped") {
+        throw new Error(
+          `panel_set_widget refused "${widgetName}" on node ${node?.id} (${node?.type}): ` +
+            `${latest.message} The panel could have written it unvalidated if /object_info ` +
+            `declared this input's option list empty — but both whole-schema probes went ` +
+            `silent, and the only schema available is a TYPE-SCOPED read (#1560) covering just ` +
+            `the node types this write resolves to. That is enough to authorize the node type ` +
+            `and not enough to license an unvalidated write. Wait for /object_info to answer ` +
+            `again (or reconnect to ComfyUI) and retry.`,
+        );
+      }
       if (provenance === "snapshot") {
         throw new Error(
           `panel_set_widget refused "${widgetName}" on node ${node?.id} (${node?.type}): ` +

--- a/web/js/lib/set-widget.js
+++ b/web/js/lib/set-widget.js
@@ -1276,6 +1276,19 @@ export async function runSetWidget(
       // value while the actual cause is a backend whose whole map never lands. Verified by
       // execution, not by reading: with this branch deleted the whole suite stayed green,
       // which is what dead code looks like from inside a passing test run.
+      // NARROWER THAN IT FIRST READ, deliberately. An earlier wording said a scoped map is
+      // "not enough to license an unvalidated write, whether or not it shows this input's
+      // list as empty" — and that over-claims, because #507's branch above DOES accept one.
+      // The two cases are not the same observation and the asymmetry is correct:
+      //
+      //   - #507: the widget's OWN list read as EMPTY and the schema says empty too. Two
+      //     agreeing observations, and the per-class def is the live server answer for this
+      //     class — byte-identical to the whole map's entry for it (measured on 0.33.2). That
+      //     branch already accepts `cache`/`reconnected`/`retired` whole maps, all of them
+      //     older than this one.
+      //   - HERE: the widget's own list could not be READ AT ALL, so the schema is the only
+      //     witness there is. Standing in for the sole witness is a stronger claim than
+      //     agreeing with a second one, and a partial view of the install may not make it.
       if (provenance === "scoped") {
         throw new Error(
           `panel_set_widget refused "${widgetName}" on node ${node?.id} (${node?.type}): ` +
@@ -1283,10 +1296,10 @@ export async function runSetWidget(
             `/object_info declared this input's option list empty — but both whole-schema ` +
             `probes went silent, so the only schema available is a TYPE-SCOPED read (#1560) ` +
             `covering just the node types this write resolves to. That is enough to authorize ` +
-            `the node type and not enough to license an unvalidated write, whether or not it ` +
-            `shows this input's list as empty. This is NOT a stale or unreadable schema and ` +
-            `reconnecting need not help: wait for /object_info to answer as a whole again, ` +
-            `then retry.`,
+            `the node type. It is not enough to stand in for a list the panel could not read ` +
+            `at all, which is the one thing that would license THIS write. This is NOT a ` +
+            `stale or unreadable schema and reconnecting need not help: wait for /object_info ` +
+            `to answer as a whole again, then retry.`,
         );
       }
       if (serverDeclaresEmptyComboOptions(authDefs, authTarget?.type, comboDefInput)) {

--- a/web/js/lib/set-widget.js
+++ b/web/js/lib/set-widget.js
@@ -400,11 +400,28 @@ export async function runSetWidget(
   // passes the whole unit suite, but it would make the resolution older by up to a full
   // budget on every healthy call to buy something only this path needs.
   //
-  // THE AWAIT THIS ADDS IS GUARDED BY THE SAME TRAP. It sits between the resolution and the
-  // write, so a promotion relinked mid-fetch could resolve deeper to a different concrete
-  // node — and that node's type is one the scoped map was never asked to cover, so it throws
-  // and the write refuses. The workflow fence (`assertTargetStillCurrent`, re-checked
-  // synchronously inside `write`) already covers a workflow switch across the same window.
+  // WHAT THE AWAIT THIS ADDS DOES AND DOES NOT COST — stated exactly, because the first
+  // version of this note claimed the scope trap guarded all of it, and it does not.
+  //
+  // The trap catches ONE of the two shapes: a promotion relinked mid-fetch that resolves
+  // deeper to a concrete node of a DIFFERENT type asks the map about a type it was never
+  // given, so it throws and the write refuses. A relink to a node of the SAME type is NOT
+  // caught, and does not need to be — the type authorization is still true of the node
+  // actually driven.
+  //
+  // What is genuinely older is `promotedResolution`, captured just above: `authTarget` and
+  // every guard below are still computed AFTER this await, exactly as they are after the
+  // whole-map fetch today, but the IMMEDIATE write target now predates one more await. So a
+  // caller who re-promotes a widget during this window can have the write land on the node
+  // the promotion pointed at when the command was resolved. That is a stale-target hazard,
+  // never a fail-open of the #458 fence: whatever is written is still registry-checked
+  // (`assertResolvedTargetRegistered`), still type-authorized against a live backend, and
+  // still fenced to the active workflow (`assertTargetStillCurrent`, re-checked synchronously
+  // inside `write` with no await after it).
+  //
+  // The window is this read alone — measured at 1.2 ms per class on this repo's own rig
+  // (#767), 15 ms in the reproduction — on a path where the alternative is a refusal that
+  // never succeeds. That is the trade, and it is taken deliberately.
   //
   // Skipped entirely for a promoted-but-unresolvable write: nothing consults freshDefs on
   // that path, so a request would only add latency to a refusal that is already decided.


### PR DESCRIPTION
Fixes #1560.

> **Review is PENDING.** grok has been asked in a comment below, with the risky parts named,
> and has not answered — no verdict exists and this is NOT gated.
>
> **A [P1] was found on this PR and fixed on `e0d5266a`.** It came from the repo's fallback
> adversarial gate (`claude-gate.mjs`), run because grok has answered no PR in this repo since
> 02:51Z today. The `provenance === "scoped"` refusal was **dead code**: the ladder's live
> re-ask re-enters the panel's shared `readObjectInfo`, which re-stamps the provenance on
> every exit path, so `"scoped"` was overwritten with `"none"` while the scoped map was still
> in hand. What fired instead told the caller the provenance *"could not be established at
> all"* and to **reconnect** — false twice over on an install whose whole map never lands.
> Provenance is now read off a **brand on the payload**, which cannot drift. Full disclosure
> in the comments, including what that gate is and where it is weaker than codex.

## The bug, reproduced by execution before a line was written

On the reporter's install (~1023 models, hundreds of packs, ComfyUI 0.33.0 / frontend 1.49.6) **both** whole-schema probes time out — `api.getNodeDefs()` on its 10 s share, `GET /object_info` on its 5 s share of the 20 s budget — while ComfyUI is idle and healthy, `/system_stats` answers 200 and `GET /object_info/SmartResolution` answers 200 in ~2.7 KB. Because no **whole** map ever lands, #1223's snapshot is never populated, so **every** `panel_set_widget` refuses **for the life of the tab**.

I reproduced that against the real `object-info-oracle.js`, the real burst cache, the real #1223 snapshot and the real `runSetWidget` body — not a mock of any of them:

```
elapsed ms          : 15015
whole /object_info  : 1 request(s), none settled
per-class fetches   : 0
node.widgets[0]     : 512 (unwritten)
outcome             : REFUSED Cannot set widget on node 1976 ("SmartResolution"): cannot verify
                      the node type against the ComfyUI backend — no usable /object_info schema
                      was obtained. Tried 2 routes: api.getNodeDefs() did not answer within its
                      10000ms share of the 20000ms budget; GET /object_info did not answer within
                      its 5000ms share of the 20000ms budget. The last-observed schema was not
                      usable either — no whole /object_info has been observed on this backend
                      connection yet. …
second call elapsed : 15015 ms → REFUSED (identical)
```

Byte-for-byte the reported message, **zero** per-class requests ever issued, and permanent. That is a different failure from the transient busy-backend timeout the budget was designed for.

## Was the reordering the oracle names actually possible? Yes — and it is not what shipped

`object-info-oracle.js` forecloses the obvious fix:

> "`set_widget` authorizes **two types** for a promoted write and fetches BEFORE resolving which target it writes to, so a single-class payload answers one question and reads the other as absent (#716/#821)."

**Half of that is load-bearing and half is an artefact of where the fetch sits**, and I established which is which by running it, not by reading it.

*Measured (feasibility).* Driving the real `resolvePromotedInnerTarget` → `followPromotionToConcrete` → `collectPromotionIntermediates` with **no schema at all**, on the nested A→B→KSampler shape the #458 suite uses:

```
resolvePromotedInnerTarget    → { promoted: true, immediateTargetId: 80 }
followPromotionToConcrete     → { id: 90, type: 'KSampler', widget: 'steps' }
collectPromotionIntermediates → [ '80:SubgraphB' ]
COMPLETE type set: SubgraphA, SubgraphB, KSampler   — all from the GRAPH, nothing fetched
```

*Measured (cost).* I then actually moved the whole-map fetch below the resolution in `set-widget.js` (splitting the #612 container diagnosis so it still sees the schema) and ran the suite: **6115 pass / 0 fail — identical to baseline.** The reorder is possible and the existing suite does not object.

**But I reverted it, and that is a finding rather than a preference.** The fetch that needs to know the target is the **fallback**, and the fallback already sits after the resolution. Moving the *primary* fetch would make the promotion resolution older by up to a full 20 s budget on **every** call — including the healthy ones — to buy something only the failing path needs. So `runSetWidget` keeps its fetch exactly where it was.

## What shipped

A new `web/js/lib/scoped-object-info.js`, reached from `runSetWidget` **only** after the whole-map oracle returned nothing **and** #1223's snapshot refused. It is handed the **complete** set of class types this write is about to be authorized against, and it fetches `/object_info/<Type>` for each.

The map it returns is **not** a per-class payload in the #716/#821 sense: it is a `Proxy` over a frozen null-prototype object that **THROWS for any type it was not asked to cover**, instead of reading it as absent.

```
assert.throws(() => Object.prototype.hasOwnProperty.call(defs, "VAELoader"),
              /Refusing to read an unfetched type as ABSENT/)
```

So "answers one question and reads the other as absent" is impossible **by construction**, not by a later reader remembering the rule.

### The promoted two-type case

`scopedAuthorizationTypes()` names every type the three guards actually ask about — the **outer** SubgraphNode (`assertMutatedNodeAuthorized`), **every intermediate** container (`assertMutatedNodeAuthorized`, per level), and the **ultimate concrete** target (`assertTypeAgainstFreshBackend`) — plus the outer type again for the #612 not-promoted diagnosis. A nested promoted write issues three requests and is verified against all three, and the fixture asserts exactly that:

```
["/object_info/KSampler", "/object_info/SubgraphA", "/object_info/SubgraphB"]
```

A promotion whose chain cannot be walked (a throw from the injected `resolveSource`) yields **no** list at all rather than a partial one, so the scoped read is simply not attempted.

The write still lands through `applyWidgetWrite` on the resolution that was threaded in, so authorization and the write hit the identical target. What that resolution does and does not guarantee across the extra await is stated exactly in the correction at the end — I got it wrong the first time.

## Fail-closed, proved in BOTH directions

**Now succeeds** (was permanently refused):
- direct write on the reported shape — 1 per-class request, write lands;
- nested promoted write — 3 per-class requests, write lands on the inner node.

**Still refuses**:
- a **removed** type answers `{}`/200 → definitively absent → the unchanged #458 guard refuses `backend does not provide node type "GoneNode"`;
- **ever-seen** + now absent → still diagnosed `its backend was removed (pack uninstalled/disabled)`;
- the per-class route **also** silent → refuses as today, and the refusal now says a third route was tried and what it did;
- a **non-200** per-class reply (a proxy sign-in page, an older ComfyUI without the route) establishes nothing → refuses;
- **all-or-nothing**: one indefinite answer anywhere in a promoted set refuses the whole write — a partial map never authorizes a partial question;
- a whole-map route that **ANSWERED** (a client expressing deny-all as `{}`) is **never** overruled — the panel decides the licence with the same `noBackendAnswerEstablished` test #1223's snapshot is licensed on, in the same statement, and **not one** per-class request is issued;
- a promotion **relinked across the scoped fetch** to a node of a DIFFERENT type resolves outside the covered set → the scope trap throws → refuses, and neither the swapped-in nor the original node is written;
- a **workflow switch** during the scoped read refuses before any mutation — that, not the trap, is what covers the window (see the correction below).

Nothing here decides anything. The route only adds a way to **ask**; every verdict is still made by the existing #458 code on the existing shapes.

### Deliberately NOT widened
- **Never** recorded into the #1223 snapshot (`object-info-snapshot.js` requires an explicit `whole: true` claim precisely so a per-class payload cannot make every other type read as a removed pack) and never filed into the ever-seen history. Asserted by test, and by a source assertion over the wiring block.
- **Does not license the #1126 blind combo write.** Provenance is a new `"scoped"` value that is *not* `"live"`, with its own honest refusal.
- **No new disclosure field on the reply.** #1223 discloses its snapshot authorization because that schema is the backend's PAST word and the caller could not tell it from a live one. A type-scoped read is the server answering NOW — about fewer types, but not staler ones — so the same argument does not apply, and adding a field to the reply shape is its own reviewable change under the freeze.
- **The whole-map attempt still runs first on EVERY call**, so each write on such an install still spends its ~15 s before the scoped read answers. Caching "the whole map does not land on this backend" would remove that, and it would also have to decide when the backend has recovered — a staleness question this change deliberately does not open.
- **`panel_refresh_nodes` is unhelped and still refuses** on such a backend. It re-registers the whole schema — an install-wide question no per-class route can answer. Same for anything that ranges over the install (`registeredSocketTypes`, #821's own example).

## Mutation evidence — 14 mutations, 14 killed

Applied to a **committed** tree and reverted with `git checkout` (baseline 0 failing), over
`set-widget-scoped-object-info`, `set-widget-fresh-backend` and `object-info-snapshot`:

| # | mutation | verdict | a named test it kills |
|---|---|---|---|
| M1 | delete the FIX — the scoped fallback never runs | KILLED (8) | `#1560 A: whole /object_info never lands, per-class answers ⇒ a DIRECT write is authorized` |
| M2 | delete the **CALL SITE** — the panel stops wiring the capability | KILLED (1) | `#1560: the panel WIRES the scoped route…` |
| M3 | drop the silence-licence **gate** | KILLED (1) | `#1560: the panel WIRES the scoped route…` |
| M4 | scope trap off — an unfetched type reads as ABSENT (#716/#821 reopened) | KILLED (3) | `#1560: a type OUTSIDE the covered set THROWS rather than reading as absent (#716/#821)` |
| M5 | drop ALL-OR-NOTHING | KILLED (3) | `#1560 B: ALL-OR-NOTHING — one indefinite answer inside a PROMOTED set refuses the whole write` |
| M6 | `scopedAuthorizationTypes` asks about the CONCRETE type only | KILLED (7) | `#1560 A: … a DIRECT write is authorized` |
| M7 | `scopedAuthorizationTypes` forgets the INTERMEDIATES | KILLED (3) | `#1560 A: a PROMOTED nested write asks about ALL THREE types` |
| M8 | `{}`/200 reads as PRESENT instead of definitively absent | KILLED (3) | `#1560 B: a REMOVED type … still FAILS CLOSED (#458 unchanged)` |
| M9 | a NON-200 per-class reply treated as a definitive absence | KILLED (3) | `#1560 B: a NON-200 per-class reply establishes nothing and refuses` |
| M10 | the brand answered by a TRAP on a non-extensible target | KILLED (1) | `#1560: the scoped map is a well-behaved object…` |
| M11 | a non-positive budget falls back to the default instead of attempting nothing | KILLED (1) | `#1560: a NON-POSITIVE budget attempts NOTHING — it must never become NO bound` |
| M12 | the class name reaches the refusal unsanitized | KILLED (1) | `#1560: a hostile class name is FLATTENED…` |
| M13 | the licence **decision** always says yes | KILLED (3) | `#1560 SHIPPED: a client ANSWERING deny-all {} licenses NOTHING — it is never overruled` |
| M14 | the licence **decision line** is deleted | KILLED (2) | `#1560 SHIPPED: hung probes LICENSE the type-scoped read…` |

M13 and M14 run through the SHIPPED `readObjectInfo` body — the #1223 suite extracts it from
the panel and evals it — so the licence has a behavioural kill, not only a source assertion.

Two things the harness itself had to be corrected for, and both are worth knowing:

- **CRLF.** The sources are CRLF; matching an LF-joined anchor against them fails silently,
  and M6/M7 first reported "MUTATION DID NOT APPLY". A mutation that never applied reads
  exactly like one that survived.
- **node:test counts a TIMED-OUT test as CANCELLED, not failed.** M11 removes the bound, so
  `withTimeout` treats the 0 as no bound and the hanging fetch never settles — the runner
  reported `fail 0` while listing the test under "failing tests" and exiting non-zero, and the
  harness called a real kill a SURVIVOR. The test now carries an explicit 15 s bound so it
  fails by name, and the harness counts cancellations.

## Suites

- `npm run test:unit` (i18n × 2, tool-vocabulary, panel-scope, `node --test`): **6143 tests / 6142 pass / 0 fail / 1 todo** — baseline on clean `origin/main` was **6116 / 0 fail**, so +27 new and nothing pre-existing disturbed.
- Playwright — see the comparison table appended below.

## Comment standard

`object-info-oracle.js`'s header foreclosed this fix, so it is updated rather than left standing: it now records what #1560 measured, which half of the original paragraph is still load-bearing, and — explicitly — **what remains a trade** (the scoped map is genuinely partial; it cannot answer an install-wide question, which is why it never reaches the snapshot, the history or the blind write, and why the honest fix is still a whole `/object_info` that lands). `object-info-cache.js` carries the same qualification for its own copy of the claim.

---

## Playwright — measured against a clean `origin/main`, not asserted

The panel is served to the browser from ComfyUI's `custom_nodes`, so running the suite from a worktree proves nothing unless ComfyUI is actually serving that worktree. I did **not** repoint the shared junction (another agent uses it). Instead, two isolated stacks:

| | fix tree | baseline |
|---|---|---|
| ComfyUI | `--base-directory .../ap-1560-cc --port 8288 --enable-cors-header --cpu` | `.../ap-1560-base --port 8388` |
| custom_nodes | junction → `wt-1560-cc` (this branch) | junction → detached `origin/main` @ `75728263` |
| served panel contains `fetchScopedObjectInfo` | **yes** (verified over HTTP) | **no** (verified over HTTP) |
| `npx playwright test --workers=1` | **19 failed / 62 passed (7.9 m)**, re-run on the final head **18 failed / 63 passed (7.8 m)** | **19 failed / 62 passed (7.7 m)** |

The first run's failure set is **byte-identical** to the baseline's; the re-run on the final head is a strict SUBSET of it (18 of the same 19 — `agent-drive.spec.ts:113:7` passed that time, so it is flaky in the baseline direction). **Zero new failures in either.** They are — `diff` of the 19 `file:line:col` locations is empty. Pre-existing, and matching the ~19 the brief describes: 7 `conversation-persistence`, 4 `workflow-chat-identity`, 3 `chat-history-v2`, and one each of `agent-drive`, `external-orchestrator`, `hidden-tab`, `pending-queue`, `streaming-render` — storage/IndexedDB and streaming, none of them near this fence. **No assertion was loosened and no spec was skipped.**

Both instances were freshly created for this run and are junctioned to worktrees, so nothing was written into the developer's own ComfyUI or its `custom_nodes`.

**Coverage I do NOT have:** no e2e spec exercises the `/object_info` write fence (it needs a backend whose whole map hangs while per-class answers). That behaviour is covered by the node-test reproduction driving the real oracle, cache, snapshot and `runSetWidget` — not by the browser suite.

## Self-review found four defects before review did

Recorded because three of them were only visible by running it:

1. A `has`/`get` **trap** answering for the `SCOPED_OBJECT_INFO` brand is a **Proxy invariant violation** once the target is non-extensible — `SCOPED_OBJECT_INFO in defs` threw `TypeError` out of a module whose job is to answer. The brand moved onto the target, before the freeze.
2. A **non-positive `deadlineMs`** took the shipped 5 000 ms default. `withTimeout` treats `ms <= 0` as **no bound**, so an exhausted budget would have removed the bound at exactly the moment the command had already run out — the #1161 signature arriving through the mechanism meant to prevent it. It now attempts nothing and issues nothing. (`budget.bounded` floors at 1 ms, so the panel never reached this arm; a direct caller could.)
3. The refusal interpolated a class name **straight off the graph** — a newline in a node type could forge structure in a message someone reads. Flattened and capped now.
4. The **silence licence** was stored as a tag list and re-tested at the gate — a second reading of a fact established at a moment, in a handler that enters the reader more than once. It is now decided in the same statement as `objectInfoSnapshot.authorize`, from the same `outcome.outcomes`, and merely read at the gate.

M10-M12 were added to the mutation harness for the first three; M13/M14 plus four behavioural tests through the SHIPPED readObjectInfo body pin the fourth.

## One correction I had to make to my own claim

The first version of the note above said the await this fallback adds is "guarded by the same trap". That is half true, and the false half is the load-bearing one:

- the trap catches a relink that resolves deeper to a concrete node of a **DIFFERENT** type — an uncovered type throws;
- a relink to a node of the **SAME** type asks a question the map CAN answer, so nothing throws.

That is not a hole. `authTarget` and every guard are still computed AFTER the await, exactly as they are after the whole-map fetch today; what is genuinely older is `promotedResolution`, so the IMMEDIATE write target can predate one more await. The cost is a stale-TARGET hazard — never a fail-open of the #458 fence, since whatever is written is still registry-checked, still type-authorized against a live backend, and still workflow-fenced with no await after the check. The window is the scoped read alone: 1.2 ms/class on this repo's own rig (#767), 15 ms in the reproduction, on a path whose alternative is a refusal that never succeeds.

The header now states which shape the trap covers and which it does not, and the prose guarantee was replaced by two checked ones — a workflow switch during the scoped read still refuses before any mutation, and the header is asserted to state the non-guarantee rather than imply the opposite.
