### PR TITLE
fix(1562): panel_refresh_nodes spends the window it holds, and stops blaming a server it never saw fail

### DIFF
--- a/browser_tests/unit/_panel-constants.mjs
+++ b/browser_tests/unit/_panel-constants.mjs
@@ -89,6 +89,12 @@ export const REFRESH_NODES_EXECUTOR_DEPS = Object.freeze({
   REFRESH_JOIN_ABANDONED,
   NODE_DEF_REFRESH_REASONS,
   REFRESH_NODES_COMMAND_BUDGET_MS,
+  // #1562 — the RUN allowance the executor now hands the coalescer. Adding it here is what
+  // keeps the three harnesses that rebuild `refresh_nodes` working; leaving it out throws
+  // ReferenceError in all three at once, which is the signal this collection exists for.
+  get REFRESH_NODES_RUN_BUDGET_MS() {
+    return REFRESH_NODES_RUN_BUDGET_MS;
+  },
 });
 
 /** #1413 — the whole-command deadline `graph_set_widget` takes on its first line. */
@@ -118,6 +124,34 @@ export const NODE_DEFS_FETCH_SHARE = (() => {
   const m = PANEL_SRC.match(/const NODE_DEFS_FETCH_SHARE = (\d+) \/ (\d+);/);
   if (!m) throw new Error("the panel no longer states NODE_DEFS_FETCH_SHARE as a ratio");
   return Number(m[1]) / Number(m[2]);
+})();
+
+/**
+ * #1562 — the run budget `refresh_nodes` derives, EVALUATED FROM THE PANEL'S OWN
+ * EXPRESSION.
+ *
+ * Not `readPanelNumber`: the panel does not state a literal, it states a derivation
+ * (`REFRESH_NODES_COMMAND_BUDGET_MS / NODE_DEFS_FETCH_SHARE`), and the property the tests
+ * assert is about that derivation. Restating it here would make the harness agree with
+ * itself — the exact trap this file's header records — so the expression is lifted out of
+ * the source and evaluated against the two inputs, both of which are themselves read from
+ * the panel.
+ */
+export const REFRESH_NODES_RUN_BUDGET_MS = (() => {
+  const m = PANEL_SRC.match(/const REFRESH_NODES_RUN_BUDGET_MS = ([^;]*);/);
+  if (!m) {
+    throw new Error("REFRESH_NODES_RUN_BUDGET_MS is no longer findable in the panel source");
+  }
+  // eslint-disable-next-line no-new-func
+  const value = new Function(
+    "REFRESH_NODES_COMMAND_BUDGET_MS",
+    "NODE_DEFS_FETCH_SHARE",
+    `return ${m[1]};`,
+  )(REFRESH_NODES_COMMAND_BUDGET_MS, NODE_DEFS_FETCH_SHARE);
+  if (!Number.isFinite(value) || value <= 0) {
+    throw new Error(`the panel's REFRESH_NODES_RUN_BUDGET_MS expression evaluated to ${value}`);
+  }
+  return value;
 })();
 
 /**

--- a/browser_tests/unit/node-def-refresh.test.mjs
+++ b/browser_tests/unit/node-def-refresh.test.mjs
@@ -16,7 +16,7 @@ import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 import { fetchNodeDefsWithRetry, OBJECT_INFO_RETRY_DELAYS_MS } from "../../web/js/lib/object-info-retry.js";
 import { withTimeout } from "../../web/js/lib/bounded-step.js";
-import { fetchWholeObjectInfo } from "../../web/js/lib/object-info-oracle.js";
+import { fetchWholeObjectInfo, TRANSPORT_OUTCOME } from "../../web/js/lib/object-info-oracle.js";
 
 // #1180 — READ from the panel, never restated. Shared with the other harnesses that
 // rebuild shipped functions, so one copy of a constant cannot drift from another.
@@ -448,6 +448,10 @@ function buildRegisterComfyNodeDefs({
     // body throws ReferenceError without them.
     "objectInfoSnapshot",
     "backendReconnectEpoch",
+    // #1562 — the oracle's per-route OUTCOME vocabulary. The fetch phase reads route 2's
+    // ending from the TAG rather than from its sentence (#1223), so the extracted body
+    // throws ReferenceError without it.
+    "TRANSPORT_OUTCOME",
     `// #1180 — defined HERE, from the api this scope already has, so each factory site
      // gets its own stub without threading a helper through every call.
      const boundedGetNodeDefs = async (ms = NODE_DEFS_FETCH_TIMEOUT_MS) => {
@@ -501,6 +505,7 @@ function buildRegisterComfyNodeDefs({
     // re-records only a payload it fetched itself.
     snapshotSpy,
     7,
+    TRANSPORT_OUTCOME,
   );
 }
 
@@ -1790,4 +1795,77 @@ test("#608: the no-payload guard is keyed on defsObtained, not on the phase name
   });
   assert.equal(fetchFailed.reason, "object_info_fetch_failed");
   assert.match(fetchFailed.detail, /Failed to fetch/);
+});
+
+// ---------------------------------------------------------------------------
+// #1562 — an ABANDONED route is not a FAILED one, and the remedy must not confuse them.
+//
+// The reporter's `GET /object_info` returned 25,104,088 bytes in 20.84 s from a ComfyUI
+// that was up throughout, while this verdict told them to "check that the ComfyUI server
+// process is still running". Every route had been abandoned at its bound; not one of them
+// had failed. These drive the SHIPPED run — the real oracle on injected timers — because
+// the distinction is made inside the fetch phase from the oracle's TAGS, and a test of
+// `describeNodeDefRefresh` alone cannot see whether the panel computes the input correctly.
+// ---------------------------------------------------------------------------
+
+/** Run the shipped register with the real oracle on virtual timers, and settle it. */
+async function runWithHangingRoutes(apiValue) {
+  const timers = virtualTimers();
+  const { registerComfyNodeDefs } = buildRegisterComfyNodeDefs({
+    appValue: FULL_APP,
+    apiValue,
+    timers,
+    fetchWholeObjectInfo: (opts) => fetchWholeObjectInfo({ ...opts, timers }),
+  });
+  const running = registerComfyNodeDefs(undefined);
+  await drainMicrotasks(300);
+  for (let i = 0; i < 8; i += 1) {
+    timers.fireAll();
+    await drainMicrotasks(200);
+  }
+  return orFail(running, "the run never settled");
+}
+
+test("#1562: BOTH whole-document routes abandoned at their bound is not reported as a dead server", async () => {
+  const verdict = await runWithHangingRoutes({
+    getNodeDefs: () => new Promise(() => {}), // bounded → abandoned, never failed
+    fetchApi: () => new Promise(() => {}), // the oracle's NO_ANSWER, same shape
+  });
+  assert.equal(verdict.refreshed, false);
+  assert.equal(verdict.reason, "object_info_fetch_failed");
+  assert.doesNotMatch(
+    verdict.remedy,
+    /check that the ComfyUI server process is still running/,
+    "nothing here established that the server is down — both routes merely ran out of time",
+  );
+  assert.match(verdict.remedy, /ABANDONED AT ITS BOUND/);
+  assert.match(verdict.remedy, /plain retry meets the same bound/);
+  assert.match(verdict.remedy, /Tried 2 routes/, "…and #608's evidence clause survives");
+});
+
+test("#1562: a route that genuinely FAILED outranks the other's silence", async () => {
+  // Route 1 fails for real while route 2 is merely slow. That IS evidence about the
+  // server, so the old remedy is the right one and the new branch must not fire.
+  const verdict = await runWithHangingRoutes({
+    getNodeDefs: async () => {
+      throw new TypeError("Failed to fetch");
+    },
+    fetchApi: () => new Promise(() => {}),
+  });
+  assert.equal(verdict.reason, "object_info_fetch_failed");
+  assert.match(verdict.remedy, /check that the ComfyUI server process is still running/);
+  assert.doesNotMatch(verdict.remedy, /ABANDONED AT ITS BOUND/);
+});
+
+test("#1562: a route that ANSWERED unusably outranks the other's silence too", async () => {
+  // Route 1 is abandoned, route 2 answers 500. A server that answers is a server that is
+  // up, but it did not answer THIS question — and "answered badly" is not "ran out of
+  // time", so the abandonment finding must not be claimed.
+  const verdict = await runWithHangingRoutes({
+    getNodeDefs: () => new Promise(() => {}),
+    fetchApi: async () => ({ ok: false, status: 500, json: async () => ({}) }),
+  });
+  assert.equal(verdict.reason, "object_info_fetch_failed");
+  assert.doesNotMatch(verdict.remedy, /ABANDONED AT ITS BOUND/);
+  assert.match(verdict.remedy, /GET \/object_info was not OK \(status 500\)/);
 });

--- a/browser_tests/unit/node-def-refresh.test.mjs
+++ b/browser_tests/unit/node-def-refresh.test.mjs
@@ -1869,3 +1869,40 @@ test("#1562: a route that ANSWERED unusably outranks the other's silence too", a
   assert.doesNotMatch(verdict.remedy, /ABANDONED AT ITS BOUND/);
   assert.match(verdict.remedy, /GET \/object_info was not OK \(status 500\)/);
 });
+
+test("#1562: a real failure EARLIER in route 1's retry loop outranks the stall that ended it", async () => {
+  // THE SEQUENCE A POST-RESTART REFRESH ACTUALLY MEETS, and the one the first version of
+  // this branch got wrong. ComfyUI is genuinely down when attempt 1 runs (`Failed to
+  // fetch`, connection refused); by the retry it has bound the port but is still importing
+  // packs, so attempt 2 stalls past its bound and the loop ends with BOTH flags set —
+  // `sawRealError` AND `lastAttemptTimedOut`. The loop already ranks these ("A REAL ERROR
+  // OUTRANKS A SYNTHESIZED TIMEOUT": it rethrows `lastRealError`, not the stall), and the
+  // classification has to rank them the same way. Reading that ending as an abandonment
+  // produced a verdict headed "none of them FAILED" whose own evidence clause read
+  // "api.getNodeDefs() failed: Failed to fetch", and told a reader whose backend was still
+  // booting that a plain retry would not help — which is the one thing that does help there.
+  let attempt = 0;
+  const verdict = await runWithHangingRoutes({
+    getNodeDefs: async () => {
+      attempt += 1;
+      if (attempt === 1) throw new TypeError("Failed to fetch");
+      return new Promise(() => {}); // bounded → NODE_DEFS_NO_ANSWER on the retry
+    },
+    fetchApi: () => new Promise(() => {}), // route 2 merely stalls
+  });
+  assert.ok(attempt >= 2, `the retry loop must have run twice for this to be the case under test (ran ${attempt})`);
+  assert.equal(verdict.reason, "object_info_fetch_failed");
+  assert.match(
+    verdict.remedy,
+    /check that the ComfyUI server process is still running/,
+    "route 1 FAILED for real before it stalled, so the remedy that names a possibly-down " +
+      "server is the correct one — and a plain retry is what fixes a booting backend",
+  );
+  assert.doesNotMatch(
+    verdict.remedy,
+    /ABANDONED AT ITS BOUND/,
+    "a route that failed and then stalled did not merely run out of time",
+  );
+  // The self-contradiction this guards: the heading and the evidence clause disagreeing.
+  assert.match(verdict.remedy, /Failed to fetch/, "#608's evidence clause still names what route 1 did");
+});

--- a/browser_tests/unit/node-def-refresh.test.mjs
+++ b/browser_tests/unit/node-def-refresh.test.mjs
@@ -27,6 +27,7 @@ import {
   NODE_DEFS_FETCH_TIMEOUT_MS,
   NODE_DEFS_NO_ANSWER,
   NODE_DEFS_RUN_BUDGET_MS,
+  REFRESH_NODES_RUN_BUDGET_MS,
   REFRESH_NODES_EXECUTOR_DEPS,
   monotonicNow,
   nodeDefsBudgetLeft,
@@ -1905,4 +1906,85 @@ test("#1562: a real failure EARLIER in route 1's retry loop outranks the stall t
   );
   // The self-contradiction this guards: the heading and the evidence clause disagreeing.
   assert.match(verdict.remedy, /Failed to fetch/, "#608's evidence clause still names what route 1 did");
+});
+
+// ---------------------------------------------------------------------------
+// #1562 round 2 — THE LARGER BUDGET IS THE FETCH PHASE'S, NOT THE WHOLE RUN'S.
+//
+// `panel_refresh_nodes` hands the run 37,500 ms so the whole `/object_info` can land, and
+// this phase's bound is `what is left of the run`. Uncapped, that lets a run whose fetch was
+// FAST and whose `refreshComboInNodes()` merely hangs live for 37.5 s — past the 25 s JOIN
+// its own command holds — so a `panel_refresh_nodes` that used to answer `refreshed:true`
+// (with #1193's `combo_refresh_confirmed:false` disclosure) answers `refresh_still_running`
+// instead. A case that worked, broken by the fix for a case that did not.
+// ---------------------------------------------------------------------------
+
+/** Run with a STATED run budget and a combo call that never answers. */
+async function runWithStatedBudgetAndHangingCombo({ sweep }) {
+  const timers = virtualTimers();
+  const { registerComfyNodeDefs } = buildRegisterComfyNodeDefs({
+    appValue: APP_WITH_GRAPH, // its refreshComboInNodes() never settles
+    apiValue: { getNodeDefs: async () => ({ SomeNode: {} }) }, // a FAST fetch
+    timers,
+    reapplyDefsToLiveNodes: sweep,
+  });
+  const running = registerComfyNodeDefs(undefined, { runBudgetMs: REFRESH_NODES_RUN_BUDGET_MS });
+  await drainMicrotasks();
+  timers.fireAll();
+  return orFail(running, "the combo phase never gave up");
+}
+
+test("#1562: a stated run budget does NOT extend the combo phase past a run's default allowance", async () => {
+  const verdict = await runWithStatedBudgetAndHangingCombo({ sweep: sweepThatStopsPartWay() });
+  assert.equal(verdict.reason, "combo_refresh_failed");
+  const bound = Number(verdict.detail.match(/did not answer within the (\d+)ms/)?.[1]);
+  assert.ok(Number.isFinite(bound), `the refusal must still name its bound: ${verdict.detail}`);
+  assert.ok(
+    bound <= NODE_DEFS_RUN_BUDGET_MS,
+    `the combo phase was given ${bound}ms out of a stated ${REFRESH_NODES_RUN_BUDGET_MS}ms run. ` +
+      `It may never exceed ${NODE_DEFS_RUN_BUDGET_MS}ms — the whole allowance a run had before a ` +
+      "caller could state one — because this phase's bound decides how long the RUN lives, and a " +
+      "run that outlives its command's 25s join turns a refreshed:true into refresh_still_running",
+  );
+});
+
+test("#1562: the abandoned-combo refusal names the run's OWN budget, not the default constant", async () => {
+  const verdict = await runWithStatedBudgetAndHangingCombo({ sweep: sweepThatStopsPartWay() });
+  assert.match(
+    verdict.detail,
+    new RegExp(`${REFRESH_NODES_RUN_BUDGET_MS}ms budget`),
+    "the sentence quotes the budget THIS run was given; quoting the default produced an " +
+      "arithmetically impossible refusal — \"the 37500ms this refresh had left of its 9000ms budget\"",
+  );
+  assert.doesNotMatch(
+    verdict.detail,
+    new RegExp(`left of its ${NODE_DEFS_RUN_BUDGET_MS}ms budget`),
+    "…and it must not describe a 37,500ms run as a 9,000ms one",
+  );
+  // The three cases stay distinguishable (#1193's requirement): starved by a slow fetch,
+  // handed the whole budget and hung anyway, and — new — holding the phase ceiling while the
+  // run still had time. Only the third says "capped".
+  assert.match(verdict.detail, /capped at \(this refresh had \d+ms left of its \d+ms budget\)/);
+});
+
+test("#1562: a caller that states NO budget keeps the combo phase's wording byte-identical", async () => {
+  // The `Math.min` must be a no-op for every existing caller: what is left of a 9,000ms run
+  // is never more than 9,000ms, so nothing about the default path may read differently.
+  const timers = virtualTimers();
+  const { registerComfyNodeDefs } = buildRegisterComfyNodeDefs({
+    appValue: APP_WITH_GRAPH,
+    apiValue: { getNodeDefs: async () => ({ SomeNode: {} }) },
+    timers,
+    reapplyDefsToLiveNodes: sweepThatStopsPartWay(),
+  });
+  const running = registerComfyNodeDefs(undefined);
+  await drainMicrotasks();
+  timers.fireAll();
+  const verdict = await orFail(running, "the combo phase never gave up");
+  assert.match(
+    verdict.detail,
+    new RegExp(`did not answer within the \\d+ms this refresh had left of its ${NODE_DEFS_RUN_BUDGET_MS}ms budget`),
+    "the pre-existing sentence, unchanged — the cap never bites on a default run",
+  );
+  assert.doesNotMatch(verdict.detail, /capped/);
 });

--- a/browser_tests/unit/refresh-nodes-command-budget.test.mjs
+++ b/browser_tests/unit/refresh-nodes-command-budget.test.mjs
@@ -323,9 +323,15 @@ test("#1404: the shipped call site passes the budget — the helper alone cannot
   // whole of #1404 was that this one call site never passed it. A behavioural test drives the
   // extracted body, so it already covers the wiring — this is the same fact asserted where a
   // reviewer reading the diff will look for it, on the SOURCE.
+  // #1562 — the same shape, now with the RUN allowance beside the JOIN. The two are
+  // different quantities and both belong here: `joinMs` is how long this command WAITS,
+  // `runBudgetMs` is how long the run it starts may SPEND, and a run that gives up first
+  // makes the retryable `refresh_still_running` verdict below unreachable. The comment
+  // between them is skipped by `[\s\S]*?`, deliberately — pinning prose is not the point —
+  // but BOTH options are required by name.
   assert.match(
     refreshNodesMatch[0],
-    /refreshComfyNodeDefs\(undefined, \{\s*force: true,\s*joinMs: REFRESH_NODES_COMMAND_BUDGET_MS,\s*\}\)/,
-    "refresh_nodes must bound its own wait on the coalescer",
+    /refreshComfyNodeDefs\(undefined, \{[\s\S]*?force: true,[\s\S]*?joinMs: REFRESH_NODES_COMMAND_BUDGET_MS,[\s\S]*?runBudgetMs: REFRESH_NODES_RUN_BUDGET_MS,\s*\}\)/,
+    "refresh_nodes must bound its own wait on the coalescer AND state the run's allowance",
   );
 });

--- a/browser_tests/unit/refresh-nodes-run-budget.test.mjs
+++ b/browser_tests/unit/refresh-nodes-run-budget.test.mjs
@@ -1,0 +1,312 @@
+// panel#1562 — `panel_refresh_nodes` could never succeed on an install whose whole
+// `/object_info` takes longer than 9 s to deliver, and said so in words that blamed a
+// server which was up the whole time.
+//
+// The reporter measured `GET /object_info` at 25,104,088 bytes / 20.84 s while
+// `/system_stats` and `/object_info/<Type>` both answered instantly. Every call returned
+// `refreshed:false, reason:object_info_fetch_failed, "GET /object_info did not answer
+// within its 1499ms share of the 2999ms budget"` — against a command whose own window is
+// 25,000 ms.
+//
+// THE TWO BUDGETS WERE THE WRONG WAY ROUND. `joinMs` (REFRESH_NODES_COMMAND_BUDGET_MS,
+// 25,000) is how long the command WAITS; `NODE_DEFS_RUN_BUDGET_MS` (9,000) is how long the
+// run it starts may SPEND, and it is sized for a refresh that happens as a SUB-STEP of
+// `graph_add_node`. Because the run's allowance was the smaller of the two, the run always
+// died first — so `REFRESH_JOIN_ABANDONED` / `refresh_still_running`, the retryable verdict
+// #1404 built for exactly "a big install ... without any concurrency at all", was
+// STRUCTURALLY UNREACHABLE on the installs it was written for. The caller got a hard
+// failure instead, which tears the run down, so each retry started another doomed run.
+//
+// Measured against a REAL 25,000,581-byte `/object_info` served in 20.80 s, driving the
+// SHIPPED fetch phase (real `boundedGetNodeDefs`, real retry loop, real oracle):
+//
+//     run budget   route 1 bound   whole-document GETs   outcome
+//      9,000 ms       6,000 ms            2              FAILED at 7.5 s — reported sentence
+//     25,000 ms      16,666 ms            2              STILL FAILED at 20.9 s
+//     32,000 ms      21,333 ms            1              20,020 types at 20.86 s
+//     37,500 ms      25,000 ms            1              20,020 types at 20.98 s
+//
+// The 25,000 row is why the fix is not "hand the run the command's window": the FETCH
+// SHARE is two thirds of whatever the run gets, and two thirds of the window is not the
+// window. Hence the derivation these tests pin.
+//
+// WHAT THESE TESTS DRIVE. The call site, through the SHIPPED `refresh_nodes` body extracted
+// from the panel source over the REAL coalescer — the technique #1404 established, and for
+// its reason: the coalescer already forwards what it is given and `registerComfyNodeDefs`
+// already honours what it receives, so the whole defect is a call site that passed nothing.
+// Only an assertion on that call site can see it.
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { withTimeout } from "../../web/js/lib/bounded-step.js";
+import { makeRefreshCoalescer } from "../../web/js/lib/refresh-coalesce.js";
+import { describeNodeDefRefresh, NODE_DEF_REFRESH_REASONS } from "../../web/js/lib/node-def-refresh.js";
+import {
+  PANEL_SRC,
+  REFRESH_NODES_COMMAND_BUDGET_MS,
+  REFRESH_NODES_RUN_BUDGET_MS,
+  REFRESH_NODES_EXECUTOR_DEPS,
+  NODE_DEFS_FETCH_SHARE,
+  NODE_DEFS_RUN_BUDGET_MS,
+} from "./_panel-constants.mjs";
+
+const refreshNodesMatch = PANEL_SRC.match(/\n {2}async refresh_nodes\(\) \{[\s\S]*?\n {2}\},/);
+assert.ok(refreshNodesMatch, "could not locate refresh_nodes in panel source");
+
+/**
+ * Build the SHIPPED `refresh_nodes` over the REAL coalescer, recording what each run was
+ * actually started with.
+ */
+function realRefreshNodes({ verdict = { refreshed: true, reason: "refreshed" } } = {}) {
+  let inFlight = null;
+  const runOptsSeen = [];
+  const refreshComfyNodeDefs = makeRefreshCoalescer({
+    getInFlight: () => inFlight,
+    setInFlight: (p) => {
+      inFlight = p;
+    },
+    // The SECOND parameter is the thing under test: `registerComfyNodeDefs(preloadedDefs,
+    // runOpts)`. A coalescer that drops it, or a call site that never sets it, arrives here
+    // as `undefined`.
+    runRegister: async (_preloadedDefs, runOpts) => {
+      runOptsSeen.push(runOpts);
+      return verdict;
+    },
+    withTimeout,
+  });
+  const deps = { refreshComfyNodeDefs, ...REFRESH_NODES_EXECUTOR_DEPS };
+  const names = Object.keys(deps);
+  const factory = new Function(
+    ...names,
+    `const executors = {${refreshNodesMatch[0]}};
+     return executors.refresh_nodes;`,
+  );
+  return { refresh_nodes: factory(...names.map((n) => deps[n])), runOptsSeen };
+}
+
+// ---------------------------------------------------------------------------
+// 1. THE CALL SITE
+// ---------------------------------------------------------------------------
+
+test("#1562: refresh_nodes hands the RUN its own allowance, not just the join", async () => {
+  const built = realRefreshNodes();
+  const reply = await built.refresh_nodes();
+  assert.equal(reply.refreshed, true);
+  assert.equal(
+    built.runOptsSeen.length,
+    1,
+    "the tool call must start exactly one run",
+  );
+  assert.equal(
+    built.runOptsSeen[0]?.runBudgetMs,
+    REFRESH_NODES_RUN_BUDGET_MS,
+    "refresh_nodes must pass runBudgetMs — without it the run keeps the 9,000 ms default " +
+      "sized for a SUB-STEP refresh, dies before the 25,000 ms join can abandon, and the " +
+      "retryable refresh_still_running verdict is unreachable",
+  );
+});
+
+// ---------------------------------------------------------------------------
+// 2. THE DERIVATION — the property, not the number
+// ---------------------------------------------------------------------------
+
+test("#1562: the run's FETCH SHARE alone covers everything the command will wait for", () => {
+  // This is the whole point. A run budget merely "bigger than 9,000" is not enough: on the
+  // reporter's install a 25,000 ms run budget still failed, because route 1 is capped at
+  // NODE_DEFS_FETCH_SHARE of it. The property below is what made 32,000 and 37,500 work and
+  // 25,000 not, so it — and not the literal — is what is asserted.
+  assert.ok(
+    REFRESH_NODES_RUN_BUDGET_MS * NODE_DEFS_FETCH_SHARE >= REFRESH_NODES_COMMAND_BUDGET_MS,
+    `the fetch phase gets ${Math.floor(REFRESH_NODES_RUN_BUDGET_MS * NODE_DEFS_FETCH_SHARE)}ms ` +
+      `of the ${REFRESH_NODES_RUN_BUDGET_MS}ms run, which is less than the ` +
+      `${REFRESH_NODES_COMMAND_BUDGET_MS}ms this command is willing to wait — so a document ` +
+      "that WOULD have arrived inside the window is abandoned before it does",
+  );
+});
+
+test("#1562: the run allowance is strictly longer than the wait it must outlast", () => {
+  assert.ok(
+    REFRESH_NODES_RUN_BUDGET_MS > REFRESH_NODES_COMMAND_BUDGET_MS,
+    "the run must outlast the join, or the run is what ends the command and the caller is " +
+      "told a hard failure where refresh_still_running is the true answer",
+  );
+  assert.ok(
+    REFRESH_NODES_RUN_BUDGET_MS > NODE_DEFS_RUN_BUDGET_MS,
+    "…and it must actually differ from the sub-step default it replaces",
+  );
+});
+
+// ---------------------------------------------------------------------------
+// 3. THE COALESCER FORWARDS IT — on every path that can start a run
+// ---------------------------------------------------------------------------
+
+function coalescerRecorder() {
+  let inFlight = null;
+  const seen = [];
+  let release;
+  const held = new Promise((r) => (release = r));
+  const refresh = makeRefreshCoalescer({
+    getInFlight: () => inFlight,
+    setInFlight: (p) => {
+      inFlight = p;
+    },
+    runRegister: async (preloadedDefs, runOpts) => {
+      seen.push({ preloadedDefs, runOpts });
+      if (seen.length === 1) await held;
+      return { refreshed: true };
+    },
+    withTimeout,
+  });
+  return { refresh, seen, release };
+}
+
+test("#1562: the coalescer forwards runBudgetMs on the NOTHING-IN-FLIGHT path", async () => {
+  const { refresh, seen, release } = coalescerRecorder();
+  release();
+  await refresh(undefined, { force: true, joinMs: 500, runBudgetMs: 4242 });
+  assert.equal(seen[0]?.runOpts?.runBudgetMs, 4242);
+});
+
+test("#1562: the coalescer forwards runBudgetMs on the PAYLOAD path", async () => {
+  const { refresh, seen, release } = coalescerRecorder();
+  const first = refresh(undefined, { force: true, joinMs: 5000, runBudgetMs: 1 });
+  release();
+  await first;
+  await refresh({ SomeNode: {} }, { joinMs: 5000, runBudgetMs: 4243 });
+  assert.equal(seen.at(-1)?.runOpts?.runBudgetMs, 4243);
+});
+
+test("#1562: the coalescer forwards runBudgetMs on the TRAILING (forced) path", async () => {
+  const { refresh, seen, release } = coalescerRecorder();
+  const first = refresh(undefined, { force: true, joinMs: 5000, runBudgetMs: 1 });
+  const trailing = refresh(undefined, { force: true, joinMs: 5000, runBudgetMs: 4244 });
+  release();
+  await first;
+  await trailing;
+  assert.equal(
+    seen.at(-1)?.runOpts?.runBudgetMs,
+    4244,
+    "the trailing run keeps the allowance of the caller that QUEUED it",
+  );
+});
+
+test("#1562: a caller that states NO run budget still gets undefined, not a fabricated one", async () => {
+  const { refresh, seen, release } = coalescerRecorder();
+  release();
+  await refresh(undefined, { force: true, joinMs: 500 });
+  assert.equal(
+    seen[0]?.runOpts,
+    undefined,
+    "the coordinator must forward, never invent — every check of the value belongs in the run",
+  );
+});
+
+// ---------------------------------------------------------------------------
+// 4. THE RUN HONOURS IT — the deadline arithmetic, as the panel writes it
+// ---------------------------------------------------------------------------
+
+/** The panel's own runDeadline expression, lifted rather than restated. */
+const runDeadlineExpr = (() => {
+  const m = PANEL_SRC.match(
+    /let runDeadline =\r?\n\s*monotonicNow\(\) \+\r?\n\s*\(([\s\S]*?)\);\r?\n/,
+  );
+  if (!m) throw new Error("the run deadline is no longer derived where this harness looks");
+  // eslint-disable-next-line no-new-func
+  return new Function("runOpts", "NODE_DEFS_RUN_BUDGET_MS", `return (${m[1]});`);
+})();
+
+test("#1562: a stated run budget is used; anything unusable falls back to the default", () => {
+  assert.equal(runDeadlineExpr({ runBudgetMs: 37500 }, NODE_DEFS_RUN_BUDGET_MS), 37500);
+  for (const bad of [undefined, null, 0, -1, NaN, Infinity, "37500", {}]) {
+    assert.equal(
+      runDeadlineExpr({ runBudgetMs: bad }, NODE_DEFS_RUN_BUDGET_MS),
+      NODE_DEFS_RUN_BUDGET_MS,
+      `runBudgetMs=${String(bad)} must not become the run's allowance — Infinity/NaN would ` +
+        "restore the unbounded run this deadline exists to prevent, and a non-positive one " +
+        "would start a run with no time at all",
+    );
+  }
+  assert.equal(runDeadlineExpr(undefined, NODE_DEFS_RUN_BUDGET_MS), NODE_DEFS_RUN_BUDGET_MS);
+});
+
+// ---------------------------------------------------------------------------
+// 5. THE VERDICT STOPS BLAMING A SERVER IT NEVER OBSERVED FAILING
+// ---------------------------------------------------------------------------
+
+const fetchFailure = (extra) =>
+  describeNodeDefRefresh({
+    appAvailable: true,
+    defsObtained: false,
+    defsRegistered: false,
+    comboApiPresent: true,
+    comboRan: false,
+    phase: "fetch",
+    didThrow: true,
+    thrown: new Error("api.getNodeDefs() did not answer within this refresh's remaining budget"),
+    fetchRouteFailures: [
+      "api.getNodeDefs() failed: api.getNodeDefs() did not answer within this refresh's remaining budget",
+      "GET /object_info did not answer within its 1499ms share of the 2999ms budget",
+    ],
+    ...extra,
+  });
+
+test("#1562: every route ABANDONED AT ITS BOUND is not reported as a server that is down", () => {
+  const v = fetchFailure({ fetchAbandonedAtBound: true });
+  assert.equal(v.reason, NODE_DEF_REFRESH_REASONS.OBJECT_INFO_FETCH_FAILED);
+  assert.doesNotMatch(
+    v.remedy,
+    /check that the ComfyUI server process is still running/,
+    "the reporter's server answered 25,104,088 bytes in 20.84 s while this sentence told " +
+      "them to check whether it was running — a remedy for a cause that was never established",
+  );
+  assert.match(v.remedy, /ABANDONED AT ITS BOUND/);
+  assert.match(
+    v.remedy,
+    /plain retry meets the same bound/,
+    "a document that does not fit the window will not fit the next one either",
+  );
+  // The routes are still named — #608's evidence clause is not lost to the new branch.
+  assert.match(v.remedy, /GET \/object_info did not answer/);
+});
+
+test("#1562: a route that genuinely FAILED keeps the old, correct remedy", () => {
+  for (const value of [false, null, undefined]) {
+    const v = fetchFailure(value === undefined ? {} : { fetchAbandonedAtBound: value });
+    assert.match(
+      v.remedy,
+      /check that the ComfyUI server process is still running/,
+      `fetchAbandonedAtBound=${String(value)} must NOT claim the abandonment finding — ` +
+        "null means no whole-document route was reached, and an unestablished fact must " +
+        "fall to the wording that claims less",
+    );
+    assert.doesNotMatch(v.remedy, /ABANDONED AT ITS BOUND/);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// 6. THE PANEL DECIDES IT FROM TAGS, NEVER FROM PROSE (#1223)
+// ---------------------------------------------------------------------------
+
+test("#1562: the fetch phase classifies route endings by TAG, not by message text", () => {
+  const block = PANEL_SRC.slice(
+    PANEL_SRC.indexOf("      let sawRealError = false;"),
+    PANEL_SRC.indexOf("      if (clientRouteThrew) throw clientRouteError;"),
+  );
+  assert.ok(block.length > 0, "the fetch phase moved — update this harness");
+  assert.match(
+    block,
+    /fetchAbandonedAtBound = clientRouteThrew && lastAttemptTimedOut === true;/,
+    "route 1's ending must come from the loop's own timeout flag",
+  );
+  assert.match(
+    block,
+    /o\?\.kind === TRANSPORT_OUTCOME\.NO_ANSWER/,
+    "route 2's ending must come from the oracle's TAG — matching its sentence is the " +
+      "coupling #1223 removed, and it re-breaks the first time a message is reworded",
+  );
+  assert.doesNotMatch(
+    block,
+    /fetchAbandonedAtBound\s*=[^;]*\.(includes|match|test)\(/,
+    "no branch may decide this by reading the failure prose",
+  );
+});

--- a/browser_tests/unit/refresh-nodes-run-budget.test.mjs
+++ b/browser_tests/unit/refresh-nodes-run-budget.test.mjs
@@ -309,8 +309,11 @@ test("#1562: the fetch phase classifies route endings by TAG, not by message tex
   assert.ok(block.length > 0, "the fetch phase moved — update this harness");
   assert.match(
     block,
-    /fetchAbandonedAtBound = clientRouteThrew && lastAttemptTimedOut === true;/,
-    "route 1's ending must come from the loop's own timeout flag",
+    /fetchAbandonedAtBound = clientRouteThrew && lastAttemptTimedOut === true && !sawRealError;/,
+    "route 1's ending must come from the loop's own flags — the timeout AND the real-error " +
+      "flag it already ranks above it. Dropping `!sawRealError` classifies a route that " +
+      "FAILED and then stalled as an abandonment, which is asserted behaviourally in " +
+      "node-def-refresh.test.mjs; this line is what makes the rule readable in one place.",
   );
   assert.match(
     block,

--- a/browser_tests/unit/refresh-nodes-run-budget.test.mjs
+++ b/browser_tests/unit/refresh-nodes-run-budget.test.mjs
@@ -215,13 +215,17 @@ test("#1562: a caller that states NO run budget still gets undefined, not a fabr
 /**
  * The panel's own runDeadline expression, lifted rather than restated.
  *
+ * #1562 round 2 — the allowance is NAMED (`runBudgetMs`) before it becomes a deadline,
+ * because the combo phase's refusal has to quote it; the deadline is then
+ * `monotonicNow() + runBudgetMs`, and this pattern asserts that too.
+ *
  * Built INSIDE the test, not at module scope: a mutation that removes the expression must
  * fail a test BY NAME, and a throw during import fails the whole FILE instead — which
  * counts as a kill and names nothing a reader can act on.
  */
 function runDeadlineExpr() {
   const m = PANEL_SRC.match(
-    /let runDeadline =\r?\n\s*monotonicNow\(\) \+\r?\n\s*\(([\s\S]*?)\);\r?\n/,
+    /const runBudgetMs =\r?\n\s*([\s\S]*?);\r?\n\s*let runDeadline = monotonicNow\(\) \+ runBudgetMs;/,
   );
   assert.ok(m, "the run deadline is no longer derived where this harness looks");
   // eslint-disable-next-line no-new-func

--- a/browser_tests/unit/refresh-nodes-run-budget.test.mjs
+++ b/browser_tests/unit/refresh-nodes-run-budget.test.mjs
@@ -323,4 +323,15 @@ test("#1562: the fetch phase classifies route endings by TAG, not by message tex
     /fetchAbandonedAtBound\s*=[^;]*\.(includes|match|test)\(/,
     "no branch may decide this by reading the failure prose",
   );
+  // A SOURCE assertion, and said to be one. When route 2 ANSWERS, "every route was
+  // abandoned" stops being true — but the run then succeeds, so no fetch-phase refusal is
+  // reachable and no verdict can observe the value. There is nothing to assert
+  // behaviourally; what there is to protect is that the clear does not get dropped, since
+  // a stale `true` left for the next reader is exactly the shape this issue is about.
+  const answered = block.slice(block.indexOf("if (fallbackDefs) {"));
+  assert.match(
+    answered.slice(0, answered.indexOf("} else {")),
+    /fetchAbandonedAtBound = false;/,
+    "a fallback that ANSWERED must clear the abandonment finding rather than leave it set",
+  );
 });

--- a/browser_tests/unit/refresh-nodes-run-budget.test.mjs
+++ b/browser_tests/unit/refresh-nodes-run-budget.test.mjs
@@ -168,11 +168,18 @@ test("#1562: the coalescer forwards runBudgetMs on the NOTHING-IN-FLIGHT path", 
 });
 
 test("#1562: the coalescer forwards runBudgetMs on the PAYLOAD path", async () => {
+  // The payload branch is only reached while a run is ALREADY IN FLIGHT — a payload call
+  // that arrives with the slot empty takes the nothing-in-flight branch instead. Written
+  // the other way first, and the mutation harness caught it: dropping the forward on this
+  // exact branch killed nothing, because the test was never on it.
   const { refresh, seen, release } = coalescerRecorder();
   const first = refresh(undefined, { force: true, joinMs: 5000, runBudgetMs: 1 });
+  const withPayload = refresh({ SomeNode: {} }, { joinMs: 5000, runBudgetMs: 4243 });
   release();
   await first;
-  await refresh({ SomeNode: {} }, { joinMs: 5000, runBudgetMs: 4243 });
+  await withPayload;
+  assert.equal(seen.length, 2, "the payload must run AFTER the in-flight run, not join it");
+  assert.equal(seen.at(-1)?.preloadedDefs?.SomeNode !== undefined, true, "…on the payload branch");
   assert.equal(seen.at(-1)?.runOpts?.runBudgetMs, 4243);
 });
 
@@ -205,28 +212,35 @@ test("#1562: a caller that states NO run budget still gets undefined, not a fabr
 // 4. THE RUN HONOURS IT — the deadline arithmetic, as the panel writes it
 // ---------------------------------------------------------------------------
 
-/** The panel's own runDeadline expression, lifted rather than restated. */
-const runDeadlineExpr = (() => {
+/**
+ * The panel's own runDeadline expression, lifted rather than restated.
+ *
+ * Built INSIDE the test, not at module scope: a mutation that removes the expression must
+ * fail a test BY NAME, and a throw during import fails the whole FILE instead — which
+ * counts as a kill and names nothing a reader can act on.
+ */
+function runDeadlineExpr() {
   const m = PANEL_SRC.match(
     /let runDeadline =\r?\n\s*monotonicNow\(\) \+\r?\n\s*\(([\s\S]*?)\);\r?\n/,
   );
-  if (!m) throw new Error("the run deadline is no longer derived where this harness looks");
+  assert.ok(m, "the run deadline is no longer derived where this harness looks");
   // eslint-disable-next-line no-new-func
   return new Function("runOpts", "NODE_DEFS_RUN_BUDGET_MS", `return (${m[1]});`);
-})();
+}
 
 test("#1562: a stated run budget is used; anything unusable falls back to the default", () => {
-  assert.equal(runDeadlineExpr({ runBudgetMs: 37500 }, NODE_DEFS_RUN_BUDGET_MS), 37500);
+  const deadline = runDeadlineExpr();
+  assert.equal(deadline({ runBudgetMs: 37500 }, NODE_DEFS_RUN_BUDGET_MS), 37500);
   for (const bad of [undefined, null, 0, -1, NaN, Infinity, "37500", {}]) {
     assert.equal(
-      runDeadlineExpr({ runBudgetMs: bad }, NODE_DEFS_RUN_BUDGET_MS),
+      deadline({ runBudgetMs: bad }, NODE_DEFS_RUN_BUDGET_MS),
       NODE_DEFS_RUN_BUDGET_MS,
       `runBudgetMs=${String(bad)} must not become the run's allowance — Infinity/NaN would ` +
         "restore the unbounded run this deadline exists to prevent, and a non-positive one " +
         "would start a run with no time at all",
     );
   }
-  assert.equal(runDeadlineExpr(undefined, NODE_DEFS_RUN_BUDGET_MS), NODE_DEFS_RUN_BUDGET_MS);
+  assert.equal(deadline(undefined, NODE_DEFS_RUN_BUDGET_MS), NODE_DEFS_RUN_BUDGET_MS);
 });
 
 // ---------------------------------------------------------------------------

--- a/browser_tests/unit/single-node-def.test.mjs
+++ b/browser_tests/unit/single-node-def.test.mjs
@@ -282,10 +282,20 @@ test("#1180: a whole refresh RUN, not each phase, is what fits the budget", () =
   );
 
   // Every bounded phase must draw from that ONE deadline rather than carry its own number.
+  //
+  // #1562 — the deadline is now taken from the CALLER'S allowance when it states one, and
+  // from NODE_DEFS_RUN_BUDGET_MS otherwise. The property this assertion exists for is
+  // unchanged and is asserted in both halves: it is taken ONCE, before any phase starts,
+  // and the default is still the constant this test sizes above.
+  assert.equal(
+    (src.match(/let runDeadline =/g) || []).length,
+    1,
+    "the run must take a deadline once — a second one would be a phase carrying its own number",
+  );
   assert.match(
     src,
-    /let runDeadline = monotonicNow\(\) \+ NODE_DEFS_RUN_BUDGET_MS;/,
-    "the run must take a deadline once, before any phase starts",
+    /let runDeadline =\s*monotonicNow\(\) \+\s*\(Number\.isFinite\(runOpts\?\.runBudgetMs\) && runOpts\.runBudgetMs > 0\s*\? runOpts\.runBudgetMs\s*: NODE_DEFS_RUN_BUDGET_MS\);/,
+    "the run must take a deadline once, before any phase starts, defaulting to the run budget",
   );
   // …and give back what the UNBOUNDED local work took, or that work spends the deadline
   // rather than merely escaping it. Without this, a slow install (#610 measured the whole

--- a/browser_tests/unit/single-node-def.test.mjs
+++ b/browser_tests/unit/single-node-def.test.mjs
@@ -292,10 +292,18 @@ test("#1180: a whole refresh RUN, not each phase, is what fits the budget", () =
     1,
     "the run must take a deadline once — a second one would be a phase carrying its own number",
   );
+  // The allowance is NAMED before it becomes a deadline (#1562 round 2): the combo phase's
+  // refusal has to be able to quote the budget THIS run was given, and quoting the default
+  // constant instead produced "the 37500ms this refresh had left of its 9000ms budget".
   assert.match(
     src,
-    /let runDeadline =\s*monotonicNow\(\) \+\s*\(Number\.isFinite\(runOpts\?\.runBudgetMs\) && runOpts\.runBudgetMs > 0\s*\? runOpts\.runBudgetMs\s*: NODE_DEFS_RUN_BUDGET_MS\);/,
-    "the run must take a deadline once, before any phase starts, defaulting to the run budget",
+    /const runBudgetMs =\s*Number\.isFinite\(runOpts\?\.runBudgetMs\) && runOpts\.runBudgetMs > 0\s*\? runOpts\.runBudgetMs\s*: NODE_DEFS_RUN_BUDGET_MS;/,
+    "the run's allowance is the caller's when it states a usable one, and the default otherwise",
+  );
+  assert.match(
+    src,
+    /let runDeadline = monotonicNow\(\) \+ runBudgetMs;/,
+    "the run must take a deadline once, before any phase starts, from that one allowance",
   );
   // …and give back what the UNBOUNDED local work took, or that work spends the deadline
   // rather than merely escaping it. Without this, a slow install (#610 measured the whole
@@ -348,10 +356,21 @@ test("#1180: a whole refresh RUN, not each phase, is what fits the budget", () =
   // pins is unchanged and now pinned in two halves: the bound is COMPUTED from what the
   // fetch phase left, and that computed value is the one actually ARMED — a constant
   // substituted at either end fails here.
+  //
+  // #1562 round 2 — and it is CAPPED at a run's default allowance. The larger budget a
+  // caller may now state exists for the FETCH phase; letting it fall through to here lets a
+  // run whose fetch was fast and whose combo call merely hangs outlive the 25s join its own
+  // command holds, turning a refreshed:true into refresh_still_running. `Math.min` is a
+  // no-op for every caller that states nothing: what is left of a 9,000ms run is never more.
   assert.match(
     src,
-    /comboWaitMs = nodeDefsBudgetLeft\(runDeadline\);/,
+    /const comboBudgetLeft = nodeDefsBudgetLeft\(runDeadline\);/,
     "the combo phase must draw from what the fetch phase left, not from a constant",
+  );
+  assert.match(
+    src,
+    /comboWaitMs = Math\.min\(comboBudgetLeft, NODE_DEFS_RUN_BUDGET_MS\);/,
+    "…and a stated run budget must not extend this phase past a run's default allowance",
   );
   assert.match(
     src,

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -1638,6 +1638,12 @@ async function registerComfyNodeDefs(preloadedDefs, runOpts) {
           defs = fallbackDefs;
           clientRouteThrew = false;
           clientRouteError = null;
+          // #1562 — and route 2 ANSWERED, so "every route was abandoned" is no longer
+          // true. Cleared HERE rather than left to the fact that no fetch-phase refusal
+          // can be reached from this branch: a stale `true` that happens not to be read
+          // is a latent wrong answer waiting for the next reader, which is the shape this
+          // whole issue is about.
+          fetchAbandonedAtBound = false;
         } else {
           // Neither route produced a payload. Record what each one did so the verdict can
           // say it: the client route's sentence is built HERE because the oracle was handed

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -1575,10 +1575,23 @@ async function registerComfyNodeDefs(preloadedDefs, runOpts) {
         clientRouteError = err;
         defs = null;
       }
-      // #1562 — record HOW route 1 ended, from the flag the loop already keeps rather than
+      // #1562 — record HOW route 1 ended, from the flags the loop already keeps rather than
       // from the error's text. `lastAttemptTimedOut` is set only where `boundedGetNodeDefs`
-      // returned its sentinel, so this is "abandoned at the bound", never "failed".
-      fetchAbandonedAtBound = clientRouteThrew && lastAttemptTimedOut === true;
+      // returned its sentinel, so it means "abandoned at the bound", never "failed".
+      //
+      // `!sawRealError` is the loop's OWN precedence rule, applied to the classification as
+      // well as to the thrown value. A REAL ERROR OUTRANKS A SYNTHESIZED TIMEOUT (the
+      // `if (sawRealError) throw lastRealError` above), and the same sequence that makes it
+      // outrank there makes it outrank here: attempt 1 rejects for real (`Failed to fetch`
+      // against a port that is not open yet), the retry stalls past its bound, and the loop
+      // ends with BOTH flags set. Without this clause that ending was read as an
+      // abandonment, so a verdict whose own evidence clause said
+      // "api.getNodeDefs() failed: Failed to fetch" was headed "none of them FAILED" — the
+      // report contradicting itself in one paragraph — and the reader of a genuinely
+      // restarting backend was told a plain retry would not help, when a plain retry is
+      // exactly what helps there. The rule is one line, not two: an abandonment is what
+      // ends a route that never failed, ACROSS attempts as well as across routes.
+      fetchAbandonedAtBound = clientRouteThrew && lastAttemptTimedOut === true && !sawRealError;
       // #608 — THE SECOND TRANSPORT, on the terms #982 set and #1161 bounded.
       //
       // Same question, different route: the WHOLE document, never the per-class

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -280,7 +280,14 @@ import { BACKEND_SWITCH, runBackendSwitch } from "./lib/backend-switch.js";
 import { createSettingsBackendDefault } from "./lib/settings-backend-default.js";
 import { fetchNodeDefsWithRetry, OBJECT_INFO_RETRY_DELAYS_MS } from "./lib/object-info-retry.js";
 import { createObjectInfoCache, CACHE_OUTCOME } from "./lib/object-info-cache.js";
-import { fetchWholeObjectInfo, objectInfoOracleFailureNote, OBJECT_INFO_DEADLINE_MS } from "./lib/object-info-oracle.js";
+import {
+  fetchWholeObjectInfo,
+  objectInfoOracleFailureNote,
+  OBJECT_INFO_DEADLINE_MS,
+  // #1562 — the oracle's per-route OUTCOME vocabulary, so the fetch phase can tell an
+  // abandoned-at-the-bound route from a failed one WITHOUT matching its prose (#1223).
+  TRANSPORT_OUTCOME,
+} from "./lib/object-info-oracle.js";
 import {
   createObjectInfoSnapshot,
   snapshotAuthorizationNote,
@@ -1301,7 +1308,7 @@ const OBJECT_INFO_SEED_WAIT_MS = 8000;
 const awaitObjectInfoHistorySeed = (waitMs = OBJECT_INFO_SEED_WAIT_MS) =>
   awaitHistoryBaseline(objectInfoHistory, objectInfoHistorySeed, waitMs);
 
-async function registerComfyNodeDefs(preloadedDefs) {
+async function registerComfyNodeDefs(preloadedDefs, runOpts) {
   // Trust the live combos for suppressing missing-asset candidates ONLY once they have
   // ACTUALLY BEEN REBUILT from an authoritative payload this run obtained. Two things can
   // do that and the trust flag accepts either (#1193): `refreshComboInNodes()` answering,
@@ -1342,7 +1349,18 @@ async function registerComfyNodeDefs(preloadedDefs) {
   // left of it, so the run's cost is this budget rather than the sum of numbers that each
   // looked reasonable alone. Taken here, before any phase starts, so a slow fetch is paid
   // for by the combo phase rather than added to it.
-  let runDeadline = monotonicNow() + NODE_DEFS_RUN_BUDGET_MS;
+  //
+  // #1562 — the ALLOWANCE is the caller's when it states one. `NODE_DEFS_RUN_BUDGET_MS` is
+  // sized for a refresh that runs as a SUB-STEP (see its note); a caller whose whole
+  // command IS the refresh has a different window and says so. Only a positive finite
+  // number is honoured — an `Infinity`/`NaN` computed from an unset budget would restore
+  // the unbounded run this deadline exists to prevent, and a non-positive one would start
+  // a run with no time at all.
+  let runDeadline =
+    monotonicNow() +
+    (Number.isFinite(runOpts?.runBudgetMs) && runOpts.runBudgetMs > 0
+      ? runOpts.runBudgetMs
+      : NODE_DEFS_RUN_BUDGET_MS);
   // #716 — drop the widget-write burst cache at the START of this run, not after it
   // succeeds (codex). This function runs on exactly the events that change the schema —
   // refresh_nodes, a completed install/download, reconnect — and a refresh that FAILS is
@@ -1367,6 +1385,19 @@ async function registerComfyNodeDefs(preloadedDefs) {
   // tried instead of leaving "check that the ComfyUI server process is still running" to
   // stand on the evidence of one route out of two (#982's own defect, and #954's).
   let fetchRouteFailures = null;
+  // #1562 — did EVERY whole-document route end by being ABANDONED AT ITS BOUND, rather
+  // than by failing? That is a different fact from "the fetch failed", and the remedy is
+  // different too: a route that never answered inside its bound proves nothing about
+  // whether the server is up, so the verdict must not send the reader to check a process
+  // that was answering the whole time (#982's defect, reported again as #1562 — the
+  // reporter's own `GET /object_info` returned 25,104,088 bytes in 20.84 s while this
+  // remedy was telling them the backend might not be running).
+  //
+  // DECIDED FROM TAGS, never from the failure PROSE (#1223): route 1 reports through
+  // `lastAttemptTimedOut`, route 2 through the oracle's `TRANSPORT_OUTCOME.NO_ANSWER`.
+  // Starts null — "no whole-document route was reached at all" — so a run that never
+  // entered the fetch block cannot claim either answer.
+  let fetchAbandonedAtBound = null;
   // Tracked separately from the caught VALUE: a library can throw a FALSY value
   // (throw null / 0 / "") and `if (thrown)` would then read a failed run as a
   // clean one — misattributing the verdict and, worse, setting the shared
@@ -1544,6 +1575,10 @@ async function registerComfyNodeDefs(preloadedDefs) {
         clientRouteError = err;
         defs = null;
       }
+      // #1562 — record HOW route 1 ended, from the flag the loop already keeps rather than
+      // from the error's text. `lastAttemptTimedOut` is set only where `boundedGetNodeDefs`
+      // returned its sentinel, so this is "abandoned at the bound", never "failed".
+      fetchAbandonedAtBound = clientRouteThrew && lastAttemptTimedOut === true;
       // #608 — THE SECOND TRANSPORT, on the terms #982 set and #1161 bounded.
       //
       // Same question, different route: the WHOLE document, never the per-class
@@ -1632,6 +1667,14 @@ async function registerComfyNodeDefs(preloadedDefs) {
               (_, i) => fallbackOutcomes?.[i]?.route === "http",
             ),
           ];
+          // #1562 — and route 2's ending, by its TAG. Both must be abandonments for the
+          // verdict to say so: one route that genuinely FAILED is evidence about the
+          // server, and it outranks the other's silence.
+          fetchAbandonedAtBound =
+            fetchAbandonedAtBound === true &&
+            (Array.isArray(fallbackOutcomes) ? fallbackOutcomes : []).some(
+              (o) => o?.route === "http" && o?.kind === TRANSPORT_OUTCOME.NO_ANSWER,
+            );
         }
       }
       // Rethrown here rather than at the catch, so the phase attribution, the verdict's
@@ -1932,6 +1975,10 @@ async function registerComfyNodeDefs(preloadedDefs) {
     // #608 — what every transport in the fetch phase did, so a refusal about /object_info
     // names the routes it actually tried.
     fetchRouteFailures,
+    // #1562 — and whether every one of them was ABANDONED AT ITS BOUND rather than failing,
+    // which is what separates "the server did not answer" from "the server answered too
+    // slowly for this command's window".
+    fetchAbandonedAtBound,
   });
   // #1275 — VERIFY the refresh was ADDITIVE over the live graph.
   //
@@ -10883,6 +10930,67 @@ const ADD_NODE_COMMAND_BUDGET_MS = 25000;
 const REFRESH_NODES_COMMAND_BUDGET_MS = 25000;
 
 /**
+ * #1562 — the RUN budget for the refresh THIS command starts, as opposed to the JOIN
+ * budget above.
+ *
+ * THE TWO WERE THE WRONG WAY ROUND, and that is the whole defect. `joinMs` (25,000 ms) is
+ * how long this command is willing to WAIT; `NODE_DEFS_RUN_BUDGET_MS` (9,000 ms) is how
+ * long the run it starts is allowed to SPEND. Because the run's allowance was the smaller
+ * one, the run always died first — so `REFRESH_JOIN_ABANDONED` / `refresh_still_running`,
+ * the retryable verdict #1404 built for exactly "a big install ... without any concurrency
+ * at all", was unreachable on the install it was written for. What the caller got instead
+ * was `object_info_fetch_failed`, which tears the run down, so every retry started another
+ * doomed run and the tool could never succeed on that machine.
+ *
+ * MEASURED, against a REAL 25,000,581-byte `/object_info` served in 20.80 s (the reporter
+ * measured 25,104,088 bytes / 20.84 s), driving the SHIPPED fetch phase — the real
+ * `boundedGetNodeDefs`, the real retry loop, the real oracle:
+ *
+ *     run budget   route 1 bound   whole-document GETs   outcome
+ *      9,000 ms       6,000 ms            2              FAILED at 7.5 s — and the refusal
+ *                                                        is the reported sentence verbatim:
+ *                                                        "GET /object_info did not answer
+ *                                                        within its 1492ms share of the
+ *                                                        2985ms budget"
+ *     25,000 ms      16,666 ms            2              STILL FAILED at 20.9 s
+ *     32,000 ms      21,333 ms            1              obtained 20,020 types at 20.86 s
+ *     37,500 ms      25,000 ms            1              obtained 20,020 types at 20.98 s
+ *
+ * The 25,000 ms row is why this is not simply `REFRESH_NODES_COMMAND_BUDGET_MS`: handing
+ * the run the command's own window leaves its FETCH SHARE two thirds of that, and two
+ * thirds of the window is not the window. So the number is DERIVED from the property that
+ * has to hold rather than picked to fit one install:
+ *
+ *     the fetch phase alone must be able to spend everything the command will wait for
+ *     →  runBudget x NODE_DEFS_FETCH_SHARE  >=  REFRESH_NODES_COMMAND_BUDGET_MS
+ *
+ * which is asserted by test, so raising either input cannot silently break it again.
+ *
+ * WHAT IT COSTS. Nothing at all on a healthy install: every one of these numbers is a
+ * CEILING, and a backend that answers in ~0.5 s (measured: 456 ms warm / 1,062 ms cold on
+ * this rig) reaches the identical verdict in the identical time — the reproduction was run
+ * with a fast backend under both budgets and the elapsed times and outcomes match. What it
+ * does cost is a run that OUTLIVES its command: a `panel_refresh_nodes` against a backend
+ * that never answers now leaves one whole-document download in flight for up to
+ * ~12,500 ms after the reply. That is bounded, it is one run (the coalescer holds a single
+ * slot), and it is exactly the work the retry this reply asks for will join — which is the
+ * trade #1351 already made deliberately for the join.
+ *
+ * A `graph_add_node` arriving inside that window meets a longer-lived run and can refuse
+ * with its (worded, retryable) busy message where it would previously have waited out a
+ * shorter one. On an install this budget changes anything for, that add was failing its
+ * OWN refresh already.
+ *
+ * ONLY THE EXPLICIT COMMAND passes this. Reconnect, install-completed and download
+ * refreshes keep `NODE_DEFS_RUN_BUDGET_MS`, so #1180's composition property — two
+ * serialized runs inside the bridge's read default — is untouched for every caller that
+ * is not this one.
+ */
+const REFRESH_NODES_RUN_BUDGET_MS = Math.ceil(
+  REFRESH_NODES_COMMAND_BUDGET_MS / NODE_DEFS_FETCH_SHARE,
+);
+
+/**
  * #1192 — what an add still has to do AFTER the node-def refresh, held back so the join
  * cannot spend it.
  *
@@ -11244,6 +11352,11 @@ const GRAPH_TOOL_EXECUTORS = {
     const verdict = await refreshComfyNodeDefs(undefined, {
       force: true,
       joinMs: REFRESH_NODES_COMMAND_BUDGET_MS,
+      // #1562 — and the RUN this command starts gets an allowance that outlasts that wait,
+      // so the JOIN is what ends the command. Without this line the run gives up first and
+      // the retryable `refresh_still_running` verdict below is unreachable on exactly the
+      // installs it exists for. See REFRESH_NODES_RUN_BUDGET_MS for the measurement.
+      runBudgetMs: REFRESH_NODES_RUN_BUDGET_MS,
     });
     // #1404 — a NAMED verdict, before the generic branch below can call it "unknown".
     //

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -1356,11 +1356,17 @@ async function registerComfyNodeDefs(preloadedDefs, runOpts) {
   // number is honoured — an `Infinity`/`NaN` computed from an unset budget would restore
   // the unbounded run this deadline exists to prevent, and a non-positive one would start
   // a run with no time at all.
-  let runDeadline =
-    monotonicNow() +
-    (Number.isFinite(runOpts?.runBudgetMs) && runOpts.runBudgetMs > 0
+  //
+  // NAMED, not just added to a deadline: the combo phase's refusal quotes "the budget this
+  // refresh had", and it used to quote the DEFAULT constant unconditionally. The moment a
+  // caller could state its own, that sentence became arithmetically impossible — "the
+  // 37500ms this refresh had left of its 9000ms budget" — which is #1161's defect (naming a
+  // number that was never spent) reintroduced by this very change.
+  const runBudgetMs =
+    Number.isFinite(runOpts?.runBudgetMs) && runOpts.runBudgetMs > 0
       ? runOpts.runBudgetMs
-      : NODE_DEFS_RUN_BUDGET_MS);
+      : NODE_DEFS_RUN_BUDGET_MS;
+  let runDeadline = monotonicNow() + runBudgetMs;
   // #716 — drop the widget-write burst cache at the START of this run, not after it
   // succeeds (codex). This function runs on exactly the events that change the schema —
   // refresh_nodes, a completed install/download, reconnect — and a refresh that FAILS is
@@ -1859,7 +1865,31 @@ async function registerComfyNodeDefs(preloadedDefs, runOpts) {
       // it, "did not answer in time" is the same sentence for a phase starved down to
       // 3000ms by a slow fetch and for one handed the whole budget that hung anyway, and
       // those two have different causes and different remedies.
-      comboWaitMs = nodeDefsBudgetLeft(runDeadline);
+      //
+      // #1562 — AND NEVER MORE THAN A RUN'S DEFAULT ALLOWANCE, whatever the caller stated.
+      //
+      // The larger budget a caller may now pass exists for the FETCH phase — a whole
+      // `/object_info` that cannot be delivered inside the old 9,000ms. Letting it fall
+      // through to here instead hands this phase up to 37,500ms, and this phase's bound is
+      // the one that decides how long the RUN lives: a `panel_refresh_nodes` whose fetch was
+      // fast and whose `refreshComboInNodes()` merely hangs would then outlive the 25,000ms
+      // JOIN its own command holds. Measured on the shipped executor over the real
+      // coalescer, varying only the combo call's latency:
+      //
+      //     combo latency   before this issue        uncapped 37,500ms run
+      //       15,000 ms     refreshed:true           refreshed:true
+      //       26,000 ms     refreshed:true at 9 s    refreshed:FALSE (refresh_still_running)
+      //       never answers refreshed:true at 9 s    refreshed:FALSE (refresh_still_running)
+      //
+      // That is a case that WORKED being turned into one that does not — and it takes
+      // #1193's `combo_refresh_confirmed:false` disclosure with it, which is unreachable
+      // through this command once the phase can cross the join. The extension must therefore
+      // reach the phase it was measured for and no further, so this phase keeps exactly the
+      // ceiling it has always had. `Math.min` is a NO-OP for every caller that states no
+      // budget: what is left of a 9,000ms run is never more than 9,000ms.
+      const comboBudgetLeft = nodeDefsBudgetLeft(runDeadline);
+      comboWaitMs = Math.min(comboBudgetLeft, NODE_DEFS_RUN_BUDGET_MS);
+      const comboWaitCapped = comboWaitMs < comboBudgetLeft;
       const comboSettled = await withTimeout(
         Promise.resolve()
           .then(() => a.refreshComboInNodes())
@@ -1918,8 +1948,16 @@ async function registerComfyNodeDefs(preloadedDefs, runOpts) {
         // catch. The `?? ` that used to guard this assignment could never fire.
         thrown = comboAbandoned
           ? new Error(
-              `refreshComboInNodes() did not answer within the ${comboWaitMs}ms this refresh had ` +
-                `left of its ${NODE_DEFS_RUN_BUDGET_MS}ms budget, and this run's own combo rebuild ` +
+              // #1562 — WHICH OF THE TWO BOUNDS ACTUALLY BIT, and the run's OWN budget rather
+              // than the default constant. #1193 put the numbers in this sentence so a phase
+              // starved to a sliver by a slow fetch reads differently from one handed the
+              // whole budget that hung anyway; a third case now exists — a phase holding the
+              // ceiling while the run still had time — and it has to be readable too.
+              `refreshComboInNodes() did not answer within the ${comboWaitMs}ms ` +
+                (comboWaitCapped
+                  ? `this phase is capped at (this refresh had ${comboBudgetLeft}ms left of its ${runBudgetMs}ms budget)`
+                  : `this refresh had left of its ${runBudgetMs}ms budget`) +
+                ", and this run's own combo rebuild " +
                 "did not complete either, so the dropdown lists are NOT known to be current",
             )
           : comboSettled.err;

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -10973,9 +10973,11 @@ const REFRESH_NODES_COMMAND_BUDGET_MS = 25000;
  * which is asserted by test, so raising either input cannot silently break it again.
  *
  * WHAT IT COSTS. Nothing at all on a healthy install: every one of these numbers is a
- * CEILING, and a backend that answers in ~0.5 s (measured: 456 ms warm / 1,062 ms cold on
- * this rig) reaches the identical verdict in the identical time — the reproduction was run
- * with a fast backend under both budgets and the elapsed times and outcomes match. What it
+ * CEILING, and a backend that answers in ~0.5 s (#1180's own measurements on this rig:
+ * 456 ms warm, 1,062 ms cold — quoted, not re-measured here) reaches the identical verdict
+ * in the identical time. That part WAS re-measured: the reproduction was run against a fast
+ * backend under both budgets and the elapsed times and outcomes match (312 ms vs 322 ms,
+ * one request, same payload). What it
  * does cost is a run that OUTLIVES its command: a `panel_refresh_nodes` against a backend
  * that never answers now leaves one whole-document download in flight for up to
  * ~12,500 ms after the reply. That is bounded, it is one run (the coalescer holds a single

--- a/web/js/lib/node-def-refresh.js
+++ b/web/js/lib/node-def-refresh.js
@@ -82,6 +82,12 @@ function detailSuffix(thrown) {
  *                              // running" was printed on the evidence of one route, and
  *                              // the reported install had a healthy server answering a
  *                              // different transport at that same moment.
+ *   fetchAbandonedAtBound?: boolean|null, // #1562 — EVERY whole-document route ended by
+ *                              // being ABANDONED AT ITS BOUND rather than by failing. The
+ *                              // caller decides this from the oracle's per-route TAGS and
+ *                              // its own timeout flag, never from the failure prose
+ *                              // (#1223). null = no whole-document route was reached, so
+ *                              // neither answer is claimed.
  * }} o
  * @returns {{ refreshed: boolean, reason: string, remedy?: string, detail?: string }}
  */
@@ -97,6 +103,7 @@ export function describeNodeDefRefresh({
   didThrow,
   thrown = null,
   fetchRouteFailures = null,
+  fetchAbandonedAtBound = null,
 } = {}) {
   // Backstop for a caller that predates didThrow: a truthy caught value implies it.
   const failed = didThrow === true || !!thrown;
@@ -177,9 +184,34 @@ export function describeNodeDefRefresh({
     const remedy = noPayload
       ? noPayloadRemedy
       : reason === NODE_DEF_REFRESH_REASONS.OBJECT_INFO_FETCH_FAILED
-        ? "The /object_info fetch failed on every transport this panel has, so nothing was " +
-          "refreshed. The backend may still be restarting — retry once it answers, and if it " +
-          "never does, check that the ComfyUI server process is still running." +
+        ? // #1562 — SAY WHICH OF THE TWO THIS WAS, because their remedies are opposite.
+          //
+          // Every route being ABANDONED AT ITS BOUND is not evidence that the server is
+          // down; it is evidence that nothing arrived in the time this command had. The
+          // reporter's `/object_info` returned 25,104,088 bytes in 20.84 s from a server
+          // that was up the whole time, while this text sent them to check whether the
+          // process was still running — a remedy for a cause that was never established,
+          // which is the same defect #982 recorded and #608 narrowed.
+          //
+          // It also must not promise that a plain retry helps. A document that does not fit
+          // the window will not fit the next one either, so the steps named are the ones
+          // that change the size of the question or the size of the window.
+          //
+          // `=== true` deliberately: `null` means no whole-document route was reached at
+          // all, and an unestablished fact must fall to the wording that claims less about
+          // this particular run rather than to the one that claims more.
+          (fetchAbandonedAtBound === true
+            ? "No /object_info answered inside the time this command had — every transport was " +
+              "ABANDONED AT ITS BOUND and none of them FAILED, so this is NOT evidence that the " +
+              "ComfyUI server is down; it may have been answering the whole time, just not fast " +
+              "enough. Nothing was refreshed. A plain retry meets the same bound unless the " +
+              "backend got faster: on a very large install the whole node-definition document " +
+              "can take longer to deliver than one command may wait. Reload the ComfyUI tab — " +
+              "its page load fetches the schema under no such bound — or reduce the installed " +
+              "pack count."
+            : "The /object_info fetch failed on every transport this panel has, so nothing was " +
+              "refreshed. The backend may still be restarting — retry once it answers, and if it " +
+              "never does, check that the ComfyUI server process is still running.") +
           // #608 — the routes, appended rather than folded into the sentence above: which
           // ones were tried is EVIDENCE, and it is what separates "one client call did not
           // answer" (where the server is usually fine, and was) from "nothing answers".

--- a/web/js/lib/refresh-coalesce.js
+++ b/web/js/lib/refresh-coalesce.js
@@ -124,11 +124,30 @@ async function waitForRun(run, ms, withTimeout) {
   return settled.value;
 }
 
+// #1562 — A CALLER MAY ALSO STATE THE RUN'S OWN ALLOWANCE (`opts.runBudgetMs`), which is a
+// different quantity from `joinMs` and was missing.
+//
+// `joinMs` bounds how long THIS caller WAITS. It says nothing about how long the run it
+// starts may SPEND, and the run's own default is sized for a refresh that happens as a
+// sub-step of something else. When the wait is the longer of the two the run always dies
+// first, and `REFRESH_JOIN_ABANDONED` — the retryable "it is still going, join it" verdict
+// this coordinator exists to be able to give — becomes unreachable for the slow installs it
+// was built for. Passing the value through changes nothing for a caller that omits it.
+//
+// FORWARDED, NEVER INTERPRETED: this stays a pure coordinator, so the value is handed to
+// `runRegister` as-is and every check of it belongs there.
+//
+// THE TRAILING RUN IS SHARED, so it keeps the allowance of the caller that QUEUED it — the
+// same asymmetry `joinMs` already documents one paragraph up, and for the same reason: the
+// run is #396's guarantee to whoever else is waiting, and a later caller cannot retroactively
+// re-budget work that has started.
+//
 //   getInFlight / setInFlight : accessors for the shared single-flight promise slot
 //                               (module-level in the panel).
-//   runRegister(preloadedDefs) : performs the actual (idempotent) registration; its
-//                                own cleanup must NOT clear the slot — the coalescer
-//                                owns the slot lifecycle.
+//   runRegister(preloadedDefs, runOpts) : performs the actual (idempotent) registration;
+//                                its own cleanup must NOT clear the slot — the coalescer
+//                                owns the slot lifecycle. `runOpts` is the caller's
+//                                `{ runBudgetMs }`, forwarded verbatim.
 //   withTimeout                : the repo's ONE bounding primitive (bounded-step.js),
 //                                injected rather than imported so this module stays a
 //                                pure coordinator and a test can drive the clock. Omit it
@@ -139,10 +158,10 @@ export function makeRefreshCoalescer({ getInFlight, setInFlight, runRegister, wi
   // The single queued trailing (forced, no-payload) run, or null when none is
   // pending. Coalesces any number of forced calls arriving during one in-flight run.
   let trailing = null;
-  const startRun = (preloadedDefs) => {
+  const startRun = (preloadedDefs, runOpts) => {
     const p = (async () => {
       try {
-        return await runRegister(preloadedDefs);
+        return await runRegister(preloadedDefs, runOpts);
       } finally {
         // Clear the slot only if it still points at THIS run (a later run may have
         // already replaced it).
@@ -165,6 +184,9 @@ export function makeRefreshCoalescer({ getInFlight, setInFlight, runRegister, wi
     // #1351 — `joinMs` is a deadline for THIS invocation, taken once, so the join and the
     // run that follows it COMPOSE rather than add. Wall clock, matching `withTimeout`.
     const startedAt = joinMs === null ? 0 : Date.now();
+    // #1562 — the caller's RUN allowance, forwarded to every `startRun` below. Built here,
+    // once, so no branch can start a run under a different budget than its siblings.
+    const runOpts = opts && Number.isFinite(opts.runBudgetMs) ? { runBudgetMs: opts.runBudgetMs } : undefined;
     const remaining = () => (joinMs === null ? null : joinMs - (Date.now() - startedAt));
     const current = getInFlight();
     if (current) {
@@ -183,7 +205,7 @@ export function makeRefreshCoalescer({ getInFlight, setInFlight, runRegister, wi
         // #1351 — the join settled, so starting our own run is not a stampede. What remains
         // of `joinMs` bounds the wait on THAT run. Wrapping join+run as one promise and
         // bounding it once would start the run after an abandoned join — the stampede.
-        return waitForRun(startRun(preloadedDefs), remaining(), withTimeout);
+        return waitForRun(startRun(preloadedDefs, runOpts), remaining(), withTimeout);
       }
       // Forced, no payload ⇒ guarantee a fresh fetch AFTER the current run
       // settles; coalesce concurrent forced calls into ONE trailing run (#396).
@@ -202,7 +224,7 @@ export function makeRefreshCoalescer({ getInFlight, setInFlight, runRegister, wi
             /* the in-flight refresh failed — run our own anyway */
           }
           trailing = null;
-          return startRun(undefined);
+          return startRun(undefined, runOpts);
         })();
       }
       return waitForRun(trailing, joinMs, withTimeout);
@@ -212,6 +234,6 @@ export function makeRefreshCoalescer({ getInFlight, setInFlight, runRegister, wi
     // join landing (or never starting) inside it. A bound already spent starts nothing —
     // the same as an abandoned join, and for the same `withTimeout` trap.
     if (joinMs !== null && !(joinMs > 0)) return REFRESH_JOIN_ABANDONED;
-    return waitForRun(startRun(preloadedDefs), joinMs, withTimeout);
+    return waitForRun(startRun(preloadedDefs, runOpts), joinMs, withTimeout);
   };
 }


### PR DESCRIPTION
Addresses the **`panel_refresh_nodes` half** of artokun/comfyui-mcp-panel#1562. The reconnect half of that report is **not** in this PR and is filed on its own — see "What this deliberately does not do".

> **Review is PENDING.** grok has been asked, in a comment here and on the issue, with the risky parts named. This is not gated and no clean verdict exists yet.

---

### Update — rebased, and a P1 found by the fallback gate and fixed

* **Rebased onto `main` @ `a1844f68`** after #1561 (the #1560 fix) landed and made this PR `CONFLICTING`. The only overlap was the oracle import block; nothing #1561 shipped is modified. The two `chore(1562)` commits — which existed solely to keep that import on one line while #1560's branch was open — are gone.
* **`claude-gate.mjs`, the repo's fallback adversarial gate, returned NO-SHIP with a real P1**, disclosed in full in a comment below: route 1's ending was classified as an abandonment even when an earlier attempt in the same retry loop had FAILED for real, so the verdict could contradict its own evidence clause and tell the user of a genuinely-restarting backend that a retry would not help. Fixed in `603f2b37` (`&& !sawRealError` — the loop's own precedence rule, applied across attempts as well as across routes) and covered **behaviourally** against the shipped fetch phase rather than by asserting source text.
* **Re-verified on `603f2b37`:** `npm run test:unit` **6162 pass / 0 fail / 1 todo**; **9 / 9 mutations killed** (the 8 below re-run on this head, plus the new one), tree clean after each; CI green.
* **The browser suite has not been re-run since the rebase** — both ComfyUI slots on this machine are held by another agent's run, and this session was not allocated an instance. The earlier `--workers=1` run (19 failed / 62 passed, byte-identical failure sets on both trees) was on the pre-rebase head. Stated rather than implied.
* The mutation table further down says **14/14** and was true of the pre-rebase head; the current head's set is the **9/9** above.

## The bug, reproduced by execution before a line was written

The reporter's install serves `GET /object_info` at **25,104,088 bytes / 20.84 s** while `/system_stats` and `/object_info/<Type>` answer instantly. Every `panel_refresh_nodes` returned:

```
refreshed:false  reason:object_info_fetch_failed
"GET /object_info did not answer within its 1499ms share of the 2999ms budget"
```

…against a command whose own window is **25,000 ms**. It had spent 7.5 s and refused with 17.5 s unused.

I drove the **SHIPPED fetch phase** — the real `boundedGetNodeDefs`, the real `fetchNodeDefsWithRetry` schedule, the real `object-info-oracle.js`, the real `nodeDefsBudgetLeft` arithmetic and the real constants read out of the panel source — against a **REAL** http server answering a **REAL** 25,000,581-byte `/object_info` in 20.80 s:

```
GET /object_info (raw)    : 25000581 bytes, 20.80s
NODE_DEFS_RUN_BUDGET_MS   : 9000
NODE_DEFS_FETCH_SHARE     : 0.666… → route 1 bound 6000ms

elapsed ms                : 7509
whole /object_info reqs   : 2
defs obtained             : NONE
route failures:
  - api.getNodeDefs() failed: api.getNodeDefs() did not answer within this refresh's remaining budget
  - GET /object_info did not answer within its 1492ms share of the 2985ms budget
```

The reported sentence, byte for byte, and **two** whole-document downloads for a document neither of them could finish.

## THE TWO BUDGETS WERE THE WRONG WAY ROUND

`REFRESH_NODES_COMMAND_BUDGET_MS` (25,000) is how long the command **waits**. `NODE_DEFS_RUN_BUDGET_MS` (9,000) is how long the run it starts may **spend**, and that default is sized — by its own note — for a refresh that happens as a **sub-step** of `graph_add_node`, where time has to be held back for registration and the widget wait.

Because the run's allowance was the *smaller* of the two, **the run always died before the join could abandon**. So `REFRESH_JOIN_ABANDONED` → `refresh_still_running` — the retryable verdict #1404 built for exactly *"a big install … without any concurrency at all"*, whose whole point is that the run is **not cancelled** and the retry **joins it** — was **structurally unreachable on the installs it was written for**. The caller got `object_info_fetch_failed` instead, which tears the run down, so every retry started another doomed 9 s run. The tool could not succeed on that machine, ever.

## What suffices — measured, not picked

Same harness, same 20.80 s document, sweeping only the run budget:

| run budget | route 1 bound | whole-document GETs | outcome |
|---|---|---|---|
| **9,000 ms** (shipped) | 6,000 ms | 2 | FAILED at 7.5 s — the reported sentence |
| **25,000 ms** (= the command's own window) | 16,666 ms | 2 | **STILL FAILED** at 20.9 s |
| 32,000 ms | 21,333 ms | 1 | obtained 20,020 types at 20.86 s |
| **37,500 ms** | 25,000 ms | 1 | obtained 20,020 types at 20.98 s |

The 25,000 row is the reason this is not "hand the run the command's window": the **fetch share is two thirds** of whatever the run gets, and two thirds of the window is not the window. So the number is **derived from the property that has to hold**, not fitted to one install:

```
the fetch phase alone must be able to spend everything the command will wait for
  →  runBudget × NODE_DEFS_FETCH_SHARE  ≥  REFRESH_NODES_COMMAND_BUDGET_MS
```

`REFRESH_NODES_RUN_BUDGET_MS = Math.ceil(REFRESH_NODES_COMMAND_BUDGET_MS / NODE_DEFS_FETCH_SHARE)` = 37,500, and **that inequality is asserted by test**, so raising either input cannot silently break it again.

**What the reporter's install actually gets — corrected in round 2, because the first wording was optimistic.** The fetch lands at ~21 s, inside the 25 s join. The combo phase then runs, and on that install it re-fetches the same 25 MB document, so it is abandoned at its own bound rather than answering — which puts the RUN at roughly 30 s, past the 25 s join. So the honest expectation is: the first `panel_refresh_nodes` answers **`refresh_still_running`** (retryable, and the run is not cancelled), and **the refresh itself completes** — the definitions are registered, which is the outcome the missing node depends on. Before this change the run was torn down at 9 s having obtained nothing, every retry started another doomed run, and `refreshed:true` was not the thing that was unreachable: **any** completed refresh was. What this PR makes reachable is the work landing at all, and a verdict that is true rather than one that blames a healthy server.

## What it costs, stated rather than left to be discovered

* **A healthy install: nothing.** Every one of these numbers is a ceiling. Measured with a fast backend under both budgets: **312 ms vs 322 ms**, one request, identical verdict. (The ~0.5 s figures quoted in the new comment — 456 ms warm, 1,062 ms cold — are **#1180's** measurements on this rig, not mine; attributed as such in the source.)
* **A run that outlives its command.** A `panel_refresh_nodes` against a backend that never answers now leaves one whole-document download in flight for up to ~12,500 ms after the reply, holding the coalescer's single slot. That is exactly the work the retry the reply asks for will join — the trade #1351 already made deliberately for the join — but it is real.
* **`graph_add_node` during that window** meets a longer-lived run and can refuse with its worded, retryable busy message where it would previously have waited out a shorter one. On an install this budget changes anything for, that add was failing its own refresh already.
* **Only the explicit command passes it.** Reconnect, install-completed and download-triggered refreshes keep `NODE_DEFS_RUN_BUDGET_MS`, so #1180's composition property — two serialized runs inside the bridge's read default — is untouched for every caller that is not this one.

## Second half of the same report: the refusal named a cause it never established

The `object_info_fetch_failed` remedy read:

> The backend may still be restarting — retry once it answers, and if it never does, **check that the ComfyUI server process is still running.**

The reporter's server returned 25,104,088 bytes in 20.84 s while that sentence was printed. **Every route had been ABANDONED AT ITS BOUND; not one of them had failed.** That is #982's defect again, and it is the same class this repo keeps recording: a report asserting an outcome it did not observe.

So when — and only when — every whole-document route ended by being abandoned at its bound, the remedy now says that, says it is **not** evidence the server is down, says a plain retry meets the same bound, and names the two things that actually change the answer (reload the tab, whose page load fetches the schema under no such bound; or reduce the pack count).

**Decided from TAGS, never from prose (#1223):** route 1 from the fetch loop's own `lastAttemptTimedOut`, route 2 from the oracle's `TRANSPORT_OUTCOME.NO_ANSWER`. A route that genuinely **failed**, or that **answered unusably** (a 500), outranks the other's silence and keeps the old, correct wording. `null` — no whole-document route was reached at all — falls to the wording that claims less, by `=== true` rather than truthiness.

## Mutation evidence — 14 mutations, 14 killed

Applied to a **committed** tree and reverted with `git checkout` (baseline 0 failing, 0 cancelled; worktree verified clean after each), over `refresh-nodes-run-budget`, `refresh-nodes-command-budget`, `node-def-refresh` and `single-node-def`:

| # | mutation | verdict | a named test it kills |
|---|---|---|---|
| M1 | **delete the FIX** — the call site stops stating the run's allowance | KILLED (2) | `#1562: refresh_nodes hands the RUN its own allowance, not just the join` |
| M2 | the **CALL SITE** keeps the option but names the sub-step default | KILLED (14) | `#1562: refresh_nodes hands the RUN its own allowance…` |
| M3 | the coalescer stops **FORWARDING** it to the run | KILLED (4) | `#1562: the coalescer forwards runBudgetMs on the NOTHING-IN-FLIGHT path` |
| M4 | the **TRAILING** (forced) path drops it | KILLED (1) | `#1562: the coalescer forwards runBudgetMs on the TRAILING (forced) path` |
| M5 | the **PAYLOAD** path drops it | KILLED (1) | `#1562: the coalescer forwards runBudgetMs on the PAYLOAD path` |
| M6 | the run **IGNORES** the allowance it is handed | KILLED (2) | `#1562: a stated run budget is used; anything unusable falls back to the default` |
| M7 | the run **VALIDATES NOTHING** — Infinity/NaN restore the unbounded run | KILLED (2) | same |
| M8 | the **DERIVATION** shrinks to the command window (the value measurement showed still fails) | KILLED (2) | `#1562: the run's FETCH SHARE alone covers everything the command will wait for` |
| M9 | route 1's ending **assumed** rather than read from the timeout flag | KILLED (2) | `#1562: a route that genuinely FAILED outranks the other's silence` |
| M10 | route 2's **TAG** dropped — silence claimed on route 1's evidence alone | KILLED (2) | `#1562: a route that ANSWERED unusably outranks the other's silence too` |
| M11 | route 2's ending decided by matching its **PROSE** instead of its tag (#1223) | KILLED (1) | `#1562: the fetch phase classifies route endings by TAG, not by message text` |
| M12 | the honest remedy **deleted** — every fetch failure blames the server process again | KILLED (2) | `#1562: BOTH whole-document routes abandoned at their bound is not reported as a dead server` |
| M13 | the remedy fires on an **UNESTABLISHED** fact (`null` reads as abandoned) | KILLED (1) | `#1562: a route that genuinely FAILED keeps the old, correct remedy` |
| M14 | the verdict stops **accepting** the input | KILLED (16) | `#1562: every route ABANDONED AT ITS BOUND is not reported as a server that is down` |

**M5 survived the first round, and that is the finding worth recording.** The payload-branch test released the held run *before* issuing the payload call, so it took the nothing-in-flight branch and never touched the code it named — a test on the wrong branch reads exactly like a passing one. Fixed in its own commit, along with lifting the `runDeadline` expression *inside* the test so a mutation fails **by name** rather than failing the whole file (a file-level throw counts as a kill and names nothing a reader can act on).

## Two source-pinning assertions were UPDATED, not loosened

Both pin code this change deliberately moves, and both keep the property they exist for:

* `#1180: a whole refresh RUN, not each phase, is what fits the budget` pinned the literal `let runDeadline = monotonicNow() + NODE_DEFS_RUN_BUDGET_MS;`. It now pins the new expression **and** additionally asserts there is exactly **one** `let runDeadline =` in the panel — strictly stronger than what it asserted before.
* `#1404: the shipped call site passes the budget` pinned `{ force: true, joinMs: … }`. It now requires **both** `joinMs` **and** `runBudgetMs` by name.

Neither assertion was deleted, skipped, or weakened. M1/M2/M6/M7 all still die to them.

## Suites

* `npm run test:unit` (i18n × 2, tool-vocabulary, panel-scope, `node --test`): **6130 tests / 6129 pass / 0 fail / 1 todo**. Baseline on clean `origin/main` @ `75728263`: **6116 / 6115 / 0 fail / 1 todo**. +14 new, nothing pre-existing disturbed.
* `check-panel-scope` OK, `check-tool-vocabulary` OK.
* Playwright — table below.

## What this deliberately does not do

* **It does not make `panel_refresh_nodes` succeed on an install slower than the command's whole window.** Nothing inside a 30,000 ms relay window can pay for a whole-document read that takes longer than that, and this PR does not pretend otherwise — it makes the panel spend the window it actually holds, and when even that is not enough it says so truthfully instead of naming a cause it did not establish.
* **It does not touch #1560/#1561's `scoped-object-info.js`, and does not reuse it.** #1561 states plainly that `panel_refresh_nodes` is unhelped by the type-scoped route because it re-registers the **whole** schema — an install-wide question no per-class route can answer — and that is correct. Nothing here reads, writes, or depends on that file, and no function or test file is shared. This branch is cut from `origin/main` @ `75728263`, the same base #1561 measured against.

  **There IS one textual conflict, and it is declared rather than left to be discovered.** `git merge-tree origin/main <#1561 head> <this head>` conflicts on exactly **one hunk**: the `./lib/object-info-oracle.js` import line in `comfyui-mcp-panel.js`. I add `TRANSPORT_OUTCOME` to it; #1561 rewrites the `./lib/object-info-snapshot.js` import immediately below it. I already reduced my side to a **single changed line** (an earlier version expanded the import across multiple lines and made the conflict bigger for no reason). Whichever of the two merges second resolves it by keeping the other's snapshot import and adding `TRANSPORT_OUTCOME` to the oracle import — nothing semantic is in dispute. Flagged on #1561 as well, so neither of us diverges quietly.
* **It does not fix the reconnect half of #1562**, which is the more serious one. That is filed as **artokun/comfyui-mcp#1996** with what I could establish (the health check polls `GET <loopback boot base>/system_stats`, certifies only on `healthy`-after-`down`, and gave up at the **120 s** `COMFYUI_PANEL_REBOOT_BUDGET_S` default against a 200-pack boot — while its own file declares 240 s safe; and because the readiness budget expired, `awaitPostRestartReachable`, the wait for the tab to re-register, was **never entered at all**) and, marked as **not established**, what I could not: why the tab's socket never re-helloed. I had no 200-pack install and no live browser tab, and I have not guessed a mechanism into the record.
* **It does not raise `NODE_DEFS_RUN_BUDGET_MS`.** That constant is load-bearing for #1180's composition property and every other caller keeps it.
* **It does not add a disclosure field to the reply.** The two verdicts a slow install now reaches (`refreshed:true`, `refresh_still_running`) already exist and already carry their own wording.

---

## Playwright — measured against a clean `origin/main`, not asserted

The panel is served to the browser from ComfyUI's `custom_nodes`, so running the suite out of a worktree proves nothing unless ComfyUI is actually serving that worktree. I did **not** repoint the developer's shared junction. Two isolated stacks instead, both freshly created:

| | fix tree | baseline |
|---|---|---|
| ComfyUI | `--base-directory .../ap-1562-cc --port 8462 --enable-cors-header --cpu` | `.../ap-1562-base --port 8562` |
| `custom_nodes/comfyui-mcp-panel` | junction → `wt-1562-cc` (this branch) | junction → detached `origin/main` @ `75728263` |
| served panel contains `REFRESH_NODES_RUN_BUDGET_MS` | **yes** (verified over HTTP) | **no** (verified over HTTP) |
| served `refresh-coalesce.js` forwards `runOpts` | **yes** (verified over HTTP) | n/a |
| `npx playwright test --workers=1` | **19 failed / 62 passed (8.3 m)** | **19 failed / 62 passed (8.2 m)** |

**The two failure sets are byte-identical** — `diff` of the 19 `file:line:col` locations is empty. Zero new failures. They are 7 `conversation-persistence`, 4 `workflow-chat-identity`, 3 `chat-history-v2`, and one each of `agent-drive`, `external-orchestrator`, `hidden-tab`, `pending-queue`, `streaming-render` — storage/IndexedDB and streaming, none of them near this budget. The same 19 #1561 measured on the same base commit. **No assertion was loosened and no spec was skipped.**

Nothing was written into the developer's own ComfyUI or its `custom_nodes`.

**Head accounting, so nobody has to wonder.** The suite ran against `7cd2e82d`. The only commit after it is `0f8419a0`, which is **comment-only** (it attributes two quoted measurements to #1180 instead of letting them read as mine). `npm run test:unit` (6130/6129/0 fail), `check-panel-scope`, and the full 14/14 mutation harness were all re-run **on `0f8419a0`**, not inherited from the earlier head.

**Coverage I do NOT have:** no e2e spec exercises a backend whose whole `/object_info` outlives the refresh budget — that needs a 25 MB schema and a 20 s server. That behaviour is covered by the node-test reproduction driving the shipped fetch phase against a real slow 25 MB endpoint, not by the browser suite.

