### PR TITLE
fix(1565): graph_run answers inside the window its reply is relayed in

### DIFF
--- a/browser_tests/unit/graph-to-prompt-failure.test.mjs
+++ b/browser_tests/unit/graph-to-prompt-failure.test.mjs
@@ -94,6 +94,18 @@ test("#1582 a long type list is bounded", () => {
 //    a few lines inside a 30k-line file that a refactor could drop with every unit test
 //    still green.
 
+test("#1565: a SYNCHRONOUS graphToPrompt still reaches the pre-flight — the bound must not remove a guard", async () => {
+  // An extension may replace graphToPrompt with a plain function returning the prompt
+  // object. `await` accepted that; a bare `.then` on a non-thenable throws, and the
+  // pre-flight's own catch would swallow it and skip a guard that used to run.
+  const msg = await runPreflight({
+    graphToPrompt: () => ({ output: { 1: { class_type: undefined, inputs: {} } }, workflow: {} }),
+    nodes: [{ id: 1, type: "LCKreaSampler", constructor: {} }],
+  });
+  assert.notEqual(msg, "__NO_REFUSAL__", "the pre-flight must still refuse an unrunnable node");
+  assert.match(msg, /^NOT queued:/);
+});
+
 test("#1582 the run path guards graphToPrompt BEFORE reading offenders", async () => {
   const { readFileSync } = await import("node:fs");
   const src = readFileSync(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf-8");

--- a/browser_tests/unit/graph-to-prompt-failure.test.mjs
+++ b/browser_tests/unit/graph-to-prompt-failure.test.mjs
@@ -16,6 +16,10 @@
 // `unrunnableNodeIds(undefined)` answers `[]` — no offenders — because a result that does not
 // exist has no unrunnable entries in it. Absence of evidence, read as evidence of absence.
 import test from "node:test";
+// #1565 — the pre-flight serialization is bounded by graph_run's command budget now;
+// the harness below drives the SHIPPED block, so it needs the same two collaborators.
+import { withTimeout } from "../../web/js/lib/bounded-step.js";
+import { makeCommandBudget } from "../../web/js/lib/command-budget.js";
 import assert from "node:assert/strict";
 
 import {
@@ -93,8 +97,16 @@ test("#1582 a long type list is bounded", () => {
 test("#1582 the run path guards graphToPrompt BEFORE reading offenders", async () => {
   const { readFileSync } = await import("node:fs");
   const src = readFileSync(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf-8");
-  const at = src.indexOf("const built = await app.graphToPrompt();");
+  // #1565 — the call is bounded by the command budget now, so the recognisable line is the
+  // bounded step rather than a bare await. Same block, same assertions below it, plus a
+  // check that it is still graphToPrompt being bounded.
+  const at = src.indexOf("const preflightBuild = await withTimeout(");
   assert.ok(at > 0, "the pre-flight's graphToPrompt call must still be recognisable");
+  assert.match(
+    src.slice(at, src.indexOf("const built = preflightBuild.value;", at)),
+    /app\.graphToPrompt\(\)/,
+    "and it must still be the pre-flight that serializes the prompt",
+  );
   // Bounded by the pre-flight's OWN catch, not a byte count. A fixed 1800 truncated
   // `unrunnableNodeIds(built)` the moment the guard's comment grew — which is the third
   // time today a fixed window in this repo reported missing wiring that was present
@@ -162,6 +174,14 @@ async function buildPreflight({ graphToPrompt, nodes = [], viewedNodes, registry
     // without this the extracted body throws a ReferenceError that the pre-flight catch
     // swallows, and the test sees no refusal at all.
     "window",
+    // #1565 — the serialization is BOUNDED by graph_run's command budget now. All three
+    // names are consts in graph_run, so leaving any of them out makes the extracted body
+    // throw a ReferenceError the pre-flight catch swallows — the test would then read "no
+    // refusal" from a pre-flight that never ran, which is the silent failure this file
+    // exists to stop, one layer down.
+    "withTimeout",
+    "budget",
+    "RUN_SERIALIZE_TIMEOUT_MS",
     `return async function preflight() {\n${body}\n};`,
   );
   // The VIEWED graph is deliberately a DIFFERENT object from the root when the caller
@@ -181,6 +201,11 @@ async function buildPreflight({ graphToPrompt, nodes = [], viewedNodes, registry
     { _nodes: nodes },
     mod.unresolvedNodeTypes,
     { LiteGraph: { registered_node_types: registry } },
+    withTimeout,
+    // A REAL budget with room to spare: this file is about what the pre-flight REFUSES,
+    // and an already-spent budget would answer every case with a skipped pre-flight.
+    makeCommandBudget(30000),
+    8000,
   );
 }
 

--- a/browser_tests/unit/missing-node-preflight.test.mjs
+++ b/browser_tests/unit/missing-node-preflight.test.mjs
@@ -121,8 +121,10 @@ test("#1460 a long list is bounded but says how many were withheld", () => {
 test("#1460 WIRING: the preflight reads the SERIALIZED prompt, not the canvas", () => {
   const src = readFileSync(join(ROOT, "web/js/comfyui-mcp-panel.js"), "utf8");
   assert.match(src, /import \{[\s\S]*?unrunnableNodeIdsInScope,[\s\S]*?\} from "\.\/lib\/missing-node-preflight\.js";/);
-  const at = src.indexOf("const built = await app.graphToPrompt();");
+  // #1565 — bounded by graph_run's command budget now; the block is the same one.
+  const at = src.indexOf("const preflightBuild = await withTimeout(");
   assert.ok(at > 0, "the preflight must serialize the prompt itself");
+  assert.match(src.slice(at, at + 400), /app\.graphToPrompt\(\)/, "and it is graphToPrompt it bounds");
   // Bounded by the pre-flight's OWN catch rather than a byte count. A fixed 600 excluded
   // `unrunnableNodeIds(built)` as soon as #1582 added a guard above it — reporting missing
   // wiring while the wiring was fine. The window exists to keep this assertion scoped to
@@ -212,7 +214,7 @@ test("#1871 WIRING: the run-to-node target is RESOLVED before the pre-flight rea
 
 test("#1460 WIRING: it runs BEFORE the prompt is queued", () => {
   const src = readFileSync(join(ROOT, "web/js/comfyui-mcp-panel.js"), "utf8");
-  const check = src.indexOf("const built = await app.graphToPrompt();");
+  const check = src.indexOf("const preflightBuild = await withTimeout(");
   const queue = src.indexOf("app.queuePrompt", check);
   assert.ok(check > 0 && queue > check, "the check must precede queuePrompt");
 });

--- a/browser_tests/unit/run-command-budget.test.mjs
+++ b/browser_tests/unit/run-command-budget.test.mjs
@@ -556,3 +556,206 @@ test("#1565 CALL SITE: graph_run takes its budget from RUN_COMMAND_BUDGET_MS on 
     "the pre-flight serialization draws from the command budget, not its own fresh clock",
   );
 });
+
+// ---------------------------------------------------------------------------
+// 5. THE UNSCOPED FULL RUN — `graph_run({})`, no to_node_id.
+//
+// The first cut of #1565 bounded only the scoped path and disclosed the unscoped one as
+// deliberately out of scope, on the argument that abandoning an unbounded queue call
+// risks claiming `queued` with no receipt. A review returned that as a P1. MEASURED
+// against the shipped body, both halves of the argument turned out to be true and only
+// one of them survives:
+//
+//   - the harm is REAL and identical to the scoped one. `graph_run({})` against a
+//     frontend whose queue processor never answers never replied; the caller timed out
+//     at 20,007 ms, retried on the advice of a message blaming a "backgrounded or
+//     frozen" tab, and the retry queued at 20,022 ms while the FIRST run's post landed
+//     at 21,011 ms — TWO full-graph renders from one user intent, on the MORE COMMON
+//     path;
+//   - and the receipt objection is real: `buildQueueAcceptResult` with no ids answers a
+//     bare `{queued: true, batch_count: N}` — a definite positive with nothing behind it.
+//
+// What resolves it is that the honest vocabulary already existed. `queued_unknown` was
+// built for exactly this epistemic state on the scoped path, so the bound routes into it
+// rather than into a `queued` the run cannot back.
+// ---------------------------------------------------------------------------
+
+/**
+ * A frontend for the UNSCOPED path.
+ * @param {"late"|"never"|"silent"|"postThenHang"} mode
+ *   late         posts and settles after drainMs (healthy)
+ *   never        never settles; posts drainMs later (the busy processor)
+ *   silent       never settles, never posts
+ *   postThenHang posts and captures a prompt_id, then never settles (partial batch)
+ */
+function makeUnscopedFrontend({ apiTarget, mode, drainMs = 5 }) {
+  const app = {
+    queueItems: [],
+    graph: { _nodes: [] },
+    graphToPrompt: async () => ({ output: OUR_OUTPUT, workflow: {} }),
+    queuePrompt: async () => {
+      const post = () =>
+        apiTarget.fetchApi("/prompt", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ prompt: OUR_OUTPUT, client_id: "x" }),
+        });
+      if (mode === "silent") return new Promise(() => {});
+      if (mode === "postThenHang") {
+        await post();
+        return new Promise(() => {});
+      }
+      if (mode === "never") {
+        const t = setTimeout(post, drainMs);
+        if (typeof t.unref === "function") t.unref();
+        return new Promise(() => {});
+      }
+      await post();
+      return true;
+    },
+  };
+  return app;
+}
+
+test("#1565 P1: a full run whose queue call never settles ANSWERS inside its budget — it does not hang to the relay timeout", async () => {
+  const stop = keepAlive();
+  try {
+    const apiTarget = { fetchApi: makeServer() };
+    const app = makeUnscopedFrontend({ apiTarget, mode: "never", drainMs: 60000 });
+    const built = realGraphRun({ app, apiTarget, budgetMs: 600, serializeMs: 400 });
+    const started = Date.now();
+    const answer = await Promise.race([
+      built.graph_run({}).then((r) => ({ replied: r })),
+      new Promise((r) => setTimeout(() => r({ hung: true }), 5000)),
+    ]);
+    assert.ok(
+      !answer.hung,
+      "graph_run({}) never replied — the unbounded queue call is the reported hang, on the " +
+        "MORE COMMON path: the caller then times out and retries, and the late post still lands",
+    );
+    assert.ok(Date.now() - started <= 5000);
+  } finally {
+    stop();
+  }
+});
+
+test("#1565 P1: an abandoned full run NEVER answers a bare queued:true — the receipt objection, honoured", async () => {
+  const stop = keepAlive();
+  try {
+    const apiTarget = { fetchApi: makeServer() };
+    const app = makeUnscopedFrontend({ apiTarget, mode: "silent" });
+    const built = realGraphRun({ app, apiTarget, budgetMs: 600, serializeMs: 400 });
+    const res = await built.graph_run({});
+    // buildQueueAcceptResult with no ids answers {queued:true, batch_count:N}. Routing an
+    // abandoned run through it would assert a render nobody observed.
+    assert.notEqual(res.queued, true, "a run with no receipt must never claim it queued");
+    assert.equal(res.queued_unknown, true, "it takes the honest shape the scoped path already uses");
+    assert.equal("queued" in res, false, "and OMITS `queued` — there is no boolean that means unknown");
+    assert.match(String(res.retry_guidance), /blind retry renders the whole graph twice/);
+  } finally {
+    stop();
+  }
+});
+
+test("#1565 P1: `queued:false` is never earned by an abandoned run — a bounded observation cannot license an unbounded negative", async () => {
+  const stop = keepAlive();
+  try {
+    const apiTarget = { fetchApi: makeServer() };
+    const server = apiTarget.fetchApi;
+    // Nothing has left the panel when the budget expires — but the queue call is STILL
+    // RUNNING and posts afterwards. Measured on the real body: answered at 1.5 s with
+    // posted === 0, and the post left at 21 s anyway. Telling the caller "nothing was
+    // queued, safe to re-issue" there moves the duplicate render rather than removing it.
+    const app = makeUnscopedFrontend({ apiTarget, mode: "never", drainMs: 400 });
+    const built = realGraphRun({ app, apiTarget, budgetMs: 250, serializeMs: 150 });
+    const res = await built.graph_run({});
+    assert.equal(server.calls.length, 0, "nothing had left the panel at the moment of the reply");
+    assert.notEqual(
+      res.queued,
+      false,
+      "`queued:false` says the run can be re-issued safely; the frontend can still post it",
+    );
+    assert.equal(res.queued_unknown, true);
+    assert.match(String(res.retry_guidance), /STILL RUNNING/);
+    // And the late post does arrive, which is exactly why the negative was not honest.
+    await new Promise((r) => setTimeout(r, 700));
+    assert.equal(server.calls.length, 1, "the abandoned queue call posted after the reply");
+  } finally {
+    stop();
+  }
+});
+
+test("#1565 P1: prompts that DID queue before the budget expired are reported with their real ids", async () => {
+  const stop = keepAlive();
+  try {
+    const apiTarget = { fetchApi: makeServer() };
+    const app = makeUnscopedFrontend({ apiTarget, mode: "postThenHang" });
+    const built = realGraphRun({ app, apiTarget, budgetMs: 600, serializeMs: 400 });
+    const res = await built.graph_run({});
+    // Reporting this as a failure would send the caller to re-run work that is rendering.
+    assert.equal(res.queued, true);
+    assert.equal(res.partially_queued, true);
+    assert.deepEqual(res.queued_prompt_ids, ["srv-1"]);
+    assert.equal(res.complete, false);
+    assert.match(String(res.incomplete_reason), /command budget/);
+  } finally {
+    stop();
+  }
+});
+
+test("#1565 P1: a HEALTHY full run is untouched — same accept result, no budget in sight", async () => {
+  const stop = keepAlive();
+  try {
+    const apiTarget = { fetchApi: makeServer() };
+    const app = makeUnscopedFrontend({ apiTarget, mode: "late", drainMs: 5 });
+    const built = realGraphRun({ app, apiTarget, budgetMs: 15000, serializeMs: 8000 });
+    const res = await built.graph_run({});
+    assert.deepEqual(res, { queued: true, batch_count: 1, prompt_id: "srv-1" });
+  } finally {
+    stop();
+  }
+});
+
+test("#1565 P1: the run interceptor COUNTS what left the panel, so the reply states it rather than assuming it", async () => {
+  const stop = keepAlive();
+  try {
+    let release;
+    const gate = new Promise((r) => (release = r));
+    const inner = async (route, options) => {
+      await gate;
+      return { status: 200, clone: () => ({ json: async () => ({ prompt_id: "p1" }) }), text: async () => "{}" };
+    };
+    const interceptor = createRunFetchInterceptor({ origFetchApi: inner });
+    assert.deepEqual(interceptor.state, { posted: 0, inFlight: 0 });
+    const post = interceptor("/prompt", { method: "POST", body: JSON.stringify({ prompt: {} }) });
+    assert.deepEqual(interceptor.state, { posted: 1, inFlight: 1 }, "counted BEFORE the request leaves");
+    release();
+    await post;
+    assert.deepEqual(interceptor.state, { posted: 1, inFlight: 0 }, "and settled when it answers");
+    // A non-prompt request is never counted as this run's work.
+    await interceptor("/queue", { method: "GET" });
+    assert.deepEqual(interceptor.state, { posted: 1, inFlight: 0 });
+  } finally {
+    stop();
+  }
+});
+
+test("#1565 P1: an unreadable request cannot stop a fetch that previously went out", async () => {
+  const stop = keepAlive();
+  try {
+    let reached = false;
+    const inner = async () => {
+      reached = true;
+      return { status: 200, clone: () => ({ json: async () => ({}) }), text: async () => "{}" };
+    };
+    const interceptor = createRunFetchInterceptor({ origFetchApi: inner });
+    // Classification moved BEFORE the await, so a throwing `options` must not become a
+    // request that never leaves — this used to run only after the fetch.
+    const hostile = new Proxy({}, { get() { throw new Error("hostile options"); } });
+    await interceptor("/prompt", hostile);
+    assert.equal(reached, true, "the request still went out");
+    assert.equal(interceptor.state.posted, 0, "it simply is not counted");
+  } finally {
+    stop();
+  }
+});

--- a/browser_tests/unit/run-command-budget.test.mjs
+++ b/browser_tests/unit/run-command-budget.test.mjs
@@ -311,6 +311,61 @@ test("#1565: NO budget ⇒ no new bound — an existing caller keeps today's beh
   }
 });
 
+test("#1565 P0: a run abandoned at its bound still FENCES its own late post, with another run's guard installed on top", async () => {
+  const stop = keepAlive();
+  try {
+    const apiTarget = { fetchApi: makeServer() };
+    const server = apiTarget.fetchApi;
+    const raw = apiTarget.fetchApi;
+    // Run A: its queue call never settles, so it is abandoned at the bound. The post it
+    // already handed to the busy processor arrives LATER — after A has been reported.
+    let latePost = null;
+    const appA = {
+      queueItems: [],
+      graphToPrompt: async () => ({ output: OUR_OUTPUT, workflow: {} }),
+      queuePrompt: async (number) => {
+        // The processor will emit this run's post long after queuePrompt is abandoned,
+        // through WHATEVER fetchApi is installed by then — which is another run's guard.
+        latePost = () =>
+          apiTarget.fetchApi("/prompt", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ prompt: OUR_OUTPUT, client_id: "x", number }),
+          });
+        return new Promise(() => {});
+      },
+    };
+    const a = await dispatchScopedRun({
+      app: appA, apiTarget, execIds: ["327"], batch: 1, toNodeId: 327,
+      verifyTimeoutMs: 300, budget: makeCommandBudget(400),
+    });
+    assert.notEqual(a.outcome, "dispatched", "A was abandoned at its bound");
+    assert.notEqual(apiTarget.fetchApi, raw, "and its fence is still in the chain, never restored to raw fetch");
+
+    // Run B starts afterwards and installs ITS guard on top of A's closed one.
+    const appB = makeBusyDroppingFrontend({ apiTarget, drainMs: 5 });
+    const b = await dispatchScopedRun({
+      app: appB, apiTarget, execIds: ["327"], batch: 1, toNodeId: 327,
+      verifyTimeoutMs: 300, budget: makeCommandBudget(2000),
+    });
+    assert.equal(b.outcome, "dispatched", "B is unaffected by A's abandoned fence");
+    const postsAfterB = server.calls.length;
+
+    // NOW A's late post arrives. It must travel B's guard (mark mismatch, passed through)
+    // and meet A's CLOSED guard below it — refused, never forwarded to the server.
+    const res = await latePost();
+    assert.equal(res.status, 400, "A's late post is refused by A's own closed fence");
+    assert.equal(
+      server.calls.length,
+      postsAfterB,
+      "a post from an abandoned run must never reach ComfyUI scopeless — that is the " +
+        "full-graph execution this whole module exists to prevent",
+    );
+  } finally {
+    stop();
+  }
+});
+
 // ---------------------------------------------------------------------------
 // 3. THE CALL SITE. The whole fix is one budget reaching the dispatch, and a
 //    library-level test cannot see whether it does. This runs the SHIPPED

--- a/browser_tests/unit/run-command-budget.test.mjs
+++ b/browser_tests/unit/run-command-budget.test.mjs
@@ -290,6 +290,33 @@ test("#1565: a queuePrompt that THROWS still throws — a bound must not relabel
   }
 });
 
+test("#1565: even a FALSY thrown value still throws — the bound settles into {value}/{error}, and `error` may be undefined", async () => {
+  const stop = keepAlive();
+  try {
+    const apiTarget = { fetchApi: makeServer() };
+    const app = makeBusyDroppingFrontend({ apiTarget });
+    // `throw undefined` is legal. A truthiness test on the settled object would read it as
+    // "no error" and continue into the give-up path, reporting a timeout for a frontend
+    // that actually refused. The bare `await` it replaced propagated it.
+    app.queuePrompt = async () => {
+      throw undefined;
+    };
+    let threw = false;
+    try {
+      await dispatchScopedRun({
+        app, apiTarget, execIds: ["327"], batch: 1, toNodeId: 327,
+        verifyTimeoutMs: 500, budget: makeCommandBudget(600),
+      });
+    } catch (err) {
+      threw = true;
+      assert.equal(err, undefined, "and it is the SAME value the frontend threw");
+    }
+    assert.ok(threw, "a falsy throw must still reject, not be relabelled as a timeout");
+  } finally {
+    stop();
+  }
+});
+
 test("#1565: NO budget ⇒ no new bound — an existing caller keeps today's behaviour", async () => {
   const stop = keepAlive();
   try {

--- a/browser_tests/unit/run-command-budget.test.mjs
+++ b/browser_tests/unit/run-command-budget.test.mjs
@@ -1,0 +1,476 @@
+// panel#1565 — `panel_run` timed out on `graph_run` (20,000 ms) twice in a row, including
+// an explicit `retry_of` retry, while `panel_query_graph` reads to the SAME tab answered
+// sub-second throughout. That asymmetry rules out a dead socket, a lost `hello` and a
+// wedged bridge: something makes the RUN path specifically block while the read path is
+// fine.
+//
+// WHAT THE RUN PATH AWAITS THAT THE READ PATH DOES NOT — measured on the shipped module,
+// not read off the source:
+//
+//   1. `app.graphToPrompt()` — serializing the whole workflow, every extension's own
+//      serializeValue included. No bound of any kind.
+//   2. `app.queuePrompt()` — the frontend's queue processor. No bound of any kind, and on
+//      the reporter's machine BOTH `app.queuePrompt` and `api.queuePrompt` are shadowed by
+//      an extension's own property. A wrapper that never settles held `graph_run` open
+//      FOREVER while a read of the same objects answered in 0.06 ms.
+//   3. the scoped-dispatch observation wait — ONCE PER ARGUMENT SHAPE, each starting a
+//      fresh `verifyTimeoutMs`. Four shapes × 5,000 ms is 20,000 ms: EXACTLY the window
+//      `panel_run` relays this command in, with nothing left for the reply itself.
+//
+// `panel_query_graph` takes none of them — it reads live LiteGraph objects.
+//
+// MEASURED BEFORE THE FIX, driving the shipped `dispatchScopedRun` with a busy queue
+// processor draining at 4,990 ms per item (the reporter had user Queue presses interleaved
+// with agent runs): dispatchScopedRun took **20,003 ms**, and the prompt POSTED at
+// 20,003 ms — i.e. the run genuinely queued AFTER the caller had already been told the tab
+// "may be backgrounded or frozen". A retry of that "failed" run renders the branch twice,
+// which is a worse bug than the one reported.
+//
+// The fix is ONE deadline for the whole command, taken on `graph_run`'s first line and
+// threaded into the dispatch, so those bounds COMPOSE instead of summing — the same shape
+// #1192 (`graph_add_node`) and #671 (`nodes_install`) already needed. These tests drive the
+// REAL `dispatchScopedRun` and the SHIPPED `graph_run` body; a helper-level test cannot
+// reach this defect, because every individual bound here is defensible on its own and the
+// bug lives entirely in whether the call site threads one budget through them.
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import { dispatchScopedRun, createRunFetchInterceptor } from "../../web/js/lib/run-scope-guard.js";
+import { makeCommandBudget } from "../../web/js/lib/command-budget.js";
+import { withTimeout } from "../../web/js/lib/bounded-step.js";
+import {
+  graphToPromptUnusable,
+  unrunnableNodeIdsInScope,
+  unserializableGraphRefusal,
+  unresolvedNodeTypes,
+  missingNodeRunRefusal,
+  describeUnrunnable,
+} from "../../web/js/lib/missing-node-preflight.js";
+import { buildQueueAcceptResult, summarizePromptRejection } from "../../web/js/lib/queue-rejection.js";
+import { installGraphToPromptNullSafety } from "../../web/js/lib/widget-null-safety.js";
+import { collectAllGraphs } from "../../web/js/lib/asset-staleness.js";
+import {
+  findRepeatingControlWidgets,
+  findRgthreeSeedNodes,
+  repeatingRgthreeSeeds,
+  scopedBatchSeedNote,
+  rgthreeFixedSeedNote,
+} from "../../web/js/lib/scoped-batch-seed.js";
+import { collectVirtualSourceFeeds, virtualSourceNote } from "../../web/js/lib/virtual-source-promotion.js";
+import { collectDisabledAncestorOutputs, disabledOutputsNote } from "../../web/js/lib/muted-subgraph-outputs.js";
+import { prunedRetryNote } from "../../web/js/lib/partial-run-prune.js";
+import {
+  describeQueuePromptChain,
+  describeQueuePromptChainForReport,
+  queuePromptChainDeps,
+} from "../../web/js/lib/queue-prompt-chain.js";
+import { MUTATION_BINDING_BAR } from "../../web/js/lib/graph-binding.js";
+
+const panelPath = fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url));
+const panelSrc = readFileSync(panelPath, "utf8");
+
+const runMatch = panelSrc.match(/\n {2}async graph_run\(\{ batch_count, to_node_id \}\) \{[\s\S]*?\n {2}\},/);
+assert.ok(runMatch, "could not locate graph_run in panel source");
+
+/** The window the OTHER repo relays this command in (`ctx.call(runCmd, 20000, …)`). */
+const RUN_RELAY_WINDOW_MS = 20000;
+
+/** Node 22 cancels pending tests when only unref'd timers remain (the guard unrefs by design). */
+function keepAlive() {
+  const ka = setInterval(() => {}, 25);
+  return () => clearInterval(ka);
+}
+
+// ---------------------------------------------------------------------------
+// Fixtures — a frontend whose queue processor is BUSY, and which drops the scope
+// in every app.queuePrompt argument shape. That is the reporter's own machine:
+// every successful run in their session came back `scope_applied_by:
+// "request_body_repair"`, i.e. the first three shapes always drop and only the
+// fourth (the panel writing partial_execution_targets into the body) carries it.
+// ---------------------------------------------------------------------------
+
+const OUR_OUTPUT = {
+  "3": { class_type: "KSampler", inputs: {} },
+  "9": { class_type: "SaveImage", inputs: {} },
+  "327": { class_type: "SaveImage", inputs: {} },
+};
+
+function jsonResponse(status, obj) {
+  return {
+    status,
+    clone: () => ({ json: async () => JSON.parse(JSON.stringify(obj)) }),
+    text: async () => JSON.stringify(obj),
+  };
+}
+
+function makeServer() {
+  const calls = [];
+  const fetchApi = async (route, options) => {
+    calls.push({ route, options, at: Date.now() });
+    return jsonResponse(200, { prompt_id: `srv-${calls.length}` });
+  };
+  fetchApi.calls = calls;
+  return fetchApi;
+}
+
+/**
+ * @param {object} o
+ * @param {number} o.drainMs how long the busy processor takes to get to our item
+ * @param {"defer"|"never"|"throw"} [o.queue] how app.queuePrompt itself behaves
+ * @param {"ok"|"never"} [o.serialize] how app.graphToPrompt behaves
+ */
+function makeBusyDroppingFrontend({ apiTarget, drainMs = 4990, queue = "defer", serialize = "ok" }) {
+  const app = {
+    queueItems: [],
+    posted: [],
+    graphToPrompt: serialize === "never" ? () => new Promise(() => {}) : async () => ({ output: OUR_OUTPUT, workflow: {} }),
+    queuePrompt: async (number, batch) => {
+      if (queue === "never") return new Promise(() => {});
+      if (queue === "throw") throw new Error("frontend refused the queue call");
+      // "dropping": no argument shape carries the scope through to the request.
+      const item = { number, batchCount: batch, queueNodeIds: undefined };
+      app.queueItems.push(item);
+      // The busy processor serializes and posts our item LATER — exactly what the real
+      // frontend does while `processingQueue` is true.
+      const t = setTimeout(() => {
+        const i = app.queueItems.indexOf(item);
+        if (i < 0) return; // the panel cancelled it
+        app.queueItems.splice(i, 1);
+        const body = { prompt: OUR_OUTPUT, client_id: "x", number: item.number };
+        app.posted.push({ body, at: Date.now() });
+        apiTarget.fetchApi("/prompt", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(body),
+        });
+      }, drainMs);
+      if (typeof t.unref === "function") t.unref();
+      return false; // busy — returns immediately, like the real one
+    },
+  };
+  return app;
+}
+
+// ---------------------------------------------------------------------------
+// 1. The reported composition, at the library the run path actually uses.
+// ---------------------------------------------------------------------------
+
+test("#1565: four argument shapes on a busy frontend cannot outlast ONE command budget", async () => {
+  const stop = keepAlive();
+  try {
+    const apiTarget = { fetchApi: makeServer() };
+    const server = apiTarget.fetchApi;
+    // Per-attempt wait 500 ms, budget 600 ms. WITHOUT the budget the four attempts each
+    // start their own 500 ms clock and the command runs ~2,000 ms — the same 4× shape that
+    // measured 20,003 ms against the real 5,000 ms/20,000 ms pair.
+    const app = makeBusyDroppingFrontend({ apiTarget, drainMs: 490 });
+    const started = Date.now();
+    const result = await dispatchScopedRun({
+      app,
+      apiTarget,
+      execIds: ["327"],
+      batch: 1,
+      toNodeId: 327,
+      verifyTimeoutMs: 500,
+      budget: makeCommandBudget(600),
+    });
+    const elapsed = Date.now() - started;
+    assert.ok(
+      elapsed <= 600 + 250,
+      `the scoped dispatch spent ${elapsed}ms of a 600ms command budget — the per-attempt ` +
+        `waits are not composing, which is what put a real run past its 20,000ms relay window`,
+    );
+    assert.notEqual(
+      result.outcome,
+      "dispatched",
+      "a run that ran out of budget must not report a dispatch it never observed",
+    );
+    // The prompt must not queue AFTER the caller has been answered. Before the fix this is
+    // exactly what happened: the post left at 20,003 ms, past the caller's deadline, so a
+    // retry of the "failed" run rendered the branch twice.
+    await new Promise((r) => setTimeout(r, 700));
+    assert.equal(
+      server.calls.length,
+      0,
+      "a post that arrives after the run was reported must meet the fence, not ComfyUI",
+    );
+  } finally {
+    stop();
+  }
+});
+
+test("#1565: an app.queuePrompt that NEVER SETTLES is bounded by the command budget", async () => {
+  const stop = keepAlive();
+  try {
+    const apiTarget = { fetchApi: makeServer() };
+    const app = makeBusyDroppingFrontend({ apiTarget, queue: "never" });
+    const started = Date.now();
+    // Raced, so an unbounded await FAILS this test instead of hanging the runner.
+    const outcome = await Promise.race([
+      dispatchScopedRun({
+        app,
+        apiTarget,
+        execIds: ["327"],
+        batch: 1,
+        toNodeId: 327,
+        verifyTimeoutMs: 500,
+        budget: makeCommandBudget(600),
+      }).then((r) => ({ replied: r })),
+      new Promise((r) => setTimeout(() => r({ hung: true }), 4000)),
+    ]);
+    const elapsed = Date.now() - started;
+    assert.ok(
+      !outcome.hung,
+      `dispatchScopedRun never answered — a frontend queue call that does not settle must ` +
+        `not be able to hold graph_run open past the window its reply is relayed in`,
+    );
+    assert.ok(elapsed <= 4000, `answered in ${elapsed}ms`);
+    assert.notEqual(outcome.replied.outcome, "dispatched");
+  } finally {
+    stop();
+  }
+});
+
+test("#1565: an app.graphToPrompt that NEVER SETTLES is bounded, and nothing is queued", async () => {
+  const stop = keepAlive();
+  try {
+    const apiTarget = { fetchApi: makeServer() };
+    const app = makeBusyDroppingFrontend({ apiTarget, serialize: "never" });
+    const outcome = await Promise.race([
+      dispatchScopedRun({
+        app,
+        apiTarget,
+        execIds: ["327"],
+        batch: 1,
+        toNodeId: 327,
+        verifyTimeoutMs: 500,
+        budget: makeCommandBudget(600),
+      }).then((r) => ({ replied: r })),
+      new Promise((r) => setTimeout(() => r({ hung: true }), 4000)),
+    ]);
+    assert.ok(!outcome.hung, "a serializer that never answers must not hold the command open");
+    assert.equal(
+      outcome.replied.outcome,
+      "unverifiable",
+      "no fingerprint means no attribution — the established fail-closed state, nothing queued",
+    );
+    assert.equal(apiTarget.fetchApi.calls.length, 0, "nothing was posted");
+  } finally {
+    stop();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// 2. The bound must not invent outcomes. Two regressions the bound could cause.
+// ---------------------------------------------------------------------------
+
+test("#1565: a queuePrompt that THROWS still throws — a bound must not relabel a refusal as a timeout", async () => {
+  const stop = keepAlive();
+  try {
+    const apiTarget = { fetchApi: makeServer() };
+    const app = makeBusyDroppingFrontend({ apiTarget, queue: "throw" });
+    await assert.rejects(
+      () =>
+        dispatchScopedRun({
+          app,
+          apiTarget,
+          execIds: ["327"],
+          batch: 1,
+          toNodeId: 327,
+          verifyTimeoutMs: 500,
+          budget: makeCommandBudget(600),
+        }),
+      /frontend refused the queue call/,
+      "the frontend's own error is what the caller has to see; a timeout story would be a wrong one",
+    );
+  } finally {
+    stop();
+  }
+});
+
+test("#1565: NO budget ⇒ no new bound — an existing caller keeps today's behaviour", async () => {
+  const stop = keepAlive();
+  try {
+    const apiTarget = { fetchApi: makeServer() };
+    // Posts promptly, so the happy path still dispatches with no budget in sight.
+    const app = makeBusyDroppingFrontend({ apiTarget, drainMs: 5 });
+    const result = await dispatchScopedRun({
+      app,
+      apiTarget,
+      execIds: ["327"],
+      batch: 1,
+      toNodeId: 327,
+      verifyTimeoutMs: 500,
+    });
+    assert.equal(result.outcome, "dispatched");
+    assert.equal(result.scopeAppliedBy, "request_body_repair", "the 4th shape is what carries it on this build");
+  } finally {
+    stop();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// 3. THE CALL SITE. The whole fix is one budget reaching the dispatch, and a
+//    library-level test cannot see whether it does. This runs the SHIPPED
+//    graph_run body with injected collaborators.
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the real `graph_run` executor from panel source.
+ *
+ * `budgetMs` / `serializeMs` are injected in place of the shipped constants (the same
+ * technique add-node-command-budget.test.mjs uses) so the wiring can be exercised in
+ * milliseconds; the shipped VALUES are pinned separately below.
+ */
+function realGraphRun({ app, apiTarget, budgetMs, serializeMs, dispatch }) {
+  const seen = { dispatchArgs: null };
+  const deps = {
+    RUN_COMMAND_BUDGET_MS: budgetMs,
+    RUN_SERIALIZE_TIMEOUT_MS: serializeMs,
+    makeCommandBudget,
+    monotonicNow: () => performance.now(),
+    withTimeout,
+    api: apiTarget,
+    window: { LiteGraph: { registered_node_types: {} } },
+    getGraphCtx: () => ({ app, graph: app.graph, rootGraph: app.graph }),
+    assertGraphBoundToActiveWorkflow: () => {},
+    MUTATION_BINDING_BAR,
+    // Target resolution is not what this test is about; the run-to-node resolver has its
+    // own suite (subgraph-scope). Answer the way it answers for a root-level output node.
+    resolveRunToNodeTarget: () => ({ ok: true, execId: "327", node: { type: "SaveImage" } }),
+    dispatchScopedRun: async (args) => {
+      seen.dispatchArgs = args;
+      return dispatch ? dispatch(args) : { outcome: "unverified", queueMark: 1, verified: 0, error: "stub" };
+    },
+    createRunFetchInterceptor,
+    graphToPromptUnusable,
+    unrunnableNodeIdsInScope,
+    unserializableGraphRefusal,
+    unresolvedNodeTypes,
+    missingNodeRunRefusal,
+    describeUnrunnable,
+    installGraphToPromptNullSafety,
+    collectAllGraphs,
+    findRepeatingControlWidgets,
+    findRgthreeSeedNodes,
+    repeatingRgthreeSeeds,
+    scopedBatchSeedNote,
+    rgthreeFixedSeedNote,
+    summarizePromptRejection,
+    buildQueueAcceptResult,
+    collectVirtualSourceFeeds,
+    virtualSourceNote,
+    collectDisabledAncestorOutputs,
+    disabledOutputsNote,
+    prunedRetryNote,
+    describeQueuePromptChain,
+    describeQueuePromptChainForReport,
+    queuePromptChainDeps,
+    runCompletionRef: { onQueued() {} },
+    armRunReconcileSweepRef: () => {},
+  };
+  const names = Object.keys(deps);
+  const factory = new Function(
+    ...names,
+    `const executors = {${runMatch[0]}};
+     return executors.graph_run;`,
+  );
+  return { graph_run: factory(...names.map((n) => deps[n])), seen };
+}
+
+test("#1565 CALL SITE: graph_run hands the dispatch its own command budget", async () => {
+  const stop = keepAlive();
+  try {
+    const apiTarget = { fetchApi: makeServer() };
+    const app = makeBusyDroppingFrontend({ apiTarget, drainMs: 5 });
+    app.graph = { _nodes: [] };
+    const built = realGraphRun({ app, apiTarget, budgetMs: 600, serializeMs: 400 });
+    await built.graph_run({ to_node_id: 327 });
+    const passed = built.seen.dispatchArgs?.budget;
+    assert.ok(
+      passed && typeof passed.bounded === "function",
+      "graph_run dispatched a scoped run WITHOUT a command budget — the dispatch then keeps " +
+        "its per-attempt clocks (4 × 5,000 ms = the whole 20,000 ms relay window) and its " +
+        "unbounded queue call, which is the reported hang",
+    );
+    assert.equal(passed.totalMs, 600, "the budget is the command's own, not one invented inside the dispatch");
+    assert.ok(passed.bounded(999999) <= 600, "every allowance is capped by what the COMMAND has left");
+  } finally {
+    stop();
+  }
+});
+
+test("#1565 CALL SITE: graph_run answers inside its budget when the frontend queue call never settles", async () => {
+  const stop = keepAlive();
+  try {
+    const apiTarget = { fetchApi: makeServer() };
+    const app = makeBusyDroppingFrontend({ apiTarget, queue: "never" });
+    app.graph = { _nodes: [] };
+    // The REAL dispatch, so the budget has to travel from graph_run's first line all the
+    // way into the per-attempt bounds for this to answer at all.
+    const built = realGraphRun({
+      app,
+      apiTarget,
+      budgetMs: 800,
+      serializeMs: 400,
+      dispatch: (args) => dispatchScopedRun({ ...args, verifyTimeoutMs: 500 }),
+    });
+    const started = Date.now();
+    const answer = await Promise.race([
+      built.graph_run({ to_node_id: 327 }).then((r) => ({ replied: r })),
+      new Promise((r) => setTimeout(() => r({ hung: true }), 5000)),
+    ]);
+    const elapsed = Date.now() - started;
+    assert.ok(
+      !answer.hung,
+      "graph_run never replied — this is the reported symptom: the run path blocks while " +
+        "reads on the same tab answer instantly",
+    );
+    assert.ok(elapsed <= 5000, `graph_run answered in ${elapsed}ms`);
+    assert.equal(answer.replied.queued, false, "and it says truthfully that nothing was queued");
+    assert.ok(
+      typeof answer.replied.error === "string" && answer.replied.error.length > 0,
+      "with words, not a bare relay timeout that blames a tab which is answering reads fine",
+    );
+  } finally {
+    stop();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// 4. The shipped numbers. Injected above so the wiring tests run in ms; pinned
+//    here so the values that actually ship cannot drift past the relay window.
+// ---------------------------------------------------------------------------
+
+test("#1565: the shipped run budget leaves room inside the 20,000 ms window the reply is relayed in", () => {
+  const budget = Number(panelSrc.match(/const RUN_COMMAND_BUDGET_MS = (\d+);/)?.[1]);
+  const serialize = Number(panelSrc.match(/const RUN_SERIALIZE_TIMEOUT_MS = (\d+);/)?.[1]);
+  assert.ok(Number.isFinite(budget), "RUN_COMMAND_BUDGET_MS must exist — graph_run is relayed in a fixed window");
+  assert.ok(Number.isFinite(serialize), "RUN_SERIALIZE_TIMEOUT_MS must exist");
+  assert.ok(
+    budget < RUN_RELAY_WINDOW_MS,
+    `a ${budget}ms budget cannot answer inside a ${RUN_RELAY_WINDOW_MS}ms relay window`,
+  );
+  assert.ok(
+    RUN_RELAY_WINDOW_MS - budget >= 5000,
+    "leave the same 5,000 ms of slack the other command budgets leave, for composing the " +
+      "reply and the websocket hop",
+  );
+  assert.ok(serialize <= budget, "one serialization may not be allowed more than the whole command");
+});
+
+test("#1565 CALL SITE: graph_run takes its budget from RUN_COMMAND_BUDGET_MS on the monotonic clock", () => {
+  assert.match(
+    runMatch[0],
+    /const budget = makeCommandBudget\(RUN_COMMAND_BUDGET_MS, monotonicNow\);/,
+    "the budget must be taken before anything can spend the window, on the monotonic clock " +
+      "(a wall clock jump either refuses a run that did nothing wrong or extends it past the relay)",
+  );
+  assert.match(
+    runMatch[0],
+    /budget\.bounded\(RUN_SERIALIZE_TIMEOUT_MS\)/,
+    "the pre-flight serialization draws from the command budget, not its own fresh clock",
+  );
+});

--- a/browser_tests/unit/scope-fingerprint-cause.test.mjs
+++ b/browser_tests/unit/scope-fingerprint-cause.test.mjs
@@ -96,7 +96,9 @@ const guardSrc = () =>
 
 test("#1571 the fingerprint catch BINDS what was thrown", () => {
   const s = guardSrc();
-  const at = s.indexOf("contentCanon = canonicalizePrompt((await app.graphToPrompt())?.output");
+  // #1565 — the fingerprint serialization is bounded by the command budget now, so the
+  // canonicalize reads the bounded step's value. Same block, same binding requirement.
+  const at = s.indexOf("contentCanon = canonicalizePrompt(built.value?.output");
   assert.ok(at > 0, "the fingerprint call must still be recognisable");
   // Bounded by the refusal it feeds, not by a byte count (#1472/#1460/#1582: fixed windows
   // in this repo have reported missing wiring that was present three separate times).

--- a/browser_tests/unit/scoped-batch-seed.test.mjs
+++ b/browser_tests/unit/scoped-batch-seed.test.mjs
@@ -153,7 +153,15 @@ test("#988 (codex) source guard: the scan runs BEFORE dispatch, not after", () =
   // let the caller cancel — a remedy it could not offer.
   const src = readFileSync(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8");
   const scan = src.indexOf("repeatingControls = findRepeatingControlWidgets(");
-  const dispatch = src.indexOf("await app.queuePrompt(0, batch, undefined)");
+  // #1565 — the unscoped dispatch is BOUNDED by the command budget now, so the literal is
+  // no longer a bare `await`. The anchor follows the call; the ordering property it guards
+  // is unchanged, and the assertion below pins that it is still the bounded call.
+  const dispatch = src.indexOf("app.queuePrompt(0, batch, undefined)");
+  assert.match(
+    src.slice(Math.max(0, dispatch - 200), dispatch + 200),
+    /Promise\.resolve\(app\.queuePrompt\(0, batch, undefined\)\)/,
+    "the unscoped dispatch must stay bounded — an unbounded one hangs past the relay window",
+  );
   const scopedDispatch = src.indexOf("runScopeResult = await dispatchScopedRun({");
   assert.ok(scan > 0, "the pre-dispatch scan must exist");
   assert.ok(scan < dispatch && scan < scopedDispatch, "and precede BOTH dispatch paths");

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -15765,7 +15765,9 @@ const GRAPH_TOOL_EXECUTORS = {
         () => null,
       );
       if (preflightBuild == null) throw new Error("graph_run pre-flight: graphToPrompt did not answer in time");
-      if (preflightBuild.error) throw preflightBuild.error;
+      // `"error" in` rather than a truthiness test: a falsy thrown value must still reach
+      // the pre-flight catch as a throw, exactly as the bare await delivered it.
+      if ("error" in preflightBuild) throw preflightBuild.error;
       const built = preflightBuild.value;
       // comfyui-mcp#1582 — SERIALIZATION ITSELF CAN FAIL, and this is where that has to
       // be caught. `unrunnableNodeIds(undefined)` answers `[]` — correctly, since a

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -15756,8 +15756,12 @@ const GRAPH_TOOL_EXECUTORS = {
       // the catch below already treats as "pre-flight unavailable" and skips — the
       // documented fail-soft contract, unchanged. The dispatch's own bounded serialization
       // then produces the truthful, worded refusal.
+      // `Promise.resolve(...)` because an extension may replace graphToPrompt with a
+      // SYNCHRONOUS function returning the prompt object. `await` accepted that; a bare
+      // `.then` on it throws, and the catch below would silently skip a pre-flight that
+      // used to run — a bound that removes a guard is the failure it exists to prevent.
       const preflightBuild = await withTimeout(
-        app.graphToPrompt().then(
+        Promise.resolve(app.graphToPrompt()).then(
           (value) => ({ value }),
           (error) => ({ error }),
         ),

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -10998,6 +10998,44 @@ function widenSocketProofBudget(deadlineMs) {
 const SET_WIDGET_COMMAND_BUDGET_MS = 25000;
 
 /**
+ * #1565 — `graph_run` was the one mutating command on this list with NO command budget at
+ * all, and the only one relayed in 20,000 ms rather than 30,000.
+ *
+ * What the RUN path awaits that the READ path does not: `app.graphToPrompt()` (serializing
+ * the whole workflow, including every extension's own serializeValue), `app.queuePrompt()`
+ * (the frontend's queue processor — shadowed by an extension's own property on the
+ * reporter's machine), and the scoped-dispatch observation wait, ONCE PER ARGUMENT SHAPE.
+ * `panel_query_graph` takes none of them: it reads live LiteGraph objects. That is the
+ * whole of the reported asymmetry — reads sub-second on the same tab while the run never
+ * answered at all, twice, including an explicit retry.
+ *
+ * Two things were measured on the shipped module rather than reasoned about:
+ *   - a busy queue processor draining at 4,990 ms/item made dispatchScopedRun take
+ *     20,003 ms — four argument shapes × a fresh 5,000 ms wait each — and the prompt
+ *     POSTED at 20,003 ms, i.e. AFTER the caller had been told the tab may be frozen. A
+ *     retry of that "failed" run renders the branch twice.
+ *   - an `app.queuePrompt` that never settles never returned at all, while a read on the
+ *     same objects answered in 0.06 ms.
+ *
+ * 15,000 ms, mirroring the 5,000 ms of slack ADD_NODE_COMMAND_BUDGET_MS and
+ * SET_WIDGET_COMMAND_BUDGET_MS leave against their own 30,000 ms window — for composing
+ * the reply and the websocket hop. Mirrored rather than derived for the same reason: the
+ * relay constant lives in the OTHER repo and a derived copy here could not be kept true.
+ */
+const RUN_COMMAND_BUDGET_MS = 15000;
+
+/**
+ * #1565 — what ONE `app.graphToPrompt()` may take before the panel stops waiting on it.
+ *
+ * The pre-flight and the scoped dispatch each serialize the workflow once, and a 69-node
+ * graph with extension serializers is the reported case, so this is generous rather than
+ * tight: the guarantee that matters is the COMMAND budget above, which caps the sum
+ * whatever this says. Its own job is only to stop ONE serializer that never settles from
+ * being the thing that spends the whole window.
+ */
+const RUN_SERIALIZE_TIMEOUT_MS = 8000;
+
+/**
  * #1413 — what a widget write still has to do AFTER the stale-combo refresh, held back so
  * the join cannot spend it.
  *
@@ -15611,6 +15649,10 @@ const GRAPH_TOOL_EXECUTORS = {
   },
 
   async graph_run({ batch_count, to_node_id }) {
+    // #1565 — taken on the FIRST line, before anything can spend the window. Every bound
+    // below draws from this one deadline, so they compose instead of each starting a fresh
+    // clock; see RUN_COMMAND_BUDGET_MS.
+    const budget = makeCommandBudget(RUN_COMMAND_BUDGET_MS, monotonicNow);
     const { app, graph, rootGraph } = getGraphCtx();
     // /run invokes this executor directly rather than through bridge dispatch.
     // Queueing a stale root would render the wrong workflow even though no graph
@@ -15707,7 +15749,24 @@ const GRAPH_TOOL_EXECUTORS = {
       // 200, against a snapshot that could drift from what the run actually sent.
       // None of that applies here: no network, no cap, and the bytes inspected are
       // the bytes that would have been POSTed.
-      const built = await app.graphToPrompt();
+      // #1565 — BOUNDED by the command budget. This serialization is the run path's first
+      // await, and it had none: an extension's serializeValue that never settles held the
+      // whole command open and the caller's only possible outcome was the bare "the tab may
+      // be backgrounded or frozen" timeout. A bound that fires throws a plain Error, which
+      // the catch below already treats as "pre-flight unavailable" and skips — the
+      // documented fail-soft contract, unchanged. The dispatch's own bounded serialization
+      // then produces the truthful, worded refusal.
+      const preflightBuild = await withTimeout(
+        app.graphToPrompt().then(
+          (value) => ({ value }),
+          (error) => ({ error }),
+        ),
+        budget.bounded(RUN_SERIALIZE_TIMEOUT_MS),
+        () => null,
+      );
+      if (preflightBuild == null) throw new Error("graph_run pre-flight: graphToPrompt did not answer in time");
+      if (preflightBuild.error) throw preflightBuild.error;
+      const built = preflightBuild.value;
       // comfyui-mcp#1582 — SERIALIZATION ITSELF CAN FAIL, and this is where that has to
       // be caught. `unrunnableNodeIds(undefined)` answers `[]` — correctly, since a
       // result that does not exist has no unrunnable entries in it — and the check below
@@ -15935,6 +15994,11 @@ const GRAPH_TOOL_EXECUTORS = {
         execIds: partialTargets,
         batch,
         toNodeId: to_node_id,
+        // #1565 — THE WHOLE FIX IS THIS ONE ARGUMENT reaching the dispatch. Without it
+        // dispatchScopedRun keeps its per-attempt clocks (4 × 5,000 ms = the entire
+        // 20,000 ms relay window) and its unbounded `await app.queuePrompt`, so the
+        // command cannot answer OR refuse inside the window its reply is relayed in.
+        budget,
         onRejection: captureRejection,
         onPromptId: capturePromptId,
         onAcceptedNodeErrors: captureAcceptedNodeErrors,

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -15891,6 +15891,11 @@ const GRAPH_TOOL_EXECUTORS = {
     // around EACH attempt so even a hypothetical nested wrap unwinds cleanly.
     let promptRejection = null;
     let runScopeResult = null;
+    // #1565 — the UNSCOPED run's capture wrap, kept so its live counts (what left the
+    // panel, what is still in flight) can be read after the call, and a flag for the
+    // one exit that needs them: a queue call abandoned at the command budget.
+    let runInterceptor = null;
+    let fullRunAbandoned = false;
     const queuedPromptIds = [];
     const prevFetchApi =
       typeof api?.fetchApi === "function" ? api.fetchApi : null;
@@ -15972,7 +15977,7 @@ const GRAPH_TOOL_EXECUTORS = {
       // UNSCOPED full run — the historical single-shot path: capture wrap for
       // exactly the duration of the queuePrompt call, then restore.
       if (origFetchApi) {
-        api.fetchApi = createRunFetchInterceptor({
+        runInterceptor = createRunFetchInterceptor({
           origFetchApi,
           onRejection: captureRejection,
           onPromptId: capturePromptId,
@@ -15981,9 +15986,45 @@ const GRAPH_TOOL_EXECUTORS = {
           // afterwards with a second app.graphToPrompt() would describe a different
           // compilation than the one ComfyUI accepted, and that call is not read-only.
         });
+        api.fetchApi = runInterceptor;
       }
       try {
-        await app.queuePrompt(0, batch, undefined);
+        // #1565 — BOUNDED, on the SAME command budget the scoped path draws from, so
+        // there is ONE rule for the run path rather than two.
+        //
+        // This was left unbounded in the first cut of #1565 on the argument that
+        // abandoning it risks claiming `queued` with no receipt. MEASURED, both halves
+        // of that argument are true and only one of them survives:
+        //
+        //   - the harm is real and IDENTICAL to the scoped one. `graph_run({})` against
+        //     a frontend whose queue processor never answers never replied; the caller
+        //     timed out at 20,007 ms, retried on the advice of a message blaming a
+        //     "backgrounded or frozen" tab, and the retry queued at 20,022 ms while the
+        //     FIRST run's post landed at 21,011 ms — TWO renders of the full graph from
+        //     one user intent. The more common path, the same duplicate.
+        //   - and the receipt objection is real: `buildQueueAcceptResult` with no ids
+        //     answers a bare `{queued: true, batch_count: N}` — a definite positive with
+        //     nothing behind it.
+        //
+        // What resolves it is that the honest vocabulary ALREADY EXISTS. `queued_unknown`
+        // (with `indeterminate_count` and retry guidance) was built for exactly this
+        // epistemic state on the scoped path; the reply below routes into it rather than
+        // into a `queued` this run cannot back. Nothing is claimed that was not observed:
+        // the interceptor COUNTS what left the panel.
+        //
+        // The whole remainder of the budget, not a slice: unlike the scoped path there is
+        // one queue call here, so nothing is owed to a later attempt.
+        const queued = await withTimeout(
+          Promise.resolve(app.queuePrompt(0, batch, undefined)).then(
+            (value) => ({ value }),
+            (error) => ({ error }),
+          ),
+          budget.bounded(),
+          () => null,
+        );
+        if (queued == null) fullRunAbandoned = true;
+        // `"error" in` rather than a truthiness test — a falsy thrown value still throws.
+        else if ("error" in queued) throw queued.error;
       } finally {
         if (origFetchApi) api.fetchApi = prevFetchApi;
       }
@@ -16104,6 +16145,86 @@ const GRAPH_TOOL_EXECUTORS = {
         };
       }
       return { queued: false, error: runScopeResult.error };
+    }
+    // #1565 — THE FULL RUN WAS ABANDONED AT THE COMMAND BUDGET. Everything below this
+    // point builds a reply out of what the interceptor captured, and every one of those
+    // shapes asserts something this run cannot back: `buildQueueAcceptResult` with no
+    // ids answers a bare `{queued: true, batch_count: N}` — a definite positive with
+    // nothing behind it — and `queued: false` would be a definite negative about a
+    // request that may already be executing. Neither is honest, so neither is used.
+    //
+    // The vocabulary here is the SCOPED path's, unchanged: a partial batch reports the
+    // prompts that really did queue, an unobserved dispatch that LEFT the panel omits
+    // `queued` entirely and says why, and only a run where nothing left gets the
+    // definite `queued: false`. One rule for the run path, not two.
+    //
+    // The counts are the interceptor's own observations, never an inference: `posted`
+    // is what this run handed to the network, `inFlight` is what had not answered when
+    // the budget expired.
+    if (fullRunAbandoned) {
+      const posted = Number(runInterceptor?.state?.posted) || 0;
+      const inFlight = Number(runInterceptor?.state?.inFlight) || 0;
+      const budgetSeconds = Math.round(RUN_COMMAND_BUDGET_MS / 1000);
+      const why =
+        `the frontend's queue call did not answer within this run's ${budgetSeconds}s command ` +
+        `budget — the panel stopped waiting ON PURPOSE, inside the window its reply is relayed ` +
+        `in, rather than let the call run the window out and leave you with a timeout that ` +
+        `blames a tab which is answering reads normally (#1565). The ComfyUI queue is the ` +
+        `authority on what actually ran.`;
+      if (queuedPromptIds.length) {
+        // Some prompts WERE accepted before the budget expired — they are queued and
+        // rendering, and are already registered for reconnect reconciliation above.
+        // Reporting this as a failure would send the caller to re-run work that is
+        // running; between the two misreadings that is the destructive one.
+        return {
+          queued: true,
+          complete: false,
+          partially_queued: true,
+          queued_count: queuedPromptIds.length,
+          queued_prompt_ids: queuedPromptIds.slice(),
+          incomplete_reason: why,
+          retry_guidance:
+            `${queuedPromptIds.length} of ${batch} prompt(s) ARE queued (prompt_ids above) and ` +
+            `are rendering. The rest were never confirmed. Check the ComfyUI queue before ` +
+            `re-running anything: re-running the whole batch would queue the already-running ` +
+            `prompt(s) again.`,
+        };
+      }
+      // NOTHING CONFIRMED. `queued` is OMITTED rather than set false, and that holds even
+      // when NOTHING has left the panel yet — which is the one thing this branch got wrong
+      // when it was first written, caught by measuring it rather than reading it.
+      //
+      // `posted === 0` is an observation about the instant the budget expired. "Nothing was
+      // queued, safe to re-issue" is a claim about the FUTURE, and `app.queuePrompt` is
+      // still running: on the measured 21 s-drain frontend the panel answered at 1.5 s with
+      // posted === 0, and the post left at 21 s anyway. A caller told it was safe to
+      // re-issue re-issues, and the late post still lands — the duplicate render, moved
+      // rather than removed. A bounded observation cannot license an unbounded negative.
+      //
+      // `queued: false` on this path is therefore only ever reachable when app.queuePrompt
+      // actually SETTLED, which is not this branch.
+      //
+      // WHY THE PENDING ITEM IS NOT CANCELLED, unlike the scoped path: cancellation there
+      // is licensed by an ownership tag plus this run's unique queue mark. An unscoped full
+      // run's pending item carries `number: 0` and no scope — byte-identical to the item a
+      // user's own Queue press leaves. Removing it could cancel THEIR render, so it is left
+      // alone and disclosed instead.
+      return {
+        queued_unknown: true,
+        indeterminate_count: posted,
+        error: `The full-graph run could not be confirmed: ${why}`,
+        retry_guidance:
+          (posted > 0
+            ? `No prompt was CONFIRMED queued, but ${posted} /prompt request(s) DID leave the ` +
+              `panel${inFlight > 0 ? ` (${inFlight} still awaiting a response)` : ""} — ComfyUI ` +
+              `may have accepted them. `
+            : `Nothing had left the panel when the budget expired, but the frontend's queue ` +
+              `call is STILL RUNNING and can post this run whenever its processor resumes — ` +
+              `so this is not a report that nothing will be queued. `) +
+          `Check the queue (or get_history) before retrying rather than assuming nothing ran; ` +
+          `a blind retry renders the whole graph twice. This result deliberately omits ` +
+          `"queued" because neither true nor false is honest here.`,
+      };
     }
     // Verdict from BOTH channels: the captured top-level rejection (#358) and the
     // per-node errors the frontend stashed. null ⇒ genuinely accepted.

--- a/web/js/lib/run-scope-guard.js
+++ b/web/js/lib/run-scope-guard.js
@@ -23,6 +23,15 @@ import { ueQueueTimeLinkPairs } from "./use-everywhere-links.js";
 // can also be present by OPTION SHAPE before its beforeQueued hook is re-hung.
 // Both detectors already live in their own modules; this file imports the verdict.
 import { controlAfterGenerateEntries } from "./control-after-generate.js";
+// #1565 — THE RUN PATH HAS TO ANSWER INSIDE THE WINDOW ITS REPLY IS RELAYED IN.
+// `panel_run` relays `graph_run` in 20,000 ms, and every wait below is a wait the
+// READ path (panel_query_graph reads live LiteGraph objects) never takes — which is
+// exactly the asymmetry the reporter measured: reads sub-second on the same tab
+// while the run never answered at all. The bounds here are APPLIED with the shared
+// `withTimeout`; the allowances come from the caller's command budget. A second
+// timeout helper is how this repo keeps producing near-duplicate bugs (bounded-step's
+// own header), so there is not one.
+import { withTimeout } from "./bounded-step.js";
 // #556 — panel_run's to_node_id ("run to node") must NEVER silently fall through
 // to a FULL-graph execution. A scoped run can fail open on two channels:
 //
@@ -1007,14 +1016,31 @@ export function describeFingerprintFailure(cause) {
  *    verified prompts DID queue (scoped); only the unverified remainder is
  *    in doubt.
  */
-export function scopeUnverifiedError({ toNodeId, timeoutMs, cancelled = false, verified = 0, batch = 1, inFlight = 0 }) {
+export function scopeUnverifiedError({
+  toNodeId,
+  timeoutMs,
+  cancelled = false,
+  verified = 0,
+  batch = 1,
+  inFlight = 0,
+  budgetMs = 0,
+}) {
   const count =
     verified > 0
       ? ` (${verified} of ${batch} batch prompts WERE verified and are queued with the scope)`
       : "";
+  // #1565 — SAY WHICH CLOCK RAN OUT. When the command budget is what expired, the
+  // per-attempt figure is whatever slice was left (as little as 1 ms) and quoting it
+  // would describe a wait nobody made. The budget is also the actionable number: it
+  // tells the reader the panel STOPPED WAITING ON PURPOSE, inside the window its reply
+  // is relayed in, rather than that their frontend answered in 0s.
+  const waited =
+    budgetMs > 0
+      ? `within this run's whole ${Math.round(budgetMs / 1000)}s command budget`
+      : `within ${Math.round(timeoutMs / 1000)}s of queueing`;
   const base =
     `run-to-node scope for node ${toNodeId} could not be verified: no scoped ` +
-    `dispatch was observed within ${Math.round(timeoutMs / 1000)}s of queueing ` +
+    `dispatch was observed ${waited} ` +
     `(the frontend deferred or silently dropped the request)${count}. `;
   // IN FLIGHT ≠ NEVER SENT (codex gate r9). A correctly-scoped request that has
   // already left the panel but whose response has not come back yet is neither
@@ -1625,11 +1651,74 @@ export async function dispatchScopedRun({
   toNodeId = null,
   verifyTimeoutMs = 5000,
   queueMark = null,
+  budget = null,
   onRejection = null,
   onPromptId = null,
   onAcceptedNodeErrors = null,
 } = {}) {
   const mark = queueMark ?? newScopedQueueMark();
+  // #1565 — ONE DEADLINE FOR THE WHOLE DISPATCH, so the per-attempt bounds COMPOSE.
+  //
+  // Every wait in this function used to start its own fresh clock: four argument
+  // shapes are tried in sequence, and each one that reached no verdict paid a full
+  // `verifyTimeoutMs`. 4 × 5,000 ms is 20,000 ms — EXACTLY the window `panel_run`
+  // relays `graph_run` in — so on a frontend whose queue processor is busy (the
+  // reporter had user Queue presses interleaved with agent runs) the command could
+  // not answer, or refuse, inside its own reply window. MEASURED on the shipped
+  // module with a busy processor draining at 4,990 ms/item: dispatchScopedRun took
+  // 20,003 ms and the prompt POSTED at 20,003 ms — after the caller had already been
+  // told the tab "may be backgrounded or frozen". A retry then renders twice.
+  //
+  // `budget.bounded(ms)` caps every allowance by what the COMMAND has left, so the
+  // sum can never exceed it. NO BUDGET ⇒ NO BOUND: `withTimeout` treats ms <= 0 as
+  // no bound, so a caller that supplies none keeps today's behaviour byte for byte
+  // (the panel's own call site always supplies one — see graph_run).
+  const hasBudget = !!budget && typeof budget.bounded === "function";
+  /** The bound for one step, capped by what the command has left; 0 (= unbounded) with no budget. */
+  const boundedBy = (ms) => (hasBudget ? budget.bounded(ms) : 0);
+  /**
+   * This attempt's FAIR SHARE of what is left. A fresh `verifyTimeoutMs` per attempt is
+   * what failed to compose; handing the first attempt everything would be the same defect
+   * with a different shape — on the reporter's build the ONLY argument shape that carries
+   * the scope is the LAST one (they reported `scope_applied_by:"request_body_repair"` on
+   * every successful run), so an allocation that starves the later attempts would refuse
+   * the runs that work today. Never MORE than the caller's own `verifyTimeoutMs`.
+   */
+  const shareFor = (attemptsLeft) => {
+    if (!hasBudget) return verifyTimeoutMs;
+    const left = typeof budget.remaining === "function" ? budget.remaining() : 0;
+    const share = Math.floor(left / Math.max(1, attemptsLeft));
+    return budget.bounded(Math.min(verifyTimeoutMs, share));
+  };
+  /**
+   * The command budget's total, but ONLY once it is actually spent — that is the one
+   * case where quoting the per-attempt slice would describe a wait nobody made. A
+   * give-up that happens while the command still has room is honestly a per-attempt
+   * give-up and keeps saying so.
+   */
+  const budgetSpent = () =>
+    hasBudget && typeof budget.exhausted === "function" && budget.exhausted()
+      ? Number(budget.totalMs) || 0
+      : 0;
+  // Sentinel for a bounded step that did not settle. A Symbol so it can never collide
+  // with a value the bounded promise itself resolves.
+  const TIMED_OUT = Symbol("cmcp-run-step-timeout");
+  /**
+   * Await `promise` under `ms`, PRESERVING ITS REJECTION. `withTimeout` folds a
+   * rejection into its timeout fallback, which here would turn a frontend that THREW
+   * (today: propagates out of graph_run and is reported as the error it is) into one
+   * that "timed out" — a different, wrong story. Settling into {value}/{error} first
+   * keeps the two apart; the caller re-throws.
+   */
+  const boundedStep = (promise, ms) =>
+    withTimeout(
+      Promise.resolve(promise).then(
+        (value) => ({ value }),
+        (error) => ({ error }),
+      ),
+      ms,
+      () => TIMED_OUT,
+    );
   // CHAIN COMPOSITION (codex gate r8). Both the entry-time capture below and
   // the per-attempt restore used to be WRONG in the presence of a concurrent
   // run:
@@ -1682,7 +1771,20 @@ export async function dispatchScopedRun({
       // This panel's live root is app.graph (r8) — app.rootGraph only as a
       // fallback for frontends that expose it instead.
       volatileInputs = collectVolatileInputs(app?.graph ?? app?.rootGraph ?? null);
-      contentCanon = canonicalizePrompt((await app.graphToPrompt())?.output, volatileInputs);
+      // #1565 — BOUNDED. Serializing the whole workflow is the first thing the run path
+      // does that the read path never does, and an extension's serializeValue that never
+      // settles held the command open with no bound at all. A serializer that will not
+      // answer leaves no fingerprint, which is already the fail-closed state below:
+      // `unverifiable`, nothing queued, and the cause named.
+      const built = await boundedStep(app.graphToPrompt(), boundedBy(verifyTimeoutMs));
+      if (built === TIMED_OUT) {
+        throw new Error(
+          `app.graphToPrompt did not answer within this run's command budget — the ` +
+            `frontend could not serialize the workflow, so nothing was queued`,
+        );
+      }
+      if (built.error) throw built.error;
+      contentCanon = canonicalizePrompt(built.value?.output, volatileInputs);
       contentHash = contentCanon ? fnv1aHex(JSON.stringify(contentCanon)) : null;
     }
   } catch (err) {
@@ -1754,14 +1856,29 @@ export async function dispatchScopedRun({
       onAcceptedNodeErrors,
     });
     apiTarget.fetchApi = guard;
+    // #1565 — this attempt's slice of the command budget, taken ONCE so the queue
+    // call and the observation wait are quoted the same number in the refusal.
+    const attemptMs = shareFor(attempts.length - attemptIndex);
     try {
-      await app.queuePrompt(mark, batch, scopeArg);
+      // #1565 — BOUNDED. `await app.queuePrompt(…)` had no bound of any kind, and it is
+      // the single most reachable hang on the run path: the reporter's own machine has
+      // BOTH `app.queuePrompt` and `api.queuePrompt` shadowed by an extension's own
+      // property, and a wrapper that never settles held graph_run open forever while
+      // reads on the same tab answered in 0.06 ms (MEASURED against this module).
+      //
+      // Abandoning the wait is safe HERE and only here: falling through with no verdict
+      // is the state the give-up path below already exists for — it cancels the still-
+      // pending queue item and, either way, CLOSES this guard, so a post the abandoned
+      // queuePrompt emits later still meets the fence and is refused rather than
+      // dispatched scopeless. A throw is re-thrown unchanged (boundedStep keeps it).
+      const queued = await boundedStep(app.queuePrompt(mark, batch, scopeArg), boundedBy(attemptMs));
+      if (queued !== TIMED_OUT && queued.error) throw queued.error;
       if (!guard.verdictReached()) {
         // queuePrompt returned without our dispatch surfacing — the
         // frontend's processor was busy and will serialize/post the item
         // LATER. Keep the guard installed and wait for the WHOLE batch to be
         // accounted (r5: never dispatched on a partial count), or the timeout.
-        await guard.waitForVerdict(verifyTimeoutMs);
+        await guard.waitForVerdict(attemptMs);
       }
       if (!guard.verdictReached()) {
         // GIVE-UP. The guard stays (that is now the default — the finally only
@@ -1801,7 +1918,7 @@ export async function dispatchScopedRun({
             indeterminate: guard.state.indeterminate,
             inFlight,
             volatileInputs: volatileList,
-            error: scopeUnverifiedError({ toNodeId, timeoutMs: verifyTimeoutMs, cancelled: true, verified, batch, inFlight }),
+            error: scopeUnverifiedError({ toNodeId, timeoutMs: attemptMs, cancelled: true, verified, batch, inFlight, budgetMs: budgetSpent() }),
           };
         }
         return {
@@ -1811,7 +1928,7 @@ export async function dispatchScopedRun({
           indeterminate: guard.state.indeterminate,
           inFlight,
           volatileInputs: volatileList,
-          error: scopeUnverifiedError({ toNodeId, timeoutMs: verifyTimeoutMs, cancelled: false, verified, batch, inFlight }),
+          error: scopeUnverifiedError({ toNodeId, timeoutMs: attemptMs, cancelled: false, verified, batch, inFlight, budgetMs: budgetSpent() }),
         };
       }
       // r6: a dispatch FAILURE with the batch not fully accounted — the

--- a/web/js/lib/run-scope-guard.js
+++ b/web/js/lib/run-scope-guard.js
@@ -1228,6 +1228,15 @@ async function classifyRunResponse(res, { onRejection, onPromptId, onAcceptedNod
  * lands on lastNodeErrors), so the raw non-200 /prompt body is the only place
  * that error exists; and EVERY accepted prompt_id is captured for the recovery
  * ledger. Installed only for the duration of the queuePrompt call.
+ *
+ * #1565 — IT ALSO COUNTS WHAT LEFT. `interceptor.state` is live:
+ *   - `posted`   /prompt requests this run handed to the network, ever;
+ *   - `inFlight` those whose response has not come back yet.
+ * A full run whose `app.queuePrompt` is abandoned at the command budget has to say
+ * whether anything actually left the panel, and "nothing was queued" and "a request
+ * is in flight" are different answers with different retry advice — only one of them
+ * is safe to act on blindly. This is the only place that sees the request leave, so
+ * it is the only place that can answer it from observation rather than assumption.
  */
 export function createRunFetchInterceptor({
   origFetchApi,
@@ -1235,13 +1244,35 @@ export function createRunFetchInterceptor({
   onPromptId = null,
   onAcceptedNodeErrors = null,
 } = {}) {
-  return async function runFetchInterceptor(route, options) {
-    const res = await origFetchApi(route, options);
-    if (isPromptPost(route, options) && res) {
-      await captureRunResponse(res, { onRejection, onPromptId, onAcceptedNodeErrors });
+  const state = { posted: 0, inFlight: 0 };
+  const interceptor = async function runFetchInterceptor(route, options) {
+    // Classified BEFORE the request leaves, because that is the only moment at which
+    // "this one is ours to count" can still be decided. Guarded: reading `options`
+    // is itself an operation that can throw (a throwing getter, a Proxy), and this
+    // used to run only AFTER the fetch — so a throw here must not be able to stop a
+    // request that previously went out. An unreadable request is simply not counted.
+    let isPost = false;
+    try {
+      isPost = isPromptPost(route, options);
+    } catch {
+      isPost = false;
     }
-    return res;
+    if (isPost) {
+      state.posted++;
+      state.inFlight++;
+    }
+    try {
+      const res = await origFetchApi(route, options);
+      if (isPost && res) {
+        await captureRunResponse(res, { onRejection, onPromptId, onAcceptedNodeErrors });
+      }
+      return res;
+    } finally {
+      if (isPost) state.inFlight--;
+    }
   };
+  interceptor.state = state;
+  return interceptor;
 }
 
 /**

--- a/web/js/lib/run-scope-guard.js
+++ b/web/js/lib/run-scope-guard.js
@@ -1691,15 +1691,14 @@ export async function dispatchScopedRun({
     return budget.bounded(Math.min(verifyTimeoutMs, share));
   };
   /**
-   * The command budget's total, but ONLY once it is actually spent — that is the one
-   * case where quoting the per-attempt slice would describe a wait nobody made. A
-   * give-up that happens while the command still has room is honestly a per-attempt
-   * give-up and keeps saying so.
+   * The command budget's total, but ONLY when the budget is what SHORTENED this attempt's
+   * wait — i.e. the slice came out below the caller's own `verifyTimeoutMs`. Then the
+   * per-attempt figure describes a wait the budget imposed, and rounding it to seconds can
+   * read as "0s", which is a wait nobody made. A give-up that happens while the command
+   * still had room for a full slice is honestly a per-attempt give-up and keeps saying so.
    */
-  const budgetSpent = () =>
-    hasBudget && typeof budget.exhausted === "function" && budget.exhausted()
-      ? Number(budget.totalMs) || 0
-      : 0;
+  const budgetShortened = (attemptMs) =>
+    hasBudget && attemptMs < verifyTimeoutMs ? Number(budget.totalMs) || 0 : 0;
   // Sentinel for a bounded step that did not settle. A Symbol so it can never collide
   // with a value the bounded promise itself resolves.
   const TIMED_OUT = Symbol("cmcp-run-step-timeout");
@@ -1783,7 +1782,9 @@ export async function dispatchScopedRun({
             `frontend could not serialize the workflow, so nothing was queued`,
         );
       }
-      if (built.error) throw built.error;
+      // `"error" in` rather than a truthiness test: a falsy thrown value (`throw undefined`)
+      // used to propagate out of here, and a bound must not swallow it.
+      if ("error" in built) throw built.error;
       contentCanon = canonicalizePrompt(built.value?.output, volatileInputs);
       contentHash = contentCanon ? fnv1aHex(JSON.stringify(contentCanon)) : null;
     }
@@ -1872,7 +1873,8 @@ export async function dispatchScopedRun({
       // queuePrompt emits later still meets the fence and is refused rather than
       // dispatched scopeless. A throw is re-thrown unchanged (boundedStep keeps it).
       const queued = await boundedStep(app.queuePrompt(mark, batch, scopeArg), boundedBy(attemptMs));
-      if (queued !== TIMED_OUT && queued.error) throw queued.error;
+      // `"error" in` rather than a truthiness test — a falsy thrown value still throws.
+      if (queued !== TIMED_OUT && "error" in queued) throw queued.error;
       if (!guard.verdictReached()) {
         // queuePrompt returned without our dispatch surfacing — the
         // frontend's processor was busy and will serialize/post the item
@@ -1918,7 +1920,7 @@ export async function dispatchScopedRun({
             indeterminate: guard.state.indeterminate,
             inFlight,
             volatileInputs: volatileList,
-            error: scopeUnverifiedError({ toNodeId, timeoutMs: attemptMs, cancelled: true, verified, batch, inFlight, budgetMs: budgetSpent() }),
+            error: scopeUnverifiedError({ toNodeId, timeoutMs: attemptMs, cancelled: true, verified, batch, inFlight, budgetMs: budgetShortened(attemptMs) }),
           };
         }
         return {
@@ -1928,7 +1930,7 @@ export async function dispatchScopedRun({
           indeterminate: guard.state.indeterminate,
           inFlight,
           volatileInputs: volatileList,
-          error: scopeUnverifiedError({ toNodeId, timeoutMs: attemptMs, cancelled: false, verified, batch, inFlight, budgetMs: budgetSpent() }),
+          error: scopeUnverifiedError({ toNodeId, timeoutMs: attemptMs, cancelled: false, verified, batch, inFlight, budgetMs: budgetShortened(attemptMs) }),
         };
       }
       // r6: a dispatch FAILURE with the batch not fully accounted — the


### PR DESCRIPTION
Fixes #1565

## The report

`panel_run` timed out on `graph_run` after 20,000 ms, **twice in a row** including an explicit `retry_of` retry, while `panel_query_graph` reads to the **same panel tab** answered sub-second throughout. That asymmetry rules out a dead socket, a lost `hello` and a wedged bridge, so this is not a generic timeout — something makes the *run* path specifically block while the read path is fine.

## Reproduced, by execution, before anything was written

Driving the **shipped** `dispatchScopedRun` (the orchestration `graph_run` runs) against a frontend modelled on the reporter's machine — a busy queue processor (they had user Queue presses interleaved with agent runs) that **drops the scope in every `app.queuePrompt` argument shape**, which is what their `scope_applied_by: "request_body_repair"` on every successful run means:

| busy processor drain | `dispatchScopedRun` elapsed | outcome | POST /prompt after the caller's 20s deadline | read on the same objects |
|---|---|---|---|---|
| 4,800 ms/item | 19,255 ms | dispatched | 0 | 0.055 ms |
| 4,950 ms/item | 19,856 ms | dispatched | 0 | 0.041 ms |
| **4,990 ms/item** | **20,003 ms** | dispatched | **1** | 0.043 ms |
| `app.queuePrompt` never settles | **never replied** (raced out at 22 s) | — | — | 0.056 ms |

## What the run path awaits that the read path does not

1. **`app.graphToPrompt()`** — serializing the whole workflow, every extension's own `serializeValue` included. **No bound of any kind.**
2. **`app.queuePrompt()`** — the frontend's queue processor. **No bound of any kind**, and on the reporter's machine *both* `app.queuePrompt` and `api.queuePrompt` are shadowed by an extension's own property (they reported the chain line verbatim). A wrapper that never settles held `graph_run` open **forever**.
3. **the scoped-dispatch observation wait — once per argument shape**, each attempt starting a **fresh** `verifyTimeoutMs`. Four shapes x 5,000 ms = **20,000 ms: exactly the window `panel_run` relays this command in**, with nothing left for the reply itself.

`panel_query_graph` takes none of them: it reads live LiteGraph objects. That is the whole of the reported asymmetry.

`graph_run` was also the only mutating panel command with **no command budget at all**, and the only one relayed in 20,000 ms rather than 30,000 — `nodes_install`, `graph_add_node`, `graph_set_widget`, `graph_refresh_nodes` and `workflow_save` all have one. Same shape as #1192 and #671.

## Did the prompt actually run while the caller timed out?

**Yes, on the boundary — and that is worse than the reported bug.** At a 4,990 ms drain the run reported `dispatched` at 20,003 ms and the POST left at 20,003 ms, i.e. *after* the caller had already been told the tab "may be backgrounded or frozen". A `retry_of` retry of that "failed" run renders the branch **twice**. After the fix the same scenario answers in 3,762 ms with `serverPostsEver: 0` — the abandoned item meets the fence and is refused, so nothing queues behind the caller's back.

(In the reporter's own session nothing was queued — their `queue(action:"list")` was empty — which is the sub-20s side of the same boundary.)

## The fix

**One deadline for the whole command**, taken on `graph_run`'s first line and threaded into the dispatch, so the bounds *compose* instead of summing.

- `RUN_COMMAND_BUDGET_MS = 15000` — the same 5,000 ms of slack the other command budgets leave against their own window, for composing the reply and the websocket hop. Mirrored, not derived: the relay constant lives in the other repo.
- `RUN_SERIALIZE_TIMEOUT_MS = 8000` bounds **one** `app.graphToPrompt()`; the command budget caps the sum whatever it says.
- `dispatchScopedRun` takes `budget` and gives each attempt a **fair share of what is left**, never more than `verifyTimeoutMs`. Fair share rather than first-come, because on the reporter's build the **last** argument shape is the only one that carries the scope — an allocation that starved the later attempts would refuse the runs that work today.
- `await app.queuePrompt(...)` is bounded on **both** the scoped and the full-graph paths, falling into the **existing** give-up / unknown-outcome paths.

**No budget means no bound.** `withTimeout` treats `ms <= 0` as no bound, so any caller that passes no budget keeps today's behaviour byte for byte.

## The full-graph run (review P1)

The first cut bounded only the scoped path and disclosed the unscoped one as deliberately out of scope, on the argument that abandoning an unbounded queue call risks claiming `queued` with no receipt. **Review returned that as a P1 and was right.** Measured against the shipped body:

- `graph_run({})` never replied; the caller timed out at **20,007 ms**, retried on the advice of a message blaming a "backgrounded or frozen" tab, and the retry queued at **20,022 ms** while the FIRST run's post landed at **21,011 ms** — **two full-graph renders from one user intent**, on the more common path.
- The receipt objection was also real: `buildQueueAcceptResult` with no ids answers a bare `{queued: true, batch_count: N}`.

It is resolved by routing into **`queued_unknown`** — with `indeterminate_count` and retry guidance, and `queued` *omitted* rather than set false — the honest shape an earlier round on this cluster had already built for exactly this state. One rule for the run path instead of two, and no receipt design left to file. `createRunFetchInterceptor` now carries live `state = { posted, inFlight }` so the reply states what actually left the panel instead of inferring it.

A defect that fix introduced, caught by measuring it: the first cut answered `queued: false` when nothing had left the panel. `posted === 0` is an observation about one instant while `app.queuePrompt` is still running — on the 21 s-drain frontend the panel answered at 1.5 s with `posted === 0` and the post left at 21 s anyway, **moving** the duplicate render rather than removing it. An abandoned run therefore never says `queued: false`.

The pending item is **not** cancelled, unlike the scoped path: cancellation there is licensed by an ownership tag plus a unique queue mark, and an unscoped item is byte-identical to what a user's own Queue press leaves. Cancelling it could kill **their** render, so it is disclosed instead.

A healthy full run is byte-identical: `{queued: true, batch_count: 1, prompt_id: …}` in 15 ms, budget never consulted.

## Why abandoning a queue call is safe here

Only because the give-up path already **CLOSES the guard** (`retireGuard` defaults false; the fence is only ever stood down when handing over to another attempt of the same run). A post the abandoned `queuePrompt` emits later carries this run's unique mark, meets the closed guard, and is **refused rather than dispatched scopeless** — measured: `serverPostsEver: 0`, and pinned by a test that installs a *second* run's guard on top. The bound also preserves a **rejection**: `withTimeout` folds a rejection into its timeout fallback, which would have turned a frontend that *threw* into one that "timed out", so the call settles into `{value}`/`{error}` first and the caller re-throws.

## Mutation evidence (fix deleted, named tests watched)

**Round 1 — the scoped path**

| mutation | tests that died |
|---|---|
| **M1 CALL SITE** — drop `budget,` from the `dispatchScopedRun` options | `CALL SITE: graph_run hands the dispatch its own command budget`, `CALL SITE: … never settles` |
| **M2 CALL SITE** — `graph_run` takes no budget | `CALL SITE: … own command budget`, `CALL SITE: … on the monotonic clock` |
| **M3 LIB** — per-attempt wait back to a fresh `verifyTimeoutMs` | `four argument shapes on a busy frontend cannot outlast ONE command budget` |
| **M4 LIB** — `app.queuePrompt` back to an unbounded await | `an app.queuePrompt that NEVER SETTLES is bounded…` |
| **M4b LIB** — falsy-throw check back to truthiness | `even a FALSY thrown value still throws…` |
| **M5 LIB** — fingerprint serialization back to an unbounded await | `an app.graphToPrompt that NEVER SETTLES is bounded, and nothing is queued` |
| **M6 CALL SITE** — pre-flight serialization takes its own fresh clock | `CALL SITE: … on the monotonic clock` |
| **M7 CONSTANT** — budget raised past the relay window | `the shipped run budget leaves room inside the 20,000 ms window…` |
| **M8 / M8b LIB** — abandoned attempt RETIRES, or RESTORES raw `fetchApi` | `P0: a run abandoned at its bound still FENCES its own late post…` |
| **M9 CALL SITE** — drop `Promise.resolve(...)` from the bounded pre-flight | `a SYNCHRONOUS graphToPrompt still reaches the pre-flight…` |
| **M10 LIB** — `boundedBy` always unbounded | both NEVER-SETTLES tests |
| **M5b LIB** — falsy-throw check on the fingerprint | **SURVIVED — equivalent mutant, reported not hidden** (see below) |

**Round 2 — the full-graph path**

| mutation | tests that died |
|---|---|
| **N1 CALL SITE** — unscoped `queuePrompt` back to an unbounded await | `P1: a full run whose queue call never settles ANSWERS inside its budget` |
| **N2 CALL SITE** — abandoned run falls through to the normal accept path | `P1: never answers a bare queued:true`; `P1: queued:false is never earned`; `P1: … real ids` |
| **N3 CALL SITE** — abandoned run with nothing posted claims `queued:false` | `P1: never answers a bare queued:true`; `P1: queued:false is never earned` |
| **N4 LIB** — interceptor stops counting what left the panel | `P1: the run interceptor COUNTS what left the panel` |
| **N5 LIB** — request classification moves back AFTER the fetch | `P1: an unreadable request cannot stop a fetch that previously went out` |

**M5b survived and is not being hidden.** On the fingerprint path the two forms are **observably identical**, so no test can separate them: verified by calling `canonicalizePrompt(undefined)` → `null` and `describeFingerprintFailure(undefined)` → `""`, both branches end at the same `unverifiable` refusal with an empty cause. The change is defensive symmetry with the `queuePrompt` bound, where it IS observable (M4b).

Every mutation was applied against a **committed** fix and reverted afterwards, with `git status --porcelain` verified clean between runs. Anchors that failed to match (CRLF, and a later edit) were re-anchored and re-run rather than read as "survived".

## Existing tests that had to follow the code

Four source anchors named literals the bounds replaced — `graph-to-prompt-failure`, `missing-node-preflight`, `scope-fingerprint-cause`, and `scoped-batch-seed`'s `#988` ordering guard. Each was re-anchored on the new form **and additionally asserts the call is still the bounded one**, so an anchor cannot drift back to an unbounded dispatch while the test stays green. `graph-to-prompt-failure.test.mjs` also needed `withTimeout` / `budget` / `RUN_SERIALIZE_TIMEOUT_MS` injected into its `new Function` harness: without them the extracted body throws a `ReferenceError` that the pre-flight's own catch swallows, and every one of those tests would read "no refusal" from a pre-flight that never ran. **No assertion was loosened.**

## What I deliberately did NOT do

- **Did not raise the 20,000 ms relay budget.** A constant bump would have hidden exactly the block measured above.
- **Did not implement the reporter's suggested "probe the tab with a cheap read before returning the timeout".** That wording lives in the orchestrator repo (`ui-bridge.ts`), not here, and with the panel now answering inside the window it no longer fires for this cause.
- **Did not touch the `scope_applied_by: "request_body_repair"` / frontend-1.49.6 observation** they flagged as possibly separate. It is a real signal about that build and belongs in its own issue; it is not what blocked the run.
- **Did not cancel the unscoped pending queue item** — no ownership identity exists to do it safely; see above.
- No live-rig verification: this rig has no ComfyUI frontend 1.49.6 with the reporter's extension set. Everything above is measured against the shipped modules.

## Verification

- **unit**: `npm run test:unit` — **6196 passed / 0 failed** on the merged head (i18n, i18n-render, tool-vocabulary and panel-scope gates all OK).
- **gate**: `codex-gate.mjs --base origin/main --name 1570` → **SHIP**.
- **mutation**: seventeen mutations across both rounds, sixteen killed by named tests; the one survivor (M5b) is an observably equivalent mutant, reported above.
- **browser**: `npx playwright test --workers=1` — branch **17 failed / 64 passed** vs a clean `origin/main` baseline of **18 failed / 63 passed** measured back to back; the branch's failing set is a **strict subset** (zero regressions). Two limitations stated plainly in the evidence comment: the Tier-1 suite never exercises `graph_run` at all, and on this rig the pack junction serves the main checkout rather than the worktree — so no browser coverage is claimed for the fix itself.
- **main moved mid-round** (`75728263` → `869362ec`, three PRs, all touching the same 39k-line panel file). Merged in as `7ddf421f`, no conflicts, suite re-run green on the merged result, and both the scoped and unscoped measurements re-taken on it: the duplicate-render case answers at 15,007 ms with `queued_unknown`, and the scoped path still refuses at 3,761 ms with `serverPostsEver: 0`.

Full evidence and the exact spec-set diff are in the comments below.
