### PR TITLE
fix(1563,1564): a save whose tracker snapshot is behind the canvas is refused, not reported as success

### DIFF
--- a/browser_tests/stale-snapshot-save-refused.spec.ts
+++ b/browser_tests/stale-snapshot-save-refused.spec.ts
@@ -1,0 +1,174 @@
+/**
+ * Tier 1 — panel#1563/#1564: a save must never report success for a graph the file
+ * does not contain (agent-free).
+ *
+ * THE MEASURED DEFECT, reproduced here end to end on a real ComfyUI. ComfyUI persists
+ * a tab by serializing `changeTracker.activeState` — the tracker SNAPSHOT, never the
+ * graph on screen — and refreshes that snapshot first via `prepareForSave()` →
+ * `captureCanvasState()`. That capture opens with a silent early return:
+ *
+ *     if (!app.graph || this.changeCount > 0 || this._restoringState ||
+ *         ChangeTracker.isLoadingGraph) return
+ *
+ * With one of those windows open, `panel_create_group` lands a group on the canvas,
+ * the snapshot never moves, and (before this fix) `panel_save_workflow` answered
+ * `{"saved": true}` while the file came back WITHOUT the group. The same stale snapshot
+ * is what the binding fence sees, which is the `root-shape-mismatch` half of #1563.
+ *
+ * The window is opened here by setting one of upstream's OWN flags, the way an undo
+ * restore sets it — not by stubbing the panel. The unit suites pin the verdict and the wiring;
+ * this spec is the part they cannot reach: that the refusal actually reaches
+ * `panel_save_workflow` through ComfyUI's real save funnel, that the file on disk is
+ * untouched, and that the guard CLEARS — a guard that wedged saving would be a worse
+ * bug than the one it fixes.
+ *
+ * #1564 is why this spec does not test "await the capture": that experiment was run on
+ * the live panel and failed. A suppressed capture returns `undefined` synchronously —
+ * there is nothing to await.
+ *
+ * PREREQUISITE: a real ComfyUI at http://localhost:8188 with this pack linked into
+ * custom_nodes and CORS enabled (see playwright.config.ts).
+ */
+import { test, expect, deleteSavedWorkflow } from './fixtures/panelTest'
+import type { MockBridge } from './fixtures/MockBridge'
+import { routeWorktreeSource } from './fixtures/worktreeSource'
+
+interface CmdReply {
+  ok: boolean
+  result?: Record<string, any>
+  error?: string
+}
+
+async function cmd(
+  bridge: MockBridge,
+  name: string,
+  args: Record<string, unknown> = {},
+  timeoutMs = 30_000
+): Promise<CmdReply> {
+  const reply = (await bridge.command(name, args, timeoutMs)) as unknown as CmdReply
+  return { ok: !!reply.ok, result: reply.result, error: reply.error }
+}
+
+test.beforeEach(async ({ context }) => {
+  await routeWorktreeSource(context)
+})
+
+test.describe('a save whose snapshot is behind the canvas (panel#1563)', () => {
+  test('is refused instead of silently writing a file without the new group', async ({
+    panel,
+    mockBridge
+  }) => {
+    test.setTimeout(120_000)
+    await panel.goto()
+    await panel.setBridgeUrl(mockBridge.url)
+    await panel.page
+      .locator('[class~="comfyui-mcp.agent-tab-button"]')
+      .first()
+      .click({ timeout: 20_000 })
+    await panel.page.locator('.cmcp-root').waitFor({ state: 'visible', timeout: 20_000 })
+    await panel.connect()
+
+    const name = `cmcp-e2e-1563-${Date.now()}`
+    const path = `workflows/${name}.json`
+
+    /**
+     * Open or close one of upstream's OWN suppression windows. `_restoringState` is the
+     * flag ComfyUI holds for the whole of an undo/redo restore (it awaits
+     * `loadGraphData`), so a panel command arriving during one meets exactly this. It is
+     * used here rather than `isLoadingGraph` because that static also gates unrelated
+     * frontend work — with it set, `graph_create_group` itself fails with "Illegal
+     * invocation", which would test the harness rather than the guard.
+     */
+    const setSuppressionWindow = (open: boolean) =>
+      panel.page.evaluate((isOpen) => {
+        const app = (window as any).app
+        const tracker = app?.extensionManager?.workflow?.activeWorkflow?.changeTracker
+        if (!tracker) return false
+        tracker._restoringState = isOpen
+        return tracker._restoringState === isOpen
+      }, open)
+
+    const groupsOnDisk = () =>
+      panel.page.evaluate(async (p) => {
+        const api = (window as any).comfyAPI?.api?.api
+        const res = await api.fetchApi(`/userdata/${encodeURIComponent(p)}`)
+        if (!res?.ok) return { error: `HTTP ${res?.status}` }
+        const json = await res.json()
+        return {
+          nodes: Array.isArray(json?.nodes) ? json.nodes.length : null,
+          titles: (Array.isArray(json?.groups) ? json.groups : []).map((g: any) => g?.title)
+        }
+      }, path)
+
+    try {
+      await cmd(mockBridge, 'graph_clear')
+      const ids: number[] = []
+      for (let i = 0; i < 4; i++) {
+        const added = await cmd(mockBridge, 'graph_add_node', { class_type: 'VAEDecode' })
+        ids.push(Number(added.result?.added?.id))
+      }
+      // Spread them so the two groups cannot overlap into one another's box.
+      await panel.page.evaluate((nodeIds) => {
+        const graph = (window as any).app.graph
+        nodeIds.forEach((id: number, i: number) => {
+          const node = graph.getNodeById(id)
+          if (node) node.pos = [200 + i * 600, 200]
+        })
+      }, ids)
+
+      const pre = await cmd(mockBridge, 'graph_create_group', { title: 'Pre', node_ids: [ids[0]] })
+      expect(pre.ok, pre.error).toBe(true)
+      const saved = await cmd(mockBridge, 'workflow_save', { name })
+      expect(saved.ok, saved.error).toBe(true)
+      expect(await groupsOnDisk()).toMatchObject({ titles: ['Pre'] })
+
+      // ---- the reported sequence -------------------------------------------
+      // Let upstream's 50ms debounced `squashState` (scheduled by the save's own
+      // capture) drain FIRST. It re-captures without checking `_restoringState`, so a
+      // squash still in flight would heal the snapshot and this spec would silently
+      // stop exercising the defect.
+      await panel.page.waitForTimeout(300)
+      expect(await setSuppressionWindow(true)).toBe(true)
+
+      const created = await cmd(mockBridge, 'graph_create_group', {
+        title: 'Added',
+        node_ids: [ids[2], ids[3]]
+      })
+      expect(created.ok, created.error).toBe(true)
+
+      // The canvas HAS the group; the tracker snapshot does not — read both from the
+      // engine so a drifted precondition is diagnosable rather than a mystery.
+      const drift = await panel.page.evaluate(() => {
+        const app = (window as any).app
+        const tracker = app?.extensionManager?.workflow?.activeWorkflow?.changeTracker
+        return {
+          live: (app?.rootGraph?.serialize?.()?.groups ?? []).length,
+          snapshot: (tracker?.activeState?.groups ?? []).length
+        }
+      })
+      expect(drift, JSON.stringify(drift)).toEqual({ live: 2, snapshot: 1 })
+
+      const lossy = await cmd(mockBridge, 'workflow_save', {})
+      expect(lossy.ok, `the save must NOT report success: ${JSON.stringify(lossy.result)}`).toBe(
+        false
+      )
+      expect(lossy.error ?? '').toMatch(/BEHIND the live canvas/)
+      expect(lossy.error ?? '').toMatch(/NOTHING was written/)
+
+      // And nothing was written: the file still holds exactly what it held before.
+      expect(await groupsOnDisk()).toMatchObject({ nodes: 4, titles: ['Pre'] })
+
+      // ---- and the guard CLEARS ---------------------------------------------
+      // Every suppression condition upstream is transient. Once the window closes the
+      // save must go through and carry the group with it — a guard that wedged saving
+      // would trade data loss for a cannot-save bug.
+      expect(await setSuppressionWindow(false)).toBe(true)
+      const healed = await cmd(mockBridge, 'workflow_save', {})
+      expect(healed.ok, healed.error).toBe(true)
+      expect(await groupsOnDisk()).toMatchObject({ nodes: 4, titles: ['Pre', 'Added'] })
+    } finally {
+      await setSuppressionWindow(false).catch(() => false)
+      await deleteSavedWorkflow(panel.page, name)
+    }
+  })
+})

--- a/browser_tests/unit/change-tracker-snapshot.test.mjs
+++ b/browser_tests/unit/change-tracker-snapshot.test.mjs
@@ -25,7 +25,7 @@ test("#581 defers the captured tracker snapshot and preserves its receiver", () 
     deferChangeTrackerSnapshot(tracker, (callback, ms) => {
       queued = callback;
       delay = ms;
-    }),
+    }, () => {}, owns(tracker)),
     true,
   );
   assert.equal(calls, 0, "the expensive serialization cannot run before the reply path returns");
@@ -155,7 +155,7 @@ test("#1723 defers and flushes on a tracker that only has captureCanvasState", (
   const tracker = { captureCanvasState() { calls += 1; } };
   let queued = null;
   assert.equal(
-    deferChangeTrackerSnapshot(tracker, (callback) => { queued = callback; }),
+    deferChangeTrackerSnapshot(tracker, (callback) => { queued = callback; }, () => {}, owns(tracker)),
     true,
     "a current-frontend tracker must still queue — checkState-only support leaves the fingerprint stale forever",
   );
@@ -186,6 +186,9 @@ test("#1723 wires the flush BEFORE the graph-binding fence in the dispatch path"
 /** Upstream's own shape, reduced to what decides this: `captureCanvasState()` returns
  *  early — no throw, no value — while a suppression window is open, and only replaces
  *  `activeState` when it actually runs and the canvas moved. */
+/** A POSITIVE ownership answer: the store names THIS tracker as the active one. */
+const owns = (tracker) => (candidate) => candidate === tracker;
+
 function upstreamTracker({ suppressed = false } = {}) {
   return {
     activeState: { nodes: [], generation: 0 },
@@ -227,7 +230,7 @@ test("#1563 a SWALLOWED deferred capture is retried until upstream stops skippin
   deferChangeTrackerSnapshot(tracker, (cb, ms) => {
     queue.push({ cb, ms });
     return queue.length;
-  }, () => {});
+  }, () => {}, owns(tracker));
 
   queue.shift().cb(); // first attempt: swallowed
   assert.equal(tracker.activeState.generation, 0, "upstream skipped it");
@@ -249,7 +252,7 @@ test("#1563 the retry chain is BOUNDED — a window that never closes cannot spi
   deferChangeTrackerSnapshot(tracker, (cb) => {
     queue.push(cb);
     return queue.length;
-  }, () => {});
+  }, () => {}, owns(tracker));
   let fired = 0;
   while (queue.length && fired < 50) {
     queue.shift()();
@@ -269,7 +272,7 @@ test("#1563 a NO-CHANGE capture is not retried — an unchanged snapshot is the 
   deferChangeTrackerSnapshot(tracker, (cb) => {
     queue.push(cb);
     return queue.length;
-  }, () => {});
+  }, () => {}, owns(tracker));
   queue.shift()();
   assert.equal(tracker.calls, 1);
   assert.equal(queue.length, 0, "an unchanged snapshot on a readable, unsuppressed tracker is not a swallowed call");
@@ -371,20 +374,62 @@ test("#1563 r2 an ownership question that THROWS is not a licence to write", () 
   assert.equal(queue.length, 0);
 });
 
-test("#1563 r2 a caller that supplies NO ownership predicate is unchanged", () => {
-  // The predicate only ever withdraws a licence it can positively see is gone; absent
-  // one, the chain behaves exactly as it did before r2.
+test("#1563 r3 a caller that supplies NO ownership predicate captures NOTHING, and says so", async () => {
+  // r2 asserted the opposite — "no predicate ⇒ behaves as before" — and that assertion
+  // WAS the P1: with no way to establish ownership the module cannot know whose canvas
+  // it is about to serialize, and "as before" was the unguarded write. Fail closed.
+  // A FRESH module instance: the disclosure is deliberately once-per-session, so
+  // asserting it against the shared import would pass or fail on test ORDER.
+  const fresh = await import(`../../web/js/lib/change-tracker-snapshot.js?r3=${Date.now()}`);
+  const tracker = upstreamTracker();
+  const warnings = [];
+  const realWarn = console.warn;
+  console.warn = (...args) => warnings.push(args.join(" "));
+  try {
+    const queue = [];
+    fresh.deferChangeTrackerSnapshot(tracker, (cb) => {
+      queue.push(cb);
+      return queue.length;
+    }, () => {});
+    queue.shift()();
+    assert.equal(tracker.calls, 0, "an unestablished owner may not authorise a capture");
+    assert.equal(queue.length, 0, "and the chain does not keep asking");
+  } finally {
+    console.warn = realWarn;
+  }
+  // Failing closed silently is how a missing guard survives a release (#1667).
+  assert.equal(warnings.length, 1);
+  assert.match(warnings[0], /without an ownership predicate/);
+});
+
+test("#1563 r3 an UNANSWERABLE ownership question abandons the chain", () => {
+  // The shape codex caught at the call site: `activeWorkflowRef()` answers null both
+  // when nothing is active and when the lookup failed. Neither is "still yours".
+  for (const answer of [null, undefined, 0, "", NaN]) {
+    const tracker = upstreamTracker({ suppressed: true });
+    const queue = [];
+    deferChangeTrackerSnapshot(tracker, (cb) => {
+      queue.push(cb);
+      return queue.length;
+    }, () => {}, () => answer);
+    queue.shift()();
+    assert.equal(tracker.calls, 0, `answer ${String(answer)} must not authorise a capture`);
+    assert.equal(queue.length, 0, `answer ${String(answer)} must not leave a chain armed`);
+  }
+});
+
+test("#1563 r3 a TRUTHY-but-not-true answer is still not permission", () => {
+  // `=== true` deliberately, not truthiness: a predicate returning an object (a
+  // workflow record, say) is answering a different question than the one asked.
   const tracker = upstreamTracker({ suppressed: true });
   const queue = [];
   deferChangeTrackerSnapshot(tracker, (cb) => {
     queue.push(cb);
     return queue.length;
-  }, () => {});
+  }, () => {}, () => ({ changeTracker: tracker }));
   queue.shift()();
-  assert.ok(queue.length > 0, "no predicate ⇒ the retry chain is armed as before");
-  tracker.changeCount = 0;
-  queue.shift()();
-  assert.equal(tracker.activeState.generation, 1, "and it still catches the snapshot up");
+  assert.equal(tracker.calls, 0);
+  assert.equal(queue.length, 0);
 });
 
 test("#1563 r2 a NEW defer cancels the previous record's armed chain", () => {

--- a/browser_tests/unit/change-tracker-snapshot.test.mjs
+++ b/browser_tests/unit/change-tracker-snapshot.test.mjs
@@ -191,6 +191,13 @@ test("#1563 upstream's three suppression conditions are read; an unknown tracker
   assert.equal(trackerCaptureSuppressed({}), false);
   assert.equal(trackerCaptureSuppressed(null), false);
   assert.equal(trackerCaptureSuppressed({ changeCount: 0, _restoringState: false }), false);
+  // TRUTHY, not `=== true`. `captureWasSuppressed` (#882, the destructive close path)
+  // delegates here and read these flags as truthy before the refactor; a strict identity
+  // check would silently narrow that fail-closed guard.
+  assert.equal(trackerCaptureSuppressed({ _restoringState: 1 }), true);
+  class LoadingTruthy {}
+  LoadingTruthy.isLoadingGraph = 1;
+  assert.equal(trackerCaptureSuppressed(new LoadingTruthy()), true);
 });
 
 test("#1563 a SWALLOWED deferred capture is retried until upstream stops skipping it", () => {

--- a/browser_tests/unit/change-tracker-snapshot.test.mjs
+++ b/browser_tests/unit/change-tracker-snapshot.test.mjs
@@ -56,7 +56,11 @@ test("#581 wires the deferred snapshot after delivering a successful command rep
   // reason unrelated to what it checks.
   const deliver = source.slice(capture).search(/if \(deliverReply\(reply, msg\.cmd, superseded[,)]/);
   const deliverAt = deliver === -1 ? -1 : capture + deliver;
-  const defer = source.indexOf("deferChangeTrackerSnapshot(changeTrackerToSnapshot)", deliverAt);
+  // panel#1563 r2 — matched WITHOUT the closing paren, for the reason stated above: the
+  // claim is about ORDER, and the call grew a fourth argument (the ownership predicate
+  // that stops an orphaned retry chain). Pinning the arity again would break a passing
+  // assertion for a reason unrelated to what it checks.
+  const defer = source.indexOf("deferChangeTrackerSnapshot(changeTrackerToSnapshot", deliverAt);
   assert.ok(capture >= 0, "successful executor path captures its tracker");
   assert.ok(deliverAt > capture, "reply delivery follows the successful executor");
   assert.ok(defer > deliverAt, "snapshot is scheduled only after the reply is delivered");
@@ -91,15 +95,32 @@ test("#1723 flush refuses a tracker that does not own the pending snapshot", () 
   const trackerA = { checkState() { callsA += 1; } };
   const trackerB = { checkState() { assert.fail("tracker B must never be captured by A's snapshot"); } };
   let queued = null;
-  assert.equal(deferChangeTrackerSnapshot(trackerA, (callback) => { queued = callback; }), true);
+  let live = false;
+  const schedule = (callback) => {
+    queued = callback;
+    live = true;
+    return "timer-A";
+  };
+  const cancel = (timer) => {
+    if (timer === "timer-A") live = false;
+  };
+  assert.equal(deferChangeTrackerSnapshot(trackerA, schedule, cancel), true);
 
-  // A tab switch in the window: the pending capture belongs to A and stays deferred.
+  // A tab switch in the window. A's capture is never run against B's tracker — that
+  // refusal is #1723's and is unchanged.
   assert.equal(flushPendingChangeTrackerSnapshot(trackerB), false);
-  assert.equal(flushPendingChangeTrackerSnapshot(null), false);
   assert.equal(callsA, 0);
-  // The original timer still fires for A, exactly once.
-  queued();
-  assert.equal(callsA, 1);
+  // panel#1563 r2 — and A's timer is DISARMED, not left deferred. This flush is called
+  // with the active workflow's tracker, so a record for another tracker is stranded:
+  // when it fired it would serialize B's canvas into A's snapshot, and a later save of
+  // A would write B's graph over A's file. #1723's original "stays deferred" was the
+  // hazard, not a feature — upstream refuses a non-active tracker's capture anyway.
+  assert.equal(live, false, "the stranded record's timer must be cancelled");
+  assert.equal(flushPendingChangeTrackerSnapshot(trackerA), false, "the record is gone, not merely skipped");
+  assert.equal(callsA, 0, "nothing was captured for A after it lost the canvas");
+  // A null tracker is not evidence that anything was stranded: nothing to disarm.
+  assert.equal(flushPendingChangeTrackerSnapshot(null), false);
+  assert.equal(typeof queued, "function");
 });
 
 test("#1723 a stale timer must not clear a NEWER pending record", () => {
@@ -252,6 +273,143 @@ test("#1563 a NO-CHANGE capture is not retried — an unchanged snapshot is the 
   queue.shift()();
   assert.equal(tracker.calls, 1);
   assert.equal(queue.length, 0, "an unchanged snapshot on a readable, unsuppressed tracker is not a swallowed call");
+});
+
+// ---------------------------------------------------------------------------
+// panel#1563 r2 — THE ORPHANED CHAIN. A capture serializes the GLOBAL live canvas
+// into THIS tracker's `activeState`, so a chain that outlives its workflow does not
+// just waste a timer: it writes whatever canvas is on screen now into the snapshot of
+// the workflow that armed it, and a later save of that workflow persists the wrong
+// graph over its file. The retry window is exactly where that became reachable —
+// `isLoadingGraph` is a CLASS STATIC, so an orphaned record reads "suppressed" for the
+// whole of the NEXT workflow's load and then fires the moment that load completes.
+// ---------------------------------------------------------------------------
+
+test("#1563 r2 WIRING: the dispatch path SUPPLIES the ownership predicate, and it reads the store live", () => {
+  // The helper tests above inject a predicate by hand, so they stay green even if
+  // production stops passing one — the argument is a one-line wiring change and this is
+  // the only thing that can see it go missing.
+  const here = dirname(fileURLToPath(import.meta.url));
+  const source = readFileSync(join(here, "../../web/js/comfyui-mcp-panel.js"), "utf8").replace(/\r\n/g, "\n");
+  const at = source.indexOf("deferChangeTrackerSnapshot(changeTrackerToSnapshot");
+  assert.ok(at > 0, "the dispatch path defers the tracker snapshot");
+  const call = source.slice(at, at + 400);
+  assert.match(
+    call,
+    /deferChangeTrackerSnapshot\(\s*changeTrackerToSnapshot\s*,[^)]*\(tracker\)\s*=>/,
+    "the defer must carry an ownership predicate, or an orphaned retry chain can capture another workflow's canvas",
+  );
+  assert.match(
+    call,
+    /activeWorkflowRef\(\)/,
+    "ownership must be re-read from the store when the timer fires, not captured at defer time",
+  );
+  assert.match(
+    call,
+    /active\.changeTracker === tracker/,
+    "ownership is tracker identity against the ACTIVE workflow",
+  );
+});
+
+test("#1563 r2 the retry chain STOPS once its tracker no longer owns the canvas", () => {
+  const trackerA = upstreamTracker({ suppressed: true });
+  const queue = [];
+  let ownsCanvas = true;
+  deferChangeTrackerSnapshot(
+    trackerA,
+    (cb, ms) => {
+      queue.push({ cb, ms });
+      return queue.length;
+    },
+    () => {},
+    (tracker) => tracker === trackerA && ownsCanvas,
+  );
+
+  queue.shift().cb(); // swallowed while A still owns the canvas: the chain continues
+  assert.ok(queue.length > 0, "a swallowed capture on the OWNING tracker still retries");
+
+  // Workflow B opens. A's tracker keeps reading "suppressed" (isLoadingGraph is a class
+  // static), and when the load finishes the canvas on screen is B's.
+  ownsCanvas = false;
+  trackerA.changeCount = 0; // the window closes — WITHOUT the ownership check this captures
+  queue.shift().cb();
+
+  assert.equal(
+    trackerA.activeState.generation,
+    0,
+    "the orphaned chain must NOT capture: that write would stamp workflow B's canvas into workflow A's snapshot",
+  );
+  assert.equal(queue.length, 0, "and the chain ends rather than asking again");
+});
+
+test("#1563 r2 an ownership question that THROWS is not a licence to write", () => {
+  const tracker = upstreamTracker({ suppressed: true });
+  const queue = [];
+  deferChangeTrackerSnapshot(
+    tracker,
+    (cb) => {
+      queue.push(cb);
+      return queue.length;
+    },
+    () => {},
+    () => {
+      throw new Error("workflow store torn down mid-reload");
+    },
+  );
+  tracker.changeCount = 0;
+  queue.shift()();
+  assert.equal(tracker.activeState.generation, 0, "unreadable ownership must not capture");
+  assert.equal(queue.length, 0);
+});
+
+test("#1563 r2 a caller that supplies NO ownership predicate is unchanged", () => {
+  // The predicate only ever withdraws a licence it can positively see is gone; absent
+  // one, the chain behaves exactly as it did before r2.
+  const tracker = upstreamTracker({ suppressed: true });
+  const queue = [];
+  deferChangeTrackerSnapshot(tracker, (cb) => {
+    queue.push(cb);
+    return queue.length;
+  }, () => {});
+  queue.shift()();
+  assert.ok(queue.length > 0, "no predicate ⇒ the retry chain is armed as before");
+  tracker.changeCount = 0;
+  queue.shift()();
+  assert.equal(tracker.activeState.generation, 1, "and it still catches the snapshot up");
+});
+
+test("#1563 r2 a NEW defer cancels the previous record's armed chain", () => {
+  const trackerA = upstreamTracker({ suppressed: true });
+  const trackerB = upstreamTracker();
+  const cancelled = [];
+  let id = 0;
+  const schedule = (cb) => {
+    id += 1;
+    return { id, cb };
+  };
+  deferChangeTrackerSnapshot(trackerA, schedule, (timer) => cancelled.push(timer?.id));
+  deferChangeTrackerSnapshot(trackerB, schedule, (timer) => cancelled.push(timer?.id));
+  assert.deepEqual(cancelled, [1], "replacing the pending marker must also disarm the record it replaced");
+});
+
+test("#1563 r2 a flush for a DIFFERENT tracker cancels the stranded chain", () => {
+  // The flush is called with the ACTIVE workflow's tracker before every graph command,
+  // so a pending record for another tracker is provably stranded.
+  const trackerA = upstreamTracker({ suppressed: true });
+  const trackerB = upstreamTracker();
+  const queue = [];
+  let cancelled = 0;
+  deferChangeTrackerSnapshot(trackerA, (cb) => {
+    queue.push(cb);
+    return queue.length;
+  }, () => {
+    cancelled += 1;
+  });
+  queue.length = 0;
+
+  assert.equal(flushPendingChangeTrackerSnapshot(trackerB), false, "a foreign tracker is never flushed");
+  assert.equal(cancelled, 1, "and the stranded record is disarmed rather than left to fire on B's canvas");
+  assert.equal(flushPendingChangeTrackerSnapshot(trackerA), false, "the stranded record is gone, not merely skipped");
 });
 
 test("#1563 a flush upstream swallows keeps the record PENDING for the next command", () => {

--- a/browser_tests/unit/change-tracker-snapshot.test.mjs
+++ b/browser_tests/unit/change-tracker-snapshot.test.mjs
@@ -285,30 +285,39 @@ test("#1563 a NO-CHANGE capture is not retried — an unchanged snapshot is the 
 // whole of the NEXT workflow's load and then fires the moment that load completes.
 // ---------------------------------------------------------------------------
 
-test("#1563 r2 WIRING: the dispatch path SUPPLIES the ownership predicate, and it reads the store live", () => {
+test("#1563 r2 WIRING: the dispatch path supplies trackerStillOwnsCanvas, and it demands POSITIVE ownership", () => {
   // The helper tests above inject a predicate by hand, so they stay green even if
-  // production stops passing one — the argument is a one-line wiring change and this is
-  // the only thing that can see it go missing.
+  // production stops passing one — the argument is a one-line wiring change, and this is
+  // the only thing that can see it go missing. The predicate itself is sliced from the
+  // panel source and DRIVEN, so its answer is pinned rather than its spelling.
   const here = dirname(fileURLToPath(import.meta.url));
   const source = readFileSync(join(here, "../../web/js/comfyui-mcp-panel.js"), "utf8").replace(/\r\n/g, "\n");
   const at = source.indexOf("deferChangeTrackerSnapshot(changeTrackerToSnapshot");
   assert.ok(at > 0, "the dispatch path defers the tracker snapshot");
-  const call = source.slice(at, at + 400);
   assert.match(
-    call,
-    /deferChangeTrackerSnapshot\(\s*changeTrackerToSnapshot\s*,[^)]*\(tracker\)\s*=>/,
-    "the defer must carry an ownership predicate, or an orphaned retry chain can capture another workflow's canvas",
+    source.slice(at, at + 200),
+    /deferChangeTrackerSnapshot\(\s*changeTrackerToSnapshot\s*,[^)]*trackerStillOwnsCanvas/,
+    "the defer must carry the ownership predicate, or an orphaned retry chain can capture another workflow's canvas",
   );
-  assert.match(
-    call,
-    /activeWorkflowRef\(\)/,
-    "ownership must be re-read from the store when the timer fires, not captured at defer time",
-  );
-  assert.match(
-    call,
-    /active\.changeTracker === tracker/,
-    "ownership is tracker identity against the ACTIVE workflow",
-  );
+
+  const fnAt = source.indexOf("function trackerStillOwnsCanvas(tracker) {");
+  assert.ok(fnAt > 0, "the predicate must be a named function, not an inline closure");
+  const fnEnd = source.indexOf("\n}", fnAt);
+  const slice = source.slice(fnAt, fnEnd + 2);
+  const build = (activeWorkflow) =>
+    new Function("activeWorkflowRef", `${slice}\nreturn trackerStillOwnsCanvas;`)(() => activeWorkflow);
+
+  const tracker = { captureCanvasState() {} };
+  const other = { captureCanvasState() {} };
+  assert.equal(build({ changeTracker: tracker })(tracker), true, "the owning tracker keeps its licence");
+  assert.equal(build({ changeTracker: other })(tracker), false, "another workflow's tracker has none");
+  // THE POINT: an unreadable store is NOT permission. During a tab switch or a close the
+  // store answers null while the canvas on screen is already someone else's, and a
+  // capture then writes that canvas into this tracker's state — which a later save
+  // persists over its own file.
+  assert.equal(build(null)(tracker), false, "a null active workflow must never license a capture");
+  assert.equal(build(undefined)(tracker), false);
+  assert.equal(build({})(tracker), false, "an active workflow with no tracker proves nothing");
 });
 
 test("#1563 r2 the retry chain STOPS once its tracker no longer owns the canvas", () => {

--- a/browser_tests/unit/change-tracker-snapshot.test.mjs
+++ b/browser_tests/unit/change-tracker-snapshot.test.mjs
@@ -7,6 +7,7 @@ import { dirname, join } from "node:path";
 import {
   deferChangeTrackerSnapshot,
   flushPendingChangeTrackerSnapshot,
+  trackerCaptureSuppressed,
 } from "../../web/js/lib/change-tracker-snapshot.js";
 
 test("#581 defers the captured tracker snapshot and preserves its receiver", () => {
@@ -155,4 +156,113 @@ test("#1723 wires the flush BEFORE the graph-binding fence in the dispatch path"
   const fence = source.indexOf("assertGraphBoundToActiveWorkflow(graph, rootGraph, graphCommandBindingBar(msg.cmd))");
   assert.ok(flush >= 0, "the dispatch path flushes a pending tracker snapshot");
   assert.ok(fence > flush, "the flush lands before the binding fence reads the tracker");
+});
+
+// ---------------------------------------------------------------------------
+// panel#1563/#1564 — a capture upstream SILENTLY skips.
+// ---------------------------------------------------------------------------
+
+/** Upstream's own shape, reduced to what decides this: `captureCanvasState()` returns
+ *  early — no throw, no value — while a suppression window is open, and only replaces
+ *  `activeState` when it actually runs and the canvas moved. */
+function upstreamTracker({ suppressed = false } = {}) {
+  return {
+    activeState: { nodes: [], generation: 0 },
+    changeCount: suppressed ? 1 : 0,
+    _restoringState: false,
+    calls: 0,
+    captureCanvasState() {
+      this.calls += 1;
+      if (this._restoringState || this.changeCount > 0) return; // the silent early return
+      this.activeState = { nodes: [], generation: this.activeState.generation + 1 };
+    },
+  };
+}
+
+test("#1563 upstream's three suppression conditions are read; an unknown tracker is NOT suppressed", () => {
+  assert.equal(trackerCaptureSuppressed({ changeCount: 1 }), true);
+  assert.equal(trackerCaptureSuppressed({ _restoringState: true }), true);
+  class Loading {}
+  Loading.isLoadingGraph = true;
+  assert.equal(trackerCaptureSuppressed(new Loading()), true);
+  // POSITIVE evidence only: a tracker whose fields this panel cannot read must not put
+  // the retry chain into a spin. (The destructive close path's `captureWasSuppressed`
+  // deliberately answers the other way; see its comment.)
+  assert.equal(trackerCaptureSuppressed({}), false);
+  assert.equal(trackerCaptureSuppressed(null), false);
+  assert.equal(trackerCaptureSuppressed({ changeCount: 0, _restoringState: false }), false);
+});
+
+test("#1563 a SWALLOWED deferred capture is retried until upstream stops skipping it", () => {
+  const tracker = upstreamTracker({ suppressed: true });
+  const queue = [];
+  deferChangeTrackerSnapshot(tracker, (cb, ms) => {
+    queue.push({ cb, ms });
+    return queue.length;
+  }, () => {});
+
+  queue.shift().cb(); // first attempt: swallowed
+  assert.equal(tracker.activeState.generation, 0, "upstream skipped it");
+  assert.ok(queue.length > 0, "a swallowed capture must leave a retry armed — otherwise the snapshot is stranded behind the canvas forever");
+
+  queue.shift().cb(); // still suppressed
+  assert.equal(tracker.activeState.generation, 0);
+  assert.ok(queue.length > 0);
+
+  tracker.changeCount = 0; // the transient window closes
+  queue.shift().cb();
+  assert.equal(tracker.activeState.generation, 1, "the snapshot catches up once upstream allows it");
+  assert.equal(queue.length, 0, "a landed capture arms nothing further");
+});
+
+test("#1563 the retry chain is BOUNDED — a window that never closes cannot spin forever", () => {
+  const tracker = upstreamTracker({ suppressed: true });
+  const queue = [];
+  deferChangeTrackerSnapshot(tracker, (cb) => {
+    queue.push(cb);
+    return queue.length;
+  }, () => {});
+  let fired = 0;
+  while (queue.length && fired < 50) {
+    queue.shift()();
+    fired += 1;
+  }
+  assert.equal(queue.length, 0, "the chain terminates");
+  assert.ok(fired <= 10, `bounded attempts, got ${fired}`);
+  assert.equal(tracker.activeState.generation, 0, "nothing was captured — that is what the save guard then refuses on");
+});
+
+test("#1563 a NO-CHANGE capture is not retried — an unchanged snapshot is the clean-tab case", () => {
+  const tracker = upstreamTracker();
+  tracker.captureCanvasState = function () {
+    this.calls += 1; // ran, saw no difference, left activeState alone
+  };
+  const queue = [];
+  deferChangeTrackerSnapshot(tracker, (cb) => {
+    queue.push(cb);
+    return queue.length;
+  }, () => {});
+  queue.shift()();
+  assert.equal(tracker.calls, 1);
+  assert.equal(queue.length, 0, "an unchanged snapshot on a readable, unsuppressed tracker is not a swallowed call");
+});
+
+test("#1563 a flush upstream swallows keeps the record PENDING for the next command", () => {
+  const tracker = upstreamTracker({ suppressed: true });
+  const queue = [];
+  const schedule = (cb) => {
+    queue.push(cb);
+    return queue.length;
+  };
+  deferChangeTrackerSnapshot(tracker, schedule, () => {});
+  queue.length = 0; // the fence's flush pre-empts the timer
+
+  assert.equal(flushPendingChangeTrackerSnapshot(tracker), true);
+  assert.equal(tracker.activeState.generation, 0, "the flush was swallowed too");
+  assert.ok(queue.length > 0, "the swallowed flush must re-arm rather than consume the record");
+  // The record is still THIS tracker's, so the next command's flush can still take it.
+  tracker.changeCount = 0;
+  assert.equal(flushPendingChangeTrackerSnapshot(tracker), true);
+  assert.equal(tracker.activeState.generation, 1);
+  assert.equal(flushPendingChangeTrackerSnapshot(tracker), false, "a LANDED flush consumes the record");
 });

--- a/browser_tests/unit/save-path-guard.test.mjs
+++ b/browser_tests/unit/save-path-guard.test.mjs
@@ -362,6 +362,13 @@ function staleFixture({ suppressed = true, live = "extra-group", active = true }
       this.saved.push(wf.path);
     },
   };
+  // panel#1563 r4 — the COPY point. `workflowStore.saveAs` seeds the new record from
+  // `existingWorkflow.activeState`, so a stale source snapshot becomes a stale file.
+  store.copies = [];
+  store.saveAs = function (sourceWf, path) {
+    this.copies.push({ from: sourceWf?.path, to: path });
+    return { path, isTemporary: false };
+  };
   return {
     store,
     wfA,
@@ -496,4 +503,72 @@ test("#1563 WIRING: the wrapper passes its own observation, not a constant", () 
     /snapshotIsStale: saveWouldPersistStaleSnapshot\(wf, state\)/,
     "the stale-snapshot evidence must be computed from the SAME state the write serializes",
   );
+});
+
+// ---------------------------------------------------------------------------
+// 4. panel#1563 r4 — the Save-As COPY point, where the evidence still exists.
+// ---------------------------------------------------------------------------
+
+test("#1563 r4 WRAPPER: a Save-As is refused BEFORE the stale snapshot is copied", () => {
+  // The gate's P1: the `saveWorkflow` wrapper cannot catch this. `saveAs` seeds the copy
+  // from the SOURCE's snapshot, `openWorkflow` then loads that stale state onto the
+  // canvas, and the fresh target tracker captures it — so by the time the save reaches
+  // the other wrapper the tracker is unsuppressed AND the canvas agrees with the
+  // snapshot. Every piece of evidence is gone. It has to be caught here.
+  const { buildInstaller: build } = buildInstaller();
+  const fx = staleFixture();
+  const install = build({ activeWorkflow: fx.activeWorkflow, rootGraph: fx.rootGraph });
+  install(fx.appRef);
+  assert.throws(() => fx.store.saveAs(fx.wfA, "workflows/Copy.json"), /BEHIND the live canvas/);
+  assert.deepEqual(fx.store.copies, [], "no copy may be created from a stale snapshot");
+  assert.deepEqual(fx.store.saved, [], "and nothing may be written");
+});
+
+test("#1563 r4 WRAPPER: a healthy Save-As still copies", () => {
+  const { buildInstaller: build } = buildInstaller();
+  const fx = staleFixture({ suppressed: false });
+  const install = build({ activeWorkflow: fx.activeWorkflow, rootGraph: fx.rootGraph });
+  install(fx.appRef);
+  const made = fx.store.saveAs(fx.wfA, "workflows/Copy.json");
+  assert.equal(made.path, "workflows/Copy.json");
+  assert.deepEqual(fx.store.copies, [{ from: "workflows/A.json", to: "workflows/Copy.json" }]);
+});
+
+test("#1563 r4 WRAPPER: a Save-As of an INACTIVE source is not judged against this canvas", () => {
+  const { buildInstaller: build } = buildInstaller();
+  const fx = staleFixture({ active: false });
+  const install = build({ activeWorkflow: fx.activeWorkflow, rootGraph: fx.rootGraph });
+  install(fx.appRef);
+  fx.store.saveAs(fx.wfA, "workflows/Copy.json");
+  assert.equal(fx.store.copies.length, 1);
+});
+
+test("#1563 r4 WRAPPER: a frontend with no saveAs is DISCLOSED, not silently unguarded", () => {
+  const { buildInstaller: build, warnings } = buildInstaller();
+  const fx = staleFixture();
+  delete fx.store.saveAs;
+  const install = build({ activeWorkflow: fx.activeWorkflow, rootGraph: fx.rootGraph });
+  install(fx.appRef);
+  assert.equal(warnings.length, 1);
+  assert.match(warnings[0], /saveAs is unavailable/);
+});
+
+test("#1563 r4 WIRING: the guard is installed on the COPY point, from the source's own state", () => {
+  const source = PANEL_SRC();
+  const at = source.indexOf("svc.saveAs = function (sourceWf, destPath, ...rest) {");
+  assert.ok(at > 0, "the save funnel must wrap workflowStore.saveAs");
+  const body = source.slice(at, at + 1400);
+  assert.match(
+    body,
+    /sourceWf\?\.changeTracker\?\.activeState \?\? sourceWf\?\.activeState/,
+    "the evidence must come from the SOURCE snapshot the copy is built from",
+  );
+  assert.match(
+    body,
+    /snapshotIsStale: saveWouldPersistStaleSnapshot\(sourceWf, sourceState\)/,
+    "and it must be the same predicate, not a re-derived one",
+  );
+  const throwAt = body.indexOf("throw workflowSaveRefusalError(verdict);");
+  const callAt = body.indexOf("return origSaveAs(");
+  assert.ok(throwAt > 0 && callAt > throwAt, "the refusal must precede the copy");
 });

--- a/browser_tests/unit/save-path-guard.test.mjs
+++ b/browser_tests/unit/save-path-guard.test.mjs
@@ -19,6 +19,13 @@
  *   2. The REAL `installSavePathGuard`, extracted from the panel source and driven
  *      over a fake workflow store, proving the wrapper throws BEFORE the original
  *      save is called — nothing is written — and that a healthy save passes through.
+ *
+ * panel#1563/#1564 added a SECOND refusal to the same funnel: the state about to be
+ * written is not foreign, it is simply BEHIND the canvas, because upstream's pre-save
+ * `captureCanvasState()` was silently skipped. Same outcome as #1667 — a save that
+ * reports success and loses the user's work — reached without any identity crossing.
+ * Its cases live at the bottom of this file, pinned on both sides: the refusal, and
+ * every shape that must still save.
  */
 import test from "node:test";
 import assert from "node:assert/strict";
@@ -32,6 +39,8 @@ import {
   SAVE_PATH_GUARD_REASON,
 } from "../../web/js/lib/save-path-guard.js";
 import { sameWorkflowObject } from "../../web/js/lib/workflow-chat-identity.js";
+import { trackerCaptureSuppressed } from "../../web/js/lib/change-tracker-snapshot.js";
+import { graphRootReproducesStateContent } from "../../web/js/lib/graph-binding.js";
 
 // ---------------------------------------------------------------------------
 // 1. The pure verdict.
@@ -161,24 +170,39 @@ function buildInstaller() {
   const source = src.slice(start, end);
 
   const warnings = [];
+  // panel#1563 — `saveWouldPersistStaleSnapshot` lives inside this same slice, so the
+  // wrapper's SECOND verdict is exercised as WIRED, not as a helper called by hand.
+  // Its collaborators are the REAL ones (the suppression predicate and the tolerant
+  // content comparison); only `window`/`app` are shadowed, because the slice reads the
+  // live root off the app object and node has no `window`.
   const build = new Function(
     "WORKFLOW_META_NAMESPACE",
     "WORKFLOW_PATH_FIELD",
     "sameWorkflowObject",
     "decideWorkflowSaveVerdict",
     "workflowSaveRefusalError",
+    "activeWorkflowRef",
+    "trackerCaptureSuppressed",
+    "graphRootReproducesStateContent",
+    "window",
+    "app",
     "console",
     `${source}\nreturn { installSavePathGuard };`,
   );
   return {
     warnings,
-    buildInstaller: () =>
+    buildInstaller: ({ activeWorkflow = null, rootGraph = null } = {}) =>
       build(
         "comfyui_mcp",
         "workflow_path",
         sameWorkflowObject,
         decideWorkflowSaveVerdict,
         workflowSaveRefusalError,
+        () => activeWorkflow,
+        trackerCaptureSuppressed,
+        graphRootReproducesStateContent,
+        {},
+        { rootGraph },
         { warn: (...args) => warnings.push(args.join(" ")) },
       ).installSavePathGuard,
   };
@@ -252,4 +276,155 @@ test("#1667 WRAPPER: a missing store is DISCLOSED, not silent — saves proceed 
   install({ extensionManager: {} });
   assert.equal(warnings.length, 1);
   assert.match(warnings[0], /save-path guard NOT installed/);
+});
+
+// ---------------------------------------------------------------------------
+// 3. panel#1563 — a snapshot that has fallen BEHIND the canvas.
+// ---------------------------------------------------------------------------
+
+test("#1563 THE REPORTED CASE: a stale snapshot is refused before it can be written", () => {
+  const verdict = decideWorkflowSaveVerdict({
+    destinationPath: "workflows/big.json",
+    destinationPersisted: true,
+    snapshotIsStale: true,
+  });
+  assert.equal(verdict.allow, false);
+  assert.equal(verdict.reason, SAVE_PATH_GUARD_REASON.STALE_SNAPSHOT);
+  assert.match(workflowSaveRefusalError(verdict).message, /BEHIND the live canvas/);
+  assert.match(workflowSaveRefusalError(verdict).message, /NOTHING was written/);
+});
+
+test("#1563 a FIRST save is refused too — lost work reported as success is the same defect", () => {
+  // Not gated on `destinationPersisted`: no existing file is destroyed, but the user is
+  // still told a canvas reached disk when part of it did not.
+  const verdict = decideWorkflowSaveVerdict({
+    destinationPath: "workflows/new.json",
+    destinationPersisted: false,
+    snapshotIsStale: true,
+  });
+  assert.equal(verdict.allow, false);
+  assert.equal(verdict.reason, SAVE_PATH_GUARD_REASON.STALE_SNAPSHOT);
+});
+
+test("#1563 a healthy save is untouched — the new conjunct defaults to allow", () => {
+  assert.deepEqual(
+    decideWorkflowSaveVerdict({ destinationPath: "workflows/A.json", destinationPersisted: true }),
+    { allow: true },
+  );
+  assert.deepEqual(
+    decideWorkflowSaveVerdict({
+      destinationPath: "workflows/A.json",
+      destinationPersisted: true,
+      snapshotIsStale: false,
+    }),
+    { allow: true },
+  );
+});
+
+/** The reported shape: the canvas gained a group the tracker never captured. */
+function staleFixture({ suppressed = true, live = "extra-group", active = true } = {}) {
+  const snapshot = {
+    nodes: [{ id: 1, type: "VAEDecode", pos: [0, 0] }],
+    groups: [{ id: 1, title: "Pre", bounding: [0, 0, 10, 10] }],
+    extra: {},
+  };
+  const liveState =
+    live === "extra-group"
+      ? {
+          nodes: [{ id: 1, type: "VAEDecode", pos: [0, 0] }],
+          groups: [
+            { id: 1, title: "Pre", bounding: [0, 0, 10, 10] },
+            { id: 2, title: "New17", bounding: [20, 0, 10, 10] },
+          ],
+          extra: {},
+        }
+      : JSON.parse(JSON.stringify(snapshot));
+  const wfA = {
+    path: "workflows/A.json",
+    isTemporary: false,
+    // `changeCount > 0` is one of upstream's own three suppression conditions.
+    changeTracker: { activeState: snapshot, changeCount: suppressed ? 1 : 0, _restoringState: false },
+  };
+  const wfB = { path: "workflows/B.json", isTemporary: false };
+  const store = {
+    saved: [],
+    getWorkflowByPath(p) {
+      if (p === "workflows/A.json") return wfA;
+      if (p === "workflows/B.json") return wfB;
+      return null;
+    },
+    async saveWorkflow(wf) {
+      this.saved.push(wf.path);
+    },
+  };
+  return {
+    store,
+    wfA,
+    appRef: { extensionManager: { workflow: store } },
+    activeWorkflow: active ? wfA : wfB,
+    rootGraph: { serialize: () => liveState },
+  };
+}
+
+test("#1563 WRAPPER: the save that loses the group is refused and never reaches the store", async () => {
+  const { buildInstaller: build } = buildInstaller();
+  const fx = staleFixture();
+  const install = build({ activeWorkflow: fx.activeWorkflow, rootGraph: fx.rootGraph });
+  install(fx.appRef);
+  await assert.rejects(() => fx.store.saveWorkflow(fx.wfA), /BEHIND the live canvas/);
+  assert.deepEqual(fx.store.saved, [], "nothing may be written when the snapshot is stale");
+});
+
+test("#1563 WRAPPER: a suppressed capture on an ALREADY-EQUAL canvas still saves", async () => {
+  // The ordinary state of a clean tab. Refusing here would trade data loss for a
+  // cannot-save bug.
+  const { buildInstaller: build } = buildInstaller();
+  const fx = staleFixture({ live: "equal" });
+  const install = build({ activeWorkflow: fx.activeWorkflow, rootGraph: fx.rootGraph });
+  install(fx.appRef);
+  await fx.store.saveWorkflow(fx.wfA);
+  assert.deepEqual(fx.store.saved, ["workflows/A.json"]);
+});
+
+test("#1563 WRAPPER: a content difference with NO suppression still saves", async () => {
+  // Ordinary tracker lag, which `prepareForSave()` resolves a microsecond later. Only
+  // upstream's own positive "I skipped it" turns a difference into a refusal.
+  const { buildInstaller: build } = buildInstaller();
+  const fx = staleFixture({ suppressed: false });
+  const install = build({ activeWorkflow: fx.activeWorkflow, rootGraph: fx.rootGraph });
+  install(fx.appRef);
+  await fx.store.saveWorkflow(fx.wfA);
+  assert.deepEqual(fx.store.saved, ["workflows/A.json"]);
+});
+
+test("#1563 WRAPPER: an INACTIVE workflow is never judged against the active canvas", async () => {
+  // `app.rootGraph` is the ACTIVE tab's canvas. Comparing it with another tab's
+  // snapshot would refuse a save that loses nothing.
+  const { buildInstaller: build } = buildInstaller();
+  const fx = staleFixture({ active: false });
+  const install = build({ activeWorkflow: fx.activeWorkflow, rootGraph: fx.rootGraph });
+  install(fx.appRef);
+  await fx.store.saveWorkflow(fx.wfA);
+  assert.deepEqual(fx.store.saved, ["workflows/A.json"]);
+});
+
+test("#1563 WRAPPER: with no live root readable the guard invents nothing", async () => {
+  const { buildInstaller: build } = buildInstaller();
+  const fx = staleFixture();
+  const install = build({ activeWorkflow: fx.activeWorkflow, rootGraph: null });
+  install(fx.appRef);
+  await fx.store.saveWorkflow(fx.wfA);
+  assert.deepEqual(fx.store.saved, ["workflows/A.json"]);
+});
+
+test("#1563 WIRING: the wrapper passes its own observation, not a constant", () => {
+  const source = PANEL_SRC();
+  const decide = source.indexOf("verdict = decideWorkflowSaveVerdict({");
+  assert.ok(decide > 0, "the save funnel decides with decideWorkflowSaveVerdict");
+  const call = source.slice(decide, decide + 1400);
+  assert.match(
+    call,
+    /snapshotIsStale: saveWouldPersistStaleSnapshot\(wf, state\)/,
+    "the stale-snapshot evidence must be computed from the SAME state the write serializes",
+  );
 });

--- a/browser_tests/unit/save-path-guard.test.mjs
+++ b/browser_tests/unit/save-path-guard.test.mjs
@@ -40,7 +40,10 @@ import {
 } from "../../web/js/lib/save-path-guard.js";
 import { sameWorkflowObject } from "../../web/js/lib/workflow-chat-identity.js";
 import { trackerCaptureSuppressed } from "../../web/js/lib/change-tracker-snapshot.js";
-import { graphRootReproducesStateContent } from "../../web/js/lib/graph-binding.js";
+import {
+  describeGraphStateDifference,
+  graphRootReproducesStateContent,
+} from "../../web/js/lib/graph-binding.js";
 
 // ---------------------------------------------------------------------------
 // 1. The pure verdict.
@@ -183,6 +186,7 @@ function buildInstaller() {
     "workflowSaveRefusalError",
     "activeWorkflowRef",
     "trackerCaptureSuppressed",
+    "describeGraphStateDifference",
     "graphRootReproducesStateContent",
     "window",
     "app",
@@ -200,6 +204,7 @@ function buildInstaller() {
         workflowSaveRefusalError,
         () => activeWorkflow,
         trackerCaptureSuppressed,
+        describeGraphStateDifference,
         graphRootReproducesStateContent,
         {},
         { rootGraph },
@@ -415,6 +420,70 @@ test("#1563 WRAPPER: with no live root readable the guard invents nothing", asyn
   install(fx.appRef);
   await fx.store.saveWorkflow(fx.wfA);
   assert.deepEqual(fx.store.saved, ["workflows/A.json"]);
+});
+
+// ---------------------------------------------------------------------------
+// panel#1563 r2 — AN ABSENT COMPARISON IS NOT EVIDENCE.
+//
+// `graphRootReproducesStateContent` answers the same `proven: false` for "the canvas
+// provably differs" and for "no comparison was possible", and its own contract says
+// `comparable:false` is not evidence either way. Reading `proven !== true` alone turned
+// every unreadable root into a REFUSAL of ComfyUI's whole save funnel — autosave and
+// Ctrl+S included — and told the user their file was missing changes on no evidence.
+// A serialization hook is exactly where a broken or hostile custom node sits.
+// ---------------------------------------------------------------------------
+
+test("#1563 r2 WRAPPER: a root whose serialize() THROWS never manufactures a refusal", async () => {
+  const { buildInstaller: build } = buildInstaller();
+  const fx = staleFixture();
+  const install = build({
+    activeWorkflow: fx.activeWorkflow,
+    rootGraph: {
+      serialize() {
+        throw new Error("custom node exploded in a serialization hook");
+      },
+    },
+  });
+  install(fx.appRef);
+  await fx.store.saveWorkflow(fx.wfA);
+  assert.deepEqual(fx.store.saved, ["workflows/A.json"], "an unreadable canvas must not block the save");
+});
+
+test("#1563 r2 WRAPPER: a root that answers null never manufactures a refusal", async () => {
+  const { buildInstaller: build } = buildInstaller();
+  const fx = staleFixture();
+  const install = build({
+    activeWorkflow: fx.activeWorkflow,
+    rootGraph: { serialize: () => null },
+  });
+  install(fx.appRef);
+  await fx.store.saveWorkflow(fx.wfA);
+  assert.deepEqual(fx.store.saved, ["workflows/A.json"]);
+});
+
+test("#1563 r2 WRAPPER: a root the comparison cannot read is not a stale snapshot", async () => {
+  // No `nodes` array ⇒ `describeGraphStateDifference` reports `comparable:false`. The
+  // state may be perfectly current; nothing has been established either way.
+  const { buildInstaller: build } = buildInstaller();
+  const fx = staleFixture();
+  const install = build({
+    activeWorkflow: fx.activeWorkflow,
+    rootGraph: { serialize: () => ({ groups: [{ id: 1 }] }) },
+  });
+  install(fx.appRef);
+  await fx.store.saveWorkflow(fx.wfA);
+  assert.deepEqual(fx.store.saved, ["workflows/A.json"]);
+});
+
+test("#1563 r2 WRAPPER: the reported case still refuses — comparability is a floor, not a bypass", async () => {
+  // The guard must not have been softened into inertness by the two tests above: a
+  // readable canvas that genuinely holds the new group is still refused.
+  const { buildInstaller: build } = buildInstaller();
+  const fx = staleFixture();
+  const install = build({ activeWorkflow: fx.activeWorkflow, rootGraph: fx.rootGraph });
+  install(fx.appRef);
+  await assert.rejects(() => fx.store.saveWorkflow(fx.wfA), /BEHIND the live canvas/);
+  assert.deepEqual(fx.store.saved, []);
 });
 
 test("#1563 WIRING: the wrapper passes its own observation, not a constant", () => {

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -3706,11 +3706,17 @@ const _savePathGuardRefusalsLogged = new Set();
  *   1. `trackerCaptureSuppressed` — upstream POSITIVELY reports it skipped the
  *      capture. Without this a save could be refused for ordinary tracker lag, which
  *      `prepareForSave` would have resolved a microsecond later.
- *   2. the live root does not reproduce the state about to be written — the tolerant
- *      comparison (`graphRootReproducesStateContent`), so a frontend that re-measures
- *      node boxes or renumbers subgraph link ids on load does not manufacture a
- *      refusal. Without this, a suppressed capture on an already-equal canvas — the
- *      ordinary state of a clean tab — would block every save.
+ *   2. a comparison of the live root against the state about to be written ACTUALLY
+ *      HAPPENED (`describeGraphStateDifference(...).comparable === true`) and the
+ *      tolerant proof (`graphRootReproducesStateContent`) did not vouch for it. Both
+ *      halves are load-bearing: the tolerance stops a frontend that re-measures node
+ *      boxes or renumbers subgraph link ids from manufacturing a refusal, and the
+ *      comparability stops an ABSENT comparison from doing the same — the proof
+ *      answers `proven:false` for "could not compare" exactly as it does for "differs",
+ *      so reading it alone made a root that cannot be serialized indistinguishable
+ *      from a canvas with lost work. Without conjunct 2 at all, a suppressed capture
+ *      on an already-equal canvas — the ordinary state of a clean tab — would block
+ *      every save.
  *
  * ACTIVE WORKFLOW ONLY. `app.rootGraph` is the ACTIVE tab's canvas; comparing it with
  * an inactive tab's snapshot would compare two different workflows and refuse a save
@@ -3727,7 +3733,35 @@ function saveWouldPersistStaleSnapshot(wf, state) {
     const appRef = window.comfyAPI?.app?.app ?? (typeof app !== "undefined" ? app : null);
     const rootGraph = appRef?.rootGraph ?? appRef?.graph ?? null;
     if (typeof rootGraph?.serialize !== "function") return false;
-    return graphRootReproducesStateContent({ rootGraph, state })?.proven !== true;
+    // panel#1563 r2 — SERIALIZE ONCE, and require a comparison that actually happened.
+    //
+    // `graphRootReproducesStateContent` answers the SAME `proven: false` for "the canvas
+    // provably differs" and for "no comparison was possible" — a `serialize()` that
+    // throws or answers null, a difference its classifier cannot account for. Reading
+    // `proven !== true` alone therefore turned every unreadable root into a REFUSAL: a
+    // broken or hostile custom node with a serialization hook could block Ctrl+S and
+    // autosave outright, and the message would tell the user their file is missing
+    // changes the canvas has, on no evidence at all. That inverts this function's own
+    // rule (a guard that cannot read its evidence must never invent a refusal) and the
+    // contract of the comparison itself, which states `comparable:false` is not evidence
+    // either way.
+    //
+    // The single frozen snapshot is the same discipline `graphRootReproducesStateContent`
+    // documents internally: asking two questions off two serializations lets a
+    // synchronous hook show one answer to the comparability check and another to the
+    // proof, so the refusal would rest on content no single comparison ever saw.
+    let liveState;
+    try {
+      liveState = rootGraph.serialize();
+    } catch {
+      return false; // a root that cannot be read is not proof that the snapshot is stale
+    }
+    if (liveState == null) return false;
+    const frozen = { serialize: () => liveState };
+    if (describeGraphStateDifference({ rootGraph: frozen, state })?.comparable !== true) {
+      return false;
+    }
+    return graphRootReproducesStateContent({ rootGraph: frozen, state })?.proven !== true;
   } catch {
     return false;
   }
@@ -23578,7 +23612,14 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
           // becomes a claim about what the caller received — only `applied` is that.
           markOpenReceiptReplySent(openReceipts, msg.rid);
         }
-        deferChangeTrackerSnapshot(changeTrackerToSnapshot);
+        // panel#1563 r2 — ownership, re-read on every attempt (see `stillOwnsCanvas`):
+        // the retry chain can still be armed when another workflow opens, and a capture
+        // writes the LIVE canvas into this tracker's state. Unreadable store ⇒ `true`.
+        deferChangeTrackerSnapshot(changeTrackerToSnapshot, undefined, undefined, (tracker) => {
+          const active = activeWorkflowRef();
+          if (!active) return true;
+          return active.changeTracker === tracker;
+        });
         if (superseded) return;
         // ask_user / request_secret paint their OWN cards and their replies carry
         // user input (a choice, or a SECRET) — never echo them as an activity card

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -484,6 +484,7 @@ import {
 import {
   deferChangeTrackerSnapshot,
   flushPendingChangeTrackerSnapshot,
+  trackerCaptureSuppressed,
 } from "./lib/change-tracker-snapshot.js";
 import { flushSourceCanvasBeforeSwitch } from "./lib/flush-source-before-switch.js";
 import { coerceMessageText, isDroppedAgentReplay, serializeContext, stripAgentDirectedBlocks } from "./lib/chat-serialize.js";
@@ -3260,9 +3261,13 @@ function captureWasSuppressed(tracker) {
     if (typeof tracker?._restoringState === "undefined") return true;
     if (typeof tracker?.changeCount === "undefined") return true;
     if (typeof tracker?.constructor?.isLoadingGraph === "undefined") return true;
-    if (tracker._restoringState) return true; // an undo/redo is restoring
-    if (Number(tracker.changeCount) > 0) return true; // inside a change transaction
-    if (tracker.constructor.isLoadingGraph) return true; // a graph is loading
+    // The three conditions themselves live in ONE place (panel#1563), so this
+    // question and the retry's question can never disagree about what upstream's
+    // early return reads. Only the DEFAULT for an unreadable tracker differs, and
+    // that difference is the shape-first block above: here an unknown tracker is
+    // suppressed (a close must not discard a canvas on an unproven flag), there it
+    // is not (a retry must not spin on a frontend it cannot read).
+    if (trackerCaptureSuppressed(tracker)) return true;
     const graph =
       window.comfyAPI?.app?.app?.graph ?? (typeof app !== "undefined" ? app?.graph : null);
     return !graph;
@@ -3686,6 +3691,48 @@ function installCreateBoundaryFork(appRef) {
 // satisfies the stamp check; a crossed one is refused here too, which is the point.
 let _savePathGuardInstalled = false;
 const _savePathGuardRefusalsLogged = new Set();
+/**
+ * panel#1563/#1564 — would this save persist a snapshot that has fallen BEHIND the
+ * canvas, and so report success for work the file will not contain?
+ *
+ * The write serializes `changeTracker.activeState`, and the refresh that is supposed
+ * to make it current (`prepareForSave()` → `captureCanvasState()`) is a SILENT no-op
+ * inside upstream's own load / undo / change-transaction windows. Measured on the live
+ * rig with one of those windows open: create_group landed on the canvas, the save
+ * answered `saved: true`, and the file came back without the group.
+ *
+ * TWO CONJUNCTS, both required, and the caller supplies neither by inference:
+ *
+ *   1. `trackerCaptureSuppressed` — upstream POSITIVELY reports it skipped the
+ *      capture. Without this a save could be refused for ordinary tracker lag, which
+ *      `prepareForSave` would have resolved a microsecond later.
+ *   2. the live root does not reproduce the state about to be written — the tolerant
+ *      comparison (`graphRootReproducesStateContent`), so a frontend that re-measures
+ *      node boxes or renumbers subgraph link ids on load does not manufacture a
+ *      refusal. Without this, a suppressed capture on an already-equal canvas — the
+ *      ordinary state of a clean tab — would block every save.
+ *
+ * ACTIVE WORKFLOW ONLY. `app.rootGraph` is the ACTIVE tab's canvas; comparing it with
+ * an inactive tab's snapshot would compare two different workflows and refuse a save
+ * that loses nothing. An unreadable identity answers false — a guard that cannot read
+ * its evidence must never invent a refusal (the same rule the #1667 guard states).
+ */
+function saveWouldPersistStaleSnapshot(wf, state) {
+  try {
+    if (!wf || !state || !Array.isArray(state.nodes)) return false;
+    const active = activeWorkflowRef();
+    if (!active || !sameWorkflowObject(active, wf)) return false;
+    const tracker = wf.changeTracker ?? null;
+    if (!tracker || !trackerCaptureSuppressed(tracker)) return false;
+    const appRef = window.comfyAPI?.app?.app ?? (typeof app !== "undefined" ? app : null);
+    const rootGraph = appRef?.rootGraph ?? appRef?.graph ?? null;
+    if (typeof rootGraph?.serialize !== "function") return false;
+    return graphRootReproducesStateContent({ rootGraph, state })?.proven !== true;
+  } catch {
+    return false;
+  }
+}
+
 function installSavePathGuard(appRef) {
   try {
     if (_savePathGuardInstalled) return;
@@ -3723,6 +3770,11 @@ function installSavePathGuard(appRef) {
           destinationPersisted: Boolean(destRecord) && destRecord?.isTemporary !== true,
           stampedPath: typeof stampedPath === "string" && stampedPath ? stampedPath : null,
           stampedPathOwnedByOther: Boolean(stampedRecord) && !sameWorkflowObject(stampedRecord, wf),
+          // panel#1563 — the OTHER way this funnel loses a graph: not a foreign
+          // canvas, just a snapshot upstream silently refused to refresh. Read from
+          // the same `state` the write serializes, so the check and the write can
+          // never be looking at different things.
+          snapshotIsStale: saveWouldPersistStaleSnapshot(wf, state),
         });
       } catch {
         verdict = { allow: true }; // a guard that cannot read its evidence must never invent a refusal
@@ -3732,7 +3784,7 @@ function installSavePathGuard(appRef) {
         // The autosave watcher logs a one-line "Auto save failed" for a thrown save;
         // make the refusal itself unmistakable in the console — but once per crossing,
         // not once per autosave retry.
-        const key = `${verdict.destinationPath}<-${verdict.stampedPath}`;
+        const key = `${verdict.reason}:${verdict.destinationPath}<-${verdict.stampedPath ?? ""}`;
         if (!_savePathGuardRefusalsLogged.has(key)) {
           _savePathGuardRefusalsLogged.add(key);
           try {

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -3723,6 +3723,29 @@ const _savePathGuardRefusalsLogged = new Set();
  * that loses nothing. An unreadable identity answers false — a guard that cannot read
  * its evidence must never invent a refusal (the same rule the #1667 guard states).
  */
+/**
+ * panel#1563 r2 — does this tracker still own the live canvas? (the deferred capture's
+ * licence to write, re-asked on every retry attempt)
+ *
+ * A capture serializes the GLOBAL canvas into THIS tracker's `activeState`, and the retry
+ * chain can stay armed for up to ~1.4s — long enough for another workflow to open. The
+ * chain's own stop condition is upstream's `isLoadingGraph`, a CLASS STATIC, so an
+ * orphaned record reads "suppressed" for the whole of the next workflow's load and then
+ * fires the instant it completes, when the canvas belongs to someone else.
+ *
+ * POSITIVE OWNERSHIP ONLY — an unreadable store is NOT permission. During a tab switch, a
+ * close, or a teardown, `activeWorkflowRef()` answers null while the canvas on screen is
+ * already someone else's; capturing then writes that canvas into this tracker's state, and
+ * a later save of its workflow persists the wrong graph over its own file (#1667's shape).
+ * Being wrong the other way costs a snapshot that stays behind until the next command —
+ * which `saveWouldPersistStaleSnapshot` refuses LOUDLY rather than losing silently. One
+ * side of that trade is recoverable and the other is not.
+ */
+function trackerStillOwnsCanvas(tracker) {
+  const active = activeWorkflowRef(); // already try/catch-guarded; returns null when unreadable
+  return Boolean(active) && active.changeTracker === tracker;
+}
+
 function saveWouldPersistStaleSnapshot(wf, state) {
   try {
     if (!wf || !state || !Array.isArray(state.nodes)) return false;
@@ -23612,14 +23635,10 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
           // becomes a claim about what the caller received — only `applied` is that.
           markOpenReceiptReplySent(openReceipts, msg.rid);
         }
-        // panel#1563 r2 — ownership, re-read on every attempt (see `stillOwnsCanvas`):
-        // the retry chain can still be armed when another workflow opens, and a capture
-        // writes the LIVE canvas into this tracker's state. Unreadable store ⇒ `true`.
-        deferChangeTrackerSnapshot(changeTrackerToSnapshot, undefined, undefined, (tracker) => {
-          const active = activeWorkflowRef();
-          if (!active) return true;
-          return active.changeTracker === tracker;
-        });
+        // panel#1563 r2 — ownership, re-read on every attempt: the retry chain can still
+        // be armed when another workflow opens, and a capture writes the LIVE canvas into
+        // this tracker's state. See `trackerStillOwnsCanvas`.
+        deferChangeTrackerSnapshot(changeTrackerToSnapshot, undefined, undefined, trackerStillOwnsCanvas);
         if (superseded) return;
         // ask_user / request_secret paint their OWN cards and their replies carry
         // user input (a choice, or a SECRET) — never echo them as an activity card

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -3852,6 +3852,60 @@ function installSavePathGuard(appRef) {
       }
       return orig(wf, ...rest);
     };
+    // panel#1563 r4 — THE SAVE-AS COPY POINT, which the `saveWorkflow` wrapper above
+    // cannot see.
+    //
+    // MEASURED in comfyui-frontend 1.49.6. `workflowStore.saveAs` seeds the new record
+    // from the SOURCE's tracker snapshot and nothing else:
+    //
+    //     const state = JSON.parse(JSON.stringify(existingWorkflow.activeState))
+    //     workflow.originalContent = workflow.content = JSON.stringify(state)
+    //
+    // and `workflowService.saveWorkflowAs` calls `prepareForSave()` only on the TARGET,
+    // after the copy. So when the source's capture is suppressed, its snapshot is copied
+    // stale; `openWorkflow(target)` then loads that stale state onto the canvas — taking
+    // the unsaved edits off the screen too — and the fresh target tracker captures the
+    // now-stale canvas. By the time `saveWorkflow(target)` reaches the wrapper above,
+    // all three suppression flags are false and the canvas AGREES with the snapshot:
+    // every piece of evidence the guard reads has been destroyed, and it correctly
+    // allows a write that is missing the user's work.
+    //
+    // The evidence exists only HERE, before the copy. Same predicate, same refusal,
+    // asked of the SOURCE — and it throws before `saveAs` returns a record, so no file
+    // is created and the canvas is left exactly as the user has it.
+    if (typeof svc.saveAs === "function") {
+      const origSaveAs = svc.saveAs.bind(svc);
+      svc.saveAs = function (sourceWf, destPath, ...rest) {
+        let verdict = { allow: true };
+        try {
+          // The state the copy will be built from — read the SAME way `saveAs` reads it.
+          const sourceState = sourceWf?.changeTracker?.activeState ?? sourceWf?.activeState ?? null;
+          verdict = decideWorkflowSaveVerdict({
+            destinationPath: typeof destPath === "string" ? destPath : null,
+            snapshotIsStale: saveWouldPersistStaleSnapshot(sourceWf, sourceState),
+          });
+        } catch {
+          verdict = { allow: true }; // a guard that cannot read its evidence never invents a refusal
+        }
+        if (!verdict.allow) {
+          const key = `saveAs:${verdict.destinationPath}`;
+          if (!_savePathGuardRefusalsLogged.has(key)) {
+            _savePathGuardRefusalsLogged.add(key);
+            try {
+              console.warn(`[comfyui-mcp] ${workflowSaveRefusalError(verdict).message}`);
+            } catch {}
+          }
+          throw workflowSaveRefusalError(verdict);
+        }
+        return origSaveAs(sourceWf, destPath, ...rest);
+      };
+    } else {
+      // Disclosed, never silent — the same rule the missing-store branch above follows.
+      console.warn(
+        "[comfyui-mcp] save-path guard: workflowStore.saveAs is unavailable on this frontend — " +
+          "a Save-As copy is NOT checked against a stale tracker snapshot (panel#1563).",
+      );
+    }
     _savePathGuardInstalled = true;
   } catch (err) {
     _savePathGuardInstalled = false;

--- a/web/js/lib/change-tracker-snapshot.js
+++ b/web/js/lib/change-tracker-snapshot.js
@@ -69,9 +69,16 @@ let pendingSnapshot = null;
  */
 export function trackerCaptureSuppressed(tracker) {
   try {
-    if (tracker?._restoringState === true) return true; // an undo/redo is restoring
+    // TRUTHINESS, not `=== true`. Upstream declares both flags `boolean`, but
+    // `captureWasSuppressed` (which delegates here) is a fail-closed guard on a
+    // DESTRUCTIVE path, and it read them as truthy before this refactor. Tightening
+    // to a strict identity check would let a truthy non-boolean — the exact drift a
+    // defensive guard exists for — slip past it. Optional chaining still gives the
+    // positive-evidence default this function needs: an absent field is `undefined`,
+    // which is falsy, so an unreadable tracker answers "not suppressed" here.
+    if (tracker?._restoringState) return true; // an undo/redo is restoring
     if (Number(tracker?.changeCount) > 0) return true; // inside a change transaction
-    if (tracker?.constructor?.isLoadingGraph === true) return true; // a graph is loading
+    if (tracker?.constructor?.isLoadingGraph) return true; // a graph is loading
     return false;
   } catch {
     return false;

--- a/web/js/lib/change-tracker-snapshot.js
+++ b/web/js/lib/change-tracker-snapshot.js
@@ -51,6 +51,20 @@ const SUPPRESSED_CAPTURE_RETRY_MS = Object.freeze([16, 50, 150, 400, 800]);
 
 let pendingSnapshot = null;
 
+let _warnedMissingOwnership = false;
+function warnMissingOwnershipOnce() {
+  if (_warnedMissingOwnership) return;
+  _warnedMissingOwnership = true;
+  try {
+    console.warn(
+      "[comfyui-mcp] deferChangeTrackerSnapshot called without an ownership predicate — " +
+        "the tracker snapshot cannot be proven to still own the canvas, so it will NOT be " +
+        "captured (panel#1563). Undo integration and the back-to-back fence flush stay " +
+        "disabled until the caller supplies one.",
+    );
+  } catch { /* a logger that throws must not also eat the refusal */ }
+}
+
 /**
  * Did upstream POSITIVELY tell us this capture was a no-op? (panel#1563)
  *
@@ -147,14 +161,31 @@ function armCapture(record, delayMs) {
  * belongs to someone else.
  *
  * The flush path has always refused on this hazard (its doc names it); the retry path
- * had no equivalent, so it gets the same question, asked positively. `stillOwnsCanvas`
- * is supplied by the caller because ownership lives in the workflow store and this
- * module is deliberately dependency-light. Only a POSITIVE `false` stops the chain: a
- * caller that supplies no predicate behaves exactly as it did before.
+ * had no equivalent, so it gets the same question. `stillOwnsCanvas` is supplied by the
+ * caller because ownership lives in the workflow store and this module is deliberately
+ * dependency-light.
+ *
+ * ASKED POSITIVELY, AT THIS LAYER TOO. The call-site predicate was corrected to require
+ * a readable active workflow, but this function still granted on "only a POSITIVE
+ * `false` stops the chain, and no predicate behaves as before" — the same
+ * unknown-as-permission reading, one layer down, in the function the review flagged.
+ * Three unknowns reached `true` through it: no predicate supplied, a predicate
+ * answering `undefined`/`null`, and any non-boolean answer. Latent today (the one
+ * production caller supplies a strict boolean), which is exactly when it is cheap to
+ * close: a default-permit API hands the NEXT caller an authorisation nobody decided to
+ * give it, which is the reasoning `graphCommandBindingBar` already applies to
+ * `staleTagReadBypass`.
+ *
+ * So the answer must be a POSITIVE `true`. Everything else — including an unanswerable
+ * question and an absent one — abandons the chain. Abandoning costs a snapshot that
+ * stays behind the canvas, which the next command's flush can still repair and which
+ * `saveWouldPersistStaleSnapshot` refuses loudly rather than losing silently;
+ * proceeding costs a wrong-graph write nothing downstream can tell from the user's
+ * own work.
  */
 function recordMayCapture(record) {
   try {
-    return record.stillOwnsCanvas ? record.stillOwnsCanvas(record.tracker) !== false : true;
+    return record.stillOwnsCanvas?.(record.tracker) === true;
   } catch {
     return false; // an ownership question that throws is not a licence to write.
   }
@@ -209,6 +240,13 @@ export function deferChangeTrackerSnapshot(
   // orphan chain is the one that captures into a tracker that no longer owns the
   // canvas. Replacing the marker was never enough to stop it.
   pendingSnapshot?.cancelTimer?.();
+  if (typeof stillOwnsCanvas !== "function") {
+    // Failing closed must never be SILENT. With no ownership question this module
+    // cannot establish that the tracker still owns the canvas, so it captures nothing —
+    // say so once, rather than let undo integration and the #1723 flush disappear the
+    // way #1667's missing store guard did.
+    warnMissingOwnershipOnce();
+  }
   const record = {
     tracker: changeTracker,
     schedule,

--- a/web/js/lib/change-tracker-snapshot.js
+++ b/web/js/lib/change-tracker-snapshot.js
@@ -134,10 +134,49 @@ function armCapture(record, delayMs) {
   record.timer = schedule(() => runAttempt(record), delayMs);
 }
 
+/**
+ * May this record still capture? (panel#1563 r2)
+ *
+ * A capture serializes the GLOBAL live canvas into THIS tracker's `activeState`, so a
+ * chain that outlives its workflow does not merely waste a timer — it stamps whatever
+ * canvas is on screen now into the snapshot of the workflow that armed it, and a later
+ * save of that workflow writes the wrong graph over its file. The retry window is
+ * exactly where that is reachable: the chain's own stop condition, `isLoadingGraph`, is
+ * a CLASS STATIC, so an orphaned record reads "suppressed" for the whole of the next
+ * workflow's load and then fires the moment that load completes — when the canvas
+ * belongs to someone else.
+ *
+ * The flush path has always refused on this hazard (its doc names it); the retry path
+ * had no equivalent, so it gets the same question, asked positively. `stillOwnsCanvas`
+ * is supplied by the caller because ownership lives in the workflow store and this
+ * module is deliberately dependency-light. Only a POSITIVE `false` stops the chain: a
+ * caller that supplies no predicate behaves exactly as it did before.
+ */
+function recordMayCapture(record) {
+  try {
+    return record.stillOwnsCanvas ? record.stillOwnsCanvas(record.tracker) !== false : true;
+  } catch {
+    return false; // an ownership question that throws is not a licence to write.
+  }
+}
+
+function dropRecord(record) {
+  record.cancelTimer();
+  if (pendingSnapshot === record) pendingSnapshot = null;
+}
+
 function runAttempt(record) {
   // A flush (or a newer defer) may have consumed the record already; the
   // capture is diff-based and idempotent, so firing anyway is harmless — only
   // the pending marker must not be cleared from under a NEWER record.
+  //
+  // panel#1563 r2 — but "harmless" holds only while this tracker still owns the
+  // canvas. Once it does not, the capture is a WRITE of someone else's graph into
+  // this tracker's state; the chain ends here rather than asking again.
+  if (!recordMayCapture(record)) {
+    dropRecord(record);
+    return;
+  }
   const outcome = captureNow(record.tracker);
   if (!outcome.suppressed || record.attempt >= SUPPRESSED_CAPTURE_RETRY_MS.length) {
     if (pendingSnapshot === record) pendingSnapshot = null;
@@ -154,14 +193,28 @@ function runAttempt(record) {
  * reply. Returns whether a snapshot was queued. `schedule` is injectable for the
  * no-DOM unit test; production uses the browser timer.
  */
-export function deferChangeTrackerSnapshot(changeTracker, schedule = setTimeout, cancel = clearTimeout) {
+export function deferChangeTrackerSnapshot(
+  changeTracker,
+  schedule = setTimeout,
+  cancel = clearTimeout,
+  stillOwnsCanvas = null,
+) {
   if (
     typeof changeTracker?.captureCanvasState !== "function" &&
     typeof changeTracker?.checkState !== "function"
   ) {
     return false;
   }
-  const record = { tracker: changeTracker, schedule, attempt: 0 };
+  // panel#1563 r2 — the record being REPLACED keeps its armed timer otherwise, and an
+  // orphan chain is the one that captures into a tracker that no longer owns the
+  // canvas. Replacing the marker was never enough to stop it.
+  pendingSnapshot?.cancelTimer?.();
+  const record = {
+    tracker: changeTracker,
+    schedule,
+    attempt: 0,
+    stillOwnsCanvas: typeof stillOwnsCanvas === "function" ? stillOwnsCanvas : null,
+  };
   record.cancelTimer = () => cancel(record.timer);
   pendingSnapshot = record;
   armCapture(record, 0);
@@ -183,7 +236,16 @@ export function deferChangeTrackerSnapshot(changeTracker, schedule = setTimeout,
  */
 export function flushPendingChangeTrackerSnapshot(changeTracker) {
   const record = pendingSnapshot;
-  if (!record || !changeTracker || record.tracker !== changeTracker) return false;
+  if (!record) return false;
+  if (!changeTracker || record.tracker !== changeTracker) {
+    // panel#1563 r2 — this flush is called with the ACTIVE tracker, so a pending record
+    // for a DIFFERENT one is stranded: the workflow that armed it no longer owns the
+    // canvas, and every remaining retry would capture this tab's graph into that
+    // workflow's snapshot. Refusing to flush it was always right; leaving its timer
+    // armed was not.
+    if (changeTracker) dropRecord(record);
+    return false;
+  }
   pendingSnapshot = null;
   record.cancelTimer();
   const outcome = captureNow(changeTracker);

--- a/web/js/lib/change-tracker-snapshot.js
+++ b/web/js/lib/change-tracker-snapshot.js
@@ -16,21 +16,130 @@
 // graph command FLUSH the already-committed capture synchronously before its
 // fence runs: the capture was going to happen either way, so flushing changes
 // only WHEN it lands, never WHETHER.
+//
+// panel#1563/#1564 — ASKING FOR A CAPTURE IS NOT GETTING ONE. Measured on the
+// live rig (ComfyUI 0.33.2, frontend 1.49.6): `ChangeTracker.captureCanvasState`
+// opens with
+//
+//     if (!app.graph || this.changeCount > 0 || this._restoringState ||
+//         ChangeTracker.isLoadingGraph) return
+//
+// — a SILENT early return. No throw, no return value, nothing to await. While one
+// of those windows is open the tracker's `activeState` stops following the canvas,
+// and it never catches up on its own: upstream's only self-heal (`squashState`) is
+// scheduled from INSIDE a capture that succeeded, so a suppressed capture schedules
+// nothing, and `isLoadingGraph` suppresses `squashState` as well. Everything
+// downstream then reads a snapshot that is behind the canvas — the binding fence
+// refuses the right canvas with `root-shape-mismatch`, and a save (which serializes
+// `activeState`, not the live graph) writes a file missing whatever the canvas
+// gained.
+//
+// This is exactly why #1563's proposed fix — awaiting a thenable returned by
+// `captureCanvasState` — could not work, and #1564 is the measurement that proved
+// it: the suppressed call returns `undefined` synchronously, so there is nothing to
+// await. The answer is not to wait longer for one call, it is to NOTICE that the
+// call was swallowed and to ask again once the window closes. Every suppression
+// condition upstream is transient by construction (mid-undo, mid-load,
+// mid-transaction), so a bounded retry chain is all a stranded snapshot needs; the
+// durable case is caught instead by the save guard (`decideWorkflowSaveVerdict`),
+// which refuses to persist a snapshot that provably lost the canvas.
+
+/** Bounded retry schedule, in ms, for a capture upstream silently skipped.
+ *  Short and finite: the suppression windows are transient, and a chain that
+ *  never gives up would keep a dead workflow's record alive forever. */
+const SUPPRESSED_CAPTURE_RETRY_MS = Object.freeze([16, 50, 150, 400, 800]);
 
 let pendingSnapshot = null;
 
+/**
+ * Did upstream POSITIVELY tell us this capture was a no-op? (panel#1563)
+ *
+ * Reads the three fields `captureCanvasState`'s own early return reads. It is
+ * deliberately POSITIVE-evidence-only — an unrecognised tracker answers `false`,
+ * not `true` — because the one caller that acts on it here RETRIES, and retrying
+ * forever on a frontend whose fields were renamed would be a busy loop that no
+ * measurement asked for.
+ *
+ * That is the opposite default from the panel's `captureWasSuppressed`, which
+ * answers the different question "may I CLAIM the capture landed" for the
+ * destructive close path (#882) and must fail closed on an unknown shape. The two
+ * are kept in one place — `captureWasSuppressed` delegates the three conditions
+ * here — so the rule itself cannot drift between them; only the default for an
+ * unreadable tracker differs, and each caller states why.
+ */
+export function trackerCaptureSuppressed(tracker) {
+  try {
+    if (tracker?._restoringState === true) return true; // an undo/redo is restoring
+    if (Number(tracker?.changeCount) > 0) return true; // inside a change transaction
+    if (tracker?.constructor?.isLoadingGraph === true) return true; // a graph is loading
+    return false;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Run the capture and report what actually happened.
+ *
+ *   attempted   a capture function existed and was called (the old return value).
+ *   landed      the tracker replaced its snapshot object — positive proof it captured.
+ *   suppressed  upstream skipped the call silently and the snapshot did not move.
+ *
+ * `landed:false, suppressed:false` is the ordinary NO-CHANGE case: the canvas
+ * already equals the snapshot, so upstream correctly left it alone. Only the
+ * suppressed case is a problem, and only that case is retried.
+ */
 function captureNow(changeTracker) {
   // `checkState` is DEPRECATED upstream — it warns, then delegates to this — so
   // prefer the current name and keep the old one as the fallback for older
   // frontends (mirrors captureCanvasIntoTracker's resolution order).
   const capture = changeTracker?.captureCanvasState ?? changeTracker?.checkState;
-  if (typeof capture !== "function") return false;
+  if (typeof capture !== "function") return { attempted: false, landed: false, suppressed: false };
+  // Read through a guard: `activeState` is a plain field today, but a version that
+  // makes it a throwing accessor must not blow past the deferred timer.
+  const readState = () => {
+    try {
+      return changeTracker.activeState;
+    } catch {
+      return undefined;
+    }
+  };
+  const before = readState();
   try {
     capture.call(changeTracker);
   } catch {
-    // Older frontends and transient workflow teardown keep undo best-effort.
+    // Older frontends and transient workflow teardown keep undo best-effort. A
+    // THROW is not the silent-no-op window this module retries: upstream told us
+    // it failed, and retrying a throwing tracker just repeats the failure.
+    return { attempted: true, landed: false, suppressed: false };
   }
-  return true;
+  const landed = readState() !== before;
+  return { attempted: true, landed, suppressed: !landed && trackerCaptureSuppressed(changeTracker) };
+}
+
+function armCapture(record, delayMs) {
+  // Read the scheduler into a local and call it BARE. `record.schedule(...)` is a
+  // METHOD call, so `this` would be the record — and the browser's `setTimeout`
+  // rejects any receiver that is not the window with "Illegal invocation", which on
+  // the live rig surfaced as the NEXT graph command failing rather than as a timer
+  // problem (caught by browser_tests/stale-snapshot-save-refused.spec.ts).
+  const schedule = record.schedule;
+  record.timer = schedule(() => runAttempt(record), delayMs);
+}
+
+function runAttempt(record) {
+  // A flush (or a newer defer) may have consumed the record already; the
+  // capture is diff-based and idempotent, so firing anyway is harmless — only
+  // the pending marker must not be cleared from under a NEWER record.
+  const outcome = captureNow(record.tracker);
+  if (!outcome.suppressed || record.attempt >= SUPPRESSED_CAPTURE_RETRY_MS.length) {
+    if (pendingSnapshot === record) pendingSnapshot = null;
+    return;
+  }
+  // Upstream swallowed it. Keep the record pending so the next graph command can
+  // still flush it, and ask again after the transient window has had time to close.
+  armCapture(record, SUPPRESSED_CAPTURE_RETRY_MS[record.attempt]);
+  record.attempt += 1;
 }
 
 /**
@@ -45,16 +154,10 @@ export function deferChangeTrackerSnapshot(changeTracker, schedule = setTimeout,
   ) {
     return false;
   }
-  const record = { tracker: changeTracker };
-  const timer = schedule(() => {
-    // A flush (or a newer defer) may have consumed the record already; the
-    // capture is diff-based and idempotent, so firing anyway is harmless — only
-    // the pending marker must not be cleared from under a NEWER record.
-    if (pendingSnapshot === record) pendingSnapshot = null;
-    captureNow(changeTracker);
-  }, 0);
-  record.cancel = () => cancel(timer);
+  const record = { tracker: changeTracker, schedule, attempt: 0 };
+  record.cancelTimer = () => cancel(record.timer);
   pendingSnapshot = record;
+  armCapture(record, 0);
   return true;
 }
 
@@ -65,11 +168,22 @@ export function deferChangeTrackerSnapshot(changeTracker, schedule = setTimeout,
  * it would stamp one workflow's canvas onto another's state. Returns whether a
  * pending snapshot was consumed. The timer is cancelled so the capture runs
  * exactly once.
+ *
+ * panel#1563 — if THIS capture is swallowed too, the record stays pending with its
+ * retry chain re-armed rather than being dropped. Consuming it would leave the
+ * snapshot stranded behind the canvas with nothing left to move it, which is the
+ * state the fence then refuses and the save then persists.
  */
 export function flushPendingChangeTrackerSnapshot(changeTracker) {
   const record = pendingSnapshot;
   if (!record || !changeTracker || record.tracker !== changeTracker) return false;
   pendingSnapshot = null;
-  record.cancel();
-  return captureNow(changeTracker);
+  record.cancelTimer();
+  const outcome = captureNow(changeTracker);
+  if (outcome.suppressed && record.attempt < SUPPRESSED_CAPTURE_RETRY_MS.length) {
+    pendingSnapshot = record;
+    armCapture(record, SUPPRESSED_CAPTURE_RETRY_MS[record.attempt]);
+    record.attempt += 1;
+  }
+  return outcome.attempted;
 }

--- a/web/js/lib/save-path-guard.js
+++ b/web/js/lib/save-path-guard.js
@@ -38,6 +38,36 @@
 // refused. That refusal is recoverable (the message names the re-bind that heals it);
 // the overwrite it exists to prevent is not.
 //
+// panel#1563/#1564 — the SECOND way this same funnel loses a graph, and it needs no
+// crossed identity at all: the state it serializes can simply be BEHIND the canvas.
+//
+// `ComfyWorkflow.save()` writes `JSON.stringify(this.activeState)` — the ChangeTracker
+// snapshot, never the live root — and `workflowService.saveWorkflow` refreshes that
+// snapshot first by calling `changeTracker.prepareForSave()` → `captureCanvasState()`.
+// That capture returns EARLY AND SILENTLY while a graph is loading, while an undo is
+// restoring, or inside an open change transaction. When it does, the save proceeds on
+// the stale snapshot and the file loses whatever the canvas gained since.
+//
+// MEASURED on the live rig (ComfyUI 0.33.2, comfyui-frontend 1.49.6, one suppression
+// window held open): panel_create_group added group 2 to the canvas, the following
+// panel_graph_outline was refused `[root-shape-mismatch] ... both the workflow and the
+// live canvas report 6 node(s), but the canvas does not reproduce the workflow's own
+// state`, panel_save_workflow answered `{"saved": true}`, and the file on disk came
+// back with ONE group. Reported success, work gone — the same shape as #1667, reached
+// without any identity crossing.
+//
+// So the guard also refuses a write whose state is PROVABLY stale, on two conjuncts,
+// both required:
+//
+//   * upstream POSITIVELY says the pre-save capture was skipped (its own
+//     `changeCount` / `_restoringState` / `isLoadingGraph` conditions), and
+//   * the live root does not reproduce the state about to be written.
+//
+// Neither alone: a suppressed capture on a canvas that already equals the snapshot
+// loses nothing, and a content difference alone cannot be told from ordinary tracker
+// lag on a frontend whose fields this panel does not recognise. Requiring both keeps
+// an unknown frontend on today's behaviour instead of refusing every save on it.
+//
 // Dependency-light: path normalization is imported; the store reads stay in the caller.
 // Unit-testable with plain fixtures.
 
@@ -45,6 +75,7 @@ import { normalizedWorkflowPath } from "./workflow-chat-identity.js";
 
 export const SAVE_PATH_GUARD_REASON = Object.freeze({
   STAMPED_PATH_FOREIGN: "stamped_path_foreign",
+  STALE_SNAPSHOT: "stale_snapshot",
 });
 
 /**
@@ -60,14 +91,30 @@ export const SAVE_PATH_GUARD_REASON = Object.freeze({
  *   state about to be serialized, or null when absent/unreadable.
  * @param {boolean} [input.stampedPathOwnedByOther] true when the workflow store still
  *   has a record at `stampedPath` that is NOT the workflow being saved.
- * @returns {{allow: true} | {allow: false, reason: string, destinationPath: string, stampedPath: string}}
+ * @param {boolean} [input.snapshotIsStale] panel#1563 — true only when the caller has
+ *   BOTH observations: upstream positively reports the pre-save capture was skipped,
+ *   AND the live root of this (active) workflow does not reproduce the state about to
+ *   be serialized. Absent/false → allow, exactly as before.
+ * @returns {{allow: true} | {allow: false, reason: string, destinationPath: string, stampedPath?: string}}
  */
 export function decideWorkflowSaveVerdict({
   destinationPath,
   destinationPersisted = false,
   stampedPath = null,
   stampedPathOwnedByOther = false,
+  snapshotIsStale = false,
 } = {}) {
+  // panel#1563 — ordered FIRST, and deliberately NOT gated on `destinationPersisted`.
+  // Overwriting an existing file with a stale snapshot destroys the old content, but a
+  // FIRST save that writes a stale snapshot is the same lost work reported as success:
+  // the user is told their canvas is on disk when part of it is not. Both refuse.
+  if (snapshotIsStale) {
+    return {
+      allow: false,
+      reason: SAVE_PATH_GUARD_REASON.STALE_SNAPSHOT,
+      destinationPath,
+    };
+  }
   if (!destinationPersisted) return { allow: true };
   const dest = normalizedWorkflowPath(destinationPath);
   const stamped = normalizedWorkflowPath(stampedPath);
@@ -91,6 +138,20 @@ export function workflowSaveRefusalError(verdict) {
   const dest = typeof verdict?.destinationPath === "string" && verdict.destinationPath
     ? verdict.destinationPath
     : "this workflow's file";
+  if (verdict?.reason === SAVE_PATH_GUARD_REASON.STALE_SNAPSHOT) {
+    return new Error(
+      `REFUSED to save: the state this save would write to "${dest}" is BEHIND the live ` +
+        `canvas, so the file would be missing changes the canvas already has. ComfyUI saves ` +
+        `the ChangeTracker snapshot rather than the graph on screen, and it refreshes that ` +
+        `snapshot first — but that refresh is skipped while a workflow is loading, while an ` +
+        `undo is restoring, or inside an open change transaction, and one of those is true ` +
+        `right now. NOTHING was written; the canvas is intact. This clears by itself once the ` +
+        `load/undo/transaction finishes — wait a moment and save again. If it persists, ` +
+        `reload the ComfyUI tab (panel_reload) and re-open the workflow ` +
+        `(panel_open_workflow); do NOT close the tab first, closing discards the canvas that ` +
+        `holds the only copy of those changes (panel#1563).`,
+    );
+  }
   const stamped = typeof verdict?.stampedPath === "string" && verdict.stampedPath
     ? verdict.stampedPath
     : "a different workflow";


### PR DESCRIPTION
Fixes #1563
Fixes #1564

## What actually happens (established by execution, not by reading)

Reproduced end to end on a real rig — ComfyUI 0.33.2, **comfyui-frontend 1.49.6** (the reporter's exact frontend), the panel served from this branch:

```
graph_create_group  -> ok, group 2 on the canvas
graph_outline       -> [root-shape-mismatch] The live graph is out of sync with the active
                       workflow: both the workflow and the live canvas report 6 node(s), but
                       the canvas does not reproduce the workflow's own state
workflow_save       -> {"saved": true}
file on disk        -> {"nodes": 6, "groups": 1, "groupTitles": ["Pre"]}   <-- the group is GONE
```

That is both reported symptoms at once, and they are **one cause**.

**ComfyUI never saves the canvas. It saves the ChangeTracker snapshot.**
`ComfyWorkflow.save()` is literally `this.content = JSON.stringify(this.activeState)`, and
`workflowService.saveWorkflow()` refreshes that snapshot first with
`changeTracker.prepareForSave()` → `captureCanvasState()`.

`captureCanvasState()` (frontend 1.49.6, `src/scripts/changeTracker.ts`) opens with:

```ts
captureCanvasState() {
  const isUndoRedoing = this._restoringState
  const isInsideChangeTransaction = this.changeCount > 0
  if (!app.graph || isInsideChangeTransaction || isUndoRedoing || ChangeTracker.isLoadingGraph)
    return
  if (!isActiveTracker(this)) { reportInactiveTrackerCall(...); return }
  ...
}
```

A **silent early return**: no throw, no return value, no signal of any kind. While one of
those windows is open the snapshot stops following the canvas, and it does not catch up on
its own — upstream's only self-heal (`squashState`) is scheduled from *inside* a capture
that succeeded, so a suppressed capture schedules nothing.

From there both symptoms follow mechanically:

* the binding fence compares the live root with `changeTracker.activeState`, sees a real
  difference and refuses — **correctly**. `root-shape-mismatch` is the fence reporting the
  stale snapshot, not misfiring on it.
* the save serializes that same stale snapshot, and `workflow_save` returned
  `{saved: true}` unconditionally. **Reported success, work gone.**

Instrumented on the rig, the tracker's own numbers at the moment of the refusal:
`{isModified: false, activeStateGroups: 1, liveGroups: 2, blocked: "isLoadingGraph"}`.

## Why #1563's proposed fix could not have worked, and #1564 is the proof

#1563 proposed awaiting a thenable returned by `captureCanvasState` in
`flushPendingChangeTrackerSnapshot`. #1564 loaded that patch, ran it live, and
`panel_graph_outline` still refused. That result is exactly what the code above predicts:
**a suppressed capture returns `undefined` synchronously from an early `return`** — there
is no promise, so there is nothing to await, at any depth. This branch does not re-apply
that patch.

## What was ruled out, by measurement

| Hypothesis | Verdict |
| --- | --- |
| An unawaited async capture (#1563's proposal) | **Ruled out.** #1564's live run, and the source above: the early return is synchronous. |
| The fence is too strict / needs widening | **Ruled out and refused.** The canvas genuinely differs from the workflow's recorded state. Widening the root-shape fence would trade a loud refusal for a silent wrong-target write. |
| The tracker omits `groups` from its comparison | **Ruled out.** `ChangeTracker.graphEqual` compares `groups` with a plain deep equality; a healthy capture after `create_group` updates `activeState` and flips `isModified` — measured, twice, on the same rig. |
| `graph_create_group` leaks an unbalanced `beforeChange` | **Ruled out.** Audited every `beforeChange`/`afterChange` pair in the panel; all are `try`/`finally`-paired, and the balanced pair captures correctly on the rig. |
| A panel-side ordering bug (flush after the fence) | **Ruled out.** The flush already runs before the fence (#1723) and is pinned by a source-order test. |
| The reported flow needs 83 nodes / 10 groups to reproduce | **Ruled out.** Size is irrelevant; the suppression window is the whole trigger. Reproduces at 4 nodes. |

## Do the refusal and the lossy save share a cause?

**Yes — one stale snapshot, two readers.** They are not equally serious, and the fixes differ:

* The **lossy save** is the data-loss defect: the panel reported success for a file that
  does not contain the user's work. That is fixed here, and it is the half that matters.
* The **refusal** is the fence doing its job. There is nothing safe to "fix" in the fence.
  What *is* fixable is the cause: the snapshot. So the deferred capture now notices when
  upstream swallowed it and asks again until the transient window closes, instead of giving
  up after one silent no-op.

## The change

**1. `web/js/lib/change-tracker-snapshot.js` — a swallowed capture is noticed and retried.**
`captureNow()` now reports `{attempted, landed, suppressed}`: `landed` is proof (the
snapshot object was replaced), `suppressed` is upstream's own positive "I skipped it".
A suppressed capture re-arms a **bounded** chain (5 retries over ~1.4s) and the pending
record survives a flush that was also swallowed, so the next graph command can still take
it. A capture that ran and found no change is *not* retried — that is every clean tab.

**2. `web/js/lib/save-path-guard.js` — a save that would persist a stale snapshot is refused
before anything is written.** This is the same funnel #1667 already guards
(`workflowStore.saveWorkflow` — autosave, Ctrl+S, reconnect-restore, and
`panel_save_workflow` all pass through it) and the same failure mode: a write that destroys
work and reports success. New verdict `STALE_SNAPSHOT`, refusal thrown before the store is
called, message naming what was compared, that nothing was written, and the recovery.

**3. `saveWouldPersistStaleSnapshot()` supplies the evidence — TWO conjuncts, both required:**

* upstream **positively** reports the capture was skipped, and
* the live root does not reproduce the state about to be written (the *tolerant*
  comparison, so a frontend re-measuring node boxes or renumbering subgraph link ids does
  not manufacture a refusal).

Neither alone: a suppressed capture on an already-equal canvas loses nothing, and a content
difference alone cannot be told from ordinary tracker lag. An unrecognised frontend, an
inactive workflow, or an unreadable root all answer *allow* — today's behaviour. A guard
that refuses on a guess is a cannot-save bug, which would be worse than the one it fixes.

The three suppression conditions now have **one definition**: the destructive-close path's
`captureWasSuppressed` (#882) delegates to `trackerCaptureSuppressed`. Only the default for
an *unreadable* tracker differs, and each caller states why — a close must not discard a
canvas on an unproven flag; a retry must not spin on a frontend it cannot read.

## Verification

**Live rig** — ComfyUI 0.33.2 / frontend 1.49.6, panel served from this branch, dedicated
instance. New spec `browser_tests/stale-snapshot-save-refused.spec.ts` drives the reported
sequence through the real dispatcher and the real save funnel, and asserts the drift from
the **engine** (`{live: 2, snapshot: 1}`), the refusal, the file on disk unchanged, and
that the guard **clears** once the window closes and the save then carries the group.

**Mutation evidence (11 mutations, 10 applied, 10 killed):**

| Mutation | Killed by |
| --- | --- |
| verdict ignores `snapshotIsStale` | `#1563 THE REPORTED CASE` + 2 |
| **CALL SITE** drops the evidence (`snapshotIsStale: false`) | `#1563 WIRING…` + `#1563 WRAPPER: the save that loses the group…` |
| helper drops the suppression conjunct | `#1563 WRAPPER: a content difference with NO suppression still saves` |
| helper drops the active-workflow conjunct | `#1563 WRAPPER: an INACTIVE workflow is never judged…` |
| helper drops the content conjunct | `#1563 WRAPPER: a suppressed capture on an ALREADY-EQUAL canvas still saves` |
| defer never retries a swallowed capture | `#1563 a SWALLOWED deferred capture is retried…` |
| flush consumes a swallowed record | `#1563 a flush upstream swallows keeps the record PENDING…` |
| suppression predicate ignores `changeCount` | 3 tests across both suites |
| retry chain unbounded | `#1563 the retry chain is BOUNDED…` |
| `landed` never observed | 2 tests |

And **against the e2e**: reverting either the verdict or the call site makes
`stale-snapshot-save-refused.spec.ts` fail with the reporter's symptom verbatim —
`the save must NOT report success: {"saved":true,...}`.

The browser suite also caught a defect in the fix itself: `record.schedule(...)` is a method
call, so `this` was the record and the browser's `setTimeout` threw *Illegal invocation* —
surfacing as the **next graph command** failing, not as a timer problem. Unit tests inject
their own scheduler and were green throughout. Fixed and re-verified on the rig.

## Playwright baseline

`npx playwright test --workers=1`, two dedicated ComfyUI instances on the same box, one
junctioned to clean `origin/main` (`75728263`) and one to this branch, run back to back:

| | failed | passed | total |
| --- | --- | --- | --- |
| clean `origin/main` | **19** | 62 | 81 |
| this branch | **18** | 64 | 82 |

**Zero new failures.** The branch's 18 are a strict SUBSET of the baseline's 19 (diffed
per test title, not off the totals); the extra baseline failure is
`agent-drive.spec.ts:113 › highlight issued BEFORE the first page lands`, a timing spec
that went green on the branch run. The 82nd test is the new spec, passing. Failing files
on both sides are the known storage/IndexedDB set: `chat-history-v2`,
`conversation-persistence`, `external-orchestrator`, `hidden-tab`, `pending-queue`,
`streaming-render`, `workflow-chat-identity`.

The save-path specs most exposed to a false refusal from this guard —
`save-persists-node-set-values` ("an in-place save persists a value the tracker never
saw"), `reopen-preserves-node-set-values`, `noname-save-keeps-app-json`,
`save-as-reports-identity` — and the #882 close-guard specs (`dirty-guards-see-node-writes`)
all pass on the branch. Those are the ones I would expect to break first if the two
conjuncts were too loose.

Unit suite: `npm run test:unit` — 6129 passed, 0 failed (1 todo).

## What I deliberately did not do

* **Did not widen the root-shape fence.** The refusal is correct; the snapshot was wrong.
* **Did not write `activeState` directly from the live root.** Upstream states the
  invariant — only the active workflow's tracker may read the canvas — and one of the
  suppression conditions (`!isActiveTracker`) exists precisely to stop that write. Forcing
  it would stamp one workflow's canvas onto another's state.
* **Did not fix the upstream suppression itself.** Whether `isLoadingGraph` can stay open
  longer than it should (it is released in a `finally`, but the try block awaits a media
  pipeline and can show dialogs) is a frontend question. The panel's job is to stop
  reporting success over it, and to stop giving up after one swallowed call.
* **Did not make the refusal message tell the fence's story.** The `root-shape-mismatch`
  text still offers the generic re-open recovery. Now that the snapshot catches up on its
  own, that path should be much rarer; a message change would be a separate, testable
  change and this PR is already load-bearing.

## Round 2 — two defects found by review, both reproduced before being fixed

The first head of this PR was gated and came back **NO-SHIP** with two findings. Both were
real. Both are fixed in `4ce9eb44`, and each is pinned by a test that fails when the fix is
deleted.

**P0 — the retry chain outlived its workflow, and could stamp another workflow's canvas.**
A capture serializes the **global** live canvas into *this* tracker's `activeState`, and the
chain's own stop condition (`isLoadingGraph`) is a **class static**. So an orphaned record
for workflow A reads "suppressed" for the whole of workflow B's load and then fires the
moment that load completes — when the canvas on screen is B's. A's snapshot would hold B's
graph, and a later save of A writes B over A's file: the #1667 shape, reached through the
very window this PR opened. The new save guard cannot catch it either, because by then all
three suppression flags are false.

* the retry now asks, on every attempt, whether its tracker still owns the canvas
  (`stillOwnsCanvas`, supplied by the dispatch path because ownership lives in the workflow
  store). Only a positive `false` stops the chain; an unreadable store behaves exactly as
  before. An ownership question that **throws** stops it — that is not a licence to write.
* a new defer disarms the record it replaces, and a flush for a **different** tracker
  disarms the stranded one instead of leaving it armed. #1723's flush *refusal* is
  unchanged; its "the timer still fires for A" was the hazard, and that test now pins the
  disarm (upstream refuses a non-active tracker's capture anyway).

**P1 — an absent comparison was being read as proof of a stale snapshot.**
`graphRootReproducesStateContent` answers the same `proven: false` for "the canvas provably
differs" and for "no comparison was possible" — a `serialize()` that throws or returns
null, a difference it cannot classify — and its own contract states `comparable:false` is
not evidence either way. Reading `?.proven !== true` alone therefore turned every unreadable
root into a **refusal of ComfyUI's entire save funnel, autosave and Ctrl+S included**, with
a message telling the user their file was missing changes, on no evidence. A serialization
hook is exactly where a broken or hostile custom node sits. The root is now serialized
**once** (the same frozen-snapshot discipline that function documents internally) and the
refusal requires a comparison that actually happened.

## Verification of round 2

**Mutation, 6 applied, 5 killed** — each fix deleted, the named test observed to fail:

| Mutation | Killed by |
| --- | --- |
| ownership check deleted from the retry | `#1563 r2 the retry chain STOPS once its tracker no longer owns the canvas` + `…an ownership question that THROWS…` |
| defer stops disarming the record it replaces | `#1563 r2 a NEW defer cancels the previous record's armed chain` |
| flush leaves a stranded record armed (pre-r2) | `#1723 flush refuses a tracker that does not own the pending snapshot` + `#1563 r2 a flush for a DIFFERENT tracker…` |
| comparability gate removed (the P1 revert) | `#1563 r2 WRAPPER: a root the comparison cannot read is not a stale snapshot` |
| **CALL SITE** drops the ownership predicate | `#1563 r2 WIRING: the dispatch path SUPPLIES the ownership predicate…` |
| `liveState == null` bail removed | **not killed** — `describeGraphStateDifference` already reports `comparable:false` for a null state, so the two overlap. Kept as an explicit bail; stated here rather than claimed as independently pinned. |

The three earlier conjunct mutations were re-run against this head and still kill:
dropping either conjunct of `saveWouldPersistStaleSnapshot`, or the call site's
`snapshotIsStale`, fails a named test.

**Upstream mechanism re-checked against the shipped bundle**, not from memory — the
installed `comfyui_frontend_package` (1.48.7 here; the reporter is on 1.49.6):
`captureCanvasState(){...if(!$.graph||t||e||ChangeTracker.isLoadingGraph)return;if(!isActiveTracker(this)){reportInactiveTrackerCall(...);return}...}`
— the silent early return this PR is about, plus a fourth, *inactive-tracker* return that
the save guard's active-workflow conjunct already stays clear of.

**The "permanent cannot-save" risk was bounded by audit, not assumed.** All three
suppression windows are transient by construction: `isLoadingGraph` and `_restoringState`
are released in upstream `finally` blocks (read in the bundle), and `changeCount` is a
balanced counter whose every panel call site is `try`/`finally`-paired (re-audited on this
head). A durable leak — the one state where the refusal would not clear on its own — has no
path I could find from panel code.

**Unit suite on the merge head: 6188 passed, 1 failed, and that one failure is the known
wall-clock flake** `#671 verifyInstalled … fast-draining install` (named in the runbook);
re-run alone it is **125 passed / 0 failed**.

## Browser coverage — what is and is not fresh

The Playwright baseline above was measured by the fix author on `f181abc2`. I did **not**
re-run it on this head: no ComfyUI is listening on this box that I may repoint (the one
live instance is a long-lived shared slot serving a different checkout, and this run was
allocated none). So:

* fresh on `4ce9eb44`: the full unit suite and every mutation above.
* inherited, not re-measured: the 82-spec browser comparison. The rebase onto current
  `main` produced a byte-identical diff to the measured one; round 2 adds source changes
  that the browser suite has **not** seen.
* The r2 changes that a browser run would exercise and unit tests cannot: the real
  `setTimeout` receiver in `armCapture` (already the reason the bare-scheduler call exists)
  and a real workflow switch mid-chain.

## Round 3 — a second gate found the one place round 2 chose compatibility

An independent gate run on `4ce9eb44` returned NO-SHIP on the ownership predicate's
default: `activeWorkflowRef() === null` was treated as permission for a pending retry to
capture. It was right, and it is the exact risk round 2 listed as attack point 2 in its own
review request — "unknown ⇒ allowed" preserves the pre-r2 behaviour on precisely the path
where the pre-r2 behaviour is the bug. During a tab switch, a close, or a teardown the
store answers null while the canvas on screen already belongs to someone else.

Fixed in `4f63df1d`: a named `trackerStillOwnsCanvas` now requires **positive** ownership —
a readable active workflow whose `changeTracker` **is** this tracker. `null`, `undefined`
and a trackerless active workflow all answer `false`.

The trade is written into the code rather than left silent: refusing to capture on an
unreadable store can leave the snapshot behind until the next command, and that state is
caught **loudly** by `saveWouldPersistStaleSnapshot`, which refuses the save instead of
persisting it. One side of that trade is recoverable; the other writes the wrong graph over
a user's file.

**The wiring test is now executable rather than textual** — it slices the predicate out of
the panel source and drives it, so its ANSWER is pinned, not its spelling:
owning tracker → `true`; another workflow's tracker → `false`; `null`/`undefined` →
`false`; active workflow with no tracker → `false`.

| Mutation (against the committed head) | Result |
| --- | --- |
| restore `if (!active) return true` | ✖ `#1563 r2 WIRING…` fails |
| drop `trackerStillOwnsCanvas` from the defer call | ✖ `#1563 r2 WIRING…` fails |

**The P0 was also reproduced by execution, not by reading.** Driving the real module with a
virtual clock through the reported sequence — command on A → B opens → `isLoadingGraph`
true → B's load completes → A's chain fires — and modelling a frontend that predates
upstream's `isActiveTracker` guard (this panel still falls back to the deprecated
`checkState`, so it supports those):

```
pre-fix module :  trackerA.activeState = {"nodes":[{"id":9},{"id":10}],"tag":"B-canvas"}
                  ^ workflow B's canvas, sitting in workflow A's snapshot
post-fix module:  trackerA.activeState = {"nodes":[],"tag":"A-initial"}   (1 attempt, chain stopped)
```

That reproduction matches the gate's independently-measured value exactly.

Unit suite on `4f63df1d`: **6188 passed**, 1 failed — the known `#671` wall-clock flake,
**125 passed / 0 failed** when that file is run alone.

## Review

**Two independent gate rounds, both NO-SHIP, both findings real and fixed:**

| Round | Head | Verdict | Finding | Status |
| --- | --- | --- | --- | --- |
| 1 | `e10ee95d` | NO-SHIP | P0 orphaned retry chain captures another workflow's canvas; P1 an absent comparison read as proof of staleness | fixed in `4ce9eb44` |
| 2 | `4ce9eb44` | NO-SHIP | ownership predicate treated an unreadable store as permission | fixed in `4f63df1d` |
| 3 | `4f63df1d` | running | — | — |

Disclosure, which the fallback gate requires: round 1 and round 3 are `claude-gate.mjs`,
this repo's **substituted** adversarial gate — a fresh session that has never seen the
implementation, handed only the diff and told to refute and to run the code. It is
structurally independent of the author but weaker than codex at *executing* hostile inputs.
`codex-gate.mjs` was deliberately not run (that account is repointed at a weak model, so a
SHIP from it would carry authority it has not earned). Copilot declined with a quota
message, which is not a review. **grok was asked on the PR and on issue #1563 and has not
answered.**

Where a later reviewer should still attack, ranked:

1. `saveWouldPersistStaleSnapshot` conjunct 2 — the tolerant proof is reachable only behind
   a positive `comparable === true`, off one frozen serialization. A shape that is
   comparable and not proven, where the save was actually fine, is still a cannot-save bug.
2. A workflow **closed** mid-chain. The record is disarmed on a new defer, on a foreign
   flush, and on lost ownership; a close that does none of those three is the remaining gap.
3. The browser suite has **not** run against rounds 2–3 (see the coverage note above) — the
   real `setTimeout` receiver and a real workflow switch mid-chain are unit-modelled only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
